### PR TITLE
Fix for wound overlays.

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -580,8 +580,9 @@ This function completely restores a damaged organ to perfect condition.
 	if(brute_dam || burn_dam)
 		return TRUE
 	if(knitting_time > 0)
-		return 1
-	return 0
+		return TRUE
+	update_wounds()
+	return FALSE
 
 /obj/limb/process()
 


### PR DESCRIPTION
# About the pull request

Yet another disastrous consequence of that "research warcrimes" PR. For whatever reason, it removed a line that actually was doing something important. If we have been processing the limb (otherwise `need_process()` should not be called at all) and after going through all the checks decided to cease processing it (which only happens when all damage is gone), we do need to update wounds one final time first to remove all the overlays from wounds/bandages that have healed but have not been removed by limb's not-every-tick update in regular `process()`.

# Explain why it's good for the game

Fixes #4764.


# Changelog

:cl:
fix: Fully healed limbs should now properly remove the overlays for their wounds and bandages.
/:cl:

