### PR TITLE
demo scanner now properly works for incinerator tanks

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -340,6 +340,20 @@ FORENSIC SCANNER
 	ex_potential = 0
 	int_potential = 0
 	rad_potential = 0
+
+	if(istype(O, /obj/item/ammo_magazine/flamer_tank))
+		var/obj/item/ammo_magazine/flamer_tank/tank = O
+		if(tank.reagents.reagent_list.len < 1)
+			to_chat(user, SPAN_NOTICE("No fuel detected in [O]"))
+			return
+		var/result
+		var/datum/reagent/chem = tank.reagents.reagent_list[1]
+		result += SPAN_BLUE("<br>Intensity: [min(chem.intensityfire, tank.max_intensity)]")
+		result += SPAN_BLUE("<br>Duration: [min(chem.durationfire, tank.max_duration)]")
+		result += SPAN_BLUE("<br>Range: [min(chem.rangefire, tank.max_range)]")
+		to_chat(user, SPAN_NOTICE("[result]"))
+		return
+
 	if(istype(O,/obj/item/explosive))
 		var/obj/item/explosive/E = O
 		if(!E.customizable)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -343,7 +343,7 @@ FORENSIC SCANNER
 
 	if(istype(O, /obj/item/ammo_magazine/flamer_tank))
 		var/obj/item/ammo_magazine/flamer_tank/tank = O
-		if(tank.reagents.reagent_list.len < 1)
+		if(!length(tank.reagents.reagent_list))
 			to_chat(user, SPAN_NOTICE("No fuel detected in [O]"))
 			return
 		var/result

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -348,6 +348,7 @@ FORENSIC SCANNER
 			return
 		var/result
 		var/datum/reagent/chem = tank.reagents.reagent_list[1]
+		result += SPAN_BLUE("Fuel Statistics:")
 		result += SPAN_BLUE("<br>Intensity: [min(chem.intensityfire, tank.max_intensity)]")
 		result += SPAN_BLUE("<br>Duration: [min(chem.durationfire, tank.max_duration)]")
 		result += SPAN_BLUE("<br>Range: [min(chem.rangefire, tank.max_range)]")

--- a/code/modules/projectiles/magazines/flamer.dm
+++ b/code/modules/projectiles/magazines/flamer.dm
@@ -244,7 +244,7 @@
 	max_duration = 50
 
 /obj/item/ammo_magazine/flamer_tank/smoke
-	name = "Custom incinerator smoke tank"
+	name = "custom incinerator smoke tank"
 	desc = "A tank holding powdered smoke that expands when exposed to an open flame and carries any chemicals along with it."
 	matter = list("metal" = 3750)
 	flamer_chem = null
@@ -252,7 +252,7 @@
 
 //tanks printable by the research biomass machine
 /obj/item/ammo_magazine/flamer_tank/custom/upgraded
-	name = "Upgraded custom incinerator tank"
+	name = "upgraded custom incinerator tank"
 	desc = "A fuel tank used to store fuel for use in the M240 incinerator unit. This one has been modified with a larger and more sophisticated internal propellant tank, allowing for bigger capacity and stronger fuels."
 	matter = list("metal" = 50) // no free metal
 	flamer_chem = null
@@ -264,7 +264,7 @@
 	custom = TRUE
 
 /obj/item/ammo_magazine/flamer_tank/smoke/upgraded
-	name = "Large custom incinerator smoke tank"
+	name = "large custom incinerator smoke tank"
 	desc = "A tank holding powdered smoke that expands when exposed to an open flame and carries any chemicals along with it. This one has been outfitted with an upgraded internal compressor, allowing for bigger capacity."
 	matter = list("metal" = 50) //no free metal
 	flamer_chem = null


### PR DESCRIPTION
# About the pull request
will now display the stats of the reagent itself instead of the mix of 100 units. Will also display the caps of the tank instead if the reagent goes above them
also fixes some grammar

# Explain why it's good for the game
bug fix good
grammar fix good

# Testing Photographs and Procedure
scanning a normal flamer fuel tank:
![demo scanner](https://github.com/cmss13-devs/cmss13/assets/140007537/8d5a746a-cb2b-4040-a658-e3aaf90ea10b)

image is outdated. I added "fuel statistics" above intensity

# Changelog
:cl:
fix: Demolitions scanner now properly works for incinerator tanks.
spellcheck: Fixed some capitalization with custom incinerator tanks.
/:cl:
