### PR TITLE
Better throw logic

### DIFF
--- a/code/modules/movement/launching/launching.dm
+++ b/code/modules/movement/launching/launching.dm
@@ -182,7 +182,6 @@
 
 	add_temp_pass_flags(pass_flags)
 
-	var/turf/start_turf = get_step_towards(src, LM.target)
 	var/last_loc = loc
 
 	var/early_exit = FALSE

--- a/code/modules/movement/launching/launching.dm
+++ b/code/modules/movement/launching/launching.dm
@@ -183,20 +183,17 @@
 	add_temp_pass_flags(pass_flags)
 
 	var/turf/start_turf = get_step_towards(src, LM.target)
-	var/list/turf/path = get_line(start_turf, LM.target)
 	var/last_loc = loc
 
 	var/early_exit = FALSE
 	LM.dist = 0
-	for (var/turf/T in path)
-		if (!src || !throwing || loc != last_loc || !isturf(src.loc))
-			break
+	while (src && throwing && loc == last_loc && isturf(src.loc)) // While looks scary at first but it's basically just a for until LM.dist reaches LM.range
 		if (!LM || QDELETED(LM))
 			early_exit = TRUE
 			break
 		if (LM.dist >= LM.range)
 			break
-		if (!Move(T)) // If this returns FALSE, then a collision happened
+		if (!Move(get_step_towards(src, LM.target))) // If this returns FALSE, then a collision happened
 			break
 		last_loc = loc
 		if (++LM.dist >= LM.range)


### PR DESCRIPTION

# About the pull request
Throw will now attempt to reach the target rather than the a predefined path that could change if thrown towards an object

Tested on local but this affect a lot of stuff so needs to be tested
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
When you try to throw something and the target slightly moves one nanosecond after you throw it sucks
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Throws will now attempt to reach their target rather than the turf they were on when thrown
/:cl:
