### PR TITLE
Temporary mute now also prevents hive death messages

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -159,6 +159,8 @@
 #define TRAIT_DAZED "dazed"
 /// Apply this to identify a mob as merged with weeds
 #define TRAIT_MERGED_WITH_WEEDS "merged_with_weeds"
+/// Apply this to identify a mob as temporarily muted
+#define TRAIT_TEMPORARILY_MUTED "temporarily_muted"
 
 // SPECIES TRAITS
 /// Knowledge of Yautja technology
@@ -422,6 +424,8 @@ GLOBAL_LIST(trait_name_map)
 ///Status trait coming from ability
 #define TRAIT_SOURCE_ABILITY(ability) "t_s_ability_[ability]"
 #define TRAIT_SOURCE_LIMB(limb) "t_s_limb_[limb]"
+///Status trait coming from temporary_mute
+#define TRAIT_SOURCE_TEMPORARY_MUTE "t_s_temporary_mute"
 ///Status trait forced by the xeno action charge
 #define TRAIT_SOURCE_XENO_ACTION_CHARGE "t_s_xeno_action_charge"
 ///Status trait coming from a xeno nest

--- a/code/datums/components/temporary_mute.dm
+++ b/code/datums/components/temporary_mute.dm
@@ -27,6 +27,7 @@
 	RegisterSignal(parent, COMSIG_XENO_TRY_HIVEMIND_TALK, PROC_REF(on_hivemind))
 	RegisterSignal(parent, COMSIG_MOB_TRY_EMOTE, PROC_REF(on_emote))
 	RegisterSignal(parent, COMSIG_MOB_TRY_POINT, PROC_REF(on_point))
+	ADD_TRAIT(parent, TRAIT_TEMPORARILY_MUTED, TRAIT_SOURCE_TEMPORARY_MUTE)
 
 /datum/component/temporary_mute/UnregisterFromParent()
 	..()
@@ -37,6 +38,7 @@
 		UnregisterSignal(parent, COMSIG_MOB_TRY_POINT)
 		if(on_unmute_message)
 			to_chat(parent, SPAN_NOTICE(on_unmute_message))
+		REMOVE_TRAIT(parent, TRAIT_TEMPORARILY_MUTED, TRAIT_SOURCE_TEMPORARY_MUTE)
 
 /datum/component/temporary_mute/proc/on_speak(
 	mob/user,

--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -84,7 +84,8 @@
 			playsound(loc, prob(50) == 1 ? 'sound/voice/alien_death.ogg' : 'sound/voice/alien_death2.ogg', 25, 1)
 		var/area/A = get_area(src)
 		if(hive && hive.living_xeno_queen)
-			xeno_message("Hive: [src] has <b>died</b>[A? " at [sanitize_area(A.name)]":""]! [banished ? "They were banished from the hive." : ""]", death_fontsize, hivenumber)
+			if(!HAS_TRAIT(src, TRAIT_TEMPORARILY_MUTED))
+				xeno_message("Hive: [src] has <b>died</b>[A? " at [sanitize_area(A.name)]":""]! [banished ? "They were banished from the hive." : ""]", death_fontsize, hivenumber)
 
 	if(hive && IS_XENO_LEADER(src)) //Strip them from the Xeno leader list, if they are indexed in here
 		hive.remove_hive_leader(src)


### PR DESCRIPTION

# About the pull request

This PR is a followup to #5688 to additionally prevent death messages getting sent to the hive during the temporary mute time.

# Explain why it's good for the game

Ultimately this is to quell more concerns with ghosts using meta knowledge of say a flank approaching and throwing themselves at that flank and informing the hive of the flank via their death message location.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/76988376/8b8426bd-8f82-43f6-bb70-a91346c47534

</details>


# Changelog
:cl: Drathek
del: Removed death messages for lesser drones and facehuggers that are still temporarily muted
/:cl:
