### PR TITLE
First Drop Protections: Gas and Static Turrets

### DIFF
--- a/code/__DEFINES/defenses.dm
+++ b/code/__DEFINES/defenses.dm
@@ -22,6 +22,12 @@
 #define DEFENSE_BELL_TOWER 4
 #define DEFENSE_TESLA_COIL 5
 
+// Defines for /obj/structure/machinery/defenses/sentry/premade/deployable/colony/landing_zone
+#define TURRET_BATTERY_STATE_OK 0
+#define TURRET_BATTERY_STATE_LOW 1
+#define TURRET_BATTERY_STATE_CRITICAL 2
+#define TURRET_BATTERY_STATE_DEAD 3
+
 // What range the generator has to be in or defenses has to be in.
 #define GEN_SEARCH_RANGE 5
 #define GEN_PLASTEEL_COST 10

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -25,6 +25,7 @@
 #define SMOKE_RANK_MED 3
 #define SMOKE_RANK_HIGH 4
 #define SMOKE_RANK_BOILER 5
+#define SMOKE_RANK_MAX 6
 
 // What kind of function to use for Explosions falling off.
 

--- a/code/game/area/BigRed.dm
+++ b/code/game/area/BigRed.dm
@@ -515,27 +515,35 @@
 	is_resin_allowed = FALSE
 	ceiling_muffle = FALSE
 	base_muffle = MUFFLE_LOW
+	is_landing_zone = TRUE
 
 /area/bigredv2/outside/telecomm/lz2_cave
 	name = "\improper Central Grounds Communications Relay"
+	is_landing_zone = FALSE
 
 /area/bigredv2/outside/telecomm/n_cave
 	name = "\improper North Cave Communications Relay"
+	is_landing_zone = FALSE
 
 /area/bigredv2/outside/telecomm/warehouse
 	name = "\improper Warehouse Communications Relay"
+	is_landing_zone = FALSE
 
 /area/bigredv2/outside/telecomm/security
 	name = "\improper Security Communications Relay"
+	is_landing_zone = FALSE
 
 /area/bigredv2/outside/telecomm/store
 	name = "\improper General Store Communications Relay"
+	is_landing_zone = FALSE
 
 /area/bigredv2/outside/telecomm/admin
 	name = "\improper Administrative Communications Relay"
+	is_landing_zone = FALSE
 
 /area/bigredv2/outside/telecomm/engi
 	name = "\improper Engineering Communications Relay"
+	is_landing_zone = FALSE
 
 
 /area/bigredv2/outside/engineering

--- a/code/game/area/Corsat.dm
+++ b/code/game/area/Corsat.dm
@@ -523,7 +523,6 @@
 /area/corsat/omega/hangar
 	name = "\improper Landing Bay Omega"
 	icon_state = "omega_hangar"
-	is_landing_zone = TRUE
 
 /area/corsat/omega/hangar/office
 	name = "\improper Omega Hangar Office"

--- a/code/game/area/DesertDam.dm
+++ b/code/game/area/DesertDam.dm
@@ -216,6 +216,7 @@
 /area/desert_dam/building/substation/northwest
 	name = "Command Substation"
 	icon_state = "northewestern_ss"
+	is_landing_zone = TRUE
 /area/desert_dam/building/substation/northeast
 	name = "Command Substation"
 	icon_state = "northeastern_ss"

--- a/code/game/area/LV522_Chances_Claim.dm
+++ b/code/game/area/LV522_Chances_Claim.dm
@@ -48,6 +48,11 @@
 	name = "Chance's Claim - Landing Zone One Tunnels"
 	ceiling = CEILING_METAL
 
+/area/lv522/landing_zone_1/tunnel/far
+	name = "Chance's Claim - Landing Zone One Tunnels"
+	ceiling = CEILING_METAL
+	is_landing_zone = FALSE
+
 /area/shuttle/drop1/lv522
 	name = "Chance's Claim - Dropship Alamo Landing Zone"
 	icon_state = "shuttle"

--- a/code/game/area/Prison_Station_FOP.dm
+++ b/code/game/area/Prison_Station_FOP.dm
@@ -90,6 +90,7 @@
 /area/prison/security/checkpoint/hangar
 	name = "\improper Main Hangar Traffic Control"
 	is_resin_allowed = FALSE
+	is_landing_zone = TRUE
 
 /area/prison/storage
 	icon_state = "engine_storage"
@@ -211,6 +212,7 @@
 	name = "\improper Hangar-Barracks Maintenance"
 	icon_state = "maint_e_shuttle"
 	is_resin_allowed = FALSE
+	is_landing_zone = TRUE
 
 /area/prison/canteen
 	name = "\improper Canteen"
@@ -457,6 +459,7 @@
 /area/prison/monorail/east
 	name = "\improper East Monorail Station"
 	is_resin_allowed = FALSE
+	is_landing_zone = TRUE
 
 /area/prison/monorail/west
 	name = "\improper West Monorail Station"
@@ -467,10 +470,12 @@
 /area/prison/hanger/main
 	name = "\improper Main Hanger"
 	icon_state = "hangar_alpha"
+	is_landing_zone = TRUE
 
 /area/prison/hanger/research
 	name = "\improper Research Hanger"
 	icon_state = "hangar_beta"
+	is_landing_zone = TRUE
 
 /area/prison/hangar_storage/main
 	name = "\improper Main Hangar Storage"
@@ -480,9 +485,11 @@
 	name = "\improper Research Hangar Storage"
 	icon_state = "toxstorage"
 	is_resin_allowed = FALSE
+	is_landing_zone = TRUE
 
 /area/prison/hangar_storage/research/shuttle
 	name = "Corporate Shuttle"
+	is_landing_zone = FALSE
 
 /area/prison/telecomms
 	name = "\improper Telecommunications"

--- a/code/game/area/Sulaco.dm
+++ b/code/game/area/Sulaco.dm
@@ -14,6 +14,7 @@
 	flags_area = AREA_NOTUNNEL
 	is_landing_zone = TRUE
 	ceiling = CEILING_REINFORCED_METAL
+	base_lighting_alpha = 0
 
 /area/shuttle/drop1/Enter(atom/movable/O, atom/oldloc)
 	if(istype(O, /obj/structure/barricade))
@@ -71,6 +72,7 @@
 	flags_area = AREA_NOTUNNEL
 	is_landing_zone = TRUE
 	ceiling = CEILING_REINFORCED_METAL
+	base_lighting_alpha = 0
 
 /area/shuttle/drop2/sulaco
 	name = "\improper Dropship Normandy"

--- a/code/game/area/Sulaco.dm
+++ b/code/game/area/Sulaco.dm
@@ -25,6 +25,7 @@
 	name = "\improper Dropship Alamo"
 	icon_state = "shuttlered"
 	base_muffle = MUFFLE_HIGH
+	base_lighting_alpha = 255
 
 /area/shuttle/drop1/LV624
 	name = "\improper Dropship Alamo"
@@ -78,6 +79,7 @@
 	name = "\improper Dropship Normandy"
 	icon_state = "shuttle"
 	base_muffle = MUFFLE_HIGH
+	base_lighting_alpha = 255
 
 /area/shuttle/drop2/LV624
 	name = "\improper Dropship Normandy"

--- a/code/game/area/kutjevo.dm
+++ b/code/game/area/kutjevo.dm
@@ -203,12 +203,14 @@
 	icon_state = "Colony_int"
 	ceiling = CEILING_METAL
 	is_resin_allowed = FALSE
+	is_landing_zone = TRUE
 
 /area/kutjevo/interior/complex/Northwest_Flight_Control
 	name =  "Kutjevo Complex - Northwest Flight Control Room"
 	icon_state = "Colony_int"
 	ceiling = CEILING_METAL
 	is_resin_allowed = FALSE
+	is_landing_zone = TRUE
 
 /area/kutjevo/interior/complex/Northwest_Security_Checkpoint
 	name = "Kutjevo Complex - Northwest Security Checkpoint"
@@ -216,6 +218,7 @@
 	ceiling = CEILING_METAL
 	is_resin_allowed = FALSE
 	minimap_color = MINIMAP_AREA_SEC
+	is_landing_zone = TRUE
 
 //Out buildings + foremans
 /area/kutjevo/interior/power

--- a/code/game/area/prison.dm
+++ b/code/game/area/prison.dm
@@ -57,6 +57,7 @@
 	name = "\improper control room"
 	icon_state = "bridge"
 	minimap_color = MINIMAP_AREA_COMMAND
+	is_landing_zone = TRUE
 
 /area/prison/hallway/central_ring
 	name = "\improper central ring"

--- a/code/game/area/prison_v3_fiorina.dm
+++ b/code/game/area/prison_v3_fiorina.dm
@@ -183,6 +183,7 @@
 
 /area/fiorina/station/telecomm/lz1_tram
 	name = "Fiorina - LZ1 Aux Port Communications Relay"
+	is_landing_zone = TRUE
 
 /area/fiorina/station/telecomm/lz1_engineering
 	name = "Fiorina - Engineering Primary Communications Relay"

--- a/code/game/area/shiva.dm
+++ b/code/game/area/shiva.dm
@@ -238,6 +238,12 @@
 /area/shiva/interior/warehouse
 	name = "Shiva's Snowball - Blue Warehouse"
 	icon_state = "hangars1"
+	is_landing_zone = TRUE
+
+/area/shiva/interior/warehouse/caves
+	name = "Shiva's Snowball - Blue Warehouse Ice Cave"
+	icon_state = "caves1"
+	is_landing_zone = FALSE
 
 /area/shiva/interior/valley_huts
 	name = "Shiva's Snowball - Valley Bunker 1"
@@ -250,10 +256,6 @@
 /area/shiva/interior/valley_huts/disposals
 	name = "Shiva's Snowball - Valley Disposals"
 	icon_state = "hangars3"
-
-/area/shiva/interior/warehouse/caves
-	name = "Shiva's Snowball - Blue Warehouse Ice Cave"
-	icon_state = "caves1"
 
 /area/shiva/interior/garage
 	name = "Shiva's Snowball - Cargo Tug Repair Station"

--- a/code/game/area/shiva.dm
+++ b/code/game/area/shiva.dm
@@ -238,12 +238,10 @@
 /area/shiva/interior/warehouse
 	name = "Shiva's Snowball - Blue Warehouse"
 	icon_state = "hangars1"
-	is_landing_zone = TRUE
 
 /area/shiva/interior/warehouse/caves
 	name = "Shiva's Snowball - Blue Warehouse Ice Cave"
 	icon_state = "caves1"
-	is_landing_zone = FALSE
 
 /area/shiva/interior/valley_huts
 	name = "Shiva's Snowball - Valley Bunker 1"

--- a/code/game/area/shiva.dm
+++ b/code/game/area/shiva.dm
@@ -262,6 +262,7 @@
 /area/shiva/interior/lz2_habs
 	name = "Shiva's Snowball - Argentinian Research Headquarters"
 	icon_state = "bar1"
+	is_landing_zone = TRUE
 
 /area/shiva/interior/aux_power
 	name = "Shiva's Snowball - Auxiliary Generator Station"

--- a/code/game/area/varadero.dm
+++ b/code/game/area/varadero.dm
@@ -84,6 +84,7 @@
 	requires_power = FALSE
 	is_resin_allowed = FALSE
 	minimap_color = MINIMAP_AREA_LZ
+	is_landing_zone = TRUE
 
 /area/varadero/exterior/lz1_console/two
 	name = "New Varadero - Palm Airfield"
@@ -98,12 +99,14 @@
 	icon_state = "lz1"
 	is_resin_allowed = FALSE
 	minimap_color = MINIMAP_AREA_LZ
+	is_landing_zone = TRUE
 
 /area/varadero/exterior/lz2_near
 	name = "New Varadero - Palm Airfield"
 	icon_state = "lz2"
 	is_resin_allowed = FALSE
 	minimap_color = MINIMAP_AREA_LZ
+	is_landing_zone = TRUE
 
 /area/varadero/exterior/pontoon_beach
 	name = "New Varadero - Rockabilly Beach"
@@ -157,6 +160,7 @@
 	is_resin_allowed = FALSE
 	minimap_color = MINIMAP_AREA_JUNGLE
 	sound_environment = SOUND_ENVIRONMENT_ROOM
+	is_landing_zone = TRUE
 
 /area/varadero/interior/cargo
 	name = "New Varadero - Cargo"

--- a/code/game/area/varadero.dm
+++ b/code/game/area/varadero.dm
@@ -114,6 +114,9 @@
 	is_resin_allowed = FALSE
 	minimap_color = MINIMAP_AREA_JUNGLE
 
+/area/varadero/exterior/pontoon_beach/lz
+	is_landing_zone = TRUE
+
 /area/varadero/exterior/eastbeach
 	name = "New Varadero - East Beach"
 	is_resin_allowed = FALSE

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -121,7 +121,7 @@
 
 	addtimer(CALLBACK(src, PROC_REF(ares_online)), 5 SECONDS)
 	addtimer(CALLBACK(src, PROC_REF(map_announcement)), 20 SECONDS)
-	addtimer(CALLBACK(src, PROC_REF(start_lz_hazards)), 2 MINUTES)
+	addtimer(CALLBACK(src, PROC_REF(start_lz_hazards)), 3 MINUTES)
 
 	return ..()
 

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -1,5 +1,6 @@
 #define HIJACK_EXPLOSION_COUNT 5
-#define MARINE_MAJOR_ROUND_END_DELAY 3 MINUTES
+#define MARINE_MAJOR_ROUND_END_DELAY (3 MINUTES)
+#define LZ_HAZARD_START (3 MINUTES)
 
 /datum/game_mode/colonialmarines
 	name = "Distress Signal"
@@ -121,7 +122,7 @@
 
 	addtimer(CALLBACK(src, PROC_REF(ares_online)), 5 SECONDS)
 	addtimer(CALLBACK(src, PROC_REF(map_announcement)), 20 SECONDS)
-	addtimer(CALLBACK(src, PROC_REF(start_lz_hazards)), 3 MINUTES)
+	addtimer(CALLBACK(src, PROC_REF(start_lz_hazards)), LZ_HAZARD_START)
 
 	return ..()
 

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -182,7 +182,7 @@
 
 ///Spawns a droppod with a temporary defense sentry at the given turf
 /datum/game_mode/colonialmarines/proc/spawn_lz_sentry(turf/target, list/structures_to_break)
-	var/obj/structure/droppod/equipment/droppod = new(target, /obj/structure/machinery/sentry_holder/landing_zone)
+	var/obj/structure/droppod/equipment/sentry_holder/droppod = new(target, /obj/structure/machinery/sentry_holder/landing_zone)
 	droppod.special_structures_to_damage = structures_to_break
 	droppod.special_structure_damage = 500
 	droppod.drop_time = 5 SECONDS

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -165,7 +165,7 @@
 ///Returns a list of non-dense turfs using the given block arguments ignoring the provided structure types
 /datum/game_mode/colonialmarines/proc/get_valid_sentry_turfs(left, bottom, z, width, height, list/structures_to_ignore)
 	var/valid_turfs = list()
-	for(var/turf/turf in block(left, bottom, z, left+width-1, bottom+height-1))
+	for(var/turf/turf as anything in block(left, bottom, z, left+width-1, bottom+height-1))
 		if(turf.density)
 			continue
 		var/structure_blocking = FALSE

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -185,7 +185,7 @@
 	var/obj/structure/droppod/equipment/sentry_holder/droppod = new(target, /obj/structure/machinery/sentry_holder/landing_zone)
 	droppod.special_structures_to_damage = structures_to_break
 	droppod.special_structure_damage = 500
-	droppod.drop_time = 5 SECONDS
+	droppod.drop_time = 0
 	droppod.launch(target)
 
 ///Creates an OB warning at each LZ to warn of the miasma and then spawns the miasma

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -190,6 +190,8 @@
 
 ///Creates an OB warning at each LZ to warn of the miasma and then spawns the miasma
 /datum/game_mode/colonialmarines/proc/start_lz_hazards()
+	if(SSobjectives.first_drop_complete)
+		return // Just for sanity
 	INVOKE_ASYNC(src, PROC_REF(warn_lz_hazard), locate(/obj/structure/machinery/computer/shuttle/dropship/flight/lz1))
 	INVOKE_ASYNC(src, PROC_REF(warn_lz_hazard), locate(/obj/structure/machinery/computer/shuttle/dropship/flight/lz2))
 	addtimer(CALLBACK(src, PROC_REF(spawn_lz_hazards)), OB_TRAVEL_TIMING + 1 SECONDS)

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -16,6 +16,7 @@
 	var/next_research_allocation = 0
 	var/next_stat_check = 0
 	var/list/running_round_stats = list()
+	var/list/lz_smoke = list()
 
 ////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -120,8 +121,115 @@
 
 	addtimer(CALLBACK(src, PROC_REF(ares_online)), 5 SECONDS)
 	addtimer(CALLBACK(src, PROC_REF(map_announcement)), 20 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(start_lz_hazards)), 2 MINUTES)
 
 	return ..()
+
+/datum/game_mode/colonialmarines/ds_first_landed(obj/docking_port/stationary/marine_dropship)
+	. = ..()
+	clear_lz_hazards() // This shouldn't normally do anything, but is here just in case
+
+	// Assumption: Shuttle origin is its center
+	// Assumption: dwidth is atleast 2 and dheight is atleast 4 otherwise there will be overlap
+	var/list/options = list()
+	var/list/structures_to_break = list(/obj/structure/barricade, /obj/structure/surface/table, /obj/structure/bed)
+	var/bottom = marine_dropship.y - marine_dropship.dheight - 2
+	var/top = marine_dropship.y + marine_dropship.dheight + 2
+	var/left = marine_dropship.x - marine_dropship.dwidth - 2
+	var/right = marine_dropship.x + marine_dropship.dwidth + 2
+	var/z = marine_dropship.z
+
+	// Bottom left
+	options += get_valid_sentry_turfs(left, bottom, z, width=5, height=2, structures_to_ignore=structures_to_break)
+	options += get_valid_sentry_turfs(left, bottom + 2, z, width=2, height=6, structures_to_ignore=structures_to_break)
+	spawn_lz_sentry(pick(options), structures_to_break)
+
+	// Bottom right
+	options.Cut()
+	options += get_valid_sentry_turfs(right-4, bottom, z, width=5, height=2, structures_to_ignore=structures_to_break)
+	options += get_valid_sentry_turfs(right-1, bottom + 2, z, width=2, height=6, structures_to_ignore=structures_to_break)
+	spawn_lz_sentry(pick(options), structures_to_break)
+
+	// Top left
+	options.Cut()
+	options += get_valid_sentry_turfs(left, top-1, z, width=5, height=2, structures_to_ignore=structures_to_break)
+	options += get_valid_sentry_turfs(left, top-7, z, width=2, height=6, structures_to_ignore=structures_to_break)
+	spawn_lz_sentry(pick(options), structures_to_break)
+
+	// Top right
+	options.Cut()
+	options += get_valid_sentry_turfs(right-4, top-1, z, width=5, height=2, structures_to_ignore=structures_to_break)
+	options += get_valid_sentry_turfs(right-1, top-7, z, width=2, height=6, structures_to_ignore=structures_to_break)
+	spawn_lz_sentry(pick(options), structures_to_break)
+
+///Returns a list of non-dense turfs using the given block arguments ignoring the provided structure types
+/datum/game_mode/colonialmarines/proc/get_valid_sentry_turfs(left, bottom, z, width, height, list/structures_to_ignore)
+	var/valid_turfs = list()
+	for(var/turf/turf in block(left, bottom, z, left+width-1, bottom+height-1))
+		if(turf.density)
+			continue
+		var/structure_blocking = FALSE
+		for(var/obj/structure/existing_structure in turf)
+			if(!existing_structure.density)
+				continue
+			if(!is_type_in_list(existing_structure, structures_to_ignore))
+				structure_blocking = TRUE
+				break
+		if(structure_blocking)
+			continue
+		valid_turfs += turf
+	return valid_turfs
+
+///Spawns a droppod with a temporary defense sentry at the given turf
+/datum/game_mode/colonialmarines/proc/spawn_lz_sentry(turf/target, list/structures_to_break)
+	var/obj/structure/droppod/equipment/droppod = new(target, /obj/structure/machinery/sentry_holder/landing_zone)
+	droppod.special_structures_to_damage = structures_to_break
+	droppod.special_structure_damage = 500
+	droppod.drop_time = 5 SECONDS
+	droppod.launch(target)
+
+///Creates an OB warning at each LZ to warn of the miasma and then spawns the miasma
+/datum/game_mode/colonialmarines/proc/start_lz_hazards()
+	INVOKE_ASYNC(src, PROC_REF(warn_lz_hazard), locate(/obj/structure/machinery/computer/shuttle/dropship/flight/lz1))
+	INVOKE_ASYNC(src, PROC_REF(warn_lz_hazard), locate(/obj/structure/machinery/computer/shuttle/dropship/flight/lz2))
+	addtimer(CALLBACK(src, PROC_REF(spawn_lz_hazards)), OB_TRAVEL_TIMING + 1 SECONDS)
+
+///Creates an OB warning at each LZ to warn of the incoming miasma
+/datum/game_mode/colonialmarines/proc/warn_lz_hazard(lz)
+	if(!lz)
+		return
+	var/turf/target = get_turf(lz)
+	if(!target)
+		return
+	var/obj/structure/ob_ammo/warhead/explosive/warhead = new
+	warhead.name = "\improper CN20-X miasma warhead"
+	warhead.clear_power = 0
+	warhead.clear_falloff = 400
+	warhead.standard_power = 0
+	warhead.standard_falloff = 30
+	warhead.clear_delay = 3
+	warhead.double_explosion_delay = 6
+	warhead.warhead_impact(target) // This is a blocking call
+	playsound(target, 'sound/effects/smoke.ogg', vol=50, vary=1, sound_range=75)
+
+///Spawns miasma smoke in landing zones
+/datum/game_mode/colonialmarines/proc/spawn_lz_hazards()
+	var/datum/cause_data/new_cause_data = create_cause_data("CN20-X miasma")
+	for(var/area/area in GLOB.all_areas)
+		if(!area.is_landing_zone)
+			continue
+		if(!is_ground_level(area.z))
+			continue
+		for(var/turf/turf in area)
+			if(turf.density)
+				continue
+			lz_smoke += new /obj/effect/particle_effect/smoke/miasma(turf, null, new_cause_data)
+
+///Clears miasma smoke in landing zones
+/datum/game_mode/colonialmarines/proc/clear_lz_hazards()
+	for(var/obj/effect/particle_effect/smoke/miasma/smoke as anything in lz_smoke)
+		smoke.time_to_live = rand(1, 5)
+	lz_smoke.Cut()
 
 #define MONKEYS_TO_TOTAL_RATIO 1/32
 
@@ -289,6 +397,7 @@
 /datum/game_mode/colonialmarines/ds_first_drop(obj/docking_port/mobile/marine_dropship)
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_blurb_uscm)), DROPSHIP_DROP_MSG_DELAY)
 	add_current_round_status_to_end_results("First Drop")
+	clear_lz_hazards()
 
 ///////////////////////////
 //Checks to see who won///

--- a/code/game/machinery/sentry_holder.dm
+++ b/code/game/machinery/sentry_holder.dm
@@ -171,9 +171,11 @@
 
 		to_chat(user, SPAN_NOTICE("You deploy [src]."))
 		deploy_sentry()
+		msg_admin_niche("[key_name(user)] deployed [turret] at [get_location_in_text(src)] [ADMIN_JMP(loc)]")
 		return
 
 	to_chat(user, SPAN_NOTICE("You retract [src]."))
+	msg_admin_niche("[key_name(user)] retracted [turret] at [get_location_in_text(src)] [ADMIN_JMP(loc)]")
 	undeploy_sentry()
 	return
 

--- a/code/game/machinery/sentry_holder.dm
+++ b/code/game/machinery/sentry_holder.dm
@@ -148,10 +148,7 @@
 	icon_state = "floor_sentry_installed" // TODO: More appropriate sprites
 	turret_path = /obj/structure/machinery/defenses/sentry/premade/deployable/colony/landing_zone
 	base_icon_state = "floor_sentry" // TODO: More appropriate sprites
-
-/obj/structure/machinery/sentry_holder/landing_zone/Initialize()
-	. = ..()
-	deploy_sentry()
+	layer = HATCH_LAYER // Needs to not hide barricades
 
 /obj/structure/machinery/sentry_holder/landing_zone/attack_hand(mob/user)
 	var/obj/structure/machinery/defenses/sentry/premade/deployable/colony/landing_zone/turret = deployed_turret

--- a/code/game/machinery/sentry_holder.dm
+++ b/code/game/machinery/sentry_holder.dm
@@ -143,3 +143,42 @@
 /obj/structure/machinery/sentry_holder/almayer/mini/aicore/attack_hand(mob/user)
 	to_chat(user, SPAN_WARNING("[src] can only be deployed remotely."))
 	return
+
+/obj/structure/machinery/sentry_holder/landing_zone
+	icon_state = "floor_sentry_installed" // TODO: More appropriate sprites
+	turret_path = /obj/structure/machinery/defenses/sentry/premade/deployable/colony/landing_zone
+	base_icon_state = "floor_sentry" // TODO: More appropriate sprites
+
+/obj/structure/machinery/sentry_holder/landing_zone/Initialize()
+	. = ..()
+	deploy_sentry()
+
+/obj/structure/machinery/sentry_holder/landing_zone/attack_hand(mob/user)
+	var/obj/structure/machinery/defenses/sentry/premade/deployable/colony/landing_zone/turret = deployed_turret
+	if(!istype(turret))
+		to_chat(user, SPAN_WARNING("[src] is unresponsive."))
+		return
+
+	if(deployment_cooldown > world.time)
+		to_chat(user, SPAN_WARNING("[src] is busy."))
+		return
+
+	if(deployed_turret.loc == src) //not deployed
+		if(turret.battery_state == TURRET_BATTERY_STATE_DEAD)
+			to_chat(user, SPAN_WARNING("[src] is non-functional."))
+			return
+
+		if(require_red_alert && (seclevel2num(get_security_level()) < SEC_LEVEL_RED))
+			to_chat(user, SPAN_WARNING("[src] can only be activated in emergencies."))
+			return
+
+		to_chat(user, SPAN_NOTICE("You deploy [src]."))
+		deploy_sentry()
+		return
+
+	to_chat(user, SPAN_NOTICE("You retract [src]."))
+	undeploy_sentry()
+	return
+
+/obj/structure/machinery/sentry_holder/landing_zone/update_use_power(new_use_power)
+	return

--- a/code/game/objects/effects/effect_system/chemsmoke.dm
+++ b/code/game/objects/effects/effect_system/chemsmoke.dm
@@ -263,7 +263,13 @@
 
 	return
 
-/obj/effect/particle_effect/smoke/chem/affect(mob/living/carbon/M)
-	if(reagents.reagent_list.len)
-		for(var/datum/reagent/reagent in reagents.reagent_list)
-			reagent.reaction_mob(M, volume = reagent.volume * POTENCY_MULTIPLIER_LOW, permeable = FALSE)
+/obj/effect/particle_effect/smoke/chem/affect(mob/living/carbon/affected_mob)
+	. = ..()
+	if(!.)
+		return FALSE
+	if(!length(reagents?.reagent_list))
+		return FALSE
+
+	for(var/datum/reagent/reagent in reagents.reagent_list)
+		reagent.reaction_mob(affected_mob, volume = reagent.volume * POTENCY_MULTIPLIER_LOW, permeable = FALSE)
+	return TRUE

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -160,6 +160,8 @@
 	opacity = FALSE
 	alpha = 75
 	color = "#301934"
+	var/burn_damage = 4
+	var/xeno_yautja_multiplier = 3
 
 /obj/effect/particle_effect/smoke/miasma/Initialize(mapload, oldamount, new_cause_data)
 	. = ..()
@@ -176,8 +178,17 @@
 /obj/effect/particle_effect/smoke/miasma/affect(mob/living/carbon/affected_mob)
 	..()
 
-	affected_mob.apply_damage(10, TOX)
-	affected_mob.SetEyeBlind(1)
+	var/damage = burn_damage
+	if(isxeno(affected_mob))
+		damage *= xeno_yautja_multiplier
+	else if(isyautja(affected_mob))
+		if(prob(75))
+			return FALSE
+		damage *= xeno_yautja_multiplier
+
+	affected_mob.apply_damage(damage, BURN)
+	affected_mob.AdjustEyeBlur(0.75)
+
 	if(affected_mob.coughedtime < world.time && !affected_mob.stat)
 		affected_mob.coughedtime = world.time + 2 SECONDS
 		if(ishuman(affected_mob)) //Humans only to avoid issues

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -177,9 +177,15 @@
 
 /obj/effect/particle_effect/smoke/miasma/process()
 	. = ..()
-	for(var/obj/structure/closet/container in get_turf(src))
+	var/turf/turf = get_turf(src)
+	for(var/obj/structure/closet/container in turf)
 		for(var/mob/living/carbon/mob in container)
 			affect(mob)
+	var/obj/vehicle/multitile/car = locate() in turf
+	var/datum/interior/car_interior = car?.interior
+	var/list/passengers = car_interior?.get_passengers()
+	for(var/mob/living/mob as anything in passengers)
+		affect(mob)
 
 /obj/effect/particle_effect/smoke/miasma/affect(mob/living/carbon/affected_mob)
 	. = ..()

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -149,6 +149,47 @@
 				affected_mob.emote("cough")
 
 /////////////////////////////////////////////
+// Miasma smoke (for LZs)
+/////////////////////////////////////////////
+
+/obj/effect/particle_effect/smoke/miasma
+	name = "CN20-X miasma"
+	amount = 1
+	time_to_live = INFINITY
+	smokeranking = SMOKE_RANK_MAX
+	opacity = FALSE
+	alpha = 75
+	color = "#301934"
+
+/obj/effect/particle_effect/smoke/miasma/Initialize(mapload, oldamount, new_cause_data)
+	. = ..()
+	// Mimic dispersal without actually doing spread logic
+	alpha = 0
+	addtimer(VARSET_CALLBACK(src, alpha, initial(alpha)), rand(1, 6) SECONDS)
+
+/obj/effect/particle_effect/smoke/miasma/process()
+	. = ..()
+	for(var/obj/structure/closet/container in get_turf(src))
+		for(var/mob/living/carbon/mob in container)
+			affect(mob)
+
+/obj/effect/particle_effect/smoke/miasma/affect(mob/living/carbon/affected_mob)
+	..()
+
+	affected_mob.apply_damage(10, TOX)
+	affected_mob.SetEyeBlind(1)
+	if(affected_mob.coughedtime < world.time && !affected_mob.stat)
+		affected_mob.coughedtime = world.time + 2 SECONDS
+		if(ishuman(affected_mob)) //Humans only to avoid issues
+			if(prob(50))
+				affected_mob.emote("cough")
+			else
+				affected_mob.emote("gasp")
+			if(prob(20))
+				affected_mob.drop_held_item()
+		to_chat(affected_mob, SPAN_DANGER("Something is not right here..."))
+
+/////////////////////////////////////////////
 // Sleep smoke
 /////////////////////////////////////////////
 

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -222,6 +222,9 @@
 		to_chat(affected_mob, SPAN_DANGER("Something is not right here..."))
 	return TRUE
 
+/obj/effect/particle_effect/smoke/miasma/ex_act(severity)
+	return
+
 /////////////////////////////////////////////
 // Sleep smoke
 /////////////////////////////////////////////

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -99,7 +99,7 @@
 		var/obj/effect/particle_effect/smoke/smoke = new type(cur_turf, amount, cause_data)
 		smoke.setDir(pick(GLOB.cardinals))
 		smoke.time_to_live = time_to_live
-		if(smoke.amount>0)
+		if(smoke.amount > 0)
 			smoke.spread_smoke()
 
 
@@ -620,7 +620,7 @@
 
 		smoke.setDir(pick(GLOB.cardinals))
 		smoke.time_to_live = time_to_live
-		if(smoke.amount>0)
+		if(smoke.amount > 0)
 			smoke.spread_smoke()
 
 
@@ -658,7 +658,7 @@
 	var/obj/effect/particle_effect/smoke/smoke = new smoke_type(location, amount+1, cause_data)
 	if(lifetime)
 		smoke.time_to_live = lifetime
-	if(smoke.amount)
+	if(smoke.amount > 0)
 		smoke.spread_smoke(direction)
 
 /datum/effect_system/smoke_spread/bad
@@ -707,5 +707,5 @@
 
 	if(lifetime)
 		smoke.time_to_live = lifetime
-	if(smoke.amount)
+	if(smoke.amount > 0)
 		smoke.spread_smoke(direction)

--- a/code/modules/cm_tech/droppod/equipment.dm
+++ b/code/modules/cm_tech/droppod/equipment.dm
@@ -27,11 +27,22 @@
 		equipment_to_spawn.forceMove(loc)
 
 /obj/structure/droppod/equipment/sentry/spawn_equipment(equipment, mob/M)
-	var/obj/structure/machinery/defenses/sentry/S = ..()
-	S.owner_mob = M
-	return S
+	var/obj/structure/machinery/defenses/sentry/sentry = ..()
+	sentry.owner_mob = M
+	return sentry
 
 /obj/structure/droppod/equipment/sentry/move_equipment()
 	..()
-	var/obj/structure/machinery/defenses/sentry/S = equipment_to_spawn
-	S.power_on()
+	var/obj/structure/machinery/defenses/sentry/sentry = equipment_to_spawn
+	sentry.power_on()
+
+/obj/structure/droppod/equipment/sentry_holder/spawn_equipment(equipment, mob/M)
+	var/obj/structure/machinery/sentry_holder/holder = ..()
+	var/obj/structure/machinery/defenses/sentry/sentry = holder.deployed_turret
+	sentry.owner_mob = M
+	return holder
+
+/obj/structure/droppod/equipment/sentry_holder/move_equipment()
+	..()
+	var/obj/structure/machinery/sentry_holder/holder = equipment_to_spawn
+	holder.deploy_sentry()

--- a/code/modules/defenses/defenses.dm
+++ b/code/modules/defenses/defenses.dm
@@ -81,7 +81,7 @@
 	if(ishuman(user))
 		message += SPAN_INFO("A multitool can be used to disassemble it.")
 		message += "\n"
-		message += SPAN_INFO("The turret is currently [locked? "locked" : "unlocked"] to non-engineers.")
+		message += SPAN_INFO("It is currently [locked? "locked" : "unlocked"] to non-engineers.")
 		message += "\n"
 		message += SPAN_INFO("It has [SPAN_HELPFUL("[health]/[health_max]")] health.")
 	message += "\n"

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -550,16 +550,19 @@
 	name = "\improper UA-577 Spaceborn Gauss Turret"
 	fire_delay = 2
 	omni_directional = TRUE
-	var/battery_low = 7 MINUTES
-	var/battery_critical = 9 MINUTES
-	var/battery_dead = 10 MINUTES
+	/// How long the battery for this turret lasts. Will warn low at 70% and critical at 90% use.
+	var/battery_duration = 10 MINUTES
+	/// The current battery state
 	var/battery_state = TURRET_BATTERY_STATE_OK
 
 /obj/structure/machinery/defenses/sentry/premade/deployable/colony/landing_zone/Initialize()
 	. = ..()
-	addtimer(CALLBACK(src, PROC_REF(set_battery_state), TURRET_BATTERY_STATE_LOW), battery_low)
-	addtimer(CALLBACK(src, PROC_REF(set_battery_state), TURRET_BATTERY_STATE_CRITICAL), battery_critical)
-	addtimer(CALLBACK(src, PROC_REF(set_battery_state), TURRET_BATTERY_STATE_DEAD), battery_dead)
+
+	var/low_battery_time = ceil(battery_duration * 0.7)
+	var/critical_battery_time = ceil(battery_duration * 0.9)
+	addtimer(CALLBACK(src, PROC_REF(set_battery_state), TURRET_BATTERY_STATE_LOW), low_battery_time)
+	addtimer(CALLBACK(src, PROC_REF(set_battery_state), TURRET_BATTERY_STATE_CRITICAL), critical_battery_time)
+	addtimer(CALLBACK(src, PROC_REF(set_battery_state), TURRET_BATTERY_STATE_DEAD), battery_duration)
 
 /obj/structure/machinery/defenses/sentry/premade/deployable/colony/landing_zone/get_examine_text(mob/user)
 	. = ..()

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -565,13 +565,13 @@
 	. = ..()
 	switch(battery_state)
 		if(TURRET_BATTERY_STATE_OK)
-			. += "Its battery indictor is green, fully charged."
+			. += SPAN_INFO("Its battery indictor is green, fully charged.")
 		if(TURRET_BATTERY_STATE_LOW)
-			. += "Its battery indictor is flashing yellow."
+			. += SPAN_INFO("Its battery indictor is flashing yellow.")
 		if(TURRET_BATTERY_STATE_CRITICAL)
-			. += "Its battery indictor is flashing red."
+			. += SPAN_INFO("Its battery indictor is flashing red.")
 		if(TURRET_BATTERY_STATE_DEAD)
-			. += "It appears to be offline."
+			. += SPAN_INFO("It appears to be offline.")
 
 /obj/structure/machinery/defenses/sentry/premade/deployable/colony/landing_zone/proc/set_battery_state(state)
 	battery_state = state

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -468,7 +468,7 @@
 	fire(target)
 
 /obj/structure/machinery/defenses/sentry/premade
-	name = "UA-577 Gauss Turret"
+	name = "\improper UA-577 Gauss Turret"
 	immobile = TRUE
 	turned_on = TRUE
 	icon_state = "premade" //for the map editor only
@@ -497,14 +497,14 @@
 	return
 
 /obj/structure/machinery/defenses/sentry/premade/dumb
-	name = "Modified UA-577 Gauss Turret"
+	name = "modified UA-577 Gauss Turret"
 	desc = "A deployable, semi-automated turret with AI targeting capabilities. Armed with an M30 Autocannon and a high-capacity drum magazine. This one's IFF system has been disabled, and it will open fire on any targets within range."
 	faction_group = null
 	ammo = new /obj/item/ammo_magazine/sentry/premade/dumb
 
 //the turret inside a static sentry deployment system
 /obj/structure/machinery/defenses/sentry/premade/deployable
-	name = "UA-633 Static Gauss Turret"
+	name = "\improper UA-633 Static Gauss Turret"
 	desc = "A fully-automated defence turret with mid-range targeting capabilities. Armed with a modified M32-S Autocannon and an internal belt feed."
 	density = TRUE
 	faction_group = FACTION_LIST_MARINE
@@ -527,13 +527,13 @@
 	selected_categories[SENTRY_CATEGORY_IFF] = FACTION_COLONY
 
 /obj/structure/machinery/defenses/sentry/premade/deployable/almayer
-	name = "UA-635C Static Gauss Turret"
+	name = "\improper UA-635C Static Gauss Turret"
 	desc = "A fully-automated defence turret with mid-range targeting capabilities. Armed with a modified M32-S Autocannon and an internal belt feed and modified for UA warship use."
 	fire_delay = 0.4 SECONDS
 	omni_directional = TRUE
 
 /obj/structure/machinery/defenses/sentry/premade/deployable/almayer/mini
-	name = "UA 512-S mini sentry"
+	name = "\improper UA 512-S mini sentry"
 	desc = "A fully-automated defence turret with mid-range targeting capabilities. Armed with a modified M30 Autocannon and an internal belt feed and modified for UA warship use."
 	defense_type = "Mini"
 	fire_delay = 0.25 SECONDS
@@ -566,7 +566,7 @@
 
 #define SENTRY_SNIPER_RANGE 10
 /obj/structure/machinery/defenses/sentry/dmr
-	name = "UA 725-D Sniper Sentry"
+	name = "\improper UA 725-D Sniper Sentry"
 	desc = "A fully-automated defence turret with long-range targeting capabilities. Armed with a modified M32-S Autocannon and an internal belt feed."
 	defense_type = "DMR"
 	health = 150
@@ -603,7 +603,7 @@
 
 #undef SENTRY_SNIPER_RANGE
 /obj/structure/machinery/defenses/sentry/shotgun
-	name = "UA 12-G Shotgun Sentry"
+	name = "\improper UA 12-G Shotgun Sentry"
 	defense_type = "Shotgun"
 	health = 250
 	health_max = 250
@@ -634,7 +634,7 @@
 				L.apply_effect(1, WEAKEN)
 
 /obj/structure/machinery/defenses/sentry/mini
-	name = "UA 512-M mini sentry"
+	name = "\improper UA 512-M mini sentry"
 	defense_type = "Mini"
 	fire_delay = 0.15 SECONDS
 	health = 150

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -547,11 +547,12 @@
 	composite_icon = FALSE
 
 /obj/structure/machinery/defenses/sentry/premade/deployable/colony/landing_zone
-	name = "\improper UA-577 Spaceborn Gauss Turret"
+	name = "\improper UA-577 Spaceborne Gauss Turret"
 	fire_delay = 2
+	sentry_range = 10
 	omni_directional = TRUE
 	/// How long the battery for this turret lasts. Will warn low at 70% and critical at 90% use.
-	var/battery_duration = 10 MINUTES
+	var/battery_duration = 20 MINUTES
 	/// The current battery state
 	var/battery_state = TURRET_BATTERY_STATE_OK
 
@@ -590,6 +591,23 @@
 			turned_on = FALSE
 			power_off_action()
 			update_icon()
+
+/obj/structure/machinery/defenses/sentry/premade/deployable/colony/landing_zone/set_range()
+	var/range = sentry_range - 1
+	var/dbl_range = range * 2
+
+	if(omni_directional)
+		range_bounds = RECT(x, y, dbl_range, dbl_range)
+		return
+	switch(dir)
+		if(EAST)
+			range_bounds = RECT(x+range, y, dbl_range, dbl_range)
+		if(WEST)
+			range_bounds = RECT(x-range, y, dbl_range, dbl_range)
+		if(NORTH)
+			range_bounds = RECT(x, y+range, dbl_range, dbl_range)
+		if(SOUTH)
+			range_bounds = RECT(x, y-range, dbl_range, dbl_range)
 
 //the turret inside the shuttle sentry deployment system
 /obj/structure/machinery/defenses/sentry/premade/dropship

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -546,6 +546,45 @@
 	handheld_type = /obj/item/defenses/handheld/sentry/mini
 	composite_icon = FALSE
 
+/obj/structure/machinery/defenses/sentry/premade/deployable/colony/landing_zone
+	name = "\improper UA-577 Spaceborn Gauss Turret"
+	fire_delay = 2
+	omni_directional = TRUE
+	var/battery_low = 7 MINUTES
+	var/battery_critical = 9 MINUTES
+	var/battery_dead = 10 MINUTES
+	var/battery_state = TURRET_BATTERY_STATE_OK
+
+/obj/structure/machinery/defenses/sentry/premade/deployable/colony/landing_zone/Initialize()
+	. = ..()
+	addtimer(CALLBACK(src, PROC_REF(set_battery_state), TURRET_BATTERY_STATE_LOW), battery_low)
+	addtimer(CALLBACK(src, PROC_REF(set_battery_state), TURRET_BATTERY_STATE_CRITICAL), battery_critical)
+	addtimer(CALLBACK(src, PROC_REF(set_battery_state), TURRET_BATTERY_STATE_DEAD), battery_dead)
+
+/obj/structure/machinery/defenses/sentry/premade/deployable/colony/landing_zone/get_examine_text(mob/user)
+	. = ..()
+	switch(battery_state)
+		if(TURRET_BATTERY_STATE_LOW)
+			. += "Its battery indictor is flashing yellow."
+		if(TURRET_BATTERY_STATE_CRITICAL)
+			. += "Its battery indictor is flashing red."
+		if(TURRET_BATTERY_STATE_DEAD)
+			. += "It appears to be offline."
+
+/obj/structure/machinery/defenses/sentry/premade/deployable/colony/landing_zone/proc/set_battery_state(state)
+	battery_state = state
+	switch(state)
+		if(TURRET_BATTERY_STATE_LOW)
+			playsound(loc, 'sound/weapons/smg_empty_alarm.ogg', 15, 1)
+			visible_message(SPAN_WARNING("[name] beeps steadily as its battery is getting low."))
+		if(TURRET_BATTERY_STATE_CRITICAL)
+			playsound(loc, 'sound/weapons/smg_empty_alarm.ogg', 20, 1)
+			visible_message(SPAN_WARNING("[name] beeps steadily as its battery gets critically low."))
+		if(TURRET_BATTERY_STATE_DEAD)
+			playsound(loc, 'sound/machines/terminal_shutdown.ogg', 35, 1)
+			turned_on = FALSE
+			power_off_action()
+			update_icon()
 
 //the turret inside the shuttle sentry deployment system
 /obj/structure/machinery/defenses/sentry/premade/dropship

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -564,6 +564,8 @@
 /obj/structure/machinery/defenses/sentry/premade/deployable/colony/landing_zone/get_examine_text(mob/user)
 	. = ..()
 	switch(battery_state)
+		if(TURRET_BATTERY_STATE_OK)
+			. += "Its battery indictor is green, fully charged."
 		if(TURRET_BATTERY_STATE_LOW)
 			. += "Its battery indictor is flashing yellow."
 		if(TURRET_BATTERY_STATE_CRITICAL)

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -141,7 +141,7 @@
 	icon_state = "road_edge_decal11"
 	},
 /turf/open/asphalt,
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "aaB" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal9"
@@ -307,13 +307,13 @@
 	dir = 4;
 	icon_state = "desert_transition_edge1"
 	},
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "abb" = (
 /obj/structure/flora/bush/desert{
 	icon_state = "tree_3"
 	},
 /turf/open/desert/dirt,
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "abc" = (
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 4
@@ -370,7 +370,7 @@
 	dir = 6;
 	icon_state = "desert_transition_edge1"
 	},
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "abk" = (
 /turf/closed/wall/hangar{
 	name = "reinforced metal wall"
@@ -551,7 +551,7 @@
 	dir = 5;
 	icon_state = "desert_transition_edge1"
 	},
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "abO" = (
 /obj/structure/surface/rack,
 /turf/open/floor/prison,
@@ -1032,7 +1032,7 @@
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached1"
 	},
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "adr" = (
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 6
@@ -1273,7 +1273,7 @@
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached1"
 	},
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "aeh" = (
 /obj/effect/blocker/toxic_water/Group_2,
 /turf/open/desert/desert_shore/shore_edge1{
@@ -1569,7 +1569,7 @@
 "aeY" = (
 /obj/structure/prop/dam/boulder/boulder1,
 /turf/open/desert/dirt,
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "aeZ" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -1745,7 +1745,7 @@
 /turf/open/asphalt{
 	icon_state = "tile"
 	},
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "afz" = (
 /turf/open/desert/rock/deep/transition{
 	dir = 9
@@ -4391,7 +4391,7 @@
 /turf/open/asphalt{
 	icon_state = "tile"
 	},
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "ani" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/asphalt/cement_sunbleached{
@@ -5021,11 +5021,6 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_central_hallway)
-"apa" = (
-/turf/open/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached4"
-	},
-/area/desert_dam/exterior/valley/valley_northwest)
 "apb" = (
 /obj/structure/machinery/computer/shuttle/elevator_controller/elevator_call/trijent/lz1{
 	pixel_y = 32
@@ -5254,7 +5249,7 @@
 "apP" = (
 /obj/structure/flora/grass/desert/lightgrass_7,
 /turf/open/desert/dirt,
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "apR" = (
 /obj/effect/decal/sand_overlay/sand1/corner1,
 /turf/open/desert/desert_shore/desert_shore1,
@@ -5353,7 +5348,7 @@
 	dir = 4
 	},
 /turf/open/asphalt,
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "aqg" = (
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_northwest)
@@ -5610,7 +5605,7 @@
 	dir = 1
 	},
 /turf/open/asphalt,
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "aqU" = (
 /obj/structure/machinery/door/airlock/almayer/security/glass/colony{
 	dir = 1;
@@ -10195,7 +10190,7 @@
 	unacidable = 1
 	},
 /turf/open/asphalt,
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "aEH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -11271,7 +11266,7 @@
 "aHW" = (
 /obj/structure/flora/grass/desert/lightgrass_4,
 /turf/open/desert/dirt,
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "aHX" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -12854,7 +12849,7 @@
 	icon_state = "S"
 	},
 /turf/open/floor/plating,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "aMK" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/tech_supply,
@@ -12875,7 +12870,7 @@
 	icon_state = "tree_3"
 	},
 /turf/open/desert/dirt,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "aMN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
@@ -12930,13 +12925,13 @@
 	icon_state = "W"
 	},
 /turf/open/floor/plating,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "aMU" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
 	},
 /turf/open/floor/plating,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "aMV" = (
 /obj/effect/decal/sand_overlay/sand1/corner1{
 	dir = 4
@@ -13019,7 +13014,7 @@
 	icon_state = "N"
 	},
 /turf/open/floor/plating,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "aNf" = (
 /obj/structure/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
@@ -13069,7 +13064,7 @@
 	icon_state = "N"
 	},
 /turf/open/floor/plating,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "aNn" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal9"
@@ -13152,7 +13147,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/plating,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "aNy" = (
 /turf/open/floor/prison{
 	dir = 10;
@@ -13162,14 +13157,14 @@
 "aNz" = (
 /obj/effect/decal/sand_overlay/sand1,
 /turf/open/floor/plating,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "aNA" = (
 /obj/effect/decal/sand_overlay/sand1,
 /obj/structure/machinery/conveyor_switch{
 	id = "cargo_landing"
 	},
 /turf/open/floor/plating,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "aNB" = (
 /obj/structure/surface/rack,
 /obj/item/stack/sheet/mineral/phoron{
@@ -13768,7 +13763,7 @@
 	icon_state = "tree_2"
 	},
 /turf/open/desert/dirt,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "aPL" = (
 /obj/structure/machinery/shower{
 	dir = 1
@@ -14541,7 +14536,7 @@
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached19"
 	},
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "aSe" = (
 /turf/open/floor{
 	dir = 1;
@@ -15004,7 +14999,7 @@
 	dir = 5;
 	icon_state = "desert_transition_edge1"
 	},
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "aTF" = (
 /turf/open/desert/rock/deep/transition{
 	dir = 5
@@ -15331,7 +15326,7 @@
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached9"
 	},
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "aUK" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/prison{
@@ -15464,7 +15459,7 @@
 /turf/open/asphalt/cement_sunbleached{
 	icon_state = "cement_sunbleached1"
 	},
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "aVm" = (
 /turf/closed/wall/r_wall,
 /area/desert_dam/building/administration/office)
@@ -15559,14 +15554,6 @@
 	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/landing_pad_one)
-"aVH" = (
-/obj/effect/decal/sand_overlay/sand1{
-	dir = 8
-	},
-/turf/open/asphalt/cement_sunbleached{
-	icon_state = "cement_sunbleached15"
-	},
-/area/desert_dam/exterior/valley/valley_northwest)
 "aVI" = (
 /turf/closed/wall/r_wall,
 /area/desert_dam/building/administration/control_room)
@@ -17275,7 +17262,7 @@
 	icon_state = "stop_decal5"
 	},
 /turf/open/asphalt,
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "baX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/asphalt/cement_sunbleached{
@@ -17763,7 +17750,7 @@
 	},
 /obj/structure/desertdam/decals/road_stop,
 /turf/open/asphalt,
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "bcD" = (
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 8
@@ -18815,7 +18802,7 @@
 	dir = 5;
 	icon_state = "desert_transition_edge1"
 	},
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "bgf" = (
 /obj/structure/platform_decoration{
 	dir = 8
@@ -19158,6 +19145,10 @@
 /obj/structure/surface/table,
 /turf/open/floor/prison,
 /area/desert_dam/building/water_treatment_two/control_room)
+"bhp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_two)
 "bhq" = (
 /turf/open/floor/prison,
 /area/desert_dam/building/water_treatment_two/control_room)
@@ -26357,6 +26348,12 @@
 	},
 /turf/open/asphalt,
 /area/desert_dam/exterior/landing_pad_one)
+"bFC" = (
+/obj/structure/flora/grass/tallgrass/desert/corner{
+	dir = 9
+	},
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_two)
 "bFD" = (
 /turf/open/floor/prison{
 	dir = 10;
@@ -36823,7 +36820,7 @@
 	dir = 4
 	},
 /turf/open/asphalt,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "cnB" = (
 /obj/structure/platform{
 	dir = 8
@@ -40528,7 +40525,7 @@
 	dir = 8;
 	icon_state = "desert_transition_corner1"
 	},
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "czB" = (
 /obj/structure/platform,
 /obj/effect/blocker/toxic_water/Group_1,
@@ -41767,9 +41764,6 @@
 	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/workshop_foyer)
-"cCY" = (
-/turf/open/desert/dirt,
-/area/desert_dam/exterior/rock)
 "cCZ" = (
 /obj/structure/machinery/landinglight/ds2/delaytwo{
 	dir = 4
@@ -43119,7 +43113,7 @@
 	dir = 5;
 	icon_state = "desert_transition_edge1"
 	},
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "cGS" = (
 /obj/structure/machinery/landinglight/ds2/delaytwo,
 /turf/open/asphalt/cement_sunbleached{
@@ -45890,7 +45884,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/asphalt,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "cQd" = (
 /obj/item/trash/cheesie,
 /obj/effect/landmark/objective_landmark/close,
@@ -46085,7 +46079,7 @@
 	dir = 10
 	},
 /turf/open/desert/dirt,
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "cQN" = (
 /obj/structure/machinery/power/apc{
 	dir = 1;
@@ -46507,6 +46501,12 @@
 	icon_state = "cement_sunbleached15"
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
+"cSn" = (
+/turf/open/desert/dirt{
+	dir = 8;
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/landing_pad_one)
 "cSo" = (
 /obj/structure/surface/table/reinforced,
 /obj/structure/machinery/door/window/eastleft{
@@ -46707,7 +46707,7 @@
 	dir = 5
 	},
 /turf/open/desert/dirt,
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "cTa" = (
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	dir = 4;
@@ -47725,7 +47725,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/asphalt,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "cXD" = (
 /turf/open/floor/prison{
 	icon_state = "darkbrown2"
@@ -48278,7 +48278,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/plating,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "dax" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -48373,9 +48373,6 @@
 	},
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_civilian)
-"daU" = (
-/turf/open/floor/plating,
-/area/desert_dam/exterior/valley/valley_cargo)
 "daX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -48403,7 +48400,7 @@
 	id = "cargo_landing"
 	},
 /turf/open/floor/plating,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "dbd" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -49335,7 +49332,7 @@
 	},
 /obj/effect/landmark/railgun_camera_pos,
 /turf/open/asphalt,
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "deA" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/prison{
@@ -49455,13 +49452,13 @@
 	icon_state = "S"
 	},
 /turf/open/floor/plating,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "deV" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
 	},
 /turf/open/floor/plating,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "deW" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -49945,7 +49942,7 @@
 "dgG" = (
 /obj/structure/prop/dam/large_boulder/boulder2,
 /turf/open/desert/dirt,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "dgH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -50260,6 +50257,12 @@
 	},
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_civilian)
+"dja" = (
+/obj/structure/flora/grass/tallgrass/desert/corner{
+	dir = 8
+	},
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_one)
 "djg" = (
 /obj/item/paper_bin,
 /obj/item/tool/stamp,
@@ -51765,7 +51768,7 @@
 	dir = 1
 	},
 /turf/open/desert/dirt,
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "dvZ" = (
 /obj/structure/flora/grass/tallgrass/desert/corner{
 	dir = 9
@@ -53108,7 +53111,7 @@
 /turf/open/desert/dirt{
 	icon_state = "desert_transition_edge1"
 	},
-/area/desert_dam/exterior/valley/valley_northwest)
+/area/desert_dam/exterior/landing_pad_one)
 "dDD" = (
 /obj/structure/surface/table/reinforced,
 /obj/item/clothing/head/welding,
@@ -60135,6 +60138,12 @@
 	icon_state = "cement_sunbleached9"
 	},
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"ekN" = (
+/obj/structure/desertdam/decals/road_edge{
+	icon_state = "road_edge_decal7"
+	},
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_one)
 "emt" = (
 /obj/effect/decal/sand_overlay/sand1/corner1{
 	dir = 1
@@ -60160,6 +60169,12 @@
 	icon_state = "whitered"
 	},
 /area/desert_dam/building/medical/surgery_room_one)
+"erF" = (
+/turf/open/desert/dirt{
+	dir = 5;
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/landing_pad_two)
 "esG" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -60200,7 +60215,7 @@
 	},
 /obj/effect/decal/sand_overlay/sand1/corner1,
 /turf/open/asphalt,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "eCK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -60242,6 +60257,18 @@
 	},
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
+"eRL" = (
+/obj/structure/desertdam/decals/road_edge{
+	icon_state = "road_edge_decal2"
+	},
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_one)
+"eRX" = (
+/obj/structure/desertdam/decals/road_edge{
+	icon_state = "road_edge_decal8"
+	},
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_two)
 "eTi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/objective_landmark/close,
@@ -60311,6 +60338,15 @@
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
+"eZC" = (
+/obj/structure/desertdam/decals/road_edge{
+	icon_state = "road_edge_decal2"
+	},
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 8
+	},
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_one)
 "eZE" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal2"
@@ -60320,6 +60356,12 @@
 	},
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"eZN" = (
+/obj/structure/desertdam/decals/road_edge{
+	icon_state = "road_edge_decal10"
+	},
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_one)
 "faE" = (
 /obj/structure/flora/grass/tallgrass/desert/corner{
 	dir = 1
@@ -60426,6 +60468,12 @@
 	},
 /turf/closed/wall/rock/orange,
 /area/desert_dam/exterior/rock)
+"fqj" = (
+/turf/open/desert/dirt{
+	dir = 8;
+	icon_state = "desert_transition_corner1"
+	},
+/area/desert_dam/exterior/landing_pad_one)
 "fqt" = (
 /turf/open/desert/dirt{
 	dir = 9;
@@ -60581,7 +60629,7 @@
 "fSc" = (
 /obj/structure/flora/grass/desert/lightgrass_12,
 /turf/open/desert/dirt,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "fTk" = (
 /obj/structure/sink/kitchen,
 /obj/structure/surface/table/reinforced,
@@ -60600,6 +60648,10 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"fYz" = (
+/obj/structure/flora/grass/tallgrass/desert/corner,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_two)
 "fYS" = (
 /obj/structure/largecrate/random,
 /obj/effect/decal/cleanable/dirt,
@@ -60806,6 +60858,16 @@
 	icon_state = "whiteyellow"
 	},
 /area/desert_dam/interior/dam_interior/garage)
+"gBQ" = (
+/obj/structure/desertdam/decals/road_edge{
+	icon_state = "road_edge_decal4"
+	},
+/obj/structure/desertdam/decals/road_stop{
+	dir = 8;
+	icon_state = "stop_decal5"
+	},
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_one)
 "gBV" = (
 /obj/effect/landmark/crap_item,
 /obj/effect/decal/cleanable/dirt,
@@ -60883,6 +60945,12 @@
 	dir = 10
 	},
 /area/desert_dam/interior/dam_interior/garage)
+"gLg" = (
+/turf/open/desert/dirt{
+	dir = 1;
+	icon_state = "desert_transition_corner1"
+	},
+/area/desert_dam/exterior/landing_pad_two)
 "gLl" = (
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 1
@@ -61050,6 +61118,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"hjz" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N"
+	},
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_two)
+"hjW" = (
+/turf/open/desert/dirt{
+	dir = 9;
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/landing_pad_two)
 "hmA" = (
 /obj/structure/surface/table/almayer,
 /obj/item/paper_bin,
@@ -61095,6 +61175,11 @@
 	icon_state = "cement_sunbleached1"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"htc" = (
+/turf/open/desert/dirt{
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/landing_pad_two)
 "hvD" = (
 /obj/structure/shuttle/diagonal{
 	icon_state = "swall_f10"
@@ -61173,6 +61258,10 @@
 "hCf" = (
 /turf/open/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/valley/south_valley_dam)
+"hCY" = (
+/obj/structure/flora/grass/desert/lightgrass_3,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_two)
 "hDT" = (
 /obj/structure/flora/bush/desert/cactus{
 	icon_state = "cactus_4"
@@ -61242,6 +61331,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/building/mining/workshop)
+"hTf" = (
+/obj/structure/flora/grass/tallgrass/desert/corner{
+	dir = 6
+	},
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_two)
 "hTg" = (
 /obj/effect/landmark/survivor_spawner,
 /turf/open/floor{
@@ -61260,6 +61355,10 @@
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/closed/wall/r_wall/chigusa,
 /area/desert_dam/interior/lab_northeast/east_lab_west_hallway)
+"hVV" = (
+/obj/structure/flora/grass/desert/lightgrass_9,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_two)
 "hWz" = (
 /obj/structure/surface/table/reinforced,
 /obj/effect/landmark/objective_landmark/medium,
@@ -61349,6 +61448,12 @@
 	},
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"ign" = (
+/turf/open/desert/dirt{
+	dir = 10;
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/landing_pad_one)
 "ihT" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/objective_landmark/close,
@@ -61521,6 +61626,12 @@
 	icon_state = "desert_transition_edge1"
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
+"iHF" = (
+/turf/open/desert/dirt{
+	dir = 10;
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/landing_pad_two)
 "iIB" = (
 /obj/structure/surface/table/reinforced,
 /obj/effect/landmark/objective_landmark/far,
@@ -61533,6 +61644,10 @@
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison,
 /area/desert_dam/exterior/valley/south_valley_dam)
+"iKp" = (
+/obj/structure/desertdam/decals/road_edge,
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_one)
 "iNg" = (
 /obj/structure/machinery/door/airlock/almayer/engineering/colony{
 	dir = 2;
@@ -61622,11 +61737,19 @@
 	icon_state = "cement_sunbleached18"
 	},
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"iZY" = (
+/obj/structure/flora/grass/desert/heavygrass_3,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_one)
 "jbx" = (
 /turf/open/asphalt{
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"jcb" = (
+/obj/structure/flora/grass/desert/lightgrass_6,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_two)
 "jci" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/landmark/objective_landmark/close,
@@ -61662,6 +61785,15 @@
 	icon_state = "cement_sunbleached14"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"jqU" = (
+/obj/structure/desertdam/decals/road_edge{
+	icon_state = "road_edge_decal2"
+	},
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 8
+	},
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_two)
 "jre" = (
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison{
@@ -62031,6 +62163,12 @@
 	},
 /turf/open/floor/sandstone/runed,
 /area/desert_dam/interior/caves/temple)
+"kPo" = (
+/obj/structure/desertdam/decals/road_edge{
+	icon_state = "road_edge_decal4"
+	},
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_two)
 "kPs" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/desert/dirt,
@@ -62241,6 +62379,11 @@
 	},
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"lzs" = (
+/turf/open/desert/dirt{
+	icon_state = "rock1"
+	},
+/area/desert_dam/exterior/landing_pad_two)
 "lzZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
@@ -62277,6 +62420,9 @@
 	icon_state = "whiteyellowfull"
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_lobby)
+"lIt" = (
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_two)
 "lIK" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal4"
@@ -62285,7 +62431,7 @@
 	dir = 1
 	},
 /turf/open/asphalt,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "lJM" = (
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 9
@@ -62383,6 +62529,12 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"lZP" = (
+/obj/structure/flora/grass/tallgrass/desert/corner{
+	dir = 9
+	},
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_one)
 "mar" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/tech_supply,
@@ -62430,6 +62582,13 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_civilian)
+"mfH" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_two)
 "mfK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62459,6 +62618,12 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/interior/dam_interior/workshop)
+"mjR" = (
+/obj/structure/desertdam/decals/road_edge{
+	icon_state = "road_edge_decal6"
+	},
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_one)
 "mkd" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
@@ -62500,6 +62665,12 @@
 	icon_state = "green"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
+"moq" = (
+/turf/open/desert/dirt{
+	dir = 6;
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/landing_pad_one)
 "mqM" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/desert/rock,
@@ -62530,6 +62701,10 @@
 	icon_state = "multi_tiles"
 	},
 /area/desert_dam/interior/caves/temple)
+"muj" = (
+/obj/structure/flora/grass/tallgrass/desert,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_two)
 "myx" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/floor/prison{
@@ -62566,6 +62741,19 @@
 	},
 /turf/open/gm/river/desert/shallow,
 /area/desert_dam/exterior/river/riverside_south)
+"mBO" = (
+/obj/structure/flora/grass/tallgrass/desert,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_one)
+"mDd" = (
+/obj/structure/desertdam/decals/road_edge{
+	icon_state = "road_edge_decal12"
+	},
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 10
+	},
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_two)
 "mDz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/asphalt/cement_sunbleached{
@@ -62707,6 +62895,9 @@
 	icon_state = "kitchen"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
+"mZb" = (
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_one)
 "mZj" = (
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 4
@@ -62737,6 +62928,12 @@
 "ncm" = (
 /turf/open/desert/rock/deep,
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
+"ndF" = (
+/turf/open/desert/dirt{
+	dir = 1;
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/landing_pad_one)
 "ndP" = (
 /obj/structure/stairs/perspective{
 	color = "#b29082";
@@ -62762,6 +62959,12 @@
 	icon_state = "cement_sunbleached13"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"niN" = (
+/obj/structure/flora/grass/tallgrass/desert/corner{
+	dir = 1
+	},
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_two)
 "nji" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison{
@@ -62808,6 +63011,12 @@
 	icon_state = "sterile_white"
 	},
 /area/desert_dam/building/dorms/restroom)
+"nnv" = (
+/turf/open/desert/dirt{
+	dir = 9;
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/landing_pad_one)
 "nsf" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal12"
@@ -63009,6 +63218,11 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/open/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"ogc" = (
+/turf/open/desert/dirt{
+	icon_state = "rock1"
+	},
+/area/desert_dam/exterior/landing_pad_one)
 "oit" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/desert/dirt{
@@ -63022,6 +63236,10 @@
 	},
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"onm" = (
+/obj/structure/flora/grass/desert/lightgrass_4,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_two)
 "onA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
@@ -63151,6 +63369,10 @@
 	icon_state = "desert_transition_edge1"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"oJT" = (
+/obj/structure/flora/grass/desert/lightgrass_2,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_one)
 "oJW" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -63163,6 +63385,12 @@
 	},
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"oMz" = (
+/turf/open/desert/dirt{
+	dir = 4;
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/landing_pad_one)
 "oNS" = (
 /obj/structure/stairs,
 /obj/structure/platform{
@@ -63326,7 +63554,7 @@
 	dir = 1
 	},
 /turf/open/asphalt,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "ppS" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/objective_landmark/science,
@@ -63388,6 +63616,14 @@
 	icon_state = "white"
 	},
 /area/desert_dam/interior/dam_interior/garage)
+"pzk" = (
+/obj/effect/decal/sand_overlay/sand1/corner1{
+	dir = 1
+	},
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/landing_pad_one)
 "pzv" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal5"
@@ -63450,6 +63686,13 @@
 /obj/structure/window/framed/hangar/reinforced,
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/garage)
+"pHs" = (
+/obj/structure/desertdam/decals/road_stop{
+	dir = 8;
+	icon_state = "stop_decal5"
+	},
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_one)
 "pHU" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
@@ -63498,6 +63741,11 @@
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/valley/valley_civilian)
+"pRD" = (
+/turf/open/desert/dirt{
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/landing_pad_one)
 "pSM" = (
 /obj/effect/landmark/nightmare{
 	insert_tag = "purple-new-bridge"
@@ -63562,6 +63810,12 @@
 	dir = 6
 	},
 /area/desert_dam/interior/caves/temple)
+"qkz" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_two)
 "qkJ" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal4"
@@ -63575,6 +63829,10 @@
 	icon_state = "cement12"
 	},
 /area/desert_dam/exterior/telecomm/lz1_south)
+"qlr" = (
+/obj/structure/flora/grass/desert/heavygrass_4,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_one)
 "qlx" = (
 /obj/effect/decal/sand_overlay/sand1,
 /obj/structure/blocker/forcefield/multitile_vehicles,
@@ -63696,6 +63954,12 @@
 	icon_state = "cement_sunbleached18"
 	},
 /area/desert_dam/exterior/valley/south_valley_dam)
+"qDl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached9"
+	},
+/area/desert_dam/exterior/landing_pad_one)
 "qEJ" = (
 /obj/structure/desertdam/decals/road_edge,
 /obj/effect/decal/cleanable/dirt,
@@ -63714,6 +63978,12 @@
 /obj/structure/flora/grass/tallgrass/desert/corner,
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"qHh" = (
+/obj/structure/flora/grass/tallgrass/desert/corner{
+	dir = 10
+	},
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_two)
 "qHt" = (
 /obj/structure/surface/table,
 /obj/effect/landmark/objective_landmark/close,
@@ -63725,6 +63995,10 @@
 /obj/structure/flora/grass/desert/lightgrass_10,
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"qIC" = (
+/obj/structure/flora/tree/joshua,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_one)
 "qJI" = (
 /obj/structure/machinery/power/apc{
 	dir = 1;
@@ -63762,6 +64036,12 @@
 	icon_state = "squareswood"
 	},
 /area/desert_dam/interior/caves/temple)
+"qLE" = (
+/turf/open/desert/dirt{
+	dir = 5;
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/landing_pad_one)
 "qLT" = (
 /obj/structure/showcase{
 	desc = "An ancient, dusty tomb with strange alien writing. It's best not to touch it.";
@@ -64142,6 +64422,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"sav" = (
+/turf/open/desert/dirt{
+	icon_state = "desert_transition_corner1"
+	},
+/area/desert_dam/exterior/landing_pad_two)
+"saQ" = (
+/obj/structure/fence,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_two)
+"saS" = (
+/obj/structure/flora/grass/desert/heavygrass_9,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_one)
 "sbP" = (
 /obj/effect/decal/sand_overlay/sand1,
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -64325,6 +64618,22 @@
 	icon_state = "cement_sunbleached4"
 	},
 /area/desert_dam/exterior/valley/valley_hydro)
+"sAm" = (
+/turf/open/desert/dirt{
+	dir = 1;
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/landing_pad_two)
+"sAZ" = (
+/obj/structure/desertdam/decals/road_edge{
+	icon_state = "road_edge_decal7"
+	},
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_two)
+"sCW" = (
+/obj/structure/largecrate/random/secure,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_one)
 "sDf" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/prison{
@@ -64403,7 +64712,7 @@
 	dir = 6
 	},
 /turf/open/asphalt,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "sOu" = (
 /obj/structure/surface/table/reinforced,
 /obj/structure/machinery/chem_dispenser/soda{
@@ -64431,6 +64740,14 @@
 	icon_state = "desert_transition_corner1"
 	},
 /area/desert_dam/interior/caves/temple)
+"sQE" = (
+/obj/effect/decal/sand_overlay/sand1/corner1{
+	dir = 4
+	},
+/turf/open/asphalt/cement_sunbleached{
+	icon_state = "cement_sunbleached18"
+	},
+/area/desert_dam/exterior/landing_pad_one)
 "sRl" = (
 /obj/effect/landmark/nightmare{
 	insert_tag = "uppcrash"
@@ -64451,6 +64768,14 @@
 "sUr" = (
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
+"sUF" = (
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 8
+	},
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/landing_pad_one)
 "sWS" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -64565,7 +64890,7 @@
 	icon_state = "road_edge_decal3"
 	},
 /turf/open/asphalt,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "tni" = (
 /obj/effect/decal/sand_overlay/sand1,
 /turf/open/asphalt{
@@ -64608,6 +64933,12 @@
 	icon_state = "bright_clean"
 	},
 /area/desert_dam/interior/dam_interior/garage)
+"txr" = (
+/turf/open/desert/dirt{
+	dir = 4;
+	icon_state = "desert_transition_corner1"
+	},
+/area/desert_dam/exterior/landing_pad_one)
 "txD" = (
 /obj/structure/toilet{
 	dir = 8
@@ -64792,6 +65123,15 @@
 /obj/structure/flora/grass/tallgrass/desert,
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"ucS" = (
+/obj/structure/desertdam/decals/road_edge{
+	icon_state = "road_edge_decal2"
+	},
+/obj/effect/decal/sand_overlay/sand1/corner1{
+	dir = 4
+	},
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_one)
 "uez" = (
 /turf/closed/wall/hangar{
 	name = "reinforced metal wall"
@@ -64823,6 +65163,10 @@
 	dir = 1
 	},
 /area/desert_dam/interior/caves/temple)
+"uic" = (
+/obj/structure/machinery/colony_floodlight,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_two)
 "uis" = (
 /obj/effect/decal/sand_overlay/sand1,
 /turf/open/asphalt/cement_sunbleached{
@@ -64874,6 +65218,15 @@
 	},
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/south_valley_dam)
+"urC" = (
+/obj/structure/desertdam/decals/road_edge{
+	icon_state = "road_edge_decal9"
+	},
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 9
+	},
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_two)
 "uso" = (
 /obj/structure/surface/table/reinforced/prison{
 	color = "#6b675e"
@@ -64955,6 +65308,12 @@
 	icon_state = "dirt2"
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
+"uHx" = (
+/obj/structure/desertdam/decals/road_edge{
+	icon_state = "road_edge_decal8"
+	},
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_one)
 "uHT" = (
 /obj/structure/machinery/camera/autoname/lz_camera,
 /turf/open/floor/plating,
@@ -64967,6 +65326,10 @@
 	icon_state = "whitegreenfull"
 	},
 /area/desert_dam/building/medical/treatment_room)
+"uJl" = (
+/obj/structure/flora/grass/desert/lightgrass_9,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_one)
 "uKo" = (
 /obj/structure/platform/mineral/sandstone/runed{
 	dir = 4
@@ -64995,6 +65358,10 @@
 	},
 /turf/open/desert/rock,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"uME" = (
+/obj/structure/flora/grass/desert/lightgrass_2,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_two)
 "uMG" = (
 /obj/structure/platform{
 	dir = 1
@@ -65036,6 +65403,11 @@
 /obj/structure/flora/grass/desert/lightgrass_9,
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"uSv" = (
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/landing_pad_two)
 "uTo" = (
 /obj/structure/flora/grass/tallgrass/desert,
 /turf/open/desert/dirt,
@@ -65051,6 +65423,11 @@
 /obj/effect/decal/remains/human,
 /turf/open/desert/rock,
 /area/desert_dam/interior/caves/temple)
+"uWt" = (
+/turf/closed/wall/hangar{
+	name = "reinforced metal wall"
+	},
+/area/desert_dam/exterior/landing_pad_two)
 "uWT" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -65072,6 +65449,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
+"uZr" = (
+/turf/open/desert/dirt{
+	icon_state = "desert_transition_corner1"
+	},
+/area/desert_dam/exterior/landing_pad_one)
 "vfr" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/desert/dirt{
@@ -65116,6 +65498,10 @@
 /obj/structure/fence,
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"vjO" = (
+/obj/structure/flora/grass/desert/lightgrass_12,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_one)
 "vnf" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -65263,6 +65649,12 @@
 	icon_state = "cement_sunbleached3"
 	},
 /area/desert_dam/exterior/telecomm/lz2_storage)
+"vGu" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_two)
 "vHj" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -65338,6 +65730,12 @@
 	icon_state = "cement_sunbleached19"
 	},
 /area/desert_dam/exterior/valley/bar_valley_dam)
+"vTA" = (
+/turf/open/desert/dirt{
+	dir = 6;
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/landing_pad_two)
 "vTR" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal4"
@@ -65434,6 +65832,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/bunker,
 /area/desert_dam/interior/dam_interior/garage)
+"wpr" = (
+/obj/effect/decal/sand_overlay/sand1,
+/turf/open/asphalt{
+	icon_state = "tile"
+	},
+/area/desert_dam/exterior/landing_pad_one)
 "wpW" = (
 /obj/structure/flora/grass/desert/lightgrass_6,
 /turf/open/desert/dirt,
@@ -65487,6 +65891,12 @@
 /obj/structure/desertdam/decals/road_edge,
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_telecoms)
+"wuV" = (
+/obj/structure/desertdam/decals/road_edge{
+	icon_state = "road_edge_decal5"
+	},
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_one)
 "wya" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -65519,6 +65929,16 @@
 	},
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_telecoms)
+"wDC" = (
+/obj/structure/prop/dam/large_boulder/boulder1,
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_one)
+"wEy" = (
+/turf/open/desert/dirt{
+	dir = 1;
+	icon_state = "desert_transition_corner1"
+	},
+/area/desert_dam/exterior/landing_pad_one)
 "wFv" = (
 /obj/structure/surface/table/reinforced,
 /turf/open/floor/prison{
@@ -65682,6 +66102,12 @@
 	},
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_hydro)
+"xbA" = (
+/obj/structure/desertdam/decals/road_edge{
+	icon_state = "road_edge_decal12"
+	},
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_one)
 "xcG" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal3"
@@ -65988,6 +66414,12 @@
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/desert/dirt,
 /area/desert_dam/exterior/valley/valley_civilian)
+"xOm" = (
+/obj/structure/flora/grass/tallgrass/desert/corner{
+	dir = 5
+	},
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_two)
 "xOK" = (
 /obj/effect/blocker/toxic_water/Group_2,
 /obj/structure/disposalpipe/segment,
@@ -66024,6 +66456,12 @@
 	icon_state = "tile"
 	},
 /area/desert_dam/exterior/valley/valley_labs)
+"xUS" = (
+/turf/open/desert/dirt{
+	dir = 4;
+	icon_state = "desert_transition_edge1"
+	},
+/area/desert_dam/exterior/landing_pad_two)
 "xUU" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/body,
 /turf/open/floor/corsat{
@@ -66031,6 +66469,12 @@
 	icon_state = "squareswood"
 	},
 /area/desert_dam/interior/caves/temple)
+"xWj" = (
+/obj/structure/flora/grass/tallgrass/desert/corner{
+	dir = 6
+	},
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/landing_pad_one)
 "xYb" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_wall,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
@@ -66066,6 +66510,13 @@
 	},
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_labs)
+"ybW" = (
+/obj/structure/desertdam/decals/road_edge,
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 4
+	},
+/turf/open/asphalt,
+/area/desert_dam/exterior/landing_pad_two)
 "ydw" = (
 /obj/structure/window/framed/hangar/reinforced,
 /obj/structure/blocker/forcefield/multitile_vehicles,
@@ -66133,7 +66584,7 @@
 	icon_state = "E"
 	},
 /turf/open/asphalt,
-/area/desert_dam/exterior/valley/valley_cargo)
+/area/desert_dam/exterior/landing_pad_two)
 "ylT" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -68236,7 +68687,7 @@ dTs
 dTs
 dTs
 dTs
-cuH
+lzs
 dTs
 dTs
 dTs
@@ -68244,7 +68695,7 @@ dTs
 dTs
 dTs
 dTs
-cuH
+lzs
 dTs
 dTs
 dTs
@@ -68468,18 +68919,18 @@ dTs
 dTs
 dTs
 dTs
-csA
-crq
-csA
-crq
+gLg
+sav
+gLg
+sav
 dTs
 dTs
 dTs
-cwB
-cwB
-crq
-csA
-crq
+xUS
+xUS
+sav
+gLg
+sav
 dTs
 dTs
 dTs
@@ -68695,27 +69146,27 @@ dTs
 dTs
 dTs
 dTs
-csA
-cwB
-crq
+gLg
+xUS
+sav
 dTs
 dTs
-csA
-cwB
-csD
-crr
-csD
-crr
-cwB
-cwB
-csD
-doE
-doE
-crr
-csD
-crr
-crq
-cuH
+gLg
+xUS
+vTA
+erF
+vTA
+erF
+xUS
+xUS
+vTA
+lIt
+lIt
+erF
+vTA
+erF
+sav
+lzs
 dTs
 dTs
 dTs
@@ -68922,35 +69373,35 @@ dTs
 dTs
 dTs
 dTs
-csA
-cwB
-crq
+gLg
+xUS
+sav
 dTs
 dTs
-csA
-cwB
-csD
-doE
-cxV
-csB
-crr
-csD
-doE
-doE
-doE
+gLg
+xUS
+vTA
+lIt
+sAm
+htc
+erF
+vTA
+lIt
+lIt
+lIt
 aMM
-doE
-doE
-doE
-doE
-doE
-doE
-doE
-doE
-doE
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
 cGR
-cwB
-crq
+xUS
+sav
 dTs
 dTs
 dTs
@@ -69154,37 +69605,37 @@ dTs
 dTs
 dTs
 dTs
-cuH
-csA
-csD
-doE
-crr
-cwB
-crq
-csB
-doE
-doE
-doE
+lzs
+gLg
+vTA
+lIt
+erF
+xUS
+sav
+htc
+lIt
+lIt
+lIt
 cGR
-csD
-doE
-doE
-doE
-doE
-doE
-doE
-doE
-doE
-doE
-doE
-doE
-doE
-doE
-doE
-doE
-doE
-doE
-cxV
+vTA
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+sAm
 dTs
 dTs
 dTs
@@ -69387,39 +69838,39 @@ cUf
 cxV
 dTs
 dTs
-cwB
-cwB
-csD
-doE
-doE
-doE
-doE
-crr
-csD
-doE
-doE
-doE
-doE
-doE
-doE
-doE
-doE
-doE
-doE
-doE
-doE
-doE
-doE
-doE
-doE
-cuL
-crw
-crw
-cuz
-doE
-doE
-crr
-crq
+xUS
+xUS
+vTA
+lIt
+lIt
+lIt
+lIt
+erF
+vTA
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+urC
+ybW
+ybW
+mDd
+lIt
+lIt
+erF
+sav
 dTs
 dTs
 dTs
@@ -69432,20 +69883,17 @@ dTs
 dTs
 dTs
 dTs
-air
+wEy
 dTs
 dTs
-air
-amP
-apt
-ahu
-dTs
-dTs
-dTs
-apt
+wEy
+oMz
+uZr
+ogc
 dTs
 dTs
 dTs
+uZr
 dTs
 dTs
 dTs
@@ -69462,9 +69910,12 @@ dTs
 dTs
 dTs
 dTs
-ahu
-air
-apt
+dTs
+dTs
+dTs
+ogc
+wEy
+uZr
 dTs
 dTs
 dTs
@@ -69620,7 +70071,7 @@ cCO
 ctK
 dTs
 dTs
-cwz
+iHF
 aKY
 cMq
 cGu
@@ -69647,14 +70098,14 @@ cGu
 cMq
 cQn
 lIK
-crx
-crx
+dws
+dws
 tlh
-doE
-doE
+lIt
+lIt
 dgG
-cxV
-cuH
+sAm
+lzs
 dTs
 dTs
 acu
@@ -69665,44 +70116,44 @@ dTs
 dTs
 dTs
 dTs
-ahu
-ais
-apu
+ogc
+pRD
+qLE
 aba
 abj
 cSZ
 abN
-apt
-ahu
-air
-aiY
-apu
-apt
-ahu
+uZr
+ogc
+wEy
+moq
+qLE
+uZr
+ogc
 dTs
 dTs
 dTs
 dTs
-air
-dTs
-dTs
-dTs
-dTs
-dTs
+wEy
 dTs
 dTs
 dTs
 dTs
 dTs
 dTs
-air
-amP
-aiY
-axZ
-ahu
 dTs
-amP
-apt
+dTs
+dTs
+dTs
+dTs
+wEy
+oMz
+moq
+ndF
+ogc
+dTs
+oMz
+uZr
 dTs
 dTs
 dTs
@@ -69854,7 +70305,7 @@ cCU
 cAa
 dTs
 dTs
-csD
+vTA
 alh
 cMC
 aav
@@ -69880,14 +70331,14 @@ cGG
 cDL
 cMC
 cgh
-cUl
-cvJ
-crz
+kPo
+qkz
+hjz
 tlh
-doE
-doE
-doE
-cxV
+lIt
+lIt
+lIt
+sAm
 dTs
 dTs
 dTs
@@ -69897,47 +70348,47 @@ acu
 acu
 dTs
 dTs
-ahu
-ahu
-air
-aiY
-aqz
-cQf
-nzB
-nzB
+ogc
+ogc
+wEy
+moq
+uJl
+xWj
+mBO
+mBO
 cSZ
 aTC
-amP
-aiY
-aiZ
-aiZ
-apu
-apt
-ahu
+oMz
+moq
+mZb
+mZb
+qLE
+uZr
+ogc
 dTs
 dTs
-air
-aiY
-apu
-amP
-apt
-dTs
-dTs
-dTs
+wEy
+moq
+qLE
+oMz
+uZr
 dTs
 dTs
 dTs
 dTs
 dTs
-aiY
-apc
+dTs
+dTs
+dTs
+moq
+oJT
 apP
-apu
-apt
-ait
-aja
-apu
-apt
+qLE
+uZr
+txr
+ign
+qLE
+uZr
 dTs
 dTs
 dTs
@@ -70114,15 +70565,15 @@ tcB
 cDY
 cMD
 cBS
-cUl
-crx
-crx
+kPo
+dws
+dws
 tlh
-doE
-doE
-doE
-crr
-crq
+lIt
+lIt
+lIt
+erF
+sav
 dTs
 dTs
 acu
@@ -70130,52 +70581,52 @@ acu
 (18,1,1) = {"
 acu
 dTs
-air
-amP
-amP
-aiY
-aiZ
-aiZ
+wEy
+oMz
+oMz
+moq
+mZb
+mZb
 cQL
-cRc
-nzB
+dja
+mBO
 dvW
 apP
-aiZ
-aiZ
-aiZ
-aiZ
-aiZ
-apu
-apt
-air
-amP
-aiY
-aiZ
-aJm
-aiZ
-apu
-amP
-apt
-ahu
+mZb
+mZb
+mZb
+mZb
+mZb
+qLE
+uZr
+wEy
+oMz
+moq
+mZb
+qIC
+mZb
+qLE
+oMz
+uZr
+ogc
 dTs
 dTs
-aiY
-axZ
-ait
-aja
-aiZ
-apc
-aiZ
-apu
-amP
-aiY
-aiZ
-apu
-apt
-ahu
-air
-apt
+moq
+ndF
+txr
+ign
+mZb
+oJT
+mZb
+qLE
+oMz
+moq
+mZb
+qLE
+uZr
+ogc
+wEy
+uZr
 dTs
 dTs
 dTs
@@ -70348,69 +70799,69 @@ cDY
 cDY
 cML
 cBS
-cUl
-crx
-crx
+kPo
+dws
+dws
 tlh
-doE
-cuO
-doE
-doE
-cxV
-cuH
+lIt
+uic
+lIt
+lIt
+sAm
+lzs
 dTs
 acu
 "}
 (19,1,1) = {"
 acu
 dTs
-ais
-aiZ
-aJm
-aiZ
-aiZ
+pRD
+mZb
+qIC
+mZb
+mZb
 aQS
-anF
+vjO
 aHW
 cQL
-dvZ
-aqz
-aiZ
-aiZ
-aiZ
+lZP
+uJl
+mZb
+mZb
+mZb
 aQS
-aqz
-aiZ
-apu
-aiY
-aiZ
-aiZ
-aiZ
-aiZ
-aiZ
-aiZ
+uJl
+mZb
+qLE
+moq
+mZb
+mZb
+mZb
+mZb
+mZb
+mZb
 aQS
-apu
-amP
-aiY
-aiZ
-aiZ
-apu
-amP
-aiY
-aiZ
-aiZ
+qLE
+oMz
+moq
+mZb
+mZb
+qLE
+oMz
+moq
+mZb
+mZb
 ben
-aiZ
-aiZ
-aiZ
-aiZ
-aiZ
+mZb
+mZb
+mZb
+mZb
+mZb
 bge
-amP
-aiY
-apu
-amP
+oMz
+moq
+qLE
+oMz
 bht
 bht
 bht
@@ -70582,15 +71033,15 @@ cDY
 cDY
 cNb
 cRB
-cUl
-cvJ
-crz
+kPo
+qkz
+hjz
 tlh
-doE
-doE
-doE
-doE
-cxV
+lIt
+lIt
+lIt
+lIt
+sAm
 dTs
 dTs
 acu
@@ -70598,9 +71049,9 @@ acu
 (20,1,1) = {"
 acu
 dTs
-ais
-aiZ
-aiZ
+pRD
+mZb
+mZb
 aPA
 aQe
 aQT
@@ -70816,14 +71267,14 @@ cDY
 cDY
 cNh
 djl
-daD
-crx
-crx
+sAZ
+dws
+dws
 tlh
-doE
-doE
-csE
-cxU
+lIt
+lIt
+uME
+hjW
 dTs
 dTs
 dTs
@@ -70832,9 +71283,9 @@ acu
 (21,1,1) = {"
 acu
 dTs
-ait
-aja
-aiZ
+txr
+ign
+mZb
 aPB
 aQf
 aQU
@@ -71024,7 +71475,7 @@ cRM
 cRM
 dFn
 doE
-cCY
+doE
 cDb
 abS
 cDY
@@ -71050,15 +71501,15 @@ cDY
 cDY
 cNi
 dws
-crx
-crx
-crx
+dws
+dws
+dws
 tlh
-crv
-drL
-drO
-crr
-crq
+onm
+hTf
+xOm
+erF
+sav
 dTs
 dTs
 acu
@@ -71067,8 +71518,8 @@ acu
 acu
 dTs
 dTs
-ait
-aja
+txr
+ign
 aPB
 aQg
 aQV
@@ -71284,15 +71735,15 @@ cDY
 cDY
 cNx
 dws
-crx
-cvJ
-crz
+dws
+qkz
+hjz
 tlh
 fSc
-dsE
-drT
-cru
-cxV
+fYz
+niN
+hCY
+sAm
 dTs
 dTs
 acu
@@ -71302,7 +71753,7 @@ acu
 dTs
 dTs
 dTs
-ais
+pRD
 aPB
 aQg
 aQV
@@ -71518,15 +71969,15 @@ cDY
 cDY
 cPI
 dws
-crx
-crx
-crx
+dws
+dws
+dws
 tlh
-drL
-uTo
-drN
-doE
-crr
+hTf
+muj
+bFC
+lIt
+erF
 dTs
 dTs
 acu
@@ -71536,7 +71987,7 @@ acu
 dTs
 dTs
 dTs
-ais
+pRD
 aPB
 aQg
 aQV
@@ -71752,15 +72203,15 @@ cDY
 cDY
 cPW
 djk
-cUk
-crx
-crx
+eRX
+dws
+dws
 tlh
-duc
-drN
-cAd
-doE
-cxU
+qHh
+bFC
+hVV
+lIt
+hjW
 czA
 dTs
 acu
@@ -71770,7 +72221,7 @@ acu
 dTs
 dTs
 dTs
-ais
+pRD
 aPB
 aQg
 aQV
@@ -71986,14 +72437,14 @@ cDY
 cDY
 cMD
 cRE
-cUl
-cvJ
-crz
+kPo
+qkz
+hjz
 tlh
-csE
-cxT
-doE
-doE
+uME
+jcb
+lIt
+lIt
 dTs
 dTs
 dTs
@@ -72004,7 +72455,7 @@ acu
 dTs
 dTs
 dTs
-ais
+pRD
 aPB
 aQg
 aQV
@@ -72220,15 +72671,15 @@ cDY
 cDY
 cML
 cBS
-cUl
-crx
-crx
+kPo
+dws
+dws
 tlh
-cru
-csE
-doE
-doE
-cxV
+hCY
+uME
+lIt
+lIt
+sAm
 dTs
 dTs
 acu
@@ -72237,8 +72688,8 @@ acu
 acu
 dTs
 dTs
-air
-aiY
+wEy
+moq
 aPB
 aQh
 aQW
@@ -72454,15 +72905,15 @@ tcB
 cDY
 cNb
 cBS
-cUl
-crx
-crx
+kPo
+dws
+dws
 tlh
-drL
-drO
-doE
-doE
-cxV
+hTf
+xOm
+lIt
+lIt
+sAm
 dTs
 dTs
 acu
@@ -72472,7 +72923,7 @@ acu
 dTs
 dTs
 dDB
-aiZ
+mZb
 aPC
 aQi
 aQX
@@ -72688,15 +73139,15 @@ cFP
 cLL
 cMC
 cgh
-cUl
-cvJ
-crz
+kPo
+qkz
+hjz
 tlh
-dsE
-drT
-cru
-doE
-cxV
+fYz
+niN
+hCY
+lIt
+sAm
 dTs
 dTs
 acu
@@ -72705,9 +73156,9 @@ acu
 acu
 dTs
 dTs
-ais
-aiZ
-aiZ
+pRD
+mZb
+mZb
 aQj
 aQY
 aQZ
@@ -72922,14 +73373,14 @@ cDX
 cDX
 cES
 cRB
-cUl
-crx
-crx
+kPo
+dws
+dws
 tlh
-duc
-drN
-csE
-cxU
+qHh
+bFC
+uME
+hjW
 dTs
 dTs
 dTs
@@ -72939,9 +73390,9 @@ acu
 acu
 tZQ
 aad
-aiY
-aiZ
-aiZ
+moq
+mZb
+mZb
 aQj
 aQZ
 aQZ
@@ -73132,38 +73583,38 @@ cEa
 crw
 crw
 poM
-cRM
-cRM
-cRM
-cRM
-cRM
-cRM
-cRM
-cRM
-cRM
-cRM
-cRM
-cRM
-cRM
-cRM
-cRM
-cRM
-cRM
-cRM
-cRM
-cRM
-cRM
-cRM
-cRM
-cRM
-daD
-crx
-crx
+djl
+djl
+djl
+djl
+djl
+djl
+djl
+djl
+djl
+djl
+djl
+djl
+djl
+djl
+djl
+djl
+djl
+djl
+djl
+djl
+djl
+djl
+djl
+djl
+sAZ
+dws
+dws
 tlh
-csE
-cAd
-doE
-cxV
+uME
+hVV
+lIt
+sAm
 dTs
 dTs
 dTs
@@ -73177,15 +73628,15 @@ aqf
 aqf
 aqf
 aqT
-auy
-auy
-auy
-aPJ
-aql
-ara
-asc
-auy
-arZ
+iKp
+iKp
+iKp
+ekN
+aSY
+aQg
+mjR
+iKp
+xbA
 aLa
 aWh
 aWh
@@ -73366,38 +73817,38 @@ crx
 crx
 crx
 ylS
-crx
-crx
+dws
+dws
 ylS
-crx
-crx
+dws
+dws
 ylS
-dvo
-dvo
+bhp
+bhp
 ylS
-crx
-crx
+dws
+dws
 ylS
-dvo
-dvo
+bhp
+bhp
 cXA
-crx
-crx
+dws
+dws
 ylS
-crx
-crx
+dws
+dws
 ylS
-crx
-crx
+dws
+dws
 ylS
-crx
-cvJ
-crz
+dws
+qkz
+hjz
 tlh
-doE
-cuO
+lIt
+uic
 aPK
-cxV
+sAm
 dTs
 dTs
 dTs
@@ -73405,21 +73856,21 @@ acu
 "}
 (32,1,1) = {"
 acu
-aqg
-aqg
-aDb
-aqg
-aqg
-aDb
-aqg
-aqg
-aDb
-aqg
-aqg
-aqg
-agV
-aqg
-asa
+aQV
+aQV
+aQW
+aQV
+aQV
+aQW
+aQV
+aQV
+aQW
+aQV
+aQV
+aQV
+beT
+aQV
+aUi
 qoJ
 aWh
 aWh
@@ -73599,39 +74050,39 @@ crx
 crx
 crx
 crx
-cvG
-crx
-crx
-cvG
-crx
-crx
-cvG
-crx
-dvo
-cKL
-dvo
-dvo
-cKL
-dvo
-crx
-cvG
-crx
-crx
-cvG
-crx
-crx
-cvG
-crx
-crx
-cvG
-crx
-crx
-crx
+vGu
+dws
+dws
+vGu
+dws
+dws
+vGu
+dws
+bhp
+mfH
+bhp
+bhp
+mfH
+bhp
+dws
+vGu
+dws
+dws
+vGu
+dws
+dws
+vGu
+dws
+dws
+vGu
+dws
+dws
+dws
 tlh
-csE
-doE
-doE
-cxV
+uME
+lIt
+lIt
+sAm
 dTs
 dTs
 dTs
@@ -73639,21 +74090,21 @@ acu
 "}
 (33,1,1) = {"
 acu
-aqg
-aqg
-aDc
-aqg
-aqg
-aDc
-aqg
-aqg
-aDc
-aqg
-aqg
-aqg
-agV
-aqg
-asa
+aQV
+aQV
+aQU
+aQV
+aQV
+aQU
+aQV
+aQV
+aQU
+aQV
+aQV
+aQV
+beT
+aQV
+aUi
 abQ
 aWh
 aWh
@@ -73833,38 +74284,38 @@ cuJ
 cuJ
 cuJ
 cuJ
-cuJ
+jqU
 cnA
-cMJ
-cMJ
-cMJ
-cMJ
-cMJ
-cMJ
-cUk
-crx
-dvo
+djk
+djk
+djk
+djk
+djk
+djk
+eRX
+dws
+bhp
 cQc
-cMJ
-cMJ
-cMJ
-cMJ
-cMJ
-cMJ
-cMJ
-cMJ
-cMJ
-cMJ
+djk
+djk
+djk
+djk
+djk
+djk
+djk
+djk
+djk
+djk
 eCk
-cuJ
-cuJ
-cuJ
-cuJ
-cuJ
+jqU
+jqU
+jqU
+jqU
+jqU
 sNX
-doE
-doE
-doE
+lIt
+lIt
+lIt
 dTs
 dTs
 dTs
@@ -73873,21 +74324,21 @@ acu
 "}
 (34,1,1) = {"
 acu
-aKW
-aKW
-aKW
-aKW
-aKW
-aKW
-aKW
-aKW
-aSc
-aIJ
-aql
-ara
-agV
-aqg
-asa
+eZC
+eZC
+eZC
+eZC
+eZC
+eZC
+eZC
+eZC
+ucS
+uHx
+aSY
+aQg
+beT
+aQV
+aUi
 cEc
 aWh
 aWh
@@ -74086,18 +74537,18 @@ cNo
 bvA
 daw
 deU
-cQm
-cQm
+uSv
+uSv
 aMT
 aNx
-cKp
-doE
-doE
-doE
-doE
-doE
-doE
-doE
+uWt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
+lIt
 dTs
 dTs
 dTs
@@ -74110,18 +74561,18 @@ acu
 tZQ
 tZQ
 dTs
-ars
-aja
-aiZ
-aiZ
-aFu
+cSn
+ign
+mZb
+mZb
+wDC
 aSd
-apz
-aqg
-aqg
-aqg
-aqg
-asa
+aSx
+aQV
+aQV
+aQV
+aQV
+aUi
 aLa
 aWh
 aWh
@@ -74318,20 +74769,20 @@ cVH
 cVH
 cXD
 bvA
-daU
+cDY
 deV
-cQm
-cQm
+uSv
+uSv
 aMU
 aNz
-cKr
-doE
-doE
-doE
-doE
-doE
+saQ
+lIt
+lIt
+lIt
+lIt
+lIt
 dTs
-doE
+lIt
 dTs
 dTs
 dTs
@@ -74345,17 +74796,17 @@ dTs
 dTs
 dTs
 dTs
-ait
-aja
-aiZ
-aiZ
-aIa
-apz
-aqg
-aqg
-agV
-aqg
-asa
+txr
+ign
+mZb
+mZb
+aPB
+aSx
+aQV
+aQV
+beT
+aQV
+aUi
 qoJ
 aWh
 aWh
@@ -74552,17 +75003,17 @@ cVH
 cVH
 cXN
 bvA
-daU
+cDY
 aMJ
-cQm
-cQm
+uSv
+uSv
 aNe
 aNz
-cKr
-doE
-doE
-doE
-doE
+saQ
+lIt
+lIt
+lIt
+lIt
 dTs
 dTs
 dTs
@@ -74580,16 +75031,16 @@ dTs
 dTs
 dTs
 dTs
-ais
-aiZ
-aiZ
-aIa
-apz
-aql
-ara
-agV
-aqg
-asa
+pRD
+mZb
+mZb
+aPB
+aSx
+aSY
+aQg
+beT
+aQV
+aUi
 abQ
 aWh
 aWh
@@ -74788,14 +75239,14 @@ aMw
 aMI
 dbc
 aMJ
-cQm
-cQm
+uSv
+uSv
 aNm
 aNA
-cKr
-doE
-doE
-doE
+saQ
+lIt
+lIt
+lIt
 dTs
 dTs
 dTs
@@ -74814,16 +75265,16 @@ dTs
 dTs
 dTs
 dTs
-ait
-aja
-aiZ
-aIa
-apz
-aqg
-aqg
-agV
-aqg
-asa
+txr
+ign
+mZb
+aPB
+aSx
+aQV
+aQV
+beT
+aQV
+aUi
 cEc
 aWh
 aWh
@@ -75027,8 +75478,8 @@ bvA
 ddJ
 bvA
 bvA
-doE
-doE
+lIt
+lIt
 dTs
 dTs
 dTs
@@ -75049,14 +75500,14 @@ dTs
 dTs
 dTs
 dTs
-ais
+pRD
 abb
-aIa
-apz
-aqg
-aqg
-asd
-auz
+aPB
+aSx
+aQV
+aQV
+wuV
+eRL
 aaA
 aLa
 aWh
@@ -75283,13 +75734,13 @@ dTs
 dTs
 dTs
 dTs
-ait
-aja
-aIa
-apz
-aql
-ara
-asa
+txr
+ign
+aPB
+aSx
+aSY
+aQg
+aUi
 aUD
 aVg
 acJ
@@ -75516,14 +75967,14 @@ dTs
 dTs
 dTs
 dTs
-ahu
-ahu
-ais
-aIa
-apz
-aqg
-aqg
-asa
+ogc
+ogc
+pRD
+aPB
+aSx
+aQV
+aQV
+aUi
 aUD
 aVh
 aQY
@@ -75749,15 +76200,15 @@ dTs
 dTs
 dTs
 dTs
-ahu
-ahu
-air
-aiY
-aIa
-apz
-aqg
-aqg
-asa
+ogc
+ogc
+wEy
+moq
+aPB
+aSx
+aQV
+aQV
+aUi
 aUE
 aVj
 aQX
@@ -75987,38 +76438,38 @@ aOc
 aOc
 aOc
 aOc
-aoD
-apz
-aql
-ara
-asc
-auy
-auy
-auy
-auy
-auy
-auy
-auy
-auy
-auy
-auy
-auy
-auy
-auy
-auy
-auy
-auy
-auy
-auy
-auy
-auy
-auy
-auy
-auy
-auy
-auy
-auy
-auy
+pzk
+aSx
+aSY
+aQg
+mjR
+iKp
+iKp
+iKp
+iKp
+iKp
+iKp
+iKp
+iKp
+iKp
+iKp
+iKp
+iKp
+iKp
+iKp
+iKp
+iKp
+iKp
+iKp
+iKp
+iKp
+iKp
+iKp
+iKp
+iKp
+iKp
+iKp
+iKp
 aQg
 aQV
 aQV
@@ -76221,38 +76672,38 @@ aPD
 byX
 iqK
 aOc
-aoE
-apz
-aqg
-aqg
-aqg
-aDb
-aqg
-aqg
-aDb
-aqg
-aqg
-aDb
-aqg
-aqg
-aDb
-aqg
-aqg
-aDb
-aqg
-aqg
-aDb
-aqg
-aqg
-aDb
-aqg
-aqg
-aDb
-aqg
-aqg
-aDb
-aqg
-aqg
+aSa
+aSx
+aQV
+aQV
+aQV
+aQW
+aQV
+aQV
+aQW
+aQV
+aQV
+aQW
+aQV
+aQV
+aQW
+aQV
+aQV
+aQW
+aQV
+aQV
+aQW
+aQV
+aQV
+aQW
+aQV
+aQV
+aQW
+aQV
+aQV
+aQW
+aQV
+aQV
 aQg
 aQV
 aSY
@@ -76455,38 +76906,38 @@ aPD
 aPD
 iqK
 aau
-aoE
-apz
-aqg
-aqg
-aqg
-aDc
-aqg
-aqg
-aDc
-aqg
-aqg
-aDc
-aqg
-aqg
-aDc
-aqg
-aqg
-aDc
-aqg
-aqg
-aDc
-aqg
-aqg
-aDc
-aqg
-aqg
-aDc
-aqg
-aqg
-aDc
-aqg
-aqg
+aSa
+aSx
+aQV
+aQV
+aQV
+aQU
+aQV
+aQV
+aQU
+aQV
+aQV
+aQU
+aQV
+aQV
+aQU
+aQV
+aQV
+aQU
+aQV
+aQV
+aQU
+aQV
+aQV
+aQU
+aQV
+aQV
+aQU
+aQV
+aQV
+aQU
+aQV
+aQV
 aQg
 aQV
 aSY
@@ -76689,38 +77140,38 @@ aPE
 pDd
 aPE
 aau
-aoE
-aIK
-auz
-auz
-auz
-auz
-auz
-auz
-auz
-auz
-auz
-auz
-auz
-auz
-auz
-auz
-auz
-auz
-auz
-auz
-auz
-auz
-auz
-auz
-aIJ
-aqg
-aqg
-asd
-auz
-auz
-auz
-auz
+aSa
+eZN
+eRL
+eRL
+eRL
+eRL
+eRL
+eRL
+eRL
+eRL
+eRL
+eRL
+eRL
+eRL
+eRL
+eRL
+eRL
+eRL
+eRL
+eRL
+eRL
+eRL
+eRL
+eRL
+uHx
+aQV
+aQV
+wuV
+eRL
+eRL
+eRL
+eRL
 aQg
 aQV
 aQV
@@ -76923,38 +77374,38 @@ rFz
 aPF
 aRc
 aOc
-akz
-aNp
-aNp
-aNp
-aNp
-alo
-alo
-alo
-alo
-alo
-alo
-alo
-alo
-alo
-aNp
-aNp
-alo
-alo
-aNp
-aNp
-aNp
-aNp
-aNp
-apO
-apA
+aUE
+aQX
+aQX
+aQX
+aQX
+aVg
+aVg
+aVg
+aVg
+aVg
+aVg
+aVg
+aVg
+aVg
+aQX
+aQX
+aVg
+aVg
+aQX
+aQX
+aQX
+aQX
+aQX
+aRZ
+gBQ
 dez
-aNL
+pHs
 baW
-aky
-aNp
-aNp
-apO
+aUC
+aQX
+aQX
+aRZ
 bfn
 aQW
 aQW
@@ -77170,24 +77621,24 @@ aVk
 adq
 aeg
 aVk
-aVH
-aoe
+bhh
+sUF
 afy
-apa
-aoG
+aUD
+aVh
 anh
-aoe
-aoe
-aoe
-aoe
-bco
+sUF
+sUF
+sUF
+sUF
+sQE
 bcC
-aNL
-aNL
+pHs
+pHs
 baW
-aoE
+aSa
 anh
-aoe
+sUF
 aUH
 bfo
 bfo
@@ -77396,41 +77847,41 @@ rFz
 rFz
 bzU
 aOc
-bej
-bfp
-bej
-aiZ
-acW
-aiZ
-aiZ
-aiZ
+iZY
+saS
+iZY
+mZb
+sCW
+mZb
+mZb
+mZb
 aeY
-aiZ
-ajS
-bvh
-avC
-aDe
-beD
-aiZ
-aiZ
-aiZ
-aIa
-apz
-aql
-ara
-asa
-aoE
-aDe
-aiZ
-aqy
-aja
-aiZ
-aqy
-ars
-aja
-aiZ
-aiZ
-aqy
+mZb
+aQj
+qDl
+aVG
+wpr
+qlr
+mZb
+mZb
+mZb
+aPB
+aSx
+aSY
+aQg
+aUi
+aSa
+wpr
+mZb
+nnv
+ign
+mZb
+nnv
+cSn
+ign
+mZb
+mZb
+nnv
 dTs
 dTs
 dTs
@@ -77630,8 +78081,8 @@ rFz
 rFz
 aRc
 aau
-aja
-bej
+ign
+iZY
 aVI
 aVI
 aVI
@@ -77655,15 +78106,15 @@ aqg
 asa
 bdV
 bep
-aqy
-axY
-ait
-ars
+nnv
+fqj
+txr
+cSn
 dTs
 dTs
-ait
-ars
-ars
+txr
+cSn
+cSn
 dTs
 dTs
 dTs
@@ -77864,8 +78315,8 @@ aPF
 aPF
 aRc
 aau
-ait
-aja
+txr
+ign
 aVI
 azf
 aYu
@@ -77889,14 +78340,14 @@ aqg
 asa
 bdW
 aiZ
-axZ
-ahu
+ndF
+ogc
 dTs
 dTs
 dTs
 dTs
 dTs
-ahu
+ogc
 dTs
 dTs
 dTs
@@ -78098,8 +78549,8 @@ aRD
 aTg
 aTh
 aOc
-ahu
-ait
+ogc
+txr
 aVI
 aNs
 aWl

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -1942,7 +1942,7 @@
 	},
 /obj/item/stack/snow,
 /turf/open/auto_turf/snow/layer3,
-/area/shiva/exterior/lz1_valley)
+/area/shiva/exterior/junkyard)
 "aje" = (
 /obj/structure/machinery/light/double{
 	dir = 4;
@@ -2015,7 +2015,7 @@
 	},
 /obj/item/tool/shovel/snow,
 /turf/open/auto_turf/snow/layer3,
-/area/shiva/exterior/lz1_valley)
+/area/shiva/exterior/junkyard)
 "ajF" = (
 /obj/item/tool/shovel/etool,
 /turf/open/auto_turf/snow/layer3,
@@ -3767,7 +3767,7 @@
 	dir = 1
 	},
 /turf/open/auto_turf/snow/layer3,
-/area/shiva/exterior/lz1_valley)
+/area/shiva/exterior/junkyard)
 "avz" = (
 /obj/structure/surface/rack,
 /obj/item/bodybag/tarp/snow{
@@ -6661,10 +6661,6 @@
 	opacity = 0
 	},
 /area/shiva/interior/aerodrome)
-"bcM" = (
-/obj/structure/flora/bush/ausbushes/lavendergrass,
-/turf/open/auto_turf/snow/layer3,
-/area/shiva/exterior/lz1_valley)
 "bcV" = (
 /obj/structure/platform/strata{
 	dir = 1
@@ -7244,7 +7240,7 @@
 	dir = 8
 	},
 /turf/open/auto_turf/snow/layer2,
-/area/shiva/exterior/lz1_valley)
+/area/shiva/exterior/junkyard)
 "bHN" = (
 /obj/item/ammo_magazine/rifle/boltaction{
 	pixel_x = -7;
@@ -9396,7 +9392,7 @@
 	dir = 1
 	},
 /turf/open/auto_turf/snow/layer2,
-/area/shiva/exterior/lz1_valley)
+/area/shiva/exterior/junkyard)
 "eit" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/auto_turf/ice/layer1,
@@ -9955,7 +9951,7 @@
 "eSN" = (
 /obj/vehicle/train/cargo/engine,
 /turf/open/floor/plating/plating_catwalk/shiva,
-/area/shiva/exterior/lz1_valley)
+/area/shiva/exterior/junkyard)
 "eTV" = (
 /obj/structure/flora/bush/ausbushes/lavendergrass{
 	icon_state = "lavendergrass_2"
@@ -12418,7 +12414,7 @@
 	dir = 8
 	},
 /turf/open/auto_turf/snow/layer2,
-/area/shiva/exterior/lz1_valley)
+/area/shiva/exterior/junkyard)
 "hyu" = (
 /turf/open/floor/shiva{
 	icon_state = "bluefull"
@@ -13037,10 +13033,6 @@
 	dir = 1
 	},
 /area/shiva/interior/colony/deck)
-"idG" = (
-/obj/structure/flora/tree/dead/tree_4,
-/turf/open/auto_turf/snow/layer2,
-/area/shiva/exterior/lz1_valley)
 "idR" = (
 /obj/structure/platform_decoration/strata{
 	dir = 1
@@ -13255,10 +13247,6 @@
 /obj/effect/decal/cleanable/blood/oil/streak,
 /turf/open/auto_turf/snow/layer0,
 /area/shiva/interior/warehouse)
-"ipc" = (
-/obj/vehicle/train/cargo/trolley,
-/turf/open/auto_turf/snow/layer0,
-/area/shiva/exterior/lz1_valley)
 "ipP" = (
 /obj/structure/machinery/colony_floodlight,
 /turf/open/auto_turf/snow/layer3,
@@ -13694,7 +13682,7 @@
 	dir = 8
 	},
 /turf/open/auto_turf/snow/layer4,
-/area/shiva/exterior/lz1_valley)
+/area/shiva/exterior/junkyard)
 "iHN" = (
 /obj/effect/landmark/survivor_spawner,
 /turf/open/floor/shiva{
@@ -13770,7 +13758,7 @@
 	dir = 4
 	},
 /turf/open/auto_turf/snow/layer1,
-/area/shiva/exterior/lz1_valley)
+/area/shiva/exterior/junkyard)
 "iLf" = (
 /obj/item/lightstick/red/spoke/planted{
 	pixel_x = 12;
@@ -13839,7 +13827,7 @@
 	pixel_y = 28
 	},
 /turf/open/auto_turf/snow/layer0,
-/area/shiva/exterior/lz1_valley)
+/area/shiva/exterior/junkyard)
 "iPg" = (
 /turf/open/floor/shiva{
 	dir = 8;
@@ -14105,7 +14093,7 @@
 	dir = 4
 	},
 /turf/open/auto_turf/snow/layer3,
-/area/shiva/exterior/lz1_valley)
+/area/shiva/exterior/junkyard)
 "jay" = (
 /turf/open/floor/shiva{
 	dir = 1;
@@ -14191,7 +14179,7 @@
 	dir = 8
 	},
 /turf/open/auto_turf/snow/layer4,
-/area/shiva/exterior/lz1_valley)
+/area/shiva/exterior/junkyard)
 "jhq" = (
 /turf/open/floor/shiva{
 	icon_state = "radiator_tile"
@@ -15125,7 +15113,7 @@
 	dir = 4
 	},
 /turf/open/auto_turf/snow/layer2,
-/area/shiva/exterior/lz1_valley)
+/area/shiva/exterior/junkyard)
 "khz" = (
 /obj/item/device/flashlight,
 /turf/open/floor/shiva,
@@ -18470,7 +18458,7 @@
 "nAs" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/auto_turf/snow/layer1,
-/area/shiva/exterior/lz1_valley)
+/area/shiva/exterior/junkyard)
 "nAY" = (
 /turf/open/floor/shiva{
 	icon_state = "yellowcorners"
@@ -18543,13 +18531,6 @@
 	icon_state = "yellowfull"
 	},
 /area/shiva/interior/aux_power)
-"nEH" = (
-/obj/effect/landmark/monkey_spawn,
-/obj/effect/decal/warning_stripes{
-	icon_state = "E-corner"
-	},
-/turf/open/floor/plating,
-/area/shiva/exterior/lz1_valley)
 "nEQ" = (
 /obj/structure/inflatable,
 /turf/open/auto_turf/snow/layer2,
@@ -20544,7 +20525,7 @@
 "pKK" = (
 /obj/item/lightstick/red/variant,
 /turf/open/auto_turf/snow/layer0,
-/area/shiva/exterior/lz1_valley)
+/area/shiva/exterior/junkyard)
 "pKP" = (
 /obj/structure/surface/table,
 /obj/item/device/flashlight/lamp/green{
@@ -21261,7 +21242,7 @@
 "que" = (
 /obj/item/lightstick/red/variant/planted,
 /turf/open/auto_turf/snow/layer3,
-/area/shiva/exterior/lz1_valley)
+/area/shiva/exterior/junkyard)
 "qvr" = (
 /obj/structure/machinery/alarm{
 	dir = 8;
@@ -22362,6 +22343,10 @@
 /obj/structure/prop/ice_colony/soil_net,
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/junkyard)
+"rNY" = (
+/obj/effect/landmark/monkey_spawn,
+/turf/open/auto_turf/snow/layer0,
+/area/shiva/exterior/junkyard)
 "rNZ" = (
 /obj/structure/prop/ice_colony/dense/planter_box{
 	dir = 9
@@ -22668,7 +22653,7 @@
 	dir = 4
 	},
 /turf/open/auto_turf/snow/layer2,
-/area/shiva/exterior/lz1_valley)
+/area/shiva/exterior/junkyard)
 "scN" = (
 /obj/structure/surface/table,
 /obj/item/device/assembly/infra,
@@ -22901,10 +22886,6 @@
 	},
 /turf/open/auto_turf/snow/layer2,
 /area/shiva/exterior/junkyard/cp_bar)
-"sqb" = (
-/obj/item/lightstick/red/variant/planted,
-/turf/open/auto_turf/snow/layer2,
-/area/shiva/exterior/lz1_valley)
 "sqy" = (
 /obj/item/wrapping_paper,
 /obj/structure/surface/table/reinforced/prison,
@@ -23055,7 +23036,7 @@
 	dir = 4
 	},
 /turf/open/auto_turf/snow/layer2,
-/area/shiva/exterior/lz1_valley)
+/area/shiva/exterior/junkyard)
 "sAe" = (
 /obj/structure/machinery/light/double{
 	dir = 4;
@@ -23837,7 +23818,7 @@
 /area/shiva/interior/caves/cp_camp)
 "tpg" = (
 /turf/open/floor/plating/plating_catwalk/shiva,
-/area/shiva/exterior/lz1_valley)
+/area/shiva/exterior/junkyard)
 "tpL" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out"
@@ -25752,10 +25733,6 @@
 	icon_state = "kitchen"
 	},
 /area/shiva/interior/colony/central)
-"vdk" = (
-/obj/vehicle/train/cargo/engine,
-/turf/open/auto_turf/snow/layer0,
-/area/shiva/exterior/lz1_valley)
 "vdw" = (
 /obj/item/lightstick/red/spoke/planted{
 	layer = 2.99;
@@ -25983,7 +25960,7 @@
 	dir = 8
 	},
 /turf/open/auto_turf/snow/layer2,
-/area/shiva/exterior/lz1_valley)
+/area/shiva/exterior/junkyard)
 "voH" = (
 /obj/structure/machinery/landinglight/ds2/spoke{
 	pixel_x = 1;
@@ -26021,7 +25998,7 @@
 	dir = 9
 	},
 /turf/open/auto_turf/snow/layer2,
-/area/shiva/exterior/lz1_valley)
+/area/shiva/exterior/junkyard)
 "vrm" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -27183,7 +27160,7 @@
 	dir = 4
 	},
 /turf/open/auto_turf/snow/layer1,
-/area/shiva/exterior/lz1_valley)
+/area/shiva/exterior/junkyard)
 "wOq" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/shiva{
@@ -27679,12 +27656,16 @@
 	icon_state = "multi_tiles"
 	},
 /area/shiva/interior/colony/research_hab)
+"xwk" = (
+/obj/item/lightstick/red/variant,
+/turf/open/auto_turf/snow/layer1,
+/area/shiva/exterior/junkyard)
 "xwo" = (
 /obj/structure/platform/shiva/catwalk{
 	dir = 8
 	},
 /turf/open/auto_turf/snow/layer3,
-/area/shiva/exterior/lz1_valley)
+/area/shiva/exterior/junkyard)
 "xwL" = (
 /obj/structure/filingcabinet,
 /obj/effect/landmark/objective_landmark/close,
@@ -34636,7 +34617,7 @@ mcH
 mcH
 mcH
 mcH
-nEH
+mcH
 mcH
 mcH
 mcH
@@ -34952,22 +34933,22 @@ pvv
 pvv
 fRg
 uji
-aDM
-uqb
-uqb
-uqb
-kLM
-kLM
-iQq
-iQq
-iQq
-iQq
-kLM
-kLM
-sqb
-lNg
-aDM
-aDM
+ofw
+kop
+kop
+kop
+tHd
+tHd
+kyD
+kyD
+kyD
+kyD
+tHd
+tHd
+rtZ
+jMf
+ofw
+ofw
 huz
 huz
 huz
@@ -35114,22 +35095,22 @@ pvv
 pvv
 fRg
 hGj
-kLM
-iOu
-uqb
-kJQ
-uqb
-iQq
-iQq
-iQq
-iQq
-kLM
-iQq
-kLM
-uqb
-kLM
+tHd
+xvp
+kop
+xwk
+kop
+kyD
+kyD
+kyD
+kyD
+tHd
+kyD
+tHd
+kop
+tHd
 que
-aDM
+ofw
 huz
 kys
 pef
@@ -35276,22 +35257,22 @@ pvv
 pvv
 fRg
 hGj
-kLM
-iQq
-kLM
-uqb
-kLM
-iQq
-iQq
-iQq
-iQq
-iQq
-kLM
-iQq
-iQq
-kLM
-kLM
-kLM
+tHd
+kyD
+tHd
+kop
+tHd
+kyD
+kyD
+kyD
+kyD
+kyD
+tHd
+kyD
+kyD
+tHd
+tHd
+tHd
 huz
 krU
 axJ
@@ -35438,22 +35419,22 @@ pvv
 pvv
 gxK
 hGj
-iQq
-iQq
-iQq
-kLM
-iQq
-iQq
-iQq
-iQq
-iQq
-iQq
-iQq
-kLM
-kLM
-iQq
-iQq
-iQq
+kyD
+kyD
+kyD
+tHd
+kyD
+kyD
+kyD
+kyD
+kyD
+kyD
+kyD
+tHd
+tHd
+kyD
+kyD
+kyD
 huz
 axJ
 axJ
@@ -35600,21 +35581,21 @@ dbH
 fhv
 fRg
 hGj
-kLM
-kLM
-iQq
-iQq
-kLM
-vdk
-iQq
-iQq
-iQq
-iQq
-iQq
-iQq
-iQq
-iQq
-iQq
+tHd
+tHd
+kyD
+kyD
+tHd
+fHx
+kyD
+kyD
+kyD
+kyD
+kyD
+kyD
+kyD
+kyD
+kyD
 tpg
 exX
 qIr
@@ -35762,21 +35743,21 @@ aUA
 gIQ
 fRg
 hGj
-uqb
-uqb
-uqb
-kLM
-iQq
-ipc
-iQq
-iQq
-iQq
-iQq
-iQq
-iQq
-iQq
-iQq
-iQq
+kop
+kop
+kop
+tHd
+kyD
+dyt
+kyD
+kyD
+kyD
+rNY
+kyD
+kyD
+kyD
+kyD
+kyD
 eSN
 akF
 alS
@@ -35924,21 +35905,21 @@ deV
 eVG
 fRg
 hGj
-uqb
-kLM
-kLM
-iQq
-iQq
-ipc
-iQq
-kLM
-iQq
-iQq
-iQq
-iQq
-iQq
-iQq
-iQq
+kop
+tHd
+tHd
+kyD
+kyD
+dyt
+kyD
+tHd
+kyD
+kyD
+kyD
+kyD
+kyD
+kyD
+kyD
 tpg
 exX
 qIr
@@ -36086,21 +36067,21 @@ dKR
 pvv
 fRg
 hGj
-kLM
-iQq
-iQq
-iQq
-iQq
-iQq
-kLM
-kLM
-uqb
-kLM
-iQq
-iQq
-iQq
-iQq
-iQq
+tHd
+kyD
+kyD
+kyD
+kyD
+kyD
+tHd
+tHd
+kop
+tHd
+kyD
+kyD
+kyD
+kyD
+kyD
 tpg
 exX
 qIr
@@ -36248,22 +36229,22 @@ pvv
 pvv
 fRg
 hGj
-iQq
-iQq
-iQq
-iQq
-iQq
-iQq
-kLM
-aDM
-kLM
-iQq
-iQq
-iQq
-iQq
-iQq
-iQq
-iQq
+kyD
+kyD
+kyD
+kyD
+kyD
+kyD
+tHd
+ofw
+tHd
+kyD
+kyD
+kyD
+kyD
+kyD
+kyD
+kyD
 huz
 aut
 rdS
@@ -36410,22 +36391,22 @@ pvv
 pvv
 fRg
 hGj
-iQq
-iOu
-kLM
-iOu
-kLM
-kLM
-iQq
-kLM
-iQq
-iQq
-iQq
-iQq
+kyD
+xvp
+tHd
+xvp
+tHd
+tHd
+kyD
+tHd
+kyD
+kyD
+kyD
+kyD
 pKK
-iQq
-iOu
-kLM
+kyD
+xvp
+tHd
 huz
 rdS
 axJ
@@ -36577,12 +36558,12 @@ khx
 jac
 khx
 iHu
-idG
-kLM
-iQq
-iQq
-kLM
-kLM
+jXD
+tHd
+kyD
+kyD
+tHd
+tHd
 huz
 huz
 huz
@@ -36739,12 +36720,12 @@ iMA
 iMA
 uKZ
 ehV
-aDM
-kTP
-iQq
-iQq
-kLM
-uqb
+ofw
+aQJ
+kyD
+kyD
+tHd
+kop
 huz
 cio
 ieD
@@ -36902,10 +36883,10 @@ cLq
 iMA
 avx
 voo
-kLM
-iQq
-iQq
-kLM
+tHd
+kyD
+kyD
+tHd
 tpg
 exX
 qIr
@@ -37063,11 +37044,11 @@ fRg
 xQa
 iMA
 avx
-uqb
-kLM
-iQq
-iQq
-kLM
+kop
+tHd
+kyD
+kyD
+tHd
 tpg
 exX
 alW
@@ -37225,12 +37206,12 @@ fRg
 uKZ
 uKZ
 vqV
-kLM
-kLM
-iQq
-iQq
-iQq
-kLM
+tHd
+tHd
+kyD
+kyD
+kyD
+tHd
 huz
 pJM
 ayZ
@@ -37387,12 +37368,12 @@ fRg
 iMA
 nIA
 scp
-kLM
-iQq
-iQq
-kLM
-iQq
-iQq
+tHd
+kyD
+kyD
+tHd
+kyD
+kyD
 huz
 aQq
 axJ
@@ -37548,13 +37529,13 @@ pvv
 oCG
 kjM
 oCG
-iQq
-iQq
-iQq
-kLM
-aDM
-kLM
-iQq
+kyD
+kyD
+kyD
+tHd
+ofw
+tHd
+kyD
 huz
 huz
 avz
@@ -37710,14 +37691,14 @@ pvv
 oCG
 wRm
 oCG
-iQq
-iQq
-iQq
+kyD
+kyD
+kyD
 szU
-kLM
-iQq
-iQq
-uqb
+tHd
+kyD
+kyD
+kop
 ncS
 pTp
 pTp
@@ -37873,13 +37854,13 @@ fRg
 iMA
 tLC
 hye
-kLM
-iQq
-kLM
-iQq
-iQq
-kLM
-uqb
+tHd
+kyD
+tHd
+kyD
+kyD
+tHd
+kop
 ncS
 mRc
 rdS
@@ -38035,13 +38016,13 @@ iMA
 uKZ
 uKZ
 ehV
-kLM
-iQq
-iQq
-iQq
-kLM
-kLM
-uqb
+tHd
+kyD
+kyD
+kyD
+tHd
+tHd
+kop
 ncS
 bWB
 auh
@@ -38197,12 +38178,12 @@ obb
 vHX
 iMA
 ehV
-kLM
-iQq
-iQq
-kLM
-uqb
-uqb
+tHd
+kyD
+kyD
+tHd
+kop
+kop
 huz
 huz
 auh
@@ -38359,11 +38340,11 @@ krm
 iXx
 iMA
 ehV
-uqb
-kLM
-iQq
+kop
+tHd
+kyD
 nAs
-uqb
+kop
 ajE
 huz
 qSW
@@ -38521,11 +38502,11 @@ iMA
 iMA
 uKZ
 ehV
-uqb
-kLM
-iQq
-iQq
-kLM
+kop
+tHd
+kyD
+kyD
+tHd
 ajd
 huz
 fjS
@@ -38683,11 +38664,11 @@ jhm
 bHC
 bHC
 iKW
-kLM
-iQq
-iQq
-iQq
-iQq
+tHd
+kyD
+kyD
+kyD
+kyD
 qIr
 oWk
 qIr
@@ -38840,16 +38821,16 @@ pvv
 pvv
 fRg
 hvZ
-kLM
-iOu
-kLM
-iOu
-kLM
-iQq
-kLM
-iQq
-iQq
-iQq
+tHd
+xvp
+tHd
+xvp
+tHd
+kyD
+tHd
+kyD
+kyD
+kyD
 qIr
 oWk
 qIr
@@ -39002,16 +38983,16 @@ aSA
 pvv
 fRg
 hvZ
-kLM
-iQq
-iQq
-iQq
-iQq
-kLM
-iQq
-iQq
-iQq
-iQq
+tHd
+kyD
+kyD
+kyD
+kyD
+tHd
+kyD
+kyD
+kyD
+kyD
 qIr
 akF
 alS
@@ -39164,16 +39145,16 @@ wTz
 pvv
 fRg
 hvZ
-iQq
-kLM
-iQq
-iQq
-iQq
-iQq
-iQq
-kLM
-iQq
-iQq
+kyD
+tHd
+kyD
+kyD
+kyD
+kyD
+kyD
+tHd
+kyD
+kyD
 qIr
 exX
 qIr
@@ -39326,16 +39307,16 @@ dbH
 wvx
 fRg
 hvZ
-kLM
-iQq
-kLM
-iQq
-iQq
-iQq
-kLM
-snN
-kTP
-iQq
+tHd
+kyD
+tHd
+kyD
+kyD
+kyD
+tHd
+rli
+aQJ
+kyD
 huz
 huz
 kLi
@@ -39488,16 +39469,16 @@ dCS
 eoH
 fRg
 hvZ
-iQq
-iQq
-kLM
-iQq
-iQq
-kLM
-bcM
-aDM
-lNg
-kLM
+kyD
+kyD
+tHd
+kyD
+kyD
+tHd
+qLS
+ofw
+jMf
+tHd
 huz
 huz
 dLi
@@ -39650,16 +39631,16 @@ deV
 uyI
 fRg
 hvZ
-iQq
-iQq
-iQq
-iQq
-iQq
-iQq
-kLM
-aDM
-uqb
-iQq
+kyD
+kyD
+kyD
+kyD
+kyD
+kyD
+tHd
+ofw
+kop
+kyD
 huz
 huz
 huz
@@ -39812,17 +39793,17 @@ pti
 pvv
 fRg
 hvZ
-kLM
-iQq
-iQq
-iQq
-iQq
-iQq
-kLM
-lNg
-kLM
-iQq
-iQq
+tHd
+kyD
+kyD
+kyD
+kyD
+kyD
+tHd
+jMf
+tHd
+kyD
+kyD
 huz
 huz
 huz
@@ -39974,18 +39955,18 @@ pvv
 pvv
 fRg
 hvZ
-kLM
-kLM
-iQq
-iQq
-iQq
-iQq
-iQq
-kLM
-kLM
-iQq
-iQq
-iQq
+tHd
+tHd
+kyD
+kyD
+kyD
+kyD
+kyD
+tHd
+tHd
+kyD
+kyD
+kyD
 lXQ
 cwZ
 kAw
@@ -40136,18 +40117,18 @@ pvv
 pvv
 fRg
 hvZ
-kLM
-iOu
-kLM
-iOu
-kLM
-kLM
-iQq
-kLM
-iQq
-iQq
-kLM
-iQq
+tHd
+xvp
+tHd
+xvp
+tHd
+tHd
+kyD
+tHd
+kyD
+kyD
+tHd
+kyD
 jWh
 cwZ
 kAw
@@ -40299,17 +40280,17 @@ pvv
 fWq
 uji
 iOA
-aDM
-lNg
-kLM
-uqb
-uqb
-iQq
-iQq
-kLM
-kLM
-kLM
-kLM
+ofw
+jMf
+tHd
+kop
+kop
+kyD
+kyD
+tHd
+tHd
+tHd
+tHd
 fpF
 wSv
 kAw

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -244,7 +244,7 @@
 "arh" = (
 /obj/item/prop/alien/hugger,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "arr" = (
 /obj/structure/blocker/invisible_wall,
 /obj/structure/platform/kutjevo{
@@ -541,7 +541,7 @@
 "aIy" = (
 /obj/structure/largecrate/black_market/confiscated_equipment,
 /turf/open/floor/kutjevo/tan,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "aIF" = (
 /obj/structure/prop/dam/boulder/boulder1,
 /turf/open/auto_turf/sand/layer1,
@@ -767,7 +767,7 @@
 /turf/open/floor/kutjevo/tan/alt_edge{
 	dir = 1
 	},
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "bde" = (
 /obj/structure/flora/grass/tallgrass/desert/corner{
 	dir = 10
@@ -1139,10 +1139,13 @@
 	pixel_y = 4
 	},
 /turf/open/floor/almayer/research/containment/floor1,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "bEp" = (
 /turf/closed/wall/kutjevo/rock,
 /area/kutjevo/exterior/scrubland)
+"bEt" = (
+/turf/open/floor/kutjevo/multi_tiles,
+/area/kutjevo/exterior/lz_pad)
 "bEH" = (
 /turf/open/auto_turf/sand/layer2,
 /area/kutjevo/interior/colony_north)
@@ -1180,7 +1183,7 @@
 "bGi" = (
 /obj/item/stack/sheet/wood,
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "bGv" = (
 /obj/item/reagent_container/food/drinks/cans/waterbottle,
 /turf/open/auto_turf/sand/layer0,
@@ -1423,7 +1426,7 @@
 	icon_state = "tree_3"
 	},
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "bXc" = (
 /obj/structure/surface/rack,
 /obj/effect/landmark/objective_landmark/close,
@@ -1481,7 +1484,7 @@
 	dir = 4
 	},
 /turf/open/floor/kutjevo/multi_tiles,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "ccu" = (
 /turf/open/floor/kutjevo/tan/grey_inner_edge{
 	dir = 8
@@ -1595,6 +1598,10 @@
 	},
 /turf/open/floor/kutjevo/colors/cyan/tile,
 /area/kutjevo/interior/complex/med/operating)
+"cou" = (
+/obj/effect/decal/cleanable/blood/xeno,
+/turf/open/floor/kutjevo/multi_tiles,
+/area/kutjevo/exterior/lz_pad)
 "coF" = (
 /obj/structure/machinery/power/apc{
 	dir = 1;
@@ -1645,6 +1652,12 @@
 	dir = 6
 	},
 /area/kutjevo/interior/complex/botany)
+"cpD" = (
+/obj/structure/flora/bush/desert{
+	icon_state = "tree_3"
+	},
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/exterior/lz_pad)
 "cqc" = (
 /obj/structure/surface/table/almayer,
 /obj/item/ammo_magazine/shotgun/buckshot{
@@ -1692,7 +1705,7 @@
 "ctA" = (
 /obj/structure/largecrate,
 /turf/open/floor/almayer/research/containment/floor2,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "ctD" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_30"
@@ -1982,6 +1995,10 @@
 	},
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/lz_dunes)
+"cLr" = (
+/obj/item/stack/sheet/metal,
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/exterior/lz_pad)
 "cLQ" = (
 /turf/open/mars_cave{
 	icon_state = "mars_cave_7"
@@ -2243,7 +2260,7 @@
 "cYb" = (
 /obj/structure/largecrate/supply/floodlights,
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "cZt" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/machinery/door_control/brbutton{
@@ -2397,7 +2414,7 @@
 	dir = 4
 	},
 /turf/open/floor/kutjevo/multi_tiles,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "dib" = (
 /turf/open/gm/river/desert/shallow_edge,
 /area/kutjevo/exterior/runoff_river)
@@ -2437,6 +2454,9 @@
 	dir = 10
 	},
 /area/kutjevo/interior/colony_South/power2)
+"dmy" = (
+/turf/open/asphalt/cement_sunbleached,
+/area/kutjevo/exterior/lz_pad)
 "dnd" = (
 /turf/open/gm/river/desert/shallow_edge{
 	dir = 8
@@ -2484,11 +2504,11 @@
 	dir = 1
 	},
 /turf/open/floor/kutjevo/multi_tiles,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "dpH" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/kutjevo/tan,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "dql" = (
 /obj/structure/prop/dam/wide_boulder/boulder1,
 /turf/open/auto_turf/sand/layer1,
@@ -2649,7 +2669,7 @@
 /turf/open/desert/desert_shore/shore_edge1{
 	dir = 8
 	},
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "dzd" = (
 /obj/item/storage/briefcase,
 /turf/open/auto_turf/sand/layer0,
@@ -2694,6 +2714,9 @@
 	dir = 8
 	},
 /area/kutjevo/exterior/runoff_river)
+"dBj" = (
+/turf/open/floor/kutjevo/plate,
+/area/kutjevo/exterior/lz_pad)
 "dBt" = (
 /obj/structure/flora/bush/ausbushes/grassybush{
 	pixel_x = -8;
@@ -2746,7 +2769,7 @@
 /area/kutjevo/exterior/Northwest_Colony)
 "dDL" = (
 /turf/open/gm/river/desert/shallow,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "dEI" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/structure/machinery/landinglight/ds1/delayone,
@@ -2914,7 +2937,7 @@
 	pixel_y = 14
 	},
 /turf/open/desert/desert_shore/desert_shore1,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "dQq" = (
 /obj/structure/flora/grass/tallgrass/desert/corner{
 	dir = 5
@@ -3255,7 +3278,7 @@
 	dir = 8
 	},
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "ejP" = (
 /obj/structure/bed/sofa/south/grey/left,
 /turf/open/floor/kutjevo/multi_tiles,
@@ -3398,7 +3421,7 @@
 /obj/structure/surface/rack,
 /obj/item/tool/crowbar/red,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "era" = (
 /obj/structure/closet/crate/freezer/rations,
 /obj/item/defenses/handheld/tesla_coil,
@@ -3650,7 +3673,7 @@
 /turf/open/desert/desert_shore/desert_shore1{
 	dir = 1
 	},
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "eFX" = (
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
@@ -3673,7 +3696,7 @@
 "eGL" = (
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "eHX" = (
 /turf/open/auto_turf/sand/layer0,
 /area/kutjevo/exterior/telecomm/lz1_south)
@@ -3910,7 +3933,7 @@
 /obj/structure/closet/crate,
 /obj/effect/landmark/objective_landmark/medium,
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "eVv" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -4188,7 +4211,7 @@
 /area/kutjevo/exterior/stonyfields)
 "fmN" = (
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "fmR" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/food/drinks/bottle/vodka,
@@ -4617,7 +4640,7 @@
 /obj/structure/surface/table/gamblingtable,
 /obj/item/toy/handcard/aceofspades,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "fTk" = (
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 4
@@ -4687,7 +4710,7 @@
 	dir = 4
 	},
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "fYI" = (
 /turf/open/gm/river/desert/shallow_corner{
 	dir = 4
@@ -4839,7 +4862,7 @@
 "gmA" = (
 /obj/item/stack/sheet/wood,
 /turf/open/floor/kutjevo/tan,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "gmS" = (
 /obj/structure/machinery/shower{
 	dir = 1;
@@ -5344,7 +5367,7 @@
 "gTO" = (
 /obj/structure/surface/rack,
 /turf/open/floor/kutjevo/plate,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "gUa" = (
 /obj/structure/platform/kutjevo/smooth{
 	dir = 1
@@ -5555,7 +5578,7 @@
 	dir = 4
 	},
 /turf/open/floor/kutjevo/multi_tiles,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "hnE" = (
 /obj/structure/platform/kutjevo/rock{
 	dir = 4
@@ -6167,7 +6190,7 @@
 "iiy" = (
 /obj/item/weapon/twohanded/folded_metal_chair,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "iiG" = (
 /turf/open/gm/river/desert/deep,
 /area/kutjevo/interior/complex/botany/east_tech)
@@ -6318,6 +6341,10 @@
 	dir = 4
 	},
 /area/kutjevo/interior/complex/med/triage)
+"izY" = (
+/obj/effect/decal/cleanable/blood/xeno,
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/exterior/lz_pad)
 "iBa" = (
 /turf/open/floor/kutjevo/colors/orange/inner_corner{
 	dir = 1
@@ -6377,7 +6404,7 @@
 /obj/structure/flora/grass/desert/lightgrass_9,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "iDz" = (
 /obj/structure/flora/grass/tallgrass/desert/corner,
 /turf/open/auto_turf/sand/layer1,
@@ -6974,7 +7001,7 @@
 "juC" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "juH" = (
 /obj/structure/stairs/perspective/kutjevo{
 	dir = 6;
@@ -7162,6 +7189,9 @@
 	dir = 6
 	},
 /area/kutjevo/interior/power)
+"jGF" = (
+/turf/open/floor/almayer/research/containment/floor2,
+/area/kutjevo/exterior/lz_pad)
 "jGX" = (
 /obj/effect/landmark/survivor_spawner,
 /turf/open/floor/kutjevo/colors,
@@ -7302,7 +7332,7 @@
 	dir = 8
 	},
 /turf/open/floor/kutjevo/multi_tiles,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "jUP" = (
 /obj/structure/stairs/perspective/kutjevo{
 	dir = 1;
@@ -7789,7 +7819,7 @@
 /obj/structure/closet/crate,
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/almayer/research/containment/floor2,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "kBz" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/auto_turf/sand/layer1,
@@ -7822,7 +7852,7 @@
 	anchored = 0
 	},
 /turf/open/floor/kutjevo/tan,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "kDS" = (
 /turf/open/floor/kutjevo/tan,
 /area/kutjevo/interior/complex/botany)
@@ -8071,7 +8101,7 @@
 "kVA" = (
 /obj/structure/largecrate/supply/supplies/metal,
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "kVH" = (
 /obj/structure/flora/grass/desert/lightgrass_11,
 /turf/open/auto_turf/sand/layer1,
@@ -8096,6 +8126,9 @@
 	dir = 1
 	},
 /area/kutjevo/interior/complex/Northwest_Security_Checkpoint)
+"kWX" = (
+/turf/open/auto_turf/sand/layer2,
+/area/kutjevo/exterior/lz_pad)
 "kYb" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/book/manual/atmospipes,
@@ -8435,7 +8468,7 @@
 "lxN" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/almayer/research/containment/floor2,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "lyD" = (
 /obj/structure/stairs/perspective/kutjevo{
 	dir = 8;
@@ -8466,6 +8499,9 @@
 	dir = 4
 	},
 /area/kutjevo/interior/power/comms)
+"lzD" = (
+/turf/open/floor/almayer/research/containment/floor1,
+/area/kutjevo/exterior/lz_pad)
 "lAn" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -8584,6 +8620,9 @@
 	dir = 1
 	},
 /area/kutjevo/interior/foremans_office)
+"lKk" = (
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/exterior/lz_pad)
 "lKR" = (
 /obj/structure/platform_decoration/kutjevo,
 /turf/open/floor/kutjevo/colors/purple/edge{
@@ -8654,7 +8693,7 @@
 	dir = 1
 	},
 /turf/open/floor/kutjevo/multi_tiles,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "lNt" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/stack/sheet/metal/medium_stack,
@@ -8805,7 +8844,7 @@
 "mao" = (
 /obj/structure/prop/dam/large_boulder/boulder1,
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "mar" = (
 /turf/open/floor/kutjevo/tan/multi_tiles{
 	dir = 1
@@ -8913,7 +8952,7 @@
 "mfk" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "mfD" = (
 /obj/structure/prop/dam/truck/mining,
 /turf/open/auto_turf/sand/layer1,
@@ -9004,7 +9043,7 @@
 /turf/open/desert/desert_shore/shore_edge1{
 	dir = 1
 	},
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "mkJ" = (
 /obj/structure/machinery/light,
 /turf/open/floor/kutjevo/colors/orange,
@@ -9191,6 +9230,11 @@
 /obj/item/storage/pill_bottle/dexalin/skillless,
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/complex/med)
+"mAb" = (
+/turf/open/floor/kutjevo/tan/multi_tiles{
+	dir = 1
+	},
+/area/kutjevo/exterior/lz_pad)
 "mAD" = (
 /obj/structure/barricade/wooden{
 	dir = 1;
@@ -9433,7 +9477,7 @@
 "mIT" = (
 /obj/structure/machinery/landinglight/ds2/delayone,
 /turf/open/floor/kutjevo/multi_tiles,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "mJq" = (
 /obj/structure/machinery/computer/cameras/telescreen/entertainment{
 	icon_state = "ai_bsod";
@@ -9922,6 +9966,12 @@
 	},
 /turf/open/floor/almayer/research/containment/floor2,
 /area/kutjevo/interior/complex/botany)
+"nvi" = (
+/obj/structure/flora/grass/tallgrass/desert/corner{
+	dir = 9
+	},
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/lz_pad)
 "nvG" = (
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/kutjevo/colors/red,
@@ -10695,7 +10745,7 @@
 "oun" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/almayer/research/containment/floor2,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "ouR" = (
 /obj/structure/blocker/invisible_wall,
 /obj/structure/xenoautopsy/tank/larva,
@@ -10888,7 +10938,7 @@
 /area/kutjevo/interior/complex/botany/east_tech)
 "oJE" = (
 /turf/open/floor/kutjevo/tan/alt_edge,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "oJV" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -10897,7 +10947,7 @@
 /area/kutjevo/exterior/scrubland)
 "oKx" = (
 /turf/closed/wall/kutjevo/rock,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "oKA" = (
 /obj/item/storage/toolbox/electrical,
 /turf/open/floor/kutjevo/colors/orange,
@@ -10931,6 +10981,10 @@
 "oMZ" = (
 /turf/closed/wall/kutjevo/colony,
 /area/kutjevo/interior/foremans_office)
+"oNE" = (
+/obj/structure/flora/grass/tallgrass/desert,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/lz_pad)
 "oNG" = (
 /turf/closed/wall/kutjevo/rock,
 /area/kutjevo/exterior/construction)
@@ -11795,7 +11849,7 @@
 	dir = 8
 	},
 /turf/open/floor/kutjevo/multi_tiles,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "pPJ" = (
 /turf/open/gm/river/desert/shallow,
 /area/kutjevo/exterior/lz_dunes)
@@ -11827,7 +11881,7 @@
 "pRL" = (
 /obj/structure/largecrate,
 /turf/open/floor/kutjevo/tan,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "pRS" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/kutjevo/multi_tiles{
@@ -11866,7 +11920,7 @@
 	pixel_y = 14
 	},
 /turf/open/floor/almayer/research/containment/floor2,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "pVd" = (
 /obj/structure/platform/kutjevo{
 	dir = 1
@@ -12035,7 +12089,7 @@
 /turf/open/floor/kutjevo/tan/alt_edge{
 	dir = 1
 	},
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "qny" = (
 /turf/open/desert/desert_shore/shore_corner2{
 	dir = 1
@@ -12289,7 +12343,7 @@
 /turf/open/floor/kutjevo/tan/alt_edge{
 	dir = 4
 	},
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "qEq" = (
 /turf/open/floor/kutjevo/tan/alt_inner_edge{
 	dir = 4
@@ -12500,7 +12554,7 @@
 	dir = 1
 	},
 /turf/open/floor/kutjevo/multi_tiles,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "qTN" = (
 /obj/structure/platform/kutjevo/smooth{
 	dir = 1
@@ -12510,7 +12564,7 @@
 "qUC" = (
 /obj/structure/surface/rack,
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "qUZ" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor/kutjevo/tan/alt_edge{
@@ -12607,7 +12661,7 @@
 "rdx" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer/research/containment/floor2,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "rej" = (
 /obj/structure/prop/dam/large_boulder/boulder1,
 /turf/open/auto_turf/sand/layer0,
@@ -12617,7 +12671,7 @@
 /turf/open/desert/desert_shore/desert_shore1{
 	dir = 4
 	},
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "rfE" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/closed/wall/kutjevo/colony/reinforced,
@@ -12735,12 +12789,16 @@
 	dir = 4
 	},
 /turf/open/floor/kutjevo/tan,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "rme" = (
 /turf/open/floor/kutjevo/multi_tiles{
 	dir = 4
 	},
 /area/kutjevo/interior/complex/botany)
+"rmg" = (
+/obj/structure/flora/grass/tallgrass/desert,
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/exterior/lz_pad)
 "rmo" = (
 /obj/structure/platform/kutjevo/rock,
 /obj/structure/platform/kutjevo/rock{
@@ -12808,6 +12866,10 @@
 	},
 /turf/open/floor/kutjevo/colors/purple,
 /area/kutjevo/interior/construction)
+"rst" = (
+/obj/structure/prop/dam/boulder/boulder1,
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/lz_pad)
 "rsM" = (
 /obj/structure/machinery/power/apc{
 	dir = 1;
@@ -13167,7 +13229,7 @@
 /turf/open/floor/kutjevo/tan/alt_edge{
 	dir = 8
 	},
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "rTi" = (
 /obj/structure/platform_decoration/kutjevo/rock{
 	dir = 1
@@ -13306,7 +13368,7 @@
 "saK" = (
 /obj/structure/machinery/landinglight/ds2/delaytwo,
 /turf/open/floor/kutjevo/multi_tiles,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "sbb" = (
 /obj/structure/stairs/perspective/kutjevo{
 	icon_state = "p_stair_ew_full_cap"
@@ -13823,7 +13885,7 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/structure/machinery/landinglight/ds2/delayone,
 /turf/open/floor/kutjevo/multi_tiles,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "sLx" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/kutjevo/colors/orange,
@@ -13943,7 +14005,7 @@
 "sUt" = (
 /obj/structure/machinery/landinglight/ds2/delaythree,
 /turf/open/floor/kutjevo/multi_tiles,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "sUC" = (
 /obj/structure/blocker/invisible_wall,
 /obj/structure/filtration/coagulation_arm,
@@ -13985,6 +14047,10 @@
 /obj/effect/landmark/queen_spawn,
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/interior/colony_N_East)
+"sWR" = (
+/obj/effect/decal/cleanable/blood/xeno,
+/turf/open/asphalt/cement_sunbleached,
+/area/kutjevo/exterior/lz_pad)
 "sXj" = (
 /obj/structure/largecrate/random/case/small,
 /obj/effect/spawner/random/toolbox{
@@ -14050,6 +14116,12 @@
 "tax" = (
 /turf/open/gm/river/desert/shallow_edge,
 /area/kutjevo/exterior/runoff_dunes)
+"tbk" = (
+/obj/structure/flora/grass/tallgrass/desert/corner{
+	dir = 10
+	},
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/lz_pad)
 "tbx" = (
 /obj/structure/flora/grass/tallgrass/desert/corner{
 	dir = 9
@@ -14220,7 +14292,7 @@
 /turf/open/desert/desert_shore/shore_edge1{
 	dir = 4
 	},
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "tnM" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -14510,13 +14582,16 @@
 "tGE" = (
 /obj/structure/machinery/floodlight/landing,
 /turf/open/floor/kutjevo/plate,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
+"tHh" = (
+/turf/open/auto_turf/sand/layer0,
+/area/kutjevo/exterior/lz_pad)
 "tHI" = (
 /obj/structure/machinery/landinglight/ds2/delaytwo{
 	dir = 8
 	},
 /turf/open/floor/kutjevo/multi_tiles,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "tIh" = (
 /turf/open/gm/river/desert/shallow_edge{
 	dir = 4
@@ -14547,7 +14622,7 @@
 /area/kutjevo/exterior/runoff_dunes)
 "tIY" = (
 /turf/open/desert/desert_shore/shore_edge1,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "tKC" = (
 /obj/structure/bed/sofa/vert/white,
 /turf/open/floor/kutjevo/tan,
@@ -15474,7 +15549,7 @@
 "uTr" = (
 /obj/structure/largecrate,
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "uWk" = (
 /obj/structure/platform/kutjevo/rock{
 	dir = 1
@@ -15817,7 +15892,7 @@
 "vrB" = (
 /obj/structure/machinery/floodlight,
 /turf/open/floor/kutjevo/tan,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "vse" = (
 /obj/structure/bed/stool,
 /turf/open/auto_turf/sand/layer0,
@@ -16166,7 +16241,7 @@
 /area/kutjevo/interior/complex/botany)
 "vPm" = (
 /turf/open/floor/kutjevo/tan,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "vPE" = (
 /obj/effect/decal/cleanable/blood/xeno{
 	icon_state = "xgib1"
@@ -16295,6 +16370,9 @@
 	},
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/exterior/scrubland)
+"wax" = (
+/turf/closed/wall/kutjevo/colony,
+/area/kutjevo/exterior/lz_pad)
 "waP" = (
 /obj/structure/stairs/perspective/kutjevo{
 	icon_state = "p_stair_ew_full_cap_butt"
@@ -16423,7 +16501,7 @@
 "wlg" = (
 /obj/structure/surface/rack,
 /turf/open/floor/kutjevo/tan,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "wlq" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/book/manual/engineering_construction,
@@ -16496,7 +16574,7 @@
 	dir = 4
 	},
 /turf/open/floor/kutjevo/multi_tiles,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "wrO" = (
 /turf/open/gm/river/desert/shallow_edge{
 	dir = 1
@@ -16566,7 +16644,7 @@
 "wvg" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor/almayer/research/containment/floor1,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "wvr" = (
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/interior/colony_South)
@@ -16586,7 +16664,7 @@
 "wvX" = (
 /obj/structure/machinery/landinglight/ds2,
 /turf/open/floor/kutjevo/multi_tiles,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "wwc" = (
 /obj/structure/prop/wooden_cross{
 	desc = "A wooden grave marker. The name 'Richard' is carved into the wood.";
@@ -16598,7 +16676,7 @@
 	pixel_y = -2
 	},
 /turf/open/auto_turf/sand/layer0,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "wwd" = (
 /obj/item/stool,
 /turf/open/floor/kutjevo/colors/green/tile,
@@ -16731,7 +16809,7 @@
 	pixel_y = 13
 	},
 /turf/open/floor/almayer/research/containment/floor2,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "wFa" = (
 /obj/structure/filingcabinet,
 /obj/effect/landmark/objective_landmark/science,
@@ -16910,7 +16988,7 @@
 	dir = 1
 	},
 /turf/open/floor/kutjevo/multi_tiles,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "wXy" = (
 /obj/effect/landmark/static_comms/net_two,
 /turf/open/auto_turf/sand/layer2,
@@ -16985,7 +17063,7 @@
 "xcG" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/kutjevo/colors/orange,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "xcI" = (
 /obj/structure/barricade/wooden{
 	dir = 4
@@ -17197,7 +17275,7 @@
 "xrT" = (
 /obj/structure/flora/grass/desert/lightgrass_8,
 /turf/open/auto_turf/sand/layer1,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "xti" = (
 /obj/structure/stairs/perspective/kutjevo{
 	dir = 4;
@@ -17299,7 +17377,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer/research/containment/floor1,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "xBb" = (
 /obj/structure/platform/kutjevo{
 	dir = 4
@@ -17321,7 +17399,7 @@
 	dir = 8
 	},
 /turf/open/floor/kutjevo/multi_tiles,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "xDY" = (
 /obj/item/weapon/gun/rifle/m16,
 /turf/open/floor/kutjevo/colors/orange,
@@ -17337,7 +17415,7 @@
 /obj/structure/surface/rack,
 /obj/item/packageWrap,
 /turf/open/floor/almayer/research/containment/floor2,
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "xGF" = (
 /obj/structure/stairs/perspective/kutjevo{
 	dir = 4;
@@ -17652,7 +17730,7 @@
 /turf/open/desert/desert_shore/desert_shore1{
 	dir = 8
 	},
-/area/kutjevo/exterior/Northwest_Colony)
+/area/kutjevo/exterior/lz_pad)
 "yfo" = (
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/interior/colony_central)
@@ -18510,9 +18588,9 @@ dxF
 dxF
 dxF
 nTw
-huR
-huR
-huR
+dmy
+dmy
+dmy
 nTw
 dxF
 sWF
@@ -18677,10 +18755,10 @@ dxF
 dxF
 dxF
 dxF
-huR
-huR
-huR
-xBm
+dmy
+dmy
+dmy
+jGF
 sWF
 sWF
 nJp
@@ -18844,9 +18922,9 @@ dxF
 dxF
 dxF
 dxF
-huR
-huR
-huR
+dmy
+dmy
+dmy
 oun
 wwQ
 oca
@@ -19011,9 +19089,9 @@ dxF
 dxF
 dxF
 dxF
-huR
-huR
-huR
+dmy
+dmy
+dmy
 oun
 wwQ
 oFX
@@ -19178,9 +19256,9 @@ dxF
 dxF
 dxF
 dxF
-huR
-huR
-huR
+dmy
+dmy
+dmy
 oun
 wwQ
 oFX
@@ -19326,13 +19404,13 @@ dxF
 dxF
 dxF
 dxF
-ybV
-ybV
-ybV
-ybV
-ybV
-ybV
-ybV
+oNE
+oNE
+oNE
+oNE
+oNE
+oNE
+oNE
 dxF
 dxF
 dxF
@@ -19345,10 +19423,10 @@ dxF
 dxF
 dxF
 dxF
-huR
-huR
-huR
-xBm
+dmy
+dmy
+dmy
+jGF
 sWF
 bQk
 opQ
@@ -19491,17 +19569,17 @@ dxF
 dxF
 dxF
 wwc
-hrz
-arM
-ybV
-mSG
-ybV
-mSG
-mSG
-mSG
-ybV
-ybV
-ybV
+tHh
+tbk
+oNE
+rmg
+oNE
+rmg
+rmg
+rmg
+oNE
+oNE
+oNE
 dxF
 dxF
 dxF
@@ -19512,10 +19590,10 @@ dxF
 dxF
 dxF
 dxF
-huR
-huR
-huR
-xBm
+dmy
+dmy
+dmy
+jGF
 qzj
 sOF
 swq
@@ -19650,17 +19728,17 @@ dxF
 dxF
 dxF
 dxF
-hrz
+tHh
 dxF
 dxF
 dxF
 dxF
-hrz
-hrz
-hrz
-hrz
-hrz
-arM
+tHh
+tHh
+tHh
+tHh
+tHh
+tbk
 eiX
 eiX
 eiX
@@ -19669,7 +19747,7 @@ eiX
 eiX
 eiX
 eiX
-ksW
+nvi
 dxF
 dxF
 dxF
@@ -19679,10 +19757,10 @@ dxF
 dxF
 dxF
 dxF
-huR
-huR
-huR
-xBm
+dmy
+dmy
+dmy
+jGF
 qzj
 qfw
 rwL
@@ -19817,28 +19895,28 @@ dxF
 mjW
 yfc
 tIY
-hrz
+tHh
 dxF
 dxF
 dxF
-hrz
+tHh
 bWA
-hrz
-hrz
-hrz
-sVF
-iin
-iin
-hrz
-hrz
-hrz
-hrz
-hrz
-hrz
-hrz
-hrz
-hrz
-hrz
+tHh
+tHh
+tHh
+lKk
+kWX
+kWX
+tHh
+tHh
+tHh
+tHh
+tHh
+tHh
+tHh
+tHh
+tHh
+tHh
 dxF
 dxF
 dxF
@@ -19846,10 +19924,10 @@ dxF
 dxF
 dxF
 dxF
-huR
-huR
-huR
-xBm
+dmy
+dmy
+dmy
+jGF
 wwQ
 eur
 opQ
@@ -19984,39 +20062,39 @@ dxF
 eFy
 dDL
 dOU
-hrz
-hrz
-hrz
-hrz
-hrz
-hrz
-sVF
-sVF
-sVF
-sVF
-sVF
-iin
-iin
-hrz
-hrz
-bNG
-hrz
-hrz
-sVF
-sVF
-sVF
-hrz
-hrz
+tHh
+tHh
+tHh
+tHh
+tHh
+tHh
+lKk
+lKk
+lKk
+lKk
+lKk
+kWX
+kWX
+tHh
+tHh
+rst
+tHh
+tHh
+lKk
+lKk
+lKk
+tHh
+tHh
 bWA
-hrz
+tHh
 dxF
 dxF
 dxF
 dxF
-iin
-huR
-huR
-xBm
+kWX
+dmy
+dmy
+jGF
 sWF
 sWF
 khW
@@ -20151,40 +20229,40 @@ dxF
 tnI
 rfz
 dyW
-sVF
-sVF
-sVF
-iin
-iin
-sVF
-sVF
-hrz
-hrz
-hrz
-sVF
-iin
-iin
-iin
-hrz
-hrz
-hrz
-hrz
-sVF
-hrz
-hrz
-hrz
-hrz
-hrz
-hrz
-hrz
-iin
-iin
-sVF
-sVF
-huR
-huR
-xBm
-aUF
+lKk
+lKk
+lKk
+kWX
+kWX
+lKk
+lKk
+tHh
+tHh
+tHh
+lKk
+kWX
+kWX
+kWX
+tHh
+tHh
+tHh
+tHh
+lKk
+tHh
+tHh
+tHh
+tHh
+tHh
+tHh
+tHh
+kWX
+kWX
+lKk
+lKk
+dmy
+dmy
+jGF
+bEt
 sWF
 sWF
 sWF
@@ -20316,50 +20394,50 @@ dxF
 dxF
 dxF
 dxF
-iin
-hrz
-hrz
-hrz
-hrz
-sVF
-hrz
-hrz
-hrz
-iin
-hrz
-hrz
-hrz
-hrz
-hrz
-hrz
-hrz
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-hrz
-hrz
-hrz
-hrz
-hrz
-sVF
-sVF
-sVF
-huR
-huR
-lRy
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
+kWX
+tHh
+tHh
+tHh
+tHh
+lKk
+tHh
+tHh
+tHh
+kWX
+tHh
+tHh
+tHh
+tHh
+tHh
+tHh
+tHh
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+tHh
+tHh
+tHh
+tHh
+tHh
+lKk
+lKk
+lKk
+dmy
+dmy
+dBj
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
 rzh
 dxF
 dxF
@@ -20484,49 +20562,49 @@ dxF
 dxF
 dxF
 dxF
-hrz
-hrz
-iin
-sVF
+tHh
+tHh
+kWX
+lKk
 qDH
 qDH
 qDH
-iin
-iin
-iin
-iin
-iin
-sVF
+kWX
+kWX
+kWX
+kWX
+kWX
+lKk
 qDH
 qDH
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
 qDH
 qDH
 qDH
-sVF
-sVF
-huR
-huR
-sVF
-sVF
-sVF
-iin
-iin
-iin
-sVF
-sVF
-sVF
-sVF
+lKk
+lKk
+dmy
+dmy
+lKk
+lKk
+lKk
+kWX
+kWX
+kWX
+lKk
+lKk
+lKk
+lKk
 dxF
 dxF
 dxF
@@ -20651,49 +20729,49 @@ dxF
 dxF
 dxF
 dxF
-hrz
-iin
-iin
-sVF
-lRy
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-lRy
-huR
-huR
-huR
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
+tHh
+kWX
+kWX
+lKk
+dBj
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+dBj
+dmy
+dmy
+dmy
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
 dxF
 dxF
 dxF
@@ -20818,11 +20896,11 @@ dxF
 dxF
 dxF
 dxF
-hrz
-iin
-sVF
+tHh
+kWX
+lKk
 oJE
-xBm
+jGF
 tGE
 hnq
 dhL
@@ -20847,19 +20925,19 @@ ccs
 hnq
 dhL
 tGE
-xBm
-huR
-huR
-huR
-sVF
-sVF
+jGF
+dmy
+dmy
+dmy
+lKk
+lKk
 qDH
 qDH
 qDH
 qDH
 qDH
-sVF
-sVF
+lKk
+lKk
 dxF
 dxF
 dxF
@@ -20985,11 +21063,11 @@ dxF
 dxF
 dxF
 dxF
-iin
-sVF
-hrz
-sVF
-xBm
+kWX
+lKk
+tHh
+lKk
+jGF
 wvX
 hzN
 wqk
@@ -21014,17 +21092,17 @@ wqk
 hzN
 hzN
 dpt
-xBm
-huR
-huR
-huR
-sVF
+jGF
+dmy
+dmy
+dmy
+lKk
 oJE
-lRy
-dht
-dht
-dht
-lRy
+dBj
+lzD
+lzD
+lzD
+dBj
 qnd
 xrT
 dxF
@@ -21151,12 +21229,12 @@ dxF
 dxF
 dxF
 dxF
-iin
-iin
-sVF
-hrz
-sVF
-xBm
+kWX
+kWX
+lKk
+tHh
+lKk
+jGF
 sUt
 hzN
 hzN
@@ -21181,19 +21259,19 @@ hzN
 ppX
 hzN
 lNl
-xBm
-huR
-huR
-huR
-sVF
+jGF
+dmy
+dmy
+dmy
+lKk
 oJE
-xBm
+jGF
 uTr
 mfk
 mfk
-xBm
+jGF
 qnd
-sVF
+lKk
 dxF
 dxF
 dxF
@@ -21318,12 +21396,12 @@ dxF
 dxF
 dxF
 dxF
-iin
-bGg
-sVF
-hrz
+kWX
+cpD
+lKk
+tHh
 oJE
-xBm
+jGF
 saK
 hzN
 hzN
@@ -21348,20 +21426,20 @@ hzN
 ppX
 hzN
 qTI
-xBm
-huR
-huR
-sVF
-sVF
+jGF
+dmy
+dmy
+lKk
+lKk
 oJE
-xBm
+jGF
 rlI
 pRL
 vrB
-xBm
+jGF
 qnd
-sVF
-pkP
+lKk
+wax
 pkP
 pkP
 hrz
@@ -21485,12 +21563,12 @@ dxF
 dxF
 dxF
 dxF
-iin
-sVF
-sVF
-sVF
+kWX
+lKk
+lKk
+lKk
 oJE
-xBm
+jGF
 sLf
 hzN
 ppX
@@ -21515,20 +21593,20 @@ ppX
 ppX
 hzN
 wXf
-xBm
-huR
-huR
-sVF
-iin
+jGF
+dmy
+dmy
+lKk
+kWX
 oJE
-xBm
+jGF
 fmN
 fmN
 fmN
-xBm
+jGF
 qnd
-sVF
-mar
+lKk
+mAb
 ggC
 mar
 hrz
@@ -21652,12 +21730,12 @@ dxF
 dxF
 dxF
 dxF
-iin
-sVF
-sVF
-sVF
+kWX
+lKk
+lKk
+lKk
 oJE
-xBm
+jGF
 wvX
 hzN
 ppX
@@ -21682,20 +21760,20 @@ hzN
 eBI
 hzN
 dpt
-xBm
-huR
-huR
-sVF
-iin
+jGF
+dmy
+dmy
+lKk
+kWX
 oJE
-xBm
+jGF
 wlg
 vPm
 vPm
-xBm
+jGF
 qnd
-sVF
-mar
+lKk
+mAb
 ggC
 mar
 hrz
@@ -21819,12 +21897,12 @@ dxF
 dxF
 dxF
 dxF
-iin
-iin
-sVF
-hrz
+kWX
+kWX
+lKk
+tHh
 oJE
-xBm
+jGF
 sUt
 hzN
 ppX
@@ -21849,20 +21927,20 @@ hzN
 hzN
 hzN
 lNl
-xBm
-huR
-huR
-sVF
-sVF
+jGF
+dmy
+dmy
+lKk
+lKk
 oJE
-xBm
+jGF
 qUC
 kVA
 fmN
-xBm
+jGF
 qnd
-sVF
-mar
+lKk
+mAb
 ggC
 mar
 sVF
@@ -21986,12 +22064,12 @@ dxF
 dxF
 dxF
 dxF
-hrz
-iin
-hrz
-iin
-iin
-xBm
+tHh
+kWX
+tHh
+kWX
+kWX
+jGF
 saK
 hzN
 ppX
@@ -22016,20 +22094,20 @@ hzN
 hzN
 hzN
 qTI
-xBm
-huR
-huR
-sVF
-sVF
+jGF
+dmy
+dmy
+lKk
+lKk
 oJE
-lRy
-dht
-dht
-dht
-lRy
+dBj
+lzD
+lzD
+lzD
+dBj
 qnd
-sVF
-mar
+lKk
+mAb
 pkP
 mar
 iin
@@ -22153,12 +22231,12 @@ dxF
 dxF
 dxF
 dxF
-hrz
-hrz
-hrz
-hrz
+tHh
+tHh
+tHh
+tHh
 oJE
-xBm
+jGF
 mIT
 hzN
 ppX
@@ -22183,20 +22261,20 @@ ppX
 ppX
 hzN
 wXf
-xBm
-huR
-huR
-huR
-sVF
-sVF
+jGF
+dmy
+dmy
+dmy
+lKk
+lKk
 rSU
 rSU
 rSU
 rSU
 rSU
-sVF
-sVF
-mar
+lKk
+lKk
+mAb
 ggC
 mar
 hrz
@@ -22320,12 +22398,12 @@ dxF
 dxF
 dxF
 dxF
-hrz
+tHh
 mao
-hrz
-iin
+tHh
+kWX
 oJE
-xBm
+jGF
 wvX
 hzN
 hzN
@@ -22350,20 +22428,20 @@ hzN
 ppX
 eBI
 dpt
-xBm
-huR
-huR
-huR
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-bGg
-mar
+jGF
+dmy
+dmy
+dmy
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+cpD
+mAb
 ggC
 mar
 hrz
@@ -22487,12 +22565,12 @@ dxF
 dxF
 dxF
 dxF
-hrz
-hrz
-hrz
-hrz
-iin
-xBm
+tHh
+tHh
+tHh
+tHh
+kWX
+jGF
 sUt
 hzN
 hzN
@@ -22517,20 +22595,20 @@ hzN
 ppX
 eBI
 lNl
-xBm
-huR
-huR
-huR
-sVF
-hrz
-sVF
-sVF
-sVF
-sVF
-tjJ
-sVF
-sVF
-mar
+jGF
+dmy
+dmy
+dmy
+lKk
+tHh
+lKk
+lKk
+lKk
+lKk
+izY
+lKk
+lKk
+mAb
 ggC
 mar
 hrz
@@ -22654,12 +22732,12 @@ dxF
 dxF
 dxF
 dxF
-hrz
-hrz
-hrz
-hrz
+tHh
+tHh
+tHh
+tHh
 oJE
-xBm
+jGF
 saK
 hzN
 wqk
@@ -22684,18 +22762,18 @@ wqk
 hzN
 hzN
 qTI
-xBm
-huR
-huR
-huR
-lRy
-dht
-dht
-dht
-dht
-dht
-dht
-dht
+jGF
+dmy
+dmy
+dmy
+dBj
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
 hoK
 hoK
 hoK
@@ -22821,12 +22899,12 @@ dxF
 dxF
 dxF
 dxF
-hrz
-hrz
-hrz
-sVF
+tHh
+tHh
+tHh
+lKk
 oJE
-xBm
+jGF
 tGE
 pPz
 jUK
@@ -22851,17 +22929,17 @@ tHI
 pPz
 jUK
 tGE
-xBm
-huR
-huR
-huR
-xBm
-aUF
-aUF
-aUF
-aUF
-aUF
-aUF
+jGF
+dmy
+dmy
+dmy
+jGF
+bEt
+bEt
+bEt
+bEt
+bEt
+bEt
 hoK
 hoK
 hbL
@@ -22988,42 +23066,42 @@ dxF
 dxF
 dxF
 dxF
-hrz
-hrz
-sVF
-sVF
+tHh
+tHh
+lKk
+lKk
 oJE
-lRy
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-dht
-lRy
-huR
-huR
-huR
+dBj
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+lzD
+dBj
+dmy
+dmy
+dmy
 lxN
-aUF
+bEt
 hoK
 hoK
 dkW
@@ -23155,42 +23233,42 @@ dxF
 dxF
 dxF
 dxF
-hrz
-iin
-sVF
-sVF
-bGg
+tHh
+kWX
+lKk
+lKk
+cpD
 rSU
 rSU
 rSU
-sVF
+lKk
 rSU
 rSU
-sVF
+lKk
 rSU
 rSU
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
 rSU
-sVF
-huR
-huR
-huR
-xBm
-aUF
+lKk
+dmy
+dmy
+dmy
+jGF
+bEt
 hoK
 lOr
 iNY
@@ -23321,43 +23399,43 @@ dxF
 dxF
 dxF
 dxF
-iin
-iin
-iin
-iin
-sVF
-hrz
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-sVF
-hrz
-sVF
-sVF
-hrz
-hrz
-hrz
-hrz
-iin
-iin
+kWX
+kWX
+kWX
+kWX
+lKk
+tHh
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+lKk
+tHh
+lKk
+lKk
+tHh
+tHh
+tHh
+tHh
+kWX
+kWX
 oKx
 oKx
-sVF
+lKk
 qDH
 qDH
 qDH
 qDH
 qDH
-sVF
-huR
-huR
-huR
-xBm
-aUF
+lKk
+dmy
+dmy
+dmy
+jGF
+bEt
 uAJ
 iZi
 nZK
@@ -23489,42 +23567,42 @@ dxF
 dxF
 dxF
 dxF
-iin
-iin
-iin
-iin
-iin
-iin
-iin
-sVF
-sVF
-sVF
-sVF
-sVF
-dFx
-hrz
-hrz
-hrz
-hrz
-hrz
-sVF
-hrz
-hrz
-hrz
-hrz
+kWX
+kWX
+kWX
+kWX
+kWX
+kWX
+kWX
+lKk
+lKk
+lKk
+lKk
+lKk
+cLr
+tHh
+tHh
+tHh
+tHh
+tHh
+lKk
+tHh
+tHh
+tHh
+tHh
 oKx
-sVF
+lKk
 gTO
-dht
-dht
-dht
-lRy
+lzD
+lzD
+lzD
+dBj
 qnd
-huR
-huR
-huR
-xBm
-aUF
+dmy
+dmy
+dmy
+jGF
+bEt
 hEC
 ipy
 nZK
@@ -23661,37 +23739,37 @@ dxF
 dxF
 dxF
 rzh
-dht
+lzD
 bEn
 bEn
-dht
-dht
-dht
+lzD
+lzD
+lzD
 xAr
-dht
+lzD
 xAr
 wvg
-dht
-dht
-dht
-dht
-lRy
-hrz
-hrz
-hrz
-hrz
+lzD
+lzD
+lzD
+lzD
+dBj
+tHh
+tHh
+tHh
+tHh
 eqQ
 xFN
 cYb
 gmA
 juC
-xBm
+jGF
 qnd
-huR
-huR
-huR
-xBm
-aUF
+dmy
+dmy
+dmy
+jGF
+bEt
 uAJ
 mbc
 nZK
@@ -23840,25 +23918,25 @@ uzp
 acx
 jnV
 jnV
-aUF
-aUF
-xBm
-hrz
-hrz
-hrz
-hrz
+bEt
+bEt
+jGF
+tHh
+tHh
+tHh
+tHh
 oJE
-xBm
+jGF
 fmN
 vPm
 uTr
 kBm
 bdd
-huR
-huR
-huR
-xBm
-gzb
+dmy
+dmy
+dmy
+jGF
+cou
 hEC
 fEu
 nZK
@@ -24008,24 +24086,24 @@ sjE
 pHR
 jnV
 jnV
-aUF
-xBm
-sVF
-hrz
-hrz
-hrz
+bEt
+jGF
+lKk
+tHh
+tHh
+tHh
 oJE
-xBm
+jGF
 kDD
 vPm
 vPm
 rdx
 bdd
-huR
-huR
-huR
-xBm
-aUF
+dmy
+dmy
+dmy
+jGF
+bEt
 hoK
 pLN
 fYE
@@ -24176,23 +24254,23 @@ cWc
 hst
 jnV
 jnV
-xBm
-sVF
+jGF
+lKk
 fYF
-hrz
-hrz
+tHh
+tHh
 oJE
-xBm
+jGF
 fmN
 vPm
 fmN
 ctA
 qnd
-huR
-huR
-huR
-xBm
-aUF
+dmy
+dmy
+dmy
+jGF
+bEt
 hoK
 hoK
 ybd
@@ -24343,23 +24421,23 @@ cWc
 cWc
 dfz
 jnV
-xBm
-sVF
+jGF
+lKk
 fSK
-sVF
-sVF
+lKk
+lKk
 oJE
-xBm
+jGF
 fmN
 vPm
 bGi
-xBm
+jGF
 bdd
-huR
-huR
-huR
-xBm
-aUF
+dmy
+dmy
+dmy
+jGF
+bEt
 hoK
 hoK
 nmw
@@ -24511,22 +24589,22 @@ cWc
 kSy
 pma
 wEU
-sVF
+lKk
 iiy
 eGL
-bGg
-sVF
-xBm
+cpD
+lKk
+jGF
 xcG
 vPm
 fmN
-xBm
-iin
-huR
-huR
-huR
-xBm
-aUF
+jGF
+kWX
+dmy
+dmy
+dmy
+jGF
+bEt
 hoK
 yhV
 onC
@@ -24678,22 +24756,22 @@ cWc
 jiX
 fto
 pUB
-sVF
+lKk
 arh
-sVF
-sVF
-iin
-xBm
+lKk
+lKk
+kWX
+jGF
 dpH
 aIy
 vPm
-xBm
-iin
-huR
-huR
-huR
-xBm
-aUF
+jGF
+kWX
+dmy
+dmy
+dmy
+jGF
+bEt
 uAJ
 uEr
 nZK
@@ -24844,23 +24922,23 @@ lSc
 lSc
 fto
 jnV
-xBm
-sVF
-sVF
-sVF
-sVF
-iin
-xBm
+jGF
+lKk
+lKk
+lKk
+lKk
+kWX
+jGF
 eUJ
 aIy
 juC
-xBm
+jGF
 qnd
-sVF
-huR
-kZV
-xBm
-aUF
+lKk
+dmy
+sWR
+jGF
+bEt
 uAJ
 jOA
 nZK
@@ -25011,23 +25089,23 @@ iXh
 ntz
 jnV
 jnV
-xBm
-sVF
-sVF
-sVF
-sVF
+jGF
+lKk
+lKk
+lKk
+lKk
 oJE
-xBm
+jGF
 fmN
 dpH
 juC
-xBm
+jGF
 qnd
-iin
-huR
-huR
-xBm
-gzb
+kWX
+dmy
+dmy
+jGF
+cou
 hEC
 fKD
 nZK
@@ -25182,19 +25260,19 @@ rzh
 dxF
 dxF
 iCQ
-sVF
-sVF
-lRy
-dht
-dht
-dht
-lRy
+lKk
+lKk
+dBj
+lzD
+lzD
+lzD
+dBj
 qnd
-iin
-huR
-huR
-xBm
-aUF
+kWX
+dmy
+dmy
+jGF
+bEt
 uAJ
 iZi
 nZK
@@ -25350,18 +25428,18 @@ dxF
 dxF
 dxF
 dxF
-sVF
+lKk
 rSU
 rSU
 rSU
 rSU
 rSU
-sVF
-sVF
-huR
-huR
-xBm
-aUF
+lKk
+lKk
+dmy
+dmy
+jGF
+bEt
 hoK
 xca
 pyZ

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -331,10 +331,6 @@
 	icon_state = "marked"
 	},
 /area/lv522/indoors/b_block/bar)
-"ait" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/gm/river,
-/area/lv522/landing_zone_1/tunnel)
 "aiw" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal3";
@@ -799,7 +795,7 @@
 	},
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "aut" = (
 /turf/open/floor/corsat{
 	dir = 5;
@@ -1090,7 +1086,6 @@
 	id = "LZ1_Lockdown_Lo";
 	name = "Emergency Lockdown"
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -1466,7 +1461,7 @@
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "aQU" = (
 /obj/structure/machinery/computer/cameras{
 	dir = 4;
@@ -1496,7 +1491,7 @@
 	},
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "aRH" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out";
@@ -3246,7 +3241,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "bLI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/engineering_electrical,
@@ -3404,7 +3399,7 @@
 /area/lv522/outdoors/colony_streets/north_street)
 "bPJ" = (
 /turf/closed/wall/strata_outpost,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "bPQ" = (
 /obj/item/prop/helmetgarb/spacejam_tickets{
 	desc = "Two original, crisp, orange, tickets.";
@@ -3446,7 +3441,7 @@
 "bQA" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "bQC" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -4456,14 +4451,6 @@
 	icon_state = "greenfull"
 	},
 /area/lv522/indoors/b_block/hydro)
-"cpU" = (
-/obj/structure/machinery/floodlight/landing,
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "greenfull"
-	},
-/area/lv522/landing_zone_1)
 "cpX" = (
 /obj/item/toy/beach_ball/holoball,
 /obj/item/shard{
@@ -4893,7 +4880,7 @@
 "czE" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "czG" = (
 /obj/structure/sign/safety/radio_rad{
 	pixel_y = 26
@@ -5244,13 +5231,6 @@
 	icon_state = "brown"
 	},
 /area/lv522/atmos/east_reactor)
-"cHY" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/gm/river,
-/area/lv522/landing_zone_1/tunnel)
 "cIe" = (
 /obj/structure/surface/rack,
 /obj/item/tool/minihoe{
@@ -5409,7 +5389,7 @@
 	},
 /obj/item/stack/sheet/wood,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "cJW" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 10
@@ -6261,7 +6241,6 @@
 	},
 /area/lv522/oob)
 "das" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /obj/structure/machinery/landinglight/ds1/delayone,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1)
@@ -7046,7 +7025,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "dnQ" = (
 /turf/open/floor/corsat{
 	icon_state = "browncorner"
@@ -7171,7 +7150,6 @@
 	dir = 4;
 	icon_state = "p_stair_full"
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "drg" = (
@@ -8925,7 +8903,7 @@
 /obj/vehicle/train/cargo/trolley,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "edk" = (
 /turf/open/floor/corsat{
 	dir = 8;
@@ -8972,7 +8950,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "eeG" = (
 /obj/structure/prop/ice_colony/dense/planter_box{
 	dir = 9
@@ -9250,7 +9228,6 @@
 	pixel_y = -6
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -9467,6 +9444,10 @@
 	icon_state = "marked"
 	},
 /area/lv522/atmos/east_reactor)
+"enB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/lv522/landing_zone_1/tunnel/far)
 "enD" = (
 /obj/structure/curtain/red,
 /turf/open/floor/prison{
@@ -9640,7 +9621,6 @@
 /area/lv522/atmos/north_command_centre)
 "epN" = (
 /obj/structure/closet/emcloset,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "epS" = (
@@ -9709,7 +9689,7 @@
 "eqV" = (
 /obj/structure/largecrate/random/barrel,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "erw" = (
 /obj/vehicle/train/cargo/trolley,
 /obj/effect/landmark/objective_landmark/close,
@@ -9854,10 +9834,9 @@
 	},
 /obj/vehicle/train/cargo/engine,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "evg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /obj/structure/machinery/power/apc/weak{
 	dir = 8
 	},
@@ -9874,7 +9853,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "evv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/surface/table/reinforced/prison,
@@ -9947,7 +9926,6 @@
 /area/lv522/atmos/east_reactor)
 "ewn" = (
 /obj/structure/platform,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement4"
 	},
@@ -10011,7 +9989,6 @@
 	dir = 1
 	},
 /obj/structure/largecrate,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "exZ" = (
@@ -10054,7 +10031,6 @@
 	},
 /area/lv522/outdoors/colony_streets/central_streets)
 "eyy" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /obj/structure/machinery/landinglight/ds1,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1)
@@ -10995,6 +10971,9 @@
 	icon_state = "floor_plate"
 	},
 /area/lv522/landing_zone_2/ceiling)
+"eSW" = (
+/turf/open/gm/river,
+/area/lv522/landing_zone_1/tunnel/far)
 "eSY" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
@@ -11006,16 +10985,6 @@
 	icon_state = "plate"
 	},
 /area/lv522/atmos/reactor_garage)
-"eTu" = (
-/obj/structure/stairs/perspective{
-	icon_state = "p_stair_full"
-	},
-/obj/structure/platform{
-	dir = 4
-	},
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
 "eTQ" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 10
@@ -11327,7 +11296,6 @@
 	phone_id = "LZ1 Service Tunnel";
 	pixel_y = 24
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "eZY" = (
@@ -11381,12 +11349,6 @@
 	},
 /turf/open/floor/grass,
 /area/lv522/indoors/a_block/garden)
-"fbh" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/asphalt/cement{
-	icon_state = "cement1"
-	},
-/area/lv522/outdoors/colony_streets/south_west_street)
 "fbA" = (
 /obj/structure/prop/invuln/ice_prefab/standalone{
 	icon_state = "white"
@@ -12247,7 +12209,7 @@
 	dir = 8
 	},
 /turf/open/gm/river,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "fvo" = (
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/corsat{
@@ -12372,10 +12334,6 @@
 	icon_state = "plate"
 	},
 /area/lv522/atmos/east_reactor/west)
-"fxZ" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
 "fyl" = (
 /obj/structure/pipes/vents/pump,
 /obj/effect/decal/cleanable/dirt,
@@ -12567,7 +12525,6 @@
 	},
 /area/lv522/outdoors/colony_streets/east_central_street)
 "fBL" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /obj/structure/machinery/landinglight/ds1/delaytwo,
 /turf/open/floor/prison{
 	dir = 4;
@@ -12610,7 +12567,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "fCl" = (
 /obj/structure/barricade/wooden{
 	dir = 1
@@ -12688,7 +12645,6 @@
 /obj/item/tool/pen/blue/clicky,
 /obj/effect/landmark/objective_landmark/close,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -12734,7 +12690,6 @@
 	pixel_x = 5;
 	registered_name = "John Forklift"
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -12898,10 +12853,6 @@
 	icon_state = "blue_plate"
 	},
 /area/lv522/indoors/c_block/mining)
-"fHB" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/asphalt/cement,
-/area/lv522/outdoors/colony_streets/south_west_street)
 "fHC" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 5
@@ -12990,7 +12941,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "fKf" = (
 /obj/structure/platform{
 	dir = 1
@@ -13072,7 +13023,6 @@
 	id = "LZ1_Lockdown_Lo";
 	name = "Emergency Lockdown"
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -13090,7 +13040,6 @@
 	pixel_x = 8;
 	pixel_y = 12
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "fLP" = (
@@ -13262,12 +13211,6 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/prison,
 /area/lv522/indoors/lone_buildings/outdoor_bot)
-"fPt" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/asphalt/cement{
-	icon_state = "cement2"
-	},
-/area/lv522/outdoors/colony_streets/south_west_street)
 "fPB" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -13391,7 +13334,6 @@
 	},
 /area/lv522/atmos/sewer)
 "fSo" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /obj/structure/machinery/landinglight/ds1,
 /turf/open/floor/prison{
 	dir = 4;
@@ -13532,7 +13474,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "fVU" = (
 /obj/structure/prop/invuln/ice_prefab{
 	dir = 1
@@ -13693,7 +13635,7 @@
 	dir = 4
 	},
 /turf/open/gm/river,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "fYP" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/floor/corsat{
@@ -13735,7 +13677,7 @@
 	},
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "fZy" = (
 /obj/structure/prop/invuln/ice_prefab{
 	dir = 10
@@ -14001,7 +13943,6 @@
 /area/lv522/atmos/east_reactor)
 "gej" = (
 /obj/structure/platform,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement4"
 	},
@@ -14097,7 +14038,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/platform,
 /turf/open/gm/river,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "gfi" = (
 /obj/item/weapon/twohanded/folded_metal_chair,
 /obj/item/prop/alien/hugger{
@@ -14118,7 +14059,7 @@
 /obj/item/prop/alien/hugger,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "gfu" = (
 /obj/structure/surface/table/woodentable/fancy,
 /obj/item/device/flashlight/lamp/green,
@@ -14185,7 +14126,6 @@
 	},
 /area/lv522/indoors/a_block/hallway)
 "ggS" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -14391,7 +14331,7 @@
 /obj/structure/machinery/light/small,
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "gkY" = (
 /obj/structure/closet/bombcloset,
 /turf/open/asphalt/cement,
@@ -14804,7 +14744,7 @@
 /obj/structure/largecrate/random,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "guj" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
 	dir = 1;
@@ -15557,7 +15497,7 @@
 	},
 /obj/structure/platform,
 /turf/open/gm/river,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "gJD" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -15603,7 +15543,6 @@
 	id = "LZ1_Lockdown_Lo";
 	name = "Emergency Lockdown"
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -15900,7 +15839,6 @@
 	pixel_y = 6
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -16147,7 +16085,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "gWg" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_nest,
 /obj/effect/landmark/xeno_spawn,
@@ -16202,7 +16140,6 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "gXc" = (
@@ -16414,7 +16351,6 @@
 	},
 /area/lv522/indoors/b_block/bridge)
 "haf" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /obj/structure/machinery/landinglight/ds1/delaytwo,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1)
@@ -16993,7 +16929,7 @@
 	dir = 4
 	},
 /turf/open/gm/river,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "hiV" = (
 /obj/item/prop/alien/hugger,
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -18193,6 +18129,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/lv522/atmos/outdoor)
+"hHe" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/turf/open/gm/river,
+/area/lv522/landing_zone_1/tunnel/far)
 "hHh" = (
 /obj/structure/platform{
 	dir = 4
@@ -18911,7 +18853,6 @@
 /area/lv522/atmos/sewer)
 "hTW" = (
 /obj/structure/largecrate/random/secure,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/landing_zone_1)
 "hTX" = (
@@ -18960,7 +18901,6 @@
 	pixel_x = 7;
 	pixel_y = 7
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "hUY" = (
@@ -19298,7 +19238,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/prop/alien/hugger,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "ici" = (
 /obj/effect/decal/cleanable/vomit{
 	icon_state = "vomit_4"
@@ -19718,7 +19658,6 @@
 /area/lv522/indoors/c_block/mining)
 "ikb" = (
 /obj/structure/surface/rack,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "ike" = (
@@ -19850,7 +19789,6 @@
 	pixel_y = 6
 	},
 /obj/item/tool/pen/blue/clicky,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -20039,7 +19977,6 @@
 /obj/structure/platform_decoration{
 	dir = 4
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement,
 /area/lv522/outdoors/colony_streets/south_west_street)
 "isa" = (
@@ -20223,7 +20160,6 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "ivj" = (
@@ -20346,7 +20282,7 @@
 "ixV" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "ixW" = (
 /obj/structure/stairs/perspective{
 	dir = 8;
@@ -20772,7 +20708,7 @@
 	},
 /obj/structure/machinery/light/small,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "iGF" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -20865,7 +20801,6 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "iIs" = (
@@ -21852,7 +21787,7 @@
 	dir = 8
 	},
 /turf/open/gm/river,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "jbd" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -23183,7 +23118,6 @@
 /area/lv522/landing_zone_2)
 "jxF" = (
 /obj/structure/largecrate/guns/russian,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "jxI" = (
@@ -23466,7 +23400,6 @@
 /area/lv522/outdoors/nw_rockies)
 "jCh" = (
 /obj/structure/machinery/door/airlock/almayer/maint,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -23657,7 +23590,7 @@
 	icon_state = "p_stair_full"
 	},
 /turf/open/gm/river,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "jFr" = (
 /obj/structure/cargo_container/arious/rightmid,
 /turf/open/floor/prison,
@@ -24187,7 +24120,6 @@
 	dir = 5;
 	icon_state = "p_stair_full"
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/landing_zone_1)
 "jPj" = (
@@ -24252,7 +24184,6 @@
 "jQC" = (
 /obj/structure/machinery/light,
 /obj/structure/machinery/disposal,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -24682,7 +24613,6 @@
 	dir = 6;
 	icon_state = "p_stair_full"
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/landing_zone_1)
 "jYZ" = (
@@ -24720,7 +24650,6 @@
 	},
 /area/lv522/indoors/a_block/hallway)
 "jZD" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement3"
 	},
@@ -24811,7 +24740,6 @@
 "kbo" = (
 /obj/structure/surface/rack,
 /obj/item/stack/sheet/metal/medium_stack,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "kbq" = (
@@ -26527,7 +26455,7 @@
 	dir = 4
 	},
 /turf/open/gm/river,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "kEo" = (
 /obj/structure/machinery/colony_floodlight{
 	layer = 4.3
@@ -26703,6 +26631,15 @@
 	icon_state = "darkredfull2"
 	},
 /area/lv522/indoors/a_block/security)
+"kHW" = (
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_full"
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/lv522/landing_zone_1/tunnel/far)
 "kHX" = (
 /obj/structure/platform_decoration{
 	dir = 4
@@ -27087,7 +27024,6 @@
 	id = "LZ1_Lockdown_Lo";
 	name = "Emergency Lockdown"
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -27529,13 +27465,6 @@
 	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
-"kWp" = (
-/obj/structure/window/framed/strata/reinforced,
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/floor/corsat{
-	icon_state = "marked"
-	},
-/area/lv522/landing_zone_1/ceiling)
 "kWH" = (
 /obj/structure/stairs/perspective{
 	dir = 8;
@@ -27678,7 +27607,6 @@
 /obj/structure/platform_decoration{
 	dir = 8
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "kZs" = (
@@ -27690,18 +27618,6 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/admin)
-"kZJ" = (
-/obj/structure/window/framed/strata/reinforced,
-/obj/structure/machinery/door/poddoor/almayer/closed{
-	id = "LZ1_Lockdown_Lo";
-	name = "Emergency Lockdown"
-	},
-/obj/effect/landmark/lv624/fog_blocker/short,
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/floor/corsat{
-	icon_state = "marked"
-	},
-/area/lv522/landing_zone_1/ceiling)
 "kZX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal{
@@ -28047,7 +27963,6 @@
 /obj/structure/platform_decoration{
 	dir = 1
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/landing_zone_1)
 "lhb" = (
@@ -29054,10 +28969,6 @@
 	icon_state = "darkpurplefull2"
 	},
 /area/lv522/indoors/a_block/dorms)
-"lBl" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/auto_turf/sand_white/layer0,
-/area/lv522/landing_zone_1)
 "lBu" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -29490,7 +29401,6 @@
 /area/lv522/atmos/filt)
 "lJq" = (
 /obj/structure/largecrate/random/secure,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/landing_zone_1)
 "lJU" = (
@@ -29500,7 +29410,6 @@
 	pixel_y = 6
 	},
 /obj/item/tool/pen/blue/clicky,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -30057,7 +29966,6 @@
 /area/lv522/indoors/a_block/kitchen/glass)
 "lWj" = (
 /obj/structure/platform,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/landing_zone_1)
 "lWm" = (
@@ -30712,6 +30620,10 @@
 	icon_state = "floor_marked"
 	},
 /area/lv522/atmos/east_reactor/south)
+"mlv" = (
+/obj/structure/largecrate/random/secure,
+/turf/open/floor/plating,
+/area/lv522/landing_zone_1/tunnel/far)
 "mly" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/decal/cleanable/dirt,
@@ -30818,7 +30730,6 @@
 /obj/structure/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement1"
 	},
@@ -30927,7 +30838,6 @@
 /obj/structure/machinery/light{
 	dir = 8
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -30945,7 +30855,6 @@
 	pixel_x = 8;
 	pixel_y = 20
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -31266,7 +31175,6 @@
 	pixel_x = -8;
 	pixel_y = 4
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/landing_zone_1/ceiling)
 "muP" = (
@@ -31309,7 +31217,6 @@
 /area/lv522/atmos/reactor_garage)
 "mvP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/landing_zone_1/ceiling)
 "mvR" = (
@@ -31426,7 +31333,6 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/landing_zone_1/ceiling)
 "mxO" = (
@@ -31486,7 +31392,6 @@
 	dir = 8;
 	pixel_y = 5
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -31506,7 +31411,6 @@
 /obj/item/device/flashlight/lamp{
 	pixel_x = 6
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -31756,7 +31660,6 @@
 	},
 /obj/effect/landmark/objective_landmark/close,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -31918,7 +31821,7 @@
 	},
 /obj/vehicle/train/cargo/trolley,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "mJt" = (
 /obj/structure/stairs/perspective{
 	dir = 9;
@@ -32125,7 +32028,6 @@
 /area/lv522/atmos/filt)
 "mMX" = (
 /obj/structure/powerloader_wreckage,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "mNc" = (
@@ -32213,7 +32115,6 @@
 /obj/item/device/flashlight/lamp{
 	pixel_x = -8
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -32299,7 +32200,6 @@
 	name = "remote door-control";
 	pixel_y = 4
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -32899,7 +32799,6 @@
 	},
 /area/lv522/indoors/a_block/hallway)
 "naS" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /obj/structure/machinery/landinglight/ds1/delaythree,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1)
@@ -33246,13 +33145,6 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/floor/plating,
 /area/lv522/atmos/filt)
-"nhi" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/obj/structure/machinery/landinglight/ds1/delaytwo{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/lv522/landing_zone_1)
 "nhs" = (
 /obj/item/weapon/twohanded/folded_metal_chair,
 /obj/effect/decal/cleanable/dirt,
@@ -33301,7 +33193,6 @@
 /area/lv522/atmos/filt)
 "niA" = (
 /obj/structure/largecrate/random/barrel/green,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement12"
 	},
@@ -33566,7 +33457,6 @@
 	pixel_y = -8
 	},
 /obj/effect/decal/strata_decals/grime/grime3,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison,
 /area/lv522/landing_zone_1/ceiling)
 "nnz" = (
@@ -33603,7 +33493,6 @@
 /obj/item/weapon/twohanded/folded_metal_chair,
 /obj/item/prop/alien/hugger,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison,
 /area/lv522/landing_zone_1/ceiling)
 "noD" = (
@@ -33907,7 +33796,6 @@
 	pixel_y = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison,
 /area/lv522/landing_zone_1/ceiling)
 "nsv" = (
@@ -33991,7 +33879,6 @@
 "ntT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/largecrate/random/barrel/white,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "nud" = (
@@ -34044,7 +33931,6 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -34071,13 +33957,6 @@
 	},
 /turf/open/floor/prison,
 /area/lv522/indoors/lone_buildings/outdoor_bot)
-"nvV" = (
-/obj/structure/platform{
-	dir = 1
-	},
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/gm/river,
-/area/lv522/landing_zone_1/tunnel)
 "nwj" = (
 /turf/closed/wall/strata_outpost,
 /area/lv522/indoors/a_block/dorms/glass)
@@ -34121,7 +34000,6 @@
 /area/lv522/indoors/a_block/admin)
 "nxF" = (
 /obj/structure/machinery/light/small,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "nxJ" = (
@@ -34402,7 +34280,6 @@
 	},
 /area/lv522/atmos/east_reactor/south)
 "nEq" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/landing_zone_1/ceiling)
 "nEX" = (
@@ -34461,7 +34338,6 @@
 /area/lv522/atmos/filt)
 "nGe" = (
 /obj/structure/cargo_container/kelland/left,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/landing_zone_1)
 "nGq" = (
@@ -34497,7 +34373,6 @@
 /area/lv522/atmos/filt)
 "nGJ" = (
 /obj/structure/cargo_container/kelland/right,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/landing_zone_1)
 "nGU" = (
@@ -34729,7 +34604,6 @@
 /area/lv522/indoors/a_block/dorm_north)
 "nMc" = (
 /obj/structure/largecrate,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/landing_zone_1)
 "nMd" = (
@@ -35164,7 +35038,7 @@
 /obj/structure/largecrate/random/secure,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "nSm" = (
 /obj/structure/surface/table/almayer,
 /obj/item/trash/plate,
@@ -35181,7 +35055,6 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "nSA" = (
@@ -35328,7 +35201,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "nVN" = (
 /obj/item/ammo_magazine/flamer_tank/empty,
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -35583,7 +35456,7 @@
 "nYU" = (
 /obj/effect/acid_hole,
 /turf/closed/wall/strata_outpost,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "nYW" = (
 /obj/structure/machinery/space_heater/radiator/red{
 	dir = 1;
@@ -35615,6 +35488,9 @@
 	icon_state = "floor_plate"
 	},
 /area/lv522/atmos/cargo_intake)
+"nZP" = (
+/turf/open/floor/plating,
+/area/lv522/landing_zone_1/tunnel/far)
 "oaa" = (
 /turf/open/asphalt/cement{
 	icon_state = "cement14"
@@ -35857,7 +35733,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "oeT" = (
 /obj/structure/pipes/vents/pump,
 /obj/structure/machinery/light{
@@ -35916,7 +35792,6 @@
 	pixel_x = -9;
 	pixel_y = 12
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "ofZ" = (
@@ -36084,7 +35959,6 @@
 	dir = 9;
 	icon_state = "p_stair_full"
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/landing_zone_1)
 "oiD" = (
@@ -36118,7 +35992,6 @@
 /turf/open/floor/plating,
 /area/lv522/atmos/cargo_intake)
 "oiY" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement14"
 	},
@@ -36137,7 +36010,6 @@
 /obj/structure/machinery/space_heater/radiator/red{
 	dir = 4
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -36259,7 +36131,6 @@
 	pixel_x = 9;
 	pixel_y = 4
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -36333,7 +36204,7 @@
 	},
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "ooG" = (
 /obj/structure/machinery/power/apc/weak{
 	dir = 1
@@ -36372,7 +36243,6 @@
 	},
 /obj/structure/machinery/light,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -36495,6 +36365,12 @@
 	icon_state = "blue"
 	},
 /area/lv522/indoors/a_block/hallway)
+"orA" = (
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/turf/open/gm/river,
+/area/lv522/landing_zone_1/tunnel/far)
 "orE" = (
 /obj/item/prop/colony/used_flare,
 /turf/open/auto_turf/sand_white/layer0,
@@ -36876,7 +36752,6 @@
 /area/lv522/indoors/a_block/dorms)
 "oyY" = (
 /obj/structure/largecrate,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/landing_zone_1)
 "ozk" = (
@@ -37006,7 +36881,6 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "oBx" = (
@@ -37391,7 +37265,6 @@
 /obj/structure/platform_decoration{
 	dir = 10
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/landing_zone_1)
 "oKI" = (
@@ -37667,7 +37540,6 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -37740,7 +37612,6 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -37941,7 +37812,6 @@
 /obj/structure/machinery/space_heater/radiator/red{
 	dir = 8
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -38007,7 +37877,6 @@
 	name = "High Pressure Door";
 	unacidable = 1
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -38116,11 +37985,6 @@
 	icon_state = "floor_plate"
 	},
 /area/lv522/atmos/way_in_command_centre)
-"oYM" = (
-/obj/structure/platform_decoration,
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/auto_turf/sand_white/layer0,
-/area/lv522/landing_zone_1)
 "oYO" = (
 /obj/structure/platform{
 	dir = 1
@@ -38180,7 +38044,6 @@
 /area/lv522/indoors/a_block/admin)
 "paT" = (
 /obj/structure/cargo_container/kelland/right,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/landing_zone_1)
 "pbi" = (
@@ -38272,7 +38135,7 @@
 	dir = 8
 	},
 /turf/open/gm/river,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "pdq" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper B-Block - Hydroponics Airlock";
@@ -38376,7 +38239,6 @@
 /area/lv522/atmos/way_in_command_centre)
 "pez" = (
 /obj/structure/cargo_container/horizontal/blue/top,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/landing_zone_1)
 "peM" = (
@@ -38384,7 +38246,7 @@
 	dir = 1
 	},
 /turf/open/gm/river,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "peS" = (
 /obj/structure/surface/table/almayer{
 	dir = 1;
@@ -38621,13 +38483,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/cargo)
-"pid" = (
-/obj/structure/machinery/door/airlock/almayer/generic,
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/floor/corsat{
-	icon_state = "marked"
-	},
-/area/lv522/landing_zone_1/ceiling)
 "pit" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/auto_turf/sand_white/layer0,
@@ -38666,10 +38521,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/cargo)
-"pjl" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/closed/wall/strata_ice/dirty,
-/area/lv522/oob)
 "pjm" = (
 /obj/structure/platform{
 	dir = 8
@@ -38738,13 +38589,6 @@
 	icon_state = "squares"
 	},
 /area/lv522/atmos/reactor_garage)
-"pkH" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "greenfull"
-	},
-/area/lv522/landing_zone_1)
 "plb" = (
 /obj/structure/machinery/door_display/research_cell{
 	dir = 4;
@@ -39128,16 +38972,6 @@
 	},
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/central_streets)
-"pvd" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/obj/structure/machinery/landinglight/ds1/delayone{
-	dir = 4
-	},
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "greenfull"
-	},
-/area/lv522/landing_zone_1)
 "pvz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/light,
@@ -39208,17 +39042,7 @@
 	pixel_y = -6
 	},
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
-"pwH" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/obj/structure/machinery/landinglight/ds1/delayone{
-	dir = 8
-	},
-/turf/open/floor/prison{
-	dir = 4;
-	icon_state = "greenfull"
-	},
-/area/lv522/landing_zone_1)
+/area/lv522/landing_zone_1/tunnel/far)
 "pwJ" = (
 /obj/structure/prop/dam/crane/damaged,
 /turf/open/floor/prison{
@@ -39694,12 +39518,10 @@
 /obj/structure/platform_decoration{
 	dir = 4
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "pFw" = (
 /obj/structure/cargo_container/horizontal/blue/middle,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/landing_zone_1)
 "pFF" = (
@@ -39813,7 +39635,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "pHT" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/corsat,
@@ -39967,17 +39789,6 @@
 	},
 /turf/open/floor/corsat,
 /area/lv522/atmos/cargo_intake)
-"pLm" = (
-/obj/structure/platform,
-/obj/structure/platform{
-	dir = 4
-	},
-/obj/structure/platform_decoration{
-	dir = 6
-	},
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/auto_turf/sand_white/layer0,
-/area/lv522/landing_zone_1)
 "pLs" = (
 /obj/structure/barricade/wooden{
 	dir = 4
@@ -40248,7 +40059,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "pQx" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/prison{
@@ -40269,7 +40080,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -40651,7 +40461,7 @@
 "pXv" = (
 /obj/item/prop/alien/hugger,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "pXx" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -40699,7 +40509,6 @@
 /obj/structure/stairs/perspective{
 	icon_state = "p_stair_full"
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "pYu" = (
@@ -40815,10 +40624,9 @@
 	icon_state = "p_stair_full"
 	},
 /turf/open/gm/river,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "qbf" = (
 /obj/structure/cargo_container/horizontal/blue/bottom,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/landing_zone_1)
 "qbi" = (
@@ -41924,7 +41732,7 @@
 "qxf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/strata_outpost,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "qxg" = (
 /obj/structure/surface/table/almayer,
 /obj/item/paper,
@@ -42007,7 +41815,7 @@
 	},
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "qxX" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/decal/cleanable/dirt,
@@ -42264,11 +42072,6 @@
 	icon_state = "marked"
 	},
 /area/lv522/indoors/a_block/bridges/corpo)
-"qCs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
 "qCB" = (
 /obj/structure/surface/rack,
 /obj/item/clothing/shoes/blue{
@@ -42356,7 +42159,6 @@
 	dir = 1;
 	icon_state = "p_stair_full"
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/landing_zone_1)
 "qDw" = (
@@ -42368,7 +42170,6 @@
 	dir = 5;
 	icon_state = "p_stair_full"
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/landing_zone_1)
 "qDL" = (
@@ -42739,7 +42540,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "qLa" = (
 /obj/structure/barricade/wooden{
 	dir = 4
@@ -42764,12 +42565,10 @@
 /area/lv522/outdoors/w_rockies)
 "qLk" = (
 /obj/structure/closet/firecloset/full,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "qLu" = (
 /obj/structure/platform,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement,
 /area/lv522/outdoors/colony_streets/south_west_street)
 "qLy" = (
@@ -42834,13 +42633,6 @@
 	icon_state = "70"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
-"qMJ" = (
-/obj/structure/platform{
-	dir = 8
-	},
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/auto_turf/sand_white/layer0,
-/area/lv522/landing_zone_1)
 "qNg" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
 	name = "\improper Bedroom"
@@ -43043,7 +42835,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "qPT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/space_heater/radiator/red{
@@ -43468,7 +43260,6 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "qWf" = (
@@ -43520,7 +43311,6 @@
 "qXs" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "qXH" = (
@@ -43945,7 +43735,6 @@
 /area/lv522/indoors/a_block/fitness/glass)
 "rcR" = (
 /obj/structure/largecrate/random/barrel/white,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "rcV" = (
@@ -44182,7 +43971,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "rhh" = (
 /obj/structure/bed/chair/wheelchair,
 /obj/effect/decal/cleanable/dirt,
@@ -44405,7 +44194,6 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "rmD" = (
@@ -44485,7 +44273,6 @@
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/north_west_street)
 "rnT" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement12"
 	},
@@ -44707,7 +44494,7 @@
 	},
 /obj/structure/largecrate/random/barrel,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "rsF" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 5
@@ -45060,7 +44847,6 @@
 	dir = 4;
 	icon_state = "p_stair_full"
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/landing_zone_1)
 "ryu" = (
@@ -45121,7 +44907,6 @@
 /area/lv522/outdoors/colony_streets/north_west_street)
 "rzz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -45160,7 +44945,6 @@
 /area/lv522/indoors/a_block/dorms)
 "rAu" = (
 /obj/structure/platform_decoration,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement2"
 	},
@@ -45186,7 +44970,7 @@
 "rAM" = (
 /obj/structure/largecrate/random/case,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "rAX" = (
 /turf/open/floor{
 	dir = 4;
@@ -45356,12 +45140,6 @@
 	icon_state = "51"
 	},
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
-"rFw" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/asphalt/cement{
-	icon_state = "cement4"
-	},
-/area/lv522/outdoors/colony_streets/south_west_street)
 "rFT" = (
 /obj/structure/machinery/landinglight/ds2,
 /turf/open/floor/plating,
@@ -45472,7 +45250,6 @@
 	id = "LZ1_Lockdown_Lo";
 	name = "Emergency Lockdown"
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -45498,12 +45275,6 @@
 	icon_state = "floor_marked"
 	},
 /area/lv522/outdoors/colony_streets/north_east_street)
-"rJv" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/asphalt/cement{
-	icon_state = "cement15"
-	},
-/area/lv522/outdoors/colony_streets/south_west_street)
 "rJB" = (
 /obj/effect/decal/cleanable/blood/xeno{
 	icon_state = "xgib3"
@@ -45829,7 +45600,6 @@
 	dir = 6;
 	layer = 3.51
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement,
 /area/lv522/landing_zone_1)
 "rOD" = (
@@ -45870,13 +45640,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/lv522/indoors/c_block/t_comm)
-"rPQ" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/auto_turf/sand_white/layer0,
-/area/lv522/landing_zone_1)
 "rQd" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /turf/open/floor/prison{
@@ -46034,7 +45797,6 @@
 /area/lv522/indoors/a_block/admin)
 "rSh" = (
 /obj/structure/largecrate/random/barrel/white,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -46302,7 +46064,6 @@
 /obj/structure/platform_decoration{
 	dir = 10
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement,
 /area/lv522/outdoors/colony_streets/south_west_street)
 "rYu" = (
@@ -46440,7 +46201,6 @@
 /area/lv522/oob)
 "saL" = (
 /obj/structure/platform,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement,
 /area/lv522/landing_zone_1)
 "saQ" = (
@@ -46603,7 +46363,6 @@
 /area/lv522/indoors/a_block/dorms)
 "sdN" = (
 /obj/structure/largecrate,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "sdR" = (
@@ -46672,7 +46431,6 @@
 /obj/structure/platform_decoration{
 	dir = 1
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement9"
 	},
@@ -46886,7 +46644,6 @@
 /obj/item/key/cargo_train{
 	icon_state = "keys"
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -47216,10 +46973,6 @@
 	},
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/outdoors/colony_streets/north_street)
-"spj" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/closed/wall/strata_outpost/reinforced,
-/area/lv522/landing_zone_1/tunnel)
 "spm" = (
 /obj/structure/bed/chair/comfy,
 /obj/effect/decal/cleanable/dirt,
@@ -47455,12 +47208,6 @@
 	icon_state = "89"
 	},
 /area/lv522/landing_zone_forecon/UD6_Tornado)
-"std" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/asphalt/cement{
-	icon_state = "cement9"
-	},
-/area/lv522/outdoors/colony_streets/south_west_street)
 "stG" = (
 /obj/structure/pipes/vents/pump,
 /obj/effect/decal/cleanable/dirt,
@@ -47695,7 +47442,6 @@
 /obj/structure/machinery/door/airlock/almayer/generic{
 	dir = 2
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -47728,7 +47474,6 @@
 /obj/structure/platform{
 	dir = 8
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement1"
 	},
@@ -47843,7 +47588,6 @@
 	dir = 9;
 	icon_state = "p_stair_full"
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement3"
 	},
@@ -47862,13 +47606,6 @@
 	icon_state = "darkbrownfull2"
 	},
 /area/lv522/indoors/c_block/mining)
-"sCk" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/obj/structure/machinery/landinglight/ds1{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/lv522/landing_zone_1)
 "sCp" = (
 /turf/closed/shuttle/dropship2/tornado{
 	icon_state = "75"
@@ -48114,7 +47851,7 @@
 	dir = 4
 	},
 /turf/open/gm/river,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "sHk" = (
 /obj/structure/curtain/red,
 /turf/open/floor/corsat{
@@ -48180,7 +47917,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -48902,7 +48638,6 @@
 	id = "LZ1_Lockdown_Lo";
 	name = "Emergency Lockdown"
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -49189,7 +48924,6 @@
 /obj/structure/stairs/perspective{
 	icon_state = "p_stair_full"
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/landing_zone_1)
 "tbl" = (
@@ -49454,7 +49188,6 @@
 	icon_state = "p_stair_full"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement3"
 	},
@@ -49468,7 +49201,6 @@
 "tfl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/railgun_camera_pos,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	icon_state = "floor_plate"
 	},
@@ -49778,7 +49510,7 @@
 	},
 /obj/structure/platform,
 /turf/open/gm/river,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "tlR" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/faxmachine{
@@ -49834,7 +49566,6 @@
 	pixel_x = -1;
 	pixel_y = 1
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -50211,7 +49942,6 @@
 	dir = 1;
 	icon_state = "p_stair_full"
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/landing_zone_1)
 "tue" = (
@@ -51065,7 +50795,6 @@
 /area/lv522/atmos/reactor_garage)
 "tKS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	icon_state = "floor_plate"
 	},
@@ -51155,7 +50884,6 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/dorm_north)
 "tMq" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement2"
 	},
@@ -51166,7 +50894,6 @@
 	dir = 10;
 	icon_state = "p_stair_full"
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement3"
 	},
@@ -51401,7 +51128,7 @@
 	},
 /obj/structure/largecrate/random,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "tRI" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/cameras/wooden_tv{
@@ -51413,7 +51140,6 @@
 	pixel_y = 4
 	},
 /obj/structure/machinery/light,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -51559,7 +51285,6 @@
 /obj/structure/surface/table/almayer,
 /obj/item/trash/plate,
 /obj/item/reagent_container/food/snacks/mushroompizzaslice,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -51586,7 +51311,6 @@
 /area/lv522/atmos/way_in_command_centre)
 "tVj" = (
 /obj/structure/largecrate/random/barrel/white,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "floor_marked"
@@ -51689,7 +51413,7 @@
 	},
 /obj/vehicle/train/cargo/trolley,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "tXd" = (
 /obj/structure/prop/invuln/lattice_prop{
 	dir = 1;
@@ -51727,7 +51451,6 @@
 	},
 /obj/item/prop/alien/hugger,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	icon_state = "floor_plate"
 	},
@@ -51832,13 +51555,6 @@
 	icon_state = "greenfull"
 	},
 /area/lv522/indoors/a_block/fitness)
-"tZM" = (
-/obj/structure/platform{
-	dir = 4
-	},
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/auto_turf/sand_white/layer0,
-/area/lv522/landing_zone_1)
 "tZP" = (
 /obj/item/prop/alien/hugger,
 /obj/effect/decal/cleanable/dirt,
@@ -52204,7 +51920,6 @@
 	pixel_y = 6
 	},
 /obj/structure/machinery/light,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -52556,7 +52271,6 @@
 /obj/structure/platform{
 	dir = 4
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement3"
 	},
@@ -52629,7 +52343,6 @@
 	pixel_x = -8;
 	pixel_y = 4
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -52647,12 +52360,10 @@
 /area/lv522/indoors/c_block/cargo)
 "uol" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison,
 /area/lv522/landing_zone_1/ceiling)
 "uom" = (
 /obj/structure/machinery/disposal,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -52704,7 +52415,6 @@
 	pixel_x = 6;
 	pixel_y = 16
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -52730,7 +52440,6 @@
 /area/lv522/indoors/b_block/hydro)
 "upX" = (
 /obj/structure/machinery/disposal,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/landing_zone_1/ceiling)
 "upZ" = (
@@ -52750,7 +52459,6 @@
 /obj/structure/machinery/power/apc/weak{
 	dir = 1
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "uqo" = (
@@ -52890,7 +52598,6 @@
 	pixel_y = 4
 	},
 /obj/effect/landmark/objective_landmark/close,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -52914,7 +52621,6 @@
 /obj/item/trash/cigbutt{
 	pixel_x = 4
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -52965,7 +52671,6 @@
 /obj/structure/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "uul" = (
@@ -53073,7 +52778,7 @@
 "uwe" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "uwk" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/corsat{
@@ -53211,7 +52916,7 @@
 	},
 /obj/structure/platform,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "uzD" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/prop/almayer/computer/PC{
@@ -53447,7 +53152,6 @@
 	dir = 1
 	},
 /obj/structure/largecrate,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "uEX" = (
@@ -53482,7 +53186,6 @@
 /obj/structure/platform_decoration{
 	dir = 8
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement14"
 	},
@@ -53699,7 +53402,6 @@
 /area/lv522/indoors/c_block/garage)
 "uIF" = (
 /obj/structure/barricade/handrail,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "uIJ" = (
@@ -53729,7 +53431,7 @@
 "uIY" = (
 /obj/structure/platform_decoration,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "uIZ" = (
 /obj/structure/window_frame/strata,
 /obj/item/stack/rods,
@@ -53838,7 +53540,6 @@
 /obj/structure/platform_decoration{
 	dir = 9
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement,
 /area/lv522/landing_zone_1)
 "uLk" = (
@@ -54027,7 +53728,6 @@
 /obj/structure/platform_decoration{
 	dir = 5
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement,
 /area/lv522/outdoors/colony_streets/south_west_street)
 "uOD" = (
@@ -54076,7 +53776,6 @@
 /area/lv522/indoors/c_block/cargo)
 "uPo" = (
 /obj/structure/largecrate/guns/russian,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "floor_marked"
@@ -54245,7 +53944,6 @@
 /obj/structure/platform{
 	dir = 4
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/gm/river,
 /area/lv522/landing_zone_1/tunnel)
 "uSn" = (
@@ -54345,7 +54043,6 @@
 /obj/structure/platform_decoration{
 	dir = 4
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement1"
 	},
@@ -54553,7 +54250,6 @@
 /obj/structure/platform{
 	dir = 8
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/ceiling)
 "uXO" = (
@@ -54691,7 +54387,6 @@
 	},
 /area/lv522/atmos/east_reactor/south)
 "vbu" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison,
 /area/lv522/landing_zone_1/ceiling)
 "vbF" = (
@@ -54848,7 +54543,6 @@
 /obj/structure/platform_decoration{
 	dir = 4
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/ceiling)
 "vdV" = (
@@ -54866,10 +54560,6 @@
 	},
 /turf/open/floor/wood,
 /area/lv522/indoors/c_block/casino)
-"veq" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/auto_turf/shale/layer1,
-/area/lv522/landing_zone_1)
 "ves" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -55186,7 +54876,6 @@
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/dorms)
 "vjC" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/ceiling)
 "vjF" = (
@@ -55542,10 +55231,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/a_block/admin)
-"vqw" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/auto_turf/shale/layer2,
-/area/lv522/landing_zone_1)
 "vqF" = (
 /obj/item/ammo_magazine/rifle/heap{
 	current_rounds = 0
@@ -55672,7 +55357,6 @@
 /area/lv522/indoors/c_block/mining)
 "vso" = (
 /obj/structure/largecrate/random/barrel/yellow,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "floor_marked"
@@ -55759,7 +55443,6 @@
 	},
 /area/lv522/indoors/a_block/kitchen)
 "vtN" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement{
 	icon_state = "cement4"
 	},
@@ -55790,14 +55473,12 @@
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 1
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
 /area/lv522/landing_zone_1/ceiling)
 "vuH" = (
 /obj/structure/largecrate,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "floor_marked"
@@ -56076,7 +55757,6 @@
 	},
 /area/lv522/atmos/east_reactor)
 "vAW" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "floor_marked"
@@ -56119,7 +55799,6 @@
 /obj/structure/platform_decoration{
 	dir = 9
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/gm/river,
 /area/lv522/landing_zone_1/tunnel)
 "vBx" = (
@@ -56223,7 +55902,6 @@
 	pixel_y = 19;
 	serial_number = 16
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/landing_zone_1/ceiling)
 "vCG" = (
@@ -56410,7 +56088,6 @@
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/central_streets)
 "vGo" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/asphalt/cement,
 /area/lv522/landing_zone_1)
 "vGp" = (
@@ -56862,8 +56539,6 @@
 	id = "LZ1_Lockdown_Lo";
 	name = "Emergency Lockdown"
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -57176,11 +56851,9 @@
 "vTQ" = (
 /obj/structure/barricade/handrail,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "vTT" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/corsat{
 	icon_state = "marked"
 	},
@@ -57250,7 +56923,6 @@
 /area/lv522/indoors/a_block/admin)
 "vUX" = (
 /obj/structure/powerloader_wreckage/ft,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	icon_state = "floor_plate"
 	},
@@ -57278,7 +56950,6 @@
 /area/lv522/indoors/a_block/kitchen)
 "vVi" = (
 /obj/structure/largecrate,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -57426,7 +57097,6 @@
 /obj/structure/machinery/computer/cameras/wooden_tv{
 	pixel_y = 6
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "vZm" = (
@@ -57458,7 +57128,6 @@
 /area/lv522/indoors/toilet)
 "vZv" = (
 /obj/structure/cargo_container/kelland/left,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -57519,7 +57188,6 @@
 	dir = 4
 	},
 /obj/structure/largecrate,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "waD" = (
@@ -57695,7 +57363,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/largecrate/random/case,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "wdd" = (
 /obj/item/stack/sheet/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -57724,7 +57392,6 @@
 /area/lv522/outdoors/colony_streets/central_streets)
 "wdI" = (
 /obj/structure/cargo_container/kelland/right,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "floor_marked"
@@ -57860,7 +57527,7 @@
 	icon_state = "p_stair_full"
 	},
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "wfE" = (
 /obj/structure/stairs/perspective{
 	dir = 4;
@@ -58174,7 +57841,6 @@
 /area/lv522/indoors/c_block/cargo)
 "wlY" = (
 /obj/structure/largecrate/random/secure,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "floor_marked"
@@ -58226,7 +57892,6 @@
 /obj/structure/machinery/space_heater/radiator/red{
 	dir = 4
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -59246,7 +58911,6 @@
 	},
 /obj/item/clothing/head/hardhat/white,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -59431,7 +59095,7 @@
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "wLN" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/food/drinks/coffee,
@@ -60197,7 +59861,6 @@
 	pixel_x = -13;
 	pixel_y = 2
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -60674,7 +60337,6 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	icon_state = "floor_plate"
 	},
@@ -60907,7 +60569,7 @@
 /obj/structure/largecrate/random/barrel,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "xtb" = (
 /turf/closed/wall/strata_outpost,
 /area/lv522/indoors/a_block/fitness)
@@ -61204,7 +60866,6 @@
 	pixel_y = 9
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -61642,7 +61303,6 @@
 "xIK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/largecrate,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
 "xIW" = (
@@ -62346,7 +62006,7 @@
 	dir = 8
 	},
 /turf/open/gm/river,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 "xVI" = (
 /obj/effect/spawner/gibspawner/xeno,
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -62560,11 +62220,6 @@
 	icon_state = "plate"
 	},
 /area/lv522/atmos/cargo_intake)
-"xZN" = (
-/obj/structure/largecrate/random/secure,
-/obj/effect/landmark/lv624/fog_blocker/short,
-/turf/open/floor/plating,
-/area/lv522/landing_zone_1/tunnel)
 "xZP" = (
 /obj/structure/stairs/perspective{
 	dir = 1;
@@ -63013,7 +62668,6 @@
 	},
 /area/lv522/outdoors/colony_streets/south_street)
 "yhU" = (
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	icon_state = "floor_plate"
 	},
@@ -63255,7 +62909,6 @@
 	pixel_x = -7
 	},
 /obj/effect/landmark/objective_landmark/close,
-/obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison{
 	dir = 4;
 	icon_state = "greenfull"
@@ -63310,7 +62963,7 @@
 "ymf" = (
 /obj/structure/platform_decoration,
 /turf/open/gm/river,
-/area/lv522/landing_zone_1/tunnel)
+/area/lv522/landing_zone_1/tunnel/far)
 
 (1,1,1) = {"
 bMX
@@ -64403,7 +64056,7 @@ nGe
 pez
 pFw
 qbf
-lBl
+pxb
 paT
 pxb
 pxb
@@ -64627,11 +64280,11 @@ cpy
 cpy
 oyY
 paT
-lBl
-lBl
-lBl
-lBl
-lBl
+pxb
+pxb
+pxb
+pxb
+pxb
 pxb
 nQz
 tPf
@@ -64853,12 +64506,12 @@ cpy
 cpy
 cpy
 hTW
-lBl
-vqw
-lBl
-lBl
-lBl
-oYM
+pxb
+xqp
+pxb
+pxb
+pxb
+nQz
 tPf
 oKc
 uZc
@@ -65079,13 +64732,13 @@ cpy
 cpy
 cpy
 nGe
-veq
-veq
-vqw
-vqw
-vqw
-oYM
-pLm
+pwa
+pwa
+xqp
+xqp
+xqp
+nQz
+oKc
 ryU
 ryU
 ryU
@@ -65306,12 +64959,12 @@ cpy
 cpy
 cpy
 nGJ
-veq
-veq
-lBl
-oYM
-tZM
-pLm
+pwa
+pwa
+pxb
+nQz
+tPf
+oKc
 ryU
 ryU
 uiM
@@ -65533,10 +65186,10 @@ cpy
 cpy
 cpy
 nMc
-lBl
-oYM
-tZM
-pLm
+pxb
+nQz
+tPf
+oKc
 ryU
 ryU
 ryU
@@ -65759,11 +65412,11 @@ cpy
 cpy
 cpy
 lJq
-lBl
-oYM
-pLm
-pkH
-pkH
+pxb
+nQz
+oKc
+ryU
+ryU
 ryU
 wuK
 xfW
@@ -65986,11 +65639,11 @@ cpy
 cpy
 cpy
 lJq
-oYM
-pLm
-pkH
-pvd
-nhi
+nQz
+oKc
+ryU
+rhk
+uTd
 oyf
 tns
 fOc
@@ -66212,9 +65865,9 @@ cpy
 cpy
 cpy
 cpy
-veq
+pwa
 lWj
-cpU
+uZc
 fSo
 nFj
 pRg
@@ -66439,9 +66092,9 @@ tFx
 tFx
 tFx
 niA
-veq
+pwa
 oiC
-pkH
+ryU
 naS
 nFj
 nFj
@@ -66666,9 +66319,9 @@ wnP
 evg
 syM
 rnT
-lBl
+pxb
 ttT
-pkH
+ryU
 haf
 nFj
 nFj
@@ -66893,9 +66546,9 @@ mvP
 ggS
 tFx
 rnT
-lBl
+pxb
 ttT
-pkH
+ryU
 das
 sYH
 sYH
@@ -67118,11 +66771,11 @@ tFx
 moI
 mxD
 uom
-kWp
+ymc
 rnT
-lBl
+pxb
 ttT
-pkH
+ryU
 eyy
 sYH
 sYH
@@ -67158,11 +66811,11 @@ cpy
 eYM
 eYM
 eYM
-fxZ
-fxZ
-fxZ
+wfP
+wfP
+wfP
 eYM
-nvV
+sRM
 eYM
 eYM
 cpy
@@ -67345,11 +66998,11 @@ tFx
 inm
 myQ
 myZ
-kWp
+ymc
 rnT
-lBl
+pxb
 ttT
-pkH
+ryU
 naS
 sYH
 sYH
@@ -67385,12 +67038,12 @@ eYM
 eYM
 uqe
 pNa
-fxZ
-fxZ
-fxZ
+wfP
+wfP
+wfP
 pNa
-nvV
-ait
+sRM
+hTe
 eYM
 cpy
 cpy
@@ -67574,9 +67227,9 @@ rIM
 rIM
 tFx
 rnT
-lBl
+pxb
 ttT
-pkH
+ryU
 haf
 sYH
 sYH
@@ -67609,15 +67262,15 @@ pxb
 cpy
 eYM
 eYM
-qCs
-fxZ
+jJF
+wfP
 eYM
-fxZ
-fxZ
-fxZ
+wfP
+wfP
+wfP
 eYM
-nvV
-ait
+sRM
+hTe
 eYM
 cpy
 cpy
@@ -67796,14 +67449,14 @@ qJy
 aRN
 ien
 mmw
-fbh
-fbh
-fHB
+veQ
+veQ
+fnA
 sSQ
 rnT
-lBl
+pxb
 ttT
-pkH
+ryU
 das
 sYH
 sYH
@@ -67836,15 +67489,15 @@ pxb
 cpy
 eYM
 hUM
-qCs
-fxZ
+jJF
+wfP
 eYM
-fxZ
-fxZ
-fxZ
+wfP
+wfP
+wfP
 eYM
-nvV
-ait
+sRM
+hTe
 eYM
 cpy
 cpy
@@ -68025,12 +67678,12 @@ tZh
 ofi
 ofi
 max
-rFw
+osN
 sSQ
 rnT
-lBl
+pxb
 ttT
-pkH
+ryU
 eyy
 nFj
 nFj
@@ -68063,15 +67716,15 @@ cpy
 cpy
 eYM
 vYY
-fxZ
-fxZ
+wfP
+wfP
 eYM
-qCs
-fxZ
-fxZ
+jJF
+wfP
+wfP
 eYM
-nvV
-ait
+sRM
+hTe
 eYM
 cpy
 cpy
@@ -68252,12 +67905,12 @@ hpq
 tZh
 ofi
 max
-rFw
+osN
 sSQ
 rnT
-lBl
+pxb
 jPg
-pkH
+ryU
 naS
 nFj
 nFj
@@ -68291,14 +67944,14 @@ cpy
 eYM
 ofX
 rmC
-fxZ
+wfP
 eYM
-qCs
-fxZ
-fxZ
+jJF
+wfP
+wfP
 eYM
-nvV
-ait
+sRM
+hTe
 eYM
 cpy
 cpy
@@ -68482,9 +68135,9 @@ max
 ien
 ien
 ien
-lBl
+pxb
 lWj
-cpU
+uZc
 fBL
 nFj
 pRg
@@ -68518,14 +68171,14 @@ cpy
 eYM
 fLM
 rmC
-fxZ
+wfP
 eYM
-qCs
-fxZ
-fxZ
+jJF
+wfP
+wfP
 eYM
-nvV
-ait
+sRM
+hTe
 eYM
 cpy
 cpy
@@ -68706,15 +68359,15 @@ hpq
 ofi
 ofi
 max
-rFw
+osN
 sSQ
 rnT
-lBl
+pxb
 lgY
 oKG
-pkH
-pwH
-sCk
+ryU
+uEH
+vJj
 jIk
 aGS
 dhP
@@ -68745,14 +68398,14 @@ cpy
 eYM
 eYM
 ivb
-fxZ
+wfP
 eYM
-fxZ
-fxZ
-fxZ
+wfP
+wfP
+wfP
 eYM
-nvV
-ait
+sRM
+hTe
 eYM
 cpy
 cpy
@@ -68933,15 +68586,15 @@ gpB
 ofi
 ofi
 max
-rFw
+osN
 sSQ
 rnT
-lBl
-lBl
+pxb
+pxb
 lgY
 oKG
-pkH
-pkH
+ryU
+ryU
 ryU
 tgq
 qcO
@@ -68971,15 +68624,15 @@ pxb
 cpy
 eYM
 exQ
-fxZ
-fxZ
+wfP
+wfP
 eYM
-fxZ
-fxZ
-fxZ
+wfP
+wfP
+wfP
 eYM
-nvV
-ait
+sRM
+hTe
 eYM
 eYM
 cpy
@@ -69163,11 +68816,11 @@ max
 ien
 ien
 ien
-veq
-lBl
-lBl
+pwa
+pxb
+pxb
 lgY
-qMJ
+udi
 oKG
 ryU
 ryU
@@ -69198,16 +68851,16 @@ cpy
 cpy
 eYM
 eYM
-fxZ
-fxZ
+wfP
+wfP
 eYM
-fxZ
-fxZ
-fxZ
+wfP
+wfP
+wfP
 eYM
-nvV
-ait
-ait
+sRM
+hTe
+hTe
 eYM
 cpy
 cpy
@@ -69387,16 +69040,16 @@ hpq
 ofi
 tZh
 max
-rFw
+osN
 sSQ
 rnT
-veq
-veq
-lBl
-lBl
-lBl
+pwa
+pwa
+pxb
+pxb
+pxb
 lgY
-qMJ
+udi
 oKG
 ryU
 ryU
@@ -69425,16 +69078,16 @@ cpy
 cpy
 eYM
 jxF
-fxZ
-xZN
+wfP
+mzi
 eYM
-fxZ
-fxZ
+wfP
+wfP
 nxF
 eYM
-nvV
-ait
-ait
+sRM
+hTe
+hTe
 eYM
 cpy
 cpy
@@ -69614,16 +69267,16 @@ hpq
 ofi
 max
 max
-rFw
+osN
 sSQ
 rnT
-veq
-veq
-veq
-lBl
-lBl
-lBl
-lBl
+pwa
+pwa
+pwa
+pxb
+pxb
+pxb
+pxb
 lgY
 oKG
 ryU
@@ -69656,12 +69309,12 @@ jCh
 eYM
 eYM
 ivb
-fxZ
-fxZ
+wfP
+wfP
 eYM
 vBm
-cHY
-ait
+qxk
+hTe
 eYM
 cpy
 cpy
@@ -69841,7 +69494,7 @@ hpq
 max
 max
 max
-rFw
+osN
 sSQ
 vGo
 jZD
@@ -69849,11 +69502,11 @@ jZD
 jZD
 jZD
 oiY
-lBl
-lBl
-lBl
+pxb
+pxb
+pxb
 lgY
-qMJ
+udi
 oKG
 uZc
 ryU
@@ -69878,17 +69531,17 @@ pxb
 cpy
 eYM
 eYM
-fxZ
-fxZ
-fxZ
+wfP
+wfP
+wfP
 eYM
-fxZ
-fxZ
-qCs
+wfP
+wfP
+jJF
 eYM
 eYM
-nvV
-ait
+sRM
+hTe
 eYM
 cpy
 cpy
@@ -70068,54 +69721,54 @@ hpq
 max
 max
 max
-rFw
+osN
 tFx
-kWp
+ymc
 tFx
 tFx
-kWp
+ymc
 tFx
 rnT
-lBl
-lBl
-lBl
-lBl
-lBl
+pxb
+pxb
+pxb
+pxb
+pxb
 lgY
-qMJ
+udi
 qDt
-pkH
-pkH
-pkH
+ryU
+ryU
+ryU
 taW
-qMJ
-rPQ
-lBl
-lBl
-lBl
-lBl
-lBl
-lBl
-veq
-veq
-veq
-vqw
-vqw
+udi
+gVn
+pxb
+pxb
+pxb
+pxb
+pxb
+pxb
+pwa
+pwa
+pwa
+xqp
+xqp
 cpy
 cpy
 eYM
 mMX
-fxZ
-fxZ
-fxZ
+wfP
+wfP
+wfP
 eYM
-fxZ
-fxZ
-qCs
+wfP
+wfP
+jJF
 xIK
 eYM
-nvV
-ait
+sRM
+hTe
 eYM
 cpy
 cpy
@@ -70295,54 +69948,54 @@ xVV
 max
 max
 ofi
-rFw
+osN
 aFf
 wHo
 xzp
 ojb
 uom
-kWp
+ymc
 rnT
-lBl
-lBl
-lBl
-veq
-veq
-lBl
-lBl
+pxb
+pxb
+pxb
+pwa
+pwa
+pxb
+pxb
 qDD
 rys
 rys
 rys
 jYK
-lBl
-lBl
-lBl
-lBl
-veq
-veq
-lBl
-veq
-veq
-veq
-lBl
-vqw
-vqw
+pxb
+pxb
+pxb
+pxb
+pwa
+pwa
+pxb
+pwa
+pwa
+pwa
+pxb
+xqp
+xqp
 cpy
 cpy
 eYM
 mMX
-fxZ
-fxZ
-fxZ
+wfP
+wfP
+wfP
 eYM
-fxZ
-fxZ
-fxZ
-qCs
+wfP
+wfP
+wfP
+jJF
 eYM
-nvV
-ait
+sRM
+hTe
 eYM
 cpy
 cpy
@@ -70522,54 +70175,54 @@ max
 max
 max
 ofi
-rFw
-kZJ
+osN
+aFf
 ggS
 uol
 uol
 rzz
-kWp
+ymc
 rnT
-lBl
-lBl
-veq
-veq
-veq
-veq
-veq
-veq
-lBl
-lBl
-lBl
-lBl
-lBl
-lBl
-lBl
-veq
-veq
-veq
-veq
-veq
-veq
-lBl
-lBl
-veq
-vqw
+pxb
+pxb
+pwa
+pwa
+pwa
+pwa
+pwa
+pwa
+pxb
+pxb
+pxb
+pxb
+pxb
+pxb
+pxb
+pwa
+pwa
+pwa
+pwa
+pwa
+pwa
+pxb
+pxb
+pwa
+xqp
 cpy
 cpy
 eYM
 oBw
-fxZ
-fxZ
-fxZ
+wfP
+wfP
+wfP
 eYM
-xZN
-fxZ
-fxZ
-qCs
+mzi
+wfP
+wfP
+jJF
 eYM
-nvV
-ait
+sRM
+hTe
 eYM
 cpy
 cpy
@@ -70749,7 +70402,7 @@ max
 max
 max
 ofi
-rFw
+osN
 kPJ
 ggS
 nEq
@@ -70757,46 +70410,46 @@ nEq
 rzz
 syM
 rnT
-lBl
-veq
-veq
-veq
-vqw
-veq
-veq
-veq
-veq
-veq
-veq
-veq
-lBl
-lBl
-veq
-veq
-veq
-veq
-veq
-veq
-lBl
-lBl
-lBl
-lBl
-lBl
+pxb
+pwa
+pwa
+pwa
+xqp
+pwa
+pwa
+pwa
+pwa
+pwa
+pwa
+pwa
+pxb
+pxb
+pwa
+pwa
+pwa
+pwa
+pwa
+pwa
+pxb
+pxb
+pxb
+pxb
+pxb
 cpy
 cpy
 eYM
 sdN
-fxZ
-fxZ
-qCs
+wfP
+wfP
+jJF
 eYM
 xIK
-fxZ
-fxZ
+wfP
+wfP
 rcR
 eYM
-nvV
-ait
+sRM
+hTe
 eYM
 cpy
 cpy
@@ -70976,31 +70629,31 @@ max
 max
 ofi
 tZh
-rFw
+osN
 aFf
 lJU
 uol
 vbu
 oPR
-kWp
+ymc
 rnT
-veq
-veq
-veq
-lBl
-vqw
-vqw
-veq
-veq
-vqw
-vqw
-vqw
-veq
-veq
-veq
-veq
-veq
-veq
+pwa
+pwa
+pwa
+pxb
+xqp
+xqp
+pwa
+pwa
+xqp
+xqp
+xqp
+pwa
+pwa
+pwa
+pwa
+pwa
+pwa
 tMq
 jZD
 jZD
@@ -71013,17 +70666,17 @@ cpy
 cpy
 eYM
 kbo
-fxZ
-qCs
-qCs
+wfP
+jJF
+jJF
 eYM
 xIK
-qCs
-fxZ
+jJF
+wfP
 rcR
 eYM
-nvV
-ait
+sRM
+hTe
 eYM
 cpy
 cpy
@@ -71203,22 +70856,22 @@ max
 max
 ofi
 tZh
-rFw
+osN
 aFf
 xdn
 rzz
 omG
 oRS
-kWp
+ymc
 rnT
-veq
-veq
-lBl
+pwa
+pwa
+pxb
 cpy
-lBl
-lBl
-lBl
-veq
+pxb
+pxb
+pxb
+pwa
 rAu
 umK
 sCb
@@ -71226,8 +70879,8 @@ tfb
 tMt
 umK
 uFp
-veq
-veq
+pwa
+pwa
 vtN
 tFx
 tFx
@@ -71240,17 +70893,17 @@ cpy
 cpy
 eYM
 ikb
-fxZ
-qCs
+wfP
+jJF
 eYM
 eYM
 eYM
 ntT
-fxZ
-fxZ
+wfP
+wfP
 eYM
-nvV
-ait
+sRM
+hTe
 eYM
 cpy
 cpy
@@ -71429,22 +71082,22 @@ max
 max
 max
 tZh
-fPt
-fHB
+pAj
+fnA
 tFx
-kWp
-pid
-kWp
+ymc
+xXO
+ymc
 tFx
 tFx
 rnT
-lBl
-lBl
+pxb
+pxb
 cpy
 cpy
-lBl
-lBl
-lBl
+pxb
+pxb
+pxb
 rAu
 rOw
 tFx
@@ -71476,8 +71129,8 @@ eYM
 jCh
 eYM
 eYM
-nvV
-ait
+sRM
+hTe
 eYM
 cpy
 cpy
@@ -71656,7 +71309,7 @@ cxv
 max
 max
 tZh
-rFw
+osN
 tFx
 tFx
 eiP
@@ -71665,13 +71318,13 @@ jQC
 tFx
 tFx
 rnT
-lBl
-lBl
-lBl
-lBl
-lBl
-lBl
-veq
+pxb
+pxb
+pxb
+pxb
+pxb
+pxb
+pwa
 gej
 tFx
 tFx
@@ -71693,17 +71346,17 @@ tFx
 eYM
 uEV
 sdN
-fxZ
-qCs
-qCs
+wfP
+jJF
+jJF
 eYM
 eYM
 eYM
 nSq
-fxZ
-qCs
+wfP
+jJF
 vTQ
-nvV
+sRM
 eYM
 eYM
 cpy
@@ -71883,22 +71536,22 @@ kmq
 cxv
 max
 max
-rFw
+osN
 aFf
 mFm
 nnv
 vbu
 vbu
 rzz
-kWp
+ymc
 rnT
-lBl
-lBl
-lBl
-lBl
-lBl
-lBl
-veq
+pxb
+pxb
+pxb
+pxb
+pxb
+pxb
+pwa
 gej
 tFx
 ykU
@@ -71919,18 +71572,18 @@ ggS
 tFx
 eZW
 pET
-fxZ
-fxZ
-fxZ
-qCs
+wfP
+wfP
+wfP
+jJF
 xIK
 eYM
 qXs
-qCs
-fxZ
-fxZ
+jJF
+wfP
+wfP
 vTQ
-nvV
+sRM
 eYM
 cpy
 cpy
@@ -72110,7 +71763,7 @@ mBF
 hpq
 max
 max
-rFw
+osN
 aFf
 mOf
 nnW
@@ -72119,13 +71772,13 @@ uol
 rzz
 syM
 rnT
-lBl
-lBl
-lBl
-lBl
-lBl
-veq
-veq
+pxb
+pxb
+pxb
+pxb
+pxb
+pwa
+pwa
 gej
 ymc
 gQy
@@ -72145,19 +71798,19 @@ ggS
 rSh
 vNW
 pYj
-fxZ
-fxZ
-fxZ
-fxZ
-fxZ
+wfP
+wfP
+wfP
+wfP
+wfP
 waz
 eYM
 qLk
-fxZ
-fxZ
-fxZ
+wfP
+wfP
+wfP
 uIF
-nvV
+sRM
 eYM
 cpy
 cpy
@@ -72337,14 +71990,14 @@ kbS
 hpq
 max
 max
-rFw
+osN
 aFf
 mOP
 nsr
 uol
 uol
 oVK
-kWp
+ymc
 vGo
 jZD
 ien
@@ -72371,20 +72024,20 @@ nEq
 ggS
 tVj
 tFx
-eTu
+cLB
 kZq
-qCs
+jJF
 qVQ
-qCs
+jJF
 xIK
 eYM
 eYM
 epN
-fxZ
-qCs
-qCs
+wfP
+jJF
+jJF
 uIF
-nvV
+sRM
 eYM
 cpy
 cpy
@@ -72564,7 +72217,7 @@ fnA
 dPP
 max
 max
-rFw
+osN
 tFx
 tFx
 nuU
@@ -72607,11 +72260,11 @@ eYM
 eYM
 eYM
 epN
-fxZ
-fxZ
-fxZ
+wfP
+wfP
+wfP
 vTQ
-nvV
+sRM
 eYM
 cpy
 cpy
@@ -72791,22 +72444,22 @@ mBF
 hpq
 max
 max
-std
-fHB
+gMQ
+fnA
 tFx
 rIM
 rIM
 rIM
 tFx
-fHB
-fbh
-fbh
+fnA
+veQ
+veQ
 ien
-fbh
-fbh
-fbh
+veQ
+veQ
+veQ
 ien
-fbh
+veQ
 qLu
 aFf
 fDF
@@ -72825,25 +72478,25 @@ vAW
 tVj
 tFx
 tFx
-pjl
-pjl
-pjl
-pjl
-pjl
-pjl
-pjl
+cpy
+cpy
+cpy
+cpy
+cpy
+cpy
+cpy
 eYM
 eYM
-qCs
+jJF
 gXb
-qCs
-qCs
+jJF
+jJF
 eYM
 eYM
-pjl
-pjl
-pjl
-pjl
+cpy
+cpy
+cpy
+cpy
 bMX
 "}
 (43,1,1) = {"
@@ -73019,13 +72672,13 @@ hpq
 max
 max
 max
-std
-fbh
-fbh
-fbh
-fbh
-fbh
-rJv
+gMQ
+veQ
+veQ
+veQ
+veQ
+veQ
+xVV
 ofi
 max
 max
@@ -73051,23 +72704,23 @@ tFx
 tFx
 tFx
 tFx
-pjl
-pjl
 cpy
 cpy
 cpy
 cpy
 cpy
-pjl
-pjl
-spj
+cpy
+cpy
+cpy
+cpy
+eYM
 eYM
 eYM
 oWK
 eYM
 eYM
-pjl
-pjl
+cpy
+cpy
 cpy
 cpy
 cpy
@@ -73270,16 +72923,16 @@ ufS
 tFx
 tFx
 cpy
-fHB
-fbh
-fbh
-fbh
-fbh
-fbh
-fbh
-fbh
-fbh
-fHB
+fnA
+veQ
+veQ
+veQ
+veQ
+veQ
+veQ
+veQ
+veQ
+fnA
 cpy
 cpy
 cpy
@@ -73287,13 +72940,13 @@ cpy
 cpy
 cpy
 cpy
-pjl
-spj
+cpy
+eYM
 iIa
 drd
 uug
-spj
-pjl
+eYM
+cpy
 cpy
 cpy
 cpy
@@ -73517,7 +73170,7 @@ bPJ
 bPJ
 bPJ
 aue
-wfP
+nZP
 dnO
 bPJ
 bPJ
@@ -73745,7 +73398,7 @@ jba
 bPJ
 edi
 pXv
-wfP
+nZP
 pQq
 nVr
 bPJ
@@ -73966,14 +73619,14 @@ ofi
 osN
 aQH
 qaT
-hTe
-hTe
+eSW
+eSW
 jFl
 aQH
 mJs
 czE
-wfP
-wfP
+nZP
+nZP
 wcY
 bPJ
 bPJ
@@ -74193,15 +73846,15 @@ ofi
 osN
 bPJ
 fYD
-qxk
+orA
 ymf
 sHd
 bPJ
 eeb
-wfP
+nZP
 ixV
-wfP
-wfP
+nZP
+nZP
 uwe
 bPJ
 bPJ
@@ -74426,11 +74079,11 @@ bPJ
 bPJ
 bPJ
 rAM
-wfP
-wfP
-wfP
-wfP
-sRM
+nZP
+nZP
+nZP
+nZP
+hHe
 bPJ
 cpy
 bMX
@@ -74653,11 +74306,11 @@ cpy
 bPJ
 bPJ
 qxf
-wfP
-wfP
-wfP
+nZP
+nZP
+nZP
 pXv
-sRM
+hHe
 bPJ
 cpy
 bMX
@@ -74880,10 +74533,10 @@ cpy
 cpy
 bPJ
 evu
-wfP
-wfP
-wfP
-jJF
+nZP
+nZP
+nZP
+enB
 hiL
 bPJ
 cpy
@@ -75108,10 +74761,10 @@ cpy
 bPJ
 bPJ
 gfs
-wfP
-wfP
+nZP
+nZP
 gWc
-wfP
+nZP
 bPJ
 cpy
 bMX
@@ -75562,9 +75215,9 @@ cpy
 cpy
 cpy
 bPJ
-wfP
-wfP
-wfP
+nZP
+nZP
+nZP
 iGD
 bPJ
 cpy
@@ -75790,7 +75443,7 @@ cpy
 cpy
 bPJ
 bPJ
-wfP
+nZP
 ixV
 bPJ
 bPJ
@@ -76017,8 +75670,8 @@ cpy
 cpy
 cpy
 bPJ
-wfP
-wfP
+nZP
+nZP
 ixV
 bPJ
 cpy
@@ -76245,7 +75898,7 @@ cpy
 cpy
 bPJ
 ica
-wfP
+nZP
 fvn
 bPJ
 cpy
@@ -76472,8 +76125,8 @@ bPJ
 bPJ
 bPJ
 qKV
-jJF
-sRM
+enB
+hHe
 bPJ
 cpy
 bMX
@@ -76699,8 +76352,8 @@ fnA
 bPJ
 bPJ
 fCb
-jJF
-sRM
+enB
+hHe
 bPJ
 cpy
 bMX
@@ -76926,7 +76579,7 @@ osN
 bPJ
 oeN
 rgS
-wfP
+nZP
 hiL
 bPJ
 cpy
@@ -77153,8 +76806,8 @@ osN
 bPJ
 tXc
 fJr
-wfP
-wfP
+nZP
+nZP
 bPJ
 cpy
 bMX
@@ -77380,7 +77033,7 @@ osN
 aQH
 euT
 fJr
-wfP
+nZP
 bPJ
 bPJ
 cpy
@@ -77605,9 +77258,9 @@ max
 max
 osN
 bPJ
-cLB
+kHW
 cJF
-wfP
+nZP
 gkH
 bPJ
 cpy
@@ -77834,7 +77487,7 @@ fnA
 bPJ
 bPJ
 aRB
-jJF
+enB
 bPJ
 bPJ
 cpy
@@ -78061,8 +77714,8 @@ bPJ
 bPJ
 bPJ
 bLA
-jJF
-wfP
+enB
+nZP
 bPJ
 cpy
 bMX
@@ -78287,8 +77940,8 @@ fnA
 cpy
 cpy
 bPJ
-wfP
-jJF
+nZP
+enB
 fvn
 bPJ
 cpy
@@ -78514,9 +78167,9 @@ cpy
 cpy
 cpy
 bPJ
-wfP
+nZP
 uwe
-sRM
+hHe
 bPJ
 cpy
 bMX
@@ -78741,9 +78394,9 @@ wIr
 cpy
 bPJ
 bPJ
-wfP
-wfP
-sRM
+nZP
+nZP
+hHe
 bPJ
 cpy
 bMX
@@ -78968,8 +78621,8 @@ wIr
 wIr
 bPJ
 xsN
-wfP
-wfP
+nZP
+nZP
 bPJ
 bPJ
 cpy
@@ -79196,7 +78849,7 @@ wIr
 wIr
 nRY
 uwe
-wfP
+nZP
 bPJ
 cpy
 cpy
@@ -79423,7 +79076,7 @@ lBd
 wIr
 guh
 bQA
-wfP
+nZP
 bPJ
 cpy
 cpy
@@ -79649,7 +79302,7 @@ hhI
 hLx
 wIr
 oox
-mzi
+mlv
 pXv
 bPJ
 cpy
@@ -80104,7 +79757,7 @@ pfq
 wIr
 rsD
 bQA
-wfP
+nZP
 bPJ
 cpy
 cpy
@@ -80329,9 +79982,9 @@ aPu
 mOJ
 wIr
 wIr
-mzi
-wfP
-jJF
+mlv
+nZP
+enB
 bPJ
 cpy
 cpy
@@ -80556,9 +80209,9 @@ vDL
 wIr
 wIr
 evu
-wfP
-jJF
-jJF
+nZP
+enB
+enB
 bPJ
 cpy
 cpy
@@ -80783,8 +80436,8 @@ wIr
 wIr
 qxf
 qxf
-wfP
-jJF
+nZP
+enB
 bPJ
 bPJ
 cpy
@@ -81009,9 +80662,9 @@ vLI
 wIr
 bPJ
 wLw
-wfP
-wfP
-wfP
+nZP
+nZP
+nZP
 bPJ
 cpy
 cpy
@@ -81236,9 +80889,9 @@ tOo
 bPJ
 bPJ
 fZo
-wfP
-wfP
-wfP
+nZP
+nZP
+nZP
 bPJ
 cpy
 cpy
@@ -81463,9 +81116,9 @@ mnb
 ouj
 bPJ
 pdp
-wfP
-wfP
-wfP
+nZP
+nZP
+nZP
 bPJ
 cpy
 cpy
@@ -81690,9 +81343,9 @@ mnb
 gmu
 nYU
 geT
-wfP
-jJF
-jJF
+nZP
+enB
+enB
 bPJ
 cpy
 cpy
@@ -81917,8 +81570,8 @@ mnb
 gmu
 bPJ
 tlB
-wfP
-jJF
+nZP
+enB
 bPJ
 bPJ
 cpy
@@ -82144,8 +81797,8 @@ mnb
 eDq
 bPJ
 gJr
-wfP
-wfP
+nZP
+nZP
 bPJ
 cpy
 cpy
@@ -82371,7 +82024,7 @@ tOo
 bPJ
 bPJ
 pHi
-wfP
+nZP
 uIY
 bPJ
 cpy

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -17330,10 +17330,6 @@
 /obj/structure/flora/jungle/vines/heavy,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/south_west_jungle)
-"kxo" = (
-/obj/effect/landmark/monkey_spawn,
-/turf/open/gm/grass/grass1,
-/area/lv624/lazarus/landing_zones/lz2)
 "kxv" = (
 /obj/effect/decal/grass_overlay/grass1/inner{
 	dir = 1
@@ -22591,6 +22587,10 @@
 	},
 /turf/open/gm/grass/grass1,
 /area/lv624/lazarus/landing_zones/lz1)
+"tLe" = (
+/obj/effect/landmark/monkey_spawn,
+/turf/open/gm/grass/grass1,
+/area/lv624/ground/jungle/north_west_jungle)
 "tLQ" = (
 /obj/structure/flora/bush/ausbushes/genericbush,
 /turf/open/gm/grass/grass1,
@@ -30912,7 +30912,7 @@ avo
 aFQ
 xTM
 aAl
-aDv
+aAl
 aAp
 aAp
 nmO
@@ -31140,7 +31140,7 @@ auf
 aFm
 aAl
 wXg
-aDv
+aAl
 aAp
 nmO
 aXX
@@ -31368,7 +31368,7 @@ auf
 aFm
 aAl
 aAl
-aDv
+aAl
 aAp
 aXX
 aRG
@@ -32507,7 +32507,7 @@ tka
 lCG
 cDQ
 oTJ
-nuW
+aAp
 aAp
 cIL
 nmO
@@ -33191,7 +33191,7 @@ oTJ
 oTJ
 oTJ
 oTJ
-nuW
+aAp
 aAp
 nmO
 aXX
@@ -35709,7 +35709,7 @@ aDv
 aDv
 aRx
 aXX
-kxo
+aXX
 aXX
 aXX
 aXX
@@ -38432,7 +38432,7 @@ nuW
 psh
 psh
 psh
-psh
+tLe
 psh
 tLQ
 ado

--- a/maps/map_files/New_Varadero/New_Varadero.dmm
+++ b/maps/map_files/New_Varadero/New_Varadero.dmm
@@ -430,6 +430,21 @@
 /obj/structure/flora/bush/ausbushes/var3/fullgrass,
 /turf/open/auto_turf/sand_white/layer1,
 /area/varadero/interior/maintenance/security)
+"apt" = (
+/obj/structure/platform/kutjevo/smooth{
+	climb_delay = 1;
+	layer = 2.99
+	},
+/obj/structure/platform/kutjevo/smooth{
+	dir = 8;
+	climb_delay = 1;
+	layer = 2.99
+	},
+/turf/open/gm/river{
+	name = "shallow ocean";
+	default_name = "shallow ocean"
+	},
+/area/varadero/exterior/pontoon_beach/lz)
 "apG" = (
 /obj/structure/blocker/invisible_wall/water,
 /obj/item/lightstick/variant/planted,
@@ -834,6 +849,23 @@
 	icon_state = "floor3"
 	},
 /area/varadero/interior/disposals)
+"aBY" = (
+/obj/structure/barricade/handrail{
+	desc = "Your platforms look pretty heavy king, let me support them for you.";
+	dir = 1;
+	icon_state = "hr_kutjevo";
+	name = "support struts"
+	},
+/obj/structure/platform/kutjevo/smooth{
+	dir = 1;
+	climb_delay = 1;
+	layer = 2.99
+	},
+/turf/open/gm/river{
+	name = "shallow ocean";
+	default_name = "shallow ocean"
+	},
+/area/varadero/exterior/pontoon_beach/lz)
 "aCd" = (
 /obj/structure/barricade/handrail/wire{
 	layer = 3.1
@@ -1687,7 +1719,7 @@
 	name = "deep ocean";
 	default_name = "deep ocean"
 	},
-/area/varadero/exterior/pontoon_beach)
+/area/varadero/exterior/pontoon_beach/lz)
 "bak" = (
 /obj/structure/prop/invuln/overhead_pipe{
 	dir = 4;
@@ -2499,7 +2531,7 @@
 	name = "shallow ocean";
 	default_name = "shallow ocean"
 	},
-/area/varadero/exterior/pontoon_beach)
+/area/varadero/exterior/pontoon_beach/lz)
 "bDs" = (
 /obj/item/weapon/gun/flare{
 	current_mag = null
@@ -4030,7 +4062,7 @@
 	name = "shallow ocean";
 	default_name = "shallow ocean"
 	},
-/area/varadero/exterior/pontoon_beach)
+/area/varadero/exterior/pontoon_beach/lz)
 "cEu" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -6724,7 +6756,7 @@
 	layer = 2.99
 	},
 /turf/open/gm/coast/beachcorner/south_west,
-/area/varadero/exterior/pontoon_beach)
+/area/varadero/exterior/pontoon_beach/lz)
 "evV" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_22"
@@ -9167,7 +9199,7 @@
 	layer = 3.1
 	},
 /turf/open/gm/coast/beachcorner2/north_west,
-/area/varadero/exterior/pontoon_beach)
+/area/varadero/exterior/pontoon_beach/lz)
 "fWR" = (
 /obj/structure/stairs/perspective{
 	color = "#b29082";
@@ -10880,7 +10912,7 @@
 "haR" = (
 /obj/structure/prop/rock/brown,
 /turf/open/gm/coast/beachcorner2/north_west,
-/area/varadero/exterior/pontoon_beach)
+/area/varadero/exterior/pontoon_beach/lz)
 "haT" = (
 /turf/open/floor/shiva{
 	icon_state = "multi_tiles"
@@ -15468,7 +15500,7 @@
 	name = "shallow ocean";
 	default_name = "shallow ocean"
 	},
-/area/varadero/exterior/pontoon_beach)
+/area/varadero/exterior/pontoon_beach/lz)
 "kaY" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/pill_bottle/inaprovaline/skillless{
@@ -16575,6 +16607,17 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/auto_turf/sand_white/layer1,
 /area/varadero/exterior/lz2_near)
+"kMe" = (
+/obj/structure/platform/kutjevo/smooth{
+	dir = 4;
+	climb_delay = 1;
+	layer = 2.99
+	},
+/turf/open/gm/river{
+	name = "shallow ocean";
+	default_name = "shallow ocean"
+	},
+/area/varadero/exterior/pontoon_beach/lz)
 "kMf" = (
 /obj/structure/window/framed/colony/reinforced/tinted,
 /turf/open/floor/plating,
@@ -18075,7 +18118,7 @@
 	name = "shallow ocean";
 	default_name = "shallow ocean"
 	},
-/area/varadero/exterior/pontoon_beach)
+/area/varadero/exterior/pontoon_beach/lz)
 "lIo" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 6
@@ -18900,6 +18943,12 @@
 	},
 /turf/open/floor/carpet,
 /area/varadero/interior/chapel)
+"mfP" = (
+/turf/open/gm/river/ocean{
+	name = "deep ocean";
+	default_name = "deep ocean"
+	},
+/area/varadero/exterior/pontoon_beach/lz)
 "mgq" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/disposalpipe/segment,
@@ -22013,7 +22062,7 @@
 	layer = 2.99
 	},
 /turf/open/gm/coast/beachcorner2/south_west,
-/area/varadero/exterior/pontoon_beach)
+/area/varadero/exterior/pontoon_beach/lz)
 "ohM" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -22191,6 +22240,12 @@
 	},
 /turf/open/floor/carpet,
 /area/varadero/interior/library)
+"ooP" = (
+/turf/open/gm/river{
+	name = "shallow ocean";
+	default_name = "shallow ocean"
+	},
+/area/varadero/exterior/pontoon_beach/lz)
 "opd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/beerkeg,
@@ -23809,6 +23864,13 @@
 	icon_state = "floor3"
 	},
 /area/varadero/interior/security)
+"ppU" = (
+/obj/structure/flora/bush/ausbushes/var3/stalkybush,
+/turf/open/gm/river/ocean{
+	name = "deep ocean";
+	default_name = "deep ocean"
+	},
+/area/varadero/exterior/pontoon_beach/lz)
 "pqf" = (
 /obj/structure/window/phoronreinforced{
 	dir = 4;
@@ -24259,6 +24321,17 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/auto_turf/sand_white/layer1,
 /area/varadero/interior_protected/caves/digsite)
+"pEo" = (
+/obj/structure/platform/kutjevo/smooth{
+	dir = 8;
+	climb_delay = 1;
+	layer = 2.99
+	},
+/turf/open/gm/river{
+	name = "shallow ocean";
+	default_name = "shallow ocean"
+	},
+/area/varadero/exterior/pontoon_beach/lz)
 "pEE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24936,6 +25009,9 @@
 	},
 /turf/open/floor/wood,
 /area/varadero/interior/bunks)
+"pYH" = (
+/turf/open/gm/coast/beachcorner2/south_west,
+/area/varadero/exterior/pontoon_beach/lz)
 "pYI" = (
 /obj/effect/landmark/lv624/fog_blocker{
 	time_to_dispel = 25000
@@ -25792,7 +25868,7 @@
 	name = "shallow ocean";
 	default_name = "shallow ocean"
 	},
-/area/varadero/exterior/pontoon_beach)
+/area/varadero/exterior/pontoon_beach/lz)
 "qAS" = (
 /obj/effect/landmark/corpsespawner/colonist/burst,
 /turf/open/auto_turf/sand_white/layer1,
@@ -28848,6 +28924,15 @@
 	icon_state = "asteroidfloor"
 	},
 /area/varadero/exterior/lz1_near)
+"ssw" = (
+/obj/structure/platform_decoration/kutjevo{
+	dir = 1
+	},
+/turf/open/gm/river{
+	name = "shallow ocean";
+	default_name = "shallow ocean"
+	},
+/area/varadero/exterior/pontoon_beach/lz)
 "ssZ" = (
 /obj/item/storage/belt/marine,
 /turf/open/floor/carpet,
@@ -29147,6 +29232,13 @@
 	icon_state = "multi_tiles"
 	},
 /area/varadero/interior/cargo)
+"sAW" = (
+/obj/structure/prop/rock/brown,
+/turf/open/gm/river/ocean{
+	name = "deep ocean";
+	default_name = "deep ocean"
+	},
+/area/varadero/exterior/pontoon_beach/lz)
 "sAY" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 1;
@@ -30286,7 +30378,7 @@
 	name = "shallow ocean";
 	default_name = "shallow ocean"
 	},
-/area/varadero/exterior/pontoon_beach)
+/area/varadero/exterior/pontoon_beach/lz)
 "tlq" = (
 /obj/item/lightstick/red/spoke/planted{
 	pixel_x = -10;
@@ -30654,6 +30746,15 @@
 	icon_state = "floor3"
 	},
 /area/varadero/interior/medical)
+"tyV" = (
+/obj/structure/platform_decoration/kutjevo{
+	dir = 4
+	},
+/turf/open/gm/river{
+	name = "shallow ocean";
+	default_name = "shallow ocean"
+	},
+/area/varadero/exterior/pontoon_beach/lz)
 "tzp" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -31025,6 +31126,16 @@
 	icon_state = "asteroidplating"
 	},
 /area/varadero/interior/oob)
+"tOB" = (
+/obj/structure/platform/kutjevo/smooth{
+	climb_delay = 1;
+	layer = 2.99
+	},
+/turf/open/gm/river{
+	name = "shallow ocean";
+	default_name = "shallow ocean"
+	},
+/area/varadero/exterior/pontoon_beach/lz)
 "tOK" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/device/camera{
@@ -33585,6 +33696,9 @@
 	icon_state = "red"
 	},
 /area/varadero/interior/security)
+"vzi" = (
+/turf/closed/wall/rock/brown,
+/area/varadero/exterior/pontoon_beach/lz)
 "vzq" = (
 /obj/structure/machinery/storm_siren{
 	pixel_y = 5
@@ -34078,6 +34192,13 @@
 	icon_state = "darkredfull2"
 	},
 /area/varadero/interior/dock_control)
+"vLI" = (
+/obj/structure/prop/rock/brown,
+/turf/open/gm/river{
+	name = "shallow ocean";
+	default_name = "shallow ocean"
+	},
+/area/varadero/exterior/pontoon_beach/lz)
 "vLU" = (
 /obj/structure/machinery/vending/security,
 /turf/open/floor/shiva{
@@ -34259,6 +34380,21 @@
 	},
 /turf/open/floor/carpet,
 /area/varadero/interior/chapel)
+"vQF" = (
+/obj/structure/platform/kutjevo/smooth{
+	dir = 8;
+	climb_delay = 1;
+	layer = 2.99
+	},
+/obj/structure/platform/kutjevo/smooth{
+	climb_delay = 1;
+	layer = 2.99
+	},
+/turf/open/gm/river{
+	name = "shallow ocean";
+	default_name = "shallow ocean"
+	},
+/area/varadero/exterior/pontoon_beach/lz)
 "vQK" = (
 /obj/structure/platform/kutjevo/smooth{
 	dir = 8;
@@ -34440,7 +34576,7 @@
 	layer = 2.99
 	},
 /turf/open/gm/coast/beachcorner/north_west,
-/area/varadero/exterior/pontoon_beach)
+/area/varadero/exterior/pontoon_beach/lz)
 "vWG" = (
 /obj/structure/bed/chair,
 /obj/structure/machinery/storm_siren{
@@ -34602,7 +34738,7 @@
 	name = "deep ocean";
 	default_name = "deep ocean"
 	},
-/area/varadero/exterior/pontoon_beach)
+/area/varadero/exterior/pontoon_beach/lz)
 "vZS" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/shiva{
@@ -37276,7 +37412,7 @@
 	name = "deep ocean";
 	default_name = "deep ocean"
 	},
-/area/varadero/exterior/pontoon_beach)
+/area/varadero/exterior/pontoon_beach/lz)
 "xLE" = (
 /obj/structure/noticeboard{
 	pixel_y = 32
@@ -49392,8 +49528,8 @@ mPk
 mPk
 wBp
 fjv
-qwQ
-uYJ
+mfP
+ppU
 bah
 uZK
 kME
@@ -49573,9 +49709,9 @@ mPk
 mPk
 wBp
 wBp
-qwQ
-uYJ
-lTR
+mfP
+ppU
+ooP
 kap
 wMw
 wMw
@@ -49754,10 +49890,10 @@ mPk
 mPk
 rYC
 fjv
-uYJ
-qwQ
-pAX
-lTR
+ppU
+mfP
+sAW
+ooP
 kap
 wMw
 wMw
@@ -49935,11 +50071,11 @@ mPk
 mPk
 wBp
 wBp
-qwQ
-qwQ
-qwQ
-lTR
-qwQ
+mfP
+mfP
+mfP
+ooP
+mfP
 kap
 wMw
 wMw
@@ -50116,12 +50252,12 @@ mPk
 mPk
 imk
 wBp
-qwQ
-uYJ
-qwQ
-qwQ
-qwQ
-qwQ
+mfP
+ppU
+mfP
+mfP
+mfP
+mfP
 kap
 sSz
 miT
@@ -50298,12 +50434,12 @@ mPk
 mPk
 mPk
 fjv
-qwQ
-qwQ
-pAX
-qwQ
-qwQ
-qwQ
+mfP
+mfP
+sAW
+mfP
+mfP
+mfP
 kap
 cmU
 wMw
@@ -50480,12 +50616,12 @@ mPk
 mPk
 mPk
 wBp
-qwQ
-qwQ
-qwQ
-qwQ
-qwQ
-lTR
+mfP
+mfP
+mfP
+mfP
+mfP
+ooP
 kap
 rgZ
 olD
@@ -50662,18 +50798,18 @@ mPk
 mPk
 mPk
 rYC
-lTR
-pAX
-qwQ
-qwQ
-lTR
-lTR
-eDY
+ooP
+sAW
+mfP
+mfP
+ooP
+ooP
+tOB
 tpV
 asx
 cfq
 qAI
-bJV
+pEo
 ohC
 euS
 vWn
@@ -50844,20 +50980,20 @@ mPk
 mPk
 mPk
 wBp
-lTR
-qwQ
-qwQ
-qwQ
-lTR
-qwQ
-eDY
+ooP
+mfP
+mfP
+mfP
+ooP
+mfP
+tOB
 lZR
 aCo
 lZR
-caD
-lTR
-aTY
-eGX
+aBY
+ooP
+vLI
+pYH
 haR
 kap
 wMw
@@ -51028,19 +51164,19 @@ mPk
 xVw
 dXg
 dXg
-qwQ
-qwQ
-qwQ
-qwQ
+mfP
+mfP
+mfP
+mfP
 xLB
 gnC
 mYR
 asx
-caD
-lTR
-dXg
-lTR
-lTR
+aBY
+ooP
+vzi
+ooP
+ooP
 kap
 wMw
 ygY
@@ -51211,18 +51347,18 @@ wBp
 qwQ
 dXg
 dXg
-qwQ
-lTR
-qwQ
-fHf
-wPl
+mfP
+ooP
+mfP
+ssw
+vQF
 xOX
 lId
-jLS
-lTR
-dXg
-dXg
-aTY
+tyV
+ooP
+vzi
+vzi
+vLI
 kap
 oLa
 vUQ
@@ -51393,18 +51529,18 @@ wBp
 uYJ
 dXg
 dXg
-qwQ
-qwQ
-qwQ
-qwQ
+mfP
+mfP
+mfP
+mfP
 xLB
 xOX
 bCM
-rlI
-rlI
-rlI
-rlI
-rlI
+kMe
+kMe
+kMe
+kMe
+kMe
 cEm
 fZB
 wMw
@@ -51577,9 +51713,9 @@ qwQ
 dXg
 dXg
 dXg
-qwQ
-qwQ
-eDY
+mfP
+mfP
+tOB
 xOX
 tkV
 asx
@@ -51761,7 +51897,7 @@ dXg
 dXg
 dXg
 dXg
-eDY
+tOB
 asx
 asx
 kzo
@@ -51945,7 +52081,7 @@ qwQ
 dXg
 xFS
 vZR
-eha
+apt
 dKy
 qVD
 fXu


### PR DESCRIPTION
# About the pull request

This PR is a more fleshed out implementation of #6296 that can likely be expanded more into Zonespace's plans for generators powering turrets and more (additional help for low pop).

Smoke takes 6 seconds from its spawn before it will deal burn damage and smoke in vehicles takes up to 7 seconds to dissipate.

The sequence of events are as follows:
1. After ~~two~~ three minutes from round start, a "fake" OB will be launched to each landing zone that then causes a miasma (loosely considered CN20-X miasma since it affects xenos too) in all landing zone areas.
2. When the first dropship departs, the smoke will clear
3. When the first dropship lands, four ~~10~~ 20 minute gauss sentries are automatically deployed randomly in the NW, NE, SW, and SE regions of the LZ immediately around the dropship:
![dropship](https://github.com/cmss13-devs/cmss13/assets/76988376/b87de40a-a718-43ca-9776-f6e47118bc8f)
4. As the sentry runs out of power it warns the battery is running low (battery still depletes if undeployed & cannot be moved or manipulated any other than deployment/undeployment)
5. When unpowered, it can only be undeployed so it is no longer blocking movement.

Since I am primarily using the `is_landing_zone` area var to determine where to make inhospitable, all maps need to be verified:
- [X] LV-624
- [X] Shivas Snowball
- [X] Solaris Ridge
- [X] Fiorina Science Annex
- [X] Trijent Dam
- [ ] Sorokyne Strata (Would need mapping fixes to expand LZs, but would conflict with https://github.com/cmss13-devs/cmss13/pull/6071)
- [X] Kutjevo Refinery
- [X] Chances Claim
- [X] New Varadero
- [X] Corsat* (Current Corsat is fine, https://github.com/cmss13-devs/cmss13/pull/6217 would need some changes)
- [X] Fiorina Cellblocks*
- [X] LV-759 Hybrisa Prospera*

# Explain why it's good for the game

Ultimately this came about because of problems where marines are not able to get a foothold quickly enough first drop before being overwhelmed. This especially affects low pop.

The goals of this change are to make survivors holding LZs basically impossible, to deter xenos from wanting to go near LZs, and to give marines at least ~~10~~20 minutes after first drop time to create a FOB.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/o8kE13Oua6o

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/fdf2bc5e-44b6-4c7f-a01b-defbd5630bf0)

![vehicle smoke](https://github.com/cmss13-devs/cmss13/assets/76988376/b62b020f-5988-4a6a-9646-8eacd9c168ca)

</details>

# Changelog
:cl: Drathek cuberound
balance: After three minutes from round start, landing zones will be covered in a deadly gas
balance: First dropship deployment will clear gas, and first dropship arrival will deploy 4 sentries that last 20 minutes
refactor: Refactored smoke code
maptweak: Expanded LZ areas on Trijent Dam and Kutjevo Refinery
maptweak: Shrunk LZ1 on Shivas Snowball and LZ2 on LV624 slightly
maptweak: Removed fog on Chances Claim since it will be replaced by smoke and tweaked southern tunnel area to not be considered a LZ
fix: Fixed weird LZ lighting on some maps
spellcheck: Replaced/removed synth coughing emotes in smoke
/:cl: