### PR TITLE
Adds a warning to potentially-laggy uses of `drop-bomb`

### DIFF
--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -116,7 +116,7 @@
 			if(power > custom_limit)
 				return
 
-			if((power > power_warn_threshold) && ((1 / (power / falloff)) <= falloff_warn_threshold) && (explosion_shape == EXPLOSION_FALLOFF_SHAPE_LINEAR)) // The lag can be a bit situational, but a large-power explosion with minimal (linear) falloff can absolutely bring the server to a halt in certain cases.
+			if((power >= power_warn_threshold) && ((1 / (power / falloff)) <= falloff_warn_threshold) && (explosion_shape == EXPLOSION_FALLOFF_SHAPE_LINEAR)) // The lag can be a bit situational, but a large-power explosion with minimal (linear) falloff can absolutely bring the server to a halt in certain cases.
 				if(tgui_input_list(src, "This bomb has the potential to lag the server. Are you sure you wish to drop it?", "Drop confirm", list("Yes", "No")) != "Yes")
 					return
 

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -81,6 +81,8 @@
 
 /client/proc/handle_bomb_drop(atom/epicenter)
 	var/custom_limit = 5000
+	var/power_warn_threshold = 500
+	var/falloff_warn_threshold = 0.05
 	var/list/choices = list("Small Bomb", "Medium Bomb", "Big Bomb", "Custom Bomb")
 	var/list/falloff_shape_choices = list("CANCEL", "Linear", "Exponential")
 	var/choice = tgui_input_list(usr, "What size explosion would you like to produce?", "Drop Bomb", choices)
@@ -113,6 +115,11 @@
 
 			if(power > custom_limit)
 				return
+
+			if((power > power_warn_threshold) && ((1 / (power / falloff)) <= falloff_warn_threshold) && (explosion_shape == EXPLOSION_FALLOFF_SHAPE_LINEAR)) // The lag can be a bit situational, but a large-power explosion with minimal (linear) falloff can absolutely bring the server to a halt in certain cases.
+				if(tgui_input_list(src, "This bomb has the potential to lag the server. Are you sure you wish to drop it?", "Drop confirm", list("Yes", "No")) != "Yes")
+					return
+
 			cell_explosion(epicenter, power, falloff, explosion_shape, null, cause_data)
 			message_admins("[key_name(src, TRUE)] dropped a custom cell bomb with power [power], falloff [falloff] and falloff_shape [shape_choice]!")
 	message_admins("[ckey] used 'Drop Bomb' at [epicenter.loc].")


### PR DESCRIPTION

# About the pull request

Bombs with linear falloff, power >= 500, and falloff <= 5% of power have an extra confirmation before dropping.

# Explain why it's good for the game

While there is an existing bomb cap (5000), this confirmation just makes sure admins know what they're doing before dropping the bomb.

~~no this has nothing to do with me bringing the server to a halt~~

# Changelog
:cl:
admin: Potentially laggy uses of the drop-bomb verb now have a confirmation warning.
/:cl:
