### PR TITLE
donation alerts

### DIFF
--- a/code/game/machinery/computer/camera_console.dm
+++ b/code/game/machinery/computer/camera_console.dm
@@ -225,7 +225,10 @@
 			to_chat(user, SPAN_WARNING("Streamer is not accepting donations at this time."))
 			return
 
-		var/message = tgui_input_text(user, "What would you like to message the streamer? (48 Characters MAX)", "Message", max_length = 48)
+		var/message = "Thanks for your donation!"
+		if(spacecash.worth >= 10)
+			message = tgui_input_text(user, "What would you like to message the streamer? (48 Characters MAX)", "Message", max_length = 48)
+
 		var/nickname = tgui_input_text(user, "What would you like your displayed name to be? (20 Characters MAX)", "Name", max_length = 20)
 
 		broadcastingcamera.donationsaccount.money += spacecash.worth

--- a/code/game/machinery/computer/camera_console.dm
+++ b/code/game/machinery/computer/camera_console.dm
@@ -205,7 +205,7 @@
 
 /obj/structure/machinery/computer/cameras/wooden_tv/broadcast
 	name = "Television Set"
-	desc = "An old TV hooked up to a video cassette recorder, you can even use it to time shift WOW."
+	desc = "An old TV hooked up to a video cassette recorder, which has been modified to function as... money slot?"
 	network = list(CAMERA_NET_CORRESPONDENT)
 	stay_connected = TRUE
 	circuit = /obj/item/circuitboard/computer/cameras/tv
@@ -220,22 +220,25 @@
 		if(spacecash.counterfeit)
 			return
 
+
 		if(!broadcastingcamera.donationsaccount)
 			to_chat(user, SPAN_WARNING("Streamer is not accepting donations at this time."))
 			return
 
 		var/message = tgui_input_text(user, "What would you like to message the streamer? (48 Characters MAX)", "What?", max_length = 48)
-		!broadcastingcamera.donationsaccount.money += spacecash.worth
-		streamer.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>You've received a new donation!</u></span><br>" + message, /atom/movable/screen/text/screen_text/command_order, pick("#FF0000", "#008000", "#C71585", "#0000FF"))
+		broadcastingcamera.donationsaccount.money += spacecash.worth
+		if(ishuman(broadcastingcamera.loc))
+			var/mob/living/carbon/human/streamer = broadcastingcamera.loc
+			streamer.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>You've received a new donation!</u></span><br>" + message, /atom/movable/screen/text/screen_text/command_order, pick("#FF0000", "#008000", "#C71585", "#0000FF"))
 		playsound(broadcastingcamera, 'sound/machines/ping.ogg', 25)
 
 		var/datum/transaction/T = new()
-		T.target_name = acc.owner_name
+		T.target_name = broadcastingcamera.donationsaccount.owner_name
 		T.purpose = "Donation"
 		T.amount = spacecash:worth
 		T.date = GLOB.current_date_string
 		T.time = worldtime2text()
-		!broadcastingcamera.donationsaccount.transaction_log.Add(T)
+		broadcastingcamera.donationsaccount.transaction_log.Add(T)
 		qdel(spacecash)
 
 	..()

--- a/code/game/machinery/computer/camera_console.dm
+++ b/code/game/machinery/computer/camera_console.dm
@@ -211,6 +211,35 @@
 	circuit = /obj/item/circuitboard/computer/cameras/tv
 	var/obj/item/device/camera/broadcasting/broadcastingcamera = null
 
+/obj/structure/machinery/computer/cameras/wooden_tv/broadcast/attackby(obj/item/I, mob/user)
+	if(!broadcastingcamera)
+		return
+
+	if(istype(I, /obj/item/spacecash))
+		var/obj/item/spacecash/spacecash = I
+		if(spacecash.counterfeit)
+			return
+
+		if(!broadcastingcamera.donationsaccount)
+			to_chat(user, SPAN_WARNING("Streamer is not accepting donations at this time."))
+			return
+
+		var/message = tgui_input_text(user, "What would you like to message the streamer? (48 Characters MAX)", "What?", max_length = 48)
+		!broadcastingcamera.donationsaccount.money += spacecash.worth
+		streamer.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>You've received a new donation!</u></span><br>" + message, /atom/movable/screen/text/screen_text/command_order, pick("#FF0000", "#008000", "#C71585", "#0000FF"))
+		playsound(broadcastingcamera, 'sound/machines/ping.ogg', 25)
+
+		var/datum/transaction/T = new()
+		T.target_name = acc.owner_name
+		T.purpose = "Donation"
+		T.amount = spacecash:worth
+		T.date = GLOB.current_date_string
+		T.time = worldtime2text()
+		!broadcastingcamera.donationsaccount.transaction_log.Add(T)
+		qdel(spacecash)
+
+	..()
+
 /obj/structure/machinery/computer/cameras/wooden_tv/broadcast/Destroy()
 	broadcastingcamera = null
 	return ..()

--- a/code/game/machinery/computer/camera_console.dm
+++ b/code/game/machinery/computer/camera_console.dm
@@ -225,13 +225,14 @@
 			to_chat(user, SPAN_WARNING("Streamer is not accepting donations at this time."))
 			return
 
-		var/message = tgui_input_text(user, "What would you like to message the streamer? (48 Characters MAX)", "What?", max_length = 48)
+		var/message = tgui_input_text(user, "What would you like to message the streamer? (48 Characters MAX)", "Message", max_length = 48)
+		var/nickname = tgui_input_text(user, "What would you like your displayed name to be? (20 Characters MAX)", "Name?", max_length = 20)
+
 		broadcastingcamera.donationsaccount.money += spacecash.worth
 		if(ishuman(broadcastingcamera.loc))
 			var/mob/living/carbon/human/streamer = broadcastingcamera.loc
-			streamer.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>You've received a new donation of [spacecash.worth]$!</u></span><br>" + message, /atom/movable/screen/text/screen_text/command_order, pick("#FF0000", "#008000", "#C71585", "#0000FF"))
-		broadcastingcamera.latestmessage = message
-		broadcastingcamera.latestsum = spacecash.worth
+			streamer.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>You've received a new donation of [spacecash.worth]$ from [nickname]!</u></span><br>" + message, /atom/movable/screen/text/screen_text/command_order, pick("#FF0000", "#008000", "#C71585", "#0000FF"))
+		broadcastingcamera.latestmessage = "[nickname], [spacecash.worth], \"[message]\""
 		playsound(broadcastingcamera, 'sound/machines/ping.ogg', 25)
 
 		var/datum/transaction/T = new()

--- a/code/game/machinery/computer/camera_console.dm
+++ b/code/game/machinery/computer/camera_console.dm
@@ -226,7 +226,7 @@
 			return
 
 		var/message = tgui_input_text(user, "What would you like to message the streamer? (48 Characters MAX)", "Message", max_length = 48)
-		var/nickname = tgui_input_text(user, "What would you like your displayed name to be? (20 Characters MAX)", "Name?", max_length = 20)
+		var/nickname = tgui_input_text(user, "What would you like your displayed name to be? (20 Characters MAX)", "Name", max_length = 20)
 
 		broadcastingcamera.donationsaccount.money += spacecash.worth
 		if(ishuman(broadcastingcamera.loc))

--- a/code/game/machinery/computer/camera_console.dm
+++ b/code/game/machinery/computer/camera_console.dm
@@ -232,7 +232,7 @@
 		if(ishuman(broadcastingcamera.loc))
 			var/mob/living/carbon/human/streamer = broadcastingcamera.loc
 			streamer.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>You've received a new donation of [spacecash.worth]$ from [nickname]!</u></span><br>" + message, /atom/movable/screen/text/screen_text/command_order, pick("#FF0000", "#008000", "#C71585", "#0000FF"))
-		broadcastingcamera.latestmessage = "[nickname], [spacecash.worth], \"[message]\""
+		broadcastingcamera.latestmessage = "[nickname], [spacecash.worth]$, \"[message]\""
 		playsound(broadcastingcamera, 'sound/machines/ping.ogg', 25)
 
 		var/datum/transaction/T = new()

--- a/code/game/machinery/computer/camera_console.dm
+++ b/code/game/machinery/computer/camera_console.dm
@@ -230,6 +230,7 @@
 		if(ishuman(broadcastingcamera.loc))
 			var/mob/living/carbon/human/streamer = broadcastingcamera.loc
 			streamer.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>You've received a new donation!</u></span><br>" + message, /atom/movable/screen/text/screen_text/command_order, pick("#FF0000", "#008000", "#C71585", "#0000FF"))
+		broadcastingcamera.latestmessage = message
 		playsound(broadcastingcamera, 'sound/machines/ping.ogg', 25)
 
 		var/datum/transaction/T = new()

--- a/code/game/machinery/computer/camera_console.dm
+++ b/code/game/machinery/computer/camera_console.dm
@@ -229,8 +229,9 @@
 		broadcastingcamera.donationsaccount.money += spacecash.worth
 		if(ishuman(broadcastingcamera.loc))
 			var/mob/living/carbon/human/streamer = broadcastingcamera.loc
-			streamer.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>You've received a new donation!</u></span><br>" + message, /atom/movable/screen/text/screen_text/command_order, pick("#FF0000", "#008000", "#C71585", "#0000FF"))
+			streamer.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>You've received a new donation of [spacecash.worth]$!</u></span><br>" + message, /atom/movable/screen/text/screen_text/command_order, pick("#FF0000", "#008000", "#C71585", "#0000FF"))
 		broadcastingcamera.latestmessage = message
+		broadcastingcamera.latestsum = spacecash.worth
 		playsound(broadcastingcamera, 'sound/machines/ping.ogg', 25)
 
 		var/datum/transaction/T = new()

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -359,10 +359,13 @@
 	flags_equip_slot = NO_FLAGS //cannot be equiped
 	var/obj/structure/machinery/camera/correspondent/linked_cam
 	var/datum/money_account/donationsaccount
+	var/latestmessage
 
 /obj/item/device/camera/broadcasting/get_examine_text(mob/user)
 	. = ..()
 	. += "Linked account: [donationsaccount ? "account_number" : "None, swipe your ID-card to link it."]."
+	if(latestmessage)
+		. += "Latest donation: [latestmessage]."
 
 /obj/item/device/camera/broadcasting/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/card/id))

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -358,6 +358,15 @@
 	w_class = SIZE_HUGE
 	flags_equip_slot = NO_FLAGS //cannot be equiped
 	var/obj/structure/machinery/camera/correspondent/linked_cam
+	var/datum/money_account/donationsaccount
+
+/obj/item/device/camera/broadcasting/attackby(obj/item/I, mob/user)
+	if(istype(I, /obj/item/card/id))
+		var/obj/item/card/id/id = I
+		if(!id.associated_account_number)
+			return
+		donationsaccount = get_account(id.associated_account_number)
+		to_chat(user, SPAN_NOTICE("Account linked for donations!"))
 
 /obj/item/device/camera/broadcasting/Initialize(mapload, ...)
 	. = ..()

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -360,13 +360,12 @@
 	var/obj/structure/machinery/camera/correspondent/linked_cam
 	var/datum/money_account/donationsaccount
 	var/latestmessage
-	var/latestsum
 
 /obj/item/device/camera/broadcasting/get_examine_text(mob/user)
 	. = ..()
 	. += "Linked account: [donationsaccount ? "[donationsaccount.account_number]" : "None, swipe your ID-card to link it"]."
 	if(latestmessage)
-		. += "Latest donation: [latestmessage], [latestsum]$."
+		. += "Latest donation: [latestmessage]"
 
 /obj/item/device/camera/broadcasting/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/card/id))

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -360,6 +360,10 @@
 	var/obj/structure/machinery/camera/correspondent/linked_cam
 	var/datum/money_account/donationsaccount
 
+/obj/item/device/camera/broadcasting/get_examine_text(mob/user)
+	. = ..()
+	. += "Linked account: [donationsaccount ? "account_number" : "None, swipe your ID-card to link it."]."
+
 /obj/item/device/camera/broadcasting/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/card/id))
 		var/obj/item/card/id/id = I

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -363,7 +363,7 @@
 
 /obj/item/device/camera/broadcasting/get_examine_text(mob/user)
 	. = ..()
-	. += "Linked account: [donationsaccount ? "account_number" : "None, swipe your ID-card to link it."]."
+	. += "Linked account: [donationsaccount ? "[donationsaccount.account_number]" : "None, swipe your ID-card to link it."]."
 	if(latestmessage)
 		. += "Latest donation: [latestmessage]."
 

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -360,12 +360,13 @@
 	var/obj/structure/machinery/camera/correspondent/linked_cam
 	var/datum/money_account/donationsaccount
 	var/latestmessage
+	var/latestsum
 
 /obj/item/device/camera/broadcasting/get_examine_text(mob/user)
 	. = ..()
 	. += "Linked account: [donationsaccount ? "[donationsaccount.account_number]" : "None, swipe your ID-card to link it"]."
 	if(latestmessage)
-		. += "Latest donation: [latestmessage]."
+		. += "Latest donation: [latestmessage], [latestsum]$."
 
 /obj/item/device/camera/broadcasting/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/card/id))

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -363,7 +363,7 @@
 
 /obj/item/device/camera/broadcasting/get_examine_text(mob/user)
 	. = ..()
-	. += "Linked account: [donationsaccount ? "[donationsaccount.account_number]" : "None, swipe your ID-card to link it."]."
+	. += "Linked account: [donationsaccount ? "[donationsaccount.account_number]" : "None, swipe your ID-card to link it"]."
 	if(latestmessage)
 		. += "Latest donation: [latestmessage]."
 

--- a/html/changelogs/AutoChangeLog-pr-6193.yml
+++ b/html/changelogs/AutoChangeLog-pr-6193.yml
@@ -1,0 +1,4 @@
+author: "Lagomorphica"
+delete-after: True
+changes:
+  - balance: "The spotter laser designators, scout laser designators, and scout cloak are now unmeltable and indestructible to explosions."


### PR DESCRIPTION
# About the pull request

![image](https://github.com/cmss13-devs/cmss13/assets/44546836/a2801a1c-d68e-41d8-8bc5-b47dc09fb56a)


allows fans to send donations to their favorite streamer (Combat Correspondent) through the TV Set

# Explain why it's good for the game

while watching and hearing CC on TV is cool and all, it's a little underwhelming since you can't really interact with them in any meaningful way. this adds this "meaningful way" while also giving some use to money apart from RP and vendors and shit

if maintainers feel like it's too memey, i can remove nickname choosing

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

yep...

</details>


# Changelog
:cl:
add: Added donations mechanic for Combat Correspondent. Just hit your local TV with cash.
/:cl:
