### PR TITLE
WY Research Consultant gets reagent scanner goggles

### DIFF
--- a/code/modules/gear_presets/wy_goons.dm
+++ b/code/modules/gear_presets/wy_goons.dm
@@ -135,6 +135,7 @@
 
 /datum/equipment_preset/goon/researcher/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/WY, WEAR_L_EAR)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/science, WEAR_EYES)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/liaison_suit/corporate_formal, WEAR_BODY)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/labcoat, WEAR_JACKET)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/corporate, WEAR_FEET)


### PR DESCRIPTION

# About the pull request
WY consultant (chem goon ERT) gets scigoggles so that they can identify the various chemicals that research gets.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
It's a bit strange how the research consultant doesn't actually have a way to identify whether the vial they're given is the same one as the DDI paper tells them it is without using a chem machine.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Chem Goon Research Consultant now spawns with reagent scanner goggles.
/:cl:
