### PR TITLE
Allows pyro spec flamer tanks to accept custom fuel

### DIFF
--- a/code/modules/projectiles/magazines/flamer.dm
+++ b/code/modules/projectiles/magazines/flamer.dm
@@ -196,6 +196,7 @@
 	item_state = "flametank_large"
 	max_rounds = 250
 	gun_type = /obj/item/weapon/gun/flamer/M240T
+	custom = TRUE
 
 	max_intensity = 80
 	max_range = 5


### PR DESCRIPTION

# About the pull request
Allows pyro spec's fuel tanks to accept custom fuel
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
No reason for the spec known for using flames to be left behind with the new flamer fuels that can be made now
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Allows pyro spec flamer tanks to accept custom fuels.
/:cl:
