### PR TITLE
Dropship doors can now always be broken by queen

### DIFF
--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -123,14 +123,16 @@
 		radio_connection.post_signal(src, signal, range = AIRLOCK_CONTROL_RANGE, filter = RADIO_AIRLOCK)
 
 
-/obj/structure/machinery/door/airlock/open(surpress_send)
+/obj/structure/machinery/door/airlock/open(forced)
 	. = ..()
-	if(!surpress_send) send_status()
+	if(!forced)
+		send_status()
 
 
-/obj/structure/machinery/door/airlock/close(surpress_send)
+/obj/structure/machinery/door/airlock/close(forced)
 	. = ..()
-	if(!surpress_send) send_status()
+	if(!forced)
+		send_status()
 
 
 /obj/structure/machinery/door/airlock/proc/set_frequency(new_frequency)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -214,7 +214,7 @@
 			flick("door_deny", src)
 	return
 
-/obj/structure/machinery/door/proc/open(forced=0)
+/obj/structure/machinery/door/proc/open(forced)
 	if(!density)
 		return TRUE
 	if(operating || !loc)

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -297,7 +297,7 @@
 	to_chat(xeno, SPAN_NOTICE("You try and force the doors open"))
 	if(do_after(xeno, 3 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
 		unlock(TRUE)
-		open(1)
+		open(TRUE)
 		lock(TRUE)
 		var/direction
 		switch(id)

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -291,9 +291,6 @@
 	if(!queen_pryable)
 		return ..()
 
-	if(!locked)
-		return ..()
-
 	if(xeno.action_busy)
 		return
 


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #5808 removing a locked check to break the doors.

# Explain why it's good for the game

Now regardless of currently locked or open, the queen can break the doors to prevent further door spamming.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/76988376/e62c432d-b421-455d-80e0-5c55e612fdcf

</details>


# Changelog
:cl: Drathek
fix: Dropship door prying can now always be performed by queen even if open or not locked
/:cl:
