### PR TITLE
reduces impact area from 9x9 to 7x7, lowers DPS slightly

### DIFF
--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -144,7 +144,7 @@
 	ammo_used_per_firing = 40
 	point_cost = 275
 	fire_mission_delay = 2
-	var/bullet_spread_range = 4 //how far from the real impact turf can bullets land
+	var/bullet_spread_range = 3 //how far from the real impact turf can bullets land
 	var/shrapnel_type = /datum/ammo/bullet/shrapnel/gau //For siming 30mm bullet impacts.
 	var/directhit_damage = 105 //how much damage is to be inflicted to a mob, this is here so that we can hit resting mobs.
 	var/penetration = 10 //AP value pretty much
@@ -169,27 +169,26 @@
 
 	for(var/i = 1 to ammo_used_per_firing)
 		sleep(1)
-		for(var/j in 1 to 2) //rather than halving the sleep, were doubling the bullets shot "bang"
-			var/turf/impact_tile = pick(turf_list)
-			var/datum/cause_data/cause_data = create_cause_data(fired_from.name, source_mob)
-			impact_tile.ex_act(EXPLOSION_THRESHOLD_VLOW, pick(GLOB.alldirs), cause_data)
-			create_shrapnel(impact_tile,1,0,0,shrapnel_type,cause_data,FALSE,100) //simulates a bullet
-			for(var/atom/movable/explosion_effect in impact_tile)
-				if(iscarbon(explosion_effect))
-					var/mob/living/carbon/bullet_effect = explosion_effect
-					explosion_effect.ex_act(EXPLOSION_THRESHOLD_VLOW, null, cause_data)
-					bullet_effect.apply_armoured_damage(directhit_damage,ARMOR_BULLET,BRUTE,null,penetration)
-				else
-					explosion_effect.ex_act(EXPLOSION_THRESHOLD_VLOW)
-			new /obj/effect/particle_effect/expl_particles(impact_tile)
-			if(!soundplaycooldown) //so we don't play the same sound 20 times very fast.
-				playsound(impact_tile, 'sound/effects/gauimpact.ogg',40,1,20)
-				soundplaycooldown = 3
-			soundplaycooldown--
-			if(!debriscooldown)
-				impact_tile.ceiling_debris_check(1)
-				debriscooldown = 6
-			debriscooldown--
+		var/turf/impact_tile = pick(turf_list)
+		var/datum/cause_data/cause_data = create_cause_data(fired_from.name, source_mob)
+		impact_tile.ex_act(EXPLOSION_THRESHOLD_VLOW, pick(GLOB.alldirs), cause_data)
+		create_shrapnel(impact_tile,1,0,0,shrapnel_type,cause_data,FALSE,100) //simulates a bullet
+		for(var/atom/movable/explosion_effect in impact_tile)
+			if(iscarbon(explosion_effect))
+				var/mob/living/carbon/bullet_effect = explosion_effect
+				explosion_effect.ex_act(EXPLOSION_THRESHOLD_VLOW, null, cause_data)
+				bullet_effect.apply_armoured_damage(directhit_damage,ARMOR_BULLET,BRUTE,null,penetration)
+			else
+				explosion_effect.ex_act(EXPLOSION_THRESHOLD_VLOW)
+		new /obj/effect/particle_effect/expl_particles(impact_tile)
+		if(!soundplaycooldown) //so we don't play the same sound 20 times very fast.
+			playsound(impact_tile, 'sound/effects/gauimpact.ogg',40,1,20)
+			soundplaycooldown = 3
+		soundplaycooldown--
+		if(!debriscooldown)
+			impact_tile.ceiling_debris_check(1)
+			debriscooldown = 6
+		debriscooldown--
 	sleep(11) //speed of sound simulation
 	playsound(impact, 'sound/effects/gau.ogg',100,1,60)
 


### PR DESCRIPTION
# About the pull request

okey this is basicly copy of my suggested buff from more then a year ago, but now it is a nerf. Main complain on why the GAU is so OP and strong is its spreat ( that used to be the reason why it was so weak and shit). Therfore, lets do some math. Current situation is that the GAU fires 80 rounds per burst at area of 81 tiles( 9x9) ~0,988 round per tile, the proposed change aims the keep the damage on anyone standing in the impact area about the same ( it is a bit lower might need compensation with bringing the damage to pre double bullet values) , by bringing down the impact area to 49 tiles (7x7) and lowering the number of shots fired to 40, we get value of ~0,816 round per tile. meanwhile it keeps the rest like how long the bursts last the just as long.
(https://github.com/cmss13-devs/cmss13/pull/4302 the old "buff")

# Explain why it's good for the game
Making two bullets per bullet was not a bad idea in general, it brought the DPS on competetive level with other weapons, but the huge spread leads to too big compared to other ordinance. Bringing it in line with other ordinance should allow for easier CAS balance around smaller impact FMs.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: reduced GAU spread from 9x9 to 7x7
balance: reduced GAU shots fired per shot back to 1 (bullets per tile from 0.99 to 0.82)
/:cl:
