### PR TITLE
Data detector tweaks

### DIFF
--- a/code/game/objects/items/devices/data_detector.dm
+++ b/code/game/objects/items/devices/data_detector.dm
@@ -42,17 +42,15 @@
 		var/detected
 		for(var/DT in objects_to_detect)
 			if(istype(I, DT))
-				if((istype(I, /obj/item/storage/fancy/vials/random) && !I.contents.len) || (istype(I, /obj/item/reagent_container/glass/beaker/vial/random) && !I.reagents.total_volume))
+				if((istype(I, /obj/item/storage/fancy/vials/random) && !length(I.contents)) || (istype(I, /obj/item/reagent_container/glass/beaker/vial/random) && !I.reagents?.total_volume))
 					break //We don't need to ping already looted containers
-				else
-					detected = TRUE
+				detected = TRUE
 			if(I.contents)
 				for(var/obj/item/CI in I.contents)
 					if(istype(CI, DT))
-						if((istype(CI, /obj/item/storage/fancy/vials/random) && !CI.contents.len) || (istype(CI, /obj/item/reagent_container/glass/beaker/vial/random) && !CI.reagents.total_volume))
+						if((istype(CI, /obj/item/storage/fancy/vials/random) && !length(CI.contents)) || (istype(CI, /obj/item/reagent_container/glass/beaker/vial/random) && !CI.reagents?.total_volume))
 							break
-						else
-							detected = TRUE
+						detected = TRUE
 			if(human_user && detected)
 				show_blip(human_user, I)
 
@@ -72,10 +70,9 @@
 			for(var/obj/I in M.contents_twice())
 				for(var/DT in objects_to_detect)
 					if(istype(I, DT))
-						if((istype(I, /obj/item/storage/fancy/vials/random) && !I.contents.len) || (istype(I, /obj/item/reagent_container/glass/beaker/vial/random) && !I.reagents.total_volume))
+						if((istype(I, /obj/item/storage/fancy/vials/random) && !length(I.contents)) || (istype(I, /obj/item/reagent_container/glass/beaker/vial/random) && !I.reagents?.total_volume))
 							break
-						else
-							detected = TRUE
+						detected = TRUE
 
 		if(human_user && detected)
 			show_blip(human_user, M)

--- a/code/game/objects/items/devices/data_detector.dm
+++ b/code/game/objects/items/devices/data_detector.dm
@@ -42,13 +42,17 @@
 		var/detected
 		for(var/DT in objects_to_detect)
 			if(istype(I, DT))
-				if((istype(I, /obj/item/storage/fancy/vials/random) && !length(I.contents)) || (istype(I, /obj/item/reagent_container/glass/beaker/vial/random) && !I.reagents?.total_volume))
+				if(istype(I, /obj/item/storage/fancy/vials/random) && !length(I.contents))
+					break //We don't need to ping already looted containers
+				if(istype(I, /obj/item/reagent_container/glass/beaker/vial/random) && !I.reagents?.total_volume)
 					break //We don't need to ping already looted containers
 				detected = TRUE
 			if(I.contents)
 				for(var/obj/item/CI in I.contents)
 					if(istype(CI, DT))
-						if((istype(CI, /obj/item/storage/fancy/vials/random) && !length(CI.contents)) || (istype(CI, /obj/item/reagent_container/glass/beaker/vial/random) && !CI.reagents?.total_volume))
+						if(istype(CI, /obj/item/storage/fancy/vials/random) && !length(CI.contents))
+							break
+						if(istype(CI, /obj/item/reagent_container/glass/beaker/vial/random) && !CI.reagents?.total_volume)
 							break
 						detected = TRUE
 			if(human_user && detected)
@@ -70,7 +74,9 @@
 			for(var/obj/I in M.contents_twice())
 				for(var/DT in objects_to_detect)
 					if(istype(I, DT))
-						if((istype(I, /obj/item/storage/fancy/vials/random) && !length(I.contents)) || (istype(I, /obj/item/reagent_container/glass/beaker/vial/random) && !I.reagents?.total_volume))
+						if(istype(I, /obj/item/storage/fancy/vials/random) && !length(I.contents))
+							break
+						if(istype(I, /obj/item/reagent_container/glass/beaker/vial/random) && !I.reagents?.total_volume)
 							break
 						detected = TRUE
 

--- a/code/game/objects/items/devices/data_detector.dm
+++ b/code/game/objects/items/devices/data_detector.dm
@@ -17,7 +17,6 @@
 		/obj/structure/machinery/computer/objective,
 		/obj/item/limb/head/synth,
 	)
-	var/detect_empty_vial_boxes = FALSE
 
 /obj/item/device/motiondetector/intel/get_help_text()
 	. = "Green indicators on your HUD will show the location of intelligence objects detected by the scanner. Has two modes: slow long-range [SPAN_HELPFUL("(14 tiles)")] and fast short-range [SPAN_HELPFUL("(7 tiles)")]."
@@ -43,22 +42,19 @@
 		var/detected
 		for(var/DT in objects_to_detect)
 			if(istype(I, DT))
-				if(!detect_empty_vial_boxes && istype(I, /obj/item/storage/fancy/vials/random))
-					if(!I.contents)
-						continue
-				detected = TRUE
+				if((istype(I, /obj/item/storage/fancy/vials/random) && !I.contents.len) || (istype(I, /obj/item/reagent_container/glass/beaker/vial/random) && !I.reagents.total_volume))
+					break //We don't need to ping already looted containers
+				else
+					detected = TRUE
 			if(I.contents)
 				for(var/obj/item/CI in I.contents)
 					if(istype(CI, DT))
-						if(!detect_empty_vial_boxes && istype(I, /obj/item/storage/fancy/vials/random))
-							if(!I.contents)
-								continue
-						detected = TRUE
-						break
+						if((istype(I, /obj/item/storage/fancy/vials/random) && !I.contents.len) || (istype(I, /obj/item/reagent_container/glass/beaker/vial/random) && !I.reagents.total_volume))
+							break
+						else
+							detected = TRUE
 			if(human_user && detected)
 				show_blip(human_user, I)
-			if(detected)
-				break
 
 		if(detected)
 			detected_sound = TRUE
@@ -76,13 +72,10 @@
 			for(var/obj/I in M.contents_twice())
 				for(var/DT in objects_to_detect)
 					if(istype(I, DT))
-						if(!detect_empty_vial_boxes && istype(I, /obj/item/storage/fancy/vials/random))
-							if(!I.contents)
-								continue
-						detected = TRUE
-						break
-				if(detected)
-					break
+						if((istype(I, /obj/item/storage/fancy/vials/random) && !I.contents.len) || (istype(I, /obj/item/reagent_container/glass/beaker/vial/random) && !I.reagents.total_volume))
+							break
+						else
+							detected = TRUE
 
 		if(human_user && detected)
 			show_blip(human_user, M)

--- a/code/game/objects/items/devices/data_detector.dm
+++ b/code/game/objects/items/devices/data_detector.dm
@@ -49,7 +49,7 @@
 			if(I.contents)
 				for(var/obj/item/CI in I.contents)
 					if(istype(CI, DT))
-						if((istype(I, /obj/item/storage/fancy/vials/random) && !I.contents.len) || (istype(I, /obj/item/reagent_container/glass/beaker/vial/random) && !I.reagents.total_volume))
+						if((istype(CI, /obj/item/storage/fancy/vials/random) && !CI.contents.len) || (istype(CI, /obj/item/reagent_container/glass/beaker/vial/random) && !CI.reagents.total_volume))
 							break
 						else
 							detected = TRUE


### PR DESCRIPTION

# About the pull request

Makes it so that empty vial boxes don't trigger a data detector ping.
Also makes it so that empty randomchem vials don't trigger a data detector ping.

The former is a bugfix as there is already (non-functional) code in place to try and achieve this result (see: #3595).
The latter is not a bugfix, but I believe fits nicely into this PR.

*Note that this will still ping vial boxes containing empty vials. However, I believe this is a fine outcome since there is a low chance for a vial box to spawn with only empty vials, and I do believe those should still be pinged until someone checks and empties them.*


# Explain why it's good for the game

There's no reason for empty vial boxes or emptied vials to show up on the data detector.
Fixing non-functional code is good.


# Testing Photographs and Procedure
<details>
<summary>Testing Evidence</summary>

*Shows that both the intended result of this PR has been achieved and that nothing else regarding the detector has regressed  in the process.*

https://streamable.com/c7hyn6

</details>


# Changelog
:cl:
qol: Emptied randomchem vials no longer show up on the data detector
fix: Fixes empty vial storage boxes showing up on the data detector
/:cl:
