### PR TITLE
DCC Buff/medical knowledge needed

### DIFF
--- a/code/game/jobs/job/command/auxiliary/crew_chief.dm
+++ b/code/game/jobs/job/command/auxiliary/crew_chief.dm
@@ -10,6 +10,7 @@
 	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>Your job is to assist</a> the pilot officer maintain the ship's dropship. You have authority only on the dropship, but you are expected to maintain order, as not to disrupt the pilot."
 
 AddTimelock(/datum/job/command/crew_chief, list(
+	JOB_MEDIC_ROLES = 1 HOURS,
 	JOB_SQUAD_ROLES = 5 HOURS
 ))
 

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -266,9 +266,11 @@
 			if(!skillcheck(user, SKILL_PILOT, SKILL_PILOT_TRAINED))
 				to_chat(user, SPAN_WARNING("You don't seem to understand how to restore a remote connection to [src]."))
 				return
+			if(user.action_busy)
+				return
 			else
 				to_chat(user, SPAN_WARNING("You begin to restore the remote connection to [src]."))
-				if(!do_after(user, 5 SECONDS, INTERRUPT_ALL, BUSY_ICON_BUILD))
+				if(!do_after(user, 8 SECONDS, INTERRUPT_ALL, BUSY_ICON_BUILD))
 					to_chat(user, SPAN_WARNING("You fail to restore a remote connection to [src]."))
 					return
 				unlock(TRUE)

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -262,7 +262,7 @@
 		var/datum/door_controller/single/control = linked_dropship.door_control.door_controllers[direction]
 		if (control.status != SHUTTLE_DOOR_BROKEN)
 			return ..()
-		if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
+		if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI, SKILL_PILOT_TRAINED))
 			to_chat(user, SPAN_WARNING("You don't seem to understand how to restore a remote connection to [src]."))
 			return
 		if(user.action_busy)

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -262,9 +262,20 @@
 		var/datum/door_controller/single/control = linked_dropship.door_control.door_controllers[direction]
 		if (control.status != SHUTTLE_DOOR_BROKEN)
 			return ..()
-		if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI, SKILL_PILOT, SKILL_PILOT_TRAINED))
-			to_chat(user, SPAN_WARNING("You don't seem to understand how to restore a remote connection to [src]."))
-			return
+		if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
+			if(!skillcheck(user, SKILL_PILOT, SKILL_PILOT_TRAINED))
+				to_chat(user, SPAN_WARNING("You don't seem to understand how to restore a remote connection to [src]."))
+				return
+			else
+				to_chat(user, SPAN_WARNING("You begin to restore the remote connection to [src]."))
+				if(!do_after(user, 5 SECONDS, INTERRUPT_ALL, BUSY_ICON_BUILD))
+					to_chat(user, SPAN_WARNING("You fail to restore a remote connection to [src]."))
+					return
+				unlock(TRUE)
+				close(FALSE)
+				control.status = SHUTTLE_DOOR_UNLOCKED
+				to_chat(user, SPAN_WARNING("You successfully restored the remote connection to [src]."))
+				return
 		if(user.action_busy)
 			return
 

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -262,9 +262,11 @@
 		var/datum/door_controller/single/control = linked_dropship.door_control.door_controllers[direction]
 		if (control.status != SHUTTLE_DOOR_BROKEN)
 			return ..()
-		if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI, SKILL_PILOT_TRAINED))
-			to_chat(user, SPAN_WARNING("You don't seem to understand how to restore a remote connection to [src]."))
-			return
+		if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
+			if(!skillcheck(user, SKILL_PILOT, SKILL_PILOT_TRAINED))
+				to_chat(user, SPAN_WARNING("You don't seem to understand how to restore a remote connection to [src]."))
+			else
+				return ..()
 		if(user.action_busy)
 			return
 

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -262,11 +262,9 @@
 		var/datum/door_controller/single/control = linked_dropship.door_control.door_controllers[direction]
 		if (control.status != SHUTTLE_DOOR_BROKEN)
 			return ..()
-		if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
-			if(!skillcheck(user, SKILL_PILOT, SKILL_PILOT_TRAINED))
-				to_chat(user, SPAN_WARNING("You don't seem to understand how to restore a remote connection to [src]."))
-			else
-				return ..()
+		if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI, SKILL_PILOT, SKILL_PILOT_TRAINED))
+			to_chat(user, SPAN_WARNING("You don't seem to understand how to restore a remote connection to [src]."))
+			return
 		if(user.action_busy)
 			return
 

--- a/strings/marinetips.txt
+++ b/strings/marinetips.txt
@@ -86,10 +86,10 @@ If you've been pounced on and your squad is unloading into the target, you can h
 You can check the landing zone as a marine in the status panel.
 The Colonial Marshals may come to crack down on too heavy of a Black Market usage.
 A night vision HUD optic can be recharged by removing it with a screwdriver, then placing it into a recharger.
-You can put a pistol belt on your suit slot. (Just grab a rifle instead.)
+You can put a pistol belt on your suit slot. You can also place a mag harness on a Mod-88. (Just grab a rifle instead.)
 Alt-clicking the Squad Leader tracker lets you track your fireteam leader instead.
 Armor consistently protects you from damage to your chest, arms, and legs, but does not protect hands and feet. Take the wiki damage values as a best-case scenario.
-You can click on your Security Access Tuner (multitool) in your hand to locate the area's APC if there is one.
+You can click or use your Security Access Tuner (multitool) in your hand to locate the area's APC if there is one.
 Need help learning the game and these tips aren't enough? Use MentorHelp or try to get ahold of your ship's Senior Enlisted Advisor.
 Clicking on your sprite with help intent will let you check your body, seeing where your fractures and other wounds are.
 Armor has insulative properties - taking it off will help you cool off and take less damage faster if you've been set on fire.
@@ -101,3 +101,4 @@ The nuclear ordnance requires BOTH communication towers to be actively held to d
 ARES will periodically report the amount of available tech points on Command Channel.
 The quick wield keys generally prioritize wieldable gear going from left to right on your inventory bar.
 Orbital Bombardment warheads respect roofing and hive core protection. They won't hit inside of protected areas.
+As a Queen, you can unbolt dropship doors open by clicking on them, even if they are unlocked. Pilots, Dropship crew chiefs, Engineers and Synths can repair these doors with a multitool.


### PR DESCRIPTION

# About the pull request

This PR adds in a medical hour requirement for dropship crew chiefs, as they have medical training and should are required to be knowledgeable on medical.
It also adds in the ability for dropship crew to fix their doors with a multitool. Instead of the usual five seconds for engineering trained personnel, dropship crew take eight seconds.
Finally, a tip is added, 

> "As a Queen, you can unbolt dropship doors open by clicking on them, even if they are unlocked. Pilots, Dropship crew chiefs, Engineers and Synths can repair these doors with a multitool."

And two others are modified.

# Explain why it's good for the game

Since Dropship Crew Chiefs have surgery knowledge, they must have a buffer to make sure that people who play Dropship Crew Chief are knowledgeable on medicine. This is the same for medics and doctors.

Next, it seems kinda stupid that Dropship crew aren't able to fix the own doors to their own dropship, and adds to the stigma that transport pilots and DCC's are un-fun to play, ignored and useless. By making it so they can actually repair their own dropships, they can bring a little more usefulness to rounds.

Finally, a tip is added to accommodate this PR, as I'm pretty sure no one even knew you CAN repair queen destroyed doors. I'd like to add a description to broken doors, but I'm not sure if that's possible with doorcode.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

i tested it and it worked but my medal didnt work so uh take my word for it

</details>

# Changelog

:cl:
add: Adds 1 medical hour for DCC
add: Adds and modifies some tips of the rounds. 
balance: Dropship crew chiefs and pilots can now repair dropship doors
/:cl:
