### PR TITLE
Fixes a few runtimes from HUD cycling

### DIFF
--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -120,11 +120,17 @@
 	if(.)
 		return
 
+	// Get the user's marine helmet (if they're wearing one)
 	var/mob/living/carbon/human/human_user = user.mob
-	var/obj/item/clothing/head/helmet/marine/marine_helmet = human_user?.head
-	var/cycled_hud = marine_helmet?.cycle_huds(human_user)
+	var/obj/item/clothing/head/helmet/marine/marine_helmet = human_user.head
+	if(!istype(marine_helmet))
+		return
 
+	// Cycle the HUD on the helmet.
+	var/cycled_hud = marine_helmet.cycle_huds(human_user)
+
+	// Update the helmet's 'cycle hud' action button
 	var/datum/action/item_action/cycle_helmet_huds/cycle_action = locate() in marine_helmet.actions
-	cycle_action.set_action_overlay(cycled_hud)
+	cycle_action?.set_action_overlay(cycled_hud)
 
 	return TRUE

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -124,6 +124,7 @@
 	var/mob/living/carbon/human/human_user = user.mob
 	var/obj/item/clothing/head/helmet/marine/marine_helmet = human_user.head
 	if(!istype(marine_helmet))
+		// If their hat isn't a marine helmet, or is null, return.
 		return
 
 	// Cycle the HUD on the helmet.


### PR DESCRIPTION

# About the pull request

Fixes a few runtimes from the 'Cycle Helmet HUD' keybind.
Specifically:

<hr>

```
runtime error: undefined proc or verb /obj/item/clothing/head/beret/cm/cycle huds().
 - 
 - proc name: down (/datum/keybinding/human/cycle_helmet_hud/down)
 -   source file: human.dm,125
 -   usr: Sean Agg (/mob/living/carbon/human)
 -   src: cycle_helmet_hud (/datum/keybinding/human/cycle_helmet_hud)
 -   usr.loc: the floor (48,79,2) (/turf/open/floor/almayer)
 -   call stack:
 - cycle_helmet_hud (/datum/keybinding/human/cycle_helmet_hud): down(SabreML (/client))
 - SabreML (/client): keyDown("J")
```
Caused if the player was wearing a hat which wasn't a `/obj/item/clothing/head/helmet/marine` subtype.
(In this case a beret)
<hr>

```
runtime error: Cannot read null.vars
 - proc name: down (/datum/keybinding/human/cycle_helmet_hud/down)
 -   source file: human.dm,127
 -   usr: Sean Agg (/mob/living/carbon/human)
 -   src: cycle_helmet_hud (/datum/keybinding/human/cycle_helmet_hud)
 -   usr.loc: the floor (48,78,2) (/turf/open/floor/almayer)
 -   call stack:
 - cycle_helmet_hud (/datum/keybinding/human/cycle_helmet_hud): down(SabreML (/client))
 - SabreML (/client): keyDown("J")
```
Caused if the player wasn't wearing a hat at all.
<hr>

```
runtime error: Cannot execute null.set action overlay().
 - proc name: down (/datum/keybinding/human/cycle_helmet_hud/down)
 -   source file: human.dm,128
 -   usr: Sean Agg (/mob/living/carbon/human)
 -   src: cycle_helmet_hud (/datum/keybinding/human/cycle_helmet_hud)
 -   usr.loc: the floor (49,77,2) (/turf/open/floor/almayer)
 -   call stack:
 - cycle_helmet_hud (/datum/keybinding/human/cycle_helmet_hud): down(SabreML (/client))
 - SabreML (/client): keyDown("J")
```
Caused if the player was wearing a `/obj/item/clothing/head/helmet/marine` subtype, but it didn't have a HUD action.
(In this case the reporter helmet)
<hr>

I should note that while this is mostly adding extra checks, I *did* remove the `?` from `human_user?.head` check. As far as I know it isn't possible for a client *not* to have an attached `mob`, and `/datum/keybinding/human/can_use()` covers that either way.

# Explain why it's good for the game

Three bugfixes for the price of one!

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixed a few runtime errors caused by the 'Cycle Helmet HUD' keybind.
/:cl:
