### PR TITLE
Adds One Slot to IFAK/Tools Pouches.

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -192,7 +192,7 @@
 	name = "first-aid pouch"
 	desc = "It contains, by default, autoinjectors. But it may also hold ointments, bandages, and pill packets."
 	icon_state = "firstaid"
-	storage_slots = 4
+	storage_slots = 5
 	can_hold = list(
 		/obj/item/stack/medical/ointment,
 		/obj/item/reagent_container/hypospray/autoinjector,
@@ -209,9 +209,11 @@
 	new /obj/item/reagent_container/hypospray/autoinjector/kelotane(src)
 	new /obj/item/reagent_container/hypospray/autoinjector/tramadol(src)
 	new /obj/item/reagent_container/hypospray/autoinjector/emergency(src)
+	new /obj/item/stack/medical/splint(src)
 
 /obj/item/storage/pouch/firstaid/full/alternate/fill_preset_inventory()
 	new /obj/item/reagent_container/hypospray/autoinjector/tricord(src)
+	new /obj/item/reagent_container/hypospray/autoinjector/tramadol(src)
 	new /obj/item/stack/medical/splint(src)
 	new /obj/item/stack/medical/ointment(src)
 	new /obj/item/stack/medical/bruise_pack(src)
@@ -221,6 +223,7 @@
 	new /obj/item/storage/pill_bottle/packet/kelotane(src)
 	new /obj/item/storage/pill_bottle/packet/tramadol(src)
 	new /obj/item/storage/pill_bottle/packet/tramadol(src)
+	new /obj/item/stack/medical/splint(src)
 
 /obj/item/storage/pouch/firstaid/ert
 	desc = "It can contain autoinjectors, ointments, and bandages. This one has some extra stuff."
@@ -1194,7 +1197,7 @@
 /obj/item/storage/pouch/tools
 	name = "tools pouch"
 	desc = "It's designed to hold maintenance tools - screwdriver, wrench, cable coil, etc. It also has a hook for an entrenching tool or light replacer."
-	storage_slots = 4
+	storage_slots = 5
 	max_w_class = SIZE_MEDIUM
 	icon_state = "tools"
 	can_hold = list(


### PR DESCRIPTION

# About the pull request

Adds one more storage slot of the first aid and tools pouches. Adds meds that fit into the empty slot. (splints for the pills and autoinjector presets, tramadol for the general preset)

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

There's currently no reason to take the first aid kit or tools pouch over webbing, the first aid pouch is further outclassed by the first responder pouch. This is hopefully enough change to flesh out loadouts enough to make the first aid pouch or tools pouch something other than a noob trap.

To add onto this, pouches are starting to take niches, like the machete pouch or sling pouch, I think its best for that aspect to be buffed in the pouches effected by this change.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Stakeyng
balance: Buffed the storage space of the firstaid/tools pouches by one slot.
/:cl:
