### PR TITLE
Fixes for Professor Dummy.

### DIFF
--- a/code/game/objects/items/devices/dummy_tablet.dm
+++ b/code/game/objects/items/devices/dummy_tablet.dm
@@ -7,8 +7,28 @@
 	item_state = "Cotablet"
 
 	var/mob/living/carbon/human/linked_dummy
+	///Should the dummy be destroyed on hijack?
+	var/dust_on_hijack = FALSE
+
+/obj/item/device/professor_dummy_tablet/Initialize()
+	. = ..()
+	var/turf/actual_location = get_turf(src)
+	if(is_mainship_level(actual_location.z))
+		dust_on_hijack = TRUE
+	RegisterSignal(SSdcs, COMSIG_GLOB_HIJACK_LANDED, PROC_REF(destroy_dummy_upon_hijack))
+
+/obj/item/device/professor_dummy_tablet/proc/destroy_dummy_upon_hijack()
+	SIGNAL_HANDLER
+
+	if(!dust_on_hijack)
+		return
+	if(!linked_dummy)
+		return
+	linked_dummy.visible_message(SPAN_WARNING("The [linked_dummy] suddenly disintegrates!"))
+	linked_dummy.dust(create_cause_data("hijack autodelete"))
 
 /obj/item/device/professor_dummy_tablet/Destroy()
+	UnregisterSignal(src, COMSIG_GLOB_HIJACK_LANDED)
 	linked_dummy = null
 	. = ..()
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -186,9 +186,7 @@
 
 /obj/structure/closet/secure_closet/professor_dummy/Initialize()
 	. = ..()
-	var/mob/living/carbon/human/dummy/professor_dummy/spawned_dummy = new(src)
-	var/datum/equipment_preset/dummy_preset = /datum/equipment_preset/other/professor_dummy
-	arm_equipment(spawned_dummy, initial(dummy_preset.name), TRUE, FALSE)
+	new /mob/living/carbon/human/professor_dummy(src)
 
 /obj/structure/closet/secure_closet/professor_dummy/togglelock(mob/living/user)
 	if(user.job == JOB_CMO || user.job == JOB_SEA)
@@ -197,13 +195,13 @@
 	to_chat(user, SPAN_WARNING("Only the [JOB_CMO] or the [JOB_SEA] can toggle this lock."))
 
 /obj/structure/closet/secure_closet/professor_dummy/dump_contents()
-	if(locate(/mob/living/carbon/human/dummy/professor_dummy) in src)
+	if(locate(/mob/living/carbon/human/professor_dummy) in src)
 		visible_message(SPAN_HIGHDANGER("Professor DUMMY should only be used for teaching medical personnel, exclusively done by the [JOB_CMO] or the [JOB_SEA]. Do not abuse it."))
 	return ..()
 
 /obj/structure/closet/secure_closet/professor_dummy/close()
 	for(var/mob/mob in loc)
-		if(!istype(mob, /mob/living/carbon/human/dummy/professor_dummy))
+		if(!istype(mob, /mob/living/carbon/human/professor_dummy))
 			visible_message(SPAN_WARNING("[src] won't budge!"))
 			return
 	..()
@@ -216,7 +214,7 @@
 	return
 
 /obj/structure/closet/secure_closet/professor_dummy/proc/check_and_destroy_dummy()
-	var/mob/dummy = locate(/mob/living/carbon/human/dummy/professor_dummy) in src
+	var/mob/dummy = locate(/mob/living/carbon/human/professor_dummy) in src
 	if(dummy)
 		visible_message(SPAN_DANGER("Something in [src] blows apart!"))
 		playsound(src, 'sound/effects/metal_crash.ogg', 25, 1)

--- a/code/modules/mob/living/carbon/human/human_dummy.dm
+++ b/code/modules/mob/living/carbon/human/human_dummy.dm
@@ -82,17 +82,8 @@ GLOBAL_LIST_EMPTY(dummy_mob_list)
 	ADD_TRAIT(src, TRAIT_IMMOBILIZED, TRAIT_SOURCE_TUTORIAL)
 	anchored = TRUE
 
-// Professor Dummy, used by CMOs and SEAs to teach new nurses/doctors
-/mob/living/carbon/human/dummy/professor_dummy/Initialize(mapload)
+/// Professor Dummy, used by CMOs and SEAs to teach new nurses/doctors
+/mob/living/carbon/human/professor_dummy/Initialize()
 	. = ..()
-	RegisterSignal(SSdcs, COMSIG_GLOB_HIJACK_LANDED, PROC_REF(destroy_upon_hijack))
-
-/mob/living/carbon/human/dummy/professor_dummy/proc/destroy_upon_hijack()
-	SIGNAL_HANDLER
-
-	visible_message(SPAN_WARNING("The [src] suddenly disintegrates!"))
-	dust(create_cause_data("hijack autodelete"))
-
-/mob/living/carbon/human/dummy/professor_dummy/Destroy()
-	UnregisterSignal(src, COMSIG_GLOB_HIJACK_LANDED)
-	return ..()
+	create_hud()
+	arm_equipment(src, /datum/equipment_preset/other/professor_dummy)


### PR DESCRIPTION
# About the pull request

Followup to #5874.

# Explain why it's good for the game

`human/dummy` is designed to be noninteractive. It has godmode (not that godmode does much), it is not processed (thus no bleeding, no medicaments etc), it is not even added to medical HUD. Medical training dummy should not be a subtype of it.
Also shuffled some code around so that, for example, somebody using a dummy in thunderdome does not suddenly lose it on hijack.

# Changelog

:cl:
fix: Professor Dummy in CMO's office now works properly.
/:cl: