### PR TITLE
Fixes sentry targeting xenos inside of vents

### DIFF
--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -271,6 +271,11 @@
 	if(!(world.time-last_fired >= fire_delay) || !turned_on || !ammo || QDELETED(target))
 		return
 
+	if(isliving(A))
+		var/mob/living/vent_mob = A
+		if(vent_mob.is_ventcrawling)
+			return
+
 	if(world.time-last_fired >= 30 SECONDS) //if we haven't fired for a while, beep first
 		playsound(loc, 'sound/machines/twobeep.ogg', 50, 1)
 		sleep(3)

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -271,11 +271,6 @@
 	if(!(world.time-last_fired >= fire_delay) || !turned_on || !ammo || QDELETED(target))
 		return
 
-	if(isliving(A))
-		var/mob/living/vent_mob = A
-		if(vent_mob.is_ventcrawling)
-			return
-
 	if(world.time-last_fired >= 30 SECONDS) //if we haven't fired for a while, beep first
 		playsound(loc, 'sound/machines/twobeep.ogg', 50, 1)
 		sleep(3)
@@ -367,6 +362,10 @@
 			if(M.stat & DEAD)
 				if(A == target)
 					target = null
+				targets.Remove(A)
+				continue
+
+			if(M.is_ventcrawling)
 				targets.Remove(A)
 				continue
 

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -365,11 +365,7 @@
 				targets.Remove(A)
 				continue
 
-			if(M.is_ventcrawling)
-				targets.Remove(A)
-				continue
-
-			if(M.get_target_lock(faction_group) || M.invisibility || HAS_TRAIT(M, TRAIT_ABILITY_BURROWED))
+			if(M.get_target_lock(faction_group) || M.invisibility || HAS_TRAIT(M, TRAIT_ABILITY_BURROWED) || M.is_ventcrawling)
 				if(M == target)
 					target = null
 				targets.Remove(M)


### PR DESCRIPTION
# About the pull request

Closes #6110, #5556. Honestly I was unable to reproduce the issue, but this seems like it should work regardless of the original problem. 


# Changelog
:cl:
fix: Fixes sentries firing at xenos while vent crawling.
/:cl:

