### PR TITLE
techpoint price change

### DIFF
--- a/code/datums/supply_packs/operations.dm
+++ b/code/datums/supply_packs/operations.dm
@@ -10,18 +10,12 @@
 		/obj/structure/ob_ammo/ob_fuel,
 		/obj/structure/ob_ammo/ob_fuel,
 		/obj/structure/ob_ammo/warhead/incendiary,
-		/obj/structure/ob_ammo/ob_fuel,
-		/obj/structure/ob_ammo/ob_fuel,
-		/obj/structure/ob_ammo/ob_fuel,
-		/obj/structure/ob_ammo/ob_fuel,
-		/obj/structure/ob_ammo/ob_fuel,
-		/obj/structure/ob_ammo/warhead/incendiary,
 	)
 
 	name = "OB Incendiary Crate"
 	cost = 0
 	containertype = /obj/structure/closet/crate/secure/ob
-	containername = "OB Ammo Crate (Incendiary x2)"
+	containername = "OB Ammo Crate (Incendiary)"
 	buyable = 0
 	group = "Operations"
 
@@ -33,18 +27,12 @@
 		/obj/structure/ob_ammo/ob_fuel,
 		/obj/structure/ob_ammo/ob_fuel,
 		/obj/structure/ob_ammo/warhead/explosive,
-		/obj/structure/ob_ammo/ob_fuel,
-		/obj/structure/ob_ammo/ob_fuel,
-		/obj/structure/ob_ammo/ob_fuel,
-		/obj/structure/ob_ammo/ob_fuel,
-		/obj/structure/ob_ammo/ob_fuel,
-		/obj/structure/ob_ammo/warhead/explosive,
 	)
 
 	name = "OB HE Crate"
 	cost = 0
 	containertype = /obj/structure/closet/crate/secure/ob
-	containername = "OB Ammo Crate (HE x2)"
+	containername = "OB Ammo Crate (HE)"
 	buyable = 0
 	group = "Operations"
 
@@ -56,18 +44,12 @@
 		/obj/structure/ob_ammo/ob_fuel,
 		/obj/structure/ob_ammo/ob_fuel,
 		/obj/structure/ob_ammo/warhead/cluster,
-		/obj/structure/ob_ammo/ob_fuel,
-		/obj/structure/ob_ammo/ob_fuel,
-		/obj/structure/ob_ammo/ob_fuel,
-		/obj/structure/ob_ammo/ob_fuel,
-		/obj/structure/ob_ammo/ob_fuel,
-		/obj/structure/ob_ammo/warhead/cluster,
 	)
 
 	name = "OB Cluster Crate"
 	cost = 0
 	containertype = /obj/structure/closet/crate/secure/ob
-	containername = "OB Ammo Crate (Cluster x2)"
+	containername = "OB Ammo Crate (Cluster)"
 	buyable = 0
 	group = "Operations"
 

--- a/code/modules/cm_tech/techs/marine/tier1/points.dm
+++ b/code/modules/cm_tech/techs/marine/tier1/points.dm
@@ -6,13 +6,13 @@
 	announce_name = "ALMAYER SPECIAL ASSETS AUTHORIZED"
 	announce_message = "Additional supply budget has been authorised for this operation."
 
-	required_points = 15
+	required_points = 7
 	increase_per_purchase = 1
 
 	flags = TREE_FLAG_MARINE
 	tier = /datum/tier/one
 
-	var/points_to_give = 100
+	var/points_to_give = 50
 
 /datum/tech/repeatable/req_points/proc/get_tech_scaling_value()
 	//We take the number of marine players, deduced from other lists, and then get a scale multiplier from it, to be used in arbitrary manners to distribute equipment
@@ -33,13 +33,13 @@
 
 	announce_message = "Additional dropship part fabricator points have been authorised for this operation."
 
-	required_points = 12
+	required_points = 6
 	increase_per_purchase = 1
 
 	flags = TREE_FLAG_MARINE
 	tier = /datum/tier/one
 
-	var/points_to_give = 2500
+	var/points_to_give = 2000
 
 /datum/tech/repeatable/dropship_points/on_unlock()
 	. = ..()

--- a/code/modules/cm_tech/techs/marine/tier2/orbital_ammo.dm
+++ b/code/modules/cm_tech/techs/marine/tier2/orbital_ammo.dm
@@ -2,7 +2,7 @@
 	name = "OB Ammo"
 	desc = "Purchase orbital bombardment ammo."
 
-	required_points = 10
+	required_points = 5
 	increase_per_purchase = 2
 
 	tier = /datum/tier/two


### PR DESCRIPTION
# About the pull request

Halves the price of OB, supply points, and CAS budget. OB gives one shell, supply budget gives 50 points from 100, CAS budget 2000 from 2500 (FACTCHECK, it is used one per two days( not twice a year) and is not worth even the 5 points)

# Explain why it's good for the game

Makes it easier to diversify for command and reduces the extre commitment when buying certain stuff, ten intel points is huge portion of budget on loads of rounds. Also having to buy two of the same OB shell is quite the commitment and this makes it so that it costs the same when you diversify the shells you buy and more if you buy two of the same. Preventing foxtrot buy buying ds or req budget just is not done as you have better options aka foxtrot and saving up for nuke. Dropship budget was never bought and even this buff does not even place it in line with other stuff, 3 -5 firemissions of budget or 5 more marines or OB.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: dropship fabricator extra budget price 12 -> 6 , 2500 -> 2000 points
balance: supply extra budget 15 -> 7, 10k -> 5k
balance: all OB 10 -> 5 intel points, one shell and five fuel
/:cl:
