### PR TITLE
research buff: clearance can now only be bought after first drop

### DIFF
--- a/code/game/machinery/computer/research.dm
+++ b/code/game/machinery/computer/research.dm
@@ -160,6 +160,9 @@
 		if("broker_clearance")
 			if(!photocopier)
 				return
+			if(!SSobjectives.first_drop_complete)
+				visible_message(SPAN_NOTICE("Clearance access increase denied, first deployment necessary for purchase."))
+				return
 			if(GLOB.chemical_data.clearance_level < 5)
 				var/cost = max(RESEARCH_LEVEL_INCREASE_MULTIPLIER*(GLOB.chemical_data.clearance_level + 1), 1)
 				if(cost <= GLOB.chemical_data.rsc_credits)


### PR DESCRIPTION
# About the pull request
you can only buy clearance after first drop

# Explain why it's good for the game
slightly prevents bald researchers from buying clearance before survivors get a chance to swipe their card and raise it for free.

to all neverplayers: after the dissections PR, research no longer gets passive income increase when buying clearance

# Testing Photographs and Procedure
probably works

# Changelog
:cl:
add: Research clearance can now only be bought after first drop.
/:cl:
