### PR TITLE
Revert damage changes in "MP QoL: part 1"

### DIFF
--- a/code/datums/ammo/energy.dm
+++ b/code/datums/ammo/energy.dm
@@ -28,8 +28,7 @@
 	icon_state = "stun"
 	damage_type = OXY
 	flags_ammo_behavior = AMMO_ENERGY|AMMO_IGNORE_RESIST|AMMO_ALWAYS_FF //Not that ignoring will do much right now.
-	damage = 15 //excessive use COULD be lethal
-	stamina_damage = 40
+	stamina_damage = 45
 	accuracy = HIT_ACCURACY_TIER_8
 	shell_speed = AMMO_SPEED_TIER_1 // Slightly faster
 	hit_effect_color = "#FFFF00"

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -4,10 +4,10 @@
 	icon_state = "stunbaton"
 	item_state = "baton"
 	flags_equip_slot = SLOT_WAIST
-	force = 20
+	force = 15
+	throwforce = 7
 	sharp = FALSE
 	edge = FALSE
-	throwforce = 10
 	w_class = SIZE_MEDIUM
 
 	attack_verb = list("beaten")


### PR DESCRIPTION
# About the pull request

This PR reverts the damage changes in #5554 

# Explain why it's good for the game

Batons don't need to be more deadly than they were. Tazers do not need to cause blood effects because of brute damage applied.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
balance: Reverted damage changes to tazers and batons.
/:cl:
