### PR TITLE
Xenos holding on warding don't lose it while on weeds

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -130,7 +130,8 @@
 
 	if(frenzy_aura != frenzy_new || warding_aura != warding_new || recovery_aura != recovery_new)
 		frenzy_aura = frenzy_new
-		warding_aura = warding_new
+		if(health > crit_health || warding_new > warding_aura || !check_weeds_for_healing())
+			warding_aura = warding_new
 		recovery_aura = recovery_new
 		recalculate_move_delay = TRUE
 		hud_set_pheromone()


### PR DESCRIPTION
# About the pull request
Xeno who is below crit health (i.e. holding on health provided by warding) doesn't lose warding as long as xeno is on weeds.

# Explain why it's good for the game
Exploding on weeds from losing warding is extremely confusing for all parties involved. You cannot bleed out while on weeds, so this is a bit more consistent.

# Testing Photographs and Procedure
<details>

https://github.com/cmss13-devs/cmss13/assets/115417687/b8996a56-b1fa-4bda-9155-6b73f7a42639

</details>


# Changelog
:cl: ihatethisengine
balance: xenos holding on warding don't lose it while on weeds
/:cl:
