### PR TITLE
Holes for gardener drone

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/drone/gardener.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/drone/gardener.dm
@@ -15,6 +15,7 @@
 		/datum/action/xeno_action/onclick/plant_resin_fruit/greater, // fourth macro
 		/datum/action/xeno_action/onclick/change_fruit,
 		/datum/action/xeno_action/activable/transfer_plasma,
+		/datum/action/xeno_action/onclick/place_trap,
 	)
 
 	behavior_delegate_type = /datum/behavior_delegate/drone_gardener

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/drone/gardener.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/drone/gardener.dm
@@ -267,6 +267,7 @@
 	var/obj/structure/mineral_door/resin/door = target_atom
 	var/turf/closed/wall/resin/wall = target_turf
 
+
 	var/wall_present = istype(wall) && wall.hivenumber == xeno.hivenumber
 	var/door_present = istype(door) && door.hivenumber == xeno.hivenumber
 	// Is my tile either a wall or a door


### PR DESCRIPTION

# About the pull request

gives ability to make holes to gardener, as it was not wanted for boiler for lack of cooperation, gardener should encourage cooperation, the plasma cost might need to be increased tho as right now it is quite spamable...

# Explain why it's good for the game

encorages gardener to cooperate with sentinel castes or carrier/burrower to make traps


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: gives resin hole ability to gardener
/:cl:
