### PR TITLE
Fixes issuing a null order

### DIFF
--- a/code/modules/mob/living/carbon/human/powers/issue_order.dm
+++ b/code/modules/mob/living/carbon/human/powers/issue_order.dm
@@ -22,7 +22,7 @@
 		if(order == "help")
 			to_chat(src, SPAN_NOTICE("<br>Orders give a buff to nearby soldiers for a short period of time, followed by a cooldown, as follows:<br><B>Move</B> - Increased mobility and chance to dodge projectiles.<br><B>Hold</B> - Increased resistance to pain and combat wounds.<br><B>Focus</B> - Increased gun accuracy and effective range.<br>"))
 			return
-		if(order == "cancel")
+		if(!order || order == "cancel")
 			return
 
 		if(!command_aura_available)


### PR DESCRIPTION

# About the pull request

This PR fixes issuing no order if you pick no order in the input list (clicking the X). Not only does it look goofy you give the order to ! it does put your orders on cooldown for no reason.

# Explain why it's good for the game

Fixes 
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/7c5387fa-32d2-405e-947d-c69eb6cbe25f)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
fix: Fixed issuing a null order via the issue order verb.
/:cl:
