### PR TITLE
Removes an outdated xeno tip, adds a new one.

### DIFF
--- a/strings/marinetips.txt
+++ b/strings/marinetips.txt
@@ -80,7 +80,7 @@ You can shoot through tents, but they won't protect you much in return.
 Reqs doesn't have an infinite budget.
 Good Reqs can land supplies anywhere outside - given coords - and sometimes in a minimal amount of time.
 A ‘point blank’ or ‘PB’ is a type of attack with a firearm where you click directly on a mob next to you. These attacks are not effected by accuracy allowing you to quickly fire with weapons like a shotgun to great effect.
-Intel Officers can be put in a squad by going to CIC and requesting it.
+Intel Officers can be put in a different squad by going to CIC and requesting it.
 Any marine can perform CPR. On dead marines, this will increase the time they have until they become unrevivable.
 If you've been pounced on and your squad is unloading into the target, you can hit the 'rest' button to stay down so you don't get filled with lead after getting up.
 You can check the landing zone as a marine in the status panel.
@@ -88,7 +88,7 @@ The Colonial Marshals may come to crack down on too heavy of a Black Market usag
 A night vision HUD optic can be recharged by removing it with a screwdriver, then placing it into a recharger.
 You can put a pistol belt on your suit slot. (Just grab a rifle instead.)
 Alt-clicking the Squad Leader tracker lets you track your fireteam leader instead.
-Armor has a randomized reduction in effectiveness, and does not protect the digits. Take the wiki damage values as a best-case scenario.
+Armor consistently protects you from damage to your chest, arms, and legs, but does not protect hands and feet. Take the wiki damage values as a best-case scenario.
 You can click on your Security Access Tuner (multitool) in your hand to locate the area's APC if there is one.
 Need help learning the game and these tips aren't enough? Use MentorHelp or try to get ahold of your ship's Senior Enlisted Advisor.
 Clicking on your sprite with help intent will let you check your body, seeing where your fractures and other wounds are.

--- a/strings/xenotips.txt
+++ b/strings/xenotips.txt
@@ -23,13 +23,12 @@ Claymores have directional explosions. Set them off early by slashing them from 
 If you have difficulty clicking marines, try using Directional Slashing, though there's no directional slashing for abilities.
 You can diagonally pounce through the corners of fire as a Lurker or Runner without getting ignited.
 When playing as Xeno, consider aiming at the limbs instead of the chest. Marine armor doesn't protect the arms and legs as well as it does the body.
-As Xeno, you can break Night-Vision goggles that some marines wear on their helmets. Just aim for the head and slash until the goggles shatter.
 You can dodge pounces that aren't aimed directly at you by laying down.
 You may rest immediately during a pounce to pounce straight through mobs. It's not very practical or useful though.
 Pouncing someone who is buckled to a chair will still stun them, but you won't jump into their tile and they will not be knocked to the ground.
 Star shell dust from said grenades is just as meltable as normal flares.
 You can join the hive as a living Facehugger by clicking on the hive's Eggmorpher. This works on other hives too..
-Playable Facehuggers can leap onto targets with a one-second windup, but this will only infect them if they are adjacent to it.  Otherwise, it will simply knock them down for a small duration.
+Playable Facehuggers can leap onto targets with a one-second windup, but this will only infect them if they are adjacent to it. Otherwise, it will simply knock them down for a small duration.
 As a Facehugger, you cannot talk in hivemind, but you can still open Hive Status and overwatch your sisters. This can be useful if you're locating other Facehuggers, flanker castes, or trying to learn from experienced Facehugger players.
 Shift-clicking the Queen indicator will tell you what area you are in, on the map.
 As a Ravager your abilities become greatly enhanced when you empower with three or more people around you.
@@ -37,3 +36,4 @@ Resisting on a water tile will immediately put out fires. Make sure you're alone
 You can filter out the Xenomorphs displayed in hive status by health, allowing you to look only for wounded sisters.
 Each xeno has their own ‘tackle counter’ on a marine. The range to successfully tackle can be anywhere from two to six tackles based on caste. If a marine gets stunned or knocked over by other means it will reset everyone's tackle counters and they may get up!
 As a Xenomorph, the list of available tunnels is sorted by their distance to the player!
+As a Xenomorph, pay attention to what a marine is wearing. If they have no helmet, aiming for the head will be significantly more damaging, if they aren't wearing gloves, then think about going for their hands.


### PR DESCRIPTION
# About the pull request
removes an outdated xeno tip about breaking NVG goggles (you couldn't as of #4549)
removes a doublespace on a tip
adds a new tip about targeting marines based on what they're (not) wearing
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
tips not being outdated... good??? new tips good I think.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Added a new xeno tip about where to target.
spellcheck: changed a few tips' wording.
del: Removed an outdated xeno tip about slashing NVGs
/:cl:
