### PR TITLE
Command Tablets for Provost Marshals

### DIFF
--- a/code/modules/gear_presets/uscm_event.dm
+++ b/code/modules/gear_presets/uscm_event.dm
@@ -375,6 +375,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/device/taperecorder(new_human), WEAR_L_STORE)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/magazine/pistol/pmc_mateba(new_human), WEAR_R_STORE)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/marine/MP/provost/marshal(new_human.back), WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/device/cotablet(new_human.back), WEAR_IN_BACK)
 
 /datum/equipment_preset/uscm_event/provost/marshal/sector
 	name = "Provost Sector Marshal (MO7)"


### PR DESCRIPTION

# About the pull request

Adds Command Tablets for Provost Marshals+

# Explain why it's good for the game

Generals already get Command Tablets but Provost Marshals do not.

Also Provost Marshals are required by Marine Law to announce their Battlefield Executions, the only piece of Marine Law that Marshals have to strictly follow.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: LTNTS
add: Adds Command Tablets to Provost Marshal+
/:cl:
