### PR TITLE
Fixes synthetics being in a weird limbo state when they have their head reattached.

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -17,8 +17,8 @@
 	if(is_a_synth)
 		spawn_gibs()
 		return
-	else
-		undefibbable = TRUE
+
+	undefibbable = TRUE
 
 	..()
 

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -10,13 +10,16 @@
 			// Override the current limb status
 			E.droplimb(0, 0, cause)
 
-	undefibbable = TRUE
+
 
 	GLOB.data_core.manifest_modify(real_name, WEAKREF(src), null, null, "*Deceased*")
 
 	if(is_a_synth)
 		spawn_gibs()
 		return
+	else
+		undefibbable = TRUE
+
 	..()
 
 /mob/living/carbon/human/gib_animation()


### PR DESCRIPTION

# About the pull request

Did some digging.
Turns out, when the Queen gibs someone the flag 'undefibbable' gets set.
Then, next time the Life() proc is called we get removed from the 'processable_humans_list' on SSHuman. (Makes sense, no reason to process someone unrevivable, which non-synth gibbed people are)
This means when the synth has their head reattached and they get revived they no longer process Life() ticks. This means their blindness + critical state will never get cleared.

I fixed this by not making synths 'undefibbable'. You already can't revive someone without a head, so you won't be able to revive a headless corpse.

In addition I checked the usages of 'undefibbable' and didn't find anything that would break from this not being set.

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Tested the following:
Not able to revive headless corpse
Not able to revive before head is fully attached
Revived synth can speak normally + see
Revived synth can walk and do normal actions when limbs are reattached.

</details>


# Changelog
:cl:
fix: Synths can now have their heads reattached without being sent to limbo-crit-hell.
/:cl:
