### PR TITLE
gives proper light armor slowdown to goon armor

### DIFF
--- a/code/modules/clothing/suits/marine_armor/ert.dm
+++ b/code/modules/clothing/suits/marine_armor/ert.dm
@@ -79,6 +79,7 @@
 	item_state = "armor"
 	item_state_slots = null
 	contained_sprite = TRUE
+	slowdown = SLOWDOWN_ARMOR_LIGHT
 
 	flags_armor_protection = BODY_FLAG_CHEST
 	flags_cold_protection = BODY_FLAG_CHEST

--- a/code/modules/clothing/suits/marine_armor/ert.dm
+++ b/code/modules/clothing/suits/marine_armor/ert.dm
@@ -85,8 +85,6 @@
 	flags_cold_protection = BODY_FLAG_CHEST
 	flags_heat_protection = BODY_FLAG_CHEST
 
-	slowdown = SLOWDOWN_ARMOR_NONE // only protects chest, but enables rapid movement
-
 /obj/item/clothing/suit/storage/marine/veteran/pmc/light/corporate/lead
 	desc = "A basic vest with a Weyland-Yutani badge on the right breast. This variant is worn by low-level guards that have elevated in rank due to 'good conduct in the field', also known as corporate bootlicking."
 	icon_state = "lead_armor"

--- a/code/modules/clothing/under/marine_uniform.dm
+++ b/code/modules/clothing/under/marine_uniform.dm
@@ -888,6 +888,7 @@
 	item_icons = list(
 		WEAR_BODY = 'icons/mob/humans/onmob/uniform_1.dmi',
 	)
+
 /obj/item/clothing/under/marine/reporter/black
 	icon_state = "cc_black"
 	worn_state = "cc_black"

--- a/code/modules/clothing/under/marine_uniform.dm
+++ b/code/modules/clothing/under/marine_uniform.dm
@@ -492,6 +492,7 @@
 	contained_sprite = TRUE
 	item_state_slots = null
 	flags_jumpsuit = UNIFORM_SLEEVE_ROLLABLE
+	slowdown = SLOWDOWN_ARMOR_LIGHT
 
 /obj/item/clothing/under/marine/veteran/pmc/corporate/lead
 	desc = "An armored uniform worn by Weyland-Yutani corporate security members. This variant is commonly worn by the lead of the 'goonsquad', as they are colloquially known."
@@ -888,7 +889,7 @@
 	item_icons = list(
 		WEAR_BODY = 'icons/mob/humans/onmob/uniform_1.dmi',
 	)
-	
+
 /obj/item/clothing/under/marine/reporter/black
 	icon_state = "cc_black"
 	worn_state = "cc_black"

--- a/code/modules/clothing/under/marine_uniform.dm
+++ b/code/modules/clothing/under/marine_uniform.dm
@@ -492,7 +492,6 @@
 	contained_sprite = TRUE
 	item_state_slots = null
 	flags_jumpsuit = UNIFORM_SLEEVE_ROLLABLE
-	slowdown = SLOWDOWN_ARMOR_LIGHT
 
 /obj/item/clothing/under/marine/veteran/pmc/corporate/lead
 	desc = "An armored uniform worn by Weyland-Yutani corporate security members. This variant is commonly worn by the lead of the 'goonsquad', as they are colloquially known."

--- a/code/modules/clothing/under/marine_uniform.dm
+++ b/code/modules/clothing/under/marine_uniform.dm
@@ -888,7 +888,6 @@
 	item_icons = list(
 		WEAR_BODY = 'icons/mob/humans/onmob/uniform_1.dmi',
 	)
-
 /obj/item/clothing/under/marine/reporter/black
 	icon_state = "cc_black"
 	worn_state = "cc_black"


### PR DESCRIPTION

# About the pull request
Gives light_slowdown to the goon armor that spawns on survivors, since it has BETTER THEN LIGHTARMOR without any slowdown

# Explain why it's good for the game

People are powergaming with survivor armor and i dont like it, also the goon armor is described as being shady and bad. Doesnt make sense it has nearly medium stats with no slowdown at all.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Goon armor properly has slowdown now
/:cl:
