### PR TITLE
Adds a "Healed amount" to warden and makes the ability organization less messy

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_powers.dm
@@ -868,8 +868,9 @@
 		targetXeno.visible_message(SPAN_BOLDNOTICE("[X] places its claws on [targetXeno], and its wounds are quickly sealed!")) //marines probably should know if a xeno gets healed
 		X.gain_health(heal_amount*0.5 + bonus_heal*0.5)
 		X.flick_heal_overlay(3 SECONDS, "#00B800")
-		var/datum/behavior_delegate/praetorian_warden/warden_delegate = X.behavior_delegate
-		warden_delegate.modify_transferred(heal_amount)
+		if(X.mutation_type == PRAETORIAN_WARDEN)
+			var/datum/behavior_delegate/praetorian_warden/warden_delegate = X.behavior_delegate
+			warden_delegate.transferred_healing += heal_amount
 		use_plasma = TRUE //it's already hard enough to gauge health without hp showing on the mob
 		targetXeno.flick_heal_overlay(3 SECONDS, "#00B800")//so the visible_message and recovery overlay will warn marines and possibly predators that the xenomorph has been healed!
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_powers.dm
@@ -868,6 +868,8 @@
 		targetXeno.visible_message(SPAN_BOLDNOTICE("[X] places its claws on [targetXeno], and its wounds are quickly sealed!")) //marines probably should know if a xeno gets healed
 		X.gain_health(heal_amount*0.5 + bonus_heal*0.5)
 		X.flick_heal_overlay(3 SECONDS, "#00B800")
+		var/datum/behavior_delegate/praetorian_warden/warden_delegate = X.behavior_delegate
+		warden_delegate.modify_transferred(heal_amount)
 		use_plasma = TRUE //it's already hard enough to gauge health without hp showing on the mob
 		targetXeno.flick_heal_overlay(3 SECONDS, "#00B800")//so the visible_message and recovery overlay will warn marines and possibly predators that the xenomorph has been healed!
 

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/praetorian/warden.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/praetorian/warden.dm
@@ -49,12 +49,18 @@
 	var/internal_hitpoints_per_attack = 50
 	var/internal_hp_per_life = 5
 
+
 	// State
 	var/internal_hitpoints = 0
+	var/transferred_healing = 0
+
+/datum/behavior_delegate/praetorian_warden/proc/modify_transferred(heal_amount)
+	transferred_healing += heal_amount
 
 /datum/behavior_delegate/praetorian_warden/append_to_stat()
 	. = list()
 	. += "Energy Reserves: [internal_hitpoints]/[internal_hitpoints_max]"
+	. += "Transferred health amount: [transferred_healing]"
 
 /datum/behavior_delegate/praetorian_warden/on_life()
 	internal_hitpoints = min(internal_hitpoints_max, internal_hitpoints + internal_hp_per_life)

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/praetorian/warden.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/praetorian/warden.dm
@@ -58,8 +58,6 @@
 	var/internal_hitpoints = 0
 	var/transferred_healing = 0
 
-/datum/behavior_delegate/praetorian_warden/proc/modify_transferred(heal_amount)
-	transferred_healing += heal_amount
 
 /datum/behavior_delegate/praetorian_warden/append_to_stat()
 	. = list()

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/praetorian/warden.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/praetorian/warden.dm
@@ -7,16 +7,20 @@
 	individual_only = TRUE
 	caste_whitelist = list(XENO_CASTE_PRAETORIAN) // Only bae
 	mutator_actions_to_remove = list(
+		/datum/action/xeno_action/activable/xeno_spit,
 		/datum/action/xeno_action/activable/pounce/base_prae_dash,
 		/datum/action/xeno_action/activable/prae_acid_ball,
 		/datum/action/xeno_action/activable/spray_acid/base_prae_spray_acid,
+		/datum/action/xeno_action/onclick/tacmap,
 	)
 	mutator_actions_to_add = list(
+		/datum/action/xeno_action/onclick/emit_pheromones,
+		/datum/action/xeno_action/activable/xeno_spit,
 		/datum/action/xeno_action/activable/spray_acid/prae_warden,
 		/datum/action/xeno_action/activable/warden_heal,
 		/datum/action/xeno_action/activable/prae_retrieve,
 		/datum/action/xeno_action/onclick/prae_switch_heal_type,
-		/datum/action/xeno_action/onclick/emit_pheromones,
+		/datum/action/xeno_action/onclick/tacmap,
 	)
 	behavior_delegate_type = /datum/behavior_delegate/praetorian_warden
 	keystone = TRUE
@@ -60,7 +64,7 @@
 /datum/behavior_delegate/praetorian_warden/append_to_stat()
 	. = list()
 	. += "Energy Reserves: [internal_hitpoints]/[internal_hitpoints_max]"
-	. += "Transferred health amount: [transferred_healing]"
+	. += "Healing Done: [transferred_healing]"
 
 /datum/behavior_delegate/praetorian_warden/on_life()
 	internal_hitpoints = min(internal_hitpoints_max, internal_hitpoints + internal_hp_per_life)


### PR DESCRIPTION
# About the pull request

Adds a way to see how much you've healed as warden
# Explain why it's good for the game
Just a fun addition that i felt might be nice being able to see how much you've healed. Might be added to the fun facts later down the line
# Testing Photographs and Procedure
![image](https://github.com/cmss13-devs/cmss13/assets/47158596/7edb69fb-a30f-4f5c-ba96-a1bed609d732)


# Changelog


:cl:
add: Warden Praetorians can now see how much healing they've done.
qol: Re-organizes the warden ''hotbar''
/:cl:
