### PR TITLE
removes sticky napalm recipe since no one uses it

### DIFF
--- a/code/modules/reagents/chemistry_reactions/other.dm
+++ b/code/modules/reagents/chemistry_reactions/other.dm
@@ -174,13 +174,6 @@
 	holder.trigger_volatiles = TRUE
 	return
 
-/datum/chemical_reaction/custom/sticky
-	name = "Sticky-Napalm"
-	id = "stickynapalm"
-	result = "stickynapalm"
-	required_reagents = list("napalm" = 1, "fuel" = 1)
-	result_amount = 2
-
 /datum/chemical_reaction/custom/high_damage
 	name = "High-Combustion Napalm Fuel"
 	id = "highdamagenapalm"


### PR DESCRIPTION

# About the pull request
removes sticky napalm recipe
was gonna remove the whole chem but somebody made it so a WY turret uses it for some reason

# Explain why it's good for the game
less bloat

# Testing Photographs and Procedure
probably works

# Changelog
:cl:
del: Removed sticky napalm recipe
/:cl:
