### PR TITLE
Adds medlinks to WO and ground maps

### DIFF
--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -27889,6 +27889,14 @@
 	icon_state = "wood"
 	},
 /area/bigredv2/outside/library)
+"efh" = (
+/obj/structure/machinery/cm_vending/sorted/medical/no_access,
+/obj/structure/medical_supply_link,
+/turf/open/floor{
+	dir = 1;
+	icon_state = "darkyellow2"
+	},
+/area/bigredv2/caves/eta/research)
 "efK" = (
 /obj/structure/machinery/computer/crew{
 	density = 0;
@@ -66550,7 +66558,7 @@ bvY
 kdr
 kdr
 aBv
-bwZ
+efh
 bxo
 bxz
 bxo

--- a/maps/map_files/CORSAT/Corsat.dmm
+++ b/maps/map_files/CORSAT/Corsat.dmm
@@ -179,7 +179,6 @@
 "aaF" = (
 /obj/structure/machinery/door/airlock/almayer/security/glass/colony{
 	dir = 1;
-	locked = 0;
 	name = "CORSAT Armory";
 	req_access_txt = "101"
 	},
@@ -2354,7 +2353,6 @@
 /obj/structure/machinery/door/airlock/almayer/maint/colony{
 	damage_cap = 4000;
 	dir = 1;
-	locked = 0;
 	name = "\improper Emergency Access";
 	req_access_txt = "100";
 	req_one_access = null
@@ -5915,7 +5913,6 @@
 "arv" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony{
 	damage_cap = 4000;
-	locked = 0;
 	name = "\improper Emergency Access";
 	req_access_txt = "100";
 	req_one_access = null
@@ -21812,8 +21809,7 @@
 /area/corsat/gamma/engineering)
 "bij" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0
+	name = "Floodlight"
 	},
 /turf/open/auto_turf/snow/layer3,
 /area/corsat/gamma/biodome)
@@ -27730,6 +27726,7 @@
 /area/corsat/gamma/medbay)
 "bAg" = (
 /obj/structure/machinery/cm_vending/sorted/medical/no_access,
+/obj/structure/medical_supply_link,
 /turf/open/floor/corsat{
 	dir = 5;
 	icon_state = "greenwhite"
@@ -28919,7 +28916,6 @@
 /area/corsat/omega/checkpoint)
 "bDv" = (
 /obj/structure/machinery/door/airlock/almayer/security/glass/colony{
-	locked = 0;
 	name = "Security Armory";
 	req_access_txt = "101"
 	},
@@ -30377,8 +30373,7 @@
 /area/corsat/gamma/airlock/control)
 "bJE" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0
+	name = "Floodlight"
 	},
 /turf/open/mars,
 /area/corsat/sigma/biodome)
@@ -34143,8 +34138,7 @@
 /area/corsat/sigma/airlock/control)
 "bVD" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0
+	name = "Floodlight"
 	},
 /turf/open/floor{
 	dir = 1;
@@ -35393,7 +35387,6 @@
 /obj/structure/machinery/door/airlock/almayer/research/glass/colony{
 	dir = 1;
 	name = "Weapons Development";
-	req_access = null;
 	req_one_access_txt = "103"
 	},
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -35720,8 +35713,7 @@
 /area/corsat/omega/control)
 "caS" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0
+	name = "Floodlight"
 	},
 /turf/open/floor/plating,
 /area/corsat/sigma/biodome/testgrounds)
@@ -37793,8 +37785,7 @@
 /area/corsat/omega/hallways)
 "dFb" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0
+	name = "Floodlight"
 	},
 /turf/open/auto_turf/snow/layer0,
 /area/corsat/gamma/biodome)
@@ -48442,7 +48433,6 @@
 /obj/structure/machinery/door/airlock/almayer/research/glass/colony{
 	dir = 1;
 	name = "Teleportation Lab";
-	req_access = null;
 	req_one_access_txt = "103"
 	},
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -49076,8 +49066,7 @@
 /area/corsat/omega/airlocknorth/id)
 "lUY" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0
+	name = "Floodlight"
 	},
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/auto_turf/snow/layer3,
@@ -50944,7 +50933,6 @@
 /obj/structure/machinery/door/airlock/almayer/research/glass/colony{
 	dir = 1;
 	name = "Teleportation Chamber";
-	req_access = null;
 	req_one_access_txt = "101;103"
 	},
 /turf/open/floor/corsat{
@@ -61779,7 +61767,6 @@
 "vqF" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony{
 	damage_cap = 4000;
-	locked = 0;
 	name = "\improper Emergency Access";
 	req_access_txt = "100";
 	req_one_access = null

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -64959,6 +64959,14 @@
 /obj/structure/machinery/camera/autoname/lz_camera,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/landing_pad_one)
+"uIC" = (
+/obj/structure/machinery/cm_vending/sorted/medical/no_access,
+/obj/structure/medical_supply_link/green,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull"
+	},
+/area/desert_dam/building/medical/treatment_room)
 "uKo" = (
 /obj/structure/platform/mineral/sandstone/runed{
 	dir = 4
@@ -102788,7 +102796,7 @@ cvU
 cvU
 cCn
 ctW
-cEy
+uIC
 cEB
 cGg
 cHc

--- a/maps/map_files/FOP_v2_Cellblocks/Prison_Station_FOP.dmm
+++ b/maps/map_files/FOP_v2_Cellblocks/Prison_Station_FOP.dmm
@@ -1378,8 +1378,7 @@
 /obj/structure/machinery/door/airlock/almayer/security/glass/colony{
 	density = 0;
 	icon_state = "door_open";
-	name = "Cell Access";
-	req_access = null
+	name = "Cell Access"
 	},
 /turf/open/floor/prison{
 	dir = 10;
@@ -1574,8 +1573,7 @@
 	density = 0;
 	icon_state = "door_open";
 	name = "Cell";
-	opacity = 0;
-	req_access = null
+	opacity = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1621,8 +1619,7 @@
 	dir = 2;
 	icon_state = "door_open";
 	name = "Cell";
-	opacity = 0;
-	req_access = null
+	opacity = 0
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
@@ -3915,8 +3912,7 @@
 /obj/structure/machinery/door/airlock/almayer/security/glass/colony{
 	density = 0;
 	icon_state = "door_open";
-	name = "Cell Access";
-	req_access = null
+	name = "Cell Access"
 	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -8229,13 +8225,6 @@
 	icon_state = "bright_clean"
 	},
 /area/prison/chapel)
-"awd" = (
-/obj/structure/machinery/door/airlock/almayer/security/colony{
-	locked = 0;
-	name = "Research Containment Locker"
-	},
-/turf/open/floor/prison,
-/area/prison/research/secret)
 "awe" = (
 /obj/structure/window/framed/prison/reinforced/hull,
 /turf/open/floor/plating,
@@ -28265,8 +28254,7 @@
 /area/prison/hallway/east)
 "bDU" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/comdoor/colony{
-	dir = 2;
-	req_access = null
+	dir = 2
 	},
 /turf/open/floor/prison{
 	dir = 10;
@@ -31414,9 +31402,7 @@
 /turf/open/floor/wood,
 /area/prison/residential/south)
 "bNt" = (
-/obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
-	locked = 0
-	},
+/obj/structure/machinery/door/airlock/multi_tile/almayer/generic,
 /turf/open/floor/prison{
 	icon_state = "damaged3"
 	},
@@ -47865,6 +47851,14 @@
 	icon_state = "yellowfull"
 	},
 /area/prison/cellblock/protective)
+"rmb" = (
+/obj/structure/machinery/cm_vending/sorted/medical/no_access,
+/obj/structure/medical_supply_link/green,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "whitegreenfull"
+	},
+/area/prison/medbay)
 "rpB" = (
 /obj/structure/flora/bush/ausbushes/var3/brflowers,
 /obj/structure/machinery/light{
@@ -82696,7 +82690,7 @@ arx
 apK
 asp
 asT
-att
+rmb
 att
 avj
 avn
@@ -87123,7 +87117,7 @@ aeZ
 aeZ
 aiN
 aiN
-awd
+atK
 aiN
 aiN
 aiN

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -22085,6 +22085,7 @@
 	dir = 8;
 	health = 80
 	},
+/obj/structure/medical_supply_link,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "sterile_white"

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -11583,6 +11583,7 @@
 /area/shiva/exterior/junkyard)
 "gHh" = (
 /obj/structure/machinery/cm_vending/sorted/medical/no_access,
+/obj/structure/medical_supply_link,
 /turf/open/floor/shiva{
 	dir = 9;
 	icon_state = "wred"

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -13120,6 +13120,7 @@
 /area/kutjevo/exterior/lz_dunes)
 "rQa" = (
 /obj/structure/machinery/cm_vending/sorted/medical/no_access,
+/obj/structure/medical_supply_link/green,
 /turf/open/floor/kutjevo/colors/cyan/inner_corner{
 	dir = 1
 	},

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -44755,6 +44755,7 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
+/obj/structure/medical_supply_link/green,
 /turf/open/floor/strata{
 	dir = 4;
 	icon_state = "white_cyan3"

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -14881,6 +14881,7 @@
 /area/lv624/lazarus/engineering)
 "fAz" = (
 /obj/structure/machinery/cm_vending/sorted/medical/no_access,
+/obj/structure/medical_supply_link,
 /turf/open/floor{
 	icon_state = "whitebluefull"
 	},

--- a/maps/map_files/New_Varadero/New_Varadero.dmm
+++ b/maps/map_files/New_Varadero/New_Varadero.dmm
@@ -1890,9 +1890,7 @@
 /area/varadero/interior/hall_N)
 "bhU" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0;
-	wrenchable = 1
+	name = "Floodlight"
 	},
 /obj/structure/platform_decoration/kutjevo{
 	dir = 8
@@ -10659,9 +10657,7 @@
 /area/varadero/interior/security)
 "gRU" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0;
-	wrenchable = 1
+	name = "Floodlight"
 	},
 /turf/open/auto_turf/sand_white/layer1,
 /area/varadero/interior_protected/caves/digsite)
@@ -13796,9 +13792,7 @@
 /area/varadero/interior/administration)
 "iWX" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0;
-	wrenchable = 1
+	name = "Floodlight"
 	},
 /turf/open/auto_turf/sand_white/layer1,
 /area/varadero/exterior/eastbeach)
@@ -19282,9 +19276,7 @@
 /area/varadero/interior/cargo)
 "mtp" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0;
-	wrenchable = 1
+	name = "Floodlight"
 	},
 /turf/open/floor/plating/icefloor{
 	icon_state = "asteroidplating"
@@ -19372,9 +19364,7 @@
 /area/varadero/interior/hall_SE)
 "mvO" = (
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0;
-	wrenchable = 1
+	name = "Floodlight"
 	},
 /turf/open/floor/shiva{
 	dir = 1;
@@ -19887,9 +19877,7 @@
 	dir = 1
 	},
 /obj/structure/machinery/floodlight{
-	name = "Floodlight";
-	unacidable = 0;
-	wrenchable = 1
+	name = "Floodlight"
 	},
 /turf/open/floor/shiva{
 	dir = 1;
@@ -27273,6 +27261,7 @@
 /area/varadero/interior/caves/east)
 "rsh" = (
 /obj/structure/machinery/cm_vending/sorted/medical/no_access,
+/obj/structure/medical_supply_link,
 /turf/open/floor/shiva{
 	dir = 9;
 	icon_state = "wred"

--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -33534,6 +33534,7 @@
 /area/strata/ag/interior/outpost/med)
 "jsd" = (
 /obj/structure/machinery/cm_vending/sorted/medical/no_access,
+/obj/structure/medical_supply_link,
 /turf/open/floor/strata{
 	icon_state = "floor2"
 	},

--- a/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
+++ b/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
@@ -2413,6 +2413,7 @@
 /area/whiskey_outpost/inside/bunker/bunker/front)
 "iJ" = (
 /obj/structure/machinery/cm_vending/sorted/medical,
+/obj/structure/medical_supply_link/green,
 /turf/open/floor{
 	dir = 10;
 	icon_state = "whitegreen"
@@ -2446,6 +2447,7 @@
 /area/whiskey_outpost/outside/mortar_pit)
 "iN" = (
 /obj/structure/machinery/cm_vending/sorted/medical,
+/obj/structure/medical_supply_link/green,
 /turf/open/floor{
 	icon_state = "whitegreen"
 	},
@@ -3686,16 +3688,6 @@
 	icon_state = "whitegreencorner"
 	},
 /area/whiskey_outpost/inside/hospital/triage)
-"ne" = (
-/obj/effect/decal/medical_decals{
-	icon_state = "docstripingdir"
-	},
-/obj/structure/machinery/cm_vending/gear/medic,
-/turf/open/floor{
-	dir = 1;
-	icon_state = "asteroidfloor"
-	},
-/area/whiskey_outpost)
 "nf" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/medical_decals{
@@ -3713,12 +3705,10 @@
 /area/whiskey_outpost/outside/south/very_far)
 "ni" = (
 /obj/structure/machinery/cm_vending/sorted/medical/marinemed,
-/obj/effect/decal/medical_decals{
-	icon_state = "docstripingdir"
-	},
 /obj/structure/machinery/light{
 	dir = 1
 	},
+/obj/structure/medical_supply_link,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -3911,9 +3901,7 @@
 /area/whiskey_outpost)
 "nR" = (
 /obj/structure/machinery/cm_vending/sorted/medical/marinemed,
-/obj/effect/decal/medical_decals{
-	icon_state = "docstripingdir"
-	},
+/obj/structure/medical_supply_link,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -13296,6 +13284,7 @@
 /area/whiskey_outpost/outside/south)
 "Zm" = (
 /obj/structure/machinery/cm_vending/sorted/medical/chemistry,
+/obj/structure/medical_supply_link,
 /turf/open/floor{
 	icon_state = "white"
 	},
@@ -23638,7 +23627,7 @@ lG
 iV
 qz
 qz
-ne
+kh
 kj
 oW
 OX


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #5677 assuming changes from #6103 adding a medlink to each ground map as well as medlinks for the WO main base.

The other map changes are just the result of StrongDMM's sanitize variables setting where it deletes var edits that match what the type already has initially.

# Explain why it's good for the game

Helps establish colony medbays as a temporary objective that can help the groundside operation with medical supplies. Some maps this is more practical than others, but the medlinks need to not be too close to a landing zone else it is too hard to contest them.

As far as WO, there isn't a shipside medical so the main base instead should serve that purpose.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
maptweak: Added medlinks to WO
maptweak: Added a medlink to each ground map
/:cl:
