### PR TITLE
Makes larvae and facehuggers able to use custom emotes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -220,7 +220,13 @@
 	return
 
 /mob/living/carbon/xenomorph/facehugger/emote(act, m_type, message, intentional, force_silence)
+	// Custom emote
+	if(act == "me")
+		return ..()
+
+	// Otherwise, ""roar""!
 	playsound(loc, "alien_roar_larva", 15)
+	return TRUE
 
 /mob/living/carbon/xenomorph/facehugger/get_status_tab_items()
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
@@ -157,7 +157,13 @@
 	return larva
 
 /mob/living/carbon/xenomorph/larva/emote(act, m_type, message, intentional, force_silence)
+	// Custom emote
+	if(act == "me")
+		return ..()
+
+	// Otherwise, ""roar""!
 	playsound(loc, "alien_roar_larva", 15)
+	return TRUE
 
 /mob/living/carbon/xenomorph/larva/is_xeno_grabbable()
 	return TRUE


### PR DESCRIPTION

# About the pull request

Makes larvae and facehuggers able to use custom emotes with the 'me' verb. (All other emotes still work the same as before.)

(The code just being copy+pasted between the two castes isn't great, but I can't really think of a cleaner way of doing it.)

# Explain why it's good for the game

Larva RP is one of the most vital parts of the game.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Made larvae and facehuggers able to use custom emotes.
/:cl:
