### PR TITLE
Boosting now works with fire properties

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -78,7 +78,9 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 		P.reset_reagent()
 
 	for(var/datum/chem_property/P in properties)
-		P.update_reagent()
+		var/mods = handle_pre_processing()
+		var/potency = mods[REAGENT_EFFECT] * ((P.level+mods[REAGENT_BOOST]) * 0.5)
+		P.update_reagent(potency)
 
 	for(var/datum/chem_property/P in properties)
 		P.post_update_reagent()

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -78,9 +78,12 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 		P.reset_reagent()
 
 	for(var/datum/chem_property/P in properties)
-		var/mods = handle_pre_processing()
-		var/potency = mods[REAGENT_EFFECT] * ((P.level+mods[REAGENT_BOOST]) * 0.5)
-		P.update_reagent(potency)
+		if(P.name == PROPERTY_BOOSTING)
+			var/boost = P.pre_process()
+			var/potency = boost[REAGENT_EFFECT] * ((P.level+boost[REAGENT_BOOST]) * 0.5)
+			P.update_reagent(potency)
+		else
+			P.update_reagent()
 
 	for(var/datum/chem_property/P in properties)
 		P.post_update_reagent()

--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -705,7 +705,7 @@
 
 	..()
 
-/datum/chem_property/positive/fire/update_reagent(potency)
+/datum/chem_property/positive/fire/update_reagent(potency = 1)
 	holder.chemfiresupp = TRUE
 
 	holder.radiusmod += radiusmod_per_level * potency * 2

--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -705,16 +705,16 @@
 
 	..()
 
-/datum/chem_property/positive/fire/update_reagent()
+/datum/chem_property/positive/fire/update_reagent(potency)
 	holder.chemfiresupp = TRUE
 
-	holder.radiusmod += radiusmod_per_level * level
-	holder.durationmod += durationmod_per_level * level
-	holder.intensitymod += intensitymod_per_level * level
+	holder.radiusmod += radiusmod_per_level * potency * 2
+	holder.durationmod += durationmod_per_level * potency * 2
+	holder.intensitymod += intensitymod_per_level * potency * 2
 
-	holder.rangefire += range_per_level * level
-	holder.durationfire += duration_per_level * level
-	holder.intensityfire += intensity_per_level * level
+	holder.rangefire += range_per_level * potency * 2
+	holder.durationfire += duration_per_level * potency * 2
+	holder.intensityfire += intensity_per_level * potency * 2
 
 	..()
 


### PR DESCRIPTION

# About the pull request
fixes boosting not working with fire properties

# Explain why it's good for the game
boosting should work for all properties

# Testing Photographs and Procedure
make a custom chem with Oxidizing 5 and Boosting 3

oxidizing increases the intensity by 6 per level. without the fix we see that its at 30.

![without fix](https://github.com/cmss13-devs/cmss13/assets/140007537/12f4888b-864d-46b7-97c1-baf9cf0b5056)

with the fix its at the proper 48

![with fix](https://github.com/cmss13-devs/cmss13/assets/140007537/802e7f04-f400-4aaf-be15-452261dd744f)

# Changelog
:cl:
fix: Boosting now works with fire properties.
/:cl:
