### PR TITLE
Fixes "Unbound" keybind slots sometimes not being removed

### DIFF
--- a/code/modules/client/tgui_macro.dm
+++ b/code/modules/client/tgui_macro.dm
@@ -101,6 +101,7 @@ GLOBAL_LIST_EMPTY(ui_data_keybindings)
 			prefs.save_preferences()
 			INVOKE_ASYNC(owner, /client/proc/set_macros)
 			return TRUE
+
 		if("clear_keybind")
 			var/list/kbinds = prefs.key_bindings
 			var/kb_name = params["keybinding"]
@@ -111,13 +112,15 @@ GLOBAL_LIST_EMPTY(ui_data_keybindings)
 			for(var/key in keys)
 				if(kbinds[key])
 					kbinds[key] -= kb_name
-					kbinds["Unbound"] += kb_name
 					if(!length(kbinds[key]))
 						kbinds -= key
+			// Add the keybind name to the 'unbound' list if it's not already in there.
+			kbinds["Unbound"] |= kb_name
 
 			prefs.save_preferences()
 			INVOKE_ASYNC(owner, /client/proc/set_macros)
 			return TRUE
+
 		if("clear_all_keybinds")
 			var/choice = tgui_alert(owner, "Would you prefer 'hotkey' or 'classic' defaults?", "Setup keybindings", list("Hotkey", "Classic", "Cancel"))
 			if(choice == "Cancel")


### PR DESCRIPTION

# About the pull request

Fixes keybinds sometimes getting 'Unbound' slots permanently stuck to them.
This was caused by the `"clear_keybind"` act code adding the keybind to the `"Unbound"` list for every key assigned to the keybind, rather than just once.
(I can't really explain this very well but there's an example video below)

# Explain why it's good for the game

It doesn't actually change the keybind's behaviour at all, but it's a bit weird to have an extra unremovable "Unbound" slot on some keybinds.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

**Before:**

https://github.com/cmss13-devs/cmss13/assets/57483089/73d9749b-239a-48b4-b85b-fb03219b370e

**After:**

https://github.com/cmss13-devs/cmss13/assets/57483089/7a33b93e-a776-49ef-a81c-0c4be87c9d7f

</details>


# Changelog
:cl:
fix: Fixed the 'Clear' button not resetting the number of keybind assignment slots. (Keybinds menu)
/:cl:
