### PR TITLE
Remove self-extinguishing with acid spray

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -116,7 +116,6 @@
 				var/mob/living/carbon/C = M
 				if (C.ally_of_hivenumber(hivenumber))
 					continue
-				
 				apply_spray(M)
 				M.apply_armoured_damage(get_xeno_damage_acid(M, damage_amount), ARMOR_BIO, BURN) // Deal extra damage when first placing ourselves down.
 

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -107,7 +107,7 @@
 		if(isliving(atm)) //For extinguishing mobs on fire
 			var/mob/living/M = atm
 
-			if(!(M == cause_data.resolve_mob()))
+			if(M != cause_data.resolve_mob())
 				M.ExtinguishMob()
 
 			if(M.stat == DEAD) // NO. DAMAGING. DEAD. MOBS.

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -106,14 +106,17 @@
 		// Humans?
 		if(isliving(atm)) //For extinguishing mobs on fire
 			var/mob/living/M = atm
-			M.ExtinguishMob()
+
+			if(!(M == cause_data.resolve_mob()))
+				M.ExtinguishMob()
+
 			if(M.stat == DEAD) // NO. DAMAGING. DEAD. MOBS.
 				continue
 			if (iscarbon(M))
 				var/mob/living/carbon/C = M
 				if (C.ally_of_hivenumber(hivenumber))
 					continue
-
+				
 				apply_spray(M)
 				M.apply_armoured_damage(get_xeno_damage_acid(M, damage_amount), ARMOR_BIO, BURN) // Deal extra damage when first placing ourselves down.
 
@@ -144,6 +147,9 @@
 
 /obj/effect/xenomorph/spray/Crossed(AM as mob|obj)
 	..()
+	if(AM == cause_data.resolve_mob())
+		return
+	
 	if(isliving(AM))
 		var/mob/living/living_mob = AM
 		if(living_mob.ally_of_hivenumber(hivenumber))


### PR DESCRIPTION

# About the pull request
This PR makes it so you cannot extinguish yourself with your own spray (this includes things that used to be possible like starting acid spray with base praetorian and dashing to the end or extinguishing yourself with spitter and bonus movement speed)
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Self-extinguishing discourages teamwork and makes castes that are supposed to be vulnerable to fire able to wipe it off easily.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: You can no longer extinguish yourself with your own acid spray.
/:cl:
