### PR TITLE
SDQL2 bugfixes & features

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,11 @@
 # This list auto requests reviews from the specified org members
+
 # when a PR that modifies the file in question is opened
+
 # This list is alphabetized by User -> Filename and separated into sections for Maintainers KEEP IT THAT WAY
+
 # In the event that people are to be informed of changes
+
 # to the same file or dir, add them to the end of under Multiple Owners
 
 # Fira
@@ -31,6 +35,7 @@
 # Zonespace
 
 /code/datums/tutorial/ @Zonespace27
+/code/modules/admin/verbs/SDQL2/ @Zonespace27
 /maps/tutorial/ @Zonespace27
 
 # MULTIPLE OWNERS

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,7 @@
 # This list auto requests reviews from the specified org members
-
 # when a PR that modifies the file in question is opened
-
 # This list is alphabetized by User -> Filename and separated into sections for Maintainers KEEP IT THAT WAY
-
 # In the event that people are to be informed of changes
-
 # to the same file or dir, add them to the end of under Multiple Owners
 
 # Fira

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -212,6 +212,9 @@ SUBSYSTEM_DEF(statpanels)
 
 /// Sets the current tab to the SDQL tab
 /datum/controller/subsystem/statpanels/proc/set_SDQL2_tab(client/target)
+	if(!target)
+		return
+
 	var/list/sdql2_initial = list()
 	sdql2_initial[++sdql2_initial.len] = list("", "Access Global SDQL2 List", REF(GLOB.sdql2_vv_statobj))
 	var/list/sdql2_querydata = list()
@@ -223,6 +226,9 @@ SUBSYSTEM_DEF(statpanels)
 
 ///immediately update the active statpanel tab of the target client
 /datum/controller/subsystem/statpanels/proc/immediate_send_stat_data(client/target)
+	if(!target)
+		return FALSE
+
 	if(!target.stat_panel.is_ready())
 		return FALSE
 

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -213,10 +213,10 @@ SUBSYSTEM_DEF(statpanels)
 /// Sets the current tab to the SDQL tab
 /datum/controller/subsystem/statpanels/proc/set_SDQL2_tab(client/target)
 	var/list/sdql2_initial = list()
-	//sdql2_initial[length(sdql2_initial)++] = list("", "Access Global SDQL2 List", REF(GLOB.sdql2_vv_statobj))
+	sdql2_initial[++sdql2_initial.len] = list("", "Access Global SDQL2 List", REF(GLOB.sdql2_vv_statobj))
 	var/list/sdql2_querydata = list()
-	//for(var/datum/sdql2_query/query as anything in GLOB.sdql2_queries)
-		//sdql2_querydata = query.generate_stat()
+	for(var/datum/sdql2_query/query as anything in GLOB.sdql2_queries)
+		sdql2_querydata += query.generate_stat()
 
 	sdql2_initial += sdql2_querydata
 	target.stat_panel.send_message("update_sdql2", sdql2_initial)

--- a/code/game/objects/effects/effect.dm
+++ b/code/game/objects/effects/effect.dm
@@ -1,5 +1,6 @@
 /obj/effect
 	icon = 'icons/effects/effects.dmi'
+	blocks_emissive = EMISSIVE_BLOCK_GENERIC
 
 /obj/effect/get_applying_acid_time()
 	return -1

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -218,12 +218,12 @@
 	var/prompt = tgui_alert(usr, "Run SDQL2 Query?", "SDQL2", list("Yes", "Cancel"))
 	if (prompt != "Yes")
 		return
-	var/list/results = world.SDQL2_query(query_text, key_name_admin(usr), "[key_name(usr)]")
+	var/list/results = world.SDQL2_query(query_text, key_name_admin(usr), "[key_name(usr)]", executor = src)
 	if(length(results) == 3)
 		for(var/I in 1 to 3)
 			to_chat(usr, results[I], confidential = TRUE)
 
-/world/proc/SDQL2_query(query_text, log_entry1, log_entry2, silent = FALSE)
+/world/proc/SDQL2_query(query_text, log_entry1, log_entry2, silent = FALSE, client/executor)
 	var/query_log = "executed SDQL query(s): \"[query_text]\"."
 	if(!silent)
 		message_admins("[log_entry1] [query_log]")
@@ -254,6 +254,8 @@
 		waiting_queue += query
 		if(query.options & SDQL2_OPTION_SEQUENTIAL)
 			sequential = TRUE
+
+	SSstatpanels.set_SDQL2_tab(executor)
 
 	if(sequential) //Start first one
 		var/datum/sdql2_query/query = popleft(waiting_queue)

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -1333,7 +1333,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/sdql2_vv_all, new(null
 	return query_list
 
 
-/obj/effect/statclick/SDQL2_delete/Click()
+/obj/effect/statclick/SDQL2_delete/clicked()
 	if(!CLIENT_IS_STAFF(usr.client))
 		message_admins("[key_name_admin(usr)] non-staff clicked on a statclick! ([src])")
 		log_admin("non-staff clicked on a statclick! ([src])")
@@ -1341,7 +1341,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/sdql2_vv_all, new(null
 	var/datum/sdql2_query/Q = target
 	Q.delete_click()
 
-/obj/effect/statclick/SDQL2_action/Click()
+/obj/effect/statclick/SDQL2_action/clicked()
 	if(!CLIENT_IS_STAFF(usr.client))
 		message_admins("[key_name_admin(usr)] non-staff clicked on a statclick! ([src])")
 		log_admin("non-staff clicked on a statclick! ([src])")
@@ -1352,7 +1352,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/sdql2_vv_all, new(null
 /obj/effect/statclick/sdql2_vv_all
 	name = "VIEW VARIABLES"
 
-/obj/effect/statclick/sdql2_vv_all/Click()
+/obj/effect/statclick/sdql2_vv_all/clicked()
 	if(!CLIENT_IS_STAFF(usr.client))
 		message_admins("[key_name_admin(usr)] non-staff clicked on a statclick! ([src])")
 		log_admin("non-staff clicked on a statclick! ([src])")

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
@@ -136,6 +136,9 @@
 		if("call")
 			call_query(i, node)
 
+		if("singlecall")
+			singlecall_query(i, node)
+
 		if("explain")
 			node += "explain"
 			node["explain"] = list()
@@ -193,6 +196,14 @@
 	i = object_selectors(i + 1, select)
 
 	node["on"] = select
+
+	return i
+
+//singlecall_query: 'CALL' object.call_function
+/datum/sdql_parser/proc/singlecall_query(i, list/node)
+	var/list/func = list()
+	i = variable(i + 1, func)
+	node["singlecall"] = func
 
 	return i
 

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -175,6 +175,9 @@
 /proc/_sin(X)
 	return sin(X)
 
+/proc/_sleep(Delay)
+	sleep(Delay)
+
 /proc/_list_add(list/L, ...)
 	if (args.len < 2)
 		return


### PR DESCRIPTION
# About the pull request

## Fixes

- Fixed partially empty string being printed to chat when `CALL` query wasn't used
- Fixed `SDQL_print()` not handling assoc lists-in-lists correctly

## Features

- SDQL2 tab now works. Also appears instantly instead of on next `SSstatpanels` fire.
- Clients now can be selected without needing to add `IN global.clients` to a query.
- Added `LISTSOURCE` option, taking arg `OPTIMIZED`. Adding this arg will use some CM-added lists (like `GLOB.mob_list`) instead of iterating over `world`. This arg does nothing if the list being queried isn't `world`.
- Added `SELECTPRINT` option, taking arg `NO_PRINT`. Adding this arg will prevent the HTML window containing every object found using a `SELECT` query. Useful because assembling the HTML window is incredibly taxing on the server when `SELECT`ing a massive amount of objects at once.
- You can now call `sleep()` in SDQL queries by using `global._sleep()`
- Added `SINGLECALL` query, taking an arg of `object.proc_call()`. This allows you to call a proc on an object (`global`, `marked`, `SSticker`, etc.) without needing to iterate over anything. Primarily useful for an in-between when chaining queries together.

For more details and examples, see [my SDQL2 documentation](https://hackmd.io/@mRAdleXgRfmKqh97O8ixSA/ryZ-oqE2c).

# Explain why it's good for the game
Fixes good, features that make SDQL2 better good.

# Changelog
:cl:
admin: Added LISTSOURCE and SELECTPRINT options to SDQL queries.
admin: Added SINGLECALL SQDL query.
admin: SDQL tab now works.
admin: Clients can now be selected with SDQL more easily.
/:cl:
