### PR TITLE
Hazard Joe Emote Backend

### DIFF
--- a/code/__DEFINES/human.dm
+++ b/code/__DEFINES/human.dm
@@ -187,6 +187,7 @@
 #define SYNTH_COMBAT "Combat Synthetic"
 #define SYNTH_INFILTRATOR "Infiltrator Synthetic"
 #define SYNTH_WORKING_JOE "Working Joe"
+#define SYNTH_HAZARD_JOE "Hazard Joe"
 #define SYNTH_GEN_ONE "First Generation Synthetic"
 #define SYNTH_GEN_TWO "Second Generation Synthetic"
 #define SYNTH_GEN_THREE "Third Generation Synthetic"

--- a/code/modules/gear_presets/synths.dm
+++ b/code/modules/gear_presets/synths.dm
@@ -492,13 +492,32 @@
 	rank = JOB_WORKING_JOE
 	skills = /datum/skills/working_joe
 	languages = list(LANGUAGE_ENGLISH, LANGUAGE_APOLLO, LANGUAGE_RUSSIAN, LANGUAGE_JAPANESE, LANGUAGE_GERMAN, LANGUAGE_SPANISH, LANGUAGE_CHINESE)
+	var/species_type = SYNTH_WORKING_JOE
 
 /datum/equipment_preset/synth/working_joe/New()
 	. = ..()
 	access = get_access(ACCESS_LIST_GLOBAL)
 
 /datum/equipment_preset/synth/working_joe/load_race(mob/living/carbon/human/new_human)
-	new_human.set_species(SYNTH_WORKING_JOE)
+	. = ..()
+	new_human.set_species(species_type)
+	new_human.h_style = "Bald"
+	new_human.f_style = "Shaved"
+	if(prob(5))
+		new_human.grad_style = "None" //No gradients for Working Joes
+		new_human.h_style = "Shoulder-length Hair" //Added the chance of hair as per Monkeyfist lore accuracy
+	new_human.r_eyes = 0
+	new_human.g_eyes = 0
+	new_human.b_eyes = 0
+	new_human.r_hair = 100
+	new_human.g_hair = 88
+	new_human.b_hair = 74
+	new_human.r_facial = 255
+	new_human.g_facial = 255
+	new_human.b_facial = 255
+
+/datum/equipment_preset/synth/working_joe/load_name(mob/living/carbon/human/new_human, randomise)
+	new_human.change_real_name(new_human, "Working Joe #[rand(100)][rand(100)]")
 
 /datum/equipment_preset/synth/working_joe/load_vanity(mob/living/carbon/human/new_human)
 	return
@@ -531,6 +550,7 @@
 
 /datum/equipment_preset/synth/working_joe/engi
 	name = "Synthetic - Hazmat Joe"
+	species_type = SYNTH_HAZARD_JOE
 
 /datum/equipment_preset/synth/working_joe/engi/load_gear(mob/living/carbon/human/new_human)
 	var/choice = rand(1,2)
@@ -559,25 +579,10 @@
 	new_human.equip_to_slot_or_del(new /obj/item/stack/sheet/metal/large_stack(new_human.back), WEAR_IN_R_STORE)
 	new_human.equip_to_slot_or_del(new /obj/item/stack/sheet/glass/reinforced/large_stack(new_human.back), WEAR_IN_R_STORE)
 
-/datum/equipment_preset/synth/working_joe/load_race(mob/living/carbon/human/new_human)
-	. = ..()
-	new_human.h_style = "Bald"
-	new_human.f_style = "Shaved"
-	if(prob(5))
-		new_human.grad_style = "None" //No gradients for Working Joes
-		new_human.h_style = "Shoulder-length Hair" //Added the chance of hair as per Monkeyfist lore accuracy
-	new_human.r_eyes = 0
-	new_human.g_eyes = 0
-	new_human.b_eyes = 0
-	new_human.r_hair = 100
-	new_human.g_hair = 88
-	new_human.b_hair = 74
-	new_human.r_facial = 255
-	new_human.g_facial = 255
-	new_human.b_facial = 255
 
-/datum/equipment_preset/synth/working_joe/load_name(mob/living/carbon/human/new_human, randomise)
-	new_human.change_real_name(new_human, "Working Joe #[rand(100)][rand(100)]")
+
+/datum/equipment_preset/synth/working_joe/load_race(mob/living/carbon/human/new_human)
+	new_human.set_species(SYNTH_WORKING_JOE)
 
 //*****************************************************************************************************/
 

--- a/code/modules/gear_presets/synths.dm
+++ b/code/modules/gear_presets/synths.dm
@@ -579,11 +579,6 @@
 	new_human.equip_to_slot_or_del(new /obj/item/stack/sheet/metal/large_stack(new_human.back), WEAR_IN_R_STORE)
 	new_human.equip_to_slot_or_del(new /obj/item/stack/sheet/glass/reinforced/large_stack(new_human.back), WEAR_IN_R_STORE)
 
-
-
-/datum/equipment_preset/synth/working_joe/load_race(mob/living/carbon/human/new_human)
-	new_human.set_species(SYNTH_WORKING_JOE)
-
 //*****************************************************************************************************/
 
 /datum/equipment_preset/synth/survivor/cultist_synth

--- a/code/modules/mob/living/carbon/human/species/working_joe/_emote.dm
+++ b/code/modules/mob/living/carbon/human/species/working_joe/_emote.dm
@@ -6,3 +6,5 @@
 	var/category = ""
 	/// Override text for the emote to be displayed in the WJ emote panel
 	var/override_say = ""
+	/// Is used by Hazard Joes.
+	var/hazard = FALSE

--- a/code/modules/mob/living/carbon/human/species/working_joe/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/working_joe/_species.dm
@@ -10,6 +10,7 @@
 	hair_color = "#000000"
 	icobase = 'icons/mob/humans/species/r_synthetic.dmi'
 	deform = 'icons/mob/humans/species/r_synthetic.dmi'
+	var/emote_panel_type = /datum/joe_emote_panel
 
 /datum/species/synthetic/colonial/working_joe/handle_post_spawn(mob/living/carbon/human/joe)
 	. = ..()
@@ -21,9 +22,14 @@
 		playsound(dying_joe.loc, pick_weight(list('sound/voice/joe/death_normal.ogg' = 75, 'sound/voice/joe/death_silence.ogg' = 10, 'sound/voice/joe/death_tomorrow.ogg' = 10,'sound/voice/joe/death_dream.ogg' = 5)), 25, FALSE)
 	return ..()
 
+/datum/species/synthetic/colonial/working_joe/hazard
+	name = SYNTH_HAZARD_JOE
+	name_plural = "Hazard Joes"
+	emote_panel_type = /datum/joe_emote_panel/hazard
+
 /// Open the WJ's emote panel, which allows them to use voicelines
 /datum/species/synthetic/colonial/working_joe/open_emote_panel()
-	var/datum/joe_emote_panel/ui = new(usr)
+	var/datum/joe_emote_panel/ui = new emote_panel_type(usr)
 	ui.ui_interact(usr)
 
 
@@ -66,6 +72,21 @@
 		var/list/emotes_to_add = list()
 		for(var/datum/emote/living/carbon/human/synthetic/working_joe/emote as anything in subtypesof(/datum/emote/living/carbon/human/synthetic/working_joe))
 			if(!initial(emote.key) || !initial(emote.say_message))
+				continue
+
+			if(!(initial(emote.category) in wj_categories))
+				wj_categories += initial(emote.category)
+
+			emotes_to_add += emote
+
+
+		wj_emotes = emotes_to_add
+
+/datum/joe_emote_panel/hazard/New()
+	if(!length(wj_emotes))
+		var/list/emotes_to_add = list()
+		for(var/datum/emote/living/carbon/human/synthetic/working_joe/emote as anything in subtypesof(/datum/emote/living/carbon/human/synthetic/working_joe))
+			if(!initial(emote.hazard) || !initial(emote.key) || !initial(emote.say_message))
 				continue
 
 			if(!(initial(emote.category) in wj_categories))

--- a/code/modules/mob/living/carbon/human/species/working_joe/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/working_joe/_species.dm
@@ -71,7 +71,7 @@
 	if(!length(wj_emotes))
 		var/list/emotes_to_add = list()
 		for(var/datum/emote/living/carbon/human/synthetic/working_joe/emote as anything in subtypesof(/datum/emote/living/carbon/human/synthetic/working_joe))
-			if(!initial(emote.key) || !initial(emote.say_message))
+			if(initial(emote.hazard) || !initial(emote.key) || !initial(emote.say_message))
 				continue
 
 			if(!(initial(emote.category) in wj_categories))


### PR DESCRIPTION

# About the pull request
The backend element for Working Joe emote separation so Hazard Joes can use different voice lines.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
code: Added the backend element separation for Working Joe emotes.
/:cl:
