### PR TITLE
removes helmet squad sprite after removing helmet 

### DIFF
--- a/code/__DEFINES/human.dm
+++ b/code/__DEFINES/human.dm
@@ -178,7 +178,7 @@
 /// If you're hit by an acid DoT
 #define EFFECTS_LAYER 1
 
-#define TOTAL_LAYERS 42
+#define TOTAL_LAYERS 64
 //////////////////////////////////
 
 //Synthetic Defines

--- a/code/__DEFINES/human.dm
+++ b/code/__DEFINES/human.dm
@@ -153,7 +153,8 @@
 /// Unrevivable headshot overlays, suicide/execution.
 #define HEADSHOT_LAYER 18
 #define HEAD_LAYER 17
-#define HEAD_SQUAD_LAYER 16
+#define HEAD_SQUAD_LAYER 64
+#define HEAD_GARB_LAYER_1 16
 #define HEAD_GARB_LAYER_2 15 // These actual defines are unused but this space within the overlays list is
 #define HEAD_GARB_LAYER_3 14 //  |
 #define HEAD_GARB_LAYER_4 13 //  |


### PR DESCRIPTION
# About the pull request

should fix #6041 and PROPABLY fix #5912 too, they are the same with diferent method of removing the helmet , shuggest how it should be done right, layering code is... weard

# Explain why it's good for the game
bugfix


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: helmet squad stripe remaining after helmet removal
/:cl: