### PR TITLE
M3A1 Synthetic Utility Vest becomes light(er)weight

### DIFF
--- a/code/modules/clothing/suits/marine_armor/_marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor/_marine_armor.dm
@@ -483,7 +483,7 @@
 
 /obj/item/clothing/suit/storage/marine/light/synvest
 	name = "\improper M3A1 Synthetic Utility Vest"
-	desc = "This variant of the ubiquitous M3 pattern ballistics vest has been extensively modified, providing no protection in exchange for maximum mobility and storage space. Synthetic programming compliant."
+	desc = "This variant of the ubiquitous M3 pattern vest has been extensively modified, providing no protection in exchange for maximum mobility and added storage. Synthetic programming compliant."
 	icon_state = "VL_syn_camo"
 	flags_atom = NO_NAME_OVERRIDE
 	flags_marine_armor = ARMOR_LAMP_OVERLAY|SYNTH_ALLOWED //No squad colors + can be worn by synths.
@@ -496,7 +496,7 @@
 	armor_rad = CLOTHING_ARMOR_NONE
 	armor_internaldamage = CLOTHING_ARMOR_NONE
 	storage_slots = 3
-	slowdown = SLOWDOWN_ARMOR_VERY_LIGHT
+	slowdown = SLOWDOWN_ARMOR_SUPER_LIGHT
 	time_to_unequip = 0.5 SECONDS
 	time_to_equip = 1 SECONDS
 	uniform_restricted = null


### PR DESCRIPTION

# About the pull request

This PR changes the M3A1 Synthetic Utility Vest to have a 10% slowdown
TLDR, I want more people to use this vest because its flavorful. I conducted a poll last year to see why pretty much no one used it and its because of the slowdown with nothing to show for it, as it is an armor vest .. without the armor. Less than 1% of participants of the poll cared about the storage space(which is quite laughable, at 1 slot)

Adding armor is not something I intend, but minimizing the slowdown is something I intend, and I see it as intuitive.

If an armor vest weighs 25kg and you remove 2 inserts of 10kg armor, how does it still weigh 25kg?!? It is a stretch to say it has any slower movement at all.



You get: added storage(1 slot), a suit light
For: 20% slowdown

Because the main intended user of this is a USCM Synthetic, they don't really benefit from the suitlight since they are usually with Marines.
Speed is key for any support role and for Synthetic it is especially crucial, slowing yourself down for a single inventory slot is just ridiculous. Granted, there is still a slowdown here. 

Overall I'd just like to see it being used more under various circumstances, whether its for flavor during preparations in dangerous situations, or if its just part of someones outfit. 

# Explain why it's good for the game

Despite many attempts to get more people to use it, the M3A1 is used by borderline nobody because of the slowdown. 

The description states that ALL ARMOR is removed(and indeed, all armor is removed). Why does it weight as much as combat vests that ALSO have lights and storage pouches? It just doesn't make sense. Armor weighs a significant amount and removing it should lighten the vest **significantly,** as described.

Making it more lightweight will hopefully have more people use it. It is the only USCM styled Synthetic piece available. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: M3A1 Synthetic Utility Vest only has a 10% slowdown.
/:cl:
