### PR TITLE
Refactor areas on Almayer in upper deck and tweak map a bit to reflect it.

### DIFF
--- a/code/game/area/almayer.dm
+++ b/code/game/area/almayer.dm
@@ -370,6 +370,10 @@
 	name = "\improper Upper Deck Stern Hallway"
 	icon_state = "stern"
 
+/area/almayer/hallways/upper/midship_hallway
+	name = "\improper Upper Deck Midship Hallway"
+	icon_state = "stern"
+
 /area/almayer/hallways/upper/port
 	name = "\improper Upper Deck Port Hallway"
 	icon_state = "port"
@@ -424,6 +428,18 @@
 
 /area/almayer/maint/upper/u_m_s
 	name = "\improper Upper Deck Starboard-Midship Maintenance"
+
+/area/almayer/maint/upper/u_a_p
+	name = "\improper Upper Deck Port-Aft Maintenance"
+
+/area/almayer/maint/upper/u_a_s
+	name = "\improper Upper Deck Starboard-Aft Maintenance"
+
+/area/almayer/maint/upper/u_s_p
+	name = "\improper Upper Deck Port-Stern Maintenance"
+
+/area/almayer/maint/upper/u_s_s
+	name = "\improper Upper Deck Starboard-Stern Maintenance"
 
 // hull areas
 /area/almayer/maint/hull

--- a/code/game/area/almayer.dm
+++ b/code/game/area/almayer.dm
@@ -366,8 +366,8 @@
 	name = "\improper Upper Deck Aft Hallway"
 	icon_state = "aft"
 
-/area/almayer/hallways/upper/stern_hallway
-	name = "\improper Upper Deck Stern Hallway"
+/area/almayer/hallways/upper/fore_hallway
+	name = "\improper Upper Deck Fore Hallway"
 	icon_state = "stern"
 
 /area/almayer/hallways/upper/midship_hallway
@@ -429,17 +429,17 @@
 /area/almayer/maint/upper/u_m_s
 	name = "\improper Upper Deck Starboard-Midship Maintenance"
 
+/area/almayer/maint/upper/u_f_p
+	name = "\improper Upper Deck Port-Fore Maintenance"
+
+/area/almayer/maint/upper/u_f_s
+	name = "\improper Upper Deck Starboard-Fore Maintenance"
+
 /area/almayer/maint/upper/u_a_p
 	name = "\improper Upper Deck Port-Aft Maintenance"
 
 /area/almayer/maint/upper/u_a_s
 	name = "\improper Upper Deck Starboard-Aft Maintenance"
-
-/area/almayer/maint/upper/u_s_p
-	name = "\improper Upper Deck Port-Stern Maintenance"
-
-/area/almayer/maint/upper/u_s_s
-	name = "\improper Upper Deck Starboard-Stern Maintenance"
 
 // hull areas
 /area/almayer/maint/hull

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -569,7 +569,7 @@
 /area/almayer/shipboard/weapon_room)
 "acQ" = (
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "acS" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -1848,13 +1848,6 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
-"akS" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/machinery/light,
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/command/lifeboat)
 "ald" = (
 /turf/open/floor/almayer{
 	icon_state = "red"
@@ -2014,7 +2007,7 @@
 /turf/open/floor/almayer{
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "amd" = (
 /obj/structure/machinery/vending/cola{
 	density = 0;
@@ -7309,6 +7302,11 @@
 	icon_state = "red"
 	},
 /area/almayer/hallways/upper/starboard)
+"aLh" = (
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/hallways/upper/starboard)
 "aLp" = (
 /obj/structure/sign/safety/cryo{
 	pixel_x = 8;
@@ -7762,7 +7760,7 @@
 	dir = 6;
 	icon_state = "orange"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "aOy" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -8006,15 +8004,6 @@
 	icon_state = "emerald"
 	},
 /area/almayer/command/cic)
-"aPC" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/aft_hallway)
 "aPD" = (
 /obj/structure/machinery/photocopier,
 /turf/open/floor/almayer{
@@ -8290,7 +8279,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "aRo" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -8299,12 +8288,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/bravo)
-"aRp" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/command/lifeboat)
 "aRq" = (
 /obj/structure/closet/secure_closet/staff_officer/gear,
 /obj/structure/machinery/camera/autoname/almayer{
@@ -10473,7 +10456,7 @@
 	dir = 5;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "bfl" = (
 /turf/open/floor/almayer{
 	dir = 5;
@@ -10641,7 +10624,7 @@
 	dir = 9;
 	icon_state = "silver"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "bgj" = (
 /obj/structure/machinery/landinglight/ds1{
 	dir = 8
@@ -10979,7 +10962,7 @@
 	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/port)
 "biq" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/glass/beaker/large,
@@ -11035,7 +11018,7 @@
 	dir = 5;
 	icon_state = "orange"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "biC" = (
 /obj/structure/largecrate/random/case,
 /obj/structure/machinery/access_button/airlock_exterior,
@@ -11178,11 +11161,14 @@
 	},
 /area/almayer/hallways/hangar)
 "bkb" = (
+/obj/structure/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/almayer{
 	dir = 4;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/port)
 "bkd" = (
 /obj/structure/machinery/landinglight/ds2/delaytwo{
 	dir = 8
@@ -12287,7 +12273,7 @@
 	dir = 4;
 	icon_state = "orange"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "brn" = (
 /obj/structure/machinery/door/airlock/almayer/marine/bravo/smart,
 /turf/open/floor/almayer{
@@ -13007,10 +12993,10 @@
 	pixel_y = 25
 	},
 /turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "orange"
+	dir = 4;
+	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "bwP" = (
 /obj/effect/step_trigger/clone_cleaner,
 /turf/open/floor/plating/almayer{
@@ -13097,7 +13083,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "bxA" = (
 /obj/structure/machinery/power/apc/almayer/hardened,
 /obj/effect/decal/warning_stripes{
@@ -13161,7 +13147,7 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "bxY" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/flora/pottedplant{
@@ -13822,7 +13808,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "bDn" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/closed/wall/almayer,
@@ -15159,7 +15145,7 @@
 /turf/open/floor/almayer{
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "bLh" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -15395,7 +15381,7 @@
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "bMq" = (
 /obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep,
 /obj/structure/machinery/light{
@@ -15556,11 +15542,8 @@
 	pixel_x = 14;
 	pixel_y = 32
 	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "bluecorner"
-	},
-/area/almayer/hallways/upper/aft_hallway)
+/turf/open/floor/almayer,
+/area/almayer/hallways/upper/midship_hallway)
 "bNa" = (
 /obj/structure/surface/table/almayer,
 /obj/item/folder/black,
@@ -15771,7 +15754,7 @@
 	dir = 1;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "bNL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -15822,7 +15805,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "bOq" = (
 /obj/structure/prop/almayer/cannon_cables,
 /turf/open/floor/almayer{
@@ -16622,7 +16605,7 @@
 	dir = 4;
 	icon_state = "greencorner"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "bTE" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -17085,6 +17068,11 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/chapel)
+"bWx" = (
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/hallways/upper/port)
 "bWJ" = (
 /obj/structure/machinery/shower{
 	dir = 4
@@ -17340,7 +17328,7 @@
 	dir = 9;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "bZr" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -17626,7 +17614,7 @@
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "cbL" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 1;
@@ -18115,10 +18103,8 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/open/floor/almayer{
-	icon_state = "orange"
-	},
-/area/almayer/hallways/upper/stern_hallway)
+/turf/open/floor/almayer,
+/area/almayer/hallways/upper/midship_hallway)
 "chL" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -18333,7 +18319,7 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "ciN" = (
 /turf/open/floor/almayer{
 	dir = 6;
@@ -19574,10 +19560,10 @@
 	pixel_y = 30
 	},
 /turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "orange"
+	dir = 4;
+	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "cuq" = (
 /obj/structure/machinery/computer/arcade,
 /turf/open/floor/wood/ship,
@@ -19615,7 +19601,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "cuN" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -19703,7 +19689,7 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "cwo" = (
 /obj/structure/largecrate/random/mini/chest{
 	pixel_x = 4
@@ -19725,9 +19711,9 @@
 	pixel_y = -25
 	},
 /turf/open/floor/almayer{
-	icon_state = "orange"
+	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "cwS" = (
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor/almayer/aicore/no_build,
@@ -19835,7 +19821,7 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "czN" = (
 /obj/item/device/radio/intercom{
 	freerange = 1;
@@ -20184,7 +20170,7 @@
 	dir = 8;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "cFP" = (
 /obj/structure/sign/safety/outpatient{
 	pixel_x = -17;
@@ -20430,7 +20416,7 @@
 /turf/open/floor/almayer{
 	allow_construction = 0
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "cKm" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/glass/bucket/mopbucket{
@@ -20464,12 +20450,6 @@
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/upper_engineering/port)
-"cKW" = (
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "blue"
-	},
-/area/almayer/hallways/upper/aft_hallway)
 "cLl" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -20903,7 +20883,7 @@
 	dir = 8;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "cSP" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 6
@@ -21030,7 +21010,7 @@
 	dir = 6;
 	icon_state = "orange"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "cVZ" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
@@ -21501,7 +21481,7 @@
 	dir = 9;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "ddw" = (
 /obj/structure/machinery/cm_vending/sorted/tech/comp_storage,
 /obj/structure/sign/safety/terminal{
@@ -21511,15 +21491,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/lower/workshop/hangar)
-"ddx" = (
-/obj/structure/machinery/status_display{
-	pixel_y = 30
-	},
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "blue"
-	},
-/area/almayer/hallways/upper/aft_hallway)
 "ddz" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = 32
@@ -21667,7 +21638,7 @@
 	dir = 1;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "dha" = (
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -21757,13 +21728,6 @@
 	icon_state = "cargo_arrow"
 	},
 /area/almayer/squads/alpha_bravo_shared)
-"djd" = (
-/obj/structure/machinery/light,
-/turf/open/floor/almayer{
-	dir = 6;
-	icon_state = "blue"
-	},
-/area/almayer/hallways/upper/aft_hallway)
 "djQ" = (
 /obj/item/device/radio/intercom{
 	freerange = 1;
@@ -21885,7 +21849,7 @@
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "dmg" = (
 /obj/structure/machinery/vending/coffee,
 /obj/structure/sign/safety/coffee{
@@ -21980,7 +21944,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "dnm" = (
 /obj/structure/machinery/cm_vending/sorted/cargo_guns/intelligence_officer,
 /obj/structure/machinery/light{
@@ -22118,7 +22082,7 @@
 	dir = 8;
 	icon_state = "orange"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "dpO" = (
 /obj/structure/machinery/cm_vending/clothing/marine/delta{
 	density = 0;
@@ -22134,7 +22098,7 @@
 	dir = 4;
 	icon_state = "bluecorner"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "dqb" = (
 /obj/structure/sign/safety/security{
 	pixel_x = -16
@@ -22331,7 +22295,7 @@
 	},
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "duT" = (
 /obj/structure/bed,
 /obj/structure/machinery/flasher{
@@ -22576,7 +22540,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "dyK" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -22595,6 +22559,18 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/general_equipment)
+"dzV" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/hallways/upper/midship_hallway)
 "dzX" = (
 /obj/structure/sign/safety/water{
 	pixel_x = -17
@@ -22782,7 +22758,7 @@
 	dir = 8;
 	icon_state = "silver"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "dCe" = (
 /obj/structure/machinery/cryopod{
 	pixel_y = 6
@@ -22866,7 +22842,7 @@
 	dir = 8;
 	icon_state = "silver"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "dDp" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W";
@@ -23021,7 +22997,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "dFk" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -23307,7 +23283,7 @@
 	dir = 4;
 	icon_state = "silvercorner"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "dKK" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -23479,7 +23455,7 @@
 /turf/open/floor/almayer{
 	icon_state = "silver"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "dPd" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/flashlight/lamp{
@@ -23634,7 +23610,6 @@
 	},
 /area/almayer/shipboard/brig/mp_bunks)
 "dRo" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/sign/safety/bridge{
 	pixel_x = 15;
 	pixel_y = 32
@@ -23643,9 +23618,10 @@
 	pixel_y = 32
 	},
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	dir = 5;
+	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "dRs" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/almayer{
@@ -24112,20 +24088,11 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/engineering/lower/workshop/hangar)
-"dZP" = (
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "silver"
-	},
-/area/almayer/hallways/upper/aft_hallway)
 "dZR" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "orange"
-	},
-/area/almayer/hallways/upper/stern_hallway)
+/turf/open/floor/almayer,
+/area/almayer/hallways/upper/midship_hallway)
 "dZZ" = (
 /obj/structure/surface/rack,
 /obj/item/tool/weldpack,
@@ -24243,7 +24210,7 @@
 	pixel_y = 30
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "ecb" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -24281,7 +24248,7 @@
 	dir = 8;
 	icon_state = "silver"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "ecS" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -24934,7 +24901,6 @@
 	},
 /area/almayer/engineering/lower/workshop)
 "enz" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/sign/safety/bridge{
 	pixel_x = 15;
 	pixel_y = -32
@@ -24943,15 +24909,16 @@
 	pixel_y = -32
 	},
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	dir = 6;
+	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "enF" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out"
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "enK" = (
 /obj/effect/step_trigger/clone_cleaner,
 /obj/structure/blocker/forcefield/multitile_vehicles,
@@ -25906,7 +25873,7 @@
 	dir = 1
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "eFa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25951,7 +25918,7 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "eFK" = (
 /obj/structure/bed{
 	icon_state = "abed"
@@ -26133,12 +26100,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/lower/starboard_fore_hallway)
-"eJg" = (
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "red"
-	},
-/area/almayer/hallways/upper/aft_hallway)
 "eJj" = (
 /obj/structure/closet/crate,
 /obj/item/ammo_box/magazine/l42a,
@@ -26474,7 +26435,7 @@
 /turf/open/floor/almayer{
 	icon_state = "silvercorner"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "eQm" = (
 /obj/structure/machinery/power/apc/almayer{
 	dir = 1
@@ -26800,7 +26761,7 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "eXb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27243,7 +27204,7 @@
 	dir = 6;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "fdx" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -27519,11 +27480,6 @@
 /obj/item/device/camera_film,
 /turf/open/floor/almayer,
 /area/almayer/command/corporateliaison)
-"fiH" = (
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/hallways/upper/stern_hallway)
 "fiN" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating/plating_catwalk,
@@ -27966,7 +27922,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "frM" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S";
@@ -28005,7 +27961,6 @@
 	},
 /area/almayer/living/gym)
 "fsu" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -28013,9 +27968,10 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	dir = 4;
+	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "fsR" = (
 /obj/structure/pipes/vents/pump{
 	dir = 8;
@@ -28043,10 +27999,10 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	dir = 5;
+	dir = 1;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "ftG" = (
 /obj/structure/sign/safety/life_support{
 	pixel_x = 8;
@@ -28064,7 +28020,7 @@
 	dir = 4;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "fuz" = (
 /obj/structure/machinery/cm_vending/clothing/pilot_officer,
 /turf/open/floor/almayer{
@@ -28167,7 +28123,7 @@
 	dir = 1;
 	icon_state = "bluecorner"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "fvJ" = (
 /obj/structure/machinery/cm_vending/sorted/medical/bolted,
 /turf/open/floor/almayer{
@@ -28328,7 +28284,7 @@
 	dir = 6;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "fzq" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -28405,7 +28361,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "fBi" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -28431,7 +28387,7 @@
 /turf/open/floor/almayer{
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "fBO" = (
 /obj/structure/machinery/chem_master{
 	vial_maker = 1
@@ -28483,7 +28439,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "fCT" = (
 /obj/structure/surface/table/almayer,
 /obj/item/fuel_cell,
@@ -28521,7 +28477,7 @@
 /turf/open/floor/almayer{
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "fDG" = (
 /obj/structure/machinery/vending/coffee,
 /obj/structure/machinery/light{
@@ -28737,7 +28693,7 @@
 "fGD" = (
 /obj/effect/step_trigger/clone_cleaner,
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "fHb" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating/plating_catwalk,
@@ -29279,15 +29235,6 @@
 	},
 /turf/open/floor/carpet,
 /area/almayer/command/corporateliaison)
-"fQU" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "orange"
-	},
-/area/almayer/hallways/upper/stern_hallway)
 "fRg" = (
 /obj/structure/closet/emcloset,
 /obj/structure/machinery/camera/autoname/almayer{
@@ -29497,7 +29444,7 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "fXg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -29685,7 +29632,7 @@
 	pixel_y = 25
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "gaJ" = (
 /turf/closed/wall/almayer,
 /area/almayer/shipboard/brig/cryo)
@@ -29769,10 +29716,10 @@
 	pixel_y = 32
 	},
 /turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "orange"
+	dir = 4;
+	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "gcm" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -29783,19 +29730,6 @@
 	icon_state = "red"
 	},
 /area/almayer/hallways/upper/port)
-"gcq" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "NE-out";
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/hallways/upper/starboard)
 "gcN" = (
 /obj/structure/machinery/door/airlock/almayer/command{
 	access_modified = 1;
@@ -29942,15 +29876,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/grunt_rnr)
-"gft" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer,
-/area/almayer/hallways/upper/stern_hallway)
 "gfu" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -29964,7 +29889,7 @@
 /area/almayer/command/airoom)
 "gfv" = (
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "gfE" = (
 /obj/structure/machinery/recharge_station,
 /turf/open/floor/plating,
@@ -30231,7 +30156,7 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "gll" = (
 /obj/structure/machinery/power/apc/almayer{
 	dir = 1
@@ -30323,7 +30248,7 @@
 	dir = 9;
 	icon_state = "orange"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "gnu" = (
 /obj/structure/surface/table/almayer,
 /obj/item/facepaint/green,
@@ -30458,7 +30383,7 @@
 "gqf" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "gqt" = (
 /obj/structure/sign/safety/storage{
 	pixel_x = -17
@@ -30470,7 +30395,7 @@
 	dir = 5;
 	icon_state = "silver"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "gqP" = (
 /obj/structure/largecrate/random/case,
 /obj/structure/machinery/camera/autoname/almayer{
@@ -30880,7 +30805,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "gxU" = (
 /obj/structure/surface/table/almayer,
 /obj/item/toy/deck,
@@ -30898,7 +30823,7 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "gym" = (
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/mp_bunks)
@@ -31106,12 +31031,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/maint/hull/upper/u_f_p)
-"gBg" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer,
-/area/almayer/hallways/upper/stern_hallway)
 "gBo" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 5
@@ -31229,7 +31148,7 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "gDW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31302,7 +31221,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "gFN" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -31310,7 +31229,7 @@
 /turf/open/floor/almayer{
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "gFP" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/shipboard/stern_point_defense)
@@ -31453,7 +31372,7 @@
 	allow_construction = 0;
 	icon_state = "plate"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "gHZ" = (
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -31509,7 +31428,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "gIO" = (
 /obj/structure/bed/chair/bolted{
 	dir = 8
@@ -32165,7 +32084,7 @@
 	dir = 1;
 	icon_state = "silver"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "gUf" = (
 /obj/structure/machinery/portable_atmospherics/hydroponics,
 /turf/open/floor/almayer{
@@ -32191,7 +32110,7 @@
 	dir = 8
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "gUn" = (
 /obj/structure/largecrate/random/barrel/red,
 /turf/open/floor/plating/plating_catwalk,
@@ -32844,7 +32763,7 @@
 	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "hfv" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/almayer{
@@ -32926,7 +32845,7 @@
 	dir = 8;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "hgB" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/intel,
@@ -33354,7 +33273,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "hmC" = (
 /obj/structure/machinery/cm_vending/sorted/marine_food{
 	density = 0;
@@ -33607,8 +33526,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/stern_hallway)
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/hallways/upper/midship_hallway)
 "hqW" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/medidoor{
 	name = "\improper Medical Bay";
@@ -33808,7 +33730,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "htG" = (
 /obj/item/tool/soap,
 /obj/structure/machinery/light/small{
@@ -33850,7 +33772,7 @@
 	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/port)
 "huD" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -34233,7 +34155,7 @@
 	pixel_y = 28
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "hBc" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 4
@@ -34265,7 +34187,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "hBz" = (
 /obj/item/mortar_kit,
 /turf/open/floor/almayer{
@@ -34338,7 +34260,7 @@
 /turf/open/floor/almayer{
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "hCS" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/paper_bin/uscm{
@@ -34514,7 +34436,7 @@
 	dir = 1;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "hGG" = (
 /obj/effect/step_trigger/clone_cleaner,
 /obj/effect/decal/warning_stripes{
@@ -34700,7 +34622,7 @@
 	dir = 4;
 	icon_state = "silver"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "hKO" = (
 /obj/structure/largecrate/random/barrel/green,
 /obj/structure/sign/safety/maint{
@@ -34885,10 +34807,9 @@
 	pixel_y = -30
 	},
 /turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "orange"
+	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "hPu" = (
 /obj/structure/largecrate/supply,
 /obj/item/tool/crowbar,
@@ -34998,21 +34919,6 @@
 	icon_state = "mono"
 	},
 /area/almayer/medical/medical_science)
-"hRc" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "NW-out"
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "SW-out";
-	layer = 2.5
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/hallways/upper/port)
 "hRd" = (
 /obj/structure/machinery/vending/coffee,
 /turf/open/floor/almayer{
@@ -35406,7 +35312,7 @@
 /turf/open/floor/plating/almayer{
 	allow_construction = 0
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "hXb" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -35738,7 +35644,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "ied" = (
 /obj/structure/machinery/power/apc/almayer{
 	dir = 1
@@ -36020,7 +35926,7 @@
 	},
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "ijr" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 4
@@ -36165,6 +36071,12 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/living/offices/flight)
+"imM" = (
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "silver"
+	},
+/area/almayer/hallways/upper/midship_hallway)
 "inh" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 8
@@ -36634,12 +36546,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/lower)
-"ivV" = (
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "orange"
-	},
-/area/almayer/hallways/upper/stern_hallway)
 "iwf" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 10
@@ -37134,12 +37040,6 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_four)
-"iGE" = (
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/hallways/upper/aft_hallway)
 "iGQ" = (
 /obj/structure/machinery/landinglight/ds2/delayone{
 	dir = 8
@@ -37151,15 +37051,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/hangar)
-"iGZ" = (
-/obj/structure/machinery/alarm/almayer{
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "blue"
-	},
-/area/almayer/hallways/upper/aft_hallway)
 "iHc" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/upper_engineering/notunnel)
@@ -37228,7 +37119,7 @@
 	dir = 4;
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "iIR" = (
 /obj/structure/surface/table/almayer,
 /obj/item/trash/USCMtray{
@@ -37506,7 +37397,7 @@
 	dir = 5;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "iOX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37566,10 +37457,9 @@
 	dir = 9
 	},
 /turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "orange"
+	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "iPN" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/station_alert,
@@ -37598,7 +37488,7 @@
 /turf/open/floor/almayer{
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "iQd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -37699,7 +37589,7 @@
 	dir = 4;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "iRp" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/poddoor/shutters/almayer/open{
@@ -37783,7 +37673,7 @@
 /turf/open/floor/almayer{
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "iSB" = (
 /obj/structure/platform_decoration{
 	dir = 8
@@ -37933,7 +37823,7 @@
 /turf/open/floor/almayer{
 	icon_state = "bluecorner"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "iUW" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -38228,7 +38118,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "jaf" = (
 /obj/structure/bed/chair/comfy/bravo{
 	dir = 4
@@ -38262,7 +38152,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "jas" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
@@ -38735,7 +38625,7 @@
 	dir = 10;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "jhb" = (
 /obj/structure/sign/safety/cryo{
 	pixel_x = -6;
@@ -38751,7 +38641,7 @@
 /turf/open/floor/almayer{
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "jhn" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -38995,6 +38885,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/briefing)
+"jkL" = (
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "orangecorner"
+	},
+/area/almayer/hallways/upper/midship_hallway)
 "jkN" = (
 /obj/structure/largecrate/random/barrel/yellow,
 /turf/open/floor/almayer{
@@ -39209,11 +39105,8 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 6
 	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "orange"
-	},
-/area/almayer/hallways/upper/stern_hallway)
+/turf/open/floor/almayer,
+/area/almayer/hallways/upper/midship_hallway)
 "jnD" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -39477,13 +39370,6 @@
 "juo" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/port_fore_hallway)
-"jux" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "bluecorner"
-	},
-/area/almayer/hallways/upper/aft_hallway)
 "juD" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -39569,7 +39455,7 @@
 	dir = 8;
 	icon_state = "silvercorner"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "jvB" = (
 /obj/effect/step_trigger/clone_cleaner,
 /turf/open/floor/almayer/aicore/no_build{
@@ -39859,15 +39745,6 @@
 	dir = 8
 	},
 /area/almayer/medical/containment/cell)
-"jBX" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/command/lifeboat)
 "jCg" = (
 /obj/docking_port/stationary/escape_pod/south,
 /turf/open/floor/plating,
@@ -40375,7 +40252,7 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "jMQ" = (
 /obj/item/device/radio/intercom{
 	freerange = 1;
@@ -40638,7 +40515,7 @@
 "jRg" = (
 /obj/effect/landmark/crap_item,
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "jRm" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 8
@@ -40648,7 +40525,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "jRp" = (
 /obj/structure/largecrate/supply/supplies/water,
 /obj/item/toy/deck{
@@ -41173,7 +41050,7 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "jZY" = (
 /obj/structure/closet/l3closet/virology,
 /turf/open/floor/almayer{
@@ -41323,7 +41200,7 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "kbV" = (
 /obj/structure/platform{
 	dir = 1
@@ -41466,9 +41343,6 @@
 /turf/open/floor/almayer,
 /area/almayer/engineering/upper_engineering/starboard)
 "kfo" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "NE-out";
 	pixel_x = 1;
@@ -41478,8 +41352,13 @@
 	icon_state = "SE-out";
 	pixel_x = 1
 	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	dir = 8;
+	icon_state = "red"
 	},
 /area/almayer/hallways/upper/port)
 "kfB" = (
@@ -41646,7 +41525,7 @@
 	dir = 1;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "kiy" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -41818,10 +41697,6 @@
 	icon_state = "mono"
 	},
 /area/almayer/lifeboat_pumps/south2)
-"kkI" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/aft_hallway)
 "kkN" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/manifold/fourway/hidden/supply,
@@ -41843,7 +41718,7 @@
 	dir = 1;
 	icon_state = "silver"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "klH" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 4
@@ -42601,11 +42476,8 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "orange"
-	},
-/area/almayer/hallways/upper/stern_hallway)
+/turf/open/floor/almayer,
+/area/almayer/hallways/upper/midship_hallway)
 "kzT" = (
 /obj/structure/machinery/door_control{
 	id = "ARES StairsLower";
@@ -42773,9 +42645,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/hangar)
-"kCo" = (
-/turf/open/floor/almayer,
-/area/almayer/hallways/upper/stern_hallway)
 "kCu" = (
 /obj/structure/machinery/portable_atmospherics/powered/scrubber,
 /turf/open/floor/almayer{
@@ -43000,7 +42869,7 @@
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "kHd" = (
 /obj/structure/machinery/computer/arcade,
 /obj/item/prop/helmetgarb/spacejam_tickets{
@@ -43446,6 +43315,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_m_p)
+"kON" = (
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "blue"
+	},
+/area/almayer/hallways/upper/midship_hallway)
 "kOR" = (
 /obj/structure/machinery/light/small{
 	dir = 1
@@ -43768,7 +43643,7 @@
 	dir = 1;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "kUA" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
@@ -43835,7 +43710,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "kWk" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 10
@@ -44147,7 +44022,7 @@
 /turf/open/floor/plating/almayer{
 	allow_construction = 0
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "lbf" = (
 /obj/structure/machinery/cryopod{
 	pixel_y = 6
@@ -44253,7 +44128,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "ldt" = (
 /obj/structure/machinery/conveyor{
 	dir = 8;
@@ -44923,8 +44798,7 @@
 /area/almayer/living/briefing)
 "loz" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "SW-out";
-	layer = 2.5
+	icon_state = "W"
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/upper/starboard)
@@ -45053,11 +44927,13 @@
 /area/almayer/living/port_emb)
 "lrd" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/hallways/upper/midship_hallway)
 "lrq" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/shipboard/brig/armory)
@@ -45196,7 +45072,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "ltv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45528,7 +45404,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "lAa" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/lightreplacer{
@@ -45584,7 +45460,7 @@
 	dir = 10;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "lBg" = (
 /obj/structure/bedsheetbin,
 /turf/open/floor/almayer{
@@ -45636,10 +45512,8 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/open/floor/almayer{
-	icon_state = "orange"
-	},
-/area/almayer/hallways/upper/stern_hallway)
+/turf/open/floor/almayer,
+/area/almayer/hallways/upper/midship_hallway)
 "lCm" = (
 /obj/structure/machinery/light/small{
 	dir = 1
@@ -46258,7 +46132,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "lOr" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/firedoor/border_only/almayer,
@@ -46771,7 +46645,7 @@
 	dir = 1;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "maI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -46813,15 +46687,6 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
-"mbu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/stern_hallway)
 "mbx" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -46947,7 +46812,7 @@
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "meT" = (
 /obj/structure/machinery/door/poddoor/almayer/open{
 	id = "Hangar Lockdown";
@@ -47422,7 +47287,7 @@
 	dir = 8;
 	icon_state = "greencorner"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "mnI" = (
 /turf/open/floor/almayer{
 	icon_state = "blue"
@@ -47443,7 +47308,7 @@
 /turf/open/floor/almayer{
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "mnW" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/reagent_scanner{
@@ -47586,7 +47451,7 @@
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "mqg" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -47625,18 +47490,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/bravo)
-"mqR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "blue"
-	},
-/area/almayer/hallways/upper/aft_hallway)
 "mqU" = (
 /obj/structure/pipes/vents/pump{
 	dir = 8;
@@ -47956,7 +47809,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "mxT" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/flashlight/lamp,
@@ -48430,7 +48283,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "mGu" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -48617,7 +48470,7 @@
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "mJu" = (
 /turf/open/floor/almayer/uscm/directional,
 /area/almayer/command/cic)
@@ -48927,7 +48780,7 @@
 /turf/open/floor/almayer{
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "mOE" = (
 /obj/structure/sign/safety/water{
 	pixel_x = -17
@@ -49059,11 +48912,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/port_atmos)
 "mQF" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "mQY" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 1
@@ -49248,7 +49100,7 @@
 	dir = 4;
 	icon_state = "silver"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "mTp" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -49469,18 +49321,6 @@
 	icon_state = "orange"
 	},
 /area/almayer/hallways/lower/port_aft_hallway)
-"mXP" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 6;
-	icon_state = "orange"
-	},
-/area/almayer/hallways/upper/stern_hallway)
 "mYd" = (
 /obj/structure/sign/safety/escapepod{
 	pixel_y = 32
@@ -49493,7 +49333,7 @@
 	dir = 1;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "mYt" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W";
@@ -49647,7 +49487,7 @@
 /turf/open/floor/almayer{
 	icon_state = "silver"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "nar" = (
 /obj/structure/toilet{
 	dir = 4
@@ -49719,7 +49559,6 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/port_midship_hallway)
 "nbW" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -49727,9 +49566,9 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "ncf" = (
 /obj/structure/machinery/cryopod/right{
 	layer = 3.1;
@@ -49990,14 +49829,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/bravo)
-"ngE" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/hallways/upper/starboard)
 "ngI" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -50127,7 +49958,7 @@
 	dir = 4;
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "nhV" = (
 /obj/structure/machinery/light/small,
 /turf/open/floor/almayer{
@@ -50941,13 +50772,13 @@
 /turf/open/floor/almayer{
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "nww" = (
 /turf/open/floor/almayer{
 	dir = 6;
 	icon_state = "silver"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "nwx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
@@ -51162,15 +50993,6 @@
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/command/corporateliaison)
-"nBo" = (
-/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
-	pixel_y = 25
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "bluecorner"
-	},
-/area/almayer/hallways/upper/aft_hallway)
 "nBw" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -51605,7 +51427,7 @@
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "nIG" = (
 /obj/structure/machinery/power/apc/almayer{
 	dir = 4
@@ -51722,7 +51544,7 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "nMe" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -52287,7 +52109,7 @@
 /turf/open/floor/plating/almayer{
 	allow_construction = 0
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "nVB" = (
 /turf/open/floor/almayer,
 /area/almayer/command/securestorage)
@@ -52628,7 +52450,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "odb" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer{
@@ -52813,18 +52635,6 @@
 	icon_state = "red"
 	},
 /area/almayer/hallways/upper/port)
-"ogd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/hallways/upper/stern_hallway)
 "ogK" = (
 /obj/structure/bed/bedroll{
 	desc = "A bed of cotton fabric, purposely made for a cat to comfortably sleep on.";
@@ -52934,13 +52744,6 @@
 /obj/effect/landmark/yautja_teleport,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_m_s)
-"oig" = (
-/obj/structure/machinery/light,
-/turf/open/floor/almayer{
-	dir = 6;
-	icon_state = "orange"
-	},
-/area/almayer/hallways/upper/stern_hallway)
 "oih" = (
 /obj/structure/bed{
 	icon_state = "abed"
@@ -53121,7 +52924,7 @@
 	dir = 9;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "okD" = (
 /obj/structure/prop/almayer/name_stencil{
 	icon_state = "almayer6"
@@ -53233,7 +53036,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "omt" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -53282,7 +53085,7 @@
 	dir = 8;
 	icon_state = "orange"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "onn" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer,
@@ -53425,7 +53228,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "opV" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -53718,18 +53521,6 @@
 /obj/structure/machinery/light,
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/starboard_midship_hallway)
-"otE" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "orange"
-	},
-/area/almayer/hallways/upper/stern_hallway)
 "otW" = (
 /obj/structure/machinery/light/small,
 /obj/structure/prop/invuln/overhead_pipe{
@@ -53912,7 +53703,7 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "oxi" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 10
@@ -54063,6 +53854,15 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/lower/port_umbilical)
+"oAp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/hallways/upper/midship_hallway)
 "oAB" = (
 /obj/structure/platform{
 	dir = 8;
@@ -54108,7 +53908,7 @@
 	allow_construction = 0;
 	icon_state = "plate"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "oBq" = (
 /obj/structure/bed,
 /obj/structure/machinery/flasher{
@@ -54842,7 +54642,7 @@
 "oNa" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "oNb" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/flora/pottedplant{
@@ -54913,7 +54713,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "oOp" = (
 /obj/structure/surface/table/almayer,
 /obj/item/tool/wirecutters,
@@ -55003,12 +54803,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_a_s)
-"oPT" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/almayer,
-/area/almayer/hallways/upper/aft_hallway)
 "oQn" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -55317,7 +55111,7 @@
 	name = "ship-grade camera"
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "oUZ" = (
 /obj/structure/surface/rack,
 /obj/item/tool/crowbar,
@@ -55462,18 +55256,6 @@
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/wood/ship,
 /area/almayer/shipboard/brig/cells)
-"oXt" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "NW-out";
-	pixel_y = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/hallways/upper/starboard)
 "oXJ" = (
 /obj/structure/machinery/suit_storage_unit/compression_suit/uscm,
 /turf/open/floor/almayer{
@@ -55871,7 +55653,7 @@
 	dir = 4;
 	icon_state = "silver"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "peM" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer{
@@ -56165,7 +55947,7 @@
 	dir = 10;
 	icon_state = "silver"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "pjR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -56176,15 +55958,6 @@
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/living/commandbunks)
-"pjY" = (
-/obj/structure/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "red"
-	},
-/area/almayer/hallways/upper/aft_hallway)
 "pkz" = (
 /turf/open/floor/almayer{
 	icon_state = "redfull"
@@ -56393,7 +56166,7 @@
 	dir = 4;
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "pqw" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = 32
@@ -56504,7 +56277,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "prX" = (
 /obj/structure/ladder{
 	height = 2;
@@ -56701,12 +56474,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer,
 /area/almayer/living/port_emb)
-"pvi" = (
-/turf/open/floor/almayer{
-	dir = 6;
-	icon_state = "red"
-	},
-/area/almayer/hallways/upper/aft_hallway)
 "pvE" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -56715,7 +56482,7 @@
 	dir = 4;
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "pvI" = (
 /obj/structure/sign/safety/rad_haz{
 	pixel_x = 8;
@@ -56772,7 +56539,7 @@
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "pwx" = (
 /obj/structure/sign/safety/distribution_pipes{
 	pixel_x = -17
@@ -56871,12 +56638,6 @@
 	icon_state = "cargo_arrow"
 	},
 /area/almayer/squads/bravo)
-"pym" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/hallways/upper/stern_hallway)
 "pyx" = (
 /obj/structure/machinery/door_display/research_cell{
 	dir = 4;
@@ -57007,7 +56768,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "pBG" = (
 /turf/closed/wall/almayer,
 /area/almayer/command/corporateliaison)
@@ -57117,12 +56878,6 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/chief_mp_office)
-"pEd" = (
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "orangecorner"
-	},
-/area/almayer/hallways/upper/stern_hallway)
 "pEl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -57174,18 +56929,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/lifeboat_pumps/south1)
-"pFf" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "blue"
-	},
-/area/almayer/hallways/upper/aft_hallway)
 "pFq" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/binoculars,
@@ -57611,7 +57354,7 @@
 	dir = 4;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/port)
 "pOD" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
@@ -57743,12 +57486,6 @@
 	icon_state = "plating"
 	},
 /area/almayer/hallways/lower/vehiclehangar)
-"pPU" = (
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "silver"
-	},
-/area/almayer/hallways/upper/aft_hallway)
 "pQr" = (
 /obj/structure/bed,
 /turf/open/floor/almayer{
@@ -57888,7 +57625,7 @@
 	pixel_x = -1
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "pSQ" = (
 /obj/structure/reagent_dispensers/fueltank{
 	anchored = 1
@@ -58232,18 +57969,6 @@
 	icon_state = "silvercorner"
 	},
 /area/almayer/shipboard/brig/cic_hallway)
-"pZq" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/hallways/upper/stern_hallway)
 "pZH" = (
 /obj/structure/machinery/shower{
 	dir = 8
@@ -58386,7 +58111,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "qdk" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -59206,7 +58931,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "qpQ" = (
 /obj/item/reagent_container/glass/beaker/bluespace,
 /obj/structure/machinery/chem_dispenser/medbay,
@@ -59232,7 +58957,7 @@
 	dir = 9;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "qqf" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer,
@@ -59330,9 +59055,6 @@
 /turf/open/floor/almayer,
 /area/almayer/engineering/ce_room)
 "qtj" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out";
 	layer = 2.5
@@ -59340,8 +59062,12 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out"
 	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	dir = 4;
+	icon_state = "red"
 	},
 /area/almayer/hallways/upper/port)
 "qtv" = (
@@ -59378,7 +59104,6 @@
 	},
 /area/almayer/medical/cryo_tubes)
 "quy" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/sign/safety/maint{
 	pixel_x = 8;
 	pixel_y = -32
@@ -59387,9 +59112,7 @@
 	icon_state = "SW-out";
 	pixel_x = -1
 	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
+/turf/open/floor/almayer,
 /area/almayer/command/lifeboat)
 "quJ" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -59480,7 +59203,7 @@
 	dir = 1;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "qwo" = (
 /obj/structure/machinery/washing_machine,
 /obj/structure/machinery/washing_machine{
@@ -59627,7 +59350,7 @@
 	dir = 4;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "qxL" = (
 /obj/structure/machinery/medical_pod/autodoc,
 /turf/open/floor/almayer{
@@ -59993,7 +59716,7 @@
 "qEc" = (
 /obj/effect/step_trigger/clone_cleaner,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "qEk" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -60201,7 +59924,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "qGU" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer{
@@ -60213,7 +59936,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "qHg" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -60235,7 +59958,7 @@
 	dir = 1
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "qHG" = (
 /obj/structure/machinery/light/small{
 	dir = 1
@@ -60664,7 +60387,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "qPD" = (
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/perma)
@@ -60787,7 +60510,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "qSm" = (
 /obj/structure/pipes/vents/pump{
 	dir = 4
@@ -61467,7 +61190,7 @@
 	dir = 8;
 	icon_state = "silver"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "rdt" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -61629,10 +61352,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/port_point_defense)
-"rfQ" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer,
-/area/almayer/hallways/upper/stern_hallway)
 "rfT" = (
 /obj/item/frame/camera{
 	desc = "The Staff Officer insisted he needed to monitor everyone at all times.";
@@ -61753,16 +61472,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/port_emb)
-"rhX" = (
-/obj/structure/sign/safety/maint{
-	pixel_x = 8;
-	pixel_y = 32
-	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "orangecorner"
-	},
-/area/almayer/hallways/upper/stern_hallway)
 "rib" = (
 /obj/structure/sink{
 	dir = 8;
@@ -61831,7 +61540,7 @@
 	dir = 1;
 	icon_state = "silvercorner"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "riP" = (
 /obj/structure/machinery/light,
 /obj/structure/sign/safety/rewire{
@@ -62059,7 +61768,7 @@
 /turf/open/floor/almayer{
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "rmD" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -62094,7 +61803,7 @@
 	dir = 4;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "rnF" = (
 /obj/structure/machinery/door/airlock/almayer/engineering{
 	dir = 2;
@@ -62129,15 +61838,6 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
-"rnO" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/hallways/upper/stern_hallway)
 "rob" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
@@ -62344,7 +62044,7 @@
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "rrK" = (
 /obj/structure/bed/chair{
 	can_buckle = 0;
@@ -62590,7 +62290,7 @@
 	dir = 1;
 	icon_state = "silver"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "rwj" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -62931,7 +62631,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "rDr" = (
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/almayer{
@@ -63212,7 +62912,7 @@
 /turf/open/floor/almayer{
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "rHo" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	layer = 1.9
@@ -63798,7 +63498,7 @@
 	dir = 4;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/port)
 "rRq" = (
 /turf/closed/wall/almayer,
 /area/almayer/lifeboat_pumps/south2)
@@ -63964,11 +63664,6 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/computerlab)
-"rUN" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/almayer,
-/area/almayer/hallways/upper/aft_hallway)
 "rVc" = (
 /obj/structure/bed/chair{
 	dir = 8;
@@ -64152,7 +63847,7 @@
 /turf/open/floor/almayer{
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "rYh" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -64195,7 +63890,7 @@
 	dir = 4;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "rYI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64249,7 +63944,7 @@
 /turf/open/floor/almayer{
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "rZP" = (
 /obj/structure/surface/table/almayer,
 /obj/item/tool/weldpack,
@@ -64284,7 +63979,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "sbq" = (
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	icon_state = "almayer_pdoor";
@@ -65227,7 +64922,7 @@
 	dir = 8;
 	icon_state = "silver"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "sqa" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -65360,7 +65055,7 @@
 	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/port)
 "ssU" = (
 /obj/structure/machinery/constructable_frame,
 /turf/open/floor/almayer{
@@ -65400,7 +65095,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "str" = (
 /obj/effect/step_trigger/teleporter_vector{
 	name = "Almayer_Down3";
@@ -65670,7 +65365,7 @@
 	dir = 1;
 	icon_state = "orange"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "szf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -65893,7 +65588,7 @@
 	dir = 5;
 	icon_state = "plating"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "sDu" = (
 /obj/item/clothing/under/marine/dress,
 /turf/open/floor/almayer{
@@ -66539,7 +66234,7 @@
 /turf/open/floor/almayer{
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "sQF" = (
 /turf/open/floor/almayer{
 	icon_state = "red"
@@ -66743,7 +66438,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "sVT" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/toolbox/mechanical,
@@ -67120,12 +66815,12 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "tbF" = (
 /turf/open/floor/almayer{
 	icon_state = "silvercorner"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "tcd" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/radio{
@@ -67629,7 +67324,7 @@
 "tiZ" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "tjj" = (
 /turf/open/floor/almayer{
 	dir = 5;
@@ -67987,7 +67682,7 @@
 /turf/open/floor/plating/almayer{
 	allow_construction = 0
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "tpn" = (
 /turf/closed/wall/almayer,
 /area/almayer/shipboard/brig/evidence_storage)
@@ -68559,7 +68254,7 @@
 	dir = 10;
 	icon_state = "orange"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "txp" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/plating/plating_catwalk,
@@ -68665,7 +68360,7 @@
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "tzL" = (
 /obj/structure/sign/safety/waterhazard{
 	pixel_x = 8;
@@ -68835,7 +68530,7 @@
 	dir = 8;
 	icon_state = "cargo_arrow"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "tCT" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 8
@@ -68927,11 +68622,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/command/airoom)
-"tFQ" = (
-/turf/open/floor/almayer{
-	icon_state = "orange"
-	},
-/area/almayer/hallways/upper/stern_hallway)
 "tFS" = (
 /obj/structure/machinery/computer/supplycomp,
 /obj/structure/sign/safety/terminal{
@@ -69028,7 +68718,7 @@
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "tHk" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/toolbox,
@@ -69191,12 +68881,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/charlie_delta_shared)
-"tJH" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/hallways/upper/stern_hallway)
 "tJN" = (
 /obj/structure/machinery/cryopod/right{
 	layer = 3.1;
@@ -69223,15 +68907,6 @@
 	icon_state = "green"
 	},
 /area/almayer/living/grunt_rnr)
-"tKf" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/command/lifeboat)
 "tKr" = (
 /obj/structure/machinery/cryopod/right{
 	dir = 2
@@ -69451,7 +69126,7 @@
 "tPz" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "tPB" = (
 /obj/effect/projector{
 	name = "Almayer_Down2";
@@ -69461,7 +69136,7 @@
 /turf/open/floor/almayer{
 	allow_construction = 0
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "tPI" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -69515,7 +69190,7 @@
 /turf/open/floor/almayer{
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "tQV" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/lifeboat_pumps/south1)
@@ -69569,15 +69244,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/briefing)
-"tSY" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/almayer,
-/area/almayer/hallways/upper/stern_hallway)
 "tTk" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -69737,7 +69403,7 @@
 	dir = 1;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "tWi" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 8
@@ -70107,7 +69773,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "ucp" = (
 /obj/structure/window/framed/almayer,
 /turf/open/floor/plating,
@@ -70611,13 +70277,13 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "umI" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "umS" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -70872,7 +70538,7 @@
 	dir = 1;
 	icon_state = "orange"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "ury" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -70951,13 +70617,8 @@
 	},
 /area/almayer/medical/medical_science)
 "usL" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
+/turf/open/floor/almayer,
 /area/almayer/hallways/upper/port)
 "usX" = (
 /obj/structure/disposalpipe/segment{
@@ -71159,7 +70820,7 @@
 	dir = 4;
 	icon_state = "orange"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "uvt" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer{
@@ -71409,7 +71070,7 @@
 /turf/open/floor/almayer{
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "uAj" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -71797,7 +71458,7 @@
 /turf/open/floor/almayer{
 	icon_state = "greencorner"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "uIv" = (
 /turf/open/floor/almayer{
 	icon_state = "orange"
@@ -72087,6 +71748,12 @@
 	icon_state = "blue"
 	},
 /area/almayer/living/basketball)
+"uPB" = (
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "silver"
+	},
+/area/almayer/hallways/upper/midship_hallway)
 "uPE" = (
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/port_aft_hallway)
@@ -72131,7 +71798,7 @@
 /turf/open/floor/almayer{
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "uQm" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -72280,7 +71947,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "uTk" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/plating,
@@ -72470,7 +72137,7 @@
 	dir = 10;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "uVh" = (
 /obj/structure/filingcabinet/seeds,
 /turf/open/floor/almayer{
@@ -72528,7 +72195,7 @@
 	dir = 5;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "uWc" = (
 /obj/structure/surface/table/almayer,
 /turf/open/floor/almayer{
@@ -72715,7 +72382,7 @@
 	dir = 8;
 	icon_state = "bluecorner"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "uZV" = (
 /obj/structure/reagent_dispensers/fueltank/gas/methane{
 	anchored = 1
@@ -72927,15 +72594,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/u_f_s)
-"vcO" = (
-/obj/structure/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "red"
-	},
-/area/almayer/hallways/upper/aft_hallway)
 "vdl" = (
 /obj/structure/window/reinforced/ultra{
 	pixel_y = -12
@@ -73318,14 +72976,11 @@
 	},
 /area/almayer/lifeboat_pumps/south1)
 "vjd" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out";
 	pixel_y = 1
 	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
+/turf/open/floor/almayer,
 /area/almayer/command/lifeboat)
 "vjg" = (
 /obj/structure/prop/almayer/missile_tube{
@@ -73515,7 +73170,7 @@
 	dir = 5;
 	icon_state = "orange"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "vkR" = (
 /obj/structure/machinery/power/apc/almayer{
 	dir = 1
@@ -73604,7 +73259,7 @@
 /turf/open/floor/almayer{
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "vlX" = (
 /obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep,
 /turf/open/floor/almayer{
@@ -73701,7 +73356,7 @@
 /turf/open/floor/almayer{
 	icon_state = "orange"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "vop" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -74076,7 +73731,7 @@
 	dir = 4;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/starboard)
 "vuF" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	access_modified = 1;
@@ -74832,7 +74487,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "vFH" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer{
@@ -74987,22 +74642,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/command/cic)
-"vHA" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "SE-out"
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "NE-out";
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/hallways/upper/starboard)
 "vHO" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -75048,7 +74687,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "vIu" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -75784,7 +75423,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "vUP" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/shipboard/brig/cic_hallway)
@@ -76189,7 +75828,7 @@
 	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/starboard)
 "wbu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/camera/autoname/almayer{
@@ -76729,18 +76368,12 @@
 	},
 /area/almayer/shipboard/port_point_defense)
 "wjE" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
 /obj/effect/decal/warning_stripes{
-	icon_state = "SW-out"
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "NW-out";
-	pixel_y = 1
+	icon_state = "W"
 	},
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	dir = 4;
+	icon_state = "red"
 	},
 /area/almayer/hallways/upper/starboard)
 "wjL" = (
@@ -76971,7 +76604,7 @@
 /turf/open/floor/almayer{
 	icon_state = "orange"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "wmK" = (
 /obj/structure/surface/table/almayer,
 /obj/item/clipboard,
@@ -77676,7 +77309,7 @@
 	dir = 4;
 	icon_state = "silvercorner"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "wyG" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/machinery/door/airlock/almayer/maint{
@@ -77719,7 +77352,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "wzZ" = (
 /obj/structure/machinery/door/airlock/almayer/medical/glass{
 	dir = 1;
@@ -78174,7 +77807,7 @@
 	dir = 10;
 	icon_state = "orange"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "wJh" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -78392,6 +78025,15 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/starboard_hallway)
+"wLT" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/hallways/upper/midship_hallway)
 "wMl" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 8;
@@ -79150,7 +78792,7 @@
 /turf/open/floor/plating/almayer{
 	allow_construction = 0
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "wZp" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
@@ -79159,7 +78801,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "wZv" = (
 /obj/structure/prop/invuln{
 	desc = "An inflated membrane. This one is puncture proof. Wow!";
@@ -79305,7 +78947,8 @@
 /area/almayer/command/airoom)
 "xci" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "SE-out"
+	icon_state = "E";
+	pixel_x = 1
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/upper/starboard)
@@ -79350,7 +78993,7 @@
 	dir = 4;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "xdf" = (
 /obj/structure/pipes/standard/manifold/fourway/hidden/supply,
 /obj/structure/disposalpipe/segment{
@@ -79358,11 +79001,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/port_midship_hallway)
-"xdl" = (
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/hallways/upper/aft_hallway)
 "xdx" = (
 /obj/structure/surface/rack,
 /obj/item/storage/firstaid/regular/empty,
@@ -79441,7 +79079,7 @@
 	dir = 4;
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "xer" = (
 /obj/structure/machinery/power/apc/almayer,
 /turf/open/floor/plating/plating_catwalk,
@@ -79463,7 +79101,7 @@
 	dir = 10;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "xfq" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -79571,7 +79209,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "xgJ" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -79622,11 +79260,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_m_p)
-"xhi" = (
-/turf/open/floor/almayer{
-	icon_state = "orangecorner"
-	},
-/area/almayer/hallways/upper/stern_hallway)
 "xhn" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer{
@@ -79762,7 +79395,7 @@
 	dir = 4;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "xjK" = (
 /obj/structure/sign/safety/hazard{
 	pixel_y = 32
@@ -79813,7 +79446,7 @@
 	dir = 1;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "xkB" = (
 /obj/structure/bed/chair/comfy/charlie{
 	dir = 1
@@ -79971,7 +79604,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "xoj" = (
 /turf/open/floor/almayer,
 /area/almayer/engineering/lower/workshop)
@@ -80265,7 +79898,7 @@
 	},
 /obj/structure/machinery/light,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "xtM" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer{
@@ -80283,7 +79916,7 @@
 	dir = 1;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "xub" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -80395,7 +80028,7 @@
 	dir = 5;
 	icon_state = "silver"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "xvQ" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/sentencing{
@@ -80484,7 +80117,7 @@
 /turf/open/floor/almayer{
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "xwX" = (
 /turf/open/floor/almayer{
 	dir = 9;
@@ -80937,7 +80570,7 @@
 /turf/open/floor/almayer{
 	icon_state = "silver"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "xFZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/manifold/hidden/supply{
@@ -81426,7 +81059,7 @@
 	dir = 4;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "xNu" = (
 /obj/structure/toilet{
 	dir = 1
@@ -81653,7 +81286,7 @@
 	dir = 1;
 	icon_state = "greencorner"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "xRw" = (
 /turf/open/floor/almayer/uscm/directional{
 	dir = 1
@@ -81688,7 +81321,7 @@
 	dir = 4;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "xSw" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -82087,7 +81720,7 @@
 	dir = 6;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/aft_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "xZk" = (
 /obj/item/prop/helmetgarb/gunoil{
 	layer = 4.2;
@@ -82213,18 +81846,6 @@
 	},
 /turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
-"yaR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/hallways/upper/stern_hallway)
 "yaX" = (
 /obj/structure/machinery/door/poddoor/railing{
 	dir = 2;
@@ -82247,7 +81868,7 @@
 /area/almayer/command/airoom)
 "ybk" = (
 /turf/closed/wall/almayer,
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/hallways/upper/midship_hallway)
 "ybm" = (
 /obj/structure/surface/table/almayer,
 /obj/item/clothing/head/hardhat{
@@ -108322,9 +107943,9 @@ aiX
 asf
 atT
 aiX
-cKW
-mqR
-xZf
+eWN
+mxg
+rmB
 lIj
 tBY
 gkE
@@ -108925,7 +108546,7 @@ jRm
 gDQ
 gDQ
 gDQ
-rUN
+dZR
 gDQ
 gDQ
 dFd
@@ -108934,8 +108555,8 @@ rDm
 gDQ
 saT
 gDQ
-rUN
-rUN
+dZR
+dZR
 bxt
 tPz
 tPz
@@ -112575,7 +112196,7 @@ gfv
 gfv
 gfv
 gfv
-aPC
+wZp
 tzF
 aEe
 akA
@@ -113184,7 +112805,7 @@ aed
 aeG
 abE
 umI
-fsu
+dzV
 umI
 vOy
 oNp
@@ -116025,7 +115646,7 @@ fcE
 aef
 uNN
 abE
-iGZ
+ftb
 lOn
 rmB
 vOy
@@ -116837,7 +116458,7 @@ aco
 aco
 dYu
 bsw
-cKW
+kON
 xNl
 dpS
 jao
@@ -119073,8 +118694,8 @@ agK
 agu
 aej
 ftb
-mqR
-djd
+mxg
+hCF
 vOy
 wWz
 pEJ
@@ -119090,9 +118711,9 @@ xQm
 tfH
 wTM
 vOy
-ddx
-pFf
-xZf
+nLM
+jao
+rmB
 eyI
 byH
 jtU
@@ -119275,9 +118896,9 @@ aej
 agO
 aid
 aej
-umI
+kON
 fsu
-umI
+xZf
 vOy
 wWz
 uwZ
@@ -119293,9 +118914,9 @@ vfP
 sNz
 wTM
 vOy
-umI
+kON
 fsu
-umI
+xZf
 mRU
 mRU
 veW
@@ -119463,7 +119084,7 @@ fTj
 jOD
 oOw
 cPK
-oXt
+wjE
 loz
 sAz
 jZC
@@ -119474,10 +119095,10 @@ cQW
 lQa
 wjE
 vuE
-bkb
-kGS
-kGS
-pvi
+ilq
+aLh
+aLh
+ltt
 bgh
 spW
 pjQ
@@ -119499,9 +119120,9 @@ vOy
 bgh
 spW
 pjQ
-eJg
+ltt
 bkb
-kGS
+bWx
 rRf
 pOC
 qtj
@@ -119513,7 +119134,7 @@ kMp
 jkB
 hlT
 qNI
-hRc
+wrX
 tqO
 kdn
 nyS
@@ -119666,7 +119287,7 @@ dho
 wVt
 wVt
 jlc
-ngE
+sVV
 kbv
 dTn
 kbv
@@ -119675,12 +119296,12 @@ kbv
 jlc
 kbv
 dTn
-ngE
-acQ
-acQ
-acQ
-acQ
-xdl
+sVV
+sVV
+sVV
+sVV
+sVV
+ltt
 klr
 bNT
 dOW
@@ -119703,11 +119324,11 @@ gTV
 mGk
 xFW
 lrd
-kkI
-kkI
-kkI
-kkI
-usL
+cMz
+cMz
+cMz
+cMz
+cMz
 gsC
 cMz
 qLg
@@ -119869,7 +119490,7 @@ bGa
 dVn
 vwC
 fbR
-gcq
+xMz
 xci
 eON
 gxn
@@ -119878,12 +119499,12 @@ xMz
 sdv
 xMO
 wDg
-vHA
+xMz
 waV
-iGE
-kGS
-kGS
-pjY
+gxn
+aLh
+aLh
+ltt
 gqv
 hKJ
 nww
@@ -119905,9 +119526,9 @@ vOy
 xvO
 peu
 nww
-vcO
+ltt
 ssF
-kGS
+bWx
 bij
 hux
 kfo
@@ -119919,7 +119540,7 @@ nNx
 pMA
 ncT
 gHh
-kfo
+oWx
 dbc
 cNM
 ofU
@@ -120090,21 +119711,21 @@ ael
 htF
 bNT
 jvz
-ltt
-pPU
-pPU
+uPB
+uPB
+uPB
 ecz
-pPU
-pPU
-pPU
-pPU
-pPU
-pPU
-pPU
+uPB
+uPB
+uPB
+uPB
+uPB
+uPB
+uPB
 ecz
-pPU
-pPU
-ltt
+uPB
+uPB
+uPB
 riK
 bNT
 hmB
@@ -120290,10 +119911,10 @@ afE
 agT
 agT
 ael
-oPT
+qHu
 lOn
 acQ
-ltt
+acQ
 acQ
 gfv
 gfv
@@ -120307,7 +119928,7 @@ gfv
 gfv
 gfv
 jRg
-ltt
+acQ
 acQ
 bNT
 oNa
@@ -120496,10 +120117,10 @@ ael
 bMV
 jao
 tbF
-ltt
-dZP
+imM
+imM
 tbF
-dZP
+imM
 eQh
 mTo
 tCD
@@ -120507,10 +120128,10 @@ tCD
 tCD
 mTo
 wyE
-dZP
+imM
 dKD
-dZP
-ltt
+imM
+imM
 dKD
 bNT
 enF
@@ -120696,7 +120317,7 @@ afI
 agY
 oxi
 xfm
-jux
+tiZ
 gIN
 jvz
 mOi
@@ -120899,9 +120520,9 @@ afJ
 agY
 aiq
 ajJ
-dpS
+acQ
 mxg
-iUV
+acQ
 mOi
 rCw
 rCw
@@ -121102,9 +120723,9 @@ afK
 ahc
 air
 ael
-nBo
+gar
 mxg
-uZI
+acQ
 mOi
 wCT
 sIf
@@ -122117,9 +121738,9 @@ afO
 ahh
 aiw
 adO
-mQF
-yaR
-mQF
+acQ
+mxg
+acQ
 lmK
 lmK
 lmK
@@ -122135,9 +121756,9 @@ cnH
 kzk
 cnR
 aHq
-mQF
-yaR
-mQF
+acQ
+mxg
+acQ
 aUH
 sIA
 gSj
@@ -122321,8 +121942,8 @@ ahh
 aiw
 adO
 ebV
-mbu
-kCo
+bNT
+acQ
 ioU
 pvK
 qPE
@@ -122340,7 +121961,7 @@ cbn
 aHq
 ebV
 qGP
-pym
+tzF
 aUd
 ckK
 iKM
@@ -122524,8 +122145,8 @@ ahh
 aiw
 adO
 qHu
-hqx
-kCo
+lOn
+acQ
 ioU
 qyZ
 wTd
@@ -122541,9 +122162,9 @@ liJ
 qmP
 uoH
 aHq
-kCo
-mbu
-kCo
+acQ
+bNT
+acQ
 aUH
 dbv
 lII
@@ -122726,9 +122347,9 @@ aiw
 ahh
 aiw
 nph
-kCo
-tSY
-kCo
+acQ
+jao
+acQ
 ioU
 mSz
 nIG
@@ -122745,8 +122366,8 @@ aGN
 qrv
 aHq
 hBa
-gft
-kCo
+mxg
+acQ
 aGz
 ckd
 mQC
@@ -122929,9 +122550,9 @@ afP
 ahh
 aiw
 nph
-kCo
-hqx
-kCo
+acQ
+lOn
+acQ
 ioU
 ioU
 ioU
@@ -122948,8 +122569,8 @@ aGN
 pSU
 aHq
 qcL
-gft
-kCo
+mxg
+acQ
 aGz
 drk
 mQC
@@ -123132,9 +122753,9 @@ afQ
 aiw
 aiw
 nph
-kCo
-hqx
-kCo
+acQ
+lOn
+acQ
 ioU
 lPO
 vJg
@@ -123151,8 +122772,8 @@ aGN
 rub
 aHq
 gar
-gft
-kCo
+mxg
+acQ
 aGz
 eqB
 obC
@@ -123335,9 +122956,9 @@ ahJ
 ahJ
 ahJ
 adO
-kCo
-tSY
-kCo
+acQ
+jao
+acQ
 ioU
 dnS
 viN
@@ -123354,8 +122975,8 @@ aGN
 qrv
 aHq
 oUO
-gft
-kCo
+mxg
+acQ
 aUH
 aGz
 aGz
@@ -123538,9 +123159,9 @@ aeC
 aeC
 aeC
 ybk
-kCo
-tSY
-kCo
+acQ
+jao
+acQ
 ioU
 pPM
 qKz
@@ -123557,8 +123178,8 @@ iLO
 bUa
 aHq
 qHu
-mbu
-kCo
+bNT
+acQ
 ybk
 vcE
 vcE
@@ -123945,7 +123566,7 @@ asA
 btu
 oOi
 szb
-rfQ
+tiZ
 vnZ
 jvY
 jvY
@@ -124350,8 +123971,8 @@ qnf
 aeC
 wPm
 ybk
-mQF
-mQF
+jkL
+acQ
 nbW
 jvY
 arh
@@ -124368,8 +123989,8 @@ jvY
 nSG
 aOs
 jvY
-mQF
-pZq
+jkL
+jao
 mQF
 ybk
 dJF
@@ -124553,7 +124174,7 @@ ggQ
 ggQ
 aME
 aep
-ivV
+jkL
 jnx
 iPK
 jvY
@@ -124571,9 +124192,9 @@ axo
 atm
 aOr
 jvY
-ivV
-otE
-ivV
+jkL
+jao
+mQF
 aep
 aME
 ggQ
@@ -124756,7 +124377,7 @@ afj
 afk
 agM
 aep
-pEd
+jkL
 tbD
 fDk
 jvY
@@ -124774,9 +124395,9 @@ bzD
 atm
 aOs
 jvY
-pEd
-hqx
-xhi
+jkL
+lOn
+mQF
 aep
 aHS
 afk
@@ -124959,7 +124580,7 @@ afk
 afk
 afk
 aep
-pEd
+jkL
 tbD
 fDk
 jvY
@@ -124977,9 +124598,9 @@ axo
 atm
 thv
 jvY
-pEd
-hqx
-xhi
+jkL
+lOn
+mQF
 aep
 afk
 aHl
@@ -125162,9 +124783,9 @@ aep
 aep
 aep
 aep
-pvE
-tbD
-fDk
+umI
+wLT
+oAp
 jvY
 alL
 atk
@@ -125180,9 +124801,9 @@ jvY
 aAy
 alL
 jvY
-pEd
+umI
 hqx
-xhi
+umI
 aep
 aep
 aep
@@ -125365,7 +124986,7 @@ aep
 aep
 aep
 aep
-pEd
+jkL
 tbD
 fDk
 jvY
@@ -125383,8 +125004,8 @@ alL
 aMo
 aOt
 jvY
-pEd
-hqx
+jkL
+lOn
 jhm
 oIB
 jgr
@@ -125568,7 +125189,7 @@ taw
 taw
 taw
 taw
-pEd
+jkL
 tbD
 fDk
 jvY
@@ -125586,7 +125207,7 @@ aIT
 atm
 aVF
 jvY
-pEd
+jkL
 wZp
 amc
 oIB
@@ -125790,8 +125411,8 @@ jvY
 jvY
 jvY
 xeq
-hqx
-xhi
+lOn
+mQF
 oIB
 wqr
 bZw
@@ -125974,7 +125595,7 @@ mfH
 nwT
 nwT
 mfH
-pym
+tzF
 gqf
 fDk
 alL
@@ -125992,9 +125613,9 @@ jvY
 wjv
 fDG
 alL
-pEd
+jkL
 wZp
-pym
+tzF
 qgK
 tEB
 uBM
@@ -126195,9 +125816,9 @@ arq
 anO
 qaV
 kwd
-urs
-hqx
-tFQ
+acQ
+lOn
+mQF
 oIB
 wKF
 hzb
@@ -126583,9 +126204,9 @@ taw
 cap
 fiN
 taw
-vkQ
+jkL
 kzR
-mXP
+jao
 kwd
 amA
 atq
@@ -126601,9 +126222,9 @@ atq
 atq
 aoT
 kwd
-vkQ
+acQ
 kzR
-oig
+jhm
 oIB
 cHC
 dha
@@ -126786,9 +126407,9 @@ taw
 taw
 taw
 taw
-mQF
-rnO
-ogd
+jkL
+kzR
+nbW
 alO
 ars
 amx
@@ -126804,8 +126425,8 @@ amx
 amx
 aOC
 alO
-mQF
-rnO
+jkL
+kzR
 mQF
 loP
 loP
@@ -126990,8 +126611,8 @@ liF
 wPR
 taw
 cui
-fQU
-onh
+kzR
+nbW
 inw
 amA
 amx
@@ -127007,8 +126628,8 @@ atq
 amx
 aoT
 inw
-ivV
-fQU
+jkL
+kzR
 hPr
 loP
 iwB
@@ -127192,8 +126813,8 @@ taw
 oQL
 oQL
 taw
-pEd
-gBg
+jkL
+kzR
 bLg
 aqj
 arw
@@ -127210,9 +126831,9 @@ atq
 atq
 wwJ
 inw
-pEd
+jkL
 tbD
-xhi
+mQF
 loP
 joG
 sDu
@@ -127395,8 +127016,8 @@ taw
 oQL
 oQL
 taw
-rhX
-gBg
+gbR
+kzR
 fDk
 inw
 qHM
@@ -127413,9 +127034,9 @@ amx
 amx
 aBs
 inw
-pEd
+jkL
 tbD
-xhi
+mQF
 loP
 kxo
 wSn
@@ -127598,8 +127219,8 @@ kiR
 oxy
 oxy
 kiR
-fiH
-gBg
+kGS
+kzR
 xsX
 alO
 alO
@@ -127616,9 +127237,9 @@ atq
 atq
 aBs
 alO
-pEd
-gBg
-fiH
+jkL
+kzR
+kGS
 fTF
 xBY
 xBY
@@ -127801,8 +127422,8 @@ taw
 oQL
 oQL
 lnD
-pEd
-gBg
+jkL
+kzR
 iea
 alO
 gKZ
@@ -127821,7 +127442,7 @@ aBs
 alO
 pvE
 tbD
-xhi
+mQF
 gdS
 wSn
 kXN
@@ -128004,8 +127625,8 @@ taw
 kLZ
 tty
 lnD
-pEd
-gBg
+jkL
+kzR
 iea
 alO
 arz
@@ -128022,9 +127643,9 @@ auB
 atc
 aOF
 alO
-pEd
+jkL
 tbD
-xhi
+mQF
 gdS
 lBg
 dXd
@@ -128207,8 +127828,8 @@ taw
 taw
 taw
 taw
-pEd
-gBg
+jkL
+kzR
 iea
 alO
 arz
@@ -128225,9 +127846,9 @@ aIU
 aMq
 aOG
 alO
-pEd
-gBg
-xhi
+jkL
+kzR
+mQF
 loP
 loP
 loP
@@ -128410,8 +128031,8 @@ aYU
 uxs
 iDs
 taw
-pEd
-gBg
+jkL
+kzR
 iea
 alO
 arz
@@ -128428,9 +128049,9 @@ xBe
 xBe
 xBe
 xBe
-pEd
-gBg
-xhi
+jkL
+kzR
+mQF
 jWh
 eFK
 wGd
@@ -128614,7 +128235,7 @@ oQL
 keE
 taw
 pvE
-gBg
+kzR
 iea
 xnR
 arm
@@ -128631,9 +128252,9 @@ aIV
 qqr
 arH
 xBe
-pEd
-gBg
-xhi
+jkL
+kzR
+mQF
 vXd
 duF
 hSk
@@ -128816,7 +128437,7 @@ gNQ
 gNQ
 gNQ
 xDG
-tJH
+dlT
 qpH
 iSu
 alO
@@ -128834,8 +128455,8 @@ azo
 aJg
 abR
 xBe
-pEd
-gBg
+jkL
+kzR
 jhm
 jWh
 oih
@@ -129019,9 +128640,9 @@ taw
 taw
 taw
 taw
-rhX
-gBg
-xhi
+gbR
+kzR
+mQF
 wDM
 wDM
 wDM
@@ -129037,9 +128658,9 @@ atv
 auV
 amE
 xBe
-pEd
-gBg
-xhi
+jkL
+kzR
+mQF
 jWh
 jWh
 uUz
@@ -129222,9 +128843,9 @@ tfb
 tfb
 tfb
 ptK
-pEd
+jkL
 tbD
-xhi
+mQF
 wDM
 aOM
 aoW
@@ -129240,9 +128861,9 @@ atv
 auV
 amE
 xBe
-pEd
+jkL
 tbD
-xhi
+mQF
 jWh
 xXa
 xXa
@@ -129425,9 +129046,9 @@ jhx
 jhx
 dnH
 gpc
-fiH
+kGS
 tbD
-xhi
+mQF
 wDM
 uto
 aoX
@@ -129445,7 +129066,7 @@ abR
 xBe
 pvE
 gxR
-pym
+tzF
 dEt
 soP
 pDr
@@ -129630,7 +129251,7 @@ owg
 ptK
 nhT
 gqf
-xhi
+mQF
 wDM
 aOQ
 fxI
@@ -129646,9 +129267,9 @@ azp
 qJf
 anV
 xBe
-pEd
+jkL
 tbD
-xhi
+mQF
 jWh
 iqH
 khE
@@ -129831,8 +129452,8 @@ eNi
 eNi
 eNi
 eNi
-pEd
-gBg
+jkL
+kzR
 jhm
 wDM
 aOH
@@ -129849,7 +129470,7 @@ xBe
 xBe
 xBe
 xBe
-pEd
+jkL
 tbD
 rXV
 jWh
@@ -130034,9 +129655,9 @@ olO
 wiG
 nWN
 eNi
-pEd
+jkL
 tbD
-xhi
+mQF
 wDM
 wDM
 wDM
@@ -130052,7 +129673,7 @@ aJh
 arq
 ufx
 alR
-pEd
+jkL
 tbD
 jhm
 jWh
@@ -130237,9 +129858,9 @@ ueG
 rPt
 jyE
 eNi
-pEd
+jkL
 tbD
-xhi
+mQF
 hwC
 rcS
 amx
@@ -130255,9 +129876,9 @@ aJi
 azs
 atq
 alR
-pEd
+jkL
 tbD
-xhi
+mQF
 jlQ
 tst
 uUe
@@ -130440,9 +130061,9 @@ iKD
 rPt
 rPt
 eNi
-pEd
+jkL
 tbD
-xhi
+mQF
 alR
 amA
 atq
@@ -130458,9 +130079,9 @@ aJj
 aMD
 atq
 alR
-pEd
+jkL
 tbD
-xhi
+mQF
 jlQ
 tZZ
 gLz
@@ -130644,8 +130265,8 @@ eNi
 gIh
 eNi
 iIQ
-gBg
-xhi
+kzR
+mQF
 alR
 amA
 atq
@@ -130661,9 +130282,9 @@ amA
 ayl
 amx
 alR
-pEd
+jkL
 tbD
-xhi
+mQF
 jWh
 jmQ
 vcu
@@ -130846,9 +130467,9 @@ aWb
 dyK
 vzK
 wYY
-pEd
-gBg
-xhi
+jkL
+kzR
+mQF
 alR
 amA
 atq
@@ -130864,9 +130485,9 @@ aJl
 amx
 atq
 alR
-pEd
+jkL
 tbD
-xhi
+mQF
 jlQ
 snE
 sGL
@@ -131049,9 +130670,9 @@ tii
 eJX
 sAC
 wYY
-pEd
-gBg
-xhi
+jkL
+kzR
+mQF
 alR
 amA
 amx
@@ -131067,9 +130688,9 @@ aJk
 amx
 atq
 alR
-pEd
+jkL
 tbD
-xhi
+mQF
 jlQ
 tZZ
 cBj
@@ -131252,9 +130873,9 @@ sjj
 fzP
 sAC
 wYY
-pEd
+jkL
 tbD
-xhi
+mQF
 alR
 amA
 atq
@@ -131270,7 +130891,7 @@ xEO
 xEO
 lnP
 alR
-pEd
+jkL
 tbD
 jhm
 jWh
@@ -131457,7 +131078,7 @@ qsL
 nim
 prV
 gqf
-xhi
+mQF
 alR
 amA
 atq
@@ -131473,9 +131094,9 @@ iWR
 iWR
 kbx
 alR
-pEd
+jkL
 tbD
-xhi
+mQF
 jWh
 jWh
 jlQ
@@ -131660,7 +131281,7 @@ kTN
 eNi
 pvE
 tbD
-xhi
+mQF
 alR
 amA
 atq
@@ -131676,9 +131297,9 @@ xEO
 xEO
 aOV
 alR
-pEd
+jkL
 tbD
-xhi
+mQF
 jWh
 wFQ
 bop
@@ -131861,9 +131482,9 @@ oNb
 iFC
 qAA
 eNi
-pEd
-gBg
-xhi
+jkL
+kzR
+mQF
 alR
 arK
 atc
@@ -131879,9 +131500,9 @@ aJq
 aMG
 aOW
 alR
-pEd
+jkL
 tbD
-xhi
+mQF
 jWh
 bXy
 bop
@@ -132064,8 +131685,8 @@ eNi
 eNi
 eNi
 eNi
-mQF
-rnO
+jkL
+kzR
 mQF
 alO
 alO
@@ -132082,8 +131703,8 @@ alO
 alO
 alO
 alO
-mQF
-rnO
+jkL
+tbD
 mQF
 jWh
 wFQ
@@ -132470,7 +132091,7 @@ keR
 jhx
 keR
 dwI
-pym
+tzF
 jae
 tGW
 hal
@@ -132490,7 +132111,7 @@ uYg
 hal
 rrG
 jae
-pym
+tzF
 mPh
 soP
 tWi
@@ -134301,9 +133922,9 @@ iYm
 fLl
 fLl
 vjd
-aRp
-jBX
-akS
+eky
+wZX
+vUh
 aHe
 oxU
 bsy
@@ -134311,9 +133932,9 @@ oir
 gzw
 shh
 aHe
-tKf
-jBX
-aRp
+svf
+wZX
+eky
 quy
 eZm
 eZm

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -50221,13 +50221,6 @@
 /obj/structure/surface/table/almayer,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cells)
-"nhT" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "orangecorner"
-	},
-/area/almayer/hallways/upper/aft_hallway)
 "nhV" = (
 /obj/structure/machinery/light/small,
 /turf/open/floor/almayer{
@@ -53640,6 +53633,9 @@
 "orq" = (
 /obj/item/storage/toolbox/mechanical{
 	pixel_y = 13
+	},
+/obj/structure/machinery/power/apc/almayer{
+	dir = 1
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -58123,6 +58119,16 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/command/corporateliaison)
+"pVI" = (
+/obj/effect/step_trigger/clone_cleaner,
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out"
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "green"
+	},
+/area/almayer/hallways/upper/fore_hallway)
 "pWb" = (
 /obj/effect/landmark/start/marine/tl/delta,
 /obj/effect/landmark/late_join/delta,
@@ -67727,7 +67733,6 @@
 	pixel_x = 4;
 	pixel_y = -3
 	},
-/obj/structure/machinery/power/apc/almayer,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -77170,6 +77175,7 @@
 	pixel_y = 28
 	},
 /obj/structure/closet,
+/obj/item/clothing/head/bearpelt,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -112488,7 +112494,7 @@ cuI
 ocX
 ocX
 ocX
-fCP
+pVI
 fCP
 fCP
 fCP
@@ -129509,8 +129515,8 @@ jhx
 jhx
 dnH
 gpc
-bKU
-vpi
+kjX
+gqf
 iZz
 wDM
 uto
@@ -129712,8 +129718,8 @@ nwU
 owg
 owg
 ptK
-nhT
-gqf
+fes
+vpi
 iZz
 wDM
 aOQ

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -649,16 +649,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/stair_clone/upper)
-"ado" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 8;
-	name = "ship-grade camera"
-	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "green"
-	},
-/area/almayer/living/starboard_garden)
 "adq" = (
 /turf/closed/wall/almayer,
 /area/almayer/lifeboat_pumps/north1)
@@ -1054,7 +1044,7 @@
 	dir = 9;
 	icon_state = "red"
 	},
-/area/almayer/living/starboard_garden)
+/area/almayer/lifeboat_pumps/north1)
 "afE" = (
 /obj/structure/machinery/vending/dinnerware,
 /obj/structure/machinery/firealarm{
@@ -1268,12 +1258,6 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/living/basketball)
-"agB" = (
-/turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "red"
-	},
-/area/almayer/living/starboard_garden)
 "agH" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/disposalpipe/segment{
@@ -1329,12 +1313,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/cafeteria_officer)
-"agS" = (
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "red"
-	},
-/area/almayer/living/starboard_garden)
 "agT" = (
 /turf/open/floor/prison{
 	icon_state = "kitchen"
@@ -1388,12 +1366,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/powered)
-"ahl" = (
-/turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "green"
-	},
-/area/almayer/living/starboard_garden)
 "aho" = (
 /obj/structure/window/framed/almayer,
 /turf/open/floor/plating,
@@ -1572,12 +1544,6 @@
 	allow_construction = 0
 	},
 /area/almayer/stair_clone/upper)
-"aiP" = (
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/almayer/living/starboard_garden)
 "aiQ" = (
 /obj/structure/machinery/faxmachine,
 /obj/structure/surface/table/almayer,
@@ -1889,18 +1855,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/command/lifeboat)
-"akW" = (
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/living/starboard_garden)
-"akY" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/living/starboard_garden)
 "ald" = (
 /turf/open/floor/almayer{
 	icon_state = "red"
@@ -1914,7 +1868,7 @@
 	dir = 8
 	},
 /turf/open/floor/almayer,
-/area/almayer/living/starboard_garden)
+/area/almayer/lifeboat_pumps/north1)
 "alf" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -2524,13 +2478,6 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
-"aoV" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/lifeboat_pumps/north1)
 "aoW" = (
 /obj/structure/machinery/portable_atmospherics/powered/pump,
 /obj/structure/machinery/camera/autoname/almayer{
@@ -2604,12 +2551,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/pilotbunks)
-"apr" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/lifeboat_pumps/north1)
 "aps" = (
 /obj/effect/step_trigger/teleporter_vector{
 	name = "Almayer_Down2";
@@ -2628,16 +2569,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/pilotbunks)
-"apu" = (
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
-/turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "red"
-	},
-/area/almayer/living/starboard_garden)
 "apz" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/door_control{
@@ -2831,7 +2762,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/almayer,
-/area/almayer/living/starboard_garden)
+/area/almayer/lifeboat_pumps/north1)
 "aqm" = (
 /obj/item/bedsheet/brown,
 /obj/structure/bed,
@@ -3414,9 +3345,6 @@
 	icon_state = "orange"
 	},
 /area/almayer/command/cic)
-"asS" = (
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/living/starboard_garden)
 "asT" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer,
@@ -3656,17 +3584,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/pilotbunks)
 "aub" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "NE-out";
 	pixel_y = 1
 	},
-/turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "red"
-	},
+/turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
 "auc" = (
 /obj/effect/step_trigger/clone_cleaner,
@@ -8401,7 +8323,7 @@
 	dir = 4;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/lifeboat_pumps/south2)
 "aRt" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -9524,18 +9446,6 @@
 	icon_state = "cargo"
 	},
 /area/almayer/hallways/hangar)
-"aYq" = (
-/turf/open/floor/almayer{
-	dir = 6;
-	icon_state = "red"
-	},
-/area/almayer/living/starboard_garden)
-"aYs" = (
-/turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "red"
-	},
-/area/almayer/living/starboard_garden)
 "aYt" = (
 /turf/open/floor/almayer,
 /area/almayer/hallways/hangar)
@@ -10546,13 +10456,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/chapel)
-"bfb" = (
-/obj/effect/step_trigger/clone_cleaner,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "green"
-	},
-/area/almayer/hallways/upper/aft_hallway)
 "bfd" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -11189,7 +11092,7 @@
 	dir = 10;
 	icon_state = "red"
 	},
-/area/almayer/living/starboard_garden)
+/area/almayer/lifeboat_pumps/north1)
 "biV" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 8
@@ -12033,9 +11936,6 @@
 	icon_state = "mono"
 	},
 /area/almayer/squads/req)
-"boL" = (
-/turf/open/floor/almayer,
-/area/almayer/living/starboard_garden)
 "boU" = (
 /obj/structure/surface/table/almayer,
 /obj/item/tool/weldingtool,
@@ -12675,6 +12575,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/gym)
+"btu" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/north2)
 "btv" = (
 /obj/structure/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -13932,12 +13838,6 @@
 	icon_state = "sterile_green"
 	},
 /area/almayer/medical/lockerroom)
-"bDD" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/turf/open/floor/almayer,
-/area/almayer/living/starboard_garden)
 "bDF" = (
 /obj/structure/machinery/door/poddoor/almayer{
 	dir = 4;
@@ -17943,12 +17843,6 @@
 	icon_state = "cargo_arrow"
 	},
 /area/almayer/squads/alpha)
-"ceu" = (
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "green"
-	},
-/area/almayer/living/starboard_garden)
 "ceC" = (
 /obj/structure/prop/almayer/ship_memorial,
 /turf/open/floor/plating/almayer,
@@ -21210,12 +21104,6 @@
 	icon_state = "green"
 	},
 /area/almayer/living/offices)
-"cWv" = (
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "green"
-	},
-/area/almayer/living/starboard_garden)
 "cWy" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/reagent_container/food/snacks/packaged_burger,
@@ -22420,11 +22308,6 @@
 	icon_state = "emeraldfull"
 	},
 /area/almayer/living/briefing)
-"dux" = (
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/living/starboard_garden)
 "duz" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -22558,7 +22441,7 @@
 	dir = 6;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/lifeboat_pumps/north2)
 "dxu" = (
 /obj/structure/sink{
 	dir = 1;
@@ -22749,7 +22632,7 @@
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/lifeboat_pumps/south2)
 "dAA" = (
 /obj/structure/prop/invuln/overhead_pipe{
 	pixel_x = 12
@@ -23392,7 +23275,7 @@
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/lifeboat_pumps/south2)
 "dJG" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 9
@@ -23815,6 +23698,12 @@
 	},
 /turf/open/floor/carpet,
 /area/almayer/command/corporateliaison)
+"dRQ" = (
+/turf/open/floor/almayer{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/north2)
 "dRT" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 4
@@ -25510,16 +25399,6 @@
 	},
 /turf/open/floor/almayer/aicore/glowing/no_build,
 /area/almayer/command/airoom)
-"euO" = (
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
-/turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "red"
-	},
-/area/almayer/lifeboat_pumps/north1)
 "euV" = (
 /turf/open/floor/almayer/uscm/directional{
 	dir = 8;
@@ -25934,6 +25813,12 @@
 	icon_state = "cargo"
 	},
 /area/almayer/engineering/lower/engine_core)
+"eCC" = (
+/obj/structure/bed/chair,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/lifeboat_pumps/north1)
 "eCI" = (
 /obj/structure/window/reinforced/ultra{
 	pixel_y = -12
@@ -28250,19 +28135,6 @@
 	icon_state = "silver"
 	},
 /area/almayer/living/briefing)
-"fvj" = (
-/obj/effect/step_trigger/clone_cleaner,
-/obj/effect/decal/warning_stripes{
-	icon_state = "NW-out";
-	layer = 2.5
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/hallways/upper/aft_hallway)
 "fvo" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/clothing/glasses/welding{
@@ -28864,12 +28736,7 @@
 /area/almayer/maint/hull/lower/l_a_s)
 "fGD" = (
 /obj/effect/step_trigger/clone_cleaner,
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
+/turf/open/floor/almayer,
 /area/almayer/hallways/upper/aft_hallway)
 "fHb" = (
 /obj/structure/largecrate/random/case/small,
@@ -28900,7 +28767,7 @@
 "fHM" = (
 /obj/docking_port/stationary/escape_pod/cl,
 /turf/open/floor/plating,
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/command/corporateliaison)
 "fIM" = (
 /obj/effect/landmark/start/marine/tl/bravo,
 /obj/effect/landmark/late_join/bravo,
@@ -31280,7 +31147,7 @@
 /turf/open/floor/almayer{
 	icon_state = "redfull"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/lifeboat_pumps/north2)
 "gCf" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/almayer{
@@ -35595,15 +35462,6 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/engineering/upper_engineering/port)
-"hXV" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "red"
-	},
-/area/almayer/lifeboat_pumps/south1)
 "hXX" = (
 /obj/effect/projector{
 	name = "Almayer_Down4";
@@ -35866,6 +35724,9 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_f_p)
+"idM" = (
+/turf/open/floor/plating,
+/area/almayer/command/corporateliaison)
 "idX" = (
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/prison{
@@ -36960,6 +36821,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/offices)
+"izu" = (
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/north2)
 "izG" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -38265,15 +38132,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/s_stern)
-"iYr" = (
-/obj/structure/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "green"
-	},
-/area/almayer/living/starboard_garden)
 "iYt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -42020,16 +41878,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/offices)
-"kmx" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "W"
-	},
-/obj/effect/step_trigger/clone_cleaner,
-/turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "green"
-	},
-/area/almayer/hallways/upper/aft_hallway)
 "kmE" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 5
@@ -45164,6 +45012,13 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/powered/agent)
+"lpJ" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_y = 1
+	},
+/turf/open/floor/almayer,
+/area/almayer/lifeboat_pumps/north1)
 "lql" = (
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -48796,6 +48651,12 @@
 	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
+"mJX" = (
+/turf/open/floor/almayer{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/south2)
 "mKb" = (
 /obj/structure/flora/pottedplant{
 	desc = "It is made of Fiberbush(tm). It contains asbestos.";
@@ -49705,6 +49566,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/port_point_defense)
+"mZv" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/south2)
 "mZF" = (
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	icon_state = "almayer_pdoor";
@@ -50764,15 +50631,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/req)
 "nqG" = (
-/obj/structure/machinery/light,
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out";
 	pixel_x = 1
 	},
-/turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "red"
-	},
+/turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
 "nqO" = (
 /obj/structure/closet/secure_closet/fridge/fish/stock,
@@ -50928,15 +50791,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north2)
-"nub" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "green"
-	},
-/area/almayer/living/starboard_garden)
 "nux" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/poddoor/almayer/open{
@@ -53151,12 +53005,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/warden_office)
-"oiB" = (
-/turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "green"
-	},
-/area/almayer/hallways/upper/aft_hallway)
 "oiL" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -53381,11 +53229,9 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out"
 	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	dir = 8;
+	icon_state = "green"
 	},
 /area/almayer/hallways/upper/aft_hallway)
 "omt" = (
@@ -56075,6 +55921,12 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/shipboard/brig/starboard_hallway)
+"pfe" = (
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/south2)
 "pfp" = (
 /obj/effect/step_trigger/teleporter_vector{
 	name = "Almayer_Up4";
@@ -59224,7 +59076,7 @@
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/lifeboat_pumps/north2)
 "qnh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61455,6 +61307,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/lower/engine_core)
+"rao" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/south2)
 "raE" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer{
@@ -62337,7 +62196,7 @@
 	dir = 9;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/lifeboat_pumps/south2)
 "rpp" = (
 /obj/effect/landmark/start/executive,
 /turf/open/floor/plating/plating_catwalk,
@@ -63279,7 +63138,7 @@
 	dir = 10;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/lifeboat_pumps/north2)
 "rGj" = (
 /turf/open/floor/almayer{
 	icon_state = "red"
@@ -64185,12 +64044,6 @@
 	icon_state = "cargo"
 	},
 /area/almayer/living/cryo_cells)
-"rWP" = (
-/obj/effect/step_trigger/clone_cleaner,
-/turf/open/floor/almayer{
-	icon_state = "green"
-	},
-/area/almayer/hallways/upper/aft_hallway)
 "rWT" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/manifold/hidden/supply{
@@ -64896,7 +64749,7 @@
 	dir = 5;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/lifeboat_pumps/south2)
 "siT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65931,7 +65784,7 @@
 /turf/open/floor/almayer{
 	icon_state = "redfull"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/lifeboat_pumps/south2)
 "sBL" = (
 /obj/structure/machinery/portable_atmospherics/hydroponics,
 /obj/structure/machinery/light,
@@ -67035,16 +66888,6 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
-"sYj" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "W"
-	},
-/obj/effect/step_trigger/clone_cleaner,
-/turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "green"
-	},
-/area/almayer/hallways/upper/aft_hallway)
 "sYl" = (
 /obj/structure/machinery/body_scanconsole{
 	dir = 8
@@ -67653,6 +67496,13 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/port)
+"tic" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/north2)
 "tig" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/food/condiment/hotsauce/tabasco{
@@ -67729,6 +67579,12 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/port)
+"tiO" = (
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/south2)
 "tiR" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/airlock/almayer/maint/reinforced{
@@ -67963,15 +67819,11 @@
 	},
 /area/almayer/shipboard/brig/execution)
 "tmI" = (
-/obj/structure/machinery/light,
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out";
 	pixel_x = -1
 	},
-/turf/open/floor/almayer{
-	dir = 6;
-	icon_state = "red"
-	},
+/turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
 "tmK" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
@@ -70909,6 +70761,11 @@
 	icon_state = "cargo_arrow"
 	},
 /area/almayer/living/offices)
+"upQ" = (
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/lifeboat_pumps/north1)
 "upR" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -76150,12 +76007,6 @@
 	},
 /turf/open/floor/almayer/aicore/glowing/no_build,
 /area/almayer/command/airoom)
-"vXk" = (
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/hallways/upper/stern_hallway)
 "vXo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -77395,7 +77246,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/almayer,
-/area/almayer/living/starboard_garden)
+/area/almayer/lifeboat_pumps/north1)
 "wrT" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/radio/marine,
@@ -78735,7 +78586,7 @@
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
-/area/almayer/hallways/upper/stern_hallway)
+/area/almayer/lifeboat_pumps/north2)
 "wPz" = (
 /turf/open/floor/almayer{
 	icon_state = "mono"
@@ -78970,12 +78821,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/charlie_delta_shared)
-"wTy" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/lifeboat_pumps/south1)
 "wTB" = (
 /obj/structure/surface/table/almayer,
 /obj/item/fuel_cell,
@@ -82046,6 +81891,12 @@
 	icon_state = "red"
 	},
 /area/almayer/hallways/upper/starboard)
+"xVg" = (
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/almayer/lifeboat_pumps/north2)
 "xVk" = (
 /turf/open/space,
 /area/space/almayer/lifeboat_dock)
@@ -108905,9 +108756,9 @@ nIN
 nIN
 nIN
 nIN
-hXV
+gnv
 yhI
-rRz
+tTu
 pgD
 tQV
 aaa
@@ -109052,9 +108903,9 @@ aaa
 aaa
 abs
 adq
-apr
-apr
-aoV
+afr
+akc
+apg
 njn
 rWz
 rWz
@@ -109108,9 +108959,9 @@ rgL
 rgL
 nTc
 nIN
-wTy
-wTy
-wTy
+crh
+csI
+qhb
 pgD
 tQV
 aaa
@@ -109256,8 +109107,8 @@ aaa
 abs
 adq
 aub
-akc
-euO
+akt
+awW
 njn
 rWz
 rWz
@@ -109311,8 +109162,8 @@ rgL
 rgL
 rgL
 nIN
-crh
-csI
+baw
+sMM
 nqG
 pgD
 tQV
@@ -110270,9 +110121,9 @@ aaa
 aaa
 abs
 adq
-aWm
-aka
-kyY
+lpJ
+akt
+awW
 njn
 mfR
 sqP
@@ -110326,8 +110177,8 @@ aGm
 xzh
 ear
 nIN
-rQW
-yhI
+baw
+sMM
 tmI
 pgD
 tQV
@@ -110473,9 +110324,9 @@ aaa
 aaa
 abs
 adq
-apr
-apr
-apr
+aWm
+aka
+kyY
 njn
 hzl
 vdT
@@ -110529,9 +110380,9 @@ xzh
 xzh
 moq
 nIN
-wTy
-wTy
-wTy
+rQW
+yhI
+rRz
 pgD
 tQV
 aaa
@@ -110674,11 +110525,11 @@ bdH
 bdH
 bdH
 bdH
-acf
-aet
-afB
-akW
-apu
+abs
+adq
+afr
+akc
+apg
 njn
 njn
 lBB
@@ -110732,9 +110583,9 @@ xzh
 gNo
 nIN
 nIN
-crh
+vpn
 csI
-qhb
+goL
 pgD
 tQV
 bdH
@@ -110877,12 +110728,12 @@ aaf
 aaf
 aaf
 aaf
-acv
-aez
-boL
-akY
-boL
-aiH
+abw
+eCC
+awW
+akt
+awW
+upQ
 hbl
 cGR
 fwP
@@ -111080,10 +110931,10 @@ aag
 aag
 aag
 aag
-acv
-aez
-boL
-akY
+abw
+eCC
+awW
+akt
 wrQ
 njn
 njn
@@ -111283,11 +111134,11 @@ aag
 aag
 aag
 aag
-acf
-aet
-agS
-aiP
-aYq
+abs
+adq
+aeZ
+aka
+aoI
 njn
 rWz
 rWz
@@ -111486,11 +111337,11 @@ aag
 aag
 aag
 aag
-acf
-aet
-agB
-akW
-aYs
+abs
+adq
+afr
+akc
+apg
 njn
 rWz
 rWz
@@ -111689,11 +111540,11 @@ aag
 aag
 aag
 aag
-acv
-aez
-boL
-akY
-boL
+abw
+eCC
+awW
+akt
+awW
 avJ
 rWz
 rWz
@@ -111892,10 +111743,10 @@ aag
 aag
 aag
 aag
-acv
-aez
-boL
-akY
+abw
+eCC
+awW
+akt
 aqk
 njn
 rWz
@@ -112095,11 +111946,11 @@ aag
 aag
 aag
 aag
-acf
-aet
-agS
-aiP
-aYq
+abs
+adq
+aeZ
+aka
+aoI
 njn
 rWz
 rWz
@@ -112298,10 +112149,10 @@ aag
 aag
 aag
 aag
-acf
-aet
+abs
+adq
 afB
-akW
+akc
 biT
 njn
 njn
@@ -112501,22 +112352,22 @@ aag
 aag
 aag
 aag
-acv
-aez
-boL
-boL
-boL
-ahl
-cWv
-cWv
-cWv
-cWv
+abw
+eCC
+awW
+awW
+awW
+ltt
+fCP
+fCP
+fCP
+fCP
 omp
-kmx
+ocX
 xog
 xog
 vFy
-ltt
+fCP
 fCP
 vUO
 fCP
@@ -112548,17 +112399,17 @@ mnC
 vUO
 qRx
 fCP
-ltt
+fCP
 cuI
 ocX
 ocX
-sYj
-fvj
+ocX
 fCP
 fCP
-kGS
 fCP
-oiB
+fCP
+fCP
+ltt
 baw
 baw
 qYC
@@ -112704,22 +112555,22 @@ aag
 aag
 aag
 aag
-acv
-aez
-boL
-asS
-boL
-ceu
-boL
-boL
-boL
-boL
-fGD
-bfb
-qEc
-qEc
-qEc
+abw
+eCC
+awW
+aTm
+awW
 ltt
+acQ
+acQ
+acQ
+acQ
+fGD
+fGD
+qEc
+qEc
+qEc
+acQ
 gfv
 gfv
 gfv
@@ -112751,17 +112602,17 @@ gfv
 gfv
 gfv
 gfv
-ltt
+acQ
 qEc
 qEc
 qEc
-rWP
+fGD
 fGD
 acQ
 acQ
 acQ
 acQ
-uQi
+ltt
 baw
 vbB
 ley
@@ -112907,22 +112758,22 @@ aah
 aah
 aah
 aah
-acf
-acf
-boL
+abs
+abs
+awW
 ale
-bDD
-nub
-dux
-iYr
-dux
-ado
+ajE
 ltt
-uVZ
+kGS
+rYG
+kGS
+xcY
+qxK
+qxK
 qxK
 qxK
 rYG
-ltt
+qxK
 qxK
 qxK
 qxK
@@ -112954,17 +112805,17 @@ uIa
 qxK
 qxK
 qxK
-ltt
+qxK
 rYG
 qxK
 qxK
-fdf
-ltt
+qxK
+qxK
 qxK
 kGS
 ftZ
 qxK
-fdf
+ltt
 baw
 dBp
 gVA
@@ -113112,10 +112963,10 @@ aaa
 aaa
 aaa
 acf
-aet
+biV
 aet
 biV
-biV
+aet
 ekY
 aet
 ekY
@@ -113154,15 +113005,15 @@ sqf
 uVZ
 rnd
 fdf
-mRU
-mRU
-mRU
-mRU
-mRU
-mRU
-mRU
-mRU
-mRU
+pBG
+pBG
+pBG
+pBG
+pBG
+pBG
+pBG
+pBG
+pBG
 mRU
 oiq
 mRU
@@ -113357,11 +113208,11 @@ sqf
 umI
 uch
 umI
-mRU
-qSw
-qSw
-qSw
-qSw
+pBG
+idM
+idM
+idM
+idM
 fHM
 pBG
 rLp
@@ -113560,12 +113411,12 @@ asn
 okx
 cFH
 xfo
-mRU
-qSw
-qSw
-qSw
-qSw
-qSw
+pBG
+idM
+idM
+idM
+idM
+idM
 pBG
 jZU
 jAe
@@ -113763,12 +113614,12 @@ asn
 eWN
 lOn
 rmB
-mRU
-qSw
-qSw
-qSw
-qSw
-qSw
+pBG
+idM
+idM
+idM
+idM
+idM
 pBG
 cVq
 nOb
@@ -113966,12 +113817,12 @@ asn
 eWN
 jao
 hCF
-mRU
-qSw
-qSw
-qSw
-qSw
-qSw
+pBG
+idM
+idM
+idM
+idM
+idM
 pBG
 dzp
 ngV
@@ -114169,7 +114020,7 @@ sqf
 jMP
 jao
 rmB
-mRU
+pBG
 pBG
 pBG
 pBG
@@ -123683,9 +123534,9 @@ ily
 cGd
 moK
 cGd
-fiH
-fiH
-fiH
+aeC
+aeC
+aeC
 ybk
 kCo
 tSY
@@ -123709,9 +123560,9 @@ qHu
 mbu
 kCo
 ybk
-fiH
-fiH
-fiH
+vcE
+vcE
+vcE
 mRU
 gBs
 mRU
@@ -123883,12 +123734,12 @@ aeC
 aeC
 ajs
 aeC
-bZq
-fiH
+mzS
+aeC
 rGc
-xjI
-xjI
-fzm
+izu
+izu
+dRQ
 pBg
 gmZ
 dpN
@@ -123912,12 +123763,12 @@ gmZ
 onh
 wJd
 pBg
-iOP
-xjI
-xjI
+pfe
+tiO
+tiO
 roY
-vXk
-jgS
+uHr
+nuM
 vcE
 kUV
 vcE
@@ -124086,12 +123937,12 @@ wXh
 aeC
 ydz
 ayb
-rrG
+tic
 gBZ
-tGW
-rfQ
-rfQ
-tGW
+btu
+asA
+asA
+btu
 oOi
 szb
 rfQ
@@ -124115,12 +123966,12 @@ urs
 eEF
 wmH
 oOi
-rrG
-rfQ
-rfQ
-rrG
+rao
+yeH
+yeH
+rao
 sBK
-tGW
+mZv
 sSl
 kkx
 vcE
@@ -124289,12 +124140,12 @@ ngl
 aeA
 ajk
 aeA
-iOP
-fiH
+xVg
+aeC
 dwJ
-vXk
-vXk
-jgS
+nBK
+nBK
+wYa
 pBg
 vkQ
 brm
@@ -124318,12 +124169,12 @@ biB
 uvq
 cVT
 pBg
-bZq
-vXk
-vXk
+xwX
+uHr
+uHr
 siS
 aRr
-fzm
+mJX
 lJY
 xVS
 lJY
@@ -124496,7 +124347,7 @@ taw
 mRI
 taw
 qnf
-fiH
+aeC
 wPm
 ybk
 mQF
@@ -124522,7 +124373,7 @@ pZq
 mQF
 ybk
 dJF
-fiH
+vcE
 dAr
 kNq
 cWo

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -208,6 +208,12 @@
 /obj/structure/window/framed/almayer/hull,
 /turf/open/floor/plating,
 /area/almayer/lifeboat_pumps/north1)
+"abz" = (
+/obj/structure/machinery/door/airlock/almayer/maint,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/maint/upper/u_f_p)
 "abB" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -502,6 +508,9 @@
 	icon_state = "mono"
 	},
 /area/almayer/lifeboat_pumps/north2)
+"acB" = (
+/turf/closed/wall/almayer,
+/area/almayer/maint/upper/u_a_p)
 "acI" = (
 /obj/structure/desertdam/decals/road_edge{
 	pixel_x = -12
@@ -2007,7 +2016,7 @@
 /turf/open/floor/almayer{
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "amd" = (
 /obj/structure/machinery/vending/cola{
 	density = 0;
@@ -3173,6 +3182,11 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/living/pilotbunks)
+"ash" = (
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/hallways/upper/fore_hallway)
 "asm" = (
 /obj/structure/stairs{
 	dir = 4
@@ -5499,7 +5513,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/maint/upper/u_m_p)
 "aBR" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/ashtray/glass,
@@ -6526,6 +6540,11 @@
 /obj/structure/window/reinforced/tinted/frosted,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/numbertwobunks)
+"aHo" = (
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/maint/upper/u_f_s)
 "aHq" = (
 /turf/closed/wall/almayer,
 /area/almayer/command/computerlab)
@@ -9499,7 +9518,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "aZe" = (
 /obj/structure/machinery/alarm/almayer{
 	dir = 1
@@ -10456,7 +10475,7 @@
 	dir = 5;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "bfl" = (
 /turf/open/floor/almayer{
 	dir = 5;
@@ -10953,7 +10972,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "bij" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = 32
@@ -11764,7 +11783,7 @@
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/maint/upper/u_m_p)
 "bnH" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -11926,7 +11945,7 @@
 /obj/structure/surface/table/almayer,
 /obj/item/tool/weldingtool,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "boV" = (
 /obj/structure/cargo_container/wy/left,
 /obj/structure/prop/almayer/minigun_crate{
@@ -12996,7 +13015,7 @@
 	dir = 4;
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "bwP" = (
 /obj/effect/step_trigger/clone_cleaner,
 /turf/open/floor/plating/almayer{
@@ -13083,7 +13102,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "bxA" = (
 /obj/structure/machinery/power/apc/almayer/hardened,
 /obj/effect/decal/warning_stripes{
@@ -13272,7 +13291,7 @@
 	dir = 5;
 	icon_state = "silver"
 	},
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/maint/upper/u_m_p)
 "bzg" = (
 /obj/structure/pipes/vents/pump{
 	dir = 8;
@@ -13479,7 +13498,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/maint/upper/u_m_p)
 "bBd" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -13808,7 +13827,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "bDn" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/closed/wall/almayer,
@@ -15105,6 +15124,11 @@
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/shipboard/sea_office)
+"bKU" = (
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/hallways/upper/aft_hallway)
 "bKX" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/box/masks,
@@ -15145,7 +15169,7 @@
 /turf/open/floor/almayer{
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "bLh" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -15563,7 +15587,7 @@
 	dir = 8;
 	icon_state = "orangecorner"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "bNe" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 8;
@@ -15754,7 +15778,7 @@
 	dir = 1;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "bNL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -16605,7 +16629,7 @@
 	dir = 4;
 	icon_state = "greencorner"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "bTE" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -17328,7 +17352,7 @@
 	dir = 9;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "bZr" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -17460,7 +17484,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "caq" = (
 /obj/structure/machinery/light/small,
 /turf/open/floor/plating/plating_catwalk,
@@ -17614,7 +17638,7 @@
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "cbL" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 1;
@@ -18104,7 +18128,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "chL" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -19339,7 +19363,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/maint/upper/u_m_p)
 "cqd" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -19563,7 +19587,7 @@
 	dir = 4;
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "cuq" = (
 /obj/structure/machinery/computer/arcade,
 /turf/open/floor/wood/ship,
@@ -19601,7 +19625,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "cuN" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -19630,7 +19654,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "cvb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -19651,7 +19675,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "cvx" = (
 /turf/closed/wall/almayer,
 /area/almayer/maint/lower/cryo_cells)
@@ -19689,7 +19713,7 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "cwo" = (
 /obj/structure/largecrate/random/mini/chest{
 	pixel_x = 4
@@ -19713,7 +19737,7 @@
 /turf/open/floor/almayer{
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "cwS" = (
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor/almayer/aicore/no_build,
@@ -20238,7 +20262,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/upper/u_m_p)
+/area/almayer/maint/upper/u_f_p)
 "cHu" = (
 /turf/closed/wall/almayer/research/containment/wall/south,
 /area/almayer/medical/containment/cell/cl)
@@ -20416,7 +20440,7 @@
 /turf/open/floor/almayer{
 	allow_construction = 0
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "cKm" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/glass/bucket/mopbucket{
@@ -20435,6 +20459,15 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/maint/lower/constr)
+"cKp" = (
+/obj/structure/machinery/firealarm{
+	pixel_y = 28
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "blue"
+	},
+/area/almayer/hallways/upper/fore_hallway)
 "cKJ" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -21045,7 +21078,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/maint/hull/upper/u_a_p)
+/area/almayer/maint/upper/u_a_p)
 "cWr" = (
 /obj/structure/machinery/photocopier{
 	density = 0;
@@ -21113,7 +21146,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "cXi" = (
 /obj/structure/machinery/light{
 	unacidable = 1;
@@ -21456,7 +21489,7 @@
 "dcZ" = (
 /obj/structure/machinery/power/apc/almayer,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/upper/u_m_p)
+/area/almayer/maint/upper/u_f_p)
 "ddf" = (
 /obj/structure/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/almayer{
@@ -21481,7 +21514,7 @@
 	dir = 9;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "ddw" = (
 /obj/structure/machinery/cm_vending/sorted/tech/comp_storage,
 /obj/structure/sign/safety/terminal{
@@ -21506,7 +21539,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_p)
+/area/almayer/maint/upper/u_a_p)
 "ddL" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer,
@@ -21539,7 +21572,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/upper/u_m_s)
+/area/almayer/maint/upper/u_f_s)
 "deD" = (
 /obj/structure/machinery/prop/almayer/CICmap{
 	pixel_x = -5
@@ -21633,12 +21666,17 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/chief_mp_office)
+"dgI" = (
+/turf/open/floor/almayer{
+	icon_state = "blue"
+	},
+/area/almayer/hallways/upper/fore_hallway)
 "dgP" = (
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "dha" = (
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -21808,7 +21846,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "dkO" = (
 /obj/effect/step_trigger/teleporter_vector{
 	name = "Almayer_Down2";
@@ -21849,7 +21887,7 @@
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "dmg" = (
 /obj/structure/machinery/vending/coffee,
 /obj/structure/sign/safety/coffee{
@@ -22200,6 +22238,11 @@
 	icon_state = "redcorner"
 	},
 /area/almayer/shipboard/brig/execution)
+"dsS" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hallways/upper/fore_hallway)
 "dsY" = (
 /turf/open/floor/almayer{
 	icon_state = "orangecorner"
@@ -22295,7 +22338,7 @@
 	},
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "duT" = (
 /obj/structure/bed,
 /obj/structure/machinery/flasher{
@@ -22570,7 +22613,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "dzX" = (
 /obj/structure/sign/safety/water{
 	pixel_x = -17
@@ -22758,7 +22801,7 @@
 	dir = 8;
 	icon_state = "silver"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "dCe" = (
 /obj/structure/machinery/cryopod{
 	pixel_y = 6
@@ -22842,7 +22885,7 @@
 	dir = 8;
 	icon_state = "silver"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "dDp" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W";
@@ -22997,7 +23040,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "dFk" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -23481,7 +23524,7 @@
 	dir = 4;
 	icon_state = "red"
 	},
-/area/almayer/maint/hull/upper/u_a_p)
+/area/almayer/maint/upper/u_a_p)
 "dPm" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -23621,7 +23664,7 @@
 	dir = 5;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "dRs" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/almayer{
@@ -24092,7 +24135,7 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "dZZ" = (
 /obj/structure/surface/rack,
 /obj/item/tool/weldpack,
@@ -24136,7 +24179,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/upper/u_m_p)
+/area/almayer/maint/upper/u_f_p)
 "eas" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24507,7 +24550,7 @@
 	pixel_y = 13
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/maint/upper/u_m_p)
 "ehc" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 1;
@@ -24912,7 +24955,7 @@
 	dir = 6;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "enF" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out"
@@ -24960,6 +25003,17 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/lower/port_midship_hallway)
+"eoD" = (
+/obj/structure/machinery/door/airlock/almayer/maint{
+	dir = 1
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/maint/upper/u_m_s)
 "eoE" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/almayer{
@@ -25412,6 +25466,13 @@
 	icon_state = "cargo"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
+"evG" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/hallways/upper/fore_hallway)
 "evR" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/toolbox/mechanical/green{
@@ -25455,6 +25516,18 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/brig/execution)
+"ewL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "blue"
+	},
+/area/almayer/hallways/upper/fore_hallway)
 "ewO" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 1
@@ -25528,7 +25601,7 @@
 	name = "hypersleep curtain"
 	},
 /turf/open/floor/plating,
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/maint/upper/u_m_p)
 "eyM" = (
 /obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/almayer{
@@ -25802,7 +25875,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_p)
+/area/almayer/maint/upper/u_a_p)
 "eDo" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W";
@@ -26067,7 +26140,7 @@
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/maint/hull/upper/u_a_p)
+/area/almayer/maint/upper/u_a_p)
 "eHY" = (
 /obj/structure/surface/rack,
 /obj/item/device/taperecorder,
@@ -26107,7 +26180,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "eJQ" = (
 /obj/structure/prop/invuln{
 	desc = "An inflated membrane. This one is puncture proof. Wow!";
@@ -26127,7 +26200,7 @@
 "eJZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "eKa" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
 	dir = 2;
@@ -26426,7 +26499,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "eQh" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out";
@@ -26511,7 +26584,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "eRR" = (
 /obj/item/clothing/head/helmet/marine{
 	pixel_x = 16;
@@ -27204,7 +27277,7 @@
 	dir = 6;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "fdx" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -27272,6 +27345,12 @@
 	icon_state = "green"
 	},
 /area/almayer/living/grunt_rnr)
+"fes" = (
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "orangecorner"
+	},
+/area/almayer/hallways/upper/aft_hallway)
 "feD" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_22";
@@ -27483,7 +27562,7 @@
 "fiN" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "fiQ" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -27564,6 +27643,12 @@
 	icon_state = "bluecorner"
 	},
 /area/almayer/living/pilotbunks)
+"fmX" = (
+/obj/structure/machinery/light/small,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/maint/upper/u_a_p)
 "fmZ" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -27939,7 +28024,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "fsf" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -28003,6 +28088,11 @@
 	icon_state = "blue"
 	},
 /area/almayer/hallways/upper/midship_hallway)
+"ftw" = (
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/maint/upper/u_f_p)
 "ftG" = (
 /obj/structure/sign/safety/life_support{
 	pixel_x = 8;
@@ -28011,7 +28101,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "ftZ" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = 32
@@ -28020,7 +28110,7 @@
 	dir = 4;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "fuz" = (
 /obj/structure/machinery/cm_vending/clothing/pilot_officer,
 /turf/open/floor/almayer{
@@ -28184,7 +28274,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/upper/u_m_s)
+/area/almayer/maint/upper/u_f_s)
 "fwY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28284,7 +28374,7 @@
 	dir = 6;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "fzq" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -28387,7 +28477,7 @@
 /turf/open/floor/almayer{
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "fBO" = (
 /obj/structure/machinery/chem_master{
 	vial_maker = 1
@@ -28439,7 +28529,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "fCT" = (
 /obj/structure/surface/table/almayer,
 /obj/item/fuel_cell,
@@ -28576,6 +28666,14 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/morgue)
+"fFs" = (
+/obj/structure/machinery/door/airlock/almayer/maint{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/maint/upper/u_f_s)
 "fFD" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -28693,7 +28791,7 @@
 "fGD" = (
 /obj/effect/step_trigger/clone_cleaner,
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "fHb" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating/plating_catwalk,
@@ -29195,7 +29293,7 @@
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/maint/hull/upper/u_a_p)
+/area/almayer/maint/upper/u_a_p)
 "fQn" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -29444,7 +29542,7 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "fXg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -29719,7 +29817,7 @@
 	dir = 4;
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "gcm" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -30148,6 +30246,15 @@
 	icon_state = "plate"
 	},
 /area/almayer/command/cic)
+"gkV" = (
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hallways/upper/fore_hallway)
 "glc" = (
 /obj/structure/machinery/firealarm{
 	pixel_y = 28
@@ -30383,7 +30490,7 @@
 "gqf" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "gqt" = (
 /obj/structure/sign/safety/storage{
 	pixel_x = -17
@@ -30629,7 +30736,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/upper/u_m_s)
+/area/almayer/maint/upper/u_f_s)
 "guK" = (
 /obj/effect/projector{
 	name = "Almayer_Up3";
@@ -30805,7 +30912,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "gxU" = (
 /obj/structure/surface/table/almayer,
 /obj/item/toy/deck,
@@ -31114,7 +31221,7 @@
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "gDp" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -31138,6 +31245,14 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/processing)
+"gDF" = (
+/obj/structure/largecrate/random/case{
+	layer = 2.98
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/maint/upper/u_a_s)
 "gDH" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_y = 25
@@ -31229,7 +31344,7 @@
 /turf/open/floor/almayer{
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "gFP" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/shipboard/stern_point_defense)
@@ -31372,7 +31487,7 @@
 	allow_construction = 0;
 	icon_state = "plate"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "gHZ" = (
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -31520,7 +31635,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/upper/u_m_p)
+/area/almayer/maint/upper/u_f_p)
 "gKd" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -31697,7 +31812,7 @@
 "gMJ" = (
 /obj/structure/largecrate/supply/weapons/pistols,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "gMN" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -31806,7 +31921,7 @@
 "gNQ" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "gNZ" = (
 /obj/structure/machinery/light/small{
 	dir = 1
@@ -32763,7 +32878,7 @@
 	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "hfv" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/almayer{
@@ -32995,7 +33110,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "hji" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -33418,7 +33533,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_p)
+/area/almayer/maint/upper/u_a_p)
 "hoK" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -33530,7 +33645,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "hqW" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/medidoor{
 	name = "\improper Medical Bay";
@@ -33759,6 +33874,12 @@
 	icon_state = "greenfull"
 	},
 /area/almayer/living/offices)
+"htS" = (
+/obj/structure/machinery/door/airlock/almayer/maint,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/maint/upper/u_m_s)
 "hux" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 8;
@@ -33826,7 +33947,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "hvv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/manifold/hidden/supply{
@@ -34026,7 +34147,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/upper/u_m_s)
+/area/almayer/maint/upper/u_f_s)
 "hzs" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -34187,7 +34308,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "hBz" = (
 /obj/item/mortar_kit,
 /turf/open/floor/almayer{
@@ -34361,7 +34482,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "hEl" = (
 /obj/structure/machinery/alarm/almayer{
 	dir = 1
@@ -34403,6 +34524,12 @@
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
+"hFt" = (
+/obj/structure/machinery/power/apc/almayer{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/maint/upper/u_a_p)
 "hFw" = (
 /obj/structure/machinery/disposal/broken,
 /turf/open/floor/almayer{
@@ -34436,7 +34563,7 @@
 	dir = 1;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "hGG" = (
 /obj/effect/step_trigger/clone_cleaner,
 /obj/effect/decal/warning_stripes{
@@ -34557,6 +34684,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_a_p)
+"hJe" = (
+/obj/structure/machinery/door/airlock/almayer/maint,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/maint/upper/u_a_p)
 "hJg" = (
 /obj/structure/pipes/trinary/mixer{
 	dir = 4;
@@ -34643,7 +34776,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_p)
+/area/almayer/maint/upper/u_a_p)
 "hLu" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -34809,7 +34942,7 @@
 /turf/open/floor/almayer{
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "hPu" = (
 /obj/structure/largecrate/supply,
 /obj/item/tool/crowbar,
@@ -35312,7 +35445,7 @@
 /turf/open/floor/plating/almayer{
 	allow_construction = 0
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "hXb" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -35573,6 +35706,12 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/maint/hull/upper/u_f_s)
+"icn" = (
+/obj/structure/machinery/power/apc/almayer,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/maint/upper/u_m_p)
 "icp" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -35644,7 +35783,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "ied" = (
 /obj/structure/machinery/power/apc/almayer{
 	dir = 1
@@ -35991,7 +36130,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "ikQ" = (
 /obj/structure/surface/table/woodentable/fancy,
 /obj/item/tool/stamp/hop{
@@ -36195,7 +36334,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "ipB" = (
 /obj/structure/surface/rack,
 /obj/item/tool/kitchen/rollingpin,
@@ -36344,6 +36483,14 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_m_p)
+"isB" = (
+/obj/structure/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/maint/upper/u_m_s)
 "isC" = (
 /obj/effect/projector{
 	name = "Almayer_AresDown";
@@ -36449,6 +36596,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/p_bow)
+"iuh" = (
+/obj/structure/largecrate/random/barrel,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/maint/upper/u_m_p)
 "iun" = (
 /obj/effect/spawner/random/tool,
 /turf/open/floor/plating/plating_catwalk,
@@ -37119,7 +37272,7 @@
 	dir = 4;
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "iIR" = (
 /obj/structure/surface/table/almayer,
 /obj/item/trash/USCMtray{
@@ -37397,7 +37550,7 @@
 	dir = 5;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "iOX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37488,7 +37641,7 @@
 /turf/open/floor/almayer{
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "iQd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -37571,6 +37724,12 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/processing)
+"iQG" = (
+/obj/structure/largecrate/random/barrel/red,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/maint/upper/u_a_s)
 "iQJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37589,7 +37748,7 @@
 	dir = 4;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "iRp" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/poddoor/shutters/almayer/open{
@@ -37673,7 +37832,7 @@
 /turf/open/floor/almayer{
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "iSB" = (
 /obj/structure/platform_decoration{
 	dir = 8
@@ -38067,6 +38226,11 @@
 	},
 /turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
+"iZz" = (
+/turf/open/floor/almayer{
+	icon_state = "orangecorner"
+	},
+/area/almayer/hallways/upper/aft_hallway)
 "iZE" = (
 /obj/structure/machinery/cm_vending/sorted/tech/tool_storage,
 /obj/effect/decal/warning_stripes{
@@ -38118,7 +38282,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "jaf" = (
 /obj/structure/bed/chair/comfy/bravo{
 	dir = 4
@@ -38226,7 +38390,7 @@
 "jaW" = (
 /obj/effect/landmark/start/reporter,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/maint/upper/u_m_p)
 "jbq" = (
 /obj/structure/window/framed/almayer/hull,
 /turf/open/floor/plating,
@@ -38625,7 +38789,7 @@
 	dir = 10;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "jhb" = (
 /obj/structure/sign/safety/cryo{
 	pixel_x = -6;
@@ -38641,7 +38805,7 @@
 /turf/open/floor/almayer{
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "jhn" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -38979,6 +39143,12 @@
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/living/basketball)
+"jlO" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/hallways/upper/aft_hallway)
 "jlQ" = (
 /obj/structure/window/framed/almayer,
 /turf/open/floor/plating,
@@ -39377,6 +39547,15 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/living/port_emb)
+"juG" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/maint/upper/u_a_p)
+"juM" = (
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "blue"
+	},
+/area/almayer/hallways/upper/fore_hallway)
 "juS" = (
 /obj/structure/machinery/gear{
 	id = "vehicle_elevator_gears"
@@ -39563,7 +39742,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/maint/upper/u_m_p)
 "jwP" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out";
@@ -40055,7 +40234,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/maint/upper/u_m_p)
 "jIC" = (
 /obj/structure/machinery/computer/working_joe{
 	dir = 4;
@@ -40525,7 +40704,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "jRp" = (
 /obj/structure/largecrate/supply/supplies/water,
 /obj/item/toy/deck{
@@ -40980,7 +41159,16 @@
 	dir = 9;
 	icon_state = "red"
 	},
-/area/almayer/maint/hull/upper/u_a_p)
+/area/almayer/maint/upper/u_a_p)
+"jZl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hallways/upper/fore_hallway)
 "jZo" = (
 /obj/structure/machinery/door/airlock/almayer/maint,
 /obj/effect/step_trigger/clone_cleaner,
@@ -41316,7 +41504,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "keG" = (
 /obj/structure/machinery/door/airlock/almayer/security{
 	dir = 2;
@@ -41525,7 +41713,7 @@
 	dir = 1;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "kiy" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -41652,6 +41840,12 @@
 	icon_state = "cargo"
 	},
 /area/almayer/hallways/lower/port_midship_hallway)
+"kjX" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/hallways/upper/aft_hallway)
 "kjY" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer{
@@ -42477,7 +42671,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "kzT" = (
 /obj/structure/machinery/door_control{
 	id = "ARES StairsLower";
@@ -42769,6 +42963,12 @@
 	icon_state = "redfull"
 	},
 /area/almayer/living/briefing)
+"kED" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/almayer{
+	icon_state = "cargo"
+	},
+/area/almayer/hallways/upper/fore_hallway)
 "kEE" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -43087,7 +43287,7 @@
 "kLB" = (
 /obj/docking_port/stationary/escape_pod/east,
 /turf/open/floor/plating,
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "kLE" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/poddoor/almayer{
@@ -43118,7 +43318,7 @@
 	},
 /obj/structure/largecrate/random/barrel/red,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "kMa" = (
 /obj/structure/platform_decoration,
 /turf/open/floor/almayer{
@@ -43470,7 +43670,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "kRD" = (
 /obj/item/reagent_container/glass/bucket/janibucket,
 /obj/structure/machinery/light{
@@ -43494,7 +43694,7 @@
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
-/area/almayer/maint/hull/upper/u_a_p)
+/area/almayer/maint/upper/u_a_p)
 "kRP" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/item/prop/magazine/dirty/torn,
@@ -43643,7 +43843,7 @@
 	dir = 1;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "kUA" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
@@ -43710,7 +43910,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "kWk" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 10
@@ -43971,7 +44171,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "laQ" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -44022,7 +44222,7 @@
 /turf/open/floor/plating/almayer{
 	allow_construction = 0
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "lbf" = (
 /obj/structure/machinery/cryopod{
 	pixel_y = 6
@@ -44139,6 +44339,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/gym)
+"ldz" = (
+/obj/structure/machinery/power/apc/almayer{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/maint/hull/upper/u_a_s)
 "ldC" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -44214,6 +44420,9 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_lobby)
+"lfc" = (
+/turf/closed/wall/almayer,
+/area/almayer/maint/upper/u_f_s)
 "lft" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/firstaid/fire,
@@ -44407,7 +44616,7 @@
 /obj/item/clothing/head/cmcap,
 /obj/item/clothing/head/cmcap,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "liJ" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -44603,6 +44812,15 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
+"llt" = (
+/obj/structure/machinery/power/apc/almayer{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "silver"
+	},
+/area/almayer/hallways/upper/midship_hallway)
 "llK" = (
 /obj/structure/platform_decoration{
 	dir = 4
@@ -44702,7 +44920,7 @@
 "lnD" = (
 /obj/structure/window/framed/almayer,
 /turf/open/floor/plating,
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "lnP" = (
 /obj/structure/machinery/vending/cola,
 /obj/structure/window/reinforced,
@@ -44983,7 +45201,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "lsn" = (
 /obj/structure/surface/table/almayer,
 /obj/item/paper{
@@ -45287,6 +45505,11 @@
 	icon_state = "cargo"
 	},
 /area/almayer/living/commandbunks)
+"lxJ" = (
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/maint/upper/u_a_p)
 "lxT" = (
 /obj/structure/machinery/constructable_frame,
 /turf/open/floor/almayer{
@@ -45404,7 +45627,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "lAa" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/lightreplacer{
@@ -45460,7 +45683,7 @@
 	dir = 10;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "lBg" = (
 /obj/structure/bedsheetbin,
 /turf/open/floor/almayer{
@@ -45495,7 +45718,7 @@
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/maint/upper/u_m_p)
 "lBB" = (
 /obj/structure/machinery/power/apc/almayer{
 	dir = 1
@@ -45503,7 +45726,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/upper/u_m_s)
+/area/almayer/maint/upper/u_f_s)
 "lCc" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 8
@@ -45513,7 +45736,18 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
+"lCf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "orangecorner"
+	},
+/area/almayer/hallways/upper/aft_hallway)
 "lCm" = (
 /obj/structure/machinery/light/small{
 	dir = 1
@@ -46218,7 +46452,7 @@
 "lPW" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/maint/upper/u_m_p)
 "lQa" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -46645,7 +46879,7 @@
 	dir = 1;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "maI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -46838,7 +47072,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "mfM" = (
 /obj/structure/surface/table/almayer,
 /obj/effect/landmark/map_item,
@@ -46867,7 +47101,7 @@
 /obj/item/tool/pen,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/upper/u_m_s)
+/area/almayer/maint/upper/u_f_s)
 "mgb" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_m_p)
@@ -47042,6 +47276,9 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_a_p)
+"mjR" = (
+/turf/open/floor/plating,
+/area/almayer/maint/upper/u_f_s)
 "mjS" = (
 /obj/structure/machinery/firealarm{
 	pixel_y = 28
@@ -47287,7 +47524,7 @@
 	dir = 8;
 	icon_state = "greencorner"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "mnI" = (
 /turf/open/floor/almayer{
 	icon_state = "blue"
@@ -47308,7 +47545,7 @@
 /turf/open/floor/almayer{
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "mnW" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/reagent_scanner{
@@ -47348,7 +47585,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/upper/u_m_p)
+/area/almayer/maint/upper/u_f_p)
 "mor" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -47611,6 +47848,14 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
+"mtq" = (
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/maint/upper/u_m_s)
 "mtr" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -48123,7 +48368,7 @@
 	},
 /obj/item/tool/soap,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "mDJ" = (
 /turf/open/floor/almayer,
 /area/almayer/engineering/upper_engineering/starboard)
@@ -48470,7 +48715,7 @@
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "mJu" = (
 /turf/open/floor/almayer/uscm/directional,
 /area/almayer/command/cic)
@@ -48581,6 +48826,15 @@
 	icon_state = "plate"
 	},
 /area/almayer/command/lifeboat)
+"mKG" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/upper/fore_hallway)
 "mKJ" = (
 /obj/structure/machinery/firealarm{
 	pixel_y = 28
@@ -48745,7 +48999,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "mNX" = (
 /turf/open/floor/almayer_hull{
 	dir = 4;
@@ -48780,7 +49034,7 @@
 /turf/open/floor/almayer{
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "mOE" = (
 /obj/structure/sign/safety/water{
 	pixel_x = -17
@@ -48797,7 +49051,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/upper/u_m_s)
+/area/almayer/maint/upper/u_f_s)
 "mPc" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -49167,7 +49421,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "mUY" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/tool,
@@ -49333,7 +49587,7 @@
 	dir = 1;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "mYt" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W";
@@ -49569,6 +49823,12 @@
 	icon_state = "orangecorner"
 	},
 /area/almayer/hallways/upper/midship_hallway)
+"nbY" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/hallways/upper/aft_hallway)
 "ncf" = (
 /obj/structure/machinery/cryopod/right{
 	layer = 3.1;
@@ -49631,7 +49891,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "ndl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -49829,6 +50089,15 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/bravo)
+"ngF" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/upper/aft_hallway)
 "ngI" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -49958,7 +50227,7 @@
 	dir = 4;
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "nhV" = (
 /obj/structure/machinery/light/small,
 /turf/open/floor/almayer{
@@ -50320,7 +50589,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "nnL" = (
 /obj/structure/toilet{
 	dir = 8
@@ -50679,7 +50948,7 @@
 	dir = 6;
 	icon_state = "silver"
 	},
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/maint/upper/u_m_p)
 "nve" = (
 /obj/structure/janitorialcart,
 /obj/item/tool/mop,
@@ -50772,7 +51041,7 @@
 /turf/open/floor/almayer{
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "nww" = (
 /turf/open/floor/almayer{
 	dir = 6;
@@ -50794,7 +51063,7 @@
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/maint/hull/upper/u_a_p)
+/area/almayer/maint/upper/u_a_p)
 "nwD" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -50821,7 +51090,7 @@
 "nwT" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "nwU" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -51328,7 +51597,7 @@
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
-/area/almayer/maint/hull/upper/u_a_p)
+/area/almayer/maint/upper/u_a_p)
 "nHu" = (
 /obj/structure/largecrate/random/barrel/yellow,
 /obj/structure/machinery/light{
@@ -51620,7 +51889,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "nNT" = (
 /obj/item/tool/weldingtool,
 /turf/open/floor/plating/plating_catwalk,
@@ -51820,7 +52089,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "nQA" = (
 /turf/open/floor/carpet,
 /area/almayer/command/corporateliaison)
@@ -51916,7 +52185,7 @@
 "nTc" = (
 /obj/docking_port/stationary/escape_pod/south,
 /turf/open/floor/plating,
-/area/almayer/maint/upper/u_m_p)
+/area/almayer/maint/upper/u_f_p)
 "nTl" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -52109,7 +52378,7 @@
 /turf/open/floor/plating/almayer{
 	allow_construction = 0
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "nVB" = (
 /turf/open/floor/almayer,
 /area/almayer/command/securestorage)
@@ -52289,6 +52558,14 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/u_a_p)
+"nZK" = (
+/obj/structure/machinery/door/airlock/almayer/maint{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/maint/upper/u_f_p)
 "nZR" = (
 /obj/structure/machinery/power/apc/almayer{
 	dir = 8
@@ -52380,7 +52657,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "obQ" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -52440,7 +52717,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "ocX" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -52450,7 +52727,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "odb" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer{
@@ -52601,6 +52878,12 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/computerlab)
+"oeN" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/almayer{
+	icon_state = "cargo"
+	},
+/area/almayer/hallways/upper/fore_hallway)
 "oeZ" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/shipboard/brig/medical)
@@ -52918,7 +53201,7 @@
 	dir = 10;
 	icon_state = "red"
 	},
-/area/almayer/maint/hull/upper/u_a_p)
+/area/almayer/maint/upper/u_a_p)
 "okx" = (
 /turf/open/floor/almayer{
 	dir = 9;
@@ -52952,7 +53235,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/upper/u_m_s)
+/area/almayer/maint/upper/u_f_s)
 "olM" = (
 /obj/structure/bed/chair{
 	can_buckle = 0;
@@ -53036,7 +53319,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "omt" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -53228,7 +53511,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "opV" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -53361,7 +53644,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "orH" = (
 /turf/open/floor/almayer/uscm/directional{
 	dir = 10
@@ -53377,6 +53660,9 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/lower/workshop/hangar)
+"orV" = (
+/turf/open/floor/almayer,
+/area/almayer/hallways/upper/fore_hallway)
 "osc" = (
 /obj/structure/machinery/cm_vending/sorted/uniform_supply/squad_prep,
 /obj/structure/machinery/light{
@@ -53400,7 +53686,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/upper/u_m_s)
+/area/almayer/maint/upper/u_f_s)
 "osx" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -53862,7 +54148,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "oAB" = (
 /obj/structure/platform{
 	dir = 8;
@@ -53908,7 +54194,7 @@
 	allow_construction = 0;
 	icon_state = "plate"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "oBq" = (
 /obj/structure/bed,
 /obj/structure/machinery/flasher{
@@ -54192,6 +54478,14 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_a_s)
+"oFU" = (
+/obj/structure/machinery/door/airlock/almayer/maint{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/maint/upper/u_a_p)
 "oFV" = (
 /obj/structure/sign/poster{
 	pixel_x = -32;
@@ -55007,7 +55301,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "oTe" = (
 /obj/item/prop/almayer/box,
 /obj/item/prop{
@@ -55343,7 +55637,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/maint/upper/u_m_p)
 "oZp" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/light,
@@ -56166,7 +56460,7 @@
 	dir = 4;
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "pqw" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = 32
@@ -56215,6 +56509,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/lower/workshop)
+"pqR" = (
+/obj/structure/largecrate/random/case/double,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/maint/upper/u_f_p)
 "pqX" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -56277,7 +56577,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "prX" = (
 /obj/structure/ladder{
 	height = 2;
@@ -56452,7 +56752,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/upper/u_m_s)
+/area/almayer/maint/upper/u_f_s)
 "puO" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = 32
@@ -56482,7 +56782,7 @@
 	dir = 4;
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "pvI" = (
 /obj/structure/sign/safety/rad_haz{
 	pixel_x = 8;
@@ -56539,7 +56839,7 @@
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "pwx" = (
 /obj/structure/sign/safety/distribution_pipes{
 	pixel_x = -17
@@ -56799,7 +57099,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "pDh" = (
 /obj/structure/machinery/power/monitor{
 	name = "Core Power Monitoring"
@@ -56896,6 +57196,14 @@
 	icon_state = "green"
 	},
 /area/almayer/living/grunt_rnr)
+"pEA" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/hallways/upper/fore_hallway)
 "pEB" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -56945,6 +57253,14 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_a_p)
+"pFJ" = (
+/obj/structure/machinery/door/airlock/almayer/maint{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/maint/upper/u_a_s)
 "pGh" = (
 /obj/effect/decal/cleanable/cobweb{
 	pixel_x = -9;
@@ -57001,6 +57317,12 @@
 	icon_state = "green"
 	},
 /area/almayer/hallways/lower/port_midship_hallway)
+"pHj" = (
+/obj/structure/machinery/light/small,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/maint/upper/u_m_p)
 "pHp" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/perma)
@@ -57059,7 +57381,7 @@
 /turf/open/floor/almayer{
 	icon_state = "dark_sterile"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "pIo" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 1
@@ -57743,7 +58065,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "pVr" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
@@ -58494,6 +58816,9 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/tankerbunks)
+"qii" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/maint/upper/u_a_s)
 "qim" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/manifold/hidden/supply{
@@ -58558,7 +58883,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "qjV" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 9
@@ -58931,7 +59256,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer,
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "qpQ" = (
 /obj/item/reagent_container/glass/beaker/bluespace,
 /obj/structure/machinery/chem_dispenser/medbay,
@@ -59203,7 +59528,7 @@
 	dir = 1;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "qwo" = (
 /obj/structure/machinery/washing_machine,
 /obj/structure/machinery/washing_machine{
@@ -59350,7 +59675,7 @@
 	dir = 4;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "qxL" = (
 /obj/structure/machinery/medical_pod/autodoc,
 /turf/open/floor/almayer{
@@ -59474,6 +59799,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/p_bow)
+"qzQ" = (
+/obj/structure/machinery/door/airlock/almayer/maint,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/maint/upper/u_a_s)
 "qAs" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
@@ -59713,10 +60044,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_a_p)
+"qDX" = (
+/turf/closed/wall/almayer,
+/area/almayer/hallways/upper/aft_hallway)
 "qEc" = (
 /obj/effect/step_trigger/clone_cleaner,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "qEk" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -59824,7 +60158,7 @@
 /turf/open/floor/almayer{
 	icon_state = "dark_sterile"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "qFi" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 4
@@ -59959,6 +60293,9 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/upper/midship_hallway)
+"qHA" = (
+/turf/closed/wall/almayer,
+/area/almayer/maint/upper/u_a_s)
 "qHG" = (
 /obj/structure/machinery/light/small{
 	dir = 1
@@ -60167,6 +60504,15 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_a_p)
+"qKU" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hallways/upper/aft_hallway)
 "qKY" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -60294,6 +60640,15 @@
 	icon_state = "cargo"
 	},
 /area/almayer/squads/delta)
+"qNe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/upper/fore_hallway)
 "qNI" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -60456,7 +60811,7 @@
 	dir = 6;
 	icon_state = "red"
 	},
-/area/almayer/maint/hull/upper/u_a_p)
+/area/almayer/maint/upper/u_a_p)
 "qQS" = (
 /turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
@@ -60510,16 +60865,13 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "qSm" = (
 /obj/structure/pipes/vents/pump{
 	dir = 4
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/port_point_defense)
-"qSw" = (
-/turf/open/floor/plating,
-/area/almayer/maint/hull/upper/u_m_p)
 "qSE" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/food/condiment/hotsauce/cholula,
@@ -61190,7 +61542,7 @@
 	dir = 8;
 	icon_state = "silver"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "rdt" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -61803,7 +62155,7 @@
 	dir = 4;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "rnF" = (
 /obj/structure/machinery/door/airlock/almayer/engineering{
 	dir = 2;
@@ -61918,6 +62270,10 @@
 	icon_state = "plate"
 	},
 /area/almayer/command/cichallway)
+"rpP" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer,
+/area/almayer/hallways/upper/fore_hallway)
 "rqb" = (
 /obj/structure/sign/safety/distribution_pipes{
 	pixel_x = 32
@@ -62044,7 +62400,7 @@
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "rrK" = (
 /obj/structure/bed/chair{
 	can_buckle = 0;
@@ -62098,6 +62454,11 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/grunt_rnr)
+"rsN" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/almayer,
+/area/almayer/hallways/upper/fore_hallway)
 "rsO" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/almayer,
@@ -62742,7 +63103,7 @@
 /turf/open/floor/almayer{
 	icon_state = "orange"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "rEt" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/almayer{
@@ -62912,7 +63273,7 @@
 /turf/open/floor/almayer{
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "rHo" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	layer = 1.9
@@ -63019,7 +63380,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "rIH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -63136,7 +63497,7 @@
 	dir = 5;
 	icon_state = "red"
 	},
-/area/almayer/maint/hull/upper/u_a_p)
+/area/almayer/maint/upper/u_a_p)
 "rKd" = (
 /turf/open/floor/almayer/uscm/directional{
 	dir = 5
@@ -63380,6 +63741,17 @@
 "rPt" = (
 /turf/open/floor/wood/ship,
 /area/almayer/engineering/ce_room)
+"rPB" = (
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	name = "General Listening Channel";
+	pixel_y = 28
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "blue"
+	},
+/area/almayer/hallways/upper/fore_hallway)
 "rPE" = (
 /obj/structure/bed/chair{
 	dir = 8;
@@ -63489,7 +63861,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "rRf" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = -17
@@ -63601,7 +63973,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/upper/u_m_p)
+/area/almayer/maint/upper/u_f_p)
 "rTk" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 4
@@ -63847,7 +64219,7 @@
 /turf/open/floor/almayer{
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "rYh" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -63890,7 +64262,7 @@
 	dir = 4;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "rYI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -63979,7 +64351,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "sbq" = (
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	icon_state = "almayer_pdoor";
@@ -64506,7 +64878,7 @@
 	dir = 8;
 	icon_state = "silver"
 	},
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/maint/upper/u_m_p)
 "sjz" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out";
@@ -64967,7 +65339,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/upper/u_m_s)
+/area/almayer/maint/upper/u_f_s)
 "sqW" = (
 /obj/structure/machinery/portable_atmospherics/hydroponics,
 /obj/item/seeds/tomatoseed,
@@ -65095,7 +65467,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "str" = (
 /obj/effect/step_trigger/teleporter_vector{
 	name = "Almayer_Down3";
@@ -65120,7 +65492,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "stO" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/faxmachine/uscm/brig,
@@ -65250,7 +65622,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "swt" = (
 /turf/open/floor/almayer{
 	icon_state = "greencorner"
@@ -65588,7 +65960,7 @@
 	dir = 5;
 	icon_state = "plating"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "sDu" = (
 /obj/item/clothing/under/marine/dress,
 /turf/open/floor/almayer{
@@ -66201,6 +66573,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/offices)
+"sPk" = (
+/obj/structure/machinery/light,
+/turf/open/floor/almayer{
+	icon_state = "blue"
+	},
+/area/almayer/hallways/upper/fore_hallway)
 "sPF" = (
 /obj/structure/bed/chair{
 	can_buckle = 0;
@@ -66234,7 +66612,7 @@
 /turf/open/floor/almayer{
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "sQF" = (
 /turf/open/floor/almayer{
 	icon_state = "red"
@@ -66259,7 +66637,7 @@
 	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/maint/hull/upper/u_a_p)
+/area/almayer/maint/upper/u_a_p)
 "sSa" = (
 /obj/structure/machinery/door/airlock/almayer/marine/requisitions{
 	dir = 2;
@@ -66438,7 +66816,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "sVT" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/toolbox/mechanical,
@@ -66987,7 +67365,7 @@
 "tey" = (
 /obj/item/tool/wet_sign,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/upper/u_m_s)
+/area/almayer/maint/upper/u_f_s)
 "tez" = (
 /obj/effect/landmark/ert_spawns/distress_cryo,
 /obj/effect/landmark/late_join,
@@ -67206,12 +67584,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/alpha)
-"tih" = (
-/obj/structure/largecrate/random/case/double,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/maint/hull/upper/u_m_p)
 "tii" = (
 /obj/structure/machinery/firealarm{
 	pixel_x = 6;
@@ -67355,10 +67727,11 @@
 	pixel_x = 4;
 	pixel_y = -3
 	},
+/obj/structure/machinery/power/apc/almayer,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "tjH" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/device/radio/headset/almayer/mt,
@@ -67682,7 +68055,7 @@
 /turf/open/floor/plating/almayer{
 	allow_construction = 0
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "tpn" = (
 /turf/closed/wall/almayer,
 /area/almayer/shipboard/brig/evidence_storage)
@@ -67958,7 +68331,7 @@
 /obj/item/clothing/glasses/mgoggles,
 /obj/item/clothing/glasses/mgoggles,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "ttB" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating/plating_catwalk,
@@ -68101,7 +68474,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "tvt" = (
 /obj/structure/window/framed/almayer/hull,
 /turf/open/floor/plating,
@@ -68165,7 +68538,7 @@
 "tvS" = (
 /obj/docking_port/stationary/escape_pod/south,
 /turf/open/floor/plating,
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "twp" = (
 /obj/structure/ladder{
 	height = 1;
@@ -68520,7 +68893,7 @@
 	dir = 8;
 	icon_state = "orange"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "tCD" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -68718,7 +69091,7 @@
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "tHk" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/toolbox,
@@ -68986,7 +69359,7 @@
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
-/area/almayer/maint/hull/upper/u_a_p)
+/area/almayer/maint/upper/u_a_p)
 "tMU" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -69126,7 +69499,7 @@
 "tPz" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "tPB" = (
 /obj/effect/projector{
 	name = "Almayer_Down2";
@@ -69136,7 +69509,7 @@
 /turf/open/floor/almayer{
 	allow_construction = 0
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "tPI" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -69177,7 +69550,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/maint/upper/u_m_s)
+/area/almayer/maint/upper/u_f_s)
 "tQL" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/machinery/light,
@@ -69190,7 +69563,7 @@
 /turf/open/floor/almayer{
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "tQV" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/lifeboat_pumps/south1)
@@ -69282,6 +69655,13 @@
 	icon_state = "kitchen"
 	},
 /area/almayer/living/captain_mess)
+"tTE" = (
+/obj/structure/sign/safety/hvac_old{
+	pixel_x = 8;
+	pixel_y = 32
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/maint/upper/u_m_p)
 "tTG" = (
 /obj/structure/sign/safety/terminal{
 	pixel_x = 8;
@@ -69379,7 +69759,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/upper/u_m_s)
+/area/almayer/maint/upper/u_f_s)
 "tVx" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -69403,7 +69783,7 @@
 	dir = 1;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "tWi" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 8
@@ -69451,7 +69831,7 @@
 "tWM" = (
 /obj/docking_port/stationary/escape_pod/north,
 /turf/open/floor/plating,
-/area/almayer/maint/upper/u_m_s)
+/area/almayer/maint/upper/u_f_s)
 "tWY" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -69636,7 +70016,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "tZZ" = (
 /obj/structure/machinery/cryopod,
 /obj/effect/decal/warning_stripes{
@@ -69773,7 +70153,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "ucp" = (
 /obj/structure/window/framed/almayer,
 /turf/open/floor/plating,
@@ -70072,6 +70452,11 @@
 /obj/structure/closet/secure_closet/guncabinet/red/mp_armory_m4ra_rifle,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
+"uhI" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer,
+/area/almayer/hallways/upper/fore_hallway)
 "uhM" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 5
@@ -70140,7 +70525,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/upper/u_m_s)
+/area/almayer/maint/upper/u_f_s)
 "ujz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -70277,13 +70662,13 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "umI" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "umS" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -70518,11 +70903,11 @@
 /turf/open/floor/almayer{
 	icon_state = "orangecorner"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "urg" = (
 /obj/docking_port/stationary/escape_pod/east,
 /turf/open/floor/plating,
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/maint/upper/u_m_p)
 "urk" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -70567,7 +70952,7 @@
 	pixel_y = 13
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/upper/u_m_s)
+/area/almayer/maint/upper/u_f_s)
 "urM" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -70582,6 +70967,9 @@
 /obj/effect/landmark/late_join/charlie,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/charlie)
+"usi" = (
+/turf/open/floor/almayer,
+/area/almayer/hallways/upper/aft_hallway)
 "usm" = (
 /obj/structure/machinery/light,
 /obj/structure/sign/safety/waterhazard{
@@ -70669,7 +71057,7 @@
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "utK" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -70876,7 +71264,7 @@
 "uwf" = (
 /obj/structure/machinery/light,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "uws" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -70956,7 +71344,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "uxC" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -70986,6 +71374,12 @@
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/living/basketball)
+"uxW" = (
+/obj/structure/largecrate/random/case/small,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/maint/upper/u_a_s)
 "uxX" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/almayer,
@@ -71458,7 +71852,7 @@
 /turf/open/floor/almayer{
 	icon_state = "greencorner"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "uIv" = (
 /turf/open/floor/almayer{
 	icon_state = "orange"
@@ -71735,7 +72129,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_p)
+/area/almayer/maint/upper/u_a_p)
 "uOJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer{
@@ -71762,7 +72156,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "uPP" = (
 /obj/structure/machinery/door/airlock/almayer/engineering{
 	dir = 2;
@@ -71798,7 +72192,7 @@
 /turf/open/floor/almayer{
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "uQm" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -71971,6 +72365,12 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/bravo)
+"uTD" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/hallways/upper/fore_hallway)
 "uTE" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -72137,7 +72537,7 @@
 	dir = 10;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "uVh" = (
 /obj/structure/filingcabinet/seeds,
 /turf/open/floor/almayer{
@@ -72195,7 +72595,7 @@
 	dir = 5;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "uWc" = (
 /obj/structure/surface/table/almayer,
 /turf/open/floor/almayer{
@@ -72482,7 +72882,7 @@
 	dir = 4;
 	icon_state = "orange"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "vbB" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/south1)
@@ -72648,7 +73048,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/upper/u_m_s)
+/area/almayer/maint/upper/u_f_s)
 "ven" = (
 /obj/structure/bed/chair,
 /turf/open/floor/almayer{
@@ -72683,7 +73083,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "veW" = (
 /obj/structure/machinery/door/airlock/almayer/generic/glass{
 	name = "\improper Passenger Cryogenics Bay"
@@ -72691,7 +73091,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/maint/upper/u_m_p)
 "vfa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73184,7 +73584,12 @@
 "vkV" = (
 /obj/effect/landmark/start/liaison,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/maint/upper/u_m_p)
+"vle" = (
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/maint/upper/u_a_s)
 "vlk" = (
 /obj/structure/closet/emcloset,
 /obj/item/clothing/mask/gas,
@@ -73290,7 +73695,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_p)
+/area/almayer/maint/upper/u_a_p)
 "vmE" = (
 /turf/open/floor/almayer{
 	icon_state = "orangecorner"
@@ -73388,6 +73793,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_m_p)
+"vpi" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hallways/upper/aft_hallway)
 "vpn" = (
 /turf/open/floor/almayer{
 	dir = 9;
@@ -73446,6 +73857,9 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/brig/processing)
+"vqh" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/maint/upper/u_f_s)
 "vqz" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -73907,7 +74321,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/maint/upper/u_m_p)
 "vwU" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
@@ -74128,7 +74542,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/maint/upper/u_m_s)
+/area/almayer/maint/upper/u_f_s)
 "vzP" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/box/cups,
@@ -74350,7 +74764,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/upper/u_m_s)
+/area/almayer/maint/upper/u_f_s)
 "vDz" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 9
@@ -74371,7 +74785,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_p)
+/area/almayer/maint/upper/u_a_p)
 "vEf" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 10
@@ -74487,7 +74901,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "vFH" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer{
@@ -74687,7 +75101,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "vIu" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -74828,6 +75242,14 @@
 	icon_state = "cargo_arrow"
 	},
 /area/almayer/squads/charlie)
+"vLM" = (
+/obj/structure/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/maint/upper/u_m_p)
 "vMb" = (
 /obj/item/stool{
 	pixel_x = -15;
@@ -74907,7 +75329,7 @@
 "vMQ" = (
 /obj/docking_port/stationary/escape_pod/north,
 /turf/open/floor/plating,
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/maint/upper/u_m_p)
 "vMU" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NE-out";
@@ -75199,7 +75621,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "vRR" = (
 /obj/effect/step_trigger/clone_cleaner,
 /obj/effect/decal/warning_stripes{
@@ -75423,7 +75845,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "vUP" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/shipboard/brig/cic_hallway)
@@ -75489,9 +75911,6 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_lobby)
-"vVY" = (
-/turf/open/floor/plating,
-/area/almayer/maint/hull/upper/u_m_s)
 "vVZ" = (
 /obj/structure/machinery/door/airlock/almayer/maint,
 /obj/structure/disposalpipe/segment{
@@ -76389,7 +76808,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "wjQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/prop/invuln/overhead_pipe{
@@ -76545,7 +76964,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/maint/upper/u_m_p)
 "wlD" = (
 /obj/structure/machinery/suit_storage_unit/compression_suit/uscm,
 /obj/effect/decal/warning_stripes{
@@ -76776,7 +77195,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "wqc" = (
 /obj/structure/sign/poster{
 	pixel_y = 32
@@ -77156,6 +77575,15 @@
 	icon_state = "cargo"
 	},
 /area/almayer/living/synthcloset)
+"wwi" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hallways/upper/fore_hallway)
 "wwr" = (
 /obj/structure/machinery/cryopod{
 	layer = 3.1;
@@ -77284,6 +77712,9 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/grunt_rnr)
+"wyc" = (
+/turf/open/floor/plating,
+/area/almayer/maint/upper/u_f_p)
 "wyt" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/machinery/microwave{
@@ -77352,7 +77783,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "wzZ" = (
 /obj/structure/machinery/door/airlock/almayer/medical/glass{
 	dir = 1;
@@ -78033,7 +78464,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "wMl" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 8;
@@ -78069,6 +78500,9 @@
 	icon_state = "test_floor5"
 	},
 /area/almayer/hallways/lower/starboard_midship_hallway)
+"wMD" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/maint/upper/u_f_p)
 "wMF" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer{
@@ -78263,7 +78697,7 @@
 /obj/item/clothing/head/beret/cm,
 /obj/item/clothing/head/beret/cm,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "wQu" = (
 /obj/effect/projector{
 	name = "Almayer_Up3";
@@ -78792,7 +79226,7 @@
 /turf/open/floor/plating/almayer{
 	allow_construction = 0
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "wZp" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
@@ -78801,7 +79235,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "wZv" = (
 /obj/structure/prop/invuln{
 	desc = "An inflated membrane. This one is puncture proof. Wow!";
@@ -78964,7 +79398,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "xcI" = (
 /obj/structure/sign/safety/water{
 	pixel_x = 8;
@@ -78993,7 +79427,7 @@
 	dir = 4;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "xdf" = (
 /obj/structure/pipes/standard/manifold/fourway/hidden/supply,
 /obj/structure/disposalpipe/segment{
@@ -79079,7 +79513,7 @@
 	dir = 4;
 	icon_state = "orangecorner"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "xer" = (
 /obj/structure/machinery/power/apc/almayer,
 /turf/open/floor/plating/plating_catwalk,
@@ -79090,7 +79524,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "xfm" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/window/framed/almayer,
@@ -79167,7 +79601,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "xgh" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 4
@@ -79395,7 +79829,7 @@
 	dir = 4;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "xjK" = (
 /obj/structure/sign/safety/hazard{
 	pixel_y = 32
@@ -79446,7 +79880,7 @@
 	dir = 1;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "xkB" = (
 /obj/structure/bed/chair/comfy/charlie{
 	dir = 1
@@ -79604,7 +80038,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "xoj" = (
 /turf/open/floor/almayer,
 /area/almayer/engineering/lower/workshop)
@@ -79898,7 +80332,7 @@
 	},
 /obj/structure/machinery/light,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "xtM" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer{
@@ -79916,7 +80350,7 @@
 	dir = 1;
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "xub" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -79996,6 +80430,9 @@
 	icon_state = "silver"
 	},
 /area/almayer/shipboard/brig/cic_hallway)
+"xvB" = (
+/turf/closed/wall/almayer,
+/area/almayer/maint/upper/u_f_p)
 "xvE" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/airlock/multi_tile/almayer/marine/charlie{
@@ -80117,7 +80554,7 @@
 /turf/open/floor/almayer{
 	icon_state = "green"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "xwX" = (
 /turf/open/floor/almayer{
 	dir = 9;
@@ -80480,6 +80917,14 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/maint/hull/upper/u_f_p)
+"xCS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "orangecorner"
+	},
+/area/almayer/hallways/upper/aft_hallway)
 "xDe" = (
 /obj/effect/projector{
 	name = "Almayer_Down4";
@@ -80515,7 +80960,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/maint/hull/upper/u_a_s)
+/area/almayer/maint/upper/u_a_s)
 "xDV" = (
 /obj/effect/step_trigger/clone_cleaner,
 /obj/effect/decal/warning_stripes{
@@ -80690,7 +81135,7 @@
 	dir = 10;
 	icon_state = "silver"
 	},
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/maint/upper/u_m_p)
 "xHS" = (
 /obj/structure/reagent_dispensers/fueltank/oxygentank{
 	anchored = 1
@@ -80880,6 +81325,12 @@
 	icon_state = "cargo"
 	},
 /area/almayer/shipboard/brig/general_equipment)
+"xLm" = (
+/obj/structure/largecrate/random/case/double,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/maint/upper/u_a_s)
 "xLn" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer{
@@ -81173,7 +81624,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_p)
+/area/almayer/maint/upper/u_a_p)
 "xPZ" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 10
@@ -81286,7 +81737,7 @@
 	dir = 1;
 	icon_state = "greencorner"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/fore_hallway)
 "xRw" = (
 /turf/open/floor/almayer/uscm/directional{
 	dir = 1
@@ -81321,7 +81772,7 @@
 	dir = 4;
 	icon_state = "red"
 	},
-/area/almayer/hallways/upper/midship_hallway)
+/area/almayer/hallways/upper/aft_hallway)
 "xSw" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -81414,6 +81865,15 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/numbertwobunks)
+"xTO" = (
+/obj/structure/machinery/status_display{
+	pixel_y = 30
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "blue"
+	},
+/area/almayer/hallways/upper/fore_hallway)
 "xTR" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/poddoor/almayer/open{
@@ -81751,7 +82211,7 @@
 "xZz" = (
 /obj/item/paper/almayer_storage,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_p)
+/area/almayer/maint/upper/u_a_p)
 "xZG" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -81980,6 +82440,9 @@
 	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
+"yde" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hallways/upper/fore_hallway)
 "ydf" = (
 /obj/structure/platform{
 	dir = 1
@@ -82166,7 +82629,7 @@
 	dir = 9;
 	icon_state = "silver"
 	},
-/area/almayer/maint/hull/upper/u_m_p)
+/area/almayer/maint/upper/u_m_p)
 "yfO" = (
 /obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
 	name = "\improper Warden's Office";
@@ -82466,7 +82929,7 @@
 	current_rounds = 0
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_m_s)
+/area/almayer/maint/upper/u_m_s)
 "ylc" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -105914,7 +106377,7 @@ auZ
 aiX
 aiX
 mJp
-bNT
+jZl
 cbK
 awF
 hRk
@@ -106116,9 +106579,9 @@ pQV
 apq
 ana
 aiX
-glc
-bNT
-rmB
+cKp
+jZl
+dgI
 awF
 xTL
 lmA
@@ -106319,8 +106782,8 @@ xQg
 wWC
 szO
 aiX
-nLM
-bNT
+xTO
+jZl
 iPU
 awF
 awF
@@ -106522,10 +106985,10 @@ yjM
 qbO
 aqw
 hnI
-kGS
-bNT
+ash
+jZl
 gFN
-bMi
+kED
 awF
 nvG
 vGI
@@ -106725,10 +107188,10 @@ aqy
 nBE
 pOD
 bZa
-nIF
+evG
 duR
 gFN
-mqd
+oeN
 awF
 aHn
 szU
@@ -106928,8 +107391,8 @@ aiX
 aiX
 aiX
 aiX
-eFI
-bNT
+rPB
+jZl
 sQu
 tsr
 tsr
@@ -107131,9 +107594,9 @@ aiX
 aKG
 amb
 aiX
-eWN
-bNT
-rmB
+juM
+jZl
+dgI
 tsr
 sOL
 jIC
@@ -107335,8 +107798,8 @@ aKH
 and
 aiX
 umD
-bNT
-kGS
+jZl
+ash
 fyT
 xIV
 xIV
@@ -107538,7 +108001,7 @@ aiX
 aiX
 aiX
 cwi
-bNT
+jZl
 fBA
 tsr
 iPN
@@ -107741,8 +108204,8 @@ mBe
 atT
 aiX
 fXf
-bNT
-hCF
+jZl
+sPk
 tsr
 tsr
 vOY
@@ -107943,9 +108406,9 @@ aiX
 asf
 atT
 aiX
-eWN
-mxg
-rmB
+juM
+qNe
+dgI
 lIj
 tBY
 gkE
@@ -108147,7 +108610,7 @@ aiX
 aiX
 aiX
 dRo
-fsu
+ewL
 enz
 lIj
 lIj
@@ -108324,12 +108787,12 @@ adq
 aei
 aka
 aWn
-njn
-njn
-njn
-njn
-njn
-njn
+lfc
+lfc
+lfc
+lfc
+lfc
+lfc
 oGC
 awW
 acW
@@ -108343,8 +108806,8 @@ fCP
 fCP
 stk
 fCP
-kGS
-kGS
+ash
+ash
 sVA
 fCP
 vUO
@@ -108371,12 +108834,12 @@ baw
 sgU
 baw
 baw
-nIN
-nIN
-nIN
-nIN
-nIN
-nIN
+xvB
+xvB
+xvB
+xvB
+xvB
+xvB
 gnv
 yhI
 tTu
@@ -108527,12 +108990,12 @@ adq
 afr
 akc
 apg
-njn
-rWz
-rWz
-rWz
+lfc
+mjR
+mjR
+mjR
 tWM
-njn
+lfc
 aea
 oGC
 xjD
@@ -108543,24 +109006,24 @@ oAO
 pIZ
 qwf
 jRm
-gDQ
-gDQ
-gDQ
-dZR
-gDQ
-gDQ
+dsS
+dsS
+dsS
+rsN
+dsS
+dsS
 dFd
-rDm
-rDm
-gDQ
+uhI
+uhI
+dsS
 saT
-gDQ
-dZR
-dZR
+dsS
+rsN
+rsN
 bxt
 tPz
 tPz
-tiZ
+rpP
 tPz
 tPz
 tPz
@@ -108574,12 +109037,12 @@ aZz
 nsc
 baw
 cxk
-nIN
-rgL
-rgL
-rgL
+xvB
+wyc
+wyc
+wyc
 nTc
-nIN
+xvB
 crh
 csI
 qhb
@@ -108730,12 +109193,12 @@ adq
 aub
 akt
 awW
-njn
-rWz
-rWz
-rWz
-rWz
-njn
+lfc
+mjR
+mjR
+mjR
+mjR
+lfc
 oGC
 sHp
 oGC
@@ -108745,7 +109208,7 @@ awW
 aSJ
 isI
 dgP
-jao
+mKG
 uIa
 qxK
 rYG
@@ -108767,7 +109230,7 @@ qxK
 rYG
 qxK
 bTD
-jao
+mKG
 uQi
 dCD
 aXe
@@ -108777,12 +109240,12 @@ baw
 mnA
 baw
 baw
-nIN
-rgL
-rgL
-rgL
-rgL
-nIN
+xvB
+wyc
+wyc
+wyc
+wyc
+xvB
 baw
 sMM
 nqG
@@ -108934,21 +109397,21 @@ avd
 akt
 awW
 qHq
-rWz
-rWz
-rWz
-rWz
-njn
+mjR
+mjR
+mjR
+mjR
+lfc
 vzO
-njn
-njn
-njn
-njn
-njn
-njn
-njn
+lfc
+lfc
+lfc
+lfc
+lfc
+lfc
+lfc
 dgP
-jao
+mKG
 uQi
 aoe
 aoe
@@ -108970,21 +109433,21 @@ aoe
 aoe
 aoe
 maF
-jao
+mKG
 mOw
-nIN
-nIN
-nIN
-nIN
-nIN
-nIN
-rBD
-nIN
-nIN
-rgL
-rgL
-rgL
-rgL
+xvB
+xvB
+xvB
+xvB
+xvB
+xvB
+abz
+xvB
+xvB
+wyc
+wyc
+wyc
+wyc
 eOM
 baw
 sMM
@@ -109136,12 +109599,12 @@ adq
 aGP
 aka
 aWu
-njn
-rWz
-rWz
-rWz
-rWz
-njn
+lfc
+mjR
+mjR
+mjR
+mjR
+lfc
 gur
 osn
 vDt
@@ -109149,9 +109612,9 @@ puJ
 deA
 olC
 ujf
-njn
+lfc
 xky
-jao
+mKG
 uQi
 aoe
 aoh
@@ -109173,22 +109636,22 @@ isN
 cnZ
 aoe
 dgP
-jao
+mKG
 uQi
-nIN
+xvB
 cHn
 cHn
-gNo
-aZv
-gNo
-xzh
+ftw
+nZK
+ftw
+wMD
 dcZ
-nIN
-rgL
-rgL
-rgL
-rgL
-nIN
+xvB
+wyc
+wyc
+wyc
+wyc
+xvB
 hWB
 yhI
 qSX
@@ -109339,22 +109802,22 @@ adq
 aGQ
 akc
 apg
-njn
-rWz
-rWz
-rWz
-rWz
-njn
-jsA
-cGR
+lfc
+mjR
+mjR
+mjR
+mjR
+lfc
+aHo
+vqh
 tey
 urL
 tey
-cGR
-jsA
+vqh
+aHo
 tQA
-kGS
-lOn
+ash
+wwi
 uQi
 aoe
 vbS
@@ -109376,22 +109839,22 @@ aEi
 coa
 aoe
 tWf
-lOn
-kGS
-aZv
-gNo
-xzh
-xzh
-nIN
+wwi
+ash
+nZK
+ftw
+wMD
+wMD
+xvB
 gJY
-gNo
-gNo
-nIN
-rgL
-rgL
-rgL
-rgL
-nIN
+ftw
+ftw
+xvB
+wyc
+wyc
+wyc
+wyc
+xvB
 wvj
 csI
 iPH
@@ -109542,11 +110005,11 @@ aee
 avd
 akt
 qWI
-njn
-njn
-njn
-njn
-njn
+lfc
+lfc
+lfc
+lfc
+lfc
 gxm
 gxm
 gxm
@@ -109557,7 +110020,7 @@ gxm
 gxm
 gxm
 tWf
-lOn
+wwi
 uQi
 aoe
 qQc
@@ -109579,7 +110042,7 @@ aEi
 fFh
 aoe
 dgP
-lOn
+wwi
 uQi
 gxm
 gxm
@@ -109590,11 +110053,11 @@ gxm
 gxm
 gxm
 gxm
-nIN
-nIN
-nIN
-nIN
-nIN
+xvB
+xvB
+xvB
+xvB
+xvB
 ehj
 irS
 ilJ
@@ -109745,7 +110208,7 @@ adq
 lpJ
 akt
 awW
-njn
+lfc
 mfR
 sqP
 tVs
@@ -109760,7 +110223,7 @@ aps
 aps
 gxm
 xtO
-jao
+mKG
 uQi
 aoe
 vbS
@@ -109782,7 +110245,7 @@ hFF
 aoe
 aoe
 dgP
-jao
+mKG
 uQi
 gxm
 aiJ
@@ -109794,10 +110257,10 @@ cJV
 cJV
 gxm
 ear
-aGm
-xzh
+pqR
+wMD
 ear
-nIN
+xvB
 baw
 sMM
 tmI
@@ -109948,11 +110411,11 @@ adq
 aWm
 aka
 kyY
-njn
+lfc
 hzl
 vdT
-jsA
-jsA
+aHo
+aHo
 gxm
 tPB
 tPB
@@ -109963,7 +110426,7 @@ aps
 aps
 gxm
 hGo
-lOn
+wwi
 uQi
 aoe
 aop
@@ -109985,7 +110448,7 @@ aQz
 aRJ
 ajl
 dgP
-lOn
+wwi
 uQi
 gxm
 aiJ
@@ -109996,11 +110459,11 @@ cJV
 cJV
 cJV
 gxm
-aGm
-xzh
-xzh
+pqR
+wMD
+wMD
 moq
-nIN
+xvB
 rQW
 yhI
 rRz
@@ -110151,10 +110614,10 @@ adq
 afr
 akc
 apg
-njn
-njn
+lfc
+lfc
 lBB
-cGR
+vqh
 mOR
 gxm
 gHX
@@ -110188,7 +110651,7 @@ aQz
 aRK
 ajl
 kUs
-lOn
+wwi
 uQi
 gxm
 aiJ
@@ -110200,10 +110663,10 @@ oAY
 oAY
 gxm
 rTe
-xzh
-gNo
-nIN
-nIN
+wMD
+ftw
+xvB
+xvB
 vpn
 csI
 goL
@@ -110355,8 +110818,8 @@ awW
 akt
 awW
 upQ
-hbl
-cGR
+fFs
+vqh
 fwP
 mOR
 gxm
@@ -110369,7 +110832,7 @@ asm
 asm
 gxm
 dgP
-mxg
+qNe
 mnV
 aoe
 pjF
@@ -110391,7 +110854,7 @@ fOL
 aRS
 ajl
 hGo
-jao
+mKG
 uQi
 gxm
 alW
@@ -110402,10 +110865,10 @@ nVA
 nVA
 nVA
 gxm
-aGm
+pqR
 ear
-gNo
-aZv
+ftw
+nZK
 aJU
 baw
 sMM
@@ -110557,11 +111020,11 @@ eCC
 awW
 akt
 wrQ
-njn
-njn
-njn
-njn
-njn
+lfc
+lfc
+lfc
+lfc
+lfc
 gxm
 tpj
 tpj
@@ -110572,7 +111035,7 @@ asm
 asm
 gxm
 dgP
-lOn
+wwi
 tQO
 sqf
 sqf
@@ -110593,8 +111056,8 @@ upM
 akw
 alD
 vEx
-kGS
-lOn
+ash
+wwi
 uQi
 gxm
 alW
@@ -110605,11 +111068,11 @@ nVA
 nVA
 nVA
 gxm
-nIN
-nIN
-nIN
-nIN
-nIN
+xvB
+xvB
+xvB
+xvB
+xvB
 nTH
 sMM
 baw
@@ -110760,10 +111223,10 @@ adq
 aeZ
 aka
 aoI
-njn
-rWz
-rWz
-rWz
+lfc
+mjR
+mjR
+mjR
 tWM
 gxm
 tpj
@@ -110775,7 +111238,7 @@ asm
 asm
 gxm
 dgP
-lOn
+wwi
 uQi
 sqf
 anp
@@ -110797,7 +111260,7 @@ onQ
 alD
 ajl
 bNI
-lOn
+wwi
 uQi
 gxm
 alW
@@ -110808,11 +111271,11 @@ nVA
 nVA
 nVA
 gxm
-rgL
-rgL
-rgL
+wyc
+wyc
+wyc
 nTc
-nIN
+xvB
 gnv
 yhI
 tTu
@@ -110963,11 +111426,11 @@ adq
 afr
 akc
 apg
-njn
-rWz
-rWz
-rWz
-rWz
+lfc
+mjR
+mjR
+mjR
+mjR
 gxm
 lbc
 tpj
@@ -110978,7 +111441,7 @@ asm
 asm
 gxm
 dgP
-jao
+mKG
 uQi
 sqf
 sOZ
@@ -111000,7 +111463,7 @@ aCp
 alD
 ajl
 kiq
-jao
+mKG
 uQi
 gxm
 alW
@@ -111011,11 +111474,11 @@ nVA
 nVA
 wZk
 gxm
-rgL
-rgL
-rgL
-rgL
-nIN
+wyc
+wyc
+wyc
+wyc
+xvB
 vpn
 csI
 goL
@@ -111167,10 +111630,10 @@ awW
 akt
 awW
 avJ
-rWz
-rWz
-rWz
-rWz
+mjR
+mjR
+mjR
+mjR
 gxm
 tpj
 tpj
@@ -111181,7 +111644,7 @@ asm
 asm
 gxm
 dgP
-mxg
+qNe
 mOw
 sqf
 anq
@@ -111203,7 +111666,7 @@ akx
 alD
 gWG
 dgP
-jao
+mKG
 uQi
 gxm
 alW
@@ -111214,10 +111677,10 @@ nVA
 nVA
 nVA
 gxm
-rgL
-rgL
-rgL
-rgL
+wyc
+wyc
+wyc
+wyc
 qxz
 baw
 sMM
@@ -111369,11 +111832,11 @@ eCC
 awW
 akt
 aqk
-njn
-rWz
-rWz
-rWz
-rWz
+lfc
+mjR
+mjR
+mjR
+mjR
 gxm
 tpj
 tpj
@@ -111384,7 +111847,7 @@ asm
 asm
 gxm
 dgP
-jao
+mKG
 uQi
 sqf
 anr
@@ -111406,7 +111869,7 @@ akx
 alD
 gWG
 dgP
-jao
+mKG
 uQi
 gxm
 alW
@@ -111417,11 +111880,11 @@ nVA
 nVA
 nVA
 gxm
-rgL
-rgL
-rgL
-rgL
-nIN
+wyc
+wyc
+wyc
+wyc
+xvB
 xuY
 sMM
 baw
@@ -111572,11 +112035,11 @@ adq
 aeZ
 aka
 aoI
-njn
-rWz
-rWz
-rWz
-rWz
+lfc
+mjR
+mjR
+mjR
+mjR
 gxm
 tpj
 tpj
@@ -111587,7 +112050,7 @@ asm
 asm
 gxm
 maF
-jao
+mKG
 uQi
 sqf
 sqf
@@ -111609,7 +112072,7 @@ hVz
 alD
 ajl
 tWf
-jao
+mKG
 uQi
 gxm
 alW
@@ -111620,11 +112083,11 @@ nVA
 nVA
 nVA
 gxm
-rgL
-rgL
-rgL
-rgL
-nIN
+wyc
+wyc
+wyc
+wyc
+xvB
 gnv
 yhI
 tTu
@@ -111775,11 +112238,11 @@ adq
 afB
 akc
 biT
-njn
-njn
-njn
-njn
-njn
+lfc
+lfc
+lfc
+lfc
+lfc
 gxm
 hWV
 hWV
@@ -111790,7 +112253,7 @@ gxm
 gxm
 gxm
 mYd
-lOn
+wwi
 xwU
 ajl
 qhx
@@ -111812,7 +112275,7 @@ nMV
 vIf
 ajl
 maF
-lOn
+wwi
 nwu
 gxm
 gxm
@@ -111823,11 +112286,11 @@ hWV
 hWV
 hWV
 gxm
-nIN
-nIN
-nIN
-nIN
-nIN
+xvB
+xvB
+xvB
+xvB
+xvB
 crh
 csI
 qhb
@@ -111978,7 +112441,7 @@ eCC
 awW
 awW
 awW
-ltt
+pEA
 fCP
 fCP
 fCP
@@ -111993,8 +112456,8 @@ fCP
 vUO
 fCP
 xRn
-lOn
-kGS
+wwi
+ash
 bVE
 aos
 akw
@@ -112014,8 +112477,8 @@ ans
 aos
 alE
 bVE
-kGS
-lOn
+ash
+wwi
 mnC
 vUO
 qRx
@@ -112030,7 +112493,7 @@ fCP
 fCP
 fCP
 fCP
-ltt
+pEA
 baw
 baw
 qYC
@@ -112181,23 +112644,23 @@ eCC
 awW
 aTm
 awW
-ltt
-acQ
-acQ
-acQ
-acQ
+pEA
+orV
+orV
+orV
+orV
 fGD
 fGD
 qEc
 qEc
 qEc
-acQ
-gfv
-gfv
-gfv
-gfv
-wZp
-tzF
+orV
+yde
+yde
+yde
+yde
+gkV
+uTD
 aEe
 akA
 akA
@@ -112217,23 +112680,23 @@ akA
 oap
 aSb
 aEe
-tzF
+uTD
 lzF
-gfv
-gfv
-gfv
-gfv
-acQ
+yde
+yde
+yde
+yde
+orV
 qEc
 qEc
 qEc
 fGD
 fGD
-acQ
-acQ
-acQ
-acQ
-ltt
+orV
+orV
+orV
+orV
+pEA
 baw
 vbB
 ley
@@ -112384,10 +112847,10 @@ abs
 awW
 ale
 ajE
-ltt
-kGS
+pEA
+ash
 rYG
-kGS
+ash
 xcY
 qxK
 qxK
@@ -112399,7 +112862,7 @@ qxK
 qxK
 qxK
 bTD
-mxg
+qNe
 uQi
 vOy
 vOy
@@ -112421,7 +112884,7 @@ wMO
 wky
 sqf
 bNI
-mxg
+qNe
 uIa
 qxK
 qxK
@@ -112433,10 +112896,10 @@ qxK
 qxK
 qxK
 qxK
-kGS
+ash
 ftZ
 qxK
-ltt
+pEA
 baw
 dBp
 gVA
@@ -112635,7 +113098,7 @@ pBG
 pBG
 pBG
 pBG
-mRU
+pBG
 oiq
 mRU
 mRU
@@ -112838,7 +113301,7 @@ fHM
 pBG
 rLp
 ttX
-mRU
+pBG
 vpf
 mRU
 vor
@@ -113041,7 +113504,7 @@ idM
 pBG
 jZU
 jAe
-mRU
+pBG
 jtU
 mRU
 tNw
@@ -113244,7 +113707,7 @@ idM
 pBG
 cVq
 nOb
-mRU
+pBG
 vpI
 mRU
 mRU
@@ -113447,7 +113910,7 @@ idM
 pBG
 dzp
 ngV
-mRU
+pBG
 jtU
 jtU
 uBx
@@ -113650,7 +114113,7 @@ pBG
 pBG
 saL
 pBG
-mRU
+pBG
 mRU
 mRU
 mRU
@@ -117865,18 +118328,18 @@ aam
 gxm
 hgk
 tob
-cGd
-cGd
-cGd
-cGd
-cGd
-cGd
-cGd
-cGd
-cGd
-cGd
-cGd
-cGd
+njn
+njn
+njn
+njn
+njn
+njn
+njn
+njn
+njn
+njn
+njn
+aej
 aej
 aej
 aej
@@ -117902,22 +118365,22 @@ vOy
 bxV
 lOn
 uAi
-mRU
-mRU
-mRU
-mRU
-mRU
-mRU
-mRU
-mRU
-mRU
-mRU
-mRU
-mRU
-mRU
-mRU
-mRU
-mRU
+nIN
+nIN
+nIN
+nIN
+nIN
+nIN
+nIN
+nIN
+nIN
+nIN
+nIN
+nIN
+nIN
+nIN
+nIN
+nIN
 jtU
 vpf
 gxm
@@ -118068,16 +118531,16 @@ aam
 gxm
 bLf
 tob
-cGd
-vVY
-vVY
-vVY
-vVY
+njn
+rWz
+rWz
+rWz
+rWz
 kLB
-vVY
-vVY
-vVY
-vVY
+rWz
+rWz
+rWz
+rWz
 kLB
 aej
 aeO
@@ -118105,22 +118568,22 @@ vOy
 eWN
 lOn
 rmB
-mRU
+nIN
 bnF
 lBw
 bnF
-mRU
-qSw
-qSw
-qSw
-qSw
+nIN
+rgL
+rgL
+rgL
+rgL
 urg
-qSw
-qSw
-qSw
-qSw
+rgL
+rgL
+rgL
+rgL
 urg
-mRU
+nIN
 jtU
 nVE
 gxm
@@ -118271,17 +118734,17 @@ aam
 gxm
 rGz
 tob
-cGd
-vVY
-vVY
-vVY
-vVY
-vVY
-vVY
-vVY
-vVY
-vVY
-vVY
+njn
+rWz
+rWz
+rWz
+rWz
+rWz
+rWz
+rWz
+rWz
+rWz
+rWz
 aej
 aeP
 agI
@@ -118309,21 +118772,21 @@ eWN
 jao
 rmB
 eyI
-jtU
+xzh
 jaW
 vkV
-mRU
-qSw
-qSw
-qSw
-qSw
-qSw
-qSw
-qSw
-qSw
-qSw
-qSw
-mRU
+nIN
+rgL
+rgL
+rgL
+rgL
+rgL
+rgL
+rgL
+rgL
+rgL
+rgL
+nIN
 jtU
 bWg
 gxm
@@ -118474,17 +118937,17 @@ gxm
 gxm
 hqb
 vsd
-cGd
-vVY
-vVY
-vVY
-vVY
-vVY
-vVY
-vVY
-vVY
-vVY
-vVY
+njn
+rWz
+rWz
+rWz
+rWz
+rWz
+rWz
+rWz
+rWz
+rWz
+rWz
 aej
 aeQ
 agK
@@ -118515,18 +118978,18 @@ eyI
 yfL
 sjw
 xHD
-mRU
-qSw
-qSw
-qSw
-qSw
-qSw
-qSw
-qSw
-qSw
-qSw
-qSw
-mRU
+nIN
+rgL
+rgL
+rgL
+rgL
+rgL
+rgL
+rgL
+rgL
+rgL
+rgL
+nIN
 jZo
 hQK
 gxm
@@ -118677,17 +119140,17 @@ ouf
 aLc
 wBI
 hGG
-cGd
-vVY
-vVY
-vVY
-vVY
-vVY
-vVY
-vVY
-vVY
-vVY
-vVY
+njn
+rWz
+rWz
+rWz
+rWz
+rWz
+rWz
+rWz
+rWz
+rWz
+rWz
 aej
 aeR
 agK
@@ -118716,20 +119179,20 @@ jao
 rmB
 eyI
 byH
-jtU
+xzh
 nvd
-mRU
-qSw
-qSw
-qSw
-qSw
-qSw
-qSw
-qSw
-qSw
-qSw
-qSw
-mRU
+nIN
+rgL
+rgL
+rgL
+rgL
+rgL
+rgL
+rgL
+rgL
+rgL
+rgL
+nIN
 vmJ
 elv
 vRR
@@ -118880,17 +119343,17 @@ ouf
 sdf
 cRL
 hGG
-cGd
-cGd
-cGd
+njn
+njn
+njn
 ahi
-cGd
-cGd
-cGd
-cGd
+njn
+njn
+njn
+njn
 uux
-cGd
-cGd
+njn
+njn
 aej
 aej
 agO
@@ -118917,22 +119380,22 @@ vOy
 kON
 fsu
 xZf
-mRU
-mRU
+nIN
+nIN
 veW
-mRU
-mRU
-mRU
-mRU
+nIN
+nIN
+nIN
+nIN
 nNX
-mRU
-mRU
-mRU
-mRU
+nIN
+nIN
+nIN
+nIN
 ayo
-mRU
-mRU
-mRU
+nIN
+nIN
+nIN
 cna
 nzD
 xDV
@@ -119689,20 +120152,20 @@ vHn
 ggD
 tob
 cGd
-cGd
-cGd
-cGd
-cGd
-cGd
-cGd
+njn
+njn
+njn
+njn
+njn
+njn
 hZE
 sVV
 oON
-cGd
-cGd
+njn
+njn
 cva
-cGd
-cGd
+njn
+njn
 ael
 ael
 agQ
@@ -119720,7 +120183,7 @@ uPB
 uPB
 uPB
 uPB
-uPB
+llt
 uPB
 ecz
 uPB
@@ -119729,25 +120192,25 @@ uPB
 riK
 bNT
 hmB
-mRU
-mRU
-gBs
-mRU
-mRU
-mRU
-gBs
-mRU
-mRU
-mRU
+nIN
+nIN
+rBD
+nIN
+nIN
+nIN
+rBD
+nIN
+nIN
+nIN
 mKi
 sfT
 hGV
-mRU
-mRU
-mRU
-mRU
-mRU
-mRU
+nIN
+nIN
+nIN
+nIN
+nIN
+nIN
 mRU
 vpf
 tMU
@@ -119892,16 +120355,16 @@ vHn
 hgk
 hoT
 hoT
-cGd
-vVY
-vVY
-vVY
+njn
+rWz
+rWz
+rWz
 tvS
-cGd
+njn
 xVe
 sVV
 mbx
-cGd
+njn
 orq
 rRb
 qjT
@@ -119932,25 +120395,25 @@ acQ
 acQ
 bNT
 oNa
-mRU
-tih
-vpf
-tih
-mRU
+nIN
+aGm
+gNo
+aGm
+nIN
 jwM
-jtU
-jtU
+xzh
+xzh
 jHX
-mRU
+nIN
 aDS
 sfT
 hGV
-mRU
-qSw
-qSw
-qSw
+nIN
+rgL
+rgL
+rgL
 vMQ
-mRU
+nIN
 upS
 jtU
 jtU
@@ -120095,18 +120558,18 @@ vHn
 vHn
 tob
 tob
-cGd
-vVY
-vVY
-vVY
-vVY
-cGd
+njn
+rWz
+rWz
+rWz
+rWz
+njn
 hHe
 gxn
 ioH
-cGd
+njn
 mNS
-tob
+cGR
 hvq
 pCQ
 ael
@@ -120135,25 +120598,25 @@ imM
 dKD
 bNT
 enF
-mRU
-mRU
-jtU
+nIN
+nIN
+xzh
 wlB
-mRU
+nIN
 bBc
-vpf
-jtU
+gNo
+xzh
 bBc
-mRU
+nIN
 uRY
 pMA
 waJ
-mRU
-qSw
-qSw
-qSw
-qSw
-mRU
+nIN
+rgL
+rgL
+rgL
+rgL
+nIN
 oNM
 vpf
 woU
@@ -120298,19 +120761,19 @@ aag
 vHn
 hoT
 hoT
-cGd
-vVY
-vVY
-vVY
-vVY
+njn
+rWz
+rWz
+rWz
+rWz
 aba
 aGA
 kbv
 fZo
-cGd
+njn
 nnH
-hoT
-hoT
+jsA
+jsA
 eJj
 ael
 afI
@@ -120339,24 +120802,24 @@ klr
 mxg
 qGZ
 bMi
-mRU
-jtU
-vpf
-rXF
-jtU
-jtU
-jtU
-vpf
-mRU
+nIN
+xzh
+gNo
+aZv
+xzh
+xzh
+xzh
+gNo
+nIN
 mzs
 aPT
 xyB
 ceD
-qSw
-qSw
-qSw
-qSw
-mRU
+rgL
+rgL
+rgL
+rgL
+nIN
 isq
 vpf
 woU
@@ -120501,19 +120964,19 @@ aag
 vHn
 hoT
 tob
-cGd
-vVY
-vVY
-vVY
-vVY
-cGd
+njn
+rWz
+rWz
+rWz
+rWz
+njn
 mAF
 ilq
 pjj
-cGd
+njn
 dkt
-tob
-hoT
+cGR
+jsA
 xfW
 ael
 afJ
@@ -120542,24 +121005,24 @@ rwf
 mxg
 qGZ
 mqd
-mRU
-jtU
-vzB
-mRU
+nIN
+xzh
+pHj
+nIN
 bBc
-vpf
-jtU
-vpf
-mRU
+gNo
+xzh
+icn
+nIN
 gfN
 efj
 sxE
-mRU
-qSw
-qSw
-qSw
-qSw
-mRU
+nIN
+rgL
+rgL
+rgL
+rgL
+nIN
 vpI
 jtU
 woU
@@ -120704,19 +121167,19 @@ aag
 vHn
 tob
 xLu
-cGd
-vVY
-vVY
-vVY
-vVY
-cGd
+njn
+rWz
+rWz
+rWz
+rWz
+njn
 hZE
 kbv
 mbx
-cGd
+njn
 gMJ
-tob
-hoT
+cGR
+jsA
 xfW
 ael
 afK
@@ -120744,25 +121207,25 @@ cnS
 klr
 mxg
 pSN
-mRU
-mRU
-jtU
-oNM
-mRU
-tih
-ycM
-jtU
-vpf
-mRU
+nIN
+nIN
+xzh
+iuh
+nIN
+aGm
+vLM
+xzh
+gNo
+nIN
 aDS
 aPT
 hGV
-mRU
-qSw
-qSw
-qSw
-qSw
-mRU
+nIN
+rgL
+rgL
+rgL
+rgL
+nIN
 jtU
 vpf
 woU
@@ -120907,16 +121370,16 @@ aag
 vHn
 tob
 hUb
-cGd
-cGd
-cGd
-cGd
-cGd
-cGd
+njn
+njn
+njn
+njn
+njn
+njn
 laM
 kbv
 nkH
-cGd
+njn
 eJZ
 rRb
 cXd
@@ -120947,25 +121410,25 @@ cnS
 riK
 mxg
 kGS
-rXF
-vpf
-vpf
+aZv
+gNo
+gNo
 aBQ
-mRU
-mRU
-mRU
-gBs
-mRU
-mRU
+nIN
+nIN
+nIN
+rBD
+nIN
+nIN
 oIa
 aPT
 bqY
-mRU
-mRU
-mRU
-mRU
-mRU
-mRU
+nIN
+nIN
+nIN
+nIN
+nIN
+nIN
 vpf
 vpf
 woU
@@ -121110,20 +121573,20 @@ aag
 vHn
 tJq
 bLf
-cGd
-vVY
-vVY
-vVY
+njn
+rWz
+rWz
+rWz
 tvS
-cGd
+njn
 hZE
 kbv
 mbx
-cGd
+njn
 cva
-cGd
-cGd
-cGd
+njn
+njn
+njn
 adO
 adO
 adO
@@ -121150,25 +121613,25 @@ cnT
 meS
 gUk
 naj
-mRU
-mRU
-mRU
-mRU
-mRU
+nIN
+nIN
+nIN
+nIN
+nIN
 jwM
 oZn
-jtU
+xzh
 lPW
-mRU
+nIN
 aDS
 aPT
 hGV
-mRU
-qSw
-qSw
-qSw
+nIN
+rgL
+rgL
+rgL
 vMQ
-mRU
+nIN
 wUJ
 vpf
 woU
@@ -121313,18 +121776,18 @@ aag
 vHn
 hoT
 rGz
-cGd
-vVY
-vVY
-vVY
-vVY
-cGd
+njn
+rWz
+rWz
+rWz
+rWz
+njn
 hHe
 gxn
 gKd
-cGd
-hoT
-hoT
+njn
+jsA
+jsA
 svV
 rIE
 adO
@@ -121357,21 +121820,21 @@ aUH
 aXx
 jKI
 aXx
-mRU
-tih
-vpf
-jtU
-vpf
-mRU
+nIN
+aGm
+gNo
+xzh
+gNo
+nIN
 lCL
 pMA
 gcm
-mRU
-qSw
-qSw
-qSw
-qSw
-mRU
+nIN
+rgL
+rgL
+rgL
+rgL
+nIN
 uNz
 jtU
 woU
@@ -121516,19 +121979,19 @@ aag
 vHn
 tob
 alh
-cGd
-vVY
-vVY
-vVY
-vVY
+njn
+rWz
+rWz
+rWz
+rWz
 bWh
 hmj
 kbv
 fZo
-cGd
+njn
 ykY
-hoT
-hoT
+jsA
+jsA
 tjz
 adO
 afN
@@ -121560,21 +122023,21 @@ aUH
 oyE
 mMP
 mMP
-mRU
-jtU
-vpf
-jtU
-vpf
-mRU
+nIN
+xzh
+gNo
+xzh
+gNo
+nIN
 mzs
 aPT
 xyB
 cix
-qSw
-qSw
-qSw
-qSw
-mRU
+rgL
+rgL
+rgL
+rgL
+nIN
 bWg
 jtU
 woU
@@ -121719,19 +122182,19 @@ aag
 vHn
 btV
 hoT
-cGd
-vVY
-vVY
-vVY
-vVY
-cGd
+njn
+rWz
+rWz
+rWz
+rWz
+njn
 mAF
 ilq
 pjj
-cGd
+njn
 boU
 nNI
-hoT
+jsA
 veO
 adO
 afO
@@ -121763,21 +122226,21 @@ aUH
 sIA
 gSj
 aXA
-mRU
-jtU
-vpf
-jtU
+nIN
+xzh
+gNo
+xzh
 bBc
-mRU
+nIN
 gfN
 efj
 sxE
-mRU
-qSw
-qSw
-qSw
-qSw
-mRU
+nIN
+rgL
+rgL
+rgL
+rgL
+nIN
 kUL
 tMU
 woU
@@ -121922,19 +122385,19 @@ aag
 vHn
 tob
 tob
-cGd
-vVY
-vVY
-vVY
-vVY
-cGd
+njn
+rWz
+rWz
+rWz
+rWz
+njn
 xXT
 sVV
 tkR
-cGd
+njn
 ipr
 pUL
-tob
+cGR
 eQd
 adO
 jkj
@@ -121966,21 +122429,21 @@ aUd
 ckK
 iKM
 aHM
-mRU
-jtU
-vpf
+nIN
+xzh
+gNo
 lPW
 vwJ
-mRU
+nIN
 nme
 sfT
 vAH
-mRU
-qSw
-qSw
-qSw
-qSw
-mRU
+nIN
+rgL
+rgL
+rgL
+rgL
+nIN
 edG
 vpf
 woU
@@ -122125,21 +122588,21 @@ aag
 vHn
 hoT
 hoT
-cGd
-cGd
-cGd
-cGd
-cGd
-cGd
+njn
+njn
+njn
+njn
+njn
+njn
 ehL
 kyr
 chb
-cGd
-cGd
-cGd
-moK
-cGd
-cGd
+njn
+njn
+njn
+htS
+njn
+njn
 lFt
 ahh
 aiw
@@ -122169,21 +122632,21 @@ aUH
 dbv
 lII
 aWc
-mRU
-gBs
-mRU
-mRU
-mRU
-mRU
+nIN
+rBD
+nIN
+nIN
+nIN
+nIN
 tCx
 ncG
 tZg
-mRU
-mRU
-mRU
-mRU
-mRU
-mRU
+nIN
+nIN
+nIN
+nIN
+nIN
+nIN
 jtU
 jtU
 woU
@@ -122337,12 +122800,12 @@ rpG
 cSa
 aeA
 sjz
-rpG
-hqm
-tob
-tob
-hoT
-fkK
+hbl
+isB
+cGR
+cGR
+jsA
+eoD
 aiw
 ahh
 aiw
@@ -122372,12 +122835,12 @@ aGz
 ckd
 mQC
 aHM
-rXF
-jtU
-jtU
+aZv
+xzh
+xzh
 egQ
-ycM
-rXF
+vLM
+aZv
 wcm
 lJY
 guo
@@ -122540,12 +123003,12 @@ cGd
 wYa
 nBK
 mzS
-cGd
-cGd
-cGd
-cGd
-tob
-cGd
+njn
+njn
+njn
+njn
+cGR
+njn
 afP
 ahh
 aiw
@@ -122575,12 +123038,12 @@ aGz
 drk
 mQC
 mkG
-mRU
-vpI
-mRU
-mRU
-mRU
-mRU
+nIN
+tTE
+nIN
+nIN
+nIN
+nIN
 nuM
 uHr
 xwX
@@ -122746,9 +123209,9 @@ aeA
 bbe
 aeA
 aeA
-cGd
-tob
-cGd
+njn
+cGR
+njn
 afQ
 aiw
 aiw
@@ -122778,9 +123241,9 @@ aGz
 eqB
 obC
 hcf
-mRU
+nIN
 cpQ
-mRU
+nIN
 lJY
 lJY
 lFK
@@ -122949,9 +123412,9 @@ asA
 amF
 kmE
 aeA
-cGd
-iTQ
-cGd
+njn
+mtq
+njn
 ahJ
 ahJ
 ahJ
@@ -122981,9 +123444,9 @@ aUH
 aGz
 aGz
 aGz
-mRU
-vzB
-mRU
+nIN
+pHj
+nIN
 lJY
 qbx
 dcp
@@ -123152,9 +123615,9 @@ aeC
 vOh
 gUX
 ily
-cGd
-moK
-cGd
+njn
+htS
+njn
 aeC
 aeC
 aeC
@@ -123184,9 +123647,9 @@ ybk
 vcE
 vcE
 vcE
-mRU
-gBs
-mRU
+nIN
+rBD
+nIN
 cBb
 xVS
 lJY
@@ -123964,9 +124427,9 @@ nqV
 aeA
 ajk
 ily
-taw
-mRI
-taw
+qHA
+qzQ
+qHA
 qnf
 aeC
 wPm
@@ -123996,9 +124459,9 @@ ybk
 dJF
 vcE
 dAr
-kNq
+acB
 cWo
-kNq
+acB
 cBb
 xVS
 lJY
@@ -124167,7 +124630,7 @@ wXh
 aeC
 ajs
 qon
-taw
+qHA
 obJ
 aep
 ggQ
@@ -124201,7 +124664,7 @@ ggQ
 aME
 aep
 hog
-kNq
+acB
 dHe
 kUV
 vcE
@@ -124370,8 +124833,8 @@ aeC
 aeC
 ajs
 aeC
-taw
-oxy
+qHA
+qii
 aep
 afj
 afk
@@ -124404,7 +124867,7 @@ afk
 sHo
 aep
 vmu
-kNq
+acB
 vcE
 kUV
 vcE
@@ -124573,8 +125036,8 @@ aeC
 aeA
 ajk
 aeA
-taw
-oxy
+qHA
+qii
 aep
 afk
 afk
@@ -124607,7 +125070,7 @@ aHl
 afk
 aep
 hLt
-kNq
+acB
 lJY
 itR
 kKR
@@ -124776,14 +125239,14 @@ asA
 amF
 ohL
 aeA
-taw
-oQL
+qHA
+vle
 aep
 aep
 aep
 aep
 aep
-umI
+nbY
 wLT
 oAp
 jvY
@@ -124801,16 +125264,16 @@ jvY
 aAy
 alL
 jvY
-umI
+nbY
 hqx
-umI
+nbY
 aep
 aep
 aep
 aep
 aep
 ddF
-kNq
+acB
 lJY
 ucw
 dcp
@@ -124979,16 +125442,16 @@ ntI
 aeA
 aeC
 puO
-taw
-oxy
+qHA
+qii
 eRG
 aep
 aep
 aep
 aep
-jkL
-tbD
-fDk
+fes
+vpi
+xCS
 jvY
 arl
 atm
@@ -125004,8 +125467,8 @@ alL
 aMo
 aOt
 jvY
-jkL
-lOn
+fes
+qKU
 jhm
 oIB
 jgr
@@ -125013,7 +125476,7 @@ qUG
 rtc
 oIB
 vmu
-kNq
+acB
 lJY
 uxC
 lJY
@@ -125176,22 +125639,22 @@ atr
 aeC
 atr
 aeC
-taw
-taw
-taw
-taw
+qHA
+qHA
+qHA
+qHA
 mRI
-taw
-taw
-oxy
+qHA
+qHA
+qii
 hja
-taw
-taw
-taw
-taw
-jkL
-tbD
-fDk
+qHA
+qHA
+qHA
+qHA
+fes
+vpi
+xCS
 jvY
 abF
 atm
@@ -125207,7 +125670,7 @@ aIT
 atm
 aVF
 jvY
-jkL
+fes
 wZp
 amc
 oIB
@@ -125216,8 +125679,8 @@ kaS
 aiQ
 oIB
 vmu
-kNq
-kNq
+acB
+acB
 kNq
 kNq
 qDB
@@ -125379,22 +125842,22 @@ atr
 aeC
 atr
 aeC
-taw
+qHA
 hEj
 cvi
-taw
+qHA
 wFX
-taw
+qHA
 ncV
-oxy
-oQL
-taw
-oQL
-oQL
-taw
+qii
+vle
+qHA
+vle
+vle
+qHA
 pqv
 gqf
-fDk
+xCS
 jvY
 jvY
 jvY
@@ -125411,8 +125874,8 @@ jvY
 jvY
 jvY
 xeq
-lOn
-mQF
+qKU
+iZz
 oIB
 wqr
 bZw
@@ -125420,7 +125883,7 @@ xUV
 oIB
 vmu
 vDR
-kNq
+acB
 toD
 wDq
 aPO
@@ -125582,12 +126045,12 @@ atu
 azU
 aeC
 ldl
-taw
-oxy
+qHA
+qii
 stA
-taw
+qHA
 tvA
-taw
+qHA
 oTc
 nwT
 ocI
@@ -125595,9 +126058,9 @@ mfH
 nwT
 nwT
 mfH
-tzF
+kjX
 gqf
-fDk
+xCS
 alL
 urM
 dBG
@@ -125613,9 +126076,9 @@ jvY
 wjv
 fDG
 alL
-jkL
+fes
 wZp
-tzF
+kjX
 qgK
 tEB
 uBM
@@ -125623,7 +126086,7 @@ dXo
 oIB
 xPu
 uOE
-kNq
+acB
 swG
 jei
 aPO
@@ -125785,21 +126248,21 @@ taw
 taw
 mRI
 taw
-taw
+qHA
 wpT
 stA
-taw
+qHA
 wTn
-taw
+qHA
 nQw
-oxy
+qii
 wjP
-taw
-oQL
-oQL
-taw
+qHA
+vle
+vle
+qHA
 gbR
-tbD
+vpi
 chC
 aqe
 amw
@@ -125816,17 +126279,17 @@ arq
 anO
 qaV
 kwd
-acQ
-lOn
-mQF
+usi
+qKU
+iZz
 oIB
 wKF
 hzb
 ltU
 oIB
-aPO
+juG
 eDk
-kNq
+acB
 bCR
 jei
 aPO
@@ -125988,19 +126451,19 @@ qlu
 taw
 wTn
 kCu
-taw
+qHA
 uPN
 stA
-taw
+qHA
 wFX
-taw
+qHA
 lsh
-oxy
+qii
 hja
-taw
-oQL
+qHA
+vle
 hja
-taw
+qHA
 bwN
 gxR
 lCc
@@ -126027,9 +126490,9 @@ phj
 vEf
 cNK
 oIB
-aPO
-jei
-oYr
+hFt
+lxJ
+oFU
 aPO
 aPO
 aPO
@@ -126191,22 +126654,22 @@ rWb
 taw
 oAK
 kCu
-taw
-mRI
-taw
-taw
+qHA
+qzQ
+qHA
+qHA
 tvA
-taw
-oQL
-oxy
-oQL
-taw
+qHA
+vle
+qii
+vle
+qHA
 cap
 fiN
-taw
-jkL
+qHA
+fes
 kzR
-jao
+ngF
 kwd
 amA
 atq
@@ -126222,7 +126685,7 @@ atq
 atq
 aoT
 kwd
-acQ
+usi
 kzR
 jhm
 oIB
@@ -126230,9 +126693,9 @@ cHC
 dha
 pxj
 oIB
-aPO
-oUx
-kNq
+juG
+fmX
+acB
 fPF
 jei
 nNT
@@ -126399,17 +126862,17 @@ oQL
 gqt
 oxy
 oxy
-kiR
-oxy
-oxy
-oQL
-taw
-taw
-taw
-taw
-jkL
+pFJ
+qii
+qii
+vle
+qHA
+qHA
+qHA
+qHA
+fes
 kzR
-nbW
+lCf
 alO
 ars
 amx
@@ -126425,9 +126888,9 @@ amx
 amx
 aOC
 alO
-jkL
+fes
 kzR
-mQF
+iZz
 loP
 loP
 loP
@@ -126595,24 +127058,24 @@ fTl
 wIu
 wXJ
 taw
-oxy
+ldz
 kMa
 qIa
 iSB
 oxy
 oQL
 hdy
-taw
-oQL
-oxy
-oQL
-taw
+qHA
+vle
+qii
+vle
+qHA
 liF
 wPR
-taw
+qHA
 cui
 kzR
-nbW
+lCf
 inw
 amA
 amx
@@ -126628,7 +127091,7 @@ atq
 amx
 aoT
 inw
-jkL
+fes
 kzR
 hPr
 loP
@@ -126805,15 +127268,15 @@ iKV
 oxy
 oQL
 oFr
-taw
+qHA
 mUL
-oxy
-oQL
-taw
-oQL
-oQL
-taw
-jkL
+qii
+vle
+qHA
+vle
+vle
+qHA
+fes
 kzR
 bLg
 aqj
@@ -126831,9 +127294,9 @@ atq
 atq
 wwJ
 inw
-jkL
-tbD
-mQF
+fes
+vpi
+iZz
 loP
 joG
 sDu
@@ -127008,17 +127471,17 @@ qAG
 oxy
 kMa
 gQu
-taw
+qHA
 lsh
-oxy
+qii
 wjP
-taw
-oQL
-oQL
-taw
+qHA
+vle
+vle
+qHA
 gbR
 kzR
-fDk
+xCS
 inw
 qHM
 emn
@@ -127034,9 +127497,9 @@ amx
 amx
 aBs
 inw
-jkL
-tbD
-mQF
+fes
+vpi
+iZz
 loP
 kxo
 wSn
@@ -127211,15 +127674,15 @@ ydf
 oxy
 wOv
 ixu
-taw
-wXJ
-oxy
-oxy
-kiR
-oxy
-oxy
-kiR
-kGS
+qHA
+uxW
+qii
+qii
+pFJ
+qii
+qii
+pFJ
+bKU
 kzR
 xsX
 alO
@@ -127237,9 +127700,9 @@ atq
 atq
 aBs
 alO
-jkL
+fes
 kzR
-kGS
+bKU
 fTF
 xBY
 xBY
@@ -127414,15 +127877,15 @@ cnP
 oxy
 wOv
 qlu
-taw
-qlu
-oxy
-oQL
-taw
-oQL
-oQL
+qHA
+xLm
+qii
+vle
+qHA
+vle
+vle
 lnD
-jkL
+fes
 kzR
 iea
 alO
@@ -127441,8 +127904,8 @@ atq
 aBs
 alO
 pvE
-tbD
-mQF
+vpi
+iZz
 gdS
 wSn
 kXN
@@ -127617,15 +128080,15 @@ lUQ
 oxy
 tBU
 iDs
-taw
-qlu
-oxy
+qHA
+xLm
+qii
 hja
-taw
+qHA
 kLZ
 tty
 lnD
-jkL
+fes
 kzR
 iea
 alO
@@ -127643,9 +128106,9 @@ auB
 atc
 aOF
 alO
-jkL
-tbD
-mQF
+fes
+vpi
+iZz
 gdS
 lBg
 dXd
@@ -127815,20 +128278,20 @@ mOE
 gUG
 oxy
 oQL
-taw
-taw
-mRI
-taw
-taw
-taw
-ixu
-oxy
-oQL
-taw
-taw
-taw
-taw
-jkL
+qHA
+qHA
+qzQ
+qHA
+qHA
+qHA
+gDF
+qii
+vle
+qHA
+qHA
+qHA
+qHA
+fes
 kzR
 iea
 alO
@@ -127846,9 +128309,9 @@ aIU
 aMq
 aOG
 alO
-jkL
+fes
 kzR
-mQF
+iZz
 loP
 loP
 loP
@@ -127858,10 +128321,10 @@ vyI
 lPB
 oHl
 jWh
-kNq
-qDB
-kNq
-kNq
+acB
+hJe
+acB
+acB
 kNq
 kNq
 kNq
@@ -128018,20 +128481,20 @@ oxy
 bCv
 oxy
 oQL
-taw
+qHA
 gCQ
 rEs
 tvr
-taw
+qHA
 lsh
-oQL
-oxy
-oQL
+vle
+qii
+vle
 aYU
 uxs
-iDs
-taw
-jkL
+iQG
+qHA
+fes
 kzR
 iea
 alO
@@ -128049,9 +128512,9 @@ xBe
 xBe
 xBe
 xBe
-jkL
+fes
 kzR
-mQF
+iZz
 jWh
 eFK
 wGd
@@ -128064,7 +128527,7 @@ jWh
 jZj
 sRP
 oko
-kNq
+acB
 tiY
 qAK
 xGK
@@ -128221,19 +128684,19 @@ oQL
 qmq
 oQL
 nXo
-taw
+qHA
 gCQ
 bNc
 tCC
-taw
+qHA
 ftG
-oQL
-oxy
-oQL
-oQL
-oQL
+vle
+qii
+vle
+vle
+vle
 keE
-taw
+qHA
 pvE
 kzR
 iea
@@ -128252,9 +128715,9 @@ aIV
 qqr
 arH
 xBe
-jkL
+fes
 kzR
-mQF
+iZz
 vXd
 duF
 hSk
@@ -128265,9 +128728,9 @@ hSk
 uIv
 jWh
 eHz
-aPO
+juG
 tMT
-kNq
+acB
 jei
 ltm
 oAT
@@ -128420,13 +128883,13 @@ aag
 aag
 fTl
 oxy
-taw
-taw
+qHA
+qHA
 xcs
-taw
-taw
+qHA
+qHA
 utC
-oxy
+qii
 ikC
 vRJ
 gNQ
@@ -128437,7 +128900,7 @@ gNQ
 gNQ
 gNQ
 xDG
-dlT
+jlO
 qpH
 iSu
 alO
@@ -128455,7 +128918,7 @@ azo
 aJg
 abR
 xBe
-jkL
+fes
 kzR
 jhm
 jWh
@@ -128470,7 +128933,7 @@ jWh
 nwA
 xZz
 kRN
-kNq
+acB
 jei
 ltm
 ejj
@@ -128623,26 +129086,26 @@ aag
 aag
 fTl
 oxy
-taw
+qHA
 tZM
 qEZ
 frV
-taw
+qHA
 gCQ
 uqJ
 vbu
-taw
-taw
-taw
-mRI
-taw
-taw
-taw
-taw
-taw
+qHA
+qHA
+qHA
+qzQ
+qHA
+qHA
+qHA
+qHA
+qHA
 gbR
 kzR
-mQF
+iZz
 wDM
 wDM
 wDM
@@ -128658,9 +129121,9 @@ atv
 auV
 amE
 xBe
-jkL
+fes
 kzR
-mQF
+iZz
 jWh
 jWh
 uUz
@@ -128671,9 +129134,9 @@ jWh
 jWh
 jWh
 fQl
-aPO
+juG
 nGZ
-kNq
+acB
 xQe
 jei
 lVR
@@ -128826,15 +129289,15 @@ aag
 aag
 fTl
 lmq
-taw
+qHA
 mDz
 pIf
 uwf
-taw
+qHA
 gCQ
 rEs
 bhZ
-taw
+qHA
 uiG
 rTZ
 tfb
@@ -128843,9 +129306,9 @@ tfb
 tfb
 tfb
 ptK
-jkL
-tbD
-mQF
+fes
+vpi
+iZz
 wDM
 aOM
 aoW
@@ -128861,9 +129324,9 @@ atv
 auV
 amE
 xBe
-jkL
-tbD
-mQF
+fes
+vpi
+iZz
 jWh
 xXa
 xXa
@@ -128876,7 +129339,7 @@ jWh
 rJY
 dPl
 qQG
-kNq
+acB
 cfm
 jei
 oSR
@@ -129029,15 +129492,15 @@ aag
 aag
 fTl
 oxy
-taw
-taw
-taw
-taw
-taw
-taw
-mRI
-taw
-taw
+qHA
+qHA
+qHA
+qHA
+qHA
+qHA
+qzQ
+qHA
+qHA
 bNM
 wkX
 jhx
@@ -129046,9 +129509,9 @@ jhx
 jhx
 dnH
 gpc
-kGS
-tbD
-mQF
+bKU
+vpi
+iZz
 wDM
 uto
 aoX
@@ -129066,7 +129529,7 @@ abR
 xBe
 pvE
 gxR
-tzF
+kjX
 dEt
 soP
 pDr
@@ -129076,10 +129539,10 @@ soP
 eoG
 uIv
 jWh
-kNq
-qDB
-kNq
-kNq
+acB
+hJe
+acB
+acB
 kNq
 fJp
 ekz
@@ -129251,7 +129714,7 @@ owg
 ptK
 nhT
 gqf
-mQF
+iZz
 wDM
 aOQ
 fxI
@@ -129267,9 +129730,9 @@ azp
 qJf
 anV
 xBe
-jkL
-tbD
-mQF
+fes
+vpi
+iZz
 jWh
 iqH
 khE
@@ -129452,7 +129915,7 @@ eNi
 eNi
 eNi
 eNi
-jkL
+fes
 kzR
 jhm
 wDM
@@ -129470,8 +129933,8 @@ xBe
 xBe
 xBe
 xBe
-jkL
-tbD
+fes
+vpi
 rXV
 jWh
 jWh
@@ -129655,9 +130118,9 @@ olO
 wiG
 nWN
 eNi
-jkL
-tbD
-mQF
+fes
+vpi
+iZz
 wDM
 wDM
 wDM
@@ -129673,8 +130136,8 @@ aJh
 arq
 ufx
 alR
-jkL
-tbD
+fes
+vpi
 jhm
 jWh
 hSk
@@ -129858,9 +130321,9 @@ ueG
 rPt
 jyE
 eNi
-jkL
-tbD
-mQF
+fes
+vpi
+iZz
 hwC
 rcS
 amx
@@ -129876,9 +130339,9 @@ aJi
 azs
 atq
 alR
-jkL
-tbD
-mQF
+fes
+vpi
+iZz
 jlQ
 tst
 uUe
@@ -130061,9 +130524,9 @@ iKD
 rPt
 rPt
 eNi
-jkL
-tbD
-mQF
+fes
+vpi
+iZz
 alR
 amA
 atq
@@ -130079,9 +130542,9 @@ aJj
 aMD
 atq
 alR
-jkL
-tbD
-mQF
+fes
+vpi
+iZz
 jlQ
 tZZ
 gLz
@@ -130266,7 +130729,7 @@ gIh
 eNi
 iIQ
 kzR
-mQF
+iZz
 alR
 amA
 atq
@@ -130282,9 +130745,9 @@ amA
 ayl
 amx
 alR
-jkL
-tbD
-mQF
+fes
+vpi
+iZz
 jWh
 jmQ
 vcu
@@ -130467,9 +130930,9 @@ aWb
 dyK
 vzK
 wYY
-jkL
+fes
 kzR
-mQF
+iZz
 alR
 amA
 atq
@@ -130485,9 +130948,9 @@ aJl
 amx
 atq
 alR
-jkL
-tbD
-mQF
+fes
+vpi
+iZz
 jlQ
 snE
 sGL
@@ -130670,9 +131133,9 @@ tii
 eJX
 sAC
 wYY
-jkL
+fes
 kzR
-mQF
+iZz
 alR
 amA
 amx
@@ -130688,9 +131151,9 @@ aJk
 amx
 atq
 alR
-jkL
-tbD
-mQF
+fes
+vpi
+iZz
 jlQ
 tZZ
 cBj
@@ -130873,9 +131336,9 @@ sjj
 fzP
 sAC
 wYY
-jkL
-tbD
-mQF
+fes
+vpi
+iZz
 alR
 amA
 atq
@@ -130891,8 +131354,8 @@ xEO
 xEO
 lnP
 alR
-jkL
-tbD
+fes
+vpi
 jhm
 jWh
 qLs
@@ -131078,7 +131541,7 @@ qsL
 nim
 prV
 gqf
-mQF
+iZz
 alR
 amA
 atq
@@ -131094,9 +131557,9 @@ iWR
 iWR
 kbx
 alR
-jkL
-tbD
-mQF
+fes
+vpi
+iZz
 jWh
 jWh
 jlQ
@@ -131280,8 +131743,8 @@ gyO
 kTN
 eNi
 pvE
-tbD
-mQF
+vpi
+iZz
 alR
 amA
 atq
@@ -131297,9 +131760,9 @@ xEO
 xEO
 aOV
 alR
-jkL
-tbD
-mQF
+fes
+vpi
+iZz
 jWh
 wFQ
 bop
@@ -131482,9 +131945,9 @@ oNb
 iFC
 qAA
 eNi
-jkL
+fes
 kzR
-mQF
+iZz
 alR
 arK
 atc
@@ -131500,9 +131963,9 @@ aJq
 aMG
 aOW
 alR
-jkL
-tbD
-mQF
+fes
+vpi
+iZz
 jWh
 bXy
 bop
@@ -131685,9 +132148,9 @@ eNi
 eNi
 eNi
 eNi
-jkL
+fes
 kzR
-mQF
+iZz
 alO
 alO
 alO
@@ -131703,9 +132166,9 @@ alO
 alO
 alO
 alO
-jkL
-tbD
-mQF
+fes
+vpi
+iZz
 jWh
 wFQ
 bop
@@ -132091,7 +132554,7 @@ keR
 jhx
 keR
 dwI
-tzF
+kjX
 jae
 tGW
 hal
@@ -132111,7 +132574,7 @@ uYg
 hal
 rrG
 jae
-tzF
+kjX
 mPh
 soP
 tWi
@@ -132497,9 +132960,9 @@ ucp
 cIW
 ptK
 ptK
-ybk
+qDX
 sDe
-ybk
+qDX
 aHe
 jlT
 exi


### PR DESCRIPTION
# About the pull request
1-added a new hallway area to upper deck so that we have fore mid aft hallway.
2-added two new maintenance fore and aft and change placement of mid to make sense.
3-removed all the emergency shutter that weren't at the borders of each areas.
4-i added back the bear belt because it was deleted when it was move finding no real place to fit it in i settled for a closet in alpha/bravo dormitory 
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
1,2-make it easier to relocate and for maintenance it's part of a PR that will come after...
3-to standardize and make it way more clear how they are supposed to placed,used.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
refactor: refactored areas replaced stern hallway by aft added two new hallway area(fore, midship)
refactor: refactored areas replaced midship maintenance by for and added two new maintenance  areas(fore, aft) with each starboard and port side.
maptweak: removed all the emergency shutter that weren't at the borders of each areas.
maptweak: added back the bear belt in a closet in a dormitory.
maptweak: reconnect some air  pipe in an hallway north upper engi.
/:cl:
