### PR TITLE
Makes the pod-locks on Trijent destructible

### DIFF
--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -51516,7 +51516,8 @@
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	dir = 2;
 	id = "dam_stormlock_north2";
-	name = "\improper Storm Lock"
+	name = "\improper Storm Lock";
+	unacidable = 0
 	},
 /turf/open/asphalt,
 /area/desert_dam/interior/dam_interior/south_tunnel)
@@ -51545,7 +51546,8 @@
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	dir = 2;
 	id = "dam_stormlock_north2";
-	name = "\improper Storm Lock"
+	name = "\improper Storm Lock";
+	unacidable = 0
 	},
 /turf/open/asphalt,
 /area/desert_dam/interior/dam_interior/south_tunnel)
@@ -51915,7 +51917,8 @@
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	dir = 2;
 	id = "dam_stormlock_north2";
-	name = "\improper Storm Lock"
+	name = "\improper Storm Lock";
+	unacidable = 0
 	},
 /turf/open/asphalt,
 /area/desert_dam/interior/dam_interior/south_tunnel)
@@ -52107,7 +52110,8 @@
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	dir = 2;
 	id = "dam_stormlock_north2";
-	name = "\improper Storm Lock"
+	name = "\improper Storm Lock";
+	unacidable = 0
 	},
 /turf/open/asphalt,
 /area/desert_dam/interior/dam_interior/south_tunnel)


### PR DESCRIPTION
# About the pull request

This seems like an oversight with the var-editing, but correct me if I'm wrong.

These locks specifically:
![image](https://github.com/cmss13-devs/cmss13/assets/5618080/ba9afccc-480b-4905-92aa-d022c09a8dae)

Technically a balance PR I guess?

If you blow up the button there's no way to ever open these, which seems uintentional

- [ ] Do the rest of the pod locks

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: The locks south of Reseach on Trijent Dam can now be blown up.
/:cl:
