### PR TITLE
Fixes edited `.jsx` files not triggering a TGUI recompile

### DIFF
--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -176,7 +176,7 @@ export const TguiTarget = new Juke.Target({
     "tgui/.yarn/install-target",
     "tgui/webpack.config.js",
     "tgui/**/package.json",
-    "tgui/packages/**/*.+(js|cjs|ts|tsx|scss)",
+    "tgui/packages/**/*.+(js|jsx|cjs|ts|tsx|scss)",
   ],
   outputs: [
     "tgui/public/tgui.bundle.css",


### PR DESCRIPTION

# About the pull request

Fixes `.jsx` files not triggering a TGUI recompile in build.bat when they've been edited.
Currently you need to manually run `yarn tgui:build` (or equivalent) to make any changes appear in-game.

I double checked TG's version of this just to make sure I didn't miss something obvious, and it looks like they've only recently fixed this themselves: https://github.com/tgstation/tgstation/pull/80630

# Explain why it's good for the game

Editing a TGUI file should trigger a rebuild.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
Nothing player-facing.
