### PR TITLE
fixes high combustion napalm and sticky napalm working for OT assemblies

### DIFF
--- a/code/modules/reagents/chemistry_reagents/other.dm
+++ b/code/modules/reagents/chemistry_reagents/other.dm
@@ -705,9 +705,11 @@
 	description = "A custom napalm mix, stickier and lasts longer but lower damage"
 	reagent_state = LIQUID
 	color = "#f8e3b2"
-	chemfiresupp = FALSE
 	burncolor = "#f8e3b2"
 	burn_sprite = "dynamic"
+	intensitymod = -1.5
+	durationmod = -5
+	radiusmod = -0.5
 	properties = list(
 		PROPERTY_INTENSITY = BURN_LEVEL_TIER_2,
 		PROPERTY_DURATION = BURN_TIME_TIER_5,
@@ -720,9 +722,11 @@
 	description = "A custom napalm mix, higher damage but not as sticky"
 	reagent_state = LIQUID
 	color = "#c51c1c"
-	chemfiresupp = FALSE
 	burncolor = "#c51c1c"
 	burn_sprite = "dynamic"
+	intensitymod = -4.5
+	durationmod = -1
+	radiusmod = -0.5
 	properties = list(
 		PROPERTY_INTENSITY = BURN_LEVEL_TIER_8,
 		PROPERTY_DURATION = BURN_TIME_TIER_1,


### PR DESCRIPTION

# About the pull request
I didn't intend for these to work in OT assemblies, they're too good
apparently chemfiresupp doesn't work if you have fire properties cause they set the reagent's chemfiresupp to true forcefully
so I manually set the durationmod, intensitymod and radiusmod to negative to exatcly counter how much they affect

# Explain why it's good for the game
bugfix good
unintended behaviour

# Testing Photographs and Procedure
it works, trust me

# Changelog
:cl:
fix: custom flamer fuels no longer work for increasing OT assembly's caps
/:cl:
