### PR TITLE
Fixes a bug that would jam guns entirely

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -872,6 +872,8 @@ User can be passed as null, (a gun reloading itself for instance), so we need to
 
 	if(!current_mag || QDELETED(current_mag) || (current_mag.loc != src && !loc_override))
 		cock(user)
+		current_mag = null
+		update_icon()
 		return
 
 	if(drop_override || !user) //If we want to drop it on the ground or there's no user.


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

I couldn't figure out what caused this bug but it was getting kinda bad, something about alternating akimbo would cause guns to be entirely disabled, with the current_mag having been ejected, but still marked as in the gun, but not in the contents, meaning the gun was entirely broke as you couldnt clear out the mag inside of it cause there was no mag.

this pr just adds a failsafe to prevent this from ever happening

# Explain why it's good for the game

Having your gun becoming entirely unusable and having to just toss it out cause a bug broke it isnt fun


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
fix: fixes a bug that fully jammed guns being used in akimbo
/:cl:

