### PR TITLE
Jensenshades are now proper thermal glasses

### DIFF
--- a/code/game/objects/effects/spawners/random.dm
+++ b/code/game/objects/effects/spawners/random.dm
@@ -273,7 +273,7 @@
 				prob(4);/obj/item/clothing/glasses/thermal/monocle,\
 				prob(4);/obj/item/clothing/glasses/thermal/eyepatch,\
 				prob(4);/obj/item/clothing/glasses/welding/superior,\
-				prob(4);/obj/item/clothing/glasses/hud/security/jensenshades,\
+				prob(4);/obj/item/clothing/glasses/thermal/jensenshades,\
 				prob(4);/obj/item/clothing/glasses/meson/refurbished,\
 				prob(4);/obj/item/clothing/glasses/science,\
 				prob(4);/obj/item/clothing/glasses/hud/sensor,\

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -133,14 +133,3 @@
 	name = "\improper Prescription PatrolMate HUD"
 	desc = "A heads-up display that scans the humans in view and provides accurate data about their ID status and security records."
 	prescription = TRUE
-
-/obj/item/clothing/glasses/hud/security/jensenshades
-	name = "augmented shades"
-	gender = PLURAL
-	desc = "Polarized bioneural eyewear, designed to augment your vision. Why don't you try getting a job?"
-	icon_state = "jensenshades"
-	item_state = "jensenshades"
-	vision_flags = SEE_MOBS
-	invisa_view = 2
-	toggleable = FALSE
-	actions_types = list()

--- a/code/modules/clothing/glasses/thermal.dm
+++ b/code/modules/clothing/glasses/thermal.dm
@@ -70,6 +70,14 @@
 	item_state = "syringe_kit"
 	toggleable = FALSE
 
+/obj/item/clothing/glasses/thermal/jensenshades
+	name = "augmented shades"
+	gender = PLURAL
+	desc = "Polarized bioneural eyewear, designed to augment your vision. Why don't you try getting a job?"
+	icon_state = "jensenshades"
+	item_state = "jensenshades"
+	toggleable = FALSE
+
 /obj/item/clothing/glasses/thermal/empproof
 	desc = "Thermals in the shape of glasses. This one is EMP proof."
 	blinds_on_emp = FALSE


### PR DESCRIPTION
# About the pull request
JensenShades were a type of thermals that gave you see_mobs but not night vision, with the changes to lighting they don't work anymore as you now need light to see a mob through walls even if you have see_mobs.
this turns them into proper thermal glasses with night vision

# Explain why it's good for the game
bug bad
item works now

# Testing Photographs and Procedure
probably works

# Changelog
:cl:
fix: Jensenshades are now proper thermal glasses
/:cl:
