### PR TITLE
Makes spotter laser designators, scout laser designators, and scout cloak unmeltable + indestructible.

### DIFF
--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -354,13 +354,16 @@
 /obj/item/device/binoculars/range/designator/scout
 	name = "scout laser designator"
 	desc = "An improved laser designator, issued to USCM scouts, with two modes: target marking for CAS with IR laser and rangefinding. Ctrl + Click turf to target something. Ctrl + Click designator to stop lasing. Alt + Click designator to switch modes."
+	unacidable = TRUE
+	indestructible = TRUE
 	cooldown_duration = 80
 	target_acquisition_delay = 30
 
 /obj/item/device/binoculars/range/designator/spotter
 	name = "spotter's laser designator"
 	desc = "A specially-designed laser designator, issued to USCM spotters, with two modes: target marking for CAS with IR laser and rangefinding. Ctrl + Click turf to target something. Ctrl + Click designator to stop lasing. Alt + Click designator to switch modes. Additionally, a trained spotter can laze targets for a USCM marksman, increasing the speed of target acquisition. A targeting beam will connect the binoculars to the target, but it may inherit the user's cloak, if possible."
-
+	unacidable = TRUE
+	indestructible = TRUE
 	var/is_spotting = FALSE
 	var/spotting_time = 10 SECONDS
 	var/spotting_cooldown_delay = 5 SECONDS

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -729,6 +729,8 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	name = "\improper M68 Thermal Cloak"
 	desc = "The lightweight thermal dampeners and optical camouflage provided by this cloak are weaker than those found in standard USCM ghillie suits. In exchange, the cloak can be worn over combat armor and offers the wearer high maneuverability and adaptability to many environments."
 	icon_state = "scout_cloak"
+	unacidable = TRUE
+	indestructible = TRUE
 	uniform_restricted = list(/obj/item/clothing/suit/storage/marine/M3S) //Need to wear Scout armor and helmet to equip this.
 	has_gamemode_skin = FALSE //same sprite for all gamemode.
 	var/camo_active = FALSE


### PR DESCRIPTION
# About the pull request

The spotter laser designator, scout laser designator and scout cloak are now unmeltable + indestructible as other irreplaceable specialist gear is.

# Explain why it's good for the game

The spotter laser designator stood out to me as the most egregious considering it is mandatory to play the role of spotter effectively - it should not be destroyable or acidable when it is expected for you to carry it and when past attempts have been made to enforce reading the pamphlet and using it. The scout cloak is also OOCly required to be carried and is irreplaceable + a mandatory part of the role. It seems more like an oversight than an intended thing to have them meltable.

The scout laser designators I am not entirely certain on making although it is also irreplaceable and important as a major facet of the scouts role. 


# Testing Photographs and Procedure
I did test this PR to ensure it worked by attempting to melt and firing a standard OB at the items. They survived.

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
balance: The spotter laser designators, scout laser designators, and scout cloak are now unmeltable and indestructible to explosions.
/:cl:
