### PR TITLE
fixes check to look for slot being hand not item, this might solve bugs with some items that should be droped but use u_equip

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -201,10 +201,10 @@
 	if((I.flags_item & NODROP) && !force)
 		return FALSE //u_equip() only fails if item has NODROP
 	var/slot = get_slot_by_item(I)
-	if (I == r_hand)
+	if (slot == r_hand)
 		r_hand = null
 		update_inv_r_hand()
-	else if (I == l_hand)
+	else if (slot == l_hand)
 		l_hand = null
 		update_inv_l_hand()
 


### PR DESCRIPTION
# About the pull request

when looking into chesse bug I noticed that the u_equip checks if item is r_hand not if the slot is

# Explain why it's good for the game
might slove some bugs, untested


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: no player facing fix
/:cl:
