### PR TITLE
reduces effects of impact ammo with range, proof of concept numbers can be adjusted

### DIFF
--- a/code/datums/ammo/bullet/rifle.dm
+++ b/code/datums/ammo/bullet/rifle.dm
@@ -169,14 +169,14 @@
 	shell_speed = AMMO_SPEED_TIER_6
 
 /datum/ammo/bullet/rifle/m4ra/impact/on_hit_mob(mob/M, obj/projectile/P)
-	knockback(M, P, 32) // Can knockback basically at max range
+	knockback(M, P, 32) // Can knockback basically at max range max range is 24 tiles...
 
 /datum/ammo/bullet/rifle/m4ra/impact/knockback_effects(mob/living/living_mob, obj/projectile/fired_projectile)
 	if(iscarbonsizexeno(living_mob))
 		var/mob/living/carbon/xenomorph/target = living_mob
 		to_chat(target, SPAN_XENODANGER("You are shaken and slowed by the sudden impact!"))
-		target.KnockDown(0.5-fired_projectile.distance_travelled/10) // purely for visual effect, noone actually cares
-		target.Stun(0.5-fired_projectile.distance_travelled/10)
+		target.KnockDown(0.5-fired_projectile.distance_travelled/100) // purely for visual effect, noone actually cares
+		target.Stun(0.5-fired_projectile.distance_travelled/100)
 		target.apply_effect(2-fired_projectile.distance_travelled/20, SUPERSLOW)
 		target.apply_effect(5-fired_projectile.distance_travelled/10, SLOW)
 	else

--- a/code/datums/ammo/bullet/rifle.dm
+++ b/code/datums/ammo/bullet/rifle.dm
@@ -175,10 +175,10 @@
 	if(iscarbonsizexeno(living_mob))
 		var/mob/living/carbon/xenomorph/target = living_mob
 		to_chat(target, SPAN_XENODANGER("You are shaken and slowed by the sudden impact!"))
-		target.KnockDown(0.5) // purely for visual effect, noone actually cares
-		target.Stun(0.5)
-		target.apply_effect(2, SUPERSLOW)
-		target.apply_effect(5, SLOW)
+		target.KnockDown(0.5-fired_projectile.distance_travelled/10) // purely for visual effect, noone actually cares
+		target.Stun(0.5-fired_projectile.distance_travelled/10)
+		target.apply_effect(2-fired_projectile.distance_travelled/20, SUPERSLOW)
+		target.apply_effect(5-fired_projectile.distance_travelled/10, SLOW)
 	else
 		if(!isyautja(living_mob)) //Not predators.
 			living_mob.apply_effect(1, SUPERSLOW)


### PR DESCRIPTION

# About the pull request

attempt to adress the issue with offscreen stun rather then removing scope . NUMBERS ARE UP FOR DEBATE, they are just placeholders

# Explain why it's good for the game

offscreen stun sucks shure, but that is not a reason to limit gameplay options, high impact should have lower effect with higer range just like it does with revolvers (a bit diferent aproach in this PR rather then having suden drop in effect it is gradual) also it has almoust no effect on close range spec reducing the effects by about 1/10 for stuff on screen


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: m4ra ammo looses about 1/5 of initial effect duration per 10 tiles traveled
/:cl:
