### PR TITLE
TWE on Who.

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -17,6 +17,7 @@
 							FACTION_PMC = 0,
 							FACTION_CLF = 0,
 							FACTION_UPP = 0,
+							FACTION_TWE = 0,
 							FACTION_FREELANCER = 0,
 							FACTION_SURVIVOR = 0,
 							FACTION_WY_DEATHSQUAD = 0,


### PR DESCRIPTION
# About the pull request

Selfevident.

# Explain why it's good for the game

Is fix.

# Changelog

:cl:
admin: TWE mobs are now properly counted on Who screen.
/:cl: