### PR TITLE
Queen give_evo changes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -313,7 +313,7 @@
 	if(!choice)
 		return
 	var/evo_points_per_larva = 250
-	var/required_larva = 3
+	var/required_larva = 1
 	var/mob/living/carbon/xenomorph/target_xeno
 
 	for(var/mob/living/carbon/xenomorph/xeno in user_xeno.hive.totalXenos)


### PR DESCRIPTION
# About the pull request

changes the required_larva to 1 instead of 3

# Explain why it's good for the game

with our pop we never have 3 burrowed larva, i still think it wont be able to get used even with the limit being one because of how our que system and etc works but atleast this should make it get used more compared to the 3 burrowed limit

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: You now only need 1 burrowed larva to trade it for evolution as Queen instead of 3 burrowed larva.
/:cl:
