### PR TITLE
Fix for crates and traps.

### DIFF
--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -22,32 +22,18 @@
 
 	playsound(src, unpacking_sound, 35)
 
-	/// Store the reference of the crate material
-	var/obj/item/stack/sheet/material_sheet
-	if(parts_type) // Create the crate material and store its reference
-		material_sheet = new parts_type(current_turf, 2)
-
-	// Move the objects back to the turf, above the crate material
+	// Move the contents back to the turf
 	for(var/atom/movable/moving_atom as anything in contents)
 		moving_atom.forceMove(current_turf)
 
+	if(parts_type) // Create the crate material
+		new parts_type(current_turf, 2)
+
 	deconstruct(TRUE)
-
-	// Move the crate material to the bottom of the turf's contents
-	if(material_sheet)
-		move_to_bottom(material_sheet, current_turf)
-
-/// Custom proc to move an object to the bottom of the turf's contents
-/obj/structure/largecrate/proc/move_to_bottom(obj/moving_down, turf/current_turf)
-	if(!istype(moving_down) || !istype(current_turf))
-		return
-	for(var/atom/movable/checking_atom in current_turf.contents)
-		if(checking_atom != moving_down)
-			checking_atom.layer = max(checking_atom.layer, moving_down.layer + 0.1)
 
 /obj/structure/largecrate/deconstruct(disassembled = TRUE)
 	if(!disassembled)
-		new /obj/item/stack/sheet/wood(loc)
+		new parts_type(loc)
 	return ..()
 
 


### PR DESCRIPTION
# About the pull request

This is essentially a revert of #3075.

# Explain why it's good for the game

Firstly, I can challenge the basic idea of that PR. In my humble personal experience, when I pry apart crates (read: actually barrels), I am interested in their metal far more than in anything actually contained within. On the relatively rarer occasions involving actually prying crates of supplies for their contents, I am going to move the leftover planks of wood off the tile anyway - it does not make much difference whether they are on top or on bottom of the pile of supplies.

But more importantly, I have to question the execution. Messing with layers of items on the fly is not a good idea. It is even worse idea to extend it to all the movable atoms instead of simply items. I assume that the intent is to affect structures, but side effects of that allow an outright exploit. If you know, you know.

Some of the machinery crates can use a slight adjustment to make them look neater. I will probably get to that in a next PR once this one passes.

# Changelog

:cl:
fix: Removed an exploit involving crates.
/:cl: