### PR TITLE
Fixes armor light staying on after removal

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -459,8 +459,8 @@ cases. Override_icon_state should be a list.*/
 
 	if(item.flags_equip_slot & slotdefine2slotbit(slot))
 		if(is_type_in_list(item, uniform_restricted))
-			if(src.light_on)
-				src.turn_light(toggle_on = FALSE)
+			if(light_on)
+				turn_light(toggle_on = FALSE)
 			user.drop_inv_item_on_ground(src)
 			to_chat(user, SPAN_NOTICE("You drop \the [src] to the ground while unequipping \the [item]."))
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -459,6 +459,8 @@ cases. Override_icon_state should be a list.*/
 
 	if(item.flags_equip_slot & slotdefine2slotbit(slot))
 		if(is_type_in_list(item, uniform_restricted))
+			if(src.light_on)
+				src.turn_light(toggle_on = FALSE)
 			user.drop_inv_item_on_ground(src)
 			to_chat(user, SPAN_NOTICE("You drop \the [src] to the ground while unequipping \the [item]."))
 

--- a/code/game/objects/items/storage/internal.dm
+++ b/code/game/objects/items/storage/internal.dm
@@ -61,10 +61,13 @@
 						else
 							user.drop_inv_item_on_ground(master_item)
 							user.put_in_r_hand(master_item)
-						return
 					else
 						user.drop_inv_item_on_ground(master_item)
 						user.put_in_r_hand(master_item)
+
+					if(master_item.light_on)
+						master_item.turn_light(toggle_on = FALSE)
+					return
 				if("l_hand")
 					if(master_item.time_to_unequip)
 						user.visible_message(SPAN_NOTICE("[user] starts taking off \the [master_item]."))
@@ -73,10 +76,13 @@
 						else
 							user.drop_inv_item_on_ground(master_item)
 							user.put_in_l_hand(master_item)
-						return
 					else
 						user.drop_inv_item_on_ground(master_item)
 						user.put_in_l_hand(master_item)
+
+					if(master_item.light_on)
+						master_item.turn_light(toggle_on = FALSE)
+					return
 			master_item.add_fingerprint(user)
 			return FALSE
 	return FALSE

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -525,6 +525,8 @@
 	interact_item.add_fingerprint(src)
 	if(do_after(src, get_strip_delay(src, target_mob), INTERRUPT_ALL, BUSY_ICON_GENERIC, target_mob, INTERRUPT_MOVED, BUSY_ICON_GENERIC))
 		if(interact_item && Adjacent(target_mob) && interact_item == target_mob.get_item_by_slot(slot_to_process))
+			if(interact_item.light_on)
+				interact_item.turn_light(toggle_on = FALSE)
 			target_mob.drop_inv_item_on_ground(interact_item)
 			log_interact(src, target_mob, "[key_name(src)] removed [key_name(target_mob)]'s [interact_item.name] ([slot_to_process]) successfully.")
 


### PR DESCRIPTION
# About the pull request
Fixes #5672 , just put a conditional to check if the armor contains a light source that is currently turned on, if so we just turn it off when the user removes it from their inventory.

# Changelog
:cl:
fix: Fixes armor light staying on after removal. 

