### PR TITLE
Fixes the equipment attach point being on the wrong plane

### DIFF
--- a/code/modules/dropships/attach_points/attach_point.dm
+++ b/code/modules/dropships/attach_points/attach_point.dm
@@ -7,6 +7,7 @@
 	unacidable = TRUE
 	anchored = TRUE
 	layer = ABOVE_TURF_LAYER
+	plane = FLOOR_PLANE
 	/// The currently installed equipment, if any
 	var/obj/structure/dropship_equipment/installed_equipment
 	/// What kind of equipment this base accepts


### PR DESCRIPTION
# About the pull request

Currently, the equipment attach points (the ones on the Alamo and the Normandy) are on the basic atom layer, -6. This causes certain effects, such as hive clusters or egg morphers layer below it (that are on `FLOOR_PLANE`, -7).

See the images for a before and after.

# Explain why it's good for the game

No weird layering. Hive clusters are now visible when placed on the same tile as attach points.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Before: 

![image](https://github.com/cmss13-devs/cmss13/assets/49321394/26097bbd-37bc-43e3-8538-b9830a7d0d08)

After:

![image](https://github.com/cmss13-devs/cmss13/assets/49321394/ad545dd7-3c95-4f89-b224-4634e1a8afff)

</details>


# Changelog
:cl:
fix: Special xeno structures no longer layer below the Alamo and Normandy's equipment attach points.
/:cl:
