### PR TITLE
"Upgraded custom incinerator tank" nerf

### DIFF
--- a/code/modules/projectiles/magazines/flamer.dm
+++ b/code/modules/projectiles/magazines/flamer.dm
@@ -257,10 +257,9 @@
 	matter = list("metal" = 50) // no free metal
 	flamer_chem = null
 	max_rounds = 200
-	max_range = 7
+	max_range = 6
 	fuel_pressure = 1
 	max_duration = 50
-	max_intensity = 60
 	custom = TRUE
 
 /obj/item/ammo_magazine/flamer_tank/smoke/upgraded


### PR DESCRIPTION
# About the pull request

Downgrades flamer_tank/custom/upgraded to flamer_tank/large/X (almost, napalmx has 40 duration instead of 50). Pyro still has even better custom tank.

# Explain why it's good for the game

It's too op for non specialists to have 1.5(+fire penetration, +1 range) better fire than roundstart pyro, and same as custom pyro. It is not ok for non specialist to deal about 500 damage (initial setting on fire and 10 second before extinguish) in 1 click of flamer. Also, it makes pyro with custom fuel fully replaceable.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
balance: reduces max intensity and max range of "Upgraded custom incinerator tank".
/:cl:
