### PR TITLE
refactor to reduce the number variable using colour in them instead of color.

### DIFF
--- a/code/game/jobs/job/marine/squads.dm
+++ b/code/game/jobs/job/marine/squads.dm
@@ -34,11 +34,11 @@
 	/// If uses the overlay
 	var/use_stripe_overlay = TRUE
 	/// Color for the squad marines gear overlays
-	var/equipment_color = "#FFFFFF"
+	var/equipment_color = COLOR_WHITE
 	/// The alpha for the armor overlay used by equipment color
 	var/armor_alpha = 125
 	/// Color for the squad marines langchat
-	var/chat_color = "#FFFFFF"
+	var/chat_color = COLOR_WHITE
 	/// Which special access do we grant them
 	var/list/access = list()
 	/// Can use any squad vendor regardless of squad connection
@@ -400,17 +400,17 @@
 
 /// Displays a message to squad members directly on the game map
 /datum/squad/proc/send_maptext(text = "", title_text = "", only_leader = 0)
-	var/message_colour = chat_color
+	var/message_color = chat_color
 	if(only_leader)
 		if(squad_leader)
 			if(!squad_leader.stat && squad_leader.client)
 				playsound_client(squad_leader.client, 'sound/effects/radiostatic.ogg', squad_leader.loc, 25, FALSE)
-				squad_leader.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>[title_text]</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order, message_colour)
+				squad_leader.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>[title_text]</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order, message_color)
 	else
 		for(var/mob/living/carbon/human/marine in marines_list)
 			if(!marine.stat && marine.client) //Only living and connected people in our squad
 				playsound_client(marine.client, 'sound/effects/radiostatic.ogg', marine.loc, 25, FALSE)
-				marine.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>[title_text]</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order, message_colour)
+				marine.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>[title_text]</u></span><br>" + text, /atom/movable/screen/text/screen_text/command_order, message_color)
 
 /// Displays a message to the squad members in chat
 /datum/squad/proc/send_message(text = "", plus_name = 0, only_leader = 0)

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -368,7 +368,7 @@
 	var/unspooled = FALSE
 	var/list/icons_available = list()
 	var/radial_icon_file = 'icons/mob/radial_tape.dmi'
-	var/list/cassette_colours = list("blue", "gray", "green", "orange", "pink_stripe", "purple", "rainbow", "red_black", "red_stripe", "camo", "rising_sun", "orange", "blue", "ocean", "aesthetic")
+	var/list/cassette_colors = list("blue", "gray", "green", "orange", "pink_stripe", "purple", "rainbow", "red_black", "red_stripe", "camo", "rising_sun", "orange", "blue", "ocean", "aesthetic")
 	var/list/cassette_map_themes = list("solaris", "ice", "lz", "dam", "worstmap")
 	inherent_traits = list(TRAIT_ITEM_RENAME_SPECIAL) //used to make the rename component work specially.
 	///used to store the tape's name for one side and the other side
@@ -501,7 +501,7 @@
 	icon_state = "cassette_rainbow"
 
 /obj/item/tape/random/Initialize(mapload)
-	icon_state = "cassette_[pick(cassette_colours)]"
+	icon_state = "cassette_[pick(cassette_colors)]"
 	. = ..()
 
 /obj/item/tape/regulation

--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -503,7 +503,7 @@
 /obj/item/reagent_container/food/snacks/egg/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype( W, /obj/item/toy/crayon ))
 		var/obj/item/toy/crayon/C = W
-		var/clr = C.colourName
+		var/clr = C.colorName
 
 		if(!(clr in list("blue","green","mime","orange","purple","rainbow","red","yellow")))
 			to_chat(usr, SPAN_NOTICE(" The egg refuses to take on this color!"))

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -103,11 +103,11 @@
 	overlays = list() //resets list
 	overlays += image('icons/obj/items/crayons.dmi',"crayonbox")
 	for(var/obj/item/toy/crayon/crayon in contents)
-		overlays += image('icons/obj/items/crayons.dmi',crayon.colourName)
+		overlays += image('icons/obj/items/crayons.dmi',crayon.colorName)
 
 /obj/item/storage/fancy/crayons/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/toy/crayon))
-		switch(W:colourName)
+		switch(W:colorName)
 			if("mime")
 				to_chat(usr, "This crayon is too sad to be contained in this box.")
 				return

--- a/code/game/objects/items/toys/crayons.dm
+++ b/code/game/objects/items/toys/crayons.dm
@@ -1,70 +1,70 @@
 /obj/item/toy/crayon/red
 	icon_state = "crayonred"
 	crayon_color = "#DA0000"
-	shadeColour = "#810C0C"
-	colourName = "red"
+	shade_color = "#810C0C"
+	colorName = "red"
 
 /obj/item/toy/crayon/orange
 	icon_state = "crayonorange"
 	crayon_color = "#FF9300"
-	shadeColour = "#A55403"
-	colourName = "orange"
+	shade_color = "#A55403"
+	colorName = "orange"
 
 /obj/item/toy/crayon/yellow
 	icon_state = "crayonyellow"
 	crayon_color = "#FFF200"
-	shadeColour = "#886422"
-	colourName = "yellow"
+	shade_color = "#886422"
+	colorName = "yellow"
 
 /obj/item/toy/crayon/green
 	icon_state = "crayongreen"
 	crayon_color = "#A8E61D"
-	shadeColour = "#61840F"
-	colourName = "green"
+	shade_color = "#61840F"
+	colorName = "green"
 
 /obj/item/toy/crayon/blue
 	icon_state = "crayonblue"
 	crayon_color = "#00B7EF"
-	shadeColour = "#0082A8"
-	colourName = "blue"
+	shade_color = "#0082A8"
+	colorName = "blue"
 
 /obj/item/toy/crayon/purple
 	icon_state = "crayonpurple"
 	crayon_color = "#DA00FF"
-	shadeColour = "#810CFF"
-	colourName = "purple"
+	shade_color = "#810CFF"
+	colorName = "purple"
 
 /obj/item/toy/crayon/mime
 	icon_state = "crayonmime"
 	desc = "A very sad-looking crayon."
 	crayon_color = COLOR_WHITE
-	shadeColour = COLOR_BLACK
-	colourName = "mime"
+	shade_color = COLOR_BLACK
+	colorName = "mime"
 	uses = 0
 
 /obj/item/toy/crayon/mime/attack_self(mob/living/user) //inversion
 	..()
 
-	if(crayon_color != COLOR_WHITE && shadeColour != COLOR_BLACK)
+	if(crayon_color != COLOR_WHITE && shade_color != COLOR_BLACK)
 		crayon_color = COLOR_WHITE
-		shadeColour = COLOR_BLACK
+		shade_color = COLOR_BLACK
 		to_chat(user, "You will now draw in white and black with this crayon.")
 	else
 		crayon_color = COLOR_BLACK
-		shadeColour = COLOR_WHITE
+		shade_color = COLOR_WHITE
 		to_chat(user, "You will now draw in black and white with this crayon.")
 
 /obj/item/toy/crayon/rainbow
 	icon_state = "crayonrainbow"
 	crayon_color = "#FFF000"
-	shadeColour = "#000FFF"
-	colourName = "rainbow"
+	shade_color = "#000FFF"
+	colorName = "rainbow"
 	uses = 0
 
 /obj/item/toy/crayon/rainbow/attack_self(mob/living/user)
 	..()
 	crayon_color = input(user, "Please select the main color.", "Crayon color") as color
-	shadeColour = input(user, "Please select the shade color.", "Crayon color") as color
+	shade_color = input(user, "Please select the shade color.", "Crayon color") as color
 
 /obj/item/toy/crayon/afterattack(atom/target, mob/user, proximity)
 	if(!proximity)
@@ -80,7 +80,7 @@
 			if("rune")
 				to_chat(user, "You start drawing a rune on the [target.name].")
 		if(instant || do_after(user, 50, INTERRUPT_ALL, BUSY_ICON_GENERIC))
-			new /obj/effect/decal/cleanable/crayon(target,crayon_color,shadeColour,drawtype)
+			new /obj/effect/decal/cleanable/crayon(target,crayon_color,shade_color,drawtype)
 			to_chat(user, "You finish drawing.")
 			target.add_fingerprint(user) // Adds their fingerprints to the floor the crayon is drawn on.
 			if(uses)

--- a/code/game/objects/items/toys/toys.dm
+++ b/code/game/objects/items/toys/toys.dm
@@ -12,7 +12,6 @@
  * Other things
  */
 
-
 //recreational items
 
 /obj/item/toy
@@ -22,7 +21,6 @@
 	throw_range = 20
 	force = 0
 	black_market_value = 5
-
 
 /*
  * Balloons
@@ -118,24 +116,24 @@
 	icon_state = "singularity_s1"
 
 
-
 /*
  * Crayons
  */
 
 /obj/item/toy/crayon
 	name = "crayon"
-	desc = "A colourful crayon. Please refrain from eating it or putting it in your nose."
+	desc = "A colorful crayon. Please refrain from eating it or putting it in your nose."
 	icon = 'icons/obj/items/crayons.dmi'
 	icon_state = "crayonred"
 	w_class = SIZE_TINY
-	attack_verb = list("attacked", "coloured")
+	attack_verb = list("attacked", "colored")
 	black_market_value = 5
-	var/crayon_color = "#FF0000" //RGB
-	var/shadeColour = "#220000" //RGB
-	var/uses = 30 //0 for unlimited uses
+	var/crayon_color = COLOR_RED
+	var/shade_color = "#220000"
+	/// 0 for unlimited uses
+	var/uses = 30
 	var/instant = 0
-	var/colourName = "red" //for updateIcon purposes
+	var/colorName = "red" //for updateIcon purposes
 
 /*
  * Snap pops
@@ -235,7 +233,6 @@
 /obj/item/toy/waterflower/get_examine_text(mob/user)
 	. = ..()
 	. += "[reagents.total_volume] units of water left!"
-
 
 
 /*

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -341,7 +341,7 @@
 /obj/item/clothing/glasses/disco_fever/proc/apply_discovision(mob/user)
 	//Caramelldansen HUD overlay.
 	//Use of this filter in armed conflict is in direct contravention of the Geneva Suggestions (2120 revision)
-	//Colours are based on a bit of the music video. Original version was a rainbow with #c20000 and #db6c03 as well.
+	//Colors are based on a bit of the music video. Original version was a rainbow with #c20000 and #db6c03 as well.
 
 	//Animate the obj and onmob in sync with the client.
 	for(var/I in list(obj_glass_overlay, mob_glass_overlay))
@@ -361,35 +361,35 @@
 	if(!user.client) //Shouldn't happen but can't hurt to check.
 		return
 
-	var/base_colour
+	var/base_colors
 	if(!user.client.color) //No set client color.
-		base_colour = color_matrix_saturation(1.35) //Crank up the saturation and get ready to party.
+		base_colors = color_matrix_saturation(1.35) //Crank up the saturation and get ready to party.
 	else if(istext(user.client.color)) //Hex color string.
-		base_colour = color_matrix_multiply(color_matrix_from_string(user.client.color), color_matrix_saturation(1.35))
-	else //Colour matrix.
-		base_colour = color_matrix_multiply(user.client.color, color_matrix_saturation(1.35))
+		base_colors = color_matrix_multiply(color_matrix_from_string(user.client.color), color_matrix_saturation(1.35))
+	else //Color matrix.
+		base_colors = color_matrix_multiply(user.client.color, color_matrix_saturation(1.35))
 
 	var/list/colours = list(
-		"yellow" = color_matrix_multiply(base_colour, color_matrix_from_string("#d4c218")),
-		"green" = color_matrix_multiply(base_colour, color_matrix_from_string("#2dc404")),
-		"cyan" = color_matrix_multiply(base_colour, color_matrix_from_string("#2ac1db")),
-		"blue" = color_matrix_multiply(base_colour, color_matrix_from_string("#005BF7")),
-		"indigo" = color_matrix_multiply(base_colour, color_matrix_from_string("#b929f7"))
+		"yellow" = color_matrix_multiply(base_colors, color_matrix_from_string("#d4c218")),
+		"green" = color_matrix_multiply(base_colors, color_matrix_from_string("#2dc404")),
+		"cyan" = color_matrix_multiply(base_colors, color_matrix_from_string("#2ac1db")),
+		"blue" = color_matrix_multiply(base_colors, color_matrix_from_string("#005BF7")),
+		"indigo" = color_matrix_multiply(base_colors, color_matrix_from_string("#b929f7"))
 		)
 
 	//Animate the victim's client.
 	animate(user.client, color = colours["indigo"], time = 0.3 SECONDS, loop = -1)
-	animate(color = base_colour, time = 0.3 SECONDS)
+	animate(color = base_colors, time = 0.3 SECONDS)
 	animate(color = colours["cyan"], time = 0.3 SECONDS)
-	animate(color = base_colour, time = 0.3 SECONDS)
+	animate(color = base_colors, time = 0.3 SECONDS)
 	animate(color = colours["yellow"], time = 0.3 SECONDS)
-	animate(color = base_colour, time = 0.3 SECONDS)
+	animate(color = base_colors, time = 0.3 SECONDS)
 	animate(color = colours["green"], time = 0.3 SECONDS)
-	animate(color = base_colour, time = 0.3 SECONDS)
+	animate(color = base_colors, time = 0.3 SECONDS)
 	animate(color = colours["blue"], time = 0.3 SECONDS)
-	animate(color = base_colour, time = 0.3 SECONDS)
+	animate(color = base_colors, time = 0.3 SECONDS)
 	animate(color = colours["yellow"], time = 0.3 SECONDS)
-	animate(color = base_colour, time = 0.3 SECONDS)
+	animate(color = base_colors, time = 0.3 SECONDS)
 
 /obj/item/clothing/glasses/disco_fever/dropped(mob/living/carbon/human/user)
 	. = ..()

--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -138,9 +138,9 @@
 		dat += "<br>It will periodically alter the local temperature by [grown_seed.alter_temp] degrees Kelvin."
 
 	if(grown_seed.biolum)
-		dat += "<br>It is [grown_seed.biolum_colour ? "<font color='[grown_seed.biolum_colour]'>bio-luminescent</font>" : "bio-luminescent"]."
+		dat += "<br>It is [grown_seed.biolum_color ? "<font color='[grown_seed.biolum_color]'>bio-luminescent</font>" : "bio-luminescent"]."
 	if(grown_seed.flowers)
-		dat += "<br>It has [grown_seed.flower_colour ? "<font color='[grown_seed.flower_colour]'>flowers</font>" : "flowers"]."
+		dat += "<br>It has [grown_seed.flower_color ? "<font color='[grown_seed.flower_color]'>flowers</font>" : "flowers"]."
 
 	if(dat)
 		show_browser(user, dat, "Plant Analysis", "plant_analyzer")

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -111,13 +111,13 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 	// Cosmetics.
 	var/plant_icon   // Icon to use for the plant growing in the tray.
 	var/product_icon // Base to use for fruit coming from this plant (if a vine).
-	var/product_colour   // Color to apply to product base (if a vine).
+	var/product_color   // Color to apply to product base (if a vine).
 	var/packet_icon = "seed" // Icon to use for physical seed packet item.
 	var/biolum   // Plant is bioluminescent.
-	var/biolum_colour    // The color of the plant's radiance.
+	var/biolum_color    // The color of the plant's radiance.
 	var/flowers  // Plant has a flower overlay.
 	var/flower_icon = "vine_fruit"  // Which overlay to use.
-	var/flower_colour    // Which color to use.
+	var/flower_color    // Which color to use.
 
 //Creates a random seed. MAKE SURE THE LINE HAS DIVERGED BEFORE THIS IS CALLED.
 /datum/seed/proc/randomize()
@@ -301,7 +301,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 
 	if(prob(5))
 		biolum = 1
-		biolum_colour = "#[pick(list("FF0000","FF7F00","FFFF00","00FF00","0000FF","4B0082","8F00FF"))]"
+		biolum_color = "#[pick(list("FF0000","FF7F00","FFFF00","00FF00","0000FF","4B0082","8F00FF"))]"
 
 	endurance = rand(60,100)
 	yield = rand(3,15)
@@ -364,8 +364,8 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 					if(biolum)
 						source_turf.visible_message(SPAN_NOTICE("\The [display_name] begins to glow!"))
 						if(prob(degree*2))
-							biolum_colour = "#[pick(list("FF0000","FF7F00","FFFF00","00FF00","0000FF","4B0082","8F00FF"))]"
-							source_turf.visible_message(SPAN_NOTICE("\The [display_name]'s glow <font color='[biolum_colour]'>changes color</font>!"))
+							biolum_color = "#[pick(list("FF0000","FF7F00","FFFF00","00FF00","0000FF","4B0082","8F00FF"))]"
+							source_turf.visible_message(SPAN_NOTICE("\The [display_name]'s glow <font color='[biolum_color]'>changes color</font>!"))
 					else
 						source_turf.visible_message(SPAN_NOTICE("\The [display_name]'s glow dims..."))
 			if(11) //Flowers?
@@ -374,8 +374,8 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 					if(flowers)
 						source_turf.visible_message(SPAN_NOTICE("\The [display_name] sprouts a bevy of flowers!"))
 						if(prob(degree*2))
-							flower_colour = "#[pick(list("FF0000","FF7F00","FFFF00","00FF00","0000FF","4B0082","8F00FF"))]"
-						source_turf.visible_message(SPAN_NOTICE("\The [display_name]'s flowers <font=[flower_colour]>changes color</font>!"))
+							flower_color = "#[pick(list("FF0000","FF7F00","FFFF00","00FF00","0000FF","4B0082","8F00FF"))]"
+						source_turf.visible_message(SPAN_NOTICE("\The [display_name]'s flowers <font=[flower_color]>changes color</font>!"))
 					else
 						source_turf.visible_message(SPAN_NOTICE("\The [display_name]'s flowers wither and fall off."))
 			else //New chems! (20% chance)
@@ -487,12 +487,12 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 			if(gene.values.len < 7) return
 
 			product_icon =  gene.values[1]
-			product_colour =    gene.values[2]
+			product_color =    gene.values[2]
 			biolum =    gene.values[3]
-			biolum_colour = gene.values[4]
+			biolum_color = gene.values[4]
 			flowers =   gene.values[5]
 			flower_icon =   gene.values[6]
-			flower_colour = gene.values[7]
+			flower_color = gene.values[7]
 
 //Returns a list of the desired trait values.
 /datum/seed/proc/get_gene(genetype)
@@ -554,12 +554,12 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 		if("flowers")
 			P.values = list(
 				(product_icon  ? product_icon  : 0),
-				(product_colour    ? product_colour    : 0),
+				(product_color    ? product_color    : 0),
 				(biolum    ? biolum    : 0),
-				(biolum_colour ? biolum_colour : 0),
+				(biolum_color ? biolum_color : 0),
 				(flowers   ? flowers   : 0),
 				(flower_icon   ? flower_icon   : 0),
-				(flower_colour ? flower_colour : 0)
+				(flower_color ? flower_color : 0)
 				)
 
 	return (P ? P : 0)
@@ -673,10 +673,10 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 	new_seed.parasite =  parasite
 	new_seed.plant_icon =    plant_icon
 	new_seed.product_icon =  product_icon
-	new_seed.product_colour =    product_colour
+	new_seed.product_color =    product_color
 	new_seed.packet_icon =   packet_icon
 	new_seed.biolum =    biolum
-	new_seed.biolum_colour = biolum_colour
+	new_seed.biolum_color = biolum_color
 	new_seed.flowers =   flowers
 	new_seed.flower_icon =   flower_icon
 	new_seed.alter_temp = alter_temp
@@ -1099,7 +1099,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 	potency = 30
 	growth_stages = 4
 	biolum = 1
-	biolum_colour = "#006622"
+	biolum_color = "#006622"
 
 /datum/seed/mushroom/plastic
 	name = "plastic"
@@ -1551,7 +1551,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 	packet_icon = "seed-kudzu"
 	products = list(/obj/item/reagent_container/food/snacks/grown/kudzupod)
 	plant_icon = "kudzu"
-	product_colour = "#96D278"
+	product_color = "#96D278"
 	chems = list("plantmatter" = list(1,50), "anti_toxin" = list(1,25))
 
 	lifespan = 20

--- a/code/modules/hydroponics/vines.dm
+++ b/code/modules/hydroponics/vines.dm
@@ -181,14 +181,14 @@
 
 		if(harvest)
 			var/image/fruit_overlay = image('icons/obj/structures/machinery/hydroponics.dmi',"")
-			if(seed.product_colour)
-				fruit_overlay.color = seed.product_colour
+			if(seed.product_color)
+				fruit_overlay.color = seed.product_color
 			overlays += fruit_overlay
 
 		if(seed.flowers)
 			var/image/flower_overlay = image('icons/obj/structures/machinery/hydroponics.dmi',"[seed.flower_icon]")
-			if(seed.flower_colour)
-				flower_overlay.color = seed.flower_colour
+			if(seed.flower_color)
+				flower_overlay.color = seed.flower_color
 			overlays += flower_overlay
 
 /obj/effect/plantsegment/proc/spread()

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -128,7 +128,7 @@
 
 	blood_data["blood_type"] = get_blood_type()
 
-	blood_data["blood_colour"] = get_blood_color()
+	blood_data["blood_color"] = get_blood_color()
 	blood_data["viruses"] = list()
 
 	return blood_data

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1173,7 +1173,7 @@
 		for(var/datum/cm_objective/Objective in src.mind.objective_memory.disks)
 			src.mind.objective_memory.disks -= Objective
 
-/mob/living/carbon/human/proc/set_species(new_species, default_colour)
+/mob/living/carbon/human/proc/set_species(new_species, default_color)
 	if(!new_species)
 		new_species = "Human"
 
@@ -1207,7 +1207,7 @@
 
 	species.create_organs(src)
 
-	if(species.base_color && default_colour)
+	if(species.base_color && default_color)
 		//Apply color.
 		r_skin = hex2num(copytext(species.base_color,2,4))
 		g_skin = hex2num(copytext(species.base_color,4,6))

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -196,7 +196,7 @@ There are several things that need to be remembered:
 		if(facial_hair_style && facial_hair_style.species_allowed && (species.name in facial_hair_style.species_allowed))
 			var/image/facial_s = new/image("icon" = facial_hair_style.icon, "icon_state" = "[facial_hair_style.icon_state]_s")
 			facial_s.layer = -FACIAL_LAYER
-			if(facial_hair_style.do_colouration)
+			if(facial_hair_style.do_coloration)
 				facial_s.color = list(null, null, null, null, rgb(r_facial, g_facial, b_facial))
 			overlays_standing[FACIAL_LAYER] = facial_s
 			apply_overlay(FACIAL_LAYER)
@@ -206,7 +206,7 @@ There are several things that need to be remembered:
 		if(hair_style && (species.name in hair_style.species_allowed))
 			var/image/hair_s = new/image("icon" = hair_style.icon, "icon_state" = "[hair_style.icon_state]_s")
 			hair_s.layer = -HAIR_LAYER
-			if(hair_style.do_colouration)
+			if(hair_style.do_coloration)
 				hair_s.color = list(null, null, null, null, rgb(r_hair, g_hair, b_hair))
 
 			if(grad_style)

--- a/code/modules/mob/new_player/sprite_accessories/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories/sprite_accessories.dm
@@ -43,6 +43,6 @@
 		SYNTH_INFILTRATOR
 		)
 
-	// Whether or not the accessory can be affected by colouration
-	var/do_colouration = 1
+	// Whether or not the accessory can be affected by coloration
+	var/do_coloration = 1
 	var/selectable = 1

--- a/code/modules/mob/new_player/sprite_accessories/yautja_hair.dm
+++ b/code/modules/mob/new_player/sprite_accessories/yautja_hair.dm
@@ -1,7 +1,7 @@
 /datum/sprite_accessory/yautja_hair
 	icon = 'icons/mob/humans/yaut_hair.dmi'
 	species_allowed = list(SPECIES_YAUTJA)
-	do_colouration = FALSE
+	do_coloration = FALSE
 
 /datum/sprite_accessory/yautja_hair/standard
 	name = "Standard"

--- a/code/modules/organs/limb_objects.dm
+++ b/code/modules/organs/limb_objects.dm
@@ -105,7 +105,7 @@
 		var/datum/sprite_accessory/facial_hair_style = GLOB.facial_hair_styles_list[H.f_style]
 		if(facial_hair_style)
 			var/icon/facial = new/icon("icon" = facial_hair_style.icon, "icon_state" = "[facial_hair_style.icon_state]_s")
-			if(facial_hair_style.do_colouration)
+			if(facial_hair_style.do_coloration)
 				facial.Blend(rgb(H.r_facial, H.g_facial, H.b_facial), ICON_ADD)
 
 			overlays.Add(facial) // icon.Blend(facial, ICON_OVERLAY)
@@ -115,7 +115,7 @@
 		if(hair_style)
 			var/icon/hair = new/icon("icon" = hair_style.icon, "icon_state" = "[hair_style.icon_state]_s")
 			var/icon/eyes = new/icon("icon" = 'icons/mob/humans/onmob/human_face.dmi', "icon_state" = H.species ? H.species.eyes : "eyes_s")
-			if(hair_style.do_colouration)
+			if(hair_style.do_coloration)
 				hair.Blend(rgb(H.r_hair, H.g_hair, H.b_hair), ICON_ADD)
 				eyes.Blend(rgb(H.r_eyes, H.g_eyes, H.b_eyes), ICON_ADD)
 

--- a/code/modules/organs/organ_objects.dm
+++ b/code/modules/organs/organ_objects.dm
@@ -4,14 +4,20 @@
 	icon = 'icons/obj/items/organs.dmi'
 	icon_state = "appendix"
 
-	health = 100   // Process() ticks before death.
-
-	var/fresh = 3  // Squirts of blood left in it.
-	var/dead_icon  // Icon used when the organ dies.
-	var/robotic    // Is the limb prosthetic?
-	var/organ_tag  // What slot does it go in?
-	var/organ_type = /datum/internal_organ // Used to spawn the relevant organ data when produced via a machine or spawn().
-	var/datum/internal_organ/organ_data    // Stores info when removed.
+	/// Process() ticks before death.
+	health = 100
+	/// Squirts of blood left in it.
+	var/fresh = 3
+	/// Icon used when the organ dies.
+	var/dead_icon
+	/// Is the limb prosthetic?
+	var/robotic
+	/// What slot does it go in?
+	var/organ_tag
+	/// Used to spawn the relevant organ data when produced via a machine or spawn().
+	var/organ_type = /datum/internal_organ
+	/// Stores info when removed.
+	var/datum/internal_organ/organ_data
 	black_market_value = 25
 
 /obj/item/organ/attack_self(mob/user)
@@ -100,7 +106,7 @@
 	gender = PLURAL
 	organ_tag = "eyes"
 	organ_type = /datum/internal_organ/eyes
-	var/eye_colour
+	var/eyes_color
 
 /obj/item/organ/liver
 	name = "liver"
@@ -164,13 +170,13 @@
 
 /obj/item/organ/eyes/removed(mob/living/target, mob/living/user)
 
-	if(!eye_colour)
-		eye_colour = list(0,0,0)
+	if(!eyes_color)
+		eyes_color = list(0,0,0)
 
 	..() //Make sure target is set so we can steal their eye color for later.
 	var/mob/living/carbon/human/H = target
 	if(istype(H))
-		eye_colour = list(
+		eyes_color = list(
 			H.r_eyes ? H.r_eyes : 0,
 			H.g_eyes ? H.g_eyes : 0,
 			H.b_eyes ? H.b_eyes : 0
@@ -189,10 +195,10 @@
 
 	// Apply our eye color to the target.
 	var/mob/living/carbon/human/H = target
-	if(istype(H) && eye_colour)
-		H.r_eyes = eye_colour[1]
-		H.g_eyes = eye_colour[2]
-		H.b_eyes = eye_colour[3]
+	if(istype(H) && eyes_color)
+		H.r_eyes = eyes_color[1]
+		H.g_eyes = eyes_color[2]
+		H.b_eyes = eyes_color[3]
 		H.update_body()
 
 /obj/item/organ/proc/bitten(mob/user)

--- a/code/modules/paperwork/notepad.dm
+++ b/code/modules/paperwork/notepad.dm
@@ -14,14 +14,14 @@
 	var/page = 1
 	var/screen = 0
 
-	var/list/cover_colours = list("red", "green", "black", "blue")
-	var/cover_colour
+	var/list/cover_colors = list("red", "green", "black", "blue")
+	var/cover_color
 
 /obj/item/notepad/Initialize(mapload, ...)
 	. = ..()
-	if(!cover_colour)
-		cover_colour = pick(cover_colours)
-	icon_state = initial(icon_state) + "_[cover_colour]"
+	if(!cover_color)
+		cover_color = pick(cover_colors)
+	icon_state = initial(icon_state) + "_[cover_color]"
 
 	for(var/i = 1 to paper_left)
 		new /obj/item/paper(src)
@@ -129,13 +129,13 @@
 	add_fingerprint(usr)
 
 /obj/item/notepad/black
-	cover_colour = "black"
+	cover_color = "black"
 
 /obj/item/notepad/blue
-	cover_colour = "blue"
+	cover_color = "blue"
 
 /obj/item/notepad/green
-	cover_colour = "green"
+	cover_color = "green"
 
 /obj/item/notepad/red
-	cover_colour = "red"
+	cover_color = "red"

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -374,7 +374,7 @@
 	if(total_volume + amount > maximum_volume)
 		amount = maximum_volume - total_volume //Doesnt fit in. Make it disappear. Shouldnt happen. Will happen.
 
-	var/new_data = list("blood_type" = null, "blood_colour" = "#A10808", "viruses" = null, "resistances" = null, "last_source_mob" = null)
+	var/new_data = list("blood_type" = null, "blood_color" = "#A10808", "viruses" = null, "resistances" = null, "last_source_mob" = null)
 	if(data)
 		for(var/index in data)
 			new_data[index] = data[index]

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -19,7 +19,7 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	var/datum/reagents/holder = null
 	var/reagent_state = SOLID
 	var/data = 0 //Scratchpad for random chemicals to do their own thing TODO: unify this somehow?
-	var/list/data_properties = list("blood_type" = null, "blood_colour" = "#A10808", "viruses" = null, "resistances" = null) //mostly for viruses...
+	var/list/data_properties = list("blood_type" = null, "blood_color" = "#A10808", "viruses" = null, "resistances" = null) //mostly for viruses...
 	var/volume = 0
 	var/nutriment_factor = 0
 	var/custom_metabolism = REAGENTS_METABOLISM

--- a/code/modules/reagents/chemistry_reagents/other.dm
+++ b/code/modules/reagents/chemistry_reagents/other.dm
@@ -9,7 +9,7 @@
 	description = "Blood is classified as a connective tissue and consists of two main components: Plasma, which is a clear extracellular fluid. Formed elements, which are made up of the blood cells and platelets."
 	reagent_state = LIQUID
 	color = "#A10808"
-	data_properties = new/list("blood_type"=null,"blood_colour"= "#A10808","viruses"=null,"resistances"=null)
+	data_properties = new/list("blood_type"=null,"blood_color"= "#A10808","viruses"=null,"resistances"=null)
 	chemclass = CHEM_CLASS_RARE
 
 


### PR DESCRIPTION

# About the pull request
another PR to reduce the number of time colour is being used for variables.

did some change of comment to be to standard format too.

left with 54 instance of colour in 15 differents files. most that is left have color var that could create conflit so i would rather do in a seperate PR later.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
refactor: refactor to reduce the number variable using colour in them instead of color.
/:cl:
