### PR TITLE
Trijent Mapping Fix

### DIFF
--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -421,9 +421,6 @@
 	dir = 8
 	},
 /area/desert_dam/exterior/valley/valley_labs)
-"abt" = (
-/turf/open/desert/rock,
-/area/desert_dam/exterior/rock)
 "abu" = (
 /obj/effect/blocker/toxic_water,
 /turf/open/gm/river/desert/shallow_edge{
@@ -57196,9 +57193,6 @@
 	},
 /turf/open/asphalt,
 /area/desert_dam/exterior/river/riverside_south)
-"dTI" = (
-/turf/open/desert/rock,
-/area/desert_dam/building/hydroponics/hydroponics_breakroom)
 "dTK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/asphalt/cement_sunbleached{
@@ -92516,8 +92510,8 @@ dTs
 dTs
 dTs
 dTs
-dTI
-dTI
+dTs
+dTs
 cPL
 cTk
 cTO
@@ -92750,8 +92744,8 @@ dTs
 dTs
 dTs
 dTs
-dTI
-dTI
+dTs
+dTs
 cPL
 cTl
 cTO
@@ -92985,7 +92979,7 @@ dTs
 dTs
 dTs
 dTs
-abt
+dTs
 cPL
 cTm
 cTO


### PR DESCRIPTION
# About the pull request

Fills in a random hole in the wall.

# Explain why it's good for the game

I think this was a map oversight or an unfinished easter egg? It's just a random hole in the wall with nothing in it - I'm mostly removing this because Burrowers can potentially burrow in and hide there, basically being impossible to find. It serves no purpose so I don't see why it should stay.

# Changelog

:cl:
maptweak: Filled in a hole in the map.
/:cl:
