### PR TITLE
Removes CLF synth from nightmare insert

### DIFF
--- a/code/game/objects/effects/landmarks/survivor_spawner.dm
+++ b/code/game/objects/effects/landmarks/survivor_spawner.dm
@@ -31,7 +31,6 @@
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf
 	hostile = TRUE
 	equipment = /datum/equipment_preset/survivor/clf
-	synth_equipment = /datum/equipment_preset/clf/synth
 	intro_text = list("<h2>You are a survivor of a crash landing!</h2>",\
 	"<span class='notice'>You are NOT aware of the xenomorph threat.</span>",\
 	"<span class='danger'>Your primary objective is to heal up and survive. If you want to assault the hive - adminhelp.</span>")
@@ -45,7 +44,6 @@
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf_engineer
 	hostile = TRUE
 	equipment = /datum/equipment_preset/clf/engineer
-	synth_equipment = /datum/equipment_preset/clf/synth
 	intro_text = list("<h2>You are a survivor of a crash landing!</h2>",\
 	"You are NOT aware of the xenomorph threat.",\
 	"Your primary objective is to heal up and survive. If you want to assault the hive - adminhelp.")
@@ -59,7 +57,6 @@
 /obj/effect/landmark/survivor_spawner/lv624_crashed_clf_medic
 	hostile = TRUE
 	equipment = /datum/equipment_preset/clf/medic
-	synth_equipment = /datum/equipment_preset/clf/synth
 	intro_text = list("<h2>You are a survivor of a crash landing!</h2>",\
 	"You are NOT aware of the xenomorph threat.",\
 	"Your primary objective is to heal up and survive. If you want to assault the hive - adminhelp.")


### PR DESCRIPTION
# About the pull request

Removes CLF synth from the nightmare insert

# Explain why it's good for the game
Synths are meant to be a roleplay role, that adds to the round rather than subtracts it.
There is a trend of synth players logging on just to try and roll for combat synth. There is also a reason why combat synths are reserved for ERTs.
They have natural armor, night vision, fast speed and can't get any fractures.
CLF synths also like permamently removing people from rounds, which I think is a net negative for the main parts of the game (Xenomorphs, Marines)
On ROUNDID: 20539 Me, as an IO and my IO team were looking for intel and roleplaying, talking whilst grabbing intel and clearing out the backline.
It ended with one bullet, off-screen sniper bullet from a CLF synth that heartbroke me and then dragged off to perma.
I've played CLF and UPP synth extensively, I know how overpowered it is and I think it should be removed completely from the normal gameplay loop..
A video of me fragging out as a combat synth will be attached shortly.
https://streamable.com/u6owl1


# Testing Photographs and Procedure
N/A




# Changelog

:cl: stalkerino
del: removes CLF synth from nightmare insert

/:cl:


