### PR TITLE
Revives heavy revolver ammo

### DIFF
--- a/code/datums/ammo/ammo.dm
+++ b/code/datums/ammo/ammo.dm
@@ -89,6 +89,9 @@
 	/// The flicker that plays when a bullet hits a target. Usually red. Can be nulled so it doesn't show up at all.
 	var/hit_effect_color = "#FF0000"
 
+	/// How much fire delay to add to the weapon after firing this kind of ammo
+	var/fire_delay_modifier = 0
+
 /datum/ammo/New()
 	set_bullet_traits()
 

--- a/code/datums/ammo/bullet/revolver.dm
+++ b/code/datums/ammo/bullet/revolver.dm
@@ -25,10 +25,10 @@
 	damage = 35
 	penetration = ARMOR_PENETRATION_TIER_4
 	accuracy = HIT_ACCURACY_TIER_3
+	fire_delay_modifier = 1 SECONDS
 
-/datum/ammo/bullet/revolver/heavy/on_hit_mob(mob/entity, obj/projectile/bullet)
-	slowdown(entity, bullet)
-	pushback(entity, bullet, 4)
+/datum/ammo/bullet/revolver/heavy/on_hit_mob(mob/M, obj/projectile/P)
+	knockback(M, P, 4)
 
 /datum/ammo/bullet/revolver/incendiary
 	name = "incendiary revolver bullet"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1142,6 +1142,8 @@ and you're good to go.
 		flags_gun_features &= ~GUN_BURST_FIRING
 		return NONE
 
+	var/ammo_fire_delay = projectile_to_fire.ammo.fire_delay_modifier // Save this early because projectile_to_fire is going to be nulled
+
 	apply_bullet_effects(projectile_to_fire, user, reflex, dual_wield) //User can be passed as null.
 	SEND_SIGNAL(projectile_to_fire, COMSIG_BULLET_USER_EFFECTS, user)
 
@@ -1204,7 +1206,7 @@ and you're good to go.
 		if(check_for_attachment_fire)
 			active_attachable.last_fired = world.time
 		else
-			last_fired = world.time
+			last_fired = world.time + ammo_fire_delay
 			var/delay_left = (last_fired + fire_delay + additional_fire_group_delay) - world.time
 			if(fire_delay_group && delay_left > 0)
 				LAZYSET(user.fire_delay_next_fire, src, world.time + delay_left)


### PR DESCRIPTION

# About the pull request
This PR re-adds the stun to heavy revolver ammo and increases its fire delay (only for heavy impact ammo)
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Heavy revolver ammo went from something you'd race for at the start of the round to completely useless ammo nobody ever uses.
This PR aims to make it more appealing by returning its stun gimmick without the stunlock, allowing for xenos hit to disengage.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Heavy revolver ammo now stuns instead of knocking back but also increases the fire delay by one second.
/:cl:
