### PR TITLE
Correct Vampire Lurker Strain Damage Modifications

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/lurker/vampire.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/lurker/vampire.dm
@@ -21,8 +21,7 @@
 	lurker.health_modifier -= XENO_HEALTH_MOD_MED
 	lurker.speed_modifier += XENO_SPEED_FASTMOD_TIER_1
 	lurker.armor_modifier += XENO_ARMOR_MOD_LARGE
-	lurker.melee_damage_lower = XENO_DAMAGE_TIER_3
-	lurker.melee_damage_upper = XENO_DAMAGE_TIER_3
+	lurker.damage_modifier -= XENO_DAMAGE_MOD_VERY_SMALL
 	lurker.attack_speed_modifier -= 2
 
 	lurker.recalculate_everything()


### PR DESCRIPTION

# About the pull request

This PR corrects an erroneous change in `apply_strain` because only modifiers can be set here. The change to lower the damage tier would be undone when `recalculate_damage` would apply the lurker caste's values for the upper and lower damage values.

Ultimately I'm not certain it does need the damage reduction - but as of #5625 it does more with direct tail stabs so between the two this should be a minor nerf.

# Explain why it's good for the game

Corrects an intended reduction in damage for taking the strain.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

# Changelog
:cl: Drathek
balance: Corrected vampire lurker damage values (Effectively reduction by 5 damage for most attacks)
/:cl:
