### PR TITLE
shoulderholster storage increase, small pistol magazine pouch can also hold pistol

### DIFF
--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -768,6 +768,7 @@
 	hold = /obj/item/storage/internal/accessory/holster
 
 /obj/item/storage/internal/accessory/holster
+	storage_slots = 5
 	w_class = SIZE_LARGE
 	max_w_class = SIZE_MEDIUM
 	var/obj/item/weapon/gun/current_gun


### PR DESCRIPTION

# About the pull request

work in progress, the pistol magazine pouch holster will replace small magazine pouch idealy. needs sprite for said pouch. 
current pistol stuff numbers are: webbing can hold pistol and 2 mags ( you can carry more in drop pouch). Small pistol pouch is just... trap it can carry 3 pistol mags, meanwhile you can carry 3 rifle mags in rifle mag pouch ( and pistol mags too). large pistol magazine pouch can carry 6 mags, that is kinda fine. pistol pouch can carry one pistol, that is just shit... The changes make shoulderholster able to carry 4 extra mags instead of 2. merge pistol pouch and small pistol magazine pouch into one aka making small magazine pouch able to hold pistol and 3 pistol mags.

changlelog not up to date will change after the changes are agreed on

# Explain why it's good for the game

this should bring those storage options more in line with the other options and hopefuly allow use of sidearms and make them viable for medics and engineers for self defense when they do not need long rifle but want to use storage that allows for more then three engagments before running out of ammo
in terms of balance, this does not really effect pistols as primary weapon as for that people already just carry ammoboxes so few more mags in a pouch is not going to make it an issue. pistols as primary are extramly rare so that should not be an issue


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: small pistol magazine pouch can not also hold pistol
balance: shoulder holster can carry 4 mags from 2
/:cl:
