### PR TITLE
makes splint breaking message bigger

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -477,7 +477,7 @@ This function completely restores a damaged organ to perfect condition.
 	if(!(status & LIMB_SPLINTED_INDESTRUCTIBLE) && (status & LIMB_SPLINTED) && damage > 5 && prob(50 + damage * 2.5)) //If they have it splinted, the splint won't hold.
 		status &= ~LIMB_SPLINTED
 		playsound(get_turf(loc), 'sound/items/splintbreaks.ogg', 20)
-		to_chat(owner, SPAN_DANGER("The splint on your [display_name] comes apart!"))
+		to_chat(owner, SPAN_HIGHDANGER("The splint on your [display_name] comes apart!"))
 		owner.pain.apply_pain(PAIN_BONE_BREAK_SPLINTED)
 		owner.update_med_icon()
 


### PR DESCRIPTION

# About the pull request

![image](https://github.com/cmss13-devs/cmss13/assets/44546836/6efab173-1cb7-487d-923a-8e264648a64e)
# Explain why it's good for the game

in the heat of a battle it might be hard to notice your splints breaking and finding out that you're fucked only after you get some organ damage is pretty sad so this should help

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Made splint breaking message bigger
/:cl:
