### PR TITLE
scouts can no longer attach 2x-4x scopes on their gun

### DIFF
--- a/code/modules/projectiles/guns/specialist/scout.dm
+++ b/code/modules/projectiles/guns/specialist/scout.dm
@@ -42,8 +42,6 @@
 		/obj/item/attachable/verticalgrip,
 		/obj/item/attachable/angledgrip,
 		/obj/item/attachable/lasersight,
-		/obj/item/attachable/scope,
-		/obj/item/attachable/scope/mini,
 		/obj/item/attachable/flashlight/grip,
 	)
 


### PR DESCRIPTION

# About the pull request
makes it so you cant attach the 2x-4x scopes on the gun
# Explain why it's good for the game

its not fun being stunned from 2/3 screens away, especially with burstfire it becomes neigh uncounterable. scout should be semi cqc check below for the video

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>


https://github.com/cmss13-devs/cmss13/assets/47158596/f025e43b-8d50-4e49-ac46-1d5505bd4dfc



</details>


# Changelog
:cl:
balance: Scouts can no longer put 2x-4x scopes on their gun
/:cl:
