### PR TITLE
Personal Civilian Clothing Storage Unit For Marines

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
@@ -412,3 +412,105 @@
 		/obj/item/clothing/suit/storage/marine/heavy/skull,
 		/obj/item/clothing/suit/storage/marine/heavy/smooth,
 	)
+
+//------------MARINE CIVILIAN CLOTHING---------------
+
+GLOBAL_LIST_INIT(cm_vending_clothing_marine_snowflake, list(
+	list("SHIRTS AND UNIFORMS", 0, null, null, null),
+	list("White T-Shirt and Brown Jeans", 12, /obj/item/clothing/under/tshirt/w_br, null, VENDOR_ITEM_REGULAR),
+	list("Gray T-Shirt and Blue Jeans", 12, /obj/item/clothing/under/tshirt/gray_blu, null, VENDOR_ITEM_REGULAR),
+	list("Red T-Shirt and Black Jeans", 12, /obj/item/clothing/under/tshirt/r_bla, null, VENDOR_ITEM_REGULAR),
+	list("Frontier Jumpsuit", 12, /obj/item/clothing/under/rank/synthetic/frontier, null, VENDOR_ITEM_REGULAR),
+	list("UA Grey Jumpsuit", 12, /obj/item/clothing/under/colonist/ua_civvies, null, VENDOR_ITEM_REGULAR),
+	list("UA Brown Jumpsuit", 12, /obj/item/clothing/under/colonist/wy_davisone, null, VENDOR_ITEM_REGULAR),
+	list("UA Green Utility Uniform", 12, /obj/item/clothing/under/rank/synthetic/utility, null, VENDOR_ITEM_REGULAR),
+	list("Grey Utilities", 12, /obj/item/clothing/under/rank/synthetic/utility/yellow, null, VENDOR_ITEM_REGULAR),
+	list("Grey Utilities and Blue Jeans", 12, /obj/item/clothing/under/rank/synthetic/utility/red, null, VENDOR_ITEM_REGULAR),
+	list("Blue Utilities and Brown Jeans", 12, /obj/item/clothing/under/rank/synthetic/utility/blue, null, VENDOR_ITEM_REGULAR),
+	list("White Service Uniform", 12, /obj/item/clothing/under/colonist/white_service, null, VENDOR_ITEM_REGULAR),
+	list("Steward Clothes", 12, /obj/item/clothing/under/colonist/wy_joliet_shopsteward, null, VENDOR_ITEM_REGULAR),
+	list("Red Dress Skirt", 12, /obj/item/clothing/under/blackskirt, null, VENDOR_ITEM_REGULAR),
+	list("Blue Suit Pants", 12, /obj/item/clothing/under/liaison_suit/blue, null, VENDOR_ITEM_REGULAR),
+	list("Brown Suit Pants", 12, /obj/item/clothing/under/liaison_suit/brown, null, VENDOR_ITEM_REGULAR),
+	list("White Suit Pants", 12, /obj/item/clothing/under/liaison_suit/corporate_formal, null, VENDOR_ITEM_REGULAR),
+	list("Working Joe Uniform", 36, /obj/item/clothing/under/rank/synthetic/joe, null, VENDOR_ITEM_REGULAR),
+
+	list("GLASSES", 0, null, null, null),
+	list("Marine RPG Glasses", 12, /obj/item/clothing/glasses/regular, null, VENDOR_ITEM_REGULAR),
+	list("Sunglasses", 12, /obj/item/clothing/glasses/sunglasses, null, VENDOR_ITEM_REGULAR),
+
+	list("SHOES", 0, null, null, null),
+	list("Boots", 12, /obj/item/clothing/shoes/marine, null, VENDOR_ITEM_REGULAR),
+	list("Shoes, Black", 12, /obj/item/clothing/shoes/black, null, VENDOR_ITEM_REGULAR),
+	list("Shoes, Blue", 12, /obj/item/clothing/shoes/blue, null, VENDOR_ITEM_REGULAR),
+	list("Shoes, Brown", 12, /obj/item/clothing/shoes/brown, null, VENDOR_ITEM_REGULAR),
+	list("Shoes, Green", 12, /obj/item/clothing/shoes/green, null, VENDOR_ITEM_REGULAR),
+	list("Shoes, Purple", 12, /obj/item/clothing/shoes/purple, null, VENDOR_ITEM_REGULAR),
+	list("Shoes, Red", 12, /obj/item/clothing/shoes/red, null, VENDOR_ITEM_REGULAR),
+	list("Shoes, White", 12, /obj/item/clothing/shoes/white, null, VENDOR_ITEM_REGULAR),
+	list("Shoes, Yellow", 12, /obj/item/clothing/shoes/yellow, null, VENDOR_ITEM_REGULAR),
+
+	list("HEADWEAR", 0, null, null, null),
+	list("Beanie", 12, /obj/item/clothing/head/beanie, null, VENDOR_ITEM_REGULAR),
+	list("Beret, Engineering", 12, /obj/item/clothing/head/beret/eng, null, VENDOR_ITEM_REGULAR),
+	list("Beret, Purple", 12, /obj/item/clothing/head/beret/jan, null, VENDOR_ITEM_REGULAR),
+	list("Beret, Red", 12, /obj/item/clothing/head/beret/cm/red, null, VENDOR_ITEM_REGULAR),
+	list("Beret, Standard", 12, /obj/item/clothing/head/beret/cm, null, VENDOR_ITEM_REGULAR),
+	list("Beret, Tan", 12, /obj/item/clothing/head/beret/cm/tan, null, VENDOR_ITEM_REGULAR),
+	list("Beret, Green", 12, /obj/item/clothing/head/beret/cm, MARINE_CAN_BUY_HELMET, VENDOR_ITEM_REGULAR),
+	list("Beret, Black", 12, /obj/item/clothing/head/beret/cm/black, null, VENDOR_ITEM_REGULAR),
+	list("Beret, White", 12, /obj/item/clothing/head/beret/cm/white, null, VENDOR_ITEM_REGULAR),
+	list("Ushanka", 12, /obj/item/clothing/head/ushanka, null, VENDOR_ITEM_REGULAR),
+	list("Cap", 12, /obj/item/clothing/head/cmcap, null, VENDOR_ITEM_REGULAR),
+	list("Fedora", 12, /obj/item/clothing/head/fedora, null, VENDOR_ITEM_REGULAR),
+
+	list("SUIT", 0, null, null, null),
+	list("Bomber Jacket, Brown", 12, /obj/item/clothing/suit/storage/bomber, null, VENDOR_ITEM_REGULAR),
+	list("Bomber Jacket, Black", 12, /obj/item/clothing/suit/storage/bomber/alt, null, VENDOR_ITEM_REGULAR),
+	list("External Webbing", 12, /obj/item/clothing/suit/storage/webbing, null, VENDOR_ITEM_REGULAR),
+	list("Utility Vest", 12, /obj/item/clothing/suit/storage/utility_vest, null, VENDOR_ITEM_REGULAR),
+	list("Hazard Vest(Orange)", 12, /obj/item/clothing/suit/storage/hazardvest, null, VENDOR_ITEM_REGULAR),
+	list("Hazard Vest(Blue)", 12, /obj/item/clothing/suit/storage/hazardvest/blue, null, VENDOR_ITEM_REGULAR),
+	list("Hazard Vest(Yellow)", 12, /obj/item/clothing/suit/storage/hazardvest/yellow, null, VENDOR_ITEM_REGULAR),
+	list("Hazard Vest(Black)", 12, /obj/item/clothing/suit/storage/hazardvest/black, null, VENDOR_ITEM_REGULAR),
+	list("USCM Service Jacket", 12, /obj/item/clothing/suit/storage/jacket/marine/service, null, VENDOR_ITEM_REGULAR),
+	list("Windbreaker, Brown", 12, /obj/item/clothing/suit/storage/windbreaker/windbreaker_brown, null, VENDOR_ITEM_REGULAR),
+	list("Windbreaker, Grey", 12, /obj/item/clothing/suit/storage/windbreaker/windbreaker_gray, null, VENDOR_ITEM_REGULAR),
+	list("Windbreaker, Green", 12, /obj/item/clothing/suit/storage/windbreaker/windbreaker_green, null, VENDOR_ITEM_REGULAR),
+	list("Windbreaker, First Responder", 12, /obj/item/clothing/suit/storage/windbreaker/windbreaker_fr, null, VENDOR_ITEM_REGULAR),
+	list("Windbreaker, Exploration", 12, /obj/item/clothing/suit/storage/windbreaker/windbreaker_covenant, null, VENDOR_ITEM_REGULAR),
+	list("Black Suit Jacket", 12, /obj/item/clothing/suit/storage/jacket/marine/corporate/black, null, VENDOR_ITEM_REGULAR),
+	list("Brown Suit Jacket", 12, /obj/item/clothing/suit/storage/jacket/marine/corporate/brown, null, VENDOR_ITEM_REGULAR),
+	list("Blue Suit Jacket", 12, /obj/item/clothing/suit/storage/jacket/marine/corporate/blue, null, VENDOR_ITEM_REGULAR),
+	list("Brown Vest", 12, /obj/item/clothing/suit/storage/jacket/marine/vest, null, VENDOR_ITEM_REGULAR),
+	list("Tan Vest", 12, /obj/item/clothing/suit/storage/jacket/marine/vest/tan, null, VENDOR_ITEM_REGULAR),
+	list("Grey Vest", 12, /obj/item/clothing/suit/storage/jacket/marine/vest/grey, null, VENDOR_ITEM_REGULAR),
+
+	list("BACKPACK", 0, null, null, null),
+	list("Backpack, Industrial", 12, /obj/item/storage/backpack/industrial, null, VENDOR_ITEM_REGULAR),
+	list("Satchel, Leather", 12, /obj/item/storage/backpack/satchel, null, VENDOR_ITEM_REGULAR),
+	list("Satchel, Medical", 12, /obj/item/storage/backpack/satchel/med, null, VENDOR_ITEM_REGULAR),
+
+	list("OTHER", 0, null, null, null),
+	list("Red Armband", 6, /obj/item/clothing/accessory/armband, null, VENDOR_ITEM_REGULAR),
+	list("Purple Armband", 6, /obj/item/clothing/accessory/armband/science, null, VENDOR_ITEM_REGULAR),
+	list("Yellow Armband", 6, /obj/item/clothing/accessory/armband/engine, null, VENDOR_ITEM_REGULAR),
+	list("Green Armband", 6, /obj/item/clothing/accessory/armband/medgreen, null, VENDOR_ITEM_REGULAR),
+	list("Dress Gloves", 6, /obj/item/clothing/gloves/marine/dress, null, VENDOR_ITEM_REGULAR),
+
+))
+
+/obj/structure/machinery/cm_vending/clothing/marine/snowflake
+	name = "\improper Personal Civilian Clothing Storage Unit"
+	desc = "The vendor where all of your personal civilian clothing is stored while you are on-duty."
+	icon_state = "snowflake"
+	show_points = TRUE
+	use_snowflake_points = TRUE
+	vendor_theme = VENDOR_THEME_COMPANY
+	req_access = list()
+	vendor_role = list()
+
+	vend_delay = 1 SECONDS
+
+/obj/structure/machinery/cm_vending/clothing/marine/snowflake/get_listed_products(mob/user)
+	return GLOB.cm_vending_clothing_marine_snowflake

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -11041,6 +11041,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/hangar)
+"bjZ" = (
+/obj/structure/machinery/cm_vending/clothing/marine/snowflake,
+/turf/open/floor/almayer{
+	icon_state = "cargo"
+	},
+/area/almayer/living/gym)
 "bkb" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -12003,12 +12009,6 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/lower/starboard_fore_hallway)
-"bqm" = (
-/obj/structure/closet/boxinggloves,
-/turf/open/floor/almayer{
-	icon_state = "plate"
-	},
-/area/almayer/living/gym)
 "bqF" = (
 /obj/structure/dropship_equipment/fuel/fuel_enhancer,
 /turf/open/floor/almayer{
@@ -25259,6 +25259,19 @@
 	icon_state = "cargo"
 	},
 /area/almayer/engineering/upper_engineering/starboard)
+"evC" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/machinery/door_control{
+	id = "civ_uniforms";
+	name = "Uniform Vendor Lockdown";
+	pixel_x = -24;
+	pixel_y = -7;
+	req_access_txt = "31"
+	},
+/turf/open/floor/almayer,
+/area/almayer/living/gym)
 "evM" = (
 /obj/structure/machinery/status_display{
 	pixel_y = 30
@@ -26700,8 +26713,7 @@
 	icon_state = "ramptop"
 	},
 /turf/open/floor/almayer/aicore/glowing/no_build{
-	icon_state = "ai_floor3";
-	light_range = 3
+	icon_state = "ai_floor3"
 	},
 /area/almayer/command/airoom)
 "eXD" = (
@@ -41891,6 +41903,16 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_f_p)
+"kox" = (
+/obj/structure/machinery/door/poddoor/shutters/almayer/uniform_vendors{
+	dir = 4;
+	id = "civ_uniforms"
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "cargo_arrow"
+	},
+/area/almayer/living/gym)
 "koB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44823,6 +44845,9 @@
 	icon_state = "silvercorner"
 	},
 /area/almayer/shipboard/brig/cic_hallway)
+"lnu" = (
+/turf/closed/wall/almayer/reinforced/temphull,
+/area/almayer/living/gym)
 "lnP" = (
 /obj/structure/machinery/vending/cola,
 /obj/structure/window/reinforced,
@@ -50499,8 +50524,7 @@
 	vector_y = -61
 	},
 /turf/open/floor/almayer/aicore/glowing/no_build{
-	icon_state = "ai_floor3";
-	light_range = 3
+	icon_state = "ai_floor3"
 	},
 /area/almayer/command/airoom)
 "nkX" = (
@@ -55830,8 +55854,7 @@
 	dir = 1
 	},
 /turf/open/floor/almayer/aicore/glowing/no_build{
-	icon_state = "ai_floor3";
-	light_range = 3
+	icon_state = "ai_floor3"
 	},
 /area/almayer/command/airoom)
 "oZp" = (
@@ -55952,8 +55975,7 @@
 	dir = 8
 	},
 /turf/open/floor/almayer/aicore/glowing/no_build{
-	icon_state = "ai_floor3";
-	light_range = 3
+	icon_state = "ai_floor3"
 	},
 /area/almayer/command/airoom)
 "paI" = (
@@ -69638,8 +69660,7 @@
 	dir = 8
 	},
 /turf/open/floor/almayer/aicore/glowing/no_build{
-	icon_state = "ai_floor3";
-	light_range = 3
+	icon_state = "ai_floor3"
 	},
 /area/almayer/command/airoom)
 "tIF" = (
@@ -73721,10 +73742,6 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/medical/lower_medical_medbay)
-"vhY" = (
-/obj/structure/sign/goldenplaque,
-/turf/closed/wall/almayer,
-/area/almayer/living/gym)
 "vif" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 1
@@ -108725,11 +108742,11 @@ sZc
 abj
 mUE
 coo
-eWs
-aRu
-aRu
-aRu
-aRu
+lnu
+lnu
+lnu
+lnu
+lnu
 aRu
 aRu
 bcm
@@ -108928,12 +108945,12 @@ iOX
 kIl
 jmz
 hsK
-wfE
-wfE
-wfE
-wfE
-wfE
-wfE
+lnu
+bjZ
+bjZ
+bjZ
+lnu
+sGU
 wfE
 wfE
 yap
@@ -109132,10 +109149,10 @@ wfE
 wfE
 wfE
 wfE
-sGU
-vhY
+kox
+kox
+kox
 wfE
-bqm
 bsD
 btr
 wfE
@@ -109334,11 +109351,11 @@ jOo
 wrC
 mHx
 pqX
-pqX
+evC
 xbk
 wFR
-bmF
 wFR
+bmF
 wFR
 xbk
 aWw
@@ -110343,7 +110360,7 @@ aad
 sGw
 xzB
 dvD
-wfE
+sGU
 iYx
 opD
 xbk


### PR DESCRIPTION
# About the pull request

Adds a set of civilian clothing vendors on the Almayer in the Gym., these vendors can be used by anyone to vend civilian style clothing, the contents are almost identical to the Synthetic clothing vendor, minus the military themed clothing and unique backpack/similar options. These vendors are locked behind a set of shutters with the same high-level access requirements as the Dress uniform vendors, so CIC can determine when access is authorized. 

Anyone can access the vendor, each person has a 120 point limit to what they can buy. 

# Explain why it's good for the game

Grants regular Marines the ability to vend their own personal civilian clothing, for events or whenever CIC authorizes it (Maybe a event where the marines are going on shore leave before something terrible happened?).

The advantage here is to further allow regular players to craft their own characters apperance and roleplay what they might wear off-duty, in circumstances that allow for it. 

The area is locked thus CIC has control on when Marines can access it, and there is also the fact it is the job of the MPs to ensure Marines are wearing proper clothing. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
mapadd: Civilian Clothing Storage Vendors have been added to the Gym on the USS Almayer. These allow anyone to vend civilian clothes. These vendors require CIC access to unlock however. 
/:cl:
