### PR TITLE
Changes overwatch consoles to useSharedState to prevent losing state information upon closing the UI

### DIFF
--- a/tgui/packages/tgui/interfaces/OverwatchConsole.jsx
+++ b/tgui/packages/tgui/interfaces/OverwatchConsole.jsx
@@ -1,4 +1,4 @@
-import { useBackend, useLocalState, useSharedState } from '../backend';
+import { useBackend, useSharedState } from '../backend';
 import { Button, Section, Stack, Tabs, Table, Box, Input, NumberInput, LabeledControls, Divider, Collapsible } from '../components';
 import { Window } from '../layouts';
 
@@ -60,7 +60,7 @@ const HomePanel = (props) => {
 const SquadPanel = (props) => {
   const { act, data } = useBackend();
 
-  const [category, setCategory] = useLocalState('selected', 'monitor');
+  const [category, setCategory] = useSharedState('selected', 'monitor');
 
   return (
     <>
@@ -325,21 +325,21 @@ const SquadMonitor = (props) => {
 
   let { marines, squad_leader } = data;
 
-  const [hidden_marines, setHiddenMarines] = useLocalState(
+  const [hidden_marines, setHiddenMarines] = useSharedState(
     'hidden_marines',
     []
   );
 
-  const [showHiddenMarines, setShowHiddenMarines] = useLocalState(
+  const [showHiddenMarines, setShowHiddenMarines] = useSharedState(
     'showhidden',
     false
   );
-  const [showDeadMarines, setShowDeadMarines] = useLocalState(
+  const [showDeadMarines, setShowDeadMarines] = useSharedState(
     'showdead',
     false
   );
 
-  const [marineSearch, setMarineSearch] = useLocalState('marinesearch', null);
+  const [marineSearch, setMarineSearch] = useSharedState('marinesearch', null);
 
   let determine_status_color = (status) => {
     let conscious = status.includes('Conscious');


### PR DESCRIPTION

# About the pull request

Overwatch console will now save your filter settings, and they affect other people using the console

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
refactor: Overwatch console will now save your filter settings
/:cl:
