### PR TITLE
Closets now dense themselves based on pixel offset when being reclosed

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -118,7 +118,7 @@
 	update_icon()
 
 	playsound(src.loc, close_sound, 15, 1)
-	if(initial(density) != density) // If it didn't start dense (ea map placement) then don't make it dense
+	if(pixel_y < 10 || pixel_x < 10) // If it's offsetted to a point where it would confuse players, don't make dense
 		density = TRUE
 	return TRUE
 


### PR DESCRIPTION
_""noooo you can't offset closets into walls and make them non dense on your map"""_


ok then how about now

Closets will now check their pixel offset (<10) before making themselves dense again since stuff being offset past a certain point is generally understood to be passable

also updated the vars to 2000s standards

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
makes so mappers have a little less ancient shitcode limiting their mapping
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/42422230/9d08894e-9ee4-43d7-bffe-b597070c3c58

video featuring a non dense test closet and a normal closet both working as intended. 
Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Totalepicness5
fix: Closets initially passable will remain passable after closing
/:cl:
