### PR TITLE
Fixes Burrowers being able to use corrosive acid while underground

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
@@ -106,6 +106,10 @@
 			to_chat(src, SPAN_WARNING("[A] is already drenched in acid."))
 			return
 
+	if(HAS_TRAIT(src, TRAIT_ABILITY_BURROWED)) //Checked again to avoid people placing acid mid burrow
+		to_chat(src, SPAN_WARNING("We can't melt [O] from here!"))
+		return
+
 	if(!check_state())
 		return
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
@@ -106,7 +106,7 @@
 			to_chat(src, SPAN_WARNING("[A] is already drenched in acid."))
 			return
 
-	if(HAS_TRAIT(src, TRAIT_ABILITY_BURROWED)) //Checked again to avoid people placing acid mid burrow
+	if(HAS_TRAIT(src, TRAIT_ABILITY_BURROWED)) //Checked again to account for people trying to place acid while channeling the burrow ability
 		to_chat(src, SPAN_WARNING("We can't melt [O] from here!"))
 		return
 


### PR DESCRIPTION

# About the pull request

Adds an extra check for being burrowed *after* the do_after in corrosive acid.

Without this (how things are before this PR) it's possible to start channeling the burrow ability and then start aciding an object, in which case the acid will finish applying while you're underground since you've already cleared the check for being burrowed.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Obviously unintended behavior and I *have* seen people in-game abusing this.
It's quite awful to play against since there is absolutely zero counterplay.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

https://streamable.com/22ualc
</details>


# Changelog
:cl:
fix: Fixed an exploit that allowed Burrowers to apply acid to objects while underground
/:cl:
