### PR TITLE
Dir assist now prioritises non-xenos

### DIFF
--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -22,12 +22,13 @@
 
 			if (!L.is_xeno_grabbable() || L == src) //Xenos never attack themselves.
 				continue
-			if(!isxeno(L))
+			var/isxeno = isxeno(L)
+			if(!isxeno)
 				non_xeno_target = L
 			if (L.body_position == LYING_DOWN)
 				alt = L
 				continue
-			else if (!isxeno(L))
+			else if (!isxeno)
 				break
 			target = L
 		if (target == T && alt)

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -27,6 +27,8 @@
 			if (L.body_position == LYING_DOWN)
 				alt = L
 				continue
+			else if (!isxeno(L))
+				break
 			target = L
 		if (target == T && alt)
 			target = alt

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -13,6 +13,7 @@
 
 	if(isturf(target) && tile_attack) //Attacks on turfs must be done indirectly through directional attacks or clicking own sprite.
 		var/turf/T = target
+		var/mob/living/non_xeno_target
 		for(var/mob/living/L in T)
 			if (!iscarbon(L))
 				if (!alt)
@@ -21,13 +22,16 @@
 
 			if (!L.is_xeno_grabbable() || L == src) //Xenos never attack themselves.
 				continue
+			if(!isxeno(L))
+				non_xeno_target = L
 			if (L.body_position == LYING_DOWN)
 				alt = L
 				continue
 			target = L
-			break
 		if (target == T && alt)
 			target = alt
+		if(non_xeno_target)
+			target = non_xeno_target
 		if (T && ignores_resin) // Will not target resin walls and doors if this is set to true. This is normally only set to true through a directional attack.
 			if(istype(T, /obj/structure/mineral_door/resin))
 				var/obj/structure/mineral_door/resin/attacked_door = T


### PR DESCRIPTION

# About the pull request
This PR makes it so when using dir assist against a xeno and a non-xeno on the same tile the attack will prioritize the non-xeno over the xeno.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
You are more likely to want to target the marine than shove\slash the xeno ontop of the marine.
It is annoying when John runner stands ontop of the guy you are currently pulling and now you have to click the 3 remaining pixels visible.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Dir-assist will now prioritize non-xenos over xenos.
/:cl:
