### PR TITLE
Removes the two gauss sentry guns someone accidently boxxed into ice 3 over a year ago that has somehow survived multiple bugfixes and a rework of the map

### DIFF
--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -9203,10 +9203,6 @@
 "dYp" = (
 /turf/closed/wall/shiva/ice,
 /area/shiva/interior/bar)
-"dYw" = (
-/obj/structure/machinery/defenses/sentry/premade,
-/turf/open/auto_turf/snow/layer0,
-/area/shiva/exterior/junkyard)
 "dZb" = (
 /obj/structure/closet/secure_closet/guncabinet,
 /obj/structure/machinery/firealarm{
@@ -45631,7 +45627,7 @@ kyD
 tHd
 pDr
 tHd
-dYw
+kyD
 kyD
 kyD
 kyD
@@ -45793,7 +45789,7 @@ tHd
 kyD
 pDr
 kyD
-dYw
+kyD
 kyD
 kyD
 kyD


### PR DESCRIPTION

# About the pull request

title

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

bug


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: SpartanBobby
maptweak: Fixes the two gauss sentry guns that were boxxed in by a mapper over a year ago on ice 3
/:cl:
