### PR TITLE
Fixes black tiles on lifeboats

### DIFF
--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -112,15 +112,12 @@
 	playsound(loc, 'sound/machines/hydraulics_2.ogg', 40, 1)
 	var/duration_time = 10
 	var/point_loc
-	var/old_loc = src.loc
 	if(ship_base)
 		duration_time = 70 //uninstalling equipment takes more time
 		point_loc = ship_base.loc
 	if(!do_after(user, duration_time * user.get_skill_duration_multiplier(SKILL_ENGINEER), INTERRUPT_NO_NEEDHAND|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 		return
 	if(point_loc && ship_base && ship_base.loc != point_loc) //dropship flew away
-		return
-	if(old_loc != src.loc) //We somehow moved (possibly into a different powerloader)
 		return
 	if(!PC.linked_powerloader || PC.loaded || PC.linked_powerloader.buckled_mob != user)
 		return

--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -112,12 +112,15 @@
 	playsound(loc, 'sound/machines/hydraulics_2.ogg', 40, 1)
 	var/duration_time = 10
 	var/point_loc
+	var/old_loc = src.loc
 	if(ship_base)
 		duration_time = 70 //uninstalling equipment takes more time
 		point_loc = ship_base.loc
 	if(!do_after(user, duration_time * user.get_skill_duration_multiplier(SKILL_ENGINEER), INTERRUPT_NO_NEEDHAND|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 		return
 	if(point_loc && ship_base && ship_base.loc != point_loc) //dropship flew away
+		return
+	if(old_loc != src.loc) //We somehow moved (possibly into a different powerloader)
 		return
 	if(!PC.linked_powerloader || PC.loaded || PC.linked_powerloader.buckled_mob != user)
 		return

--- a/maps/shuttles/lifeboat-port.dmm
+++ b/maps/shuttles/lifeboat-port.dmm
@@ -320,7 +320,8 @@
 /area/shuttle/lifeboat)
 "Jg" = (
 /turf/open/shuttle/escapepod{
-	icon_state = "floor8"
+	icon_state = "floor1";
+	dir = 4
 	},
 /area/shuttle/lifeboat)
 "Jw" = (

--- a/maps/shuttles/lifeboat-starboard.dmm
+++ b/maps/shuttles/lifeboat-starboard.dmm
@@ -446,7 +446,8 @@
 /area/shuttle/lifeboat)
 "VZ" = (
 /turf/open/shuttle/escapepod{
-	icon_state = "floor8"
+	icon_state = "floor1";
+	dir = 4
 	},
 /area/shuttle/lifeboat)
 "Xj" = (


### PR DESCRIPTION
# About the pull request

Caused by #3642

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.
These: 
![image](https://github.com/cmss13-devs/cmss13/assets/5618080/1b32fe0b-3dae-4ada-9639-dd82aac9247d)

Back to these:
![image](https://github.com/cmss13-devs/cmss13/assets/5618080/d6be385f-1dd4-4df2-b5fa-b528756fec21)

</details>


# Changelog
:cl:
fix: Fixes the lifeboat black turfs of Doom
/:cl:
