### PR TITLE
Makes drone castes be able to destroy special resin buildings faster; enables destruction from roundstart

### DIFF
--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -94,7 +94,12 @@
 		else
 			playsound(loc, "alien_resin_break", 25)
 
-		health -= (M.melee_damage_upper + 50) //Beef up the damage a bit
+		var/damage_to_structure = M.melee_damage_upper + XENO_DAMAGE_TIER_7
+		// Builders can destroy beefy things in maximum 5 hits
+		if(isxeno_builder(M))
+			health -= max(initial(health) * 0.2, damage_to_structure)
+		else
+			health -= damage_to_structure
 		healthcheck()
 	return XENO_ATTACK_ACTION
 

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -12,7 +12,7 @@
 	var/egg_planting_range = 15
 	var/slashing_allowed = XENO_SLASH_ALLOWED //This initial var allows the queen to turn on or off slashing. Slashing off means harm intent does much less damage.
 	var/construction_allowed = NORMAL_XENO //Who can place construction nodes for special structures
-	var/destruction_allowed = XENO_LEADER //Who can destroy special structures
+	var/destruction_allowed = NORMAL_XENO //Who can destroy special structures
 	var/unnesting_allowed = TRUE
 	var/hive_orders = "" //What orders should the hive have
 	var/color = null


### PR DESCRIPTION
# About the pull request

1. All xenomorph hives except for ferals now start with special resin structure destruction enabled for leaders AND builders (all drone castes), instead of leaders only.
2. Builders can now destroy every special resin structure with a maximum of 5 hits.

# Explain why it's good for the game

1. All xenomorph hives except for ferals now start with special resin structure destruction enabled for leaders AND builders (all drone castes), instead of leaders only.

**Why**: This is an old, leftover restriction from back when people actively griefed destroying stuff and the hive had no hive-wide announcements for it. Now it just devolved into "queen plz allow special deconstruction" every single round drone castes try to move things around. It is tiresome for both builders and the queen to always enable this.

2. Builders can now destroy every special resin structure with a maximum of 5 hits.

**Why**: Most often drones and hivelords are sicced on destroying backline clusters/recovery nodes, since xenos have a limited amount of special structures they can build. Here are the number of hits you needed before to destroy them:

| name | health | # of drone hits | # of carrier hits | # of burrower hits | # hivelord hits |
| --- | --- | --- | --- | --- | --- | 
| hive cluster | 1200 | 16 | 15 | 15 | 16 |
| recovery node | 400 | 6 | 5 | 5 | 6 |
| egg morpher | 300 | 4 | 4 | 4 | 4 |

It is soul-killing to hit things 15-16 times for it to get destroyed. Factor in the extra hits when one has to destroy a cluster _and_ recovery nodes and you can quickly see why this is not fun.

This part of the code:

```
		var/damage_to_structure = M.melee_damage_upper + XENO_DAMAGE_TIER_7
		// Builders can destroy beefy things in maximum 5 hits
		if(isxeno_builder(M))
			health -= max(initial(health) * 0.2, damage_to_structure)
		else
			health -= damage_to_structure
```

ensures that if your melee damage is higher than the 1/5th of the special structure's max health, you will deal your melee damage instead. This way, you can still destroy egg morphers in only 4 hits, as opposed to 5.

# Testing Photographs and Procedure

1. Spawn in a cluster, recovery node, and an egg morpher
2. Slash them and observe the health change

# Changelog

:cl:
tweak: Xenomorph special structure deconstruction is now enabled for leaders and builders from roundstart instead of leaders only, except for feral hives.
qol: Drone castes can now destroy clusters and recovery nodes with a maximum of 5 hits (instead of 15-16 and 6, respectively).
/:cl:
