### PR TITLE
Fix for Ceiling().

### DIFF
--- a/code/__HELPERS/#maths.dm
+++ b/code/__HELPERS/#maths.dm
@@ -8,7 +8,7 @@ GLOBAL_LIST_INIT(sqrtTable, list(1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 4,
 
 // MATH DEFINES
 
-#define Ceiling(x) (-round(-x))
+#define Ceiling(x) (-round(-(x)))
 #define CLAMP01(x) (clamp(x, 0, 1))
 
 // cotangent


### PR DESCRIPTION
# About the pull request

Somebody mentioned seeing incorrect numbers for "you need to play X more xeno hours to unlock prefix/postfix". Turns out, `time_left_until()` is defined as `Ceiling(target_time - current time)`, which translates to `-round( - target_time - current time)`, or in other words, `round(target_time + current_time)`.
In general, any byond macro involving doing math on the argument should probably have that argument bracketed every time it appears to avoid precisely this nonsense.

# Explain why it's good for the game

Is fix.


# Changelog
:cl:
fix: Some cases of calculations for "time remaining until something" no longer display incorrect results.
/:cl:
