### PR TITLE
Mouth and Eyes Surgical Incisions Show on Scanner & Open Surgical Incisions Alone Show Up On Scanner - A Fix To Issue #5639

### DIFF
--- a/code/modules/mob/living/living_healthscan.dm
+++ b/code/modules/mob/living/living_healthscan.dm
@@ -178,7 +178,7 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 				bleeding_check = TRUE
 				break
 
-			if((!limb.brute_dam && !limb.burn_dam && !(limb.status & LIMB_DESTROYED)) && !bleeding_check && !internal_bleeding_check && !(implant && detail_level >= DETAIL_LEVEL_BODYSCAN ) && !(limb.status & LIMB_UNCALIBRATED_PROSTHETIC) && !(limb.status & LIMB_BROKEN) && !(limb.status & LIMB_SPLINTED) && !(limb.status & LIMB_SPLINTED_INDESTRUCTIBLE))
+			if((!limb.brute_dam && !limb.burn_dam && !(limb.status & LIMB_DESTROYED)) && !bleeding_check && !internal_bleeding_check && !(implant && detail_level >= DETAIL_LEVEL_BODYSCAN ) && !(limb.status & LIMB_UNCALIBRATED_PROSTHETIC) && !(limb.status & LIMB_BROKEN) && !(limb.status & LIMB_SPLINTED) && !(limb.status & LIMB_SPLINTED_INDESTRUCTIBLE) && !(limb.get_incision_depth()))
 				continue
 			var/list/core_body_parts = list("head", "chest", "groin")
 			var/list/current_list = list(

--- a/code/modules/mob/living/living_healthscan.dm
+++ b/code/modules/mob/living/living_healthscan.dm
@@ -190,7 +190,6 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 				"missing" = (limb.status & LIMB_DESTROYED),
 				"limb_status" = null,
 				"bleeding" = bleeding_check,
-				"open_incision" = limb.get_incision_depth(),
 				"implant" = implant,
 				"internal_bleeding" = internal_bleeding_check
 			)
@@ -247,6 +246,24 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 				limb_type = "Synthskin"
 			if(limb_type)
 				current_list["limb_type"] = limb_type
+
+			//checking for open incisions, but since eyes and mouths incisions are "head incisions" but not "head surgeries" gotta do some snowflake
+			if(limb.name == "head")
+				if(human_target_mob.active_surgeries["head"])
+					current_list["open_incision"] = TRUE
+
+				var/zone
+				if(human_target_mob.active_surgeries["eyes"])
+					zone = "eyes"
+				if(human_target_mob.active_surgeries["mouth"])
+					if(zone)
+						zone = "eyes and mouth"
+					else
+						zone = "mouth"
+				current_list["open_zone_incision"] = capitalize(zone)
+
+			else
+				current_list["open_incision"] = limb.get_incision_depth()
 
 			limb_data_lists["[limb.name]"] = current_list
 

--- a/tgui/packages/tgui/interfaces/HealthScan.jsx
+++ b/tgui/packages/tgui/interfaces/HealthScan.jsx
@@ -389,6 +389,11 @@ const ScannerLimbs = (props) => {
                       [Embedded Object]
                     </Box>
                   ) : null}
+                  {limb.open_zone_incision ? (
+                    <Box inline color={'red'} bold={1}>
+                      [Open Surgical Incision In {limb.open_zone_incision}]
+                    </Box>
+                  ) : null}
                 </Flex.Item>
               </>
             )}


### PR DESCRIPTION
# About the pull request

Fixes #5639 

This is done by adding open surgical incisions as a way to have a limb show up on scanners

Also, the "mouth" and "eyes" zones of the head now have their own snowflake way to be picked up on scanners.

# Explain why it's good for the game

Incisions probably should be detectable by scanners

# Testing Photographs and Procedure

<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/69102610/a3d105ae-2de3-4e5b-9f0d-fcb93e5f5680)
![image](https://github.com/cmss13-devs/cmss13/assets/69102610/c98585de-3d8f-4628-9e24-6ffb45173c4f)


# Changelog

:cl:
fix: Open surgical incisions now show up on a health scanner even if there is nothing else wrong.
fix: Open surgical incisions in the head "zones" (mouth and eyes) now show up independently on health scanner
/:cl:
