### PR TITLE
fence nerf + fuel cell recycler + showcase is now destroyable

### DIFF
--- a/code/game/machinery/fuelcell_recycler.dm
+++ b/code/game/machinery/fuelcell_recycler.dm
@@ -3,8 +3,10 @@
 	desc = "A large machine with whirring fans and two cylindrical holes in the top. Used to regenerate fuel cells."
 	icon = 'icons/obj/structures/machinery/fusion_eng.dmi'
 	icon_state = "recycler"
-	density = TRUE
 	active_power_usage = 15000
+	unslashable = TRUE
+	unacidable = TRUE
+	indestructible = TRUE
 
 	///How much to recharge the cells per process
 	var/recharge_amount = 5
@@ -17,6 +19,11 @@
 	. = ..()
 	QDEL_NULL(cell_left)
 	QDEL_NULL(cell_right)
+
+/obj/structure/machinery/fuelcell_recycler/ex_act(severity)
+	if(indestructible)
+		return
+	. = ..()
 
 /obj/structure/machinery/fuelcell_recycler/get_examine_text(mob/user)
 	. = ..()

--- a/code/game/machinery/fuelcell_recycler.dm
+++ b/code/game/machinery/fuelcell_recycler.dm
@@ -5,9 +5,6 @@
 	icon_state = "recycler"
 	density = TRUE
 	active_power_usage = 15000
-	unslashable = TRUE
-	unacidable = TRUE
-	indestructible = TRUE
 
 	///How much to recharge the cells per process
 	var/recharge_amount = 5
@@ -150,11 +147,6 @@
 		icon_state = "recycler"
 		return
 	icon_state = "recycler_on"
-
-/obj/structure/machinery/fuelcell_recycler/ex_act(severity)
-	if(indestructible)
-		return
-	. = ..()
 
 /obj/structure/machinery/fuelcell_recycler/proc/turn_off()
 	visible_message(SPAN_NOTICE("[src] stops whirring as it turns off."))

--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -7,6 +7,20 @@
 	anchored = TRUE
 	health = 250
 
+/obj/structure/showcase/attack_alien(mob/living/carbon/xenomorph/xeno)
+	if(xeno.a_intent == INTENT_HARM)
+		if(unslashable)
+			return
+		xeno.animation_attack_on(src)
+		playsound(loc, 'sound/effects/metalhit.ogg', 25, 1)
+		xeno.visible_message(SPAN_DANGER("[xeno] slices [src] apart!"),
+		SPAN_DANGER("We slice [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+		deconstruct(FALSE)
+		return XENO_ATTACK_ACTION
+	else
+		attack_hand(xeno)
+		return XENO_NONCOMBAT_ACTION
+
 /obj/structure/showcase/initialize_pass_flags(datum/pass_flags_container/PF)
 	..()
 	if (PF)
@@ -273,7 +287,7 @@
 	. = ..()
 	if(over_object != usr || !Adjacent(usr))
 		return
-		
+
 	if(!ishuman(usr))
 		return
 

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -504,7 +504,7 @@
 //Slashing fences
 /obj/structure/fence/attack_alien(mob/living/carbon/xenomorph/M)
 	M.animation_attack_on(src)
-	var/damage_dealt = 5
+	var/damage_dealt = 25
 	M.visible_message(SPAN_DANGER("[M] mangles [src]!"), \
 	SPAN_DANGER("We mangle [src]!"), \
 	SPAN_DANGER("We hear twisting metal!"), 5, CHAT_TYPE_XENO_COMBAT)


### PR DESCRIPTION
# About the pull request
fuel cell recycler is no longer dense
showcases are now slashable by xenos
fences are now a 2 tap hit to be destroyed by any xeno (or 1 tap + pounce)

# Explain why it's good for the game
less stupid crap blocking your movement
fences were super nerfed for xenos and just turned into more annoying movement blockers that don't provide cover

# Testing Photographs and Procedure

https://github.com/cmss13-devs/cmss13/assets/140007537/db66e5cf-095e-4a72-9a47-5bfe4c386c37

https://github.com/cmss13-devs/cmss13/assets/140007537/290200e5-1dd7-4ed4-b244-72c7fe1b1a97

# Changelog
:cl:
balance: Fence health nerfed, now can be 2 tapped by xenos
qol: Fuel cell recyclers no longer block movement
qol: Showcases are now slashable by xenos
/:cl:
