### PR TITLE
Synthetics X Gibber Fanfiction (Reworks how Synthetics and the meat gibber interact)

### DIFF
--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -105,15 +105,28 @@
 		to_chat(user, SPAN_WARNING("You need a better grip to do that!"))
 		return
 
-	if(victim.abiotic(1))
+	if(victim.abiotic(TRUE))
 		to_chat(user, SPAN_WARNING("Subject may not have abiotic items on."))
 		return
 
 	user.visible_message(SPAN_DANGER("[user] starts to put [victim] into the gibber!"))
 	add_fingerprint(user)
 
+	///If synth is getting gibbed, we will 'soft gib' them, but this is still pretty LRP so let admin know.
+	if(issynth(victim) && ishuman_strict(user) && !occupant)
+		var/turf/turf_ref = get_turf(user)
+		var/area/area = get_area(user)
+		message_admins("ALERT: [user] ([user.key]) is trying to shove [victim] in a gibber! (They are a synth, so this will delimb them) ([victim.key]) in [area.name] [ADMIN_JMP(turf_ref)]</font>")
+		log_attack("[key_name(user)] tried to delimb [victim] using a gibber ([victim.key]) in [area.name]")
+		to_chat(user, SPAN_DANGER("What are you doing..."))
+		if(do_after(user, 30 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE && grabbed && grabbed.grabbed_thing && !occupant))
+			user.visible_message(SPAN_DANGER("[user] stuffs [victim] into the gibber!"))
+			victim.forceMove(src)
+			occupant = victim
+			update_icon()
+
 	///If someone's being LRP and doing funny chef shit, this lets admins know. This *shouldn't* flag preds, though.
-	if(ishuman(victim) && ishuman_strict(user) && !occupant)
+	else if(ishuman(victim) && ishuman_strict(user) && !occupant)
 		var/turf/turf_ref = get_turf(user)
 		var/area/area = get_area(user)
 		message_admins("ALERT: [user] ([user.key]) is trying to gib [victim] ([victim.key]) in [area.name] [ADMIN_JMP(turf_ref)]</font>")
@@ -142,18 +155,22 @@
 	add_fingerprint(usr)
 	return
 
-/obj/structure/machinery/gibber/proc/go_out()
+/obj/structure/machinery/gibber/proc/go_out(launch = FALSE)
 	if (!occupant)
-		return
+		return FALSE
 	for(var/obj/O in src)
 		O.forceMove(loc)
 	if (occupant.client)
 		occupant.client.eye = occupant.client.mob
 		occupant.client.perspective = MOB_PERSPECTIVE
 	occupant.forceMove(loc)
+	if(launch)
+		// yeet them out of the gibber
+		var/turf/Tx = locate(x - 3, y, z)
+		occupant.throw_atom(Tx, 3, SPEED_FAST, src, TRUE)
 	occupant = null
 	update_icon()
-	return
+	return TRUE
 
 
 /obj/structure/machinery/gibber/proc/startgibbing(mob/user as mob)
@@ -168,6 +185,8 @@
 	update_icon()
 
 	var/totalslabs = 2
+
+	var/synthetic = issynth(occupant)
 
 	var/obj/item/reagent_container/food/snacks/meat/meat_template = /obj/item/reagent_container/food/snacks/meat/monkey
 	if(istype(occupant, /mob/living/carbon/xenomorph))
@@ -186,6 +205,33 @@
 			meat_template = /obj/item/reagent_container/food/snacks/meat/human
 			totalslabs = 3
 
+	// Synths only get delimbed from this. 1 meat per limb
+	if(synthetic)
+		meat_template = /obj/item/reagent_container/food/snacks/meat/synthmeat/synthflesh
+		totalslabs = 0
+		var/mob/living/carbon/human/victim = occupant
+
+		// Check for arms and legs, and get grinding
+		var/obj/limb/limb = victim.get_limb("r_leg")
+		if(limb)
+			totalslabs += 1
+			limb.droplimb(FALSE, TRUE, "gibber")
+
+		limb = victim.get_limb("l_leg")
+		if(limb)
+			totalslabs += 1
+			limb.droplimb(FALSE, TRUE, "gibber")
+
+		limb = victim.get_limb("r_arm")
+		if(limb)
+			totalslabs += 1
+			limb.droplimb(FALSE, TRUE, "gibber")
+
+		limb = victim.get_limb("l_arm")
+		if(limb)
+			totalslabs += 1
+			limb.droplimb(FALSE, TRUE, "gibber")
+
 	var/obj/item/reagent_container/food/snacks/meat/allmeat[totalslabs]
 	for(var/i in 1 to totalslabs)
 		var/obj/item/reagent_container/food/snacks/meat/newmeat
@@ -193,6 +239,14 @@
 		newmeat.made_from_player = occupant.real_name + "-"
 		newmeat.name = newmeat.made_from_player + newmeat.name
 		allmeat[i] = newmeat
+
+		// Synths wont die to this (on it's own at least), dont log as a gib
+		if(synthetic)
+			if(src.occupant.client) // Log still
+				src.occupant.attack_log += "\[[time_stamp()]\] Was delimbed by <b>[key_name(user)]</b>"
+				user.attack_log += "\[[time_stamp()]\] delimbed <b>[key_name(occupant)]</b>"
+				msg_admin_attack("[key_name(user)] delimbed [key_name(occupant)] with a gibber in [user.loc.name]([user.x], [user.y], [user.z]).", user.x, user.y, user.z)
+			continue
 
 		if(src.occupant.client) // Gibbed a cow with a client in it? log that shit
 			src.occupant.attack_log += "\[[time_stamp()]\] Was gibbed by <b>[key_name(user)]</b>"
@@ -202,6 +256,9 @@
 		src.occupant.death(create_cause_data("gibber", user), TRUE)
 		src.occupant.ghostize()
 
+	if(synthetic)
+		go_out(TRUE) //launch them out
+		return
 	QDEL_NULL(occupant)
 
 	addtimer(CALLBACK(src, PROC_REF(create_gibs), totalslabs, allmeat), gibtime)

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -248,19 +248,19 @@
 
 		// Synths wont die to this (on it's own at least), dont log as a gib
 		if(synthetic)
-			if(src.occupant.client) // Log still
-				src.occupant.attack_log += "\[[time_stamp()]\] Was delimbed by <b>[key_name(user)]</b>"
+			if(occupant.client) // Log still
+				occupant.attack_log += "\[[time_stamp()]\] Was delimbed by <b>[key_name(user)]</b>"
 				user.attack_log += "\[[time_stamp()]\] delimbed <b>[key_name(occupant)]</b>"
 				msg_admin_attack("[key_name(user)] delimbed [key_name(occupant)] with a gibber in [user.loc.name]([user.x], [user.y], [user.z]).", user.x, user.y, user.z)
 			continue
 
-		if(src.occupant.client) // Gibbed a cow with a client in it? log that shit
-			src.occupant.attack_log += "\[[time_stamp()]\] Was gibbed by <b>[key_name(user)]</b>"
+		if(occupant.client) // Gibbed a cow with a client in it? log that shit
+			occupant.attack_log += "\[[time_stamp()]\] Was gibbed by <b>[key_name(user)]</b>"
 			user.attack_log += "\[[time_stamp()]\] Gibbed <b>[key_name(occupant)]</b>"
 			msg_admin_attack("[key_name(user)] gibbed [key_name(occupant)] in [user.loc.name] ([user.x], [user.y], [user.z]).", user.x, user.y, user.z)
 
-		src.occupant.death(create_cause_data("gibber", user), TRUE)
-		src.occupant.ghostize()
+		occupant.death(create_cause_data("gibber", user), TRUE)
+		occupant.ghostize()
 
 	if(synthetic)
 		to_chat(occupant, SPAN_HIGHDANGER("You can detect your limbs being ripped off your body, but it begins to malfunction as it reaches your torso!"))

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -166,6 +166,7 @@
 	occupant.forceMove(loc)
 	if(launch)
 		// yeet them out of the gibber
+		visible_message(SPAN_DANGER("[occupant] suddenly is launched out of the [src]!"))
 		var/turf/Tx = locate(x - 3, y, z)
 		occupant.throw_atom(Tx, 3, SPEED_FAST, src, TRUE)
 	occupant = null

--- a/code/game/objects/items/reagent_containers/food/snacks/meat.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks/meat.dm
@@ -28,7 +28,8 @@
 	name = "synthetic meat"
 	desc = "A synthetic slab of flesh."
 
-/obj/item/reagent_container/food/snacks/meat/synthmeat/synthflesh //meat made from synthetics. Slightly toxic
+/// Meat made from synthetics. Slightly toxic
+/obj/item/reagent_container/food/snacks/meat/synthmeat/synthflesh
 	name = "synthetic flesh"
 	desc = "A slab of artificial, inorganic 'flesh' that resembles human meat. Probably came from a synth."
 	icon_state = "synthmeat"

--- a/code/modules/cm_tech/droppod/lz_effect.dm
+++ b/code/modules/cm_tech/droppod/lz_effect.dm
@@ -34,6 +34,7 @@
 
 /obj/effect/warning/explosive/proc/disappear()
 	qdel(src)
+
 /obj/effect/warning/explosive/gas
 	name = "gas warning"
 	color = "#42acd6"

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -342,7 +342,7 @@ GLOBAL_LIST_INIT(limb_types_by_name, list(
 	return FALSE
 
 
-/mob/proc/abiotic(full_body = 0)
+/mob/proc/abiotic(full_body = FALSE)
 	if(full_body && ((src.l_hand && !( src.l_hand.flags_item & ITEM_ABSTRACT )) || (src.r_hand && !( src.r_hand.flags_item & ITEM_ABSTRACT )) || (src.back || src.wear_mask)))
 		return TRUE
 


### PR DESCRIPTION

# About the pull request

- Synthetic is delimbed and spat out of gibber instead of a true gib, making them not die in the process
- Synthetics now spawn their proper meat as desired

# Explain why it's good for the game

![image](https://github.com/cmss13-devs/cmss13/assets/91219575/19a5e852-b968-4a49-8784-916b319ed0cb)
Desired by lore contributor, makes it so synthetic snowflake situation where they are shoved in gibber is handled properly.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>


https://github.com/cmss13-devs/cmss13/assets/91219575/96d92eaf-a60e-45f3-ac80-6d0275e82428


</details>


# Changelog
:cl:
add: Synthetics when shoved into meat gibber will not be delimbed and spawn their own flesh, but would not die (they are spat out as a torso and head)
admin: Adjustment to meatgibber code to notify admins when a synthetic is being shoved into gibber
/:cl:
