### PR TITLE
Disables New Varadero from the current map pool. 

### DIFF
--- a/map_config/maps.txt
+++ b/map_config/maps.txt
@@ -58,6 +58,7 @@ map lv522_chances_claim
 endmap
 
 map new_varadero
+	disabled
 endmap
 
 map whiskey_outpost_v2


### PR DESCRIPTION

# About the pull request

Disables New Varadero from the current map pool. 

# Explain why it's good for the game

Despite numerous fixes and improvements to the map, it is still a fundamentally flawed meme of a map(It's literally half of Old Ice, slightly revamped), it still is the universal "Vote Varadero and leave hehehehe" map.



# Changelog
:cl:

del: Removed New Varadero from the map pool

/:cl:
