### PR TITLE
lets you dig out shrapnel with the throwing knife (+ screwdriver)

### DIFF
--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -50,6 +50,7 @@
 	throw_range = 5
 	matter = list("metal" = 75)
 	attack_verb = list("stabbed")
+	flags_item = CAN_DIG_SHRAPNEL
 	inherent_traits = list(TRAIT_TOOL_SCREWDRIVER)
 
 

--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -125,6 +125,7 @@
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	flags_equip_slot = SLOT_STORE|SLOT_FACE
 	flags_armor_protection = SLOT_FACE
+	flags_item = CAN_DIG_SHRAPNEL
 
 /obj/item/weapon/unathiknife
 	name = "duelling knife"


### PR DESCRIPTION
# About the pull request

does what it says on the tin, found this to be mildly irritating that you couldn't do it

# Explain why it's good for the game

mostly a convenience thing, lets marines eschew the normal bayonet boot knife for a throwable if they prefer without having to carry the bayonet in their webbing or rip the one off their gun every time. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
add: you can now remove shrapnel from your body with the M11 Throwing Knife and screwdrivers
/:cl:

