### PR TITLE
ceil(x) conversion for 515

### DIFF
--- a/code/__DEFINES/_math.dm
+++ b/code/__DEFINES/_math.dm
@@ -12,9 +12,7 @@
 #define LEFT 1
 #define RIGHT 2
 
-#define CEILING(x, y) ( -round(-(x) / (y)) * (y) )
-
-#define ROUND_UP(x) ( -round(-(x)))
+#define CEILING(x, y) ( ceil((x) / (y)) * (y) )
 
 // round() acts like floor(x, 1) by default but can't handle other values
 #define FLOOR(x, y) ( round((x) / (y)) * (y) )

--- a/code/__HELPERS/#maths.dm
+++ b/code/__HELPERS/#maths.dm
@@ -8,7 +8,6 @@ GLOBAL_LIST_INIT(sqrtTable, list(1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 4,
 
 // MATH DEFINES
 
-#define Ceiling(x) (-round(-(x)))
 #define CLAMP01(x) (clamp((x), 0, 1))
 
 // cotangent

--- a/code/__HELPERS/_time.dm
+++ b/code/__HELPERS/_time.dm
@@ -48,7 +48,7 @@ GLOBAL_VAR_INIT(rollovercheck_last_timeofday, 0)
 	return gameTimestamp("mm:ss", time)
 
 /proc/time_left_until(target_time, current_time, time_unit)
-	return Ceiling(target_time - current_time) / time_unit
+	return ceil(target_time - current_time) / time_unit
 
 /proc/text2duration(text = "00:00") // Attempts to convert time text back to time value
 	var/split_text = splittext(text, ":")

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1060,7 +1060,7 @@ GLOBAL_DATUM(action_purple_power_up, /image)
 
 	var/cur_user_zone_sel = busy_user.zone_selected
 	var/cur_target_zone_sel
-	var/delayfraction = Ceiling(delay/numticks)
+	var/delayfraction = ceil(delay/numticks)
 	var/user_orig_loc = busy_user.loc
 	var/user_orig_turf = get_turf(busy_user)
 	var/target_orig_loc
@@ -1562,7 +1562,7 @@ GLOBAL_LIST_INIT(WALLITEMS, list(
 	. = 0
 	var/i = DS2TICKS(initial_delay)
 	do
-		. += Ceiling(i*DELTA_CALC)
+		. += ceil(i*DELTA_CALC)
 		sleep(i*world.tick_lag*DELTA_CALC)
 		i *= 2
 	while (TICK_USAGE > min(TICK_LIMIT_TO_RUN, Master.current_ticklimit))
@@ -1665,7 +1665,7 @@ GLOBAL_LIST_INIT(WALLITEMS, list(
 
 	// Redistribute the net displacement evenly on the side of the center line that needs it
 	// Only half the points are gonna be affected.
-	var/to_redistribute = abs(Ceiling(net_displacement / (variances.len/2)))
+	var/to_redistribute = abs(ceil(net_displacement / (variances.len/2)))
 	for(var/i in 1 to variances.len)
 		if(!net_displacement)
 			break

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -583,7 +583,7 @@ SUBSYSTEM_DEF(timer)
 			be supported and may refuse to run or run with a 0 wait")
 
 	if (flags & TIMER_CLIENT_TIME) // REALTIMEOFDAY has a resolution of 1 decisecond
-		wait = max(Ceiling(wait), 1) // so if we use tick_lag timers may be inserted in the "past"
+		wait = max(ceil(wait), 1) // so if we use tick_lag timers may be inserted in the "past"
 	else
 		wait = max(CEILING(wait, world.tick_lag), world.tick_lag)
 

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -125,11 +125,11 @@
 		//Position the effect so the beam is one continous line
 		var/a
 		if(abs(Pixel_x)>world.icon_size)
-			a = Pixel_x > 0 ? round(Pixel_x/32) : Ceiling(Pixel_x/world.icon_size)
+			a = Pixel_x > 0 ? round(Pixel_x/32) : ceil(Pixel_x/world.icon_size)
 			X.x += a
 			Pixel_x %= world.icon_size
 		if(abs(Pixel_y)>world.icon_size)
-			a = Pixel_y > 0 ? round(Pixel_y/32) : Ceiling(Pixel_y/world.icon_size)
+			a = Pixel_y > 0 ? round(Pixel_y/32) : ceil(Pixel_y/world.icon_size)
 			X.y += a
 			Pixel_y %= world.icon_size
 

--- a/code/datums/components/overlay_lighting.dm
+++ b/code/datums/components/overlay_lighting.dm
@@ -340,7 +340,7 @@
 		turn_off()
 	range = clamp(CEILING(new_range, 0.5), 1, 7)
 	var/pixel_bounds = ((range - 1) * 64) + 32
-	lumcount_range = Ceiling(range)
+	lumcount_range = ceil(range)
 	if(current_holder && overlay_lighting_flags & LIGHTING_ON)
 		current_holder.underlays -= visible_mask
 	visible_mask.icon = light_overlays["[pixel_bounds]"]

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -205,7 +205,7 @@ GLOBAL_LIST_INIT(advance_cures, list(
 		hidden = list( (properties["stealth"] > 2), (properties["stealth"] > 3) )
 		// The more symptoms we have, the less transmittable it is but some symptoms can make up for it.
 		SetSpread(clamp(properties["transmittable"] - symptoms.len, BLOOD, AIRBORNE))
-		permeability_mod = max(Ceiling(0.4 * properties["transmittable"]), 1)
+		permeability_mod = max(ceil(0.4 * properties["transmittable"]), 1)
 		cure_chance = 15 - clamp(properties["resistance"], -5, 5) // can be between 10 and 20
 		stage_prob = max(properties["stage_rate"], 2)
 		SetSeverity(properties["severity"])

--- a/code/game/objects/items/devices/motion_detector.dm
+++ b/code/game/objects/items/devices/motion_detector.dm
@@ -270,9 +270,9 @@
 		var/view_y_offset = 0
 		if(c_view > 7)
 			if(user.client.pixel_x >= 0) view_x_offset = round(user.client.pixel_x/32)
-			else view_x_offset = Ceiling(user.client.pixel_x/32)
+			else view_x_offset = ceil(user.client.pixel_x/32)
 			if(user.client.pixel_y >= 0) view_y_offset = round(user.client.pixel_y/32)
-			else view_y_offset = Ceiling(user.client.pixel_y/32)
+			else view_y_offset = ceil(user.client.pixel_y/32)
 
 		var/diff_dir_x = 0
 		var/diff_dir_y = 0

--- a/code/game/objects/items/reagent_containers/food/sandwich.dm
+++ b/code/game/objects/items/reagent_containers/food/sandwich.dm
@@ -74,7 +74,7 @@
 
 	name = lowertext("[fullname] sandwich")
 	if(length(name) > 80) name = "[pick(list("absurd","colossal","enormous","ridiculous"))] sandwich"
-	w_class = Ceiling(clamp((ingredients.len/2),1,3))
+	w_class = ceil(clamp((ingredients.len/2),1,3))
 
 /obj/item/reagent_container/food/snacks/csandwich/Destroy()
 	QDEL_NULL_LIST(ingredients)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -127,7 +127,7 @@
 			var/obj/item/explosive/plastic/P = I
 			if(P.active)
 				continue
-		var/item_size = Ceiling(I.w_class / 2)
+		var/item_size = ceil(I.w_class / 2)
 		if(stored_units + item_size > storage_capacity)
 			continue
 		if(!I.anchored)

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -1036,7 +1036,7 @@ INITIALIZE_IMMEDIATE(/turf/closed/wall/indestructible/splashscreen)
 	SPAN_XENONOTICE("You claw \the [src]."))
 	playsound(src, "alien_resin_break", 25)
 	if (M.hivenumber == hivenumber)
-		take_damage(Ceiling(HEALTH_WALL_XENO * 0.25)) //Four hits for a regular wall
+		take_damage(ceil(HEALTH_WALL_XENO * 0.25)) //Four hits for a regular wall
 	else
 		take_damage(M.melee_damage_lower*RESIN_XENO_DAMAGE_MULTIPLIER)
 	return XENO_ATTACK_ACTION
@@ -1252,7 +1252,7 @@ INITIALIZE_IMMEDIATE(/turf/closed/wall/indestructible/splashscreen)
 	SPAN_XENONOTICE("We claw \the [src]."))
 	playsound(src, "alien_resin_break", 25)
 	if (M.hivenumber == hivenumber)
-		take_damage(Ceiling(HEALTH_WALL_XENO * 0.25)) //Four hits for a regular wall
+		take_damage(ceil(HEALTH_WALL_XENO * 0.25)) //Four hits for a regular wall
 	else
 		take_damage(M.melee_damage_lower*RESIN_XENO_DAMAGE_MULTIPLIER)
 	return XENO_ATTACK_ACTION

--- a/code/modules/clans/client.dm
+++ b/code/modules/clans/client.dm
@@ -440,7 +440,7 @@
 									return
 							if(CLAN_LIMIT_SIZE)
 								var/list/datum/view_record/clan_playerbase_view/clan_players = DB_VIEW(/datum/view_record/clan_playerbase_view/, DB_COMP("clan_id", DB_EQUALS, target.clan_id))
-								var/available_slots = Ceiling(clan_players.len / chosen_rank.limit)
+								var/available_slots = ceil(clan_players.len / chosen_rank.limit)
 
 								if(players_in_rank >= available_slots)
 									to_chat(src, SPAN_DANGER("This slot is full! (Maximum of [chosen_rank.limit] per player in the clan, currently [available_slots])"))

--- a/code/modules/cm_tech/techs/marine/tier4/nuke.dm
+++ b/code/modules/cm_tech/techs/marine/tier4/nuke.dm
@@ -36,10 +36,10 @@
 		return
 
 	if(ROUND_TIME < NUKE_UNLOCK_TIME)
-		to_chat(unlocking_mob, SPAN_WARNING("You cannot purchase this node before [Ceiling((NUKE_UNLOCK_TIME + SSticker.round_start_time) / (1 MINUTES))] minutes into the operation."))
+		to_chat(unlocking_mob, SPAN_WARNING("You cannot purchase this node before [ceil((NUKE_UNLOCK_TIME + SSticker.round_start_time) / (1 MINUTES))] minutes into the operation."))
 		return FALSE
 
 	return TRUE
 
 /datum/tech/nuke/proc/handle_description()
-	desc = "Purchase a nuclear device. Only purchasable [Ceiling((NUKE_UNLOCK_TIME + SSticker.round_start_time) / (1 MINUTES))] minutes into the operation. It's the only way to be sure."
+	desc = "Purchase a nuclear device. Only purchasable [ceil((NUKE_UNLOCK_TIME + SSticker.round_start_time) / (1 MINUTES))] minutes into the operation. It's the only way to be sure."

--- a/code/modules/cm_tech/techtree.dm
+++ b/code/modules/cm_tech/techtree.dm
@@ -95,7 +95,7 @@
 
 		y_offset += 3
 
-	entrance = locate(Ceiling((longest_tier*2 + 1)*0.5), 2, zlevel.z_value)
+	entrance = locate(ceil((longest_tier*2 + 1)*0.5), 2, zlevel.z_value)
 
 /datum/techtree/ui_status(mob/user, datum/ui_state/state)
 	. = ..()

--- a/code/modules/lighting/lighting_mask/shadow_calculator.dm
+++ b/code/modules/lighting/lighting_mask/shadow_calculator.dm
@@ -95,7 +95,7 @@
 	SSlighting.total_shadow_calculations ++
 
 	//Ceiling the range since we need it in integer form
-	var/range = Ceiling(radius)
+	var/range = ceil(radius)
 	DO_SOMETHING_IF_DEBUGGING_SHADOWS(var/timer = TICK_USAGE)
 
 	//Work out our position

--- a/code/modules/lighting/lighting_static/static_lighting_source.dm
+++ b/code/modules/lighting/lighting_static/static_lighting_source.dm
@@ -223,8 +223,8 @@
 	var/list/turf/turfs = list()
 	if (source_turf)
 		var/oldlum = source_turf.luminosity
-		source_turf.luminosity = Ceiling(light_range)
-		for(var/turf/T in view(Ceiling(light_range), source_turf))
+		source_turf.luminosity = ceil(light_range)
+		for(var/turf/T in view(ceil(light_range), source_turf))
 			if(!IS_OPAQUE_TURF(T))
 				if (!T.lighting_corners_initialised)
 					T.static_generate_missing_corners()

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -612,7 +612,7 @@
 
 		// We're gonna skip all the entries above the upper x, or maxx if cropMap is set
 		var/x_target = line_len - key_len + 1
-		var/x_step_count = ROUND_UP(x_target / key_len)
+		var/x_step_count = ceil(x_target / key_len)
 		var/final_x = relative_x + (x_step_count - 1)
 		var/x_delta_with = x_upper
 		if(crop_map)

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -601,10 +601,10 @@
 			effective_total++
 
 	// Tier 3 slots are always 20% of the total xenos in the hive
-	slots[TIER_3][OPEN_SLOTS] = max(0, Ceiling(0.20*effective_total/tier_slot_multiplier) - used_tier_3_slots)
+	slots[TIER_3][OPEN_SLOTS] = max(0, ceil(0.20*effective_total/tier_slot_multiplier) - used_tier_3_slots)
 	// Tier 2 slots are between 30% and 50% of the hive, depending
 	// on how many T3s there are.
-	slots[TIER_2][OPEN_SLOTS] = max(0, Ceiling(0.5*effective_total/tier_slot_multiplier) - used_tier_2_slots - used_tier_3_slots)
+	slots[TIER_2][OPEN_SLOTS] = max(0, ceil(0.5*effective_total/tier_slot_multiplier) - used_tier_2_slots - used_tier_3_slots)
 
 	return slots
 
@@ -726,7 +726,7 @@
 		if(is_mainship_level(turf?.z))
 			shipside_humans_weighted_count += GLOB.RoleAuthority.calculate_role_weight(job)
 	hijack_burrowed_surge = TRUE
-	hijack_burrowed_left = max(Ceiling(shipside_humans_weighted_count * 0.5) - xenos_count, 5)
+	hijack_burrowed_left = max(ceil(shipside_humans_weighted_count * 0.5) - xenos_count, 5)
 	hivecore_cooldown = FALSE
 	xeno_message(SPAN_XENOBOLDNOTICE("The weeds have recovered! A new hive core can be built!"),3,hivenumber)
 

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -251,7 +251,7 @@
 				hud_used.alien_armor_display.icon_state = "armor_00"
 		return TRUE
 
-	var/severity = HUD_PAIN_STATES_XENO - Ceiling(((max(health, 0) / maxHealth) * HUD_PAIN_STATES_XENO))
+	var/severity = HUD_PAIN_STATES_XENO - ceil(((max(health, 0) / maxHealth) * HUD_PAIN_STATES_XENO))
 	if(severity)
 		overlay_fullscreen("xeno_pain", /atom/movable/screen/fullscreen/xeno_pain, severity)
 	else
@@ -271,7 +271,7 @@
 		return TRUE
 
 	if(hud_used.healths)
-		var/health_stacks = Ceiling((health / maxHealth) * HUD_HEALTH_STATES_XENO)
+		var/health_stacks = ceil((health / maxHealth) * HUD_HEALTH_STATES_XENO)
 		hud_used.healths.icon_state = "health_[health_stacks]"
 		if(health_stacks >= HUD_HEALTH_STATES_XENO)
 			hud_used.healths.icon_state = "health_full"
@@ -283,7 +283,7 @@
 			hud_used.alien_plasma_display.icon_state = "power_display_empty"
 		else
 			var/plasma_stacks = (get_plasma_percentage() * 0.01) * HUD_PLASMA_STATES_XENO
-			hud_used.alien_plasma_display.icon_state = "power_display_[Ceiling(plasma_stacks)]"
+			hud_used.alien_plasma_display.icon_state = "power_display_[ceil(plasma_stacks)]"
 			if(plasma_stacks >= HUD_PLASMA_STATES_XENO)
 				hud_used.alien_plasma_display.icon_state = "power_display_full"
 			else if(plasma_stacks <= 0)

--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -327,7 +327,7 @@
 		return
 
 	var/health_threshold
-	health_threshold = max(Ceiling((health * 4) / (maxHealth)), 0) //From 0 to 4, in 25% chunks
+	health_threshold = max(ceil((health * 4) / (maxHealth)), 0) //From 0 to 4, in 25% chunks
 	if(health > HEALTH_THRESHOLD_DEAD)
 		if(health_threshold > 3)
 			wound_icon_holder.icon_state = "none"

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -410,7 +410,7 @@
 
 	switch(client.prefs?.pain_overlay_pref_level)
 		if(PAIN_OVERLAY_IMPAIR)
-			overlay_fullscreen("eye_blur", /atom/movable/screen/fullscreen/impaired, Ceiling(clamp(eye_blurry * 0.3, 1, 6)))
+			overlay_fullscreen("eye_blur", /atom/movable/screen/fullscreen/impaired, ceil(clamp(eye_blurry * 0.3, 1, 6)))
 		if(PAIN_OVERLAY_LEGACY)
 			overlay_fullscreen("eye_blur", /atom/movable/screen/fullscreen/blurry)
 		else // PAIN_OVERLAY_BLURRY

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -110,7 +110,7 @@
 
 	wound_icon_holder.layer = layer + 0.01
 	wound_icon_holder.dir = dir
-	var/health_threshold = max(Ceiling((health * 4) / (maxHealth)), 0) //From 0 to 4, in 25% chunks
+	var/health_threshold = max(ceil((health * 4) / (maxHealth)), 0) //From 0 to 4, in 25% chunks
 	if(health > HEALTH_THRESHOLD_DEAD)
 		if(health_threshold > 3)
 			wound_icon_holder.icon_state = "none"

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -224,7 +224,7 @@ GLOBAL_LIST_INIT(limb_types_by_name, list(
 	if(strength < 1)
 		return phrase
 	else
-		strength = Ceiling(strength/5)
+		strength = ceil(strength/5)
 
 	var/list/split_phrase = text2list(phrase," ") //Split it up into words.
 	var/list/unstuttered_words = split_phrase.Copy()

--- a/code/modules/reagents/chemistry_machinery/chem_simulator.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_simulator.dm
@@ -442,7 +442,7 @@
 	for(var/datum/chem_property/P in creation_template)
 		creation_cost += max(abs(P.value), 1) * P.level
 		if(P.level > 5) // a penalty is added at each level above 5 (+1 at 6, +2 at 7, +4 at 8, +5 at 9, +7 at 10)
-			creation_cost += P.level - 6 + Ceiling((P.level - 5) / 2)
+			creation_cost += P.level - 6 + ceil((P.level - 5) / 2)
 	creation_cost += ((new_od_level - 10) / 5) * 3 //3 cost for every 5 units above 10
 	for(var/rarity in creation_complexity)
 		switch(rarity)

--- a/code/modules/vehicles/multitile/multitile_bump.dm
+++ b/code/modules/vehicles/multitile/multitile_bump.dm
@@ -494,7 +494,7 @@
 
 /obj/vehicle/handle_vehicle_bump(obj/vehicle/multitile/V)
 	V.take_damage_type(5, "blunt", V)
-	health = health - Ceiling(maxhealth/2.8) //we destroy any simple vehicle in 3 crushes
+	health = health - ceil(maxhealth/2.8) //we destroy any simple vehicle in 3 crushes
 	healthcheck()
 
 	visible_message(SPAN_DANGER("\The [V] crushes into \the [src]!"))

--- a/code/modules/vehicles/multitile/multitile_movement.dm
+++ b/code/modules/vehicles/multitile/multitile_movement.dm
@@ -254,7 +254,7 @@
 	if(abs(move_momentum) <= 1)
 		return
 
-	var/fling_distance = Ceiling(move_momentum/move_max_momentum) * 2
+	var/fling_distance = ceil(move_momentum/move_max_momentum) * 2
 	var/turf/target = interior.get_middle_turf()
 
 	for (var/x in 0 to fling_distance-1)
@@ -272,7 +272,7 @@
 			if(isliving(A))
 				var/mob/living/M = A
 
-				shake_camera(M, 2, Ceiling(move_momentum/move_max_momentum) * 1)
+				shake_camera(M, 2, ceil(move_momentum/move_max_momentum) * 1)
 				if(!M.buckled)
 					M.apply_effect(1, STUN)
 					M.apply_effect(2, WEAKEN)


### PR DESCRIPTION
# About the pull request

![image](https://github.com/cmss13-devs/cmss13/assets/14267245/dbe15f89-ddae-4dfe-8d09-0c159675b7f4)
https://www.byond.com/docs/ref/#/proc/ceil

With the move to 515, removes these two defines in favor of `ceil(x)`:
`#define ROUND_UP(x) ( -round(-(x)))`
`#define Ceiling(x) (-round(-(x)))`

Also converts the two-argument `CEILING(x, y)` to use `ceil` internally.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Less bespoke code means less points of failure.
# Testing Photographs and Procedure
Boots without obvious issue.


# Changelog
No player-facing changes.
