### PR TITLE
stops mentors seeing debug messages

### DIFF
--- a/code/__HELPERS/logging.dm
+++ b/code/__HELPERS/logging.dm
@@ -90,9 +90,10 @@ GLOBAL_VAR_INIT(log_end, world.system_type == UNIX ? ascii2text(13) : "")
 
 	GLOB.STUI?.debug.Add("\[[time]]DEBUG: [text]")
 	GLOB.STUI?.processing |= STUI_LOG_DEBUG
-	for(var/client/C in GLOB.admins)
-		if(C.prefs.toggles_chat & CHAT_DEBUGLOGS)
-			to_chat(C, "DEBUG: [text]", type = MESSAGE_TYPE_DEBUG)
+	for(var/client/client in GLOB.admins)
+		if(CLIENT_IS_STAFF(client))
+			if(client.prefs.toggles_chat & CHAT_DEBUGLOGS)
+				to_chat(client, "DEBUG: [text]", type = MESSAGE_TYPE_DEBUG)
 
 
 /proc/log_game(text)

--- a/code/controllers/mc/failsafe.dm
+++ b/code/controllers/mc/failsafe.dm
@@ -155,7 +155,7 @@ GLOBAL_REAL(Failsafe, /datum/controller/failsafe)
 	if (. == 1) //We were able to create a new master
 		SSticker.Recover(); //Recover the ticket system so the Masters runlevel gets set
 		Master.Initialize(10, FALSE, TRUE) //Need to manually start the MC, normally world.new would do this
-		to_chat(GLOB.admins, SPAN_ADMINNOTICE("MC successfully recreated after recovering all subsystems!"))
+		message_admins(SPAN_ADMINNOTICE("MC successfully recreated after recovering all subsystems!"))
 	else
 		message_admins(SPAN_BOLDANNOUNCE("Failed to create new MC!"))
 
@@ -169,7 +169,7 @@ GLOBAL_REAL(Failsafe, /datum/controller/failsafe)
 	if (. == 1) //We were able to create a new master
 		SSticker.Recover(); //Recover the ticket system so the Masters runlevel gets set
 		Master.Initialize(10, FALSE, TRUE) //Need to manually start the MC, normally world.new would do this
-		to_chat(GLOB.admins, SPAN_ADMINNOTICE("MC successfully recreated after deleting and recreating all subsystems!"))
+		message_admins(SPAN_ADMINNOTICE("MC successfully recreated after deleting and recreating all subsystems!"))
 	else
 		message_admins(SPAN_BOLDANNOUNCE("Failed to create new MC!"))
 

--- a/code/controllers/mc/master.dm
+++ b/code/controllers/mc/master.dm
@@ -194,7 +194,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 				msg = "The [BadBoy.name] subsystem seems to be destabilizing the MC and will be put offline."
 				BadBoy.flags |= SS_NO_FIRE
 		if(msg)
-			to_chat(GLOB.admins, SPAN_BOLDANNOUNCE("[msg]"))
+			message_admins(SPAN_BOLDANNOUNCE("[msg]"))
 			log_world(msg)
 
 	if (istype(Master.subsystems))

--- a/code/modules/tgchat/to_chat.dm
+++ b/code/modules/tgchat/to_chat.dm
@@ -29,6 +29,14 @@
 	if(target == world)
 		target = GLOB.clients
 
+	var/list/true_targets = list()
+	if(target == GLOB.admins)
+		for(var/admin in target)
+			var/client/admin_client = CLIENT_FROM_VAR(admin)
+			if(CLIENT_IS_STAFF(admin_client))
+				true_targets += admin_client
+		target = true_targets
+
 	// Build a message
 	var/message = list()
 	if(type) message["type"] = type


### PR DESCRIPTION

# About the pull request
As  title

# Explain why it's good for the game

Shouldn't be sending debug logs to mentors.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
admin: Mentors no longer receive debug logs as a result of being in GLOB.admins
/:cl:
