### PR TITLE
Fix bound math on mass screenshot verb

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -117,8 +117,8 @@
 		var/datum/space_level/cur_level = SSmapping.z_list[cur_z]
 		cur_x += cur_level.bounds[MAP_MINX] - 1
 		cur_y += cur_level.bounds[MAP_MINY] - 1
-		width = cur_level.bounds[MAP_MAXX] - cur_level.bounds[MAP_MINX] - half_chunk_size + 1
-		height = cur_level.bounds[MAP_MAXY] - cur_level.bounds[MAP_MINY] - half_chunk_size + 1
+		width = cur_level.bounds[MAP_MAXX] - cur_level.bounds[MAP_MINX] - half_chunk_size + 3
+		height = cur_level.bounds[MAP_MAXY] - cur_level.bounds[MAP_MINY] - half_chunk_size + 3
 	else
 		width = world.maxx - half_chunk_size + 2
 		height = world.maxy - half_chunk_size + 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR is a follow up to #5165 fixing the mass screenshot verb. See screenshots section below for comparison.

As far as I can tell the max x and max y is unchanged from before to now, so its just the concept of a min x and y that was handled incorrectly in how this verb was modified:
Before that PR: `cur_level.x_bounds: 175 cur_level.y_bounds: 226`
After that PR: `MAP_MAXX: 175 MAP_MINX: 1 MAP_MAXY: 226 MAP_MINY: 1`

# Explain why it's good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->

Bug fixes are good.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Before this PR:
![before](https://github.com/cmss13-devs/cmss13/assets/76988376/a5b44164-b621-423b-af05-af20bd28fb57)

After this PR:
![after](https://github.com/cmss13-devs/cmss13/assets/76988376/da8e9a5a-3bae-4a5e-a918-6daf9dc44f37)

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Drathek
fix: Fixed the Mass Screenshot Debug verb bounds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
