### PR TITLE
Increase repeated weed expansion delay for the same tile

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_abilities.dm
@@ -38,7 +38,7 @@
 
 	var/node_plant_cooldown = 7 SECONDS
 	var/node_plant_plasma_cost = 300
-	var/turf_build_cooldown = 7 SECONDS
+	var/turf_build_cooldown = 10 SECONDS
 
 /datum/action/xeno_action/onclick/manage_hive
 	name = "Manage The Hive"


### PR DESCRIPTION

# About the pull request

This PR tweaks the delay required to expand weeds to the same tile. As in when a marine destroys weeds a queen just expanded, she must wait this much delay to spread it to that location again.

# Explain why it's good for the game

Disincentives using weeds next to marines slightly

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
balance: Increased same tile weed expansion delay for queen from 7s to 10s
/:cl:
