### PR TITLE
Normalises the HUD damage overlay so synths and predators HUD overlays trigger at the same %-wise damage as humans.

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -42,7 +42,7 @@
 
 			//Fire and Brute damage overlay (BSSR)
 			var/max_health_normalisation = (species ? species.total_health : 100) / 100
-			var/hurtdamage = (src.getBruteLoss() + src.getFireLoss()) / max_health_normalisation + damageoverlaytemp
+			var/hurtdamage = (getBruteLoss() + getFireLoss()) / max_health_normalisation + damageoverlaytemp
 			damageoverlaytemp = 0 // We do this so we can detect if someone hits us or not.
 			if(hurtdamage)
 				var/severity = 0

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -40,9 +40,9 @@
 			else
 				clear_fullscreen("oxy")
 
-
 			//Fire and Brute damage overlay (BSSR)
-			var/hurtdamage = src.getBruteLoss() + src.getFireLoss() + damageoverlaytemp
+			var/max_health_normalisation = (species ? species.total_health : 100) / 100
+			var/hurtdamage = (src.getBruteLoss() + src.getFireLoss()) / max_health_normalisation + damageoverlaytemp
 			damageoverlaytemp = 0 // We do this so we can detect if someone hits us or not.
 			if(hurtdamage)
 				var/severity = 0


### PR DESCRIPTION

# About the pull request

As human, you get the max damage overlay at 85 damage, i.e 15% health
As synth, you get the max damage overlay also at 85 damage, but that's 43% health.

Normalises this, so synths get it at 15%, and so on.

# Explain why it's good for the game

If you've still got gas left in the tank, there's no reason to overlay a large and disturbing overlay.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: The game no longer tricks predators and synths into thinking they're more damaged than they actually are.
/:cl:
