### PR TITLE
Fixes some improper APC placements on Shivas Snowball

### DIFF
--- a/code/game/area/shiva.dm
+++ b/code/game/area/shiva.dm
@@ -262,3 +262,7 @@
 /area/shiva/interior/lz2_habs
 	name = "Shiva's Snowball - Argentinian Research Headquarters"
 	icon_state = "bar1"
+
+/area/shiva/interior/aux_power
+	name = "Shiva's Snowball - Auxiliary Generator Station"
+	icon_state = "hangars0"

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -2618,7 +2618,7 @@
 /area/shiva/interior/colony/medseceng)
 "anc" = (
 /turf/closed/wall/shiva/prefabricated/white,
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "anm" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 1
@@ -4775,7 +4775,7 @@
 	pixel_y = -1
 	},
 /turf/closed/wall/shiva/prefabricated/white,
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "aEq" = (
 /obj/structure/flora/tree/dead/tree_6,
 /turf/open/auto_turf/snow/layer3,
@@ -5080,7 +5080,7 @@
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "aIG" = (
 /obj/item/weapon/wirerod,
 /turf/open/shuttle/elevator/grating,
@@ -7051,7 +7051,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "bwP" = (
 /obj/structure/flora/tree/dead/tree_6,
 /turf/open/auto_turf/snow/layer3,
@@ -7895,6 +7895,11 @@
 	icon_state = "redfull"
 	},
 /area/shiva/interior/colony/research_hab)
+"ctz" = (
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/aux_power)
 "ctC" = (
 /obj/structure/surface/table/reinforced/prison,
 /turf/open/floor/shiva{
@@ -8150,6 +8155,11 @@
 	},
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/interior/caves/cp_camp)
+"cJu" = (
+/turf/open/floor/shiva{
+	dir = 1
+	},
+/area/shiva/interior/aux_power)
 "cJy" = (
 /obj/structure/surface/table,
 /turf/open/floor/shiva{
@@ -8889,7 +8899,7 @@
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "dxS" = (
 /turf/open/auto_turf/ice/layer2,
 /area/shiva/interior/caves/right_spiders)
@@ -9139,7 +9149,7 @@
 	dir = 1;
 	start_charge = 0
 	},
-/turf/open/auto_turf/ice/layer1,
+/turf/open/floor/plating,
 /area/shiva/interior/caves/research_caves)
 "dWp" = (
 /turf/open/floor/shiva{
@@ -9321,7 +9331,7 @@
 	dir = 1;
 	start_charge = 0
 	},
-/turf/open/auto_turf/snow/layer3,
+/turf/open/floor/plating,
 /area/shiva/exterior/cp_colony_grounds)
 "eep" = (
 /obj/effect/landmark/hunter_primary,
@@ -9446,7 +9456,7 @@
 /turf/open/floor/shiva{
 	dir = 1
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "enc" = (
 /obj/structure/prop/invuln/ice_prefab,
 /turf/open/auto_turf/ice/layer0,
@@ -10115,7 +10125,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "ffo" = (
 /obj/structure/surface/rack,
 /obj/item/fuel_cell,
@@ -10336,7 +10346,7 @@
 	icon_state = "pink_trim"
 	},
 /turf/closed/wall/shiva/prefabricated/white,
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "fse" = (
 /obj/structure/surface/table/woodentable,
 /obj/item/storage/box/lightstick/red{
@@ -10427,7 +10437,7 @@
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "fyC" = (
 /obj/structure/prop/ice_colony/dense/planter_box/hydro{
 	pixel_x = -17;
@@ -11927,7 +11937,7 @@
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "gYu" = (
 /obj/item/lightstick/red/planted,
 /turf/open/auto_turf/snow/layer0,
@@ -12672,7 +12682,7 @@
 /turf/open/floor/shiva{
 	dir = 1
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "hLf" = (
 /turf/closed/wall/shiva/prefabricated,
 /area/shiva/interior/colony/n_admin)
@@ -13812,7 +13822,7 @@
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "iQe" = (
 /obj/structure/barricade/handrail/wire{
 	dir = 8;
@@ -13977,7 +13987,7 @@
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "iXE" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/landmark/good_item,
@@ -14814,7 +14824,7 @@
 	dir = 8;
 	icon_state = "yellowfull"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "jXD" = (
 /obj/structure/flora/tree/dead/tree_4,
 /turf/open/auto_turf/snow/layer2,
@@ -14889,7 +14899,7 @@
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "kbJ" = (
 /obj/structure/machinery/light/double{
 	dir = 4;
@@ -15677,7 +15687,7 @@
 /turf/open/floor/shiva{
 	dir = 1
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "kLG" = (
 /obj/structure/flora/bush/ausbushes/lavendergrass,
 /obj/structure/flora/grass/tallgrass/ice,
@@ -15829,6 +15839,13 @@
 	icon_state = "chapel"
 	},
 /area/shiva/interior/colony/central)
+"kRR" = (
+/obj/structure/filingcabinet,
+/obj/effect/landmark/objective_landmark/close,
+/turf/open/floor/shiva{
+	icon_state = "floor3"
+	},
+/area/shiva/interior/aux_power)
 "kRV" = (
 /obj/structure/surface/table,
 /obj/item/device/flashlight/lamp/green,
@@ -15928,7 +15945,7 @@
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "kXs" = (
 /obj/item/lightstick/red/spoke/planted{
 	pixel_x = 11;
@@ -16183,7 +16200,7 @@
 	dir = 8;
 	icon_state = "yellowfull"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "lnH" = (
 /obj/structure/flora/bush/snow{
 	icon_state = "snowgrassbb_2"
@@ -16570,7 +16587,7 @@
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "lHX" = (
 /obj/structure/surface/table,
 /obj/item/reagent_container/food/drinks/bottle/holywater,
@@ -16960,7 +16977,7 @@
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "mah" = (
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
 	dir = 1;
@@ -17408,7 +17425,7 @@
 /turf/open/floor/shiva{
 	icon_state = "radiator_tile2"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "mCo" = (
 /obj/structure/flora/bush/snow{
 	icon_state = "snowgrassall_1"
@@ -17890,7 +17907,7 @@
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "mYK" = (
 /obj/structure/prop/invuln/minecart_tracks{
 	dir = 1
@@ -18048,7 +18065,7 @@
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "nhB" = (
 /obj/structure/surface/rack,
 /obj/item/weapon/ice_axe,
@@ -18213,7 +18230,7 @@
 /turf/open/floor/shiva{
 	dir = 1
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "nrN" = (
 /obj/structure/prop/invuln/ice_prefab/standalone,
 /turf/open/auto_turf/snow/layer2,
@@ -18225,7 +18242,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "nsI" = (
 /obj/structure/surface/table,
 /obj/item/paper/research_notes,
@@ -18439,7 +18456,7 @@
 	dir = 8;
 	icon_state = "yellowfull"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "nEH" = (
 /obj/effect/landmark/monkey_spawn,
 /obj/effect/decal/warning_stripes{
@@ -18732,7 +18749,7 @@
 	dir = 8;
 	icon_state = "yellowfull"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "nUa" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -20171,6 +20188,9 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/botany)
+"pBL" = (
+/turf/open/floor/plating/plating_catwalk/shiva,
+/area/shiva/interior/aux_power)
 "pCe" = (
 /obj/structure/stairs/perspective/ice{
 	dir = 1;
@@ -20303,7 +20323,7 @@
 	dir = 8;
 	icon_state = "yellowfull"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "pGf" = (
 /turf/open/floor/shiva{
 	dir = 10;
@@ -20887,7 +20907,7 @@
 /turf/open/floor/shiva{
 	icon_state = "yellow"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "qid" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -20933,7 +20953,7 @@
 "qkt" = (
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating/plating_catwalk/shiva,
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "qkC" = (
 /turf/open/shuttle/elevator,
 /area/shiva/interior/aerodrome)
@@ -21315,7 +21335,7 @@
 	dir = 1;
 	start_charge = 0
 	},
-/turf/open/auto_turf/snow/layer2,
+/turf/open/floor/plating,
 /area/shiva/exterior/junkyard)
 "qEB" = (
 /obj/structure/flora/grass/tallgrass/ice/corner,
@@ -21634,7 +21654,7 @@
 	dir = 6;
 	icon_state = "multi_tiles"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "rad" = (
 /obj/structure/inflatable/popped,
 /turf/open/auto_turf/ice/layer1,
@@ -21644,7 +21664,7 @@
 	dir = 1;
 	start_charge = 0
 	},
-/turf/open/auto_turf/snow/layer2,
+/turf/open/floor/plating,
 /area/shiva/exterior/junkyard/cp_bar)
 "rbc" = (
 /obj/structure/flora/grass/tallgrass/ice/corner{
@@ -22002,7 +22022,7 @@
 	dir = 10;
 	icon_state = "yellow"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "rzw" = (
 /obj/structure/platform_decoration/strata,
 /turf/open/auto_turf/snow/layer3,
@@ -22318,7 +22338,7 @@
 	dir = 6;
 	icon_state = "multi_tiles"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "rSL" = (
 /obj/item/weapon/gun/boltaction{
 	pixel_x = -6
@@ -22367,7 +22387,7 @@
 	dir = 8;
 	icon_state = "yellowfull"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "rUW" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/auto_turf/snow/layer3,
@@ -22460,7 +22480,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "rZq" = (
 /obj/structure/surface/table/reinforced/prison{
 	dir = 4;
@@ -23677,7 +23697,7 @@
 	dir = 8;
 	start_charge = 0
 	},
-/turf/open/auto_turf/snow/layer2,
+/turf/open/floor/plating,
 /area/shiva/exterior/cp_lz2)
 "too" = (
 /obj/structure/prop/ice_colony/soil_net,
@@ -23861,7 +23881,7 @@
 /turf/open/floor/shiva{
 	icon_state = "multi_tiles"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "txU" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/shiva{
@@ -23913,7 +23933,7 @@
 	dir = 6;
 	icon_state = "multi_tiles"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "tzH" = (
 /turf/open/floor/shiva{
 	dir = 4;
@@ -24443,7 +24463,7 @@
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "tYw" = (
 /turf/closed/wall/shiva/prefabricated/reinforced/hull,
 /area/shiva/exterior/junkyard)
@@ -24771,7 +24791,7 @@
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "ulm" = (
 /obj/structure/machinery/disposal,
 /turf/open/floor/shiva{
@@ -24829,7 +24849,7 @@
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "uoI" = (
 /obj/structure/prop/invuln/ice_prefab/standalone/trim{
 	icon_state = "white_trim"
@@ -25051,7 +25071,7 @@
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "uCp" = (
 /obj/structure/machinery/light/small{
 	dir = 8
@@ -25134,7 +25154,7 @@
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "uHa" = (
 /obj/structure/morgue,
 /obj/structure/machinery/light/double{
@@ -25398,7 +25418,7 @@
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "uRn" = (
 /obj/item/weapon/gun/boltaction,
 /turf/open/floor/shiva{
@@ -26398,7 +26418,7 @@
 	dir = 4;
 	start_charge = 0
 	},
-/turf/open/auto_turf/ice/layer1,
+/turf/open/floor/plating,
 /area/shiva/interior/caves/cp_camp)
 "vYm" = (
 /turf/open/auto_turf/snow/layer0,
@@ -26624,7 +26644,7 @@
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "wlJ" = (
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/telecomm/lz2_northeast)
@@ -27083,7 +27103,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "wRm" = (
 /turf/open/floor/plating,
 /area/shiva/interior/aerodrome)
@@ -27299,7 +27319,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "xeq" = (
 /obj/structure/prop/ice_colony/surveying_device/measuring_device{
 	dir = 4;
@@ -27381,7 +27401,7 @@
 /turf/open/floor/shiva{
 	icon_state = "floor3"
 	},
-/area/shiva/interior/lz2_habs)
+/area/shiva/interior/aux_power)
 "xlg" = (
 /obj/structure/flora/grass/tallgrass/ice/corner{
 	dir = 10
@@ -36458,10 +36478,10 @@ puZ
 puZ
 anc
 tYm
-xQJ
-xQJ
+cJu
+cJu
 nTC
-odz
+pBL
 bsM
 edw
 edw
@@ -36620,10 +36640,10 @@ puZ
 puZ
 anc
 uot
-xQJ
-xQJ
+cJu
+cJu
 nTC
-odz
+pBL
 uCO
 bsM
 edw
@@ -36782,12 +36802,12 @@ puZ
 anc
 anc
 wls
-xQJ
+cJu
 emy
 nTC
 qkt
-odz
-odz
+pBL
+pBL
 anc
 anc
 anc
@@ -37107,11 +37127,11 @@ anc
 nED
 mCn
 uRi
-xQJ
+cJu
 qZa
-xQJ
+cJu
 qZa
-xQJ
+cJu
 nTC
 tzu
 mae
@@ -37276,7 +37296,7 @@ ffn
 xdT
 ryZ
 txS
-pth
+kRR
 anc
 gJI
 aEJ
@@ -37430,8 +37450,8 @@ puZ
 anc
 nED
 mCn
-cce
-xQJ
+ctz
+cJu
 qZa
 hKS
 qZa
@@ -37600,7 +37620,7 @@ bwJ
 nrU
 rZj
 txS
-pth
+kRR
 aEd
 ayc
 qta
@@ -37754,12 +37774,12 @@ puZ
 anc
 nED
 mCn
-cce
-xQJ
+ctz
+cJu
 qZa
-xQJ
+cJu
 qZa
-xQJ
+cJu
 nTC
 rSr
 aIv
@@ -38077,13 +38097,13 @@ puZ
 puZ
 anc
 anc
-cce
-xQJ
-xQJ
+ctz
+cJu
+cJu
 nTC
-odz
-odz
-odz
+pBL
+pBL
+pBL
 anc
 anc
 anc
@@ -38240,10 +38260,10 @@ puZ
 puZ
 anc
 kbl
-xQJ
+cJu
 nrB
 nTC
-odz
+pBL
 bsM
 edw
 iVj
@@ -38402,10 +38422,10 @@ puZ
 puZ
 anc
 dxh
-xQJ
-xQJ
+cJu
+cJu
 nTC
-odz
+pBL
 edw
 bsM
 iVj

--- a/maps/map_files/Ice_Colony_v3/lz2-variations/southeast-gate/cleared.dmm
+++ b/maps/map_files/Ice_Colony_v3/lz2-variations/southeast-gate/cleared.dmm
@@ -48,7 +48,7 @@
 /obj/structure/machinery/power/apc{
 	dir = 8
 	},
-/turf/open/auto_turf/snow/layer2,
+/turf/open/floor/plating,
 /area/shiva/exterior/cp_lz2)
 "r" = (
 /obj/effect/decal/cleanable/ash,

--- a/maps/map_files/Ice_Colony_v3/lz2-variations/southeast-gate/closed.dmm
+++ b/maps/map_files/Ice_Colony_v3/lz2-variations/southeast-gate/closed.dmm
@@ -35,7 +35,7 @@
 /obj/structure/machinery/power/apc{
 	dir = 8
 	},
-/turf/open/auto_turf/snow/layer2,
+/turf/open/floor/plating,
 /area/shiva/exterior/cp_lz2)
 "o" = (
 /obj/structure/machinery/door_control{


### PR DESCRIPTION
# About the pull request

Fixes a few APCs that were previously placed on top of indestructible dirt, preventing the APC terminal being accessible, and thus making them impossible to move or repair.

Also changes the area path used by the small North generator room/communications room. This room previously shared the same area pathing as the room on the West side of LZ2, both of which had APCs. Doubling up APCs in one area is a mapping sin and makes resolving any issues with either of the APCs extremely frustrating.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Bad object placement is bad (the design is very human).

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
This is the room with the area pathing changes:

![image](https://github.com/cmss13-devs/cmss13/assets/80382633/e52a54f8-98af-49bc-8d96-8386c952eebb)

See MapDiffBot for the rest, I don't think it's particularly practical for me to screenshot multiple 1 tile changes.
</details>


# Changelog
:cl:
fix: Fixes improperly placed APCs on Shivas Snowball
/:cl:
