### PR TITLE
Fixes the USCM observer icon

### DIFF
--- a/code/datums/factions/uscm.dm
+++ b/code/datums/factions/uscm.dm
@@ -75,6 +75,9 @@
 			if(JOB_CO)
 				marine_rk = "co"
 				border_rk = "command"
+			if(JOB_USCM_OBSV)
+				marine_rk = "vo"
+				border_rk = "command"
 			if(JOB_SO)
 				marine_rk = "so"
 				border_rk = "command"


### PR DESCRIPTION

# About the pull request

As title, I forgot to actually give the goddamn role it's icon.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixed the USCM Observer icon not displaying. Forest dumb.
/:cl:
