### PR TITLE
Return to client macros for tgsay

### DIFF
--- a/code/__DEFINES/tgui.dm
+++ b/code/__DEFINES/tgui.dm
@@ -37,6 +37,12 @@
 	"%7b%22type%22%3a%22[type]%22%2c%22payload%22%3a[url_encode(json_encode(payload))]%7d" \
 )
 
+/// Creates a message packet for sending via output() specifically for opening tgsay using an embedded winget
+// This is {"type":"open","payload":{"channel":channel,"mapfocus":"[[map.focus]]"}}, but pre-encoded.
+#define TGUI_CREATE_OPEN_MESSAGE(channel) ( \
+	"%7b%22type%22%3a%22open%22%2c%22payload%22%3a%7B%22channel%22%3a%22[channel]%22%2c%22mapfocus%22%3a\[\[map.focus\]\]%7d%7d" \
+)
+
 /*
 *Defines for the TGUI health analyser interface
 *The higher the level, the more information you can see

--- a/code/__DEFINES/tgui.dm
+++ b/code/__DEFINES/tgui.dm
@@ -38,7 +38,7 @@
 )
 
 /// Creates a message packet for sending via output() specifically for opening tgsay using an embedded winget
-// This is {"type":"open","payload":{"channel":channel,"mapfocus":"[[map.focus]]"}}, but pre-encoded.
+// This is {"type":"open","payload":{"channel":channel,"mapfocus":[[map.focus]]}}, but pre-encoded.
 #define TGUI_CREATE_OPEN_MESSAGE(channel) ( \
 	"%7b%22type%22%3a%22open%22%2c%22payload%22%3a%7B%22channel%22%3a%22[channel]%22%2c%22mapfocus%22%3a\[\[map.focus\]\]%7d%7d" \
 )

--- a/code/datums/keybinding/communication.dm
+++ b/code/datums/keybinding/communication.dm
@@ -8,30 +8,12 @@
 	full_name = "IC Say"
 	keybind_signal = COMSIG_KB_CLIENT_SAY_DOWN
 
-/datum/keybinding/client/communication/say/down(client/user)
-	. = ..()
-	if(.)
-		return
-	if(!user.prefs.tgui_say)
-		return
-	winset(user, null, "command=[user.tgui_say_create_open_command(SAY_CHANNEL)]")
-	return TRUE
-
 /datum/keybinding/client/communication/ooc
 	hotkey_keys = list("O")
 	classic_keys = list("F2")
 	name = OOC_CHANNEL
 	full_name = "Out Of Character Say (OOC)"
 	keybind_signal = COMSIG_KB_CLIENT_OOC_DOWN
-
-/datum/keybinding/client/communication/ooc/down(client/user)
-	. = ..()
-	if(.)
-		return
-	if(!user.prefs.tgui_say)
-		return
-	winset(user, null, "command=[user.tgui_say_create_open_command(OOC_CHANNEL)]")
-	return TRUE
 
 /datum/keybinding/client/communication/looc
 	hotkey_keys = list("L")
@@ -40,30 +22,12 @@
 	full_name = "Local Out Of Character Say (OOC)"
 	keybind_signal = COMSIG_KB_CLIENT_LOOC_DOWN
 
-/datum/keybinding/client/communication/looc/down(client/user)
-	. = ..()
-	if(.)
-		return
-	if(!user.prefs.tgui_say)
-		return
-	winset(user, null, "command=[user.tgui_say_create_open_command(LOOC_CHANNEL)]")
-	return TRUE
-
 /datum/keybinding/client/communication/me
 	hotkey_keys = list("M")
 	classic_keys = list("F4")
 	name = ME_CHANNEL
 	full_name = "Custom Emote (/Me)"
 	keybind_signal = COMSIG_KB_CLIENT_ME_DOWN
-
-/datum/keybinding/client/communication/me/down(client/user)
-	. = ..()
-	if(.)
-		return
-	if(!user.prefs.tgui_say)
-		return
-	winset(user, null, "command=[user.tgui_say_create_open_command(ME_CHANNEL)]")
-	return TRUE
 
 /datum/keybinding/client/communication/whisper
 	hotkey_keys = list("Unbound")
@@ -78,15 +42,6 @@
 	full_name = "IC Comms (;)"
 	keybind_signal = COMSIG_KG_CLIENT_RADIO_DOWN
 
-/datum/keybinding/client/communication/radiochannels/down(client/user)
-	. = ..()
-	if(.)
-		return
-	if(!user.prefs.tgui_say)
-		return
-	winset(user, null, "command=[user.tgui_say_create_open_command(COMMS_CHANNEL)]")
-	return TRUE
-
 /datum/keybinding/client/communication/asay
 	hotkey_keys = list("F3")
 	classic_keys = list("F5")
@@ -95,17 +50,6 @@
 	description = "Talk with other admins."
 	keybind_signal = COMSIG_KB_ADMIN_ASAY_DOWN
 
-/datum/keybinding/client/communication/asay/down(client/user)
-	. = ..()
-	if(.)
-		return
-	if(!user.prefs.tgui_say)
-		return
-	if(!user.admin_holder?.check_for_rights(R_MOD))
-		return
-	winset(user, null, "command=[user.tgui_say_create_open_command(ADMIN_CHANNEL)]")
-	return TRUE
-
 /datum/keybinding/client/communication/mentor_say
 	hotkey_keys = list("Unbound")
 	classic_keys = list("Unbound")
@@ -113,14 +57,3 @@
 	full_name = "Mentor Say"
 	description = "Talk with other mentors."
 	keybind_signal = COMSIG_KB_ADMIN_MENTORSAY_DOWN
-
-/datum/keybinding/client/communication/mentor_say/down(client/user)
-	. = ..()
-	if(.)
-		return
-	if(!user.prefs.tgui_say)
-		return
-	if(!user.admin_holder?.check_for_rights(R_MENTOR))
-		return
-	winset(user, null, "command=[user.tgui_say_create_open_command(MENTOR_CHANNEL)]")
-	return TRUE

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -684,33 +684,39 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 					movement_keys[key] = SOUTH
 				if(SAY_CHANNEL)
 					if(prefs.tgui_say)
-						winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=")
+						var/say = tgui_say_create_open_command(SAY_CHANNEL)
+						winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=[say]")
 					else
 						winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=\"say\\n.typing\"")
 				if(COMMS_CHANNEL)
 					if(prefs.tgui_say)
-						winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=")
+						var/radio = tgui_say_create_open_command(COMMS_CHANNEL)
+						winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=[radio]")
 					else
 						winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=\"say\\n.typing\"")
 				if(ME_CHANNEL)
 					if(prefs.tgui_say)
-						winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=")
+						var/me = tgui_say_create_open_command(ME_CHANNEL)
+						winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=[me]")
 					else
 						winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=\"me\\n.typing\"")
 				if(OOC_CHANNEL)
 					if(prefs.tgui_say)
-						winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=")
+						var/ooc = tgui_say_create_open_command(OOC_CHANNEL)
+						winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=[ooc]")
 					else
 						winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=ooc")
 				if(LOOC_CHANNEL)
 					if(prefs.tgui_say)
-						winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=")
+						var/looc = tgui_say_create_open_command(LOOC_CHANNEL)
+						winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=[looc]")
 					else
 						winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=looc")
 				if(ADMIN_CHANNEL)
 					if(admin_holder?.check_for_rights(R_MOD))
 						if(prefs.tgui_say)
-							winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=")
+							var/asay = tgui_say_create_open_command(ADMIN_CHANNEL)
+							winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=[asay]")
 						else
 							winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=asay")
 					else
@@ -718,7 +724,8 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 				if(MENTOR_CHANNEL)
 					if(admin_holder?.check_for_rights(R_MENTOR))
 						if(prefs.tgui_say)
-							winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=")
+							var/mentor = tgui_say_create_open_command(MENTOR_CHANNEL)
+							winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=[mentor]")
 						else
 							winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=mentorsay")
 					else

--- a/code/modules/tgui/tgui-say/modal.dm
+++ b/code/modules/tgui/tgui-say/modal.dm
@@ -10,9 +10,7 @@
  * string - A JSON encoded message to open the modal.
  */
 /client/proc/tgui_say_create_open_command(channel)
-	var/message = TGUI_CREATE_MESSAGE("open", list(
-		channel = channel,
-	))
+	var/message = TGUI_CREATE_OPEN_MESSAGE(channel)
 	return "\".output tgui_say.browser:update [message]\""
 
 /**

--- a/tgui/packages/tgui-say/TguiSay.tsx
+++ b/tgui/packages/tgui-say/TguiSay.tsx
@@ -11,6 +11,7 @@ import { byondMessages } from './timers';
 
 type ByondOpen = {
   channel: Channel;
+  mapfocus: BooleanLike;
 };
 
 type ByondProps = {
@@ -246,11 +247,15 @@ export class TguiSay extends Component<{}, State> {
   }
 
   handleOpen = (data: ByondOpen) => {
+    const { channel, mapfocus } = data;
+    if (!mapfocus) {
+      return;
+    }
+
     setTimeout(() => {
       this.innerRef.current?.focus();
     }, 0);
 
-    const { channel } = data;
     // Catches the case where the modal is already open
     if (this.channelIterator.isSay()) {
       this.channelIterator.set(channel);


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #6244 effectively reverting the changes ported from https://github.com/tgstation/tgstation/pull/75463

Instead of using the down() proc on the server, we are once again doing the tgsay open via winset on hotkey so it is more responsive. However, to fix the issue with tgsay opening when say another window is focused, it now has an embedded winget for map.focus and thats sent in the payload.

# Explain why it's good for the game

Should make tgsay open more responsively again.

This was the reason why I needed to make the change in the first place: 
![bug](https://github.com/cmss13-devs/cmss13/assets/76988376/0288d3d1-e3c9-4cf7-95c2-9f7ef88095da)

# Testing Photographs and Procedure
But now that bug is fixed, and we're opening the old way again!

![tgsay](https://github.com/cmss13-devs/cmss13/assets/76988376/0997f797-7b99-4e6e-acda-722a783b010f)

# Changelog
:cl: Drathek
ui: TGSay is now opened the same way it used to for more responsiveness
/:cl:
