### PR TITLE
doctors spawn with dark blue scrubs, surgeons spawn with green scrubs

### DIFF
--- a/code/modules/gear_presets/uscm_medical.dm
+++ b/code/modules/gear_presets/uscm_medical.dm
@@ -78,7 +78,7 @@
 		back_item = /obj/item/storage/backpack/marine
 
 	new_human.equip_to_slot_or_del(new back_item(new_human), WEAR_BACK)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/rank/medical/green(new_human), WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/rank/medical/blue(new_human), WEAR_BODY)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(new_human), WEAR_FEET)
 
 
@@ -87,6 +87,15 @@
 /datum/equipment_preset/uscm_ship/uscm_medical/doctor/surgeon
 
 	assignment = JOB_SURGEON
+
+/datum/equipment_preset/uscm_ship/uscm_medical/doctor/surgeon/load_gear(mob/living/carbon/human/new_human)
+	var/back_item = /obj/item/storage/backpack/marine/satchel
+	if (new_human.client && new_human.client.prefs && (new_human.client.prefs.backbag == 1))
+		back_item = /obj/item/storage/backpack/marine
+
+	new_human.equip_to_slot_or_del(new back_item(new_human), WEAR_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/rank/medical/green(new_human), WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(new_human), WEAR_FEET)
 
 //*****************************************************************************************************/
 


### PR DESCRIPTION
# About the pull request

doctors spawn with dark blue scrubs, surgeons spawn with green scrubs

# Explain why it's good for the game
highly flavorful (soulful, even) and true to old scrub color hierarchies where surgical scrubs are the green ones and medical scrubs are /whatever/ color (dark blue usually for physicians, though). not impeding in a meaningful way, i'd wager, since people can still freely vend their preferred scrubs, just neat.

feels like this makes sense and fits since our nurses adhere to the Scrub Hierarchy with their respective light blue scrubs on spawn

# Testing Photographs and Procedure
![image](https://github.com/cmss13-devs/cmss13/assets/29965103/4b614d87-93c9-4a05-af6f-e465a3db20d3)

one of them did residency for 3 years and one of them did residency for five years !! you will now know!!! unless they go to their vendor, then all bets are off !!

tested; without duplicating Every Thing from the parent doc datum for the surgeon clothing datum, they spawn shoeless and bagless, and this makes me sad. if there's a better way to NOT copy 5 extra lines, i'm all ears

# Changelog

:cl:
add: Doctors will spawn in dark blue scrubs by default; Setting your preferred job title to "Surgeon" for doctor roles will now spawn you in green scrubs
/:cl: