### PR TITLE
Raises the amount of magazines in the MP handgun cases to 6

### DIFF
--- a/code/modules/cm_marines/equipment/guncases.dm
+++ b/code/modules/cm_marines/equipment/guncases.dm
@@ -354,7 +354,7 @@
 /obj/item/storage/box/guncase/mod88
 	name = "\improper 88 Mod 4 Combat Pistol case"
 	desc = "A gun case containing an 88 Mod 4 Combat Pistol."
-	storage_slots = 5
+	storage_slots = 8
 	can_hold = list(/obj/item/attachable/flashlight, /obj/item/weapon/gun/pistol/mod88, /obj/item/ammo_magazine/pistol/mod88)
 
 /obj/item/storage/box/guncase/mod88/fill_preset_inventory()
@@ -363,12 +363,15 @@
 	new /obj/item/ammo_magazine/pistol/mod88(src)
 	new /obj/item/ammo_magazine/pistol/mod88(src)
 	new /obj/item/ammo_magazine/pistol/mod88(src)
+	new /obj/item/ammo_magazine/pistol/mod88(src)
+	new /obj/item/ammo_magazine/pistol/mod88(src)
+	new /obj/item/ammo_magazine/pistol/mod88(src)
 
 //M44 Combat Revolver
 /obj/item/storage/box/guncase/m44
 	name = "\improper M44 Combat Revolver case"
 	desc = "A gun case containing an M44 Combat Revolver loaded with marksman ammo."
-	storage_slots = 5
+	storage_slots = 8
 	can_hold = list(/obj/item/attachable/flashlight, /obj/item/weapon/gun/revolver/m44, /obj/item/ammo_magazine/revolver)
 
 /obj/item/storage/box/guncase/m44/fill_preset_inventory()
@@ -377,17 +380,23 @@
 	new /obj/item/ammo_magazine/revolver/marksman(src)
 	new /obj/item/ammo_magazine/revolver/marksman(src)
 	new /obj/item/ammo_magazine/revolver/marksman(src)
+	new /obj/item/ammo_magazine/revolver/marksman(src)
+	new /obj/item/ammo_magazine/revolver/marksman(src)
+	new /obj/item/ammo_magazine/revolver/marksman(src)
 
 //M4A3 Service Pistol
 /obj/item/storage/box/guncase/m4a3
 	name = "\improper M4A3 Service Pistol case"
 	desc = "A gun case containing an M4A3 Service Pistol."
-	storage_slots = 5
+	storage_slots = 8
 	can_hold = list(/obj/item/attachable/flashlight, /obj/item/weapon/gun/pistol/m4a3, /obj/item/ammo_magazine/pistol)
 
 /obj/item/storage/box/guncase/m4a3/fill_preset_inventory()
 	new /obj/item/attachable/flashlight(src)
 	new /obj/item/weapon/gun/pistol/m4a3(src)
+	new /obj/item/ammo_magazine/pistol(src)
+	new /obj/item/ammo_magazine/pistol(src)
+	new /obj/item/ammo_magazine/pistol(src)
 	new /obj/item/ammo_magazine/pistol(src)
 	new /obj/item/ammo_magazine/pistol(src)
 	new /obj/item/ammo_magazine/pistol(src)


### PR DESCRIPTION
# About the pull request

Basically adds three more magazines to the MP handgun cases for a total of six magazines, as before the pistols were moved to seperate guncases.

# Explain why it's good for the game

MPs should be able to fill their holster belts without raiding squad preps.


# Testing Photographs and Procedure

Working (probaly)


# Changelog

:cl:
add: Added three more magazines to each of the MP's handgun cases
/:cl:
