### PR TITLE
Fix MRE automatic trashing and nade box trashing

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -745,7 +745,7 @@
 	storage_slots = 7
 	max_w_class = 0
 	use_sound = "rip"
-	var/isopened = 0
+	var/isopened = FALSE
 
 /obj/item/storage/box/MRE/fill_preset_inventory()
 	pickflavor()

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -574,7 +574,7 @@
 		new /obj/item/device/flashlight/flare(src)
 
 /obj/item/storage/box/m94/update_icon()
-	if(!contents.len)
+	if(!length(contents))
 		icon_state = "m94_e"
 	else
 		icon_state = "m94"
@@ -590,7 +590,7 @@
 		new /obj/item/device/flashlight/flare/signal(src)
 
 /obj/item/storage/box/m94/signal/update_icon()
-	if(!contents.len)
+	if(!length(contents))
 		icon_state = "m89_e"
 	else
 		icon_state = "m89"
@@ -608,6 +608,24 @@
 	var/grenade_type = /obj/item/explosive/grenade/high_explosive
 	has_gamemode_skin = TRUE
 
+/obj/item/storage/box/nade_box/Initialize()
+	. = ..()
+	RegisterSignal(src, COMSIG_ITEM_DROPPED, PROC_REF(try_forced_folding))
+
+/obj/item/storage/box/nade_box/proc/try_forced_folding(datum/source, mob/user)
+	SIGNAL_HANDLER
+
+	if(!isturf(loc))
+		return
+
+	if(length(contents))
+		return
+
+	UnregisterSignal(src, COMSIG_ITEM_DROPPED)
+	storage_close(user)
+	to_chat(user, SPAN_NOTICE("You throw away [src]."))
+	qdel(src)
+
 /obj/item/storage/box/nade_box/post_skin_selection()
 	base_icon = icon_state
 
@@ -616,9 +634,8 @@
 		new grenade_type(src)
 
 /obj/item/storage/box/nade_box/update_icon()
-	if(!contents.len)
+	if(!length(contents))
 		icon_state = "[base_icon]_e"
-		qdel(src) //No reason to keep it - nobody will reuse it...
 	else
 		icon_state = base_icon
 
@@ -766,12 +783,15 @@
 
 /obj/item/storage/box/MRE/Initialize()
 	. = ..()
-	isopened = 0
+	isopened = FALSE
 	icon_state = "mealpack"
 	RegisterSignal(src, COMSIG_ITEM_DROPPED, PROC_REF(try_forced_folding))
 
 /obj/item/storage/box/MRE/proc/try_forced_folding(datum/source, mob/user)
 	SIGNAL_HANDLER
+
+	if(!isturf(loc))
+		return
 
 	if(locate(/obj/item/reagent_container/food/snacks/packaged_meal) in src)
 		return
@@ -782,10 +802,8 @@
 	qdel(src)
 
 /obj/item/storage/box/MRE/update_icon()
-	if(!contents.len)
-		qdel(src)
-	else if(!isopened)
-		isopened = 1
+	if(!isopened)
+		isopened = TRUE
 		icon_state = "mealpackopened"
 
 //food boxes for storage in bulk


### PR DESCRIPTION
# About the pull request

This PR fixes runtimes with MREs if they spawn on someone that doesn't have space for them (causing 2 extra qdels than needed), fixes MREs getting thrown away when you aren't dropping them on the ground, and changes the behavior of nade_box to not automatically qdel when it is emptied but instead now has the same behavior as a MRE without food being dropped on the ground.

# Explain why it's good for the game

Fixes 
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/65dd8860-2728-4a2d-a251-96dfe12878da)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
add: Nade boxes now have the same throw away logic when dropped to the ground instead of in update_icon when empty.
fix: Fixed MREs getting thrown away if you don't drop them to the ground.
fix: Fixed MREs throwing runtimes if spawned on a person that doesn't have space for the MRE.
/:cl:
