### PR TITLE
Fix chestrig expecting map skins

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -498,6 +498,7 @@
 	name = "\improper USCM chestrig"
 	desc = "A chestrig used by some USCM personnel."
 	icon_state = "chestrig"
+	has_gamemode_skin = FALSE
 
 GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/rto)
 


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #5620 setting the setting required to indicate it doesn't have map specific skins (e.g. Shiva)

# Explain why it's good for the game
Fixes #5910 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![rig](https://github.com/cmss13-devs/cmss13/assets/76988376/412f41c3-338c-414e-a218-434ac4917ade)

</details>


# Changelog
:cl: Drathek
fix: Fix chestrig not displaying on maps with different skins (e.g. Shivas)
/:cl:
