### PR TITLE
Allows lifeboat surgery

### DIFF
--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -999,6 +999,7 @@
 	icon = 'icons/turf/almayer.dmi'
 	icon_state = "plating"
 	allow_construction = FALSE
+	supports_surgery = TRUE
 
 // Elevator floors
 /turf/open/shuttle/elevator


### PR DESCRIPTION

# About the pull request
Title.

# Explain why it's good for the game
I believe blocking lifeboat surgery was an unintended consequence of https://github.com/cmss13-devs/cmss13/pull/439. That PR was focused on blocking vehicle surgery, to which lifeboats are not quite the kind that was being focused. Allowing lifeboats to support surgery will allow people mid-flight to get surgery, in addition to making them a slightly better pre-eject hold spot.

# Changelog
:cl:
balance: Lifeboats now support surgery.
/:cl:
