### PR TITLE
Fixes facehuggers being able to flip tables

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -353,7 +353,12 @@
 	set category = "Object"
 	set src in oview(1)
 
-	if(!can_touch(usr) || ismouse(usr))
+	if(!can_touch(usr))
+		return
+
+	// Small regular mob, or very small xeno.
+	if(usr.mob_size == MOB_SIZE_SMALL || usr.mob_size == MOB_SIZE_XENO_VERY_SMALL)
+		to_chat(usr, SPAN_WARNING("[isxeno(usr) ? "We are" : "You're"] too small to flip [src]."))
 		return
 
 	if(usr.a_intent != INTENT_HARM)


### PR DESCRIPTION

# About the pull request

Fixes #5563 by adding a `mob_size` check to the table flipping verb.

# Explain why it's good for the game

Probably not an intentional feature lol

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixed facehuggers being able to flip tables.
/:cl:
