### PR TITLE
Fix ToD not getting updated if ghostized without a client

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -471,6 +471,12 @@ Works together with spawning an observer, noted above.
 
 	mind = null
 
+	// Larva queue: We use the larger of their existing queue time or the new timeofdeath except for facehuggers or lesser drone
+	var/new_tod = (isfacehugger(src) || islesserdrone(src)) ? 1 : ghost.timeofdeath
+
+	// if they died as facehugger or lesser drone, bypass typical TOD checks
+	ghost.bypass_time_of_death_checks = (isfacehugger(src) || islesserdrone(src))
+
 	if(ghost.client)
 		ghost.client.init_verbs()
 		ghost.client.change_view(GLOB.world_view_size) //reset view range to default
@@ -485,13 +491,12 @@ Works together with spawning an observer, noted above.
 		if(ghost.client.player_data)
 			ghost.client.player_data.load_timestat_data()
 
-		// Larva queue: We use the larger of their existing queue time or the new timeofdeath except for facehuggers or lesser drone
-		var/new_tod = (isfacehugger(src) || islesserdrone(src)) ? 1 : ghost.timeofdeath
+		ghost.client.player_details.larva_queue_time = max(ghost.client.player_details.larva_queue_time, new_tod)
 
-		// if they died as facehugger or lesser drone, bypass typical TOD checks
-		ghost.bypass_time_of_death_checks = (isfacehugger(src) || islesserdrone(src))
-
-		ghost.client?.player_details.larva_queue_time = max(ghost.client.player_details.larva_queue_time, new_tod)
+	else if(persistent_ckey)
+		var/datum/player_details/details = GLOB.player_details[persistent_ckey]
+		if(details)
+			details.larva_queue_time = max(ghost.client.player_details.larva_queue_time, new_tod)
 
 	ghost.set_huds_from_prefs()
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -496,7 +496,7 @@ Works together with spawning an observer, noted above.
 	else if(persistent_ckey)
 		var/datum/player_details/details = GLOB.player_details[persistent_ckey]
 		if(details)
-			details.larva_queue_time = max(ghost.client.player_details.larva_queue_time, new_tod)
+			details.larva_queue_time = max(details.larva_queue_time, new_tod)
 
 	ghost.set_huds_from_prefs()
 


### PR DESCRIPTION

# About the pull request

This should fix the edge case where a mob is ghostized and they don't currently have a client. Normally the player_details is accessed via the client, but we can fallback to the GLOB need be.

# Explain why it's good for the game

Fixes an edge case where a time of death is not recorded for a player as far as the larva queue is concerned.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
fix: Fixed larva queue time of death not getting recorded if client is missing
/:cl:
