### PR TITLE
Adds UA 45-F, UA 60-FP, M2C, M56D ammo to req

### DIFF
--- a/code/datums/supply_packs/ammo.dm
+++ b/code/datums/supply_packs/ammo.dm
@@ -346,15 +346,15 @@
 
 //------------------------Sentries Ammo----------------
 
-/datum/supply_packs/ammo_sentry
-	name = "UA 571-C sentry ammunition (x2)"
+/datum/supply_packs/ammo_sentry_shotgun
+	name = "UA 12-G sentry shotgun ammunition (x2)"
 	contains = list(
-		/obj/item/ammo_magazine/sentry,
-		/obj/item/ammo_magazine/sentry,
+		/obj/item/ammo_magazine/sentry/shotgun,
+		/obj/item/ammo_magazine/sentry/shotgun,
 	)
 	cost = 40
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "\improper sentry ammo crate"
+	containername = "\improper sentry shotgun ammo crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_sentry_flamer
@@ -368,15 +368,37 @@
 	containername = "\improper sentry flamer ammo crate"
 	group = "Ammo"
 
-/datum/supply_packs/ammo_sentry_shotgun
-	name = "UA 12-G sentry shotgun ammunition (x2)"
+/datum/supply_packs/ammo_mini_sentry_flamer
+	name = "UA 45-F mini sentry flamer ammunition (x2)"
 	contains = list(
-		/obj/item/ammo_magazine/sentry/shotgun,
-		/obj/item/ammo_magazine/sentry/shotgun,
+		/obj/item/ammo_magazine/sentry_flamer/mini,
+		/obj/item/ammo_magazine/sentry_flamer/mini,
 	)
 	cost = 40
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "\improper sentry shotgun ammo crate"
+	containername = "\improper mini sentry flamer ammo crate"
+	group = "Ammo"
+
+/datum/supply_packs/ammo_glob_sentry_flamer
+	name = "UA 60-FP sentry plasma incinerator tank (x2)"
+	contains = list(
+		/obj/item/ammo_magazine/sentry_flamer/glob,
+		/obj/item/ammo_magazine/sentry_flamer/glob,
+	)
+	cost = 40
+	containertype = /obj/structure/closet/crate/ammo
+	containername = "\improper sentry plasma incinerator ammo crate"
+	group = "Ammo"
+
+/datum/supply_packs/ammo_sentry
+	name = "UA 571-C sentry ammunition (x2)"
+	contains = list(
+		/obj/item/ammo_magazine/sentry,
+		/obj/item/ammo_magazine/sentry,
+	)
+	cost = 40
+	containertype = /obj/structure/closet/crate/ammo
+	containername = "\improper sentry ammo crate"
 	group = "Ammo"
 
 //------------------------M240 flamer tanks----------------
@@ -417,6 +439,29 @@
 	)
 	cost = 40
 	containertype = /obj/structure/closet/crate/ammo/alt/flame
+	group = "Ammo"
+
+//------------------------Mounted guns ammo----------------
+/datum/supply_packs/ammo_m2c
+	name = "M2C ammunition crate (x2)"
+	contains = list(
+		/obj/item/ammo_magazine/m2c,
+		/obj/item/ammo_magazine/m2c,
+	)
+	cost = 25
+	containertype = /obj/structure/closet/crate/ammo
+	containername = "\improper m2c ammunition crate"
+	group = "Ammo"
+
+/datum/supply_packs/ammo_m56d
+	name = "M56D drum magazine crate (x2)"
+	contains = list(
+		/obj/item/ammo_magazine/m56d,
+		/obj/item/ammo_magazine/m56d,
+	)
+	cost = 25
+	containertype = /obj/structure/closet/crate/ammo
+	containername = "\improper m56d drum magazine crate"
 	group = "Ammo"
 
 //This crate has a little bit of everything, mostly okay stuff, but it does have some really unique picks.

--- a/code/datums/supply_packs/ammo.dm
+++ b/code/datums/supply_packs/ammo.dm
@@ -454,9 +454,8 @@
 	group = "Ammo"
 
 /datum/supply_packs/ammo_m56d
-	name = "M56D drum magazine crate (x2)"
+	name = "M56D drum magazine crate (x1)"
 	contains = list(
-		/obj/item/ammo_magazine/m56d,
 		/obj/item/ammo_magazine/m56d,
 	)
 	cost = 25


### PR DESCRIPTION
# About the pull request

Adds some missing ammunition to requisitions. None of these can be randomly gained via ASRS.

- The new UA 45-F and UA 60-FP ammo crates cost the exact same as the other sentries' ammo.
- The new M2C and M56D ammo crates were a bit more tricky. You can order M2C and M56D kits that also have ammo boxes, so I aimed at making the ammo ordering to be more cost effective than just getting a new gun and the ammo coming with it.

| name | price | # of ammo boxes 
| --- | --- | --- |
| m2c kit | $6000 | 4 |
| m2c ammo crate (**added**) | $2500 | 2 |
| m56d kit | $6000 | 2 |
| m56d ammo crate (**added**) | $2500 | 1 |

Resolves #5745 

# Explain why it's good for the game

I believe it is just an oversight that these weapons had no ammunition available for order before.

# Testing Photographs and Procedure

Ordering and receiving:

<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/49321394/6b72a15a-9622-4158-9623-070747229f49)

![image](https://github.com/cmss13-devs/cmss13/assets/49321394/39c88109-cb94-40fe-92b7-b0a1b6a6de6e)

</details>


# Changelog

:cl:
add: You can now order the following in Requisitions: M2C ammo, M56D ammo, UA 45-F mini sentry ammo, UA 60-FP sentry ammo.
/:cl:
