### PR TITLE
XM4 Armor Slowdown Change

### DIFF
--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -282,6 +282,7 @@
 	name = "\improper XM4 pattern intelligence officer armor"
 	uniform_restricted = list(/obj/item/clothing/under/marine/officer, /obj/item/clothing/under/rank/qm_suit, /obj/item/clothing/under/marine/officer/intel)
 	specialty = "XM4 pattern intel"
+	slowdown = SLOWDOWN_ARMOR_LIGHT
 
 /obj/item/clothing/suit/storage/marine/MP
 	name = "\improper M2 pattern MP armor"


### PR DESCRIPTION
# About the pull request
Changes the XM4 armor slowdown to `SLOWDOWN_ARMOR_LIGHT (0.35)` instead of the current `SLOWDOWN_ARMOR_MEDIUM (0.55)`.

As it stands the XM4 armor is a "noobtrap", with majority of experienced Intelligence Officers (IOs) opting to use either the Service Jacket or Light Armor from the squad prep vendors. Changing the XM4 slowdown to match the slowdown of the light armor makes it a viable option, while not making it overpowered.

# Explain why it's good for the game

IOs rely on speed and awareness to survive in most cases. This will also match the general "fluff" of IOs having advanced gear a slight cut above normal Marines. This should not have any major effects on balance vs. Xenos, as IOs already have the capability to use Light Armor for the same speed. Regardless, most IOs are going to wind up dead in a colony corner anyways if they get jumped, so the differences in the armor values are likely negligible. This merge would really just cut down on the prep time for IOs.

# Testing Photographs and Procedure
N/A

# Changelog
:cl:
qol: XM4 slowdown = SLOWDOWN_ARMOR_LIGHT (0.35) changing from the current 0.55

:cl: