### PR TITLE
Fix for Marsoc spawnpoint.

### DIFF
--- a/code/datums/emergency_calls/deathsquad.dm
+++ b/code/datums/emergency_calls/deathsquad.dm
@@ -88,84 +88,44 @@
 //################################################################################################
 // Marine commandos - USCM Deathsquad. Event only
 /datum/emergency_call/marsoc
-	name = "Marine Raider Strike Team (!DEATHSQUAD!)"
+	name = "Marine Raider Operatives (!DEATHSQUAD!)"
 	mob_max = 8
 	mob_min = 5
 	probability = 0
 	shuttle_id = MOBILE_SHUTTLE_ID_ERT2
 	home_base = /datum/lazy_template/ert/weyland_station
 	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_pmc
+	var/leader_preset = /datum/equipment_preset/uscm/marsoc/sl
+	var/member_preset = /datum/equipment_preset/uscm/marsoc
 
-/datum/emergency_call/marsoc/create_member(datum/mind/M, turf/override_spawn_loc)
+/datum/emergency_call/marsoc/create_member(datum/mind/player, turf/override_spawn_loc)
 
 	var/turf/spawn_loc = override_spawn_loc ? override_spawn_loc : get_spawn_point()
 
 	if(!istype(spawn_loc))
 		return //Didn't find a useable spawn point.
 
-	var/mob/living/carbon/human/H = new(spawn_loc)
-	M.transfer_to(H, TRUE)
+	var/mob/living/carbon/human/member = new(spawn_loc)
+	player.transfer_to(member, TRUE)
 
-	if(!leader && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(H.client, JOB_SQUAD_LEADER, time_required_for_job))    //First one spawned is always the leader.
-		leader = H
-		to_chat(H, SPAN_WARNING(FONT_SIZE_BIG("You are a Marine Raider Team Leader, better than all the rest.")))
-		arm_equipment(H, /datum/equipment_preset/uscm/marsoc/sl, TRUE, TRUE)
+	if(!leader && HAS_FLAG(member.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(member.client, JOB_SQUAD_LEADER, time_required_for_job))    //First one spawned is always the leader.
+		leader = member
+		to_chat(member, SPAN_WARNING(FONT_SIZE_BIG("You are a Marine Raider Team Leader, better than all the rest.")))
+		arm_equipment(member, leader_preset, TRUE, TRUE)
 	else
-		to_chat(H, SPAN_WARNING(FONT_SIZE_BIG("You are an elite Marine Raider Operative, the best of the best.")))
-		arm_equipment(H, /datum/equipment_preset/uscm/marsoc, TRUE, TRUE)
-	to_chat(H, SPAN_BOLDNOTICE("You are absolutely loyal to High Command and must follow their directives."))
-	to_chat(H, SPAN_BOLDNOTICE("Execute the mission assigned to you with extreme prejudice!"))
+		to_chat(member, SPAN_WARNING(FONT_SIZE_BIG("You are an elite Marine Raider Operative, the best of the best.")))
+		arm_equipment(member, member_preset, TRUE, TRUE)
+	to_chat(member, SPAN_BOLDNOTICE("You are absolutely loyal to High Command and must follow their directives."))
+	to_chat(member, SPAN_BOLDNOTICE("Execute the mission assigned to you with extreme prejudice!"))
 	return
 
-/datum/emergency_call/marsoc_covert
+/datum/emergency_call/marsoc/covert
 	name = "Marine Raider Operatives (!DEATHSQUAD! Covert)"
-	mob_max = 8
-	mob_min = 5
-	probability = 0
-	shuttle_id = MOBILE_SHUTTLE_ID_ERT2
-	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_pmc
-	home_base = /datum/lazy_template/ert/weyland_station
-
-/datum/emergency_call/marsoc_covert/create_member(datum/mind/M)
-
-	var/turf/spawn_loc = get_spawn_point()
-
-	if(!istype(spawn_loc))
-		return //Didn't find a useable spawn point.
-
-	var/mob/living/carbon/human/H = new(spawn_loc)
-	M.transfer_to(H, TRUE)
-	if(!leader && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(H.client, JOB_SQUAD_LEADER, time_required_for_job))    //First one spawned is always the leader.
-		leader = H
-		to_chat(H, SPAN_WARNING(FONT_SIZE_BIG("You are a Marine Raider Team Leader, better than all the rest.")))
-		arm_equipment(H, /datum/equipment_preset/uscm/marsoc/sl/covert, TRUE, TRUE)
-	else
-		to_chat(H, SPAN_WARNING(FONT_SIZE_BIG("You are an elite Marine Raider, the best of the best.")))
-		arm_equipment(H, /datum/equipment_preset/uscm/marsoc/covert, TRUE, TRUE)
-	to_chat(H, SPAN_BOLDNOTICE("You are absolutely loyal to High Command and must follow their directives."))
-	to_chat(H, SPAN_BOLDNOTICE("Execute the mission assigned to you with extreme prejudice!"))
-	return
+	leader_preset = /datum/equipment_preset/uscm/marsoc/sl/covert
+	member_preset = /datum/equipment_preset/uscm/marsoc/covert
 
 
 /datum/emergency_call/marsoc/low_threat
 	name = "Marine Raider Operatives"
-
-/datum/emergency_call/marsoc/low_threat/create_member(datum/mind/MIND)
-
-	var/turf/spawn_loc = get_spawn_point()
-
-	if(!istype(spawn_loc))
-		return //Didn't find a useable spawn point.
-
-	var/mob/living/carbon/human/player = new(spawn_loc)
-	MIND.transfer_to(player, TRUE)
-	if(!leader && HAS_FLAG(player.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(player.client, JOB_SQUAD_LEADER, time_required_for_job))    //First one spawned is always the leader.
-		leader = player
-		to_chat(player, SPAN_WARNING(FONT_SIZE_BIG("You are a Marine Raider Team Leader, better than all the rest.")))
-		arm_equipment(player, /datum/equipment_preset/uscm/marsoc/low_threat/sl, TRUE, TRUE)
-	else
-		to_chat(player, SPAN_WARNING(FONT_SIZE_BIG("You are an elite Marine Raider, the best of the best.")))
-		arm_equipment(player, /datum/equipment_preset/uscm/marsoc/low_threat, TRUE, TRUE)
-	to_chat(player, SPAN_BOLDNOTICE("You are absolutely loyal to High Command and must follow their directives."))
-	to_chat(player, SPAN_BOLDNOTICE("Execute the mission assigned to you with extreme prejudice!"))
-	return
+	leader_preset = /datum/equipment_preset/uscm/marsoc/low_threat/sl
+	member_preset = /datum/equipment_preset/uscm/marsoc/low_threat


### PR DESCRIPTION
# About the pull request

One of those copypasted blocks missed a `? :` for `spawn_loc`. But who needs copypasted blocks?

# Explain why it's good for the game

Fixes #5880.

# Changelog

:cl:
admin: Spawning nondeathsquad MARSOC now properly recognises "current location" option.
/:cl: