### PR TITLE
Xenothumbs Minor Event Button Comeback

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -179,6 +179,8 @@
 // HIVE TRAITS
 /// If the Hive is a Xenonid Hive
 #define TRAIT_XENONID "t_xenonid"
+/// If the hive or xeno can use objects.
+#define TRAIT_OPPOSABLE_THUMBS "t_thumbs"
 /// If the Hive delays round end (this is overridden for some hives). Does not occur naturally. Must be applied in events.
 #define TRAIT_NO_HIVE_DELAY "t_no_hive_delay"
 /// If the Hive uses it's colors on the mobs. Does not occur naturally, excepting the Mutated hive.

--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -765,7 +765,7 @@ SUBSYSTEM_DEF(minimaps)
 	data["canDraw"] = FALSE
 	data["canViewTacmap"] = TRUE
 	data["canViewCanvas"] = FALSE
-	data["isXeno"] = FALSE
+	data["isxeno"] = FALSE
 
 	return data
 
@@ -781,7 +781,7 @@ SUBSYSTEM_DEF(minimaps)
 	var/is_xeno = istype(xeno)
 	var/faction = is_xeno ? xeno.hivenumber : user.faction
 
-	data["isXeno"] = is_xeno
+	data["isxeno"] = is_xeno
 	data["canViewTacmap"] = is_xeno
 	data["canViewCanvas"] = faction == FACTION_MARINE || faction == XENO_HIVE_NORMAL
 
@@ -799,7 +799,7 @@ SUBSYSTEM_DEF(minimaps)
 	data["canDraw"] = FALSE
 	data["canViewTacmap"] = FALSE
 	data["canViewCanvas"] = TRUE
-	data["isXeno"] = FALSE
+	data["isxeno"] = FALSE
 
 	return data
 
@@ -811,7 +811,7 @@ SUBSYSTEM_DEF(minimaps)
 	data["canDraw"] = FALSE
 	data["canViewTacmap"] = FALSE
 	data["canViewCanvas"] = TRUE
-	data["isXeno"] = TRUE
+	data["isxeno"] = TRUE
 
 	return data
 

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -191,6 +191,8 @@
 		var/mob/living/carbon/human/human = owner
 		if(human.body_position == STANDING_UP)
 			return TRUE
+	if((ishuman(owner) || HAS_TRAIT(owner, TRAIT_OPPOSABLE_THUMBS)) && !owner.is_mob_incapacitated() && !owner.lying)
+		return TRUE
 
 /datum/action/item_action/update_button_icon()
 	button.overlays.Cut()

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -191,7 +191,7 @@
 		var/mob/living/carbon/human/human = owner
 		if(human.body_position == STANDING_UP)
 			return TRUE
-	if((ishuman(owner) || HAS_TRAIT(owner, TRAIT_OPPOSABLE_THUMBS)) && !owner.is_mob_incapacitated() && !owner.lying)
+	if((HAS_TRAIT(owner, TRAIT_OPPOSABLE_THUMBS)) && !owner.is_mob_incapacitated())
 		return TRUE
 
 /datum/action/item_action/update_button_icon()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -254,6 +254,11 @@ Class Procs:
 		return TRUE
 	if(user.is_mob_incapacitated())
 		return TRUE
+	if(!(istype(user, /mob/living/carbon/human) || isRemoteControlling(user) || istype(user, /mob/living/carbon/Xenomorph)))
+		to_chat(world,"thumbcheck")
+		if(!HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
+			to_chat(usr, SPAN_DANGER("You don't have the dexterity to do this!"))
+			return TRUE
 	if(!is_valid_user(user))
 		to_chat(usr, SPAN_DANGER("You don't have the dexterity to do this!"))
 		return TRUE

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -254,8 +254,7 @@ Class Procs:
 		return TRUE
 	if(user.is_mob_incapacitated())
 		return TRUE
-	if(!(istype(user, /mob/living/carbon/human) || isRemoteControlling(user) || istype(user, /mob/living/carbon/Xenomorph)))
-		to_chat(world,"thumbcheck")
+	if(!(istype(user, /mob/living/carbon/human) || isRemoteControlling(user) || istype(user, /mob/living/carbon/xenomorph)))
 		if(!HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
 			to_chat(usr, SPAN_DANGER("You don't have the dexterity to do this!"))
 			return TRUE

--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -517,7 +517,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 		return
 
 	var/mob/living/carbon/human/human_user
-	var/mob/living/carbon/user = usr
+	var/mob/living/carbon/user = ui.user
 
 	if(ishuman(user))
 		human_user = usr

--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -394,7 +394,11 @@ GLOBAL_LIST_EMPTY(vending_products)
 
 	if(M.action_busy)
 		return XENO_NO_DELAY_ACTION
-
+	if(M.a_intent == INTENT_HELP)
+		M.set_interaction(src)
+		ui_interact(M)
+		to_chat(world,"help")
+		return XENO_NO_DELAY_ACTION
 	M.visible_message(SPAN_WARNING("[M] begins to lean against [src]."), \
 	SPAN_WARNING("You begin to lean against [src]."), null, 5, CHAT_TYPE_XENO_COMBAT)
 	var/shove_time = 80

--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -373,45 +373,49 @@ GLOBAL_LIST_EMPTY(vending_products)
 
 //------------INTERACTION PROCS---------------
 
-/obj/structure/machinery/cm_vending/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/machinery/cm_vending/attack_alien(mob/living/carbon/xenomorph/user)
 	if(stat & TIPPED_OVER || indestructible)
-		to_chat(M, SPAN_WARNING("There's no reason to bother with that old piece of trash."))
+		to_chat(user, SPAN_WARNING("There's no reason to bother with that old piece of trash."))
 		return XENO_NO_DELAY_ACTION
 
-	if(M.a_intent == INTENT_HARM && !unslashable)
-		M.animation_attack_on(src)
-		if(prob(M.melee_damage_lower))
+	if(user.a_intent == INTENT_HARM && !unslashable)
+		user.animation_attack_on(src)
+		if(prob(user.melee_damage_lower))
 			playsound(loc, 'sound/effects/metalhit.ogg', 25, 1)
-			M.visible_message(SPAN_DANGER("[M] smashes [src] beyond recognition!"), \
+			user.visible_message(SPAN_DANGER("[user] smashes [src] beyond recognition!"), \
 			SPAN_DANGER("You enter a frenzy and smash [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 			malfunction()
 			tip_over()
 		else
-			M.visible_message(SPAN_DANGER("[M] slashes [src]!"), \
+			user.visible_message(SPAN_DANGER("[user] slashes [src]!"), \
 			SPAN_DANGER("You slash [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 			playsound(loc, 'sound/effects/metalhit.ogg', 25, 1)
 		return XENO_ATTACK_ACTION
 
-	if(M.action_busy)
+	if(user.action_busy)
 		return XENO_NO_DELAY_ACTION
-	if(M.a_intent == INTENT_HELP)
-		M.set_interaction(src)
-		ui_interact(M)
-		to_chat(world,"help")
-		return XENO_NO_DELAY_ACTION
-	M.visible_message(SPAN_WARNING("[M] begins to lean against [src]."), \
+	if(user.a_intent == INTENT_HELP && user.IsAdvancedToolUser())
+		user.set_interaction(src)
+		tgui_interact(user)
+		if(!hacked)
+			to_chat(user, SPAN_WARNING("You slash open [src]'s front panel, revealing the items within."))
+			var/datum/effect_system/spark_spread/spark_system = new
+			spark_system.set_up(5, 5, get_turf(src))
+			hacked = TRUE
+		return XENO_ATTACK_ACTION
+	user.visible_message(SPAN_WARNING("[user] begins to lean against [src]."), \
 	SPAN_WARNING("You begin to lean against [src]."), null, 5, CHAT_TYPE_XENO_COMBAT)
 	var/shove_time = 80
-	if(M.mob_size >= MOB_SIZE_BIG)
+	if(user.mob_size >= MOB_SIZE_BIG)
 		shove_time = 30
-	if(istype(M,/mob/living/carbon/xenomorph/crusher))
+	if(istype(user,/mob/living/carbon/xenomorph/crusher))
 		shove_time = 15
 
-	xeno_attack_delay(M) //Adds delay here and returns nothing because otherwise it'd cause lag *after* finishing the shove.
+	xeno_attack_delay(user) //Adds delay here and returns nothing because otherwise it'd cause lag *after* finishing the shove.
 
-	if(do_after(M, shove_time, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
-		M.animation_attack_on(src)
-		M.visible_message(SPAN_DANGER("[M] knocks [src] down!"), \
+	if(do_after(user, shove_time, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
+		user.animation_attack_on(src)
+		user.visible_message(SPAN_DANGER("[user] knocks [src] down!"), \
 		SPAN_DANGER("You knock [src] down!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 		tip_over()
 	return XENO_NO_DELAY_ACTION
@@ -512,7 +516,12 @@ GLOBAL_LIST_EMPTY(vending_products)
 	if(.)
 		return
 
-	var/mob/living/carbon/human/user = usr
+	var/mob/living/carbon/human/human_user
+	var/mob/living/carbon/user = usr
+
+	if(ishuman(user))
+		human_user = usr
+
 	switch (action)
 		if ("vend")
 			if(stat & IN_USE)
@@ -532,8 +541,11 @@ GLOBAL_LIST_EMPTY(vending_products)
 					to_chat(usr, SPAN_WARNING("The floor is too cluttered, make some space."))
 					vend_fail()
 					return FALSE
-
-			if((!user.assigned_squad && squad_tag) || (!user.assigned_squad?.omni_squad_vendor && (squad_tag && user.assigned_squad.name != squad_tag)))
+			if(HAS_TRAIT(user,TRAIT_OPPOSABLE_THUMBS)) // the big monster 7 ft with thumbs does not care for squads
+				vendor_successful_vend(itemspec, usr)
+				add_fingerprint(usr)
+				return TRUE
+			if((!human_user.assigned_squad && squad_tag) || (!human_user.assigned_squad?.omni_squad_vendor && (squad_tag && human_user.assigned_squad.name != squad_tag)))
 				to_chat(user, SPAN_WARNING("This machine isn't for your squad."))
 				vend_fail()
 				return FALSE
@@ -558,7 +570,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 								to_chat(user, SPAN_WARNING("That set is already taken."))
 								vend_fail()
 								return FALSE
-							var/obj/item/card/id/ID = user.wear_id
+							var/obj/item/card/id/ID = human_user.wear_id
 							if(!istype(ID) || !ID.check_biometrics(user))
 								to_chat(user, SPAN_WARNING("You must be wearing your [SPAN_INFO("dog tags")] to select a specialization!"))
 								return FALSE
@@ -583,7 +595,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 									to_chat(user, SPAN_WARNING("<b>Something bad occurred with [src], tell a Dev.</b>"))
 									vend_fail()
 									return FALSE
-							ID.set_assignment((user.assigned_squad ? (user.assigned_squad.name + " ") : "") + JOB_SQUAD_SPECIALIST + " ([specialist_assignment])")
+							ID.set_assignment((human_user.assigned_squad ? (human_user.assigned_squad.name + " ") : "") + JOB_SQUAD_SPECIALIST + " ([specialist_assignment])")
 							GLOB.data_core.manifest_modify(user.real_name, WEAKREF(user), ID.assignment)
 							GLOB.available_specialist_sets -= p_name
 						else if(vendor_role.Find(JOB_SYNTH))
@@ -776,6 +788,8 @@ GLOBAL_LIST_EMPTY(vending_products)
 	return listed_products
 
 /obj/structure/machinery/cm_vending/proc/can_access_to_vend(mob/user, display = TRUE, ignore_hack = FALSE)
+	if(HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS)) // We're just going to skip the mess of access checks assuming xenos with thumbs are human and just allow them to access because it's funny
+		return TRUE
 	if(!hacked || ignore_hack)
 		if(!allowed(user))
 			if(display)

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -36,7 +36,7 @@
 		to_chat(user, SPAN_WARNING("You don't have the dexterity to do this!"))
 		return FALSE
 
-	if(harmful && !user.allow_gun_usage)
+	if(harmful && ishuman(user) && !user.allow_gun_usage)
 		to_chat(user, SPAN_WARNING("Your programming prevents you from using this!"))
 		return FALSE
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -269,7 +269,7 @@
 	if (!ismob(M) || (get_dist(src, user) > 1) || user.is_mob_restrained() || user.stat || buckled_mob || M.buckled || !isturf(user.loc))
 		return
 
-	if (isXeno(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
+	if (isxeno(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
 		to_chat(user, SPAN_WARNING("You don't have the dexterity to do that, try a nest."))
 		return
 	if (iszombie(user))

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -269,7 +269,7 @@
 	if (!ismob(M) || (get_dist(src, user) > 1) || user.is_mob_restrained() || user.stat || buckled_mob || M.buckled || !isturf(user.loc))
 		return
 
-	if (isxeno(user))
+	if (isXeno(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
 		to_chat(user, SPAN_WARNING("You don't have the dexterity to do that, try a nest."))
 		return
 	if (iszombie(user))
@@ -292,12 +292,12 @@
 			if(M.loc != src.loc)
 				return
 			. = buckle_mob(M)
-	if (M.mob_size <= MOB_SIZE_XENO && M.stat == DEAD && istype(src, /obj/structure/bed/roller))
-		do_buckle(M, user)
-		return
-	if (M.mob_size > MOB_SIZE_HUMAN)
-		to_chat(user, SPAN_WARNING("[M] is too big to buckle in."))
-		return
+	if (M.mob_size <= MOB_SIZE_XENO)
+		if ((M.stat == DEAD && istype(src, /obj/structure/bed/roller) || HAS_TRAIT(M, TRAIT_OPPOSABLE_THUMBS)))
+			do_buckle(M, user)
+		else if ((M.mob_size > MOB_SIZE_HUMAN))
+			to_chat(user, SPAN_WARNING("[M] is too big to buckle in."))
+			return
 	do_buckle(M, user)
 
 // the actual buckling proc

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -773,6 +773,7 @@
 		<A href='?src=\ref[src];[HrefToken()];events=nuke'>Spawn a nuke</A><BR>
 		<A href='?src=\ref[src];[HrefToken()];events=pmcguns'>Toggle PMC gun restrictions</A><BR>
 		<A href='?src=\ref[src];[HrefToken()];events=monkify'>Turn everyone into monkies</A><BR>
+		<A href='?src=\ref[src];[HrefToken()];events=xenothumbs'>Give or take opposable thumbs and gun permits from xenos</A><BR>
 		<BR>
 		"}
 

--- a/code/modules/admin/topic/topic_events.dm
+++ b/code/modules/admin/topic/topic_events.dm
@@ -142,15 +142,15 @@
 				return
 
 			if(grant == "Grant")
-				message_staff("[usr] granted 2nd Amendment rights to [length(handled_xenos) > 1 ? "[length(handled_xenos)] xenos" : "[length(handled_xenos) == 1 ? "[handled_xenos[1]]" : "no xenos"]"]\
+				message_admins("[usr] granted 2nd Amendment rights to [length(handled_xenos) > 1 ? "[length(handled_xenos)] xenos" : "[length(handled_xenos) == 1 ? "[handled_xenos[1]]" : "no xenos"]"]\
 					[length(permit_hives) > 1 ? " in all hives, and to any new xenos. Quite possibly we will all regret this." : "[length(permit_hives) == 1 ? " in [permit_hives[1]], and to any new xenos in that hive." : "."]"]")
 			else
-				message_staff("[usr] revoked 2nd Amendment rights from [length(handled_xenos) > 1 ? "[length(handled_xenos)] xenos" : "[length(handled_xenos) == 1 ? "[handled_xenos[1]]" : "no xenos"]"]\
+				message_admins("[usr] revoked 2nd Amendment rights from [length(handled_xenos) > 1 ? "[length(handled_xenos)] xenos" : "[length(handled_xenos) == 1 ? "[handled_xenos[1]]" : "no xenos"]"]\
 					[length(permit_hives) > 1 ? " in all hives, and from any new xenos." : "[length(permit_hives) == 1 ? " in [permit_hives[1]], and from any new xenos in that hive." : "."]"]")
 
 
 
-/datum/admins/proc/create_humans_list(var/href_list)
+/datum/admins/proc/create_humans_list(href_list)
 	if(SSticker?.current_state < GAME_STATE_PLAYING)
 		alert("Please wait until the game has started before spawning humans")
 		return

--- a/code/modules/admin/topic/topic_events.dm
+++ b/code/modules/admin/topic/topic_events.dm
@@ -98,7 +98,7 @@
 			if(grant == "Cancel")
 				return
 
-			var/list/mob/living/carbon/Xenomorph/permit_recipients = list()
+			var/list/mob/living/carbon/xenomorph/permit_recipients = list()
 			var/list/datum/hive_status/permit_hives = list()
 			switch(alert(usr, "Do you wish to do this for one Xeno or an entire hive?", "Recipients", "Xeno", "Hive", "All Xenos"))
 				if("Xeno")
@@ -117,19 +117,19 @@
 
 			var/list/handled_xenos = list()
 
-			for(var/mob/living/carbon/Xenomorph/X as anything in permit_recipients)
-				if(QDELETED(X) || X.stat == DEAD) //Xenos might die before the admin picks them.
-					to_chat(usr, SPAN_HIGHDANGER("[X] died before her firearms permit could be issued!"))
+			for(var/mob/living/carbon/xenomorph/xeno as anything in permit_recipients)
+				if(QDELETED(xeno) || xeno.stat == DEAD) //Xenos might die before the admin picks them.
+					to_chat(usr, SPAN_HIGHDANGER("[xeno] died before her firearms permit could be issued!"))
 					continue
-				if(HAS_TRAIT(X, TRAIT_OPPOSABLE_THUMBS))
+				if(HAS_TRAIT(xeno, TRAIT_OPPOSABLE_THUMBS))
 					if(grant == "Revoke")
-						REMOVE_TRAIT(X, TRAIT_OPPOSABLE_THUMBS, TRAIT_SOURCE_HIVE)
-						to_chat(X, SPAN_XENOANNOUNCE("You forget how thumbs work. You feel a terrible sense of loss."))
-						handled_xenos += X
+						REMOVE_TRAIT(xeno, TRAIT_OPPOSABLE_THUMBS, TRAIT_SOURCE_HIVE)
+						to_chat(xeno, SPAN_XENOANNOUNCE("You forget how thumbs work. You feel a terrible sense of loss."))
+						handled_xenos += xeno
 				else if(grant == "Grant")
-					ADD_TRAIT(X, TRAIT_OPPOSABLE_THUMBS, TRAIT_SOURCE_HIVE)
-					to_chat(X, SPAN_XENOANNOUNCE("You suddenly comprehend the magic of opposable thumbs along with surprising kinesthetic intelligence. You could do... <b><i>so much</b></i> with this knowledge."))
-					handled_xenos += X
+					ADD_TRAIT(xeno, TRAIT_OPPOSABLE_THUMBS, TRAIT_SOURCE_HIVE)
+					to_chat(xeno, SPAN_XENOANNOUNCE("You suddenly comprehend the magic of opposable thumbs along with surprising kinesthetic intelligence. You could do... <b><i>so much</b></i> with this knowledge."))
+					handled_xenos += xeno
 
 			for(var/datum/hive_status/permit_hive as anything in permit_hives)
 				//Give or remove the trait from newly-born xenos in this hive.

--- a/code/modules/admin/topic/topic_events.dm
+++ b/code/modules/admin/topic/topic_events.dm
@@ -128,7 +128,7 @@
 						handled_xenos += X
 				else if(grant == "Grant")
 					ADD_TRAIT(X, TRAIT_OPPOSABLE_THUMBS, TRAIT_SOURCE_HIVE)
-					to_chat(X, SPAN_XENOANNOUNCE("You suddenly comprehend the magic of opposable thumbs. You could do... <b><i>so much</b></i> with this knowledge."))
+					to_chat(X, SPAN_XENOANNOUNCE("You suddenly comprehend the magic of opposable thumbs along with surprising kinesthetic intelligence. You could do... <b><i>so much</b></i> with this knowledge."))
 					handled_xenos += X
 
 			for(var/datum/hive_status/permit_hive as anything in permit_hives)

--- a/code/modules/admin/topic/topic_events.dm
+++ b/code/modules/admin/topic/topic_events.dm
@@ -93,7 +93,64 @@
 				message_admins("[key_name_admin(usr)] added [amount] research credits.")
 				GLOB.chemical_data.update_credits(amount)
 
-/datum/admins/proc/create_humans_list(href_list)
+		if("xenothumbs")
+			var/grant = alert(usr, "Do you wish to grant or revoke Xenomorph firearms permits?", "Give or Take", "Grant", "Revoke", "Cancel")
+			if(grant == "Cancel")
+				return
+
+			var/list/mob/living/carbon/Xenomorph/permit_recipients = list()
+			var/list/datum/hive_status/permit_hives = list()
+			switch(alert(usr, "Do you wish to do this for one Xeno or an entire hive?", "Recipients", "Xeno", "Hive", "All Xenos"))
+				if("Xeno")
+					permit_recipients += tgui_input_list(usr, "Select recipient Xenomorph:", "Armed Xenomorph", GLOB.living_xeno_list)
+					if(isnull(permit_recipients[1])) //Cancel button.
+						return
+				if("Hive")
+					permit_hives += GLOB.hive_datum[tgui_input_list(usr, "Select recipient hive:", "Armed Hive", GLOB.hive_datum)]
+					if(isnull(permit_hives[1])) //Cancel button.
+						return
+					permit_recipients = permit_hives[1].totalXenos.Copy()
+				if("All Xenos")
+					permit_recipients = GLOB.living_xeno_list.Copy()
+					for(var/H in GLOB.hive_datum)
+						permit_hives += GLOB.hive_datum[H]
+
+			var/list/handled_xenos = list()
+
+			for(var/mob/living/carbon/Xenomorph/X as anything in permit_recipients)
+				if(QDELETED(X) || X.stat == DEAD) //Xenos might die before the admin picks them.
+					to_chat(usr, SPAN_HIGHDANGER("[X] died before her firearms permit could be issued!"))
+					continue
+				if(HAS_TRAIT(X, TRAIT_OPPOSABLE_THUMBS))
+					if(grant == "Revoke")
+						REMOVE_TRAIT(X, TRAIT_OPPOSABLE_THUMBS, TRAIT_SOURCE_HIVE)
+						to_chat(X, SPAN_XENOANNOUNCE("You forget how thumbs work. You feel a terrible sense of loss."))
+						handled_xenos += X
+				else if(grant == "Grant")
+					ADD_TRAIT(X, TRAIT_OPPOSABLE_THUMBS, TRAIT_SOURCE_HIVE)
+					to_chat(X, SPAN_XENOANNOUNCE("You suddenly comprehend the magic of opposable thumbs. You could do... <b><i>so much</b></i> with this knowledge."))
+					handled_xenos += X
+
+			for(var/datum/hive_status/permit_hive as anything in permit_hives)
+				//Give or remove the trait from newly-born xenos in this hive.
+				if(grant == "Grant")
+					LAZYADD(permit_hive.hive_inherant_traits, TRAIT_OPPOSABLE_THUMBS)
+				else
+					LAZYREMOVE(permit_hive.hive_inherant_traits, TRAIT_OPPOSABLE_THUMBS)
+
+			if(!length(handled_xenos) && !length(permit_hives))
+				return
+
+			if(grant == "Grant")
+				message_staff("[usr] granted 2nd Amendment rights to [length(handled_xenos) > 1 ? "[length(handled_xenos)] xenos" : "[length(handled_xenos) == 1 ? "[handled_xenos[1]]" : "no xenos"]"]\
+					[length(permit_hives) > 1 ? " in all hives, and to any new xenos. Quite possibly we will all regret this." : "[length(permit_hives) == 1 ? " in [permit_hives[1]], and to any new xenos in that hive." : "."]"]")
+			else
+				message_staff("[usr] revoked 2nd Amendment rights from [length(handled_xenos) > 1 ? "[length(handled_xenos)] xenos" : "[length(handled_xenos) == 1 ? "[handled_xenos[1]]" : "no xenos"]"]\
+					[length(permit_hives) > 1 ? " in all hives, and from any new xenos." : "[length(permit_hives) == 1 ? " in [permit_hives[1]], and from any new xenos in that hive." : "."]"]")
+
+
+
+/datum/admins/proc/create_humans_list(var/href_list)
 	if(SSticker?.current_state < GAME_STATE_PLAYING)
 		alert("Please wait until the game has started before spawning humans")
 		return

--- a/code/modules/cm_marines/m2c.dm
+++ b/code/modules/cm_marines/m2c.dm
@@ -73,7 +73,7 @@
 	icon_state = icon_name
 
 /obj/item/device/m2c_gun/proc/check_can_setup(mob/user, turf/rotate_check, turf/open/OT, list/ACR)
-	if(!ishuman(user))
+	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
 		return FALSE
 	if(broken_gun)
 		to_chat(user, SPAN_WARNING("You can't set up \the [src], it's completely broken!"))
@@ -148,7 +148,7 @@
 		HMG.try_mount_gun(user)
 
 /obj/item/device/m2c_gun/attackby(obj/item/O as obj, mob/user as mob)
-	if(!ishuman(user))
+	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
 		return
 
 	if(!iswelder(O) || user.action_busy)
@@ -330,7 +330,7 @@
 	update_icon()
 
 /obj/structure/machinery/m56d_hmg/auto/attackby(obj/item/O as obj, mob/user as mob)
-	if(!ishuman(user))
+	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
 		return
 	// RELOADING
 	if(istype(O, /obj/item/ammo_magazine/m2c))
@@ -456,13 +456,12 @@
 // DISASSEMBLY
 
 /obj/structure/machinery/m56d_hmg/auto/MouseDrop(over_object, src_location, over_location)
-	if(!ishuman(usr))
-		return
-	var/mob/living/carbon/human/user = usr
+	var/mob/living/carbon/user = usr
 	// If the user is unconscious or dead.
 	if(user.stat)
 		return
-
+	if(!ishuman(user)  && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
+		return
 	if(over_object == user && in_range(src, user))
 		if((rounds > 0) && (user.a_intent & (INTENT_GRAB)))
 			playsound(src.loc, 'sound/items/m56dauto_load.ogg', 75, 1)

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -188,7 +188,7 @@
 /obj/item/device/m56d_post/attack_self(mob/user)
 	..()
 
-	if(!ishuman(user))
+	if(!ishuman(usr))
 		return
 	if(SSinterior.in_interior(user))
 		to_chat(usr, SPAN_WARNING("It's too cramped in here to deploy \a [src]."))
@@ -296,9 +296,9 @@
 	return XENO_ATTACK_ACTION
 
 /obj/structure/machinery/m56d_post/MouseDrop(over_object, src_location, over_location) //Drag the tripod onto you to fold it.
-	if(!ishuman(usr) || !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
+	if(!ishuman(usr))
 		return
-	var/mob/living/carbon/user = usr //this is us
+	var/mob/living/carbon/human/user = usr //this is us
 	if(over_object == user && in_range(src, user))
 		if(anchored && gun_mounted)
 			to_chat(user, SPAN_WARNING("\The [src] can't be folded while there's an unsecured gun mounted on it. Either complete the assembly or take the gun off with a crowbar."))
@@ -313,7 +313,7 @@
 		qdel(src)
 
 /obj/structure/machinery/m56d_post/attackby(obj/item/O, mob/user)
-	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS)) //first make sure theres no funkiness
+	if(!ishuman(user)) //first make sure theres no funkiness
 		return
 
 	if(HAS_TRAIT(O, TRAIT_TOOL_WRENCH)) //rotate the mount
@@ -568,7 +568,7 @@
 	return
 
 /obj/structure/machinery/m56d_hmg/attackby(obj/item/O as obj, mob/user as mob) //This will be how we take it apart.
-	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
+	if(!ishuman(user))
 		return ..()
 
 	if(QDELETED(O))
@@ -779,54 +779,9 @@
 	playsound(loc, empty_alarm, 25, 1)
 	update_icon() //final safeguard.
 
-// New proc for MGs and stuff replaced handle_manual_fire(). Same arguements though, so alls good.
-/obj/structure/machinery/m56d_hmg/handle_click(mob/living/carbon/user, atom/A, var/list/mods)
+/obj/structure/machinery/m56d_hmg/proc/try_fire()
 	if(!operator)
 		return
-		return HANDLE_CLICK_UNHANDLED
-	if(operator != user)
-		return HANDLE_CLICK_UNHANDLED
-	if(ishuman(user))
-		var/mob/living/carbon/human/human = user
-		if(!human.allow_gun_usage)
-			to_chat(user, SPAN_WARNING("You aren't allowed to use firearms!"))
-			return HANDLE_CLICK_UNHANDLED
-	if(istype(A,/atom/movable/screen))
-		return HANDLE_CLICK_UNHANDLED
-	if(is_bursting)
-		return HANDLE_CLICK_UNHANDLED
-	if(user.lying || get_dist(user,src) > 1 || user.is_mob_incapacitated())
-		user.unset_interaction()
-		return HANDLE_CLICK_UNHANDLED
-	if(user.get_active_hand() || user.get_inactive_hand())
-		to_chat(usr, SPAN_WARNING("You need two free hands to shoot \the [src]."))
-		return HANDLE_CLICK_UNHANDLED
-
-	target = A
-	if(!istype(target))
-		return HANDLE_CLICK_UNHANDLED
-
-	if(target.z != src.z || target.z == 0 || src.z == 0 || isnull(operator.loc) || isnull(src.loc))
-		return HANDLE_CLICK_UNHANDLED
-
-	if(get_dist(target,src.loc) > 15)
-		return HANDLE_CLICK_UNHANDLED
-
-	if(mods["middle"] || mods["shift"] || mods["alt"] || mods["ctrl"])
-		handle_modded_clicks(user, mods)
-		return HANDLE_CLICK_PASS_THRU
-
-	var/angle = get_dir(src, target)
-	//we can only fire in a 90 degree cone
-	if(target.loc != src.loc && target.loc != operator.loc)
-		if(dir & angle)
-			try_fire(user)
-			return HANDLE_CLICK_HANDLED
-		else if(handle_outside_cone(user))
-			return HANDLE_CLICK_HANDLED
-	return HANDLE_CLICK_UNHANDLED
-
-/obj/structure/machinery/m56d_hmg/proc/try_fire(mob/living/carbon/user)
 	if(!rounds)
 		to_chat(operator, SPAN_WARNING("<b>*click*</b>"))
 		playsound(src, 'sound/weapons/gun_empty.ogg', 25, 1, 5)
@@ -839,14 +794,9 @@
 	return fire_shot()
 
 /obj/structure/machinery/m56d_hmg/proc/handle_outside_cone(mob/living/carbon/human/user)
-/obj/structure/machinery/m56d_hmg/proc/handle_outside_cone(mob/living/carbon/user)
 	return FALSE
 
 /obj/structure/machinery/m56d_hmg/proc/muzzle_flash(angle) // Might as well keep this too.
-/obj/structure/machinery/m56d_hmg/proc/handle_modded_clicks(mob/living/carbon/user, var/list/mods)
-	return HANDLE_CLICK_PASS_THRU
-
-/obj/structure/machinery/m56d_hmg/proc/muzzle_flash(var/angle) // Might as well keep this too.
 	if(isnull(angle))
 		return
 
@@ -880,16 +830,9 @@
 	I.flick_overlay(src, 3)
 
 /obj/structure/machinery/m56d_hmg/MouseDrop(over_object, src_location, over_location) //Drag the MG to us to man it.
-	var/mob/living/carbon/user = usr
-	var/mob/living/carbon/human/human_user
-	if(!ishuman(user) || !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
-		to_chat_immediate(world,"a")
 	// If the gun sprite wasn't dragged onto the user, or the user isn't adjacent.
 	if(over_object != usr || !in_range(src, usr))
 		return
-	else
-		human_user = user
-	var/user_turf = get_turf(user)
 	// If the user is already manning the gun.
 	if(operator == usr)
 		// Exit the gun.
@@ -901,7 +844,6 @@
 /obj/structure/machinery/m56d_hmg/proc/try_mount_gun(mob/living/carbon/human/user)
 	// If the user isn't a human.
 	if(!istype(user))
-	if(!Adjacent(user))
 		return
 	// If the user is unconscious or dead.
 	if(user.stat)
@@ -912,13 +854,10 @@
 		to_chat(user, SPAN_WARNING("You aren't allowed to use firearms!"))
 		return
 
-					if(!human_user.allow_gun_usage)
-						to_chat(user, SPAN_WARNING("You aren't allowed to use firearms!"))
-						return
-					else
-						user.freeze()
-						user.set_interaction(src)
-						give_action(user, /datum/action/human_action/mg_exit)
+	// If the user is invisible.
+	if(user.alpha <= 60)
+		to_chat(user, SPAN_WARNING("You can't use [src] while cloaked!"))
+		return
 
 	// Make sure we're not manning two guns at once, tentacle arms.
 	if(user.interactee)
@@ -1123,39 +1062,6 @@
 	to_chat(user, SPAN_NOTICE("[icon2html(src, user)] You switch to <b>[gun_firemode]</b>."))
 	SEND_SIGNAL(src, COMSIG_GUN_FIRE_MODE_TOGGLE, gun_firemode)
 
-/obj/item/device/m2c_gun/proc/check_can_setup(mob/user, var/turf/rotate_check, var/turf/open/OT, var/list/ACR)
-	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
-		to_chat_immediate(world,"a2")
-		return FALSE
-	if(broken_gun)
-		to_chat(user, SPAN_WARNING("You can't set up \the [src], it's completely broken!"))
-		return FALSE
-	if(user.z == GLOB.interior_manager.interior_z)
-		to_chat(usr, SPAN_WARNING("It's too cramped in here to deploy \a [src]."))
-		return FALSE
-	if(OT.density || !isturf(OT))
-		to_chat(user, SPAN_WARNING("You can't set up \the [src] here."))
-		return FALSE
-	if(rotate_check.density)
-		to_chat(user, SPAN_WARNING("You can't set up \the [src] that way, there's a wall behind you!"))
-		return FALSE
-	if((locate(/obj/structure/barricade) in ACR) || (locate(/obj/structure/window_frame) in ACR) || (locate(/obj/structure/window) in ACR) || (locate(/obj/structure/windoor_assembly) in ACR))
-		to_chat(user, SPAN_WARNING("There are barriers nearby, you can't set up \the [src] here!"))
-		return FALSE
-	var/fail = FALSE
-	for(var/obj/X in OT.contents - src)
-		if(istype(X, /obj/structure/machinery/defenses))
-			fail = TRUE
-			break
-		else if(istype(X, /obj/structure/machinery/door))
-			fail = TRUE
-			break
-		else if(istype(X, /obj/structure/machinery/m56d_hmg))
-			fail = TRUE
-			break
-	if(fail)
-		to_chat(user, SPAN_WARNING("You can't install \the [src] here, something is in the way."))
-		return FALSE
 ///Set the target to its turf, so we keep shooting even when it was qdeled
 /obj/structure/machinery/m56d_hmg/proc/clean_target()
 	SIGNAL_HANDLER
@@ -1192,23 +1098,6 @@
 	if(!isturf(operator.loc))
 		return
 
-	var/obj/structure/machinery/m56d_hmg/auto/M =  new /obj/structure/machinery/m56d_hmg/auto(user.loc)
-	M.set_name_label(name_label)
-	M.setDir(user.dir) // Make sure we face the right direction
-	M.anchored = TRUE
-	playsound(M, 'sound/items/m56dauto_setup.ogg', 75, TRUE)
-	to_chat(user, SPAN_NOTICE("You deploy \the [M]."))
-	if((rounds > 0) && !user.get_inactive_hand())
-		user.set_interaction(M)
-	M.rounds = rounds
-	M.overheat_value = overheat_value
-	M.health = health
-	M.update_icon()
-	qdel(src)
-
-/obj/item/device/m2c_gun/attackby(var/obj/item/O as obj, mob/user as mob)
-	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
-		to_chat_immediate(world,"a3")
 	if(istype(object, /atom/movable/screen))
 		return
 

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -188,7 +188,7 @@
 /obj/item/device/m56d_post/attack_self(mob/user)
 	..()
 
-	if(!ishuman(usr))
+	if(!ishuman(user))
 		return
 	if(SSinterior.in_interior(user))
 		to_chat(usr, SPAN_WARNING("It's too cramped in here to deploy \a [src]."))
@@ -296,9 +296,9 @@
 	return XENO_ATTACK_ACTION
 
 /obj/structure/machinery/m56d_post/MouseDrop(over_object, src_location, over_location) //Drag the tripod onto you to fold it.
-	if(!ishuman(usr))
+	if(!ishuman(usr) || !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
 		return
-	var/mob/living/carbon/human/user = usr //this is us
+	var/mob/living/carbon/user = usr //this is us
 	if(over_object == user && in_range(src, user))
 		if(anchored && gun_mounted)
 			to_chat(user, SPAN_WARNING("\The [src] can't be folded while there's an unsecured gun mounted on it. Either complete the assembly or take the gun off with a crowbar."))
@@ -313,7 +313,7 @@
 		qdel(src)
 
 /obj/structure/machinery/m56d_post/attackby(obj/item/O, mob/user)
-	if(!ishuman(user)) //first make sure theres no funkiness
+	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS)) //first make sure theres no funkiness
 		return
 
 	if(HAS_TRAIT(O, TRAIT_TOOL_WRENCH)) //rotate the mount
@@ -567,8 +567,8 @@
 		icon_state = "[icon_full]"
 	return
 
-/obj/structure/machinery/m56d_hmg/attackby(obj/item/O as obj, mob/user as mob) //This will be how we take it apart.
-	if(!ishuman(user))
+/obj/structure/machinery/m56d_hmg/attackby(var/obj/item/O as obj, mob/user as mob) //This will be how we take it apart.
+	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
 		return ..()
 
 	if(QDELETED(O))
@@ -779,9 +779,54 @@
 	playsound(loc, empty_alarm, 25, 1)
 	update_icon() //final safeguard.
 
-/obj/structure/machinery/m56d_hmg/proc/try_fire()
+// New proc for MGs and stuff replaced handle_manual_fire(). Same arguements though, so alls good.
+/obj/structure/machinery/m56d_hmg/handle_click(mob/living/carbon/user, atom/A, var/list/mods)
 	if(!operator)
 		return
+		return HANDLE_CLICK_UNHANDLED
+	if(operator != user)
+		return HANDLE_CLICK_UNHANDLED
+	if(ishuman(user))
+		var/mob/living/carbon/human/human = user
+		if(!human.allow_gun_usage)
+			to_chat(user, SPAN_WARNING("You aren't allowed to use firearms!"))
+			return HANDLE_CLICK_UNHANDLED
+	if(istype(A,/atom/movable/screen))
+		return HANDLE_CLICK_UNHANDLED
+	if(is_bursting)
+		return HANDLE_CLICK_UNHANDLED
+	if(user.lying || get_dist(user,src) > 1 || user.is_mob_incapacitated())
+		user.unset_interaction()
+		return HANDLE_CLICK_UNHANDLED
+	if(user.get_active_hand() || user.get_inactive_hand())
+		to_chat(usr, SPAN_WARNING("You need two free hands to shoot \the [src]."))
+		return HANDLE_CLICK_UNHANDLED
+
+	target = A
+	if(!istype(target))
+		return HANDLE_CLICK_UNHANDLED
+
+	if(target.z != src.z || target.z == 0 || src.z == 0 || isnull(operator.loc) || isnull(src.loc))
+		return HANDLE_CLICK_UNHANDLED
+
+	if(get_dist(target,src.loc) > 15)
+		return HANDLE_CLICK_UNHANDLED
+
+	if(mods["middle"] || mods["shift"] || mods["alt"] || mods["ctrl"])
+		handle_modded_clicks(user, mods)
+		return HANDLE_CLICK_PASS_THRU
+
+	var/angle = get_dir(src, target)
+	//we can only fire in a 90 degree cone
+	if(target.loc != src.loc && target.loc != operator.loc)
+		if(dir & angle)
+			try_fire(user)
+			return HANDLE_CLICK_HANDLED
+		else if(handle_outside_cone(user))
+			return HANDLE_CLICK_HANDLED
+	return HANDLE_CLICK_UNHANDLED
+
+/obj/structure/machinery/m56d_hmg/proc/try_fire(mob/living/carbon/user)
 	if(!rounds)
 		to_chat(operator, SPAN_WARNING("<b>*click*</b>"))
 		playsound(src, 'sound/weapons/gun_empty.ogg', 25, 1, 5)
@@ -794,9 +839,14 @@
 	return fire_shot()
 
 /obj/structure/machinery/m56d_hmg/proc/handle_outside_cone(mob/living/carbon/human/user)
+/obj/structure/machinery/m56d_hmg/proc/handle_outside_cone(mob/living/carbon/user)
 	return FALSE
 
 /obj/structure/machinery/m56d_hmg/proc/muzzle_flash(angle) // Might as well keep this too.
+/obj/structure/machinery/m56d_hmg/proc/handle_modded_clicks(mob/living/carbon/user, var/list/mods)
+	return HANDLE_CLICK_PASS_THRU
+
+/obj/structure/machinery/m56d_hmg/proc/muzzle_flash(var/angle) // Might as well keep this too.
 	if(isnull(angle))
 		return
 
@@ -830,6 +880,9 @@
 	I.flick_overlay(src, 3)
 
 /obj/structure/machinery/m56d_hmg/MouseDrop(over_object, src_location, over_location) //Drag the MG to us to man it.
+	var/mob/living/carbon/user = usr
+	if(!ishuman(user) || !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
+		to_chat_immediate(world,"a")
 	// If the gun sprite wasn't dragged onto the user, or the user isn't adjacent.
 	if(over_object != usr || !in_range(src, usr))
 		return
@@ -844,6 +897,7 @@
 /obj/structure/machinery/m56d_hmg/proc/try_mount_gun(mob/living/carbon/human/user)
 	// If the user isn't a human.
 	if(!istype(user))
+	if(!Adjacent(user))
 		return
 	// If the user is unconscious or dead.
 	if(user.stat)
@@ -1062,6 +1116,39 @@
 	to_chat(user, SPAN_NOTICE("[icon2html(src, user)] You switch to <b>[gun_firemode]</b>."))
 	SEND_SIGNAL(src, COMSIG_GUN_FIRE_MODE_TOGGLE, gun_firemode)
 
+/obj/item/device/m2c_gun/proc/check_can_setup(mob/user, var/turf/rotate_check, var/turf/open/OT, var/list/ACR)
+	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
+		to_chat_immediate(world,"a2")
+		return FALSE
+	if(broken_gun)
+		to_chat(user, SPAN_WARNING("You can't set up \the [src], it's completely broken!"))
+		return FALSE
+	if(user.z == GLOB.interior_manager.interior_z)
+		to_chat(usr, SPAN_WARNING("It's too cramped in here to deploy \a [src]."))
+		return FALSE
+	if(OT.density || !isturf(OT))
+		to_chat(user, SPAN_WARNING("You can't set up \the [src] here."))
+		return FALSE
+	if(rotate_check.density)
+		to_chat(user, SPAN_WARNING("You can't set up \the [src] that way, there's a wall behind you!"))
+		return FALSE
+	if((locate(/obj/structure/barricade) in ACR) || (locate(/obj/structure/window_frame) in ACR) || (locate(/obj/structure/window) in ACR) || (locate(/obj/structure/windoor_assembly) in ACR))
+		to_chat(user, SPAN_WARNING("There are barriers nearby, you can't set up \the [src] here!"))
+		return FALSE
+	var/fail = FALSE
+	for(var/obj/X in OT.contents - src)
+		if(istype(X, /obj/structure/machinery/defenses))
+			fail = TRUE
+			break
+		else if(istype(X, /obj/structure/machinery/door))
+			fail = TRUE
+			break
+		else if(istype(X, /obj/structure/machinery/m56d_hmg))
+			fail = TRUE
+			break
+	if(fail)
+		to_chat(user, SPAN_WARNING("You can't install \the [src] here, something is in the way."))
+		return FALSE
 ///Set the target to its turf, so we keep shooting even when it was qdeled
 /obj/structure/machinery/m56d_hmg/proc/clean_target()
 	SIGNAL_HANDLER
@@ -1098,6 +1185,23 @@
 	if(!isturf(operator.loc))
 		return
 
+	var/obj/structure/machinery/m56d_hmg/auto/M =  new /obj/structure/machinery/m56d_hmg/auto(user.loc)
+	M.set_name_label(name_label)
+	M.setDir(user.dir) // Make sure we face the right direction
+	M.anchored = TRUE
+	playsound(M, 'sound/items/m56dauto_setup.ogg', 75, TRUE)
+	to_chat(user, SPAN_NOTICE("You deploy \the [M]."))
+	if((rounds > 0) && !user.get_inactive_hand())
+		user.set_interaction(M)
+	M.rounds = rounds
+	M.overheat_value = overheat_value
+	M.health = health
+	M.update_icon()
+	qdel(src)
+
+/obj/item/device/m2c_gun/attackby(var/obj/item/O as obj, mob/user as mob)
+	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
+		to_chat_immediate(world,"a3")
 	if(istype(object, /atom/movable/screen))
 		return
 

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -70,7 +70,7 @@
 	return
 
 /obj/item/device/m56d_gun/attackby(obj/item/O as obj, mob/user as mob)
-	if(!ishuman(user) || !HAS_TRAIT(user,TRAIT_OPPOSABLE_THUMBS))
+	if(!ishuman(user) || !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
 		return
 
 	if(QDELETED(O))

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -70,7 +70,7 @@
 	return
 
 /obj/item/device/m56d_gun/attackby(obj/item/O as obj, mob/user as mob)
-	if(!ishuman(user))
+	if(!ishuman(user) || !HAS_TRAIT(user,TRAIT_OPPOSABLE_THUMBS))
 		return
 
 	if(QDELETED(O))
@@ -92,7 +92,7 @@
 		if(istype(machine, /obj/structure/machinery/m56d_hmg) || istype(machine, /obj/structure/machinery/m56d_post))
 			to_chat(user, SPAN_WARNING("This is too close to [machine]!"))
 			return
-	if(!ishuman(user))
+	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
 		return
 	if(!has_mount)
 		return
@@ -188,7 +188,7 @@
 /obj/item/device/m56d_post/attack_self(mob/user)
 	..()
 
-	if(!ishuman(usr))
+	if(!ishuman(usr) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
 		return
 	if(SSinterior.in_interior(user))
 		to_chat(usr, SPAN_WARNING("It's too cramped in here to deploy \a [src]."))
@@ -296,9 +296,9 @@
 	return XENO_ATTACK_ACTION
 
 /obj/structure/machinery/m56d_post/MouseDrop(over_object, src_location, over_location) //Drag the tripod onto you to fold it.
-	if(!ishuman(usr))
+	var/mob/living/carbon/user = usr //this is us
+	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
 		return
-	var/mob/living/carbon/human/user = usr //this is us
 	if(over_object == user && in_range(src, user))
 		if(anchored && gun_mounted)
 			to_chat(user, SPAN_WARNING("\The [src] can't be folded while there's an unsecured gun mounted on it. Either complete the assembly or take the gun off with a crowbar."))
@@ -313,7 +313,7 @@
 		qdel(src)
 
 /obj/structure/machinery/m56d_post/attackby(obj/item/O, mob/user)
-	if(!ishuman(user)) //first make sure theres no funkiness
+	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS)) //first make sure theres no funkiness
 		return
 
 	if(HAS_TRAIT(O, TRAIT_TOOL_WRENCH)) //rotate the mount
@@ -549,7 +549,7 @@
 
 /obj/structure/machinery/m56d_hmg/get_examine_text(mob/user) //Let us see how much ammo we got in this thing.
 	. = ..()
-	if(ishuman(user))
+	if(ishuman(user) || HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
 		if(rounds)
 			. += SPAN_NOTICE("It has [rounds] round\s out of [rounds_max].")
 		else
@@ -568,7 +568,7 @@
 	return
 
 /obj/structure/machinery/m56d_hmg/attackby(obj/item/O as obj, mob/user as mob) //This will be how we take it apart.
-	if(!ishuman(user))
+	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
 		return ..()
 
 	if(QDELETED(O))
@@ -692,16 +692,18 @@
 	update_health(round(P.damage / 10)) //Universal low damage to what amounts to a post with a gun.
 	return 1
 
-/obj/structure/machinery/m56d_hmg/attack_alien(mob/living/carbon/xenomorph/M) // Those Ayy lmaos.
-	if(islarva(M))
+/obj/structure/machinery/m56d_hmg/attack_alien(mob/living/carbon/xenomorph/xeno) // Those Ayy lmaos.
+	if(islarva(xeno))
 		return //Larvae can't do shit
-
-	M.visible_message(SPAN_DANGER("[M] has slashed [src]!"),
+	if(xeno.IsAdvancedToolUser() && xeno.a_intent == INTENT_HELP)
+		try_mount_gun(xeno)
+		return XENO_NO_DELAY_ACTION
+	xeno.visible_message(SPAN_DANGER("[xeno] has slashed [src]!"),
 	SPAN_DANGER("You slash [src]!"))
-	M.animation_attack_on(src)
-	M.flick_attack_overlay(src, "slash")
+	xeno.animation_attack_on(src)
+	xeno.flick_attack_overlay(src, "slash")
 	playsound(loc, "alien_claw_metal", 25)
-	update_health(rand(M.melee_damage_lower,M.melee_damage_upper))
+	update_health(rand(xeno.melee_damage_lower,xeno.melee_damage_upper))
 	return XENO_ATTACK_ACTION
 
 /obj/structure/machinery/m56d_hmg/proc/load_into_chamber()
@@ -841,17 +843,21 @@
 		// Try to man the gun
 		try_mount_gun(usr)
 
-/obj/structure/machinery/m56d_hmg/proc/try_mount_gun(mob/living/carbon/human/user)
+/obj/structure/machinery/m56d_hmg/proc/try_mount_gun(mob/living/carbon/user)
 	// If the user isn't a human.
 	if(!istype(user))
 		return
 	// If the user is unconscious or dead.
 	if(user.stat)
 		return
-
+	if(ishuman(user))
+		var/mob/living/carbon/human/human = user
+		if(!human.allow_gun_usage)
+			to_chat(user, SPAN_WARNING("You aren't allowed to use firearms!"))
+			return
 	// If the user isn't actually allowed to use guns.
-	if(!user.allow_gun_usage)
-		to_chat(user, SPAN_WARNING("You aren't allowed to use firearms!"))
+	else if (!HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
+		to_chat(user, SPAN_WARNING("You don't know what to do with [src]!"))
 		return
 
 	// If the user is invisible.

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -567,7 +567,7 @@
 		icon_state = "[icon_full]"
 	return
 
-/obj/structure/machinery/m56d_hmg/attackby(var/obj/item/O as obj, mob/user as mob) //This will be how we take it apart.
+/obj/structure/machinery/m56d_hmg/attackby(obj/item/O as obj, mob/user as mob) //This will be how we take it apart.
 	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
 		return ..()
 

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -881,11 +881,15 @@
 
 /obj/structure/machinery/m56d_hmg/MouseDrop(over_object, src_location, over_location) //Drag the MG to us to man it.
 	var/mob/living/carbon/user = usr
+	var/mob/living/carbon/human/human_user
 	if(!ishuman(user) || !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
 		to_chat_immediate(world,"a")
 	// If the gun sprite wasn't dragged onto the user, or the user isn't adjacent.
 	if(over_object != usr || !in_range(src, usr))
 		return
+	else
+		human_user = user
+	var/user_turf = get_turf(user)
 	// If the user is already manning the gun.
 	if(operator == usr)
 		// Exit the gun.
@@ -908,10 +912,13 @@
 		to_chat(user, SPAN_WARNING("You aren't allowed to use firearms!"))
 		return
 
-	// If the user is invisible.
-	if(user.alpha <= 60)
-		to_chat(user, SPAN_WARNING("You can't use [src] while cloaked!"))
-		return
+					if(!human_user.allow_gun_usage)
+						to_chat(user, SPAN_WARNING("You aren't allowed to use firearms!"))
+						return
+					else
+						user.freeze()
+						user.set_interaction(src)
+						give_action(user, /datum/action/human_action/mg_exit)
 
 	// Make sure we're not manning two guns at once, tentacle arms.
 	if(user.interactee)

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -339,7 +339,6 @@
 
 	var/image/I = image('icons/obj/items/weapons/projectiles.dmi', src, "muzzle_flash", layer + 0.1)
 	var/image_layer = layer + 0.1
-	var/offset = 13
 
 	var/image/flash = image('icons/obj/items/weapons/projectiles.dmi',src,"muzzle_flash",image_layer)
 	var/matrix/rotate = matrix() //Change the flash angle.

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -334,15 +334,12 @@
 	if(isnull(angle))
 		return
 
-	SetLuminosity(SENTRY_MUZZLELUM)
-	addtimer(CALLBACK(src, /atom.proc/SetLuminosity, -SENTRY_MUZZLELUM), 10)
-
-	var/image/I = image('icons/obj/items/weapons/projectiles.dmi', src, "muzzle_flash", layer + 0.1)
 	var/image_layer = layer + 0.1
+	var/offset = 13
 
 	var/image/flash = image('icons/obj/items/weapons/projectiles.dmi',src,"muzzle_flash",image_layer)
 	var/matrix/rotate = matrix() //Change the flash angle.
-	rotate.Translate(0, 13)
+	rotate.Translate(0, offset)
 	rotate.Turn(angle)
 	flash.transform = rotate
 	flash.flick_overlay(src, 3)
@@ -666,9 +663,6 @@
 	. = ..()
 	QDEL_NULL(linked_cam)
 
-
-/obj/structure/machinery/defenses/sentry/launchable/attack_hand_checks(var/mob/user)
-	return TRUE // We want to be able to turn it on / off while keeping it immobile
 
 /obj/structure/machinery/defenses/sentry/launchable/attackby(obj/item/stack/sheets, mob/user)
 	. = ..()

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -334,12 +334,16 @@
 	if(isnull(angle))
 		return
 
+	SetLuminosity(SENTRY_MUZZLELUM)
+	addtimer(CALLBACK(src, /atom.proc/SetLuminosity, -SENTRY_MUZZLELUM), 10)
+
+	var/image/I = image('icons/obj/items/weapons/projectiles.dmi', src, "muzzle_flash", layer + 0.1)
 	var/image_layer = layer + 0.1
 	var/offset = 13
 
 	var/image/flash = image('icons/obj/items/weapons/projectiles.dmi',src,"muzzle_flash",image_layer)
 	var/matrix/rotate = matrix() //Change the flash angle.
-	rotate.Translate(0, offset)
+	rotate.Translate(0, 13)
 	rotate.Turn(angle)
 	flash.transform = rotate
 	flash.flick_overlay(src, 3)
@@ -663,6 +667,9 @@
 	. = ..()
 	QDEL_NULL(linked_cam)
 
+
+/obj/structure/machinery/defenses/sentry/launchable/attack_hand_checks(var/mob/user)
+	return TRUE // We want to be able to turn it on / off while keeping it immobile
 
 /obj/structure/machinery/defenses/sentry/launchable/attackby(obj/item/stack/sheets, mob/user)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -649,6 +649,10 @@
 
 	tracked_marker = null
 
+	///This permits xenos with thumbs to fire guns and arm grenades. God help us all.
+/mob/living/carbon/Xenomorph/IsAdvancedToolUser()
+	return HAS_TRAIT(src, TRAIT_OPPOSABLE_THUMBS)
+
 /mob/living/carbon/xenomorph/proc/do_nesting_host(mob/current_mob, nest_structural_base)
 	var/list/xeno_hands = list(get_active_hand(), get_inactive_hand())
 

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -650,7 +650,7 @@
 	tracked_marker = null
 
 	///This permits xenos with thumbs to fire guns and arm grenades. God help us all.
-/mob/living/carbon/Xenomorph/IsAdvancedToolUser()
+/mob/living/carbon/xenomorph/IsAdvancedToolUser()
 	return HAS_TRAIT(src, TRAIT_OPPOSABLE_THUMBS)
 
 /mob/living/carbon/xenomorph/proc/do_nesting_host(mob/current_mob, nest_structural_base)

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -51,9 +51,9 @@
 	faction = FACTION_XENOMORPH
 	gender = NEUTER
 	icon_size = 48
+	black_market_value = KILL_MENDOZA
 	///How much to horizontally adjust the sprites of held item onmobs by. Based on icon size. Most xenos have hands about the same height as a human's.
 	var/xeno_inhand_item_offset
-	black_market_value = KILL_MENDOZA
 	dead_black_market_value = 50
 	light_system = MOVABLE_LIGHT
 	var/obj/item/clothing/suit/wear_suit = null
@@ -374,8 +374,6 @@
 			for(var/datum/action/xeno_action/onclick/xenohide/hide in actions)
 				layer = XENO_HIDING_LAYER
 				hide.button.icon_state = "template_active"
-	update_icon_source()
-	xeno_inhand_item_offset = (icon_size - 32) * 0.5
 
 		//If we're holding things drop them
 		for(var/obj/item/item in old_xeno.contents) //Drop stuff
@@ -433,7 +431,7 @@
 
 	GLOB.living_xeno_list += src
 	GLOB.xeno_mob_list += src
-
+	xeno_inhand_item_offset = (icon_size - 32) * 0.5
 	// More setup stuff for names, abilities etc
 	update_icon_source()
 	generate_name()

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -51,6 +51,8 @@
 	faction = FACTION_XENOMORPH
 	gender = NEUTER
 	icon_size = 48
+	///How much to horizontally adjust the sprites of held item onmobs by. Based on icon size. Most xenos have hands about the same height as a human's.
+	var/xeno_inhand_item_offset
 	black_market_value = KILL_MENDOZA
 	dead_black_market_value = 50
 	light_system = MOVABLE_LIGHT
@@ -372,6 +374,8 @@
 			for(var/datum/action/xeno_action/onclick/xenohide/hide in actions)
 				layer = XENO_HIDING_LAYER
 				hide.button.icon_state = "template_active"
+	update_icon_source()
+	xeno_inhand_item_offset = (icon_size - 32) * 0.5
 
 		//If we're holding things drop them
 		for(var/obj/item/item in old_xeno.contents) //Drop stuff

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -385,9 +385,9 @@
 		to_chat(M, SPAN_WARNING("We stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
 
-/obj/structure/magazine_box/attack_alien(mob/living/carbon/Xenomorph/M)
+/obj/structure/magazine_box/attack_alien(mob/living/carbon/xenomorph/xeno)
 	if(HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
-		attack_hand(M)
+		attack_hand(xeno)
 		return XENO_NONCOMBAT_ACTION
 	else
 		. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -397,8 +397,8 @@ There is a trait that permits them to handle items.**/
 //If we sent it to monkey we'd get some weird shit happening.
 /obj/structure/attack_alien(mob/living/carbon/xenomorph/M)
 	// fuck off dont destroy my unslashables
-	if(unslashable || health <= 0)
-		to_chat(M, SPAN_WARNING("We stare at \the [src] cluelessly."))
+	if(unslashable || health <= 0 && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
+		to_chat(M, SPAN_WARNING("You stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
 
 /obj/structure/magazine_box/attack_alien(mob/living/carbon/Xenomorph/M)
@@ -685,9 +685,9 @@ There is a trait that permits them to handle items.**/
 
 //Xenomorphs can't use machinery, not even the "intelligent" ones
 //Exception is Queen and shuttles, because plot power
+	if(unslashable || health <= 0 && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
+		to_chat(M, SPAN_WARNING("You stare at \the [src] cluelessly."))
 /obj/structure/machinery/attack_alien(mob/living/carbon/xenomorph/M)
-	if(unslashable || health <= 0)
-		to_chat(M, SPAN_WARNING("We stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
 
 	M.animation_attack_on(src)
@@ -704,9 +704,10 @@ There is a trait that permits them to handle items.**/
 	return XENO_ATTACK_ACTION
 
 // Destroying reagent dispensers
+/obj/structure/reagent_dispensers/attack_alien(mob/living/carbon/Xenomorph/M)
+	if(unslashable || health <= 0 && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
+		to_chat(M, SPAN_WARNING("You stare at \the [src] cluelessly."))
 /obj/structure/reagent_dispensers/attack_alien(mob/living/carbon/xenomorph/M)
-	if(unslashable || health <= 0)
-		to_chat(M, SPAN_WARNING("We stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
 
 	M.animation_attack_on(src)

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -309,31 +309,15 @@
 	else
 		return FALSE // leave the dead alone
 
-/**This proc is here to prevent Xenomorphs from picking up objects (default attack_hand behaviour)
-Note that this is overriden by every proc concerning a child of obj unless inherited
-There is a trait that permits them to handle items.**/
-/obj/item/attack_alien(mob/living/carbon/Xenomorph/M)
-	if(HAS_TRAIT(M, TRAIT_OPPOSABLE_THUMBS))
-		attack_hand(M)
+//This proc is here to prevent Xenomorphs from picking up objects (default attack_hand behaviour)
+//Note that this is overridden by every proc concerning a child of obj unless inherited
+/obj/item/attack_alien(mob/living/carbon/xenomorph/xeno)
+	if(HAS_TRAIT(xeno, TRAIT_OPPOSABLE_THUMBS))
+		attack_hand(xeno)
 		return XENO_NONCOMBAT_ACTION
 	return
 
-
-/obj/vehicle/attack_alien(mob/living/carbon/Xenomorph/M)
-	if(M.a_intent == INTENT_HARM)
-		M.animation_attack_on(src)
-		M.flick_attack_overlay(src, "slash")
-		health -= 15
-		playsound(loc, "alien_claw_metal", 25, 1)
-		M.visible_message(SPAN_DANGER("[M] [M.slashes_verb] [src]."),SPAN_DANGER("You [M.slash_verb] [src]."), null, 5, CHAT_TYPE_XENO_COMBAT)
-		healthcheck()
-		return XENO_ATTACK_ACTION
-	else
-		attack_hand(M)
-		return XENO_NONCOMBAT_ACTION
-
-
-/obj/attack_larva(mob/living/carbon/Xenomorph/Larva/M)
+/obj/attack_larva(mob/living/carbon/xenomorph/larva/M)
 	return //larva can't do anything
 
 //Breaking tables and racks
@@ -398,7 +382,7 @@ There is a trait that permits them to handle items.**/
 /obj/structure/attack_alien(mob/living/carbon/xenomorph/M)
 	// fuck off dont destroy my unslashables
 	if(unslashable || health <= 0 && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
-		to_chat(M, SPAN_WARNING("You stare at \the [src] cluelessly."))
+		to_chat(M, SPAN_WARNING("We stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
 
 /obj/structure/magazine_box/attack_alien(mob/living/carbon/Xenomorph/M)
@@ -685,9 +669,9 @@ There is a trait that permits them to handle items.**/
 
 //Xenomorphs can't use machinery, not even the "intelligent" ones
 //Exception is Queen and shuttles, because plot power
-	if(unslashable || health <= 0 && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
-		to_chat(M, SPAN_WARNING("You stare at \the [src] cluelessly."))
 /obj/structure/machinery/attack_alien(mob/living/carbon/xenomorph/M)
+	if(unslashable || health <= 0 && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
+		to_chat(M, SPAN_WARNING("We stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
 
 	M.animation_attack_on(src)
@@ -704,10 +688,9 @@ There is a trait that permits them to handle items.**/
 	return XENO_ATTACK_ACTION
 
 // Destroying reagent dispensers
-/obj/structure/reagent_dispensers/attack_alien(mob/living/carbon/Xenomorph/M)
-	if(unslashable || health <= 0 && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
-		to_chat(M, SPAN_WARNING("You stare at \the [src] cluelessly."))
 /obj/structure/reagent_dispensers/attack_alien(mob/living/carbon/xenomorph/M)
+	if(unslashable || health <= 0 && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
+		to_chat(M, SPAN_WARNING("We stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
 
 	M.animation_attack_on(src)

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -309,12 +309,31 @@
 	else
 		return FALSE // leave the dead alone
 
-//This proc is here to prevent Xenomorphs from picking up objects (default attack_hand behaviour)
-//Note that this is overridden by every proc concerning a child of obj unless inherited
-/obj/item/attack_alien(mob/living/carbon/xenomorph/M)
+/**This proc is here to prevent Xenomorphs from picking up objects (default attack_hand behaviour)
+Note that this is overriden by every proc concerning a child of obj unless inherited
+There is a trait that permits them to handle items.**/
+/obj/item/attack_alien(mob/living/carbon/Xenomorph/M)
+	if(HAS_TRAIT(M, TRAIT_OPPOSABLE_THUMBS))
+		attack_hand(M)
+		return XENO_NONCOMBAT_ACTION
 	return
 
-/obj/attack_larva(mob/living/carbon/xenomorph/larva/M)
+
+/obj/vehicle/attack_alien(mob/living/carbon/Xenomorph/M)
+	if(M.a_intent == INTENT_HARM)
+		M.animation_attack_on(src)
+		M.flick_attack_overlay(src, "slash")
+		health -= 15
+		playsound(loc, "alien_claw_metal", 25, 1)
+		M.visible_message(SPAN_DANGER("[M] [M.slashes_verb] [src]."),SPAN_DANGER("You [M.slash_verb] [src]."), null, 5, CHAT_TYPE_XENO_COMBAT)
+		healthcheck()
+		return XENO_ATTACK_ACTION
+	else
+		attack_hand(M)
+		return XENO_NONCOMBAT_ACTION
+
+
+/obj/attack_larva(mob/living/carbon/Xenomorph/Larva/M)
 	return //larva can't do anything
 
 //Breaking tables and racks
@@ -382,6 +401,12 @@
 		to_chat(M, SPAN_WARNING("We stare at \the [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
 
+/obj/structure/magazine_box/attack_alien(mob/living/carbon/Xenomorph/M)
+	if(HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
+		attack_hand(M)
+		return XENO_NONCOMBAT_ACTION
+	else
+		. = ..()
 
 //Beds, nests and chairs - unbuckling
 /obj/structure/bed/attack_alien(mob/living/carbon/xenomorph/M)

--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -148,7 +148,12 @@
 		var/t_state = r_hand.item_state
 		if(!t_state)
 			t_state = r_hand.icon_state
-		overlays_standing[X_R_HAND_LAYER] = r_hand.get_mob_overlay(src, WEAR_R_HAND)
+		/*Move inhand image to the center of the sprite. Strictly speaking this should probably be like monkey get_offset_overlay_image() and tailor item icon
+		positions to the hands of the xeno, but outside of special occasions xenos can't really pick items up and this tends to look better than human default.*/
+		var/image/inhand_image = r_hand.get_mob_overlay(src, WEAR_R_HAND)
+		inhand_image.pixel_x = xeno_inhand_item_offset
+		overlays_standing[X_R_HAND_LAYER] = inhand_image
+
 		apply_overlay(X_R_HAND_LAYER)
 
 /mob/living/carbon/xenomorph/update_inv_l_hand()
@@ -161,7 +166,13 @@
 		var/t_state = l_hand.item_state
 		if(!t_state)
 			t_state = l_hand.icon_state
-		overlays_standing[X_L_HAND_LAYER] = l_hand.get_mob_overlay(src, WEAR_L_HAND)
+
+		/*Move inhand image overlay to the center of the sprite. Strictly speaking this should probably be like monkey get_offset_overlay_image() and tailor item icon
+		positions to the hands of the xeno, but outside of special occasions xenos can't really pick items up and this tends to look better than human default.*/
+		var/image/inhand_image = l_hand.get_mob_overlay(src, WEAR_L_HAND)
+		inhand_image.pixel_x = xeno_inhand_item_offset
+		overlays_standing[X_L_HAND_LAYER] = inhand_image
+
 		apply_overlay(X_L_HAND_LAYER)
 
 /mob/living/carbon/xenomorph/update_inv_back()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1521,7 +1521,7 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 		return //We just put the gun up. Can't do it that fast
 
 	if(ismob(user)) //Could be an object firing the gun.
-		if(!user.IsAdvancedToolUser())
+		if(!user.IsAdvancedToolUser() && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
 			to_chat(user, SPAN_WARNING("You don't have the dexterity to do this!"))
 			return
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1751,7 +1751,7 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 		else
 			total_recoil -= user.skills.get_skill_level(SKILL_FIREARMS)*RECOIL_AMOUNT_TIER_5
 
-	if(total_recoil > 0 && ishuman(user))
+	if(total_recoil > 0 && (ishuman(user) || HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS)))
 		if(total_recoil >= 4)
 			shake_camera(user, total_recoil * 0.5, total_recoil)
 		else
@@ -1763,7 +1763,7 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 /obj/item/weapon/gun/proc/muzzle_flash(angle,mob/user)
 	if(!muzzle_flash || flags_gun_features & GUN_SILENCED || isnull(angle))
 		return //We have to check for null angle here, as 0 can also be an angle.
-	if(!istype(user) || !istype(user.loc,/turf))
+	if(!istype(user) || !isturf(user.loc))
 		return
 
 	var/prev_light = light_range
@@ -1772,12 +1772,12 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 		set_light_on(TRUE)
 		addtimer(CALLBACK(src, PROC_REF(reset_light_range), prev_light), 0.5 SECONDS)
 
-	var/image_layer = (user && user.dir == SOUTH) ? MOB_LAYER+0.1 : MOB_LAYER-0.1
-	var/offset = 5
-
-	var/image/I = image('icons/obj/items/weapons/projectiles.dmi',user,muzzle_flash,image_layer)
+	var/image/I = image('icons/obj/items/weapons/projectiles.dmi', user, muzzle_flash, user.dir == NORTH ? ABOVE_LYING_MOB_LAYER : FLOAT_LAYER)
 	var/matrix/rotate = matrix() //Change the flash angle.
-	rotate.Translate(0, offset)
+	if(isCarbonSizeXeno(user))
+		var/mob/living/carbon/Xenomorph/X = user
+		I.pixel_x = X.xeno_inhand_item_offset //To center it on the xeno sprite without being thrown off by rotation.
+	rotate.Translate(0, 5) //Y offset to push the flash overlay outwards.
 	rotate.Turn(angle)
 	I.transform = rotate
 	I.flick_overlay(user, 3)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1774,9 +1774,9 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 
 	var/image/I = image('icons/obj/items/weapons/projectiles.dmi', user, muzzle_flash, user.dir == NORTH ? ABOVE_LYING_MOB_LAYER : FLOAT_LAYER)
 	var/matrix/rotate = matrix() //Change the flash angle.
-	if(isCarbonSizeXeno(user))
-		var/mob/living/carbon/Xenomorph/X = user
-		I.pixel_x = X.xeno_inhand_item_offset //To center it on the xeno sprite without being thrown off by rotation.
+	if(iscarbonsizexeno(user))
+		var/mob/living/carbon/xenomorph/xeno = user
+		I.pixel_x = xeno.xeno_inhand_item_offset //To center it on the xeno sprite without being thrown off by rotation.
 	rotate.Translate(0, 5) //Y offset to push the flash overlay outwards.
 	rotate.Turn(angle)
 	I.transform = rotate

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -462,7 +462,7 @@ DEFINES in setup.dm, referenced here.
 /obj/item/weapon/gun/proc/get_active_firearm(mob/user, restrictive = TRUE)
 	if(user.is_mob_incapacitated() || !isturf(usr.loc))
 		return
-	if(!ishuman(usr) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
+	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
 		to_chat(user, SPAN_WARNING("Not right now."))
 		return
 
@@ -782,7 +782,7 @@ DEFINES in setup.dm, referenced here.
 	if(flags_gun_features & GUN_BURST_FIRING)
 		return
 
-	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
+	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
 		return
 
 	if(usr.is_mob_incapacitated() || !usr.loc || !isturf(usr.loc))

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -782,7 +782,7 @@ DEFINES in setup.dm, referenced here.
 	if(flags_gun_features & GUN_BURST_FIRING)
 		return
 
-	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
+	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
 		return
 
 	if(usr.is_mob_incapacitated() || !usr.loc || !isturf(usr.loc))

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -460,9 +460,10 @@ DEFINES in setup.dm, referenced here.
 		else attack_verb = list("slashed", "stabbed", "speared", "torn", "punctured", "pierced", "gored") //Greater than 35
 
 /obj/item/weapon/gun/proc/get_active_firearm(mob/user, restrictive = TRUE)
-	if(!ishuman(usr))
-		return
 	if(user.is_mob_incapacitated() || !isturf(usr.loc))
+		return
+	if(!ishuman(usr))
+	if(!ishuman(usr) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
 		to_chat(user, SPAN_WARNING("Not right now."))
 		return
 
@@ -782,7 +783,7 @@ DEFINES in setup.dm, referenced here.
 	if(flags_gun_features & GUN_BURST_FIRING)
 		return
 
-	if(!ishuman(usr))
+	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
 		return
 
 	if(usr.is_mob_incapacitated() || !usr.loc || !isturf(usr.loc))

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -462,7 +462,6 @@ DEFINES in setup.dm, referenced here.
 /obj/item/weapon/gun/proc/get_active_firearm(mob/user, restrictive = TRUE)
 	if(user.is_mob_incapacitated() || !isturf(usr.loc))
 		return
-	if(!ishuman(usr))
 	if(!ishuman(usr) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
 		to_chat(user, SPAN_WARNING("Not right now."))
 		return

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1040,21 +1040,11 @@
 
 	var/ammo_flags = P.ammo.flags_ammo_behavior | P.projectile_override_flags
 
-	if(isXeno(P.firer) && ammo_flags & (AMMO_XENO_ACID|AMMO_XENO_TOX)) //Xenomorph shooting spit. Xenos with thumbs and guns can fully FF.
-		var/mob/living/carbon/Xenomorph/X = P.firer
 	if((ammo_flags & AMMO_FLAME) && (src.caste.fire_immunity & FIRE_IMMUNITY_NO_IGNITE|FIRE_IMMUNITY_NO_DAMAGE))
 		to_chat(src, SPAN_AVOIDHARM("You shrug off the glob of flame."))
 		bullet_message(P, damaging = FALSE)
 		return
 
-	if(isxeno(P.firer))
-		var/mob/living/carbon/xenomorph/X = P.firer
-		if(X.can_not_harm(src))
-			bullet_ping(P)
-			return -1
-		else
-			damage *= XVX_PROJECTILE_DAMAGEMULT
-			damage_result = damage
 	if(isxeno(P.firer) && ammo_flags & (AMMO_ACIDIC|AMMO_XENO)) //Xenomorph shooting spit. Xenos with thumbs and guns can fully FF.
 		if(isxeno(P.firer))
 			var/mob/living/carbon/xenomorph/X = P.firer

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1040,6 +1040,8 @@
 
 	var/ammo_flags = P.ammo.flags_ammo_behavior | P.projectile_override_flags
 
+	if(isXeno(P.firer) && ammo_flags & (AMMO_XENO_ACID|AMMO_XENO_TOX)) //Xenomorph shooting spit. Xenos with thumbs and guns can fully FF.
+		var/mob/living/carbon/Xenomorph/X = P.firer
 	if((ammo_flags & AMMO_FLAME) && (src.caste.fire_immunity & FIRE_IMMUNITY_NO_IGNITE|FIRE_IMMUNITY_NO_DAMAGE))
 		to_chat(src, SPAN_AVOIDHARM("You shrug off the glob of flame."))
 		bullet_message(P, damaging = FALSE)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1046,14 +1046,13 @@
 		return
 
 	if(isxeno(P.firer) && ammo_flags & (AMMO_ACIDIC|AMMO_XENO)) //Xenomorph shooting spit. Xenos with thumbs and guns can fully FF.
-		if(isxeno(P.firer))
-			var/mob/living/carbon/xenomorph/X = P.firer
-			if(X.can_not_harm(src))
-				bullet_ping(P)
-				return -1
-			else
-				damage *= XVX_PROJECTILE_DAMAGEMULT
-				damage_result = damage
+		var/mob/living/carbon/xenomorph/X = P.firer
+		if(X.can_not_harm(src))
+			bullet_ping(P)
+			return -1
+		else
+			damage *= XVX_PROJECTILE_DAMAGEMULT
+			damage_result = damage
 
 	if(P.weapon_cause_data && P.weapon_cause_data.cause_name)
 		var/mob/M = P.weapon_cause_data.resolve_mob()

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1055,6 +1055,15 @@
 		else
 			damage *= XVX_PROJECTILE_DAMAGEMULT
 			damage_result = damage
+	if(isxeno(P.firer) && ammo_flags & (AMMO_ACIDIC|AMMO_XENO)) //Xenomorph shooting spit. Xenos with thumbs and guns can fully FF.
+		if(isxeno(P.firer))
+			var/mob/living/carbon/xenomorph/X = P.firer
+			if(X.can_not_harm(src))
+				bullet_ping(P)
+				return -1
+			else
+				damage *= XVX_PROJECTILE_DAMAGEMULT
+				damage_result = damage
 
 	if(P.weapon_cause_data && P.weapon_cause_data.cause_name)
 		var/mob/M = P.weapon_cause_data.resolve_mob()

--- a/code/modules/vehicles/interior/interactable/seats.dm
+++ b/code/modules/vehicles/interior/interactable/seats.dm
@@ -107,8 +107,9 @@
 			else
 				to_chat(user, SPAN_WARNING("You are unable to use heavy weaponry."))
 			return
-
-	for(var/obj/item/I in user.contents) //prevents shooting while zoomed in, but zoom can still be activated and used without shooting
+	else if(!HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
+		return
+	for(var/obj/item/I in user.contents)		//prevents shooting while zoomed in, but zoom can still be activated and used without shooting
 		if(I.zoom)
 			I.zoom(user)
 

--- a/code/modules/vehicles/interior/interactable/seats.dm
+++ b/code/modules/vehicles/interior/interactable/seats.dm
@@ -107,8 +107,9 @@
 			else
 				to_chat(user, SPAN_WARNING("You are unable to use heavy weaponry."))
 			return
-	else if(!HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
-		return
+
+		else if(!HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
+			return
 	for(var/obj/item/I in user.contents)		//prevents shooting while zoomed in, but zoom can still be activated and used without shooting
 		if(I.zoom)
 			I.zoom(user)

--- a/code/modules/vehicles/interior/interactable/seats.dm
+++ b/code/modules/vehicles/interior/interactable/seats.dm
@@ -108,7 +108,7 @@
 				to_chat(user, SPAN_WARNING("You are unable to use heavy weaponry."))
 			return
 
-		else if(!HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
+		if(!HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
 			return
 	for(var/obj/item/I in user.contents)		//prevents shooting while zoomed in, but zoom can still be activated and used without shooting
 		if(I.zoom)

--- a/tgui/packages/tgui/interfaces/TacticalMap.tsx
+++ b/tgui/packages/tgui/interfaces/TacticalMap.tsx
@@ -13,7 +13,7 @@ interface TacMapProps {
   svgData: any;
   canViewTacmap: number;
   canDraw: number;
-  isXeno: boolean;
+  isxeno: boolean;
   canViewCanvas: number;
   newCanvasFlatImage: string;
   oldCanvasFlatImage: string;
@@ -104,7 +104,7 @@ export const TacticalMap = (props) => {
     <Window
       width={700}
       height={850}
-      theme={data.isXeno ? 'hive_status' : 'crtblue'}>
+      theme={data.isxeno ? 'hive_status' : 'crtblue'}>
       <Window.Content>
         <Section
           fitted
@@ -123,7 +123,7 @@ export const TacticalMap = (props) => {
                   return (
                     <Tabs.Tab
                       key={i}
-                      color={data.isXeno ? 'purple' : 'blue'}
+                      color={data.isxeno ? 'purple' : 'blue'}
                       selected={i === pageIndex}
                       disabled={page.canOpen(data) === 0}
                       icon={page.icon}


### PR DESCRIPTION
# About the pull request
Working version that is TMable for april fools. 


Revived and fixed up https://gitlab.com/cmdevs/colonial-warfare/-/merge_requests/1915/diffs#9ec310cca070259d82839a4a70e89dd858ded438_958_958

https://github.com/cmss13-devs/cmss13/pull/2997

Additions from  Vanagandr's original MR
- xenos can use health items on marines
- vendors are usable now, all checks are simply skipped so introducing xenos with thumbs to snowflake vendors is a horrible idea (as if enabling this in the first place wasn't bad enough) [needs further testing]
- xenos can drive
- M2C usable


I think this is pretty much done, it's already exceeding the scope of the original and we're just making xenos human past this point

Original description
> TL;DR: https://streamable.com/rlvs86
> 
> Mainly this allows xenos to pick up items. They can then use most of them.
> 
> Ex. a xeno can't flip a plasteel cade open - but if she has a toolbelt and time to work, she can unwrench it.
> 
> They can fumble about but a lot of QoL and objects (middleclick container open, click-dragging containers, tables, etc.) were never designed to be interacted with by xenos so item interactions are a bit clunky.
> 
> They can't strip clothing and gear from people.
> 
> They *can* strip and attach attachments but can't aim down scopes.
> 
> They *can* FF.
> 
> They *can't* use MGs.
> 
> IFF works, roughly, not picking up on specific hives but allowing them to shoot past other xenos and hit humans.
> 
> They pass spec checks and can clumsily handle medic gear.
> 
> needless to say this is all colossally imbalanced and has potential for fuckery limited only by the xeno's imagination and whether the thing they're messing with makes an explicit ishuman() check. Or is a structure. They can't hand-interact with structures, so they can shove shells into a mortar but can't change its coords.
> 
> Cosmetically, gun inhands don't line up with xenos. Tweaked it a bit to center it horizontally but lining inhands up with hands for every xeno and xenonid sprite is a bit more hassle than seems worthwhile ATM.
> 
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
TM funny
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:  Vanagandr, totalepicness
add: Added a button to event panel to give xenomorphs opposable thumbs and firearms permits, to individuals, to hives, or to all xenos everywhere. They're clumsy, though, and have issues with fine manipulation sometimes. Remember that warriors cannot throw objects and make for poor grenadiers.
add: Xenos with opposable thumbs can use buckles, drive vehicles, use machine guns and vendors without care for access or skills
/:cl:
