### PR TITLE
Dynamic Sound

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_client.dm
+++ b/code/__DEFINES/dcs/signals/signals_client.dm
@@ -27,3 +27,6 @@
 
 /// Called when something is removed from a client's screen : /client/proc/remove_from_screen(screen_remove)
 #define COMSIG_CLIENT_SCREEN_REMOVE "client_screen_remove"
+
+/// From movement.dm: /atom/movable/proc/Moved(atom/oldloc, direction, Forced = FALSE)
+#define COMSIG_CLIENT_MOB_MOVED "client_mob_moved"

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -155,7 +155,7 @@
 			human.remove_language(LANGUAGE_ENGLISH) // You lose the ability to understand english. Language processing is handled in the mind not the body.
 			var/datum/species/zombie/zombie_species = GLOB.all_species[SPECIES_ZOMBIE]
 			zombie_species.handle_alert_ghost(human)
-		playsound(human.loc, 'sound/hallucinations/wail.ogg', 25, 1)
+		playsound(human, 'sound/hallucinations/wail.ogg', 25, 1)
 		human.jitteriness = 0
 		human.set_species(SPECIES_ZOMBIE)
 		stage = 4

--- a/code/datums/soundOutput.dm
+++ b/code/datums/soundOutput.dm
@@ -110,7 +110,7 @@
 		current_sounds[num2text(S.channel)] = T
 	sound_to(owner, S)
 
-/client/verb/sound_ended(channel as num, source as atom)
+/client/verb/sound_ended(channel as num, source as mob|obj|turf)
 	set name = ".soundend"
 
 	soundOutput.remove_sound(num2text(channel))

--- a/code/datums/soundOutput.dm
+++ b/code/datums/soundOutput.dm
@@ -19,11 +19,13 @@
 	RegisterSignal(owner.mob, COMSIG_MOVABLE_MOVED, PROC_REF(on_mob_moved))
 	RegisterSignal(owner.mob, COMSIG_MOB_LOGOUT, PROC_REF(on_mob_logout))
 	RegisterSignal(owner, COMSIG_CLIENT_MOB_LOGGED_IN, PROC_REF(on_client_mob_logged_in))
+	RegisterSignal(owner, COMSIG_CLIENT_MOB_MOVED, PROC_REF(update_sounds))
 	return ..()
 
 /datum/soundOutput/Destroy()
 	UnregisterSignal(owner.mob, list(COMSIG_MOVABLE_MOVED, COMSIG_MOB_LOGOUT))
 	UnregisterSignal(owner, COMSIG_CLIENT_MOB_LOGGED_IN)
+	UnregisterSignal(owner, COMSIG_CLIENT_MOB_MOVED)
 	owner = null
 	return ..()
 

--- a/code/datums/soundOutput.dm
+++ b/code/datums/soundOutput.dm
@@ -25,7 +25,7 @@
 	owner = null
 	return ..()
 
-#define SMOOTHING 2 // [1, 32], 32 Means best sound most lag 1 Means worst sound least lag
+#define SMOOTHING 8 // [1, 32], 32 Means best sound most lag 1 Means worst sound least lag
 
 /datum/soundOutput/proc/update_sounds(atom/user, direction)
 	SIGNAL_HANDLER

--- a/code/datums/soundOutput.dm
+++ b/code/datums/soundOutput.dm
@@ -4,7 +4,6 @@
 	var/list/soundscape_playlist = list() //Updated on changing areas
 	var/ambience = null //The file currently being played as ambience
 	var/status_flags = 0 //For things like ear deafness, psychodelic effects, and other things that change how all sounds behave
-	var/list/echo
 	var/list/current_sounds = list()
 	var/list/source_sounds = list()
 

--- a/code/datums/soundOutput.dm
+++ b/code/datums/soundOutput.dm
@@ -25,7 +25,7 @@
 	owner = null
 	return ..()
 
-#define SMOOTHING 8 // [1, 32], 32 Means best sound most lag 1 Means worst sound least lag
+#define SMOOTHING 1 // [1, 32], 32 Means best sound most lag 1 Means worst sound least lag
 
 /datum/soundOutput/proc/update_sounds(atom/user, direction)
 	SIGNAL_HANDLER

--- a/code/datums/soundOutput.dm
+++ b/code/datums/soundOutput.dm
@@ -38,7 +38,7 @@
 				if(2)
 					process_sound(current_sounds[channel], TRUE, 0, 1-i/32)
 				if(4)
-					process_sound(current_sounds[channel], TRUE, -1+i/32)
+					process_sound(current_sounds[channel], TRUE, -1+i/32, 0)
 				if(8)
 					process_sound(current_sounds[channel], TRUE, 1-i/32, 0)
 
@@ -55,7 +55,7 @@
 					if(2)
 						process_sound(template, TRUE, 0, -1-i/32)
 					if(4)
-						process_sound(template, TRUE, 1+i/32)
+						process_sound(template, TRUE, 1+i/32, 0)
 					if(8)
 						process_sound(template, TRUE, -1-i/32, 0)
 			break
@@ -80,7 +80,7 @@
 	else
 		S.status = SOUND_UPDATE 		
 	
-	var/positional_sound = FALSE
+	var/positional_sound = TRUE
 	var/turf/source_turf
 	if(T.source && !QDELETED(T.source))
 		source_turf = get_turf(T.source)
@@ -89,8 +89,9 @@
 			source_sounds[num2text(T.channel)] = T.source
 			RegisterSignal(T.source, COMSIG_MOVABLE_MOVED, PROC_REF(update_sounds_from_source))
 	else if (T.x && T.y && T.z)
-		positional_sound = TRUE
 		source_turf = locate(T.x, T.y, T.z)
+	else
+		positional_sound = FALSE
 
 	if(positional_sound)
 		var/turf/owner_turf = get_turf(owner.mob)
@@ -236,10 +237,10 @@
 
 	src.owner_environment = new_environment
 
-/datum/soundOutput/proc/on_mob_moved(datum/source, atom/oldloc, direction, Forced)
-	SIGNAL_HANDLER //COMSIG_MOVABLE_MOVED
-	update_sounds()
+/datum/soundOutput/proc/on_mob_moved(atom/source, direction)
+	SIGNAL_HANDLER //COMSIG_CLIENT_MOB_MOVED
 	update_area_environment()
+	update_sounds(source, direction)
 
 /client/proc/adjust_volume_prefs(volume_key, prompt = "", channel_update = 0)
 	volume_preferences[volume_key] = (tgui_input_number(src, prompt, "Volume", volume_preferences[volume_key]*100)) / 100

--- a/code/datums/soundOutput.dm
+++ b/code/datums/soundOutput.dm
@@ -42,7 +42,7 @@
 				if(8)
 					process_sound(current_sounds[channel], TRUE, 1-i/32, 0)
 
-/datum/soundOutput/proc/update_sounds_from_source(atom/source, direction)
+/datum/soundOutput/proc/update_sounds_from_source(datum/source, atom/oldloc, direction, Forced)
 	SIGNAL_HANDLER
 	for(var/channel in source_sounds)
 		if(source_sounds[channel] == source)
@@ -51,13 +51,13 @@
 				i = i * SMOOTHING
 				switch(direction)
 					if(1)
-						process_sound(template, TRUE, 0, 1+i/32)
+						process_sound(template, TRUE, 0, 1-i/32)
 					if(2)
-						process_sound(template, TRUE, 0, -1-i/32)
+						process_sound(template, TRUE, 0, -1+i/32)
 					if(4)
-						process_sound(template, TRUE, 1+i/32, 0)
+						process_sound(template, TRUE, 1-i/32, 0)
 					if(8)
-						process_sound(template, TRUE, -1-i/32, 0)
+						process_sound(template, TRUE, -1+i/32, 0)
 			break
 
 /datum/soundOutput/proc/remove_sound(channel)
@@ -73,9 +73,9 @@
 		S.channel = T.channel
 	S.frequency = T.frequency
 	S.falloff = T.falloff
-
+	S.params = list("on-end" = ".soundend [S.channel]")
+	
 	if(!update)
-		S.params = list("on-end" = ".soundend [S.channel]")
 		S.status = T.status
 	else
 		S.status = SOUND_UPDATE 		
@@ -112,7 +112,7 @@
 		S.x += T.x_s_offset
 		S.echo = SOUND_ECHO_REVERB_ON
 
-		if(!update)
+		if(!update && T.source && T.source != owner.mob)
 			current_sounds[num2text(S.channel)] = T
 
 	if(owner.mob.ear_deaf > 0)

--- a/code/datums/soundOutput.dm
+++ b/code/datums/soundOutput.dm
@@ -85,7 +85,7 @@
 	if(T.source && !QDELETED(T.source))
 		source_turf = get_turf(T.source)
 
-		if(!update && istype(T.source, /atom/movable) && T.source != owner.mob)
+		if(!update && istype(T.source, /atom/movable) && T.source != owner.mob && T.use_smoothing)
 			source_sounds[num2text(T.channel)] = T.source
 			RegisterSignal(T.source, COMSIG_MOVABLE_MOVED, PROC_REF(update_sounds_from_source))
 	else if (T.x && T.y && T.z)
@@ -112,7 +112,7 @@
 		S.x += T.x_s_offset
 		S.echo = SOUND_ECHO_REVERB_ON
 
-		if(!update && T.source && T.source != owner.mob)
+		if(!update && T.source && T.source != owner.mob && T.use_smoothing)
 			current_sounds[num2text(S.channel)] = T
 
 	if(owner.mob.ear_deaf > 0)

--- a/code/datums/soundOutput.dm
+++ b/code/datums/soundOutput.dm
@@ -29,7 +29,7 @@
 	owner = null
 	return ..()
 
-#define SMOOTHING 1 // How much smoothing when moving between tiles, smaller value means more smoothing
+#define SMOOTHING 2 // [1, 32], 32 Means best sound most lag 1 Means worst sound least lag
 
 /datum/soundOutput/proc/update_sounds(atom/user, direction)
 	SIGNAL_HANDLER

--- a/code/datums/soundOutput.dm
+++ b/code/datums/soundOutput.dm
@@ -85,7 +85,7 @@
 	if(T.source && !QDELETED(T.source))
 		source_turf = get_turf(T.source)
 
-		if(!update && istype(T.source, /atom/movable))
+		if(!update && istype(T.source, /atom/movable) && T.source != owner.mob)
 			source_sounds[num2text(T.channel)] = T.source
 			RegisterSignal(T.source, COMSIG_MOVABLE_MOVED, PROC_REF(update_sounds_from_source))
 	else if (T.x && T.y && T.z)

--- a/code/datums/soundOutput.dm
+++ b/code/datums/soundOutput.dm
@@ -48,18 +48,18 @@
 
 /datum/soundOutput/proc/update_sounds_from_source(atom/source, direction)
 	SIGNAL_HANDLER
-	for(var/channel in source_sounds[source])
+	for(var/datum/sound_template/template in source_sounds[source])
 		for(var/i in 0 to round(32/SMOOTHING))
 			i = i * SMOOTHING
 			switch(direction)
 				if(1)
-					process_sound(current_sounds[channel], TRUE, 0, 1+i/32)
+					process_sound(template, TRUE, 0, 1+i/32)
 				if(2)
-					process_sound(current_sounds[channel], TRUE, 0, -1-i/32)
+					process_sound(template, TRUE, 0, -1-i/32)
 				if(4)
-					process_sound(current_sounds[channel], TRUE, 1+i/32)
+					process_sound(template, TRUE, 1+i/32)
 				if(8)
-					process_sound(current_sounds[channel], TRUE, -1-i/32, 0)
+					process_sound(template, TRUE, -1-i/32, 0)
 
 /datum/soundOutput/proc/remove_sound(channel)
 	current_sounds -= channel

--- a/code/datums/soundOutput.dm
+++ b/code/datums/soundOutput.dm
@@ -103,7 +103,8 @@
 		S.z = source_turf.y - owner_turf.y + offset_y
 	S.y += T.y_s_offset
 	S.x += T.x_s_offset
-	S.echo = SOUND_ECHO_REVERB_ON
+	if(source_turf.x && source_turf.y && source_turf.z)
+		S.echo = SOUND_ECHO_REVERB_ON
 	if(owner.mob.ear_deaf > 0)
 		S.status |= SOUND_MUTE
 

--- a/code/datums/soundOutput.dm
+++ b/code/datums/soundOutput.dm
@@ -16,10 +16,12 @@
 		return
 	owner = client
 	RegisterSignal(owner, COMSIG_CLIENT_MOB_MOVED, PROC_REF(on_mob_moved))
+	RegisterSignal(owner, COMSIG_CLIENT_MOB_LOGGED_IN, PROC_REF(on_client_mob_logged_in))
 	return ..()
 
 /datum/soundOutput/Destroy()
 	UnregisterSignal(owner, COMSIG_CLIENT_MOB_MOVED)
+	UnregisterSignal(owner, COMSIG_CLIENT_MOB_LOGGED_IN)
 	owner = null
 	return ..()
 
@@ -78,7 +80,7 @@
 	else
 		S.status = SOUND_UPDATE 		
 	
-	var/positonal_sound = FALSE
+	var/positional_sound = FALSE
 	var/turf/source_turf
 	if(T.source && !QDELETED(T.source))
 		source_turf = get_turf(T.source)
@@ -87,10 +89,10 @@
 			source_sounds[num2text(T.channel)] = T.source
 			RegisterSignal(T.source, COMSIG_MOVABLE_MOVED, PROC_REF(update_sounds_from_source))
 	else if (T.x && T.y && T.z)
-		positonal_sound = TRUE
+		positional_sound = TRUE
 		source_turf = locate(T.x, T.y, T.z)
 
-	if(positonal_sound)
+	if(positional_sound)
 		var/turf/owner_turf = get_turf(owner.mob)
 		if(owner_turf)
 			// We're in an interior and sound came from outside
@@ -121,6 +123,10 @@
 	set name = ".soundend"
 
 	soundOutput.remove_sound(num2text(channel))
+
+/datum/soundOutput/proc/on_client_mob_logged_in(datum/source, mob/new_mob)
+	SIGNAL_HANDLER //COMSIG_CLIENT_MOB_LOGGED_IN
+	update_mob_environment_override()
 
 /datum/soundOutput/proc/update_ambience(area/target_area, ambience_override, force_update = FALSE)
 	var/status_flags = SOUND_STREAM

--- a/code/datums/soundOutput.dm
+++ b/code/datums/soundOutput.dm
@@ -77,6 +77,7 @@
 		S.params = list("on-end" = ".soundend [S.channel] [T.source]")
 
 
+	var/positonal_sound = FALSE
 	var/turf/source_turf
 	if(!QDELETED(T.source))
 		source_turf = get_turf(T.source)
@@ -84,27 +85,29 @@
 		if(!update && istype(T.source, /atom/movable))
 			source_sounds[T.source] = T
 			RegisterSignal(T.source, COMSIG_MOVABLE_MOVED, PROC_REF(update_sounds))
-	else
+	else if (T.x && T.y && T.z)
+		positonal_sound = TRUE
 		source_turf = locate(T.x, T.y, T.z)
 
-	var/turf/owner_turf = get_turf(owner.mob)
-	if(owner_turf)
-		// We're in an interior and sound came from outside
-		if(SSinterior.in_interior(owner_turf) && owner_turf.z != T.z)
-			var/datum/interior/VI = SSinterior.get_interior_by_coords(owner_turf.x, owner_turf.y, owner_turf.z)
-			if(VI && VI.exterior)
-				var/turf/candidate = get_turf(VI.exterior)
-				if(candidate.z != T.z)
-					return // Invalid location
-				S.falloff /= 2
-				owner_turf = candidate
-		S.x = source_turf.x - owner_turf.x + offset_x
-		S.y = 0
-		S.z = source_turf.y - owner_turf.y + offset_y
-	S.y += T.y_s_offset
-	S.x += T.x_s_offset
-	if(source_turf.x && source_turf.y && source_turf.z)
+	if(positonal_sound)
+		var/turf/owner_turf = get_turf(owner.mob)
+		if(owner_turf)
+			// We're in an interior and sound came from outside
+			if(SSinterior.in_interior(owner_turf) && owner_turf.z != T.z)
+				var/datum/interior/VI = SSinterior.get_interior_by_coords(owner_turf.x, owner_turf.y, owner_turf.z)
+				if(VI && VI.exterior)
+					var/turf/candidate = get_turf(VI.exterior)
+					if(candidate.z != T.z)
+						return // Invalid location
+					S.falloff /= 2
+					owner_turf = candidate
+			S.x = source_turf.x - owner_turf.x + offset_x
+			S.y = 0
+			S.z = source_turf.y - owner_turf.y + offset_y
+		S.y += T.y_s_offset
+		S.x += T.x_s_offset
 		S.echo = SOUND_ECHO_REVERB_ON
+
 	if(owner.mob.ear_deaf > 0)
 		S.status |= SOUND_MUTE
 

--- a/code/datums/soundOutput.dm
+++ b/code/datums/soundOutput.dm
@@ -108,11 +108,12 @@
 		S.x += T.x_s_offset
 		S.echo = SOUND_ECHO_REVERB_ON
 
+		if(!update)
+			current_sounds[num2text(S.channel)] = T
+
 	if(owner.mob.ear_deaf > 0)
 		S.status |= SOUND_MUTE
-
-	if(!update)
-		current_sounds[num2text(S.channel)] = T
+		
 	sound_to(owner, S)
 
 /client/verb/sound_ended(channel as num, source as mob|obj|turf)

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -452,7 +452,7 @@
 /obj/structure/machinery/bot/mulebot/proc/load(atom/movable/C)
 	if((wires & WIRE_LOADCHECK) && !istype(C,/obj/structure/closet/crate))
 		src.visible_message("[src] makes a sighing buzz.", "You hear an electronic buzzing sound.")
-		playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 25, 0)
+		playsound(src, 'sound/machines/buzz-sigh.ogg', 25, 0)
 		return // if not emagged, only allow crates to be loaded
 
 	//I'm sure someone will come along and ask why this is here... well people were dragging screen items onto the mule, and that was not cool.
@@ -636,25 +636,25 @@
 						mode = 4
 						if(blockcount == 3)
 							src.visible_message("[src] makes an annoyed buzzing sound", "You hear an electronic buzzing sound.")
-							playsound(src.loc, 'sound/machines/buzz-two.ogg', 25, 0)
+							playsound(src, 'sound/machines/buzz-two.ogg', 25, 0)
 
 						if(blockcount > 5) // attempt 5 times before recomputing
 							// find new path excluding blocked turf
 							src.visible_message("[src] makes a sighing buzz.", "You hear an electronic buzzing sound.")
-							playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 25, 0)
+							playsound(src, 'sound/machines/buzz-sigh.ogg', 25, 0)
 
 							spawn(2)
 								calc_path(next)
 								if(length(path) > 0)
 									src.visible_message("[src] makes a delighted ping!", "You hear a ping.")
-									playsound(src.loc, 'sound/machines/ping.ogg', 25, 0)
+									playsound(src, 'sound/machines/ping.ogg', 25, 0)
 								mode = 4
 							mode =6
 							return
 						return
 				else
 					src.visible_message("[src] makes an annoyed buzzing sound", "You hear an electronic buzzing sound.")
-					playsound(src.loc, 'sound/machines/buzz-two.ogg', 25, 0)
+					playsound(src, 'sound/machines/buzz-two.ogg', 25, 0)
 					mode = 5
 					return
 			else
@@ -671,11 +671,11 @@
 					blockcount = 0
 					mode = 4
 					src.visible_message("[src] makes a delighted ping!", "You hear a ping.")
-					playsound(src.loc, 'sound/machines/ping.ogg', 25, 0)
+					playsound(src, 'sound/machines/ping.ogg', 25, 0)
 
 				else
 					src.visible_message("[src] makes a sighing buzz.", "You hear an electronic buzzing sound.")
-					playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 25, 0)
+					playsound(src, 'sound/machines/buzz-sigh.ogg', 25, 0)
 
 					mode = 7
 		//if(6)
@@ -720,7 +720,7 @@
 /obj/structure/machinery/bot/mulebot/proc/at_target()
 	if(!reached_target)
 		src.visible_message("[src] makes a chiming sound!", "You hear a chime.")
-		playsound(src.loc, 'sound/machines/chime.ogg', 25, 0)
+		playsound(src, 'sound/machines/chime.ogg', 25, 0)
 		reached_target = 1
 
 		if(load) // if loaded, unload at target
@@ -770,7 +770,7 @@
 // when mulebot is in the same loc
 /obj/structure/machinery/bot/mulebot/proc/RunOver(mob/living/carbon/human/H)
 	src.visible_message(SPAN_DANGER("[src] drives over [H]!"))
-	playsound(src.loc, 'sound/effects/splat.ogg', 25, 1)
+	playsound(src, 'sound/effects/splat.ogg', 25, 1)
 
 	var/damage = rand(5,15)
 	H.apply_damage(2*damage, BRUTE, "head")

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -18,6 +18,7 @@
 	var/z
 	var/y_s_offset // Vertical sound offset
 	var/x_s_offset // Horizontal sound offset
+	var/atom/source
 
 /proc/get_free_channel()
 	var/static/cur_chan = 1
@@ -72,6 +73,7 @@
 	S.x = turf_source.x
 	S.y = turf_source.y
 	S.z = turf_source.z
+	S.source = source
 
 	if(!SSinterior)
 		SSsound.queue(S)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -19,6 +19,7 @@
 	var/y_s_offset // Vertical sound offset
 	var/x_s_offset // Horizontal sound offset
 	var/atom/source
+	var/use_smoothing = TRUE
 
 /proc/get_free_channel()
 	var/static/cur_chan = 1
@@ -37,7 +38,7 @@
 //status: the regular 4 sound flags
 //falloff: max range till sound volume starts dropping as distance increases
 
-/proc/playsound(atom/source, soundin, vol = 100, vary = FALSE, sound_range, vol_cat = VOLUME_SFX, channel = 0, status , falloff = 1, y_s_offset,x_s_offset)
+/proc/playsound(atom/source, soundin, vol = 100, vary = FALSE, sound_range, vol_cat = VOLUME_SFX, channel = 0, status , falloff = 1, y_s_offset,x_s_offset, smoothing=TRUE)
 	if(isarea(source))
 		error("[source] is an area and is trying to make the sound: [soundin]")
 		return FALSE
@@ -57,6 +58,7 @@
 	S.volume_cat = vol_cat
 	S.y_s_offset = y_s_offset
 	S.x_s_offset = x_s_offset
+	S.use_smoothing = smoothing
 	if(vary != FALSE)
 		if(vary > 1)
 			S.frequency = vary

--- a/code/modules/mob/living/carbon/human/human_abilities.dm
+++ b/code/modules/mob/living/carbon/human/human_abilities.dm
@@ -347,7 +347,7 @@ CULT
 
 	H.put_in_any_hand_if_possible(new /obj/item/device/flashlight, FALSE, TRUE)
 
-	playsound(H.loc, 'sound/voice/scream_horror1.ogg', 25)
+	playsound(H, 'sound/voice/scream_horror1.ogg', 25)
 
 	H.visible_message(SPAN_HIGHDANGER("[H] puts on their robes."), SPAN_WARNING("You put on your robes."))
 	for(var/datum/action/human_action/activable/cult/obtain_equipment/O in H.actions)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -160,7 +160,7 @@
 				if(M != src)
 					M.show_message(SPAN_NOTICE("[src] talks into [length(used_radios) ? used_radios[1] : "the radio."]"), SHOW_MESSAGE_VISIBLE)
 			if(ishumansynth_strict(src))
-				playsound(src.loc, 'sound/effects/radiostatic.ogg', 15, 1)
+				playsound(src, 'sound/effects/radiostatic.ogg', 15, 1)
 
 			italics = 1
 			message_range = 2

--- a/code/modules/mob/living/carbon/human/species/zombie.dm
+++ b/code/modules/mob/living/carbon/human/species/zombie.dm
@@ -80,9 +80,9 @@
 
 /datum/species/zombie/handle_unique_behavior(mob/living/carbon/human/zombie)
 	if(prob(5))
-		playsound(zombie.loc, basic_moan, 15, basic_variance)
+		playsound(zombie, basic_moan, 15, basic_variance)
 	else if(prob(5))
-		playsound(zombie.loc, rare_moan, 15, rare_variance)
+		playsound(zombie, rare_moan, 15, rare_variance)
 
 /datum/species/zombie/handle_death(mob/living/carbon/human/zombie, gibbed)
 	set waitfor = FALSE

--- a/code/modules/mob/living/carbon/xenomorph/Abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Abilities.dm
@@ -136,7 +136,7 @@
 		if(hugger.stat != DEAD)
 			hugger.die()
 
-	playsound(xeno.loc, pick(xeno.screech_sound_effect_list), 75, 0, status = 0)
+	playsound(xeno, pick(xeno.screech_sound_effect_list), 75, 0, status = 0)
 	xeno.visible_message(SPAN_XENOHIGHDANGER("[xeno] emits an ear-splitting guttural roar!"))
 	xeno.create_shriekwave(14) //Adds the visual effect. Wom wom wom, 14 shriekwaves
 

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -293,9 +293,9 @@
 	human.disable_lights()
 	human.disable_special_items()
 	if(ishuman_strict(human))
-		playsound(loc, human.gender == "male" ? 'sound/misc/facehugged_male.ogg' : 'sound/misc/facehugged_female.ogg' , 25, 0)
+		playsound(human, human.gender == "male" ? 'sound/misc/facehugged_male.ogg' : 'sound/misc/facehugged_female.ogg' , 25, 0)
 	else if(isyautja(human))
-		playsound(loc, 'sound/voice/pred_facehugged.ogg', 65, FALSE)
+		playsound(human, 'sound/voice/pred_facehugged.ogg', 65, FALSE)
 	if(!sterile)
 		if(!human.species || !(human.species.flags & IS_SYNTHETIC)) //synthetics aren't paralyzed
 			human.apply_effect(MIN_IMPREGNATION_TIME * 0.5 * knockout_mod, PARALYZE) //THIS MIGHT NEED TWEAKS
@@ -435,7 +435,7 @@
 	stat = DEAD
 	flags_inventory &= ~CANTSTRIP
 	visible_message("[icon2html(src, viewers(src))] <span class='danger'>\The [src] curls up into a ball!</span>")
-	playsound(src.loc, 'sound/voice/alien_facehugger_dies.ogg', 25, 1)
+	playsound(src, 'sound/voice/alien_facehugger_dies.ogg', 25, 1)
 
 	if(ismob(loc)) //Make it fall off the person so we can update their icons. Won't update if they're in containers thou
 		var/mob/holder_mob = loc

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -319,7 +319,7 @@
 
 	if (pounceAction.freeze_self)
 		if(pounceAction.freeze_play_sound)
-			playsound(loc, rand(0, 100) < 95 ? 'sound/voice/alien_pounce.ogg' : 'sound/voice/alien_pounce2.ogg', 25, 1)
+			playsound(src, rand(0, 100) < 95 ? 'sound/voice/alien_pounce.ogg' : 'sound/voice/alien_pounce2.ogg', 25, 1)
 		ADD_TRAIT(src, TRAIT_IMMOBILIZED, TRAIT_SOURCE_ABILITY("Pounce"))
 		pounceAction.freeze_timer_id = addtimer(CALLBACK(src, PROC_REF(unfreeze_pounce)), pounceAction.freeze_time, TIMER_STOPPABLE)
 	pounceAction.additional_effects(M)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
@@ -138,7 +138,7 @@
 		R.take_damage_type(40 / A.acid_delay, "acid", src)
 		visible_message(SPAN_XENOWARNING("[src] vomits globs of vile stuff at \the [O]. It sizzles under the bubbling mess of acid!"), \
 			SPAN_XENOWARNING("We vomit globs of vile stuff at [O]. It sizzles under the bubbling mess of acid!"), null, 5)
-		playsound(loc, "sound/bullets/acid_impact1.ogg", 25)
+		playsound(O, "sound/bullets/acid_impact1.ogg", 25)
 		QDEL_IN(A, 20)
 		return
 
@@ -158,7 +158,7 @@
 		attack_log += text("\[[time_stamp()]\] <font color='green'>Spat acid on [O]</font>")
 	visible_message(SPAN_XENOWARNING("[src] vomits globs of vile stuff all over [O]. It begins to sizzle and melt under the bubbling mess of acid!"), \
 	SPAN_XENOWARNING("We vomit globs of vile stuff all over [O]. It begins to sizzle and melt under the bubbling mess of acid!"), null, 5)
-	playsound(loc, "sound/bullets/acid_impact1.ogg", 25)
+	playsound(O, "sound/bullets/acid_impact1.ogg", 25)
 
 /proc/unroot_human(mob/living/carbon/H, trait_source)
 	if (!isxeno_human(H))

--- a/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_powers.dm
@@ -44,7 +44,7 @@
 				COMSIG_LIVING_FLAMER_FLAMED,
 		), PROC_REF(flamer_crossed_immune))
 	add_traits(list(TRAIT_ABILITY_BURROWED, TRAIT_UNDENSE, TRAIT_IMMOBILIZED), TRAIT_SOURCE_ABILITY("Burrow"))
-	playsound(src.loc, 'sound/effects/burrowing_b.ogg', 25)
+	playsound(src, 'sound/effects/burrowing_b.ogg', 25)
 	update_icons()
 	addtimer(CALLBACK(src, PROC_REF(do_burrow_cooldown)), (caste ? caste.burrow_cooldown : 5 SECONDS))
 	burrow_timer = world.time + 90 // How long we can be burrowed

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -757,7 +757,7 @@
 	if(xeno.ammo.spit_windup)
 		spitting = TRUE
 		if(xeno.ammo.pre_spit_warn)
-			playsound(xeno.loc,"alien_drool", 55, 1)
+			playsound(xeno, "alien_drool", 55, 1)
 		to_chat(xeno, SPAN_WARNING("We begin to prepare a large spit!"))
 		xeno.visible_message(SPAN_WARNING("[xeno] prepares to spit a massive glob!"),\
 		SPAN_WARNING("We begin to spit [xeno.ammo.name]!"))
@@ -775,7 +775,7 @@
 	xeno.visible_message(SPAN_XENOWARNING("[xeno] spits at [atom]!"), \
 
 	SPAN_XENOWARNING("We spit [xeno.ammo.name] at [atom]!") )
-	playsound(xeno.loc, sound_to_play, 25, 1)
+	playsound(xeno, sound_to_play, 25, 1)
 
 	var/obj/projectile/proj = new (current_turf, create_cause_data(xeno.ammo.name, xeno))
 	proj.generate_bullet(xeno.ammo)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/predalien/predalien_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/predalien/predalien_powers.dm
@@ -10,7 +10,7 @@
 	if(!check_and_use_plasma_owner())
 		return
 
-	playsound(xeno.loc, pick(predalien_roar), 75, 0, status = 0)
+	playsound(xeno, pick(predalien_roar), 75, 0, status = 0)
 	xeno.visible_message(SPAN_XENOHIGHDANGER("[xeno] emits a guttural roar!"))
 	xeno.create_shriekwave(7) //Adds the visual effect. Wom wom wom, 7 shriekwaves
 	for(var/mob/living/carbon/carbon in view(7, xeno))

--- a/code/modules/mob/living/carbon/xenomorph/abilities/runner/runner_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/runner/runner_powers.dm
@@ -126,7 +126,7 @@
 		multitile_vehicle.take_damage_type(20 / acid.acid_delay, "acid", src)
 		visible_message(SPAN_XENOWARNING("[src] vomits globs of vile stuff at [multitile_vehicle]. It sizzles under the bubbling mess of acid!"), \
 			SPAN_XENOWARNING("We vomit globs of vile stuff at [multitile_vehicle]. It sizzles under the bubbling mess of acid!"), null, 5)
-		playsound(loc, "sound/bullets/acid_impact1.ogg", 25)
+		playsound(O, "sound/bullets/acid_impact1.ogg", 25)
 		QDEL_IN(acid, 20)
 		return
 
@@ -135,7 +135,7 @@
 
 	visible_message(SPAN_XENOWARNING("[src] vomits globs of vile stuff all over [affected_atom]. It begins to sizzle and melt under the bubbling mess of acid!"), \
 	SPAN_XENOWARNING("We vomit globs of vile stuff all over [affected_atom]. It begins to sizzle and melt under the bubbling mess of acid!"), null, 5)
-	playsound(loc, "sound/bullets/acid_impact1.ogg", 25)
+	playsound(O, "sound/bullets/acid_impact1.ogg", 25)
 
 
 /datum/action/xeno_action/activable/acider_for_the_hive/use_ability(atom/affected_atom)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/runner/runner_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/runner/runner_powers.dm
@@ -126,7 +126,7 @@
 		multitile_vehicle.take_damage_type(20 / acid.acid_delay, "acid", src)
 		visible_message(SPAN_XENOWARNING("[src] vomits globs of vile stuff at [multitile_vehicle]. It sizzles under the bubbling mess of acid!"), \
 			SPAN_XENOWARNING("We vomit globs of vile stuff at [multitile_vehicle]. It sizzles under the bubbling mess of acid!"), null, 5)
-		playsound(O, "sound/bullets/acid_impact1.ogg", 25)
+		playsound(affected_atom, "sound/bullets/acid_impact1.ogg", 25)
 		QDEL_IN(acid, 20)
 		return
 
@@ -135,7 +135,7 @@
 
 	visible_message(SPAN_XENOWARNING("[src] vomits globs of vile stuff all over [affected_atom]. It begins to sizzle and melt under the bubbling mess of acid!"), \
 	SPAN_XENOWARNING("We vomit globs of vile stuff all over [affected_atom]. It begins to sizzle and melt under the bubbling mess of acid!"), null, 5)
-	playsound(O, "sound/bullets/acid_impact1.ogg", 25)
+	playsound(affected_atom, "sound/bullets/acid_impact1.ogg", 25)
 
 
 /datum/action/xeno_action/activable/acider_for_the_hive/use_ability(atom/affected_atom)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/sentinel/sentinel_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/sentinel/sentinel_powers.dm
@@ -18,7 +18,7 @@
 	xeno.visible_message(SPAN_XENOWARNING("[xeno] spits at [target]!"), \
 	SPAN_XENOWARNING("You spit at [target]!") )
 	var/sound_to_play = pick(1, 2) == 1 ? 'sound/voice/alien_spitacid.ogg' : 'sound/voice/alien_spitacid2.ogg'
-	playsound(xeno.loc, sound_to_play, 25, 1)
+	playsound(xeno, sound_to_play, 25, 1)
 
 	xeno.ammo = GLOB.ammo_list[/datum/ammo/xeno/toxin]
 	var/obj/projectile/projectile = new /obj/projectile(current_turf, create_cause_data(initial(xeno.caste_type), xeno))
@@ -50,7 +50,7 @@
 	xeno.visible_message(SPAN_XENOWARNING("[xeno] spits at [target]!"), \
 	SPAN_XENOWARNING("You spit at [target]!") )
 	var/sound_to_play = pick(1, 2) == 1 ? 'sound/voice/alien_spitacid.ogg' : 'sound/voice/alien_spitacid2.ogg'
-	playsound(xeno.loc, sound_to_play, 25, 1)
+	playsound(xeno, sound_to_play, 25, 1)
 
 	xeno.ammo = GLOB.ammo_list[/datum/ammo/xeno/toxin/shotgun]
 	var/obj/projectile/projectile = new /obj/projectile(current_turf, create_cause_data(initial(xeno.caste_type), xeno))

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -237,7 +237,7 @@
 			return FALSE
 
 	// Otherwise, ""roar""!
-	playsound(loc, "alien_roar_larva", 15)
+	playsound(src, "alien_roar_larva", 15)
 	return TRUE
 
 /mob/living/carbon/xenomorph/facehugger/get_status_tab_items()

--- a/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
@@ -176,7 +176,7 @@
 			return FALSE
 
 	// Otherwise, ""roar""!
-	playsound(loc, "alien_roar_larva", 15)
+	playsound(src, "alien_roar_larva", 15)
 	return TRUE
 
 /mob/living/carbon/xenomorph/larva/is_xeno_grabbable()

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -399,7 +399,7 @@
 	if(!should_block_game_interaction(src))//so admins can safely spawn Queens in Thunderdome for tests.
 		xeno_message(SPAN_XENOANNOUNCE("A new Queen has risen to lead the Hive! Rejoice!"),3,hivenumber)
 		notify_ghosts(header = "New Queen", message = "A new Queen has risen.", source = src, action = NOTIFY_ORBIT)
-	playsound(loc, 'sound/voice/alien_queen_command.ogg', 75, 0)
+	playsound(src, 'sound/voice/alien_queen_command.ogg', 75, 0)
 	set_resin_build_order(GLOB.resin_build_order_drone)
 	for(var/datum/action/xeno_action/action in actions)
 		// Also update the choose_resin icon since it resets
@@ -522,7 +522,7 @@
 
 	if(stat != DEAD)
 		if(++breathing_counter >= rand(22, 27)) //Increase the breathing variable each tick. Play it at random intervals.
-			playsound(loc, pick('sound/voice/alien_queen_breath1.ogg', 'sound/voice/alien_queen_breath2.ogg'), 15, 1, 4)
+			playsound(src, pick('sound/voice/alien_queen_breath1.ogg', 'sound/voice/alien_queen_breath2.ogg'), 15, 1, 4)
 			breathing_counter = 0 //Reset the counter
 
 		if(observed_xeno)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -225,7 +225,7 @@
 			if(ishuman(M))
 				if(world.time > devour_timer - 50 && world.time < devour_timer - 30)
 					to_chat(src, SPAN_WARNING("We're about to regurgitate [M]..."))
-					playsound(loc, 'sound/voice/alien_drool1.ogg', 50, 1)
+					playsound(src, 'sound/voice/alien_drool1.ogg', 50, 1)
 				var/mob/living/carbon/human/H = M
 				if(world.time > devour_timer || (H.stat == DEAD && !H.chestburst))
 					regurgitate(H)

--- a/code/modules/mob/living/carbon/xenomorph/say.dm
+++ b/code/modules/mob/living/carbon/xenomorph/say.dm
@@ -76,7 +76,7 @@
 
 	if(forced)
 		if(speaking_noise)
-			playsound(loc, speaking_noise, 25, 1)
+			playsound(src, speaking_noise, 25, 1)
 		..(message, speaking, verb, null, null, message_range, null)
 	else
 		hivemind_talk(message)

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/carrier/eggsac.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/carrier/eggsac.dm
@@ -24,7 +24,7 @@
 	carrier.recalculate_pheromones()
 
 	if(carrier.huggers_cur)
-		playsound(carrier.loc, 'sound/voice/alien_facehugger_dies.ogg', 25, TRUE)
+		playsound(carrier, 'sound/voice/alien_facehugger_dies.ogg', 25, TRUE)
 	carrier.huggers_cur = 0
 	carrier.huggers_max = 0
 	carrier.update_hugger_overlays()
@@ -80,7 +80,7 @@
 		my_egg.start_unstoppable_decay()
 
 	M.visible_message(SPAN_XENOWARNING("[M] throes as its eggsac bursts into a mess of acid!"))
-	playsound(M.loc, 'sound/effects/alien_egg_burst.ogg', 25, TRUE)
+	playsound(M, 'sound/effects/alien_egg_burst.ogg', 25, TRUE)
 
 ///Remove all references to src in eggs_sustained
 /datum/behavior_delegate/carrier_eggsac/Destroy()

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -62,7 +62,7 @@
 	if((src.loc) && isturf(src.loc))
 		if(stat != DEAD)
 			if(++miaow_counter >= rand(20, 30)) //Increase the meow variable each tick. Play it at random intervals.
-				playsound(loc, "cat_meow", 15, 1, 4)
+				playsound(src, "cat_meow", 15, 1, 4)
 				miaow_counter = 0 //Reset the counter
 		if(!stat && !resting && !buckled)
 			for(var/mob/prey in view(1,src))

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -137,7 +137,7 @@
 
 /mob/living/simple_animal/hostile/alien/proc/roar_emote()
 	visible_message("<B>The [name]</B> roars!")
-	playsound(loc, "alien_roar", 40)
+	playsound(src, "alien_roar", 40)
 
 /mob/living/simple_animal/hostile/alien/death(cause, gibbed, deathmessage = "lets out a waning guttural screech, green blood bubbling from its maw. The caustic acid starts melting the body away...")
 	. = ..()

--- a/code/modules/movement/movement.dm
+++ b/code/modules/movement/movement.dm
@@ -92,6 +92,10 @@
 
 /atom/movable/proc/Moved(atom/oldloc, direction, Forced = FALSE)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_MOVED, oldloc, direction, Forced)
+	if(ismob(src))
+		var/mob/moved = src
+		if(moved.client)
+			SEND_SIGNAL(moved.client, COMSIG_MOVABLE_MOVED, direction)
 	for(var/datum/dynamic_light_source/light as anything in hybrid_light_sources)
 		light.source_atom.update_light()
 		if(!isturf(loc))

--- a/code/modules/movement/movement.dm
+++ b/code/modules/movement/movement.dm
@@ -95,7 +95,7 @@
 	if(ismob(src))
 		var/mob/moved = src
 		if(moved.client)
-			SEND_SIGNAL(moved.client, COMSIG_MOVABLE_MOVED, direction)
+			SEND_SIGNAL(moved.client, COMSIG_CLIENT_MOB_MOVED, direction)
 	for(var/datum/dynamic_light_source/light as anything in hybrid_light_sources)
 		light.source_atom.update_light()
 		if(!isturf(loc))

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1684,15 +1684,15 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 		//firing from an attachment
 		if(active_attachable && active_attachable.flags_attach_features & ATTACH_PROJECTILE)
 			if(active_attachable.fire_sound) //If we're firing from an attachment, use that noise instead.
-				playsound(user, active_attachable.fire_sound, 50)
+				playsound(user, active_attachable.fire_sound, 50, use_smoothing=FALSE)
 		else
 			if(!(flags_gun_features & GUN_SILENCED))
 				if (firing_sndfreq && fire_rattle)
-					playsound(user, fire_rattle, firesound_volume, FALSE)//if the gun has a unique 'mag rattle' SFX play that instead of pitch shifting.
+					playsound(user, fire_rattle, firesound_volume, FALSE, use_smoothing=FALSE)//if the gun has a unique 'mag rattle' SFX play that instead of pitch shifting.
 				else
-					playsound(user, actual_sound, firesound_volume, firing_sndfreq)
+					playsound(user, actual_sound, firesound_volume, firing_sndfreq, use_smoothing=FALSE)
 			else
-				playsound(user, actual_sound, 25, firing_sndfreq)
+				playsound(user, actual_sound, 25, firing_sndfreq, use_smoothing=FALSE)
 
 	return 1
 


### PR DESCRIPTION
# About the pull request
Makes sounds react to your and its source moving around and become louder\quieter and change direction

Splits sounds into sounds the originate from a location and sounds that originate from a source - sounds that originate from a location will stay put at the location while sounds from a source will move around with the source (For example a Queen screech is a source and being slammed into a wall is a location). Due to this some things will probably not sound right because they should be a source while being a location or vice versa and this will have to be tweaked along when\if this is tested.

You still can't hear sounds if you were completely out of range when they started.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
It's really cool if it doesn't lag the game to hell and back
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Sounds will now change as you move around their source and become quieter \ louder and change direction
code: Added support for sounds having a movable source, simply put the atom as the source
/:cl:
