### PR TITLE
Buffs M4RA ('s Audio)

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -421,6 +421,28 @@
 /obj/item/weapon/gun/rifle/m41aMK1/anchorpoint/gl
 	desc = "A classic M41 MK1 Pulse Rifle painted in a fresh coat of the classic Humbrol 170 camoflauge. This one appears to be used by the Colonial Marine contingent aboard Anchorpoint Station, and is equipped with an underbarrel grenade launcher. Uses 10x24mm caseless ammunition."
 	starting_attachment_types = list(/obj/item/attachable/stock/rifle/collapsible, /obj/item/attachable/attached_gun/grenade/mk1)
+
+//Civ Gun
+
+/obj/item/weapon/gun/rifle/m4ar
+	name = "\improper M4-AR Pulse Rifle"
+	desc = "A civilian issued variant of the M41A MK1. Popular amongst faraway colonists. Uses 10x24 caseless ammunition."
+	icon = 'icons/obj/items/weapons/guns/guns_by_faction/uscm.dmi'
+	icon_state = "m4ar" //Placeholder.
+	item_state = "m4ar" //Placeholder.
+	fire_sound = "gun_pulse"
+	reload_sound = 'sound/weapons/handling/m41_reload.ogg'
+	unload_sound = 'sound/weapons/handling/m41_unload.ogg'
+	current_mag = /obj/item/ammo_magazine/rifle/m4ar
+	attachable_allowed = list(
+		/obj/item/attachable/bayonet,
+		/obj/item/attachable/bayonet/upp,
+		/obj/item/attachable/reddot,
+		/obj/item/attachable/magnetic_harness,
+		/obj/item/attachable/flashlight,
+	)
+
+
 //----------------------------------------------
 //Special gun for the CO to replace the smartgun
 
@@ -1534,7 +1556,7 @@
 	desc = "The M4RA battle rifle is a designated marksman rifle in service with the USCM. Sporting a bullpup configuration, the M4RA battle rifle is perfect for reconnaissance and fire support teams.\nTakes *only* non-high-velocity M4RA magazines."
 	icon_state = "m4ra"
 	item_state = "m4ra"
-	fire_sound = 'sound/weapons/gun_m4ra.ogg'
+	fire_sound = 'sound/weapons/gun_carbine.ogg'
 	reload_sound = 'sound/weapons/handling/l42_reload.ogg'
 	unload_sound = 'sound/weapons/handling/l42_unload.ogg'
 	current_mag = /obj/item/ammo_magazine/rifle/m4ra
@@ -1867,123 +1889,3 @@
 	f90_shotgun_barrel.Attach(src)
 	update_attachable(f90_shotgun.slot)
 	update_attachable(f90_shotgun_barrel.slot)
-
-//-------------------------------------------------------
-//XM51, Breaching Scattergun
-
-/obj/item/weapon/gun/rifle/xm51
-	name = "\improper XM51 breaching scattergun"
-	desc = "An experimental shotgun model going through testing trials in the USCM. Based on the original civilian and CMB version, the XM51 is a mag-fed, pump-action shotgun. It utilizes special 16-gauge breaching rounds which are effective at breaching walls and doors. Users are advised not to employ the weapon against soft or armored targets due to low performance of the shells."
-	icon_state = "xm51"
-	item_state = "xm51"
-	fire_sound = 'sound/weapons/gun_shotgun_xm51.ogg'
-	reload_sound = 'sound/weapons/handling/l42_reload.ogg'
-	unload_sound = 'sound/weapons/handling/l42_unload.ogg'
-	current_mag = /obj/item/ammo_magazine/rifle/xm51
-	attachable_allowed = list(
-		/obj/item/attachable/bayonet,
-		/obj/item/attachable/bayonet/upp,
-		/obj/item/attachable/bayonet/co2,
-		/obj/item/attachable/reddot,
-		/obj/item/attachable/reflex,
-		/obj/item/attachable/verticalgrip,
-		/obj/item/attachable/angledgrip,
-		/obj/item/attachable/gyro,
-		/obj/item/attachable/flashlight/grip,
-		/obj/item/attachable/flashlight,
-		/obj/item/attachable/magnetic_harness,
-		/obj/item/attachable/stock/xm51,
-	)
-	flags_equip_slot = SLOT_BACK
-	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
-	gun_category = GUN_CATEGORY_SHOTGUN
-	aim_slowdown = SLOWDOWN_ADS_SHOTGUN
-	map_specific_decoration = TRUE
-
-	var/pump_delay //How long we have to wait before we can pump the shotgun again.
-	var/pump_sound = "shotgunpump"
-	var/message_delay = 1 SECONDS //To stop message spam when trying to pump the gun constantly.
-	var/burst_count = 0 //To detect when the burst fire is near its end.
-	COOLDOWN_DECLARE(allow_message)
-	COOLDOWN_DECLARE(allow_pump)
-
-/obj/item/weapon/gun/rifle/xm51/set_gun_attachment_offsets()
-	attachable_offset = list("muzzle_x" = 34, "muzzle_y" = 18, "rail_x" = 12, "rail_y" = 20, "under_x" = 24, "under_y" = 13, "stock_x" = 15, "stock_y" = 16)
-
-/obj/item/weapon/gun/rifle/xm51/set_gun_config_values()
-	..()
-	set_fire_delay(FIRE_DELAY_TIER_4*2)
-	set_burst_amount(0)
-	burst_scatter_mult = SCATTER_AMOUNT_TIER_7
-	accuracy_mult = BASE_ACCURACY_MULT + 2*HIT_ACCURACY_MULT_TIER_8
-	accuracy_mult_unwielded = BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_8
-	recoil = RECOIL_AMOUNT_TIER_4
-	recoil_unwielded = RECOIL_AMOUNT_TIER_2
-	scatter = SCATTER_AMOUNT_TIER_6
-
-/obj/item/weapon/gun/rifle/xm51/Initialize(mapload, spawn_empty)
-	. = ..()
-	pump_delay = FIRE_DELAY_TIER_8*3
-	additional_fire_group_delay += pump_delay
-
-/obj/item/weapon/gun/rifle/xm51/set_bullet_traits()
-	LAZYADD(traits_to_give, list(
-		BULLET_TRAIT_ENTRY_ID("turfs", /datum/element/bullet_trait_damage_boost, 30, GLOB.damage_boost_turfs), //2550, 2 taps colony walls, 4 taps reinforced walls
-		BULLET_TRAIT_ENTRY_ID("xeno turfs", /datum/element/bullet_trait_damage_boost, 0.23, GLOB.damage_boost_turfs_xeno), //2550*0.23 = 586, 2 taps resin walls, 3 taps thick resin
-		BULLET_TRAIT_ENTRY_ID("breaching", /datum/element/bullet_trait_damage_boost, 15, GLOB.damage_boost_breaching), //1275, enough to 1 tap airlocks
-		BULLET_TRAIT_ENTRY_ID("pylons", /datum/element/bullet_trait_damage_boost, 6, GLOB.damage_boost_pylons) //510, 4 shots to take out a pylon
-	))
-
-/obj/item/weapon/gun/rifle/xm51/unique_action(mob/user)
-	if(!COOLDOWN_FINISHED(src, allow_pump))
-		return
-	if(in_chamber)
-		if(COOLDOWN_FINISHED(src, allow_message))
-			to_chat(usr, SPAN_WARNING("<i>[src] already has a shell in the chamber!<i>"))
-			COOLDOWN_START(src, allow_message, message_delay)
-		return
-
-	playsound(user, pump_sound, 10, 1)
-	COOLDOWN_START(src, allow_pump, pump_delay)
-	ready_in_chamber()
-	burst_count = 0 //Reset the count for burst mode.
-
-/obj/item/weapon/gun/rifle/xm51/load_into_chamber(mob/user)
-	return in_chamber
-
-/obj/item/weapon/gun/rifle/xm51/reload_into_chamber(mob/user) //Don't chamber bullets after firing.
-	if(!current_mag)
-		update_icon()
-		return
-
-	in_chamber = null
-	if(current_mag.current_rounds <= 0 && flags_gun_features & GUN_AUTO_EJECTOR)
-		if (user.client?.prefs && (user.client?.prefs?.toggle_prefs & TOGGLE_AUTO_EJECT_MAGAZINE_OFF))
-			update_icon()
-		else if (!(flags_gun_features & GUN_BURST_FIRING) || !in_chamber) // Magazine will only unload once burstfire is over
-			var/drop_to_ground = TRUE
-			if (user.client?.prefs && (user.client?.prefs?.toggle_prefs & TOGGLE_AUTO_EJECT_MAGAZINE_TO_HAND))
-				drop_to_ground = FALSE
-				unwield(user)
-				user.swap_hand()
-			unload(user, TRUE, drop_to_ground) // We want to quickly autoeject the magazine. This proc does the rest based on magazine type. User can be passed as null.
-			playsound(src, empty_sound, 25, 1)
-	if(gun_firemode == GUN_FIREMODE_BURSTFIRE & burst_count < burst_amount - 1) //Fire two (or more) shots in a burst without having to pump.
-		ready_in_chamber()
-		burst_count++
-		return in_chamber
-
-/obj/item/weapon/gun/rifle/xm51/replace_magazine(mob/user, obj/item/ammo_magazine/magazine) //Don't chamber a round when reloading.
-	user.drop_inv_item_to_loc(magazine, src) //Click!
-	current_mag = magazine
-	replace_ammo(user,magazine)
-	user.visible_message(SPAN_NOTICE("[user] loads [magazine] into [src]!"),
-		SPAN_NOTICE("You load [magazine] into [src]!"), null, 3, CHAT_TYPE_COMBAT_ACTION)
-	if(reload_sound)
-		playsound(user, reload_sound, 25, 1, 5)
-
-/obj/item/weapon/gun/rifle/xm51/cock_gun(mob/user)
-	return
-
-/obj/item/weapon/gun/rifle/xm51/cock(mob/user) //Stops the "You cock the gun." message where nothing happens.
-	return


### PR DESCRIPTION

# About the pull request

Changes the gunfire audio of the M4RA to the same one the L42A uses. 

# Explain why it's good for the game

This gun sound is far better than the default M4RA. Whilst the M4RA is a sub-par weapon (compared to the m41a) I think the different audio will be a morale booster to its operators. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
soundadd: M4RA now uses the L42A's firing audio. 
/:cl:
