### PR TITLE
Fixes admins not being able to award queens

### DIFF
--- a/code/datums/medal_awards.dm
+++ b/code/datums/medal_awards.dm
@@ -289,23 +289,21 @@ GLOBAL_LIST_INIT(xeno_medals, list(XENO_SLAUGHTER_MEDAL, XENO_RESILIENCE_MEDAL, 
 	var/list/recipient_castes = list()
 	var/list/recipient_mobs = list()
 	for(var/mob/living/carbon/xenomorph/xeno in hive.totalXenos)
-		if (xeno.persistent_ckey == usr.persistent_ckey) // Don't award self
+		if(xeno.persistent_ckey == usr.persistent_ckey) // Don't award self
 			continue
-		if (xeno.tier == 0) // Don't award larva or facehuggers
-			continue
-		if (!as_admin && istype(xeno.caste, /datum/caste_datum/queen)) // Don't award queens unless admin
-			continue
+		if(xeno.tier == 0) // Don't award larva or facehuggers
+			if(!as_admin || !isqueen(xeno))  // Don't award queens unless admin (She is tier 0 for whatever reason)
+				continue
 		var/recipient_name = xeno.real_name
 		recipient_castes[recipient_name] = xeno.caste_type
 		recipient_mobs[recipient_name] = xeno
 		possible_recipients += recipient_name
 	for(var/mob/living/carbon/xenomorph/xeno in hive.total_dead_xenos)
-		if (xeno.persistent_ckey == usr.persistent_ckey) // Don't award previous selves
+		if(xeno.persistent_ckey == usr.persistent_ckey) // Don't award previous selves
 			continue
-		if (xeno.tier == 0) // Don't award larva or facehuggers
-			continue
-		if (!as_admin && istype(xeno.caste, /datum/caste_datum/queen)) // Don't award previous queens unless admin
-			continue
+		if(xeno.tier == 0) // Don't award larva or facehuggers
+			if(!as_admin || !isqueen(xeno))  // Don't award queens unless admin (She is tier 0 for whatever reason)
+				continue
 		var/recipient_name = xeno.real_name
 		recipient_castes[recipient_name] = xeno.caste_type
 		recipient_mobs[recipient_name] = xeno


### PR DESCRIPTION

# About the pull request

This PR fixes the royal jellies skipping tier 0 xenos which includes queen.

# Explain why it's good for the game

Fixes #6444 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

As admin, queen was an option (but not lesser) but as the queen she could not (also tested spawning a second queen since you can't award self)
![image](https://github.com/cmss13-devs/cmss13/assets/76988376/9413449b-bf3d-46fe-b31d-db94f983a874)

</details>


# Changelog
:cl: Drathek
fix: Fixed Queen Mother being unable to award a Queen
/:cl:
