### PR TITLE
Warrior BUff

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -148,6 +148,8 @@
 			continue
 
 		final_lifesteal++
+	if(isyautja(carbon))
+		bound_xeno.gain_health(20) // You heal a +20 health each time you slash a predator.
 
 // This part is then outside the for loop
 		if(final_lifesteal >= max_lifesteal)


### PR DESCRIPTION

# About the pull request
Gives warrior slash extra healing on predators

# Explain why it's good for the game
You used to be reliably one v one a predator as warrior, and i think this is a good way to rebase that without adding in further slow / stuns or whatever, had a good talk with a councilor that made some great points on how adding more CC in the fight would made it more boring / cancer, so we settled on just giving it more health per slash which should just helpthe warrior without hindering the predator too much

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Warrior slash now heals +20 if the slashed target is a predator
/:cl:
