### PR TITLE
Roundstart xenomorph count changes

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -77,6 +77,7 @@
 #define ROUNDSTATUS_FOG_DOWN 1
 #define ROUNDSTATUS_PODDOORS_OPEN 2
 
+#define LATEJOIN_MARINES_PER_LATEJOIN_LARVA_EARLY 4
 #define LATEJOIN_MARINES_PER_LATEJOIN_LARVA 2.5
 
 //=================================================

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -74,6 +74,7 @@ Additional game mode variables.
 	var/monkey_amount = 0 //How many monkeys do we spawn on this map ?
 	var/list/monkey_types = list() //What type of monkeys do we spawn
 	var/latejoin_tally = 0 //How many people latejoined Marines
+	var/latejoin_larva_drop_early = LATEJOIN_MARINES_PER_LATEJOIN_LARVA_EARLY
 	var/latejoin_larva_drop = LATEJOIN_MARINES_PER_LATEJOIN_LARVA //A larva will spawn in once the tally reaches this level. If set to 0, no latejoin larva drop
 	/// Amount of latejoin_tally already awarded as larvas
 	var/latejoin_larva_used = 0

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -259,7 +259,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 	var/list/roles_left = list()
 	var/assigned = 0
 	for(var/priority in HIGH_PRIORITY to LOW_PRIORITY)
-		// Assigning xenos first
+		// Assigning xenos first.
 		assigned += assign_initial_roles(priority, roles_for_mode & GLOB.ROLES_XENO, unassigned_players)
 		// Assigning special roles second. (survivor, predator)
 		assigned += assign_initial_roles(priority, roles_for_mode & (GLOB.ROLES_WHITELISTED|GLOB.ROLES_SPECIAL), unassigned_players)

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -259,8 +259,8 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 	var/list/roles_left = list()
 	var/assigned = 0
 	for(var/priority in HIGH_PRIORITY to LOW_PRIORITY)
-		// Assigning xenos first.
-		assigned += assign_initial_roles(priority, roles_for_mode & GLOB.ROLES_XENO, unassigned_players)
+		// Assigning xenos first, should not be counted
+		assign_initial_roles(priority, roles_for_mode & GLOB.ROLES_XENO, unassigned_players)
 		// Assigning special roles second. (survivor, predator)
 		assigned += assign_initial_roles(priority, roles_for_mode & (GLOB.ROLES_WHITELISTED|GLOB.ROLES_SPECIAL), unassigned_players)
 		// Assigning command third.

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -259,8 +259,8 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 	var/list/roles_left = list()
 	var/assigned = 0
 	for(var/priority in HIGH_PRIORITY to LOW_PRIORITY)
-		// Assigning xenos first, should not be counted
-		assign_initial_roles(priority, roles_for_mode & GLOB.ROLES_XENO, unassigned_players)
+		// Assigning xenos first
+		assigned += assign_initial_roles(priority, roles_for_mode & GLOB.ROLES_XENO, unassigned_players)
 		// Assigning special roles second. (survivor, predator)
 		assigned += assign_initial_roles(priority, roles_for_mode & (GLOB.ROLES_WHITELISTED|GLOB.ROLES_SPECIAL), unassigned_players)
 		// Assigning command third.

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -270,7 +270,7 @@
 	var/latejoin_larva_drop = SSticker.mode.latejoin_larva_drop
 
 	if (ROUND_TIME < XENO_ROUNDSTART_PROGRESS_TIME_2)
-		latejoin_larva_drop = SStgui.mode.latejoin_larva_drop_early
+		latejoin_larva_drop = SSticker.mode.latejoin_larva_drop_early
 
 	if(latejoin_larva_drop && SSticker.mode.latejoin_tally - SSticker.mode.latejoin_larva_used >= latejoin_larva_drop)
 		SSticker.mode.latejoin_larva_used += latejoin_larva_drop

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -267,8 +267,13 @@
 			sq.max_engineers = engi_slot_formula(GLOB.clients.len)
 			sq.max_medics = medic_slot_formula(GLOB.clients.len)
 
-	if(SSticker.mode.latejoin_larva_drop && SSticker.mode.latejoin_tally - SSticker.mode.latejoin_larva_used >= SSticker.mode.latejoin_larva_drop)
-		SSticker.mode.latejoin_larva_used += SSticker.mode.latejoin_larva_drop
+	var/latejoin_larva_drop = SSticker.mode.latejoin_larva_drop
+
+	if (ROUND_TIME < XENO_ROUNDSTART_PROGRESS_TIME_2)
+		latejoin_larva_drop = SStgui.mode.latejoin_larva_drop_early
+
+	if(latejoin_larva_drop && SSticker.mode.latejoin_tally - SSticker.mode.latejoin_larva_used >= latejoin_larva_drop)
+		SSticker.mode.latejoin_larva_used += latejoin_larva_drop
 		var/datum/hive_status/hive
 		for(var/hivenumber in GLOB.hive_datum)
 			hive = GLOB.hive_datum[hivenumber]


### PR DESCRIPTION
# About the pull request
Changes roundstart xeno amounts to try to keep a 1:3 to 1:4 xeno to combat role ratio
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
https://imgur.com/5dSXlmX
This is just an example but this image is taken pre-drop and there are 23 (25 if you count IOs who do not take part on the front for the most part) compared to 12 xenos (one died to pred), the goal was always to keep a 1:3 or 1:4 ratio and it is currently not working and causing lowpop rounds to be onesided steamrolls.
Every time marines win in lowpop you hear after the round from xenos "we had 7 burrowed" so yeah something here is wrong.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Latejoin marines to larva ratio changed to 1:4 for the first 15 minutes, going back to 1:2.5 afterwards.
/:cl:
