### PR TITLE
Fix req tutorial landmark not being cleaned up

### DIFF
--- a/code/datums/tutorial/marine/reqs_line.dm
+++ b/code/datums/tutorial/marine/reqs_line.dm
@@ -106,6 +106,8 @@
 	active_agent = null
 	loser_agent = null
 	QDEL_LIST(agents)
+	var/obj/effect/landmark/tutorial/reqs_line_cleaner/line_cleaner = locate() in GLOB.landmarks_list
+	qdel(line_cleaner)
 	return ..()
 
 /datum/tutorial/marine/reqs_line/init_map()


### PR DESCRIPTION

# About the pull request
The `empty()` proc that's called to clean up reservation turfs ignores landmarks. This isn't an issue for other landmarks, but it is for this one as it's mapped in and not manually tracked.

Closes #6629

# Explain why it's good for the game
#6629


# Changelog
:cl:
fix: Fixed a rare case of people on shuttles being inexplicably deleted.
/:cl:
