### PR TITLE
Fixes being gibbed sometimes breaking observer movement

### DIFF
--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -2,16 +2,6 @@
 	category = CATEGORY_HUMAN
 	weight = WEIGHT_MOB
 
-/datum/keybinding/mob/down(client/user)
-	. = ..()
-	if(isobserver(user.mob))
-		return TRUE
-
-/datum/keybinding/mob/up(client/user)
-	. = ..()
-	if(isobserver(user.mob))
-		return TRUE
-
 /datum/keybinding/mob/stop_pulling
 	hotkey_keys = list("H", "Delete")
 	classic_keys = list("Delete")


### PR DESCRIPTION

# About the pull request

Fixes a bug where having holding down the Ctrl or Alt key, being gibbed, then releasing the key could completely prevent you from moving. (Until you relog or respawn)

This was caused by `/datum/keybinding/mob/prevent_movement`'s `down()`/`up()` procs returning early if the user's body was an observer.
In this case, `user.movement_locked` gets set to `TRUE` while the user has a body, the body gets gibbed and the user is forced into an observer, and then the proc is unable to set it back to `FALSE`.
https://github.com/cmss13-devs/cmss13/blob/93a1a8b10846da366d1ad2ce44f124d8f0f4ac7c/code/datums/keybinding/mob.dm#L229-L239

<hr>

Having spent a while looking around the codebase, I'm almost certain that removing the `isobserver()` checks won't have any negative side effects. Despite that, this PR should maybe get testmerged anyway just in case it does.

# Explain why it's good for the game

Observers should be able to move around.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

**NOTE:** These videos aren't the best at showing what's happening since you can't see my keyboard inputs, so for reference I started holding Ctrl before pressing 'Yes', then released it after the facehugger gibbed.

## Before:

https://github.com/cmss13-devs/cmss13/assets/57483089/5b801b0c-2a9a-4bf9-83d7-144ec857e6a7

## After:

https://github.com/cmss13-devs/cmss13/assets/57483089/51ffded5-011d-410b-9076-55368d41c254

</details>


# Changelog
:cl:
fix: Fixed being gibbed with the Ctrl or Alt key held sometimes breaking movement as an observer.
/:cl:
