### PR TITLE
Fix OD lint errors

### DIFF
--- a/code/__pragmas.dm
+++ b/code/__pragmas.dm
@@ -12,7 +12,6 @@
 #pragma SoftReservedKeyword error
 #pragma DuplicateVariable error
 #pragma DuplicateProcDefinition error
-#pragma TooManyArguments error
 #pragma PointlessParentCall error
 #pragma PointlessBuiltinCall error
 #pragma SuspiciousMatrixCall error

--- a/code/datums/global_variables.dm
+++ b/code/datums/global_variables.dm
@@ -118,15 +118,11 @@
 
 /client/proc/debug_global_variable(name, value, level)
 	var/html = ""
-	var/change = 0
 	//to make the value bold if changed
 	if(!(admin_holder.rights & R_DEBUG))
 		return html
 
 	html += "<li style='backgroundColor:white'><a href='?_src_=glob_vars;varnameedit=[name]'>E</a><a href='?_src_=glob_vars;varnamechange=[name]'>C</a> "
-	if(value != initial(global.vars[name]))
-		html += "<font color='#B300B3'>"
-		change = 1
 
 	if (isnull(value))
 		html += "[name] = <span class='value'>null</span>"
@@ -175,8 +171,6 @@
 
 	else
 		html += "[name] = <span class='value'>[value]</span>"
-	if(change)
-		html += "</font>"
 
 	html += "</li>"
 
@@ -353,7 +347,6 @@
 		if(admin_holder && admin_holder.marked_datum)
 			possible_classes += "marked datum"
 		possible_classes += "edit referenced object"
-		possible_classes += "restore to default"
 
 		class = tgui_input_list(usr, "What kind of variable?","Variable Type", possible_classes)
 		if(!class)
@@ -364,9 +357,6 @@
 		if("list")
 			mod_list(global.vars[variable])
 			return
-
-		if("restore to default")
-			global.vars[variable] = initial(global.vars[variable])
 
 		if("edit referenced object")
 			return .(global.vars[variable])


### PR DESCRIPTION

# About the pull request

This PR fixes these messages for the OD lint:
```
Warning OD1002 at code/__pragmas.dm:15:26: Warning 'TooManyArguments' does not exist
Error OD0000 at code/datums/global_variables.dm:127:30: attempt to reference r-value
Error OD0000 at code/datums/global_variables.dm:369:44: attempt to reference r-value
```
`TooManyArguments` was replaced with `InvalidArgumentCount` which should already be an error. The other two errors are regarding initial not working on globals, which it does not appear to.

# Explain why it's good for the game

Passing checks is good.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/76988376/22a4520c-555d-4d03-971d-703b4bb6197e)

</details>


# Changelog

No player facing changes.
