### PR TITLE
Fixes Warden Praetorians being able to move around the ovipositored Queen

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_powers.dm
@@ -926,15 +926,15 @@
 		to_chat(X, SPAN_XENODANGER("We cannot retrieve ourself!"))
 		return
 
-	if(X.anchored)
-		to_chat(X, SPAN_XENODANGER("That sister cannot move!"))
-		return
-
 	if(!(A in view(7, X)))
 		to_chat(X, SPAN_XENODANGER("That sister is too far away!"))
 		return
 
 	var/mob/living/carbon/xenomorph/targetXeno = A
+
+	if(targetXeno.anchored)
+		to_chat(X, SPAN_XENODANGER("That sister cannot move!"))
+		return
 
 	if(!(targetXeno.resting || targetXeno.stat == UNCONSCIOUS))
 		if(targetXeno.mob_size > MOB_SIZE_BIG)


### PR DESCRIPTION
# About the pull request

Fixes this bug:

- Queen gets on ovipositor
- Rests
- Warden Praetorian uses the "Retrieve" skill on the Queen
- Queen moves

https://github.com/cmss13-devs/cmss13/assets/49321394/9b2f8415-4961-4541-b6dc-c79a81ddab15

# Explain why it's good for the game

This is a silly bug. The original anchored check checked if the Praetorian was anchored, not its target.

# Testing Photographs and Procedure

No longer works:

<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/49321394/402cda65-b605-4c78-9b72-952563fc104b

</details>


# Changelog

:cl:
fix: Fixed Warden Praetorians being able to move around the ovipositored Queen with their Retrieve ability.
/:cl:
