### PR TITLE
Fixes ammo magazine checking with helmet if the mag is exactly half full

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -476,10 +476,10 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 /obj/item/clothing/head/helmet/marine/attackby(obj/item/attacking_item, mob/user)
 	if(istype(attacking_item, /obj/item/ammo_magazine) && world.time > helmet_bash_cooldown && user)
 		var/obj/item/ammo_magazine/M = attacking_item
-		var/ammo_level = "somewhat"
+		var/ammo_level = "more than half full."
 		playsound(user, 'sound/items/trayhit1.ogg', 15, FALSE)
-		if(M.current_rounds > (M.max_rounds/2))
-			ammo_level = "more than half full."
+		if(M.current_rounds == (M.max_rounds/2))
+			ammo_level = "half full."
 		if(M.current_rounds < (M.max_rounds/2))
 			ammo_level = "less than half full."
 		if(M.current_rounds < (M.max_rounds/6))


### PR DESCRIPTION
# About the pull request

Hitting an ammo magazine against your helmet had a faulty examine text if the mag had exactly half of its capacity.

Fixes #5714 

# Explain why it's good for the game

Not having cut off text in the game is

# Testing Photographs and Procedure

Here:

<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/49321394/ca96275f-e3ea-4530-8965-5cb39b62cf10)

![image](https://github.com/cmss13-devs/cmss13/assets/49321394/f0f54765-f1e4-44c7-9b9e-7161b2a8103c)

![image](https://github.com/cmss13-devs/cmss13/assets/49321394/0014c882-65b7-4311-ad6a-263d7a7f1c31)

![image](https://github.com/cmss13-devs/cmss13/assets/49321394/a46c3d73-ce04-4e95-8787-e3a172daa444)

![image](https://github.com/cmss13-devs/cmss13/assets/49321394/9bda789a-3f33-41ee-a0e7-777c8200b814)

</details>


# Changelog

:cl:
fix: Fixes a missing examine text when you hit an exactly half-full ammo magazine against your helmet.
/:cl:
