### PR TITLE
Watcher nerf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
@@ -195,6 +195,10 @@
 			client.pixel_x = -viewoffset
 			client.pixel_y = 0
 
+	for (var/datum/action/xeno_action/onclick/toggle_long_range/action in actions)
+		action.on_zoom_in()
+		return
+
 /mob/living/carbon/xenomorph/proc/zoom_out()
 	if(!client)
 		return

--- a/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_abilities.dm
@@ -17,3 +17,8 @@
 	freeze_time = 5
 	freeze_play_sound = FALSE
 	can_be_shield_blocked = TRUE
+
+/datum/action/xeno_action/onclick/toggle_long_range/facehugger
+	handles_movement = FALSE
+	should_delay = FALSE
+	ability_primacy = XENO_PRIMARY_ACTION_3

--- a/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_powers.dm
@@ -25,14 +25,23 @@
 		if(current_airlock.density) //if its CLOSED YOU'RE SCUTTLING AND CANNOT POUNCE!!!
 			to_chat(owner, SPAN_WARNING("We cannot do that while squeezing and scuttling!"))
 			return FALSE
+
+	if(HAS_TRAIT(owner, TRAIT_IMMOBILIZED))
+		to_chat(owner, SPAN_WARNING("We cannot do that while immobilized!"))
+		return FALSE
+	
 	return ..()
 
-/datum/action/xeno_action/onclick/toggle_long_range/facehugger/use_ability()
+/datum/action/xeno_action/onclick/toggle_long_range/facehugger/on_zoom_out()
 	. = ..()
 
 	var/mob/living/carbon/xenomorph/facehugger/facehugger = owner
 
-	if (facehugger.is_zoomed)
-		ADD_TRAIT(facehugger, TRAIT_IMMOBILIZED, TRAIT_SOURCE_ABILITY("Long-Range Sight"))
-	else
-		REMOVE_TRAIT(facehugger, TRAIT_IMMOBILIZED, TRAIT_SOURCE_ABILITY("Long-Range Sight"))
+	REMOVE_TRAIT(facehugger, TRAIT_IMMOBILIZED, TRAIT_SOURCE_ABILITY("Long-Range Sight"))
+
+/datum/action/xeno_action/onclick/toggle_long_range/facehugger/on_zoom_in()
+	. = ..()
+
+	var/mob/living/carbon/xenomorph/facehugger/facehugger = owner
+	ADD_TRAIT(facehugger, TRAIT_IMMOBILIZED, TRAIT_SOURCE_ABILITY("Long-Range Sight"))
+

--- a/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_powers.dm
@@ -36,7 +36,6 @@
 	. = ..()
 
 	var/mob/living/carbon/xenomorph/facehugger/facehugger = owner
-
 	REMOVE_TRAIT(facehugger, TRAIT_IMMOBILIZED, TRAIT_SOURCE_ABILITY("Long-Range Sight"))
 
 /datum/action/xeno_action/onclick/toggle_long_range/facehugger/on_zoom_in()

--- a/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_powers.dm
@@ -26,3 +26,13 @@
 			to_chat(owner, SPAN_WARNING("We cannot do that while squeezing and scuttling!"))
 			return FALSE
 	return ..()
+
+/datum/action/xeno_action/onclick/toggle_long_range/facehugger/use_ability()
+	. = ..()
+
+	var/mob/living/carbon/xenomorph/facehugger/facehugger = owner
+
+	if (facehugger.is_zoomed)
+		ADD_TRAIT(facehugger, TRAIT_IMMOBILIZED, TRAIT_SOURCE_ABILITY("Long-Range Sight"))
+	else
+		REMOVE_TRAIT(facehugger, TRAIT_IMMOBILIZED, TRAIT_SOURCE_ABILITY("Long-Range Sight"))

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
@@ -329,6 +329,9 @@
 		xeno.recalculate_speed()
 	button.icon_state = "template"
 
+/datum/action/xeno_action/onclick/toggle_long_range/proc/on_zoom_in()
+	return
+
 /datum/action/xeno_action/onclick/toggle_long_range/proc/handle_mob_move_or_look(mob/living/carbon/xenomorph/xeno, actually_moving, direction, specific_direction)
 	SIGNAL_HANDLER
 	movement_buffer--

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/facehugger/watcher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/facehugger/watcher.dm
@@ -7,7 +7,7 @@
 		/datum/action/xeno_action/onclick/xenohide,
 	)
 	actions_to_add = list(
-		/datum/action/xeno_action/onclick/toggle_long_range/runner,
+		/datum/action/xeno_action/onclick/toggle_long_range/facehugger,
 	)
 
 	behavior_delegate_type = /datum/behavior_delegate/facehugger_watcher
@@ -21,5 +21,5 @@
 	name = "Watcher Facehugger Behavior Delegate"
 
 /datum/behavior_delegate/facehugger_watcher/on_life()
-	if(bound_xeno.body_position == STANDING_UP && !(locate(/obj/effect/alien/weeds) in get_turf(bound_xeno)))
+	if(bound_xeno.body_position == STANDING_UP && !(locate(/obj/effect/alien/weeds) in get_turf(bound_xeno)) && !bound_xeno.is_zoomed)
 		bound_xeno.adjustBruteLoss(1)

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/facehugger/watcher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/facehugger/watcher.dm
@@ -1,6 +1,6 @@
 /datum/xeno_strain/watcher
 	name = FACEHUGGER_WATCHER
-	description = "You lose your ability to hide in exchange to see further and the ability to no longer take damage outside of weeds. This enables you to stalk your host from a distance and wait for the perfect oppertunity to strike."
+	description = "You lose your ability to hide in exchange to see further. This enables you to stalk your host from a distance and wait for the perfect oppertunity to strike."
 	flavor_description = "No need to hide when you can see the danger."
 
 	actions_to_remove = list(
@@ -19,3 +19,7 @@
 // This has no special effects, it's just here to skip `/datum/behavior_delegate/facehugger_base/on_life()`.
 /datum/behavior_delegate/facehugger_watcher
 	name = "Watcher Facehugger Behavior Delegate"
+
+/datum/behavior_delegate/facehugger_watcher/on_life()
+	if(bound_xeno.body_position == STANDING_UP && !(locate(/obj/effect/alien/weeds) in get_turf(bound_xeno)))
+		bound_xeno.adjustBruteLoss(1)

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/facehugger/watcher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/facehugger/watcher.dm
@@ -21,5 +21,11 @@
 	name = "Watcher Facehugger Behavior Delegate"
 
 /datum/behavior_delegate/facehugger_watcher/on_life()
-	if(bound_xeno.body_position == STANDING_UP && !(locate(/obj/effect/alien/weeds) in get_turf(bound_xeno)) && !bound_xeno.is_zoomed)
-		bound_xeno.adjustBruteLoss(1)
+	// Sap health if we're standing, not on weeds, and not zoomed out
+	if(bound_xeno.body_position != STANDING_UP)
+		return
+	if(bound_xeno.is_zoomed)
+		return
+	if(locate(/obj/effect/alien/weeds) in get_turf(bound_xeno))
+		return
+	bound_xeno.adjustBruteLoss(1)


### PR DESCRIPTION
# About the pull request
Watcher facehugger strain now takes damage off weeds the same as the base variant 
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
It's a straight up upgrade to the base variant + Metagaming afk marines \ open cades from ghost is cancer
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Watcher is now immobilized when zoomed out and loses health off weeds when not zoomed out
/:cl:
