### PR TITLE
Makes Research Civilians Again.

### DIFF
--- a/code/game/jobs/job/civilians/other/liaison.dm
+++ b/code/game/jobs/job/civilians/other/liaison.dm
@@ -6,7 +6,7 @@
 	selection_class = "job_cl"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/liaison
-	entry_message_body = "As a <a href='"+WIKI_PLACEHOLDER+"'>representative of Weyland-Yutani Corporation</a>, your job requires you to stay in character at all times. You are not required to follow military orders; however, you cannot give military orders. Your primary job is to observe and report back your findings to Weyland-Yutani. Follow regular game rules unless told otherwise by your superiors. Use your office fax machine to communicate with corporate headquarters or to acquire new directives. You may not receive anything back, and this is normal."
+	entry_message_body = "As a <a href='"+WIKI_PLACEHOLDER+"'>representative of Weyland-Yutani Corporation</a>, your job requires you to stay in character at all times. You are not required to follow military orders; however, you cannot give military orders. Thankfully, the Company has positioned Weyland-Yutani Researchers contracted by the USCM on the ship, you may wish to work together alongside them. You are not their boss, remember that. Your primary job is to observe and report back your findings to Weyland-Yutani. Follow regular game rules unless told otherwise by your superiors. Use your office fax machine to communicate with corporate headquarters or to acquire new directives. You may not receive anything back, and this is normal."
 	var/mob/living/carbon/human/active_liaison
 
 /datum/job/civilian/liaison/generate_entry_conditions(mob/living/liaison, whitelist_status)

--- a/code/game/jobs/job/civilians/support/researcher.dm
+++ b/code/game/jobs/job/civilians/support/researcher.dm
@@ -10,7 +10,7 @@
 	selection_class = "job_researcher"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/uscm_medical/researcher
-	entry_message_body = "You're a Weyland-Yutani Researcher contracted out by the Company to the USCMC for their own R&D Project which is still in it's infancy, you are not in the ship's chain of command. You are tasked with <a href='"+WIKI_PLACEHOLDER+"'>researching</a> and developing new medical treatments, helping your fellow doctors, and generally learning new things. Your role involves a lot of roleplaying, but you can perform the function of a regular doctor. Do not hand out things to Marines without getting permission from your supervisor."
+	entry_message_body = "You're a Weyland-Yutani Researcher contracted out by the Company to the USCMC for their own R&D Project which is still in it's infancy, you are not in the ship's chain of command. The Executive aboard the ship is not your boss and neither are you theirs, the Company wants all it's employees to work together. 'Building Better Worlds since 2099!' With that out of the way, you are tasked with <a href='"+WIKI_PLACEHOLDER+"'>researching</a> and developing new medical treatments, helping your fellow doctors, and work with the Liaison in an equivalent work environment. Your role involves a lot of roleplaying, but you can perform the function of a regular doctor. Do not hand out things to Marines without getting permission from your supervisor."
 
 /datum/job/civilian/researcher/set_spawn_positions(count)
 	spawn_positions = rsc_slot_formula(count)

--- a/code/game/jobs/job/civilians/support/researcher.dm
+++ b/code/game/jobs/job/civilians/support/researcher.dm
@@ -10,7 +10,7 @@
 	selection_class = "job_researcher"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	gear_preset = /datum/equipment_preset/uscm_ship/uscm_medical/researcher
-	entry_message_body = "You're a commissioned officer of the USCM, though you are not in the ship's chain of command. You are tasked with <a href='"+WIKI_PLACEHOLDER+"'>researching</a> and developing new medical treatments, helping your fellow doctors, and generally learning new things. Your role involves a lot of roleplaying, but you can perform the function of a regular doctor. Do not hand out things to Marines without getting permission from your supervisor."
+	entry_message_body = "You're a Weyland-Yutani Researcher contracted out by the Company to the USCMC for their own R&D Project which is still in it's infancy, you are not in the ship's chain of command. You are tasked with <a href='"+WIKI_PLACEHOLDER+"'>researching</a> and developing new medical treatments, helping your fellow doctors, and generally learning new things. Your role involves a lot of roleplaying, but you can perform the function of a regular doctor. Do not hand out things to Marines without getting permission from your supervisor."
 
 /datum/job/civilian/researcher/set_spawn_positions(count)
 	spawn_positions = rsc_slot_formula(count)

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -98,7 +98,7 @@
 /obj/item/device/encryptionkey/medres
 	name = "Research Radio Encryption Key"
 	icon_state = "med_key"
-	channels = list(RADIO_CHANNEL_MEDSCI = TRUE, RADIO_CHANNEL_INTEL = TRUE)
+	channels = list(RADIO_CHANNEL_MEDSCI = TRUE, RADIO_CHANNEL_INTEL = TRUE, RADIO_CHANNEL_WY = TRUE)
 
 // MARINE MILITARY POLICE
 

--- a/code/modules/gear_presets/uscm_medical.dm
+++ b/code/modules/gear_presets/uscm_medical.dm
@@ -120,12 +120,12 @@
 
 //*****************************************************************************************************/
 /datum/equipment_preset/uscm_ship/uscm_medical/researcher
-	name = "USCM Researcher"
+	name = "W-Y Researcher"
 
 	access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_RESEARCH, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_MORGUE)
 	assignment = JOB_RESEARCHER
 	rank = JOB_RESEARCHER
-	paygrade = PAY_SHORT_MO1
+	paygrade = PAY_SHORT_CCMO
 	role_comm_title = "Rsr"
 	skills = /datum/skills/researcher
 


### PR DESCRIPTION

# About the pull request

We did it Research and Company bros.

https://forum.cm-ss13.com/t/should-research-return-to-being-civilians-employed-by-w-y-and-contracted-by-the-uscm/5924

https://forum.cm-ss13.com/t/make-research-a-civilian-departement-under-military-contract/1013

I wanna thank all the forum posts, likes, thumps up and HRP nerds for making this happen.

# Explain why it's good for the game

I think the forum posts speak for themselves, increase of shipside RP for one. 
Jean also points out that the current implementation for them being USCM Officers is bad.
Gives the CL someone friendly to interact with. ~~(WE HATE THE COMPANY)~~
BlackDragon also said it adds soul, which I totally agree with.
My favorite CO Chen said that there can be alot of scenarios which increase the shipside conflict when the CL had Research friends. Favorite one's boycotting the USCM.

I can go on and on about what other people said on the two forum posts I posted, now I can point to some negatives, which is namely, that the CL should not get to be the boss, or should not even exist (perhaps a bit extreme)

I hope my changes to the spawn-in text will at least make some contribution to the lack of CLs attempting to take over, but most Junior Execs, are well, new people, who need to learn the hard or easy way how it is and that they will never be the the Research Director, but a very close friend on equal footing to the rest of the department. 

# Changelog
:cl:
add: Replaced the USCM Commissioned Officer Researchers with W-Y Contracted Researchers.
add: Gave the Research radio a W-Y key.
/:cl:
