### PR TITLE
iron teeth character trait

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -233,6 +233,8 @@
 #define TRAIT_IN_TUTORIAL "t_IN_TUTORIAL"
 /// If the mob is cloaked in any form
 #define TRAIT_CLOAKED "t_cloaked"
+/// If the mob won't drop items held in face slot when downed
+#define TRAIT_IRON_TEETH "t_iron_teeth"
 
 // -- ability traits --
 /// Xenos with this trait cannot have plasma transfered to them

--- a/code/datums/elements/mouth_drop_item.dm
+++ b/code/datums/elements/mouth_drop_item.dm
@@ -18,7 +18,7 @@
 /datum/element/mouth_drop_item/proc/item_equipped(obj/item/I, mob/living/carbon/human/user, slot)
 	SIGNAL_HANDLER
 
-	if(slot == WEAR_FACE)
+	if(slot == WEAR_FACE && !HAS_TRAIT(user, TRAIT_IRON_TEETH))
 		I.RegisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION, TYPE_PROC_REF(/obj/item, drop_to_floor))
 
 /datum/element/mouth_drop_item/proc/item_dropped(obj/item/I, mob/living/carbon/human/user)

--- a/code/modules/character_traits/biology_traits.dm
+++ b/code/modules/character_traits/biology_traits.dm
@@ -130,3 +130,16 @@
 /datum/character_trait/biology/hardcore/unapply_trait(mob/living/carbon/human/target)
 	REMOVE_TRAIT(target, TRAIT_HARDCORE, ROUNDSTART_TRAIT)
 	..()
+
+/datum/character_trait/biology/iron_teeth
+	trait_name = "Iron Teeth"
+	trait_desc = "You've got iron teeth or really good dental insurance. Items in your face slot won't fall out when you go down."
+	applyable = TRUE
+	cost = 1
+/datum/character_trait/biology/iron_teeth/apply_trait(mob/living/carbon/human/target, datum/equipment_preset/preset)
+	ADD_TRAIT(target, TRAIT_IRON_TEETH, ROUNDSTART_TRAIT)
+	..()
+
+/datum/character_trait/biology/lisp/unapply_trait(mob/living/carbon/human/target)
+	REMOVE_TRAIT(target, TRAIT_IRON_TEETH, ROUNDSTART_TRAIT)
+	..()

--- a/code/modules/character_traits/biology_traits.dm
+++ b/code/modules/character_traits/biology_traits.dm
@@ -136,6 +136,7 @@
 	trait_desc = "You've got iron teeth or really good dental insurance. Items in your face slot won't fall out when you go down."
 	applyable = TRUE
 	cost = 1
+
 /datum/character_trait/biology/iron_teeth/apply_trait(mob/living/carbon/human/target, datum/equipment_preset/preset)
 	ADD_TRAIT(target, TRAIT_IRON_TEETH, ROUNDSTART_TRAIT)
 	..()

--- a/code/modules/character_traits/biology_traits.dm
+++ b/code/modules/character_traits/biology_traits.dm
@@ -140,6 +140,6 @@
 	ADD_TRAIT(target, TRAIT_IRON_TEETH, ROUNDSTART_TRAIT)
 	..()
 
-/datum/character_trait/biology/lisp/unapply_trait(mob/living/carbon/human/target)
+/datum/character_trait/biology/iron_teeth/unapply_trait(mob/living/carbon/human/target)
 	REMOVE_TRAIT(target, TRAIT_IRON_TEETH, ROUNDSTART_TRAIT)
 	..()


### PR DESCRIPTION

# About the pull request
adds "iron teeth" trait for 1 point that allows marines to hold stuff in their face slot with no fear of it falling out when they drop
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
i tried to larp as rambo and my combat knife fell out of my mouth and i thought man you can only hold minor shit in your face slot would it be cool if it was a little more useful so here we are 
besides more character traits is good theres a shortage of them i think
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

got the trait... put a knife in my mouth... rested... hit myself with an explosion to stun... knife was still in my mouth... no runtimes

</details>


# Changelog
:cl:
add: Adds "Iron teeth" trait.
/:cl:
