### PR TITLE
Adds an APOLLO maintenance controller to the Warden's Office.

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -28017,8 +28017,8 @@
 	pixel_y = 9;
 	req_access_txt = "3"
 	},
-/obj/structure/machinery/light{
-	dir = 1
+/obj/structure/machinery/computer/working_joe{
+	pixel_y = 16
 	},
 /turf/open/floor/almayer{
 	dir = 1;
@@ -33316,14 +33316,18 @@
 "hlI" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/recharger,
-/obj/structure/sign/safety/terminal{
-	pixel_y = 32
-	},
 /obj/structure/transmitter/rotary{
 	name = "Brig Wardens's Office Telephone";
 	phone_category = "MP Dept.";
 	phone_id = "Brig Warden's Office";
 	pixel_x = 15
+	},
+/obj/structure/sign/safety/terminal{
+	pixel_x = 8;
+	pixel_y = 32
+	},
+/obj/structure/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/almayer{
 	dir = 9;


### PR DESCRIPTION

# About the pull request

Simply adds an APOLLO maintenance controller to the MW office in the brig. Moves some of the buttons down a bit to accommodate new computer console. Screenshot provided in the relevant section.

# Explain why it's good for the game

The brig, despite being a zone that's prone to all sorts of maintenance issues, has no APOLLO maintenance controllers at all. The nearest one being at the CIC. This should give both wardens and WJs something to do when it's quiet.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/42235601/58267043-1313-48a1-934e-429430704604)

</details>


# Changelog
:cl:
mapadd: Added an APOLLO maintenance controller to the Warden's Office.
/:cl:
