### PR TITLE
Only researchers can now use the biomass machine

### DIFF
--- a/code/modules/reagents/chemistry_machinery/xenomorph_analyzer.dm
+++ b/code/modules/reagents/chemistry_machinery/xenomorph_analyzer.dm
@@ -30,6 +30,9 @@
 	if(!skillcheck(user, SKILL_RESEARCH, SKILL_RESEARCH_TRAINED))
 		to_chat(user, SPAN_WARNING("You have no idea how to use this."))
 		return
+	if(user.job != JOB_RESEARCHER)
+		to_chat(user, SPAN_WARNING("Access denied."))
+		return
 	tgui_interact(user)
 
 /obj/structure/machinery/xenoanalyzer/tgui_interact(mob/user, datum/tgui/ui)


### PR DESCRIPTION
# About the pull request
only USCM researchers can now use the biomass analyzer

# Explain why it's good for the game
The biomass machine is there for researchers, CMO or survs shouldn't be able to barge in and waste all of your points instantly because "I want to"

# Testing Photographs and Procedure
it works

# Changelog
:cl:
add: Only researchers can now use the biomass analyzer.
/:cl:
