### PR TITLE
Fixes missing poncho sprites

### DIFF
--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -377,7 +377,8 @@
 
 /obj/item/clothing/accessory/poncho/Initialize()
 	. = ..()
-	select_gamemode_skin(type)
+	// Only do this for the base type '/obj/item/clothing/accessory/poncho'.
+	select_gamemode_skin(/obj/item/clothing/accessory/poncho)
 	inv_overlay = image("icon" = 'icons/obj/items/clothing/ties_overlay.dmi', "icon_state" = "[icon_state]")
 	update_icon()
 


### PR DESCRIPTION

# About the pull request

Fixes #5484 by making only the parent type `/obj/item/clothing/accessory/poncho` change its sprite depending on the map.

# Explain why it's good for the game

poncho.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
(Tested on Shiva's Snowball)

![image](https://github.com/cmss13-devs/cmss13/assets/57483089/9912b053-1f75-4306-9081-2117bb6b8bdf)


</details>


# Changelog
:cl:
fix: Fixed ponchos not having icon states on specific maps.
/:cl:
