### PR TITLE
turns oxygentank into fueltank fixes issue #5512

### DIFF
--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -148,13 +148,6 @@
 	icon_state = "ammoniatank"
 	chemical = "ammonia"
 
-/obj/structure/reagent_dispensers/oxygentank
-	name = "oxygentank"
-	desc = "An oxygen tank"
-	icon = 'icons/obj/objects.dmi'
-	icon_state = "oxygentank"
-	chemical = "oxygen"
-
 /obj/structure/reagent_dispensers/acidtank
 	name = "sulfuric acid tank"
 	desc = "A sulfuric acid tank"
@@ -393,6 +386,13 @@
 	desc = "A hydrogen tank"
 	icon_state = "hydrogentank"
 	chemical = "hydrogen"
+
+/obj/structure/reagent_dispensers/fueltank/oxygentank
+	name = "oxygentank"
+	desc = "An oxygen tank"
+	icon = 'icons/obj/objects.dmi'
+	icon_state = "oxygentank"
+	chemical = "oxygen"
 
 /obj/structure/reagent_dispensers/fueltank/custom
 	name = "reagent tank"

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -24439,7 +24439,7 @@
 /area/fiorina/tumor/ice_lab)
 "oIg" = (
 /obj/structure/platform,
-/obj/structure/reagent_dispensers/oxygentank{
+/obj/structure/reagent_dispensers/fueltank/oxygentank{
 	layer = 2.6
 	},
 /turf/open/floor/prison,

--- a/maps/map_files/FOP_v3_Sciannex/sprinkles/30.repairpanelslz.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/sprinkles/30.repairpanelslz.dmm
@@ -170,7 +170,7 @@
 	},
 /area/template_noop)
 "H" = (
-/obj/structure/reagent_dispensers/oxygentank,
+/obj/structure/reagent_dispensers/fueltank/oxygentank,
 /turf/open/space,
 /area/template_noop)
 "I" = (

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -79268,7 +79268,7 @@
 	},
 /area/almayer/medical/lower_medical_lobby)
 "xgm" = (
-/obj/structure/reagent_dispensers/oxygentank,
+/obj/structure/reagent_dispensers/fueltank/oxygentank,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -80720,7 +80720,7 @@
 	},
 /area/almayer/hull/upper_hull/u_m_p)
 "xHS" = (
-/obj/structure/reagent_dispensers/oxygentank{
+/obj/structure/reagent_dispensers/fueltank/oxygentank{
 	anchored = 1
 	},
 /obj/effect/decal/warning_stripes{


### PR DESCRIPTION

# About the pull request
fixes issue #5512 by turning oxygentank into fueltank subclass

# Explain why it's good for the game

having to move oxygen into custom tank to fill custom flamethrowertank is a bug


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
fix: allows custom flamethrower tanks to be filled directly from oxygentank
/:cl:
