### PR TITLE
Makes 'Join as Xeno' disable admin larva protection

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -263,7 +263,7 @@
 			continue
 
 		// Mods with larva protection cannot be drafted
-		if((cur_obs.client.admin_holder && (cur_obs.client.admin_holder.rights & R_MOD)) && !cur_obs.adminlarva)
+		if(check_client_rights(cur_obs.client, R_MOD, FALSE) && cur_obs.admin_larva_protection)
 			continue
 
 		if(hive)

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -396,6 +396,10 @@ Additional game mode variables.
 			return FALSE
 		var/mob/dead/observer/candidate_observer = xeno_candidate
 
+		// If an observing mod wants to join as a xeno, make sure that they can actually enter the queue.
+		if(check_client_rights(candidate_observer.client, R_MOD, FALSE))
+			candidate_observer.adminlarva = TRUE
+
 		// Give the player a cached message of their queue status if they are an observer
 		if(candidate_observer.larva_queue_cached_message)
 			to_chat(candidate_observer, SPAN_XENONOTICE(candidate_observer.larva_queue_cached_message))

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -385,34 +385,45 @@ Additional game mode variables.
 			available_xenos[larva_option] = list(hive)
 
 	if(!available_xenos.len || (instant_join && !available_xenos_non_ssd.len))
-		if(!xeno_candidate.client || !xeno_candidate.client.prefs || !(xeno_candidate.client.prefs.be_special & BE_ALIEN_AFTER_DEATH))
-			to_chat(xeno_candidate, SPAN_WARNING("There aren't any available xenomorphs or burrowed larvae. You can try getting spawned as a chestburster larva by toggling your Xenomorph candidacy in Preferences -> Toggle SpecialRole Candidacy."))
+		if(!xeno_candidate.client?.prefs || !(xeno_candidate.client.prefs.be_special & BE_ALIEN_AFTER_DEATH))
+			to_chat(xeno_candidate, SPAN_WARNING("There aren't any available xenomorphs or burrowed larvae. \
+				You can try getting spawned as a chestburster larva by toggling your Xenomorph candidacy in \
+				Preferences -> Toggle SpecialRole Candidacy."))
 			return FALSE
 		to_chat(xeno_candidate, SPAN_WARNING("There aren't any available xenomorphs or burrowed larvae."))
 
-		// Give the player a cached message of their queue status if they are an observer
+		if(!isobserver(xeno_candidate))
+			return FALSE
 		var/mob/dead/observer/candidate_observer = xeno_candidate
-		if(istype(candidate_observer))
-			if(candidate_observer.larva_queue_cached_message)
-				to_chat(xeno_candidate, SPAN_XENONOTICE(candidate_observer.larva_queue_cached_message))
-				return FALSE
 
-			// No cache, lets check now then
-			message_alien_candidates(get_alien_candidates(), dequeued = 0, cache_only = TRUE)
-			if(candidate_observer.larva_queue_cached_message)
-				var/datum/hive_status/cur_hive
-				for(var/hive_num in GLOB.hive_datum)
-					cur_hive = GLOB.hive_datum[hive_num]
-					for(var/mob_name in cur_hive.banished_ckeys)
-						if(cur_hive.banished_ckeys[mob_name] == xeno_candidate.ckey)
-							candidate_observer.larva_queue_cached_message += "\nNOTE: You are banished from the [cur_hive] and you may not rejoin unless the Queen re-admits you or dies. Your queue number won't update until there is a hive you aren't banished from."
-							break
-				to_chat(xeno_candidate, SPAN_XENONOTICE(candidate_observer.larva_queue_cached_message))
-				return FALSE
+		// Give the player a cached message of their queue status if they are an observer
+		if(candidate_observer.larva_queue_cached_message)
+			to_chat(candidate_observer, SPAN_XENONOTICE(candidate_observer.larva_queue_cached_message))
+			return FALSE
 
-			// We aren't in queue yet, lets teach them about the queue then
-			candidate_observer.larva_queue_cached_message = "You are currently awaiting assignment in the larva queue. The ordering is based on your time of death or the time you joined. When you have been dead long enough and are not inactive, you will periodically receive messages where you are in the queue relative to other currently valid xeno candidates. Your current position will shift as others change their preferences or go inactive, but your relative position compared to all observers is the same. Note: Playing as a facehugger or in the thunderdome will not alter your time of death. This means you won't lose your relative place in queue if you step away, disconnect, play as a facehugger, or play in the thunderdome."
-			to_chat(xeno_candidate, SPAN_XENONOTICE(candidate_observer.larva_queue_cached_message))
+		// No cache, lets check now then
+		message_alien_candidates(get_alien_candidates(), dequeued = 0, cache_only = TRUE)
+
+		// If we aren't in the queue yet, let's teach them about the queue
+		if(!candidate_observer.larva_queue_cached_message)
+			candidate_observer.larva_queue_cached_message = "You are currently awaiting assignment in the larva queue. \
+				The ordering is based on your time of death or the time you joined. When you have been dead long enough and are not inactive, \
+				you will periodically receive messages where you are in the queue relative to other currently valid xeno candidates. \
+				Your current position will shift as others change their preferences or go inactive, but your relative position compared to all observers is the same. \
+				Note: Playing as a facehugger or in the thunderdome will not alter your time of death. \
+				This means you won't lose your relative place in queue if you step away, disconnect, play as a facehugger, or play in the thunderdome."
+			to_chat(candidate_observer, SPAN_XENONOTICE(candidate_observer.larva_queue_cached_message))
+			return FALSE
+
+		var/datum/hive_status/cur_hive
+		for(var/hive_num in GLOB.hive_datum)
+			cur_hive = GLOB.hive_datum[hive_num]
+			for(var/mob_name in cur_hive.banished_ckeys)
+				if(cur_hive.banished_ckeys[mob_name] == candidate_observer.ckey)
+					candidate_observer.larva_queue_cached_message += "\nNOTE: You are banished from the [cur_hive] and you may not rejoin unless \
+						the Queen re-admits you or dies. Your queue number won't update until there is a hive you aren't banished from."
+					break
+		to_chat(candidate_observer, SPAN_XENONOTICE(candidate_observer.larva_queue_cached_message))
 		return FALSE
 
 	var/mob/living/carbon/xenomorph/new_xeno

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -396,9 +396,9 @@ Additional game mode variables.
 			return FALSE
 		var/mob/dead/observer/candidate_observer = xeno_candidate
 
-		// If an observing mod wants to join as a xeno, make sure that they can actually enter the queue.
+		// If an observing mod wants to join as a xeno, disable their larva protection so that they can enter the queue.
 		if(check_client_rights(candidate_observer.client, R_MOD, FALSE))
-			candidate_observer.adminlarva = TRUE
+			candidate_observer.admin_larva_protection = FALSE
 
 		// Give the player a cached message of their queue status if they are an observer
 		if(candidate_observer.larva_queue_cached_message)

--- a/code/modules/admin/tabs/admin_tab.dm
+++ b/code/modules/admin/tabs/admin_tab.dm
@@ -29,21 +29,12 @@
 
 	if(!admin_holder)
 		return
+	if(!isobserver(mob))
+		to_chat(usr, SPAN_WARNING("You must be a ghost to use this."))
 
-	if(istype(mob,/mob/dead/observer))
-		var/mob/dead/observer/ghost = mob
-		if(ghost.adminlarva == 0)
-			ghost.adminlarva = 1
-			to_chat(usr, SPAN_BOLDNOTICE("You have disabled your larva protection."))
-		else if(ghost.adminlarva == 1)
-			ghost.adminlarva = 0
-			to_chat(usr, SPAN_BOLDNOTICE("You have re-activated your larva protection."))
-		else
-			to_chat(usr, SPAN_BOLDNOTICE("Something went wrong tell a coder"))
-	else if(istype(mob,/mob/new_player))
-		to_chat(src, "<font color='red'>Error: Lose larva Protection: Can't lose larva protection whilst in the lobby. Observe first.</font>")
-	else
-		to_chat(src, "<font color='red'>Error: Lose larva Protection: You must be a ghost to use this.</font>")
+	var/mob/dead/observer/ghost = mob
+	ghost.adminlarva = !ghost.adminlarva
+	to_chat(usr, SPAN_BOLDNOTICE("You have [ghost.adminlarva ? "dis" : "en"]abled your larva protection."))
 
 /client/proc/unban_panel()
 	set name = "Unban Panel"

--- a/code/modules/admin/tabs/admin_tab.dm
+++ b/code/modules/admin/tabs/admin_tab.dm
@@ -33,8 +33,8 @@
 		to_chat(usr, SPAN_WARNING("You must be a ghost to use this."))
 
 	var/mob/dead/observer/ghost = mob
-	ghost.adminlarva = !ghost.adminlarva
-	to_chat(usr, SPAN_BOLDNOTICE("You have [ghost.adminlarva ? "dis" : "en"]abled your larva protection."))
+	ghost.admin_larva_protection = !ghost.admin_larva_protection
+	to_chat(usr, SPAN_BOLDNOTICE("You have [ghost.admin_larva_protection ? "en" : "dis"]abled your larva protection."))
 
 /client/proc/unban_panel()
 	set name = "Unban Panel"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -33,7 +33,9 @@
 	layer = ABOVE_FLY_LAYER
 	stat = DEAD
 	mob_flags = KNOWS_TECHNOLOGY
-	var/adminlarva = FALSE
+
+	/// If the observer is an admin, are they excluded from the xeno queue?
+	var/admin_larva_protection = TRUE // Enabled by default
 	var/ghostvision = TRUE
 	var/can_reenter_corpse
 	var/started_as_observer //This variable is set to 1 when you enter the game as an observer.


### PR DESCRIPTION

# About the pull request

Makes the 'Join as Xeno' button/verb automatically disable admin larva protection when clicked.

# Explain why it's good for the game

Mostly just a QOL thing. Currently you have to go to the admin tab and click the verb every time you die in order to actually join the xeno queue, whereas with this it's tied directly to the usual button.
There shouldn't be any issues with it being clicked accidentally either, since larva protection can always be re-enabled using the verb as usual.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
admin: Made the 'Join as Xeno' button disable the user's larva protection when clicked by a moderator.
/:cl:
