### PR TITLE
Fixes "Cannot Examine"

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -484,7 +484,7 @@ GLOBAL_LIST_INIT(limb_types_by_name, list(
  * [this byond forum post](https://secure.byond.com/forum/?post=1326139&page=2#comment8198716)
  * for why this isn't atom/verb/examine()
  */
-/mob/verb/examinate(atom/examinify as mob|obj|turf in view(client))
+/mob/verb/examinate(atom/examinify as mob|obj|turf in view(28, usr))
 	set name = "Examine"
 	set category = "IC"
 


### PR DESCRIPTION

# About the pull request

Fixes https://github.com/cmss13-devs/cmss13/issues/6612 . More accurately, not being able to examine interface buttons is normal, its that the right-click Examine option appeared in the first place was the issue.

A recent change adjusted what objects right-click Examine appears for:
https://github.com/cmss13-devs/cmss13/pull/6591/files#diff-574e8bc8332bd8c31272b0986d27302f529a6414a8011ae367b178a46284dc57L487-R487

Before, with `view()` (effectively `view(usr)`):
Examine verb only visible on objects in-world & visible to the usr's mob, within default view range. Examine works on all these objects. The option to Examine interface items did not exist. If client's view range is longer than the default, Examine does not appear as an option on objects beyond that range.

After, with `view(client)` (effectively `view(src.client)`):
Examine verb visible on any object the client can see out to the client's view range, including nullspace objects like interface buttons. Examine only works on in-world objects, and produces weird content in the command bar for nullspace objects and inventory items.

The way a verb's `in view(...)` works is super bespoke. I can't find a way for it to work with a user's dynamic view range and exclude interface items. Closest I can come is:
- `in view(28, usr)` : works as in Before, but will work out to a range of 28 (highest view range in the codebase)
- `in world` : works on all objects anywhere, even interface buttons (which aren't really meant to be examined and have descriptions like "That's Minimap.")

I went with `view(28, usr)` in order to more closely match the previous functionality.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

The right-click Examine option should not appear for objects that were never intended to be examined.
# Testing Photographs and Procedure
Right-click Examine exists and works on world objects and inventory items, out to a ghost's maximum zoom out (view range 28). Does not exist for interface buttons.


# Changelog
:cl:
fix: right-click Examine no longer appears for interface buttons
/:cl:
