### PR TITLE
removes facehugger plasma

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -1,8 +1,8 @@
 /datum/caste_datum/facehugger
 	caste_type = XENO_CASTE_FACEHUGGER
 	tier = 0
-	plasma_gain = 0.1
-	plasma_max = 10
+	plasma_gain = XENO_PLASMA_GAIN_TIER_1
+	plasma_max = XENO_NO_PLASMA
 	melee_damage_lower = 5
 	melee_damage_upper = 5
 	max_health = XENO_HEALTH_LARVA
@@ -249,6 +249,14 @@
 
 /datum/behavior_delegate/facehugger_base
 	name = "Base Facehugger Behavior Delegate"
+
+/mob/living/carbon/xenomorph/facehugger/ghostize(can_reenter_corpse = FALSE, aghosted = FALSE)
+	. = ..()
+	if(. && !aghosted)
+		gib()
+
+/mob/living/carbon/xenomorph/facehugger/handle_ghost_message()
+	return
 
 /datum/behavior_delegate/facehugger_base/on_life()
 	if(bound_xeno.body_position == STANDING_UP && !(locate(/obj/effect/alien/weeds) in get_turf(bound_xeno)))

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -253,7 +253,8 @@
 /mob/living/carbon/xenomorph/facehugger/ghostize(can_reenter_corpse = FALSE, aghosted = FALSE)
 	. = ..()
 	if(. && !aghosted)
-		gib()
+		new /obj/item/clothing/mask/facehugger(loc, hivenumber)
+		qdel(src)
 
 /mob/living/carbon/xenomorph/facehugger/handle_ghost_message()
 	return

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -250,15 +250,6 @@
 /datum/behavior_delegate/facehugger_base
 	name = "Base Facehugger Behavior Delegate"
 
-/mob/living/carbon/xenomorph/facehugger/ghostize(can_reenter_corpse = FALSE, aghosted = FALSE)
-	. = ..()
-	if(. && !aghosted)
-		new /obj/item/clothing/mask/facehugger(loc, hivenumber)
-		qdel(src)
-
-/mob/living/carbon/xenomorph/facehugger/handle_ghost_message()
-	return
-
 /datum/behavior_delegate/facehugger_base/on_life()
 	if(bound_xeno.body_position == STANDING_UP && !(locate(/obj/effect/alien/weeds) in get_turf(bound_xeno)))
 		bound_xeno.adjustBruteLoss(1)


### PR DESCRIPTION
# About the pull request

Facehuggers have no plasma, their abilities don't use plasma, they don't have any reason to have plasma, just HUD clutter.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Facehuggers no longer show as having any plasma

/:cl:
