### PR TITLE
Adds Flank Route & Choke Point West of Eastern Lab Trijent Dam

### DIFF
--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -11227,9 +11227,6 @@
 /obj/structure/flora/grass/desert/heavygrass_3,
 /turf/open/desert/dirt,
 /area/desert_dam/interior/caves/central_caves)
-"aHO" = (
-/turf/open/desert/rock/deep,
-/area/desert_dam/exterior/valley/valley_wilderness)
 "aHP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/asphalt{
@@ -96349,7 +96346,7 @@ awC
 awC
 dTs
 dTs
-dTs
+aXv
 aPP
 aaC
 aXC
@@ -96582,8 +96579,8 @@ awd
 awd
 awd
 axl
-ahT
-aHO
+dTs
+dTs
 aPP
 aaB
 abZ
@@ -96817,7 +96814,7 @@ awf
 awD
 axl
 ahT
-aHO
+dTs
 aPP
 aXW
 aVZ

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -11228,9 +11228,7 @@
 /turf/open/desert/dirt,
 /area/desert_dam/interior/caves/central_caves)
 "aHO" = (
-/turf/open/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached16"
-	},
+/turf/open/desert/rock/deep,
 /area/desert_dam/exterior/valley/valley_wilderness)
 "aHP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -96351,7 +96349,7 @@ awC
 awC
 dTs
 dTs
-aHO
+dTs
 aPP
 aaC
 aXC
@@ -96584,8 +96582,8 @@ awd
 awd
 awd
 axl
-dTs
-dTs
+ahT
+aHO
 aPP
 aaB
 abZ
@@ -96597,7 +96595,7 @@ aVZ
 aHd
 dTs
 aOh
-dTs
+aWz
 dTs
 dTs
 dTs
@@ -96819,7 +96817,7 @@ awf
 awD
 axl
 ahT
-dTs
+aHO
 aPP
 aXW
 aVZ
@@ -98703,8 +98701,8 @@ dTs
 dTs
 dTs
 dTs
-aam
-ayp
+dTs
+dTs
 aeE
 aeE
 ayD
@@ -99875,7 +99873,7 @@ dTs
 dTs
 aam
 ayp
-aeE
+dTs
 aeE
 bgH
 dTs


### PR DESCRIPTION
# About the pull request

Adds another path for Xenos to attack marines when at eastern labs. 

# Explain why it's good for the game

Allows for more combat on Trijent. 
I think Trijent is boring, and once marines get into Eastern Lab, the xenos usually just die and just a few marines are fighting because there's not enough space for xenos to fight.


# Testing Photographs and Procedure
Small map edit. 

<details>
The changes I made and a picture circling what was changed. 

![image](https://github.com/cmss13-devs/cmss13/assets/142365554/90b03182-8f82-44ef-8974-bd3324693af6)

![image](https://github.com/cmss13-devs/cmss13/assets/142365554/09867473-4782-4b73-8865-36b1869599c4)

Areas are also setup. 
![image](https://github.com/cmss13-devs/cmss13/assets/142365554/e25dc3bc-819c-4170-aa01-7abb22a33aa6)


</details>


# Changelog

:cl:
maptweak: tweaked Trijent Dam to add a new choke point. 
/:cl:
