### PR TITLE
Autocompressor Efficiency Increase mk2

### DIFF
--- a/code/game/objects/items/tools/experimental_tools.dm
+++ b/code/game/objects/items/tools/experimental_tools.dm
@@ -157,7 +157,7 @@
 		end_cpr()
 		return PROCESS_KILL
 
-	if(world.time > last_pump + 10 SECONDS)
+	if(world.time > last_pump + 7.5 SECONDS)
 		last_pump = world.time
 		if(H.stat == UNCONSCIOUS)
 			var/suff = min(H.getOxyLoss(), 10) //Pre-merge level, less healing, more prevention of dying.

--- a/code/game/objects/items/tools/experimental_tools.dm
+++ b/code/game/objects/items/tools/experimental_tools.dm
@@ -157,7 +157,7 @@
 		end_cpr()
 		return PROCESS_KILL
 
-	if(world.time > last_pump + 7.5 SECONDS)
+	if(world.time > last_pump + 10 SECONDS)
 		last_pump = world.time
 		if(H.stat == UNCONSCIOUS)
 			var/suff = min(H.getOxyLoss(), 10) //Pre-merge level, less healing, more prevention of dying.


### PR DESCRIPTION
# About the pull request

Makes the autocompressor more useful and less set dressing, compresses every 7.5 seconds rather than every 10 seconds. 

# Explain why it's good for the game

Gives more reason to take tools and not weapons.

# Testing Photographs and Procedure
Tested on local 

# Changelog

:cl:
balance: Autocompressor gives 7 seconds of grace time every 7.5 seconds, instead of 7 seconds every 10 seconds. Approximately 93% efficient, increased from 70% efficient.
/:cl:

