### PR TITLE
Fix burrower lifeboat tunneling

### DIFF
--- a/code/game/area/shuttles.dm
+++ b/code/game/area/shuttles.dm
@@ -81,4 +81,4 @@
 /area/shuttle/lifeboat
 	icon = 'icons/turf/area_almayer.dmi'
 	icon_state = "lifeboat"
-	flags_atom = AREA_NOTUNNEL
+	flags_area = AREA_NOTUNNEL

--- a/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_powers.dm
@@ -156,7 +156,7 @@
 		addtimer(CALLBACK(src, PROC_REF(process_tunnel), T), 1 SECONDS)
 
 /mob/living/carbon/xenomorph/proc/do_tunnel(turf/T)
-	to_chat(src, SPAN_NOTICE("We tunnel to your destination."))
+	to_chat(src, SPAN_NOTICE("We tunnel to the destination."))
 	anchored = FALSE
 	forceMove(T)
 	burrow_off()


### PR DESCRIPTION

# About the pull request

This PR effectively revives the fix from #5603 that was allowing burrowing in lifeboats. The other grammar changes it was doing were for marines, so it would not be correct to we/our them.

# Explain why it's good for the game

Fixes burrowing into lifeboats.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: AtticusRezzer
fix: Fixed the incorrect area flag in lifeboats allowing tunneling
/:cl:
