### PR TITLE
Fix for empty lists of frequencies.

### DIFF
--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -66,6 +66,8 @@ Frequency range: 1200 to 1600
 Radiochat range: 1441 to 1489 (most devices refuse to be tune to other frequency, even during mapmaking)
 */
 
+#define UNIVERSAL_FREQ 1
+
 #define MIN_FREE_FREQ 1201 // -------------------------------------------------
 
 //Misc channels
@@ -327,11 +329,11 @@ SUBSYSTEM_DEF(radio)
 	if(length(extra_zs))
 		target_zs += extra_zs
 	for(var/obj/structure/machinery/telecomms/T as anything in tcomm_machines_ground)
-		if(!length(T.freq_listening) || (frequency in T.freq_listening))
+		if((UNIVERSAL_FREQ in T.freq_listening) || (frequency in T.freq_listening))
 			target_zs += SSmapping.levels_by_trait(ZTRAIT_GROUND)
 			break
 	for(var/obj/structure/machinery/telecomms/T as anything in tcomm_machines_almayer)
-		if(!length(T.freq_listening) || (frequency in T.freq_listening))
+		if((UNIVERSAL_FREQ in T.freq_listening) || (frequency in T.freq_listening))
 			target_zs += SSmapping.levels_by_trait(ZTRAIT_MARINE_MAIN_SHIP)
 			target_zs += SSmapping.levels_by_trait(ZTRAIT_RESERVED)
 			break

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -155,7 +155,7 @@
 	toggle_state(user) // just flip dat switch
 
 /obj/structure/machinery/telecomms/relay/preset/tower/all
-	freq_listening = list()
+	freq_listening = list(UNIVERSAL_FREQ)
 
 /obj/structure/machinery/telecomms/relay/preset/tower/faction
 	name = "UPP telecommunications relay"
@@ -268,7 +268,7 @@ GLOBAL_LIST_EMPTY(all_static_telecomms_towers)
 			return
 		var/choice = tgui_input_list(user, "What do you wish to do?", "TC-3T comms tower", list("Wipe communication frequencies", "Add your faction's frequencies"))
 		if(choice == "Wipe communication frequencies")
-			freq_listening = null
+			freq_listening.Cut()
 			to_chat(user, SPAN_NOTICE("You wipe the preexisting frequencies from \the [src]."))
 			return
 		else if(choice == "Add your faction's frequencies")

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -26,7 +26,7 @@ GLOBAL_LIST_EMPTY_TYPED(telecomms_list, /obj/structure/machinery/telecomms)
 	var/traffic = 0 // value increases as traffic increases
 	var/netspeed = 5 // how much traffic to lose per tick (50 gigabytes/second * netspeed)
 	var/list/autolinkers = list() // list of text/number values to link with
-	var/list/freq_listening = list() // list of frequencies to tune into: if none, will listen to all
+	var/list/freq_listening = list(UNIVERSAL_FREQ) // list of frequencies to tune into: if universal frequency is included, will listen to all
 	var/machinetype = 0 // just a hacky way of preventing alike machines from pairing
 	var/delay = 10 // how many process() ticks to delay per heat
 	var/long_range_link = 0 // Can you link it across Z levels or on the otherside of the map? (Relay & Hub)


### PR DESCRIPTION
# About the pull request

Followup to #5833. First I thought that I had simply fumbled back then by fixing things enough that breaking them actually works now and fixing it is simply a matter of making the list empty itself instead of replacing itself with a null so that trying to `|=` to it no longer would runtime.
And then I discovered that somebody once had decided that the syntax to declare comms machines as universal shall be by giving them empty frequency lists. Please never do that. It is a pain to track which cases are intended to be empty because they are meant to be universal and which are intended to be empty because they will be filled via some procedure. I _think_ that I sorted them correctly, but if something will break again, more fixing will need doing.

# Explain why it's good for the game

Is fix.

# Changelog

:cl:
fix: Wiping frequencies off radiotowers no longer breaks them forever.
/:cl: