### PR TITLE
Fixes xeno tacklestrength

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -839,6 +839,8 @@
 	tackle_min = caste.tackle_min
 	tackle_max = caste.tackle_max
 	tackle_chance = caste.tackle_chance + tackle_chance_modifier
+	tacklestrength_min = caste.tacklestrength_min
+	tacklestrength_max = caste.tacklestrength_max
 
 /mob/living/carbon/xenomorph/proc/recalculate_health()
 	var/new_max_health = nocrit ? health_modifier + maxHealth : health_modifier + caste.max_health


### PR DESCRIPTION
# About the pull request

Fixes #5765.
This was caused by me in #5542 deleting a couple of lines from `/mob/living/carbon/xenomorph/proc/recalculate_tackle()`, when I should have only removed the `mutators`/`hive.mutators` part.

![image](https://github.com/cmss13-devs/cmss13/assets/57483089/b54a3e03-03cd-49a3-a093-ab0765059a7b)

# Explain why it's good for the game

Whoops

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

`tacklestrength_min` and `tacklestrength_max` are being applied correctly:
![image](https://github.com/cmss13-devs/cmss13/assets/57483089/8404ddf3-17e0-42a5-a3cf-91a85beb1e50)

</details>


# Changelog
:cl:
fix: Fixed Xenomorphs not having their caste's tackle duration values applied to them.
/:cl:
