### PR TITLE
Increase Double Throw Delay

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -141,8 +141,8 @@
 #define WIELD_DELAY_VERY_SLOW 10
 #define WIELD_DELAY_HORRIBLE 12
 
-///This is how long you must wait after throwing something to throw again
-#define THROW_DELAY (0.4 SECONDS)
+///This is how long you must wait to throw again after throwing two things
+#define THROW_DELAY (1.5 SECONDS)
 
 //Explosion level thresholds. Upper bounds
 #define EXPLOSION_THRESHOLD_VLOW 50


### PR DESCRIPTION
# About the pull request

This PR is simply a number tweak increasing the cooldown to throw two items.

# Explain why it's good for the game

Throwing knives are still very powerful. This change brings them closer to an acceptable range, but even still they are rather deadly. Any amount past this though will likely make throwing other items too cumbersome. See Testing.

To elaborate further:

- A 0.4s delay to throw two knives (assuming the player wants to get optimal damage out of them) is asking the player to retrieve a weapon, prepare to throw it, and throw it on a target every 0.2 seconds (This PR raises that period to 0.75s). This is just not practical to expect w/o the use of macros - and we don't want to encourage macro usage both because third party macros are not allowed (Rule 5) and byond macros will likely be disabled.
- Throwing knives were already a problem before thus #3284 which added the 0.4s delay in the first place. But didn't do enough. In fact this PR probably doesn't do enough - but this is probably as far as the throwing delay should go. Anything else would either be how much damage they do or reduced likelihood of retrieval.
- Throwing knives should not be comparable to primary weapons. They should be on the level of sidearms used as a backup weapon or weapons to use in conjunction with your primary weapon.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/76988376/a7410e93-4208-409a-9f2a-c2ddc548635c


</details>


# Changelog
:cl: Drathek
balance: Increased double throw delay from .4s to 1.5s
/:cl:
