### PR TITLE
Fix Round Time Offset

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -69,7 +69,10 @@ GLOBAL_LIST_INIT(reboot_sfx, file2list("config/reboot_sfx.txt"))
 	initiate_minimap_icons()
 
 	change_tick_lag(CONFIG_GET(number/ticklag))
-	GLOB.timezoneOffset = text2num(time2text(0,"hh")) * 36000
+
+	// As of byond 515.1637 time2text now treats 0 like it does negative numbers so the hour is wrong
+	// We could instead use world.timezone but IMO better to not assume lummox will keep time2text in parity with it
+	GLOB.timezoneOffset = text2num(time2text(10,"hh")) * 36000
 
 	Master.Initialize(10, FALSE, TRUE)
 


### PR DESCRIPTION
# About the pull request

As of byond 515.1637 time2text's behavior has changed again (see https://www.byond.com/forum/post/2922387 ). This fixes the timezone offset used for round time by ensuring time2text is parsing a positive number since it now treats 0 like it does negative numbers somreason.

# Explain why it's good for the game

Fixes #6381 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/5ce5aa6f-f66f-424a-8039-b327d45909a1)

</details>


# Changelog
:cl: Drathek
fix: Fixed round time having the wrong timezone offset because of an engine change to time2text
/:cl:
