### PR TITLE
Mapping LV624 updated apc to the new standart where they autoname and pixel themself to the wall.

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1372,3 +1372,7 @@ GLOBAL_LIST_INIT(apc_wire_descriptions, list(
 	crash_break_probability = 0
 
 #undef APC_UPDATE_ICON_COOLDOWN
+
+// apc that start at zero charge.
+/obj/structure/machinery/power/apc/nocharge.
+	start_charge = 0

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -17035,6 +17035,17 @@
 /obj/effect/landmark/objective_landmark/far,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/sand_temple)
+"jQX" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 1
+	},
+/turf/open/floor{
+	icon_state = "grimy"
+	},
+/area/lv624/lazarus/hop)
 "jRm" = (
 /turf/open/gm/dirt,
 /area/lv624/ground/colony/north_nexus_road)
@@ -51003,7 +51014,7 @@ aSA
 aSA
 aTC
 aQM
-aUD
+jQX
 aVq
 aVM
 aSB

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -2125,8 +2125,7 @@
 "akh" = (
 /obj/item/trash/candy,
 /obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Corporate Lobby APC"
+	dir = 1
 	},
 /obj/structure/machinery/door_control{
 	id = "secure_outer_blast";
@@ -3238,11 +3237,8 @@
 	},
 /area/lv624/lazarus/hydroponics)
 "aru" = (
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Hydroponics APC";
-	pixel_y = 30;
-	start_charge = 0
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 1
 	},
 /turf/open/floor{
 	dir = 9;
@@ -4413,11 +4409,8 @@
 	},
 /area/lv624/lazarus/fitness)
 "aww" = (
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Fitness APC";
-	pixel_y = 30;
-	start_charge = 0
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 1
 	},
 /turf/open/floor{
 	dir = 4;
@@ -5132,11 +5125,8 @@
 	},
 /area/lv624/lazarus/robotics)
 "azc" = (
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Robotics Lab APC";
-	pixel_y = 30;
-	start_charge = 0
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 1
 	},
 /turf/open/floor{
 	icon_state = "vault"
@@ -5625,33 +5615,27 @@
 	},
 /area/lv624/lazarus/sleep_male)
 "aAR" = (
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Research APC";
-	pixel_y = 30;
-	start_charge = 0
-	},
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
 /obj/structure/surface/table,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 1
+	},
 /turf/open/floor{
 	dir = 5;
 	icon_state = "whitepurple"
 	},
 /area/lv624/lazarus/research)
 "aAS" = (
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Men's Dorms APC";
-	pixel_y = 30;
-	start_charge = 0
-	},
 /obj/structure/surface/table,
 /obj/item/toy/deck,
 /obj/item/storage/fancy/cigarettes/wypacket,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 1
+	},
 /turf/open/floor{
 	icon_state = "bluecorner"
 	},
@@ -6067,12 +6051,6 @@
 "aCd" = (
 /obj/structure/machinery/light/small{
 	dir = 4
-	},
-/obj/structure/machinery/power/apc{
-	dir = 4;
-	name = "Women's Dorms APC";
-	pixel_x = 30;
-	start_charge = 0
 	},
 /turf/open/floor{
 	dir = 9;
@@ -6498,11 +6476,8 @@
 	},
 /area/lv624/lazarus/sleep_female)
 "aDE" = (
-/obj/structure/machinery/power/apc{
-	dir = 8;
-	name = "Storage Pods APC";
-	pixel_x = -30;
-	start_charge = 0
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 8
 	},
 /turf/open/floor/vault,
 /area/lv624/lazarus/quartstorage)
@@ -6682,11 +6657,8 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Unisex Bathrooms APC";
-	pixel_y = 30;
-	start_charge = 0
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 8
 	},
 /turf/open/floor{
 	icon_state = "freezerfloor"
@@ -6779,14 +6751,11 @@
 	},
 /area/lv624/ground/caves/north_central_caves)
 "aEK" = (
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Chapel APC";
-	pixel_y = 30;
-	start_charge = 0
-	},
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
+	},
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 1
 	},
 /turf/open/floor{
 	dir = 1;
@@ -6915,15 +6884,12 @@
 	},
 /area/lv624/lazarus/quart)
 "aEZ" = (
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Quartermaster APC";
-	pixel_y = 30;
-	start_charge = 0
-	},
 /obj/structure/largecrate/random,
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
+	},
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 1
 	},
 /turf/open/floor{
 	dir = 4;
@@ -7756,15 +7722,12 @@
 	},
 /area/lv624/lazarus/main_hall)
 "aIh" = (
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Central Hallway APC";
-	pixel_y = 30;
-	start_charge = 0
-	},
 /obj/structure/surface/table,
 /obj/effect/landmark/crap_item,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 1
+	},
 /turf/open/floor{
 	icon_state = "white"
 	},
@@ -8313,9 +8276,8 @@
 /area/lv624/lazarus/yggdrasil)
 "aKq" = (
 /obj/structure/flora/jungle/vines/light_1,
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Atmospherics Processing APC"
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 1
 	},
 /turf/open/gm/grass/grass2,
 /area/lv624/lazarus/yggdrasil)
@@ -9003,9 +8965,8 @@
 	},
 /area/lv624/lazarus/security)
 "aNR" = (
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Security Office APC"
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 1
 	},
 /turf/open/floor{
 	icon_state = "red"
@@ -9148,11 +9109,8 @@
 /turf/open/gm/dirt,
 /area/lv624/ground/jungle/east_central_jungle)
 "aOy" = (
-/obj/structure/machinery/power/apc{
-	dir = 8;
-	name = "Secure Vault APC";
-	pixel_x = -28;
-	start_charge = 0
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 8
 	},
 /turf/open/floor{
 	icon_state = "cult"
@@ -9775,11 +9733,8 @@
 	},
 /area/lv624/lazarus/kitchen)
 "aQQ" = (
-/obj/structure/machinery/power/apc{
-	dir = 8;
-	name = "Cafeteria APC";
-	pixel_x = -28;
-	start_charge = 0
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 8
 	},
 /turf/open/floor{
 	icon_state = "bar"
@@ -10128,11 +10083,8 @@
 	},
 /area/lv624/ground/caves/south_east_caves)
 "aSq" = (
-/obj/structure/machinery/power/apc{
-	dir = 8;
-	name = "Commandant's Quarters APC";
-	pixel_x = -28;
-	start_charge = 0
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 8
 	},
 /turf/open/floor{
 	icon_state = "grimy"
@@ -10483,7 +10435,6 @@
 "aTJ" = (
 /obj/structure/machinery/power/apc{
 	dir = 1;
-	name = "Telecomms APC";
 	start_charge = 15
 	},
 /turf/open/floor{
@@ -10594,8 +10545,7 @@
 "aUc" = (
 /obj/structure/surface/rack,
 /obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Kitchen APC"
+	dir = 1
 	},
 /turf/open/floor{
 	icon_state = "freezerfloor"
@@ -10748,18 +10698,6 @@
 	icon_state = "grimy"
 	},
 /area/lv624/lazarus/hop)
-"aUF" = (
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Research Director's APC"
-	},
-/turf/open/floor{
-	icon_state = "grimy"
-	},
-/area/lv624/lazarus/hop)
 "aUG" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -10823,8 +10761,6 @@
 "aUR" = (
 /obj/structure/machinery/power/apc{
 	dir = 1;
-	name = "Secure Vault APC";
-	pixel_y = 30;
 	start_charge = 200
 	},
 /turf/open/floor/greengrid,
@@ -11562,10 +11498,8 @@
 /area/lv624/ground/jungle/east_central_jungle)
 "aXs" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Geothermal APC";
-	start_charge = 0
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 1
 	},
 /turf/open/floor{
 	icon_state = "delivery"
@@ -14779,9 +14713,7 @@
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_central_caves)
 "fqM" = (
-/obj/structure/machinery/power/apc{
-	start_charge = 0
-	},
+/obj/structure/machinery/power/apc/nocharge,
 /turf/open/floor{
 	dir = 4;
 	icon_state = "asteroidwarning"
@@ -14951,9 +14883,7 @@
 /turf/open/floor/plating,
 /area/lv624/lazarus/engineering)
 "fFZ" = (
-/obj/structure/machinery/power/apc{
-	start_charge = 0
-	},
+/obj/structure/machinery/power/apc/nocharge,
 /turf/open/floor{
 	dir = 1;
 	icon_state = "asteroidfloor"
@@ -16668,6 +16598,15 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_jungle)
+"jcb" = (
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 4
+	},
+/turf/open/floor{
+	dir = 9;
+	icon_state = "purple"
+	},
+/area/lv624/lazarus/sleep_female)
 "jcn" = (
 /obj/effect/decal/grass_overlay/grass1{
 	dir = 8
@@ -20098,11 +20037,8 @@
 /turf/open/auto_turf/strata_grass/layer1,
 /area/lv624/ground/barrens/north_east_barrens)
 "pgf" = (
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Medbay APC";
-	pixel_y = 30;
-	start_charge = 0
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 1
 	},
 /turf/open/floor{
 	dir = 1;
@@ -51067,7 +51003,7 @@ aSA
 aSA
 aTC
 aQM
-aUF
+aUD
 aVq
 aVM
 aSB
@@ -54914,7 +54850,7 @@ azw
 aBg
 azR
 aCd
-aBC
+jcb
 aDb
 aOo
 aDY

--- a/maps/map_files/LV624/armory/10.cheese.dmm
+++ b/maps/map_files/LV624/armory/10.cheese.dmm
@@ -151,12 +151,6 @@
 	},
 /area/lv624/lazarus/security)
 "u" = (
-/obj/structure/machinery/power/apc{
-	dir = 8;
-	name = "Secure Vault APC";
-	pixel_x = -28;
-	start_charge = 0
-	},
 /obj/structure/surface/rack,
 /obj/item/reagent_container/food/snacks/cheesewedge/verymature{
 	pixel_x = -7;
@@ -168,6 +162,9 @@
 	},
 /obj/item/reagent_container/food/snacks/cheesewedge/verymature{
 	pixel_y = 6
+	},
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 8
 	},
 /turf/open/floor{
 	icon_state = "cult"

--- a/maps/map_files/LV624/armory/10.extra.dmm
+++ b/maps/map_files/LV624/armory/10.extra.dmm
@@ -168,11 +168,8 @@
 	},
 /area/lv624/lazarus/security)
 "u" = (
-/obj/structure/machinery/power/apc{
-	dir = 8;
-	name = "Secure Vault APC";
-	pixel_x = -28;
-	start_charge = 0
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 8
 	},
 /turf/open/floor{
 	icon_state = "cult"

--- a/maps/map_files/LV624/armory/10.looted.dmm
+++ b/maps/map_files/LV624/armory/10.looted.dmm
@@ -135,11 +135,8 @@
 	},
 /area/lv624/lazarus/security)
 "u" = (
-/obj/structure/machinery/power/apc{
-	dir = 8;
-	name = "Secure Vault APC";
-	pixel_x = -28;
-	start_charge = 0
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 8
 	},
 /turf/open/floor{
 	icon_state = "cult"

--- a/maps/map_files/LV624/gym/20.pool.dmm
+++ b/maps/map_files/LV624/gym/20.pool.dmm
@@ -221,13 +221,10 @@
 	},
 /area/lv624/lazarus/fitness)
 "Be" = (
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Fitness APC";
-	pixel_y = 30;
-	start_charge = 0
-	},
 /obj/effect/decal/remains/human,
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 1
+	},
 /turf/open/floor{
 	dir = 4;
 	icon_state = "whitepurplecorner"

--- a/maps/map_files/LV624/gym/30.alternate.dmm
+++ b/maps/map_files/LV624/gym/30.alternate.dmm
@@ -658,11 +658,8 @@
 /turf/open/floor/plating,
 /area/lv624/lazarus/fitness)
 "Wy" = (
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Fitness APC";
-	pixel_y = 30;
-	start_charge = 0
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 1
 	},
 /turf/open/floor{
 	dir = 4;

--- a/maps/map_files/LV624/medbay/10.destroyed.dmm
+++ b/maps/map_files/LV624/medbay/10.destroyed.dmm
@@ -48,11 +48,8 @@
 	},
 /area/lv624/lazarus/medbay)
 "hW" = (
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Medbay APC";
-	pixel_y = 30;
-	start_charge = 0
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 1
 	},
 /turf/open/floor{
 	icon_state = "white"

--- a/maps/map_files/LV624/medbay/30.larvasurgery.dmm
+++ b/maps/map_files/LV624/medbay/30.larvasurgery.dmm
@@ -363,14 +363,11 @@
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/north_west_jungle)
 "qP" = (
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Medbay APC";
-	pixel_y = 30;
-	start_charge = 0
-	},
 /obj/effect/landmark/corpsespawner/colonist/random/burst,
 /obj/effect/decal/cleanable/blood,
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 1
+	},
 /turf/open/floor{
 	dir = 1;
 	icon_state = "whiteblue"

--- a/maps/map_files/LV624/science/10.yautja.dmm
+++ b/maps/map_files/LV624/science/10.yautja.dmm
@@ -266,12 +266,6 @@
 	},
 /area/lv624/lazarus/research)
 "aL" = (
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Research APC";
-	pixel_y = 30;
-	start_charge = 0
-	},
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
@@ -516,6 +510,16 @@
 	icon_state = "freezerfloor"
 	},
 /area/lv624/lazarus/research)
+"Hj" = (
+/obj/effect/landmark/crap_item,
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 1
+	},
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/lv624/lazarus/research)
 "Lo" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/remains/human,
@@ -724,7 +728,7 @@ Zw
 al
 aE
 ab
-ec
+Hj
 ak
 al
 ab

--- a/maps/map_files/LV624/science/40.fullylocked.dmm
+++ b/maps/map_files/LV624/science/40.fullylocked.dmm
@@ -310,12 +310,6 @@
 	},
 /area/lv624/lazarus/research)
 "aS" = (
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Research APC";
-	pixel_y = 30;
-	start_charge = 0
-	},
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
@@ -450,6 +444,15 @@
 "DC" = (
 /obj/structure/machinery/light,
 /obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/lv624/lazarus/research)
+"Fm" = (
+/obj/structure/machinery/power/apc/nocharge{
+	dir = 1
+	},
 /turf/open/floor{
 	dir = 5;
 	icon_state = "whitepurple"
@@ -663,7 +666,7 @@ Mu
 ay
 aJ
 ab
-ay
+Fm
 ak
 ay
 ab

--- a/maps/map_files/LV624/standalone/clfship.dmm
+++ b/maps/map_files/LV624/standalone/clfship.dmm
@@ -1601,12 +1601,10 @@
 	},
 /area/lv624/lazarus/crashed_ship)
 "Px" = (
-/obj/structure/machinery/power/apc{
-	dir = 1;
-	name = "Crashed Ship APC";
-	pixel_y = 25
-	},
 /obj/structure/machinery/autolathe,
+/obj/structure/machinery/power/apc{
+	dir = 1
+	},
 /turf/open/floor/almayer{
 	dir = 9;
 	icon_state = "orange"


### PR DESCRIPTION
# About the pull request
created a new subtype of APC for when they have no charge.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: some apc are a bit moved around to avoid them having a small light on them.
/:cl:
