### PR TITLE
[FIX,MAP] move semiotic in north evac pod so you can't see it when your behind in hull maintenance.

### DIFF
--- a/maps/shuttles/escape_shuttle_n.dmm
+++ b/maps/shuttles/escape_shuttle_n.dmm
@@ -50,7 +50,7 @@
 /obj/structure/machinery/cryopod/evacuation,
 /obj/structure/sign/safety/cryo{
 	pixel_x = 8;
-	pixel_y = -35
+	pixel_y = -28
 	},
 /turf/open/shuttle/escapepod{
 	icon_state = "floor4"


### PR DESCRIPTION
# About the pull request
fixing some semiotic placement from -35 to -28. because it stick out and it's weird.
![313985469-d5514670-5476-42b3-9963-8e5d85988c12](https://github.com/cmss13-devs/cmss13/assets/117036822/a7b062c2-2e83-4840-801e-6c9d8a1960fc)

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: move semiotic in north evac pod so you can't see it when your behind in hull maintenance.
/:cl:
