### PR TITLE
Buff XM88

### DIFF
--- a/code/datums/ammo/bullet/lever_action.dm
+++ b/code/datums/ammo/bullet/lever_action.dm
@@ -52,7 +52,7 @@
 /datum/ammo/bullet/lever_action/xm88
 	name = ".458 SOCOM round"
 
-	damage = 80
+	damage = 104
 	penetration = ARMOR_PENETRATION_TIER_2
 	accuracy = HIT_ACCURACY_TIER_1
 	shell_speed = AMMO_SPEED_TIER_6

--- a/code/modules/projectiles/guns/lever_action.dm
+++ b/code/modules/projectiles/guns/lever_action.dm
@@ -378,7 +378,6 @@ their unique feature is that a direct hit will buff your damage and firerate
 		/obj/item/attachable/bayonet/upp, // Barrel
 		/obj/item/attachable/bayonet,
 		/obj/item/attachable/extended_barrel,
-		/obj/item/attachable/heavy_barrel,
 		/obj/item/attachable/suppressor,
 		/obj/item/attachable/compensator,
 		/obj/item/attachable/reddot, // Rail

--- a/code/modules/projectiles/guns/lever_action.dm
+++ b/code/modules/projectiles/guns/lever_action.dm
@@ -393,9 +393,9 @@ their unique feature is that a direct hit will buff your damage and firerate
 
 /obj/item/weapon/gun/lever_action/xm88/set_gun_config_values()
 	..()
-	set_fire_delay(FIRE_DELAY_TIER_2)
+	set_fire_delay(FIRE_DELAY_TIER_2 + FIRE_DELAY_TIER_11)
 	lever_delay = FIRE_DELAY_TIER_3
-	accuracy_mult = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_5
+	accuracy_mult = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_2
 	accuracy_mult_unwielded = BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_10
 	scatter = SCATTER_AMOUNT_TIER_8
 	burst_scatter_mult = 0


### PR DESCRIPTION
# About the pull request

This PR changes the XM88 to have comparable values as if the weapon had a barrel charger attached to it, this includes a buff of its damage to 104, and a decrease to its inherent accuracy and rate of fire. 

# Explain why it's good for the game

The removal of the barrel charger from the gameplay loop had the unintended side-affect of indirectly nerfing the XM88 in a significant manner. Prior to its removal the barrel charger was a "must-have" attachment for the weapon, as it brought its damage up to a level of greater lethality, wherein without it the weapon now struggles more so against hardened targets. Furthermore, the weapons higher skill requirement means that you will regularly miss shots on a target, thus the weapon having a higher damage upfront rewards you for landing your shots.

To account for this, this PR effects the change to presume the weapon is under the benefits and drawbacks of having a barrel charger attached to it. Meaning the gun has a higher damage per bullet but suffers a rate of fire decrease and a major decrease in its accuracy. 

Functionally this is bringing the weapon back to its older state that was what the majority of the player base grew to expect the weapon to perform. 

Due to the major nerfs to the extended barrel, the now ability to attach it to this weapon comports a almost non-existant boon to the weapon and thus is not a point of balance contention.

Furthermore, after doing some offline testing I can ascertain that the average time-to-kill on a stationary target in white-room conditions is almost virtually unchanged. For example, a Warrior can expect to be dead in 8 seconds from both the original and this new version. The difference really comes down to the weapon having slightly higher damage up-front if you do land your shot. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: The XM88 now deals higher damage per-bullet at the cost of a slightly lower rate of fire and accuracy. This is identical to as if it had a barrel charger attached to it. 
balance: Per the above, the barrel charger is no longer compatible with the XM88. 
/:cl:
