### PR TITLE
Autocompressor Efficiency Increase

### DIFF
--- a/code/game/objects/items/tools/experimental_tools.dm
+++ b/code/game/objects/items/tools/experimental_tools.dm
@@ -172,7 +172,7 @@
 			return
 		else if(H.is_revivable() && H.stat == DEAD)
 			if(H.cpr_cooldown < world.time)
-				H.revive_grace_period += 7 SECONDS
+				H.revive_grace_period += 9 SECONDS
 				H.visible_message(SPAN_NOTICE("<b>\The [src]</b> automatically performs <b>CPR</b> on <b>[H]</b>."))
 			else
 				H.visible_message(SPAN_NOTICE("<b>\The [src]</b> fails to perform CPR on <b>[H]</b>."))


### PR DESCRIPTION
# About the pull request

Makes the autocompressor a worthwhile tool to take, by making it more efficient. Previously the autocompressor adds 7 seconds of grace time per 10 seconds, which is significantly worse than manually performing CPR. Real mechanical compression devices are very effective, and the compressor's poor efficiency resulted in almost nobody taking it. Increased the autocompressor to add 9 seconds of grace time per 10 seconds, so you will still die eventually on autocompressor only, but it is 90% efficient instead of 70% so you would last far longer.

# Explain why it's good for the game

Helps chip away at the experimental tool weapon picks by buffing some support kit. Also makes this tool a good way to account for using standard defibrillators and working on people alone. 

# Testing Photographs and Procedure

Local server testing.

# Changelog
:cl:
balance: Increase autocompressor grace time per cycle from 7 to 9 seconds
/:cl: