### PR TITLE
length() over .len

### DIFF
--- a/code/__DEFINES/tgs.config.dm
+++ b/code/__DEFINES/tgs.config.dm
@@ -8,5 +8,5 @@
 #define TGS_WARNING_LOG(message) log_world("TGS Warn: [##message]")
 #define TGS_ERROR_LOG(message) log_world("TGS Error: [##message]")
 #define TGS_NOTIFY_ADMINS(event) message_admins(##event)
-#define TGS_CLIENT_COUNT GLOB.clients.len
+#define TGS_CLIENT_COUNT length(GLOB.clients)
 #define TGS_PROTECT_DATUM(Path) GENERAL_PROTECT_DATUM(##Path)

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -103,7 +103,7 @@
 /proc/bitfield_to_list(bitfield = 0, list/wordlist)
 	var/list/return_list = list()
 	if(islist(wordlist))
-		var/max = min(wordlist.len, 24)
+		var/max = min(length(wordlist), 24)
 		var/bit = 1
 		for(var/i in 1 to max)
 			if(bitfield & bit)
@@ -148,10 +148,10 @@
  * Returns TRUE if the list had nulls, FALSE otherwise
 **/
 /proc/list_clear_nulls(list/list_to_clear)
-	var/start_len = list_to_clear.len
+	var/start_len = length(list_to_clear)
 	var/list/new_list = new(start_len)
 	list_to_clear -= new_list
-	return list_to_clear.len < start_len
+	return length(list_to_clear) < start_len
 
 ///Return a list with no duplicate entries
 /proc/unique_list(list/inserted_list)
@@ -174,6 +174,6 @@
 	if(!inserted_list)
 		return
 
-	for(var/i in 1 to inserted_list.len - 1)
-		inserted_list.Swap(i, rand(i, inserted_list.len))
+	for(var/i in 1 to length(inserted_list) - 1)
+		inserted_list.Swap(i, rand(i, length(inserted_list)))
 

--- a/code/__HELPERS/chat.dm
+++ b/code/__HELPERS/chat.dm
@@ -22,7 +22,7 @@
 		if((!admin_only || channel.is_admin_channel) && (channel_tag in applicable_tags))
 			channels_to_use += channel
 
-	if(channels_to_use.len)
+	if(length(channels_to_use))
 		world.TgsChatBroadcast(message, channels_to_use)
 
 /**

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -58,7 +58,7 @@
 
 /proc/recursive_mob_check(atom/O, list/L = list(), recursion_limit = 3, client_check = 1, sight_check = 1, include_radio = 1)
 
-	//debug_mob += O.contents.len
+	//debug_mob += length(O.contents)
 	if(!recursion_limit)
 		return L
 	for(var/atom/A in O.contents)
@@ -294,7 +294,7 @@
  * * cache_only - Whether to not actually send a to_chat message and instead only update larva_queue_cached_message
  */
 /proc/message_alien_candidates(list/candidates, dequeued, cache_only = FALSE)
-	for(var/i in (1 + dequeued) to candidates.len)
+	for(var/i in (1 + dequeued) to length(candidates))
 		var/mob/dead/observer/cur_obs = candidates[i]
 
 		// Generate the messages

--- a/code/__HELPERS/guid.dm
+++ b/code/__HELPERS/guid.dm
@@ -6,7 +6,7 @@
 /proc/GUID()
 	var/const/GUID_VERSION = "b"
 	var/const/GUID_VARIANT = "d"
-	var/node_id = copytext_char(md5("[rand()*rand(1,9999999)][world.name][world.hub][world.hub_password][world.internet_address][world.address][world.contents.len][world.status][world.port][rand()*rand(1,9999999)]"), 1, 13)
+	var/node_id = copytext_char(md5("[rand()*rand(1,9999999)][world.name][world.hub][world.hub_password][world.internet_address][world.address][length(world.contents)][world.status][world.port][rand()*rand(1,9999999)]"), 1, 13)
 
 	var/time_high = "[num2hex(text2num(time2text(world.realtime,"YYYY")), 2)][num2hex(world.realtime, 6)]"
 

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -332,7 +332,7 @@ world
 /proc/getFlatIcon(image/appearance, defdir, deficon, defstate, defblend, start = TRUE, no_anim = FALSE, appearance_flags = FALSE)
 	// Loop through the underlays, then overlays, sorting them into the layers list
 	#define PROCESS_OVERLAYS_OR_UNDERLAYS(flat, process, base_layer) \
-		for (var/i in 1 to process.len) { \
+		for (var/i in 1 to length(process)) { \
 			var/image/current = process[i]; \
 			if (!current) { \
 				continue; \
@@ -347,7 +347,7 @@ world
 				} \
 				current_layer = base_layer + appearance.layer + current_layer / 1000; \
 			} \
-			for (var/index_to_compare_to in 1 to layers.len) { \
+			for (var/index_to_compare_to in 1 to length(layers)) { \
 				var/compare_to = layers[index_to_compare_to]; \
 				if (current_layer < layers[compare_to]) { \
 					layers.Insert(index_to_compare_to, current); \
@@ -403,7 +403,7 @@ world
 
 	var/curblend = appearance.blend_mode || defblend
 
-	if(appearance.overlays.len || appearance.underlays.len)
+	if(length(appearance.overlays) || length(appearance.underlays))
 		var/icon/flat = icon(flat_template)
 		// Layers will be a sorted list of icons/overlays, based on the order in which they are displayed
 		var/list/layers = list()
@@ -556,7 +556,7 @@ world
 /proc/sort_atoms_by_layer(list/atoms)
 	// Comb sort icons based on levels
 	var/list/result = atoms.Copy()
-	var/gap = result.len
+	var/gap = length(result)
 	var/swapped = 1
 	while (gap > 1 || swapped)
 		swapped = 0
@@ -564,7 +564,7 @@ world
 			gap = floor(gap / 1.3) // 1.3 is the emperic comb sort coefficient
 		if(gap < 1)
 			gap = 1
-		for(var/i = 1; gap + i <= result.len; i++)
+		for(var/i = 1; gap + i <= length(result); i++)
 			var/atom/l = result[i] //Fucking hate
 			var/atom/r = result[gap+i] //how lists work here
 			if(l.layer > r.layer) //no "result[i].layer" for me

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -12,7 +12,7 @@
 
 //Returns a list in plain english as a string
 /proc/english_list(list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "" )
-	var/total = input.len
+	var/total = length(input)
 	if (!total)
 		return "[nothing_text]"
 	else if (total == 1)
@@ -33,9 +33,9 @@
 
 //Returns list element or null. Should prevent "index out of bounds" error.
 /proc/listgetindex(list/list,index)
-	if(istype(list) && list.len)
+	if(istype(list) && length(list))
 		if(isnum(index))
-			if(ISINRANGE(index,1,list.len))
+			if(ISINRANGE(index,1,length(list)))
 				return list[index]
 		else if(list[index])
 			return list[index]
@@ -106,35 +106,35 @@
 /// Pick a random element from the list and remove it from the list.
 /proc/pick_n_take(list/L)
 	RETURN_TYPE(L[_].type)
-	if(L.len)
-		var/picked = rand(1,L.len)
+	if(length(L))
+		var/picked = rand(1,length(L))
 		. = L[picked]
 		L.Cut(picked,picked+1) //Cut is far more efficient that Remove()
 
 //Returns the top(last) element from the list and removes it from the list (typical stack function)
 /proc/pop(list/L)
-	if(L.len)
-		. = L[L.len]
+	if(length(L))
+		. = L[length(L)]
 		L.len--
 
 /proc/popleft(list/L)
-	if(L.len)
+	if(length(L))
 		. = L[1]
 		L.Cut(1,2)
 
 //Returns the next element in parameter list after first appearance of parameter element. If it is the last element of the list or not present in list, returns first element.
 /proc/next_in_list(element, list/L)
-	for(var/i=1, i<L.len, i++)
+	for(var/i=1, i<length(L), i++)
 		if(L[i] == element)
 			return L[i+1]
 	return L[1]
 
 //Returns the previous element in parameter list before last appearance of parameter element. If it is the first element of the list or not present in list, returns last element.
 /proc/prev_in_list(element, list/L)
-	for(var/i=L.len, i>1, i--)
+	for(var/i=length(L), i>1, i--)
 		if(L[i] == element)
 			return L[i-1]
-	return L[L.len]
+	return L[length(L)]
 
 /*
  * Sorting
@@ -144,7 +144,7 @@
 /proc/reverselist(list/L)
 	var/list/output = list()
 	if(L)
-		for(var/i = L.len; i >= 1; i--)
+		for(var/i = length(L); i >= 1; i--)
 			output += L[i]
 	return output
 
@@ -155,7 +155,7 @@
 		. = L_n
 		var/L_o[] = L.Copy()
 		var/i
-		while(L_o.len)
+		while(length(L_o))
 			i = pick(L_o)
 			if(!ref) L_n += i
 			else L_n[i] = L_o[i]
@@ -171,9 +171,9 @@
 
 //Mergesort: divides up the list into halves to begin the sort
 /proc/sortKey(list/client/L, order = 1)
-	if(isnull(L) || L.len < 2)
+	if(isnull(L) || length(L) < 2)
 		return L
-	var/middle = L.len / 2 + 1
+	var/middle = length(L) / 2 + 1
 	return mergeKey(sortKey(L.Copy(0,middle)), sortKey(L.Copy(middle)), order)
 
 //Mergsort: does the actual sorting and returns the results back to sortAtom
@@ -181,7 +181,7 @@
 	var/Li=1
 	var/Ri=1
 	var/list/result = new()
-	while(Li <= L.len && Ri <= R.len)
+	while(Li <= length(L) && Ri <= length(R))
 		var/client/rL = L[Li]
 		var/client/rR = R[Ri]
 		if(sorttext(rL.ckey, rR.ckey) == order)
@@ -189,20 +189,20 @@
 		else
 			result += R[Ri++]
 
-	if(Li <= L.len)
+	if(Li <= length(L))
 		return (result + L.Copy(Li, 0))
 	return (result + R.Copy(Ri, 0))
 
 // Quicksort implementation
 /proc/sortAtom(list/atom/L, order = 1)
-	if(isnull(L) || L.len < 2)
+	if(isnull(L) || length(L) < 2)
 		return L
 	var/startIndex = 1
 	var/list/atom/M = new/list()
 	for(var/atom/mob in L)
 		if(istype(mob))
 			M.Add(mob)
-	var/endIndex = M.len - 1
+	var/endIndex = length(M) - 1
 	var/top = 0
 	var/list/stack[endIndex*2]
 	stack[++top] = startIndex
@@ -241,9 +241,9 @@
 /proc/sortRecord(list/datum/data/record/L, field = "name", order = 1)
 	if(isnull(L))
 		return list()
-	if(L.len < 2)
+	if(length(L) < 2)
 		return L
-	var/middle = L.len / 2 + 1
+	var/middle = length(L) / 2 + 1
 	return mergeRecordLists(sortRecord(L.Copy(0, middle), field, order), sortRecord(L.Copy(middle), field, order), field, order)
 
 //Mergsort: does the actual sorting and returns the results back to sortRecord
@@ -252,7 +252,7 @@
 	var/Ri=1
 	var/list/result = new()
 	if(!isnull(L) && !isnull(R))
-		while(Li <= L.len && Ri <= R.len)
+		while(Li <= length(L) && Ri <= length(R))
 			var/datum/data/record/rL = L[Li]
 			if(isnull(rL))
 				L -= rL
@@ -266,7 +266,7 @@
 			else
 				result += R[Ri++]
 
-		if(Li <= L.len)
+		if(Li <= length(L))
 			return (result + L.Copy(Li, 0))
 	return (result + R.Copy(Ri, 0))
 
@@ -285,9 +285,9 @@
 	RETURN_TYPE(/list)
 	if(!istype(L))
 		return
-	if(L.len < 2)
+	if(length(L) < 2)
 		return L
-	var/middle = L.len / 2 + 1 // Copy is first,second-1
+	var/middle = length(L) / 2 + 1 // Copy is first,second-1
 	return mergeLists(sortList(L.Copy(0,middle)), sortList(L.Copy(middle))) //second parameter null = to end of list
 
 //Mergsorge: uses sortList() but uses the var's name specifically. This should probably be using mergeAtom() instead
@@ -301,13 +301,13 @@
 	var/Li=1
 	var/Ri=1
 	var/list/result = new()
-	while(Li <= L.len && Ri <= R.len)
+	while(Li <= length(L) && Ri <= length(R))
 		if(sorttext(L[Li], R[Ri]) < 1)
 			result += R[Ri++]
 		else
 			result += L[Li++]
 
-	if(Li <= L.len)
+	if(Li <= length(L))
 		return (result + L.Copy(Li, 0))
 	return (result + R.Copy(Ri, 0))
 
@@ -322,68 +322,68 @@
 
 // List of lists, sorts by element[key] - for things like crew monitoring computer sorting records by name.
 /proc/sortByKey(list/L, key)
-	if(L.len < 2)
+	if(length(L) < 2)
 		return L
-	var/middle = L.len / 2 + 1
+	var/middle = length(L) / 2 + 1
 	return mergeKeyedLists(sortByKey(L.Copy(0, middle), key), sortByKey(L.Copy(middle), key), key)
 
 /proc/mergeKeyedLists(list/L, list/R, key)
 	var/Li=1
 	var/Ri=1
 	var/list/result = new()
-	while(Li <= L.len && Ri <= R.len)
+	while(Li <= length(L) && Ri <= length(R))
 		if(sorttext(L[Li][key], R[Ri][key]) < 1)
 			// Works around list += list2 merging lists; it's not pretty but it works
 			result += "temp item"
-			result[result.len] = R[Ri++]
+			result[length(result)] = R[Ri++]
 		else
 			result += "temp item"
-			result[result.len] = L[Li++]
+			result[length(result)] = L[Li++]
 
-	if(Li <= L.len)
+	if(Li <= length(L))
 		return (result + L.Copy(Li, 0))
 	return (result + R.Copy(Ri, 0))
 
 
 //Mergesort: any value in a list, preserves key=value structure
 /proc/sortAssoc(list/L)
-	if(L.len < 2)
+	if(length(L) < 2)
 		return L
-	var/middle = L.len / 2 + 1 // Copy is first,second-1
+	var/middle = length(L) / 2 + 1 // Copy is first,second-1
 	return mergeAssoc(sortAssoc(L.Copy(0,middle)), sortAssoc(L.Copy(middle))) //second parameter null = to end of list
 
 /proc/mergeAssoc(list/L, list/R)
 	var/Li=1
 	var/Ri=1
 	var/list/result = new()
-	while(Li <= L.len && Ri <= R.len)
+	while(Li <= length(L) && Ri <= length(R))
 		if(sorttext(L[Li], R[Ri]) < 1)
 			result += R&R[Ri++]
 		else
 			result += L&L[Li++]
 
-	if(Li <= L.len)
+	if(Li <= length(L))
 		return (result + L.Copy(Li, 0))
 	return (result + R.Copy(Ri, 0))
 
 // Same as sortAssoc but rather than creating a whole new list keeps the original list ref and just returns that list modified
 /proc/sortAssocKeepList(list/L)
-	if(L.len < 2)
+	if(length(L) < 2)
 		return L
-	var/middle = L.len / 2 + 1 // Copy is first,second-1
+	var/middle = length(L) / 2 + 1 // Copy is first,second-1
 	return mergeAssocKeepList(sortAssoc(L.Copy(0,middle)), sortAssoc(L.Copy(middle)), L) //second parameter null = to end of list
 
 /proc/mergeAssocKeepList(list/L, list/R, list/original)
 	var/Li=1
 	var/Ri=1
 	var/list/result = new()
-	while(Li <= L.len && Ri <= R.len)
+	while(Li <= length(L) && Ri <= length(R))
 		if(sorttext(L[Li], R[Ri]) < 1)
 			result += R&R[Ri++]
 		else
 			result += L&L[Li++]
 
-	if(Li <= L.len)
+	if(Li <= length(L))
 		result += L.Copy(Li, 0)
 	else
 		result += R.Copy(Ri, 0)
@@ -408,7 +408,7 @@
 /proc/bitfield2list(bitfield = 0, list/wordlist)
 	var/list/r = list()
 	if(islist(wordlist))
-		var/max = min(wordlist.len,16)
+		var/max = min(length(wordlist),16)
 		var/bit = 1
 		for(var/i=1, i<=max, i++)
 			if(bitfield & bit)
@@ -430,9 +430,9 @@
 
 //Move a single element from position fromIndex within a list, to position toIndex
 //All elements in the range [1,toIndex) before the move will be before the pivot afterwards
-//All elements in the range [toIndex, L.len+1) before the move will be after the pivot afterwards
+//All elements in the range [toIndex, length(L)+1) before the move will be after the pivot afterwards
 //In other words, it's as if the range [fromIndex,toIndex) have been rotated using a <<< operation common to other languages.
-//fromIndex and toIndex must be in the range [1,L.len+1]
+//fromIndex and toIndex must be in the range [1,length(L)+1]
 //This will preserve associations ~Carnie
 /proc/moveElement(list/L, fromIndex, toIndex)
 	if(fromIndex == toIndex || fromIndex+1 == toIndex) //no need to move
@@ -493,13 +493,13 @@
 
 //replaces reverseList ~Carnie
 /proc/reverseRange(list/L, start=1, end=0)
-	if(L.len)
-		start = start % L.len
-		end = end % (L.len+1)
+	if(length(L))
+		start = start % length(L)
+		end = end % (length(L)+1)
 		if(start <= 0)
-			start += L.len
+			start += length(L)
 		if(end <= 0)
-			end += L.len + 1
+			end += length(L) + 1
 
 		--end
 		while(start < end)
@@ -518,13 +518,13 @@
 
 ///replaces reverseList ~Carnie
 /proc/reverse_range(list/inserted_list, start = 1, end = 0)
-	if(inserted_list.len)
-		start = start % inserted_list.len
-		end = end % (inserted_list.len + 1)
+	if(length(inserted_list))
+		start = start % length(inserted_list)
+		end = end % (length(inserted_list) + 1)
 		if(start <= 0)
-			start += inserted_list.len
+			start += length(inserted_list)
 		if(end <= 0)
-			end += inserted_list.len + 1
+			end += length(inserted_list) + 1
 
 		--end
 		while(start < end)
@@ -574,7 +574,7 @@
 	var/list/found = list()
 	for(var/atom/A in contents)
 		found += A
-		if(A.contents.len)
+		if(length(A.contents))
 			found += A.contents_recursive()
 	return found
 
@@ -582,7 +582,7 @@
 	var/list/found = list()
 	for(var/atom/A in contents)
 		found += A
-		if(A.contents.len)
+		if(length(A.contents))
 			found += A.contents
 	return found
 
@@ -594,15 +594,15 @@
 	if(!sort)
 		return L
 
-	if(L.len <= 1)
+	if(length(L) <= 1)
 		return L
 
-	var/middle = floor(L.len / 2)
+	var/middle = floor(length(L) / 2)
 	var/list/left = custom_mergesort(L.Copy(1, middle + 1))
 	var/list/right = custom_mergesort(L.Copy(middle + 1))
 	var/list/result = list()
 
-	while(left.len > 0 && right.len > 0)
+	while(length(left) > 0 && length(right) > 0)
 		var/a = left[1]
 		var/b = right[1]
 
@@ -613,11 +613,11 @@
 			result += b
 			right.Cut(1,2)
 
-	while(left.len > 0)
+	while(length(left) > 0)
 		result += left[1]
 		left.Cut(1,2)
 
-	while(right.len > 0)
+	while(length(right) > 0)
 		result += right[1]
 		right.Cut(1,2)
 

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -26,7 +26,7 @@
 			continue
 		valid_hairstyles[hairstyle] = GLOB.hair_styles_list[hairstyle]
 
-	if(valid_hairstyles.len)
+	if(length(valid_hairstyles))
 		h_style = pick(valid_hairstyles)
 
 	return h_style
@@ -48,7 +48,7 @@
 			continue
 		valid_facialhairstyles[facialhairstyle] = GLOB.facial_hair_styles_list[facialhairstyle]
 
-	if(valid_facialhairstyles.len)
+	if(length(valid_facialhairstyles))
 		f_style = pick(valid_facialhairstyles)
 
 		return f_style

--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -20,7 +20,7 @@
 /proc/sanitize_inlist(value, list/List, default)
 	if(value in List) return value
 	if(default) return default
-	if(List && List.len)return List[1]
+	if(LAZYLEN(List))return List[1]
 
 /proc/sanitize_list(list/List, list/filter = list(null), default = list())
 	if(!islist(List))

--- a/code/__HELPERS/shell.dm
+++ b/code/__HELPERS/shell.dm
@@ -20,7 +20,7 @@
 				shelleo_id = "[seo_id]"
 				break
 		if(!shelleo_id)
-			shelleo_id = "[shelleo_ids.len + 1]"
+			shelleo_id = "[length(shelleo_ids) + 1]"
 			shelleo_ids += shelleo_id
 			shelleo_ids[shelleo_id] = TRUE
 		out_file = "[SHELLEO_NAME][shelleo_id][SHELLEO_OUT]"

--- a/code/__HELPERS/sorts/TimSort.dm
+++ b/code/__HELPERS/sorts/TimSort.dm
@@ -1,12 +1,12 @@
 //TimSort interface
 /proc/sortTim(list/L, cmp=/proc/cmp_numeric_asc, associative, fromIndex=1, toIndex=0)
-	if(L && L.len >= 2)
-		fromIndex = fromIndex % L.len
-		toIndex = toIndex % (L.len+1)
+	if(length(L) >= 2)
+		fromIndex = fromIndex % length(L)
+		toIndex = toIndex % (length(L)+1)
 		if(fromIndex <= 0)
-			fromIndex += L.len
+			fromIndex += length(L)
 		if(toIndex <= 0)
-			toIndex += L.len + 1
+			toIndex += length(L) + 1
 
 		var/datum/sortInstance/sort_instance = GLOB.sortInstance
 		if(!sort_instance)

--- a/code/__HELPERS/sorts/_Main.dm
+++ b/code/__HELPERS/sorts/_Main.dm
@@ -76,7 +76,7 @@ GLOBAL_DATUM_INIT(sortInstance, /datum/sortInstance, new())
 		//Merge all remaining runs to complete sort
 	//ASSERT(start == end)
 	mergeForceCollapse();
-	//ASSERT(runBases.len == 1)
+	//ASSERT(length(runBases) == 1)
 
 		//reset minGallop, for successive calls
 	minGallop = MIN_GALLOP
@@ -178,8 +178,8 @@ GLOBAL_DATUM_INIT(sortInstance, /datum/sortInstance, new())
 //This method is called each time a new run is pushed onto the stack.
 //So the invariants are guaranteed to hold for i<stackSize upon entry to the method
 /datum/sortInstance/proc/mergeCollapse()
-	while(runBases.len >= 2)
-		var/n = runBases.len - 1
+	while(length(runBases) >= 2)
+		var/n = length(runBases) - 1
 		if(n > 1 && runLens[n-1] <= runLens[n] + runLens[n+1])
 			if(runLens[n-1] < runLens[n+1])
 				--n
@@ -193,8 +193,8 @@ GLOBAL_DATUM_INIT(sortInstance, /datum/sortInstance, new())
 //Merges all runs on the stack until only one remains.
 //Called only once, to finalise the sort
 /datum/sortInstance/proc/mergeForceCollapse()
-	while(runBases.len >= 2)
-		var/n = runBases.len - 1
+	while(length(runBases) >= 2)
+		var/n = length(runBases) - 1
 		if(n > 1 && runLens[n-1] < runLens[n+1])
 			--n
 		mergeAt(n)
@@ -204,9 +204,9 @@ GLOBAL_DATUM_INIT(sortInstance, /datum/sortInstance, new())
 	//Run i must be the penultimate or antepenultimate run on the stack
 	//In other words, i must be equal to stackSize-2 or stackSize-3
 /datum/sortInstance/proc/mergeAt(i)
-	//ASSERT(runBases.len >= 2)
+	//ASSERT(length(runBases) >= 2)
 	//ASSERT(i >= 1)
-	//ASSERT(i == runBases.len - 1 || i == runBases.len - 2)
+	//ASSERT(i == length(runBases) - 1 || i == length(runBases) - 2)
 
 	var/base1 = runBases[i]
 	var/base2 = runBases[i+1]
@@ -596,8 +596,8 @@ GLOBAL_DATUM_INIT(sortInstance, /datum/sortInstance, new())
 
 	while(remaining > 0)
 
-	while(runBases.len >= 2)
-		var/n = runBases.len - 1
+	while(length(runBases) >= 2)
+		var/n = length(runBases) - 1
 		if(n > 1 && runLens[n-1] <= runLens[n] + runLens[n+1])
 			if(runLens[n-1] < runLens[n+1])
 				--n
@@ -607,8 +607,8 @@ GLOBAL_DATUM_INIT(sortInstance, /datum/sortInstance, new())
 		else
 			break //Invariant is established
 
-	while(runBases.len >= 2)
-		var/n = runBases.len - 1
+	while(length(runBases) >= 2)
+		var/n = length(runBases) - 1
 		if(n > 1 && runLens[n-1] < runLens[n+1])
 			--n
 		mergeAt2(n)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -534,7 +534,7 @@
 /atom/proc/GetAllContents(searchDepth = 5, list/toReturn = list())
 	for(var/atom/part as anything in contents)
 		toReturn += part
-		if(part.contents.len && searchDepth)
+		if(length(part.contents) && searchDepth)
 			part.GetAllContents(searchDepth - 1, toReturn)
 	return toReturn
 
@@ -555,7 +555,7 @@
 		if(part.loc != src) // That's a multitile atom, and it's not actually here stricto sensu
 			continue
 		toReturn += part
-		if(part.contents.len && searchDepth)
+		if(length(part.contents) && searchDepth)
 			part.GetAllContents(searchDepth - 1, toReturn)
 	return toReturn
 
@@ -1082,7 +1082,7 @@ GLOBAL_DATUM(action_purple_power_up, /image)
 
 	var/list/doors = new/list()
 
-	if(toupdate.len)
+	if(length(toupdate))
 		for(var/turf/T1 in toupdate)
 			for(var/obj/structure/machinery/door/D2 in T1)
 				doors += D2
@@ -1091,7 +1091,7 @@ GLOBAL_DATUM(action_purple_power_up, /image)
 			else
 				air_master.tiles_to_update += T1*/
 
-	if(fromupdate.len)
+	if(length(fromupdate))
 		for(var/turf/T2 in fromupdate)
 			for(var/obj/structure/machinery/door/D2 in T2)
 				doors += D2
@@ -1287,7 +1287,7 @@ GLOBAL_LIST_INIT(WALLITEMS, list(
 	for(var/turf/T in orange(origin, outer_range))
 		if(!inner_range || get_dist(origin, T) >= inner_range)
 			turfs += T
-	if(turfs.len)
+	if(length(turfs))
 		return pick(turfs)
 
 // Returns true if arming a given explosive might be considered grief
@@ -1531,7 +1531,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		return GetAllContents()
 	var/list/processing = list(src)
 	var/list/assembled = list()
-	while(processing.len)
+	while(length(processing))
 		var/atom/A = processing[1]
 		processing.Cut(1,2)
 		if(!ignore_typecache[A.type])

--- a/code/_globalvars/global_lists.dm
+++ b/code/_globalvars/global_lists.dm
@@ -303,7 +303,7 @@ GLOBAL_LIST_INIT(hj_emotes, setup_hazard_joe_emotes())
 
 /proc/number_list_decode(number_list_data)
 	var/list/L = params2list(number_list_data)
-	for(var/i in 1 to L.len)
+	for(var/i in 1 to length(L))
 		L[i] = text2num(L[i])
 	return L
 

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -74,7 +74,7 @@
 	lazy_list[key] |= value;
 
 // Insert an object A into a sorted list using cmp_proc (/code/_helpers/cmp.dm) for comparison.
-#define ADD_SORTED(list, A, cmp_proc) if(!list.len) {list.Add(A)} else {list.Insert(FindElementIndex(A, list, cmp_proc), A)}
+#define ADD_SORTED(list, A, cmp_proc) if(!length(list)) {list.Add(A)} else {list.Insert(FindElementIndex(A, list, cmp_proc), A)}
 
 //Currently used in SDQL2 stuff
 #define send_output(target, msg, control) target << output(msg, control)

--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -262,10 +262,10 @@ Quick adjacency (to turf):
 	// Make sure pass flags are removed
 	A.remove_temp_pass_flags(pass_flags)
 
-	if ((fd1 && !blockers["fd1"].len) || (fd2 && !blockers["fd2"].len)) // This means that for a given direction it did not have a blocker
+	if ((fd1 && !length(blockers["fd1"])) || (fd2 && !length(blockers["fd2"]))) // This means that for a given direction it did not have a blocker
 		return src
 
-	if (blockers["fd1"].len || blockers["fd2"].len)
+	if (length(blockers["fd1"]) || length(blockers["fd2"]))
 		var/guaranteed_hit = 0 // indicates whether there is a guaranteed hit (aka there is not chance to bypass blocker). 0 = nothing
 		var/list/cur_dense_blockers = list()
 		for (var/atom/blocker in blockers["fd1"])

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -199,7 +199,7 @@
 
 	if (mods["alt"])
 		var/turf/T = get_turf(src)
-		if(T && user.TurfAdjacent(T) && T.contents.len)
+		if(T && user.TurfAdjacent(T) && length(T.contents))
 			user.set_listed_turf(T)
 
 		return TRUE

--- a/code/_onclick/click_hold.dm
+++ b/code/_onclick/click_hold.dm
@@ -88,7 +88,7 @@
 	if(mods["left"])
 		SEND_SIGNAL(src, COMSIG_CLIENT_LMB_DRAG, src_obj, over_obj, params)
 
-	var/atom/last_atom = LAZYACCESS(mouse_trace_history, mouse_trace_history.len)
+	var/atom/last_atom = LAZYACCESS(mouse_trace_history, length(mouse_trace_history))
 	if(over_obj == last_atom)
 		return
 

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -91,19 +91,19 @@
 /datum/hud/Destroy()
 	if(mymob.hud_used == src)
 		mymob.hud_used = null
-	if(static_inventory.len)
+	if(length(static_inventory))
 		for(var/thing in static_inventory)
 			qdel(thing)
 		static_inventory.Cut()
-	if(toggleable_inventory.len)
+	if(length(toggleable_inventory))
 		for(var/thing in toggleable_inventory)
 			qdel(thing)
 		toggleable_inventory.Cut()
-	if(hotkeybuttons.len)
+	if(length(hotkeybuttons))
 		for(var/thing in hotkeybuttons)
 			qdel(thing)
 		hotkeybuttons.Cut()
-	if(infodisplay.len)
+	if(length(infodisplay))
 		for(var/thing in infodisplay)
 			qdel(thing)
 		infodisplay.Cut()
@@ -188,24 +188,24 @@
 	switch(display_hud_version)
 		if(HUD_STYLE_STANDARD) //Default HUD
 			hud_shown = 1 //Governs behavior of other procs
-			if(static_inventory.len)
+			if(length(static_inventory))
 				screenmob.client.add_to_screen(static_inventory)
-			if(toggleable_inventory.len && inventory_shown)
+			if(length(toggleable_inventory) && inventory_shown)
 				screenmob.client.add_to_screen(toggleable_inventory)
-			if(hotkeybuttons.len && !hotkey_ui_hidden)
+			if(length(hotkeybuttons) && !hotkey_ui_hidden)
 				screenmob.client.add_to_screen(hotkeybuttons)
-			if(infodisplay.len)
+			if(length(infodisplay))
 				screenmob.client.add_to_screen(infodisplay)
 
 		if(HUD_STYLE_REDUCED) //Reduced HUD
 			hud_shown = 0 //Governs behavior of other procs
-			if(static_inventory.len)
+			if(length(static_inventory))
 				screenmob.client.remove_from_screen(static_inventory)
-			if(toggleable_inventory.len)
+			if(length(toggleable_inventory))
 				screenmob.client.remove_from_screen(toggleable_inventory)
-			if(hotkeybuttons.len)
+			if(length(hotkeybuttons))
 				screenmob.client.remove_from_screen(hotkeybuttons)
-			if(infodisplay.len)
+			if(length(infodisplay))
 				screenmob.client.add_to_screen(infodisplay)
 
 			//These ones are a part of 'static_inventory', 'toggleable_inventory' or 'hotkeybuttons' but we want them to stay
@@ -218,13 +218,13 @@
 
 		if(HUD_STYLE_NOHUD) //No HUD
 			hud_shown = 0 //Governs behavior of other procs
-			if(static_inventory.len)
+			if(length(static_inventory))
 				screenmob.client.remove_from_screen(static_inventory)
-			if(toggleable_inventory.len)
+			if(length(toggleable_inventory))
 				screenmob.client.remove_from_screen(toggleable_inventory)
-			if(hotkeybuttons.len)
+			if(length(hotkeybuttons))
 				screenmob.client.remove_from_screen(hotkeybuttons)
-			if(infodisplay.len)
+			if(length(infodisplay))
 				screenmob.client.remove_from_screen(infodisplay)
 
 	hud_version = display_hud_version

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -120,7 +120,7 @@
 	if(!screenmob?.client)
 		return
 
-	if(!gear.len)
+	if(!length(gear))
 		inventory_shown = FALSE
 		return //species without inv slots don't show items.
 

--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -143,9 +143,9 @@ GLOBAL_LIST_EMPTY(radial_menus)
 		zone = 360 - starting_angle + ending_angle
 
 	max_elements = floor(zone / min_angle)
-	var/paged = max_elements < choices.len
-	if(elements.len < max_elements)
-		var/elements_to_add = max_elements - elements.len
+	var/paged = max_elements < length(choices)
+	if(length(elements) < max_elements)
+		var/elements_to_add = max_elements - length(elements)
 		for(var/i in 1 to elements_to_add) //Create all elements
 			var/atom/movable/screen/radial/slice/new_element = new /atom/movable/screen/radial/slice
 			new_element.tooltips = use_tooltips
@@ -246,7 +246,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	selected_choice = choices_values[choice_id]
 
 /datum/radial_menu/proc/get_next_id()
-	return "c_[choices.len]"
+	return "c_[length(choices)]"
 
 /datum/radial_menu/proc/set_choices(list/new_choices, use_tooltips, use_labels)
 	if(length(choices))

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -119,7 +119,7 @@
 	layer = HUD_LAYER
 
 /atom/movable/screen/storage/proc/update_fullness(obj/item/storage/master_storage)
-	if(!master_storage.contents.len)
+	if(!length(master_storage.contents))
 		color = null
 	else
 		var/total_w = 0
@@ -131,7 +131,7 @@
 		if (master_storage.storage_slots == null)
 			fullness = floor(10*total_w/master_storage.max_storage_space)
 		else
-			fullness = floor(10*master_storage.contents.len/master_storage.storage_slots)
+			fullness = floor(10*length(master_storage.contents)/master_storage.storage_slots)
 		switch(fullness)
 			if(10)
 				color = "#ff0000"

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -90,7 +90,7 @@
 		power = floor(power * (1 + 0.25 * user.skills.get_skill_level(SKILL_MELEE_WEAPONS))) //25% bonus per melee level
 	if(!ishuman(M))
 		var/used_verb = "attacked"
-		if(attack_verb && attack_verb.len)
+		if(LAZYLEN(attack_verb))
 			used_verb = pick(attack_verb)
 		user.visible_message(SPAN_DANGER("[M] has been [used_verb] with [src][showname]."), \
 			SPAN_DANGER("You [used_verb] [M == user ? "yourself":M] with [src]."), null, 5, CHAT_TYPE_MELEE_HIT)

--- a/code/_onclick/ventcrawl.dm
+++ b/code/_onclick/ventcrawl.dm
@@ -24,10 +24,10 @@
 	for(var/obj/structure/pipes/vents/V in range(1))
 		if(Adjacent(V) && !V.welded)
 			pipes |= V
-	if(!pipes || !pipes.len)
+	if(!LAZYLEN(pipes))
 		to_chat(src, SPAN_WARNING("There are no pipes that we can ventcrawl into within range!"))
 		return
-	if(pipes.len == 1)
+	if(length(pipes) == 1)
 		pipe = pipes[1]
 	else
 		pipe = tgui_input_list(usr, "Crawl Through Vent", "Pick a pipe", pipes)

--- a/code/controllers/configuration/config_entry.dm
+++ b/code/controllers/configuration/config_entry.dm
@@ -125,7 +125,7 @@
 		if(isnull(temp))
 			return FALSE
 		new_list += temp
-	if(!new_list.len)
+	if(!length(new_list))
 		return FALSE
 	config_entry_value = new_list
 	return TRUE

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -329,7 +329,7 @@
 			continue
 		in_character_filter += REGEX_QUOTE(line)
 
-	ic_filter_regex = in_character_filter.len ? regex("\\b([jointext(in_character_filter, "|")])\\b", "i") : null
+	ic_filter_regex = length(in_character_filter) ? regex("\\b([jointext(in_character_filter, "|")])\\b", "i") : null
 
 //Message admins when you can.
 /datum/controller/configuration/proc/DelayedMessageAdmins(text)

--- a/code/controllers/mc/globals.dm
+++ b/code/controllers/mc/globals.dm
@@ -20,7 +20,7 @@ GLOBAL_REAL(GLOB, /datum/controller/global_vars)
 
 	QDEL_IN(exclude_these, 0) //signal logging isn't ready
 
-	log_world("[vars.len - gvars_datum_in_built_vars.len] global variables")
+	log_world("[length(vars) - length(gvars_datum_in_built_vars)] global variables")
 
 	Initialize()
 
@@ -42,10 +42,10 @@ GLOBAL_REAL(GLOB, /datum/controller/global_vars)
 	gvars_datum_init_order = list()
 	gvars_datum_protected_varlist = list(NAMEOF(src, gvars_datum_protected_varlist) = TRUE)
 	var/list/global_procs = typesof(/datum/controller/global_vars/proc)
-	var/expected_len = vars.len - gvars_datum_in_built_vars.len
-	if(global_procs.len != expected_len)
-		warning("Unable to detect all global initialization procs! Expected [expected_len] got [global_procs.len]!")
-		if(global_procs.len)
+	var/expected_len = length(vars) - length(gvars_datum_in_built_vars)
+	if(length(global_procs) != expected_len)
+		warning("Unable to detect all global initialization procs! Expected [expected_len] got [length(global_procs)]!")
+		if(length(global_procs))
 			var/list/expected_global_procs = vars - gvars_datum_in_built_vars
 			for(var/I in global_procs)
 				expected_global_procs -= replacetext("[I]", "InitGlobal", "")

--- a/code/controllers/mc/master.dm
+++ b/code/controllers/mc/master.dm
@@ -415,9 +415,9 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 
 		var/ss_runlevels = SS.runlevels
 		var/added_to_any = FALSE
-		for(var/I in 1 to GLOB.bitflags.len)
+		for(var/I in 1 to length(GLOB.bitflags))
 			if(ss_runlevels & GLOB.bitflags[I])
-				while(runlevel_sorted_subsystems.len < I)
+				while(length(runlevel_sorted_subsystems) < I)
 					runlevel_sorted_subsystems += list(list())
 				runlevel_sorted_subsystems[I] += SS
 				added_to_any = TRUE

--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -215,7 +215,7 @@
 			dock_controller_map[shuttle.docking_controller_tag] = shuttle
 
 	//search for the controllers, if we have one.
-	if(dock_controller_map.len)
+	if(length(dock_controller_map))
 		for(var/obj/structure/machinery/embedded_controller/radio/C in GLOB.machines) //only radio controllers are supported at the moment
 			if (istype(C.program, /datum/computer/file/embedded_program/docking))
 				if(dock_controller_map[C.id_tag])
@@ -226,7 +226,7 @@
 
 	//sanity check
 	//NO SANITY
-// if (dock_controller_map.len || dock_controller_map_station.len || dock_controller_map_offsite.len)
+// if (length(dock_controller_map) || length(dock_controller_map_station) || length(dock_controller_map_offsite))
 // var/dat = ""
 // for (var/dock_tag in dock_controller_map + dock_controller_map_station + dock_controller_map_offsite)
 // dat += "\"[dock_tag]\", "

--- a/code/controllers/subsystem/acid_pillar.dm
+++ b/code/controllers/subsystem/acid_pillar.dm
@@ -11,8 +11,8 @@ SUBSYSTEM_DEF(acid_pillar)
 	if (!resumed)
 		currentrun = queuedrun.Copy()
 
-	while (currentrun.len)
-		var/hash = currentrun[currentrun.len]
+	while (length(currentrun))
+		var/hash = currentrun[length(currentrun)]
 		var/datum/acid_spray_info/data = currentrun[hash]
 		currentrun.len--
 

--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -62,7 +62,7 @@ SUBSYSTEM_DEF(atoms)
 
 	processing_late_loaders = TRUE
 
-	for(var/I = 1; I <= late_loaders.len; I++)
+	for(var/I = 1; I <= length(late_loaders); I++)
 		var/atom/A = late_loaders[I]
 		//I hate that we need this
 		if(QDELETED(A))
@@ -70,7 +70,7 @@ SUBSYSTEM_DEF(atoms)
 		A.LateInitialize()
 
 	#ifdef TESTING
-	testing("Late initialized [late_loaders.len] atoms")
+	testing("Late initialized [length(late_loaders)] atoms")
 	#endif
 	late_loaders.Cut()
 	processing_late_loaders = FALSE
@@ -87,10 +87,10 @@ SUBSYSTEM_DEF(atoms)
 	var/list/mapload_arg = list(TRUE)
 	if(atoms)
 		#ifdef TESTING
-		count = atoms.len
+		count = length(atoms)
 		#endif
 
-		for(var/I in 1 to atoms.len)
+		for(var/I in 1 to length(atoms))
 			var/atom/A = atoms[I]
 			if(!(A.flags_atom & INITIALIZED))
 				CHECK_TICK

--- a/code/controllers/subsystem/cellauto.dm
+++ b/code/controllers/subsystem/cellauto.dm
@@ -9,15 +9,15 @@ SUBSYSTEM_DEF(cellauto)
 	var/list/currentrun = list()
 
 /datum/controller/subsystem/cellauto/stat_entry(msg)
-	msg = "C: [GLOB.cellauto_cells.len]"
+	msg = "C: [length(GLOB.cellauto_cells)]"
 	return ..()
 
 /datum/controller/subsystem/cellauto/fire(resumed = FALSE)
 	if (!resumed)
 		currentrun = GLOB.cellauto_cells.Copy()
 
-	while(currentrun.len)
-		var/datum/automata_cell/C = currentrun[currentrun.len]
+	while(length(currentrun))
+		var/datum/automata_cell/C = currentrun[length(currentrun)]
 		currentrun.len--
 
 		if (!C || QDELETED(C))

--- a/code/controllers/subsystem/decorator.dm
+++ b/code/controllers/subsystem/decorator.dm
@@ -35,7 +35,7 @@ SUBSYSTEM_DEF(decorator)
 		if(!decor.is_active_decor())
 			continue
 		var/list/applicable_types = decor.get_decor_types()
-		if(!applicable_types || !applicable_types.len)
+		if(!LAZYLEN(applicable_types))
 			continue
 		active_decorators |= decor
 		for(var/app_type in applicable_types)
@@ -64,7 +64,7 @@ SUBSYSTEM_DEF(decorator)
 		currentrun = swap
 
 	while(length(currentrun))
-		var/datum/weakref/ref = currentrun[currentrun.len]
+		var/datum/weakref/ref = currentrun[length(currentrun)]
 		currentrun.len--
 		var/atom/A = ref?.resolve()
 		if(A) A.Decorate(deferable = FALSE)
@@ -80,7 +80,7 @@ SUBSYSTEM_DEF(decorator)
 	// DECORATOR IS ENABLED FORCEFULLY
 
 	var/list/applicable_types = decor.get_decor_types()
-	if(!applicable_types || !applicable_types.len)
+	if(!LAZYLEN(applicable_types))
 		return
 	active_decorators |= decor
 	for(var/app_type in applicable_types)
@@ -100,7 +100,7 @@ SUBSYSTEM_DEF(decorator)
 
 /datum/controller/subsystem/decorator/stat_entry(msg)
 	if(registered_decorators && decoratable)
-		msg = "D:[registered_decorators.len],P:[decoratable.len]"
+		msg = "D:[length(registered_decorators)],P:[length(decoratable)]"
 	return ..()
 
 /datum/controller/subsystem/decorator/proc/decorate(atom/o)
@@ -118,25 +118,25 @@ SUBSYSTEM_DEF(decorator)
 /datum/controller/subsystem/decorator/proc/sortDecorators(list/datum/decorator/L)
 	if(!istype(L))
 		return null
-	if(L.len < 2)
+	if(length(L) < 2)
 		return L
-	var/middle = L.len / 2 + 1
+	var/middle = length(L) / 2 + 1
 	return mergeDecoratorLists(sortDecorators(L.Copy(0, middle)), sortDecorators(L.Copy(middle)))
 
 /datum/controller/subsystem/decorator/proc/mergeDecoratorLists(list/datum/decorator/L, list/datum/decorator/R)
 	var/Li=1
 	var/Ri=1
 	var/list/result = new()
-	while(Li <= L.len && Ri <= R.len)
+	while(Li <= length(L) && Ri <= length(R))
 		if(sorttext(L[Li].priority, R[Ri].priority) < 1)
 			// Works around list += list2 merging lists; it's not pretty but it works
 			result += "temp item"
-			result[result.len] = R[Ri++]
+			result[length(result)] = R[Ri++]
 		else
 			result += "temp item"
-			result[result.len] = L[Li++]
+			result[length(result)] = L[Li++]
 
-	if(Li <= L.len)
+	if(Li <= length(L))
 		return (result + L.Copy(Li, 0))
 	return (result + R.Copy(Ri, 0))
 

--- a/code/controllers/subsystem/disease.dm
+++ b/code/controllers/subsystem/disease.dm
@@ -8,15 +8,15 @@ SUBSYSTEM_DEF(disease)
 	var/list/datum/disease/currentrun = list()
 
 /datum/controller/subsystem/disease/stat_entry(msg)
-	msg = "P:[all_diseases.len]"
+	msg = "P:[length(all_diseases)]"
 	return ..()
 
 /datum/controller/subsystem/disease/fire(resumed = FALSE)
 	if (!resumed)
 		currentrun = all_diseases.Copy()
 
-	while (currentrun.len)
-		var/datum/disease/D = currentrun[currentrun.len]
+	while (length(currentrun))
+		var/datum/disease/D = currentrun[length(currentrun)]
 		currentrun.len--
 
 		if (!D || QDELETED(D))

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -35,8 +35,8 @@ SUBSYSTEM_DEF(events)
 	//cache for sanic speed (lists are references anyways)
 	var/list/currentrun = src.currentrun
 
-	while(currentrun.len)
-		var/datum/thing = currentrun[currentrun.len]
+	while(length(currentrun))
+		var/datum/thing = currentrun[length(currentrun)]
 		currentrun.len--
 		if(thing)
 			thing.process()

--- a/code/controllers/subsystem/fz_transitions.dm
+++ b/code/controllers/subsystem/fz_transitions.dm
@@ -10,7 +10,7 @@ SUBSYSTEM_DEF(fz_transitions)
 	flags = SS_KEEP_TIMING
 
 /datum/controller/subsystem/fz_transitions/stat_entry(msg)
-	msg = "P:[GLOB.projectors.len]|C:[GLOB.clones.len]|T:[GLOB.clones_t.len]"
+	msg = "P:[length(GLOB.projectors)]|C:[length(GLOB.clones)]|T:[length(GLOB.clones_t)]"
 	return ..()
 
 /datum/controller/subsystem/fz_transitions/Initialize()

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -297,7 +297,7 @@ SUBSYSTEM_DEF(garbage)
 /datum/controller/subsystem/garbage/Recover()
 	InitQueues() //We first need to create the queues before recovering data
 	if (istype(SSgarbage.queues))
-		for (var/i in 1 to SSgarbage.queues.len)
+		for (var/i in 1 to length(SSgarbage.queues))
 			queues[i] |= SSgarbage.queues[i]
 
 /// Qdel Item: Holds statistics on each type that passes thru qdel

--- a/code/controllers/subsystem/human.dm
+++ b/code/controllers/subsystem/human.dm
@@ -10,15 +10,15 @@ SUBSYSTEM_DEF(human)
 
 
 /datum/controller/subsystem/human/stat_entry(msg)
-	msg = "P:[processable_human_list.len]"
+	msg = "P:[length(processable_human_list)]"
 	return ..()
 
 /datum/controller/subsystem/human/fire(resumed = FALSE)
 	if (!resumed)
 		currentrun = processable_human_list.Copy()
 
-	while (currentrun.len)
-		var/mob/living/carbon/human/M = currentrun[currentrun.len]
+	while (length(currentrun))
+		var/mob/living/carbon/human/M = currentrun[length(currentrun)]
 		currentrun.len--
 
 		if (!M || QDELETED(M))

--- a/code/controllers/subsystem/init/landmarks.dm
+++ b/code/controllers/subsystem/init/landmarks.dm
@@ -47,14 +47,14 @@ SUBSYSTEM_DEF(landmark_init)
 			message_admins("Item pool [pool.pool_name] has no master landmark, aborting item spawns. Tell the devs. Code: ITEM_POOL_3")
 			continue
 
-		if (pool.quota > pool.turfs.len)
-			log_debug("Item pool [pool.pool_name] wants to spawn more items than it has landmarks for. Spawning [pool.turfs.len] instances of [pool.type_to_spawn] instead. Code: ITEM_POOL_4")
-			message_admins("Item pool [pool.pool_name] wants to spawn more items than it has landmarks for. Spawning [pool.turfs.len] instances of [pool.type_to_spawn] instead. Tell the devs. Code: ITEM_POOL_4")
-			pool.quota = pool.turfs.len
+		if (pool.quota > length(pool.turfs))
+			log_debug("Item pool [pool.pool_name] wants to spawn more items than it has landmarks for. Spawning [length(pool.turfs)] instances of [pool.type_to_spawn] instead. Code: ITEM_POOL_4")
+			message_admins("Item pool [pool.pool_name] wants to spawn more items than it has landmarks for. Spawning [length(pool.turfs)] instances of [pool.type_to_spawn] instead. Tell the devs. Code: ITEM_POOL_4")
+			pool.quota = length(pool.turfs)
 
 		// Quota times, pick a random turf, spawn an item there, then remove that turf from the list.
 		for (var/i in 1 to pool.quota)
-			var/turf/T = pool.turfs[rand(1, pool.turfs.len)]
+			var/turf/T = pool.turfs[rand(1, length(pool.turfs))]
 			var/atom/movable/newly_spawned = new pool.type_to_spawn()
 
 			newly_spawned.forceMove(T)

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -33,7 +33,7 @@ SUBSYSTEM_DEF(input)
 // Badmins just wanna have fun ♪
 /datum/controller/subsystem/input/proc/refresh_client_macro_sets()
 	var/list/clients = GLOB.clients
-	for(var/i in 1 to clients.len)
+	for(var/i in 1 to length(clients))
 		var/client/user = clients[i]
 		INVOKE_ASYNC(user, /client/proc/set_macros)
 

--- a/code/controllers/subsystem/item_cleanup.dm
+++ b/code/controllers/subsystem/item_cleanup.dm
@@ -18,9 +18,9 @@ SUBSYSTEM_DEF(item_cleanup)
 		//Do nothing for the first 35 minutes to preserve the colony look for the first drop
 		return
 
-	var/to_delete = items_to_clean_up.len * percentage_of_garbage_to_delete
+	var/to_delete = length(items_to_clean_up) * percentage_of_garbage_to_delete
 	var/deleted = 0
-	var/total_items = items_to_clean_up.len //save total before we start deleting stuff
+	var/total_items = length(items_to_clean_up) //save total before we start deleting stuff
 	for (var/atom/o in items_to_clean_up)
 		if(QDELETED(o))
 			items_to_clean_up -= o
@@ -34,9 +34,9 @@ SUBSYSTEM_DEF(item_cleanup)
 			break
 
 	//We transfer items from the global garbage list onto the next iteration list
-	while(!isnull(GLOB.item_cleanup_list) && GLOB.item_cleanup_list.len > 0)
-		addToListNoDupe(items_to_clean_up, GLOB.item_cleanup_list[GLOB.item_cleanup_list.len])
-		GLOB.item_cleanup_list -= GLOB.item_cleanup_list[GLOB.item_cleanup_list.len]
+	while(!isnull(GLOB.item_cleanup_list) && length(GLOB.item_cleanup_list) > 0)
+		addToListNoDupe(items_to_clean_up, GLOB.item_cleanup_list[length(GLOB.item_cleanup_list)])
+		GLOB.item_cleanup_list -= GLOB.item_cleanup_list[length(GLOB.item_cleanup_list)]
 
 	log_debug("item_cleanup deleted [deleted] garbage out of total [total_items]")
 

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -27,7 +27,7 @@ SUBSYSTEM_DEF(lighting)
 
 
 /datum/controller/subsystem/lighting/stat_entry()
-	. = ..("ShCalcs:[total_shadow_calculations]|SourcQ:[static_sources_queue.len]|CcornQ:[corners_queue.len]|ObjQ:[objects_queue.len]|HybrQ:[mask_queue.len]")
+	. = ..("ShCalcs:[total_shadow_calculations]|SourcQ:[length(static_sources_queue)]|CcornQ:[length(corners_queue)]|ObjQ:[length(objects_queue)]|HybrQ:[length(mask_queue)]")
 
 /datum/controller/subsystem/lighting/fire(resumed, init_tick_checks)
 	MC_SPLIT_TICK_INIT(3)

--- a/code/controllers/subsystem/machinery.dm
+++ b/code/controllers/subsystem/machinery.dm
@@ -19,15 +19,15 @@ SUBSYSTEM_DEF(machinery)
 	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/machinery/stat_entry(msg)
-	msg = "M:[GLOB.processing_machines.len]"
+	msg = "M:[length(GLOB.processing_machines)]"
 	return ..()
 
 /datum/controller/subsystem/machinery/fire(resumed = FALSE)
 	if (!resumed)
 		currentrunmachines = GLOB.processing_machines.Copy()
 
-	while (currentrunmachines.len)
-		var/obj/structure/machinery/M = currentrunmachines[currentrunmachines.len]
+	while (length(currentrunmachines))
+		var/obj/structure/machinery/M = currentrunmachines[length(currentrunmachines)]
 		currentrunmachines.len--
 
 		if (!M || QDELETED(M))

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -161,11 +161,11 @@ SUBSYSTEM_DEF(mapping)
 	if (!length(traits))  // null or empty - default
 		for (var/i in 1 to total_z)
 			traits += list(default_traits)
-	else if (total_z != traits.len)  // mismatch
-		INIT_ANNOUNCE("WARNING: [traits.len] trait sets specified for [total_z] z-levels in [path]!")
-		if (total_z < traits.len)  // ignore extra traits
+	else if (total_z != length(traits))  // mismatch
+		INIT_ANNOUNCE("WARNING: [length(traits)] trait sets specified for [total_z] z-levels in [path]!")
+		if (total_z < length(traits))  // ignore extra traits
 			traits.Cut(total_z + 1)
-		while (total_z > traits.len)  // fall back to defaults on extra levels
+		while (total_z > length(traits))  // fall back to defaults on extra levels
 			traits += list(default_traits)
 
 	// preload the relevant space_level datums
@@ -236,8 +236,8 @@ SUBSYSTEM_DEF(mapping)
 
 	if(LAZYLEN(FailedZs)) //but seriously, unless the server's filesystem is messed up this will never happen
 		var/msg = "RED ALERT! The following map files failed to load: [FailedZs[1]]"
-		if(FailedZs.len > 1)
-			for(var/I in 2 to FailedZs.len)
+		if(length(FailedZs) > 1)
+			for(var/I in 2 to length(FailedZs))
 				msg += ", [FailedZs[I]]"
 		msg += ". Yell at your server host!"
 		INIT_ANNOUNCE(msg)
@@ -276,7 +276,7 @@ SUBSYSTEM_DEF(mapping)
 	. = list()
 	var/list/Lines = file2list(filename)
 
-	if(!Lines.len)
+	if(!length(Lines))
 		return
 	for (var/t in Lines)
 		if (!t)

--- a/code/controllers/subsystem/mob.dm
+++ b/code/controllers/subsystem/mob.dm
@@ -8,7 +8,7 @@ SUBSYSTEM_DEF(mob)
 	var/list/living_misc_mobs = list()
 
 /datum/controller/subsystem/mob/stat_entry(msg)
-	msg = "P:[living_misc_mobs.len]"
+	msg = "P:[length(living_misc_mobs)]"
 	return ..()
 
 
@@ -16,8 +16,8 @@ SUBSYSTEM_DEF(mob)
 	if (!resumed)
 		currentrun = living_misc_mobs.Copy()
 
-	while (currentrun.len)
-		var/mob/living/M = currentrun[currentrun.len]
+	while (length(currentrun))
+		var/mob/living/M = currentrun[length(currentrun)]
 		currentrun.len--
 
 		if (!M || QDELETED(M))

--- a/code/controllers/subsystem/nanoui.dm
+++ b/code/controllers/subsystem/nanoui.dm
@@ -13,15 +13,15 @@ SUBSYSTEM_DEF(nano)
 	nanomanager = new()
 
 /datum/controller/subsystem/nano/stat_entry(msg)
-	msg = "P:[nanomanager.processing_uis.len]"
+	msg = "P:[length(nanomanager.processing_uis)]"
 	return ..()
 
 /datum/controller/subsystem/nano/fire(resumed = FALSE)
 	if (!resumed)
 		currentrun = nanomanager.processing_uis.Copy()
 
-	while (currentrun.len)
-		var/datum/nanoui/UI = currentrun[currentrun.len]
+	while (length(currentrun))
+		var/datum/nanoui/UI = currentrun[length(currentrun)]
 		currentrun.len--
 
 		if (!UI || QDELETED(UI))

--- a/code/controllers/subsystem/perf_logging.dm
+++ b/code/controllers/subsystem/perf_logging.dm
@@ -26,8 +26,8 @@ SUBSYSTEM_DEF(perf_logging)
 			if(SS?.cost > 0.1)
 				currentrun += SS
 
-	while(currentrun.len)
-		var/datum/controller/subsystem/SS = currentrun[currentrun.len]
+	while(length(currentrun))
+		var/datum/controller/subsystem/SS = currentrun[length(currentrun)]
 		currentrun.len--
 		var/datum/entity/mc_controller/C = controller_assoc[SS.type]
 		new_record(SS, C)

--- a/code/controllers/subsystem/ping.dm
+++ b/code/controllers/subsystem/ping.dm
@@ -14,7 +14,7 @@ SUBSYSTEM_DEF(ping)
 	var/list/currentrun = list()
 
 /datum/controller/subsystem/ping/stat_entry()
-	..("P:[GLOB.clients.len]")
+	..("P:[length(GLOB.clients)]")
 
 /datum/controller/subsystem/ping/fire(resumed = FALSE)
 	// Prepare the new batch of clients
@@ -24,8 +24,8 @@ SUBSYSTEM_DEF(ping)
 	// De-reference the list for sanic speeds
 	var/list/currentrun = src.currentrun
 
-	while (currentrun.len)
-		var/client/client = currentrun[currentrun.len]
+	while (length(currentrun))
+		var/client/client = currentrun[length(currentrun)]
 		currentrun.len--
 
 		if (client?.tgui_panel?.is_ready())

--- a/code/controllers/subsystem/playtime.dm
+++ b/code/controllers/subsystem/playtime.dm
@@ -12,8 +12,8 @@ SUBSYSTEM_DEF(playtime)
 
 	var/list/currentrun = src.currentrun
 
-	while (currentrun.len)
-		var/client/C = currentrun[currentrun.len]
+	while (length(currentrun))
+		var/client/C = currentrun[length(currentrun)]
 		currentrun.len--
 
 		var/mob/M = C.mob

--- a/code/controllers/subsystem/police_clues.dm
+++ b/code/controllers/subsystem/police_clues.dm
@@ -8,15 +8,15 @@ SUBSYSTEM_DEF(clues)
 	var/list/prints_list = list()
 
 /datum/controller/subsystem/clues/stat_entry(msg)
-	msg = "P:[prints_list.len]"
+	msg = "P:[length(prints_list)]"
 	return ..()
 
 /datum/controller/subsystem/clues/fire(resumed = FALSE)
 	if(!resumed && length(prints_list))
 		currentrun = prints_list.Copy()
 
-	while(currentrun.len)
-		var/obj/effect/decal/prints/P = currentrun[currentrun.len]
+	while(length(currentrun))
+		var/obj/effect/decal/prints/P = currentrun[length(currentrun)]
 		currentrun.len--
 
 		if(!P || QDELETED(P))

--- a/code/controllers/subsystem/power.dm
+++ b/code/controllers/subsystem/power.dm
@@ -12,7 +12,7 @@ SUBSYSTEM_DEF(power)
 	var/list/currentrun_areas = list()
 
 /datum/controller/subsystem/power/stat_entry(msg)
-	msg = "PN:[GLOB.powernets.len]|PM:[GLOB.power_machines.len]|A:[GLOB.active_areas.len]"
+	msg = "PN:[length(GLOB.powernets)]|PM:[length(GLOB.power_machines)]|A:[length(GLOB.active_areas)]"
 	return ..()
 
 
@@ -29,8 +29,8 @@ SUBSYSTEM_DEF(power)
 
 	// First we reset the powernets.
 	// This is done first because we want the power machinery to have acted last on the powernet between intervals.
-	while(currentrun_powerents.len)
-		var/datum/powernet/Powernet = currentrun_powerents[currentrun_powerents.len]
+	while(length(currentrun_powerents))
+		var/datum/powernet/Powernet = currentrun_powerents[length(currentrun_powerents)]
 		currentrun_powerents.len--
 		if(Powernet)
 			Powernet.process()
@@ -39,8 +39,8 @@ SUBSYSTEM_DEF(power)
 
 
 	// Next we let the power machines operate, this way until the next tick it will be as if they have all done their work.
-	while (currentrun_power_machines.len)
-		var/datum/X = currentrun_power_machines[currentrun_power_machines.len]
+	while (length(currentrun_power_machines))
+		var/datum/X = currentrun_power_machines[length(currentrun_power_machines)]
 		currentrun_power_machines.len--
 		if (!X || QDELETED(X))
 			continue

--- a/code/controllers/subsystem/processing/obj_tab_items.dm
+++ b/code/controllers/subsystem/processing/obj_tab_items.dm
@@ -12,8 +12,8 @@ PROCESSING_SUBSYSTEM_DEF(obj_tab_items)
 	//cache for sanic speed (lists are references anyways)
 	var/list/current_run = currentrun
 
-	while(current_run.len)
-		var/datum/thing = current_run[current_run.len]
+	while(length(current_run))
+		var/datum/thing = current_run[length(current_run)]
 		if(QDELETED(thing))
 			processing -= thing
 		else if(thing.process(wait * 0.1) == PROCESS_KILL)

--- a/code/controllers/subsystem/processing/processing.dm
+++ b/code/controllers/subsystem/processing/processing.dm
@@ -20,8 +20,8 @@ SUBSYSTEM_DEF(processing)
 	//cache for sanic speed (lists are references anyways)
 	var/list/current_run = currentrun
 
-	while(current_run.len)
-		var/datum/thing = current_run[current_run.len]
+	while(length(current_run))
+		var/datum/thing = current_run[length(current_run)]
 		current_run.len--
 		if(QDELETED(thing))
 			processing -= thing

--- a/code/controllers/subsystem/projectiles.dm
+++ b/code/controllers/subsystem/projectiles.dm
@@ -28,7 +28,7 @@ SUBSYSTEM_DEF(projectiles)
 	 */
 
 /datum/controller/subsystem/projectiles/stat_entry(msg)
-	msg = " | #Proj: [projectiles.len]"
+	msg = " | #Proj: [length(projectiles)]"
 	return ..()
 
 /datum/controller/subsystem/projectiles/Initialize(start_timeofday)
@@ -41,8 +41,8 @@ SUBSYSTEM_DEF(projectiles)
 	if(!resumed)
 		flying = projectiles.Copy()
 		flying -= sleepers
-	while(flying.len)
-		var/obj/projectile/projectile = flying[flying.len]
+	while(length(flying))
+		var/obj/projectile/projectile = flying[length(flying)]
 		flying.len--
 		var/delta_time = wait * world.tick_lag * (1 SECONDS)
 		handle_projectile_flight(projectile, delta_time)

--- a/code/controllers/subsystem/quadtrees.dm
+++ b/code/controllers/subsystem/quadtrees.dm
@@ -24,17 +24,17 @@ SUBSYSTEM_DEF(quadtree)
 	if(!resumed)
 		player_feed = GLOB.clients.Copy()
 		cur_quadtrees = new_quadtrees.Copy()
-		if(new_quadtrees.len < world.maxz)
+		if(length(new_quadtrees) < world.maxz)
 			new_quadtrees.len = world.maxz
 		for(var/i in 1 to world.maxz)
 			new_quadtrees[i] = QTREE(RECT(world.maxx/2,world.maxy/2, world.maxx, world.maxy), i)
 
 	while(length(player_feed))
-		var/client/C = player_feed[player_feed.len]
+		var/client/C = player_feed[length(player_feed)]
 		player_feed.len--
 		if(!C) continue
 		var/turf/T = get_turf(C.mob)
-		if(!T?.z || new_quadtrees.len < T.z)
+		if(!T?.z || length(new_quadtrees) < T.z)
 			continue
 		var/datum/coords/qtplayer/p_coords = new
 		p_coords.player = C
@@ -52,7 +52,7 @@ SUBSYSTEM_DEF(quadtree)
 	var/list/players = list()
 	if(!cur_quadtrees)
 		return players
-	if(z_level && cur_quadtrees.len >= z_level)
+	if(z_level && length(cur_quadtrees) >= z_level)
 		var/datum/quadtree/Q = cur_quadtrees[z_level]
 		if(!Q)
 			return players

--- a/code/controllers/subsystem/round_recording.dm
+++ b/code/controllers/subsystem/round_recording.dm
@@ -35,8 +35,8 @@ SUBSYSTEM_DEF(round_recording)
 			return
 		currentrun = recorder.tracked_players.Copy()
 
-	while(currentrun.len)
-		var/mob/M = currentrun[currentrun.len]
+	while(length(currentrun))
+		var/mob/M = currentrun[length(currentrun)]
 		currentrun.len--
 
 		// Try to stop the tracking

--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -94,7 +94,7 @@ SUBSYSTEM_DEF(shuttle)
 				qdel(T, force=TRUE)
 
 	if(!SSmapping.clearing_reserved_turfs)
-		while(transit_requesters.len)
+		while(length(transit_requesters))
 			var/requester = popleft(transit_requesters)
 			var/success = null
 			// Do not try and generate any transit if we're using more then our max already
@@ -311,7 +311,7 @@ SUBSYSTEM_DEF(shuttle)
 
 /datum/controller/subsystem/shuttle/proc/get_containing_shuttle(atom/A)
 	var/list/mobile_cache = mobile
-	for(var/i in 1 to mobile_cache.len)
+	for(var/i in 1 to length(mobile_cache))
 		var/obj/docking_port/port = mobile_cache[i]
 		if(port.is_in_shuttle_bounds(A))
 			return port
@@ -319,7 +319,7 @@ SUBSYSTEM_DEF(shuttle)
 /datum/controller/subsystem/shuttle/proc/get_containing_dock(atom/A)
 	. = list()
 	var/list/stationary_cache = stationary
-	for(var/i in 1 to stationary_cache.len)
+	for(var/i in 1 to length(stationary_cache))
 		var/obj/docking_port/port = stationary_cache[i]
 		if(port.is_in_shuttle_bounds(A))
 			. += port
@@ -327,7 +327,7 @@ SUBSYSTEM_DEF(shuttle)
 /datum/controller/subsystem/shuttle/proc/get_dock_overlap(x0, y0, x1, y1, z)
 	. = list()
 	var/list/stationary_cache = stationary
-	for(var/i in 1 to stationary_cache.len)
+	for(var/i in 1 to length(stationary_cache))
 		var/obj/docking_port/port = stationary_cache[i]
 		if(!port || port.z != z)
 			continue
@@ -335,7 +335,7 @@ SUBSYSTEM_DEF(shuttle)
 		var/list/overlap = get_overlap(x0, y0, x1, y1, bounds[1], bounds[2], bounds[3], bounds[4])
 		var/list/xs = overlap[1]
 		var/list/ys = overlap[2]
-		if(xs.len && ys.len)
+		if(length(xs) && length(ys))
 			.[port] = overlap
 
 /datum/controller/subsystem/shuttle/proc/update_hidden_docking_ports(list/remove_turfs, list/add_turfs)
@@ -353,7 +353,7 @@ SUBSYSTEM_DEF(shuttle)
 		for(var/V in add_turfs)
 			var/turf/T = V
 			var/image/I
-			if(remove_images.len)
+			if(length(remove_images))
 				//we can just reuse any images we are about to delete instead of making new ones
 				I = remove_images[1]
 				remove_images.Cut(1, 2)

--- a/code/controllers/subsystem/sound.dm
+++ b/code/controllers/subsystem/sound.dm
@@ -24,7 +24,7 @@ SUBSYSTEM_DEF(sound)
 			if(MC_TICK_CHECK)
 				return
 		while(length(run_hearers)) // Output sound to hearers
-			var/client/C = run_hearers[run_hearers.len]
+			var/client/C = run_hearers[length(run_hearers)]
 			run_hearers.len--
 			if(C && C.soundOutput)
 				C.soundOutput.process_sound(run_template)
@@ -40,6 +40,6 @@ SUBSYSTEM_DEF(sound)
 		for(var/datum/interior/VI in extra_interiors)
 			if(VI?.ready)
 				var/list/bounds = VI.get_middle_coords()
-				if(bounds.len >= 2)
+				if(length(bounds) >= 2)
 					hearers |= SSquadtree.players_in_range(RECT(bounds[1], bounds[2], VI.map_template.width, VI.map_template.height), bounds[3])
 	template_queue[template] = hearers

--- a/code/controllers/subsystem/soundscape.dm
+++ b/code/controllers/subsystem/soundscape.dm
@@ -15,8 +15,8 @@ SUBSYSTEM_DEF(soundscape)
 	if(!resumed)
 		currentrun = GLOB.clients.Copy()
 
-	while(currentrun.len)
-		var/client/C = currentrun[currentrun.len]
+	while(length(currentrun))
+		var/client/C = currentrun[length(currentrun)]
 		currentrun.len--
 
 		if(!C || !C.soundOutput)

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -197,7 +197,7 @@ SUBSYSTEM_DEF(statpanels)
 /datum/controller/subsystem/statpanels/proc/generate_mc_data()
 	mc_data = list(
 		list("CPU:", world.cpu),
-		list("Instances:", "[num2text(world.contents.len, 10)]"),
+		list("Instances:", "[num2text(length(world.contents), 10)]"),
 		list("World Time:", "[world.time]"),
 		list("Globals:", GLOB.stat_entry(), "\ref[GLOB]"),
 		list("[config]:", config.stat_entry(), "\ref[config]"),

--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -45,8 +45,8 @@ SUBSYSTEM_DEF(tgui)
 		src.current_run = open_uis.Copy()
 	// Cache for sanic speed (lists are references anyways)
 	var/list/current_run = src.current_run
-	while(current_run.len)
-		var/datum/tgui/ui = current_run[current_run.len]
+	while(length(current_run))
+		var/datum/tgui/ui = current_run[length(current_run)]
 		current_run.len--
 		// TODO: Move user/src_object check to process()
 		if(ui?.user && ui.src_object)

--- a/code/controllers/subsystem/tracking.dm
+++ b/code/controllers/subsystem/tracking.dm
@@ -98,7 +98,7 @@ SUBSYSTEM_DEF(tracking)
 
 /datum/controller/subsystem/tracking/proc/setup_trackers(mob/mob, tracked_group)
 	if(!tracked_group)
-		tracked_group = "tracked_[tracked_mobs.len]"
+		tracked_group = "tracked_[length(tracked_mobs)]"
 
 	tracked_mobs[tracked_group] = list()
 	leaders[tracked_group] = mob

--- a/code/controllers/subsystem/xeno.dm
+++ b/code/controllers/subsystem/xeno.dm
@@ -7,7 +7,7 @@ SUBSYSTEM_DEF(xeno)
 	var/list/currentrun = list()
 
 /datum/controller/subsystem/xeno/stat_entry(msg)
-	msg = "P:[GLOB.xeno_mob_list.len]"
+	msg = "P:[length(GLOB.xeno_mob_list)]"
 	return ..()
 
 
@@ -15,8 +15,8 @@ SUBSYSTEM_DEF(xeno)
 	if (!resumed)
 		currentrun = GLOB.xeno_mob_list.Copy()
 
-	while (currentrun.len)
-		var/mob/living/carbon/xenomorph/M = currentrun[currentrun.len]
+	while (length(currentrun))
+		var/mob/living/carbon/xenomorph/M = currentrun[length(currentrun)]
 		currentrun.len--
 
 		if (!M || QDELETED(M))

--- a/code/datums/_ndatabase/code/brsql_adapter.dm
+++ b/code/datums/_ndatabase/code/brsql_adapter.dm
@@ -103,7 +103,7 @@
 /datum/db/adapter/brsql_adapter/insert_table(table_name, list/values, datum/callback/CB, sync = FALSE)
 	set waitfor = FALSE
 
-	var/length = values.len
+	var/length = length(values)
 	var/list/qpars = list()
 	var/query_inserttable = getquery_insert_table(table_name, values, qpars)
 	var/datum/callback/callback = CALLBACK(src, TYPE_PROC_REF(/datum/db/adapter/brsql_adapter, after_insert_table), CB, length, table_name)
@@ -150,7 +150,7 @@
 	if(table_meta.status != DB_QUERY_FINISHED)
 		issue_log += "Unable to access system table, error: '[table_meta.error]'"
 		return FALSE // OH SHIT OH FUCK
-	if(!table_meta.results.len) // Table doesn't exist
+	if(!length(table_meta.results)) // Table doesn't exist
 		return internal_create_table(table_name, field_types) && internal_record_table_in_sys(type_name, table_name, field_types)
 
 	var/id =  table_meta.results[1][DB_DEFAULT_ID_FIELD]
@@ -178,7 +178,7 @@
 	if(index_meta.status != DB_QUERY_FINISHED)
 		issue_log += "Unable to access system index table, error: '[index_meta.error]'"
 		return FALSE // OH SHIT OH FUCK
-	if(!index_meta.results.len) // Index doesn't exist
+	if(!length(index_meta.results)) // Index doesn't exist
 		return internal_create_index(index_name, table_name, fields, unique, cluster) && internal_record_index_in_sys(index_name, table_name, fields)
 
 	var/id =  index_meta.results[1][DB_DEFAULT_ID_FIELD]

--- a/code/datums/_ndatabase/code/native_adapter.dm
+++ b/code/datums/_ndatabase/code/native_adapter.dm
@@ -92,7 +92,7 @@
 
 /datum/db/adapter/native_adapter/insert_table(table_name, list/values, datum/callback/CB, sync = FALSE)
 	set waitfor = 0
-	var/length = values.len
+	var/length = length(values)
 	var/startid = internal_request_insert_allocation(table_name, length)
 	var/list/qpars = list()
 	var/query_inserttable = getquery_insert_table(table_name, values, startid, qpars)
@@ -138,7 +138,7 @@
 	if(table_meta.status != DB_QUERY_FINISHED)
 		issue_log += "Unable to access system table, error: '[table_meta.error]'"
 		return FALSE // OH SHIT OH FUCK
-	if(!table_meta.results.len) // Table doesn't exist
+	if(!length(table_meta.results)) // Table doesn't exist
 		return internal_create_table(table_name, field_types) && internal_record_table_in_sys(type_name, table_name, field_types)
 
 	var/id =  table_meta.results[1][DB_DEFAULT_ID_FIELD]

--- a/code/datums/_ndatabase/code/native_persistent_query.dm
+++ b/code/datums/_ndatabase/code/native_persistent_query.dm
@@ -29,7 +29,7 @@
 /datum/db/query/native/read_single()
 	if(status >= DB_QUERY_FINISHED || completed) //broken or finished
 		return
-	
+
 	if(!completed)
 		completed = TRUE
 		var/status = query.Execute(db)
@@ -41,9 +41,9 @@
 	if(!results)
 		results = list()
 	var/list/cols = query.Columns()
-	if(cols && cols.len>0)
+	if(LAZYLEN(cols)>0)
 		while(query.NextRow())
 			var/list/current_row = query.GetRowData()
 			results += list(current_row)
-	affected_rows = query.RowsAffected() 
+	affected_rows = query.RowsAffected()
 	status = DB_QUERY_FINISHED

--- a/code/datums/_ndatabase/subsystems/database_query_manager.dm
+++ b/code/datums/_ndatabase/subsystems/database_query_manager.dm
@@ -62,7 +62,7 @@ GLOBAL_REAL(SSdatabase, /datum/controller/subsystem/database_query_manager)
 
 /datum/controller/subsystem/database_query_manager/stat_entry(msg)
 	var/text = (connection && connection.status == DB_CONNECTION_READY) ? ("READY") : ("PREPPING")
-	msg = "[text], AQ:[queries_active.len]; SQ:[queries_standby.len]; P:[queries_current.len]; C:[in_callback]"
+	msg = "[text], AQ:[length(queries_active)]; SQ:[length(queries_standby)]; P:[length(queries_current)]; C:[in_callback]"
 	return ..()
 
 /datum/controller/subsystem/database_query_manager/fire(resumed = FALSE)

--- a/code/datums/_ndatabase/subsystems/entity_manager.dm
+++ b/code/datums/_ndatabase/subsystems/entity_manager.dm
@@ -102,8 +102,8 @@ GLOBAL_REAL(SSentity_manager, /datum/controller/subsystem/entity_manager)
 		currentrun = tables_unsorted.Copy()
 	if(!SSdatabase.connection.connection_ready())
 		return
-	while (currentrun.len)
-		var/datum/entity_meta/Q = currentrun[currentrun.len]
+	while (length(currentrun))
+		var/datum/entity_meta/Q = currentrun[length(currentrun)]
 		do_select(Q)
 		do_insert(Q)
 		do_update(Q)

--- a/code/datums/_ndatabase/tests/test_entity.dm
+++ b/code/datums/_ndatabase/tests/test_entity.dm
@@ -50,7 +50,7 @@
 	SSentity_manager.filter_then(/datum/entity/test_entity, DB_COMP("value", DB_EQUALS, value), CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(log_filter)))
 
 /proc/log_filter(list/datum/entity/elist)
-	to_world("got [elist.len] items")
+	to_world("got [length(elist)] items")
 
 /proc/log_sync(datum/entity/test_entity/ET)
 	to_world("id:[ET.id] = name: [ET.name], description: [ET.description], value: [ET.value]")

--- a/code/datums/ammo/ammo.dm
+++ b/code/datums/ammo/ammo.dm
@@ -212,7 +212,7 @@
 
 		M.apply_damage(damage,damage_type)
 
-		if(XNO && XNO.xeno_shields.len)
+		if(XNO && length(XNO.xeno_shields))
 			P.play_shielded_hit_effect(M)
 		else
 			P.play_hit_effect(M)

--- a/code/datums/ammo/misc.dm
+++ b/code/datums/ammo/misc.dm
@@ -200,7 +200,7 @@
 	if(!M || M == P.firer) return
 	if(M.throw_mode && !M.get_active_hand()) //empty active hand and we're in throw mode. If so we catch the can.
 		if(!M.is_mob_incapacitated()) // People who are not able to catch cannot catch.
-			if(P.contents.len == 1)
+			if(length(P.contents) == 1)
 				for(var/obj/item/reagent_container/food/drinks/cans/souto/S in P.contents)
 					M.put_in_active_hand(S)
 					for(var/mob/O in viewers(GLOB.world_view_size, P)) //find all people in view.
@@ -214,7 +214,7 @@
 			H.apply_effect(15, DAZE)
 			H.apply_effect(15, SLOW)
 		shake_camera(H, 2, 1)
-		if(P.contents.len)
+		if(length(P.contents))
 			drop_can(P.loc, P) //We make a can at the location.
 
 /datum/ammo/souto/on_hit_obj(obj/O,obj/projectile/P)
@@ -230,7 +230,7 @@
 	drop_can(P.loc, P) //We make a can at the location.
 
 /datum/ammo/souto/proc/drop_can(loc, obj/projectile/P)
-	if(P.contents.len)
+	if(length(P.contents))
 		for(var/obj/item/I in P.contents)
 			I.forceMove(loc)
 	randomize_projectile(P)

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -117,9 +117,9 @@
 		window_size = "size=[width]x[height];"
 	common_asset.send(user)
 	other_asset.send(user)
-	if (stylesheets.len)
+	if (length(stylesheets))
 		SSassets.transport.send_assets(user, stylesheets)
-	if (scripts.len)
+	if (length(scripts))
 		SSassets.transport.send_assets(user, scripts)
 
 	user << browse(get_content(), "window=[window_id];[window_size][window_options]")

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -102,7 +102,7 @@
 				components_of_type = test
 			if(I == our_type) //exact match, take priority
 				var/inserted = FALSE
-				for(var/J in 1 to components_of_type.len)
+				for(var/J in 1 to length(components_of_type))
 					var/datum/component/C = components_of_type[J]
 					if(C.type != our_type) //but not over other exact matches
 						components_of_type.Insert(J, I)
@@ -127,13 +127,13 @@
 		var/list/components_of_type = dc[I]
 		if(length(components_of_type)) //
 			var/list/subtracted = components_of_type - src
-			if(subtracted.len == 1) //only 1 guy left
+			if(length(subtracted) == 1) //only 1 guy left
 				dc[I] = subtracted[1] //make him special
 			else
 				dc[I] = subtracted
 		else //just us
 			dc -= I
-	if(!dc.len)
+	if(!length(dc))
 		P.datum_components = null
 
 	UnregisterFromParent()
@@ -243,7 +243,7 @@
 				lookup[sig] -= src
 
 	signal_procs[target] -= sig_type_or_types
-	if(!signal_procs[target].len)
+	if(!length(signal_procs[target]))
 		signal_procs -= target
 
 /**

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -119,7 +119,7 @@
 			var/datum/component/C = all_components
 			qdel(C, FALSE, TRUE)
 		if(datum_components)
-			debug_log("'[src]' datum_components was not null after removing all components! [datum_components.len] entries remained...")
+			debug_log("'[src]' datum_components was not null after removing all components! [length(datum_components)] entries remained...")
 			datum_components.Cut()
 
 	var/list/lookup = comp_lookup

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -50,7 +50,7 @@ GLOBAL_LIST_INIT(advance_cures, list(
 /datum/disease/advance/New(process = 1, datum/disease/advance/D)
 
 	// Setup our dictionary if it hasn't already.
-	if(!GLOB.dictionary_symptoms.len)
+	if(!length(GLOB.dictionary_symptoms))
 		for(var/symp in GLOB.list_symptoms)
 			var/datum/symptom/S = new symp
 			GLOB.dictionary_symptoms[S.id] = symp
@@ -59,9 +59,9 @@ GLOBAL_LIST_INIT(advance_cures, list(
 		D = null
 	// Generate symptoms if we weren't given any.
 
-	if(!symptoms || !symptoms.len)
+	if(!LAZYLEN(symptoms))
 
-		if(!D || !D.symptoms || !D.symptoms.len)
+		if(!D || !LAZYLEN(D.symptoms))
 			symptoms = GenerateSymptoms()
 		else
 			for(var/datum/symptom/S in D.symptoms)
@@ -80,7 +80,7 @@ GLOBAL_LIST_INIT(advance_cures, list(
 // Randomly pick a symptom to activate.
 /datum/disease/advance/stage_act()
 	..()
-	if(symptoms && symptoms.len)
+	if(LAZYLEN(symptoms))
 
 		if(!processing)
 			processing = 1
@@ -148,7 +148,7 @@ GLOBAL_LIST_INIT(advance_cures, list(
 			if(!HasSymptom(S))
 				possible_symptoms += S
 
-	if(!possible_symptoms.len)
+	if(!length(possible_symptoms))
 		return
 		//error("Advance Disease - We weren't able to get any possible symptoms in GenerateSymptoms([type_level_limit], [amount_get])")
 
@@ -182,7 +182,7 @@ GLOBAL_LIST_INIT(advance_cures, list(
 //Generate disease properties based on the effects. Returns an associated list.
 /datum/disease/advance/proc/GenerateProperties()
 
-	if(!symptoms || !symptoms.len)
+	if(!LAZYLEN(symptoms))
 		CRASH("We did not have any symptoms before generating properties.")
 
 	var/list/properties = list("resistance" = 1, "stealth" = 1, "stage_rate" = 1, "transmittable" = 1, "severity" = 1)
@@ -200,11 +200,11 @@ GLOBAL_LIST_INIT(advance_cures, list(
 // Assign the properties that are in the list.
 /datum/disease/advance/proc/AssignProperties(list/properties = list())
 
-	if(properties && properties.len)
+	if(LAZYLEN(properties))
 
 		hidden = list( (properties["stealth"] > 2), (properties["stealth"] > 3) )
 		// The more symptoms we have, the less transmittable it is but some symptoms can make up for it.
-		SetSpread(clamp(properties["transmittable"] - symptoms.len, BLOOD, AIRBORNE))
+		SetSpread(clamp(properties["transmittable"] - length(symptoms), BLOOD, AIRBORNE))
 		permeability_mod = max(ceil(0.4 * properties["transmittable"]), 1)
 		cure_chance = 15 - clamp(properties["resistance"], -5, 5) // can be between 10 and 20
 		stage_prob = max(properties["stage_rate"], 2)
@@ -253,8 +253,8 @@ GLOBAL_LIST_INIT(advance_cures, list(
 
 // Will generate a random cure, the less resistance the symptoms have, the harder the cure.
 /datum/disease/advance/proc/GenerateCure(list/properties = list())
-	if(properties && properties.len)
-		var/res = clamp(properties["resistance"] - (symptoms.len / 2), 1, GLOB.advance_cures.len)
+	if(LAZYLEN(properties))
+		var/res = clamp(properties["resistance"] - (length(symptoms) / 2), 1, length(GLOB.advance_cures))
 		cure_id = GLOB.advance_cures[res]
 
 		// Get the cure name from the cure_id
@@ -274,7 +274,7 @@ GLOBAL_LIST_INIT(advance_cures, list(
 
 // Randomly remove a symptom.
 /datum/disease/advance/proc/Devolve()
-	if(symptoms.len > 1)
+	if(length(symptoms) > 1)
 		var/s = SAFEPICK(symptoms)
 		if(s)
 			RemoveSymptom(s)
@@ -305,7 +305,7 @@ GLOBAL_LIST_INIT(advance_cures, list(
 	if(HasSymptom(S))
 		return
 
-	if(symptoms.len < 5 + rand(-1, 1))
+	if(length(symptoms) < 5 + rand(-1, 1))
 		symptoms += S
 	else
 		RemoveSymptom(pick(symptoms))
@@ -331,14 +331,14 @@ GLOBAL_LIST_INIT(advance_cures, list(
 	for(var/datum/disease/advance/A in D_list)
 		diseases += A.Copy()
 
-	if(!diseases.len)
+	if(!length(diseases))
 		return null
-	if(diseases.len <= 1)
+	if(length(diseases) <= 1)
 		return pick(diseases) // Just return the only entry.
 
 	var/i = 0
 	// Mix our diseases until we are left with only one result.
-	while(i < 20 && diseases.len > 1)
+	while(i < 20 && length(diseases) > 1)
 
 		i++
 
@@ -362,7 +362,7 @@ GLOBAL_LIST_INIT(advance_cures, list(
 			R.data_properties = data.Copy()
 		else
 			R.data_properties = data
-		if(preserve.len)
+		if(length(preserve))
 			R.data_properties["viruses"] = preserve
 
 /proc/AdminCreateVirus(mob/user)
@@ -385,7 +385,7 @@ GLOBAL_LIST_INIT(advance_cures, list(
 				i--
 	while(i > 0)
 
-	if(D.symptoms.len > 0)
+	if(length(D.symptoms) > 0)
 
 		var/new_name = input(user, "Name your new disease.", "New Name")
 		D.AssignName(new_name)

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -17,7 +17,7 @@ GLOBAL_LIST_EMPTY(dictionary_symptoms)
 
 /datum/symptom/New()
 	var/list/S = GLOB.list_symptoms
-	for(var/i = 1; i <= S.len; i++)
+	for(var/i = 1; i <= length(S); i++)
 		if(src.type == S[i])
 			id = "[i]"
 			return

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -301,12 +301,12 @@
 /obj/item/storage/fancy/blackgoo/get_examine_text(mob/user)
 	. = ..()
 	. += "A strange looking metal container..."
-	if(contents.len <= 0)
+	if(length(contents) <= 0)
 		. += "There are no bottles left inside it."
-	else if(contents.len == 1)
+	else if(length(contents) == 1)
 		. += "There is one bottle left inside it."
 	else
-		. += "There are [src.contents.len] bottles inside the container."
+		. += "There are [length(src.contents)] bottles inside the container."
 
 
 /obj/item/storage/fancy/blackgoo/Initialize()

--- a/code/datums/emergency_calls/custom.dm
+++ b/code/datums/emergency_calls/custom.dm
@@ -19,7 +19,7 @@
 	if(!istype(spawn_loc))
 		return //Didn't find a useable spawn point.
 
-	if(!players_to_offer.len)
+	if(!length(players_to_offer))
 		return // No more players
 
 	var/mob/living/carbon/human/H = pick(players_to_offer)

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -64,11 +64,11 @@
 	var/home_base = /datum/lazy_template/ert/freelancer_station
 
 /datum/game_mode/proc/initialize_emergency_calls()
-	if(all_calls.len) //It's already been set up.
+	if(length(all_calls)) //It's already been set up.
 		return
 
 	var/list/total_calls = typesof(/datum/emergency_call)
-	if(!total_calls.len)
+	if(!length(total_calls))
 		to_world(SPAN_DANGER("\b Error setting up emergency calls, no datums found."))
 		return FALSE
 	for(var/S in total_calls)
@@ -154,7 +154,7 @@
 	if(jobban_isbanned(src, "Syndicate") || jobban_isbanned(src, "Emergency Response Team"))
 		to_chat(src, SPAN_DANGER("You are jobbanned from the emergency response team!"))
 		return
-	if(!SSticker.mode || !SSticker.mode.picked_calls.len)
+	if(!SSticker.mode || !length(SSticker.mode.picked_calls))
 		to_chat(src, SPAN_WARNING("No distress beacons are active. You will be notified if this changes."))
 		return
 
@@ -230,8 +230,8 @@
 
 	SEND_SIGNAL(src, COMSIG_ERT_SETUP)
 
-	if(candidates.len < mob_min && !spawn_max_amount)
-		message_admins("Aborting distress beacon, not enough candidates: found [candidates.len].")
+	if(length(candidates) < mob_min && !spawn_max_amount)
+		message_admins("Aborting distress beacon, not enough candidates: found [length(candidates)].")
 		members = list() //Empty the members list.
 		candidates = list()
 
@@ -244,7 +244,7 @@
 	var/list/datum/mind/picked_candidates = list()
 	if(mob_max > 0)
 		var/mob_count = 0
-		while (mob_count < mob_max && candidates.len)
+		while (mob_count < mob_max && length(candidates))
 			var/datum/mind/M = pick(candidates) //Get a random candidate, then remove it from the candidates list.
 			if(!istype(M))//Something went horrifically wrong
 				candidates.Remove(M)
@@ -254,13 +254,13 @@
 				continue
 			if(M.current && M.current.stat != DEAD)
 				candidates.Remove(M) //Strip them from the list, they aren't dead anymore.
-				if(!candidates.len)
+				if(!length(candidates))
 					break //NO picking from empty lists
 				continue
 			picked_candidates.Add(M)
 			candidates.Remove(M)
 			mob_count++
-		if(candidates.len)
+		if(length(candidates))
 			for(var/datum/mind/I in candidates)
 				if(I.current)
 					to_chat(I.current, SPAN_WARNING("You didn't get selected to join the distress team. Better luck next time!"))
@@ -310,7 +310,7 @@
 		SSshuttle.moveShuttleToDock(shuttle, pick(active_lzs), TRUE)
 
 	var/i = 0
-	if(picked_candidates.len)
+	if(length(picked_candidates))
 		for(var/datum/mind/M in picked_candidates)
 			members += M
 			i++

--- a/code/datums/entities/player.dm
+++ b/code/datums/entities/player.dm
@@ -606,14 +606,14 @@ BSQL_PROTECT_DATUM(/datum/entity/player)
 			note.admin_rank = "N/A"
 		note.date = I.timestamp
 		var/list/splitting = splittext(I.content, "|")
-		if(splitting.len == 1)
+		if(length(splitting) == 1)
 			note.text = I.content
 			note.is_ban = FALSE
-		if(splitting.len == 3)
+		if(length(splitting) == 3)
 			note.text = splitting[3]
 			note.ban_time = text2num(replacetext(replacetext(splitting[2],"Duration: ","")," minutes",""))
 			note.is_ban = TRUE
-		if(splitting.len == 2)
+		if(length(splitting) == 2)
 			note.text = I.content
 			note.is_ban = TRUE
 

--- a/code/datums/global_variables.dm
+++ b/code/datums/global_variables.dm
@@ -158,9 +158,9 @@
 
 	else if (istype(value, /list))
 		var/list/L = value
-		html += "[name] = /list ([L.len])"
+		html += "[name] = /list ([length(L)])"
 
-		if (L.len > 0 && !(name == "underlays" || name == "overlays" || name == "vars" || L.len > 500))
+		if (length(L) > 0 && !(name == "underlays" || name == "overlays" || name == "vars" || length(L) > 500))
 			// not sure if this is completely right...
 			html += "<ul>"
 			var/index = 1

--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -41,7 +41,7 @@ GLOBAL_DATUM_INIT(revdata, /datum/getrev, new)
 	return msg.Join("\n")
 
 /datum/getrev/proc/GetTestMergeInfo(header = TRUE)
-	if(!testmerge.len)
+	if(!length(testmerge))
 		return ""
 	. = header ? "The following pull requests are currently test merged:<br>" : ""
 	for(var/line in testmerge)
@@ -70,7 +70,7 @@ GLOBAL_DATUM_INIT(revdata, /datum/getrev, new)
 	var/pc = revdata.originmastercommit
 	if(pc)
 		msg += "Master commit: <a href=\"[CONFIG_GET(string/githuburl)]/commit/[pc]\">[pc]</a>"
-	if(revdata.testmerge.len)
+	if(length(revdata.testmerge))
 		msg += revdata.GetTestMergeInfo()
 	if(revdata.commit && revdata.commit != revdata.originmastercommit)
 		msg += "Local commit: [revdata.commit]"

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -157,8 +157,8 @@
 		precision = rand(1,100)
 
 	var/list/bagholding = teleatom.search_contents_for(/obj/item/storage/backpack/holding)
-	if(bagholding.len)
-		precision = max(rand(1,100)*bagholding.len,100)
+	if(length(bagholding))
+		precision = max(rand(1,100)*length(bagholding),100)
 		if(istype(teleatom, /mob/living))
 			var/mob/living/MM = teleatom
 			to_chat(MM, SPAN_WARNING("The Bluespace interface on your Bag of Holding interferes with the teleport!"))

--- a/code/datums/matrix_editor.dm
+++ b/code/datums/matrix_editor.dm
@@ -72,11 +72,11 @@
 				if(!elements_str)
 					return
 				var/list/elements = splittext(elements_str, ",")
-				if(elements.len != 6)
-					to_chat(usr, "When creating a custom matrix, explicitly provide all 6 elements! Only [elements.len] were provided.")
+				if(length(elements) != 6)
+					to_chat(usr, "When creating a custom matrix, explicitly provide all 6 elements! Only [length(elements)] were provided.")
 					return
 
-				for(var/i = 1 to elements.len)
+				for(var/i = 1 to length(elements))
 					var/num_ver = text2num(elements[i])
 					if(isnull(num_ver))
 						to_chat(usr, "Failed to convert element #[i] ([elements[i]]) to a number.")

--- a/code/datums/medal_awards.dm
+++ b/code/datums/medal_awards.dm
@@ -402,7 +402,7 @@ GLOBAL_LIST_INIT(xeno_medals, list(XENO_SLAUGHTER_MEDAL, XENO_RESILIENCE_MEDAL, 
 		to_chat(usr, "Error: Could not find the [is_marine_medal ? "marine" : "xeno"] awards for '[recipient_name]'!")
 		return FALSE
 
-	if(index < 1 || index > recipient_award.medal_names.len)
+	if(index < 1 || index > length(recipient_award.medal_names))
 		to_chat(usr, "Error: Index [index] is out of bounds!")
 		return FALSE
 
@@ -429,7 +429,7 @@ GLOBAL_LIST_INIT(xeno_medals, list(XENO_SLAUGHTER_MEDAL, XENO_RESILIENCE_MEDAL, 
 	// Either entirely delete the award from the list, or just remove the entry if there are multiple
 	var/medal_type = recipient_award.medal_names[index]
 	var/citation = recipient_award.medal_citations[index]
-	if(recipient_award.medal_names.len == 1)
+	if(length(recipient_award.medal_names) == 1)
 		if(is_marine_medal)
 			GLOB.medal_awards.Remove(recipient_name)
 		else

--- a/code/datums/quadtree.dm
+++ b/code/datums/quadtree.dm
@@ -103,7 +103,7 @@
 		player_coords = list(p_coords)
 		return TRUE
 
-	else if(!final_divide && player_coords.len >= QUADTREE_CAPACITY)
+	else if(!final_divide && length(player_coords) >= QUADTREE_CAPACITY)
 		if(!is_divided)
 			subdivide()
 		if(nw_branch.insert_player(p_coords))

--- a/code/datums/recipe.dm
+++ b/code/datums/recipe.dm
@@ -49,7 +49,7 @@
 				. = -1
 			else
 				return 0
-	if ((reagents?(reagents.len):(0)) < avail_reagents.reagent_list.len)
+	if ((LAZYLEN(reagents) || 0) < length(avail_reagents.reagent_list))
 		return -1
 	return .
 
@@ -70,7 +70,7 @@
 				break
 		if (!found)
 			. = -1
-	if (checklist.len)
+	if (length(checklist))
 		return 0
 	return .
 
@@ -107,17 +107,17 @@
 	for (var/datum/recipe/recipe in available_recipes)
 		if (recipe.check_reagents(obj.reagents)==exact && recipe.check_items(obj)==exact)
 			possible_recipes+=recipe
-	if (possible_recipes.len==0)
+	if (length(possible_recipes)==0)
 		return null
-	else if (possible_recipes.len==1)
+	else if (length(possible_recipes)==1)
 		return possible_recipes[1]
 	else //okay, let's select the most complicated recipe
 		var/r_count = 0
 		var/i_count = 0
 		. = possible_recipes[1]
 		for (var/datum/recipe/recipe in possible_recipes)
-			var/N_i = (recipe.items)?(recipe.items.len):0
-			var/N_r = (recipe.reagents)?(recipe.reagents.len):0
+			var/N_i = LAZYLEN(recipe.items) || 0
+			var/N_r = LAZYLEN(recipe.reagents) || 0
 			if (N_i > i_count || (N_i== i_count && N_r > r_count ))
 				r_count = N_r
 				i_count = N_i

--- a/code/datums/soundOutput.dm
+++ b/code/datums/soundOutput.dm
@@ -104,7 +104,7 @@
 /datum/soundOutput/proc/update_soundscape()
 	scape_cooldown--
 	if(scape_cooldown <= 0)
-		if(soundscape_playlist.len)
+		if(length(soundscape_playlist))
 			var/sound/S = sound()
 			S.file = pick(soundscape_playlist)
 			S.volume = 100 * owner.volume_preferences[VOLUME_AMB]

--- a/code/datums/statistics/entities/panel_stats.dm
+++ b/code/datums/statistics/entities/panel_stats.dm
@@ -463,7 +463,7 @@
 		total_deaths_list += list(list("name" = S.name, "value" = S.value))
 
 	for(var/datum/entity/statistic/death/S in death_stats_list)
-		if(new_death_stats_list.len >= STATISTICS_DEATH_LIST_LEN)
+		if(length(new_death_stats_list) >= STATISTICS_DEATH_LIST_LEN)
 			break
 		var/list/damage_list = list()
 		if(S.total_brute)
@@ -496,7 +496,7 @@
 			"y" = S.y,
 			"z" = S.z
 		))
-		if(new_death_stats_list.len < STATISTICS_DEATH_LIST_LEN)
+		if(length(new_death_stats_list) < STATISTICS_DEATH_LIST_LEN)
 			new_death_stats_list += death
 
 	for(var/iteration in weapon_stats_list)

--- a/code/datums/statistics/entities/round_stats.dm
+++ b/code/datums/statistics/entities/round_stats.dm
@@ -300,8 +300,8 @@
 		if(death_data["death_stats_list"])
 			new_death_list = death_data["death_stats_list"]
 		new_death_list.Insert(1, death)
-		if(new_death_list.len > STATISTICS_DEATH_LIST_LEN)
-			new_death_list.Cut(STATISTICS_DEATH_LIST_LEN+1, new_death_list.len)
+		if(length(new_death_list) > STATISTICS_DEATH_LIST_LEN)
+			new_death_list.Cut(STATISTICS_DEATH_LIST_LEN+1, length(new_death_list))
 		death_data["death_stats_list"] = new_death_list
 	track_dead_participant(new_death.faction_name)
 

--- a/code/datums/weather/weather_map_holder.dm
+++ b/code/datums/weather/weather_map_holder.dm
@@ -33,7 +33,7 @@
 // Return a type that can be initialized into the next weather event.
 // Feel free to override this
 /datum/weather_ss_map_holder/proc/get_new_event()
-	if (potential_weather_events && potential_weather_events.len != 0)
+	if (LAZYLEN(potential_weather_events) != 0)
 		return pick(potential_weather_events)
 	else
 		log_debug("Weather subsystem map holder [src] is improperly configured. Code: WSSMH03")

--- a/code/defines/procs/AStar.dm
+++ b/code/defines/procs/AStar.dm
@@ -46,13 +46,13 @@ length to avoid portals or something i guess?? Not that they're counted right no
 	cmp = compare
 
 /PriorityQueue/proc/IsEmpty()
-	return !L.len
+	return !length(L)
 
 /PriorityQueue/proc/Enqueue(d)
 	var/i
 	var/j
 	L.Add(d)
-	i = L.len
+	i = length(L)
 	j = i>>1
 	while(i > 1 &&  call(cmp)(L[j],L[i]) > 0)
 		L.Swap(i,j)
@@ -60,22 +60,22 @@ length to avoid portals or something i guess?? Not that they're counted right no
 		j >>= 1
 
 /PriorityQueue/proc/Dequeue()
-	if(!L.len) return 0
+	if(!length(L)) return 0
 	. = L[1]
 	Remove(1)
 
 /PriorityQueue/proc/Remove(i)
-	if(i > L.len) return 0
-	L.Swap(i,L.len)
-	L.Cut(L.len)
-	if(i < L.len)
+	if(i > length(L)) return 0
+	L.Swap(i,length(L))
+	L.Cut(length(L))
+	if(i < length(L))
 		_Fix(i)
 
 /PriorityQueue/proc/_Fix(i)
 	var/child = i + i
 	var/item = L[i]
-	while(child <= L.len)
-		if(child + 1 <= L.len && call(cmp)(L[child],L[child + 1]) > 0)
+	while(child <= length(L))
+		if(child + 1 <= length(L) && call(cmp)(L[child],L[child + 1]) > 0)
 			child++
 		if(call(cmp)(item,L[child]) > 0)
 			L[i] = L[child]
@@ -159,7 +159,7 @@ length to avoid portals or something i guess?? Not that they're counted right no
 			var/ng = cur.g + call(cur.source,dist)(d)
 			if(d.bestF)
 				if(ng + call(d,dist)(end) < d.bestF)
-					for(var/i = 1; i <= open.L.len; i++)
+					for(var/i = 1; i <= length(open.L); i++)
 						var/PathNode/n = open.L[i]
 						if(n.source == d)
 							open.Remove(i)
@@ -168,21 +168,21 @@ length to avoid portals or something i guess?? Not that they're counted right no
 					continue
 
 			open.Enqueue(new /PathNode(d,cur,ng,call(d,dist)(end),cur.nt+1))
-			if(maxnodes && open.L.len > maxnodes)
-				open.L.Cut(open.L.len)
+			if(maxnodes && length(open.L) > maxnodes)
+				open.L.Cut(length(open.L))
 	}
 
 	var/PathNode/temp
 	while(!open.IsEmpty())
 		temp = open.Dequeue()
 		temp.source.bestF = 0
-	while(closed.len)
-		temp = closed[closed.len]
+	while(length(closed))
+		temp = closed[length(closed)]
 		temp.bestF = 0
-		closed.Cut(closed.len)
+		closed.Cut(length(closed))
 
 	if(path)
-		for(var/i = 1; i <= path.len/2; i++)
-			path.Swap(i,path.len-i+1)
+		for(var/i = 1; i <= length(path)/2; i++)
+			path.Swap(i,length(path)-i+1)
 
 	return path

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -238,7 +238,7 @@ directive is properly returned.
 				pass |= istype(A, type)
 			if(!pass)
 				continue
-		if(A.contents.len)
+		if(length(A.contents))
 			found += A.search_contents_for(path,filter_path)
 	return found
 

--- a/code/game/cas_manager/datums/cas_fire_mission.dm
+++ b/code/game/cas_manager/datums/cas_fire_mission.dm
@@ -80,7 +80,7 @@
 
 /datum/cas_fire_mission/proc/check(obj/structure/machinery/computer/dropship_weapons/linked_console)
 	error_weapon = null
-	if(records.len == 0)
+	if(length(records) == 0)
 		return FIRE_MISSION_ALL_GOOD //I mean yes... but why?
 
 	for(var/datum/cas_fire_mission_record/record in records)
@@ -105,7 +105,7 @@
 		var/i
 		if(!record.offsets)
 			continue
-		for(i=1,i<=record.offsets.len,i++)
+		for(i=1,i<=length(record.offsets),i++)
 			if(cd > 0)
 				cd--
 			if(record.offsets[i] == null || record.offsets[i] == "-")
@@ -192,7 +192,7 @@
 				envelope.change_current_loc(current_turf)
 		var/datum/cas_fire_mission_record/item
 		for(item in records)
-			if(item.offsets.len < step || item.offsets[step] == null || item.offsets[step]=="-")
+			if(length(item.offsets) < step || item.offsets[step] == null || item.offsets[step]=="-")
 				continue
 			var/offset = item.offsets[step]
 			if (current_turf == null)

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -118,7 +118,7 @@ Additional game mode variables.
 /datum/game_mode/proc/initialize_special_clamps()
 	xeno_starting_num = clamp((GLOB.readied_players/CONFIG_GET(number/xeno_number_divider)), xeno_required_num, INFINITY) //(n, minimum, maximum)
 	surv_starting_num = clamp((GLOB.readied_players/CONFIG_GET(number/surv_number_divider)), 2, 8) //this doesnt run
-	marine_starting_num = GLOB.player_list.len - xeno_starting_num - surv_starting_num
+	marine_starting_num = length(GLOB.player_list) - xeno_starting_num - surv_starting_num
 	for(var/datum/squad/sq in GLOB.RoleAuthority.squads)
 		if(sq)
 			sq.max_engineers = engi_slot_formula(marine_starting_num)
@@ -266,7 +266,7 @@ Additional game mode variables.
 /datum/game_mode/proc/initialize_starting_xenomorph_list(list/hives = list(XENO_HIVE_NORMAL), bypass_checks = FALSE)
 	var/list/datum/mind/possible_xenomorphs = get_players_for_role(JOB_XENOMORPH)
 	var/list/datum/mind/possible_queens = get_players_for_role(JOB_XENOMORPH_QUEEN)
-	if(possible_xenomorphs.len < xeno_required_num && !bypass_checks) //We don't have enough aliens, we don't consider people rolling for only Queen.
+	if(length(possible_xenomorphs) < xeno_required_num && !bypass_checks) //We don't have enough aliens, we don't consider people rolling for only Queen.
 		to_world("<h2 style=\"color:red\">Not enough players have chosen to be a xenomorph in their character setup. <b>Aborting</b>.</h2>")
 		return
 
@@ -388,7 +388,7 @@ Additional game mode variables.
 			available_xenos += larva_option
 			available_xenos[larva_option] = list(hive)
 
-	if(!available_xenos.len || (instant_join && !available_xenos_non_ssd.len))
+	if(!length(available_xenos) || (instant_join && !length(available_xenos_non_ssd)))
 		if(!xeno_candidate.client?.prefs || !(xeno_candidate.client.prefs.be_special & BE_ALIEN_AFTER_DEATH))
 			to_chat(xeno_candidate, SPAN_WARNING("There aren't any available xenomorphs or burrowed larvae. \
 				You can try getting spawned as a chestburster larva by toggling your Xenomorph candidacy in \
@@ -524,16 +524,16 @@ Additional game mode variables.
 	var/last_active_hive = 0
 	for(var/hivenumber in GLOB.hive_datum)
 		hive = GLOB.hive_datum[hivenumber]
-		if(hive.totalXenos.len <= 0)
+		if(length(hive.totalXenos) <= 0)
 			continue
 		active_hives[hive.name] = hive.hivenumber
 		last_active_hive = hive.hivenumber
 
-	if(active_hives.len <= 0)
+	if(length(active_hives) <= 0)
 		to_chat(xeno_candidate, SPAN_WARNING("There aren't any Hives active at this point for you to join."))
 		return FALSE
 
-	if(active_hives.len > 1)
+	if(length(active_hives) > 1)
 		var/hive_picked = tgui_input_list(xeno_candidate, "Select which Hive to attempt joining.", "Hive Choice", active_hives, theme="hive_status")
 		if(!hive_picked)
 			to_chat(xeno_candidate, SPAN_ALERT("Hive choice error. Aborting."))
@@ -558,7 +558,7 @@ Additional game mode variables.
 				var/descriptive_name = "[morpher.name] in [area_name]"
 				available_facehugger_sources[descriptive_name] = morpher
 
-	if(available_facehugger_sources.len <= 0)
+	if(length(available_facehugger_sources) <= 0)
 		to_chat(xeno_candidate, SPAN_WARNING("There aren't any Carriers or Egg Morphers with available Facehuggers for you to join. Please try again later!"))
 		return FALSE
 
@@ -590,16 +590,16 @@ Additional game mode variables.
 	var/last_active_hive = 0
 	for(var/hivenumber in GLOB.hive_datum)
 		hive = GLOB.hive_datum[hivenumber]
-		if(hive.totalXenos.len <= 0)
+		if(length(hive.totalXenos) <= 0)
 			continue
 		active_hives[hive.name] = hive.hivenumber
 		last_active_hive = hive.hivenumber
 
-	if(active_hives.len <= 0)
+	if(length(active_hives) <= 0)
 		to_chat(xeno_candidate, SPAN_WARNING("There aren't any Hives active at this point for you to join."))
 		return FALSE
 
-	if(active_hives.len > 1)
+	if(length(active_hives) > 1)
 		var/hive_picked = tgui_input_list(xeno_candidate, "Select which Hive to attempt joining.", "Hive Choice", active_hives, theme="hive_status")
 		if(!hive_picked)
 			to_chat(xeno_candidate, SPAN_ALERT("Hive choice error. Aborting."))
@@ -826,7 +826,7 @@ Additional game mode variables.
 	H.name = H.get_visible_name()
 
 	if(!H.first_xeno) //Only give objectives/back-stories to uninfected survivors
-		if(spawner.intro_text && spawner.intro_text.len)
+		if(LAZYLEN(spawner.intro_text))
 			spawn(4)
 				for(var/line in spawner.intro_text)
 					to_chat(H, line)
@@ -893,7 +893,7 @@ Additional game mode variables.
 	var/story //The actual story they will get to read.
 	var/random_name
 	var/datum/mind/survivor
-	while(current_survivors.len)
+	while(length(current_survivors))
 		survivor = pick(current_survivors)
 		if(!istype(survivor))
 			current_survivors -= survivor
@@ -905,8 +905,8 @@ Additional game mode variables.
 			current_survivors -= survivor
 			continue
 
-		if(current_survivors.len > 1) //If we have another survivor to pick from.
-			if(survivor_multi_story.len) //Unlikely.
+		if(length(current_survivors) > 1) //If we have another survivor to pick from.
+			if(length(survivor_multi_story)) //Unlikely.
 				var/datum/mind/another_survivor = pick(current_survivors - survivor) // We don't want them to be picked twice.
 				current_survivors -= another_survivor
 				if(!istype(another_survivor)) continue//If somehow this thing screwed up, we're going to run another pass.
@@ -921,7 +921,7 @@ Additional game mode variables.
 					to_chat(another_survivor.current, temp_story)
 					another_survivor.memory += temp_story
 		else
-			if(survivor_story.len) //Shouldn't happen, but technically possible.
+			if(length(survivor_story)) //Shouldn't happen, but technically possible.
 				story = pick(survivor_story)
 				survivor_story -= story
 				spawn(6)

--- a/code/game/gamemodes/cm_process.dm
+++ b/code/game/gamemodes/cm_process.dm
@@ -40,12 +40,12 @@ of predators), but can be added to include variant game modes (like humans vs. h
 	set waitfor = 0
 	sleep(2 SECONDS)
 	GLOB.fallen_list += GLOB.fallen_list_cross
-	if(GLOB.fallen_list.len)
+	if(length(GLOB.fallen_list))
 		var/dat = "<br>"
 		dat += SPAN_ROUNDBODY("In Flanders fields...<br>")
 		dat += SPAN_CENTERBOLD("In memoriam of our fallen soldiers: <br>")
-		for(var/i = 1 to GLOB.fallen_list.len)
-			if(i != GLOB.fallen_list.len)
+		for(var/i = 1 to length(GLOB.fallen_list))
+			if(i != length(GLOB.fallen_list))
 				dat += "[GLOB.fallen_list[i]], "
 			else
 				dat += "[GLOB.fallen_list[i]].<br>"
@@ -87,20 +87,20 @@ of predators), but can be added to include variant game modes (like humans vs. h
 /datum/game_mode/proc/declare_completion_announce_medal_awards()
 	set waitfor = 0
 	sleep(2 SECONDS)
-	if(GLOB.medal_awards.len)
+	if(length(GLOB.medal_awards))
 		var/dat = "<br>"
 		dat +=  SPAN_ROUNDBODY("<br>Medal Awards:")
 		for(var/recipient in GLOB.medal_awards)
 			var/datum/recipient_awards/recipient_award = GLOB.medal_awards[recipient]
-			for(var/i in 1 to recipient_award.medal_names.len)
+			for(var/i in 1 to length(recipient_award.medal_names))
 				dat += "<br><b>[recipient_award.recipient_rank] [recipient]</b> is awarded [recipient_award.posthumous[i] ? "posthumously " : ""]the <span class='boldnotice'>[recipient_award.medal_names[i]]</span>: \'<i>[recipient_award.medal_citations[i]]</i>\'."
 		to_world(dat)
-	if(GLOB.jelly_awards.len)
+	if(length(GLOB.jelly_awards))
 		var/dat = "<br>"
 		dat +=  SPAN_ROUNDBODY("<br>Royal Jelly Awards:")
 		for(var/recipient in GLOB.jelly_awards)
 			var/datum/recipient_awards/recipient_award = GLOB.jelly_awards[recipient]
-			for(var/i in 1 to recipient_award.medal_names.len)
+			for(var/i in 1 to length(recipient_award.medal_names))
 				dat += "<br><b>[recipient]</b> is awarded [recipient_award.posthumous[i] ? "posthumously " : ""]a <span class='boldnotice'>[recipient_award.medal_names[i]]</span>: \'<i>[recipient_award.medal_citations[i]]</i>\'[recipient_award.giver_rank[i] ? " by [recipient_award.giver_rank[i]]" : ""][recipient_award.giver_name[i] ? " ([recipient_award.giver_name[i]])" : ""]."
 		to_world(dat)
 

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -89,7 +89,7 @@
 			new type_to_spawn(T)
 
 	//desert river test
-	if(!round_toxic_river.len)
+	if(!length(round_toxic_river))
 		round_toxic_river = null //No tiles?
 	else
 		round_time_river = rand(-100,100)
@@ -100,7 +100,7 @@
 	var/obj/structure/tunnel/T
 	var/i = 0
 	var/turf/t
-	while(GLOB.xeno_tunnels.len && i++ < 3)
+	while(length(GLOB.xeno_tunnels) && i++ < 3)
 		t = get_turf(pick_n_take(GLOB.xeno_tunnels))
 		T = new(t)
 		T.id = "hole[i]"
@@ -522,7 +522,7 @@
 		GLOB.round_statistics.game_mode = name
 		GLOB.round_statistics.round_length = world.time
 		GLOB.round_statistics.round_result = round_finished
-		GLOB.round_statistics.end_round_player_population = GLOB.clients.len
+		GLOB.round_statistics.end_round_player_population = length(GLOB.clients)
 
 		GLOB.round_statistics.log_round_statistics()
 
@@ -641,7 +641,7 @@
 			total_marines += squad_marines_job_report[job_type]
 			total_squad_marines += squad_marines_job_report[job_type]
 			incrementer++
-			if(incrementer < squad_marines_job_report.len)
+			if(incrementer < length(squad_marines_job_report))
 				squad_marine_job_text += ", "
 
 		var/auxiliary_marine_job_text = ""
@@ -651,7 +651,7 @@
 			auxiliary_marine_job_text += "[job_type]: [auxiliary_marines_job_report[job_type]]"
 			total_marines += auxiliary_marines_job_report[job_type]
 			incrementer++
-			if(incrementer < auxiliary_marines_job_report.len)
+			if(incrementer < length(auxiliary_marines_job_report))
 				auxiliary_marine_job_text += ", "
 
 		var/total_non_standard = 0
@@ -662,7 +662,7 @@
 			non_standard_job_text += "[job_type]: [non_standard_job_report[job_type]]"
 			total_non_standard += non_standard_job_report[job_type]
 			incrementer++
-			if(incrementer < non_standard_job_report.len)
+			if(incrementer < length(non_standard_job_report))
 				non_standard_job_text += ", "
 
 		var/list/hive_xeno_numbers = list()
@@ -676,7 +676,7 @@
 				hive_caste_text += "[hive_caste]: [per_hive_status[hive_caste]]"
 				hive_amount += per_hive_status[hive_caste]
 				incrementer++
-				if(incrementer < per_hive_status.len)
+				if(incrementer < length(per_hive_status))
 					hive_caste_text += ", "
 			if(hive_amount)
 				hive_xeno_numbers[hive] = hive_amount

--- a/code/game/gamemodes/colonialmarines/huntergames.dm
+++ b/code/game/gamemodes/colonialmarines/huntergames.dm
@@ -212,10 +212,10 @@
 	var/mob/living/carbon/human/H
 	var/turf/picked
 
-	if(GLOB.hunter_primaries.len)
+	if(length(GLOB.hunter_primaries))
 		picked = get_turf(pick_n_take(GLOB.hunter_primaries))
 	else
-		if(GLOB.hunter_secondaries.len)
+		if(length(GLOB.hunter_secondaries))
 			picked = get_turf(pick_n_take(GLOB.hunter_secondaries))
 		else
 			message_admins("There were no spawn points available for a contestant.")
@@ -226,7 +226,7 @@
 
 	if(istype(M,/mob/living/carbon/human)) //somehow?
 		H = M
-		if(H.contents.len)
+		if(length(H.contents))
 			for(var/obj/item/I in H.contents)
 				qdel(I)
 		H.forceMove(picked)
@@ -315,7 +315,7 @@
 			last_drop = world.time
 			waiting_for_drop_votes = 1
 			sleep(600)
-			if(!supply_votes.len)
+			if(!length(supply_votes))
 				to_world(SPAN_ROUNDBODY("Nobody got anything! .. weird."))
 				waiting_for_drop_votes = 0
 				supply_votes = list()

--- a/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
+++ b/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
@@ -201,9 +201,9 @@
 /datum/game_mode/whiskey_outpost/proc/announce_xeno_wave(datum/whiskey_outpost_wave/wave_data)
 	if(!istype(wave_data))
 		return
-	if(wave_data.command_announcement.len > 0)
+	if(length(wave_data.command_announcement) > 0)
 		marine_announcement(wave_data.command_announcement[1], wave_data.command_announcement[2])
-	if(wave_data.sound_effect.len > 0)
+	if(length(wave_data.sound_effect) > 0)
 		playsound_z(SSmapping.levels_by_trait(ZTRAIT_GROUND), pick(wave_data.sound_effect))
 
 //CHECK WIN
@@ -297,7 +297,7 @@
 	if(GLOB.round_statistics)
 		GLOB.round_statistics.game_mode = name
 		GLOB.round_statistics.round_length = world.time
-		GLOB.round_statistics.end_round_player_population = GLOB.clients.len
+		GLOB.round_statistics.end_round_player_population = length(GLOB.clients)
 
 		GLOB.round_statistics.log_round_statistics()
 
@@ -485,7 +485,7 @@
 	if(crate)
 		crate.storage_capacity = 60
 
-	if(randomitems.len)
+	if(length(randomitems))
 		for(var/i = 0; i < choosemax; i++)
 			var/path = pick(randomitems)
 			var/obj/I = new path(crate)
@@ -536,7 +536,7 @@
 			for(var/obj/O in T)
 				if(istype(O,/obj/structure/closet/crate))
 					var/obj/structure/closet/crate/C = O
-					if(C.contents.len)
+					if(length(C.contents))
 						to_chat(user, SPAN_DANGER("[O] must be emptied before it can be recycled"))
 						continue
 					new /obj/item/stack/sheet/metal(get_step(src,dir))
@@ -778,7 +778,7 @@
 	return
 
 /obj/item/storage/box/attachments/update_icon()
-	if(!contents.len)
+	if(!length(contents))
 		var/turf/T = get_turf(src)
 		if(T)
 			new /obj/item/paper/crumpled(T)

--- a/code/game/gamemodes/colonialmarines/whiskey_outpost/whiskey_output_waves.dm
+++ b/code/game/gamemodes/colonialmarines/whiskey_outpost/whiskey_output_waves.dm
@@ -43,7 +43,7 @@
 
 	available_xenos += unique_xenos
 
-	if(!available_xenos.len)
+	if(!length(available_xenos))
 		to_chat(xeno_candidate, SPAN_WARNING("There aren't any available xenomorphs."))
 		return FALSE
 

--- a/code/game/gamemodes/colonialmarines/xenovsxeno.dm
+++ b/code/game/gamemodes/colonialmarines/xenovsxeno.dm
@@ -44,8 +44,8 @@
 /datum/game_mode/xenovs/pre_setup()
 	monkey_types = SSmapping.configs[GROUND_MAP].monkey_types
 	if(monkey_amount)
-		if(monkey_types.len)
-			for(var/i = min(floor(monkey_amount*GLOB.clients.len), GLOB.monkey_spawns.len), i > 0, i--)
+		if(length(monkey_types))
+			for(var/i = min(floor(monkey_amount*length(GLOB.clients)), length(GLOB.monkey_spawns)), i > 0, i--)
 
 				var/turf/T = get_turf(pick_n_take(GLOB.monkey_spawns))
 				var/monkey_to_spawn = pick(monkey_types)
@@ -265,7 +265,7 @@
 	if(GLOB.round_statistics)
 		GLOB.round_statistics.game_mode = name
 		GLOB.round_statistics.round_length = world.time
-		GLOB.round_statistics.end_round_player_population = GLOB.clients.len
+		GLOB.round_statistics.end_round_player_population = length(GLOB.clients)
 
 		GLOB.round_statistics.log_round_statistics()
 

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -42,7 +42,7 @@
 	if(GLOB.round_statistics)
 		GLOB.round_statistics.game_mode = name
 		GLOB.round_statistics.round_length = world.time
-		GLOB.round_statistics.end_round_player_population = GLOB.clients.len
+		GLOB.round_statistics.end_round_player_population = length(GLOB.clients)
 		GLOB.round_statistics.log_round_statistics()
 
 	calculate_end_statistics()

--- a/code/game/gamemodes/extended/infection.dm
+++ b/code/game/gamemodes/extended/infection.dm
@@ -71,16 +71,16 @@
 		possible_synth_survivors -= A
 
 	possible_survivors = shuffle(possible_survivors) //Shuffle them up a bit
-	if(possible_survivors.len) //We have some, it looks like.
+	if(length(possible_survivors)) //We have some, it looks like.
 		for(var/datum/mind/A in possible_survivors) //Strip out any xenos first so we don't double-dip.
 			if(A.roundstart_picked)
 				possible_survivors -= A
 
-		if(possible_survivors.len) //We may have stripped out all the contendors, so check again.
+		if(length(possible_survivors)) //We may have stripped out all the contendors, so check again.
 			var/i = surv_starting_num
 			var/datum/mind/new_survivor
 			while(i > 0)
-				if(!possible_survivors.len)
+				if(!length(possible_survivors))
 					break  //Ran out of candidates! Can't have a null pick(), so just stick with what we have.
 				new_survivor = pick(possible_survivors)
 				if(!new_survivor)
@@ -123,7 +123,7 @@
 	if(GLOB.round_statistics)
 		GLOB.round_statistics.game_mode = name
 		GLOB.round_statistics.round_length = world.time
-		GLOB.round_statistics.end_round_player_population = GLOB.clients.len
+		GLOB.round_statistics.end_round_player_population = length(GLOB.clients)
 		GLOB.round_statistics.log_round_statistics()
 
 	declare_completion_announce_xenomorphs()

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -61,7 +61,7 @@
 	gen_access()
 	if(!islist(req_access)) return 1//something's very wrong
 	var/L[] = req_access
-	if(!L.len && (!req_one_access || !req_one_access.len)) return 1//no requirements
+	if(!length(L) && !LAZYLEN(req_one_access)) return 1//no requirements
 	if(!I) return
 
 	var/list/A = I.GetAccess()
@@ -69,7 +69,7 @@
 		if(!(i in A))
 			return FALSE//doesn't have this access
 
-	if(req_one_access && req_one_access.len)
+	if(LAZYLEN(req_one_access))
 		for(var/i in req_one_access)
 			if(i in A)
 				return TRUE//has an access from the single access list
@@ -80,14 +80,14 @@
 	gen_access()
 	if(!req_access  && !req_one_access) return 1
 	if(!islist(req_access)) return 1
-	if(!req_access.len && !islist(req_one_access))
+	if(!length(req_access) && !islist(req_one_access))
 		return TRUE
-	if(!req_access.len && (!req_one_access || !req_one_access.len)) return 1
+	if(!length(req_access) && !LAZYLEN(req_one_access)) return 1
 	if(!islist(L)) return
 	var/i
 	for(i in req_access)
 		if(!(i in L)) return //doesn't have this access
-	if(req_one_access && req_one_access.len)
+	if(LAZYLEN(req_one_access))
 		for(i in req_one_access)
 			if(i in L) return 1//has an access from the single access list
 		return

--- a/code/game/jobs/job/civilians/other/survivors.dm
+++ b/code/game/jobs/job/civilians/other/survivors.dm
@@ -187,7 +187,7 @@ AddTimelock(/datum/job/civilian/survivor, list(
 
 /datum/job/civilian/survivor/commanding_officer/set_spawn_positions()
 	var/list/CO_survivor_types = SSmapping.configs[GROUND_MAP].CO_survivor_types
-	if(CO_survivor_types.len)
+	if(length(CO_survivor_types))
 		total_positions = 1
 		spawn_positions = 1
 	return spawn_positions

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -188,7 +188,7 @@
 				remembered_info += "<b>Your account pin is:</b> [generated_account.remote_access_pin]<br>"
 				remembered_info += "<b>Your account funds are:</b> $[generated_account.money]<br>"
 
-				if(generated_account.transaction_log.len)
+				if(length(generated_account.transaction_log))
 					var/datum/transaction/T = generated_account.transaction_log[1]
 					remembered_info += "<b>Your account was created:</b> [T.time], [T.date] at [T.source_terminal]<br>"
 				account_user.mind.store_memory(remembered_info)

--- a/code/game/jobs/job/marine/squad_info.dm
+++ b/code/game/jobs/job/marine/squad_info.dm
@@ -9,7 +9,7 @@
 	return GLOB.not_incapacitated_state
 
 /datum/squad/ui_data(mob/user)
-	if(!squad_info_data.len) //initial first update of data
+	if(!length(squad_info_data)) //initial first update of data
 		update_all_squad_info()
 	if(squad_info_data["total_mar"] != count) //updates for new marines
 		update_free_mar()
@@ -130,7 +130,7 @@
 
 //fireteam and TL update
 /datum/squad/proc/update_fireteam(team)
-	squad_info_data["fireteams"][team]["total"] = fireteams[team].len
+	squad_info_data["fireteams"][team]["total"] = length(fireteams[team])
 	if(squad_info_data["fireteams"][team]["total"] < 1)
 		squad_info_data["fireteams"][team]["tl"] = list()
 		squad_info_data["fireteams"][team]["mar"] = list()
@@ -197,7 +197,7 @@
 	squad_info_data["total_kia"] = 0
 	var/mar_free = count
 	for(var/team in fireteams)
-		mar_free -= fireteams[team].len
+		mar_free -= length(fireteams[team])
 	if(squad_leader)
 		mar_free--
 	for(var/list/freeman in squad_info_data["mar_free"])

--- a/code/game/jobs/job/marine/squads.dm
+++ b/code/game/jobs/job/marine/squads.dm
@@ -649,7 +649,7 @@
 //Not a safe proc. Returns null if squads or jobs aren't set up.
 //Mostly used in the marine squad console in marine_consoles.dm.
 /proc/get_squad_by_name(text)
-	if(!GLOB.RoleAuthority || GLOB.RoleAuthority.squads.len == 0)
+	if(!GLOB.RoleAuthority || length(GLOB.RoleAuthority.squads) == 0)
 		return null
 	var/datum/squad/S
 	for(S in GLOB.RoleAuthority.squads)

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -331,7 +331,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 		var/i = 0
 		var/j
 		while(++i < 3) //Get two passes.
-			if(!roles_to_iterate.len || prob(65)) break //Base chance to become a marine when being assigned randomly, or there are no roles available.
+			if(!length(roles_to_iterate) || prob(65)) break //Base chance to become a marine when being assigned randomly, or there are no roles available.
 			j = pick(roles_to_iterate)
 			J = roles_to_iterate[j]
 
@@ -533,7 +533,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 
 //Find which squad has the least population. If all 4 squads are equal it should just use a random one
 /datum/authority/branch/role/proc/get_lowest_squad(mob/living/carbon/human/H)
-	if(!squads.len) //Something went wrong, our squads aren't set up.
+	if(!length(squads)) //Something went wrong, our squads aren't set up.
 		to_world("Warning, something messed up in get_lowest_squad(). No squads set up!")
 		return null
 
@@ -542,7 +542,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 	var/list/squads_copy = squads.Copy()
 	var/list/mixed_squads = list()
 
-	for(var/i= 1 to squads_copy.len)
+	for(var/i= 1 to length(squads_copy))
 		var/datum/squad/S = pick_n_take(squads_copy)
 		if (S.roundstart && S.usable && S.faction == H.faction && S.name != "Root")
 			mixed_squads += S
@@ -586,7 +586,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 	if(!H)
 		return
 
-	if(!squads.len)
+	if(!length(squads))
 		to_chat(H, "Something went wrong with your squad randomizer! Tell a coder!")
 		return //Shit, where's our squad data
 
@@ -597,7 +597,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 	var/list/squads_copy = squads.Copy()
 	var/list/mixed_squads = list()
 	// The following code removes non useable squads from the lists of squads we assign marines too.
-	for(var/i= 1 to squads_copy.len)
+	for(var/i= 1 to length(squads_copy))
 		var/datum/squad/S = pick_n_take(squads_copy)
 		if (S.roundstart && S.usable && S.faction == H.faction && S.name != "Root")
 			mixed_squads += S

--- a/code/game/machinery/air_alarm.dm
+++ b/code/game/machinery/air_alarm.dm
@@ -264,10 +264,10 @@
 /obj/structure/machinery/alarm/proc/register_env_machine(m_id, device_type)
 	var/new_name
 	if (device_type=="AVP")
-		new_name = "[alarm_area.name] Vent Pump #[alarm_area.air_vent_names.len+1]"
+		new_name = "[alarm_area.name] Vent Pump #[length(alarm_area.air_vent_names)+1]"
 		alarm_area.air_vent_names[m_id] = new_name
 	else if (device_type=="AScr")
-		new_name = "[alarm_area.name] Air Scrubber #[alarm_area.air_scrub_names.len+1]"
+		new_name = "[alarm_area.name] Air Scrubber #[length(alarm_area.air_scrub_names)+1]"
 		alarm_area.air_scrub_names[m_id] = new_name
 	else
 		return
@@ -648,7 +648,7 @@ Pressure: <span class='dl[pressure_dangerlevel]'>[environment_pressure]</span>kP
 
 		if (AALARM_SCREEN_VENT)
 			var/sensor_data = ""
-			if(alarm_area.air_vent_names.len)
+			if(length(alarm_area.air_vent_names))
 				for(var/id_tag in alarm_area.air_vent_names)
 					var/long_name = alarm_area.air_vent_names[id_tag]
 					var/list/data = alarm_area.air_vent_info[id_tag]
@@ -690,7 +690,7 @@ siphoning
 			output = {"<a href='?src=\ref[src];screen=[AALARM_SCREEN_MAIN]'>Main menu</a><br>[sensor_data]"}
 		if (AALARM_SCREEN_SCRUB)
 			var/sensor_data = ""
-			if(alarm_area.air_scrub_names.len)
+			if(length(alarm_area.air_scrub_names))
 				for(var/id_tag in alarm_area.air_scrub_names)
 					var/long_name = alarm_area.air_scrub_names[id_tag]
 					var/list/data = alarm_area.air_scrub_info[id_tag]
@@ -735,7 +735,7 @@ Nitrous Oxide
 				AALARM_MODE_FILL = SET_CLASS("Fill - Shuts off scrubbers and opens vents", INTERFACE_GREEN),\
 				AALARM_MODE_OFF  = SET_CLASS("Off - Shuts off vents and scrubbers", INTERFACE_BLUE)
 			)
-			for (var/m=1,m<=modes.len,m++)
+			for (var/m=1,m<=length(modes),m++)
 				if (mode==m)
 					output += "<li><A href='?src=\ref[src];mode=[m]'><b>[modes[m]]</b></A> (selected)</li>"
 				else

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -106,7 +106,7 @@
 /obj/structure/machinery/autolathe/ui_data(mob/user)
 	var/list/data = list()
 
-	if(queue.len)
+	if(length(queue))
 		var/list/queue_list = list()
 		var/i = 0
 		for(var/params in queue)
@@ -119,7 +119,7 @@
 	else
 		data["queued"] = null
 
-	if(currently_making_data.len)
+	if(length(currently_making_data))
 		data["currently_making"] = currently_making_data
 	else
 		data["currently_making"] = null
@@ -129,7 +129,7 @@
 
 	var/list/wire_descriptions = get_wire_descriptions()
 	var/list/panel_wires = list()
-	for(var/wire = 1 to wire_descriptions.len)
+	for(var/wire = 1 to length(wire_descriptions))
 		panel_wires += list(list("desc" = wire_descriptions[wire], "cut" = isWireCut(wire)))
 
 	data["electrical"] = list(
@@ -164,7 +164,7 @@
 	switch(action)
 		if("cancel")
 			var/index = params["index"]
-			if(index < 1 || index > queue.len)
+			if(index < 1 || index > length(queue))
 				return
 
 			var/list/to_del = queue[index]
@@ -198,7 +198,7 @@
 			if(!initial(make_loc))
 				make_loc = get_step(loc, get_dir(src,usr))
 
-			if(index > 0 && index <= recipes.len)
+			if(index > 0 && index <= length(recipes))
 				making = recipes[index]
 
 			//Exploit detection, not sure if necessary after rewrite.
@@ -358,7 +358,7 @@
 		storage_capacity[material] = tot_rating  * 30000
 
 /obj/structure/machinery/autolathe/proc/try_queue(mob/living/carbon/human/user, datum/autolathe/recipe/making, turf/make_loc, multiplier = 1)
-	if(queue.len >= queue_max)
+	if(length(queue) >= queue_max)
 		to_chat(usr, SPAN_DANGER("The [name] has queued the maximum number of operations. Please wait for completion of current operation."))
 		return AUTOLATHE_FAILED
 
@@ -392,7 +392,7 @@
 
 	busy = TRUE
 
-	while (queue.len)
+	while (length(queue))
 		print_params = queue[1]
 		queue -= list(print_params)
 		print_item(arglist(print_params))
@@ -526,7 +526,7 @@
 
 		max_print_amt = -1
 
-		if(!R.resources || !R.resources.len)
+		if(!LAZYLEN(R.resources))
 			print_data["materials"] = "No resources required"
 		else
 			//Make sure it's buildable and list requires resources.

--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -180,7 +180,7 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 		if (!should_patrol)
 			return
 
-		if (!patrol_path || patrol_path.len < 1)
+		if (LAZYLEN(patrol_path) < 1)
 			var/datum/radio_frequency/frequency = SSradio.return_frequency(beacon_freq)
 
 			if(!frequency) return
@@ -204,20 +204,20 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 
 		return
 
-	if(target && path.len == 0)
+	if(target && length(path) == 0)
 		spawn(0)
 			if(!src || !target) return
 			src.path = AStar(src.loc, src.target.loc, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 30, id=botcard)
 			if (!path) path = list()
-			if(src.path.len == 0)
+			if(length(src.path) == 0)
 				src.oldtarget = src.target
 				target.targeted_by = null
 				src.target = null
 		return
-	if(src.path.len > 0 && src.target && (src.target != null))
+	if(length(src.path) > 0 && src.target && (src.target != null))
 		step_to(src, src.path[1])
 		src.path -= src.path[1]
-	else if(src.path.len == 1)
+	else if(length(src.path) == 1)
 		step_to(src, target)
 
 	if(src.target && (src.target != null))
@@ -231,7 +231,7 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 	src.oldloc = src.loc
 
 /obj/structure/machinery/bot/cleanbot/proc/patrol_move()
-	if (src.patrol_path.len <= 0)
+	if (length(src.patrol_path) <= 0)
 		return
 
 	var/next = src.patrol_path[1]

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -199,21 +199,21 @@
 			src.oldtarget = null
 		return
 
-	if(src.target && (src.target != null) && src.path.len == 0)
+	if(src.target && (src.target != null) && length(src.path) == 0)
 		spawn(0)
 			if(!istype(src.target, /turf/))
 				src.path = AStar(src.loc, src.target.loc, /turf/proc/AdjacentTurfsSpace, /turf/proc/Distance, 0, 30, id=botcard)
 			else
 				src.path = AStar(src.loc, src.target, /turf/proc/AdjacentTurfsSpace, /turf/proc/Distance, 0, 30, id=botcard)
 			if (!src.path) src.path = list()
-			if(src.path.len == 0)
+			if(length(src.path) == 0)
 				src.oldtarget = src.target
 				src.target = null
 		return
-	if(src.path.len > 0 && src.target && (src.target != null))
+	if(length(src.path) > 0 && src.target && (src.target != null))
 		step_to(src, src.path[1])
 		src.path -= src.path[1]
-	else if(src.path.len == 1)
+	else if(length(src.path) == 1)
 		step_to(src, target)
 		src.path = new()
 
@@ -342,7 +342,7 @@
 	if(!istype(T, /obj/item/stack/tile/plasteel))
 		..()
 		return
-	if(src.contents.len >= 1)
+	if(length(src.contents) >= 1)
 		to_chat(user, SPAN_NOTICE("That won't fit, there's already stuff inside."))
 		return
 	for(var/mob/M in content_watchers)

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -62,7 +62,7 @@
 		src.overlays += image('icons/obj/structures/machinery/aibots.dmi', "medskin_[src.skin]")
 
 	src.botcard = new /obj/item/card/id(src)
-	if(isnull(src.botcard_access) || (src.botcard_access.len < 1))
+	if(!LAZYLEN(src.botcard_access))
 		var/datum/job/J = GLOB.RoleAuthority ? GLOB.RoleAuthority.roles_by_path[/datum/job/civilian/doctor] : new /datum/job/civilian/doctor
 		botcard.access = J.get_access()
 	else
@@ -278,31 +278,31 @@
 			src.medicate_patient(src.patient)
 		return
 
-	else if(src.patient && (src.path.len) && (get_dist(src.patient,src.path[src.path.len]) > 2))
+	else if(src.patient && (length(src.path)) && (get_dist(src.patient,src.path[length(src.path)]) > 2))
 		src.path = new()
 		src.currently_healing = 0
 		src.last_found = world.time
 
-	if(src.patient && src.path.len == 0 && (get_dist(src,src.patient) > 1))
+	if(src.patient && length(src.path) == 0 && (get_dist(src,src.patient) > 1))
 		spawn(0)
 			src.path = AStar(src.loc, get_turf(src.patient), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 30,id=botcard)
 			if (!path) path = list()
-			if(src.path.len == 0)
+			if(length(src.path) == 0)
 				src.oldpatient = src.patient
 				src.patient = null
 				src.currently_healing = 0
 				src.last_found = world.time
 		return
 
-	if(src.path.len > 0 && src.patient)
+	if(length(src.path) > 0 && src.patient)
 		step_to(src, src.path[1])
 		src.path -= src.path[1]
 		spawn(3)
-			if(src.path.len)
+			if(length(src.path))
 				step_to(src, src.path[1])
 				src.path -= src.path[1]
 
-	if(src.path.len > 8 && src.patient)
+	if(length(src.path) > 8 && src.patient)
 		src.frustration++
 
 	return
@@ -487,7 +487,7 @@
 		return
 
 	//Making a medibot!
-	if(src.contents.len >= 1)
+	if(length(src.contents) >= 1)
 		to_chat(user, SPAN_NOTICE("You need to empty [src] out first."))
 		return
 

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -105,12 +105,12 @@
 	var/list/orders = list("0","1","2","3","4","5","6","7","8","9")
 	wire_text = list()
 	wire_order = list()
-	while(colours.len > 0)
-		var/color = colours[ rand(1,colours.len) ]
+	while(length(colours) > 0)
+		var/color = colours[ rand(1,length(colours)) ]
 		wire_text += color
 		colours -= color
 
-		var/order = orders[ rand(1,orders.len) ]
+		var/order = orders[ rand(1,length(orders)) ]
 		wire_order += text2num(order)
 		orders -= order
 
@@ -584,7 +584,7 @@
 				at_target()
 				return
 
-			else if(path.len > 0 && target) // valid path
+			else if(length(path) > 0 && target) // valid path
 
 				var/turf/next = path[1]
 				reached_target = 0
@@ -645,7 +645,7 @@
 
 							spawn(2)
 								calc_path(next)
-								if(path.len > 0)
+								if(length(path) > 0)
 									src.visible_message("[src] makes a delighted ping!", "You hear a ping.")
 									playsound(src.loc, 'sound/machines/ping.ogg', 25, 0)
 								mode = 4
@@ -667,7 +667,7 @@
 
 				calc_path()
 
-				if(path.len > 0)
+				if(length(path) > 0)
 					blockcount = 0
 					mode = 4
 					src.visible_message("[src] makes a delighted ping!", "You hear a ping.")

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -52,13 +52,13 @@ GLOBAL_LIST_EMPTY_TYPED(all_cameras, /obj/structure/machinery/camera)
 	if(colony_camera_mapload && mapload && is_ground_level(z))
 		network = list(CAMERA_NET_COLONY)
 
-	if(!src.network || src.network.len < 1)
+	if(LAZYLEN(src.network) < 1)
 		if(loc)
 			error("[src.name] in [get_area(src)] (x:[src.x] y:[src.y] z:[src.z]) has errored. [src.network?"Empty network list":"Null network list"]")
 		else
 			error("[src.name] in [get_area(src)]has errored. [src.network?"Empty network list":"Null network list"]")
 		ASSERT(src.network)
-		ASSERT(src.network.len > 0)
+		ASSERT(length(src.network) > 0)
 
 	set_pixel_location()
 	update_icon()

--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -32,7 +32,7 @@
 /obj/structure/machinery/camera/proc/lostTarget(mob/target)
 	if (target in motionTargets)
 		motionTargets -= target
-	if (motionTargets.len == 0)
+	if (length(motionTargets) == 0)
 		cancelAlarm()
 
 /obj/structure/machinery/camera/proc/cancelAlarm()

--- a/code/game/machinery/computer/almayer_control.dm
+++ b/code/game/machinery/computer/almayer_control.dm
@@ -85,7 +85,7 @@
 	if(SShijack.evac_status == EVACUATION_STATUS_INITIATED)
 		data["evac_eta"] = SShijack.get_evac_eta()
 
-	if(!messagetitle.len)
+	if(!length(messagetitle))
 		data["messages"] = null
 	else
 		for(var/i in 1 to length(messagetitle))

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -122,7 +122,7 @@
 			src.gameover = 1
 			src.temp = "[src.enemy_name] has fallen! Rejoice!"
 
-			if(!contents.len)
+			if(!length(contents))
 				var/prizeselect = pickweight(prizes)
 				new prizeselect(src.loc)
 

--- a/code/game/machinery/computer/atmos_alert.dm
+++ b/code/game/machinery/computer/atmos_alert.dm
@@ -62,10 +62,10 @@
 	..()
 	if(inoperable())
 		return
-	if(priority_alarms.len)
+	if(length(priority_alarms))
 		icon_state = "alert:2"
 
-	else if(minor_alarms.len)
+	else if(length(minor_alarms))
 		icon_state = "alert:1"
 
 	else
@@ -77,13 +77,13 @@
 	var/priority_text
 	var/minor_text
 
-	if(priority_alarms.len)
+	if(length(priority_alarms))
 		for(var/zone in priority_alarms)
 			priority_text += "<FONT color='red'><B>[zone]</B></FONT>  <A href='?src=\ref[src];priority_clear=[ckey(zone)]'>X</A><BR>"
 	else
 		priority_text = "No priority alerts detected.<BR>"
 
-	if(minor_alarms.len)
+	if(length(minor_alarms))
 		for(var/zone in minor_alarms)
 			minor_text += "<B>[zone]</B>  <A href='?src=\ref[src];minor_clear=[ckey(zone)]'>X</A><BR>"
 	else

--- a/code/game/machinery/computer/camera_console.dm
+++ b/code/game/machinery/computer/camera_console.dm
@@ -167,7 +167,7 @@
 			stack_trace("Camera in a cameranet has a non-list camera network")
 			continue
 		var/list/tempnetwork = C.network & network
-		if(tempnetwork.len)
+		if(length(tempnetwork))
 			D["[C.c_tag]"] = C
 	return D
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -366,7 +366,7 @@
 						dat += "<BR><A HREF='?src=\ref[src];operation=selectlz'>Select primary LZ</A>"
 					dat += "<BR><hr>"
 					dat += "<BR><A HREF='?src=\ref[src];operation=announce'>Make an announcement</A>"
-					dat += GLOB.admins.len > 0 ? "<BR><A HREF='?src=\ref[src];operation=messageUSCM'>Send a message to USCM</A>" : "<BR>USCM communication offline"
+					dat += length(GLOB.admins) > 0 ? "<BR><A HREF='?src=\ref[src];operation=messageUSCM'>Send a message to USCM</A>" : "<BR>USCM communication offline"
 					dat += "<BR><A HREF='?src=\ref[src];operation=award'>Award a medal</A>"
 					dat += "<BR><A HREF='?src=\ref[src];operation=distress'>Send Distress Beacon</A>"
 					dat += "<BR><A HREF='?src=\ref[src];operation=destroy'>Activate Self-Destruct</A>"
@@ -393,7 +393,7 @@
 
 		if(STATE_MESSAGELIST)
 			dat += "Messages:"
-			for(var/i = 1; i<=messagetitle.len; i++)
+			for(var/i = 1; i<=length(messagetitle); i++)
 				dat += "<BR><A HREF='?src=\ref[src];operation=viewmessage;message-num=[i]'>[messagetitle[i]]</A>"
 
 		if(STATE_VIEWMESSAGE)
@@ -466,7 +466,7 @@
 
 		if(STATE_MESSAGELIST)
 			dat += "Messages:"
-			for(var/i = 1; i<=messagetitle.len; i++)
+			for(var/i = 1; i<=length(messagetitle); i++)
 				dat += "<BR><A HREF='?src=\ref[src];operation=viewmessage;message-num=[i]'>[messagetitle[i]]</A>"
 
 		if(STATE_VIEWMESSAGE)

--- a/code/game/machinery/computer/dropship_weapons.dm
+++ b/code/game/machinery/computer/dropship_weapons.dm
@@ -581,8 +581,8 @@
 	for(var/datum/cas_fire_mission_record/firerec as anything in editing_firemission.records)
 		var/gimbal = firerec.get_offsets()
 		var/ammo = firerec.get_ammo()
-		var/offsets = new /list(firerec.offsets.len)
-		for(var/idx = 1; idx < firerec.offsets.len; idx++)
+		var/offsets = new /list(length(firerec.offsets))
+		for(var/idx = 1; idx < length(firerec.offsets); idx++)
 			offsets[idx] = firerec.offsets[idx] == null ? "-" : firerec.offsets[idx]
 			. += list(
 				"name" = sanitize(copytext(firerec.weapon.name, 1, 50)),
@@ -738,7 +738,7 @@
 	if(!skillcheck(weapon_operator, SKILL_PILOT, SKILL_PILOT_TRAINED)) //only pilots can fire dropship weapons.
 		to_chat(weapon_operator, SPAN_WARNING("A screen with graphics and walls of physics and engineering values open, you immediately force it closed."))
 		return FALSE
-	if(firemission_tag > firemission_envelope.missions.len)
+	if(firemission_tag > length(firemission_envelope.missions))
 		to_chat(weapon_operator, SPAN_WARNING("Fire Mission ID corrupted or already deleted."))
 		return FALSE
 	if(selected_firemission == firemission_envelope.missions[firemission_tag])
@@ -757,7 +757,7 @@
 	if(firemission_envelope.stat > FIRE_MISSION_STATE_IN_TRANSIT && firemission_envelope.stat < FIRE_MISSION_STATE_COOLDOWN)
 		to_chat(weapon_operator, SPAN_WARNING("Fire Mission already underway."))
 		return FALSE
-	if(firemission_tag > firemission_envelope.missions.len)
+	if(firemission_tag > length(firemission_envelope.missions))
 		to_chat(weapon_operator, SPAN_WARNING("Fire Mission ID corrupted or deleted."))
 		return FALSE
 	if(selected_firemission == firemission_envelope.missions[firemission_tag])

--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -165,7 +165,7 @@
 				if (giver)
 					var/number = add_zero("[rand(0,9999)]", 4)
 					var/entry = "\[[worldtime2text()]\] Pass #[number] issued by [giver.registered_name] ([giver.assignment]) to [giv_name]. Reason: [reason]. Grants access to following areas: "
-					for (var/i=1 to accesses.len)
+					for (var/i=1 to length(accesses))
 						var/A = accesses[i]
 						if (A)
 							var/area = get_access_desc(A)

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -155,7 +155,7 @@
 					dat += text("<A href='?src=\ref[];choice=New Record (Security)'>New Security Record</A><BR><BR>", src)
 				dat += text("\n<A href='?src=\ref[];choice=Print Record'>Print Record</A><BR>\n<A href='?src=\ref[];choice=Return'>Back</A><BR>", src, src)
 			if(4.0)
-				if(!Perp.len)
+				if(!length(Perp))
 					dat += text("ERROR.  String could not be located.<br><br><A href='?src=\ref[];choice=Return'>Back</A>", src)
 				else
 					dat += {"
@@ -172,7 +172,7 @@
 <th>Rank</th>
 <th>Criminal Status</th>
 </tr> "}
-					for(var/i=1, i<=Perp.len, i += 2)
+					for(var/i=1, i<=length(Perp), i += 2)
 						var/crimstat = ""
 						var/datum/data/record/R = Perp[i]
 						if(istype(Perp[i+1],/datum/data/record/))
@@ -271,16 +271,16 @@ What a mess.*/
 				Perp = new/list()
 				t1 = lowertext(t1)
 				var/list/components = splittext(t1, " ")
-				if(components.len > 5)
+				if(length(components) > 5)
 					return //Lets not let them search too greedily.
 				for(var/datum/data/record/R in GLOB.data_core.general)
 					var/temptext = R.fields["name"] + " " + R.fields["id"] + " " + R.fields["rank"]
-					for(var/i = 1, i<=components.len, i++)
+					for(var/i = 1, i<=length(components), i++)
 						if(findtext(temptext,components[i]))
 							var/prelist = new/list(2)
 							prelist[1] = R
 							Perp += prelist
-				for(var/i = 1, i<=Perp.len, i+=2)
+				for(var/i = 1, i<=length(Perp), i+=2)
 					for(var/datum/data/record/E in GLOB.data_core.security)
 						var/datum/data/record/R = Perp[i]
 						if ((E.fields["name"] == R.fields["name"] && E.fields["id"] == R.fields["id"]))

--- a/code/game/machinery/computer/skills.dm
+++ b/code/game/machinery/computer/skills.dm
@@ -97,7 +97,7 @@
 						dat += "<B>General Record Lost!</B><BR>"
 					dat += "\n<A href='?src=\ref[src];choice=Delete Record (ALL)'>Delete Record (ALL)</A><BR><BR>\n<A href='?src=\ref[src];choice=Print Record'>Print Record</A><BR>\n<A href='?src=\ref[src];choice=Return'>Back</A><BR>"
 				if(4.0)
-					if(!Perp.len)
+					if(!length(Perp))
 						dat += "ERROR.  String could not be located.<br><br><A href='?src=\ref[src];choice=Return'>Back</A>"
 					else
 						dat += {"
@@ -114,7 +114,7 @@
 <th>Rank</th>
 <th>Fingerprints</th>
 </tr> "}
-						for(var/i=1, i<=Perp.len, i += 2)
+						for(var/i=1, i<=length(Perp), i += 2)
 							var/crimstat = ""
 							var/datum/data/record/R = Perp[i]
 							if(istype(Perp[i+1],/datum/data/record/))
@@ -202,16 +202,16 @@ What a mess.*/
 				Perp = new/list()
 				t1 = lowertext(t1)
 				var/list/components = splittext(t1, " ")
-				if(components.len > 5)
+				if(length(components) > 5)
 					return //Lets not let them search too greedily.
 				for(var/datum/data/record/R in GLOB.data_core.general)
 					var/temptext = R.fields["name"] + " " + R.fields["id"] + " " + R.fields["rank"]
-					for(var/i = 1, i<=components.len, i++)
+					for(var/i = 1, i<=length(components), i++)
 						if(findtext(temptext,components[i]))
 							var/prelist = new/list(2)
 							prelist[1] = R
 							Perp += prelist
-				for(var/i = 1, i<=Perp.len, i+=2)
+				for(var/i = 1, i<=length(Perp), i+=2)
 					for(var/datum/data/record/E in GLOB.data_core.security)
 						var/datum/data/record/R = Perp[i]
 						if ((E.fields["name"] == R.fields["name"] && E.fields["id"] == R.fields["id"]))

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -55,7 +55,7 @@
 	var/list/CL = null
 	if(O && islist(O))
 		CL = O
-		if (CL.len == 1)
+		if (length(CL) == 1)
 			C = CL[1]
 	else if(O && istype(O, /obj/structure/machinery/camera))
 		C = O
@@ -73,7 +73,7 @@
 			var/list/srcs  = alarm[3]
 			if (origin in srcs)
 				srcs -= origin
-			if (srcs.len == 0)
+			if (length(srcs) == 0)
 				cleared = 1
 				L -= I
 	return !cleared
@@ -85,7 +85,7 @@
 	var/active_alarms = 0
 	for (var/cat in src.alarms)
 		var/list/L = src.alarms[cat]
-		if(L.len) active_alarms = 1
+		if(length(L)) active_alarms = 1
 	if(active_alarms)
 		icon_state = "alert:2"
 	else

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -124,7 +124,7 @@
 				state = CONSTRUCTION_STATE_BEGIN
 				circuit.forceMove(loc)
 				circuit = null
-				if(components.len == 0)
+				if(length(components) == 0)
 					to_chat(user, SPAN_NOTICE("You remove the circuit board."))
 				else
 					to_chat(user, SPAN_NOTICE("You remove the circuit board and other components."))

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -114,7 +114,7 @@
 
 	data["isBeakerLoaded"] = beaker ? TRUE : FALSE
 	var/beakerContents = list()
-	if(beaker && beaker.reagents && beaker.reagents.reagent_list.len)
+	if(beaker && beaker.reagents && length(beaker.reagents.reagent_list))
 		for(var/datum/reagent/R in beaker.reagents.reagent_list)
 			beakerContents += list(list("name" = R.name, "volume" = R.volume))
 	data["beakerContents"] = beakerContents

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -103,7 +103,7 @@ GLOBAL_LIST_INIT(frozen_items, list(SQUAD_MARINE_1 = list(), SQUAD_MARINE_2 = li
 
 	else if(href_list["item"])
 
-		if(frozen_items_for_type.len == 0)
+		if(length(frozen_items_for_type) == 0)
 			to_chat(user, SPAN_WARNING("There is nothing to recover from storage."))
 			return
 
@@ -122,7 +122,7 @@ GLOBAL_LIST_INIT(frozen_items, list(SQUAD_MARINE_1 = list(), SQUAD_MARINE_2 = li
 
 	else if(href_list["allitems"])
 
-		if(frozen_items_for_type.len == 0)
+		if(length(frozen_items_for_type) == 0)
 			to_chat(user, SPAN_WARNING("There is nothing to recover from storage."))
 			return
 

--- a/code/game/machinery/door_display/door_display.dm
+++ b/code/game/machinery/door_display/door_display.dm
@@ -35,7 +35,7 @@
 		if (D.id == id)
 			targets += D
 
-	if(targets.len == 0)
+	if(length(targets) == 0)
 		stat |= BROKEN
 	update_icon()
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -677,9 +677,9 @@ GLOBAL_LIST_INIT(airlock_wire_descriptions, list(
 					airlock_electronics = new/obj/item/circuitboard/airlock(loc)
 					if(!req_access || !req_one_access)
 						check_access()
-					if(req_access.len)
+					if(length(req_access))
 						airlock_electronics.conf_access = req_access
-					else if(req_one_access.len)
+					else if(length(req_one_access))
 						airlock_electronics.conf_access = req_one_access
 						airlock_electronics.one_access = TRUE
 				else

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -75,7 +75,7 @@
 		. += SPAN_WARNING("WARNING: Current pressure differential is [pdiff]kPa! Opening door may result in injury!")
 
 	. += "<b>Sensor readings:</b>"
-	for(var/index = 1; index <= tile_info.len; index++)
+	for(var/index = 1; index <= length(tile_info); index++)
 		var/o = "&nbsp;&nbsp;"
 		switch(index)
 			if(1)
@@ -101,10 +101,10 @@
 		o += "[pressure]kPa</span></li>"
 		. += o
 
-	if(islist(users_to_open) && users_to_open.len)
+	if(islist(users_to_open) && length(users_to_open))
 		var/users_to_open_string = users_to_open[1]
-		if(users_to_open.len >= 2)
-			for(var/i = 2 to users_to_open.len)
+		if(length(users_to_open) >= 2)
+			for(var/i = 2 to length(users_to_open))
 				users_to_open_string += ", [users_to_open[i]]"
 		. += "These people have opened \the [src] during an alert: [users_to_open_string]."
 
@@ -275,7 +275,7 @@
 		if(dir_alerts)
 			for(var/d=1;d<=4;d++)
 				var/cdir = GLOB.cardinals[d]
-				for(var/i=1;i<=ALERT_STATES.len;i++)
+				for(var/i=1;i<=length(ALERT_STATES);i++)
 					if(dir_alerts[d] & (1<<(i-1)))
 						overlays += new/icon(icon,"alert_[ALERT_STATES[i]]", dir=cdir)
 	else

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -15,7 +15,7 @@
 /obj/structure/machinery/door/window/Initialize()
 	. = ..()
 	addtimer(CALLBACK(src, PROC_REF(update_icon)), 1)
-	if (src.req_access && src.req_access.len)
+	if (LAZYLEN(src.req_access))
 		src.icon_state = "[src.icon_state]"
 		src.base_state = src.icon_state
 
@@ -105,9 +105,9 @@
 			ae = new/obj/item/circuitboard/airlock( src.loc )
 			if(!src.req_access)
 				src.check_access()
-			if(src.req_access.len)
+			if(length(src.req_access))
 				ae.conf_access = src.req_access
-			else if (src.req_one_access && src.req_one_access.len)
+			else if (LAZYLEN(src.req_one_access))
 				ae.conf_access = src.req_one_access
 				ae.one_access = 1
 		else
@@ -189,9 +189,9 @@
 				ae = new/obj/item/circuitboard/airlock( src.loc )
 				if(!src.req_access)
 					src.check_access()
-				if(src.req_access.len)
+				if(length(src.req_access))
 					ae.conf_access = src.req_access
-				else if (src.req_one_access.len)
+				else if (length(src.req_one_access))
 					ae.conf_access = src.req_one_access
 					ae.one_access = 1
 			else

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -190,7 +190,7 @@
 	. += "The IV drip is [mode ? "injecting" : "taking blood"]."
 
 	if(beaker)
-		if(beaker.reagents && beaker.reagents.reagent_list.len)
+		if(beaker.reagents && length(beaker.reagents.reagent_list))
 			. += SPAN_NOTICE(" Attached is \a [beaker] with [beaker.reagents.total_volume] units of liquid.")
 		else
 			. += SPAN_NOTICE(" Attached is an empty [beaker].")

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -42,7 +42,7 @@
 			for (var/reagent in recipe.reagents)
 				acceptable_reagents |= reagent
 			if (recipe.items)
-				max_n_of_items = max(max_n_of_items,recipe.items.len)
+				max_n_of_items = max(max_n_of_items,length(recipe.items))
 
 		// This will do until I can think of a fun recipe to use dionaea in -
 		// will also allow anything using the holder item to be microwaved into
@@ -115,7 +115,7 @@
 	else if(operating)
 		to_chat(user, SPAN_DANGER("It's running!"))
 	else if(is_type_in_list(O,acceptable_items))
-		if (contents.len>=max_n_of_items)
+		if (length(contents)>=max_n_of_items)
 			to_chat(user, SPAN_DANGER("This [src] is full of ingredients, you cannot put more."))
 			return 1
 		if(istype(O, /obj/item/stack) && O:get_amount() > 1) // This is bad, but I can't think of how to change it

--- a/code/game/machinery/kitchen/processor.dm
+++ b/code/game/machinery/kitchen/processor.dm
@@ -41,7 +41,7 @@
 	if(!skillcheck(user, SKILL_DOMESTIC, SKILL_DOMESTIC_MASTER))
 		to_chat(user, SPAN_DANGER("You aren't trained to remove dangerous substances from food!"))
 		return FALSE
-	return TRUE	
+	return TRUE
 
 /datum/food_processor_process/meat
 	input = /obj/item/reagent_container/food/snacks/meat
@@ -55,7 +55,7 @@
 	if(!skillcheck(user, SKILL_DOMESTIC, SKILL_DOMESTIC_MASTER))
 		to_chat(user, SPAN_DANGER("You aren't trained to remove dangerous substances from food!"))
 		return FALSE
-	return TRUE	
+	return TRUE
 
 /datum/food_processor_process/potato
 	input = /obj/item/reagent_container/food/snacks/grown/potato
@@ -102,7 +102,7 @@
 	if(processing)
 		to_chat(user, SPAN_DANGER("The processor is in the process of processing."))
 		return 1
-	if(contents.len > 0) //TODO: several items at once? several different items?
+	if(length(contents) > 0) //TODO: several items at once? several different items?
 		to_chat(user, SPAN_DANGER("Something is already in the processing chamber."))
 		return 1
 	if(HAS_TRAIT(O, TRAIT_TOOL_WRENCH))
@@ -130,7 +130,7 @@
 	if(src.processing)
 		to_chat(user, SPAN_DANGER("The processor is in the process of processing."))
 		return 1
-	if(src.contents.len == 0)
+	if(length(src.contents) == 0)
 		to_chat(user, SPAN_DANGER("The processor is empty."))
 		return 1
 	for(var/O in src.contents)

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -125,7 +125,7 @@
 			user.visible_message( \
 				SPAN_NOTICE("[user] loads \the [src] with \the [P]."), \
 				SPAN_NOTICE("You load \the [src] with \the [P]."))
-			if(P.contents.len > 0)
+			if(length(P.contents) > 0)
 				to_chat(user, SPAN_NOTICE("Some items are refused."))
 
 	else if(!(O.flags_item & NOBLUDGEON)) //so we can spray, scan, c4 the machine.
@@ -186,7 +186,7 @@
 
 	var/list/wire_descriptions = get_wire_descriptions()
 	var/list/panel_wires = list()
-	for(var/wire = 1 to wire_descriptions.len)
+	for(var/wire = 1 to length(wire_descriptions))
 		panel_wires += list(list("desc" = wire_descriptions[wire], "cut" = isWireCut(wire)))
 
 	.["electrical"] = list(

--- a/code/game/machinery/medical_pod/autodoc.dm
+++ b/code/game/machinery/medical_pod/autodoc.dm
@@ -109,7 +109,7 @@
 
 /obj/structure/machinery/medical_pod/autodoc/proc/heal_limb(mob/living/carbon/human/human, brute, burn)
 	var/list/obj/limb/parts = human.get_damaged_limbs(brute,burn)
-	if(!parts.len) return
+	if(!length(parts)) return
 	var/obj/limb/picked = pick(parts)
 	if(picked.status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 		picked.heal_damage(brute, burn, TRUE)
@@ -248,7 +248,7 @@
 			if(L.status & LIMB_DESTROYED)
 				if(!(L.parent.status & LIMB_DESTROYED) && L.name != "head")
 					surgery_list += create_autodoc_surgery(L,LIMB_SURGERY,"missing")
-			if(L.implants.len)
+			if(length(L.implants))
 				for(var/I in L.implants)
 					if(!is_type_in_list(I,known_implants))
 						surgery_list += create_autodoc_surgery(L,LIMB_SURGERY,"shrapnel")
@@ -294,7 +294,7 @@
 
 	var/list/surgery_todo_list = N.fields["autodoc_manual"]
 
-	if(!surgery_todo_list.len)
+	if(!length(surgery_todo_list))
 		visible_message("\The [src] buzzes, no surgical procedures were queued.")
 		return
 
@@ -320,7 +320,7 @@
 			surgery_todo_list -= A
 
 	var/currentsurgery = 1
-	while(surgery_todo_list.len > 0)
+	while(length(surgery_todo_list) > 0)
 		if(!surgery)
 			break;
 		sleep(-1)
@@ -508,7 +508,7 @@
 						open_incision(H,S.limb_ref)
 						if(S.limb_ref.name == "chest" || S.limb_ref.name == "head")
 							open_encased(H,S.limb_ref)
-						if(S.limb_ref.implants.len)
+						if(length(S.limb_ref.implants))
 							for(var/obj/item/I in S.limb_ref.implants)
 								if(!surgery) break
 								if(!is_type_in_list(I,known_implants))
@@ -893,7 +893,7 @@
 				var/known_implants = list(/obj/item/implant/chem, /obj/item/implant/death_alarm, /obj/item/implant/loyalty, /obj/item/implant/tracking, /obj/item/implant/neurostim)
 				for(var/obj/limb/L in connected.occupant.limbs)
 					if(L)
-						if(L.implants.len)
+						if(length(L.implants))
 							for(var/I in L.implants)
 								if(!is_type_in_list(I,known_implants))
 									N.fields["autodoc_manual"] += create_autodoc_surgery(L,LIMB_SURGERY,"shrapnel")

--- a/code/game/machinery/medical_pod/bodyscanner.dm
+++ b/code/game/machinery/medical_pod/bodyscanner.dm
@@ -333,7 +333,7 @@
 			open = "Open<br>"
 
 		var/unknown_body = 0
-		if (e.implants.len)
+		if (length(e.implants))
 			for(var/I in e.implants)
 				if(is_type_in_list(I,known_implants))
 					imp += "[I] implanted<br>"

--- a/code/game/machinery/nuclearbomb.dm
+++ b/code/game/machinery/nuclearbomb.dm
@@ -345,7 +345,7 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 		var/datum/hive_status/hive
 		for(var/hivenumber in GLOB.hive_datum)
 			hive = GLOB.hive_datum[hivenumber]
-			if(!hive.totalXenos.len)
+			if(!length(hive.totalXenos))
 				return
 			xeno_announcement(SPAN_XENOANNOUNCE(warning), hive.hivenumber, XENO_GENERAL_ANNOUNCE)
 		return
@@ -358,7 +358,7 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 		yautja_announcement(SPAN_YAUTJABOLDBIG("WARNING!<br>A human purification device has been detected. You have approximately [t_left] to abandon the hunting grounds before it activates."))
 		for(var/hivenumber in GLOB.hive_datum)
 			hive = GLOB.hive_datum[hivenumber]
-			if(!hive.totalXenos.len)
+			if(!length(hive.totalXenos))
 				continue
 			xeno_announcement(SPAN_XENOANNOUNCE("The tallhosts have deployed a hive killer at [get_area_name(loc)]! Stop it at all costs!"), hive.hivenumber, XENO_GENERAL_ANNOUNCE)
 	else
@@ -367,7 +367,7 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 		yautja_announcement(SPAN_YAUTJABOLDBIG("WARNING!<br>The human purification device's signature has disappeared."))
 		for(var/hivenumber in GLOB.hive_datum)
 			hive = GLOB.hive_datum[hivenumber]
-			if(!hive.totalXenos.len)
+			if(!length(hive.totalXenos))
 				continue
 			xeno_announcement(SPAN_XENOANNOUNCE("The hive killer has been disabled! Rejoice!"), hive.hivenumber, XENO_GENERAL_ANNOUNCE)
 	return
@@ -594,7 +594,7 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 		var/datum/hive_status/hive
 		for(var/hivenumber in GLOB.hive_datum)
 			hive = GLOB.hive_datum[hivenumber]
-			if(!hive.totalXenos.len)
+			if(!length(hive.totalXenos))
 				return
 			xeno_announcement(SPAN_XENOANNOUNCE(warning), hive.hivenumber, XENO_GENERAL_ANNOUNCE)
 		return

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -167,7 +167,7 @@
 				doing_stuff = TRUE
 			if(!doing_stuff)
 				for(var/obj/limb/current_limb in humanoid_occupant.limbs)
-					if(current_limb.implants.len)
+					if(length(current_limb.implants))
 						doing_stuff = TRUE
 						to_chat(occupant, "Foreign material detected. Beginning removal process...")
 						for(var/obj/item/current_implant in current_limb.implants)

--- a/code/game/machinery/scoreboard.dm
+++ b/code/game/machinery/scoreboard.dm
@@ -16,8 +16,7 @@
 	update_display()
 
 /obj/structure/machinery/scoreboard/proc/update_display()
-	if(overlays.len)
-		overlays.Cut()
+	LAZYCLEARLIST(overlays)
 
 	var/score_state = "s[( floor(scoreleft/10) > scoreleft/10 ? floor(scoreleft/10)-1 : floor(scoreleft/10) )]a"
 	overlays += image('icons/obj/structures/machinery/scoreboard.dmi', icon_state=score_state)

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -158,8 +158,7 @@
 	return ""
 
 /obj/structure/machinery/status_display/proc/remove_display()
-	if(overlays.len)
-		overlays.Cut()
+	LAZYCLEARLIST(overlays)
 	if(maptext)
 		maptext = ""
 
@@ -241,8 +240,7 @@
 
 /obj/structure/machinery/ai_status_display/proc/set_picture(state)
 	picture_state = state
-	if(overlays.len)
-		overlays.Cut()
+	LAZYCLEARLIST(overlays)
 	overlays += image('icons/obj/structures/machinery/status_display.dmi', icon_state=picture_state)
 
 #undef DEFAULT_FONT_COLOR

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -69,7 +69,7 @@
 					to_chat(user, "You finish prying out the components.")
 
 					// Drop all the component stuff
-					if(contents.len > 0)
+					if(length(contents) > 0)
 						for(var/obj/x in src)
 							x.forceMove(user.loc)
 					else
@@ -125,7 +125,7 @@
 		else
 			dat += "<br>Identification String: <a href='?src=\ref[src];input=id'>NULL</a>"
 		dat += "<br>Network: <a href='?src=\ref[src];input=network'>[network]</a>"
-		dat += "<br>Prefabrication: [autolinkers.len ? "TRUE" : "FALSE"]"
+		dat += "<br>Prefabrication: [length(autolinkers) ? "TRUE" : "FALSE"]"
 		if(hide) dat += "<br>Shadow Link: ACTIVE</a>"
 
 		//Show additional options for certain GLOB.machines.

--- a/code/game/machinery/telecomms/portable_comms.dm
+++ b/code/game/machinery/telecomms/portable_comms.dm
@@ -18,9 +18,9 @@
 			is_wired = 1
 			break
 	if(components)
-		switch(components.len)
+		switch(length(components))
 			if(0 to 8)
-				icon_state = "construct_[contents.len]_[is_wired]"
+				icon_state = "construct_[length(contents)]_[is_wired]"
 			else
 				icon_state = "construct_8_1"
 	else if(state)

--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -247,7 +247,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 	//M94 flare packs handling
 	else if(istype(item_to_stock, /obj/item/storage/box/m94))
 		var/obj/item/storage/box/m94/flare_pack = item_to_stock
-		if(flare_pack.contents.len < flare_pack.max_storage_space)
+		if(length(flare_pack.contents) < flare_pack.max_storage_space)
 			to_chat(user, SPAN_WARNING("\The [item_to_stock] is not full."))
 			return
 		var/flare_type
@@ -272,7 +272,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 	//Machete holsters handling
 	else if(istype(item_to_stock, /obj/item/clothing/suit/storage/marine))
 		var/obj/item/clothing/suit/storage/marine/AR = item_to_stock
-		if(AR.pockets && AR.pockets.contents.len)
+		if(AR.pockets && length(AR.pockets.contents))
 			if(user)
 				to_chat(user, SPAN_WARNING("\The [AR] has something inside it. Empty it before restocking."))
 			return FALSE
@@ -300,7 +300,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 			if(AM.current_rounds != AM.max_rounds)
 				to_chat(user, SPAN_WARNING("\The [A] isn't full. You need to fill it before you can restock it."))
 				return
-		else if(A.contents.len < A.num_of_magazines)
+		else if(length(A.contents) < A.num_of_magazines)
 			to_chat(user, SPAN_WARNING("[A] is not full."))
 			return
 		else
@@ -317,14 +317,14 @@ GLOBAL_LIST_EMPTY(vending_products)
 	//Marine armor handling
 	else if(istype(item_to_stock, /obj/item/clothing/suit/storage/marine))
 		var/obj/item/clothing/suit/storage/marine/AR = item_to_stock
-		if(AR.pockets && AR.pockets.contents.len)
+		if(AR.pockets && length(AR.pockets.contents))
 			if(user)
 				to_chat(user, SPAN_WARNING("\The [AR] has something inside it. Empty it before restocking."))
 			return FALSE
 	//Marine helmet handling
 	else if(istype(item_to_stock, /obj/item/clothing/head/helmet/marine))
 		var/obj/item/clothing/head/helmet/marine/H = item_to_stock
-		if(H.pockets && H.pockets.contents.len)
+		if(H.pockets && length(H.pockets.contents))
 			if(user)
 				to_chat(user, SPAN_WARNING("\The [H] has something inside it. Empty it before restocking."))
 			return FALSE
@@ -541,7 +541,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 
 			var/turf/target_turf = get_appropriate_vend_turf(user)
 			if(vend_flags & VEND_CLUTTER_PROTECTION)
-				if(target_turf.contents.len > 25)
+				if(length(target_turf.contents) > 25)
 					to_chat(usr, SPAN_WARNING("The floor is too cluttered, make some space."))
 					vend_fail()
 					return FALSE
@@ -991,7 +991,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 			tmp_list += list(list(initial(IBP.box.name), floor(L[2] / IBP.items_in_box), IBP.box, VENDOR_ITEM_REGULAR))
 
 	//Putting Ammo and other boxes on the bottom of the list as per player preferences
-	if(tmp_list.len > 0)
+	if(length(tmp_list) > 0)
 		listed_products += list(list("BOXES", -1, null, null))
 		for(var/list/L as anything in tmp_list)
 			listed_products += list(L)

--- a/code/game/machinery/vending/vending.dm
+++ b/code/game/machinery/vending/vending.dm
@@ -728,7 +728,7 @@ GLOBAL_LIST_EMPTY_TYPED(total_vending_machines, /obj/structure/machinery/vending
 
 	var/list/wire_descriptions = get_wire_descriptions()
 	var/list/panel_wires = list()
-	for(var/wire = 1 to wire_descriptions.len)
+	for(var/wire = 1 to length(wire_descriptions))
 		panel_wires += list(list("desc" = wire_descriptions[wire], "cut" = isWireCut(wire)))
 
 	.["electrical"] = list(
@@ -898,7 +898,7 @@ GLOBAL_LIST_EMPTY_TYPED(total_vending_machines, /obj/structure/machinery/vending
 		seconds_electrified--
 
 	//Pitch to the people!  Really sell it!
-	if(((last_slogan + slogan_delay) <= world.time) && (slogan_list.len > 0) && (!shut_up) && prob(5))
+	if(((last_slogan + slogan_delay) <= world.time) && (length(slogan_list) > 0) && (!shut_up) && prob(5))
 		var/slogan = pick(slogan_list)
 		speak(slogan)
 		last_slogan = world.time

--- a/code/game/machinery/vending/vendor_types/dress.dm
+++ b/code/game/machinery/vending/vendor_types/dress.dm
@@ -197,11 +197,11 @@
 		if(findtext("[path]", item))
 			matches += path
 
-	if(matches.len==0)
+	if(length(matches)==0)
 		return
 
 	var/obj/item/chosen
-	if(matches.len==1)
+	if(length(matches)==1)
 		chosen = matches[1]
 	else
 		//If we have multiple options, let them select which one they meant

--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -438,13 +438,13 @@
 			//Marine armor handling
 			if(istype(item_to_stock, /obj/item/clothing/suit/storage/marine))
 				var/obj/item/clothing/suit/storage/marine/AR = item_to_stock
-				if(AR.pockets && AR.pockets.contents.len)
+				if(AR.pockets && length(AR.pockets.contents))
 					to_chat(user, SPAN_WARNING("\The [AR] has something inside it. Empty it before restocking."))
 					return
 			//Marine helmet handling
 			else if(istype(item_to_stock, /obj/item/clothing/head/helmet/marine))
 				var/obj/item/clothing/head/helmet/marine/H = item_to_stock
-				if(H.pockets && H.pockets.contents.len)
+				if(H.pockets && length(H.pockets.contents))
 					to_chat(user, SPAN_WARNING("\The [H] has something inside it. Empty it before restocking."))
 					return
 

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -131,7 +131,7 @@
 			to_chat(user, "This item does not fit.")
 			return
 
-		if(contents.len < 5)
+		if(length(contents) < 5)
 			if ( state in list(1, 3) )
 				if(user.drop_inv_item_to_loc(W, src))
 					state = 3

--- a/code/game/objects/effects/decals/cleanable/blood/blood.dm
+++ b/code/game/objects/effects/decals/cleanable/blood/blood.dm
@@ -112,7 +112,7 @@
 
 /obj/effect/decal/cleanable/blood/writing/New()
 	..()
-	if(random_icon_states.len)
+	if(length(random_icon_states))
 		for(var/obj/effect/decal/cleanable/blood/writing/W in loc)
 			random_icon_states.Remove(W.icon_state)
 		icon_state = pick(random_icon_states)

--- a/code/game/objects/effects/decals/posters.dm
+++ b/code/game/objects/effects/decals/posters.dm
@@ -10,7 +10,7 @@
 
 /obj/item/poster/New(turf/loc, given_serial = 0)
 	if(given_serial == 0)
-		serial_number = rand(1, GLOB.poster_designs.len)
+		serial_number = rand(1, length(GLOB.poster_designs))
 	else
 		serial_number = given_serial
 	name += " - No. [serial_number]"
@@ -33,7 +33,7 @@
 		serial_number = serial
 
 	if(!isnum(serial_number))
-		serial_number = rand(1, GLOB.poster_designs.len)
+		serial_number = rand(1, length(GLOB.poster_designs))
 
 	var/designtype = GLOB.poster_designs[serial_number]
 	var/datum/poster/design=new designtype

--- a/code/game/objects/effects/effect_system/chemsmoke.dm
+++ b/code/game/objects/effects/effect_system/chemsmoke.dm
@@ -70,7 +70,7 @@
 	smokeFlow(location, targetTurfs, wallList)
 
 	//set the density of the cloud - for diluting reagents
-	density = max(1, targetTurfs.len / 4) //clamp the cloud density minimum to 1 so it cant multiply the reagents
+	density = max(1, length(targetTurfs) / 4) //clamp the cloud density minimum to 1 so it cant multiply the reagents
 
 	//Admin messaging
 	var/contained = ""
@@ -110,7 +110,7 @@
 		return
 
 	//reagent application - only run if there are extra reagents in the smoke
-	if(chemholder.reagents.reagent_list.len)
+	if(length(chemholder.reagents.reagent_list))
 		for(var/datum/reagent/R in chemholder.reagents.reagent_list)
 			var/proba = 100
 			var/runs = 5
@@ -197,7 +197,7 @@
 //------------------------------------------
 /datum/effect_system/smoke_spread/chem/proc/spawnSmoke(turf/T, icon/I, dist = 1)
 	var/obj/effect/particle_effect/smoke/chem/smoke = new(location)
-	if(chemholder.reagents.reagent_list.len)
+	if(length(chemholder.reagents.reagent_list))
 		chemholder.reagents.copy_to(smoke, chemholder.reagents.total_volume / dist, safety = 1) //copy reagents to the smoke so mob/breathe() can handle inhaling the reagents
 	smoke.icon = I
 	smoke.layer = FLY_LAYER
@@ -230,7 +230,7 @@
 
 	pending += location
 
-	while(pending.len)
+	while(length(pending))
 		for(var/turf/current in pending)
 			for(var/D in GLOB.cardinals)
 				var/turf/target = get_step(current, D)

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -65,7 +65,7 @@
 		if(direction & i)
 			dirList += i
 
-	if(dirList.len)
+	if(length(dirList))
 		var/newDir = pick(dirList)
 		if(newDir == 16)
 			floor = 1

--- a/code/game/objects/effects/spawners/gibspawner.dm
+++ b/code/game/objects/effects/spawners/gibspawner.dm
@@ -43,7 +43,7 @@
 	qdel(src)
 
 /obj/effect/spawner/gibspawner/proc/Gib(list/viruses = list(), mob/living/ml = null)
-	if(gibtypes.len != gibamounts.len || gibamounts.len != gibdirections.len)
+	if(length(gibtypes) != length(gibamounts) || length(gibamounts) != length(gibdirections))
 		to_world(SPAN_DANGER("Gib list length mismatch!"))
 		return
 
@@ -58,7 +58,7 @@
 		s.set_up(2, 1, loc)
 		s.start()
 
-	for(var/i = 1, i<= gibtypes.len, i++)
+	for(var/i = 1, i<= length(gibtypes), i++)
 		if(gibamounts[i])
 			for(var/j = 1, j<= gibamounts[i], j++)
 				var/gibType = gibtypes[i]
@@ -72,7 +72,7 @@
 
 				gib.update_icon()
 
-				if(viruses.len > 0)
+				if(length(viruses) > 0)
 					for(var/datum/disease/D in viruses)
 						if(prob(virusProb))
 							var/datum/disease/viruus = D.Copy(1)
@@ -80,7 +80,7 @@
 							viruus.holder = gib
 
 				var/list/directions = gibdirections[i]
-				if(directions.len)
+				if(length(directions))
 					INVOKE_ASYNC(gib, /obj/effect/decal/cleanable/blood/gibs/proc/streak, directions)
 
 

--- a/code/game/objects/effects/spawners/wo_spawners/supplies.dm
+++ b/code/game/objects/effects/spawners/wo_spawners/supplies.dm
@@ -6,7 +6,7 @@
 
 /obj/effect/landmark/wo_supplies/New()
 	..()
-	if(stuff.len)
+	if(length(stuff))
 		for(var/s in stuff)
 			var/amt = rand(amount[1], amount[2])
 			for(var/i = 1, i <= amt, i++)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -144,7 +144,7 @@
 	//=================
 	if(prob(25))
 		var/list/nearby = oview(5, src)
-		if(nearby.len)
+		if(length(nearby))
 			var/target_atom = pick(nearby)
 			walk_to(src, target_atom, 5)
 			if(prob(25))
@@ -170,7 +170,7 @@
 	//=================
 	if(prob(25))
 		var/list/nearby = oview(5, src)
-		if(nearby.len)
+		if(length(nearby))
 			var/target_atom = pick(nearby)
 			walk_to(src, target_atom, 5)
 			if(prob(25))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -244,9 +244,9 @@ cases. Override_icon_state should be a list.*/
 	var/new_icon_state
 	var/new_protection
 	var/new_item_state
-	if(override_icon_state && override_icon_state.len)
+	if(LAZYLEN(override_icon_state))
 		new_icon_state = override_icon_state[SSmapping.configs[GROUND_MAP].map_name]
-	if(override_protection && override_protection.len)
+	if(LAZYLEN(override_protection))
 		new_protection = override_protection[SSmapping.configs[GROUND_MAP].map_name]
 	switch(SSmapping.configs[GROUND_MAP].camouflage_type)
 		if("snow")

--- a/code/game/objects/items/ashtray.dm
+++ b/code/game/objects/items/ashtray.dm
@@ -12,7 +12,7 @@
 	if (health < 1)
 		return
 	if (istype(W,/obj/item/trash/cigbutt) || istype(W,/obj/item/clothing/mask/cigarette) || istype(W, /obj/item/tool/match))
-		if (contents.len >= max_butts)
+		if (length(contents) >= max_butts)
 			to_chat(user, "This ashtray is full.")
 			return
 		var/drop = TRUE
@@ -42,10 +42,10 @@
 		user.update_inv_l_hand(0)
 		user.update_inv_r_hand()
 		add_fingerprint(user)
-		if (contents.len == max_butts)
+		if (length(contents) == max_butts)
 			icon_state = icon_full
 			desc = empty_desc + " It's stuffed full."
-		else if (contents.len > max_butts/2)
+		else if (length(contents) > max_butts/2)
 			icon_state = icon_half
 			desc = empty_desc + " It's half-filled."
 	else
@@ -61,7 +61,7 @@
 		if (health < 1)
 			die()
 			return
-		if (contents.len)
+		if (length(contents))
 			src.visible_message(SPAN_DANGER("[src] slams into [hit_atom] spilling its contents!"))
 		for (var/obj/item/clothing/mask/cigarette/O in contents)
 			O.forceMove(src.loc)

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -137,7 +137,7 @@
 			continue
 		dead_mobs += mob
 	var/mob/living/mob_to_store
-	if(dead_mobs.len)
+	if(length(dead_mobs))
 		mob_to_store = pick(dead_mobs)
 		mob_to_store.forceMove(src)
 		stored_units += mob_size
@@ -169,7 +169,7 @@
 	..()
 	if(over_object == usr && Adjacent(usr) && !roller_buckled)
 		if(!ishuman(usr)) return
-		if(contents.len) return 0
+		if(length(contents)) return 0
 		visible_message(SPAN_NOTICE("[usr] folds up [name]."))
 		var/obj/item/I = new item_path(get_turf(src), src)
 		usr.put_in_hands(I)
@@ -271,7 +271,7 @@
 			continue
 		mobs_can_store += H
 	var/mob/living/carbon/human/mob_to_store
-	if(mobs_can_store.len)
+	if(length(mobs_can_store))
 		mob_to_store = pick(mobs_can_store)
 		mob_to_store.forceMove(src)
 		stored_units += mob_size

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -391,7 +391,7 @@
 /obj/item/dogtag/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/dogtag))
 		var/obj/item/dogtag/D = I
-		to_chat(user, SPAN_NOTICE("You join the [fallen_names.len>1 ? "tags":"two tags"] together."))
+		to_chat(user, SPAN_NOTICE("You join the [length(fallen_names)>1 ? "tags":"two tags"] together."))
 		name = "information dog tags"
 		if(D.fallen_names)
 			fallen_names += D.fallen_names
@@ -404,11 +404,11 @@
 
 /obj/item/dogtag/get_examine_text(mob/user)
 	. = ..()
-	if(ishuman(user) && fallen_names && fallen_names.len)
-		var/msg = "There [fallen_names.len>1 ? \
-			"are [fallen_names.len] tags.<br>They read":\
+	if(ishuman(user) && LAZYLEN(fallen_names))
+		var/msg = "There [length(fallen_names)>1 ? \
+			"are [length(fallen_names)] tags.<br>They read":\
 			"is one ID tag.<br>It reads"]:"
-		for (var/i=1 to fallen_names.len)
+		for (var/i=1 to length(fallen_names))
 			msg += "<br>[i]. \"[fallen_names[i]] - [fallen_assgns[i]] - [fallen_blood_types[i]]\""
 		. += SPAN_NOTICE("[msg]")
 

--- a/code/game/objects/items/circuitboards/airlock.dm
+++ b/code/game/objects/items/circuitboards/airlock.dm
@@ -48,7 +48,7 @@
 		for (var/acc in accesses)
 			var/aname = get_access_desc(acc)
 
-			if (!conf_access || !conf_access.len || !(acc in conf_access))
+			if (!LAZYLEN(conf_access) || !(acc in conf_access))
 				t1 += "<a href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
 			else if(one_access)
 				t1 += "<a style='color: green' href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
@@ -107,7 +107,7 @@
 			conf_access += req
 		else
 			conf_access -= req
-			if (!conf_access.len)
+			if (!length(conf_access))
 				conf_access = null
 
 

--- a/code/game/objects/items/circuitboards/computer.dm
+++ b/code/game/objects/items/circuitboards/computer.dm
@@ -285,7 +285,7 @@
 			return
 		var/list/tempnetwork = splittext(input, ",")
 		tempnetwork = difflist(tempnetwork,GLOB.RESTRICTED_CAMERA_NETWORKS,1)
-		if(tempnetwork.len < 1)
+		if(length(tempnetwork) < 1)
 			to_chat(usr, "No network found please hang up and try your call again.")
 			return
 		network = tempnetwork

--- a/code/game/objects/items/devices/autopsy_scanner.dm
+++ b/code/game/objects/items/devices/autopsy_scanner.dm
@@ -46,7 +46,7 @@
 	return W
 
 /obj/item/device/autopsy_scanner/proc/add_data(obj/limb/O)
-	if(!O.autopsy_data.len && !O.trace_chemicals.len) return
+	if(!length(O.autopsy_data) && !length(O.trace_chemicals)) return
 
 	for(var/V in O.autopsy_data)
 		var/datum/autopsy_data/W = O.autopsy_data[V]
@@ -133,7 +133,7 @@
 			if(30 to 1000)
 				damage_desc = "<font color='red'>severe</font>"
 
-		if(!total_score) total_score = D.organs_scanned.len
+		if(!total_score) total_score = length(D.organs_scanned)
 
 		scan_data += "<b>Weapon #[n]</b><br>"
 		if(damaging_weapon)
@@ -149,7 +149,7 @@
 
 		n++
 
-	if(chemtraces.len)
+	if(length(chemtraces))
 		scan_data += "<b>Trace Chemicals: </b><br>"
 		for(var/chemID in chemtraces)
 			scan_data += chemID

--- a/code/game/objects/items/devices/clue_scanner.dm
+++ b/code/game/objects/items/devices/clue_scanner.dm
@@ -52,4 +52,4 @@
 	if(!newlyfound)
 		to_chat(user, SPAN_INFO("No new print sets found!"))
 	else
-		to_chat(user, SPAN_INFO("New print sets found: [newlyfound], total stored amount: [print_list.len]"))
+		to_chat(user, SPAN_INFO("New print sets found: [newlyfound], total stored amount: [length(print_list)]"))

--- a/code/game/objects/items/devices/data_detector.dm
+++ b/code/game/objects/items/devices/data_detector.dm
@@ -70,7 +70,7 @@
 		if(M == loc) continue //device user isn't detected
 		if((isxeno(M) || isyautja(M)) && M.stat == DEAD )
 			detected = TRUE
-		else if(ishuman(M) && M.stat == DEAD && M.contents.len)
+		else if(ishuman(M) && M.stat == DEAD && length(M.contents))
 			for(var/obj/I in M.contents_twice())
 				for(var/DT in objects_to_detect)
 					if(istype(I, DT))

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -196,7 +196,7 @@
 		return radio_connection
 
 	// Otherwise, if a channel is specified, look for it.
-	if(channels && channels.len)
+	if(LAZYLEN(channels))
 		if (message_mode == RADIO_CHANNEL_DEPARTMENT ) // Department radio shortcut
 			message_mode = channels[1]
 

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -276,7 +276,7 @@ FORENSIC SCANNER
 
 	if(!QDELETED(O.reagents))
 		var/dat = ""
-		if(O.reagents.reagent_list.len > 0)
+		if(length(O.reagents.reagent_list) > 0)
 			var/one_percent = O.reagents.total_volume / 100
 			for (var/datum/reagent/R in O.reagents.reagent_list)
 				if(prob(reliability))
@@ -381,7 +381,7 @@ FORENSIC SCANNER
 /obj/item/device/demo_scanner/proc/scan(obj/O)
 	if(QDELETED(O.reagents))
 		return
-	if(O.reagents.reagent_list.len > 0)
+	if(length(O.reagents.reagent_list) > 0)
 		for(var/datum/reagent/R in O.reagents.reagent_list)
 			dat += SPAN_BLUE("<br>[R.name]: [R.volume]u")
 			if(R.explosive)

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -67,7 +67,7 @@
 	if(!playing && !recording)
 		icons_available += list("Record" = image(radial_icon_file,"record"))
 		icons_available += list("Play" = image(radial_icon_file,"play"))
-		if(canprint && mytape?.storedinfo.len)
+		if(canprint && length(mytape?.storedinfo))
 			icons_available += list("Print Transcript" = image(radial_icon_file,"print"))
 
 	if(playing || recording)
@@ -241,7 +241,7 @@
 	if(playing)
 		return
 
-	if(mytape.storedinfo.len < 1)
+	if(length(mytape.storedinfo) < 1)
 		audible_message(SPAN_MAROON("[icon2html(src, usr)] Tape has no data."))
 		return
 
@@ -257,7 +257,7 @@
 			break
 		if(playing == FALSE)
 			break
-		if(mytape.storedinfo.len < i)
+		if(length(mytape.storedinfo) < i)
 			audible_message(SPAN_MAROON("[icon2html(src, usr)] End of recording."))
 			break
 
@@ -265,7 +265,7 @@
 		langchat_speech(mytape.storedinfo[i], heard, GLOB.all_languages, skip_language_check = TRUE, additional_styles = list("langchat_small"))
 
 		audible_message(SPAN_MAROON("[icon2html(src, usr)] [mytape.storedinfo[i]]"))//We want to display this properly, don't double encode
-		if(mytape.storedinfo.len < i + 1)
+		if(length(mytape.storedinfo) < i + 1)
 			playsleepseconds = 1
 			sleep(1 SECONDS)
 		else
@@ -310,7 +310,7 @@
 	set name = "Print Transcript"
 	set category = "Object"
 
-	if(!mytape.storedinfo.len)
+	if(!length(mytape.storedinfo))
 		return
 	if(!can_use(usr))
 		return
@@ -326,7 +326,7 @@
 	playsound(src, 'sound/items/taperecorder/taperecorder_print.ogg', 50, FALSE)
 	var/obj/item/paper/sheet_of_paper = new /obj/item/paper(get_turf(src))
 	var/t1 = "<B>Transcript:</B><BR><BR>"
-	for(var/i in 1 to mytape.storedinfo.len)
+	for(var/i in 1 to length(mytape.storedinfo))
 		t1 += "[mytape.storedinfo[i]]<BR>"
 	sheet_of_paper.info = t1
 	var/tapename = mytape.name

--- a/code/game/objects/items/devices/teleportation.dm
+++ b/code/game/objects/items/devices/teleportation.dm
@@ -156,7 +156,7 @@
 		if(T.x>world.maxx-8 || T.x<8) continue //putting them at the edge is dumb
 		if(T.y>world.maxy-8 || T.y<8) continue
 		turfs += T
-	if(turfs.len)
+	if(length(turfs))
 		L["None (Dangerous)"] = pick(turfs)
 	var/t1 = tgui_input_list(user, "Please select a teleporter to lock in on.", "Hand Teleporter", L)
 	if ((user.get_active_hand() != src || user.stat || user.is_mob_restrained()))

--- a/code/game/objects/items/devices/walkman.dm
+++ b/code/game/objects/items/devices/walkman.dm
@@ -95,17 +95,17 @@
 
 /obj/item/device/walkman/proc/play()
 	if(!current_song)
-		if(current_playlist.len > 0)
+		if(length(current_playlist) > 0)
 			current_song = sound(current_playlist[pl_index], 0, 0, SOUND_CHANNEL_WALKMAN, volume)
 			current_song.status = SOUND_STREAM
 		else
 			return
 	paused = FALSE
 	if(current_song.status & SOUND_PAUSED)
-		to_chat(current_listener,SPAN_INFO("Resuming [pl_index] of [current_playlist.len]"))
+		to_chat(current_listener,SPAN_INFO("Resuming [pl_index] of [length(current_playlist)]"))
 		update_song(current_song,current_listener)
 	else
-		to_chat(current_listener,SPAN_INFO("Now playing [pl_index] of [current_playlist.len]"))
+		to_chat(current_listener,SPAN_INFO("Now playing [pl_index] of [length(current_playlist)]"))
 		update_song(current_song,current_listener,0)
 
 	update_song(current_song,current_listener)
@@ -146,11 +146,11 @@
 
 /obj/item/device/walkman/proc/next_song(mob/user)
 
-	if(user.is_mob_incapacitated() || current_playlist.len == 0) return
+	if(user.is_mob_incapacitated() || length(current_playlist) == 0) return
 
 	break_sound()
 
-	if(pl_index + 1 <= current_playlist.len)
+	if(pl_index + 1 <= length(current_playlist))
 		pl_index++
 	else
 		pl_index = 1

--- a/code/game/objects/items/explosives/explosive.dm
+++ b/code/game/objects/items/explosives/explosive.dm
@@ -74,13 +74,13 @@
 			detonator=null
 			assembly_stage = ASSEMBLY_EMPTY
 			icon_state = base_icon_state
-		else if(containers.len)
+		else if(length(containers))
 			for(var/obj/B in containers)
 				if(istype(B))
 					containers -= B
 					user.put_in_hands(B)
 			current_container_volume = 0
-		desc = initial(desc) + "\n Contains [containers.len] containers[detonator?" and detonator":""]"
+		desc = initial(desc) + "\n Contains [length(containers)] containers[detonator?" and detonator":""]"
 		return
 	cause_data = create_cause_data(initial(name), user)
 	return TRUE
@@ -128,11 +128,11 @@
 		det.forceMove(src)
 		detonator = det
 		assembly_stage = ASSEMBLY_UNLOCKED
-		desc = initial(desc) + "\n Contains [containers.len] containers[detonator?" and detonator":""]"
+		desc = initial(desc) + "\n Contains [length(containers)] containers[detonator?" and detonator":""]"
 		update_icon()
 	else if(HAS_TRAIT(W, TRAIT_TOOL_SCREWDRIVER))
 		if(assembly_stage == ASSEMBLY_UNLOCKED)
-			if(containers.len)
+			if(length(containers))
 				to_chat(user, SPAN_NOTICE("You lock the assembly."))
 			else
 				to_chat(user, SPAN_NOTICE("You lock the empty assembly."))
@@ -143,7 +143,7 @@
 		else if(assembly_stage == ASSEMBLY_LOCKED)
 			to_chat(user, SPAN_NOTICE("You unlock the assembly."))
 			playsound(loc, 'sound/items/Screwdriver.ogg', 25, 0, 6)
-			desc = initial(desc) + "\n Contains [containers.len] containers[detonator?" and detonator":""]"
+			desc = initial(desc) + "\n Contains [length(containers)] containers[detonator?" and detonator":""]"
 			assembly_stage = ASSEMBLY_UNLOCKED
 		update_icon()
 	else if(is_type_in_list(W, allowed_containers) && (!assembly_stage || assembly_stage == ASSEMBLY_UNLOCKED))
@@ -161,7 +161,7 @@
 					containers += W
 					current_container_volume += W.reagents.maximum_volume
 					assembly_stage = ASSEMBLY_UNLOCKED
-					desc = initial(desc) + "\n Contains [containers.len] containers[detonator?" and detonator":""]"
+					desc = initial(desc) + "\n Contains [length(containers)] containers[detonator?" and detonator":""]"
 			else
 				to_chat(user, SPAN_DANGER("\the [W] is empty."))
 
@@ -210,7 +210,7 @@
 		reagents.source_mob = WEAKREF(cause_mob)
 		msg_admin_niche("[key_name(cause_mob)] detonated custom explosive by [key_name(creator)]: [name] (REAGENTS: [reagent_list_text]) in [get_area(src)] [ADMIN_JMP(loc)]", loc.x, loc.y, loc.z)
 
-	if(containers.len < 2)
+	if(length(containers) < 2)
 		reagents.trigger_volatiles = TRUE //Explode on the first transfer
 
 	for(var/obj/item/reagent_container/glass/G in containers)

--- a/code/game/objects/items/frames/camera.dm
+++ b/code/game/objects/items/frames/camera.dm
@@ -89,7 +89,7 @@
 					return
 
 				var/list/tempnetwork = splittext(input, ",")
-				if(tempnetwork.len < 1)
+				if(length(tempnetwork) < 1)
 					to_chat(usr, "No network found please hang up and try your call again.")
 					return
 
@@ -133,7 +133,7 @@
 		return
 
 	// Taking out upgrades
-	else if(HAS_TRAIT(W, TRAIT_TOOL_CROWBAR) && upgrades.len)
+	else if(HAS_TRAIT(W, TRAIT_TOOL_CROWBAR) && length(upgrades))
 		var/obj/U = locate(/obj) in upgrades
 		if(U)
 			to_chat(user, "You unattach an upgrade from the assembly.")

--- a/code/game/objects/items/frames/matrix.dm
+++ b/code/game/objects/items/frames/matrix.dm
@@ -18,7 +18,7 @@
 /obj/item/frame/matrix_frame/attackby(obj/item/W, mob/user as mob)
 	switch(state)
 		if(ASSEMBLY_EMPTY)
-			if(istype(W, /obj/item/reagent_container/glass/beaker/vial) && W.reagents.total_volume == 30 && W.reagents.reagent_list.len == 1)
+			if(istype(W, /obj/item/reagent_container/glass/beaker/vial) && W.reagents.total_volume == 30 && length(W.reagents.reagent_list) == 1)
 				user.drop_held_item(W)
 				W.forceMove(src)
 				state = ASSEMBLY_UNLOCKED
@@ -45,7 +45,7 @@
 			else if(W.reagents.total_volume < 30)
 				to_chat(user, SPAN_WARNING("The testing indicator lights up with red! The container requires to be fully filled!"))
 				return
-			else if (W.reagents.reagent_list.len > 1)
+			else if (length(W.reagents.reagent_list) > 1)
 				to_chat(user, SPAN_WARNING("The testing indicator lights up with red! The container requires a pure sample!"))
 
 		if(ASSEMBLY_UNLOCKED)

--- a/code/game/objects/items/implants/implantchair.dm
+++ b/code/game/objects/items/implants/implantchair.dm
@@ -38,7 +38,7 @@
 	var/dat ="<B>Implanter Status</B><BR>"
 
 	dat +="<B>Current occupant:</B> [src.occupant ? "<BR>Name: [src.occupant]<BR>Health: [health_text]<BR>" : "<FONT color=red>None</FONT>"]<BR>"
-	dat += "<B>Implants:</B> [src.implant_list.len ? "[implant_list.len]" : "<A href='?src=\ref[src];replenish=1'>Replenish</A>"]<BR>"
+	dat += "<B>Implants:</B> [length(src.implant_list) ? "[length(implant_list)]" : "<A href='?src=\ref[src];replenish=1'>Replenish</A>"]<BR>"
 	if(src.occupant)
 		dat += "[src.ready ? "<A href='?src=\ref[src];implant=1'>Implant</A>" : "Recharging"]<BR>"
 	user.set_interaction(src)
@@ -113,7 +113,7 @@
 /obj/structure/machinery/implantchair/proc/implant(mob/M)
 	if (!istype(M, /mob/living/carbon))
 		return
-	if(!implant_list.len) return
+	if(!length(implant_list)) return
 	for(var/obj/item/implant/loyalty/imp in implant_list)
 		if(!imp) continue
 		if(istype(imp, /obj/item/implant/loyalty))

--- a/code/game/objects/items/misc.dm
+++ b/code/game/objects/items/misc.dm
@@ -224,7 +224,7 @@
 		to_chat(user, SPAN_NOTICE("[I] won't fit in [src]."))
 		return
 
-	if(contents.len)
+	if(length(contents))
 		to_chat(user, SPAN_NOTICE("[src] already has something inside it."))
 		return
 
@@ -257,7 +257,7 @@
 /obj/item/evidencebag/attack_self(mob/user)
 	..()
 
-	if(contents.len)
+	if(length(contents))
 		var/obj/item/I = contents[1]
 		user.visible_message("[user] takes [I] out of [src]", "You take [I] out of [src].",\
 		"You hear someone rustle around in a plastic bag, and remove something.")

--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -289,7 +289,7 @@
 
 /obj/item/reagent_container/hypospray/autoinjector/skillless/get_examine_text(mob/user)
 	. = ..()
-	if(reagents && reagents.reagent_list.len)
+	if(reagents && length(reagents.reagent_list))
 		. += SPAN_NOTICE("It is currently loaded.")
 	else if(!uses_left)
 		. += SPAN_NOTICE("It is spent.")

--- a/code/game/objects/items/reagent_containers/food/condiment.dm
+++ b/code/game/objects/items/reagent_containers/food/condiment.dm
@@ -88,7 +88,7 @@
 /obj/item/reagent_container/food/condiment/on_reagent_change()
 	if(icon_state == "saltshakersmall" || icon_state == "peppermillsmall" || icon_state == "hotsauce_cholula" || icon_state == "hotsauce_franks" || icon_state == "hotsauce_sriracha" || icon_state == "hotsauce_tabasco" || icon_state == "coldsauce_cole")
 		return
-	if(reagents.reagent_list.len > 0)
+	if(length(reagents.reagent_list) > 0)
 		switch(reagents.get_master_reagent_id())
 			if("ketchup")
 				name = "Ketchup"
@@ -131,7 +131,7 @@
 				center_of_mass = "x=16;y=6"
 			else
 				name = "Misc Condiment Bottle"
-				if (reagents.reagent_list.len==1)
+				if (length(reagents.reagent_list)==1)
 					desc = "Looks like it is [reagents.get_master_reagent_name()], but you are not sure."
 				else
 					desc = "A mixture of various condiments. [reagents.get_master_reagent_name()] is one of them."

--- a/code/game/objects/items/reagent_containers/food/drinks/bottle.dm
+++ b/code/game/objects/items/reagent_containers/food/drinks/bottle.dm
@@ -93,7 +93,7 @@
 /obj/item/reagent_container/food/drinks/bottle/attackby(obj/item/I, mob/living/user)
 	if(!isGlass || !istype(I, /obj/item/paper))
 		return ..()
-	if(!reagents || !reagents.reagent_list.len)
+	if(!reagents || !length(reagents.reagent_list))
 		to_chat(user, SPAN_NOTICE("\The [src] is empty..."))
 		return
 	var/alcohol_potency = 0

--- a/code/game/objects/items/reagent_containers/food/drinks/drinkingglass.dm
+++ b/code/game/objects/items/reagent_containers/food/drinks/drinkingglass.dm
@@ -10,14 +10,14 @@
 	center_of_mass = "x=16;y=10"
 
 /obj/item/reagent_container/food/drinks/drinkingglass/on_reagent_change()
-	/*if(reagents.reagent_list.len > 1 )
+	/*if(length(reagents.reagent_list) > 1 )
 		icon_state = "glass_brown"
 		name = "Glass of Hooch"
 		desc = "Two or more drinks, mixed together."*/
-	/*else if(reagents.reagent_list.len == 1)
+	/*else if(length(reagents.reagent_list) == 1)
 		for(var/datum/reagent/R in reagents.reagent_list)
 			switch(R.id)*/
-	if (reagents.reagent_list.len > 0)
+	if (length(reagents.reagent_list) > 0)
 		//mrid = R.get_master_reagent_id()
 		var/datum/reagent/R = reagents.get_master_reagent()
 		switch(R.id)

--- a/code/game/objects/items/reagent_containers/food/drinks/jar.dm
+++ b/code/game/objects/items/reagent_containers/food/drinks/jar.dm
@@ -10,7 +10,7 @@
 	center_of_mass = "x=15;y=8"
 
 /obj/item/reagent_container/food/drinks/jar/on_reagent_change()
-	if(reagents.reagent_list.len > 0)
+	if(length(reagents.reagent_list) > 0)
 		icon_state ="jar_what"
 		name = "jar of something"
 		desc = "You can't really tell what this is."

--- a/code/game/objects/items/reagent_containers/food/sandwich.dm
+++ b/code/game/objects/items/reagent_containers/food/sandwich.dm
@@ -26,7 +26,7 @@
 		if(istype(O,/obj/item/reagent_container/food/snacks/breadslice))
 			sandwich_limit += 4
 
-	if(src.contents.len > sandwich_limit)
+	if(length(src.contents) > sandwich_limit)
 		to_chat(user, SPAN_DANGER("If you put anything else on \the [src] it's going to collapse."))
 		return
 	else if(istype(W,/obj/item/shard))
@@ -56,7 +56,7 @@
 		i++
 		if(i == 1)
 			fullname += "[O.name]"
-		else if(i == ingredients.len)
+		else if(i == length(ingredients))
 			fullname += " and [O.name]"
 		else
 			fullname += ", [O.name]"
@@ -69,12 +69,12 @@
 
 	var/image/T = new(src.icon, "sandwich_top")
 	T.pixel_x = pick(list(-1,0,1))
-	T.pixel_y = (ingredients.len * 2)+1
+	T.pixel_y = (length(ingredients) * 2)+1
 	overlays += T
 
 	name = lowertext("[fullname] sandwich")
 	if(length(name) > 80) name = "[pick(list("absurd","colossal","enormous","ridiculous"))] sandwich"
-	w_class = ceil(clamp((ingredients.len/2),1,3))
+	w_class = ceil(clamp((length(ingredients)/2),1,3))
 
 /obj/item/reagent_container/food/snacks/csandwich/Destroy()
 	QDEL_NULL_LIST(ingredients)
@@ -82,7 +82,7 @@
 
 /obj/item/reagent_container/food/snacks/csandwich/get_examine_text(mob/user)
 	. = ..()
-	if(contents && contents.len)
+	if(LAZYLEN(contents))
 		var/obj/item/O = pick(contents)
 		. += SPAN_NOTICE("You think you can see [O.name] in there.")
 

--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -2755,10 +2755,10 @@
 	// Set appropriate description
 	if( open && pizza )
 		desc = "A box suited for pizzas. It appears to have a [pizza.name] inside."
-	else if( boxes.len > 0 )
-		desc = "A pile of boxes suited for pizzas. There appears to be [boxes.len + 1] boxes in the pile."
+	else if( length(boxes) > 0 )
+		desc = "A pile of boxes suited for pizzas. There appears to be [length(boxes) + 1] boxes in the pile."
 
-		var/obj/item/pizzabox/topbox = boxes[boxes.len]
+		var/obj/item/pizzabox/topbox = boxes[length(boxes)]
 		var/toptag = topbox.boxtag
 		if( toptag != "" )
 			desc = "[desc] The box on top has a tag, it reads: '[toptag]'."
@@ -2784,8 +2784,8 @@
 	else
 		// Stupid code because byondcode sucks
 		var/doimgtag = 0
-		if( boxes.len > 0 )
-			var/obj/item/pizzabox/topbox = boxes[boxes.len]
+		if( length(boxes) > 0 )
+			var/obj/item/pizzabox/topbox = boxes[length(boxes)]
 			if( topbox.boxtag != "" )
 				doimgtag = 1
 		else
@@ -2794,10 +2794,10 @@
 
 		if( doimgtag )
 			var/image/tagimg = image("food.dmi", icon_state = "pizzabox_tag")
-			tagimg.pixel_y = boxes.len * 3
+			tagimg.pixel_y = length(boxes) * 3
 			overlays += tagimg
 
-	icon_state = "pizzabox[boxes.len+1]"
+	icon_state = "pizzabox[length(boxes)+1]"
 
 /obj/item/pizzabox/attack_hand( mob/user as mob )
 
@@ -2809,12 +2809,12 @@
 		update_icon()
 		return
 
-	if( boxes.len > 0 )
+	if( length(boxes) > 0 )
 		if( user.get_inactive_hand() != src )
 			..()
 			return
 
-		var/obj/item/pizzabox/box = boxes[boxes.len]
+		var/obj/item/pizzabox/box = boxes[length(boxes)]
 		boxes -= box
 
 		user.put_in_hands( box )
@@ -2847,7 +2847,7 @@
 			for(var/obj/item/pizzabox/i in box.boxes)
 				boxestoadd += i
 
-			if( (boxes.len+1) + boxestoadd.len <= 5 )
+			if( (length(boxes)+1) + length(boxestoadd) <= 5 )
 				user.drop_inv_item_to_loc(box, src)
 				box.boxes = list() // Clear the box boxes so we don't have boxes inside boxes. - Xzibit
 				src.boxes.Add( boxestoadd )
@@ -2884,8 +2884,8 @@
 		var/t = stripped_input(user,"Enter what you want to add to the tag:", "Write", "", 30)
 
 		var/obj/item/pizzabox/boxtotagto = src
-		if( boxes.len > 0 )
-			boxtotagto = boxes[boxes.len]
+		if( length(boxes) > 0 )
+			boxtotagto = boxes[length(boxes)]
 
 		boxtotagto.boxtag = "[boxtotagto.boxtag][t]"
 		playsound(src, "paper_writing", 15, TRUE)

--- a/code/game/objects/items/reagent_containers/food/snacks/grown.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks/grown.dm
@@ -591,7 +591,7 @@
 		if(T.x>world.maxx-outer_teleport_radius || T.x<outer_teleport_radius) continue
 		if(T.y>world.maxy-outer_teleport_radius || T.y<outer_teleport_radius) continue
 		turfs += T
-	if(!turfs.len)
+	if(!length(turfs))
 		var/list/turfs_to_pick_from = list()
 		for(var/turf/T in orange(M,outer_teleport_radius))
 			if(!(T in orange(M,inner_teleport_radius)))

--- a/code/game/objects/items/reagent_containers/reagent_container.dm
+++ b/code/game/objects/items/reagent_containers/reagent_container.dm
@@ -86,11 +86,11 @@
 
 //returns a text listing the reagents (and their volume) in the atom. Used by Attack logs for reagents in pills
 /obj/item/reagent_container/proc/get_reagent_list_text()
-	if(reagents && reagents.reagent_list && reagents.reagent_list.len)
+	if(reagents && LAZYLEN(reagents.reagent_list))
 		var/datum/reagent/R = reagents.reagent_list[1]
 		. = "[R.name]([R.volume]u)"
-		if(reagents.reagent_list.len < 2) return
-		for (var/i in 2 to reagents.reagent_list.len)
+		if(length(reagents.reagent_list) < 2) return
+		for (var/i in 2 to length(reagents.reagent_list))
 			R = reagents.reagent_list[i]
 			if(!R) continue
 			. += "; [R.name]([R.volume]u)"

--- a/code/game/objects/items/reagent_containers/spray.dm
+++ b/code/game/objects/items/reagent_containers/spray.dm
@@ -190,7 +190,7 @@
 	var/turf/T2 = get_step(T,turn(direction, -90))
 	var/list/the_targets = list(T,T1,T2)
 
-	for(var/i=1, i<=Sprays.len, i++)
+	for(var/i=1, i<=length(Sprays), i++)
 		spawn()
 			var/obj/effect/decal/chempuff/D = Sprays[i]
 			if(!D) continue

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -93,7 +93,7 @@ Also change the icon to reflect the amount of sheets, if possible.*/
 		var/datum/stack_recipe_list/srl = recipe_list[recipes_sublist]
 		recipe_list = srl.recipes
 	var/t1 = text("<HTML><HEAD><title>Constructions from []</title></HEAD><body><TT>Amount Left: []<br>", src, src.amount)
-	for(var/i = 1; i <= recipe_list.len, i++)
+	for(var/i = 1; i <= length(recipe_list), i++)
 		var/E = recipe_list[i]
 		if(isnull(E))
 			t1 += "<hr>"

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -1084,11 +1084,11 @@
 	if(ammo_dumping.flags_magazine & AMMUNITION_HANDFUL_BOX)
 		var/handfuls = round(ammo_dumping.current_rounds / amount_to_dump, 1) //The number of handfuls, we round up because we still want the last one that isn't full
 		if(ammo_dumping.current_rounds != 0)
-			if(contents.len < storage_slots - 1) //this is because it's a gunbelt and the final slot is reserved for the gun
+			if(length(contents) < storage_slots - 1) //this is because it's a gunbelt and the final slot is reserved for the gun
 				to_chat(user, SPAN_NOTICE("You start refilling [src] with [ammo_dumping]."))
 				if(!do_after(user, 1.5 SECONDS, INTERRUPT_ALL, BUSY_ICON_GENERIC)) return
 				for(var/i = 1 to handfuls)
-					if(contents.len < storage_slots - 1)
+					if(length(contents) < storage_slots - 1)
 						var/obj/item/ammo_magazine/handful/new_handful = new /obj/item/ammo_magazine/handful
 						var/transferred_handfuls = min(ammo_dumping.current_rounds, amount_to_dump)
 						new_handful.generate_handful(ammo_dumping.default_ammo, ammo_dumping.caliber, amount_to_dump, transferred_handfuls, ammo_dumping.gun_type)
@@ -1383,7 +1383,7 @@
 	set name = "Detach revolver holster"
 	set src in usr
 	if(ishuman(usr))
-		if(contents.len)
+		if(length(contents))
 			to_chat(usr, SPAN_WARNING("The belt needs to be fully empty to remove the holster!"))
 			return
 		to_chat(usr, SPAN_NOTICE("You detach the holster from the belt."))

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -383,7 +383,7 @@
 
 /obj/item/storage/pill_bottle/get_examine_text(mob/user)
 	. = ..()
-	var/pills_amount = contents.len
+	var/pills_amount = length(contents)
 	if(pills_amount)
 		var/percentage_filled = floor(pills_amount/max_storage_space * 100)
 		switch(percentage_filled)
@@ -409,7 +409,7 @@
 	if(skilllock && !skillcheck(user, SKILL_MEDICAL, SKILL_MEDICAL_MEDIC))
 		error_idlock(user)
 		return
-	if(contents.len)
+	if(length(contents))
 		var/obj/item/I = contents[1]
 		if(user.put_in_inactive_hand(I))
 			playsound(loc, use_sound, 10, TRUE, 3)
@@ -464,7 +464,7 @@
 	if(C.is_mob_restrained())
 		to_chat(user, SPAN_WARNING("You are restrained!"))
 		return FALSE
-	if(!contents.len)
+	if(!length(contents))
 		to_chat(user, SPAN_WARNING("The [name] is empty."))
 		return FALSE
 	var/obj/item/I = contents[1]

--- a/code/game/objects/items/storage/large_holster.dm
+++ b/code/game/objects/items/storage/large_holster.dm
@@ -332,7 +332,7 @@
 
 /obj/item/storage/large_holster/fuelpack/get_examine_text(mob/user)
 	. = ..()
-	if(contents.len)
+	if(length(contents))
 		. += "It is storing a M240-T incinerator unit."
 	if (get_dist(user, src) <= 1)
 		if(fuel)

--- a/code/game/objects/items/storage/misc.dm
+++ b/code/game/objects/items/storage/misc.dm
@@ -30,7 +30,7 @@
 	to_chat(user, message)
 	open = !open
 	update_icon()
-	if(!contents.len)
+	if(!length(contents))
 		..()
 	return
 
@@ -100,7 +100,7 @@
 		new /obj/item/reagent_container/food/drinks/cans/aspen(src)
 
 /obj/item/storage/beer_pack/update_icon()
-	if(contents.len == 1)
+	if(length(contents) == 1)
 		var/turf/T = get_turf(src)
 		var/obj/item/reagent_container/food/drinks/cans/aspen/B = new(T)
 		if(ishuman(loc))
@@ -109,7 +109,7 @@
 			H.put_in_inactive_hand(B)
 		qdel(src)
 	else
-		icon_state = "6_pack_[contents.len]"
+		icon_state = "6_pack_[length(contents)]"
 
 /obj/item/storage/box/clf
 	name = "D18-storing box"

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -871,13 +871,13 @@
 	inner = new /obj/item/reagent_container/glass/pressurized_canister()
 	//Only add an autoinjector if the canister is empty
 	//Important for the snowflake /obj/item/storage/pouch/pressurized_reagent_canister/oxycodone
-	if(contents.len == 0)
+	if(length(contents) == 0)
 		new /obj/item/reagent_container/hypospray/autoinjector/empty/medic(src)
 	update_icon()
 
 /obj/item/storage/pouch/pressurized_reagent_canister/proc/fill_with(ragent)
 	inner.reagents.add_reagent(ragent, inner.volume)
-	if(contents.len > 0)
+	if(length(contents) > 0)
 		var/obj/item/reagent_container/hypospray/autoinjector/empty/A = contents[1]
 		A.reagents.add_reagent(ragent, A.volume)
 		A.update_uses_left()
@@ -903,7 +903,7 @@
 	inner.reagents.add_reagent("adrenaline", inner.volume/3)
 	inner.reagents.add_reagent("inaprovaline", inner.volume/3)
 	inner.reagents.add_reagent("tricordrazine", inner.volume/3)
-	if(contents.len > 0)
+	if(length(contents) > 0)
 		var/obj/item/reagent_container/hypospray/autoinjector/empty/medic/A = contents[1]
 		A.reagents.add_reagent("adrenaline", A.volume/3)
 		A.reagents.add_reagent("inaprovaline", A.volume/3)
@@ -973,7 +973,7 @@
 
 
 	var/obj/O = target
-	if(!O.reagents || O.reagents.reagent_list.len < 1)
+	if(!O.reagents || length(O.reagents.reagent_list) < 1)
 		to_chat(user, SPAN_WARNING("[O] is empty!"))
 		return
 
@@ -986,7 +986,7 @@
 	O.reagents.trans_to(inner, amt_to_remove)
 
 	//Refill our autoinjector
-	if(contents.len > 0)
+	if(length(contents) > 0)
 		fill_autoinjector(contents[1])
 
 	//Top up our inner reagent canister after filling up the injector
@@ -1032,14 +1032,14 @@
 
 //returns a text listing the reagents (and their volume) in the atom. Used by Attack logs for reagents in pills
 /obj/item/storage/pouch/pressurized_reagent_canister/proc/get_reagent_list_text()
-	if(inner && inner.reagents && inner.reagents.reagent_list && inner.reagents.reagent_list.len)
+	if(inner && inner.reagents && LAZYLEN(inner.reagents.reagent_list))
 		var/datum/reagent/R = inner.reagents.reagent_list[1]
 		. = "[R.name]([R.volume]u)"
 
-		if(inner.reagents.reagent_list.len < 2)
+		if(length(inner.reagents.reagent_list) < 2)
 			return
 
-		for(var/i in 2 to inner.reagents.reagent_list.len)
+		for(var/i in 2 to length(inner.reagents.reagent_list))
 			R = inner.reagents.reagent_list[i]
 
 			if(!R)

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -366,7 +366,7 @@ GLOBAL_LIST_EMPTY_TYPED(item_storage_box_cache, /datum/item_storage_box)
 //This proc determins the size of the inventory to be displayed. Please touch it only if you know what you're doing.
 /obj/item/storage/proc/orient2hud()
 
-	var/adjusted_contents = contents.len
+	var/adjusted_contents = length(contents)
 
 	//Numbered contents display
 	var/list/datum/numbered_display/numbered_contents
@@ -396,7 +396,7 @@ GLOBAL_LIST_EMPTY_TYPED(item_storage_box_cache, /datum/item_storage_box)
 
 ///Returns TRUE if there is room for the given item. W_class_override allows checking for just a generic W_class, meant for checking shotgun handfuls without having to spawn and delete one just to check.
 /obj/item/storage/proc/has_room(obj/item/new_item, W_class_override = null)
-	if(storage_slots != null && contents.len < storage_slots)
+	if(storage_slots != null && length(contents) < storage_slots)
 		return TRUE //At least one open slot.
 	//calculate storage space only for containers that don't have slots
 	if (storage_slots == null)
@@ -458,7 +458,7 @@ GLOBAL_LIST_EMPTY_TYPED(item_storage_box_cache, /datum/item_storage_box)
 		return
 
 	var/w_limit_bypassed = 0
-	if(bypass_w_limit.len)
+	if(length(bypass_w_limit))
 		for(var/A in bypass_w_limit)
 			if(istype(W, A))
 				w_limit_bypassed = 1
@@ -585,7 +585,7 @@ W is always an item. stop_warning prevents messaging. user may be null.**/
 			if(storage_flags & STORAGE_USING_FIFO_DRAWING)
 				I = contents[1]
 			else
-				I = contents[contents.len]
+				I = contents[length(contents)]
 			I.attack_hand(user)
 		else
 			open(user)
@@ -707,7 +707,7 @@ W is always an item. stop_warning prevents messaging. user may be null.**/
 	if(storage_flags & STORAGE_USING_FIFO_DRAWING)
 		item_obj = contents[1]
 	else
-		item_obj = contents[contents.len]
+		item_obj = contents[length(contents)]
 	if(!istype(item_obj))
 		return
 	remove_from_storage(item_obj, tile)
@@ -725,11 +725,11 @@ W is always an item. stop_warning prevents messaging. user may be null.**/
 	if(ammo_dumping.flags_magazine & AMMUNITION_HANDFUL_BOX)
 		var/handfuls = round(ammo_dumping.current_rounds / amount_to_dump, 1) //The number of handfuls, we round up because we still want the last one that isn't full
 		if(ammo_dumping.current_rounds != 0)
-			if(contents.len < storage_slots)
+			if(length(contents) < storage_slots)
 				to_chat(user, SPAN_NOTICE("You start refilling [src] with [ammo_dumping]."))
 				if(!do_after(user, 1.5 SECONDS, INTERRUPT_ALL, BUSY_ICON_GENERIC)) return
 				for(var/i = 1 to handfuls)
-					if(contents.len < storage_slots)
+					if(length(contents) < storage_slots)
 						//Hijacked from /obj/item/ammo_magazine/proc/create_handful because it had to be handled differently
 						//All this because shell types are instances and not their own objects :)
 
@@ -754,7 +754,7 @@ W is always an item. stop_warning prevents messaging. user may be null.**/
 	if(user.action_busy)
 		return
 
-	if(!origin_storage.contents.len)
+	if(!length(origin_storage.contents))
 		to_chat(user, SPAN_WARNING("[origin_storage] is empty."))
 		return
 	if(!has_room(origin_storage.contents[1])) //Does it have room for the first item to be inserted?
@@ -857,7 +857,7 @@ W is always an item. stop_warning prevents messaging. user may be null.**/
 	..()
 
 	//Clicking on itself will empty it, if it has contents and the verb to do that. Contents but no verb means nothing happens.
-	if(contents.len)
+	if(length(contents))
 		empty(user)
 		return
 

--- a/code/game/objects/items/storage/surgical_tray.dm
+++ b/code/game/objects/items/storage/surgical_tray.dm
@@ -34,7 +34,7 @@
 	new /obj/item/tool/surgery/synthgraft(src)
 
 /obj/item/storage/surgical_tray/update_icon()
-	if(!contents.len)
+	if(!length(contents))
 		icon_state = "surgical_tray_e"
 	else
 		icon_state = "surgical_tray"

--- a/code/game/objects/items/tools/experimental_tools.dm
+++ b/code/game/objects/items/tools/experimental_tools.dm
@@ -379,5 +379,5 @@
 		arms_to_damage -= l_arm
 	if(r_arm.status & LIMB_DESTROYED)
 		arms_to_damage -= r_arm
-	if(arms_to_damage.len)
+	if(length(arms_to_damage))
 		human_to_damage.apply_damage(3, BRUTE, pick(arms_to_damage))

--- a/code/game/objects/items/tools/extinguisher.dm
+++ b/code/game/objects/items/tools/extinguisher.dm
@@ -153,7 +153,7 @@
 	var/list/unpicked_targets = list()
 
 	for(var/a in 0 to (EXTINGUISHER_WATER_USE_AMT-1))
-		if (!unpicked_targets.len)
+		if (!length(unpicked_targets))
 			unpicked_targets += targets
 		var/turf/TT = pick(unpicked_targets)
 		unpicked_targets -= TT

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -248,7 +248,7 @@
 			showname = "."
 
 		var/used_verb = "attacked"
-		if(attack_verb && attack_verb.len)
+		if(LAZYLEN(attack_verb))
 			used_verb = pick(attack_verb)
 		user.visible_message(SPAN_DANGER("[M] has been [used_verb] with [src][showname]."),\
 						SPAN_DANGER("You [used_verb] [M] with [src]."), null, 5)

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -128,8 +128,8 @@ LINEN BINS
 		amount--
 
 		var/obj/item/bedsheet/B
-		if(sheets.len > 0)
-			B = sheets[sheets.len]
+		if(length(sheets) > 0)
+			B = sheets[length(sheets)]
 			sheets.Remove(B)
 
 		else

--- a/code/game/objects/structures/bookcase.dm
+++ b/code/game/objects/structures/bookcase.dm
@@ -54,7 +54,7 @@
 		..()
 
 /obj/structure/bookcase/attack_hand(mob/user as mob)
-	if(contents.len)
+	if(length(contents))
 		var/obj/item/book/choice = input("Which book would you like to remove from the shelf?") as null|obj in contents
 		if(choice)
 			if(user.is_mob_incapacitated() || !in_range(loc, user))
@@ -84,8 +84,8 @@
 			return
 
 /obj/structure/bookcase/update_icon()
-	if(contents.len < 5)
-		icon_state = "book-[contents.len]"
+	if(length(contents) < 5)
+		icon_state = "book-[length(contents)]"
 	else
 		icon_state = "book-5"
 

--- a/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
@@ -10,7 +10,7 @@
 		var/list/T = list()
 		for(var/turf/open/O in range(1))
 			T += O
-		if(supply.len)
+		if(length(supply))
 			for(var/s in supply)
 				var/amount = supply[s]
 				for(var/i = 1, i <= amount, i++)
@@ -92,7 +92,7 @@
 
 /obj/structure/largecrate/supply/Initialize()
 	. = ..()
-	if(supplies.len)
+	if(length(supplies))
 		for(var/s in supplies)
 			var/amount = supplies[s]
 			for(var/i = 1, i <= amount, i++)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -31,7 +31,7 @@
 	if(morgue_open)
 		icon_state = "[morgue_type]0"
 	else
-		if(contents.len > 1) //not counting the morgue tray
+		if(length(contents) > 1) //not counting the morgue tray
 			icon_state = "[morgue_type]2"
 		else
 			icon_state = "[morgue_type]1"
@@ -217,7 +217,7 @@
 	if(cremating)
 		return
 
-	if(contents.len <= 1) //1 because the tray is inside.
+	if(length(contents) <= 1) //1 because the tray is inside.
 		visible_message(SPAN_DANGER("You hear a hollow crackle."))
 	else
 		visible_message(SPAN_DANGER("You hear a roar as the crematorium activates."))

--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -34,7 +34,7 @@
 	. = ..()
 	if(get_dist(user, src) > 2 && user != loc) return
 	. += SPAN_NOTICE("It contains:")
-	if(reagents && reagents.reagent_list.len)
+	if(reagents && length(reagents.reagent_list))
 		for(var/datum/reagent/R in reagents.reagent_list)
 			. += SPAN_NOTICE(" [R.volume] units of [R.name]")
 	else

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -124,7 +124,7 @@ FLOOR SAFES
 	dat += "Dial 2: <a href='?src=\ref[src];decrement2=1'>-</a> [tumbler_2_pos] <a href='?src=\ref[src];increment2=1'>+</a><br>"
 	if(open)
 		dat += "<table>"
-		for(var/i = contents.len, i>=1, i--)
+		for(var/i = length(contents), i>=1, i--)
 			var/obj/item/P = contents[i]
 			dat += "<tr><td><a href='?src=\ref[src];retrieve=\ref[P]'>[P.name]</a></td></tr>"
 		dat += "</table></center>"

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -95,7 +95,7 @@
 		if(href_list["oxygen"])
 			if(oxygentanks > 0)
 				var/obj/item/tank/oxygen/O
-				if(oxytanks.len == oxygentanks)
+				if(length(oxytanks) == oxygentanks)
 					O = oxytanks[1]
 					oxytanks.Remove(O)
 				else
@@ -107,7 +107,7 @@
 		if(href_list["phoron"])
 			if(phorontanks > 0)
 				var/obj/item/tank/phoron/P
-				if(platanks.len == phorontanks)
+				if(length(platanks) == phorontanks)
 					P = platanks[1]
 					platanks.Remove(P)
 				else

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -405,4 +405,4 @@
 	set category = "Debug"
 
 	for(var/sound/S in SoundQuery())
-		UNLINT(to_chat(src, "channel#[S.channel]: [S.status] - [S.file] - len=[S.len], wait=[S.wait], offset=[S.offset], repeat=[S.repeat]")) // unlint until spacemandmm suite-1.7
+		UNLINT(to_chat(src, "channel#[S.channel]: [S.status] - [S.file] - len=[length(S)], wait=[S.wait], offset=[S.offset], repeat=[S.repeat]")) // unlint until spacemandmm suite-1.7

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -472,7 +472,7 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 		return
 	for(var/pool in base_random_crate_intervals)
 		var/interval = base_random_crate_intervals[pool]
-		if(interval && iteration % interval == 0 && shoppinglist.len <= 20)
+		if(interval && iteration % interval == 0 && length(shoppinglist) <= 20)
 			add_random_crates(pool)
 		crate_iteration++
 
@@ -539,7 +539,7 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 	if(istype(A,/mob/living) && !black_market_enabled)
 		return TRUE
 
-	for(var/i=1, i<=A.contents.len, i++)
+	for(var/i=1, i<=length(A.contents), i++)
 		var/atom/B = A.contents[i]
 		if(.(B))
 			return 1
@@ -560,7 +560,7 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 	for(var/atom/movable/movable_atom in area_shuttle)
 		if(istype(movable_atom, /obj/item/paper/manifest))
 			var/obj/item/paper/manifest/M = movable_atom
-			if(M.stamped && M.stamped.len)
+			if(LAZYLEN(M.stamped))
 				points += points_per_slip
 
 		//black market points
@@ -601,19 +601,19 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 //Buyin
 /datum/controller/supply/proc/buy()
 	var/area/area_shuttle = shuttle?.get_location_area()
-	if(!area_shuttle || !shoppinglist.len)
+	if(!area_shuttle || !length(shoppinglist))
 		return
 
 	// Try to find an available turf to place our package
 	var/list/turf/clear_turfs = list()
 	for(var/turf/T in area_shuttle)
-		if(T.density || T.contents?.len)
+		if(T.density || LAZYLEN(T.contents))
 			continue
 		clear_turfs += T
 
 	for(var/datum/supply_order/order in shoppinglist)
 		// No space! Forget buying, it's no use.
-		if(!clear_turfs.len)
+		if(!length(clear_turfs))
 			shoppinglist.Cut()
 			return
 
@@ -716,7 +716,7 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 		<tr><td>Approved by:</td>  \
 		<td>[approvedby]</td></tr> \
 		<tr><td># packages:</td>   \
-		<td class='field'>[packages.len]</td></tr> \
+		<td class='field'>[length(packages)]</td></tr> \
 		</table><hr><p class='header important'>Contents</p>   \
 		<ul class='field'>"
 
@@ -1050,11 +1050,11 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 		temp = "Invalid Request"
 		temp += "<BR><A href='?src=\ref[src];order=[last_viewed_group]'>Back</A>|<A href='?src=\ref[src];mainmenu=1'>Main Menu</A>"
 
-		if(GLOB.supply_controller.shoppinglist.len > 20)
+		if(length(GLOB.supply_controller.shoppinglist) > 20)
 			to_chat(usr, SPAN_DANGER("Current retrieval load has reached maximum capacity."))
 			return
 
-		for(var/i=1, i<=GLOB.supply_controller.requestlist.len, i++)
+		for(var/i=1, i<=length(GLOB.supply_controller.requestlist), i++)
 			var/datum/supply_order/SO = GLOB.supply_controller.requestlist[i]
 			if(SO.ordernum == ordernum)
 				supply_order = SO
@@ -1115,7 +1115,7 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 	else if (href_list["rreq"])
 		var/ordernum = text2num(href_list["rreq"])
 		temp = "Invalid Request.<BR>"
-		for(var/i=1, i<=GLOB.supply_controller.requestlist.len, i++)
+		for(var/i=1, length(i<=GLOB.supply_controller.requestlist), i++)
 			var/datum/supply_order/SO = GLOB.supply_controller.requestlist[i]
 			if(SO.ordernum == ordernum)
 				GLOB.supply_controller.requestlist.Cut(i,i+1)
@@ -1259,7 +1259,7 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 	if(!area_shuttle)
 		return
 	for(var/turf/elevator_turfs in area_shuttle)
-		if(elevator_turfs.density || elevator_turfs.contents?.len)
+		if(elevator_turfs.density || LAZYLEN(elevator_turfs.contents))
 			continue
 		clear_turfs |= elevator_turfs
 	var/turf/chosen_turf = pick(clear_turfs)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -370,7 +370,7 @@
 		next_target = initial(current_target.baseturfs)
 
 	baseturfs = new_baseturfs
-	created_baseturf_lists[new_baseturfs[new_baseturfs.len]] = new_baseturfs.Copy()
+	created_baseturf_lists[new_baseturfs[length(new_baseturfs)]] = new_baseturfs.Copy()
 	return new_baseturfs
 
 // Creates a new turf
@@ -456,14 +456,14 @@
 		return
 	if(length(baseturfs))
 		var/list/new_baseturfs = baseturfs.Copy()
-		var/turf_type = new_baseturfs[max(1, new_baseturfs.len - amount + 1)]
+		var/turf_type = new_baseturfs[max(1, length(new_baseturfs) - amount + 1)]
 		while(ispath(turf_type, /turf/baseturf_skipover))
 			amount++
-			if(amount > new_baseturfs.len)
+			if(amount > length(new_baseturfs))
 				CRASH("The bottomost baseturf of a turf is a skipover [src]([type])")
-			turf_type = new_baseturfs[max(1, new_baseturfs.len - amount + 1)]
-		new_baseturfs.len -= min(amount, new_baseturfs.len - 1) // No removing the very bottom
-		if(new_baseturfs.len == 1)
+			turf_type = new_baseturfs[max(1, length(new_baseturfs) - amount + 1)]
+		length(new_baseturfs) -= min(amount, length(new_baseturfs) - 1) // No removing the very bottom
+		if(length(new_baseturfs) == 1)
 			new_baseturfs = new_baseturfs[1]
 		return ChangeTurf(turf_type, new_baseturfs, flags)
 
@@ -774,9 +774,9 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	insert_self_into_baseturfs()
 	var/turf/change_type
 	if(length(new_baseturfs))
-		change_type = new_baseturfs[new_baseturfs.len]
+		change_type = new_baseturfs[length(new_baseturfs)]
 		new_baseturfs.len--
-		if(new_baseturfs.len)
+		if(length(new_baseturfs))
 			baseturfs += new_baseturfs
 	else
 		change_type = new_baseturfs
@@ -817,7 +817,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	var/static/list/ignored_atoms = typecacheof(list(/mob/dead, /obj/effect/landmark, /obj/docking_port))
 	var/list/removable_contents = typecache_filter_list_reverse(GetAllContentsIgnoring(ignore_typecache), ignored_atoms)
 	removable_contents -= src
-	for(var/i in 1 to removable_contents.len)
+	for(var/i in 1 to length(removable_contents))
 		var/thing = removable_contents[i]
 		qdel(thing, force=TRUE)
 
@@ -834,9 +834,9 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	if(depth)
 		var/list/target_baseturfs
 		if(length(copytarget.baseturfs))
-			// with default inputs this would be Copy(clamp(2, -INFINITY, baseturfs.len))
+			// with default inputs this would be Copy(clamp(2, -INFINITY, length(baseturfs)))
 			// Don't forget a lower index is lower in the baseturfs stack, the bottom is baseturfs[1]
-			target_baseturfs = copytarget.baseturfs.Copy(clamp(1 + ignore_bottom, 1 + copytarget.baseturfs.len - depth, copytarget.baseturfs.len))
+			target_baseturfs = copytarget.baseturfs.Copy(clamp(1 + ignore_bottom, 1 + length(copytarget.baseturfs) - depth, length(copytarget.baseturfs)))
 		else if(!ignore_bottom)
 			target_baseturfs = list(copytarget.baseturfs)
 		if(target_baseturfs)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -462,7 +462,7 @@
 			if(amount > length(new_baseturfs))
 				CRASH("The bottomost baseturf of a turf is a skipover [src]([type])")
 			turf_type = new_baseturfs[max(1, length(new_baseturfs) - amount + 1)]
-		length(new_baseturfs) -= min(amount, length(new_baseturfs) - 1) // No removing the very bottom
+		new_baseturfs.len -= min(amount, length(new_baseturfs) - 1) // No removing the very bottom
 		if(length(new_baseturfs) == 1)
 			new_baseturfs = new_baseturfs[1]
 		return ChangeTurf(turf_type, new_baseturfs, flags)

--- a/code/game/turfs/walls/wall_icon.dm
+++ b/code/game/turfs/walls/wall_icon.dm
@@ -31,9 +31,9 @@
 			overlays += I
 
 	if(damage)
-		var/current_dmg_overlay = floor(damage / damage_cap * damage_overlays.len) + 1
-		if(current_dmg_overlay > damage_overlays.len)
-			current_dmg_overlay = damage_overlays.len
+		var/current_dmg_overlay = floor(damage / damage_cap * length(damage_overlays)) + 1
+		if(current_dmg_overlay > length(damage_overlays))
+			current_dmg_overlay = length(damage_overlays)
 
 		damage_overlay = current_dmg_overlay
 		overlays += damage_overlays[damage_overlay]
@@ -52,9 +52,9 @@
 #undef cur_increment
 
 /turf/closed/wall/proc/generate_damage_overlays()
-	var/alpha_inc = 256 / damage_overlays.len
+	var/alpha_inc = 256 / length(damage_overlays)
 
-	for(var/i = 1; i <= damage_overlays.len; i++)
+	for(var/i = 1; i <= length(damage_overlays); i++)
 		var/image/img = image(icon = 'icons/turf/walls/walls.dmi', icon_state = "overlay_damage")
 		img.blend_mode = BLEND_MULTIPLY
 		img.appearance_flags = NO_CLIENT_COLOR
@@ -118,7 +118,7 @@
 
 	var/list/ret = list(NORTHWEST, SOUTHEAST, NORTHEAST, SOUTHWEST)
 
-	for(var/i = 1 to ret.len)
+	for(var/i = 1 to length(ret))
 		var/dir = ret[i]
 		. = CORNER_NONE
 		if(dir in dirs)

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -188,7 +188,7 @@
 		dat += "<BR><B>Current [category] ([length(listings[category])]):<BR></B>\n"
 		for(var/client/entry in listings[category])
 			dat += "\t[entry.key] is \a [entry.admin_holder.rank]"
-			if(entry.admin_holder.extra_titles?.len)
+			if(LAZYLEN(entry.admin_holder.extra_titles))
 				for(var/srank in entry.admin_holder.extra_titles)
 					dat += " & [srank]"
 			if(CLIENT_IS_STAFF(src))

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -269,7 +269,7 @@ GLOBAL_LIST_INIT(reboot_sfx, file2list("config/reboot_sfx.txt"))
 
 /world/proc/load_tm_message()
 	var/datum/getrev/revdata = GLOB.revdata
-	if(revdata.testmerge.len)
+	if(length(revdata.testmerge))
 		GLOB.current_tms = revdata.GetTestMergeInfo()
 
 /world/proc/update_status()

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -22,7 +22,7 @@
 	if(GLOB.admin_datums[ckey] && (GLOB.admin_datums[ckey].rights & R_MOD))
 		return ..()
 
-	if(CONFIG_GET(number/limit_players) && CONFIG_GET(number/limit_players) < GLOB.clients.len)
+	if(CONFIG_GET(number/limit_players) && CONFIG_GET(number/limit_players) < length(GLOB.clients))
 		return list("reason"="POP CAPPED", "desc"="\nReason: Server is pop capped at the moment at [CONFIG_GET(number/limit_players)] players. Attempt reconnection in 2-3 minutes.")
 
 	var/datum/entity/player/P = get_player_from_key(ckey)

--- a/code/modules/admin/STUI.dm
+++ b/code/modules/admin/STUI.dm
@@ -85,31 +85,31 @@ GLOBAL_DATUM_INIT(STUI, /datum/STUI, new)
 	. = list()
 	.["logs"] = list()
 	if(user.client.admin_holder.rights & R_MOD)
-		if(attack.len > stui_length+1)
-			attack.Cut(,attack.len-stui_length)
+		if(length(attack) > stui_length+1)
+			attack.Cut(,length(attack)-stui_length)
 		.["logs"][STUI_TEXT_ATTACK] = attack
-		if(admin.len > stui_length+1)
-			admin.Cut(,admin.len-stui_length)
+		if(length(admin) > stui_length+1)
+			admin.Cut(,length(admin)-stui_length)
 		.["logs"][STUI_TEXT_STAFF] = admin
-		if(staff.len > stui_length+1)
-			staff.Cut(,staff.len-stui_length)
+		if(length(staff) > stui_length+1)
+			staff.Cut(,length(staff)-stui_length)
 		.["logs"][STUI_TEXT_STAFF_CHAT] = staff
-		if(ooc.len > stui_length+1)
-			ooc.Cut(,ooc.len-stui_length)
+		if(length(ooc) > stui_length+1)
+			ooc.Cut(,length(ooc)-stui_length)
 		.["logs"][STUI_TEXT_OOC] = ooc
 	if((user.client.admin_holder.rights & R_MOD) || (user.client.admin_holder.rights & R_DEBUG))
-		if(game.len > stui_length+1)
-			game.Cut(,game.len-stui_length)
+		if(length(game) > stui_length+1)
+			game.Cut(,length(game)-stui_length)
 		.["logs"][STUI_TEXT_GAME] = game
 	if(user.client.admin_holder.rights & R_DEBUG)
-		if(debug.len > stui_length+1)
-			debug.Cut(,debug.len-stui_length)
+		if(length(debug) > stui_length+1)
+			debug.Cut(,length(debug)-stui_length)
 		.["logs"][STUI_TEXT_DEBUG] = debug
-		if(runtime.len > stui_length+1)
-			runtime.Cut(,runtime.len-stui_length)
+		if(length(runtime) > stui_length+1)
+			runtime.Cut(,length(runtime)-stui_length)
 		.["logs"][STUI_TEXT_RUNTIME] = runtime
-		if(tgui.len > stui_length+1)
-			tgui.Cut(,tgui.len-stui_length)
+		if(length(tgui) > stui_length+1)
+			tgui.Cut(,length(tgui)-stui_length)
 		.["logs"][STUI_TEXT_TGUI] = tgui
 
 /client/proc/open_STUI()

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -67,7 +67,7 @@
 	var/savefile/info = new("data/player_saves/[copytext(key, 1, 2)]/[key]/info.sav")
 	var/list/infos
 	info >> infos
-	if(!infos || !infos.len) return 0
+	if(!LAZYLEN(infos)) return 0
 	else return 1
 
 /datum/admins/proc/player_notes_all(key as text)
@@ -179,11 +179,11 @@
 		if(findtext("[path]", object))
 			matches += path
 
-	if(matches.len==0)
+	if(length(matches)==0)
 		return
 
 	var/chosen
-	if(matches.len==1)
+	if(length(matches)==1)
 		chosen = matches[1]
 	else
 		chosen = tgui_input_list(usr, "Select an atom type", "Spawn Atom", matches)

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -15,7 +15,7 @@ GLOBAL_LIST_EMPTY(admin_ranks) //list of all ranks with associated rights
 		if(copytext(line,1,2) == "#") continue
 
 		var/list/List = splittext(line,"+")
-		if(!List.len) continue
+		if(!length(List)) continue
 
 		var/rank = ckeyEx(List[1])
 		switch(rank)
@@ -23,7 +23,7 @@ GLOBAL_LIST_EMPTY(admin_ranks) //list of all ranks with associated rights
 			if("Removed") continue //Reserved
 
 		var/rights = 0
-		for(var/i=2, i<=List.len, i++)
+		for(var/i=2, i<=length(List), i++)
 			switch(ckey(List[i]))
 				if("@","prev") rights |= previous_rights
 				if("buildmode","build") rights |= R_BUILDMODE
@@ -93,7 +93,7 @@ GLOBAL_LIST_EMPTY(admin_ranks) //list of all ranks with associated rights
 
 	//Split the line at every "-"
 	var/list/List = splittext(line, "-")
-	if(!List.len) return
+	if(!length(List)) return
 
 	//ckey is before the first "-"
 	var/ckey = ckey(List[1])
@@ -101,11 +101,11 @@ GLOBAL_LIST_EMPTY(admin_ranks) //list of all ranks with associated rights
 
 	//rank follows the first "-"
 	var/rank = ""
-	if(List.len >= 2)
+	if(length(List) >= 2)
 		rank = ckeyEx(List[2])
 
 	var/list/extra_titles = list()
-	if(List.len >= 3)
+	if(length(List) >= 3)
 		extra_titles = List.Copy(3)
 
 	if(mentor)

--- a/code/modules/admin/callproc.dm
+++ b/code/modules/admin/callproc.dm
@@ -140,7 +140,7 @@ GLOBAL_PROTECT(LastAdminCalledProc)
 	if (!length(proclist))
 		return
 
-	var/procname = proclist[proclist.len]
+	var/procname = proclist[length(proclist)]
 	var/proctype = ("verb" in proclist) ? "verb" :"proc"
 
 	if(targetselected)
@@ -161,15 +161,15 @@ GLOBAL_PROTECT(LastAdminCalledProc)
 		if(!target)
 			to_chat(usr, "<font color='red'>Error: callproc(): owner of proc no longer exists.</font>", confidential = TRUE)
 			return
-		var/msg = "[key_name(src)] called [target]'s [procname]() with [lst.len ? "the arguments [list2params(lst)]":"no arguments"]."
+		var/msg = "[key_name(src)] called [target]'s [procname]() with [length(lst) ? "the arguments [list2params(lst)]":"no arguments"]."
 		log_admin(msg)
 		message_admins(msg) //Proccall announce removed.
 		admin_ticket_log(target, msg)
 		returnval = WrapAdminProcCall(target, procname, lst) // Pass the lst as an argument list to the proc
 	else
 		//this currently has no hascall protection. wasn't able to get it working.
-		log_admin("[key_name(src)] called [procname]() with [lst.len ? "the arguments [list2params(lst)]":"no arguments"].")
-		message_admins("[key_name(src)] called [procname]() with [lst.len ? "the arguments [list2params(lst)]":"no arguments"].") //Proccall announce removed.
+		log_admin("[key_name(src)] called [procname]() with [length(lst) ? "the arguments [list2params(lst)]":"no arguments"].")
+		message_admins("[key_name(src)] called [procname]() with [length(lst) ? "the arguments [list2params(lst)]":"no arguments"].") //Proccall announce removed.
 		returnval = WrapAdminProcCall(GLOBAL_PROC, procname, lst) // Pass the lst as an argument list to the proc
 	if(get_retval)
 		get_retval += returnval
@@ -251,8 +251,8 @@ GLOBAL_PROTECT(LastAdminCalledProc)
 	if(!called_datum || !is_valid_src(called_datum))
 		to_chat(usr, SPAN_WARNING("Error: callproc_datum(): owner of proc no longer exists."), confidential = TRUE)
 		return
-	log_admin("[key_name(src)] called [called_datum]'s [procname]() with [lst.len ? "the arguments [list2params(lst)]":"no arguments"].")
-	var/msg = "[key_name(src)] called [called_datum]'s [procname]() with [lst.len ? "the arguments [list2params(lst)]":"no arguments"]."
+	log_admin("[key_name(src)] called [called_datum]'s [procname]() with [length(lst) ? "the arguments [list2params(lst)]":"no arguments"].")
+	var/msg = "[key_name(src)] called [called_datum]'s [procname]() with [length(lst) ? "the arguments [list2params(lst)]":"no arguments"]."
 	message_admins(msg)
 	admin_ticket_log(called_datum, msg)
 
@@ -285,7 +285,7 @@ GLOBAL_PROTECT(LastAdminCalledProc)
 	if(islist(returnval))
 		var/list/returnedlist = returnval
 		. = "<font color='blue'>"
-		if(returnedlist.len)
+		if(length(returnedlist))
 			var/assoc_check = returnedlist[1]
 			if(istext(assoc_check) && (returnedlist[assoc_check] != null))
 				. += "[procname] returned an associative list:"

--- a/code/modules/admin/medal_panel/medals_panel_tgui.dm
+++ b/code/modules/admin/medal_panel/medals_panel_tgui.dm
@@ -25,14 +25,14 @@ GLOBAL_DATUM_INIT(medals_panel, /datum/medals_panel_tgui, new)
 		var/datum/recipient_awards/recipient_award = GLOB.medal_awards[recipient_name]
 		uscm_awards[recipient_name] = list()
 		uscm_award_ckeys[recipient_name] = recipient_award.recipient_ckey ? " ([recipient_award.recipient_ckey])" : ""
-		for(var/i in 1 to recipient_award.medal_names.len) // We're assuming everything is same length
+		for(var/i in 1 to length(recipient_award.medal_names)) // We're assuming everything is same length
 			uscm_awards[recipient_name] += "[recipient_award.medal_names[i]]: \'[recipient_award.medal_citations[i]]\' by [recipient_award.giver_rank[i] ? "[recipient_award.giver_rank[i]] " : ""][recipient_award.giver_name[i] ? "[recipient_award.giver_name[i]] " : ""]([recipient_award.giver_ckey[i]])."
 
 	for(var/recipient_name as anything in GLOB.jelly_awards)
 		var/datum/recipient_awards/recipient_award = GLOB.jelly_awards[recipient_name]
 		xeno_awards[recipient_name] = list()
 		xeno_award_ckeys[recipient_name] = recipient_award.recipient_ckey ? " ([recipient_award.recipient_ckey])" : ""
-		for(var/i in 1 to recipient_award.medal_names.len) // We're assuming everything is same length
+		for(var/i in 1 to length(recipient_award.medal_names)) // We're assuming everything is same length
 			xeno_awards[recipient_name] += "[recipient_award.medal_names[i]]: \'[recipient_award.medal_citations[i]]\' by [recipient_award.giver_rank[i] ? "[recipient_award.giver_rank[i]] " : ""][recipient_award.giver_name[i] ? "[recipient_award.giver_name[i]] " : ""]([recipient_award.giver_ckey[i]])."
 
 	data["uscm_awards"] = uscm_awards

--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -57,7 +57,7 @@
 	var/savefile/info = new("data/player_saves/[copytext(key, 1, 2)]/[key]/info.sav")
 	var/list/infos
 	info >> infos
-	if(!infos || infos.len < index) return
+	if(LAZYLEN(infos) < index) return
 
 	var/datum/player_info/item = infos[index]
 	infos.Remove(item)

--- a/code/modules/admin/player_panel/player_panel.dm
+++ b/code/modules/admin/player_panel/player_panel.dm
@@ -338,7 +338,7 @@
 				dat += "<td><a href='?src=\ref[src];[HrefToken()];adminplayeropts=\ref[H]'>PP</a></td>"
 		dat += "</table>"
 
-	if(SSticker.mode.survivors.len)
+	if(length(SSticker.mode.survivors))
 		dat += "<br><table cellspacing=5><tr><td><B>Survivors</B></td><td></td><td></td></tr>"
 		for(var/datum/mind/L in SSticker.mode.survivors)
 			var/mob/M = L.current
@@ -350,7 +350,7 @@
 				dat += "<td><A href='?src=\ref[src];[HrefToken()];adminplayeropts=\ref[M]'>PP</A></td></TR>"
 		dat += "</table>"
 
-	if(SSticker.mode.xenomorphs.len)
+	if(length(SSticker.mode.xenomorphs))
 		dat += "<br><table cellspacing=5><tr><td><B>Aliens</B></td><td></td><td></td></tr>"
 		for(var/datum/mind/L in SSticker.mode.xenomorphs)
 			var/mob/M = L.current
@@ -362,7 +362,7 @@
 				dat += "<td><A href='?src=\ref[src];[HrefToken()];adminplayeropts=\ref[M]'>PP</A></td></TR>"
 		dat += "</table>"
 
-	if(SSticker.mode.survivors.len)
+	if(length(SSticker.mode.survivors))
 		dat += "<br><table cellspacing=5><tr><td><B>Survivors</B></td><td></td><td></td></tr>"
 		for(var/datum/mind/L in SSticker.mode.survivors)
 			var/mob/M = L.current

--- a/code/modules/admin/tabs/debug_tab.dm
+++ b/code/modules/admin/tabs/debug_tab.dm
@@ -32,7 +32,7 @@
 
 	var/value = SStechtree.trees[1]
 
-	if(trees.len > 1)
+	if(length(trees) > 1)
 		value = tgui_input_list(src, "Choose which tree to enter", "Enter Tree", trees)
 
 	if(!value)
@@ -60,7 +60,7 @@
 
 	var/value = SStechtree.trees[1]
 
-	if(trees.len > 1)
+	if(length(trees) > 1)
 		value = tgui_input_list(src, "Choose which tree to give points to", "Give Points", trees)
 
 	if(!value)

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -445,7 +445,7 @@
 	var/datum/hive_status/hive
 	for(var/hivenumber in GLOB.hive_datum)
 		hive = GLOB.hive_datum[hivenumber]
-		if(hive.totalXenos.len > 0 || hive.total_dead_xenos.len > 0)
+		if(length(hive.totalXenos) > 0 || length(hive.total_dead_xenos) > 0)
 			hives += list("[hive.name]" = hive.hivenumber)
 			last_hive_checked = hive
 

--- a/code/modules/admin/topic/topic.dm
+++ b/code/modules/admin/topic/topic.dm
@@ -73,7 +73,7 @@
 
 		else if(task == "rank")
 			var/new_rank
-			if(GLOB.admin_ranks.len)
+			if(length(GLOB.admin_ranks))
 				new_rank = tgui_input_list(usr, "Please select a rank", "New rank", (GLOB.admin_ranks|"*New Rank*"))
 			else
 				new_rank = tgui_input_list(usr, "Please select a rank", "New rank", list("Game Master","Game Admin", "Trial Admin", "Admin Observer","*New Rank*"))
@@ -91,7 +91,7 @@
 						to_chat(usr, "<font color='red'>Error: Topic 'editrights': Invalid rank</font>")
 						return
 					if(CONFIG_GET(flag/admin_legacy_system))
-						if(GLOB.admin_ranks.len)
+						if(length(GLOB.admin_ranks))
 							if(new_rank in GLOB.admin_ranks)
 								rights = GLOB.admin_ranks[new_rank] //we typed a rank which already exists, use its rights
 							else
@@ -553,7 +553,7 @@
 				notbannedlist += job
 
 		//Banning comes first
-		if(notbannedlist.len)
+		if(length(notbannedlist))
 			if(!check_rights(R_BAN))  return
 			var/reason = input(usr,"Reason?","Please State Reason","") as text|null
 			if(reason)
@@ -565,7 +565,7 @@
 
 		//Unbanning joblist
 		//all jobs in joblist are banned already OR we didn't give a reason (implying they shouldn't be banned)
-		if(joblist.len) //at least 1 banned job exists in joblist so we have stuff to unban.
+		if(length(joblist)) //at least 1 banned job exists in joblist so we have stuff to unban.
 			for(var/job in joblist)
 				var/reason = jobban_isbanned(M, job, P1)
 				if(!reason) continue //skip if it isn't jobbanned anyway
@@ -1951,9 +1951,9 @@
 
 		var/list/offset = splittext(href_list["offset"],",")
 		var/number = clamp(text2num(href_list["object_count"]), 1, 100)
-		var/X = offset.len > 0 ? text2num(offset[1]) : 0
-		var/Y = offset.len > 1 ? text2num(offset[2]) : 0
-		var/Z = offset.len > 2 ? text2num(offset[3]) : 0
+		var/X = length(offset) > 0 ? text2num(offset[1]) : 0
+		var/Y = length(offset) > 1 ? text2num(offset[2]) : 0
+		var/Z = length(offset) > 2 ? text2num(offset[3]) : 0
 		var/tmp_dir = href_list["object_dir"]
 		var/obj_dir = tmp_dir ? text2num(tmp_dir) : 2
 		if(!obj_dir || !(obj_dir in list(1,2,4,8,5,6,9,10)))

--- a/code/modules/admin/topic/topic_chems.dm
+++ b/code/modules/admin/topic/topic_chems.dm
@@ -286,7 +286,7 @@
 						response = alert(usr,"What do you want customized?","Custom reaction [target]","Add component","Add catalyst","Finish")
 					else
 						return
-			if(R.required_reagents.len < 3)
+			if(length(R.required_reagents) < 3)
 				to_chat(usr,SPAN_WARNING("You need to add at least 3 components excluding catalysts. The reaction has not been saved."))
 				return
 			//Save our reaction

--- a/code/modules/admin/topic/topic_events.dm
+++ b/code/modules/admin/topic/topic_events.dm
@@ -259,7 +259,7 @@
 			var/datum/emergency_call/custom/em_call = new()
 			var/name = input(usr, "Please name your ERT", "ERT Name", "Admin spawned humans")
 			em_call.name = name
-			em_call.mob_max = humans.len
+			em_call.mob_max = length(humans)
 			em_call.players_to_offer = humans
 			em_call.owner = owner
 
@@ -347,7 +347,7 @@
 			var/datum/emergency_call/custom/em_call = new()
 			var/name = input(usr, "Please name your ERT", "ERT Name", "Admin spawned xenos")
 			em_call.name = name
-			em_call.mob_max = xenos.len
+			em_call.mob_max = length(xenos)
 			em_call.players_to_offer = xenos
 			em_call.owner = owner
 

--- a/code/modules/admin/topic/topic_teleports.dm
+++ b/code/modules/admin/topic/topic_teleports.dm
@@ -83,10 +83,10 @@
 			for(var/mob/living/M in range(collect_range, owner.mob))
 				if(M.stat != DEAD)
 					targets.Add(M)
-			if(targets.len < 1)
+			if(length(targets) < 1)
 				to_chat(owner, SPAN_ALERT("No alive /living mobs found. Aborting."))
 				return
-			if(alert(owner, "[targets.len] mobs were marked for teleportation. Pressing \"TELEPORT\" will teleport them to your location at the moment of pressing button.", "Confirmation", "Teleport", "Cancel") == "Cancel")
+			if(alert(owner, "[length(targets)] mobs were marked for teleportation. Pressing \"TELEPORT\" will teleport them to your location at the moment of pressing button.", "Confirmation", "Teleport", "Cancel") == "Cancel")
 				return
 			for(var/mob/M in targets)
 				if(!M)
@@ -94,7 +94,7 @@
 				M.on_mob_jump()
 				M.forceMove(get_turf(owner.mob))
 
-			message_admins(WRAP_STAFF_LOG(owner.mob, "mass-teleported [targets.len] mobs in [collect_range] tiles range to themselves in [get_area(owner.mob)] ([owner.mob.x],[owner.mob.y],[owner.mob.z])."), owner.mob.x, owner.mob.y, owner.mob.z)
+			message_admins(WRAP_STAFF_LOG(owner.mob, "mass-teleported [length(targets)] mobs in [collect_range] tiles range to themselves in [get_area(owner.mob)] ([owner.mob.x],[owner.mob.y],[owner.mob.z])."), owner.mob.x, owner.mob.y, owner.mob.z)
 
 		if("teleport_mobs_by_faction")
 			var/faction = tgui_input_list(owner, "Choose between humanoids and xenomorphs.", "Mobs Choice", list("Humanoids", "Xenomorphs"))
@@ -109,10 +109,10 @@
 					var/area/AR = get_area(H)
 					if(H.faction != faction || AR.statistic_exempt)
 						targets.Remove(H)
-				if(targets.len < 1)
+				if(length(targets) < 1)
 					to_chat(owner, SPAN_ALERT("No alive /human mobs of [faction] faction were found. Aborting."))
 					return
-				if(alert(owner, "[targets.len] humanoids of [faction] faction were marked for teleportation. Pressing \"TELEPORT\" will teleport them to your location at the moment of pressing button.", "Confirmation", "Teleport", "Cancel") == "Cancel")
+				if(alert(owner, "[length(targets)] humanoids of [faction] faction were marked for teleportation. Pressing \"TELEPORT\" will teleport them to your location at the moment of pressing button.", "Confirmation", "Teleport", "Cancel") == "Cancel")
 					return
 
 				for(var/mob/M in targets)
@@ -121,7 +121,7 @@
 					M.on_mob_jump()
 					M.forceMove(get_turf(owner.mob))
 
-				message_admins(WRAP_STAFF_LOG(owner.mob, "mass-teleported [targets.len] human mobs of [faction] faction to themselves in [get_area(owner.mob)] ([owner.mob.x],[owner.mob.y],[owner.mob.z])."), owner.mob.x, owner.mob.y, owner.mob.z)
+				message_admins(WRAP_STAFF_LOG(owner.mob, "mass-teleported [length(targets)] human mobs of [faction] faction to themselves in [get_area(owner.mob)] ([owner.mob.x],[owner.mob.y],[owner.mob.z])."), owner.mob.x, owner.mob.y, owner.mob.z)
 
 			else if(faction == "Xenomorphs")
 				faction = null
@@ -141,10 +141,10 @@
 					var/area/AR = get_area(X)
 					if(X.stat == DEAD || AR.statistic_exempt)
 						targets.Remove(X)
-				if(targets.len < 1)
+				if(length(targets) < 1)
 					to_chat(owner, SPAN_ALERT("No alive xenomorphs of [faction] Hive were found. Aborting."))
 					return
-				if(alert(owner, "[targets.len] xenomorphs of [faction] Hive were marked for teleportation. Pressing \"TELEPORT\" will teleport them to your location at the moment of pressing button.", "Confirmation", "Teleport", "Cancel") == "Cancel")
+				if(alert(owner, "[length(targets)] xenomorphs of [faction] Hive were marked for teleportation. Pressing \"TELEPORT\" will teleport them to your location at the moment of pressing button.", "Confirmation", "Teleport", "Cancel") == "Cancel")
 					return
 
 				for(var/mob/M in targets)
@@ -153,25 +153,25 @@
 					M.on_mob_jump()
 					M.forceMove(get_turf(owner.mob))
 
-				message_admins(WRAP_STAFF_LOG(owner.mob, "mass-teleported [targets.len] xenomorph mobs of [faction] Hive to themselves in [get_area(owner.mob)] ([owner.mob.x],[owner.mob.y],[owner.mob.z])."), owner.mob.x, owner.mob.y, owner.mob.z)
+				message_admins(WRAP_STAFF_LOG(owner.mob, "mass-teleported [length(targets)] xenomorph mobs of [faction] Hive to themselves in [get_area(owner.mob)] ([owner.mob.x],[owner.mob.y],[owner.mob.z])."), owner.mob.x, owner.mob.y, owner.mob.z)
 
 			else
 				to_chat(owner, SPAN_ALERT("Mobs choice error. Aborting."))
 				return
 
 		if("teleport_corpses")
-			if(GLOB.dead_mob_list.len < 0)
+			if(length(GLOB.dead_mob_list) < 0)
 				to_chat(owner, SPAN_ALERT("No corpses found. Aborting."))
 				return
 
-			if(alert(owner, "[GLOB.dead_mob_list.len] corpses are marked for teleportation. Pressing \"TELEPORT\" will teleport them to your location at the moment of pressing button.", "Confirmation", "Teleport", "Cancel") == "Cancel")
+			if(alert(owner, "[length(GLOB.dead_mob_list)] corpses are marked for teleportation. Pressing \"TELEPORT\" will teleport them to your location at the moment of pressing button.", "Confirmation", "Teleport", "Cancel") == "Cancel")
 				return
 			for(var/mob/M in GLOB.dead_mob_list)
 				if(!M)
 					continue
 				M.on_mob_jump()
 				M.forceMove(get_turf(owner.mob))
-			message_admins(WRAP_STAFF_LOG(owner.mob, "mass-teleported [GLOB.dead_mob_list.len] corpses to themselves in [get_area(owner.mob)] ([owner.mob.x],[owner.mob.y],[owner.mob.z])."), owner.mob.x, owner.mob.y, owner.mob.z)
+			message_admins(WRAP_STAFF_LOG(owner.mob, "mass-teleported [length(GLOB.dead_mob_list)] corpses to themselves in [get_area(owner.mob)] ([owner.mob.x],[owner.mob.y],[owner.mob.z])."), owner.mob.x, owner.mob.y, owner.mob.z)
 
 		if("teleport_items_by_type")
 			var/item = input(owner,"What item?", "Item Fetcher","") as text|null
@@ -186,11 +186,11 @@
 				if(findtext("[path]", item))
 					matches += path
 
-			if(matches.len==0)
+			if(length(matches)==0)
 				return
 
 			var/chosen
-			if(matches.len==1)
+			if(length(matches)==1)
 				chosen = matches[1]
 			else
 				//If we have multiple options, let them select which one they meant
@@ -205,11 +205,11 @@
 				if(istype(M, chosen))
 					targets += M
 
-			if(targets.len < 1)
+			if(length(targets) < 1)
 				to_chat(owner, SPAN_ALERT("No items of type [chosen] were found. Aborting."))
 				return
 
-			if(alert(owner, "[targets.len] items are marked for teleportation. Pressing \"TELEPORT\" will teleport them to your location at the moment of pressing button.", "Confirmation", "Teleport", "Cancel") == "Cancel")
+			if(alert(owner, "[length(targets)] items are marked for teleportation. Pressing \"TELEPORT\" will teleport them to your location at the moment of pressing button.", "Confirmation", "Teleport", "Cancel") == "Cancel")
 				return
 
 			//Fetch the items
@@ -218,4 +218,4 @@
 					continue
 				M.forceMove(get_turf(owner.mob))
 
-			message_admins(WRAP_STAFF_LOG(owner.mob, "mass-teleported [targets.len] items of type [chosen] to themselves in [get_area(owner.mob)] ([owner.mob.x],[owner.mob.y],[owner.mob.z])."), owner.mob.x, owner.mob.y, owner.mob.z)
+			message_admins(WRAP_STAFF_LOG(owner.mob, "mass-teleported [length(targets)] items of type [chosen] to themselves in [get_area(owner.mob)] ([owner.mob.x],[owner.mob.y],[owner.mob.z])."), owner.mob.x, owner.mob.y, owner.mob.z)

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -595,7 +595,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/sdql2_vv_all, new(null
 
 	// 1 and 2 are type and FROM.
 	var/i = 3
-	while (i <= tree.len)
+	while (i <= length(tree))
 		var/key = tree[i++]
 		var/list/expression = tree[i++]
 		switch (key)
@@ -805,7 +805,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/sdql2_vv_all, new(null
 					out += d
 				SDQL2_TICK_CHECK
 				SDQL2_HALT_CHECK
-	obj_count_all = out.len
+	obj_count_all = length(out)
 	return out
 
 /datum/sdql2_query/proc/Execute(list/found)
@@ -1092,7 +1092,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/sdql2_vv_all, new(null
 	for(var/val in query_list)
 		if(val == ";")
 			do_parse = 1
-		else if(pos >= query_list.len)
+		else if(pos >= length(query_list))
 			query_tree += val
 			do_parse = 1
 
@@ -1192,7 +1192,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/sdql2_vv_all, new(null
 		else if(expression[start + 1] == "\[" && islist(v))
 			var/list/L = v
 			var/index = query.SDQL_expression(source, expression[start + 2])
-			if(isnum(index) && ((floor(index) != index) || L.len < index))
+			if(isnum(index) && ((floor(index) != index) || length(L) < index))
 				to_chat(usr, SPAN_DANGER("Invalid list index: [index]"), confidential = TRUE)
 				return null
 			return L[index]

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
@@ -61,7 +61,7 @@
 /datum/sdql_parser/proc/parse_error(error_message)
 	error = 1
 	to_chat(usr, SPAN_WARNING("SDQL2 Parsing Error: [error_message]"), confidential = TRUE)
-	return query.len + 1
+	return length(query) + 1
 
 /datum/sdql_parser/proc/parse()
 	tree = list()
@@ -73,14 +73,14 @@
 		return tree
 
 /datum/sdql_parser/proc/token(i)
-	if(i <= query.len)
+	if(i <= length(query))
 		return query[i]
 
 	else
 		return null
 
 /datum/sdql_parser/proc/tokens(i, num)
-	if(i + num <= query.len)
+	if(i + num <= length(query))
 		return query.Copy(i, i + num)
 
 	else
@@ -473,7 +473,7 @@
 				if (tok == ":")
 					temp_expression_list = list()
 					i = expression(i + 1, temp_expression_list)
-					expression_list[expression_list[expression_list.len]] = temp_expression_list
+					expression_list[expression_list[length(expression_list)]] = temp_expression_list
 					temp_expression_list = null
 					tok = token(i)
 					if (tok != ",")

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -179,7 +179,7 @@
 	sleep(Delay)
 
 /proc/_list_add(list/L, ...)
-	if (args.len < 2)
+	if (length(args) < 2)
 		return
 	L += args.Copy(2)
 
@@ -199,7 +199,7 @@
 	return L.Join(Glue, Start, End)
 
 /proc/_list_remove(list/L, ...)
-	if (args.len < 2)
+	if (length(args) < 2)
 		return
 	L -= args.Copy(2)
 

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -58,7 +58,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			ticket_list = resolved_tickets
 		else
 			CRASH("Invalid ticket state: [new_ticket.state]")
-	var/num_closed = ticket_list.len
+	var/num_closed = length(ticket_list)
 	if(num_closed)
 		for(var/I in 1 to num_closed)
 			var/datum/admin_help/AH = ticket_list[I]
@@ -97,8 +97,8 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	SHOULD_NOT_SLEEP(TRUE)
 	var/list/L = list()
 	var/num_disconnected = 0
-	L[++L.len] = list("Active Tickets:", "[astatclick.update("[active_tickets.len]")]", null, REF(astatclick))
-	astatclick.update("[active_tickets.len]")
+	L[++L.len] = list("Active Tickets:", "[astatclick.update("[length(active_tickets)]")]", null, REF(astatclick))
+	astatclick.update("[length(active_tickets)]")
 	for(var/I in active_tickets)
 		var/datum/admin_help/AH = I
 		if(AH.initiator)
@@ -108,8 +108,8 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			++num_disconnected
 	if(num_disconnected)
 		L[++L.len] = list("Disconnected:", "[astatclick.update("[num_disconnected]")]", null, REF(astatclick))
-	L[++L.len] = list("Closed Tickets:", "[cstatclick.update("[closed_tickets.len]")]", null, REF(cstatclick))
-	L[++L.len] = list("Resolved Tickets:", "[rstatclick.update("[resolved_tickets.len]")]", null, REF(rstatclick))
+	L[++L.len] = list("Closed Tickets:", "[cstatclick.update("[length(closed_tickets)]")]", null, REF(cstatclick))
+	L[++L.len] = list("Resolved Tickets:", "[rstatclick.update("[length(resolved_tickets)]")]", null, REF(rstatclick))
 	return L
 
 //Reassociate still open ticket if one exists
@@ -300,7 +300,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		webhook_sent = WEBHOOK_URGENT
 	var/list/adm = get_admin_counts(R_BAN)
 	var/list/activemins = adm["present"]
-	var/admin_number_present = activemins.len
+	var/admin_number_present = length(activemins)
 
 	log_admin_private("Ticket #[id]: [key_name(initiator)]: [name] - heard by [admin_number_present] non-AFK admins who have +BAN.")
 	if(admin_number_present <= 0)
@@ -660,7 +660,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 	// Append any tickets also opened by this user if relevant
 	var/list/related_tickets = GLOB.ahelp_tickets.TicketsByCKey(initiator_ckey)
-	if (related_tickets.len > 1)
+	if (length(related_tickets) > 1)
 		dat += "<br/><b>Other Tickets by User</b><br/>"
 		for (var/datum/admin_help/related_ticket in related_tickets)
 			if (related_ticket.id == id)

--- a/code/modules/admin/verbs/adminpanelweapons.dm
+++ b/code/modules/admin/verbs/adminpanelweapons.dm
@@ -108,13 +108,13 @@
 			picked_area = pick(GLOB.ship_areas)
 			for(var/turf/my_turf in picked_area)
 				turfs_of_area += my_turf
-			if(turfs_of_area.len > 0)
+			if(length(turfs_of_area) > 0)
 				picked_atom = pick(turfs_of_area)
 				if (picked_atom != null)
 					targets += picked_atom
 					break
 
-	if(targets.len < turfquantity)
+	if(length(targets) < turfquantity)
 		return null
 	else
 		return targets

--- a/code/modules/admin/verbs/autoreplace.dm
+++ b/code/modules/admin/verbs/autoreplace.dm
@@ -32,7 +32,7 @@ GLOBAL_LIST_INIT_TYPED(admin_runtime_decorators, /datum/decorator/manual/admin_r
 
 	GLOB.admin_runtime_decorators.Add(SSdecorator.add_decorator(/datum/decorator/manual/admin_runtime, types, subtypes, field, value))
 
-	message_admins("[src] activated new decorator id: [GLOB.admin_runtime_decorators.len] set for [hint_text] `[types]` for field `[field]` set value `[value]`")
+	message_admins("[src] activated new decorator id: [length(GLOB.admin_runtime_decorators)] set for [hint_text] `[types]` for field `[field]` set value `[value]`")
 
 /client/proc/deactivate_autoreplacer()
 	set category = "Admin.Events"

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -277,7 +277,7 @@
 		remembered_info += "<b>Your account pin is:</b> [generated_account.remote_access_pin]<br>"
 		remembered_info += "<b>Your account funds are:</b> $[generated_account.money]<br>"
 
-		if(generated_account.transaction_log.len)
+		if(length(generated_account.transaction_log))
 			var/datum/transaction/T = generated_account.transaction_log[1]
 			remembered_info += "<b>Your account was created:</b> [T.time], [T.date] at [T.source_terminal]<br>"
 		account_user.mind.store_memory(remembered_info)

--- a/code/modules/admin/view_variables/debug_variables.dm
+++ b/code/modules/admin/view_variables/debug_variables.dm
@@ -69,8 +69,8 @@
 		var/list/L = value
 		var/list/items = list()
 
-		if (L.len > 0 && !(name == "underlays" || name == "overlays" || L.len > (IS_NORMAL_LIST(L) ? VV_NORMAL_LIST_NO_EXPAND_THRESHOLD : VV_SPECIAL_LIST_NO_EXPAND_THRESHOLD)))
-			for (var/i in 1 to L.len)
+		if (length(L) > 0 && !(name == "underlays" || name == "overlays" || length(L) > (IS_NORMAL_LIST(L) ? VV_NORMAL_LIST_NO_EXPAND_THRESHOLD : VV_SPECIAL_LIST_NO_EXPAND_THRESHOLD)))
+			for (var/i in 1 to length(L))
 				var/key = L[i]
 				var/val
 				if (IS_NORMAL_LIST(L) && !isnum(key))
@@ -81,9 +81,9 @@
 
 				items += debug_variable(key, val, level + 1, sanitize = sanitize)
 
-			item = "[name_part] = <a href='?_src_=vars;[HrefToken()];Vars=[REF(value)]'>/list ([L.len])</a><ul>[items.Join()]</ul>"
+			item = "[name_part] = <a href='?_src_=vars;[HrefToken()];Vars=[REF(value)]'>/list ([length(L)])</a><ul>[items.Join()]</ul>"
 		else
-			item = "[name_part] = <a href='?_src_=vars;[HrefToken()];Vars=[REF(value)]'>/list ([L.len])</a>"
+			item = "[name_part] = <a href='?_src_=vars;[HrefToken()];Vars=[REF(value)]'>/list ([length(L)])</a>"
 
 	else if (name in GLOB.bitfields)
 		var/list/flags = list()

--- a/code/modules/admin/view_variables/get_variables.dm
+++ b/code/modules/admin/view_variables/get_variables.dm
@@ -390,7 +390,7 @@
 	var/list/matches = new
 	var/end_len = -1
 	var/list/endcheck = splittext(filter, "!")
-	if(endcheck.len > 1)
+	if(length(endcheck) > 1)
 		filter = endcheck[1]
 		end_len = length_char(filter)
 

--- a/code/modules/admin/view_variables/mass_edit_variables.dm
+++ b/code/modules/admin/view_variables/mass_edit_variables.dm
@@ -101,7 +101,7 @@
 		if(VV_RESTORE_DEFAULT)
 			to_chat(src, "Finding items...", confidential = TRUE)
 			var/list/items = get_all_of_type(O.type, method)
-			to_chat(src, "Changing [items.len] items...", confidential = TRUE)
+			to_chat(src, "Changing [length(items)] items...", confidential = TRUE)
 			for(var/thing in items)
 				if (!thing)
 					continue
@@ -116,7 +116,7 @@
 			var/list/varsvars = vv_parse_text(O, new_value)
 			var/pre_processing = new_value
 			var/unique
-			if (varsvars?.len)
+			if (LAZYLEN(varsvars))
 				unique = tgui_alert(usr, "Process vars unique to each instance, or same for all?", "Variable Association", list("Unique", "Same"))
 				if(unique == "Unique")
 					unique = TRUE
@@ -127,7 +127,7 @@
 
 			to_chat(src, "Finding items...", confidential = TRUE)
 			var/list/items = get_all_of_type(O.type, method)
-			to_chat(src, "Changing [items.len] items...", confidential = TRUE)
+			to_chat(src, "Changing [length(items)] items...", confidential = TRUE)
 			for(var/thing in items)
 				if (!thing)
 					continue
@@ -155,7 +155,7 @@
 			var/type = value["type"]
 			to_chat(src, "Finding items...", confidential = TRUE)
 			var/list/items = get_all_of_type(O.type, method)
-			to_chat(src, "Changing [items.len] items...", confidential = TRUE)
+			to_chat(src, "Changing [length(items)] items...", confidential = TRUE)
 			for(var/thing in items)
 				if (!thing)
 					continue
@@ -173,7 +173,7 @@
 		else
 			to_chat(src, "Finding items...", confidential = TRUE)
 			var/list/items = get_all_of_type(O.type, method)
-			to_chat(src, "Changing [items.len] items...", confidential = TRUE)
+			to_chat(src, "Changing [length(items)] items...", confidential = TRUE)
 			for(var/thing in items)
 				if (!thing)
 					continue

--- a/code/modules/admin/view_variables/modify_variables.dm
+++ b/code/modules/admin/view_variables/modify_variables.dm
@@ -21,16 +21,15 @@ GLOBAL_PROTECT(VVpixelmovement)
 	if (!ispath(type))
 		return
 	var/list/subtypes = subtypesof(type)
-	if (!subtypes || !subtypes.len)
+	if (!LAZYLEN(subtypes))
 		return FALSE
-	if (subtypes?.len)
-		switch(tgui_alert(usr,"Strict object type detection?", "Type detection", list("Strictly this type","This type and subtypes", "Cancel")))
-			if("Strictly this type")
-				return FALSE
-			if("This type and subtypes")
-				return TRUE
-			else
-				return
+	switch(tgui_alert(usr,"Strict object type detection?", "Type detection", list("Strictly this type","This type and subtypes", "Cancel")))
+		if("Strictly this type")
+			return FALSE
+		if("This type and subtypes")
+			return TRUE
+		else
+			return
 
 /client/proc/vv_reference_list(type, subtypes)
 	. = list()
@@ -115,14 +114,14 @@ GLOBAL_PROTECT(VVpixelmovement)
 		to_chat(src, "Not a List.", confidential = TRUE)
 		return
 
-	if(L.len > 1000)
+	if(length(L) > 1000)
 		var/confirm = tgui_alert(usr, "The list you're trying to edit is very long, continuing may crash the server.", "Warning", list("Continue", "Abort"))
 		if(confirm != "Continue")
 			return
 
 	var/is_normal_list = IS_NORMAL_LIST(L)
 	var/list/names = list()
-	for (var/i in 1 to L.len)
+	for (var/i in 1 to length(L))
 		var/key = L[i]
 		var/value
 		if (is_normal_list && !isnum(key))

--- a/code/modules/admin/view_variables/reference_tracking.dm
+++ b/code/modules/admin/view_variables/reference_tracking.dm
@@ -130,7 +130,7 @@
 				#endif
 				log_reftracker("Found [type] [text_ref(src)] in list [container_name].")
 				var/msg
-				for(var/i in 1 to min(10, potential_cache.len))
+				for(var/i in 1 to min(10, length(potential_cache)))
 					msg += "[potential_cache[i]],"
 				if(msg)
 					log_reftracker("List contents: [msg]")
@@ -148,7 +148,7 @@
 				#endif
 				log_reftracker("Found [type] [text_ref(src)] in list [container_name]\[[element_in_list]\]")
 				var/msg
-				for(var/i in 1 to min(10, potential_cache.len))
+				for(var/i in 1 to min(10, length(potential_cache)))
 					msg += "[potential_cache[i]],"
 				if(msg)
 					log_reftracker("List contents: [msg]")

--- a/code/modules/admin/view_variables/topic_list.dm
+++ b/code/modules/admin/view_variables/topic_list.dm
@@ -30,12 +30,12 @@
 			message_admins("[key_name_admin(src)] modified list's contents: CLEAR NULLS")
 		if(href_list[VV_HK_LIST_SET_LENGTH])
 			var/value = vv_get_value(VV_NUM)
-			if (value["class"] != VV_NUM || value["value"] > max(50000, target.len)) //safety - would rather someone not put an extra 0 and erase the server's memory lmao.
+			if (value["class"] != VV_NUM || value["value"] > max(50000, length(target))) //safety - would rather someone not put an extra 0 and erase the server's memory lmao.
 				return
 			target.len = value["value"]
-			log_world("### ListVarEdit by [src]: /list len: [target.len]")
-			log_admin("[key_name(src)] modified list's len: [target.len]")
-			message_admins("[key_name_admin(src)] modified list's len: [target.len]")
+			log_world("### ListVarEdit by [src]: /list len: [length(target)]")
+			log_admin("[key_name(src)] modified list's len: [length(target)]")
+			message_admins("[key_name_admin(src)] modified list's len: [length(target)]")
 		if(href_list[VV_HK_LIST_SHUFFLE])
 			shuffle_inplace(target)
 			log_world("### ListVarEdit by [src]: /list contents: SHUFFLE")

--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -86,7 +86,7 @@
 	var/list/variable_html = list()
 	if(islist)
 		var/list/L = D
-		for(var/i in 1 to L.len)
+		for(var/i in 1 to length(L))
 			var/key = L[i]
 			var/value
 			if(IS_NORMAL_LIST(L) && IS_VALID_ASSOC_KEY(key))

--- a/code/modules/almayer/machinery.dm
+++ b/code/modules/almayer/machinery.dm
@@ -222,8 +222,8 @@
 	. = ..()
 	if((isobserver(user) || ishuman(user)) && GLOB.fallen_list)
 		var/faltext = ""
-		for(var/i = 1 to GLOB.fallen_list.len)
-			if(i != GLOB.fallen_list.len)
+		for(var/i = 1 to length(GLOB.fallen_list))
+			if(i != length(GLOB.fallen_list))
 				faltext += "[GLOB.fallen_list[i]], "
 			else
 				faltext += GLOB.fallen_list[i]

--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -203,7 +203,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 
 	for (var/icon_state_name in icon_states(I))
 		for (var/direction in directions)
-			var/prefix2 = (directions.len > 1) ? "[dir2text(direction)]-" : ""
+			var/prefix2 = (length(directions) > 1) ? "[dir2text(direction)]-" : ""
 			Insert("[prefix][prefix2][icon_state_name]", I, icon_state=icon_state_name, dir=direction)
 
 /datum/asset/spritesheet/proc/css_tag()
@@ -260,7 +260,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 			if (!asset)
 				continue
 			asset = fcopy_rsc(asset) //dedupe
-			var/prefix2 = (directions.len > 1) ? "[dir2text(direction)]." : ""
+			var/prefix2 = (length(directions) > 1) ? "[dir2text(direction)]." : ""
 			var/asset_name = sanitize_filename("[prefix].[prefix2][icon_state_name].png")
 			if (generic_icon_names)
 				asset_name = "[generate_asset_name(asset)].png"

--- a/code/modules/asset_cache/transports/asset_transport.dm
+++ b/code/modules/asset_cache/transports/asset_transport.dm
@@ -113,8 +113,8 @@
 			continue
 		unreceived[asset_name] = ACI
 
-	if (unreceived.len)
-		if (unreceived.len >= ASSET_CACHE_TELL_CLIENT_AMOUNT)
+	if (length(unreceived))
+		if (length(unreceived) >= ASSET_CACHE_TELL_CLIENT_AMOUNT)
 			to_chat(client, "Sending Resources...")
 
 		for (var/asset_name in unreceived)

--- a/code/modules/clans/client.dm
+++ b/code/modules/clans/client.dm
@@ -145,7 +145,7 @@
 			player_move_clans = (clan_info.permissions & CLAN_PERMISSION_ADMIN_MOVE)
 		)
 
-	var/list/clan_members[CPV.len]
+	var/list/clan_members[length(CPV)]
 
 	var/index = 1
 	for(var/datum/view_record/clan_playerbase_view/CP in CPV)
@@ -361,7 +361,7 @@
 				for(var/datum/view_record/clan_view/CV in CPV)
 					clans += list("[CV.name]" = CV.clan_id)
 
-				if(is_clan_manager && clans.len >= 1)
+				if(is_clan_manager && length(clans) >= 1)
 					if(target.permissions & CLAN_PERMISSION_ADMIN_ANCIENT)
 						clans += list("Remove from Ancient")
 					else
@@ -431,7 +431,7 @@
 
 					if(chosen_rank.limit_type)
 						var/list/datum/view_record/clan_playerbase_view/CPV = DB_VIEW(/datum/view_record/clan_playerbase_view/, DB_AND(DB_COMP("clan_id", DB_EQUALS, target.clan_id), DB_COMP("rank", DB_EQUALS, GLOB.clan_ranks_ordered[input])))
-						var/players_in_rank = CPV.len
+						var/players_in_rank = length(CPV)
 
 						switch(chosen_rank.limit_type)
 							if(CLAN_LIMIT_NUMBER)
@@ -440,7 +440,7 @@
 									return
 							if(CLAN_LIMIT_SIZE)
 								var/list/datum/view_record/clan_playerbase_view/clan_players = DB_VIEW(/datum/view_record/clan_playerbase_view/, DB_COMP("clan_id", DB_EQUALS, target.clan_id))
-								var/available_slots = ceil(clan_players.len / chosen_rank.limit)
+								var/available_slots = ceil(length(clan_players) / chosen_rank.limit)
 
 								if(players_in_rank >= available_slots)
 									to_chat(src, SPAN_DANGER("This slot is full! (Maximum of [chosen_rank.limit] per player in the clan, currently [available_slots])"))

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -297,7 +297,7 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 	var/static/next_external_rsc = 0
 	var/list/external_rsc_urls = CONFIG_GET(keyed_list/external_rsc_urls)
 	if(length(external_rsc_urls))
-		next_external_rsc = WRAP(next_external_rsc+1, 1, external_rsc_urls.len+1)
+		next_external_rsc = WRAP(next_external_rsc+1, 1, length(external_rsc_urls)+1)
 		preload_rsc = external_rsc_urls[next_external_rsc]
 
 	player_entity = setup_player_entity(ckey)

--- a/code/modules/client/player_details.dm
+++ b/code/modules/client/player_details.dm
@@ -17,7 +17,7 @@ GLOBAL_LIST_EMPTY(player_details) // ckey -> /datum/player_details
 /proc/log_played_names(ckey, ...)
 	if(!ckey)
 		return
-	if(args.len < 2)
+	if(length(args) < 2)
 		return
 	var/list/names = args.Copy(2)
 	var/datum/player_details/P = GLOB.player_details[ckey]

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -404,7 +404,7 @@ GLOBAL_LIST_INIT(bgstate_options, list(
 
 			if(length(gear))
 				dat += "<br>"
-				for(var/i = 1; i <= gear.len; i++)
+				for(var/i = 1; i <= length(gear); i++)
 					var/datum/gear/G = GLOB.gear_datums_by_name[gear[i]]
 					if(G)
 						total_cost += G.cost
@@ -416,7 +416,7 @@ GLOBAL_LIST_INIT(bgstate_options, list(
 
 			if(total_cost < MAX_GEAR_COST)
 				dat += " <a href='byond://?src=\ref[user];preference=loadout;task=input'><b>Add</b></a>"
-				if(gear && gear.len)
+				if(LAZYLEN(gear))
 					dat += " <a href='byond://?src=\ref[user];preference=loadout;task=clear'><b>Clear</b></a>"
 
 			dat += "</div>"
@@ -1041,7 +1041,7 @@ GLOBAL_LIST_INIT(bgstate_options, list(
 					var/datum/gear/G
 					if(isnull(gear) || !islist(gear))
 						gear = list()
-					if(gear.len)
+					if(length(gear))
 						for(var/gear_name in gear)
 							G = GLOB.gear_datums_by_name[gear_name]
 							total_cost += G?.cost
@@ -1056,7 +1056,7 @@ GLOBAL_LIST_INIT(bgstate_options, list(
 
 				if("remove")
 					var/i_remove = text2num(href_list["gear"])
-					if(i_remove < 1 || i_remove > gear.len) return
+					if(i_remove < 1 || i_remove > length(gear)) return
 					gear.Cut(i_remove, i_remove + 1)
 
 				if("clear")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -57,9 +57,8 @@
 	if(savefile_version < 17) //remove omniglots
 		var/list/language_traits = list()
 		S["traits"] >> language_traits
-		if(language_traits)
-			if(language_traits.len > 1)
-				language_traits = null
+		if(LAZYLEN(language_traits) > 1)
+			language_traits = null
 		S["traits"] << language_traits
 
 	if(savefile_version < 18) // adds ambient occlusion by default
@@ -594,7 +593,7 @@
 	b_eyes = sanitize_integer(b_eyes, 0, 255, initial(b_eyes))
 	underwear = sanitize_inlist(underwear, gender == MALE ? GLOB.underwear_m : GLOB.underwear_f, initial(underwear))
 	undershirt = sanitize_inlist(undershirt, gender == MALE ? GLOB.undershirt_m : GLOB.undershirt_f, initial(undershirt))
-	backbag = sanitize_integer(backbag, 1, GLOB.backbaglist.len, initial(backbag))
+	backbag = sanitize_integer(backbag, 1, length(GLOB.backbaglist), initial(backbag))
 	preferred_armor = sanitize_inlist(preferred_armor, GLOB.armor_style_list, "Random")
 	//b_type = sanitize_text(b_type, initial(b_type))
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -26,9 +26,9 @@
 	for(var/obj/item/clothing/accessory/accessory in accessories)
 		if(accessory.high_visibility)
 			ties += "\a [accessory.get_examine_line(user)]"
-	if(ties.len)
+	if(length(ties))
 		.+= " with [english_list(ties)] attached"
-	if(LAZYLEN(accessories) > ties.len)
+	if(LAZYLEN(accessories) > length(ties))
 		.+= ". <a href='?src=\ref[src];list_acc=1'>\[See accessories\]</a>"
 
 /obj/item/clothing/Topic(href, href_list)
@@ -284,7 +284,7 @@
 			tankcheck = list(C.r_hand, C.l_hand, C.back)
 		var/best = 0
 		var/bestpressure = 0
-		for(var/i=1, i<tankcheck.len+1, ++i)
+		for(var/i=1, i<length(tankcheck)+1, ++i)
 			if(istype(tankcheck[i], /obj/item/tank))
 				var/obj/item/tank/t = tankcheck[i]
 				var/goodtank

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -50,7 +50,7 @@
 /obj/item/clothing/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/clothing/accessory))
 
-		if(!valid_accessory_slots || !valid_accessory_slots.len)
+		if(!LAZYLEN(valid_accessory_slots))
 			to_chat(usr, SPAN_WARNING("You cannot attach accessories of any kind to \the [src]."))
 			return
 

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -557,7 +557,7 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 	// the human sprite is the only thing that reliably renders things, so
 	// we have to add overlays to that.
 	helmet_overlays = list() // Rebuild our list every time
-	if(pockets && pockets.contents.len && (flags_marine_helmet & HELMET_GARB_OVERLAY))
+	if(pockets && length(pockets.contents) && (flags_marine_helmet & HELMET_GARB_OVERLAY))
 		var/list/above_band_layer = list()
 		var/list/below_band_layer = list()
 		var/has_helmet_band = FALSE

--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -54,7 +54,7 @@ GLOBAL_LIST_INIT(breach_burn_descriptors, list(
 //Repair a certain amount of brute or burn damage to the suit.
 /obj/item/clothing/suit/space/proc/repair_breaches(damtype, amount, mob/user)
 
-	if(!can_breach || !breaches || !breaches.len || !damage)
+	if(!can_breach || !LAZYLEN(breaches) || !damage)
 		to_chat(user, "There are no breaches to repair on \the [src].")
 		return
 
@@ -64,7 +64,7 @@ GLOBAL_LIST_INIT(breach_burn_descriptors, list(
 		if(B.damtype == damtype)
 			valid_breaches += B
 
-	if(!valid_breaches.len)
+	if(!length(valid_breaches))
 		to_chat(user, "There are no breaches to repair on \the [src].")
 		return
 
@@ -145,7 +145,7 @@ GLOBAL_LIST_INIT(breach_burn_descriptors, list(
 	brute_damage = 0
 	burn_damage = 0
 
-	if(!can_breach || !breaches || !breaches.len)
+	if(!can_breach || !LAZYLEN(breaches))
 		name = base_name
 		return 0
 
@@ -220,6 +220,6 @@ GLOBAL_LIST_INIT(breach_burn_descriptors, list(
 
 /obj/item/clothing/suit/space/get_examine_text(mob/user)
 	. = ..()
-	if(can_breach && breaches && breaches.len)
+	if(can_breach && LAZYLEN(breaches))
 		for(var/datum/breach/B in breaches)
 			. += SPAN_DANGER("It has \a [B.descriptor].")

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -65,7 +65,7 @@
 /obj/item/clothing/suit/space/proc/check_limb_support()
 
 	// If this isn't set, then we don't need to care.
-	if(!supporting_limbs || !supporting_limbs.len)
+	if(!LAZYLEN(supporting_limbs))
 		return
 
 	var/mob/living/carbon/human/H = src.loc

--- a/code/modules/cm_aliens/structures/special/recovery_node.dm
+++ b/code/modules/cm_aliens/structures/special/recovery_node.dm
@@ -23,7 +23,7 @@
 			continue
 		heal_candidates += X
 	last_healed = world.time
-	if(!heal_candidates.len)
+	if(!length(heal_candidates))
 		return
 	var/mob/living/carbon/xenomorph/picked_candidate = pick(heal_candidates)
 	picked_candidate.visible_message(SPAN_HELPFUL("\The [picked_candidate] glows as a warm aura envelops them."), \

--- a/code/modules/cm_aliens/structures/tunnel.dm
+++ b/code/modules/cm_aliens/structures/tunnel.dm
@@ -129,7 +129,7 @@
 	if(isxeno(usr) && isfriendly(usr) && (usr.loc == src))
 		pick_tunnel(usr)
 	else
-		to_chat(usr, "You stare into the dark abyss" + "[contents.len ? ", making out what appears to be two little lights... almost like something is watching." : "."]")
+		to_chat(usr, "You stare into the dark abyss" + "[length(contents) ? ", making out what appears to be two little lights... almost like something is watching." : "."]")
 
 /obj/structure/tunnel/verb/exit_tunnel_verb()
 	set name = "Exit Tunnel"
@@ -177,7 +177,7 @@
 
 		var/obj/structure/tunnel/T = input_tunnels[pick]
 
-		if(T.contents.len > 2)// max 3 xenos in a tunnel
+		if(length(T.contents) > 2)// max 3 xenos in a tunnel
 			to_chat(X, SPAN_WARNING("The tunnel is too crowded, wait for others to exit!"))
 			return FALSE
 		if(!T.loc)
@@ -236,11 +236,11 @@
 		to_chat(M, SPAN_XENOWARNING("We can't climb through a tunnel while immobile."))
 		return XENO_NO_DELAY_ACTION
 
-	if(!hive.tunnels.len)
+	if(!length(hive.tunnels))
 		to_chat(M, SPAN_WARNING("[src] doesn't seem to lead anywhere."))
 		return XENO_NO_DELAY_ACTION
 
-	if(contents.len > 2)
+	if(length(contents) > 2)
 		to_chat(M, SPAN_WARNING("The tunnel is too crowded, wait for others to exit!"))
 		return XENO_NO_DELAY_ACTION
 
@@ -263,7 +263,7 @@
 		to_chat(M, SPAN_WARNING("Our crawling was interrupted!"))
 		return XENO_NO_DELAY_ACTION
 
-	if(hive.tunnels.len) //Make sure other tunnels exist
+	if(length(hive.tunnels)) //Make sure other tunnels exist
 		M.forceMove(src) //become one with the tunnel
 		to_chat(M, SPAN_HIGHDANGER("Alt + Click the tunnel to exit, Ctrl + Click to choose a destination."))
 		pick_tunnel(M)

--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -1216,7 +1216,7 @@
 
 	var/list/possible_fultons = get_targets()
 
-	if(!possible_fultons.len)
+	if(!length(possible_fultons))
 		to_chat(user, SPAN_WARNING("No active balloons detected."))
 		return
 

--- a/code/modules/cm_marines/equipment/gear.dm
+++ b/code/modules/cm_marines/equipment/gear.dm
@@ -108,7 +108,7 @@
 			continue
 		mobs_can_store += H
 	var/mob/living/carbon/human/mob_to_store
-	if(mobs_can_store.len)
+	if(length(mobs_can_store))
 		mob_to_store = pick(mobs_can_store)
 		mob_to_store.forceMove(src)
 		mob_to_store.unset_interaction()

--- a/code/modules/cm_marines/equipment/kit_boxes.dm
+++ b/code/modules/cm_marines/equipment/kit_boxes.dm
@@ -323,7 +323,7 @@
 		overlays += image('icons/obj/items/storage.dmi', "+[pro_case_overlay]")
 
 /obj/item/storage/box/kit/update_icon()
-	if(!contents.len)
+	if(!length(contents))
 		qdel(src)
 /obj/item/storage/box/kit/mou53_sapper
 	name = "\improper M-OU53 Field Test Kit"

--- a/code/modules/cm_marines/equipment/weapons.dm
+++ b/code/modules/cm_marines/equipment/weapons.dm
@@ -21,9 +21,8 @@
 	update_icon()
 
 /obj/item/storage/box/m56_system/update_icon()
-	if(overlays.len)
-		overlays.Cut()
-	if(contents.len)
+	LAZYCLEARLIST(overlays)
+	if(length(contents))
 		icon_state = "kit_case"
 		overlays += image(icon, "smartgun")
 	else
@@ -50,9 +49,8 @@
 	update_icon()
 
 /obj/item/storage/box/m56c_system/update_icon()
-	if(overlays.len)
-		overlays.Cut()
-	if(contents.len)
+	LAZYCLEARLIST(overlays)
+	if(length(contents))
 		icon_state = "kit_case"
 		overlays += image(icon, "smartgun")
 	else
@@ -80,9 +78,8 @@
 	update_icon()
 
 /obj/item/storage/box/m56_dirty_system/update_icon()
-	if(overlays.len)
-		overlays.Cut()
-	if(contents.len)
+	LAZYCLEARLIST(overlays)
+	if(length(contents))
 		icon_state = "kit_case"
 		overlays += image(icon, "smartgun")
 	else

--- a/code/modules/cm_marines/marines_consoles.dm
+++ b/code/modules/cm_marines/marines_consoles.dm
@@ -805,7 +805,7 @@ GLOBAL_LIST_EMPTY_TYPED(crewmonitor, /datum/crewmonitor)
 		ui.open()
 
 /datum/crewmonitor/proc/show(mob/M, source)
-	if(!ui_sources.len)
+	if(!length(ui_sources))
 		START_PROCESSING(SSprocessing, src)
 	ui_sources[M] = source
 	tgui_interact(M)
@@ -823,7 +823,7 @@ GLOBAL_LIST_EMPTY_TYPED(crewmonitor, /datum/crewmonitor)
 /datum/crewmonitor/ui_close(mob/M)
 	. = ..()
 	ui_sources -= M
-	if(!ui_sources.len)
+	if(!length(ui_sources))
 		STOP_PROCESSING(SSprocessing, src)
 
 /datum/crewmonitor/ui_host(mob/user)

--- a/code/modules/cm_marines/shuttle_backend.dm
+++ b/code/modules/cm_marines/shuttle_backend.dm
@@ -107,7 +107,7 @@ DOCUMENTATION ON HOW TO ADD A NEW SHUTTLE: Fourkhan, 6/7/19
 /proc/rotate_shuttle_turfs(list/L, deg = 0)
 
 	if((deg % 90) != 0) return //Not a right or straight angle, don't do anything
-	if(!istype(L) || !L.len) return null
+	if(!istype(L) || !length(L)) return null
 
 	var/i //iterator
 	var/x //Placeholder while we do math

--- a/code/modules/cm_preds/yaut_items.dm
+++ b/code/modules/cm_preds/yaut_items.dm
@@ -944,7 +944,7 @@
 	new /obj/item/tool/surgery/healing_gel/(src)
 
 /obj/item/storage/medicomp/update_icon()
-	if(!contents.len)
+	if(!length(contents))
 		icon_state = "medicomp_open"
 	else
 		icon_state = "medicomp"

--- a/code/modules/customitems/item_spawning.dm
+++ b/code/modules/customitems/item_spawning.dm
@@ -10,10 +10,10 @@ GLOBAL_LIST_FILE_LOAD(custom_items, "config/custom_items.txt")
 	for(var/line in GLOB.custom_items)
 		// split & clean up
 		var/list/Entry = splittext(line, ":")
-		for(var/i = 1 to Entry.len)
+		for(var/i = 1 to length(Entry))
 			Entry[i] = trim(Entry[i])
 
-		if(Entry.len < 2)
+		if(length(Entry) < 2)
 			continue;
 
 		if(Entry[1] == M.ckey)

--- a/code/modules/decorators/cassette_decorator.dm
+++ b/code/modules/decorators/cassette_decorator.dm
@@ -3,7 +3,7 @@
 
 /datum/decorator/cassette/is_active_decor()
 	cassette_data = file2list("sound/music/walkman/playlist.txt")
-	return cassette_data.len > 0
+	return length(cassette_data) > 0
 
 /datum/decorator/cassette/get_decor_types()
 	return typesof(/obj/item/device/cassette_tape)

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -85,7 +85,7 @@
 	if(!targets)
 		return FALSE
 
-	if(!target && targets.len)
+	if(!target && length(targets))
 		target = pick(targets)
 
 	get_target(target)
@@ -290,7 +290,7 @@
 		if(actual_fire(A))
 			break
 
-	if(targets.len)
+	if(length(targets))
 		addtimer(CALLBACK(src, PROC_REF(get_target)), fire_delay)
 
 	if(!engaged_timer)
@@ -350,7 +350,7 @@
 	if(!targets.Find(new_target))
 		targets.Add(new_target)
 
-	if(!targets.len)
+	if(!length(targets))
 		return
 
 	var/list/conscious_targets = list()
@@ -405,7 +405,7 @@
 				continue
 
 		var/list/turf/path = get_line(src, A, include_start_atom = FALSE)
-		if(!path.len || get_dist(src, A) > sentry_range)
+		if(!length(path) || get_dist(src, A) > sentry_range)
 			if(A == target)
 				target = null
 			targets.Remove(A)
@@ -457,9 +457,9 @@
 			else
 				conscious_targets += M
 
-	if(conscious_targets.len)
+	if(length(conscious_targets))
 		target = pick(conscious_targets)
-	else if(unconscious_targets.len)
+	else if(length(unconscious_targets))
 		target = pick(unconscious_targets)
 
 	if(!target) //No targets, don't bother firing

--- a/code/modules/droppod/droppod_ui.dm
+++ b/code/modules/droppod/droppod_ui.dm
@@ -90,7 +90,7 @@ GLOBAL_LIST_INIT(droppod_target_mode, list(
 	var/list/acceptableTurfs = list()
 	for (var/t in ordered_area) //Go through the orderedArea list
 		var/turf/unchecked_turf = t
-		if (typecache_filter_list_reverse(unchecked_turf.contents, ignored_atoms).len != 0) //if there is something in this turf that isn't in the blacklist, we consider this turf "acceptable" and add it to the acceptableTurfs list
+		if (length(typecache_filter_list_reverse(unchecked_turf.contents, ignored_atoms)) != 0) //if there is something in this turf that isn't in the blacklist, we consider this turf "acceptable" and add it to the acceptableTurfs list
 			acceptableTurfs.Add(unchecked_turf) //Because orderedArea was an ordered linear list, acceptableTurfs will be as well.
 
 	launch_list = list() //Anything in launch_list will go into the supplypod when it is launched

--- a/code/modules/dropships/cas/fire_mission_record.dm
+++ b/code/modules/dropships/cas/fire_mission_record.dm
@@ -31,7 +31,7 @@
 	var/used = 0
 	var/max_ammo = 0
 	if(weapon.ammo_equipped)
-		for(var/step = 1; step<=offsets.len; step++)
+		for(var/step = 1; step<=length(offsets); step++)
 			if(offsets[step]!=null && offsets[step]!="-")
 				used += weapon.ammo_equipped.ammo_used_per_firing
 		max_ammo = weapon.ammo_equipped.max_ammo_count

--- a/code/modules/economy/economy_misc.dm
+++ b/code/modules/economy/economy_misc.dm
@@ -77,8 +77,8 @@ GLOBAL_VAR_INIT(economy_init, FALSE)
 
 	for(var/loc_type in typesof(/datum/trade_destination) - /datum/trade_destination)
 		var/datum/trade_destination/D = new loc_type
-		GLOB.weighted_randomevent_locations[D] = D.viable_random_events.len
-		GLOB.weighted_mundaneevent_locations[D] = D.viable_mundane_events.len
+		GLOB.weighted_randomevent_locations[D] = length(D.viable_random_events)
+		GLOB.weighted_mundaneevent_locations[D] = length(D.viable_mundane_events)
 
 	create_station_account()
 

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -54,7 +54,7 @@ Gunshots/explosions/opening doors/less rare audio (done)
 							slots_free += ui_datum.ui_storage1
 						if(!H.r_store)
 							slots_free += ui_datum.ui_storage2
-					if(slots_free.len)
+					if(length(slots_free))
 						halitem.screen_loc = pick(slots_free)
 						halitem.layer = 50
 						switch(rand(1,6))
@@ -97,7 +97,7 @@ Gunshots/explosions/opening doors/less rare audio (done)
 					var/list/possible_points = list()
 					for(var/turf/open/floor/F in view(src,GLOB.world_view_size))
 						possible_points += F
-					if(possible_points.len)
+					if(length(possible_points))
 						var/turf/open/floor/target = pick(possible_points)
 
 						switch(rand(1,3))
@@ -161,7 +161,7 @@ Gunshots/explosions/opening doors/less rare audio (done)
 					var/list/possible_points = list()
 					for(var/turf/open/floor/F in view(src,GLOB.world_view_size))
 						possible_points += F
-					if(possible_points.len)
+					if(length(possible_points))
 						var/turf/open/floor/target = pick(possible_points)
 						switch(rand(1,3))
 							if(1)
@@ -203,12 +203,12 @@ Gunshots/explosions/opening doors/less rare audio (done)
 		"Play Charades","Oxygen","Inject BeAcOs","Ninja Lizards","Limit Break","Build Sentry")
 
 		if(mid_txts)
-			while(mid_txts.len)
+			while(length(mid_txts))
 				var/mid_txt = pick(mid_txts)
 				mocktxt += mid_txt
 				mid_txts -= mid_txt
 
-		while(buttons.len)
+		while(length(buttons))
 
 			var/button = pick(buttons)
 
@@ -356,7 +356,7 @@ GLOBAL_LIST_INIT(non_fakeattack_weapons, list(/obj/item/device/aicard,\
 		clone = H
 		break //changed the code a bit. Less randomised, but less work to do. Should be ok, world.contents aren't stored in any particular order.
 
-// if(!possible_clones.len) return
+// if(!length(possible_clones)) return
 // clone = pick(possible_clones)
 	if(!clone) return
 

--- a/code/modules/flufftext/TextFilters.dm
+++ b/code/modules/flufftext/TextFilters.dm
@@ -30,10 +30,10 @@
 
 	var/list/unstuttered_words = split_phrase.Copy()
 	var/i = rand(1,3)
-	if(stunned) i = split_phrase.len
+	if(stunned) i = length(split_phrase)
 	for(,i > 0,i--) //Pick a few words to stutter on.
 
-		if (!unstuttered_words.len)
+		if (!length(unstuttered_words))
 			break
 		var/word = pick(unstuttered_words)
 		unstuttered_words -= word //Remove from unstuttered words so we don't stutter it again.

--- a/code/modules/hydroponics/grown_inedible.dm
+++ b/code/modules/hydroponics/grown_inedible.dm
@@ -24,7 +24,7 @@
 		for(var/rid in S.chems)
 			var/list/reagent_data = S.chems[rid]
 			var/rtotal = reagent_data[1]
-			if(reagent_data.len > 1 && potency > 0)
+			if(length(reagent_data) > 1 && potency > 0)
 				rtotal += floor(potency/reagent_data[2])
 			reagents.add_reagent(rid,max(1,rtotal))
 

--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -48,7 +48,7 @@
 	dat += "<tr><td><b>Potency</b></td><td>[grown_seed.potency]</td></tr>"
 	dat += "</table>"
 
-	if(grown_reagents && grown_reagents.reagent_list && grown_reagents.reagent_list.len)
+	if(grown_reagents && LAZYLEN(grown_reagents.reagent_list))
 		dat += "<h2>Reagent Data</h2>"
 		dat += "<br>This sample contains: "
 		for(var/datum/reagent/R in grown_reagents.reagent_list)
@@ -64,8 +64,8 @@
 	else if(grown_seed.immutable > 0)
 		dat += "This plant does not possess genetics that are alterable.<br>"
 
-	if(grown_seed.products && grown_seed.products.len)
-		dat += "The mature plant will produce [grown_seed.products.len == 1 ? "fruit" : "[grown_seed.products.len] varieties of fruit"].<br>"
+	if(LAZYLEN(grown_seed.products))
+		dat += "The mature plant will produce [length(grown_seed.products) == 1 ? "fruit" : "[length(grown_seed.products)] varieties of fruit"].<br>"
 
 	if(grown_seed.requires_nutrients)
 		if(grown_seed.nutrient_consumption < 0.05)
@@ -83,7 +83,7 @@
 		else
 			dat += "It requires a stable supply of water.<br>"
 
-	if(grown_seed.mutants && grown_seed.mutants.len)
+	if(LAZYLEN(grown_seed.mutants))
 		dat += "It exhibits a high degree of potential subspecies shift.<br>"
 
 	dat += "It thrives in a temperature of [grown_seed.ideal_heat] Kelvin."

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -262,7 +262,7 @@
 		pestlevel = 0
 
 	// If enough time (in cycles, not ticks) has passed since the plant was harvested, we're ready to harvest again.
-	else if(seed.products && seed.products.len && age > seed.production && (age - lastproduce) > seed.production && (!harvest && !dead))
+	else if(LAZYLEN(seed.products) && age > seed.production && (age - lastproduce) > seed.production && (!harvest && !dead))
 		harvest = 1
 		lastproduce = age
 
@@ -448,7 +448,7 @@
 		return
 
 	// Check if we should even bother working on the current seed datum.
-	if(seed.mutants && seed.mutants.len && severity > 1)
+	if(LAZYLEN(seed.mutants) && severity > 1)
 		mutate_species()
 		return
 

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -27,7 +27,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 	for(var/type in typesof(/datum/seed)-/datum/seed)
 		var/datum/seed/S = new type
 		GLOB.seed_types[S.name] = S
-		S.uid = "[GLOB.seed_types.len]"
+		S.uid = "[length(GLOB.seed_types)]"
 		S.roundstart = 1
 
 	// Make sure any seed packets that were mapped in are updated
@@ -45,7 +45,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 	var/list/gene_tags = list("products","consumption","environment","resistance","vigour","flowers")
 	var/list/used_masks = list()
 
-	while(gene_tags && gene_tags.len)
+	while(LAZYLEN(gene_tags))
 		var/gene_tag = pick(gene_tags)
 		var/gene_mask = "[num2hex(rand(0,255))] - [gene_tag]"
 
@@ -250,7 +250,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 			)
 
 		for(var/x=1;x<=additional_chems;x++)
-			if(!possible_chems.len)
+			if(!length(possible_chems))
 				break
 			var/new_chem = pick(possible_chems)
 			possible_chems -= new_chem
@@ -311,7 +311,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 
 //Returns a key corresponding to an entry in the global seed list.
 /datum/seed/proc/get_mutant_variant()
-	if(!mutants || !mutants.len || immutable > 0) return 0
+	if(!LAZYLEN(mutants) || immutable > 0) return 0
 	return pick(mutants)
 
 //Mutates the plant overall (randomly).
@@ -400,7 +400,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 		//Splicing products has some detrimental effects on yield and lifespan.
 		if("products")
 
-			if(gene.values.len < 6) return
+			if(length(gene.values) < 6) return
 
 			if(yield > 0)  yield =  max(1,floor(yield*0.85))
 			if(endurance > 0) endurance = max(1,floor(endurance*0.85))
@@ -420,7 +420,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 					chems[rid] = gene_chem.Copy()
 					continue
 
-				for(var/i=1;i<=gene_chem.len;i++)
+				for(var/i=1;i<=length(gene_chem);i++)
 
 					if(isnull(gene_chem[i])) gene_chem[i] = 0
 
@@ -442,7 +442,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 
 		if("consumption")
 
-			if(gene.values.len < 7) return
+			if(length(gene.values) < 7) return
 
 			consume_gasses =    gene.values[1]
 			requires_nutrients =   gene.values[2]
@@ -454,7 +454,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 
 		if("environment")
 
-			if(gene.values.len < 6) return
+			if(length(gene.values) < 6) return
 
 			ideal_heat =    gene.values[1]
 			heat_tolerance =    gene.values[2]
@@ -465,7 +465,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 
 		if("resistance")
 
-			if(gene.values.len < 3) return
+			if(length(gene.values) < 3) return
 
 			toxins_tolerance =  gene.values[1]
 			pest_tolerance =    gene.values[2]
@@ -473,7 +473,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 
 		if("vigour")
 
-			if(gene.values.len < 6) return
+			if(length(gene.values) < 6) return
 
 			endurance = gene.values[1]
 			yield = gene.values[2]
@@ -484,7 +484,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 
 		if("flowers")
 
-			if(gene.values.len < 7) return
+			if(length(gene.values) < 7) return
 
 			product_icon =  gene.values[1]
 			product_color =    gene.values[2]
@@ -571,7 +571,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 		return
 
 	var/got_product
-	if(!isnull(products) && products.len && yield > 0)
+	if(LAZYLEN(products) && yield > 0)
 		got_product = 1
 
 	if(!got_product && !harvest_sample)
@@ -581,7 +581,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 
 		//This may be a new line. Update the global if it is.
 		if(name == "new line" || !(name in GLOB.seed_types))
-			uid = GLOB.seed_types.len + 1
+			uid = length(GLOB.seed_types) + 1
 			name = "[uid]"
 			GLOB.seed_types[name] = src
 

--- a/code/modules/hydroponics/seed_machines/seed_editor.dm
+++ b/code/modules/hydroponics/seed_machines/seed_editor.dm
@@ -17,7 +17,7 @@
 
 	data["disk"] = loaded_disk
 
-	if(loaded_disk && loaded_disk.genes.len)
+	if(loaded_disk && length(loaded_disk.genes))
 		data["sourceName"] = loaded_disk.genesource
 
 		for(var/datum/plantgene/P in loaded_disk.genes)

--- a/code/modules/hydroponics/seed_machines/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines/seed_machines.dm
@@ -31,7 +31,7 @@
 	seed.forceMove(get_turf(src))
 
 	if(seed.seed.name == "new line" || isnull(GLOB.seed_types[seed.seed.name]))
-		seed.seed.uid = GLOB.seed_types.len + 1
+		seed.seed.uid = length(GLOB.seed_types) + 1
 		seed.seed.name = "[seed.seed.uid]"
 		GLOB.seed_types[seed.seed.name] = seed.seed
 
@@ -75,7 +75,7 @@
 		else
 			var/obj/item/disk/botany/B = W
 
-			if(B.genes && B.genes.len)
+			if(LAZYLEN(B.genes))
 				if(!disk_needs_genes)
 					to_chat(user, SPAN_WARNING("That disk already has gene data loaded."))
 					return

--- a/code/modules/hydroponics/vines.dm
+++ b/code/modules/hydroponics/vines.dm
@@ -156,7 +156,7 @@
 				H.updatehealth()
 
 			// Inject some chems.
-			if(seed.chems && seed.chems.len && istype(H))
+			if(LAZYLEN(seed.chems) && istype(H))
 				to_chat(H, SPAN_DANGER("You feel something seeping into your skin!"))
 				for(var/rid in seed.chems)
 					var/injecting = min(5,max(1,seed.potency/5))
@@ -175,7 +175,7 @@
 	// Update flower/product overlay.
 	overlays.Cut()
 	if(age >= seed.maturation)
-		if(prob(20) && seed.products && seed.products.len && !harvest && ((age-lastproduce) > seed.production))
+		if(prob(20) && LAZYLEN(seed.products) && !harvest && ((age-lastproduce) > seed.production))
 			harvest = 1
 			lastproduce = age
 
@@ -319,9 +319,9 @@
 		return
 
 	// Check if we're too big for our own good.
-	if(vines.len >= (seed ? seed.potency * collapse_limit : 250) && !reached_collapse_size)
+	if(length(vines) >= (seed ? seed.potency * collapse_limit : 250) && !reached_collapse_size)
 		reached_collapse_size = 1
-	if(vines.len >= (seed ? seed.potency * slowdown_limit : 30) && !reached_slowdown_size )
+	if(length(vines) >= (seed ? seed.potency * slowdown_limit : 30) && !reached_slowdown_size )
 		reached_slowdown_size = 1
 
 	var/length = 0
@@ -335,7 +335,7 @@
 	else
 		length = 1
 
-	length = min(30, max(length, vines.len/5))
+	length = min(30, max(length, length(vines)/5))
 
 	// Update as many pieces of vine as we're allowed to.
 	// Append updated vines to the end of the growth queue.

--- a/code/modules/mapping/preloader.dm
+++ b/code/modules/mapping/preloader.dm
@@ -9,7 +9,7 @@ GLOBAL_LIST_INIT(_preloader_path, null)
 	var/target_path
 
 /world/proc/preloader_setup(list/the_attributes, path)
-	if(the_attributes.len)
+	if(length(the_attributes))
 		GLOB.use_preloader = TRUE
 		GLOB._preloader_attributes = the_attributes
 		GLOB._preloader_path = path

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -795,8 +795,8 @@ GLOBAL_LIST_EMPTY(map_model_default)
 		// We can skip calling this proc every time we see XXX
 		if(!set_space \
 			&& no_changeturf \
-			&& members_attributes.len == 2 \
-			&& members.len == 2 \
+			&& length(members_attributes) == 2 \
+			&& length(members) == 2 \
 			&& members_attributes[1] == default_list \
 			&& members_attributes[2] == default_list \
 			&& members[2] == world.area \
@@ -878,8 +878,8 @@ GLOBAL_LIST_EMPTY(map_model_default)
 		// We can skip calling this proc every time we see XXX
 		if(!set_space \
 			&& no_changeturf \
-			&& members.len == 2 \
-			&& members_attributes.len == 2 \
+			&& length(members) == 2 \
+			&& length(members_attributes) == 2 \
 			&& length(members_attributes[1]) == 0 \
 			&& length(members_attributes[2]) == 0 \
 			&& (world.area in members) \
@@ -911,7 +911,7 @@ GLOBAL_LIST_EMPTY(map_model_default)
 
 	//The next part of the code assumes there's ALWAYS an /area AND a /turf on a given tile
 	//first instance the /area and remove it from the members list
-	index = members.len
+	index = length(members)
 	var/area/old_area
 	if(members[index] != /area/template_noop)
 		if(members_attributes[index] != default_list)

--- a/code/modules/mapping/space_management/traits.dm
+++ b/code/modules/mapping/space_management/traits.dm
@@ -3,15 +3,15 @@
 	if (!isnum(z) || z < 1)
 		return null
 	if (z_list)
-		if (z > z_list.len)
-			stack_trace("Unmanaged z-level [z]! maxz = [world.maxz], z_list.len = [z_list.len]")
+		if (z > length(z_list))
+			stack_trace("Unmanaged z-level [z]! maxz = [world.maxz], length(z_list) = [length(z_list)]")
 			return list()
 		var/datum/space_level/S = get_level(z)
 		return S.traits[trait]
 	else
 		var/list/default = DEFAULT_MAP_TRAITS
-		if (z > default.len)
-			stack_trace("Unmanaged z-level [z]! maxz = [world.maxz], default.len = [default.len]")
+		if (z > length(default))
+			stack_trace("Unmanaged z-level [z]! maxz = [world.maxz], length(default) = [length(default)]")
 			return list()
 		return default[z][DL_TRAITS][trait]
 

--- a/code/modules/mapping/space_management/zlevel_manager.dm
+++ b/code/modules/mapping/space_management/zlevel_manager.dm
@@ -6,12 +6,12 @@
 	z_list = list()
 	var/list/default_map_traits = DEFAULT_MAP_TRAITS
 
-	if (default_map_traits.len != world.maxz)
-		WARNING("More or less map attributes pre-defined ([default_map_traits.len]) than existent z-levels ([world.maxz]). Ignoring the larger.")
-		if (default_map_traits.len > world.maxz)
+	if (length(default_map_traits) != world.maxz)
+		WARNING("More or less map attributes pre-defined ([length(default_map_traits)]) than existent z-levels ([world.maxz]). Ignoring the larger.")
+		if (length(default_map_traits) > world.maxz)
 			default_map_traits.Cut(world.maxz + 1)
 
-	for (var/I in 1 to default_map_traits.len)
+	for (var/I in 1 to length(default_map_traits))
 		var/list/features = default_map_traits[I]
 		var/datum/space_level/S = new(I, features[DL_NAME], features[DL_TRAITS])
 		manage_z_level(S, filled_with_space = FALSE)
@@ -20,7 +20,7 @@
 /datum/controller/subsystem/mapping/proc/add_new_zlevel(name, traits = list(), z_type = /datum/space_level, contain_turfs = TRUE)
 	UNTIL(!adding_new_zlevel)
 	adding_new_zlevel = TRUE
-	var/new_z = z_list.len + 1
+	var/new_z = length(z_list) + 1
 	if (world.maxz < new_z)
 		world.incrementMaxZ()
 		CHECK_TICK
@@ -34,6 +34,6 @@
 	return S
 
 /datum/controller/subsystem/mapping/proc/get_level(z)
-	if (z_list && z >= 1 && z <= z_list.len)
+	if (z_list && z >= 1 && z <= length(z_list))
 		return z_list[z]
-	CRASH("Unmanaged z-level [z]! maxz = [world.maxz], z_list.len = [z_list ? z_list.len : "null"]")
+	CRASH("Unmanaged z-level [z]! maxz = [world.maxz], length(z_list) = [z_list ? length(z_list) : "null"]")

--- a/code/modules/mapping/verify.dm
+++ b/code/modules/mapping/verify.dm
@@ -21,19 +21,19 @@
 	if(!loadable)
 		html += "<p><b>Not loadable</b>: some tiles are missing their turfs or areas.</p>"
 
-	if(bad_paths.len)
+	if(length(bad_paths))
 		html += "<p>Bad paths: <ol>"
 		for(var/path in bad_paths)
 			var/list/keys = bad_paths[path]
-			html += "<li><tt>[path]</tt>: used in ([keys.len]): <tt>[keys.Join("</tt>, <tt>")]</tt>"
+			html += "<li><tt>[path]</tt>: used in ([length(keys)]): <tt>[keys.Join("</tt>, <tt>")]</tt>"
 		html += "</ol></p>"
 
-	if(bad_keys.len)
+	if(length(bad_keys))
 		html += "<p>Bad keys: <ul>"
 		for(var/key in bad_keys)
 			var/list/messages = bad_keys[key]
 			html += "<li><tt>[key]</tt>"
-			if(messages.len == 1)
+			if(length(messages) == 1)
 				html += ": [bad_keys[key][1]]"
 			else
 				html += "<ul><li>[messages.Join("</li><li>")]</li></ul>"
@@ -74,7 +74,7 @@
 
 		var/turfs = 0
 		var/areas = 0
-		for(var/i in 1 to members.len)
+		for(var/i in 1 to length(members))
 			var/atom/path = members[i]
 
 			turfs += ispath(path, /turf)
@@ -91,7 +91,7 @@
 			LAZYADD(report.bad_keys[key], "[areas] areas instead of 1")
 
 	// return the report
-	if(report.bad_paths.len || report.bad_keys.len || !report.loadable)
+	if(length(report.bad_paths) || length(report.bad_keys) || !report.loadable)
 		// keep the report around so it can be referenced later
 		report.tag = "mapreport_[++report.tag_number]"
 		report.crashed = FALSE

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -628,7 +628,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	var/value = SStechtree.trees[1]
 
-	if(trees.len > 1)
+	if(length(trees) > 1)
 		value = tgui_input_list(src, "Choose which tree to enter", "Enter Tree", trees)
 
 	if(!value)
@@ -655,7 +655,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	for(var/turf/T in get_area_turfs(thearea.type))
 		L+=T
 
-	if(!L || !L.len)
+	if(!LAZYLEN(L))
 		to_chat(src, "<span style='color: red;'>No area available.</span>")
 		return
 
@@ -879,7 +879,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/datum/hive_status/hive
 	for(var/hivenumber in GLOB.hive_datum)
 		hive = GLOB.hive_datum[hivenumber]
-		if(hive.totalXenos.len > 0)
+		if(length(hive.totalXenos) > 0)
 			hives += list("[hive.name]" = hive.hivenumber)
 			last_hive_checked = hive
 

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -18,7 +18,7 @@
 	if(!say_understands(speaker,language))
 		if(istype(speaker,/mob/living/simple_animal))
 			var/mob/living/simple_animal/S = speaker
-			if(S.speak.len)
+			if(length(S.speak))
 				message = pick(S.speak)
 			else
 				message = stars(message)
@@ -189,7 +189,7 @@
 
 		var/list/punctuation = list(",", "!", ".", ";", "?")
 		var/list/messages = splittext(message, " ")
-		var/R = rand(1, messages.len)
+		var/R = rand(1, length(messages))
 		var/heardword = messages[R]
 		if(copytext(heardword,1, 1) in punctuation)
 			heardword = copytext(heardword,2)

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -15,7 +15,7 @@
 
 /obj/item/holder/process()
 
-	if(istype(loc,/turf) || !(contents.len))
+	if(istype(loc,/turf) || !(length(contents)))
 
 		for(var/mob/M in contents)
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -340,7 +340,7 @@
 		if(WEAR_IN_BACK)
 			if (src.back && isstorage(src.back))
 				var/obj/item/storage/B = src.back
-				if(B.contents.len < B.storage_slots && W.w_class <= B.max_w_class)
+				if(length(B.contents) < B.storage_slots && W.w_class <= B.max_w_class)
 					W.forceMove(B)
 					equipped = 1
 		if(WEAR_IN_SHOES)
@@ -353,7 +353,7 @@
 		if(WEAR_IN_SCABBARD)
 			if(src.back && istype(src.back, /obj/item/storage/large_holster))
 				var/obj/item/storage/large_holster/B = src.back
-				if(B.contents.len < B.storage_slots && W.w_class <= B.max_w_class)
+				if(length(B.contents) < B.storage_slots && W.w_class <= B.max_w_class)
 					W.forceMove(B)
 					equipped = 1
 		if(WEAR_IN_ACCESSORY)
@@ -377,25 +377,25 @@
 		if(WEAR_IN_BELT)
 			if(src.belt && isstorage(src.belt))
 				var/obj/item/storage/B = src.belt
-				if(B.contents.len < B.storage_slots && W.w_class <= B.max_w_class)
+				if(length(B.contents) < B.storage_slots && W.w_class <= B.max_w_class)
 					W.forceMove(B)
 					equipped = 1
 		if(WEAR_IN_J_STORE)
 			if(src.s_store && isstorage(src.s_store))
 				var/obj/item/storage/B = src.s_store
-				if(B.contents.len < B.storage_slots && W.w_class <= B.max_w_class)
+				if(length(B.contents) < B.storage_slots && W.w_class <= B.max_w_class)
 					W.forceMove(B)
 					equipped = 1
 		if(WEAR_IN_L_STORE)
 			if(src.l_store && istype(src.l_store, /obj/item/storage/pouch))
 				var/obj/item/storage/pouch/P = src.l_store
-				if(P.contents.len < P.storage_slots && W.w_class <= P.max_w_class)
+				if(length(P.contents) < P.storage_slots && W.w_class <= P.max_w_class)
 					W.forceMove(P)
 					equipped = 1
 		if(WEAR_IN_R_STORE)
 			if(src.r_store && istype(src.r_store, /obj/item/storage/pouch))
 				var/obj/item/storage/pouch/P = src.r_store
-				if(P.contents.len < P.storage_slots && W.w_class <= P.max_w_class)
+				if(length(P.contents) < P.storage_slots && W.w_class <= P.max_w_class)
 					W.forceMove(P)
 					equipped = 1
 

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -60,12 +60,12 @@
 /datum/language/proc/add_to_cache(input, scrambled_text)
 	// Add it to cache, cutting old entries if the list is too long
 	scramble_cache[input] = scrambled_text
-	if(scramble_cache.len > SCRAMBLE_CACHE_LEN)
-		scramble_cache.Cut(1, scramble_cache.len-SCRAMBLE_CACHE_LEN-1)
+	if(length(scramble_cache) > SCRAMBLE_CACHE_LEN)
+		scramble_cache.Cut(1, length(scramble_cache)-SCRAMBLE_CACHE_LEN-1)
 
 /datum/language/proc/scramble(input)
 
-	if(!syllables || !syllables.len)
+	if(!LAZYLEN(syllables))
 		return stars(input)
 
 	// If the input is cached already, move it to the end of the cache and return it

--- a/code/modules/mob/language/language_handling.dm
+++ b/code/modules/mob/language/language_handling.dm
@@ -18,7 +18,7 @@
 	return 0
 
 /mob/proc/get_default_language()
-	if (languages.len > 0)
+	if (length(languages) > 0)
 		return languages[1]
 	return null
 

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -110,9 +110,9 @@
 		//An even amount of each plasma and blood type
 		if(plasma == PLASMA_EGG)
 			//Preserve hive_number for the possible larva
-			O.reagents.add_reagent(plasma, amount / plasmas.len, list("hive_number" = hivenumber))
+			O.reagents.add_reagent(plasma, amount / length(plasmas), list("hive_number" = hivenumber))
 		else
-			O.reagents.add_reagent(plasma, amount / plasmas.len)
+			O.reagents.add_reagent(plasma, amount / length(plasmas))
 
 	blood_volume = max(0, blood_volume - amount)
 	return 1
@@ -142,7 +142,7 @@
 	for(var/datum/disease/D in viruses)
 		blood_data["viruses"] += D.Copy()
 
-	if(resistances && resistances.len)
+	if(LAZYLEN(resistances))
 		blood_data["resistances"] = resistances.Copy()
 
 	return blood_data

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -482,7 +482,7 @@
 
 /mob/living/carbon/on_stored_atom_del(atom/movable/AM)
 	..()
-	if(stomach_contents.len && ismob(AM))
+	if(length(stomach_contents) && ismob(AM))
 		for(var/X in stomach_contents)
 			if(AM == X)
 				stomach_contents -= AM

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -263,7 +263,7 @@
 						wound_flavor_text["[temp.display_name]"] += SPAN_WARNING(pick(" a lot of burns"," severe melting"))
 				if(wound_flavor_text["[temp.display_name]"])
 					wound_flavor_text["[temp.display_name]"] += SPAN_WARNING("!\n")
-			else if(temp.wounds.len > 0)
+			else if(length(temp.wounds) > 0)
 				var/list/wound_descriptors = list()
 				for(var/datum/wound/W as anything in temp.wounds)
 					if(W.internal && incision_depths[temp.name] == SURGERY_DEPTH_SURFACE)
@@ -286,37 +286,37 @@
 						wound_descriptors[this_wound_desc] += W.amount
 						continue
 					wound_descriptors[this_wound_desc] = W.amount
-				if(wound_descriptors.len)
+				if(length(wound_descriptors))
 					var/list/flavor_text = list()
 					var/list/no_exclude = list("gaping wound", "big gaping wound", "massive wound", "large bruise",\
 					"huge bruise", "massive bruise", "severe burn", "large burn", "deep burn", "carbonised area")
 					for(var/wound in wound_descriptors)
 						switch(wound_descriptors[wound])
 							if(1)
-								if(!flavor_text.len)
+								if(!length(flavor_text))
 									flavor_text += SPAN_WARNING("[t_He] has[prob(10) && !(wound in no_exclude)  ? " what might be" : ""] a [wound]")
 								else
 									flavor_text += "[prob(10) && !(wound in no_exclude) ? " what might be" : ""] a [wound]"
 							if(2)
-								if(!flavor_text.len)
+								if(!length(flavor_text))
 									flavor_text += SPAN_WARNING("[t_He] has[prob(10) && !(wound in no_exclude) ? " what might be" : ""] a pair of [wound]s")
 								else
 									flavor_text += "[prob(10) && !(wound in no_exclude) ? " what might be" : ""] a pair of [wound]s"
 							if(3 to 5)
-								if(!flavor_text.len)
+								if(!length(flavor_text))
 									flavor_text += SPAN_WARNING("[t_He] has several [wound]s")
 								else
 									flavor_text += " several [wound]s"
 							if(6 to INFINITY)
-								if(!flavor_text.len)
+								if(!length(flavor_text))
 									flavor_text += SPAN_WARNING("[t_He] has a bunch of [wound]s")
 								else
 									flavor_text += " a ton of [wound]\s"
 					var/flavor_text_string = ""
-					for(var/text = 1, text <= flavor_text.len, text++)
-						if(text == flavor_text.len && flavor_text.len > 1)
+					for(var/text = 1, text <= length(flavor_text), text++)
+						if(text == length(flavor_text) && length(flavor_text) > 1)
 							flavor_text_string += ", and"
-						else if(flavor_text.len > 1 && text > 1)
+						else if(length(flavor_text) > 1 && text > 1)
 							flavor_text_string += ","
 						flavor_text_string += flavor_text[text]
 					flavor_text_string += " on [t_his] [temp.display_name].</span><br>"

--- a/code/modules/mob/living/carbon/human/exercise.dm
+++ b/code/modules/mob/living/carbon/human/exercise.dm
@@ -83,7 +83,7 @@ Verbs related to getting fucking jacked, bro
 		if(!get_limb(zone))
 			extremities.Remove(zone)
 
-	if(extremities.len < 8)
+	if(length(extremities) < 8)
 		to_chat(src, SPAN_WARNING("How do you think you'll be able to do a pushup without two hands and feet to stand on? See a doctor!"))
 		return FALSE
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1000,8 +1000,8 @@
 
 	if(self)
 		var/list/L = get_broken_limbs() - list("chest","head","groin")
-		if(L.len > 0)
-			msg += "Your [english_list(L)] [L.len > 1 ? "are" : "is"] broken\n"
+		if(length(L) > 0)
+			msg += "Your [english_list(L)] [length(L) > 1 ? "are" : "is"] broken\n"
 	to_chat(usr,SPAN_NOTICE("You [self ? "take a moment to analyze yourself":"start analyzing [src]"]"))
 	if(toxloss > 20)
 		msg += "[self ? "Your" : "Their"] skin is slightly green\n"
@@ -1404,13 +1404,13 @@
 				to_splint.Add(l)
 
 		var/msg = "" // Have to use this because there are issues with the to_chat macros and text macros and quotation marks
-		if(to_splint.len)
+		if(length(to_splint))
 			if(do_after(user, HUMAN_STRIP_DELAY * user.get_skill_duration_multiplier(SKILL_MEDICAL), INTERRUPT_ALL, BUSY_ICON_GENERIC, target, INTERRUPT_MOVED, BUSY_ICON_GENERIC))
 				var/can_reach_splints = TRUE
 				var/amount_removed = 0
 				if(wear_suit && istype(wear_suit,/obj/item/clothing/suit/space))
 					var/obj/item/clothing/suit/space/suit = target.wear_suit
-					if(suit.supporting_limbs && suit.supporting_limbs.len)
+					if(LAZYLEN(suit.supporting_limbs))
 						msg = "[user == target ? "your":"\proper [target]'s"]"
 						to_chat(user, SPAN_WARNING("You cannot remove the splints, [msg] [suit] is supporting some of the breaks."))
 						can_reach_splints = FALSE

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -179,7 +179,7 @@
 			for(var/obj/limb/O in limbs)
 				if(O.status & (LIMB_ROBOT|LIMB_DESTROYED|LIMB_MUTATED|LIMB_SYNTHSKIN)) continue
 				candidates |= O
-			if(candidates.len)
+			if(length(candidates))
 				var/obj/limb/O = pick(candidates)
 				O.mutate()
 				to_chat(src, SPAN_NOTICE("Something is not right with your [O.display_name]..."))
@@ -260,7 +260,7 @@
 //It automatically updates health status
 /mob/living/carbon/human/heal_limb_damage(brute, burn)
 	var/list/obj/limb/parts = get_damaged_limbs(brute,burn)
-	if(!parts.len)
+	if(!length(parts))
 		return
 	var/obj/limb/picked = pick(parts)
 	if(brute != 0)
@@ -279,7 +279,7 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 //It automatically updates health status
 /mob/living/carbon/human/take_limb_damage(brute, burn, sharp = 0, edge = 0)
 	var/list/obj/limb/parts = get_damageable_limbs()
-	if(!parts.len) return
+	if(!length(parts)) return
 	var/obj/limb/picked = pick(parts)
 	if(brute != 0)
 		apply_damage(brute, BRUTE, picked, sharp, edge)
@@ -294,7 +294,7 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 	var/list/obj/limb/parts = get_damaged_limbs(brute,burn)
 
 	var/update = 0
-	while(parts.len && (brute>0 || burn>0) )
+	while(length(parts) && (brute>0 || burn>0) )
 		var/obj/limb/picked = pick(parts)
 
 		var/brute_was = picked.brute_dam

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -194,7 +194,7 @@ Contains most of the procs that are called when a mob is attacked by something
 	if((user != src) && check_shields(I.force, "the [I.name]"))
 		return FALSE
 
-	if(I.attack_verb && I.attack_verb.len)
+	if(LAZYLEN(I.attack_verb))
 		visible_message(SPAN_DANGER("<B>[src] has been [pick(I.attack_verb)] in the [hit_area] with [I.name] by [user]!</B>"), null, null, 5)
 	else
 		visible_message(SPAN_DANGER("<B>[src] has been attacked in the [hit_area] with [I.name] by [user]!</B>"), null, null, 5)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -369,7 +369,7 @@
 
 /mob/living/carbon/human/proc/has_foreign_object()
 	for(var/obj/limb/L in limbs)
-		if(L.implants && L.implants.len > 0)
+		if(LAZYLEN(L.implants) > 0)
 			return TRUE
 	for(var/obj/item/alien_embryo/A in contents)
 		return TRUE

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -10,7 +10,7 @@
 	if(species.slowdown)
 		. += species.slowdown
 
-	if(embedded_items.len > 0)
+	if(length(embedded_items) > 0)
 		handle_embedded_objects() //Moving with objects stuck in you can cause bad times.
 
 	var/reducible_tally = 0 //Tally elements that can be reduced are put here, then we apply MST effects

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -198,7 +198,7 @@
 		hud_used.slowed_icon.name = ""
 		hud_used.slowed_icon.icon_state = "status_0"
 
-	var/is_embedded = embedded_items.len
+	var/is_embedded = length(embedded_items)
 	if(is_embedded)
 		hud_used.shrapnel_icon.name = "shrapnel"
 		hud_used.shrapnel_icon.icon_state = "status_shrapnel"
@@ -228,7 +228,7 @@
 		hud_used.tethered_icon.name = ""
 		hud_used.tethered_icon.icon_state = "status_0"
 
-	if(active_transfusions.len)
+	if(length(active_transfusions))
 		hud_used.tethered_icon.name = "transfusion"
 		hud_used.tethered_icon.icon_state = "status_blood"
 		hud_used.tethered_icon.screen_loc = ui_datum.get_status_loc(status_effect_placement)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -158,7 +158,7 @@
 
 			for(var/mob/living/M in hearers(message_range, src))
 				if(M != src)
-					M.show_message(SPAN_NOTICE("[src] talks into [used_radios.len ? used_radios[1] : "the radio."]"), SHOW_MESSAGE_VISIBLE)
+					M.show_message(SPAN_NOTICE("[src] talks into [length(used_radios) ? used_radios[1] : "the radio."]"), SHOW_MESSAGE_VISIBLE)
 			if(ishumansynth_strict(src))
 				playsound(src.loc, 'sound/effects/radiostatic.ogg', 15, 1)
 

--- a/code/modules/mob/living/carbon/human/species/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/monkey.dm
@@ -70,7 +70,7 @@
 		for(var/obj/O in range(1,get_turf(H)))
 			if(O.Adjacent(H))
 				touchables += O
-		if(touchables.len)
+		if(length(touchables))
 			var/obj/touchy = pick(touchables)
 			touchy.attack_hand(H)
 

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -401,7 +401,7 @@
 
 /datum/species/proc/get_offset_overlay_image(spritesheet, mob_icon, mob_state, color, slot)
 	// If we don't actually need to offset this, don't bother with any of the generation/caching.
-	if(!spritesheet && equip_adjust.len && equip_adjust[slot] && LAZYLEN(equip_adjust[slot]))
+	if(!spritesheet && length(equip_adjust) && equip_adjust[slot] && LAZYLEN(equip_adjust[slot]))
 
 		// Check the cache for previously made icons.
 		var/image_key = "[mob_icon]-[mob_state]-[color]"

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -476,7 +476,7 @@ Applied by gun suicide and high impact bullet executions, removed by rejuvenate,
 					apply_overlay(HEAD_SQUAD_LAYER)
 
 			var/num_helmet_overlays = 0
-			for(var/i in 1 to marine_helmet.helmet_overlays.len)
+			for(var/i in 1 to length(marine_helmet.helmet_overlays))
 				// Add small numbers to the head garb layer so we don't have a layer conflict
 				// the i-1 bit is to make it 0-based, not 1-based like BYOND wants
 				overlays_standing[HEAD_GARB_LAYER + (i-1)] = image('icons/mob/humans/onmob/helmet_garb.dmi', src, marine_helmet.helmet_overlays[i])
@@ -537,7 +537,7 @@ Applied by gun suicide and high impact bullet executions, removed by rejuvenate,
 					overlays_standing[SUIT_SQUAD_LAYER] = squad_overlay
 					apply_overlay(SUIT_SQUAD_LAYER)
 
-			if(marine_armor.armor_overlays.len)
+			if(length(marine_armor.armor_overlays))
 				var/image/K
 				var/image/IMG
 				for(var/i in marine_armor.armor_overlays)

--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -104,7 +104,7 @@
 			M << speech_bubble
 		M.hear_say(message, verb, speaking, alt_name, italics, src)
 
-	if (eavesdropping.len)
+	if (length(eavesdropping))
 		var/new_message = stars(message) //hopefully passing the message twice through stars() won't hurt... I guess if you already don't understand the language, when they speak it too quietly to hear normally you would be able to catch even less.
 		for(var/mob/M in eavesdropping)
 			if(not_dead_speaker)
@@ -120,7 +120,7 @@
 			for(var/mob/M in eavesdropping)
 				if(M.client) M.client.images -= speech_bubble
 
-	if (watching.len)
+	if (length(watching))
 		var/rendered = "<span class='game say'><span class='name'>[src.name]</span> whispers something.</span>"
 		for (var/mob/M in watching)
 			M.show_message(rendered, SHOW_MESSAGE_AUDIBLE)

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -15,7 +15,7 @@
 		if(3)
 			fontsize_style = "large"
 
-	if(SSticker.mode && SSticker.mode.xenomorphs.len) //Send to only xenos in our gamemode list. This is faster than scanning all mobs
+	if(SSticker.mode && length(SSticker.mode.xenomorphs)) //Send to only xenos in our gamemode list. This is faster than scanning all mobs
 		for(var/datum/mind/L in SSticker.mode.xenomorphs)
 			var/mob/living/carbon/M = L.current
 			if(M && istype(M) && !M.stat && M.client && (!hivenumber || M.hivenumber == hivenumber)) //Only living and connected xenos
@@ -26,7 +26,7 @@
 	if(text == "" || !hivenumber)
 		return //Logic
 
-	if(SSticker.mode && SSticker.mode.xenomorphs.len) //Send to only xenos in our gamemode list. This is faster than scanning all mobs
+	if(SSticker.mode && length(SSticker.mode.xenomorphs)) //Send to only xenos in our gamemode list. This is faster than scanning all mobs
 		for(var/datum/mind/living in SSticker.mode.xenomorphs)
 			var/mob/living/carbon/xenomorph/xeno = living.current
 			if(istype(xeno) && !xeno.stat && xeno.client && xeno.hivenumber == hivenumber) //Only living and connected xenos
@@ -370,13 +370,13 @@
 
 //Bleuugh
 /mob/living/carbon/xenomorph/proc/empty_gut()
-	if(stomach_contents.len)
+	if(length(stomach_contents))
 		for(var/atom/movable/S in stomach_contents)
 			stomach_contents.Remove(S)
 			S.acid_damage = 0 //Reset the acid damage
 			S.forceMove(get_true_turf(src))
 
-	if(contents.len) //Get rid of anything that may be stuck inside us as well
+	if(length(contents)) //Get rid of anything that may be stuck inside us as well
 		for(var/atom/movable/A in contents)
 			A.forceMove(get_true_turf(src))
 
@@ -392,7 +392,7 @@
 	update_sight()
 
 /mob/living/carbon/xenomorph/proc/regurgitate(mob/living/victim, stuns = FALSE)
-	if(stomach_contents.len)
+	if(length(stomach_contents))
 		if(victim)
 			stomach_contents.Remove(victim)
 			victim.acid_damage = 0

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
@@ -289,7 +289,7 @@
 	for(var/turf/T in turflist)
 		distance++
 
-		if(!prev_turf && turflist.len > 1)
+		if(!prev_turf && length(turflist) > 1)
 			prev_turf = get_turf(src)
 			continue //So we don't burn the tile we be standin on
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -111,9 +111,9 @@
 	var/mob/living/carbon/xenomorph/X = owner
 	if(!X.check_state())
 		return
-	for(var/i in 1 to X.caste.spit_types.len)
+	for(var/i in 1 to length(X.caste.spit_types))
 		if(X.ammo == GLOB.ammo_list[X.caste.spit_types[i]])
-			if(i == X.caste.spit_types.len)
+			if(i == length(X.caste.spit_types))
 				X.ammo = GLOB.ammo_list[X.caste.spit_types[1]]
 			else
 				X.ammo = GLOB.ammo_list[X.caste.spit_types[i+1]]
@@ -132,7 +132,7 @@
 		to_chat(X, SPAN_WARNING("We cannot regurgitate here."))
 		return
 
-	if(X.stomach_contents.len)
+	if(length(X.stomach_contents))
 		for(var/mob/living/M in X.stomach_contents)
 			// Also has good reason to be a proc on all Xenos
 			X.regurgitate(M, TRUE)
@@ -367,7 +367,7 @@
 		SEND_SIGNAL(src, COMSIG_XENO_START_EMIT_PHEROMONES, pheromone)
 		playsound(loc, "alien_drool", 25)
 
-	if(isqueen(src) && hive && hive.xeno_leader_list.len && anchored)
+	if(isqueen(src) && hive && length(hive.xeno_leader_list) && anchored)
 		for(var/mob/living/carbon/xenomorph/L in hive.xeno_leader_list)
 			L.handle_xeno_leader_pheromones()
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_powers.dm
@@ -69,7 +69,7 @@
 		current_mob.apply_armoured_damage(get_xeno_damage_slash(current_mob, damage), ARMOR_MELEE, BRUTE, null, 20)
 		playsound(current_mob, 'sound/weapons/alien_tail_attack.ogg', 30, TRUE)
 
-	if (target_mobs.len >= shield_regen_threshold)
+	if (length(target_mobs) >= shield_regen_threshold)
 		var/datum/behavior_delegate/praetorian_vanguard/behavior = source_xeno.behavior_delegate
 		if (istype(behavior))
 			behavior.regen_shield()
@@ -133,7 +133,7 @@
 		H.apply_armoured_damage(get_xeno_damage_slash(H, damage), ARMOR_MELEE, BRUTE)
 		playsound(get_turf(H), "alien_claw_flesh", 30, 1)
 
-	if (target_mobs.len >= shield_regen_threshold)
+	if (length(target_mobs) >= shield_regen_threshold)
 		var/datum/behavior_delegate/praetorian_vanguard/behavior = X.behavior_delegate
 		if (istype(behavior))
 			behavior.regen_shield()

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -216,8 +216,8 @@
 		return
 	var/datum/hive_status/hive = X.hive
 	if(X.observed_xeno)
-		if(!hive.open_xeno_leader_positions.len && X.observed_xeno.hive_pos == NORMAL_XENO)
-			to_chat(X, SPAN_XENOWARNING("You currently have [hive.xeno_leader_list.len] promoted leaders. You may not maintain additional leaders until your power grows."))
+		if(!length(hive.open_xeno_leader_positions) && X.observed_xeno.hive_pos == NORMAL_XENO)
+			to_chat(X, SPAN_XENOWARNING("You currently have [length(hive.xeno_leader_list)] promoted leaders. You may not maintain additional leaders until your power grows."))
 			return
 		var/mob/living/carbon/xenomorph/T = X.observed_xeno
 		if(T == X)
@@ -239,12 +239,12 @@
 		for(var/mob/living/carbon/xenomorph/T in hive.xeno_leader_list)
 			possible_xenos += T
 
-		if(possible_xenos.len > 1)
+		if(length(possible_xenos) > 1)
 			var/mob/living/carbon/xenomorph/selected_xeno = tgui_input_list(X, "Target", "Watch which leader?", possible_xenos, theme="hive_status")
 			if(!selected_xeno || selected_xeno.hive_pos == NORMAL_XENO || selected_xeno == X.observed_xeno || selected_xeno.stat == DEAD || selected_xeno.z != X.z || !X.check_state())
 				return
 			X.overwatch(selected_xeno)
-		else if(possible_xenos.len)
+		else if(length(possible_xenos))
 			X.overwatch(possible_xenos[1])
 		else
 			to_chat(X, SPAN_XENOWARNING("There are no Xenomorph leaders. Overwatch a Xenomorph to make it a leader."))

--- a/code/modules/mob/living/carbon/xenomorph/castes/Crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Crusher.dm
@@ -184,7 +184,7 @@
 				. = FALSE
 			else if (O.anchored)
 				visible_message(SPAN_DANGER("[src] crushes [O]!"), SPAN_XENODANGER("We crush [O]!"))
-				if(O.contents.len) //Hopefully won't auto-delete things inside crushed stuff.
+				if(length(O.contents)) //Hopefully won't auto-delete things inside crushed stuff.
 					var/turf/T = get_turf(src)
 					for(var/atom/movable/S in T.contents) S.forceMove(T)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -534,14 +534,14 @@
 			if(egg_amount >= 1)
 				if(isturf(loc))
 					var/turf/T = loc
-					if(T.contents.len <= 25) //so we don't end up with a million object on that turf.
+					if(length(T.contents) <= 25) //so we don't end up with a million object on that turf.
 						egg_amount--
 						new /obj/item/xeno_egg(loc, hivenumber)
 
 /mob/living/carbon/xenomorph/queen/get_status_tab_items()
 	. = ..()
 	var/stored_larvae = GLOB.hive_datum[hivenumber].stored_larva
-	var/xeno_leader_num = hive?.queen_leader_limit - hive?.open_xeno_leader_positions.len
+	var/xeno_leader_num = hive?.queen_leader_limit - length(hive?.open_xeno_leader_positions)
 
 	. += "Pooled Larvae: [stored_larvae]"
 	. += "Leaders: [xeno_leader_num] / [hive?.queen_leader_limit]"

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -54,7 +54,7 @@
 
 	last_damage_data = istype(cause_data) ? cause_data : create_cause_data(cause_data)
 
-	if(severity > EXPLOSION_THRESHOLD_LOW && stomach_contents.len)
+	if(severity > EXPLOSION_THRESHOLD_LOW && length(stomach_contents))
 		for(var/mob/M in stomach_contents)
 			M.ex_act(severity - EXPLOSION_THRESHOLD_LOW, last_damage_data, pierce)
 
@@ -170,7 +170,7 @@
 		return
 
 	var/shielded = FALSE
-	if(xeno_shields.len != 0 && damage > 0)
+	if(length(xeno_shields) != 0 && damage > 0)
 		shielded = TRUE
 		for(var/datum/xeno_shield/XS in xeno_shields)
 			damage = XS.on_hit(damage)

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -292,15 +292,15 @@
 	//No leaders for a Hive without a Queen!
 	queen_leader_limit = living_xeno_queen ? 4 : 0
 
-	if (xeno_leader_list.len > queen_leader_limit)
+	if (length(xeno_leader_list) > queen_leader_limit)
 		var/diff = 0
-		for (var/i in queen_leader_limit + 1 to xeno_leader_list.len)
+		for (var/i in queen_leader_limit + 1 to length(xeno_leader_list))
 			if(!open_xeno_leader_positions.Remove(i))
 				remove_hive_leader(xeno_leader_list[i])
 			diff++
 		xeno_leader_list.len -= diff // Changing the size of xeno_leader_list needs to go at the end or else it won't iterate through the list properly
-	else if (xeno_leader_list.len < queen_leader_limit)
-		for (var/i in xeno_leader_list.len + 1 to queen_leader_limit)
+	else if (length(xeno_leader_list) < queen_leader_limit)
+		for (var/i in length(xeno_leader_list) + 1 to queen_leader_limit)
 			open_xeno_leader_positions += i
 			xeno_leader_list.len++
 
@@ -309,7 +309,7 @@
 /datum/hive_status/proc/add_hive_leader(mob/living/carbon/xenomorph/xeno)
 	if(!xeno)
 		return FALSE //How did this even happen?
-	if(!open_xeno_leader_positions.len)
+	if(!length(open_xeno_leader_positions))
 		return FALSE //Too many leaders already (no available xeno leader positions)
 	if(xeno.hive_pos != NORMAL_XENO)
 		return FALSE //Already on the list
@@ -342,7 +342,7 @@
 
 	// Need to maintain ascending order of open_xeno_leader_positions
 	for (var/i in 1 to queen_leader_limit)
-		if (i > open_xeno_leader_positions.len || open_xeno_leader_positions[i] > leader_num)
+		if (i > length(open_xeno_leader_positions) || open_xeno_leader_positions[i] > leader_num)
 			open_xeno_leader_positions.Insert(i, leader_num)
 			break
 
@@ -626,7 +626,7 @@
 /datum/hive_status/proc/has_structure(structure_name)
 	if(!structure_name)
 		return FALSE
-	if(hive_structures[structure_name] && hive_structures[structure_name].len)
+	if(LAZYLEN(hive_structures[structure_name]))
 		return TRUE
 	return FALSE
 
@@ -636,7 +636,7 @@
 	var/name_ref = initial(S.template.name)
 	if(!hive_constructions[name_ref])
 		hive_constructions[name_ref] = list()
-	if(hive_constructions[name_ref].len >= hive_structures_limit[name_ref])
+	if(length(hive_constructions[name_ref]) >= hive_structures_limit[name_ref])
 		return FALSE
 	hive_constructions[name_ref] += src
 	return TRUE
@@ -654,7 +654,7 @@
 	var/name_ref = initial(S.name)
 	if(!hive_structures[name_ref])
 		hive_structures[name_ref] = list()
-	if(hive_structures[name_ref].len >= hive_structures_limit[name_ref])
+	if(length(hive_structures[name_ref]) >= hive_structures_limit[name_ref])
 		return FALSE
 	hive_structures[name_ref] += S
 	return TRUE
@@ -667,9 +667,9 @@
 	return TRUE
 
 /datum/hive_status/proc/has_special_structure(name_ref)
-	if(!name_ref || !hive_structures[name_ref] || !hive_structures[name_ref].len)
+	if(!name_ref || !LAZYLEN(hive_structures[name_ref]))
 		return 0
-	return hive_structures[name_ref].len
+	return length(hive_structures[name_ref])
 
 /datum/hive_status/proc/abandon_on_hijack()
 	var/area/hijacked_dropship = get_area(living_xeno_queen)
@@ -686,7 +686,7 @@
 		if(get_area(xeno) != hijacked_dropship && xeno.loc && is_ground_level(xeno.loc.z))
 			if(isfacehugger(xeno) || islesserdrone(xeno))
 				to_chat(xeno, SPAN_XENOANNOUNCE("The Queen has left without you, you quickly find a hiding place to enter hibernation as you lose touch with the hive mind."))
-				if(xeno.stomach_contents.len)
+				if(length(xeno.stomach_contents))
 					xeno.devour_timer = 0
 					xeno.handle_stomach_contents()
 				qdel(xeno)
@@ -696,7 +696,7 @@
 				xeno.set_hive_and_update(XENO_HIVE_FORSAKEN)
 			else
 				to_chat(xeno, SPAN_XENOANNOUNCE("The Queen has left without you, you quickly find a hiding place to enter hibernation as you lose touch with the hive mind."))
-				if(xeno.stomach_contents.len)
+				if(length(xeno.stomach_contents))
 					xeno.devour_timer = 0
 					xeno.handle_stomach_contents()
 				qdel(xeno)
@@ -847,7 +847,7 @@
 		var/time_left = floor((user.timeofdeath + JOIN_AS_FACEHUGGER_DELAY - world.time) / 10)
 		to_chat(user, SPAN_WARNING("You ghosted too recently. You cannot become a facehugger until 3 minutes have passed ([time_left] seconds remaining)."))
 		return FALSE
-	if(totalXenos.len <= 0)
+	if(length(totalXenos) <= 0)
 		//This is to prevent people from joining as Forsaken Huggers on the pred ship
 		to_chat(user, SPAN_WARNING("The hive has fallen, you can't join it!"))
 		return FALSE
@@ -910,7 +910,7 @@
 		to_chat(user, SPAN_WARNING("You ghosted too recently. You cannot become a lesser drone until 30 seconds have passed ([time_left] seconds remaining)."))
 		return FALSE
 
-	if(totalXenos.len <= 0)
+	if(length(totalXenos) <= 0)
 		to_chat(user, SPAN_WARNING("The hive has fallen, you can't join it!"))
 		return FALSE
 

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -220,7 +220,7 @@
 
 /mob/living/carbon/xenomorph/proc/handle_stomach_contents()
 	//Deal with dissolving/damaging stuff in stomach.
-	if(stomach_contents.len)
+	if(length(stomach_contents))
 		for(var/atom/movable/M in stomach_contents)
 			if(ishuman(M))
 				if(world.time > devour_timer - 50 && world.time < devour_timer - 30)
@@ -481,7 +481,7 @@ Make sure their actual health updates immediately.*/
 	if(status_flags & GODMODE)
 		health = maxHealth
 		set_stat(CONSCIOUS)
-	else if(xeno_shields.len != 0)
+	else if(length(xeno_shields) != 0)
 		overlay_shields()
 		health = maxHealth - getFireLoss() - getBruteLoss()
 	else

--- a/code/modules/mob/living/carbon/xenomorph/say.dm
+++ b/code/modules/mob/living/carbon/xenomorph/say.dm
@@ -22,14 +22,14 @@
 
 	var/datum/language/speaking = null
 	if(length(message) >= 2)
-		if(can_hivemind_speak && copytext(message,1,2) == ";" && languages.len)
+		if(can_hivemind_speak && copytext(message,1,2) == ";" && length(languages))
 			for(var/datum/language/L in languages)
 				if(L.flags & HIVEMIND)
 					verb = L.speech_verb
 					speaking = L
 					break
 		var/channel_prefix = copytext(message, 1, 3)
-		if(languages.len)
+		if(length(languages))
 			for(var/datum/language/L in languages)
 				if(lowertext(channel_prefix) == ":[L.key]" || lowertext(channel_prefix) == ".[L.key]")
 					verb = L.speech_verb

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/runner/acid.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/runner/acid.dm
@@ -96,7 +96,7 @@
 		var/amplitude = 50 + 50 * (caboom_timer - caboom_left) / caboom_timer
 		playsound(bound_xeno, caboom_sound[caboom_loop], amplitude, FALSE, 10)
 		caboom_loop++
-		if(caboom_loop > caboom_sound.len)
+		if(caboom_loop > length(caboom_sound))
 			caboom_loop = 1
 	if(caboom_left <= 0)
 		caboom_trigger = FALSE

--- a/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
@@ -2,7 +2,7 @@
 	return (mob_size < MOB_SIZE_BIG && caste.can_vent_crawl)
 
 /mob/living/carbon/xenomorph/ventcrawl_carry()
-	if(stomach_contents.len)
+	if(length(stomach_contents))
 		for(var/mob/living/carbon/human/H in stomach_contents)
 			if(!isspeciesmonkey(H))
 				to_chat(src, SPAN_XENOWARNING("You cannot ventcrawl with [H] inside you!"))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -66,7 +66,7 @@
 /mob/living/proc/burn_skin(burn_amount)
 	if(ishuman(src))
 		var/mob/living/carbon/human/H = src //make this damage method divide the damage to be done among all the body parts, then burn each body part for that much damage. will have better effect then just randomly picking a body part
-		var/divided_damage = (burn_amount)/(H.limbs.len)
+		var/divided_damage = (burn_amount)/(length(H.limbs))
 		var/extradam = 0 //added to when organ is at max dam
 		for(var/obj/limb/affecting in H.limbs)
 			if(!affecting) continue
@@ -472,7 +472,7 @@
 
 /mob/living/create_clone_movable(shift_x, shift_y)
 	..()
-	src.clone.hud_list = new /list(src.hud_list.len)
+	src.clone.hud_list = new /list(length(src.hud_list))
 	for(var/h in src.hud_possible) //Clone HUD
 		src.clone.hud_list[h] = new /image("loc" = src.clone, "icon" = src.hud_list[h].icon)
 

--- a/code/modules/mob/living/living_healthscan.dm
+++ b/code/modules/mob/living/living_healthscan.dm
@@ -439,7 +439,7 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 						"icon" = "window-close",
 						"color" = "red"
 						))
-		if(advice.len)
+		if(length(advice))
 			data["advice"] = advice
 		else
 			data["advice"] = null // interstingly even if we don't set data at all, re-using UI that had this data still has it
@@ -457,7 +457,7 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 					"cure" = disease.cure
 				)
 				diseases += list(current_disease)
-		if(diseases.len)
+		if(length(diseases))
 			data["diseases"] = diseases
 		else
 			data["diseases"] = null // interstingly even if we don't set data at all, re-using UI that had this data still has it
@@ -633,7 +633,7 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 	if(ishuman(src))
 		var/mob/living/carbon/human/H = src
 
-		if(H.embedded_items.len > 0)
+		if(length(H.embedded_items) > 0)
 			embedded_item_detected = TRUE
 
 		var/core_fracture = 0
@@ -665,7 +665,7 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 					reagentdata["[R.id]"] = "[R.overdose != 0 && R.volume > R.overdose && !(R.flags & REAGENT_CANNOT_OVERDOSE) ? SPAN_WARNING("<b>OD: </b>") : ""] <font color='#9773C4'><b>[round(R.volume, 1)]u [R.name]</b></font>"
 				else
 					unknown++
-			if(reagentdata.len)
+			if(length(reagentdata))
 				dat += "\n\tBeneficial reagents:\n"
 				for(var/d in reagentdata)
 					dat += "\t\t [reagentdata[d]]\n"

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -6,7 +6,7 @@
 
 	..()
 
-	if(pipes_shown && pipes_shown.len) //ventcrawling, need to reapply pipe vision
+	if(LAZYLEN(pipes_shown)) //ventcrawling, need to reapply pipe vision
 		var/obj/structure/pipes/A = loc
 		if(istype(A)) //a sanity check just to be safe
 			remove_ventcrawl()

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -39,10 +39,10 @@
 	. = ..()
 	if(.)
 		//chance to go crazy and start wacking stuff
-		if(!enemies.len && prob(1))
+		if(!length(enemies) && prob(1))
 			Retaliate()
 
-		if(enemies.len && prob(10))
+		if(length(enemies) && prob(10))
 			enemies = list()
 			LoseTarget()
 			src.visible_message(SPAN_NOTICE("[src] calms down."))

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
@@ -13,7 +13,7 @@
 			enemies -= L
 
 /mob/living/simple_animal/hostile/retaliate/ListTargets()
-	if(!enemies.len)
+	if(!length(enemies))
 		return list()
 	var/list/see = ..()
 	see &= enemies // Remove all entries that aren't in enemies

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -122,7 +122,7 @@
 			switch(remove_from)
 				if("ears")
 					if(ears)
-						if(available_channels.len)
+						if(length(available_channels))
 							src.say("[pick(available_channels)] BAWWWWWK LEAVE THE HEADSET BAWKKKKK!")
 						else
 							src.say("BAWWWWWK LEAVE THE HEADSET BAWKKKKK!")
@@ -276,8 +276,8 @@
 	   Phrases that the parrot hears in mob/living/say() get added to speach_buffer.
 	   Every once in a while, the parrot picks one of the lines from the buffer and replaces an element of the 'speech' list.
 	   Then it clears the buffer to make sure they dont magically remember something from hours ago. */
-	if(speech_buffer.len && prob(10))
-		if(speak.len)
+	if(length(speech_buffer) && prob(10))
+		if(length(speak))
 			speak.Remove(pick(speak))
 
 		speak.Add(pick(speech_buffer))
@@ -304,10 +304,10 @@
 			parrot_sleep_dur = parrot_sleep_max
 
 			//Cycle through message modes for the headset
-			if(speak.len)
+			if(length(speak))
 				var/list/newspeak = list()
 
-				if(available_channels.len && src.ears)
+				if(length(available_channels) && src.ears)
 					for(var/possible_phrase in speak)
 
 						//50/50 chance to not use the radio at all
@@ -685,7 +685,7 @@
 		return
 
 	var/verb = "says"
-	if(speak_emote.len)
+	if(length(speak_emote))
 		verb = pick(speak_emote)
 
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -109,33 +109,33 @@
 	//Speaking
 	if(!client && speak_chance)
 		if(rand(0,200) < speak_chance)
-			if(speak && speak.len)
-				if((emote_hear && emote_hear.len) || (emote_see && emote_see.len))
-					var/length = speak.len
-					if(emote_hear && emote_hear.len)
-						length += emote_hear.len
-					if(emote_see && emote_see.len)
-						length += emote_see.len
+			if(LAZYLEN(speak))
+				if(LAZYLEN(emote_hear) || LAZYLEN(emote_see))
+					var/length = length(speak)
+					if(LAZYLEN(emote_hear))
+						length += length(emote_hear)
+					if(LAZYLEN(emote_see))
+						length += length(emote_see)
 					var/randomValue = rand(1,length)
-					if(randomValue <= speak.len)
+					if(randomValue <= length(speak))
 						INVOKE_ASYNC(src, PROC_REF(say), pick(speak))
 					else
-						randomValue -= speak.len
-						if(emote_see && randomValue <= emote_see.len)
+						randomValue -= length(speak)
+						if(emote_see && randomValue <= length(emote_see))
 							INVOKE_ASYNC(src, PROC_REF(manual_emote), pick(emote_see),1)
 						else
 							INVOKE_ASYNC(src, PROC_REF(manual_emote), pick(emote_hear),2)
 				else
 					INVOKE_ASYNC(src, PROC_REF(say), pick(speak))
 			else
-				if(!(emote_hear && emote_hear.len) && (emote_see && emote_see.len))
+				if(!LAZYLEN(emote_hear) && LAZYLEN(emote_see))
 					INVOKE_ASYNC(src, PROC_REF(manual_emote), pick(emote_see),1)
-				if((emote_hear && emote_hear.len) && !(emote_see && emote_see.len))
+				if(LAZYLEN(emote_hear) && !LAZYLEN(emote_see))
 					INVOKE_ASYNC(src, PROC_REF(manual_emote), pick(emote_hear),2)
-				if((emote_hear && emote_hear.len) && (emote_see && emote_see.len))
-					var/length = emote_hear.len + emote_see.len
+				if(LAZYLEN(emote_hear) && LAZYLEN(emote_see))
+					var/length = length(emote_hear) + length(emote_see)
 					var/pick = rand(1,length)
-					if(pick <= emote_see.len)
+					if(pick <= length(emote_see))
 						INVOKE_ASYNC(src, PROC_REF(manual_emote), pick(emote_see),1)
 					else
 						INVOKE_ASYNC(src, PROC_REF(manual_emote), pick(emote_hear),2)
@@ -352,7 +352,7 @@
 
 	var/verb = "says"
 
-	if(speak_emote.len)
+	if(length(speak_emote))
 		verb = pick(speak_emote)
 
 	message = capitalize(trim_left(message))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -771,7 +771,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 	else
 		visible_message(SPAN_WARNING("<b>[usr] rips [selection] out of [src]'s body.</b>"),SPAN_WARNING("<b>[usr] rips [selection] out of your body.</b>"), null, 5)
 
-	if(valid_objects.len == 1) //Yanking out last object - removing verb.
+	if(length(valid_objects) == 1) //Yanking out last object - removing verb.
 		remove_verb(src, /mob/proc/yank_out_object)
 
 	if(ishuman(src))

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -397,7 +397,7 @@
 		if(!check_rights(R_SPAWN))
 			return
 
-		if(!languages.len)
+		if(!length(languages))
 			to_chat(usr, "This mob knows no languages.")
 			return
 

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -119,7 +119,7 @@
 		if(pulled.stat == DEAD && !pulled.chestburst)
 			to_chat(xeno, SPAN_WARNING("Ew, [pulled] is already starting to rot."))
 			return 0
-		if(xeno.stomach_contents.len) //Only one thing in the stomach at a time, please
+		if(length(xeno.stomach_contents)) //Only one thing in the stomach at a time, please
 			to_chat(xeno, SPAN_WARNING("You already have something in your belly, there's no way that will fit."))
 			return 0
 			/* Saving this in case we want to allow devouring of dead bodies UNLESS their client is still online somewhere
@@ -138,10 +138,10 @@
 		if(HAS_TRAIT(xeno, TRAIT_CLOAKED)) //cloaked don't show the visible message, so we gotta work around
 			to_chat(pulled, FONT_SIZE_HUGE(SPAN_DANGER("[xeno] is trying to devour you!")))
 		if(do_after(xeno, 50, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE))
-			if(isxeno(pulled.loc) && !xeno.stomach_contents.len)
+			if(isxeno(pulled.loc) && !length(xeno.stomach_contents))
 				to_chat(xeno, SPAN_WARNING("Someone already ate \the [pulled]."))
 				return 0
-			if(xeno.pulling == pulled && !pulled.buckled && (pulled.stat != DEAD || pulled.chestburst) && !xeno.stomach_contents.len) //make sure you've still got them in your claws, and alive
+			if(xeno.pulling == pulled && !pulled.buckled && (pulled.stat != DEAD || pulled.chestburst) && !length(xeno.stomach_contents)) //make sure you've still got them in your claws, and alive
 				if(SEND_SIGNAL(pulled, COMSIG_MOB_DEVOURED, xeno) & COMPONENT_CANCEL_DEVOUR)
 					return FALSE
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -229,11 +229,11 @@ GLOBAL_LIST_INIT(limb_types_by_name, list(
 	var/list/split_phrase = text2list(phrase," ") //Split it up into words.
 	var/list/unstuttered_words = split_phrase.Copy()
 
-	var/max_stutter = min(strength, split_phrase.len)
+	var/max_stutter = min(strength, length(split_phrase))
 	var/stutters = rand(max(max_stutter - 3, 1), max_stutter)
 
 	for(var/i = 0, i < stutters, i++)
-		if (!unstuttered_words.len)
+		if (!length(unstuttered_words))
 			break
 
 		var/word = pick(unstuttered_words)
@@ -268,7 +268,7 @@ GLOBAL_LIST_INIT(limb_types_by_name, list(
 				else // normal stutter
 					word = R.Replace(word, "$1$2-$2$3$4")
 
-		if(prob(3 * strength) && index != unstuttered_words.len - 1) // stammer / pause - don't pause at the end of sentences!
+		if(prob(3 * strength) && index != length(unstuttered_words) - 1) // stammer / pause - don't pause at the end of sentences!
 			word = R.Replace(word, "$0 ...")
 
 		split_phrase[index] = word

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -191,7 +191,7 @@
 				for(var/zone in extremities)
 					if(!(human.get_limb(zone)))
 						extremities.Remove(zone)
-				if(extremities.len < 4)
+				if(length(extremities) < 4)
 					return
 			//now crawl
 			mob.crawling = TRUE

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -264,8 +264,8 @@
 
 	for(var/datum/squad/sq in GLOB.RoleAuthority.squads)
 		if(sq)
-			sq.max_engineers = engi_slot_formula(GLOB.clients.len)
-			sq.max_medics = medic_slot_formula(GLOB.clients.len)
+			sq.max_engineers = engi_slot_formula(length(GLOB.clients))
+			sq.max_medics = medic_slot_formula(length(GLOB.clients))
 
 	var/latejoin_larva_drop = SSticker.mode.latejoin_larva_drop
 

--- a/code/modules/nano/nanomanager.dm
+++ b/code/modules/nano/nanomanager.dm
@@ -97,7 +97,7 @@
 * @return int The number of uis updated
 */
 /datum/nanomanager/proc/update_user_uis(mob/user, src_object = null, ui_key = null)
-	if (isnull(user.open_uis) || !istype(user.open_uis, /list) || open_uis.len == 0)
+	if (isnull(user.open_uis) || !istype(user.open_uis, /list) || length(open_uis) == 0)
 		return 0 // has no open uis
 
 	var/update_count = 0
@@ -118,7 +118,7 @@
 * @return int The number of uis closed
 */
 /datum/nanomanager/proc/close_user_uis(mob/user, src_object = null, ui_key = null)
-	if (isnull(user.open_uis) || !istype(user.open_uis, /list) || open_uis.len == 0)
+	if (isnull(user.open_uis) || !istype(user.open_uis, /list) || length(open_uis) == 0)
 		//testing("nanomanager/close_user_uis mob [user.name] has no open uis")
 		return 0 // has no open uis
 
@@ -128,7 +128,7 @@
 			ui.close()
 			close_count++
 
-	//testing("nanomanager/close_user_uis mob [user.name] closed [open_uis.len] of [close_count] uis")
+	//testing("nanomanager/close_user_uis mob [user.name] closed [length(open_uis_] of [close_count] uis")
 
 	return close_count
 
@@ -151,7 +151,7 @@
 	var/list/uis = open_uis[src_object_key][ui.ui_key]
 	uis.Add(ui)
 	processing_uis.Add(ui)
-	//testing("nanomanager/ui_opened mob [ui.user.name] [ui.src_object:name] [ui.ui_key] - user.open_uis [ui.user.open_uis.len]|uis [uis.len]|processing_uis [processing_uis.len]")
+	//testing("nanomanager/ui_opened mob [ui.user.name] [ui.src_object:name] [ui.ui_key] - user.open_uis [length(ui.user.open_uis)]|uis [length(uis)]|processing_uis [length(processing_uis)]")
 
 /**
 * Remove a /nanoui ui from the list of open uis
@@ -173,7 +173,7 @@
 	var/list/uis = open_uis[src_object_key][ui.ui_key]
 	uis.Remove(ui)
 
-	//testing("nanomanager/ui_closed mob [ui.user.name] [ui.src_object:name] [ui.ui_key] - user.open_uis [ui.user.open_uis.len]|uis [uis.len]|processing_uis [processing_uis.len]")
+	//testing("nanomanager/ui_closed mob [ui.user.name] [ui.src_object:name] [ui.ui_key] - user.open_uis [length(ui.user.open_uis)]|uis [length(uis)]|processing_uis [length(processing_uis)]")
 
 	return 1
 
@@ -204,7 +204,7 @@
 	//testing("nanomanager/user_transferred from mob [oldMob.name] to mob [newMob.name]")
 	if(QDELETED(oldMob) || QDELETED(newMob))
 		return FALSE //ERROR
-	if (isnull(oldMob.open_uis) || !istype(oldMob.open_uis, /list) || open_uis.len == 0)
+	if (isnull(oldMob.open_uis) || !istype(oldMob.open_uis, /list) || length(open_uis) == 0)
 		//testing("nanomanager/user_transferred mob [oldMob.name] has no open uis")
 		return 0 // has no open uis
 

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -386,7 +386,7 @@ nanoui is used to open and update nano browser uis
 		head_content += "<link rel='stylesheet' type='text/css' href='[SSassets.transport.get_asset_url(file)]'> "
 
 	var/template_data_json = "{}" // An empty JSON object
-	if (templates.len > 0)
+	if (length(templates) > 0)
 		template_data_json = strip_improper(json_encode(templates))
 
 	var/url_parameters_json = json_encode(list("src" = "\ref[src]"))

--- a/code/modules/nightmare/nmtasks/mapscheduler.dm
+++ b/code/modules/nightmare/nmtasks/mapscheduler.dm
@@ -16,7 +16,7 @@
 
 /datum/nmtask/scheduler/mapload/proc/register_tainted_bounds(datum/nmtask/task, list/bounds)
 	tainted_bounds.len++
-	tainted_bounds[tainted_bounds.len] = bounds
+	tainted_bounds[length(tainted_bounds)] = bounds
 
 /datum/nmtask/scheduler/mapload/proc/patch_lighting()
 	var/list/tainted = list()

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -20,7 +20,7 @@
 	var/display_name
 
 	var/list/datum/wound/wounds = list()
-	var/number_wounds = 0 // cache the number of wounds, which is NOT wounds.len!
+	var/number_wounds = 0 // cache the number of wounds, which is NOT length(wounds)!
 
 	var/tmp/perma_injury = 0
 
@@ -349,9 +349,9 @@
 				possible_points += parent
 			if(children)
 				possible_points += children
-			if(forbidden_limbs.len)
+			if(length(forbidden_limbs))
 				possible_points -= forbidden_limbs
-			if(possible_points.len)
+			if(length(possible_points))
 				//And pass the damage around, but not the chance to cut the limb off.
 				var/obj/limb/target = pick(possible_points)
 				if(brute_reduced_by == -1)
@@ -483,14 +483,14 @@ This function completely restores a damaged organ to perfect condition.
 
 	// first check whether we can widen an existing wound
 	var/datum/wound/W
-	if(wounds.len > 0 && prob(max(50+(number_wounds-1)*10,90)))
+	if(length(wounds) > 0 && prob(max(50+(number_wounds-1)*10,90)))
 		if((type == CUT || type == BRUISE) && damage >= 5)
 			//we need to make sure that the wound we are going to worsen is compatible with the type of damage...
 			var/compatible_wounds[] = new
 			for(W in wounds)
 				if(W.can_worsen(type, damage)) compatible_wounds += W
 
-			if(compatible_wounds.len)
+			if(length(compatible_wounds))
 				W = pick(compatible_wounds)
 				W.open_wound(damage)
 				if(type != BURN)
@@ -654,7 +654,7 @@ This function completely restores a damaged organ to perfect condition.
 			//configurable regen speed woo, no-regen hardcore or instaheal hugbox, choose your destiny
 			heal_amt = heal_amt * CONFIG_GET(number/organ_regeneration_multiplier)
 			// amount of healing is spread over all the wounds
-			heal_amt = heal_amt / (wounds.len + 1)
+			heal_amt = heal_amt / (length(wounds) + 1)
 			// making it look prettier on scanners
 			heal_amt = round(heal_amt,0.1)
 
@@ -801,7 +801,7 @@ This function completely restores a damaged organ to perfect condition.
 		if(istype(E, /obj/limb/chest) || istype(E, /obj/limb/groin) || istype(E, /obj/limb/head))
 			continue
 		limbs_to_remove += E
-	if(limbs_to_remove.len)
+	if(length(limbs_to_remove))
 		var/obj/limb/L = pick(limbs_to_remove)
 		var/limb_name = L.display_name
 		L.droplimb(0, delete_limb)

--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -56,7 +56,7 @@
 
 // returns 1 if there's a next stage, 0 otherwise
 /datum/wound/proc/init_stage(initial_damage)
-	current_stage = stages.len
+	current_stage = length(stages)
 
 	while(src.current_stage > 1 && src.damage_list[current_stage-1] <= initial_damage / src.amount)
 		src.current_stage--
@@ -108,7 +108,7 @@
 	amount -= healed_damage
 	src.damage -= healed_damage
 
-	while(src.wound_damage() < damage_list[current_stage] && current_stage < src.desc_list.len)
+	while(src.wound_damage() < damage_list[current_stage] && current_stage < length(src.desc_list))
 		current_stage++
 	desc = desc_list[current_stage]
 	src.min_damage = damage_list[current_stage]

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -64,7 +64,7 @@
 				to_chat(user, SPAN_NOTICE("You can't put [P] in [src]!"))
 
 /obj/structure/filingcabinet/attack_hand(mob/user as mob)
-	if(contents.len <= 0)
+	if(length(contents) <= 0)
 		to_chat(user, SPAN_NOTICE("\The [src] is empty."))
 		return
 

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -41,7 +41,7 @@
 
 /obj/item/folder/update_icon()
 	overlays.Cut()
-	if(contents.len)
+	if(length(contents))
 		overlays += "folder_paper"
 	return
 

--- a/code/modules/paperwork/notepad.dm
+++ b/code/modules/paperwork/notepad.dm
@@ -31,7 +31,7 @@
 
 	if(HAS_TRAIT(attack_item, TRAIT_TOOL_PEN) || istype(attack_item, /obj/item/toy/crayon))
 		close_browser(usr, name) //Closes the dialog
-		if(page < contents.len)
+		if(page < length(contents))
 			page = 1
 		var/obj/item/paper/paper = contents[page]
 		paper.attackby(attack_item, user)
@@ -93,8 +93,8 @@
 			page--
 			playsound(loc, "pageturn", 15, 1)
 		if(href_list["remove"])
-			if(contents.len < page)
-				page = contents.len
+			if(length(contents) < page)
+				page = length(contents)
 			var/obj/item/ripped_out_page = contents[page]
 			usr.put_in_hands(ripped_out_page)
 			to_chat(usr, SPAN_NOTICE("You rip out [ripped_out_page] from [src]."))

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -687,7 +687,7 @@
 				var/datum/reagent/R = GLOB.chemical_reagents_list["[I]"]
 				var/U = G.required_reagents[I]
 				txt += "<font size = \"2\"><I> - [U] [R.name]</I></font><BR>\n"
-			if(G.required_catalysts && G.required_catalysts.len)
+			if(LAZYLEN(G.required_catalysts))
 				txt += "<BR>\nWhile using the following catalysts: <BR>\n<BR>\n"
 				for(var/I in G.required_catalysts)
 					var/datum/reagent/R = GLOB.chemical_reagents_list["[I]"]
@@ -835,17 +835,16 @@
 			else
 				var/U = C.required_reagents[I]
 				info += "<font size = \"2\"><I> - [U] [R.name]</I></font><BR>\n"
-		if(C.required_catalysts)
-			if(C.required_catalysts.len)
-				info += "<BR>Reaction would require the following catalysts:<BR>\n"
-				for(var/I in C.required_catalysts)
-					var/datum/reagent/R = GLOB.chemical_reagents_list["[I]"]
-					if(R.chemclass >= CHEM_CLASS_SPECIAL && !GLOB.chemical_data.chemical_identified_list[R.id] && !info_only)
-						info += "<font size = \"2\"><I> - Unknown emission spectrum</I></font><BR>\n"
-						completed = FALSE
-					else
-						var/U = C.required_catalysts[I]
-						info += "<font size = \"2\"><I> - [U] [R.name]</I></font><BR>\n"
+		if(LAZYLEN(C.required_catalysts))
+			info += "<BR>Reaction would require the following catalysts:<BR>\n"
+			for(var/I in C.required_catalysts)
+				var/datum/reagent/R = GLOB.chemical_reagents_list["[I]"]
+				if(R.chemclass >= CHEM_CLASS_SPECIAL && !GLOB.chemical_data.chemical_identified_list[R.id] && !info_only)
+					info += "<font size = \"2\"><I> - Unknown emission spectrum</I></font><BR>\n"
+					completed = FALSE
+				else
+					var/U = C.required_catalysts[I]
+					info += "<font size = \"2\"><I> - [U] [R.name]</I></font><BR>\n"
 	else if(GLOB.chemical_gen_classes_list["C1"].Find(S.id))
 		info += "<font size = \"2\"><I> - [S.name]</I></font><BR>\n"
 	else

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -44,8 +44,8 @@
 	else
 		if(HAS_TRAIT(W, TRAIT_TOOL_PEN) || istype(W, /obj/item/toy/crayon))
 			close_browser(usr, name) //Closes the dialog
-		if(page < contents.len)
-			page = contents.len
+		if(page < length(contents))
+			page = length(contents)
 		P = contents[page]
 		P.attackby(W, user)
 
@@ -148,8 +148,8 @@
 			page--
 			playsound(src.loc, "pageturn", 15, 1)
 		if(href_list["remove"])
-			if(contents.len < page)
-				page = contents.len
+			if(length(contents) < page)
+				page = length(contents)
 			var/obj/item/W = contents[page]
 			usr.put_in_hands(W)
 			to_chat(usr, SPAN_NOTICE("You remove the [W.name] from the bundle."))
@@ -198,7 +198,7 @@
 	qdel(src)
 
 /obj/item/paper_bundle/update_icon()
-	if(contents.len)
+	if(length(contents))
 		var/obj/item/I = contents[1]
 		icon_state = I.icon_state
 		overlays = I.overlays

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -28,7 +28,7 @@
 
 /obj/item/paper_bin/attack_hand(mob/user)
 	var/response = ""
-	if(!papers.len > 0)
+	if(!length(papers) > 0)
 		response = alert(user, "What kind of paper?", "Paper type request", "Regular", sec_paper_type, "Cancel")
 		if (response != "Regular" && response != "Carbon-Copy" && response != "Company Document" && response != "USCM Document")
 			add_fingerprint(user)
@@ -39,8 +39,8 @@
 			update_icon()
 
 		var/obj/item/paper/P
-		if(papers.len > 0) //If there's any custom paper on the stack, use that instead of creating a new paper.
-			P = papers[papers.len]
+		if(length(papers) > 0) //If there's any custom paper on the stack, use that instead of creating a new paper.
+			P = papers[length(papers)]
 			papers.Remove(P)
 		else
 			if (response == "Regular")

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -199,7 +199,7 @@
 
 	//Iterates through stamps and puts a matching gray overlay onto the copy
 	var/image/img //
-	for (var/j = 1, j <= original.ico.len, j++)
+	for (var/j = 1, j <= length(original.ico), j++)
 		if (findtext(original.ico[j], "cap") || findtext(original.ico[j], "cent"))
 			img = image('icons/obj/items/paper.dmi', "paper_stamp-circle")
 		else if (findtext(original.ico[j], "deny"))

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -457,13 +457,13 @@ GLOBAL_LIST_INIT(apc_wire_descriptions, list(
 			icon_state = "apcewires"
 
 	if(!(update_state & UPSTATE_ALLGOOD))
-		if(overlays.len)
+		if(length(overlays))
 			overlays = 0
 			return
 
 	if(update & 2)
 
-		if(overlays.len)
+		if(length(overlays))
 			overlays = 0
 
 		if(!(stat & (BROKEN|MAINT)) && update_state & UPSTATE_ALLGOOD)

--- a/code/modules/power/power_monitor.dm
+++ b/code/modules/power/power_monitor.dm
@@ -57,7 +57,7 @@
 
 		t += "<FONT SIZE=-1>"
 
-		if(L.len > 0)
+		if(length(L) > 0)
 			var/total_demand = 0
 			t += "Area    Eqp./Lgt./Env.  Load   Cell<HR>"
 

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -26,7 +26,7 @@
 
 	var/numapc = 0
 
-	if(nodes && nodes.len) // Added to fix a bad list bug -- TLE
+	if(LAZYLEN(nodes)) // Added to fix a bad list bug -- TLE
 		for(var/obj/structure/machinery/power/terminal/term in nodes)
 			if( istype( term.master, /obj/structure/machinery/power/apc ) )
 				numapc++
@@ -45,7 +45,7 @@
 		perapc = avail/numapc + perapc_excess
 
 	if( netexcess > 100) // if there was excess power last cycle
-		if(nodes && nodes.len)
+		if(LAZYLEN(nodes))
 			for(var/obj/structure/machinery/power/smes/S in nodes) // find the SMESes in the network
 				if(S.powernet == src)
 					S.restore() // and restore some of the power that was used

--- a/code/modules/projectiles/ammo_boxes/ammo_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/ammo_boxes.dm
@@ -126,10 +126,10 @@
 	if(src.loc != user) //feeling box weight in a distance is unnatural and bad
 		return
 	if(!handfuls)
-		if(contents.len < (num_of_magazines/3))
+		if(length(contents) < (num_of_magazines/3))
 			. += SPAN_INFO("It feels almost empty.")
 			return
-		if(contents.len < ((num_of_magazines*2)/3))
+		if(length(contents) < ((num_of_magazines*2)/3))
 			. += SPAN_INFO("It feels about half full.")
 			return
 		. += SPAN_INFO("It feels almost full.")

--- a/code/modules/projectiles/ammo_boxes/box_structures.dm
+++ b/code/modules/projectiles/ammo_boxes/box_structures.dm
@@ -32,13 +32,13 @@
 	if(!item_box.handfuls)
 		if(item_box.overlay_ammo_type)
 			overlays += image(text_markings_icon, icon_state = "base_type[item_box.overlay_ammo_type]") //adding base color stripes
-		if(item_box.contents.len == item_box.num_of_magazines)
+		if(length(item_box.contents) == item_box.num_of_magazines)
 			overlays += image(magazines_icon, icon_state = "magaz[item_box.overlay_content]")
-		else if(item_box.contents.len > (item_box.num_of_magazines/2))
+		else if(length(item_box.contents) > (item_box.num_of_magazines/2))
 			overlays += image(magazines_icon, icon_state = "magaz[item_box.overlay_content]_3")
-		else if(item_box.contents.len > (item_box.num_of_magazines/4))
+		else if(length(item_box.contents) > (item_box.num_of_magazines/4))
 			overlays += image(magazines_icon, icon_state = "magaz[item_box.overlay_content]_2")
-		else if(item_box.contents.len > 0)
+		else if(length(item_box.contents) > 0)
 			overlays += image(magazines_icon, icon_state = "magaz[item_box.overlay_content]_1")
 	else
 		var/obj/item/ammo_magazine/AM = locate(/obj/item/ammo_magazine) in item_box.contents
@@ -103,7 +103,7 @@
 		if(AM)
 			. +=  SPAN_INFO("It has roughly [floor(AM.current_rounds/5)] handfuls remaining.")
 	else
-		. +=  SPAN_INFO("It has [item_box.contents.len] magazines out of [item_box.num_of_magazines].")
+		. +=  SPAN_INFO("It has [length(item_box.contents)] magazines out of [item_box.num_of_magazines].")
 	if(burning)
 		. +=  SPAN_DANGER("It's on fire and might explode!")
 
@@ -111,7 +111,7 @@
 	if(burning)
 		to_chat(user, SPAN_DANGER("It's on fire and might explode!"))
 		return
-	if(item_box.contents.len)
+	if(length(item_box.contents))
 		if(!item_box.handfuls)
 			var/obj/item/ammo_magazine/AM = pick(item_box.contents)
 			item_box.contents -= AM
@@ -133,7 +133,7 @@
 		if(istypestrict(W,item_box.magazine_type))
 			if(istype(W, /obj/item/storage/box/m94))
 				var/obj/item/storage/box/m94/flare_pack = W
-				if(flare_pack.contents.len < flare_pack.max_storage_space)
+				if(length(flare_pack.contents) < flare_pack.max_storage_space)
 					to_chat(user, SPAN_WARNING("[W] is not full."))
 					return
 				var/flare_type
@@ -158,7 +158,7 @@
 				if(cell.charge != cell.maxcharge)
 					to_chat(user, SPAN_WARNING("[W] needs to be fully charged before it can be stored in [src]."))
 					return
-			if(item_box.contents.len < item_box.num_of_magazines)
+			if(length(item_box.contents) < item_box.num_of_magazines)
 				user.drop_inv_item_to_loc(W, src)
 				item_box.contents += W
 				to_chat(user, SPAN_NOTICE("You put \a [W] into [src]"))

--- a/code/modules/projectiles/ammo_boxes/misc_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/misc_boxes.dm
@@ -96,7 +96,7 @@
 /obj/item/ammo_box/magazine/misc/flares/get_severity()
 	var/flare_amount = 0
 	for(var/obj/item/storage/box/m94/flare_box in contents)
-		flare_amount += flare_box.contents.len
+		flare_amount += length(flare_box.contents)
 	flare_amount = floor(flare_amount / 8) //10 packs, 8 flares each, maximum total of 10 flares we can throw out
 	return flare_amount
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -471,7 +471,7 @@
 
 
 /obj/item/weapon/gun/proc/handle_starting_attachment()
-	if(starting_attachment_types && starting_attachment_types.len)
+	if(LAZYLEN(starting_attachment_types))
 		for(var/path in starting_attachment_types)
 			var/obj/item/attachable/A = new path(src)
 			A.Attach(src)

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -2973,7 +2973,7 @@ Defined in conflicts.dm of the #defines folder.
 			current_rounds += transfered_rounds
 			FT.current_rounds -= transfered_rounds
 
-			var/amount_of_reagents = FT.reagents.reagent_list.len
+			var/amount_of_reagents = length(FT.reagents.reagent_list)
 			var/amount_removed_per_reagent = transfered_rounds / amount_of_reagents
 			for(var/datum/reagent/R in FT.reagents.reagent_list)
 				R.volume -= amount_removed_per_reagent

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -815,11 +815,11 @@ DEFINES in setup.dm, referenced here.
 		if(attachment && (attachment.flags_attach_features & ATTACH_ACTIVATION) )
 			usable_attachments += attachment
 
-	if(!usable_attachments.len) //No usable attachments.
+	if(!length(usable_attachments)) //No usable attachments.
 		to_chat(usr, SPAN_WARNING("[src] does not have any usable attachments!"))
 		return
 
-	if(usable_attachments.len == 1) //Activates the only attachment if there is only one.
+	if(length(usable_attachments) == 1) //Activates the only attachment if there is only one.
 		chosen_attachment = usable_attachments[1]
 	else
 		chosen_attachment = tgui_input_list(usr, "Which attachment to activate?", "Activate attachment", usable_attachments)

--- a/code/modules/projectiles/guns/flamer/flamer.dm
+++ b/code/modules/projectiles/guns/flamer/flamer.dm
@@ -203,7 +203,7 @@
 /obj/item/weapon/gun/flamer/proc/unleash_flame(atom/target, mob/living/user)
 	set waitfor = 0
 	last_fired = world.time
-	if(!current_mag || !current_mag.reagents || !current_mag.reagents.reagent_list.len)
+	if(!current_mag || !current_mag.reagents || !length(current_mag.reagents.reagent_list))
 		return
 
 	var/datum/reagent/R = current_mag.reagents.reagent_list[1]
@@ -234,7 +234,7 @@
 
 /obj/item/weapon/gun/flamer/proc/unleash_smoke(atom/target, mob/living/user)
 	last_fired = world.time
-	if(!current_mag || !current_mag.reagents || !current_mag.reagents.reagent_list.len)
+	if(!current_mag || !current_mag.reagents || !length(current_mag.reagents.reagent_list))
 		return
 
 	var/source_turf = get_turf(user)
@@ -251,7 +251,7 @@
 	var/turf/turfs[] = get_line(user, target, FALSE)
 	var/turf/first_turf = turfs[1]
 	var/turf/second_turf = turfs[2]
-	var/ammount_required = (min(turfs.len, smoke_range) * use_multiplier) // the ammount of units that this click requires
+	var/ammount_required = (min(length(turfs), smoke_range) * use_multiplier) // the ammount of units that this click requires
 	for(var/turf/turf in turfs)
 
 		if(chemical.volume < ammount_required)
@@ -294,7 +294,7 @@
 
 /obj/item/weapon/gun/flamer/proc/unleash_foam(atom/target, mob/living/user)
 	last_fired = world.time
-	if(!current_mag || !current_mag.reagents || !current_mag.reagents.reagent_list.len)
+	if(!current_mag || !current_mag.reagents || !length(current_mag.reagents.reagent_list))
 		return
 
 	var/source_turf = get_turf(user)
@@ -305,7 +305,7 @@
 
 	var/turf/turfs[] = get_line(user, target, FALSE)
 	var/turf/first_turf = turfs[1]
-	var/ammount_required = (min(turfs.len, foam_range) * use_multiplier) // the ammount of units that this click requires
+	var/ammount_required = (min(length(turfs), foam_range) * use_multiplier) // the ammount of units that this click requires
 	for(var/turf/turf in turfs)
 
 		if(chemical.volume < ammount_required)

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -1020,7 +1020,7 @@ can cause issues with ammo types getting mixed up during the burst.
 			throw_turfs.Remove(T)
 			continue
 		var/list/turf/path = get_line(get_step_towards(src, T), T) //Same path throw code will calculate from.
-		if(!path.len)
+		if(!length(path))
 			throw_turfs.Remove(T)
 			continue
 		var/prev_turf = start_turf

--- a/code/modules/projectiles/guns/smartgun.dm
+++ b/code/modules/projectiles/guns/smartgun.dm
@@ -501,7 +501,7 @@
 
 		path = get_line(user, M)
 
-		if(path.len)
+		if(length(path))
 			var/blocked = FALSE
 			for(T in path)
 				if(T.density || T.opacity)
@@ -524,9 +524,9 @@
 			else
 				conscious_targets += M
 
-	if(conscious_targets.len)
+	if(length(conscious_targets))
 		. = pick(conscious_targets)
-	else if(unconscious_targets.len)
+	else if(length(unconscious_targets))
 		. = pick(unconscious_targets)
 
 /obj/item/weapon/gun/smartgun/proc/process_shot(mob/living/user, warned)

--- a/code/modules/projectiles/guns/specialist/sniper.dm
+++ b/code/modules/projectiles/guns/specialist/sniper.dm
@@ -222,7 +222,7 @@
 
 /datum/action/item_action/specialist/aimed_shot/proc/check_shot_is_blocked(mob/firer, mob/target, obj/projectile/P)
 	var/list/turf/path = get_line(firer, target, include_start_atom = FALSE)
-	if(!path.len || get_dist(firer, target) > P.ammo.max_range)
+	if(!length(path) || get_dist(firer, target) > P.ammo.max_range)
 		return TRUE
 
 	var/blocked = FALSE

--- a/code/modules/projectiles/magazines/flamer.dm
+++ b/code/modules/projectiles/magazines/flamer.dm
@@ -78,7 +78,7 @@
 	if(!istype(target, /obj/structure/reagent_dispensers/fueltank) && !istype(target, /obj/item/tool/weldpack) && !istype(target, /obj/item/storage/backpack/marine/engineerpack))
 		return ..()
 
-	if(!target.reagents || target.reagents.reagent_list.len < 1)
+	if(!target.reagents || length(target.reagents.reagent_list) < 1)
 		to_chat(user, SPAN_WARNING("[target] is empty!"))
 		return
 
@@ -133,7 +133,7 @@
 /obj/item/ammo_magazine/flamer_tank/get_examine_text(mob/user)
 	. = ..()
 	. += SPAN_NOTICE("It contains:")
-	if(reagents && reagents.reagent_list.len)
+	if(reagents && length(reagents.reagent_list))
 		for(var/datum/reagent/R in reagents.reagent_list)
 			. += SPAN_NOTICE(" [R.volume] units of [R.name].")
 	else

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -298,7 +298,7 @@
 	var/pixel_x_source = vis_source.x * world.icon_size + vis_source_pixel_x
 	var/pixel_y_source = vis_source.y * world.icon_size + vis_source_pixel_y
 
-	var/turf/vis_target = path[path.len]
+	var/turf/vis_target = path[length(path)]
 	var/pixel_x_target = vis_target.x * world.icon_size + p_x
 	var/pixel_y_target = vis_target.y * world.icon_size + p_y
 
@@ -311,7 +311,7 @@
 
 	//Determine apparent position along visual path, then lerp between start and end positions
 
-	var/vis_length = vis_travelled + path.len
+	var/vis_length = vis_travelled + length(path)
 	var/vis_current = vis_travelled + speed * (time_carry * 0.1) //speed * (time_carry * 0.1) for remainder time movement, visually "catching up" to where it should be
 	var/vis_interpolant = vis_current / vis_length
 
@@ -1130,7 +1130,7 @@
 		handle_blood_splatter(get_dir(P.starting, loc))
 
 		apply_damage(damage_result,P.ammo.damage_type, P.def_zone) //Deal the damage.
-		if(xeno_shields.len)
+		if(length(xeno_shields))
 			P.play_shielded_hit_effect(src)
 		else
 			P.play_hit_effect(src)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -39,13 +39,13 @@
 	var/total_transfered = 0
 	var/current_list_element = 1
 
-	current_list_element = rand(1,reagent_list.len)
+	current_list_element = rand(1,length(reagent_list))
 
 	while(total_transfered != amount)
 		if(total_transfered >= amount) break
-		if(total_volume <= 0 || !reagent_list.len) break
+		if(total_volume <= 0 || !length(reagent_list)) break
 
-		if(current_list_element > reagent_list.len) current_list_element = 1
+		if(current_list_element > length(reagent_list)) current_list_element = 1
 		var/datum/reagent/current_reagent = reagent_list[current_list_element]
 
 		remove_reagent(current_reagent.id, 1)
@@ -62,17 +62,17 @@
 	var/total_transfered = 0
 	var/current_list_element = 1
 
-	current_list_element = rand(1, reagent_list.len)
+	current_list_element = rand(1, length(reagent_list))
 
 	while(total_transfered != amount)
 		if(total_transfered >= amount) break
-		if(total_volume <= 0 || !reagent_list.len) break
+		if(total_volume <= 0 || !length(reagent_list)) break
 
-		if(current_list_element > reagent_list.len) current_list_element = 1
+		if(current_list_element > length(reagent_list)) current_list_element = 1
 		var/datum/reagent/current_reagent = reagent_list[current_list_element]
 
 		if(current_reagent.id == reagent_to_ignore)
-			if(reagent_list.len == 1) break //if the reagent to be avoided is the only one in the list, we're done here.
+			if(length(reagent_list) == 1) break //if the reagent to be avoided is the only one in the list, we're done here.
 			if(current_list_element == 1)
 				current_reagent = reagent_list[current_list_element + 1] //if the selected reagent was number 1, we don't want it trying to draw id.0, so we add 1
 			else
@@ -252,11 +252,11 @@
 
 				var/datum/chemical_reaction/C = reaction
 
-				var/total_required_reagents = C.required_reagents.len
+				var/total_required_reagents = length(C.required_reagents)
 				var/total_matching_reagents = 0
 				var/total_required_catalysts = 0
 				if(C.required_catalysts)
-					total_required_catalysts = C.required_catalysts.len
+					total_required_catalysts = length(C.required_catalysts)
 				var/total_matching_catalysts= 0
 				var/matching_container = 0
 				var/matching_other = 0

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -346,7 +346,7 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 			R = new P.type()
 			break
 		i++
-		if(i > properties.len)
+		if(i > length(properties))
 			return FALSE
 	R.level = new_level
 	R.holder = src

--- a/code/modules/reagents/chemistry_machinery/autodispenser.dm
+++ b/code/modules/reagents/chemistry_machinery/autodispenser.dm
@@ -164,7 +164,7 @@
 		data["output_container"] = output_container.name
 		data["output_totalvol"] = output_container.reagents.total_volume
 		data["output_maxvol"] = output_container.reagents.maximum_volume
-		if(output_container.reagents.reagent_list.len)
+		if(length(output_container.reagents.reagent_list))
 			data["output_color"] = mix_color_from_reagents(output_container.reagents.reagent_list)
 		else
 			data["output_color"] = null
@@ -182,12 +182,12 @@
 	var/list/memorylist = program_amount[PROGRAM_MEMORY]
 	var/list/boxlist = program_amount[PROGRAM_BOX]
 
-	if(memorylist.len)
+	if(length(memorylist))
 		data["memory"] = tgui_friendly_program_list[PROGRAM_MEMORY]
 	else
 		data["memory"] = "Empty"
 
-	if(boxlist.len)
+	if(length(boxlist))
 		data["box"] = tgui_friendly_program_list[PROGRAM_BOX]
 	else
 		data["box"] = "Empty"
@@ -308,7 +308,7 @@
 		update_icon()
 		return
 
-	for(var/i=stage,i<=programs[1].len + programs[2].len && i != 0,i++)
+	for(var/i=stage,i<=length(programs[1]) + length(programs[2]) && i != 0,i++)
 		if(status < AUTODISPENSER_IDLE) //We're waiting for new chems to be stored
 			status++
 			if(status == AUTODISPENSER_IDLE)
@@ -376,7 +376,7 @@
 	for(var/obj/item/reagent_container/glass/beaker/vial/V in input_container.contents)
 		if(!V.reagents.get_reagents()) //Ignore empty vials
 			continue
-		if(V.reagents.reagent_list.len > 1) //We don't work with impure vials
+		if(length(V.reagents.reagent_list) > 1) //We don't work with impure vials
 			continue
 		var/datum/reagent/R = V.reagents.reagent_list[1]
 		if(program_amount[save_to]["[R.name]"])
@@ -395,11 +395,11 @@
 	use_power(1500)
 
 /obj/structure/machinery/autodispenser/proc/run_program()
-	if(programs[PROGRAM_MEMORY].len)
+	if(length(programs[PROGRAM_MEMORY]))
 		program = PROGRAM_MEMORY
 	else
 		program = PROGRAM_BOX
-	if(programs[program].len && (outputmode == OUTPUT_TO_CONTAINER && output_container) || outputmode != OUTPUT_TO_CONTAINER)
+	if(length(programs[program]) && (outputmode == OUTPUT_TO_CONTAINER && output_container) || outputmode != OUTPUT_TO_CONTAINER)
 		status = AUTODISPENSER_RUNNING
 		update_icon()
 	else
@@ -407,8 +407,8 @@
 
 /obj/structure/machinery/autodispenser/proc/next_stage()
 	stage++
-	if(stage > programs[program].len) //End of program
-		if(programs[PROGRAM_MEMORY].len && programs[PROGRAM_BOX].len)
+	if(stage > length(programs[program])) //End of program
+		if(length(programs[PROGRAM_MEMORY]) && length(programs[PROGRAM_BOX]))
 			if(program == PROGRAM_BOX)
 				cycle++
 				program--

--- a/code/modules/reagents/chemistry_machinery/centrifuge.dm
+++ b/code/modules/reagents/chemistry_machinery/centrifuge.dm
@@ -176,17 +176,17 @@
 		cleanup()
 		return FALSE
 
-	if(status == 0 && input_source == INPUT_TURING && connected_turing && connected_turing.outputmode == 2 && (connected_turing.programs[1].len || connected_turing.programs[2].len))
+	if(status == 0 && input_source == INPUT_TURING && connected_turing && connected_turing.outputmode == 2 && (length(connected_turing.programs[1]) || length(connected_turing.programs[2])))
 		return TRUE
 	return FALSE
 
 /obj/structure/machinery/centrifuge/proc/centrifuge()
-	if(!output_container.contents.len) return //Is output empty?
+	if(!length(output_container.contents)) return //Is output empty?
 
 	var/obj/item/reagent_container/source_container = input_container
 	if(input_source == INPUT_TURING)
 		source_container = connected_turing
-	var/initial_reagents = source_container.reagents.reagent_list.len
+	var/initial_reagents = length(source_container.reagents.reagent_list)
 	var/list/vials = list()
 	for(var/obj/item/reagent_container/V in output_container.contents)
 		vials += V
@@ -203,7 +203,7 @@
 			var/obj/item/reagent_container/hypospray/autoinjector/A = V
 			if(autolabel)
 				A.name = "autoinjector ([autolabel])"
-			else if(!(A.reagents.reagent_list.len))
+			else if(!length(A.reagents.reagent_list))
 				A.name = "autoinjector"
 			else
 				A.name = "autoinjector (" + A.reagents.reagent_list[1].name + ")"
@@ -213,7 +213,7 @@
 		else
 			if(autolabel)
 				V.name = "vial ([autolabel])"
-			else if(!(V.reagents.reagent_list.len) || (V.reagents.reagent_list.len > 1))
+			else if(!length(V.reagents.reagent_list) || (length(V.reagents.reagent_list) > 1))
 				V.name = "vial"
 			else
 				V.name = "vial (" + V.reagents.reagent_list[1].name + ")"

--- a/code/modules/reagents/chemistry_machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_dispenser.dm
@@ -140,7 +140,7 @@
 
 	var/list/beakerContents = list()
 	var/beakerCurrentVolume = 0
-	if(beaker && beaker.reagents && beaker.reagents.reagent_list.len)
+	if(beaker && beaker.reagents && length(beaker.reagents.reagent_list))
 		for(var/datum/reagent/current_reagent in beaker.reagents.reagent_list)
 			beakerContents += list(list("name" = current_reagent.name, "volume" = current_reagent.volume))  // list in a list because Byond merges the first list...
 			beakerCurrentVolume += current_reagent.volume

--- a/code/modules/reagents/chemistry_machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_master.dm
@@ -248,7 +248,7 @@
 				P.icon_state = "pill"+pillsprite
 				reagents.trans_to(P,amount_per_pill)
 				if(loaded_pill_bottle)
-					if(loaded_pill_bottle.contents.len < loaded_pill_bottle.max_storage_space)
+					if(length(loaded_pill_bottle.contents) < loaded_pill_bottle.max_storage_space)
 						loaded_pill_bottle.handle_item_insertion(P, TRUE)
 						updateUsrDialog()
 
@@ -354,7 +354,7 @@
 		dat = "Please insert beaker.<BR>"
 		if(pill_maker)
 			if(loaded_pill_bottle)
-				dat += "<A href='?src=\ref[src];ejectp=1;user=\ref[user]'>Eject Pill Bottle \[[loaded_pill_bottle.contents.len]/[loaded_pill_bottle.max_storage_space]\]</A><BR><BR>"
+				dat += "<A href='?src=\ref[src];ejectp=1;user=\ref[user]'>Eject Pill Bottle \[[length(loaded_pill_bottle.contents)]/[loaded_pill_bottle.max_storage_space]\]</A><BR><BR>"
 			else
 				dat += "No pill bottle inserted.<BR><BR>"
 		dat += "<A href='?src=\ref[src];close=1'>Close</A>"
@@ -362,10 +362,10 @@
 		dat += "<A href='?src=\ref[src];eject=1;user=\ref[user]'>Eject beaker and Clear Buffer</A><BR><BR>"
 		if(pill_maker)
 			if(loaded_pill_bottle)
-				dat += "<A href='?src=\ref[src];ejectp=1;user=\ref[user]'>Eject [loaded_pill_bottle] \[[loaded_pill_bottle.contents.len]/[loaded_pill_bottle.max_storage_space]\]</A><BR>"
-				dat += "<A href='?src=\ref[src];addlabelp=1;user=\ref[user]'>Add label to [loaded_pill_bottle] \[[loaded_pill_bottle.contents.len]/[loaded_pill_bottle.max_storage_space]\]</A><BR>"
-				dat += "<A href='?src=\ref[src];setcolor=1;user=\ref[user]'>Set color to [loaded_pill_bottle] \[[loaded_pill_bottle.contents.len]/[loaded_pill_bottle.max_storage_space]\]</A><BR><BR>"
-				dat += "<A href='?src=\ref[src];transferp=1;'>Transfer [loaded_pill_bottle] \[[loaded_pill_bottle.contents.len]/[loaded_pill_bottle.max_storage_space]\] to the smartfridge</A><BR><BR>"
+				dat += "<A href='?src=\ref[src];ejectp=1;user=\ref[user]'>Eject [loaded_pill_bottle] \[[length(loaded_pill_bottle.contents)]/[loaded_pill_bottle.max_storage_space]\]</A><BR>"
+				dat += "<A href='?src=\ref[src];addlabelp=1;user=\ref[user]'>Add label to [loaded_pill_bottle] \[[length(loaded_pill_bottle.contents)]/[loaded_pill_bottle.max_storage_space]\]</A><BR>"
+				dat += "<A href='?src=\ref[src];setcolor=1;user=\ref[user]'>Set color to [loaded_pill_bottle] \[[length(loaded_pill_bottle.contents)]/[loaded_pill_bottle.max_storage_space]\]</A><BR><BR>"
+				dat += "<A href='?src=\ref[src];transferp=1;'>Transfer [loaded_pill_bottle] \[[length(loaded_pill_bottle.contents)]/[loaded_pill_bottle.max_storage_space]\] to the smartfridge</A><BR><BR>"
 			else
 				dat += "No pill bottle inserted.<BR><BR>"
 		if(!connected && pill_maker)

--- a/code/modules/reagents/chemistry_machinery/chem_simulator.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_simulator.dm
@@ -679,7 +679,7 @@
 	R.make_alike(assoc_R)
 
 	if(mode != MODE_CREATE)
-		if(R.required_reagents.len > 2 && !recipe_targets[recipe_target]) //we only replace if the recipe isn't small and the target is not set TRUE to being elevated
+		if(length(R.required_reagents) > 2 && !recipe_targets[recipe_target]) //we only replace if the recipe isn't small and the target is not set TRUE to being elevated
 			LAZYREMOVE(R.required_reagents, pick(R.required_reagents))
 		R.add_component(recipe_target)
 

--- a/code/modules/reagents/chemistry_machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry_machinery/pandemic.dm
@@ -75,7 +75,7 @@
 							Blood = L
 							break
 					var/list/res = Blood.data_properties["resistances"]
-					spawn(res.len*200)
+					spawn(length(res)*200)
 						wait = null
 		else
 			temphtml = "The replicator is not ready yet."
@@ -160,7 +160,7 @@
 			if(B)
 				Blood = B
 				break
-		if(!beaker.reagents.total_volume||!beaker.reagents.reagent_list.len)
+		if(!beaker.reagents.total_volume||!length(beaker.reagents.reagent_list))
 			dat += "The beaker is empty<BR>"
 		else if(!Blood)
 			dat += "No blood sample found in beaker"
@@ -172,7 +172,7 @@
 
 			if(Blood.data_properties["viruses"])
 				var/list/vir = Blood.data_properties["viruses"]
-				if(vir.len)
+				if(length(vir))
 					for(var/datum/disease/D in Blood.data_properties["viruses"])
 						if(!D.hidden[PANDEMIC])
 
@@ -209,7 +209,7 @@
 			dat += "<BR><b>Contains antibodies to:</b> "
 			if(Blood.data_properties["resistances"])
 				var/list/res = Blood.data_properties["resistances"]
-				if(res.len)
+				if(length(res))
 					dat += "<ul>"
 					for(var/type in Blood.data_properties["resistances"])
 						var/disease_name = "Unknown"
@@ -230,7 +230,7 @@
 					dat += "nothing<BR>"
 			else
 				dat += "nothing<BR>"
-		dat += "<BR><A href='?src=\ref[src];eject=1'>Eject beaker</A>[((beaker.reagents.total_volume && beaker.reagents.reagent_list.len) ? "-- <A href='?src=\ref[src];empty_beaker=1'>Empty beaker</A>":"")]<BR>"
+		dat += "<BR><A href='?src=\ref[src];eject=1'>Eject beaker</A>[((beaker.reagents.total_volume && length(beaker.reagents.reagent_list)) ? "-- <A href='?src=\ref[src];empty_beaker=1'>Empty beaker</A>":"")]<BR>"
 		dat += "<A href='?src=\ref[user];mach_close=pandemic'>Close</A>"
 
 	show_browser(user, "<TITLE>[name]</TITLE><BR>[dat]", name, "pandemic")

--- a/code/modules/reagents/chemistry_machinery/reagent_analyzer.dm
+++ b/code/modules/reagents/chemistry_machinery/reagent_analyzer.dm
@@ -33,7 +33,7 @@
 				to_chat(user, SPAN_WARNING("Someone else removed the sample. Make up your mind!"))
 				return
 			processing = TRUE
-			if(sample.reagents.total_volume < 30 || sample.reagents.reagent_list.len > 1)
+			if(sample.reagents.total_volume < 30 || length(sample.reagents.reagent_list) > 1)
 				icon_state = "reagent_analyzer_error"
 				reagent_process()
 			else
@@ -54,12 +54,12 @@
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/structure/machinery/reagent_analyzer, finish_reagent_process)), 4 SECONDS)
 
 /obj/structure/machinery/reagent_analyzer/proc/finish_reagent_process()
-	if(!sample || !sample.reagents || sample.reagents.total_volume < 30 || sample.reagents.reagent_list.len > 1)
+	if(!sample || !sample.reagents || sample.reagents.total_volume < 30 || length(sample.reagents.reagent_list) > 1)
 		if(!sample || !sample.reagents)
 			print_report(0, "SAMPLE EMPTY.")
 		else if(sample.reagents.total_volume < 30)
 			print_report(0, "SAMPLE SIZE INSUFFICIENT;<BR>\n<I>A sample size of 30 units is required for analysis.</I>")
-		else if(sample.reagents.reagent_list.len > 1)
+		else if(length(sample.reagents.reagent_list) > 1)
 			print_report(0, "SAMPLE CONTAMINATED;<BR>\n<I>A pure sample is required for analysis.</I>")
 		else
 			print_report(0, "UNKNOWN.")

--- a/code/modules/reagents/chemistry_machinery/reagent_grinder.dm
+++ b/code/modules/reagents/chemistry_machinery/reagent_grinder.dm
@@ -90,17 +90,17 @@
 		updateUsrDialog()
 		return 0
 
-	if(holdingitems && holdingitems.len >= limit)
+	if(LAZYLEN(holdingitems) >= limit)
 		to_chat(user, SPAN_WARNING("The machine cannot hold anymore items."))
 		return 1
 
 	if(istype(O,/obj/item/storage))
 		var/obj/item/storage/B = O
-		if(B.contents.len > 0)
+		if(length(B.contents) > 0)
 			to_chat(user, SPAN_NOTICE("You start dumping the contents of [B] into [src]."))
 			if(!do_after(user, 15, INTERRUPT_ALL, BUSY_ICON_GENERIC)) return
 			for(var/obj/item/I in B)
-				if(holdingitems && holdingitems.len >= limit)
+				if(LAZYLEN(holdingitems) >= limit)
 					to_chat(user, SPAN_WARNING("The machine cannot hold anymore items."))
 					break
 				else
@@ -165,7 +165,7 @@
 		if(is_beaker_ready && !is_chamber_empty && !(inoperable()))
 			dat += "<A href='?src=\ref[src];action=grind'>Grind the reagents</a><BR>"
 			dat += "<A href='?src=\ref[src];action=juice'>Juice the reagents</a><BR><BR>"
-		if(holdingitems && holdingitems.len > 0)
+		if(LAZYLEN(holdingitems) > 0)
 			dat += "<A href='?src=\ref[src];action=eject'>Eject the reagents</a><BR>"
 		if(beaker)
 			dat += "<A href='?src=\ref[src];action=detach'>Detach the beaker</a><BR>"
@@ -357,7 +357,7 @@
 			if(beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
 				break
 
-		if(O.reagents.reagent_list.len == 0)
+		if(length(O.reagents.reagent_list) == 0)
 			remove_object(O)
 
 	//Sheets

--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -435,7 +435,7 @@
 		if(L.status & (LIMB_ROBOT|LIMB_SYNTHSKIN))
 			L.take_damage(0, potency)
 			return
-		if(L.implants && L.implants.len > 0)
+		if(LAZYLEN(L.implants) > 0)
 			var/obj/implanted_object = pick(L.implants)
 			if(implanted_object)
 				L.implants -= implanted_object

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -65,7 +65,7 @@
 	start_processing()
 
 /obj/structure/machinery/disposal/Destroy()
-	if(contents.len)
+	if(length(contents))
 		eject()
 	trunk = null
 	return ..()
@@ -86,7 +86,7 @@
 	add_fingerprint(user)
 	if(mode <= 0) //It's off
 		if(HAS_TRAIT(I, TRAIT_TOOL_SCREWDRIVER))
-			if(contents.len > 0)
+			if(length(contents) > 0)
 				to_chat(user, SPAN_WARNING("Eject the contents first!"))
 				return
 			if(mode == DISPOSALS_OFF) //It's off but still not unscrewed
@@ -103,7 +103,7 @@
 			if(!HAS_TRAIT(I, TRAIT_TOOL_BLOWTORCH))
 				to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
 				return
-			if(contents.len > 0)
+			if(length(contents) > 0)
 				to_chat(user, SPAN_WARNING("Eject the contents first!"))
 				return
 			var/obj/item/tool/weldingtool/W = I
@@ -339,7 +339,7 @@
 		return
 
 	//Check for items in disposal - occupied light
-	if(contents.len > 0)
+	if(length(contents) > 0)
 		overlays += image('icons/obj/pipes/disposal.dmi', "dispover-full")
 
 	//Charging and ready light
@@ -356,7 +356,7 @@
 
 	flush_count++
 	if(flush_count >= flush_after_ticks)
-		if(contents.len)
+		if(length(contents))
 			if(mode == DISPOSALS_CHARGED)
 				spawn(0)
 					flush()
@@ -372,7 +372,7 @@
 	else if(disposal_pressure >= SEND_PRESSURE)
 		mode = DISPOSALS_CHARGED //If full enough, switch to ready mode
 		update()
-		if(!contents.len)
+		if(!length(contents))
 			//Full and nothing to flush - stop processing!
 			stop_processing()
 	else

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -337,7 +337,7 @@
 	var/dat = "<tt><center><h1><b>TagMaster 2.3</b></h1></center>"
 
 	dat += "<table style='width:100%; padding:4px;'><tr>"
-	for(var/i = 1, i <= GLOB.tagger_locations.len, i++)
+	for(var/i = 1, i <= length(GLOB.tagger_locations), i++)
 		dat += "<td><a href='?src=\ref[src];nextTag=[GLOB.tagger_locations[i]]'>[GLOB.tagger_locations[i]]</a></td>"
 
 		if (i%4==0)

--- a/code/modules/shuttle/docking.dm
+++ b/code/modules/shuttle/docking.dm
@@ -64,7 +64,7 @@
 	var/list/new_hidden_turfs
 	if(hidden)
 		new_hidden_turfs = list()
-		for(var/i in 1 to old_turfs.len)
+		for(var/i in 1 to length(old_turfs))
 			CHECK_TICK
 			var/turf/oldT = old_turfs[i]
 			if(old_turfs[oldT] & MOVE_TURF)
@@ -135,7 +135,7 @@
 		old_turfs[oldT] = move_mode
 
 /obj/docking_port/mobile/proc/takeoff(list/old_turfs, list/new_turfs, list/moved_atoms, rotation, movement_direction, old_dock, area/underlying_old_area)
-	for(var/i in 1 to old_turfs.len)
+	for(var/i in 1 to length(old_turfs))
 		var/turf/oldT = old_turfs[i]
 		var/turf/newT = new_turfs[i]
 		var/move_mode = old_turfs[oldT]
@@ -162,12 +162,12 @@
 	var/new_parallax_dir = FALSE
 	if(istype(new_dock, /obj/docking_port/stationary/transit))
 		new_parallax_dir = preferred_direction
-	for(var/i in 1 to areas_to_move.len)
+	for(var/i in 1 to length(areas_to_move))
 		CHECK_TICK
 		var/area/internal_area = areas_to_move[i]
 		internal_area.afterShuttleMove(new_parallax_dir) //areas
 
-	for(var/i in 1 to old_turfs.len)
+	for(var/i in 1 to length(old_turfs))
 		CHECK_TICK
 		if(!(old_turfs[old_turfs[i]] & MOVE_TURF))
 			continue
@@ -175,7 +175,7 @@
 		var/turf/newT = new_turfs[i]
 		newT.afterShuttleMove(oldT, rotation) //turfs
 
-	for(var/i in 1 to moved_atoms.len)
+	for(var/i in 1 to length(moved_atoms))
 		CHECK_TICK
 		var/atom/movable/moved_object = moved_atoms[i]
 		if(QDELETED(moved_object))
@@ -187,12 +187,12 @@
 
 	underlying_old_area.lateShuttleMove()
 
-	for(var/i in 1 to areas_to_move.len)
+	for(var/i in 1 to length(areas_to_move))
 		CHECK_TICK
 		var/area/internal_area = areas_to_move[i]
 		internal_area.lateShuttleMove()
 
-	for(var/i in 1 to old_turfs.len)
+	for(var/i in 1 to length(old_turfs))
 		CHECK_TICK
 		if(!(old_turfs[old_turfs[i]] & MOVE_CONTENTS | MOVE_TURF))
 			continue
@@ -200,7 +200,7 @@
 		var/turf/newT = new_turfs[i]
 		newT.lateShuttleMove(oldT)
 
-	for(var/i in 1 to moved_atoms.len)
+	for(var/i in 1 to length(moved_atoms))
 		CHECK_TICK
 		var/atom/movable/moved_object = moved_atoms[i]
 		if(QDELETED(moved_object))

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -64,7 +64,7 @@ All ShuttleMove procs go here
 	var/shuttle_boundary = baseturfs.Find(/turf/baseturf_skipover/shuttle)
 	if(!shuttle_boundary)
 		CRASH("A turf queued to move via shuttle somehow had no skipover in baseturfs. [src]([type]):[loc]")
-	var/depth = baseturfs.len - shuttle_boundary + 1
+	var/depth = length(baseturfs) - shuttle_boundary + 1
 	newT.CopyOnTop(src, 1, depth, TRUE)
 	return TRUE
 
@@ -76,7 +76,7 @@ All ShuttleMove procs go here
 
 	var/shuttle_boundary = baseturfs.Find(/turf/baseturf_skipover/shuttle)
 	if(shuttle_boundary)
-		oldT.ScrapeAway(baseturfs.len - shuttle_boundary + 1)
+		oldT.ScrapeAway(length(baseturfs) - shuttle_boundary + 1)
 
 	if(rotation)
 		shuttleRotate(rotation) //see shuttle_rotate.dm

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -469,13 +469,13 @@
 	. = ..()
 
 	if(!id)
-		id = "[SSshuttle.mobile.len]"
+		id = "[length(SSshuttle.mobile)]"
 	if(name == "shuttle")
-		name = "shuttle[SSshuttle.mobile.len]"
+		name = "shuttle[length(SSshuttle.mobile)]"
 
 	shuttle_areas = list()
 	var/list/all_turfs = return_ordered_turfs(x, y, z, dir)
-	for(var/i in 1 to all_turfs.len)
+	for(var/i in 1 to length(all_turfs))
 		var/turf/curT = all_turfs[i]
 		var/area/cur_area = get_area(curT)
 		if(istype(cur_area, area_type))
@@ -693,7 +693,7 @@
 	if(!underlying_area)
 		underlying_area = new underlying_area_type(null)
 
-	for(var/i in 1 to old_turfs.len)
+	for(var/i in 1 to length(old_turfs))
 		var/turf/oldT = old_turfs[i]
 		if(!oldT || !istype(oldT.loc, area_type))
 			continue
@@ -706,7 +706,7 @@
 		var/list/baseturf_cache = oldT.baseturfs
 		for(var/k in 1 to length(baseturf_cache))
 			if(ispath(baseturf_cache[k], /turf/baseturf_skipover/shuttle))
-				oldT.ScrapeAway(baseturf_cache.len - k + 1)
+				oldT.ScrapeAway(length(baseturf_cache) - k + 1)
 				break
 
 	qdel(src, force=TRUE)
@@ -745,7 +745,7 @@
 
 	var/list/ripple_turfs = list()
 
-	for(var/i in 1 to L0.len)
+	for(var/i in 1 to length(L0))
 		var/turf/T0 = L0[i]
 		var/turf/T1 = L1[i]
 		if(!T0 || !T1)
@@ -819,7 +819,7 @@
 	set_idle()
 
 /obj/docking_port/mobile/proc/check_effects()
-	if(!ripples.len)
+	if(!length(ripples))
 		if((mode == SHUTTLE_PREARRIVAL))
 			var/tl = timeLeft(1)
 			if(tl <= SHUTTLE_RIPPLE_TIME)

--- a/code/modules/shuttles/marine_ferry.dm
+++ b/code/modules/shuttles/marine_ferry.dm
@@ -44,7 +44,7 @@
 	if(!LAZYLEN(locs_land))
 		return TRUE
 
-	if(!main_doors.len && !controls.len)
+	if(!length(main_doors) && !length(controls))
 		var/turf/T_src = pick(locs_dock)
 		var/list/turfs = get_shuttle_turfs(T_src, info_datums)
 		for(var/turf/T in turfs)
@@ -164,7 +164,7 @@
 	var/int_rot = locs_move[T_int]
 	var/turf/T_trg
 	var/trg_rot
-	if(!locs_land.len) // We check here as well to make sure that the order of operations/lag/changing it after launch. Wont mess this up.
+	if(!length(locs_land)) // We check here as well to make sure that the order of operations/lag/changing it after launch. Wont mess this up.
 		transit_gun_mission = 1
 
 	if(transit_gun_mission)//gun mission makes you land back where you started.
@@ -349,7 +349,7 @@
 			for(var/turf/TU in SSoldshuttle.shuttle_controller.locs_crash[target_section])
 				if(istype(get_area(TU), /area/almayer/hallways/hangar))
 					crash_turfs += TU
-			if(crash_turfs.len) T_trg = pick(crash_turfs)
+			if(length(crash_turfs)) T_trg = pick(crash_turfs)
 			else message_admins("no crash turf found in Almayer Hangar, contact coders.")
 			break
 

--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -238,7 +238,7 @@ GLOBAL_LIST_EMPTY(shuttle_controls)
 			return
 		if(istype(shuttle, /datum/shuttle/ferry/marine))
 			var/datum/shuttle/ferry/marine/s = shuttle
-			if(!s.locs_land.len && !s.transit_gun_mission)
+			if(!length(s.locs_land) && !s.transit_gun_mission)
 				to_chat(usr, SPAN_WARNING("There is no suitable LZ for this shuttle. Flight configuration changed to fire-mission."))
 				s.transit_gun_mission = 1
 		if(shuttle.moving_status == SHUTTLE_IDLE) //Multi consoles, hopefully this will work

--- a/code/modules/teleporters/teleporter.dm
+++ b/code/modules/teleporters/teleporter.dm
@@ -29,12 +29,12 @@
 	var/list/turf/source_turfs = locations[location_source]
 	var/list/turf/dest_turfs = locations[location_dest]
 
-	if(!source_turfs || source_turfs.len == 0)
+	if(!LAZYLEN(source_turfs))
 		log_debug("Invalid source location ID [location_source] handed to teleporter [id]. Error code: TELEPORTER_3")
 		log_admin("Invalid source location ID [location_source] handed to teleporter [id]. Tell the devs. Error code: TELEPORTER_3")
 		return FALSE
 
-	if(!dest_turfs || dest_turfs.len == 0)
+	if(!LAZYLEN(dest_turfs))
 		log_debug("Invalid destination location ID [location_dest] handed to teleporter [id]. Error code: TELEPORTER_3")
 		log_admin("Invalid destination location ID [location_dest] handed to teleporter [id]. Tell the devs. Error code: TELEPORTER_3")
 		return FALSE

--- a/code/modules/teleporters/teleporter_console.dm
+++ b/code/modules/teleporters/teleporter_console.dm
@@ -175,7 +175,7 @@
 	if(SSmapping.configs[GROUND_MAP].map_name != MAP_CORSAT) // Bad style, but I'm leaving it here for now until someone wants to add a teleporter to another map
 		return
 
-	if(GLOB.teleporters.len) // already made the damn thing
+	if(length(GLOB.teleporters)) // already made the damn thing
 		return
 
 	var/datum/teleporter/corsat/teleporter = new

--- a/code/modules/tgs/core/tgs_version.dm
+++ b/code/modules/tgs/core/tgs_version.dm
@@ -5,11 +5,11 @@
 	var/list/version_bits = splittext(deprefixed_parameter, ".")
 
 	suite = text2num(version_bits[1])
-	if(version_bits.len > 1)
+	if(length(version_bits) > 1)
 		minor = text2num(version_bits[2])
-		if(version_bits.len > 2)
+		if(length(version_bits) > 2)
 			patch = text2num(version_bits[3])
-			if(version_bits.len == 4)
+			if(length(version_bits) == 4)
 				deprecated_patch = text2num(version_bits[4])
 
 /datum/tgs_version/proc/Valid(allow_wildcards = FALSE)

--- a/code/modules/tgs/v3210/api.dm
+++ b/code/modules/tgs/v3210/api.dm
@@ -64,17 +64,17 @@
 		instance_name = "TG Station Server" //maybe just upgraded
 
 	var/list/logs = TGS_FILE2LIST(".git/logs/HEAD")
-	if(logs.len)
-		logs = splittext(logs[logs.len], " ")
-		if (logs.len >= 2)
+	if(length(logs))
+		logs = splittext(logs[length(logs)], " ")
+		if (length(logs) >= 2)
 			commit = logs[2]
 		else
 			TGS_ERROR_LOG("Error parsing commit logs")
 
 	logs = TGS_FILE2LIST(".git/logs/refs/remotes/origin/master")
-	if(logs.len)
-		logs = splittext(logs[logs.len], " ")
-		if (logs.len >= 2)
+	if(length(logs))
+		logs = splittext(logs[length(logs)], " ")
+		if (length(logs) >= 2)
 			originmastercommit = logs[2]
 		else
 			TGS_ERROR_LOG("Error parsing origin commmit logs")

--- a/code/modules/tgui_panel/telemetry.dm
+++ b/code/modules/tgui_panel/telemetry.dm
@@ -85,7 +85,7 @@
 		var/list/row = telemetry_connections[i]
 
 		// Check for a malformed history object
-		if (!row || row.len < 3 || (!row["ckey"] || !row["address"] || !row["computer_id"]))
+		if (LAZYLEN(row) < 3 || (!row["ckey"] || !row["address"] || !row["computer_id"]))
 			continue
 
 		/* TODO - Reintroduce this when we get a proper round ID tracking,

--- a/code/modules/unit_tests/unit_test.dm
+++ b/code/modules/unit_tests/unit_test.dm
@@ -87,7 +87,7 @@ GLOBAL_VAR_INIT(focused_test, focused_test())
 /datum/unit_test/proc/allocate(type, ...)
 	var/list/arguments = args.Copy(2)
 	if(ispath(type, /atom))
-		if (!arguments.len)
+		if (!length(arguments))
 			arguments = list(run_loc_floor_bottom_left)
 		else if (arguments[1] == null)
 			arguments[1] = run_loc_floor_bottom_left

--- a/code/modules/vehicles/hardpoints/primary/minigun.dm
+++ b/code/modules/vehicles/hardpoints/primary/minigun.dm
@@ -61,7 +61,7 @@
 	COOLDOWN_START(src, fire_cooldown, fire_delay * stage_delay_mult)
 
 /obj/item/hardpoint/primary/minigun/proc/calculate_stage_delay_mult()
-	var/stage_rate_len = stage_rate.len
+	var/stage_rate_len = length(stage_rate)
 	var/delta_time = world.time - last_fired
 
 	var/old_spin_stage = spin_stage

--- a/code/modules/vehicles/multitile/multitile_verbs.dm
+++ b/code/modules/vehicles/multitile/multitile_verbs.dm
@@ -65,7 +65,7 @@
 	if(!new_hp)
 		new_hp = 0
 
-	new_hp = (new_hp % usable_hps.len) + 1
+	new_hp = (new_hp % length(usable_hps)) + 1
 	var/obj/item/hardpoint/HP = usable_hps[new_hp]
 	if(!HP)
 		return


### PR DESCRIPTION

# About the pull request

Replaces `list.len` lookup with `length(list)`.

The following replacements are broadly applied:
- `list.len` -> `length(list)` : except where `len is being assigned or modified, such as `list.len--`, which is a valid use-case
- `list && list.len`, `!isnull(list) && list.len`, `list?.len` -> `LAZYLEN(list)` : also the inverted form; `LAZYLEN` is just a define for `length` but is used here to more clearly communicate that originally the list was tested for existence
- `if(list.len) list.Cut()` -> `LAZYCLEARLIST(list)` : identical to the define so instead of replacing `len` with `length` just used the define

A few one-offs:
- `(list?(list.len):(0))` -> `(LAZYLEN(list) || 0)` in `recipe.dm` : resulting value gets assigned to a variable that is used elsewhere, so ensured it returned 0 in the same circumstances
- `if(!list || !list.len) { return FALSE } if(list?.len) { ...`-> `if(!LAZYLEN(list)) { return FALSE } ...` in `modify_variables.dm` : simplified two branching checks into one
- `!list || list.len == 0` -> `!LAZYLEN(list)` in `teleporter.dm` : removed the `==` test to allow simplifying down to `LAZYLEN` while ensuring it has the same truthiness

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

`length(list)` is preferred over `list.len` since it inherently handles nulls and is allegedly slightly more performant.
# Testing Photographs and Procedure
Boots without issue.


# Changelog
No player-facing changes.
