### PR TITLE
Fixes spotlight breaking every time

### DIFF
--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -524,12 +524,6 @@
 		if(light_on)
 			set_light(0)
 
-/obj/structure/dropship_equipment/electronics/spotlights/on_launch()
-	set_light(0)
-
-/obj/structure/dropship_equipment/electronics/spotlights/on_arrival()
-	set_light(brightness)
-
 /obj/structure/dropship_equipment/electronics/spotlights/ui_data(mob/user)
 	. = list()
 	var/is_deployed = light_on


### PR DESCRIPTION

# About the pull request

Spotlight no longer turns off during transit. Who cares about lighting in space anyway?

# Explain why it's good for the game

Convenient and clear.


# Testing Photographs and Procedure
<details>
I tested it

</details>


# Changelog
:cl: ihatethisengine
fix: spotlight no longer breaks after every flight
/:cl:
