### PR TITLE
Fixes crates layering under the fulton recovery system

### DIFF
--- a/code/modules/dropships/attach_points/attach_point.dm
+++ b/code/modules/dropships/attach_points/attach_point.dm
@@ -27,45 +27,45 @@
 
 /obj/effect/attach_point/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/powerloader_clamp))
-		var/obj/item/powerloader_clamp/PC = I
-		install_equipment(PC, user)
+		var/obj/item/powerloader_clamp/clamp = I
+		install_equipment(clamp, user)
 		return TRUE
 	return ..()
 
 /// Called when a real user with a powerloader attempts to install an equipment on the attach point
-/obj/effect/attach_point/proc/install_equipment(obj/item/powerloader_clamp/PC, mob/living/user)
-	if(!istype(PC.loaded, /obj/structure/dropship_equipment))
+/obj/effect/attach_point/proc/install_equipment(obj/item/powerloader_clamp/clamp, mob/living/user)
+	if(!istype(clamp.loaded, /obj/structure/dropship_equipment))
 		return
-	var/obj/structure/dropship_equipment/SE = PC.loaded
-	if(!(base_category in SE.equip_categories))
-		to_chat(user, SPAN_WARNING("[SE] doesn't fit on [src]."))
-		return TRUE
+	var/obj/structure/dropship_equipment/ds_equipment = clamp.loaded
+	if(!(base_category in ds_equipment.equip_categories))
+		to_chat(user, SPAN_WARNING("[ds_equipment] doesn't fit on [src]."))
+		return
 	if(installed_equipment)
-		return TRUE
-	playsound(loc, 'sound/machines/hydraulics_1.ogg', 40, 1)
+		return
+	playsound(loc, 'sound/machines/hydraulics_1.ogg', 40, TRUE)
 	var/point_loc = loc
 	if(!user || !do_after(user, (7 SECONDS) * user.get_skill_duration_multiplier(SKILL_ENGINEER), INTERRUPT_NO_NEEDHAND|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
-		return TRUE
+		return
 	if(loc != point_loc)//dropship flew away
-		return TRUE
-	if(installed_equipment || PC.loaded != SE)
-		return TRUE
-	to_chat(user, SPAN_NOTICE("You install [SE] on [src]."))
-	SE.forceMove(loc)
-	PC.loaded = null
-	playsound(loc, 'sound/machines/hydraulics_2.ogg', 40, 1)
-	PC.update_icon()
-	installed_equipment = SE
-	SE.ship_base = src
-	SE.plane = plane
+		return
+	if(installed_equipment || clamp.loaded != ds_equipment)
+		return
+	to_chat(user, SPAN_NOTICE("You install [ds_equipment] on [src]."))
+	ds_equipment.forceMove(loc)
+	clamp.loaded = null
+	playsound(loc, 'sound/machines/hydraulics_2.ogg', 40, TRUE)
+	clamp.update_icon()
+	installed_equipment = ds_equipment
+	ds_equipment.ship_base = src
+	ds_equipment.plane = plane
 
 	for(var/obj/docking_port/mobile/marine_dropship/shuttle in SSshuttle.mobile)
 		if(shuttle.id == ship_tag)
-			SE.linked_shuttle = shuttle
-			SEND_SIGNAL(shuttle, COMSIG_DROPSHIP_ADD_EQUIPMENT, SE)
+			ds_equipment.linked_shuttle = shuttle
+			SEND_SIGNAL(shuttle, COMSIG_DROPSHIP_ADD_EQUIPMENT, ds_equipment)
 			break
 
-	SE.update_equipment()
+	ds_equipment.update_equipment()
 
 /// Weapon specific attachment point
 /obj/effect/attach_point/weapon

--- a/code/modules/dropships/attach_points/attach_point.dm
+++ b/code/modules/dropships/attach_points/attach_point.dm
@@ -57,6 +57,7 @@
 	PC.update_icon()
 	installed_equipment = SE
 	SE.ship_base = src
+	SE.plane = plane
 
 	for(var/obj/docking_port/mobile/marine_dropship/shuttle in SSshuttle.mobile)
 		if(shuttle.id == ship_tag)


### PR DESCRIPTION
# About the pull request

Fixes crates and some other fultonable objects being on a layer below the dropship's fulton recovery system.

This was happening because crates (any closet subtypes really) are on `BELOW_OBJ_LAYER`, and dropship equipment is on `ABOVE_OBJ_LAYER`.
Changing the layer of `/obj/structure/dropship_equipment` to something lower would probably work, but I felt the safest solution would be to just set the equipment's `plane` to whatever the attach point has.
This has no effect on the outside attachment points, but fixes the layering issue since the inside ones are on `FLOOR_PLANE`.

I should also mention that the actual fix is in the first commit (b8e44956cfb4ed11d971456be8059fd9eaeb928f) and is only one line. All the rest of this is just because the `install_equipment()` proc was a bit confusing as it was.

# Explain why it's good for the game

Unless I've missed something in git blame, this has probably been a bug for 4+ years.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

**Before:**
![image](https://github.com/cmss13-devs/cmss13/assets/57483089/77d8e10c-6354-4902-a1c1-982a69709612)

**After:** (Also a regular crate too)
![dreamseeker_htRSczUHZh](https://github.com/cmss13-devs/cmss13/assets/57483089/a7a93420-c7c0-4203-b4df-c3f3415cc98c) ![dreamseeker_yV0pi23XYY](https://github.com/cmss13-devs/cmss13/assets/57483089/8e4155ee-5b5e-437a-9cde-788755cc164a)

**Verifying that other hardpoints aren't affected:**
![ds](https://github.com/cmss13-devs/cmss13/assets/57483089/1e67da09-910a-452e-ba26-27df763d0a31)

</details>


# Changelog
:cl:
fix: Fixed crates and similar objects layering below the dropship's fulton recovery system.
/:cl:
