### PR TITLE
Fix UPP & CLF Synth Skills

### DIFF
--- a/code/__DEFINES/human.dm
+++ b/code/__DEFINES/human.dm
@@ -182,8 +182,8 @@
 
 //Synthetic Defines
 #define SYNTH_COLONY "Third Generation Colonial Synthetic"
-#define SYNTH_COLONY_GEN_TWO "First Generation Colonial Synthetic"
-#define SYNTH_COLONY_GEN_ONE "Second Generation Colonial Synthetic"
+#define SYNTH_COLONY_GEN_TWO "Second Generation Colonial Synthetic"
+#define SYNTH_COLONY_GEN_ONE "First Generation Colonial Synthetic"
 #define SYNTH_COMBAT "Combat Synthetic"
 #define SYNTH_INFILTRATOR "Infiltrator Synthetic"
 #define SYNTH_WORKING_JOE "Working Joe"

--- a/code/modules/gear_presets/clf.dm
+++ b/code/modules/gear_presets/clf.dm
@@ -746,6 +746,7 @@
 	new_human.set_species(SYNTH_COLONY_GEN_ONE)
 
 /datum/equipment_preset/clf/synth/load_skills(mob/living/carbon/human/new_human)
+	. = ..()
 	new_human.allow_gun_usage = FALSE
 
 /datum/equipment_preset/clf/synth/load_gear(mob/living/carbon/human/new_human)

--- a/code/modules/gear_presets/upp.dm
+++ b/code/modules/gear_presets/upp.dm
@@ -2638,6 +2638,7 @@
 	new_human.set_species(SYNTH_GEN_THREE)
 
 /datum/equipment_preset/upp/synth/load_skills(mob/living/carbon/human/new_human)
+	. = ..()
 	new_human.allow_gun_usage = FALSE
 
 /datum/equipment_preset/upp/synth/load_gear(mob/living/carbon/human/new_human)


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #5830 And also fixes the incorrect defines (used for name) of colony synth gen 1 and 2.

# Explain why it's good for the game
Fixes #5853 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/c7c6bfb9-fc6c-4c38-a6c7-3941179c313f)
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/5a9bf223-30db-4e7c-a821-f4f79a4e4313)

</details>


# Changelog
:cl: Drathek
fix: Fixed skills not getting set for UPP and CLF synths
spellcheck: Fixed naming of colony synth gen 1 and gen 2 being swapped
/:cl:
