### PR TITLE
Restraints now show up on examine.

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -162,10 +162,10 @@
 
 	//Restraints
 	if(handcuffed)
-		msg += SPAN_ORANGE("[t_his] arms are restrained by [handcuffed].\n")
+		msg += SPAN_ORANGE("[capitalize(t_his)] arms are restrained by [handcuffed].\n")
 
 	if(legcuffed)
-		msg += SPAN_ORANGE("[t_his] ankles are restrained by [legcuffed].\n")
+		msg += SPAN_ORANGE("[capitalize(t_his)] ankles are restrained by [legcuffed].\n")
 
 	//Admin-slept
 	if(sleeping > 8000000)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -160,6 +160,13 @@
 	if(wear_id)
 		msg += "[t_He] [t_is] [wear_id.get_examine_location(src, user, WEAR_ID, t_He, t_his, t_him, t_has, t_is)].\n"
 
+	//Restraints
+	if(handcuffed)
+		msg += SPAN_ORANGE("[t_He] arms are restrained by [handcuffed].\n")
+
+	if(legcuffed)
+		msg += SPAN_ORANGE("[t_He] ankles are restrained by [legcuffed].\n")
+
 	//Admin-slept
 	if(sleeping > 8000000)
 		msg += SPAN_HIGHDANGER("<B>This player has been slept by staff.</B>\n")

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -162,10 +162,10 @@
 
 	//Restraints
 	if(handcuffed)
-		msg += SPAN_ORANGE("[t_He] arms are restrained by [handcuffed].\n")
+		msg += SPAN_ORANGE("[t_his] arms are restrained by [handcuffed].\n")
 
 	if(legcuffed)
-		msg += SPAN_ORANGE("[t_He] ankles are restrained by [legcuffed].\n")
+		msg += SPAN_ORANGE("[t_his] ankles are restrained by [legcuffed].\n")
 
 	//Admin-slept
 	if(sleeping > 8000000)


### PR DESCRIPTION

# About the pull request

As title says, this makes handcuffs/legcuffs appear on examine.

# Explain why it's good for the game

Depending on various overlapping sprites/locations, it can be difficult to tell if someone is restrained just by looking at them. This adds to examine something that should have been there to start with.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Handcuffs & Legcuffs now appear on examine.
/:cl:
