### PR TITLE
Ghost health scan usable range increase

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -655,7 +655,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	usr.forceMove(pick(L))
 	following = null
 
-/mob/dead/observer/proc/scan_health(mob/living/target in oview())
+/mob/dead/observer/proc/scan_health(mob/living/target in view(src.client))
 	set name = "Scan Health"
 
 	if(!istype(target))


### PR DESCRIPTION

# About the pull request

The "Scan Health" verb can now be used by ghosts on any visible mob.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Currently ghost's "Scan Health" only works on mobs that are within the default view distance, even though ghosts can zoom out significantly farther. This allows the ghost to scan anything their client can see.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: ghost "Scan Health" works at any range
/:cl:
