### PR TITLE
Delayless resin doors

### DIFF
--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -416,7 +416,6 @@
 	isSwitchingStates = 1
 	playsound(loc, "alien_resin_move", 25)
 	flick("[mineralType]opening",src)
-	sleep(3)
 	density = FALSE
 	opacity = FALSE
 	state = 1

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -503,7 +503,14 @@
 	Decorate()
 
 	RegisterSignal(src, COMSIG_MOB_SCREECH_ACT, PROC_REF(handle_screech_act))
+	RegisterSignal(src, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(check_door))
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_XENO_SPAWN, src)
+
+/mob/living/carbon/xenomorph/proc/check_door(mob/xeno, turf/new_loc)
+	SIGNAL_HANDLER
+	for(var/obj/structure/mineral_door/resin/door in new_loc.contents)
+		if(door.hivenumber == hivenumber)
+			door.Open()
 
 /mob/living/carbon/xenomorph/proc/handle_screech_act(mob/self, mob/living/carbon/xenomorph/queen/queen)
 	SIGNAL_HANDLER


### PR DESCRIPTION

# About the pull request
Removes delay when moving into a resin door for xenos
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Waiting for doors to open is annoying so the idea is qol and I believe the balance wise it isn't too much of an advantage but probably has to be tested what people do with it (e.g door spam)
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Removed delay when trying to move into a resin door for xenos
/:cl:
