### PR TITLE
Fixes acid pillars shooting captured humans

### DIFF
--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -578,6 +578,11 @@
 	if(current_mob.stat == DEAD)
 		return FALSE
 
+	if(HAS_TRAIT(current_mob, TRAIT_NESTED) && (current_mob.status_flags & XENO_HOST))
+		for(var/obj/item/alien_embryo/embryo in current_mob)
+			if(HIVE_ALLIED_TO_HIVE(hivenumber, embryo.hivenumber))
+				return FALSE
+
 	var/turf/current_turf
 	var/turf/last_turf = loc
 	var/atom/temp_atom = new acid_type()

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -578,10 +578,8 @@
 	if(current_mob.stat == DEAD)
 		return FALSE
 
-	if(HAS_TRAIT(current_mob, TRAIT_NESTED) && (current_mob.status_flags & XENO_HOST))
-		for(var/obj/item/alien_embryo/embryo in current_mob)
-			if(HIVE_ALLIED_TO_HIVE(hivenumber, embryo.hivenumber))
-				return FALSE
+	if(HAS_TRAIT(current_mob, TRAIT_NESTED))
+		return FALSE
 
 	var/turf/current_turf
 	var/turf/last_turf = loc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes #5806 by making `/obj/effect/alien/resin/acid_pillar/proc/can_target()` check if the target is nested.

This specifically only checks if they're nested and not if they've actually been hugged to avoid the same issue happening in the rare cases where both aren't true.

# Explain why it's good for the game

Acid pillars shouldn't be helping marines by killing captured people.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Fixed acid pillars shooting nested marines.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
