### PR TITLE
Slightly expands weedible area to of west lZ2 T-comms area

### DIFF
--- a/code/game/area/LV624.dm
+++ b/code/game/area/LV624.dm
@@ -37,6 +37,7 @@
 	name ="\improper Western Jungle"
 	icon_state = "west"
 	//ambience = list('sound/ambience/jungle_amb1.ogg')
+	is_resin_allowed = FALSE
 
 /area/lv624/ground/jungle/west_jungle/ceiling
 	ceiling = CEILING_GLASS

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -26180,7 +26180,7 @@ asK
 aAl
 ase
 atu
-atu
+asx
 asw
 asw
 asw
@@ -26408,8 +26408,8 @@ aAl
 avf
 aAl
 aAl
-aAl
 ase
+atu
 asx
 aro
 aro

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -1895,7 +1895,7 @@
 /area/lv624/ground/barrens/east_barrens/ceiling)
 "aja" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/open/gm/dirtgrassborder/east,
+/turf/open/gm/dirtgrassborder/grassdirt_corner2/south_east,
 /area/lv624/ground/jungle/west_jungle)
 "ajc" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
@@ -2585,9 +2585,9 @@
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/west_caves)
 "amK" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/gm/dirtgrassborder/grassdirt_corner2/south_east,
-/area/lv624/ground/river/west_river)
+/obj/structure/flora/bush/ausbushes/var3/leafybush,
+/turf/open/gm/dirt,
+/area/lv624/ground/jungle/west_jungle)
 "amL" = (
 /obj/structure/flora/bush/ausbushes/palebush,
 /turf/open/gm/river,
@@ -3061,7 +3061,7 @@
 /area/lv624/lazarus/hydroponics)
 "aqq" = (
 /obj/structure/flora/bush/ausbushes/pointybush,
-/turf/open/gm/dirtgrassborder/west,
+/turf/open/gm/dirtgrassborder/grassdirt_corner2/south_west,
 /area/lv624/ground/jungle/west_jungle)
 "aqr" = (
 /obj/structure/flora/bush/ausbushes/var3/fernybush,
@@ -3262,7 +3262,8 @@
 /turf/open/gm/dirtgrassborder/west,
 /area/lv624/lazarus/quartstorage/outdoors)
 "arE" = (
-/turf/open/gm/dirtgrassborder/grassdirt_corner2/north_east,
+/obj/structure/flora/jungle/vines/light_1,
+/turf/open/gm/dirtgrassborder/grassdirt_corner/south_west,
 /area/lv624/ground/jungle/west_jungle)
 "arG" = (
 /obj/effect/landmark/survivor_spawner,
@@ -3337,8 +3338,8 @@
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/west_jungle)
 "asd" = (
-/obj/structure/flora/bush/ausbushes/var3/fullgrass,
-/turf/open/gm/dirtgrassborder/south,
+/obj/structure/flora/jungle/vines/light_3,
+/turf/open/gm/dirtgrassborder/west,
 /area/lv624/ground/jungle/west_jungle)
 "ase" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/south_west,
@@ -3426,8 +3427,8 @@
 	},
 /area/lv624/lazarus/landing_zones/lz1)
 "asK" = (
-/obj/structure/flora/bush/ausbushes/pointybush,
-/turf/open/gm/grass/grass1,
+/obj/structure/flora/jungle/vines/light_3,
+/turf/open/gm/dirt,
 /area/lv624/ground/jungle/west_jungle)
 "asL" = (
 /obj/item/tool/warning_cone,
@@ -3497,16 +3498,12 @@
 	},
 /area/lv624/lazarus/research)
 "asX" = (
-/obj/structure/flora/grass/tallgrass/jungle/corner{
-	dir = 6
-	},
-/turf/open/gm/grass/grass2,
+/obj/structure/flora/jungle/vines/light_3,
+/turf/open/gm/dirtgrassborder/south,
 /area/lv624/ground/jungle/west_jungle)
 "asY" = (
-/obj/structure/flora/grass/tallgrass/jungle/corner{
-	dir = 10
-	},
-/turf/open/gm/grass/grass2,
+/obj/effect/landmark/monkey_spawn,
+/turf/open/gm/dirt,
 /area/lv624/ground/jungle/west_jungle)
 "asZ" = (
 /obj/structure/flora/bush/ausbushes/var3/ywflowers,
@@ -4446,10 +4443,6 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/lv624/lazarus/fitness)
-"awz" = (
-/obj/structure/flora/grass/tallgrass/jungle/corner,
-/turf/open/gm/grass/grass1,
-/area/lv624/ground/jungle/west_jungle)
 "awC" = (
 /obj/structure/flora/bush/ausbushes/reedbush,
 /turf/open/gm/coast/beachcorner/north_east,
@@ -4829,9 +4822,6 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/lv624/lazarus/fitness)
-"axV" = (
-/turf/open/gm/dirtgrassborder/north,
-/area/lv624/ground/jungle/west_jungle)
 "axW" = (
 /obj/effect/decal/remains/xeno,
 /obj/structure/fence,
@@ -4860,12 +4850,6 @@
 /obj/effect/landmark/lv624/xeno_tunnel,
 /turf/open/gm/grass/grass1,
 /area/lv624/lazarus/quartstorage/outdoors)
-"ayd" = (
-/obj/structure/flora/grass/tallgrass/jungle/corner{
-	dir = 4
-	},
-/turf/open/gm/grass/grass1,
-/area/lv624/ground/jungle/west_jungle)
 "ayg" = (
 /obj/structure/computerframe,
 /turf/open/floor/plating{
@@ -4895,12 +4879,6 @@
 	icon_state = "vault"
 	},
 /area/lv624/lazarus/robotics)
-"ayl" = (
-/obj/structure/flora/grass/tallgrass/jungle/corner{
-	dir = 1
-	},
-/turf/open/gm/grass/grass1,
-/area/lv624/ground/jungle/west_jungle)
 "aym" = (
 /obj/structure/machinery/autolathe,
 /turf/open/floor{
@@ -5070,10 +5048,6 @@
 	icon_state = "whitepurple"
 	},
 /area/lv624/lazarus/research)
-"ayN" = (
-/obj/structure/flora/bush/ausbushes/reedbush,
-/turf/open/gm/dirtgrassborder/grassdirt_corner2/south_west,
-/area/lv624/ground/jungle/west_jungle)
 "ayO" = (
 /obj/item/weapon/baseballbat/metal,
 /obj/item/weapon/baseballbat/metal{
@@ -7819,14 +7793,6 @@
 /area/lv624/lazarus/main_hall)
 "aIm" = (
 /obj/structure/flora/bush/ausbushes/var3/fernybush,
-/turf/open/gm/grass/grass1,
-/area/lv624/ground/jungle/west_jungle)
-"aIn" = (
-/obj/structure/flora/bush/ausbushes/var3/sunnybush,
-/turf/open/gm/grass/grass1,
-/area/lv624/ground/jungle/west_jungle)
-"aIo" = (
-/obj/structure/flora/bush/ausbushes/var3/stalkybush,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/west_jungle)
 "aIp" = (
@@ -12333,10 +12299,6 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/west_central_jungle)
-"bbu" = (
-/obj/structure/flora/bush/ausbushes/var3/stalkybush,
-/turf/open/gm/grass/grass2,
-/area/lv624/ground/jungle/west_jungle)
 "bbx" = (
 /obj/structure/flora/jungle/vines/light_1,
 /obj/structure/flora/jungle/vines/heavy,
@@ -12344,7 +12306,7 @@
 /area/lv624/ground/jungle/east_central_jungle)
 "bbC" = (
 /obj/effect/landmark/hunter_primary,
-/turf/open/gm/grass/grass2,
+/turf/open/gm/dirt,
 /area/lv624/ground/jungle/west_jungle)
 "bbH" = (
 /obj/structure/flora/bush/ausbushes/var3/sparsegrass,
@@ -16023,7 +15985,7 @@
 /area/lv624/lazarus/comms)
 "hJn" = (
 /obj/structure/flora/jungle/vines/light_2,
-/turf/open/gm/grass/grass2,
+/turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/west_jungle)
 "hJW" = (
 /turf/open/gm/dirtgrassborder/south,
@@ -21378,10 +21340,6 @@
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/vault,
 /area/lv624/lazarus/quartstorage)
-"rvL" = (
-/obj/structure/flora/bush/ausbushes/ausbush,
-/turf/open/gm/grass/grass2,
-/area/lv624/ground/jungle/west_jungle)
 "rvW" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/gm/grass/grass1,
@@ -23306,9 +23264,6 @@
 /obj/structure/fence,
 /turf/open/gm/dirtgrassborder/north,
 /area/lv624/ground/colony/west_tcomms_road)
-"uSw" = (
-/turf/open/gm/dirtgrassborder/grassdirt_corner/north_east,
-/area/lv624/ground/jungle/west_jungle)
 "uSy" = (
 /turf/open/gm/coast/beachcorner2/north_east,
 /area/lv624/ground/barrens/east_barrens)
@@ -25769,7 +25724,7 @@ atC
 aAt
 aro
 aHE
-aIn
+aro
 asw
 asw
 asw
@@ -25989,13 +25944,13 @@ nsk
 nsk
 nsk
 aun
-aqS
-suv
-atZ
+ase
+arE
+atC
 vVD
-ayT
-aro
-aro
+asd
+atu
+asx
 aro
 asw
 asw
@@ -26216,20 +26171,20 @@ aYX
 alC
 alC
 auc
-amK
-arn
-asK
+aZb
+aAl
+ase
 pbd
 avf
-ayT
-aro
-aBk
-aro
-aIo
+asK
+aAl
+ase
+atu
+atu
 asw
 asw
 asw
-aro
+arP
 awb
 awe
 awe
@@ -26444,18 +26399,18 @@ aYS
 aud
 aud
 auP
-aqS
-rvL
-asc
-aro
-aro
-aro
-asw
-aro
-aro
-aro
-aro
-aro
+aAl
+aAl
+aAl
+aAl
+aAl
+aAl
+avf
+aAl
+aAl
+aAl
+ase
+asx
 aro
 aro
 ata
@@ -26672,19 +26627,19 @@ arV
 aud
 aud
 auP
-aqS
+aAl
 avf
-aro
-awb
-ayd
-azg
-aro
-aro
-aIm
-aro
-aro
-arP
-asc
+aAl
+aAl
+aAl
+aAl
+aAl
+aAl
+aAl
+aAl
+aAl
+ase
+asx
 aro
 aro
 aro
@@ -26900,18 +26855,18 @@ aud
 amG
 bGb
 auP
-asd
+aAl
 avf
-asX
-awe
-awe
-ayl
-aro
-aro
-aro
-aIq
-aCO
-atu
+aAl
+aAl
+aAl
+aAl
+aAl
+aAl
+aAl
+asY
+aAl
+aAl
 aqq
 atu
 atu
@@ -27128,17 +27083,17 @@ aud
 aud
 asp
 auP
-aqS
-asc
-asY
-awe
-awe
-awV
-aro
-asw
-aro
-aCO
-aEe
+aAl
+aAl
+aAl
+aAl
+aAl
+aAl
+aAl
+avf
+avf
+aAl
+aAl
 aAl
 aAl
 aAl
@@ -27356,16 +27311,16 @@ aud
 aud
 aud
 auP
-aqS
-bbu
-asZ
-awz
-ayl
-aro
-atA
-aro
-asg
-axV
+aAl
+aAl
+aAl
+aAl
+aAl
+aAl
+aAl
+avf
+aAl
+aAl
 aAl
 aAl
 aAl
@@ -27584,16 +27539,16 @@ asF
 aud
 fQL
 aBn
-asd
-aro
-asX
-awe
-ayA
-ayd
-azg
-aro
-aCO
-aEe
+aAl
+aAl
+aAl
+aAl
+aAl
+aAl
+aAl
+aAl
+aAl
+aAl
 aAl
 aAl
 ayh
@@ -27812,15 +27767,15 @@ aud
 aud
 oym
 xuK
-ase
-asx
-ata
-awV
-asw
-ata
-awV
-aro
-axV
+aAl
+aAl
+aAl
+avf
+avf
+aAl
+aAl
+aAl
+aAl
 kQY
 knd
 knd
@@ -28040,15 +27995,15 @@ arU
 aud
 atJ
 aYR
-akZ
-aqS
-arP
-aro
-aro
-aro
-asc
-aCO
-aEe
+axw
+aAl
+aAl
+aAl
+avf
+avf
+aAl
+aAl
+aAl
 oek
 jga
 jga
@@ -28269,14 +28224,14 @@ xJA
 xJA
 bGb
 dmf
-ase
-atu
-atu
-asx
-aro
+aAl
+aAl
+aAl
+aAl
+aAl
 bbC
-axV
-ayh
+aAl
+kQY
 ayV
 jga
 azs
@@ -28500,10 +28455,10 @@ bBu
 knd
 knd
 axw
-ase
-atu
-atu
-aEe
+aAl
+aAl
+aAl
+aAl
 oek
 jga
 jga
@@ -29633,8 +29588,8 @@ aud
 aud
 asF
 auP
-aqR
-arE
+aAl
+aAl
 npf
 sTB
 sTB
@@ -29861,13 +29816,13 @@ aud
 aud
 bGb
 auP
-aqS
-uSw
-asa
-asa
-asa
-asa
-arE
+aAl
+aAl
+aAl
+aAl
+aAl
+aAl
+aAl
 awC
 sTB
 sTB
@@ -30089,13 +30044,13 @@ aud
 asp
 aud
 auP
-aqS
-arP
-asc
-asg
-aro
-atA
-axV
+aAl
+amK
+aAl
+aAl
+aAl
+aAl
+aAl
 aiS
 aAl
 aAl
@@ -30317,15 +30272,15 @@ aud
 aud
 aud
 auP
-aqS
+aAl
 aFm
 aFm
 auO
 aFm
 aFm
 aAl
-aqR
-asa
+aAl
+aAl
 aja
 asa
 asa
@@ -30545,16 +30500,16 @@ aud
 aud
 amG
 auP
-aqS
+aAl
 aFm
 aue
 auf
 aXC
 aFm
 aAl
-ayN
-asx
-ayT
+aqi
+aAl
+asX
 aAp
 aAp
 baN
@@ -30773,7 +30728,7 @@ aud
 aud
 aud
 asR
-aqS
+aAl
 aFm
 auf
 auf
@@ -30781,7 +30736,7 @@ aZp
 aFm
 aAl
 omu
-aqS
+aAl
 aAp
 aAp
 aAp
@@ -31001,7 +30956,7 @@ amG
 aud
 aul
 aBn
-aqS
+aAl
 aFQ
 aug
 wFx
@@ -31229,7 +31184,7 @@ aud
 bGb
 auP
 aqi
-ase
+aAl
 aFm
 aZn
 axp

--- a/maps/map_files/LV624/standalone/leftsidepass.dmm
+++ b/maps/map_files/LV624/standalone/leftsidepass.dmm
@@ -1,8 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"ab" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/gm/coast/north,
-/area/lv624/ground/river/west_river)
 "ac" = (
 /obj/effect/landmark/hunter_primary,
 /turf/open/gm/dirt,
@@ -53,39 +49,11 @@
 "ar" = (
 /turf/open/gm/coast/beachcorner/south_east,
 /area/lv624/ground/river/west_river)
-"as" = (
-/obj/structure/flora/bush/ausbushes/var3/fullgrass,
-/turf/open/gm/dirt,
-/area/lv624/ground/jungle/west_jungle)
-"at" = (
-/turf/open/gm/dirtgrassborder/grassdirt_corner2/south_east,
-/area/lv624/ground/river/west_river)
 "au" = (
 /turf/open/gm/dirtgrassborder/south,
 /area/lv624/ground/jungle/west_jungle)
-"av" = (
-/turf/open/gm/dirtgrassborder/grassdirt_corner2/south_west,
-/area/lv624/ground/jungle/west_jungle)
 "aw" = (
-/obj/structure/flora/bush/ausbushes/reedbush,
 /turf/open/gm/coast/beachcorner/south_west,
-/area/lv624/ground/jungle/west_jungle)
-"ax" = (
-/turf/open/gm/dirtgrassborder/grassdirt_corner/south_east,
-/area/lv624/ground/jungle/west_jungle)
-"ay" = (
-/obj/structure/flora/bush/ausbushes/ausbush,
-/turf/open/gm/grass/grass2,
-/area/lv624/ground/jungle/west_jungle)
-"az" = (
-/turf/open/gm/grass/grass2,
-/area/lv624/ground/jungle/west_jungle)
-"aA" = (
-/obj/structure/flora/bush/ausbushes/var3/stalkybush,
-/turf/open/gm/grass/grass2,
-/area/lv624/ground/jungle/west_jungle)
-"aB" = (
-/turf/open/gm/dirtgrassborder/grassdirt_corner/south_west,
 /area/lv624/ground/jungle/west_jungle)
 "aC" = (
 /obj/structure/flora/jungle/vines/light_2,
@@ -93,47 +61,14 @@
 /area/lv624/ground/jungle/west_jungle)
 "aD" = (
 /obj/structure/flora/jungle/vines/light_1,
-/turf/open/gm/grass/grass2,
+/turf/open/gm/dirtgrassborder/grassdirt_corner/south_west,
 /area/lv624/ground/jungle/west_jungle)
 "aE" = (
-/obj/structure/flora/bush/ausbushes/pointybush,
-/turf/open/gm/grass/grass1,
-/area/lv624/ground/jungle/west_jungle)
-"aF" = (
-/obj/structure/flora/grass/tallgrass/jungle/corner{
-	dir = 6
-	},
-/turf/open/gm/grass/grass2,
-/area/lv624/ground/jungle/west_jungle)
-"aG" = (
-/obj/structure/flora/grass/tallgrass/jungle/corner{
-	dir = 10
-	},
-/turf/open/gm/grass/grass2,
-/area/lv624/ground/jungle/west_jungle)
-"aH" = (
-/obj/structure/flora/bush/ausbushes/var3/ywflowers,
-/turf/open/gm/grass/grass1,
-/area/lv624/ground/jungle/west_jungle)
-"aI" = (
-/obj/structure/flora/grass/tallgrass/jungle/corner{
-	dir = 10
-	},
-/turf/open/gm/grass/grass1,
-/area/lv624/ground/jungle/west_jungle)
-"aJ" = (
-/obj/structure/flora/bush/ausbushes/var3/leafybush,
-/turf/open/gm/grass/grass1,
-/area/lv624/ground/jungle/west_jungle)
-"aK" = (
-/turf/open/gm/dirtgrassborder/west,
+/turf/open/gm/dirtgrassborder/grassdirt_corner2/south_west,
 /area/lv624/ground/jungle/west_jungle)
 "aU" = (
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/river/west_river)
-"aV" = (
-/turf/open/gm/grass/grass1,
-/area/lv624/ground/jungle/west_jungle)
 "aX" = (
 /turf/open/gm/coast/beachcorner2/south_east,
 /area/lv624/ground/river/west_river)
@@ -172,8 +107,7 @@
 /turf/open/gm/river,
 /area/lv624/ground/river/west_river)
 "bV" = (
-/obj/structure/flora/bush/ausbushes/var3/fullgrass,
-/turf/open/gm/dirtgrassborder/south,
+/turf/open/gm/dirt,
 /area/lv624/ground/jungle/west_jungle)
 "gX" = (
 /turf/closed/wall/rock/brown,
@@ -268,7 +202,7 @@ ES
 ES
 ES
 qG
-au
+aE
 aD
 "}
 (4,1,1) = {"
@@ -282,8 +216,8 @@ ai
 ad
 ad
 aq
-at
-ax
+ES
+bV
 aE
 "}
 (5,1,1) = {"
@@ -297,9 +231,9 @@ bm
 bc
 bc
 bt
-au
-ay
-az
+bV
+bV
+bV
 "}
 (6,1,1) = {"
 bi
@@ -312,9 +246,9 @@ aj
 bc
 bc
 bt
-au
+bV
 Za
-aV
+bV
 "}
 (7,1,1) = {"
 bi
@@ -329,7 +263,7 @@ FJ
 bt
 bV
 Za
-aF
+bV
 "}
 (8,1,1) = {"
 bi
@@ -342,9 +276,9 @@ bc
 bc
 am
 bt
-au
-az
-aG
+bV
+bV
+bV
 "}
 (9,1,1) = {"
 bx
@@ -357,9 +291,9 @@ bc
 bc
 bc
 bt
-au
-aA
-aH
+bV
+bV
+bV
 "}
 (10,1,1) = {"
 bf
@@ -373,8 +307,8 @@ bc
 aX
 ar
 bV
-aV
-aF
+bV
+bV
 "}
 (11,1,1) = {"
 bi
@@ -386,10 +320,10 @@ bN
 bc
 bc
 bt
-as
-av
-aB
-aI
+bV
+bV
+bV
+bV
 "}
 (12,1,1) = {"
 bi
@@ -403,8 +337,8 @@ bc
 ao
 zW
 aw
-au
-aJ
+bV
+bV
 "}
 (13,1,1) = {"
 bx
@@ -418,12 +352,12 @@ bc
 bc
 ve
 Ms
-av
-aK
+bV
+bV
 "}
 (14,1,1) = {"
 bi
-ab
+bL
 af
 af
 af


### PR DESCRIPTION

# About the pull request

Adds another weedable zone west of LZ2 T-comms tower

# Explain why it's good for the game

The weedibility of the area is quite light compared to the other tower and players lack a lot of options other than assaulting from across the river


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: SpartanBobby
maptweak: New weedable zone west of LZ2 T-comms tower
/:cl:
