### PR TITLE
Reverts flare buff from #4229

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -238,7 +238,7 @@
 	desc = "A red USCM issued flare. There are instructions on the side, it reads 'pull cord, make light'."
 	w_class = SIZE_SMALL
 	light_power = 2
-	light_range = 7
+	light_range = 5
 	icon_state = "flare"
 	item_state = "flare"
 	actions = list() //just pull it manually, neckbeard.


### PR DESCRIPTION

# About the pull request
Reverts the flare buff that came alongside fancy lighting from 7 range to 5
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Since the fancy lighting change, other factors have come in to play, most notably the rise in the flare gun, the increase in pouch storage and the buff to armour light, making controlling lighting incredibly easy just with 1, with them being infinitely more difficult to deal with than flashlights and a lot more accessible while being safer to use with other utility.

 I believe it is fair to revert the buff especially considering how bright flares are in real life, being more of a concentrated amount of light, not overpowering a military issue flashlight 10 fold without the cone effect to boot.

With how considerable the nerf would be I doubt they will fall into the realm of uselessness, with them still being a great option for scouting ahead of what is visible and still being very easy to carry, just needing an additional flare or so for a room that would be lit up by one.

# Testing Photographs and Procedure
https://imgur.com/5VNOQrh

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
balance: Reverted flare range buff 7->5 tiles
/:cl:

