### PR TITLE
adds stun to exiting maintenance stations

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -12,18 +12,19 @@
 	/// the borg inside
 	var/mob/living/occupant = null
 	/// Two charged borgs in a row with default cell
-	var/max_internal_charge = 15000 
+	var/max_internal_charge = 15000
 	/// Starts charged, to prevent power surges on round start
-	var/current_internal_charge = 15000 
-	var/charging_cap_active = 25000 // Active Cap - When cyborg is inside
+	var/current_internal_charge = 15000
+	/// Active Cap - When cyborg is inside
+	var/charging_cap_active = 25000
 	/// Passive Cap - Recharging internal capacitor when no cyborg is inside
-	var/charging_cap_passive = 2500 
+	var/charging_cap_passive = 2500
 	/// Used to update icon only once every 10 ticks
-	var/icon_update_tick = 0 
+	var/icon_update_tick = 0
 	/// implants to not remove
 	var/known_implants = list(/obj/item/implant/chem, /obj/item/implant/death_alarm, /obj/item/implant/loyalty, /obj/item/implant/tracking, /obj/item/implant/neurostim)
-	///stun time upon exiting, if at all	
-	var/exit_stun = 2 
+	///stun time upon exiting, if at all
+	var/exit_stun = 2
 
 
 /obj/structure/machinery/recharge_station/Initialize(mapload, ...)
@@ -201,7 +202,7 @@
 
 	cyborg.forceMove(loc)
 	if(exit_stun)
-		cyborg.apply_effect(exit_stun, STUN) //Action delay when going out of a closet
+		cyborg.Stun(exit_stun) //Action delay when going out of a closet
 	if(cyborg.mobility_flags & MOBILITY_MOVE)
 		cyborg.visible_message(SPAN_WARNING("[cyborg] suddenly gets out of [src]!"), SPAN_WARNING("You get out of [src] and get your bearings!"))
 

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -8,14 +8,22 @@
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 50
 	active_power_usage = 50
-	var/mob/living/occupant = null
-	var/max_internal_charge = 15000 // Two charged borgs in a row with default cell
-	var/current_internal_charge = 15000 // Starts charged, to prevent power surges on round start
-	var/charging_cap_active = 25000 // Active Cap - When cyborg is inside
-	var/charging_cap_passive = 2500 // Passive Cap - Recharging internal capacitor when no cyborg is inside
-	var/icon_update_tick = 0 // Used to update icon only once every 10 ticks
-	var/known_implants = list(/obj/item/implant/chem, /obj/item/implant/death_alarm, /obj/item/implant/loyalty, /obj/item/implant/tracking, /obj/item/implant/neurostim)
 	can_buckle = TRUE
+	/// the borg inside
+	var/mob/living/occupant = null
+	/// Two charged borgs in a row with default cell
+	var/max_internal_charge = 15000 
+	/// Starts charged, to prevent power surges on round start
+	var/current_internal_charge = 15000 
+	var/charging_cap_active = 25000 // Active Cap - When cyborg is inside
+	/// Passive Cap - Recharging internal capacitor when no cyborg is inside
+	var/charging_cap_passive = 2500 
+	/// Used to update icon only once every 10 ticks
+	var/icon_update_tick = 0 
+	/// implants to not remove
+	var/known_implants = list(/obj/item/implant/chem, /obj/item/implant/death_alarm, /obj/item/implant/loyalty, /obj/item/implant/tracking, /obj/item/implant/neurostim)
+	///stun time upon exiting, if at all	
+	var/exit_stun = 2 
 
 
 /obj/structure/machinery/recharge_station/Initialize(mapload, ...)
@@ -183,15 +191,21 @@
 
 
 /obj/structure/machinery/recharge_station/proc/go_out()
-	if(!( src.occupant ))
+	if(!occupant)
 		return
-	//for(var/obj/O in src)
-	// O.forceMove(src.loc)
-	if (src.occupant.client)
-		src.occupant.client.eye = src.occupant.client.mob
-		src.occupant.client.perspective = MOB_PERSPECTIVE
-	src.occupant.forceMove(loc)
-	src.occupant = null
+	var/mob/living/cyborg = occupant
+
+	if(cyborg.client)
+		cyborg.client.eye = cyborg.client.mob
+		cyborg.client.perspective = MOB_PERSPECTIVE
+
+	cyborg.forceMove(loc)
+	if(exit_stun)
+		cyborg.apply_effect(exit_stun, STUN) //Action delay when going out of a closet
+	if(cyborg.mobility_flags & MOBILITY_MOVE)
+		cyborg.visible_message(SPAN_WARNING("[cyborg] suddenly gets out of [src]!"), SPAN_WARNING("You get out of [src] and get your bearings!"))
+
+	occupant = null
 	update_icon()
 	update_use_power(USE_POWER_IDLE)
 	return

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -194,22 +194,21 @@
 /obj/structure/machinery/recharge_station/proc/go_out()
 	if(!occupant)
 		return
-	var/mob/living/cyborg = occupant
+	var/mob/living/synth = occupant
 
-	if(cyborg.client)
-		cyborg.client.eye = cyborg.client.mob
-		cyborg.client.perspective = MOB_PERSPECTIVE
+	if(synth.client)
+		synth.client.eye = synth.client.mob
+		synth.client.perspective = MOB_PERSPECTIVE
 
-	cyborg.forceMove(loc)
+	synth.forceMove(loc)
 	if(exit_stun)
-		cyborg.Stun(exit_stun) //Action delay when going out of a closet
-	if(cyborg.mobility_flags & MOBILITY_MOVE)
-		cyborg.visible_message(SPAN_WARNING("[cyborg] suddenly gets out of [src]!"), SPAN_WARNING("You get out of [src] and get your bearings!"))
+		synth.Stun(exit_stun) //Action delay when going out of a closet
+	if(synth.mobility_flags & MOBILITY_MOVE)
+		synth.visible_message(SPAN_WARNING("[synth] suddenly gets out of [src]!"), SPAN_WARNING("You get out of [src] and get your bearings!"))
 
 	occupant = null
 	update_icon()
 	update_use_power(USE_POWER_IDLE)
-	return
 
 /obj/structure/machinery/recharge_station/verb/move_eject()
 	set category = "Object"


### PR DESCRIPTION

# About the pull request

stun when exiting maintenance stations like in /obj/structure/closet/proc/dump_contents()
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

makes it function similarly to other places mobs can hide in
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Lok1
add: maintenance stations stun when exiting like closets
/:cl:
