### PR TITLE
Adds Cardboard Boxes To Squad Rooms

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -24105,6 +24105,10 @@
 	pixel_x = 4;
 	pixel_y = -2
 	},
+/obj/item/stack/sheet/cardboard/small_stack{
+	pixel_x = -6;
+	pixel_y = 9
+	},
 /turf/open/floor/almayer,
 /area/almayer/squads/charlie_delta_shared)
 "dXI" = (
@@ -26160,7 +26164,14 @@
 	pixel_x = -1;
 	pixel_y = 10
 	},
-/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil{
+	pixel_y = 1;
+	pixel_x = 8
+	},
+/obj/item/stack/sheet/cardboard/small_stack{
+	pixel_y = -3;
+	pixel_x = -8
+	},
 /turf/open/floor/almayer,
 /area/almayer/squads/alpha_bravo_shared)
 "eGq" = (
@@ -67445,7 +67456,11 @@
 "teu" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/weapon/gun/shotgun/pump{
-	starting_attachment_types = list(/obj/item/attachable/stock/shotgun)
+	starting_attachment_types = list(/obj/item/attachable/stock/shotgun);
+	pixel_y = 9
+	},
+/obj/item/stack/sheet/cardboard/small_stack{
+	pixel_y = -6
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/charlie_delta_shared)
@@ -72048,7 +72063,12 @@
 	desc = "A large handheld tool used to override various machine functions. Primarily used to pulse Airlock and APC wires on a shortwave frequency. It contains a small data buffer as well. This one is comically oversized. Made in Texas.";
 	icon_state = "multitool_big";
 	name = "\improper Oversized Security Access Tuner";
-	pixel_y = 8
+	pixel_y = 16;
+	pixel_x = 10
+	},
+/obj/item/stack/sheet/cardboard/medium_stack{
+	pixel_y = -6;
+	pixel_x = -7
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/alpha_bravo_shared)

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -24103,11 +24103,13 @@
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/device/camera_film{
 	pixel_x = 4;
-	pixel_y = -2
+	pixel_y = 1;
+	layer = 3.03
 	},
 /obj/item/stack/sheet/cardboard/small_stack{
-	pixel_x = -6;
-	pixel_y = 9
+	pixel_x = -5;
+	pixel_y = 3;
+	layer = 3.02
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/charlie_delta_shared)
@@ -26169,8 +26171,9 @@
 	pixel_x = 8
 	},
 /obj/item/stack/sheet/cardboard/small_stack{
-	pixel_y = -3;
-	pixel_x = -8
+	pixel_y = 2;
+	pixel_x = -3;
+	layer = 3.01
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/alpha_bravo_shared)
@@ -67460,7 +67463,7 @@
 	pixel_y = 9
 	},
 /obj/item/stack/sheet/cardboard/small_stack{
-	pixel_y = -6
+	layer = 3.01
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/charlie_delta_shared)
@@ -72063,12 +72066,13 @@
 	desc = "A large handheld tool used to override various machine functions. Primarily used to pulse Airlock and APC wires on a shortwave frequency. It contains a small data buffer as well. This one is comically oversized. Made in Texas.";
 	icon_state = "multitool_big";
 	name = "\improper Oversized Security Access Tuner";
-	pixel_y = 16;
-	pixel_x = 10
+	pixel_y = 11;
+	pixel_x = 4
 	},
 /obj/item/stack/sheet/cardboard/medium_stack{
 	pixel_y = -6;
-	pixel_x = -7
+	pixel_x = -7;
+	layer = 3.01
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/alpha_bravo_shared)


### PR DESCRIPTION

# About the pull request

Adds some cardboard boxes to the squad prep rooms. 

# Explain why it's good for the game

Small quality of life boon for proactive Marines wishing to make ammo boxes for the FOB, frontline or personal use. 

Adds four stacks of boxes inside the squad prep areas. Each stack contains 10 units, though the Bravo one has 30. 

No balance implications as boxes are free to make from empty shotgun shell boxes. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: Adds several cardboard box spawns in to squad prep rooms. 
/:cl:
