### PR TITLE
Fix synths being affected by boiler neurotoxin

### DIFF
--- a/code/datums/effects/neurotoxin.dm
+++ b/code/datums/effects/neurotoxin.dm
@@ -37,6 +37,10 @@
 		return FALSE
 	if(affected_mob.stat == DEAD)
 		return
+
+	if(issynth(affected_atom))
+		return
+	
 // General effects
 	affected_mob.last_damage_data = cause_data
 	affected_mob.apply_stamina_damage(stam_dam)


### PR DESCRIPTION

# About the pull request
For some reason the neurotoxin is an effect instead of a chemical and lacks the proper checks so it affected synths which is pretty funny
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Consistency and it makes no sense
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Synths no longer get affected by boiler's neurotoxin
/:cl:
