### PR TITLE
Fixes trash carts not working with fultons

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -335,7 +335,7 @@
 	icon_closed = "closed_supply"
 
 /obj/structure/closet/crate/trashcart
-	name = "\improper trash cart"
+	name = "trash cart"
 	desc = "A heavy, metal trashcart with wheels."
 	icon_state = "closed_trashcart"
 	icon_opened = "open_trashcart"
@@ -437,4 +437,3 @@
 	density = TRUE
 	icon_opened = "open_mcart_y"
 	icon_closed = "closed_mcart_y"
-

--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -1144,9 +1144,11 @@
 
 	var/list/possible_fultons = get_targets()
 
-	var/obj/item/stack/fulton/fult = possible_fultons[fulton_choice]
 	if(!fulton_choice)
 		return
+	// Strip any \proper or \improper in order to match the entry in possible_fultons.
+	fulton_choice = strip_improper(fulton_choice)
+	var/obj/item/stack/fulton/fult = possible_fultons[fulton_choice]
 
 	if(!ship_base) //system was uninstalled midway
 		return


### PR DESCRIPTION

# About the pull request

Fixes #5621, which was caused by a runtime in `/obj/structure/dropship_equipment/fulton_system/proc/automate_interact()`.
The cart's entry in `possible_fultons` has a key of `"�\u{16}trash cart"`, but the `fulton_choice` passed from the UI is just `"trash cart"`. Because they don't match, `fult` is unable to be set, and an error is thrown on L1154.
https://github.com/cmss13-devs/cmss13/blob/2657502ad1c5de88fd0aef35072900a736be84fe/code/modules/cm_marines/dropship_equipment.dm#L1141-L1154

# Explain why it's good for the game

Bugfix!

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

**Before:**
Runtime error. *(I can't be bothered to go through the set up again just to record this)*

**After:**

https://github.com/cmss13-devs/cmss13/assets/57483089/9ee496a4-d201-43b2-95d2-963dcc7c8569

</details>


# Changelog
:cl:
fix: Fixed trash carts not being pick-uppable by the dropship's fulton recovery system.
/:cl:
