### PR TITLE
Acid runner tweaks 

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/runner/acid.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/runner/acid.dm
@@ -83,7 +83,10 @@
 		modify_acid(acid_slash_regen_standing)
 
 /datum/behavior_delegate/runner_acider/on_life()
-	modify_acid(acid_passive_regen)
+	if(acid_amount > 400)
+		return
+	else
+		modify_acid(acid_passive_regen)
 	if(!bound_xeno)
 		return
 	if(bound_xeno.stat == DEAD)


### PR DESCRIPTION
# About the pull request
Makes it so you no longer get passive acid above 400.
Tailstab no longer applies acid.

# Explain why it's good for the game
In the midst of nothingburgers, people have started complaining about acid runners. And i wanted to touch it up before anyone else did because half of the people complaining have never touched xenomorph in their life

Why didnt you touch the queen screech + acid bomb combo

Because an acider needed to farm one thousand acid, plus a queen, plus her being off ovi, plus coordination which i think all of that teamwork should be rewarded

Why didnt you make the runner bomb stop if he went into crit

With the amount of IFF, Grenades, and all the other doo hickeys we have its kind of impossible to run at marines without instantly getting into crit, and all that effort being wasted because of that doesnt feel good for the runner.

Why did you make it so you dont get passive acid above 400
So people dont stay afk in hive from the start to instantly bomb the front

Why didnt you make it so the tailstab doesnt apply acid

An attacked abiltiy that already dazes you with a caste that fast shouldnt reward you with an AOE stack ontop of it. personally it wasnt really an issue for me but i can see why it would be to other people


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Tailstab no longer applies acid
balance: Passive acid gain for the acider strain now caps at 400.
/:cl:
