### PR TITLE
Combat Technician Prep Nailgun: Option 1

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_engineer.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_engineer.dm
@@ -206,5 +206,5 @@ GLOBAL_LIST_INIT(cm_vending_clothing_engi, list(
 		/obj/item/stack/sheet/plasteel/medium_stack,
 		/obj/item/cell/high,
 		/obj/item/tool/shovel/etool/folded,
-		/obj/item/device/lightreplacer,
+		/obj/item/weapon/gun/smg/nailgun,
 	)

--- a/code/game/objects/structures/barricade/barricade.dm
+++ b/code/game/objects/structures/barricade/barricade.dm
@@ -461,7 +461,7 @@
 	update_health(-repair_value*maxhealth)
 	to_chat(user, SPAN_WARNING("You nail [material] to [src], restoring some of its integrity!"))
 	update_damage_state()
-	material.use(1)
+	material.use(4)
 	nailgun.current_mag.current_rounds -= 3
 	nailgun.in_chamber = null
 	nailgun.load_into_chamber()

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -9,7 +9,7 @@
 	var/hull = 0
 	var/walltype = WALL_METAL
 	/// when walls smooth with one another, the type of junction each wall is.
-	var/junctiontype 
+	var/junctiontype
 	var/thermite = 0
 	var/melting = FALSE
 	var/claws_minimum = CLAW_TYPE_SHARP
@@ -24,7 +24,7 @@
 
 	var/damage = 0
 	/// Wall will break down to girders if damage reaches this point
-	var/damage_cap = HEALTH_WALL 
+	var/damage_cap = HEALTH_WALL
 
 	var/damage_overlay
 	var/global/damage_overlays[8]
@@ -38,7 +38,7 @@
 	var/d_state = 0 //Normal walls are now as difficult to remove as reinforced walls
 
 	/// the acid hole inside the wall
-	var/obj/effect/acid_hole/acided_hole 
+	var/obj/effect/acid_hole/acided_hole
 	var/acided_hole_dir = SOUTH
 
 	var/special_icon = 0
@@ -553,7 +553,7 @@
 		to_chat(user, SPAN_WARNING("You need [amount_needed] sheets of material to fix this!"))
 		return FALSE
 
-	for(var/i = 1 to amount_needed)
+	for(var/i = 4 to amount_needed)
 		var/soundchannel = playsound(src, NG.repair_sound, 25, 1)
 		if(!do_after(user, NG.nailing_speed, INTERRUPT_ALL, BUSY_ICON_FRIENDLY, src))
 			playsound(src, null, channel = soundchannel)


### PR DESCRIPTION
# About the pull request
The purpose of this PR to replace the antiquated light replacer in engi prep with the far more useful nailgun.
<!-- Remove this text and explain what the purpose of your PR is.
Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

1. The light replacer being essential for engineers is a vestigal feature from ~2016, majority of maps no longer use the base game light fixtures as often as back then. 

2. This replaces it with a nailgun, which allows engineers to do emergency repairs to take cades out of a critical unrepairable state. This is a far more useful feature than the light replacer in the current state of the game.

3. To compensate the increased availability, the metal sheets required to repair a cade is increased from one to four.

4. The nailgun now serves as a QoL for engineers, rather than having to wait for a critical cade to be destroyed or go through the process of deconstructing it, they can now use the nailgun to "save" the cade. This effectively means the engis can bypass the time & danger needed to construct a new cade, but still costing the same amount in materials.

OPTION 1: Replaces light replacer, increases the mats required for repair.
OPTION 2: Adds the nailgun as a purchasable item to engi prep. No balance change.

Numbers are subject to change as needed.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>
</details>


# Changelog

:cl:
NervanCatos
qol: Replaces light replacer with nailgun in engi prep
balance: nailgun now requires four metal to save a barricade
/:cl:

