### PR TITLE
changes fire color on incen OB to be blueish instead of orange

### DIFF
--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -512,15 +512,13 @@ GLOBAL_LIST_EMPTY(orbital_cannon_cancellation)
 	var/distance = 18
 	var/fire_level = 70
 	var/burn_level = 80
-	var/fire_color = null
+	var/fire_color = LIGHT_COLOR_CYAN
 	var/fire_type = "white"
 
 /obj/structure/ob_ammo/warhead/incendiary/warhead_impact(turf/target)
 	. = ..()
 	if (!.)
 		return
-	if(fire_color)
-		fire_type = "dynamic"
 
 	new /obj/effect/overlay/temp/blinking_laser (target)
 	sleep(10)


### PR DESCRIPTION
# About the pull request
changes the fire light color on the incen OB to be blueish instead of orange

# Explain why it's good for the game

Fixes #6469
looks betterer


# Testing Photographs and Procedure
![image](https://github.com/cmss13-devs/cmss13/assets/29965103/b84a9542-bea3-4644-99ef-8b880fc83a0c)
doesn't inhibit custom admin incen OBs from being whatever color

# Changelog
:cl:
fix: incen OB fire now makes blue light.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
