### PR TITLE
You can no longer fit OT grenades in grenade launchers

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -2797,7 +2797,7 @@ Defined in conflicts.dm of the #defines folder.
 	if(!breech_open)
 		to_chat(user, SPAN_WARNING("\The [src]'s breech must be open to load grenades! (use unique-action)"))
 		return
-	if(!istype(G) || istype(G, /obj/item/explosive/grenade/spawnergrenade/))
+	if(!istype(G) || istype(G, /obj/item/explosive/grenade/spawnergrenade/) || istype(G, /obj/item/explosive/grenade/custom))
 		to_chat(user, SPAN_WARNING("[src] doesn't accept that type of grenade."))
 		return
 	if(!G.active) //can't load live grenades

--- a/code/modules/projectiles/guns/specialist/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/specialist/launcher/grenade_launcher.dm
@@ -25,7 +25,7 @@
 	///Does it launch its grenades in a low arc or a high? Do they strike people in their path, or fly beyond?
 	var/is_lobbing = FALSE
 	///Verboten munitions. This is a blacklist. Anything in this list isn't loadable.
-	var/disallowed_grenade_types = list(/obj/item/explosive/grenade/spawnergrenade, /obj/item/explosive/grenade/alien, /obj/item/explosive/grenade/incendiary/molotov, /obj/item/explosive/grenade/flashbang)
+	var/disallowed_grenade_types = list(/obj/item/explosive/grenade/spawnergrenade, /obj/item/explosive/grenade/alien, /obj/item/explosive/grenade/incendiary/molotov, /obj/item/explosive/grenade/flashbang, /obj/item/explosive/grenade/custom)
 	///What is this weapon permitted to fire? This is a whitelist. Anything in this list can be fired. Anything.
 	var/valid_munitions = list(/obj/item/explosive/grenade)
 
@@ -200,8 +200,6 @@
 	fired.activate(user, FALSE)
 	fired.forceMove(get_turf(src))
 	fired.throw_atom(target, 20, SPEED_VERY_FAST, user, null, NORMAL_LAUNCH, pass_flags)
-
-
 
 //Doesn't use these. Listed for reference.
 /obj/item/weapon/gun/launcher/grenade/load_into_chamber()


### PR DESCRIPTION

# About the pull request
grenade launchers no longer accept OT grenades
setting this to balance just in case

# Explain why it's good for the game
OT grenades don't have their timer reduced when firing from grenade launchers (intended) which means you're better off cooking and throwing them manually in 99% of cases
less noob bait in the game

# Testing Photographs and Procedure
it probably works

# Changelog
:cl:
balance: OT grenades can no longer fit in grenade launchers.
/:cl:
