### PR TITLE
ARC features

### DIFF
--- a/code/datums/supply_packs/vehicle_equipment.dm
+++ b/code/datums/supply_packs/vehicle_equipment.dm
@@ -7,3 +7,13 @@
 	containertype = /obj/structure/closet/crate/weapon
 	containername = "RE700 Rotary Cannon crate"
 	group = "Vehicle Equipment"
+
+/datum/supply_packs/driving_manual
+	name = "Standard Issue Driving Manual (x1)"
+	contains = list(
+		/obj/item/pamphlet/skill/vc,
+	)
+	cost = 50
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "Driving Manual crate"
+	group = "Vehicle Equipment"

--- a/code/modules/vehicles/arc/arc.dm
+++ b/code/modules/vehicles/arc/arc.dm
@@ -17,7 +17,7 @@
 
 	interior_map = /datum/map_template/interior/arc
 
-	passengers_slots = 3
+	passengers_slots = 4
 	xenos_slots = 5
 
 	entrances = list(
@@ -28,6 +28,7 @@
 	entrance_speed = 0.5 SECONDS
 
 	required_skill = SKILL_VEHICLE_LARGE
+	driving_access = ACCESS_MARINE_COMMAND
 
 	movement_sound = 'sound/vehicles/tank_driving.ogg'
 

--- a/code/modules/vehicles/interior/interactable/seats.dm
+++ b/code/modules/vehicles/interior/interactable/seats.dm
@@ -18,7 +18,6 @@
 
 	// Which vehicle skill level required to use this
 	var/required_skill = SKILL_VEHICLE_SMALL
-	req_access = list()
 
 /obj/structure/bed/chair/comfy/vehicle/ex_act()
 	return
@@ -80,8 +79,8 @@
 		if(target == user)
 			to_chat(user, SPAN_WARNING("You have no idea how to drive this thing!"))
 		return FALSE
-	if(!allowed(target))
-		to_chat(user, SPAN_WARNING("The driving console blinks as it refuses your ID, Access Denied"))
+	if(!allowed(target) && !isxeno(target)) // xenos cant hold IDs DUH
+		to_chat(user, SPAN_WARNING("The driving console blinks as it refuses your ID"))
 		return FALSE
 	if(vehicle)
 		vehicle.vehicle_faction = target.faction

--- a/code/modules/vehicles/interior/interactable/seats.dm
+++ b/code/modules/vehicles/interior/interactable/seats.dm
@@ -18,6 +18,7 @@
 
 	// Which vehicle skill level required to use this
 	var/required_skill = SKILL_VEHICLE_SMALL
+	req_access = list()
 
 /obj/structure/bed/chair/comfy/vehicle/ex_act()
 	return
@@ -79,7 +80,9 @@
 		if(target == user)
 			to_chat(user, SPAN_WARNING("You have no idea how to drive this thing!"))
 		return FALSE
-
+	if(!allowed(target))
+		to_chat(user, SPAN_WARNING("The driving console blinks as it refuses your ID, Access Denied"))
+		return FALSE
 	if(vehicle)
 		vehicle.vehicle_faction = target.faction
 

--- a/code/modules/vehicles/interior/interior_landmarks.dm
+++ b/code/modules/vehicles/interior/interior_landmarks.dm
@@ -71,6 +71,7 @@
 	S.layer = layer
 	S.vehicle = I.exterior
 	S.required_skill = S.vehicle.required_skill
+	S.req_access += S.vehicle.driving_access
 	S.setDir(dir)
 	S.alpha = alpha
 	S.update_icon()
@@ -116,6 +117,7 @@
 	S.icon_state = icon_state
 	S.vehicle = I.exterior
 	S.required_skill = S.vehicle.required_skill
+	S.req_access += S.vehicle.driving_access
 	S.setDir(dir)
 	S.update_icon()
 	S.alpha = alpha

--- a/code/modules/vehicles/multitile/multitile.dm
+++ b/code/modules/vehicles/multitile/multitile.dm
@@ -65,7 +65,7 @@
 
 	// The amount of skill required to drive the vehicle
 	var/required_skill = SKILL_VEHICLE_SMALL
-
+	var/driving_access = null
 
 	req_access = list() //List of accesses you need to enter
 	req_one_access = list() //List of accesses you need one of to enter


### PR DESCRIPTION

# About the pull request
- Adds support for custom access requirements for the driving seat ( something like a key )
- increases the ARC passeger amount to 4
- Adds Command Access lock for the ARC driver.
- Adds a pamphlet crate with driving skill on requisitions.

# Explain why it's good for the game

-Adds more flexibility to the ARC in cases where there may not be 2 SOs available or they preffer a different driver. to focus more on Commanding inside of the ARC.
-Prevents future funnsies from happening . you now require a Access to drive the ARC meaning . only people granted access by command may drive the ARC. (( can be changed to ACCESS_CREWMAN in the future or even create custom "keys"))
-adds one more passenger to the ARC  so marines can retrieve the 3 corpses inside or someone can enter to talk .. etc . the extra slot is meant for a passerby therefore no seat will be added.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: ARC now has a Generic Command access lock for the driver seat
add: Adds a a pamplet crate containing 1 pamplet for the ARC for 5000$
balance: increased ARC capacity to 4
code: Added support for Access locks on Vehicles
/:cl:
