### PR TITLE
Metal rods take up less space now (from medium to small)

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -4,7 +4,7 @@
 	singular_name = "metal rod"
 	icon_state = "rods"
 	flags_atom = FPRINT|CONDUCT
-	w_class = SIZE_MEDIUM
+	w_class = SIZE_SMALL
 	force = 9
 	throwforce = 15
 	throw_speed = SPEED_VERY_FAST
@@ -54,7 +54,7 @@ GLOBAL_LIST_INIT(rod_recipes, list (
 	singular_name = "plasteel rod"
 	icon_state = "rods_plasteel"
 	flags_atom = FPRINT
-	w_class = SIZE_MEDIUM
+	w_class = SIZE_SMALL
 	force = 9
 	throwforce = 15
 	throw_speed = SPEED_VERY_FAST


### PR DESCRIPTION

# About the pull request

This PR changes metal rods and plasteel rods from occupying 3 spaces to 2. 

I haven't done a PR in a bit so this is a warm up. I have a little list of things tiny little things I wanted to do, its like the sandbag change morrow did forever ago 

# Explain why it's good for the game

Metal rods and plasteel rods come from metal and plasteel sheets respectively. These rods are a fraction of the size of said sheet, yet they occupy the same space. Although people usually don't carry rods, it didn't seem intuitive to me for them to take up so much space - its like smaller versions of tent poles, you can usually fit them in your backpack and they occupy less space than a sock. 

There is no incentive to carry rods instead of sheets, because they take up the same space - despite multiple rods coming from one sheet. It just doesn't feel intuitive

# Testing Photographs and Procedure
https://cdn.discordapp.com/attachments/1042176396711170119/1221640724911620166/image.png?ex=66135095&is=6600db95&hm=f8fd020781cbc8d68e5acf552ecf485a6cf34a20291289eef06d823b8c103fce&

# Changelog
:cl:
balance: Metal rods take up less space in an inventory (3 slots to 2)
/:cl:
