### PR TITLE
Jtac, Intel kits for req and IO vendor

### DIFF
--- a/code/datums/supply_packs/restricted_equipment.dm
+++ b/code/datums/supply_packs/restricted_equipment.dm
@@ -33,7 +33,7 @@
 	group = "Restricted Equipment"
 
 /datum/supply_packs/jtac_kit
-	name = "JTAC Radio Kit crate (x1 full flare gun belt, x2 m94 signal flare packs, 1x laser designator, 1x jtac radio key, 1x radiopack)"
+	name = "JTAC Radio Kit crate (x1 full flare gun belt, x2 M89-S signal flare packs, 1x laser designator, 1x jtac radio key, 1x radiopack)"
 	contains = list(
 		/obj/item/storage/box/kit/mini_jtac,
 	)

--- a/code/datums/supply_packs/restricted_equipment.dm
+++ b/code/datums/supply_packs/restricted_equipment.dm
@@ -21,3 +21,23 @@
 	containertype = /obj/structure/closet/crate
 	containername = "M4 pattern marine armor crate"
 	group = "Restricted Equipment"
+
+/datum/supply_packs/intel_kit
+	name = "Field Intelligence Support Kit crate (x1 fulton pack, x1 data detector, x1 intel pamphlet, x1 large document pouch, 1x intel radio key)"
+	contains = list(
+		/obj/item/storage/box/kit/mini_intel,
+	)
+	cost = 20
+	containertype = /obj/structure/closet/crate
+	containername = "Field Intelligence Support Kit crate"
+	group = "Restricted Equipment"
+
+/datum/supply_packs/jtac_kit
+	name = "JTAC Radio Kit crate (x1 full flare gun belt, x2 m94 signal flare packs, 1x laser designator, 1x jtac radio key, 1x radiopack)"
+	contains = list(
+		/obj/item/storage/box/kit/mini_jtac,
+	)
+	cost = 30
+	containertype = /obj/structure/closet/crate
+	containername = "JTAC Radio Kit crate"
+	group = "Restricted Equipment"

--- a/code/game/machinery/vending/vendor_types/intelligence_officer.dm
+++ b/code/game/machinery/vending/vendor_types/intelligence_officer.dm
@@ -52,6 +52,9 @@ GLOBAL_LIST_INIT(cm_vending_gear_intelligence_officer, list(
 
 		list("RADIO KEYS", 0, null, null, null),
 		list("Intel Radio Encryption Key", 5, /obj/item/device/encryptionkey/intel, null, VENDOR_ITEM_REGULAR),
+
+		list("SPARE INTEL KIT", 0, null, null, null),
+		list("Field Intelligence Support Kit (For untrained personnel)", 20, /obj/item/storage/box/kit/mini_intel, null, VENDOR_ITEM_REGULAR),
 	))
 
 /obj/structure/machinery/cm_vending/gear/intelligence_officer

--- a/code/modules/cm_marines/equipment/kit_boxes.dm
+++ b/code/modules/cm_marines/equipment/kit_boxes.dm
@@ -483,6 +483,7 @@
 	new /obj/item/storage/box/m94/signal(src)
 	new /obj/item/device/binoculars/range/designator(src)
 	new /obj/item/device/encryptionkey/jtac(src)
+	new /obj/item/storage/backpack/marine/satchel/rto(src)
 
 /obj/item/storage/box/kit/mini_intel
 	name = "\improper Field Intelligence Support Kit"
@@ -493,7 +494,7 @@
 	new /obj/item/device/encryptionkey/intel(src)
 	new /obj/item/pamphlet/skill/intel(src)
 	new /obj/item/device/motiondetector/intel(src)
-	new /obj/item/storage/pouch/document/small(src)
+	new /obj/item/storage/pouch/document(src)
 
 /obj/item/storage/box/kit/mini_grenadier
 	name = "\improper Frontline M40 Grenadier Kit"


### PR DESCRIPTION
# About the pull request

Adds Jtac and Intel kits to req

Swaps small doc pouch with large one in intel kit.

Added radiopack to Jtac kit.

Adds Intel kit to IO vendor


# Explain why it's good for the game

Req now has ability to compensate lack of jtac/intel personnel, especially if jtac pamphlets are out or if all IOs are dead/missing.

IOs on the other hand, can assign addional mini IOs to their squad more easily.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![8jXEpgQEM9](https://github.com/cmss13-devs/cmss13/assets/100090741/66445a9e-c05c-417e-ae34-0f8fffaf00fd)
![VMpjJotr3q](https://github.com/cmss13-devs/cmss13/assets/100090741/fde8de1e-4de6-46be-8d70-9c804f250fdf)


</details>


# Changelog
:cl:
add: jtac and Intel kits to ASRS store
add: Intel kit to IO points vendor
balance: intel kit now has large doc pouch instead of small
balance: jtac kit now has radiopack
/:cl:
