### PR TITLE
Fixes wrong dropship attachment planes

### DIFF
--- a/code/modules/dropships/attach_points/attach_point.dm
+++ b/code/modules/dropships/attach_points/attach_point.dm
@@ -7,7 +7,7 @@
 	unacidable = TRUE
 	anchored = TRUE
 	layer = ABOVE_TURF_LAYER
-	plane = FLOOR_PLANE
+	plane = GAME_PLANE
 	/// The currently installed equipment, if any
 	var/obj/structure/dropship_equipment/installed_equipment
 	/// What kind of equipment this base accepts

--- a/code/modules/dropships/attach_points/templates.dm
+++ b/code/modules/dropships/attach_points/templates.dm
@@ -87,8 +87,14 @@
 /obj/effect/attach_point/crew_weapon/dropship1
 	ship_tag = DROPSHIP_ALAMO
 
+/obj/effect/attach_point/crew_weapon/dropship1/floor
+	plane = FLOOR_PLANE
+
 /obj/effect/attach_point/crew_weapon/dropship2
 	ship_tag = DROPSHIP_NORMANDY
+
+/obj/effect/attach_point/crew_weapon/dropship2/floor
+	plane = FLOOR_PLANE
 
 /obj/effect/attach_point/electronics
 	name = "electronic system attach point"

--- a/maps/shuttles/dropship_alamo.dmm
+++ b/maps/shuttles/dropship_alamo.dmm
@@ -416,7 +416,7 @@
 	},
 /area/shuttle/drop1/sulaco)
 "Kk" = (
-/obj/effect/attach_point/crew_weapon/dropship1{
+/obj/effect/attach_point/crew_weapon/dropship1/floor{
 	attach_id = 7
 	},
 /turf/open/shuttle/dropship{
@@ -450,7 +450,7 @@
 	},
 /area/shuttle/drop1/sulaco)
 "Nv" = (
-/obj/effect/attach_point/crew_weapon/dropship1{
+/obj/effect/attach_point/crew_weapon/dropship1/floor{
 	attach_id = 8
 	},
 /turf/open/shuttle/dropship{
@@ -507,7 +507,7 @@
 	},
 /area/shuttle/drop1/sulaco)
 "PV" = (
-/obj/effect/attach_point/crew_weapon/dropship1{
+/obj/effect/attach_point/crew_weapon/dropship1/floor{
 	attach_id = 9
 	},
 /turf/open/shuttle/dropship{

--- a/maps/shuttles/dropship_normandy.dmm
+++ b/maps/shuttles/dropship_normandy.dmm
@@ -96,7 +96,7 @@
 	},
 /area/shuttle/drop2/sulaco)
 "hn" = (
-/obj/effect/attach_point/crew_weapon/dropship2{
+/obj/effect/attach_point/crew_weapon/dropship2/floor{
 	attach_id = 8
 	},
 /turf/open/shuttle/dropship{
@@ -326,7 +326,7 @@
 	},
 /area/shuttle/drop2/sulaco)
 "Bg" = (
-/obj/effect/attach_point/crew_weapon/dropship2{
+/obj/effect/attach_point/crew_weapon/dropship2/floor{
 	attach_id = 7
 	},
 /turf/open/shuttle/dropship{
@@ -478,7 +478,7 @@
 /turf/template_noop,
 /area/shuttle/drop2/sulaco)
 "MA" = (
-/obj/effect/attach_point/crew_weapon/dropship2{
+/obj/effect/attach_point/crew_weapon/dropship2/floor{
 	attach_id = 9
 	},
 /turf/open/shuttle/dropship{


### PR DESCRIPTION
# About the pull request

Fixes #5494 that I broke with #5475

sorry

# Explain why it's good for the game

You can attach engines/weapons to the dropships again _and_ not have xeno structures layer below the floor attach points.

# Testing Photographs and Procedure

1. Attach various equipment to the dropships
2. See if they show up
3. Spawn xeno structures on the floor attach points

see screenshots below

<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/49321394/0d7344f2-0e38-4955-b8c2-3394dd1eb197)

![image](https://github.com/cmss13-devs/cmss13/assets/49321394/2a8dc816-58db-478b-825d-81b78efaf80d)

![image](https://github.com/cmss13-devs/cmss13/assets/49321394/e45e6d91-2b74-4e83-9457-9d90501bcad7)

![image](https://github.com/cmss13-devs/cmss13/assets/49321394/7f4e4ddf-a509-49f6-90fb-6d3009905334)

</details>


# Changelog
:cl:
fix: Fixes engine/weapon attach points layering below the dropship walls.
/:cl:
