### PR TITLE
Allow surgery on select tiles on lifeboats

### DIFF
--- a/maps/shuttles/lifeboat-port.dmm
+++ b/maps/shuttles/lifeboat-port.dmm
@@ -239,6 +239,11 @@
 	},
 /turf/template_noop,
 /area/shuttle/lifeboat)
+"BZ" = (
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
+/area/shuttle/lifeboat)
 "Ct" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/machinery/computer/shuttle/lifeboat{
@@ -533,7 +538,7 @@ fr
 Rs
 Id
 jX
-nn
+BZ
 Ro
 iR
 vZ
@@ -542,7 +547,7 @@ vZ
 mB
 PU
 yf
-nn
+BZ
 Ro
 OX
 tI
@@ -603,7 +608,7 @@ xS
 "}
 (15,1,1) = {"
 Nm
-dt
+Ro
 Ro
 Jg
 Ro

--- a/maps/shuttles/lifeboat-port.dmm
+++ b/maps/shuttles/lifeboat-port.dmm
@@ -608,7 +608,7 @@ xS
 "}
 (15,1,1) = {"
 Nm
-Ro
+dt
 Ro
 Jg
 Ro

--- a/maps/shuttles/lifeboat-starboard.dmm
+++ b/maps/shuttles/lifeboat-starboard.dmm
@@ -95,6 +95,11 @@
 /obj/structure/bed/chair/dropship/passenger/shuttle_chair,
 /turf/open/shuttle/lifeboat,
 /area/shuttle/lifeboat)
+"ly" = (
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
+/area/shuttle/lifeboat)
 "lK" = (
 /turf/closed/shuttle/lifeboat{
 	icon_state = "22,0"
@@ -533,7 +538,7 @@ iP
 em
 kC
 ix
-XV
+ly
 OO
 zK
 Ow
@@ -542,7 +547,7 @@ Ow
 GA
 Td
 GQ
-XV
+ly
 OO
 GD
 ho


### PR DESCRIPTION
# About the pull request

Allows Surgery on select tiles on Lifeboats only. 

Video demonstrates test. 

# Explain why it's good for the game

Once life boats are "away" successfully, there is no way to do surgery on IB. 
If crash landed, still no surgery. 

I get that "if it's flying, you can't surgery." but these aren't moving up and down a combat zone. they're either stationary, crashing, or safely away. 

I limited it to two tiles. Figured that's enough. 
I also put it in the back of the boat so it's more risky being far from lifeboat controls so if they're coming, you gotta run and you'll be seen. 
Also thematic sense that the pilot needs to fly, not be concerned about blood and stuff.

Made the tiles white for visual distinction so it's very obvious that "these are surgery tiles" instead of dealing with "oh yeah, THIS tile is the one you can operate on." 

# Testing Photographs and Procedure

put tiles down. Made sure I could do surgery. made sure I couldn't do surgery if patient was not on said tile. 

<details>
<summary>Screenshots & Videos</summary>

Same video. 
https://youtu.be/rwDW8lstr1Y

https://www.youtube.com/watch?v=rwDW8lstr1Y

</details>


# Changelog

:cl:
qol: Allows surgery on specific tiles on lifeboats. 
/:cl:

