### PR TITLE
Fixes being able to see Command helmet cams from the groundside operations console.

### DIFF
--- a/code/game/machinery/computer/groundside_operations.dm
+++ b/code/game/machinery/computer/groundside_operations.dm
@@ -362,7 +362,7 @@
 
 //returns the helmet camera the human is wearing
 /obj/structure/machinery/computer/groundside_operations/proc/get_camera_from_target(mob/living/carbon/human/H)
-	if(current_squad)
+	if(current_squad || show_command_squad)
 		if(H && istype(H) && istype(H.head, /obj/item/clothing/head/helmet/marine))
 			var/obj/item/clothing/head/helmet/marine/helm = H.head
 			return helm.camera


### PR DESCRIPTION

# About the pull request

Missed a sanity check in the console when adding this, oops.

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Command can now access the helmet cameras of any deploying command staff
/:cl:
