### PR TITLE
increases recovery node healing from 2 per sec to 8 per sec

### DIFF
--- a/code/modules/cm_aliens/structures/special/recovery_node.dm
+++ b/code/modules/cm_aliens/structures/special/recovery_node.dm
@@ -30,4 +30,4 @@
 				SPAN_HELPFUL("You feel a warm aura envelop you."))
 	if(!do_after(picked_candidate, heal_cooldown, INTERRUPT_MOVED, BUSY_ICON_MEDICAL))
 		return
-	picked_candidate.gain_health(heal_amount*picked_candidate.caste.heal_resting)
+	picked_candidate.gain_health(heal_amount)

--- a/code/modules/cm_aliens/structures/special/recovery_node.dm
+++ b/code/modules/cm_aliens/structures/special/recovery_node.dm
@@ -30,4 +30,4 @@
 				SPAN_HELPFUL("You feel a warm aura envelop you."))
 	if(!do_after(picked_candidate, heal_cooldown, INTERRUPT_MOVED, BUSY_ICON_MEDICAL))
 		return
-	picked_candidate.gain_health(heal_amount*picked_candidate.heal_resting)
+	picked_candidate.gain_health(heal_amount*picked_candidate.caste.heal_resting)

--- a/code/modules/cm_aliens/structures/special/recovery_node.dm
+++ b/code/modules/cm_aliens/structures/special/recovery_node.dm
@@ -5,7 +5,7 @@
 	desc = "A warm, soothing light source that pulsates with a faint hum."
 	icon_state = "recovery"
 	health = 400
-	var/heal_amount = 40
+	var/heal_amount = 20
 	var/heal_cooldown = 5 SECONDS
 	var/last_healed
 
@@ -30,4 +30,4 @@
 				SPAN_HELPFUL("You feel a warm aura envelop you."))
 	if(!do_after(picked_candidate, heal_cooldown, INTERRUPT_MOVED, BUSY_ICON_MEDICAL))
 		return
-	picked_candidate.gain_health(heal_amount)
+	picked_candidate.gain_health(heal_amount*picked_candidate.heal_resting)

--- a/code/modules/cm_aliens/structures/special/recovery_node.dm
+++ b/code/modules/cm_aliens/structures/special/recovery_node.dm
@@ -5,7 +5,7 @@
 	desc = "A warm, soothing light source that pulsates with a faint hum."
 	icon_state = "recovery"
 	health = 400
-	var/heal_amount = 10
+	var/heal_amount = 40
 	var/heal_cooldown = 5 SECONDS
 	var/last_healed
 


### PR DESCRIPTION
# About the pull request
you can delete this if #5518 gets approved

increases value to make recovery nodes heal 8 hp per sec from current 2hp, simple

# Explain why it's good for the game
Recovery nodes right now are just noob trap, they heal 10 hp per 5 sec that amounts to 2 hp per sec, preaty far from being worth the space, they need 3x3 open area, time efford and risk to heal near them. the PR increases the healing so that it is at least a bit worth it. More tools for players to use means more fun. Even with the buff it is far from OP as even square of 4 nodes heals 32 per second to single target, while needing loads of space resting in middle of that open space and quite some efford to build, also there is hardcap on how many healing nodes can have.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
balance: increases healing node heal from 10hp every 5 sec to 20 hp every 5 sec
/:cl:

