### PR TITLE
Small xeno tailstab nerf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
@@ -473,6 +473,9 @@
 	/// Used for defender's tail 'stab'.
 	var/blunt_stab = FALSE
 
+	var/small_xeno_range = 1
+	var/large_xeno_range = 2
+
 /datum/action/xeno_action/onclick/evolve
 	name = "Evolve"
 	action_icon_state = "evolve"

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -926,7 +926,15 @@
 		return FALSE
 
 	var/distance = get_dist(stabbing_xeno, targetted_atom)
-	if(distance > 2)
+	var/size = stabbing_xeno.mob_size
+	var/range = 0
+
+	if (size < MOB_SIZE_BIG)
+		range = small_xeno_range
+	else
+		range = large_xeno_range
+
+	if(distance > range)
 		return FALSE
 
 	var/list/turf/path = get_line(stabbing_xeno, targetted_atom, include_start_atom = FALSE)


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Completely removes the risk from some castes (Runner, Acider)
While giving an extra attack in a combo while completely safe for others (Lurker)
Or just being used as an annoying hit an run mechanic with low risk and high damage (Lurker, Lessers, Drones etc.)
Seems just unhealthy, On large xenos with less mobility it seems more sensible to have a 2 tiles range as well as it being needed for some large castes (e.g zerker using tail stab with apprehend to get the initial slow on)
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Reduces tailstab range on small xenos from 2 to 1.
/:cl:
