### PR TITLE
custom research chemicals with an intensityfire above or equal to 50 will now burn white

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -3235,7 +3235,7 @@ Defined in conflicts.dm of the #defines folder.
 	ammo_datum.flamer_reagent_id = flamer_reagent.id
 	P.generate_bullet(ammo_datum)
 	P.icon_state = "naptha_ball"
-	P.color = flamer_reagent.color
+	P.color = flamer_reagent.burncolor
 	P.hit_effect_color = flamer_reagent.burncolor
 	P.fire_at(target, user, user, max_range, AMMO_SPEED_TIER_2, null)
 	var/turf/user_turf = get_turf(user)

--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -728,6 +728,11 @@
 	holder.durationfire = max(holder.durationfire, 1)
 	holder.intensityfire = max(holder.intensityfire, 1)
 
+	if(holder.intensityfire >= 50 && istype(holder, /datum/reagent/generated))
+		holder.burncolor = "#ffffff"
+	else
+		holder.burncolor = holder.color
+
 /datum/chem_property/positive/fire/fueling
 	name = PROPERTY_FUELING
 	code = "FUL"


### PR DESCRIPTION

# About the pull request
title

# Explain why it's good for the game
warns the player of the high damage flame
super cool OB looking white flame very cool

# Testing Photographs and Procedure

https://github.com/cmss13-devs/cmss13/assets/140007537/484f7045-cd5e-45da-9822-b587cec7ea5d

# Changelog
:cl:
balance: Custom research chemicals with an intensityfire above or equal to 50 will now burn white.
/:cl:
