### PR TITLE
New Varadero - Tunnel Touch-Up

### DIFF
--- a/maps/map_files/New_Varadero/New_Varadero.dmm
+++ b/maps/map_files/New_Varadero/New_Varadero.dmm
@@ -3629,7 +3629,7 @@
 	},
 /area/varadero/interior/hall_NW)
 "coc" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/tunnel/maint_tunnel,
 /turf/open/floor/shiva{
 	icon_state = "blue"
 	},
@@ -6436,7 +6436,7 @@
 	id = "north_research_tunnel"
 	},
 /turf/open/auto_turf/sand_white/layer1,
-/area/varadero/interior/caves/north_research)
+/area/varadero/interior_protected/caves/digsite)
 "emC" = (
 /obj/structure/surface/rack,
 /obj/item/tool/surgery/scalpel/pict_system,
@@ -7297,6 +7297,7 @@
 /turf/open/floor/wood,
 /area/varadero/interior/court)
 "eMD" = (
+/obj/structure/tunnel/maint_tunnel,
 /turf/open/floor/shiva{
 	dir = 10;
 	icon_state = "red"
@@ -18168,6 +18169,7 @@
 	},
 /area/varadero/interior/medical)
 "lLq" = (
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/shiva{
 	dir = 8;
 	icon_state = "yellowfull"
@@ -35354,11 +35356,11 @@
 	},
 /area/varadero/interior/comms3)
 "wvI" = (
-/obj/structure/tunnel{
-	id = "north_research_tunnel"
+/obj/structure/tunnel/maint_tunnel,
+/turf/open/floor/shiva{
+	icon_state = "purple"
 	},
-/turf/open/auto_turf/sand_white/layer1,
-/area/varadero/interior/hall_SE)
+/area/varadero/interior/research)
 "wvK" = (
 /obj/structure/closet/crate/freezer,
 /obj/effect/landmark/objective_landmark/close,
@@ -39119,7 +39121,7 @@ oPQ
 xCn
 cBI
 xCn
-emt
+xCn
 ljt
 pGs
 pGs
@@ -41301,7 +41303,7 @@ wmg
 vSY
 izs
 oyi
-sDM
+wvI
 fay
 ebr
 ebr
@@ -52785,7 +52787,7 @@ cto
 iFb
 mCF
 jdm
-mCF
+mSa
 mCF
 mCF
 mCF
@@ -53503,7 +53505,7 @@ pKs
 chs
 chs
 kGq
-wvI
+ixr
 ixr
 ixr
 ixr
@@ -53545,7 +53547,7 @@ xxk
 xxk
 xEG
 cSa
-mCF
+mSa
 mCF
 mCF
 mCF
@@ -62111,7 +62113,7 @@ cty
 cty
 aOg
 mCF
-mSa
+mCF
 mCF
 pGs
 pGs
@@ -62979,7 +62981,7 @@ wXs
 xJZ
 ouy
 eyt
-wnE
+kbQ
 kbQ
 kbQ
 kbQ
@@ -64787,7 +64789,7 @@ eyt
 eyt
 jqw
 qfu
-kbQ
+wnE
 sgk
 kbQ
 kbQ
@@ -65918,7 +65920,7 @@ bsf
 bsf
 bsf
 bsf
-bsf
+emt
 bsf
 bsf
 pDX


### PR DESCRIPTION
# About the pull request

Adds some new tunnels to New Varadero and relocates some existing ones.

# Explain why it's good for the game

New Varadero currently only has five tunnels focused entirely on the cave system and lack any real central-map coverage and some of the existing spots are also, in my opinion, not particularly good. The intent of these new tunnels and the re-shuffling of the locations is to provide more mid-map options and better overall coverage for travel, bringing N.V more in line with other maps which, on average, have between 7-8 tunnels by default.

Research, Engineering and Security now have tunnels to allow easier access to the middle of the map ; I have taken care to not put them too far north as they would be too close to the LZs.

One tunnel in the far south of the caves has been moved eastwards towards the crashed ship to make it more useful, it is at the front of the ship and should be easily taken down should marines push the area. Another tunnel north of the sensor tower has now been placed right next to it and should be easily taken down if the area is pushed, this is to keep it from being too close to the new additions to Engineering and Security. 

The research tunnel has been moved into the main research area instead of the caves to allow more streamlined travel into the mid-map area. The tunnel originally at the entrance to the beach caves has been moved northwards to distance it from the crashed ship tunnel. Another tunnel has been added in the far south tunnel to cover the area.

The overall intent of this PR is to bring it more in line with the average amount that other maps have by default and to generally improve the coverage of the base tunnels and allow more middle-map coverage, similar to what I did with my PR to amend the tunnels on Sorokyne.

# Testing Photographs and Procedure

_(Colored lines are visual aides to help you see them, they are not indicative of any special function*)_

The original tunnel setup.
![Varadero Base - Tunnel Diagram](https://github.com/cmss13-devs/cmss13/assets/31109792/20fbb51a-07f3-4ea8-b875-2f3006c20416)

The new tunnel setup.
![Varadero Modified - Tunnel Diagram](https://github.com/cmss13-devs/cmss13/assets/31109792/97f001ac-b974-4680-bb05-5a4d23dc5469)

Combined version, orange is the original and blue is the proposed.
![Varadero Modified - Complete Tunnel Diagram - Cropped](https://github.com/cmss13-devs/cmss13/assets/31109792/5d6f64aa-b9e1-4b94-a22e-ba39c87ed658)

# Changelog
:cl:
mapadd: Added three new tunnels to New Varadero.
maptweak: Adjusts placement of some existing tunnels on New Varadero.
/:cl:
