### PR TITLE
Implement chambering from handfuls of bullets

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -817,7 +817,7 @@ User can be passed as null, (a gun reloading itself for instance), so we need to
 		return
 
 	if(magazine.flags_magazine & AMMUNITION_HANDFUL)
-		to_chat(user, SPAN_WARNING("[src] needs an actual magazine."))
+		hand_load_chamber(user, magazine)
 		return
 
 	if(magazine.current_rounds <= 0)
@@ -848,6 +848,25 @@ User can be passed as null, (a gun reloading itself for instance), so we need to
 
 	update_icon()
 	return TRUE
+
+//Loads a bullet into the chamber from a handful of ammo. Ejects current one if there is.
+/obj/item/weapon/gun/proc/hand_load_chamber(mob/user, obj/item/ammo_magazine/handful)
+	var datum/ammo/new_cartridge = GLOB.ammo_list[handful.default_ammo]
+	if(in_chamber==null)
+		to_chat(user, SPAN_NOTICE("You load a [new_cartridge] into the [src]'s chamber."))
+	else
+		unload_chamber(user)
+		to_chat(user, SPAN_NOTICE("You clear the chamber of the [src] then load a [new_cartridge]."))
+	in_chamber = create_bullet(new_cartridge, initial(name))
+	apply_traits(in_chamber)
+	cock_gun(user) //placeholder
+
+	handful.current_rounds -= 1
+	if(handful.current_rounds <= 0)
+		if(user)
+			user.temp_drop_inv_item(handful)
+		qdel(handful)
+	else handful.update_icon()
 
 /obj/item/weapon/gun/proc/replace_magazine(mob/user, obj/item/ammo_magazine/magazine)
 	user.drop_inv_item_to_loc(magazine, src) //Click!


### PR DESCRIPTION

# About the pull request

Added the possibility of putting a bullet directly into the chamber from a held handful of bullets.
Still testing it and I would also like to get a better sound for the action.
Will also likely add a delay to it for balance purposes, so we wont see scouts loading funny bullets mid-chase.

# Explain why it's good for the game

Mostly a QOL thing, chambering inc bullets for Sniper and Scout already exists, is just very clunky to do.
This will make it not so annoying to do it.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>


https://github.com/cmss13-devs/cmss13/assets/15560820/c1c53621-fc84-4564-9b03-bfd136bb0d6f



</details>


# Changelog
:cl:
add: Single bullets can now be chambered into guns from a handful of bullets
/:cl:
