### PR TITLE
dehardcodes client version warnings

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -650,7 +650,7 @@ This maintains a list of ip addresses that are able to bypass topic filtering.
 	min_val = 0
 
 /datum/config_entry/string/client_warn_message
-	default = "Your version of byond may have issues or be blocked from accessing this server in the future."
+	default = "Your version of BYOND may have issues or be blocked from accessing this server in the future."
 
 /datum/config_entry/flag/client_warn_popup
 
@@ -659,7 +659,7 @@ This maintains a list of ip addresses that are able to bypass topic filtering.
 	min_val = 500
 
 /datum/config_entry/string/client_error_message
-	default = "Your version of byond is too old, may have issues, and is blocked from accessing this server."
+	default = "Your version of BYOND is too old, may have issues, and is blocked from accessing this server."
 
 /datum/config_entry/number/client_error_build
 	default = null

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -658,9 +658,9 @@ This maintains a list of ip addresses that are able to bypass topic filtering.
 	default = null
 	min_val = 500
 
-/datum/config_entry/string/client_error_message
-	default = "Your version of BYOND is too old, may have issues, and is blocked from accessing this server."
-
 /datum/config_entry/number/client_error_build
 	default = null
 	min_val = 0
+
+/datum/config_entry/string/client_error_message
+	default = "Your version of BYOND is too old, may have issues, and is blocked from accessing this server."

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -640,3 +640,27 @@ This maintains a list of ip addresses that are able to bypass topic filtering.
 	splitter = "|"
 	key_mode = KEY_MODE_TEXT_UNALTERED
 	value_mode = VALUE_MODE_TEXT
+
+/datum/config_entry/number/client_warn_version
+	default = null
+	min_val = 500
+
+/datum/config_entry/number/client_warn_build
+	default = null
+	min_val = 0
+
+/datum/config_entry/string/client_warn_message
+	default = "Your version of byond may have issues or be blocked from accessing this server in the future."
+
+/datum/config_entry/flag/client_warn_popup
+
+/datum/config_entry/number/client_error_version
+	default = null
+	min_val = 500
+
+/datum/config_entry/string/client_error_message
+	default = "Your version of byond is too old, may have issues, and is blocked from accessing this server."
+
+/datum/config_entry/number/client_error_build
+	default = null
+	min_val = 0

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -5,8 +5,6 @@
 #define UPLOAD_LIMIT 10485760 //Restricts client uploads to the server to 10MB //Boosted this thing. What's the worst that can happen?
 #define MIN_CLIENT_VERSION 0 //Just an ambiguously low version for now, I don't want to suddenly stop people playing.
 									//I would just like the code ready should it ever need to be used.
-#define GOOD_BYOND_MAJOR 513
-#define GOOD_BYOND_MINOR 1500
 
 GLOBAL_LIST_INIT(blacklisted_builds, list(
 	"1407" = "bug preventing client display overrides from working leads to clients being able to see things/mobs they shouldn't be able to see",
@@ -362,14 +360,34 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 		INVOKE_ASYNC(src, /client/proc/set_macros)
 
 	// Version check below if we ever need to start checking against BYOND versions again.
+	var/breaking_version = CONFIG_GET(number/client_error_version)
+	var/breaking_build = CONFIG_GET(number/client_error_build)
+	var/warn_version = CONFIG_GET(number/client_warn_version)
+	var/warn_build = CONFIG_GET(number/client_warn_build)
 
-	/*if((byond_version < world.byond_version) || ((byond_version == world.byond_version) && (byond_build < world.byond_build)))
-		src << "<span class='warning'>Your version of Byond (v[byond_version].[byond_build]) differs from the server (v[world.byond_version].[world.byond_build]). You may experience graphical glitches, crashes, or other errors. You will be disconnected until your version matches or exceeds the server version.<br> \
-		Direct Download (Windows Installer): http://www.byond.com/download/build/[world.byond_version]/[world.byond_version].[world.byond_build]_byond.exe <br> \
-		Other versions (search for [world.byond_build] or higher): http://www.byond.com/download/build/[world.byond_version]</span>"
+	if (byond_version < breaking_version || (byond_version == breaking_version && byond_build < breaking_build)) //Out of date client.
+		to_chat_immediate(src, SPAN_DANGER("<b>Your version of BYOND is too old:</b>"))
+		to_chat_immediate(src, CONFIG_GET(string/client_error_message))
+		to_chat_immediate(src, "Your version: [byond_version].[byond_build]")
+		to_chat_immediate(src, "Required version: [breaking_version].[breaking_build] or later")
+		to_chat_immediate(src, "Visit <a href=\"https://www.byond.com/download\">BYOND's website</a> to get the latest version of BYOND.")
 		qdel(src)
-		return*/
-	//hardcode for now
+		return
+
+	if (byond_version < warn_version || (byond_version == warn_version && byond_build < warn_build)) //We have words for this client.
+		if(CONFIG_GET(flag/client_warn_popup))
+			var/msg = "<b>Your version of byond may be getting out of date:</b><br>"
+			msg += CONFIG_GET(string/client_warn_message) + "<br><br>"
+			msg += "Your version: [byond_version].[byond_build]<br>"
+			msg += "Required version to remove this message: [warn_version].[warn_build] or later<br>"
+			msg += "Visit <a href=\"https://www.byond.com/download\">BYOND's website</a> to get the latest version of BYOND.<br>"
+			src << browse(msg, "window=warning_popup")
+		else
+			to_chat_immediate(src, SPAN_DANGER("<b>Your version of byond may be getting out of date:</b>"))
+			to_chat_immediate(src, CONFIG_GET(string/client_warn_message))
+			to_chat_immediate(src, "Your version: [byond_version].[byond_build]")
+			to_chat_immediate(src, "Required version to remove this message: [warn_version].[warn_build] or later")
+			to_chat_immediate(src, "Visit <a href=\"https://www.byond.com/download\">BYOND's website</a> to get the latest version of BYOND.")
 
 	if (num2text(byond_build) in GLOB.blacklisted_builds)
 		log_access("Failed login: [key] - blacklisted byond build ([byond_version].[byond_build])")
@@ -379,10 +397,6 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 		to_chat_immediate(src, SPAN_NOTICE(FONT_SIZE_LARGE("You will now be automatically disconnected. Have a CM day.")))
 		qdel(src)
 		return
-
-	//do this check after the blacklist check to avoid confusion
-	if((byond_version < GOOD_BYOND_MAJOR) || ((byond_version == GOOD_BYOND_MAJOR) && (byond_build < GOOD_BYOND_MINOR)))
-		to_chat(src, FONT_SIZE_HUGE(SPAN_BOLDNOTICE("YOUR BYOND VERSION IS NOT WELL SUITED FOR THIS SERVER. Download latest BETA build or you may suffer random crashes or disconnects.")))
 
 	// Initialize tgui panel
 	stat_panel.initialize(

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -376,14 +376,14 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 
 	if (byond_version < warn_version || (byond_version == warn_version && byond_build < warn_build)) //We have words for this client.
 		if(CONFIG_GET(flag/client_warn_popup))
-			var/msg = "<b>Your version of byond may be getting out of date:</b><br>"
+			var/msg = "<b>Your version of BYOND may be getting out of date:</b><br>"
 			msg += CONFIG_GET(string/client_warn_message) + "<br><br>"
 			msg += "Your version: [byond_version].[byond_build]<br>"
 			msg += "Required version to remove this message: [warn_version].[warn_build] or later<br>"
 			msg += "Visit <a href=\"https://www.byond.com/download\">BYOND's website</a> to get the latest version of BYOND.<br>"
 			src << browse(msg, "window=warning_popup")
 		else
-			to_chat_immediate(src, SPAN_DANGER("<b>Your version of byond may be getting out of date:</b>"))
+			to_chat_immediate(src, SPAN_DANGER("<b>Your version of BYOND may be getting out of date:</b>"))
 			to_chat_immediate(src, CONFIG_GET(string/client_warn_message))
 			to_chat_immediate(src, "Your version: [byond_version].[byond_build]")
 			to_chat_immediate(src, "Required version to remove this message: [warn_version].[warn_build] or later")

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -383,11 +383,11 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 			msg += "Visit <a href=\"https://www.byond.com/download\">BYOND's website</a> to get the latest version of BYOND.<br>"
 			src << browse(msg, "window=warning_popup")
 		else
-			to_chat_immediate(src, SPAN_DANGER("<b>Your version of BYOND may be getting out of date:</b>"))
-			to_chat_immediate(src, CONFIG_GET(string/client_warn_message))
-			to_chat_immediate(src, "Your version: [byond_version].[byond_build]")
-			to_chat_immediate(src, "Required version to remove this message: [warn_version].[warn_build] or later")
-			to_chat_immediate(src, "Visit <a href=\"https://www.byond.com/download\">BYOND's website</a> to get the latest version of BYOND.")
+			to_chat(src, SPAN_DANGER("<b>Your version of BYOND may be getting out of date:</b>"))
+			to_chat(src, CONFIG_GET(string/client_warn_message))
+			to_chat(src, "Your version: [byond_version].[byond_build]")
+			to_chat(src, "Required version to remove this message: [warn_version].[warn_build] or later")
+			to_chat(src, "Visit <a href=\"https://www.byond.com/download\">BYOND's website</a> to get the latest version of BYOND.")
 
 	if (num2text(byond_build) in GLOB.blacklisted_builds)
 		log_access("Failed login: [key] - blacklisted byond build ([byond_version].[byond_build])")

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -241,3 +241,5 @@ GAMEMODE_DEFAULT Extended
 
 ## How long the mob will take to chestburst, in seconds
 #EMBRYO_BURST_TIMER 450
+
+CLIENT_ERROR_VERSION 514

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -242,4 +242,14 @@ GAMEMODE_DEFAULT Extended
 ## How long the mob will take to chestburst, in seconds
 #EMBRYO_BURST_TIMER 450
 
+## CLIENT VERSION CONTROL
+## This allows you to configure the minimum required client version, as well as a warning version, and message for both.
+## These trigger for any version below (non-inclusive) the given version, so 510 triggers on 509 or lower.
+## These messages will be followed by one stating the clients current version and the required version for clarity.
+#CLIENT_WARN_VERSION 514
+#CLIENT_WARN_BUILD 1589
+#CLIENT_WARN_MESSAGE Your version of BYOND may have issues or be blocked from accessing this server in the future.
+#CLIENT_WARN_POPUP
 CLIENT_ERROR_VERSION 514
+#CLIENT_ERROR_BUILD 1589
+#CLIENT_ERROR_MESSAGE Your version of BYOND is too old, may have issues, and is blocked from accessing this server.


### PR DESCRIPTION
:cl: MrStonedOne, LemonInTheDark
server: config now allows you to warn players to upgrade their byond version, or bar them based on their byond version
/:cl:

thanks to https://github.com/tgstation/tgstation/pull/73549 https://github.com/tgstation/tgstation/pull/16914