### PR TITLE
Metal Foam rebalance.

### DIFF
--- a/code/datums/supply_packs/explosives.dm
+++ b/code/datums/supply_packs/explosives.dm
@@ -12,8 +12,8 @@
 		/obj/item/explosive/grenade/high_explosive/m15,
 		/obj/item/explosive/grenade/high_explosive/pmc,
 		/obj/item/explosive/grenade/high_explosive/pmc,
-		/obj/item/explosive/grenade/metal_foam
-		/obj/item/explosive/grenade/metal_foam
+		/obj/item/explosive/grenade/metal_foam,
+		/obj/item/explosive/grenade/metal_foam,
 	)
 	cost = 40
 	containertype = /obj/structure/closet/crate/explosives

--- a/code/datums/supply_packs/explosives.dm
+++ b/code/datums/supply_packs/explosives.dm
@@ -1,7 +1,7 @@
 // Group to populate with all the explosives exept OB and mortar shell
 
 /datum/supply_packs/explosives
-	name = "surplus explosives crate (claymore mine x5, M40 HIDP x2, M40 HEDP x2, M15 Frag x2, M12 Blast x2)"
+	name = "surplus explosives crate (claymore mine x5, M40 HIDP x2, M40 HEDP x2, M15 Frag x2, M12 Blast x2, M40 MFHS x2)"
 	contains = list(
 		/obj/item/storage/box/explosive_mines,
 		/obj/item/explosive/grenade/high_explosive,
@@ -12,6 +12,8 @@
 		/obj/item/explosive/grenade/high_explosive/m15,
 		/obj/item/explosive/grenade/high_explosive/pmc,
 		/obj/item/explosive/grenade/high_explosive/pmc,
+		/obj/item/explosive/grenade/metal_foam
+		/obj/item/explosive/grenade/metal_foam
 	)
 	cost = 40
 	containertype = /obj/structure/closet/crate/explosives

--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -55,7 +55,7 @@
 		list("M74 AGM-Star Shell", round(scale * 2), /obj/item/explosive/grenade/high_explosive/airburst/starshell, VENDOR_ITEM_REGULAR),
 		list("M74 AGM-Hornet Shell", round(scale * 4), /obj/item/explosive/grenade/high_explosive/airburst/hornet_shell, VENDOR_ITEM_REGULAR),
 		list("M40 HIRR Baton Slug", round(scale * 8), /obj/item/explosive/grenade/slug/baton, VENDOR_ITEM_REGULAR),
-		list("M40 MFHS Metal Foam Grenade", round(scale * 3), /obj/item/explosive/grenade/metal_foam, VENDOR_ITEM_REGULAR),
+		list("M40 MFHS Metal Foam Grenade", round(scale * 6), /obj/item/explosive/grenade/metal_foam, VENDOR_ITEM_REGULAR),
 		list("Plastic Explosives", round(scale * 3), /obj/item/explosive/plastic, VENDOR_ITEM_REGULAR),
 		list("Breaching Charge", round(scale * 2), /obj/item/explosive/plastic/breaching_charge, VENDOR_ITEM_REGULAR),
 

--- a/code/game/objects/effects/effect_system/foam.dm
+++ b/code/game/objects/effects/effect_system/foam.dm
@@ -156,7 +156,7 @@
 // dense and opaque, but easy to break
 
 #define FOAMED_METAL_FIRE_ACT_DMG 50
-#define FOAMED_METAL_XENO_SLASH 0.8
+#define FOAMED_METAL_XENO_SLASH 2.5
 #define FOAMED_METAL_ITEM_MELEE 2
 #define FOAMED_METAL_BULLET_DMG 2
 #define FOAMED_METAL_EXPLOSION_DMG 1

--- a/code/game/objects/effects/effect_system/foam.dm
+++ b/code/game/objects/effects/effect_system/foam.dm
@@ -211,7 +211,7 @@
 	return FALSE
 
 /obj/structure/foamed_metal/attack_alien(mob/living/carbon/xenomorph/X, dam_bonus)
-	var/damage = (rand(X.melee_damage_lower, X.melee_damage_upper) + dam_bonus)
+	var/damage = ((round((X.melee_damage_lower+X.melee_damage_upper)/2)) + dam_bonus)
 
 	//Frenzy bonus
 	if(X.frenzy_aura > 0)

--- a/code/game/objects/effects/effect_system/foam.dm
+++ b/code/game/objects/effects/effect_system/foam.dm
@@ -156,7 +156,7 @@
 // dense and opaque, but easy to break
 
 #define FOAMED_METAL_FIRE_ACT_DMG 50
-#define FOAMED_METAL_XENO_SLASH 2.5
+#define FOAMED_METAL_XENO_SLASH 1.75
 #define FOAMED_METAL_ITEM_MELEE 2
 #define FOAMED_METAL_BULLET_DMG 2
 #define FOAMED_METAL_EXPLOSION_DMG 1
@@ -173,7 +173,7 @@
 
 /obj/structure/foamed_metal/iron
 	icon_state = "ironfoam"
-	health = 85
+	health = 70
 	name = "foamed iron"
 	desc = "A slightly stronger lightweight foamed iron wall."
 

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -705,11 +705,11 @@
 	det_time = 20
 	underslug_launchable = TRUE
 	harmful = FALSE
-	var/foam_metal_type = FOAM_METAL_TYPE_ALUMINIUM
+	var/foam_metal_type = FOAM_METAL_TYPE_IRON
 
 /obj/item/explosive/grenade/metal_foam/prime()
 	var/datum/effect_system/foam_spread/s = new()
-	s.set_up(12, get_turf(src), metal_foam = foam_metal_type) //Metalfoam 1 for aluminum foam, 2 for iron foam (Stronger), 12 amt = 2 tiles radius (5 tile length diamond)
+	s.set_up(12, get_turf(src), metal_foam = foam_metal_type) //12 amt = 2 tiles radius (5 tile length diamond)
 	s.start()
 	qdel(src)
 

--- a/code/modules/reagents/chemistry_reactions/other.dm
+++ b/code/modules/reagents/chemistry_reactions/other.dm
@@ -385,29 +385,10 @@
 		to_chat(M, SPAN_WARNING("The solution spews out a metallic shiny foam!"))
 
 	var/datum/effect_system/foam_spread/s = new()
-	s.set_up(created_volume, location, holder, 1)
-	s.start()
-
-
-/datum/chemical_reaction/ironfoam
-	name = "Iron Foam"
-	id = "ironlfoam"
-	result = null
-	required_reagents = list("iron" = 3, "foaming_agent" = 1, "pacid" = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/ironfoam/on_reaction(datum/reagents/holder, created_volume)
-	var/location = get_turf(holder.my_atom)
-
-	for(var/mob/M as anything in viewers(5, location))
-		to_chat(M, SPAN_WARNING("The solution spews out a metallic dull foam!"))
-
-	var/datum/effect_system/foam_spread/s = new()
 	if (created_volume > 300)
 		created_volume = 300
-	s.set_up(created_volume, location, holder, 2)
+	s.set_up(created_volume, location, holder, 1)
 	s.start()
-
 
 /datum/chemical_reaction/foaming_agent
 	name = "Foaming Agent"

--- a/code/modules/reagents/chemistry_reactions/other.dm
+++ b/code/modules/reagents/chemistry_reactions/other.dm
@@ -394,7 +394,7 @@
 	id = "ironlfoam"
 	result = null
 	required_reagents = list("iron" = 3, "foaming_agent" = 1, "pacid" = 1)
-	result_amount = 5
+	result_amount = 3
 
 /datum/chemical_reaction/ironfoam/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -403,6 +403,8 @@
 		to_chat(M, SPAN_WARNING("The solution spews out a metallic dull foam!"))
 
 	var/datum/effect_system/foam_spread/s = new()
+	if (created_volume > 300)
+		created_volume = 300
 	s.set_up(created_volume, location, holder, 2)
 	s.start()
 


### PR DESCRIPTION
# About the pull request
Increases the xeno damage multiplier against foam from 0.8x to 1.75x (and decreasing iron foam hp from 85 to 70), meaning that combat t2s xenos will be able to 1shot aluminum metal foam, but only T3s can 1shot iron metal foam. 

makes damage consistent against foam so that the queen/crusher/basePrae don't randomly fail to smash it in a single hit.

aluminium foam now is cap'd at 300u.

iron foam is no longer able to be created by chemistry

foam grenades now use iron foam
increased amount of iron foam grenades in req
surplus explosives crate now contains 2 metal foam grenades

To make metal foam grenades (the ones that are bought from vendors/req) not completely useless, they now use metal foam, which (as said above) will be able to stop T1s and T2s in their tracks.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Currently, metal foam when detonated in a reagent tank is able to flood an entire area of the map with metal foam, causing it to be near impossible for xenos to get past without spending 10 minutes clicking on foam. Meanwhile, marines are able to 1shot all foam using either bullets or a BOOT KNIFE. a giant alien with **scythes for hands** is slower at clearing out a chunk of metal foam than a human with a boot knife.

With this PR, metal foam will be significantly worse at stopping T2s and T3s. Buffing iron foam allows
# Testing Photographs and Procedure
<details>
<summary>Testing </summary>
300u metal foam maxcap: (outdated, only aluminium foam can be created, but size should be the same)

![image](https://github.com/cmss13-devs/cmss13/assets/54422837/269e7cf0-c5cd-4955-ac48-cf97184e7258)

foam changes (heavily compressed because github only allows 10mb)

https://github.com/cmss13-devs/cmss13/assets/54422837/bbadd8c5-06fe-4216-881d-38ec7b9eac14



</details>


# Changelog
:cl:
balance: Xenos do greatly increased damage to metal foam (0.8x to 1.75x)
balance: Iron metal foam hp decreased from 85 to 75, meaning that all T3s other than boiler can instantly break it.
balance: Metal foam grenades now create iron foam.
balance: Aluminum foam reactions are now cap'd at 300u
balance: amount of metal foam grenades in req doubled.
balance: Surplus explosive pack now contains 2 metal foam grenades
del: metal foam is no longer able to be created in chemistry
/:cl:
