### PR TITLE
Vampire tail jab changes (try 2)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_powers.dm
@@ -282,9 +282,19 @@
 
 	stab_direction = turn(get_dir(xeno, targeted_atom), 180)
 	playsound(hit_target,'sound/weapons/alien_tail_attack.ogg', 50, TRUE)
-	if(hit_target.mob_size < MOB_SIZE_BIG)
-		step_away(hit_target, xeno)
 
+	var/direction = Get_Compass_Dir(xeno, targeted_atom) //More precise than get_dir.
+	if(!direction) //Same tile.
+		return
+	if(!step(hit_target, direction))
+		playsound(hit_target.loc, "punch", 25, 1)
+		hit_target.visible_message(SPAN_DANGER("[hit_target] slams into an obstacle!"),
+		isxeno(hit_target) ? SPAN_XENODANGER("We slam into an obstacle!") : SPAN_HIGHDANGER("You slam into an obstacle!"), null, 4, CHAT_TYPE_TAKING_HIT)
+		hit_target.apply_damage(MELEE_FORCE_TIER_2)
+		if (hit_target.mob_size < MOB_SIZE_BIG)
+			hit_target.apply_effect(0.5, WEAKEN)
+		else
+			hit_target.apply_effects(0.5, SLOW)
 	/// To reset the direction if they haven't moved since then in below callback.
 	var/last_dir = xeno.dir
 
@@ -296,11 +306,7 @@
 	addtimer(CALLBACK(src, PROC_REF(reset_direction), xeno, last_dir, new_dir), 0.5 SECONDS)
 
 	hit_target.apply_armoured_damage(get_xeno_damage_slash(hit_target, xeno.caste.melee_damage_upper), ARMOR_MELEE, BRUTE, "chest")
-
-	if(hit_target.mob_size < MOB_SIZE_BIG)
-		hit_target.apply_effect(0.5, WEAKEN)
-	else
-		hit_target.apply_effect(0.5, SLOW)
+	hit_target.apply_effect(0.5, SLOW)
 
 	hit_target.last_damage_data = create_cause_data(xeno.caste_type, xeno)
 	log_attack("[key_name(xeno)] attacked [key_name(hit_target)] with Tail Jab")

--- a/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_powers.dm
@@ -267,10 +267,10 @@
 
 	if(iscarbon(hit_target) && !xeno.can_not_harm(hit_target) && hit_target.stat != DEAD)
 		if(targeted_atom == hit_target) //reward for a direct hit
-			to_chat(xeno, SPAN_XENOHIGHDANGER("We directly slam [hit_target] with our tail, throwing it back after impaling it on our tail!"))
+			to_chat(xeno, SPAN_XENOHIGHDANGER("We attack [hit_target], with our tail, piercing their body!"))
 			hit_target.apply_armoured_damage(15, ARMOR_MELEE, BRUTE, "chest")
 		else
-			to_chat(xeno, SPAN_XENODANGER("We attack [hit_target] with our tail, throwing it back after stabbing it with our tail!"))
+			to_chat(xeno, SPAN_XENODANGER("We attack [hit_target], slashing them with our tail!"))
 	else
 		xeno.visible_message(SPAN_XENOWARNING("\The [xeno] swipes their tail through the air!"), SPAN_XENOWARNING("We swipe our tail through the air!"))
 		apply_cooldown(cooldown_modifier = 0.2)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_powers.dm
@@ -292,9 +292,9 @@
 		isxeno(hit_target) ? SPAN_XENODANGER("We slam into an obstacle!") : SPAN_HIGHDANGER("You slam into an obstacle!"), null, 4, CHAT_TYPE_TAKING_HIT)
 		hit_target.apply_damage(MELEE_FORCE_TIER_2)
 		if (hit_target.mob_size < MOB_SIZE_BIG)
-			hit_target.apply_effect(0.5, WEAKEN)
+			hit_target.KnockDown(0.5)
 		else
-			hit_target.apply_effects(0.5, SLOW)
+			hit_target.Slow(0.5)
 	/// To reset the direction if they haven't moved since then in below callback.
 	var/last_dir = xeno.dir
 
@@ -306,7 +306,7 @@
 	addtimer(CALLBACK(src, PROC_REF(reset_direction), xeno, last_dir, new_dir), 0.5 SECONDS)
 
 	hit_target.apply_armoured_damage(get_xeno_damage_slash(hit_target, xeno.caste.melee_damage_upper), ARMOR_MELEE, BRUTE, "chest")
-	hit_target.apply_effect(0.5, SLOW)
+	hit_target.Slow(0.5)
 
 	hit_target.last_damage_data = create_cause_data(xeno.caste_type, xeno)
 	log_attack("[key_name(xeno)] attacked [key_name(hit_target)] with Tail Jab")

--- a/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_powers.dm
@@ -284,8 +284,7 @@
 	playsound(hit_target,'sound/weapons/alien_tail_attack.ogg', 50, TRUE)
 
 	var/direction = Get_Compass_Dir(xeno, targeted_atom) //More precise than get_dir.
-	if(!direction) //Same tile.
-		return
+
 	if(!step(hit_target, direction))
 		playsound(hit_target.loc, "punch", 25, 1)
 		hit_target.visible_message(SPAN_DANGER("[hit_target] slams into an obstacle!"),


### PR DESCRIPTION

# About the pull request
Makes tail jab only knock you down if you hit an obstacle.

# Explain why it's good for the game

A caste that already has healing, acid runner speed, very low cooldowns, dash, execute that heals even more and more does not need an auto aimed ability that stuns you just because you clicked near the marine.

Theres a difference between making the game accessible to newer players and completely removing any resemblance of skill / effort required to do well.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Vampire tail jab now only stuns if you knockback an enemy into an obstacle.
spellcheck: Vampire lurkers no longer "throw it back" after hitting somebody with their Tail Jab
/:cl:
