### PR TITLE
SG can now put a weapon on their back, still no backpacks

### DIFF
--- a/code/modules/clothing/suits/marine_armor/smartgunner.dm
+++ b/code/modules/clothing/suits/marine_armor/smartgunner.dm
@@ -32,7 +32,7 @@
 /obj/item/clothing/suit/storage/marine/smartgunner/mob_can_equip(mob/equipping_mob, slot, disable_warning = FALSE)
 	. = ..()
 
-	if(equipping_mob.back && !(equipping_mob.back.flags_item & SMARTGUNNER_BACKPACK_OVERRIDE))
+	if(equipping_mob.back && !istype(equipping_mob.back, /obj/item/weapon/gun) && !(equipping_mob.back.flags_item & SMARTGUNNER_BACKPACK_OVERRIDE))
 		to_chat(equipping_mob, SPAN_WARNING("You can't equip [src] while wearing a backpack."))
 		return FALSE
 
@@ -51,11 +51,9 @@
 	if(equipping_item.flags_item & SMARTGUNNER_BACKPACK_OVERRIDE)
 		return
 
-	. = COMPONENT_HUMAN_CANCEL_ATTEMPT_EQUIP
-
-	if(equipping_item.flags_equip_slot == SLOT_BACK)
+	if(!istype(equipping_item, /obj/item/weapon/gun) && equipping_item.flags_equip_slot == SLOT_BACK)
 		to_chat(equipping_human, SPAN_WARNING("You can't equip [equipping_item] on your back while wearing [src]."))
-		return
+		return COMPONENT_HUMAN_CANCEL_ATTEMPT_EQUIP
 
 /obj/item/clothing/suit/storage/marine/smartgunner/unequipped(mob/user, slot)
 	. = ..()


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Smartgunners can put a primary weapon on their back. They are still not able to put backpacks on their back.

# Explain why it's good for the game
Having a backup weapon on an SG gives you more options. As the SG takes time to reload it can be useful to have a weapon which allows you to gain some space. Alternatively, having a weapon which only have some utility such as a flamer could be useful.

By making heavy use of the secondary weapon, you are reducing your effectiveness as an SG, your primary benefit is to be using that SG as much as possible. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Smartgunners can put a primary weapon in their backpack slot whilst wearing the M56d harness
/:cl:
