### PR TITLE
Fixes delayed launch launching lifeboat even if locked by queen

### DIFF
--- a/code/modules/shuttle/shuttles/crashable/lifeboats.dm
+++ b/code/modules/shuttle/shuttles/crashable/lifeboats.dm
@@ -41,6 +41,9 @@
 	port_direction = EAST
 
 /obj/docking_port/mobile/crashable/lifeboat/evac_launch()
+	if (status == LIFEBOAT_LOCKED)
+		return
+
 	. = ..()
 
 	available = FALSE


### PR DESCRIPTION

# About the pull request
Queen locking a lifeboat should cancel its launch.

# Explain why it's good for the game
Trust me.
<details>
I did not test it.

</details>


# Changelog
:cl: ihatethisengine
fix: Fixed delayed launch launching lifeboat even if locked by queen
/:cl:
