### PR TITLE
Fix Weird Inventories

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -277,11 +277,15 @@ Also change the icon to reflect the amount of sheets, if possible.*/
 	if(used > amount) //If it's larger than what we have, no go.
 		return FALSE
 	amount -= used
-	update_icon()
 	if(amount <= 0)
-		if(usr && loc == usr)
-			usr.temp_drop_inv_item(src)
+		if(loc == usr)
+			usr?.temp_drop_inv_item(src)
+		else if(isstorage(loc))
+			var/obj/item/storage/storage = loc
+			storage.remove_from_storage(src)
 		qdel(src)
+	else
+		update_icon()
 	return TRUE
 
 /obj/item/stack/proc/add(extra)

--- a/code/game/objects/items/toys/cards.dm
+++ b/code/game/objects/items/toys/cards.dm
@@ -352,6 +352,9 @@
 				user.visible_message(SPAN_NOTICE("\The [user] adds [cards_length > 1 ? "their hand" : "<b>[cards[length(cards)].name]</b>"] to \the [src]."), SPAN_NOTICE("You add [cards_length > 1 ? "your hand" : "<b>[cards[length(cards)].name]</b>"] to \the [src]."))
 		else
 			if(loc != user)
+				if(isstorage(loc))
+					var/obj/item/storage/storage = loc
+					storage.remove_from_storage(src)
 				user.put_in_hands(src)
 		update_icon()
 		return
@@ -405,6 +408,10 @@
 		return
 	if(ismob(loc))
 		return
+
+	if(isstorage(loc))
+		var/obj/item/storage/storage = loc
+		storage.remove_from_storage(src)
 	usr.put_in_hands(src)
 
 /obj/item/toy/handcard/get_examine_text(mob/user)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -228,7 +228,7 @@
 //Remove an item on a mob's inventory.  It does not change the item's loc, just unequips it from the mob.
 //Used just before you want to delete the item, or moving it afterwards.
 /mob/proc/temp_drop_inv_item(obj/item/I, force)
-	return u_equip(I, null, force)
+	return u_equip(I, null, TRUE, force)
 
 
 //Outdated but still in use apparently. This should at least be a human proc.

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -175,7 +175,9 @@
 		if(!previously_held_object)
 			remembered_dropped_objects -= weak_ref
 			break
-		if(previously_held_object.in_contents_of(check_turf))
+		if(previously_held_object in check_turf)
+			if(previously_held_object.throwing)
+				return FALSE
 			if(previously_held_object.anchored)
 				return FALSE
 			put_in_hands(previously_held_object, drop_on_fail = FALSE)


### PR DESCRIPTION

# About the pull request

This PR resolves the unresolved issues in #5337 and should fix #4604 See testing for more details.

One note is that we aren't actually doing anything different for mob/proc/u_equip for nomoveupdate. I attempted a few things including a snippet from tg's code (https://github.com/tgstation/tgstation/blob/master/code/modules/mob/inventory.dm#L377-L381) but at least for thrown items it would just make them poof; so for now I just corrected a misused call of it.

# Explain why it's good for the game

No more funny business nor weird inventory overlays (atleast for cards and stacks - let me know if there is anything else that has this behavior)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Busted:

https://github.com/cmss13-devs/cmss13/assets/76988376/a596d661-49f0-4f3e-b77e-51046676408c

Fixed:

https://github.com/cmss13-devs/cmss13/assets/76988376/98bc6680-d0b5-4ce8-b7a0-22629274d8ad

</details>


# Changelog
:cl: Drathek
fix: Fixed more item exploits
fix: Fixed lingering overlays in inventories for metal stacks and cards
/:cl:
