### PR TITLE
Makes larvae do the attack animation when nudging

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -288,6 +288,7 @@
 /mob/living/attack_larva(mob/living/carbon/xenomorph/larva/M)
 	M.visible_message(SPAN_DANGER("[M] nudges its head against [src]."), \
 	SPAN_DANGER("We nudge our head against [src]."), null, 5, CHAT_TYPE_XENO_FLUFF)
+	M.animation_attack_on(src)
 
 /mob/living/proc/is_xeno_grabbable()
 	if(stat == DEAD)


### PR DESCRIPTION
# About the pull request

Makes larvae do the attack animation when nudging, as they put their entire tiny body into the action.

Like this:

<details>
<summary>Larva attack</summary>

https://github.com/cmss13-devs/cmss13/assets/49321394/c3a2a254-d186-4fac-817a-37f4dcabf07e

</details>

# Explain why it's good for the game

When there is a roundstart Queen, larvae often rush her to greet her; they usually spam emotes to be little rascals. This way they could spam emotes _and_ mercilessly nudge her. Just a mechanic for a bit of RP, I guess.

Might be funny to bump marines too when the larva is in a really messed up situation. Maybe it scares them.

# Testing Photographs and Procedure

See above.

# Changelog

:cl:
add: Larvae now do the attack animation when nudging.
/:cl:
