### PR TITLE
Replaces the normal Zippo with Wey-Yu Zippo in the CLs briefcase

### DIFF
--- a/code/game/objects/items/devices/portable_vendor.dm
+++ b/code/game/objects/items/devices/portable_vendor.dm
@@ -276,7 +276,7 @@
 		list("SMOKABLES", 0, null, null, null),
 		list("Cigars", 5, /obj/item/storage/fancy/cigar, "white", "Case of premium cigars, untampered."),
 		list("Cigarettes", 5, /obj/item/storage/fancy/cigarettes/wypacket, "white", "Weyland-Yutani Gold packet, for the more sophisticated taste."),
-		list("Zippo", 5, /obj/item/tool/lighter/zippo, "white", "A Zippo lighter, for those smoking in style."),
+		list("Zippo", 5, /obj/item/tool/lighter/zippo/executive, "white", "A Weyland-Yutani brand Zippo lighter, for those smoking in style."),
 
 		list("DRINKABLES", 0, null, null, null),
 		list("Sake", 5, /obj/item/reagent_container/food/drinks/bottle/sake, "white", "Weyland-Yutani Sake, for a proper business dinner."),


### PR DESCRIPTION

# About the pull request

Title

# Explain why it's good for the game

I want the new zippo to see some use first of all and second, if anyone asks the CL for a lighter, he can print one of these bad boys out and remind the Marines who control thems everytime they light a cig. Promotional material for the Company. Maybe I should add those W-Y mugs too.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Added the Wey-Yu lighter to the CLs briefcase instead of a normal one
/:cl:
