### PR TITLE
[Do Not Merge] Adds Pylon Integration for Xeno EndGame double pyloning

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -180,6 +180,12 @@
 /// The time until you can re-corrupt a comms relay after the last pylon was destroyed
 #define XENO_PYLON_DESTRUCTION_DELAY (5 MINUTES)
 
+/// The time it takes for the double pylon bonus to be activated
+#define XENO_DOUBLE_PYLON_BONUS_STARTUP_COOLDOWN (10 MINUTES)
+
+/// The time it takes for the double pylon bonus to be upgraded
+#define XENO_DOUBLE_PYLON_BONUS_UPGRADE_COOLDOWN (7.5 MINUTES)
+
 /// Evolution boost during hijack
 #define XENO_HIJACK_EVILUTION_BUFF 10
 

--- a/code/controllers/subsystem/x_evolution.dm
+++ b/code/controllers/subsystem/x_evolution.dm
@@ -33,7 +33,7 @@ SUBSYSTEM_DEF(xevolution)
 			continue
 
 		if(!HS.dynamic_evolution)
-			boost_power[HS.hivenumber] = HS.evolution_rate + HS.evolution_bonus
+			boost_power[HS.hivenumber] = HS.evolution_rate + HS.evolution_bonus + (HS.double_pylon_bonus * 0.5)
 			HS.hive_ui.update_burrowed_larva()
 			continue
 
@@ -49,7 +49,7 @@ SUBSYSTEM_DEF(xevolution)
 
 		boost_power_new = clamp(boost_power_new, BOOST_POWER_MIN, BOOST_POWER_MAX)
 
-		boost_power_new += HS.evolution_bonus
+		boost_power_new += HS.evolution_bonus + (HS.double_pylon_bonus * 0.5)
 		if(!force_boost_power)
 			boost_power[HS.hivenumber] = boost_power_new
 

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -69,6 +69,9 @@
 	/// If hit limit of larva from pylons
 	var/hit_larva_pylon_limit = FALSE
 
+	/// Bonus from having both pylons held for a time
+	var/double_pylon_bonus = 0
+
 	var/see_humans_on_tacmap = FALSE
 
 	var/list/hive_inherant_traits
@@ -951,7 +954,7 @@
 		var/turf/turf = get_turf(current_human)
 		if(is_ground_level(turf?.z))
 			groundside_humans_weighted_count += GLOB.RoleAuthority.calculate_role_weight(job)
-	hit_larva_pylon_limit = (get_real_total_xeno_count() + stored_larva) > (groundside_humans_weighted_count * ENDGAME_LARVA_CAP_MULTIPLIER)
+	hit_larva_pylon_limit = (get_real_total_xeno_count() + stored_larva) > (groundside_humans_weighted_count * ENDGAME_LARVA_CAP_MULTIPLIER + (0.03 * double_pylon_bonus))
 	hive_ui.update_pylon_status()
 	return hit_larva_pylon_limit
 

--- a/code/modules/mob/living/carbon/xenomorph/hive_status_ui.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status_ui.dm
@@ -125,6 +125,8 @@
 		pylon_status = "The hive's power has surpassed what the pylons can provide."
 	else
 		pylon_status = "Pylons are strengthening our numbers!"
+	if(assoc_hive.get_structure_count(XENO_STRUCTURE_PYLON) >= 2)
+		pylon_status += " Pylon Integration: [assoc_hive.double_pylon_bonus]/[DOUBLE_PYLON_BONUS_MAX]"
 	if(send_update)
 		SStgui.update_uis(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

<!-- . -->

[Do Not Merge]

For TM only until #5893 is complete

---

After both comms have been pyloned for 10 minutes, pylon integration is put in place.

Pylon integration is a linear process with three stages (stage 1 activating after 10 minutes after the second pylon is placed, stage 2 after 7.5, and stage 3 after another 7.5). 

Breaking a single pylon during this time will reset pylon integration back to 0 and the timer for all will reset.
Pylon integration effects (all linear)

**Stage 1:**

+0.5 evilution
90 seconds per non-ovi'd lesser drone generation per pylon (from 120)
+3% to human:xeno pylon larva generation ratio (xenos can get 53%)

**Stage 2:**

+1.0 evilution
60 seconds per non-ovi'd lesser drone generation per pylon (from 120)
+6% to human:xeno pylon larva generation ratio (xenos can get 56%)

**stage 3:**

+1.5 evilution
30 seconds per non-ovi'd lesser drone generation per pylon (from 120)
+9% to human:xeno pylon larva generation ratio (xenos can get 59%)

---

tested and functional

# Explain why it's good for the game

Following #5122 , FOB sieges have been lasting forever even with marines getting stomped outside of FOB and losing both pylons for 20-60 minutes. This has led to rounds for the past few months to be artificially extended for 30 minutes to 2 hours because xenos cant break the FOB siege and marines just have to wait it out until they get enough latejoins/stims/xeno numbers to thin enough for them to push out and win.

The current meta strat is to pull back to FOB asap as soon as minor losses are taken in order to force a siege, losing one or both pylons in the process. This PR sets out to fix this awful FOB siege meta by creating pylon integration, which puts marines on a soft time limit to regain atleast one comms relay (or atleast push to it and break the pylon then retreating) or face progressingly more difficult groundside xenomorphs.

Noone likes the current FOB siege meta and this will hopefully serve as a means to make it less of 'lets sit behind cades for 60 minutes :)' and more of a 'we have to go get the pylon or else we will lose'

This PR is not intended as a permanent fix, but instead a temporary fix to be TM'd until the xeno end game PR becomes a thing because its been a while.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: Adds pylon integration as a xeno endgame bonus for having held both pylons for 10+ minutes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
