### PR TITLE
Med Skill Rebalance Mk2 Demon Free Edition

### DIFF
--- a/code/game/objects/items/devices/defibrillator.dm
+++ b/code/game/objects/items/devices/defibrillator.dm
@@ -175,7 +175,7 @@
 	playsound(get_turf(src),'sound/items/defib_charge.ogg', 25, 0) //Do NOT vary this tune, it needs to be precisely 7 seconds
 
 	//Taking square root not to make defibs too fast...
-	if(!do_after(user, 7 SECONDS * user.get_skill_duration_multiplier(SKILL_MEDICAL), INTERRUPT_NO_NEEDHAND|BEHAVIOR_IMMOBILE, BUSY_ICON_FRIENDLY, H, INTERRUPT_MOVED, BUSY_ICON_MEDICAL))
+	if(!do_after(user, (4 + (3 * user.get_skill_duration_multiplier(SKILL_MEDICAL))) SECONDS, INTERRUPT_NO_NEEDHAND|BEHAVIOR_IMMOBILE, BUSY_ICON_FRIENDLY, H, INTERRUPT_MOVED, BUSY_ICON_MEDICAL))
 		user.visible_message(SPAN_WARNING("[user] stops setting up the paddles on [H]'s chest."), \
 		SPAN_WARNING("You stop setting up the paddles on [H]'s chest."))
 		return

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -482,7 +482,7 @@ GLOBAL_LIST_INIT(limb_types_by_name, list(
 // Medical
 		if(SKILL_MEDICAL)
 			if(skillcheck(src, SKILL_MEDICAL, SKILL_MEDICAL_MASTER))
-				return DURATION_MULTIPLIER_TIER_2
+				return 0.35
 			if(skillcheck(src, SKILL_MEDICAL, SKILL_MEDICAL_DOCTOR))
 				return DURATION_MULTIPLIER_TIER_1
 // Surgeon


### PR DESCRIPTION
# About the pull request

Got demons in my code, removed them from #5937 .

This does 2 main things, the medical 4 generalized multiplier changed to a non-standard value of 0.35, 10% less than it was before but 15% better than most recent. The other part is changing how medical skill affects defibrillators, with medical 4 shocking right as defibrillators finish their charge sound. Medical 2 is still unaffected by how the math works.
# Explain why it's good for the game

Keeps some of the splint/inject/CPR time from before, while maximizing the speed you can get before the shock sound.

# Testing Photographs and Procedure

Please TM

Tested on local server to make sure all the scaling worked properly.

# Changelog

:cl:
balance: changed medical 4 skill speed multiplier from tier 2 to a non-standard 0.35
balance: changed defib medical skill speed scaling
/:cl:

