### PR TITLE
MapTweaks: removed a bed sheet for soul and added warning stripes bellow doors that didn't have them for safety.

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -49890,7 +49890,7 @@
 "mza" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer{
 	dir = 2;
-	id = "firearm_storage_armory";
+	id = "bot_armory";
 	name = "\improper Armory Shutters"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer{

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -1568,7 +1568,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "test_floor4"
 	},
 /area/almayer/squads/req)
 "agw" = (
@@ -17274,6 +17274,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/port_hallway)
+"bHg" = (
+/obj/structure/bed,
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "sterile_green_side"
+	},
+/area/almayer/medical/lower_medical_medbay)
 "bHk" = (
 /turf/open/floor/almayer/research/containment/floor2{
 	dir = 1
@@ -43133,7 +43140,7 @@
 	name = "Lobby"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile"
+	icon_state = "test_floor4"
 	},
 /area/almayer/medical/lower_medical_medbay)
 "jXk" = (
@@ -59866,7 +59873,9 @@
 	dir = 1;
 	name = "\improper Combat Correspondent Room"
 	},
-/turf/open/floor/almayer,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
 /area/almayer/command/combat_correspondent)
 "qgN" = (
 /obj/structure/bed/chair{
@@ -63511,7 +63520,7 @@
 "rtj" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "test_floor4"
 	},
 /area/almayer/squads/req)
 "rtA" = (
@@ -66664,7 +66673,7 @@
 	name = "\improper Officer's Bunk"
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "test_floor4"
 	},
 /area/almayer/living/bridgebunks)
 "sxE" = (
@@ -73405,7 +73414,7 @@
 	name = "Medical Storage"
 	},
 /turf/open/floor/almayer{
-	icon_state = "sterile_green"
+	icon_state = "test_floor4"
 	},
 /area/almayer/medical/lower_medical_medbay)
 "vaV" = (
@@ -78061,7 +78070,7 @@
 	req_one_access = null
 	},
 /turf/open/floor/almayer{
-	icon_state = "sterile_green"
+	icon_state = "test_floor4"
 	},
 /area/almayer/medical/lower_medical_medbay)
 "wAR" = (
@@ -82051,7 +82060,7 @@
 	req_one_access_txt = "19;21"
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "test_floor4"
 	},
 /area/almayer/squads/req)
 "xWp" = (
@@ -111700,7 +111709,7 @@ bJw
 rlZ
 hBc
 hzs
-hzs
+bHg
 hzs
 aZK
 rlZ


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: added warning stripe bellow doors that didn't have them.
maptweak: Removed a bed sheet in medical to restore the lore of the unknown alpha that stole it.
maptweak: Reconnect the CIC armory to one of the brig door armory allowing them to open it at a distance.
/:cl:
