### PR TITLE
Make Non-Toxic Water Stop Glowing

### DIFF
--- a/code/game/turfs/floors/desert.dm
+++ b/code/game/turfs/floors/desert.dm
@@ -114,6 +114,7 @@
 			set_light(2)
 			icon = 'icons/turf/floors/desert_water_toxic.dmi'
 		if(0)
+			set_light(0)
 			icon = 'icons/turf/floors/desert_water.dmi'
 		if(-1)
 			set_light(1)
@@ -198,6 +199,7 @@
 			set_light(2)
 			icon = 'icons/turf/floors/desert_water_toxic.dmi'
 		if(0)
+			set_light(0)
 			icon = 'icons/turf/floors/desert_water.dmi'
 		if(-1)
 			set_light(1)
@@ -222,6 +224,7 @@
 			set_light(2)
 			icon = 'icons/turf/floors/desert_water_toxic.dmi'
 		if(0)
+			set_light(0)
 			icon = 'icons/turf/floors/desert_water.dmi'
 		if(-1)
 			set_light(1)

--- a/code/game/turfs/floors/desert.dm
+++ b/code/game/turfs/floors/desert.dm
@@ -114,7 +114,6 @@
 			set_light(2)
 			icon = 'icons/turf/floors/desert_water_toxic.dmi'
 		if(0)
-			set_light(0)
 			icon = 'icons/turf/floors/desert_water.dmi'
 		if(-1)
 			set_light(1)

--- a/code/game/turfs/floors/desert.dm
+++ b/code/game/turfs/floors/desert.dm
@@ -198,7 +198,6 @@
 			set_light(2)
 			icon = 'icons/turf/floors/desert_water_toxic.dmi'
 		if(0)
-			set_light(1)
 			icon = 'icons/turf/floors/desert_water.dmi'
 		if(-1)
 			set_light(1)
@@ -223,7 +222,6 @@
 			set_light(2)
 			icon = 'icons/turf/floors/desert_water_toxic.dmi'
 		if(0)
-			set_light(0)
 			icon = 'icons/turf/floors/desert_water.dmi'
 		if(-1)
 			set_light(1)

--- a/code/game/turfs/floors/desert.dm
+++ b/code/game/turfs/floors/desert.dm
@@ -114,7 +114,7 @@
 			set_light(2)
 			icon = 'icons/turf/floors/desert_water_toxic.dmi'
 		if(0)
-			set_light(1)
+			set_light(0)
 			icon = 'icons/turf/floors/desert_water.dmi'
 		if(-1)
 			set_light(1)
@@ -224,7 +224,7 @@
 			set_light(2)
 			icon = 'icons/turf/floors/desert_water_toxic.dmi'
 		if(0)
-			set_light(1)
+			set_light(0)
 			icon = 'icons/turf/floors/desert_water.dmi'
 		if(-1)
 			set_light(1)

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -168,6 +168,7 @@
 /turf/open/river
 	can_bloody = FALSE
 	supports_surgery = FALSE
+	var/toxic = 0
 
 // Prison grass
 /turf/open/organic/grass
@@ -605,6 +606,7 @@
 	icon_state = "beach"
 	baseturfs = /turf/open/gm/coast
 	supports_surgery = FALSE
+	toxic = 0
 
 /turf/open/gm/coast/north
 

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -12,7 +12,6 @@
 	var/scorchable = FALSE //if TRUE set to be an icon_state which is the full sprite version of whatever gets scorched --> for border turfs like grass edges and shorelines
 	var/scorchedness = 0 //how scorched is this turf 0 to 3
 	var/icon_state_before_scorching //this is really dumb, blame the mappers...
-	var/set_light //this remove or enable light (0 to disable)
 
 /turf/open/Initialize(mapload, ...)
 	. = ..()
@@ -169,7 +168,6 @@
 /turf/open/river
 	can_bloody = FALSE
 	supports_surgery = FALSE
-	set_light = 0
 
 // Prison grass
 /turf/open/organic/grass
@@ -607,7 +605,6 @@
 	icon_state = "beach"
 	baseturfs = /turf/open/gm/coast
 	supports_surgery = FALSE
-	set_light = 0
 
 /turf/open/gm/coast/north
 

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -606,7 +606,7 @@
 	icon_state = "beach"
 	baseturfs = /turf/open/gm/coast
 	supports_surgery = FALSE
-	toxic = 0
+	var/toxic = 0
 
 /turf/open/gm/coast/north
 

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -12,6 +12,7 @@
 	var/scorchable = FALSE //if TRUE set to be an icon_state which is the full sprite version of whatever gets scorched --> for border turfs like grass edges and shorelines
 	var/scorchedness = 0 //how scorched is this turf 0 to 3
 	var/icon_state_before_scorching //this is really dumb, blame the mappers...
+	var/set_light //this remove or enable light (0 to disable)
 
 /turf/open/Initialize(mapload, ...)
 	. = ..()
@@ -168,7 +169,7 @@
 /turf/open/river
 	can_bloody = FALSE
 	supports_surgery = FALSE
-	var/toxic = 0
+	set_light = 0
 
 // Prison grass
 /turf/open/organic/grass
@@ -606,7 +607,7 @@
 	icon_state = "beach"
 	baseturfs = /turf/open/gm/coast
 	supports_surgery = FALSE
-	var/toxic = 0
+	set_light = 0
 
 /turf/open/gm/coast/north
 


### PR DESCRIPTION
# About the pull request

This PR make non-toxic water stop glowing, it kinda don't make sense, that on some maps, where water cover essential points is just GLOWING, now water will not glow unless its intended to be glowing.

# Explain why it's good for the game
Water should not glow in darkness (unless its intended like on trijent dam)


# Testing Photographs and Procedure
![waterchange-ezgif com-video-to-gif-converter](https://github.com/cmss13-devs/cmss13/assets/89580971/7a61318c-dce4-4af3-87b1-727000ebad68)


# Changelog
:cl:
fix: Make non-toxic water stop glowing.
/:cl:
