### PR TITLE
Fixes Marine Minor (Hive collapse)

### DIFF
--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -332,7 +332,7 @@
 			if(HS.living_xeno_queen && !should_block_game_interaction(HS.living_xeno_queen.loc))
 				//Some Queen is alive, we shouldn't end the game yet
 				return
-		if (HS.totalXenos <= 3)
+		if(length(HS.totalXenos) <= 3)
 			round_finished = MODE_INFESTATION_M_MAJOR
 		else
 			round_finished = MODE_INFESTATION_M_MINOR


### PR DESCRIPTION

# About the pull request

Fixes a runtime in `/datum/game_mode/colonialmarines/check_queen_status()` which was stopping the 'Marine Minor' round result (Hive collapse) from being set. (Added by a tiny mistake in #5442)
```
runtime error: type mismatch: cannot compare /list (/list) to 3
 - proc name: check queen status (/datum/game_mode/colonialmarines/check_queen_status)
 -   source file: code/game/gamemodes/colonialmarines/colonialmarines.dm,335
 -   usr: null
 -   src: Distress Signal (/datum/game_mode/colonialmarines)
 -   call stack:
 - Distress Signal (/datum/game_mode/colonialmarines): check queen status("xeno_hive_normal")
```
The `totalXenos` list itself was being compared to the number instead of the list's length, which aborted the proc before `round_finished` could be set.
I've gone through all of this year's game logs just to double check, and there hasn't been a 'Marine Minor Victory' since the 24th of January.

# Explain why it's good for the game
Marines get a slightly worse victory condition again. (woo!)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixed a runtime error preventing a 'Marine Minor' (Hive collapse) roundend state.
/:cl:
