### PR TITLE
Fix CMB ERT & Path Based ERT Calling

### DIFF
--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -105,13 +105,6 @@
 		em_call.activate(quiet_launch, announce_incoming)
 		return
 
-	for(var/datum/emergency_call/cur_em_call as anything in all_calls) //Loop through all potential candidates
-		if(cur_em_call.name == call_name)
-			var/datum/emergency_call/em_call = new cur_em_call.type()
-			em_call.objective_info = info
-			em_call.activate(quiet_launch, announce_incoming)
-			return
-
 	error("get_specific_call could not find emergency call '[call_name]'")
 	return
 

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -92,12 +92,26 @@
 		return chosen_call
 
 /datum/game_mode/proc/get_specific_call(call_name, quiet_launch = FALSE, announce_incoming = TRUE, info = "")
-	for(var/datum/emergency_call/E in all_calls) //Loop through all potential candidates
-		if(E.name == call_name)
-			var/datum/emergency_call/em_call = new E.type()
+	if(ispath(call_name, /datum/emergency_call))
+		var/datum/emergency_call/em_call = new call_name
+		em_call.objective_info = info
+		em_call.activate(quiet_launch, announce_incoming)
+		return
+
+	var/call_path = text2path(call_name)
+	if(ispath(call_path, /datum/emergency_call))
+		var/datum/emergency_call/em_call = new call_path
+		em_call.objective_info = info
+		em_call.activate(quiet_launch, announce_incoming)
+		return
+
+	for(var/datum/emergency_call/cur_em_call in all_calls) //Loop through all potential candidates
+		if(cur_em_call.name == call_name)
+			var/datum/emergency_call/em_call = new cur_em_call.type()
 			em_call.objective_info = info
 			em_call.activate(quiet_launch, announce_incoming)
 			return
+
 	error("get_specific_call could not find emergency call '[call_name]'")
 	return
 

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -105,7 +105,7 @@
 		em_call.activate(quiet_launch, announce_incoming)
 		return
 
-	for(var/datum/emergency_call/cur_em_call in all_calls) //Loop through all potential candidates
+	for(var/datum/emergency_call/cur_em_call as anything in all_calls) //Loop through all potential candidates
 		if(cur_em_call.name == call_name)
 			var/datum/emergency_call/em_call = new cur_em_call.type()
 			em_call.objective_info = info

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -265,7 +265,7 @@
 			continue
 
 	if(groundside_humans > (groundside_xenos * GROUNDSIDE_XENO_MULTIPLIER))
-		SSticker.mode.get_specific_call("Xenomorphs Groundside (Forsaken)", TRUE, FALSE)
+		SSticker.mode.get_specific_call(/datum/emergency_call/forsaken_xenos, TRUE, FALSE) // "Xenomorphs Groundside (Forsaken)"
 
 	TIMER_COOLDOWN_START(src, COOLDOWN_HIJACK_GROUND_CHECK, 1 MINUTES)
 

--- a/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
+++ b/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
@@ -194,7 +194,7 @@
 	announce_xeno_wave(wave)
 	if(xeno_wave == 7)
 		//Wave when Marines get reinforcements!
-		get_specific_call("Marine Reinforcements (Squad)", FALSE, TRUE)
+		get_specific_call(/datum/emergency_call/wo, FALSE, TRUE) // "Marine Reinforcements (Squad)"
 	xeno_wave = min(xeno_wave + 1, WO_MAX_WAVE)
 
 

--- a/code/game/objects/items/handheld_distress_beacon.dm
+++ b/code/game/objects/items/handheld_distress_beacon.dm
@@ -12,9 +12,9 @@
 	///Tells the user who the beacon will be sent to IC
 	var/recipient = "the USCSS Royce"
 	///The name of the ERT that will be passed to get_specific_call
-	var/list/ert_full_name = list("Weyland-Yutani PMC (Chemical Investigation Squad)")
+	var/list/ert_paths = list(/datum/emergency_call/pmc/chem_retrieval) // "Weyland-Yutani PMC (Chemical Investigation Squad)"
 	///The clickable version that will be sent in message_admins
-	var/list/ert_short_name = list("SEND PMCs")
+	var/list/ert_short_names = list("SEND PMCs")
 	///Whether beacon can be used, or has already been used
 	var/active = FALSE
 
@@ -41,13 +41,13 @@
 	active = TRUE
 	update_icon()
 
-	if(!ert_full_name || !ert_short_name || (length(ert_full_name) != length(ert_short_name))) //Make sure they are greater than 0, and both are same length
+	if(!ert_paths || !ert_short_names || (length(ert_paths) != length(ert_short_names))) //Make sure they are greater than 0, and both are same length
 		to_chat(user, SPAN_BOLDWARNING("[src] is broken!"))
 		CRASH("[src] was improperly set, and has been disabled.") //For the runtime logs
 
 	var/beacon_call_buttons
-	for(var/current_ert_num in 1 to length(ert_full_name))
-		beacon_call_buttons += "(<A HREF='?_src_=admin_holder;[HrefToken(forceGlobal = TRUE)];distress_handheld=\ref[user];ert_name=[ert_full_name[current_ert_num]]'>[ert_short_name[current_ert_num]]</A>) "
+	for(var/current_ert_num in 1 to length(ert_paths))
+		beacon_call_buttons += "(<A HREF='?_src_=admin_holder;[HrefToken(forceGlobal = TRUE)];distress_handheld=\ref[user];ert_name=[ert_paths[current_ert_num]]'>[ert_short_names[current_ert_num]]</A>) "
 
 	for(var/client/admin_client in GLOB.admins)
 		if((R_ADMIN|R_MOD) & admin_client.admin_holder.rights)
@@ -62,8 +62,9 @@
 
 	beacon_type = "CMB beacon"
 	recipient = "Anchorpoint Station"
-	ert_full_name = list("CMB - Patrol Team - Marshals in Distress (Friendly)", "CMB - Anchorpoint Station Colonial Marine QRF (Friendly)")
-	ert_short_name = list("SEND CMB", "SEND QRF")
+	// "CMB - Patrol Team - Marshals in Distress (Friendly)", "CMB - Anchorpoint Station Colonial Marine QRF (Friendly)"
+	ert_paths = list(/datum/emergency_call/cmb/alt, /datum/emergency_call/cmb/anchorpoint)
+	ert_short_names = list("SEND CMB", "SEND QRF")
 
 // Corporate Lawyer beacon available for 50 points at the CLs briefcase
 /obj/item/handheld_distress_beacon/lawyer
@@ -72,8 +73,8 @@
 
 	beacon_type = "Lawyer beacon"
 	recipient = "the Corporate Affairs Division"
-	ert_full_name = list("Lawyers - Corporate")
-	ert_short_name = list("SEND LAWYERS")
+	ert_paths = list(/datum/emergency_call/inspection_wy/lawyer) // "Lawyers - Corporate"
+	ert_short_names = list("SEND LAWYERS")
 
 // Corporate Security Bodyguard beacon available for 50 points at the CLs briefcase
 /obj/item/handheld_distress_beacon/bodyguard
@@ -82,5 +83,5 @@
 
 	beacon_type = "Bodyguard beacon"
 	recipient = "the Corporate Security Division"
-	ert_full_name = list("Weyland-Yutani Goon (Executive Bodyguard Detail)")
-	ert_short_name = list("SEND BODYGUARD")
+	ert_paths = list(/datum/emergency_call/goon/bodyguard) // "Weyland-Yutani Goon (Executive Bodyguard Detail)"
+	ert_short_names = list("SEND BODYGUARD")

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -1277,7 +1277,7 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 
 /datum/controller/supply/proc/black_market_investigation()
 	black_market_heat = -1
-	SSticker.mode.get_specific_call("Inspection - Colonial Marshal Ledger Investigation Team", TRUE, TRUE)
+	SSticker.mode.get_specific_call(/datum/emergency_call/inspection_cmb/black_market, TRUE, TRUE) // "Inspection - Colonial Marshals Ledger Investigation Team"
 	log_game("Black Market Inspection auto-triggered.")
 
 /obj/structure/machinery/computer/supplycomp/proc/is_buyable(datum/supply_packs/supply_pack)

--- a/code/modules/cm_tech/techs/marine/tier3/cryo_spec.dm
+++ b/code/modules/cm_tech/techs/marine/tier3/cryo_spec.dm
@@ -21,4 +21,4 @@
 
 /datum/tech/cryomarine/on_unlock()
 	. = ..()
-	SSticker.mode.get_specific_call("Marine Cryo Reinforcement (Spec)", TRUE, FALSE)
+	SSticker.mode.get_specific_call(/datum/emergency_call/cryo_spec, TRUE, FALSE) // "Marine Cryo Reinforcement (Spec)"

--- a/code/modules/cm_tech/techs/marine/tier3/cryorine.dm
+++ b/code/modules/cm_tech/techs/marine/tier3/cryorine.dm
@@ -23,4 +23,4 @@
 
 /datum/tech/repeatable/cryomarine/on_unlock()
 	. = ..()
-	SSticker.mode.get_specific_call("Marine Cryo Reinforcements (Tech)", TRUE, FALSE)
+	SSticker.mode.get_specific_call(/datum/emergency_call/cryo_squad/tech, TRUE, FALSE) // "Marine Cryo Reinforcements (Tech)"

--- a/code/modules/reagents/chemistry_properties/prop_special.dm
+++ b/code/modules/reagents/chemistry_properties/prop_special.dm
@@ -96,7 +96,7 @@
 		H.contract_disease(new /datum/disease/xeno_transformation(0),1) //This is the real reason PMCs are being sent to retrieve it.
 
 /datum/chem_property/special/DNA_Disintegrating/trigger()
-	SSticker.mode.get_specific_call("Weyland-Yutani Goon (Chemical Investigation Squad)", TRUE, FALSE, holder.name)
+	SSticker.mode.get_specific_call(/datum/emergency_call/goon/chem_retrieval, TRUE, FALSE, holder.name) // "Weyland-Yutani Goon (Chemical Investigation Squad)"
 	GLOB.chemical_data.update_credits(10)
 	message_admins("The research department has discovered DNA_Disintegrating in [holder.name] adding 10 bonus tech points.")
 	var/datum/techtree/tree = GET_TREE(TREE_MARINE)


### PR DESCRIPTION
# About the pull request

This PR fixes the black market CMB automatic ERT and makes get_specific_call ~~more flexible and~~ efficient.

# Explain why it's good for the game

Fixes `## ERROR: get_specific_call could not find emergency call 'Inspection - Colonial Marshal Ledger Investigation Team'` caused by a grammar fix from Marshal to Marshals. This should generally be harder to cause since the call can now only be called via a path.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![1](https://github.com/cmss13-devs/cmss13/assets/76988376/2beff6de-ea6a-40bd-b4e8-7c13ed618308)
![2](https://github.com/cmss13-devs/cmss13/assets/76988376/4dbd1ba2-6782-4849-87ba-fef0ae57121b)
![4](https://github.com/cmss13-devs/cmss13/assets/76988376/58d5017e-9ebf-4d93-86b5-de0428b5e7bb)
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/74d47e01-5d7c-4fd2-b02e-6ee32d57e357)
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/acd80c2f-100a-41cc-8401-b1803a04ad7d)

</details>


# Changelog
:cl: Drathek
fix: Fixed automatic CMB ERT caused by black market heat
code: get_specific_call now only accepts a path or a string of a path
/:cl:
