### PR TITLE
Re-adds the Mk1 to the SL vendor

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
@@ -12,6 +12,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_leader, list(
 		list("M56D Heavy Machine Gun", 0, /obj/item/storage/box/guncase/m56d, MARINE_CAN_BUY_KIT, VENDOR_ITEM_REGULAR),
 		list("M79 Grenade Launcher", 0, /obj/item/storage/box/guncase/m79, MARINE_CAN_BUY_KIT, VENDOR_ITEM_REGULAR),
 		list("MOU-53 Shotgun", 0, /obj/item/storage/box/guncase/mou53, MARINE_CAN_BUY_KIT, VENDOR_ITEM_REGULAR),
+		list("M41A Veteran Kit", 0, /obj/item/storage/box/guncase/m41aMK1, MARINE_CAN_BUY_KIT, VENDOR_ITEM_REGULAR),
 		list("XM88 Heavy Rifle", 0, /obj/item/storage/box/guncase/xm88, MARINE_CAN_BUY_KIT, VENDOR_ITEM_REGULAR),
 		list("Basic Engineering Supplies", 0, /obj/item/storage/box/kit/engineering_supply_kit, MARINE_CAN_BUY_KIT, VENDOR_ITEM_REGULAR),
 


### PR DESCRIPTION

# About the pull request

Re-adds the Mk1 to the SL vendor.

# Explain why it's good for the game

Back in the elden days it was removed because people would play SL just to get the Mk1. This isn't really a problem anymore because of the changed to roleplay (DO YOUR JOB!!!). You'll still have to go to req for extra mags though.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

i am not testing this

</details>


# Changelog
:cl:
add: Re-added the Mk1 to the SL vendor
/:cl:
