### PR TITLE
Vampire Lurker Changes (TailStab/Armour/Speed)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_powers.dm
@@ -267,10 +267,10 @@
 
 	if(iscarbon(hit_target) && !xeno.can_not_harm(hit_target) && hit_target.stat != DEAD)
 		if(targeted_atom == hit_target) //reward for a direct hit
-			to_chat(xeno, SPAN_XENOHIGHDANGER("We attack [hit_target], with our tail, piercing their body!"))
+			to_chat(xeno, SPAN_XENOHIGHDANGER("We directly slam [hit_target] with our tail, throwing it back after impaling it on our tail!"))
 			hit_target.apply_armoured_damage(15, ARMOR_MELEE, BRUTE, "chest")
 		else
-			to_chat(xeno, SPAN_XENODANGER("We attack [hit_target], slashing them with our tail!"))
+			to_chat(xeno, SPAN_XENODANGER("We attack [hit_target] with our tail, throwing it back after stabbing it with our tail!"))
 	else
 		xeno.visible_message(SPAN_XENOWARNING("\The [xeno] swipes their tail through the air!"), SPAN_XENOWARNING("We swipe our tail through the air!"))
 		apply_cooldown(cooldown_modifier = 0.2)
@@ -282,18 +282,9 @@
 
 	stab_direction = turn(get_dir(xeno, targeted_atom), 180)
 	playsound(hit_target,'sound/weapons/alien_tail_attack.ogg', 50, TRUE)
+	if(hit_target.mob_size < MOB_SIZE_BIG)
+		step_away(hit_target, xeno)
 
-	var/direction = Get_Compass_Dir(xeno, targeted_atom) //More precise than get_dir.
-
-	if(!step(hit_target, direction))
-		playsound(hit_target.loc, "punch", 25, 1)
-		hit_target.visible_message(SPAN_DANGER("[hit_target] slams into an obstacle!"),
-		isxeno(hit_target) ? SPAN_XENODANGER("We slam into an obstacle!") : SPAN_HIGHDANGER("You slam into an obstacle!"), null, 4, CHAT_TYPE_TAKING_HIT)
-		hit_target.apply_damage(MELEE_FORCE_TIER_2)
-		if (hit_target.mob_size < MOB_SIZE_BIG)
-			hit_target.KnockDown(0.5)
-		else
-			hit_target.Slow(0.5)
 	/// To reset the direction if they haven't moved since then in below callback.
 	var/last_dir = xeno.dir
 
@@ -305,7 +296,11 @@
 	addtimer(CALLBACK(src, PROC_REF(reset_direction), xeno, last_dir, new_dir), 0.5 SECONDS)
 
 	hit_target.apply_armoured_damage(get_xeno_damage_slash(hit_target, xeno.caste.melee_damage_upper), ARMOR_MELEE, BRUTE, "chest")
-	hit_target.Slow(0.5)
+
+	if(hit_target.mob_size < MOB_SIZE_BIG)
+		hit_target.apply_effect(0.5, WEAKEN)
+	else
+		hit_target.apply_effect(0.5, SLOW)
 
 	hit_target.last_damage_data = create_cause_data(xeno.caste_type, xeno)
 	log_attack("[key_name(xeno)] attacked [key_name(hit_target)] with Tail Jab")

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/lurker/vampire.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/lurker/vampire.dm
@@ -20,8 +20,7 @@
 /datum/xeno_strain/vampire/apply_strain(mob/living/carbon/xenomorph/lurker/lurker)
 	lurker.plasmapool_modifier = 0
 	lurker.health_modifier -= XENO_HEALTH_MOD_MED
-	lurker.speed_modifier += XENO_SPEED_FASTMOD_TIER_1
-	lurker.armor_modifier += XENO_ARMOR_MOD_LARGE
+	lurker.armor_modifier += XENO_ARMOR_MOD_SMALL
 	lurker.damage_modifier -= XENO_DAMAGE_MOD_VERY_SMALL
 	lurker.attack_speed_modifier -= 2
 

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/lurker/vampire.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/lurker/vampire.dm
@@ -1,6 +1,6 @@
 /datum/xeno_strain/vampire
 	name = LURKER_VAMPIRE
-	description = "You lose all of your abilities and you forefeit a chunk of your health and damage in exchange for a large amount of armor, a little bit of movement speed, increased attack speed, and brand new abilities that make you an assassin. Rush on your opponent to disorient them and Flurry to unleash a forward cleave that can hit and slow three talls and heal you for every tall you hit. Use your special AoE Tail Jab to knock talls away, doing more damage with direct hits and even more damage and a stun if they smack into walls. Finally, execute unconscious talls with a headbite to heal your wounds."
+	description = "You lose all of your abilities and you forefeit a chunk of your health and damage in exchange for a small amount of armor, increased attack speed, and brand new abilities that make you an assassin. Rush on your opponent to disorient them and Flurry to unleash a forward cleave that can hit and slow three talls and heal you for every tall you hit. Use your special AoE Tail Jab to knock away talls and stun them, doing more damage with direct hits. Finally, execute unconscious talls with a headbite to heal your wounds."
 	flavor_description = "Show no mercy! Slaughter them all!"
 	icon_state_prefix = "Vampire"
 


### PR DESCRIPTION

# About the pull request

Vampire re-gains its Tail Stab stun on hit

Vampire has had its armour reduced from 20 to 10

Vampire no longer gains any speed-boost over the default Lurker. 

# Explain why it's good for the game

The recent changes to the Vampire strain of the Lurker have, I feel, missed the true reasons as to why the strain is seen as more oppressive than you would expect from a T2 strain. Under the control of the best players, the strain's dominance is due to its ability to move at incredible speeds off-weeds and shrug off significant damage thanks to its high armour whilst having the ability to easily disengage from combat.

The removal of its tail-stab stun failed to touch the real issues plaguing the strain and simply made the strain significantly harder for a new player to get engaged with, as the micro-stun played a important role in the Vampire's combo of landing hits. Whilst the stun removal had absolutely zero impact on a higher skilled players ability to dominate with the role as the reasons why they are allowed to dominate were left untouched.

By making my proposed changes, a Vampire Lurker is now much easier for a Marine to track and shoot, instead of moving basically as fast as a Runner, plus its lack of armour AND the fact it has less health than a stock Lurker makes it take damage much faster, especially from weapons with armour penetration. Its tiny amount of armour offers a small amount of defence but not enough to make it very tanky.

Its health is as such where two point-blank buckshots will crit it, and a single PB will leave it on the verge of crit. Not too dissimilar to the base Lurker. 

I believe this change will reign in some of the more excessive gameplay elements from the most skilled players whilst not overly harming the roles ability to function AND making it easier for new players to get into the role. 

(I should note that removing or reducing the range of its leap ability would further eliminate these issues but I will await feedback before making any change here, as this may have harsher implications for the role)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: The Vampire Lurker has re-gained its tail-stab stun.
balance: To compensate, the Vampire Lurker no longer gains any speed-boost bonus over the default Lurker, and its armour has been reduced from 20 to 10. 
/:cl:
