### PR TITLE
[Balance] OT Damage Falloff Rebalance Attempt

### DIFF
--- a/code/modules/reagents/chemistry_reagents/other.dm
+++ b/code/modules/reagents/chemistry_reagents/other.dm
@@ -491,7 +491,7 @@
 	//------------------//
 	explosive = TRUE
 	power = 0.12
-	falloff_modifier = -0.1
+	falloff_modifier = 0.1
 	burncolor = "#ff9900"
 	chemclass = CHEM_CLASS_RARE
 	properties = list(PROPERTY_FUELING = 5, PROPERTY_OXIDIZING = 3, PROPERTY_VISCOUS = 4, PROPERTY_TOXIC = 1)
@@ -894,7 +894,7 @@
 	description = "Ammonium nitrate fuel oil (ANFO) is a low cost bulk explosive commonly used for mining and construction operations."
 	explosive = TRUE
 	power = 1
-	falloff_modifier = -0.6
+	falloff_modifier = 0.2
 
 /datum/reagent/nitroglycerin
 	name = "Nitroglycerin"
@@ -905,7 +905,7 @@
 	custom_metabolism = AMOUNT_PER_TIME(1, 200 SECONDS)
 	explosive = TRUE
 	power = 1
-	falloff_modifier = -0.5
+	falloff_modifier = 0.4
 
 /datum/reagent/cyclonite
 	name = "Cyclonite"
@@ -915,7 +915,7 @@
 	color = "#E3E0BA"
 	explosive = TRUE
 	power = 1.5
-	falloff_modifier = -0.4
+	falloff_modifier = 0.5
 
 /datum/reagent/cyclonite/on_mob_life(mob/living/M)
 	. = ..()
@@ -929,7 +929,7 @@
 	color = "#F5F5F5"
 	explosive = TRUE
 	power = 2
-	falloff_modifier = -0.2
+	falloff_modifier = 0.6
 	chemfiresupp = TRUE
 	properties = list(PROPERTY_OXIDIZING = 2)
 


### PR DESCRIPTION
# About the pull request

Makes falloff modifier never negative. Falloff modifiers being negative meant that the explosion was still pretty strong a few tiles away.

![image](https://github.com/cmss13-devs/cmss13/assets/107966994/5851c924-bd35-4567-a4fe-7fa434714937)

https://github.com/cmss13-devs/cmss13/commit/006988ef0ac5d76e98e85f20997f157cc79aabf5

Looking through the git history and commit for this particular balance change, I'm unsure why some of these values were negative, especially welding fuel which is so easily accessible. The philosophy seemed to be the more power, the less the falloff but either way it seemed that the falloff would decrease instead of increase.

Thermite and ammonium nitrate had lower power, but also higher falloff. 

![image](https://github.com/cmss13-devs/cmss13/assets/107966994/395a0945-42d4-4b6b-b347-d37f8fe56c1c)
![image](https://github.com/cmss13-devs/cmss13/assets/107966994/5593609f-ef3e-4873-b814-1b06a7d95763)

Given the above, I'm unsure how the falloff modifiers for the other chemicals were negative since while they increased power, they decreased falloff.


Before:
Welding fuel: Decreased falloff by 0.1 per volume
ANFO: Decreased falloff by 0.6 per volume
Nitroglycerin: Decreased falloff by 0.5 per volume
Cyclonite: Decreased falloff by 0.4 per volume
Octogen: Decreased falloff by 0.2 per volume

After:
Welding fuel: Increased falloff by 0.1 per volume
ANFO: Increased falloff by 0.2 per volume
Nitroglycerin: Increased falloff by 0.4 per volume
Cyclonite: Increased falloff by 0.5 per volume
Octogen: Increased  falloff by 0.6  per volume

This change should keep with the philosophy of trading between ANFO and Octogen.

![image](https://github.com/cmss13-devs/cmss13/assets/107966994/9681605e-6981-46f9-bfb9-426e82cfe348)

![image](https://github.com/cmss13-devs/cmss13/assets/107966994/d9a99c8e-b92f-4fa4-a508-d146b07a3e33)

Didn't touch this formula or anything but it's also a bit confusing.

So the higher the level, the stronger the power, but the smaller the decrease to falloff.

Level 1 = 1 explosion power, -3 falloff modifier
Level 10 = 10 explosion power, -0.3 falloff modifier


# Explain why it's good for the game

Rockets shouldn't somehow be critting anyone a huge distance away.

Chemicals should not be somehow decreasing the falloff.


# Testing Photographs and Procedure


# Changelog


:cl:
balance: Falloffs modifiers for chemicals are now positive
/:cl:
