### PR TITLE
Fix humans seeing lesser drone information when examining the core

### DIFF
--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -62,6 +62,9 @@
 /obj/effect/alien/resin/special/pylon/get_examine_text(mob/user)
 	. = ..()
 
+	if(!isobserver(user) && !isxeno(user))
+		return
+
 	var/lesser_count = 0
 	for(var/mob/living/carbon/xenomorph/lesser_drone/lesser in linked_hive.totalXenos)
 		lesser_count++


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #4280 where it failed to make any check on the user examining the core.

# Explain why it's good for the game

Fixes #6509 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/029ae013-16be-4d35-8c86-6cd027b1fca3)

</details>


# Changelog
:cl: Drathek
fix: Fixed the core showing lesser drone counts to humans when examined
/:cl:
