### PR TITLE
Tacmap makes no update noise for observers when hear/silence ghost announcement is toggled on

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -603,6 +603,8 @@ GLOBAL_LIST_INIT(limb_types_by_name, list(
 	for(var/mob/dead/observer/ghost as anything in GLOB.observer_list)
 		if(!ghost.client)
 			continue
+		if(!(ghost.client?.prefs?.toggles_sound & SOUND_OBSERVER_ANNOUNCEMENTS))
+			ghost_sound = null
 		ghost.notify_ghost(message, ghost_sound, enter_link, enter_text, source, alert_overlay, action, flashwindow, ignore_mapload, ignore_key, header, notify_volume, extra_large)
 
 /mob/dead/observer/proc/notify_ghost(message, ghost_sound, enter_link, enter_text, atom/source, mutable_appearance/alert_overlay, action = NOTIFY_JUMP, flashwindow = FALSE, ignore_mapload = TRUE, ignore_key, header, notify_volume = 100, extra_large = FALSE) //Easy notification of a single ghosts.

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -603,9 +603,10 @@ GLOBAL_LIST_INIT(limb_types_by_name, list(
 	for(var/mob/dead/observer/ghost as anything in GLOB.observer_list)
 		if(!ghost.client)
 			continue
+		var/specific_ghost_sound = ghost_sound
 		if(!(ghost.client?.prefs?.toggles_sound & SOUND_OBSERVER_ANNOUNCEMENTS))
-			ghost_sound = null
-		ghost.notify_ghost(message, ghost_sound, enter_link, enter_text, source, alert_overlay, action, flashwindow, ignore_mapload, ignore_key, header, notify_volume, extra_large)
+			specific_ghost_sound = null
+		ghost.notify_ghost(message, specific_ghost_sound, enter_link, enter_text, source, alert_overlay, action, flashwindow, ignore_mapload, ignore_key, header, notify_volume, extra_large)
 
 /mob/dead/observer/proc/notify_ghost(message, ghost_sound, enter_link, enter_text, atom/source, mutable_appearance/alert_overlay, action = NOTIFY_JUMP, flashwindow = FALSE, ignore_mapload = TRUE, ignore_key, header, notify_volume = 100, extra_large = FALSE) //Easy notification of a single ghosts.
 	if(ignore_mapload && SSatoms.initialized != INITIALIZATION_INNEW_REGULAR)	//don't notify for objects created during a map load


### PR DESCRIPTION
# About the pull request

This is a follow-up to #5895 that mutes announcement sounds with a new preference option.

Tacmaps use a different proc that I missed the first time, this PR mutes them too.

# Explain why it's good for the game

Same as in #5895, if someone just wants to be online but not get jumpscared by random noises (e.g. staff or people waiting for larva/ERT), this helps them.

# Testing Photographs and Procedure

1. Spawn in as CO
2. Spawn in cotablet
3. Mute the CO game instance
4. Join the server with another ckey
5. Observe
6. Mute their ghost announcements
7. Update tacmap as CO
8. Unmute the observer's ghost announcements
9. Update tacmap as CO


# Changelog

:cl:
add: Tacmap announcements are now also muted if you have hear/silence ghost announcements toggled on.
/:cl:
