### PR TITLE
'movable_pre_move overridden' runtime fix

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -125,6 +125,9 @@
 	..()
 
 /obj/item/storage/backpack/proc/is_accessible_by(mob/user)
+	// If the user is already looking inside this backpack.
+	if(user.s_active == src)
+		return TRUE
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(!worn_accessible)


### PR DESCRIPTION

# About the pull request

Fixes this runtime error:
```
runtime error: movable_pre_move overridden. Use override = TRUE to suppress this warning
 - proc name: stack trace (/proc/stack_trace)
 -   source file: unsorted.dm,1834
 -   usr: Sean Agg (/mob/living/carbon/human)
 -   src: null
 -   usr.loc: the floor (45,79,2) (/turf/open/floor/almayer)
 -   call stack:
 - stack trace("movable_pre_move overridden. U...")
 - the USCM technician welderpack (/obj/item/storage/backpack/marine/engineerpack): RegisterSignal(Sean Agg (/mob/living/carbon/human), "movable_pre_move", /obj/item/storage/proc/storage... (/obj/item/storage/proc/storage_close), 0)
 - the USCM technician welderpack (/obj/item/storage/backpack/marine/engineerpack): is accessible by(Sean Agg (/mob/living/carbon/human))
 - the USCM technician welderpack (/obj/item/storage/backpack/marine/engineerpack): open(Sean Agg (/mob/living/carbon/human))
 - the USCM technician welderpack (/obj/item/storage/backpack/marine/engineerpack): handle mmb open(Sean Agg (/mob/living/carbon/human))
 - the USCM technician welderpack (/obj/item/storage/backpack/marine/engineerpack): clicked(Sean Agg (/mob/living/carbon/human), /list (/list), null, "icon-x=18;icon-y=19;middle=1;b...")
 - Sean Agg (/mob/living/carbon/human): do click(the USCM technician welderpack (/obj/item/storage/backpack/marine/engineerpack), null, "icon-x=18;icon-y=19;middle=1;b...")
 - SabreML (/client): Click(the USCM technician welderpack (/obj/item/storage/backpack/marine/engineerpack), null, "mapwindow.map", "icon-x=18;icon-y=19;middle=1;b...")
```

This happened when a player tried to open their equipped backpack while it's already open.

# Explain why it's good for the game

One less error!

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixed a runtime error caused when trying to open an already opened backpack.
/:cl:
