### PR TITLE
Fix observer huds resetting if ghostized while disconnected

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -314,6 +314,8 @@
 	if(observe_target_mob)
 		clean_observe_target()
 
+	set_huds_from_prefs()
+
 /mob/dead/observer/Destroy(force)
 	GLOB.observer_list -= src
 	QDEL_NULL(orbit_menu)


### PR DESCRIPTION

# About the pull request

If you are ghostized when you have no client, your preference for huds cannot be read. So this PR makes it so when an client attaches to an observer mob, it reads the client's hud settings.

# Explain why it's good for the game

Fixes HUDs resetting if you are ghostized while disconnected.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
fix: Fixed ghost huds resetting settings if you were ghostized while disconnected
/:cl:
