### PR TITLE
removes macho sauce and water recipe

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -83,9 +83,6 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	for(var/datum/chem_property/P in properties)
 		P.post_update_reagent()
 
-	if(intensityfire >= 50)
-		burncolor = "#ffffff"
-
 /datum/reagent/proc/reaction_mob(mob/M, method=TOUCH, volume, permeable) //By default we have a chance to transfer some
 	if(!istype(M, /mob/living))
 		return FALSE

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -83,6 +83,9 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	for(var/datum/chem_property/P in properties)
 		P.post_update_reagent()
 
+	if(intensityfire >= 50)
+		burncolor = "#ffffff"
+
 /datum/reagent/proc/reaction_mob(mob/M, method=TOUCH, volume, permeable) //By default we have a chance to transfer some
 	if(!istype(M, /mob/living))
 		return FALSE

--- a/code/modules/reagents/chemistry_reactions/food_drink.dm
+++ b/code/modules/reagents/chemistry_reactions/food_drink.dm
@@ -131,15 +131,6 @@
 /datum/chemical_reaction/machosauce/infinite/pineapple
 	required_reagents = list("machosauce" = 1, "pineapple" = 1)
 
-/datum/chemical_reaction/machosauce/weaksauce
-	required_reagents = list("machosauce" = 1, "water" = 1)
-
-/datum/chemical_reaction/machosauce/weaksauce/infinite
-	required_reagents = list("machosauce" = 1, "weaksauce" = 1)
-
-/datum/chemical_reaction/machosauce/weaksauce/infinite/water
-	required_reagents = list("water" = 1, "weaksauce" = 1)
-
 /datum/chemical_reaction/sodiumchloride
 	name = "Sodium Chloride"
 	id = "sodiumchloride"


### PR DESCRIPTION

# About the pull request
removes the infinite macho sauce with water recipe
also what the hell is this "weaksauce"? theres no mention of it anywhere else in code, the chem straight up does not exist

# Explain why it's good for the game
create custom flamer chemical
chem needs water when mixing or else it will explode
get shafted by RNG and get macho sauce catalyst
macho sauce mixes with the water before the main reaction
get set on fire and die

# Testing Photographs and Procedure
probably works

# Changelog
:cl:
del: Removed macho sauce and water infinite recipe
/:cl:
