### PR TITLE
Warriors punch now slows predators, damage made a little more consistent

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_abilities.dm
@@ -41,5 +41,5 @@
 	// Configurables
 	var/base_damage = 25
 	var/base_punch_damage_synth = 30
-	var/base_punch_damage_pred = 25
+	var/base_punch_damage_pred = 30
 	var/damage_variance = 5

--- a/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_powers.dm
@@ -158,6 +158,7 @@
 			carbon.apply_effect(3, SLOW)
 
 		if(isyautja(carbon))
+			carbon.apply_effect(2, SLOW)
 			damage = rand(base_punch_damage_pred, base_punch_damage_pred + damage_variance)
 		else if(target_limb.status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 			damage = rand(base_punch_damage_synth, base_punch_damage_synth + damage_variance)


### PR DESCRIPTION
# About the pull request

Warriors punch now slows predators, 1 second less than against humans. The base damage is also now the same as it is against synths, but with predator armor this means it's consistently 4-6 brute instead of less.

# Explain why it's good for the game

Completely useless ability in fights against preds, only serves to immediately let go of the pred after a lunge and avoid being hit. It's damage is usually worse then straight up slashing and it's also inconsistent that it will slow synths/humans but not predators because the if check only checks for humans (which includes synths) but not predators. The slow is a second shorter, and is a normal slow (not superslow) so it shouldn't be egregious in warrior versus pred fights.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
balance: Warriors punch will slow Predators, base damage increased slightly
/:cl:


