### PR TITLE
nerfs Kutjevo ledges

### DIFF
--- a/code/game/objects/structures/platforms.dm
+++ b/code/game/objects/structures/platforms.dm
@@ -142,7 +142,6 @@
 	icon_state = "kutjevo_platform"
 	name = "raised metal edge"
 	desc =  "A raised level of metal, often used to elevate areas above others, or construct bridges. You could probably climb it."
-	climb_delay = 10
 
 /obj/structure/platform_decoration/kutjevo
 	name = "raised metal corner"


### PR DESCRIPTION

# About the pull request
Kutjevo ledges now take only 0.2 seconds to climb instead of 1 whole second

# Explain why it's good for the game
why should kutjevo ledges take longer to climb?
consistency

# Testing Photographs and Procedure
probably works

# Changelog
:cl:
balance: Kutjevo ledges now take only 0.2 seconds to climb instead of 1 whole second
/:cl:
