### PR TITLE
Fixes flash bug

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -94,7 +94,8 @@
 		if(iscarbon(M))
 			flashfail = !M.flash_eyes()
 			if(!flashfail)
-				M.apply_effect(10, WEAKEN)
+				M.KnockDown(10)
+				M.Stun(10)
 
 		else if(isSilicon(M))
 			M.apply_effect(rand(5,10), WEAKEN)

--- a/code/game/objects/items/explosives/grenades/flashbang.dm
+++ b/code/game/objects/items/explosives/grenades/flashbang.dm
@@ -135,9 +135,9 @@
 		deafen_amount = 0
 		to_chat(M, SPAN_HELPFUL("Your gear protects you from the worst of the 'bang'."))
 
-	M.apply_effect(weaken_amount, STUN)
-	M.apply_effect(weaken_amount, WEAKEN)	
-	M.apply_effect(paralyze_amount, PARALYZE)
+	M.Stun(weaken_amount)
+	M.KnockDown(weaken_amount)	
+	M.KnockOut(paralyze_amount)
 	if(deafen_amount)
 		M.SetEarDeafness(max(M.ear_deaf, deafen_amount))
 

--- a/code/game/objects/items/explosives/grenades/flashbang.dm
+++ b/code/game/objects/items/explosives/grenades/flashbang.dm
@@ -136,7 +136,7 @@
 		to_chat(M, SPAN_HELPFUL("Your gear protects you from the worst of the 'bang'."))
 
 	M.apply_effect(weaken_amount, STUN)
-	M.apply_effect(weaken_amount, KNOCKDOWN)	
+	M.apply_effect(weaken_amount, WEAKEN)	
 	M.apply_effect(paralyze_amount, PARALYZE)
 	if(deafen_amount)
 		M.SetEarDeafness(max(M.ear_deaf, deafen_amount))

--- a/code/game/objects/items/explosives/grenades/flashbang.dm
+++ b/code/game/objects/items/explosives/grenades/flashbang.dm
@@ -135,7 +135,8 @@
 		deafen_amount = 0
 		to_chat(M, SPAN_HELPFUL("Your gear protects you from the worst of the 'bang'."))
 
-	M.apply_effect(weaken_amount, WEAKEN)
+	M.apply_effect(weaken_amount, STUN)
+	M.apply_effect(weaken_amount, KNOCKDOWN)	
 	M.apply_effect(paralyze_amount, PARALYZE)
 	if(deafen_amount)
 		M.SetEarDeafness(max(M.ear_deaf, deafen_amount))


### PR DESCRIPTION
https://github.com/cmss13-devs/cmss13/pull/4842 - after we moved to the TG system for many status effects, certain things needed to be converted from WEAKEN to Stun/KnockDown in order to function properly - for example tablestunning was converted in that PR. From testing, it seems like flash, flashbang needs to be converted as well.

# Explain why it's good for the game

Fixes weird flash/flashbang issue(s)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: converts flash, flashbang to TG effect system, fixing issue(s)
/:cl:
