### PR TITLE
Fixes getting a prayer confirmation per affected admin, instead of just once

### DIFF
--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -25,7 +25,8 @@
 			to_chat(admin, SPAN_STAFF_IC(msg))
 			if(admin.prefs.toggles_sound & SOUND_ARES_MESSAGE)
 				admin << 'sound/machines/terminal_alert.ogg'
-		to_chat(usr, receipt)
+
+	to_chat(usr, receipt)
 
 /proc/high_command_announce(text , mob/Sender , iamessage)
 	var/msg = copytext(sanitize(text), 1, MAX_MESSAGE_LEN)


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

moves the thing outside the loop

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Your prayers have been received by the gods will now only be said once per prayer
/:cl:
