### PR TITLE
VP78 Range + ROF Buff

### DIFF
--- a/code/datums/ammo/bullet/pistol.dm
+++ b/code/datums/ammo/bullet/pistol.dm
@@ -180,6 +180,7 @@
 	headshot_state = HEADSHOT_OVERLAY_MEDIUM
 	debilitate = list(0,0,0,0,0,0,0,2)
 
+	effective_range_max = 3
 	accuracy = HIT_ACCURACY_TIER_4
 	damage = 45
 	penetration= ARMOR_PENETRATION_TIER_6

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -715,9 +715,9 @@
 
 /obj/item/weapon/gun/pistol/vp78/set_gun_config_values()
 	..()
-	set_fire_delay(FIRE_DELAY_TIER_4)
+	set_fire_delay(FIRE_DELAY_TIER_11)
 	set_burst_amount(BURST_AMOUNT_TIER_3)
-	set_burst_delay(FIRE_DELAY_TIER_11)
+	set_burst_delay(FIRE_DELAY_TIER_10)
 	accuracy_mult = BASE_ACCURACY_MULT
 	accuracy_mult_unwielded = BASE_ACCURACY_MULT
 	scatter = SCATTER_AMOUNT_TIER_6
@@ -726,7 +726,6 @@
 	damage_mult = BASE_BULLET_DAMAGE_MULT
 	recoil = RECOIL_AMOUNT_TIER_5
 	recoil_unwielded = RECOIL_AMOUNT_TIER_4
-
 
 //-------------------------------------------------------
 /*

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -717,7 +717,7 @@
 	..()
 	set_fire_delay(FIRE_DELAY_TIER_7)
 	set_burst_amount(BURST_AMOUNT_TIER_3)
-	set_burst_delay(FIRE_DELAY_TIER_10)
+	set_burst_delay(FIRE_DELAY_TIER_11)
 	accuracy_mult = BASE_ACCURACY_MULT
 	accuracy_mult_unwielded = BASE_ACCURACY_MULT
 	scatter = SCATTER_AMOUNT_TIER_6

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -727,6 +727,7 @@
 	recoil = RECOIL_AMOUNT_TIER_5
 	recoil_unwielded = RECOIL_AMOUNT_TIER_4
 
+
 //-------------------------------------------------------
 /*
 Auto 9 The gun RoboCop uses. A better version of the VP78, with more rounds per magazine. Probably the best pistol around, but takes no attachments.

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -715,7 +715,7 @@
 
 /obj/item/weapon/gun/pistol/vp78/set_gun_config_values()
 	..()
-	set_fire_delay(FIRE_DELAY_TIER_11)
+	set_fire_delay(FIRE_DELAY_TIER_7)
 	set_burst_amount(BURST_AMOUNT_TIER_3)
 	set_burst_delay(FIRE_DELAY_TIER_10)
 	accuracy_mult = BASE_ACCURACY_MULT


### PR DESCRIPTION
# About the pull request

This PR increases the rate of fire of the VP-78 to something comparable, but slightly slower, than the Mod88 Pistol. Primarily this is significantly buffing the weapon's single-shot mode to be comparable to the rate of fire of the burst firing mode, it also very slightly increases the burst fire's rate of fire. The idea here is to ensure the single-fire is viable to use alongside the burst-fire, wherein currently the single-fire is objectively inferior to the burst fire. 

This PR also increases the minimum damage falloff range from 0 tiles to 3 tiles, meaning the weapon will now experience falloff from 3 tiles onwards instead of immediately upon exiting the barrel. This is to make this weapon function on-par with almost every other firearm in the game. 

# Explain why it's good for the game

Born out of this discussion thread: https://forum.cm-ss13.com/t/make-vp78-not-dogshit/8028

In universe the VP78 is billed as the imminent replacement sidearm of the USCMC, and it is also the standard issue sidearm of the Three World Empire's Commando forces, and for the highly placed Corporate PMC forces. 

In practice the weapon is completely unusable and is widely seen as being useless as a firearm. It suffers from a myriad of issues, such as noted above how the firearm experiences damage falloff immediately as soon as the bullet leaves the gun, meaning you will only deal the full, advertised, damage to a target if you are sprite-click point-blank shooting a target.

By the time your bullet is 2 to 3 tiles away from you, you are already dealing less than half your expected damage. 

Its accuracy is suboptimal as it struggles to strike long range targets (even if you are already dealing 20 to 10 damage per bullet at this range) and its burst fire mode is prone to wild inaccuracy.

Furthermore, its rate of fire is so slow that assuming you are in a white room perfect testing conditions environment, you can spend at minimum of 20 seconds, often far longer, to kill a single, T2 offensive, xeno after expending multiple magazines wherein any other firearm has done so within 5 seconds and with only one magazine. 

Because the weapon seems billed as a very powerful pistol, its resupply is constrained to represent this, meaning most Marine roles need to buy ammo from their personal vendor, and requisitions will not purchase, or even bother to send a, resupply crate or spare ammo. 

The summation is that this weapons in-universe predecessor, the Mod88, is heads above a superior firearm in virtually every single possible respect to the VP78. Furthermore, the M4A3 pistol, a decidedly even more ancient firearm, is also superior of a firearm to this .  

This change is aimed at making the VP78 an actually viable firearm. With damage output similar to some primary weapons, and at least a similar damage output to the other good pistols, but with a harsh ammo supply limit.

I am 100% open to making needed balance changes to make this merge ready, but I assessed this is a good starting spot as the weapon needs something to make it more than a fluff piece. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: The VP78 pistol has received a rate of fire boost, and it will deal full damage up to 3 tiles from the shooter's position before suffering damage falloff. 
/:cl:
