### PR TITLE
Moves a table, adds a photocopier to brig.

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -14979,6 +14979,22 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/computerlab)
+"btn" = (
+/obj/item/device/camera{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/structure/surface/table/almayer,
+/obj/item/device/camera_film{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/device/camera_film,
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/main_office)
 "btp" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 4
@@ -78195,16 +78211,7 @@
 	},
 /area/almayer/hallways/upper/starboard)
 "wDp" = (
-/obj/structure/surface/table/almayer,
-/obj/item/device/camera{
-	pixel_x = 4;
-	pixel_y = 8
-	},
-/obj/item/device/camera_film{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/obj/item/device/camera_film,
+/obj/structure/machinery/photocopier,
 /turf/open/floor/almayer{
 	dir = 10;
 	icon_state = "red"
@@ -92325,7 +92332,7 @@ vBm
 lOI
 pJv
 jLM
-tak
+btn
 cMb
 rbi
 wDp


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. --> Adds a Photocopier to the Brig. Moves a table and it's contents out the way a little. Specifically the camera and it's films two tiles north of where they previously were.

# Explain why it's good for the game
Allows MPs to photocopy photos and papers without barging into CIC or going elsewhere. A small QOL tweak.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![EveryoneLovesPaperwork](https://github.com/cmss13-devs/cmss13/assets/7815982/b9044efb-c3aa-409c-a0af-deca1a36db1c)

![EveryoneLovesPaperwork2](https://github.com/cmss13-devs/cmss13/assets/7815982/a18989b2-b702-43a5-a0f0-448d69f04ea8)


Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: Add Brig Photocopier
/:cl:
