### PR TITLE
Cats now have the correct name and description when held and in your bag

### DIFF
--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -34,6 +34,15 @@
 	for(var/mob/living/M in contents)
 		M.show_message(message,m_type)
 
+/obj/item/holder/get_examine_text(mob/user)
+	. = list()
+	. += "[icon2html(src, user)] That's \a [src]."
+	if(desc)
+		. += desc
+	if(desc_lore)
+		. += SPAN_NOTICE("This has an <a href='byond://?src=\ref[src];desc_lore=1'>extended lore description</a>.")
+
+
 //Mob procs and vars for scooping up
 /mob/living/var/holder_type
 
@@ -48,9 +57,10 @@
 		return
 
 	var/obj/item/holder/mob_holder = new holder_type(loc)
-	src.forceMove(mob_holder)
-	mob_holder.name = src.name
-	mob_holder.desc = src.desc
+	forceMove(mob_holder)
+	mob_holder.name = name
+	mob_holder.desc = desc
+	mob_holder.gender = gender
 	mob_holder.attack_hand(grabber)
 
 	to_chat(grabber, "You scoop up [src].")

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -49,7 +49,8 @@
 
 	var/obj/item/holder/mob_holder = new holder_type(loc)
 	src.forceMove(mob_holder)
-	mob_holder.name = loc.name
+	mob_holder.name = src.name
+	mob_holder.desc = src.desc
 	mob_holder.attack_hand(grabber)
 
 	to_chat(grabber, "You scoop up [src].")


### PR DESCRIPTION

# About the pull request

changes the get_scooped proc so that it now uses the correct name and description when creating a new mob_holder object. This means that mobs will have the correct name and description when held or in a container.

# Explain why it's good for the game

saying, "Here's the colony cat, Orion!" and then using the show held item verb, only to show "cat" with the default cat description makes no sense and breaks my immersion.


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog



:cl: Nomoresolvalou

fix: fixed cats not specifically defined in code displaying wrong info when held or stored in a container. This should also fix any other mob capable of being picked up that is not defined in code as well.

/:cl:
