### PR TITLE
Fix medbay vendor access

### DIFF
--- a/code/game/machinery/vending/vendor_types/medical.dm
+++ b/code/game/machinery/vending/vendor_types/medical.dm
@@ -4,7 +4,7 @@
 	name = "\improper Wey-Med Plus"
 	desc = "Medical Pharmaceutical dispenser. Provided by Wey-Yu Pharmaceuticals Division(TM)."
 	icon_state = "med"
-	req_access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY)
+	req_access = list(ACCESS_MARINE_MEDBAY)
 
 	unacidable = TRUE
 	unslashable = FALSE
@@ -183,6 +183,7 @@
 	name = "\improper Wey-Chem Plus"
 	desc = "Medical chemistry dispenser. Provided by Wey-Yu Pharmaceuticals Division(TM)."
 	icon_state = "chem"
+	req_access = list(ACCESS_MARINE_CHEMISTRY)
 
 	healthscan = FALSE
 	chem_refill = list(
@@ -221,7 +222,6 @@
 	req_access = list()
 
 /obj/structure/machinery/cm_vending/sorted/medical/bolted
-	req_access = list()
 	wrenchable = FALSE
 
 /obj/structure/machinery/cm_vending/sorted/medical/chemistry/no_access
@@ -300,7 +300,6 @@
 	stack_refill = null
 
 /obj/structure/machinery/cm_vending/sorted/medical/blood/bolted
-	req_access = list()
 	wrenchable = FALSE
 
 /obj/structure/machinery/cm_vending/sorted/medical/blood/populate_product_list(scale)


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #5490 that had an undocumented change of resetting the medbay vendors to no access required.

# Explain why it's good for the game

Medbay vendors are for medbay. You should have medbay access to use them. The change was unintentional.

However, compared to how it originally was, corpsmen now have access to the vendors.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/b71aec79-3943-452c-98e0-c3e2e7605ffd)
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/e3c094ab-c2f2-42de-a4eb-ef6c64f3df1b)


</details>


# Changelog
:cl: Drathek
balance: Compared to originally, corpsmen now have access to medbay vendors, and chemistry only requires chemistry access.
fix: Fixed unintended change to medbay vendors access: 
/:cl:
