### PR TITLE
adds helmet camera viewing consoles to research and OT

### DIFF
--- a/code/game/machinery/computer/camera_console.dm
+++ b/code/game/machinery/computer/camera_console.dm
@@ -289,6 +289,11 @@
 /obj/structure/machinery/computer/cameras/mortar/set_broken()
 	return
 
+/obj/structure/machinery/computer/cameras/public_helmet
+	name = "Helmet Camera Interface"
+	desc = "A computer linked to the helmet camera network. Commonly used by bored staff."
+	network = list(CAMERA_NET_OVERWATCH)
+
 /obj/structure/machinery/computer/cameras/dropship
 	name = "abstract dropship camera computer"
 	desc = "A computer to monitor cameras linked to the dropship."

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -144,6 +144,24 @@
 	icon_state = "plate"
 	},
 /area/almayer/stair_clone/upper)
+"aaP" = (
+/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
+	dir = 2;
+	name = "\improper Brig Armoury";
+	req_access = null;
+	req_one_access_txt = "1;3"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "aaY" = (
 /obj/structure/lattice,
 /turf/open/space,
@@ -503,9 +521,6 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
 	pixel_x = 1
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "acK" = (
@@ -1502,9 +1517,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/cafeteria_officer)
-"aii" = (
-/turf/closed/wall/almayer/reinforced,
-/area/almayer/shipboard/brig/starboard_hallway)
 "aij" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 8;
@@ -1936,6 +1948,17 @@
 	},
 /turf/closed/wall/almayer/research/containment/wall/purple,
 /area/almayer/medical/containment/cell)
+"alp" = (
+/obj/structure/machinery/firealarm{
+	pixel_y = -28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "alw" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
 	dir = 2;
@@ -3176,15 +3199,6 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/cic)
-"arQ" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/machinery/firealarm{
-	pixel_y = 28
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/mp_bunks)
 "arR" = (
 /obj/structure/machinery/status_display{
 	pixel_y = 30
@@ -3216,17 +3230,6 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/cic)
-"asd" = (
-/obj/structure/surface/rack,
-/obj/item/storage/box/gloves{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/masks,
-/turf/open/floor/almayer{
-	icon_state = "sterile_green_side"
-	},
-/area/almayer/shipboard/brig/medical)
 "ase" = (
 /turf/open/floor/almayer{
 	icon_state = "cargo"
@@ -3298,6 +3301,18 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north2)
+"asC" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 1
+	},
+/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
+	name = "\improper Brig Lobby";
+	closeOtherId = "brignorth"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "asD" = (
 /obj/effect/step_trigger/clone_cleaner,
 /obj/structure/machinery/door_control{
@@ -3306,9 +3321,6 @@
 	pixel_x = -24;
 	pixel_y = 24;
 	req_one_access_txt = "90;91;92"
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "asE" = (
@@ -3325,7 +3337,7 @@
 	req_one_access_txt = "91;92"
 	},
 /turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
+	icon_state = "test_floor4"
 	},
 /area/almayer/command/airoom)
 "asG" = (
@@ -3334,9 +3346,6 @@
 	indestructible = 1;
 	unacidable = 1;
 	unslashable = 1
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "asH" = (
@@ -3670,14 +3679,10 @@
 /area/almayer/command/airoom)
 "auf" = (
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom,
-/turf/closed/wall/almayer/white/hull,
 /area/almayer/command/airoom)
 "aug" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "aui" = (
@@ -3948,11 +3953,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/powered)
-"avK" = (
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
-/area/almayer/command/airoom)
 "avL" = (
 /obj/structure/machinery/door_control{
 	id = "ARES StairsUpper";
@@ -3986,9 +3986,6 @@
 	pixel_y = -24;
 	req_one_access_txt = "91;92"
 	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
 "avM" = (
 /obj/structure/machinery/computer/cameras/almayer/ares{
@@ -4006,9 +4003,6 @@
 	pixel_y = 6
 	},
 /obj/item/tool/pen,
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
 "avN" = (
 /obj/structure/machinery/telecomms/processor/preset_two,
@@ -4098,13 +4092,6 @@
 	icon_state = "rasputin15"
 	},
 /area/almayer/powered/agent)
-"awb" = (
-/obj/structure/bed/chair/bolted,
-/turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/interrogation)
 "awd" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/living/pilotbunks)
@@ -4187,9 +4174,6 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "W";
 	pixel_x = -1
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "awv" = (
@@ -5674,9 +5658,6 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
 "aCf" = (
 /obj/structure/window/framed/almayer/hull/hijack_bustable,
@@ -5912,6 +5893,10 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/upper_engineering)
+"aDt" = (
+/obj/structure/machinery/cm_vending/clothing/military_police_warden,
+/turf/open/floor/wood/ship,
+/area/almayer/shipboard/brig/warden_office)
 "aDv" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -6905,23 +6890,6 @@
 	icon_state = "mono"
 	},
 /area/almayer/medical/hydroponics)
-"aIN" = (
-/obj/structure/closet/secure_closet/cmdcabinet{
-	desc = "A bulletproof cabinet containing communications equipment.";
-	name = "communications cabinet";
-	pixel_y = 24;
-	req_access = null;
-	req_one_access_txt = "3"
-	},
-/obj/item/device/radio/listening_bug/radio_linked/mp{
-	pixel_y = 8
-	},
-/obj/item/device/radio/listening_bug/radio_linked/mp,
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/warden_office)
 "aIP" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -6985,6 +6953,22 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/tankerbunks)
+"aIY" = (
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
+	},
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 8;
+	pixel_y = -2
+	},
+/obj/item/storage/firstaid/regular,
+/obj/item/reagent_container/spray/cleaner,
+/turf/open/floor/almayer{
+	icon_state = "sterile_green_side"
+	},
+/area/almayer/shipboard/brig/medical)
 "aJc" = (
 /obj/structure/machinery/door/airlock/almayer/command{
 	name = "\improper Commanding Officer's Mess"
@@ -7257,9 +7241,6 @@
 	pixel_y = -1;
 	unacidable = 0;
 	unslashable = 0
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "aKu" = (
@@ -7769,6 +7750,11 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/alpha)
+"aNW" = (
+/turf/open/floor/almayer{
+	icon_state = "redcorner"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "aNY" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -8680,22 +8666,6 @@
 	icon_state = "kitchen"
 	},
 /area/almayer/living/captain_mess)
-"aSz" = (
-/obj/structure/machinery/door/airlock/almayer/medical/glass{
-	name = "\improper Brig Medbay";
-	req_access = null;
-	req_one_access = null;
-	req_one_access_txt = "20;3";
-	closeOtherId = "brigmed"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/medical)
 "aSA" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 4;
@@ -9160,6 +9130,12 @@
 	icon_state = "bluefull"
 	},
 /area/almayer/living/captain_mess)
+"aVm" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/almayer{
+	icon_state = "cargo"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "aVo" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -9792,9 +9768,6 @@
 	pixel_y = -24;
 	req_one_access_txt = "200;91;92"
 	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
 "baw" = (
 /turf/open/floor/almayer,
@@ -9899,6 +9872,18 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/briefing)
+"bbi" = (
+/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	dir = 1;
+	name = "\improper Brig"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/medical)
 "bbr" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -10162,12 +10147,6 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_two)
-"bcW" = (
-/obj/structure/bed/chair/bolted{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/interrogation)
 "bcZ" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/box/masks,
@@ -11226,15 +11205,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/perma)
-"bjp" = (
-/obj/structure/machinery/door/airlock/almayer/generic{
-	dir = 1;
-	name = "Bathroom"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "bjs" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -11998,6 +11968,12 @@
 	icon_state = "blue"
 	},
 /area/almayer/hallways/lower/port_midship_hallway)
+"bop" = (
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "cargo"
+	},
+/area/almayer/engineering/upper_engineering/port)
 "boq" = (
 /obj/structure/bed/chair/comfy/alpha,
 /turf/open/floor/almayer{
@@ -12215,7 +12191,6 @@
 /turf/open/floor/almayer,
 /area/almayer/squads/req)
 "bpR" = (
-/turf/open/floor/almayer/empty,
 /area/supply/station)
 "bpS" = (
 /obj/structure/machinery/door/poddoor/railing{
@@ -12289,17 +12264,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/medical/lower_medical_lobby)
-"bqK" = (
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
-/obj/structure/surface/table/almayer,
-/obj/item/storage/donut_box,
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "bqL" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -12561,6 +12525,15 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/gym)
+"bsF" = (
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 1;
+	name = "ship-grade camera"
+	},
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "bsG" = (
 /obj/structure/machinery/disposal{
 	density = 0;
@@ -12587,7 +12560,6 @@
 /area/almayer/squads/req)
 "bsK" = (
 /obj/effect/landmark/supply_elevator,
-/turf/open/floor/almayer/empty,
 /area/supply/station)
 "bsL" = (
 /obj/structure/machinery/door/poddoor/railing{
@@ -12936,18 +12908,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/briefing)
-"bvu" = (
-/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	dir = 1;
-	name = "\improper Brig"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/medical)
 "bvz" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/structure/closet/secure_closet/surgical{
@@ -12988,19 +12948,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/brig/general_equipment)
-"bvL" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "bvX" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -13270,17 +13217,12 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/living/port_emb)
-"bxD" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 1;
-	name = "ship-grade camera"
-	},
+"bxE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
+/obj/structure/pipes/standard/manifold/hidden/supply,
+/obj/structure/machinery/light,
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
@@ -14773,8 +14715,12 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/navigation)
-"bHw" = (
-/turf/open/floor/almayer,
+"bHu" = (
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
+	},
+/turf/open/floor/wood/ship,
 /area/almayer/shipboard/brig/warden_office)
 "bHB" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -14855,15 +14801,6 @@
 /obj/structure/machinery/door/poddoor/shutters/almayer{
 	id = "ARES Mainframe Left";
 	name = "\improper ARES Mainframe Shutters";
-	plane = -7
-	},
-/obj/structure/machinery/door/poddoor/almayer/blended/white/open{
-	closed_layer = 3.2;
-	id = "ARES Emergency";
-	layer = 3.2;
-	name = "ARES Emergency Lockdown";
-	needs_power = 0;
-	open_layer = 1.9;
 	plane = -7
 	},
 /turf/open/floor/almayer/no_build{
@@ -15209,6 +15146,15 @@
 	icon_state = "cargo"
 	},
 /area/almayer/living/cryo_cells)
+"bKI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/starboard_hallway)
 "bKJ" = (
 /obj/structure/machinery/door/airlock/almayer/maint,
 /turf/open/floor/almayer{
@@ -15220,6 +15166,25 @@
 /obj/effect/landmark/late_join/charlie,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/charlie)
+"bKN" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
+	dir = 2;
+	name = "\improper Brig Armoury";
+	req_access = null;
+	req_one_access_txt = "1;3";
+	closeOtherId = "brignorth"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "bKP" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -15397,10 +15362,6 @@
 /obj/structure/machinery/camera/autoname/almayer/containment/ares{
 	dir = 8;
 	pixel_y = 2
-	},
-/turf/open/floor/almayer/no_build{
-	dir = 4;
-	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "bLw" = (
@@ -16105,12 +16066,6 @@
 	icon_state = "emeraldcorner"
 	},
 /area/almayer/squads/charlie)
-"bPb" = (
-/obj/structure/closet/secure_closet/medical2,
-/turf/open/floor/almayer{
-	icon_state = "sterile_green_side"
-	},
-/area/almayer/shipboard/brig/medical)
 "bPg" = (
 /obj/vehicle/powerloader,
 /obj/structure/machinery/light{
@@ -17204,17 +17159,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/chapel)
-"bWD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "bWJ" = (
 /obj/structure/machinery/shower{
 	dir = 4
@@ -17230,6 +17174,10 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/req)
+"bWQ" = (
+/obj/structure/pipes/vents/pump,
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/warden_office)
 "bWT" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -17283,6 +17231,15 @@
 	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/operating_room_two)
+"bXy" = (
+/obj/structure/machinery/cm_vending/clothing/maintenance_technician,
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/engineering/upper_engineering/port)
 "bXz" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating/plating_catwalk,
@@ -17319,12 +17276,6 @@
 "bYn" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/engineering/upper_engineering/port)
-"bYp" = (
-/obj/structure/bed/chair/comfy/orange{
-	dir = 8
-	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/warden_office)
 "bYq" = (
 /obj/structure/cargo_container/wy/left,
 /turf/open/floor/almayer{
@@ -17822,9 +17773,6 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "S";
 	layer = 3.3
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "ccs" = (
@@ -18823,24 +18771,6 @@
 "cls" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/port_point_defense)
-"clw" = (
-/obj/structure/machinery/light{
-	dir = 8;
-	invisibility = 101;
-	unacidable = 1;
-	unslashable = 1
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
-/area/almayer/command/airoom)
-"clD" = (
-/obj/structure/machinery/power/apc/almayer,
-/obj/structure/sign/safety/rewire{
-	pixel_y = -38
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/warden_office)
 "clE" = (
 /obj/structure/machinery/door/airlock/almayer/marine/delta/medic,
 /turf/open/floor/almayer{
@@ -19098,6 +19028,9 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/lower/starboard_midship_hallway)
+"cmM" = (
+/turf/closed/wall/almayer,
+/area/almayer/shipboard/brig/medical)
 "cmN" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/almayer{
@@ -19148,9 +19081,6 @@
 "cnp" = (
 /obj/structure/machinery/light{
 	dir = 4
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "cnq" = (
@@ -19313,9 +19243,9 @@
 	},
 /area/almayer/medical/morgue)
 "cnZ" = (
-/obj/item/tool/surgery/hemostat,
-/obj/item/tool/surgery/scalpel,
 /obj/structure/surface/table/reinforced/prison,
+/obj/item/tool/surgery/scalpel,
+/obj/item/tool/surgery/hemostat,
 /turf/open/floor/almayer{
 	dir = 8;
 	icon_state = "sterile_green_corner"
@@ -19515,9 +19445,6 @@
 	pixel_x = 5;
 	pixel_y = 6
 	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
 "cqp" = (
 /obj/structure/largecrate/random/barrel/white,
@@ -19567,15 +19494,6 @@
 /obj/item/storage/fancy/cigar/tarbacktube,
 /turf/open/floor/almayer,
 /area/almayer/living/bridgebunks)
-"cqZ" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "crc" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -19617,6 +19535,12 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/stern)
+"csy" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/warden_office)
 "csI" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -19817,15 +19741,6 @@
 "cvx" = (
 /turf/closed/wall/almayer,
 /area/almayer/maint/lower/cryo_cells)
-"cvE" = (
-/obj/effect/decal/cleanable/vomit,
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_21"
-	},
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/engineering/upper_engineering/port)
 "cvH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -19871,6 +19786,12 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/req)
+"cwC" = (
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "cwL" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_y = -25
@@ -19881,9 +19802,6 @@
 /area/almayer/hallways/upper/stern_hallway)
 "cwS" = (
 /obj/structure/blocker/invisible_wall,
-/turf/open/floor/almayer/no_build{
-	icon_state = "plating"
-	},
 /area/almayer/command/airoom)
 "cwX" = (
 /obj/structure/ladder{
@@ -19896,12 +19814,6 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "S";
 	layer = 3.3
-	},
-/obj/structure/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "tcomms"
 	},
 /area/almayer/command/airoom)
 "cxk" = (
@@ -19917,6 +19829,16 @@
 	icon_state = "test_floor5"
 	},
 /area/almayer/hallways/lower/port_midship_hallway)
+"cyc" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/structure/pipes/vents/pump,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "cyo" = (
 /obj/structure/machinery/vending/cigarette,
 /turf/open/floor/almayer{
@@ -19971,28 +19893,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cells)
-"czm" = (
-/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	name = "\improper Warden's Office";
-	closeOtherId = "brigwarden"
-	},
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 4;
-	id = "Warden Office Shutters";
-	name = "\improper Privacy Shutters"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 8
-	},
-/obj/structure/machinery/door/poddoor/almayer/open{
-	dir = 4;
-	id = "courtyard_cells";
-	name = "\improper Courtyard Lockdown Shutter"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/warden_office)
 "czJ" = (
 /obj/structure/sign/safety/distribution_pipes{
 	pixel_x = 15;
@@ -20063,6 +19963,9 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical_lobby)
+"cAR" = (
+/turf/closed/wall/almayer/reinforced,
+/area/almayer/shipboard/brig/mp_bunks)
 "cBb" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -20107,10 +20010,6 @@
 /obj/structure/stairs{
 	dir = 1;
 	icon_state = "ramptop"
-	},
-/turf/open/floor/almayer/no_build{
-	dir = 4;
-	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "cBs" = (
@@ -20402,6 +20301,9 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/upper_engineering)
+"cHk" = (
+/turf/closed/wall/almayer/reinforced,
+/area/almayer/shipboard/brig/warden_office)
 "cHl" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -20420,9 +20322,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/upper/u_m_p)
-"cHp" = (
-/turf/closed/wall/almayer/reinforced,
-/area/almayer/shipboard/brig/execution_storage)
 "cHu" = (
 /turf/closed/wall/almayer/research/containment/wall/south,
 /area/almayer/medical/containment/cell/cl)
@@ -20613,6 +20512,15 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/maint/lower/constr)
+"cKJ" = (
+/obj/structure/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/interrogation)
 "cKL" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -20638,9 +20546,6 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
 	pixel_y = 1
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "cargo_arrow"
 	},
 /area/almayer/command/airoom)
 "cLq" = (
@@ -20745,6 +20650,17 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/medical/containment/cell/cl)
+"cNI" = (
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
+/area/almayer/shipboard/brig/medical)
+"cNJ" = (
+/obj/structure/pipes/vents/pump,
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "cNK" = (
 /obj/structure/pipes/vents/pump{
 	dir = 1
@@ -20939,6 +20855,9 @@
 "cQv" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/shipboard/brig/general_equipment)
+"cQG" = (
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/starboard_hallway)
 "cQL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -21080,6 +20999,12 @@
 	icon_state = "cargo"
 	},
 /area/almayer/squads/req)
+"cTy" = (
+/obj/structure/closet/secure_closet/medical2,
+/turf/open/floor/almayer{
+	icon_state = "sterile_green_side"
+	},
+/area/almayer/shipboard/brig/medical)
 "cTC" = (
 /obj/structure/machinery/vending/walkman,
 /turf/open/floor/almayer{
@@ -21296,15 +21221,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_m_s)
-"cXv" = (
-/obj/structure/bed/chair/bolted{
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/interrogation)
 "cXC" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -21314,6 +21230,19 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/containment)
+"cXD" = (
+/obj/structure/surface/rack,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/glasses/sunglasses/blindfold,
+/obj/item/clothing/mask/muzzle,
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 8;
+	name = "ship-grade camera"
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/execution_storage)
 "cXF" = (
 /obj/structure/machinery/flasher{
 	alpha = 1;
@@ -21332,6 +21261,12 @@
 	icon_state = "greencorner"
 	},
 /area/almayer/squads/req)
+"cXV" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/mp_bunks)
 "cXW" = (
 /obj/structure/machinery/status_display{
 	pixel_y = 30
@@ -21472,9 +21407,6 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/port)
-"daz" = (
-/turf/closed/wall/almayer/white/hull,
-/area/almayer/command/airoom)
 "daF" = (
 /obj/structure/machinery/power/apc/almayer{
 	dir = 1
@@ -21608,18 +21540,19 @@
 /obj/structure/machinery/power/apc/almayer,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/upper/u_m_p)
-"dda" = (
-/obj/structure/machinery/cm_vending/clothing/maintenance_technician,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/engineering/upper_engineering/port)
 "ddf" = (
 /obj/structure/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
 /area/almayer/engineering/lower/engine_core)
+"ddj" = (
+/obj/structure/bed/chair/bolted,
+/turf/open/floor/almayer{
+	dir = 9;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/interrogation)
 "ddk" = (
 /obj/structure/surface/table/almayer,
 /turf/open/floor/almayer{
@@ -21710,6 +21643,9 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_m_s)
+"deH" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/warden_office)
 "deT" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -21755,17 +21691,6 @@
 	icon_state = "green"
 	},
 /area/almayer/living/grunt_rnr)
-"dfU" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/poddoor/almayer/open{
-	id = "Brig Lockdown Shutters";
-	name = "\improper Brig Lockdown Shutter"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/starboard_hallway)
 "dgg" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 4;
@@ -22035,6 +21960,18 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/cichallway)
+"dmr" = (
+/obj/structure/transmitter{
+	name = "Brig Offices Telephone";
+	phone_category = "MP Dept.";
+	phone_id = "Brig Main Offices";
+	pixel_y = 32
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "dmv" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -23003,9 +22940,6 @@
 	icon_state = "W";
 	layer = 3.3
 	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "tcomms"
-	},
 /area/almayer/command/airoom)
 "dDt" = (
 /obj/structure/toilet{
@@ -23161,6 +23095,19 @@
 	icon_state = "redcorner"
 	},
 /area/almayer/command/lifeboat)
+"dFl" = (
+/obj/structure/sign/safety/security{
+	pixel_x = 15;
+	pixel_y = 32
+	},
+/obj/structure/sign/safety/restrictedarea{
+	pixel_y = 32
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "dFF" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_21"
@@ -23218,10 +23165,6 @@
 /obj/structure/stairs{
 	dir = 1
 	},
-/turf/open/floor/almayer/no_build{
-	dir = 8;
-	icon_state = "silver"
-	},
 /area/almayer/command/airoom)
 "dGr" = (
 /obj/structure/pipes/vents/scrubber{
@@ -23256,6 +23199,17 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/maint/hull/lower/l_f_s)
+"dGT" = (
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
+	},
+/obj/structure/surface/table/almayer,
+/obj/item/storage/donut_box,
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "dGU" = (
 /obj/structure/sign/poster/propaganda{
 	pixel_x = -27
@@ -23317,18 +23271,9 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/living/bridgebunks)
-"dIi" = (
-/obj/structure/pipes/standard/simple/hidden/supply/no_boom,
-/turf/open/floor/plating/plating_catwalk{
-	allow_construction = 0
-	},
-/area/almayer/command/airoom)
 "dIn" = (
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 5
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "dID" = (
@@ -23380,39 +23325,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/p_bow)
-"dJB" = (
-/obj/structure/sign/safety/rewire{
-	pixel_y = 32
-	},
-/obj/item/bedsheet/brown{
-	layer = 3.1
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/structure/bed{
-	can_buckle = 0
-	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 3.3;
-	pixel_y = 4
-	},
-/obj/structure/bed{
-	buckling_y = 13;
-	layer = 3.5;
-	pixel_y = 13
-	},
-/obj/item/bedsheet/brown{
-	pixel_y = 13
-	},
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "dJF" = (
 /obj/structure/pipes/standard/cap/hidden{
 	dir = 4
@@ -23443,6 +23355,9 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/briefing)
+"dJJ" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/execution_storage)
 "dKp" = (
 /turf/open/floor/almayer/research/containment/corner{
 	dir = 4
@@ -23524,20 +23439,6 @@
 	icon_state = "cargo"
 	},
 /area/almayer/lifeboat_pumps/south1)
-"dMf" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/photo_album{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/item/folder/black{
-	pixel_x = 7;
-	pixel_y = -3
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/command/combat_correspondent)
 "dMB" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -23549,13 +23450,6 @@
 	dir = 8
 	},
 /area/almayer/medical/containment/cell)
-"dNm" = (
-/obj/structure/machinery/cm_vending/sorted/medical,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "sterile_green_side"
-	},
-/area/almayer/shipboard/brig/medical)
 "dNq" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -23616,15 +23510,6 @@
 	icon_state = "cargo"
 	},
 /area/almayer/engineering/lower/workshop/hangar)
-"dOf" = (
-/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
-	pixel_y = 25
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "dOl" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/storage/fancy/cigar,
@@ -23748,10 +23633,6 @@
 /obj/structure/stairs{
 	dir = 1
 	},
-/turf/open/floor/almayer/no_build{
-	dir = 4;
-	icon_state = "silver"
-	},
 /area/almayer/command/airoom)
 "dQp" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -23797,6 +23678,21 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/hydroponics)
+"dRj" = (
+/obj/structure/toilet{
+	pixel_y = 13
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "dRo" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/sign/safety/bridge{
@@ -23825,6 +23721,20 @@
 	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
+"dRA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/status_display{
+	pixel_y = -32
+	},
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "dRD" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/machinery/door/airlock/almayer/security{
@@ -24003,10 +23913,6 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
-"dVE" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/starboard_hallway)
 "dVH" = (
 /obj/structure/platform{
 	dir = 8
@@ -24108,11 +24014,6 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/engineering/laundry)
-"dXm" = (
-/turf/open/floor/almayer{
-	icon_state = "dark_sterile"
-	},
-/area/almayer/shipboard/brig/medical)
 "dXo" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/taperecorder,
@@ -24388,9 +24289,6 @@
 /obj/item/clothing/shoes/red,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/u_m_p)
-"ebN" = (
-/turf/closed/wall/almayer/white/reinforced,
-/area/almayer/command/airoom)
 "ebV" = (
 /obj/structure/machinery/status_display{
 	pixel_y = 30
@@ -24477,43 +24375,10 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_m_p)
-"edJ" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/box/bodybags{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/storage/box/bodybags,
-/obj/structure/machinery/light/small{
-	dir = 4;
-	pixel_y = -12
-	},
-/obj/structure/machinery/power/apc/almayer{
-	dir = 4
-	},
-/obj/structure/sign/safety/rewire{
-	pixel_x = 32;
-	pixel_y = 17
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/execution_storage)
 "edV" = (
 /obj/structure/machinery/power/terminal,
 /turf/open/floor/almayer,
 /area/almayer/maint/upper/mess)
-"edW" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
-	name = "\improper Brig Cells"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "eed" = (
 /turf/open/floor/almayer{
 	icon_state = "mono"
@@ -24754,6 +24619,9 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
+"ehl" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/interrogation)
 "ehx" = (
 /obj/effect/landmark/start/marine/tl/alpha,
 /obj/effect/landmark/late_join/alpha,
@@ -24970,6 +24838,16 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/starboard_garden)
+"ekZ" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/secure_data{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/warden_office)
 "elf" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -25007,6 +24885,21 @@
 	dir = 1
 	},
 /area/almayer/medical/containment/cell)
+"elV" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/obj/structure/machinery/door/airlock/almayer/security/reinforced{
+	dir = 2;
+	name = "\improper Execution Equipment"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/execution_storage)
 "elY" = (
 /obj/structure/machinery/light/small{
 	dir = 1
@@ -25386,17 +25279,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_m_s)
-"erN" = (
-/obj/structure/machinery/light{
-	dir = 8
-	},
-/obj/structure/pipes/vents/pump/no_boom{
-	dir = 1
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
-/area/almayer/command/airoom)
 "esd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25415,13 +25297,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_f_s)
-"esq" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/medical)
 "esC" = (
 /obj/structure/toilet{
 	pixel_y = 13
@@ -25531,9 +25406,6 @@
 /obj/effect/landmark/yautja_teleport,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/s_bow)
-"etW" = (
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/execution_storage)
 "eua" = (
 /obj/structure/machinery/vending/cigarette,
 /turf/open/floor/almayer{
@@ -25570,9 +25442,6 @@
 	pixel_x = 24;
 	pixel_y = 24;
 	req_one_access_txt = "200;91;92"
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "tcomms"
 	},
 /area/almayer/command/airoom)
 "euO" = (
@@ -25686,13 +25555,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/squads/delta)
-"ewP" = (
-/obj/structure/janitorialcart,
-/obj/item/tool/mop,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/execution_storage)
 "ewS" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -25739,12 +25601,9 @@
 	icon_state = "greencorner"
 	},
 /area/almayer/hallways/lower/starboard_midship_hallway)
-"eyc" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/mp_bunks)
+"eyD" = (
+/turf/closed/wall/almayer/reinforced,
+/area/almayer/shipboard/brig/starboard_hallway)
 "eyG" = (
 /obj/structure/platform,
 /turf/open/floor/almayer{
@@ -25911,6 +25770,12 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
+"eBx" = (
+/obj/structure/closet/emcloset/legacy,
+/turf/open/floor/almayer{
+	icon_state = "cargo"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "eBE" = (
 /obj/structure/machinery/photocopier{
 	anchored = 0
@@ -26393,15 +26258,6 @@
 /obj/structure/machinery/status_display{
 	pixel_y = 30
 	},
-/obj/structure/machinery/light{
-	dir = 4;
-	invisibility = 101;
-	unacidable = 1;
-	unslashable = 1
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
 "eKQ" = (
 /obj/structure/pipes/vents/scrubber{
@@ -26478,6 +26334,15 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_m_s)
+"eLX" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "eMh" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
 	name = "\improper Laundry Room"
@@ -26594,16 +26459,6 @@
 	icon_state = "orange"
 	},
 /area/almayer/hallways/lower/starboard_umbilical)
-"ePA" = (
-/obj/structure/pipes/vents/pump,
-/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
-	pixel_y = 25
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "sterile_green_side"
-	},
-/area/almayer/shipboard/brig/medical)
 "ePM" = (
 /obj/structure/sign/safety/distribution_pipes{
 	pixel_x = 32
@@ -26758,15 +26613,6 @@
 	icon_state = "cargo_arrow"
 	},
 /area/almayer/engineering/lower/workshop/hangar)
-"eRX" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_21"
-	},
-/turf/open/floor/almayer{
-	dir = 6;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "eSk" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -26835,12 +26681,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_a_s)
-"eTM" = (
-/obj/structure/pipes/vents/pump,
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "eUe" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -27023,10 +26863,10 @@
 "eXk" = (
 /obj/effect/landmark/late_join/working_joe,
 /obj/effect/landmark/start/working_joe,
-/obj/structure/machinery/light{
-	dir = 8
+/obj/structure/machinery/light/small{
+	dir = 8;
+	light_color = "#d69c46"
 	},
-/turf/open/floor/plating/plating_catwalk,
 /area/almayer/command/airoom)
 "eXq" = (
 /turf/closed/wall/almayer,
@@ -27104,9 +26944,6 @@
 /obj/structure/machinery/computer/working_joe{
 	dir = 8;
 	pixel_x = 29
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "eYD" = (
@@ -27437,15 +27274,8 @@
 /area/almayer/engineering/lower)
 "fcX" = (
 /obj/effect/step_trigger/clone_cleaner,
-/obj/structure/machinery/light{
-	dir = 8
-	},
 /obj/structure/platform_decoration{
 	dir = 1
-	},
-/turf/open/floor/almayer/no_build{
-	dir = 8;
-	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "fdf" = (
@@ -27634,6 +27464,15 @@
 	icon_state = "green"
 	},
 /area/almayer/squads/req)
+"fgt" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 9;
+	icon_state = "sterile_green_side"
+	},
+/area/almayer/shipboard/brig/medical)
 "fgE" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -27799,9 +27638,6 @@
 	icon_state = "E";
 	pixel_x = 1
 	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
 "fmB" = (
 /obj/structure/bed/chair/comfy{
@@ -27869,18 +27705,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/squads/req)
-"fnO" = (
-/obj/structure/machinery/door/airlock/almayer/security{
-	dir = 2;
-	name = "\improper Interrogation Observation"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/interrogation)
 "foC" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/disposalpipe/segment{
@@ -27974,13 +27798,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/starboard_aft_hallway)
-"fpO" = (
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/warden_office)
 "fpR" = (
 /obj/structure/surface/table/almayer,
 /obj/effect/spawner/random/tool,
@@ -28069,6 +27886,16 @@
 /obj/structure/surface/table/reinforced/black,
 /turf/open/floor/carpet,
 /area/almayer/command/cichallway)
+"fqQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "fqU" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -28119,6 +27946,42 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
+"frt" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/door_control{
+	id = "courtyard_cells";
+	name = "\improper Courtyard Lockdown Shutters";
+	pixel_x = 6;
+	req_access_txt = "3"
+	},
+/obj/structure/machinery/door_control{
+	id = "Brig Lockdown Shutters";
+	name = "Brig Lockdown Shutters";
+	pixel_x = -6;
+	req_access_txt = "3"
+	},
+/obj/structure/machinery/door_control{
+	id = "courtyard window";
+	name = "Courtyard Window Shutters";
+	pixel_x = -6;
+	pixel_y = 9;
+	req_access_txt = "3"
+	},
+/obj/structure/machinery/door_control{
+	id = "Cell Privacy Shutters";
+	name = "Cell Privacy Shutters";
+	pixel_x = 6;
+	pixel_y = 9;
+	req_access_txt = "3"
+	},
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/warden_office)
 "frz" = (
 /obj/structure/machinery/door/airlock/almayer/secure/reinforced{
 	name = "\improper Exterior Airlock";
@@ -28136,25 +27999,6 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/starboard_missiles)
-"frG" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
-	dir = 2;
-	name = "\improper Brig Armoury";
-	req_access = null;
-	req_one_access_txt = "1;3";
-	closeOtherId = "brignorth"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "frI" = (
 /obj/structure/sign/safety/distribution_pipes{
 	pixel_x = 8;
@@ -28170,9 +28014,6 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out";
 	pixel_y = 1
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "tcomms"
 	},
 /area/almayer/command/airoom)
 "frV" = (
@@ -28295,6 +28136,15 @@
 	icon_state = "orange"
 	},
 /area/almayer/hallways/lower/port_umbilical)
+"fuY" = (
+/obj/structure/bed/chair/bolted{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/interrogation)
 "fva" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -28495,6 +28345,12 @@
 	},
 /turf/open/floor/plating/almayer,
 /area/almayer/living/briefing)
+"fyI" = (
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
+	pixel_y = -25
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/warden_office)
 "fyT" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -28601,17 +28457,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/upper/aft_hallway)
-"fAZ" = (
-/obj/structure/surface/table/almayer,
-/obj/item/weapon/gun/energy/taser,
-/obj/item/weapon/gun/energy/taser{
-	pixel_y = 8
-	},
-/obj/structure/machinery/recharger,
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "fBi" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -28728,10 +28573,6 @@
 	icon_state = "orangecorner"
 	},
 /area/almayer/hallways/upper/stern_hallway)
-"fDw" = (
-/obj/structure/pipes/vents/scrubber,
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/starboard_hallway)
 "fDG" = (
 /obj/structure/machinery/vending/coffee,
 /obj/structure/machinery/light{
@@ -28807,9 +28648,6 @@
 /obj/structure/machinery/camera/autoname/almayer/containment/ares{
 	dir = 4
 	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
 "fER" = (
 /obj/structure/machinery/autolathe,
@@ -28817,12 +28655,6 @@
 	icon_state = "cargo"
 	},
 /area/almayer/hallways/hangar)
-"fEX" = (
-/obj/structure/machinery/cm_vending/clothing/senior_officer,
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/medical/upper_medical)
 "fFe" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = 32
@@ -28890,12 +28722,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_f_p)
-"fFV" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 10
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/starboard_hallway)
 "fGa" = (
 /obj/structure/surface/rack,
 /obj/effect/decal/warning_stripes{
@@ -28967,12 +28793,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/upper/aft_hallway)
-"fGU" = (
-/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
-	pixel_y = -25
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/warden_office)
 "fHb" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating/plating_catwalk,
@@ -29093,21 +28913,9 @@
 	icon_state = "green"
 	},
 /area/almayer/shipboard/brig/cells)
-"fJY" = (
-/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
-	dir = 4
-	},
-/turf/open/floor/almayer/no_build{
-	dir = 8;
-	icon_state = "cargo_arrow"
-	},
-/area/almayer/command/airoom)
 "fKe" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out"
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "tcomms"
 	},
 /area/almayer/command/airoom)
 "fKh" = (
@@ -29276,10 +29084,6 @@
 	pixel_y = -8;
 	req_one_access_txt = "90;91;92"
 	},
-/turf/open/floor/almayer/no_build{
-	dir = 4;
-	icon_state = "silver"
-	},
 /area/almayer/command/airoom)
 "fMt" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer{
@@ -29288,15 +29092,6 @@
 	plane = -7
 	},
 /obj/effect/step_trigger/ares_alert/core,
-/obj/structure/machinery/door/poddoor/almayer/blended/white/open{
-	closed_layer = 3.2;
-	id = "ARES Emergency";
-	layer = 3.2;
-	name = "ARES Emergency Lockdown";
-	needs_power = 0;
-	open_layer = 1.9;
-	plane = -7
-	},
 /obj/structure/sign/safety/laser{
 	pixel_x = 32;
 	pixel_y = -8
@@ -29358,16 +29153,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
-"fOm" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/cameras/almayer_network{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/warden_office)
 "fOv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29964,9 +29749,6 @@
 	pixel_x = 8;
 	pixel_y = -8
 	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
 "gbg" = (
 /obj/structure/sign/safety/terminal{
@@ -29989,9 +29771,6 @@
 	pixel_x = -24;
 	pixel_y = -8;
 	req_one_access_txt = "90;91;92"
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "gbs" = (
@@ -30075,6 +29854,16 @@
 	icon_state = "red"
 	},
 /area/almayer/hallways/hangar)
+"gdG" = (
+/obj/structure/bed/chair{
+	dir = 8;
+	pixel_y = 3
+	},
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "gdJ" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -30143,6 +29932,21 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/port_midship_hallway)
+"gfd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/power/apc/almayer,
+/obj/structure/sign/safety/rewire{
+	pixel_y = -38
+	},
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "gfo" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 1;
@@ -30173,9 +29977,6 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "S";
 	layer = 3.3
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "tcomms"
 	},
 /area/almayer/command/airoom)
 "gfv" = (
@@ -30288,6 +30089,15 @@
 "ghF" = (
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/vehiclehangar)
+"gii" = (
+/obj/structure/bed/chair/bolted{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/interrogation)
 "gio" = (
 /obj/structure/closet/emcloset,
 /obj/structure/sign/safety/restrictedarea{
@@ -30387,9 +30197,6 @@
 /obj/item/storage/box/ids{
 	pixel_x = -4
 	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
 "gjB" = (
 /obj/structure/machinery/light{
@@ -30469,6 +30276,17 @@
 	icon_state = "mono"
 	},
 /area/almayer/medical/medical_science)
+"glG" = (
+/obj/structure/surface/rack,
+/obj/item/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/masks,
+/turf/open/floor/almayer{
+	icon_state = "sterile_green_side"
+	},
+/area/almayer/shipboard/brig/medical)
 "glH" = (
 /obj/structure/machinery/door/airlock/almayer/engineering{
 	dir = 2;
@@ -30482,6 +30300,13 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/lower/workshop)
+"glP" = (
+/obj/structure/janitorialcart,
+/obj/item/tool/mop,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/execution_storage)
 "gmb" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 1
@@ -30502,42 +30327,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/starboard_point_defense)
-"gmm" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/door_control{
-	id = "courtyard_cells";
-	name = "\improper Courtyard Lockdown Shutters";
-	pixel_x = 6;
-	req_access_txt = "3"
-	},
-/obj/structure/machinery/door_control{
-	id = "Brig Lockdown Shutters";
-	name = "Brig Lockdown Shutters";
-	pixel_x = -6;
-	req_access_txt = "3"
-	},
-/obj/structure/machinery/door_control{
-	id = "courtyard window";
-	name = "Courtyard Window Shutters";
-	pixel_x = -6;
-	pixel_y = 9;
-	req_access_txt = "3"
-	},
-/obj/structure/machinery/door_control{
-	id = "Cell Privacy Shutters";
-	name = "Cell Privacy Shutters";
-	pixel_x = 6;
-	pixel_y = 9;
-	req_access_txt = "3"
-	},
-/obj/structure/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/warden_office)
 "gms" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -31073,6 +30862,17 @@
 	icon_state = "red"
 	},
 /area/almayer/hallways/upper/starboard)
+"gxt" = (
+/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	name = "\improper Warden's Office"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/warden_office)
 "gxI" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/maint/hull/upper/s_bow)
@@ -31115,6 +30915,9 @@
 	icon_state = "blue"
 	},
 /area/almayer/hallways/upper/aft_hallway)
+"gym" = (
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/mp_bunks)
 "gyn" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -31256,9 +31059,6 @@
 	pixel_x = 24;
 	pixel_y = 8;
 	req_one_access_txt = "91;92"
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "gAj" = (
@@ -31552,22 +31352,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/delta)
-"gGp" = (
-/obj/structure/surface/table/almayer,
-/obj/item/clothing/mask/cigarette/pipe{
-	pixel_x = 8
-	},
-/obj/structure/transmitter/rotary{
-	name = "Reporter Telephone";
-	phone_category = "Almayer";
-	phone_id = "Reporter";
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/command/combat_correspondent)
 "gGr" = (
 /obj/structure/machinery/vending/cigarette,
 /turf/open/floor/almayer{
@@ -31708,6 +31492,21 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_a_p)
+"gIz" = (
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 1;
+	name = "ship-grade camera"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "gII" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -31726,6 +31525,12 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/upper/aft_hallway)
+"gIO" = (
+/obj/structure/bed/chair/bolted{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/interrogation)
 "gIU" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/box/tapes{
@@ -31759,6 +31564,23 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/lower/repair_bay)
+"gJE" = (
+/obj/structure/machinery/door_control{
+	id = "Interrogation Shutters";
+	name = "\improper Shutters";
+	pixel_x = 24;
+	pixel_y = 12;
+	req_access_txt = "3"
+	},
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 8;
+	name = "ship-grade camera"
+	},
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/interrogation)
 "gJF" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/maint/hull/upper/s_stern)
@@ -31968,20 +31790,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/starboard_fore_hallway)
-"gMw" = (
-/obj/structure/surface/table/almayer,
-/obj/item/paper_bin{
-	pixel_x = -7
-	},
-/obj/item/tool/pen,
-/obj/item/tool/pen{
-	pixel_y = 3
-	},
-/turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "gMJ" = (
 /obj/structure/largecrate/supply/weapons/pistols,
 /turf/open/floor/plating/plating_catwalk,
@@ -32014,9 +31822,6 @@
 	pixel_y = -1;
 	unacidable = 0;
 	unslashable = 0
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "gMS" = (
@@ -32131,10 +31936,6 @@
 	unacidable = 0;
 	unslashable = 0
 	},
-/turf/open/floor/almayer/no_build{
-	dir = 4;
-	icon_state = "silver"
-	},
 /area/almayer/command/airoom)
 "gOC" = (
 /obj/structure/machinery/recharge_station,
@@ -32171,15 +31972,8 @@
 	vector_x = -97;
 	vector_y = 65
 	},
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
 /obj/structure/stairs{
 	dir = 1
-	},
-/turf/open/floor/almayer/no_build{
-	dir = 4
 	},
 /area/almayer/command/airoom)
 "gPS" = (
@@ -32320,6 +32114,12 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/maint/hull/upper/u_f_s)
+"gSz" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 10
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/mp_bunks)
 "gSH" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/almayer{
@@ -32348,9 +32148,6 @@
 /obj/structure/machinery/computer/med_data/laptop{
 	dir = 4;
 	pixel_y = -18
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "gTK" = (
@@ -32412,10 +32209,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/maint/hull/upper/u_f_p)
-"gUC" = (
-/obj/structure/machinery/cm_vending/clothing/military_police_warden,
-/turf/open/floor/wood/ship,
-/area/almayer/shipboard/brig/warden_office)
 "gUG" = (
 /obj/structure/prop/invuln/overhead_pipe{
 	dir = 4;
@@ -32445,10 +32238,6 @@
 "gUN" = (
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 4
-	},
-/turf/open/floor/almayer/no_build{
-	dir = 4;
-	icon_state = "cargo_arrow"
 	},
 /area/almayer/command/airoom)
 "gUS" = (
@@ -32511,14 +32300,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/south1)
-"gWi" = (
-/obj/structure/machinery/medical_pod/sleeper{
-	dir = 8
-	},
-/turf/open/floor/almayer{
-	icon_state = "dark_sterile"
-	},
-/area/almayer/shipboard/brig/medical)
 "gWm" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 4
@@ -32655,6 +32436,15 @@
 	icon_state = "redfull"
 	},
 /area/almayer/living/offices/flight)
+"gYx" = (
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
+	pixel_y = 25
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "gYI" = (
 /obj/structure/platform{
 	dir = 4
@@ -32783,6 +32573,16 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/lower/s_bow)
+"haY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer{
+	icon_state = "redcorner"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "hbl" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 1
@@ -32822,17 +32622,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/port_umbilical)
-"hbD" = (
-/obj/structure/machinery/firealarm{
-	pixel_y = -28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "hbE" = (
 /obj/structure/largecrate/random,
 /obj/item/reagent_container/food/snacks/cheesecakeslice{
@@ -32888,15 +32677,6 @@
 	icon_state = "silver"
 	},
 /area/almayer/engineering/port_atmos)
-"hco" = (
-/obj/structure/machinery/keycard_auth{
-	pixel_x = 25
-	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/warden_office)
 "hcw" = (
 /obj/structure/surface/table/reinforced/black,
 /obj/item/explosive/grenade/high_explosive/training,
@@ -32960,6 +32740,18 @@
 	icon_state = "green"
 	},
 /area/almayer/squads/req)
+"hdQ" = (
+/obj/structure/closet/secure_closet{
+	name = "\improper Execution Firearms"
+	},
+/obj/item/weapon/gun/rifle/m4ra,
+/obj/item/weapon/gun/rifle/m4ra,
+/obj/item/weapon/gun/rifle/m4ra,
+/obj/item/ammo_box/magazine/m4ra,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/execution_storage)
 "hdV" = (
 /obj/structure/sign/safety/escapepod{
 	pixel_x = 8;
@@ -32976,15 +32768,6 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
-"heg" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "heo" = (
 /obj/structure/machinery/power/apc/almayer{
 	cell_type = /obj/item/cell/hyper;
@@ -33311,12 +33094,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/briefing)
-"hjq" = (
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/interrogation)
 "hjs" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -33377,24 +33154,6 @@
 	icon_state = "mono"
 	},
 /area/almayer/lifeboat_pumps/south2)
-"hkr" = (
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "SE-out"
-	},
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "hkz" = (
 /obj/structure/machinery/light/small{
 	dir = 8
@@ -33481,6 +33240,23 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/lower)
+"hlI" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/recharger,
+/obj/structure/sign/safety/terminal{
+	pixel_y = 32
+	},
+/obj/structure/transmitter/rotary{
+	name = "Brig Wardens's Office Telephone";
+	phone_category = "MP Dept.";
+	phone_id = "Brig Warden's Office";
+	pixel_x = 15
+	},
+/turf/open/floor/almayer{
+	dir = 9;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/warden_office)
 "hlT" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out";
@@ -33662,6 +33438,22 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_a_p)
+"hnE" = (
+/obj/structure/surface/table/almayer,
+/obj/item/storage/box/ids{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/device/flash,
+/obj/structure/machinery/light{
+	dir = 8;
+	invisibility = 101
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "hnI" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -33710,11 +33502,30 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_a_p)
+"hoK" = (
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "hoT" = (
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_m_s)
+"hoW" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/adv,
+/obj/item/device/defibrillator,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "sterile_green_side"
+	},
+/area/almayer/shipboard/brig/medical)
 "hpk" = (
 /obj/structure/sign/safety/fire_haz{
 	pixel_x = 8;
@@ -34053,15 +33864,6 @@
 	icon_state = "redcorner"
 	},
 /area/almayer/living/cryo_cells)
-"huN" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "sterile_green_side"
-	},
-/area/almayer/shipboard/brig/medical)
 "huO" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -34093,15 +33895,9 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/briefing)
-"huZ" = (
-/obj/structure/machinery/cm_vending/clothing/maintenance_technician,
-/obj/structure/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/engineering/upper_engineering/port)
+"hvd" = (
+/turf/closed/wall/almayer/reinforced,
+/area/almayer/shipboard/brig/interrogation)
 "hvq" = (
 /obj/structure/bed/chair{
 	dir = 8;
@@ -34266,6 +34062,19 @@
 "hyQ" = (
 /turf/closed/wall/almayer,
 /area/almayer/living/synthcloset)
+"hyV" = (
+/obj/structure/machinery/power/apc/almayer{
+	dir = 4
+	},
+/obj/structure/sign/safety/rewire{
+	pixel_x = 32;
+	pixel_y = 24
+	},
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/interrogation)
 "hza" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34315,6 +34124,15 @@
 	icon_state = "cargo"
 	},
 /area/almayer/squads/delta)
+"hzG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/starboard_hallway)
 "hzL" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/poddoor/almayer/open{
@@ -34345,6 +34163,13 @@
 	icon_state = "cargo"
 	},
 /area/almayer/squads/req)
+"hAf" = (
+/obj/structure/machinery/iv_drip,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "sterile_green_side"
+	},
+/area/almayer/shipboard/brig/medical)
 "hAh" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/hallways/lower/port_umbilical)
@@ -34763,12 +34588,6 @@
 	icon_state = "red"
 	},
 /area/almayer/lifeboat_pumps/south1)
-"hHK" = (
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "redcorner"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "hIp" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -35079,20 +34898,6 @@
 	icon_state = "cargo"
 	},
 /area/almayer/maint/hull/upper/u_f_p)
-"hPx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "hPD" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 8
@@ -35225,6 +35030,9 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/numbertwobunks)
+"hRu" = (
+/turf/closed/wall/almayer/outer,
+/area/almayer/shipboard/brig/execution_storage)
 "hRA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35258,9 +35066,6 @@
 /obj/structure/sign/safety/fibre_optics{
 	pixel_x = 14;
 	pixel_y = 38
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "hSb" = (
@@ -35351,9 +35156,6 @@
 	pixel_y = 16
 	},
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom,
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
 "hTt" = (
 /obj/structure/machinery/brig_cell/cell_1{
@@ -35429,6 +35231,14 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_m_s)
+"hUh" = (
+/obj/structure/machinery/medical_pod/bodyscanner{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
+/area/almayer/shipboard/brig/medical)
 "hUk" = (
 /turf/open/floor/almayer{
 	dir = 10;
@@ -35452,6 +35262,28 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/port_emb)
+"hUU" = (
+/obj/structure/surface/table/almayer,
+/obj/item/storage/box/bodybags{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/storage/box/bodybags,
+/obj/structure/machinery/light/small{
+	dir = 4;
+	pixel_y = -12
+	},
+/obj/structure/machinery/power/apc/almayer{
+	dir = 4
+	},
+/obj/structure/sign/safety/rewire{
+	pixel_x = 32;
+	pixel_y = 17
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/execution_storage)
 "hUW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -35701,15 +35533,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/engineering/lower/workshop/hangar)
-"hZj" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
-/area/almayer/command/airoom)
 "hZw" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out"
@@ -35834,12 +35657,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/lower/s_bow)
-"ibl" = (
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "ibP" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = -19;
@@ -36003,9 +35820,6 @@
 	dir = 1;
 	icon_state = "ramptop"
 	},
-/turf/open/floor/almayer/no_build{
-	dir = 4
-	},
 /area/almayer/command/airoom)
 "ieX" = (
 /obj/structure/surface/table/almayer,
@@ -36031,9 +35845,15 @@
 	icon_state = "red"
 	},
 /area/almayer/lifeboat_pumps/north1)
-"ifR" = (
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/mp_bunks)
+"ifz" = (
+/obj/structure/machinery/keycard_auth{
+	pixel_x = 25
+	},
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/warden_office)
 "igb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -36044,9 +35864,6 @@
 "igr" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out"
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "tcomms"
 	},
 /area/almayer/command/airoom)
 "igs" = (
@@ -36143,15 +35960,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/squads/bravo)
-"iio" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 1;
-	name = "ship-grade camera"
-	},
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "iis" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -36187,12 +35995,6 @@
 	icon_state = "mono"
 	},
 /area/almayer/medical/hydroponics)
-"iiX" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 1
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/warden_office)
 "iiZ" = (
 /obj/structure/machinery/cm_vending/sorted/marine_food,
 /turf/open/floor/almayer{
@@ -36557,12 +36359,6 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/port)
-"iqO" = (
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "iqR" = (
 /obj/structure/sign/safety/cryo{
 	pixel_x = -16
@@ -36643,9 +36439,6 @@
 	dir = 1;
 	icon_state = "ramptop"
 	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
 "isI" = (
 /obj/structure/sign/nosmoking_2{
@@ -36690,10 +36483,6 @@
 	open_layer = 2.1;
 	unacidable = 0;
 	unslashable = 0
-	},
-/turf/open/floor/almayer/no_build{
-	dir = 8;
-	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "ito" = (
@@ -37001,9 +36790,6 @@
 	unacidable = 1;
 	unslashable = 1
 	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
 "iyS" = (
 /obj/structure/disposalpipe/segment{
@@ -37048,6 +36834,12 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
+"iAg" = (
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "redcorner"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "iAw" = (
 /obj/item/tool/warning_cone{
 	pixel_x = -12
@@ -37273,6 +37065,15 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/offices)
+"iFK" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 6
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "iFM" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -37285,14 +37086,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/port_emb)
-"iFS" = (
-/obj/structure/machinery/medical_pod/bodyscanner{
-	dir = 8
-	},
-/turf/open/floor/almayer{
-	icon_state = "dark_sterile"
-	},
-/area/almayer/shipboard/brig/medical)
 "iFY" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/sign/safety/cryo{
@@ -37631,6 +37424,17 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
+"iNh" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
+	name = "\improper Brig Cells"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "iNk" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -37676,11 +37480,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/port_midship_hallway)
-"iOx" = (
-/turf/open/floor/almayer{
-	icon_state = "redcorner"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "iOD" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -37886,16 +37685,19 @@
 	icon_state = "green"
 	},
 /area/almayer/hallways/upper/aft_hallway)
+"iRp" = (
+/obj/structure/window/framed/almayer,
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 8;
+	id = "Interrogation Shutters";
+	name = "\improper Privacy Shutters"
+	},
+/turf/open/floor/plating,
+/area/almayer/shipboard/brig/interrogation)
 "iRy" = (
 /obj/structure/pipes/vents/pump/on,
 /turf/open/floor/almayer,
 /area/almayer/living/gym)
-"iRC" = (
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "iRN" = (
 /obj/structure/machinery/light/containment{
 	dir = 4
@@ -37975,15 +37777,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_a_s)
-"iSL" = (
-/obj/structure/bed/chair/bolted{
-	dir = 8
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/interrogation)
 "iSV" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	access_modified = 1;
@@ -38108,6 +37901,19 @@
 	icon_state = "mono"
 	},
 /area/almayer/medical/hydroponics)
+"iUG" = (
+/obj/structure/closet/secure_closet/surgical{
+	pixel_x = -30
+	},
+/obj/structure/machinery/power/apc/almayer,
+/obj/structure/sign/safety/rewire{
+	pixel_y = -38
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "sterile_green_corner"
+	},
+/area/almayer/shipboard/brig/medical)
 "iUV" = (
 /turf/open/floor/almayer{
 	icon_state = "bluecorner"
@@ -38123,6 +37929,22 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
+"iUX" = (
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_x = -8;
+	pixel_y = 18
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_x = 8;
+	pixel_y = 18
+	},
+/obj/item/device/taperecorder,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/interrogation)
 "iVy" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -38346,10 +38168,6 @@
 	},
 /obj/structure/stairs{
 	dir = 1
-	},
-/turf/open/floor/almayer/no_build{
-	dir = 4;
-	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "iZE" = (
@@ -38872,6 +38690,39 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/maint/hull/lower/l_m_s)
+"jgR" = (
+/obj/structure/sign/safety/rewire{
+	pixel_y = 32
+	},
+/obj/item/bedsheet/brown{
+	layer = 3.1
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/structure/bed{
+	can_buckle = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 3.3;
+	pixel_y = 4
+	},
+/obj/structure/bed{
+	buckling_y = 13;
+	layer = 3.5;
+	pixel_y = 13
+	},
+/obj/item/bedsheet/brown{
+	pixel_y = 13
+	},
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "jgS" = (
 /turf/open/floor/almayer{
 	dir = 10;
@@ -39038,16 +38889,6 @@
 	icon_state = "sterile_green"
 	},
 /area/almayer/medical/lower_medical_medbay)
-"jjH" = (
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
-/obj/structure/sign/safety/rewire{
-	pixel_y = -38
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/execution)
 "jjS" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -39197,6 +39038,20 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/lower/port_fore_hallway)
+"jlE" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/structure/surface/table/almayer,
+/obj/item/toy/deck/uno,
+/obj/item/toy/deck{
+	pixel_x = -9
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "jlG" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out";
@@ -39242,19 +39097,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/command/lifeboat)
-"jme" = (
-/obj/structure/sign/safety/maint{
-	pixel_x = -17
-	},
-/obj/structure/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "jmn" = (
 /obj/structure/surface/table/almayer,
 /obj/item/prop/magazine/dirty{
@@ -39333,6 +39175,29 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/starboard_aft_hallway)
+"jnp" = (
+/obj/structure/surface/table/almayer,
+/obj/item/cell/high{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/ashtray/plastic{
+	icon_state = "ashtray_full_bl";
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = -10;
+	pixel_y = 13
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = -6;
+	pixel_y = -9
+	},
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/engineering/upper_engineering/port)
 "jnx" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 6
@@ -39380,16 +39245,6 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/engineering/laundry)
-"joN" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "jpn" = (
 /obj/structure/stairs{
 	icon_state = "ramptop"
@@ -39437,15 +39292,6 @@
 	plane = -7
 	},
 /obj/effect/step_trigger/ares_alert/core,
-/obj/structure/machinery/door/poddoor/almayer/blended/white/open{
-	closed_layer = 3.2;
-	id = "ARES Emergency";
-	layer = 3.2;
-	name = "ARES Emergency Lockdown";
-	needs_power = 0;
-	open_layer = 1.9;
-	plane = -7
-	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "test_floor4"
 	},
@@ -39585,14 +39431,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/vehiclehangar)
-"jtj" = (
-/obj/structure/machinery/status_display{
-	pixel_y = 30
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
-/area/almayer/command/airoom)
 "jts" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/disposalpipe/segment{
@@ -39662,6 +39500,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/medical/lower_medical_medbay)
+"jvc" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/mp_bunks)
 "jvp" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -39706,9 +39550,6 @@
 /area/almayer/hallways/upper/aft_hallway)
 "jvB" = (
 /obj/effect/step_trigger/clone_cleaner,
-/turf/open/floor/almayer/no_build{
-	dir = 4
-	},
 /area/almayer/command/airoom)
 "jvD" = (
 /obj/structure/machinery/door_control{
@@ -39789,6 +39630,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/u_f_p)
+"jwr" = (
+/obj/structure/machinery/light,
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "jwJ" = (
 /obj/structure/platform_decoration,
 /turf/open/floor/plating/plating_catwalk,
@@ -40033,6 +39880,10 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_lobby)
+"jCX" = (
+/obj/structure/pipes/vents/scrubber,
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/starboard_hallway)
 "jDk" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 4
@@ -40050,9 +39901,6 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/lower/workshop/hangar)
-"jDx" = (
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/interrogation)
 "jDz" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -40098,20 +39946,7 @@
 	pixel_x = 24;
 	req_one_access_txt = "90;91;92"
 	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
-"jEk" = (
-/obj/structure/disposalpipe/junction,
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "jEA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40140,6 +39975,20 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/chief_mp_office)
+"jEV" = (
+/obj/structure/surface/table/almayer,
+/obj/item/paper_bin{
+	pixel_x = -7
+	},
+/obj/item/tool/pen,
+/obj/item/tool/pen{
+	pixel_y = 3
+	},
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "jFf" = (
 /obj/structure/machinery/shower{
 	pixel_y = 16
@@ -40213,13 +40062,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_m_s)
-"jFP" = (
-/obj/structure/machinery/cm_vending/sorted/medical/blood,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "sterile_green_side"
-	},
-/area/almayer/shipboard/brig/medical)
 "jFY" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer{
@@ -40921,11 +40763,6 @@
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/lower)
-"jTE" = (
-/turf/open/floor/almayer{
-	allow_construction = 0
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "jTH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40947,21 +40784,11 @@
 	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie_delta_shared)
-"jTK" = (
-/obj/structure/toilet{
-	pixel_y = 13
-	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/structure/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/almayer{
-	icon_state = "dark_sterile"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
+"jTU" = (
+/obj/structure/bed,
+/obj/item/bedsheet/red,
+/turf/open/floor/wood/ship,
+/area/almayer/shipboard/brig/warden_office)
 "jUb" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/toy/deck{
@@ -41110,6 +40937,19 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/offices)
+"jXc" = (
+/obj/structure/sign/safety/maint{
+	pixel_x = -17
+	},
+/obj/structure/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "jXd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -41209,9 +41049,6 @@
 	},
 /obj/structure/machinery/camera/autoname/almayer/containment/ares{
 	dir = 4
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "tcomms"
 	},
 /area/almayer/command/airoom)
 "jZd" = (
@@ -41367,6 +41204,16 @@
 	icon_state = "bluefull"
 	},
 /area/almayer/squads/charlie_delta_shared)
+"kaQ" = (
+/obj/structure/disposalpipe/junction,
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "kaS" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -41426,9 +41273,6 @@
 	},
 /obj/structure/stairs{
 	dir = 1
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "kbJ" = (
@@ -41561,15 +41405,6 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical_lobby)
-"ked" = (
-/obj/structure/machinery/body_scanconsole{
-	dir = 8
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "sterile_green_side"
-	},
-/area/almayer/shipboard/brig/medical)
 "keE" = (
 /obj/structure/largecrate/random/barrel/red,
 /obj/structure/machinery/light/small,
@@ -41577,6 +41412,18 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_a_s)
+"keG" = (
+/obj/structure/machinery/door/airlock/almayer/security{
+	dir = 2;
+	name = "\improper Interrogation Observation"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/interrogation)
 "keO" = (
 /obj/structure/largecrate/random/secure,
 /obj/effect/decal/warning_stripes{
@@ -41590,17 +41437,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/engineering/upper_engineering/starboard)
-"kfa" = (
-/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	name = "\improper Warden's Office"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 8
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/warden_office)
 "kfo" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -41752,9 +41588,6 @@
 	},
 /obj/structure/machinery/camera/autoname/almayer/containment/ares{
 	dir = 8
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "tcomms"
 	},
 /area/almayer/command/airoom)
 "kil" = (
@@ -42148,6 +41981,15 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_m_p)
+"kqd" = (
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "kqm" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_y = 25
@@ -42328,6 +42170,10 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/processing)
+"ksm" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/starboard_hallway)
 "ksp" = (
 /obj/structure/machinery/cryopod/right{
 	pixel_y = 6
@@ -42454,6 +42300,16 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/upper_engineering)
+"kvL" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/cameras/almayer_network{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/warden_office)
 "kvU" = (
 /obj/structure/surface/table/almayer,
 /turf/open/floor/plating/plating_catwalk,
@@ -42516,13 +42372,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/hangar)
-"kwX" = (
-/obj/structure/machinery/iv_drip,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "sterile_green_side"
-	},
-/area/almayer/shipboard/brig/medical)
 "kxd" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -42566,9 +42415,12 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/squads/req)
-"kxU" = (
-/turf/closed/wall/almayer,
-/area/almayer/shipboard/brig/medical)
+"kxP" = (
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "kyh" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -42668,14 +42520,6 @@
 /obj/structure/machinery/light/small,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_f_p)
-"kzv" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "kzy" = (
 /obj/structure/bed/chair,
 /turf/open/floor/almayer{
@@ -42750,10 +42594,6 @@
 	pixel_x = -24;
 	pixel_y = -8;
 	req_one_access_txt = "90;91;92"
-	},
-/turf/open/floor/almayer/no_build{
-	dir = 8;
-	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "kAh" = (
@@ -42935,18 +42775,13 @@
 	},
 /area/almayer/medical/containment)
 "kCY" = (
-/obj/structure/surface/rack,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/glasses/sunglasses/blindfold,
-/obj/item/clothing/mask/muzzle,
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 8;
-	name = "ship-grade camera"
+/obj/structure/machinery/sleep_console{
+	dir = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate"
+	icon_state = "dark_sterile"
 	},
-/area/almayer/shipboard/brig/execution_storage)
+/area/almayer/shipboard/brig/medical)
 "kDd" = (
 /obj/structure/sign/safety/water{
 	pixel_x = 8;
@@ -43042,15 +42877,6 @@
 	icon_state = "redfull"
 	},
 /area/almayer/living/briefing)
-"kEw" = (
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "dark_sterile"
-	},
-/area/almayer/shipboard/brig/medical)
 "kEE" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -43163,6 +42989,22 @@
 	icon_state = "green"
 	},
 /area/almayer/living/grunt_rnr)
+"kHo" = (
+/obj/item/device/camera{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/structure/surface/table/almayer,
+/obj/item/device/camera_film{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/device/camera_film,
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "kHS" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -43301,10 +43143,6 @@
 /obj/structure/stairs{
 	dir = 1;
 	icon_state = "ramptop"
-	},
-/turf/open/floor/almayer/no_build{
-	dir = 8;
-	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "kKB" = (
@@ -43607,21 +43445,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/req)
-"kPf" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "SW-out"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/obj/structure/machinery/door/airlock/almayer/security/reinforced{
-	dir = 2;
-	name = "\improper Execution Equipment"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/execution_storage)
 "kPx" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/mass_spectrometer,
@@ -43822,9 +43645,6 @@
 	pixel_y = 24;
 	req_one_access_txt = "200;91;92"
 	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "tcomms"
-	},
 /area/almayer/command/airoom)
 "kSA" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
@@ -43861,6 +43681,13 @@
 	icon_state = "plating"
 	},
 /area/almayer/squads/req)
+"kTp" = (
+/obj/structure/window/framed/almayer,
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/almayer/shipboard/brig/medical)
 "kTv" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -43886,6 +43713,16 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/hangar)
+"kUg" = (
+/obj/structure/machinery/firealarm{
+	dir = 4;
+	pixel_x = 21
+	},
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/warden_office)
 "kUh" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic2{
@@ -43949,19 +43786,6 @@
 	icon_state = "mono"
 	},
 /area/almayer/lifeboat_pumps/south2)
-"kVE" = (
-/obj/structure/machinery/power/apc/almayer{
-	dir = 4
-	},
-/obj/structure/sign/safety/rewire{
-	pixel_x = 32;
-	pixel_y = 24
-	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/interrogation)
 "kVV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -44072,10 +43896,6 @@
 	},
 /area/almayer/command/computerlab)
 "kXj" = (
-/turf/open/floor/almayer/no_build{
-	dir = 4;
-	icon_state = "silver"
-	},
 /area/almayer/command/airoom)
 "kXm" = (
 /obj/effect/decal/warning_stripes{
@@ -44090,6 +43910,15 @@
 	icon_state = "plating"
 	},
 /area/almayer/shipboard/stern_point_defense)
+"kXt" = (
+/obj/structure/closet/fireaxecabinet{
+	pixel_y = 32
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "kXu" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -44153,6 +43982,15 @@
 	icon_state = "plating"
 	},
 /area/almayer/engineering/lower/engine_core)
+"kYU" = (
+/obj/structure/machinery/firealarm{
+	pixel_y = 28
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "kYV" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 6
@@ -44652,26 +44490,7 @@
 	dir = 1;
 	icon_state = "ramptop"
 	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
-"lit" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	id = "Interrogation Shutters";
-	name = "\improper Privacy Shutters"
-	},
-/obj/structure/machinery/door/airlock/almayer/security{
-	dir = 2;
-	name = "\improper Interrogation"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/interrogation)
 "liF" = (
 /obj/structure/machinery/light/small{
 	dir = 8
@@ -44933,7 +44752,6 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/medical_science)
 "lmz" = (
-/turf/closed/wall/almayer/white/hull,
 /area/space)
 "lmA" = (
 /obj/structure/flora/pottedplant{
@@ -45007,9 +44825,6 @@
 	pixel_x = 24;
 	pixel_y = -8;
 	req_one_access_txt = "90;91;92"
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "lok" = (
@@ -45319,7 +45134,6 @@
 "ltc" = (
 /obj/effect/landmark/late_join/working_joe,
 /obj/effect/landmark/start/working_joe,
-/turf/open/floor/plating/plating_catwalk,
 /area/almayer/command/airoom)
 "ltm" = (
 /obj/structure/bed/chair/comfy/orange,
@@ -45375,6 +45189,19 @@
 	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
+"ltO" = (
+/obj/structure/closet/secure_closet{
+	name = "\improper Lethal Injection Locker"
+	},
+/obj/item/reagent_container/ld50_syringe/choral,
+/obj/item/reagent_container/ld50_syringe/choral,
+/obj/item/reagent_container/ld50_syringe/choral,
+/obj/item/reagent_container/ld50_syringe/choral,
+/obj/item/reagent_container/ld50_syringe/choral,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/execution_storage)
 "ltU" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -45808,19 +45635,6 @@
 	icon_state = "red"
 	},
 /area/almayer/hallways/upper/port)
-"lCN" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/adv,
-/obj/item/device/defibrillator,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "sterile_green_side"
-	},
-/area/almayer/shipboard/brig/medical)
 "lDa" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_29"
@@ -45954,16 +45768,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/lower/vehiclehangar)
-"lFd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/manifold/hidden/supply,
-/obj/structure/machinery/light,
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "lFe" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -46906,12 +46710,14 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/medical/hydroponics)
-"maB" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 26
+"may" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_21";
+	pixel_y = 16
 	},
+/obj/structure/surface/table/almayer,
 /turf/open/floor/almayer{
-	dir = 1;
+	dir = 9;
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/starboard_hallway)
@@ -46987,15 +46793,10 @@
 /obj/docking_port/stationary/escape_pod/north,
 /turf/open/floor/plating,
 /area/almayer/maint/hull/lower/l_m_p)
-"mcJ" = (
-/obj/structure/surface/table/almayer,
-/obj/item/paper_bin/uscm{
-	pixel_y = 7
-	},
-/obj/item/tool/pen,
+"mcp" = (
 /turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/almayer/shipboard/brig/starboard_hallway)
 "mcL" = (
@@ -47049,10 +46850,16 @@
 	},
 /obj/item/folder/white,
 /obj/item/folder/white,
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
+"mea" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_21"
+	},
+/turf/open/floor/almayer{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "mem" = (
 /obj/structure/machinery/light/small{
 	dir = 1
@@ -47088,13 +46895,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/lower/vehiclehangar)
-"meG" = (
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
-/turf/open/floor/wood/ship,
-/area/almayer/shipboard/brig/warden_office)
 "meQ" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/starboard_midship_hallway)
@@ -47122,15 +46922,6 @@
 	damage_cap = 15000
 	},
 /area/almayer/squads/alpha)
-"mfk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/starboard_hallway)
 "mfH" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 1
@@ -47285,6 +47076,17 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/alpha)
+"miy" = (
+/obj/structure/machinery/optable,
+/obj/structure/sign/safety/medical{
+	pixel_x = 8;
+	pixel_y = 29
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "sterile_green_corner"
+	},
+/area/almayer/shipboard/brig/medical)
 "miE" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1
@@ -47505,9 +47307,6 @@
 	icon_state = "NE-out";
 	pixel_y = 1
 	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "tcomms"
-	},
 /area/almayer/command/airoom)
 "mlm" = (
 /turf/open/floor/almayer{
@@ -47563,9 +47362,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/starboard_umbilical)
-"mne" = (
-/turf/closed/wall/almayer,
-/area/almayer/shipboard/brig/mp_bunks)
 "mng" = (
 /turf/open/floor/almayer{
 	icon_state = "redcorner"
@@ -48200,6 +47996,21 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/brig/armory)
+"mze" = (
+/obj/structure/machinery/door/poddoor/almayer/open{
+	dir = 4;
+	id = "Brig Lockdown Shutters";
+	name = "\improper Brig Lockdown Shutter"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	name = "\improper Brig";
+	closeOtherId = "brigmaint_n"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "mzg" = (
 /turf/open/floor/almayer{
 	icon_state = "emerald"
@@ -48287,6 +48098,15 @@
 	icon_state = "cargo"
 	},
 /area/almayer/squads/delta)
+"mAY" = (
+/obj/structure/machinery/status_display{
+	pixel_y = 30
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "mBa" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -48515,15 +48335,6 @@
 	name = "\improper ARES Mainframe Shutters";
 	plane = -7
 	},
-/obj/structure/machinery/door/poddoor/almayer/blended/white/open{
-	closed_layer = 3.2;
-	id = "ARES Emergency";
-	layer = 3.2;
-	name = "ARES Emergency Lockdown";
-	needs_power = 0;
-	open_layer = 1.9;
-	plane = -7
-	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "test_floor4"
 	},
@@ -48588,20 +48399,6 @@
 /obj/item/device/portable_vendor/corporate,
 /turf/open/floor/wood/ship,
 /area/almayer/command/corporateliaison)
-"mGV" = (
-/obj/item/stack/sheet/glass/reinforced{
-	amount = 50
-	},
-/obj/effect/spawner/random/toolbox,
-/obj/effect/spawner/random/powercell,
-/obj/effect/spawner/random/powercell,
-/obj/structure/surface/rack,
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 1;
-	name = "ship-grade camera"
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/warden_office)
 "mHb" = (
 /obj/structure/machinery/power/apc/almayer{
 	dir = 1
@@ -48654,12 +48451,6 @@
 	icon_state = "mono"
 	},
 /area/almayer/medical/hydroponics)
-"mHE" = (
-/turf/open/floor/almayer/no_build{
-	dir = 8;
-	icon_state = "silver"
-	},
-/area/almayer/command/airoom)
 "mHF" = (
 /obj/structure/surface/rack,
 /obj/item/clothing/head/headband/red{
@@ -48722,14 +48513,6 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/engineering/upper_engineering/port)
-"mIZ" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "dark_sterile"
-	},
-/area/almayer/shipboard/brig/medical)
 "mJa" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/trash/boonie,
@@ -48786,12 +48569,6 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
-"mJI" = (
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "mJL" = (
 /turf/open/floor/almayer{
 	dir = 5;
@@ -49239,15 +49016,6 @@
 	plane = -7
 	},
 /obj/effect/step_trigger/ares_alert/core,
-/obj/structure/machinery/door/poddoor/almayer/blended/white/open{
-	closed_layer = 3.2;
-	id = "ARES Emergency";
-	layer = 3.2;
-	name = "ARES Emergency Lockdown";
-	needs_power = 0;
-	open_layer = 1.9;
-	plane = -7
-	},
 /obj/structure/sign/safety/terminal{
 	pixel_x = -18;
 	pixel_y = -8
@@ -49455,20 +49223,6 @@
 /obj/structure/machinery/computer/cameras/almayer/ares{
 	dir = 8;
 	pixel_x = 17
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
-/area/almayer/command/airoom)
-"mUC" = (
-/obj/structure/machinery/light{
-	dir = 4;
-	invisibility = 101;
-	unacidable = 1;
-	unslashable = 1
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "mUE" = (
@@ -50003,16 +49757,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/lower/vehiclehangar)
-"neh" = (
-/obj/structure/machinery/firealarm{
-	dir = 4;
-	pixel_x = 21
-	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/warden_office)
 "new" = (
 /obj/item/reagent_container/glass/bucket/janibucket,
 /obj/item/reagent_container/glass/bucket/janibucket{
@@ -50485,12 +50229,6 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/starboard_missiles)
-"nkA" = (
-/obj/structure/closet/emcloset/legacy,
-/turf/open/floor/almayer{
-	icon_state = "cargo"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "nkF" = (
 /obj/structure/bed/chair/bolted{
 	dir = 4
@@ -51021,6 +50759,20 @@
 /obj/effect/landmark/late_join/alpha,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/alpha)
+"nuZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out"
+	},
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "nvd" = (
 /turf/open/floor/almayer{
 	dir = 6;
@@ -51439,6 +51191,11 @@
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/living/commandbunks)
+"nCD" = (
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "nCM" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/almayer{
@@ -51472,15 +51229,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/command/lifeboat)
-"nCZ" = (
-/obj/structure/closet/fireaxecabinet{
-	pixel_y = 32
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "nDa" = (
 /obj/structure/machinery/power/terminal{
 	dir = 4
@@ -51994,19 +51742,6 @@
 	icon_state = "emeraldfull"
 	},
 /area/almayer/squads/charlie_delta_shared)
-"nNW" = (
-/obj/structure/sign/safety/security{
-	pixel_x = 15;
-	pixel_y = 32
-	},
-/obj/structure/sign/safety/restrictedarea{
-	pixel_y = 32
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "nNX" = (
 /obj/structure/machinery/door/airlock/almayer/secure/reinforced{
 	name = "\improper Evacuation Airlock PU-1";
@@ -52429,6 +52164,25 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/briefing)
+"nVm" = (
+/obj/structure/machinery/door_control{
+	id = "firearm_storage_armory";
+	name = "Armory Lockdown";
+	pixel_y = 24;
+	req_access_txt = "4"
+	},
+/obj/structure/sign/safety/ammunition{
+	pixel_y = 32
+	},
+/obj/structure/sign/safety/restrictedarea{
+	pixel_x = 15;
+	pixel_y = 32
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "nVn" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out";
@@ -52481,30 +52235,6 @@
 	icon_state = "cargo_arrow"
 	},
 /area/almayer/living/offices)
-"nVG" = (
-/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
-	dir = 2;
-	name = "\improper Brig Armoury";
-	req_access = null;
-	req_one_access_txt = "1;3"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
-"nVH" = (
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "redcorner"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "nVQ" = (
 /obj/structure/machinery/light,
 /obj/structure/sign/safety/security{
@@ -52533,6 +52263,14 @@
 /obj/structure/surface/table/almayer,
 /turf/open/floor/wood/ship,
 /area/almayer/engineering/ce_room)
+"nWS" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
+/area/almayer/shipboard/brig/medical)
 "nXo" = (
 /obj/item/storage/box/donkpockets,
 /obj/structure/surface/rack,
@@ -52803,9 +52541,6 @@
 /obj/structure/sign/safety/rewire{
 	pixel_y = 38
 	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
 "ocI" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -52973,6 +52708,9 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/computerlab)
+"oeZ" = (
+/turf/closed/wall/almayer/reinforced,
+/area/almayer/shipboard/brig/medical)
 "ofH" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
@@ -53189,6 +52927,13 @@
 	icon_state = "redfull"
 	},
 /area/almayer/shipboard/port_missiles)
+"oix" = (
+/obj/structure/machinery/power/apc/almayer,
+/obj/structure/sign/safety/rewire{
+	pixel_y = -38
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/warden_office)
 "oiB" = (
 /turf/open/floor/almayer{
 	dir = 10;
@@ -53215,7 +52960,6 @@
 /area/almayer/squads/bravo)
 "oiX" = (
 /obj/docking_port/stationary/vehicle_elevator/almayer,
-/turf/open/floor/almayer/empty,
 /area/almayer/hallways/lower/vehiclehangar)
 "oiY" = (
 /obj/effect/decal/warning_stripes{
@@ -53320,6 +53064,12 @@
 	icon_state = "outerhull_dir"
 	},
 /area/space)
+"okO" = (
+/obj/structure/machinery/cm_vending/clothing/senior_officer,
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/medical/upper_medical)
 "old" = (
 /obj/structure/machinery/light/small,
 /obj/structure/largecrate/random/case/double,
@@ -53590,23 +53340,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/lower/engine_core)
-"opI" = (
-/obj/structure/closet/secure_closet,
-/obj/item/device/camera_film,
-/obj/item/device/camera_film,
-/obj/item/device/camera_film,
-/obj/item/storage/box/tapes,
-/obj/item/clothing/head/fedora,
-/obj/item/clothing/suit/storage/marine/light/reporter,
-/obj/item/clothing/head/helmet/marine/reporter,
-/obj/item/clothing/head/cmcap/reporter,
-/obj/item/device/flashlight,
-/obj/item/device/toner,
-/obj/item/device/toner,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/command/combat_correspondent)
 "opJ" = (
 /obj/docking_port/stationary/emergency_response/external/port4,
 /turf/open/space/basic,
@@ -53694,20 +53427,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_m_p)
-"oqN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/machinery/status_display{
-	pixel_y = -32
-	},
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "oqS" = (
 /obj/structure/toilet{
 	dir = 1
@@ -53829,14 +53548,7 @@
 /area/almayer/hallways/hangar)
 "osy" = (
 /obj/effect/step_trigger/clone_cleaner,
-/obj/structure/machinery/light{
-	dir = 4
-	},
 /obj/structure/platform_decoration,
-/turf/open/floor/almayer/no_build{
-	dir = 4;
-	icon_state = "silver"
-	},
 /area/almayer/command/airoom)
 "osz" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
@@ -53911,36 +53623,15 @@
 	icon_state = "red"
 	},
 /area/almayer/hallways/lower/starboard_midship_hallway)
-"otl" = (
-/obj/item/bedsheet/brown{
-	pixel_y = 13
-	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 3.3;
-	pixel_y = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/structure/bed{
-	can_buckle = 0
-	},
-/obj/structure/bed{
-	buckling_y = 13;
-	layer = 3.5;
-	pixel_y = 13
-	},
-/obj/item/bedsheet/brown{
-	layer = 3.1
+"otp" = (
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
 	},
 /turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "red"
+	icon_state = "dark_sterile"
 	},
-/area/almayer/shipboard/brig/mp_bunks)
+/area/almayer/shipboard/brig/medical)
 "otq" = (
 /obj/structure/machinery/line_nexter{
 	dir = 1;
@@ -54012,12 +53703,6 @@
 	pixel_y = 6
 	},
 /obj/item/tool/pen,
-/obj/structure/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
 "ouw" = (
 /obj/structure/machinery/light/small{
@@ -54207,6 +53892,12 @@
 /obj/structure/machinery/photocopier,
 /turf/open/floor/almayer,
 /area/almayer/command/lifeboat)
+"oyC" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 10
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/starboard_hallway)
 "oyE" = (
 /obj/effect/landmark/start/intel,
 /obj/structure/sign/poster{
@@ -54584,16 +54275,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/engineering/lower/workshop/hangar)
-"oEA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer{
-	icon_state = "redcorner"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "oEE" = (
 /obj/structure/machinery/light{
 	unacidable = 1;
@@ -54680,9 +54361,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/s_bow)
-"oGl" = (
-/turf/closed/wall/almayer/reinforced,
-/area/almayer/shipboard/brig/warden_office)
 "oGm" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -54894,6 +54572,12 @@
 "oJk" = (
 /turf/closed/wall/almayer,
 /area/almayer/engineering/lower/workshop)
+"oJm" = (
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "oJp" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
@@ -54939,9 +54623,6 @@
 	name = "ARES Core Access";
 	pixel_x = -24;
 	req_one_access_txt = "90;91;92"
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "oKb" = (
@@ -55006,10 +54687,6 @@
 	pixel_y = -8
 	},
 /obj/effect/step_trigger/clone_cleaner,
-/turf/open/floor/almayer/no_build{
-	dir = 8;
-	icon_state = "silver"
-	},
 /area/almayer/command/airoom)
 "oLF" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
@@ -55115,12 +54792,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/medical/hydroponics)
-"oNG" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 10
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/mp_bunks)
 "oNJ" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -55187,15 +54858,6 @@
 	icon_state = "red"
 	},
 /area/almayer/hallways/upper/starboard)
-"oOG" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 6
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "oON" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -55349,17 +55011,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/maint/hull/upper/u_f_s)
-"oRG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "redcorner"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "oRJ" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -55390,9 +55041,6 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "W";
 	pixel_x = -1
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "oRW" = (
@@ -55713,6 +55361,15 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/starboard_fore_hallway)
+"oWK" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "oWN" = (
 /obj/structure/pipes/vents/pump{
 	dir = 1
@@ -55766,16 +55423,6 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
-"oYb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "oYi" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -55954,6 +55601,36 @@
 	dir = 1
 	},
 /area/almayer/command/cic)
+"pbm" = (
+/obj/item/bedsheet/brown{
+	pixel_y = 13
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 3.3;
+	pixel_y = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/structure/bed{
+	can_buckle = 0
+	},
+/obj/structure/bed{
+	buckling_y = 13;
+	layer = 3.5;
+	pixel_y = 13
+	},
+/obj/item/bedsheet/brown{
+	layer = 3.1
+	},
+/turf/open/floor/almayer{
+	dir = 9;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "pbo" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/almayer{
@@ -56094,23 +55771,16 @@
 	icon_state = "plating"
 	},
 /area/almayer/engineering/lower/engine_core)
-"pdR" = (
-/obj/structure/machinery/door_control{
-	id = "Interrogation Shutters";
-	name = "\improper Shutters";
-	pixel_x = 24;
-	pixel_y = 12;
-	req_access_txt = "3"
-	},
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 8;
-	name = "ship-grade camera"
+"pdT" = (
+/obj/structure/pipes/vents/pump,
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
+	pixel_y = 25
 	},
 /turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "red"
+	dir = 1;
+	icon_state = "sterile_green_side"
 	},
-/area/almayer/shipboard/brig/interrogation)
+/area/almayer/shipboard/brig/medical)
 "pek" = (
 /turf/closed/wall/almayer,
 /area/almayer/maint/hull/upper/s_bow)
@@ -56165,6 +55835,17 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
+"pfd" = (
+/obj/structure/window/framed/almayer,
+/obj/structure/machinery/door/poddoor/almayer/open{
+	id = "Brig Lockdown Shutters";
+	name = "\improper Brig Lockdown Shutter"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/almayer/shipboard/brig/starboard_hallway)
 "pfp" = (
 /obj/effect/step_trigger/teleporter_vector{
 	name = "Almayer_Up4";
@@ -56235,9 +55916,6 @@
 /obj/structure/stairs{
 	dir = 1;
 	icon_state = "ramptop"
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "pgJ" = (
@@ -56490,9 +56168,6 @@
 	pixel_y = 16
 	},
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom,
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
 "pnh" = (
 /obj/structure/ladder{
@@ -56891,15 +56566,6 @@
 	icon_state = "silver"
 	},
 /area/almayer/living/cryo_cells)
-"puz" = (
-/obj/structure/closet/secure_closet/personal/cabinet{
-	req_access = null
-	},
-/obj/item/storage/donut_box{
-	pixel_y = 8
-	},
-/turf/open/floor/wood/ship,
-/area/almayer/shipboard/brig/warden_office)
 "puI" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -56934,20 +56600,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/stern)
-"pva" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/machinery/door/airlock/almayer/security/glass{
-	name = "\improper Brig Breakroom"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	layer = 1.9
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "pvh" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /obj/item/tool/warning_cone{
@@ -57652,19 +57304,6 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/living/port_emb)
-"pJR" = (
-/obj/effect/step_trigger/teleporter_vector{
-	name = "Almayer_AresUp";
-	vector_x = -97;
-	vector_y = 65
-	},
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/almayer/no_build{
-	dir = 4
-	},
-/area/almayer/command/airoom)
 "pKh" = (
 /obj/structure/machinery/alarm/almayer{
 	dir = 1
@@ -57682,6 +57321,15 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/s_stern)
+"pKU" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/firealarm{
+	pixel_y = 28
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/mp_bunks)
 "pKW" = (
 /obj/structure/machinery/door/poddoor/almayer/open{
 	id = "Hangar Lockdown";
@@ -57910,10 +57558,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/panic)
-"pPn" = (
-/obj/structure/pipes/vents/pump,
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/warden_office)
 "pPv" = (
 /obj/structure/closet/cabinet,
 /obj/item/reagent_container/food/drinks/bottle/wine,
@@ -58023,6 +57667,16 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/charlie_delta_shared)
+"pQI" = (
+/obj/structure/machinery/power/apc/almayer{
+	cell_type = /obj/item/cell/hyper;
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "pQN" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/food/condiment/hotsauce/franks,
@@ -58359,39 +58013,6 @@
 	icon_state = "blue"
 	},
 /area/almayer/living/pilotbunks)
-"pXe" = (
-/obj/structure/surface/table/almayer,
-/obj/item/cell/high{
-	pixel_x = -8;
-	pixel_y = 8
-	},
-/obj/item/ashtray/plastic{
-	icon_state = "ashtray_full_bl";
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/item/trash/cigbutt{
-	pixel_x = -10;
-	pixel_y = 13
-	},
-/obj/item/trash/cigbutt{
-	pixel_x = -6;
-	pixel_y = -9
-	},
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/engineering/upper_engineering/port)
-"pXh" = (
-/obj/structure/machinery/power/apc/almayer{
-	cell_type = /obj/item/cell/hyper;
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "pXl" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -58446,15 +58067,8 @@
 	},
 /area/almayer/hallways/lower/starboard_midship_hallway)
 "pYi" = (
-/obj/structure/machinery/light{
-	dir = 4
-	},
 /obj/structure/pipes/vents/pump/no_boom{
 	dir = 8
-	},
-/turf/open/floor/almayer/no_build{
-	dir = 4;
-	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "pYo" = (
@@ -59057,14 +58671,8 @@
 /area/almayer/medical/lower_medical_lobby)
 "qit" = (
 /obj/structure/surface/table/reinforced/almayer_B,
-/obj/structure/machinery/light{
-	dir = 8
-	},
 /obj/item/paper_bin/uscm,
 /obj/item/tool/pen,
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
 "qiy" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
@@ -59088,6 +58696,12 @@
 	icon_state = "silvercorner"
 	},
 /area/almayer/command/computerlab)
+"qjK" = (
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "qjL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -59459,20 +59073,6 @@
 	icon_state = "plating"
 	},
 /area/almayer/engineering/lower/engine_core)
-"qoX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "SW-out"
-	},
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "qoY" = (
 /obj/structure/machinery/vending/hydroseeds,
 /turf/open/floor/almayer{
@@ -59725,6 +59325,24 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/living/port_emb)
+"qvE" = (
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out"
+	},
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "qvI" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = -17
@@ -59793,10 +59411,6 @@
 	pixel_x = -24;
 	pixel_y = -8;
 	req_one_access_txt = "90;91;92"
-	},
-/turf/open/floor/almayer/no_build{
-	dir = 8;
-	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "qwY" = (
@@ -60168,6 +59782,16 @@
 /obj/effect/landmark/start/captain,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/bridgebunks)
+"qCA" = (
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
+	},
+/obj/structure/sign/safety/rewire{
+	pixel_y = -38
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/execution)
 "qCG" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -60252,9 +59876,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_a_p)
-"qDT" = (
-/turf/closed/wall/almayer/reinforced,
-/area/almayer/shipboard/brig/mp_bunks)
 "qEc" = (
 /obj/effect/step_trigger/clone_cleaner,
 /turf/open/floor/plating/plating_catwalk,
@@ -60420,6 +60041,9 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_a_s)
+"qFX" = (
+/turf/closed/wall/almayer,
+/area/almayer/shipboard/brig/mp_bunks)
 "qGc" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -60516,12 +60140,6 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
-"qHP" = (
-/obj/structure/closet/firecloset/full,
-/turf/open/floor/almayer{
-	icon_state = "cargo"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "qIa" = (
 /obj/structure/platform{
 	dir = 4
@@ -60779,9 +60397,6 @@
 /area/almayer/living/port_emb)
 "qLS" = (
 /obj/structure/pipes/standard/manifold/hidden/supply/no_boom,
-/turf/open/floor/almayer/no_build{
-	dir = 4
-	},
 /area/almayer/command/airoom)
 "qLV" = (
 /obj/structure/surface/table/almayer,
@@ -61002,18 +60617,6 @@
 	icon_state = "red"
 	},
 /area/almayer/maint/hull/upper/u_a_p)
-"qQS" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S";
-	layer = 3.3
-	},
-/obj/structure/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "tcomms"
-	},
-/area/almayer/command/airoom)
 "qRb" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
@@ -61177,6 +60780,26 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/processing)
+"qUG" = (
+/obj/structure/surface/table/almayer,
+/obj/item/clothing/mask/cigarette/pipe{
+	pixel_x = 8
+	},
+/obj/structure/transmitter/rotary{
+	name = "Reporter Telephone";
+	phone_category = "Almayer";
+	phone_id = "Reporter";
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/item/device/toner{
+	pixel_y = -11;
+	pixel_x = -2
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/command/combat_correspondent)
 "qUL" = (
 /obj/structure/machinery/landinglight/ds1/delaythree{
 	dir = 4
@@ -61363,13 +60986,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/perma)
-"qXG" = (
-/obj/structure/machinery/photocopier,
-/turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "qXO" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/food/snacks/mre_pack/xmas3{
@@ -61621,9 +61237,6 @@
 	pixel_x = 24;
 	pixel_y = -24;
 	req_one_access_txt = "200;91;92"
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "rbB" = (
@@ -61961,12 +61574,6 @@
 "rgL" = (
 /turf/open/floor/plating,
 /area/almayer/maint/upper/u_m_p)
-"rgQ" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/starboard_hallway)
 "rgW" = (
 /turf/open/floor/almayer{
 	icon_state = "emeraldcorner"
@@ -62203,6 +61810,23 @@
 /obj/structure/pipes/vents/scrubber,
 /turf/open/floor/almayer,
 /area/almayer/living/gym)
+"rkV" = (
+/obj/structure/window/framed/almayer/hull/hijack_bustable,
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 4;
+	id = "Warden Office Shutters";
+	name = "\improper Privacy Shutters"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 8
+	},
+/obj/structure/machinery/door/poddoor/almayer/open{
+	dir = 4;
+	id = "courtyard_cells";
+	name = "\improper Courtyard Lockdown Shutter"
+	},
+/turf/open/floor/plating,
+/area/almayer/shipboard/brig/warden_office)
 "rlc" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -62279,6 +61903,15 @@
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
+"rmk" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 26
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "rmx" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/recharger,
@@ -62316,9 +61949,6 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/engineering/upper_engineering/port)
-"rna" = (
-/turf/closed/wall/almayer/white,
-/area/almayer/command/airoom)
 "rnd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62352,9 +61982,6 @@
 /obj/structure/machinery/computer/crew/alt{
 	dir = 8;
 	pixel_x = 17
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "rnN" = (
@@ -62665,6 +62292,23 @@
 /obj/structure/machinery/light,
 /turf/open/floor/plating,
 /area/almayer/maint/lower/constr)
+"rtc" = (
+/obj/structure/surface/table/almayer,
+/obj/item/storage/photo_album{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/folder/black{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/device/camera_film{
+	pixel_x = -5
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/command/combat_correspondent)
 "rtd" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -62692,9 +62336,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/alpha_bravo_shared)
-"rtP" = (
-/turf/closed/wall/almayer/reinforced,
-/area/almayer/shipboard/brig/interrogation)
 "rtV" = (
 /obj/structure/surface/table/almayer,
 /obj/item/pizzabox{
@@ -62774,11 +62415,6 @@
 /obj/structure/window/framed/almayer/hull/hijack_bustable,
 /turf/open/floor/plating,
 /area/almayer/engineering/lower/workshop/hangar)
-"rvf" = (
-/obj/structure/bed,
-/obj/item/bedsheet/red,
-/turf/open/floor/wood/ship,
-/area/almayer/shipboard/brig/warden_office)
 "rvA" = (
 /turf/open/floor/almayer,
 /area/almayer/living/numbertwobunks)
@@ -63059,9 +62695,6 @@
 	icon_state = "mono"
 	},
 /area/almayer/lifeboat_pumps/south1)
-"rCd" = (
-/turf/closed/wall/almayer/reinforced,
-/area/almayer/shipboard/brig/medical)
 "rCh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -63074,9 +62707,6 @@
 "rCi" = (
 /obj/structure/machinery/camera/autoname/almayer/containment/ares{
 	dir = 8
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "rCl" = (
@@ -63100,9 +62730,6 @@
 	},
 /obj/structure/stairs{
 	dir = 1
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "rCD" = (
@@ -63678,22 +63305,6 @@
 	dir = 5
 	},
 /area/almayer/command/cic)
-"rKh" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/box/ids{
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/obj/item/device/flash,
-/obj/structure/machinery/light{
-	dir = 8;
-	invisibility = 101
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "rKn" = (
 /obj/structure/machinery/door_control{
 	id = "agentshuttle";
@@ -63865,9 +63476,6 @@
 	unacidable = 1;
 	unslashable = 1
 	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
 "rNK" = (
 /obj/structure/surface/table/almayer,
@@ -63943,6 +63551,11 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/delta)
+"rPF" = (
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "rPO" = (
 /turf/open/floor/almayer{
 	dir = 10;
@@ -64008,12 +63621,6 @@
 	icon_state = "cargo_arrow"
 	},
 /area/almayer/squads/delta)
-"rQP" = (
-/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
-	pixel_y = 25
-	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/starboard_hallway)
 "rQV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64344,6 +63951,25 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/gym)
+"rXE" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out"
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/sign/safety/ammunition{
+	pixel_x = 15;
+	pixel_y = -32
+	},
+/obj/structure/sign/safety/hazard{
+	pixel_y = -32
+	},
+/obj/structure/machinery/power/apc/almayer{
+	dir = 8
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/execution)
 "rXF" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 1
@@ -64558,7 +64184,6 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/port_fore_hallway)
 "sbJ" = (
-/turf/closed/wall/almayer/white/hull,
 /area/almayer/powered/agent)
 "sbP" = (
 /obj/effect/landmark/start/police,
@@ -64646,20 +64271,6 @@
 	icon_state = "orangefull"
 	},
 /area/almayer/living/briefing)
-"scS" = (
-/obj/structure/machinery/status_display{
-	pixel_y = 30
-	},
-/obj/structure/machinery/light{
-	dir = 8;
-	invisibility = 101;
-	unacidable = 1;
-	unslashable = 1
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
-/area/almayer/command/airoom)
 "scX" = (
 /obj/structure/surface/table/almayer,
 /obj/item/tool/kitchen/tray,
@@ -64768,22 +64379,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/squads/req)
-"sge" = (
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 8;
-	pixel_y = -2
-	},
-/obj/item/storage/firstaid/regular,
-/obj/item/reagent_container/spray/cleaner,
-/turf/open/floor/almayer{
-	icon_state = "sterile_green_side"
-	},
-/area/almayer/shipboard/brig/medical)
 "sgi" = (
 /turf/closed/wall/almayer,
 /area/almayer/shipboard/brig/processing)
@@ -65043,7 +64638,6 @@
 	},
 /area/almayer/medical/lower_medical_medbay)
 "sje" = (
-/turf/open/floor/almayer/empty,
 /area/almayer/hallways/lower/vehiclehangar)
 "sjj" = (
 /obj/structure/machinery/keycard_auth{
@@ -65152,21 +64746,6 @@
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/command/corporateliaison)
-"slb" = (
-/obj/structure/machinery/door/poddoor/almayer/open{
-	dir = 4;
-	id = "Brig Lockdown Shutters";
-	name = "\improper Brig Lockdown Shutter"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	name = "\improper Brig";
-	closeOtherId = "brigmaint_n"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "sld" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65550,14 +65129,6 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
-"sqO" = (
-/obj/structure/machinery/sleep_console{
-	dir = 8
-	},
-/turf/open/floor/almayer{
-	icon_state = "dark_sterile"
-	},
-/area/almayer/shipboard/brig/medical)
 "sqP" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/emails{
@@ -65990,6 +65561,20 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/offices)
+"szG" = (
+/obj/item/stack/sheet/glass/reinforced{
+	amount = 50
+	},
+/obj/effect/spawner/random/toolbox,
+/obj/effect/spawner/random/powercell,
+/obj/effect/spawner/random/powercell,
+/obj/structure/surface/rack,
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 1;
+	name = "ship-grade camera"
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/warden_office)
 "szM" = (
 /obj/structure/flora/pottedplant{
 	desc = "It is made of Fiberbush(tm). It contains asbestos.";
@@ -66175,9 +65760,6 @@
 	icon_state = "plating"
 	},
 /area/almayer/hallways/upper/stern_hallway)
-"sDp" = (
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/starboard_hallway)
 "sDu" = (
 /obj/item/clothing/under/marine/dress,
 /turf/open/floor/almayer{
@@ -66287,12 +65869,14 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_a_p)
+"sEz" = (
+/turf/open/floor/almayer{
+	allow_construction = 0
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "sEK" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "tcomms"
 	},
 /area/almayer/command/airoom)
 "sEM" = (
@@ -66344,6 +65928,17 @@
 	icon_state = "cargo"
 	},
 /area/almayer/shipboard/starboard_missiles)
+"sFu" = (
+/obj/structure/surface/table/almayer,
+/obj/item/paper_bin/uscm{
+	pixel_y = 7
+	},
+/obj/item/tool/pen,
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "sGh" = (
 /turf/open/floor/almayer/uscm/directional,
 /area/almayer/command/lifeboat)
@@ -66443,9 +66038,6 @@
 	},
 /obj/structure/stairs{
 	dir = 1
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "sIr" = (
@@ -66561,9 +66153,6 @@
 	dir = 8;
 	layer = 3.25
 	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
 "sLk" = (
 /obj/structure/ladder{
@@ -66598,37 +66187,12 @@
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/processing)
-"sLT" = (
-/obj/structure/closet/secure_closet/surgical{
-	pixel_x = -30
-	},
-/obj/structure/machinery/power/apc/almayer,
-/obj/structure/sign/safety/rewire{
-	pixel_y = -38
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "sterile_green_corner"
-	},
-/area/almayer/shipboard/brig/medical)
 "sLX" = (
 /turf/open/floor/almayer{
 	dir = 4;
 	icon_state = "emeraldcorner"
 	},
 /area/almayer/hallways/lower/port_midship_hallway)
-"sMp" = (
-/obj/structure/closet/secure_closet{
-	name = "\improper Execution Firearms"
-	},
-/obj/item/weapon/gun/rifle/m4ra,
-/obj/item/weapon/gun/rifle/m4ra,
-/obj/item/weapon/gun/rifle/m4ra,
-/obj/item/ammo_box/magazine/m4ra,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/execution_storage)
 "sMu" = (
 /obj/item/trash/uscm_mre,
 /obj/structure/bed/chair/comfy/charlie{
@@ -66927,15 +66491,6 @@
 	icon_state = "blue"
 	},
 /area/almayer/living/basketball)
-"sTe" = (
-/obj/structure/machinery/firealarm{
-	pixel_y = 28
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "sTm" = (
 /obj/structure/surface/table/reinforced/black,
 /turf/open/floor/carpet,
@@ -67149,10 +66704,6 @@
 /obj/effect/landmark/late_join/bravo,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/bravo)
-"sXx" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/starboard_hallway)
 "sXB" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -67210,6 +66761,15 @@
 	icon_state = "green"
 	},
 /area/almayer/hallways/upper/aft_hallway)
+"sYl" = (
+/obj/structure/machinery/body_scanconsole{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "sterile_green_side"
+	},
+/area/almayer/shipboard/brig/medical)
 "sYr" = (
 /obj/structure/machinery/door/airlock/almayer/maint,
 /obj/structure/machinery/door/poddoor/almayer/open{
@@ -67336,11 +66896,6 @@
 	icon_state = "blue"
 	},
 /area/almayer/living/port_emb)
-"sZX" = (
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "tab" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/storage/box/flashbangs{
@@ -67646,6 +67201,17 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/lobby)
+"tfE" = (
+/obj/structure/surface/rack,
+/obj/item/storage/firstaid/adv{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/execution_storage)
 "tfH" = (
 /obj/structure/machinery/light/containment,
 /obj/effect/decal/warning_stripes{
@@ -67659,6 +67225,21 @@
 /obj/structure/machinery/light/small,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_a_p)
+"tfZ" = (
+/obj/structure/reagent_dispensers/water_cooler/stacks{
+	density = 0;
+	pixel_x = -7;
+	pixel_y = 17
+	},
+/obj/structure/sign/safety/cryo{
+	pixel_x = 12;
+	pixel_y = 28
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "tge" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 4
@@ -67701,6 +67282,9 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/port_midship_hallway)
+"tgJ" = (
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/warden_office)
 "tgK" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -67947,21 +67531,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_a_p)
-"tjI" = (
-/obj/structure/reagent_dispensers/water_cooler/stacks{
-	density = 0;
-	pixel_x = -7;
-	pixel_y = 17
-	},
-/obj/structure/sign/safety/cryo{
-	pixel_x = 12;
-	pixel_y = 28
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "tjO" = (
 /obj/structure/janitorialcart,
 /obj/item/tool/mop,
@@ -68031,15 +67600,6 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/shipboard/brig/general_equipment)
-"tlm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/starboard_hallway)
 "tln" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 5
@@ -68106,18 +67666,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/port_midship_hallway)
-"tmG" = (
-/obj/structure/transmitter{
-	name = "Brig Offices Telephone";
-	phone_category = "MP Dept.";
-	phone_id = "Brig Main Offices";
-	pixel_y = 32
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "tmH" = (
 /obj/structure/pipes/vents/pump,
 /obj/structure/machinery/camera/autoname/almayer{
@@ -68307,15 +67855,6 @@
 "tpn" = (
 /turf/closed/wall/almayer,
 /area/almayer/shipboard/brig/evidence_storage)
-"tpx" = (
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "tpB" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -68581,22 +68120,6 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/powered/agent)
-"ttq" = (
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_x = -8;
-	pixel_y = 18
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_x = 8;
-	pixel_y = 18
-	},
-/obj/item/device/taperecorder,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/interrogation)
 "tty" = (
 /obj/structure/surface/table/almayer,
 /obj/item/clipboard,
@@ -68725,15 +68248,6 @@
 	icon_state = "orange"
 	},
 /area/almayer/hallways/hangar)
-"tuW" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 8;
-	id = "Interrogation Shutters";
-	name = "\improper Privacy Shutters"
-	},
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/interrogation)
 "tuZ" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -68776,6 +68290,16 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/u_a_s)
+"tvJ" = (
+/obj/structure/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "tvM" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -69006,12 +68530,6 @@
 	icon_state = "mono"
 	},
 /area/almayer/hallways/upper/aft_hallway)
-"tzK" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "tzL" = (
 /obj/structure/sign/safety/waterhazard{
 	pixel_x = 8;
@@ -69097,6 +68615,18 @@
 	icon_state = "mono"
 	},
 /area/almayer/lifeboat_pumps/south1)
+"tBP" = (
+/obj/structure/surface/table/almayer,
+/obj/item/storage/fancy/cigarettes/lucky_strikes,
+/obj/item/tool/lighter,
+/obj/item/clothing/glasses/sunglasses/blindfold,
+/obj/structure/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/execution_storage)
 "tBU" = (
 /obj/structure/platform,
 /obj/structure/largecrate/random/case/double{
@@ -69417,9 +68947,6 @@
 /area/almayer/shipboard/brig/cells)
 "tId" = (
 /obj/structure/machinery/recharge_station,
-/turf/open/floor/almayer{
-	icon_state = "cargo"
-	},
 /area/almayer/command/airoom)
 "tIe" = (
 /obj/structure/machinery/camera/autoname/almayer{
@@ -69535,9 +69062,6 @@
 /obj/structure/machinery/cryopod/right{
 	layer = 3.1;
 	pixel_y = 13
-	},
-/turf/open/floor/almayer{
-	icon_state = "cargo"
 	},
 /area/almayer/command/airoom)
 "tJR" = (
@@ -69957,6 +69481,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/u_a_s)
+"tTO" = (
+/obj/structure/machinery/photocopier,
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "tUh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -69973,6 +69504,17 @@
 "tUx" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cells)
+"tUK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "tUN" = (
 /obj/structure/machinery/door/airlock/almayer/maint/reinforced{
 	access_modified = 1;
@@ -70388,9 +69930,6 @@
 	icon_state = "E";
 	pixel_x = 1
 	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
 "ubI" = (
 /obj/structure/surface/table/almayer,
@@ -70488,25 +70027,6 @@
 	icon_state = "red"
 	},
 /area/almayer/living/briefing)
-"udo" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "NW-out"
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/sign/safety/ammunition{
-	pixel_x = 15;
-	pixel_y = -32
-	},
-/obj/structure/sign/safety/hazard{
-	pixel_y = -32
-	},
-/obj/structure/machinery/power/apc/almayer{
-	dir = 8
-	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/execution)
 "udr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -70670,6 +70190,17 @@
 /obj/structure/machinery/cm_vending/sorted/marine_food,
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
+"ugw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "redcorner"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "ugJ" = (
 /obj/structure/largecrate/random/case/small,
 /obj/structure/largecrate/random/mini/small_case{
@@ -70722,6 +70253,12 @@
 	icon_state = "redfull"
 	},
 /area/almayer/hallways/lower/starboard_midship_hallway)
+"uhA" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "uhE" = (
 /obj/structure/closet/secure_closet/guncabinet/red/mp_armory_m4ra_rifle,
 /turf/open/floor/plating/plating_catwalk,
@@ -70872,27 +70409,6 @@
 	icon_state = "plating_striped"
 	},
 /area/almayer/squads/req)
-"ulB" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/door_control{
-	id = "Interrogation Shutters";
-	name = "\improper Shutters";
-	pixel_x = -6;
-	pixel_y = -6;
-	req_access_txt = "3"
-	},
-/obj/item/device/taperecorder{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/structure/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/interrogation)
 "ulH" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 8
@@ -71039,15 +70555,6 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
-"unY" = (
-/obj/structure/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/interrogation)
 "unZ" = (
 /obj/structure/platform{
 	dir = 1
@@ -71384,6 +70891,14 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/bravo)
+"uun" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "uuu" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -71582,16 +71097,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cic_hallway)
-"uwV" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
-/obj/structure/pipes/vents/pump,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "uwZ" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -71689,12 +71194,6 @@
 	icon_state = "red"
 	},
 /area/almayer/hallways/upper/starboard)
-"uyn" = (
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/warden_office)
 "uys" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/squads/req)
@@ -71732,6 +71231,22 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/ce_room)
+"uzH" = (
+/obj/structure/machinery/door/airlock/almayer/medical/glass{
+	name = "\improper Brig Medbay";
+	req_access = null;
+	req_one_access = null;
+	req_one_access_txt = "20;3";
+	closeOtherId = "brigmed"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/medical)
 "uAb" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out"
@@ -71978,15 +71493,6 @@
 	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
-"uEd" = (
-/obj/structure/machinery/status_display{
-	pixel_y = 30
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "uEO" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -72068,9 +71574,6 @@
 /obj/effect/landmark/map_item,
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
-"uFI" = (
-/turf/closed/wall/almayer/outer,
-/area/almayer/shipboard/brig/execution_storage)
 "uGc" = (
 /obj/structure/machinery/suit_storage_unit/compression_suit/uscm,
 /obj/structure/sign/safety/hazard{
@@ -72276,6 +71779,13 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/starboard_point_defense)
+"uLE" = (
+/obj/structure/machinery/cm_vending/sorted/medical/blood,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "sterile_green_side"
+	},
+/area/almayer/shipboard/brig/medical)
 "uLG" = (
 /obj/structure/closet/crate/freezer{
 	desc = "A freezer crate. Someone has written 'open on christmas' in marker on the top."
@@ -72524,17 +72034,6 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
-"uRx" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_21";
-	pixel_y = 16
-	},
-/obj/structure/surface/table/almayer,
-/turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "uRD" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -72839,14 +72338,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_a_p)
-"uVv" = (
-/obj/structure/pipes/standard/manifold/hidden/supply/no_boom{
-	dir = 1
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
-/area/almayer/command/airoom)
 "uVA" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -72863,23 +72354,6 @@
 	icon_state = "plating_striped"
 	},
 /area/almayer/living/cryo_cells)
-"uVF" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/recharger,
-/obj/structure/sign/safety/terminal{
-	pixel_y = 32
-	},
-/obj/structure/transmitter/rotary{
-	name = "Brig Wardens's Office Telephone";
-	phone_category = "MP Dept.";
-	phone_id = "Brig Warden's Office";
-	pixel_x = 15
-	},
-/turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/warden_office)
 "uVV" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -72977,6 +72451,22 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_f_p)
+"uXu" = (
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	id = "Interrogation Shutters";
+	name = "\improper Privacy Shutters"
+	},
+/obj/structure/machinery/door/airlock/almayer/security{
+	dir = 2;
+	name = "\improper Interrogation"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/interrogation)
 "uXL" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -73131,6 +72621,9 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/medical/lower_medical_medbay)
+"vaS" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/mp_bunks)
 "vaV" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -73425,11 +72918,6 @@
 	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
-"vfB" = (
-/turf/open/floor/almayer/no_build{
-	dir = 4
-	},
-/area/almayer/command/airoom)
 "vfP" = (
 /turf/open/floor/almayer/research/containment/corner{
 	dir = 1
@@ -73543,9 +73031,6 @@
 /obj/item/folder/white,
 /obj/item/folder/white,
 /obj/item/folder/white,
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
 "vhw" = (
 /obj/structure/disposalpipe/trunk{
@@ -73644,9 +73129,6 @@
 /obj/structure/pipes/standard/manifold/hidden/supply/no_boom{
 	dir = 1
 	},
-/turf/open/floor/plating/plating_catwalk{
-	allow_construction = 0
-	},
 /area/almayer/command/airoom)
 "viJ" = (
 /obj/structure/machinery/door/airlock/almayer/maint,
@@ -73729,6 +73211,12 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/engineering/lower/workshop/hangar)
+"vjB" = (
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
+	pixel_y = 25
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/starboard_hallway)
 "vjC" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -74058,16 +73546,6 @@
 	icon_state = "orange"
 	},
 /area/almayer/hallways/upper/stern_hallway)
-"voa" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/secure_data{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/warden_office)
 "vop" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -74641,6 +74119,22 @@
 /obj/structure/machinery/light,
 /turf/open/floor/almayer,
 /area/almayer/hallways/hangar)
+"vxh" = (
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 2;
+	id = "Warden Office Shutters";
+	name = "\improper Privacy Shutters"
+	},
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	dir = 1;
+	name = "\improper Warden's Office";
+	closeOtherId = "brigwarden"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/warden_office)
 "vxu" = (
 /obj/structure/machinery/meter,
 /obj/structure/pipes/standard/simple/visible{
@@ -74785,6 +74279,19 @@
 "vzp" = (
 /turf/open/floor/almayer/research/containment/entrance,
 /area/almayer/medical/containment/cell/cl)
+"vzy" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "vzz" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	dir = 1;
@@ -74908,15 +74415,8 @@
 	},
 /area/almayer/medical/medical_science)
 "vAU" = (
-/obj/structure/machinery/light{
-	dir = 8
-	},
 /obj/structure/pipes/vents/scrubber/no_boom{
 	dir = 4
-	},
-/turf/open/floor/almayer/no_build{
-	dir = 8;
-	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "vBp" = (
@@ -75193,6 +74693,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_f_p)
+"vGn" = (
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/interrogation)
 "vGA" = (
 /obj/structure/bed/sofa/south/grey/right,
 /turf/open/floor/almayer{
@@ -75227,20 +74733,6 @@
 	icon_state = "plating"
 	},
 /area/almayer/command/airoom)
-"vHf" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
-/obj/structure/surface/table/almayer,
-/obj/item/toy/deck/uno,
-/obj/item/toy/deck{
-	pixel_x = -9
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "vHh" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/item/tool/warning_cone{
@@ -75404,6 +74896,12 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/command/cichallway)
+"vJc" = (
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/warden_office)
 "vJg" = (
 /obj/structure/machinery/light/small,
 /turf/open/floor/almayer{
@@ -75474,6 +74972,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
+"vKF" = (
+/obj/structure/machinery/cm_vending/sorted/medical,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "sterile_green_side"
+	},
+/area/almayer/shipboard/brig/medical)
 "vKI" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -75580,6 +75085,20 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/cichallway)
+"vMJ" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/door/airlock/almayer/security/glass{
+	name = "\improper Brig Breakroom"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	layer = 1.9
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "vMM" = (
 /obj/structure/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -75601,12 +75120,6 @@
 	icon_state = "redcorner"
 	},
 /area/almayer/hallways/lower/port_fore_hallway)
-"vMZ" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/mp_bunks)
 "vNp" = (
 /obj/structure/sign/safety/three{
 	pixel_x = -17
@@ -75617,18 +75130,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cells)
-"vNs" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 1
-	},
-/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
-	name = "\improper Brig Lobby";
-	closeOtherId = "brignorth"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "vND" = (
 /obj/structure/bed/chair{
 	dir = 8;
@@ -75636,11 +75137,16 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/charlie)
-"vNV" = (
-/turf/open/floor/almayer{
-	icon_state = "red"
+"vNT" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 1
 	},
-/area/almayer/shipboard/brig/mp_bunks)
+/obj/structure/disposalpipe/segment,
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "vNW" = (
 /turf/open/floor/almayer/uscm/directional{
 	dir = 9
@@ -75650,22 +75156,17 @@
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north2)
-"vOj" = (
-/obj/item/device/camera{
-	pixel_x = 4;
+"vOu" = (
+/obj/structure/surface/table/almayer,
+/obj/item/weapon/gun/energy/taser,
+/obj/item/weapon/gun/energy/taser{
 	pixel_y = 8
 	},
-/obj/structure/surface/table/almayer,
-/obj/item/device/camera_film{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/obj/item/device/camera_film,
+/obj/structure/machinery/recharger,
 /turf/open/floor/almayer{
-	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/starboard_hallway)
+/area/almayer/shipboard/brig/mp_bunks)
 "vOw" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/toolbox,
@@ -76095,6 +75596,12 @@
 /obj/structure/machinery/light,
 /turf/open/floor/almayer,
 /area/almayer/command/lifeboat)
+"vUI" = (
+/obj/structure/bed/chair/comfy/orange{
+	dir = 8
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/warden_office)
 "vUJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -76122,9 +75629,6 @@
 "vUP" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/shipboard/brig/cic_hallway)
-"vUV" = (
-/turf/closed/wall/almayer,
-/area/almayer/shipboard/brig/starboard_hallway)
 "vVb" = (
 /obj/structure/machinery/cm_vending/gear/tl{
 	density = 0;
@@ -76341,9 +75845,6 @@
 /obj/structure/machinery/computer/working_joe{
 	dir = 4;
 	pixel_x = -17
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "vXk" = (
@@ -76853,18 +76354,6 @@
 	icon_state = "cargo"
 	},
 /area/almayer/living/offices)
-"wfc" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/fancy/cigarettes/lucky_strikes,
-/obj/item/tool/lighter,
-/obj/item/clothing/glasses/sunglasses/blindfold,
-/obj/structure/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/execution_storage)
 "wfn" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/almayer{
@@ -76927,23 +76416,6 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/cichallway)
-"wgM" = (
-/obj/structure/window/framed/almayer/hull/hijack_bustable,
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 4;
-	id = "Warden Office Shutters";
-	name = "\improper Privacy Shutters"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 8
-	},
-/obj/structure/machinery/door/poddoor/almayer/open{
-	dir = 4;
-	id = "courtyard_cells";
-	name = "\improper Courtyard Lockdown Shutter"
-	},
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/warden_office)
 "wgO" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -76987,6 +76459,15 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/cichallway)
+"whQ" = (
+/obj/structure/closet/secure_closet/personal/cabinet{
+	req_access = null
+	},
+/obj/item/storage/donut_box{
+	pixel_y = 8
+	},
+/turf/open/floor/wood/ship,
+/area/almayer/shipboard/brig/warden_office)
 "wid" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/maint/hull/lower/p_bow)
@@ -77207,15 +76688,6 @@
 	alert_message = "Caution: Movement detected in ARES Core.";
 	cooldown_duration = 1200
 	},
-/obj/structure/machinery/door/poddoor/almayer/blended/white/open{
-	closed_layer = 3.2;
-	id = "ARES Emergency";
-	layer = 3.2;
-	name = "ARES Emergency Lockdown";
-	needs_power = 0;
-	open_layer = 1.9;
-	plane = -7
-	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "test_floor4"
 	},
@@ -77241,6 +76713,27 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/hangar)
+"wlg" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/door_control{
+	id = "Interrogation Shutters";
+	name = "\improper Shutters";
+	pixel_x = -6;
+	pixel_y = -6;
+	req_access_txt = "3"
+	},
+/obj/item/device/taperecorder{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/structure/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/interrogation)
 "wlh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -77349,10 +76842,6 @@
 	icon_state = "cargo"
 	},
 /area/almayer/living/bridgebunks)
-"wnh" = (
-/obj/structure/window/framed/almayer/white/hull,
-/turf/open/floor/plating,
-/area/almayer/command/airoom)
 "wnw" = (
 /obj/structure/machinery/flasher{
 	id = "Perma 2";
@@ -77876,9 +77365,6 @@
 	icon_state = "cargo"
 	},
 /area/almayer/squads/charlie)
-"wwt" = (
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/mp_bunks)
 "wwv" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -77957,12 +77443,23 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/starboard_aft_hallway)
-"wxO" = (
+"wxF" = (
+/obj/structure/closet/secure_closet/cmdcabinet{
+	desc = "A bulletproof cabinet containing communications equipment.";
+	name = "communications cabinet";
+	pixel_y = 24;
+	req_access = null;
+	req_one_access_txt = "3"
+	},
+/obj/item/device/radio/listening_bug/radio_linked/mp{
+	pixel_y = 8
+	},
+/obj/item/device/radio/listening_bug/radio_linked/mp,
 /turf/open/floor/almayer{
-	dir = 4;
+	dir = 5;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/mp_bunks)
+/area/almayer/shipboard/brig/warden_office)
 "wxU" = (
 /obj/item/ashtray/bronze{
 	pixel_x = 7;
@@ -78035,32 +77532,10 @@
 	icon_state = "plating"
 	},
 /area/almayer/command/airoom)
-"wzg" = (
-/obj/structure/machinery/door_control{
-	id = "firearm_storage_armory";
-	name = "Armory Lockdown";
-	pixel_y = 24;
-	req_access_txt = "4"
-	},
-/obj/structure/sign/safety/ammunition{
-	pixel_y = 32
-	},
-/obj/structure/sign/safety/restrictedarea{
-	pixel_x = 15;
-	pixel_y = 32
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "wzy" = (
 /obj/effect/step_trigger/clone_cleaner,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/port_fore_hallway)
-"wzE" = (
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/warden_office)
 "wzJ" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -78161,9 +77636,6 @@
 	},
 /obj/structure/stairs{
 	dir = 1
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "wDg" = (
@@ -78342,6 +77814,9 @@
 	icon_state = "redfull"
 	},
 /area/almayer/command/cic)
+"wFs" = (
+/turf/closed/wall/almayer,
+/area/almayer/shipboard/brig/starboard_hallway)
 "wFz" = (
 /obj/item/prop{
 	desc = "Predecessor to the M56 the M38 was known for its extreme reliability in the field. This particular M38D is fondly remembered for its stalwart defence of the hangar bay during the Arcturian commando raid of the USS Almayer on Io.";
@@ -78365,6 +77840,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/panic)
+"wFQ" = (
+/obj/structure/machinery/cm_vending/clothing/maintenance_technician,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/engineering/upper_engineering/port)
 "wFR" = (
 /turf/open/floor/almayer,
 /area/almayer/living/gym)
@@ -78503,12 +77984,6 @@
 	icon_state = "silvercorner"
 	},
 /area/almayer/shipboard/brig/cic_hallway)
-"wIR" = (
-/obj/structure/machinery/light,
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "wIX" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -78553,9 +78028,6 @@
 /area/almayer/medical/upper_medical)
 "wJB" = (
 /obj/structure/machinery/cryopod/right,
-/turf/open/floor/almayer{
-	icon_state = "cargo"
-	},
 /area/almayer/command/airoom)
 "wJC" = (
 /obj/structure/largecrate/random/barrel/yellow,
@@ -78588,6 +78060,15 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/u_f_s)
+"wKc" = (
+/obj/effect/decal/cleanable/vomit,
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_21"
+	},
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/engineering/upper_engineering/port)
 "wKm" = (
 /obj/item/device/radio/intercom{
 	freerange = 1;
@@ -78726,6 +78207,20 @@
 	icon_state = "sterile_green"
 	},
 /area/almayer/medical/containment)
+"wLS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "wMl" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 8;
@@ -79236,6 +78731,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/grunt_rnr)
+"wVh" = (
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/warden_office)
 "wVm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -79379,6 +78881,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_a_p)
+"wXz" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/starboard_hallway)
 "wXH" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -79759,16 +79267,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/lower/workshop)
-"xem" = (
-/obj/structure/bed/chair{
-	dir = 8;
-	pixel_y = 3
-	},
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "xeq" = (
 /obj/structure/sign/safety/distribution_pipes{
 	pixel_x = 8;
@@ -79813,21 +79311,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_a_p)
-"xfA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/machinery/power/apc/almayer,
-/obj/structure/sign/safety/rewire{
-	pixel_y = -38
-	},
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "xfK" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -79882,19 +79365,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_m_s)
-"xgc" = (
-/obj/structure/closet/secure_closet{
-	name = "\improper Lethal Injection Locker"
-	},
-/obj/item/reagent_container/ld50_syringe/choral,
-/obj/item/reagent_container/ld50_syringe/choral,
-/obj/item/reagent_container/ld50_syringe/choral,
-/obj/item/reagent_container/ld50_syringe/choral,
-/obj/item/reagent_container/ld50_syringe/choral,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/execution_storage)
 "xgh" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 4
@@ -80016,6 +79486,10 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/bravo)
+"xhU" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/starboard_hallway)
 "xhW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -80280,7 +79754,6 @@
 	},
 /obj/effect/landmark/late_join/working_joe,
 /obj/effect/landmark/start/working_joe,
-/turf/open/floor/plating/plating_catwalk,
 /area/almayer/command/airoom)
 "xnz" = (
 /obj/effect/decal/warning_stripes{
@@ -80403,6 +79876,14 @@
 	icon_state = "blue"
 	},
 /area/almayer/hallways/lower/port_midship_hallway)
+"xpw" = (
+/obj/structure/machinery/medical_pod/sleeper{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
+/area/almayer/shipboard/brig/medical)
 "xpL" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -80734,10 +80215,6 @@
 	req_one_access_txt = "90;91;92"
 	},
 /obj/effect/step_trigger/clone_cleaner,
-/turf/open/floor/almayer/no_build{
-	dir = 4;
-	icon_state = "silver"
-	},
 /area/almayer/command/airoom)
 "xvO" = (
 /obj/structure/disposalpipe/segment{
@@ -81027,6 +80504,9 @@
 	icon_state = "mono"
 	},
 /area/almayer/lifeboat_pumps/south2)
+"xyN" = (
+/turf/closed/wall/almayer/reinforced,
+/area/almayer/shipboard/brig/execution_storage)
 "xyQ" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -81213,22 +80693,6 @@
 	icon_state = "silver"
 	},
 /area/almayer/shipboard/brig/cic_hallway)
-"xDu" = (
-/obj/structure/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/almayer{
-	dir = 6;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
-"xDC" = (
-/obj/structure/pipes/standard/simple/hidden/supply/no_boom,
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
-/area/almayer/command/airoom)
 "xDF" = (
 /obj/structure/machinery/autolathe,
 /turf/open/floor/almayer{
@@ -81481,17 +80945,6 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/processing)
-"xIO" = (
-/obj/structure/machinery/optable,
-/obj/structure/sign/safety/medical{
-	pixel_x = 8;
-	pixel_y = 29
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "sterile_green_corner"
-	},
-/area/almayer/shipboard/brig/medical)
 "xIQ" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -81727,17 +81180,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/panic)
-"xMJ" = (
-/obj/structure/surface/rack,
-/obj/item/storage/firstaid/adv{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/execution_storage)
 "xML" = (
 /obj/structure/machinery/computer/cameras/wooden_tv/prop{
 	pixel_x = -4;
@@ -81891,22 +81333,6 @@
 	dir = 4
 	},
 /area/almayer/medical/containment/cell)
-"xPi" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 2;
-	id = "Warden Office Shutters";
-	name = "\improper Privacy Shutters"
-	},
-/obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	dir = 1;
-	name = "\improper Warden's Office";
-	closeOtherId = "brigwarden"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/warden_office)
 "xPn" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out";
@@ -82003,12 +81429,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/lower/port_aft_hallway)
-"xQV" = (
-/obj/effect/step_trigger/clone_cleaner,
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
-/area/almayer/command/airoom)
 "xQW" = (
 /obj/structure/sign/safety/bathunisex{
 	pixel_x = -18
@@ -82278,9 +81698,6 @@
 	pixel_x = 24;
 	pixel_y = 24;
 	req_one_access_txt = "90;91;92"
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "xVe" = (
@@ -82609,9 +82026,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 9
 	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
 "yaR" = (
 /obj/structure/disposalpipe/segment{
@@ -82638,15 +82052,6 @@
 	icon_state = "cargo_arrow"
 	},
 /area/almayer/hallways/lower/vehiclehangar)
-"yaZ" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S";
-	layer = 3.3
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
-/area/almayer/command/airoom)
 "ybk" = (
 /turf/closed/wall/almayer,
 /area/almayer/hallways/upper/stern_hallway)
@@ -82815,9 +82220,6 @@
 	icon_state = "W";
 	pixel_x = -1
 	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
-	},
 /area/almayer/command/airoom)
 "ydM" = (
 /obj/structure/window{
@@ -82950,6 +82352,28 @@
 	icon_state = "silver"
 	},
 /area/almayer/maint/hull/upper/u_m_p)
+"yfO" = (
+/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	name = "\improper Warden's Office";
+	closeOtherId = "brigwarden"
+	},
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 4;
+	id = "Warden Office Shutters";
+	name = "\improper Privacy Shutters"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 8
+	},
+/obj/structure/machinery/door/poddoor/almayer/open{
+	dir = 4;
+	id = "courtyard_cells";
+	name = "\improper Courtyard Lockdown Shutter"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/warden_office)
 "yfS" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -83027,18 +82451,21 @@
 	icon_state = "red"
 	},
 /area/almayer/lifeboat_pumps/south1)
-"yhO" = (
-/turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "cargo"
-	},
-/area/almayer/engineering/upper_engineering/port)
 "yhR" = (
 /obj/structure/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_m_s)
+"yhV" = (
+/obj/structure/machinery/door/airlock/almayer/generic{
+	dir = 1;
+	name = "Bathroom"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "yhZ" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/maint/hull/lower/p_bow)
@@ -83055,14 +82482,8 @@
 	},
 /area/almayer/maint/hull/lower/l_m_s)
 "yit" = (
-/obj/structure/machinery/light{
-	dir = 4
-	},
 /obj/structure/pipes/vents/pump/no_boom{
 	dir = 1
-	},
-/turf/open/floor/almayer/no_build{
-	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "yiW" = (
@@ -90642,13 +90063,13 @@ dhd
 oog
 jNT
 fag
-jjH
+qCA
 feb
-uFI
-uFI
-uFI
-uFI
-uFI
+hRu
+hRu
+hRu
+hRu
+hRu
 ajZ
 aaa
 aaa
@@ -90846,12 +90267,12 @@ nPb
 fZX
 dBS
 nSu
-udo
-cHp
-xgc
-wfc
-xMJ
-uFI
+rXE
+xyN
+ltO
+tBP
+tfE
+hRu
 aag
 aaf
 ajY
@@ -91050,11 +90471,11 @@ qVF
 xdJ
 kzr
 jqY
-kPf
-etW
-etW
-ewP
-uFI
+elV
+dJJ
+dJJ
+glP
+hRu
 xiV
 xiV
 ajZ
@@ -91253,11 +90674,11 @@ mtl
 mtl
 mtl
 ewI
-cHp
-sMp
-edJ
-kCY
-cHp
+xyN
+hdQ
+hUU
+cXD
+xyN
 igS
 xiV
 xiV
@@ -91456,11 +90877,11 @@ tul
 mNK
 gtU
 bjk
-cHp
-cHp
-cHp
-cHp
-cHp
+xyN
+xyN
+xyN
+xyN
+xyN
 iuf
 pnh
 xiV
@@ -92046,13 +91467,13 @@ uDg
 uDg
 gkr
 xkc
-rtP
-rtP
-rtP
-rtP
-rtP
-slb
-aii
+hvd
+hvd
+hvd
+hvd
+hvd
+mze
+eyD
 naB
 kry
 pHp
@@ -92249,13 +91670,13 @@ uDg
 pOp
 gkr
 cth
-rtP
-awb
-ulB
-cXv
-rtP
-sDp
-jme
+hvd
+ddj
+wlg
+fuY
+hvd
+cQG
+jXc
 naB
 pQr
 bsp
@@ -92452,13 +91873,13 @@ uDg
 lDT
 xkc
 xyZ
-rtP
-hjq
-jDx
-jDx
-lit
-sDp
-hbD
+hvd
+vGn
+ehl
+ehl
+uXu
+cQG
+alp
 naB
 naB
 naB
@@ -92654,20 +92075,20 @@ aag
 uDg
 xkc
 gkr
-rtP
-rtP
-tuW
-tuW
-tuW
-rtP
-uwV
-bvL
-oYb
-vOj
-mcJ
-rKh
-qXG
-vUV
+hvd
+hvd
+iRp
+iRp
+iRp
+hvd
+cyc
+vzy
+fqQ
+kHo
+sFu
+hnE
+tTO
+wFs
 nkX
 iQB
 cmv
@@ -92857,20 +92278,20 @@ aag
 lrE
 xkc
 gkr
-rtP
-ttq
-iSL
-bcW
-bcW
-rtP
-dOf
-fFV
-mfk
-dVE
-dVE
-fDw
-jTE
-edW
+hvd
+iUX
+gii
+gIO
+gIO
+hvd
+gYx
+oyC
+bKI
+xhU
+xhU
+jCX
+sEz
+iNh
 wdF
 wdF
 wdF
@@ -93060,20 +92481,20 @@ aag
 lrE
 gkr
 xkc
-rtP
-ttq
-pdR
-unY
-kVE
-fnO
-sDp
-sDp
-oRG
-mJI
-mJI
-jTE
-mJI
-kzv
+hvd
+iUX
+gJE
+cKJ
+hyV
+keG
+cQG
+cQG
+ugw
+cwC
+cwC
+sEz
+cwC
+uun
 oRk
 oRk
 oRk
@@ -93270,8 +92691,8 @@ lrq
 lrq
 lrq
 lrq
-tzK
-nVG
+uhA
+aaP
 tpn
 tpn
 srT
@@ -93473,8 +92894,8 @@ cAy
 uhE
 vKB
 lrq
-rQP
-bxD
+vjB
+gIz
 tpn
 eVR
 cak
@@ -93676,8 +93097,8 @@ nqe
 nqe
 nqe
 tLa
-sDp
-xfA
+cQG
+gfd
 tpn
 rqS
 cak
@@ -93879,8 +93300,8 @@ pId
 qMD
 uqo
 lrq
-wzg
-oqN
+nVm
+dRA
 tpn
 gIU
 xIq
@@ -94082,8 +93503,8 @@ nqe
 nqe
 nqe
 mza
-sDp
-hkr
+cQG
+qvE
 tpn
 tpn
 tpn
@@ -94285,13 +93706,13 @@ fxJ
 fAr
 qmU
 lrq
-tmG
-hPx
-qHP
-kxU
-xIO
-sLT
-kxU
+dmr
+wLS
+aVm
+cmM
+miy
+iUG
+cmM
 snX
 oIh
 oIh
@@ -94488,13 +93909,13 @@ iwV
 iwV
 lrq
 lrq
-nCZ
-hPx
-nkA
-kxU
-kwX
-dXm
-bvu
+kXt
+wLS
+eBx
+cmM
+hAf
+cNI
+bbi
 wdF
 wdF
 wdF
@@ -94691,13 +94112,13 @@ bvH
 evR
 cQv
 cQv
-maB
-qoX
-kxU
-kxU
-ePA
-kEw
-kxU
+rmk
+nuZ
+cmM
+cmM
+pdT
+otp
+cmM
 tzd
 tzd
 sgi
@@ -94894,13 +94315,13 @@ kde
 ajj
 mZQ
 cQv
-nNW
-bWD
-esq
-ked
-huN
-sqO
-esq
+dFl
+tUK
+kTp
+sYl
+fgt
+kCY
+kTp
 gHt
 oIh
 eNR
@@ -95097,13 +94518,13 @@ quj
 vgi
 rXd
 cqJ
-ibl
-bWD
-esq
-iFS
-mIZ
-gWi
-esq
+oJm
+tUK
+kTp
+hUh
+nWS
+xpw
+kTp
 neC
 mjt
 vqc
@@ -95300,13 +94721,13 @@ lEe
 pGT
 pGT
 vkM
-sXx
-lFd
-kxU
-rCd
-aSz
-rCd
-rCd
+ksm
+bxE
+cmM
+oeZ
+uzH
+oeZ
+oeZ
 ptq
 oRk
 eNR
@@ -95503,13 +94924,13 @@ vyH
 ajj
 rXd
 cqJ
-ibl
-bWD
-esq
-jFP
-mIZ
-bPb
-rCd
+oJm
+tUK
+kTp
+uLE
+nWS
+cTy
+oeZ
 emp
 emp
 emp
@@ -95706,13 +95127,13 @@ sBg
 uGN
 rXd
 cQv
-uEd
-bWD
-esq
-lCN
-mIZ
-sge
-rCd
+mAY
+tUK
+kTp
+hoW
+nWS
+aIY
+oeZ
 cFC
 oIh
 lUm
@@ -95909,13 +95330,13 @@ kde
 ajj
 tuk
 cQv
-sTe
-bWD
-esq
-dNm
-mIZ
-asd
-rCd
+kYU
+tUK
+kTp
+vKF
+nWS
+glG
+oeZ
 ehX
 mTN
 hZJ
@@ -96112,13 +95533,13 @@ ioV
 cQv
 tlk
 cQv
-tzK
-frG
-rCd
-rCd
-aSz
-rCd
-rCd
+uhA
+bKN
+oeZ
+oeZ
+uzH
+oeZ
+oeZ
 mFc
 eKa
 emp
@@ -96132,12 +95553,12 @@ bQc
 pgP
 uVV
 iBl
-oGl
-wgM
-wgM
-oGl
-czm
-oGl
+cHk
+rkV
+rkV
+cHk
+yfO
+cHk
 pRs
 pdp
 xiV
@@ -96313,11 +95734,11 @@ rdM
 gUg
 cov
 cqJ
-uRx
-iqO
-hHK
-tlm
-aii
+may
+hoK
+mcp
+hzG
+eyD
 ngr
 cDN
 peO
@@ -96335,12 +95756,12 @@ emp
 lFJ
 emp
 emp
-oGl
-uVF
-voa
-fOm
-clD
-oGl
+cHk
+hlI
+ekZ
+kvL
+oix
+cHk
 uxb
 oDh
 pdp
@@ -96516,11 +95937,11 @@ vxM
 vxM
 vxM
 vxM
-tjI
-sDp
-sDp
-tlm
-aii
+tfZ
+cQG
+cQG
+hzG
+eyD
 tdy
 cDN
 oFY
@@ -96538,13 +95959,13 @@ qUz
 ksg
 oIh
 iTl
-oGl
-gmm
-bYp
-bHw
-fpO
-oGl
-oGl
+cHk
+frt
+vUI
+tgJ
+wVh
+cHk
+cHk
 oDh
 pdp
 xiV
@@ -96719,11 +96140,11 @@ kGu
 iqR
 fyp
 wJh
-ibl
-sDp
-sDp
-tlm
-vNs
+oJm
+cQG
+cQG
+hzG
+asC
 tff
 cDN
 oFY
@@ -96741,13 +96162,13 @@ oDy
 wsq
 vxK
 gwj
-xPi
-iiX
-iiX
-pPn
-wzE
-mGV
-oGl
+vxh
+csy
+csy
+bWQ
+deH
+szG
+cHk
 pdp
 kIf
 xiV
@@ -96922,11 +96343,11 @@ wee
 wee
 fRS
 wJh
-oOG
-sXx
-oEA
-jEk
-joN
+iFK
+ksm
+haY
+kaQ
+vNT
 oSC
 uFq
 wsl
@@ -96944,13 +96365,13 @@ mBx
 utZ
 pyj
 jPP
-oGl
-aIN
-uyn
-neh
-hco
-fGU
-oGl
+cHk
+wxF
+vJc
+kUg
+ifz
+fyI
+cHk
 pdp
 ome
 xiV
@@ -97125,11 +96546,11 @@ rDQ
 rDQ
 rDQ
 ctT
-rgQ
-iOx
-xDu
-aii
-aii
+wXz
+aNW
+tvJ
+eyD
+eyD
 tsX
 tsX
 epu
@@ -97150,10 +96571,10 @@ lnh
 wIC
 rWn
 rWn
-oGl
-oGl
-kfa
-oGl
+cHk
+cHk
+gxt
+cHk
 dJy
 aCA
 xiV
@@ -97328,10 +96749,10 @@ sbP
 sbP
 sbP
 wJh
-heg
-wIR
-aii
-aii
+oWK
+jwr
+eyD
+eyD
 tHr
 mqg
 udR
@@ -97354,9 +96775,9 @@ dgx
 fKi
 vxG
 wIC
-puz
-meG
-oGl
+whQ
+bHu
+cHk
 oLf
 hIG
 xiV
@@ -97531,9 +96952,9 @@ ncf
 kjk
 qxr
 wJh
-heg
-sZX
-dfU
+oWK
+rPF
+pfd
 ceZ
 jnD
 hUW
@@ -97557,9 +96978,9 @@ jPS
 jPS
 xrt
 wIC
-gUC
-rvf
-oGl
+aDt
+jTU
+cHk
 oDh
 xas
 xiV
@@ -97734,9 +97155,9 @@ vxM
 vxM
 vxM
 gaJ
-pva
-mne
-qDT
+vMJ
+qFX
+cAR
 vGA
 hUW
 dHd
@@ -97760,9 +97181,9 @@ qFi
 vAG
 hsj
 wIC
-oGl
-oGl
-oGl
+cHk
+cHk
+cHk
 oDh
 nEc
 xiV
@@ -97934,12 +97355,12 @@ xkc
 ode
 xkc
 gNg
-qDT
-jTK
-bjp
-eyc
-gMw
-qDT
+cAR
+dRj
+yhV
+jvc
+jEV
+cAR
 iuE
 uwN
 vka
@@ -98137,12 +97558,12 @@ cYo
 ode
 gkr
 gkr
-qDT
-qDT
-qDT
-arQ
-fAZ
-qDT
+cAR
+cAR
+cAR
+pKU
+vOu
+cAR
 udK
 mwA
 lnt
@@ -98340,12 +97761,12 @@ akC
 akC
 uvp
 gkr
-qDT
-otl
-iRC
-eyc
-bqK
-qDT
+cAR
+pbm
+qjK
+jvc
+dGT
+cAR
 bmz
 wSR
 mMV
@@ -98543,12 +97964,12 @@ bzz
 akC
 pzc
 gkr
-qDT
-pXh
-wwt
-oNG
-eTM
-qDT
+cAR
+pQI
+gym
+gSz
+cNJ
+cAR
 pZS
 pEB
 jUY
@@ -98746,12 +98167,12 @@ aHZ
 akC
 lDT
 gkr
-qDT
-dJB
-nVH
-ifR
-iio
-qDT
+cAR
+jgR
+iAg
+vaS
+bsF
+cAR
 vkR
 wsD
 jUY
@@ -98949,12 +98370,12 @@ btv
 akC
 lCm
 gkr
-qDT
-qDT
-cqZ
-ifR
-vNV
-qDT
+cAR
+cAR
+eLX
+vaS
+nCD
+cAR
 kfE
 wsD
 jUY
@@ -99153,11 +98574,11 @@ akC
 jdn
 lgk
 hMM
-qDT
-vHf
-vMZ
-tpx
-qDT
+cAR
+jlE
+cXV
+kqd
+cAR
 xDn
 pEB
 jUY
@@ -99356,11 +98777,11 @@ akC
 pek
 rir
 pek
-qDT
-xem
-wxO
-eRX
-qDT
+cAR
+gdG
+kxP
+mea
+cAR
 nNv
 pEB
 jUY
@@ -99559,11 +98980,11 @@ akC
 ibP
 loE
 cmr
-qDT
-qDT
-qDT
-qDT
-qDT
+cAR
+cAR
+cAR
+cAR
+cAR
 xSz
 pEB
 jUY
@@ -111548,7 +110969,7 @@ jZY
 jZY
 sqf
 wpu
-fEX
+okO
 ajl
 ajl
 ajl
@@ -121293,8 +120714,8 @@ lin
 oJR
 tFe
 asD
-xQV
-avK
+jvB
+kXj
 aqU
 aCZ
 dgg
@@ -121495,8 +120916,8 @@ sIf
 isC
 isC
 tFe
-xQV
-xQV
+jvB
+jvB
 rNF
 aqU
 qjF
@@ -121699,7 +121120,7 @@ pgH
 jDV
 tFe
 xVc
-xQV
+jvB
 eYz
 aqU
 gjB
@@ -122104,7 +121525,7 @@ mLE
 bUx
 mLE
 tmK
-avK
+kXj
 aug
 avL
 aqU
@@ -125772,8 +125193,8 @@ hqx
 jhm
 oIB
 jgr
-gGp
-dMf
+qUG
+rtc
 oIB
 vmu
 kNq
@@ -126989,7 +126410,7 @@ vkQ
 kzR
 oig
 oIB
-opI
+dha
 dha
 pxj
 oIB
@@ -132064,10 +131485,10 @@ pEd
 tbD
 xhi
 jWh
-dda
-yhO
+wFQ
+bop
 vyI
-pXe
+jnp
 thV
 fCL
 uIv
@@ -132267,8 +131688,8 @@ pEd
 tbD
 xhi
 jWh
-huZ
-yhO
+bXy
+bop
 vyI
 vyI
 vyI
@@ -132470,10 +131891,10 @@ mQF
 rnO
 mQF
 jWh
-dda
-yhO
+wFQ
+bop
 vyI
-cvE
+wKc
 thV
 uWV
 uIv
@@ -139816,19 +139237,19 @@ lmz
 lmz
 lmz
 lmz
-daz
-daz
-daz
-daz
-daz
-daz
-daz
-daz
-daz
-daz
-daz
-daz
-daz
+kXj
+kXj
+kXj
+kXj
+kXj
+kXj
+kXj
+kXj
+kXj
+kXj
+kXj
+kXj
+kXj
 lmz
 lmz
 lmz
@@ -140019,19 +139440,19 @@ lmz
 lmz
 lmz
 lmz
-daz
+kXj
 vhe
 fEN
 cqm
 gTH
 qit
-rna
-qQS
+kXj
+cxc
 gwn
 pfT
 jYR
 dyp
-daz
+kXj
 lmz
 lmz
 lmz
@@ -140222,19 +139643,19 @@ lmz
 sbJ
 sbJ
 sbJ
-daz
-jtj
-avK
-avK
+kXj
+eKJ
+kXj
+kXj
 sKY
-avK
+kXj
 bIp
 fKe
 dDp
 dDp
 frM
 lcg
-daz
+kXj
 lmz
 lmz
 lmz
@@ -140418,17 +139839,17 @@ lmz
 lmz
 lmz
 lmz
-daz
-daz
-daz
-daz
-daz
+kXj
+kXj
+kXj
+kXj
+kXj
 tte
 hvw
 auf
 pmV
-xDC
-xDC
+auf
+auf
 dIn
 rby
 bIp
@@ -140437,7 +139858,7 @@ sEK
 sEK
 mlb
 lcg
-daz
+kXj
 lmz
 lmz
 lmz
@@ -140620,27 +140041,27 @@ lmz
 lmz
 lmz
 lmz
-daz
-daz
+kXj
+kXj
 hRW
 asZ
 vXh
-daz
-daz
+kXj
+kXj
 kfU
-daz
-rna
-rna
+kXj
+kXj
+kXj
 lnS
-uVv
+viB
 yit
-rna
+kXj
 cxc
 kBy
 kBy
 gfu
 fPB
-daz
+kXj
 lmz
 lmz
 lmz
@@ -140822,29 +140243,29 @@ bdH
 lmz
 lmz
 lmz
-daz
-daz
-scS
-yaZ
+kXj
+kXj
+eKJ
+cxc
 ffE
-hZj
-clw
-daz
-daz
-daz
+cLo
+kXj
+kXj
+kXj
+kXj
 sGZ
-rna
-rna
+kXj
+kXj
 roH
-ebN
-ebN
-ebN
-daz
-wnh
-wnh
-daz
-daz
-daz
+kXj
+kXj
+kXj
+kXj
+mLE
+mLE
+kXj
+kXj
+kXj
 lmz
 lmz
 lmz
@@ -141025,7 +140446,7 @@ bdH
 lmz
 lmz
 lmz
-daz
+kXj
 acJ
 ubA
 cck
@@ -141035,10 +140456,10 @@ ubA
 gMN
 mRn
 itf
-mHE
+kXj
 vAU
 qwJ
-fJY
+gUN
 kzT
 wkM
 oLm
@@ -141047,7 +140468,7 @@ kKv
 kKv
 dGl
 dGl
-daz
+kXj
 lmz
 lmz
 lmz
@@ -141228,7 +140649,7 @@ bdH
 lmz
 lmz
 lmz
-daz
+kXj
 cwS
 ffE
 vHa
@@ -141238,19 +140659,19 @@ ffE
 ffE
 jqP
 cLo
-vfB
+kXj
 viB
-dIi
+auf
 qLS
-vfB
+kXj
 wkM
 jvB
 jvB
 ieF
 ieF
-pJR
 gPr
-daz
+gPr
+kXj
 lmz
 lmz
 lmz
@@ -141431,7 +140852,7 @@ bdH
 lmz
 lmz
 lmz
-daz
+kXj
 oRV
 ydI
 mdW
@@ -141453,7 +140874,7 @@ cBm
 cBm
 iZw
 dQl
-daz
+kXj
 lmz
 lmz
 lmz
@@ -141634,29 +141055,29 @@ bdH
 lmz
 lmz
 lmz
-daz
-daz
+kXj
+kXj
 eKJ
-yaZ
+cxc
 ffE
-hZj
-mUC
-daz
-daz
-daz
+cLo
+kXj
+kXj
+kXj
+kXj
 tHu
-rna
-rna
+kXj
+kXj
 gXs
-ebN
-ebN
-ebN
-daz
-wnh
-wnh
-daz
-daz
-daz
+kXj
+kXj
+kXj
+kXj
+mLE
+mLE
+kXj
+kXj
+kXj
 lmz
 lmz
 lmz
@@ -141838,27 +141259,27 @@ lmz
 lmz
 lmz
 lmz
-daz
-daz
+kXj
+kXj
 ocB
 nJH
 rnH
-daz
-daz
+kXj
+kXj
 sTV
-daz
-rna
-rna
+kXj
+kXj
+kXj
 gbg
-uVv
-erN
-rna
-qQS
+viB
+yit
+kXj
+cxc
 kBy
 kBy
 gfu
 kBy
-daz
+kXj
 lmz
 lmz
 lmz
@@ -142042,17 +141463,17 @@ lmz
 lmz
 lmz
 lmz
-daz
-daz
-daz
-daz
-daz
+kXj
+kXj
+kXj
+kXj
+kXj
 tte
 hvw
 auf
 hTl
-xDC
-xDC
+auf
+auf
 yaQ
 bat
 mFN
@@ -142061,7 +141482,7 @@ dDp
 dDp
 frM
 lcg
-daz
+kXj
 lmz
 lmz
 lmz
@@ -142248,23 +141669,23 @@ lmz
 lmz
 lmz
 lmz
-daz
+kXj
 sbJ
 sbJ
 sbJ
-daz
-jtj
-avK
-avK
+kXj
+eKJ
+kXj
+kXj
 aCd
-avK
+kXj
 mFN
 igr
 sEK
 sEK
 mlb
 lcg
-daz
+kXj
 lmz
 lmz
 lmz
@@ -142451,7 +141872,7 @@ lmz
 lmz
 lmz
 lmz
-daz
+kXj
 ltc
 eXk
 xns
@@ -142461,13 +141882,13 @@ rCi
 gba
 mUz
 our
-rna
+kXj
 cxc
 kBy
 kBy
 khJ
 gyN
-daz
+kXj
 lmz
 lmz
 lmz
@@ -142654,23 +142075,23 @@ lmz
 lmz
 lmz
 lmz
-daz
+kXj
 tId
 wJB
 tJN
-daz
-daz
-daz
-daz
-daz
-daz
-daz
-daz
-daz
-daz
-daz
-daz
-daz
+kXj
+kXj
+kXj
+kXj
+kXj
+kXj
+kXj
+kXj
+kXj
+kXj
+kXj
+kXj
+kXj
 lmz
 lmz
 lmz
@@ -142857,11 +142278,11 @@ bdH
 bdH
 bdH
 lmz
-daz
-daz
-daz
-daz
-daz
+kXj
+kXj
+kXj
+kXj
+kXj
 lmz
 lmz
 lmz

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -522,6 +522,7 @@
 	icon_state = "E";
 	pixel_x = 1
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "acK" = (
 /obj/structure/desertdam/decals/road_edge{
@@ -3322,6 +3323,7 @@
 	pixel_y = 24;
 	req_one_access_txt = "90;91;92"
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "asE" = (
 /obj/structure/bed/chair/office/dark{
@@ -3347,6 +3349,7 @@
 	unacidable = 1;
 	unslashable = 1
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "asH" = (
 /obj/structure/machinery/telecomms/bus/preset_three,
@@ -3679,11 +3682,13 @@
 /area/almayer/command/airoom)
 "auf" = (
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom,
+/turf/closed/wall/almayer/aicore/hull,
 /area/almayer/command/airoom)
 "aug" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "aui" = (
 /obj/structure/machinery/telecomms/hub/preset,
@@ -3986,6 +3991,7 @@
 	pixel_y = -24;
 	req_one_access_txt = "91;92"
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "avM" = (
 /obj/structure/machinery/computer/cameras/almayer/ares{
@@ -4003,6 +4009,7 @@
 	pixel_y = 6
 	},
 /obj/item/tool/pen,
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "avN" = (
 /obj/structure/machinery/telecomms/processor/preset_two,
@@ -4175,6 +4182,7 @@
 	icon_state = "W";
 	pixel_x = -1
 	},
+/turf/open/floor/almayer/aicore/glowing/no_build,
 /area/almayer/command/airoom)
 "awv" = (
 /obj/structure/machinery/computer/telecomms/monitor,
@@ -5658,6 +5666,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "aCf" = (
 /obj/structure/window/framed/almayer/hull/hijack_bustable,
@@ -7242,6 +7251,7 @@
 	unacidable = 0;
 	unslashable = 0
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "aKu" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -7471,6 +7481,9 @@
 	pixel_y = 16
 	},
 /obj/item/clothing/accessory/stethoscope,
+/obj/structure/closet/secure_closet/professor_dummy{
+	pixel_x = -32
+	},
 /turf/open/floor/almayer{
 	dir = 8;
 	icon_state = "sterile_green_corner"
@@ -9768,6 +9781,7 @@
 	pixel_y = -24;
 	req_one_access_txt = "200;91;92"
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "baw" = (
 /turf/open/floor/almayer,
@@ -12191,6 +12205,7 @@
 /turf/open/floor/almayer,
 /area/almayer/squads/req)
 "bpR" = (
+/turf/open/floor/almayer/empty/requisitions,
 /area/supply/station)
 "bpS" = (
 /obj/structure/machinery/door/poddoor/railing{
@@ -12560,6 +12575,7 @@
 /area/almayer/squads/req)
 "bsK" = (
 /obj/effect/landmark/supply_elevator,
+/turf/open/floor/almayer/empty/requisitions,
 /area/supply/station)
 "bsL" = (
 /obj/structure/machinery/door/poddoor/railing{
@@ -14803,6 +14819,15 @@
 	name = "\improper ARES Mainframe Shutters";
 	plane = -7
 	},
+/obj/structure/machinery/door/poddoor/almayer/blended/aicore/open{
+	closed_layer = 3.2;
+	id = "ARES Emergency";
+	layer = 3.2;
+	name = "ARES Emergency Lockdown";
+	needs_power = 0;
+	open_layer = 1.9;
+	plane = -7
+	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "test_floor4"
 	},
@@ -15362,6 +15387,10 @@
 /obj/structure/machinery/camera/autoname/almayer/containment/ares{
 	dir = 8;
 	pixel_y = 2
+	},
+/turf/open/floor/almayer/aicore/no_build{
+	icon_state = "ai_silver";
+	dir = 4
 	},
 /area/almayer/command/airoom)
 "bLw" = (
@@ -17774,6 +17803,7 @@
 	icon_state = "S";
 	layer = 3.3
 	},
+/turf/open/floor/almayer/aicore/glowing/no_build,
 /area/almayer/command/airoom)
 "ccs" = (
 /obj/structure/disposalpipe/segment{
@@ -18771,6 +18801,11 @@
 "cls" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/port_point_defense)
+"clw" = (
+/turf/open/floor/almayer/aicore/glowing/no_build{
+	icon_state = "ai_floor3"
+	},
+/area/almayer/command/airoom)
 "clE" = (
 /obj/structure/machinery/door/airlock/almayer/marine/delta/medic,
 /turf/open/floor/almayer{
@@ -19082,6 +19117,7 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "cnq" = (
 /obj/structure/machinery/line_nexter{
@@ -19445,6 +19481,7 @@
 	pixel_x = 5;
 	pixel_y = 6
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "cqp" = (
 /obj/structure/largecrate/random/barrel/white,
@@ -19802,6 +19839,7 @@
 /area/almayer/hallways/upper/stern_hallway)
 "cwS" = (
 /obj/structure/blocker/invisible_wall,
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "cwX" = (
 /obj/structure/ladder{
@@ -19815,6 +19853,7 @@
 	icon_state = "S";
 	layer = 3.3
 	},
+/turf/open/floor/almayer/aicore/glowing/no_build,
 /area/almayer/command/airoom)
 "cxk" = (
 /obj/structure/machinery/light,
@@ -20011,6 +20050,7 @@
 	dir = 1;
 	icon_state = "ramptop"
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "cBs" = (
 /obj/structure/bed/chair,
@@ -20330,6 +20370,12 @@
 	icon_state = "orangefull"
 	},
 /area/almayer/living/briefing)
+"cHC" = (
+/obj/structure/machinery/cm_vending/clothing/combat_correspondent,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/command/combat_correspondent)
 "cHE" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -20546,6 +20592,9 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
 	pixel_y = 1
+	},
+/turf/open/floor/almayer/aicore/no_build{
+	icon_state = "ai_arrow"
 	},
 /area/almayer/command/airoom)
 "cLq" = (
@@ -21407,6 +21456,9 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/port)
+"daz" = (
+/turf/closed/wall/almayer/aicore/hull,
+/area/almayer/command/airoom)
 "daF" = (
 /obj/structure/machinery/power/apc/almayer{
 	dir = 1
@@ -22940,6 +22992,7 @@
 	icon_state = "W";
 	layer = 3.3
 	},
+/turf/open/floor/almayer/aicore/glowing/no_build,
 /area/almayer/command/airoom)
 "dDt" = (
 /obj/structure/toilet{
@@ -23165,6 +23218,7 @@
 /obj/structure/stairs{
 	dir = 1
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "dGr" = (
 /obj/structure/pipes/vents/scrubber{
@@ -23271,10 +23325,15 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/living/bridgebunks)
+"dIi" = (
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom,
+/turf/open/floor/plating/plating_catwalk/aicore,
+/area/almayer/command/airoom)
 "dIn" = (
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 5
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "dID" = (
 /obj/effect/decal/warning_stripes{
@@ -23633,6 +23692,7 @@
 /obj/structure/stairs{
 	dir = 1
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "dQp" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -24289,6 +24349,9 @@
 /obj/item/clothing/shoes/red,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/u_m_p)
+"ebN" = (
+/turf/closed/wall/almayer/aicore/reinforced,
+/area/almayer/command/airoom)
 "ebV" = (
 /obj/structure/machinery/status_display{
 	pixel_y = 30
@@ -25279,6 +25342,11 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_m_s)
+"erN" = (
+/turf/open/floor/almayer/aicore/no_build{
+	icon_state = "ai_plates"
+	},
+/area/almayer/command/airoom)
 "esd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25443,6 +25511,7 @@
 	pixel_y = 24;
 	req_one_access_txt = "200;91;92"
 	},
+/turf/open/floor/almayer/aicore/glowing/no_build,
 /area/almayer/command/airoom)
 "euO" = (
 /obj/structure/machinery/light{
@@ -26258,6 +26327,9 @@
 /obj/structure/machinery/status_display{
 	pixel_y = 30
 	},
+/turf/open/floor/almayer/aicore/glowing/no_build{
+	icon_state = "ai_floor3"
+	},
 /area/almayer/command/airoom)
 "eKQ" = (
 /obj/structure/pipes/vents/scrubber{
@@ -26867,6 +26939,7 @@
 	dir = 8;
 	light_color = "#d69c46"
 	},
+/turf/open/floor/plating/plating_catwalk/aicore,
 /area/almayer/command/airoom)
 "eXq" = (
 /turf/closed/wall/almayer,
@@ -26945,6 +27018,7 @@
 	dir = 8;
 	pixel_x = 29
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "eYD" = (
 /obj/effect/decal/warning_stripes{
@@ -27276,6 +27350,10 @@
 /obj/effect/step_trigger/clone_cleaner,
 /obj/structure/platform_decoration{
 	dir = 1
+	},
+/turf/open/floor/almayer/aicore/no_build{
+	icon_state = "ai_silver";
+	dir = 8
 	},
 /area/almayer/command/airoom)
 "fdf" = (
@@ -27638,6 +27716,7 @@
 	icon_state = "E";
 	pixel_x = 1
 	},
+/turf/open/floor/almayer/aicore/glowing/no_build,
 /area/almayer/command/airoom)
 "fmB" = (
 /obj/structure/bed/chair/comfy{
@@ -28015,6 +28094,7 @@
 	icon_state = "NW-out";
 	pixel_y = 1
 	},
+/turf/open/floor/almayer/aicore/glowing/no_build,
 /area/almayer/command/airoom)
 "frV" = (
 /obj/structure/toilet{
@@ -28648,6 +28728,7 @@
 /obj/structure/machinery/camera/autoname/almayer/containment/ares{
 	dir = 4
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "fER" = (
 /obj/structure/machinery/autolathe,
@@ -28913,10 +28994,20 @@
 	icon_state = "green"
 	},
 /area/almayer/shipboard/brig/cells)
+"fJY" = (
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
+	dir = 4
+	},
+/turf/open/floor/almayer/aicore/no_build{
+	icon_state = "ai_arrow";
+	dir = 8
+	},
+/area/almayer/command/airoom)
 "fKe" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out"
 	},
+/turf/open/floor/almayer/aicore/glowing/no_build,
 /area/almayer/command/airoom)
 "fKh" = (
 /obj/structure/window/framed/almayer,
@@ -29084,6 +29175,10 @@
 	pixel_y = -8;
 	req_one_access_txt = "90;91;92"
 	},
+/turf/open/floor/almayer/aicore/no_build{
+	icon_state = "ai_silver";
+	dir = 4
+	},
 /area/almayer/command/airoom)
 "fMt" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer{
@@ -29092,6 +29187,15 @@
 	plane = -7
 	},
 /obj/effect/step_trigger/ares_alert/core,
+/obj/structure/machinery/door/poddoor/almayer/blended/aicore/open{
+	closed_layer = 3.2;
+	id = "ARES Emergency";
+	layer = 3.2;
+	name = "ARES Emergency Lockdown";
+	needs_power = 0;
+	open_layer = 1.9;
+	plane = -7
+	},
 /obj/structure/sign/safety/laser{
 	pixel_x = 32;
 	pixel_y = -8
@@ -29749,6 +29853,7 @@
 	pixel_x = 8;
 	pixel_y = -8
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "gbg" = (
 /obj/structure/sign/safety/terminal{
@@ -29771,6 +29876,9 @@
 	pixel_x = -24;
 	pixel_y = -8;
 	req_one_access_txt = "90;91;92"
+	},
+/turf/open/floor/almayer/aicore/glowing/no_build{
+	icon_state = "ai_floor3"
 	},
 /area/almayer/command/airoom)
 "gbs" = (
@@ -29978,6 +30086,7 @@
 	icon_state = "S";
 	layer = 3.3
 	},
+/turf/open/floor/almayer/aicore/glowing/no_build,
 /area/almayer/command/airoom)
 "gfv" = (
 /turf/open/floor/plating/plating_catwalk,
@@ -30197,6 +30306,7 @@
 /obj/item/storage/box/ids{
 	pixel_x = -4
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "gjB" = (
 /obj/structure/machinery/light{
@@ -31060,6 +31170,7 @@
 	pixel_y = 8;
 	req_one_access_txt = "91;92"
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "gAj" = (
 /obj/structure/bed/chair/comfy/charlie{
@@ -31823,6 +31934,7 @@
 	unacidable = 0;
 	unslashable = 0
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "gMS" = (
 /obj/structure/machinery/camera/autoname/almayer{
@@ -31936,6 +32048,10 @@
 	unacidable = 0;
 	unslashable = 0
 	},
+/turf/open/floor/almayer/aicore/no_build{
+	icon_state = "ai_silver";
+	dir = 4
+	},
 /area/almayer/command/airoom)
 "gOC" = (
 /obj/structure/machinery/recharge_station,
@@ -31975,6 +32091,7 @@
 /obj/structure/stairs{
 	dir = 1
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "gPS" = (
 /obj/effect/decal/warning_stripes{
@@ -32149,6 +32266,9 @@
 	dir = 4;
 	pixel_y = -18
 	},
+/turf/open/floor/almayer/aicore/glowing/no_build{
+	icon_state = "ai_floor3"
+	},
 /area/almayer/command/airoom)
 "gTK" = (
 /obj/effect/decal/warning_stripes{
@@ -32237,6 +32357,10 @@
 /area/almayer/living/bridgebunks)
 "gUN" = (
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom{
+	dir = 4
+	},
+/turf/open/floor/almayer/aicore/no_build{
+	icon_state = "ai_arrow";
 	dir = 4
 	},
 /area/almayer/command/airoom)
@@ -35067,6 +35191,7 @@
 	pixel_x = 14;
 	pixel_y = 38
 	},
+/turf/open/floor/almayer/aicore/glowing/no_build,
 /area/almayer/command/airoom)
 "hSb" = (
 /obj/structure/largecrate/random/secure,
@@ -35156,6 +35281,7 @@
 	pixel_y = 16
 	},
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom,
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "hTt" = (
 /obj/structure/machinery/brig_cell/cell_1{
@@ -35533,6 +35659,13 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/engineering/lower/workshop/hangar)
+"hZj" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/turf/open/floor/almayer/aicore/no_build,
+/area/almayer/command/airoom)
 "hZw" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out"
@@ -35820,6 +35953,7 @@
 	dir = 1;
 	icon_state = "ramptop"
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "ieX" = (
 /obj/structure/surface/table/almayer,
@@ -35865,6 +35999,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out"
 	},
+/turf/open/floor/almayer/aicore/glowing/no_build,
 /area/almayer/command/airoom)
 "igs" = (
 /obj/structure/surface/table/almayer,
@@ -36439,6 +36574,7 @@
 	dir = 1;
 	icon_state = "ramptop"
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "isI" = (
 /obj/structure/sign/nosmoking_2{
@@ -36483,6 +36619,10 @@
 	open_layer = 2.1;
 	unacidable = 0;
 	unslashable = 0
+	},
+/turf/open/floor/almayer/aicore/no_build{
+	icon_state = "ai_silver";
+	dir = 8
 	},
 /area/almayer/command/airoom)
 "ito" = (
@@ -36790,6 +36930,7 @@
 	unacidable = 1;
 	unslashable = 1
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "iyS" = (
 /obj/structure/disposalpipe/segment{
@@ -38169,6 +38310,7 @@
 /obj/structure/stairs{
 	dir = 1
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "iZE" = (
 /obj/structure/machinery/cm_vending/sorted/tech/tool_storage,
@@ -39292,6 +39434,15 @@
 	plane = -7
 	},
 /obj/effect/step_trigger/ares_alert/core,
+/obj/structure/machinery/door/poddoor/almayer/blended/aicore/open{
+	closed_layer = 3.2;
+	id = "ARES Emergency";
+	layer = 3.2;
+	name = "ARES Emergency Lockdown";
+	needs_power = 0;
+	open_layer = 1.9;
+	plane = -7
+	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "test_floor4"
 	},
@@ -39431,6 +39582,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/vehiclehangar)
+"jtj" = (
+/obj/effect/step_trigger/clone_cleaner,
+/turf/open/floor/almayer/aicore/glowing/no_build{
+	icon_state = "ai_floor3"
+	},
+/area/almayer/command/airoom)
 "jts" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/disposalpipe/segment{
@@ -39550,6 +39707,9 @@
 /area/almayer/hallways/upper/aft_hallway)
 "jvB" = (
 /obj/effect/step_trigger/clone_cleaner,
+/turf/open/floor/almayer/aicore/no_build{
+	icon_state = "ai_plates"
+	},
 /area/almayer/command/airoom)
 "jvD" = (
 /obj/structure/machinery/door_control{
@@ -39946,6 +40106,7 @@
 	pixel_x = 24;
 	req_one_access_txt = "90;91;92"
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "jEA" = (
 /obj/structure/disposalpipe/segment{
@@ -41050,6 +41211,7 @@
 /obj/structure/machinery/camera/autoname/almayer/containment/ares{
 	dir = 4
 	},
+/turf/open/floor/almayer/aicore/glowing/no_build,
 /area/almayer/command/airoom)
 "jZd" = (
 /obj/structure/pipes/vents/pump{
@@ -41274,6 +41436,7 @@
 /obj/structure/stairs{
 	dir = 1
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "kbJ" = (
 /obj/effect/decal/warning_stripes{
@@ -41589,6 +41752,7 @@
 /obj/structure/machinery/camera/autoname/almayer/containment/ares{
 	dir = 8
 	},
+/turf/open/floor/almayer/aicore/glowing/no_build,
 /area/almayer/command/airoom)
 "kil" = (
 /obj/structure/stairs/perspective{
@@ -42595,6 +42759,10 @@
 	pixel_y = -8;
 	req_one_access_txt = "90;91;92"
 	},
+/turf/open/floor/almayer/aicore/no_build{
+	icon_state = "ai_silver";
+	dir = 8
+	},
 /area/almayer/command/airoom)
 "kAh" = (
 /obj/structure/sign/safety/restrictedarea{
@@ -43144,6 +43312,7 @@
 	dir = 1;
 	icon_state = "ramptop"
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "kKB" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
@@ -43645,6 +43814,7 @@
 	pixel_y = 24;
 	req_one_access_txt = "200;91;92"
 	},
+/turf/open/floor/almayer/aicore/glowing/no_build,
 /area/almayer/command/airoom)
 "kSA" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
@@ -43896,6 +44066,10 @@
 	},
 /area/almayer/command/computerlab)
 "kXj" = (
+/turf/open/floor/almayer/aicore/no_build{
+	icon_state = "ai_silver";
+	dir = 4
+	},
 /area/almayer/command/airoom)
 "kXm" = (
 /obj/effect/decal/warning_stripes{
@@ -44490,6 +44664,7 @@
 	dir = 1;
 	icon_state = "ramptop"
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "liF" = (
 /obj/structure/machinery/light/small{
@@ -44752,6 +44927,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/medical_science)
 "lmz" = (
+/turf/closed/wall/almayer/aicore/hull,
 /area/space)
 "lmA" = (
 /obj/structure/flora/pottedplant{
@@ -44825,6 +45001,9 @@
 	pixel_x = 24;
 	pixel_y = -8;
 	req_one_access_txt = "90;91;92"
+	},
+/turf/open/floor/almayer/aicore/glowing/no_build{
+	icon_state = "ai_floor3"
 	},
 /area/almayer/command/airoom)
 "lok" = (
@@ -45134,6 +45313,7 @@
 "ltc" = (
 /obj/effect/landmark/late_join/working_joe,
 /obj/effect/landmark/start/working_joe,
+/turf/open/floor/plating/plating_catwalk/aicore,
 /area/almayer/command/airoom)
 "ltm" = (
 /obj/structure/bed/chair/comfy/orange,
@@ -46850,6 +47030,7 @@
 	},
 /obj/item/folder/white,
 /obj/item/folder/white,
+/turf/open/floor/almayer/aicore/glowing/no_build,
 /area/almayer/command/airoom)
 "mea" = (
 /obj/structure/flora/pottedplant{
@@ -47307,6 +47488,7 @@
 	icon_state = "NE-out";
 	pixel_y = 1
 	},
+/turf/open/floor/almayer/aicore/glowing/no_build,
 /area/almayer/command/airoom)
 "mlm" = (
 /turf/open/floor/almayer{
@@ -48335,6 +48517,15 @@
 	name = "\improper ARES Mainframe Shutters";
 	plane = -7
 	},
+/obj/structure/machinery/door/poddoor/almayer/blended/aicore/open{
+	closed_layer = 3.2;
+	id = "ARES Emergency";
+	layer = 3.2;
+	name = "ARES Emergency Lockdown";
+	needs_power = 0;
+	open_layer = 1.9;
+	plane = -7
+	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "test_floor4"
 	},
@@ -48451,6 +48642,12 @@
 	icon_state = "mono"
 	},
 /area/almayer/medical/hydroponics)
+"mHE" = (
+/turf/open/floor/almayer/aicore/no_build{
+	icon_state = "ai_silver";
+	dir = 8
+	},
+/area/almayer/command/airoom)
 "mHF" = (
 /obj/structure/surface/rack,
 /obj/item/clothing/head/headband/red{
@@ -49016,6 +49213,15 @@
 	plane = -7
 	},
 /obj/effect/step_trigger/ares_alert/core,
+/obj/structure/machinery/door/poddoor/almayer/blended/aicore/open{
+	closed_layer = 3.2;
+	id = "ARES Emergency";
+	layer = 3.2;
+	name = "ARES Emergency Lockdown";
+	needs_power = 0;
+	open_layer = 1.9;
+	plane = -7
+	},
 /obj/structure/sign/safety/terminal{
 	pixel_x = -18;
 	pixel_y = -8
@@ -49223,6 +49429,9 @@
 /obj/structure/machinery/computer/cameras/almayer/ares{
 	dir = 8;
 	pixel_x = 17
+	},
+/turf/open/floor/almayer/aicore/glowing/no_build{
+	icon_state = "ai_floor3"
 	},
 /area/almayer/command/airoom)
 "mUE" = (
@@ -52541,6 +52750,7 @@
 /obj/structure/sign/safety/rewire{
 	pixel_y = 38
 	},
+/turf/open/floor/almayer/aicore/glowing/no_build,
 /area/almayer/command/airoom)
 "ocI" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -52960,6 +53170,7 @@
 /area/almayer/squads/bravo)
 "oiX" = (
 /obj/docking_port/stationary/vehicle_elevator/almayer,
+/turf/open/floor/almayer/empty/vehicle_bay,
 /area/almayer/hallways/lower/vehiclehangar)
 "oiY" = (
 /obj/effect/decal/warning_stripes{
@@ -53549,6 +53760,10 @@
 "osy" = (
 /obj/effect/step_trigger/clone_cleaner,
 /obj/structure/platform_decoration,
+/turf/open/floor/almayer/aicore/no_build{
+	icon_state = "ai_silver";
+	dir = 4
+	},
 /area/almayer/command/airoom)
 "osz" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
@@ -53703,6 +53918,7 @@
 	pixel_y = 6
 	},
 /obj/item/tool/pen,
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "ouw" = (
 /obj/structure/machinery/light/small{
@@ -54624,6 +54840,7 @@
 	pixel_x = -24;
 	req_one_access_txt = "90;91;92"
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "oKb" = (
 /obj/structure/machinery/status_display{
@@ -54687,6 +54904,10 @@
 	pixel_y = -8
 	},
 /obj/effect/step_trigger/clone_cleaner,
+/turf/open/floor/almayer/aicore/no_build{
+	icon_state = "ai_silver";
+	dir = 8
+	},
 /area/almayer/command/airoom)
 "oLF" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
@@ -55042,6 +55263,7 @@
 	icon_state = "W";
 	pixel_x = -1
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "oRW" = (
 /obj/structure/surface/table/almayer,
@@ -55917,6 +56139,7 @@
 	dir = 1;
 	icon_state = "ramptop"
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "pgJ" = (
 /obj/structure/sign/safety/hvac_old{
@@ -56168,6 +56391,7 @@
 	pixel_y = 16
 	},
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom,
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "pnh" = (
 /obj/structure/ladder{
@@ -57304,6 +57528,19 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/living/port_emb)
+"pJR" = (
+/obj/effect/step_trigger/teleporter_vector{
+	name = "Almayer_AresUp";
+	vector_x = -97;
+	vector_y = 65
+	},
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/almayer/aicore/glowing/no_build{
+	icon_state = "ai_floor3"
+	},
+/area/almayer/command/airoom)
 "pKh" = (
 /obj/structure/machinery/alarm/almayer{
 	dir = 1
@@ -58070,6 +58307,10 @@
 /obj/structure/pipes/vents/pump/no_boom{
 	dir = 8
 	},
+/turf/open/floor/almayer/aicore/no_build{
+	icon_state = "ai_silver";
+	dir = 4
+	},
 /area/almayer/command/airoom)
 "pYo" = (
 /obj/effect/decal/warning_stripes{
@@ -58673,6 +58914,7 @@
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/paper_bin/uscm,
 /obj/item/tool/pen,
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "qiy" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
@@ -59411,6 +59653,10 @@
 	pixel_x = -24;
 	pixel_y = -8;
 	req_one_access_txt = "90;91;92"
+	},
+/turf/open/floor/almayer/aicore/no_build{
+	icon_state = "ai_silver";
+	dir = 8
 	},
 /area/almayer/command/airoom)
 "qwY" = (
@@ -60397,6 +60643,9 @@
 /area/almayer/living/port_emb)
 "qLS" = (
 /obj/structure/pipes/standard/manifold/hidden/supply/no_boom,
+/turf/open/floor/almayer/aicore/glowing/no_build{
+	icon_state = "ai_floor3"
+	},
 /area/almayer/command/airoom)
 "qLV" = (
 /obj/structure/surface/table/almayer,
@@ -60617,6 +60866,9 @@
 	icon_state = "red"
 	},
 /area/almayer/maint/hull/upper/u_a_p)
+"qQS" = (
+/turf/open/floor/almayer/aicore/no_build,
+/area/almayer/command/airoom)
 "qRb" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
@@ -61238,6 +61490,7 @@
 	pixel_y = -24;
 	req_one_access_txt = "200;91;92"
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "rbB" = (
 /turf/open/floor/almayer{
@@ -61949,6 +62202,12 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/engineering/upper_engineering/port)
+"rna" = (
+/obj/structure/machinery/status_display{
+	pixel_y = 30
+	},
+/turf/open/floor/almayer/aicore/no_build,
+/area/almayer/command/airoom)
 "rnd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61983,6 +62242,7 @@
 	dir = 8;
 	pixel_x = 17
 	},
+/turf/open/floor/almayer/aicore/glowing/no_build,
 /area/almayer/command/airoom)
 "rnN" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -62708,6 +62968,7 @@
 /obj/structure/machinery/camera/autoname/almayer/containment/ares{
 	dir = 8
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "rCl" = (
 /obj/effect/decal/warning_stripes{
@@ -62731,6 +62992,7 @@
 /obj/structure/stairs{
 	dir = 1
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "rCD" = (
 /obj/structure/machinery/light/small{
@@ -63476,6 +63738,7 @@
 	unacidable = 1;
 	unslashable = 1
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "rNK" = (
 /obj/structure/surface/table/almayer,
@@ -64184,6 +64447,7 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/port_fore_hallway)
 "sbJ" = (
+/turf/closed/wall/almayer/aicore/hull,
 /area/almayer/powered/agent)
 "sbP" = (
 /obj/effect/landmark/start/police,
@@ -64638,6 +64902,7 @@
 	},
 /area/almayer/medical/lower_medical_medbay)
 "sje" = (
+/turf/open/floor/almayer/empty/vehicle_bay,
 /area/almayer/hallways/lower/vehiclehangar)
 "sjj" = (
 /obj/structure/machinery/keycard_auth{
@@ -65878,6 +66143,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
 	},
+/turf/open/floor/almayer/aicore/glowing/no_build,
 /area/almayer/command/airoom)
 "sEM" = (
 /obj/structure/surface/table/reinforced/almayer_B,
@@ -66039,6 +66305,7 @@
 /obj/structure/stairs{
 	dir = 1
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "sIr" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -66153,6 +66420,7 @@
 	dir = 8;
 	layer = 3.25
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "sLk" = (
 /obj/structure/ladder{
@@ -68947,6 +69215,9 @@
 /area/almayer/shipboard/brig/cells)
 "tId" = (
 /obj/structure/machinery/recharge_station,
+/turf/open/floor/almayer/aicore/no_build{
+	icon_state = "ai_cargo"
+	},
 /area/almayer/command/airoom)
 "tIe" = (
 /obj/structure/machinery/camera/autoname/almayer{
@@ -69062,6 +69333,9 @@
 /obj/structure/machinery/cryopod/right{
 	layer = 3.1;
 	pixel_y = 13
+	},
+/turf/open/floor/almayer/aicore/no_build{
+	icon_state = "ai_cargo"
 	},
 /area/almayer/command/airoom)
 "tJR" = (
@@ -69930,6 +70204,7 @@
 	icon_state = "E";
 	pixel_x = 1
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "ubI" = (
 /obj/structure/surface/table/almayer,
@@ -72338,6 +72613,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_a_p)
+"uVv" = (
+/obj/structure/pipes/standard/manifold/hidden/supply/no_boom{
+	dir = 1
+	},
+/turf/open/floor/almayer/aicore/no_build,
+/area/almayer/command/airoom)
 "uVA" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -73031,6 +73312,7 @@
 /obj/item/folder/white,
 /obj/item/folder/white,
 /obj/item/folder/white,
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "vhw" = (
 /obj/structure/disposalpipe/trunk{
@@ -73129,6 +73411,7 @@
 /obj/structure/pipes/standard/manifold/hidden/supply/no_boom{
 	dir = 1
 	},
+/turf/open/floor/plating/plating_catwalk/aicore,
 /area/almayer/command/airoom)
 "viJ" = (
 /obj/structure/machinery/door/airlock/almayer/maint,
@@ -74417,6 +74700,10 @@
 "vAU" = (
 /obj/structure/pipes/vents/scrubber/no_boom{
 	dir = 4
+	},
+/turf/open/floor/almayer/aicore/no_build{
+	icon_state = "ai_silver";
+	dir = 8
 	},
 /area/almayer/command/airoom)
 "vBp" = (
@@ -75846,6 +76133,7 @@
 	dir = 4;
 	pixel_x = -17
 	},
+/turf/open/floor/almayer/aicore/glowing/no_build,
 /area/almayer/command/airoom)
 "vXk" = (
 /turf/open/floor/almayer{
@@ -76688,6 +76976,15 @@
 	alert_message = "Caution: Movement detected in ARES Core.";
 	cooldown_duration = 1200
 	},
+/obj/structure/machinery/door/poddoor/almayer/blended/aicore/open{
+	closed_layer = 3.2;
+	id = "ARES Emergency";
+	layer = 3.2;
+	name = "ARES Emergency Lockdown";
+	needs_power = 0;
+	open_layer = 1.9;
+	plane = -7
+	},
 /turf/open/floor/almayer/no_build{
 	icon_state = "test_floor4"
 	},
@@ -76842,6 +77139,10 @@
 	icon_state = "cargo"
 	},
 /area/almayer/living/bridgebunks)
+"wnh" = (
+/obj/structure/window/framed/almayer/aicore/hull,
+/turf/open/floor/plating,
+/area/almayer/command/airoom)
 "wnw" = (
 /obj/structure/machinery/flasher{
 	id = "Perma 2";
@@ -77637,6 +77938,7 @@
 /obj/structure/stairs{
 	dir = 1
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "wDg" = (
 /obj/effect/decal/warning_stripes{
@@ -78028,6 +78330,9 @@
 /area/almayer/medical/upper_medical)
 "wJB" = (
 /obj/structure/machinery/cryopod/right,
+/turf/open/floor/almayer/aicore/no_build{
+	icon_state = "ai_cargo"
+	},
 /area/almayer/command/airoom)
 "wJC" = (
 /obj/structure/largecrate/random/barrel/yellow,
@@ -79754,6 +80059,7 @@
 	},
 /obj/effect/landmark/late_join/working_joe,
 /obj/effect/landmark/start/working_joe,
+/turf/open/floor/plating/plating_catwalk/aicore,
 /area/almayer/command/airoom)
 "xnz" = (
 /obj/effect/decal/warning_stripes{
@@ -80215,6 +80521,10 @@
 	req_one_access_txt = "90;91;92"
 	},
 /obj/effect/step_trigger/clone_cleaner,
+/turf/open/floor/almayer/aicore/no_build{
+	icon_state = "ai_silver";
+	dir = 4
+	},
 /area/almayer/command/airoom)
 "xvO" = (
 /obj/structure/disposalpipe/segment{
@@ -80693,6 +81003,10 @@
 	icon_state = "silver"
 	},
 /area/almayer/shipboard/brig/cic_hallway)
+"xDC" = (
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom,
+/turf/open/floor/almayer/aicore/no_build,
+/area/almayer/command/airoom)
 "xDF" = (
 /obj/structure/machinery/autolathe,
 /turf/open/floor/almayer{
@@ -81429,6 +81743,10 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/lower/port_aft_hallway)
+"xQV" = (
+/obj/effect/step_trigger/clone_cleaner,
+/turf/open/floor/almayer/aicore/no_build,
+/area/almayer/command/airoom)
 "xQW" = (
 /obj/structure/sign/safety/bathunisex{
 	pixel_x = -18
@@ -81699,6 +82017,7 @@
 	pixel_y = 24;
 	req_one_access_txt = "90;91;92"
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "xVe" = (
 /obj/effect/decal/warning_stripes{
@@ -82026,6 +82345,7 @@
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 9
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "yaR" = (
 /obj/structure/disposalpipe/segment{
@@ -82052,6 +82372,13 @@
 	icon_state = "cargo_arrow"
 	},
 /area/almayer/hallways/lower/vehiclehangar)
+"yaZ" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	layer = 3.3
+	},
+/turf/open/floor/almayer/aicore/no_build,
+/area/almayer/command/airoom)
 "ybk" = (
 /turf/closed/wall/almayer,
 /area/almayer/hallways/upper/stern_hallway)
@@ -82220,6 +82547,7 @@
 	icon_state = "W";
 	pixel_x = -1
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "ydM" = (
 /obj/structure/window{
@@ -82485,6 +82813,7 @@
 /obj/structure/pipes/vents/pump/no_boom{
 	dir = 1
 	},
+/turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "yiW" = (
 /obj/structure/machinery/cryopod/right{
@@ -120714,8 +121043,8 @@ lin
 oJR
 tFe
 asD
-jvB
-kXj
+xQV
+qQS
 aqU
 aCZ
 dgg
@@ -120916,8 +121245,8 @@ sIf
 isC
 isC
 tFe
-jvB
-jvB
+xQV
+xQV
 rNF
 aqU
 qjF
@@ -121120,7 +121449,7 @@ pgH
 jDV
 tFe
 xVc
-jvB
+xQV
 eYz
 aqU
 gjB
@@ -121525,7 +121854,7 @@ mLE
 bUx
 mLE
 tmK
-kXj
+qQS
 aug
 avL
 aqU
@@ -126410,7 +126739,7 @@ vkQ
 kzR
 oig
 oIB
-dha
+cHC
 dha
 pxj
 oIB
@@ -139237,19 +139566,19 @@ lmz
 lmz
 lmz
 lmz
-kXj
-kXj
-kXj
-kXj
-kXj
-kXj
-kXj
-kXj
-kXj
-kXj
-kXj
-kXj
-kXj
+daz
+daz
+daz
+daz
+daz
+daz
+daz
+daz
+daz
+daz
+daz
+daz
+daz
 lmz
 lmz
 lmz
@@ -139440,19 +139769,19 @@ lmz
 lmz
 lmz
 lmz
-kXj
+daz
 vhe
 fEN
 cqm
 gTH
 qit
-kXj
+ebN
 cxc
 gwn
 pfT
 jYR
 dyp
-kXj
+daz
 lmz
 lmz
 lmz
@@ -139643,19 +139972,19 @@ lmz
 sbJ
 sbJ
 sbJ
-kXj
-eKJ
-kXj
-kXj
+daz
+rna
+clw
+qQS
 sKY
-kXj
+qQS
 bIp
 fKe
 dDp
 dDp
 frM
 lcg
-kXj
+daz
 lmz
 lmz
 lmz
@@ -139839,17 +140168,17 @@ lmz
 lmz
 lmz
 lmz
-kXj
-kXj
-kXj
-kXj
-kXj
+daz
+daz
+daz
+daz
+daz
 tte
 hvw
 auf
 pmV
-auf
-auf
+xDC
+xDC
 dIn
 rby
 bIp
@@ -139858,7 +140187,7 @@ sEK
 sEK
 mlb
 lcg
-kXj
+daz
 lmz
 lmz
 lmz
@@ -140041,27 +140370,27 @@ lmz
 lmz
 lmz
 lmz
-kXj
-kXj
+daz
+daz
 hRW
 asZ
 vXh
-kXj
-kXj
+daz
+daz
 kfU
-kXj
-kXj
-kXj
+daz
+ebN
+ebN
 lnS
-viB
+uVv
 yit
-kXj
+ebN
 cxc
 kBy
 kBy
 gfu
 fPB
-kXj
+daz
 lmz
 lmz
 lmz
@@ -140243,29 +140572,29 @@ bdH
 lmz
 lmz
 lmz
-kXj
-kXj
+daz
+daz
 eKJ
-cxc
+yaZ
 ffE
-cLo
-kXj
-kXj
-kXj
-kXj
+hZj
+clw
+daz
+daz
+daz
 sGZ
-kXj
-kXj
+ebN
+ebN
 roH
-kXj
-kXj
-kXj
-kXj
-mLE
-mLE
-kXj
-kXj
-kXj
+ebN
+ebN
+ebN
+daz
+wnh
+wnh
+daz
+daz
+daz
 lmz
 lmz
 lmz
@@ -140446,7 +140775,7 @@ bdH
 lmz
 lmz
 lmz
-kXj
+daz
 acJ
 ubA
 cck
@@ -140456,10 +140785,10 @@ ubA
 gMN
 mRn
 itf
-kXj
+mHE
 vAU
 qwJ
-gUN
+fJY
 kzT
 wkM
 oLm
@@ -140468,7 +140797,7 @@ kKv
 kKv
 dGl
 dGl
-kXj
+daz
 lmz
 lmz
 lmz
@@ -140649,7 +140978,7 @@ bdH
 lmz
 lmz
 lmz
-kXj
+daz
 cwS
 ffE
 vHa
@@ -140659,19 +140988,19 @@ ffE
 ffE
 jqP
 cLo
-kXj
+clw
 viB
-auf
+dIi
 qLS
-kXj
+erN
 wkM
 jvB
-jvB
+jtj
 ieF
 ieF
+pJR
 gPr
-gPr
-kXj
+daz
 lmz
 lmz
 lmz
@@ -140852,7 +141181,7 @@ bdH
 lmz
 lmz
 lmz
-kXj
+daz
 oRV
 ydI
 mdW
@@ -140874,7 +141203,7 @@ cBm
 cBm
 iZw
 dQl
-kXj
+daz
 lmz
 lmz
 lmz
@@ -141055,29 +141384,29 @@ bdH
 lmz
 lmz
 lmz
-kXj
-kXj
+daz
+daz
 eKJ
-cxc
+yaZ
 ffE
-cLo
-kXj
-kXj
-kXj
-kXj
+hZj
+clw
+daz
+daz
+daz
 tHu
-kXj
-kXj
+ebN
+ebN
 gXs
-kXj
-kXj
-kXj
-kXj
-mLE
-mLE
-kXj
-kXj
-kXj
+ebN
+ebN
+ebN
+daz
+wnh
+wnh
+daz
+daz
+daz
 lmz
 lmz
 lmz
@@ -141259,27 +141588,27 @@ lmz
 lmz
 lmz
 lmz
-kXj
-kXj
+daz
+daz
 ocB
 nJH
 rnH
-kXj
-kXj
+daz
+daz
 sTV
-kXj
-kXj
-kXj
+daz
+ebN
+ebN
 gbg
-viB
+uVv
 yit
-kXj
+ebN
 cxc
 kBy
 kBy
 gfu
 kBy
-kXj
+daz
 lmz
 lmz
 lmz
@@ -141463,17 +141792,17 @@ lmz
 lmz
 lmz
 lmz
-kXj
-kXj
-kXj
-kXj
-kXj
+daz
+daz
+daz
+daz
+daz
 tte
 hvw
 auf
 hTl
-auf
-auf
+xDC
+xDC
 yaQ
 bat
 mFN
@@ -141482,7 +141811,7 @@ dDp
 dDp
 frM
 lcg
-kXj
+daz
 lmz
 lmz
 lmz
@@ -141669,23 +141998,23 @@ lmz
 lmz
 lmz
 lmz
-kXj
+daz
 sbJ
 sbJ
 sbJ
-kXj
-eKJ
-kXj
-kXj
+daz
+rna
+clw
+qQS
 aCd
-kXj
+qQS
 mFN
 igr
 sEK
 sEK
 mlb
 lcg
-kXj
+daz
 lmz
 lmz
 lmz
@@ -141872,7 +142201,7 @@ lmz
 lmz
 lmz
 lmz
-kXj
+daz
 ltc
 eXk
 xns
@@ -141882,13 +142211,13 @@ rCi
 gba
 mUz
 our
-kXj
+ebN
 cxc
 kBy
 kBy
 khJ
 gyN
-kXj
+daz
 lmz
 lmz
 lmz
@@ -142075,23 +142404,23 @@ lmz
 lmz
 lmz
 lmz
-kXj
+daz
 tId
 wJB
 tJN
-kXj
-kXj
-kXj
-kXj
-kXj
-kXj
-kXj
-kXj
-kXj
-kXj
-kXj
-kXj
-kXj
+daz
+daz
+daz
+daz
+daz
+daz
+daz
+daz
+daz
+daz
+daz
+daz
+daz
 lmz
 lmz
 lmz
@@ -142278,11 +142607,11 @@ bdH
 bdH
 bdH
 lmz
-kXj
-kXj
-kXj
-kXj
-kXj
+daz
+daz
+daz
+daz
+daz
 lmz
 lmz
 lmz

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -144,24 +144,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/stair_clone/upper)
-"aaP" = (
-/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
-	dir = 2;
-	name = "\improper Brig Armoury";
-	req_access = null;
-	req_one_access_txt = "1;3"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "aaY" = (
 /obj/structure/lattice,
 /turf/open/space,
@@ -522,7 +504,9 @@
 	icon_state = "E";
 	pixel_x = 1
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "acK" = (
 /obj/structure/desertdam/decals/road_edge{
@@ -1518,6 +1502,9 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/cafeteria_officer)
+"aii" = (
+/turf/closed/wall/almayer/reinforced,
+/area/almayer/shipboard/brig/starboard_hallway)
 "aij" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 8;
@@ -1949,17 +1936,6 @@
 	},
 /turf/closed/wall/almayer/research/containment/wall/purple,
 /area/almayer/medical/containment/cell)
-"alp" = (
-/obj/structure/machinery/firealarm{
-	pixel_y = -28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "alw" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
 	dir = 2;
@@ -3200,6 +3176,15 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/cic)
+"arQ" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/firealarm{
+	pixel_y = 28
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/mp_bunks)
 "arR" = (
 /obj/structure/machinery/status_display{
 	pixel_y = 30
@@ -3231,6 +3216,17 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/cic)
+"asd" = (
+/obj/structure/surface/rack,
+/obj/item/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/masks,
+/turf/open/floor/almayer{
+	icon_state = "sterile_green_side"
+	},
+/area/almayer/shipboard/brig/medical)
 "ase" = (
 /turf/open/floor/almayer{
 	icon_state = "cargo"
@@ -3302,18 +3298,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north2)
-"asC" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 1
-	},
-/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
-	name = "\improper Brig Lobby";
-	closeOtherId = "brignorth"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "asD" = (
 /obj/effect/step_trigger/clone_cleaner,
 /obj/structure/machinery/door_control{
@@ -3323,7 +3307,9 @@
 	pixel_y = 24;
 	req_one_access_txt = "90;91;92"
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "asE" = (
 /obj/structure/bed/chair/office/dark{
@@ -3339,7 +3325,7 @@
 	req_one_access_txt = "91;92"
 	},
 /turf/open/floor/almayer/no_build{
-	icon_state = "test_floor4"
+	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "asG" = (
@@ -3349,7 +3335,9 @@
 	unacidable = 1;
 	unslashable = 1
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "asH" = (
 /obj/structure/machinery/telecomms/bus/preset_three,
@@ -3682,13 +3670,15 @@
 /area/almayer/command/airoom)
 "auf" = (
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom,
-/turf/closed/wall/almayer/aicore/hull,
+/turf/closed/wall/almayer/white/hull,
 /area/almayer/command/airoom)
 "aug" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "aui" = (
 /obj/structure/machinery/telecomms/hub/preset,
@@ -3958,6 +3948,11 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/powered)
+"avK" = (
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
+/area/almayer/command/airoom)
 "avL" = (
 /obj/structure/machinery/door_control{
 	id = "ARES StairsUpper";
@@ -3991,7 +3986,9 @@
 	pixel_y = -24;
 	req_one_access_txt = "91;92"
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "avM" = (
 /obj/structure/machinery/computer/cameras/almayer/ares{
@@ -4009,7 +4006,9 @@
 	pixel_y = 6
 	},
 /obj/item/tool/pen,
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "avN" = (
 /obj/structure/machinery/telecomms/processor/preset_two,
@@ -4099,6 +4098,13 @@
 	icon_state = "rasputin15"
 	},
 /area/almayer/powered/agent)
+"awb" = (
+/obj/structure/bed/chair/bolted,
+/turf/open/floor/almayer{
+	dir = 9;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/interrogation)
 "awd" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/living/pilotbunks)
@@ -4182,7 +4188,9 @@
 	icon_state = "W";
 	pixel_x = -1
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "awv" = (
 /obj/structure/machinery/computer/telecomms/monitor,
@@ -5666,7 +5674,9 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "aCf" = (
 /obj/structure/window/framed/almayer/hull/hijack_bustable,
@@ -5902,10 +5912,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/upper_engineering)
-"aDt" = (
-/obj/structure/machinery/cm_vending/clothing/military_police_warden,
-/turf/open/floor/wood/ship,
-/area/almayer/shipboard/brig/warden_office)
 "aDv" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -6899,6 +6905,23 @@
 	icon_state = "mono"
 	},
 /area/almayer/medical/hydroponics)
+"aIN" = (
+/obj/structure/closet/secure_closet/cmdcabinet{
+	desc = "A bulletproof cabinet containing communications equipment.";
+	name = "communications cabinet";
+	pixel_y = 24;
+	req_access = null;
+	req_one_access_txt = "3"
+	},
+/obj/item/device/radio/listening_bug/radio_linked/mp{
+	pixel_y = 8
+	},
+/obj/item/device/radio/listening_bug/radio_linked/mp,
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/warden_office)
 "aIP" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -6962,22 +6985,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/tankerbunks)
-"aIY" = (
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 8;
-	pixel_y = -2
-	},
-/obj/item/storage/firstaid/regular,
-/obj/item/reagent_container/spray/cleaner,
-/turf/open/floor/almayer{
-	icon_state = "sterile_green_side"
-	},
-/area/almayer/shipboard/brig/medical)
 "aJc" = (
 /obj/structure/machinery/door/airlock/almayer/command{
 	name = "\improper Commanding Officer's Mess"
@@ -7251,7 +7258,9 @@
 	unacidable = 0;
 	unslashable = 0
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "aKu" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -7481,9 +7490,6 @@
 	pixel_y = 16
 	},
 /obj/item/clothing/accessory/stethoscope,
-/obj/structure/closet/secure_closet/professor_dummy{
-	pixel_x = -32
-	},
 /turf/open/floor/almayer{
 	dir = 8;
 	icon_state = "sterile_green_corner"
@@ -7763,11 +7769,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/alpha)
-"aNW" = (
-/turf/open/floor/almayer{
-	icon_state = "redcorner"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "aNY" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -8679,6 +8680,22 @@
 	icon_state = "kitchen"
 	},
 /area/almayer/living/captain_mess)
+"aSz" = (
+/obj/structure/machinery/door/airlock/almayer/medical/glass{
+	name = "\improper Brig Medbay";
+	req_access = null;
+	req_one_access = null;
+	req_one_access_txt = "20;3";
+	closeOtherId = "brigmed"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/medical)
 "aSA" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 4;
@@ -9143,12 +9160,6 @@
 	icon_state = "bluefull"
 	},
 /area/almayer/living/captain_mess)
-"aVm" = (
-/obj/structure/closet/firecloset/full,
-/turf/open/floor/almayer{
-	icon_state = "cargo"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "aVo" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -9781,7 +9792,9 @@
 	pixel_y = -24;
 	req_one_access_txt = "200;91;92"
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "baw" = (
 /turf/open/floor/almayer,
@@ -9886,18 +9899,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/briefing)
-"bbi" = (
-/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	dir = 1;
-	name = "\improper Brig"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/medical)
 "bbr" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -10161,6 +10162,12 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_two)
+"bcW" = (
+/obj/structure/bed/chair/bolted{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/interrogation)
 "bcZ" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/box/masks,
@@ -11219,6 +11226,15 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/perma)
+"bjp" = (
+/obj/structure/machinery/door/airlock/almayer/generic{
+	dir = 1;
+	name = "Bathroom"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "bjs" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -11982,12 +11998,6 @@
 	icon_state = "blue"
 	},
 /area/almayer/hallways/lower/port_midship_hallway)
-"bop" = (
-/turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "cargo"
-	},
-/area/almayer/engineering/upper_engineering/port)
 "boq" = (
 /obj/structure/bed/chair/comfy/alpha,
 /turf/open/floor/almayer{
@@ -12205,7 +12215,7 @@
 /turf/open/floor/almayer,
 /area/almayer/squads/req)
 "bpR" = (
-/turf/open/floor/almayer/empty/requisitions,
+/turf/open/floor/almayer/empty,
 /area/supply/station)
 "bpS" = (
 /obj/structure/machinery/door/poddoor/railing{
@@ -12279,6 +12289,17 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/medical/lower_medical_lobby)
+"bqK" = (
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
+	},
+/obj/structure/surface/table/almayer,
+/obj/item/storage/donut_box,
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "bqL" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -12540,15 +12561,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/gym)
-"bsF" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 1;
-	name = "ship-grade camera"
-	},
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "bsG" = (
 /obj/structure/machinery/disposal{
 	density = 0;
@@ -12575,7 +12587,7 @@
 /area/almayer/squads/req)
 "bsK" = (
 /obj/effect/landmark/supply_elevator,
-/turf/open/floor/almayer/empty/requisitions,
+/turf/open/floor/almayer/empty,
 /area/supply/station)
 "bsL" = (
 /obj/structure/machinery/door/poddoor/railing{
@@ -12924,6 +12936,18 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/briefing)
+"bvu" = (
+/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	dir = 1;
+	name = "\improper Brig"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/medical)
 "bvz" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/structure/closet/secure_closet/surgical{
@@ -12964,6 +12988,19 @@
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/brig/general_equipment)
+"bvL" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "bvX" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -13233,12 +13270,17 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/living/port_emb)
-"bxE" = (
+"bxD" = (
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 1;
+	name = "ship-grade camera"
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/pipes/standard/manifold/hidden/supply,
-/obj/structure/machinery/light,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
@@ -14731,12 +14773,8 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/navigation)
-"bHu" = (
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
-/turf/open/floor/wood/ship,
+"bHw" = (
+/turf/open/floor/almayer,
 /area/almayer/shipboard/brig/warden_office)
 "bHB" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -14819,7 +14857,7 @@
 	name = "\improper ARES Mainframe Shutters";
 	plane = -7
 	},
-/obj/structure/machinery/door/poddoor/almayer/blended/aicore/open{
+/obj/structure/machinery/door/poddoor/almayer/blended/white/open{
 	closed_layer = 3.2;
 	id = "ARES Emergency";
 	layer = 3.2;
@@ -15171,15 +15209,6 @@
 	icon_state = "cargo"
 	},
 /area/almayer/living/cryo_cells)
-"bKI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/starboard_hallway)
 "bKJ" = (
 /obj/structure/machinery/door/airlock/almayer/maint,
 /turf/open/floor/almayer{
@@ -15191,25 +15220,6 @@
 /obj/effect/landmark/late_join/charlie,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/charlie)
-"bKN" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
-	dir = 2;
-	name = "\improper Brig Armoury";
-	req_access = null;
-	req_one_access_txt = "1;3";
-	closeOtherId = "brignorth"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "bKP" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -15388,9 +15398,9 @@
 	dir = 8;
 	pixel_y = 2
 	},
-/turf/open/floor/almayer/aicore/no_build{
-	icon_state = "ai_silver";
-	dir = 4
+/turf/open/floor/almayer/no_build{
+	dir = 4;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "bLw" = (
@@ -16095,6 +16105,12 @@
 	icon_state = "emeraldcorner"
 	},
 /area/almayer/squads/charlie)
+"bPb" = (
+/obj/structure/closet/secure_closet/medical2,
+/turf/open/floor/almayer{
+	icon_state = "sterile_green_side"
+	},
+/area/almayer/shipboard/brig/medical)
 "bPg" = (
 /obj/vehicle/powerloader,
 /obj/structure/machinery/light{
@@ -17188,6 +17204,17 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/chapel)
+"bWD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "bWJ" = (
 /obj/structure/machinery/shower{
 	dir = 4
@@ -17203,10 +17230,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/req)
-"bWQ" = (
-/obj/structure/pipes/vents/pump,
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/warden_office)
 "bWT" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -17260,15 +17283,6 @@
 	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/operating_room_two)
-"bXy" = (
-/obj/structure/machinery/cm_vending/clothing/maintenance_technician,
-/obj/structure/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/engineering/upper_engineering/port)
 "bXz" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating/plating_catwalk,
@@ -17305,6 +17319,12 @@
 "bYn" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/engineering/upper_engineering/port)
+"bYp" = (
+/obj/structure/bed/chair/comfy/orange{
+	dir = 8
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/warden_office)
 "bYq" = (
 /obj/structure/cargo_container/wy/left,
 /turf/open/floor/almayer{
@@ -17803,7 +17823,9 @@
 	icon_state = "S";
 	layer = 3.3
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "ccs" = (
 /obj/structure/disposalpipe/segment{
@@ -18802,10 +18824,23 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/port_point_defense)
 "clw" = (
-/turf/open/floor/almayer/aicore/glowing/no_build{
-	icon_state = "ai_floor3"
+/obj/structure/machinery/light{
+	dir = 8;
+	invisibility = 101;
+	unacidable = 1;
+	unslashable = 1
+	},
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
+"clD" = (
+/obj/structure/machinery/power/apc/almayer,
+/obj/structure/sign/safety/rewire{
+	pixel_y = -38
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/warden_office)
 "clE" = (
 /obj/structure/machinery/door/airlock/almayer/marine/delta/medic,
 /turf/open/floor/almayer{
@@ -19063,9 +19098,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/lower/starboard_midship_hallway)
-"cmM" = (
-/turf/closed/wall/almayer,
-/area/almayer/shipboard/brig/medical)
 "cmN" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/almayer{
@@ -19117,7 +19149,9 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "cnq" = (
 /obj/structure/machinery/line_nexter{
@@ -19279,9 +19313,9 @@
 	},
 /area/almayer/medical/morgue)
 "cnZ" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/tool/surgery/scalpel,
 /obj/item/tool/surgery/hemostat,
+/obj/item/tool/surgery/scalpel,
+/obj/structure/surface/table/reinforced/prison,
 /turf/open/floor/almayer{
 	dir = 8;
 	icon_state = "sterile_green_corner"
@@ -19481,7 +19515,9 @@
 	pixel_x = 5;
 	pixel_y = 6
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "cqp" = (
 /obj/structure/largecrate/random/barrel/white,
@@ -19531,6 +19567,15 @@
 /obj/item/storage/fancy/cigar/tarbacktube,
 /turf/open/floor/almayer,
 /area/almayer/living/bridgebunks)
+"cqZ" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "crc" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -19572,12 +19617,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/stern)
-"csy" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 1
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/warden_office)
 "csI" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -19778,6 +19817,15 @@
 "cvx" = (
 /turf/closed/wall/almayer,
 /area/almayer/maint/lower/cryo_cells)
+"cvE" = (
+/obj/effect/decal/cleanable/vomit,
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_21"
+	},
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/engineering/upper_engineering/port)
 "cvH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -19823,12 +19871,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/req)
-"cwC" = (
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "cwL" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_y = -25
@@ -19839,7 +19881,9 @@
 /area/almayer/hallways/upper/stern_hallway)
 "cwS" = (
 /obj/structure/blocker/invisible_wall,
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "plating"
+	},
 /area/almayer/command/airoom)
 "cwX" = (
 /obj/structure/ladder{
@@ -19853,7 +19897,12 @@
 	icon_state = "S";
 	layer = 3.3
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build,
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/almayer/no_build{
+	icon_state = "tcomms"
+	},
 /area/almayer/command/airoom)
 "cxk" = (
 /obj/structure/machinery/light,
@@ -19868,16 +19917,6 @@
 	icon_state = "test_floor5"
 	},
 /area/almayer/hallways/lower/port_midship_hallway)
-"cyc" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
-/obj/structure/pipes/vents/pump,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "cyo" = (
 /obj/structure/machinery/vending/cigarette,
 /turf/open/floor/almayer{
@@ -19932,6 +19971,28 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cells)
+"czm" = (
+/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	name = "\improper Warden's Office";
+	closeOtherId = "brigwarden"
+	},
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 4;
+	id = "Warden Office Shutters";
+	name = "\improper Privacy Shutters"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 8
+	},
+/obj/structure/machinery/door/poddoor/almayer/open{
+	dir = 4;
+	id = "courtyard_cells";
+	name = "\improper Courtyard Lockdown Shutter"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/warden_office)
 "czJ" = (
 /obj/structure/sign/safety/distribution_pipes{
 	pixel_x = 15;
@@ -20002,9 +20063,6 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical_lobby)
-"cAR" = (
-/turf/closed/wall/almayer/reinforced,
-/area/almayer/shipboard/brig/mp_bunks)
 "cBb" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -20050,7 +20108,10 @@
 	dir = 1;
 	icon_state = "ramptop"
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	dir = 4;
+	icon_state = "silver"
+	},
 /area/almayer/command/airoom)
 "cBs" = (
 /obj/structure/bed/chair,
@@ -20341,9 +20402,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/upper_engineering)
-"cHk" = (
-/turf/closed/wall/almayer/reinforced,
-/area/almayer/shipboard/brig/warden_office)
 "cHl" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -20362,6 +20420,9 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/upper/u_m_p)
+"cHp" = (
+/turf/closed/wall/almayer/reinforced,
+/area/almayer/shipboard/brig/execution_storage)
 "cHu" = (
 /turf/closed/wall/almayer/research/containment/wall/south,
 /area/almayer/medical/containment/cell/cl)
@@ -20370,12 +20431,6 @@
 	icon_state = "orangefull"
 	},
 /area/almayer/living/briefing)
-"cHC" = (
-/obj/structure/machinery/cm_vending/clothing/combat_correspondent,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/command/combat_correspondent)
 "cHE" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -20558,15 +20613,6 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/maint/lower/constr)
-"cKJ" = (
-/obj/structure/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/interrogation)
 "cKL" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -20593,8 +20639,8 @@
 	icon_state = "N";
 	pixel_y = 1
 	},
-/turf/open/floor/almayer/aicore/no_build{
-	icon_state = "ai_arrow"
+/turf/open/floor/almayer/no_build{
+	icon_state = "cargo_arrow"
 	},
 /area/almayer/command/airoom)
 "cLq" = (
@@ -20699,17 +20745,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/medical/containment/cell/cl)
-"cNI" = (
-/turf/open/floor/almayer{
-	icon_state = "dark_sterile"
-	},
-/area/almayer/shipboard/brig/medical)
-"cNJ" = (
-/obj/structure/pipes/vents/pump,
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "cNK" = (
 /obj/structure/pipes/vents/pump{
 	dir = 1
@@ -20904,9 +20939,6 @@
 "cQv" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/shipboard/brig/general_equipment)
-"cQG" = (
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/starboard_hallway)
 "cQL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -21048,12 +21080,6 @@
 	icon_state = "cargo"
 	},
 /area/almayer/squads/req)
-"cTy" = (
-/obj/structure/closet/secure_closet/medical2,
-/turf/open/floor/almayer{
-	icon_state = "sterile_green_side"
-	},
-/area/almayer/shipboard/brig/medical)
 "cTC" = (
 /obj/structure/machinery/vending/walkman,
 /turf/open/floor/almayer{
@@ -21270,6 +21296,15 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_m_s)
+"cXv" = (
+/obj/structure/bed/chair/bolted{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/interrogation)
 "cXC" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -21279,19 +21314,6 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/containment)
-"cXD" = (
-/obj/structure/surface/rack,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/glasses/sunglasses/blindfold,
-/obj/item/clothing/mask/muzzle,
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 8;
-	name = "ship-grade camera"
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/execution_storage)
 "cXF" = (
 /obj/structure/machinery/flasher{
 	alpha = 1;
@@ -21310,12 +21332,6 @@
 	icon_state = "greencorner"
 	},
 /area/almayer/squads/req)
-"cXV" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/mp_bunks)
 "cXW" = (
 /obj/structure/machinery/status_display{
 	pixel_y = 30
@@ -21457,7 +21473,7 @@
 	},
 /area/almayer/engineering/upper_engineering/port)
 "daz" = (
-/turf/closed/wall/almayer/aicore/hull,
+/turf/closed/wall/almayer/white/hull,
 /area/almayer/command/airoom)
 "daF" = (
 /obj/structure/machinery/power/apc/almayer{
@@ -21592,19 +21608,18 @@
 /obj/structure/machinery/power/apc/almayer,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/upper/u_m_p)
+"dda" = (
+/obj/structure/machinery/cm_vending/clothing/maintenance_technician,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/engineering/upper_engineering/port)
 "ddf" = (
 /obj/structure/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
 /area/almayer/engineering/lower/engine_core)
-"ddj" = (
-/obj/structure/bed/chair/bolted,
-/turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/interrogation)
 "ddk" = (
 /obj/structure/surface/table/almayer,
 /turf/open/floor/almayer{
@@ -21695,9 +21710,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_m_s)
-"deH" = (
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/warden_office)
 "deT" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -21743,6 +21755,17 @@
 	icon_state = "green"
 	},
 /area/almayer/living/grunt_rnr)
+"dfU" = (
+/obj/structure/window/framed/almayer,
+/obj/structure/machinery/door/poddoor/almayer/open{
+	id = "Brig Lockdown Shutters";
+	name = "\improper Brig Lockdown Shutter"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/almayer/shipboard/brig/starboard_hallway)
 "dgg" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 4;
@@ -22012,18 +22035,6 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/cichallway)
-"dmr" = (
-/obj/structure/transmitter{
-	name = "Brig Offices Telephone";
-	phone_category = "MP Dept.";
-	phone_id = "Brig Main Offices";
-	pixel_y = 32
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "dmv" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -22992,7 +23003,9 @@
 	icon_state = "W";
 	layer = 3.3
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "tcomms"
+	},
 /area/almayer/command/airoom)
 "dDt" = (
 /obj/structure/toilet{
@@ -23148,19 +23161,6 @@
 	icon_state = "redcorner"
 	},
 /area/almayer/command/lifeboat)
-"dFl" = (
-/obj/structure/sign/safety/security{
-	pixel_x = 15;
-	pixel_y = 32
-	},
-/obj/structure/sign/safety/restrictedarea{
-	pixel_y = 32
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "dFF" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_21"
@@ -23218,7 +23218,10 @@
 /obj/structure/stairs{
 	dir = 1
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	dir = 8;
+	icon_state = "silver"
+	},
 /area/almayer/command/airoom)
 "dGr" = (
 /obj/structure/pipes/vents/scrubber{
@@ -23253,17 +23256,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/maint/hull/lower/l_f_s)
-"dGT" = (
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
-/obj/structure/surface/table/almayer,
-/obj/item/storage/donut_box,
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "dGU" = (
 /obj/structure/sign/poster/propaganda{
 	pixel_x = -27
@@ -23327,13 +23319,17 @@
 /area/almayer/living/bridgebunks)
 "dIi" = (
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom,
-/turf/open/floor/plating/plating_catwalk/aicore,
+/turf/open/floor/plating/plating_catwalk{
+	allow_construction = 0
+	},
 /area/almayer/command/airoom)
 "dIn" = (
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 5
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "dID" = (
 /obj/effect/decal/warning_stripes{
@@ -23384,6 +23380,39 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/p_bow)
+"dJB" = (
+/obj/structure/sign/safety/rewire{
+	pixel_y = 32
+	},
+/obj/item/bedsheet/brown{
+	layer = 3.1
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/structure/bed{
+	can_buckle = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 3.3;
+	pixel_y = 4
+	},
+/obj/structure/bed{
+	buckling_y = 13;
+	layer = 3.5;
+	pixel_y = 13
+	},
+/obj/item/bedsheet/brown{
+	pixel_y = 13
+	},
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "dJF" = (
 /obj/structure/pipes/standard/cap/hidden{
 	dir = 4
@@ -23414,9 +23443,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/briefing)
-"dJJ" = (
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/execution_storage)
 "dKp" = (
 /turf/open/floor/almayer/research/containment/corner{
 	dir = 4
@@ -23498,6 +23524,20 @@
 	icon_state = "cargo"
 	},
 /area/almayer/lifeboat_pumps/south1)
+"dMf" = (
+/obj/structure/surface/table/almayer,
+/obj/item/storage/photo_album{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/folder/black{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/command/combat_correspondent)
 "dMB" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -23509,6 +23549,13 @@
 	dir = 8
 	},
 /area/almayer/medical/containment/cell)
+"dNm" = (
+/obj/structure/machinery/cm_vending/sorted/medical,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "sterile_green_side"
+	},
+/area/almayer/shipboard/brig/medical)
 "dNq" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -23569,6 +23616,15 @@
 	icon_state = "cargo"
 	},
 /area/almayer/engineering/lower/workshop/hangar)
+"dOf" = (
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
+	pixel_y = 25
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "dOl" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/storage/fancy/cigar,
@@ -23692,7 +23748,10 @@
 /obj/structure/stairs{
 	dir = 1
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	dir = 4;
+	icon_state = "silver"
+	},
 /area/almayer/command/airoom)
 "dQp" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -23738,21 +23797,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/hydroponics)
-"dRj" = (
-/obj/structure/toilet{
-	pixel_y = 13
-	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/structure/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/almayer{
-	icon_state = "dark_sterile"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "dRo" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/sign/safety/bridge{
@@ -23781,20 +23825,6 @@
 	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
-"dRA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/machinery/status_display{
-	pixel_y = -32
-	},
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "dRD" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/machinery/door/airlock/almayer/security{
@@ -23973,6 +24003,10 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
+"dVE" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/starboard_hallway)
 "dVH" = (
 /obj/structure/platform{
 	dir = 8
@@ -24074,6 +24108,11 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/engineering/laundry)
+"dXm" = (
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
+/area/almayer/shipboard/brig/medical)
 "dXo" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/taperecorder,
@@ -24350,7 +24389,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/u_m_p)
 "ebN" = (
-/turf/closed/wall/almayer/aicore/reinforced,
+/turf/closed/wall/almayer/white/reinforced,
 /area/almayer/command/airoom)
 "ebV" = (
 /obj/structure/machinery/status_display{
@@ -24438,10 +24477,43 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_m_p)
+"edJ" = (
+/obj/structure/surface/table/almayer,
+/obj/item/storage/box/bodybags{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/storage/box/bodybags,
+/obj/structure/machinery/light/small{
+	dir = 4;
+	pixel_y = -12
+	},
+/obj/structure/machinery/power/apc/almayer{
+	dir = 4
+	},
+/obj/structure/sign/safety/rewire{
+	pixel_x = 32;
+	pixel_y = 17
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/execution_storage)
 "edV" = (
 /obj/structure/machinery/power/terminal,
 /turf/open/floor/almayer,
 /area/almayer/maint/upper/mess)
+"edW" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
+	name = "\improper Brig Cells"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "eed" = (
 /turf/open/floor/almayer{
 	icon_state = "mono"
@@ -24682,9 +24754,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
-"ehl" = (
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/interrogation)
 "ehx" = (
 /obj/effect/landmark/start/marine/tl/alpha,
 /obj/effect/landmark/late_join/alpha,
@@ -24901,16 +24970,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/starboard_garden)
-"ekZ" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/secure_data{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/warden_office)
 "elf" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -24948,21 +25007,6 @@
 	dir = 1
 	},
 /area/almayer/medical/containment/cell)
-"elV" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "SW-out"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/obj/structure/machinery/door/airlock/almayer/security/reinforced{
-	dir = 2;
-	name = "\improper Execution Equipment"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/execution_storage)
 "elY" = (
 /obj/structure/machinery/light/small{
 	dir = 1
@@ -25343,8 +25387,14 @@
 	},
 /area/almayer/maint/hull/lower/l_m_s)
 "erN" = (
-/turf/open/floor/almayer/aicore/no_build{
-	icon_state = "ai_plates"
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/obj/structure/pipes/vents/pump/no_boom{
+	dir = 1
+	},
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "esd" = (
@@ -25365,6 +25415,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_f_s)
+"esq" = (
+/obj/structure/window/framed/almayer,
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/almayer/shipboard/brig/medical)
 "esC" = (
 /obj/structure/toilet{
 	pixel_y = 13
@@ -25474,6 +25531,9 @@
 /obj/effect/landmark/yautja_teleport,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/s_bow)
+"etW" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/execution_storage)
 "eua" = (
 /obj/structure/machinery/vending/cigarette,
 /turf/open/floor/almayer{
@@ -25511,7 +25571,9 @@
 	pixel_y = 24;
 	req_one_access_txt = "200;91;92"
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "tcomms"
+	},
 /area/almayer/command/airoom)
 "euO" = (
 /obj/structure/machinery/light{
@@ -25624,6 +25686,13 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/squads/delta)
+"ewP" = (
+/obj/structure/janitorialcart,
+/obj/item/tool/mop,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/execution_storage)
 "ewS" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -25670,9 +25739,12 @@
 	icon_state = "greencorner"
 	},
 /area/almayer/hallways/lower/starboard_midship_hallway)
-"eyD" = (
-/turf/closed/wall/almayer/reinforced,
-/area/almayer/shipboard/brig/starboard_hallway)
+"eyc" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/mp_bunks)
 "eyG" = (
 /obj/structure/platform,
 /turf/open/floor/almayer{
@@ -25839,12 +25911,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
-"eBx" = (
-/obj/structure/closet/emcloset/legacy,
-/turf/open/floor/almayer{
-	icon_state = "cargo"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "eBE" = (
 /obj/structure/machinery/photocopier{
 	anchored = 0
@@ -26327,8 +26393,14 @@
 /obj/structure/machinery/status_display{
 	pixel_y = 30
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build{
-	icon_state = "ai_floor3"
+/obj/structure/machinery/light{
+	dir = 4;
+	invisibility = 101;
+	unacidable = 1;
+	unslashable = 1
+	},
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "eKQ" = (
@@ -26406,15 +26478,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_m_s)
-"eLX" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "eMh" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
 	name = "\improper Laundry Room"
@@ -26531,6 +26594,16 @@
 	icon_state = "orange"
 	},
 /area/almayer/hallways/lower/starboard_umbilical)
+"ePA" = (
+/obj/structure/pipes/vents/pump,
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
+	pixel_y = 25
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "sterile_green_side"
+	},
+/area/almayer/shipboard/brig/medical)
 "ePM" = (
 /obj/structure/sign/safety/distribution_pipes{
 	pixel_x = 32
@@ -26685,6 +26758,15 @@
 	icon_state = "cargo_arrow"
 	},
 /area/almayer/engineering/lower/workshop/hangar)
+"eRX" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_21"
+	},
+/turf/open/floor/almayer{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "eSk" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -26753,6 +26835,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_a_s)
+"eTM" = (
+/obj/structure/pipes/vents/pump,
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "eUe" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -26935,11 +27023,10 @@
 "eXk" = (
 /obj/effect/landmark/late_join/working_joe,
 /obj/effect/landmark/start/working_joe,
-/obj/structure/machinery/light/small{
-	dir = 8;
-	light_color = "#d69c46"
+/obj/structure/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/plating/plating_catwalk/aicore,
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/command/airoom)
 "eXq" = (
 /turf/closed/wall/almayer,
@@ -27018,7 +27105,9 @@
 	dir = 8;
 	pixel_x = 29
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "eYD" = (
 /obj/effect/decal/warning_stripes{
@@ -27348,12 +27437,15 @@
 /area/almayer/engineering/lower)
 "fcX" = (
 /obj/effect/step_trigger/clone_cleaner,
+/obj/structure/machinery/light{
+	dir = 8
+	},
 /obj/structure/platform_decoration{
 	dir = 1
 	},
-/turf/open/floor/almayer/aicore/no_build{
-	icon_state = "ai_silver";
-	dir = 8
+/turf/open/floor/almayer/no_build{
+	dir = 8;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "fdf" = (
@@ -27542,15 +27634,6 @@
 	icon_state = "green"
 	},
 /area/almayer/squads/req)
-"fgt" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "sterile_green_side"
-	},
-/area/almayer/shipboard/brig/medical)
 "fgE" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -27716,7 +27799,9 @@
 	icon_state = "E";
 	pixel_x = 1
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "fmB" = (
 /obj/structure/bed/chair/comfy{
@@ -27784,6 +27869,18 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/squads/req)
+"fnO" = (
+/obj/structure/machinery/door/airlock/almayer/security{
+	dir = 2;
+	name = "\improper Interrogation Observation"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/interrogation)
 "foC" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/disposalpipe/segment{
@@ -27877,6 +27974,13 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/starboard_aft_hallway)
+"fpO" = (
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/warden_office)
 "fpR" = (
 /obj/structure/surface/table/almayer,
 /obj/effect/spawner/random/tool,
@@ -27965,16 +28069,6 @@
 /obj/structure/surface/table/reinforced/black,
 /turf/open/floor/carpet,
 /area/almayer/command/cichallway)
-"fqQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "fqU" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -28025,42 +28119,6 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
-"frt" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/door_control{
-	id = "courtyard_cells";
-	name = "\improper Courtyard Lockdown Shutters";
-	pixel_x = 6;
-	req_access_txt = "3"
-	},
-/obj/structure/machinery/door_control{
-	id = "Brig Lockdown Shutters";
-	name = "Brig Lockdown Shutters";
-	pixel_x = -6;
-	req_access_txt = "3"
-	},
-/obj/structure/machinery/door_control{
-	id = "courtyard window";
-	name = "Courtyard Window Shutters";
-	pixel_x = -6;
-	pixel_y = 9;
-	req_access_txt = "3"
-	},
-/obj/structure/machinery/door_control{
-	id = "Cell Privacy Shutters";
-	name = "Cell Privacy Shutters";
-	pixel_x = 6;
-	pixel_y = 9;
-	req_access_txt = "3"
-	},
-/obj/structure/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/warden_office)
 "frz" = (
 /obj/structure/machinery/door/airlock/almayer/secure/reinforced{
 	name = "\improper Exterior Airlock";
@@ -28078,6 +28136,25 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/starboard_missiles)
+"frG" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
+	dir = 2;
+	name = "\improper Brig Armoury";
+	req_access = null;
+	req_one_access_txt = "1;3";
+	closeOtherId = "brignorth"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "frI" = (
 /obj/structure/sign/safety/distribution_pipes{
 	pixel_x = 8;
@@ -28094,7 +28171,9 @@
 	icon_state = "NW-out";
 	pixel_y = 1
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "tcomms"
+	},
 /area/almayer/command/airoom)
 "frV" = (
 /obj/structure/toilet{
@@ -28216,15 +28295,6 @@
 	icon_state = "orange"
 	},
 /area/almayer/hallways/lower/port_umbilical)
-"fuY" = (
-/obj/structure/bed/chair/bolted{
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/interrogation)
 "fva" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -28425,12 +28495,6 @@
 	},
 /turf/open/floor/plating/almayer,
 /area/almayer/living/briefing)
-"fyI" = (
-/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
-	pixel_y = -25
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/warden_office)
 "fyT" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -28537,6 +28601,17 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/upper/aft_hallway)
+"fAZ" = (
+/obj/structure/surface/table/almayer,
+/obj/item/weapon/gun/energy/taser,
+/obj/item/weapon/gun/energy/taser{
+	pixel_y = 8
+	},
+/obj/structure/machinery/recharger,
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "fBi" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -28653,6 +28728,10 @@
 	icon_state = "orangecorner"
 	},
 /area/almayer/hallways/upper/stern_hallway)
+"fDw" = (
+/obj/structure/pipes/vents/scrubber,
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/starboard_hallway)
 "fDG" = (
 /obj/structure/machinery/vending/coffee,
 /obj/structure/machinery/light{
@@ -28728,7 +28807,9 @@
 /obj/structure/machinery/camera/autoname/almayer/containment/ares{
 	dir = 4
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "fER" = (
 /obj/structure/machinery/autolathe,
@@ -28736,6 +28817,12 @@
 	icon_state = "cargo"
 	},
 /area/almayer/hallways/hangar)
+"fEX" = (
+/obj/structure/machinery/cm_vending/clothing/senior_officer,
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/medical/upper_medical)
 "fFe" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = 32
@@ -28803,6 +28890,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_f_p)
+"fFV" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 10
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/starboard_hallway)
 "fGa" = (
 /obj/structure/surface/rack,
 /obj/effect/decal/warning_stripes{
@@ -28874,6 +28967,12 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/upper/aft_hallway)
+"fGU" = (
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
+	pixel_y = -25
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/warden_office)
 "fHb" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating/plating_catwalk,
@@ -28998,16 +29097,18 @@
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 4
 	},
-/turf/open/floor/almayer/aicore/no_build{
-	icon_state = "ai_arrow";
-	dir = 8
+/turf/open/floor/almayer/no_build{
+	dir = 8;
+	icon_state = "cargo_arrow"
 	},
 /area/almayer/command/airoom)
 "fKe" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out"
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "tcomms"
+	},
 /area/almayer/command/airoom)
 "fKh" = (
 /obj/structure/window/framed/almayer,
@@ -29175,9 +29276,9 @@
 	pixel_y = -8;
 	req_one_access_txt = "90;91;92"
 	},
-/turf/open/floor/almayer/aicore/no_build{
-	icon_state = "ai_silver";
-	dir = 4
+/turf/open/floor/almayer/no_build{
+	dir = 4;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "fMt" = (
@@ -29187,7 +29288,7 @@
 	plane = -7
 	},
 /obj/effect/step_trigger/ares_alert/core,
-/obj/structure/machinery/door/poddoor/almayer/blended/aicore/open{
+/obj/structure/machinery/door/poddoor/almayer/blended/white/open{
 	closed_layer = 3.2;
 	id = "ARES Emergency";
 	layer = 3.2;
@@ -29257,6 +29358,16 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
+"fOm" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/cameras/almayer_network{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/warden_office)
 "fOv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29853,7 +29964,9 @@
 	pixel_x = 8;
 	pixel_y = -8
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "gbg" = (
 /obj/structure/sign/safety/terminal{
@@ -29877,8 +29990,8 @@
 	pixel_y = -8;
 	req_one_access_txt = "90;91;92"
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build{
-	icon_state = "ai_floor3"
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "gbs" = (
@@ -29962,16 +30075,6 @@
 	icon_state = "red"
 	},
 /area/almayer/hallways/hangar)
-"gdG" = (
-/obj/structure/bed/chair{
-	dir = 8;
-	pixel_y = 3
-	},
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "gdJ" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -30024,18 +30127,8 @@
 /area/almayer/maint/hull/upper/u_f_p)
 "ger" = (
 /obj/structure/surface/table/almayer,
-/obj/item/paper_bin/wy{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/tool/pen{
-	pixel_x = 8
-	},
-/obj/item/clipboard{
-	pixel_x = -8
-	},
-/obj/item/folder/white{
-	pixel_x = -8
+/obj/structure/machinery/computer/cameras/public_helmet{
+	dir = 4
 	},
 /turf/open/floor/almayer{
 	icon_state = "dark_sterile"
@@ -30050,21 +30143,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/port_midship_hallway)
-"gfd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/machinery/power/apc/almayer,
-/obj/structure/sign/safety/rewire{
-	pixel_y = -38
-	},
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "gfo" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 1;
@@ -30096,7 +30174,9 @@
 	icon_state = "S";
 	layer = 3.3
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "tcomms"
+	},
 /area/almayer/command/airoom)
 "gfv" = (
 /turf/open/floor/plating/plating_catwalk,
@@ -30208,15 +30288,6 @@
 "ghF" = (
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/vehiclehangar)
-"gii" = (
-/obj/structure/bed/chair/bolted{
-	dir = 8
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/interrogation)
 "gio" = (
 /obj/structure/closet/emcloset,
 /obj/structure/sign/safety/restrictedarea{
@@ -30316,7 +30387,9 @@
 /obj/item/storage/box/ids{
 	pixel_x = -4
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "gjB" = (
 /obj/structure/machinery/light{
@@ -30396,17 +30469,6 @@
 	icon_state = "mono"
 	},
 /area/almayer/medical/medical_science)
-"glG" = (
-/obj/structure/surface/rack,
-/obj/item/storage/box/gloves{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/masks,
-/turf/open/floor/almayer{
-	icon_state = "sterile_green_side"
-	},
-/area/almayer/shipboard/brig/medical)
 "glH" = (
 /obj/structure/machinery/door/airlock/almayer/engineering{
 	dir = 2;
@@ -30420,13 +30482,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/lower/workshop)
-"glP" = (
-/obj/structure/janitorialcart,
-/obj/item/tool/mop,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/execution_storage)
 "gmb" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 1
@@ -30447,6 +30502,42 @@
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/starboard_point_defense)
+"gmm" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/door_control{
+	id = "courtyard_cells";
+	name = "\improper Courtyard Lockdown Shutters";
+	pixel_x = 6;
+	req_access_txt = "3"
+	},
+/obj/structure/machinery/door_control{
+	id = "Brig Lockdown Shutters";
+	name = "Brig Lockdown Shutters";
+	pixel_x = -6;
+	req_access_txt = "3"
+	},
+/obj/structure/machinery/door_control{
+	id = "courtyard window";
+	name = "Courtyard Window Shutters";
+	pixel_x = -6;
+	pixel_y = 9;
+	req_access_txt = "3"
+	},
+/obj/structure/machinery/door_control{
+	id = "Cell Privacy Shutters";
+	name = "Cell Privacy Shutters";
+	pixel_x = 6;
+	pixel_y = 9;
+	req_access_txt = "3"
+	},
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/warden_office)
 "gms" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -30982,17 +31073,6 @@
 	icon_state = "red"
 	},
 /area/almayer/hallways/upper/starboard)
-"gxt" = (
-/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	name = "\improper Warden's Office"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 8
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/warden_office)
 "gxI" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/maint/hull/upper/s_bow)
@@ -31035,9 +31115,6 @@
 	icon_state = "blue"
 	},
 /area/almayer/hallways/upper/aft_hallway)
-"gym" = (
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/mp_bunks)
 "gyn" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -31180,7 +31257,9 @@
 	pixel_y = 8;
 	req_one_access_txt = "91;92"
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "gAj" = (
 /obj/structure/bed/chair/comfy/charlie{
@@ -31473,6 +31552,22 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/delta)
+"gGp" = (
+/obj/structure/surface/table/almayer,
+/obj/item/clothing/mask/cigarette/pipe{
+	pixel_x = 8
+	},
+/obj/structure/transmitter/rotary{
+	name = "Reporter Telephone";
+	phone_category = "Almayer";
+	phone_id = "Reporter";
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/command/combat_correspondent)
 "gGr" = (
 /obj/structure/machinery/vending/cigarette,
 /turf/open/floor/almayer{
@@ -31613,21 +31708,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_a_p)
-"gIz" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 1;
-	name = "ship-grade camera"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "gII" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -31646,12 +31726,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/upper/aft_hallway)
-"gIO" = (
-/obj/structure/bed/chair/bolted{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/interrogation)
 "gIU" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/box/tapes{
@@ -31685,23 +31759,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/lower/repair_bay)
-"gJE" = (
-/obj/structure/machinery/door_control{
-	id = "Interrogation Shutters";
-	name = "\improper Shutters";
-	pixel_x = 24;
-	pixel_y = 12;
-	req_access_txt = "3"
-	},
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 8;
-	name = "ship-grade camera"
-	},
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/interrogation)
 "gJF" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/maint/hull/upper/s_stern)
@@ -31911,6 +31968,20 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/starboard_fore_hallway)
+"gMw" = (
+/obj/structure/surface/table/almayer,
+/obj/item/paper_bin{
+	pixel_x = -7
+	},
+/obj/item/tool/pen,
+/obj/item/tool/pen{
+	pixel_y = 3
+	},
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "gMJ" = (
 /obj/structure/largecrate/supply/weapons/pistols,
 /turf/open/floor/plating/plating_catwalk,
@@ -31944,7 +32015,9 @@
 	unacidable = 0;
 	unslashable = 0
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "gMS" = (
 /obj/structure/machinery/camera/autoname/almayer{
@@ -32058,9 +32131,9 @@
 	unacidable = 0;
 	unslashable = 0
 	},
-/turf/open/floor/almayer/aicore/no_build{
-	icon_state = "ai_silver";
-	dir = 4
+/turf/open/floor/almayer/no_build{
+	dir = 4;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "gOC" = (
@@ -32098,10 +32171,16 @@
 	vector_x = -97;
 	vector_y = 65
 	},
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
+	},
 /obj/structure/stairs{
 	dir = 1
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	dir = 4
+	},
 /area/almayer/command/airoom)
 "gPS" = (
 /obj/effect/decal/warning_stripes{
@@ -32241,12 +32320,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/maint/hull/upper/u_f_s)
-"gSz" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 10
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/mp_bunks)
 "gSH" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/almayer{
@@ -32276,8 +32349,8 @@
 	dir = 4;
 	pixel_y = -18
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build{
-	icon_state = "ai_floor3"
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "gTK" = (
@@ -32339,6 +32412,10 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/maint/hull/upper/u_f_p)
+"gUC" = (
+/obj/structure/machinery/cm_vending/clothing/military_police_warden,
+/turf/open/floor/wood/ship,
+/area/almayer/shipboard/brig/warden_office)
 "gUG" = (
 /obj/structure/prop/invuln/overhead_pipe{
 	dir = 4;
@@ -32369,9 +32446,9 @@
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 4
 	},
-/turf/open/floor/almayer/aicore/no_build{
-	icon_state = "ai_arrow";
-	dir = 4
+/turf/open/floor/almayer/no_build{
+	dir = 4;
+	icon_state = "cargo_arrow"
 	},
 /area/almayer/command/airoom)
 "gUS" = (
@@ -32434,6 +32511,14 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/south1)
+"gWi" = (
+/obj/structure/machinery/medical_pod/sleeper{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
+/area/almayer/shipboard/brig/medical)
 "gWm" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 4
@@ -32570,15 +32655,6 @@
 	icon_state = "redfull"
 	},
 /area/almayer/living/offices/flight)
-"gYx" = (
-/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
-	pixel_y = 25
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "gYI" = (
 /obj/structure/platform{
 	dir = 4
@@ -32707,16 +32783,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/lower/s_bow)
-"haY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer{
-	icon_state = "redcorner"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "hbl" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 1
@@ -32756,6 +32822,17 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/port_umbilical)
+"hbD" = (
+/obj/structure/machinery/firealarm{
+	pixel_y = -28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "hbE" = (
 /obj/structure/largecrate/random,
 /obj/item/reagent_container/food/snacks/cheesecakeslice{
@@ -32811,6 +32888,15 @@
 	icon_state = "silver"
 	},
 /area/almayer/engineering/port_atmos)
+"hco" = (
+/obj/structure/machinery/keycard_auth{
+	pixel_x = 25
+	},
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/warden_office)
 "hcw" = (
 /obj/structure/surface/table/reinforced/black,
 /obj/item/explosive/grenade/high_explosive/training,
@@ -32874,18 +32960,6 @@
 	icon_state = "green"
 	},
 /area/almayer/squads/req)
-"hdQ" = (
-/obj/structure/closet/secure_closet{
-	name = "\improper Execution Firearms"
-	},
-/obj/item/weapon/gun/rifle/m4ra,
-/obj/item/weapon/gun/rifle/m4ra,
-/obj/item/weapon/gun/rifle/m4ra,
-/obj/item/ammo_box/magazine/m4ra,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/execution_storage)
 "hdV" = (
 /obj/structure/sign/safety/escapepod{
 	pixel_x = 8;
@@ -32902,6 +32976,15 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
+"heg" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "heo" = (
 /obj/structure/machinery/power/apc/almayer{
 	cell_type = /obj/item/cell/hyper;
@@ -33228,6 +33311,12 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/briefing)
+"hjq" = (
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/interrogation)
 "hjs" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -33288,6 +33377,24 @@
 	icon_state = "mono"
 	},
 /area/almayer/lifeboat_pumps/south2)
+"hkr" = (
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out"
+	},
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "hkz" = (
 /obj/structure/machinery/light/small{
 	dir = 8
@@ -33374,23 +33481,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/lower)
-"hlI" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/recharger,
-/obj/structure/sign/safety/terminal{
-	pixel_y = 32
-	},
-/obj/structure/transmitter/rotary{
-	name = "Brig Wardens's Office Telephone";
-	phone_category = "MP Dept.";
-	phone_id = "Brig Warden's Office";
-	pixel_x = 15
-	},
-/turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/warden_office)
 "hlT" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out";
@@ -33572,22 +33662,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_a_p)
-"hnE" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/box/ids{
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/obj/item/device/flash,
-/obj/structure/machinery/light{
-	dir = 8;
-	invisibility = 101
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "hnI" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -33636,30 +33710,11 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_a_p)
-"hoK" = (
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "hoT" = (
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_m_s)
-"hoW" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/adv,
-/obj/item/device/defibrillator,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "sterile_green_side"
-	},
-/area/almayer/shipboard/brig/medical)
 "hpk" = (
 /obj/structure/sign/safety/fire_haz{
 	pixel_x = 8;
@@ -33998,6 +34053,15 @@
 	icon_state = "redcorner"
 	},
 /area/almayer/living/cryo_cells)
+"huN" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 9;
+	icon_state = "sterile_green_side"
+	},
+/area/almayer/shipboard/brig/medical)
 "huO" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -34029,9 +34093,15 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/briefing)
-"hvd" = (
-/turf/closed/wall/almayer/reinforced,
-/area/almayer/shipboard/brig/interrogation)
+"huZ" = (
+/obj/structure/machinery/cm_vending/clothing/maintenance_technician,
+/obj/structure/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/engineering/upper_engineering/port)
 "hvq" = (
 /obj/structure/bed/chair{
 	dir = 8;
@@ -34196,19 +34266,6 @@
 "hyQ" = (
 /turf/closed/wall/almayer,
 /area/almayer/living/synthcloset)
-"hyV" = (
-/obj/structure/machinery/power/apc/almayer{
-	dir = 4
-	},
-/obj/structure/sign/safety/rewire{
-	pixel_x = 32;
-	pixel_y = 24
-	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/interrogation)
 "hza" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34258,15 +34315,6 @@
 	icon_state = "cargo"
 	},
 /area/almayer/squads/delta)
-"hzG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/starboard_hallway)
 "hzL" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/poddoor/almayer/open{
@@ -34297,13 +34345,6 @@
 	icon_state = "cargo"
 	},
 /area/almayer/squads/req)
-"hAf" = (
-/obj/structure/machinery/iv_drip,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "sterile_green_side"
-	},
-/area/almayer/shipboard/brig/medical)
 "hAh" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/hallways/lower/port_umbilical)
@@ -34722,6 +34763,12 @@
 	icon_state = "red"
 	},
 /area/almayer/lifeboat_pumps/south1)
+"hHK" = (
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "redcorner"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "hIp" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -35032,6 +35079,20 @@
 	icon_state = "cargo"
 	},
 /area/almayer/maint/hull/upper/u_f_p)
+"hPx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "hPD" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 8
@@ -35164,9 +35225,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/numbertwobunks)
-"hRu" = (
-/turf/closed/wall/almayer/outer,
-/area/almayer/shipboard/brig/execution_storage)
 "hRA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35201,7 +35259,9 @@
 	pixel_x = 14;
 	pixel_y = 38
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "hSb" = (
 /obj/structure/largecrate/random/secure,
@@ -35291,7 +35351,9 @@
 	pixel_y = 16
 	},
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom,
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "hTt" = (
 /obj/structure/machinery/brig_cell/cell_1{
@@ -35367,14 +35429,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_m_s)
-"hUh" = (
-/obj/structure/machinery/medical_pod/bodyscanner{
-	dir = 8
-	},
-/turf/open/floor/almayer{
-	icon_state = "dark_sterile"
-	},
-/area/almayer/shipboard/brig/medical)
 "hUk" = (
 /turf/open/floor/almayer{
 	dir = 10;
@@ -35398,28 +35452,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/port_emb)
-"hUU" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/box/bodybags{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/storage/box/bodybags,
-/obj/structure/machinery/light/small{
-	dir = 4;
-	pixel_y = -12
-	},
-/obj/structure/machinery/power/apc/almayer{
-	dir = 4
-	},
-/obj/structure/sign/safety/rewire{
-	pixel_x = 32;
-	pixel_y = 17
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/execution_storage)
 "hUW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -35674,7 +35706,9 @@
 	icon_state = "N";
 	pixel_y = 1
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "hZw" = (
 /obj/effect/decal/warning_stripes{
@@ -35800,6 +35834,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/lower/s_bow)
+"ibl" = (
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "ibP" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = -19;
@@ -35963,7 +36003,9 @@
 	dir = 1;
 	icon_state = "ramptop"
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	dir = 4
+	},
 /area/almayer/command/airoom)
 "ieX" = (
 /obj/structure/surface/table/almayer,
@@ -35989,15 +36031,9 @@
 	icon_state = "red"
 	},
 /area/almayer/lifeboat_pumps/north1)
-"ifz" = (
-/obj/structure/machinery/keycard_auth{
-	pixel_x = 25
-	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/warden_office)
+"ifR" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/mp_bunks)
 "igb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -36009,7 +36045,9 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out"
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "tcomms"
+	},
 /area/almayer/command/airoom)
 "igs" = (
 /obj/structure/surface/table/almayer,
@@ -36105,6 +36143,15 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/squads/bravo)
+"iio" = (
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 1;
+	name = "ship-grade camera"
+	},
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "iis" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -36140,6 +36187,12 @@
 	icon_state = "mono"
 	},
 /area/almayer/medical/hydroponics)
+"iiX" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/warden_office)
 "iiZ" = (
 /obj/structure/machinery/cm_vending/sorted/marine_food,
 /turf/open/floor/almayer{
@@ -36504,6 +36557,12 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/port)
+"iqO" = (
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "iqR" = (
 /obj/structure/sign/safety/cryo{
 	pixel_x = -16
@@ -36584,7 +36643,9 @@
 	dir = 1;
 	icon_state = "ramptop"
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "isI" = (
 /obj/structure/sign/nosmoking_2{
@@ -36630,9 +36691,9 @@
 	unacidable = 0;
 	unslashable = 0
 	},
-/turf/open/floor/almayer/aicore/no_build{
-	icon_state = "ai_silver";
-	dir = 8
+/turf/open/floor/almayer/no_build{
+	dir = 8;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "ito" = (
@@ -36940,7 +37001,9 @@
 	unacidable = 1;
 	unslashable = 1
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "iyS" = (
 /obj/structure/disposalpipe/segment{
@@ -36985,12 +37048,6 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
-"iAg" = (
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "redcorner"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "iAw" = (
 /obj/item/tool/warning_cone{
 	pixel_x = -12
@@ -37216,15 +37273,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/offices)
-"iFK" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 6
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "iFM" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -37237,6 +37285,14 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/port_emb)
+"iFS" = (
+/obj/structure/machinery/medical_pod/bodyscanner{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
+/area/almayer/shipboard/brig/medical)
 "iFY" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/sign/safety/cryo{
@@ -37575,17 +37631,6 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
-"iNh" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
-	name = "\improper Brig Cells"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "iNk" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -37631,6 +37676,11 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/port_midship_hallway)
+"iOx" = (
+/turf/open/floor/almayer{
+	icon_state = "redcorner"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "iOD" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -37836,19 +37886,16 @@
 	icon_state = "green"
 	},
 /area/almayer/hallways/upper/aft_hallway)
-"iRp" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 8;
-	id = "Interrogation Shutters";
-	name = "\improper Privacy Shutters"
-	},
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/interrogation)
 "iRy" = (
 /obj/structure/pipes/vents/pump/on,
 /turf/open/floor/almayer,
 /area/almayer/living/gym)
+"iRC" = (
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "iRN" = (
 /obj/structure/machinery/light/containment{
 	dir = 4
@@ -37928,6 +37975,15 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_a_s)
+"iSL" = (
+/obj/structure/bed/chair/bolted{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/interrogation)
 "iSV" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	access_modified = 1;
@@ -38052,19 +38108,6 @@
 	icon_state = "mono"
 	},
 /area/almayer/medical/hydroponics)
-"iUG" = (
-/obj/structure/closet/secure_closet/surgical{
-	pixel_x = -30
-	},
-/obj/structure/machinery/power/apc/almayer,
-/obj/structure/sign/safety/rewire{
-	pixel_y = -38
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "sterile_green_corner"
-	},
-/area/almayer/shipboard/brig/medical)
 "iUV" = (
 /turf/open/floor/almayer{
 	icon_state = "bluecorner"
@@ -38080,22 +38123,6 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
-"iUX" = (
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_x = -8;
-	pixel_y = 18
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_x = 8;
-	pixel_y = 18
-	},
-/obj/item/device/taperecorder,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/interrogation)
 "iVy" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -38320,7 +38347,10 @@
 /obj/structure/stairs{
 	dir = 1
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	dir = 4;
+	icon_state = "silver"
+	},
 /area/almayer/command/airoom)
 "iZE" = (
 /obj/structure/machinery/cm_vending/sorted/tech/tool_storage,
@@ -38842,39 +38872,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/maint/hull/lower/l_m_s)
-"jgR" = (
-/obj/structure/sign/safety/rewire{
-	pixel_y = 32
-	},
-/obj/item/bedsheet/brown{
-	layer = 3.1
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/structure/bed{
-	can_buckle = 0
-	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 3.3;
-	pixel_y = 4
-	},
-/obj/structure/bed{
-	buckling_y = 13;
-	layer = 3.5;
-	pixel_y = 13
-	},
-/obj/item/bedsheet/brown{
-	pixel_y = 13
-	},
-/turf/open/floor/almayer{
-	dir = 5;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "jgS" = (
 /turf/open/floor/almayer{
 	dir = 10;
@@ -39041,6 +39038,16 @@
 	icon_state = "sterile_green"
 	},
 /area/almayer/medical/lower_medical_medbay)
+"jjH" = (
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
+	},
+/obj/structure/sign/safety/rewire{
+	pixel_y = -38
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/execution)
 "jjS" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -39190,20 +39197,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/lower/port_fore_hallway)
-"jlE" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
-/obj/structure/surface/table/almayer,
-/obj/item/toy/deck/uno,
-/obj/item/toy/deck{
-	pixel_x = -9
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "jlG" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out";
@@ -39249,6 +39242,19 @@
 	icon_state = "plate"
 	},
 /area/almayer/command/lifeboat)
+"jme" = (
+/obj/structure/sign/safety/maint{
+	pixel_x = -17
+	},
+/obj/structure/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "jmn" = (
 /obj/structure/surface/table/almayer,
 /obj/item/prop/magazine/dirty{
@@ -39327,29 +39333,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/starboard_aft_hallway)
-"jnp" = (
-/obj/structure/surface/table/almayer,
-/obj/item/cell/high{
-	pixel_x = -8;
-	pixel_y = 8
-	},
-/obj/item/ashtray/plastic{
-	icon_state = "ashtray_full_bl";
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/item/trash/cigbutt{
-	pixel_x = -10;
-	pixel_y = 13
-	},
-/obj/item/trash/cigbutt{
-	pixel_x = -6;
-	pixel_y = -9
-	},
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/engineering/upper_engineering/port)
 "jnx" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 6
@@ -39397,6 +39380,16 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/engineering/laundry)
+"joN" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "jpn" = (
 /obj/structure/stairs{
 	icon_state = "ramptop"
@@ -39444,7 +39437,7 @@
 	plane = -7
 	},
 /obj/effect/step_trigger/ares_alert/core,
-/obj/structure/machinery/door/poddoor/almayer/blended/aicore/open{
+/obj/structure/machinery/door/poddoor/almayer/blended/white/open{
 	closed_layer = 3.2;
 	id = "ARES Emergency";
 	layer = 3.2;
@@ -39593,9 +39586,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/vehiclehangar)
 "jtj" = (
-/obj/effect/step_trigger/clone_cleaner,
-/turf/open/floor/almayer/aicore/glowing/no_build{
-	icon_state = "ai_floor3"
+/obj/structure/machinery/status_display{
+	pixel_y = 30
+	},
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "jts" = (
@@ -39667,12 +39662,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/medical/lower_medical_medbay)
-"jvc" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/mp_bunks)
 "jvp" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -39717,8 +39706,8 @@
 /area/almayer/hallways/upper/aft_hallway)
 "jvB" = (
 /obj/effect/step_trigger/clone_cleaner,
-/turf/open/floor/almayer/aicore/no_build{
-	icon_state = "ai_plates"
+/turf/open/floor/almayer/no_build{
+	dir = 4
 	},
 /area/almayer/command/airoom)
 "jvD" = (
@@ -39800,12 +39789,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/u_f_p)
-"jwr" = (
-/obj/structure/machinery/light,
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "jwJ" = (
 /obj/structure/platform_decoration,
 /turf/open/floor/plating/plating_catwalk,
@@ -40050,10 +40033,6 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_lobby)
-"jCX" = (
-/obj/structure/pipes/vents/scrubber,
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/starboard_hallway)
 "jDk" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 4
@@ -40071,6 +40050,9 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/lower/workshop/hangar)
+"jDx" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/interrogation)
 "jDz" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -40116,8 +40098,20 @@
 	pixel_x = 24;
 	req_one_access_txt = "90;91;92"
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
+"jEk" = (
+/obj/structure/disposalpipe/junction,
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "jEA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40146,20 +40140,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/chief_mp_office)
-"jEV" = (
-/obj/structure/surface/table/almayer,
-/obj/item/paper_bin{
-	pixel_x = -7
-	},
-/obj/item/tool/pen,
-/obj/item/tool/pen{
-	pixel_y = 3
-	},
-/turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "jFf" = (
 /obj/structure/machinery/shower{
 	pixel_y = 16
@@ -40233,6 +40213,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_m_s)
+"jFP" = (
+/obj/structure/machinery/cm_vending/sorted/medical/blood,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "sterile_green_side"
+	},
+/area/almayer/shipboard/brig/medical)
 "jFY" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer{
@@ -40934,6 +40921,11 @@
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/lower)
+"jTE" = (
+/turf/open/floor/almayer{
+	allow_construction = 0
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "jTH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40955,11 +40947,21 @@
 	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie_delta_shared)
-"jTU" = (
-/obj/structure/bed,
-/obj/item/bedsheet/red,
-/turf/open/floor/wood/ship,
-/area/almayer/shipboard/brig/warden_office)
+"jTK" = (
+/obj/structure/toilet{
+	pixel_y = 13
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "jUb" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/toy/deck{
@@ -41108,19 +41110,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/offices)
-"jXc" = (
-/obj/structure/sign/safety/maint{
-	pixel_x = -17
-	},
-/obj/structure/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "jXd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -41221,7 +41210,9 @@
 /obj/structure/machinery/camera/autoname/almayer/containment/ares{
 	dir = 4
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "tcomms"
+	},
 /area/almayer/command/airoom)
 "jZd" = (
 /obj/structure/pipes/vents/pump{
@@ -41376,16 +41367,6 @@
 	icon_state = "bluefull"
 	},
 /area/almayer/squads/charlie_delta_shared)
-"kaQ" = (
-/obj/structure/disposalpipe/junction,
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "kaS" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -41446,7 +41427,9 @@
 /obj/structure/stairs{
 	dir = 1
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "kbJ" = (
 /obj/effect/decal/warning_stripes{
@@ -41578,6 +41561,15 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical_lobby)
+"ked" = (
+/obj/structure/machinery/body_scanconsole{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "sterile_green_side"
+	},
+/area/almayer/shipboard/brig/medical)
 "keE" = (
 /obj/structure/largecrate/random/barrel/red,
 /obj/structure/machinery/light/small,
@@ -41585,18 +41577,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_a_s)
-"keG" = (
-/obj/structure/machinery/door/airlock/almayer/security{
-	dir = 2;
-	name = "\improper Interrogation Observation"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/interrogation)
 "keO" = (
 /obj/structure/largecrate/random/secure,
 /obj/effect/decal/warning_stripes{
@@ -41610,6 +41590,17 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/engineering/upper_engineering/starboard)
+"kfa" = (
+/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	name = "\improper Warden's Office"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/warden_office)
 "kfo" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -41762,7 +41753,9 @@
 /obj/structure/machinery/camera/autoname/almayer/containment/ares{
 	dir = 8
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "tcomms"
+	},
 /area/almayer/command/airoom)
 "kil" = (
 /obj/structure/stairs/perspective{
@@ -42155,15 +42148,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_m_p)
-"kqd" = (
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "kqm" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_y = 25
@@ -42344,10 +42328,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/processing)
-"ksm" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/starboard_hallway)
 "ksp" = (
 /obj/structure/machinery/cryopod/right{
 	pixel_y = 6
@@ -42474,16 +42454,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/upper_engineering)
-"kvL" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/cameras/almayer_network{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/warden_office)
 "kvU" = (
 /obj/structure/surface/table/almayer,
 /turf/open/floor/plating/plating_catwalk,
@@ -42546,6 +42516,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/hangar)
+"kwX" = (
+/obj/structure/machinery/iv_drip,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "sterile_green_side"
+	},
+/area/almayer/shipboard/brig/medical)
 "kxd" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -42589,12 +42566,9 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/squads/req)
-"kxP" = (
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
+"kxU" = (
+/turf/closed/wall/almayer,
+/area/almayer/shipboard/brig/medical)
 "kyh" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -42694,6 +42668,14 @@
 /obj/structure/machinery/light/small,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_f_p)
+"kzv" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "kzy" = (
 /obj/structure/bed/chair,
 /turf/open/floor/almayer{
@@ -42769,9 +42751,9 @@
 	pixel_y = -8;
 	req_one_access_txt = "90;91;92"
 	},
-/turf/open/floor/almayer/aicore/no_build{
-	icon_state = "ai_silver";
-	dir = 8
+/turf/open/floor/almayer/no_build{
+	dir = 8;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "kAh" = (
@@ -42953,13 +42935,18 @@
 	},
 /area/almayer/medical/containment)
 "kCY" = (
-/obj/structure/machinery/sleep_console{
-	dir = 8
+/obj/structure/surface/rack,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/glasses/sunglasses/blindfold,
+/obj/item/clothing/mask/muzzle,
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 8;
+	name = "ship-grade camera"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile"
+	icon_state = "plate"
 	},
-/area/almayer/shipboard/brig/medical)
+/area/almayer/shipboard/brig/execution_storage)
 "kDd" = (
 /obj/structure/sign/safety/water{
 	pixel_x = 8;
@@ -43055,6 +43042,15 @@
 	icon_state = "redfull"
 	},
 /area/almayer/living/briefing)
+"kEw" = (
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
+/area/almayer/shipboard/brig/medical)
 "kEE" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -43167,22 +43163,6 @@
 	icon_state = "green"
 	},
 /area/almayer/living/grunt_rnr)
-"kHo" = (
-/obj/item/device/camera{
-	pixel_x = 4;
-	pixel_y = 8
-	},
-/obj/structure/surface/table/almayer,
-/obj/item/device/camera_film{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/obj/item/device/camera_film,
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "kHS" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -43322,7 +43302,10 @@
 	dir = 1;
 	icon_state = "ramptop"
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	dir = 8;
+	icon_state = "silver"
+	},
 /area/almayer/command/airoom)
 "kKB" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
@@ -43624,6 +43607,21 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/req)
+"kPf" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/obj/structure/machinery/door/airlock/almayer/security/reinforced{
+	dir = 2;
+	name = "\improper Execution Equipment"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/execution_storage)
 "kPx" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/mass_spectrometer,
@@ -43824,7 +43822,9 @@
 	pixel_y = 24;
 	req_one_access_txt = "200;91;92"
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "tcomms"
+	},
 /area/almayer/command/airoom)
 "kSA" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
@@ -43861,13 +43861,6 @@
 	icon_state = "plating"
 	},
 /area/almayer/squads/req)
-"kTp" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/medical)
 "kTv" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -43893,16 +43886,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/hangar)
-"kUg" = (
-/obj/structure/machinery/firealarm{
-	dir = 4;
-	pixel_x = 21
-	},
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/warden_office)
 "kUh" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic2{
@@ -43966,6 +43949,19 @@
 	icon_state = "mono"
 	},
 /area/almayer/lifeboat_pumps/south2)
+"kVE" = (
+/obj/structure/machinery/power/apc/almayer{
+	dir = 4
+	},
+/obj/structure/sign/safety/rewire{
+	pixel_x = 32;
+	pixel_y = 24
+	},
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/interrogation)
 "kVV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -44076,9 +44072,9 @@
 	},
 /area/almayer/command/computerlab)
 "kXj" = (
-/turf/open/floor/almayer/aicore/no_build{
-	icon_state = "ai_silver";
-	dir = 4
+/turf/open/floor/almayer/no_build{
+	dir = 4;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "kXm" = (
@@ -44094,15 +44090,6 @@
 	icon_state = "plating"
 	},
 /area/almayer/shipboard/stern_point_defense)
-"kXt" = (
-/obj/structure/closet/fireaxecabinet{
-	pixel_y = 32
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "kXu" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -44166,15 +44153,6 @@
 	icon_state = "plating"
 	},
 /area/almayer/engineering/lower/engine_core)
-"kYU" = (
-/obj/structure/machinery/firealarm{
-	pixel_y = 28
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "kYV" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 6
@@ -44674,8 +44652,26 @@
 	dir = 1;
 	icon_state = "ramptop"
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
+"lit" = (
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	id = "Interrogation Shutters";
+	name = "\improper Privacy Shutters"
+	},
+/obj/structure/machinery/door/airlock/almayer/security{
+	dir = 2;
+	name = "\improper Interrogation"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/interrogation)
 "liF" = (
 /obj/structure/machinery/light/small{
 	dir = 8
@@ -44937,7 +44933,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/medical_science)
 "lmz" = (
-/turf/closed/wall/almayer/aicore/hull,
+/turf/closed/wall/almayer/white/hull,
 /area/space)
 "lmA" = (
 /obj/structure/flora/pottedplant{
@@ -45012,8 +45008,8 @@
 	pixel_y = -8;
 	req_one_access_txt = "90;91;92"
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build{
-	icon_state = "ai_floor3"
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "lok" = (
@@ -45323,7 +45319,7 @@
 "ltc" = (
 /obj/effect/landmark/late_join/working_joe,
 /obj/effect/landmark/start/working_joe,
-/turf/open/floor/plating/plating_catwalk/aicore,
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/command/airoom)
 "ltm" = (
 /obj/structure/bed/chair/comfy/orange,
@@ -45379,19 +45375,6 @@
 	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
-"ltO" = (
-/obj/structure/closet/secure_closet{
-	name = "\improper Lethal Injection Locker"
-	},
-/obj/item/reagent_container/ld50_syringe/choral,
-/obj/item/reagent_container/ld50_syringe/choral,
-/obj/item/reagent_container/ld50_syringe/choral,
-/obj/item/reagent_container/ld50_syringe/choral,
-/obj/item/reagent_container/ld50_syringe/choral,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/execution_storage)
 "ltU" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -45825,6 +45808,19 @@
 	icon_state = "red"
 	},
 /area/almayer/hallways/upper/port)
+"lCN" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/adv,
+/obj/item/device/defibrillator,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "sterile_green_side"
+	},
+/area/almayer/shipboard/brig/medical)
 "lDa" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_29"
@@ -45958,6 +45954,16 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/lower/vehiclehangar)
+"lFd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/manifold/hidden/supply,
+/obj/structure/machinery/light,
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "lFe" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -46900,14 +46906,12 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/medical/hydroponics)
-"may" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_21";
-	pixel_y = 16
+"maB" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 26
 	},
-/obj/structure/surface/table/almayer,
 /turf/open/floor/almayer{
-	dir = 9;
+	dir = 1;
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/starboard_hallway)
@@ -46983,10 +46987,15 @@
 /obj/docking_port/stationary/escape_pod/north,
 /turf/open/floor/plating,
 /area/almayer/maint/hull/lower/l_m_p)
-"mcp" = (
+"mcJ" = (
+/obj/structure/surface/table/almayer,
+/obj/item/paper_bin/uscm{
+	pixel_y = 7
+	},
+/obj/item/tool/pen,
 /turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "redcorner"
+	dir = 8;
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/starboard_hallway)
 "mcL" = (
@@ -47040,17 +47049,10 @@
 	},
 /obj/item/folder/white,
 /obj/item/folder/white,
-/turf/open/floor/almayer/aicore/glowing/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
-"mea" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_21"
-	},
-/turf/open/floor/almayer{
-	dir = 6;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "mem" = (
 /obj/structure/machinery/light/small{
 	dir = 1
@@ -47086,6 +47088,13 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/lower/vehiclehangar)
+"meG" = (
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
+	},
+/turf/open/floor/wood/ship,
+/area/almayer/shipboard/brig/warden_office)
 "meQ" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/starboard_midship_hallway)
@@ -47113,6 +47122,15 @@
 	damage_cap = 15000
 	},
 /area/almayer/squads/alpha)
+"mfk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/starboard_hallway)
 "mfH" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 1
@@ -47267,17 +47285,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/alpha)
-"miy" = (
-/obj/structure/machinery/optable,
-/obj/structure/sign/safety/medical{
-	pixel_x = 8;
-	pixel_y = 29
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "sterile_green_corner"
-	},
-/area/almayer/shipboard/brig/medical)
 "miE" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1
@@ -47498,7 +47505,9 @@
 	icon_state = "NE-out";
 	pixel_y = 1
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "tcomms"
+	},
 /area/almayer/command/airoom)
 "mlm" = (
 /turf/open/floor/almayer{
@@ -47554,6 +47563,9 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/starboard_umbilical)
+"mne" = (
+/turf/closed/wall/almayer,
+/area/almayer/shipboard/brig/mp_bunks)
 "mng" = (
 /turf/open/floor/almayer{
 	icon_state = "redcorner"
@@ -48188,21 +48200,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/brig/armory)
-"mze" = (
-/obj/structure/machinery/door/poddoor/almayer/open{
-	dir = 4;
-	id = "Brig Lockdown Shutters";
-	name = "\improper Brig Lockdown Shutter"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	name = "\improper Brig";
-	closeOtherId = "brigmaint_n"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "mzg" = (
 /turf/open/floor/almayer{
 	icon_state = "emerald"
@@ -48290,15 +48287,6 @@
 	icon_state = "cargo"
 	},
 /area/almayer/squads/delta)
-"mAY" = (
-/obj/structure/machinery/status_display{
-	pixel_y = 30
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "mBa" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -48527,7 +48515,7 @@
 	name = "\improper ARES Mainframe Shutters";
 	plane = -7
 	},
-/obj/structure/machinery/door/poddoor/almayer/blended/aicore/open{
+/obj/structure/machinery/door/poddoor/almayer/blended/white/open{
 	closed_layer = 3.2;
 	id = "ARES Emergency";
 	layer = 3.2;
@@ -48600,6 +48588,20 @@
 /obj/item/device/portable_vendor/corporate,
 /turf/open/floor/wood/ship,
 /area/almayer/command/corporateliaison)
+"mGV" = (
+/obj/item/stack/sheet/glass/reinforced{
+	amount = 50
+	},
+/obj/effect/spawner/random/toolbox,
+/obj/effect/spawner/random/powercell,
+/obj/effect/spawner/random/powercell,
+/obj/structure/surface/rack,
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 1;
+	name = "ship-grade camera"
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/warden_office)
 "mHb" = (
 /obj/structure/machinery/power/apc/almayer{
 	dir = 1
@@ -48653,9 +48655,9 @@
 	},
 /area/almayer/medical/hydroponics)
 "mHE" = (
-/turf/open/floor/almayer/aicore/no_build{
-	icon_state = "ai_silver";
-	dir = 8
+/turf/open/floor/almayer/no_build{
+	dir = 8;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "mHF" = (
@@ -48720,6 +48722,14 @@
 	icon_state = "dark_sterile"
 	},
 /area/almayer/engineering/upper_engineering/port)
+"mIZ" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
+/area/almayer/shipboard/brig/medical)
 "mJa" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/trash/boonie,
@@ -48776,6 +48786,12 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
+"mJI" = (
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "mJL" = (
 /turf/open/floor/almayer{
 	dir = 5;
@@ -49223,7 +49239,7 @@
 	plane = -7
 	},
 /obj/effect/step_trigger/ares_alert/core,
-/obj/structure/machinery/door/poddoor/almayer/blended/aicore/open{
+/obj/structure/machinery/door/poddoor/almayer/blended/white/open{
 	closed_layer = 3.2;
 	id = "ARES Emergency";
 	layer = 3.2;
@@ -49440,8 +49456,19 @@
 	dir = 8;
 	pixel_x = 17
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build{
-	icon_state = "ai_floor3"
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
+/area/almayer/command/airoom)
+"mUC" = (
+/obj/structure/machinery/light{
+	dir = 4;
+	invisibility = 101;
+	unacidable = 1;
+	unslashable = 1
+	},
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "mUE" = (
@@ -49976,6 +50003,16 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/lower/vehiclehangar)
+"neh" = (
+/obj/structure/machinery/firealarm{
+	dir = 4;
+	pixel_x = 21
+	},
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/warden_office)
 "new" = (
 /obj/item/reagent_container/glass/bucket/janibucket,
 /obj/item/reagent_container/glass/bucket/janibucket{
@@ -50448,6 +50485,12 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/starboard_missiles)
+"nkA" = (
+/obj/structure/closet/emcloset/legacy,
+/turf/open/floor/almayer{
+	icon_state = "cargo"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "nkF" = (
 /obj/structure/bed/chair/bolted{
 	dir = 4
@@ -50978,20 +51021,6 @@
 /obj/effect/landmark/late_join/alpha,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/alpha)
-"nuZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "SW-out"
-	},
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "nvd" = (
 /turf/open/floor/almayer{
 	dir = 6;
@@ -51410,11 +51439,6 @@
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/living/commandbunks)
-"nCD" = (
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "nCM" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/almayer{
@@ -51448,6 +51472,15 @@
 	icon_state = "plate"
 	},
 /area/almayer/command/lifeboat)
+"nCZ" = (
+/obj/structure/closet/fireaxecabinet{
+	pixel_y = 32
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "nDa" = (
 /obj/structure/machinery/power/terminal{
 	dir = 4
@@ -51961,6 +51994,19 @@
 	icon_state = "emeraldfull"
 	},
 /area/almayer/squads/charlie_delta_shared)
+"nNW" = (
+/obj/structure/sign/safety/security{
+	pixel_x = 15;
+	pixel_y = 32
+	},
+/obj/structure/sign/safety/restrictedarea{
+	pixel_y = 32
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "nNX" = (
 /obj/structure/machinery/door/airlock/almayer/secure/reinforced{
 	name = "\improper Evacuation Airlock PU-1";
@@ -52383,25 +52429,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/briefing)
-"nVm" = (
-/obj/structure/machinery/door_control{
-	id = "firearm_storage_armory";
-	name = "Armory Lockdown";
-	pixel_y = 24;
-	req_access_txt = "4"
-	},
-/obj/structure/sign/safety/ammunition{
-	pixel_y = 32
-	},
-/obj/structure/sign/safety/restrictedarea{
-	pixel_x = 15;
-	pixel_y = 32
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "nVn" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out";
@@ -52454,6 +52481,30 @@
 	icon_state = "cargo_arrow"
 	},
 /area/almayer/living/offices)
+"nVG" = (
+/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
+	dir = 2;
+	name = "\improper Brig Armoury";
+	req_access = null;
+	req_one_access_txt = "1;3"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
+"nVH" = (
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "redcorner"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "nVQ" = (
 /obj/structure/machinery/light,
 /obj/structure/sign/safety/security{
@@ -52482,14 +52533,6 @@
 /obj/structure/surface/table/almayer,
 /turf/open/floor/wood/ship,
 /area/almayer/engineering/ce_room)
-"nWS" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "dark_sterile"
-	},
-/area/almayer/shipboard/brig/medical)
 "nXo" = (
 /obj/item/storage/box/donkpockets,
 /obj/structure/surface/rack,
@@ -52760,7 +52803,9 @@
 /obj/structure/sign/safety/rewire{
 	pixel_y = 38
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "ocI" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -52928,9 +52973,6 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/computerlab)
-"oeZ" = (
-/turf/closed/wall/almayer/reinforced,
-/area/almayer/shipboard/brig/medical)
 "ofH" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
@@ -53147,13 +53189,6 @@
 	icon_state = "redfull"
 	},
 /area/almayer/shipboard/port_missiles)
-"oix" = (
-/obj/structure/machinery/power/apc/almayer,
-/obj/structure/sign/safety/rewire{
-	pixel_y = -38
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/warden_office)
 "oiB" = (
 /turf/open/floor/almayer{
 	dir = 10;
@@ -53180,7 +53215,7 @@
 /area/almayer/squads/bravo)
 "oiX" = (
 /obj/docking_port/stationary/vehicle_elevator/almayer,
-/turf/open/floor/almayer/empty/vehicle_bay,
+/turf/open/floor/almayer/empty,
 /area/almayer/hallways/lower/vehiclehangar)
 "oiY" = (
 /obj/effect/decal/warning_stripes{
@@ -53285,12 +53320,6 @@
 	icon_state = "outerhull_dir"
 	},
 /area/space)
-"okO" = (
-/obj/structure/machinery/cm_vending/clothing/senior_officer,
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/medical/upper_medical)
 "old" = (
 /obj/structure/machinery/light/small,
 /obj/structure/largecrate/random/case/double,
@@ -53561,6 +53590,23 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/lower/engine_core)
+"opI" = (
+/obj/structure/closet/secure_closet,
+/obj/item/device/camera_film,
+/obj/item/device/camera_film,
+/obj/item/device/camera_film,
+/obj/item/storage/box/tapes,
+/obj/item/clothing/head/fedora,
+/obj/item/clothing/suit/storage/marine/light/reporter,
+/obj/item/clothing/head/helmet/marine/reporter,
+/obj/item/clothing/head/cmcap/reporter,
+/obj/item/device/flashlight,
+/obj/item/device/toner,
+/obj/item/device/toner,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/command/combat_correspondent)
 "opJ" = (
 /obj/docking_port/stationary/emergency_response/external/port4,
 /turf/open/space/basic,
@@ -53648,6 +53694,20 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_m_p)
+"oqN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/status_display{
+	pixel_y = -32
+	},
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "oqS" = (
 /obj/structure/toilet{
 	dir = 1
@@ -53769,10 +53829,13 @@
 /area/almayer/hallways/hangar)
 "osy" = (
 /obj/effect/step_trigger/clone_cleaner,
-/obj/structure/platform_decoration,
-/turf/open/floor/almayer/aicore/no_build{
-	icon_state = "ai_silver";
+/obj/structure/machinery/light{
 	dir = 4
+	},
+/obj/structure/platform_decoration,
+/turf/open/floor/almayer/no_build{
+	dir = 4;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "osz" = (
@@ -53848,15 +53911,36 @@
 	icon_state = "red"
 	},
 /area/almayer/hallways/lower/starboard_midship_hallway)
-"otp" = (
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
+"otl" = (
+/obj/item/bedsheet/brown{
+	pixel_y = 13
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 3.3;
+	pixel_y = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/structure/bed{
+	can_buckle = 0
+	},
+/obj/structure/bed{
+	buckling_y = 13;
+	layer = 3.5;
+	pixel_y = 13
+	},
+/obj/item/bedsheet/brown{
+	layer = 3.1
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile"
+	dir = 9;
+	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/medical)
+/area/almayer/shipboard/brig/mp_bunks)
 "otq" = (
 /obj/structure/machinery/line_nexter{
 	dir = 1;
@@ -53928,7 +54012,12 @@
 	pixel_y = 6
 	},
 /obj/item/tool/pen,
-/turf/open/floor/almayer/aicore/no_build,
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "ouw" = (
 /obj/structure/machinery/light/small{
@@ -54118,12 +54207,6 @@
 /obj/structure/machinery/photocopier,
 /turf/open/floor/almayer,
 /area/almayer/command/lifeboat)
-"oyC" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 10
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/starboard_hallway)
 "oyE" = (
 /obj/effect/landmark/start/intel,
 /obj/structure/sign/poster{
@@ -54501,6 +54584,16 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/engineering/lower/workshop/hangar)
+"oEA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer{
+	icon_state = "redcorner"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "oEE" = (
 /obj/structure/machinery/light{
 	unacidable = 1;
@@ -54587,6 +54680,9 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/s_bow)
+"oGl" = (
+/turf/closed/wall/almayer/reinforced,
+/area/almayer/shipboard/brig/warden_office)
 "oGm" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -54798,12 +54894,6 @@
 "oJk" = (
 /turf/closed/wall/almayer,
 /area/almayer/engineering/lower/workshop)
-"oJm" = (
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "oJp" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
@@ -54850,7 +54940,9 @@
 	pixel_x = -24;
 	req_one_access_txt = "90;91;92"
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "oKb" = (
 /obj/structure/machinery/status_display{
@@ -54914,9 +55006,9 @@
 	pixel_y = -8
 	},
 /obj/effect/step_trigger/clone_cleaner,
-/turf/open/floor/almayer/aicore/no_build{
-	icon_state = "ai_silver";
-	dir = 8
+/turf/open/floor/almayer/no_build{
+	dir = 8;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "oLF" = (
@@ -55023,6 +55115,12 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/medical/hydroponics)
+"oNG" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 10
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/mp_bunks)
 "oNJ" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -55089,6 +55187,15 @@
 	icon_state = "red"
 	},
 /area/almayer/hallways/upper/starboard)
+"oOG" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 6
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "oON" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -55242,6 +55349,17 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/maint/hull/upper/u_f_s)
+"oRG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	icon_state = "redcorner"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "oRJ" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -55273,7 +55391,9 @@
 	icon_state = "W";
 	pixel_x = -1
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "oRW" = (
 /obj/structure/surface/table/almayer,
@@ -55593,15 +55713,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/starboard_fore_hallway)
-"oWK" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "oWN" = (
 /obj/structure/pipes/vents/pump{
 	dir = 1
@@ -55655,6 +55766,16 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
+"oYb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "oYi" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -55833,36 +55954,6 @@
 	dir = 1
 	},
 /area/almayer/command/cic)
-"pbm" = (
-/obj/item/bedsheet/brown{
-	pixel_y = 13
-	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 3.3;
-	pixel_y = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/structure/bed{
-	can_buckle = 0
-	},
-/obj/structure/bed{
-	buckling_y = 13;
-	layer = 3.5;
-	pixel_y = 13
-	},
-/obj/item/bedsheet/brown{
-	layer = 3.1
-	},
-/turf/open/floor/almayer{
-	dir = 9;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "pbo" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/almayer{
@@ -56003,16 +56094,23 @@
 	icon_state = "plating"
 	},
 /area/almayer/engineering/lower/engine_core)
-"pdT" = (
-/obj/structure/pipes/vents/pump,
-/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
-	pixel_y = 25
+"pdR" = (
+/obj/structure/machinery/door_control{
+	id = "Interrogation Shutters";
+	name = "\improper Shutters";
+	pixel_x = 24;
+	pixel_y = 12;
+	req_access_txt = "3"
+	},
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 8;
+	name = "ship-grade camera"
 	},
 /turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "sterile_green_side"
+	dir = 5;
+	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/medical)
+/area/almayer/shipboard/brig/interrogation)
 "pek" = (
 /turf/closed/wall/almayer,
 /area/almayer/maint/hull/upper/s_bow)
@@ -56067,17 +56165,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
-"pfd" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/poddoor/almayer/open{
-	id = "Brig Lockdown Shutters";
-	name = "\improper Brig Lockdown Shutter"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/starboard_hallway)
 "pfp" = (
 /obj/effect/step_trigger/teleporter_vector{
 	name = "Almayer_Up4";
@@ -56149,7 +56236,9 @@
 	dir = 1;
 	icon_state = "ramptop"
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "pgJ" = (
 /obj/structure/sign/safety/hvac_old{
@@ -56401,7 +56490,9 @@
 	pixel_y = 16
 	},
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom,
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "pnh" = (
 /obj/structure/ladder{
@@ -56626,15 +56717,6 @@
 	icon_state = "plating"
 	},
 /area/almayer/hallways/lower/vehiclehangar)
-"prx" = (
-/obj/structure/bed/chair/comfy{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/almayer{
-	icon_state = "dark_sterile"
-	},
-/area/almayer/medical/medical_science)
 "prE" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/tool/kitchen/tray,
@@ -56809,6 +56891,15 @@
 	icon_state = "silver"
 	},
 /area/almayer/living/cryo_cells)
+"puz" = (
+/obj/structure/closet/secure_closet/personal/cabinet{
+	req_access = null
+	},
+/obj/item/storage/donut_box{
+	pixel_y = 8
+	},
+/turf/open/floor/wood/ship,
+/area/almayer/shipboard/brig/warden_office)
 "puI" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -56843,6 +56934,20 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/stern)
+"pva" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/door/airlock/almayer/security/glass{
+	name = "\improper Brig Breakroom"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	layer = 1.9
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "pvh" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /obj/item/tool/warning_cone{
@@ -57556,8 +57661,8 @@
 /obj/structure/stairs{
 	dir = 1
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build{
-	icon_state = "ai_floor3"
+/turf/open/floor/almayer/no_build{
+	dir = 4
 	},
 /area/almayer/command/airoom)
 "pKh" = (
@@ -57577,15 +57682,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/s_stern)
-"pKU" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/machinery/firealarm{
-	pixel_y = 28
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/mp_bunks)
 "pKW" = (
 /obj/structure/machinery/door/poddoor/almayer/open{
 	id = "Hangar Lockdown";
@@ -57814,6 +57910,10 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/panic)
+"pPn" = (
+/obj/structure/pipes/vents/pump,
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/warden_office)
 "pPv" = (
 /obj/structure/closet/cabinet,
 /obj/item/reagent_container/food/drinks/bottle/wine,
@@ -57923,16 +58023,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/charlie_delta_shared)
-"pQI" = (
-/obj/structure/machinery/power/apc/almayer{
-	cell_type = /obj/item/cell/hyper;
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "pQN" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/food/condiment/hotsauce/franks,
@@ -58269,6 +58359,39 @@
 	icon_state = "blue"
 	},
 /area/almayer/living/pilotbunks)
+"pXe" = (
+/obj/structure/surface/table/almayer,
+/obj/item/cell/high{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/ashtray/plastic{
+	icon_state = "ashtray_full_bl";
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = -10;
+	pixel_y = 13
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = -6;
+	pixel_y = -9
+	},
+/turf/open/floor/almayer{
+	icon_state = "mono"
+	},
+/area/almayer/engineering/upper_engineering/port)
+"pXh" = (
+/obj/structure/machinery/power/apc/almayer{
+	cell_type = /obj/item/cell/hyper;
+	dir = 1
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "pXl" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -58323,12 +58446,15 @@
 	},
 /area/almayer/hallways/lower/starboard_midship_hallway)
 "pYi" = (
+/obj/structure/machinery/light{
+	dir = 4
+	},
 /obj/structure/pipes/vents/pump/no_boom{
 	dir = 8
 	},
-/turf/open/floor/almayer/aicore/no_build{
-	icon_state = "ai_silver";
-	dir = 4
+/turf/open/floor/almayer/no_build{
+	dir = 4;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "pYo" = (
@@ -58931,9 +59057,14 @@
 /area/almayer/medical/lower_medical_lobby)
 "qit" = (
 /obj/structure/surface/table/reinforced/almayer_B,
+/obj/structure/machinery/light{
+	dir = 8
+	},
 /obj/item/paper_bin/uscm,
 /obj/item/tool/pen,
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "qiy" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
@@ -58957,12 +59088,6 @@
 	icon_state = "silvercorner"
 	},
 /area/almayer/command/computerlab)
-"qjK" = (
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "qjL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -59334,6 +59459,20 @@
 	icon_state = "plating"
 	},
 /area/almayer/engineering/lower/engine_core)
+"qoX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out"
+	},
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "qoY" = (
 /obj/structure/machinery/vending/hydroseeds,
 /turf/open/floor/almayer{
@@ -59586,24 +59725,6 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/living/port_emb)
-"qvE" = (
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "SE-out"
-	},
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "qvI" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = -17
@@ -59673,9 +59794,9 @@
 	pixel_y = -8;
 	req_one_access_txt = "90;91;92"
 	},
-/turf/open/floor/almayer/aicore/no_build{
-	icon_state = "ai_silver";
-	dir = 8
+/turf/open/floor/almayer/no_build{
+	dir = 8;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "qwY" = (
@@ -60047,16 +60168,6 @@
 /obj/effect/landmark/start/captain,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/bridgebunks)
-"qCA" = (
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
-/obj/structure/sign/safety/rewire{
-	pixel_y = -38
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/execution)
 "qCG" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -60141,6 +60252,9 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_a_p)
+"qDT" = (
+/turf/closed/wall/almayer/reinforced,
+/area/almayer/shipboard/brig/mp_bunks)
 "qEc" = (
 /obj/effect/step_trigger/clone_cleaner,
 /turf/open/floor/plating/plating_catwalk,
@@ -60306,9 +60420,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_a_s)
-"qFX" = (
-/turf/closed/wall/almayer,
-/area/almayer/shipboard/brig/mp_bunks)
 "qGc" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -60405,6 +60516,12 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
+"qHP" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/almayer{
+	icon_state = "cargo"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "qIa" = (
 /obj/structure/platform{
 	dir = 4
@@ -60662,8 +60779,8 @@
 /area/almayer/living/port_emb)
 "qLS" = (
 /obj/structure/pipes/standard/manifold/hidden/supply/no_boom,
-/turf/open/floor/almayer/aicore/glowing/no_build{
-	icon_state = "ai_floor3"
+/turf/open/floor/almayer/no_build{
+	dir = 4
 	},
 /area/almayer/command/airoom)
 "qLV" = (
@@ -60886,7 +61003,16 @@
 	},
 /area/almayer/maint/hull/upper/u_a_p)
 "qQS" = (
-/turf/open/floor/almayer/aicore/no_build,
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	layer = 3.3
+	},
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/almayer/no_build{
+	icon_state = "tcomms"
+	},
 /area/almayer/command/airoom)
 "qRb" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -61051,26 +61177,6 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/processing)
-"qUG" = (
-/obj/structure/surface/table/almayer,
-/obj/item/clothing/mask/cigarette/pipe{
-	pixel_x = 8
-	},
-/obj/structure/transmitter/rotary{
-	name = "Reporter Telephone";
-	phone_category = "Almayer";
-	phone_id = "Reporter";
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/obj/item/device/toner{
-	pixel_y = -11;
-	pixel_x = -2
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/command/combat_correspondent)
 "qUL" = (
 /obj/structure/machinery/landinglight/ds1/delaythree{
 	dir = 4
@@ -61257,6 +61363,13 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/perma)
+"qXG" = (
+/obj/structure/machinery/photocopier,
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "qXO" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/food/snacks/mre_pack/xmas3{
@@ -61509,7 +61622,9 @@
 	pixel_y = -24;
 	req_one_access_txt = "200;91;92"
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "rbB" = (
 /turf/open/floor/almayer{
@@ -61846,6 +61961,12 @@
 "rgL" = (
 /turf/open/floor/plating,
 /area/almayer/maint/upper/u_m_p)
+"rgQ" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/starboard_hallway)
 "rgW" = (
 /turf/open/floor/almayer{
 	icon_state = "emeraldcorner"
@@ -62082,23 +62203,6 @@
 /obj/structure/pipes/vents/scrubber,
 /turf/open/floor/almayer,
 /area/almayer/living/gym)
-"rkV" = (
-/obj/structure/window/framed/almayer/hull/hijack_bustable,
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 4;
-	id = "Warden Office Shutters";
-	name = "\improper Privacy Shutters"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 8
-	},
-/obj/structure/machinery/door/poddoor/almayer/open{
-	dir = 4;
-	id = "courtyard_cells";
-	name = "\improper Courtyard Lockdown Shutter"
-	},
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/warden_office)
 "rlc" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -62175,15 +62279,6 @@
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
-"rmk" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 26
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "rmx" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/recharger,
@@ -62222,10 +62317,7 @@
 	},
 /area/almayer/engineering/upper_engineering/port)
 "rna" = (
-/obj/structure/machinery/status_display{
-	pixel_y = 30
-	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/closed/wall/almayer/white,
 /area/almayer/command/airoom)
 "rnd" = (
 /obj/structure/disposalpipe/segment{
@@ -62261,7 +62353,9 @@
 	dir = 8;
 	pixel_x = 17
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "rnN" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -62571,23 +62665,6 @@
 /obj/structure/machinery/light,
 /turf/open/floor/plating,
 /area/almayer/maint/lower/constr)
-"rtc" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/photo_album{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/item/folder/black{
-	pixel_x = 7;
-	pixel_y = -3
-	},
-/obj/item/device/camera_film{
-	pixel_x = -5
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/command/combat_correspondent)
 "rtd" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -62615,6 +62692,9 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/alpha_bravo_shared)
+"rtP" = (
+/turf/closed/wall/almayer/reinforced,
+/area/almayer/shipboard/brig/interrogation)
 "rtV" = (
 /obj/structure/surface/table/almayer,
 /obj/item/pizzabox{
@@ -62694,6 +62774,11 @@
 /obj/structure/window/framed/almayer/hull/hijack_bustable,
 /turf/open/floor/plating,
 /area/almayer/engineering/lower/workshop/hangar)
+"rvf" = (
+/obj/structure/bed,
+/obj/item/bedsheet/red,
+/turf/open/floor/wood/ship,
+/area/almayer/shipboard/brig/warden_office)
 "rvA" = (
 /turf/open/floor/almayer,
 /area/almayer/living/numbertwobunks)
@@ -62974,6 +63059,9 @@
 	icon_state = "mono"
 	},
 /area/almayer/lifeboat_pumps/south1)
+"rCd" = (
+/turf/closed/wall/almayer/reinforced,
+/area/almayer/shipboard/brig/medical)
 "rCh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -62987,7 +63075,9 @@
 /obj/structure/machinery/camera/autoname/almayer/containment/ares{
 	dir = 8
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "rCl" = (
 /obj/effect/decal/warning_stripes{
@@ -63011,7 +63101,9 @@
 /obj/structure/stairs{
 	dir = 1
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "rCD" = (
 /obj/structure/machinery/light/small{
@@ -63586,6 +63678,22 @@
 	dir = 5
 	},
 /area/almayer/command/cic)
+"rKh" = (
+/obj/structure/surface/table/almayer,
+/obj/item/storage/box/ids{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/device/flash,
+/obj/structure/machinery/light{
+	dir = 8;
+	invisibility = 101
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "rKn" = (
 /obj/structure/machinery/door_control{
 	id = "agentshuttle";
@@ -63757,7 +63865,9 @@
 	unacidable = 1;
 	unslashable = 1
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "rNK" = (
 /obj/structure/surface/table/almayer,
@@ -63833,11 +63943,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/delta)
-"rPF" = (
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "rPO" = (
 /turf/open/floor/almayer{
 	dir = 10;
@@ -63903,6 +64008,12 @@
 	icon_state = "cargo_arrow"
 	},
 /area/almayer/squads/delta)
+"rQP" = (
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
+	pixel_y = 25
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/starboard_hallway)
 "rQV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64233,25 +64344,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/gym)
-"rXE" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "NW-out"
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/sign/safety/ammunition{
-	pixel_x = 15;
-	pixel_y = -32
-	},
-/obj/structure/sign/safety/hazard{
-	pixel_y = -32
-	},
-/obj/structure/machinery/power/apc/almayer{
-	dir = 8
-	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/execution)
 "rXF" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 1
@@ -64466,7 +64558,7 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/port_fore_hallway)
 "sbJ" = (
-/turf/closed/wall/almayer/aicore/hull,
+/turf/closed/wall/almayer/white/hull,
 /area/almayer/powered/agent)
 "sbP" = (
 /obj/effect/landmark/start/police,
@@ -64554,6 +64646,20 @@
 	icon_state = "orangefull"
 	},
 /area/almayer/living/briefing)
+"scS" = (
+/obj/structure/machinery/status_display{
+	pixel_y = 30
+	},
+/obj/structure/machinery/light{
+	dir = 8;
+	invisibility = 101;
+	unacidable = 1;
+	unslashable = 1
+	},
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
+/area/almayer/command/airoom)
 "scX" = (
 /obj/structure/surface/table/almayer,
 /obj/item/tool/kitchen/tray,
@@ -64662,6 +64768,22 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/squads/req)
+"sge" = (
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
+	},
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 8;
+	pixel_y = -2
+	},
+/obj/item/storage/firstaid/regular,
+/obj/item/reagent_container/spray/cleaner,
+/turf/open/floor/almayer{
+	icon_state = "sterile_green_side"
+	},
+/area/almayer/shipboard/brig/medical)
 "sgi" = (
 /turf/closed/wall/almayer,
 /area/almayer/shipboard/brig/processing)
@@ -64921,7 +65043,7 @@
 	},
 /area/almayer/medical/lower_medical_medbay)
 "sje" = (
-/turf/open/floor/almayer/empty/vehicle_bay,
+/turf/open/floor/almayer/empty,
 /area/almayer/hallways/lower/vehiclehangar)
 "sjj" = (
 /obj/structure/machinery/keycard_auth{
@@ -65030,6 +65152,21 @@
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/command/corporateliaison)
+"slb" = (
+/obj/structure/machinery/door/poddoor/almayer/open{
+	dir = 4;
+	id = "Brig Lockdown Shutters";
+	name = "\improper Brig Lockdown Shutter"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	name = "\improper Brig";
+	closeOtherId = "brigmaint_n"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "sld" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65413,6 +65550,14 @@
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
+"sqO" = (
+/obj/structure/machinery/sleep_console{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "dark_sterile"
+	},
+/area/almayer/shipboard/brig/medical)
 "sqP" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/emails{
@@ -65845,20 +65990,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/offices)
-"szG" = (
-/obj/item/stack/sheet/glass/reinforced{
-	amount = 50
-	},
-/obj/effect/spawner/random/toolbox,
-/obj/effect/spawner/random/powercell,
-/obj/effect/spawner/random/powercell,
-/obj/structure/surface/rack,
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 1;
-	name = "ship-grade camera"
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/warden_office)
 "szM" = (
 /obj/structure/flora/pottedplant{
 	desc = "It is made of Fiberbush(tm). It contains asbestos.";
@@ -66044,6 +66175,9 @@
 	icon_state = "plating"
 	},
 /area/almayer/hallways/upper/stern_hallway)
+"sDp" = (
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/starboard_hallway)
 "sDu" = (
 /obj/item/clothing/under/marine/dress,
 /turf/open/floor/almayer{
@@ -66153,16 +66287,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_a_p)
-"sEz" = (
-/turf/open/floor/almayer{
-	allow_construction = 0
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "sEK" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "tcomms"
+	},
 /area/almayer/command/airoom)
 "sEM" = (
 /obj/structure/surface/table/reinforced/almayer_B,
@@ -66213,17 +66344,6 @@
 	icon_state = "cargo"
 	},
 /area/almayer/shipboard/starboard_missiles)
-"sFu" = (
-/obj/structure/surface/table/almayer,
-/obj/item/paper_bin/uscm{
-	pixel_y = 7
-	},
-/obj/item/tool/pen,
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "sGh" = (
 /turf/open/floor/almayer/uscm/directional,
 /area/almayer/command/lifeboat)
@@ -66324,7 +66444,9 @@
 /obj/structure/stairs{
 	dir = 1
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "sIr" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -66439,7 +66561,9 @@
 	dir = 8;
 	layer = 3.25
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "sLk" = (
 /obj/structure/ladder{
@@ -66474,12 +66598,37 @@
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/processing)
+"sLT" = (
+/obj/structure/closet/secure_closet/surgical{
+	pixel_x = -30
+	},
+/obj/structure/machinery/power/apc/almayer,
+/obj/structure/sign/safety/rewire{
+	pixel_y = -38
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "sterile_green_corner"
+	},
+/area/almayer/shipboard/brig/medical)
 "sLX" = (
 /turf/open/floor/almayer{
 	dir = 4;
 	icon_state = "emeraldcorner"
 	},
 /area/almayer/hallways/lower/port_midship_hallway)
+"sMp" = (
+/obj/structure/closet/secure_closet{
+	name = "\improper Execution Firearms"
+	},
+/obj/item/weapon/gun/rifle/m4ra,
+/obj/item/weapon/gun/rifle/m4ra,
+/obj/item/weapon/gun/rifle/m4ra,
+/obj/item/ammo_box/magazine/m4ra,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/execution_storage)
 "sMu" = (
 /obj/item/trash/uscm_mre,
 /obj/structure/bed/chair/comfy/charlie{
@@ -66778,6 +66927,15 @@
 	icon_state = "blue"
 	},
 /area/almayer/living/basketball)
+"sTe" = (
+/obj/structure/machinery/firealarm{
+	pixel_y = 28
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "sTm" = (
 /obj/structure/surface/table/reinforced/black,
 /turf/open/floor/carpet,
@@ -66991,6 +67149,10 @@
 /obj/effect/landmark/late_join/bravo,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/bravo)
+"sXx" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/starboard_hallway)
 "sXB" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -67048,15 +67210,6 @@
 	icon_state = "green"
 	},
 /area/almayer/hallways/upper/aft_hallway)
-"sYl" = (
-/obj/structure/machinery/body_scanconsole{
-	dir = 8
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "sterile_green_side"
-	},
-/area/almayer/shipboard/brig/medical)
 "sYr" = (
 /obj/structure/machinery/door/airlock/almayer/maint,
 /obj/structure/machinery/door/poddoor/almayer/open{
@@ -67183,6 +67336,11 @@
 	icon_state = "blue"
 	},
 /area/almayer/living/port_emb)
+"sZX" = (
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "tab" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/storage/box/flashbangs{
@@ -67488,17 +67646,6 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/lobby)
-"tfE" = (
-/obj/structure/surface/rack,
-/obj/item/storage/firstaid/adv{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/execution_storage)
 "tfH" = (
 /obj/structure/machinery/light/containment,
 /obj/effect/decal/warning_stripes{
@@ -67512,21 +67659,6 @@
 /obj/structure/machinery/light/small,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_a_p)
-"tfZ" = (
-/obj/structure/reagent_dispensers/water_cooler/stacks{
-	density = 0;
-	pixel_x = -7;
-	pixel_y = 17
-	},
-/obj/structure/sign/safety/cryo{
-	pixel_x = 12;
-	pixel_y = 28
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "tge" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 4
@@ -67569,9 +67701,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/port_midship_hallway)
-"tgJ" = (
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/warden_office)
 "tgK" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -67818,6 +67947,21 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_a_p)
+"tjI" = (
+/obj/structure/reagent_dispensers/water_cooler/stacks{
+	density = 0;
+	pixel_x = -7;
+	pixel_y = 17
+	},
+/obj/structure/sign/safety/cryo{
+	pixel_x = 12;
+	pixel_y = 28
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "tjO" = (
 /obj/structure/janitorialcart,
 /obj/item/tool/mop,
@@ -67887,6 +68031,15 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/shipboard/brig/general_equipment)
+"tlm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/starboard_hallway)
 "tln" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 5
@@ -67953,6 +68106,18 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/port_midship_hallway)
+"tmG" = (
+/obj/structure/transmitter{
+	name = "Brig Offices Telephone";
+	phone_category = "MP Dept.";
+	phone_id = "Brig Main Offices";
+	pixel_y = 32
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "tmH" = (
 /obj/structure/pipes/vents/pump,
 /obj/structure/machinery/camera/autoname/almayer{
@@ -68142,6 +68307,15 @@
 "tpn" = (
 /turf/closed/wall/almayer,
 /area/almayer/shipboard/brig/evidence_storage)
+"tpx" = (
+/obj/structure/machinery/light{
+	unacidable = 1;
+	unslashable = 1
+	},
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "tpB" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -68407,6 +68581,22 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/powered/agent)
+"ttq" = (
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_x = -8;
+	pixel_y = 18
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_x = 8;
+	pixel_y = 18
+	},
+/obj/item/device/taperecorder,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/interrogation)
 "tty" = (
 /obj/structure/surface/table/almayer,
 /obj/item/clipboard,
@@ -68535,6 +68725,15 @@
 	icon_state = "orange"
 	},
 /area/almayer/hallways/hangar)
+"tuW" = (
+/obj/structure/window/framed/almayer,
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 8;
+	id = "Interrogation Shutters";
+	name = "\improper Privacy Shutters"
+	},
+/turf/open/floor/plating,
+/area/almayer/shipboard/brig/interrogation)
 "tuZ" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer{
@@ -68577,16 +68776,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/u_a_s)
-"tvJ" = (
-/obj/structure/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/almayer{
-	dir = 6;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "tvM" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -68817,6 +69006,12 @@
 	icon_state = "mono"
 	},
 /area/almayer/hallways/upper/aft_hallway)
+"tzK" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "tzL" = (
 /obj/structure/sign/safety/waterhazard{
 	pixel_x = 8;
@@ -68902,18 +69097,6 @@
 	icon_state = "mono"
 	},
 /area/almayer/lifeboat_pumps/south1)
-"tBP" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/fancy/cigarettes/lucky_strikes,
-/obj/item/tool/lighter,
-/obj/item/clothing/glasses/sunglasses/blindfold,
-/obj/structure/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/shipboard/brig/execution_storage)
 "tBU" = (
 /obj/structure/platform,
 /obj/structure/largecrate/random/case/double{
@@ -69234,8 +69417,8 @@
 /area/almayer/shipboard/brig/cells)
 "tId" = (
 /obj/structure/machinery/recharge_station,
-/turf/open/floor/almayer/aicore/no_build{
-	icon_state = "ai_cargo"
+/turf/open/floor/almayer{
+	icon_state = "cargo"
 	},
 /area/almayer/command/airoom)
 "tIe" = (
@@ -69353,8 +69536,8 @@
 	layer = 3.1;
 	pixel_y = 13
 	},
-/turf/open/floor/almayer/aicore/no_build{
-	icon_state = "ai_cargo"
+/turf/open/floor/almayer{
+	icon_state = "cargo"
 	},
 /area/almayer/command/airoom)
 "tJR" = (
@@ -69774,13 +69957,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/u_a_s)
-"tTO" = (
-/obj/structure/machinery/photocopier,
-/turf/open/floor/almayer{
-	dir = 10;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "tUh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -69797,17 +69973,6 @@
 "tUx" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cells)
-"tUK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "tUN" = (
 /obj/structure/machinery/door/airlock/almayer/maint/reinforced{
 	access_modified = 1;
@@ -70223,7 +70388,9 @@
 	icon_state = "E";
 	pixel_x = 1
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "ubI" = (
 /obj/structure/surface/table/almayer,
@@ -70321,6 +70488,25 @@
 	icon_state = "red"
 	},
 /area/almayer/living/briefing)
+"udo" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out"
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/sign/safety/ammunition{
+	pixel_x = 15;
+	pixel_y = -32
+	},
+/obj/structure/sign/safety/hazard{
+	pixel_y = -32
+	},
+/obj/structure/machinery/power/apc/almayer{
+	dir = 8
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/execution)
 "udr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -70484,17 +70670,6 @@
 /obj/structure/machinery/cm_vending/sorted/marine_food,
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
-"ugw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "redcorner"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "ugJ" = (
 /obj/structure/largecrate/random/case/small,
 /obj/structure/largecrate/random/mini/small_case{
@@ -70547,12 +70722,6 @@
 	icon_state = "redfull"
 	},
 /area/almayer/hallways/lower/starboard_midship_hallway)
-"uhA" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "uhE" = (
 /obj/structure/closet/secure_closet/guncabinet/red/mp_armory_m4ra_rifle,
 /turf/open/floor/plating/plating_catwalk,
@@ -70703,6 +70872,27 @@
 	icon_state = "plating_striped"
 	},
 /area/almayer/squads/req)
+"ulB" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/door_control{
+	id = "Interrogation Shutters";
+	name = "\improper Shutters";
+	pixel_x = -6;
+	pixel_y = -6;
+	req_access_txt = "3"
+	},
+/obj/item/device/taperecorder{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/structure/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/interrogation)
 "ulH" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 8
@@ -70849,6 +71039,15 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical_medbay)
+"unY" = (
+/obj/structure/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/interrogation)
 "unZ" = (
 /obj/structure/platform{
 	dir = 1
@@ -71185,14 +71384,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/bravo)
-"uun" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "uuu" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -71391,6 +71582,16 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cic_hallway)
+"uwV" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/structure/pipes/vents/pump,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "uwZ" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -71488,6 +71689,12 @@
 	icon_state = "red"
 	},
 /area/almayer/hallways/upper/starboard)
+"uyn" = (
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/warden_office)
 "uys" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/squads/req)
@@ -71525,22 +71732,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/ce_room)
-"uzH" = (
-/obj/structure/machinery/door/airlock/almayer/medical/glass{
-	name = "\improper Brig Medbay";
-	req_access = null;
-	req_one_access = null;
-	req_one_access_txt = "20;3";
-	closeOtherId = "brigmed"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/medical)
 "uAb" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out"
@@ -71787,6 +71978,15 @@
 	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
+"uEd" = (
+/obj/structure/machinery/status_display{
+	pixel_y = 30
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "uEO" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -71868,6 +72068,9 @@
 /obj/effect/landmark/map_item,
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
+"uFI" = (
+/turf/closed/wall/almayer/outer,
+/area/almayer/shipboard/brig/execution_storage)
 "uGc" = (
 /obj/structure/machinery/suit_storage_unit/compression_suit/uscm,
 /obj/structure/sign/safety/hazard{
@@ -72073,13 +72276,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/starboard_point_defense)
-"uLE" = (
-/obj/structure/machinery/cm_vending/sorted/medical/blood,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "sterile_green_side"
-	},
-/area/almayer/shipboard/brig/medical)
 "uLG" = (
 /obj/structure/closet/crate/freezer{
 	desc = "A freezer crate. Someone has written 'open on christmas' in marker on the top."
@@ -72328,6 +72524,17 @@
 	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
+"uRx" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_21";
+	pixel_y = 16
+	},
+/obj/structure/surface/table/almayer,
+/turf/open/floor/almayer{
+	dir = 9;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "uRD" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -72636,7 +72843,9 @@
 /obj/structure/pipes/standard/manifold/hidden/supply/no_boom{
 	dir = 1
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "uVA" = (
 /turf/open/floor/almayer{
@@ -72654,6 +72863,23 @@
 	icon_state = "plating_striped"
 	},
 /area/almayer/living/cryo_cells)
+"uVF" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/recharger,
+/obj/structure/sign/safety/terminal{
+	pixel_y = 32
+	},
+/obj/structure/transmitter/rotary{
+	name = "Brig Wardens's Office Telephone";
+	phone_category = "MP Dept.";
+	phone_id = "Brig Warden's Office";
+	pixel_x = 15
+	},
+/turf/open/floor/almayer{
+	dir = 9;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/warden_office)
 "uVV" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -72751,22 +72977,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_f_p)
-"uXu" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	id = "Interrogation Shutters";
-	name = "\improper Privacy Shutters"
-	},
-/obj/structure/machinery/door/airlock/almayer/security{
-	dir = 2;
-	name = "\improper Interrogation"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 1
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/interrogation)
 "uXL" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -72921,9 +73131,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/medical/lower_medical_medbay)
-"vaS" = (
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/mp_bunks)
 "vaV" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -73218,6 +73425,11 @@
 	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
+"vfB" = (
+/turf/open/floor/almayer/no_build{
+	dir = 4
+	},
+/area/almayer/command/airoom)
 "vfP" = (
 /turf/open/floor/almayer/research/containment/corner{
 	dir = 1
@@ -73331,7 +73543,9 @@
 /obj/item/folder/white,
 /obj/item/folder/white,
 /obj/item/folder/white,
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "vhw" = (
 /obj/structure/disposalpipe/trunk{
@@ -73430,7 +73644,9 @@
 /obj/structure/pipes/standard/manifold/hidden/supply/no_boom{
 	dir = 1
 	},
-/turf/open/floor/plating/plating_catwalk/aicore,
+/turf/open/floor/plating/plating_catwalk{
+	allow_construction = 0
+	},
 /area/almayer/command/airoom)
 "viJ" = (
 /obj/structure/machinery/door/airlock/almayer/maint,
@@ -73513,12 +73729,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/engineering/lower/workshop/hangar)
-"vjB" = (
-/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
-	pixel_y = 25
-	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/starboard_hallway)
 "vjC" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -73848,6 +74058,16 @@
 	icon_state = "orange"
 	},
 /area/almayer/hallways/upper/stern_hallway)
+"voa" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/secure_data{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/warden_office)
 "vop" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -74414,28 +74634,13 @@
 /area/almayer/command/cic)
 "vwY" = (
 /obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/cameras/public_helmet,
 /turf/open/floor/almayer,
 /area/almayer/engineering/lower/workshop/hangar)
 "vxb" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer,
 /area/almayer/hallways/hangar)
-"vxh" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 2;
-	id = "Warden Office Shutters";
-	name = "\improper Privacy Shutters"
-	},
-/obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	dir = 1;
-	name = "\improper Warden's Office";
-	closeOtherId = "brigwarden"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/warden_office)
 "vxu" = (
 /obj/structure/machinery/meter,
 /obj/structure/pipes/standard/simple/visible{
@@ -74580,19 +74785,6 @@
 "vzp" = (
 /turf/open/floor/almayer/research/containment/entrance,
 /area/almayer/medical/containment/cell/cl)
-"vzy" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "vzz" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	dir = 1;
@@ -74716,12 +74908,15 @@
 	},
 /area/almayer/medical/medical_science)
 "vAU" = (
+/obj/structure/machinery/light{
+	dir = 8
+	},
 /obj/structure/pipes/vents/scrubber/no_boom{
 	dir = 4
 	},
-/turf/open/floor/almayer/aicore/no_build{
-	icon_state = "ai_silver";
-	dir = 8
+/turf/open/floor/almayer/no_build{
+	dir = 8;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "vBp" = (
@@ -74998,12 +75193,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_f_p)
-"vGn" = (
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/interrogation)
 "vGA" = (
 /obj/structure/bed/sofa/south/grey/right,
 /turf/open/floor/almayer{
@@ -75038,6 +75227,20 @@
 	icon_state = "plating"
 	},
 /area/almayer/command/airoom)
+"vHf" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/structure/surface/table/almayer,
+/obj/item/toy/deck/uno,
+/obj/item/toy/deck{
+	pixel_x = -9
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "vHh" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/item/tool/warning_cone{
@@ -75201,12 +75404,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/command/cichallway)
-"vJc" = (
-/turf/open/floor/almayer{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/warden_office)
 "vJg" = (
 /obj/structure/machinery/light/small,
 /turf/open/floor/almayer{
@@ -75277,13 +75474,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
-"vKF" = (
-/obj/structure/machinery/cm_vending/sorted/medical,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "sterile_green_side"
-	},
-/area/almayer/shipboard/brig/medical)
 "vKI" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -75390,20 +75580,6 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/cichallway)
-"vMJ" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/machinery/door/airlock/almayer/security/glass{
-	name = "\improper Brig Breakroom"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	layer = 1.9
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "vMM" = (
 /obj/structure/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -75425,6 +75601,12 @@
 	icon_state = "redcorner"
 	},
 /area/almayer/hallways/lower/port_fore_hallway)
+"vMZ" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/mp_bunks)
 "vNp" = (
 /obj/structure/sign/safety/three{
 	pixel_x = -17
@@ -75435,6 +75617,18 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cells)
+"vNs" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 1
+	},
+/obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
+	name = "\improper Brig Lobby";
+	closeOtherId = "brignorth"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "vND" = (
 /obj/structure/bed/chair{
 	dir = 8;
@@ -75442,16 +75636,11 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/charlie)
-"vNT" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/pipes/standard/simple/hidden/supply,
+"vNV" = (
 /turf/open/floor/almayer{
-	icon_state = "test_floor4"
+	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/starboard_hallway)
+/area/almayer/shipboard/brig/mp_bunks)
 "vNW" = (
 /turf/open/floor/almayer/uscm/directional{
 	dir = 9
@@ -75461,17 +75650,22 @@
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north2)
-"vOu" = (
-/obj/structure/surface/table/almayer,
-/obj/item/weapon/gun/energy/taser,
-/obj/item/weapon/gun/energy/taser{
+"vOj" = (
+/obj/item/device/camera{
+	pixel_x = 4;
 	pixel_y = 8
 	},
-/obj/structure/machinery/recharger,
+/obj/structure/surface/table/almayer,
+/obj/item/device/camera_film{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/device/camera_film,
 /turf/open/floor/almayer{
+	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/mp_bunks)
+/area/almayer/shipboard/brig/starboard_hallway)
 "vOw" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/toolbox,
@@ -75901,12 +76095,6 @@
 /obj/structure/machinery/light,
 /turf/open/floor/almayer,
 /area/almayer/command/lifeboat)
-"vUI" = (
-/obj/structure/bed/chair/comfy/orange{
-	dir = 8
-	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/warden_office)
 "vUJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -75934,6 +76122,9 @@
 "vUP" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/shipboard/brig/cic_hallway)
+"vUV" = (
+/turf/closed/wall/almayer,
+/area/almayer/shipboard/brig/starboard_hallway)
 "vVb" = (
 /obj/structure/machinery/cm_vending/gear/tl{
 	density = 0;
@@ -76151,7 +76342,9 @@
 	dir = 4;
 	pixel_x = -17
 	},
-/turf/open/floor/almayer/aicore/glowing/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "vXk" = (
 /turf/open/floor/almayer{
@@ -76660,6 +76853,18 @@
 	icon_state = "cargo"
 	},
 /area/almayer/living/offices)
+"wfc" = (
+/obj/structure/surface/table/almayer,
+/obj/item/storage/fancy/cigarettes/lucky_strikes,
+/obj/item/tool/lighter,
+/obj/item/clothing/glasses/sunglasses/blindfold,
+/obj/structure/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/execution_storage)
 "wfn" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/almayer{
@@ -76722,6 +76927,23 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/cichallway)
+"wgM" = (
+/obj/structure/window/framed/almayer/hull/hijack_bustable,
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 4;
+	id = "Warden Office Shutters";
+	name = "\improper Privacy Shutters"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 8
+	},
+/obj/structure/machinery/door/poddoor/almayer/open{
+	dir = 4;
+	id = "courtyard_cells";
+	name = "\improper Courtyard Lockdown Shutter"
+	},
+/turf/open/floor/plating,
+/area/almayer/shipboard/brig/warden_office)
 "wgO" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -76765,15 +76987,6 @@
 	icon_state = "silver"
 	},
 /area/almayer/command/cichallway)
-"whQ" = (
-/obj/structure/closet/secure_closet/personal/cabinet{
-	req_access = null
-	},
-/obj/item/storage/donut_box{
-	pixel_y = 8
-	},
-/turf/open/floor/wood/ship,
-/area/almayer/shipboard/brig/warden_office)
 "wid" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/maint/hull/lower/p_bow)
@@ -76994,7 +77207,7 @@
 	alert_message = "Caution: Movement detected in ARES Core.";
 	cooldown_duration = 1200
 	},
-/obj/structure/machinery/door/poddoor/almayer/blended/aicore/open{
+/obj/structure/machinery/door/poddoor/almayer/blended/white/open{
 	closed_layer = 3.2;
 	id = "ARES Emergency";
 	layer = 3.2;
@@ -77028,27 +77241,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/hangar)
-"wlg" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/door_control{
-	id = "Interrogation Shutters";
-	name = "\improper Shutters";
-	pixel_x = -6;
-	pixel_y = -6;
-	req_access_txt = "3"
-	},
-/obj/item/device/taperecorder{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/structure/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/almayer{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/interrogation)
 "wlh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -77158,7 +77350,7 @@
 	},
 /area/almayer/living/bridgebunks)
 "wnh" = (
-/obj/structure/window/framed/almayer/aicore/hull,
+/obj/structure/window/framed/almayer/white/hull,
 /turf/open/floor/plating,
 /area/almayer/command/airoom)
 "wnw" = (
@@ -77684,6 +77876,9 @@
 	icon_state = "cargo"
 	},
 /area/almayer/squads/charlie)
+"wwt" = (
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/mp_bunks)
 "wwv" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -77762,23 +77957,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/starboard_aft_hallway)
-"wxF" = (
-/obj/structure/closet/secure_closet/cmdcabinet{
-	desc = "A bulletproof cabinet containing communications equipment.";
-	name = "communications cabinet";
-	pixel_y = 24;
-	req_access = null;
-	req_one_access_txt = "3"
-	},
-/obj/item/device/radio/listening_bug/radio_linked/mp{
-	pixel_y = 8
-	},
-/obj/item/device/radio/listening_bug/radio_linked/mp,
+"wxO" = (
 /turf/open/floor/almayer{
-	dir = 5;
+	dir = 4;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/warden_office)
+/area/almayer/shipboard/brig/mp_bunks)
 "wxU" = (
 /obj/item/ashtray/bronze{
 	pixel_x = 7;
@@ -77851,10 +78035,32 @@
 	icon_state = "plating"
 	},
 /area/almayer/command/airoom)
+"wzg" = (
+/obj/structure/machinery/door_control{
+	id = "firearm_storage_armory";
+	name = "Armory Lockdown";
+	pixel_y = 24;
+	req_access_txt = "4"
+	},
+/obj/structure/sign/safety/ammunition{
+	pixel_y = 32
+	},
+/obj/structure/sign/safety/restrictedarea{
+	pixel_x = 15;
+	pixel_y = 32
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "wzy" = (
 /obj/effect/step_trigger/clone_cleaner,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/port_fore_hallway)
+"wzE" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/warden_office)
 "wzJ" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -77956,7 +78162,9 @@
 /obj/structure/stairs{
 	dir = 1
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "wDg" = (
 /obj/effect/decal/warning_stripes{
@@ -78134,9 +78342,6 @@
 	icon_state = "redfull"
 	},
 /area/almayer/command/cic)
-"wFs" = (
-/turf/closed/wall/almayer,
-/area/almayer/shipboard/brig/starboard_hallway)
 "wFz" = (
 /obj/item/prop{
 	desc = "Predecessor to the M56 the M38 was known for its extreme reliability in the field. This particular M38D is fondly remembered for its stalwart defence of the hangar bay during the Arcturian commando raid of the USS Almayer on Io.";
@@ -78160,12 +78365,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/panic)
-"wFQ" = (
-/obj/structure/machinery/cm_vending/clothing/maintenance_technician,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/engineering/upper_engineering/port)
 "wFR" = (
 /turf/open/floor/almayer,
 /area/almayer/living/gym)
@@ -78304,6 +78503,12 @@
 	icon_state = "silvercorner"
 	},
 /area/almayer/shipboard/brig/cic_hallway)
+"wIR" = (
+/obj/structure/machinery/light,
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "wIX" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -78348,8 +78553,8 @@
 /area/almayer/medical/upper_medical)
 "wJB" = (
 /obj/structure/machinery/cryopod/right,
-/turf/open/floor/almayer/aicore/no_build{
-	icon_state = "ai_cargo"
+/turf/open/floor/almayer{
+	icon_state = "cargo"
 	},
 /area/almayer/command/airoom)
 "wJC" = (
@@ -78383,15 +78588,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/u_f_s)
-"wKc" = (
-/obj/effect/decal/cleanable/vomit,
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_21"
-	},
-/turf/open/floor/almayer{
-	icon_state = "mono"
-	},
-/area/almayer/engineering/upper_engineering/port)
 "wKm" = (
 /obj/item/device/radio/intercom{
 	freerange = 1;
@@ -78530,20 +78726,6 @@
 	icon_state = "sterile_green"
 	},
 /area/almayer/medical/containment)
-"wLS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
-/turf/open/floor/almayer{
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/starboard_hallway)
 "wMl" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 8;
@@ -79054,13 +79236,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/grunt_rnr)
-"wVh" = (
-/obj/structure/machinery/light{
-	unacidable = 1;
-	unslashable = 1
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/warden_office)
 "wVm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -79204,12 +79379,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_a_p)
-"wXz" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/brig/starboard_hallway)
 "wXH" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -79590,6 +79759,16 @@
 	icon_state = "plate"
 	},
 /area/almayer/engineering/lower/workshop)
+"xem" = (
+/obj/structure/bed/chair{
+	dir = 8;
+	pixel_y = 3
+	},
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "xeq" = (
 /obj/structure/sign/safety/distribution_pipes{
 	pixel_x = 8;
@@ -79634,6 +79813,21 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_a_p)
+"xfA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/power/apc/almayer,
+/obj/structure/sign/safety/rewire{
+	pixel_y = -38
+	},
+/turf/open/floor/almayer{
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "xfK" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -79688,6 +79882,19 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_m_s)
+"xgc" = (
+/obj/structure/closet/secure_closet{
+	name = "\improper Lethal Injection Locker"
+	},
+/obj/item/reagent_container/ld50_syringe/choral,
+/obj/item/reagent_container/ld50_syringe/choral,
+/obj/item/reagent_container/ld50_syringe/choral,
+/obj/item/reagent_container/ld50_syringe/choral,
+/obj/item/reagent_container/ld50_syringe/choral,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/execution_storage)
 "xgh" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 4
@@ -79809,10 +80016,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/bravo)
-"xhU" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/starboard_hallway)
 "xhW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -80077,7 +80280,7 @@
 	},
 /obj/effect/landmark/late_join/working_joe,
 /obj/effect/landmark/start/working_joe,
-/turf/open/floor/plating/plating_catwalk/aicore,
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/command/airoom)
 "xnz" = (
 /obj/effect/decal/warning_stripes{
@@ -80200,14 +80403,6 @@
 	icon_state = "blue"
 	},
 /area/almayer/hallways/lower/port_midship_hallway)
-"xpw" = (
-/obj/structure/machinery/medical_pod/sleeper{
-	dir = 8
-	},
-/turf/open/floor/almayer{
-	icon_state = "dark_sterile"
-	},
-/area/almayer/shipboard/brig/medical)
 "xpL" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -80539,9 +80734,9 @@
 	req_one_access_txt = "90;91;92"
 	},
 /obj/effect/step_trigger/clone_cleaner,
-/turf/open/floor/almayer/aicore/no_build{
-	icon_state = "ai_silver";
-	dir = 4
+/turf/open/floor/almayer/no_build{
+	dir = 4;
+	icon_state = "silver"
 	},
 /area/almayer/command/airoom)
 "xvO" = (
@@ -80832,9 +81027,6 @@
 	icon_state = "mono"
 	},
 /area/almayer/lifeboat_pumps/south2)
-"xyN" = (
-/turf/closed/wall/almayer/reinforced,
-/area/almayer/shipboard/brig/execution_storage)
 "xyQ" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -81021,9 +81213,21 @@
 	icon_state = "silver"
 	},
 /area/almayer/shipboard/brig/cic_hallway)
+"xDu" = (
+/obj/structure/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/starboard_hallway)
 "xDC" = (
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom,
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "xDF" = (
 /obj/structure/machinery/autolathe,
@@ -81277,6 +81481,17 @@
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig/processing)
+"xIO" = (
+/obj/structure/machinery/optable,
+/obj/structure/sign/safety/medical{
+	pixel_x = 8;
+	pixel_y = 29
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "sterile_green_corner"
+	},
+/area/almayer/shipboard/brig/medical)
 "xIQ" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -81512,6 +81727,17 @@
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/panic)
+"xMJ" = (
+/obj/structure/surface/rack,
+/obj/item/storage/firstaid/adv{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/execution_storage)
 "xML" = (
 /obj/structure/machinery/computer/cameras/wooden_tv/prop{
 	pixel_x = -4;
@@ -81665,6 +81891,22 @@
 	dir = 4
 	},
 /area/almayer/medical/containment/cell)
+"xPi" = (
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 2;
+	id = "Warden Office Shutters";
+	name = "\improper Privacy Shutters"
+	},
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
+	dir = 1;
+	name = "\improper Warden's Office";
+	closeOtherId = "brigwarden"
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/warden_office)
 "xPn" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out";
@@ -81763,7 +82005,9 @@
 /area/almayer/hallways/lower/port_aft_hallway)
 "xQV" = (
 /obj/effect/step_trigger/clone_cleaner,
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "xQW" = (
 /obj/structure/sign/safety/bathunisex{
@@ -82035,7 +82279,9 @@
 	pixel_y = 24;
 	req_one_access_txt = "90;91;92"
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "xVe" = (
 /obj/effect/decal/warning_stripes{
@@ -82363,7 +82609,9 @@
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 9
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "yaR" = (
 /obj/structure/disposalpipe/segment{
@@ -82395,7 +82643,9 @@
 	icon_state = "S";
 	layer = 3.3
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "ybk" = (
 /turf/closed/wall/almayer,
@@ -82565,7 +82815,9 @@
 	icon_state = "W";
 	pixel_x = -1
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "ydM" = (
 /obj/structure/window{
@@ -82698,28 +82950,6 @@
 	icon_state = "silver"
 	},
 /area/almayer/maint/hull/upper/u_m_p)
-"yfO" = (
-/obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
-	name = "\improper Warden's Office";
-	closeOtherId = "brigwarden"
-	},
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 4;
-	id = "Warden Office Shutters";
-	name = "\improper Privacy Shutters"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 8
-	},
-/obj/structure/machinery/door/poddoor/almayer/open{
-	dir = 4;
-	id = "courtyard_cells";
-	name = "\improper Courtyard Lockdown Shutter"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/warden_office)
 "yfS" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -82797,21 +83027,18 @@
 	icon_state = "red"
 	},
 /area/almayer/lifeboat_pumps/south1)
+"yhO" = (
+/turf/open/floor/almayer{
+	dir = 10;
+	icon_state = "cargo"
+	},
+/area/almayer/engineering/upper_engineering/port)
 "yhR" = (
 /obj/structure/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_m_s)
-"yhV" = (
-/obj/structure/machinery/door/airlock/almayer/generic{
-	dir = 1;
-	name = "Bathroom"
-	},
-/turf/open/floor/almayer{
-	icon_state = "test_floor4"
-	},
-/area/almayer/shipboard/brig/mp_bunks)
 "yhZ" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/maint/hull/lower/p_bow)
@@ -82828,10 +83055,15 @@
 	},
 /area/almayer/maint/hull/lower/l_m_s)
 "yit" = (
+/obj/structure/machinery/light{
+	dir = 4
+	},
 /obj/structure/pipes/vents/pump/no_boom{
 	dir = 1
 	},
-/turf/open/floor/almayer/aicore/no_build,
+/turf/open/floor/almayer/no_build{
+	icon_state = "ai_floors"
+	},
 /area/almayer/command/airoom)
 "yiW" = (
 /obj/structure/machinery/cryopod/right{
@@ -90410,13 +90642,13 @@ dhd
 oog
 jNT
 fag
-qCA
+jjH
 feb
-hRu
-hRu
-hRu
-hRu
-hRu
+uFI
+uFI
+uFI
+uFI
+uFI
 ajZ
 aaa
 aaa
@@ -90614,12 +90846,12 @@ nPb
 fZX
 dBS
 nSu
-rXE
-xyN
-ltO
-tBP
-tfE
-hRu
+udo
+cHp
+xgc
+wfc
+xMJ
+uFI
 aag
 aaf
 ajY
@@ -90818,11 +91050,11 @@ qVF
 xdJ
 kzr
 jqY
-elV
-dJJ
-dJJ
-glP
-hRu
+kPf
+etW
+etW
+ewP
+uFI
 xiV
 xiV
 ajZ
@@ -91021,11 +91253,11 @@ mtl
 mtl
 mtl
 ewI
-xyN
-hdQ
-hUU
-cXD
-xyN
+cHp
+sMp
+edJ
+kCY
+cHp
 igS
 xiV
 xiV
@@ -91224,11 +91456,11 @@ tul
 mNK
 gtU
 bjk
-xyN
-xyN
-xyN
-xyN
-xyN
+cHp
+cHp
+cHp
+cHp
+cHp
 iuf
 pnh
 xiV
@@ -91814,13 +92046,13 @@ uDg
 uDg
 gkr
 xkc
-hvd
-hvd
-hvd
-hvd
-hvd
-mze
-eyD
+rtP
+rtP
+rtP
+rtP
+rtP
+slb
+aii
 naB
 kry
 pHp
@@ -92017,13 +92249,13 @@ uDg
 pOp
 gkr
 cth
-hvd
-ddj
-wlg
-fuY
-hvd
-cQG
-jXc
+rtP
+awb
+ulB
+cXv
+rtP
+sDp
+jme
 naB
 pQr
 bsp
@@ -92220,13 +92452,13 @@ uDg
 lDT
 xkc
 xyZ
-hvd
-vGn
-ehl
-ehl
-uXu
-cQG
-alp
+rtP
+hjq
+jDx
+jDx
+lit
+sDp
+hbD
 naB
 naB
 naB
@@ -92422,20 +92654,20 @@ aag
 uDg
 xkc
 gkr
-hvd
-hvd
-iRp
-iRp
-iRp
-hvd
-cyc
-vzy
-fqQ
-kHo
-sFu
-hnE
-tTO
-wFs
+rtP
+rtP
+tuW
+tuW
+tuW
+rtP
+uwV
+bvL
+oYb
+vOj
+mcJ
+rKh
+qXG
+vUV
 nkX
 iQB
 cmv
@@ -92625,20 +92857,20 @@ aag
 lrE
 xkc
 gkr
-hvd
-iUX
-gii
-gIO
-gIO
-hvd
-gYx
-oyC
-bKI
-xhU
-xhU
-jCX
-sEz
-iNh
+rtP
+ttq
+iSL
+bcW
+bcW
+rtP
+dOf
+fFV
+mfk
+dVE
+dVE
+fDw
+jTE
+edW
 wdF
 wdF
 wdF
@@ -92828,20 +93060,20 @@ aag
 lrE
 gkr
 xkc
-hvd
-iUX
-gJE
-cKJ
-hyV
-keG
-cQG
-cQG
-ugw
-cwC
-cwC
-sEz
-cwC
-uun
+rtP
+ttq
+pdR
+unY
+kVE
+fnO
+sDp
+sDp
+oRG
+mJI
+mJI
+jTE
+mJI
+kzv
 oRk
 oRk
 oRk
@@ -93038,8 +93270,8 @@ lrq
 lrq
 lrq
 lrq
-uhA
-aaP
+tzK
+nVG
 tpn
 tpn
 srT
@@ -93241,8 +93473,8 @@ cAy
 uhE
 vKB
 lrq
-vjB
-gIz
+rQP
+bxD
 tpn
 eVR
 cak
@@ -93444,8 +93676,8 @@ nqe
 nqe
 nqe
 tLa
-cQG
-gfd
+sDp
+xfA
 tpn
 rqS
 cak
@@ -93647,8 +93879,8 @@ pId
 qMD
 uqo
 lrq
-nVm
-dRA
+wzg
+oqN
 tpn
 gIU
 xIq
@@ -93850,8 +94082,8 @@ nqe
 nqe
 nqe
 mza
-cQG
-qvE
+sDp
+hkr
 tpn
 tpn
 tpn
@@ -94053,13 +94285,13 @@ fxJ
 fAr
 qmU
 lrq
-dmr
-wLS
-aVm
-cmM
-miy
-iUG
-cmM
+tmG
+hPx
+qHP
+kxU
+xIO
+sLT
+kxU
 snX
 oIh
 oIh
@@ -94256,13 +94488,13 @@ iwV
 iwV
 lrq
 lrq
-kXt
-wLS
-eBx
-cmM
-hAf
-cNI
-bbi
+nCZ
+hPx
+nkA
+kxU
+kwX
+dXm
+bvu
 wdF
 wdF
 wdF
@@ -94459,13 +94691,13 @@ bvH
 evR
 cQv
 cQv
-rmk
-nuZ
-cmM
-cmM
-pdT
-otp
-cmM
+maB
+qoX
+kxU
+kxU
+ePA
+kEw
+kxU
 tzd
 tzd
 sgi
@@ -94662,13 +94894,13 @@ kde
 ajj
 mZQ
 cQv
-dFl
-tUK
-kTp
-sYl
-fgt
-kCY
-kTp
+nNW
+bWD
+esq
+ked
+huN
+sqO
+esq
 gHt
 oIh
 eNR
@@ -94865,13 +95097,13 @@ quj
 vgi
 rXd
 cqJ
-oJm
-tUK
-kTp
-hUh
-nWS
-xpw
-kTp
+ibl
+bWD
+esq
+iFS
+mIZ
+gWi
+esq
 neC
 mjt
 vqc
@@ -95068,13 +95300,13 @@ lEe
 pGT
 pGT
 vkM
-ksm
-bxE
-cmM
-oeZ
-uzH
-oeZ
-oeZ
+sXx
+lFd
+kxU
+rCd
+aSz
+rCd
+rCd
 ptq
 oRk
 eNR
@@ -95271,13 +95503,13 @@ vyH
 ajj
 rXd
 cqJ
-oJm
-tUK
-kTp
-uLE
-nWS
-cTy
-oeZ
+ibl
+bWD
+esq
+jFP
+mIZ
+bPb
+rCd
 emp
 emp
 emp
@@ -95474,13 +95706,13 @@ sBg
 uGN
 rXd
 cQv
-mAY
-tUK
-kTp
-hoW
-nWS
-aIY
-oeZ
+uEd
+bWD
+esq
+lCN
+mIZ
+sge
+rCd
 cFC
 oIh
 lUm
@@ -95677,13 +95909,13 @@ kde
 ajj
 tuk
 cQv
-kYU
-tUK
-kTp
-vKF
-nWS
-glG
-oeZ
+sTe
+bWD
+esq
+dNm
+mIZ
+asd
+rCd
 ehX
 mTN
 hZJ
@@ -95880,13 +96112,13 @@ ioV
 cQv
 tlk
 cQv
-uhA
-bKN
-oeZ
-oeZ
-uzH
-oeZ
-oeZ
+tzK
+frG
+rCd
+rCd
+aSz
+rCd
+rCd
 mFc
 eKa
 emp
@@ -95900,12 +96132,12 @@ bQc
 pgP
 uVV
 iBl
-cHk
-rkV
-rkV
-cHk
-yfO
-cHk
+oGl
+wgM
+wgM
+oGl
+czm
+oGl
 pRs
 pdp
 xiV
@@ -96081,11 +96313,11 @@ rdM
 gUg
 cov
 cqJ
-may
-hoK
-mcp
-hzG
-eyD
+uRx
+iqO
+hHK
+tlm
+aii
 ngr
 cDN
 peO
@@ -96103,12 +96335,12 @@ emp
 lFJ
 emp
 emp
-cHk
-hlI
-ekZ
-kvL
-oix
-cHk
+oGl
+uVF
+voa
+fOm
+clD
+oGl
 uxb
 oDh
 pdp
@@ -96284,11 +96516,11 @@ vxM
 vxM
 vxM
 vxM
-tfZ
-cQG
-cQG
-hzG
-eyD
+tjI
+sDp
+sDp
+tlm
+aii
 tdy
 cDN
 oFY
@@ -96306,13 +96538,13 @@ qUz
 ksg
 oIh
 iTl
-cHk
-frt
-vUI
-tgJ
-wVh
-cHk
-cHk
+oGl
+gmm
+bYp
+bHw
+fpO
+oGl
+oGl
 oDh
 pdp
 xiV
@@ -96487,11 +96719,11 @@ kGu
 iqR
 fyp
 wJh
-oJm
-cQG
-cQG
-hzG
-asC
+ibl
+sDp
+sDp
+tlm
+vNs
 tff
 cDN
 oFY
@@ -96509,13 +96741,13 @@ oDy
 wsq
 vxK
 gwj
-vxh
-csy
-csy
-bWQ
-deH
-szG
-cHk
+xPi
+iiX
+iiX
+pPn
+wzE
+mGV
+oGl
 pdp
 kIf
 xiV
@@ -96690,11 +96922,11 @@ wee
 wee
 fRS
 wJh
-iFK
-ksm
-haY
-kaQ
-vNT
+oOG
+sXx
+oEA
+jEk
+joN
 oSC
 uFq
 wsl
@@ -96712,13 +96944,13 @@ mBx
 utZ
 pyj
 jPP
-cHk
-wxF
-vJc
-kUg
-ifz
-fyI
-cHk
+oGl
+aIN
+uyn
+neh
+hco
+fGU
+oGl
 pdp
 ome
 xiV
@@ -96893,11 +97125,11 @@ rDQ
 rDQ
 rDQ
 ctT
-wXz
-aNW
-tvJ
-eyD
-eyD
+rgQ
+iOx
+xDu
+aii
+aii
 tsX
 tsX
 epu
@@ -96918,10 +97150,10 @@ lnh
 wIC
 rWn
 rWn
-cHk
-cHk
-gxt
-cHk
+oGl
+oGl
+kfa
+oGl
 dJy
 aCA
 xiV
@@ -97096,10 +97328,10 @@ sbP
 sbP
 sbP
 wJh
-oWK
-jwr
-eyD
-eyD
+heg
+wIR
+aii
+aii
 tHr
 mqg
 udR
@@ -97122,9 +97354,9 @@ dgx
 fKi
 vxG
 wIC
-whQ
-bHu
-cHk
+puz
+meG
+oGl
 oLf
 hIG
 xiV
@@ -97299,9 +97531,9 @@ ncf
 kjk
 qxr
 wJh
-oWK
-rPF
-pfd
+heg
+sZX
+dfU
 ceZ
 jnD
 hUW
@@ -97325,9 +97557,9 @@ jPS
 jPS
 xrt
 wIC
-aDt
-jTU
-cHk
+gUC
+rvf
+oGl
 oDh
 xas
 xiV
@@ -97502,9 +97734,9 @@ vxM
 vxM
 vxM
 gaJ
-vMJ
-qFX
-cAR
+pva
+mne
+qDT
 vGA
 hUW
 dHd
@@ -97528,9 +97760,9 @@ qFi
 vAG
 hsj
 wIC
-cHk
-cHk
-cHk
+oGl
+oGl
+oGl
 oDh
 nEc
 xiV
@@ -97702,12 +97934,12 @@ xkc
 ode
 xkc
 gNg
-cAR
-dRj
-yhV
-jvc
-jEV
-cAR
+qDT
+jTK
+bjp
+eyc
+gMw
+qDT
 iuE
 uwN
 vka
@@ -97905,12 +98137,12 @@ cYo
 ode
 gkr
 gkr
-cAR
-cAR
-cAR
-pKU
-vOu
-cAR
+qDT
+qDT
+qDT
+arQ
+fAZ
+qDT
 udK
 mwA
 lnt
@@ -98108,12 +98340,12 @@ akC
 akC
 uvp
 gkr
-cAR
-pbm
-qjK
-jvc
-dGT
-cAR
+qDT
+otl
+iRC
+eyc
+bqK
+qDT
 bmz
 wSR
 mMV
@@ -98311,12 +98543,12 @@ bzz
 akC
 pzc
 gkr
-cAR
-pQI
-gym
-gSz
-cNJ
-cAR
+qDT
+pXh
+wwt
+oNG
+eTM
+qDT
 pZS
 pEB
 jUY
@@ -98514,12 +98746,12 @@ aHZ
 akC
 lDT
 gkr
-cAR
-jgR
-iAg
-vaS
-bsF
-cAR
+qDT
+dJB
+nVH
+ifR
+iio
+qDT
 vkR
 wsD
 jUY
@@ -98717,12 +98949,12 @@ btv
 akC
 lCm
 gkr
-cAR
-cAR
-eLX
-vaS
-nCD
-cAR
+qDT
+qDT
+cqZ
+ifR
+vNV
+qDT
 kfE
 wsD
 jUY
@@ -98921,11 +99153,11 @@ akC
 jdn
 lgk
 hMM
-cAR
-jlE
-cXV
-kqd
-cAR
+qDT
+vHf
+vMZ
+tpx
+qDT
 xDn
 pEB
 jUY
@@ -99124,11 +99356,11 @@ akC
 pek
 rir
 pek
-cAR
-gdG
-kxP
-mea
-cAR
+qDT
+xem
+wxO
+eRX
+qDT
 nNv
 pEB
 jUY
@@ -99327,11 +99559,11 @@ akC
 ibP
 loE
 cmr
-cAR
-cAR
-cAR
-cAR
-cAR
+qDT
+qDT
+qDT
+qDT
+qDT
 xSz
 pEB
 jUY
@@ -111316,7 +111548,7 @@ jZY
 jZY
 sqf
 wpu
-okO
+fEX
 ajl
 ajl
 ajl
@@ -115383,7 +115615,7 @@ lmw
 vOy
 dyb
 tsM
-prx
+fpT
 fpT
 eVT
 kgs
@@ -121062,7 +121294,7 @@ oJR
 tFe
 asD
 xQV
-qQS
+avK
 aqU
 aCZ
 dgg
@@ -121872,7 +122104,7 @@ mLE
 bUx
 mLE
 tmK
-qQS
+avK
 aug
 avL
 aqU
@@ -125540,8 +125772,8 @@ hqx
 jhm
 oIB
 jgr
-qUG
-rtc
+gGp
+dMf
 oIB
 vmu
 kNq
@@ -126757,7 +126989,7 @@ vkQ
 kzR
 oig
 oIB
-cHC
+opI
 dha
 pxj
 oIB
@@ -131832,10 +132064,10 @@ pEd
 tbD
 xhi
 jWh
-wFQ
-bop
+dda
+yhO
 vyI
-jnp
+pXe
 thV
 fCL
 uIv
@@ -132035,8 +132267,8 @@ pEd
 tbD
 xhi
 jWh
-bXy
-bop
+huZ
+yhO
 vyI
 vyI
 vyI
@@ -132238,10 +132470,10 @@ mQF
 rnO
 mQF
 jWh
-wFQ
-bop
+dda
+yhO
 vyI
-wKc
+cvE
 thV
 uWV
 uIv
@@ -139793,8 +140025,8 @@ fEN
 cqm
 gTH
 qit
-ebN
-cxc
+rna
+qQS
 gwn
 pfT
 jYR
@@ -139991,11 +140223,11 @@ sbJ
 sbJ
 sbJ
 daz
-rna
-clw
-qQS
+jtj
+avK
+avK
 sKY
-qQS
+avK
 bIp
 fKe
 dDp
@@ -140397,12 +140629,12 @@ daz
 daz
 kfU
 daz
-ebN
-ebN
+rna
+rna
 lnS
 uVv
 yit
-ebN
+rna
 cxc
 kBy
 kBy
@@ -140592,7 +140824,7 @@ lmz
 lmz
 daz
 daz
-eKJ
+scS
 yaZ
 ffE
 hZj
@@ -140601,8 +140833,8 @@ daz
 daz
 daz
 sGZ
-ebN
-ebN
+rna
+rna
 roH
 ebN
 ebN
@@ -141006,14 +141238,14 @@ ffE
 ffE
 jqP
 cLo
-clw
+vfB
 viB
 dIi
 qLS
-erN
+vfB
 wkM
 jvB
-jtj
+jvB
 ieF
 ieF
 pJR
@@ -141408,13 +141640,13 @@ eKJ
 yaZ
 ffE
 hZj
-clw
+mUC
 daz
 daz
 daz
 tHu
-ebN
-ebN
+rna
+rna
 gXs
 ebN
 ebN
@@ -141615,13 +141847,13 @@ daz
 daz
 sTV
 daz
-ebN
-ebN
+rna
+rna
 gbg
 uVv
-yit
-ebN
-cxc
+erN
+rna
+qQS
 kBy
 kBy
 gfu
@@ -142021,11 +142253,11 @@ sbJ
 sbJ
 sbJ
 daz
-rna
-clw
-qQS
+jtj
+avK
+avK
 aCd
-qQS
+avK
 mFN
 igr
 sEK
@@ -142229,7 +142461,7 @@ rCi
 gba
 mUz
 our
-ebN
+rna
 cxc
 kBy
 kBy


### PR DESCRIPTION
# About the pull request
adds helmet camera viewing consoles to OT and Research
adds new camera console type that uses the overwatch network

# Explain why it's good for the game
its very frustrating not being able to see your creations on the battlefield without ghosting.
lets them spectate when they have nothing to do.

# Testing Photographs and Procedure

https://github.com/cmss13-devs/cmss13/assets/140007537/bf31802f-355f-4f1f-830b-e92dd7f5e156



# Changelog
:cl:
add: Added helmet camera viewing consoles
maptweak: Added helmet camera viewing consoles to research and OT
/:cl:
