### PR TITLE
Hugger deletion checking in drone tutorial

### DIFF
--- a/code/datums/tutorial/xenomorph/xenomorph_basic.dm
+++ b/code/datums/tutorial/xenomorph/xenomorph_basic.dm
@@ -160,7 +160,16 @@
 	add_highlight(hugger, COLOR_YELLOW)
 	message_to_player("This is a facehugger, highlighted in yellow. Pick up the facehugger by clicking it.")
 	message_to_player("Stand next to the downed human and click them to apply the facehugger. Or drop the facehugger near them to see it leap onto their face automatically.")
-	RegisterSignal(human_dummy, COMSIG_HUMAN_IMPREGNATE, PROC_REF(nest_cap_phase))
+	RegisterSignal(hugger, COMSIG_PARENT_QDELETING, PROC_REF(on_hugger_deletion))
+	RegisterSignal(human_dummy, COMSIG_HUMAN_IMPREGNATE, PROC_REF(nest_cap_phase), override = TRUE)
+
+/datum/tutorial/xenomorph/basic/proc/on_hugger_deletion(hugger)
+	SIGNAL_HANDLER
+	TUTORIAL_ATOM_FROM_TRACKING(/obj/effect/alien/resin/special/eggmorph, morpher)
+	morpher.stored_huggers = 1
+	add_highlight(morpher, COLOR_YELLOW)
+	message_to_player("Click the egg morpher to take a <b>facehugger</b>.")
+	RegisterSignal(xeno, COMSIG_XENO_TAKE_HUGGER_FROM_MORPHER, PROC_REF(take_facehugger_phase))
 
 /datum/tutorial/xenomorph/basic/proc/nest_cap_phase()
 	SIGNAL_HANDLER
@@ -168,6 +177,7 @@
 	TUTORIAL_ATOM_FROM_TRACKING(/obj/item/clothing/mask/facehugger, hugger)
 	UnregisterSignal(human_dummy, COMSIG_MOB_TAKE_DAMAGE)
 	UnregisterSignal(human_dummy, COMSIG_HUMAN_IMPREGNATE)
+	UnregisterSignal(hugger, COMSIG_PARENT_QDELETING)
 	remove_highlight(hugger)
 
 	message_to_player("We should nest the infected human to make sure they don't get away.")

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -413,9 +413,6 @@
 			M.stored_huggers++
 			qdel(src)
 			return
-		// Tutorial facehuggers never time out
-		if(hivenumber == XENO_HIVE_TUTORIAL)
-			return
 	die()
 
 /obj/item/clothing/mask/facehugger/proc/die()
@@ -441,12 +438,15 @@
 	playsound(src.loc, 'sound/voice/alien_facehugger_dies.ogg', 25, 1)
 
 	if(ismob(loc)) //Make it fall off the person so we can update their icons. Won't update if they're in containers thou
-		var/mob/M = loc
-		M.drop_inv_item_on_ground(src)
+		var/mob/holder_mob = loc
+		holder_mob.drop_inv_item_on_ground(src)
 
 	layer = TURF_LAYER //so dead hugger appears below live hugger if stacked on same tile. (and below nested hosts)
 
-	addtimer(CALLBACK(src, PROC_REF(decay)), 3 MINUTES)
+	if(hivenumber == XENO_HIVE_TUTORIAL)
+		addtimer(CALLBACK(src, PROC_REF(decay)), 5 SECONDS)
+	else
+		addtimer(CALLBACK(src, PROC_REF(decay)), 3 MINUTES)
 
 /obj/item/clothing/mask/facehugger/proc/decay()
 	visible_message("[icon2html(src, viewers(src))] <span class='danger'>\The [src] decays into a mass of acid and chitin.</span>")


### PR DESCRIPTION

# About the pull request

This PR is sort of a follow up to #6140 since it became obvious you could soft-lock yourself in the hugger portion of the tutorial. Rather than add more checks to prevent huggers deleting in tutorial, I instead implemented handling when the hugger does die so you can still acquire another hugger. The 30s deletion timer is still disabled for tutorial huggers, but jump attempt deaths are possible.

# Explain why it's good for the game

Better replicates the hugger behavior in game, though still not 1-1 and allows the tutorial to not be soft locked which could be very confusing for a new player.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/9EBQNe2p4Sw

</details>


# Changelog
:cl: Drathek
fix: Fixed hugger handling in drone tutorial: Now the hugger dying will put another hugger into the tutorial morpher.
/:cl:
