### PR TITLE
Relay Ping Browser

### DIFF
--- a/code/controllers/configuration/config_entry.dm
+++ b/code/controllers/configuration/config_entry.dm
@@ -137,6 +137,7 @@
 	var/key_mode
 	var/value_mode
 	var/splitter = " "
+	var/to_lower_keys = TRUE
 
 /datum/config_entry/keyed_list/New()
 	. = ..()
@@ -153,7 +154,9 @@
 	var/key_value = null
 
 	if(key_pos || value_mode == VALUE_MODE_FLAG)
-		key_name = lowertext(copytext(str_val, 1, key_pos))
+		key_name = copytext(str_val, 1, key_pos)
+		if(to_lower_keys)
+			key_name = lowertext(key_name)
 		if(key_pos)
 			key_value = copytext(str_val, key_pos + length(str_val[key_pos]))
 		var/new_key

--- a/code/controllers/configuration/config_entry.dm
+++ b/code/controllers/configuration/config_entry.dm
@@ -4,6 +4,7 @@
 
 #define KEY_MODE_TEXT 0
 #define KEY_MODE_TYPE 1
+#define KEY_MODE_TEXT_UNALTERED 2
 
 /datum/config_entry
 	var/name //read-only, this is determined by the last portion of the derived entry type
@@ -137,7 +138,6 @@
 	var/key_mode
 	var/value_mode
 	var/splitter = " "
-	var/to_lower_keys = TRUE
 
 /datum/config_entry/keyed_list/New()
 	. = ..()
@@ -155,7 +155,7 @@
 
 	if(key_pos || value_mode == VALUE_MODE_FLAG)
 		key_name = copytext(str_val, 1, key_pos)
-		if(to_lower_keys)
+		if(key_mode != KEY_MODE_TEXT_UNALTERED)
 			key_name = lowertext(key_name)
 		if(key_pos)
 			key_value = copytext(str_val, key_pos + length(str_val[key_pos]))
@@ -164,7 +164,7 @@
 		var/continue_check_value
 		var/continue_check_key
 		switch(key_mode)
-			if(KEY_MODE_TEXT)
+			if(KEY_MODE_TEXT, KEY_MODE_TEXT_UNALTERED)
 				new_key = key_name
 				continue_check_key = new_key
 			if(KEY_MODE_TYPE)

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -629,3 +629,16 @@ This maintains a list of ip addresses that are able to bypass topic filtering.
 /datum/config_entry/flag/guest_ban
 
 /datum/config_entry/flag/auto_profile
+
+/// Relay Ping Browser configuration
+/datum/config_entry/keyed_list/connection_relay_ping
+	splitter = "|"
+	key_mode = KEY_MODE_TEXT
+	value_mode = VALUE_MODE_TEXT
+	to_lower_keys = FALSE
+
+/datum/config_entry/keyed_list/connection_relay_con
+	splitter = "|"
+	key_mode = KEY_MODE_TEXT
+	value_mode = VALUE_MODE_TEXT
+	to_lower_keys = FALSE

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -633,12 +633,10 @@ This maintains a list of ip addresses that are able to bypass topic filtering.
 /// Relay Ping Browser configuration
 /datum/config_entry/keyed_list/connection_relay_ping
 	splitter = "|"
-	key_mode = KEY_MODE_TEXT
+	key_mode = KEY_MODE_TEXT_UNALTERED
 	value_mode = VALUE_MODE_TEXT
-	to_lower_keys = FALSE
 
 /datum/config_entry/keyed_list/connection_relay_con
 	splitter = "|"
-	key_mode = KEY_MODE_TEXT
+	key_mode = KEY_MODE_TEXT_UNALTERED
 	value_mode = VALUE_MODE_TEXT
-	to_lower_keys = FALSE

--- a/code/modules/tgui_panel/ping_relay.dm
+++ b/code/modules/tgui_panel/ping_relay.dm
@@ -12,3 +12,16 @@ GLOBAL_DATUM_INIT(relays_panel, /datum/ping_relay_tgui, new)
 
 /datum/ping_relay_tgui/ui_state(mob/user)
 	return GLOB.always_state
+
+/datum/ping_relay_tgui/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	if(.)
+		return
+
+	var/mob/user = ui.user
+
+	switch(action)
+		if("connect")
+			user << link(params["url"])
+			ui.close()
+			return

--- a/code/modules/tgui_panel/ping_relay.dm
+++ b/code/modules/tgui_panel/ping_relay.dm
@@ -46,6 +46,7 @@ GLOBAL_DATUM_INIT(relays_panel, /datum/ping_relay_tgui, new)
 
 	switch(action)
 		if("connect")
+			to_chat(user, "Now connecting via [params["desc"]]. Please wait...");
 			user << link(params["url"])
 			ui.close()
 			return

--- a/code/modules/tgui_panel/ping_relay.dm
+++ b/code/modules/tgui_panel/ping_relay.dm
@@ -1,0 +1,14 @@
+GLOBAL_DATUM_INIT(relays_panel, /datum/ping_relay_tgui, new)
+
+/datum/tgui_panel/proc/ping_relays()
+	GLOB.relays_panel.tgui_interact(client.mob)
+
+/datum/ping_relay_tgui/tgui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "PingRelaysPanel", "Relay Pings")
+		ui.open()
+		//ui.set_autoupdate(FALSE)
+
+/datum/ping_relay_tgui/ui_state(mob/user)
+	return GLOB.always_state

--- a/code/modules/tgui_panel/ping_relay.dm
+++ b/code/modules/tgui_panel/ping_relay.dm
@@ -8,7 +8,7 @@ GLOBAL_DATUM_INIT(relays_panel, /datum/ping_relay_tgui, new)
 	if(!ui)
 		ui = new(user, src, "PingRelaysPanel", "Relay Pings")
 		ui.open()
-		//ui.set_autoupdate(FALSE)
+		ui.set_autoupdate(FALSE)
 
 /datum/ping_relay_tgui/ui_state(mob/user)
 	return GLOB.always_state

--- a/code/modules/tgui_panel/ping_relay.dm
+++ b/code/modules/tgui_panel/ping_relay.dm
@@ -4,6 +4,11 @@ GLOBAL_DATUM_INIT(relays_panel, /datum/ping_relay_tgui, new)
 	GLOB.relays_panel.tgui_interact(client.mob)
 
 /datum/ping_relay_tgui/tgui_interact(mob/user, datum/tgui/ui)
+	var/list/relay_ping_conf = CONFIG_GET(keyed_list/connection_relay_ping)
+	if(!length(relay_ping_conf))
+		to_chat(user, "There are no relays configured to test.")
+		return
+
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "PingRelaysPanel", "Relay Pings")

--- a/code/modules/tgui_panel/ping_relay.dm
+++ b/code/modules/tgui_panel/ping_relay.dm
@@ -13,6 +13,25 @@ GLOBAL_DATUM_INIT(relays_panel, /datum/ping_relay_tgui, new)
 /datum/ping_relay_tgui/ui_state(mob/user)
 	return GLOB.always_state
 
+/datum/ping_relay_tgui/ui_static_data(mob/user)
+	var/list/data = list()
+	var/list/relay_names = list()
+	var/list/relay_pings = list()
+	var/list/relay_cons = list()
+
+	var/list/relay_ping_conf = CONFIG_GET(keyed_list/connection_relay_ping)
+	var/list/relay_con_conf = CONFIG_GET(keyed_list/connection_relay_con)
+	for(var/key in relay_ping_conf)
+		// assumption: keys are the same in both configs
+		relay_names += key
+		relay_pings += relay_ping_conf[key]
+		relay_cons += relay_con_conf[key]
+
+	data["relay_names"] = relay_names
+	data["relay_pings"] = relay_pings
+	data["relay_cons"] = relay_cons
+	return data
+
 /datum/ping_relay_tgui/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
 	if(.)

--- a/code/modules/tgui_panel/ping_relay.dm
+++ b/code/modules/tgui_panel/ping_relay.dm
@@ -8,7 +8,7 @@ GLOBAL_DATUM_INIT(relays_panel, /datum/ping_relay_tgui, new)
 	if(!ui)
 		ui = new(user, src, "PingRelaysPanel", "Relay Pings")
 		ui.open()
-		ui.set_autoupdate(FALSE)
+		//ui.set_autoupdate(FALSE)
 
 /datum/ping_relay_tgui/ui_state(mob/user)
 	return GLOB.always_state

--- a/code/modules/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui_panel/tgui_panel.dm
@@ -92,6 +92,9 @@
 	if(type == "telemetry")
 		analyze_telemetry(payload)
 		return TRUE
+	if(type == "act/ping_relays")
+		ping_relays()
+		return TRUE
 
 /**
  * public

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -2356,6 +2356,7 @@
 #include "code\modules\tgui_input\text.dm"
 #include "code\modules\tgui_panel\audio.dm"
 #include "code\modules\tgui_panel\external.dm"
+#include "code\modules\tgui_panel\ping_relay.dm"
 #include "code\modules\tgui_panel\telemetry.dm"
 #include "code\modules\tgui_panel\tgui_panel.dm"
 #include "code\modules\tooltip\tooltip.dm"

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -4,6 +4,7 @@
 # $include dbconfig.txt
 # $include resources.txt
 # $include icon_source.txt
+# $include relays.txt
 
 ## Server name: This appears at the top of the screen in-game. In this case it will read "tgstation: station_name" where station_name is the randomly generated name of the station for the round. Remove the # infront of SERVERNAME and replace 'tgstation' with the name of your choice
 # SERVERNAME spacestation13

--- a/config/example/relays.txt
+++ b/config/example/relays.txt
@@ -1,0 +1,22 @@
+## Settings controlling the relay ping browser accessed via PingIndicator in TGChat
+## Pings are performed by timing how long it takes to download favicon.ico from the PingURL
+
+## Connection Relays: Name must match both ping and connect pairs
+## CONNECTION_RELAY_PING Name|PingURL
+## CONNECTION_RELAY_CON Name|ConnectURL
+CONNECTION_RELAY_PING Direct|play.cm-ss13.com:8998
+CONNECTION_RELAY_CON Direct|play.cm-ss13.com:1400
+CONNECTION_RELAY_PING United Kingdom, London|uk.cm-ss13.com:8998
+CONNECTION_RELAY_CON United Kingdom, London|uk.cm-ss13.com:1400
+CONNECTION_RELAY_PING France, Gravelines|eu-w.cm-ss13.com:8998
+CONNECTION_RELAY_CON France, Gravelines|eu-w.cm-ss13.com:1400
+CONNECTION_RELAY_PING Poland, Warsaw|eu-e.cm-ss13.com:8998
+CONNECTION_RELAY_CON Poland, Warsaw|eu-e.cm-ss13.com:1400
+CONNECTION_RELAY_PING Oregon, Hillsboro|us-w.cm-ss13.com:8998
+CONNECTION_RELAY_CON Oregon, Hillsboro|us-w.cm-ss13.com:1400
+CONNECTION_RELAY_PING Virginia, Vint Hill|us-e.cm-ss13.com:8998
+CONNECTION_RELAY_CON Virginia, Vint Hill|us-e.cm-ss13.com:1400
+CONNECTION_RELAY_PING Singapore|asia-se.cm-ss13.com:8998
+CONNECTION_RELAY_CON Singapore|asia-se.cm-ss13.com:1400
+CONNECTION_RELAY_PING Australia, Sydney|aus.cm-ss13.com:8998
+CONNECTION_RELAY_CON Australia, Sydney|aus.cm-ss13.com:1400

--- a/tgui/docs/component-reference.md
+++ b/tgui/docs/component-reference.md
@@ -250,6 +250,7 @@ A button with an extra confirmation step, using native button component.
 - See inherited props: [Button](#button)
 - `confirmContent: string` - Text to display after first click; defaults to "Confirm?"
 - `confirmColor: string` - Color to display after first click; defaults to "bad"
+- `onConfirmChange: function` - Called when the clickedOnce state changes: When the element is clicked the first time or unfocused.
 
 ### `Button.Input`
 

--- a/tgui/packages/common/ping.js
+++ b/tgui/packages/common/ping.js
@@ -24,7 +24,7 @@ export class Ping {
    * @param callback Callback function to trigger when completed. Returns error and ping value.
    * @param delay Optional number of milliseconds to wait before starting.
    */
-  ping(source, callback, delay = 500) {
+  ping(source, callback, delay = 1000) {
     let timer;
     timer = setTimeout(() => {
       this.pingNow(source, callback);
@@ -75,7 +75,7 @@ export class Ping {
           if (self.logError) {
             console.error('error loading resource: ' + e.error);
           }
-          return callback(e ? 'error' : 'timeout', pong);
+          return callback(e ? 'Error' : 'Timed Out', pong);
         }
         return callback(null, pong);
       } else {

--- a/tgui/packages/common/ping.js
+++ b/tgui/packages/common/ping.js
@@ -13,7 +13,7 @@ export class Ping {
   constructor(opt) {
     this.opt = opt || {};
     this.favicon = this.opt.favicon || '/favicon.ico';
-    this.timeout = this.opt.timeout || 0;
+    this.timeout = this.opt.timeout || 10000;
     this.logError = this.opt.logError || false;
   }
   /**

--- a/tgui/packages/common/ping.js
+++ b/tgui/packages/common/ping.js
@@ -1,0 +1,100 @@
+/**
+ * @file https://www.jsdelivr.com/package/npm/ping.js?tab=files&version=0.3.0&path=src
+ * @copyright 2021 Alfred Gutierrez
+ * @license MIT
+ */
+
+/**
+ * Creates a Ping instance.
+ * @returns {Ping}
+ * @constructor
+ */
+export class Ping {
+  constructor(opt) {
+    this.opt = opt || {};
+    this.favicon = this.opt.favicon || '/favicon.ico';
+    this.timeout = this.opt.timeout || 0;
+    this.logError = this.opt.logError || false;
+  }
+  /**
+   * Pings source and triggers a callback when completed.
+   * @param {string} source Source of the website or server, including protocol and port.
+   * @param {Function} callback Callback function to trigger when completed. Returns error and ping value.
+   * @returns {Promise|undefined} A promise that both resolves and rejects to the ping value. Or undefined if the browser does not support Promise.
+   */
+  ping(source, callback) {
+    let promise, resolve, reject;
+    if (typeof Promise !== 'undefined') {
+      promise = new Promise((_resolve, _reject) => {
+        resolve = _resolve;
+        reject = _reject;
+      });
+    }
+
+    let self = this;
+    self.wasSuccess = false;
+    self.img = new Image();
+    self.img.onload = onload;
+    self.img.onerror = onerror;
+
+    let timer;
+    let start = new Date();
+
+    const onload = function (e) {
+      self.wasSuccess = true;
+      pingCheck.call(self, e);
+    };
+
+    const onerror = function (e) {
+      self.wasSuccess = false;
+      pingCheck.call(self, e);
+    };
+
+    if (self.timeout) {
+      timer = setTimeout(() => {
+        pingCheck.call(self, undefined);
+      }, self.timeout);
+    }
+
+    /**
+     * Times ping and triggers callback.
+     */
+    const pingCheck = function () {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      let pong = new Date() - start;
+
+      if (!callback) {
+        if (promise) {
+          return this.wasSuccess ? resolve(pong) : reject(pong);
+        } else {
+          throw new Error(
+            'Promise is not supported by your browser. Use callback instead.'
+          );
+        }
+      } else if (typeof callback === 'function') {
+        // When operating in timeout mode, the timeout callback doesn't pass [event] as e.
+        // Notice [this] instead of [self], since .call() was used with context
+        if (!this.wasSuccess) {
+          if (self.logError) {
+            console.error('error loading resource');
+          }
+          if (promise) {
+            reject(pong);
+          }
+          return callback('error', pong);
+        }
+        if (promise) {
+          resolve(pong);
+        }
+        return callback(null, pong);
+      } else {
+        throw new Error('Callback is not a function.');
+      }
+    };
+
+    self.img.src = source + self.favicon + '?' + +new Date(); // Trigger image load with cache buster
+    return promise;
+  }
+}

--- a/tgui/packages/common/ping.js
+++ b/tgui/packages/common/ping.js
@@ -1,5 +1,5 @@
 /**
- * @file https://www.jsdelivr.com/package/npm/ping.js?tab=files&version=0.3.0&path=src
+ * @file https://www.jsdelivr.com/package/npm/ping.js
  * @copyright 2021 Alfred Gutierrez
  * @license MIT
  */
@@ -13,24 +13,16 @@ export class Ping {
   constructor(opt) {
     this.opt = opt || {};
     this.favicon = this.opt.favicon || '/favicon.ico';
-    this.timeout = this.opt.timeout || 10000;
+    this.timeout = this.opt.timeout || 5000;
     this.logError = this.opt.logError || false;
   }
   /**
    * Pings source and triggers a callback when completed.
-   * @param {string} source Source of the website or server, including protocol and port.
-   * @param {Function} callback Callback function to trigger when completed. Returns error and ping value.
-   * @returns {Promise|undefined} A promise that both resolves and rejects to the ping value. Or undefined if the browser does not support Promise.
+   * @param source Source of the website or server, including protocol and port.
+   * @param callback Callback function to trigger when completed. Returns error and ping value.
+   * @param timeout Optional number of milliseconds to wait before aborting.
    */
   ping(source, callback) {
-    let promise, resolve, reject;
-    if (typeof Promise !== 'undefined') {
-      promise = new Promise((_resolve, _reject) => {
-        resolve = _resolve;
-        reject = _reject;
-      });
-    }
-
     let self = this;
     self.wasSuccess = false;
     self.img = new Image();
@@ -65,28 +57,14 @@ export class Ping {
       }
       let pong = new Date() - start;
 
-      if (!callback) {
-        if (promise) {
-          return this.wasSuccess ? resolve(pong) : reject(pong);
-        } else {
-          throw new Error(
-            'Promise is not supported by your browser. Use callback instead.'
-          );
-        }
-      } else if (typeof callback === 'function') {
+      if (typeof callback === 'function') {
         // When operating in timeout mode, the timeout callback doesn't pass [event] as e.
         // Notice [this] instead of [self], since .call() was used with context
         if (!this.wasSuccess) {
           if (self.logError) {
             console.error('error loading resource');
           }
-          if (promise) {
-            reject(pong);
-          }
           return callback('error', pong);
-        }
-        if (promise) {
-          resolve(pong);
         }
         return callback(null, pong);
       } else {
@@ -95,6 +73,5 @@ export class Ping {
     };
 
     self.img.src = source + self.favicon + '?' + +new Date(); // Trigger image load with cache buster
-    return promise;
   }
 }

--- a/tgui/packages/common/ping.js
+++ b/tgui/packages/common/ping.js
@@ -26,21 +26,17 @@ export class Ping {
     let self = this;
     self.wasSuccess = false;
     self.img = new Image();
-    self.img.onload = onload;
-    self.img.onerror = onerror;
-
-    let timer;
-    let start = new Date();
-
-    const onload = function (e) {
+    self.img.onload = (e) => {
       self.wasSuccess = true;
       pingCheck.call(self, e);
     };
-
-    const onerror = function (e) {
+    self.img.onerror = (e) => {
       self.wasSuccess = false;
       pingCheck.call(self, e);
     };
+
+    let timer;
+    let start = new Date();
 
     if (self.timeout) {
       timer = setTimeout(() => {

--- a/tgui/packages/tgui-panel/ping/PingIndicator.js
+++ b/tgui/packages/tgui-panel/ping/PingIndicator.js
@@ -6,11 +6,12 @@
 
 import { Color } from 'common/color';
 import { toFixed } from 'common/math';
-import { useSelector } from 'tgui/backend';
-import { Box } from 'tgui/components';
+import { useSelector, useBackend } from 'tgui/backend';
+import { Button, Box } from 'tgui/components';
 import { selectPing } from './selectors';
 
 export const PingIndicator = (props) => {
+  const { act } = useBackend();
   const ping = useSelector(selectPing);
   const color = Color.lookup(ping.networkQuality, [
     new Color(220, 40, 40),
@@ -19,9 +20,16 @@ export const PingIndicator = (props) => {
   ]);
   const roundtrip = ping.roundtrip ? toFixed(ping.roundtrip) : '--';
   return (
-    <div className="Ping">
+    <Button
+      lineHeight="15px"
+      width="50px"
+      className="Ping"
+      color="transparent"
+      tooltip="Ping relays"
+      tooltipPosition="bottom-start"
+      onClick={() => act('ping_relays')}>
       <Box className="Ping__indicator" backgroundColor={color} />
       {roundtrip}
-    </div>
+    </Button>
   );
 };

--- a/tgui/packages/tgui-panel/ping/PingIndicator.js
+++ b/tgui/packages/tgui-panel/ping/PingIndicator.js
@@ -25,6 +25,9 @@ export const PingIndicator = (props) => {
       width="50px"
       className="Ping"
       color="transparent"
+      hover
+      py="0.125em" // Override what light theme does to this
+      px="0.25em" // Override what light theme does to this
       tooltip="Ping relays"
       tooltipPosition="bottom-start"
       onClick={() => act('ping_relays')}>

--- a/tgui/packages/tgui/components/Button.jsx
+++ b/tgui/packages/tgui/components/Button.jsx
@@ -172,6 +172,9 @@ export class ButtonConfirm extends Component {
     } else {
       window.removeEventListener('click', this.handleClick);
     }
+    if (this.props.onConfirmChange) {
+      this.props.onConfirmChange(clickedOnce);
+    }
   }
 
   render() {
@@ -183,6 +186,7 @@ export class ButtonConfirm extends Component {
       color,
       content,
       onClick,
+      onConfirmChange,
       ...rest
     } = this.props;
     return (

--- a/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
+++ b/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
@@ -1,4 +1,5 @@
 import { useBackend } from '../backend';
+import { round } from 'common/math';
 import { Box, Stack, Button, Icon, RoundGauge, Flex } from '../components';
 import { Window } from '../layouts';
 import { Color } from 'common/color';
@@ -46,7 +47,7 @@ class PingApp extends Component {
       this.results[this.state.currentIndex]?.update(
         desc,
         'byond://' + connectURL,
-        pong,
+        round(pong * 0.75), // The ping is inflated so lets compensate a bit
         error
       );
       this.setState((prevState) => ({

--- a/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
+++ b/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
@@ -30,12 +30,12 @@ export class PingResult {
     this.color = color;
   }
 
-  update(desc, url, ping) {
+  update = function (desc, url, ping) {
     this.desc = desc;
     this.url = url;
     this.ping = ping;
     this.color = getPingColor(ping);
-  }
+  };
 }
 
 let p = new Ping();
@@ -48,7 +48,7 @@ for (let i = 0; i < 8; i++) {
 const startTest = function (desc, pingURL, connectURL) {
   logger.log('starting test for ' + desc); // TODO: Remove this
   p.ping('http://' + pingURL, (err, data) => {
-    results[++currentIndex].update(desc, 'byond://' + connectURL, data);
+    results[currentIndex++].update(desc, 'byond://' + connectURL, data);
     logger.log('finished ' + currentIndex + ' ' + data + ' ' + err); // TODO: Remove this
   });
 };

--- a/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
+++ b/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
@@ -101,6 +101,10 @@ class PingApp extends Component {
     );
   }
 
+  componentWillUnmount() {
+    this.pinger.cancel();
+  }
+
   render() {
     const { act } = useBackend();
 

--- a/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
+++ b/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
@@ -6,7 +6,6 @@ import { Color } from 'common/color';
 import { Ping } from 'common/ping';
 import { Component } from 'react';
 
-const RELAY_COUNT = 8;
 const RED = new Color(220, 40, 40);
 
 export class PingResult {
@@ -30,16 +29,12 @@ class PingApp extends Component {
     super();
 
     this.pinger = new Ping();
+    this.results = new Array();
     this.state = {
       currentIndex: 0,
       lastClickedIndex: 0,
       lastClickedState: false,
     };
-
-    this.results = new Array(RELAY_COUNT);
-    for (let i = 0; i < RELAY_COUNT; i++) {
-      this.results[i] = new PingResult();
-    }
   }
 
   startTest(desc, pingURL, connectURL) {
@@ -64,42 +59,15 @@ class PingApp extends Component {
   }
 
   componentDidMount() {
-    this.startTest('Direct', 'play.cm-ss13.com:8998', 'play.cm-ss13.com:1400');
-    this.startTest(
-      'United Kingdom, London',
-      'uk.cm-ss13.com:8998',
-      'uk.cm-ss13.com:1400'
-    );
-    this.startTest(
-      'France, Gravelines',
-      'eu-w.cm-ss13.com:8998',
-      'eu-w.cm-ss13.com:1400'
-    );
-    this.startTest(
-      'Poland, Warsaw',
-      'eu-e.cm-ss13.com:8998',
-      'eu-e.cm-ss13.com:1400'
-    );
-    this.startTest(
-      'Oregon, Hillsboro',
-      'us-w.cm-ss13.com:8998',
-      'us-w.cm-ss13.com:1400'
-    );
-    this.startTest(
-      'Virginia, Vint Hill',
-      'us-e.cm-ss13.com:8998',
-      'us-e.cm-ss13.com:1400'
-    );
-    this.startTest(
-      'Singapore',
-      'asia-se.cm-ss13.com:8998',
-      'asia-se.cm-ss13.com:1400'
-    );
-    this.startTest(
-      'Australia, Sydney',
-      'aus.cm-ss13.com:8998',
-      'aus.cm-ss13.com:1400'
-    );
+    this.setState({ currentIndex: 0 });
+    for (let i = 0; i < this.props.relayNames.length; i++) {
+      this.results.push(new PingResult());
+      this.startTest(
+        this.props.relayNames[i],
+        this.props.relayPings[i],
+        this.props.relayCons[i]
+      );
+    }
   }
 
   componentWillUnmount() {
@@ -188,10 +156,17 @@ class PingApp extends Component {
 }
 
 export const PingRelaysPanel = () => {
+  const { data } = useBackend();
+  const { relay_names, relay_pings, relay_cons } = data;
+
   return (
     <Window width={400} height={300} theme={'weyland'}>
       <Window.Content>
-        <PingApp />
+        <PingApp
+          relayNames={relay_names}
+          relayPings={relay_pings}
+          relayCons={relay_cons}
+        />
       </Window.Content>
     </Window>
   );

--- a/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
+++ b/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
@@ -1,5 +1,5 @@
 import { useBackend } from '../backend';
-import { Box, Stack, Button, Icon, RoundGauge } from '../components';
+import { Box, Stack, Button, Icon, RoundGauge, Flex } from '../components';
 import { Window } from '../layouts';
 import { Color } from 'common/color';
 import { Ping } from 'common/ping';
@@ -29,7 +29,11 @@ class PingApp extends Component {
     super();
 
     this.pinger = new Ping();
-    this.state = { currentIndex: 0 };
+    this.state = {
+      currentIndex: 0,
+      lastClickedIndex: 0,
+      lastClickedState: false,
+    };
 
     this.results = new Array(RELAY_COUNT);
     for (let i = 0; i < RELAY_COUNT; i++) {
@@ -49,6 +53,13 @@ class PingApp extends Component {
         currentIndex: prevState.currentIndex + 1,
       }));
     });
+  }
+
+  handleConfirmChange(index, newState) {
+    if (newState || this.state.lastClickedIndex === index) {
+      this.setState({ lastClickedIndex: index });
+      this.setState({ lastClickedState: newState });
+    }
   }
 
   componentDidMount() {
@@ -100,44 +111,68 @@ class PingApp extends Component {
             <Button.Confirm
               fluid
               height={2}
-              confirmContent={'Connect? '}
+              confirmContent=""
               confirmColor="caution"
               disabled={result.ping === -1 || result.error}
+              onConfirmChange={(clickedOnce) =>
+                this.handleConfirmChange(i, clickedOnce)
+              }
               onClick={() => act('connect', { url: result.url })}>
               {result.ping <= -1 && result.error === null && (
-                <>
-                  <Icon name="spinner" spin inline />
-                  <Box inline>{result.desc}</Box>
-                </>
+                <Flex justify="space-between">
+                  <Flex.Item>
+                    <Icon name="spinner" spin inline />
+                  </Flex.Item>
+                  <Flex.Item>
+                    <Box inline>{result.desc}</Box>
+                  </Flex.Item>
+                  <Flex.Item width={8} />
+                </Flex>
               )}
               {result.ping > -1 && result.error === null && (
-                <>
-                  <Icon name="plug" inline />
-                  <Box preserveWhitespace inline>
-                    {result.desc + '  '}
-                  </Box>
-                  <RoundGauge
-                    value={result.ping}
-                    maxValue={1000}
-                    minValue={50}
-                    ranges={{
-                      'good': [0, 200],
-                      'average': [200, 500],
-                      'bad': [500, 1000],
-                    }}
-                    format={(x) => ' ' + x + 'ms'}
-                    inline
-                  />
-                </>
+                <Flex justify="space-between">
+                  <Flex.Item>
+                    <Icon name="plug" inline />
+                  </Flex.Item>
+                  <Flex.Item>
+                    <Box inline>
+                      {this.state.lastClickedIndex === i &&
+                      this.state.lastClickedState
+                        ? 'Connect via ' + result.desc + '?'
+                        : result.desc}
+                    </Box>
+                  </Flex.Item>
+                  <Flex.Item width={8}>
+                    <RoundGauge
+                      value={result.ping}
+                      maxValue={1000}
+                      minValue={50}
+                      minWidth={4}
+                      ranges={{
+                        'good': [0, 200],
+                        'average': [200, 500],
+                        'bad': [500, 1000],
+                      }}
+                      format={(x) => x + 'ms'}
+                      inline
+                    />
+                  </Flex.Item>
+                </Flex>
               )}
               {result.error !== null && (
-                <>
-                  <Icon name="x" inline color={RED} />
-                  <Box inline>{result.desc}</Box>
-                  <Box inline preserveWhitespace color={RED} bold>
-                    {' (' + result.error + ')'}
-                  </Box>
-                </>
+                <Flex justify="space-between">
+                  <Flex.Item>
+                    <Icon name="x" inline color={RED} />
+                  </Flex.Item>
+                  <Flex.Item>
+                    <Box inline>{result.desc}</Box>
+                  </Flex.Item>
+                  <Flex.Item width={8}>
+                    <Box inline preserveWhitespace color={RED} bold>
+                      {' (' + result.error + ')'}
+                    </Box>
+                  </Flex.Item>
+                </Flex>
               )}
             </Button.Confirm>
           </Stack.Item>

--- a/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
+++ b/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
@@ -47,8 +47,8 @@ for (let i = 0; i < 8; i++) {
 
 const startTest = function (desc, pingURL, connectURL) {
   logger.log('starting test for ' + desc); // TODO: Remove this
-  p.ping(`http://${pingURL}`, (err, data) => {
-    results[++currentIndex].update(desc, `byond://${connectURL}`, data);
+  p.ping('http://' + pingURL, (err, data) => {
+    results[++currentIndex].update(desc, 'byond://' + connectURL, data);
     logger.log('finished ' + currentIndex + ' ' + data + ' ' + err); // TODO: Remove this
   });
 };

--- a/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
+++ b/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
@@ -1,7 +1,10 @@
-import { Stack } from '../components';
+import { Box, Stack } from '../components';
 import { Window } from '../layouts';
 import { Color } from 'common/color';
 import { Ping } from 'common/ping';
+import { createLogger } from '../logging'; // TODO: Remove this
+
+const logger = createLogger('pingRelays'); // TODO: Remove this
 
 const COLORS = [
   new Color(220, 40, 40), // red
@@ -37,11 +40,16 @@ export class PingResult {
 
 let p = new Ping();
 let currentIndex = 0;
-let results = Array(8).fill(new PingResult());
+let results = new Array(8);
+for (let i = 0; i < 8; i++) {
+  results[i] = new PingResult();
+}
 
 const startTest = function (desc, pingURL, connectURL) {
+  logger.log('starting test for ' + desc); // TODO: Remove this
   p.ping(`http://${pingURL}`, (err, data) => {
     results[++currentIndex].update(desc, `byond://${connectURL}`, data);
+    logger.log('finished ' + currentIndex + ' ' + data + ' ' + err); // TODO: Remove this
   });
 };
 
@@ -78,7 +86,7 @@ export const PingRelaysPanel = () => {
           {results.map((result, i) => (
             <Stack.Item key={i} basis="content" grow={0} pb={1}>
               {result.desc}: <a href={result.url}>{result.url}</a>{' '}
-              <span color={result.color}>({result.ping})</span>
+              <Box color={result.color}>({result.ping})</Box>
             </Stack.Item>
           ))}
         </Stack>

--- a/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
+++ b/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
@@ -1,34 +1,18 @@
 import { useBackend } from '../backend';
-import { Box, Stack, Button, Icon } from '../components';
+import { Box, Stack, Button, Icon, RoundGauge } from '../components';
 import { Window } from '../layouts';
 import { Color } from 'common/color';
 import { Ping } from 'common/ping';
 import { Component } from 'react';
 
 const RELAY_COUNT = 8;
-
-const COLORS = [
-  new Color(220, 40, 40), // red
-  new Color(220, 200, 40), // yellow
-  new Color(60, 220, 40), // green
-];
-
-const getPingColor = function (ping) {
-  if (ping < 200) {
-    return COLORS[2];
-  }
-  if (ping < 500) {
-    return COLORS[1];
-  }
-  return COLORS[0];
-};
+const RED = new Color(220, 40, 40);
 
 export class PingResult {
-  constructor(desc = 'Loading...', url = '', ping = -1, color = COLORS[0]) {
+  constructor(desc = 'Loading...', url = '', ping = -1) {
     this.desc = desc;
     this.url = url;
     this.ping = ping;
-    this.color = color;
     this.error = null;
   }
 
@@ -36,7 +20,6 @@ export class PingResult {
     this.desc = desc;
     this.url = url;
     this.ping = ping;
-    this.color = getPingColor(ping);
     this.error = error;
   };
 }
@@ -130,17 +113,28 @@ class PingApp extends Component {
               {result.ping > -1 && result.error === null && (
                 <>
                   <Icon name="plug" inline />
-                  <Box inline>{result.desc}</Box>
-                  <Box inline preserveWhitespace color={result.color} bold>
-                    {' (' + result.ping + ')'}
+                  <Box preserveWhitespace inline>
+                    {result.desc + '  '}
                   </Box>
+                  <RoundGauge
+                    value={result.ping}
+                    maxValue={1000}
+                    minValue={50}
+                    ranges={{
+                      'good': [0, 200],
+                      'average': [200, 500],
+                      'bad': [500, 1000],
+                    }}
+                    format={(x) => ' ' + x + 'ms'}
+                    inline
+                  />
                 </>
               )}
               {result.error !== null && (
                 <>
-                  <Icon name="x" inline color={COLORS[0]} />
+                  <Icon name="x" inline color={RED} />
                   <Box inline>{result.desc}</Box>
-                  <Box inline preserveWhitespace color={COLORS[0]} bold>
+                  <Box inline preserveWhitespace color={RED} bold>
                     {' (' + result.error + ')'}
                   </Box>
                 </>

--- a/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
+++ b/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
@@ -90,7 +90,9 @@ class PingApp extends Component {
               onConfirmChange={(clickedOnce) =>
                 this.handleConfirmChange(i, clickedOnce)
               }
-              onClick={() => act('connect', { url: result.url })}>
+              onClick={() =>
+                act('connect', { url: result.url, desc: result.desc })
+              }>
               {result.ping <= -1 && result.error === null && (
                 <Flex justify="space-between">
                   <Flex.Item>

--- a/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
+++ b/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
@@ -2,9 +2,12 @@ import { Box, Stack } from '../components';
 import { Window } from '../layouts';
 import { Color } from 'common/color';
 import { Ping } from 'common/ping';
+import { Component } from 'react';
 import { createLogger } from '../logging'; // TODO: Remove this
 
 const logger = createLogger('pingRelays'); // TODO: Remove this
+
+const RELAY_COUNT = 8;
 
 const COLORS = [
   new Color(220, 40, 40), // red
@@ -28,68 +31,107 @@ export class PingResult {
     this.url = url;
     this.ping = ping;
     this.color = color;
+    this.error = null;
   }
 
-  update = function (desc, url, ping) {
+  update = function (desc, url, ping, error) {
     this.desc = desc;
     this.url = url;
     this.ping = ping;
     this.color = getPingColor(ping);
+    this.error = error;
   };
 }
 
-let p = new Ping();
-let currentIndex = 0;
-let results = new Array(8);
-for (let i = 0; i < 8; i++) {
-  results[i] = new PingResult();
+class PingApp extends Component {
+  constructor() {
+    super();
+
+    this.pinger = new Ping();
+    this.state = { currentIndex: 0 };
+
+    this.results = new Array(RELAY_COUNT);
+    for (let i = 0; i < RELAY_COUNT; i++) {
+      this.results[i] = new PingResult();
+    }
+  }
+
+  startTest(desc, pingURL, connectURL) {
+    logger.log('starting test for ' + desc); // TODO: Remove this
+    this.pinger.ping('http://' + pingURL, (error, pong) => {
+      this.results[this.state.currentIndex]?.update(
+        desc,
+        'byond://' + connectURL,
+        pong,
+        error
+      );
+      logger.log(
+        'finished ' + this.state.currentIndex + ' ' + pong + ' ' + error
+      ); // TODO: Remove this
+      this.setState((prevState) => ({
+        currentIndex: prevState.currentIndex + 1,
+      }));
+    });
+  }
+
+  componentDidMount() {
+    this.startTest('Direct', 'play.cm-ss13.com:8998', 'play.cm-ss13.com:1400');
+    this.startTest(
+      'United Kingdom, London',
+      'uk.cm-ss13.com:8998',
+      'uk.cm-ss13.com:1400'
+    );
+    this.startTest(
+      'France, Gravelines',
+      'eu-w.cm-ss13.com:8998',
+      'eu-w.cm-ss13.com:1400'
+    );
+    this.startTest(
+      'Poland, Warsaw',
+      'eu-e.cm-ss13.com:8998',
+      'eu-e.cm-ss13.com:1400'
+    );
+    this.startTest(
+      'Oregon, Hillsboro',
+      'us-w.cm-ss13.com:8998',
+      'us-w.cm-ss13.com:1400'
+    );
+    this.startTest(
+      'Virginia, Vint Hill',
+      'us-e.cm-ss13.com:8998',
+      'us-e.cm-ss13.com:1400'
+    );
+    this.startTest(
+      'Singapore',
+      'asia-se.cm-ss13.com:8998',
+      'asia-se.cm-ss13.com:1400'
+    );
+    this.startTest(
+      'Australia, Sydney',
+      'aus.cm-ss13.com:8996', // wrong
+      'aus.cm-ss13.com:1400'
+    );
+  }
+
+  render() {
+    return (
+      <Stack direction="column" fill>
+        {this.results.map((result, i) => (
+          <Stack.Item key={i} basis="content" grow={0} pb={1}>
+            {result.desc}: <a href={result.url}>{result.url}</a>{' '}
+            <Box color={result.color}>({result.ping})</Box> {result.error}
+          </Stack.Item>
+        ))}
+      </Stack>
+    );
+  }
 }
-
-const startTest = function (desc, pingURL, connectURL) {
-  logger.log('starting test for ' + desc); // TODO: Remove this
-  p.ping('http://' + pingURL, (err, data) => {
-    results[currentIndex++].update(desc, 'byond://' + connectURL, data);
-    logger.log('finished ' + currentIndex + ' ' + data + ' ' + err); // TODO: Remove this
-  });
-};
-
-startTest('Direct', 'play.cm-ss13.com:8998', 'play.cm-ss13.com:1400');
-startTest(
-  'United Kingdom, London',
-  'uk.cm-ss13.com:8998',
-  'uk.cm-ss13.com:1400'
-);
-startTest(
-  'France, Gravelines',
-  'eu-w.cm-ss13.com:8998',
-  'eu-w.cm-ss13.com:1400'
-);
-startTest('Poland, Warsaw', 'eu-e.cm-ss13.com:8998', 'eu-e.cm-ss13.com:1400');
-startTest(
-  'Oregon, Hillsboro',
-  'us-w.cm-ss13.com:8998',
-  'us-w.cm-ss13.com:1400'
-);
-startTest(
-  'Virginia, Vint Hill',
-  'us-e.cm-ss13.com:8998',
-  'us-e.cm-ss13.com:1400'
-);
-startTest('Singapore', 'asia-se.cm-ss13.com:8998', 'asia-se.cm-ss13.com:1400');
-startTest('Australia, Sydney', 'aus.cm-ss13.com:8998', 'aus.cm-ss13.com:1400');
 
 export const PingRelaysPanel = () => {
   return (
     <Window width={300} height={400} theme={'ntos'}>
       <Window.Content>
-        <Stack direction="column" fill>
-          {results.map((result, i) => (
-            <Stack.Item key={i} basis="content" grow={0} pb={1}>
-              {result.desc}: <a href={result.url}>{result.url}</a>{' '}
-              <Box color={result.color}>({result.ping})</Box>
-            </Stack.Item>
-          ))}
-        </Stack>
+        <PingApp />
       </Window.Content>
     </Window>
   );

--- a/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
+++ b/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
@@ -102,7 +102,7 @@ class PingApp extends Component {
     );
     this.startTest(
       'Australia, Sydney',
-      'aus.cm-ss13.com:8996', // wrong
+      'aus.cm-ss13.com:8998',
       'aus.cm-ss13.com:1400'
     );
   }

--- a/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
+++ b/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
@@ -14,10 +14,10 @@ const COLORS = [
 ];
 
 const getPingColor = function (ping) {
-  if (ping < 100) {
+  if (ping < 200) {
     return COLORS[2];
   }
-  if (ping < 400) {
+  if (ping < 500) {
     return COLORS[1];
   }
   return COLORS[0];

--- a/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
+++ b/tgui/packages/tgui/interfaces/PingRelaysPanel.jsx
@@ -1,0 +1,88 @@
+import { Stack } from '../components';
+import { Window } from '../layouts';
+import { Color } from 'common/color';
+import { Ping } from 'common/ping';
+
+const COLORS = [
+  new Color(220, 40, 40), // red
+  new Color(220, 200, 40), // yellow
+  new Color(60, 220, 40), // green
+];
+
+const getPingColor = function (ping) {
+  if (ping < 100) {
+    return COLORS[2];
+  }
+  if (ping < 400) {
+    return COLORS[1];
+  }
+  return COLORS[0];
+};
+
+export class PingResult {
+  constructor(desc = 'Loading...', url = '', ping = 0, color = COLORS[0]) {
+    this.desc = desc;
+    this.url = url;
+    this.ping = ping;
+    this.color = color;
+  }
+
+  update(desc, url, ping) {
+    this.desc = desc;
+    this.url = url;
+    this.ping = ping;
+    this.color = getPingColor(ping);
+  }
+}
+
+let p = new Ping();
+let currentIndex = 0;
+let results = Array(8).fill(new PingResult());
+
+const startTest = function (desc, pingURL, connectURL) {
+  p.ping(`http://${pingURL}`, (err, data) => {
+    results[++currentIndex].update(desc, `byond://${connectURL}`, data);
+  });
+};
+
+startTest('Direct', 'play.cm-ss13.com:8998', 'play.cm-ss13.com:1400');
+startTest(
+  'United Kingdom, London',
+  'uk.cm-ss13.com:8998',
+  'uk.cm-ss13.com:1400'
+);
+startTest(
+  'France, Gravelines',
+  'eu-w.cm-ss13.com:8998',
+  'eu-w.cm-ss13.com:1400'
+);
+startTest('Poland, Warsaw', 'eu-e.cm-ss13.com:8998', 'eu-e.cm-ss13.com:1400');
+startTest(
+  'Oregon, Hillsboro',
+  'us-w.cm-ss13.com:8998',
+  'us-w.cm-ss13.com:1400'
+);
+startTest(
+  'Virginia, Vint Hill',
+  'us-e.cm-ss13.com:8998',
+  'us-e.cm-ss13.com:1400'
+);
+startTest('Singapore', 'asia-se.cm-ss13.com:8998', 'asia-se.cm-ss13.com:1400');
+startTest('Australia, Sydney', 'aus.cm-ss13.com:8998', 'aus.cm-ss13.com:1400');
+
+export const PingRelaysPanel = () => {
+  return (
+    <Window width={300} height={400} theme={'ntos'}>
+      <Window.Content>
+        <Stack direction="column" fill>
+          {results.map((result, i) => (
+            <Stack.Item key={i} basis="content" grow={0} pb={1}>
+              {result.desc}: <a href={result.url}>{result.url}</a>{' '}
+              <span color={result.color}>({result.ping})</span>
+            </Stack.Item>
+          ))}
+        </Stack>
+      </Window.Content>
+    </Window>
+  );
+};


### PR DESCRIPTION
# About the pull request

This PR adds a way to ping the relays and also easily connect to them. You can access this panel by clicking the ping near the top right of chat. The ping reported here will likely be inflated from what you will actually experience or see reported by TGChat (its highly dependent on how fast your computer runs the JavaScript, and is based only on a single ping per connection), but should still give an accurate relative difference between the different connections.

When the component is loaded, it starts a timer to begin the pings in 1 second. Whenever the component is unloaded, it indicates this to the ping javascript which will cause it to early return on any pending operations.

The configs are added to examples in relays.txt. You can include it in config.txt.

# Explain why it's good for the game

This should give more visibility to the relays, provide an easy way to use them, and give more of an idea the differences in connection speeds to each relay.

# Testing Photographs and Procedure
Random values during testing:
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/1a67bf8d-bc45-4fe8-888c-2360e6d54656)

An actual test example (with last forced to time out):
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/4bcf24b9-e942-4936-a2a5-d6be3b4756f1)

Now with gauges:
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/62d903fe-0311-48fc-90d5-9c07d388650a)

Now with flex layout:
![layout rework](https://github.com/cmss13-devs/cmss13/assets/76988376/c9621ad4-9396-48b5-ae15-e415f53e3b06)

# Changelog
:cl: Drathek
ui: Added the relay ping browser accessed by the tgchat ping to test and use alternative connections to the server
ui: Added onConfirmChange prop to Button.Confirm component.
config: Added CONNECTION_RELAY_PING and CONNECTION_RELAY_CON in the relays.txt config that is optionally included in config.txt
/:cl:
