### PR TITLE
Fixes TGUI overwatch console & custom font entry ui runtimes

### DIFF
--- a/tgui/packages/tgui-panel/settings/SettingsPanel.jsx
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.jsx
@@ -115,7 +115,7 @@ export const SettingsGeneral = (props) => {
                 <Input
                   width="15em"
                   value={fontFamily}
-                  onChange={(value) =>
+                  onChange={(e, value) =>
                     dispatch(
                       updateSettings({
                         fontFamily: value,

--- a/tgui/packages/tgui/interfaces/OverwatchConsole.jsx
+++ b/tgui/packages/tgui/interfaces/OverwatchConsole.jsx
@@ -763,7 +763,7 @@ const SavedCoordinates = (props) => {
               <Input
                 width="100%"
                 value={coords.comment}
-                onChange={(value) =>
+                onChange={(e, value) =>
                   act('change_coordinate_comment', {
                     comment: value,
                     index: coords.index,


### PR DESCRIPTION
# About the pull request
Fixes #6366.

# Explain why it's good for the game
bug bad

# Changelog
:cl:
fix: Fixes overwatch console coordinate comment UI crash
fix: Fixes chat UI crash after entering a custom font
/:cl: