### PR TITLE
serious incen mini rework, reduces explosion strenght and price

### DIFF
--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -382,13 +382,13 @@
 	transferable_ammo = TRUE
 	point_cost = 300
 	fire_mission_delay = 3 //high cooldown
-	explosion_strenght = 200
+	explosion_strength = 200
 	explosion_falloff = 44
 
 /obj/structure/ship_ammo/minirocket/detonate_on(turf/impact, obj/structure/dropship_equipment/weapon/fired_from)
 	impact.ceiling_debris_check(2)
 	spawn(5)
-		cell_explosion(impact, explosion_strenght, explosion_falloff, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, create_cause_data(initial(name), source_mob))
+		cell_explosion(impact, explosion_strength, explosion_falloff, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, create_cause_data(initial(name), source_mob))
 		var/datum/effect_system/expl_particles/expl_particles = new/datum/effect_system/expl_particles()
 		expl_particles.set_up(4, 0, impact)
 		expl_particles.start()
@@ -413,7 +413,7 @@
 	desc = "The AGR-59-I 'Mini-Mike' incendiary minirocket is a cheap and efficient means of putting hate down range AND setting them on fire! Though rockets lack a guidance package, it makes up for it in ammunition count. Can be loaded into the LAU-229 Rocket Pod."
 	icon_state = "minirocket_inc"
 	point_cost = 350
-	explosion_strenght = 130
+	explosion_strength = 130
 	explosion_falloff = 30
 
 /obj/structure/ship_ammo/minirocket/incendiary/detonate_on(turf/impact, obj/structure/dropship_equipment/weapon/fired_from)

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -382,18 +382,20 @@
 	transferable_ammo = TRUE
 	point_cost = 300
 	fire_mission_delay = 3 //high cooldown
+	explosion_strenght = 200
+	explosion_falloff = 44
 
 /obj/structure/ship_ammo/minirocket/detonate_on(turf/impact, obj/structure/dropship_equipment/weapon/fired_from)
 	impact.ceiling_debris_check(2)
 	spawn(5)
-		cell_explosion(impact, 200, 44, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, create_cause_data(initial(name), source_mob))
-		var/datum/effect_system/expl_particles/P = new/datum/effect_system/expl_particles()
-		P.set_up(4, 0, impact)
-		P.start()
+		cell_explosion(impact, explosion_strenght, explosion_falloff, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, create_cause_data(initial(name), source_mob))
+		var/datum/effect_system/expl_particles/expl_particles = new/datum/effect_system/expl_particles()
+		expl_particles.set_up(4, 0, impact)
+		expl_particles.start()
 		spawn(5)
-			var/datum/effect_system/smoke_spread/S = new/datum/effect_system/smoke_spread()
-			S.set_up(1,0,impact,null)
-			S.start()
+			var/datum/effect_system/smoke_spread/smoke = new/datum/effect_system/smoke_spread()
+			smoke.set_up(1,0,impact,null)
+			smoke.start()
 		if(!ammo_count && loc)
 			qdel(src) //deleted after last minirocket is fired and impact the ground.
 
@@ -410,8 +412,9 @@
 	name = "\improper AGR-59-I 'Mini-Mike'"
 	desc = "The AGR-59-I 'Mini-Mike' incendiary minirocket is a cheap and efficient means of putting hate down range AND setting them on fire! Though rockets lack a guidance package, it makes up for it in ammunition count. Can be loaded into the LAU-229 Rocket Pod."
 	icon_state = "minirocket_inc"
-	point_cost = 500
-	fire_mission_delay = 3 //high cooldown
+	point_cost = 350
+	explosion_strenght = 130
+	explosion_falloff = 30
 
 /obj/structure/ship_ammo/minirocket/incendiary/detonate_on(turf/impact, obj/structure/dropship_equipment/weapon/fired_from)
 	..()
@@ -419,7 +422,7 @@
 		fire_spread(impact, create_cause_data(initial(name), source_mob), 3, 25, 20, "#EE6515")
 
 /obj/structure/ship_ammo/sentry
-	name = "\improper A/C-49-P Air Deployable Sentry"
+	name = "\improper A/C-49-expl_particles Air Deployable Sentry"
 	desc = "An omni-directional sentry, capable of defending an area from lightly armored hostile incursion. Can be loaded into the LAG-14 Internal Sentry Launcher."
 	icon_state = "launchable_sentry"
 	equipment_type = /obj/structure/dropship_equipment/weapon/launch_bay

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -382,8 +382,8 @@
 	transferable_ammo = TRUE
 	point_cost = 300
 	fire_mission_delay = 3 //high cooldown
-	explosion_strength = 200
-	explosion_falloff = 44
+	var/explosion_strength = 200
+	var/explosion_falloff = 44
 
 /obj/structure/ship_ammo/minirocket/detonate_on(turf/impact, obj/structure/dropship_equipment/weapon/fired_from)
 	impact.ceiling_debris_check(2)

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -422,7 +422,7 @@
 		fire_spread(impact, create_cause_data(initial(name), source_mob), 3, 25, 20, "#EE6515")
 
 /obj/structure/ship_ammo/sentry
-	name = "\improper A/C-49-expl_particles Air Deployable Sentry"
+	name = "\improper A/C-49-P Air Deployable Sentry"
 	desc = "An omni-directional sentry, capable of defending an area from lightly armored hostile incursion. Can be loaded into the LAG-14 Internal Sentry Launcher."
 	icon_state = "launchable_sentry"
 	equipment_type = /obj/structure/dropship_equipment/weapon/launch_bay


### PR DESCRIPTION
# About the pull request

reduces explosion about 1/3, justifing the incendiary payload in casing of the same size, reduces price as it might be a bit stronger then normal minirocket but not streight up stronger with no other drawback.
old explosion values based on range are
200, 156, 112, 68, 24
new one
130, 100, 70, 40, 10

the numbers are up for debate, but the concept is hopefully acceptable

(Others have said they would reduce the incen mini explosion when I have been asking long ago but welp...)

# Explain why it's good for the game

puts incen minirockets into its own position, weaker explosion the minirocket and weaker fire then laser but has both. Having super strong option behind what is basicly paywall is weard and this should allow for them to be more viable while getting it line with other ordinance.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: reduces incen minirocket strength from 200 to 130
balance: reduces incen minirocket falloff from 44 to 30
balance: reduces incen minirocket price from 500 to 350
/:cl:
