### PR TITLE
Fixes M4RA misspell in ASRS menu

### DIFF
--- a/code/datums/supply_packs/ammo.dm
+++ b/code/datums/supply_packs/ammo.dm
@@ -135,7 +135,7 @@
 	group = "Ammo"
 
 /datum/supply_packs/ammo_m4ra_mag_box_ap
-	name = "Magazine box (MRRA, 16x AP mags)"
+	name = "Magazine box (M4RA, 16x AP mags)"
 	contains = list(
 		/obj/item/ammo_box/magazine/m4ra/ap,
 	)


### PR DESCRIPTION

# About the pull request

As title

Closes #6187 



# Changelog

:cl:
spellcheck: Fixes a typo for M4RA AP Ammo in the ASRS menu.
/:cl:
