### PR TITLE
Project ARES: Orbital Cannon loading log

### DIFF
--- a/code/game/machinery/ARES/ARES_procs.dm
+++ b/code/game/machinery/ARES/ARES_procs.dm
@@ -144,11 +144,11 @@ GLOBAL_LIST_INIT(maintenance_categories, list(
 	var/datum/ares_datacore/datacore = GLOB.ares_datacore
 	datacore.records_bioscan.Add(new /datum/ares_record/bioscan(title, input))
 
-/proc/log_ares_bombardment(user_name, ob_name, coordinates)
+/proc/log_ares_bombardment(user_name, ob_name, message)
 	if(!ares_can_log())
 		return FALSE
 	var/datum/ares_datacore/datacore = GLOB.ares_datacore
-	datacore.records_bombardment.Add(new /datum/ares_record/bombardment(ob_name, "Bombardment fired at [coordinates].", user_name))
+	datacore.records_bombardment.Add(new /datum/ares_record/bombardment(ob_name, message, user_name))
 
 /proc/log_ares_announcement(title, message)
 	if(!ares_can_log())

--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -187,7 +187,7 @@ GLOBAL_LIST(ob_type_fuel_requirements)
 	var/ares_message = "Shell chambered."
 	if(misfuel)
 		message += " It is misfueled by [misfuel] units!"
-		ares_message += " It is misfueled by [misfuel] units!"
+		ares_message += "Fuel imbalance detected!"
 	message_admins(message, x, y, z)
 	log_ares_bombardment(user, lowertext(tray.warhead.name), ares_message)
 

--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -187,7 +187,7 @@ GLOBAL_LIST(ob_type_fuel_requirements)
 	var/ares_message = "Shell chambered."
 	if(misfuel)
 		message += " It is misfueled by [misfuel] units!"
-		ares_message += "Fuel imbalance detected!"
+		ares_message += " Fuel imbalance detected!"
 	message_admins(message, x, y, z)
 	log_ares_bombardment(user, lowertext(tray.warhead.name), ares_message)
 

--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -184,9 +184,12 @@ GLOBAL_LIST(ob_type_fuel_requirements)
 	chambered_tray = TRUE
 	var/misfuel = get_misfuel_amount()
 	var/message = "[key_name(user)] chambered the Orbital Bombardment cannon."
+	var/ares_message = "Shell chambered."
 	if(misfuel)
 		message += " It is misfueled by [misfuel] units!"
+		ares_message += " It is misfueled by [misfuel] units!"
 	message_admins(message, x, y, z)
+	log_ares_bombardment(user, lowertext(tray.warhead.name), ares_message)
 
 	update_icon()
 

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -800,7 +800,7 @@
 	notify_ghosts(header = "Bombardment Inbound", message = "\A [ob_name] targeting [get_area(T)] has been fired!", source = T, alert_overlay = warhead_appearance, extra_large = TRUE)
 
 	/// Project ARES interface log.
-	log_ares_bombardment(user.name, ob_name, "X[x_bomb], Y[y_bomb] in [get_area(T)]")
+	log_ares_bombardment(user.name, ob_name, "Bombardment fired at X[x_bomb], Y[y_bomb] in [get_area(T)]")
 
 	busy = FALSE
 	if(istype(T))

--- a/tgui/packages/tgui/interfaces/AresAdmin.js
+++ b/tgui/packages/tgui/interfaces/AresAdmin.js
@@ -665,7 +665,7 @@ const BombardmentLogs = (props, context) => {
               User
             </Flex.Item>
             <Flex.Item width="30rem" textAlign="center">
-              Coordinates
+              Details
             </Flex.Item>
           </Flex>
         )}

--- a/tgui/packages/tgui/interfaces/AresInterface.jsx
+++ b/tgui/packages/tgui/interfaces/AresInterface.jsx
@@ -628,7 +628,7 @@ const BombardmentLogs = (props) => {
               User
             </Flex.Item>
             <Flex.Item width="30rem" textAlign="center">
-              Coordinates
+              Details
             </Flex.Item>
           </Flex>
         )}


### PR DESCRIPTION

# About the pull request
Adds an ARES log for chambering the OB Cannon, and if it has been misfueled or not.

# Explain why it's good for the game
Logs who fires it, makes sense to log who loaded it.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Added an ARES Log for chambering the OB Cannon.
/:cl:
