### PR TITLE
DS equipment is unslashable and unacidable when installed

### DIFF
--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -20,6 +20,8 @@
 	var/point_cost = 0 //how many points it costs to build this with the fabricator, set to 0 if unbuildable.
 	var/skill_required = SKILL_PILOT_TRAINED
 	var/combat_equipment = TRUE
+	unslashable = FALSE
+	unacidable = FALSE
 
 
 /obj/structure/dropship_equipment/Destroy()
@@ -121,6 +123,8 @@
 		return
 	if(!PC.linked_powerloader || PC.loaded || PC.linked_powerloader.buckled_mob != user)
 		return
+	src.unslashable = FALSE
+	src.unacidable = FALSE
 	PC.grab_object(user, src, "ds_gear", 'sound/machines/hydraulics_1.ogg')
 	if(ship_base)
 		ship_base.installed_equipment = null

--- a/code/modules/dropships/attach_points/attach_point.dm
+++ b/code/modules/dropships/attach_points/attach_point.dm
@@ -57,6 +57,7 @@
 	clamp.update_icon()
 	installed_equipment = ds_equipment
 	ds_equipment.ship_base = src
+	ds_equipment.unslashable = TRUE
 	ds_equipment.plane = plane
 
 	for(var/obj/docking_port/mobile/marine_dropship/shuttle in SSshuttle.mobile)

--- a/code/modules/dropships/attach_points/attach_point.dm
+++ b/code/modules/dropships/attach_points/attach_point.dm
@@ -58,6 +58,7 @@
 	installed_equipment = ds_equipment
 	ds_equipment.ship_base = src
 	ds_equipment.unslashable = TRUE
+	ds_equipment.unacidable = TRUE
 	ds_equipment.plane = plane
 
 	for(var/obj/docking_port/mobile/marine_dropship/shuttle in SSshuttle.mobile)


### PR DESCRIPTION
# About the pull request

Truns on unslashable and unacidable flags when DS equipment is installed on DS.

# Explain why it's good for the game

Makes split drops less punishing, prevents first drop equipment camping a sneaky melting, while keeping the main reason why they are slashable and meltable in the first place, that being to prevent them being used as baricades. If you think that those are risky for xenos, they are not as long as lesser drones are in the game.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: dropship equipment can not be slashed or melted while it is installed on the DS
/:cl:
