### PR TITLE
Added Vendables to Staff Officer Closet

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/staff_officer_armory.dm
+++ b/code/game/machinery/vending/vendor_types/crew/staff_officer_armory.dm
@@ -82,6 +82,8 @@ GLOBAL_LIST_INIT(cm_vending_clothing_staff_officer_armory, list(
 		list("Space Cleaner", 2, /obj/item/reagent_container/spray/cleaner, null, VENDOR_ITEM_REGULAR),
 		list("Blowtorch", 5, /obj/item/tool/weldingtool, null, VENDOR_ITEM_REGULAR),
 		list("Wrench", 1, /obj/item/tool/wrench, null, VENDOR_ITEM_REGULAR),
+		list("Crowbar", 1, /obj/item/tool/crowbar, null, VENDOR_ITEM_REGULAR),
+		list("Entrenching Tool", 1, /obj/item/tool/shovel/etool, null, VENDOR_ITEM_REGULAR),
 		list("Whistle", 5, /obj/item/device/whistle, null, VENDOR_ITEM_REGULAR),
 		list("Machete Scabbard (Full)", 5, /obj/item/storage/large_holster/machete/full, null, VENDOR_ITEM_REGULAR)
 	))

--- a/code/game/machinery/vending/vendor_types/crew/staff_officer_armory.dm
+++ b/code/game/machinery/vending/vendor_types/crew/staff_officer_armory.dm
@@ -80,6 +80,8 @@ GLOBAL_LIST_INIT(cm_vending_clothing_staff_officer_armory, list(
 		list("Fulton Recovery Device", 5, /obj/item/stack/fulton, null, VENDOR_ITEM_REGULAR),
 		list("Motion Detector", 5, /obj/item/device/motiondetector, null, VENDOR_ITEM_REGULAR),
 		list("Space Cleaner", 2, /obj/item/reagent_container/spray/cleaner, null, VENDOR_ITEM_REGULAR),
+		list("Blowtorch", 5, /obj/item/tool/weldingtool, null, VENDOR_ITEM_REGULAR),
+		list("Wrench", 1, /obj/item/tool/wrench, null, VENDOR_ITEM_REGULAR),
 		list("Whistle", 5, /obj/item/device/whistle, null, VENDOR_ITEM_REGULAR),
 		list("Machete Scabbard (Full)", 5, /obj/item/storage/large_holster/machete/full, null, VENDOR_ITEM_REGULAR)
 	))

--- a/code/game/machinery/vending/vendor_types/crew/staff_officer_armory.dm
+++ b/code/game/machinery/vending/vendor_types/crew/staff_officer_armory.dm
@@ -69,6 +69,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_staff_officer_armory, list(
 
 		list("OTHER SUPPLIES", 0, null, null, null),
 		list("Medical Helmet Optic", 5, /obj/item/device/helmet_visor/medical, null, VENDOR_ITEM_REGULAR),
+		list("Welding Visor", 5, /obj/item/device/helmet_visor/welding_visor, null, VENDOR_ITEM_REGULAR),
 		list("Magnetic Harness", 12, /obj/item/attachable/magnetic_harness, null, VENDOR_ITEM_REGULAR),
 		list("Radio Telephone Pack", 15, /obj/item/storage/backpack/marine/satchel/rto, null, VENDOR_ITEM_RECOMMENDED),
 		list("Binoculars", 5,/obj/item/device/binoculars, null, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/crew/staff_officer_armory.dm
+++ b/code/game/machinery/vending/vendor_types/crew/staff_officer_armory.dm
@@ -18,6 +18,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_staff_officer_armory, list(
 		list("Marine Combat Gloves", 0, /obj/item/clothing/gloves/marine, MARINE_CAN_BUY_GLOVES, VENDOR_ITEM_MANDATORY),
 		list("MRE", 0, /obj/item/storage/box/MRE, MARINE_CAN_BUY_MRE, VENDOR_ITEM_MANDATORY),
 		list("Aviator Shades", 0, /obj/item/clothing/glasses/sunglasses/aviator, MARINE_CAN_BUY_GLASSES, VENDOR_ITEM_REGULAR),
+		list("Bayonet", 0, /obj/item/attachable/bayonet, null, VENDOR_ITEM_REGULAR),
 
 		list("SPECIALISATION KIT (CHOOSE 1)", 0, null, null, null),
 		list("Essential Engineer Set", 0, /obj/effect/essentials_set/engi, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_RECOMMENDED),


### PR DESCRIPTION
# About the pull request

Adds the bayonet to the Staff Officer locker as a separate free item. 

Adds Welding Visor, wrench, blowtorch, crowbar, shovel as paid items.
5, 1, 5, 1, 1 points respectively

# Explain why it's good for the game

Officers can't "just get" a bayonet, unless they use their boot knife. 
It makes deploying overly cumbersome, or you just lose your boot knife and can't remove shrapnel if you deploy. 

SO are also an all specialization leadership role, so allowing them to just help stuff really helps. 
They can take engineering kits, but don't get useful tools. 

An SO will likely want a wrench to disassemble window frames for movement or mats. 
I also added crowbar incase they want to mess with folding cases or open doors. 
Shovel to let them close tunnels. 

Doesn't permit every tool, just the "most useful" ones. 
If an SO wants to Com Tech, he'll have to take that tool belt for specialized tools like screwdrivers, and wirecutters.
But general support like a welder to fix cades makes sense to me.

Just lets SO take random one off tools if they want it. 
Permits general "fill help" so to speak. 

# Testing Photographs and Procedure

<details>


https://github.com/cmss13-devs/cmss13/assets/142365554/2e062524-fd3f-4e23-a030-69d6d5389d04

![image](https://github.com/cmss13-devs/cmss13/assets/142365554/a970997c-b17b-44b6-bf86-5d0d35078d38)

![image](https://github.com/cmss13-devs/cmss13/assets/142365554/5e939d3f-a48f-4d57-9b19-7837d0d53baa)


</details>


# Changelog

:cl:
add: Multiple tools, and welding visor to SO Locker
qol: Adds free bayonet to Staff Officer Locker
/:cl:


