### PR TITLE
Automatic egg planting

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -408,8 +408,8 @@
 	else
 		to_chat(src, SPAN_WARNING("There's nothing in our belly that needs regurgitating."))
 
-/// Checks if the target object can be obscured by other objects within the same time. Used for Eggs
-/mob/living/carbon/xenomorph/proc/check_if_can_be_obscured(turf/target_turf, obj/checked_obj)
+/// Returns true if the object would be obscured by other objects in the same turf. Used for Eggs
+/mob/living/carbon/xenomorph/proc/check_if_obscured(turf/target_turf, obj/checked_obj)
 	for(var/obj/object in target_turf.contents)
 		if(object.layer > checked_obj.layer)
 			return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -408,6 +408,13 @@
 	else
 		to_chat(src, SPAN_WARNING("There's nothing in our belly that needs regurgitating."))
 
+/// Checks if the target object can be obscured by other objects within the same time. Used for Eggs
+/mob/living/carbon/xenomorph/proc/check_if_can_be_obscured(turf/target_turf, obj/checked_obj)
+	for(var/obj/object in target_turf.contents)
+		if(object.layer > checked_obj.layer)
+			return TRUE
+		return FALSE
+
 /mob/living/carbon/xenomorph/proc/check_alien_construction(turf/current_turf, check_blockers = TRUE, silent = FALSE, check_doors = TRUE)
 	var/has_obstacle
 	for(var/obj/O in current_turf)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_abilities.dm
@@ -206,5 +206,6 @@
 
 /datum/action/xeno_action/onclick/egg_autoplant/give_to(mob/living/carbon/xenomorph/queen/Q)
 	. = ..()
+	button.icon_state = Q.egg_autoplant ? "template_active" : "template"
 	if(!Q.ovipositor)
 		hide_from(Q)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_abilities.dm
@@ -197,3 +197,14 @@
 /datum/action/xeno_action/activable/blockade/proc/handle_dismount_ovipositor(mob/living/carbon/xenomorph/queen/Q)
 	SIGNAL_HANDLER
 	hide_from(Q)
+
+/datum/action/xeno_action/onclick/egg_autoplant
+	name = "Toggle egg autoplanting"
+	action_icon_state = "retrieve_egg"
+	ability_name = "toggle egg autoplanting"
+	action_type = XENO_ACTION_TOGGLE
+
+/datum/action/xeno_action/onclick/egg_autoplant/give_to(mob/living/carbon/xenomorph/queen/Q)
+	. = ..()
+	if(!Q.ovipositor)
+		hide_from(Q)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -373,13 +373,15 @@
 /datum/action/xeno_action/onclick/manage_hive/use_ability(atom/Atom)
 	var/mob/living/carbon/xenomorph/queen/queen_manager = owner
 	plasma_cost = 0
-	var/list/options = list("Banish (500)", "Re-Admit (100)", "De-evolve (500)", "Reward Jelly (500)", "Exchange larva for evolution (100)",)
+	var/list/options = list("Banish (500)", "Re-Admit (100)", "De-evolve (500)", "Reward Jelly (500)", "Exchange larva for evolution (100)")
 	if(queen_manager.hive.hivenumber == XENO_HIVE_CORRUPTED)
 		var/datum/hive_status/corrupted/hive = queen_manager.hive
 		options += "Add Personal Ally"
 		if(length(hive.personal_allies))
 			options += "Remove Personal Ally"
 			options += "Clear Personal Allies"
+	if(queen_manager.ovipositor)
+		options += "Toggle Egg Autoplanting"
 
 	var/choice = tgui_input_list(queen_manager, "Manage The Hive", "Hive Management",  options, theme="hive_status")
 	switch(choice)
@@ -399,6 +401,8 @@
 			remove_personal_ally()
 		if("Clear Personal Allies")
 			clear_personal_allies()
+		if("Toggle Egg Autoplanting")
+			queen_manager.ovi_egg_autoplant()
 
 /datum/action/xeno_action/onclick/manage_hive/proc/add_personal_ally()
 	var/mob/living/carbon/xenomorph/queen/user_xeno = owner
@@ -857,7 +861,7 @@
 	set name = "Toggle Egg Autoplanting"
 	set desc = "Toggle if eggs automatically plant within a 5 tile radius"
 	set category = "Alien"
-
+	
 	var/mob/living/carbon/xenomorph/queen/queen = src
 
 	if(!queen.check_state())

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -858,12 +858,14 @@
 	set desc = "Toggle if eggs automatically plant within a 5 tile radius"
 	set category = "Alien"
 
-	var/mob/living/carbon/xenomorph/queen/queen = owner
+	var/mob/living/carbon/xenomorph/queen/queen = src
 
 	if(!queen.check_state())
 		return FALSE
 	if(ovipositor) // check if we are ovi, then toggle
 		if(egg_autoplant)
 			egg_autoplant = FALSE
+			to_chat(queen, SPAN_XENONOTICE("You disable automatic egg planting."))
 		else
 			egg_autoplant = TRUE
+			to_chat(queen, SPAN_XENONOTICE("You enable automatic egg planting."))

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -380,8 +380,6 @@
 		if(length(hive.personal_allies))
 			options += "Remove Personal Ally"
 			options += "Clear Personal Allies"
-	if(queen_manager.ovipositor)
-		options += "Toggle Egg Autoplanting"
 
 	var/choice = tgui_input_list(queen_manager, "Manage The Hive", "Hive Management",  options, theme="hive_status")
 	switch(choice)
@@ -401,8 +399,6 @@
 			remove_personal_ally()
 		if("Clear Personal Allies")
 			clear_personal_allies()
-		if("Toggle Egg Autoplanting")
-			queen_manager.ovi_egg_autoplant()
 
 /datum/action/xeno_action/onclick/manage_hive/proc/add_personal_ally()
 	var/mob/living/carbon/xenomorph/queen/user_xeno = owner
@@ -858,11 +854,6 @@
 	hive.tacmap.tgui_interact(src)
 
 /mob/living/carbon/xenomorph/queen/proc/ovi_egg_autoplant()
-	set name = "Toggle Egg Autoplanting"
-	set desc = "Toggle if eggs automatically plant within a 5 tile radius"
-	set category = "Alien"
-	
-
 	if(!check_state())
 		return FALSE
 	if(ovipositor) // check if we are ovi, then toggle
@@ -872,3 +863,7 @@
 		else
 			egg_autoplant = TRUE
 			to_chat(src, SPAN_XENONOTICE("You enable automatic egg planting."))
+
+/datum/action/xeno_action/onclick/egg_autoplant/use_ability()
+	var/mob/living/carbon/xenomorph/queen/queen = owner
+	queen.ovi_egg_autoplant()

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -862,14 +862,13 @@
 	set desc = "Toggle if eggs automatically plant within a 5 tile radius"
 	set category = "Alien"
 	
-	var/mob/living/carbon/xenomorph/queen/queen = src
 
-	if(!queen.check_state())
+	if(!check_state())
 		return FALSE
 	if(ovipositor) // check if we are ovi, then toggle
 		if(egg_autoplant)
 			egg_autoplant = FALSE
-			to_chat(queen, SPAN_XENONOTICE("You disable automatic egg planting."))
+			to_chat(src, SPAN_XENONOTICE("You disable automatic egg planting."))
 		else
 			egg_autoplant = TRUE
-			to_chat(queen, SPAN_XENONOTICE("You enable automatic egg planting."))
+			to_chat(src, SPAN_XENONOTICE("You enable automatic egg planting."))

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -863,6 +863,9 @@
 		else
 			egg_autoplant = TRUE
 			to_chat(src, SPAN_XENONOTICE("You enable automatic egg planting."))
+	var/datum/action/xeno_action/onclick/egg_autoplant/ability = get_xeno_action_by_type(src, /datum/action/xeno_action/onclick/egg_autoplant)
+	if(ability)
+		ability.button.icon_state = egg_autoplant ? "template_active" : "template"
 
 /datum/action/xeno_action/onclick/egg_autoplant/use_ability()
 	var/mob/living/carbon/xenomorph/queen/queen = owner

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -853,3 +853,17 @@
 	set category = "Alien"
 	hive.tacmap.tgui_interact(src)
 
+/mob/living/carbon/xenomorph/queen/proc/ovi_egg_autoplant()
+	set name = "Toggle Egg Autoplanting"
+	set desc = "Toggle if eggs automatically plant within a 5 tile radius"
+	set category = "Alien"
+
+	var/mob/living/carbon/xenomorph/queen/queen = owner
+
+	if(!queen.check_state())
+		return FALSE
+	if(ovipositor) // check if we are ovi, then toggle
+		if(egg_autoplant)
+			egg_autoplant = FALSE
+		else
+			egg_autoplant = TRUE

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -279,7 +279,7 @@
 	weed_food_states = list("Queen_1","Queen_2","Queen_3")
 	weed_food_states_flipped = list("Queen_1","Queen_2","Queen_3")
 
-	// Whether eggs automatically plant
+	/// Whether eggs automatically plant
 	var/egg_autoplant = FALSE
 
 	var/breathing_counter = 0
@@ -535,6 +535,7 @@
 					if(turf.contents.len <= 25)
 						new /obj/item/xeno_egg(loc, hivenumber)  // plop an egg
 
+/// Called via Life() to automatically place eggs around the queen when egg_autoplant is true
 /mob/living/carbon/xenomorph/queen/proc/trigger_autoplant()
 	// viable turfs within surroundings we can plant eggs on
 	var/list/turf/suitable_turfs = list()
@@ -548,7 +549,7 @@
 				suitable_turfs.Add(turf)
 
 	if(suitable_turfs.len == 0)
-		to_chat(src,SPAN_XENONOTICE("There is no more suitable ground to plant eggs! Automatic planting disabled!"))
+		to_chat(src, SPAN_XENONOTICE("There is no more suitable ground to plant eggs! Automatic planting disabled!"))
 		egg_autoplant = FALSE
 		return
 
@@ -558,7 +559,7 @@
 	var/obj/effect/alien/egg/newegg = new /obj/effect/alien/egg(pick(suitable_turfs), hivenumber)
 	playsound(get_turf(src), 'sound/effects/splat.ogg', 15, 1)
 
-	src.visible_message(SPAN_XENONOTICE("[src]'s ovipositor plants the [newegg]."))
+	visible_message(SPAN_XENONOTICE("[src]'s ovipositor plants the [newegg]."))
 
 /mob/living/carbon/xenomorph/queen/get_status_tab_items()
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -552,8 +552,11 @@
 	if(suitable_turfs.len == 0)
 		to_chat(src, SPAN_XENONOTICE("There is no more suitable ground to plant eggs! Automatic planting disabled!"))
 		egg_autoplant = FALSE
+		var/datum/action/xeno_action/onclick/egg_autoplant/ability = get_xeno_action_by_type(src, /datum/action/xeno_action/onclick/egg_autoplant)
+		if(ability)
+			ability.button.icon_state = "template"
 		return
-	if(!src.check_plasma(30)) // Skip this cycle if we don't have enough plasma
+	if(!check_plasma(30)) // Skip this cycle if we don't have enough plasma
 		return
 
 	if(!do_after(src, 1 SECONDS, INTERRUPT_INCAPACITATED, BUSY_ICON_BUILD)) // mostly intended as a visual effect

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -560,14 +560,6 @@
 
 	src.visible_message(SPAN_XENONOTICE("[src]'s ovipositor plants the [newegg]."))
 
-	/**todos
-	 * run check on every tile for suitable tiles
-	 * pick a random suitable tile
-	 * if no suitable tile found, disable and return to normal egg mode
-	 * set suitable cd
-	 * maybe plant egg every 60s instead of 30
-	 */
-
 /mob/living/carbon/xenomorph/queen/get_status_tab_items()
 	. = ..()
 	var/stored_larvae = GLOB.hive_datum[hivenumber].stored_larva

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -541,10 +541,11 @@
 	var/list/turf/suitable_turfs = list()
 	// turfs within range and view
 	var/list/turf/surroundings = oview(egg_planting_range, src)
+	var/obj/effect/alien/egg/xeno_egg = /obj/effect/alien/egg // Placeholder var
 
-	for(var/turf/turf in surroundings)
+	for(var/turf/turf in surroundings) // In every tile, w check if there are weeds, that we can build there and if it can be obscured
 		var/obj/effect/alien/weeds/weeds = locate(/obj/effect/alien/weeds) in turf
-		if(check_alien_construction(turf, silent = TRUE) && weeds)
+		if(check_alien_construction(turf, silent = TRUE) && weeds && !check_if_can_be_obscured(turf,xeno_egg))
 			if(weeds.weed_strength >= WEED_LEVEL_HIVE && weeds.linked_hive.hivenumber == hivenumber)
 				suitable_turfs.Add(turf)
 
@@ -553,13 +554,16 @@
 		egg_autoplant = FALSE
 		return
 
+	if(!src.check_plasma(30)) // Skip this cycle if we don't have enough plasma
+		return
+
 	if(!do_after(src, 1 SECONDS, INTERRUPT_INCAPACITATED, BUSY_ICON_BUILD)) // mostly intended as a visual effect
 		return
 
-	var/obj/effect/alien/egg/newegg = new /obj/effect/alien/egg(pick(suitable_turfs), hivenumber)
+	var/obj/effect/alien/egg/new_egg = new(pick(suitable_turfs), hivenumber)
 	playsound(get_turf(src), 'sound/effects/splat.ogg', 15, 1)
-
-	visible_message(SPAN_XENONOTICE("[src]'s ovipositor plants the [newegg]."))
+	src.use_plasma(30)
+	visible_message(SPAN_XENONOTICE("[src]'s ovipositor plants the [new_egg]."))
 
 /mob/living/carbon/xenomorph/queen/get_status_tab_items()
 	. = ..()
@@ -868,6 +872,7 @@
 		/datum/action/xeno_action/activable/secrete_resin/remote/queen, //fifth macro
 		/datum/action/xeno_action/onclick/queen_tacmap,
 		/datum/action/xeno_action/onclick/eye,
+		/datum/action/xeno_action/onclick/egg_autoplant,
 	)
 
 	for(var/path in immobile_abilities)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -49,6 +49,7 @@
 
 	royal_caste = TRUE
 
+
 /proc/update_living_queens() // needed to update when you change a queen to a different hive
 	outer_loop:
 		var/datum/hive_status/hive
@@ -277,6 +278,9 @@
 	weed_food_icon = 'icons/mob/xenos/weeds_64x64.dmi'
 	weed_food_states = list("Queen_1","Queen_2","Queen_3")
 	weed_food_states_flipped = list("Queen_1","Queen_2","Queen_3")
+
+	// Whether eggs automatically plant
+	var/egg_autoplant = FALSE
 
 	var/breathing_counter = 0
 	var/ovipositor = FALSE //whether the Queen is attached to an ovipositor
@@ -518,13 +522,25 @@
 
 		if(ovipositor && !is_mob_incapacitated(TRUE))
 			egg_amount += 0.07 //one egg approximately every 30 seconds
-			if(egg_amount >= 1)
+			if(egg_amount >= 1 && !egg_autoplant)
 				if(isturf(loc))
 					var/turf/T = loc
 					if(T.contents.len <= 25) //so we don't end up with a million object on that turf.
 						egg_amount--
 						new /obj/item/xeno_egg(loc, hivenumber)
 
+/mob/living/carbon/xenomorph/queen/proc/trigger_autoplant
+	var/list/turf/surroundings = oview(range, src) // Fill a list of stuff in the range so we won't have to spam oview
+	for(var/turf/turf in surroundings)
+	var/list/turf/suitable_turfs
+
+	/**todos
+	 * run check on every tile for suitable tiles
+	 * pick a random suitable tile
+	 * if no suitable tile found, disable and return to normal egg mode
+	 * set suitable cd
+	 * maybe plant egg every 60s instead of 30
+	 */
 /mob/living/carbon/xenomorph/queen/get_status_tab_items()
 	. = ..()
 	var/stored_larvae = GLOB.hive_datum[hivenumber].stored_larva

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -545,7 +545,7 @@
 
 	for(var/turf/turf in surroundings) // In every tile, w check if there are weeds, that we can build there and if it can be obscured
 		var/obj/effect/alien/weeds/weeds = locate(/obj/effect/alien/weeds) in turf
-		if(check_alien_construction(turf, silent = TRUE) && weeds && !check_if_can_be_obscured(turf,xeno_egg))
+		if(check_alien_construction(turf, silent = TRUE) && weeds && !check_if_can_be_obscured(turf,xeno_egg) && !istype(get_area(turf), /area/interior))
 			if(weeds.weed_strength >= WEED_LEVEL_HIVE && weeds.linked_hive.hivenumber == hivenumber)
 				suitable_turfs.Add(turf)
 
@@ -553,7 +553,6 @@
 		to_chat(src, SPAN_XENONOTICE("There is no more suitable ground to plant eggs! Automatic planting disabled!"))
 		egg_autoplant = FALSE
 		return
-
 	if(!src.check_plasma(30)) // Skip this cycle if we don't have enough plasma
 		return
 
@@ -562,7 +561,7 @@
 
 	var/obj/effect/alien/egg/new_egg = new(pick(suitable_turfs), hivenumber)
 	playsound(get_turf(src), 'sound/effects/splat.ogg', 15, 1)
-	src.use_plasma(30)
+	use_plasma(30)
 	visible_message(SPAN_XENONOTICE("[src]'s ovipositor plants the [new_egg]."))
 
 /mob/living/carbon/xenomorph/queen/get_status_tab_items()

--- a/code/modules/mob/living/carbon/xenomorph/egg_item.dm
+++ b/code/modules/mob/living/carbon/xenomorph/egg_item.dm
@@ -84,20 +84,20 @@
 	playsound(T, 'sound/effects/splat.ogg', 15, 1)
 	qdel(src)
 
-/obj/item/xeno_egg/proc/plant_egg(mob/living/carbon/xenomorph/user, turf/T, proximity = TRUE)
+/obj/item/xeno_egg/proc/plant_egg(mob/living/carbon/xenomorph/user, turf/cur_turf, proximity = TRUE)
 	if(!proximity)
 		return // no message because usual behavior is not to show any
 	if(!user.hive)
 		to_chat(user, SPAN_XENOWARNING("Your hive cannot procreate."))
 		return
-	if(!user.check_alien_construction(T))
+	if(!user.check_alien_construction(cur_turf))
 		return
 	if(!user.check_plasma(30))
 		return
 
 	var/obj/effect/alien/weeds/hive_weeds
 	var/obj/effect/alien/weeds/any_weeds
-	for(var/obj/effect/alien/weeds/weed in T)
+	for(var/obj/effect/alien/weeds/weed in cur_turf)
 		if(weed.weed_strength >= WEED_LEVEL_HIVE && weed.linked_hive.hivenumber == hivenumber)
 			hive_weeds = weed
 			break
@@ -116,15 +116,14 @@
 		to_chat(user, SPAN_XENOWARNING("[src] can only be planted on [lowertext(hive.prefix)]hive weeds."))
 		return
 
-	if(istype(get_area(T), /area/interior))
+	if(istype(get_area(cur_turf), /area/interior))
 		to_chat(user, SPAN_XENOWARNING("[src] cannot be planted inside a vehicle."))
 		return
 
-	for(var/obj/object in T.contents)
-		var/obj/effect/alien/egg/xeno_egg = /obj/effect/alien/egg
-		if(object.layer > initial(xeno_egg.layer))
-			to_chat(user, SPAN_XENOWARNING("[src] cannot be planted below objects that would obscure it."))
-			return
+	var/obj/effect/alien/egg/xeno_egg = /obj/effect/alien/egg // Placeholder var
+	if(user.check_if_can_be_obscured(cur_turf, xeno_egg))
+		to_chat(user, SPAN_XENOWARNING("[src] cannot be planted below objects that would obscure it."))
+		return
 
 	user.visible_message(SPAN_XENONOTICE("[user] starts planting [src]."), SPAN_XENONOTICE("You start planting [src]."), null, 5)
 
@@ -135,19 +134,19 @@
 		plant_time = 10
 	if(!do_after(user, plant_time, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 		return
-	if(!user.check_alien_construction(T))
+	if(!user.check_alien_construction(cur_turf))
 		return
 	if(!user.check_plasma(30))
 		return
 
-	for(var/obj/effect/alien/weeds/weed in T)
+	for(var/obj/effect/alien/weeds/weed in cur_turf)
 		if(weed.weed_strength >= WEED_LEVEL_HIVE || !needs_hive_weeds)
 			user.use_plasma(30)
 			var/obj/effect/alien/egg/newegg
 			if(weed.weed_strength >= WEED_LEVEL_HIVE)
-				newegg = new /obj/effect/alien/egg(T, hivenumber)
+				newegg = new /obj/effect/alien/egg(cur_turf, hivenumber)
 			else if(weed.weed_strength >= WEED_LEVEL_STANDARD)
-				newegg = new /obj/effect/alien/egg/carrier_egg(T,hivenumber, user)
+				newegg = new /obj/effect/alien/egg/carrier_egg(cur_turf, hivenumber, user)
 			else
 				to_chat(user, SPAN_XENOWARNING("[src] can't be planted on these weeds."))
 				return
@@ -155,7 +154,7 @@
 			newegg.flags_embryo = flags_embryo
 
 			newegg.add_hiddenprint(user)
-			playsound(T, 'sound/effects/splat.ogg', 15, 1)
+			playsound(cur_turf, 'sound/effects/splat.ogg', 15, 1)
 			qdel(src)
 			break
 


### PR DESCRIPTION
# About the pull request
Gives the queen a verb to automatically plant eggs while on ovi . This has a cost of a slower egg laying rate. It automatically turns off if there is no more suitable space nearby.

Recommended to activate after the hive is built to avoid eggs being placed in spots you want to build stuff on.

also it doesn't auto clear hatched/destroyed eggs so xenos still have to do some roomkeeping
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Makes managing eggs much easier as queen. Also makes so you or a drone wont have to manually plant them and can focus on better things.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Totalepicness5
add: Queen can now automatically plant eggs using the 'Toggle Egg Autoplanting' ability and verb. This has a cost of laying eggs slower and consuming plasma as eggs are planted.
/:cl:
