### PR TITLE
Working Joe Grammar Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/species/working_joe/warning.dm
+++ b/code/modules/mob/living/carbon/human/species/working_joe/warning.dm
@@ -32,7 +32,7 @@
 /datum/emote/living/carbon/human/synthetic/working_joe/warning/hurt_yourself
 	key = "hurtyourself"
 	sound = 'sound/voice/joe/hurt_yourself.ogg'
-	say_message = "Your going to hurt yourself."
+	say_message = "You're going to hurt yourself."
 	emote_type = EMOTE_AUDIBLE|EMOTE_VISIBLE
 
 /datum/emote/living/carbon/human/synthetic/working_joe/warning/someone_hurt


### PR DESCRIPTION

# About the pull request

Grammar fix for a Working Joe Voiceline (your -> you're)

# Explain why it's good for the game

It isn't.

# Changelog
:cl:
spellcheck: fixed a grammar mistake in a Working Joe voiceline
/:cl:
