### PR TITLE
Fixes indefinite stasis bug

### DIFF
--- a/code/modules/mob/living/living_verbs.dm
+++ b/code/modules/mob/living/living_verbs.dm
@@ -66,7 +66,7 @@
 		if (BB.opened)
 			return
 		visible_message("[BB] begins to wiggle violently!")
-		if(do_after(src, 5 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE, BB))//5 second unzip from inside
+		if(do_after(src, 5 SECONDS, INTERRUPT_UNCONSCIOUS, BUSY_ICON_HOSTILE, BB))//5 second unzip from inside
 			BB.open()
 
 		///The medical machines below are listed separately to allow easier changes to each process


### PR DESCRIPTION
# About the pull request

Fixes #5960, The knockdown status effect was applying a floored trait to the user on every tick through the handle_stasis_bag proc, and the interrupt_all flags was being passed into the do_after which meant that it wouldn't be possible to execute the action. This is because every time the user clicked the resist verb the interrupt_knocked_down (part of interrupt_all) flag in conjunction with the floored trait would always return false. 

To solve this I instead passed in the interrupt_unconscious flag, meaning the other conditions would allow the user to resist out of the bag, we could instead just apply a Root (immobilize status effect) to the handle_stasis_bag proc and pass in the interrupt_all flag into the do_after as it was before. The only difference being when the user exits the bag they will be standing up instead of lying down, and all other interrupts will cause the action to cancel. (KnockDown applies both a floored and immobilize trait, Root just applies the immobilize trait). Or we can just modify the bitflags and pass in a custom one without the knocked down flag. 

# Changelog

:cl:
fix: fixes users not being able to resist out of the stasis bags
/:cl:

