### PR TITLE
doubles size of flarepouch

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -1107,8 +1107,8 @@
 	name = "flare pouch"
 	desc = "A pouch designed to hold flares. Refillable with an M94 flare pack."
 	max_w_class = SIZE_SMALL
-	storage_slots = 8
-	max_storage_space = 8
+	storage_slots = 16
+	max_storage_space = 16
 	storage_flags = STORAGE_FLAGS_POUCH|STORAGE_USING_DRAWING_METHOD
 	icon_state = "flare"
 	can_hold = list(/obj/item/device/flashlight/flare,/obj/item/device/flashlight/flare/signal)


### PR DESCRIPTION

# About the pull request

soubles the internal size of flarepouch to 16 from 8

# Explain why it's good for the game

compared to other pouches flarepouch in comparison to other intem storing pouches is lacking, at current moment it can store one flarebox worth of flares, flarebox is mag sized (4), meanwhile mag pouch is able to hold 3 magazines. Even medium general pouch (size 5) does have more storage then flarepouch technicly. This makes flarepouch more viable and more used. there should not be worry about this allowing flarespam or stuff like that, when you want to do that current moment you take backpack filled with flare boxes not flarepouch anyway. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog


:cl:
balance: increases flare pouch storage slots from 8 to 16 
/:cl:
