### PR TITLE
Overwatch console now shows dead people by default

### DIFF
--- a/tgui/packages/tgui/interfaces/OverwatchConsole.jsx
+++ b/tgui/packages/tgui/interfaces/OverwatchConsole.jsx
@@ -361,7 +361,7 @@ const SquadMonitor = (props) => {
   );
   const [showDeadMarines, setShowDeadMarines] = useSharedState(
     'showdead',
-    false,
+    true,
   );
 
   const [marineSearch, setMarineSearch] = useSharedState('marinesearch', null);


### PR DESCRIPTION

# About the pull request

Pretty important to see who's dead.

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Overwatch console shows dead marines by default.
/:cl:
