### PR TITLE
Tweak Game Mode Start Handling

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -172,7 +172,27 @@ SUBSYSTEM_DEF(ticker)
 
 	CHECK_TICK
 	if(!mode.can_start(bypass_checks))
-		to_chat(world, "Reverting to pre-game lobby.")
+		to_chat(world, "Requirements to start [GLOB.master_mode] not met. Reverting to pre-game lobby.")
+		// Make only one more attempt
+		if(world.time - 2 * wait > CONFIG_GET(number/lobby_countdown) SECONDS)
+			flash_clients()
+			delay_start = TRUE
+			var/active_admins = 0
+			for(var/client/admin_client in GLOB.admins)
+				if(!admin_client.is_afk() && check_client_rights(admin_client, R_SERVER, FALSE))
+					active_admins = TRUE
+					break
+			if(active_admins)
+				to_chat(world, SPAN_CENTERBOLD("The game start has been delayed."))
+				message_admins(SPAN_ADMINNOTICE("Alert: Insufficent players ready to start [GLOB.master_mode].\nEither change mode and map or start round and bypass checks."))
+			else
+				var/fallback_mode = CONFIG_GET(string/gamemode_default)
+				SSticker.save_mode(fallback_mode)
+				GLOB.master_mode = fallback_mode
+				to_chat(world, SPAN_BOLDNOTICE("Notice: The Gamemode for next round has been set to [fallback_mode]"))
+				handle_map_reboot()
+		else
+			to_chat(world, "Attempting again...")
 		QDEL_NULL(mode)
 		GLOB.RoleAuthority.reset_roles()
 		return FALSE

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -273,12 +273,14 @@ SUBSYSTEM_DEF(vote)
 				question = "Gamemode vote"
 				randomize_entries = TRUE
 				for(var/mode_type in config.gamemode_cache)
-					var/datum/game_mode/M = mode_type
-					if(initial(M.config_tag))
-						var/vote_cycle_met = !initial(M.vote_cycle) || (text2num(SSperf_logging?.round?.id) % initial(M.vote_cycle) == 0)
-						var/min_players_met = length(GLOB.clients) >= M.required_players
-						if(initial(M.votable) && vote_cycle_met && min_players_met)
-							choices += initial(M.config_tag)
+					var/datum/game_mode/cur_mode = mode_type
+					if(initial(cur_mode.config_tag))
+						cur_mode = new mode_type
+						var/vote_cycle_met = !initial(cur_mode.vote_cycle) || (text2num(SSperf_logging?.round?.id) % initial(cur_mode.vote_cycle) == 0)
+						var/min_players_met = length(GLOB.clients) >= cur_mode.required_players
+						if(initial(cur_mode.votable) && vote_cycle_met && min_players_met)
+							choices += initial(cur_mode.config_tag)
+						qdel(cur_mode)
 			if("groundmap")
 				question = "Ground map vote"
 				vote_sound = 'sound/voice/start_your_voting.ogg'

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -259,10 +259,10 @@ Additional game mode variables.
 
 //If we are selecting xenomorphs, we NEED them to play the round. This is the expected behavior.
 //If this is an optional behavior, just override this proc or make an override here.
-/datum/game_mode/proc/initialize_starting_xenomorph_list(list/hives = list(XENO_HIVE_NORMAL), force_xenos = FALSE)
+/datum/game_mode/proc/initialize_starting_xenomorph_list(list/hives = list(XENO_HIVE_NORMAL), bypass_checks = FALSE)
 	var/list/datum/mind/possible_xenomorphs = get_players_for_role(JOB_XENOMORPH)
 	var/list/datum/mind/possible_queens = get_players_for_role(JOB_XENOMORPH_QUEEN)
-	if(possible_xenomorphs.len < xeno_required_num) //We don't have enough aliens, we don't consider people rolling for only Queen.
+	if(possible_xenomorphs.len < xeno_required_num && !bypass_checks) //We don't have enough aliens, we don't consider people rolling for only Queen.
 		to_world("<h2 style=\"color:red\">Not enough players have chosen to be a xenomorph in their character setup. <b>Aborting</b>.</h2>")
 		return
 
@@ -325,11 +325,11 @@ Additional game mode variables.
 	Our list is empty. This can happen if we had someone ready as alien and predator, and predators are picked first.
 	So they may have been removed from the list, oh well.
 	*/
-	if(LAZYLEN(xenomorphs) < xeno_required_num && LAZYLEN(picked_queens) != LAZYLEN(hives))
+	if(LAZYLEN(xenomorphs) < xeno_required_num && LAZYLEN(picked_queens) != LAZYLEN(hives) && !bypass_checks)
 		to_world("<h2 style=\"color:red\">Could not find any candidates after initial alien list pass. <b>Aborting</b>.</h2>")
 		return
 
-	return 1
+	return TRUE
 
 // Helper proc to set some constants
 /proc/setup_new_xeno(datum/mind/new_xeno)

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -21,7 +21,7 @@
 ////////////////////////////////////////////////////////////////////////////////////////
 
 /* Pre-pre-startup */
-/datum/game_mode/colonialmarines/can_start()
+/datum/game_mode/colonialmarines/can_start(bypass_checks = FALSE)
 	initialize_special_clamps()
 	return TRUE
 

--- a/code/game/gamemodes/colonialmarines/xenovsxeno.dm
+++ b/code/game/gamemodes/colonialmarines/xenovsxeno.dm
@@ -24,14 +24,14 @@
 	votable = FALSE // broken
 
 /* Pre-pre-startup */
-/datum/game_mode/xenovs/can_start()
+/datum/game_mode/xenovs/can_start(bypass_checks = FALSE)
 	for(var/hivename in SSmapping.configs[GROUND_MAP].xvx_hives)
 		if(GLOB.readied_players > SSmapping.configs[GROUND_MAP].xvx_hives[hivename])
 			hives += hivename
 	xeno_starting_num = GLOB.readied_players
-	if(!initialize_starting_xenomorph_list(hives, TRUE))
+	if(!initialize_starting_xenomorph_list(hives, bypass_checks))
 		hives.Cut()
-		return
+		return FALSE
 	return TRUE
 
 /datum/game_mode/xenovs/announce()

--- a/code/game/gamemodes/extended/infection.dm
+++ b/code/game/gamemodes/extended/infection.dm
@@ -45,9 +45,9 @@
 		if(transform_survivor(survivor) == 1)
 			survivors -= survivor
 
-/datum/game_mode/infection/can_start()
+/datum/game_mode/infection/can_start(bypass_checks = FALSE)
 	initialize_starting_survivor_list()
-	return 1
+	return TRUE
 
 //We don't actually need survivors to play, so long as aliens are present.
 /datum/game_mode/infection/proc/initialize_starting_survivor_list()

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -50,19 +50,20 @@ GLOBAL_VAR_INIT(cas_tracking_id_increment, 0) //this var used to assign unique t
 
 ///can_start()
 ///Checks to see if the game can be setup and ran with the current number of players or whatnot.
-/datum/game_mode/proc/can_start()
-	var/playerC = 0
+/datum/game_mode/proc/can_start(bypass_checks = FALSE)
+	if(bypass_checks)
+		return TRUE
+	var/players = 0
 	for(var/mob/new_player/player in GLOB.new_player_list)
-		if((player.client)&&(player.ready))
-			playerC++
-
-	if(GLOB.master_mode=="secret")
-		if(playerC >= required_players_secret)
-			return 1
+		if(player.client && player.ready)
+			players++
+	if(GLOB.master_mode == "secret")
+		if(players >= required_players_secret)
+			return TRUE
 	else
-		if(playerC >= required_players)
-			return 1
-	return 0
+		if(players >= required_players)
+			return TRUE
+	return FALSE
 
 
 ///pre_setup()

--- a/code/modules/admin/tabs/round_tab.dm
+++ b/code/modules/admin/tabs/round_tab.dm
@@ -169,8 +169,10 @@
 	set name = "Start Round"
 	set desc = "Start the round RIGHT NOW"
 	set category = "Server.Round"
-	if (alert("Are you sure you want to start the round early?",,"Yes","No") != "Yes")
-		return
+	var/response = tgui_alert(usr, "Are you sure you want to start the round early?", "Force Start Round", list("Yes", "Bypass Checks", "No"), 30 SECONDS)
+	if (response != "Yes" && response != "Bypass Checks")
+		return FALSE
+	SSticker.bypass_checks = response == "Bypass Checks"
 	if (SSticker.current_state == GAME_STATE_STARTUP)
 		message_admins("Game is setting up and will launch as soon as it is ready.")
 		message_admins(SPAN_ADMINNOTICE("[usr.key] has started the process to start the game when loading is finished."))


### PR DESCRIPTION

# About the pull request

Whisky Outpost is so rare now that it has taken two months for anyone to notice that it has been throwing a runtime when determining how many players are required for the game mode (140). Additionally, the Ticker subsystem really poorly handled this situation.

This PR makes it so:
- Admins can bypass checks to start a game mode
- Messages when a game mode fails to start is more verbose
- A game mode that fails to start will attempt again once
- Otherwise it will set game mode to default and initiate a game map vote and restart if there are no active admins; or it will delay start and message admins.

# Explain why it's good for the game

This should hopefully be less confusing to people what's going on when a game mode like WO fails to start and give admins an easier time to handle situations like this.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
No Admins (or afk admins):

![no_admins](https://github.com/cmss13-devs/cmss13/assets/76988376/8491981a-e740-4556-ac86-dd038d31c894)

With Admins:

![admins](https://github.com/cmss13-devs/cmss13/assets/76988376/0f0652a9-bd72-4993-a568-e3aed1ac6e6d)

</details>


# Changelog
:cl: Drathek
add: The game will now change game mode to default and initiate a map vote if a game mode fails to start twice and there are no admins online.
fix: Fixed a runtime during game mode voting
admin: Admins can now use the Start Round verb to bypass a gamemode's checks
/:cl:
