### PR TITLE
Fix emoting past the grave

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -229,9 +229,12 @@
 		if(DEAD)
 			to_chat(src, SPAN_WARNING("You cannot emote while dead!"))
 			return FALSE
-	if(client?.prefs.muted & MUTE_IC)
-		to_chat(src, SPAN_DANGER("You cannot emote (muted)."))
-		return
+	if(client)
+		if(client.prefs.muted & MUTE_IC)
+			to_chat(src, SPAN_DANGER("You cannot emote (muted)."))
+			return FALSE
+		if(!client.attempt_talking())
+			return FALSE
 
 	// Otherwise, ""roar""!
 	playsound(loc, "alien_roar_larva", 15)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -222,6 +222,17 @@
 	if(act == "me")
 		return ..()
 
+	switch(stat)
+		if(UNCONSCIOUS)
+			to_chat(src, SPAN_WARNING("You cannot emote while unconscious!"))
+			return FALSE
+		if(DEAD)
+			to_chat(src, SPAN_WARNING("You cannot emote while dead!"))
+			return FALSE
+	if(client?.prefs.muted & MUTE_IC)
+		to_chat(src, SPAN_DANGER("You cannot emote (muted)."))
+		return
+
 	// Otherwise, ""roar""!
 	playsound(loc, "alien_roar_larva", 15)
 	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
@@ -167,9 +167,12 @@
 		if(DEAD)
 			to_chat(src, SPAN_WARNING("You cannot emote while dead!"))
 			return FALSE
-	if(client?.prefs.muted & MUTE_IC)
-		to_chat(src, SPAN_DANGER("You cannot emote (muted)."))
-		return
+	if(client)
+		if(client.prefs.muted & MUTE_IC)
+			to_chat(src, SPAN_DANGER("You cannot emote (muted)."))
+			return FALSE
+		if(!client.attempt_talking())
+			return FALSE
 
 	// Otherwise, ""roar""!
 	playsound(loc, "alien_roar_larva", 15)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
@@ -160,6 +160,17 @@
 	if(act == "me")
 		return ..()
 
+	switch(stat)
+		if(UNCONSCIOUS)
+			to_chat(src, SPAN_WARNING("You cannot emote while unconscious!"))
+			return FALSE
+		if(DEAD)
+			to_chat(src, SPAN_WARNING("You cannot emote while dead!"))
+			return FALSE
+	if(client?.prefs.muted & MUTE_IC)
+		to_chat(src, SPAN_DANGER("You cannot emote (muted)."))
+		return
+
 	// Otherwise, ""roar""!
 	playsound(loc, "alien_roar_larva", 15)
 	return TRUE


### PR DESCRIPTION

# About the pull request

This PR fixes the lack of stat, muted, and cooldown checks for larva and facehugger emotes.

# Explain why it's good for the game

Something that is dead shouldn't be emoting.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/4dbc6375-93db-4f76-8765-c54cfca33294)

</details>


# Changelog
:cl: Drathek
fix: Fixed larva and hugger emotes performing no stat or muted or cooldown checks
/:cl:
