### PR TITLE
Dropship Fabricator UI Fix

### DIFF
--- a/tgui/packages/tgui/interfaces/PartFabricator.jsx
+++ b/tgui/packages/tgui/interfaces/PartFabricator.jsx
@@ -5,7 +5,7 @@ import { Window } from '../layouts';
 export const PartFabricator = (props) => {
   const { act, data } = useBackend();
   return (
-    <Window width={775} height={450}>
+    <Window width={900} height={450}>
       <Window.Content>
         <GeneralPanel />
       </Window.Content>


### PR DESCRIPTION
# About the pull request

Dropship fabricator TGUI is not wide enough to show the entire screen

# Explain why it's good for the game

You have to extend the screen EVERY TIME you open it to see the points, which is annoying and shouldnt be the case
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

##OLD
![ZJCsgGneyi](https://github.com/cmss13-devs/cmss13/assets/66401072/4d4a7d6a-1678-4f25-9aea-ef5865533a50)

##NEW
![tkCGtURWfs](https://github.com/cmss13-devs/cmss13/assets/66401072/b5927d5f-d54f-4d6f-9e96-662b44f419a8)


</details>


# Changelog
:cl:
fix: Widens Dropship fabricator UI. Points for ammo are no longer cut off
/:cl:
