### PR TITLE
Additional Labeler Workflow Triggers

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: Labeling and Verification
 on:
   pull_request_target:
-    types: [opened, edited]
+    types: [opened, synchronize, reopened, edited] # I would prefer this not to run on synchronize but otherwise it blocks merge queue if required
 jobs:
   label:
     runs-on: ubuntu-latest

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,8 @@
 name: Labeling and Verification
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, edited] # I would prefer this not to run on synchronize but otherwise it blocks merge queue if required
+    types: [opened, reopened, edited]
+  merge_group:
 jobs:
   label:
     runs-on: ubuntu-latest


### PR DESCRIPTION

# About the pull request

This PR simply expands the trigger for the labeler workflow. I would like the workflow to be required, but as is it simply blocked the merge queue when the `label` was made into a required check.

# Changelog

No player facing changes.