### PR TITLE
Changes CL and SEA office phones from Almayer category to Office

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -36128,7 +36128,7 @@
 	},
 /obj/structure/transmitter/rotary{
 	name = "Senior Enlisted Advisor Office Telephone";
-	phone_category = "Almayer";
+	phone_category = "Offices";
 	phone_id = "Senior Enlisted Advisor's Office";
 	pixel_x = -3
 	},
@@ -50048,7 +50048,7 @@
 "neT" = (
 /obj/structure/transmitter/rotary{
 	name = "CL Office Telephone";
-	phone_category = "Almayer";
+	phone_category = "Offices";
 	phone_id = "CL Office"
 	},
 /obj/structure/surface/table/woodentable/fancy,


### PR DESCRIPTION
# About the pull request

Makes CL Office and SEA Office telephone lines foldered under "Offices" and not "Almayer"

Didn't move ASO because he's really part of the ship's services(or more supposed to be), I guess someone can tell me if they want it moved too

# Explain why it's good for the game

they're offices so they stay in office, it just makes sense

less scrolling on Almayer category

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Moves CL's Office and SEA's Office phone lines to "Offices" category.
/:cl:
