### PR TITLE
AMR Anti-Focusing nerfs

### DIFF
--- a/code/datums/ammo/bullet/sniper.dm
+++ b/code/datums/ammo/bullet/sniper.dm
@@ -135,7 +135,7 @@
 				if(amr.focused_fire_counter < 2) // Can stack up to twice.
 					amr.focused_fire_counter += 1
 				else
-					amr.focused_fire_counter = 0
+					amr.focused_fire_counter = -1
 			else // If it's a new target
 				amr.focused_fire_counter = 0 // Stacks to 0
 				if(human_firer && !(target_mob.is_dead()))
@@ -184,17 +184,17 @@
 
 		if((focused_fire_active || isxeno(target_mob)) && !(target_mob.is_dead()))
 			switch(amr_counter)
-				if(1)
+				if(0)
 					to_chat(aimed_projectile.firer, SPAN_WARNING("One hit! You begin to carefully track the target's movements."))
 					if(isxeno(target_mob) && isxeno(old_target?.resolve()))
 						var/mob/living/carbon/xenomorph/old_xeno = old_target.resolve()
 						var/mob/living/carbon/xenomorph/new_xeno = target_mob
 						if((old_xeno.hive == new_xeno.hive) && !(old_xeno.stat)) // Must be in same hive and conscious
 							to_chat(old_xeno,SPAN_XENOLEADER("The feeling of looming danger fades as we sense that another sister has been targeted instead."))
-				if(2)
+				if(1)
 					to_chat(aimed_projectile.firer, SPAN_WARNING("Two hits! You're starting to get a good read on the target's patterns."))
-				if(3)
-					to_chat(aimed_projectile.firer, SPAN_WARNING("Bullseye! It appears the heavy hit has made the target change its patterns."))
+				if(2)
+					to_chat(aimed_projectile.firer, SPAN_WARNING("Bullseye!"))
 				else
 					to_chat(aimed_projectile.firer, SPAN_WARNING("Bullseye!"))
 		else

--- a/code/datums/ammo/bullet/sniper.dm
+++ b/code/datums/ammo/bullet/sniper.dm
@@ -184,16 +184,16 @@
 
 		if((focused_fire_active || isxeno(target_mob)) && !(target_mob.is_dead()))
 			switch(amr_counter)
-				if(0)
+				if(1)
 					to_chat(aimed_projectile.firer, SPAN_WARNING("One hit! You begin to carefully track the target's movements."))
 					if(isxeno(target_mob) && isxeno(old_target?.resolve()))
 						var/mob/living/carbon/xenomorph/old_xeno = old_target.resolve()
 						var/mob/living/carbon/xenomorph/new_xeno = target_mob
 						if((old_xeno.hive == new_xeno.hive) && !(old_xeno.stat)) // Must be in same hive and conscious
 							to_chat(old_xeno,SPAN_XENOLEADER("The feeling of looming danger fades as we sense that another sister has been targeted instead."))
-				if(1)
-					to_chat(aimed_projectile.firer, SPAN_WARNING("Two hits! You're starting to get a good read on the target's patterns."))
 				if(2)
+					to_chat(aimed_projectile.firer, SPAN_WARNING("Two hits! You're starting to get a good read on the target's patterns."))
+				if(3)
 					to_chat(aimed_projectile.firer, SPAN_WARNING("Bullseye!"))
 				else
 					to_chat(aimed_projectile.firer, SPAN_WARNING("Bullseye!"))

--- a/code/datums/ammo/bullet/sniper.dm
+++ b/code/datums/ammo/bullet/sniper.dm
@@ -135,7 +135,7 @@
 				if(amr.focused_fire_counter < 2) // Can stack up to twice.
 					amr.focused_fire_counter += 1
 				else
-					amr.focused_fire_counter = 2
+					amr.focused_fire_counter = 0
 			else // If it's a new target
 				amr.focused_fire_counter = 0 // Stacks to 0
 				if(human_firer && !(target_mob.is_dead()))
@@ -194,7 +194,7 @@
 				if(2)
 					to_chat(aimed_projectile.firer, SPAN_WARNING("Two hits! You're starting to get a good read on the target's patterns."))
 				if(3)
-					to_chat(aimed_projectile.firer, SPAN_WARNING("Bullseye! You're fully focused on the target."))
+					to_chat(aimed_projectile.firer, SPAN_WARNING("Bullseye! It appears the heavy hit has made the target change its patterns."))
 				else
 					to_chat(aimed_projectile.firer, SPAN_WARNING("Bullseye!"))
 		else

--- a/code/datums/ammo/bullet/sniper.dm
+++ b/code/datums/ammo/bullet/sniper.dm
@@ -132,10 +132,10 @@
 			old_target = amr.focused_fire_target
 
 			if(target_mob == (amr.focused_fire_target?.resolve()))
-				if(amr.focused_fire_counter < 2) // Can stack up to twice.
+				if(amr.focused_fire_counter < 3) // Can stack up to twice.
 					amr.focused_fire_counter += 1
 				else
-					amr.focused_fire_counter = -1
+					amr.focused_fire_counter = 0
 			else // If it's a new target
 				amr.focused_fire_counter = 0 // Stacks to 0
 				if(human_firer && !(target_mob.is_dead()))
@@ -144,7 +144,7 @@
 					human_firer.focused_fire_marker = focused_fire_marker_temp // Store new marker ref
 					human_firer.client?.images += focused_fire_marker_temp // Add new marker
 
-			amr_counter = amr.focused_fire_counter + 1
+			amr_counter = min(amr.focused_fire_counter + 1, 3)
 			amr.focused_fire_target = WEAKREF(target_mob)
 
 		var/size_damage_mod = 0.8 // 1.8x vs Non-Xenos (225)

--- a/code/datums/ammo/bullet/sniper.dm
+++ b/code/datums/ammo/bullet/sniper.dm
@@ -194,7 +194,7 @@
 				if(2)
 					to_chat(aimed_projectile.firer, SPAN_WARNING("Two hits! You're starting to get a good read on the target's patterns."))
 				if(3)
-					to_chat(aimed_projectile.firer, SPAN_WARNING("Bullseye!"))
+					to_chat(aimed_projectile.firer, SPAN_WARNING("Bullseye! You're fully focused on the target. You notice they are starting to change their patterns."))
 				else
 					to_chat(aimed_projectile.firer, SPAN_WARNING("Bullseye!"))
 		else

--- a/code/modules/projectiles/guns/specialist/sniper.dm
+++ b/code/modules/projectiles/guns/specialist/sniper.dm
@@ -128,7 +128,7 @@
 
 	if(istype(sniper_rifle, /obj/item/weapon/gun/rifle/sniper/XM43E1))
 		var/obj/item/weapon/gun/rifle/sniper/XM43E1/amr = sniper_rifle
-		if((amr.focused_fire_counter >= 1) && (target == amr.focused_fire_target?.resolve()))
+		if((amr.focused_fire_counter >= 1 && amr.focused_fire_counter < 3) && (target == amr.focused_fire_target?.resolve()))
 			sniper_rifle.enable_aimed_shot_icon_alt = TRUE
 		else
 			sniper_rifle.enable_aimed_shot_icon_alt = FALSE


### PR DESCRIPTION
# About the pull request
Makes the AMR counter reset to 0 after two fully charged shots
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Being rewarded for focusing down a single xeno is toxic and bad for the game. Instead, after hitting it with 2 heavy shots you will have a choice between continuing to focus that xeno or focusing a different xeno with no loss of efficiency.
According to the guy who added AMR focusing only one target is terribly inefficient so this is infact a buff.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: AMR will now reset its focus after two fully charged aimed shots on the same target.
/:cl:
