### PR TITLE
autoclimbable handrails on harm intent

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -110,7 +110,7 @@
 
 /obj/structure/proc/do_climb(mob/living/user, mods)
 	if(!can_climb(user))
-		return
+		return FALSE
 
 	var/list/climbdata = list("climb_delay" = climb_delay)
 	SEND_SIGNAL(user, COMSIG_LIVING_CLIMB_STRUCTURE, climbdata)
@@ -120,10 +120,10 @@
 	user.visible_message(SPAN_WARNING("[user] starts [flags_atom & ON_BORDER ? "leaping over" : climb_over_string] \the [src]!"))
 
 	if(!do_after(user, final_climb_delay, INTERRUPT_NO_NEEDHAND, BUSY_ICON_GENERIC, numticks = 2))
-		return
+		return FALSE
 
 	if(!can_climb(user))
-		return
+		return FALSE
 
 	var/turf/TT = get_turf(src)
 	if(flags_atom & ON_BORDER)
@@ -145,6 +145,7 @@
 	user.forceMove(TT)
 	for(var/atom/movable/thing as anything in grabbed_things) // grabbed things aren't moved to the tile immediately to: make the animation better, preserve the grab
 		thing.forceMove(TT)
+	return TRUE
 
 /obj/structure/proc/structure_shaken()
 

--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -18,6 +18,7 @@
 	var/build_state = BARRICADE_BSTATE_SECURED
 	var/reinforced = FALSE //Reinforced to be a cade or not
 	var/can_be_reinforced = TRUE //can we even reinforce this handrail or not?
+	var/climbable = TRUE
 
 /obj/structure/barricade/handrail/update_icon()
 	overlays.Cut()
@@ -42,7 +43,8 @@
 
 /obj/structure/barricade/handrail/Collided(atom/movable/movable)
 	if(ismob(movable))
-		do_climb(movable)
+		if(climbable)
+			do_climb(movable)
 	..()
 
 /obj/structure/barricade/handrail/get_examine_text(mob/user)

--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -18,7 +18,6 @@
 	var/build_state = BARRICADE_BSTATE_SECURED
 	var/reinforced = FALSE //Reinforced to be a cade or not
 	var/can_be_reinforced = TRUE //can we even reinforce this handrail or not?
-	var/autoclimbable = TRUE
 
 /obj/structure/barricade/handrail/update_icon()
 	overlays.Cut()
@@ -43,8 +42,9 @@
 
 /obj/structure/barricade/handrail/Collided(atom/movable/movable)
 	if(ismob(movable))
-		if(autoclimbable)
-			do_climb(movable)
+		var/mob/living/climber = movable
+		if(climber.a_intent == INTENT_HARM)
+			do_climb(climber)
 	..()
 
 /obj/structure/barricade/handrail/get_examine_text(mob/user)

--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -18,6 +18,7 @@
 	var/build_state = BARRICADE_BSTATE_SECURED
 	var/reinforced = FALSE //Reinforced to be a cade or not
 	var/can_be_reinforced = TRUE //can we even reinforce this handrail or not?
+	var/autoclimb = TRUE
 
 /obj/structure/barricade/handrail/update_icon()
 	overlays.Cut()
@@ -41,7 +42,7 @@
 			overlays += image(E.icon_path, icon_state = E.obj_icon_state_path)
 
 /obj/structure/barricade/handrail/Collided(atom/movable/movable)
-	if(ismob(movable))
+	if(ismob(movable && autoclimb))
 		var/mob/living/climber = movable
 		if(climber.a_intent == INTENT_HARM)
 			do_climb(climber)

--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -44,7 +44,7 @@
 /obj/structure/barricade/handrail/Collided(atom/movable/movable)
 	if(istype(movable,/mob/living/carbon/xenomorph/ravager) || istype(movable,/mob/living/carbon/xenomorph/crusher))
 		var/mob/living/carbon/xenomorph/xenomorph = movable
-		if(!xenomorph.stat) //No dead xenos jumpin on the bed~
+		if(!xenomorph.stat)
 			visible_message(SPAN_DANGER("[xenomorph] plows straight through [src]!"))
 			deconstruct(FALSE)
 	else
@@ -53,8 +53,13 @@
 			if(climber.a_intent == INTENT_HARM)
 				var/climbed = do_climb(climber)
 				if(climbed)
-					climber.apply_damage(15,BRUTE)
-					climber.visible_message(SPAN_WARNING("You hit yourself as you vault over the [src]"))
+					climber.client.move_delay += 3 DECISECONDS
+					if(prob(25))
+						if(ishuman(climber))
+							climber.apply_damage(15,BRUTE,no_limb_loss = TRUE)
+						else
+							climber.apply_damage(15,BRUTE)
+						climber.visible_message(SPAN_WARNING("You hit yourself as you vault over the [src]"))
 	..()
 
 /obj/structure/barricade/handrail/get_examine_text(mob/user)

--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -52,9 +52,9 @@
 		if(ismob(movable) && autoclimb)
 			var/mob/living/climber = movable
 			if(climber.a_intent == INTENT_HARM)
+				climber.client?.move_delay += 3 DECISECONDS
 				var/climbed = do_climb(climber)
 				if(climbed)
-					climber.client?.move_delay += 3 DECISECONDS
 					if(prob(25))
 						if(ishuman(climber))
 							var/mob/living/carbon/human/human = climber

--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -40,9 +40,9 @@
 		if(E.icon_path && E.obj_icon_state_path)
 			overlays += image(E.icon_path, icon_state = E.obj_icon_state_path)
 
-/obj/structure/barricade/handrail/Collided(atom/movable/moveable)
-	if(ismob(moveable))
-		do_climb(moveable)
+/obj/structure/barricade/handrail/Collided(atom/movable/movable)
+	if(ismob(movable))
+		do_climb(movable)
 	..()
 
 /obj/structure/barricade/handrail/get_examine_text(mob/user)

--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -48,6 +48,7 @@
 			var/climbed = do_climb(climber)
 			if(climbed)
 				climber.apply_damage(15,BRUTE)
+				climber.visible_message(SPAN_WARNING("You hit yourself as you vault over the [src]"))
 	..()
 
 /obj/structure/barricade/handrail/get_examine_text(mob/user)

--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -56,7 +56,8 @@
 					climber.client?.move_delay += 3 DECISECONDS
 					if(prob(25))
 						if(ishuman(climber))
-							climber.apply_damage(15,BRUTE,no_limb_loss = TRUE)
+							var/mob/living/carbon/human/human = climber
+							human.apply_damage(15,BRUTE,no_limb_loss = TRUE)
 						else
 							climber.apply_damage(15,BRUTE)
 						climber.visible_message(SPAN_WARNING("You hit yourself as you vault over the [src]"))

--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -60,7 +60,7 @@
 							var/mob/living/carbon/human/human = climber
 							human.apply_damage(5,BRUTE,no_limb_loss = TRUE)
 						else
-							climber.apply_damage(15,BRUTE)
+							climber.apply_damage(5,BRUTE)
 						climber.visible_message(SPAN_WARNING("You hit yourself as you vault over the [src]"))
 	..()
 

--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -40,9 +40,9 @@
 		if(E.icon_path && E.obj_icon_state_path)
 			overlays += image(E.icon_path, icon_state = E.obj_icon_state_path)
 
-/obj/structure/barricade/handrail/Collided(atom/movable/AM)
-	if(ismob(AM))
-		do_climb(AM)
+/obj/structure/barricade/handrail/Collided(atom/movable/moveable)
+	if(ismob(moveable))
+		do_climb(moveable)
 	..()
 
 /obj/structure/barricade/handrail/get_examine_text(mob/user)

--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -18,7 +18,7 @@
 	var/build_state = BARRICADE_BSTATE_SECURED
 	var/reinforced = FALSE //Reinforced to be a cade or not
 	var/can_be_reinforced = TRUE //can we even reinforce this handrail or not?
-	var/climbable = TRUE
+	var/autoclimbable = TRUE
 
 /obj/structure/barricade/handrail/update_icon()
 	overlays.Cut()
@@ -43,7 +43,7 @@
 
 /obj/structure/barricade/handrail/Collided(atom/movable/movable)
 	if(ismob(movable))
-		if(climbable)
+		if(autoclimbable)
 			do_climb(movable)
 	..()
 

--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -40,6 +40,11 @@
 		if(E.icon_path && E.obj_icon_state_path)
 			overlays += image(E.icon_path, icon_state = E.obj_icon_state_path)
 
+/obj/structure/barricade/handrail/Collided(atom/movable/AM)
+	if(ismob(AM))
+		do_climb(AM)
+	..()
+
 /obj/structure/barricade/handrail/get_examine_text(mob/user)
 	. = ..()
 	switch(build_state)

--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -42,10 +42,12 @@
 			overlays += image(E.icon_path, icon_state = E.obj_icon_state_path)
 
 /obj/structure/barricade/handrail/Collided(atom/movable/movable)
-	if(ismob(movable && autoclimb))
+	if(ismob(movable) && autoclimb)
 		var/mob/living/climber = movable
 		if(climber.a_intent == INTENT_HARM)
-			do_climb(climber)
+			var/climbed = do_climb(climber)
+			if(climbed)
+				climber.apply_damage(15,BRUTE)
 	..()
 
 /obj/structure/barricade/handrail/get_examine_text(mob/user)

--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -47,6 +47,7 @@
 		if(!xenomorph.stat)
 			visible_message(SPAN_DANGER("[xenomorph] plows straight through [src]!"))
 			deconstruct(FALSE)
+			return
 	else
 		if(ismob(movable) && autoclimb)
 			var/mob/living/climber = movable

--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -58,7 +58,7 @@
 					if(prob(25))
 						if(ishuman(climber))
 							var/mob/living/carbon/human/human = climber
-							human.apply_damage(15,BRUTE,no_limb_loss = TRUE)
+							human.apply_damage(5,BRUTE,no_limb_loss = TRUE)
 						else
 							climber.apply_damage(15,BRUTE)
 						climber.visible_message(SPAN_WARNING("You hit yourself as you vault over the [src]"))

--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -53,7 +53,7 @@
 			if(climber.a_intent == INTENT_HARM)
 				var/climbed = do_climb(climber)
 				if(climbed)
-					climber.client.move_delay += 3 DECISECONDS
+					climber.client?.move_delay += 3 DECISECONDS
 					if(prob(25))
 						if(ishuman(climber))
 							climber.apply_damage(15,BRUTE,no_limb_loss = TRUE)

--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -42,13 +42,19 @@
 			overlays += image(E.icon_path, icon_state = E.obj_icon_state_path)
 
 /obj/structure/barricade/handrail/Collided(atom/movable/movable)
-	if(ismob(movable) && autoclimb)
-		var/mob/living/climber = movable
-		if(climber.a_intent == INTENT_HARM)
-			var/climbed = do_climb(climber)
-			if(climbed)
-				climber.apply_damage(15,BRUTE)
-				climber.visible_message(SPAN_WARNING("You hit yourself as you vault over the [src]"))
+	if(istype(movable,/mob/living/carbon/xenomorph/ravager) || istype(movable,/mob/living/carbon/xenomorph/crusher))
+		var/mob/living/carbon/xenomorph/xenomorph = movable
+		if(!xenomorph.stat) //No dead xenos jumpin on the bed~
+			visible_message(SPAN_DANGER("[xenomorph] plows straight through [src]!"))
+			deconstruct(FALSE)
+	else
+		if(ismob(movable) && autoclimb)
+			var/mob/living/climber = movable
+			if(climber.a_intent == INTENT_HARM)
+				var/climbed = do_climb(climber)
+				if(climbed)
+					climber.apply_damage(15,BRUTE)
+					climber.visible_message(SPAN_WARNING("You hit yourself as you vault over the [src]"))
 	..()
 
 /obj/structure/barricade/handrail/get_examine_text(mob/user)

--- a/html/changelogs/AutoChangeLog-pr-6637.yml
+++ b/html/changelogs/AutoChangeLog-pr-6637.yml
@@ -1,0 +1,4 @@
+author: "zzzmike"
+delete-after: True
+changes:
+  - bugfix: "converts flash, flashbang to TG effect system, fixing issue(s)"


### PR DESCRIPTION
# About the pull request

you do climb when you collide with handrail, rejoice.  this makes handrails lot less of an obsticle for both huge xenos and highly rained and agile marines. also there is autoclimbable var that can be set to FALSE on req railing so you can not throw others out of the line


# Explain why it's good for the game

handrails can be major pain in ass for both marines and xenos, especily as they are used near ledges so you auto climb from one side to other but have to manualy climb back. they are also sometimes hard to spot and can get you stuck and killed, generly getting stoped by railing that you did not see feels like shit as both sides can shoot or slash it down in seconds. I am gona put this as QOL but if you think it is balance then so be it


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: handrails are autoclimbable when on harm intent, you take some harm when doing so
balance: crusher and ravager destroy handrails when trying to pass them similar to tables
/:cl:
