### PR TITLE
Fixes traps triggering when shuttlecrushed

### DIFF
--- a/code/modules/cm_aliens/structures/trap.dm
+++ b/code/modules/cm_aliens/structures/trap.dm
@@ -29,7 +29,6 @@
 
 	cause_data = create_cause_data("resin trap", X)
 	set_hive_data(src, hivenumber)
-	RegisterSignal(src, COMSIG_MOVABLE_SHUTTLE_CRUSH, PROC_REF(on_shuttle_crushing))
 	if(hivenumber == XENO_HIVE_NORMAL)
 		RegisterSignal(SSdcs, COMSIG_GLOB_GROUNDSIDE_FORSAKEN_HANDLING, PROC_REF(forsaken_handling))
 
@@ -344,18 +343,16 @@
 		to_chat(user, SPAN_XENONOTICE("You place a facehugger in [src]."))
 		qdel(FH)
 
+/obj/effect/alien/resin/trap/healthcheck()
+	if(trap_type != RESIN_TRAP_EMPTY && loc)
+		trigger_trap()
+	..()
+
 /obj/effect/alien/resin/trap/Crossed(atom/A)
 	if(ismob(A) || isVehicleMultitile(A))
 		HasProximity(A)
 
-/obj/effect/alien/resin/trap/proc/on_shuttle_crushing()
-	SIGNAL_HANDLER
-	UnregisterSignal(src, COMSIG_MOVABLE_SHUTTLE_CRUSH)
-	loc = null
-
 /obj/effect/alien/resin/trap/Destroy()
-	if(trap_type != RESIN_TRAP_EMPTY && loc)
-		trigger_trap()
 	QDEL_NULL_LIST(tripwires)
 	. = ..()
 

--- a/code/modules/cm_aliens/structures/trap.dm
+++ b/code/modules/cm_aliens/structures/trap.dm
@@ -29,6 +29,7 @@
 
 	cause_data = create_cause_data("resin trap", X)
 	set_hive_data(src, hivenumber)
+	RegisterSignal(src, COMSIG_MOVABLE_SHUTTLE_CRUSH, PROC_REF(on_shuttle_crushing))
 	if(hivenumber == XENO_HIVE_NORMAL)
 		RegisterSignal(SSdcs, COMSIG_GLOB_GROUNDSIDE_FORSAKEN_HANDLING, PROC_REF(forsaken_handling))
 
@@ -346,6 +347,10 @@
 /obj/effect/alien/resin/trap/Crossed(atom/A)
 	if(ismob(A) || isVehicleMultitile(A))
 		HasProximity(A)
+
+/obj/effect/alien/resin/trap/proc/on_shuttle_crushing()
+	UnregisterSignal(src, COMSIG_MOVABLE_SHUTTLE_CRUSH)
+	loc = null
 
 /obj/effect/alien/resin/trap/Destroy()
 	if(trap_type != RESIN_TRAP_EMPTY && loc)

--- a/code/modules/cm_aliens/structures/trap.dm
+++ b/code/modules/cm_aliens/structures/trap.dm
@@ -349,6 +349,7 @@
 		HasProximity(A)
 
 /obj/effect/alien/resin/trap/proc/on_shuttle_crushing()
+	SIGNAL_HANDLER
 	UnregisterSignal(src, COMSIG_MOVABLE_SHUTTLE_CRUSH)
 	loc = null
 


### PR DESCRIPTION
# About the pull request

Nullspaces traps when they get shuttlecrushed.

Currently, if traps get shuttlecrushed, huggers/acid appear on the dropship, instead of them simply getting deleted.

This might be a godawful way to do it, but this seemed the cleanest solution to me. Fixes #5798 

# Explain why it's good for the game

Shuttlecrushing should properly delete objects below them, it just happens that hugger/acid traps forcibly trigger upon `Destroy()`.

# Testing Photographs and Procedure
Hugger and acid traps getting shuttlecrushed:

<details>
<summary>Screenshots & Videos</summary>


https://github.com/cmss13-devs/cmss13/assets/49321394/87540656-59b1-4299-aa73-b630b72dc1b1



</details>


# Changelog

:cl:
fix: Hugger and acid traps no longer activate when they get shuttlecrushed.
/:cl:
