### PR TITLE
Fixes Whitelist Notes

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -17,12 +17,10 @@
 #define NOTE_ADMIN 1
 ///This note is used by staff for positive record keeping.
 #define NOTE_MERIT 2
-///These notes are used by respective whitelist councils for record keeping.
-#define NOTE_COMMANDER 3
-#define NOTE_SYNTHETIC 4
-#define NOTE_YAUTJA 5
+///These notes are automatically applied by the Whitelist Panel.
+#define NOTE_WHITELIST 3
 ///Note categories in text form, in order of their numerical #defines.
-GLOBAL_LIST_INIT(note_categories, list("Admin", "Merit", "Commanding Officer", "Synthetic", "Yautja"))
+GLOBAL_LIST_INIT(note_categories, list("Admin", "Merit", "Whitelist"))
 
 #define ADMIN_FLW(user) "(<a href='?_src_=admin_holder;[HrefToken(forceGlobal = TRUE)];adminplayerobservefollow=[REF(user)]'>FLW</a>)"
 #define ADMIN_PP(user) "(<a href='?_src_=admin_holder;[HrefToken(forceGlobal = TRUE)];adminplayeropts=[REF(user)]'>PP</a>)"

--- a/code/datums/entities/player.dm
+++ b/code/datums/entities/player.dm
@@ -90,11 +90,12 @@ BSQL_PROTECT_DATUM(/datum/entity/player)
 /datum/entity/player/proc/add_note(note_text, is_confidential, note_category = NOTE_ADMIN, is_ban = FALSE, duration = null)
 	var/client/admin = usr.client
 	// do all checks here, especially for sensitive stuff like this
-	if(!admin || !admin.player_data)
-		return FALSE
-	if(note_category == NOTE_ADMIN || is_confidential)
-		if (!AHOLD_IS_MOD(admin.admin_holder))
+	if(!(note_category == NOTE_WHITELIST))
+		if(!admin || !admin.player_data)
 			return FALSE
+		if(note_category == NOTE_ADMIN || is_confidential)
+			if (!AHOLD_IS_MOD(admin.admin_holder))
+				return FALSE
 
 	// this is here for a short transition period when we still are testing DB notes and constantly deleting the file
 	if(CONFIG_GET(flag/duplicate_notes_to_file))
@@ -119,7 +120,7 @@ BSQL_PROTECT_DATUM(/datum/entity/player)
 	note.note_category = note_category
 	note.is_ban = is_ban
 	note.ban_time = duration
-	note.admin_rank = admin.admin_holder.rank
+	note.admin_rank = admin.admin_holder ? admin.admin_holder.rank : "Non-Staff"
 	// since admin is in game, their player_data has to be populated. This is also checked above
 	note.admin_id = admin.player_data.id
 	note.admin = admin.player_data
@@ -134,13 +135,17 @@ BSQL_PROTECT_DATUM(/datum/entity/player)
 	notes.Add(note)
 	return TRUE
 
-/datum/entity/player/proc/remove_note(note_id)
+/datum/entity/player/proc/remove_note(note_id, whitelist = FALSE)
+	if(IsAdminAdvancedProcCall())
+		return PROC_BLOCKED
 	var/client/admin = usr.client
 	// do all checks here, especially for sensitive stuff like this
 	if(!admin || !admin.player_data)
 		return FALSE
 
-	if (!AHOLD_IS_MOD(admin.admin_holder))
+	if((!AHOLD_IS_MOD(admin.admin_holder)) && !whitelist)
+		return FALSE
+	if(whitelist && !(isSenator(admin) || CLIENT_HAS_RIGHTS(admin, R_PERMISSIONS)))
 		return FALSE
 
 	// this is here for a short transition period when we still are testing DB notes and constantly deleting the file

--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -24,6 +24,8 @@
 
 	if(isSenator(src))
 		add_verb(src, /client/proc/whitelist_panel)
+	if(isCouncil(src))
+		add_verb(src, /client/proc/other_records)
 
 /client
 	var/datum/whitelist_panel/wl_panel
@@ -144,8 +146,10 @@ GLOBAL_LIST_INIT(misc_flags, list(
 /datum/whitelist_panel/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
 	if(.)
-		return
+		return FALSE
 	var/mob/user = ui.user
+	if(!isSenator(user.client) && !CLIENT_HAS_RIGHTS(user.client, R_PERMISSIONS))
+		return FALSE
 	switch(action)
 		if("go_back")
 			go_back()
@@ -165,6 +169,7 @@ GLOBAL_LIST_INIT(misc_flags, list(
 				return
 			var/datum/entity/player/player = get_player_from_key(player_key)
 			player.set_whitelist_status(new_rights)
+			player.add_note("Whitelists updated by [user.key]. Reason: '[reason]'.", FALSE, NOTE_WHITELIST)
 			to_chat(user, SPAN_HELPFUL("Whitelists for [player_key] updated."))
 			message_admins("Whitelists for [player_key] updated by [key_name(user)]. Reason: '[reason]'.")
 			log_admin("WHITELISTS: Flags for [player_key] changed from [target_rights] to [new_rights]. Reason: '[reason]'.")

--- a/code/game/verbs/records.dm
+++ b/code/game/verbs/records.dm
@@ -1,10 +1,8 @@
-//CO Whitelist is '1', Synthetic Whitelist is '2', Yautja Whitelist is '3'.
-
 /client/verb/own_records()
 	set name = "View Own Records"
 	set category = "OOC.Records"
 
-	var/list/options = list("Admin", "Merit", "Commanding Officer", "Synthetic", "Yautja")
+	var/list/options = list("Admin", "Merit", "Whitelist")
 
 	var/choice = tgui_input_list(usr, "What record do you wish to view?", "Record Choice", options)
 	switch(choice)
@@ -12,12 +10,8 @@
 			show_own_notes(NOTE_ADMIN, choice)
 		if("Merit")
 			show_own_notes(NOTE_MERIT, choice)
-		if("Commanding Officer")
-			show_own_notes(NOTE_COMMANDER, choice)
-		if("Synthetic")
-			show_own_notes(NOTE_SYNTHETIC, choice)
-		if("Yautja")
-			show_own_notes(NOTE_YAUTJA, choice)
+		if("Whitelist")
+			show_own_notes(NOTE_WHITELIST, choice)
 		else
 			return
 	to_chat(usr, SPAN_NOTICE("Displaying your [choice] Record."))
@@ -46,12 +40,8 @@
 		switch(note_category)
 			if(NOTE_MERIT)
 				color = "#9e3dff"
-			if(NOTE_COMMANDER)
+			if(NOTE_WHITELIST)
 				color = "#324da5"
-			if(NOTE_SYNTHETIC)
-				color = "#39e7a4"
-			if(NOTE_YAUTJA)
-				color = "#114e11"
 
 		dat += "<font color=[color]>[N.text]</font> <i>by [admin_ckey] ([N.admin_rank])</i> on <i><font color=blue>[N.date] [NOTE_ROUND_ID(N)]</i></font> "
 		dat += "<br><br>"
@@ -69,16 +59,15 @@
 //Contributions and suggestions are welcome.
 //Kindly, forest2001
 
-/client/verb/other_records()
+/client/proc/other_records()
 	set name = "View Target Records"
 	set category = "OOC.Records"
 
 	///Management Access
-	var/MA
+	var/manager = FALSE
 	///Edit Access
-	var/edit_C = FALSE
-	var/edit_S = FALSE
-	var/edit_Y = FALSE
+	var/add_wl = FALSE
+	var/del_wl = FALSE
 
 	///Note category options
 	var/list/options = list()
@@ -86,7 +75,7 @@
 	if(CLIENT_IS_STAFF(src))
 		options = GLOB.note_categories.Copy()
 		if(admin_holder.rights & R_PERMISSIONS)
-			MA = TRUE
+			manager = TRUE
 	else if(!isCouncil(src))
 		to_chat(usr, SPAN_WARNING("Error: you are not authorised to view the records of another player!"))
 		return
@@ -97,15 +86,11 @@
 		return
 	target = ckey(target)
 
-	if(check_whitelist_status(WHITELIST_COMMANDER_COUNCIL))
-		options |= "Commanding Officer"
-		edit_C = TRUE
-	if(check_whitelist_status(WHITELIST_SYNTHETIC_COUNCIL))
-		options |= "Synthetic"
-		edit_S = TRUE
-	if(check_whitelist_status(WHITELIST_YAUTJA_COUNCIL))
-		options |= "Yautja"
-		edit_Y = TRUE
+	if(manager || isCouncil(src))
+		options |= "Whitelist"
+		add_wl = TRUE
+	if(manager || isSenator(src))
+		del_wl = TRUE
 
 	var/choice = tgui_input_list(usr, "What record do you wish to view?", "Record Choice", options)
 	if(!choice)
@@ -115,21 +100,8 @@
 			show_other_record(NOTE_ADMIN, choice, target, TRUE)
 		if("Merit")
 			show_other_record(NOTE_MERIT, choice, target, TRUE)
-		if("Commanding Officer")
-			if(MA || check_whitelist_status(WHITELIST_COMMANDER_LEADER))
-				show_other_record(NOTE_COMMANDER, choice, target, TRUE, TRUE)
-			else
-				show_other_record(NOTE_COMMANDER, choice, target, edit_C)
-		if("Synthetic")
-			if(MA || check_whitelist_status(WHITELIST_SYNTHETIC_LEADER))
-				show_other_record(NOTE_SYNTHETIC, choice, target, TRUE, TRUE)
-			else
-				show_other_record(NOTE_SYNTHETIC, choice, target, edit_S)
-		if("Yautja")
-			if(MA || check_whitelist_status(WHITELIST_YAUTJA_LEADER))
-				show_other_record(NOTE_YAUTJA, choice, target, TRUE, TRUE)
-			else
-				show_other_record(NOTE_YAUTJA, choice, target, edit_Y)
+		if("Whitelist")
+			show_other_record(NOTE_WHITELIST, choice, target, add_wl, del_wl)
 	to_chat(usr, SPAN_NOTICE("Displaying [target]'s [choice] notes."))
 
 
@@ -148,15 +120,9 @@
 		if(NOTE_MERIT)
 			color = "#9e3dff"
 			add_dat = "<A href='?src=\ref[usr];add_merit_info=[target]'>Add Merit Note</A><br>"
-		if(NOTE_COMMANDER)
+		if(NOTE_WHITELIST)
 			color = "#324da5"
-			add_dat = "<A href='?src=\ref[usr];add_wl_info_1=[target]'>Add Commander Note</A><br>"
-		if(NOTE_SYNTHETIC)
-			color = "#39e7a4"
-			add_dat = "<A href='?src=\ref[usr];add_wl_info_2=[target]'>Add Synthetic Note</A><br>"
-		if(NOTE_YAUTJA)
-			color = "#114e11"
-			add_dat = "<A href='?src=\ref[usr];add_wl_info_3=[target]'>Add Yautja Note</A><br>"
+			add_dat = "<A href='?src=\ref[usr];add_wl_info=[target]'>Add Whitelist Note</A><br>"
 
 	var/list/datum/view_record/note_view/NL = DB_VIEW(/datum/view_record/note_view, DB_COMP("player_ckey", DB_EQUALS, target))
 	for(var/datum/view_record/note_view/N as anything in NL)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -95,12 +95,8 @@
 				color = "#AA0055"
 			else if(N.note_category == NOTE_MERIT)
 				color = "#9e3dff"
-			else if(N.note_category == NOTE_COMMANDER)
+			else if(N.note_category == NOTE_WHITELIST)
 				color = "#324da5"
-			else if(N.note_category == NOTE_SYNTHETIC)
-				color = "#39e7a4"
-			else if(N.note_category == NOTE_YAUTJA)
-				color = "#114e11"
 
 			dat += "<font color=[color]>[N.text]</font> <i>by [admin_ckey] ([N.admin_rank])</i>[confidential_text] on <i><font color=blue>[N.date] [NOTE_ROUND_ID(N)]</i></font> "
 		if(admin_ckey == usr.ckey || admin_ckey == "Adminbot" || check_for_rights(R_PERMISSIONS))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -72,6 +72,7 @@ GLOBAL_LIST_INIT(admin_verbs_default, list(
 	/client/proc/cmd_admin_say, /*staff-only ooc chat*/
 	/client/proc/cmd_mod_say, /* alternate way of typing asay, no different than cmd_admin_say  */
 	/client/proc/cmd_admin_tacmaps_panel,
+	/client/proc/other_records,
 	))
 
 GLOBAL_LIST_INIT(admin_verbs_admin, list(

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -187,39 +187,21 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 		var/datum/entity/player/P = get_player_from_key(key)
 		P.add_note(add, FALSE, NOTE_MERIT)
 
-	if(href_list["add_wl_info_1"])
-		var/key = href_list["add_wl_info_1"]
-		var/add = input("Add Commander Note") as null|message
+	if(href_list["add_wl_info"])
+		var/key = href_list["add_wl_info"]
+		var/add = input("Add Whitelist Note") as null|message
 		if(!add)
 			return
 
 		var/datum/entity/player/P = get_player_from_key(key)
-		P.add_note(add, FALSE, NOTE_COMMANDER)
-
-	if(href_list["add_wl_info_2"])
-		var/key = href_list["add_wl_info_2"]
-		var/add = input("Add Synthetic Note") as null|message
-		if(!add)
-			return
-
-		var/datum/entity/player/P = get_player_from_key(key)
-		P.add_note(add, FALSE, NOTE_SYNTHETIC)
-
-	if(href_list["add_wl_info_3"])
-		var/key = href_list["add_wl_info_3"]
-		var/add = input("Add Yautja Note") as null|message
-		if(!add)
-			return
-
-		var/datum/entity/player/P = get_player_from_key(key)
-		P.add_note(add, FALSE, NOTE_YAUTJA)
+		P.add_note(add, FALSE, NOTE_WHITELIST)
 
 	if(href_list["remove_wl_info"])
 		var/key = href_list["remove_wl_info"]
 		var/index = text2num(href_list["remove_index"])
 
 		var/datum/entity/player/P = get_player_from_key(key)
-		P.remove_note(index)
+		P.remove_note(index, whitelist = TRUE)
 
 	switch(href_list["_src_"])
 		if("admin_holder")


### PR DESCRIPTION

# About the pull request
Makes whitelist notes actually usable. I put them in the game two years ago but they've been entirely non-functional since.

# Explain why it's good for the game
About time I fixed my crap code.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Whitelist notes now work properly. Council can add notes to players regarding whitelist issues.
add: Changing whitelist flags with the Whitelist Panel now automatically adds a note with the reason.
/:cl:
