### PR TITLE
fix burrowed burrower should not be hit by gau

### DIFF
--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -176,9 +176,10 @@
 			create_shrapnel(impact_tile,1,0,0,shrapnel_type,cause_data,FALSE,100) //simulates a bullet
 			for(var/atom/movable/explosion_effect in impact_tile)
 				if(iscarbon(explosion_effect))
-					var/mob/living/carbon/bullet_effect = explosion_effect
-					explosion_effect.ex_act(EXPLOSION_THRESHOLD_VLOW, null, cause_data)
-					bullet_effect.apply_armoured_damage(directhit_damage,ARMOR_BULLET,BRUTE,null,penetration)
+					if(!HAS_TRAIT(explosion_effect, TRAIT_ABILITY_BURROWED))
+						var/mob/living/carbon/bullet_effect = explosion_effect
+						explosion_effect.ex_act(EXPLOSION_THRESHOLD_VLOW, null, cause_data)
+						bullet_effect.apply_armoured_damage(directhit_damage,ARMOR_BULLET,BRUTE,null,penetration)
 				else
 					explosion_effect.ex_act(EXPLOSION_THRESHOLD_VLOW)
 			new /obj/effect/particle_effect/expl_particles(impact_tile)


### PR DESCRIPTION

# About the pull request

adds check for being burrowed to direct GAU damage

# Explain why it's good for the game

burrowed burrower should not be hit by any effect, bugfix (untested, not good at testing stuff that reqires checking more mobs but should work"


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: GAU can not hit burrowed burrower 
/:cl:
