### PR TITLE
Loadout Point Increase

### DIFF
--- a/code/__DEFINES/client_prefs.dm
+++ b/code/__DEFINES/client_prefs.dm
@@ -32,7 +32,7 @@
 
 #define AGE_MIN 19 //youngest a character can be
 #define AGE_MAX 90 //oldest a character can be //no. you are not allowed to be 160.
-#define MAX_GEAR_COST 7 //Used in chargen for loadout limit.
+#define MAX_GEAR_COST 8 //Used in chargen for loadout limit.
 
 ///dual_wield_pref from /datum/preferences
 ///Fire both weapons when dual wielding


### PR DESCRIPTION

# About the pull request

Changes the the loadout point limit from 7 to 8.

# Explain why it's good for the game

Honestly I don't even understand why there's a limit in the first place, but I think this will be easier to get merged then an upright removal. 90% of the stuff in the loadout menu is cosmetic and the 10% that isn't is for the most part not very useful or abusable.

<details>
<summary>Screenshots & Videos</summary>

testing not needed :)

</details>


# Changelog
:cl:
add: Loadout budget increased 7 > 8
/:cl:
