### PR TITLE
Moves click_adjacent logic to MouseDown

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -17,12 +17,13 @@
 	~ BMC777
 */
 
-/client/Click(atom/A, location, control, params)
+/client/Click(atom/A, location, control, params, mouse_down=FALSE)
+	to_world("Mouse Down: [mouse_down] Ignore Next Click: [ignore_next_click]")
 	if (control && !ignore_next_click) // No .click macros allowed, and only one click per mousedown.
 		ignore_next_click = TRUE
-		return usr.do_click(A, location, params)
+		return usr.do_click(A, location, params, mouse_down)
 
-/mob/proc/do_click(atom/A, location, params)
+/mob/proc/do_click(atom/A, location, params, mouse_down)
 	// We'll be sending a lot of signals and things later on, this will save time.
 	if(!client)
 		return
@@ -130,9 +131,10 @@
 		return
 
 	next_move = world.time
-	// If standing next to the atom clicked.
+	// Ontop or right next to us
 	if(A.Adjacent(src))
-		click_adjacent(A, W, mods)
+		if(mouse_down)
+			click_adjacent(A, W, mods)
 		return
 
 	// If not standing next to the atom clicked.

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -18,7 +18,6 @@
 */
 
 /client/Click(atom/A, location, control, params, mouse_down=FALSE)
-	to_world("Mouse Down: [mouse_down] Ignore Next Click: [ignore_next_click]")
 	if (control && !ignore_next_click) // No .click macros allowed, and only one click per mousedown.
 		ignore_next_click = TRUE
 		return usr.do_click(A, location, params, mouse_down)

--- a/code/_onclick/click_hold.dm
+++ b/code/_onclick/click_hold.dm
@@ -55,6 +55,9 @@
 
 		Click(A, T, skin_ctl, params)
 
+	if(A.Adjacent(mob))
+		Click(A, T, skin_ctl, params, TRUE)
+
 /client/MouseUp(atom/A, turf/T, skin_ctl, params)
 	if(!A)
 		return


### PR DESCRIPTION

# About the pull request
Makes it so adjacent clicks are handled on when you press down the button instead of when you press it up
This affects things like pointblanks, melee attacks, picking up items etc etc

Did some testing and fixed things like clicks not working or no click delay melee attacks but there are probably more so it needs to be tested
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Pointblank wise all of the gun code was already using MouseDown so no reason for pointblanks to stay behind, Other than that this should make adjacent clicks get "eaten" less (since if you too slow to mouse up the click won't be counted) and overall faster reaction time to your actions
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Adjacent clicks are now registered on mouse down instead of mouse up, this affects pointblanks, melee attacks etc.
/:cl:
