### PR TITLE
Makes observers see the marine version of CAS warnings

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -32,6 +32,7 @@
 	plane = GHOST_PLANE
 	layer = ABOVE_FLY_LAYER
 	stat = DEAD
+	mob_flags = KNOWS_TECHNOLOGY
 	var/adminlarva = FALSE
 	var/ghostvision = TRUE
 	var/can_reenter_corpse


### PR DESCRIPTION
# About the pull request

Makes the CAS warning messages for observers say 'Dropship' rather than 'Large bird'.

# Explain why it's good for the game

It seems a bit weird that observers get the "in-character" xeno version of the messages, rather than the "correct" version.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
(no idea what CL category to make this)

:cl:
spellcheck: Made observers see the marine version of CAS warnings, rather than the xeno one.
/:cl:
