### PR TITLE
Fixes bonus projectiles not hitting

### DIFF
--- a/code/datums/ammo/ammo.dm
+++ b/code/datums/ammo/ammo.dm
@@ -236,7 +236,7 @@
 		final_angle += rand(-total_scatter_angle, total_scatter_angle)
 		var/turf/new_target = get_angle_target_turf(curloc, final_angle, 30)
 
-		P.fire_at(new_target, original_P.firer, original_P.shot_from, P.ammo.max_range, P.ammo.shell_speed, original_P.original) //Fire!
+		P.fire_at(new_target, original_P.firer, original_P.shot_from, P.ammo.max_range, P.ammo.shell_speed, original_P.original, FALSE) //Fire!
 
 /datum/ammo/proc/drop_flame(turf/turf, datum/cause_data/cause_data) // ~Art updated fire 20JAN17
 	if(!istype(turf))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -636,6 +636,7 @@
 		return
 	. = body_position
 	body_position = new_value
+	body_position_changed = world.time
 	SEND_SIGNAL(src, COMSIG_LIVING_SET_BODY_POSITION, new_value, .)
 	if(new_value == LYING_DOWN) // From standing to lying down.
 		on_lying_down()

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -123,6 +123,8 @@
 
 	/// Variable to track the body position of a mob, regardgless of the actual angle of rotation (usually matching it, but not necessarily).
 	var/body_position = STANDING_UP
+	/// Last time the body position was changed
+	var/body_position_changed = 0
 	/// Number of degrees of rotation of a mob. 0 means no rotation, up-side facing NORTH. 90 means up-side rotated to face EAST, and so on.
 	VAR_PROTECTED/lying_angle = 0
 	/// Value of lying lying_angle before last change. TODO: Remove the need for this.

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -228,24 +228,21 @@
 		var/mob/M = firer
 		M.track_shot(weapon_cause_data.cause_name)
 
-	src.speed = speed
-
 	//If we have the right kind of ammo, we can fire several projectiles at once.
 	if(ammo.bonus_projectiles_amount && ammo.bonus_projectiles_type)
 		ammo.fire_bonus_projectiles(src)
 		bonus_projectile_check = 1 //Mark this projectile as having spawned a set of bonus projectiles.
-	else
-		// Randomize speed by a small factor to help bullet animations look okay
-		// Otherwise you get a   s   t   r   e   a   m of warping bullets in same positions
-		// Does not apply for stuff with extra projectiles as they are meant to arrive at the same time
-		src.speed *= (1 + (rand()-0.5) * 0.30) // 15.0% variance either way
-		src.speed = clamp(src.speed, 0.1, 100) // Safety to avoid loop hazards
-
 
 	path = get_line(starting, target_turf)
 	p_x += clamp((rand()-0.5)*scatter*3, -8, 8)
 	p_y += clamp((rand()-0.5)*scatter*3, -8, 8)
 	update_angle(starting, target_turf)
+
+	src.speed = speed
+	// Randomize speed by a small factor to help bullet animations look okay
+	// Otherwise you get a   s   t   r   e   a   m of warping bullets in same positions
+	src.speed *= (1 + (rand()-0.5) * 0.30) // 15.0% variance either way
+	src.speed = clamp(src.speed, 0.1, 100) // Safety to avoid loop hazards
 
 	// Also give it some headstart, flying it now ahead of tick
 	var/delta_time = world.tick_lag * rand() * 0.4

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -835,8 +835,10 @@
 //mobs use get_projectile_hit_chance instead of get_projectile_hit_boolean
 
 /mob/living/proc/get_projectile_hit_chance(obj/projectile/P)
-	if((body_position == LYING_DOWN || HAS_TRAIT(src, TRAIT_NESTED)) && src != P.original)
+	if(HAS_TRAIT(src, TRAIT_NESTED) && src != P.original)
 		return FALSE // Snowflake check for xeno nests, because we want bullets to fly through even though they're standing in it
+	if(body_position == LYING_DOWN && src != P.original && world.time - body_position_changed > 0.3 SECONDS)
+		return FALSE // Grace period of 0.3 seconds after a target is knocked down to be hit by followup projectiles
 	var/ammo_flags = P.ammo.flags_ammo_behavior | P.projectile_override_flags
 	if(ammo_flags & AMMO_XENO)
 		if((status_flags & XENO_HOST) && HAS_TRAIT(src, TRAIT_NESTED))

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -228,21 +228,24 @@
 		var/mob/M = firer
 		M.track_shot(weapon_cause_data.cause_name)
 
+	src.speed = speed
+
 	//If we have the right kind of ammo, we can fire several projectiles at once.
 	if(ammo.bonus_projectiles_amount && ammo.bonus_projectiles_type)
 		ammo.fire_bonus_projectiles(src)
 		bonus_projectile_check = 1 //Mark this projectile as having spawned a set of bonus projectiles.
+	else
+		// Randomize speed by a small factor to help bullet animations look okay
+		// Otherwise you get a   s   t   r   e   a   m of warping bullets in same positions
+		// Does not apply for stuff with extra projectiles as they are meant to arrive at the same time
+		src.speed *= (1 + (rand()-0.5) * 0.30) // 15.0% variance either way
+		src.speed = clamp(src.speed, 0.1, 100) // Safety to avoid loop hazards
+
 
 	path = get_line(starting, target_turf)
 	p_x += clamp((rand()-0.5)*scatter*3, -8, 8)
 	p_y += clamp((rand()-0.5)*scatter*3, -8, 8)
 	update_angle(starting, target_turf)
-
-	src.speed = speed
-	// Randomize speed by a small factor to help bullet animations look okay
-	// Otherwise you get a   s   t   r   e   a   m of warping bullets in same positions
-	src.speed *= (1 + (rand()-0.5) * 0.30) // 15.0% variance either way
-	src.speed = clamp(src.speed, 0.1, 100) // Safety to avoid loop hazards
 
 	// Also give it some headstart, flying it now ahead of tick
 	var/delta_time = world.tick_lag * rand() * 0.4

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -187,7 +187,7 @@
 	return damage
 
 // Target, firer, shot from (i.e. the gun), projectile range, projectile speed, original target (who was aimed at, not where projectile is going towards)
-/obj/projectile/proc/fire_at(atom/target, atom/F, atom/S, range = 30, speed = 1, atom/original_override)
+/obj/projectile/proc/fire_at(atom/target, atom/F, atom/S, range = 30, speed = 1, atom/original_override, speed_varience = TRUE)
 	SHOULD_NOT_SLEEP(TRUE)
 	original = original || original_override || target
 	if(!loc)
@@ -230,6 +230,7 @@
 
 	//If we have the right kind of ammo, we can fire several projectiles at once.
 	if(ammo.bonus_projectiles_amount && ammo.bonus_projectiles_type)
+		speed_varience = FALSE
 		ammo.fire_bonus_projectiles(src)
 		bonus_projectile_check = 1 //Mark this projectile as having spawned a set of bonus projectiles.
 
@@ -241,8 +242,9 @@
 	src.speed = speed
 	// Randomize speed by a small factor to help bullet animations look okay
 	// Otherwise you get a   s   t   r   e   a   m of warping bullets in same positions
-	src.speed *= (1 + (rand()-0.5) * 0.30) // 15.0% variance either way
-	src.speed = clamp(src.speed, 0.1, 100) // Safety to avoid loop hazards
+	if (speed_varience)
+		src.speed *= (1 + (rand()-0.5) * 0.30) // 15.0% variance either way
+		src.speed = clamp(src.speed, 0.1, 100) // Safety to avoid loop hazards
 
 	// Also give it some headstart, flying it now ahead of tick
 	var/delta_time = world.tick_lag * rand() * 0.4
@@ -837,7 +839,7 @@
 /mob/living/proc/get_projectile_hit_chance(obj/projectile/P)
 	if(HAS_TRAIT(src, TRAIT_NESTED) && src != P.original)
 		return FALSE // Snowflake check for xeno nests, because we want bullets to fly through even though they're standing in it
-	if(body_position == LYING_DOWN && src != P.original && world.time - body_position_changed > 0.3 SECONDS)
+	if(body_position == LYING_DOWN && src != P.original && world.time - body_position_changed > 0.1 SECONDS)
 		return FALSE // Grace period of 0.3 seconds after a target is knocked down to be hit by followup projectiles
 	var/ammo_flags = P.ammo.flags_ammo_behavior | P.projectile_override_flags
 	if(ammo_flags & AMMO_XENO)


### PR DESCRIPTION
# About the pull request
#1608 added random speed variance to projectiles to make them look less beamy however some projectiles and most notably buckshot requires all projectiles to be of equal speed because the main projectile causes a stun which will make the rest of the projectiles miss if they don't hit first.

Potentially fixes #3053 and #1764 
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Fixes a bug
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixes bonus projectiles not hitting sometimes
/:cl:
