### PR TITLE
Maintenance Jack pry time decreased on unpowered doors

### DIFF
--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -568,8 +568,8 @@
 		if(attacked_door.density && !attacked_door.arePowerSystemsOn()) // if its closed and unpowered
 			attacked_door.open(TRUE)
 			return
-		if(!attacked_door.density) //If its open
-		return
+		if(!attacked_door.density && attacked_door.arePowerSystemsOn()) //If its open and powered
+			return
 
 		user.visible_message(SPAN_DANGER("[user] jams [src] into [attacked_door] and starts to pry it open."),
 		SPAN_DANGER("You jam [src] into [attacked_door] and start to pry it open."))

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -568,7 +568,7 @@
 		if(attacked_door.density && !attacked_door.arePowerSystemsOn()) // if its closed and unpowered
 			attacked_door.open(TRUE)
 			return
-		if(!attacked_door.density && attacked_door.arePowerSystemsOn()) //If its open and powered
+		if(!attacked_door.density) //If its open
 			return
 
 		user.visible_message(SPAN_DANGER("[user] jams [src] into [attacked_door] and starts to pry it open."),

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -557,12 +557,16 @@
 		if(requires_superstrength_pry)
 			if(!HAS_TRAIT(user, TRAIT_SUPER_STRONG)) //basically IS_PRY_CAPABLE_CROWBAR
 				return
-		if(!attacked_door.density) //If its open
-			return
 		if(attacked_door.heavy) //Unopenable
 			to_chat(usr, SPAN_DANGER("You cannot force [attacked_door] open."))
 			return
 		if(user.action_busy)
+			return
+		if(!attacked_door.density && !attacked_door.arePowerSystemsOn()) //If its open and unpowered
+			attacked_door.close(TRUE)
+			return
+		if(attacked_door.density && !attacked_door.arePowerSystemsOn()) // if its closed and unpowered
+			attacked_door.open(TRUE)
 			return
 
 		user.visible_message(SPAN_DANGER("[user] jams [src] into [attacked_door] and starts to pry it open."),

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -568,6 +568,8 @@
 		if(attacked_door.density && !attacked_door.arePowerSystemsOn()) // if its closed and unpowered
 			attacked_door.open(TRUE)
 			return
+		if(!attacked_door.density) //If its open
+		return
 
 		user.visible_message(SPAN_DANGER("[user] jams [src] into [attacked_door] and starts to pry it open."),
 		SPAN_DANGER("You jam [src] into [attacked_door] and start to pry it open."))

--- a/code/modules/tgs/v5/chunking.dm
+++ b/code/modules/tgs/v5/chunking.dm
@@ -7,7 +7,7 @@
 	var/chunk_count
 	var/list/chunk_requests
 	for(chunk_count = 2; !chunk_requests; ++chunk_count)
-		var/max_chunk_size = -floor(-(data_length / chunk_count))
+		var/max_chunk_size = -round(-(data_length / chunk_count))
 		if(max_chunk_size > limit)
 			continue
 


### PR DESCRIPTION
# About the pull request

This changes the maintenance jack crowbar mode to now open and close unpowered doors just as fast as a normal crowbar, and allows it to pry open doors closed. powered doors still take three seconds to pry open.

# Explain why it's good for the game

As it stands, the maintenance jack is a hard sell for synthetics. the draw of the jack is that it is two tools bundled into one, with benefits for each mode not found on the individual tools (wrench can open bolts, crowbar can pry powered doors). The problem with this is that the crowbar takes forever to open closed and unpowered doors (one of the most common uses of the crowbar) which makes it practically obsolete compared to the normal crowbar. Additionally, the jack can't pry doors closed, a trait exclusive to the jack. This means that not only does it take forever to pry an unpowered door open, but you also can't pry it back closed again. This change should lead to more diversity in synthetic loadouts, as now you aren't using your precious experimental vendor points on a wrench and a straight up worse crowbar.

# Testing Photographs and Procedure




<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog



:cl: Nomoresolvalou
balance: unpowered doors are now opened instantly in maintenance jack crowbar mode instead of in three seconds.
balance: crowbar mode can now pry doors closed when unpowered.
/:cl: