### PR TITLE
Fix nanoui onclose errors

### DIFF
--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -160,7 +160,7 @@
 	dat += "</font>"
 	temp = ""
 	show_browser(user, dat, "[src] Access", "tcommachine", "size=520x500;can_resize=0")
-	onclose(user, "dormitory")
+	onclose(user, "tcommachine")
 
 
 // Off-Site Relays

--- a/code/game/objects/items/circuitboards/airlock.dm
+++ b/code/game/objects/items/circuitboards/airlock.dm
@@ -58,7 +58,7 @@
 	t1 += text("<p><a href='?src=\ref[];close=1'>Close</a></p>\n", src)
 
 	show_browser(user, t1, "Access Control", "airlock_electronics")
-	onclose(user, "airlock")
+	onclose(user, "airlock_electronics")
 
 
 /obj/item/circuitboard/airlock/Topic(href, href_list)

--- a/code/game/objects/items/devices/dummy_tablet.dm
+++ b/code/game/objects/items/devices/dummy_tablet.dm
@@ -87,8 +87,8 @@
 	dat += "<BR>\[ <A HREF='?src=\ref[src];operation=reset'>Reset</A> \]"
 	dat += "<BR><hr>"
 
-	show_browser(user, dat, "Professor DUMMY Control Tablet", window_options="size=400x500")
-	onclose(user, "communications")
+	show_browser(user, dat, "Professor DUMMY Control Tablet", "dummytablet", window_options="size=400x500")
+	onclose(user, "dummytablet")
 	updateDialog()
 	return
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -651,7 +651,7 @@ GLOBAL_LIST_INIT(bgstate_options, list(
 	dat += "</div></body>"
 
 	winshow(user, "preferencewindow", TRUE)
-	show_browser(user, dat, "Preferences", "preferencebrowser")
+	show_browser(user, dat, "Preferences", "preferencewindow")
 	onclose(user, "preferencewindow", src)
 
 /**


### PR DESCRIPTION
# About the pull request

This PR fixes some of the errors getting sent (namely with character preferences window) e.g. `winset: Parameter preferencebrowser.on-close not found.`

As far as I can tell no behavior actually changes with any of these?

# Explain why it's good for the game

Less clientside errors.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Still opens and closes and saves fine?
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/3abf8156-cc44-4987-a6bb-36cf5be0f474)

</details>


# Changelog
:cl: Drathek
fix: Fixed some winset errors with some nanoui windows
/:cl:
