### PR TITLE
Vehicle bay elevator stuff

### DIFF
--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -176,9 +176,9 @@
 		flick(initial(icon_state) + "-denied",src)
 		return
 
-	// safety first
-	if(!is_mainship_level(SSshuttle.vehicle_elevator.z))
-		flick(initial(icon_state) + "-denied",src)
+	// If someone's trying to lower the railings but the elevator isn't in the vehicle bay.
+	if(!desiredstate && !is_mainship_level(SSshuttle.vehicle_elevator.z))
+		flick(initial(icon_state) + "-denied", src) // Safety first!
 		return
 
 	use_power(5)

--- a/code/game/objects/effects/elevator.dm
+++ b/code/game/objects/effects/elevator.dm
@@ -1,6 +1,6 @@
-/obj/effect/elevator/supply
-	name = "\improper empty space"
-	desc = "There seems to be an awful lot of machinery down below"
+/obj/effect/elevator
+	name = "\proper empty space"
+	desc = "There seems to be an awful lot of machinery down below..."
 	icon = 'icons/effects/160x160.dmi'
 	icon_state = "supply_elevator_lowered"
 	unacidable = TRUE
@@ -8,17 +8,25 @@
 	layer = ABOVE_TURF_LAYER
 	appearance_flags = KEEP_TOGETHER
 
-/obj/effect/elevator/supply/ex_act(severity)
+/obj/effect/elevator/ex_act(severity)
 	return
 
-/obj/effect/elevator/supply/Destroy(force)
+/obj/effect/elevator/Destroy(force)
 	if(!force)
 		return QDEL_HINT_LETMELIVE
 	return ..()
 
-/obj/effect/elevator/supply/visible_message() //Prevents message spam with empty elevator shaft - "The empty space falls into the depths!"
+// Don't move with the elevator.
+/obj/effect/elevator/onShuttleMove(turf/newT, turf/oldT, list/movement_force, move_dir, obj/docking_port/stationary/old_dock, obj/docking_port/mobile/moving_dock)
+	return
+/obj/effect/elevator/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
+	return
+/obj/effect/elevator/lateShuttleMove(turf/oldT, list/movement_force, move_dir)
 	return
 
 /obj/effect/elevator/animation_overlay
 	blend_mode = BLEND_INSET_OVERLAY
 	appearance_flags = KEEP_TOGETHER
+
+/obj/effect/elevator/vehicle
+	icon_state = "vehicle_elevator_lowered"

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -1401,12 +1401,13 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 	if(!SSshuttle.vehicle_elevator)
 		return
 
-	dat += "Platform position: "
-	if (SSshuttle.vehicle_elevator.timeLeft())
+	dat += "Platform position:<br>"
+	if (SSshuttle.vehicle_elevator.mode != SHUTTLE_IDLE)
 		dat += "Moving"
 	else
 		if(is_mainship_level(SSshuttle.vehicle_elevator.z))
-			dat += "Raised"
+			dat += "Raised<br>"
+			dat += "\[<a href='?src=\ref[src];lower_elevator=1'>Lower</a>\]"
 		else
 			dat += "Lowered"
 	dat += "<br><hr>"
@@ -1442,15 +1443,11 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 		world.log << "## ERROR: Eek. The supply/elevator datum is missing somehow."
 		return
 
-	if(!should_block_game_interaction(SSshuttle.vehicle_elevator))
-		to_chat(usr, SPAN_WARNING("The elevator needs to be in the cargo bay dock to call a vehicle up. Ask someone to send it away."))
-		return
-
 	if(isturf(loc) && ( in_range(src, usr) || isSilicon(usr) ) )
 		usr.set_interaction(src)
 
 	if(href_list["get_vehicle"])
-		if(is_mainship_level(SSshuttle.vehicle_elevator.z))
+		if(is_mainship_level(SSshuttle.vehicle_elevator.z) || SSshuttle.vehicle_elevator.mode != SHUTTLE_IDLE)
 			return
 		// dunno why the +1 is needed but the vehicles spawn off-center
 		var/turf/middle_turf = get_turf(SSshuttle.vehicle_elevator)
@@ -1458,9 +1455,11 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 		var/obj/vehicle/multitile/ordered_vehicle
 
 		var/datum/vehicle_order/VO = locate(href_list["get_vehicle"])
+		if(!(VO in vehicles))
+			return
 
-		if(!VO) return
-		if(VO.has_vehicle_lock()) return
+		if(VO?.has_vehicle_lock())
+			return
 
 		spent = TRUE
 		ordered_vehicle = new VO.ordered_vehicle(middle_turf)
@@ -1469,6 +1468,12 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 		VO.on_created(ordered_vehicle)
 
 		SEND_GLOBAL_SIGNAL(COMSIG_GLOB_VEHICLE_ORDERED, ordered_vehicle)
+
+	else if(href_list["lower_elevator"])
+		if(!is_mainship_level(SSshuttle.vehicle_elevator.z))
+			return
+
+		SSshuttle.vehicle_elevator.request(SSshuttle.getDock("adminlevel vehicle"))
 
 	add_fingerprint(usr)
 	updateUsrDialog()

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -1401,13 +1401,14 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 	if(!SSshuttle.vehicle_elevator)
 		return
 
-	dat += "Platform position:<br>"
+	dat += "Platform position: "
 	if (SSshuttle.vehicle_elevator.mode != SHUTTLE_IDLE)
 		dat += "Moving"
 	else
 		if(is_mainship_level(SSshuttle.vehicle_elevator.z))
-			dat += "Raised<br>"
-			dat += "\[<a href='?src=\ref[src];lower_elevator=1'>Lower</a>\]"
+			dat += "Raised"
+			if(!spent)
+				dat += "<br>\[<a href='?src=\ref[src];lower_elevator=1'>Lower</a>\]"
 		else
 			dat += "Lowered"
 	dat += "<br><hr>"
@@ -1448,6 +1449,7 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 
 	if(href_list["get_vehicle"])
 		if(is_mainship_level(SSshuttle.vehicle_elevator.z) || SSshuttle.vehicle_elevator.mode != SHUTTLE_IDLE)
+			to_chat(usr, SPAN_WARNING("The elevator needs to be in the cargo bay dock to call a vehicle up!"))
 			return
 		// dunno why the +1 is needed but the vehicles spawn off-center
 		var/turf/middle_turf = get_turf(SSshuttle.vehicle_elevator)

--- a/code/game/turfs/floor_types.dm
+++ b/code/game/turfs/floor_types.dm
@@ -210,20 +210,12 @@
 	plating_type = /turf/open/floor/tdome
 	hull_floor = TRUE
 
-//Cargo elevator
+/// Base type of the requisitions and vehicle bay elevator pits.
 /turf/open/floor/almayer/empty
-	name = "empty space"
+	name = "\proper empty space"
 	desc = "There seems to be an awful lot of machinery down below"
 	icon = 'icons/turf/floors/floors.dmi'
 	icon_state = "black"
-
-/turf/open/floor/almayer/empty/Initialize(mapload, ...)
-	. = ..()
-	GLOB.asrs_empty_space_tiles_list += src
-
-/turf/open/floor/almayer/empty/Destroy(force) // may as well
-	. = ..()
-	GLOB.asrs_empty_space_tiles_list -= src
 
 /turf/open/floor/almayer/empty/is_weedable()
 	return NOT_WEEDABLE
@@ -239,8 +231,13 @@
 
 /turf/open/floor/almayer/empty/Entered(atom/movable/AM)
 	..()
-	if(!isobserver(AM))
+	if(!isobserver(AM) && !istype(AM, /obj/docking_port))
 		addtimer(CALLBACK(src, PROC_REF(enter_depths), AM), 0.2 SECONDS)
+
+/// Returns a list of turfs to be used as a destination for anyone unfortunate enough to fall into the pit.
+/turf/open/floor/almayer/empty/proc/get_depths_turfs()
+	// Empty proc to be overridden.
+	return
 
 /turf/open/floor/almayer/empty/proc/enter_depths(atom/movable/AM)
 	if(AM.throwing == 0 && istype(get_turf(AM), /turf/open/floor/almayer/empty))
@@ -252,14 +249,12 @@
 		for(var/atom/computer as anything in GLOB.supply_controller.bound_supply_computer_list)
 			computer.balloon_alert_to_viewers("you hear horrifying noises coming from the elevator!")
 
-		var/area/area_shuttle = GLOB.supply_controller.shuttle?.get_location_area()
-		if(!area_shuttle)
-			return
-		var/list/turflist = list()
-		for(var/turf/turf in area_shuttle)
-			turflist |= turf
+		var/list/depths_turfs = get_depths_turfs()
+		if(!length(depths_turfs))
+			// If this ever happens, something went wrong.
+			CRASH("get_depths_turfs() didn't return anything!")
 
-		thrown_human.forceMove(pick(turflist))
+		thrown_human.forceMove(pick(depths_turfs))
 
 		var/timer = 0.5 SECONDS
 		for(var/index in 1 to 10)
@@ -268,8 +263,33 @@
 		return
 
 	else
-		for(var/obj/effect/decal/cleanable/C in contents) //for the off chance of someone bleeding mid=flight
+		for(var/obj/effect/decal/cleanable/C in contents) //for the off chance of someone bleeding mid-flight
 			qdel(C)
+
+/// Requisitions pit.
+/turf/open/floor/almayer/empty/requisitions
+
+/turf/open/floor/almayer/empty/requisitions/Initialize(mapload, ...)
+	. = ..()
+	GLOB.asrs_empty_space_tiles_list += src
+
+/turf/open/floor/almayer/empty/requisitions/Destroy(force)
+	GLOB.asrs_empty_space_tiles_list -= src
+	return ..()
+
+/turf/open/floor/almayer/empty/requisitions/get_depths_turfs()
+	var/area/elevator_area = GLOB.supply_controller.shuttle?.get_location_area()
+
+	var/turf_list = list()
+	for(var/turf/turf in elevator_area)
+		turf_list |= turf
+	return turf_list
+
+/// Vehicle bay pit.
+/turf/open/floor/almayer/empty/vehicle_bay
+
+/turf/open/floor/almayer/empty/vehicle_bay/get_depths_turfs()
+	return SSshuttle.vehicle_elevator.return_turfs()
 
 //Others
 /turf/open/floor/almayer/uscm

--- a/code/game/turfs/floor_types.dm
+++ b/code/game/turfs/floor_types.dm
@@ -213,7 +213,7 @@
 /// Base type of the requisitions and vehicle bay elevator pits.
 /turf/open/floor/almayer/empty
 	name = "\proper empty space"
-	desc = "There seems to be an awful lot of machinery down below"
+	desc = "There seems to be an awful lot of machinery down below..."
 	icon = 'icons/turf/floors/floors.dmi'
 	icon_state = "black"
 
@@ -231,7 +231,7 @@
 
 /turf/open/floor/almayer/empty/Entered(atom/movable/AM)
 	..()
-	if(!isobserver(AM) && !istype(AM, /obj/docking_port))
+	if(!isobserver(AM) && !istype(AM, /obj/effect/elevator) && !istype(AM, /obj/docking_port))
 		addtimer(CALLBACK(src, PROC_REF(enter_depths), AM), 0.2 SECONDS)
 
 /// Returns a list of turfs to be used as a destination for anyone unfortunate enough to fall into the pit.

--- a/code/modules/shuttle/vehicle_elevator.dm
+++ b/code/modules/shuttle/vehicle_elevator.dm
@@ -87,6 +87,46 @@
 	id = "almayer vehicle"
 	roundstart_template = /datum/map_template/shuttle/vehicle
 
+	//elevator effects (four so the entire elevator doesn't vanish when there's one opaque obstacle between you and the actual elevator loc).
+	var/obj/effect/elevator/vehicle/SW
+	var/obj/effect/elevator/vehicle/SE
+	var/obj/effect/elevator/vehicle/NW
+	var/obj/effect/elevator/vehicle/NE
+
+/obj/docking_port/stationary/vehicle_elevator/almayer/Initialize(mapload)
+	. = ..()
+	// Create and offset some effects for the elevator shaft sprite.
+	SW = new(locate(src.x - 2, src.y - 2, src.z))
+
+	SE = new(locate(src.x + 2, src.y - 2, src.z))
+	SE.pixel_x = -128
+
+	NW = new(locate(src.x - 2, src.y + 2, src.z))
+	NW.pixel_y = -128
+
+	NE = new(locate(src.x + 2, src.y + 2, src.z))
+	NE.pixel_x = -128
+	NE.pixel_y = -128
+
+	SW.invisibility = INVISIBILITY_ABSTRACT
+	SE.invisibility = INVISIBILITY_ABSTRACT
+	NW.invisibility = INVISIBILITY_ABSTRACT
+	NE.invisibility = INVISIBILITY_ABSTRACT
+
+// Make the elevator shaft visible when the elevator leaves.
+/obj/docking_port/stationary/vehicle_elevator/almayer/on_departure(obj/docking_port/mobile/departing_shuttle)
+	SW.invisibility = 0
+	SE.invisibility = 0
+	NW.invisibility = 0
+	NE.invisibility = 0
+
+// And make it invisible again when the elevator returns.
+/obj/docking_port/stationary/vehicle_elevator/almayer/on_arrival(obj/docking_port/mobile/arriving_shuttle)
+	SW.invisibility = INVISIBILITY_ABSTRACT
+	SE.invisibility = INVISIBILITY_ABSTRACT
+	NW.invisibility = INVISIBILITY_ABSTRACT
+	NE.invisibility = INVISIBILITY_ABSTRACT
+
 /obj/docking_port/stationary/vehicle_elevator/adminlevel
 	name = "Adminlevel Vehicle Elevator Dock"
 	id = "adminlevel vehicle"

--- a/code/modules/shuttle/vehicle_elevator.dm
+++ b/code/modules/shuttle/vehicle_elevator.dm
@@ -7,10 +7,11 @@
 
 	id = MOBILE_SHUTTLE_VEHICLE_ELEVATOR
 
-	callTime = 5 SECONDS
-	ignitionTime = 1 SECONDS
+	// Call and ""ignition"" times are set to line up with the sound effects.
+	callTime = 4 SECONDS
+	ignitionTime = 5 SECONDS
 
-	ignition_sound = 'sound/machines/asrs_raising.ogg'
+	ignition_sound = 'sound/machines/asrs_lowering.ogg'
 	ambience_idle = null
 	ambience_flight = null
 
@@ -28,19 +29,50 @@
 			railings += R
 
 /obj/docking_port/mobile/vehicle_elevator/on_ignition()
-	for(var/i in gears)
-		var/obj/structure/machinery/gear/G = i
-		G.start_moving()
+	. = ..()
+	// If the elevator isn't in the vehicle bay, start the gears immediately.
+	if(!is_mainship_level(z))
+		start_gears()
+
+		// Play the 'raising' sound effect at the destination docking port manually.
+		// `landing_sound` can't be used since that only plays on the elevator itself,
+		// and this sound file is too long for that either way.
+		playsound(destination, 'sound/machines/asrs_raising.ogg', 60)
+		return
+
+	// If the elevator *is* in the vehicle bay, close the railings and start the gears when it leaves.
+	close_railings()
+	addtimer(CALLBACK(src, PROC_REF(start_gears)), ignitionTime)
 
 /obj/docking_port/mobile/vehicle_elevator/afterShuttleMove()
-	if(!is_mainship_level(z))
-		return
-	for(var/i in gears)
-		var/obj/structure/machinery/gear/G = i
-		G.stop_moving()
-	for(var/i in railings)
-		var/obj/structure/machinery/door/poddoor/railing/R = i
-		INVOKE_ASYNC(R, TYPE_PROC_REF(/obj/structure/machinery/door, open))
+	. = ..()
+	// Check `get_docked()` in order to skip this if it just moved to the 'transit' port.
+	if(get_docked() == destination)
+		stop_gears()
+
+	// If the elevator moved to the vehicle bay, open the railings.
+	if(is_mainship_level(z))
+		open_railings()
+
+/obj/docking_port/mobile/vehicle_elevator/proc/start_gears()
+	for(var/obj/structure/machinery/gear/gear as anything in gears)
+		gear.start_moving()
+
+/obj/docking_port/mobile/vehicle_elevator/proc/stop_gears()
+	for(var/obj/structure/machinery/gear/gear as anything in gears)
+		gear.stop_moving()
+
+/obj/docking_port/mobile/vehicle_elevator/proc/open_railings()
+	for(var/obj/structure/machinery/door/poddoor/railing/railing as anything in railings)
+		// If the railing isn't already open.
+		if(railing.density)
+			railing.open()
+
+/obj/docking_port/mobile/vehicle_elevator/proc/close_railings()
+	for(var/obj/structure/machinery/door/poddoor/railing/railing as anything in railings)
+		// If the railing isn't already closed.
+		if(!railing.density)
+			railing.close()
 
 /obj/docking_port/stationary/vehicle_elevator
 	name = "Root Vehicle Elevator Dock"

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -218,7 +218,7 @@
 		if(iselevator)
 			if(istype(T,/turf/open/space))
 				if(is_mainship_level(T.z))
-					T.ChangeTurf(/turf/open/floor/almayer/empty)
+					T.ChangeTurf(/turf/open/floor/almayer/empty/requisitions)
 				else
 					T.ChangeTurf(/turf/open/gm/empty)
 		else if(istype(T,/turf/open/space))

--- a/code/modules/shuttles/shuttle_supply.dm
+++ b/code/modules/shuttles/shuttle_supply.dm
@@ -10,10 +10,10 @@
 	var/max_late_time = 300
 	var/railing_id = "supply_elevator_railing"
 	var/gear_id = "supply_elevator_gear"
-	var/obj/effect/elevator/supply/SW //elevator effects (four so the entire elevator doesn't vanish when
-	var/obj/effect/elevator/supply/SE //there's one opaque obstacle between you and the actual elevator loc).
-	var/obj/effect/elevator/supply/NW
-	var/obj/effect/elevator/supply/NE
+	var/obj/effect/elevator/SW //elevator effects (four so the entire elevator doesn't vanish when
+	var/obj/effect/elevator/SE //there's one opaque obstacle between you and the actual elevator loc).
+	var/obj/effect/elevator/NW
+	var/obj/effect/elevator/NE
 	var/Elevator_x
 	var/Elevator_y
 	var/Elevator_z
@@ -34,15 +34,15 @@
 		Elevator_x = pick_loc().x
 		Elevator_y = pick_loc().y
 		Elevator_z = pick_loc().z
-		SW = new /obj/effect/elevator/supply(locate(Elevator_x-2,Elevator_y-2,Elevator_z))
+		SW = new /obj/effect/elevator(locate(Elevator_x-2,Elevator_y-2,Elevator_z))
 		SW.vis_contents += elevator_animation
-		SE = new /obj/effect/elevator/supply(locate(Elevator_x+2,Elevator_y-2,Elevator_z))
+		SE = new /obj/effect/elevator(locate(Elevator_x+2,Elevator_y-2,Elevator_z))
 		SE.pixel_x = -128
 		SE.vis_contents += elevator_animation
-		NW = new /obj/effect/elevator/supply(locate(Elevator_x-2,Elevator_y+2,Elevator_z))
+		NW = new /obj/effect/elevator(locate(Elevator_x-2,Elevator_y+2,Elevator_z))
 		NW.pixel_y = -128
 		NW.vis_contents += elevator_animation
-		NE = new /obj/effect/elevator/supply(locate(Elevator_x+2,Elevator_y+2,Elevator_z))
+		NE = new /obj/effect/elevator(locate(Elevator_x+2,Elevator_y+2,Elevator_z))
 		NE.pixel_x = -128
 		NE.pixel_y = -128
 		NE.vis_contents += elevator_animation

--- a/code/modules/shuttles/shuttle_supply.dm
+++ b/code/modules/shuttles/shuttle_supply.dm
@@ -184,15 +184,3 @@
 		if(M.id == gear_id)
 			spawn()
 				M.icon_state = "gear"
-
-/obj/effect/landmark/vehicleelevator/Initialize(mapload, ...)
-	. = ..()
-	GLOB.vehicle_elevator = get_turf(src)
-	return INITIALIZE_HINT_QDEL
-
-/datum/shuttle/ferry/supply/vehicle
-	railing_id = "vehicle_elevator_railing"
-	gear_id = "vehicle_elevator_gears"
-
-/datum/shuttle/ferry/supply/vehicle/pick_loc()
-	return GLOB.vehicle_elevator

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -12215,7 +12215,7 @@
 /turf/open/floor/almayer,
 /area/almayer/squads/req)
 "bpR" = (
-/turf/open/floor/almayer/empty,
+/turf/open/floor/almayer/empty/requisitions,
 /area/supply/station)
 "bpS" = (
 /obj/structure/machinery/door/poddoor/railing{
@@ -12587,7 +12587,7 @@
 /area/almayer/squads/req)
 "bsK" = (
 /obj/effect/landmark/supply_elevator,
-/turf/open/floor/almayer/empty,
+/turf/open/floor/almayer/empty/requisitions,
 /area/supply/station)
 "bsL" = (
 /obj/structure/machinery/door/poddoor/railing{
@@ -53225,7 +53225,7 @@
 /area/almayer/squads/bravo)
 "oiX" = (
 /obj/docking_port/stationary/vehicle_elevator/almayer,
-/turf/open/floor/almayer/empty,
+/turf/open/floor/almayer/empty/vehicle_bay,
 /area/almayer/hallways/lower/vehiclehangar)
 "oiY" = (
 /obj/effect/decal/warning_stripes{
@@ -65062,7 +65062,7 @@
 	},
 /area/almayer/medical/lower_medical_medbay)
 "sje" = (
-/turf/open/floor/almayer/empty,
+/turf/open/floor/almayer/empty/vehicle_bay,
 /area/almayer/hallways/lower/vehiclehangar)
 "sjj" = (
 /obj/structure/machinery/keycard_auth{


### PR DESCRIPTION
# About the pull request

Makes the Vehicle Bay elevator work better.
Specifically:
- Adds some ASRS sound effects, and tweaks the timing of various elements to line up with them.
- Adds the pre-existing vehicle bay elevator shaft sprite for when the elevator has been lowered. (No animation yet though)
- Adds `\proper` to `/turf/open/floor/almayer/empty` and the elevator shaft effect to change the grammar of its examine text:
**Before/After:**
![before](https://github.com/cmss13-devs/cmss13/assets/57483089/d4fbf696-4f2c-47e3-8a7f-8f655112b9ff) ![after](https://github.com/cmss13-devs/cmss13/assets/57483089/1d883dec-306d-4605-88d5-97c1832b7428)
- Fixes(?) the front guard rails not raising when the elevator is lowered.
- Fixes a bug where the shipside docking port would fall into the elevator shaft after the elevator left:
![image](https://github.com/cmss13-devs/cmss13/assets/57483089/5cf513a4-118b-4567-8c71-d26d53585542)
- Fixes an oversight where a human falling into the vehicle bay elevator shaft would be teleported to the requisitions elevator.
- Fixes the gear things at the corners of the elevator spinning constantly until it's called back up.

(See comparison videos below)

# Explain why it's good for the game

The vehicle bay elevator doesn't get used often, but it *does* get used. This will hopefully make it feel a bit less janky.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

### Sending the elevator down and up again:
(Unmute for sound on both videos)

**Before:**

https://github.com/cmss13-devs/cmss13/assets/57483089/5fba87cd-2ef5-42ea-81f7-dc9872e4b622

**After:**

https://github.com/cmss13-devs/cmss13/assets/57483089/3f833e89-3e52-4fee-9f07-2c376ab2000b

</details>

(I've also tested this with #5401, and it seems to work without any issues.)

# Changelog
:cl:
add: Made the vehicle bay elevator look and sound better when in use.
fix: Fixed the vehicle bay elevator's front railings not closing when the elevator was lowered.
fix: Fixed the vehicle bay elevator's docking port falling down the elevator shaft when it was lowered.
fix: Fixed falling into the vehicle bay elevator shaft teleporting players to the requisitions elevator.
/:cl:
