### PR TITLE
Adds medlinks to the marinemeds in medbay

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -10350,6 +10350,7 @@
 /area/almayer/medical/chemistry)
 "bek" = (
 /obj/structure/machinery/cm_vending/sorted/medical/marinemed,
+/obj/structure/medical_supply_link,
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "sterile_green_side"

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -60167,6 +60167,7 @@
 	dir = 8
 	},
 /obj/structure/machinery/cm_vending/sorted/medical/marinemed,
+/obj/structure/medical_supply_link,
 /turf/open/floor/almayer{
 	icon_state = "redfull"
 	},
@@ -76697,6 +76698,7 @@
 	pixel_x = 8;
 	pixel_y = 32
 	},
+/obj/structure/medical_supply_link,
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},


### PR DESCRIPTION
# About the pull request

This is a followup/accompanying PR to #5677 and #6103 adding medlinks under the 3 marine meds in medbay, hangar panic room, and CIC armory.

# Explain why it's good for the game
Marinemeds were already configured to expect medlinks, they just didn't get them mapped in.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
maptweak: Added medlinks under the marinemeds in medbay, hangar panic room, and CIC armory.
/:cl:
