### PR TITLE
Fix weeded corpses on shuttles

### DIFF
--- a/code/__DEFINES/dcs/signals/atom/signals_obj.dm
+++ b/code/__DEFINES/dcs/signals/atom/signals_obj.dm
@@ -30,7 +30,7 @@
 #define COMSIG_TENT_COLLAPSING "tent_collapsing"
 
 /// from /obj/proc/afterbuckle()
-#define COSMIG_OBJ_AFTER_BUCKLE "signal_obj_after_buckle"
+#define COMSIG_OBJ_AFTER_BUCKLE "signal_obj_after_buckle"
 
 /// from /obj/structure/machinery/cryopod/go_out()
 #define COMSIG_CRYOPOD_GO_OUT "cryopod_go_out"

--- a/code/datums/components/weed_food.dm
+++ b/code/datums/components/weed_food.dm
@@ -87,7 +87,7 @@
 	parent_buckle = null
 
 /datum/component/weed_food/RegisterWithParent()
-	RegisterSignal(parent_mob, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
+	RegisterSignal(parent_mob, COMSIG_MOVABLE_TURF_ENTERED, PROC_REF(on_move))
 	RegisterSignal(parent_mob, list(COMSIG_LIVING_REJUVENATED, COMSIG_HUMAN_REVIVED), PROC_REF(on_rejuv))
 	RegisterSignal(parent_mob, COMSIG_HUMAN_SET_UNDEFIBBABLE, PROC_REF(on_update))
 	RegisterSignal(parent_mob, COMSIG_LIVING_PREIGNITION, PROC_REF(on_preignition))
@@ -98,7 +98,7 @@
 /datum/component/weed_food/UnregisterFromParent()
 	if(parent_mob)
 		UnregisterSignal(parent_mob, list(
-			COMSIG_MOVABLE_MOVED,
+			COMSIG_MOVABLE_TURF_ENTERED,
 			COMSIG_LIVING_REJUVENATED,
 			COMSIG_HUMAN_REVIVED,
 			COMSIG_HUMAN_SET_UNDEFIBBABLE,
@@ -114,7 +114,7 @@
 		UnregisterSignal(parent_nest, COMSIG_PARENT_QDELETING)
 	UnregisterSignal(SSdcs, COMSIG_GLOB_GROUNDSIDE_FORSAKEN_HANDLING)
 
-/// SIGNAL_HANDLER for COMSIG_MOVABLE_MOVED
+/// SIGNAL_HANDLER for COMSIG_MOVABLE_TURF_ENTERED
 /datum/component/weed_food/proc/on_move()
 	SIGNAL_HANDLER
 

--- a/code/datums/components/weed_food.dm
+++ b/code/datums/components/weed_food.dm
@@ -109,7 +109,7 @@
 	if(parent_turf)
 		UnregisterSignal(parent_turf, COMSIG_WEEDNODE_GROWTH)
 	if(parent_buckle)
-		UnregisterSignal(parent_buckle, COSMIG_OBJ_AFTER_BUCKLE)
+		UnregisterSignal(parent_buckle, COMSIG_OBJ_AFTER_BUCKLE)
 	if(parent_nest)
 		UnregisterSignal(parent_nest, COMSIG_PARENT_QDELETING)
 	UnregisterSignal(SSdcs, COMSIG_GLOB_GROUNDSIDE_FORSAKEN_HANDLING)
@@ -148,7 +148,7 @@
 
 	qdel(src)
 
-/// SIGNAL_HANDLER for COSMIG_OBJ_AFTER_BUCKLE
+/// SIGNAL_HANDLER for COMSIG_OBJ_AFTER_BUCKLE
 /datum/component/weed_food/proc/on_after_buckle(obj/source, mob/buckled)
 	SIGNAL_HANDLER
 
@@ -220,12 +220,12 @@
 			return FALSE // Still buckled to the same thing
 		if(!istype(parent_mob.buckled, /obj/structure/bed/nest))
 			if(parent_buckle) // Still have a lingering reference somehow?
-				UnregisterSignal(parent_buckle, COSMIG_OBJ_AFTER_BUCKLE)
+				UnregisterSignal(parent_buckle, COMSIG_OBJ_AFTER_BUCKLE)
 			parent_buckle = parent_mob.buckled
-			RegisterSignal(parent_mob.buckled, COSMIG_OBJ_AFTER_BUCKLE, PROC_REF(on_after_buckle))
+			RegisterSignal(parent_mob.buckled, COMSIG_OBJ_AFTER_BUCKLE, PROC_REF(on_after_buckle))
 			return FALSE
 	if(parent_buckle)
-		UnregisterSignal(parent_buckle, COSMIG_OBJ_AFTER_BUCKLE)
+		UnregisterSignal(parent_buckle, COMSIG_OBJ_AFTER_BUCKLE)
 		parent_buckle = null
 
 	if(parent_mob.is_xeno_grabbable())
@@ -282,16 +282,16 @@
 			return FALSE // Still buckled to the same thing somehow?
 		if(!istype(parent_mob.buckled, /obj/structure/bed/nest))
 			if(parent_buckle) // Still have a lingering reference somehow?
-				UnregisterSignal(parent_buckle, COSMIG_OBJ_AFTER_BUCKLE)
+				UnregisterSignal(parent_buckle, COMSIG_OBJ_AFTER_BUCKLE)
 			parent_buckle = parent_mob.buckled
-			RegisterSignal(parent_mob.buckled, COSMIG_OBJ_AFTER_BUCKLE, PROC_REF(on_after_buckle))
+			RegisterSignal(parent_mob.buckled, COMSIG_OBJ_AFTER_BUCKLE, PROC_REF(on_after_buckle))
 			return FALSE
 		else
 			parent_nest = parent_mob.buckled
 			RegisterSignal(parent_nest, COMSIG_PARENT_QDELETING, PROC_REF(on_nest_deletion))
 
 	if(parent_buckle)
-		UnregisterSignal(parent_buckle, COSMIG_OBJ_AFTER_BUCKLE)
+		UnregisterSignal(parent_buckle, COMSIG_OBJ_AFTER_BUCKLE)
 		parent_buckle = null
 
 	if(SEND_SIGNAL(parent_mob, COMSIG_ATTEMPT_MOB_PULL) & COMPONENT_CANCEL_MOB_PULL)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -234,7 +234,7 @@
 
 /obj/proc/afterbuckle(mob/M as mob) // Called after somebody buckled / unbuckled
 	handle_rotation() // To be removed when we have full dir support in set_buckled
-	SEND_SIGNAL(src, COSMIG_OBJ_AFTER_BUCKLE, buckled_mob)
+	SEND_SIGNAL(src, COMSIG_OBJ_AFTER_BUCKLE, buckled_mob)
 	if(!buckled_mob)
 		UnregisterSignal(M, COMSIG_PARENT_QDELETING)
 	else


### PR DESCRIPTION

# About the pull request

This PR resolves an issue where dropships were causing the `parent_turf` is mismatch with the mob's actual `loc` because a shuttle launch changes the turf of its contents, but doesn't call the `COMSIG_MOVABLE_MOVED` signal making the corpse location incorrect.

I also renamed a cosmig signal to comsig that I previously created for weed_food.

E.g. 
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/ec02ad02-753c-4404-a971-10fb6a5453f0)

# Explain why it's good for the game

Fixes #6220 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
fix: Fixed weeded corpses staying weeded if they were transported by shuttle
/:cl:
