### PR TITLE
Food processor can be used to remove carpotoxin and acidic blood with master domestic skill

### DIFF
--- a/code/game/machinery/kitchen/processor.dm
+++ b/code/game/machinery/kitchen/processor.dm
@@ -19,14 +19,32 @@
 
 /datum/food_processor_process/process(loc, what)
 	if (src.output && loc)
-		new src.output(loc)
+		var/obj/item/reagent_container/food/snacks/created_food = new src.output(loc)
+		if (istype(created_food, /obj/item/reagent_container/food/snacks/meat/xenomeat))
+			var/obj/item/reagent_container/food/snacks/meat/original_food = what
+			created_food.made_from_player = original_food.made_from_player
+			created_food.name = ("processed " + created_food.made_from_player + created_food.name)
+			created_food.reagents.remove_reagent("xenoblood", 6)
+		else if (istype(created_food, /obj/item/reagent_container/food/snacks/carpmeat))
+			created_food.name = "processed carp fillet"
+			created_food.reagents.remove_reagent("carpotoxin", 6)
 	if (what)
 		qdel(what)
 
 	/* objs */
+
+/datum/food_processor_process/xenomeat
+	input = /obj/item/reagent_container/food/snacks/meat/xenomeat
+	output = /obj/item/reagent_container/food/snacks/meat/xenomeat
+
 /datum/food_processor_process/meat
 	input = /obj/item/reagent_container/food/snacks/meat
 	output = /obj/item/reagent_container/food/snacks/rawmeatball
+
+
+/datum/food_processor_process/carpmeat
+	input = /obj/item/reagent_container/food/snacks/carpmeat
+	output = /obj/item/reagent_container/food/snacks/carpmeat
 
 /datum/food_processor_process/potato
 	input = /obj/item/reagent_container/food/snacks/grown/potato
@@ -87,6 +105,9 @@
 	var/datum/food_processor_process/P = select_recipe(what)
 	if (!P)
 		to_chat(user, SPAN_DANGER("That probably won't blend."))
+		return 1
+	if ((istype(P,/datum/food_processor_process/xenomeat) || istype(P,/datum/food_processor_process/carpmeat)) && !skillcheck(user, SKILL_DOMESTIC, SKILL_DOMESTIC_MASTER))
+		to_chat(user, SPAN_DANGER("You aren't trained to remove dangerous substances from food"))
 		return 1
 	user.visible_message("[user] put [what] into [src].", \
 		"You put [what] into [src].")

--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -641,7 +641,7 @@
 /obj/item/reagent_container/food/snacks/carpmeat/Initialize()
 	. = ..()
 	reagents.add_reagent("fish", 3)
-	reagents.add_reagent("carpotoxin", 3)
+	reagents.add_reagent("carpotoxin", 6)
 	src.bitesize = 6
 
 /obj/item/reagent_container/food/snacks/fishfingers
@@ -653,7 +653,6 @@
 /obj/item/reagent_container/food/snacks/fishfingers/Initialize()
 	. = ..()
 	reagents.add_reagent("fish", 4)
-	reagents.add_reagent("carpotoxin", 3)
 	bitesize = 3
 
 /obj/item/reagent_container/food/snacks/hugemushroomslice
@@ -802,7 +801,6 @@
 	. = ..()
 	reagents.add_reagent("bread", 3)
 	reagents.add_reagent("fish", 3)
-	reagents.add_reagent("carpotoxin", 3)
 	bitesize = 3
 
 /obj/item/reagent_container/food/snacks/tofuburger
@@ -850,7 +848,6 @@
 	. = ..()
 	reagents.add_reagent("bread", 3)
 	reagents.add_reagent("meatprotein", 3)
-	reagents.add_reagent("xenoblood", 3)
 	bitesize = 3
 
 /obj/item/reagent_container/food/snacks/clownburger
@@ -1070,7 +1067,6 @@
 	. = ..()
 	reagents.add_reagent("bread", 4)
 	reagents.add_reagent("meatprotein", 2)
-	reagents.add_reagent("xenoblood", 4)
 	bitesize = 2
 
 /obj/item/reagent_container/food/snacks/wingfangchu
@@ -1084,7 +1080,6 @@
 	. = ..()
 	reagents.add_reagent("soysauce", 4)
 	reagents.add_reagent("meatprotein", 4)
-	reagents.add_reagent("xenoblood", 4)
 	bitesize = 2
 
 /obj/item/reagent_container/food/snacks/human/kabob
@@ -1133,7 +1128,6 @@
 /obj/item/reagent_container/food/snacks/cubancarp/Initialize()
 	. = ..()
 	reagents.add_reagent("fish", 6)
-	reagents.add_reagent("carpotoxin", 3)
 	reagents.add_reagent("hotsauce", 3)
 	bitesize = 3
 
@@ -1690,7 +1684,6 @@
 /obj/item/reagent_container/food/snacks/fishandchips/Initialize()
 	. = ..()
 	reagents.add_reagent("fish", 6)
-	reagents.add_reagent("carpotoxin", 3)
 	bitesize = 3
 
 /obj/item/reagent_container/food/snacks/sandwich
@@ -2172,7 +2165,6 @@
 	reagents.add_reagent("bread", 10)
 	reagents.add_reagent("meatprotein", 10)
 	reagents.add_reagent("cheese", 10)
-	reagents.add_reagent("xenoblood", 10)
 	bitesize = 2
 
 /obj/item/reagent_container/food/snacks/xenomeatbreadslice

--- a/code/game/objects/items/reagent_containers/food/snacks/meat.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks/meat.dm
@@ -57,7 +57,7 @@
 
 /obj/item/reagent_container/food/snacks/meat/xenomeat/Initialize()
 	. = ..()
-	reagents.add_reagent("xenoblood", 3)
+	reagents.add_reagent("xenoblood", 6)
 	src.bitesize = 6
 
 //fishable atoms meat


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR makes it so that characters with master level domestic skill are able to remove carpotoxin and acidic blood from carp fillets and xenomeat. Xenomeat, carp fillets and recipes including those have had their levels adjusted to avoid adding additional carpotoxin/xenoblood when creating a recipe so a processed ingredient won't result in a dangerous recipe.

I've tested this using characters with and without the skill with flour, potatoes, xenomeat and carp fillets to ensure that only the affected processor uses are changed, that processing works correctly and that the skill is required.

# Explain why it's good for the game

This would open more opportunities for the mess technician to serve the crew with recipes that rarely see the light of day due to being dangerous (while leaving some risk if an MST forgets to process the ingredients). Some marine players might also enjoy the roleplay opportunities around getting the chef to turn their fallen enemies into burgers.  

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

<summary>Screenshots & Videos</summary>

Here is shown a character with insufficient skill unable to modify the food, before putting it in the soda fountain to show its reagents:
https://github.com/cmss13-devs/cmss13/assets/32908370/8138d1c5-77a2-4f7d-92e9-9d7059fa3f05

Here is shown a character with sufficient the skill able to modify the food, before putting it in the soda fountain to show its reagents:
https://github.com/cmss13-devs/cmss13/assets/32908370/93bb0c99-fccf-46ca-a786-579be203629b

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Increased levels of acidic blood and carpotoxin in xenomeat and carp fillets.
del: Xenomeat and carp fillet-based recipes no longer add additional acidic blood or carpotoxin.
qol: Master level domestic skill allows the use of the food processor to remove acidic blood and carpotoxin from xenomeat and carp fillets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
