### PR TITLE
Workin Joey readded to Maint Bar

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -63098,6 +63098,10 @@
 	icon_state = "plate"
 	},
 /area/almayer/hull/lower_hull/l_m_p)
+"rix" = (
+/obj/structure/prop/invuln/joey,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hull/lower_hull/l_m_s)
 "riE" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/effect/decal/warning_stripes{
@@ -118718,7 +118722,7 @@ uRM
 ipe
 ehR
 nsY
-aLf
+rix
 aLf
 tRc
 qEW


### PR DESCRIPTION

# About the pull request

Workin Joey re-added to maint bar, it wasnt added when it was remapped.

# Explain why it's good for the game

Fixing an oversight of a prop being missing in the bar

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: Workin Joey has returned to the Maintenance Bar
/:cl:
