### PR TITLE
bipod on revolver

### DIFF
--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -310,11 +310,12 @@
 		/obj/item/attachable/lasersight,
 		/obj/item/attachable/scope/mini,
 		/obj/item/attachable/scope/mini_iff,
+		/obj/item/attachable/bipod,
 	)
 	var/folded = FALSE // Used for the stock attachment, to check if we can shoot or not
 
 /obj/item/weapon/gun/revolver/m44/set_gun_attachment_offsets()
-	attachable_offset = list("muzzle_x" = 29, "muzzle_y" = 21,"rail_x" = 12, "rail_y" = 23, "under_x" = 21, "under_y" = 18, "stock_x" = 16, "stock_y" = 20)
+	attachable_offset = list("muzzle_x" = 29, "muzzle_y" = 21,"rail_x" = 12, "rail_y" = 23, "under_x" = 21, "under_y" = 19, "stock_x" = 16, "stock_y" = 20)
 
 /obj/item/weapon/gun/revolver/m44/set_gun_config_values()
 	..()


### PR DESCRIPTION

# About the pull request

![image](https://github.com/cmss13-devs/cmss13/assets/44546836/53d9e6e7-0126-419f-a98b-29fa05c379f6)

# Explain why it's good for the game

funny gimmick loadout for GIGN larp. you can already put 4x fucking scopes on a revolver, so why not embrace the memery and use bipod?

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: M44 revolver can now be equipped with bipod.
/:cl:
