### PR TITLE
Distress beacon response messages now have a chance of being static

### DIFF
--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -28,6 +28,10 @@
 	var/mob_min = 3
 	var/dispatch_message = "An encrypted signal has been received from a nearby vessel. Stand by." //Msg to display when starting
 	var/arrival_message = "" //Msg to display about when the shuttle arrives
+	/// Probability that the message will be replaced with static. - prob(chance_hidden)
+	var/chance_hidden = 20
+	/// Message to display when distress beacon is hidden
+	var/static_message = "**STATIC** %$#&!- *!%^#$$ ^%%$# +_!@* &*%$## **STATIC** &%$#^*! @!*%$# ^%&$#@ *%&$#^ **STATIC** --SIGNAL LOST"
 	var/objectives //Txt of objectives to display to joined. Todo: make this into objective notes
 	var/objective_info //For additional info in the objectives txt
 	var/probability = 0
@@ -305,7 +309,10 @@
 
 	candidates = list()
 	if(arrival_message && announce_incoming)
-		marine_announcement(arrival_message, "Intercepted Transmission:")
+		if(prob(chance_hidden))
+			marine_announcement(static_message, "Intercepted Transmission:")
+		else
+			marine_announcement(arrival_message, "Intercepted Transmission:")
 
 /datum/emergency_call/proc/add_candidate(mob/M)
 	if(!M.client || (M.mind && (M.mind in candidates)) || istype(M, /mob/living/carbon/xenomorph))


### PR DESCRIPTION

# About the pull request

Revives this PR. https://github.com/cmss13-devs/cmss13/pull/5393

Adds a probability of (20) for the distress beacon response message to be full of static and therefore not decipherable.

# Explain why it's good for the game

Part of the fun of distress beacons was not knowing who's going to show up to your door. This brings that back, to an extent. Less of 'Oh no it's hostile UPP!!' over radio as soon as distress is received.


# Changelog
:cl:
add: Implemented a probability of playing a static-filled transmission as the distress received response.
/:cl:
