### PR TITLE
brightens the burncolor of the high-combustion napalm fuel

### DIFF
--- a/code/modules/reagents/chemistry_reagents/other.dm
+++ b/code/modules/reagents/chemistry_reagents/other.dm
@@ -710,9 +710,9 @@
 	id = "highdamagenapalm"
 	description = "A custom napalm mix, higher damage but not as sticky"
 	reagent_state = LIQUID
-	color = "#742424"
+	color = "#c51c1c"
 	chemfiresupp = FALSE
-	burncolor = "#742424"
+	burncolor = "#c51c1c"
 	burn_sprite = "dynamic"
 	properties = list(
 		PROPERTY_INTENSITY = BURN_LEVEL_TIER_8,


### PR DESCRIPTION
# About the pull request
it says on the title

# Explain why it's good for the game
its a little too hard to see currently

# Testing Photographs and Procedure

![new color](https://github.com/cmss13-devs/cmss13/assets/140007537/6faa3d84-24e1-4557-8ede-3aed85a31584)

![old color](https://github.com/cmss13-devs/cmss13/assets/140007537/23122d17-5b23-4058-8219-93399774ccf9)

</details>


# Changelog
:cl:
balance: High-Combustion napalm fuel is now easier to see on the ground
/:cl:
