### PR TITLE
External Bleeding Sealing in Cryo Tubes

### DIFF
--- a/code/datums/effects/bleeding.dm
+++ b/code/datums/effects/bleeding.dm
@@ -71,6 +71,9 @@
 			if(affected_mob.reagents.get_reagent_amount("thwei"))
 				blood_loss -= THWEI_BLOOD_REDUCTION
 
+			if(affected_mob.bodytemperature < T0C && (affected_mob.reagents.get_reagent_amount("cryoxadone") || affected_mob.reagents.get_reagent_amount("clonexadone")))
+				blood_loss -= CRYO_BLOOD_REDUCTION
+
 			var/mob/living/carbon/human/affected_human = affected_mob
 			if(istype(affected_human))
 				if(affected_human.chem_effect_flags & CHEM_EFFECT_NO_BLEEDING)
@@ -95,18 +98,19 @@
 	if(affected_mob.in_stasis == STASIS_IN_BAG)
 		return FALSE
 
-	if(affected_mob.bodytemperature < T0C && (affected_mob.reagents && affected_mob.reagents.get_reagent_amount("cryoxadone") || affected_mob.reagents.get_reagent_amount("clonexadone")))
-		blood_loss -= CRYO_BLOOD_REDUCTION
-
 	if(affected_mob.reagents) // Annoying QC check
 		if(affected_mob.reagents.get_reagent_amount("thwei"))
 			blood_loss -= THWEI_BLOOD_REDUCTION
+
+		if(affected_mob.bodytemperature < T0C && (affected_mob.reagents.get_reagent_amount("cryoxadone") || affected_mob.reagents.get_reagent_amount("clonexadone")))
+			blood_loss -= CRYO_BLOOD_REDUCTION
 
 		var/mob/living/carbon/human/affected_human = affected_mob
 		if(istype(affected_human))
 			if(affected_human.chem_effect_flags & CHEM_EFFECT_NO_BLEEDING)
 				return FALSE
 
+	blood_loss = max(blood_loss, 0) // Bleeding shouldn't give extra blood even if its only 1 tick
 	affected_mob.blood_volume = max(affected_mob.blood_volume - blood_loss, 0)
 
 	return TRUE

--- a/code/datums/effects/bleeding.dm
+++ b/code/datums/effects/bleeding.dm
@@ -72,7 +72,9 @@
 				blood_loss -= THWEI_BLOOD_REDUCTION
 
 			if(affected_mob.bodytemperature < T0C && (affected_mob.reagents.get_reagent_amount("cryoxadone") || affected_mob.reagents.get_reagent_amount("clonexadone")))
-				blood_loss -= CRYO_BLOOD_REDUCTION
+				var/obj/structure/machinery/cryo_cell/cryo = affected_mob.loc
+				if(istype(cryo) && cryo.on && cryo.operable())
+					blood_loss -= CRYO_BLOOD_REDUCTION
 
 			var/mob/living/carbon/human/affected_human = affected_mob
 			if(istype(affected_human))


### PR DESCRIPTION

# About the pull request

This PR is sort of a follow up to #6058 expanding on the bleeding stop effect for cryotubes allowing them to also seal external bleeding.

Since internal bleeding did not cap the reduction in blood loss, it could underflow resulting in blood being added for the last tick. This is now fixed.

# Explain why it's good for the game

Cryotubes already cure IB when cryo chemicals are used because of the patient reaching low temperatures, so I see little reason why the effect wouldn't also occur for external bleeding if you're in a cryotube.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/cmss13-devs/cmss13/assets/76988376/7dffed9b-051c-4cfc-9c01-7314766d5d15

</details>


# Changelog
:cl:
balance: Cryotubes now also cure external bleeding
fix: Fixed internal bleeding granting blood on its last tick
/:cl:
