### PR TITLE
Fixes gibber not killing mobs

### DIFF
--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -262,13 +262,12 @@
 		occupant.death(create_cause_data("gibber", user), TRUE)
 		occupant.ghostize()
 
+	addtimer(CALLBACK(src, PROC_REF(create_gibs), totalslabs, allmeat), gibtime)
 	if(synthetic)
 		to_chat(occupant, SPAN_HIGHDANGER("You can detect your limbs being ripped off your body, but it begins to malfunction as it reaches your torso!"))
-		addtimer(CALLBACK(src, PROC_REF(create_gibs), totalslabs, allmeat), gibtime)
 		addtimer(CALLBACK(src, PROC_REF(go_out), TRUE), gibtime)
-		return
-
-	QDEL_NULL(occupant)
+	else
+		QDEL_NULL(occupant)
 
 /obj/structure/machinery/gibber/proc/create_gibs(totalslabs, list/obj/item/reagent_container/food/snacks/allmeat)
 	playsound(loc, 'sound/effects/splat.ogg', 25, 1)


### PR DESCRIPTION
# About the pull request
Fixes #6331, gibber was essentially only partially gibbing synths leaving all other mobs unaffected.

# Explain why it's good for the game
The gibber should be able to gib mobs that aren't just synths.

# Changelog
:cl:
fix: Fixes non-synthetic mobs getting stuck in the gibber
/:cl:
