### PR TITLE
Changes LV-624 tfort's landing floodlights to colony floodlights

### DIFF
--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -1405,9 +1405,7 @@
 /area/lv624/ground/barrens/central_barrens)
 "agF" = (
 /obj/item/ammo_casing,
-/obj/structure/machinery/floodlight/landing{
-	name = "bolted floodlight"
-	},
+/obj/structure/machinery/colony_floodlight,
 /turf/open/floor/plating,
 /area/lv624/ground/barrens/central_barrens)
 "agG" = (

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -1126,9 +1126,7 @@
 /area/lv624/ground/barrens/containers)
 "afu" = (
 /obj/item/ammo_casing,
-/obj/structure/machinery/floodlight/landing{
-	name = "bolted floodlight"
-	},
+/obj/structure/machinery/colony_floodlight,
 /turf/open/floor/plating{
 	dir = 9;
 	icon_state = "warnplate"
@@ -1162,9 +1160,7 @@
 	},
 /area/lv624/ground/barrens/central_barrens)
 "afy" = (
-/obj/structure/machinery/floodlight/landing{
-	name = "bolted floodlight"
-	},
+/obj/structure/machinery/colony_floodlight,
 /turf/open/floor/plating{
 	dir = 5;
 	icon_state = "warnplate"
@@ -1588,9 +1584,7 @@
 	},
 /area/lv624/ground/barrens/west_barrens/ceiling)
 "ahM" = (
-/obj/structure/machinery/floodlight/landing{
-	name = "bolted floodlight"
-	},
+/obj/structure/machinery/colony_floodlight,
 /turf/open/floor/plating{
 	dir = 10;
 	icon_state = "warnplate"
@@ -1630,9 +1624,7 @@
 	},
 /area/lv624/ground/barrens/central_barrens)
 "ahT" = (
-/obj/structure/machinery/floodlight/landing{
-	name = "bolted floodlight"
-	},
+/obj/structure/machinery/colony_floodlight,
 /turf/open/floor/plating{
 	dir = 6;
 	icon_state = "warnplate"


### PR DESCRIPTION
# About the pull request

This PR changes the landing floodlights found at LV-624's tfort to the colony floodlight variant.

# Explain why it's good for the game

This is not going to be popular, but please read the reasoning:

LV-624 is the _only_ map that uses the "landing floodlight" variant outside of the actual landing zones (namely, at tfort) - these floodlights are unslashable, unmeltable, and unmoveable without any visual indicator (that is, they are not near LZs indicating their game-critical importance). This PR changes these landing floodlights to colony floodlight variants.

- **Why colony floodlights:** Colony floodlights are the exact same floodlights that you can find around this map (even southeast of tfort itself): these ones cannot be melted (ever), and they cannot be slashed until they were turned on, after which they are still not despawned, just a comtech has to fix them.

- **Why not regular floodlights:** Regular floodlights can be slashed. Every LV-624 round would start with xenos slashing/melting them immediately and marines would lose their light source on tfort. I feel the pain of every hivelord/drone who ever had to build around these light sources, but they have a strategic reasoning to be there.

- **Is this a marine nerf:** Yes and no. Yes, they no longer have infinite, undestroyable-by-xenos floodlights at tfort and they actually have to set up power to have light here. No, because 1) marines usually CAS/OB tfort immediately, removing everything, and 2) colony floodlights have 150 health as opposed to the landing lights's 100, so they are slightly more resistant to marine fuckery.

- **Why is this good apart from map unification:** It gives marines one more reason to properly fortify tfort: they have to protect their light sources. (Also, maybe stop OBing/CASing a strategically good place :P)

# Testing Photographs and Procedure

Tfort lights:

<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/49321394/6856fa49-aecd-4804-b0d4-342eb13b92e6)

</details>


# Changelog

:cl:
maptweak: LV-624 tfort's floodlights are now colony floodlights.
/:cl:
