### PR TITLE
Light replacer speeds up colony light repair

### DIFF
--- a/code/game/machinery/colony_floodlights.dm
+++ b/code/game/machinery/colony_floodlights.dm
@@ -251,10 +251,16 @@
 			if(!replacer.CanUse(user))
 				to_chat(user, replacer.failmsg)
 				return FALSE
-			replacer.Use(user)
-			repair_state = FLOODLIGHT_REPAIR_SCREW
-			user.visible_message(SPAN_NOTICE("[user] replaces [src]'s damaged lighting assembly."),\
-			SPAN_NOTICE("You replace [src]'s damaged lighting assembly."))
+			playsound(loc, 'sound/items/Crowbar.ogg', 25, 1)
+			user.visible_message(SPAN_NOTICE("[user] starts replacing [src]'s damaged lighting assembly."),\
+			SPAN_NOTICE("You start replacing [src]'s damaged lighting assembly."))
+			if(do_after(user, 2 SECONDS, INTERRUPT_ALL, BUSY_ICON_GENERIC))
+				if(QDELETED(src) || repair_state == FLOODLIGHT_REPAIR_SCREW)
+					return
+				replacer.Use(user)
+				repair_state = FLOODLIGHT_REPAIR_SCREW
+				user.visible_message(SPAN_NOTICE("[user] replaces [src]'s damaged lighting assembly."),\
+				SPAN_NOTICE("You replace [src]'s damaged lighting assembly."))
 			return TRUE
 
 	return ..()

--- a/code/game/machinery/colony_floodlights.dm
+++ b/code/game/machinery/colony_floodlights.dm
@@ -235,6 +235,27 @@
 						SPAN_NOTICE("You replace [src]'s damaged cables."))
 			return TRUE
 
+		else if(istype(I, /obj/item/device/lightreplacer))
+			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
+				to_chat(user, SPAN_WARNING("You have no clue how to repair [src]."))
+				return FALSE
+
+			if(repair_state == FLOODLIGHT_REPAIR_UNSCREW)
+				to_chat(user, SPAN_WARNING("You need to unscrew [src]'s maintenance hatch."))
+				return FALSE
+			if(repair_state == FLOODLIGHT_REPAIR_SCREW)
+				to_chat(user, SPAN_WARNING("You need to screw [src]'s maintenance hatch."))
+				return FALSE
+
+			var/obj/item/device/lightreplacer/replacer = I
+			if(!replacer.CanUse(user))
+				to_chat(user, replacer.failmsg)
+				return FALSE
+			replacer.Use(user)
+			repair_state = FLOODLIGHT_REPAIR_SCREW
+			user.visible_message(SPAN_NOTICE("[user] replaces [src]'s damaged lighting assembly."),\
+			SPAN_NOTICE("You replace [src]'s damaged lighting assembly."))
+			return TRUE
 
 	..()
 	return FALSE

--- a/code/game/machinery/colony_floodlights.dm
+++ b/code/game/machinery/colony_floodlights.dm
@@ -166,15 +166,15 @@
 
 			if(repair_state == FLOODLIGHT_REPAIR_CROWBAR)
 				playsound(loc, 'sound/items/Crowbar.ogg', 25, 1)
-				user.visible_message(SPAN_NOTICE("[user] starts prying [src]'s maintenance hatch open."),\
-				SPAN_NOTICE("You start prying [src]'s maintenance hatch open."))
+				user.visible_message(SPAN_NOTICE("[user] starts prying [src]'s damaged lighting assembly out."),\
+				SPAN_NOTICE("You start prying [src]'s damaged lighting assembly out."))
 				if(do_after(user, 2 SECONDS, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 					if(QDELETED(src) || repair_state != FLOODLIGHT_REPAIR_CROWBAR)
 						return
 					playsound(loc, 'sound/items/Crowbar.ogg', 25, 1)
 					repair_state = FLOODLIGHT_REPAIR_WELD
-					user.visible_message(SPAN_NOTICE("[user] pries [src]'s maintenance hatch open."),\
-					SPAN_NOTICE("You pry [src]'s maintenance hatch open."))
+					user.visible_message(SPAN_NOTICE("[user] pries [src]'s damaged lighting assembly out."),\
+					SPAN_NOTICE("You pry [src]'s damaged lighting assembly out."))
 			return TRUE
 
 		else if(iswelder(I))
@@ -274,7 +274,7 @@
 			if(skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
 				switch(repair_state)
 					if(FLOODLIGHT_REPAIR_UNSCREW) . += SPAN_INFO("You must first unscrew its maintenance hatch.")
-					if(FLOODLIGHT_REPAIR_CROWBAR) . += SPAN_INFO("You must crowbar its maintenance hatch open or use a light replacer.")
+					if(FLOODLIGHT_REPAIR_CROWBAR) . += SPAN_INFO("You must crowbar its lighting assembly out or use a light replacer.")
 					if(FLOODLIGHT_REPAIR_WELD) . += SPAN_INFO("You must weld the damage to it.")
 					if(FLOODLIGHT_REPAIR_CABLE) . += SPAN_INFO("You must replace its damaged cables.")
 					if(FLOODLIGHT_REPAIR_SCREW) . += SPAN_INFO("You must screw its maintenance hatch closed.")

--- a/code/game/machinery/colony_floodlights.dm
+++ b/code/game/machinery/colony_floodlights.dm
@@ -42,7 +42,7 @@
 
 /obj/structure/machinery/colony_floodlight_switch/process()
 	var/lightpower = 0
-	for(var/obj/structure/machinery/colony_floodlight/floodlight in floodlist)
+	for(var/obj/structure/machinery/colony_floodlight/floodlight as anything in floodlist)
 		if(!floodlight.is_lit)
 			continue
 		lightpower += floodlight.power_tick
@@ -102,7 +102,7 @@
 	layer = ABOVE_XENO_LAYER
 	///Whether it has been smashed by xenos
 	var/damaged = FALSE
-	///whether the floodlight is switched to on or off. Does not necessarily mean it emits light.
+	///Whether the floodlight is switched to on or off. Does not necessarily mean it emits light.
 	var/is_lit = FALSE
 	unslashable = TRUE
 	unacidable = TRUE
@@ -113,7 +113,7 @@
 	///Reverse lookup for power grabbing in area
 	var/obj/structure/machinery/colony_floodlight_switch/fswitch = null
 	var/lum_value = 7
-	var/repair_state = 0
+	var/repair_state = FLOODLIGHT_REPAIR_UNSCREW
 	health = 150
 
 /obj/structure/machinery/colony_floodlight/Destroy()

--- a/code/game/machinery/colony_floodlights.dm
+++ b/code/game/machinery/colony_floodlights.dm
@@ -141,7 +141,7 @@
 				playsound(loc, 'sound/items/Screwdriver.ogg', 25, 1)
 				user.visible_message(SPAN_NOTICE("[user] starts unscrewing [src]'s maintenance hatch."), \
 				SPAN_NOTICE("You start unscrewing [src]'s maintenance hatch."))
-				if(do_after(user, 20, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
+				if(do_after(user, 2 SECONDS, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 					if(QDELETED(src) || repair_state != FLOODLIGHT_REPAIR_UNSCREW)
 						return
 					playsound(loc, 'sound/items/Screwdriver.ogg', 25, 1)
@@ -153,7 +153,7 @@
 				playsound(loc, 'sound/items/Screwdriver.ogg', 25, 1)
 				user.visible_message(SPAN_NOTICE("[user] starts screwing [src]'s maintenance hatch closed."), \
 				SPAN_NOTICE("You start screwing [src]'s maintenance hatch closed."))
-				if(do_after(user, 20, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
+				if(do_after(user, 2 SECONDS, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 					if(QDELETED(src) || repair_state != FLOODLIGHT_REPAIR_SCREW)
 						return
 					playsound(loc, 'sound/items/Screwdriver.ogg', 25, 1)
@@ -176,7 +176,7 @@
 				playsound(loc, 'sound/items/Crowbar.ogg', 25, 1)
 				user.visible_message(SPAN_NOTICE("[user] starts prying [src]'s maintenance hatch open."),\
 				SPAN_NOTICE("You start prying [src]'s maintenance hatch open."))
-				if(do_after(user, 20, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
+				if(do_after(user, 2 SECONDS, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 					if(QDELETED(src) || repair_state != FLOODLIGHT_REPAIR_CROWBAR)
 						return
 					playsound(loc, 'sound/items/Crowbar.ogg', 25, 1)
@@ -200,7 +200,7 @@
 					playsound(loc, 'sound/items/weldingtool_weld.ogg', 25)
 					user.visible_message(SPAN_NOTICE("[user] starts welding [src]'s damage."),
 					SPAN_NOTICE("You start welding [src]'s damage."))
-					if(do_after(user, 40, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
+					if(do_after(user, 4 SECONDS, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 						if(QDELETED(src) || !welder.isOn() || repair_state != FLOODLIGHT_REPAIR_WELD)
 							return
 						playsound(loc, 'sound/items/Welder2.ogg', 25, 1)
@@ -225,7 +225,7 @@
 				playsound(loc, 'sound/items/Deconstruct.ogg', 25, 1)
 				user.visible_message(SPAN_NOTICE("[user] starts replacing [src]'s damaged cables."),\
 				SPAN_NOTICE("You start replacing [src]'s damaged cables."))
-				if(do_after(user, 20, INTERRUPT_ALL, BUSY_ICON_GENERIC))
+				if(do_after(user, 2 SECONDS, INTERRUPT_ALL, BUSY_ICON_GENERIC))
 					if(QDELETED(src) || repair_state != FLOODLIGHT_REPAIR_CABLE)
 						return
 					if(coil.use(2))
@@ -257,8 +257,7 @@
 			SPAN_NOTICE("You replace [src]'s damaged lighting assembly."))
 			return TRUE
 
-	..()
-	return FALSE
+	return ..()
 
 /obj/structure/machinery/colony_floodlight/attack_hand(mob/user)
 	if(ishuman(user))
@@ -267,7 +266,7 @@
 		else if(!is_lit)
 			to_chat(user, SPAN_WARNING("Nothing happens. Looks like it's powered elsewhere."))
 		return FALSE
-	..()
+	return ..()
 
 /obj/structure/machinery/colony_floodlight/get_examine_text(mob/user)
 	. = ..()

--- a/code/game/machinery/colony_floodlights.dm
+++ b/code/game/machinery/colony_floodlights.dm
@@ -6,14 +6,14 @@
 	desc = "This switch controls the floodlights surrounding the archaeology complex. It only functions when there is power."
 	density = FALSE
 	anchored = TRUE
-	var/ispowered = FALSE
-	var/turned_on = FALSE //has to be toggled in engineering
 	use_power = USE_POWER_IDLE
 	unslashable = TRUE
 	unacidable = TRUE
+	power_machine = TRUE
+	var/ispowered = FALSE
+	var/turned_on = FALSE //has to be toggled in engineering
 	///All floodlights under our control
 	var/list/floodlist = list()
-	power_machine = TRUE
 
 /obj/structure/machinery/colony_floodlight_switch/Initialize(mapload, ...)
 	. = ..()
@@ -100,16 +100,16 @@
 	density = TRUE
 	anchored = TRUE
 	layer = ABOVE_XENO_LAYER
+	unslashable = TRUE
+	unacidable = TRUE
+	use_power = USE_POWER_NONE //It's the switch that uses the actual power, not the lights
+	needs_power = FALSE
 	///Whether it has been smashed by xenos
 	var/damaged = FALSE
 	///Whether the floodlight is switched to on or off. Does not necessarily mean it emits light.
 	var/is_lit = FALSE
-	unslashable = TRUE
-	unacidable = TRUE
 	///The power each floodlight takes up per process
 	var/power_tick = 50
-	use_power = USE_POWER_NONE //It's the switch that uses the actual power, not the lights
-	needs_power = FALSE
 	///Reverse lookup for power grabbing in area
 	var/obj/structure/machinery/colony_floodlight_switch/fswitch = null
 	var/lum_value = 7

--- a/code/game/machinery/colony_floodlights.dm
+++ b/code/game/machinery/colony_floodlights.dm
@@ -61,16 +61,8 @@
 		update_icon()
 
 /obj/structure/machinery/colony_floodlight_switch/proc/toggle_lights()
-	for(var/obj/structure/machinery/colony_floodlight/floodlight in floodlist)
-		spawn(rand(0, 50))
-			floodlight.is_lit = !floodlight.is_lit
-			if(!floodlight.damaged)
-				if(floodlight.is_lit) //Shut it down
-					floodlight.set_light(floodlight.lum_value)
-				else
-					floodlight.set_light(0)
-			floodlight.update_icon()
-	return FALSE
+	for(var/obj/structure/machinery/colony_floodlight/floodlight as anything in floodlist)
+		addtimer(CALLBACK(floodlight, TYPE_PROC_REF(/obj/structure/machinery/colony_floodlight, toggle_light)), rand(0, 5 SECONDS))
 
 /obj/structure/machinery/colony_floodlight_switch/attack_hand(mob/user as mob)
 	if(!ishuman(user))
@@ -288,6 +280,13 @@
 					if(FLOODLIGHT_REPAIR_SCREW) . += SPAN_INFO("You must screw its maintenance hatch closed.")
 		else if(!is_lit)
 			. += SPAN_INFO("It doesn't seem powered.")
+
+/obj/structure/machinery/colony_floodlight/proc/toggle_light()
+	is_lit = !is_lit
+	if(!damaged)
+		set_light(is_lit ? lum_value : 0)
+	update_icon()
+	return is_lit
 
 #undef FLOODLIGHT_REPAIR_UNSCREW
 #undef FLOODLIGHT_REPAIR_CROWBAR

--- a/code/game/machinery/colony_floodlights.dm
+++ b/code/game/machinery/colony_floodlights.dm
@@ -282,7 +282,7 @@
 			if(skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
 				switch(repair_state)
 					if(FLOODLIGHT_REPAIR_UNSCREW) . += SPAN_INFO("You must first unscrew its maintenance hatch.")
-					if(FLOODLIGHT_REPAIR_CROWBAR) . += SPAN_INFO("You must crowbar its maintenance hatch open.")
+					if(FLOODLIGHT_REPAIR_CROWBAR) . += SPAN_INFO("You must crowbar its maintenance hatch open or use a light replacer.")
 					if(FLOODLIGHT_REPAIR_WELD) . += SPAN_INFO("You must weld the damage to it.")
 					if(FLOODLIGHT_REPAIR_CABLE) . += SPAN_INFO("You must replace its damaged cables.")
 					if(FLOODLIGHT_REPAIR_SCREW) . += SPAN_INFO("You must screw its maintenance hatch closed.")

--- a/code/game/machinery/colony_floodlights.dm
+++ b/code/game/machinery/colony_floodlights.dm
@@ -1,6 +1,6 @@
 //Putting these here since it's power-related
 /obj/structure/machinery/colony_floodlight_switch
-	name = "Colony Floodlight Switch"
+	name = "colony floodlight switch"
 	icon = 'icons/obj/structures/machinery/power.dmi'
 	icon_state = "panelnopower"
 	desc = "This switch controls the floodlights surrounding the archaeology complex. It only functions when there is power."
@@ -94,7 +94,7 @@
 #define FLOODLIGHT_REPAIR_SCREW 4
 
 /obj/structure/machinery/colony_floodlight
-	name = "Colony Floodlight"
+	name = "colony floodlight"
 	icon = 'icons/obj/structures/machinery/big_floodlight.dmi'
 	icon_state = "flood_s_off"
 	density = TRUE
@@ -107,6 +107,7 @@
 	var/power_tick = 50 // power each floodlight takes up per process
 	use_power = USE_POWER_NONE //It's the switch that uses the actual power, not the lights
 	var/obj/structure/machinery/colony_floodlight_switch/fswitch = null //Reverse lookup for power grabbing in area
+	needs_power = FALSE
 	var/lum_value = 7
 	var/repair_state = 0
 	health = 150

--- a/code/game/machinery/colony_floodlights.dm
+++ b/code/game/machinery/colony_floodlights.dm
@@ -7,11 +7,12 @@
 	density = FALSE
 	anchored = TRUE
 	var/ispowered = FALSE
-	var/turned_on = 0 //has to be toggled in engineering
+	var/turned_on = FALSE //has to be toggled in engineering
 	use_power = USE_POWER_IDLE
 	unslashable = TRUE
 	unacidable = TRUE
-	var/list/floodlist = list() // This will save our list of floodlights on the map
+	///All floodlights under our control
+	var/list/floodlist = list()
 	power_machine = TRUE
 
 /obj/structure/machinery/colony_floodlight_switch/Initialize(mapload, ...)
@@ -20,9 +21,9 @@
 
 /obj/structure/machinery/colony_floodlight_switch/LateInitialize()
 	. = ..()
-	for(var/obj/structure/machinery/colony_floodlight/F in GLOB.machines)
-		floodlist += F
-		F.fswitch = src
+	for(var/obj/structure/machinery/colony_floodlight/floodlight in GLOB.machines)
+		floodlist += floodlight
+		floodlight.fswitch = src
 	start_processing()
 
 /obj/structure/machinery/colony_floodlight_switch/Destroy()
@@ -30,7 +31,6 @@
 		floodlight.fswitch = null
 	floodlist = null
 	return ..()
-
 
 /obj/structure/machinery/colony_floodlight_switch/update_icon()
 	if(!ispowered)
@@ -42,10 +42,10 @@
 
 /obj/structure/machinery/colony_floodlight_switch/process()
 	var/lightpower = 0
-	for(var/obj/structure/machinery/colony_floodlight/C in floodlist)
-		if(!C.is_lit)
+	for(var/obj/structure/machinery/colony_floodlight/floodlight in floodlist)
+		if(!floodlight.is_lit)
 			continue
-		lightpower += C.power_tick
+		lightpower += floodlight.power_tick
 	use_power(lightpower)
 
 /obj/structure/machinery/colony_floodlight_switch/power_change()
@@ -54,37 +54,37 @@
 		if(ispowered && turned_on)
 			toggle_lights()
 		ispowered = FALSE
-		turned_on = 0
+		turned_on = FALSE
 		update_icon()
 	else
 		ispowered = TRUE
 		update_icon()
 
 /obj/structure/machinery/colony_floodlight_switch/proc/toggle_lights()
-	for(var/obj/structure/machinery/colony_floodlight/F in floodlist)
-		spawn(rand(0,50))
-			F.is_lit = !F.is_lit
-			if(!F.damaged)
-				if(F.is_lit) //Shut it down
-					F.set_light(F.lum_value)
+	for(var/obj/structure/machinery/colony_floodlight/floodlight in floodlist)
+		spawn(rand(0, 50))
+			floodlight.is_lit = !floodlight.is_lit
+			if(!floodlight.damaged)
+				if(floodlight.is_lit) //Shut it down
+					floodlight.set_light(floodlight.lum_value)
 				else
-					F.set_light(0)
-			F.update_icon()
-	return 0
+					floodlight.set_light(0)
+			floodlight.update_icon()
+	return FALSE
 
 /obj/structure/machinery/colony_floodlight_switch/attack_hand(mob/user as mob)
 	if(!ishuman(user))
 		to_chat(user, "Nice try.")
-		return 0
+		return FALSE
 	if(!ispowered)
 		to_chat(user, "Nothing happens.")
-		return 0
+		return FALSE
 	playsound(src,'sound/items/Deconstruct.ogg', 30, 1)
 	use_power(5)
 	toggle_lights()
-	turned_on = !(src.turned_on)
+	turned_on = !turned_on
 	update_icon()
-	return 1
+	return TRUE
 
 
 #define FLOODLIGHT_REPAIR_UNSCREW 0
@@ -100,14 +100,18 @@
 	density = TRUE
 	anchored = TRUE
 	layer = ABOVE_XENO_LAYER
-	var/damaged = 0 //Can be smashed by xenos
-	var/is_lit = 0 //whether the floodlight is switched to on or off. Does not necessarily mean it emits light.
+	///Whether it has been smashed by xenos
+	var/damaged = FALSE
+	///whether the floodlight is switched to on or off. Does not necessarily mean it emits light.
+	var/is_lit = FALSE
 	unslashable = TRUE
 	unacidable = TRUE
-	var/power_tick = 50 // power each floodlight takes up per process
+	///The power each floodlight takes up per process
+	var/power_tick = 50
 	use_power = USE_POWER_NONE //It's the switch that uses the actual power, not the lights
-	var/obj/structure/machinery/colony_floodlight_switch/fswitch = null //Reverse lookup for power grabbing in area
 	needs_power = FALSE
+	///Reverse lookup for power grabbing in area
+	var/obj/structure/machinery/colony_floodlight_switch/fswitch = null
 	var/lum_value = 7
 	var/repair_state = 0
 	health = 150
@@ -131,7 +135,7 @@
 		if(HAS_TRAIT(I, TRAIT_TOOL_SCREWDRIVER))
 			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
 				to_chat(user, SPAN_WARNING("You have no clue how to repair [src]."))
-				return 0
+				return FALSE
 
 			if(repair_state == FLOODLIGHT_REPAIR_UNSCREW)
 				playsound(loc, 'sound/items/Screwdriver.ogg', 25, 1)
@@ -153,7 +157,7 @@
 					if(QDELETED(src) || repair_state != FLOODLIGHT_REPAIR_SCREW)
 						return
 					playsound(loc, 'sound/items/Screwdriver.ogg', 25, 1)
-					damaged = 0
+					damaged = FALSE
 					repair_state = FLOODLIGHT_REPAIR_UNSCREW
 					health = initial(health)
 					user.visible_message(SPAN_NOTICE("[user] screws [src]'s maintenance hatch closed."), \
@@ -166,16 +170,16 @@
 		else if(HAS_TRAIT(I, TRAIT_TOOL_CROWBAR))
 			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
 				to_chat(user, SPAN_WARNING("You have no clue how to repair [src]."))
-				return 0
+				return FALSE
 
 			if(repair_state == FLOODLIGHT_REPAIR_CROWBAR)
-				playsound(src.loc, 'sound/items/Crowbar.ogg', 25, 1)
+				playsound(loc, 'sound/items/Crowbar.ogg', 25, 1)
 				user.visible_message(SPAN_NOTICE("[user] starts prying [src]'s maintenance hatch open."),\
 				SPAN_NOTICE("You start prying [src]'s maintenance hatch open."))
 				if(do_after(user, 20, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 					if(QDELETED(src) || repair_state != FLOODLIGHT_REPAIR_CROWBAR)
 						return
-					playsound(src.loc, 'sound/items/Crowbar.ogg', 25, 1)
+					playsound(loc, 'sound/items/Crowbar.ogg', 25, 1)
 					repair_state = FLOODLIGHT_REPAIR_WELD
 					user.visible_message(SPAN_NOTICE("[user] pries [src]'s maintenance hatch open."),\
 					SPAN_NOTICE("You pry [src]'s maintenance hatch open."))
@@ -185,37 +189,37 @@
 			if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH))
 				to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
 				return
-			var/obj/item/tool/weldingtool/WT = I
+			var/obj/item/tool/weldingtool/welder = I
 
 			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
 				to_chat(user, SPAN_WARNING("You have no clue how to repair [src]."))
-				return 0
+				return FALSE
 
 			if(repair_state == FLOODLIGHT_REPAIR_WELD)
-				if(WT.remove_fuel(1, user))
+				if(welder.remove_fuel(1, user))
 					playsound(loc, 'sound/items/weldingtool_weld.ogg', 25)
 					user.visible_message(SPAN_NOTICE("[user] starts welding [src]'s damage."),
 					SPAN_NOTICE("You start welding [src]'s damage."))
 					if(do_after(user, 40, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
-						if(QDELETED(src) || !WT.isOn() || repair_state != FLOODLIGHT_REPAIR_WELD)
+						if(QDELETED(src) || !welder.isOn() || repair_state != FLOODLIGHT_REPAIR_WELD)
 							return
 						playsound(loc, 'sound/items/Welder2.ogg', 25, 1)
 						repair_state = FLOODLIGHT_REPAIR_CABLE
 						user.visible_message(SPAN_NOTICE("[user] welds [src]'s damage."),
 						SPAN_NOTICE("You weld [src]'s damage."))
-						return 1
+						return TRUE
 				else
 					to_chat(user, SPAN_WARNING("You need more welding fuel to complete this task."))
 			return TRUE
 
 		else if(iscoil(I))
-			var/obj/item/stack/cable_coil/C = I
+			var/obj/item/stack/cable_coil/coil = I
 			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
 				to_chat(user, SPAN_WARNING("You have no clue how to repair [src]."))
-				return 0
+				return FALSE
 
 			if(repair_state == FLOODLIGHT_REPAIR_CABLE)
-				if(C.get_amount() < 2)
+				if(coil.get_amount() < 2)
 					to_chat(user, SPAN_WARNING("You need two coils of wire to replace the damaged cables."))
 					return
 				playsound(loc, 'sound/items/Deconstruct.ogg', 25, 1)
@@ -224,16 +228,16 @@
 				if(do_after(user, 20, INTERRUPT_ALL, BUSY_ICON_GENERIC))
 					if(QDELETED(src) || repair_state != FLOODLIGHT_REPAIR_CABLE)
 						return
-					if(C.use(2))
+					if(coil.use(2))
 						playsound(loc, 'sound/items/Deconstruct.ogg', 25, 1)
 						repair_state = FLOODLIGHT_REPAIR_SCREW
-						user.visible_message(SPAN_NOTICE("[user] starts replaces [src]'s damaged cables."),\
+						user.visible_message(SPAN_NOTICE("[user] replaces [src]'s damaged cables."),\
 						SPAN_NOTICE("You replace [src]'s damaged cables."))
 			return TRUE
 
 
 	..()
-	return 0
+	return FALSE
 
 /obj/structure/machinery/colony_floodlight/attack_hand(mob/user)
 	if(ishuman(user))
@@ -241,7 +245,7 @@
 			to_chat(user, SPAN_WARNING("[src] is damaged."))
 		else if(!is_lit)
 			to_chat(user, SPAN_WARNING("Nothing happens. Looks like it's powered elsewhere."))
-		return 0
+		return FALSE
 	..()
 
 /obj/structure/machinery/colony_floodlight/get_examine_text(mob/user)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -190,8 +190,9 @@ GLOBAL_LIST_INIT(apc_wire_descriptions, list(
 			ui.open()
 
 /obj/structure/machinery/power/apc/ui_status(mob/user)
-	if(!opened && can_use(user, 1))
-		. = UI_INTERACTIVE
+	. = ..()
+	if(opened || !can_use(user, TRUE))
+		return UI_DISABLED
 
 /obj/structure/machinery/power/apc/ui_state(mob/user)
 	return GLOB.not_incapacitated_and_adjacent_state

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -281,14 +281,13 @@
 // TGUI STUFF \\
 
 /obj/structure/machinery/power/smes/ui_status(mob/user)
-	if(!(stat & BROKEN) && !open_hatch)
-		. = UI_INTERACTIVE
-
-/obj/structure/machinery/power/smes/ui_state(mob/user)
+	. = ..()
 	if(stat & BROKEN)
 		return UI_CLOSE
 	if(open_hatch)
 		return UI_DISABLED
+
+/obj/structure/machinery/power/smes/ui_state(mob/user)
 	return GLOB.not_incapacitated_and_adjacent_state
 
 /obj/structure/machinery/power/smes/tgui_interact(mob/user, datum/tgui/ui)


### PR DESCRIPTION

# About the pull request

This PR addresses several things:
- Colony lights and their switch were capitalized so they were treated as proper nouns when examined
- Colony lights don't actually use power, only their switch, so their power status text was incorrect
- The light replacer can now be used to speed up the repair of colony lights by skipping 3 steps in the normal process
- APC and SMES interfaces now properly close/disable when you are not adjacent to them or incapacitated
- General refactoring of the colony_floodlights file to bring it closer to code standards

The APC and SMES UI fixes were just because I was very confused why they weren't behaving during testing, so I fixed them.

# Explain why it's good for the game
I want to push power as a meaningful objective marines want to try to secure if possible. Currently colony lights are too tedious to repair and the light replacer is underused so I hope this can help rectify both problems somewhat.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/qJf1V-RdMok

</details>

# Changelog
:cl: Drathek
balance: The light replacer can now be used to skip the crowbar, welding, and wire steps when repairing colony lights.
fix: Fixes SMES and APC interfaces not checking adjacency or incapacitated states
spellcheck: Fixed examine text for colony lights (improper names and not powered text)
/:cl:
