### PR TITLE
Fix unpacking vendors not performing area entry

### DIFF
--- a/code/modules/movement/movement.dm
+++ b/code/modules/movement/movement.dm
@@ -138,7 +138,7 @@
 			if(old_z != dest_z)
 				onTransitZ(old_z, dest_z)
 			destination.Entered(src, oldloc)
-			if(destarea && old_area != destarea)
+			if(destarea && (old_area != destarea || !isturf(oldloc)))
 				destarea.Entered(src, oldloc)
 
 			for(var/atom/movable/AM in destination)

--- a/code/modules/movement/movement.dm
+++ b/code/modules/movement/movement.dm
@@ -127,7 +127,7 @@
 		if(!same_loc)
 			if(oldloc)
 				oldloc.Exited(src, destination)
-				if(old_area && old_area != destarea)
+				if(old_area && (old_area != destarea || !isturf(destination)))
 					old_area.Exited(src, destination)
 			for(var/atom/movable/AM in oldloc)
 				AM.Uncrossed(src)


### PR DESCRIPTION
# About the pull request

This PR fixes unboxing vendors not entering the area to try and connect to the powernet. Note - this will mean all items getting picked up and dropped are now entering/exiting areas correctly. Possible there's some obscure new behavior with this but its unlikely.

# Explain why it's good for the game

If you unbox a machine in a powered area, it should be powered.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/76988376/55d47379-5780-4443-b615-f8783df59aef

</details>


# Changelog
:cl: Drathek
fix: Fixed unboxed machines not connecting to the power net
/:cl:
