### PR TITLE
Middleclick buckling.

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -11,7 +11,10 @@
 	if (mods["middle"])
 		if (isStructure(A) && get_dist(src, A) <= 1)
 			var/obj/structure/S = A
-			S.do_climb(src, mods)
+			if(S.climbable)
+				S.do_climb(src, mods)
+			else if(S.can_buckle)
+				S.buckle_mob(src, src)
 			return TRUE
 		else if(!(isitem(A) && get_dist(src, A) <= 1) && (client && (client.prefs.toggle_prefs & TOGGLE_MIDDLE_MOUSE_SWAP_HANDS)))
 			swap_hand()


### PR DESCRIPTION
# About the pull request

Drag self onto table = climb table.
Middleclick table = climb table.
Drag self onto chair = buckle to chair.
Middleclick chair = ?

# Explain why it's good for the game

Is QoL.

# Changelog

:cl:
qol: Middleclicking beds/chairs/etc is now a shortcut for buckling to them.
/:cl:
