### PR TITLE
SG small changes

### DIFF
--- a/code/modules/projectiles/guns/smartgun.dm
+++ b/code/modules/projectiles/guns/smartgun.dm
@@ -337,8 +337,8 @@
 		to_chat(user, "[icon2html(src, usr)] Can't switch ammunition type when \the [src]'s fire restriction is disabled.")
 		return
 	secondary_toggled = !secondary_toggled
-	to_chat(user, "[icon2html(src, usr)] You changed \the [src]'s ammo preparation procedures. You now fire [secondary_toggled ? "armor shredding rounds" : "highly precise rounds"].")
-	balloon_alert(user, "firing [secondary_toggled ? "armor shredding" : "highly precise"]")
+	to_chat(user, "[icon2html(src, usr)] You changed \the [src]'s ammo preparation procedures. You now fire [secondary_toggled ? "armor piercing rounds" : "high velocity rounds"].")
+	balloon_alert(user, "firing [secondary_toggled ? "armor piercing" : "high velocity"]")
 	playsound(loc,'sound/machines/click.ogg', 25, 1)
 	ammo = secondary_toggled ? ammo_secondary : ammo_primary
 	var/datum/action/item_action/smartgun/toggle_ammo_type/TAT = locate(/datum/action/item_action/smartgun/toggle_ammo_type) in actions
@@ -356,10 +356,12 @@
 	secondary_toggled = FALSE
 	if(iff_enabled)
 		add_bullet_trait(BULLET_TRAIT_ENTRY_ID("iff", /datum/element/bullet_trait_iff))
+		damage_mult -= BULLET_DAMAGE_MULT_TIER_5
 		drain += 10
 		MD.iff_signal = initial(MD.iff_signal)
 	if(!iff_enabled)
 		remove_bullet_trait("iff")
+		damage_mult += BULLET_DAMAGE_MULT_TIER_5 //:trollface:
 		drain -= 10
 		MD.iff_signal = null
 


### PR DESCRIPTION

# About the pull request

Renames SG bullet names to better fit their purpose.
Armor Shredding to Armor Piercing - armor shredding hasn't been in the game for like 3 years
Highly Precise to High Velocity - i like this better

Gives SG IFF off a small damage buff
30 to 37.5 dmg


# Explain why it's good for the game

IFF off buffed damage was a hidden mechanic for a long time, and its been a meme as long as I remember, this provides SG with a higher risk higher reward play-style and gives xenos more opportunities to attack cocky smartgunners.

I remember there was this big thing about trying to remove SG full IFF into making it only being able to shoot when no one is in the way, but I feel this is a way to incentivize more risky plays while not neutering the SG's main role of backline support.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: The smartgun now does extra damage when IFF is off.
spellcheck: Renames SG ammos to something more clear.
/:cl:
