### PR TITLE
Fix runtime since HAS_TRAIT doesn't null test

### DIFF
--- a/code/game/objects/structures/barricade/barricade.dm
+++ b/code/game/objects/structures/barricade/barricade.dm
@@ -387,7 +387,9 @@
 	update_health(-200)
 	playsound(src.loc, 'sound/items/Welder2.ogg', 25, TRUE)
 
-	welder = user.get_active_hand()
+	var/current_tool = user.get_active_hand()
+	if(current_tool != welder)
+		return TRUE // Swapped hands or tool
 	if(repeat && can_weld(welder, user, silent = TRUE))
 		// Assumption: The implementation of can_weld will return false if fully repaired
 		if(!try_weld_cade(welder, user, repeat = TRUE, skip_check = TRUE))


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #5795 fixing a runtime should you swap to an empty hand during welding. This should be caught if we used `INTERRUPT_ALL` instead of `INTERRUPT_NO_NEEDHAND` but maybe multitasking something else like wire maybe was intended.

# Explain why it's good for the game

Fixes 
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/321a502f-c5c3-4add-9add-65652428143e)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/76988376/66e29f49-3696-401f-bd6c-da12e5d3cd71

</details>


# Changelog
:cl: Drathek
fix: Fixed a runtime when swapping tools during cade welding
/:cl:
