### PR TITLE
Fixes grammar issues with webs and eggs

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -22,9 +22,9 @@
 
 /obj/effect/spider/attackby(obj/item/W, mob/user)
 	if(LAZYLEN(W.attack_verb))
-		visible_message(SPAN_DANGER("<B>\The [src] have been [pick(W.attack_verb)] with \the [W][(user ? "by [user]." : ".")]"))
+		visible_message(SPAN_DANGER("[src] has been [pick(W.attack_verb)] with \the [W][(user ? "by [user]." : ".")]"))
 	else
-		visible_message(SPAN_DANGER("<B>\The [src] have been attacked with \the [W][(user ? "by [user]." : ".")]"))
+		visible_message(SPAN_DANGER("[src] has been attacked with \the [W] [(user ? "by [user]." : ".")]"))
 
 	var/damage = W.force / 4
 

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/carrier/eggsac.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/carrier/eggsac.dm
@@ -121,7 +121,7 @@
 			if(egg_generation_progress >= 15)
 				egg_generation_progress = 0
 				xeno.eggs_cur++
-				to_chat(xeno, SPAN_XENONOTICE("You generate a egg. Now sheltering: [xeno.eggs_cur] / [xeno.eggs_max]."))
+				to_chat(xeno, SPAN_XENONOTICE("You generate an egg. Now sheltering: [xeno.eggs_cur] / [xeno.eggs_max]."))
 				xeno.update_icons()
 
 #undef EGGSAC_OFF_WEED_EGGCAP


### PR DESCRIPTION
# About the pull request

Fixes two grammar issues:
- When attacking spiderwebs (fixes #5884)
- When forming eggs with the Generate Egg (50) ability

# Explain why it's good for the game

Fewer grammar issues.

# Testing Photographs and Procedure

![image](https://github.com/cmss13-devs/cmss13/assets/49321394/68650ae4-7e14-4763-add0-ebc1cb24c4c2)

![image](https://github.com/cmss13-devs/cmss13/assets/49321394/c2a4ed3e-b06f-4b13-9879-2e58e8a40eec)

# Changelog

:cl:
spellcheck: Fixed some grammar issues when attacking spiderwebs and when producing eggs as an eggsac carrier.
/:cl:
