### PR TITLE
Fixes infinite lifeboat alarm after queen locking

### DIFF
--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -440,6 +440,8 @@
 			lifeboat.status = LIFEBOAT_LOCKED
 			lifeboat.available = FALSE
 			lifeboat.set_mode(SHUTTLE_IDLE)
+			lifeboat.alarm_sound_loop?.stop()
+			lifeboat.playing_launch_announcement_alarm = FALSE
 			var/obj/docking_port/stationary/lifeboat_dock/lifeboat_dock = lifeboat.get_docked()
 			lifeboat_dock.open_dock()
 			xeno_message(SPAN_XENOANNOUNCE("We have wrested away control of one of the metal birds! They shall not escape!"), 3, xeno.hivenumber)


### PR DESCRIPTION

# About the pull request
Fixes infinite lifeboat alarm after queen locking

# Explain why it's good for the game
Fixes infinite lifeboat alarm after queen locking


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: ihatethisengine
fix: Fixes infinite lifeboat alarm after queen locking
/:cl:
