### PR TITLE
Makes base boiler able to make traps to fill with gas

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Boiler.dm
@@ -75,6 +75,7 @@
 		/datum/action/xeno_action/activable/spray_acid/boiler, //3rd macro
 		/datum/action/xeno_action/onclick/toggle_long_range/boiler, //4th macro
 		/datum/action/xeno_action/onclick/acid_shroud, //5th macro
+		/datum/action/xeno_action/onclick/place_trap,
 		/datum/action/xeno_action/onclick/tacmap,
 	)
 


### PR DESCRIPTION

# About the pull request

gives the ability to make a trap like burrower or carrier to baseline boiler

# Explain why it's good for the game

boilers are already have the ability to fill holes with their neuro gas, but coordinating burrower or carrier with them while those mostly operate in backline and boiler near frontline is just painful so most players propably do not even know boiler is able to do that. Giving boiler ability to make holes allows them to make their own traps to possibly secure escape routes for them or to just trap marines in general, this should not lead to any huge spam as making hole and filling it combined costs 400 plasma and boiler has 400 max plasma leaving it unable to perform any other actions for some time if done in combat


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: boiler can make holes just like burrower or carrier and fill them with neurotoxing gas
/:cl:
