### PR TITLE
Fixes chair/bed teleporting

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -166,7 +166,7 @@
 		if(ismob(G.grabbed_thing))
 			var/mob/M = G.grabbed_thing
 			var/atom/blocker = LinkBlocked(user, user.loc, loc)
-			if(!src.Adjacent(M))
+			if(!Adjacent(M))
 				visible_message(SPAN_DANGER("[M] is too far to place onto [src]."))
 				return FALSE
 			if(blocker)

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -166,11 +166,14 @@
 		if(ismob(G.grabbed_thing))
 			var/mob/M = G.grabbed_thing
 			var/atom/blocker = LinkBlocked(user, user.loc, loc)
+			if(!src.Adjacent(M))
+				visible_message(SPAN_DANGER("[M] is too far to place onto the [src]"))
+				return FALSE
 			if(blocker)
 				to_chat(user, SPAN_WARNING("\The [blocker] is in the way!"))
-			else
-				to_chat(user, SPAN_NOTICE("You place [M] on [src]."))
-				M.forceMove(loc)
+				return FALSE
+			to_chat(user, SPAN_NOTICE("You place [M] on [src]."))
+			M.forceMove(loc)
 		return TRUE
 
 	else

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -167,7 +167,7 @@
 			var/mob/M = G.grabbed_thing
 			var/atom/blocker = LinkBlocked(user, user.loc, loc)
 			if(!src.Adjacent(M))
-				visible_message(SPAN_DANGER("[M] is too far to place onto the [src]"))
+				visible_message(SPAN_DANGER("[M] is too far to place onto [src]."))
 				return FALSE
 			if(blocker)
 				to_chat(user, SPAN_WARNING("\The [blocker] is in the way!"))

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -270,6 +270,9 @@
 		var/obj/item/grab/G = W
 		if(istype(G.grabbed_thing, /mob/living))
 			var/mob/living/M = G.grabbed_thing
+			if(!src.Adjacent(M))
+				visible_message(SPAN_DANGER("[M] is too far to place onto [src]"))
+				return
 			if(user.a_intent == INTENT_HARM)
 				if(user.grab_level > GRAB_AGGRESSIVE)
 					if (prob(15))

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -270,9 +270,6 @@
 		var/obj/item/grab/G = W
 		if(istype(G.grabbed_thing, /mob/living))
 			var/mob/living/M = G.grabbed_thing
-			if(!src.Adjacent(M))
-				visible_message(SPAN_DANGER("[M] is too far to place onto [src]"))
-				return
 			if(user.a_intent == INTENT_HARM)
 				if(user.grab_level > GRAB_AGGRESSIVE)
 					if (prob(15))


### PR DESCRIPTION
# About the pull request
Fixes #5604, prevents placing mobs onto chairs, beds and tables unless the mob is directly adjacent to the source tile. I'm hesitant to extend this functionality for the autodoc/scanner and xeno nests as I could see it getting very annoying quickly. 

# Changelog

:cl:
fix: Fixes teleporting when placing mobs onto chairs and beds. 
/:cl:


