### PR TITLE
LZ fog before first drop and sentryguns to guard agains early FOB rush (they last only ten minits)

### DIFF
--- a/code/game/objects/structures/blocker.dm
+++ b/code/game/objects/structures/blocker.dm
@@ -115,11 +115,8 @@ GLOBAL_LIST_INIT(landing_zone_fog, list())
 
 	if(!visible)
 		invisibility = 101
-
-
 /obj/structure/blocker/forcefield/vehicles
 	types = list(/obj/vehicle/)
-
 
 /obj/structure/blocker/forcefield/vehicles/handle_vehicle_bump(obj/vehicle/multitile/multitile_vehicle)
 	if(multitile_vehicle.vehicle_flags & VEHICLE_BYPASS_BLOCKERS)
@@ -132,9 +129,6 @@ GLOBAL_LIST_INIT(landing_zone_fog, list())
 	if(multitile_vehicle.vehicle_flags & VEHICLE_BYPASS_BLOCKERS)
 		return TRUE
 	return FALSE
-
-
-
 
 /obj/structure/blocker/forcefield/human
 	types = list(/mob/living/carbon/human)

--- a/code/game/objects/structures/blocker.dm
+++ b/code/game/objects/structures/blocker.dm
@@ -124,7 +124,7 @@ GLOBAL_LIST_INIT(landing_zone_fog, list())
 /obj/structure/blocker/forcefield/vehicles/handle_vehicle_bump(obj/vehicle/multitile/multitile_vehicle)
 	if(multitile_vehicle.vehicle_flags & VEHICLE_BYPASS_BLOCKERS)
 		return TRUE
-	return FALSE
+	return FALSE  aaa
 
 /obj/structure/blocker/forcefield/multitile_vehicles
 	types = list(/obj/vehicle/multitile/)

--- a/code/game/objects/structures/blocker.dm
+++ b/code/game/objects/structures/blocker.dm
@@ -74,10 +74,8 @@ GLOBAL_LIST_INIT(landing_zone_fog, list())
 	. = ..()
 
 /obj/structure/blocker/landing_zone_fog/proc/Clear()
-	for(var/fog in GLOB.landing_zone_fog)
-		var/obj/structure/blocker/landing_zone_fog/landing_zone_fog = fog
-		GLOB.landing_zone_fog -= landing_zone_fog
-		QDEL_IN(landing_zone_fog, rand(2 SECONDS,4 SECONDS))
+	GLOB.landing_zone_fog -= src
+	QDEL_IN(src, rand(2 SECONDS,4 SECONDS))
 
 /obj/structure/blocker/forcefield
 	name = "forcefield"
@@ -132,10 +130,7 @@ GLOBAL_LIST_INIT(landing_zone_fog, list())
 	types = list(/obj/vehicle/multitile/)
 
 
-/obj/structure/blocker/forcefield/multitile_vehicles/handle_vehicle_bump(obj/vehicle/multitile/multitile_vehicle)
-	if(multitile_vehicle.vehicle_flags & VEHICLE_BYPASS_BLOCKERS)
-		return TRUE
-	return FALSE
+
 
 /obj/structure/blocker/forcefield/human
 	types = list(/mob/living/carbon/human)

--- a/code/game/objects/structures/blocker.dm
+++ b/code/game/objects/structures/blocker.dm
@@ -75,7 +75,7 @@ GLOBAL_LIST_INIT(landing_zone_fog, list())
 
 /obj/structure/blocker/landing_zone_fog/proc/Clear()
 	GLOB.landing_zone_fog -= src
-	QDEL_IN(src, rand(2 SECONDS,4 SECONDS))
+	QDEL_IN(src, rand(3 SECONDS,5 SECONDS))
 
 /obj/structure/blocker/landing_zone_fog/Destroy()
 	GLOB.landing_zone_fog -= src

--- a/code/game/objects/structures/blocker.dm
+++ b/code/game/objects/structures/blocker.dm
@@ -73,6 +73,11 @@ GLOBAL_LIST_INIT(landing_zone_fog, list())
 	GLOB.landing_zone_fog += src
 	. = ..()
 
+/obj/structure/blocker/landing_zone_fog/proc/Clear()
+	for(var/fog in GLOB.landing_zone_fog)
+		var/obj/structure/blocker/landing_zone_fog/landing_zone_fog = fog
+		GLOB.landing_zone_fog -= landing_zone_fog
+		QDEL_IN(landing_zone_fog, rand(2 SECONDS,4 SECONDS))
 
 /obj/structure/blocker/forcefield
 	name = "forcefield"

--- a/code/game/objects/structures/blocker.dm
+++ b/code/game/objects/structures/blocker.dm
@@ -77,6 +77,11 @@ GLOBAL_LIST_INIT(landing_zone_fog, list())
 	GLOB.landing_zone_fog -= src
 	QDEL_IN(src, rand(2 SECONDS,4 SECONDS))
 
+/obj/structure/blocker/landing_zone_fog/Destroy()
+	GLOB.landing_zone_fog -= src
+	. = ..()
+
+
 /obj/structure/blocker/forcefield
 	name = "forcefield"
 

--- a/code/game/objects/structures/blocker.dm
+++ b/code/game/objects/structures/blocker.dm
@@ -73,7 +73,7 @@ GLOBAL_LIST_INIT(landing_zone_fog, list())
 	GLOB.landing_zone_fog += src
 	. = ..()
 
-/obj/structure/blocker/landing_zone_fog/proc/Clear()
+/obj/structure/blocker/landing_zone_fog/proc/clear()
 	GLOB.landing_zone_fog -= src
 	QDEL_IN(src, rand(3 SECONDS,5 SECONDS))
 

--- a/code/game/objects/structures/blocker.dm
+++ b/code/game/objects/structures/blocker.dm
@@ -128,6 +128,11 @@ GLOBAL_LIST_INIT(landing_zone_fog, list())
 /obj/structure/blocker/forcefield/multitile_vehicles
 	types = list(/obj/vehicle/multitile/)
 
+/obj/structure/blocker/forcefield/multitile_vehicles/handle_vehicle_bump(obj/vehicle/multitile/multitile_vehicle)
+	if(multitile_vehicle.vehicle_flags & VEHICLE_BYPASS_BLOCKERS)
+		return TRUE
+	return FALSE
+
 
 
 

--- a/code/game/objects/structures/blocker.dm
+++ b/code/game/objects/structures/blocker.dm
@@ -124,8 +124,7 @@ GLOBAL_LIST_INIT(landing_zone_fog, list())
 /obj/structure/blocker/forcefield/vehicles/handle_vehicle_bump(obj/vehicle/multitile/multitile_vehicle)
 	if(multitile_vehicle.vehicle_flags & VEHICLE_BYPASS_BLOCKERS)
 		return TRUE
-	return FALSE  aaa
-
+	return FALSE
 /obj/structure/blocker/forcefield/multitile_vehicles
 	types = list(/obj/vehicle/multitile/)
 

--- a/code/game/objects/structures/blocker.dm
+++ b/code/game/objects/structures/blocker.dm
@@ -61,6 +61,18 @@
 	attack_hand(M)
 	return XENO_NONCOMBAT_ACTION
 
+GLOBAL_LIST_INIT(landing_zone_fog, list())
+/obj/structure/blocker/landing_zone_fog
+	name = "dense fog"
+	desc = "It looks way too dangerous to traverse. Best wait until it has cleared up."
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "smoke"
+	opacity = TRUE
+
+/obj/structure/blocker/landing_zone_fog/Initialize()
+	GLOB.landing_zone_fog += src
+	. = ..()
+
 
 /obj/structure/blocker/forcefield
 	name = "forcefield"

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -477,6 +477,9 @@ GLOBAL_LIST_INIT(landing_zone_sentryguns, list())
 	icon_state = "premade" //for the map editor only
 	faction_group = FACTION_LIST_MARINE
 	placed = 1
+	var/first_warning = 9 MINUTES
+	var/second_warning = 9 MINUTES + 30 SECONDS
+	var/third_warning = 9 MINUTES + 57 SECONDS
 
 /obj/structure/machinery/defenses/sentry/landing_zone/Initialize()
 	GLOB.landing_zone_sentryguns += src
@@ -487,7 +490,24 @@ GLOBAL_LIST_INIT(landing_zone_sentryguns, list())
 	. = ..()
 /obj/structure/machinery/defenses/sentry/landing_zone/proc/on_landing()
 	GLOB.landing_zone_sentryguns -= src
+	addtimer(CALLBACK(src,PROC_REF(time_left), 1), first_warning)
+	addtimer(CALLBACK(src,PROC_REF(time_left), 2), second_warning)
+	addtimer(CALLBACK(src,PROC_REF(time_left), 3), third_warning)
 	QDEL_IN(src, 10 MINUTES)
+
+/obj/structure/machinery/defenses/sentry/landing_zone/proc/time_left(counter)
+	var/volume = 15
+	switch(counter)
+		if(1)
+			volume = 15
+			visible_message(SPAN_WARNING("\The [name] beeps steadily as its battery gets low."))
+		if(2)
+			volume = 20
+			visible_message(SPAN_WARNING("\The [name] beeps steadily as its battery gets criticly low."))
+		if(3)
+			visible_message(SPAN_WARNING("\The [name] beeps steadily as its battery goes out! It deconstructs itself!"))
+			volume = 25
+	playsound(loc, 'sound/weapons/smg_empty_alarm.ogg', volume, 1)
 
 /obj/structure/machinery/defenses/sentry/premade
 	name = "UA-577 Gauss Turret"

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -467,6 +467,28 @@
 
 	fire(target)
 
+GLOBAL_LIST_INIT(landing_zone_sentryguns, list())
+/obj/structure/machinery/defenses/sentry/landing_zone
+	name = "UA-577 Gauss Turret spaceborn"
+	fire_delay = 2
+	omni_directional = TRUE
+	immobile = TRUE
+	turned_on = TRUE
+	icon_state = "premade" //for the map editor only
+	faction_group = FACTION_LIST_MARINE
+	placed = 1
+
+/obj/structure/machinery/defenses/sentry/landing_zone/Initialize()
+	GLOB.landing_zone_sentryguns += src
+	. = ..()
+
+/obj/structure/machinery/defenses/sentry/landing_zone/Destroy()
+	GLOB.landing_zone_sentryguns -= src
+	. = ..()
+/obj/structure/machinery/defenses/sentry/landing_zone/proc/on_landing()
+	GLOB.landing_zone_sentryguns -= src
+	QDEL_IN(src, 10 MINUTES)
+
 /obj/structure/machinery/defenses/sentry/premade
 	name = "UA-577 Gauss Turret"
 	immobile = TRUE
@@ -529,6 +551,8 @@
 /obj/structure/machinery/defenses/sentry/premade/deployable/almayer
 	fire_delay = 4
 	omni_directional = TRUE
+
+
 
 //the turret inside the shuttle sentry deployment system
 /obj/structure/machinery/defenses/sentry/premade/dropship

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -496,18 +496,16 @@ GLOBAL_LIST_INIT(landing_zone_sentryguns, list())
 	QDEL_IN(src, 10 MINUTES)
 
 /obj/structure/machinery/defenses/sentry/landing_zone/proc/time_left(counter)
-	var/volume = 15
 	switch(counter)
 		if(1)
-			volume = 15
+			playsound(loc, 'sound/weapons/smg_empty_alarm.ogg', 15, 1)
 			visible_message(SPAN_WARNING("\The [name] beeps steadily as its battery gets low."))
 		if(2)
-			volume = 20
+			playsound(loc, 'sound/weapons/smg_empty_alarm.ogg', 20, 1)
 			visible_message(SPAN_WARNING("\The [name] beeps steadily as its battery gets criticly low."))
 		if(3)
-			visible_message(SPAN_WARNING("\The [name] beeps steadily as its battery goes out! It deconstructs itself!"))
-			volume = 25
-	playsound(loc, 'sound/weapons/smg_empty_alarm.ogg', volume, 1)
+			playsound(loc, 'sound/mecha/critdestrsyndi.ogg', 25, 1)
+			visible_message(SPAN_WARNING("\The [name] deconstructs itself as its battery goes out!))
 
 /obj/structure/machinery/defenses/sentry/premade
 	name = "UA-577 Gauss Turret"

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -505,7 +505,8 @@ GLOBAL_LIST_INIT(landing_zone_sentryguns, list())
 			visible_message(SPAN_WARNING("\The [name] beeps steadily as its battery gets criticly low."))
 		if(3)
 			playsound(loc, 'sound/mecha/critdestrsyndi.ogg', 25, 1)
-			visible_message(SPAN_WARNING("\The [name] deconstructs itself as its battery goes out!))
+			visible_message(SPAN_WARNING("\The [name] deconstructs itself as its battery goes out!"))
+
 
 /obj/structure/machinery/defenses/sentry/premade
 	name = "UA-577 Gauss Turret"

--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -261,9 +261,8 @@
 		xeno_announcement(SPAN_XENOANNOUNCE("The dropship has landed."), "everything")
 		xeno_announce = FALSE
 
-	for(var/fog in GLOB.landing_zone_fog)
-		var/obj/structure/blocker/landing_zone_fog/landing_zone_fog = fog
-		landing_zone_fog.Clear()
+	for(var/obj/structure/blocker/landing_zone_fog/fog as anything in GLOB.landing_zone_fog)
+		fog.clear()
 
 /obj/docking_port/stationary/marine_dropship/on_dock_ignition(obj/docking_port/mobile/departing_shuttle)
 	. = ..()

--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -261,6 +261,9 @@
 		xeno_announcement(SPAN_XENOANNOUNCE("The dropship has landed."), "everything")
 		xeno_announce = FALSE
 
+	for(var/obj/structure/blocker/landing_zone_fog/fog as anything in GLOB.landing_zone_fog)
+		fog.Clear()
+
 	for(var/obj/structure/machinery/defenses/sentry/landing_zone/sentrygun as anything in GLOB.landing_zone_sentryguns)
 		sentrygun.on_landing()
 

--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -261,6 +261,10 @@
 		xeno_announcement(SPAN_XENOANNOUNCE("The dropship has landed."), "everything")
 		xeno_announce = FALSE
 
+	for(var/fog in GLOB.landing_zone_fog)
+		var/obj/structure/blocker/landing_zone_fog/landing_zone_fog = fog
+		landing_zone_fog.Clear()
+
 /obj/docking_port/stationary/marine_dropship/on_dock_ignition(obj/docking_port/mobile/departing_shuttle)
 	. = ..()
 	turn_on_landing_lights()

--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -261,8 +261,8 @@
 		xeno_announcement(SPAN_XENOANNOUNCE("The dropship has landed."), "everything")
 		xeno_announce = FALSE
 
-	for(var/obj/structure/blocker/landing_zone_fog/fog as anything in GLOB.landing_zone_fog)
-		fog.clear()
+	for(var/obj/structure/machinery/defenses/sentry/landing_zone/sentrygun as anything in GLOB.landing_zone_sentryguns)
+		sentrygun.on_landing()
 
 /obj/docking_port/stationary/marine_dropship/on_dock_ignition(obj/docking_port/mobile/departing_shuttle)
 	. = ..()

--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -262,7 +262,7 @@
 		xeno_announce = FALSE
 
 	for(var/obj/structure/blocker/landing_zone_fog/fog as anything in GLOB.landing_zone_fog)
-		fog.Clear()
+		fog.clear()
 
 	for(var/obj/structure/machinery/defenses/sentry/landing_zone/sentrygun as anything in GLOB.landing_zone_sentryguns)
 		sentrygun.on_landing()

--- a/code/modules/shuttles/marine_ferry.dm
+++ b/code/modules/shuttles/marine_ferry.dm
@@ -587,7 +587,7 @@
 	for(var/fog in GLOB.landing_zone_fog)
 		var/obj/structure/blocker/landing_zone_fog/landing_zone_fog = fog
 		landing_zone_fog -= fog
-		QDEL_IN(landing_zone_fog, rand(2,4))
+		QDEL_IN(landing_zone_fog, rand(2 SECONDS,4 SECONDS))
 
 	moving_status = SHUTTLE_IDLE
 

--- a/code/modules/shuttles/marine_ferry.dm
+++ b/code/modules/shuttles/marine_ferry.dm
@@ -298,10 +298,6 @@
 		var/obj/structure/dropship_equipment/E = X
 		E.on_arrival()
 
-	for(var/fog in GLOB.landing_zone_fog)
-		var/obj/structure/blocker/landing_zone_fog/landing_zone_fog = fog
-		landing_zone_fog.Clear()
-
 	moving_status = SHUTTLE_IDLE
 
 	if(!transit_gun_mission) //we're back where we started, no location change.
@@ -577,9 +573,6 @@
 	for(var/X in equipments)
 		var/obj/structure/dropship_equipment/E = X
 		E.on_arrival()
-	for(var/fog in GLOB.landing_zone_fog)
-		var/obj/structure/blocker/landing_zone_fog/landing_zone_fog = fog
-		landing_zone_fog.Clear()
 
 	moving_status = SHUTTLE_IDLE
 

--- a/code/modules/shuttles/marine_ferry.dm
+++ b/code/modules/shuttles/marine_ferry.dm
@@ -297,6 +297,13 @@
 	for(var/X in equipments)
 		var/obj/structure/dropship_equipment/E = X
 		E.on_arrival()
+	for(var/fog in GLOB.landing_zone_fog)
+		var/obj/structure/blocker/landing_zone_fog/landing_zone_fog = fog
+		landing_zone_fog -= fog
+		QDEL_IN(landing_zone_fog, rand(2,4))
+
+
+
 
 	moving_status = SHUTTLE_IDLE
 
@@ -500,6 +507,10 @@
 	for(var/X in equipments)
 		var/obj/structure/dropship_equipment/E = X
 		E.on_arrival()
+	for(var/fog in GLOB.landing_zone_fog)
+		var/obj/structure/blocker/landing_zone_fog/landing_zone_fog = fog
+		landing_zone_fog -= fog
+		QDEL_IN(landing_zone_fog, rand(2,4))
 
 	open_doors_crashed(turfs_trg) //And now open the doors
 
@@ -573,6 +584,10 @@
 	for(var/X in equipments)
 		var/obj/structure/dropship_equipment/E = X
 		E.on_arrival()
+	for(var/fog in GLOB.landing_zone_fog)
+		var/obj/structure/blocker/landing_zone_fog/landing_zone_fog = fog
+		landing_zone_fog -= fog
+		QDEL_IN(landing_zone_fog, rand(2,4))
 
 	moving_status = SHUTTLE_IDLE
 

--- a/code/modules/shuttles/marine_ferry.dm
+++ b/code/modules/shuttles/marine_ferry.dm
@@ -297,13 +297,10 @@
 	for(var/X in equipments)
 		var/obj/structure/dropship_equipment/E = X
 		E.on_arrival()
+
 	for(var/fog in GLOB.landing_zone_fog)
 		var/obj/structure/blocker/landing_zone_fog/landing_zone_fog = fog
-		landing_zone_fog -= fog
-		QDEL_IN(landing_zone_fog, rand(2,4))
-
-
-
+		landing_zone_fog.Clear()
 
 	moving_status = SHUTTLE_IDLE
 
@@ -507,10 +504,6 @@
 	for(var/X in equipments)
 		var/obj/structure/dropship_equipment/E = X
 		E.on_arrival()
-	for(var/fog in GLOB.landing_zone_fog)
-		var/obj/structure/blocker/landing_zone_fog/landing_zone_fog = fog
-		landing_zone_fog -= fog
-		QDEL_IN(landing_zone_fog, rand(2,4))
 
 	open_doors_crashed(turfs_trg) //And now open the doors
 
@@ -586,8 +579,7 @@
 		E.on_arrival()
 	for(var/fog in GLOB.landing_zone_fog)
 		var/obj/structure/blocker/landing_zone_fog/landing_zone_fog = fog
-		landing_zone_fog -= fog
-		QDEL_IN(landing_zone_fog, rand(2 SECONDS,4 SECONDS))
+		landing_zone_fog.Clear()
 
 	moving_status = SHUTTLE_IDLE
 


### PR DESCRIPTION
# About the pull request

adds a fog that is removed on DS landing and omnisentryguns ment for LZ that last for 10 minits after first touchdown, THIS IS NOT MAPPING PR, at least for now, it is not used in any map, reqires mappers to add it. Mby getting some better smoke / gas spirte if someone is able to do that would be apriciated. aka alamayer drops gasbombs and omnisentryguns on LZ to secure the landing ( welp at least some IC explonation for fog on LZ aint it?) also fog removal on flyby landing, if it happens before first drop, is intentional. sentrgun numbers NEED adjusting, I threw in some random stuff, the sentrygun is work in progress mostly


# Explain why it's good for the game
this solves two issues, survivors or xenos camping LZs for first landing. And early FOB rushes. first one is kinda meh second one is realy needed, round ending at 40 minits just is not fun for anyone, this does not make early fob pushes impossible but a lot harder, relevant voices said that mechanical solution is better then rule, sentrygun punishes you in predictable way and you do not have to argue with it. And admins hate handeling "t3s are standing on LZ first drop" tickets so it is win win 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: adds option for fog that drops on first landing
add:  adds option landing zone sentryguns that last for 10 minits after the first drop
/:cl:
