### PR TITLE
feeding/eating a pill of NW will now stop you and alert admins if you are not a doctor/nurse

### DIFF
--- a/code/game/objects/items/reagent_containers/pill.dm
+++ b/code/game/objects/items/reagent_containers/pill.dm
@@ -60,6 +60,16 @@
 	. += ..()
 
 /obj/item/reagent_container/pill/attack(mob/M, mob/user)
+	var/list/reagents_in_pill = list()
+	for(var/datum/reagent/R in reagents.reagent_list)
+		reagents_in_pill += R.name
+
+	if(("Nitrogen" in reagents_in_pill) && ("Water" in reagents_in_pill))
+		if(!skillcheck(user, SKILL_MEDICAL, SKILL_MEDICAL_DOCTOR))
+			to_chat(user, SPAN_WARNING("You aren't certified to use this chemical mix!"))
+			message_admins("[user.ckey] is dirty metagamer metaknowledge abuser, ban them immediately!", user.x, user.y, user.z)
+			return
+
 	if(M == user)
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
@@ -69,9 +79,6 @@
 
 		M.visible_message(SPAN_NOTICE("[user] swallows [src]."),
 		SPAN_HELPFUL("You swallow [src]."))
-		var/list/reagents_in_pill = list()
-		for(var/datum/reagent/R in reagents.reagent_list)
-			reagents_in_pill += R.name
 		var/contained = english_list(reagents_in_pill)
 		msg_admin_niche("[key_name(user)] swallowed [src] (REAGENTS: [contained]) in [get_area(user)] ([user.loc.x],[user.loc.y],[user.loc.z]).", user.loc.x, user.loc.y, user.loc.z)
 		M.drop_inv_item_on_ground(src) //icon update


### PR DESCRIPTION

# About the pull request
you can no longer feed/eat NW if you are not a nurse/doctor

# Explain why it's good for the game
saves CM by removing this awful potential to metagame as a corpsmen
you clearly aren't supposed to know what NW does, its abusing metaknowledge that only certified chemistry experts should have

# Testing Photographs and Procedure


https://github.com/cmss13-devs/cmss13/assets/140007537/c9813b44-9869-4cd6-a6a8-bd56897b797e


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: fixed non doctors/nurses being able to abuse metaknowledge and fix tramadol ODs
admin: admins will now get a warning whenever a non doctor/nurse tries to use an NW pill
/:cl:
