### PR TITLE
AUTODOC.md updates

### DIFF
--- a/.github/guides/AUTODOC.md
+++ b/.github/guides/AUTODOC.md
@@ -3,7 +3,7 @@
 
 [BYOND]: https://secure.byond.com/
 
-[DMDOC]: https://github.com/SpaceManiac/SpacemanDMM/tree/master/src/dmdoc
+[DMDOC]: https://github.com/SpaceManiac/SpacemanDMM/tree/master/crates/dmdoc
 
 [DMDOC] is a documentation generator for DreamMaker, the scripting language
 of the [BYOND] game engine. It produces simple static HTML files based on

--- a/.github/guides/AUTODOC.md
+++ b/.github/guides/AUTODOC.md
@@ -13,9 +13,9 @@ We use **dmdoc** to generate [DOCUMENTATION] for our code, and that documentatio
 is automatically generated and built on every new commit to the master branch
 
 This gives new developers a clickable reference [DOCUMENTATION] they can browse to better help
-gain understanding of the /tg/station codebase structure and api reference.
+gain understanding of the CM-SS13 codebase structure and api reference.
 
-## Documenting code on /tg/station
+## Documenting code on CM-SS13
 We use block comments to document procs and classes, and we use `///` line comments
 when documenting individual variables.
 

--- a/.github/guides/AUTODOC.md
+++ b/.github/guides/AUTODOC.md
@@ -1,5 +1,5 @@
 # dmdoc
-[DOCUMENTATION]: **PUT DOCUMENTATION LINK HERE**
+[DOCUMENTATION]: https://docs.cm-ss13.com/
 
 [BYOND]: https://secure.byond.com/
 


### PR DESCRIPTION
# About the pull request

Adds a link to the auto-generated codedocs page to `.github/guides/AUTODOC.md`.

Also updates the link to the dmdoc repo, and changes '/tg/station' to 'CM-SS13'.

# Explain why it's good for the game

There's been a big bolded placeholder message right at the top of the file for 2 years and nobody noticed lol

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

### Before:
![image](https://github.com/cmss13-devs/cmss13/assets/57483089/27af761b-9ab6-4980-a8f2-b7a8f7b0194f)
<hr>

### After:
![image](https://github.com/cmss13-devs/cmss13/assets/57483089/c19496a9-b14f-42d7-bc95-277adb4c7b17)

</details>


# Changelog
N/A
