### PR TITLE
Fixes Queen xenos not automatically climbing ledges

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -538,22 +538,6 @@
 		var/time_left = time2text(timeleft(queen_age_timer_id) + 1 MINUTES, "mm") // We add a minute so that it basically ceilings the value.
 		. += "Maturity: [time_left == 1? "[time_left] minute" : "[time_left] minutes"] remaining"
 
-//Custom bump for crushers. This overwrites normal bumpcode from carbon.dm
-/mob/living/carbon/xenomorph/queen/Collide(atom/A)
-	set waitfor = 0
-
-	if(stat || !istype(A) || A == src)
-		return FALSE
-
-	if(now_pushing)
-		return FALSE//Just a plain ol turf, let's return.
-
-	var/turf/T = get_step(src, dir)
-	if(!T || !get_step_to(src, T)) //If it still exists, try to push it.
-		return ..()
-
-	return TRUE
-
 /mob/living/carbon/xenomorph/queen/proc/set_orders()
 	set category = "Alien"
 	set name = "Set Hive Orders (50)"


### PR DESCRIPTION

# About the pull request

Makes Queen xenomorphs automatically climb ledges like normal, instead of having to manually click+drag their sprite onto it. (Resolves #5589)

This was done by just removing the caste's `Collide()` override, since as far as I've been able to tell it's something left over from the old 'Charge' ability.
(When it was first added in 3b0bce5dec1eda1b300cb7b8a1d3ff3de231f543 it had some `charge_speed` and `charge_dir` checks, then those got commented out in 277f4242ae67898b134ff9b70ae6aa05d572fb92, then eventually they were removed entirely and the proc was renamed to `Collide()` in bcfa342c7da6fc7689855a811ace734f1bf4dae9.)

In its current state I'm not sure that it's actually doing *anything* other than overriding the parent procs.

# Explain why it's good for the game

I can't speak from personal experience since I actively avoid playing Queen, but from what I've heard from others it can be really irritating to get stuck on a ledge and have to sort of pixel hunt behind your massive sprite in order to climb over. Especially since, as said in the issue, a xeno as big as the Queen should really have no trouble just stepping over it.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Made the Queen able to automatically climb ledges.
/:cl:
