### PR TITLE
no more buckling xenos into chairs

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -303,9 +303,9 @@
 	if (M.mob_size <= MOB_SIZE_XENO)
 		if ((M.stat == DEAD && istype(src, /obj/structure/bed/roller) || HAS_TRAIT(M, TRAIT_OPPOSABLE_THUMBS)))
 			do_buckle(M, user)
-		else if ((M.mob_size > MOB_SIZE_HUMAN))
-			to_chat(user, SPAN_WARNING("[M] is too big to buckle in."))
-			return
+	if ((M.mob_size > MOB_SIZE_HUMAN))
+		to_chat(user, SPAN_WARNING("[M] is too big to buckle in."))
+		return
 	do_buckle(M, user)
 
 // the actual buckling proc


### PR DESCRIPTION
# About the pull request
you can no longer buckle xenos into chairs

# Explain why it's good for the game
BUG BAD!!! 
I DIED TO THIS!!!
SPEEDMERGE

# Testing Photographs and Procedure
it work

# Changelog
:cl:
fix: You can no longer buckle xenos onto chairs
/:cl:
