### PR TITLE
Removes spec pop lock

### DIFF
--- a/code/game/jobs/slot_scaling.dm
+++ b/code/game/jobs/slot_scaling.dm
@@ -40,7 +40,7 @@
 	return job_slot_formula(playercount,30,1,1,3)
 
 /proc/spec_slot_formula(playercount)
-	return job_slot_formula(playercount,20,1,2,4)
+	return job_slot_formula(playercount,20,1,4,4)
 
 /proc/sg_slot_formula(playercount)
 	return job_slot_formula(playercount,20,1,2,4)


### PR DESCRIPTION

# About the pull request
Remove 60 marines required for the 4th spec slot
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
No reason to limit it and it causes people to stay in lobby and wait for the slot to open which is bad for the game.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Removed pop lock for squad specialists, Now there will always be 4 slots
/:cl:
