### PR TITLE
Fixes Defenders staying Fortified while being in critical state

### DIFF
--- a/code/__DEFINES/dcs/signals/atom/mob/living/signals_xeno.dm
+++ b/code/__DEFINES/dcs/signals/atom/mob/living/signals_xeno.dm
@@ -73,4 +73,4 @@
 #define COMSIG_XENO_TAKE_HUGGER_FROM_MORPHER "xeno_take_hugger_from_morpher"
 
 /// From /mob/living/carbon/xenomorph/proc/handle_crit()
-#define COMSIG_XENO_GET_INTO_CRIT "xeno_getting_into_critical"
+#define COMSIG_ENTER_CRIT "xeno_entering_critical"

--- a/code/__DEFINES/dcs/signals/atom/mob/living/signals_xeno.dm
+++ b/code/__DEFINES/dcs/signals/atom/mob/living/signals_xeno.dm
@@ -71,3 +71,6 @@
 
 /// From /obj/effect/alien/resin/special/eggmorph/attack_alien: (mob/living/carbon/xenomorph/M)
 #define COMSIG_XENO_TAKE_HUGGER_FROM_MORPHER "xeno_take_hugger_from_morpher"
+
+/// From /mob/living/carbon/xenomorph/proc/handle_crit()
+#define COMSIG_XENO_GET_INTO_CRIT "xeno_getting_into_critical"

--- a/code/__DEFINES/dcs/signals/atom/mob/living/signals_xeno.dm
+++ b/code/__DEFINES/dcs/signals/atom/mob/living/signals_xeno.dm
@@ -73,4 +73,4 @@
 #define COMSIG_XENO_TAKE_HUGGER_FROM_MORPHER "xeno_take_hugger_from_morpher"
 
 /// From /mob/living/carbon/xenomorph/proc/handle_crit()
-#define COMSIG_ENTER_CRIT "xeno_entering_critical"
+#define COMSIG_XENO_ENTER_CRIT "xeno_entering_critical"

--- a/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_powers.dm
@@ -174,13 +174,13 @@
 	playsound(get_turf(xeno), 'sound/effects/stonedoor_openclose.ogg', 30, 1)
 
 	if(!xeno.fortify)
-		RegisterSignal(owner, COMSIG_ENTER_CRIT, PROC_REF(unconscious_check))
+		RegisterSignal(owner, COMSIG_XENO_ENTER_CRIT, PROC_REF(unconscious_check))
 		RegisterSignal(owner, COMSIG_MOB_DEATH, PROC_REF(unconscious_check))
 		fortify_switch(xeno, TRUE)
 		if(xeno.selected_ability != src)
 			button.icon_state = "template_active"
 	else
-		UnregisterSignal(owner, COMSIG_ENTER_CRIT)
+		UnregisterSignal(owner, COMSIG_XENO_ENTER_CRIT)
 		UnregisterSignal(owner, COMSIG_MOB_DEATH)
 		fortify_switch(xeno, FALSE)
 		if(xeno.selected_ability != src)
@@ -257,7 +257,7 @@
 	if(QDELETED(owner))
 		return
 
-	UnregisterSignal(owner, COMSIG_ENTER_CRIT)
+	UnregisterSignal(owner, COMSIG_XENO_ENTER_CRIT)
 	UnregisterSignal(owner, COMSIG_MOB_DEATH)
 	fortify_switch(owner, FALSE)
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_powers.dm
@@ -174,12 +174,14 @@
 	playsound(get_turf(xeno), 'sound/effects/stonedoor_openclose.ogg', 30, 1)
 
 	if(!xeno.fortify)
-		RegisterSignal(owner, COMSIG_XENO_GET_INTO_CRIT, PROC_REF(crit_check))
+		RegisterSignal(owner, COMSIG_XENO_GET_INTO_CRIT, PROC_REF(unconscious_check))
+		RegisterSignal(owner, COMSIG_MOB_DEATH, PROC_REF(unconscious_check))
 		fortify_switch(xeno, TRUE)
 		if(xeno.selected_ability != src)
 			button.icon_state = "template_active"
 	else
 		UnregisterSignal(owner, COMSIG_XENO_GET_INTO_CRIT)
+		UnregisterSignal(owner, COMSIG_MOB_DEATH)
 		fortify_switch(xeno, FALSE)
 		if(xeno.selected_ability != src)
 			button.icon_state = "template"
@@ -249,10 +251,14 @@
 		else
 			damagedata["armor"] += frontal_armor
 
-/datum/action/xeno_action/activable/fortify/proc/crit_check()
+/datum/action/xeno_action/activable/fortify/proc/unconscious_check()
 	SIGNAL_HANDLER
 
+	if(QDELETED(owner))
+		return
+
 	UnregisterSignal(owner, COMSIG_XENO_GET_INTO_CRIT)
+	UnregisterSignal(owner, COMSIG_MOB_DEATH)
 	fortify_switch(owner, FALSE)
 
 /datum/action/xeno_action/onclick/soak/use_ability(atom/A)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_powers.dm
@@ -174,13 +174,13 @@
 	playsound(get_turf(xeno), 'sound/effects/stonedoor_openclose.ogg', 30, 1)
 
 	if(!xeno.fortify)
-		RegisterSignal(owner, COMSIG_XENO_GET_INTO_CRIT, PROC_REF(unconscious_check))
+		RegisterSignal(owner, COMSIG_ENTER_CRIT, PROC_REF(unconscious_check))
 		RegisterSignal(owner, COMSIG_MOB_DEATH, PROC_REF(unconscious_check))
 		fortify_switch(xeno, TRUE)
 		if(xeno.selected_ability != src)
 			button.icon_state = "template_active"
 	else
-		UnregisterSignal(owner, COMSIG_XENO_GET_INTO_CRIT)
+		UnregisterSignal(owner, COMSIG_ENTER_CRIT)
 		UnregisterSignal(owner, COMSIG_MOB_DEATH)
 		fortify_switch(xeno, FALSE)
 		if(xeno.selected_ability != src)
@@ -257,7 +257,7 @@
 	if(QDELETED(owner))
 		return
 
-	UnregisterSignal(owner, COMSIG_XENO_GET_INTO_CRIT)
+	UnregisterSignal(owner, COMSIG_ENTER_CRIT)
 	UnregisterSignal(owner, COMSIG_MOB_DEATH)
 	fortify_switch(owner, FALSE)
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_powers.dm
@@ -174,12 +174,12 @@
 	playsound(get_turf(xeno), 'sound/effects/stonedoor_openclose.ogg', 30, 1)
 
 	if(!xeno.fortify)
-		RegisterSignal(owner, COMSIG_MOB_DEATH, PROC_REF(death_check))
+		RegisterSignal(owner, COMSIG_XENO_GET_INTO_CRIT, PROC_REF(crit_check))
 		fortify_switch(xeno, TRUE)
 		if(xeno.selected_ability != src)
 			button.icon_state = "template_active"
 	else
-		UnregisterSignal(owner, COMSIG_MOB_DEATH)
+		UnregisterSignal(owner, COMSIG_XENO_GET_INTO_CRIT)
 		fortify_switch(xeno, FALSE)
 		if(xeno.selected_ability != src)
 			button.icon_state = "template"
@@ -249,10 +249,10 @@
 		else
 			damagedata["armor"] += frontal_armor
 
-/datum/action/xeno_action/activable/fortify/proc/death_check()
+/datum/action/xeno_action/activable/fortify/proc/crit_check()
 	SIGNAL_HANDLER
 
-	UnregisterSignal(owner, COMSIG_MOB_DEATH)
+	UnregisterSignal(owner, COMSIG_XENO_GET_INTO_CRIT)
 	fortify_switch(owner, FALSE)
 
 /datum/action/xeno_action/onclick/soak/use_ability(atom/A)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -506,7 +506,7 @@ Make sure their actual health updates immediately.*/
 /mob/living/carbon/xenomorph/proc/handle_crit()
 	if(stat <= CONSCIOUS && !gibbing)
 		set_stat(UNCONSCIOUS)
-		SEND_SIGNAL(src, COMSIG_ENTER_CRIT)
+		SEND_SIGNAL(src, COMSIG_XENO_ENTER_CRIT)
 
 /mob/living/carbon/xenomorph/set_stat(new_stat)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -506,6 +506,7 @@ Make sure their actual health updates immediately.*/
 /mob/living/carbon/xenomorph/proc/handle_crit()
 	if(stat <= CONSCIOUS && !gibbing)
 		set_stat(UNCONSCIOUS)
+		SEND_SIGNAL(src, COMSIG_XENO_GET_INTO_CRIT)
 
 /mob/living/carbon/xenomorph/set_stat(new_stat)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -506,7 +506,7 @@ Make sure their actual health updates immediately.*/
 /mob/living/carbon/xenomorph/proc/handle_crit()
 	if(stat <= CONSCIOUS && !gibbing)
 		set_stat(UNCONSCIOUS)
-		SEND_SIGNAL(src, COMSIG_XENO_GET_INTO_CRIT)
+		SEND_SIGNAL(src, COMSIG_ENTER_CRIT)
 
 /mob/living/carbon/xenomorph/set_stat(new_stat)
 	. = ..()


### PR DESCRIPTION
# About the pull request

Defenders who use Fortify and then get into critical are not pullable, because Fortify is still technically active on them. Fortify only automatically toggles itself off upon death. This PR changes it so the Fortify ability gets turned off upon entering critical state, making other xenos/yautja/synths able to pull them while they are downed.

Fixes #5616 

It also adds xeno crit comsig for other possible uses. I _think_ my signal is only called once, when the xeno enters critical, but I may have misread the code.

# Explain why it's good for the game

Fortified defenders are anchored until they are healed (and then they manually turn it off) or until they die. This is probably unintended behaviour, they are not conscious anymore to be fortified.

# Testing Photographs and Procedure

Spawned a defender, fortified, dealt it 500+ damage, then tried to drag it. Video:

<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/49321394/335f4d39-970d-4e90-a47b-801a152d8c37

</details>


# Changelog

:cl:
fix: Fixes Defenders staying Fortified in critical state - Fortify now automatically toggles itself off upon the Defender getting critted.
/:cl:
