### PR TITLE
Helmet HUDs skip over HUDs that are already in effect on the player

### DIFF
--- a/code/game/objects/items/props/helmetgarb.dm
+++ b/code/game/objects/items/props/helmetgarb.dm
@@ -5,6 +5,7 @@
 	icon_state = null
 	w_class = SIZE_TINY
 	garbage = TRUE
+	slot = ACCESSORY_SLOT_HELM_C
 
 /obj/item/prop/helmetgarb/Initialize(mapload, ...)
 	. = ..()

--- a/code/game/objects/items/props/helmetgarb.dm
+++ b/code/game/objects/items/props/helmetgarb.dm
@@ -5,7 +5,6 @@
 	icon_state = null
 	w_class = SIZE_TINY
 	garbage = TRUE
-	slot = ACCESSORY_SLOT_HELM_C
 
 /obj/item/prop/helmetgarb/Initialize(mapload, ...)
 	. = ..()

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -670,8 +670,15 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 		for(var/hud_type in total_visors)
 			if(hud_type == active_visor)
 				if(length(total_visors) > iterator)
-					active_visor = total_visors[(iterator + 1)]
-					toggle_visor(user, total_visors[iterator], TRUE)
+					var/obj/item/device/helmet_visor/current_visor = total_visors[iterator]
+					var/obj/item/device/helmet_visor/next_visor = total_visors[iterator + 1]
+
+					if(!isnull(GLOB.huds[next_visor.hud_type].hudusers[user]))
+						iterator++
+						continue
+
+					active_visor = next_visor
+					toggle_visor(user, current_visor, silent = TRUE) // disables the old visor
 					toggle_visor(user)
 					return active_visor
 				else
@@ -680,14 +687,14 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 					return FALSE
 			iterator++
 
-	if(total_visors[1])
-		active_visor = total_visors[1]
+	for(var/obj/item/device/helmet_visor/new_visor in total_visors)
+
+		if(!isnull(GLOB.huds[new_visor.hud_type].hudusers[user]))
+			continue
+
+		active_visor = new_visor
 		toggle_visor(user)
 		return active_visor
-
-	active_visor = null
-	recalculate_visors(user)
-	return FALSE
 
 /datum/action/item_action/cycle_helmet_huds/New(Target, obj/item/holder)
 	. = ..()

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -666,24 +666,26 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 		return FALSE
 
 	if(active_visor)
+		var/visor_to_deactivate = active_visor
+		var/skipped_hud = FALSE
 		var/iterator = 1
-		for(var/hud_type in total_visors)
-			if(hud_type == active_visor)
+		for(var/obj/item/device/helmet_visor/current_visor as anything in total_visors)
+			if(current_visor == active_visor || skipped_hud)
 				if(length(total_visors) > iterator)
-					var/obj/item/device/helmet_visor/current_visor = total_visors[iterator]
 					var/obj/item/device/helmet_visor/next_visor = total_visors[iterator + 1]
 
 					if(!isnull(GLOB.huds[next_visor.hud_type].hudusers[user]))
 						iterator++
+						skipped_hud = TRUE
 						continue
 
 					active_visor = next_visor
-					toggle_visor(user, current_visor, silent = TRUE) // disables the old visor
+					toggle_visor(user, visor_to_deactivate, silent = TRUE) // disables the old visor
 					toggle_visor(user)
 					return active_visor
 				else
 					active_visor = null
-					toggle_visor(user, total_visors[iterator], FALSE)
+					toggle_visor(user, visor_to_deactivate, FALSE)
 					return FALSE
 			iterator++
 

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -696,7 +696,7 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 		toggle_visor(user)
 		return active_visor
 
-		return FALSE
+	return FALSE
 /datum/action/item_action/cycle_helmet_huds/New(Target, obj/item/holder)
 	. = ..()
 	name = "Cycle helmet HUD"

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -696,6 +696,7 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 		toggle_visor(user)
 		return active_visor
 
+		return FALSE
 /datum/action/item_action/cycle_helmet_huds/New(Target, obj/item/holder)
 	. = ..()
 	name = "Cycle helmet HUD"


### PR DESCRIPTION
# About the pull request

Makes it so that if you have an active HUD, a helmet visor that does the same thing will not be considered when switching through visors in your helmet. Credit to harryob for his help with the code.

# Explain why it's good for the game

Visors are usually a pain to switch through when their functionality isn't needed, take for example, the squad optic, which does the same job as the headset (HUD-wise). This change makes it so you don't need to switch through unneeded HUDs.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Stakeyng
qol: Removes the need to cycle through helmet visors that contain HUD effects that are already active on your character.
/:cl:
