### PR TITLE
Ghost orbit refactor

### DIFF
--- a/tgui/packages/tgui/interfaces/Orbit/index.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/index.tsx
@@ -152,7 +152,7 @@ const MarineObservable = (props: {
   const foxtrotSquad: Array<Observable> = [];
   const other: Array<Observable> = [];
 
-  section.forEach((x) => {
+  filteredSection.forEach((x) => {
     if (x.job?.includes('Alpha')) {
       alphaSquad.push(x);
     } else if (x.job?.includes('Bravo')) {

--- a/tgui/packages/tgui/interfaces/Orbit/types.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/types.ts
@@ -57,3 +57,6 @@ export const buildSquadObservable: (
     title: title,
   };
 };
+
+export type splitter = (members: Array<Observable>) => Array<SquadObservable>;
+export type groupSorter = (a: Observable, b: Observable) => number;

--- a/tgui/packages/tgui/interfaces/Orbit/types.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/types.ts
@@ -39,3 +39,21 @@ export type Observable = {
   orbiters?: number;
   ref: string;
 };
+
+export type SquadObservable = {
+  members: Array<Observable>;
+  color: string;
+  title: string;
+};
+
+export const buildSquadObservable: (
+  title: string,
+  color: string,
+  members: Array<Observable>,
+) => SquadObservable = (title, color, members = []) => {
+  return {
+    members: members,
+    color: color,
+    title: title,
+  };
+};


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Some usability changes to the orbit menu and general refactoring.

- Marines now appear per squad
- Marine job icons now appear in line with the name
- Marine job is sorted by job, similar to squad UI
- Xenos now appear per hive

# Explain why it's good for the game
Improving usability is a good thing

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

https://media.discordapp.net/attachments/964684928161808384/1244701305751212084/image.png?ex=6656baac&is=6655692c&hm=6d0bb3234ac1d511e55978a046414f080c95f8c5dd2bedc51bfb3787ee1ff754&=&format=webp&quality=lossless&width=958&height=1342

https://media.discordapp.net/attachments/964684928161808384/1244783033517871154/image.png?ex=665706ca&is=6655b54a&hm=591f86a278ab6217d28a6890efef7a344f4467b25432a8c1bcab3723004e223b&=&format=webp&quality=lossless&width=958&height=1342

</details>


# Changelog
:cl:
ui: orbit menu now splits marine squads
ui: orbit menu now splits xeno hives
ui: orbit menu sorts marines by job
/:cl:
