### PR TITLE
Opens up 1x1 hellscape on kutjevo, removes ledges in combat zone

### DIFF
--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -417,20 +417,6 @@
 	dir = 4
 	},
 /area/kutjevo/interior/complex/med)
-"azI" = (
-/obj/structure/platform/kutjevo/smooth{
-	dir = 4
-	},
-/obj/structure/barricade/handrail/kutjevo{
-	layer = 3.1
-	},
-/obj/structure/barricade/handrail/kutjevo{
-	dir = 4
-	},
-/turf/open/floor/kutjevo/multi_tiles{
-	dir = 1
-	},
-/area/kutjevo/interior/colony_South/power2)
 "azO" = (
 /turf/open/desert/desert_shore/desert_shore1{
 	dir = 8
@@ -606,15 +592,6 @@
 	},
 /turf/closed/wall/kutjevo/colony,
 /area/kutjevo/interior/construction)
-"aNj" = (
-/obj/structure/platform/kutjevo/smooth{
-	dir = 8
-	},
-/obj/structure/platform/kutjevo/smooth{
-	dir = 1
-	},
-/turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
 "aNn" = (
 /turf/open/auto_turf/sand/layer2,
 /area/kutjevo/interior/power/comms)
@@ -1999,8 +1976,8 @@
 "cKY" = (
 /obj/structure/prop/brazier/frame/full/campfire,
 /obj/item/tool/match/paper{
-	pixel_y = -2;
-	pixel_x = -11
+	pixel_x = -11;
+	pixel_y = -2
 	},
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/exterior/spring)
@@ -3643,12 +3620,12 @@
 /area/kutjevo/interior/construction)
 "eCE" = (
 /obj/item/clipboard{
-	pixel_y = 4;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 4
 	},
 /obj/item/tool/pen{
-	name = "stained pen";
 	desc = "It's a seemingly normal pen... aside from the faint red fingerprints on the side...";
+	name = "stained pen";
 	pixel_x = 2;
 	pixel_y = 10
 	},
@@ -4527,12 +4504,6 @@
 /obj/effect/landmark/corpsespawner/security/marshal,
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
-"fMi" = (
-/obj/structure/stairs/perspective/kutjevo{
-	icon_state = "p_stair_full"
-	},
-/turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
 "fMB" = (
 /obj/structure/flora/grass/tallgrass/desert/corner{
 	dir = 5
@@ -4695,14 +4666,6 @@
 /obj/structure/largecrate/random/secure,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/construction)
-"fVA" = (
-/obj/structure/barricade/handrail/kutjevo{
-	layer = 3.1
-	},
-/turf/open/floor/kutjevo/multi_tiles{
-	dir = 8
-	},
-/area/kutjevo/interior/colony_South/power2)
 "fWl" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/kutjevo/grey/plate,
@@ -5624,6 +5587,9 @@
 /obj/structure/machinery/bioprinter{
 	stored_metal = 1000
 	},
+/obj/item/clothing/glasses/thermal/syndi{
+	icon_state = "kutjevo_goggles"
+	},
 /turf/open/floor/kutjevo/colors/cyan,
 /area/kutjevo/interior/complex/med/operating)
 "hnZ" = (
@@ -5920,9 +5886,6 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/interior/colony_South)
-"hGM" = (
-/turf/closed/wall/kutjevo/colony/reinforced/hull,
-/area/kutjevo/exterior/runoff_bridge)
 "hGP" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/floor/kutjevo/plate,
@@ -6165,9 +6128,6 @@
 /area/kutjevo/exterior/lz_dunes)
 "idX" = (
 /obj/structure/closet/firecloset/full,
-/obj/item/clothing/glasses/thermal/syndi{
-	icon_state = "kutjevo_goggles"
-	},
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/interior/complex/med/locks)
@@ -6741,8 +6701,8 @@
 /area/kutjevo/exterior/complex_border/med_rec)
 "jac" = (
 /obj/item/device/radio{
-	name = "damp shortwave radio";
-	desc = "A regular shortwave radio, this one has experienced minor water damage but is still functional."
+	desc = "A regular shortwave radio, this one has experienced minor water damage but is still functional.";
+	name = "damp shortwave radio"
 	},
 /turf/open/desert/desert_shore/shore_corner2,
 /area/kutjevo/exterior/spring)
@@ -11148,14 +11108,6 @@
 	dir = 8
 	},
 /area/kutjevo/interior/complex/med/auto_doc)
-"oSx" = (
-/obj/structure/barricade/handrail/kutjevo{
-	layer = 3.1
-	},
-/turf/open/floor/kutjevo/multi_tiles{
-	dir = 4
-	},
-/area/kutjevo/interior/colony_South/power2)
 "oSK" = (
 /obj/structure/machinery/vending/snack,
 /turf/open/floor/kutjevo/tan/grey_edge,
@@ -12768,15 +12720,6 @@
 /obj/structure/platform/kutjevo/rock,
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/scrubland)
-"rgh" = (
-/obj/structure/platform/kutjevo/smooth{
-	dir = 4
-	},
-/obj/structure/platform/kutjevo/smooth{
-	dir = 1
-	},
-/turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
 "rgv" = (
 /obj/structure/machinery/power/port_gen/pacman,
 /turf/open/auto_turf/sand/layer0,
@@ -15262,20 +15205,6 @@
 	},
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/oob)
-"uxb" = (
-/obj/structure/platform/kutjevo/smooth{
-	dir = 8
-	},
-/obj/structure/barricade/handrail/kutjevo{
-	layer = 3.1
-	},
-/obj/structure/barricade/handrail/kutjevo{
-	dir = 8
-	},
-/turf/open/floor/kutjevo/multi_tiles{
-	dir = 10
-	},
-/area/kutjevo/interior/colony_South/power2)
 "uxA" = (
 /obj/structure/prop/dam/truck,
 /turf/open/asphalt/cement_sunbleached,
@@ -15428,12 +15357,6 @@
 /obj/structure/flora/grass/desert/lightgrass_3,
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/exterior/construction)
-"uHJ" = (
-/obj/structure/stairs/perspective/kutjevo{
-	icon_state = "p_stair_sn_full_cap"
-	},
-/turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
 "uHP" = (
 /turf/open/floor/kutjevo/colors/cyan,
 /area/kutjevo/interior/complex/med/auto_doc)
@@ -16063,13 +15986,6 @@
 /obj/structure/flora/grass/tallgrass/desert/corner,
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/exterior/scrubland)
-"vwB" = (
-/obj/structure/stairs/perspective/kutjevo{
-	dir = 4;
-	icon_state = "p_stair_sn_full_cap"
-	},
-/turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
 "vxe" = (
 /turf/open/floor/kutjevo/tan/alt_edge{
 	dir = 8
@@ -33461,9 +33377,9 @@ dxF
 dxF
 dxF
 dxF
-mxB
-mxB
-mxB
+dxF
+dxF
+dxF
 dxF
 dxF
 hkO
@@ -33628,8 +33544,8 @@ jPt
 pKP
 dxF
 dxF
-mxB
-mxB
+dxF
+dxF
 mhj
 dxF
 dxF
@@ -33795,7 +33711,7 @@ bjj
 fpO
 orL
 dxF
-mxB
+dxF
 mhj
 fjF
 gBl
@@ -34001,7 +33917,7 @@ kDS
 wGD
 mNM
 xvn
-hGM
+mNM
 xms
 dRj
 dRj
@@ -36506,8 +36422,8 @@ vDS
 mNM
 xvn
 dJT
-hGM
-hGM
+mNM
+mNM
 oeb
 fyD
 oeb
@@ -36673,7 +36589,7 @@ gqQ
 vys
 dRj
 lok
-hGM
+mNM
 qrl
 nOH
 fyD
@@ -37508,7 +37424,7 @@ kDS
 nOH
 xuY
 xyY
-hGM
+mNM
 juH
 dRj
 dRj
@@ -37675,7 +37591,7 @@ vfd
 mNM
 xvn
 dJT
-hGM
+mNM
 wuy
 mSd
 dTM
@@ -38507,10 +38423,10 @@ tIz
 tIz
 wtH
 wtH
-nie
-jhS
-jhS
-jhS
+wtH
+rzh
+rzh
+rzh
 jhS
 tGi
 tGi
@@ -38674,10 +38590,10 @@ vHh
 tIz
 wtH
 wtH
-nie
-jhS
-jhS
-jhS
+wtH
+rzh
+rzh
+rzh
 jhS
 kVJ
 kVJ
@@ -38841,9 +38757,9 @@ sAe
 hMu
 wCU
 wCU
-btI
-btI
-btI
+wCU
+wCU
+wCU
 btI
 jhS
 mjP
@@ -39008,8 +38924,8 @@ hMu
 hMu
 wCU
 wCU
-btI
-btI
+wCU
+wCU
 btI
 btI
 sfz
@@ -39996,14 +39912,14 @@ dip
 dip
 dip
 dip
-mMf
-mMf
 gQr
 gQr
 gQr
-gQr
-gQr
-gQr
+rIL
+rIL
+rIL
+rIL
+rIL
 rIL
 cyM
 rIL
@@ -40157,14 +40073,14 @@ szC
 lNG
 szC
 lNG
-szC
 dip
-gQr
-gQr
+dip
 rIL
 mMf
-rIL
-rIL
+mMf
+gQr
+gQr
+gQr
 rIL
 dnF
 rIL
@@ -40325,11 +40241,11 @@ dip
 dip
 dip
 dip
-dip
+rIL
 rIL
 rIL
 mMf
-rIL
+mMf
 rIL
 rIL
 rIL
@@ -40340,7 +40256,7 @@ gQr
 gQr
 iGz
 dnF
-gQr
+rIL
 rMp
 kGM
 nbu
@@ -40490,24 +40406,24 @@ oNG
 rIL
 rIL
 rIL
+rIL
+rIL
+rIL
+rIL
+rIL
+rIL
+rIL
+rIL
+rIL
+rIL
+rIL
+gQr
+gQr
+gQr
+gQr
+gQr
 mMf
-mMf
 rIL
-rIL
-rIL
-gQr
-gQr
-gQr
-gQr
-gQr
-gQr
-gQr
-gQr
-gQr
-gQr
-gQr
-gQr
-gQr
 hMu
 nbu
 kAW
@@ -40656,11 +40572,11 @@ rIL
 mMf
 rIL
 mMf
-jhS
-kVJ
-kVJ
-kVJ
-jhS
+rIL
+rIL
+rIL
+rIL
+rIL
 jhS
 jhS
 jhS
@@ -40819,15 +40735,15 @@ fyF
 sTU
 bDX
 qaI
-oNG
-oNG
+rIL
+rIL
 fAT
 dnF
-jhS
-gtL
-rzb
-vGx
-jhS
+rIL
+rIL
+rIL
+rIL
+mMf
 jhS
 gtL
 rzb
@@ -40988,13 +40904,13 @@ fyF
 qaI
 oNG
 oNG
-oNG
-oNG
-jhS
-hws
-qwg
-vcY
-jhS
+mMf
+rIL
+mMf
+rIL
+rIL
+rIL
+mMf
 jhS
 hws
 qwg
@@ -41156,12 +41072,12 @@ qaI
 oNG
 oNG
 oNG
-oNG
-jhS
-cTG
-fRZ
-cQt
-jhS
+hMu
+hMu
+rIL
+rIL
+mMf
+hMu
 jhS
 cTG
 fRZ
@@ -41324,11 +41240,11 @@ rfE
 rdm
 rdm
 rdm
-jhS
-kVJ
-kVJ
-kVJ
-jhS
+hMu
+rIL
+rIL
+mMf
+hMu
 jhS
 kVJ
 kVJ
@@ -41843,8 +41759,8 @@ vXK
 evr
 fTk
 fTk
-oSx
-eaB
+fTk
+qGx
 qGx
 qGx
 qGx
@@ -42010,8 +41926,8 @@ klE
 klE
 ngK
 klE
-azI
-rgh
+ngK
+qGx
 qGx
 qGx
 qGx
@@ -42177,8 +42093,8 @@ klE
 qGx
 qGx
 qGx
-uHJ
-uHJ
+qGx
+qGx
 qGx
 qGx
 eQW
@@ -42344,8 +42260,8 @@ qGx
 duw
 mLw
 xVZ
-fMi
-fMi
+xVZ
+mLw
 mLw
 cpg
 fqm
@@ -42511,8 +42427,8 @@ xVZ
 xVZ
 mLw
 qGx
-vwB
-vwB
+qGx
+qGx
 qGx
 qGx
 gNx
@@ -42678,8 +42594,8 @@ qGx
 mEe
 slx
 qGx
-uxb
-aNj
+klE
+qGx
 qGx
 rHE
 qGx
@@ -42845,8 +42761,8 @@ mBG
 qGx
 efr
 qGx
-fVA
-eaB
+shX
+qGx
 acD
 vSE
 acD


### PR DESCRIPTION

# About the pull request

As title, the 1x1 cave area is quite strange but cool so I wanted to open it up slightly and provide a new route into that building east of Botony I also removed ledges in that southern flank area and some strange unbreakable walls, lastly I fixed the broken thermals 

# Explain why it's good for the game

1x1s kind of suck, I like the addition of the new rotation and I think the amount of unbreakable walls on kutjevo is weird

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: SpartanBobby
maptweak: Make a few unabreakable walls on kutjevo breakable, touches the east botony caves flanks ands removes some ledges from combat routes
/:cl:
