### PR TITLE
Adds map name to game mode logging at round start.

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -108,7 +108,7 @@ GLOBAL_VAR_INIT(cas_tracking_id_increment, 0) //this var used to assign unique t
 	log_game("Round started at [time2text(world.realtime)]")
 	log_game("Operation time at round start is [worldtime2text()]")
 	if(SSticker.mode)
-		log_game("Game mode set to [SSticker.mode]")
+		log_game("Game mode set to [SSticker.mode] on the [SSmapping.configs[GROUND_MAP].map_name] map")
 	log_game("Server IP: [world.internet_address]:[world.port]")
 	return TRUE
 


### PR DESCRIPTION

# About the pull request

Adds the name of the map to the round start log with the game mode.

# Explain why it's good for the game

This will make tracking map related data easier via logs and data collection.  Evidently we did not do this in a very obvious place before, and the only way to know that a map was on while looking at logs exclusively was through context clues.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
code: log the map name at round start
/:cl:
