### PR TITLE
Fix additional cryo reagent duplication via TOUCH reaction

### DIFF
--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -157,6 +157,8 @@ GLOBAL_LIST_INIT(RESTRICTED_CAMERA_NETWORKS, list( //Those networks can only be 
 
 #define TOUCH 1
 #define INGEST 2
+/// Will convert to TOUCH after skipping permeability code in /datum/reagent/proc/reaction_mob
+#define TOUCH_NO_DUPLICATION 3
 
 /// Marks an object as organic. Used for alien structures and any other organic material
 #define OBJ_ORGANIC (1<<0)

--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -155,10 +155,10 @@ GLOBAL_LIST_INIT(RESTRICTED_CAMERA_NETWORKS, list( //Those networks can only be 
 #define RESULT_REQUIRES_SNOW (1<<0)
 
 
+/// Reaction type from touching it
 #define TOUCH 1
+/// Reaction type from eating it
 #define INGEST 2
-/// Will convert to TOUCH after skipping permeability code in /datum/reagent/proc/reaction_mob
-#define TOUCH_NO_DUPLICATION 3
 
 /// Marks an object as organic. Used for alien structures and any other organic material
 #define OBJ_ORGANIC (1<<0)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -252,6 +252,7 @@
 
 		if(can_administer)
 			beaker.reagents.trans_to(occupant, 5)
+			beaker.reagents.reaction(occupant, TOUCH_NO_DUPLICATION)
 
 	if(autoeject)
 		//release the patient automatically when brute and burn are handled on non-robotic limbs

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -252,7 +252,7 @@
 
 		if(can_administer)
 			beaker.reagents.trans_to(occupant, 5)
-			beaker.reagents.reaction(occupant, TOUCH_NO_DUPLICATION)
+			beaker.reagents.reaction(occupant, permeable_in_mobs = FALSE)
 
 	if(autoeject)
 		//release the patient automatically when brute and burn are handled on non-robotic limbs

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -252,7 +252,6 @@
 
 		if(can_administer)
 			beaker.reagents.trans_to(occupant, 5)
-			beaker.reagents.reaction(occupant)
 
 	if(autoeject)
 		//release the patient automatically when brute and burn are handled on non-robotic limbs

--- a/code/game/objects/effects/effect_system/chemsmoke.dm
+++ b/code/game/objects/effects/effect_system/chemsmoke.dm
@@ -138,7 +138,7 @@
 								var/dist = cheap_pythag(T.x - location.x, T.y - location.y)
 								if(!dist)
 									dist = 1
-								R.reaction_mob(A, volume = R.volume / dist)
+								R.reaction_mob(A, volume = R.volume / dist, permeable = FALSE)
 							else if(istype(A, /obj))
 								R.reaction_obj(A, R.volume)
 					sleep(30)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -359,12 +359,12 @@
 		del_reagent(R.id)
 	return FALSE
 
-/datum/reagents/proc/reaction(atom/A, method=TOUCH, volume_modifier=0)
+/datum/reagents/proc/reaction(atom/A, method=TOUCH, volume_modifier=0, permeable_in_mobs=TRUE)
 	if(method != TOUCH && method != INGEST)
 		return
 	for(var/datum/reagent/R in reagent_list)
 		if(ismob(A))
-			R.reaction_mob(A, method, R.volume + volume_modifier)
+			R.reaction_mob(A, method, R.volume + volume_modifier, permeable_in_mobs)
 		else if(isturf(A))
 			R.reaction_turf(A, R.volume + volume_modifier)
 		else if(isobj(A))

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -83,7 +83,7 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	for(var/datum/chem_property/P in properties)
 		P.post_update_reagent()
 
-/datum/reagent/proc/reaction_mob(mob/M, method=TOUCH, volume) //By default we have a chance to transfer some
+/datum/reagent/proc/reaction_mob(mob/M, method=TOUCH, volume, permeable) //By default we have a chance to transfer some
 	if(!istype(M, /mob/living)) return 0
 	var/datum/reagent/self = src
 	src = null   //of the reagent to the mob on TOUCHING it.
@@ -92,7 +92,7 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 		if(!istype(self.holder.my_atom, /obj/effect/particle_effect/smoke/chem))
 			// If the chemicals are in a smoke cloud, do not try to let the chemicals "penetrate" into the mob's system (balance station 13) -- Doohl
 
-			if(method == TOUCH)
+			if(method == TOUCH && permeable)
 
 				var/chance = 1
 				var/block  = 0
@@ -114,8 +114,6 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 				if(prob(chance) && !block)
 					if(M.reagents)
 						M.reagents.add_reagent(self.id,self.volume/2)
-		if(method == TOUCH_NO_DUPLICATION)
-			method = TOUCH
 		for(var/datum/chem_property/P in self.properties)
 			var/potency = P.level * 0.5
 			P.reaction_mob(M, method, volume, potency)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -96,7 +96,8 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 			var/block = FALSE
 
 			for(var/obj/item/clothing/clothing in M.get_equipped_items())
-				if(clothing.permeability_coefficient < chance) chance = clothing.permeability_coefficient
+				if(clothing.permeability_coefficient < chance)
+					chance = clothing.permeability_coefficient
 				if(istype(clothing, /obj/item/clothing/suit/bio_suit))
 					// bio suits are just about completely fool-proof - Doohl
 					// kind of a hacky way of making bio suits more resistant to chemicals but w/e
@@ -107,7 +108,7 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 					if(prob(75))
 						block = TRUE
 
-			chance = chance * 100
+			chance *= 100
 
 			if(prob(chance) && !block)
 				if(M.reagents)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -84,42 +84,40 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 		P.post_update_reagent()
 
 /datum/reagent/proc/reaction_mob(mob/M, method=TOUCH, volume, permeable) //By default we have a chance to transfer some
-	if(!istype(M, /mob/living)) return 0
+	if(!istype(M, /mob/living))
+		return FALSE
 	var/datum/reagent/self = src
 	src = null   //of the reagent to the mob on TOUCHING it.
 
 	if(self.holder) //for catching rare runtimes
-		if(!istype(self.holder.my_atom, /obj/effect/particle_effect/smoke/chem))
+		if(method == TOUCH && permeable && !istype(self.holder.my_atom, /obj/effect/particle_effect/smoke/chem))
 			// If the chemicals are in a smoke cloud, do not try to let the chemicals "penetrate" into the mob's system (balance station 13) -- Doohl
+			var/chance = 1
+			var/block = FALSE
 
-			if(method == TOUCH && permeable)
+			for(var/obj/item/clothing/clothing in M.get_equipped_items())
+				if(clothing.permeability_coefficient < chance) chance = clothing.permeability_coefficient
+				if(istype(clothing, /obj/item/clothing/suit/bio_suit))
+					// bio suits are just about completely fool-proof - Doohl
+					// kind of a hacky way of making bio suits more resistant to chemicals but w/e
+					if(prob(75))
+						block = TRUE
 
-				var/chance = 1
-				var/block  = 0
+				if(istype(clothing, /obj/item/clothing/head/bio_hood))
+					if(prob(75))
+						block = TRUE
 
-				for(var/obj/item/clothing/C in M.get_equipped_items())
-					if(C.permeability_coefficient < chance) chance = C.permeability_coefficient
-					if(istype(C, /obj/item/clothing/suit/bio_suit))
-						// bio suits are just about completely fool-proof - Doohl
-						// kind of a hacky way of making bio suits more resistant to chemicals but w/e
-						if(prob(75))
-							block = 1
+			chance = chance * 100
 
-					if(istype(C, /obj/item/clothing/head/bio_hood))
-						if(prob(75))
-							block = 1
+			if(prob(chance) && !block)
+				if(M.reagents)
+					M.reagents.add_reagent(self.id, self.volume * 0.5)
 
-				chance = chance * 100
+		for(var/datum/chem_property/property in self.properties)
+			var/potency = property.level * 0.5
+			property.reaction_mob(M, method, volume, potency)
 
-				if(prob(chance) && !block)
-					if(M.reagents)
-						M.reagents.add_reagent(self.id,self.volume/2)
-		for(var/datum/chem_property/P in self.properties)
-			var/potency = P.level * 0.5
-			P.reaction_mob(M, method, volume, potency)
-
-
-	return 1
+	return TRUE
 
 /datum/reagent/proc/reaction_obj(obj/O, volume)
 	for(var/datum/chem_property/P in properties)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -114,6 +114,8 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 				if(prob(chance) && !block)
 					if(M.reagents)
 						M.reagents.add_reagent(self.id,self.volume/2)
+		if(method == TOUCH_NO_DUPLICATION)
+			method = TOUCH
 		for(var/datum/chem_property/P in self.properties)
 			var/potency = P.level * 0.5
 			P.reaction_mob(M, method, volume, potency)

--- a/code/modules/reagents/chemistry_reagents/food.dm
+++ b/code/modules/reagents/chemistry_reagents/food.dm
@@ -150,7 +150,7 @@
 	chemclass = CHEM_CLASS_RARE
 	properties = list(PROPERTY_HYPERTHERMIC = 1)
 
-/datum/reagent/condensedcapsaicin/reaction_mob(mob/living/M, method=TOUCH, volume)
+/datum/reagent/condensedcapsaicin/reaction_mob(mob/living/M, method=TOUCH, volume, permeable)
 	if(!istype(M, /mob/living) || has_species(M,"Horror"))
 		return
 

--- a/code/modules/reagents/chemistry_reagents/other.dm
+++ b/code/modules/reagents/chemistry_reagents/other.dm
@@ -13,7 +13,7 @@
 	chemclass = CHEM_CLASS_RARE
 
 
-/datum/reagent/blood/reaction_mob(mob/M, method=TOUCH, volume)
+/datum/reagent/blood/reaction_mob(mob/M, method=TOUCH, volume, permeable)
 	var/datum/reagent/blood/self = src
 	src = null
 	if(self.data_properties && self.data_properties["viruses"])
@@ -85,7 +85,7 @@
 	color = "#C81040" // rgb: 200, 16, 64
 	properties = list(PROPERTY_CURING = 4)
 
-/datum/reagent/vaccine/reaction_mob(mob/M, method=TOUCH, volume)
+/datum/reagent/vaccine/reaction_mob(mob/M, method=TOUCH, volume, permeable)
 	if(has_species(M,"Horror"))
 		return
 	var/datum/reagent/vaccine/self = src
@@ -124,7 +124,7 @@
 	src = null
 	O.extinguish()
 
-/datum/reagent/water/reaction_mob(mob/living/M, method=TOUCH, volume)//Splashing people with water can help put them out!
+/datum/reagent/water/reaction_mob(mob/living/M, method=TOUCH, volume, permeable)//Splashing people with water can help put them out!
 	if(!istype(M, /mob/living))
 		return
 	if(method == TOUCH)
@@ -517,7 +517,7 @@
 	if(volume >= 1 && istype(T))
 		T.clean_cleanables()
 
-/datum/reagent/space_cleaner/reaction_mob(mob/M, method=TOUCH, volume)
+/datum/reagent/space_cleaner/reaction_mob(mob/M, method=TOUCH, volume, permeable)
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
 		if(C.r_hand)
@@ -592,7 +592,7 @@
 	reagent_state = LIQUID
 	color = "#535E66" // rgb: 83, 94, 102
 
-/datum/reagent/xenomicrobes/reaction_mob(mob/M, method=TOUCH, volume)
+/datum/reagent/xenomicrobes/reaction_mob(mob/M, method=TOUCH, volume, permeable)
 	src = null
 	if((prob(10) && method==TOUCH) || method==INGEST)
 		M.contract_disease(new /datum/disease/xeno_transformation(0),1)
@@ -664,7 +664,7 @@
 	custom_metabolism = 100 //disappears immediately
 	properties = list(PROPERTY_RAVENING = 1)
 
-/datum/reagent/blackgoo/reaction_mob(mob/M, method=TOUCH, volume)
+/datum/reagent/blackgoo/reaction_mob(mob/M, method=TOUCH, volume, permeable)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.species.name == "Human")


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #6058 where it was brought to my attention that chemicals were still duplicating from cryotube beakers. This is because the cryotube was trying to simulate the patient being immersed in the reagents, but with a 50% permeability that doesn't even consume the reacted reagents, it easily gets out of control if large volumes are involved and or the ratio of cryo meds is small in the mixture causing frequent reapplications of reagents.

# Explain why it's good for the game

It was intended to remove chemical duplication via cyropods. This shores up another source of chemical duplication.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![cryo](https://github.com/cmss13-devs/cmss13/assets/76988376/26b19859-9d86-48e4-8800-be34089cf1d8)

After rework 200 bicaradine and 20 cryoxadone:

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/3551f146-f874-4700-bf67-c7a9f2aebb87)

</details>


# Changelog
:cl: Drathek
fix: Fixed cryotubes still duplicating chemicals because of touch reactions
/:cl:
