### PR TITLE
Disable un-resting someone when they are dizzy

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -209,7 +209,10 @@
 		if(client)
 			sleeping = max(0,src.sleeping-5)
 		if(!sleeping)
-			set_resting(FALSE)
+			if(is_dizzy)
+				to_chat(M, SPAN_WARNING("[src] looks dizzy. Maybe you should let [t_him] rest a bit longer."))
+			else
+				set_resting(FALSE)
 		M.visible_message(SPAN_NOTICE("[M] shakes [src] trying to wake [t_him] up!"), \
 			SPAN_NOTICE("You shake [src] trying to wake [t_him] up!"), null, 4)
 	else if(HAS_TRAIT(src, TRAIT_INCAPACITATED))


### PR DESCRIPTION
# About the pull request

This PR prevents unresting someone when you pat them if they are dizzy.

# Explain why it's good for the game

Voluntary resting disables screen shifting and allows dizziness to pass faster. Other players won't necessarily know if the rest is voluntary, but this change makes it so they get all the effects of patting without the unresting aspect if they are dizzy.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/76988376/d0219430-8a94-4eb6-98a7-46d8abe7c45c

</details>


# Changelog
:cl: Drathek
add: Patting someone that is dizzy will no longer unrest them
/:cl:
