### PR TITLE
ARES reception bell unique description and longer cooldown

### DIFF
--- a/code/modules/paperwork/desk_bell.dm
+++ b/code/modules/paperwork/desk_bell.dm
@@ -96,6 +96,8 @@
 
 /obj/item/desk_bell/ares
 	name = "AI core reception bell"
+	desc = "The cornerstone of any customer service job. This one is linked to ARES and will notify any active Working Joes upon being rung."
+	ring_cooldown_length = 60 SECONDS // Prevents spam
 
 /obj/item/desk_bell/ares/ring_bell(mob/living/user)
 	if(broken_ringer)


### PR DESCRIPTION
# About the pull request

- Gives the ARES reception bell a unique description to let people know that it notifies WJs.
- Increases the cooldown of the ARES reception bell from 5 to 60 seconds.

**!! fyi I have no idea what changelog tags would be appropriate so I just went with QOL. Feel free to change if needed. !!**

# Explain why it's good for the game

Increased cooldown is to prevent spam. Happened on a previous round and was quite annoying. I don't see a need to be able to send an announcement every 5 seconds.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: XQ
qol: Updated the ARES reception bell's description to inform players it notifies Working Joes when rung.
qol: Increased the ARES reception bell's cooldown from 5 to 60 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->