### PR TITLE
Pill bottle coloring

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -526,6 +526,22 @@
 		to_chat(usr, SPAN_NOTICE("You label \the [src] with '[str]' in big, blocky letters."))
 		update_icon()
 
+/obj/item/storage/pill_bottle/verb/set_color()
+	set category = "Object"
+	set name = "Set bottle color"
+	set src in usr
+
+	if(src && ishuman(usr))
+		var/num = copytext(reject_bad_text(input(usr,"Color? (1-12)", "Set \the [src]'s color", "")), 1, 3)
+		if(!num || !length(num) || text2num(num) <= 0 || text2num(num) > 12 || copytext(num, 2, 3) == " ")
+			to_chat(usr, SPAN_NOTICE("You clear the color off \the [src]."))
+			icon_state = "pill_canister"
+			update_icon()
+			return
+		icon_state = "pill_canister" + num
+		to_chat(usr, SPAN_NOTICE("You color \the [src]."))
+		update_icon()
+
 /obj/item/storage/pill_bottle/kelotane
 	name = "\improper Kelotane pill bottle"
 	icon_state = "pill_canister2"

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -510,7 +510,9 @@
 /obj/item/storage/pill_bottle/proc/error_idlock(mob/user)
 	to_chat(user, SPAN_WARNING("It must have some kind of ID lock..."))
 
-/obj/item/storage/pill_bottle/proc/choose_color()
+/obj/item/storage/pill_bottle/proc/choose_color(mob/user)
+	if(!user)
+		user = usr
 	var/list/possible_colors = list("Orange" = "", "Blue" = "1", "Yellow" = "2", "Light Purple" = "3", "Light Grey" = "4",
 				 					"White" = "5", "Light Green" = "6", "Cyan" = "7", "Red" = "8", "Aquamarine" = "9", "Grey" = "10", "Bordeaux" = "11", "Black" = "12")
 	var/selected_color = tgui_input_list(usr, "Select a color.", "Color choice", possible_colors)

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -528,7 +528,7 @@
 		"Bordeaux" = "11",
 		"Black" = "12",
 	)
-	var/selected_color = tgui_input_list(usr, "Select a color.", "Color choice", possible_colors)
+	var/selected_color = tgui_input_list(user, "Select a color.", "Color choice", possible_colors)
 
 	if (!selected_color)
 		selected_color = ""

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -513,7 +513,7 @@
 /obj/item/storage/pill_bottle/proc/choose_color(mob/user)
 	if(!user)
 		user = usr
-	var/list/possible_colors = list(
+	var/static/list/possible_colors = list(
 		"Orange" = "",
 		"Blue" = "1",
 		"Yellow" = "2",

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -529,9 +529,8 @@
 		"Black" = "12",
 	)
 	var/selected_color = tgui_input_list(user, "Select a color.", "Color choice", possible_colors)
-
-	if (!selected_color)
-		selected_color = ""
+	if(!selected_color)
+		return
 
 	selected_color = possible_colors[selected_color]
 

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -522,10 +522,10 @@
 		"White" = "5",
 		"Light Green" = "6",
 		"Cyan" = "7",
-		"Red" = "8",
+		"Bordeaux" = "8",
 		"Aquamarine" = "9",
 		"Grey" = "10",
-		"Bordeaux" = "11",
+		"Red" = "11",
 		"Black" = "12",
 	)
 	var/selected_color = tgui_input_list(user, "Select a color.", "Color choice", possible_colors)

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -510,6 +510,20 @@
 /obj/item/storage/pill_bottle/proc/error_idlock(mob/user)
 	to_chat(user, SPAN_WARNING("It must have some kind of ID lock..."))
 
+/obj/item/storage/pill_bottle/proc/choose_color()
+	var/list/possible_colors = list("Orange" = "", "Blue" = "1", "Yellow" = "2", "Light Purple" = "3", "Light Grey" = "4",
+				 					"White" = "5", "Light Green" = "6", "Cyan" = "7", "Red" = "8", "Aquamarine" = "9", "Grey" = "10", "Bordeaux" = "11", "Black" = "12")
+	var/selected_color = tgui_input_list(usr, "Select a color.", "Color choice", possible_colors)
+
+	if (!selected_color)
+		selected_color = ""
+
+	selected_color = possible_colors[selected_color]
+
+	icon_state = "pill_canister" + selected_color
+	to_chat(usr, SPAN_NOTICE("You color \the [src]."))
+	update_icon()
+
 /obj/item/storage/pill_bottle/verb/set_maptext()
 	set category = "Object"
 	set name = "Set short label (on-sprite)"

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -521,7 +521,7 @@
 	selected_color = possible_colors[selected_color]
 
 	icon_state = "pill_canister" + selected_color
-	to_chat(usr, SPAN_NOTICE("You color \the [src]."))
+	to_chat(usr, SPAN_NOTICE("You color [src]."))
 	update_icon()
 
 /obj/item/storage/pill_bottle/verb/set_maptext()

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -513,8 +513,21 @@
 /obj/item/storage/pill_bottle/proc/choose_color(mob/user)
 	if(!user)
 		user = usr
-	var/list/possible_colors = list("Orange" = "", "Blue" = "1", "Yellow" = "2", "Light Purple" = "3", "Light Grey" = "4",
-				 					"White" = "5", "Light Green" = "6", "Cyan" = "7", "Red" = "8", "Aquamarine" = "9", "Grey" = "10", "Bordeaux" = "11", "Black" = "12")
+	var/list/possible_colors = list(
+		"Orange" = "",
+		"Blue" = "1",
+		"Yellow" = "2",
+		"Light Purple" = "3",
+		"Light Grey" = "4",
+		"White" = "5",
+		"Light Green" = "6",
+		"Cyan" = "7",
+		"Red" = "8",
+		"Aquamarine" = "9",
+		"Grey" = "10",
+		"Bordeaux" = "11",
+		"Black" = "12",
+	)
 	var/selected_color = tgui_input_list(usr, "Select a color.", "Color choice", possible_colors)
 
 	if (!selected_color)

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -526,22 +526,6 @@
 		to_chat(usr, SPAN_NOTICE("You label \the [src] with '[str]' in big, blocky letters."))
 		update_icon()
 
-/obj/item/storage/pill_bottle/verb/set_color()
-	set category = "Object"
-	set name = "Set bottle color"
-	set src in usr
-
-	if(src && ishuman(usr))
-		var/num = copytext(reject_bad_text(input(usr,"Color? (1-12)", "Set \the [src]'s color", "")), 1, 3)
-		if(!num || !length(num) || text2num(num) <= 0 || text2num(num) > 12 || copytext(num, 2, 3) == " ")
-			to_chat(usr, SPAN_NOTICE("You clear the color off \the [src]."))
-			icon_state = "pill_canister"
-			update_icon()
-			return
-		icon_state = "pill_canister" + num
-		to_chat(usr, SPAN_NOTICE("You color \the [src]."))
-		update_icon()
-
 /obj/item/storage/pill_bottle/kelotane
 	name = "\improper Kelotane pill bottle"
 	icon_state = "pill_canister2"

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -521,7 +521,7 @@
 	selected_color = possible_colors[selected_color]
 
 	icon_state = "pill_canister" + selected_color
-	to_chat(usr, SPAN_NOTICE("You color [src]."))
+	to_chat(user, SPAN_NOTICE("You color [src]."))
 	update_icon()
 
 /obj/item/storage/pill_bottle/verb/set_maptext()

--- a/code/game/objects/items/tools/misc_tools.dm
+++ b/code/game/objects/items/tools/misc_tools.dm
@@ -59,14 +59,8 @@
 		to_chat(user, SPAN_WARNING("The label won't stick to that."))
 		return
 	if(istype(A, /obj/item/storage/pill_bottle))		
-		var/num = copytext(reject_bad_text(input(usr,"Color? (1-12 or blank)", "Set \the [A]'s color", "")), 1, 3)
-		if(!num || !length(num) || text2num(num) <= 0 || text2num(num) > 12 || copytext(num, 2, 3) == " ")
-			to_chat(usr, SPAN_NOTICE("You clear the color off \the [A]."))
-			A.icon_state = "pill_canister"
-			update_icon()
-		A.icon_state = "pill_canister" + num
-		to_chat(usr, SPAN_NOTICE("You color \the [A]."))
-		update_icon()
+		var/obj/item/storage/pill_bottle/target_pill_bottle = A
+		target_pill_bottle.choose_color() 
 	
 	if(!label || !length(label))
 		remove_label(A, user)

--- a/code/game/objects/items/tools/misc_tools.dm
+++ b/code/game/objects/items/tools/misc_tools.dm
@@ -60,7 +60,7 @@
 		return
 	if(istype(A, /obj/item/storage/pill_bottle))		
 		var/obj/item/storage/pill_bottle/target_pill_bottle = A
-		target_pill_bottle.choose_color() 
+		target_pill_bottle.choose_color(user)
 	
 	if(!label || !length(label))
 		remove_label(A, user)

--- a/code/game/objects/items/tools/misc_tools.dm
+++ b/code/game/objects/items/tools/misc_tools.dm
@@ -58,6 +58,16 @@
 	if(isturf(A))
 		to_chat(user, SPAN_WARNING("The label won't stick to that."))
 		return
+	if(istype(A, /obj/item/storage/pill_bottle))		
+		var/num = copytext(reject_bad_text(input(usr,"Color? (1-12 or blank)", "Set \the [A]'s color", "")), 1, 3)
+		if(!num || !length(num) || text2num(num) <= 0 || text2num(num) > 12 || copytext(num, 2, 3) == " ")
+			to_chat(usr, SPAN_NOTICE("You clear the color off \the [A]."))
+			A.icon_state = "pill_canister"
+			update_icon()
+		A.icon_state = "pill_canister" + num
+		to_chat(usr, SPAN_NOTICE("You color \the [A]."))
+		update_icon()
+	
 	if(!label || !length(label))
 		remove_label(A, user)
 		return

--- a/code/modules/reagents/chemistry_machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_master.dm
@@ -363,7 +363,7 @@
 		if(pill_maker)
 			if(loaded_pill_bottle)
 				dat += "<A href='?src=\ref[src];ejectp=1;user=\ref[user]'>Eject [loaded_pill_bottle] \[[loaded_pill_bottle.contents.len]/[loaded_pill_bottle.max_storage_space]\]</A><BR>"
-				dat += "<A href='?src=\ref[src];addlabelp=1;user=\ref[user]'>Add label to [loaded_pill_bottle] \[[loaded_pill_bottle.contents.len]/[loaded_pill_bottle.max_storage_space]\]</A><BR><BR>"
+				dat += "<A href='?src=\ref[src];addlabelp=1;user=\ref[user]'>Add label to [loaded_pill_bottle] \[[loaded_pill_bottle.contents.len]/[loaded_pill_bottle.max_storage_space]\]</A><BR>"
 				dat += "<A href='?src=\ref[src];setcolor=1;user=\ref[user]'>Set color to [loaded_pill_bottle] \[[loaded_pill_bottle.contents.len]/[loaded_pill_bottle.max_storage_space]\]</A><BR><BR>"
 				dat += "<A href='?src=\ref[src];transferp=1;'>Transfer [loaded_pill_bottle] \[[loaded_pill_bottle.contents.len]/[loaded_pill_bottle.max_storage_space]\] to the smartfridge</A><BR><BR>"
 			else

--- a/code/modules/reagents/chemistry_machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_master.dm
@@ -141,7 +141,23 @@
 			if(length(label) < 3)
 				loaded_pill_bottle.maptext_label = label
 				loaded_pill_bottle.update_icon()
+	else if(href_list["setcolor"])
+		// Checking for state changes
+		if(!loaded_pill_bottle)
+			return
 
+		if(!Adjacent(usr))
+			return
+
+		var/num = copytext(reject_bad_text(input(usr,"Color? (1-12)", "Set \the [src]'s color", "")), 1, 3)
+		if(!num || !length(num) || text2num(num) <= 0 || text2num(num) > 12 || copytext(num, 2, 3) == " ")
+			to_chat(usr, SPAN_NOTICE("You clear the color off \the [src]."))
+			icon_state = "pill_canister"
+			update_icon()
+			return
+		loaded_pill_bottle.icon_state = "pill_canister" + num
+		to_chat(usr, SPAN_NOTICE("You color \the [loaded_pill_bottle]."))
+		loaded_pill_bottle.update_icon()
 
 	else if(href_list["close"])
 		close_browser(user, "chemmaster")
@@ -356,6 +372,7 @@
 			if(loaded_pill_bottle)
 				dat += "<A href='?src=\ref[src];ejectp=1;user=\ref[user]'>Eject [loaded_pill_bottle] \[[loaded_pill_bottle.contents.len]/[loaded_pill_bottle.max_storage_space]\]</A><BR>"
 				dat += "<A href='?src=\ref[src];addlabelp=1;user=\ref[user]'>Add label to [loaded_pill_bottle] \[[loaded_pill_bottle.contents.len]/[loaded_pill_bottle.max_storage_space]\]</A><BR><BR>"
+				dat += "<A href='?src=\ref[src];setcolor=1;user=\ref[user]'>Set color to [loaded_pill_bottle] \[[loaded_pill_bottle.contents.len]/[loaded_pill_bottle.max_storage_space]\]</A><BR><BR>"
 				dat += "<A href='?src=\ref[src];transferp=1;'>Transfer [loaded_pill_bottle] \[[loaded_pill_bottle.contents.len]/[loaded_pill_bottle.max_storage_space]\] to the smartfridge</A><BR><BR>"
 			else
 				dat += "No pill bottle inserted.<BR><BR>"

--- a/code/modules/reagents/chemistry_machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_master.dm
@@ -152,7 +152,7 @@
 		var/num = copytext(reject_bad_text(input(usr,"Color? (1-12)", "Set \the [src]'s color", "")), 1, 3)
 		if(!num || !length(num) || text2num(num) <= 0 || text2num(num) > 12 || copytext(num, 2, 3) == " ")
 			to_chat(usr, SPAN_NOTICE("You clear the color off \the [src]."))
-			icon_state = "pill_canister"
+			loaded_pill_bottle.icon_state = "pill_canister"
 			update_icon()
 			return
 		loaded_pill_bottle.icon_state = "pill_canister" + num

--- a/code/modules/reagents/chemistry_machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_master.dm
@@ -96,7 +96,7 @@
 			if(!istype(dest))
 				source.reagents.remove_reagent(reagent_id, amount)
 			else if(dest.reagents)
-				source.reagents.trans_id_to(dest, reagent_id, amount)	
+				source.reagents.trans_id_to(dest, reagent_id, amount)
 
 /obj/structure/machinery/chem_master/Topic(href, href_list)
 	. = ..()

--- a/code/modules/reagents/chemistry_machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_master.dm
@@ -96,7 +96,7 @@
 			if(!istype(dest))
 				source.reagents.remove_reagent(reagent_id, amount)
 			else if(dest.reagents)
-				source.reagents.trans_id_to(dest, reagent_id, amount)
+				source.reagents.trans_id_to(dest, reagent_id, amount)	
 
 /obj/structure/machinery/chem_master/Topic(href, href_list)
 	. = ..()
@@ -149,15 +149,7 @@
 		if(!Adjacent(usr))
 			return
 
-		var/num = copytext(reject_bad_text(input(usr,"Color? (1-12)", "Set \the [src]'s color", "")), 1, 3)
-		if(!num || !length(num) || text2num(num) <= 0 || text2num(num) > 12 || copytext(num, 2, 3) == " ")
-			to_chat(usr, SPAN_NOTICE("You clear the color off \the [src]."))
-			loaded_pill_bottle.icon_state = "pill_canister"
-			update_icon()
-			return
-		loaded_pill_bottle.icon_state = "pill_canister" + num
-		to_chat(usr, SPAN_NOTICE("You color \the [loaded_pill_bottle]."))
-		loaded_pill_bottle.update_icon()
+		loaded_pill_bottle.choose_color()
 
 	else if(href_list["close"])
 		close_browser(user, "chemmaster")


### PR DESCRIPTION
# About the pull request
You can now change pill bottle colors with 12 color options!
Color reference:
![image](https://github.com/cmss13-devs/cmss13/assets/59925169/d8ce2260-adc9-4000-80fe-0106355e9043)

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Allows for some less bland colors on custom pill bottles that are nicer on the eye
It's also pretty cool
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: You can now change the color of pill bottles in the chem master or with a hand labeler.
/:cl:
