### PR TITLE
Adds a visual indicator to the Transfer Plasma ability

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
@@ -310,6 +310,9 @@
 
 	to_chat(src, SPAN_NOTICE("We start focusing our plasma towards [target]."))
 	to_chat(target, SPAN_NOTICE("We feel that [src] starts transferring some of their plasma to us."))
+	face_atom(target)
+	target.flick_heal_overlay(transfer_delay, COLOR_CYAN)
+
 	if(!do_after(src, transfer_delay, INTERRUPT_ALL, BUSY_ICON_FRIENDLY))
 		return
 
@@ -320,6 +323,7 @@
 		amount = plasma_stored //Just use all of it
 	use_plasma(amount)
 	target.gain_plasma(amount)
+	target.xeno_jitter(1 SECONDS)
 	to_chat(target, SPAN_XENOWARNING("[src] has transfered [amount] plasma to us. We now have [target.plasma_stored]."))
 	to_chat(src, SPAN_XENOWARNING("We have transferred [amount] plasma to [target]. We now have [plasma_stored]."))
 	playsound(src, "alien_drool", 25)


### PR DESCRIPTION
# About the pull request

Adds this visual indicator to the Transfer Plasma ability:

<details>
<summary>Transfer Plasma</summary>

https://github.com/cmss13-devs/cmss13/assets/49321394/80a346c3-eb1b-4652-8d17-0f96c6d519df

</details>

# Explain why it's good for the game

1. It might make dumb idiot Hivelords and Queens stop running away from drones who try to feed them plasma.
2. There was only a generic xeno audio and a chat cue that the recipient should be standing still for two (2) seconds, both that are too easy to miss.
3. Visuals-wise, it makes it a bit more inline with the Transfer Health/Give Plasma abilities, without changing its functionality.
4. Marines can now see if someone is getting remotely plasma buffed (via Hivelords)

# Testing Photographs and Procedure

See above.

# Changelog

:cl:
qol: The Transfer Plasma ability now has a blue, healing overlay and causes a second-long jitter upon success, to show the recipient that they are being targeted.
/:cl:
