### PR TITLE
Command announcements for survivors

### DIFF
--- a/code/defines/procs/announcement.dm
+++ b/code/defines/procs/announcement.dm
@@ -42,6 +42,11 @@
 				continue
 			if(is_mainship_level(H.z)) // People on ship see everything
 				continue
+
+			// If they have iff AND a marine headset they will recieve announcements
+			if ((FACTION_MARINE in H.wear_id?.faction_group) && (istype(H.wear_l_ear, /obj/item/device/radio/headset/almayer) || istype(H.wear_r_ear, /obj/item/device/radio/headset/almayer)))
+				continue
+
 			if((H.faction != faction_to_display && !add_PMCs) || (H.faction != faction_to_display && add_PMCs && !(H.faction in FACTION_LIST_WY)) && !(faction_to_display in H.faction_group)) //faction checks
 				targets.Remove(H)
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -115,7 +115,7 @@
 			. += "Primary Objective: [html_decode(assigned_squad.primary_objective)]"
 		if(assigned_squad.secondary_objective)
 			. += "Secondary Objective: [html_decode(assigned_squad.secondary_objective)]"
-	if(faction == FACTION_MARINE || (FACTION_MARINE in wear_id.faction_group))
+	if(faction == FACTION_MARINE)
 		. += ""
 		. += "<a href='?MapView=1'>View Tactical Map</a>"
 	if(mobility_aura)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -115,7 +115,7 @@
 			. += "Primary Objective: [html_decode(assigned_squad.primary_objective)]"
 		if(assigned_squad.secondary_objective)
 			. += "Secondary Objective: [html_decode(assigned_squad.secondary_objective)]"
-	if(faction == FACTION_MARINE)
+	if(faction == FACTION_MARINE || (FACTION_MARINE in wear_id.faction_group))
 		. += ""
 		. += "<a href='?MapView=1'>View Tactical Map</a>"
 	if(mobility_aura)


### PR DESCRIPTION
# About the pull request
Allows survivors to view tacmap and hear command announcements once they get IFF and marine headsets.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
When you redeploy as a survivor (which is what you do 90% of the time) it is extremely painful to play without knowing what's going on, no announcements, no tacmap no anything. It is also makes sense that you will have access to those once temporarily enlisting with the marines and having the proper equipment.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Survivors can now receive command announcements with IFF and a marine headset.
/:cl:
