### PR TITLE
In-view verbs work for varying view ranges

### DIFF
--- a/code/modules/admin/callproc.dm
+++ b/code/modules/admin/callproc.dm
@@ -230,7 +230,7 @@ GLOBAL_PROTECT(LastAdminCalledProc)
 	to_chat(usr, SPAN_BOLDWARNING("Warning: Force attempt has been logged."))
 	message_admins("[key_name(usr)] has attempted to execute a restricted proc. ([procname])")
 
-/client/proc/callproc_datum(datum/called_datum as null|area|mob|obj|turf)
+/client/proc/callproc_datum(datum/called_datum as null|area|mob|obj|turf in view(src))
 	set category = "Debug"
 	set name = "Datum ProcCall"
 	set waitfor = FALSE

--- a/code/modules/admin/tabs/admin_tab.dm
+++ b/code/modules/admin/tabs/admin_tab.dm
@@ -435,7 +435,7 @@
 	if(tgui_alert(src, "Do you want to strip yourself as well?", "Confirmation", list("Yes", "No")) == "Yes")
 		strip_self = TRUE
 
-	for(var/mob/living/current_mob in view())
+	for(var/mob/living/current_mob in view(src))
 		if(!strip_self && usr == current_mob)
 			continue
 		for (var/obj/item/current_item in current_mob)
@@ -458,7 +458,7 @@
 	if(alert("This will rejuvenate ALL mobs within your view range. Are you sure?",,"Yes","Cancel") == "Cancel")
 		return
 
-	for(var/mob/living/M in view())
+	for(var/mob/living/M in view(src))
 		M.rejuvenate(FALSE)
 
 	message_admins(WRAP_STAFF_LOG(usr, "ahealed everyone in [get_area(usr)] ([usr.x],[usr.y],[usr.z])."), usr.x, usr.y, usr.z)
@@ -476,7 +476,7 @@
 	if(alert("This will rejuvenate ALL humans within your view range. Are you sure?",,"Yes","Cancel") == "Cancel")
 		return
 
-	for(var/mob/living/carbon/human/M in view())
+	for(var/mob/living/carbon/human/M in view(src))
 		M.rejuvenate(FALSE)
 
 	message_admins(WRAP_STAFF_LOG(usr, "ahealed all humans in [get_area(usr)] ([usr.x],[usr.y],[usr.z])"), usr.x, usr.y, usr.z)
@@ -493,7 +493,7 @@
 	if(alert("This will rejuvenate ALL revivable humans within your view range. Are you sure?",,"Yes","Cancel") == "Cancel")
 		return
 
-	for(var/mob/living/carbon/human/M in view())
+	for(var/mob/living/carbon/human/M in view(src))
 		if(!ishuman_strict(M) && !ishumansynth_strict(M))
 			continue
 
@@ -519,7 +519,7 @@
 	if(alert("This will rejuvenate ALL xenos within your view range. Are you sure?",,"Yes","Cancel") == "Cancel")
 		return
 
-	for(var/mob/living/carbon/xenomorph/X in view())
+	for(var/mob/living/carbon/xenomorph/X in view(src))
 		X.rejuvenate(FALSE)
 
 	message_admins(WRAP_STAFF_LOG(usr, "ahealed all xenos in [get_area(usr)] ([usr.x],[usr.y],[usr.z])"), usr.x, usr.y, usr.z)

--- a/code/modules/admin/verbs/freeforghosts.dm
+++ b/code/modules/admin/verbs/freeforghosts.dm
@@ -38,7 +38,7 @@
 	if(alert("This will free ALL mobs within your view range. Are you sure?",,"Yes","Cancel") == "Cancel")
 		return
 
-	for(var/mob/living/M in view())
+	for(var/mob/living/M in view(src))
 		free_for_ghosts(M, notify = FALSE)
 
 	message_admins(WRAP_STAFF_LOG(usr, "freed all mobs in [get_area(usr)] ([usr.x],[usr.y],[usr.z])"), usr.x, usr.y, usr.z)

--- a/code/modules/admin/verbs/mob_verbs.dm
+++ b/code/modules/admin/verbs/mob_verbs.dm
@@ -203,7 +203,7 @@
 		else
 			return
 
-/client/proc/cmd_admin_object_narrate(obj/selected)
+/client/proc/cmd_admin_object_narrate(obj/selected in view(src))
 	set name = "Object Narrate"
 	set category = null
 
@@ -234,7 +234,7 @@
 	log_admin("[key_name(src)] sent an Object Narrate with message [message].")
 	message_admins("[key_name(src)] sent an Object Narrate with message [message].")
 
-/client/proc/cmd_admin_direct_narrate(mob/M)
+/client/proc/cmd_admin_direct_narrate(mob/M in GLOB.mob_list)
 	set name = "Narrate"
 	set category = null
 
@@ -330,7 +330,7 @@
 
 	message_admins("[key_name_admin(usr)] made [key_name_admin(M)] drop everything!")
 
-/client/proc/cmd_admin_change_their_hivenumber(mob/living/carbon/H)
+/client/proc/cmd_admin_change_their_hivenumber(mob/living/carbon/H in GLOB.living_mob_list)
 	set name = "Change Hivenumber"
 	set category = null
 
@@ -370,7 +370,7 @@
 	message_admins("[key_name(src)] changed hivenumber of [H] to [H.hivenumber].")
 
 
-/client/proc/cmd_admin_change_their_name(mob/living/carbon/carbon)
+/client/proc/cmd_admin_change_their_name(mob/living/carbon/carbon in GLOB.living_mob_list)
 	set name = "Change Name"
 	set category = null
 

--- a/code/modules/admin/verbs/select_equipment.dm
+++ b/code/modules/admin/verbs/select_equipment.dm
@@ -98,7 +98,7 @@
 				var/datum/job/J = GLOB.RoleAuthority.roles_by_name[newskillset]
 				H.set_skills(J.get_skills())
 
-/client/proc/cmd_admin_dress(mob/M)
+/client/proc/cmd_admin_dress(mob/M in GLOB.mob_list)
 	set category = null
 	set name = "Select Equipment"
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -662,7 +662,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	usr.forceMove(pick(L))
 	following = null
 
-/mob/dead/observer/proc/scan_health(mob/living/target in view(src.client))
+/mob/dead/observer/proc/scan_health(mob/living/target in GLOB.living_mob_list)
 	set name = "Scan Health"
 
 	if(!istype(target))
@@ -695,7 +695,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		last_health_display.target_mob = target
 	last_health_display.look_at(src, DETAIL_LEVEL_FULL, bypass_checks = TRUE)
 
-/mob/dead/observer/verb/follow_local(mob/target)
+/mob/dead/observer/verb/follow_local(mob/target in GLOB.mob_list)
 	set category = "Ghost.Follow"
 	set name = "Follow Local Mob"
 	set desc = "Follow on-screen mob"

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -484,7 +484,7 @@ GLOBAL_LIST_INIT(limb_types_by_name, list(
  * [this byond forum post](https://secure.byond.com/forum/?post=1326139&page=2#comment8198716)
  * for why this isn't atom/verb/examine()
  */
-/mob/verb/examinate(atom/examinify as mob|obj|turf in view())
+/mob/verb/examinate(atom/examinify as mob|obj|turf in view(client))
 	set name = "Examine"
 	set category = "IC"
 


### PR DESCRIPTION

# About the pull request

Admin "InView" procs now take the user's current view range into account. If you zoom out as a ghost, it will use your current view size as you'd expect.

Where possible, admin and observer procs use a global list check instead of a view check. This prevents an issue where a right-clicked subject moves out of view before you can click on the menu option, which causes the option to fail and fill your command bar with some useless text.

Does *not* take view offsets into account, e.g. binoculars shifting `client.pixel_x` & `client.pixel_y`

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Procs billed as "in-view" should work based on your current view range. Right-click actions without a specific range cap should work on anything in your view range.
# Testing Photographs and Procedure
Each proc continues to work as expected, just with more lenient ranging rules.


# Changelog
:cl:
qol: ghost health scan & follow right-click actions work at any range
admin: "InView" procs use your current view range (e.g. ghost zoom)
/:cl:
