### PR TITLE
M37A2 Rework

### DIFF
--- a/code/datums/ammo/bullet/shotgun.dm
+++ b/code/datums/ammo/bullet/shotgun.dm
@@ -13,7 +13,7 @@
 
 	accurate_range = 6
 	max_range = 8
-	damage = 70
+	damage = 80
 	penetration = ARMOR_PENETRATION_TIER_4
 	damage_armor_punch = 2
 	handful_state = "slug_shell"
@@ -67,7 +67,7 @@
 
 	accuracy = -HIT_ACCURACY_TIER_2
 	max_range = 12
-	damage = 55
+	damage = 65
 	penetration= ARMOR_PENETRATION_TIER_1
 	handful_state = "incendiary_slug"
 
@@ -97,7 +97,7 @@
 	accuracy_var_low = PROJECTILE_VARIANCE_TIER_6
 	accuracy_var_high = PROJECTILE_VARIANCE_TIER_6
 	max_range = 12
-	damage = 30
+	damage = 40
 	damage_var_low = PROJECTILE_VARIANCE_TIER_8
 	damage_var_high = PROJECTILE_VARIANCE_TIER_8
 	penetration = ARMOR_PENETRATION_TIER_7
@@ -112,7 +112,7 @@
 	accuracy_var_low = PROJECTILE_VARIANCE_TIER_6
 	accuracy_var_high = PROJECTILE_VARIANCE_TIER_6
 	max_range = 12
-	damage = 30
+	damage = 40
 	damage_var_low = PROJECTILE_VARIANCE_TIER_8
 	damage_var_high = PROJECTILE_VARIANCE_TIER_8
 	penetration = ARMOR_PENETRATION_TIER_7
@@ -127,9 +127,9 @@
 
 	accuracy_var_low = PROJECTILE_VARIANCE_TIER_5
 	accuracy_var_high = PROJECTILE_VARIANCE_TIER_5
-	accurate_range = 4
-	max_range = 4
-	damage = 65
+	accurate_range = 6
+	max_range = 6
+	damage = 75
 	damage_var_low = PROJECTILE_VARIANCE_TIER_8
 	damage_var_high = PROJECTILE_VARIANCE_TIER_8
 	penetration = ARMOR_PENETRATION_TIER_1
@@ -168,7 +168,7 @@
 	accuracy_var_high = PROJECTILE_VARIANCE_TIER_6
 	accurate_range = 4
 	max_range = 6
-	damage = 65
+	damage = 75
 	damage_var_low = PROJECTILE_VARIANCE_TIER_8
 	damage_var_high = PROJECTILE_VARIANCE_TIER_8
 	penetration = ARMOR_PENETRATION_TIER_1
@@ -193,7 +193,7 @@
 	bonus_projectiles_amount = EXTRA_PROJECTILES_TIER_3
 	accurate_range = 3
 	max_range = 3
-	damage = 75
+	damage = 85
 	penetration = 0
 	shell_speed = AMMO_SPEED_TIER_2
 	damage_armor_punch = 0
@@ -214,7 +214,7 @@
 	handful_state = "heavy_dragonsbreath"
 	multiple_handful_name = TRUE
 	damage_type = BURN
-	damage = 60
+	damage = 70
 	accurate_range = 3
 	max_range = 4
 	bonus_projectiles_type = /datum/ammo/bullet/shotgun/heavy/buckshot/dragonsbreath/spread
@@ -239,7 +239,7 @@
 
 	accurate_range = 7
 	max_range = 8
-	damage = 90 //ouch.
+	damage = 100 //ouch.
 	penetration = ARMOR_PENETRATION_TIER_6
 	damage_armor_punch = 2
 
@@ -293,7 +293,7 @@
 	accuracy_var_low = PROJECTILE_VARIANCE_TIER_3
 	accuracy_var_high = PROJECTILE_VARIANCE_TIER_3
 	max_range = 12
-	damage = 45
+	damage = 55
 	damage_var_low = PROJECTILE_VARIANCE_TIER_8
 	damage_var_high = PROJECTILE_VARIANCE_TIER_8
 	penetration = ARMOR_PENETRATION_TIER_10
@@ -305,7 +305,7 @@
 	accuracy_var_low = PROJECTILE_VARIANCE_TIER_6
 	accuracy_var_high = PROJECTILE_VARIANCE_TIER_6
 	max_range = 12
-	damage = 45
+	damage = 55
 	damage_var_low = PROJECTILE_VARIANCE_TIER_8
 	damage_var_high = PROJECTILE_VARIANCE_TIER_8
 	penetration = ARMOR_PENETRATION_TIER_10

--- a/code/datums/ammo/bullet/shotgun.dm
+++ b/code/datums/ammo/bullet/shotgun.dm
@@ -127,8 +127,8 @@
 
 	accuracy_var_low = PROJECTILE_VARIANCE_TIER_5
 	accuracy_var_high = PROJECTILE_VARIANCE_TIER_5
-	accurate_range = 6
-	max_range = 6
+	accurate_range = 5
+	max_range = 5
 	damage = 75
 	damage_var_low = PROJECTILE_VARIANCE_TIER_8
 	damage_var_high = PROJECTILE_VARIANCE_TIER_8

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -41,9 +41,9 @@ can cause issues with ammo types getting mixed up during the burst.
 	scatter = SCATTER_AMOUNT_TIER_6
 	burst_scatter_mult = SCATTER_AMOUNT_TIER_6
 	scatter_unwielded = SCATTER_AMOUNT_TIER_2
-	damage_mult = BULLET_DAMAGE_MULT_TIER_3
-	recoil = RECOIL_AMOUNT_TIER_3
-	recoil_unwielded = RECOIL_AMOUNT_TIER_1
+	damage_mult = BASE_BULLET_DAMAGE_MULT
+	recoil = RECOIL_AMOUNT_TIER_4
+	recoil_unwielded = RECOIL_AMOUNT_TIER_2
 
 /obj/item/weapon/gun/shotgun/proc/replace_tube(number_to_replace)
 	if(!current_mag)
@@ -1116,15 +1116,15 @@ can cause issues with ammo types getting mixed up during the burst.
 /obj/item/weapon/gun/shotgun/pump/set_gun_config_values()
 	..()
 	set_burst_amount(BURST_AMOUNT_TIER_1)
-	set_fire_delay(FIRE_DELAY_TIER_9 * 4)
+	set_fire_delay(FIRE_DELAY_TIER_11 * 4)
 	accuracy_mult = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_3
 	accuracy_mult_unwielded = BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_10
-	scatter = SCATTER_AMOUNT_TIER_6
-	burst_scatter_mult = SCATTER_AMOUNT_TIER_6
+	scatter = SCATTER_AMOUNT_TIER_7
+	burst_scatter_mult = SCATTER_AMOUNT_TIER_7
 	scatter_unwielded = SCATTER_AMOUNT_TIER_2
 	damage_mult = BASE_BULLET_DAMAGE_MULT
-	recoil = RECOIL_AMOUNT_TIER_4
-	recoil_unwielded = RECOIL_AMOUNT_TIER_2
+	recoil = RECOIL_AMOUNT_TIER_3
+	recoil_unwielded = RECOIL_AMOUNT_TIER_1
 
 /obj/item/weapon/gun/shotgun/pump/unique_action(mob/user)
 	pump_shotgun(user)

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -1116,7 +1116,7 @@ can cause issues with ammo types getting mixed up during the burst.
 /obj/item/weapon/gun/shotgun/pump/set_gun_config_values()
 	..()
 	set_burst_amount(BURST_AMOUNT_TIER_1)
-	set_fire_delay(FIRE_DELAY_TIER_11 * 4)
+	set_fire_delay(FIRE_DELAY_TIER_7 * 4)
 	accuracy_mult = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_3
 	accuracy_mult_unwielded = BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_10
 	scatter = SCATTER_AMOUNT_TIER_7

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -41,7 +41,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	scatter = SCATTER_AMOUNT_TIER_6
 	burst_scatter_mult = SCATTER_AMOUNT_TIER_6
 	scatter_unwielded = SCATTER_AMOUNT_TIER_2
-	damage_mult = BASE_BULLET_DAMAGE_MULT_TIER_3
+	damage_mult = BULLET_DAMAGE_MULT_TIER_3
 	recoil = RECOIL_AMOUNT_TIER_3
 	recoil_unwielded = RECOIL_AMOUNT_TIER_1
 

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -41,9 +41,9 @@ can cause issues with ammo types getting mixed up during the burst.
 	scatter = SCATTER_AMOUNT_TIER_6
 	burst_scatter_mult = SCATTER_AMOUNT_TIER_6
 	scatter_unwielded = SCATTER_AMOUNT_TIER_2
-	damage_mult = BASE_BULLET_DAMAGE_MULT
-	recoil = RECOIL_AMOUNT_TIER_4
-	recoil_unwielded = RECOIL_AMOUNT_TIER_2
+	damage_mult = BASE_BULLET_DAMAGE_MULT_TIER_3
+	recoil = RECOIL_AMOUNT_TIER_3
+	recoil_unwielded = RECOIL_AMOUNT_TIER_1
 
 /obj/item/weapon/gun/shotgun/proc/replace_tube(number_to_replace)
 	if(!current_mag)
@@ -245,7 +245,7 @@ can cause issues with ammo types getting mixed up during the burst.
 
 	fire_sound = "gun_shotgun_tactical"
 	firesound_volume = 20
-	current_mag = /obj/item/ammo_magazine/internal/shotgun
+	current_mag = /obj/item/ammo_magazine/internal/shotgun/combat
 	attachable_allowed = list(
 		/obj/item/attachable/bayonet,
 		/obj/item/attachable/bayonet/upp,
@@ -274,7 +274,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	update_attachable(ugl.slot)
 	stock.hidden = FALSE
 	stock.Attach(src)
-	update_attachable(stock.slot)	
+	update_attachable(stock.slot)
 
 /obj/item/weapon/gun/shotgun/combat/set_gun_attachment_offsets()
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19,"rail_x" = 10, "rail_y" = 21, "under_x" = 14, "under_y" = 16, "stock_x" = 11, "stock_y" = 13.)
@@ -1116,7 +1116,7 @@ can cause issues with ammo types getting mixed up during the burst.
 /obj/item/weapon/gun/shotgun/pump/set_gun_config_values()
 	..()
 	set_burst_amount(BURST_AMOUNT_TIER_1)
-	set_fire_delay(FIRE_DELAY_TIER_7 * 4)
+	set_fire_delay(FIRE_DELAY_TIER_9 * 4)
 	accuracy_mult = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_3
 	accuracy_mult_unwielded = BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_10
 	scatter = SCATTER_AMOUNT_TIER_6

--- a/code/modules/projectiles/magazines/shotguns.dm
+++ b/code/modules/projectiles/magazines/shotguns.dm
@@ -96,10 +96,14 @@ also doesn't really matter. You can only reload them with handfuls.
 /obj/item/ammo_magazine/internal/shotgun
 	name = "shotgun tube"
 	desc = "An internal magazine. It is not supposed to be seen or removed."
-	default_ammo = /datum/ammo/bullet/shotgun/slug
+	default_ammo = /datum/ammo/bullet/shotgun/buckshot
 	caliber = "12g"
-	max_rounds = 9
+	max_rounds = 4
 	chamber_closed = 0
+
+/obj/item/ammo_magazine/internal/shotgun/combat
+	default_ammo = /datum/ammo/bullet/shotgun/buckshot
+	max_rounds = 9
 
 /obj/item/ammo_magazine/internal/shotgun/double //For a double barrel.
 	default_ammo = /datum/ammo/bullet/shotgun/buckshot


### PR DESCRIPTION
## About the pull request

Reworks the M37A2 and the ammo used by it to halve the mag size, increase the recoil, but increase the damage a small amount and decrease the spread.

# Explain why it's good for the game

The M37A2 has long since been a glorified secondary weapon. I want to bring it back into the limelight deserving of a primary weapon. With the recent buff in the M39's burst spread, I thought it was time to bring some of my own changes. This isn't meant to be just a straight buff, seeing as the recoil and mag size have been kneecapped respectively. These changes bring more of a rewarding feeling to the shotgun, as well as give shots more value. You miss one shot, you get punished more, you hit one shot, you get rewarded more.

# Testing Photographs and Procedure
First three links are the base shotgun, second three are the shotgun under my changes. This is meant to represent raw damage/stun.
https://cdn.discordapp.com/attachments/1198451636268445747/1199598491278774272/-_LV624_2024-01-24_01-13-19.mp4?ex=65c32027&is=65b0ab27&hm=99f238b0a0643166299cd106ade1bb3aee37813de6aa44baa6fec191369db4a5&
https://cdn.discordapp.com/attachments/1198451636268445747/1199599425757138954/-_LV624_2024-01-24_01-16-03.mp4?ex=65c32106&is=65b0ac06&hm=ff7c0f3491f7a36b45cf4bb201337ec6a21d4d2d87981788fb28f02db46b3bcc&
https://cdn.discordapp.com/attachments/1198451636268445747/1199600229331238953/-_LV624_2024-01-24_01-18-04.mp4?ex=65c321c6&is=65b0acc6&hm=fb09e6b8c00b1a8451718f5a8a263c17d60c9a14eeee16ada08dc1f856061b7a&

https://cdn.discordapp.com/attachments/1198451636268445747/1199766790436294767/-_LV624_2024-01-24_12-15-50.mp4?ex=65c3bce5&is=65b147e5&hm=1e5a4b95be5720066b2eda73e034e9caf812e07910b54fa2c1aaad17af148c95&
https://cdn.discordapp.com/attachments/1198451636268445747/1199766796119593122/-_LV624_2024-01-24_12-17-28.mp4?ex=65c3bce6&is=65b147e6&hm=e13abb3a6bb4ad91220bf6193a27b8edf2cfd3a0c2ac55bfeef39ef241a367f0&
https://cdn.discordapp.com/attachments/1198451636268445747/1199766804558516305/-_LV624_2024-01-24_12-19-32.mp4?ex=65c3bce8&is=65b147e8&hm=4df68ee0d3329450e909d3bc0f4dc62285fec4a22cb578dde2b75eec6d690998&

</details>

# Changelog
:cl: Stakeyng
balance: Reworked the M37A2
code: Edited shotgun/shotgun ammo variables.
/:cl:
