### PR TITLE
Refactors totalXenos, tweaks some tier 0 things, adds a xeno anti-delay warning

### DIFF
--- a/code/controllers/subsystem/hijack.dm
+++ b/code/controllers/subsystem/hijack.dm
@@ -201,7 +201,7 @@ SUBSYSTEM_DEF(hijack)
 	var/datum/hive_status/hive
 	for(var/hivenumber in GLOB.hive_datum)
 		hive = GLOB.hive_datum[hivenumber]
-		if(!length(hive.totalXenos))
+		if(!length(hive.total_living_xenos))
 			continue
 
 		switch(announce)
@@ -307,7 +307,7 @@ SUBSYSTEM_DEF(hijack)
 		var/datum/hive_status/hive
 		for(var/hivenumber in GLOB.hive_datum)
 			hive = GLOB.hive_datum[hivenumber]
-			if(!length(hive.totalXenos))
+			if(!length(hive.total_living_xenos))
 				continue
 
 			xeno_announcement(SPAN_XENOANNOUNCE("The talls may be attempting to take their ship down with them in Engineering, stop them!"), hive.hivenumber, XENO_HIJACK_ANNOUNCE)

--- a/code/datums/event_info_text.dm
+++ b/code/datums/event_info_text.dm
@@ -49,7 +49,7 @@
 		for(var/hivenumber in GLOB.hive_datum)
 			hive = GLOB.hive_datum[hivenumber]
 			if(hive.name == faction)
-				for(var/mob/M in hive.totalXenos)
+				for(var/mob/M in hive.total_living_xenos)
 					show_player_event_info(M)
 				return
 

--- a/code/datums/medal_awards.dm
+++ b/code/datums/medal_awards.dm
@@ -288,10 +288,8 @@ GLOBAL_LIST_INIT(xeno_medals, list(XENO_SLAUGHTER_MEDAL, XENO_RESILIENCE_MEDAL, 
 	var/list/possible_recipients = list()
 	var/list/recipient_castes = list()
 	var/list/recipient_mobs = list()
-	for(var/mob/living/carbon/xenomorph/xeno in hive.totalXenos)
+	for(var/mob/living/carbon/xenomorph/xeno in hive.total_living_xenos_advanced)
 		if (xeno.persistent_ckey == usr.persistent_ckey) // Don't award self
-			continue
-		if (xeno.tier == 0) // Don't award larva or facehuggers
 			continue
 		if (!as_admin && istype(xeno.caste, /datum/caste_datum/queen)) // Don't award queens unless admin
 			continue
@@ -338,7 +336,7 @@ GLOBAL_LIST_INIT(xeno_medals, list(XENO_SLAUGHTER_MEDAL, XENO_RESILIENCE_MEDAL, 
 	var/recipient_ckey = recipient_mob.persistent_ckey
 	var/posthumous = !isliving(recipient_mob) || recipient_mob.stat == DEAD
 	if(!as_admin) // Don't need to check for giver mob in admin mode
-		for(var/mob/mob in hive.totalXenos)
+		for(var/mob/mob in hive.total_living_xenos_advanced)
 			if(mob == usr)
 				// Giver: Increment their medals given stat
 				giver_mob = mob

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -505,7 +505,7 @@ Additional game mode variables.
 	var/last_active_hive = 0
 	for(var/hivenumber in GLOB.hive_datum)
 		hive = GLOB.hive_datum[hivenumber]
-		if(hive.totalXenos.len <= 0)
+		if(hive.total_living_xenos_advanced.len <= 0)
 			continue
 		active_hives[hive.name] = hive.hivenumber
 		last_active_hive = hive.hivenumber
@@ -526,7 +526,7 @@ Additional game mode variables.
 	//We have our Hive picked, time to figure out what we can join via
 	var/list/available_facehugger_sources = list()
 
-	for(var/mob/living/carbon/xenomorph/carrier/carrier in hive.totalXenos)
+	for(var/mob/living/carbon/xenomorph/carrier/carrier in hive.total_living_xenos_advanced)
 		if(carrier.huggers_cur > carrier.huggers_reserved)
 			var/area_name = get_area_name(carrier)
 			var/descriptive_name = "[carrier.name] in [area_name]"
@@ -571,7 +571,7 @@ Additional game mode variables.
 	var/last_active_hive = 0
 	for(var/hivenumber in GLOB.hive_datum)
 		hive = GLOB.hive_datum[hivenumber]
-		if(hive.totalXenos.len <= 0)
+		if(hive.total_living_xenos_advanced.len <= 0)
 			continue
 		active_hives[hive.name] = hive.hivenumber
 		last_active_hive = hive.hivenumber

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -505,7 +505,7 @@ Additional game mode variables.
 	var/last_active_hive = 0
 	for(var/hivenumber in GLOB.hive_datum)
 		hive = GLOB.hive_datum[hivenumber]
-		if(hive.total_living_xenos_advanced.len <= 0)
+		if(length(hive.total_living_xenos_advanced) <= 0)
 			continue
 		active_hives[hive.name] = hive.hivenumber
 		last_active_hive = hive.hivenumber
@@ -571,7 +571,7 @@ Additional game mode variables.
 	var/last_active_hive = 0
 	for(var/hivenumber in GLOB.hive_datum)
 		hive = GLOB.hive_datum[hivenumber]
-		if(hive.total_living_xenos_advanced.len <= 0)
+		if(length(hive.total_living_xenos_advanced) <= 0)
 			continue
 		active_hives[hive.name] = hive.hivenumber
 		last_active_hive = hive.hivenumber

--- a/code/game/gamemodes/cm_process.dm
+++ b/code/game/gamemodes/cm_process.dm
@@ -1,5 +1,7 @@
 
 #define QUEEN_DEATH_COUNTDOWN  10 MINUTES //10 minutes. Can be changed into a variable if it needs to be manipulated later.
+/// Marine major if we have this many or less xenos after the queen timer runs out; also used for warning last xenos
+#define XENO_HIVE_COLLAPSE_THRESHOLD	3
 
 #define MODE_INFESTATION_X_MAJOR "Xenomorph Major Victory"
 #define MODE_INFESTATION_M_MAJOR "Marine Major Victory"

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -332,7 +332,7 @@
 			if(HS.living_xeno_queen && !should_block_game_interaction(HS.living_xeno_queen.loc))
 				//Some Queen is alive, we shouldn't end the game yet
 				return
-		if (HS.totalXenos <= 3)
+		if (HS.total_living_xenos_advanced <= 3)
 			round_finished = MODE_INFESTATION_M_MAJOR
 		else
 			round_finished = MODE_INFESTATION_M_MINOR

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -332,7 +332,7 @@
 			if(HS.living_xeno_queen && !should_block_game_interaction(HS.living_xeno_queen.loc))
 				//Some Queen is alive, we shouldn't end the game yet
 				return
-		if(length(HS.total_living_xenos_advanced) <= 3)
+		if(length(HS.total_living_xenos_advanced) <= XENO_HIVE_COLLAPSE_THRESHOLD)
 			round_finished = MODE_INFESTATION_M_MAJOR
 		else
 			round_finished = MODE_INFESTATION_M_MINOR

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -332,7 +332,7 @@
 			if(HS.living_xeno_queen && !should_block_game_interaction(HS.living_xeno_queen.loc))
 				//Some Queen is alive, we shouldn't end the game yet
 				return
-		if (HS.total_living_xenos_advanced <= 3)
+		if(length(HS.total_living_xenos_advanced) <= 3)
 			round_finished = MODE_INFESTATION_M_MAJOR
 		else
 			round_finished = MODE_INFESTATION_M_MINOR

--- a/code/game/machinery/nuclearbomb.dm
+++ b/code/game/machinery/nuclearbomb.dm
@@ -345,7 +345,7 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 		var/datum/hive_status/hive
 		for(var/hivenumber in GLOB.hive_datum)
 			hive = GLOB.hive_datum[hivenumber]
-			if(!hive.totalXenos.len)
+			if(!hive.total_living_xenos.len)
 				return
 			xeno_announcement(SPAN_XENOANNOUNCE(warning), hive.hivenumber, XENO_GENERAL_ANNOUNCE)
 		return
@@ -358,7 +358,7 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 		yautja_announcement(SPAN_YAUTJABOLDBIG("WARNING!<br>A human purification device has been detected. You have approximately [t_left] to abandon the hunting grounds before it activates."))
 		for(var/hivenumber in GLOB.hive_datum)
 			hive = GLOB.hive_datum[hivenumber]
-			if(!hive.totalXenos.len)
+			if(!hive.total_living_xenos.len)
 				continue
 			xeno_announcement(SPAN_XENOANNOUNCE("The tallhosts have deployed a hive killer at [get_area_name(loc)]! Stop it at all costs!"), hive.hivenumber, XENO_GENERAL_ANNOUNCE)
 	else
@@ -367,7 +367,7 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 		yautja_announcement(SPAN_YAUTJABOLDBIG("WARNING!<br>The human purification device's signature has disappeared."))
 		for(var/hivenumber in GLOB.hive_datum)
 			hive = GLOB.hive_datum[hivenumber]
-			if(!hive.totalXenos.len)
+			if(!hive.total_living_xenos.len)
 				continue
 			xeno_announcement(SPAN_XENOANNOUNCE("The hive killer has been disabled! Rejoice!"), hive.hivenumber, XENO_GENERAL_ANNOUNCE)
 	return
@@ -574,7 +574,7 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 			var/datum/hive_status/hive
 			for(var/hivenumber in GLOB.hive_datum)
 				hive = GLOB.hive_datum[hivenumber]
-				if(!length(hive.totalXenos))
+				if(!length(hive.total_living_xenos))
 					return
 				xeno_announcement(SPAN_XENOANNOUNCE("We get a sense of impending doom... the hive killer is ready to be activated."), hive.hivenumber, XENO_GENERAL_ANNOUNCE)
 			return
@@ -594,7 +594,7 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 		var/datum/hive_status/hive
 		for(var/hivenumber in GLOB.hive_datum)
 			hive = GLOB.hive_datum[hivenumber]
-			if(!hive.totalXenos.len)
+			if(!hive.total_living_xenos.len)
 				return
 			xeno_announcement(SPAN_XENOANNOUNCE(warning), hive.hivenumber, XENO_GENERAL_ANNOUNCE)
 		return
@@ -607,7 +607,7 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 		yautja_announcement(SPAN_YAUTJABOLDBIG("WARNING!<br>A human purification device has been detected. You have approximately [time_left] before it finishes its initial phase."))
 		for(var/hivenumber in GLOB.hive_datum)
 			hive = GLOB.hive_datum[hivenumber]
-			if(!length(hive.totalXenos))
+			if(!length(hive.total_living_xenos))
 				continue
 			xeno_announcement(SPAN_XENOANNOUNCE("The tallhosts have started the initial phase of a hive killer at [get_area_name(loc)]! Destroy their communications relays!"), hive.hivenumber, XENO_GENERAL_ANNOUNCE)
 		return
@@ -617,7 +617,7 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 	yautja_announcement(SPAN_YAUTJABOLDBIG("WARNING!<br>The human purification device's signature has disappeared."))
 	for(var/hivenumber in GLOB.hive_datum)
 		hive = GLOB.hive_datum[hivenumber]
-		if(!length(hive.totalXenos))
+		if(!length(hive.total_living_xenos))
 			continue
 		xeno_announcement(SPAN_XENOANNOUNCE("The hive killer's initial phase has been halted! Rejoice!"), hive.hivenumber, XENO_GENERAL_ANNOUNCE)
 

--- a/code/game/machinery/nuclearbomb.dm
+++ b/code/game/machinery/nuclearbomb.dm
@@ -345,7 +345,7 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 		var/datum/hive_status/hive
 		for(var/hivenumber in GLOB.hive_datum)
 			hive = GLOB.hive_datum[hivenumber]
-			if(!hive.total_living_xenos.len)
+			if(!length(hive.total_living_xenos))
 				return
 			xeno_announcement(SPAN_XENOANNOUNCE(warning), hive.hivenumber, XENO_GENERAL_ANNOUNCE)
 		return
@@ -358,7 +358,7 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 		yautja_announcement(SPAN_YAUTJABOLDBIG("WARNING!<br>A human purification device has been detected. You have approximately [t_left] to abandon the hunting grounds before it activates."))
 		for(var/hivenumber in GLOB.hive_datum)
 			hive = GLOB.hive_datum[hivenumber]
-			if(!hive.total_living_xenos.len)
+			if(!length(hive.total_living_xenos))
 				continue
 			xeno_announcement(SPAN_XENOANNOUNCE("The tallhosts have deployed a hive killer at [get_area_name(loc)]! Stop it at all costs!"), hive.hivenumber, XENO_GENERAL_ANNOUNCE)
 	else
@@ -367,7 +367,7 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 		yautja_announcement(SPAN_YAUTJABOLDBIG("WARNING!<br>The human purification device's signature has disappeared."))
 		for(var/hivenumber in GLOB.hive_datum)
 			hive = GLOB.hive_datum[hivenumber]
-			if(!hive.total_living_xenos.len)
+			if(!length(hive.total_living_xenos))
 				continue
 			xeno_announcement(SPAN_XENOANNOUNCE("The hive killer has been disabled! Rejoice!"), hive.hivenumber, XENO_GENERAL_ANNOUNCE)
 	return
@@ -594,7 +594,7 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 		var/datum/hive_status/hive
 		for(var/hivenumber in GLOB.hive_datum)
 			hive = GLOB.hive_datum[hivenumber]
-			if(!hive.total_living_xenos.len)
+			if(!length(hive.total_living_xenos))
 				return
 			xeno_announcement(SPAN_XENOANNOUNCE(warning), hive.hivenumber, XENO_GENERAL_ANNOUNCE)
 		return

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -438,7 +438,7 @@
 	var/datum/hive_status/hive
 	for(var/hivenumber in GLOB.hive_datum)
 		hive = GLOB.hive_datum[hivenumber]
-		if(hive.total_living_xenos_advanced.len > 0 || hive.total_dead_xenos.len > 0)
+		if(length(hive.total_living_xenos_advanced) > 0 || hive.total_dead_xenos.len > 0)
 			hives += list("[hive.name]" = hive.hivenumber)
 			last_hive_checked = hive
 

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -438,7 +438,7 @@
 	var/datum/hive_status/hive
 	for(var/hivenumber in GLOB.hive_datum)
 		hive = GLOB.hive_datum[hivenumber]
-		if(hive.totalXenos.len > 0 || hive.total_dead_xenos.len > 0)
+		if(hive.total_living_xenos_advanced.len > 0 || hive.total_dead_xenos.len > 0)
 			hives += list("[hive.name]" = hive.hivenumber)
 			last_hive_checked = hive
 

--- a/code/modules/admin/topic/topic_teleports.dm
+++ b/code/modules/admin/topic/topic_teleports.dm
@@ -136,7 +136,7 @@
 					to_chat(owner, SPAN_ALERT("Hive choice error. Aborting."))
 					return
 				var/datum/hive_status/Hive = GLOB.hive_datum[hives[faction]]
-				var/list/targets = Hive.totalXenos
+				var/list/targets = Hive.total_living_xenos
 				for(var/mob/living/carbon/xenomorph/X in targets)
 					var/area/AR = get_area(X)
 					if(X.stat == DEAD || AR.statistic_exempt)

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -295,7 +295,7 @@
 
 	X.hive.mark_ui.update_all_data()
 
-	for(var/mob/living/carbon/xenomorph/XX in X.hive.totalXenos)
+	for(var/mob/living/carbon/xenomorph/XX in X.hive.total_living_xenos)
 		XX.hud_set_marks() //this should be a hud thing, but that code is too confusing so I am doing it here
 
 	addtimer(CALLBACK(src, PROC_REF(check_for_weeds)), 30 SECONDS, TIMER_UNIQUE)
@@ -306,7 +306,7 @@
 	if(builder_hive)
 		builder_hive.resin_marks -= src
 
-		for(var/mob/living/carbon/xenomorph/XX in builder_hive.totalXenos)
+		for(var/mob/living/carbon/xenomorph/XX in builder_hive.total_living_xenos)
 			XX.built_structures -= src
 			if(!XX.client)
 				continue
@@ -329,7 +329,7 @@
 	. = ..()
 	var/mob/living/carbon/xenomorph/xeno_createdby
 	var/datum/hive_status/builder_hive = GLOB.hive_datum[hivenumber]
-	for(var/mob/living/carbon/xenomorph/X in builder_hive.totalXenos)
+	for(var/mob/living/carbon/xenomorph/X in builder_hive.total_living_xenos)
 		if(X.nicknumber == createdby)
 			xeno_createdby = X
 	if(isxeno(user) || isobserver(user))

--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -63,7 +63,7 @@
 	. = ..()
 
 	var/lesser_count = 0
-	for(var/mob/living/carbon/xenomorph/lesser_drone/lesser in linked_hive.totalXenos)
+	for(var/mob/living/carbon/xenomorph/lesser_drone/lesser in linked_hive.total_living_xenos)
 		lesser_count++
 
 	. += "Currently holding [SPAN_NOTICE("[Floor(lesser_drone_spawns)]")]/[SPAN_NOTICE("[lesser_drone_spawn_limit]")] lesser drones."
@@ -152,7 +152,7 @@
 
 		for(var/hivenumber in GLOB.hive_datum)
 			var/datum/hive_status/checked_hive = GLOB.hive_datum[hivenumber]
-			if(!length(checked_hive.totalXenos))
+			if(!length(checked_hive.total_living_xenos))
 				continue
 
 			if(checked_hive == linked_hive)
@@ -168,7 +168,7 @@
 
 	for(var/hivenumber in GLOB.hive_datum)
 		var/datum/hive_status/checked_hive = GLOB.hive_datum[hivenumber]
-		if(!length(checked_hive.totalXenos))
+		if(!length(checked_hive.total_living_xenos))
 			continue
 
 		if(checked_hive == linked_hive)
@@ -191,7 +191,7 @@
 	if(linked_hive.check_if_hit_larva_from_pylon_limit())
 		return
 
-	linked_hive.partial_larva += (linked_hive.get_real_total_xeno_count() + linked_hive.stored_larva) * LARVA_ADDITION_MULTIPLIER
+	linked_hive.partial_larva += (length(linked_hive.total_living_xenos_advanced) + linked_hive.stored_larva) * LARVA_ADDITION_MULTIPLIER
 	linked_hive.convert_partial_larva_to_full_larva()
 	linked_hive.hive_ui.update_burrowed_larva()
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -865,7 +865,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/datum/hive_status/hive
 	for(var/hivenumber in GLOB.hive_datum)
 		hive = GLOB.hive_datum[hivenumber]
-		if(hive.total_living_xenos.len > 0)
+		if(length(hive.total_living_xenos) > 0)
 			hives += list("[hive.name]" = hive.hivenumber)
 			last_hive_checked = hive
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -865,7 +865,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/datum/hive_status/hive
 	for(var/hivenumber in GLOB.hive_datum)
 		hive = GLOB.hive_datum[hivenumber]
-		if(hive.totalXenos.len > 0)
+		if(hive.total_living_xenos.len > 0)
 			hives += list("[hive.name]" = hive.hivenumber)
 			last_hive_checked = hive
 
@@ -893,7 +893,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set category = "Ghost.View"
 
 	var/datum/hive_status/hive = GLOB.hive_datum[XENO_HIVE_NORMAL]
-	if(!hive || !length(hive.totalXenos))
+	if(!hive || !length(hive.total_living_xenos))
 		to_chat(src, SPAN_ALERT("There seems to be no living normal hive at the moment"))
 		return
 

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -87,7 +87,7 @@
 				break
 			last_living_human = cur_human
 
-		if(!see_humans_on_tacmap && shipside_humans_count < (main_hive.get_real_total_xeno_count() * HIJACK_RATIO_FOR_TACMAP))
+		if(!see_humans_on_tacmap && shipside_humans_count < (length(main_hive.total_living_xenos_advanced) * HIJACK_RATIO_FOR_TACMAP))
 			xeno_announcement("There is only a handful of tallhosts left, they are now visible on our hive mind map.", XENO_HIVE_NORMAL, SPAN_ANNOUNCEMENT_HEADER_BLUE("[QUEEN_MOTHER_ANNOUNCE]"))
 			main_hive.see_humans_on_tacmap = TRUE
 		if(last_living_human && shipside_humans_count <= 1 && (GLOB.last_qm_callout + 2 MINUTES) < world.time)

--- a/code/modules/mob/living/carbon/xenomorph/Abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Abilities.dm
@@ -85,7 +85,7 @@
 		tunnelobj.tunnel_desc = "[msg]"
 
 	if(X.hive.living_xeno_queen || X.hive.allow_no_queen_actions)
-		for(var/mob/living/carbon/xenomorph/target_for_message as anything in X.hive.totalXenos)
+		for(var/mob/living/carbon/xenomorph/target_for_message as anything in X.hive.total_living_xenos)
 			var/overwatch_target = XENO_OVERWATCH_TARGET_HREF
 			var/overwatch_src = XENO_OVERWATCH_SRC_HREF
 			to_chat(target_for_message, SPAN_XENOANNOUNCE("Hive: A new tunnel[description ? " ([description])" : ""] has been created by [X] (<a href='byond://?src=\ref[target_for_message];[overwatch_target]=\ref[X];[overwatch_src]=\ref[target_for_message]'>watch</a>) at <b>[get_area_name(tunnelobj)]</b>."))

--- a/code/modules/mob/living/carbon/xenomorph/Evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Evolution.dm
@@ -391,15 +391,12 @@
 				used_tier_3_slots -= min(slots_used, slots_free)
 
 	var/burrowed_factor = min(hive.stored_larva, sqrt(4*hive.stored_larva))
-	var/totalXenos = round(burrowed_factor)
-	for(var/mob/living/carbon/xenomorph/xeno as anything in hive.totalXenos)
-		if(xeno.counts_for_slots)
-			totalXenos++
+	var/evolution_threshold = length(hive.total_living_xenos_advanced) + round(burrowed_factor)
 
-	if(tier == 1 && (((used_tier_2_slots + used_tier_3_slots) / totalXenos) * hive.tier_slot_multiplier) >= 0.5 && castepick != XENO_CASTE_QUEEN)
+	if(tier == 1 && (((used_tier_2_slots + used_tier_3_slots) / evolution_threshold) * hive.tier_slot_multiplier) >= 0.5 && castepick != XENO_CASTE_QUEEN)
 		to_chat(src, SPAN_WARNING("The hive cannot support another Tier 2, wait for either more aliens to be born or someone to die."))
 		return FALSE
-	else if(tier == 2 && ((used_tier_3_slots / totalXenos) * hive.tier_slot_multiplier) >= 0.20 && castepick != XENO_CASTE_QUEEN)
+	else if(tier == 2 && ((used_tier_3_slots / evolution_threshold) * hive.tier_slot_multiplier) >= 0.20 && castepick != XENO_CASTE_QUEEN)
 		to_chat(src, SPAN_WARNING("The hive cannot support another Tier 3, wait for either more aliens to be born or someone to die."))
 		return FALSE
 	else if(hive.allow_queen_evolve && !hive.living_xeno_queen && potential_queens == 1 && islarva(src) && castepick != XENO_CASTE_DRONE)

--- a/code/modules/mob/living/carbon/xenomorph/Powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Powers.dm
@@ -206,7 +206,7 @@
 	if(hive.living_xeno_queen)
 		var/current_area_name = get_area_name(target_turf)
 
-		for(var/mob/living/carbon/xenomorph/X in hive.totalXenos)
+		for(var/mob/living/carbon/xenomorph/X in hive.total_living_xenos)
 			to_chat(X, SPAN_XENOANNOUNCE("[src.name] has declared: [NM.mark_meaning.desc] in [sanitize_area(current_area_name)]! (<a href='?src=\ref[X];overwatch=1;target=\ref[NM]'>Watch</a>) (<a href='?src=\ref[X];track=1;target=\ref[NM]'>Track</a>)"))
 			//this is killing the tgui chat and I dont know why
 	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -97,7 +97,6 @@
 	var/death_fontsize = 3
 
 	var/small_explosives_stun = TRUE // Have to put this here, otherwise it can't be strain specific
-	var/counts_for_slots = TRUE
 	var/counts_for_roundend = TRUE
 	var/refunds_larva_if_banished = TRUE
 	var/can_hivemind_speak = TRUE

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -308,7 +308,7 @@
 		to_chat(usr, SPAN_XENOWARNING("You must give some time for larva to spawn before sacrificing them. Please wait another [round((SSticker.mode.round_time_lobby + SHUTTLE_TIME_LOCK - world.time) / 600)] minutes."))
 		return
 
-	var/choice = tgui_input_list(user_xeno, "Choose a xenomorph to give evolution points for a burrowed larva:", "Give Evolution Points", user_xeno.hive.totalXenos, theme="hive_status")
+	var/choice = tgui_input_list(user_xeno, "Choose a xenomorph to give evolution points for a burrowed larva:", "Give Evolution Points", user_xeno.hive.total_living_xenos_advanced, theme="hive_status")
 
 	if(!choice)
 		return
@@ -316,7 +316,7 @@
 	var/required_larva = 1
 	var/mob/living/carbon/xenomorph/target_xeno
 
-	for(var/mob/living/carbon/xenomorph/xeno in user_xeno.hive.totalXenos)
+	for(var/mob/living/carbon/xenomorph/xeno in user_xeno.hive.total_living_xenos_advanced)
 		if(html_encode(xeno.name) == html_encode(choice))
 			target_xeno = xeno
 			break
@@ -397,14 +397,14 @@
 	if(!user_xeno.check_plasma(plasma_cost_banish))
 		return
 
-	var/choice = tgui_input_list(user_xeno, "Choose a xenomorph to banish:", "Banish", user_xeno.hive.totalXenos, theme="hive_status")
+	var/choice = tgui_input_list(user_xeno, "Choose a xenomorph to banish:", "Banish", user_xeno.hive.total_living_xenos, theme="hive_status")
 
 	if(!choice)
 		return
 
 	var/mob/living/carbon/xenomorph/target_xeno
 
-	for(var/mob/living/carbon/xenomorph/xeno in user_xeno.hive.totalXenos)
+	for(var/mob/living/carbon/xenomorph/xeno in user_xeno.hive.total_living_xenos)
 		if(html_encode(xeno.name) == html_encode(choice))
 			target_xeno = xeno
 			break
@@ -483,7 +483,7 @@
 	var/banished_living = FALSE
 	var/mob/living/carbon/xenomorph/target_xeno
 
-	for(var/mob/living/carbon/xenomorph/xeno in user_xeno.hive.totalXenos)
+	for(var/mob/living/carbon/xenomorph/xeno in user_xeno.hive.total_living_xenos)
 		if(xeno.ckey == banished_ckey)
 			target_xeno = xeno
 			banished_living = TRUE
@@ -627,7 +627,7 @@
 	to_chat(Q, SPAN_XENONOTICE("You rally the hive to the queen beacon!"))
 	LAZYCLEARLIST(transported_xenos)
 	RegisterSignal(SSdcs, COMSIG_GLOB_XENO_SPAWN, PROC_REF(tunnel_xeno))
-	for(var/xeno in hive.totalXenos)
+	for(var/xeno in hive.total_living_xenos)
 		if(xeno == Q)
 			continue
 		tunnel_xeno(src, xeno)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -40,7 +40,6 @@
 	life_value = 0
 	default_honor_value = 0
 	show_only_numbers = TRUE
-	counts_for_slots = FALSE
 	counts_for_roundend = FALSE
 	refunds_larva_if_banished = FALSE
 	can_hivemind_speak = FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -496,7 +496,7 @@
 
 	if(hive && hive.living_xeno_queen == src)
 		var/mob/living/carbon/xenomorph/queen/next_queen = null
-		for(var/mob/living/carbon/xenomorph/queen/queen in hive.totalXenos)
+		for(var/mob/living/carbon/xenomorph/queen/queen in hive.total_living_xenos_advanced)
 			if(!should_block_game_interaction(queen) && queen != src && !QDELETED(queen))
 				next_queen = queen
 				break
@@ -778,7 +778,7 @@
 
 		// Reset the banished ckey list
 		if(length(hive.banished_ckeys))
-			for(var/mob/living/carbon/xenomorph/target_xeno in hive.totalXenos)
+			for(var/mob/living/carbon/xenomorph/target_xeno in hive.total_living_xenos)
 				if(!target_xeno.ckey)
 					continue
 				for(var/mob_name in hive.banished_ckeys)

--- a/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
@@ -50,7 +50,6 @@
 	life_value = 0
 	default_honor_value = 0
 	show_only_numbers = TRUE
-	counts_for_slots = FALSE
 	counts_for_roundend = FALSE
 	refunds_larva_if_banished = FALSE
 	crit_health = 0

--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -119,8 +119,8 @@
 		if(SSticker.mode && SSticker.current_state != GAME_STATE_FINISHED)
 			if((GLOB.last_ares_callout + 2 MINUTES) > world.time)
 				return
-			if(hive.hivenumber == XENO_HIVE_NORMAL && (LAZYLEN(hive.totalXenos) == 1))
-				var/mob/living/carbon/xenomorph/X = LAZYACCESS(hive.totalXenos, 1)
+			if(hive.hivenumber == XENO_HIVE_NORMAL && (LAZYLEN(hive.total_living_xenos_advanced) == 1))
+				var/mob/living/carbon/xenomorph/X = LAZYACCESS(hive.total_living_xenos_advanced, 1)
 				GLOB.last_ares_callout = world.time
 				// Tell the marines where the last one is.
 				var/name = "[MAIN_AI_SYSTEM] Bioscan Status"

--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -116,10 +116,14 @@
 	if(hive)
 		hive.remove_xeno(src)
 		// Finding the last xeno for anti-delay.
-		if(SSticker.mode && SSticker.current_state != GAME_STATE_FINISHED)
+		if(SSticker.mode && SSticker.current_state != GAME_STATE_FINISHED && hive.hivenumber == XENO_HIVE_NORMAL)
+			// Notify the hive that we are about to perish
+			if(LAZYLEN(hive.total_living_xenos_advanced == XENO_HIVE_COLLAPSE_THRESHOLD))
+				xeno_message(SPAN_XENOANNOUNCE("We can feel our hive's power weakening - only a few of us are left. Without a Queen, we perish!"))
+				return
 			if((GLOB.last_ares_callout + 2 MINUTES) > world.time)
 				return
-			if(hive.hivenumber == XENO_HIVE_NORMAL && (LAZYLEN(hive.total_living_xenos_advanced) == 1))
+			if(LAZYLEN(hive.total_living_xenos_advanced) == 1)
 				var/mob/living/carbon/xenomorph/X = LAZYACCESS(hive.total_living_xenos_advanced, 1)
 				GLOB.last_ares_callout = world.time
 				// Tell the marines where the last one is.

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -852,7 +852,7 @@
 		var/time_left = round((user.timeofdeath + JOIN_AS_FACEHUGGER_DELAY - world.time) / 10)
 		to_chat(user, SPAN_WARNING("You ghosted too recently. You cannot become a facehugger until 3 minutes have passed ([time_left] seconds remaining)."))
 		return FALSE
-	if(total_living_xenos_advanced.len <= 0)
+	if(length(total_living_xenos_advanced) <= 0)
 		//This is to prevent people from joining as Forsaken Huggers on the pred ship
 		to_chat(user, SPAN_WARNING("The hive has fallen, you can't join it!"))
 		return FALSE
@@ -907,7 +907,7 @@
 		to_chat(user, SPAN_WARNING("You ghosted too recently. You cannot become a lesser drone until 30 seconds have passed ([time_left] seconds remaining)."))
 		return FALSE
 
-	if(total_living_xenos_advanced.len <= 0)
+	if(length(total_living_xenos_advanced) <= 0)
 		to_chat(user, SPAN_WARNING("The hive has fallen, you can't join it!"))
 		return FALSE
 

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -602,9 +602,7 @@
 				slots[TIER_3][GUARANTEED_SLOTS][initial(current_caste.caste_type)] = slots_free - slots_used
 
 	var/burrowed_factor = min(stored_larva, sqrt(4*stored_larva))
-	var/effective_total = round(burrowed_factor)
-	for(var/mob/living/carbon/xenomorph/xeno as anything in total_living_xenos_advanced)
-		effective_total++
+	var/effective_total = length(total_living_xenos_advanced) + round(burrowed_factor)
 
 	// Tier 3 slots are always 20% of the total xenos in the hive
 	slots[TIER_3][OPEN_SLOTS] = max(0, Ceiling(0.20*effective_total/tier_slot_multiplier) - used_tier_3_slots)

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -831,11 +831,7 @@
 	return TRUE
 
 /datum/hive_status/proc/update_hugger_limit()
-	var/countable_xeno_iterator = 0
-	for(var/mob/living/carbon/xenomorph/cycled_xeno as anything in total_living_xenos_advanced)
-		countable_xeno_iterator++
-
-	playable_hugger_limit = max(Floor(countable_xeno_iterator / playable_hugger_max_divisor), playable_hugger_minimum)
+	playable_hugger_limit = max(Floor(length(total_living_xenos_advanced) / playable_hugger_max_divisor), playable_hugger_minimum)
 
 /datum/hive_status/proc/can_spawn_as_hugger(mob/dead/observer/user)
 	if(!GLOB.hive_datum || ! GLOB.hive_datum[hivenumber])
@@ -886,11 +882,7 @@
 	hugger.timeofdeath = user.timeofdeath // Keep old death time
 
 /datum/hive_status/proc/update_lesser_drone_limit()
-	var/countable_xeno_iterator = 0
-	for(var/mob/living/carbon/xenomorph/cycled_xeno as anything in total_living_xenos_advanced)
-		countable_xeno_iterator++
-
-	lesser_drone_limit = max(Floor(countable_xeno_iterator / playable_lesser_drones_max_divisor), lesser_drone_minimum)
+	lesser_drone_limit = max(Floor(length(total_living_xenos_advanced) / playable_lesser_drones_max_divisor), lesser_drone_minimum)
 
 /datum/hive_status/proc/can_spawn_as_lesser_drone(mob/dead/observer/user, obj/effect/alien/resin/special/pylon/spawning_pylon)
 	if(!GLOB.hive_datum || ! GLOB.hive_datum[hivenumber])

--- a/code/modules/mob/living/carbon/xenomorph/mark_menu.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mark_menu.dm
@@ -64,7 +64,7 @@
 		var/obj/effect/alien/resin/marker/RM = type
 		var/mark_owner = null
 		var/mark_owner_name = null
-		for(var/mob/living/carbon/xenomorph/XX in X.hive.totalXenos)
+		for(var/mob/living/carbon/xenomorph/XX in X.hive.total_living_xenos)
 			if(XX.nicknumber == RM.createdby)
 				mark_owner = XX.nicknumber
 				mark_owner_name = XX.name
@@ -159,7 +159,7 @@
 			else if(isqueen(X))
 				var/mob/living/carbon/xenomorph/mark_to_destroy_owner
 				to_chat(X, SPAN_XENONOTICE("You psychically command the [mark_to_destroy.mark_meaning.name] resin mark to be destroyed."))
-				for(var/mob/living/carbon/xenomorph/XX in X.hive.totalXenos)
+				for(var/mob/living/carbon/xenomorph/XX in X.hive.total_living_xenos)
 					if(XX.nicknumber == mark_to_destroy.createdby)
 						mark_to_destroy_owner = XX
 				to_chat(mark_to_destroy_owner, SPAN_XENONOTICE("Your [mark_to_destroy.mark_meaning.name] resin mark was commanded to be destroyed by [X.name]."))
@@ -186,7 +186,7 @@
 			var/mob/living/carbon/xenomorph/selected_xeno = tgui_input_list(X, "Target", "Watch which xenomorph?", possible_xenos, theme="hive_status")
 
 			if(selected_xeno == FunkTownOhyea)
-				for(var/mob/living/carbon/xenomorph/forced_xeno in X.hive.totalXenos)
+				for(var/mob/living/carbon/xenomorph/forced_xeno in X.hive.total_living_xenos)
 					forced_xeno.stop_tracking_resin_mark(FALSE, TRUE)
 					to_chat(forced_xeno, SPAN_XENOANNOUNCE("Hive! Your queen commands: [mark_to_force.mark_meaning.desc] in [get_area_name(mark_to_force)]. (<a href='?src=\ref[X];overwatch=1;target=\ref[mark_to_force]'>Watch</a>) (<a href='?src=\ref[X];track=1;target=\ref[mark_to_force]'>Track</a>)"))
 					forced_xeno.start_tracking_resin_mark(mark_to_force)

--- a/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
@@ -61,10 +61,7 @@
 	var/count = 0
 
 	// Compare the areas.
-	for(var/mob/living/carbon/xenomorph/X in hive.totalXenos)
-		if(!(X in GLOB.living_xeno_list))
-			continue
-
+	for(var/mob/living/carbon/xenomorph/X in hive.total_living_xenos_advanced)
 		var/area/XA = get_area(X)
 		if(XA == MA)
 			count++

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -273,7 +273,7 @@
 		for(var/hivenumber in GLOB.hive_datum)
 			hive = GLOB.hive_datum[hivenumber]
 			if(hive.latejoin_burrowed == TRUE)
-				if(length(hive.totalXenos) && (hive.hive_location || ROUND_TIME < XENO_ROUNDSTART_PROGRESS_TIME_2))
+				if(length(hive.total_living_xenos_advanced) && (hive.hive_location || ROUND_TIME < XENO_ROUNDSTART_PROGRESS_TIME_2))
 					hive.stored_larva++
 					hive.hive_ui.update_burrowed_larva()
 

--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -255,7 +255,7 @@ GLOBAL_LIST_EMPTY(shuttle_controls)
 				var/count = Q.count_hivemember_same_area()
 
 				// Check if at least half of the hive is onboard. If not, we don't launch.
-				if(count < length(Q.hive.totalXenos) * 0.5)
+				if(count < length(Q.hive.total_living_xenos_advanced) * 0.5)
 					to_chat(Q, SPAN_WARNING("More than half of your hive is not on board. Don't leave without them!"))
 					return
 


### PR DESCRIPTION
# About the pull request

<sup>wow, expanding on xeno code surely doesn't turn into huge refactors</sup>

This PR splits the `totalXenos` list into two separate lists. Currently, the `totalXenos` list contains every tier, including facehuggers and lessers (tier 0s). A few calculations in the game have to snowflakely exclude them, while at other places, tier 0s should simply not matter, but they do (e.g. currently, if you are the last living xeno, like a drone, you won't get the warning for it, because a facehugger is AFKing somewhere under a desk).

What this PR does is that when you join as a xeno, you get added to two lists:
- `total_living_xenos`: Every single xenomorph in the hive, including tier 0s.
- `total_living_xenos_advanced`: Every xenomorph excluding tier 0s.

This PR will change a few things:
- **You can no longer join as a tier 0 if there is not a single tier 1-4 xeno.** Currently, you can join as a tier 0 if the hive had nothing but a facehugger hiding somewhere. Now, you need at least one tier 1-4 xeno to be able to do so.
- "[Hive collapse](https://github.com/cmss13-devs/cmss13/pull/5442)" (>10 minutes being queenless) happens when there are less than 4 tier 1-4 xenos. This means that if there are 3 facehuggers and a drone running around, the hive will still collapse, resulting in a marine major.
- Xenos no longer get latejoin larva if there are only tier 0s alive. (this was just silly)
- Queens can no longer hijack if more than half of the tier 1-4 xenos are not onboard. (Previously, it counted tier 0s as well.)
- Queens can no longer select tier 0s to give evolution points to.
- When there is only one tier 1-4 xeno left, they get the message of being the last one, and ARES immediately performs a scan. Again, random facehuggers hiding under tables will not stop marines from ending the round.
- **ADDED:** When a xeno dies and there are only 3 (=hive collapse number) tier 1-4 xenos left, they get notified about it. This is to avoid round delays when there are 2 runners running around, not knowing whether there are 14 xenos left or only them.

<sub>this last thing is what I wanted to add but it ended up being an entire refactor</sub>

If this refactor doesn't actually make the code better, feel free to just close it, I'm not married to the idea.

# Explain why it's good for the game

Code-wise, I believe it cleans up things a lot, including:
- Removes the `counts_for_slots` variable that was solely used for mobs that had `tier = 0`. Just use `tier`.
- Removes a few IS THIS A HUGGER OR A LESSER?? checks, including `get_real_total_xeno_count()` which was a snowflake check just for tier 0s.
- Fixes some calculations (see above), makes the game saner.

Game-wise, it is a common occurrence that once the Queen dies, xenos scatter; then we end up with a facehugger afking under a table, a drone running around aimlessly, and a runner harassing the FOB. None of these three players know the round is basically over. Let them know it.


# Testing Photographs and Procedure

Cannot really screenshot anything, it is mainly a refactor.

# Changelog

:cl:
refactor: Refactored living xenomorph lists (totalXenos) into two separate ones to iron out some jankiness with facehuggers and lesser drones, leading to the following changes. 
add: Xenomorphs are now notified if there are only three tier 1-4s are left (excluding tier 0s) to avoid further delays.
balance: The last xenomorph is now counted as the last one who is tier 1-4. A random facehugger afking under a table will no longer stop ARES from showing marines where the last xenomorph is hiding.
balance: You can no longer join as a tier 0 xenomorph when there is not a single tier 1-4 alive.
balance: Xenomorphs no longer gain burrowed larva from marine latejoins if there are only tier 0s alive.
balance: Hive collapse now happens when there are less than 4 tier 1-4s. Previously, tier 0s also stopped a hive collapse, leading to a possible marine minor instead of a marine major.
balance: Queens can no longer hijack if more than half of her tier 1-4s are not onboard. This was already a thing, but it counted facehuggers and lessers too, who should not matter in this calculation.
balance: Queens can no longer select tier 0s to give evolution to, in exchange for a larva.
/:cl:
