### PR TITLE
Adds Floors for 6312 Soro Strata APC

### DIFF
--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -32746,6 +32746,15 @@
 "idW" = (
 /turf/closed/wall/strata_outpost/reinforced/hull,
 /area/strata/ug/interior/outpost/jung/dorms/sec1)
+"ifM" = (
+/obj/item/lightstick/red/planted,
+/obj/structure/bed/chair/office{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	icon_state = "darkpurple2"
+	},
+/area/strata/ag/exterior/tcomms/tcomms_deck)
 "ifU" = (
 /obj/structure/machinery/camera/autoname{
 	dir = 1
@@ -37312,7 +37321,10 @@
 	pixel_x = -23;
 	start_charge = 0
 	},
-/turf/open/auto_turf/snow/brown_base/layer2,
+/turf/open/floor/prison{
+	dir = 4;
+	icon_state = "darkpurple2"
+	},
 /area/strata/ag/exterior/tcomms/tcomms_deck)
 "pGt" = (
 /turf/closed/shuttle/ert{
@@ -39967,6 +39979,11 @@
 	},
 /turf/open/auto_turf/ice/layer0,
 /area/strata/ag/exterior/marsh/center)
+"tYY" = (
+/turf/open/floor/prison{
+	icon_state = "darkpurple2"
+	},
+/area/strata/ag/exterior/tcomms/tcomms_deck)
 "tZF" = (
 /obj/structure/machinery/power/apc{
 	dir = 1;
@@ -41448,6 +41465,12 @@
 	},
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/security)
+"wuD" = (
+/turf/open/floor/prison{
+	dir = 6;
+	icon_state = "darkpurple2"
+	},
+/area/strata/ag/exterior/tcomms/tcomms_deck)
 "wuE" = (
 /obj/structure/barricade/handrail/strata{
 	dir = 8
@@ -56679,7 +56702,7 @@ aac
 aac
 aac
 aac
-btu
+ifM
 btv
 btq
 aac
@@ -56874,7 +56897,7 @@ aac
 aac
 aac
 qmw
-btq
+tYY
 btq
 buN
 aac
@@ -57069,7 +57092,7 @@ aac
 aac
 aac
 pGf
-btv
+wuD
 btq
 xre
 aac


### PR DESCRIPTION
# About the pull request

Fixes https://github.com/cmss13-devs/cmss13/issues/6312

# Explain why it's good for the game

Allows APC to be fixed/worked on

# Testing Photographs and Procedure

🫠 

<details>
Took floor tile from Desert_Dam where an APC was and just selected a different colour sprite that seemed like it looked nice. 

</details>


# Changelog

:cl:
fix: Adds Floors that can allow APC to be fixed on Soro Comms 2 near south LZ
maptweak: Soro APC Comms 2 floor fixed
/:cl:

