### PR TITLE
Defender crest balloon alert (plus consistent centring)

### DIFF
--- a/code/datums/balloon_alerts/balloon_alerts.dm
+++ b/code/datums/balloon_alerts/balloon_alerts.dm
@@ -37,20 +37,15 @@
 	if (isnull(viewer_client))
 		return
 
-	var/bound_width = world.icon_size
-	if (ismovable(src))
-		var/atom/movable/movable_source = src
-		bound_width = movable_source.bound_width
-
 	var/image/balloon_alert = image(loc = get_atom_on_turf(src), layer = ABOVE_MOB_LAYER)
 	balloon_alert.plane = RUNECHAT_PLANE
 	balloon_alert.alpha = 0
 	balloon_alert.color = text_color
 	balloon_alert.appearance_flags = NO_CLIENT_COLOR|KEEP_APART|RESET_COLOR|RESET_TRANSFORM|RESET_ALPHA
 	balloon_alert.maptext = MAPTEXT("<span class='center langchat'>[text]</span>")
-	balloon_alert.maptext_x = (BALLOON_TEXT_WIDTH - bound_width) * -0.5
 	balloon_alert.maptext_height = WXH_TO_HEIGHT(viewer_client?.MeasureText(text, null, BALLOON_TEXT_WIDTH))
 	balloon_alert.maptext_width = BALLOON_TEXT_WIDTH
+	balloon_alert.maptext_x = get_maxptext_x_offset(balloon_alert)
 	if(appearance_flags & PIXEL_SCALE)
 		balloon_alert.appearance_flags |= PIXEL_SCALE
 	//"<span style='text-align: center; -dm-text-outline: 1px #0005'>[text]</span>"

--- a/code/datums/langchat/langchat.dm
+++ b/code/datums/langchat/langchat.dm
@@ -47,12 +47,12 @@
 				M.client.images -= langchat_image
 	langchat_listeners = null
 
-/atom/proc/langchat_set_x_offset()
-	langchat_image.maptext_x = world.icon_size / 2 - langchat_image.maptext_width / 2
-/atom/movable/langchat_set_x_offset()
-	langchat_image.maptext_x = bound_width / 2 - langchat_image.maptext_width / 2
-/mob/langchat_set_x_offset()
-	langchat_image.maptext_x = icon_size / 2 - langchat_image.maptext_width / 2
+/atom/proc/get_maxptext_x_offset(image/maptext_image)
+	return (world.icon_size / 2) - (maptext_image.maptext_width / 2)
+/atom/movable/get_maxptext_x_offset(image/maptext_image)
+	return (bound_width / 2) - (maptext_image.maptext_width / 2)
+/mob/get_maxptext_x_offset(image/maptext_image)
+	return (icon_size / 2) - (maptext_image.maptext_width / 2)
 
 ///Creates the image if one does not exist, resets settings that are modified by speech procs.
 /atom/proc/langchat_make_image(override_color = null)
@@ -64,7 +64,7 @@
 		langchat_image.maptext_y = langchat_height
 		langchat_image.maptext_height = 64
 		langchat_image.maptext_y -= LANGCHAT_MESSAGE_POP_Y_SINK
-		langchat_set_x_offset()
+		langchat_image.maptext_x = get_maxptext_x_offset(langchat_image)
 
 	langchat_image.pixel_y = 0
 	langchat_image.alpha = 0
@@ -109,7 +109,7 @@
 
 	langchat_image.maptext = text_to_display
 	langchat_image.maptext_width = LANGCHAT_WIDTH
-	langchat_set_x_offset()
+	langchat_image.maptext_x = get_maxptext_x_offset(langchat_image)
 
 	langchat_listeners = listeners
 	for(var/mob/M in langchat_listeners)
@@ -156,7 +156,7 @@
 
 	langchat_image.maptext = text_to_display
 	langchat_image.maptext_width = LANGCHAT_WIDTH * 2
-	langchat_set_x_offset()
+	langchat_image.maptext_x = get_maxptext_x_offset(langchat_image)
 
 	langchat_listeners = listeners
 	for(var/mob/M in langchat_listeners)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_powers.dm
@@ -17,6 +17,8 @@
 
 	if(xeno.crest_defense)
 		to_chat(xeno, SPAN_XENOWARNING("We lower our crest."))
+		xeno.balloon_alert(xeno, "crest lowered")
+
 		xeno.ability_speed_modifier += speed_debuff
 		xeno.armor_deflection_buff += armor_buff
 		xeno.mob_size = MOB_SIZE_BIG //knockback immune
@@ -24,6 +26,8 @@
 		xeno.update_icons()
 	else
 		to_chat(xeno, SPAN_XENOWARNING("We raise our crest."))
+		xeno.balloon_alert(xeno, "crest raised")
+
 		xeno.ability_speed_modifier -= speed_debuff
 		xeno.armor_deflection_buff -= armor_buff
 		xeno.mob_size = MOB_SIZE_XENO //no longer knockback immune
@@ -313,4 +317,3 @@
 
 /datum/action/xeno_action/onclick/soak/proc/remove_enrage()
 	owner.remove_filter("steelcrest_enraged")
-


### PR DESCRIPTION

# About the pull request

Adds balloon alerts to the Defender's 'Toggle Crest Defense' ability.

Also a tiny refactor to make balloon alerts always be centred above the source atom's sprite, the same way runechat/langchat does it. (I can split this part off into a separate PR if necessary.)

# Explain why it's good for the game

There *is* already a sprite change when toggling the crest, but it can sometimes be difficult to notice when you're not facing to the side.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

## Before:

https://github.com/cmss13-devs/cmss13/assets/57483089/b1d80195-06b9-4c63-9cac-166214142396

https://github.com/cmss13-devs/cmss13/assets/57483089/7a868080-0608-4499-948f-9c5b91ff28f4

*(Obviously the defender text wasn't there before this PR, but just for demonstration purposes.)*

## After:

https://github.com/cmss13-devs/cmss13/assets/57483089/8700f8e9-3b23-4c83-b2d7-eb2355d01156

https://github.com/cmss13-devs/cmss13/assets/57483089/f4bf8678-81e1-4abd-adce-02833cbb5a6a

</details>


# Changelog
:cl:
add: Added a 'balloon alert' when toggling Crest Defense as a Defender.
code: Made balloon alerts centre themselves on xeno sprites.
/:cl:
