### PR TITLE
Adjust Medical Skill Duration Multiplier

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -482,7 +482,9 @@ GLOBAL_LIST_INIT(limb_types_by_name, list(
 // Medical
 		if(SKILL_MEDICAL)
 			if(skillcheck(src, SKILL_MEDICAL, SKILL_MEDICAL_MASTER))
-				return DURATION_MULTIPLIER_TIER_3
+				return DURATION_MULTIPLIER_TIER_2
+			if(skillcheck(src, SKILL_MEDICAL, SKILL_MEDICAL_DOCTOR))
+				return DURATION_MULTIPLIER_TIER_1
 // Surgeon
 		if(SKILL_SURGERY)
 			if(skillcheck(src, SKILL_SURGERY, SKILL_SURGERY_EXPERT))


### PR DESCRIPTION
# About the pull request

Adjusts medical skill level to be more incremental and based on proficiency and familiarity with the tools, as such Medical 4 doesn't get speed bonus out of nowhere, being preceded by Medical 3 giving a lower bonus and then Medical 4 getting a larger bonus. Also reduces the raw bonus of Medical 4 so that you no longer have the issue with defibrillators shocking before they're done charging.

# Explain why it's good for the game

Makes medical skill make some more sense in how it progresses, also gives a little bump to the majority of higher medical roles which have Medical 3. Because it doesn't touch Medical 2, shouldn't impact front line dynamics much if at all. 

# Testing Photographs and Procedure

Ran on local machine for testing.

# Changelog
Spoke with Drathek King Of Balance prior to posting PR

:cl:
balance: Medical Skill 4 reduced speed buff from -75% duration to -50% duration
balance: Medical Skill 3 increased speed buff from -0% duration to -25% duration
/:cl:
