### PR TITLE
preview sticks around after screen is cleared

### DIFF
--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -211,20 +211,20 @@
 
 	if(isnull(preview_front))
 		preview_front = new()
-		owner.add_to_screen(preview_front)
 		preview_front.vis_contents += preview_dummy
 		preview_front.screen_loc = "preview:0,0"
 	preview_front.icon_state = bg_state
+	owner.add_to_screen(preview_front)
 
 	if(isnull(rotate_left))
 		rotate_left = new(null, preview_dummy)
-		owner.add_to_screen(rotate_left)
 		rotate_left.screen_loc = "preview:-1:16,0"
+	owner.add_to_screen(rotate_left)
 
 	if(isnull(rotate_right))
 		rotate_right = new(null, preview_dummy)
-		owner.add_to_screen(rotate_right)
 		rotate_right.screen_loc = "preview:1:-16,0"
+	owner.add_to_screen(rotate_right)
 
 /datum/preferences/proc/job_pref_to_gear_preset()
 	var/high_priority


### PR DESCRIPTION
:cl:
fix: the preview window in character setup now remains visible when looking at it as a ghost
/:cl: