### PR TITLE
Cryo Tube Rework

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -299,21 +299,20 @@
 	set category = "Object"
 	set src in oview(1)
 	if(usr == occupant)//If the user is inside the tube...
-		if(usr.stat == 2)//and he's not dead....
+		if(usr.stat == DEAD)//and he's not dead....
 			return
 
-		if(alert(usr, "Would you like to activate the ejection sequence of the cryo cell? Healing may be in progress.", "Confirm", "Yes", "No") == "Yes")
+		if(tgui_alert(usr, "Would you like to activate the ejection sequence of the cryo cell? Healing may be in progress.", "Confirm", list("Yes", "No")) == "Yes")
 			to_chat(usr, SPAN_NOTICE("Cryo cell release sequence activated. This will take thirty seconds."))
-			visible_message(SPAN_WARNING ("The cryo cell's tank starts draining as its ejection lights blare!"))
+			visible_message(SPAN_WARNING("The cryo cell's tank starts draining as its ejection lights blare!"))
 			sleep(300)
 			if(!src || !usr || !occupant || (occupant != usr)) //Check if someone's released/replaced/bombed him already
 				return
 			go_out()//and release him from the eternal prison.
-		else
-			if(usr.stat != 0)
-				return
-			go_out()
-	return
+	else
+		if(usr.stat != CONSCIOUS)
+			return
+		go_out()
 
 /obj/structure/machinery/cryo_cell/verb/move_inside()
 	set name = "Move Inside"

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -127,6 +127,7 @@
 	switch(action)
 		if("power")
 			on = !on
+			update_use_power(on ? USE_POWER_ACTIVE : USE_POWER_IDLE)
 			update_icon()
 			. = TRUE
 		if("eject")
@@ -181,10 +182,10 @@
 
 	updateUsrDialog(user)
 
-/obj/structure/machinery/cryo_cell/update_use_power(new_use_power)
-	var/changed = new_use_power != use_power
+/obj/structure/machinery/cryo_cell/power_change(area/master_area)
 	. = ..()
-	if(changed)
+	if((occupant || on) && operable())
+		update_use_power(USE_POWER_ACTIVE)
 		update_icon()
 
 /obj/structure/machinery/cryo_cell/update_icon()

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -307,8 +307,8 @@
 	if(cur_mob.abiotic())
 		to_chat(usr, SPAN_DANGER("Subject may not have abiotic items on."))
 		return
-	if(do_after(usr, 20, INTERRUPT_NO_NEEDHAND, BUSY_ICON_GENERIC))
-		to_chat(usr, SPAN_NOTICE("You move [cur_mob.name] inside the cryo cell."))
+	if(do_after(usr, 2 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_GENERIC))
+		visible_message(SPAN_NOTICE("[usr] moves [usr == cur_mob ? "" : "[cur_mob] "]inside the cryo cell."))
 		cur_mob.forceMove(src)
 		if(cur_mob.health >= -100 && (cur_mob.health <= 0 || cur_mob.sleeping))
 			to_chat(cur_mob, SPAN_NOTICE("<b>You feel cold liquid surround you. Your skin starts to freeze up.</b>"))
@@ -337,14 +337,17 @@
 		if(tgui_alert(usr, "Would you like to activate the ejection sequence of the cryo cell? Healing may be in progress.", "Confirm", list("Yes", "No")) == "Yes")
 			to_chat(usr, SPAN_NOTICE("Cryo cell release sequence activated. This will take thirty seconds."))
 			visible_message(SPAN_WARNING("The cryo cell's tank starts draining as its ejection lights blare!"))
-			sleep(300)
-			if(!src || !usr || !occupant || (occupant != usr)) //Check if someone's released/replaced/bombed him already
-				return
-			go_out()//and release him from the eternal prison.
+			addtimer(CALLBACK(src, PROC_REF(finish_eject), usr), 30 SECONDS, TIMER_UNIQUE|TIMER_NO_HASH_WAIT)
 	else
 		if(usr.stat != CONSCIOUS)
 			return
 		go_out()
+
+/obj/structure/machinery/cryo_cell/proc/finish_eject(mob/original)
+	//Check if someone's released/replaced/bombed him already
+	if(QDELETED(src) || QDELETED(original) || !occupant || (occupant != original))
+		return
+	go_out()//and release him from the eternal prison.
 
 /obj/structure/machinery/cryo_cell/verb/move_inside()
 	set name = "Move Inside"

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -210,8 +210,19 @@
 	if(beaker && occupant.reagents && beaker.reagents)
 		var/occupant_has_cryo_meds = occupant.reagents.get_reagent_amount("cryoxadone") >= 1 || occupant.reagents.get_reagent_amount("clonexadone") >= 1
 		var/beaker_has_cryo_meds = beaker.reagents.get_reagent_amount("cryoxadone") >= 1 || beaker.reagents.get_reagent_amount("clonexadone") >= 1
-		if(occupant_has_cryo_meds ^ beaker_has_cryo_meds)
-			// Either the occupant has cryo meds and the beaker doesn't or vice versa (not both)
+
+		// To administer, either the occupant has cryo meds and the beaker doesn't or vice versa (not both)
+		var/can_administer = (occupant_has_cryo_meds ^ beaker_has_cryo_meds) && length(beaker.reagents.reagent_list)
+		if(can_administer && occupant_has_cryo_meds)
+			// If its the case of the occupant has cryo meds and not the beaker, we need to pace out the dosage
+			// So lets make sure they don't already have some of the beaker drugs
+			for(var/datum/reagent/cur_beaker_reagent in beaker.reagents.reagent_list)
+				for(var/datum/reagent/cur_occupant_reagent in occupant.reagents.reagent_list)
+					if(cur_beaker_reagent.id == cur_occupant_reagent.id)
+						can_administer = FALSE
+						break
+
+		if(can_administer)
 			beaker.reagents.trans_to(occupant, 5)
 			beaker.reagents.reaction(occupant)
 

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -179,7 +179,7 @@
 		var/mob/grabbed_mob = grabber.grabbed_thing
 		put_mob(grabbed_mob)
 
-	updateUsrDialog()
+	updateUsrDialog(user)
 
 /obj/structure/machinery/cryo_cell/update_use_power(new_use_power)
 	var/changed = new_use_power != use_power

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -260,7 +260,7 @@
 			display_message("Patient's external wounds are healed.")
 			go_out(TRUE)
 			return
-		if(occupant.health >= 100)
+		if(occupant.health >= occupant.maxHealth)
 			display_message("Patient's external wounds are healed.")
 			go_out(TRUE)
 			return
@@ -311,7 +311,7 @@
 	if(do_after(usr, 2 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_GENERIC))
 		visible_message(SPAN_NOTICE("[usr] moves [usr == cur_mob ? "" : "[cur_mob] "]inside the cryo cell."))
 		cur_mob.forceMove(src)
-		if(cur_mob.health >= -100 && (cur_mob.health <= 0 || cur_mob.sleeping))
+		if(cur_mob.health >= HEALTH_THRESHOLD_DEAD && (cur_mob.health <= 0 || cur_mob.sleeping))
 			to_chat(cur_mob, SPAN_NOTICE("You feel cold liquid surround you. Your skin starts to freeze up."))
 		occupant = cur_mob
 		occupant_death_stage = DEATH_STAGE_NONE

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -39,7 +39,7 @@
 		if(occupant.stat == DEAD && (!istype(human_occupant) || human_occupant.undefibbable))
 			go_out(TRUE, TRUE) //Whether auto-eject is on or not, we don't permit literal deadbeats to hang around.
 			playsound(src.loc, 'sound/machines/ping.ogg', 25, 1)
-			visible_message("[icon2html(src, viewers(src))] [SPAN_WARNING("\The [src] pings: Patient is dead!")]")
+			visible_message("[icon2html(src, viewers(src))] [SPAN_WARNING("[src] pings: Patient is dead!")]")
 		else
 			process_occupant()
 
@@ -195,6 +195,7 @@
 		if(occupant.bodytemperature < T0C)
 			occupant.Sleeping(10)
 			occupant.apply_effect(10, PARALYZE)
+
 			if(occupant.getOxyLoss())
 				occupant.apply_damage(-1, OXY)
 

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -345,7 +345,7 @@
 
 /obj/structure/machinery/cryo_cell/proc/finish_eject(mob/original)
 	//Check if someone's released/replaced/bombed him already
-	if(QDELETED(src) || QDELETED(original) || !occupant || (occupant != original))
+	if(QDELETED(src) || QDELETED(original) || !occupant || occupant != original)
 		return
 	go_out()//and release him from the eternal prison.
 

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -176,13 +176,21 @@
 
 	updateUsrDialog()
 
+/obj/structure/machinery/cryo_cell/update_use_power(new_use_power)
+	var/changed = new_use_power != use_power
+	. = ..()
+	if(changed)
+		update_icon()
 
 /obj/structure/machinery/cryo_cell/update_icon()
 	icon_state = initial(icon_state)
-	icon_state = "[icon_state]-[on ? "on" : "off"]-[occupant ? "occupied" : "empty"]"
+	var/is_on = on && operable()
+	icon_state = "[icon_state]-[is_on ? "on" : "off"]-[occupant ? "occupied" : "empty"]"
 
 /obj/structure/machinery/cryo_cell/proc/process_occupant()
 	if(!occupant)
+		return
+	if(!operable())
 		return
 
 	occupant.bodytemperature += 2*(temperature - occupant.bodytemperature)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -256,11 +256,11 @@
 	if(autoeject)
 		//release the patient automatically when brute and burn are handled on non-robotic limbs
 		if(!occupant.getBruteLoss(TRUE) && !occupant.getFireLoss(TRUE) && !occupant.getCloneLoss())
-			display_message("Patient's external wounds are healed.", silent = release_notice)
+			display_message("Patient's external wounds are healed.")
 			go_out(TRUE)
 			return
 		if(occupant.health >= 100)
-			display_message("Patient's external wounds are healed.", silent = release_notice)
+			display_message("Patient's external wounds are healed.")
 			go_out(TRUE)
 			return
 
@@ -282,14 +282,14 @@
 	if(occupant.bodytemperature < 261 && occupant.bodytemperature >= 70)
 		occupant.bodytemperature = 261
 		occupant.recalculate_move_delay = TRUE
-	occupant = null
 	if(auto_eject) //Turn off and announce if auto-ejected because patient is recovered or dead.
 		on = FALSE
 		if(release_notice) //If auto-release notices are on as it should be, let the doctors know what's up
-			var/reason = "<b>Reason for release:</b> Patient recovery."
+			var/reason = "Reason for release: Patient recovery."
 			if(dead)
-				reason = "<b>Reason for release:</b> Patient death."
-			ai_silent_announcement("Patient [occupant] has been automatically released from [src] at: [get_area(occupant)]. [reason]", MED_FREQ)
+				reason = "Reason for release: Patient death."
+			ai_silent_announcement("Patient [occupant] has been automatically released from [src] at: [sanitize_area((get_area(occupant))?.name)]. [reason]", ":m")
+	occupant = null
 	update_use_power(USE_POWER_IDLE)
 	update_icon()
 	return
@@ -299,10 +299,10 @@
 		to_chat(usr, SPAN_DANGER("The cryo cell is not functioning."))
 		return
 	if(!istype(cur_mob) || isxeno(cur_mob))
-		to_chat(usr, SPAN_DANGER("<B>The cryo cell cannot handle such a lifeform!</B>"))
+		to_chat(usr, SPAN_DANGER("The cryo cell cannot handle such a lifeform!"))
 		return
 	if(occupant)
-		to_chat(usr, SPAN_DANGER("<B>The cryo cell is already occupied!</B>"))
+		to_chat(usr, SPAN_DANGER("The cryo cell is already occupied!"))
 		return
 	if(cur_mob.abiotic())
 		to_chat(usr, SPAN_DANGER("Subject may not have abiotic items on."))
@@ -311,7 +311,7 @@
 		visible_message(SPAN_NOTICE("[usr] moves [usr == cur_mob ? "" : "[cur_mob] "]inside the cryo cell."))
 		cur_mob.forceMove(src)
 		if(cur_mob.health >= -100 && (cur_mob.health <= 0 || cur_mob.sleeping))
-			to_chat(cur_mob, SPAN_NOTICE("<b>You feel cold liquid surround you. Your skin starts to freeze up.</b>"))
+			to_chat(cur_mob, SPAN_NOTICE("You feel cold liquid surround you. Your skin starts to freeze up."))
 		occupant = cur_mob
 		occupant_death_stage = DEATH_STAGE_NONE
 		update_use_power(USE_POWER_ACTIVE)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -142,31 +142,33 @@
 			return "on [t_his] feet"
 	return "...somewhere?"
 
-/obj/proc/updateUsrDialog()
-	if(in_use)
-		var/is_in_use = 0
-		var/list/nearby = viewers(1, src)
-		for(var/mob/M in nearby)
-			if ((M.client && M.interactee == src))
-				is_in_use = 1
-				attack_hand(M)
-		if (isSilicon(usr))
-			if (!(usr in nearby))
-				if (usr.client && usr.interactee==src) // && M.interactee == src is omitted because if we triggered this by using the dialog, it doesn't matter if our machine changed in between triggering it and this - the dialog is probably still supposed to refresh.
-					is_in_use = 1
-					attack_remote(usr)
-		in_use = is_in_use
+/obj/proc/updateUsrDialog(mob/user)
+	if(!user)
+		user = usr
+	if(!in_use)
+		return
+
+	var/list/nearby = viewers(1, src)
+	for(var/mob/cur_mob in nearby)
+		if(cur_mob.client && cur_mob.interactee == src)
+			in_use = TRUE
+			attack_hand(cur_mob)
+	if(isSilicon(user))
+		if(!(user in nearby))
+			if (user.client && user.interactee==src) // && M.interactee == src is omitted because if we triggered this by using the dialog, it doesn't matter if our machine changed in between triggering it and this - the dialog is probably still supposed to refresh.
+				in_use = TRUE
+				attack_remote(user)
 
 /obj/proc/updateDialog()
 	// Check that people are actually using the machine. If not, don't update anymore.
-	if(in_use)
-		var/list/nearby = viewers(1, src)
-		var/is_in_use = 0
-		for(var/mob/M in nearby)
-			if ((M.client && M.interactee == src))
-				is_in_use = 1
-				src.interact(M)
-		in_use = is_in_use
+	if(!in_use)
+		return
+
+	var/list/nearby = viewers(1, src)
+	for(var/mob/cur_mob in nearby)
+		if(cur_mob.client && cur_mob.interactee == src)
+			in_use = TRUE
+			interact(cur_mob)
 
 /obj/proc/interact(mob/user)
 	return

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -145,7 +145,7 @@
 /obj/proc/updateUsrDialog(mob/user)
 	if(!user)
 		user = usr
-	if(!in_use)
+	if(!in_use || !user)
 		return
 
 	var/list/nearby = viewers(1, src)
@@ -155,7 +155,7 @@
 			attack_hand(cur_mob)
 	if(isSilicon(user))
 		if(!(user in nearby))
-			if (user.client && user.interactee==src) // && M.interactee == src is omitted because if we triggered this by using the dialog, it doesn't matter if our machine changed in between triggering it and this - the dialog is probably still supposed to refresh.
+			if(user.client && user.interactee == src) // && M.interactee == src is omitted because if we triggered this by using the dialog, it doesn't matter if our machine changed in between triggering it and this - the dialog is probably still supposed to refresh.
 				in_use = TRUE
 				attack_remote(user)
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -148,27 +148,33 @@
 	if(!in_use || !user)
 		return
 
+	var/is_in_use = FALSE
 	var/list/nearby = viewers(1, src)
 	for(var/mob/cur_mob in nearby)
 		if(cur_mob.client && cur_mob.interactee == src)
-			in_use = TRUE
+			is_in_use = TRUE
 			attack_hand(cur_mob)
 	if(isSilicon(user))
 		if(!(user in nearby))
 			if(user.client && user.interactee == src) // && M.interactee == src is omitted because if we triggered this by using the dialog, it doesn't matter if our machine changed in between triggering it and this - the dialog is probably still supposed to refresh.
-				in_use = TRUE
+				is_in_use = TRUE
 				attack_remote(user)
+
+	in_use = is_in_use
 
 /obj/proc/updateDialog()
 	// Check that people are actually using the machine. If not, don't update anymore.
 	if(!in_use)
 		return
 
+	var/is_in_use = FALSE
 	var/list/nearby = viewers(1, src)
 	for(var/mob/cur_mob in nearby)
 		if(cur_mob.client && cur_mob.interactee == src)
-			in_use = TRUE
+			is_in_use = TRUE
 			interact(cur_mob)
+
+	in_use = is_in_use
 
 /obj/proc/interact(mob/user)
 	return

--- a/code/modules/mob/living/carbon/human/life/handle_chemicals_in_body.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_chemicals_in_body.dm
@@ -43,7 +43,7 @@
 	var/has_cryo_medicine = reagents.get_reagent_amount("cryoxadone") >= 1 || reagents.get_reagent_amount("clonexadone") >= 1
 	if(has_cryo_medicine)
 		var/obj/structure/machinery/cryo_cell/cryo = loc
-		if(!istype(cryo) || !cryo.on)
+		if(!istype(cryo) || !cryo.on || cryo.inoperable())
 			has_cryo_medicine = FALSE
 
 	for(var/datum/reagent/cur_reagent in reagents.reagent_list)

--- a/code/modules/mob/living/carbon/human/life/handle_chemicals_in_body.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_chemicals_in_body.dm
@@ -39,25 +39,33 @@
 	SHOULD_NOT_SLEEP(TRUE)
 	if(!reagents || undefibbable)
 		return // Double checking due to Life() funny background=1
-	for(var/datum/reagent/generated/R in reagents.reagent_list)
+
+	var/has_cryo_medicine = reagents.get_reagent_amount("cryoxadone") >= 1 || reagents.get_reagent_amount("clonexadone") >= 1
+	if(has_cryo_medicine && !istype(loc, /obj/structure/machinery/cryo_cell))
+		has_cryo_medicine = FALSE
+
+	for(var/datum/reagent/cur_reagent in reagents.reagent_list)
+		if(!has_cryo_medicine && !istype(cur_reagent, /datum/reagent/generated))
+			continue
+
 		var/list/mods = list( REAGENT_EFFECT = TRUE,
 								REAGENT_BOOST = FALSE,
 								REAGENT_PURGE = FALSE,
-								REAGENT_FORCE = FALSE,
+								REAGENT_FORCE = has_cryo_medicine,
 								REAGENT_CANCEL = FALSE)
 
-		for(var/datum/chem_property/P in R.properties)
-			var/list/A = P.pre_process(src)
-			if(!A)
+		for(var/datum/chem_property/cur_prop in cur_reagent.properties)
+			var/list/results = cur_prop.pre_process(src)
+			if(!results)
 				continue
-			for(var/mod in A)
-				mods[mod] |= A[mod]
+			for(var/mod in results)
+				mods[mod] |= results[mod]
 
 		if(mods[REAGENT_CANCEL])
 			return
 
 		if(mods[REAGENT_FORCE])
-			R.handle_processing(src, mods, delta_time)
-			R.holder.remove_reagent(R.id, R.custom_metabolism * delta_time)
+			cur_reagent.handle_processing(src, mods, delta_time)
+			cur_reagent.holder.remove_reagent(cur_reagent.id, cur_reagent.custom_metabolism * delta_time)
 
-		R.handle_dead_processing(src, mods, delta_time)
+		cur_reagent.handle_dead_processing(src, mods, delta_time)

--- a/code/modules/mob/living/carbon/human/life/handle_chemicals_in_body.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_chemicals_in_body.dm
@@ -41,8 +41,10 @@
 		return // Double checking due to Life() funny background=1
 
 	var/has_cryo_medicine = reagents.get_reagent_amount("cryoxadone") >= 1 || reagents.get_reagent_amount("clonexadone") >= 1
-	if(has_cryo_medicine && !istype(loc, /obj/structure/machinery/cryo_cell))
-		has_cryo_medicine = FALSE
+	if(has_cryo_medicine)
+		var/obj/structure/machinery/cryo_cell/cryo = loc
+		if(!istype(cryo) || !cryo.on)
+			has_cryo_medicine = FALSE
 
 	for(var/datum/reagent/cur_reagent in reagents.reagent_list)
 		if(!has_cryo_medicine && !istype(cur_reagent, /datum/reagent/generated))

--- a/tgui/packages/tgui/interfaces/Cryo.jsx
+++ b/tgui/packages/tgui/interfaces/Cryo.jsx
@@ -34,6 +34,11 @@ export const Cryo = () => {
 
 const CryoContent = (props) => {
   const { act, data } = useBackend();
+
+  let soundicon = 'volume-high';
+  if (!data.notify) {
+    soundicon = 'volume-xmark';
+  }
   return (
     <>
       <Section title="Occupant">
@@ -89,12 +94,30 @@ const CryoContent = (props) => {
               icon="eject"
               disabled={!data.hasOccupant}
               onClick={() => act('eject')}
-              content="eject patient"
+              content="Eject Patient"
             />
             <Button
               icon={data.autoEject ? 'sign-out-alt' : 'sign-in-alt'}
-              onClick={() => act('autoeject')}
+              width="6rem"
+              tooltipPosition="top"
+              tooltip={
+                'Auto eject is ' + (data.autoEject ? 'enabled.' : 'disabled.')
+              }
               content={data.autoEject ? 'Auto' : 'Manual'}
+              onClick={() => act('autoeject')}
+            />
+            <Button
+              icon={soundicon}
+              ml="auto"
+              mr="1rem"
+              width="5.5rem"
+              tooltipPosition="top"
+              tooltip={
+                'Auto eject notifications are ' +
+                (data.notify ? 'enabled.' : 'disabled.')
+              }
+              content={data.notify ? 'Notify' : 'Silent'}
+              onClick={() => act('notice')}
             />
           </LabeledList.Item>
         </LabeledList>


### PR DESCRIPTION
# About the pull request

This PR reworks the cryotubes. The effect of diluting or multiplying chemicals is no longer possible, but now the use of cryoxadone or clonexadone in a cryotube can allow chemicals to process in the dead. Ultimately usage of the cryo chemicals will be much higher, and you need to be careful not to introduce too many chemicals into your patient because the dosage is 5u whenever cryoxadone or clonexadone is available and can be administered.

Cryotubes also now actually require power, update their icon if they lose power, and use the two-ping sfx for warnings (such as now warnings as the patient's revive timer is running out). For the critical messages, it will make an alert if the patient is dead, then once they hit the 50% mark (2.5 mins), then at the 1 minute mark.

See testing for a demonstration.

# Explain why it's good for the game

Cryotubes in general are very underused with the exception of exploiting how it can multiply chemicals. This should give them a unique feature to medbay.

It is likely that this may prove to be too powerful, but it puts more demand on chemistry to provide the cryoxadone or clonexadone in order to do so.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Initial testing:
https://youtu.be/PA43YvzDRVM

Critical (dead state) alert testing:
https://youtu.be/PLjQxzv28l8

Notification changes:
![release](https://github.com/cmss13-devs/cmss13/assets/76988376/325e852a-79ee-4a68-9c3c-cd9001f6cc0f)

Power fixes:
![power](https://github.com/cmss13-devs/cmss13/assets/76988376/afd952eb-3004-4c91-b255-83aa98fd539f)

</details>


# Changelog
:cl: Drathek
balance: Cryotubes no longer multiply chemicals.
balance: Cryotubes can now allow chemicals to process in dead if cryoxadone or clonexadone is present.
fix: Fixed cryotubes not actually updating their icons/power usage when they become unpowered.
fix: Fixed cryotubes healing despite inoperable.
fix: The cryotube Eject Occupant verb now works for people other than the occupant (useful if inoperable)
ui: Cryotubes can optionally announce again on the medical channel.
/:cl:
