### PR TITLE
Details LV624 secure storage blast area

### DIFF
--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -11174,6 +11174,7 @@
 /obj/structure/computerframe{
 	anchored = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/lv624/lazarus/secure_storage)
 "aWd" = (
@@ -11464,13 +11465,13 @@
 /turf/open/floor/greengrid,
 /area/lv624/lazarus/secure_storage)
 "aWV" = (
-/obj/structure/surface/rack,
-/obj/item/weapon/gun/rifle/m41a,
-/turf/open/floor/greengrid,
+/obj/item/stack/rods/plasteel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/gm/dirt,
 /area/lv624/lazarus/secure_storage)
 "aWW" = (
 /obj/structure/surface/rack,
-/obj/item/ammo_magazine/rifle/extended,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/greengrid,
 /area/lv624/lazarus/secure_storage)
 "aWX" = (
@@ -11686,11 +11687,13 @@
 "aXF" = (
 /obj/structure/surface/rack,
 /obj/item/ammo_magazine/shotgun/buckshot,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/greengrid,
 /area/lv624/lazarus/secure_storage)
 "aXG" = (
 /obj/structure/surface/rack,
 /obj/item/ammo_magazine/shotgun/slugs,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/greengrid,
 /area/lv624/lazarus/secure_storage)
 "aXH" = (
@@ -12272,8 +12275,7 @@
 	},
 /area/lv624/lazarus/comms)
 "aZL" = (
-/obj/structure/surface/rack,
-/obj/structure/prop/mech/drill,
+/obj/item/stack/sheet/metal,
 /turf/open/floor/greengrid,
 /area/lv624/lazarus/secure_storage)
 "aZM" = (
@@ -13034,6 +13036,12 @@
 	icon_state = "whiteyellow"
 	},
 /area/lv624/lazarus/corporate_dome)
+"cfA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/secure_storage)
 "cfD" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/lv624/lazarus/quartstorage/outdoors)
@@ -13094,6 +13102,10 @@
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/south_west_caves)
+"chy" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating,
+/area/lv624/lazarus/secure_storage)
 "cij" = (
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/north_east,
@@ -14600,6 +14612,10 @@
 "eTQ" = (
 /turf/open/gm/dirtgrassborder/north,
 /area/lv624/ground/jungle/south_east_jungle)
+"eUI" = (
+/obj/item/storage/toolbox,
+/turf/open/gm/dirt,
+/area/lv624/ground/colony/west_tcomms_road)
 "eVH" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/floor{
@@ -15064,6 +15080,12 @@
 	icon_state = "white"
 	},
 /area/lv624/lazarus/corporate_dome)
+"fMv" = (
+/obj/item/stack/sheet/metal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/greengrid,
+/area/lv624/lazarus/secure_storage)
 "fNA" = (
 /obj/structure/barricade/wooden,
 /turf/open/shuttle{
@@ -15525,6 +15547,11 @@
 "gRx" = (
 /turf/open/gm/dirtgrassborder/south,
 /area/lv624/ground/colony/south_medbay_road)
+"gSb" = (
+/obj/item/stack/sheet/metal,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/gm/dirt,
+/area/lv624/lazarus/secure_storage)
 "gTj" = (
 /obj/effect/decal/grass_overlay/grass1/inner{
 	dir = 8
@@ -15631,6 +15658,11 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/south_central_caves)
+"haE" = (
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/south_west_jungle)
 "haN" = (
 /obj/structure/flora/bush/ausbushes/grassybush,
 /turf/open/gm/grass/grass1,
@@ -15682,6 +15714,11 @@
 	icon_state = "asteroidwarning"
 	},
 /area/lv624/lazarus/landing_zones/lz2)
+"hen" = (
+/obj/item/tool/weldingtool,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/south_central_jungle)
 "hez" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
 	light_on = 1;
@@ -16107,6 +16144,12 @@
 /obj/effect/landmark/monkey_spawn,
 /turf/open/gm/dirt,
 /area/lv624/ground/jungle/east_central_jungle)
+"hTp" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/secure_storage)
 "hTR" = (
 /obj/structure/flora/bush/ausbushes/var3/ywflowers,
 /turf/open/auto_turf/strata_grass/layer1,
@@ -16640,6 +16683,10 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/dirtgrassborder/grassdirt_corner/south_east,
 /area/lv624/ground/caves/sand_temple)
+"jaw" = (
+/obj/item/stack/sheet/metal,
+/turf/open/gm/dirt,
+/area/lv624/ground/colony/west_tcomms_road)
 "jbd" = (
 /obj/structure/flora/bush/ausbushes/var3/sparsegrass,
 /turf/open/gm/grass/grass1,
@@ -17613,6 +17660,12 @@
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/sand_temple)
+"kSN" = (
+/obj/structure/girder,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/secure_storage)
 "kSR" = (
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/grassdirt_corner/north_west,
@@ -17631,6 +17684,10 @@
 /obj/structure/flora/jungle/plantbot1,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_west_jungle)
+"kVS" = (
+/obj/item/weapon/gun/rifle/m41a,
+/turf/open/gm/dirt,
+/area/lv624/lazarus/secure_storage)
 "kWH" = (
 /turf/open/floor{
 	icon_state = "dark"
@@ -18265,6 +18322,10 @@
 	},
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/caves/south_central_caves)
+"mdw" = (
+/obj/structure/prop/mech/drill,
+/turf/open/floor/greengrid,
+/area/lv624/lazarus/secure_storage)
 "mdQ" = (
 /turf/closed/wall/rock/brown,
 /area/lv624/ground/caves/west_caves)
@@ -18344,6 +18405,7 @@
 	},
 /area/lv624/ground/barrens/south_eastern_barrens)
 "mkn" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/lv624/lazarus/secure_storage)
 "mko" = (
@@ -18417,6 +18479,10 @@
 	icon_state = "whitebluefull"
 	},
 /area/lv624/lazarus/medbay)
+"mqf" = (
+/obj/item/tool/wrench,
+/turf/open/floor/plating,
+/area/lv624/lazarus/secure_storage)
 "mqw" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor{
@@ -19584,6 +19650,10 @@
 	icon_state = "asteroidwarning"
 	},
 /area/lv624/ground/colony/telecomm/cargo)
+"ose" = (
+/obj/structure/girder/displaced,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/south_central_jungle)
 "osf" = (
 /obj/item/reagent_container/food/snacks/grown/mushroom/glowshroom{
 	light_on = 1;
@@ -20075,6 +20145,11 @@
 	icon_state = "whiteblue"
 	},
 /area/lv624/lazarus/corporate_dome)
+"phk" = (
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/gm/dirt,
+/area/lv624/lazarus/secure_storage)
 "phU" = (
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
@@ -20108,6 +20183,9 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/colony/west_tcomms_road)
+"plC" = (
+/turf/open/floor/plating,
+/area/lv624/lazarus/secure_storage)
 "pmt" = (
 /obj/effect/landmark/objective_landmark/science,
 /turf/open/gm/dirt,
@@ -20866,6 +20944,10 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/colony/west_tcomms_road)
+"qEz" = (
+/obj/item/ammo_magazine/rifle/extended,
+/turf/open/floor/greengrid,
+/area/lv624/lazarus/secure_storage)
 "qGH" = (
 /obj/structure/flora/bush/ausbushes/var3/ywflowers,
 /turf/open/gm/grass/grass2,
@@ -21314,6 +21396,11 @@
 	},
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/sand_temple)
+"rwK" = (
+/obj/effect/decal/remains/xeno,
+/obj/item/stack/sheet/metal,
+/turf/open/gm/dirt,
+/area/lv624/ground/colony/west_tcomms_road)
 "rxV" = (
 /turf/open/gm/dirtgrassborder{
 	icon_state = "desert_dug"
@@ -21394,6 +21481,12 @@
 "rCV" = (
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/south_central_jungle)
+"rDK" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/lv624/lazarus/secure_storage)
 "rER" = (
 /obj/effect/decal/grass_overlay/grass1/inner{
 	dir = 6
@@ -21915,6 +22008,11 @@
 	icon_state = "whiteyellowfull"
 	},
 /area/lv624/ground/barrens/south_eastern_barrens)
+"sCx" = (
+/obj/item/clothing/head/welding,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/south_west_jungle)
 "sCJ" = (
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/floor{
@@ -22918,7 +23016,8 @@
 	phone_id = "Secure Storage";
 	pixel_y = 24
 	},
-/turf/open/floor/greengrid,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/lv624/lazarus/secure_storage)
 "umb" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_membrane,
@@ -23773,6 +23872,10 @@
 /obj/structure/flora/jungle/vines/light_1,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_east_jungle)
+"vTT" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/greengrid,
+/area/lv624/lazarus/secure_storage)
 "vUj" = (
 /obj/structure/flora/bush/ausbushes/var3/sparsegrass,
 /turf/open/gm/dirtgrassborder/south,
@@ -23894,10 +23997,20 @@
 	},
 /turf/open/gm/coast/beachcorner2/south_east,
 /area/lv624/ground/caves/sand_temple)
+"weB" = (
+/obj/item/stack/rods/plasteel,
+/turf/open/floor/greengrid,
+/area/lv624/lazarus/secure_storage)
 "weH" = (
 /obj/structure/flora/bush/ausbushes/genericbush,
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/north_jungle)
+"weR" = (
+/obj/item/stack/rods,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/lv624/lazarus/secure_storage)
 "wgk" = (
 /obj/structure/flora/bush/ausbushes/ppflowers,
 /obj/structure/platform_decoration/mineral/sandstone/runed{
@@ -23990,6 +24103,10 @@
 	},
 /turf/open/floor/sandstone/runed,
 /area/lv624/ground/caves/sand_temple)
+"wol" = (
+/obj/item/ammo_magazine/rifle/extended,
+/turf/open/floor/plating,
+/area/lv624/lazarus/secure_storage)
 "woF" = (
 /obj/structure/flora/jungle/vines/light_3,
 /obj/structure/barricade/metal/wired{
@@ -24570,6 +24687,9 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/gm/dirt,
 /area/lv624/ground/river/west_river)
+"xvj" = (
+/turf/open/gm/dirt,
+/area/lv624/lazarus/secure_storage)
 "xvz" = (
 /obj/structure/platform_decoration,
 /obj/effect/decal/cleanable/dirt,
@@ -24752,6 +24872,10 @@
 /obj/structure/flora/bush/ausbushes/var3/sparsegrass,
 /turf/open/gm/dirtgrassborder/east,
 /area/lv624/ground/jungle/south_central_jungle)
+"xOL" = (
+/obj/item/stack/rods,
+/turf/open/gm/dirt,
+/area/lv624/ground/colony/west_tcomms_road)
 "xPk" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/north_west,
 /area/lv624/ground/colony/south_medbay_road)
@@ -24780,6 +24904,10 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/east_jungle)
+"xRc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/gm/dirt,
+/area/lv624/lazarus/secure_storage)
 "xRe" = (
 /obj/effect/decal/grass_overlay/grass1/inner{
 	dir = 10
@@ -32743,7 +32871,7 @@ aWT
 aUQ
 aZL
 aUQ
-aUQ
+mdw
 aTf
 aTf
 aTf
@@ -32965,7 +33093,7 @@ aTf
 aUj
 aUQ
 aUQ
-ygp
+aZL
 aUQ
 gte
 aUQ
@@ -33422,11 +33550,11 @@ aUj
 aUQ
 aUQ
 aVZ
-aUQ
-aWV
+qEz
+ygp
 aUQ
 aXE
-aUQ
+vTT
 aUQ
 aYu
 aTf
@@ -33648,13 +33776,13 @@ aTf
 aTf
 aTf
 ulp
-aUQ
+aZL
 aWa
-aUQ
+xRc
 aWW
 aUQ
 aXF
-aUQ
+weB
 aUQ
 aTf
 aTf
@@ -33876,13 +34004,13 @@ vxU
 aTf
 aTf
 aUS
-aUQ
+xLT
 iml
-aUQ
-aWW
-aUQ
+vTT
+fMv
+plC
 aXG
-aUQ
+aZL
 aYf
 aTf
 aTf
@@ -34104,13 +34232,13 @@ aXh
 aTf
 aTf
 aTf
+aWV
 aUQ
+plC
+vTT
+weR
 aUQ
-aUQ
-aUQ
-sWk
-aUQ
-aUQ
+cfA
 aTf
 aTf
 aTf
@@ -34336,9 +34464,9 @@ aTf
 aTf
 mkn
 xLT
-mkn
-xLT
-sWk
+xvj
+cfA
+kSN
 aTf
 aTf
 aXh
@@ -34562,12 +34690,12 @@ efp
 aTf
 aTf
 aWc
-mkn
-mkn
+phk
+wol
 sWk
-mkn
-mkn
-xLT
+mqf
+gSb
+hTp
 kBq
 aXh
 aXh
@@ -34789,13 +34917,13 @@ bSm
 efp
 efp
 aTf
-aTf
-xLT
+chy
+rDK
 aWv
-aWv
+kVS
 xLT
-xTT
-xTT
+sCx
+haE
 vUj
 qGH
 aLj
@@ -35018,12 +35146,12 @@ buw
 efp
 efp
 uSq
+eUI
 qIO
 qIO
-qIO
-qIO
+jaw
 uXV
-qtj
+hen
 dMc
 knp
 iIU
@@ -35250,7 +35378,7 @@ njC
 qIO
 qIO
 qIO
-qtj
+ose
 qtj
 ksM
 rox
@@ -35474,7 +35602,7 @@ efp
 efp
 gDu
 uSq
-hDX
+rwK
 qIO
 qIO
 aXH
@@ -35702,9 +35830,9 @@ efp
 efp
 efp
 uSq
+xOL
 qIO
-qIO
-qIO
+jaw
 ntL
 kxI
 kxI


### PR DESCRIPTION

# About the pull request

This PR details LV624s blown open secure storage

# Explain why it's good for the game

A (relatively) recent PR made LV624s secure storage blown open all the time but I personally felt the area looked comparatively under detailed and undamaged for something blown open so I did that

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: SpartanBobby
maptweak: Edits to secure storage LV624s detailing
/:cl:
