### PR TITLE
Removes burrower from feral ERT

### DIFF
--- a/code/datums/emergency_calls/feral_xenos.dm
+++ b/code/datums/emergency_calls/feral_xenos.dm
@@ -39,7 +39,7 @@
 
 	else if(medics < max_medics)
 		medics++
-		var/picked = pick(/mob/living/carbon/xenomorph/drone, /mob/living/carbon/xenomorph/hivelord, /mob/living/carbon/xenomorph/burrower)
+		var/picked = pick(/mob/living/carbon/xenomorph/drone, /mob/living/carbon/xenomorph/hivelord)
 		new_xeno = new picked(spawn_loc)
 
 	else if(engineers < max_engineers)


### PR DESCRIPTION
# About the pull request
see title. this means that in the place of a burrower, there'll be a hivelord or a drone instead.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Currently, burrower doesn't really have a place in the ERT, every other "medic" type xeno (Drone and hivelord) is able to build, emit pheros, and weed. Meanwhile the burrower can only weed and make traps, this isn't very useful because there's typically only 2 or 3 xenos able to weed/emit pheros, and pheros are **Extraordinarily important** to xeno combat, especially in XvX, while the traps take far too long to set up for them to be very useful.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Burrower can no longer spawn as part of the feral xeno ERT
/:cl:
