### PR TITLE
Fix colony lights sometimes deleting after explosions

### DIFF
--- a/code/game/machinery/colony_floodlights.dm
+++ b/code/game/machinery/colony_floodlights.dm
@@ -281,6 +281,27 @@
 		else if(!is_lit)
 			. += SPAN_INFO("It doesn't seem powered.")
 
+/obj/structure/machinery/colony_floodlight/ex_act(severity)
+	switch(severity)
+		if(0 to EXPLOSION_THRESHOLD_LOW)
+			if(prob(25))
+				set_damaged()
+				return
+		if(EXPLOSION_THRESHOLD_LOW to EXPLOSION_THRESHOLD_MEDIUM)
+			if(prob(50))
+				set_damaged()
+				return
+		if(EXPLOSION_THRESHOLD_MEDIUM to INFINITY)
+			set_damaged()
+			return
+
+/obj/structure/machinery/colony_floodlight/proc/set_damaged()
+	playsound(src, "glassbreak", 70, 1)
+	damaged = TRUE
+	if(is_lit)
+		set_light(0)
+	update_icon()
+
 /obj/structure/machinery/colony_floodlight/proc/toggle_light()
 	is_lit = !is_lit
 	if(!damaged)

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -864,11 +864,7 @@
 	M.visible_message("[M] slashes away at [src]!","We slash and claw at the bright light!", max_distance = 5, message_flags = CHAT_TYPE_XENO_COMBAT)
 	health  = max(health - rand(M.melee_damage_lower, M.melee_damage_upper), 0)
 	if(!health)
-		playsound(src, "glassbreak", 70, 1)
-		damaged = TRUE
-		if(is_lit)
-			set_light(0)
-		update_icon()
+		set_damaged()
 	else
 		playsound(loc, 'sound/effects/Glasshit.ogg', 25, 1)
 	return XENO_ATTACK_ACTION


### PR DESCRIPTION

# About the pull request

I don't know if this was ever implemented, but I would like colony lights to break down, not disappear if they explode.

# Explain why it's good for the game

Fixes #6130 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/66ed4f1c-d2c9-4be6-8900-61cc9c54fe9c)

</details>


# Changelog
:cl: Drathek
fix: Fixed colony lights deconstructing sometimes after explosions
/:cl:
