### PR TITLE
increases exxecution speed of CAS FM, number is up for a debate

### DIFF
--- a/code/game/cas_manager/datums/cas_fire_mission.dm
+++ b/code/game/cas_manager/datums/cas_fire_mission.dm
@@ -160,7 +160,7 @@
 		return "Weapon [weapon_string] has not enough ammunition to complete this Fire Mission"
 	return "Unknown Error"
 
-/datum/cas_fire_mission/proc/execute_firemission(obj/structure/machinery/computer/dropship_weapons/linked_console, turf/initial_turf, direction = NORTH, steps = 12, step_delay = 3, datum/cas_fire_envelope/envelope = null)
+/datum/cas_fire_mission/proc/execute_firemission(obj/structure/machinery/computer/dropship_weapons/linked_console, turf/initial_turf, direction = NORTH, steps = 12, step_delay = 2.5, datum/cas_fire_envelope/envelope = null)
 	if(initial_turf == null || check(linked_console) != FIRE_MISSION_ALL_GOOD)
 		return FIRE_MISSION_NOT_EXECUTABLE
 

--- a/code/game/cas_manager/datums/cas_fire_mission.dm
+++ b/code/game/cas_manager/datums/cas_fire_mission.dm
@@ -160,7 +160,7 @@
 		return "Weapon [weapon_string] has not enough ammunition to complete this Fire Mission"
 	return "Unknown Error"
 
-/datum/cas_fire_mission/proc/execute_firemission(obj/structure/machinery/computer/dropship_weapons/linked_console, turf/initial_turf, direction = NORTH, steps = 12, step_delay = 2.5, datum/cas_fire_envelope/envelope = null)
+/datum/cas_fire_mission/proc/execute_firemission(obj/structure/machinery/computer/dropship_weapons/linked_console, turf/initial_turf, direction = NORTH, steps = 12, step_delay = 2, datum/cas_fire_envelope/envelope = null)
 	if(initial_turf == null || check(linked_console) != FIRE_MISSION_ALL_GOOD)
 		return FIRE_MISSION_NOT_EXECUTABLE
 


### PR DESCRIPTION
# About the pull request

reduces time betwean FM execution steps, increses it speed from 3 tiles per second to 5 tiles per second

# Explain why it's good for the game

after I added all the extra warnings it is near imposible to hit xeno with it, especily considering that even when the xeno is in the area where the CAS is being fired, the FM moves so slowly that even the slowest xenos can outrun it easily , this aims to make CAS more powerful (and also cool looking), by making it move faster so that when you end up in the area where the CAS is being fired at even after all the warnings, you can not just walk away from it without getting hit, still have chance when you are close to edge of the FM


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: increseas FM movement speed to 5 tiles per second from 3 tiles per second
/:cl:
