### PR TITLE
Adds an access check for CL evac pod.

### DIFF
--- a/code/modules/shuttle/computers/escape_pod_computer.dm
+++ b/code/modules/shuttle/computers/escape_pod_computer.dm
@@ -22,6 +22,9 @@
 /obj/structure/machinery/computer/shuttle/escape_pod_panel/attack_hand(mob/user)
 	if(..())
 		return
+	if(!allowed(user))
+		to_chat(user, SPAN_WARNING("Access denied!"))
+		return
 	tgui_interact(user)
 
 /obj/structure/machinery/computer/shuttle/escape_pod_panel/tgui_interact(mob/user, datum/tgui/ui)
@@ -86,6 +89,7 @@
 			. = TRUE
 
 /obj/structure/machinery/computer/shuttle/escape_pod_panel/liaison
+	req_access = list(ACCESS_WY_GENERAL)
 	launch_without_evac = TRUE
 
 //=========================================================================================


### PR DESCRIPTION

# About the pull request
As title, evac pod consoles now check for correct access.

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Added access check for use of escape pod consoles, and access requirement on the CLs pod.
/:cl:
