### PR TITLE
M42 Spotter Sight now requires pamphlet.

### DIFF
--- a/code/modules/clothing/glasses/night.dm
+++ b/code/modules/clothing/glasses/night.dm
@@ -70,6 +70,14 @@
 	name = "\improper M42 spotter sight"
 	desc = "A companion headset and night vision goggles system for USCM spotters. Allows highlighted imaging of surroundings. Click it to toggle."
 
+/obj/item/clothing/glasses/night/m42_night_goggles/spotter/can_use_active_effect(mob/living/carbon/human/user)
+	if(!(GLOB.character_traits[/datum/character_trait/skills/spotter] in user.traits))
+		to_chat(user, SPAN_WARNING("You have no idea how to use this!"))
+		return FALSE
+	else
+		return TRUE
+
+
 /obj/item/clothing/glasses/night/m42_night_goggles/m42c
 	name = "\improper M42C special operations sight"
 	desc = "A specialized variation of the M42 scout sight system, intended for use with the high-power M42C anti-tank sniper rifle. Allows for highlighted imaging of surroundings, as well as detection of thermal signatures even from a great distance. Click it to toggle."


### PR DESCRIPTION

# About the pull request

As title.

# Explain why it's good for the game

No more stealing the NVGs and not doing spotter stuff.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Spotter Sight is now locked to the pamphlet.
/:cl:
