### PR TITLE
Fixes cloaked scout being decapable when wearing a helmet

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -1513,7 +1513,7 @@ treat_grafted var tells it to apply to grafted but unsalved wounds, for burn kit
 /obj/limb/head/limb_delimb(damage_source)
 	var/obj/item/clothing/head/helmet/owner_helmet = owner.head
 
-	if(!istype(owner_helmet) || !owner.allow_gun_usage)
+	if(!istype(owner_helmet) || (issynth(owner) && !owner.allow_gun_usage))
 		droplimb(0, 0, damage_source)
 		return
 


### PR DESCRIPTION
# About the pull request

Closes #6215, keeps beagle's original functionality the same as well. 

# Changelog

:cl:
fix: Fixes scout being able to be decapitated with a helmet on while cloaked. 
/:cl:

