### PR TITLE
Crashed/Hijacked Dropship Mode Fixes

### DIFF
--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -141,10 +141,13 @@
 	// if the dropship has crashed don't allow more interactions
 	var/obj/docking_port/mobile/marine_dropship/shuttle = SSshuttle.getShuttle(shuttleId)
 	if(shuttle.mode == SHUTTLE_CRASHED)
-		to_chat(user, SPAN_NOTICE("\The [src] is not responsive"))
+		to_chat(user, SPAN_NOTICE("[src] is unresponsive."))
 		return
 
 	if(dropship_control_lost)
+		if(shuttle.is_hijacked)
+			to_chat(user, SPAN_WARNING("The shuttle is not responding due to an unauthorized access attempt."))
+			return
 		var/remaining_time = timeleft(door_control_cooldown) / 10
 		to_chat(user, SPAN_WARNING("The shuttle is not responding due to an unauthorized access attempt. In large text it says the lockout will be automatically removed in [remaining_time] seconds."))
 		if(!skillcheck(user, SKILL_PILOT, SKILL_PILOT_EXPERT))
@@ -324,14 +327,14 @@
 		colonial_marines.add_current_round_status_to_end_results("Hijack")
 
 /obj/structure/machinery/computer/shuttle/dropship/flight/proc/remove_door_lock()
+	if(door_control_cooldown)
+		deltimer(door_control_cooldown)
+		door_control_cooldown = null
 	var/obj/docking_port/mobile/marine_dropship/shuttle = SSshuttle.getShuttle(shuttleId)
 	if(shuttle.is_hijacked)
 		return
 	playsound(loc, 'sound/machines/terminal_success.ogg', KEYBOARD_SOUND_VOLUME, 1)
 	dropship_control_lost = FALSE
-	if(door_control_cooldown)
-		deltimer(door_control_cooldown)
-		door_control_cooldown = null
 
 /obj/structure/machinery/computer/shuttle/dropship/flight/ui_data(mob/user)
 	var/obj/docking_port/mobile/marine_dropship/shuttle = SSshuttle.getShuttle(shuttleId)

--- a/code/modules/shuttle/computers/escape_pod_computer.dm
+++ b/code/modules/shuttle/computers/escape_pod_computer.dm
@@ -238,7 +238,7 @@
 
 /obj/structure/machinery/door/airlock/evacuation/Destroy()
 	if(linked_shuttle)
-		linked_shuttle.mode = SHUTTLE_CRASHED
+		linked_shuttle.set_mode(SHUTTLE_CRASHED)
 		linked_shuttle.door_handler.doors -= list(src)
 	. = ..()
 

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -792,6 +792,10 @@
 			else if(error)
 				setTimer(20)
 				return
+			if(mode == SHUTTLE_CRASHED)
+				destination = null
+				timer = 0
+				return
 			if(rechargeTime)
 				set_mode(SHUTTLE_RECHARGING)
 				destination = null
@@ -810,6 +814,8 @@
 				setTimer(callTime * engine_coeff())
 				enterTransit()
 				return
+		if(SHUTTLE_CRASHED)
+			return
 
 	set_idle()
 

--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -304,7 +304,7 @@
 
 /obj/docking_port/stationary/marine_dropship/crash_site/on_arrival(obj/docking_port/mobile/arriving_shuttle)
 	. = ..()
-	arriving_shuttle.mode = SHUTTLE_CRASHED
+	arriving_shuttle.set_mode(SHUTTLE_CRASHED)
 	for(var/mob/living/carbon/affected_mob in (GLOB.alive_human_list + GLOB.living_xeno_list)) //knock down mobs
 		if(affected_mob.z != z)
 			continue


### PR DESCRIPTION

# About the pull request

This PR tweaks how the dropship handles crashing; namely for hijack. As is, you can attempt to recover a crashed dropship as a PO; but it would just allow you to bring the timer down to 0 seconds remaining and allow you to spam the success messages/noises.

Now dropships that are crashed won't attempt to enter the refueling mode nor get spammed to idle. They will also delete their hijack timer eventually rather than let it sit at 0.

# Explain why it's good for the game

More accurate messages when interacting with a crashed or hijacking dropship.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/76988376/1db7e545-f10f-4b74-a097-3de2743f85ce

Also tweaked the not responsive message post recording:
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/506d68f0-f5a7-4b08-9ab8-4404853c1df8)

</details>


# Changelog
:cl: Drathek
fix: Fixed crashed/hijack dropship not staying in the crashed mode.
/:cl:
