### PR TITLE
added tooltip to dropship for doors

### DIFF
--- a/tgui/packages/tgui/interfaces/DropshipFlightControl.tsx
+++ b/tgui/packages/tgui/interfaces/DropshipFlightControl.tsx
@@ -1,6 +1,6 @@
 import { useBackend, useSharedState } from '../backend';
 import { Window } from '../layouts';
-import { Box, Button, Flex, Icon, ProgressBar, Section, Stack } from '../components';
+import { Box, Button, Flex, Icon, ProgressBar, Section, Stack, Tooltip } from '../components';
 import { LaunchButton, CancelLaunchButton, DisabledScreen, InFlightCountdown, LaunchCountdown, NavigationProps, ShuttleRecharge, DockingPort } from './NavigationShuttle';
 
 interface DoorStatus {
@@ -69,6 +69,12 @@ const DropshipDoorControl = () => {
             )}
           </>
         ))}>
+      <Tooltip
+        position="bottom"
+        content="Aft - Rear ; Port - Left ; Starboard - Right">
+        <Box position="relative"> Info </Box>
+      </Tooltip>
+
       <Stack className="DoorControlStack">
         {data.door_status
           .filter((x) => x.id !== 'all')


### PR DESCRIPTION
# About the pull request

Adds a little info tooltip to help pilots that didn't join the navy what aft, port and starboard are.

# Explain why it's good for the game

Allows pilots to quickly reference which door is which.
Removes frivolous irl knowledge from getting in the way of the game.
The Pilot should reasonably know Port, aft, etc. Just like how the riflemen know how to aim an M41. 
Many irl people don't know how to handle rifles, but these characters do.

So in summary:
Just bridging the gap between what game characters know and what players know. 

# Testing Photographs and Procedure
I tooled my tip and the tip tooled me. 
A tool received a tip and that tip was a good tool. 

I also forgot what side port is, and then I hovered over the tooltip, and then I remembered which side port was. 

<details>

![image](https://github.com/cmss13-devs/cmss13/assets/142365554/1dbf48a7-cb05-4310-9c17-e3e14ccc1a01)

Tooltip is noted as being "hacky" in documentation.
The tooltip appears there despite my mouse being over the text "Info"

The following screenshot is it on the bottom.
The above screenshot with "Info" above the individual door buttons is what's being merged. Just showing an alternate option. I could maybe try right aligning the Info hover thing, but I'm open to thoughts on the visual taste. I _wanted_ the tooltip to just appear if you hovered over "Door Controls" but that wasn't quite working. 

![image](https://github.com/cmss13-devs/cmss13/assets/142365554/8315a884-5ef1-4d7c-b409-708023419076)


</details>


# Changelog

:cl:
qol: Added Tooltip for pilots to remember what side port, aft, and starboard are.
/:cl:
