### PR TITLE
Milkshakes no longer attempt to drive your body temperature to absolute zero, instead it just gets you to frozen

### DIFF
--- a/code/modules/reagents/chemistry_reagents/drink.dm
+++ b/code/modules/reagents/chemistry_reagents/drink.dm
@@ -202,7 +202,7 @@
 		M = holder.my_atom
 	if(prob(1))
 		M.emote("shiver")
-	M.bodytemperature = max(M.bodytemperature - 10 * TEMPERATURE_DAMAGE_COEFFICIENT, 0)
+	M.bodytemperature = max(M.bodytemperature - 10 * TEMPERATURE_DAMAGE_COEFFICIENT, T0C)
 	M.recalculate_move_delay = TRUE
 	holder.remove_reagent("capsaicin", 5)
 	holder.remove_reagent("hotsauce", 5)


### PR DESCRIPTION

# About the pull request

Cryo drugs start working under 170 Kelvin

Cryo drugs fix IB under 0C ~ 273.15 kelvin

Milkshakes bring you to 0 kelvin.

Now milkshakes bring you to 273.15K/0C, not enough to trigger cryo drugs, but still cold. 

Not cold enough to damage you

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:

balance: Milkshakes no longer bring you to absolute zero, just 0 celsius
/:cl:
