### PR TITLE
OT grenades will now have their timer properly reduced when fired from grenade launchers

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -2876,6 +2876,14 @@ Defined in conflicts.dm of the #defines folder.
 	G.det_time = min(15, G.det_time)
 	G.throw_range = max_range
 	G.activate(user, FALSE)
+	if(G.customizable && G.detonator) //has to be after activate because the timer assembly will set it to a minimal of 3 seconds
+		if(istimer(G.detonator.a_left))
+			var/obj/item/device/assembly/timer/timer = G.detonator.a_left
+			timer.time = 15
+		else
+			if(istimer(G.detonator.a_right))
+				var/obj/item/device/assembly/timer/timer = G.detonator.a_right
+				timer.time = 15
 	G.forceMove(get_turf(gun))
 	G.throw_atom(target, max_range, SPEED_VERY_FAST, user, null, NORMAL_LAUNCH, pass_flags)
 	current_rounds--

--- a/code/modules/projectiles/guns/specialist/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/specialist/launcher/grenade_launcher.dm
@@ -198,6 +198,14 @@
 	fired.throw_range = 20
 	fired.det_time = min(10, fired.det_time)
 	fired.activate(user, FALSE)
+	if(fired.customizable && fired.detonator) //has to be after activate because the timer assembly will set it to a minimal of 3 seconds
+		if(istimer(fired.detonator.a_left))
+			var/obj/item/device/assembly/timer/timer = fired.detonator.a_left
+			timer.time = 10
+		else
+			if(istimer(fired.detonator.a_right))
+				var/obj/item/device/assembly/timer/timer = fired.detonator.a_right
+				timer.time = 10
 	fired.forceMove(get_turf(src))
 	fired.throw_atom(target, 20, SPEED_VERY_FAST, user, null, NORMAL_LAUNCH, pass_flags)
 


### PR DESCRIPTION

# About the pull request
OT nades will now have their timer reduced when launched from grenade launchers
this is a bugfix but also a big balance change

# Explain why it's good for the game
underused M40 grenade buff
OT can now actually make stuff for grenadier
bug fix technically

# Testing Photographs and Procedure

https://github.com/cmss13-devs/cmss13/assets/140007537/52ecaf27-e2aa-425b-9415-e6ab084e1552


https://github.com/cmss13-devs/cmss13/assets/140007537/e40b48ae-e4d5-4cd3-bfb4-dcac04abcb8c


# Changelog
:cl:
balance: OT grenades will now have their detonation timer properly reduced when fired from grenade launchers
/:cl:
