### PR TITLE
incendiary minirocket price reduce

### DIFF
--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -410,7 +410,7 @@
 	name = "\improper AGR-59-I 'Mini-Mike'"
 	desc = "The AGR-59-I 'Mini-Mike' incendiary minirocket is a cheap and efficient means of putting hate down range AND setting them on fire! Though rockets lack a guidance package, it makes up for it in ammunition count. Can be loaded into the LAU-229 Rocket Pod."
 	icon_state = "minirocket_inc"
-	point_cost = 500
+	point_cost = 390
 	fire_mission_delay = 3 //high cooldown
 
 /obj/structure/ship_ammo/minirocket/incendiary/detonate_on(turf/impact, obj/structure/dropship_equipment/weapon/fired_from)


### PR DESCRIPTION

# About the pull request

reduces price of incen minirockets to 390 from 500, normal minirockes are 300

# Explain why it's good for the game
gives more variaty to reasonable CAS loudouts. the price increase of 200 (66%) for what is esentialy incendiary granade explosion that barly increases lethality, is a bit overpriced, lowering the price to 390 still keeps it noticably more expensive then normal minirockets (30%)


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: incendiary minirocket price reduced to 390 from 500
/:cl:
