### PR TITLE
Track targets in interiors

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1272,10 +1272,18 @@
 
 	if(!H || H.w_uniform?.sensor_mode != SENSOR_MODE_LOCATION)
 		return
-	if(H.z != src.z || get_dist(src,H) < 1 || src == H)
+
+	var/atom/tracking_atom = H
+	if(tracking_atom.z != src.z && SSinterior.in_interior(tracking_atom))
+		var/datum/interior/interior = SSinterior.get_interior_by_coords(tracking_atom.x, tracking_atom.y, tracking_atom.z)
+		var/atom/exterior = interior.exterior
+		if(exterior)
+			tracking_atom = exterior
+
+	if(tracking_atom.z != src.z || get_dist(src, tracking_atom) < 1 || src == tracking_atom)
 		hud_used.locate_leader.icon_state = "trackondirect[tracking_suffix]"
 	else
-		hud_used.locate_leader.setDir(Get_Compass_Dir(src,H))
+		hud_used.locate_leader.setDir(Get_Compass_Dir(src, tracking_atom))
 		hud_used.locate_leader.icon_state = "trackon[tracking_suffix]"
 
 /mob/living/carbon/proc/locate_nearest_nuke()

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -428,6 +428,12 @@ Make sure their actual health updates immediately.*/
 			queen_locator()
 		return
 
+	if(tracking_atom.loc.z != loc.z && SSinterior.in_interior(tracking_atom))
+		var/datum/interior/interior = SSinterior.get_interior_by_coords(tracking_atom.x, tracking_atom.y, tracking_atom.z)
+		var/atom/exterior = interior.exterior
+		if(exterior)
+			tracking_atom = exterior
+
 	if(tracking_atom.loc.z != loc.z || get_dist(src, tracking_atom) < 1 || src == tracking_atom)
 		locator.icon_state = "trackondirect"
 	else


### PR DESCRIPTION

# About the pull request

Squad/Queen/Leader trackers can indicate the direction of the interior the target is in.
![image](https://github.com/cmss13-devs/cmss13/assets/14267245/285565f7-8d0f-4a91-ba46-bf289bea691d)
![image](https://github.com/cmss13-devs/cmss13/assets/14267245/85dd3749-7af6-4136-9b4c-84c76f8f2c9a)

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Even though mechanically the interior is on a different z-level, their contents isn't meant to be a different dimension and the tracker should continue to give helpful information.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: squad/queen/leader trackers can find targets in interiors
/:cl:
