### PR TITLE
Removes Generic Tailstab for Vamp lurker

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/lurker/vampire.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/lurker/vampire.dm
@@ -1,13 +1,14 @@
 /datum/xeno_strain/vampire
 	name = LURKER_VAMPIRE
-	description = "You lose all of your abilities and you forefeit a chunk of your health and damage in exchange for a large amount of armor, a little bit of movement speed, increased attack speed, and brand new abilities that make you an assassin. Rush on your opponent to disorient them and Flurry to unleash a forward cleave that can hit and slow three talls and heal you for every tall you hit. Use your special AoE Tail Jab to knock talls away, doing more damage with direct hits and even more damage and a stun if they smack into walls. Finally, execute unconscious talls with a headbite that bypasses armor and heals you for a grand amount of health."
-	flavor_description = "Your thirst for tallhost blood surpasses even mine, child. Show no mercy! Slaughter them all!"
+	description = "You lose all of your abilities and you forefeit a chunk of your health and damage in exchange for a large amount of armor, a little bit of movement speed, increased attack speed, and brand new abilities that make you an assassin. Rush on your opponent to disorient them and Flurry to unleash a forward cleave that can hit and slow three talls and heal you for every tall you hit. Use your special AoE Tail Jab to knock talls away, doing more damage with direct hits and even more damage and a stun if they smack into walls. Finally, execute unconscious talls with a headbite to heal your wounds."
+	flavor_description = "Child. Show no mercy! Slaughter them all!"
 	icon_state_prefix = "Vampire"
 
 	actions_to_remove = list(
 		/datum/action/xeno_action/onclick/lurker_invisibility,
 		/datum/action/xeno_action/onclick/lurker_assassinate,
 		/datum/action/xeno_action/activable/pounce/lurker,
+		/datum/action/xeno_action/activable/tail_stab,
 	)
 	actions_to_add = list(
 		/datum/action/xeno_action/activable/pounce/rush,

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/lurker/vampire.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/lurker/vampire.dm
@@ -1,7 +1,7 @@
 /datum/xeno_strain/vampire
 	name = LURKER_VAMPIRE
 	description = "You lose all of your abilities and you forefeit a chunk of your health and damage in exchange for a large amount of armor, a little bit of movement speed, increased attack speed, and brand new abilities that make you an assassin. Rush on your opponent to disorient them and Flurry to unleash a forward cleave that can hit and slow three talls and heal you for every tall you hit. Use your special AoE Tail Jab to knock talls away, doing more damage with direct hits and even more damage and a stun if they smack into walls. Finally, execute unconscious talls with a headbite to heal your wounds."
-	flavor_description = "Child. Show no mercy! Slaughter them all!"
+	flavor_description = "Show no mercy! Slaughter them all!"
 	icon_state_prefix = "Vampire"
 
 	actions_to_remove = list(


### PR DESCRIPTION
# About the pull request

Removes vampire lurket tail stab ability as it was intended in the original design.

# Explain why it's good for the game

Tail stab was not supposed to be on the kit of Vamp lurker . the reason being is that Tail jab is pretty much the same ( tail stab did not exist when vampo lurker was designed).
it provides vamp with an insane burst of damage if they movestack both abilities which no good.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:

balance: Removes Generic tail stab from Vampire lurker
spellcheck: adjusted Vampire lurker description
/:cl:
