### PR TITLE
Fixes uncrowable floor APC in LZ1 for Chances Claim

### DIFF
--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -9855,6 +9855,17 @@
 /obj/vehicle/train/cargo/engine,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
+"evg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/lv624/fog_blocker/short,
+/obj/structure/machinery/power/apc/weak{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "greenfull"
+	},
+/area/lv522/landing_zone_1/ceiling)
 "evu" = (
 /obj/structure/tunnel/maint_tunnel{
 	pixel_y = 6
@@ -61924,15 +61935,6 @@
 	icon_state = "marked"
 	},
 /area/lv522/indoors/a_block/fitness)
-"xOS" = (
-/obj/structure/machinery/power/apc/weak{
-	dir = 1
-	},
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/asphalt/cement{
-	icon_state = "cement12"
-	},
-/area/lv522/landing_zone_1)
 "xPa" = (
 /obj/structure/machinery/conveyor,
 /turf/open/floor/plating,
@@ -66660,7 +66662,7 @@ cpy
 tFx
 tFx
 wnP
-rzz
+evg
 syM
 rnT
 lBl
@@ -66889,7 +66891,7 @@ moz
 mvP
 ggS
 tFx
-xOS
+rnT
 lBl
 ttT
 pkH


### PR DESCRIPTION

# About the pull request

moves the LZ1 APC inside the office and it could be fixed now so yeah

# Explain why it's good for the game

bug fix good


# Testing Photographs and Procedure
tested - works


# Changelog

:cl: LTNTS
maptweak: moves APC in Chance's Claim LZ1 to where it can actually be fixed
/:cl:

