### PR TITLE
Spawn verb no longer DDOSes the server/user when called with nothing

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -182,12 +182,10 @@
 	for(var/path in types)
 		if(findtext("[path]", object))
 			matches += path
-
-	if(matches.len==0)
+	if(matches.len==0 || matches == "" || matches == " ")
 		return
-
 	var/chosen
-	if(matches.len==1)
+	if(matches.len > 1)
 		chosen = matches[1]
 	else
 		chosen = tgui_input_list(usr, "Select an atom type", "Spawn Atom", matches)


### PR DESCRIPTION

# About the pull request
Prevents admins from blowing up the server if they call the spawn proc with nothing.

There was a check for this,but it was ineffective.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: TotalEpicness5
fix: Fixed the admin spawn verb so it doesn't ddos the server if nothing is called with it.
/:cl:
