### PR TITLE
Fix for survivor hostility message.

### DIFF
--- a/code/game/jobs/job/civilians/other/survivors.dm
+++ b/code/game/jobs/job/civilians/other/survivors.dm
@@ -85,6 +85,8 @@
 
 	if(hostile)
 		to_chat(survivor, SPAN_HIGHDANGER("You are HOSTILE to the USCM!"))
+	else if(survivor.faction == FACTION_CLF)
+		to_chat(survivor, SPAN_HIGHDANGER("You are HOSTILE to the USCM, but NOT to other survivors!"))
 	else
 		to_chat(survivor, SPAN_XENOHIGHDANGER("You are NON-HOSTILE to the USCM!"))
 


### PR DESCRIPTION
# About the pull request

Followup to #4628. That PR added the message telling CLF survivors that they are hostile, but it is based on the hostility of the entire survivor job, which is only toggled by the nightmare landmarks that make all the survivors hostile. It repeatedly gets CLF survivors in regular rounds confused when they get the nonhostile version - thus, a fix with an added reminder that they should not be shooting the resident guard/director/whomever.

# Explain why it's good for the game

Is fix.

# Changelog

:cl:
fix: CLF survivors no longer incorrectly get told that they are not hostile to marines.
/:cl:
