### PR TITLE
Removes playable facehuggers

### DIFF
--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -257,27 +257,6 @@
 /obj/effect/alien/egg/forsaken
 	hivenumber = XENO_HIVE_FORSAKEN
 
-/obj/effect/alien/egg/attack_ghost(mob/dead/observer/user)
-	. = ..() //Do a view printout as needed just in case the observer doesn't want to join as a Hugger but wants info
-	if(is_mainship_level(src) && !SSticker.mode.is_in_endgame) // if we're not in hijack don't allow this
-		to_chat(user, SPAN_WARNING("The hive's influence doesn't reach that far!"))
-		return
-	if(status == EGG_GROWING)
-		to_chat(user, SPAN_WARNING("\The [src] is still growing, give it some time!"))
-		return
-	if(status != EGG_GROWN)
-		to_chat(user, SPAN_WARNING("\The [src] doesn't have any facehuggers to inhabit."))
-		return
-
-	if(!GLOB.hive_datum[hivenumber].can_spawn_as_hugger(user))
-		return
-	//Need to check again because time passed due to the confirmation window
-	if(status != EGG_GROWN)
-		to_chat(user, SPAN_WARNING("\The [src] doesn't have any facehuggers to inhabit."))
-		return
-	GLOB.hive_datum[hivenumber].spawn_as_hugger(user, src)
-	Burst(FALSE, FALSE, null, TRUE)
-
 //The invisible traps around the egg to tell it there's a mob right next to it.
 /obj/effect/egg_trigger
 	name = "egg trigger"

--- a/code/modules/cm_aliens/structures/special/egg_morpher.dm
+++ b/code/modules/cm_aliens/structures/special/egg_morpher.dm
@@ -195,10 +195,6 @@
 		return XENO_NONCOMBAT_ACTION
 	..()
 
-/obj/effect/alien/resin/special/eggmorph/attack_ghost(mob/dead/observer/user)
-	. = ..() //Do a view printout as needed just in case the observer doesn't want to join as a Hugger but wants info
-	join_as_facehugger_from_this(user)
-
 /obj/effect/alien/resin/special/eggmorph/proc/join_as_facehugger_from_this(mob/dead/observer/user)
 	if(stored_huggers <= huggers_reserved)
 		to_chat(user, SPAN_WARNING("\The [src] doesn't have any facehuggers to inhabit."))

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -928,21 +928,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(SSticker.mode.check_xeno_late_join(src))
 		SSticker.mode.attempt_to_join_as_xeno(src)
 
-/mob/dead/verb/join_as_facehugger()
-	set category = "Ghost.Join"
-	set name = "Join as a Facehugger"
-	set desc = "Try joining as a Facehugger from a Carrier or Egg Morpher."
-
-	if (!client)
-		return
-
-	if(SSticker.current_state < GAME_STATE_PLAYING || !SSticker.mode)
-		to_chat(src, SPAN_WARNING("The game hasn't started yet!"))
-		return
-
-	if(SSticker.mode.check_xeno_late_join(src))
-		SSticker.mode.attempt_to_join_as_facehugger(src)
-
 /mob/dead/verb/join_as_lesser_drone()
 	set category = "Ghost.Join"
 	set name = "Join as a Lesser Drone"


### PR DESCRIPTION

# About the pull request
Removes playable facehuggers
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
1. Playable huggers gain a priority for the person they captured in larva queue, The same person could respawn 5 times before you respawn once in larva queue if you don't want to be playing it, which is reasonable.
2. They do the job of a T2 caste while being a ghost role you can respawn as every 3 minutes or instantly if you get a hug. Basically providing frontline hugs without needing a competent carrier.
3. Providing backline hugs without needing weeds or carrier
4. Hard to balance without making them either useless or annoying to play against
5. Free metagaming role
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
del: Removes playable huggers from normal gameplay.
/:cl:
