### PR TITLE
Fixes lesser drones not being able to flip tables

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -356,8 +356,7 @@
 	if(!can_touch(usr))
 		return
 
-	// Small regular mob, or very small xeno.
-	if(usr.mob_size == MOB_SIZE_SMALL || usr.mob_size == MOB_SIZE_XENO_VERY_SMALL)
+	if(usr.mob_size == MOB_SIZE_SMALL)
 		to_chat(usr, SPAN_WARNING("[isxeno(usr) ? "We are" : "You're"] too small to flip [src]."))
 		return
 


### PR DESCRIPTION

# About the pull request

Fixes #5606 by removing the `MOB_SIZE_XENO_VERY_SMALL` check added in #5580.
I honestly can't remember why I added that since the define is obviously *only* used by lesser drones, but I guess I must have thought `MOB_SIZE_XENO_VERY_SMALL` was for huggers/larvae, and `MOB_SIZE_SMALL` was for regular mobs like mice and cats.

# Explain why it's good for the game

Yet another PR to fix something that I broke by accident. :(

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/57483089/3dc0a170-3dae-4d53-b027-6778460a4e72

</details>


# Changelog
:cl:
fix: Fixed lesser drones not being able to flip tables.
/:cl:
