### PR TITLE
some grammar fixes on xeno bioscan announcement

### DIFF
--- a/code/game/bioscans.dm
+++ b/code/game/bioscans.dm
@@ -151,7 +151,7 @@ GLOBAL_DATUM_INIT(bioscan_data, /datum/bioscan_data, new)
 	var/planet_location = "[marines_on_planet && marine_planet_location ? ", including one in [marine_planet_location]" : ""]"
 
 	var/title = SPAN_XENOANNOUNCE("The Queen Mother reaches into your mind from worlds away.")
-	var/content = SPAN_XENOANNOUNCE("To my children and their Queen. I sense [metalhive_hosts] host[plural] in the metal hive [metalhive_location] and [planet_hosts] scattered elsewhere[planet_location].")
+	var/content = SPAN_XENOANNOUNCE("To my children and their Queen: I sense [metalhive_hosts] host[plural] in the metal hive[metalhive_location] and [planet_hosts] scattered elsewhere[planet_location].")
 
 	log_game("BIOSCAN: Queen Mother bioscan completed. [content]")
 	/// Shout it at everyone


### PR DESCRIPTION
# About the pull request
removes a space, replaces a period with a colon since it's an address

# Explain why it's good for the game
formatting errors make me :(
the spacing was right on the second half of the bioscan for xenos but not the first idk

# Testing Photographs and Procedure
how it is
![image](https://github.com/cmss13-devs/cmss13/assets/29965103/4bd02923-4851-4b44-b1d2-512d861b7a9f)
how it could be
![image](https://github.com/cmss13-devs/cmss13/assets/29965103/73afb84a-2be6-48a8-bf04-a15cec70b97c)
# Changelog
:cl:
spellcheck: fixed a few typos in the xeno bioscan announcement
/:cl: