### PR TITLE
floor(x) conversion for 515

### DIFF
--- a/code/__DEFINES/_math.dm
+++ b/code/__DEFINES/_math.dm
@@ -17,7 +17,7 @@
 #define ROUND_UP(x) ( -round(-(x)))
 
 // round() acts like floor(x, 1) by default but can't handle other values
-#define FLOOR(x, y) ( round((x) / (y)) * (y) )
+#define FLOOR(x, y) ( floor((x) / (y)) * (y) )
 
 // Real modulus that handles decimals
 #define MODULUS(x, y) ( (x) - (y) * round((x) / (y)) )

--- a/code/__HELPERS/#maths.dm
+++ b/code/__HELPERS/#maths.dm
@@ -18,7 +18,6 @@ GLOBAL_LIST_INIT(sqrtTable, list(1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 4,
 #define Csc(x) (1 / sin(x))
 
 #define Default(a, b) ((a) ? (a) : (b))
-#define Floor(x) (round(x))
 
 // Greatest Common Divisor - Euclid's algorithm
 #define Gcd(a, b) ((b) ? Gcd((b), (a) % (b)) : (a))
@@ -26,7 +25,7 @@ GLOBAL_LIST_INIT(sqrtTable, list(1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 4,
 #define Inverse(x) (1 / (x))
 #define IsEven(x) ((x) % 2 == 0)
 
-#define IsInteger(x) (Floor(x) == (x))
+#define IsInteger(x) (floor(x) == (x))
 #define IsOdd(x) (!IsEven(x))
 #define IsMultiple(x, y) ((x) % (y) == 0)
 

--- a/code/__HELPERS/_time.dm
+++ b/code/__HELPERS/_time.dm
@@ -91,21 +91,21 @@ GLOBAL_VAR_INIT(rollovercheck_last_timeofday, 0)
 		return "right now"
 	if(second < 60)
 		return "[second] second[(second != 1)? "s":""]"
-	var/minute = Floor(second / 60)
+	var/minute = floor(second / 60)
 	second = FLOOR(MODULUS(second, 60), round_seconds_to)
 	var/secondT
 	if(second)
 		secondT = " and [second] second[(second != 1)? "s":""]"
 	if(minute < 60)
 		return "[minute] minute[(minute != 1)? "s":""][secondT]"
-	var/hour = Floor(minute / 60)
+	var/hour = floor(minute / 60)
 	minute = MODULUS(minute, 60)
 	var/minuteT
 	if(minute)
 		minuteT = " and [minute] minute[(minute != 1)? "s":""]"
 	if(hour < 24)
 		return "[hour] hour[(hour != 1)? "s":""][minuteT][secondT]"
-	var/day = Floor(hour / 24)
+	var/day = floor(hour / 24)
 	hour = MODULUS(hour, 24)
 	var/hourT
 	if(hour)

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -597,7 +597,7 @@
 	if(L.len <= 1)
 		return L
 
-	var/middle = Floor(L.len / 2)
+	var/middle = floor(L.len / 2)
 	var/list/left = custom_mergesort(L.Copy(1, middle + 1))
 	var/list/right = custom_mergesort(L.Copy(middle + 1))
 	var/list/result = list()

--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -88,8 +88,8 @@ SUBSYSTEM_DEF(minimaps)
 				else if(yval < smallest_y)
 					smallest_y = yval
 
-		minimaps_by_z["[level]"].x_offset = Floor((SCREEN_PIXEL_SIZE-largest_x-smallest_x) / MINIMAP_SCALE)
-		minimaps_by_z["[level]"].y_offset = Floor((SCREEN_PIXEL_SIZE-largest_y-smallest_y) / MINIMAP_SCALE)
+		minimaps_by_z["[level]"].x_offset = floor((SCREEN_PIXEL_SIZE-largest_x-smallest_x) / MINIMAP_SCALE)
+		minimaps_by_z["[level]"].y_offset = floor((SCREEN_PIXEL_SIZE-largest_y-smallest_y) / MINIMAP_SCALE)
 
 		icon_gen.Shift(EAST, minimaps_by_z["[level]"].x_offset)
 		icon_gen.Shift(NORTH, minimaps_by_z["[level]"].y_offset)

--- a/code/datums/entities/player_times.dm
+++ b/code/datums/entities/player_times.dm
@@ -61,7 +61,7 @@ BSQL_PROTECT_DATUM(/datum/entity/player_time)
 	return list(
 		"job" = role_id,
 		"playtime" = round(total_minutes MINUTES_TO_HOURS, 0.1),
-		"bgcolor" = "rgb(0, [Floor(128 * playtime_percentage)], [Floor(255 * playtime_percentage)])",
+		"bgcolor" = "rgb(0, [floor(128 * playtime_percentage)], [floor(255 * playtime_percentage)])",
 		"textcolor" = "#FFFFFF",
 		"icondisplay" = icon_display
 	)

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -175,7 +175,7 @@ Additional game mode variables.
 
 	if(pred_candidate) pred_candidate.moveToNullspace() //Nullspace it for garbage collection later.
 
-#define calculate_pred_max (Floor(length(GLOB.player_list) / pred_per_players) + pred_additional_max + pred_start_count)
+#define calculate_pred_max (floor(length(GLOB.player_list) / pred_per_players) + pred_additional_max + pred_start_count)
 
 /datum/game_mode/proc/check_predator_late_join(mob/pred_candidate, show_warning = 1)
 

--- a/code/game/machinery/computer/research.dm
+++ b/code/game/machinery/computer/research.dm
@@ -179,7 +179,7 @@
 		if("purchase_document")
 			if(!photocopier)
 				return
-			var/purchase_tier = Floor(text2num(params["purchase_document"]))
+			var/purchase_tier = floor(text2num(params["purchase_document"]))
 			if(purchase_tier <= 0 || purchase_tier > 5)
 				return
 			if(purchase_tier > GLOB.chemical_data.clearance_level)

--- a/code/game/objects/items/fulton.dm
+++ b/code/game/objects/items/fulton.dm
@@ -143,8 +143,8 @@ GLOBAL_LIST_EMPTY(deployed_fultons)
 	reservation = SSmapping.request_turf_block_reservation(3, 3, 1, turf_type_override = /turf/open/space)
 	var/turf/bottom_left_turf = reservation.bottom_left_turfs[1]
 	var/turf/top_right_turf = reservation.top_right_turfs[1]
-	var/middle_x = bottom_left_turf.x + Floor((top_right_turf.x - bottom_left_turf.x) / 2)
-	var/middle_y = bottom_left_turf.y + Floor((top_right_turf.y - bottom_left_turf.y) / 2)
+	var/middle_x = bottom_left_turf.x + floor((top_right_turf.x - bottom_left_turf.x) / 2)
+	var/middle_y = bottom_left_turf.y + floor((top_right_turf.y - bottom_left_turf.y) / 2)
 	var/turf/space_tile = locate(middle_x, middle_y, bottom_left_turf.z)
 	if(!space_tile)
 		visible_message(SPAN_WARNING("[src] begins beeping like crazy. Something is wrong!"))

--- a/code/game/objects/items/toys/cards.dm
+++ b/code/game/objects/items/toys/cards.dm
@@ -462,7 +462,7 @@
 		overlays += I
 		return
 
-	var/offset = Floor(80/cards_length)
+	var/offset = floor(80/cards_length)
 
 	var/matrix/M = matrix()
 	if(direction)
@@ -482,13 +482,13 @@
 		var/image/I = new(src.icon, (concealed ? P.back_icon : P.card_icon))
 		switch(direction)
 			if(SOUTH)
-				I.pixel_x = 8 - Floor(offset*i/4)
+				I.pixel_x = 8 - floor(offset*i/4)
 			if(WEST)
-				I.pixel_y = -6 + Floor(offset*i/4)
+				I.pixel_y = -6 + floor(offset*i/4)
 			if(EAST)
-				I.pixel_y = 8 - Floor(offset*i/4)
+				I.pixel_y = 8 - floor(offset*i/4)
 			else
-				I.pixel_x = -7 + Floor(offset*i/4)
+				I.pixel_x = -7 + floor(offset*i/4)
 		I.transform = M
 		overlays += I
 		i++

--- a/code/modules/buildmode/buildmode.dm
+++ b/code/modules/buildmode/buildmode.dm
@@ -80,7 +80,7 @@
 	var/pos_idx = 0
 	for(var/thing in elements)
 		var/x = pos_idx % switch_width
-		var/y = Floor(pos_idx / switch_width)
+		var/y = floor(pos_idx / switch_width)
 		var/atom/movable/screen/buildmode/B = new buttontype(src, thing)
 		// extra .5 for a nice offset look
 		B.screen_loc = "NORTH-[(1 + 0.5 + y*1.5)],WEST+[0.5 + x*1.5]"

--- a/code/modules/clothing/suits/marine_armor/_marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor/_marine_armor.dm
@@ -191,7 +191,7 @@
 	if(. != CHECKS_PASSED)
 		return
 	set_light_range(initial(light_range))
-	set_light_power(Floor(initial(light_power) * 0.5))
+	set_light_power(floor(initial(light_power) * 0.5))
 	set_light_on(toggle_on)
 	flags_marine_armor ^= ARMOR_LAMP_ON
 

--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -66,7 +66,7 @@
 	for(var/mob/living/carbon/xenomorph/lesser_drone/lesser in linked_hive.totalXenos)
 		lesser_count++
 
-	. += "Currently holding [SPAN_NOTICE("[Floor(lesser_drone_spawns)]")]/[SPAN_NOTICE("[lesser_drone_spawn_limit]")] lesser drones."
+	. += "Currently holding [SPAN_NOTICE("[floor(lesser_drone_spawns)]")]/[SPAN_NOTICE("[lesser_drone_spawn_limit]")] lesser drones."
 	. += "There are currently [SPAN_NOTICE("[lesser_count]")] lesser drones in the hive. The hive can support [SPAN_NOTICE("[linked_hive.lesser_drone_limit]")] lesser drones."
 
 /obj/effect/alien/resin/special/pylon/attack_ghost(mob/dead/observer/user)

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -110,7 +110,7 @@
 
 		if(isliving(M))
 			var/mob/living/player = M
-			serialized["health"] = Floor(player.health / player.maxHealth * 100)
+			serialized["health"] = floor(player.health / player.maxHealth * 100)
 
 			if(isxeno(player))
 				var/mob/living/carbon/xenomorph/xeno = player
@@ -126,7 +126,7 @@
 				var/obj/item/card/id/id_card = human.get_idcard()
 				var/datum/species/human_species = human.species
 				var/max_health = human_species.total_health != human.maxHealth ? human_species.total_health : human.maxHealth
-				serialized["health"] = Floor(player.health / max_health * 100)
+				serialized["health"] = floor(player.health / max_health * 100)
 
 				serialized["job"] = id_card?.assignment ? id_card.assignment : human.job
 				serialized["nickname"] = human.real_name

--- a/code/modules/mob/living/carbon/human/human_abilities.dm
+++ b/code/modules/mob/living/carbon/human/human_abilities.dm
@@ -250,7 +250,7 @@ CULT
 		to_send_to = list(H)
 	message_admins("[key_name_admin(H)] called a tech droppod down at [get_area(assigned_droppod)].", T.x, T.y, T.z)
 	for(var/M in to_send_to)
-		to_chat(M, SPAN_BLUE("<b>SUPPLY DROP REQUEST:</b> Droppod requested at LONGITUDE: [obfuscate_x(T.x)], LATITUDE: [obfuscate_y(T.y)]. ETA [Floor(land_time*0.1)] seconds."))
+		to_chat(M, SPAN_BLUE("<b>SUPPLY DROP REQUEST:</b> Droppod requested at LONGITUDE: [obfuscate_x(T.x)], LATITUDE: [obfuscate_y(T.y)]. ETA [floor(land_time*0.1)] seconds."))
 	RegisterSignal(assigned_droppod, COMSIG_PARENT_QDELETING, PROC_REF(handle_droppod_deleted))
 */
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -819,7 +819,7 @@
 		return
 
 	var/list/alerts = list()
-	for(var/i in RANGE_TURFS(Floor(width/2), T))
+	for(var/i in RANGE_TURFS(floor(width/2), T))
 		alerts += new /obj/effect/warning/alien(i)
 
 	if(!do_after(Q, time_taken, INTERRUPT_NO_NEEDHAND, BUSY_ICON_FRIENDLY))
@@ -833,7 +833,7 @@
 	if(!check_and_use_plasma_owner())
 		return
 
-	var/turf/new_turf = locate(max(T.x - Floor(width/2), 1), max(T.y - Floor(height/2), 1), T.z)
+	var/turf/new_turf = locate(max(T.x - floor(width/2), 1), max(T.y - floor(height/2), 1), T.z)
 	to_chat(Q, SPAN_XENONOTICE("You raise a blockade!"))
 	var/obj/effect/alien/resin/resin_pillar/RP = new pillar_type(new_turf)
 	RP.start_decay(brittle_time, decay_time)

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -832,7 +832,7 @@
 		if(cycled_xeno.counts_for_slots)
 			countable_xeno_iterator++
 
-	playable_hugger_limit = max(Floor(countable_xeno_iterator / playable_hugger_max_divisor), playable_hugger_minimum)
+	playable_hugger_limit = max(floor(countable_xeno_iterator / playable_hugger_max_divisor), playable_hugger_minimum)
 
 /datum/hive_status/proc/can_spawn_as_hugger(mob/dead/observer/user)
 	if(!GLOB.hive_datum || ! GLOB.hive_datum[hivenumber])
@@ -888,7 +888,7 @@
 		if(cycled_xeno.counts_for_slots)
 			countable_xeno_iterator++
 
-	lesser_drone_limit = max(Floor(countable_xeno_iterator / playable_lesser_drones_max_divisor), lesser_drone_minimum)
+	lesser_drone_limit = max(floor(countable_xeno_iterator / playable_lesser_drones_max_divisor), lesser_drone_minimum)
 
 /datum/hive_status/proc/can_spawn_as_lesser_drone(mob/dead/observer/user, obj/effect/alien/resin/special/pylon/spawning_pylon)
 	if(!GLOB.hive_datum || ! GLOB.hive_datum[hivenumber])

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -291,7 +291,7 @@
 
 	if(hud_used.alien_armor_display)
 		var/armor_stacks = min((get_armor_integrity_percentage() * 0.01) * HUD_ARMOR_STATES_XENO, HUD_ARMOR_STATES_XENO)
-		hud_used.alien_armor_display.icon_state = "armor_[Floor(armor_stacks)]0"
+		hud_used.alien_armor_display.icon_state = "armor_[floor(armor_stacks)]0"
 
 	return TRUE
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -331,7 +331,7 @@ GLOBAL_LIST_INIT(limb_types_by_name, list(
 	while(i < steps)
 		animate(pixel_x = old_X + rand(-(strength), strength), pixel_y = old_y + rand(-(strength), strength), easing = JUMP_EASING, time = time_per_step)
 		i++
-	animate(pixel_x = old_X, pixel_y = old_y,time = clamp(Floor(strength/PIXELS_PER_STRENGTH_VAL),2,4))//ease it back
+	animate(pixel_x = old_X, pixel_y = old_y,time = clamp(floor(strength/PIXELS_PER_STRENGTH_VAL),2,4))//ease it back
 
 #undef PIXELS_PER_STRENGTH_VAL
 

--- a/code/modules/projectiles/guns/flamer/flameshape.dm
+++ b/code/modules/projectiles/guns/flamer/flameshape.dm
@@ -67,7 +67,7 @@
 	return GLOB.alldirs
 
 /datum/flameshape/star/handle_fire_spread(obj/flamer_fire/F, fire_spread_amount, burn_dam, fuel_pressure = 1)
-	fire_spread_amount = Floor(fire_spread_amount * 1.5) // branch 'length'
+	fire_spread_amount = floor(fire_spread_amount * 1.5) // branch 'length'
 	var/turf/source_turf = get_turf(F.loc)
 
 	var/list/dirs = dirs_to_use()

--- a/code/modules/vehicles/hardpoints/primary/minigun.dm
+++ b/code/modules/vehicles/hardpoints/primary/minigun.dm
@@ -77,8 +77,8 @@
 		return
 	spin_stage = clamp(spin_stage, 1, stage_rate_len)
 
-	var/old_stage_rate = stage_rate[Floor(old_spin_stage)]
-	var/new_stage_rate = stage_rate[Floor(spin_stage)]
+	var/old_stage_rate = stage_rate[floor(old_spin_stage)]
+	var/new_stage_rate = stage_rate[floor(spin_stage)]
 
 	if(old_stage_rate != new_stage_rate)
 		stage_delay_mult = 1 / new_stage_rate

--- a/code/modules/vehicles/interior/interactable/vendors.dm
+++ b/code/modules/vehicles/interior/interactable/vendors.dm
@@ -330,7 +330,7 @@
 							to_chat(user, SPAN_WARNING("\The [S] are being stored in [SPAN_HELPFUL("stacks of 5")] for convenience. You need \the [S] stack of at least 5 to restock it."))
 						return FALSE
 					else
-						stack_restock = Floor(S.amount / 5)
+						stack_restock = floor(S.amount / 5)
 				//for the ease of finding enough materials to stack, it will be stored in stacks of 10 sheets just like they come in engie vendor
 				else
 					if(S.amount < 10)
@@ -338,7 +338,7 @@
 							to_chat(user, SPAN_WARNING("\The [S] are being stored in [SPAN_HELPFUL("stacks of 10")] for convenience. You need \the [S] stack of at least 10 to restock it."))
 						return FALSE
 					else
-						stack_restock = Floor(S.amount / 10)
+						stack_restock = floor(S.amount / 10)
 
 			//item we are restocking is a stack and we need to conveniently restock it
 			//instead of demanding user to split it into stacks of appropriate amount

--- a/code/modules/vehicles/interior/interior.dm
+++ b/code/modules/vehicles/interior/interior.dm
@@ -309,12 +309,12 @@
 /datum/interior/proc/get_middle_coords()
 	var/turf/min = reservation.bottom_left_turfs[1]
 	var/turf/max = reservation.top_right_turfs[1]
-	return list(Floor(min.x + (max.x - min.x)/2), Floor(min.y + (max.y - min.y)/2), min.z)
+	return list(floor(min.x + (max.x - min.x)/2), floor(min.y + (max.y - min.y)/2), min.z)
 
 
 /datum/interior/proc/get_middle_turf()
 	var/list/turf/bounds = get_bound_turfs()
-	var/turf/middle = locate(Floor(bounds[1].x + (bounds[2].x - bounds[1].x)/2), Floor(bounds[1].y + (bounds[2].y - bounds[1].y)/2), bounds[1].z)
+	var/turf/middle = locate(floor(bounds[1].x + (bounds[2].x - bounds[1].x)/2), floor(bounds[1].y + (bounds[2].y - bounds[1].y)/2), bounds[1].z)
 
 	return middle
 

--- a/code/modules/vehicles/multitile/multitile_bump.dm
+++ b/code/modules/vehicles/multitile/multitile_bump.dm
@@ -744,7 +744,7 @@
 		return TRUE
 	else if (mob_moved)
 		if(momentum_penalty)
-			V.move_momentum = Floor(V.move_momentum*0.8)
+			V.move_momentum = floor(V.move_momentum*0.8)
 			V.update_next_move()
 		playsound(loc, "punch", 25, 1)
 		return TRUE
@@ -769,7 +769,7 @@
 			visible_message(SPAN_DANGER("[src] digs it's claws into the ground, slowing [V]'s movement!"),
 			SPAN_DANGER("You dig your claws into the ground, slowing [V]'s movement!"))
 			var/mob_moved = step(src, V.last_move_dir)
-			V.move_momentum = Floor(V.move_momentum/3)
+			V.move_momentum = floor(V.move_momentum/3)
 			V.update_next_move()
 			return mob_moved
 

--- a/code/modules/vehicles/multitile/multitile_movement.dm
+++ b/code/modules/vehicles/multitile/multitile_movement.dm
@@ -159,7 +159,7 @@
 
 	// Crashed with something that stopped us
 	if(!can_move)
-		move_momentum = Floor(move_momentum/2)
+		move_momentum = floor(move_momentum/2)
 		update_next_move()
 		interior_crash_effect()
 


### PR DESCRIPTION
# About the pull request

![image](https://github.com/cmss13-devs/cmss13/assets/14267245/7d492bcb-f934-4c2f-be5a-c0bf339feab8)
https://www.byond.com/docs/ref/#/proc/floor

With the move to 515, removes this define in favor of `floor(x)`:
`#define Floor(x) (round(x))`

Also converts the two-argument `FLOOR(x, y)` to use `floor` internally.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Less bespoke code means less points of failure.
# Testing Photographs and Procedure
Boots without obvious issue.


# Changelog
No player-facing changes.
