### PR TITLE
Fix inconsistent number ranges for EFTPOS pin & access code

### DIFF
--- a/code/modules/economy/EFTPOS.dm
+++ b/code/modules/economy/EFTPOS.dm
@@ -198,7 +198,7 @@
 						transaction_locked = 0
 						transaction_paid = 0
 					else
-						var/attempt_code = tgui_input_number(usr, "Enter EFTPOS access code", "Reset Transaction")
+						var/attempt_code = tgui_input_number(usr, "Enter EFTPOS access code", "Reset Transaction", 1000, 999999, 1000)
 						if(attempt_code == access_code)
 							transaction_locked = 0
 							transaction_paid = 0
@@ -234,7 +234,7 @@
 					var/attempt_pin = ""
 					var/datum/money_account/D = get_account(C.associated_account_number)
 					if(D.security_level)
-						attempt_pin = tgui_input_number(usr, "Enter pin code", "EFTPOS transaction")
+						attempt_pin = tgui_input_number(usr, "Enter pin code", "EFTPOS transaction", 1111, 111111, 1111)
 						D = null
 					D = attempt_account_access(C.associated_account_number, attempt_pin, 2)
 					if(D)


### PR DESCRIPTION
# About the pull request

This PR fixes a couple places where tgui_input_number is called with default arguments when it should be within a specific range for the EFTPOS when specifying the access code and pin.

# Explain why it's good for the game

Certain values can currently lock you out of using the EFTPOS.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
fix: Fixed some number entry for your pin and access code in the EFTPOS
/:cl:
