### PR TITLE
Queen qol

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -410,6 +410,15 @@
 		make_combat_effective()
 
 	AddComponent(/datum/component/footstep, 2 , 35, 11, 4, "alien_footstep_large")
+	RegisterSignal(src, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(check_block))
+
+/mob/living/carbon/xenomorph/queen/proc/check_block(mob/destroyer, turf/new_loc)
+	SIGNAL_HANDLER
+	for(var/mob/living/carbon/xenomorph/xeno in new_loc.contents)
+		if(xeno.hivenumber == src.hivenumber)
+			xeno.KnockDown((5 DECISECONDS) / GLOBAL_STATUS_MULTIPLIER)
+	
+		playsound(src.loc, 'sound/weapons/alien_knockdown.ogg', 25, 1)
 
 /mob/living/carbon/xenomorph/queen/generate_name()
 	if(!nicknumber)
@@ -423,13 +432,13 @@
 			if(XENO_NORMAL)
 				name = "[name_prefix]Queen"  //Regular
 			if(XENO_MATURE)
-				name = "[name_prefix]Elder Queen"  //Mature
+				name = "[name_prefix]Empress"  //Mature
 			if(XENO_ELDER)
 				name = "[name_prefix]Elder Empress"  //Elite
 			if(XENO_ANCIENT)
 				name = "[name_prefix]Ancient Empress" //Ancient
 			if(XENO_PRIME)
-				name = "[name_prefix]Prime Empress" //Primordial
+				name = "[name_prefix]Matriarch" //Primordial
 	else
 		age = XENO_NORMAL
 		if(client)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -417,8 +417,7 @@
 	for(var/mob/living/carbon/xenomorph/xeno in new_loc.contents)
 		if(xeno.hivenumber == src.hivenumber)
 			xeno.KnockDown((5 DECISECONDS) / GLOBAL_STATUS_MULTIPLIER)
-	
-		playsound(src.loc, 'sound/weapons/alien_knockdown.ogg', 25, 1)
+			playsound(src.loc, 'sound/weapons/alien_knockdown.ogg', 25, 1)
 
 /mob/living/carbon/xenomorph/queen/generate_name()
 	if(!nicknumber)


### PR DESCRIPTION

# About the pull request
Improves anti bodyblock and changes some prefixes
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Prefix wise the matriarch was an ancient empress\queen which sounds better than "Prime Empress" (given you are playing a queen and not an empress but that's another story)
As for the anti-bodyblock you shouldn't have to be worrying about that when playing Queen even with the shove unless you are ready to shove anyone instantly even half a second of bodyblock can make a difference and is just annoying, It is technically a buff so I will list it as balance
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Changed Queen playtime prefixes
balance: Queen will now automatically knock over allied xenomorphs in her way
/:cl:
