### PR TITLE
xeno ert no longer requires an id

### DIFF
--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -51,6 +51,10 @@
 	var/max_smartgunners = 1
 	var/shuttle_id = MOBILE_SHUTTLE_ID_ERT1 //Empty shuttle ID means we're not using shuttles (aka spawn straight into cryo)
 	var/auto_shuttle_launch = TRUE
+
+	/// If the shuttle used by this ERT should be locked to ERT member IDs
+	var/shuttle_id_locked = TRUE
+
 	var/spawn_max_amount = FALSE
 
 	var/ert_message = "An emergency beacon has been activated"

--- a/code/datums/emergency_calls/feral_xenos.dm
+++ b/code/datums/emergency_calls/feral_xenos.dm
@@ -8,6 +8,7 @@
 	max_engineers = 3 //Combat T2 castes
 	probability = 5
 	auto_shuttle_launch = TRUE //because xenos can't use the shuttle console.
+	shuttle_id_locked = FALSE
 	hostility = TRUE
 
 /datum/emergency_call/feral_xenos/New()

--- a/code/datums/emergency_calls/xenos.dm
+++ b/code/datums/emergency_calls/xenos.dm
@@ -5,6 +5,7 @@
 	mob_max = 7
 	probability = 5
 	auto_shuttle_launch = TRUE //because xenos can't use the shuttle console.
+	shuttle_id_locked = FALSE
 	hostility = TRUE
 
 /datum/emergency_call/xenos/New()

--- a/code/modules/cm_tech/implements/xeno_handler.dm
+++ b/code/modules/cm_tech/implements/xeno_handler.dm
@@ -4,6 +4,7 @@
 	mob_max = 8
 	probability = 0
 	auto_shuttle_launch = TRUE //because xenos can't use the shuttle console.
+	shuttle_id_locked = FALSE
 	hostility = FALSE
 	spawn_max_amount = TRUE
 

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -173,7 +173,7 @@
 /obj/structure/machinery/computer/shuttle/ert/tgui_interact(mob/user, datum/tgui/ui)
 	var/obj/docking_port/mobile/emergency_response/ert = SSshuttle.getShuttle(shuttleId)
 
-	if(ert.distress_beacon && ishuman(user))
+	if(ert.distress_beacon && ert.distress_beacon.shuttle_id_locked && ishuman(user))
 		var/mob/living/carbon/human/human_user = user
 		var/obj/item/card/id/id = human_user.get_active_hand()
 		if(!istype(id))


### PR DESCRIPTION
:cl:
add: xeno erts no longer require an id, so aren't permanently stuck on the almayer
/:cl:

todo: 
- [ ] make a goopy hived up ert station homebase