### PR TITLE
Fixes the X17 Riot Breaching Charge

### DIFF
--- a/code/game/objects/items/explosives/plastic.dm
+++ b/code/game/objects/items/explosives/plastic.dm
@@ -24,6 +24,9 @@
 	var/list/breachable = list(/obj/structure/window, /turf/closed, /obj/structure/machinery/door, /obj/structure/mineral_door , /obj/structure/cargo_container)
 	antigrief_protection = TRUE //Should it be checked by antigrief?
 
+	var/req_skill = SKILL_ENGINEER
+	var/req_skill_level = SKILL_ENGINEER_TRAINED
+
 /obj/item/explosive/plastic/Destroy()
 	disarm()
 	return ..()
@@ -65,7 +68,7 @@
 
 	if(user.action_busy || !flag)
 		return
-	if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))
+	if(!skillcheck(user, req_skill, req_skill_level))
 		to_chat(user, SPAN_WARNING("You don't seem to know how to use [src]..."))
 		return
 	if(!can_place(user, target))
@@ -363,6 +366,9 @@
 	overlay_image = "riot-active"
 	shrapnel_volume = 20
 	shrapnel_type = /datum/ammo/bullet/shrapnel/rubber
+	req_skill = SKILL_POLICE
+	req_skill_level = SKILL_POLICE_SKILLED
+	antigrief_protection = FALSE
 
 /obj/item/explosive/plastic/breaching_charge/plasma
 	name = "plasma charge"


### PR DESCRIPTION

# About the pull request

MPs can now use the charge.
Also refactored the skill check for plastic explosives to be variable controlled.

# Explain why it's good for the game

MPs should be able to use their own tools.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
code: Plastic Explosives and subtypes now have variable controlled skill checks rather than hard-code.
fix: MPs can now use Riot Breaching Charges as intended.
/:cl:
