### PR TITLE
Xeno Orbit Menu

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -118,6 +118,7 @@
 					var/datum/caste_datum/caste = xeno.caste
 					serialized["caste"] = caste.caste_type
 					serialized["icon"] = caste.minimap_icon
+					serialized["hivenumber"] = xeno.hivenumber
 				xenos += list(serialized)
 				continue
 

--- a/tgui/packages/tgui/interfaces/Orbit/index.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/index.tsx
@@ -129,10 +129,13 @@ const ObservableSearch = () => {
 const xenoSplitter = (members: Array<Observable>) => {
   const primeHive: Array<Observable> = [];
   const corruptedHive: Array<Observable> = [];
+  const forsakenHive: Array<Observable> = [];
 
   members.forEach((x) => {
     if (x.full_name?.includes('Corrupted')) {
       corruptedHive.push(x);
+    } else if (x.full_name?.includes('Forsaken')) {
+      forsakenHive.push(x);
     } else {
       primeHive.push(x);
     }
@@ -140,6 +143,7 @@ const xenoSplitter = (members: Array<Observable>) => {
   const squads = [
     buildSquadObservable('Prime', 'xeno', primeHive),
     buildSquadObservable('Corrupted', 'green', corruptedHive),
+    buildSquadObservable('Forsaken', 'grey', forsakenHive),
   ];
   return squads;
 };

--- a/tgui/packages/tgui/interfaces/Orbit/index.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/index.tsx
@@ -130,20 +130,24 @@ const xenoSplitter = (members: Array<Observable>) => {
   const primeHive: Array<Observable> = [];
   const corruptedHive: Array<Observable> = [];
   const forsakenHive: Array<Observable> = [];
+  const otherHives: Array<Observable> = [];
 
   members.forEach((x) => {
-    if (x.full_name?.includes('Corrupted')) {
+    if (x.hivenumber?.includes('normal')) {
+      primeHive.push(x);
+    } else if (x.hivenumber?.includes('corrupted')) {
       corruptedHive.push(x);
-    } else if (x.full_name?.includes('Forsaken')) {
+    } else if (x.hivenumber?.includes('forsaken')) {
       forsakenHive.push(x);
     } else {
-      primeHive.push(x);
+      otherHives.push(x);
     }
   });
   const squads = [
     buildSquadObservable('Prime', 'xeno', primeHive),
     buildSquadObservable('Corrupted', 'green', corruptedHive),
     buildSquadObservable('Forsaken', 'grey', forsakenHive),
+    buildSquadObservable('Other', 'light-grey', otherHives),
   ];
   return squads;
 };

--- a/tgui/packages/tgui/interfaces/Orbit/types.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/types.ts
@@ -38,6 +38,7 @@ export type Observable = {
   nickname?: string;
   orbiters?: number;
   ref: string;
+  hivenumber: string;
 };
 
 export type SquadObservable = {


### PR DESCRIPTION
# About the pull request

Adds Forsaken Hive to the orbit menu and changes how the xenoSplitter determines the hive.

# Explain why it's good for the game


# Testing Photographs and Procedure
Just to show it still works properly. (Can only show one at a time because it won't read clientless)
![image](https://github.com/cmss13-devs/cmss13/assets/41653574/56c1705a-a4ea-4ac8-82f9-eab54673a563)



# Changelog

:cl:
add: Added Forsaken sub category to orbit menu. Also adds an "Other" sub category for xeno hives, to split the main hive on its own.
code: Changed xenoSplitter to pull the hivenumber rather than base things on the name.
/:cl:
