### PR TITLE
Fix orbit menu not handling minimap_icons in list format

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -133,6 +133,10 @@
 				serialized["nickname"] = human.real_name
 
 				var/icon = human.assigned_equipment_preset?.minimap_icon
+				if(islist(icon))
+					for(var/key in icon)
+						icon = key
+						break
 				serialized["icon"] = icon ? icon : "private"
 
 				if(human.assigned_squad)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Jobs that specify a minimap_icon in list format were not handled by the new orbit menu (medical, command, mp)

# Explain why it's good for the game

More consistent looking UI. 

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/2dab269f-3ff3-4592-b068-04f2a1f8a1cc)

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Drathek
fix: Fixed some jobs having no minimap icon in orbit menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
