### PR TITLE
Fixes two of the brig's cell shutters not being linked to the button

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -20348,15 +20348,6 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
-"cJh" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 8;
-	id = "Warden Office Shutters";
-	name = "\improper Privacy Shutters"
-	},
-/turf/open/floor/plating,
-/area/almayer/shipboard/brig/cells)
 "cJm" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -93678,7 +93669,7 @@ kuJ
 sLA
 jSw
 xkd
-cJh
+qFu
 xkd
 xkd
 icM
@@ -94287,7 +94278,7 @@ wdF
 kQu
 cqM
 xkd
-cJh
+qFu
 xkd
 xkd
 pns


### PR DESCRIPTION
# About the pull request

Fixes two almayer cell shutters not being linked to the button, leading to them not opening and closing.

# Explain why it's good for the game

Bugs bad

# Testing Photographs and Procedure

Working (results may vary)

# Changelog

:cl:
maptweak: All cell shutters are now linked to the button in the warden's office
/:cl: