### PR TITLE
Flare tweaks

### DIFF
--- a/code/datums/ammo/misc.dm
+++ b/code/datums/ammo/misc.dm
@@ -113,7 +113,7 @@
 /datum/ammo/flare/set_bullet_traits()
 	. = ..()
 	LAZYADD(traits_to_give, list(
-		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_incendiary, stacks = 2.5)
+		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_incendiary, stacks = 10)
 	))
 
 /datum/ammo/flare/on_hit_mob(mob/M,obj/projectile/P)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -237,7 +237,7 @@
 	name = "flare"
 	desc = "A red USCM issued flare. There are instructions on the side, it reads 'pull cord, make light'."
 	w_class = SIZE_SMALL
-	light_power = 1
+	light_power = 2
 	light_range = 6
 	icon_state = "flare"
 	item_state = "flare"

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -237,8 +237,8 @@
 	name = "flare"
 	desc = "A red USCM issued flare. There are instructions on the side, it reads 'pull cord, make light'."
 	w_class = SIZE_SMALL
-	light_power = 2
-	light_range = 5
+	light_power = 1
+	light_range = 6
 	icon_state = "flare"
 	item_state = "flare"
 	actions = list() //just pull it manually, neckbeard.
@@ -253,7 +253,7 @@
 	/// Whether to use flame overlays for this flare type
 	var/show_flame = TRUE
 	/// Tint for the greyscale flare flame
-	var/flame_tint = "#ffcccc"
+	var/flame_tint = "#ff4545"
 	/// Color correction, added to the whole flame overlay
 	var/flame_base_tint = "#ff0000"
 	// "But, why are there two colors?"

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -237,7 +237,7 @@
 	name = "flare"
 	desc = "A red USCM issued flare. There are instructions on the side, it reads 'pull cord, make light'."
 	w_class = SIZE_SMALL
-	light_power = 2
+	light_power = 1
 	light_range = 6
 	icon_state = "flare"
 	item_state = "flare"


### PR DESCRIPTION

# About the pull request
Carries out 3 main changes with flares, increases the range to 6 tiles, decreases the power by 1 and increases the flame stack amount to 10 stacks on direct hit, along with making the light slightly more red
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
After having a good amount of testing with the previous change of decreasing the range to 5 from 7, I believe some improvements could be made, the range was the main one, settling on an inbetween of the former values, the power was decreased along with the actual light being made more red to allow for a much dimmer light that covers more area and flame stacks were buffed to 10, half of the pre nerf state but they can still be resisted out in 1 roll and in testing I only saw it needing 1-2 pats to put out, this was to bring the combat utility of it back rather than a 2 second fire that did next to nothing.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

https://imgur.com/CRvs10T
https://imgur.com/qDyuhqP

</details>


# Changelog

:cl:
balance: flare range 5->6
balance: flare power 2->1
balance: flare direct hit flame stacks 2.5->10
/:cl:

