### PR TITLE
Fixes zombies missing claws on transformation

### DIFF
--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -141,8 +141,6 @@
 
 /datum/disease/black_goo/proc/zombie_transform(mob/living/carbon/human/human)
 	set waitfor = 0
-	if(human.buckled)
-		human.buckled.unbuckle()
 	zombie_is_transforming = TRUE
 	human.vomit_on_floor()
 	human.adjust_effect(5, STUN)
@@ -150,6 +148,8 @@
 	human.make_jittery(500)
 	sleep(30)
 	if(human && human.loc)
+		if(human.buckled)
+			human.buckled.unbuckle()
 		if(human.stat == DEAD)
 			human.revive(TRUE)
 			human.remove_language(LANGUAGE_ENGLISH) // You lose the ability to understand english. Language processing is handled in the mind not the body.

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -141,7 +141,7 @@
 
 /datum/disease/black_goo/proc/zombie_transform(mob/living/carbon/human/human)
 	set waitfor = 0
-	if(human.buckled):
+	if(human.buckled)
 		human.buckled.unbuckle()
 	zombie_is_transforming = TRUE
 	human.vomit_on_floor()

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -141,6 +141,8 @@
 
 /datum/disease/black_goo/proc/zombie_transform(mob/living/carbon/human/human)
 	set waitfor = 0
+	if(human.buckled):
+		human.buckled.unbuckle()
 	zombie_is_transforming = TRUE
 	human.vomit_on_floor()
 	human.adjust_effect(5, STUN)


### PR DESCRIPTION
# About the pull request
Fixes #5485, added a simple conditional to check if a mob is buckled and then unbuckle them before transformation. I didn't look into the root of the problem but this bug seems niche enough that it shouldn't really effect anything else. If I were to guess, I'm assuming it has to do with the fact that you can't hold items in your hands while buckled to a bed, but you can while you're in a chair. Hence why everything works fine while buckled to a chair.  

# Changelog
:cl:
fix: Fixes zombies missing claws on transformation
/:cl:
