### PR TITLE
Reduce chem smoke logging spam

### DIFF
--- a/code/game/objects/effects/effect_system/chemsmoke.dm
+++ b/code/game/objects/effects/effect_system/chemsmoke.dm
@@ -91,7 +91,7 @@
 		msg_admin_niche("A chemical smoke reaction has taken place in ([whereLink])[contained]. Last associated key is [carry.my_atom.fingerprintslast].")
 		log_game("A chemical smoke reaction has taken place in ([where])[contained]. Last associated key is [carry.my_atom.fingerprintslast].")
 	else
-		msg_admin_niche("A chemical smoke reaction has taken place in ([whereLink]). No associated key.")
+		msg_admin_niche("A chemical smoke reaction has taken place in ([whereLink])[contained]. No associated key.")
 		log_game("A chemical smoke reaction has taken place in ([where])[contained]. No associated key.")
 
 

--- a/code/game/objects/effects/effect_system/chemsmoke.dm
+++ b/code/game/objects/effects/effect_system/chemsmoke.dm
@@ -26,7 +26,7 @@
 	var/list/targetTurfs
 	var/list/wallList
 	var/density
-
+	var/static/last_reaction_signature
 
 /datum/effect_system/smoke_spread/chem/New()
 	..()
@@ -79,14 +79,19 @@
 		contained = "\[[contained]\]"
 	var/area/A = get_area(location)
 
+	var/reaction_signature = "[time2text(world.timeofday, "hh:mm")]: ([A.name])[contained] by [carry.my_atom.fingerprintslast]"
+	if(last_reaction_signature == reaction_signature)
+		return
+	last_reaction_signature = reaction_signature
+
 	var/where = "[A.name]|[location.x], [location.y]"
 	var/whereLink = "<A HREF='?_src_=admin_holder;[HrefToken(forceGlobal = TRUE)];adminplayerobservecoodjump=1;X=[location.x];Y=[location.y];Z=[location.z]'>[where]</a>"
 
 	if(carry.my_atom.fingerprintslast)
-		message_admins("A chemical smoke reaction has taken place in ([whereLink])[contained]. Last associated key is [carry.my_atom.fingerprintslast].")
+		msg_admin_niche("A chemical smoke reaction has taken place in ([whereLink])[contained]. Last associated key is [carry.my_atom.fingerprintslast].")
 		log_game("A chemical smoke reaction has taken place in ([where])[contained]. Last associated key is [carry.my_atom.fingerprintslast].")
 	else
-		message_admins("A chemical smoke reaction has taken place in ([whereLink]). No associated key.")
+		msg_admin_niche("A chemical smoke reaction has taken place in ([whereLink]). No associated key.")
 		log_game("A chemical smoke reaction has taken place in ([where])[contained]. No associated key.")
 
 


### PR DESCRIPTION

# About the pull request

Smoke reactions are now a niche admin log, and somewhat spam reduced by storing the last event in a static var. The reason why I say somewhat is because say two different people spray at the same time the last event will swap between both people each cloud. Now the hour/minute, area, chem, and user are used to create a siganture.

# Explain why it's good for the game

Chem smoke is now commonly used in rounds so its better to keep information sent to admins more relevant rather than spammed.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Second log was after a minute elapsed (which makes the signature unique again)
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/eaac12d5-01ee-4679-9c67-ddc8597409b6)

</details>


# Changelog
:cl: Drathek
admin: Logging for chem smoke is now niche logged and less spammy
/:cl:
