### PR TITLE
Preferences for a darker crit overlay and a black flash overlay

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -90,6 +90,15 @@
 #define PAIN_OVERLAY_LEGACY 2 //Creates a legacy blurring effect over your screen if you have any eye_blur at all. Not recommended.
 //=================================================
 
+//=================================================
+#define FLASH_OVERLAY_WHITE 0 //Flashes your screen white.
+#define FLASH_OVERLAY_DARK 1 //Flashes your screen a dark grey.
+//=================================================
+
+//=================================================
+#define CRIT_OVERLAY_WHITE 0 //Overlays your screen white.
+#define CRIT_OVERLAY_DARK 1 //Overlays your screen a dark grey.
+//=================================================
 
 /// Number of weighted marine players for 1 gear_scale. gear_scale is clamped to 1 minimum
 #define MARINE_GEAR_SCALING_NORMAL 50

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -108,6 +108,9 @@
 	icon_state = "passage"
 	layer = FULLSCREEN_CRIT_LAYER
 
+/atom/movable/screen/fullscreen/crit/dark
+	color = COLOR_GRAY
+
 /atom/movable/screen/fullscreen/blind
 	icon_state = "blackimageoverlay"
 	layer = FULLSCREEN_BLIND_LAYER
@@ -126,6 +129,9 @@
 	icon = 'icons/mob/hud/screen1.dmi'
 	screen_loc = "WEST,SOUTH to EAST,NORTH"
 	icon_state = "noise"
+
+/atom/movable/screen/fullscreen/flash/dark
+	icon_state = "black"
 
 /atom/movable/screen/fullscreen/high
 	icon = 'icons/mob/hud/screen1.dmi'

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -55,6 +55,8 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 	/client/proc/toggle_admin_sound_types,
 	/client/proc/receive_random_tip,
 	/client/proc/set_eye_blur_type,
+	/client/proc/set_flash_type,
+	/client/proc/set_crit_type,
 ))
 
 /client/proc/reduce_minute_count()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -65,6 +65,8 @@ GLOBAL_LIST_INIT(bgstate_options, list(
 	var/chat_display_preferences = CHAT_TYPE_ALL
 	var/item_animation_pref_level = SHOW_ITEM_ANIMATIONS_ALL
 	var/pain_overlay_pref_level = PAIN_OVERLAY_BLURRY
+	var/flash_overlay_pref = FLASH_OVERLAY_WHITE
+	var/crit_overlay_pref = CRIT_OVERLAY_WHITE
 	var/UI_style_color = "#ffffff"
 	var/UI_style_alpha = 255
 	var/View_MC = FALSE
@@ -593,6 +595,8 @@ GLOBAL_LIST_INIT(bgstate_options, list(
 			dat += "<b>Play Announcement Sounds As Ghost:</b> <a href='?_src_=prefs;preference=hear_observer_announcements'><b>[(toggles_sound & SOUND_OBSERVER_ANNOUNCEMENTS) ? "Yes" : "No"]</b></a><br>"
 			dat += "<b>Toggle Meme or Atmospheric Sounds:</b> <a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_admin_sound_types'>Toggle</a><br>"
 			dat += "<b>Set Eye Blur Type:</b> <a href='?src=\ref[src];action=proccall;procpath=/client/proc/set_eye_blur_type'>Set</a><br>"
+			dat += "<b>Set Flash Type:</b> <a href='?src=\ref[src];action=proccall;procpath=/client/proc/set_flash_type'>Set</a><br>"
+			dat += "<b>Set Crit Type:</b> <a href='?src=\ref[src];action=proccall;procpath=/client/proc/set_crit_type'>Set</a><br>"
 			dat += "<b>Play Lobby Music:</b> <a href='?_src_=prefs;preference=lobby_music'><b>[(toggles_sound & SOUND_LOBBY) ? "Yes" : "No"]</b></a><br>"
 			dat += "<b>Play VOX Announcements:</b> <a href='?_src_=prefs;preference=sound_vox'><b>[(hear_vox) ? "Yes" : "No"]</b></a><br>"
 			dat += "<b>Default Ghost Night Vision Level:</b> <a href='?_src_=prefs;preference=ghost_vision_pref;task=input'><b>[ghost_vision_pref]</b></a><br>"

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -150,6 +150,8 @@
 	S["UI_style_alpha"] >> UI_style_alpha
 	S["item_animation_pref_level"] >> item_animation_pref_level
 	S["pain_overlay_pref_level"] >> pain_overlay_pref_level
+	S["flash_overlay_pref"] >> flash_overlay_pref
+	S["crit_overlay_pref"] >> crit_overlay_pref
 	S["stylesheet"] >> stylesheet
 	S["window_skin"] >> window_skin
 	S["fps"] >> fps
@@ -233,6 +235,8 @@
 	UI_style_alpha = sanitize_integer(UI_style_alpha, 0, 255, initial(UI_style_alpha))
 	item_animation_pref_level = sanitize_integer(item_animation_pref_level, SHOW_ITEM_ANIMATIONS_NONE, SHOW_ITEM_ANIMATIONS_ALL, SHOW_ITEM_ANIMATIONS_ALL)
 	pain_overlay_pref_level = sanitize_integer(pain_overlay_pref_level, PAIN_OVERLAY_BLURRY, PAIN_OVERLAY_LEGACY, PAIN_OVERLAY_BLURRY)
+	flash_overlay_pref = sanitize_integer(flash_overlay_pref, FLASH_OVERLAY_WHITE, FLASH_OVERLAY_DARK)
+	crit_overlay_pref = sanitize_integer(crit_overlay_pref, CRIT_OVERLAY_WHITE, CRIT_OVERLAY_DARK)
 	window_skin = sanitize_integer(window_skin, 0, SHORT_REAL_LIMIT, initial(window_skin))
 	ghost_vision_pref = sanitize_inlist(ghost_vision_pref, list(GHOST_VISION_LEVEL_NO_NVG, GHOST_VISION_LEVEL_MID_NVG, GHOST_VISION_LEVEL_FULL_NVG), GHOST_VISION_LEVEL_MID_NVG)
 	ghost_orbit = sanitize_inlist(ghost_orbit, GLOB.ghost_orbits, initial(ghost_orbit))
@@ -327,6 +331,8 @@
 	S["tgui_say"] << tgui_say
 	S["item_animation_pref_level"] << item_animation_pref_level
 	S["pain_overlay_pref_level"] << pain_overlay_pref_level
+	S["flash_overlay_pref"] << flash_overlay_pref
+	S["crit_overlay_pref"] << crit_overlay_pref
 	S["stylesheet"] << stylesheet
 	S["be_special"] << be_special
 	S["default_slot"] << default_slot

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -471,7 +471,7 @@
 	if(result == "White")
 		prefs.flash_overlay_pref = FLASH_OVERLAY_WHITE
 		to_chat(src, SPAN_NOTICE("If flashed your vision will now be white."))
-	if(result == "Dark")
+	else if(result == "Dark")
 		prefs.flash_overlay_pref = FLASH_OVERLAY_DARK
 		to_chat(src, SPAN_NOTICE("If flashed your vision will now be dark."))
 	prefs.save_preferences()
@@ -481,7 +481,7 @@
 	if(result == "White")
 		prefs.crit_overlay_pref = CRIT_OVERLAY_WHITE
 		to_chat(src, SPAN_NOTICE("If in critical condition your vision will now be white."))
-	if(result == "Dark")
+	else if(result == "Dark")
 		prefs.crit_overlay_pref = CRIT_OVERLAY_DARK
 		to_chat(src, SPAN_NOTICE("If in critical condition your vision will now be dark."))
 	prefs.save_preferences()

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -453,6 +453,7 @@
 	else
 		CRASH("receive_random_tip() failed: null message")
 
+/// Toggle in character preferences and toggle preferences to configure what kind of blur overlay is used in game; Either blurry, impaired, or legacy.
 /client/proc/set_eye_blur_type()
 	var/result = tgui_alert(src, "What type of eye blur do you want?", "What type of eye blur do you want?", list("Blurry", "Impair", "Legacy"))
 	if(result == "Blurry")
@@ -466,6 +467,7 @@
 		to_chat(src, SPAN_NOTICE("Your vision will now have a legacy blurring effect. This is not recommended!"))
 	prefs.save_preferences()
 
+/// Toggle in character preferences and toggle preferences to configure what kind of flash overlay is used in game; Either white or black.
 /client/proc/set_flash_type()
 	var/result = tgui_alert(src, "What type of flash overlay do you want?", "What type of flash overlay do you want?", list("White", "Dark"))
 	if(result == "White")
@@ -476,6 +478,7 @@
 		to_chat(src, SPAN_NOTICE("If flashed your vision will now be dark."))
 	prefs.save_preferences()
 
+/// Toggle in character preferences and toggle preferences to configure what kind of crit overlay is used in game; Either white or grey.
 /client/proc/set_crit_type()
 	var/result = tgui_alert(src, "What type of crit overlay do you want?", "What type of crit overlay do you want?", list("White", "Dark"))
 	if(result == "White")

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -275,6 +275,8 @@
 		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/switch_item_animations'>Toggle Item Animations</a><br>",
 		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_admin_sound_types'>Toggle Admin Sound Types</a><br>",
 		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/set_eye_blur_type'>Set Eye Blur Type</a><br>",
+		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/set_flash_type'>Set Flash Type</a><br>",
+		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/set_crit_type'>Set Crit Type</a><br>",
 	)
 
 	var/dat = ""
@@ -462,6 +464,26 @@
 	if(result == "Legacy")
 		prefs.pain_overlay_pref_level = PAIN_OVERLAY_LEGACY
 		to_chat(src, SPAN_NOTICE("Your vision will now have a legacy blurring effect. This is not recommended!"))
+	prefs.save_preferences()
+
+/client/proc/set_flash_type()
+	var/result = tgui_alert(src, "What type of flash overlay do you want?", "What type of flash overlay do you want?", list("White", "Dark"))
+	if(result == "White")
+		prefs.flash_overlay_pref = FLASH_OVERLAY_WHITE
+		to_chat(src, SPAN_NOTICE("If flashed your vision will now be white."))
+	if(result == "Dark")
+		prefs.flash_overlay_pref = FLASH_OVERLAY_DARK
+		to_chat(src, SPAN_NOTICE("If flashed your vision will now be dark."))
+	prefs.save_preferences()
+
+/client/proc/set_crit_type()
+	var/result = tgui_alert(src, "What type of crit overlay do you want?", "What type of crit overlay do you want?", list("White", "Dark"))
+	if(result == "White")
+		prefs.crit_overlay_pref = CRIT_OVERLAY_WHITE
+		to_chat(src, SPAN_NOTICE("If in critical condition your vision will now be white."))
+	if(result == "Dark")
+		prefs.crit_overlay_pref = CRIT_OVERLAY_DARK
+		to_chat(src, SPAN_NOTICE("If in critical condition your vision will now be dark."))
 	prefs.save_preferences()
 
 /client/verb/toggle_tgui_say()

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -20,7 +20,10 @@
 				if(-90 to -80) severity = 8
 				if(-95 to -90) severity = 9
 				if(-INFINITY to -95) severity = 10
-			overlay_fullscreen("crit", /atom/movable/screen/fullscreen/crit, severity)
+			if(client.prefs?.crit_overlay_pref == CRIT_OVERLAY_DARK)
+				overlay_fullscreen("crit", /atom/movable/screen/fullscreen/crit/dark, severity)
+			else
+				overlay_fullscreen("crit", /atom/movable/screen/fullscreen/crit, severity)
 		else
 			clear_fullscreen("crit")
 			if(oxyloss)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -446,8 +446,11 @@
 	return
 
 /mob/living/flash_eyes(intensity = EYE_PROTECTION_FLASH, bypass_checks, type = /atom/movable/screen/fullscreen/flash, flash_timer = 40)
-	if( bypass_checks || (get_eye_protection() < intensity && !(sdisabilities & DISABILITY_BLIND)))
-		overlay_fullscreen("flash", type)
+	if(bypass_checks || (get_eye_protection() < intensity && !(sdisabilities & DISABILITY_BLIND)))
+		if(client?.prefs?.flash_overlay_pref == FLASH_OVERLAY_DARK)
+			overlay_fullscreen("flash", /atom/movable/screen/fullscreen/flash/dark)
+		else
+			overlay_fullscreen("flash", type)
 		spawn(flash_timer)
 			clear_fullscreen("flash", 20)
 		return TRUE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -445,10 +445,10 @@
 /mob/proc/flash_eyes()
 	return
 
-/mob/living/flash_eyes(intensity = EYE_PROTECTION_FLASH, bypass_checks, type = /atom/movable/screen/fullscreen/flash, flash_timer = 40)
+/mob/living/flash_eyes(intensity = EYE_PROTECTION_FLASH, bypass_checks, flash_timer = 40, type = /atom/movable/screen/fullscreen/flash, dark_type = /atom/movable/screen/fullscreen/flash/dark)
 	if(bypass_checks || (get_eye_protection() < intensity && !(sdisabilities & DISABILITY_BLIND)))
 		if(client?.prefs?.flash_overlay_pref == FLASH_OVERLAY_DARK)
-			overlay_fullscreen("flash", /atom/movable/screen/fullscreen/flash/dark)
+			overlay_fullscreen("flash", dark_type)
 		else
 			overlay_fullscreen("flash", type)
 		spawn(flash_timer)


### PR DESCRIPTION

# About the pull request

Now these overlays have less of a shock factor for accessibility. The reasoning for also a preference for crit is because when being revived you might still be deep in crit which can also be a flashbang. These could be combined into one preference, but I feel it didn't hurt to keep them separate so they're more obvious what they affect.

- For dark crit preference, it is the original overlay but colored gray so lessen its brightness.
- For dark flash preference, the screen will turn black instead of white.

See photographs below.

# Explain why it's good for the game
It was requested that there be a preference to lessen the flash effect for people that are photosensitive.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/6bec8f49-4153-4312-a149-416364982d88)

![normal](https://github.com/cmss13-devs/cmss13/assets/76988376/cad1339c-9e6f-45fb-9b73-89cac3d41686)
![dark](https://github.com/cmss13-devs/cmss13/assets/76988376/ed968a81-cbe0-4f1e-ad50-7a26735b5d7d)

![flash_normal](https://github.com/cmss13-devs/cmss13/assets/76988376/cfdfb6de-e251-4d8a-81a7-ae164c26fa18)
![flash_dark](https://github.com/cmss13-devs/cmss13/assets/76988376/fd22dc72-68b9-47dd-a6f1-4fcb249a669d)

</details>


# Changelog
:cl: Drathek
add: Added preference for a darker crit overlay and black flash overlay
/:cl:
