### PR TITLE
Burrower burrow transparency

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_powers.dm
@@ -36,6 +36,7 @@
 	// TODO Make immune to all damage here.
 	to_chat(src, SPAN_XENOWARNING("We burrow ourselves into the ground."))
 	invisibility = 101
+	alpha = 100
 	anchored = TRUE
 	if(caste.fire_immunity == FIRE_IMMUNITY_NONE)
 		RegisterSignal(src, COMSIG_LIVING_PREIGNITION, PROC_REF(fire_immune))
@@ -72,6 +73,7 @@
 		))
 	remove_traits(list(TRAIT_ABILITY_BURROWED, TRAIT_UNDENSE, TRAIT_IMMOBILIZED), TRAIT_SOURCE_ABILITY("Burrow"))
 	invisibility = FALSE
+	alpha = initial(alpha)
 	anchored = FALSE
 	playsound(loc, 'sound/effects/burrowoff.ogg', 25)
 	for(var/mob/living/carbon/mob in loc)


### PR DESCRIPTION

# About the pull request

Burrower used to be completely invisible to the user when burrowed, this was suddenly changed some time ago (idk when, I was away) and made the Burrower completely visible as if he isnt underground.

This PR will bring back the immersion and improve it. Now the Burrower becomes partly transparent while burrowed as a visual indication that you did actually burrow and are currently underground.

Was tested, xenos and thermal equipment (pred masks, bug-b-gone goggles etc.) can still see their health/plasma/rank HUD as before (now just more transparently) and the burrower is still 100% invisible to humans.

# Explain why it's good for the game

Improves immersion, fixes a bug (I assume it is considering I've found no PR linked to the change), makes Burrower mains struggle less if they actually burrowed or not


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

video of the "new" feature (actually a fix) in action: https://gachi.gay/u1Ik4

</details>


# Changelog

:cl:Unknownity
fix: Burrowers now see themselves as partly transparent when burrowed.
/:cl:

