### PR TITLE
Changes Soro Political Prisoners to State Contractors (Or any other ideas someone might have.)

### DIFF
--- a/code/modules/gear_presets/survivors/sorokyne_strata/preset_sorokyne_strata.dm
+++ b/code/modules/gear_presets/survivors/sorokyne_strata/preset_sorokyne_strata.dm
@@ -1,6 +1,6 @@
 /datum/equipment_preset/survivor/engineer/soro
-	name = "Survivor - Sorokyne Strata Political Prisoner"
-	assignment = "Sorokyne Strata Political Prisoner"
+	name = "Survivor - Sorokyne Strata State Contractor"
+	assignment = "Sorokyne Strata State Contractor"
 
 /datum/equipment_preset/survivor/engineer/soro/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/veteran/UPP(new_human), WEAR_BODY)


### PR DESCRIPTION

# About the pull request

Changes the Soro Engineer surv name from Political Prisoner to State (meaning UPP) Contractor

# Explain why it's good for the game

Political Prisoners on Soro never really made sense to me personally, which is reinforced by the fact that Political Prisoners act like UPP, even though, they should be the exact opposite. 

Awhile back I asked on the lore channel what would be a good replacement and a name came up saying State Contractors, which is a good name considering they are the engineering survivors of Soro, plus removes the whole making everyone think this is a UPP prison colony, even though the lore of Soro's a bit more rich than that.


# Changelog
:cl:
add: Replaced the Political Survivor surv name with State Contractor
/:cl:
