### PR TITLE
Xenos cannot pylon working comms anymore

### DIFF
--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -306,14 +306,16 @@ GLOBAL_LIST_EMPTY(all_static_telecomms_towers)
 	else
 		update_icon()
 
+/obj/structure/machinery/telecomms/relay/preset/tower/mapcomms/update_state()
+	..()
+	if(inoperable())
+		handle_xeno_acquisition(get_turf(src))
+
 /// Handles xenos corrupting the tower when weeds touch the turf it is located on
 /obj/structure/machinery/telecomms/relay/preset/tower/mapcomms/proc/handle_xeno_acquisition(turf/weeded_turf)
 	SIGNAL_HANDLER
 
 	if(corrupted)
-		return
-
-	if(operable())
 		return
 
 	if(!weeded_turf.weeds)
@@ -329,6 +331,9 @@ GLOBAL_LIST_EMPTY(all_static_telecomms_towers)
 		return
 
 	if(SSticker.mode.is_in_endgame)
+		return
+
+	if(operable())
 		return
 
 	if(ROUND_TIME < XENO_COMM_ACQUISITION_TIME)

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -313,7 +313,7 @@ GLOBAL_LIST_EMPTY(all_static_telecomms_towers)
 	if(corrupted)
 		return
 
-	if(!inoperable())
+	if(!inoperable() || on)
 		return
 
 	if(!weeded_turf.weeds)

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -313,6 +313,9 @@ GLOBAL_LIST_EMPTY(all_static_telecomms_towers)
 	if(corrupted)
 		return
 
+	if(!inoperable())
+		return
+
 	if(!weeded_turf.weeds)
 		return
 

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -337,11 +337,11 @@ GLOBAL_LIST_EMPTY(all_static_telecomms_towers)
 		return
 
 	if(ROUND_TIME < XENO_COMM_ACQUISITION_TIME)
-		addtimer(CALLBACK(src, PROC_REF(handle_xeno_acquisition), weeded_turf), (XENO_COMM_ACQUISITION_TIME - ROUND_TIME))
+		addtimer(CALLBACK(src, PROC_REF(handle_xeno_acquisition), weeded_turf), (XENO_COMM_ACQUISITION_TIME - ROUND_TIME), TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 		return
 
 	if(!COOLDOWN_FINISHED(src, corruption_delay))
-		addtimer(CALLBACK(src, PROC_REF(handle_xeno_acquisition), weeded_turf), (COOLDOWN_TIMELEFT(src, corruption_delay)))
+		addtimer(CALLBACK(src, PROC_REF(handle_xeno_acquisition), weeded_turf), (COOLDOWN_TIMELEFT(src, corruption_delay)), TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 		return
 
 	var/obj/effect/alien/weeds/node/pylon/cluster/parent_node = weeded_turf.weeds.parent

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -313,7 +313,7 @@ GLOBAL_LIST_EMPTY(all_static_telecomms_towers)
 	if(corrupted)
 		return
 
-	if(!inoperable() || on)
+	if(operable())
 		return
 
 	if(!weeded_turf.weeds)


### PR DESCRIPTION
# About the pull request
First of all, it looks like a simple oversight. You cannot turn on pyloned comms tower, but for some reason it works the other way around — you can pylon working tower. Don't think this was intended. 

Secondly, I think it's a little too boring that you can get both pylon and working comms if you have corrupted xenos. It would be more interesting if you needed to choose between these options.

# Explain why it's good for the game
Consistency, balance, important choices.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: ihatethisengine
balance: only disabled comms can be pyloned
/:cl:
