### PR TITLE
Increases RMCs/TWE's Rifles ROF

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1763,9 +1763,9 @@
 
 /obj/item/weapon/gun/rifle/rmc_f90/set_gun_config_values()
 	..()
-	fire_delay = FIRE_DELAY_TIER_8
+	fire_delay = FIRE_DELAY_TIER_11
 	burst_amount = BURST_AMOUNT_TIER_3
-	burst_delay = FIRE_DELAY_TIER_8
+	burst_delay = FIRE_DELAY_TIER_11
 	accuracy_mult = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_4 + 2*HIT_ACCURACY_MULT_TIER_1
 	accuracy_mult_unwielded = BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_7
 	scatter = SCATTER_AMOUNT_TIER_8
@@ -1804,7 +1804,7 @@
 
 /obj/item/weapon/gun/rifle/rmc_f90/scope/set_gun_config_values()
 	..()
-	fire_delay = FIRE_DELAY_TIER_7
+	fire_delay = FIRE_DELAY_TIER_11
 	burst_amount = 0
 	accuracy_mult = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_4 + 2*HIT_ACCURACY_MULT_TIER_1
 	accuracy_mult_unwielded = BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_7
@@ -1844,9 +1844,9 @@
 
 /obj/item/weapon/gun/rifle/rmc_f90/shotgun/set_gun_config_values()
 	..()
-	fire_delay = FIRE_DELAY_TIER_8
+	fire_delay = FIRE_DELAY_TIER_11
 	burst_amount = BURST_AMOUNT_TIER_3
-	burst_delay = FIRE_DELAY_TIER_8
+	burst_delay = FIRE_DELAY_TIER_11
 	accuracy_mult = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_4 + 2*HIT_ACCURACY_MULT_TIER_1
 	accuracy_mult_unwielded = BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_2
 	scatter = SCATTER_AMOUNT_TIER_8


### PR DESCRIPTION

# About the pull request

Increases the ROF of the RMC's rifles to be comparable to the M41As. 

# Explain why it's good for the game

The RMC's guns are simply non-viable by ERT standards let alone Marine standards. Their ROF is too low to be an effective damage dealer in combat. This, combined with the low amount of ammo RMC's get, often leads to RMC's ditching their unique guns for a M41A. The only advantage of the guns is they don't inhibit movement speed, but I do not believe this is sufficient of a boon to justify the terrible ROF. 

Furthermore, ERT guns are generally slightly better, or far superior, to USCM weapons due to their limited nature and the small numbers of spawns that are present. Ergo, this buff is not egregious compared to UPP, PMC or other ERT spawns. Furthermore, the RMC are described as a tech advance, if small, commando force, it is justifiable that elite commandos get access to slightly better guns than the rank and file. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Royal Marine Commando's firearms now have a higher rate of fire, comparable to the M41A. 
/:cl:
