### PR TITLE
Fix Airlock Destroy

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -76,7 +76,7 @@ GLOBAL_LIST_INIT(airlock_wire_descriptions, list(
 
 /obj/structure/machinery/door/airlock/Destroy()
 	QDEL_NULL_LIST(attached_signallers)
-	QDEL_NULL(closeOther)
+	closeOther = null
 	QDEL_NULL(electronics)
 	return ..()
 


### PR DESCRIPTION

# About the pull request

This PR fixes airlocks destroying their linked airlock rather than just releasing the reference to it.

# Explain why it's good for the game

Fixes 
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/15d6610f-5422-4662-bb99-697b032399d9)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
fix: Fixed linked airlocks destroying their linked airlock incorrectly
/:cl:
