### PR TITLE
Fixes medical cryo tubes deleting occupants when destroyed.

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -196,7 +196,7 @@
 /obj/structure/machinery/cryo_cell/Destroy()
 	if(occupant)
 		go_out()
-	..()
+	. = ..()
 
 /obj/structure/machinery/cryo_cell/proc/process_occupant()
 	if(!occupant)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -193,6 +193,11 @@
 	var/is_on = on && operable()
 	icon_state = "[icon_state]-[is_on ? "on" : "off"]-[occupant ? "occupied" : "empty"]"
 
+/obj/structure/machinery/cryo_cell/Destroy()
+	if(occupant)
+		go_out()
+	..()
+
 /obj/structure/machinery/cryo_cell/proc/process_occupant()
 	if(!occupant)
 		return


### PR DESCRIPTION

# About the pull request

As title.

# Explain why it's good for the game

People being sent to the void is not a good thing.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Medical cryo tubes no longer delete their occupant when destroyed.
/:cl:
