### PR TITLE
Lesser drone nerfs

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -354,8 +354,11 @@
 
 /obj/item/clothing/mask/facehugger/proc/try_jump()
 	jump_timer = addtimer(CALLBACK(src, PROC_REF(try_jump)), time_between_jumps, TIMER_OVERRIDE|TIMER_STOPPABLE|TIMER_UNIQUE)
+	if(stat != CONSCIOUS || isnull(loc)) //Make sure we're conscious and not idle or dead.
+		jumps_left-- // Huggers should still lose hp, even when idle
 
-	if(isnull(loc))
+		if(!jumps_left)
+			end_lifecycle()
 		return
 
 	if(isxeno(loc))
@@ -363,9 +366,7 @@
 		if(X.caste.hugger_nurturing) // caste can prevent hugger death
 			return
 
-	if(stat == CONSCIOUS) //Make sure we're conscious and not idle or dead.
-		leap_at_nearest_target()
-	
+	leap_at_nearest_target()
 	jumps_left--
 	if(!jumps_left)
 		end_lifecycle()

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -350,7 +350,7 @@
 	stat = CONSCIOUS
 	jump_timer = addtimer(CALLBACK(src, PROC_REF(try_jump)), time_between_jumps, TIMER_OVERRIDE|TIMER_STOPPABLE|TIMER_UNIQUE)
 
-/obj/item/clothing/mask/facehugger/proc/go_idle(delete_timer = TRUE) //Idle state does not count toward the death timer.
+/obj/item/clothing/mask/facehugger/proc/go_idle(var/delete_timer = TRUE) //Idle state does not count toward the death timer.
 	if(stat == DEAD || stat == UNCONSCIOUS)
 		return
 

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -175,12 +175,8 @@
 
 /obj/item/clothing/mask/facehugger/equipped(mob/M)
 	SHOULD_CALL_PARENT(FALSE) // ugh equip sounds
-
-	var/mob/living/carbon/xenomorph/xeno = M
-	
-	if(xeno.caste.hugger_nurturing || hivenumber == XENO_HIVE_TUTORIAL) // caste can prevent hugger death
-		jumps_left = initial(jumps_left)
-		go_idle()
+	// So picking up a hugger does not prematurely kill it
+	go_idle()
 
 /obj/item/clothing/mask/facehugger/Crossed(atom/target)
 	has_proximity(target)
@@ -354,18 +350,10 @@
 	stat = UNCONSCIOUS
 	icon_state = "[initial(icon_state)]_inactive"
 	if(jump_timer)
-		jumps_left-- // Reduce a jump so you cannot infinitely juggle huggers unless nurturing \ tutorial
 		deltimer(jump_timer)
-
-		if(!jumps_left)
-			end_lifecycle()
-			return
-	
 	jump_timer = null
 	// Reset the jumps left to their original count
-	if(hivenumber == XENO_HIVE_TUTORIAL) // caste can prevent hugger death
-		jumps_left = initial(jumps_left)
-
+	jumps_left = initial(jumps_left)
 	addtimer(CALLBACK(src, PROC_REF(go_active)), rand(MIN_ACTIVE_TIME,MAX_ACTIVE_TIME))
 
 /obj/item/clothing/mask/facehugger/proc/try_jump()

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -175,8 +175,12 @@
 
 /obj/item/clothing/mask/facehugger/equipped(mob/M)
 	SHOULD_CALL_PARENT(FALSE) // ugh equip sounds
-	// So picking up a hugger does not prematurely kill it
-	go_idle()
+
+	var/mob/living/carbon/xenomorph/xeno = M
+	
+	if(xeno.caste.hugger_nurturing || hivenumber == XENO_HIVE_TUTORIAL) // caste can prevent hugger death
+		jumps_left = initial(jumps_left)
+		go_idle()
 
 /obj/item/clothing/mask/facehugger/Crossed(atom/target)
 	has_proximity(target)
@@ -350,10 +354,18 @@
 	stat = UNCONSCIOUS
 	icon_state = "[initial(icon_state)]_inactive"
 	if(jump_timer)
+		jumps_left-- // Reduce a jump so you cannot infinitely juggle huggers unless nurturing \ tutorial
 		deltimer(jump_timer)
+
+		if(!jumps_left)
+			end_lifecycle()
+			return
+	
 	jump_timer = null
 	// Reset the jumps left to their original count
-	jumps_left = initial(jumps_left)
+	if(hivenumber == XENO_HIVE_TUTORIAL) // caste can prevent hugger death
+		jumps_left = initial(jumps_left)
+
 	addtimer(CALLBACK(src, PROC_REF(go_active)), rand(MIN_ACTIVE_TIME,MAX_ACTIVE_TIME))
 
 /obj/item/clothing/mask/facehugger/proc/try_jump()

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -343,22 +343,22 @@
 	stat = CONSCIOUS
 	jump_timer = addtimer(CALLBACK(src, PROC_REF(try_jump)), time_between_jumps, TIMER_OVERRIDE|TIMER_STOPPABLE|TIMER_UNIQUE)
 
-/obj/item/clothing/mask/facehugger/proc/go_idle()
+/obj/item/clothing/mask/facehugger/proc/go_idle() //Idle state does not count toward the death timer.
 	if(stat == DEAD || stat == UNCONSCIOUS)
 		return
 
 	stat = UNCONSCIOUS
 	icon_state = "[initial(icon_state)]_inactive"
-
+	if(jump_timer)
+		deltimer(jump_timer)
+	jump_timer = null
+	// Reset the jumps left to their original count
+	jumps_left = initial(jumps_left)
 	addtimer(CALLBACK(src, PROC_REF(go_active)), rand(MIN_ACTIVE_TIME,MAX_ACTIVE_TIME))
 
 /obj/item/clothing/mask/facehugger/proc/try_jump()
 	jump_timer = addtimer(CALLBACK(src, PROC_REF(try_jump)), time_between_jumps, TIMER_OVERRIDE|TIMER_STOPPABLE|TIMER_UNIQUE)
 	if(stat != CONSCIOUS || isnull(loc)) //Make sure we're conscious and not idle or dead.
-		jumps_left-- // Huggers should still lose hp, even when idle
-
-		if(!jumps_left)
-			end_lifecycle()
 		return
 
 	if(isxeno(loc))

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -76,7 +76,9 @@
 		return
 	addtimer(CALLBACK(src, PROC_REF(check_turf)), 0.2 SECONDS)
 	if(stat == CONSCIOUS && loc) //Make sure we're conscious and not idle or dead.
-		go_idle()
+		var/jumps_before = jumps_left
+		go_idle(FALSE)
+		jumps_left = jumps_before
 	if(attached)
 		attached = FALSE
 		die()
@@ -173,10 +175,15 @@
 	if(exposed_temperature > 300)
 		die()
 
-/obj/item/clothing/mask/facehugger/equipped(mob/M)
+/obj/item/clothing/mask/facehugger/equipped(mob/holder)
 	SHOULD_CALL_PARENT(FALSE) // ugh equip sounds
-	// So picking up a hugger does not prematurely kill it
-	go_idle()
+	if (!isxeno(holder))
+		return
+
+	var/mob/living/carbon/xenomorph/xeno = holder
+
+	if (xeno.caste.hugger_nurturing || hivenumber == XENO_HIVE_TUTORIAL)
+		go_idle()
 
 /obj/item/clothing/mask/facehugger/Crossed(atom/target)
 	has_proximity(target)
@@ -343,22 +350,23 @@
 	stat = CONSCIOUS
 	jump_timer = addtimer(CALLBACK(src, PROC_REF(try_jump)), time_between_jumps, TIMER_OVERRIDE|TIMER_STOPPABLE|TIMER_UNIQUE)
 
-/obj/item/clothing/mask/facehugger/proc/go_idle() //Idle state does not count toward the death timer.
+/obj/item/clothing/mask/facehugger/proc/go_idle(var/delete_timer = TRUE) //Idle state does not count toward the death timer.
 	if(stat == DEAD || stat == UNCONSCIOUS)
 		return
 
 	stat = UNCONSCIOUS
 	icon_state = "[initial(icon_state)]_inactive"
-	if(jump_timer)
-		deltimer(jump_timer)
-	jump_timer = null
+	if(delete_timer)
+		if(jump_timer)
+			deltimer(jump_timer)
+		jump_timer = null
 	// Reset the jumps left to their original count
 	jumps_left = initial(jumps_left)
 	addtimer(CALLBACK(src, PROC_REF(go_active)), rand(MIN_ACTIVE_TIME,MAX_ACTIVE_TIME))
 
 /obj/item/clothing/mask/facehugger/proc/try_jump()
 	jump_timer = addtimer(CALLBACK(src, PROC_REF(try_jump)), time_between_jumps, TIMER_OVERRIDE|TIMER_STOPPABLE|TIMER_UNIQUE)
-	if(stat != CONSCIOUS || isnull(loc)) //Make sure we're conscious and not idle or dead.
+	if(isnull(loc)) //Make sure we're conscious and not idle or dead.
 		return
 
 	if(isxeno(loc))
@@ -366,7 +374,8 @@
 		if(X.caste.hugger_nurturing) // caste can prevent hugger death
 			return
 
-	leap_at_nearest_target()
+	if(stat == CONSCIOUS)
+		leap_at_nearest_target()
 	jumps_left--
 	if(!jumps_left)
 		end_lifecycle()

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -350,7 +350,7 @@
 	stat = CONSCIOUS
 	jump_timer = addtimer(CALLBACK(src, PROC_REF(try_jump)), time_between_jumps, TIMER_OVERRIDE|TIMER_STOPPABLE|TIMER_UNIQUE)
 
-/obj/item/clothing/mask/facehugger/proc/go_idle(var/delete_timer = TRUE) //Idle state does not count toward the death timer.
+/obj/item/clothing/mask/facehugger/proc/go_idle(delete_timer = TRUE) //Idle state does not count toward the death timer.
 	if(stat == DEAD || stat == UNCONSCIOUS)
 		return
 

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -343,22 +343,22 @@
 	stat = CONSCIOUS
 	jump_timer = addtimer(CALLBACK(src, PROC_REF(try_jump)), time_between_jumps, TIMER_OVERRIDE|TIMER_STOPPABLE|TIMER_UNIQUE)
 
-/obj/item/clothing/mask/facehugger/proc/go_idle() //Idle state does not count toward the death timer.
+/obj/item/clothing/mask/facehugger/proc/go_idle()
 	if(stat == DEAD || stat == UNCONSCIOUS)
 		return
 
 	stat = UNCONSCIOUS
 	icon_state = "[initial(icon_state)]_inactive"
-	if(jump_timer)
-		deltimer(jump_timer)
-	jump_timer = null
-	// Reset the jumps left to their original count
-	jumps_left = initial(jumps_left)
+
 	addtimer(CALLBACK(src, PROC_REF(go_active)), rand(MIN_ACTIVE_TIME,MAX_ACTIVE_TIME))
 
 /obj/item/clothing/mask/facehugger/proc/try_jump()
 	jump_timer = addtimer(CALLBACK(src, PROC_REF(try_jump)), time_between_jumps, TIMER_OVERRIDE|TIMER_STOPPABLE|TIMER_UNIQUE)
 	if(stat != CONSCIOUS || isnull(loc)) //Make sure we're conscious and not idle or dead.
+		jumps_left-- // Huggers should still lose hp, even when idle
+
+		if(!jumps_left)
+			end_lifecycle()
 		return
 
 	if(isxeno(loc))

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -354,11 +354,8 @@
 
 /obj/item/clothing/mask/facehugger/proc/try_jump()
 	jump_timer = addtimer(CALLBACK(src, PROC_REF(try_jump)), time_between_jumps, TIMER_OVERRIDE|TIMER_STOPPABLE|TIMER_UNIQUE)
-	if(stat != CONSCIOUS || isnull(loc)) //Make sure we're conscious and not idle or dead.
-		jumps_left-- // Huggers should still lose hp, even when idle
 
-		if(!jumps_left)
-			end_lifecycle()
+	if(isnull(loc))
 		return
 
 	if(isxeno(loc))
@@ -366,7 +363,9 @@
 		if(X.caste.hugger_nurturing) // caste can prevent hugger death
 			return
 
-	leap_at_nearest_target()
+	if(stat == CONSCIOUS) //Make sure we're conscious and not idle or dead.
+		leap_at_nearest_target()
+	
 	jumps_left--
 	if(!jumps_left)
 		end_lifecycle()

--- a/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
@@ -128,9 +128,6 @@
 	adjust_effect(6, STUN)
 	apply_effect(6, WEAKEN)
 
-/mob/living/carbon/xenomorph/lesser_drone/get_status_tab_items()
-	. = ..()
-
 /datum/behavior_delegate/lesser_drone_base
 	name = "Base Lesser Drone Behavior Delegate"
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
@@ -19,7 +19,7 @@
 	behavior_delegate_type = /datum/behavior_delegate/lesser_drone_base
 
 	caste_desc = "A builder of hives."
-	can_hold_facehuggers = TRUE
+	can_hold_facehuggers = 0
 	can_hold_eggs = CAN_HOLD_TWO_HANDS
 	acid_level = 1
 	weed_level = WEED_LEVEL_STANDARD

--- a/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
@@ -19,7 +19,7 @@
 	behavior_delegate_type = /datum/behavior_delegate/lesser_drone_base
 
 	caste_desc = "A builder of hives."
-	can_hold_facehuggers = 0
+	can_hold_facehuggers = TRUE
 	can_hold_eggs = CAN_HOLD_TWO_HANDS
 	acid_level = 1
 	weed_level = WEED_LEVEL_STANDARD
@@ -119,14 +119,6 @@
 
 /mob/living/carbon/xenomorph/lesser_drone/handle_ghost_message()
 	return
-
-/mob/living/carbon/xenomorph/lesser_drone/handle_screech_act(mob/self, mob/living/carbon/xenomorph/queen/queen)
-	return null
-
-/mob/living/carbon/xenomorph/lesser_drone/handle_queen_screech(mob/living/carbon/xenomorph/queen/queen)
-	to_chat(src, SPAN_DANGER("The mighty roar of the queen makes you tremble and fall over!"))
-	adjust_effect(6, STUN)
-	apply_effect(6, WEAKEN)
 
 /datum/behavior_delegate/lesser_drone_base
 	name = "Base Lesser Drone Behavior Delegate"

--- a/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
@@ -19,7 +19,7 @@
 	behavior_delegate_type = /datum/behavior_delegate/lesser_drone_base
 
 	caste_desc = "A builder of hives."
-	can_hold_facehuggers = TRUE
+	can_hold_facehuggers = 0
 	can_hold_eggs = CAN_HOLD_TWO_HANDS
 	acid_level = 1
 	weed_level = WEED_LEVEL_STANDARD
@@ -119,6 +119,14 @@
 
 /mob/living/carbon/xenomorph/lesser_drone/handle_ghost_message()
 	return
+
+/mob/living/carbon/xenomorph/lesser_drone/handle_screech_act(mob/self, mob/living/carbon/xenomorph/queen/queen)
+	return null
+
+/mob/living/carbon/xenomorph/lesser_drone/handle_queen_screech(mob/living/carbon/xenomorph/queen/queen)
+	to_chat(src, SPAN_DANGER("The mighty roar of the queen makes you tremble and fall over!"))
+	adjust_effect(6, STUN)
+	apply_effect(6, WEAKEN)
 
 /datum/behavior_delegate/lesser_drone_base
 	name = "Base Lesser Drone Behavior Delegate"

--- a/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
@@ -16,9 +16,10 @@
 	can_be_revived = FALSE
 
 	build_time_mult = BUILD_TIME_MULT_LESSER_DRONE
+	behavior_delegate_type = /datum/behavior_delegate/lesser_drone_base
 
 	caste_desc = "A builder of hives."
-	can_hold_facehuggers = 1
+	can_hold_facehuggers = 0
 	can_hold_eggs = CAN_HOLD_TWO_HANDS
 	acid_level = 1
 	weed_level = WEED_LEVEL_STANDARD
@@ -118,3 +119,21 @@
 
 /mob/living/carbon/xenomorph/lesser_drone/handle_ghost_message()
 	return
+
+/mob/living/carbon/xenomorph/lesser_drone/handle_screech_act(mob/self, mob/living/carbon/xenomorph/queen/queen)
+	return null
+
+/mob/living/carbon/xenomorph/lesser_drone/handle_queen_screech(mob/living/carbon/xenomorph/queen/queen)
+	to_chat(src, SPAN_DANGER("The mighty roar of the queen makes you tremble and fall over!"))
+	adjust_effect(6, STUN)
+	apply_effect(6, WEAKEN)
+
+/mob/living/carbon/xenomorph/lesser_drone/get_status_tab_items()
+	. = ..()
+
+/datum/behavior_delegate/lesser_drone_base
+	name = "Base Lesser Drone Behavior Delegate"
+
+/datum/behavior_delegate/lesser_drone_base/on_life()
+	if(bound_xeno.body_position == STANDING_UP && !(locate(/obj/effect/alien/weeds) in get_turf(bound_xeno)))
+		bound_xeno.adjustBruteLoss(5)

--- a/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
@@ -19,7 +19,7 @@
 	behavior_delegate_type = /datum/behavior_delegate/lesser_drone_base
 
 	caste_desc = "A builder of hives."
-	can_hold_facehuggers = 0
+	can_hold_facehuggers = TRUE
 	can_hold_eggs = CAN_HOLD_TWO_HANDS
 	acid_level = 1
 	weed_level = WEED_LEVEL_STANDARD


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Lesser drones can go for extremely high risk high reward strategies without any risk as there is basically an infinite amount of respawns and no punishment for dying.

I don't see why they should get a different treatment than huggers as they can just run in and apply facehuggers manually or for going off weeds to sneak into backline and place huggers on AFK marines they saw from ghost or just running around being an annoyance.

And this is coming from a xeno main.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: You can no longer infinitely extend  facehugger's lifetime by REDACTED
balance: Lessers now lose 5 hp every 2 seconds off weeds
/:cl:
