### PR TITLE
Fixes delaying round start not showing on the timer.

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1189,7 +1189,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(!SSticker.HasRoundStarted())
 		var/time_remaining = SSticker.GetTimeLeft()
 		if(time_remaining > 0)
-			. += "Time To Start: [round(time_remaining)]s"
+			. += "Time To Start: [round(time_remaining)]s [SSticker.delay_start ? "(DELAYED)" : ""]"
 		else if(time_remaining == -10)
 			. += "Time To Start: DELAYED"
 		else

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1189,7 +1189,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(!SSticker.HasRoundStarted())
 		var/time_remaining = SSticker.GetTimeLeft()
 		if(time_remaining > 0)
-			. += "Time To Start: [round(time_remaining)]s [SSticker.delay_start ? "(DELAYED)" : ""]"
+			. += "Time To Start: [round(time_remaining)]s[SSticker.delay_start ? " (DELAYED)" : ""]"
 		else if(time_remaining == -10)
 			. += "Time To Start: DELAYED"
 		else

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -451,7 +451,7 @@
 
 	var/time_remaining = SSticker.GetTimeLeft()
 	if(time_remaining > 0)
-		. += "Time To Start: [round(time_remaining)]s"[SSticker.delay_start ? " (DELAYED)" : ""]"
+		. += "Time To Start: [round(time_remaining)]s[SSticker.delay_start ? " (DELAYED)" : ""]"
 	else if(time_remaining == -10)
 		. += "Time To Start: DELAYED"
 	else

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -451,7 +451,7 @@
 
 	var/time_remaining = SSticker.GetTimeLeft()
 	if(time_remaining > 0)
-		. += "Time To Start: [round(time_remaining)]s"
+		. += "Time To Start: [round(time_remaining)]s"[SSticker.delay_start ? " (DELAYED)" : ""]"
 	else if(time_remaining == -10)
 		. += "Time To Start: DELAYED"
 	else


### PR DESCRIPTION

# About the pull request

As title

# Explain why it's good for the game

It's not always clear if it's been delayed or somehow broken anymore.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Delaying round start now shows on the timer again.
/:cl:
