### PR TITLE
Flare Uncreepening

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -238,7 +238,7 @@
 	desc = "A red USCM issued flare. There are instructions on the side, it reads 'pull cord, make light'."
 	w_class = SIZE_SMALL
 	light_power = 2
-	light_range = 5
+	light_range = 7
 	icon_state = "flare"
 	item_state = "flare"
 	actions = list() //just pull it manually, neckbeard.

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -1107,8 +1107,8 @@
 	name = "flare pouch"
 	desc = "A pouch designed to hold flares. Refillable with an M94 flare pack."
 	max_w_class = SIZE_SMALL
-	storage_slots = 16
-	max_storage_space = 16
+	storage_slots = 8
+	max_storage_space = 8
 	storage_flags = STORAGE_FLAGS_POUCH|STORAGE_USING_DRAWING_METHOD
 	icon_state = "flare"
 	can_hold = list(/obj/item/device/flashlight/flare,/obj/item/device/flashlight/flare/signal)


### PR DESCRIPTION

# About the pull request

My pull request seeks to undo some of the creeping tug-of-war regarding flare availability and strength, and put flares back into a state that is more satisfying to use. I restored the old flare radius to 7 from the current 5 (undoing PR #5709), and reduced the flare pouch capacity buff, bringing them from 16>8 (undoing #5614). 


# Explain why it's good for the game

Vision in a video game is not a luxury that player feel entitled to, it is an absolutely vital sense that when overly restricted makes a fast-paced game like CM unplayable.  We don't have the luxury of the AAA audio systems in modern horror games to reveal potential threats. Nor do we have proper silhouetting to reveal creatures lurking in the dark between light sources, or the neat vision-locked flashlights of popular FPS games. All we have is semi-clunky directional light that is unable to illuminate diagonals,  and the humble flare. Using flares should feel rewarding, bringing light to darkness and granting marines a measure of control and safety. That isn't the case anymore. 


At the moment, using flares is a task of tedium that leaves marines in the dark most of the time. Where as old flares granted a 7-radius circle of light and saftey (49 tiles), the current flares only give a 5-tile radius of light (25 tiles), nearly half of their old power, the light only reaching four tiles from a character standing directly on a flare. With the amount of lethal xeno abilities that can be landed from the edge of a 4 tile lighting zone, this grants almost no safety or warning. Maintaining a screen of vision with flares has gone from needing 5 flares to 10, doubling supply attrition. Most rounds that I've played in, the marines **_Entirely run out of flares to use_**.  Vision is a more important area control mechanic than even barricades, and it's so tiring trying to stay in the light.

All this being said, the initial doubling the amount of flares in a pouch was a bad idea, and gutting flare power was even _**worse**_. These changes have been tested long enough and I think the grand majority of the community will agree the old system was better. 


# Testing Photographs and Procedure

I booted  a local copy of the server and found no errors or runtimes. I then popped a flare and saw normal behavior. 

<details>
<summary>Screenshots & Videos</summary>

https://i.imgur.com/5myOR8D.png - Glorious light

</details>


# Changelog

:cl:

balance: Restores flare power from 5>7, and reduced flare pouch capacity from 16>8. 

/:cl:
