### PR TITLE
grow boxes can now be destroyed by xenos

### DIFF
--- a/code/game/objects/structures/props.dm
+++ b/code/game/objects/structures/props.dm
@@ -686,6 +686,20 @@
 	health = 75
 	density = TRUE
 
+/obj/structure/prop/ice_colony/dense/attack_alien(mob/living/carbon/xenomorph/xeno)
+	if(xeno.a_intent == INTENT_HARM)
+		if(unslashable)
+			return
+		xeno.animation_attack_on(src)
+		playsound(loc, 'sound/effects/metalhit.ogg', 25, 1)
+		xeno.visible_message(SPAN_DANGER("[xeno] slices [src] apart!"),
+		SPAN_DANGER("We slice [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+		deconstruct(FALSE)
+		return XENO_ATTACK_ACTION
+	else
+		attack_hand(xeno)
+		return XENO_NONCOMBAT_ACTION
+
 /obj/structure/prop/ice_colony/dense/ice_tray
 	name = "ice slab tray"
 	icon_state = "ice_tray"


### PR DESCRIPTION

# About the pull request
title

# Explain why it's good for the game
no more stupid crap made by silly mappers blocking your movement

# Testing Photographs and Procedure

https://github.com/cmss13-devs/cmss13/assets/140007537/87207bd1-5024-46df-93d2-8ab7163fd324

# Changelog
:cl:
qol: Grow boxes can now be destroyed by xenos.
/:cl:
