### PR TITLE
Revert "Helmet HUDs skip over HUDs that are already in effect on the …

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -669,39 +669,29 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 		return FALSE
 
 	if(active_visor)
-		var/visor_to_deactivate = active_visor
-		var/skipped_hud = FALSE
 		var/iterator = 1
-		for(var/obj/item/device/helmet_visor/current_visor as anything in total_visors)
-			if(current_visor == active_visor || skipped_hud)
+		for(var/hud_type in total_visors)
+			if(hud_type == active_visor)
 				if(length(total_visors) > iterator)
-					var/obj/item/device/helmet_visor/next_visor = total_visors[iterator + 1]
-
-					if(!isnull(GLOB.huds[next_visor.hud_type].hudusers[user]))
-						iterator++
-						skipped_hud = TRUE
-						continue
-
-					active_visor = next_visor
-					toggle_visor(user, visor_to_deactivate, silent = TRUE) // disables the old visor
+					active_visor = total_visors[(iterator + 1)]
+					toggle_visor(user, total_visors[iterator], TRUE)
 					toggle_visor(user)
 					return active_visor
 				else
 					active_visor = null
-					toggle_visor(user, visor_to_deactivate, FALSE)
+					toggle_visor(user, total_visors[iterator], FALSE)
 					return FALSE
 			iterator++
 
-	for(var/obj/item/device/helmet_visor/new_visor in total_visors)
-
-		if(!isnull(GLOB.huds[new_visor.hud_type].hudusers[user]))
-			continue
-
-		active_visor = new_visor
+	if(total_visors[1])
+		active_visor = total_visors[1]
 		toggle_visor(user)
 		return active_visor
 
+	active_visor = null
+	recalculate_visors(user)
 	return FALSE
+
 /datum/action/item_action/cycle_helmet_huds/New(Target, obj/item/holder)
 	. = ..()
 	name = "Cycle helmet HUD"


### PR DESCRIPTION
…player (#5600)"

This reverts commit 56c7062635192c4e4ba2243648dd7370e800a018.

#5600  has broken all helmet HUDs so this is going on TM until it can be fixed so marines who need huds can play.
`[22:38:04]RUNTIME: Cannot read null.hudusers - code/modules/clothing/head/helmet.dm@697 (500 total)`

--
Edit:

More detail this only affects the welding helmet visor not ALL visors.