### PR TITLE
LV522 Changes: Ledges, Sewer, Reactor Entry, East reactor

### DIFF
--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -50,18 +50,6 @@
 	icon_state = "cement1"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
-"abL" = (
-/obj/structure/platform{
-	dir = 1
-	},
-/obj/structure/platform{
-	dir = 4
-	},
-/obj/structure/platform_decoration{
-	dir = 9
-	},
-/turf/open/gm/river,
-/area/lv522/atmos/sewer)
 "abS" = (
 /obj/effect/acid_hole,
 /turf/closed/wall/strata_ice/dirty,
@@ -397,11 +385,13 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/a_block/dorms/glass)
 "akk" = (
-/obj/structure/platform{
+/obj/structure/machinery/power/apc/weak{
 	dir = 1
 	},
-/turf/open/asphalt/cement,
-/area/lv522/outdoors/colony_streets/south_east_street)
+/turf/open/floor/corsat{
+	icon_state = "plate"
+	},
+/area/lv522/atmos/east_reactor)
 "akl" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -450,19 +440,18 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 10
 	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate"
-	},
+/turf/open/floor/prison,
 /area/lv522/atmos/sewer)
 "amc" = (
 /obj/structure/cargo_container/kelland/left,
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/outdoors/colony_streets/north_east_street)
 "ame" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/structure/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/corsat{
-	icon_state = "squares"
+	icon_state = "plate"
 	},
 /area/lv522/atmos/east_reactor)
 "amC" = (
@@ -903,8 +892,8 @@
 	},
 /area/lv522/atmos/east_reactor/south)
 "aza" = (
-/obj/structure/platform{
-	dir = 1
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_full"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -1022,9 +1011,6 @@
 	dir = 9;
 	icon_state = "p_stair_full"
 	},
-/obj/structure/platform_decoration{
-	dir = 1
-	},
 /turf/open/asphalt/cement,
 /area/lv522/outdoors/colony_streets/north_east_street)
 "aDs" = (
@@ -1040,9 +1026,9 @@
 /turf/open/floor/plating,
 /area/shuttle/drop2/lv522)
 "aDS" = (
+/obj/structure/pipes/vents/pump,
 /turf/open/floor/corsat{
-	dir = 5;
-	icon_state = "brown"
+	icon_state = "marked"
 	},
 /area/lv522/atmos/east_reactor)
 "aDZ" = (
@@ -1261,9 +1247,13 @@
 /area/lv522/outdoors/colony_streets/north_east_street)
 "aJr" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "w-y2"
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	pixel_y = -1
+	},
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
 	},
 /area/lv522/oob/w_y_vault)
 "aJS" = (
@@ -1342,12 +1332,6 @@
 	icon_state = "blue_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
-"aLG" = (
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "w-y0"
-	},
-/area/lv522/oob/w_y_vault)
 "aLJ" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/open/floor/corsat,
@@ -1790,12 +1774,11 @@
 	},
 /area/lv522/indoors/c_block/mining)
 "aWX" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/corsat{
-	icon_state = "plate"
+	icon_state = "squares"
 	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/atmos/east_reactor/south)
 "aXa" = (
 /turf/open/floor/corsat{
 	dir = 6;
@@ -1938,10 +1921,13 @@
 	},
 /area/lv522/atmos/reactor_garage)
 "ban" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/blocker/invisible_wall,
-/turf/open/floor/plating,
-/area/lv522/indoors/c_block/cargo)
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
+/obj/effect/landmark/corpsespawner/colonist/burst,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/corsat{
+	icon_state = "plate"
+	},
+/area/lv522/atmos/east_reactor/south)
 "baG" = (
 /turf/open/floor/corsat{
 	dir = 1;
@@ -2083,7 +2069,10 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/c_block/garage)
 "bdL" = (
-/obj/structure/platform,
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
 /turf/open/asphalt/cement{
 	icon_state = "cement4"
 	},
@@ -2227,35 +2216,12 @@
 	},
 /area/lv522/atmos/east_reactor/north)
 "bhh" = (
-/obj/structure/platform{
-	dir = 1
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/turf/open/floor/corsat{
+	dir = 6;
+	icon_state = "brown"
 	},
-/obj/structure/closet/crate/freezer{
-	layer = 3
-	},
-/obj/item/reagent_container/food/snacks/grown/orange,
-/obj/item/reagent_container/food/snacks/grown/orange,
-/obj/item/reagent_container/food/snacks/grown/orange,
-/obj/item/reagent_container/food/snacks/grown/orange,
-/obj/item/reagent_container/food/snacks/grown/orange,
-/obj/item/reagent_container/food/snacks/grown/orange,
-/obj/item/reagent_container/food/snacks/grown/orange,
-/obj/item/reagent_container/food/snacks/grown/orange,
-/obj/item/reagent_container/food/snacks/grown/orange,
-/obj/item/reagent_container/food/snacks/grown/orange,
-/obj/item/reagent_container/food/snacks/grown/orange,
-/obj/item/reagent_container/food/snacks/grown/orange,
-/obj/item/reagent_container/food/snacks/grown/orange,
-/obj/item/reagent_container/food/snacks/grown/orange,
-/obj/item/reagent_container/food/snacks/grown/orange,
-/obj/item/reagent_container/food/snacks/grown/orange,
-/obj/item/reagent_container/food/snacks/grown/orange,
-/obj/item/reagent_container/food/snacks/grown/orange,
-/obj/item/reagent_container/food/snacks/grown/orange,
-/obj/item/reagent_container/food/snacks/grown/orange,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/lv522/indoors/c_block/cargo)
+/area/lv522/atmos/east_reactor/south)
 "bhD" = (
 /obj/structure/platform_decoration{
 	dir = 1
@@ -2874,11 +2840,14 @@
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "bCd" = (
-/obj/structure/machinery/light,
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
+/obj/effect/landmark/corpsespawner/colonist/burst,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/corsat{
 	icon_state = "plate"
 	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/atmos/east_reactor/south)
 "bCh" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
@@ -3769,13 +3738,11 @@
 	},
 /area/lv522/indoors/a_block/hallway)
 "bXl" = (
-/obj/structure/prop/ice_colony/ground_wire{
-	dir = 1
-	},
+/obj/effect/landmark/corpsespawner/colonist/burst,
 /turf/open/floor/corsat{
-	icon_state = "brown"
+	icon_state = "plate"
 	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/atmos/east_reactor/south)
 "bXo" = (
 /obj/structure/surface/table/almayer,
 /obj/item/paper_bin{
@@ -3858,7 +3825,13 @@
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/outdoors/colony_streets/central_streets)
 "bYV" = (
-/obj/structure/platform,
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
+/obj/structure/platform{
+	dir = 8
+	},
 /turf/open/asphalt/cement,
 /area/lv522/outdoors/colony_streets/south_street)
 "bYZ" = (
@@ -3996,20 +3969,8 @@
 /obj/structure/pipes/standard/manifold/hidden/green{
 	dir = 1
 	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate"
-	},
+/turf/open/floor/prison,
 /area/lv522/atmos/sewer)
-"cbn" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S";
-	pixel_y = -1
-	},
-/turf/open/floor{
-	dir = 4;
-	icon_state = "whiteyellowfull"
-	},
-/area/lv522/oob/w_y_vault)
 "cbp" = (
 /obj/structure/machinery/squeezer,
 /turf/open/floor{
@@ -4026,8 +3987,9 @@
 	},
 /area/lv522/atmos/east_reactor/north)
 "cbR" = (
-/obj/structure/platform{
-	dir = 4
+/obj/structure/stairs/perspective{
+	dir = 8;
+	icon_state = "p_stair_full"
 	},
 /turf/open/asphalt/cement{
 	icon_state = "cement3"
@@ -4155,7 +4117,6 @@
 	dir = 5;
 	icon_state = "p_stair_full"
 	},
-/obj/structure/platform_decoration,
 /turf/open/asphalt/cement{
 	icon_state = "cement4"
 	},
@@ -4713,11 +4674,12 @@
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "cuu" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
-/obj/effect/landmark/xeno_spawn,
 /obj/structure/machinery/light{
 	dir = 8
 	},
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
+/obj/effect/landmark/corpsespawner/colonist/burst,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/corsat{
 	icon_state = "plate"
 	},
@@ -4843,14 +4805,11 @@
 	},
 /area/lv522/indoors/a_block/dorms)
 "cxE" = (
-/obj/structure/machinery/colony_floodlight{
-	layer = 4.3
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/corsat{
+	icon_state = "plate"
 	},
-/obj/structure/platform{
-	dir = 1
-	},
-/turf/open/asphalt/cement,
-/area/lv522/outdoors/colony_streets/south_east_street)
+/area/lv522/atmos/east_reactor/south)
 "cxK" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/corsat{
@@ -5277,11 +5236,8 @@
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "cHy" = (
-/obj/structure/prop/ice_colony/ground_wire,
-/turf/open/floor/corsat{
-	icon_state = "squares"
-	},
-/area/lv522/atmos/east_reactor)
+/turf/closed/wall/strata_outpost/reinforced,
+/area/lv522/atmos/east_reactor/south)
 "cHC" = (
 /obj/structure/prop/invuln/lattice_prop{
 	icon_state = "lattice12";
@@ -5499,7 +5455,10 @@
 "cKo" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/trash/chips,
-/obj/structure/platform,
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
 /turf/open/asphalt/cement,
 /area/lv522/outdoors/colony_streets/east_central_street)
 "cKp" = (
@@ -6096,14 +6055,11 @@
 	},
 /area/lv522/indoors/a_block/security)
 "cWH" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
-/obj/structure/machinery/light{
-	dir = 8
-	},
+/obj/structure/window/framed/strata/reinforced,
 /turf/open/floor/corsat{
-	icon_state = "squares"
+	icon_state = "marked"
 	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/atmos/east_reactor/south)
 "cWL" = (
 /turf/open/floor/corsat{
 	dir = 8;
@@ -6183,13 +6139,12 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/security)
 "cYe" = (
-/obj/structure/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/corsat{
-	icon_state = "plate"
-	},
-/area/lv522/atmos/east_reactor)
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
+/obj/effect/landmark/corpsespawner/colonist/burst,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/corsat,
+/area/lv522/atmos/east_reactor/south)
 "cYf" = (
 /obj/structure/closet/secure_closet/freezer/fridge/full,
 /obj/item/reagent_container/food/condiment/enzyme,
@@ -6405,8 +6360,12 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/b_block/hydro)
 "dbP" = (
-/obj/structure/platform{
-	dir = 4
+/obj/structure/stairs/perspective{
+	dir = 8;
+	icon_state = "p_stair_full"
+	},
+/obj/structure/platform/stair_cut{
+	icon_state = "platform_stair_alt"
 	},
 /turf/open/asphalt/cement,
 /area/lv522/outdoors/colony_streets/south_west_street)
@@ -6774,11 +6733,11 @@
 	},
 /area/lv522/landing_zone_2)
 "dhJ" = (
-/turf/open/floor/corsat{
-	dir = 8;
-	icon_state = "browncorner"
-	},
-/area/lv522/atmos/east_reactor)
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
+/obj/effect/landmark/corpsespawner/colonist/burst,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/corsat,
+/area/lv522/atmos/east_reactor/south)
 "dhP" = (
 /obj/structure/machinery/landinglight/ds1/delayone{
 	dir = 8
@@ -7577,7 +7536,9 @@
 /area/lv522/indoors/a_block/medical)
 "dyS" = (
 /obj/item/stack/sheet/wood,
-/turf/open/auto_turf/sand_white/layer0,
+/turf/open/asphalt/cement{
+	icon_state = "cement12"
+	},
 /area/lv522/outdoors/colony_streets/south_street)
 "dzd" = (
 /obj/structure/closet/secure_closet/marshal,
@@ -7630,14 +7591,11 @@
 	},
 /area/lv522/atmos/north_command_centre)
 "dAG" = (
-/obj/structure/pipes/vents/pump,
-/obj/structure/machinery/light{
-	dir = 8
-	},
+/obj/item/stack/sheet/metal,
 /turf/open/floor/corsat{
-	icon_state = "plate"
+	icon_state = "browncorner"
 	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/atmos/east_reactor/south)
 "dAQ" = (
 /obj/structure/platform_decoration{
 	dir = 1
@@ -8452,8 +8410,8 @@
 	},
 /area/lv522/indoors/b_block/bar)
 "dQQ" = (
-/obj/structure/platform{
-	dir = 1
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_full"
 	},
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -8737,8 +8695,9 @@
 	},
 /area/lv522/atmos/east_reactor/east)
 "dXX" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/belt/utility,
+/obj/structure/closet/fireaxecabinet{
+	pixel_y = 29
+	},
 /turf/open/floor/prison{
 	icon_state = "floor_plate"
 	},
@@ -9081,17 +9040,6 @@
 	},
 /turf/open/gm/river,
 /area/lv522/indoors/a_block/kitchen/damage)
-"efM" = (
-/obj/structure/platform,
-/obj/structure/platform{
-	dir = 8
-	},
-/obj/structure/platform_decoration{
-	dir = 10;
-	layer = 3.51
-	},
-/turf/open/gm/river,
-/area/lv522/atmos/sewer)
 "efR" = (
 /obj/effect/decal/hefa_cult_decals/d32{
 	desc = "You think you can make out the iconography of a Xenomorph."
@@ -10464,11 +10412,12 @@
 	},
 /area/lv522/indoors/a_block/corpo/glass)
 "eHp" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/item/stack/sheet/metal,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/corsat{
-	icon_state = "squares"
+	icon_state = "plate"
 	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/atmos/east_reactor/south)
 "eHu" = (
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/prison{
@@ -10688,11 +10637,15 @@
 	},
 /area/lv522/indoors/a_block/medical)
 "eLx" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
-/turf/open/floor/corsat{
-	icon_state = "marked"
+/obj/structure/machinery/prop/almayer/computer/PC{
+	dir = 1;
+	pixel_y = 3
 	},
-/area/lv522/atmos/east_reactor)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/corsat{
+	icon_state = "plate"
+	},
+/area/lv522/atmos/east_reactor/south)
 "eLG" = (
 /obj/item/lightstick/red/spoke/planted{
 	pixel_x = -19;
@@ -10764,13 +10717,17 @@
 	},
 /area/lv522/atmos/east_reactor)
 "eMm" = (
-/obj/structure/prop/invuln/fusion_reactor,
-/obj/structure/prop/turbine_extras,
-/obj/structure/prop/turbine_extras,
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/obj/structure/platform{
+	dir = 1
 	},
-/area/lv522/atmos/east_reactor)
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/platform_decoration{
+	dir = 9
+	},
+/turf/open/gm/river,
+/area/lv522/atmos/sewer)
 "eMz" = (
 /obj/item/stack/rods/plasteel,
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -10990,12 +10947,11 @@
 	},
 /area/lv522/indoors/a_block/hallway)
 "eRg" = (
-/obj/structure/prop/turbine,
-/obj/structure/prop/turbine_extras/border,
+/obj/structure/machinery/door/airlock/almayer/maint,
 /turf/open/floor/corsat{
-	icon_state = "plate"
+	icon_state = "marked"
 	},
-/area/lv522/oob)
+/area/lv522/atmos/sewer)
 "eRI" = (
 /obj/structure/barricade/deployable{
 	dir = 8
@@ -11024,10 +10980,9 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/security/glass)
 "eSy" = (
-/obj/structure/platform{
-	dir = 1
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_full"
 	},
-/obj/structure/largecrate/random,
 /turf/open/floor/plating{
 	icon_state = "platebot"
 	},
@@ -11327,12 +11282,18 @@
 	},
 /area/lv522/outdoors/colony_streets/south_east_street)
 "eZq" = (
-/obj/structure/prop/turbine_extras/left,
-/obj/structure/prop/invuln/fusion_reactor,
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/obj/structure/transmitter/colony_net{
+	phone_category = "LV522 Chances Claim";
+	phone_color = "red";
+	phone_id = "Reactor Sewer";
+	pixel_y = 26
 	},
-/area/lv522/oob)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/static_tank/water,
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
+	},
+/area/lv522/atmos/sewer)
 "eZv" = (
 /obj/structure/fence,
 /obj/effect/decal/warning_stripes{
@@ -11918,11 +11879,12 @@
 	},
 /area/lv522/atmos/east_reactor/east)
 "fmB" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/open/floor/corsat{
 	dir = 1;
 	icon_state = "brown"
 	},
-/area/lv522/oob)
+/area/lv522/atmos/east_reactor)
 "fmH" = (
 /obj/structure/pipes/vents/pump,
 /obj/effect/decal/cleanable/dirt,
@@ -12320,12 +12282,11 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/c_block/cargo)
 "fvQ" = (
-/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/window/framed/strata/reinforced,
 /turf/open/floor/corsat{
-	dir = 1;
-	icon_state = "browncorner"
+	icon_state = "marked"
 	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/atmos/sewer)
 "fvV" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out";
@@ -12772,12 +12733,12 @@
 	},
 /area/lv522/indoors/b_block/hydro)
 "fDC" = (
-/obj/structure/prop/ice_colony/ground_wire,
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor/corsat{
-	icon_state = "squares"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/prop/static_tank/water,
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
 	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/atmos/sewer)
 "fDF" = (
 /obj/structure/surface/rack,
 /obj/item/card/id/silver/clearance_badge/cl{
@@ -13237,10 +13198,12 @@
 	},
 /area/lv522/indoors/c_block/garage)
 "fMT" = (
-/turf/open/floor/corsat{
-	icon_state = "browncorner"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
 	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/atmos/sewer)
 "fNk" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -13514,7 +13477,9 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
 	},
-/turf/open/auto_turf/shale/layer1,
+/turf/open/asphalt/cement{
+	icon_state = "cement3"
+	},
 /area/lv522/outdoors/colony_streets/south_west_street)
 "fTO" = (
 /obj/effect/landmark/xeno_spawn,
@@ -13711,10 +13676,6 @@
 	},
 /area/lv522/indoors/a_block/medical)
 "fYm" = (
-/obj/structure/stairs/perspective{
-	dir = 10;
-	icon_state = "p_stair_full"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/camera/autoname,
 /obj/structure/machinery/light/small{
@@ -13886,11 +13847,10 @@
 /area/lv522/atmos/reactor_garage)
 "gbq" = (
 /obj/structure/stairs/perspective{
-	dir = 10;
 	icon_state = "p_stair_full"
 	},
-/obj/structure/platform_decoration{
-	dir = 4
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_full"
 	},
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/cargo)
@@ -13937,7 +13897,9 @@
 	pixel_x = -2;
 	pixel_y = 16
 	},
-/turf/open/auto_turf/sand_white/layer0,
+/turf/open/asphalt/cement{
+	icon_state = "cement12"
+	},
 /area/lv522/outdoors/colony_streets/south_street)
 "gck" = (
 /obj/structure/pipes/standard/manifold/hidden/green,
@@ -14480,8 +14442,8 @@
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/mining)
 "glV" = (
-/obj/structure/platform{
-	dir = 1
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_full"
 	},
 /obj/item/stack/sheet/wood,
 /turf/open/asphalt/cement{
@@ -14696,11 +14658,13 @@
 	},
 /area/lv522/indoors/a_block/admin)
 "gqG" = (
-/obj/structure/machinery/fuelcell_recycler,
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/obj/structure/platform,
+/obj/structure/stairs/perspective{
+	dir = 8;
+	icon_state = "p_stair_full"
 	},
-/area/lv522/atmos/east_reactor)
+/turf/open/gm/river,
+/area/lv522/atmos/sewer)
 "grg" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/machinery/light{
@@ -14726,14 +14690,14 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/a_block/dorms)
 "grz" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
-	pixel_y = 6
+/obj/structure/platform_decoration{
+	dir = 1
 	},
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/obj/structure/platform_decoration{
+	dir = 8
 	},
-/area/lv522/atmos/east_reactor)
+/turf/open/gm/river,
+/area/lv522/atmos/sewer)
 "grP" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison,
@@ -14966,12 +14930,11 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/a_block/bridges/corpo)
 "gwk" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+/obj/structure/prop/static_tank/water,
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
 	},
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor/plating,
-/area/lv522/atmos/east_reactor)
+/area/lv522/atmos/sewer)
 "gwt" = (
 /obj/structure/cargo_container/wy/right,
 /turf/open/floor/prison,
@@ -15132,18 +15095,6 @@
 /obj/structure/barricade/deployable,
 /turf/open/floor/prison,
 /area/lv522/atmos/cargo_intake)
-"gzw" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "SW-out";
-	pixel_x = -1;
-	pixel_y = -1
-	},
-/obj/effect/landmark/corpsespawner/wy/manager,
-/turf/open/floor{
-	dir = 4;
-	icon_state = "whiteyellowfull"
-	},
-/area/lv522/oob/w_y_vault)
 "gzD" = (
 /obj/structure/prop/almayer/computers/sensor_computer3,
 /turf/open/floor/corsat{
@@ -15167,9 +15118,6 @@
 /obj/structure/stairs/perspective{
 	dir = 9;
 	icon_state = "p_stair_full"
-	},
-/obj/structure/platform_decoration{
-	dir = 1
 	},
 /turf/open/asphalt/cement{
 	icon_state = "cement4"
@@ -15230,7 +15178,6 @@
 	dir = 5;
 	icon_state = "p_stair_full"
 	},
-/obj/structure/platform_decoration,
 /turf/open/asphalt/cement{
 	icon_state = "cement4"
 	},
@@ -15251,7 +15198,9 @@
 /obj/item/seeds/riceseed,
 /obj/structure/closet/crate,
 /obj/item/seeds/riceseed,
-/turf/open/auto_turf/sand_white/layer0,
+/turf/open/asphalt/cement{
+	icon_state = "cement3"
+	},
 /area/lv522/outdoors/colony_streets/south_west_street)
 "gBy" = (
 /obj/effect/decal/warning_stripes{
@@ -15837,14 +15786,9 @@
 /turf/open/floor/plating,
 /area/lv522/indoors/a_block/bridges/op_centre)
 "gNN" = (
-/obj/structure/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/strata{
-	dir = 4;
-	icon_state = "white_cyan1"
-	},
-/area/lv522/oob/w_y_vault)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/lv522/atmos/sewer)
 "gOb" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -15858,12 +15802,8 @@
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/outdoors/nw_rockies)
 "gOo" = (
-/obj/structure/prop/invuln/fusion_reactor,
-/obj/structure/prop/turbine_extras,
-/turf/open/floor/corsat{
-	icon_state = "plate"
-	},
-/area/lv522/atmos/east_reactor)
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/lv522/atmos/sewer)
 "gOC" = (
 /obj/structure/pipes/vents/pump,
 /obj/effect/decal/cleanable/dirt,
@@ -15890,12 +15830,12 @@
 	},
 /area/lv522/indoors/a_block/security/glass)
 "gOG" = (
-/obj/structure/prop/turbine_extras/border,
-/obj/structure/prop/turbine,
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/obj/structure/surface/table/almayer,
+/obj/item/frame/fire_alarm,
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
 	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/atmos/sewer)
 "gOJ" = (
 /obj/item/tool/wirecutters{
 	pixel_x = -1;
@@ -16049,12 +15989,13 @@
 	},
 /area/lv522/indoors/a_block/dorms)
 "gRV" = (
-/obj/structure/prop/turbine,
-/obj/structure/prop/turbine_extras/border,
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/obj/structure/bed/chair{
+	dir = 4
 	},
-/area/lv522/atmos/east_reactor)
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
+	},
+/area/lv522/atmos/sewer)
 "gSn" = (
 /turf/open/floor/corsat{
 	icon_state = "marked"
@@ -16823,12 +16764,12 @@
 	},
 /area/lv522/indoors/c_block/cargo)
 "heF" = (
-/obj/structure/prop/server_equipment/yutani_server,
-/turf/open/floor/corsat{
-	dir = 1;
-	icon_state = "brown"
+/obj/structure/surface/table/almayer,
+/obj/item/storage/belt/utility,
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
 	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/atmos/sewer)
 "heO" = (
 /obj/structure/machinery/camera/autoname{
 	dir = 4
@@ -16842,14 +16783,10 @@
 	},
 /area/lv522/indoors/b_block/hydro)
 "heU" = (
-/obj/structure/prop/server_equipment/yutani_server/broken{
-	layer = 2.9
-	},
-/turf/open/floor/corsat{
-	dir = 1;
-	icon_state = "brown"
-	},
-/area/lv522/atmos/east_reactor)
+/obj/structure/blocker/invisible_wall,
+/obj/structure/platform_decoration,
+/turf/open/floor/plating,
+/area/lv522/atmos/sewer)
 "heX" = (
 /obj/structure/largecrate/random/barrel{
 	layer = 5.1;
@@ -16892,13 +16829,14 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/admin)
 "hfE" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/obj/structure/prop/server_equipment/yutani_server/off,
-/turf/open/floor/corsat{
-	dir = 1;
-	icon_state = "brown"
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 5
 	},
-/area/lv522/atmos/east_reactor)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
+	},
+/area/lv522/atmos/sewer)
 "hfS" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison,
@@ -16921,15 +16859,16 @@
 	},
 /area/lv522/indoors/b_block/bridge)
 "hgo" = (
-/obj/structure/stairs/perspective{
-	dir = 9;
-	icon_state = "p_stair_full"
+/obj/item/storage/backpack/marine/satchel{
+	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
+	icon = 'icons/obj/janitor.dmi';
+	icon_state = "trashbag3";
+	name = "trash bag";
+	pixel_x = -4;
+	pixel_y = 5
 	},
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "greenfull"
-	},
-/area/lv522/indoors/b_block/hydro)
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/lv522/atmos/sewer)
 "hgr" = (
 /obj/structure/girder/reinforced,
 /turf/open/auto_turf/shale/layer1,
@@ -16965,14 +16904,12 @@
 	},
 /area/lv522/atmos/east_reactor/west)
 "hgQ" = (
-/obj/structure/prop/ice_colony/ground_wire{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 5
 	},
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor/corsat{
-	icon_state = "brown"
-	},
-/area/lv522/atmos/east_reactor)
+/turf/open/floor/prison,
+/area/lv522/atmos/sewer)
 "hhb" = (
 /obj/structure/platform{
 	dir = 4
@@ -18568,14 +18505,15 @@
 	},
 /area/lv522/outdoors/colony_streets/south_east_street)
 "hME" = (
-/obj/effect/decal{
-	icon = 'icons/mob/xenos/effects.dmi';
-	icon_state = "acid_weak";
-	layer = 2;
-	name = "weak acid"
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
+	pixel_x = 1;
+	pixel_y = -1
 	},
-/turf/open/floor/corsat,
-/area/lv522/atmos/east_reactor)
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
+	},
+/area/lv522/atmos/sewer)
 "hMI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -18613,10 +18551,24 @@
 	},
 /area/lv522/atmos/east_reactor/south)
 "hNj" = (
-/obj/item/stack/sheet/metal,
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor/corsat,
-/area/lv522/atmos/east_reactor)
+/obj/structure/machinery/door_control{
+	id = "Marked_6";
+	name = "Cargo Shutter Control";
+	pixel_y = 10
+	},
+/obj/structure/surface/table/almayer,
+/obj/item/prop{
+	desc = "The first page reads. 'Classified Weyland Bio-Weapons Division level eight clearance required.' The rest talks about some sort of XX-121 combat stim?";
+	icon = 'icons/obj/items/paper.dmi';
+	icon_state = "folder_black";
+	name = "Weyland classified intelligence folder";
+	pixel_y = -2
+	},
+/turf/open/floor/strata{
+	dir = 4;
+	icon_state = "white_cyan1"
+	},
+/area/lv522/oob/w_y_vault)
 "hNk" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 9
@@ -18664,9 +18616,24 @@
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/outdoors/colony_streets/north_street)
 "hNV" = (
-/obj/item/stack/rods,
-/turf/open/floor/corsat,
-/area/lv522/atmos/east_reactor)
+/obj/item/storage/backpack/marine/satchel{
+	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
+	icon = 'icons/obj/janitor.dmi';
+	icon_state = "trashbag3";
+	name = "trash bag";
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/item/storage/backpack/marine/satchel{
+	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
+	icon = 'icons/obj/janitor.dmi';
+	icon_state = "trashbag3";
+	name = "trash bag";
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/lv522/atmos/sewer)
 "hNZ" = (
 /obj/effect/spawner/gibspawner/xeno,
 /turf/open/floor/prison{
@@ -18853,11 +18820,11 @@
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/outdoors/w_rockies)
 "hRy" = (
-/obj/structure/prop/invuln/fusion_reactor,
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 10
 	},
-/area/lv522/atmos/east_reactor)
+/turf/open/floor/prison,
+/area/lv522/atmos/sewer)
 "hRz" = (
 /obj/structure/pipes/vents/pump,
 /obj/effect/decal/cleanable/dirt,
@@ -18958,13 +18925,12 @@
 	},
 /area/lv522/indoors/c_block/cargo)
 "hTI" = (
-/obj/structure/prop/server_equipment/yutani_server/off{
-	pixel_x = -4
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
 	},
-/turf/open/floor{
-	icon_state = "bcircuit"
-	},
-/area/lv522/atmos/east_reactor)
+/turf/open/floor/prison,
+/area/lv522/atmos/sewer)
 "hTW" = (
 /obj/structure/largecrate/random/secure,
 /obj/effect/landmark/lv624/fog_blocker/short,
@@ -19020,14 +18986,12 @@
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "hUY" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/corsat{
+	icon_state = "marked"
 	},
-/obj/structure/prop/almayer/computers/sensor_computer1,
-/turf/open/floor{
-	icon_state = "bcircuit"
-	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/atmos/sewer)
 "hUZ" = (
 /obj/structure/barricade/deployable,
 /obj/item/weapon/gun/rifle/m41a{
@@ -19036,11 +19000,9 @@
 /turf/open/floor/prison,
 /area/lv522/atmos/cargo_intake)
 "hVk" = (
-/obj/item/stack/sheet/metal,
-/turf/open/floor{
-	icon_state = "bcircuit"
-	},
-/area/lv522/atmos/east_reactor)
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor/prison,
+/area/lv522/atmos/sewer)
 "hVu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
@@ -19123,13 +19085,12 @@
 /turf/closed/wall/mineral/bone_resin,
 /area/lv522/oob)
 "hXA" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/obj/structure/pipes/standard/simple/hidden/green,
+/obj/structure/closet/firecloset/full,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/corsat{
-	dir = 9;
-	icon_state = "brown"
+	icon_state = "marked"
 	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/atmos/sewer)
 "hXO" = (
 /obj/structure/prop/invuln/ice_prefab{
 	dir = 10
@@ -19143,12 +19104,8 @@
 	},
 /area/lv522/outdoors/colony_streets/central_streets)
 "hXP" = (
-/obj/item/prop/alien/hugger,
-/turf/open/floor/corsat{
-	dir = 5;
-	icon_state = "brown"
-	},
-/area/lv522/atmos/east_reactor)
+/turf/closed/wall/r_wall/biodome/biodome_unmeltable,
+/area/lv522/oob/w_y_vault)
 "hXW" = (
 /obj/item/storage/firstaid/adv/empty,
 /turf/open/floor/prison{
@@ -19157,19 +19114,11 @@
 	},
 /area/lv522/indoors/a_block/hallway)
 "hXZ" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "w-y1"
 	},
-/obj/effect/decal{
-	icon = 'icons/mob/xenos/effects.dmi';
-	icon_state = "acid_weak";
-	layer = 2;
-	name = "weak acid"
-	},
-/turf/open/floor{
-	icon_state = "bcircuit"
-	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/oob/w_y_vault)
 "hYf" = (
 /turf/open/floor/prison{
 	icon_state = "floor_plate"
@@ -19183,14 +19132,12 @@
 	},
 /area/lv522/atmos/east_reactor/south)
 "hYk" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "w-y2"
 	},
-/obj/item/stack/sheet/metal,
-/turf/open/floor{
-	icon_state = "bcircuit"
-	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/oob/w_y_vault)
 "hYn" = (
 /obj/item/tool/pen/blue/clicky{
 	pixel_x = 6
@@ -19232,13 +19179,14 @@
 	},
 /area/lv522/outdoors/colony_streets/windbreaker/observation)
 "hZn" = (
-/obj/structure/prop/server_equipment/yutani_server{
-	pixel_x = -4
+/obj/structure/machinery/light{
+	dir = 4
 	},
-/turf/open/floor{
-	icon_state = "bcircuit"
+/turf/open/floor/strata{
+	dir = 4;
+	icon_state = "white_cyan1"
 	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/oob/w_y_vault)
 "hZC" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/metal/medium_stack,
@@ -19247,16 +19195,15 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/c_block/mining)
 "hZK" = (
-/obj/structure/prop/server_equipment/yutani_server/broken{
-	pixel_x = 3
+/obj/structure/platform{
+	dir = 8
 	},
-/obj/structure/prop/server_equipment{
-	pixel_x = -16
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
 	},
-/turf/open/floor{
-	icon_state = "bcircuit"
-	},
-/area/lv522/atmos/east_reactor)
+/turf/open/gm/river,
+/area/lv522/atmos/sewer)
 "hZL" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4
@@ -19394,14 +19341,12 @@
 	},
 /area/lv522/atmos/cargo_intake)
 "icr" = (
-/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
-	dir = 1
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
 	},
-/turf/open/floor/corsat{
-	dir = 9;
-	icon_state = "brown"
-	},
-/area/lv522/atmos/east_reactor)
+/turf/open/gm/river,
+/area/lv522/atmos/sewer)
 "icy" = (
 /obj/item/prop/alien/hugger,
 /turf/open/floor/prison,
@@ -19411,25 +19356,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/lv522/indoors/lone_buildings/storage_blocks)
-"icM" = (
-/obj/structure/machinery/door_control{
-	id = "Marked_6";
-	name = "Cargo Shutter Control";
-	pixel_y = 10
-	},
-/obj/structure/surface/table/almayer,
-/obj/item/prop{
-	desc = "The first page reads. 'Classified Weyland Bio-Weapons Division level eight clearance required.' The rest talks about some sort of XX-121 combat stim?";
-	icon = 'icons/obj/items/paper.dmi';
-	icon_state = "folder_black";
-	name = "Weyland classified intelligence folder";
-	pixel_y = -2
-	},
-/turf/open/floor/strata{
-	dir = 4;
-	icon_state = "white_cyan1"
-	},
-/area/lv522/oob/w_y_vault)
 "icT" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -19462,13 +19388,15 @@
 	},
 /area/lv522/atmos/east_reactor/west)
 "idq" = (
-/obj/structure/machinery/power/apc/weak{
-	dir = 1
+/obj/structure/platform{
+	dir = 4
 	},
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
 	},
-/area/lv522/atmos/east_reactor)
+/turf/open/gm/river,
+/area/lv522/atmos/sewer)
 "idt" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -19514,14 +19442,15 @@
 /turf/closed/wall/solaris/reinforced/hull/lv522,
 /area/lv522/oob)
 "ier" = (
-/obj/structure/bed/chair/comfy{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
 	},
-/turf/open/floor/corsat{
-	dir = 9;
-	icon_state = "brown"
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
 	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/atmos/sewer)
 "ieE" = (
 /obj/item/ammo_magazine/rifle/heap{
 	current_rounds = 0
@@ -19566,14 +19495,16 @@
 /turf/open/floor/plating,
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "ifh" = (
-/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
-	dir = 1;
-	pixel_y = 6
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_x = 1;
+	pixel_y = 1
 	},
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
 	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/oob/w_y_vault)
 "ifi" = (
 /obj/structure/cargo_container/hd/left/alt,
 /turf/open/floor/corsat{
@@ -19611,14 +19542,15 @@
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/north_east_street)
 "igp" = (
-/obj/structure/bed/chair/comfy{
-	dir = 1
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
 	},
-/turf/open/floor/corsat{
-	dir = 1;
-	icon_state = "brown"
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
 	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/oob/w_y_vault)
 "igv" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal3";
@@ -19633,16 +19565,17 @@
 /turf/open/floor/wood,
 /area/lv522/indoors/a_block/fitness/glass)
 "igA" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/obj/structure/reagent_dispensers/water_cooler/stacks{
-	density = 0;
-	pixel_y = 24
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	layer = 2.5;
+	pixel_x = -1;
+	pixel_y = 1
 	},
-/turf/open/floor/corsat{
-	dir = 5;
-	icon_state = "brown"
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
 	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/oob/w_y_vault)
 "igL" = (
 /obj/structure/machinery/disposal,
 /turf/open/floor/prison{
@@ -19972,7 +19905,6 @@
 /area/lv522/outdoors/nw_rockies)
 "ioD" = (
 /obj/structure/prop/structure_lattice,
-/obj/structure/platform,
 /turf/open/asphalt/cement{
 	icon_state = "cement4"
 	},
@@ -20027,21 +19959,6 @@
 	icon_state = "white_cyan2"
 	},
 /area/lv522/indoors/toilet)
-"ipH" = (
-/obj/structure/surface/table/almayer,
-/obj/item/stack/sheet/mineral/gold{
-	amount = 60;
-	pixel_y = 6
-	},
-/obj/item/stack/sheet/mineral/gold{
-	amount = 60;
-	pixel_y = 12
-	},
-/turf/open/floor/strata{
-	dir = 4;
-	icon_state = "white_cyan1"
-	},
-/area/lv522/oob/w_y_vault)
 "ipN" = (
 /obj/structure/pipes/standard/manifold/hidden/green{
 	dir = 8
@@ -20199,17 +20116,9 @@
 	},
 /area/lv522/atmos/cargo_intake)
 "isL" = (
-/obj/structure/surface/table/almayer,
-/obj/item/spacecash/c1000,
-/obj/item/spacecash/c1000,
-/obj/item/spacecash/c1000,
-/obj/item/spacecash/c1000,
-/obj/item/spacecash/c1000,
-/obj/item/spacecash/c1000,
-/obj/item/spacecash/c1000,
-/obj/item/spacecash/c1000,
-/obj/item/spacecash/c1000,
-/obj/item/spacecash/c1000,
+/obj/structure/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/strata{
 	dir = 4;
 	icon_state = "white_cyan1"
@@ -20822,6 +20731,9 @@
 	pixel_y = 5
 	},
 /obj/item/tool/pen/blue/clicky,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
+/obj/effect/landmark/xeno_spawn,
+/obj/effect/landmark/corpsespawner/colonist/burst,
 /turf/open/floor/corsat{
 	icon_state = "plate"
 	},
@@ -20839,11 +20751,22 @@
 /turf/open/shuttle/dropship/can_surgery/light_grey_single_wide_left_to_right,
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "iGl" = (
-/obj/structure/machinery/door/airlock/almayer/engineering,
-/turf/open/floor/corsat{
-	icon_state = "marked"
+/obj/structure/surface/table/almayer,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/turf/open/floor/strata{
+	dir = 4;
+	icon_state = "white_cyan1"
 	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/oob/w_y_vault)
 "iGn" = (
 /obj/structure/largecrate/random/barrel{
 	layer = 3.2;
@@ -21156,17 +21079,11 @@
 	},
 /area/lv522/indoors/a_block/bridges/garden_bridge)
 "iLC" = (
-/obj/structure/stairs/perspective{
-	dir = 1;
-	icon_state = "p_stair_full"
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
 	},
-/obj/structure/pipes/standard/simple/hidden/green,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison{
-	dir = 9;
-	icon_state = "greenfull"
-	},
-/area/lv522/indoors/b_block/hydro)
+/turf/open/floor/prison,
+/area/lv522/atmos/sewer)
 "iMv" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/corsat,
@@ -21421,12 +21338,13 @@
 /area/lv522/indoors/a_block/admin)
 "iQR" = (
 /obj/structure/stairs/perspective{
-	dir = 5;
+	dir = 6;
 	icon_state = "p_stair_full"
 	},
-/obj/structure/platform_decoration,
-/turf/open/asphalt/cement,
-/area/lv522/outdoors/colony_streets/east_central_street)
+/turf/open/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/lv522/outdoors/colony_streets/south_east_street)
 "iRa" = (
 /obj/structure/largecrate/random,
 /obj/effect/decal/cleanable/dirt,
@@ -21440,13 +21358,12 @@
 /turf/open/floor/plating,
 /area/lv522/outdoors/colony_streets/north_east_street)
 "iRV" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
-/obj/effect/landmark/corpsespawner/colonist/burst,
-/turf/open/floor/corsat{
-	dir = 1;
-	icon_state = "brown"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_full"
 	},
-/area/lv522/atmos/east_reactor/south)
+/turf/open/floor/plating,
+/area/lv522/indoors/c_block/cargo)
 "iRW" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -21477,12 +21394,9 @@
 /turf/open/auto_turf/shale/layer2,
 /area/lv522/outdoors/colony_streets/north_west_street)
 "iSF" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/prop/server_equipment/laptop/on,
-/turf/open/floor/corsat{
-	icon_state = "plate"
-	},
-/area/lv522/atmos/east_reactor)
+/obj/structure/largecrate/random,
+/turf/open/floor/plating,
+/area/lv522/indoors/c_block/cargo)
 "iTb" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/prop/almayer/computer/PC{
@@ -21511,12 +21425,34 @@
 	},
 /area/lv522/indoors/a_block/security)
 "iTn" = (
-/obj/structure/bed/chair/comfy,
-/turf/open/floor/corsat{
-	dir = 10;
-	icon_state = "brown"
+/obj/structure/closet/crate/freezer{
+	layer = 3
 	},
-/area/lv522/atmos/east_reactor)
+/obj/item/reagent_container/food/snacks/grown/orange,
+/obj/item/reagent_container/food/snacks/grown/orange,
+/obj/item/reagent_container/food/snacks/grown/orange,
+/obj/item/reagent_container/food/snacks/grown/orange,
+/obj/item/reagent_container/food/snacks/grown/orange,
+/obj/item/reagent_container/food/snacks/grown/orange,
+/obj/item/reagent_container/food/snacks/grown/orange,
+/obj/item/reagent_container/food/snacks/grown/orange,
+/obj/item/reagent_container/food/snacks/grown/orange,
+/obj/item/reagent_container/food/snacks/grown/orange,
+/obj/item/reagent_container/food/snacks/grown/orange,
+/obj/item/reagent_container/food/snacks/grown/orange,
+/obj/item/reagent_container/food/snacks/grown/orange,
+/obj/item/reagent_container/food/snacks/grown/orange,
+/obj/item/reagent_container/food/snacks/grown/orange,
+/obj/item/reagent_container/food/snacks/grown/orange,
+/obj/item/reagent_container/food/snacks/grown/orange,
+/obj/item/reagent_container/food/snacks/grown/orange,
+/obj/item/reagent_container/food/snacks/grown/orange,
+/obj/item/reagent_container/food/snacks/grown/orange,
+/obj/item/reagent_container/food/snacks/grown/orange,
+/obj/item/reagent_container/food/snacks/grown/orange,
+/obj/item/reagent_container/food/snacks/grown/orange,
+/turf/open/floor/plating,
+/area/lv522/indoors/c_block/cargo)
 "iTF" = (
 /obj/item/ammo_box/magazine/m4ra/ap/empty,
 /obj/effect/decal/cleanable/dirt,
@@ -21586,22 +21522,13 @@
 	},
 /area/lv522/indoors/a_block/dorms)
 "iUT" = (
-/obj/structure/prop/ice_colony/ground_wire{
-	dir = 8
-	},
-/turf/open/floor/corsat{
-	dir = 8;
-	icon_state = "browncorner"
-	},
-/area/lv522/atmos/east_reactor)
+/obj/structure/machinery/squeezer,
+/turf/open/floor/plating,
+/area/lv522/indoors/c_block/cargo)
 "iUX" = (
-/obj/structure/prop/ice_colony/ground_wire{
-	dir = 4
-	},
-/turf/open/floor/corsat{
-	icon_state = "browncorner"
-	},
-/area/lv522/atmos/east_reactor)
+/obj/structure/platform,
+/turf/open/asphalt/cement,
+/area/lv522/outdoors/colony_streets/south_street)
 "iVe" = (
 /obj/structure/stairs/perspective{
 	dir = 5;
@@ -21614,12 +21541,13 @@
 	},
 /area/lv522/indoors/a_block/hallway)
 "iVk" = (
-/obj/structure/bed/chair/comfy,
-/turf/open/floor/corsat{
-	dir = 6;
-	icon_state = "brown"
+/obj/structure/platform_decoration{
+	dir = 1
 	},
-/area/lv522/atmos/east_reactor)
+/turf/open/asphalt/cement{
+	icon_state = "cement9"
+	},
+/area/lv522/outdoors/colony_streets/south_street)
 "iVm" = (
 /obj/item/storage/backpack/marine/satchel{
 	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
@@ -21640,14 +21568,11 @@
 	},
 /area/lv522/indoors/a_block/admin)
 "iVU" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/prop/almayer/computer/PC{
-	dir = 8
+/obj/structure/platform_decoration,
+/turf/open/asphalt/cement{
+	icon_state = "cement2"
 	},
-/turf/open/floor/corsat{
-	icon_state = "plate"
-	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/outdoors/colony_streets/south_street)
 "iVY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spider/spiderling/nogrow,
@@ -22118,20 +22043,23 @@
 	},
 /area/lv522/atmos/east_reactor/south)
 "jey" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
-/obj/effect/landmark/corpsespawner/colonist/burst,
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/obj/structure/pipes/standard/simple/hidden/green,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison{
+	dir = 9;
+	icon_state = "greenfull"
 	},
-/area/lv522/atmos/east_reactor/south)
+/area/lv522/indoors/b_block/bridge)
 "jeD" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/faxmachine,
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
 	},
-/area/lv522/atmos/east_reactor)
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/asphalt/cement,
+/area/lv522/outdoors/colony_streets/south_street)
 "jeH" = (
 /obj/structure/machinery/light,
 /obj/structure/pipes/vents/pump,
@@ -22203,14 +22131,14 @@
 	},
 /area/lv522/atmos/way_in_command_centre)
 "jfK" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/prop/almayer/computer/PC{
-	dir = 1
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_full"
 	},
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/obj/structure/platform{
+	dir = 4
 	},
-/area/lv522/atmos/east_reactor)
+/turf/open/asphalt/cement,
+/area/lv522/outdoors/colony_streets/south_street)
 "jfO" = (
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/kitchen/glass)
@@ -22303,37 +22231,32 @@
 	},
 /area/lv522/atmos/east_reactor)
 "jhY" = (
-/obj/structure/surface/table/almayer,
-/obj/item/clothing/glasses/meson,
-/obj/item/prop/alien/hugger,
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/obj/structure/platform{
+	dir = 4
 	},
-/area/lv522/atmos/east_reactor)
+/turf/open/asphalt/cement,
+/area/lv522/outdoors/colony_streets/south_west_street)
 "jic" = (
-/obj/structure/surface/table/almayer,
-/obj/item/reagent_container/food/snacks/cheeseburger{
-	pixel_y = 5
+/obj/structure/platform{
+	dir = 1
 	},
-/obj/item/trash/burger,
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/obj/structure/machinery/colony_floodlight,
+/obj/structure/platform{
+	dir = 8
 	},
-/area/lv522/atmos/east_reactor)
+/obj/structure/platform_decoration{
+	dir = 5
+	},
+/turf/open/asphalt/cement,
+/area/lv522/outdoors/colony_streets/south_street)
 "jig" = (
-/obj/structure/surface/table/almayer,
-/obj/item/clothing/head/hardhat{
-	pixel_x = -7;
-	pixel_y = 8
+/obj/structure/platform_decoration{
+	dir = 4
 	},
-/obj/item/clothing/head/hardhat{
-	pixel_x = 8;
-	pixel_y = 14
+/turf/open/asphalt/cement{
+	icon_state = "cement12"
 	},
-/turf/open/floor/corsat{
-	icon_state = "plate"
-	},
-/area/lv522/atmos/east_reactor)
+/area/lv522/outdoors/colony_streets/south_street)
 "jin" = (
 /obj/structure/filtration/machine_96x96/indestructible{
 	icon_state = "sedimentation_A_1";
@@ -23574,13 +23497,13 @@
 	},
 /area/lv522/atmos/cargo_intake)
 "jCQ" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/corsat{
-	dir = 8;
-	icon_state = "browncorner"
+/obj/structure/platform_decoration{
+	dir = 8
 	},
-/area/lv522/atmos/east_reactor/south)
+/turf/open/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/lv522/outdoors/colony_streets/south_street)
 "jCS" = (
 /obj/item/trash/wy_chips_pepper,
 /obj/structure/machinery/light{
@@ -23658,9 +23581,6 @@
 	density = 0;
 	pixel_y = 16
 	},
-/obj/structure/platform_decoration{
-	dir = 4
-	},
 /turf/open/gm/river,
 /area/lv522/atmos/sewer)
 "jDO" = (
@@ -23684,10 +23604,11 @@
 "jEk" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
-/obj/effect/landmark/xeno_spawn,
 /obj/structure/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/corpsespawner/colonist/burst,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/corsat{
 	icon_state = "plate"
 	},
@@ -23927,11 +23848,14 @@
 	},
 /area/lv522/outdoors/n_rockies)
 "jIQ" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+/obj/structure/machinery/colony_floodlight{
+	layer = 4.3
 	},
-/turf/open/floor/plating,
-/area/lv522/atmos/east_reactor)
+/obj/structure/platform{
+	dir = 1
+	},
+/turf/open/asphalt/cement,
+/area/lv522/outdoors/colony_streets/south_street)
 "jIR" = (
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/gm/river,
@@ -25513,12 +25437,13 @@
 	},
 /area/lv522/atmos/west_reactor)
 "kkq" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/obj/structure/machinery/light,
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/obj/structure/platform_decoration{
+	dir = 8
 	},
-/area/lv522/atmos/east_reactor)
+/turf/open/asphalt/cement{
+	icon_state = "cement3"
+	},
+/area/lv522/outdoors/colony_streets/south_west_street)
 "kkr" = (
 /obj/structure/prop/ice_colony/ground_wire{
 	dir = 8
@@ -26793,11 +26718,13 @@
 	},
 /area/lv522/indoors/a_block/security)
 "kHX" = (
-/turf/open/floor/corsat{
-	dir = 10;
-	icon_state = "brown"
+/obj/structure/platform_decoration{
+	dir = 4
 	},
-/area/lv522/atmos/east_reactor)
+/turf/open/asphalt/cement{
+	icon_state = "cement1"
+	},
+/area/lv522/outdoors/colony_streets/south_street)
 "kHZ" = (
 /obj/structure/surface/table/almayer,
 /obj/item/tool/weldpack{
@@ -26990,15 +26917,13 @@
 	},
 /area/lv522/atmos/filt)
 "kLO" = (
-/obj/structure/stairs/perspective{
-	dir = 1;
-	icon_state = "p_stair_full"
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out"
 	},
-/turf/open/floor/prison{
-	dir = 9;
-	icon_state = "greenfull"
+/turf/open/asphalt/cement{
+	icon_state = "cement3"
 	},
-/area/lv522/indoors/b_block/hydro)
+/area/lv522/outdoors/colony_streets/south_west_street)
 "kLQ" = (
 /obj/structure/cargo_container/grant/right,
 /turf/open/auto_turf/shale/layer1,
@@ -27907,7 +27832,9 @@
 /area/lv522/indoors/a_block/admin)
 "lbH" = (
 /obj/structure/largecrate/random,
-/turf/open/auto_turf/shale/layer1,
+/turf/open/asphalt/cement{
+	icon_state = "cement12"
+	},
 /area/lv522/outdoors/colony_streets/south_street)
 "lbI" = (
 /obj/structure/surface/table/almayer,
@@ -28297,6 +28224,7 @@
 "ljQ" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
 /obj/effect/landmark/corpsespawner/colonist/burst,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/corsat{
 	dir = 8;
 	icon_state = "brown"
@@ -28802,12 +28730,11 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/a_block/security)
 "lul" = (
-/obj/structure/surface/table/almayer,
-/obj/item/frame/fire_alarm,
-/turf/open/floor/prison{
-	icon_state = "floor_plate"
+/obj/structure/platform_decoration,
+/turf/open/asphalt/cement{
+	icon_state = "cement3"
 	},
-/area/lv522/atmos/sewer)
+/area/lv522/outdoors/colony_streets/south_west_street)
 "lum" = (
 /obj/structure/platform,
 /obj/structure/platform{
@@ -28832,7 +28759,9 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
 	},
-/turf/open/auto_turf/sand_white/layer0,
+/turf/open/asphalt/cement{
+	icon_state = "cement3"
+	},
 /area/lv522/outdoors/colony_streets/south_west_street)
 "lvF" = (
 /obj/item/tool/surgery/circular_saw,
@@ -28887,7 +28816,9 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 10
 	},
-/turf/open/floor/plating/plating_catwalk/prison,
+/turf/open/floor/prison{
+	icon_state = "floor_plate"
+	},
 /area/lv522/atmos/sewer)
 "lwv" = (
 /obj/structure/machinery/light{
@@ -29220,9 +29151,6 @@
 /obj/structure/stairs/perspective{
 	dir = 10;
 	icon_state = "p_stair_full"
-	},
-/obj/structure/platform_decoration{
-	dir = 4
 	},
 /turf/open/asphalt/cement{
 	icon_state = "cement12"
@@ -30300,7 +30228,6 @@
 /area/lv522/indoors/b_block/bar)
 "mad" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -31030,8 +30957,13 @@
 	},
 /area/lv522/atmos/filt)
 "moe" = (
-/turf/closed/wall/strata_outpost,
-/area/lv522/oob/w_y_vault)
+/obj/structure/stairs/perspective{
+	dir = 8;
+	icon_state = "p_stair_full"
+	},
+/obj/structure/platform,
+/turf/open/asphalt/cement,
+/area/lv522/outdoors/colony_streets/south_west_street)
 "moz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/light{
@@ -32045,7 +31977,6 @@
 /obj/structure/cargo_container/kelland/left{
 	layer = 2.9
 	},
-/obj/structure/platform,
 /turf/open/asphalt/cement{
 	icon_state = "cement4"
 	},
@@ -32285,9 +32216,13 @@
 /turf/open/shuttle/dropship/can_surgery/light_grey_bottom_left,
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "mNI" = (
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "w-y1"
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	pixel_y = -1
+	},
+/turf/open/floor{
+	dir = 4;
+	icon_state = "whiteyellowfull"
 	},
 /area/lv522/oob/w_y_vault)
 "mNR" = (
@@ -32566,9 +32501,13 @@
 	},
 /area/lv522/indoors/a_block/kitchen)
 "mRh" = (
-/obj/structure/window/framed/corsat,
-/turf/open/floor/corsat,
-/area/lv522/atmos/east_reactor)
+/obj/structure/stairs/perspective{
+	dir = 4;
+	icon_state = "p_stair_full"
+	},
+/obj/structure/platform,
+/turf/open/asphalt/cement,
+/area/lv522/outdoors/colony_streets/south_street)
 "mRs" = (
 /obj/item/prop/colony/used_flare,
 /turf/open/auto_turf/shale/layer1,
@@ -32702,21 +32641,6 @@
 	},
 /turf/open/floor/plating,
 /area/lv522/atmos/filt)
-"mUo" = (
-/obj/structure/platform{
-	dir = 8
-	},
-/obj/structure/blocker/invisible_wall,
-/obj/structure/prop/invuln{
-	desc = "big pile energy.";
-	icon = 'icons/obj/structures/props/ice_colony/barrel_yard.dmi';
-	icon_state = "pile_0";
-	layer = 2.9;
-	name = "barrel pile";
-	pixel_y = 3
-	},
-/turf/open/floor/plating,
-/area/lv522/indoors/c_block/cargo)
 "mUr" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -33023,18 +32947,6 @@
 /obj/structure/machinery/landinglight/ds1/delaythree,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1)
-"naZ" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/obj/structure/stairs/perspective{
-	dir = 6;
-	icon_state = "p_stair_full"
-	},
-/turf/open/asphalt/cement{
-	icon_state = "cement12"
-	},
-/area/lv522/outdoors/colony_streets/south_east_street)
 "nbg" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -33113,8 +33025,9 @@
 	},
 /area/lv522/atmos/cargo_intake)
 "ncg" = (
-/obj/structure/platform{
-	dir = 8
+/obj/structure/stairs/perspective{
+	dir = 4;
+	icon_state = "p_stair_full"
 	},
 /turf/open/asphalt/cement{
 	icon_state = "cement1"
@@ -33198,7 +33111,9 @@
 	icon_state = "NW-out";
 	pixel_y = 1
 	},
-/turf/open/auto_turf/sand_white/layer0,
+/turf/open/asphalt/cement{
+	icon_state = "cement3"
+	},
 /area/lv522/outdoors/colony_streets/south_west_street)
 "nee" = (
 /obj/structure/pipes/standard/manifold/hidden/green,
@@ -33626,11 +33541,13 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/c_block/casino)
 "nlY" = (
-/obj/structure/platform{
+/obj/structure/platform_decoration{
 	dir = 1
 	},
-/turf/open/asphalt/cement,
-/area/lv522/outdoors/colony_streets/east_central_street)
+/turf/open/asphalt/cement{
+	icon_state = "cement1"
+	},
+/area/lv522/outdoors/colony_streets/south_street)
 "nmh" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/structure/machinery/prop/almayer/computer/PC{
@@ -33774,7 +33691,6 @@
 /obj/effect/decal/cleanable/blood/xeno{
 	icon_state = "xgib3"
 	},
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -34435,11 +34351,10 @@
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/outdoors/w_rockies)
 "nCC" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
-	icon_state = "NW-out";
-	layer = 2.5;
-	pixel_x = -1;
-	pixel_y = 1
+	icon_state = "W";
+	pixel_x = -1
 	},
 /turf/open/floor{
 	dir = 4;
@@ -34491,7 +34406,10 @@
 "nDI" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/trash/wy_chips_pepper,
-/obj/structure/platform,
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
 /turf/open/asphalt/cement,
 /area/lv522/outdoors/colony_streets/east_central_street)
 "nDM" = (
@@ -35250,13 +35168,14 @@
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/central_streets)
 "nRy" = (
-/obj/structure/closet/fireaxecabinet{
-	pixel_y = 29
+/obj/structure/machinery/colony_floodlight{
+	layer = 4.3
 	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate"
+/obj/structure/platform{
+	dir = 8
 	},
-/area/lv522/atmos/sewer)
+/turf/open/asphalt/cement,
+/area/lv522/outdoors/colony_streets/south_street)
 "nRI" = (
 /obj/item/ammo_magazine/rifle/heap{
 	current_rounds = 0
@@ -35362,10 +35281,6 @@
 	},
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/dorm_north)
-"nTj" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/closed/wall/strata_outpost/reinforced/hull,
-/area/lv522/oob/w_y_vault)
 "nTl" = (
 /turf/closed/wall/r_wall/biodome/biodome_unmeltable,
 /area/lv522/atmos/east_reactor)
@@ -35760,8 +35675,9 @@
 /area/lv522/atmos/cargo_intake)
 "oan" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	pixel_x = 1
+	icon_state = "SE-out";
+	pixel_x = 1;
+	pixel_y = -1
 	},
 /turf/open/floor{
 	dir = 4;
@@ -36330,29 +36246,6 @@
 	icon_state = "floor_plate"
 	},
 /area/lv522/indoors/a_block/hallway)
-"okj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/backpack/marine/satchel{
-	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
-	icon = 'icons/obj/janitor.dmi';
-	icon_state = "trashbag3";
-	name = "trash bag";
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/obj/item/storage/backpack/marine/satchel{
-	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
-	icon = 'icons/obj/janitor.dmi';
-	icon_state = "trashbag3";
-	name = "trash bag";
-	pixel_x = 3;
-	pixel_y = -2
-	},
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "cell_stripe"
-	},
-/area/lv522/atmos/sewer)
 "okA" = (
 /obj/structure/surface/rack,
 /obj/structure/machinery/camera/autoname{
@@ -36540,9 +36433,7 @@
 /obj/structure/platform{
 	dir = 8
 	},
-/obj/structure/largecrate/random{
-	layer = 2.9
-	},
+/obj/structure/ore_box,
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/cargo)
 "oqn" = (
@@ -36705,17 +36596,6 @@
 	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
-"osm" = (
-/obj/structure/transmitter/colony_net{
-	phone_category = "LV522 Chances Claim";
-	phone_color = "red";
-	phone_id = "Reactor Sewer";
-	pixel_y = 26
-	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate"
-	},
-/area/lv522/atmos/sewer)
 "osE" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper A-Block Corporate Office Airlock";
@@ -38047,14 +37927,6 @@
 "oUq" = (
 /turf/closed/wall/strata_outpost/reinforced,
 /area/lv522/atmos/way_in_command_centre)
-"oUC" = (
-/obj/structure/prop/invuln/overhead/flammable_pipe/fly{
-	pixel_y = 6
-	},
-/turf/open/floor/corsat{
-	icon_state = "plate"
-	},
-/area/lv522/atmos/east_reactor)
 "oUE" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out";
@@ -38426,9 +38298,7 @@
 	dir = 1;
 	icon_state = "p_stair_full"
 	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate"
-	},
+/turf/open/floor/prison,
 /area/lv522/atmos/sewer)
 "pdp" = (
 /obj/structure/prop/invuln/overhead_pipe{
@@ -38746,15 +38616,6 @@
 	icon_state = "floor_plate"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
-"pgJ" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
-/obj/structure/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/corsat{
-	icon_state = "squares"
-	},
-/area/lv522/atmos/east_reactor)
 "pha" = (
 /obj/structure/bed/chair{
 	can_buckle = 0;
@@ -38853,9 +38714,7 @@
 /obj/structure/platform{
 	dir = 8
 	},
-/obj/structure/largecrate/random{
-	layer = 2.9
-	},
+/obj/structure/ore_box,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/cargo)
@@ -40769,15 +40628,6 @@
 	icon_state = "darkbrownfull2"
 	},
 /area/lv522/landing_zone_2/ceiling)
-"pWC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate"
-	},
-/area/lv522/atmos/sewer)
 "pWR" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 6
@@ -41805,20 +41655,8 @@
 /turf/open/asphalt/cement,
 /area/lv522/outdoors/n_rockies)
 "qqN" = (
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_x = -8;
-	pixel_y = 16
-	},
-/obj/structure/filingcabinet{
-	density = 0;
-	pixel_x = 8;
-	pixel_y = 16
-	},
-/turf/open/floor/strata{
-	dir = 4;
-	icon_state = "white_cyan1"
-	},
+/obj/effect/landmark/lv624/fog_blocker/short,
+/turf/closed/wall/r_wall/biodome/biodome_unmeltable,
 /area/lv522/oob/w_y_vault)
 "qqR" = (
 /obj/structure/platform,
@@ -42236,17 +42074,6 @@
 	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
-"qyp" = (
-/obj/structure/transmitter/colony_net{
-	phone_category = "LV522 Chances Claim";
-	phone_color = "red";
-	phone_id = "Reactor Eastern Reactor Control";
-	pixel_y = 26
-	},
-/turf/open/floor/corsat{
-	icon_state = "plate"
-	},
-/area/lv522/atmos/east_reactor)
 "qyG" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/auto_turf/sand_white/layer0,
@@ -43396,10 +43223,6 @@
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/south_street)
 "qRF" = (
-/obj/structure/stairs/perspective{
-	dir = 5;
-	icon_state = "p_stair_full"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/camera/autoname{
 	dir = 8
@@ -44122,9 +43945,6 @@
 /area/lv522/outdoors/colony_streets/east_central_street)
 "rbZ" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/obj/structure/machinery/light{
-	dir = 8
-	},
 /turf/open/floor/corsat,
 /area/lv522/atmos/east_reactor/south)
 "rcd" = (
@@ -45669,16 +45489,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/lone_buildings/engineering)
-"rIr" = (
-/obj/structure/stairs/perspective{
-	dir = 9;
-	icon_state = "p_stair_full"
-	},
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/asphalt/cement,
-/area/lv522/outdoors/colony_streets/east_central_street)
 "rIx" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -46621,8 +46431,11 @@
 	},
 /area/lv522/indoors/a_block/bridges/dorms_fitness)
 "rZK" = (
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_full"
+	},
 /obj/structure/platform{
-	dir = 1
+	dir = 8
 	},
 /turf/open/asphalt/cement,
 /area/lv522/outdoors/colony_streets/south_street)
@@ -47465,11 +47278,12 @@
 /turf/open/floor/carpet,
 /area/lv522/indoors/b_block/bar)
 "spn" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
-	icon_state = "W";
-	pixel_x = -1
+	icon_state = "SW-out";
+	pixel_x = -1;
+	pixel_y = -1
 	},
+/obj/effect/landmark/corpsespawner/wy/manager,
 /turf/open/floor{
 	dir = 4;
 	icon_state = "whiteyellowfull"
@@ -47863,7 +47677,9 @@
 /area/lv522/indoors/a_block/hallway)
 "sxg" = (
 /obj/item/stack/rods,
-/turf/open/auto_turf/shale/layer1,
+/turf/open/asphalt/cement{
+	icon_state = "cement12"
+	},
 /area/lv522/outdoors/colony_streets/south_street)
 "sxp" = (
 /obj/structure/surface/table/almayer,
@@ -48043,17 +47859,6 @@
 "sAU" = (
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/a_block/security/glass)
-"sBg" = (
-/obj/structure/prop/server_equipment/yutani_server{
-	pixel_x = 3
-	},
-/obj/structure/prop/server_equipment{
-	pixel_x = -16
-	},
-/turf/open/floor{
-	icon_state = "bcircuit"
-	},
-/area/lv522/atmos/east_reactor)
 "sBt" = (
 /obj/structure/pipes/standard/manifold/hidden/green{
 	dir = 4
@@ -48068,13 +47873,6 @@
 	icon_state = "white_cyan1"
 	},
 /area/lv522/indoors/a_block/medical)
-"sBz" = (
-/obj/structure/platform{
-	dir = 1
-	},
-/obj/structure/machinery/squeezer,
-/turf/open/floor/plating,
-/area/lv522/indoors/c_block/cargo)
 "sBH" = (
 /obj/structure/reagent_dispensers/water_cooler/stacks{
 	density = 0;
@@ -49228,16 +49026,6 @@
 	},
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/outdoors/colony_streets/east_central_street)
-"sUj" = (
-/obj/structure/stairs/perspective{
-	dir = 6;
-	icon_state = "p_stair_full"
-	},
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/lv522/indoors/c_block/cargo)
 "sUs" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
@@ -49356,18 +49144,16 @@
 	icon_state = "rasputin15"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
-"sYk" = (
-/obj/structure/platform,
-/turf/open/asphalt/cement,
-/area/lv522/outdoors/colony_streets/north_east_street)
 "sYl" = (
 /obj/item/stack/sheet/metal,
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/outdoors/colony_streets/north_east_street)
 "sYv" = (
-/obj/structure/platform{
-	dir = 8
+/obj/structure/stairs/perspective{
+	dir = 4;
+	icon_state = "p_stair_full"
 	},
+/obj/structure/platform/stair_cut,
 /turf/open/asphalt/cement,
 /area/lv522/outdoors/colony_streets/south_street)
 "sYH" = (
@@ -49494,14 +49280,19 @@
 	},
 /area/lv522/outdoors/colony_streets/north_west_street)
 "tbK" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "SE-out";
-	pixel_x = 1;
-	pixel_y = -1
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_x = -8;
+	pixel_y = 16
 	},
-/turf/open/floor{
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_x = 8;
+	pixel_y = 16
+	},
+/turf/open/floor/strata{
 	dir = 4;
-	icon_state = "whiteyellowfull"
+	icon_state = "white_cyan1"
 	},
 /area/lv522/oob/w_y_vault)
 "tcj" = (
@@ -49607,15 +49398,10 @@
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "tdM" = (
-/obj/structure/platform{
-	dir = 1
-	},
-/obj/structure/platform{
-	dir = 8
-	},
-/obj/structure/platform_decoration{
-	dir = 5;
-	layer = 3.51
+/obj/structure/platform/stair_cut,
+/obj/structure/stairs/perspective{
+	dir = 8;
+	icon_state = "p_stair_full"
 	},
 /turf/open/gm/river,
 /area/lv522/atmos/sewer)
@@ -50451,14 +50237,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/outdoors/nw_rockies)
-"tti" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/asphalt/cement{
-	icon_state = "cement12"
-	},
-/area/lv522/outdoors/colony_streets/south_east_street)
 "ttp" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/corsat{
@@ -50678,9 +50456,7 @@
 	dir = 1;
 	icon_state = "p_stair_full"
 	},
-/turf/open/floor/prison{
-	icon_state = "floor_plate"
-	},
+/turf/open/floor/prison,
 /area/lv522/atmos/sewer)
 "tyc" = (
 /obj/structure/surface/rack,
@@ -50913,12 +50689,6 @@
 "tCN" = (
 /turf/closed/wall/strata_ice/dirty,
 /area/lv522/outdoors/colony_streets/south_east_street)
-"tCX" = (
-/turf/open/floor/corsat{
-	dir = 6;
-	icon_state = "brown"
-	},
-/area/lv522/atmos/east_reactor)
 "tDd" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 10
@@ -51087,16 +50857,6 @@
 	},
 /turf/open/floor/wood,
 /area/lv522/indoors/c_block/casino)
-"tFZ" = (
-/obj/structure/surface/table/almayer,
-/obj/item/paper_bin{
-	pixel_y = 5
-	},
-/obj/item/tool/pen/blue/clicky,
-/turf/open/floor/corsat{
-	icon_state = "plate"
-	},
-/area/lv522/atmos/east_reactor)
 "tGb" = (
 /obj/structure/prop/ice_colony/ground_wire,
 /obj/structure/prop/ice_colony/ground_wire{
@@ -51424,13 +51184,9 @@
 	},
 /area/lv522/atmos/cargo_intake)
 "tLX" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/turf/open/floor{
-	dir = 4;
-	icon_state = "whiteyellowfull"
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "w-y0"
 	},
 /area/lv522/oob/w_y_vault)
 "tMk" = (
@@ -52222,7 +51978,7 @@
 "ubF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor/plating/plating_catwalk/prison,
+/turf/open/floor/prison,
 /area/lv522/atmos/sewer)
 "ubH" = (
 /obj/structure/stairs/perspective{
@@ -54284,13 +54040,6 @@
 	icon_state = "blue_plate"
 	},
 /area/lv522/indoors/a_block/admin)
-"uNT" = (
-/obj/structure/prop/invuln/fusion_reactor,
-/obj/structure/prop/turbine_extras/left,
-/turf/open/floor/corsat{
-	icon_state = "plate"
-	},
-/area/lv522/atmos/east_reactor)
 "uNW" = (
 /obj/structure/surface/table/almayer,
 /obj/item/trash/ceramic_plate{
@@ -55110,8 +54859,8 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/dorms)
 "vdp" = (
-/obj/structure/platform{
-	dir = 1
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_full"
 	},
 /turf/open/asphalt/cement{
 	icon_state = "cement12"
@@ -55814,6 +55563,16 @@
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "vqe" = (
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_x = -8;
+	pixel_y = 16
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_x = 8;
+	pixel_y = 16
+	},
 /obj/structure/machinery/light{
 	dir = 8
 	},
@@ -55900,14 +55659,18 @@
 	},
 /area/lv522/indoors/a_block/admin)
 "vrE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes{
-	icon_state = "S";
-	pixel_y = -1
+/obj/structure/surface/table/almayer,
+/obj/item/stack/sheet/mineral/gold{
+	amount = 60;
+	pixel_y = 6
 	},
-/turf/open/floor{
+/obj/item/stack/sheet/mineral/gold{
+	amount = 60;
+	pixel_y = 12
+	},
+/turf/open/floor/strata{
 	dir = 4;
-	icon_state = "whiteyellowfull"
+	icon_state = "white_cyan1"
 	},
 /area/lv522/oob/w_y_vault)
 "vrV" = (
@@ -56923,14 +56686,6 @@
 /area/lv522/indoors/a_block/fitness)
 "vJw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/storage/backpack/marine/satchel{
-	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!";
-	icon = 'icons/obj/janitor.dmi';
-	icon_state = "trashbag3";
-	name = "trash bag";
-	pixel_x = -4;
-	pixel_y = 5
-	},
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "cell_stripe"
@@ -58392,9 +58147,8 @@
 /area/lv522/indoors/lone_buildings/outdoor_bot)
 "wjP" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "NE-out";
-	pixel_x = 1;
-	pixel_y = 1
+	icon_state = "E";
+	pixel_x = 1
 	},
 /turf/open/floor{
 	dir = 4;
@@ -58718,10 +58472,6 @@
 "wrC" = (
 /turf/closed/wall/strata_outpost,
 /area/lv522/indoors/a_block/corpo)
-"wrY" = (
-/obj/structure/platform,
-/turf/open/asphalt/cement,
-/area/lv522/outdoors/colony_streets/east_central_street)
 "wsf" = (
 /obj/structure/curtain/red,
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -61151,13 +60901,6 @@
 	icon_state = "greenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
-"xqi" = (
-/obj/structure/platform{
-	dir = 1
-	},
-/obj/structure/largecrate/random,
-/turf/open/floor/plating,
-/area/lv522/indoors/c_block/cargo)
 "xqj" = (
 /obj/effect/landmark/yautja_teleport,
 /turf/open/auto_turf/shale/layer2,
@@ -61237,14 +60980,7 @@
 /turf/open/floor/plating,
 /area/lv522/landing_zone_2)
 "xsE" = (
-/obj/structure/platform{
-	dir = 4
-	},
-/obj/structure/platform,
-/obj/structure/platform_decoration{
-	dir = 6
-	},
-/turf/open/gm/river,
+/turf/open/floor/prison,
 /area/lv522/atmos/sewer)
 "xsN" = (
 /obj/structure/largecrate/random/barrel,
@@ -61393,11 +61129,10 @@
 	},
 /area/lv522/indoors/a_block/bridges)
 "xwv" = (
-/obj/structure/platform_decoration{
-	dir = 4
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_full"
 	},
 /obj/structure/stairs/perspective{
-	dir = 10;
 	icon_state = "p_stair_full"
 	},
 /turf/open/asphalt/cement{
@@ -61583,9 +61318,6 @@
 	icon_state = "marked"
 	},
 /area/lv522/indoors/c_block/mining)
-"xAw" = (
-/turf/closed/wall/strata_outpost/reinforced/hull,
-/area/lv522/indoors/a_block/bridges/op_centre)
 "xAF" = (
 /obj/structure/pipes/standard/manifold/hidden/green{
 	dir = 4
@@ -61690,9 +61422,6 @@
 /obj/structure/stairs/perspective{
 	dir = 6;
 	icon_state = "p_stair_full"
-	},
-/obj/structure/platform_decoration{
-	dir = 8
 	},
 /turf/open/asphalt/cement{
 	icon_state = "cement12"
@@ -62282,14 +62011,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/admin)
-"xOB" = (
-/obj/structure/platform{
-	dir = 1
-	},
-/turf/open/asphalt/cement{
-	icon_state = "cement12"
-	},
-/area/lv522/outdoors/colony_streets/east_central_street)
 "xOD" = (
 /obj/item/clothing/glasses/mbcg,
 /turf/open/floor/prison,
@@ -62803,8 +62524,9 @@
 	},
 /area/lv522/outdoors/colony_streets/north_street)
 "xWO" = (
-/obj/structure/platform{
-	dir = 1
+/obj/structure/stairs/perspective{
+	dir = 10;
+	icon_state = "p_stair_full"
 	},
 /turf/open/asphalt/cement{
 	icon_state = "cement12"
@@ -63167,7 +62889,9 @@
 /obj/structure/platform{
 	dir = 8
 	},
-/obj/structure/blocker/invisible_wall,
+/obj/structure/largecrate/random{
+	layer = 2.9
+	},
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/cargo)
 "ydz" = (
@@ -79086,11 +78810,11 @@ aPu
 cGw
 wIr
 wIr
-fnA
-cxv
-ofi
-ofi
-hov
+jhY
+kkq
+uOd
+uOd
+kLO
 fTN
 fTN
 fTN
@@ -79099,8 +78823,8 @@ fTN
 lvl
 ndZ
 gBv
-pAj
-fnA
+lul
+jhY
 wIr
 wIr
 xSA
@@ -79300,10 +79024,10 @@ tSL
 tSL
 tSL
 tSL
-dbP
-cbR
-cbR
-dbP
+fnA
+uOd
+uOd
+fnA
 wIr
 wIr
 mDz
@@ -79326,7 +79050,7 @@ cbR
 cbR
 cbR
 cbR
-dbP
+moe
 wIr
 wIr
 vDL
@@ -79753,7 +79477,7 @@ tSL
 tne
 kGm
 lML
-hgo
+yfR
 wIr
 tmy
 hYL
@@ -79980,13 +79704,13 @@ lIy
 xNR
 yfS
 yfS
-kLO
+yfS
 cfz
 jmv
 tkf
 dgY
 cfz
-cHb
+aPu
 qzQ
 oLa
 uWT
@@ -80207,13 +79931,13 @@ cKi
 msj
 msj
 phu
-iLC
+wyy
 tIT
 olz
 pOs
 olz
 tIT
-skS
+jey
 iXM
 uIk
 uWT
@@ -80440,7 +80164,7 @@ tmy
 pfD
 hyf
 wIr
-ttd
+dgY
 aPu
 xgH
 uWT
@@ -80889,10 +80613,10 @@ tSL
 tSL
 tSL
 tSL
-sYv
-ncg
-ncg
-sYv
+tOo
+oIu
+oIu
+tOo
 wIr
 wIr
 pXz
@@ -80915,7 +80639,7 @@ ncg
 ncg
 ncg
 ncg
-sYv
+mRh
 wIr
 wIr
 vDL
@@ -81120,7 +80844,7 @@ lyD
 mPr
 hFX
 bCy
-tOo
+iUX
 wIr
 wIr
 hwa
@@ -81129,21 +80853,21 @@ clR
 dne
 wIr
 wIr
-dGD
-lyD
-mPr
-mPr
-mPr
-mPr
-mPr
-mPr
-nax
-nax
-mPr
-mPr
-mPr
-bCy
-dGD
+jic
+kHX
+oIu
+oIu
+oIu
+oIu
+oIu
+oIu
+oIu
+oIu
+oIu
+oIu
+oIu
+nlY
+nRy
 wIr
 wIr
 epq
@@ -81347,7 +81071,7 @@ mPr
 mPr
 hFX
 hFX
-bCy
+iVk
 bYV
 wIr
 wIr
@@ -81356,7 +81080,7 @@ mpF
 wIr
 wIr
 rZK
-lyD
+jig
 mPr
 mPr
 mPr
@@ -81583,7 +81307,7 @@ jmv
 hYL
 rQg
 vdp
-mPr
+xAR
 mPr
 tNc
 gUj
@@ -81810,7 +81534,7 @@ tkf
 hYL
 rQg
 vdp
-mPr
+xAR
 mPr
 tNc
 nax
@@ -82037,7 +81761,7 @@ tkf
 hYL
 rQg
 vdp
-mPr
+xAR
 mPr
 mPr
 iCb
@@ -82264,7 +81988,7 @@ tkf
 hYL
 rQg
 vdp
-mPr
+xAR
 mPr
 nax
 bjX
@@ -82718,7 +82442,7 @@ dgY
 wIr
 wIr
 vdp
-mPr
+xAR
 mPr
 aPe
 ylo
@@ -82945,7 +82669,7 @@ tkf
 pfD
 rQg
 vdp
-mPr
+xAR
 mPr
 uXp
 ylo
@@ -83040,17 +82764,17 @@ saC
 saC
 saC
 saC
-tTv
-tTv
-tTv
-tTv
-tTv
-tTv
-tTv
-tTv
-tTv
-tTv
-tTv
+oUq
+oUq
+oUq
+oUq
+oUq
+oUq
+oUq
+oUq
+oUq
+oUq
+oUq
 oUq
 hWC
 vcF
@@ -83270,14 +82994,14 @@ saC
 saC
 saC
 saC
-tTv
+oUq
 men
 xVB
 onM
 men
 iQb
 pXh
-tTv
+oUq
 oUq
 tTl
 bJN
@@ -83399,7 +83123,7 @@ oLa
 hYL
 rQg
 vdp
-mPr
+xAR
 qbG
 aPe
 nnG
@@ -84080,7 +83804,7 @@ tkf
 pfD
 rQg
 dQQ
-nax
+xAR
 nax
 uvg
 cfT
@@ -84307,7 +84031,7 @@ jmv
 wIr
 wIr
 glV
-mPr
+xAR
 nax
 nax
 uvg
@@ -84378,11 +84102,11 @@ hLY
 saC
 lmY
 iBI
-iQe
+hmV
 pfj
-jjV
+hdQ
 cuu
-jVC
+ban
 tiQ
 tiQ
 kEx
@@ -84394,9 +84118,9 @@ saC
 uhx
 pwX
 pwX
+qjG
 saC
-saC
-tTv
+oUq
 men
 sse
 iZS
@@ -84405,14 +84129,14 @@ wIx
 jfH
 men
 iQb
-tTv
+oUq
 bUN
 saC
 saC
 saC
 saC
 saC
-tTv
+oUq
 mVm
 sBH
 kXY
@@ -84534,7 +84258,7 @@ jmv
 wIr
 wIr
 vdp
-mPr
+xAR
 nax
 nax
 nax
@@ -84621,9 +84345,9 @@ saC
 yaj
 qjG
 qjG
-saC
-saC
-tTv
+qjG
+pwC
+oUq
 nHg
 hzV
 iZS
@@ -84631,15 +84355,15 @@ jkJ
 xLi
 men
 men
-tTv
-tTv
-tTv
+oUq
+oUq
+oUq
 saC
 saC
 saC
 saC
-tTv
-tTv
+oUq
+oUq
 mVm
 hrl
 kXY
@@ -84761,7 +84485,7 @@ tkf
 pfD
 rQg
 vdp
-mPr
+xAR
 mPr
 nax
 nax
@@ -84832,33 +84556,33 @@ hLY
 qJE
 ujg
 iDg
-iRV
+hna
 yiu
-xzu
-jCQ
-jWr
+aWX
+jef
+pfj
 xmD
 xmD
-jVC
+bXl
 miH
 saC
 saC
 saC
-qgx
+cYe
 yaj
 qjG
 qjG
-qgx
-saC
-tTv
+rbZ
+pwC
+oUq
 men
 kUF
 gWu
 neI
 xLi
 men
-tTv
-tTv
+oUq
+oUq
 oUq
 oUq
 oUq
@@ -84988,7 +84712,7 @@ tkf
 hYL
 rQg
 vdp
-mPr
+xAR
 mPr
 nax
 nax
@@ -85063,28 +84787,28 @@ iSc
 wTq
 wTq
 wTq
-jWB
+bhh
 xYD
 kry
-jjV
+cxE
 miH
 saC
 saC
 saC
-pwC
+dhJ
 yaj
 qjG
 qjG
-saC
-saC
-tTv
-tTv
+qjG
+dhJ
+oUq
+oUq
 cUA
 nMX
 pco
 jzB
-tTv
-tTv
+oUq
+oUq
 oUq
 oUq
 ucY
@@ -85215,7 +84939,7 @@ oLa
 hYL
 rQg
 vdp
-mPr
+xAR
 mPr
 mPr
 nax
@@ -85287,23 +85011,23 @@ qJE
 lmY
 iFV
 iDg
-jey
+hdQ
 jlh
 jEk
-hef
+bCd
 kmP
 xmD
-jVC
+bXl
 kXa
 saC
 saC
 saC
-pwC
+dhJ
 yaj
 qjG
 qjG
-saC
-saC
+qjG
+dhJ
 saC
 saC
 afL
@@ -85311,7 +85035,7 @@ sfc
 xSE
 bCX
 iQb
-tTv
+oUq
 oUq
 cCL
 sGv
@@ -85442,7 +85166,7 @@ dgY
 hYL
 rQg
 vdp
-mPr
+xAR
 mPr
 mPr
 mPr
@@ -85528,8 +85252,8 @@ pwC
 qjG
 yaj
 qjG
+qjG
 pwC
-saC
 saC
 saC
 saC
@@ -85538,7 +85262,7 @@ saC
 jkJ
 mIq
 iQb
-tTv
+oUq
 oUq
 vVx
 fHH
@@ -85660,16 +85384,16 @@ jmG
 xAR
 mPr
 hFX
-tEu
-bYV
+iVU
+jeD
 wIr
 wIr
 bZV
 mpF
 wIr
 wIr
-rZK
-gGM
+jfK
+jCQ
 mPr
 mPr
 mPr
@@ -85765,7 +85489,7 @@ kwg
 jkJ
 xLi
 iQb
-tTv
+oUq
 oUq
 oUq
 suS
@@ -85887,7 +85611,7 @@ jmG
 xAR
 mPr
 tEu
-tOo
+iUX
 wIr
 wIr
 pNJ
@@ -85896,7 +85620,7 @@ xnp
 tPa
 wIr
 wIr
-dGD
+jIQ
 mcO
 mPr
 mPr
@@ -85992,7 +85716,7 @@ kwg
 jkJ
 xLi
 nMw
-tTv
+oUq
 oUq
 hEJ
 kgR
@@ -86219,7 +85943,7 @@ uZV
 neI
 xLi
 men
-tTv
+oUq
 oUq
 xuQ
 fHH
@@ -87136,15 +86860,15 @@ eZF
 lfj
 lfj
 yje
+lfj
 bjd
-nTj
-nTj
-nTj
+qqN
+qqN
 sPH
-nTj
-nTj
-nTj
-cpy
+hXP
+qqN
+qqN
+qqN
 ien
 rxI
 nri
@@ -87361,17 +87085,17 @@ tiQ
 bjd
 pqQ
 tdM
-vFD
+gqG
 yje
+lfj
 bjd
-nTj
 qqN
 vqe
 bjC
-vqe
+bjC
 isL
-nTj
-ien
+iGl
+qqN
 ien
 ien
 nGU
@@ -87572,7 +87296,7 @@ saC
 cnA
 hdQ
 xmD
-xQc
+qjG
 qJE
 xQc
 qJE
@@ -87590,15 +87314,15 @@ qEQ
 lYK
 hvh
 pqQ
+lfj
 bjd
-nTj
 qqN
 tbK
 oan
 wjP
-isL
-nTj
-cpy
+ifh
+iGl
+qqN
 ien
 rxI
 nLF
@@ -87697,8 +87421,8 @@ jmG
 pjm
 opQ
 ydy
-ydy
-mUo
+opQ
+opQ
 jmG
 xzK
 xxq
@@ -87798,8 +87522,8 @@ saC
 eBm
 gWg
 xmD
-xQc
-xQc
+qjG
+qjG
 qJE
 xQc
 xQc
@@ -87817,15 +87541,15 @@ qEQ
 lYK
 hvh
 pqQ
+lfj
 bjd
-nTj
-ipH
-cbn
-aLG
+qqN
+vrE
+mNI
 tLX
+igp
 bjC
-nTj
-ien
+qqN
 ien
 ien
 rxI
@@ -87923,9 +87647,9 @@ jmG
 uYq
 aVX
 meb
-ubJ
-ubJ
-ubJ
+meb
+meb
+aVX
 jmG
 hMz
 fWG
@@ -87990,14 +87714,14 @@ aEL
 aEL
 aEL
 jcl
-jVa
+jcl
 jcl
 jcl
 ewp
 fIe
 fIe
 fIe
-aWX
+fIe
 fIe
 fMd
 ewt
@@ -88023,9 +87747,9 @@ mZU
 wXA
 hwG
 syg
-jjV
 xmD
-cHu
+xmD
+tMV
 jVC
 qJE
 qJE
@@ -88044,15 +87768,15 @@ qEQ
 lYK
 hvh
 pqQ
+lfj
 bjd
-nTj
-icM
-cbn
+qqN
+hNj
 mNI
-tLX
+hXZ
+igp
 bjC
-nTj
-ien
+qqN
 ien
 ien
 ien
@@ -88150,9 +87874,9 @@ vBd
 brk
 rdF
 ild
-ban
-ubJ
-ubJ
+jwM
+iTn
+iUT
 jmG
 hMz
 fWG
@@ -88251,8 +87975,8 @@ yiu
 cpZ
 kda
 qJE
-xQc
-xQc
+qjG
+qjG
 xmD
 mPY
 qJE
@@ -88271,15 +87995,15 @@ eZF
 lYK
 hvh
 eZF
+lfj
 bjd
-nTj
-ipH
+qqN
 vrE
 aJr
-tLX
+hYk
+igp
 bjC
-nTj
-ien
+qqN
 ien
 ien
 cpy
@@ -88375,7 +88099,7 @@ jmG
 eSy
 ild
 dco
-ild
+iSF
 jwM
 liN
 ild
@@ -88478,7 +88202,7 @@ yiu
 wvB
 xmD
 qJE
-xQc
+qjG
 xmD
 xmD
 mPY
@@ -88498,15 +88222,15 @@ pqQ
 lYK
 hvh
 eZF
+lfj
 bjd
-nTj
 qqN
-gzw
+tbK
 spn
 nCC
-isL
-nTj
-cpy
+igA
+iGl
+qqN
 cpy
 cpy
 cpy
@@ -88599,8 +88323,8 @@ onX
 wiE
 uFF
 wFB
-xqi
-ild
+jCU
+iSF
 ild
 ild
 hOB
@@ -88670,7 +88394,7 @@ aLJ
 dDS
 iZI
 fFw
-fib
+iZI
 jcl
 aCQ
 dXd
@@ -88679,7 +88403,7 @@ jcl
 swu
 hwt
 jcl
-eHp
+swu
 dHk
 vAu
 lkx
@@ -88704,8 +88428,8 @@ yiu
 yiu
 wvB
 xmD
-xQc
-xQc
+qjG
+qjG
 hdQ
 iQe
 vIS
@@ -88725,15 +88449,15 @@ pqQ
 lYK
 hvh
 pqQ
+lfj
 bjd
-nTj
 qqN
+tbK
 bjC
-gNN
+hZn
 bjC
-isL
-nTj
-cpy
+iGl
+qqN
 cpy
 cpy
 cpy
@@ -88897,7 +88621,7 @@ iZI
 dDS
 iZI
 iZI
-svW
+iZI
 jcl
 aCQ
 evx
@@ -88906,11 +88630,11 @@ nTl
 jcl
 hwt
 jcl
-svW
+iZI
 dYX
-hRy
-gqG
-gOo
+lXC
+lXC
+lXC
 saC
 saC
 saC
@@ -88931,7 +88655,7 @@ yiu
 uul
 dZG
 xmD
-seF
+qjG
 qJE
 lrQ
 dRy
@@ -88952,15 +88676,15 @@ eZF
 lYK
 hvh
 pqQ
+lfj
 bjd
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-nTj
-cpy
+qqN
+qqN
+qqN
+qqN
+qqN
+qqN
+qqN
 cpy
 cpy
 cpy
@@ -89010,7 +88734,7 @@ pNs
 xGf
 xGf
 whR
-pGl
+kqb
 mOG
 qcA
 fpl
@@ -89124,7 +88848,7 @@ fib
 fXU
 fib
 fib
-svW
+aLJ
 jcl
 aCQ
 emr
@@ -89133,12 +88857,12 @@ nTl
 dBe
 qZB
 jVa
-svW
+nno
 dYX
-jcl
-jcl
-gOG
-heF
+lXC
+lXC
+lXC
+aCQ
 saC
 saC
 saC
@@ -89158,7 +88882,7 @@ yiu
 hLY
 knt
 kOF
-seF
+qjG
 qJE
 iQe
 baG
@@ -89179,14 +88903,14 @@ pqQ
 lYK
 hvh
 qEQ
-bjd
-moe
-moe
-moe
-moe
-moe
-moe
-moe
+lfj
+mPj
+mPj
+mPj
+mPj
+mPj
+mPj
+mPj
 cpy
 cpy
 cpy
@@ -89351,20 +89075,20 @@ iZI
 dDS
 iZI
 iZI
-svW
+aLJ
 jVa
 fLP
 wSb
 nTl
 nTl
-jcl
+akk
 hwt
 jcl
-svW
+nno
 dYX
-hRy
-grz
-uNT
+lXC
+lXC
+lXC
 aCQ
 saC
 saC
@@ -89381,11 +89105,11 @@ vjl
 vjl
 xzu
 xzu
-xzu
+aWX
 hLY
 knt
-xQc
-xQc
+qjG
+qjG
 srf
 dRy
 yiu
@@ -89406,16 +89130,16 @@ pqQ
 lYK
 hvh
 qEQ
-bjd
-bjd
-bjd
-bjd
-bjd
-bjd
+lfj
+mPj
+hgo
+hNV
+gOo
+lfj
 bjd
 mPj
 mPj
-mPj
+cpy
 cpy
 cpy
 cpy
@@ -89464,7 +89188,7 @@ mUS
 jxT
 kqb
 kqb
-pGl
+kqb
 kqb
 kqb
 bJp
@@ -89587,7 +89311,7 @@ fLA
 eVW
 hwt
 jcl
-svW
+nno
 rbW
 tiQ
 tiQ
@@ -89611,7 +89335,7 @@ vlq
 xwZ
 syg
 iqz
-xQc
+qjG
 qJE
 qJE
 aox
@@ -89633,14 +89357,14 @@ pqQ
 lYK
 hvh
 eZF
-bjd
-okj
+lfj
+vJw
 vJw
 apd
 apd
 lfj
-bjd
-bjd
+lfj
+lfj
 bjd
 mPj
 cpy
@@ -89691,7 +89415,7 @@ oMn
 oYZ
 pTl
 pKX
-nlY
+xXg
 xXg
 kqb
 kqb
@@ -89734,7 +89458,7 @@ wiE
 wiE
 uGl
 six
-sUj
+jCU
 jwM
 ild
 vBd
@@ -89813,12 +89537,12 @@ ojn
 swu
 swu
 hwt
-aEL
-svW
+jcl
+iZI
 dYX
-hRy
-ifh
-gOo
+lXC
+lXC
+lXC
 aCQ
 lXC
 saC
@@ -89867,8 +89591,8 @@ woU
 woU
 xXv
 lfj
-bjd
-bjd
+lfj
+lfj
 mPj
 cpy
 cpy
@@ -89896,7 +89620,7 @@ nnz
 oVD
 xjF
 xFp
-sYk
+xFp
 uNB
 xUQ
 ykc
@@ -89918,7 +89642,7 @@ djM
 xAZ
 pTl
 uNB
-nlY
+xXg
 ylr
 wIi
 kqb
@@ -89961,7 +89685,7 @@ yhi
 wiE
 spM
 jmG
-aza
+iRV
 jwM
 ild
 vBd
@@ -90040,21 +89764,21 @@ swu
 swu
 swu
 hwt
-aEL
-cWH
+jcl
+swu
 dYX
-jcl
-jcl
-gOG
-heU
+lXC
+lXC
+lXC
+aCQ
 lXC
 ijO
 saC
 tiQ
-tiQ
 saC
 saC
-tiQ
+saC
+saC
 tiQ
 saC
 saC
@@ -90065,7 +89789,7 @@ vjl
 qjG
 hLY
 knt
-whK
+tMV
 xmD
 hna
 yiu
@@ -90084,8 +89808,8 @@ pAw
 tiQ
 bjd
 yje
-lYK
-jZE
+eMm
+grz
 hNP
 hNP
 hNP
@@ -90095,7 +89819,7 @@ vFD
 dfK
 xXv
 lfj
-bjd
+lfj
 mPj
 cpy
 cpy
@@ -90123,7 +89847,7 @@ jRT
 jRT
 ryO
 xFp
-sYk
+xFp
 uNB
 xUQ
 xAZ
@@ -90145,7 +89869,7 @@ xOw
 ykT
 xUQ
 uNB
-xOB
+dCJ
 tTD
 ylr
 ylr
@@ -90188,7 +89912,7 @@ wiE
 wEW
 hzu
 wFB
-bhh
+jCU
 ild
 jwM
 vBd
@@ -90268,20 +89992,20 @@ swu
 swu
 hwt
 jcl
-mrL
+swu
 dYX
-hRy
-oUC
-uNT
+lXC
+lXC
+lXC
 aCQ
 lXC
 lXC
 tiQ
 tiQ
-icr
-kHX
-iSF
-jeD
+saC
+saC
+saC
+saC
 tiQ
 saC
 saC
@@ -90311,18 +90035,18 @@ jpm
 tiQ
 bjd
 yje
-abL
-qsW
+lfj
+eMm
 qsW
 qsW
 qsW
 cgn
 mqx
 jZE
-vFD
+hZK
 pqQ
 qpd
-bjd
+gOo
 mPj
 cpy
 cpy
@@ -90350,7 +90074,7 @@ jRT
 sgV
 ryO
 xFp
-sYk
+xFp
 uNB
 pTl
 xAZ
@@ -90372,7 +90096,7 @@ xOw
 ykT
 xUQ
 uNB
-xOB
+dCJ
 tTD
 tTD
 sKJ
@@ -90415,7 +90139,7 @@ taw
 aYQ
 gJM
 jmG
-sBz
+jCU
 ild
 jwM
 okA
@@ -90495,7 +90219,7 @@ eAz
 lFk
 hwt
 jcl
-mrL
+swu
 dYX
 tiQ
 tiQ
@@ -90504,11 +90228,11 @@ hfi
 lXC
 lXC
 tiQ
-hTI
-aCQ
-dhJ
-iTn
-jfK
+saC
+saC
+saC
+saC
+saC
 tiQ
 jEq
 saC
@@ -90519,7 +90243,7 @@ yiu
 yiu
 lDc
 lMN
-whK
+tMV
 mnw
 qjG
 yiu
@@ -90546,10 +90270,10 @@ tyU
 lYK
 mqx
 mqx
-hvh
+icr
 pqQ
 qpd
-bjd
+gOo
 mPj
 cpy
 cpy
@@ -90577,7 +90301,7 @@ ydb
 val
 ryO
 xFp
-sYk
+xFp
 uNB
 pTl
 ykT
@@ -90599,7 +90323,7 @@ xOw
 xAZ
 pTl
 uNB
-xOB
+dCJ
 tTD
 tTD
 sKJ
@@ -90722,20 +90446,20 @@ nTl
 nTl
 nTl
 lXC
-eHp
+swu
 dYX
-jcl
-jcl
-jcl
+lXC
+lXC
+lXC
 aCQ
 lXC
 lXC
 tiQ
-sBg
-hXP
-tra
-tCX
-tFZ
+saC
+saC
+saC
+saC
+saC
 tiQ
 lKl
 xmD
@@ -90746,7 +90470,7 @@ leH
 lmu
 lDr
 lNI
-aqo
+qET
 ugN
 pHT
 lXQ
@@ -90762,10 +90486,10 @@ xmD
 knt
 xmD
 skk
-tiQ
+lTi
 bjd
 bjd
-bjd
+eRg
 wRf
 bjd
 hKI
@@ -90773,10 +90497,10 @@ hFA
 lYK
 mqx
 mqx
-hvh
+icr
 pqQ
 qpd
-bjd
+gOo
 mPj
 cpy
 cpy
@@ -90804,7 +90528,7 @@ ydb
 xRQ
 xjF
 xFp
-sYk
+xFp
 pKX
 pKX
 vnq
@@ -90826,7 +90550,7 @@ qCd
 dak
 pKX
 pKX
-xOB
+dCJ
 tTD
 tTD
 tTD
@@ -90867,7 +90591,7 @@ lot
 aTR
 xvl
 xvl
-cxE
+jmG
 jmG
 jmG
 xzK
@@ -90949,20 +90673,20 @@ nTl
 nTl
 nTl
 lXC
-eLx
+lXC
 dYX
-jcl
-jcl
-jcl
+lXC
+lXC
+lXC
 aCQ
 lXC
 lXC
 tiQ
 tiQ
-idq
-jcl
-jcl
-kkq
+saC
+saC
+saC
+saC
 tiQ
 jEu
 xmD
@@ -90988,9 +90712,9 @@ xVq
 liK
 gyC
 pfj
-pvz
-tiQ
-tiQ
+ayX
+qjG
+lTi
 bjd
 rMD
 eZF
@@ -91000,10 +90724,10 @@ bjd
 lYK
 mqx
 mqx
-hvh
+icr
 pqQ
 qpd
-bjd
+gOo
 mPj
 cpy
 cpy
@@ -91052,7 +90776,7 @@ fyl
 kcd
 oig
 cLQ
-xAw
+pKX
 lCn
 tTD
 tTD
@@ -91094,7 +90818,7 @@ icW
 eHI
 xvl
 xvl
-akk
+teD
 xxq
 xxq
 xxq
@@ -91178,19 +90902,19 @@ nTl
 nTl
 nTl
 dYX
-jcl
-jcl
-jcl
+lXC
+lXC
+lXC
 aCQ
 lXC
 lXC
-hME
-hUY
-ier
-hRW
-kHX
-jcl
-dAG
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 tiQ
 jYE
 xYD
@@ -91198,8 +90922,8 @@ knt
 lAD
 saC
 saC
-seF
-xQc
+cWH
+cHy
 saC
 saC
 myV
@@ -91227,10 +90951,10 @@ cZH
 jDN
 mqx
 nJW
-hvh
+icr
 eZF
 lfj
-bjd
+lfj
 mPj
 cpy
 cpy
@@ -91411,13 +91135,13 @@ hRW
 egD
 lXC
 lXC
-iZI
-hVk
-igp
-swu
-iUT
-kHX
-evx
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 xQc
 lAK
 xYD
@@ -91428,7 +91152,7 @@ ncA
 lDN
 pxN
 saC
-xQc
+cHy
 sdR
 lNA
 wXA
@@ -91446,7 +91170,7 @@ pfj
 qjG
 qjG
 bjd
-nRy
+lfj
 pqQ
 bjd
 fSf
@@ -91454,10 +91178,10 @@ cZH
 mqx
 mqx
 mqx
-hvh
+icr
 pqQ
 qpd
-bjd
+gOo
 mPj
 cpy
 cpy
@@ -91548,7 +91272,7 @@ xgA
 bsG
 vOT
 xvB
-xWO
+otS
 fWG
 fWG
 fWG
@@ -91637,14 +91361,14 @@ enr
 elx
 elx
 elx
-elx
-hNj
-hXA
-fvQ
-fDC
-gwk
-hgQ
-exB
+aDS
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 xQc
 xmD
 xmD
@@ -91655,7 +91379,7 @@ nwR
 oem
 maj
 maj
-seF
+cWH
 knt
 hna
 yiu
@@ -91673,18 +91397,18 @@ oyK
 ayX
 vKP
 bjd
-osm
+lfj
 pqQ
 bjd
 fSf
-cZH
-cgn
-mqx
-mqx
-hvh
+heU
+qsW
+qsW
+qsW
+idq
 pqQ
 qpd
-bjd
+gOo
 mPj
 cpy
 cpy
@@ -91733,7 +91457,7 @@ art
 gNn
 mgb
 rUe
-xAw
+pKX
 xBS
 tTD
 tTD
@@ -91775,7 +91499,7 @@ aSZ
 acE
 vOT
 xvB
-xWO
+otS
 fWG
 fWG
 fWG
@@ -91865,18 +91589,18 @@ lXC
 lXC
 lXC
 lXC
-iZI
-hXP
-egY
-cHy
-jIQ
-bXl
-jcl
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 xQc
 tMV
 tMV
 kne
-xQc
+cHy
 mkb
 lnd
 xYD
@@ -91905,13 +91629,13 @@ pqQ
 bjd
 bjd
 bjd
-lYK
-mqx
-mqx
-hvh
+rMD
+rMD
+rMD
+lfj
 pqQ
 qpd
-bjd
+gOo
 mPj
 cpy
 cpy
@@ -91939,7 +91663,7 @@ rMR
 qSH
 qSH
 vGp
-onj
+uRb
 pKX
 pKX
 pKn
@@ -91961,7 +91685,7 @@ heX
 jMk
 pKX
 pKX
-xOB
+dCJ
 tTD
 tTD
 tTD
@@ -92002,7 +91726,7 @@ eMD
 qZd
 xvl
 xvl
-xWO
+otS
 fWG
 fWG
 cpy
@@ -92092,24 +91816,24 @@ tra
 egY
 lXC
 lXC
-hNV
-hXZ
-igp
-swu
-iUX
-tCX
-jcl
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 xQc
 jjV
 xmD
 knt
-xQc
+cHy
 mlp
 nxQ
 oKK
 pDM
 qTE
-xQc
+cHy
 wyA
 hna
 yiu
@@ -92127,18 +91851,18 @@ jWB
 lKl
 lTi
 bjd
-lul
+lfj
 dfK
 qKO
 xLr
-xXv
-lYK
-mqx
-mqx
-hvh
+hfE
+xsE
+xsE
+xsE
+lfj
 pqQ
 qpd
-bjd
+mPj
 mPj
 mPj
 mPj
@@ -92166,7 +91890,7 @@ qSH
 qSH
 vGp
 vGp
-onj
+uRb
 uNB
 xUQ
 ykT
@@ -92188,7 +91912,7 @@ iGn
 uOp
 bSI
 uNB
-xOB
+dCJ
 tTD
 tTD
 tTD
@@ -92229,7 +91953,7 @@ xje
 ffb
 xvl
 xvl
-xWO
+otS
 fWG
 dBD
 sps
@@ -92313,30 +92037,30 @@ nTl
 nTl
 nTl
 vQn
-aEL
-aEL
-jcl
+lXC
+lXC
+lXC
 aCQ
 lXC
 lXC
-iZI
-hYk
-aDS
-tra
-tCX
-jcl
-cYe
+saC
+saC
+saC
+saC
+saC
+saC
+saC
 tiQ
 dXo
 xYD
 kpE
-xQc
-xQc
+cHy
+cHy
 nEd
 piW
 pEp
-xQc
-xQc
+cHy
+cHy
 knt
 hna
 qFW
@@ -92355,18 +92079,18 @@ asH
 tiQ
 bjd
 dXX
-pWC
 rMD
-bjd
-pqQ
-lYK
-mqx
-mqx
-hvh
+rMD
+lao
 eZF
-bjd
-bjd
-bjd
+xsE
+xsE
+xsE
+lfj
+eZF
+lfj
+lfj
+lfj
 bjd
 bjd
 mPj
@@ -92393,7 +92117,7 @@ qSH
 qSH
 vGp
 vGp
-onj
+uRb
 uNB
 xUQ
 xAZ
@@ -92415,7 +92139,7 @@ sAp
 vHw
 fEF
 uNB
-xOB
+dCJ
 tTD
 tTD
 sKJ
@@ -92456,7 +92180,7 @@ xhD
 acE
 vOT
 xvB
-xWO
+otS
 fWG
 qjO
 ylo
@@ -92540,29 +92264,29 @@ nTl
 nno
 lXC
 hwt
-jVa
-jcl
-jcl
+lXC
+lXC
+lXC
 fkW
 lXC
 lXC
 hOy
-tiQ
-qyp
-jcl
-jcl
-bCd
+saC
+saC
+saC
+saC
+saC
 tiQ
 jEu
 xmD
 xYD
 kpE
 xmD
-xQc
-xQc
-seF
-xQc
-xQc
+cHy
+cHy
+cWH
+cHy
+cHy
 uQi
 knt
 juw
@@ -92581,19 +92305,19 @@ seF
 tiQ
 tiQ
 bjd
+eZq
+gwk
+lfj
 bjd
-bjd
-bjd
-bjd
-qEQ
-abL
-cgn
-mqx
-hvh
-dfK
-woU
-woU
-woU
+yje
+xsE
+xsE
+xsE
+xsE
+hRy
+hVk
+hVk
+hVk
 xnX
 gib
 mPj
@@ -92620,7 +92344,7 @@ qSH
 vGp
 vGp
 vGp
-onj
+uRb
 uNB
 pTl
 xAZ
@@ -92642,7 +92366,7 @@ xOw
 snb
 rkV
 uNB
-xOB
+dCJ
 tTD
 hrk
 vlT
@@ -92683,7 +92407,7 @@ xgA
 acE
 vOT
 xvB
-xWO
+otS
 fWG
 qjO
 ylo
@@ -92767,18 +92491,18 @@ nTl
 lXC
 swu
 hwt
-jVa
-jcl
-jcl
+lXC
+lXC
+lXC
 aCQ
 lXC
 lXC
 tiQ
-hZn
-aAb
-hRW
-kHX
-jhY
+saC
+saC
+saC
+saC
+saC
 tiQ
 jjV
 xmD
@@ -92807,20 +92531,20 @@ xmD
 kss
 tiQ
 tiQ
-alI
-alI
-alI
-alI
+bjd
+fvQ
+fvQ
+bjd
 bjd
 lwr
-rSs
-abL
-cgn
-jZE
-hNP
-hNP
-hNP
-efM
+hgQ
+xsE
+xsE
+xsE
+xsE
+xsE
+xsE
+xsE
 caV
 pcV
 xLr
@@ -92847,7 +92571,7 @@ qSH
 vGp
 vGp
 kqp
-sYk
+xFp
 uNB
 xUQ
 xnI
@@ -92869,7 +92593,7 @@ bSa
 xAZ
 xUQ
 uNB
-nlY
+xXg
 vlT
 wIi
 tTK
@@ -92910,7 +92634,7 @@ xjY
 qZd
 xvl
 xvl
-xWO
+otS
 fWG
 qjO
 ylo
@@ -93001,11 +92725,11 @@ aCQ
 lXC
 lXC
 tiQ
-hZK
-aCQ
-fMT
-iVk
-jic
+saC
+saC
+saC
+saC
+saC
 tiQ
 jjV
 iQe
@@ -93034,21 +92758,21 @@ pfj
 vAX
 kJc
 tiQ
-saC
-saC
-saC
-alI
+bjd
+fDC
+gNN
+bjd
 bjd
 gzY
 ama
-kbb
-abL
-qsW
-qsW
-qsW
-qsW
+hgQ
 xsE
-eZF
+xsE
+xsE
+xsE
+xsE
+xsE
+iLC
 tyb
 lao
 iJE
@@ -93096,7 +92820,7 @@ vfK
 rie
 xUQ
 pKX
-nlY
+xXg
 xXg
 tTK
 tTK
@@ -93137,7 +92861,7 @@ qIE
 wog
 xvl
 xvl
-xWO
+otS
 fWG
 qjO
 jOF
@@ -93221,18 +92945,18 @@ hwt
 jcl
 swu
 hwt
-hRy
-ifh
-gOo
+lXC
+lXC
+lXC
 aCQ
 lXC
 lXC
 tiQ
 tiQ
-igA
-tCX
-iVU
-jig
+saC
+saC
+saC
+saC
 tiQ
 xmD
 hna
@@ -93259,22 +92983,22 @@ xSL
 txo
 jef
 pfj
-tfK
+eHp
 tiQ
-saC
-saC
-saC
-alI
+bjd
+fDC
+gNN
+fDC
 bjd
 bjd
-lfj
-eTQ
-woU
-aLf
+rMD
+hRy
+hVk
 ubF
 ubF
-woU
-woU
+ubF
+hVk
+hVk
 otx
 qYy
 mPj
@@ -93364,7 +93088,7 @@ xhD
 bsG
 kEQ
 xvB
-xWO
+otS
 fWG
 qjO
 ylo
@@ -93446,19 +93170,19 @@ mrL
 lFd
 qZB
 jVa
-pgJ
+mrL
 hwt
-jcl
-jcl
-gRV
-hfE
 lXC
 lXC
-swu
+lXC
+fkW
+lXC
+lXC
+mrL
 tiQ
-mRh
-iGl
-tiQ
+saC
+saC
+saC
 tiQ
 tiQ
 vjl
@@ -93486,22 +93210,22 @@ csy
 wWc
 pfj
 syV
-kJc
-tiQ
-saC
-saC
-saC
-alI
-alI
+eLx
+vKP
+bjd
+rMD
+gOo
+rMD
 bjd
 bjd
-bjd
-bjd
-bjd
-bjd
-bjd
-bjd
-bjd
+rMD
+xsE
+xsE
+xsE
+xsE
+rMD
+rMD
+rMD
 bjd
 bjd
 mPj
@@ -93591,7 +93315,7 @@ xhD
 bsG
 vOT
 xvB
-xWO
+otS
 fWG
 qjO
 ylo
@@ -93673,18 +93397,18 @@ swu
 swu
 hwt
 jcl
-svW
+nno
 hwt
-hRy
-oUC
-uNT
+lXC
+lXC
+lXC
 aCQ
 lXC
-lXC
-swu
-swu
-swu
-jcl
+nno
+mrL
+saC
+saC
+saC
 saC
 saC
 saC
@@ -93714,18 +93438,18 @@ lmY
 sfM
 hLY
 xmD
-tiQ
-saC
-saC
-saC
-saC
-alI
-alI
-alI
-alI
-alI
-alI
-alI
+qjG
+bjd
+rMD
+lfj
+lfj
+fDC
+bjd
+rMD
+xsE
+xsE
+xsE
+rMD
 wDj
 wDj
 wDj
@@ -93900,17 +93624,17 @@ jcl
 swu
 hwt
 jcl
-svW
+nno
 bye
 tiQ
 tiQ
 tiQ
-aCQ
-lXC
-lXC
-iRY
-swu
-jcl
+fmB
+nno
+nno
+lFd
+saC
+saC
 saC
 saC
 saC
@@ -93941,22 +93665,22 @@ lmY
 sfM
 hLY
 ayX
-tiQ
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
+qjG
+bjd
+lfj
+gOo
+gOo
+rMD
+lao
+rMD
+xsE
+xsE
+rMD
 wDj
 wDj
-saC
-saC
-saC
+sOL
+sOL
+sOL
 wDj
 eOT
 sOL
@@ -94118,7 +93842,7 @@ fib
 gbQ
 jYj
 jYj
-eFP
+elx
 fIe
 egd
 ewt
@@ -94127,16 +93851,16 @@ nTl
 jcl
 hwt
 jcl
-svW
+lXC
 hwt
-hRy
-ifh
-eMm
-aCQ
 lXC
 lXC
-swu
-swu
+lXC
+fmB
+nno
+nno
+saC
+saC
 saC
 saC
 saC
@@ -94167,22 +93891,22 @@ xME
 hYg
 jWB
 eIT
-kJc
-tiQ
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
+eLx
+qjG
+bjd
+fMT
+gOo
+gOo
+lfj
+lao
+hME
+hTI
+hTI
+ier
 wDj
-saC
-saC
-saC
+sOL
+eJR
+eJR
 arN
 vGB
 sOL
@@ -94345,20 +94069,20 @@ iZI
 dDS
 iZI
 iZI
-svW
+lXC
 jVa
 fLP
 iOt
 nTl
 nTl
-dBe
-qZB
-jVa
-svW
+ame
 hwt
 jcl
-jcl
-eRg
+lXC
+hwt
+lXC
+lXC
+nno
 fmB
 saC
 saC
@@ -94392,23 +94116,23 @@ sDf
 kpo
 wQs
 llG
-noD
+dAG
 lMF
-iDg
-tiQ
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
+nqQ
+lTi
+bjd
+fMT
+lfj
+gRV
+rMD
+bjd
+bjd
+hUY
+hXA
+hUY
 wDj
-saC
-saC
+sOL
+eJR
 iJE
 hZg
 vGB
@@ -94572,7 +94296,7 @@ iZI
 dDS
 iZI
 iZI
-svW
+lXC
 jcl
 aCQ
 evx
@@ -94581,11 +94305,11 @@ nTl
 jcl
 hwt
 jcl
-svW
+lXC
 hwt
-hRy
-gqG
-eZq
+lXC
+lXC
+nno
 saC
 saC
 saC
@@ -94623,18 +94347,18 @@ jWB
 teE
 mpQ
 tiQ
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
-saC
+bjd
+bjd
+gOG
+heF
+bjd
+bjd
+bjd
+bjd
+bjd
+bjd
 wDj
-saC
+sOL
 hhJ
 sOL
 sOL
@@ -94726,7 +94450,7 @@ icW
 oPW
 xvl
 xvl
-naZ
+xwv
 uwT
 fWG
 uwT
@@ -94799,7 +94523,7 @@ iZI
 dDS
 iZI
 iZI
-fib
+iZI
 jcl
 aCQ
 equ
@@ -94808,7 +94532,7 @@ jcl
 dXd
 fbC
 fIe
-ame
+oWq
 fDn
 fDH
 fFE
@@ -94851,18 +94575,18 @@ cXi
 tiQ
 tiQ
 saC
-saC
-saC
-saC
-saC
+bjd
+bjd
+bjd
+bjd
 saC
 saC
 saC
 saC
 saC
 wDj
-saC
-saC
+wDj
+wDj
 ygD
 jJI
 uaY
@@ -94953,7 +94677,7 @@ xhD
 bsG
 kEQ
 xvB
-xWO
+otS
 uwT
 fWG
 fWG
@@ -95180,7 +94904,7 @@ xhD
 bsG
 kEQ
 xvB
-xWO
+otS
 uwT
 fWG
 fWG
@@ -95400,14 +95124,14 @@ uuD
 uuD
 lFO
 gIg
-wrY
+imT
 xvl
 xvl
 xjY
 qZd
 xvl
 xvl
-xWO
+otS
 uwT
 uwT
 fWG
@@ -95488,7 +95212,7 @@ jcl
 jcl
 evx
 jcl
-jVa
+jcl
 jcl
 jcl
 jcl
@@ -95627,14 +95351,14 @@ evv
 uuD
 uuD
 xXg
-rIr
+imT
 xvl
 xvl
 xje
 wog
 xvl
 xvl
-xWO
+otS
 uwT
 uwT
 uwT
@@ -95861,7 +95585,7 @@ xhD
 bsG
 kEQ
 xvB
-xWO
+otS
 uwT
 uwT
 uwT
@@ -96088,7 +95812,7 @@ xgA
 bsG
 vOT
 xvB
-xWO
+otS
 uxT
 sps
 sps
@@ -96308,14 +96032,14 @@ rOg
 qJH
 qUs
 xXg
-iQR
+imT
 xvl
 xvl
 xjY
 qZd
 xvl
 xvl
-xWO
+otS
 ppD
 xkO
 xkO
@@ -96535,14 +96259,14 @@ rOg
 jrJ
 qUs
 xXg
-wrY
+imT
 xvl
 xvl
 xje
 wog
 xvl
 xvl
-xWO
+otS
 ppD
 xkO
 vZn
@@ -96762,14 +96486,14 @@ bHT
 qiw
 uuD
 xXg
-wrY
+imT
 xvB
 kEQ
 xhD
 bsG
 kEQ
 xvB
-xWO
+otS
 ppD
 xkO
 xkO
@@ -96989,14 +96713,14 @@ bJG
 uuD
 uuD
 xXg
-wrY
+imT
 xvB
 vOT
 xhD
 bsG
 vOT
 xvB
-xWO
+otS
 ppD
 xkO
 ipC
@@ -97216,14 +96940,14 @@ uuD
 uuD
 viG
 xXg
-wrY
+imT
 xvl
 xvl
 jVz
 wog
 xvl
 xvl
-xWO
+otS
 ppD
 xkO
 xkO
@@ -97443,14 +97167,14 @@ xXg
 xXg
 xXg
 xXg
-wrY
+imT
 xvl
 xvl
 icW
 oPW
 xvl
 xvl
-xWO
+otS
 kIV
 mUr
 mUr
@@ -97670,14 +97394,14 @@ xXg
 xXg
 xXg
 xXg
-wrY
+imT
 xvl
 xvl
 lot
 vdz
 xvl
 xvl
-xWO
+otS
 uwT
 uwT
 uwT
@@ -97904,7 +97628,7 @@ swF
 fzV
 qqR
 cUG
-xWO
+iQR
 uwT
 uwT
 uwT
@@ -98131,7 +97855,7 @@ xRw
 uaI
 eHB
 cUG
-tti
+hMz
 uwT
 uwT
 uwT
@@ -101034,14 +100758,14 @@ qSH
 vGp
 vGp
 hHh
-sYk
+xFp
 gdO
 ene
 vTW
 puJ
 ufU
 gdO
-nlY
+xXg
 ylr
 ylr
 ylr
@@ -101268,7 +100992,7 @@ vDa
 pej
 ufU
 raj
-xOB
+dCJ
 sKJ
 tTD
 rnB
@@ -102403,7 +102127,7 @@ pej
 pej
 ufU
 raj
-xOB
+dCJ
 rnB
 rnB
 rnB
@@ -102623,7 +102347,7 @@ vGp
 vGp
 kQJ
 tPb
-onj
+uRb
 gdO
 ene
 puJ

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -356,7 +356,7 @@
 /area/lv522/outdoors/colony_streets/central_streets)
 "ajw" = (
 /obj/structure/pipes/standard/simple/hidden/green{
-	dir = 10
+	dir = 4
 	},
 /turf/open/floor/corsat{
 	dir = 4;
@@ -622,11 +622,13 @@
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/mining)
 "apS" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "W"
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 10
 	},
-/turf/open/auto_turf/shale/layer1,
-/area/lv522/outdoors/colony_streets/south_east_street)
+/turf/open/floor/corsat{
+	icon_state = "plate"
+	},
+/area/lv522/atmos/north_command_centre)
 "aqo" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
@@ -1007,12 +1009,12 @@
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/cargo)
 "aDj" = (
-/obj/structure/stairs/perspective{
-	dir = 9;
-	icon_state = "p_stair_full"
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor/corsat{
+	icon_state = "squares"
 	},
-/turf/open/asphalt/cement,
-/area/lv522/outdoors/colony_streets/north_east_street)
+/area/lv522/atmos/north_command_centre)
 "aDs" = (
 /obj/item/explosive/mine/active{
 	dir = 8
@@ -1433,15 +1435,6 @@
 	},
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/security/glass)
-"aPS" = (
-/obj/structure/stairs/perspective{
-	dir = 10;
-	icon_state = "p_stair_full"
-	},
-/turf/open/asphalt/cement{
-	icon_state = "cement12"
-	},
-/area/lv522/outdoors/colony_streets/central_streets)
 "aQe" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/structure/machinery/recharger,
@@ -3493,7 +3486,6 @@
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/outdoors/colony_streets/north_street)
 "bRN" = (
-/obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/corsat{
 	dir = 4;
 	icon_state = "browncorner"
@@ -3942,8 +3934,8 @@
 /turf/open/floor/wood/ship,
 /area/lv522/atmos/way_in_command_centre)
 "caN" = (
-/obj/structure/pipes/standard/manifold/hidden/green{
-	dir = 1
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 6
 	},
 /turf/open/floor/corsat{
 	icon_state = "squares"
@@ -4113,14 +4105,13 @@
 	},
 /area/lv522/atmos/east_reactor)
 "cfv" = (
-/obj/structure/stairs/perspective{
-	dir = 5;
-	icon_state = "p_stair_full"
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 9
 	},
-/turf/open/asphalt/cement{
-	icon_state = "cement4"
+/turf/open/floor/corsat{
+	icon_state = "brown"
 	},
-/area/lv522/outdoors/colony_streets/north_east_street)
+/area/lv522/atmos/north_command_centre)
 "cfz" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper B-Block - Hydroponics Airlock"
@@ -5831,11 +5822,11 @@
 	},
 /area/lv522/oob)
 "cRN" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor/corsat{
-	icon_state = "marked"
+/obj/structure/largecrate,
+/turf/open/asphalt/cement{
+	icon_state = "cement3"
 	},
-/area/lv522/atmos/north_command_centre)
+/area/lv522/outdoors/colony_streets/north_east_street)
 "cRT" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -7265,13 +7256,12 @@
 	},
 /area/lv522/atmos/cargo_intake)
 "dsl" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "NE-out";
-	pixel_x = 1;
-	pixel_y = 1
+/obj/structure/stairs/perspective{
+	dir = 10;
+	icon_state = "p_stair_full"
 	},
-/turf/open/auto_turf/shale/layer1,
-/area/lv522/outdoors/colony_streets/south_east_street)
+/turf/open/asphalt/cement,
+/area/lv522/outdoors/colony_streets/north_east_street)
 "dsq" = (
 /obj/structure/surface/rack,
 /obj/item/stack/sheet/mineral/iron{
@@ -9773,11 +9763,11 @@
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/north_west_street)
 "esB" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 6
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_full"
 	},
-/turf/closed/wall/mineral/bone_resin,
-/area/lv522/oob)
+/turf/open/asphalt/cement,
+/area/lv522/outdoors/colony_streets/north_east_street)
 "esF" = (
 /obj/structure/surface/rack,
 /turf/open/floor/prison{
@@ -9859,11 +9849,12 @@
 	},
 /area/lv522/indoors/a_block/medical)
 "euN" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 9
+/obj/structure/stairs/perspective{
+	dir = 6;
+	icon_state = "p_stair_full"
 	},
-/turf/closed/wall/mineral/bone_resin,
-/area/lv522/oob)
+/turf/open/asphalt/cement,
+/area/lv522/outdoors/colony_streets/north_east_street)
 "euT" = (
 /obj/structure/stairs/perspective{
 	icon_state = "p_stair_full"
@@ -10035,13 +10026,11 @@
 /turf/open/asphalt/cement,
 /area/lv522/outdoors/colony_streets/central_streets)
 "eyh" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 6
+/obj/structure/platform{
+	dir = 4
 	},
-/turf/open/floor/corsat{
-	icon_state = "marked"
-	},
-/area/lv522/atmos/north_command_centre)
+/turf/open/asphalt/cement,
+/area/lv522/outdoors/colony_streets/north_east_street)
 "eym" = (
 /obj/structure/surface/rack,
 /obj/item/storage/toolbox/mechanical/green{
@@ -10083,13 +10072,10 @@
 	},
 /area/lv522/indoors/a_block/admin)
 "ezj" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 10
+/turf/open/asphalt/cement{
+	icon_state = "cement12"
 	},
-/turf/open/floor/corsat{
-	icon_state = "plate"
-	},
-/area/lv522/atmos/east_reactor/west)
+/area/lv522/outdoors/colony_streets/north_east_street)
 "ezo" = (
 /obj/structure/surface/table/almayer,
 /obj/item/prop/helmetgarb/spacejam_tickets{
@@ -10908,12 +10894,12 @@
 /area/lv522/atmos/west_reactor)
 "eQu" = (
 /obj/structure/pipes/standard/simple/hidden/green{
-	dir = 9
+	dir = 4
 	},
-/turf/open/floor/corsat{
-	icon_state = "marked"
+/turf/open/asphalt/cement{
+	icon_state = "cement14"
 	},
-/area/lv522/atmos/north_command_centre)
+/area/lv522/outdoors/colony_streets/north_east_street)
 "eQB" = (
 /obj/structure/machinery/portable_atmospherics/canister/phoron,
 /turf/open/floor/corsat{
@@ -11450,20 +11436,21 @@
 	},
 /area/lv522/atmos/north_command_centre)
 "fcW" = (
-/obj/structure/pipes/standard/manifold/hidden/green,
-/turf/open/floor/corsat{
-	icon_state = "brown"
-	},
-/area/lv522/atmos/north_command_centre)
-"fda" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/floor/corsat{
-	dir = 6;
-	icon_state = "brown"
+/turf/open/asphalt/cement{
+	icon_state = "cement12"
 	},
-/area/lv522/atmos/north_command_centre)
+/area/lv522/outdoors/colony_streets/north_east_street)
+"fda" = (
+/obj/structure/pipes/standard/manifold/hidden/green{
+	dir = 1
+	},
+/turf/open/asphalt/cement{
+	icon_state = "cement12"
+	},
+/area/lv522/outdoors/colony_streets/north_east_street)
 "fdb" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	dir = 1;
@@ -11545,13 +11532,12 @@
 /area/lv522/landing_zone_2/ceiling)
 "feF" = (
 /obj/structure/pipes/standard/simple/hidden/green{
-	dir = 5
+	dir = 4
 	},
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/turf/open/floor/corsat{
-	icon_state = "plate"
+/turf/open/asphalt/cement{
+	icon_state = "cement15"
 	},
-/area/lv522/atmos/east_reactor/west)
+/area/lv522/outdoors/colony_streets/north_east_street)
 "feS" = (
 /obj/item/prop/colony/used_flare,
 /turf/open/floor/corsat{
@@ -11682,14 +11668,13 @@
 	},
 /area/lv522/indoors/c_block/mining)
 "fhQ" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 10
+/obj/structure/machinery/colony_floodlight{
+	layer = 4.3
 	},
-/turf/open/floor/corsat{
-	dir = 8;
-	icon_state = "brown"
+/turf/open/asphalt/cement{
+	icon_state = "cement4"
 	},
-/area/lv522/atmos/east_reactor/west)
+/area/lv522/outdoors/colony_streets/north_east_street)
 "fhY" = (
 /obj/structure/surface/rack,
 /obj/item/tool/pickaxe,
@@ -12025,14 +12010,12 @@
 	},
 /area/lv522/indoors/a_block/dorms)
 "fpB" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 5
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
 	},
-/turf/open/floor/corsat{
-	dir = 8;
-	icon_state = "brown"
-	},
-/area/lv522/atmos/east_reactor/west)
+/turf/open/asphalt/cement,
+/area/lv522/outdoors/colony_streets/north_street)
 "fpH" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 9
@@ -15116,7 +15099,7 @@
 	layer = 2.9
 	},
 /obj/structure/stairs/perspective{
-	dir = 9;
+	dir = 1;
 	icon_state = "p_stair_full"
 	},
 /turf/open/asphalt/cement{
@@ -15172,16 +15155,6 @@
 	icon_state = "blue"
 	},
 /area/lv522/indoors/a_block/hallway)
-"gBb" = (
-/obj/structure/prop/structure_lattice,
-/obj/structure/stairs/perspective{
-	dir = 5;
-	icon_state = "p_stair_full"
-	},
-/turf/open/asphalt/cement{
-	icon_state = "cement4"
-	},
-/area/lv522/outdoors/colony_streets/north_east_street)
 "gBe" = (
 /obj/item/stack/sheet/metal,
 /obj/effect/decal/cleanable/dirt,
@@ -18214,13 +18187,11 @@
 /turf/open/floor/prison,
 /area/lv522/atmos/outdoor)
 "hHh" = (
-/obj/structure/machinery/colony_floodlight{
-	layer = 4.3
+/obj/structure/platform{
+	dir = 4
 	},
-/turf/open/asphalt/cement{
-	icon_state = "cement9"
-	},
-/area/lv522/outdoors/colony_streets/north_east_street)
+/turf/open/asphalt/cement,
+/area/lv522/outdoors/colony_streets/central_streets)
 "hHj" = (
 /obj/structure/largecrate,
 /turf/open/floor/corsat{
@@ -19905,6 +19876,10 @@
 /area/lv522/outdoors/nw_rockies)
 "ioD" = (
 /obj/structure/prop/structure_lattice,
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
 /turf/open/asphalt/cement{
 	icon_state = "cement4"
 	},
@@ -26785,7 +26760,8 @@
 /area/lv522/indoors/a_block/admin)
 "kIV" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "SW-out"
+	icon_state = "SE-out";
+	pixel_x = 1
 	},
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/outdoors/colony_streets/south_east_street)
@@ -29147,15 +29123,6 @@
 	icon_state = "blue_plate"
 	},
 /area/lv522/indoors/a_block/admin)
-"lCn" = (
-/obj/structure/stairs/perspective{
-	dir = 10;
-	icon_state = "p_stair_full"
-	},
-/turf/open/asphalt/cement{
-	icon_state = "cement12"
-	},
-/area/lv522/outdoors/colony_streets/east_central_street)
 "lCx" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/prison{
@@ -29790,6 +29757,10 @@
 /area/lv522/outdoors/colony_streets/south_east_street)
 "lPv" = (
 /obj/effect/decal/cleanable/liquid_fuel,
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
 /turf/open/asphalt/cement{
 	icon_state = "cement4"
 	},
@@ -30075,7 +30046,9 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/auto_turf/shale/layer1,
+/turf/open/asphalt/cement{
+	icon_state = "cement12"
+	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "lWa" = (
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -30149,7 +30122,9 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/auto_turf/sand_white/layer0,
+/turf/open/asphalt/cement{
+	icon_state = "cement12"
+	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "lYG" = (
 /obj/structure/platform_decoration{
@@ -31976,6 +31951,10 @@
 "mJF" = (
 /obj/structure/cargo_container/kelland/left{
 	layer = 2.9
+	},
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
 	},
 /turf/open/asphalt/cement{
 	icon_state = "cement4"
@@ -34606,14 +34585,11 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/admin)
 "nIu" = (
-/obj/structure/stairs/perspective{
-	dir = 9;
-	icon_state = "p_stair_full"
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
 	},
-/turf/open/asphalt/cement{
-	icon_state = "cement4"
-	},
-/area/lv522/outdoors/colony_streets/north_street)
+/turf/open/auto_turf/sand_white/layer0,
+/area/lv522/outdoors/colony_streets/south_east_street)
 "nIF" = (
 /obj/structure/reagent_dispensers/fueltank{
 	layer = 2.9
@@ -35670,9 +35646,11 @@
 	},
 /area/lv522/outdoors/n_rockies)
 "oaj" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/closed/wall/r_wall/biodome/biodome_unmeltable,
-/area/lv522/atmos/cargo_intake)
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out"
+	},
+/turf/open/auto_turf/sand_white/layer0,
+/area/lv522/outdoors/colony_streets/south_east_street)
 "oan" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out";
@@ -36750,6 +36728,10 @@
 	layer = 2.9
 	},
 /obj/effect/decal/cleanable/liquid_fuel,
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
 /turf/open/asphalt/cement,
 /area/lv522/outdoors/colony_streets/north_street)
 "ovr" = (
@@ -38912,9 +38894,11 @@
 /area/lv522/indoors/a_block/dorms)
 "ppD" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "S"
+	icon_state = "NE-out";
+	pixel_x = 1;
+	pixel_y = 1
 	},
-/turf/open/auto_turf/sand_white/layer0,
+/turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/south_east_street)
 "ppF" = (
 /turf/closed/shuttle/dropship2/tornado/typhoon{
@@ -41562,11 +41546,15 @@
 /turf/open/floor/plating,
 /area/lv522/outdoors/colony_streets/central_streets)
 "qpD" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
+/obj/structure/machinery/light{
+	dir = 1
 	},
-/turf/closed/wall/mineral/bone_resin,
-/area/lv522/oob)
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/turf/open/auto_turf/shale/layer1,
+/area/lv522/outdoors/colony_streets/south_east_street)
 "qpE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
@@ -51021,14 +51009,18 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
-/turf/open/auto_turf/shale/layer1,
+/turf/open/asphalt/cement{
+	icon_state = "cement12"
+	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "tJG" = (
 /obj/structure/stairs/perspective{
 	icon_state = "p_stair_full"
 	},
 /obj/structure/pipes/standard/manifold/hidden/green,
-/turf/open/auto_turf/sand_white/layer0,
+/turf/open/asphalt/cement{
+	icon_state = "cement12"
+	},
 /area/lv522/outdoors/colony_streets/north_east_street)
 "tJM" = (
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -51086,9 +51078,6 @@
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/south_street)
 "tKC" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
 	pixel_y = 1
@@ -51982,12 +51971,9 @@
 /area/lv522/atmos/sewer)
 "ubH" = (
 /obj/structure/stairs/perspective{
-	dir = 6;
 	icon_state = "p_stair_full"
 	},
-/turf/open/asphalt/cement{
-	icon_state = "cement12"
-	},
+/turf/open/asphalt/cement,
 /area/lv522/outdoors/colony_streets/central_streets)
 "ubJ" = (
 /obj/structure/blocker/invisible_wall,
@@ -52518,7 +52504,7 @@
 /area/lv522/indoors/c_block/garage)
 "ujy" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "N";
+	icon_state = "NW-out";
 	pixel_y = 1
 	},
 /turf/open/auto_turf/shale/layer1,
@@ -53200,13 +53186,6 @@
 	icon_state = "darkredfull2"
 	},
 /area/lv522/indoors/a_block/security)
-"uxT" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "SE-out";
-	pixel_x = 1
-	},
-/turf/open/auto_turf/sand_white/layer0,
-/area/lv522/outdoors/colony_streets/south_east_street)
 "uya" = (
 /turf/open/floor/prison{
 	icon_state = "darkbrownfull2"
@@ -57169,6 +57148,9 @@
 /obj/structure/platform{
 	dir = 4
 	},
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_full"
+	},
 /turf/open/asphalt/cement,
 /area/lv522/outdoors/colony_streets/central_streets)
 "vSO" = (
@@ -58512,15 +58494,6 @@
 /mob/living/simple_animal/mouse,
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/cargo)
-"wsX" = (
-/obj/structure/stairs/perspective{
-	dir = 5;
-	icon_state = "p_stair_full"
-	},
-/turf/open/asphalt/cement{
-	icon_state = "cement4"
-	},
-/area/lv522/outdoors/colony_streets/north_street)
 "wsY" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -59695,8 +59668,7 @@
 /area/lv522/atmos/sewer)
 "wRk" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "NW-out";
-	pixel_y = 1
+	icon_state = "W"
 	},
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/south_east_street)
@@ -60671,6 +60643,10 @@
 	layer = 2.9
 	},
 /obj/effect/decal/cleanable/liquid_fuel,
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
 /turf/open/asphalt/cement{
 	icon_state = "cement4"
 	},
@@ -61420,12 +61396,9 @@
 /area/lv522/outdoors/n_rockies)
 "xBS" = (
 /obj/structure/stairs/perspective{
-	dir = 6;
 	icon_state = "p_stair_full"
 	},
-/turf/open/asphalt/cement{
-	icon_state = "cement12"
-	},
+/turf/open/asphalt/cement,
 /area/lv522/outdoors/colony_streets/east_central_street)
 "xCG" = (
 /obj/structure/bed/chair/comfy{
@@ -78739,15 +78712,15 @@ hhD
 oLz
 rnA
 pZi
-ahP
+fpB
 pQE
 ooG
 rAK
 oSH
 qSk
 pQE
+ubH
 rMF
-xyN
 xyN
 xyN
 xyN
@@ -78966,15 +78939,15 @@ fjr
 bPH
 dox
 tGl
-crH
+miz
 ofd
 rqs
 uPy
 qGK
 qSk
 ofd
+ubH
 spo
-vXc
 vXc
 vXc
 mqC
@@ -79116,7 +79089,7 @@ xZw
 saC
 saC
 saC
-qpD
+saC
 saC
 bzC
 iAv
@@ -79193,15 +79166,15 @@ fjr
 rZc
 dox
 tGl
-crH
+miz
 ofd
 qSk
 xeg
 uMO
 rqs
 ofd
+ubH
 spo
-vXc
 laX
 dFH
 vXc
@@ -79420,15 +79393,15 @@ fjr
 rZc
 dox
 tGl
-crH
+miz
 ofd
 qSk
 xeg
 uMO
 rqs
 ofd
+ubH
 spo
-vXc
 rjn
 bVu
 vXc
@@ -79545,10 +79518,10 @@ dLs
 afA
 saC
 saC
-esB
-sGF
-dLs
-fcW
+saC
+saC
+yeS
+jKu
 xho
 otQ
 otQ
@@ -79647,15 +79620,15 @@ nQx
 rvx
 fZy
 hAg
-crH
+miz
 ofd
 qiC
 xeg
 qGK
 rqs
 ofd
+ubH
 spo
-vXc
 qbI
 qlD
 qpz
@@ -79771,8 +79744,8 @@ aut
 dOw
 ajw
 bRN
-sGF
-euN
+saC
+saC
 saC
 yeS
 jKu
@@ -79874,15 +79847,15 @@ spe
 nQx
 fjr
 rCV
-crH
+miz
 pQE
 pQE
 rAK
 oSH
 pQE
 pQE
+ubH
 spo
-vXc
 vXc
 vXc
 vXc
@@ -79996,7 +79969,7 @@ cNV
 cNV
 cCC
 xho
-xho
+vDV
 uAd
 saC
 saC
@@ -80026,7 +79999,7 @@ saC
 saC
 saC
 saC
-oaj
+bzC
 iAv
 jqL
 vTK
@@ -80101,15 +80074,15 @@ ugV
 jXQ
 nQx
 fjr
-nIu
+miz
 ofd
 iiL
 xeg
 uMO
 oXF
 ofd
-aPS
-vXc
+ubH
+spo
 vXc
 vXc
 vXc
@@ -80223,7 +80196,7 @@ cNV
 lxW
 dCx
 dtr
-xho
+vDV
 uAd
 saC
 saC
@@ -80335,8 +80308,8 @@ ocn
 qGK
 xvW
 jct
-qQM
-vXc
+ubH
+spo
 pgm
 vXc
 yiM
@@ -80450,7 +80423,7 @@ cNV
 fcV
 dCx
 otQ
-xho
+vDV
 uAd
 saC
 kwJ
@@ -80562,8 +80535,8 @@ iaY
 bGT
 xvW
 tRd
-qQM
-vXc
+ubH
+spo
 tpD
 qQi
 qQi
@@ -80677,7 +80650,7 @@ cNV
 saC
 otQ
 otQ
-xho
+vDV
 uAd
 xgl
 kwJ
@@ -80782,7 +80755,7 @@ rCV
 cpy
 fjr
 fjr
-wsX
+miz
 ofd
 oWV
 xeg
@@ -80790,7 +80763,7 @@ qGK
 oWV
 ofd
 ubH
-vXc
+spo
 yiM
 yiM
 yiM
@@ -80904,13 +80877,13 @@ saC
 saC
 otQ
 otQ
-xho
-uAd
-dEk
-xho
-xho
-yeS
-jKu
+apS
+dAm
+aDj
+cJo
+cJo
+dLs
+cfv
 xho
 otQ
 saC
@@ -81009,15 +80982,15 @@ fjr
 cpy
 cpy
 fjr
-crH
+miz
 pQE
 pQE
 oFN
 cXm
 pQE
 pQE
+ubH
 spo
-vXc
 yiM
 yiM
 iBY
@@ -81137,7 +81110,7 @@ dEk
 yeS
 yeS
 yeS
-jKu
+oML
 xho
 saC
 saC
@@ -81236,15 +81209,15 @@ cpy
 cpy
 cpy
 fjr
-crH
+miz
 ofd
 otj
 uPy
 uMO
 rmi
 ofd
+ubH
 spo
-vXc
 yiM
 yiM
 qCY
@@ -81364,7 +81337,7 @@ ejo
 dOw
 dOw
 dOw
-fda
+gTw
 tiQ
 tiQ
 tiQ
@@ -81463,15 +81436,15 @@ cpy
 cpy
 cpy
 fjr
-crH
+miz
 ofd
 qSk
 xeg
 qGK
 qSk
 ofd
+ubH
 spo
-vXc
 yiM
 yiM
 qCY
@@ -81589,9 +81562,9 @@ saC
 saC
 saC
 otQ
-eyh
-cRN
-eQu
+otQ
+otQ
+otQ
 saC
 saC
 saC
@@ -81697,8 +81670,8 @@ xeg
 qGK
 qSk
 ofd
+ubH
 spo
-yiM
 yiM
 yiM
 qCY
@@ -81816,7 +81789,7 @@ saC
 saC
 saC
 saC
-oEw
+yeS
 saC
 saC
 saC
@@ -81924,8 +81897,8 @@ xeg
 qGK
 rqs
 ofd
+ubH
 spo
-yiM
 yiM
 yiM
 bYS
@@ -82043,7 +82016,7 @@ saC
 saC
 saC
 saC
-qpD
+saC
 saC
 saC
 saC
@@ -82152,7 +82125,7 @@ wwX
 rqs
 pQE
 vSN
-cWT
+hHh
 cWT
 cWT
 cWT
@@ -82270,7 +82243,7 @@ saC
 saC
 saC
 otQ
-eVg
+otQ
 otQ
 saC
 saC
@@ -82497,7 +82470,7 @@ saC
 wLp
 kbV
 kbV
-gPq
+kbV
 kbV
 kbV
 saC
@@ -82724,9 +82697,9 @@ wLp
 qUQ
 qUQ
 qUQ
-ezj
-cSh
-feF
+qUQ
+qUQ
+sxU
 qUQ
 qUQ
 qUQ
@@ -82953,8 +82926,8 @@ dDC
 dDC
 dDC
 dDC
-fhQ
-fpB
+dDC
+dDC
 dDC
 saC
 saC
@@ -83181,7 +83154,7 @@ tjg
 kbV
 tjg
 tjg
-gPq
+kbV
 saC
 saC
 saC
@@ -83408,7 +83381,7 @@ tjg
 kbV
 tjg
 tjg
-gPq
+kbV
 saC
 saC
 saC
@@ -83635,7 +83608,7 @@ kbV
 xiY
 fKt
 fKt
-vzd
+ear
 tQw
 saC
 saC
@@ -83862,7 +83835,7 @@ xiY
 xiY
 tjg
 tjg
-gPq
+kbV
 tjg
 tjg
 hJB
@@ -89415,7 +89388,7 @@ oMn
 oYZ
 pTl
 pKX
-xXg
+xBS
 xXg
 kqb
 kqb
@@ -89620,7 +89593,7 @@ nnz
 oVD
 xjF
 xFp
-xFp
+xZP
 uNB
 xUQ
 ykc
@@ -89642,8 +89615,8 @@ djM
 xAZ
 pTl
 uNB
+xBS
 xXg
-ylr
 wIi
 kqb
 kqb
@@ -89847,7 +89820,7 @@ jRT
 jRT
 ryO
 xFp
-xFp
+xZP
 uNB
 xUQ
 xAZ
@@ -89869,8 +89842,8 @@ xOw
 ykT
 xUQ
 uNB
-dCJ
-tTD
+xBS
+xXg
 ylr
 ylr
 ylr
@@ -90074,7 +90047,7 @@ jRT
 sgV
 ryO
 xFp
-xFp
+xZP
 uNB
 pTl
 xAZ
@@ -90096,8 +90069,8 @@ xOw
 ykT
 xUQ
 uNB
+xBS
 dCJ
-tTD
 tTD
 sKJ
 sKJ
@@ -90301,7 +90274,7 @@ ydb
 val
 ryO
 xFp
-xFp
+xZP
 uNB
 pTl
 ykT
@@ -90323,8 +90296,8 @@ xOw
 xAZ
 pTl
 uNB
+xBS
 dCJ
-tTD
 tTD
 sKJ
 tTD
@@ -90528,7 +90501,7 @@ ydb
 xRQ
 xjF
 xFp
-xFp
+xZP
 pKX
 pKX
 vnq
@@ -90550,8 +90523,8 @@ qCd
 dak
 pKX
 pKX
+xBS
 dCJ
-tTD
 tTD
 tTD
 tTD
@@ -90755,7 +90728,7 @@ jRc
 xjF
 xjF
 xFp
-aDj
+xZP
 pKX
 nvt
 ykT
@@ -90777,8 +90750,8 @@ kcd
 oig
 cLQ
 pKX
-lCn
-tTD
+xBS
+dCJ
 tTD
 tTD
 tTD
@@ -90819,7 +90792,7 @@ eHI
 xvl
 xvl
 teD
-xxq
+xzK
 xxq
 xxq
 xxq
@@ -90962,11 +90935,11 @@ cpy
 cpy
 cpy
 ien
-tNQ
-qSH
-qSH
+cRN
+vTx
+vTx
 trV
-pZo
+eQu
 vGp
 eKe
 xFp
@@ -91004,9 +90977,9 @@ qqx
 pag
 bia
 gYH
-lDE
-tTD
-tTD
+xBS
+dCJ
+rnB
 tTD
 tTD
 tTD
@@ -91046,7 +91019,7 @@ agM
 xvl
 xvl
 xWO
-fWG
+hMz
 fWG
 fWG
 fWG
@@ -91193,7 +91166,7 @@ vGB
 vGB
 wDj
 wDj
-pZo
+fcW
 vGp
 vGp
 eKe
@@ -91231,10 +91204,10 @@ mTK
 sdC
 dvp
 uKy
-lDE
-tTD
-tTD
-tTD
+xBS
+dCJ
+rnB
+rnB
 tTD
 tTD
 cpy
@@ -91273,7 +91246,7 @@ bsG
 vOT
 xvB
 otS
-fWG
+hMz
 fWG
 fWG
 fWG
@@ -91436,7 +91409,7 @@ qSH
 qSH
 qSH
 qSH
-cfv
+sPh
 pKX
 xnI
 ykT
@@ -91459,9 +91432,9 @@ mgb
 rUe
 pKX
 xBS
-tTD
-tTD
-tTD
+dCJ
+rnB
+rnB
 tTD
 tTD
 tTD
@@ -91500,7 +91473,7 @@ acE
 vOT
 xvB
 otS
-fWG
+hMz
 fWG
 fWG
 cpy
@@ -91663,7 +91636,7 @@ rMR
 qSH
 qSH
 vGp
-uRb
+sPh
 pKX
 pKX
 pKn
@@ -91685,10 +91658,10 @@ heX
 jMk
 pKX
 pKX
+xBS
 dCJ
-tTD
-tTD
-tTD
+rnB
+rnB
 tTD
 tTD
 tTD
@@ -91727,7 +91700,7 @@ qZd
 xvl
 xvl
 otS
-fWG
+hMz
 fWG
 cpy
 uwT
@@ -91890,7 +91863,7 @@ qSH
 qSH
 vGp
 vGp
-uRb
+sPh
 uNB
 xUQ
 ykT
@@ -91912,11 +91885,11 @@ iGn
 uOp
 bSI
 uNB
+xBS
 dCJ
-tTD
-tTD
-tTD
-tTD
+rnB
+rnB
+rnB
 sKJ
 tTD
 tTD
@@ -91954,7 +91927,7 @@ ffb
 xvl
 xvl
 otS
-fWG
+hMz
 dBD
 sps
 sps
@@ -92117,7 +92090,7 @@ qSH
 qSH
 vGp
 vGp
-uRb
+sPh
 uNB
 xUQ
 xAZ
@@ -92139,9 +92112,9 @@ sAp
 vHw
 fEF
 uNB
+xBS
 dCJ
-tTD
-tTD
+rnB
 sKJ
 sKJ
 sKJ
@@ -92181,7 +92154,7 @@ acE
 vOT
 xvB
 otS
-fWG
+hMz
 qjO
 ylo
 ylo
@@ -92328,7 +92301,7 @@ iMQ
 wDj
 wDj
 wDj
-pRv
+fda
 xSv
 xSv
 xSv
@@ -92344,7 +92317,7 @@ qSH
 vGp
 vGp
 vGp
-uRb
+sPh
 uNB
 pTl
 xAZ
@@ -92366,9 +92339,9 @@ xOw
 snb
 rkV
 uNB
-dCJ
-tTD
-hrk
+xBS
+xXg
+vlT
 vlT
 vlT
 vlT
@@ -92408,7 +92381,7 @@ acE
 vOT
 xvB
 otS
-fWG
+hMz
 qjO
 ylo
 byR
@@ -92553,9 +92526,9 @@ gjA
 rtX
 wDj
 wDj
-vGp
-vGp
-pZo
+xFp
+xFp
+fcW
 qSH
 qSH
 qSH
@@ -92571,7 +92544,7 @@ qSH
 vGp
 vGp
 kqp
-xFp
+xZP
 uNB
 xUQ
 xnI
@@ -92593,8 +92566,8 @@ bSa
 xAZ
 xUQ
 uNB
+xBS
 xXg
-vlT
 wIi
 tTK
 tTK
@@ -92635,7 +92608,7 @@ qZd
 xvl
 xvl
 otS
-fWG
+hMz
 qjO
 ylo
 sGj
@@ -92782,7 +92755,7 @@ vGB
 mTa
 oqn
 pdv
-umR
+fcW
 qSH
 qSH
 qSH
@@ -92820,7 +92793,7 @@ vfK
 rie
 xUQ
 pKX
-xXg
+xBS
 xXg
 tTK
 tTK
@@ -92862,7 +92835,7 @@ wog
 xvl
 xvl
 otS
-fWG
+hMz
 qjO
 jOF
 oiR
@@ -93009,7 +92982,7 @@ vGB
 ncz
 kKj
 pgp
-umR
+fcW
 qSH
 qSH
 vGp
@@ -93089,7 +93062,7 @@ bsG
 kEQ
 xvB
 otS
-fWG
+hMz
 qjO
 ylo
 hYf
@@ -93236,7 +93209,7 @@ wDj
 nff
 oxT
 pgG
-umR
+fcW
 qSH
 vGp
 vGp
@@ -93316,7 +93289,7 @@ bsG
 vOT
 xvB
 otS
-fWG
+hMz
 qjO
 ylo
 ylo
@@ -93460,10 +93433,10 @@ vGB
 moQ
 vGB
 wDj
-qSH
-qSH
-qSH
-umR
+xFp
+xFp
+dHF
+feF
 vGp
 vGp
 vGp
@@ -93543,7 +93516,7 @@ eHI
 xvl
 xvl
 xwv
-fWG
+hMz
 gBy
 mUr
 kSm
@@ -93687,8 +93660,8 @@ sOL
 sOL
 sOL
 wDj
-qSH
-qSH
+xFp
+ezj
 qSH
 umR
 vGp
@@ -93770,7 +93743,7 @@ acE
 kEQ
 xvl
 otS
-fWG
+hMz
 fWG
 fWG
 uwT
@@ -93914,8 +93887,8 @@ eJR
 eJR
 fQD
 vGB
-qSH
-qSH
+xFp
+ezj
 qSH
 umR
 vGp
@@ -93997,7 +93970,7 @@ acE
 kEQ
 meK
 otS
-fWG
+hMz
 cpy
 cpy
 uwT
@@ -94141,8 +94114,8 @@ rlB
 azE
 qYp
 vGB
-qSH
-qSH
+xFp
+ezj
 qSH
 umR
 vGp
@@ -94224,7 +94197,7 @@ bsG
 kEQ
 xvl
 otS
-fWG
+hMz
 cpy
 uwT
 uwT
@@ -94368,8 +94341,8 @@ rlB
 eJR
 loS
 vGB
-qSH
-qSH
+xFp
+ezj
 qSH
 umR
 vGp
@@ -94451,7 +94424,7 @@ oPW
 xvl
 xvl
 xwv
-uwT
+hMz
 fWG
 uwT
 uwT
@@ -94595,8 +94568,8 @@ eJR
 eJR
 xJg
 wDj
-aij
-qSH
+dsl
+ezj
 qSH
 umR
 qSH
@@ -94678,7 +94651,7 @@ bsG
 kEQ
 xvB
 otS
-uwT
+hMz
 fWG
 fWG
 uwT
@@ -94822,8 +94795,8 @@ rlB
 eJR
 rtX
 wvX
-nTp
-qSH
+esB
+ezj
 qSH
 umR
 qSH
@@ -94905,7 +94878,7 @@ bsG
 kEQ
 xvB
 otS
-uwT
+hMz
 fWG
 fWG
 uwT
@@ -95049,8 +95022,8 @@ rlB
 iJE
 rtX
 ygD
-nTp
-qSH
+esB
+ezj
 qSH
 umR
 qSH
@@ -95132,7 +95105,7 @@ qZd
 xvl
 xvl
 otS
-uwT
+hMz
 uwT
 fWG
 fWG
@@ -95276,8 +95249,8 @@ hcE
 sjQ
 wJk
 wDj
-bcl
-qSH
+euN
+ezj
 qSH
 umR
 qSH
@@ -95359,7 +95332,7 @@ wog
 xvl
 xvl
 otS
-uwT
+hMz
 uwT
 uwT
 fWG
@@ -95503,8 +95476,8 @@ eJR
 azE
 wJk
 wDj
-qSH
-qSH
+xFp
+ezj
 qSH
 qQB
 qDV
@@ -95586,7 +95559,7 @@ bsG
 kEQ
 xvB
 otS
-uwT
+hMz
 uwT
 uwT
 fWG
@@ -95730,8 +95703,8 @@ eJR
 eJR
 mnx
 wDj
-qSH
-qSH
+xFp
+ezj
 qSH
 qSH
 umR
@@ -95813,12 +95786,12 @@ bsG
 vOT
 xvB
 otS
-uxT
+hMz
+kIV
 sps
 sps
 sps
-dsl
-uwT
+ppD
 uwT
 uwT
 uwT
@@ -95957,8 +95930,8 @@ sOL
 sOL
 sOL
 wDj
-ltB
-ltB
+eyh
+eyh
 ltB
 ltB
 bBW
@@ -96040,12 +96013,12 @@ qZd
 xvl
 xvl
 otS
-ppD
+hMz
+nIu
 xkO
 xkO
 xkO
-tKC
-uwT
+qpD
 uwT
 uwT
 uwT
@@ -96267,12 +96240,12 @@ wog
 xvl
 xvl
 otS
-ppD
+hMz
+nIu
 xkO
 vZn
 waD
-ujy
-uwT
+tKC
 uwT
 uwT
 uwT
@@ -96494,12 +96467,12 @@ bsG
 kEQ
 xvB
 otS
-ppD
+hMz
+nIu
 xkO
 xkO
 xkO
-tKC
-uwT
+qpD
 uwT
 uwT
 uwT
@@ -96721,12 +96694,12 @@ bsG
 vOT
 xvB
 otS
-ppD
+hMz
+nIu
 xkO
 ipC
 waD
-ujy
-uwT
+tKC
 uwT
 uwT
 uwT
@@ -96948,12 +96921,12 @@ wog
 xvl
 xvl
 otS
-ppD
+hMz
+nIu
 xkO
 xkO
 xkO
-tKC
-fWG
+qpD
 uwT
 uwT
 uwT
@@ -97175,12 +97148,12 @@ oPW
 xvl
 xvl
 otS
-kIV
+hMz
+oaj
 mUr
 mUr
-apS
 wRk
-fWG
+ujy
 uwT
 uwT
 uwT
@@ -97402,7 +97375,7 @@ vdz
 xvl
 xvl
 otS
-uwT
+hMz
 uwT
 uwT
 fWG
@@ -97629,7 +97602,7 @@ fzV
 qqR
 cUG
 iQR
-uwT
+hMz
 uwT
 uwT
 fWG
@@ -97855,8 +97828,8 @@ xRw
 uaI
 eHB
 cUG
-hMz
-uwT
+xzK
+cpk
 uwT
 uwT
 fWG
@@ -100530,7 +100503,7 @@ umR
 vGp
 vGp
 vGp
-uRb
+fhQ
 gdO
 gdO
 gdO
@@ -100757,16 +100730,16 @@ umR
 qSH
 vGp
 vGp
-hHh
-xFp
+eKe
+xZP
 gdO
 ene
 vTW
 puJ
 ufU
 gdO
+xBS
 xXg
-ylr
 ylr
 ylr
 ylr
@@ -100992,8 +100965,8 @@ vDa
 pej
 ufU
 raj
+lDE
 dCJ
-sKJ
 tTD
 rnB
 rnB
@@ -101219,8 +101192,8 @@ vDa
 pej
 rMr
 gdO
-lCn
-tTD
+lDE
+dCJ
 rnB
 rnB
 rnB
@@ -101447,7 +101420,7 @@ puJ
 pej
 uBd
 lDE
-rnB
+dCJ
 rnB
 rnB
 rnB
@@ -101674,7 +101647,7 @@ puJ
 pej
 qZC
 lDE
-rnB
+dCJ
 rnB
 rnB
 rnB
@@ -101893,15 +101866,15 @@ vGp
 vGp
 vGp
 vGp
-gBb
+ioD
 gdO
 ene
 pej
 pej
 ufU
 gdO
-xBS
-rnB
+lDE
+dCJ
 rnB
 rnB
 rnB
@@ -102127,8 +102100,8 @@ pej
 pej
 ufU
 raj
+lDE
 dCJ
-rnB
 rnB
 rnB
 rnB
@@ -102347,7 +102320,7 @@ vGp
 vGp
 kQJ
 tPb
-uRb
+sPh
 gdO
 ene
 puJ
@@ -102355,7 +102328,7 @@ puJ
 ene
 gdO
 cpy
-rnB
+dCJ
 rnB
 rnB
 rnB


### PR DESCRIPTION

# About the pull request

This PR changes the following areas

Overall ledges: A fair amount of colony ledges have been replaced with stairs instead while visually it looks worse they maintain the depth perspective and allow for better gameplay

Sewer: Sewer while cool visually sucked to fight in and while I think fighting there is awesome others disagree so I've expanded it to be roomier added another way into the reactor caves and removed some ledges

Reactor main door a lot of the walls in the hallway are now breakable allowing marines more ease to get into the reactor proper

East reactor: removed redundant room that confused players who believed it wasn't a dead end (Originally it wasn't a dead end)

# Explain why it's good for the game

I think I've explained myself in the above section any confusion feel free to talk to me in the CM discord, the PR comments, My Discord DMs at SpartanBobby

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: SpartanBobby
maptweak: Changes to LV522: Less ledges overall
maptweak: Changes to LV522: More breakable entry to the reactor
maptweak: Changes to LV522: Removed dead end in reactor
/:cl:
