### PR TITLE
Nuclear Authentication Disks reduce Nuclear Weapon decryption time.

### DIFF
--- a/code/game/machinery/nuclearbomb.dm
+++ b/code/game/machinery/nuclearbomb.dm
@@ -632,22 +632,18 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 
 /obj/structure/machinery/nuclearbomb/tech/attackby(obj/item/nuke_disk as obj, mob/user as mob)
 	var/reduction_multiplier = 0.7 //30% reduction
-	if(istype(nuke_disk, /obj/item/disk/nuclear))
+	if(!istype(nuke_disk, /obj/item/disk/nuclear))
 		attack_hand(user)
-		if(decrypting)
-			if (decryption_time > 0)
-				decryption_end_time = LERP(world.time, decryption_end_time, reduction_multiplier)
-				decryption_time = decryption_end_time - world.time
-				to_chat(user, SPAN_WARNING("The decryption process begins using the disk's data..."))
-				announce_to_players() //Let everyone know the new time
-				qdel(nuke_disk)
-				return
-			else
-				to_chat(user, SPAN_WARNING("Decryption is already complete..."))
-				return
-		else
-			to_chat(user, SPAN_WARNING("It needs to be decrypting first!"))
-			return
-	else
 		to_chat(user, SPAN_WARNING("You probably shouldn't hit it with \the [src]..."))
 		return
+	if(!decrypting)
+		to_chat(user, SPAN_WARNING("It needs to be decrypting first!"))
+		return
+	if(decryption_time <= 0)
+		to_chat(user, SPAN_WARNING("Decryption is already complete..."))
+		return
+	decryption_end_time = LERP(world.time, decryption_end_time, reduction_multiplier)
+	decryption_time = decryption_end_time - world.time
+	to_chat(user, SPAN_WARNING("The decryption process begins using the disk's data..."))
+	announce_to_players() //Let everyone know the new time
+	qdel(nuke_disk)

--- a/code/game/machinery/nuclearbomb.dm
+++ b/code/game/machinery/nuclearbomb.dm
@@ -629,3 +629,25 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 
 	decrypting = FALSE
 	announce_to_players()
+
+/obj/structure/machinery/nuclearbomb/tech/attackby(obj/item/nuke_disk as obj, mob/user as mob)
+	var/reduction_multiplier = 0.7 //30% reduction
+	if(istype(nuke_disk, /obj/item/disk/nuclear))
+		attack_hand(user)
+		if(decrypting)
+			if (decryption_time > 0)
+				decryption_end_time = LERP(world.time, decryption_end_time, reduction_multiplier)
+				decryption_time = decryption_end_time - world.time
+				to_chat(user, SPAN_WARNING("The decryption process begins using the disk's data..."))
+				announce_to_players() //Let everyone know the new time
+				qdel(nuke_disk)
+				return
+			else
+				to_chat(user, SPAN_WARNING("Decryption is already complete..."))
+				return
+		else
+			to_chat(user, SPAN_WARNING("It needs to be decrypting first!"))
+			return
+	else
+		to_chat(user, SPAN_WARNING("You probably shouldn't hit it with \the [src]..."))
+		return


### PR DESCRIPTION

# About the pull request

Adds a simple 30% reduction in what ever decryption time is left when we use a Nuclear Authentication Disk on a nuke.

Note: Has no effect on the admin spawned nuke which does not have a decryption timer.

# Explain why it's good for the game

Presently our maps have Nuclear Authentication Disks, and when found it's treated with some semblance of gravity, but in actuality they do nothing.  This rewards finding such an important object and in the occasion that the disk is found and the End Game for the round is also a decryption nuke.


# Testing Photographs and Procedure
Tested with all listed fail states contained within /obj/structure/machinery/nuclearbomb/tech/attackby()

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Nuclear Authentication Disks now reduce remaining decryption time by 30%.
/:cl:
