### PR TITLE
Restricts contents of custom loadout weapon boxes

### DIFF
--- a/code/game/objects/items/storage/misc.dm
+++ b/code/game/objects/items/storage/misc.dm
@@ -119,6 +119,7 @@
 	w_class = SIZE_SMALL
 	max_w_class = SIZE_TINY
 	storage_slots = 2
+	can_hold = list(/obj/item/weapon/gun/pistol/clfpistol, /obj/item/ammo_magazine/pistol/clfpistol)
 
 /obj/item/storage/box/clf/fill_preset_inventory()
 	new /obj/item/weapon/gun/pistol/clfpistol(src)
@@ -132,6 +133,7 @@
 	w_class = SIZE_MEDIUM
 	max_w_class = SIZE_MEDIUM
 	storage_slots = 3
+	can_hold = list(/obj/item/weapon/gun/pistol/t73, /obj/item/ammo_magazine/pistol/t73)
 
 /obj/item/storage/box/upp/fill_preset_inventory()
 	new /obj/item/weapon/gun/pistol/t73(src)
@@ -147,6 +149,7 @@
 	storage_slots = 3
 	w_class = SIZE_SMALL
 	max_w_class = SIZE_SMALL
+	can_hold = list(/obj/item/attachable/bayonet/co2, /obj/item/co2_cartridge)
 
 /obj/item/storage/box/co2_knife/fill_preset_inventory()
 	new /obj/item/attachable/bayonet/co2(src)

--- a/code/game/objects/items/storage/misc.dm
+++ b/code/game/objects/items/storage/misc.dm
@@ -119,7 +119,6 @@
 	w_class = SIZE_SMALL
 	max_w_class = SIZE_TINY
 	storage_slots = 2
-	can_hold = list(/obj/item/weapon/gun/pistol/clfpistol, /obj/item/ammo_magazine/pistol/clfpistol)
 
 /obj/item/storage/box/clf/fill_preset_inventory()
 	new /obj/item/weapon/gun/pistol/clfpistol(src)
@@ -133,7 +132,6 @@
 	w_class = SIZE_MEDIUM
 	max_w_class = SIZE_MEDIUM
 	storage_slots = 3
-	can_hold = list(/obj/item/weapon/gun/pistol/t73, /obj/item/ammo_magazine/pistol/t73)
 
 /obj/item/storage/box/upp/fill_preset_inventory()
 	new /obj/item/weapon/gun/pistol/t73(src)
@@ -149,7 +147,6 @@
 	storage_slots = 3
 	w_class = SIZE_SMALL
 	max_w_class = SIZE_SMALL
-	can_hold = list(/obj/item/attachable/bayonet/co2, /obj/item/co2_cartridge)
 
 /obj/item/storage/box/co2_knife/fill_preset_inventory()
 	new /obj/item/attachable/bayonet/co2(src)

--- a/code/game/objects/items/storage/misc.dm
+++ b/code/game/objects/items/storage/misc.dm
@@ -144,7 +144,6 @@
 	name = "M8 cartridge bayonet packaging"
 	desc = "Contains one M8 Cartridge Bayonet and two sister CO2 cartridges. Thanks for being a dedicated Boots magazine subscriber!"
 	icon_state = "co2_box"
-	can_hold = list(/obj/item/attachable/bayonet/co2, /obj/item/co2_cartridge)
 	foldable = TRUE
 	storage_slots = 3
 	w_class = SIZE_SMALL


### PR DESCRIPTION
# About the pull request

Adds a can_hold list to the Type 73 storing case, D18-storing boxx, and the M8 cartridge bayonet packaging. 

# Explain why it's good for the game

Prevents any unintended use of these items, such as storing 3 medium sized items inside of a single medium size slot within  a satchel.

Fixing oversights is good.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

https://streamable.com/8rh75b

</details>


# Changelog
:cl:
fix: Fixed some oversights with custom loadout provided weapon boxes
/:cl: