### PR TITLE
Barricades Multi-Weld Revert & Refactoring

### DIFF
--- a/code/game/objects/structures/barricade/barricade.dm
+++ b/code/game/objects/structures/barricade/barricade.dm
@@ -388,7 +388,7 @@
 	playsound(src.loc, 'sound/items/Welder2.ogg', 25, TRUE)
 
 	welder = user.get_active_hand()
-	if(can_weld(welder, user, silent = TRUE))
+	if(repeat && can_weld(welder, user, silent = TRUE))
 		// Assumption: The implementation of can_weld will return false if fully repaired
 		if(!try_weld_cade(welder, user, repeat = TRUE, skip_check = TRUE))
 			// If this returned false, then we were interrupted or ran out of fuel, so stop looping

--- a/code/game/objects/structures/barricade/barricade.dm
+++ b/code/game/objects/structures/barricade/barricade.dm
@@ -366,8 +366,8 @@
 		if(50 to 75) damage_state = BARRICADE_DMG_SLIGHT
 		if(75 to INFINITY) damage_state = BARRICADE_DMG_NONE
 
-/obj/structure/barricade/proc/try_weld_cade(obj/item/tool/weldingtool/welder, mob/user)
-	if(!can_weld(welder, user))
+/obj/structure/barricade/proc/try_weld_cade(obj/item/tool/weldingtool/welder, mob/user, repeat = TRUE, skip_check = FALSE)
+	if(!skip_check && !can_weld(welder, user))
 		return FALSE
 
 	if(!(welder.remove_fuel(2, user)))
@@ -386,6 +386,14 @@
 	user.count_niche_stat(STATISTICS_NICHE_REPAIR_CADES)
 	update_health(-200)
 	playsound(src.loc, 'sound/items/Welder2.ogg', 25, TRUE)
+
+	welder = user.get_active_hand()
+	if(can_weld(welder, user, silent = TRUE))
+		// Assumption: The implementation of can_weld will return false if fully repaired
+		if(!try_weld_cade(welder, user, repeat = TRUE, skip_check = TRUE))
+			// If this returned false, then we were interrupted or ran out of fuel, so stop looping
+			return TRUE
+
 	return TRUE
 
 /obj/structure/barricade/verb/count_rotate()

--- a/code/game/objects/structures/barricade/barricade.dm
+++ b/code/game/objects/structures/barricade/barricade.dm
@@ -366,9 +366,8 @@
 		if(50 to 75) damage_state = BARRICADE_DMG_SLIGHT
 		if(75 to INFINITY) damage_state = BARRICADE_DMG_NONE
 
-/obj/structure/barricade/proc/weld_cade(obj/item/tool/weldingtool/welder, mob/user)
-	if(!metallic)
-		user.visible_message(SPAN_WARNING("You can't weld \the [src]!"))
+/obj/structure/barricade/proc/try_weld_cade(obj/item/tool/weldingtool/welder, mob/user)
+	if(!can_weld(welder, user))
 		return FALSE
 
 	if(!(welder.remove_fuel(2, user)))
@@ -476,20 +475,28 @@
 	nailgun.load_into_chamber()
 	return TRUE
 
-// This proc is to check a bunch of condition to cancel the action that a welder user is trying to do while giving
-// a explanation on why...
+/obj/structure/barricade/proc/can_weld(obj/item/item, mob/user, silent)
+	if(user.action_busy)
+		return FALSE
 
-/obj/structure/barricade/proc/attackby_welder(obj/item/item, mob/user)
+	if(!metallic)
+		if(!silent)
+			user.visible_message(SPAN_WARNING("You can't weld \the [src]!"))
+		return FALSE
+
 	if(!HAS_TRAIT(item, TRAIT_TOOL_BLOWTORCH))
-		to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
+		if(!silent)
+			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
 		return FALSE
 
 	if(health == maxhealth)
-		to_chat(user, SPAN_WARNING("[src] doesn't need repairs."))
+		if(!silent)
+			to_chat(user, SPAN_WARNING("[src] doesn't need repairs."))
 		return FALSE
 
 	if(!(isnull(damage_state)) && !(isnull(welder_lower_damage_limit)) && damage_state >= welder_lower_damage_limit)
-		to_chat(user, SPAN_WARNING("[src] has sustained too much structural damage to be repaired."))
+		if(!silent)
+			to_chat(user, SPAN_WARNING("[src] has sustained too much structural damage to be repaired."))
 		return FALSE
 
 	return TRUE

--- a/code/game/objects/structures/barricade/deployable.dm
+++ b/code/game/objects/structures/barricade/deployable.dm
@@ -24,34 +24,28 @@
 	. += SPAN_INFO("Drag its sprite onto yourself to undeploy.")
 
 /obj/structure/barricade/deployable/attackby(obj/item/item, mob/user)
-
 	if(iswelder(item))
-		if(!attackby_welder(item, user))
-			return FALSE
-
-
-		weld_cade(item, user)
+		try_weld_cade(item, user)
 		return
 
-	else if(HAS_TRAIT(item, TRAIT_TOOL_CROWBAR))
+	if(HAS_TRAIT(item, TRAIT_TOOL_CROWBAR))
 		if(user.action_busy)
 			return
 		if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))
 			to_chat(user, SPAN_WARNING("You do not know how to collapse [src] using a crowbar..."))
 			return
+		user.visible_message(SPAN_NOTICE("[user] starts collapsing [src]."), \
+			SPAN_NOTICE("You begin collapsing [src]..."))
+		playsound(loc, 'sound/items/Crowbar.ogg', 25, 1)
+		if(do_after(user, 1.5 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_FRIENDLY, src))
+			collapse(usr)
 		else
-			user.visible_message(SPAN_NOTICE("[user] starts collapsing [src]."), \
-				SPAN_NOTICE("You begin collapsing [src]..."))
-			playsound(loc, 'sound/items/Crowbar.ogg', 25, 1)
-			if(do_after(user, 1.5 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_FRIENDLY, src))
-				collapse(usr)
-			else
-				to_chat(user, SPAN_WARNING("You stop collapsing [src]."))
+			to_chat(user, SPAN_WARNING("You stop collapsing [src]."))
 
 	if(try_nailgun_usage(item, user))
 		return
 
-	. = ..()
+	return ..()
 
 /obj/structure/barricade/deployable/MouseDrop(obj/over_object as obj)
 	if(!ishuman(usr))
@@ -196,7 +190,7 @@
 		to_chat(user, SPAN_INFO("You transfer [to_transfer] between the stacks."))
 		return
 
-	else if(iswelder(item))
+	if(iswelder(item))
 		if(!HAS_TRAIT(item, TRAIT_TOOL_BLOWTORCH))
 			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
 			return
@@ -242,7 +236,7 @@
 		playsound(loc, 'sound/items/Welder2.ogg', 25, TRUE)
 		return
 
-	. = ..()
+	return ..()
 
 /obj/item/stack/folding_barricade/attack_hand(mob/user)
 	var/mob/living/carbon/human/human = user

--- a/code/game/objects/structures/barricade/metal.dm
+++ b/code/game/objects/structures/barricade/metal.dm
@@ -44,18 +44,20 @@
 		if(BARRICADE_UPGRADE_ANTIFF)
 			. += SPAN_NOTICE("The cade is protected by a composite upgrade.")
 
+/obj/structure/barricade/metal/can_weld(obj/item/item, mob/user, silent)
+	if(!..())
+		return FALSE
+
+	if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))
+		if(!silent)
+			to_chat(user, SPAN_WARNING("You're not trained to repair [src]..."))
+		return FALSE
+
+	return TRUE
+
 /obj/structure/barricade/metal/attackby(obj/item/item, mob/user)
 	if(iswelder(item))
-		if(!attackby_welder(item, user))
-			return FALSE
-
-
-		if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))
-			to_chat(user, SPAN_WARNING("You're not trained to repair [src]..."))
-			return FALSE
-
-		weld_cade(item, user)
-
+		try_weld_cade(item, user)
 		return
 
 	if(try_nailgun_usage(item, user))
@@ -198,11 +200,13 @@
 					to_chat(user, SPAN_WARNING("You are not trained to assemble [src]..."))
 					return
 				playsound(src.loc, 'sound/items/Screwdriver.ogg', 25, 1)
-				if(!do_after(user, 10, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD, src)) return
+				if(!do_after(user, 10, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD, src))
+					return
 				user.visible_message(SPAN_NOTICE("[user] set [src]'s protection panel back."),
 				SPAN_NOTICE("You set [src]'s protection panel back."))
 				build_state = BARRICADE_BSTATE_SECURED
 				return
+
 			if(HAS_TRAIT(item, TRAIT_TOOL_WRENCH))
 				if(user.action_busy)
 					return
@@ -210,13 +214,15 @@
 					to_chat(user, SPAN_WARNING("You are not trained to disassemble [src]..."))
 					return
 				playsound(src.loc, 'sound/items/Ratchet.ogg', 25, 1)
-				if(!do_after(user, 10, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD, src)) return
+				if(!do_after(user, 10, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD, src))
+					return
 				user.visible_message(SPAN_NOTICE("[user] loosens [src]'s anchor bolts."),
 				SPAN_NOTICE("You loosen [src]'s anchor bolts."))
 				anchored = FALSE
 				build_state = BARRICADE_BSTATE_MOVABLE
 				update_icon() //unanchored changes layer
 				return
+
 		if(BARRICADE_BSTATE_MOVABLE) //Anchor bolts loosened step. Apply crowbar to unseat the panel and take apart the whole thing. Apply wrench to resecure anchor bolts
 			if(HAS_TRAIT(item, TRAIT_TOOL_WRENCH))
 				if(user.action_busy)
@@ -233,13 +239,15 @@
 					to_chat(user, SPAN_WARNING("[src] must be secured on a proper surface!"))
 					return
 				playsound(src.loc, 'sound/items/Ratchet.ogg', 25, 1)
-				if(!do_after(user, 10, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD, src)) return
+				if(!do_after(user, 10, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD, src))
+					return
 				user.visible_message(SPAN_NOTICE("[user] secures [src]'s anchor bolts."),
 				SPAN_NOTICE("You secure [src]'s anchor bolts."))
 				build_state = BARRICADE_BSTATE_UNSECURED
 				anchored = TRUE
 				update_icon() //unanchored changes layer
 				return
+
 			if(HAS_TRAIT(item, TRAIT_TOOL_CROWBAR))
 				if(user.action_busy)
 					return
@@ -256,7 +264,7 @@
 					deconstruct(TRUE) //Note : Handles deconstruction too !
 				return
 
-	. = ..()
+	return ..()
 
 /obj/structure/barricade/metal/wired/New()
 	maxhealth += 50
@@ -265,7 +273,7 @@
 	is_wired = TRUE
 	climbable = FALSE
 	update_icon()
-	. = ..()
+	return ..()
 
 /obj/structure/barricade/metal/wired/initialize_pass_flags(datum/pass_flags_container/PF)
 	..()

--- a/code/game/objects/structures/barricade/misc.dm
+++ b/code/game/objects/structures/barricade/misc.dm
@@ -44,8 +44,8 @@
 			user.visible_message(SPAN_NOTICE("\The [user] removes \the [src]."))
 			deconstruct(TRUE)
 		return
-	else
-		. = ..()
+
+	return ..()
 
 /obj/structure/barricade/snow/hit_barricade(obj/item/I)
 	switch(I.damtype)
@@ -101,7 +101,7 @@
 	if(try_nailgun_usage(W, user))
 		return
 
-	. = ..()
+	return ..()
 
 /obj/structure/barricade/wooden/hit_barricade(obj/item/I)
 	switch(I.damtype)

--- a/code/game/objects/structures/barricade/plasteel.dm
+++ b/code/game/objects/structures/barricade/plasteel.dm
@@ -60,7 +60,7 @@
 		if(BARRICADE_BSTATE_MOVABLE)
 			. += SPAN_INFO("The protection panel has been removed and the anchor bolts loosened. It's ready to be taken apart.")
 
-/obj/structure/barricade/plasteel/try_weld_cade(obj/item/item, mob/user)
+/obj/structure/barricade/plasteel/try_weld_cade(obj/item/item, mob/user, repeat = TRUE, skip_check = FALSE)
 	busy = TRUE
 	..()
 	busy = FALSE

--- a/code/game/objects/structures/barricade/plasteel.dm
+++ b/code/game/objects/structures/barricade/plasteel.dm
@@ -47,7 +47,7 @@
 	if(!closed) // Closed = gate down for plasteel for some reason
 		return ..()
 	else
-		return 0
+		return FALSE
 
 /obj/structure/barricade/plasteel/get_examine_text(mob/user)
 	. = ..()
@@ -60,22 +60,25 @@
 		if(BARRICADE_BSTATE_MOVABLE)
 			. += SPAN_INFO("The protection panel has been removed and the anchor bolts loosened. It's ready to be taken apart.")
 
-/obj/structure/barricade/plasteel/weld_cade(obj/item/item, mob/user)
+/obj/structure/barricade/plasteel/try_weld_cade(obj/item/item, mob/user)
 	busy = TRUE
 	..()
 	busy = FALSE
 
+/obj/structure/barricade/plasteel/can_weld(obj/item/item, mob/user, silent)
+	if(!..())
+		return FALSE
+
+	if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))
+		if(!silent)
+			to_chat(user, SPAN_WARNING("You're not trained to repair [src]..."))
+		return FALSE
+
+	return TRUE
+
 /obj/structure/barricade/plasteel/attackby(obj/item/item, mob/user)
 	if(iswelder(item))
-		if(!attackby_welder(item, user))
-			return FALSE
-
-
-		if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))
-			to_chat(user, SPAN_WARNING("You're not trained to repair [src]..."))
-			return FALSE
-
-		weld_cade(item, user)
+		try_weld_cade(item, user)
 		return
 
 	if(try_nailgun_usage(item, user))
@@ -87,7 +90,7 @@
 			return
 
 	switch(build_state)
-		if(2) //Fully constructed step. Use screwdriver to remove the protection panels to reveal the bolts
+		if(BARRICADE_BSTATE_SECURED) //Fully constructed step. Use screwdriver to remove the protection panels to reveal the bolts
 			if(HAS_TRAIT(item, TRAIT_TOOL_SCREWDRIVER))
 				if(busy || tool_cooldown > world.time)
 					return
@@ -100,12 +103,14 @@
 					if(B != src && B.dir == dir)
 						to_chat(user, SPAN_WARNING("There's already a barricade here."))
 						return
-				if(!do_after(user, 10, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD, src)) return
+				if(!do_after(user, 10, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD, src))
+					return
 				user.visible_message(SPAN_NOTICE("[user] removes [src]'s protection panel."),
 				SPAN_NOTICE("You remove [src]'s protection panels, exposing the anchor bolts."))
 				playsound(src.loc, 'sound/items/Screwdriver.ogg', 25, 1)
 				build_state = BARRICADE_BSTATE_UNSECURED
 				return
+
 			if(HAS_TRAIT(item, TRAIT_TOOL_CROWBAR))
 				if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
 					to_chat(user, SPAN_WARNING("You are not trained to modify [src]..."))
@@ -125,7 +130,8 @@
 					for(var/obj/structure/barricade/plasteel/cade in get_step(src, direction))
 						cade.update_icon()
 				update_icon()
-		if(1) //Protection panel removed step. Screwdriver to put the panel back, wrench to unsecure the anchor bolts
+
+		if(BARRICADE_BSTATE_UNSECURED) //Protection panel removed step. Screwdriver to put the panel back, wrench to unsecure the anchor bolts
 			if(HAS_TRAIT(item, TRAIT_TOOL_SCREWDRIVER))
 				if(busy || tool_cooldown > world.time)
 					return
@@ -133,12 +139,14 @@
 				if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
 					to_chat(user, SPAN_WARNING("You are not trained to assemble [src]..."))
 					return
-				if(!do_after(user, 10, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD, src)) return
+				if(!do_after(user, 10, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD, src))
+					return
 				user.visible_message(SPAN_NOTICE("[user] set [src]'s protection panel back."),
 				SPAN_NOTICE("You set [src]'s protection panel back."))
 				playsound(src.loc, 'sound/items/Screwdriver.ogg', 25, 1)
 				build_state = BARRICADE_BSTATE_SECURED
 				return
+
 			if(HAS_TRAIT(item, TRAIT_TOOL_WRENCH))
 				if(busy || tool_cooldown > world.time)
 					return
@@ -146,7 +154,8 @@
 				if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
 					to_chat(user, SPAN_WARNING("You are not trained to assemble [src]..."))
 					return
-				if(!do_after(user, 10, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD, src)) return
+				if(!do_after(user, 10, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD, src))
+					return
 				user.visible_message(SPAN_NOTICE("[user] loosens [src]'s anchor bolts."),
 				SPAN_NOTICE("You loosen [src]'s anchor bolts."))
 				playsound(src.loc, 'sound/items/Ratchet.ogg', 25, 1)
@@ -155,7 +164,7 @@
 				update_icon() //unanchored changes layer
 				return
 
-		if(0) //Anchor bolts loosened step. Apply crowbar to unseat the panel and take apart the whole thing. Apply wrench to rescure anchor bolts
+		if(BARRICADE_BSTATE_MOVABLE) //Anchor bolts loosened step. Apply crowbar to unseat the panel and take apart the whole thing. Apply wrench to rescure anchor bolts
 			if(HAS_TRAIT(item, TRAIT_TOOL_WRENCH))
 				if(busy || tool_cooldown > world.time)
 					return
@@ -167,7 +176,8 @@
 				if(!(istype(T) && T.allow_construction))
 					to_chat(user, SPAN_WARNING("[src] must be secured on a proper surface!"))
 					return
-				if(!do_after(user, 10, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD, src)) return
+				if(!do_after(user, 10, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD, src))
+					return
 				user.visible_message(SPAN_NOTICE("[user] secures [src]'s anchor bolts."),
 				SPAN_NOTICE("You secure [src]'s anchor bolts."))
 				playsound(src.loc, 'sound/items/Ratchet.ogg', 25, 1)
@@ -175,6 +185,7 @@
 				build_state = BARRICADE_BSTATE_UNSECURED
 				update_icon() //unanchored changes layer
 				return
+
 			if(HAS_TRAIT(item, TRAIT_TOOL_CROWBAR))
 				if(busy || tool_cooldown > world.time)
 					return
@@ -187,15 +198,14 @@
 				playsound(src.loc, 'sound/items/Crowbar.ogg', 25, 1)
 				busy = TRUE
 				if(do_after(user, 50 * user.get_skill_duration_multiplier(SKILL_CONSTRUCTION), INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD, src))
-					busy = FALSE
 					user.visible_message(SPAN_NOTICE("[user] takes [src]'s panels apart."),
 					SPAN_NOTICE("You take [src]'s panels apart."))
 					playsound(loc, 'sound/items/Deconstruct.ogg', 25, 1)
 					deconstruct(TRUE) //Note : Handles deconstruction too !
-				else busy = FALSE
+				busy = FALSE
 				return
 
-	. = ..()
+	return ..()
 
 /obj/structure/barricade/plasteel/attack_hand(mob/user as mob)
 	if(isxeno(user))
@@ -257,7 +267,7 @@
 	is_wired = TRUE
 	climbable = FALSE
 	update_icon()
-	. = ..()
+	return ..()
 
 /obj/structure/barricade/plasteel/wired/initialize_pass_flags(datum/pass_flags_container/PF)
 	..()


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #5609 which removed a busy check from some barricades allowing multi-welding. This PR restores that setting (which is a return to normal for all but folding barricades which incorrectly allowed multi-welding before).

I have also added automatic looping to barricade welding if there is still work to be done, and it can be performed.

# Explain why it's good for the game

The PR that introduced this change was not intended to be a balance change. Additionally, it's far more difficult to tune welding speeds if the quantity of barricades being welded at the same time is variable. Technically this is a nerf though because previously multi-welding folding barricades was possible.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/76988376/32deb97f-31b0-4fd0-8baf-54637cfbf81d

After looping welding addition:

https://github.com/cmss13-devs/cmss13/assets/76988376/e67efe06-711e-4847-aa36-345c1e85222d

</details>


# Changelog
:cl: Drathek
add: Welding a barricade will now repeat automatically if it can still be repaired.
balance: Reverted multi-welding change to barricades: All barricades must be welded one at a time.
refactor: Refactored more barricade code.
/:cl:
