### PR TITLE
Allows helmets to protect Synthetics

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -1503,7 +1503,7 @@ treat_grafted var tells it to apply to grafted but unsalved wounds, for burn kit
 /obj/limb/head/limb_delimb(damage_source)
 	var/obj/item/clothing/head/helmet/owner_helmet = owner.head
 
-	if(!istype(owner_helmet) || !owner.allow_gun_usage)
+	if(!istype(owner_helmet))
 		droplimb(0, 0, damage_source)
 		return
 


### PR DESCRIPTION

# About the pull request

This PR allows helmets to once more protect Synthetics, undoing a hidden mechanic which was implemented almost 8 years ago.

Many people don't know this mechanic exists, including some of my own councilors. Originally I thought it was pretty unique for Synthetics to be decapitated via a stray bullet or slash, causing a talking head to appear and interact. I myself have had some interesting RP come from this(like guiding a doctor on how to repair the body, live) and so I understood the appeal. 

However, this mechanic makes no sense from any perspective other than to allow easy decaps, and this too has been alleviated. Helmets can now be removed in the same way a head can be removed - by damaging the head(helmet). Thus, this mechanic has certainly become antiquated, and I don't expect this change to have a large impact on gameplay outside of scenarios where, if things were about to hit the fan, then a Synthetic may wear it(riot events, HvH scenarios, special circumstances etc.)

As it stands, even with the shroud of this hidden mechanic, only 1-3% of Synthetics wore a helmet in the first place, as usual, it was to complement the appearance of the Synthetic. I don't predict a serious shift outside of scenarios where people would usually go out of their way to wear helmets anywho, such as a hostile human boarding team or riot scenarios, as aforementioned. 
# Explain why it's good for the game

Wearing something to protect, that offers no protection is absolutely misleading. Removing the protection mechanic from the game is unnecessary because helmets can still be removed through traditional means thanks to changes introduced since. The justification of removing the protection mechanic from Synthetic serves no purpose and it is not only so hidden and unexplained, but it genuinely is unnecessary due to decapitation being fully possible. Even under the threat of HvH, friendly fire, stray bullets or special circumstances - you will STILL be hard pressed to find a Synthetic wearing a helmet. For the times that they do, it should act as intended.

 This mechanic currently circumvents the 'popping off helmet' mechanic which in and of itself is a very unique and cool mechanic to witness. By undoing it, **we get both unique cases** within the realm of possibility: a helmet popping off with a big *THUNK* and the decapitation of a Synthetic. 




# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

current: https://cdn.discordapp.com/attachments/1042176396711170119/1221661321595195474/image.png?ex=661363c4&is=6600eec4&hm=3815815e392d0aabcbb0728d9cc699b0c6bfe80d0bdea9676d7a86ee34953762&
(helmet or no helmet results in possible decapitation, without any notice or input)


after PR: https://cdn.discordapp.com/attachments/1042176396711170119/1221661255450755092/image.png?ex=661363b4&is=6600eeb4&hm=a0a4c3c9228cce27939139ef2f818b5df8781400bae94ede5217e90411fc021b&

(heavily wounded, helmet is popped off with a *POP* noise, then followed by decapitation if further damage occurs. no helmet results in possible decapitation as intended)
</details>


# Changelog
:cl:
balance: Helmets now properly protect Synthetics from sudden decapitation if worn, and can be knocked off just like a human.
/:cl:
