### PR TITLE
changes recovery node from giving heals to emiting phero

### DIFF
--- a/code/modules/cm_aliens/structures/special/recovery_node.dm
+++ b/code/modules/cm_aliens/structures/special/recovery_node.dm
@@ -14,7 +14,7 @@
 /obj/effect/alien/resin/special/recovery/get_examine_text(mob/user)
 	. = ..()
 	if((isxeno(user) || isobserver(user)) && linked_hive)
-		. += "Emits pheromons to nerby xenomorphs"
+		. += "Emits pheromones to nearby Xenomorphs."
 
 /obj/effect/alien/resin/special/recovery/process()
 	for(var/mob/living/carbon/xenomorph/xenomorph in range(recovery_pheromone_range, loc))

--- a/code/modules/cm_aliens/structures/special/recovery_node.dm
+++ b/code/modules/cm_aliens/structures/special/recovery_node.dm
@@ -7,8 +7,8 @@
 	health = 400
 	var/recovery_pheromone_range = 2
 	var/warding_pheromone_range = 8
-	var/recovery_strenght = 2.5
-	var/warding_strenght = 1
+	var/recovery_strength = 2.5
+	var/warding_strength = 1
 
 
 /obj/effect/alien/resin/special/recovery/get_examine_text(mob/user)
@@ -20,11 +20,11 @@
 	for(var/mob/living/carbon/xenomorph/xenomorph in range(recovery_pheromone_range, loc))
 		if(xenomorph.ignores_pheromones)
 			continue
-		if(recovery_strenght > xenomorph.recovery_new && linked_hive == xenomorph.hivenumber)
-			xenomorph.recovery_new = recovery_strenght
+		if(recovery_strength > xenomorph.recovery_new && linked_hive == xenomorph.hivenumber)
+			xenomorph.recovery_new = recovery_strength
 
 	for(var/mob/living/carbon/xenomorph/xenomorph in range(warding_pheromone_range, loc))
 		if(xenomorph.ignores_pheromones)
 			continue
-		if(warding_strenght > xenomorph.warding_new && linked_hive == xenomorph.hivenumber)
-			xenomorph.recovery_new = warding_strenght
+		if(warding_strength > xenomorph.warding_new && linked_hive == xenomorph.hivenumber)
+			xenomorph.recovery_new = warding_strength

--- a/code/modules/cm_aliens/structures/special/recovery_node.dm
+++ b/code/modules/cm_aliens/structures/special/recovery_node.dm
@@ -20,11 +20,11 @@
 	for(var/mob/living/carbon/xenomorph/xenomorph in range(recovery_pheromone_range, loc))
 		if(xenomorph.ignores_pheromones)
 			continue
-		if(recovery_strenght > xenomorph.recovery_new)
+		if(recovery_strenght > xenomorph.recovery_new && linked_hive == xenomorph.hivenumber)
 			xenomorph.recovery_new = recovery_strenght
 
 	for(var/mob/living/carbon/xenomorph/xenomorph in range(warding_pheromone_range, loc))
 		if(xenomorph.ignores_pheromones)
 			continue
-		if(warding_strenght > xenomorph.warding_new)
+		if(warding_strenght > xenomorph.warding_new && linked_hive == xenomorph.hivenumber)
 			xenomorph.recovery_new = warding_strenght

--- a/code/modules/cm_aliens/structures/special/recovery_node.dm
+++ b/code/modules/cm_aliens/structures/special/recovery_node.dm
@@ -5,29 +5,26 @@
 	desc = "A warm, soothing light source that pulsates with a faint hum."
 	icon_state = "recovery"
 	health = 400
-	var/heal_amount = 10
-	var/heal_cooldown = 5 SECONDS
-	var/last_healed
+	var/recovery_pheromone_range = 2
+	var/warding_pheromone_range = 8
+	var/recovery_strenght = 2.5
+	var/warding_strenght = 1
+
 
 /obj/effect/alien/resin/special/recovery/get_examine_text(mob/user)
 	. = ..()
 	if((isxeno(user) || isobserver(user)) && linked_hive)
-		. += "Recovers the health of adjacent Xenomorphs."
+		. += "Emits pheromons to nerby xenomorphs"
 
 /obj/effect/alien/resin/special/recovery/process()
-	if(last_healed && world.time < last_healed + heal_cooldown)
-		return
-	var/list/heal_candidates = list()
-	for(var/mob/living/carbon/xenomorph/X in orange(src, 1))
-		if(X.health >= X.maxHealth || !X.resting || X.hivenumber != linked_hive.hivenumber)
+	for(var/mob/living/carbon/xenomorph/xenomorph in range(recovery_pheromone_range, loc))
+		if(xenomorph.ignores_pheromones)
 			continue
-		heal_candidates += X
-	last_healed = world.time
-	if(!heal_candidates.len)
-		return
-	var/mob/living/carbon/xenomorph/picked_candidate = pick(heal_candidates)
-	picked_candidate.visible_message(SPAN_HELPFUL("\The [picked_candidate] glows as a warm aura envelops them."), \
-				SPAN_HELPFUL("You feel a warm aura envelop you."))
-	if(!do_after(picked_candidate, heal_cooldown, INTERRUPT_MOVED, BUSY_ICON_MEDICAL))
-		return
-	picked_candidate.gain_health(heal_amount)
+		if(recovery_strenght > xenomorph.recovery_new)
+			xenomorph.recovery_new = recovery_strenght
+
+	for(var/mob/living/carbon/xenomorph/xenomorph in range(warding_pheromone_range, loc))
+		if(xenomorph.ignores_pheromones)
+			continue
+		if(warding_strenght > xenomorph.warding_new)
+			xenomorph.recovery_new = warding_strenght


### PR DESCRIPTION
# About the pull request

some baseground of changes, balancing straigh up heal is harder as that would use mainly stacked up for frontline rather the nspread out, makes the node emit hivelord recovery level to all xenos 2 tiles from it and drone warding to those 8 tiles away from it

# Explain why it's good for the game

recovery node is just shit right now, 2 hp per sec and stuff, this is more complex rework of it that should allow it to make meaningful backline and flank outposts by making area with weeds (needs pylon) and recovery and weak warding pheromones, should encourage placing thease on flanks rather then stacking them on front where you already have pheros 

todo add chack for hivenumber to the pheros


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
add: recovery node emits hivelord level recovery to xenos 2 tiles from it
add:  recovery node emits drone level warding to xenos 8 tiles from it
del: removes direct healing from recovery node
/:cl:
