### PR TITLE
Increase damage of standard revolver ammo from 55 to 72

### DIFF
--- a/code/datums/ammo/bullet/revolver.dm
+++ b/code/datums/ammo/bullet/revolver.dm
@@ -7,8 +7,7 @@
 /datum/ammo/bullet/revolver
 	name = "revolver bullet"
 	headshot_state = HEADSHOT_OVERLAY_MEDIUM
-
-	damage = 55
+	damage = 72
 	penetration = ARMOR_PENETRATION_TIER_1
 	accuracy = HIT_ACCURACY_TIER_1
 

--- a/code/datums/ammo/bullet/revolver.dm
+++ b/code/datums/ammo/bullet/revolver.dm
@@ -13,7 +13,7 @@
 
 /datum/ammo/bullet/revolver/marksman
 	name = "marksman revolver bullet"
-
+	damage = 55
 	shrapnel_chance = 0
 	damage_falloff = 0
 	accurate_range = 12


### PR DESCRIPTION
# About the pull request
After some testing from myself on a private server and gathering a lot of feedback from a post i made on the forum.
https://forum.cm-ss13.com/t/m44-rework-making-this-handgun-potent-and-unique-already-unique-in-uscm-weapon/6917
i think M44 is very cool buy lack damage output as an handgun if comparison to all the other handguns.

why 72 ? because it allow to kill a drone with a full mag and a runner with three bullet (if you manage to hit them)
it balance itself with the low mag capacity and the lower firing speed of it.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
because the M44 is cool to use but i also want it to make it a decent pick if you want to use an handgun.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Increase damage of standard revolver ammo from 55 to 72.
balance: Marksman ammo remains 55 damage.
/:cl:
