### PR TITLE
Deadchat no longer gets notified about tutorial facehuggers 

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -283,7 +283,7 @@
 
 	var/area/hug_area = get_area(src)
 	var/name = hugger ? "[hugger]" : "\a [src]"
-	if(!istype(hug_area, /area/misc/tutorial)) // prevent hugs from any tutorials from showing up in dchat
+	if(hivenumber != XENO_HIVE_TUTORIAL) // prevent hugs from any tutorial huggers from showing up in dchat
 		if(hug_area)
 			notify_ghosts(header = "Hugged", message = "[human] has been hugged by [name] at [hug_area]!", source = human, action = NOTIFY_ORBIT)
 			to_chat(src, SPAN_DEADSAY("<b>[human]</b> has been facehugged by <b>[name]</b> at \the <b>[hug_area]</b>"))

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -283,12 +283,14 @@
 
 	var/area/hug_area = get_area(src)
 	var/name = hugger ? "[hugger]" : "\a [src]"
-	if(hug_area)
-		notify_ghosts(header = "Hugged", message = "[human] has been hugged by [name] at [hug_area]!", source = human, action = NOTIFY_ORBIT)
-		to_chat(src, SPAN_DEADSAY("<b>[human]</b> has been facehugged by <b>[name]</b> at \the <b>[hug_area]</b>"))
-	else
-		notify_ghosts(header = "Hugged", message = "[human] has been hugged by [name]!", source = human, action = NOTIFY_ORBIT)
-		to_chat(src, SPAN_DEADSAY("<b>[human]</b> has been facehugged by <b>[name]</b>"))
+	if(!istype(hug_area, /area/misc/tutorial)) // prevent hugs from any tutorials from showing up in dchat
+		if(hug_area)
+			notify_ghosts(header = "Hugged", message = "[human] has been hugged by [name] at [hug_area]!", source = human, action = NOTIFY_ORBIT)
+			to_chat(src, SPAN_DEADSAY("<b>[human]</b> has been facehugged by <b>[name]</b> at \the <b>[hug_area]</b>"))
+		else
+			notify_ghosts(header = "Hugged", message = "[human] has been hugged by [name]!", source = human, action = NOTIFY_ORBIT)
+			to_chat(src, SPAN_DEADSAY("<b>[human]</b> has been facehugged by <b>[name]</b>"))
+
 	if(hug_area)
 		xeno_message(SPAN_XENOMINORWARNING("We sense that [name] has facehugged a host at \the [hug_area]!"), 1, hivenumber)
 	else


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Deadchat will no longer get notified about any facehugs inside a tutorial area. 

This is the best solution I can think to this problem, an alternative being checking the hive of the facehugger and canceling based on that. Recommendations are welcome.

# Explain why it's good for the game
Tutorials are irrelevent to the main game, and players shouldnt be notified that someone is using the tutorial system.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
![image](https://github.com/cmss13-devs/cmss13/assets/91113370/755baecd-b727-4105-ae4b-32c17aa510ff)

No dchat message.
</details>


# Changelog
:cl:
fix: Dchat is no longer notified of hugs from tutorials
/:cl:
