### PR TITLE
Removes OT mortar shells

### DIFF
--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -306,21 +306,6 @@
 	path = /obj/item/explosive/warhead/rocket
 	category = AUTOLATHE_CATEGORY_EXPLOSIVES
 
-/datum/autolathe/recipe/armylathe/mortar_shell
-	name = "80mm Mortar Shell"
-	path = /obj/item/mortar_shell/custom
-	category = AUTOLATHE_CATEGORY_EXPLOSIVES
-
-/datum/autolathe/recipe/armylathe/mortar_warhead
-	name = "80mm Mortar Warhead"
-	path = /obj/item/explosive/warhead/mortar
-	category = AUTOLATHE_CATEGORY_EXPLOSIVES
-
-/datum/autolathe/recipe/armylathe/mortar_camera_warhead
-	name = "80mm Mortar Camera Warhead"
-	path = /obj/item/explosive/warhead/mortar/camera
-	category = AUTOLATHE_CATEGORY_EXPLOSIVES
-
 /datum/autolathe/recipe/armylathe/flamer_tank
 	name = "Custom M240A1 Fuel Tank"
 	path = /obj/item/ammo_magazine/flamer_tank/custom


### PR DESCRIPTION

# About the pull request
removes OT shells from the armylathe

# Explain why it's good for the game
![image](https://github.com/cmss13-devs/cmss13/assets/140007537/5f1ffcda-ee1b-481c-bc96-e8b22247ec8d)

OT shells are really just CAS fatties
they clear out xeno fortifications too easily and the big radius is unfun to play against

# Testing Photographs and Procedure
probably works

# Changelog
:cl:
balance: removed OT mortar shells from normal gameplay loop
/:cl:
