### PR TITLE
CLF Engis now spawn with insulated gloves

### DIFF
--- a/code/modules/gear_presets/clf.dm
+++ b/code/modules/gear_presets/clf.dm
@@ -170,7 +170,6 @@
 
 	spawn_rebel_suit(new_human)
 	spawn_rebel_shoes(new_human)
-	spawn_rebel_gloves(new_human)
 
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/meson, WEAR_EYES)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/yellow, WEAR_HANDS)


### PR DESCRIPTION
Fixes #6380
# About the pull request

Fixed an error where the CLF Engineers would spawn with random, non-insulated gloves rather than the insulated ones they were supposed to have. The error was caused by the random equipment being spawned first and the insulated gloves not having anywhere to spawn.

# Explain why it's good for the game

Makes CLF engineers be able to do their job better.


# Testing Photographs and Procedure

Spawn CLF Engineer and check their equipment.

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: ThePiachu
fix: CLF Engineers now properly spawn with insulated gloves again.
/:cl:
