### PR TITLE
[s] Fix Tutorials

### DIFF
--- a/code/datums/tutorial/_tutorial_menu.dm
+++ b/code/datums/tutorial/_tutorial_menu.dm
@@ -71,7 +71,7 @@
 
 			path = text2path(params["tutorial_path"])
 
-			if(!path || !isnewplayer(usr))
+			if(!ispath(path, /datum/tutorial) || !isnewplayer(usr))
 				return
 
 			if(HAS_TRAIT(usr, TRAIT_IN_TUTORIAL) || istype(get_area(usr), /area/misc/tutorial))

--- a/code/datums/tutorial/xenomorph/xenomorph_basic.dm
+++ b/code/datums/tutorial/xenomorph/xenomorph_basic.dm
@@ -21,6 +21,7 @@
 	xeno.plasma_max = 0
 	xeno.melee_damage_lower = 40
 	xeno.melee_damage_upper = 40
+	xeno.lock_evolve = TRUE
 
 	message_to_player("Welcome to the Xenomorph basic tutorial. You are [xeno.name], a drone, the workhorse of the hive.")
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -316,7 +316,10 @@
 	hud_used.show_hud(hud_used.hud_version)
 
 /mob/dead/observer/Login()
-	..()
+	..() // This calls signals which might have resulted in our client getting deleted
+
+	if(!client)
+		return
 
 	if(client.check_whitelist_status(WHITELIST_PREDATOR))
 		RegisterSignal(SSdcs, COMSIG_GLOB_PREDATOR_ROUND_TOGGLED, PROC_REF(toggle_predator_action))

--- a/code/modules/mob/living/carbon/xenomorph/Evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Evolution.dm
@@ -211,7 +211,10 @@
 		return FALSE
 
 	if(lock_evolve)
-		to_chat(src, SPAN_WARNING("You are banished and cannot reach the hivemind."))
+		if(banished)
+			to_chat(src, SPAN_WARNING("We are banished and cannot reach the hivemind."))
+		else
+			to_chat(src, SPAN_WARNING("We can't evolve."))
 		return FALSE
 
 	if(jobban_isbanned(src, JOB_XENOMORPH))//~who so genius to do this is?
@@ -269,7 +272,10 @@
 		return
 
 	if(lock_evolve)
-		to_chat(src, SPAN_WARNING("We are banished and cannot reach the hivemind."))
+		if(banished)
+			to_chat(src, SPAN_WARNING("We are banished and cannot reach the hivemind."))
+		else
+			to_chat(src, SPAN_WARNING("We can't deevolve."))
 		return FALSE
 
 


### PR DESCRIPTION
# About the pull request

This PR fixes several issues with tutorials:
- Tutorial path was not guarded
- Xenomorph tutorial allowed evolution/de-evolution. For evolution this just caused runtimes. De-evolution would ghostize you weirdly (couldn't get sent to lobby).
- Ghosting when in a tutorial would throw a runtime because the observer Login would resume its call when a signal had already transferred the client to a newplayer mob.

# Explain why it's good for the game

Less runtimes and ⭐ funkyness ⭐ 

e.g. 

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/0667d66e-9531-49fb-8b96-f0dd82598473)
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/6617bc3a-a397-4cd3-9702-89b775b8cf30)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/02f8fab1-5650-4b9b-baa3-fa3d704b6ada)

</details>


# Changelog
:cl: Drathek
fix: Fixed xeno tutorial allowing evolution/de-evolution
fix: Fixed some runtimes with tutorials
/:cl:
