### PR TITLE
Fixes the `do_after()` icon rendering above everything else

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -219,6 +219,8 @@
 #define FLOOR_PLANE -7
 /// Game Plane, where most of the game objects reside
 #define GAME_PLANE -6
+/// Above Game Plane. For things which are above game objects, but below screen effects.
+#define ABOVE_GAME_PLANE -5
 /// Roof plane, disappearing when entering buildings
 #define ROOF_PLANE -4
 

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -933,103 +933,103 @@ GLOBAL_DATUM(action_purple_power_up, /image)
 		if(!GLOB.busy_indicator_clock)
 			GLOB.busy_indicator_clock = image('icons/mob/mob.dmi', null, "busy_generic", "pixel_y" = 22)
 			GLOB.busy_indicator_clock.layer = FLY_LAYER
-			GLOB.busy_indicator_clock.plane = ABOVE_HUD_PLANE
+			GLOB.busy_indicator_clock.plane = ABOVE_GAME_PLANE
 		return GLOB.busy_indicator_clock
 	else if(busy_type == BUSY_ICON_MEDICAL)
 		if(!GLOB.busy_indicator_medical)
 			GLOB.busy_indicator_medical = image('icons/mob/mob.dmi', null, "busy_medical", "pixel_y" = 0) //This shows directly on top of the mob, no offset!
 			GLOB.busy_indicator_medical.layer = FLY_LAYER
-			GLOB.busy_indicator_medical.plane = ABOVE_HUD_PLANE
+			GLOB.busy_indicator_medical.plane = ABOVE_GAME_PLANE
 		return GLOB.busy_indicator_medical
 	else if(busy_type == BUSY_ICON_BUILD)
 		if(!GLOB.busy_indicator_build)
 			GLOB.busy_indicator_build = image('icons/mob/mob.dmi', null, "busy_build", "pixel_y" = 22)
 			GLOB.busy_indicator_build.layer = FLY_LAYER
-			GLOB.busy_indicator_build.plane = ABOVE_HUD_PLANE
+			GLOB.busy_indicator_build.plane = ABOVE_GAME_PLANE
 		return GLOB.busy_indicator_build
 	else if(busy_type == BUSY_ICON_FRIENDLY)
 		if(!GLOB.busy_indicator_friendly)
 			GLOB.busy_indicator_friendly = image('icons/mob/mob.dmi', null, "busy_friendly", "pixel_y" = 22)
 			GLOB.busy_indicator_friendly.layer = FLY_LAYER
-			GLOB.busy_indicator_friendly.plane = ABOVE_HUD_PLANE
+			GLOB.busy_indicator_friendly.plane = ABOVE_GAME_PLANE
 		return GLOB.busy_indicator_friendly
 	else if(busy_type == BUSY_ICON_HOSTILE)
 		if(!GLOB.busy_indicator_hostile)
 			GLOB.busy_indicator_hostile = image('icons/mob/mob.dmi', null, "busy_hostile", "pixel_y" = 22)
 			GLOB.busy_indicator_hostile.layer = FLY_LAYER
-			GLOB.busy_indicator_hostile.plane = ABOVE_HUD_PLANE
+			GLOB.busy_indicator_hostile.plane = ABOVE_GAME_PLANE
 		return GLOB.busy_indicator_hostile
 	else if(busy_type == EMOTE_ICON_HIGHFIVE)
 		if(!GLOB.emote_indicator_highfive)
 			GLOB.emote_indicator_highfive = image('icons/mob/mob.dmi', null, "emote_highfive", "pixel_y" = 22)
 			GLOB.emote_indicator_highfive.layer = FLY_LAYER
-			GLOB.emote_indicator_highfive.plane = ABOVE_HUD_PLANE
+			GLOB.emote_indicator_highfive.plane = ABOVE_GAME_PLANE
 		return GLOB.emote_indicator_highfive
 	else if(busy_type == EMOTE_ICON_FISTBUMP)
 		if(!GLOB.emote_indicator_fistbump)
 			GLOB.emote_indicator_fistbump = image('icons/mob/mob.dmi', null, "emote_fistbump", "pixel_y" = 22)
 			GLOB.emote_indicator_fistbump.layer = FLY_LAYER
-			GLOB.emote_indicator_fistbump.plane = ABOVE_HUD_PLANE
+			GLOB.emote_indicator_fistbump.plane = ABOVE_GAME_PLANE
 		return GLOB.emote_indicator_fistbump
 	else if(busy_type == EMOTE_ICON_ROCK_PAPER_SCISSORS)
 		if(!GLOB.emote_indicator_rock_paper_scissors)
 			GLOB.emote_indicator_rock_paper_scissors = image('icons/mob/mob.dmi', null, "emote_rps", "pixel_y" = 22)
 			GLOB.emote_indicator_rock_paper_scissors.layer = FLY_LAYER
-			GLOB.emote_indicator_rock_paper_scissors.plane = ABOVE_HUD_PLANE
+			GLOB.emote_indicator_rock_paper_scissors.plane = ABOVE_GAME_PLANE
 		return GLOB.emote_indicator_rock_paper_scissors
 	else if(busy_type == EMOTE_ICON_ROCK)
 		if(!GLOB.emote_indicator_rock)
 			GLOB.emote_indicator_rock = image('icons/mob/mob.dmi', null, "emote_rock", "pixel_y" = 22)
 			GLOB.emote_indicator_rock.layer = FLY_LAYER
-			GLOB.emote_indicator_rock.plane = ABOVE_HUD_PLANE
+			GLOB.emote_indicator_rock.plane = ABOVE_GAME_PLANE
 		return GLOB.emote_indicator_rock
 	else if(busy_type == EMOTE_ICON_PAPER)
 		if(!GLOB.emote_indicator_paper)
 			GLOB.emote_indicator_paper = image('icons/mob/mob.dmi', null, "emote_paper", "pixel_y" = 22)
 			GLOB.emote_indicator_paper.layer = FLY_LAYER
-			GLOB.emote_indicator_paper.plane = ABOVE_HUD_PLANE
+			GLOB.emote_indicator_paper.plane = ABOVE_GAME_PLANE
 		return GLOB.emote_indicator_paper
 	else if(busy_type == EMOTE_ICON_SCISSORS)
 		if(!GLOB.emote_indicator_scissors)
 			GLOB.emote_indicator_scissors = image('icons/mob/mob.dmi', null, "emote_scissors", "pixel_y" = 22)
 			GLOB.emote_indicator_scissors.layer = FLY_LAYER
-			GLOB.emote_indicator_scissors.plane = ABOVE_HUD_PLANE
+			GLOB.emote_indicator_scissors.plane = ABOVE_GAME_PLANE
 		return GLOB.emote_indicator_scissors
 	else if(busy_type == EMOTE_ICON_HEADBUTT)
 		if(!GLOB.emote_indicator_headbutt)
 			GLOB.emote_indicator_headbutt = image('icons/mob/mob.dmi', null, "emote_headbutt", "pixel_y" = 22)
 			GLOB.emote_indicator_headbutt.layer = FLY_LAYER
-			GLOB.emote_indicator_headbutt.plane = ABOVE_HUD_PLANE
+			GLOB.emote_indicator_headbutt.plane = ABOVE_GAME_PLANE
 		return GLOB.emote_indicator_headbutt
 	else if(busy_type == EMOTE_ICON_TAILSWIPE)
 		if(!GLOB.emote_indicator_tailswipe)
 			GLOB.emote_indicator_tailswipe = image('icons/mob/mob.dmi', null, "emote_tailswipe", "pixel_y" = 22)
 			GLOB.emote_indicator_tailswipe.layer = FLY_LAYER
-			GLOB.emote_indicator_tailswipe.plane = ABOVE_HUD_PLANE
+			GLOB.emote_indicator_tailswipe.plane = ABOVE_GAME_PLANE
 		return GLOB.emote_indicator_tailswipe
 	else if(busy_type == ACTION_RED_POWER_UP)
 		if(!GLOB.action_red_power_up)
 			GLOB.action_red_power_up = image('icons/effects/effects.dmi', null, "anger", "pixel_x" = 16)
 			GLOB.action_red_power_up.layer = FLY_LAYER
-			GLOB.action_red_power_up.plane = ABOVE_HUD_PLANE
+			GLOB.action_red_power_up.plane = ABOVE_GAME_PLANE
 		return GLOB.action_red_power_up
 	else if(busy_type == ACTION_GREEN_POWER_UP)
 		if(!GLOB.action_green_power_up)
 			GLOB.action_green_power_up = image('icons/effects/effects.dmi', null, "vitality", "pixel_x" = 16)
 			GLOB.action_green_power_up.layer = FLY_LAYER
-			GLOB.action_green_power_up.plane = ABOVE_HUD_PLANE
+			GLOB.action_green_power_up.plane = ABOVE_GAME_PLANE
 		return GLOB.action_green_power_up
 	else if(busy_type == ACTION_BLUE_POWER_UP)
 		if(!GLOB.action_blue_power_up)
 			GLOB.action_blue_power_up = image('icons/effects/effects.dmi', null, "shock", "pixel_x" = 16)
 			GLOB.action_blue_power_up.layer = FLY_LAYER
-			GLOB.action_blue_power_up.plane = ABOVE_HUD_PLANE
+			GLOB.action_blue_power_up.plane = ABOVE_GAME_PLANE
 		return GLOB.action_blue_power_up
 	else if(busy_type == ACTION_PURPLE_POWER_UP)
 		if(!GLOB.action_purple_power_up)
 			GLOB.action_purple_power_up = image('icons/effects/effects.dmi', null, "pain", "pixel_x" = 16)
 			GLOB.action_purple_power_up.layer = FLY_LAYER
-			GLOB.action_purple_power_up.plane = ABOVE_HUD_PLANE
+			GLOB.action_purple_power_up.plane = ABOVE_GAME_PLANE
 		return GLOB.action_purple_power_up
 
 

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -49,6 +49,12 @@
 	if(istype(mymob) && mymob?.client?.prefs?.toggle_prefs & TOGGLE_AMBIENT_OCCLUSION)
 		add_filter("AO", 1, drop_shadow_filter(x = 0, y = -2, size = 4, color = "#04080FAA"))
 
+/atom/movable/screen/plane_master/game_world_above
+	name = "above game world plane master"
+	plane = ABOVE_GAME_PLANE
+	appearance_flags = PLANE_MASTER //should use client color
+	blend_mode = BLEND_OVERLAY
+
 /atom/movable/screen/plane_master/ghost
 	name = "ghost plane master"
 	plane = GHOST_PLANE


### PR DESCRIPTION

# About the pull request

Fixes the `do_after()` progress icons rendering above *everything* else, including darkness and screen effects like blindness.

When making #5379, I didn't consider the side effects of the progress icons being on `ABOVE_HUD_PLANE`. It works fine on other servers where they're usually only visible to the user performing the action, but on CM these icons are visible to everyone.
This means that progress indicators over mobs are visible in complete darkness, through crit/blindness overlays, etc.

This PR adds a new `ABOVE_GAME_PLANE` define and moves them to that instead, since it seems like the best fit for how the progress icons should behave. (Always above in-game stuff, but below any effects and lighting.)
*(I've never messed with plane masters so I'm not 100% sure I did it correctly, but it works in testing at least.)*
# Explain why it's good for the game

Fixes being able to spot xenos in darkness when they're doing something (e.g. drones building), and just makes it act as expected.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

**Before:**
![(null)scrnshot1](https://github.com/cmss13-devs/cmss13/assets/57483089/079bc397-f658-4954-a1f6-257b6f8d4a9b)

(not much point to an 'after' since it's just a black screen lol)

</details>


# Changelog
:cl:
fix: Fixed the 'busy' circle icon being drawn above darkness and screen effects.
/:cl:
