### PR TITLE
scout ammo and economy nerf

### DIFF
--- a/code/datums/ammo/bullet/rifle.dm
+++ b/code/datums/ammo/bullet/rifle.dm
@@ -137,7 +137,7 @@
 	flags_ammo_behavior = AMMO_BALLISTIC
 	accurate_range_min = 4
 
-	damage = 60
+	damage = 55
 	scatter = -SCATTER_AMOUNT_TIER_8
 	penetration= ARMOR_PENETRATION_TIER_7
 	shell_speed = AMMO_SPEED_TIER_6
@@ -165,7 +165,7 @@
 	damage = 40
 	accuracy = -HIT_ACCURACY_TIER_2
 	scatter = -SCATTER_AMOUNT_TIER_8
-	penetration = ARMOR_PENETRATION_TIER_3
+	penetration = ARMOR_PENETRATION_TIER_10
 	shell_speed = AMMO_SPEED_TIER_6
 
 /datum/ammo/bullet/rifle/m4ra/impact/on_hit_mob(mob/M, obj/projectile/P)

--- a/code/datums/ammo/bullet/rifle.dm
+++ b/code/datums/ammo/bullet/rifle.dm
@@ -165,7 +165,7 @@
 	damage = 40
 	accuracy = -HIT_ACCURACY_TIER_2
 	scatter = -SCATTER_AMOUNT_TIER_8
-	penetration = ARMOR_PENETRATION_TIER_2
+	penetration = ARMOR_PENETRATION_TIER_3
 	shell_speed = AMMO_SPEED_TIER_6
 
 /datum/ammo/bullet/rifle/m4ra/impact/on_hit_mob(mob/M, obj/projectile/P)

--- a/code/datums/ammo/bullet/rifle.dm
+++ b/code/datums/ammo/bullet/rifle.dm
@@ -137,7 +137,7 @@
 	flags_ammo_behavior = AMMO_BALLISTIC
 	accurate_range_min = 4
 
-	damage = 55
+	damage = 60
 	scatter = -SCATTER_AMOUNT_TIER_8
 	penetration= ARMOR_PENETRATION_TIER_7
 	shell_speed = AMMO_SPEED_TIER_6
@@ -165,7 +165,7 @@
 	damage = 40
 	accuracy = -HIT_ACCURACY_TIER_2
 	scatter = -SCATTER_AMOUNT_TIER_8
-	penetration = ARMOR_PENETRATION_TIER_10
+	penetration = ARMOR_PENETRATION_TIER_2
 	shell_speed = AMMO_SPEED_TIER_6
 
 /datum/ammo/bullet/rifle/m4ra/impact/on_hit_mob(mob/M, obj/projectile/P)

--- a/code/datums/supply_packs/spec_ammo.dm
+++ b/code/datums/supply_packs/spec_ammo.dm
@@ -162,8 +162,6 @@
 		/obj/item/ammo_magazine/rifle/m4ra/custom/incendiary,
 		/obj/item/ammo_magazine/rifle/m4ra/custom/incendiary,
 		/obj/item/ammo_magazine/rifle/m4ra/custom/incendiary,
-		/obj/item/ammo_magazine/rifle/m4ra/custom/incendiary,
-		/obj/item/ammo_magazine/rifle/m4ra/custom/incendiary,
 	)
 	cost = 30
 	containertype = /obj/structure/closet/crate/ammo
@@ -173,8 +171,6 @@
 /datum/supply_packs/ammo_scout_impact
 	name = "M4RA Scout Impact Magazine Crate (x5)"
 	contains = list(
-		/obj/item/ammo_magazine/rifle/m4ra/custom/impact,
-		/obj/item/ammo_magazine/rifle/m4ra/custom/impact,
 		/obj/item/ammo_magazine/rifle/m4ra/custom/impact,
 		/obj/item/ammo_magazine/rifle/m4ra/custom/impact,
 		/obj/item/ammo_magazine/rifle/m4ra/custom/impact,

--- a/code/datums/supply_packs/spec_ammo.dm
+++ b/code/datums/supply_packs/spec_ammo.dm
@@ -157,7 +157,7 @@
 	group = "Weapons Specialist Ammo"
 
 /datum/supply_packs/ammo_scout_incendiary
-	name = "M4RA Scout Incendiary Magazine Crate (x5)"
+	name = "M4RA Scout Incendiary Magazine Crate (x3)"
 	contains = list(
 		/obj/item/ammo_magazine/rifle/m4ra/custom/incendiary,
 		/obj/item/ammo_magazine/rifle/m4ra/custom/incendiary,
@@ -169,7 +169,7 @@
 	group = "Weapons Specialist Ammo"
 
 /datum/supply_packs/ammo_scout_impact
-	name = "M4RA Scout Impact Magazine Crate (x5)"
+	name = "M4RA Scout Impact Magazine Crate (x3)"
 	contains = list(
 		/obj/item/ammo_magazine/rifle/m4ra/custom/impact,
 		/obj/item/ammo_magazine/rifle/m4ra/custom/impact,


### PR DESCRIPTION
# About the pull request
This pr aims to make high impact and incindeary mags rarer.

# Explain why it's good for the game

Currently you get 5 mags per req buy, which is while normally  not alot  for any other weaponhigh impact rounds can bascially stun anything thats a stunnable caste. 
Having this easy access to this many mags is a bit broken in my opinion. I dont think this nerf will make scout useless, but it will definetly make you rethink where and how you use your ammo. Which in my opinion is important when you can solo juggle 3 xenomorphs alone.

I didnt think touching the actual cost of the crates were important as the 2 mag removal should really make a difference and make your special ammo feel special and rarer.

~~I also decided to not change the numbers on the normal bullets because i think they're already not that great, and have instead decided to remove the ARMOR_PENETRATION_TIER_10 (which equals to 50 ARMOR PIERCE ??) from HIGH IMPACT ROUNDS and change it to 10 ap instead.I dont think it needs that much ap, especially since your main combo is incin round into stun mag. This should help armored caste feel like they arent instantly dying to the stun gun.~~


~~I've decided to buff the damage of the normal mags to 60 from 55, while i dont think it will make the mags BETTER then other options, it will certainly give it a chance to deal with tier threes so you arent constantly locked to the backline, alongside its 35 AP.~~

# Testing Photographs and Procedure

</details>


# Changelog
:cl:
balance: Scout specialist incin/high impact mag crates now only has 3 instead of 5
/:cl:
