### PR TITLE
Thour tiny tutorial tweaks (and a unit test)

### DIFF
--- a/code/datums/tutorial/_tutorial.dm
+++ b/code/datums/tutorial/_tutorial.dm
@@ -52,6 +52,7 @@ GLOBAL_LIST_EMPTY_TYPED(ongoing_tutorials, /datum/tutorial)
 
 	reservation = SSmapping.RequestBlockReservation(initial(tutorial_template.width), initial(tutorial_template.height))
 	if(!reservation)
+		abort_tutorial()
 		return FALSE
 
 	var/turf/bottom_left_corner_reservation = locate(reservation.bottom_left_coords[1], reservation.bottom_left_coords[2], reservation.bottom_left_coords[3])

--- a/code/datums/tutorial/_tutorial_menu.dm
+++ b/code/datums/tutorial/_tutorial_menu.dm
@@ -79,5 +79,5 @@
 				return
 
 			path = new path
-			path.start_tutorial(usr)
-			return TRUE
+			if(path.start_tutorial(usr))
+				ui.close()

--- a/code/datums/tutorial/_tutorial_menu.dm
+++ b/code/datums/tutorial/_tutorial_menu.dm
@@ -81,3 +81,4 @@
 			path = new path
 			if(path.start_tutorial(usr))
 				ui.close()
+				return TRUE

--- a/code/datums/tutorial/xenomorph/_xenomorph.dm
+++ b/code/datums/tutorial/xenomorph/_xenomorph.dm
@@ -22,6 +22,10 @@
 
 	// We don't want people talking to other xenomorphs across tutorials
 	new_character.can_hivemind_speak = FALSE
+	// No age prefix or HUD element
+	new_character.age = XENO_NO_AGE
+	new_character.show_age_prefix = FALSE
+	new_character.generate_name()
 
 	tutorial_mob = new_character
 	xeno = new_character

--- a/code/datums/tutorial/xenomorph/xenomorph_basic.dm
+++ b/code/datums/tutorial/xenomorph/xenomorph_basic.dm
@@ -1,10 +1,10 @@
 #define WAITING_HEALTH_THRESHOLD 300
 
 /datum/tutorial/xenomorph/basic
-	//name = "Xenomorph - Basic"
-	//desc = "A tutorial to get you acquainted with the very basics of how to play a xenomorph."
-	//icon_state = "xeno"
-	//tutorial_id = "xeno_basic_1"
+	name = "Xenomorph - Basic"
+	desc = "A tutorial to get you acquainted with the very basics of how to play a xenomorph."
+	icon_state = "xeno"
+	tutorial_id = "xeno_basic_1"
 	tutorial_template = /datum/map_template/tutorial/s12x12
 	starting_xenomorph_type = /mob/living/carbon/xenomorph/drone
 

--- a/code/datums/tutorial/xenomorph/xenomorph_basic.dm
+++ b/code/datums/tutorial/xenomorph/xenomorph_basic.dm
@@ -1,10 +1,10 @@
 #define WAITING_HEALTH_THRESHOLD 300
 
 /datum/tutorial/xenomorph/basic
-	name = "Xenomorph - Basic"
-	desc = "A tutorial to get you acquainted with the very basics of how to play a xenomorph."
-	icon_state = "xeno"
-	tutorial_id = "xeno_basic_1"
+	//name = "Xenomorph - Basic"
+	//desc = "A tutorial to get you acquainted with the very basics of how to play a xenomorph."
+	//icon_state = "xeno"
+	//tutorial_id = "xeno_basic_1"
 	tutorial_template = /datum/map_template/tutorial/s12x12
 	starting_xenomorph_type = /mob/living/carbon/xenomorph/drone
 

--- a/code/datums/tutorial/xenomorph/xenomorph_basic.dm
+++ b/code/datums/tutorial/xenomorph/xenomorph_basic.dm
@@ -4,6 +4,7 @@
 	name = "Xenomorph - Basic"
 	desc = "A tutorial to get you acquainted with the very basics of how to play a xenomorph."
 	icon_state = "xeno"
+	tutorial_id = "xeno_basic_1"
 	tutorial_template = /datum/map_template/tutorial/s12x12
 	starting_xenomorph_type = /mob/living/carbon/xenomorph/drone
 
@@ -105,7 +106,7 @@
 
 	UnregisterSignal(human_dummy, COMSIG_MOB_DEATH)
 	message_to_player("Well done. Killing humans is one of many ways to help the hive.")
-	message_to_player("Another way is to <b>capture</b> them. This will grow a new xenomorph inside them  which will eventually burst into a new playable xenomorph!")
+	message_to_player("Another way is to <b>capture</b> them. This will grow a new xenomorph inside them which will eventually burst into a new playable xenomorph!")
 	addtimer(CALLBACK(human_dummy, TYPE_PROC_REF(/mob/living, rejuvenate)), 8 SECONDS)
 	addtimer(CALLBACK(src, PROC_REF(proceed_to_tackle_phase)), 10 SECONDS)
 
@@ -227,3 +228,5 @@
 
 /datum/tutorial/xenomorph/basic/init_map()
 	loc_from_corner(9,0).ChangeTurf(/turf/closed/wall/resin/tutorial)
+
+#undef WAITING_HEALTH_THRESHOLD

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -74,19 +74,23 @@
 /// A trait source when adding traits through unit tests
 #define TRAIT_SOURCE_UNIT_TESTS "unit_tests"
 
+// Unit tests
 #include "autowiki.dm"
+#include "check_runtimes.dm"
 #include "create_and_destroy.dm"
-#include "focus_only_tests.dm"
+#include "emote_panels.dm"
 #include "missing_icons.dm"
 #include "resist.dm"
+#include "spawn_humans.dm"
 #include "spritesheets.dm"
 #include "subsystem_init.dm"
 #include "tgui_create_message.dm"
 #include "timer_sanity.dm"
+#include "tutorials.dm"
+
+// Unit tests backend
+#include "focus_only_tests.dm"
 #include "unit_test.dm"
-#include "spawn_humans.dm"
-#include "check_runtimes.dm"
-#include "emote_panels.dm"
 
 #undef TEST_ASSERT
 #undef TEST_ASSERT_EQUAL

--- a/code/modules/unit_tests/tutorials.dm
+++ b/code/modules/unit_tests/tutorials.dm
@@ -1,0 +1,19 @@
+/datum/unit_test/tutorials
+
+/datum/unit_test/tutorials/Run()
+	var/datum/tutorial/base_path = /datum/tutorial
+	for(var/datum/tutorial/tutorial_path as anything in subtypesof(base_path))
+		if(initial(tutorial_path.parent_path) == tutorial_path)
+			continue
+
+		// Make sure these variables are overridden on any subtypes.
+		TEST_ASSERT_NOTEQUAL(initial(tutorial_path.name), initial(base_path.name),
+			"[tutorial_path] does not have a name set.")
+		TEST_ASSERT_NOTEQUAL(initial(tutorial_path.tutorial_id), initial(base_path.tutorial_id),
+			"[tutorial_path] does not have a tutorial_id set.")
+		TEST_ASSERT_NOTEQUAL(initial(tutorial_path.desc), initial(base_path.desc),
+			"[tutorial_path] does not have a desc set.")
+		TEST_ASSERT_NOTEQUAL(initial(tutorial_path.icon_state), initial(base_path.icon_state),
+			"[tutorial_path] does not have an icon_state set.")
+
+// TODO: Add a test verifying that a basic tutorial can be started and completed. (Requires unit test client handling)


### PR DESCRIPTION
# About the pull request

<ol>
    <li>
        Commit 5014927bc4ae6f3bd03f3ea1866cb6ba6c9e7c54: Makes the 'Tutorial Menu' automatically close when a tutorial is started.
        <ul>
            <li>Also adds an <code>abort_tutorial()</code> call to <code>/datum/tutorial/proc/start_tutorial()</code>, since it may have been possible to for player to get trapped in the tutorial otherwise.</li>
        </ul>
    </li>
    <li>Commit b10974c0471ef14c3c66ec10910e8c993cbb29d1: Adds a <code>tutorial_id</code> to the basic Xenomorph tutorial.</li>
    <li>Commit 38c03c987dbad50f7d8a2354a63c75f88d5efcce: Edited the tutorial Xenomorph a bit so that it's always "You are Inquisitive Drone (XX-123)", as opposed to "You are Inquisitive Young/Mature/etc. Drone (XX-123)".</li>
    <li>
        Commits a595b971c489922510bd984e3d324ac844450efe + 27e38e654a611aeefd548c41035bbff035caa76b: Adds a basic unit test for <code>/datum/tutorial</code> subtypes to verify that they have set some basic variables.
        <ul>
            <li>Also lightly organises the <code>#include</code>s in <code>code/modules/unit_tests/_unit_tests.dm</code>.</li>
        </ul>
    </li>
</ol>

# Explain why it's good for the game

Just a couple of things I noticed while exploring tutorial code.
The third commit is maybe a bit subjective, but I personally think it makes the tutorials seem like more of a separate game state, if that makes sense.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
ui: Made the Tutorial Menu automatically close when a tutorial is started.
code: Made the tutorial Xenomorph not inherit the user's 'age' prefix.
code: Added a basic unit test for tutorials.
/:cl:
