### PR TITLE
Bump alternative tests to 515.1630

### DIFF
--- a/.github/alternate_byond_versions.txt
+++ b/.github/alternate_byond_versions.txt
@@ -6,4 +6,4 @@
 # Example:
 # 500.1337: runtimestation
 
-515.1610: lv624
+515.1630: lv624

--- a/code/controllers/mc/globals.dm
+++ b/code/controllers/mc/globals.dm
@@ -13,7 +13,11 @@ GLOBAL_REAL(GLOB, /datum/controller/global_vars)
 	GLOB = src
 
 	var/datum/controller/exclude_these = new
-	gvars_datum_in_built_vars = exclude_these.vars + list(NAMEOF(src, gvars_datum_protected_varlist), NAMEOF(src, gvars_datum_in_built_vars), NAMEOF(src, gvars_datum_init_order))
+	// I know this is dumb but the nested vars list hangs a ref to the datum. This fixes that
+	var/list/controller_vars = exclude_these.vars.Copy()
+	controller_vars["vars"] = null
+	gvars_datum_in_built_vars = controller_vars + list(NAMEOF(src, gvars_datum_protected_varlist), NAMEOF(src, gvars_datum_in_built_vars), NAMEOF(src, gvars_datum_init_order))
+
 	QDEL_IN(exclude_these, 0) //signal logging isn't ready
 
 	log_world("[vars.len - gvars_datum_in_built_vars.len] global variables")

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -266,6 +266,8 @@
 
 /obj/effect/mine_tripwire/Destroy()
 	if(linked_claymore)
+		if(linked_claymore.tripwire == src)
+			linked_claymore.tripwire = null
 		linked_claymore = null
 	. = ..()
 


### PR DESCRIPTION
# About the pull request

This PR bumps the 515 alternative test to 515.1630 in github checks now that we have updated the server to that version. It also caused a couple more hard deletes; one of which (for globals) is sort of a byond issue but TG had a workaround for it.

# Explain why it's good for the game

Tests should replicate what is used for live.

# Testing Photographs and Procedure

See Checks.

# Changelog

No player facing changes.
