### PR TITLE
Re-adds a fax machine to the WY ERT station

### DIFF
--- a/maps/templates/lazy_templates/weyland_ert_station.dmm
+++ b/maps/templates/lazy_templates/weyland_ert_station.dmm
@@ -1932,6 +1932,11 @@
 	icon_state = "squares"
 	},
 /area/adminlevel/ert_station/weyland_station)
+"yi" = (
+/obj/structure/surface/table/woodentable/fancy,
+/obj/structure/machinery/faxmachine/corporate,
+/turf/open/floor/wood/ship,
+/area/adminlevel/ert_station/weyland_station)
 "yj" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out"
@@ -5361,7 +5366,7 @@ fX
 NR
 He
 fl
-Yb
+yi
 fl
 He
 Pk


### PR DESCRIPTION

# About the pull request

Re-adds a fax machine to the WY ERT station. Before factions got their own custom ERT station, the ERT station had this fax machine.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Lets WY teams fax HQ without admins needing to spawn shit in
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/cmss13-devs/cmss13/assets/91113370/f2494f57-e2ce-4604-9eaa-76a3ed3d4742)

</details>


# Changelog
:cl:
add: Re-added a fax machine to the WY ERT station
/:cl:
