### PR TITLE
Handheld distress beacons now require a reason input.

### DIFF
--- a/code/game/objects/items/handheld_distress_beacon.dm
+++ b/code/game/objects/items/handheld_distress_beacon.dm
@@ -37,7 +37,11 @@
 
 	if(active)
 		to_chat(user, "[src] is already active!")
-		return
+		return FALSE
+	var/reason = tgui_input_text(user, "What is the reason for activating this beacon?", "Distress Reason")
+	if(!reason)
+		return FALSE
+
 	active = TRUE
 	update_icon()
 
@@ -52,7 +56,7 @@
 	for(var/client/admin_client in GLOB.admins)
 		if((R_ADMIN|R_MOD) & admin_client.admin_holder.rights)
 			playsound_client(admin_client,'sound/effects/sos-morse-code.ogg',10)
-	message_admins("[key_name(user)] has used a [beacon_type]! [CC_MARK(user)] [beacon_call_buttons](<A HREF='?_src_=admin_holder;[HrefToken(forceGlobal = TRUE)];deny_distress_handheld=\ref[user]'>DENY</A>) [ADMIN_JMP_USER(user)] [CC_REPLY(user)]")
+	message_admins("[key_name(user)] has used a [beacon_type] for the reason '[SPAN_ORANGE(reason)]'! [CC_MARK(user)] [beacon_call_buttons](<A HREF='?_src_=admin_holder;[HrefToken(forceGlobal = TRUE)];deny_distress_handheld=\ref[user]'>DENY</A>) [ADMIN_JMP_USER(user)] [CC_REPLY(user)]")
 	to_chat(user, SPAN_NOTICE("A distress beacon request has been sent to [recipient]."))
 
 /// CMB distress beacon held by CMB Marshal for signalling distress to Anchorpoint Station


### PR DESCRIPTION

# About the pull request
We get a lot of people that trigger the beacons without any apparent reason, no faxes or anything like that, so we have no idea WHY they want whatever they're calling for. In some cases like with CMB ERT it can be more obvious, but this just makes things simpler.

# Explain why it's good for the game

Stops people spamming them for no reason & gives admins some QOL


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Added a reason input field to handheld distress beacons.
/:cl:
