### PR TITLE
Tweak flare incend fire stacks/damage

### DIFF
--- a/code/datums/ammo/misc.dm
+++ b/code/datums/ammo/misc.dm
@@ -113,7 +113,7 @@
 /datum/ammo/flare/set_bullet_traits()
 	. = ..()
 	LAZYADD(traits_to_give, list(
-		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_incendiary)
+		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_incendiary, stacks = 2.5)
 	))
 
 /datum/ammo/flare/on_hit_mob(mob/M,obj/projectile/P)
@@ -156,11 +156,13 @@
 	name = "starshell ash"
 	icon_state = "starshell_bullet"
 	max_range = 5
+	damage = 2.5
 	flare_type = /obj/item/device/flashlight/flare/on/starshell_ash
 
 /datum/ammo/flare/starshell/set_bullet_traits()
 	LAZYADD(traits_to_give, list(
-		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_iff, /datum/element/bullet_trait_incendiary)
+		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_iff),
+		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_incendiary, stacks = 1)
 	))
 
 /datum/ammo/souto


### PR DESCRIPTION
# About the pull request

This PR tunes down the amount of fire stacks a flare gun can inflict. It also fixes burning stars not properly setting their incend trait, but because they have never had that trait working I had to reduce the damage because of the multiple shells compounding the firestacks too quickly. This should really only be aesthetic than anything.

# Explain why it's good for the game

A single shot from the flare gun can currently bring a crusher to this much health if they don't resist: 
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/0e6b75a7-2638-466e-8379-334ede8cdabe)

Its fairly easy to prevent them resisting if you chase them. The xeno's only solution is to either find a friend to pat or more likely to just go on the offensive. If its still a problem this can be tuned down more, but for now I have ensured that it should kill a lesser drone or facehugger with a shot, but not outright kill anything else (assuming off weeds, no pheros, full health).

See below for results from a single shot after all fire stacks wear off.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Health after a single flare gun (lesser died):

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/f53d36e9-e6bc-4fa2-b145-49cd00b56302)

Health after a direct hit with a star airburst:

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/4f2ab26d-a246-42c6-bb0e-62b661ee072e)

</details>


# Changelog
:cl: Drathek
balance: Reduced how many fire stacks a flaregun shot provides
balance: Reduced starshell's damage, but fixed the application of the incend bullet trait.
/:cl:
