### PR TITLE
Adds third level of observer zoom to Toggle Zoom

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -811,10 +811,13 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set category = "Ghost.Settings"
 
 	if(client)
-		if(client.view != GLOB.world_view_size)
-			client.change_view(GLOB.world_view_size)
-		else
+		// Check the current zoom level and toggle to the next level cyclically
+		if (client.view == GLOB.world_view_size)
 			client.change_view(14)
+		else if (client.view == 14)
+			client.change_view(28)
+		else
+			client.change_view(GLOB.world_view_size)
 
 
 /mob/dead/observer/verb/toggle_darkness()


### PR DESCRIPTION
# About the pull request

The toggle zoom verb will now cycle between three levels of zoom.  Standard, zoomed out, and very far.

# Explain why it's good for the game

Sometimes its nice to see the whole battlefield going at once.  Further: it'd be really cool to be able to see the entirety of OBs going off.  And it will make scanning for action that much easier!


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>
Standard Zoom:
![ZoomLevel1](https://github.com/cmss13-devs/cmss13/assets/31581761/f07a6644-9e40-4055-91fe-b853f12f7de8)


Normal Level Zoom Out:
![ZoomLevel2](https://github.com/cmss13-devs/cmss13/assets/31581761/38a43082-716b-4eb6-bcd0-09849c78caf5)

New Super Zoom Level:
![ZoomLevel3](https://github.com/cmss13-devs/cmss13/assets/31581761/128644ab-18a3-4e40-989b-e281df6ee8bd)
</details>


# Changelog
:cl:
code: Added a third level of zoom to the Toggle Zoom verb
/:cl:
