### PR TITLE
removes metal from requisitions console

### DIFF
--- a/code/datums/ASRS.dm
+++ b/code/datums/ASRS.dm
@@ -6,7 +6,7 @@
 
 /datum/supply_packs_asrs
 	/// How likely we are to select this pack over others
-	var/cost = ASRS_MEDIUM_WEIGHT
+	var/cost = ASRS_MEDIUM_WEIGHT // inheritance shall not be used to improve readability
 	/// Which pool of ASRS automatically dispensed supplies this belongs to
 	var/pool = ASRS_POOL_MAIN
 	/// What supply pack would this dispense
@@ -14,45 +14,55 @@
 
 //===================================
 // Rounds
+
 /datum/supply_packs_asrs/ammo_rounds_box_rifle
 	reference_package = /datum/supply_packs/ammo_rounds_box_rifle
-	cost = ASRS_MEDIUM_WEIGHT
+	cost = ASRS_VERY_LOW_WEIGHT
 
 /datum/supply_packs_asrs/ammo_rounds_box_rifle_ap
 	reference_package = /datum/supply_packs/ammo_rounds_box_rifle_ap
-	cost = ASRS_LOW_WEIGHT
+	cost = ASRS_VERY_LOW_WEIGHT
 
-/datum/supply_packs_asrs/ammo_rounds_box_xm88
-	reference_package = /datum/supply_packs/ammo_rounds_box_xm88
-	cost = ASRS_LOW_WEIGHT
+/datum/supply_packs_asrs/ammo_rounds_box_smg
+	reference_package = /datum/supply_packs/ammo_rounds_box_smg
+	cost = ASRS_VERY_LOW_WEIGHT
+
+/datum/supply_packs_asrs/ammo_rounds_box_smg_ap
+	reference_package = /datum/supply_packs/ammo_rounds_box_smg_ap
+	cost = ASRS_VERY_LOW_WEIGHT
 
 //===================================
 // Magazines
-/datum/supply_packs_asrs/gun/ammo_hpr
-	reference_package = /datum/supply_packs/ammo_hpr
-	cost = ASRS_LOWEST_WEIGHT
 
+// USCM secondary
 /datum/supply_packs_asrs/ammo_m4a3_mag_box
 	reference_package = /datum/supply_packs/ammo_m4a3_mag_box
-	cost = ASRS_LOW_WEIGHT
-
-/datum/supply_packs_asrs/ammo_m4a3_mag_box_ap
-	reference_package = /datum/supply_packs/ammo_m4a3_mag_box_ap
 	cost = ASRS_VERY_LOW_WEIGHT
 
+/datum/supply_packs_asrs/ammo_mod88_mag_box
+	reference_package = /datum/supply_packs/ammo_mod88_mag_box_ap
+	cost = ASRS_VERY_LOW_WEIGHT
+
+/datum/supply_packs_asrs/ammo_m44_mag_box
+	reference_package = /datum/supply_packs/ammo_m44_mag_box
+	cost = ASRS_VERY_LOW_WEIGHT
+
+// USCM Primary
 /datum/supply_packs_asrs/ammo_mag_box
 	reference_package = /datum/supply_packs/ammo_mag_box
-	cost = ASRS_VERY_LOW_WEIGHT
+	cost = ASRS_LOW_WEIGHT
 
 /datum/supply_packs_asrs/ammo_mag_box_ap
 	reference_package = /datum/supply_packs/ammo_mag_box_ap
+	cost = ASRS_LOW_WEIGHT
 
 /datum/supply_packs_asrs/ammo_m4ra_mag_box
 	reference_package = /datum/supply_packs/ammo_m4ra_mag_box
-	cost = ASRS_VERY_LOW_WEIGHT
+	cost = ASRS_LOW_WEIGHT
 
 /datum/supply_packs_asrs/ammo_m4ra_mag_box_ap
 	reference_package = /datum/supply_packs/ammo_m4ra_mag_box_ap
+	cost = ASRS_LOW_WEIGHT
 
 /datum/supply_packs_asrs/ammo_shell_box
 	reference_package = /datum/supply_packs/ammo_shell_box
@@ -66,42 +76,34 @@
 	reference_package = /datum/supply_packs/ammo_shell_box_flechette
 	cost = ASRS_VERY_LOW_WEIGHT
 
-/datum/supply_packs_asrs/ammo_shell_box_breaching
-	reference_package = /datum/supply_packs/ammo_shell_box_breaching
-	cost = ASRS_VERY_LOW_WEIGHT
-
-/datum/supply_packs_asrs/ammo_xm51
-	reference_package = /datum/supply_packs/ammo_xm51
-	cost = ASRS_VERY_LOW_WEIGHT
-
-/datum/supply_packs_asrs/ammo_smartgun
+/datum/supply_packs_asrs/ammo_smartgun //todo remove magazines and send raw bullet crates
 	reference_package = /datum/supply_packs/ammo_smartgun
-
-/datum/supply_packs_asrs/ammo_napalm
-	reference_package = /datum/supply_packs/ammo_napalm
-	cost = ASRS_VERY_LOW_WEIGHT
-
-/datum/supply_packs_asrs/ammo_napalm_gel
-	reference_package = /datum/supply_packs/ammo_napalm_gel
-	cost = ASRS_VERY_LOW_WEIGHT
-
-/datum/supply_packs_asrs/ammo_flamer_mixed
-	reference_package = /datum/supply_packs/ammo_flamer_mixed
-	cost = ASRS_VERY_LOW_WEIGHT
+	cost = ASRS_MEDIUM_WEIGHT
 
 //===================================
 // Mortar ammo
 /datum/supply_packs_asrs/ammo_mortar_he
 	reference_package = /datum/supply_packs/ammo_mortar_he
+	cost = ASRS_MEDIUM_WEIGHT
 
 /datum/supply_packs_asrs/ammo_mortar_incend
 	reference_package = /datum/supply_packs/ammo_mortar_incend
+	cost = ASRS_MEDIUM_WEIGHT
 
 /datum/supply_packs_asrs/ammo_mortar_flare
 	reference_package = /datum/supply_packs/ammo_mortar_flare
+	cost = ASRS_MEDIUM_WEIGHT
 
 //===================================
 // Misc supplies
+/datum/supply_packs_asrs/metal_sheets
+	reference_package = /datum/supply_packs/flares
+	cost = ASRS_LOW_WEIGHT
+
+/datum/supply_packs_asrs/plasteel_sheets
+	reference_package = /datum/supply_packs/flares
+	cost = ASRS_MEDIUM_WEIGHT
+
 /datum/supply_packs_asrs/flares
 	reference_package = /datum/supply_packs/flares
 	cost = ASRS_LOW_WEIGHT

--- a/code/datums/ASRS.dm
+++ b/code/datums/ASRS.dm
@@ -97,11 +97,11 @@
 //===================================
 // Misc supplies
 /datum/supply_packs_asrs/metal_sheets
-	reference_package = /datum/supply_packs/flares
+	reference_package = /datum/supply_packs/metal
 	cost = ASRS_LOW_WEIGHT
 
 /datum/supply_packs_asrs/plasteel_sheets
-	reference_package = /datum/supply_packs/flares
+	reference_package = /datum/supply_packs/plas
 	cost = ASRS_MEDIUM_WEIGHT
 
 /datum/supply_packs_asrs/flares

--- a/code/datums/supply_packs/black_market.dm
+++ b/code/datums/supply_packs/black_market.dm
@@ -507,6 +507,18 @@ Primarily made up of things that would be best utilized, well, shipside. Recreat
 	crate_heat = -5
 	containertype = /obj/structure/largecrate/black_market
 
+/datum/supply_packs/contraband/shipside/gunslinger_holster
+	contains = list(
+		/obj/item/storage/belt/gun/m44/gunslinger,
+		/obj/item/storage/belt/gun/m44/gunslinger,
+	)
+	name = "Red Ranger Cowboy Gunbelt Crate (x2)"
+	dollar_cost = 35
+	crate_heat = -5
+	containertype = /obj/structure/closet/crate
+	containername = "Cowboy Costume Crate"
+	group = "Clothing"
+
 /datum/supply_packs/contraband/shipside/confiscated_medicine
 	name = "confiscated medicinal supplies crate"
 	randomised_num_contained = 5

--- a/code/datums/supply_packs/clothing.dm
+++ b/code/datums/supply_packs/clothing.dm
@@ -5,24 +5,25 @@
 		/obj/item/storage/pouch/magazine/large,
 		/obj/item/storage/pouch/magazine/pistol/large,
 		/obj/item/storage/pouch/magazine/pistol/large,
-		/obj/item/storage/pouch/general,
-		/obj/item/storage/pouch/general,
+		/obj/item/storage/pouch/general/large,
+		/obj/item/storage/pouch/general/large,
 	)
-	cost = 20
+	cost = 10
 	containertype = /obj/structure/closet/crate
 	containername = "Large Pouch"
 	group = "Clothing"
 
 /datum/supply_packs/pouches_medical
-	name = "medical pouches crate (1x firstaid, medical, syringe, medkit, autoinjector)"
+	name = "Combat medical pouches crate (6x autoinjector)"
 	contains = list(
-		/obj/item/storage/pouch/firstaid,
-		/obj/item/storage/pouch/medical,
-		/obj/item/storage/pouch/syringe,
-		/obj/item/storage/pouch/medkit,
+		/obj/item/storage/pouch/autoinjector,
+		/obj/item/storage/pouch/autoinjector,
+		/obj/item/storage/pouch/autoinjector,
+		/obj/item/storage/pouch/autoinjector,
+		/obj/item/storage/pouch/autoinjector,
 		/obj/item/storage/pouch/autoinjector,
 	)
-	cost = 20
+	cost = 10
 	containertype = /obj/structure/closet/crate
 	containername = "medical pouches crate"
 	group = "Clothing"
@@ -32,40 +33,46 @@
 //---------------------------------------------
 
 /datum/supply_packs/webbing_brown_black
-	name = "Brown And Black Webbing Crate (x2 each)"
+	name = "Brown And Black Webbing Crate (x6)"
 	contains = list(
 		/obj/item/clothing/accessory/storage/black_vest/brown_vest,
 		/obj/item/clothing/accessory/storage/black_vest/brown_vest,
+		/obj/item/clothing/accessory/storage/black_vest/brown_vest,
+		/obj/item/clothing/accessory/storage/black_vest,
 		/obj/item/clothing/accessory/storage/black_vest,
 		/obj/item/clothing/accessory/storage/black_vest,
 	)
-	cost = 20
+	cost = 10
 	containertype = /obj/structure/closet/crate/green
 	containername = "Brown And Black Webbing Crate"
 	group = "Clothing"
 
 /datum/supply_packs/webbing_large
-	name = "Webbing Crate (x4)"
+	name = "Ammo Webbing Crate (x6)"
 	contains = list(
 		/obj/item/clothing/accessory/storage/webbing,
 		/obj/item/clothing/accessory/storage/webbing,
 		/obj/item/clothing/accessory/storage/webbing,
 		/obj/item/clothing/accessory/storage/webbing,
+		/obj/item/clothing/accessory/storage/webbing,
+		/obj/item/clothing/accessory/storage/webbing,
 	)
-	cost = 20
+	cost = 10
 	containertype = /obj/structure/closet/crate/green
 	containername = "Webbing Crate"
 	group = "Clothing"
 
 /datum/supply_packs/drop_pouches
-	name = "Drop Pouch Crate (x4)"
+	name = "Drop Pouch Crate (x6)"
 	contains = list(
 		/obj/item/clothing/accessory/storage/droppouch,
 		/obj/item/clothing/accessory/storage/droppouch,
 		/obj/item/clothing/accessory/storage/droppouch,
 		/obj/item/clothing/accessory/storage/droppouch,
+		/obj/item/clothing/accessory/storage/droppouch,
+		/obj/item/clothing/accessory/storage/droppouch,
 	)
-	cost = 20
+	cost = 10
 	containertype = /obj/structure/closet/crate/green
 	containername = "Drop Pouch Crate"
 	group = "Clothing"
@@ -76,9 +83,9 @@
 	contains = list(
 		/obj/item/clothing/accessory/storage/knifeharness,//old unathi knife harness updated for our needs
 		/obj/item/clothing/accessory/storage/knifeharness,
-		/obj/item/clothing/accessory/storage/knifeharness
+		/obj/item/clothing/accessory/storage/knifeharness,
 	)
-	cost = 30
+	cost = 10
 	containertype = /obj/structure/closet/crate/green
 	containername = "Knife Vest Crate"
 	group = "Clothing"
@@ -91,33 +98,52 @@
 		/obj/item/clothing/accessory/storage/holster,
 		/obj/item/clothing/accessory/storage/holster,
 	)
-	cost = 20
+	cost = 10
 	containertype = /obj/structure/closet/crate/green
 	containername = "Shoulder Holster Crate"
 	group = "Clothing"
 
-/datum/supply_packs/gunslinger_holster
-	contains = list(
-		/obj/item/storage/belt/gun/m44/gunslinger,
-		/obj/item/storage/belt/gun/m44/gunslinger,
-	)
-	name = "Red Ranger Cowboy Gunbelt Crate (x2)"
-	cost = 20
-	contraband = 1
-	containertype = /obj/structure/closet/crate
-	containername = "Cowboy Costume Crate"
-	group = "Clothing"
-
-/datum/supply_packs/officer_outfits//lmao this shit is so hideously out of date
+/datum/supply_packs/officer_outfits//up to date :)
+	name = "officer outfit crate(x1 each)"
 	contains = list(
 		/obj/item/clothing/under/rank/qm_suit,
-		/obj/item/clothing/under/marine/officer/bridge,
-		/obj/item/clothing/under/marine/officer/bridge,
-		/obj/item/clothing/under/marine/dress,
+		/obj/item/clothing/under/marine/officer/warrant,
+		/obj/item/clothing/under/marine/chef,
+		/obj/item/clothing/under/marine/officer/command,
+		/obj/item/clothing/under/marine/officer/command,
 		/obj/item/clothing/under/marine/officer/ce,
 	)
-	name = "officer outfit crate"
-	cost = 30
+	cost = 10
+	containertype = /obj/structure/closet/crate
+	containername = "officer dress crate"
+	group = "Clothing"
+
+/datum/supply_packs/marine_formal_outfits
+	name = "Formal Marine outfit crate(x6)"
+	contains = list(
+		/obj/item/clothing/under/marine/dress,
+		/obj/item/clothing/under/marine/dress,
+		/obj/item/clothing/under/marine/dress,
+		/obj/item/clothing/under/marine/dress,
+		/obj/item/clothing/under/marine/dress,
+		/obj/item/clothing/under/marine/dress,
+	)
+	cost = 10
+	containertype = /obj/structure/closet/crate
+	containername = "officer dress crate"
+	group = "Clothing"
+
+/datum/supply_packs/officer_formal_outfits
+	name = "Formal officer outfit crate(x6)"
+	contains = list(
+		/obj/item/clothing/under/marine/dress/command,
+		/obj/item/clothing/under/marine/dress/command,
+		/obj/item/clothing/under/marine/dress/command,
+		/obj/item/clothing/under/marine/dress/command,
+		/obj/item/clothing/under/marine/dress/command,
+		/obj/item/clothing/under/marine/dress/command,
+	)
+	cost = 10
 	containertype = /obj/structure/closet/crate
 	containername = "officer dress crate"
 	group = "Clothing"

--- a/code/datums/supply_packs/engineering.dm
+++ b/code/datums/supply_packs/engineering.dm
@@ -22,6 +22,7 @@
 	name = "metal sheets (x50)"
 	contains = list(/obj/item/stack/sheet/metal/large_stack)
 	cost = 20
+	buyable = FALSE
 	containertype = /obj/structure/closet/crate/supply
 	containername = "metal sheets crate"
 	group = "Engineering"
@@ -30,6 +31,7 @@
 	name = "plasteel sheets (x40)"
 	contains = list(/obj/item/stack/sheet/plasteel/med_large_stack)
 	cost = 30
+	buyable = FALSE
 	containertype = /obj/structure/closet/crate/supply
 	containername = "plasteel sheets crate"
 	group = "Engineering"
@@ -48,6 +50,17 @@
 	cost = 20
 	containertype = /obj/structure/closet/crate/supply
 	containername = "wooden planks crate"
+	group = "Engineering"
+
+/datum/supply_packs/plastic
+	name = "plastic crate"
+	contains = list(
+		/obj/item/stack/sheet/mineral/plastic/small_stack,
+		/obj/item/stack/sheet/mineral/plastic/small_stack,
+	)
+	cost = 20
+	containertype = /obj/structure/closet/crate/secure/phoron
+	containername = "plastic crate"
 	group = "Engineering"
 
 /datum/supply_packs/folding_barricades

--- a/code/datums/supply_packs/gear.dm
+++ b/code/datums/supply_packs/gear.dm
@@ -21,7 +21,7 @@
 		/obj/item/ammo_box/magazine/misc/flares,
 		/obj/item/ammo_box/magazine/misc/flares,
 	)
-	cost = 40
+	cost = 20
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "flare pack crate"
 	group = "Gear"
@@ -33,7 +33,7 @@
 		/obj/item/device/motiondetector,
 		/obj/item/device/motiondetector,
 					)
-	cost = 40
+	cost = 30
 	containertype = /obj/structure/closet/crate/supply
 	containername = "Motion Detector crate"
 	group = "Gear"
@@ -46,7 +46,7 @@
 		/obj/item/storage/box/m94/signal,
 		/obj/item/storage/box/m94/signal,
 	)
-	cost = 60
+	cost = 30
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "signal flare pack crate"
 	group = "Gear"
@@ -59,7 +59,7 @@
 		/obj/item/stack/fulton,
 		/obj/item/stack/fulton,
 	)
-	cost = 20
+	cost = 10
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "fulton recovery device crate"
 	group = "Gear"
@@ -88,7 +88,7 @@
 		/obj/item/parachute,
 		/obj/item/parachute,
 	)
-	cost = 40
+	cost = 20
 	containertype = /obj/structure/closet/crate/supply
 	containername = "parachute crate"
 	group = "Gear"

--- a/code/datums/supply_packs/medical.dm
+++ b/code/datums/supply_packs/medical.dm
@@ -17,7 +17,7 @@
 		/obj/item/storage/pill_bottle/peridaxon,
 		/obj/item/storage/box/pillbottles,
 	)
-	cost = 15
+	cost = 10
 	containertype = /obj/structure/closet/crate/medical
 	containername = "medical crate"
 	group = "Medical"
@@ -62,7 +62,7 @@
 		/obj/item/storage/box/pillbottles,
 		/obj/item/storage/box/pillbottles,
 	)
-	cost = 15
+	cost = 10
 	containertype = /obj/structure/closet/crate/medical
 	containername = "medical crate"
 	group = "Medical"
@@ -81,7 +81,7 @@
 		/obj/item/storage/firstaid/adv,
 		/obj/item/storage/firstaid/adv,
 	)
-	cost = 11
+	cost = 10
 	containertype = /obj/structure/closet/crate/medical
 	containername = "medical crate"
 	group = "Medical"
@@ -106,7 +106,7 @@
 		/obj/item/bodybag/cryobag,
 		/obj/item/bodybag/cryobag,
 	)
-	cost = 15
+	cost = 20
 	containertype = /obj/structure/closet/crate/medical
 	containername = "stasis bag crate"
 	group = "Medical"
@@ -121,7 +121,7 @@
 		/obj/item/storage/box/masks,
 		/obj/item/storage/box/gloves,
 	)
-	cost = 25
+	cost = 20
 	containertype = /obj/structure/closet/crate/secure/surgery
 	containername = "surgery crate"
 	access = ACCESS_MARINE_MEDBAY

--- a/code/datums/supply_packs/misc.dm
+++ b/code/datums/supply_packs/misc.dm
@@ -2,21 +2,6 @@
 //SUPPLIES
 //*******************************************************************************/
 
-/datum/supply_packs/internals
-	name = "oxygen internals crate (x3 masks, x3 tanks)"
-	contains = list(
-		/obj/item/clothing/mask/gas,
-		/obj/item/clothing/mask/gas,
-		/obj/item/clothing/mask/gas,
-		/obj/item/tank/air,
-		/obj/item/tank/air,
-		/obj/item/tank/air,
-	)
-	cost = 20
-	containertype = /obj/structure/closet/crate/internals
-	containername = "internals crate"
-	group = "Supplies"
-
 /datum/supply_packs/evacuation
 	name = "emergency equipment (x2 toolbox, x2 hazard vest, x5 oxygen tank, x5 masks)"
 	contains = list(
@@ -36,27 +21,9 @@
 		/obj/item/clothing/mask/gas,
 	)
 	cost = 20
+	buyable = FALSE // TODO : remake this into a proper evac kit that can be ordered once per round.
 	containertype = /obj/structure/closet/crate/internals
 	containername = "emergency crate"
-	group = "Supplies"
-
-/datum/supply_packs/boxes
-	name = "empty boxes (x10)"
-	contains = list(
-		/obj/item/storage/box,
-		/obj/item/storage/box,
-		/obj/item/storage/box,
-		/obj/item/storage/box,
-		/obj/item/storage/box,
-		/obj/item/storage/box,
-		/obj/item/storage/box,
-		/obj/item/storage/box,
-		/obj/item/storage/box,
-		/obj/item/storage/box,
-	)
-	cost = 10
-	containertype = /obj/structure/closet/crate/supply
-	containername = "empty box crate"
 	group = "Supplies"
 
 /datum/supply_packs/janitor
@@ -78,7 +45,7 @@
 		/obj/item/reagent_container/glass/bucket/mopbucket,
 		/obj/item/paper/janitor,
 	)
-	cost = 10
+	cost = 7
 	containertype = /obj/structure/closet/crate/supply
 	containername = "\improper Janitorial supplies crate"
 	group = "Supplies"
@@ -92,7 +59,7 @@
 		/obj/item/poster,
 		/obj/item/poster,
 	)
-	cost = 10
+	cost = 4
 	containertype = /obj/structure/closet/crate/supply
 	containername = "\improper posters crate"
 	group = "Supplies"
@@ -106,7 +73,7 @@
 		/obj/item/storage/fancy/crayons,
 		/obj/item/storage/fancy/crayons,
 	)
-	cost = 20
+	cost = 50
 	containertype = /obj/structure/closet/crate/supply
 	containername = "\improper crayons crate"
 	group = "Supplies"
@@ -120,7 +87,7 @@
 		/obj/item/a_gift,
 		/obj/item/a_gift,
 	)
-	cost = 20
+	cost = 10
 	containertype = /obj/structure/closet/crate/supply
 	containername = "\improper crate of presents"
 	group = "Supplies"
@@ -135,7 +102,7 @@
 		/obj/item/tool/wirecutters,
 		/obj/item/tool/wirecutters,
 	)
-	cost = 20
+	cost = 6
 	containertype = /obj/structure/closet/crate/supply
 	containername = "\improper wrapping supplies crate"
 	group = "Supplies"

--- a/code/datums/supply_packs/reagent_tanks.dm
+++ b/code/datums/supply_packs/reagent_tanks.dm
@@ -3,7 +3,23 @@
 /datum/supply_packs/fueltank
 	name = "fuel tank crate (x1)"
 	contains = list(/obj/structure/reagent_dispensers/fueltank)
-	cost = 20
+	cost = 15
 	containertype = /obj/structure/largecrate
 	containername = "fuel tank crate"
+	group = "Reagent tanks"
+
+/datum/supply_packs/emptytank
+	name = "reagent tank crate (x1)"
+	contains = list(/obj/structure/reagent_dispensers)
+	cost = 10
+	containertype = /obj/structure/largecrate
+	containername = "empty tank crate"
+	group = "Reagent tanks"
+
+/datum/supply_packs/watertank
+	name = "water tank crate (x1)"
+	contains = list(/obj/structure/reagent_dispensers/watertank)
+	cost = 15
+	containertype = /obj/structure/largecrate
+	containername = "water tank crate"
 	group = "Reagent tanks"

--- a/code/datums/supply_packs/research.dm
+++ b/code/datums/supply_packs/research.dm
@@ -3,54 +3,20 @@
 //explosif related section
 
 /datum/supply_packs/assembly
-	name = "assembly crate"
+	name = "Explosive assembly crate"
 	contains = list(
-		/obj/item/device/assembly/igniter,
-		/obj/item/device/assembly/igniter,
-		/obj/item/device/assembly/igniter,
-		/obj/item/device/assembly/igniter,
-		/obj/item/device/assembly/igniter,
-		/obj/item/device/assembly/prox_sensor,
-		/obj/item/device/assembly/prox_sensor,
-		/obj/item/device/assembly/prox_sensor,
-		/obj/item/device/assembly/prox_sensor,
-		/obj/item/device/assembly/prox_sensor,
-		/obj/item/device/assembly/timer,
-		/obj/item/device/assembly/timer,
-		/obj/item/device/assembly/timer,
-		/obj/item/device/assembly/timer,
-		/obj/item/device/assembly/timer,
+		/obj/item/explosive/grenade/custom,
+		/obj/item/explosive/grenade/custom,
+		/obj/item/explosive/grenade/custom,
+		/obj/item/explosive/grenade/custom,
+		/obj/item/explosive/grenade/custom/large,
+		/obj/item/explosive/grenade/custom/large,
+		/obj/item/explosive/grenade/custom/large,
+		/obj/item/explosive/grenade/custom/large,
 	)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/phoron
 	containername = "assembly crate"
-	access = ACCESS_MARINE_ENGINEERING
-	group = "Research"
-
-//Chemical section
-
-/datum/supply_packs/pyrotec
-	name = "pyrotechnics crate"
-	contains = list(
-		/obj/item/reagent_container/glass/beaker/sulphuric,
-		/obj/item/reagent_container/glass/beaker/sulphuric,
-		/obj/item/reagent_container/glass/beaker/sulphuric,
-		/obj/item/reagent_container/glass/beaker/ethanol,
-		/obj/item/reagent_container/glass/beaker/ethanol,
-		/obj/item/reagent_container/glass/beaker/ethanol,
-		/obj/item/reagent_container/glass/beaker/large/phosphorus,
-		/obj/item/reagent_container/glass/beaker/large/phosphorus,
-		/obj/item/reagent_container/glass/beaker/large/phosphorus,
-		/obj/item/reagent_container/glass/beaker/large/lithium,
-		/obj/item/reagent_container/glass/beaker/large/lithium,
-		/obj/item/reagent_container/glass/beaker/large/sodiumchloride,
-		/obj/item/reagent_container/glass/beaker/large/sodiumchloride,
-		/obj/item/reagent_container/glass/beaker/large/potassiumchloride,
-		/obj/item/reagent_container/glass/beaker/large/potassiumchloride,
-	)
-	cost = 10
-	containertype = /obj/structure/closet/crate/secure/phoron
-	containername = "pyrotechnics crate"
 	access = ACCESS_MARINE_ENGINEERING
 	group = "Research"
 
@@ -63,19 +29,6 @@
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/phoron
 	containername = "phoron crate"
-	access = ACCESS_MARINE_ENGINEERING
-	group = "Research"
-
-/datum/supply_packs/plastic
-	name = "plastic crate"
-	contains = list(
-		/obj/item/stack/sheet/mineral/plastic/small_stack,
-		/obj/item/stack/sheet/mineral/plastic/small_stack,
-	)
-	cost = 20
-	containertype = /obj/structure/closet/crate/secure/phoron
-	containername = "plastic crate"
-	access = ACCESS_MARINE_ENGINEERING
 	group = "Research"
 
 /datum/supply_packs/precious_metals

--- a/code/datums/supply_packs/restricted_equipment.dm
+++ b/code/datums/supply_packs/restricted_equipment.dm
@@ -1,9 +1,11 @@
 // here they will be all the Equipment that are restricted to a role/job.
 
 /datum/supply_packs/armor_leader
-	name = "B12 pattern marine armor crate (x1 helmet, x1 armor)"
+	name = "B12 pattern marine armor crate (x2)"
 	contains = list(
 		/obj/item/clothing/head/helmet/marine/leader,
+		/obj/item/clothing/head/helmet/marine/leader,
+		/obj/item/clothing/suit/storage/marine/medium/leader,
 		/obj/item/clothing/suit/storage/marine/medium/leader,
 	)
 	cost = 20
@@ -12,9 +14,11 @@
 	group = "Restricted Equipment"
 
 /datum/supply_packs/armor_tl
-	name = "M4 pattern marine armor crate (x1 helmet, x1 armor)"
+	name = "M4 pattern marine armor crate (x2)"
 	contains = list(
 		/obj/item/clothing/head/helmet/marine/rto,
+		/obj/item/clothing/head/helmet/marine/rto,
+		/obj/item/clothing/suit/storage/marine/medium/rto,
 		/obj/item/clothing/suit/storage/marine/medium/rto,
 	)
 	cost = 20

--- a/code/datums/supply_packs/weapons.dm
+++ b/code/datums/supply_packs/weapons.dm
@@ -130,22 +130,3 @@
 	containertype = /obj/structure/closet/crate/weapon
 	containername = "\improper XM88 Heavy Rifle crate"
 	group = "Weapons"
-
-/* Uncomment me if it's decided to let the m707 be purchasable through req
-/datum/supply_packs/gun/m707
-	name = "M707 Anti-Materiel Rifle crate (M707 x1)"
-	contains = list()
-	cost = 120
-	containertype = /obj/structure/closet/crate/secure/vulture
-	containername = "M707 crate"
-	group = "Weapons"
-*/
-
-/datum/supply_packs/gun/merc
-	contains = list()
-	name = "black market firearms (x1)"
-	cost = 40
-	contraband = 1
-	containertype = /obj/structure/largecrate/guns/merc
-	containername = "\improper black market firearms crate"
-	group = "Weapons"


### PR DESCRIPTION
# About the pull request

Removes metal and plasteel from the ASRS orders console.
Adds metal and plasteel to the ASRS list.
reduces prices on non combat items.
updates old supply packs.
created a few new supply packs
Removes all restricted ammo except SG drums from ASRS

# Explain why it's good for the game

**METAL REMOVAL**
Requisitions department has become basically a metal factory over right now you are pretty much forced to buy metal and plasteel or you will likely get yelled at or even worse.
This PR aims to give req more freedom removing the metal from the console and making it come in ASRS supplies .

**ASRS Tweaking**
removed some of the crates of ASRS . with each new restricted weapon they were adding a new crate of it to the ASRS 
making it so all the new weapons have pretty much unlimited supply while the other restrictes lack of ammo very quickly.
This PR removes ASRS ammunition from non standard issue weapons. Req will have to manually buy it.

**Price reductions**
reduced the price of clothing items , toys , and other to allow for variety and shipside orders winout having great impact on the round.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Added new supply packs to ASRS
balance: Metal and Plasteel is no longer purchaseable in requisitions
balance: Added Metal and Plasteel to the ASRS pool
balance: Reduced the price of non combat crates and clothing
balance: Increases the amount of items in some crates
balance: Reworked a few crates from requisitions
/:cl:
