### PR TITLE
Makes Kutjevo caves OBable, fixes northeast/southeast caves being switched up, changes awful path names

### DIFF
--- a/code/game/area/kutjevo.dm
+++ b/code/game/area/kutjevo.dm
@@ -267,26 +267,25 @@
 
 /area/kutjevo/interior/colony_north
 	name = "Kutjevo - North Colony Caves"
-	ceiling = CEILING_DEEP_UNDERGROUND
+	ceiling = CEILING_UNDERGROUND_BLOCK_CAS
 	icon_state = "colony_caves_1"
 
-/area/kutjevo/interior/colony_S_East
-	name = "Kutjevo - North East Colony Caves"
-	ceiling = CEILING_DEEP_UNDERGROUND
+/area/kutjevo/interior/colony_southeast
+	name = "Kutjevo - Southeast Colony Caves"
+	ceiling = CEILING_UNDERGROUND_BLOCK_CAS
 	icon_state = "colony_caves_2"
 
-/area/kutjevo/interior/colony_N_East
-	name = "Kutjevo - South East Colony Caves"
-	ceiling = CEILING_DEEP_UNDERGROUND
+/area/kutjevo/interior/colony_northeast
+	name = "Kutjevo - Northeast Colony Caves"
+	ceiling = CEILING_UNDERGROUND_BLOCK_CAS
 	icon_state = "colony_caves_2"
 
-/area/kutjevo/interior/colony_South
+/area/kutjevo/interior/colony_south
 	name = "Kutjevo - South Colony Caves"
-	ceiling = CEILING_DEEP_UNDERGROUND
+	ceiling = CEILING_UNDERGROUND_BLOCK_CAS
 	icon_state = "colony_caves_3"
 
-/area/kutjevo/interior/colony_South/power2
+/area/kutjevo/interior/colony_south/power2
 	name = "Kutjevo - South Colony Treatment Plant"
-	ceiling = CEILING_DEEP_UNDERGROUND
 	icon_state = "colony_caves_3"
 	minimap_color = MINIMAP_AREA_ENGI_CAVE

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -19,7 +19,7 @@
 /area/kutjevo/exterior/lz_dunes)
 "aaY" = (
 /turf/open/floor/kutjevo/plate,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "abz" = (
 /obj/structure/stairs/perspective/kutjevo{
 	icon_state = "p_stair_full"
@@ -52,7 +52,7 @@
 	dir = 4
 	},
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "acN" = (
 /obj/structure/blocker/invisible_wall,
 /turf/open/gm/river/desert/shallow_edge{
@@ -65,7 +65,7 @@
 "adG" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "adX" = (
 /obj/item/stack/sheet/wood,
 /obj/structure/machinery/light,
@@ -197,7 +197,7 @@
 	dir = 1
 	},
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "aor" = (
 /turf/open/floor/kutjevo/colors/orange/edge{
 	dir = 5
@@ -211,7 +211,7 @@
 	icon_state = "kutjevo_platform_sm_stair_alt"
 	},
 /turf/open/floor/kutjevo/tan/multi_tiles,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "apr" = (
 /obj/structure/bed/chair,
 /turf/open/auto_turf/sand/layer1,
@@ -314,7 +314,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "atC" = (
 /obj/item/stack/rods,
 /turf/open/floor/kutjevo/colors/purple/edge{
@@ -324,11 +324,11 @@
 "atQ" = (
 /obj/item/tank/emergency_oxygen/engi,
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "auj" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer/research/containment/floor2,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "aul" = (
 /obj/structure/platform/kutjevo{
 	dir = 8
@@ -482,7 +482,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 4
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "aFf" = (
 /obj/item/tool/wirecutters/clippers,
 /turf/open/floor/kutjevo/colors/green,
@@ -565,7 +565,7 @@
 "aKg" = (
 /obj/structure/tunnel,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "aKl" = (
 /obj/structure/machinery/landinglight/ds1{
 	dir = 1
@@ -637,7 +637,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 8
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "aRS" = (
 /obj/structure/bed{
 	can_buckle = 0;
@@ -723,7 +723,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "bbc" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/structure/machinery/computer/shuttle/dropship/flight/lz1,
@@ -790,7 +790,7 @@
 	dir = 4
 	},
 /turf/open/floor/kutjevo/tan/multi_tiles,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "bex" = (
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 4
@@ -941,7 +941,7 @@
 /area/kutjevo/interior/power/comms)
 "bpj" = (
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "bpT" = (
 /obj/structure/stairs/perspective/kutjevo{
 	dir = 8;
@@ -971,7 +971,7 @@
 /area/kutjevo/exterior/runoff_river)
 "bsl" = (
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "bsm" = (
 /obj/structure/surface/rack,
 /turf/open/floor/kutjevo/tan,
@@ -988,7 +988,7 @@
 	dir = 8
 	},
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "bsP" = (
 /obj/item/device/flash,
 /turf/open/floor/kutjevo/tan,
@@ -1051,10 +1051,10 @@
 "byx" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "byH" = (
 /turf/closed/wall/kutjevo/colony/reinforced/hull,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "bzj" = (
 /obj/structure/machinery/space_heater,
 /turf/open/floor/plating/kutjevo,
@@ -1099,7 +1099,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "bDl" = (
 /obj/structure/surface/table/almayer,
 /obj/item/clipboard,
@@ -1119,7 +1119,7 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_nest,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "bDW" = (
 /obj/structure/blocker/invisible_wall,
 /turf/open/desert/desert_shore/shore_corner2{
@@ -1221,7 +1221,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "bJc" = (
 /obj/structure/platform/kutjevo{
 	dir = 1
@@ -1306,7 +1306,7 @@
 "bOc" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "bPf" = (
 /obj/structure/platform_decoration/kutjevo,
 /obj/effect/landmark/survivor_spawner,
@@ -1478,7 +1478,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "cbz" = (
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/colony_north)
@@ -1642,7 +1642,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/kutjevo/tan/multi_tiles,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "cpj" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med/limited{
 	pixel_x = -28
@@ -1735,7 +1735,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "cum" = (
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/kutjevo/colony/reinforced/hull,
@@ -1902,7 +1902,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "cFY" = (
 /obj/item/stool,
 /obj/item/frame/firstaid_arm_assembly,
@@ -2021,7 +2021,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "cMJ" = (
 /obj/structure/platform/kutjevo{
 	dir = 4
@@ -2073,7 +2073,7 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /obj/effect/landmark/xeno_spawn,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "cQt" = (
 /obj/structure/platform/kutjevo/smooth{
 	dir = 4
@@ -2125,7 +2125,7 @@
 /obj/effect/landmark/xeno_hive_spawn,
 /obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "cTj" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
@@ -2170,7 +2170,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "cUm" = (
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction)
@@ -2297,7 +2297,7 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "dck" = (
 /obj/effect/landmark/objective_landmark/medium,
 /turf/open/floor/kutjevo/colors,
@@ -2445,7 +2445,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "dnd" = (
 /turf/open/gm/river/desert/shallow_edge{
 	dir = 8
@@ -2520,7 +2520,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "dqK" = (
 /obj/structure/flora/grass/desert/lightgrass_1,
 /obj/structure/blocker/invisible_wall,
@@ -2541,7 +2541,7 @@
 	dir = 5
 	},
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "dsP" = (
 /obj/structure/lattice,
 /obj/structure/machinery/light/small{
@@ -2580,11 +2580,11 @@
 	name = "\improper South Power Shutters"
 	},
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "duw" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "duP" = (
 /obj/structure/girder,
 /turf/open/floor/plating/kutjevo,
@@ -2779,7 +2779,7 @@
 	dir = 4
 	},
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "dGi" = (
 /obj/structure/flora/grass/tallgrass/desert/corner{
 	dir = 1
@@ -3013,7 +3013,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 4
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "dUE" = (
 /obj/structure/flora/grass/desert/lightgrass_10,
 /turf/open/auto_turf/sand/layer0,
@@ -3022,7 +3022,7 @@
 /obj/structure/platform/kutjevo/smooth,
 /obj/structure/largecrate/random,
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "dUQ" = (
 /obj/item/stack/sandbags/large_stack,
 /turf/open/auto_turf/sand/layer1,
@@ -3050,7 +3050,7 @@
 "dWU" = (
 /obj/effect/landmark/queen_spawn,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "dXC" = (
 /obj/structure/stairs/perspective/kutjevo{
 	dir = 1;
@@ -3086,7 +3086,7 @@
 	dir = 1
 	},
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "eaR" = (
 /obj/structure/platform/kutjevo{
 	dir = 1
@@ -3100,7 +3100,7 @@
 "eaT" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "ebv" = (
 /turf/open/desert/desert_shore/shore_corner2{
 	dir = 8
@@ -3108,7 +3108,7 @@
 /area/kutjevo/exterior/spring)
 "ebB" = (
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "ebP" = (
 /obj/structure/platform/kutjevo/rock{
 	dir = 1
@@ -3170,7 +3170,7 @@
 /turf/open/floor/kutjevo/tan/multi_tiles{
 	dir = 6
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "efF" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -3184,7 +3184,7 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "efW" = (
 /obj/structure/surface/table/almayer,
 /obj/item/spacecash/c200,
@@ -3197,7 +3197,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 4
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "egu" = (
 /obj/structure/platform/kutjevo/smooth{
 	dir = 8
@@ -3252,7 +3252,7 @@
 "ehJ" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "eiz" = (
 /obj/structure/machinery/cm_vending/sorted/boozeomat,
 /obj/structure/machinery/light{
@@ -3301,7 +3301,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "ele" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/kutjevo/tan/multi_tiles,
@@ -3333,7 +3333,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 6
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "enK" = (
 /obj/structure/window{
 	dir = 1
@@ -3356,7 +3356,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "eoA" = (
 /obj/structure/machinery/chem_dispenser/medbay,
 /turf/open/floor/kutjevo/colors/red/tile,
@@ -3369,7 +3369,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 4
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "epd" = (
 /obj/item/reagent_container/food/drinks/cans/thirteenloko,
 /turf/open/auto_turf/sand/layer1,
@@ -3468,7 +3468,7 @@
 "eud" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "euj" = (
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/construction)
@@ -3487,10 +3487,10 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "evr" = (
 /turf/open/floor/kutjevo/colors,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "evZ" = (
 /turf/open/floor/almayer/research/containment/floor2,
 /area/kutjevo/interior/power)
@@ -3516,7 +3516,7 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_nest,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "exj" = (
 /obj/structure/flora/bush/ausbushes/reedbush,
 /obj/structure/flora/bush/ausbushes/reedbush{
@@ -3656,7 +3656,7 @@
 	dir = 8
 	},
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "eFy" = (
 /turf/open/desert/desert_shore/desert_shore1{
 	dir = 1
@@ -3666,13 +3666,13 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "eFZ" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 4
 	},
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "eGa" = (
 /obj/structure/surface/rack,
 /obj/structure/machinery/light{
@@ -3718,7 +3718,7 @@
 "eJo" = (
 /obj/effect/landmark/corpsespawner/security/marshal,
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "eKr" = (
 /obj/structure/blocker/invisible_wall,
 /turf/open/gm/river{
@@ -3782,11 +3782,11 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "eOy" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "eOD" = (
 /obj/item/weapon/gun/rifle/m16,
 /obj/structure/machinery/light{
@@ -3855,7 +3855,7 @@
 	pixel_y = 13
 	},
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "eRE" = (
 /obj/structure/machinery/colony_floodlight{
 	pixel_y = 10
@@ -3936,7 +3936,7 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "eVO" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/structure/barricade/handrail/kutjevo{
@@ -3946,7 +3946,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 4
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "eVR" = (
 /turf/open/gm/river/desert/deep,
 /area/kutjevo/exterior/spring)
@@ -4016,7 +4016,7 @@
 	},
 /obj/structure/platform_decoration/kutjevo,
 /turf/open/floor/kutjevo/tan/multi_tiles,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "fdr" = (
 /obj/structure/platform/kutjevo/smooth{
 	dir = 4
@@ -4024,7 +4024,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "fdF" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 8
@@ -4144,7 +4144,7 @@
 	dir = 1
 	},
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "fjF" = (
 /obj/structure/platform_decoration/kutjevo/rock{
 	dir = 4
@@ -4173,7 +4173,7 @@
 "fll" = (
 /obj/structure/platform/kutjevo/rock,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "flp" = (
 /obj/effect/landmark/objective_landmark/science,
 /turf/open/floor/kutjevo/tan/multi_tiles{
@@ -4223,7 +4223,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 4
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "foI" = (
 /obj/structure/barricade/wooden{
 	dir = 1;
@@ -4259,7 +4259,7 @@
 /obj/structure/largecrate/random,
 /obj/item/toy/deck,
 /turf/open/floor/kutjevo/tan/multi_tiles,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "fqA" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -4386,7 +4386,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 4
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "fEu" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/cameras,
@@ -4423,7 +4423,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 8
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "fGk" = (
 /obj/item/clipboard,
 /turf/open/floor/kutjevo/tan,
@@ -4493,7 +4493,7 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "fLE" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 8
@@ -4565,7 +4565,7 @@
 	dir = 9
 	},
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "fQx" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/colony_north)
@@ -4635,7 +4635,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 4
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "fTR" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/item/reagent_container/glass/watertank,
@@ -4679,7 +4679,7 @@
 "fWL" = (
 /obj/structure/prop/dam/gravestone,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "fYr" = (
 /obj/structure/barricade/wooden{
 	desc = "This barricade is heavily reinforced. Nothing short of blasting it open seems like it'll do the trick, that or melting the breams supporting it...";
@@ -4728,7 +4728,7 @@
 "gce" = (
 /obj/item/device/radio,
 /turf/open/floor/kutjevo/tan/multi_tiles,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "gcl" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/kutjevo/multi_tiles,
@@ -4755,7 +4755,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "gdX" = (
 /obj/structure/surface/table/almayer,
 /obj/item/paper_bin{
@@ -4848,7 +4848,7 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "gmA" = (
 /obj/item/stack/sheet/wood,
 /turf/open/floor/kutjevo/tan,
@@ -4950,7 +4950,7 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/auto_turf/sand/layer2,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "gtE" = (
 /obj/structure/blocker/invisible_wall,
 /obj/structure/platform/kutjevo,
@@ -5095,7 +5095,7 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "gBV" = (
 /obj/structure/flora/grass/desert/lightgrass_2,
 /turf/open/auto_turf/sand/layer1,
@@ -5116,7 +5116,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 6
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "gCt" = (
 /obj/structure/morgue{
 	dir = 8
@@ -5166,7 +5166,7 @@
 "gFf" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "gFo" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/kutjevo/tan/alt_edge{
@@ -5194,7 +5194,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "gHp" = (
 /obj/structure/surface/rack,
 /obj/item/tank/emergency_oxygen/engi,
@@ -5262,7 +5262,7 @@
 	dir = 8
 	},
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "gNI" = (
 /turf/open/floor/kutjevo/colors/cyan/inner_corner{
 	dir = 4
@@ -5300,7 +5300,7 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "gQF" = (
 /obj/structure/surface/table/almayer,
 /obj/item/ammo_magazine/shotgun/buckshot,
@@ -5538,7 +5538,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "hiM" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_core,
 /turf/open/auto_turf/sand/layer1,
@@ -5672,7 +5672,7 @@
 	},
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "htP" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -5693,7 +5693,7 @@
 "huV" = (
 /obj/effect/landmark/queen_spawn,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "hvq" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/flashlight/lamp/green,
@@ -5724,7 +5724,7 @@
 	dir = 1
 	},
 /turf/open/floor/almayer/research/containment/floor2,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "hxd" = (
 /obj/item/stack/sheet/wood,
 /turf/open/auto_turf/sand/layer1,
@@ -5767,7 +5767,7 @@
 	name = "\improper North Power Shutters"
 	},
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "hBD" = (
 /obj/item/trash/cheesie,
 /turf/open/auto_turf/sand/layer1,
@@ -5885,7 +5885,7 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "hGP" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/floor/kutjevo/plate,
@@ -5972,7 +5972,7 @@
 "hPD" = (
 /obj/item/storage/toolbox/syndicate,
 /turf/open/floor/kutjevo/tan/multi_tiles,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "hQj" = (
 /turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/interior/power)
@@ -6166,7 +6166,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 8
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "ige" = (
 /obj/structure/blocker/invisible_wall,
 /obj/structure/surface/table/reinforced/prison,
@@ -6199,7 +6199,7 @@
 /obj/structure/platform/kutjevo/smooth,
 /obj/structure/barricade/handrail/kutjevo,
 /turf/open/floor/kutjevo/tan/multi_tiles,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "iiN" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/kutjevo,
@@ -6315,7 +6315,7 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "iwV" = (
 /turf/open/floor/kutjevo/tan/multi_tiles{
 	dir = 1
@@ -6557,7 +6557,7 @@
 	icon_state = "p_stair_full"
 	},
 /turf/open/floor/kutjevo/tan/multi_tiles,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "iSn" = (
 /obj/structure/largecrate/random/secure,
 /obj/structure/machinery/light{
@@ -6600,7 +6600,7 @@
 /obj/effect/landmark/xeno_spawn,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "iUr" = (
 /obj/effect/landmark/objective_landmark/far,
 /turf/open/floor/kutjevo/colors/orange,
@@ -6632,7 +6632,7 @@
 	icon_state = "gravestone3"
 	},
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "iWH" = (
 /obj/effect/decal/cleanable/blood/xeno{
 	icon_state = "xgib1"
@@ -6649,7 +6649,7 @@
 	icon_state = "p_stair_full"
 	},
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "iXh" = (
 /obj/structure/surface/table/almayer,
 /turf/open/floor/kutjevo/tan,
@@ -6759,7 +6759,7 @@
 	dir = 1
 	},
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "jfs" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/kutjevo/tan,
@@ -6837,7 +6837,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 4
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "jkJ" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/item/reagent_container/glass/watertank,
@@ -6915,7 +6915,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "jos" = (
 /obj/structure/stairs/perspective/kutjevo{
 	icon_state = "p_stair_full"
@@ -6992,7 +6992,7 @@
 "jtl" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "jtu" = (
 /obj/item/ammo_magazine/revolver/cmb,
 /turf/open/floor/kutjevo/colors/orange,
@@ -7094,7 +7094,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "jxS" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -7249,7 +7249,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "jKc" = (
 /obj/structure/platform/kutjevo/smooth,
 /turf/open/asphalt/cement_sunbleached,
@@ -7261,7 +7261,7 @@
 /area/kutjevo/interior/colony_central)
 "jKI" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "jKN" = (
 /turf/open/floor/kutjevo/tan/multi_tiles,
 /area/kutjevo/interior/complex/botany/east_tech)
@@ -7270,7 +7270,7 @@
 	icon_state = "1-4-8"
 	},
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "jOx" = (
 /turf/open/gm/river/desert/shallow_edge{
 	dir = 1
@@ -7324,7 +7324,7 @@
 "jQo" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "jRd" = (
 /obj/effect/landmark/hunter_secondary,
 /turf/open/auto_turf/sand/layer1,
@@ -7374,7 +7374,7 @@
 /area/kutjevo/exterior/lz_river)
 "jYS" = (
 /turf/open/auto_turf/sand/layer2,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "jZT" = (
 /turf/open/floor/kutjevo/colors/cyan/edge{
 	dir = 8
@@ -7550,7 +7550,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "klN" = (
 /obj/structure/stairs/perspective/kutjevo{
 	icon_state = "p_stair_sn_full_cap"
@@ -7619,7 +7619,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "kqt" = (
 /obj/structure/stairs/perspective/kutjevo{
 	dir = 4;
@@ -7743,7 +7743,7 @@
 /area/kutjevo/exterior/lz_dunes)
 "kwy" = (
 /turf/closed/wall/kutjevo/colony/reinforced/hull,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "kwJ" = (
 /obj/item/clothing/suit/armor/vest/security,
 /turf/open/floor/kutjevo/colors/cyan/tile,
@@ -7779,7 +7779,7 @@
 /obj/structure/surface/table/woodentable,
 /obj/item/reagent_container/food/drinks/bottle/sake,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "kzZ" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 8
@@ -7900,7 +7900,7 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "kGM" = (
 /turf/open/floor/kutjevo/tan/grey_edge{
 	dir = 1
@@ -8046,7 +8046,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "kQa" = (
 /obj/structure/bed/bedroll,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -8154,7 +8154,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "kYs" = (
 /obj/structure/window/framed/kutjevo/reinforced/hull,
 /turf/open/floor/plating/kutjevo,
@@ -8175,7 +8175,7 @@
 /area/kutjevo/interior/complex/botany)
 "kZz" = (
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "kZV" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/asphalt/cement_sunbleached,
@@ -8183,7 +8183,7 @@
 "kZW" = (
 /obj/structure/prop/dam/torii,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "lac" = (
 /obj/item/ammo_magazine/rifle/mar40,
 /turf/open/floor/kutjevo/multi_tiles{
@@ -8286,7 +8286,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "lhu" = (
 /obj/structure/platform/kutjevo/smooth{
 	dir = 4
@@ -8295,7 +8295,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "lhY" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -8309,7 +8309,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 4
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "lkC" = (
 /turf/open/floor/kutjevo/tan/multi_tiles,
 /area/kutjevo/interior/complex/med/auto_doc)
@@ -8438,7 +8438,7 @@
 "ltv" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "ltU" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/kutjevo/tiles,
@@ -8508,7 +8508,7 @@
 	dir = 1
 	},
 /turf/open/floor/kutjevo/tan/multi_tiles,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "lyJ" = (
 /turf/open/floor/coagulation{
 	icon_state = "0,5"
@@ -8605,7 +8605,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "lFt" = (
 /obj/structure/blocker/invisible_wall,
 /obj/item/device/radio,
@@ -8837,7 +8837,7 @@
 "lXQ" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/auto_turf/sand/layer2,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "lYI" = (
 /obj/structure/blocker/invisible_wall,
 /turf/open/gm/river/desert/shallow_corner{
@@ -9014,7 +9014,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 6
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "mhj" = (
 /obj/structure/platform/kutjevo/rock{
 	dir = 1
@@ -9043,7 +9043,7 @@
 "mjd" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "mjg" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/exterior/telecomm/lz2_north)
@@ -9092,7 +9092,7 @@
 "mmH" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "mnk" = (
 /turf/open/desert/desert_shore/shore_edge1{
 	dir = 8
@@ -9117,7 +9117,7 @@
 "mpe" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_core,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "mpW" = (
 /turf/open/floor/almayer/research/containment/floor1,
 /area/kutjevo/exterior/complex_border/med_rec)
@@ -9203,7 +9203,7 @@
 	dir = 8
 	},
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "mvM" = (
 /obj/structure/closet/emcloset,
 /obj/effect/landmark/objective_landmark/medium,
@@ -9286,7 +9286,7 @@
 "mAK" = (
 /obj/structure/bed/chair,
 /turf/open/floor/kutjevo/tan/multi_tiles,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "mBD" = (
 /turf/closed/wall/kutjevo/colony,
 /area/kutjevo/exterior/stonyfields)
@@ -9295,11 +9295,11 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "mBP" = (
 /obj/structure/prop/dam/large_boulder/boulder2,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "mCd" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/kutjevo/tan/multi_tiles,
@@ -9367,7 +9367,7 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "mDH" = (
 /obj/structure/flora/bush/ausbushes/reedbush,
 /obj/structure/platform/kutjevo/smooth{
@@ -9401,7 +9401,7 @@
 "mEe" = (
 /obj/item/stack/cable_coil/random,
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "mFd" = (
 /obj/structure/platform/kutjevo{
 	dir = 4
@@ -9525,7 +9525,7 @@
 /area/kutjevo/exterior/Northwest_Colony)
 "mLw" = (
 /turf/open/floor/kutjevo/tan/multi_tiles,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "mLK" = (
 /obj/structure/bed/roller,
 /obj/structure/machinery/light{
@@ -9550,10 +9550,10 @@
 /turf/open/floor/kutjevo/tan/multi_tiles{
 	dir = 8
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "mMH" = (
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "mNa" = (
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/telecomm/lz2_north)
@@ -9602,7 +9602,7 @@
 "mPP" = (
 /obj/structure/cable/heavyduty,
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "mQl" = (
 /turf/open/desert/desert_shore/desert_shore1,
 /area/kutjevo/exterior/lz_river)
@@ -9667,7 +9667,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "mWO" = (
 /obj/structure/platform_decoration/kutjevo,
 /turf/open/auto_turf/sand/layer2,
@@ -9735,7 +9735,7 @@
 "nco" = (
 /obj/structure/flora/grass/tallgrass/desert/corner,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "nct" = (
 /turf/open/gm/river/desert/shallow_edge{
 	dir = 5
@@ -9778,7 +9778,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 1
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "ngX" = (
 /obj/structure/stairs/perspective/kutjevo{
 	dir = 8;
@@ -9825,7 +9825,7 @@
 "nkV" = (
 /obj/item/device/flashlight/on,
 /turf/open/floor/kutjevo/tan/multi_tiles,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "nkZ" = (
 /obj/structure/stairs/perspective/kutjevo{
 	dir = 9;
@@ -9910,7 +9910,7 @@
 /area/kutjevo/interior/complex/med)
 "npL" = (
 /turf/open/auto_turf/sand/layer2,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "nrk" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/exterior/scrubland)
@@ -10035,7 +10035,7 @@
 	dir = 1
 	},
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "nzB" = (
 /obj/structure/bed/sofa/vert/grey/bot{
 	pixel_y = 4
@@ -10246,7 +10246,7 @@
 	dir = 1
 	},
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "nLc" = (
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
@@ -10320,7 +10320,7 @@
 /area/kutjevo/exterior/runoff_bridge)
 "nPf" = (
 /turf/open/gm/river/desert/deep/covered,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "nPl" = (
 /obj/structure/platform/kutjevo/rock{
 	dir = 1
@@ -10431,7 +10431,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "nWo" = (
 /obj/structure/platform/kutjevo{
 	dir = 1
@@ -10539,7 +10539,7 @@
 	layer = 3.1
 	},
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "oce" = (
 /turf/open/gm/river/desert/shallow_edge{
 	dir = 1
@@ -10591,7 +10591,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 4
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "ogo" = (
 /turf/open/floor/kutjevo/colors/cyan/edge{
 	dir = 1
@@ -10630,7 +10630,7 @@
 /area/kutjevo/interior/foremans_office)
 "okv" = (
 /turf/open/floor/almayer/research/containment/floor1,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "okJ" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -10797,7 +10797,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "ovG" = (
 /turf/open/gm/river/desert/shallow,
 /area/kutjevo/exterior/runoff_bridge)
@@ -10835,7 +10835,7 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "ozl" = (
 /obj/structure/platform/kutjevo,
 /turf/open/gm/river/desert/shallow_edge{
@@ -10878,7 +10878,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "oDe" = (
 /obj/structure/closet/emcloset,
 /obj/structure/machinery/light{
@@ -10925,7 +10925,7 @@
 /obj/structure/platform/kutjevo/smooth,
 /obj/structure/machinery/light,
 /turf/open/gm/river/desert/deep/covered,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "oGC" = (
 /obj/structure/platform/kutjevo/smooth,
 /turf/open/desert/desert_shore/desert_shore1{
@@ -11000,7 +11000,7 @@
 	icon_state = "p_stair_full"
 	},
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "oMW" = (
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/kutjevo/colors/purple/edge{
@@ -11041,7 +11041,7 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_nest,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "oOO" = (
 /obj/structure/platform/kutjevo,
 /turf/open/gm/river/desert/shallow_corner{
@@ -11100,7 +11100,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 6
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "oRZ" = (
 /obj/structure/machinery/autodoc_console,
 /obj/structure/machinery/light,
@@ -11164,7 +11164,7 @@
 "oXH" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "oYQ" = (
 /obj/structure/blocker/invisible_wall,
 /obj/structure/surface/table/reinforced/prison,
@@ -11184,7 +11184,7 @@
 	icon_state = "p_stair_sn_full_cap"
 	},
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "oZK" = (
 /obj/structure/blocker/invisible_wall,
 /obj/structure/filtration/machine_96x96/indestructible{
@@ -11202,7 +11202,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 6
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "pbY" = (
 /turf/closed/wall/kutjevo/colony/reinforced/hull,
 /area/kutjevo/interior/complex/med)
@@ -11410,7 +11410,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "pnM" = (
 /obj/item/storage/belt/shotgun,
 /turf/open/floor/kutjevo/multi_tiles,
@@ -11428,11 +11428,11 @@
 	},
 /obj/structure/platform/kutjevo/rock,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "poF" = (
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "poZ" = (
 /obj/item/stool{
 	pixel_y = 8
@@ -11516,14 +11516,14 @@
 	dir = 8
 	},
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "ptS" = (
 /obj/structure/platform/kutjevo/rock,
 /turf/open/auto_turf/sand/layer2,
 /area/kutjevo/exterior/scrubland)
 "ptY" = (
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "pue" = (
 /obj/structure/bed/stool{
 	pixel_y = 8
@@ -11574,7 +11574,7 @@
 	},
 /obj/structure/platform/kutjevo/rock,
 /turf/open/gm/river/desert/deep,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "pyp" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/power)
@@ -11790,7 +11790,7 @@
 "pKn" = (
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/kutjevo/colony/reinforced,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "pKE" = (
 /obj/structure/machinery/light/small{
 	dir = 1;
@@ -11831,7 +11831,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 4
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "pNi" = (
 /obj/structure/window_frame/kutjevo,
 /turf/open/floor/plating/kutjevo,
@@ -11918,7 +11918,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 1
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "pSs" = (
 /turf/open/floor/kutjevo/colors/red,
 /area/kutjevo/interior/complex/botany)
@@ -11961,7 +11961,7 @@
 "pVi" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/auto_turf/sand/layer2,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "pVt" = (
 /obj/structure/bed/roller,
 /obj/structure/machinery/light{
@@ -11992,7 +11992,7 @@
 "pXF" = (
 /obj/item/device/flashlight/on,
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "pYf" = (
 /obj/structure/bed/chair{
 	dir = 4;
@@ -12010,7 +12010,7 @@
 	dir = 6
 	},
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "qaI" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
 /area/kutjevo/interior/construction)
@@ -12065,7 +12065,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 4
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "qgW" = (
 /turf/open/floor/kutjevo/tan/multi_tiles,
 /area/kutjevo/interior/complex/botany)
@@ -12115,7 +12115,7 @@
 /area/kutjevo/interior/colony_central)
 "qmR" = (
 /turf/open/floor/kutjevo/tan/multi_tiles,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "qnd" = (
 /turf/open/floor/kutjevo/tan/alt_edge{
 	dir = 1
@@ -12151,7 +12151,7 @@
 	dir = 1
 	},
 /turf/open/floor/kutjevo/colors,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "qpR" = (
 /obj/structure/surface/rack,
 /obj/item/storage/belt/utility/full,
@@ -12232,7 +12232,7 @@
 	icon_state = "1-2-4"
 	},
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "qtK" = (
 /obj/structure/surface/table/almayer,
 /obj/item/weapon/gun/shotgun/pump/dual_tube/cmb/m3717,
@@ -12291,7 +12291,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "qyS" = (
 /obj/structure/flora/grass/tallgrass/desert/corner{
 	dir = 9
@@ -12365,7 +12365,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 6
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "qDu" = (
 /obj/item/trash/kepler,
 /turf/open/auto_turf/sand/layer0,
@@ -12389,7 +12389,7 @@
 "qED" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "qFh" = (
 /obj/structure/flora/grass/tallgrass/desert/corner{
 	dir = 4
@@ -12407,7 +12407,7 @@
 /area/kutjevo/exterior/scrubland)
 "qGx" = (
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "qGA" = (
 /obj/item/tool/wirecutters/clippers,
 /turf/open/auto_turf/sand/layer0,
@@ -12458,14 +12458,14 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 4
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "qIV" = (
 /obj/structure/platform/kutjevo/smooth,
 /obj/structure/barricade/handrail/kutjevo{
 	layer = 3.1
 	},
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "qJx" = (
 /turf/open/floor/kutjevo/colors/orange/edge{
 	dir = 10
@@ -12491,7 +12491,7 @@
 "qLV" = (
 /obj/structure/tunnel,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "qMC" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -12533,7 +12533,7 @@
 "qOP" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "qPa" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
 /turf/open/floor/kutjevo/tan/multi_tiles,
@@ -12694,7 +12694,7 @@
 /area/kutjevo/interior/complex/med/operating)
 "rdm" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "rdx" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer/research/containment/floor2,
@@ -12712,10 +12712,10 @@
 "rfE" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/closed/wall/kutjevo/colony/reinforced,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "rfH" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "rfZ" = (
 /obj/structure/platform/kutjevo/rock,
 /turf/open/auto_turf/sand/layer0,
@@ -12838,7 +12838,7 @@
 	dir = 8
 	},
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "rmt" = (
 /turf/open/floor/kutjevo/tan/multi_tiles,
 /area/kutjevo/interior/colony_central)
@@ -12908,7 +12908,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 4
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "rsV" = (
 /turf/open/desert/desert_shore/desert_shore1{
 	dir = 8
@@ -12958,7 +12958,7 @@
 "rwC" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/auto_turf/sand/layer2,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "rwL" = (
 /obj/item/frame/table/almayer,
 /turf/open/floor/kutjevo/tan,
@@ -13017,7 +13017,7 @@
 	dir = 4
 	},
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "rzE" = (
 /obj/structure/flora/bush/ausbushes/reedbush,
 /turf/open/gm/river/desert/shallow_edge,
@@ -13104,7 +13104,7 @@
 "rHE" = (
 /obj/structure/cargo_container/grant/left,
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "rHL" = (
 /turf/open/floor/kutjevo/tan/grey_edge,
 /area/kutjevo/interior/colony_central)
@@ -13119,14 +13119,14 @@
 	name = "\improper North Power Shutters"
 	},
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "rIo" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/backpack/lightpack,
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "rID" = (
 /obj/structure/machinery/shower{
 	dir = 1;
@@ -13237,7 +13237,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 4
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "rRL" = (
 /obj/structure/platform/kutjevo{
 	dir = 1
@@ -13255,7 +13255,7 @@
 	dir = 1
 	},
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "rSU" = (
 /turf/open/floor/kutjevo/tan/alt_edge{
 	dir = 8
@@ -13422,7 +13422,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "sbX" = (
 /turf/open/auto_turf/sand/layer2,
 /area/kutjevo/exterior/runoff_river)
@@ -13436,7 +13436,7 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/open/auto_turf/sand/layer2,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "scY" = (
 /obj/effect/landmark/corpsespawner/wygoon,
 /turf/open/floor/kutjevo/tan,
@@ -13479,7 +13479,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "sgW" = (
 /obj/structure/barricade/handrail/kutjevo,
 /turf/open/floor/plating/kutjevo,
@@ -13496,7 +13496,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 8
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "sit" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -13534,7 +13534,7 @@
 /turf/open/floor/kutjevo/tan/multi_tiles{
 	dir = 6
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "slB" = (
 /obj/structure/machinery/landinglight/ds1/delaythree{
 	dir = 1
@@ -13551,7 +13551,7 @@
 	},
 /obj/structure/platform/kutjevo/smooth,
 /turf/open/floor/kutjevo/tan/multi_tiles,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "smo" = (
 /obj/structure/platform_decoration/kutjevo{
 	dir = 8
@@ -13742,7 +13742,7 @@
 "syM" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "szC" = (
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor/plating/kutjevo,
@@ -13773,7 +13773,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "sAA" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -13882,7 +13882,7 @@
 "sHQ" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_core,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "sIr" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer/open{
 	name = "\improper Medical Stormlock Shutters"
@@ -13955,7 +13955,7 @@
 /area/kutjevo/interior/power)
 "sNZ" = (
 /turf/open/auto_turf/sand/layer2,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "sOc" = (
 /obj/item/ammo_magazine/revolver/cmb{
 	pixel_x = 6;
@@ -13994,7 +13994,7 @@
 "sPp" = (
 /obj/structure/platform/kutjevo/smooth,
 /turf/open/gm/river/desert/deep/covered,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "sPE" = (
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/interior/power/comms)
@@ -14104,7 +14104,7 @@
 "sWP" = (
 /obj/effect/landmark/queen_spawn,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "sXj" = (
 /obj/structure/largecrate/random/case/small,
 /obj/effect/spawner/random/toolbox{
@@ -14234,7 +14234,7 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/auto_turf/sand/layer2,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "tgZ" = (
 /obj/structure/surface/table/almayer,
 /obj/item/weapon/gun/revolver/cmb,
@@ -14335,7 +14335,7 @@
 	icon_state = "p_stair_full"
 	},
 /turf/open/floor/kutjevo/tan/multi_tiles,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "tnI" = (
 /turf/open/desert/desert_shore/shore_edge1{
 	dir = 4
@@ -14505,7 +14505,7 @@
 /obj/effect/landmark/xeno_hive_spawn,
 /obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "tAQ" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/landmark/objective_landmark/far,
@@ -14532,7 +14532,7 @@
 "tCm" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/auto_turf/sand/layer2,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "tCK" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
@@ -14611,7 +14611,7 @@
 	},
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "tFN" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/auto_turf/sand/layer2,
@@ -14757,7 +14757,7 @@
 	icon_state = "kutjevo_platform_sm_stair"
 	},
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "tRp" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	dir = 1;
@@ -14778,12 +14778,12 @@
 "tSi" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/floor/kutjevo/tan/multi_tiles,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "tSZ" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/floor/kutjevo/tan/multi_tiles,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "tTi" = (
 /obj/structure/blocker/invisible_wall,
 /obj/structure/filingcabinet,
@@ -14824,7 +14824,7 @@
 	name = "\improper South Power Shutters"
 	},
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "tZc" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony/autoname{
 	req_one_access = null
@@ -14892,7 +14892,7 @@
 "ueJ" = (
 /obj/structure/platform/kutjevo/rock,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "ueM" = (
 /turf/open/desert/desert_shore/shore_corner2{
 	dir = 4
@@ -14914,7 +14914,7 @@
 	dir = 10
 	},
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "ufV" = (
 /obj/structure/flora/grass/tallgrass/desert/corner,
 /turf/open/auto_turf/sand/layer1,
@@ -15075,7 +15075,7 @@
 "unr" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/kutjevo/colors,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "uoz" = (
 /turf/closed/wall/kutjevo/colony/reinforced/hull,
 /area/kutjevo/interior/oob/dev_room)
@@ -15134,12 +15134,12 @@
 	dir = 1
 	},
 /turf/open/floor/kutjevo/tan/multi_tiles,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "urv" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "ury" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "xgib2"
@@ -15395,7 +15395,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "uKx" = (
 /obj/effect/decal/cleanable/blood/xeno{
 	icon_state = "xgib5"
@@ -15476,7 +15476,7 @@
 "uNW" = (
 /obj/structure/prop/dam/boulder/boulder2,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "uNZ" = (
 /obj/structure/machinery/colony_floodlight,
 /obj/structure/platform/kutjevo/smooth{
@@ -15519,7 +15519,7 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "uQa" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/structure/machinery/light{
@@ -15566,7 +15566,7 @@
 "uSr" = (
 /obj/item/stack/cable_coil/random,
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "uSG" = (
 /obj/structure/window/framed/kutjevo/reinforced/hull,
 /turf/open/floor/kutjevo/multi_tiles{
@@ -15658,7 +15658,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "vap" = (
 /obj/effect/decal/cleanable/blood/xeno{
 	icon_state = "xgib1"
@@ -15746,7 +15746,7 @@
 /area/kutjevo/interior/power)
 "vdv" = (
 /turf/closed/wall/kutjevo/rock,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "vdH" = (
 /obj/structure/machinery/vending/snack,
 /turf/open/floor/kutjevo/colors/red,
@@ -15964,7 +15964,7 @@
 /area/kutjevo/interior/construction)
 "vsP" = (
 /turf/closed/wall/kutjevo/rock,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "vsS" = (
 /turf/open/desert/desert_shore/shore_edge1{
 	dir = 1
@@ -15990,7 +15990,7 @@
 /turf/open/floor/kutjevo/tan/alt_edge{
 	dir = 8
 	},
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "vxM" = (
 /obj/structure/surface/table/almayer,
 /obj/item/ammo_magazine/shotgun/buckshot,
@@ -16027,7 +16027,7 @@
 	icon_state = "gravestone2"
 	},
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "vBI" = (
 /turf/open/floor/kutjevo/plate,
 /area/kutjevo/exterior/lz_dunes)
@@ -16090,7 +16090,7 @@
 	layer = 3.05
 	},
 /turf/open/floor/kutjevo/tan/multi_tiles,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "vDS" = (
 /turf/open/floor/kutjevo/colors/green,
 /area/kutjevo/interior/complex/botany)
@@ -16106,7 +16106,7 @@
 	name = "\improper East Power Shutters"
 	},
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "vER" = (
 /obj/structure/surface/table/almayer,
 /turf/open/floor/kutjevo/tan/grey_edge{
@@ -16190,7 +16190,7 @@
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "vKp" = (
 /obj/structure/bed,
 /obj/structure/window/reinforced{
@@ -16325,7 +16325,7 @@
 "vSE" = (
 /obj/structure/cargo_container/grant/right,
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "vSH" = (
 /obj/structure/machinery/autolathe/full,
 /turf/open/floor/kutjevo/grey/plate,
@@ -16348,7 +16348,7 @@
 /area/kutjevo/exterior/runoff_river)
 "vVr" = (
 /turf/closed/wall/kutjevo/colony/reinforced,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "vVC" = (
 /obj/structure/flora/grass/tallgrass/desert,
 /turf/open/auto_turf/sand/layer0,
@@ -16385,7 +16385,7 @@
 "vXK" = (
 /obj/structure/bed/chair/office/dark,
 /turf/open/floor/kutjevo/colors,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "vYC" = (
 /turf/open/desert/desert_shore/desert_shore1{
 	dir = 4
@@ -16420,7 +16420,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "wae" = (
 /obj/structure/flora/grass/tallgrass/desert/corner{
 	dir = 6
@@ -16566,7 +16566,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "wnk" = (
 /obj/structure/largecrate/random/case/small,
 /obj/effect/spawner/random/toolbox{
@@ -16696,7 +16696,7 @@
 "wuH" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_core,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "wuL" = (
 /obj/item/stack/rods,
 /turf/open/floor/kutjevo/colors/purple,
@@ -16707,7 +16707,7 @@
 /area/kutjevo/exterior/Northwest_Colony)
 "wvr" = (
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "wvu" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -16853,7 +16853,7 @@
 	icon_state = "p_stair_sn_full_cap"
 	},
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "wDT" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/structure/machinery/computer/cameras{
@@ -16938,7 +16938,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "wMw" = (
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor/kutjevo/multi_tiles,
@@ -17006,7 +17006,7 @@
 /obj/effect/landmark/xeno_hive_spawn,
 /obj/effect/landmark/ert_spawns/groundside_xeno,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "wTt" = (
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/interior/colony_north)
@@ -17024,7 +17024,7 @@
 "wVt" = (
 /obj/item/stack/cable_coil/random,
 /turf/open/floor/kutjevo/tan/multi_tiles,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "wWk" = (
 /obj/structure/stairs/perspective/kutjevo{
 	dir = 8;
@@ -17048,7 +17048,7 @@
 /area/kutjevo/interior/oob)
 "wXd" = (
 /turf/closed/wall/kutjevo/rock,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "wXf" = (
 /obj/structure/machinery/landinglight/ds2{
 	dir = 1
@@ -17084,7 +17084,7 @@
 "wYE" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/auto_turf/sand/layer2,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "wZo" = (
 /obj/structure/stairs/perspective/kutjevo{
 	dir = 8;
@@ -17215,13 +17215,13 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "xlt" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/closed/wall/resin/thick,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "xlD" = (
 /obj/structure/machinery/light,
 /turf/open/floor/kutjevo/colors/orange,
@@ -17251,7 +17251,7 @@
 "xnT" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_South)
+/area/kutjevo/interior/colony_south)
 "xof" = (
 /obj/structure/machinery/power/apc{
 	dir = 4;
@@ -17274,7 +17274,7 @@
 	},
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "xoV" = (
 /turf/open/desert/desert_shore/shore_corner2{
 	dir = 4
@@ -17298,7 +17298,7 @@
 "xqd" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "xqM" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -17390,7 +17390,7 @@
 	icon_state = "gravestone3"
 	},
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "xxY" = (
 /obj/structure/flora/grass/tallgrass/desert/corner,
 /turf/open/auto_turf/sand/layer0,
@@ -17484,7 +17484,7 @@
 	icon_state = "p_stair_full"
 	},
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "xGI" = (
 /obj/structure/machinery/power/terminal{
 	dir = 4
@@ -17555,7 +17555,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 10
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "xOU" = (
 /obj/structure/sign/safety/hazard{
 	pixel_x = -32
@@ -17613,7 +17613,7 @@
 "xRY" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "xSn" = (
 /obj/structure/platform/kutjevo/smooth{
 	dir = 4
@@ -17651,12 +17651,12 @@
 	dir = 8
 	},
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/interior/colony_N_East)
+/area/kutjevo/interior/colony_northeast)
 "xVZ" = (
 /turf/open/floor/kutjevo/tan/multi_tiles{
 	dir = 8
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "xWK" = (
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/exterior/construction)
@@ -17761,7 +17761,7 @@
 	},
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor/plating/kutjevo,
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "ybV" = (
 /obj/structure/flora/grass/tallgrass/desert,
 /turf/open/auto_turf/sand/layer0,
@@ -17812,7 +17812,7 @@
 "ygm" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/interior/colony_S_East)
+/area/kutjevo/interior/colony_southeast)
 "ygL" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "2-8"
@@ -17897,7 +17897,7 @@
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 4
 	},
-/area/kutjevo/interior/colony_South/power2)
+/area/kutjevo/interior/colony_south/power2)
 "ykY" = (
 /obj/effect/landmark/xeno_hive_spawn,
 /obj/effect/landmark/ert_spawns/groundside_xeno,


### PR DESCRIPTION
# About the pull request

Does three things:

1. Makes all caves OBable, but not CAS-able. See before-after:

<details>
<summary>Screenshots</summary>


- yellow can be CAS'd/OB'd
- blue can be OB'd but not CAS'd
- red cannot be CAS'd or OB'd

Before: 

![image](https://github.com/cmss13-devs/cmss13/assets/49321394/d7eaf239-8bb2-4d33-935d-3823974b63df)

After:

![image](https://github.com/cmss13-devs/cmss13/assets/49321394/ef2f01ec-2391-4ec6-bae9-1ae595c11a4d)

</details>

2. Fixes Northeast and Southeast caves being switched up

<details>
<summary>Screenshots</summary>

The red circle was called South East Caves, the blue circle was called North East Caves.

![image](https://github.com/cmss13-devs/cmss13/assets/49321394/24a634ad-452e-4f38-ba34-a430f530c03a)

</details>

3. Fixes the weird snake+camelcase path naming

# Explain why it's good for the game

Every other map (edit: except for Trijent) removed deep underground caves as it is the hive core's job to keep the area un-OBable, Kutjevo was somehow behind on this.

# Testing Photographs and Procedure

See above.

# Changelog

:cl:
maptweak: Fixed Kutjevo Northeast Caves being called Southeast Caves and Southeast Caves being called Northeast Caves.
maptweak: Kutjevo's North, Northeast, Southeast, and South Caves, and the South Colony Treatment Plant areas can be now OB'd (but not CAS'd), bringing these cave areas up to standard.
/:cl:
