### PR TITLE
Fix verb to adjust predator slots

### DIFF
--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -175,43 +175,46 @@ Additional game mode variables.
 
 	if(pred_candidate) pred_candidate.moveToNullspace() //Nullspace it for garbage collection later.
 
-#define calculate_pred_max (floor(length(GLOB.player_list) / pred_per_players) + pred_additional_max + pred_start_count)
+/datum/game_mode/proc/calculate_pred_max()
+	return floor(length(GLOB.player_list) / pred_per_players) + pred_additional_max + pred_start_count
 
-/datum/game_mode/proc/check_predator_late_join(mob/pred_candidate, show_warning = 1)
-
+/datum/game_mode/proc/check_predator_late_join(mob/pred_candidate, show_warning = TRUE)
 	if(!pred_candidate.client)
 		return
 
-	var/datum/job/J = GLOB.RoleAuthority.roles_by_name[JOB_PREDATOR]
+	var/datum/job/pred_job = GLOB.RoleAuthority.roles_by_name[JOB_PREDATOR]
 
-	if(!J)
-		if(show_warning) to_chat(pred_candidate, SPAN_WARNING("Something went wrong!"))
-		return
+	if(!pred_job)
+		if(show_warning)
+			to_chat(pred_candidate, SPAN_WARNING("Something went wrong!"))
+		return FALSE
 
 	if(!(pred_candidate?.client.check_whitelist_status(WHITELIST_PREDATOR)))
-		if(show_warning) to_chat(pred_candidate, SPAN_WARNING("You are not whitelisted! You may apply on the forums to be whitelisted as a predator."))
-		return
+		if(show_warning)
+			to_chat(pred_candidate, SPAN_WARNING("You are not whitelisted! You may apply on the forums to be whitelisted as a predator."))
+		return FALSE
 
 	if(!(flags_round_type & MODE_PREDATOR))
-		if(show_warning) to_chat(pred_candidate, SPAN_WARNING("There is no Hunt this round! Maybe the next one."))
-		return
+		if(show_warning)
+			to_chat(pred_candidate, SPAN_WARNING("There is no Hunt this round! Maybe the next one."))
+		return FALSE
 
 	if(pred_candidate.ckey in predators)
 		if(show_warning)
 			to_chat(pred_candidate, SPAN_WARNING("You already were a Yautja! Give someone else a chance."))
-		return
+		return FALSE
 
-	if(show_warning && tgui_alert(pred_candidate, "Confirm joining the hunt. You will join as \a [lowertext(J.get_whitelist_status(pred_candidate.client))] predator", "Confirmation", list("Yes", "No"), 10 SECONDS) != "Yes")
-		return
-	if(J.get_whitelist_status(pred_candidate.client) == WHITELIST_NORMAL)
-		var/pred_max = calculate_pred_max
+	if(show_warning && tgui_alert(pred_candidate, "Confirm joining the hunt. You will join as \a [lowertext(pred_job.get_whitelist_status(pred_candidate.client))] predator", "Confirmation", list("Yes", "No"), 10 SECONDS) != "Yes")
+		return FALSE
+
+	if(pred_job.get_whitelist_status(pred_candidate.client) == WHITELIST_NORMAL)
+		var/pred_max = calculate_pred_max()
 		if(pred_current_num >= pred_max)
-			if(show_warning) to_chat(pred_candidate, SPAN_WARNING("Only [pred_max] predators may spawn this round, but Councillors and Ancients do not count."))
-			return
+			if(show_warning)
+				to_chat(pred_candidate, SPAN_WARNING("Only [pred_max] predators may spawn this round, but Councillors and Ancients do not count."))
+			return FALSE
 
-	return 1
-
-#undef calculate_pred_max
+	return TRUE
 
 /datum/game_mode/proc/transform_predator(mob/pred_candidate)
 	set waitfor = FALSE

--- a/code/modules/admin/tabs/round_tab.dm
+++ b/code/modules/admin/tabs/round_tab.dm
@@ -1,22 +1,37 @@
 /client/proc/adjust_predator_round()
-	set name = "Adjust Predator Round"
-	set desc = "Adjust the number of predators present in a predator round."
+	set name = "Adjust Predator Slots"
+	set desc = "Adjust the extra slots for predators."
 	set category = "Server.Round"
 
-	if(admin_holder)
-		if(!SSticker || !SSticker.mode)
-			to_chat(src, SPAN_WARNING("The game hasn't started yet!"))
-			return
+	if(!admin_holder)
+		return
 
-		var/value = tgui_input_number(src,"How many additional predators can join? Decreasing the value is not recommended. Current predator count: [SSticker.mode.pred_current_num]","Input:", 0, (SSticker.mode.pred_additional_max - SSticker.mode.pred_current_num))
+	if(!SSticker?.mode)
+		to_chat(src, SPAN_WARNING("The game hasn't started yet!"))
+		return
 
-		if(value < SSticker.mode.pred_current_num)
-			to_chat(src, SPAN_NOTICE("Aborting. Number cannot be lower than the current pred count. (current: [SSticker.mode.pred_current_num], attempted: [value])"))
-			return
+	var/cur_extra = SSticker.mode.pred_additional_max
+	var/cur_count = SSticker.mode.pred_current_num
+	var/cur_max = SSticker.mode.calculate_pred_max()
+	var/value = tgui_input_number(src, "How many additional predators can join? Current predator count: [cur_count]/[cur_max] Current setting: [cur_extra]", "Input:", default = cur_extra, min_value = 0, integer_only = TRUE)
 
-		if(value)
-			SSticker.mode.pred_additional_max = abs(value)
-			message_admins("[key_name_admin(usr)] adjusted the additional pred amount to [abs(value)].")
+	if(isnull(value))
+		return
+
+	if(value == cur_extra)
+		return
+
+	cur_count = SSticker.mode.pred_current_num // values could have changed since asking
+	cur_max = SSticker.mode.calculate_pred_max()
+	var/free_extra = max(min(cur_extra, cur_max - cur_count), 0) // how much we could potentionally reduce pred_additional_max
+
+	// If we are reducing the count and that exceeds how much we could reduce it by
+	if(value < cur_extra && (cur_extra - value) > free_extra)
+		to_chat(src, SPAN_NOTICE("Aborting. Number cannot result in a max less than current pred count. (current: [cur_count]/[cur_max], current extra: [cur_extra], attempted: [value])"))
+		return
+
+	SSticker.mode.pred_additional_max = value
+	message_admins("[key_name_admin(usr)] adjusted the additional pred amount from [cur_extra] to [value].")
 
 /datum/admins/proc/force_predator_round()
 	set name = "Toggle Predator Round"


### PR DESCRIPTION

# About the pull request

This PR fixes the adjust_predator_round admin verb that could never do anything because its max was always set to a value <= 0. Now it can adjust the pred_additional_max value if it doesn't result in a max lower than the current count. However, I expect the `pred_current_num` to be incorrect if there are say councilors playing since only `WHITELIST_NORMAL` checks the limit, but only `CLAN_RANK_ADMIN` (ancient) prevents `pred_current_num` incrementing... Let me know if & how you would want this corrected.

# Explain why it's good for the game

Admin verbs shouldn't just be dead code.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/35cb8694-9352-4852-a700-da7c68c10d75)

</details>


# Changelog
:cl: Drathek
admin: Fixed the adjust_predator_round verb
/:cl:
