### PR TITLE
SADAR backblast now takes xeno explosion resistance into accout

### DIFF
--- a/code/modules/projectiles/guns/specialist/launcher/rocket_launcher.dm
+++ b/code/modules/projectiles/guns/specialist/launcher/rocket_launcher.dm
@@ -189,12 +189,18 @@
 	smoke.set_up(1, 0, backblast_loc, turn(user.dir, 180))
 	smoke.start()
 	playsound(src, 'sound/weapons/gun_rocketlauncher.ogg', 100, TRUE, 10)
-	for(var/mob/living/carbon/C in backblast_loc)
-		if(C.body_position == STANDING_UP && !HAS_TRAIT(C, TRAIT_EAR_PROTECTION)) //Have to be standing up to get the fun stuff
-			C.apply_damage(15, BRUTE) //The shockwave hurts, quite a bit. It can knock unarmored targets unconscious in real life
-			C.apply_effect(4, STUN) //For good measure
-			C.apply_effect(6, STUTTER)
-			C.emote("pain")
+	for(var/mob/living/carbon/mob in backblast_loc)
+		if(mob.body_position != STANDING_UP || HAS_TRAIT(mob, TRAIT_EAR_PROTECTION)) //Have to be standing up to get the fun stuff
+			continue
+		to_chat(mob, SPAN_BOLDWARNING("You got hit by the backblast!"))
+		mob.apply_damage(15, BRUTE) //The shockwave hurts, quite a bit. It can knock unarmored targets unconscious in real life
+		var/knockdown_amount = 6
+		if(isxeno(mob))
+			var/mob/living/carbon/xenomorph/xeno = mob
+			knockdown_amount = knockdown_amount * (1 - xeno.caste?.xeno_explosion_resistance / 100)
+		mob.KnockDown(knockdown_amount)
+		mob.apply_effect(6, STUTTER)
+		mob.emote("pain")
 
 //-------------------------------------------------------
 //M5 RPG'S MEAN FUCKING COUSIN


### PR DESCRIPTION

# About the pull request
I really died to this.

# Explain why it's good for the game
More consistent. Also knockdown instead of just stun.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: ihatethisengine
balance: SADAR backblast now knockdowns and is reduced by xeno explosion resistance
/:cl:
