### PR TITLE
Allows the MOU53 to be stored in the shotgun scabbard.

### DIFF
--- a/code/game/objects/items/storage/large_holster.dm
+++ b/code/game/objects/items/storage/large_holster.dm
@@ -64,6 +64,7 @@
 	can_hold = list(
 		/obj/item/weapon/gun/shotgun/pump,
 		/obj/item/weapon/gun/shotgun/combat,
+		/obj/item/weapon/gun/shotgun/double/mou53,
 	)
 	has_gamemode_skin = TRUE
 

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -274,7 +274,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	update_attachable(ugl.slot)
 	stock.hidden = FALSE
 	stock.Attach(src)
-	update_attachable(stock.slot)	
+	update_attachable(stock.slot)
 
 /obj/item/weapon/gun/shotgun/combat/set_gun_attachment_offsets()
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19,"rail_x" = 10, "rail_y" = 21, "under_x" = 14, "under_y" = 16, "stock_x" = 11, "stock_y" = 13.)


### PR DESCRIPTION

# About the pull request

Lets you store the MOU in the shotgun scabbard.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Shotgun scabbard is soul. Basically no advantage given, other than the fact that you can keep a slot reserved for your MOU.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Stakeyng
add: mou is now compatible with the shotgun scabbard
/:cl:
