### PR TITLE
fixes medal saving

### DIFF
--- a/code/datums/statistics/entities/medal_stats.dm
+++ b/code/datums/statistics/entities/medal_stats.dm
@@ -57,7 +57,7 @@
 		return
 
 	var/datum/entity/statistic/medal/new_medal = DB_ENTITY(/datum/entity/statistic/medal)
-	var/datum/entity/player/player_entity = get_player_from_key(new_recipient.ckey)
+	var/datum/entity/player/player_entity = get_player_from_key(new_recipient.persistent_ckey)
 	if(player_entity)
 		new_medal.player_id = player_entity.id
 


### PR DESCRIPTION
posthumous medals would never save because the ckey is nulled immediately on mob changes. this also applies to medals given when you're disconnected for whatever reason

:cl:
fix: medals should save more reliably
/:cl: