### PR TITLE
Prevent open crates from being supply dropped

### DIFF
--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -316,6 +316,10 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 		to_chat(usr, "[icon2html(src, usr)] [SPAN_WARNING("The landing zone appears to be obstructed or out of bounds. Package would be lost on drop.")]")
 		return
 
+	if(crate.opened)
+		to_chat(usr, "[icon2html(src, usr)] [SPAN_WARNING("The crate is not secure on the drop pad. Please close it!")]")
+		return
+
 	crate.visible_message(SPAN_WARNING("\The [crate] loads into a launch tube. Stand clear!"))
 	current_squad.send_message("'[crate.name]' supply drop incoming. Heads up!")
 	current_squad.send_maptext(crate.name, "Incoming Supply Drop:")

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -843,6 +843,10 @@
 		to_chat(usr, "[icon2html(src, usr)] [SPAN_WARNING("The landing zone appears to be obstructed or out of bounds. Package would be lost on drop.")]")
 		return
 
+	if(crate.opened)
+		to_chat(usr, "[icon2html(src, usr)] [SPAN_WARNING("The crate is not secure on the drop pad. Get Requisitions to close the crate!")]")
+		return
+
 	busy = TRUE
 	crate.visible_message(SPAN_WARNING("\The [crate] loads into a launch tube. Stand clear!"))
 	SEND_SIGNAL(crate, COMSIG_STRUCTURE_CRATE_SQUAD_LAUNCHED, current_squad)


### PR DESCRIPTION

# About the pull request

Opened crates can no longer be launched via req drop pads, so empty crates dont get launched on accident.

# Explain why it's good for the game

Really is just so QMs dont have to stand guard over their crates while CIC launches them, so random bald CTs dont cause empty crates to be sent by opening them.


# Testing Photographs and Procedure
Tested launching crates both from Req and CIC, open crates dont launch, closed ones do just as intended.



# Changelog
:cl:
qol: Requisition drop pads will now no longer launch open crates
/:cl:
