### PR TITLE
Adds 70% chance groundside reagent tanks are anchored.

### DIFF
--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -22,7 +22,7 @@
 		verbs -= /obj/structure/reagent_dispensers/verb/set_APTFT
 	if(chemical)
 		reagents.add_reagent(chemical, reagent_amount)
-	if(!anchored && (is_ground_level(z) && prob(70)))
+	if(!anchored && is_ground_level(z) && prob(70))
 		anchored = TRUE
 
 /obj/structure/reagent_dispensers/initialize_pass_flags(datum/pass_flags_container/PF)

--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -22,6 +22,8 @@
 		verbs -= /obj/structure/reagent_dispensers/verb/set_APTFT
 	if(chemical)
 		reagents.add_reagent(chemical, reagent_amount)
+	if(!anchored && (is_ground_level(z) && prob(70)))
+		anchored = TRUE
 
 /obj/structure/reagent_dispensers/initialize_pass_flags(datum/pass_flags_container/PF)
 	..()


### PR DESCRIPTION
# About the pull request

As title.

# Explain why it's good for the game

Whilst Xenos are more than capable of using environmental advantages in traps, they're not intended to move human equipment to pre-plan traps in different locations. Rather than rendering it entirely impossible however, or forbidding it from a rules end, this leaves it to chance.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Added a 70% chance groundside reagent tanks start anchored, if they don't already.
/:cl:
