### PR TITLE
Battlefield executions done on the Almayer can be heard by everyone onboard

### DIFF
--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -4,6 +4,7 @@
 #define COOLDOWN_HIJACK_GROUND_CHECK "gamemode_ground_check"
 #define COOLDOWN_ITEM_HOOD_SOUND "item_hood_sound"
 #define COOLDOWN_LIGHT "cooldown_light"
+#define COOLDOWN_SHIPWIDE_EXECUTION_ALERT "shipwide_execution_alert"
 
 //Define for ship alt
 #define COOLDOWN_ALTITUDE_CHANGE "altitude_change"

--- a/code/datums/ammo/bullet/bullet.dm
+++ b/code/datums/ammo/bullet/bullet.dm
@@ -55,8 +55,9 @@
 
 	if(fired_from.flags_gun_features & GUN_SILENCED)
 		playsound(user, fired_from.fire_sound, 25, FALSE)
-	else if(is_mainship_level(user.z))
+	else if(is_mainship_level(user.z) && !TIMER_COOLDOWN_CHECK(user, COOLDOWN_SHIPWIDE_EXECUTION_ALERT))
 		playsound_z(SSmapping.levels_by_any_trait(list(ZTRAIT_MARINE_MAIN_SHIP)), fired_from.fire_sound, volume = fired_from.firesound_volume)
+		TIMER_COOLDOWN_START(user, COOLDOWN_SHIPWIDE_EXECUTION_ALERT, 5 SECONDS)
 	else
 		playsound(user, fired_from.fire_sound, fired_from.firesound_volume, FALSE)
 

--- a/code/datums/ammo/bullet/bullet.dm
+++ b/code/datums/ammo/bullet/bullet.dm
@@ -53,10 +53,12 @@
 		fired_from.delete_bullet(firing_projectile, TRUE)
 		return
 
-	if(!(fired_from.flags_gun_features & GUN_SILENCED))
-		playsound(user, fired_from.fire_sound, fired_from.firesound_volume, FALSE)
-	else
+	if(fired_from.flags_gun_features & GUN_SILENCED)
 		playsound(user, fired_from.fire_sound, 25, FALSE)
+	else if(is_mainship_level(user.z))
+		playsound_z(SSmapping.levels_by_any_trait(list(ZTRAIT_MARINE_MAIN_SHIP)), fired_from.fire_sound, volume = fired_from.firesound_volume)
+	else
+		playsound(user, fired_from.fire_sound, fired_from.firesound_volume, FALSE)
 
 	shake_camera(user, 1, 2)
 


### PR DESCRIPTION
# About the pull request

If the CO battlefield executes someone on the Almayer (and does it with a gun that has no silencer on it), the shot will be audible for everyone onboard.

If the weapon is silenced or the CO is not on the Almayer, the execution's audio remains the same.

In case of a mass execution, there is a 5 seconds timer, meaning if the CO executes three people in 5 seconds, only one shot will be audible across the Almayer, the other two shots will be local.

# Explain why it's good for the game

Blaxxon Blonz brought this up in an [ideasguys thread](https://forum.cm-ss13.com/t/bes-should-be-audible-throughout-the-almayer/6811). I found it hilarious, so here it is.

His initial post aligns with my own opinion, please read it.

It would be cool to add some echo effect to it, but I do not think we are capable of doing so with this proc (since the audio is always based on the bullet being used).

# Testing Photographs and Procedure

1. Join a server with three ckeys, one CO, one rifleman, one doctor
2. Mute the CO and rifleman clients
3. Move the doctor to the morgue
4. Execute the rifleman in the cryostorage room
5. Listen to the audio

# Changelog

:cl:
add: Battlefield executions performed on the Almayer can be now heard by everyone onboard, unless the gun is silenced. There is a five-seconds long cooldown between ship-wide noises, pace your executions if you want everything to be heard.
/:cl:
