### PR TITLE
lifeboat state fix

### DIFF
--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -451,6 +451,7 @@
 			var/obj/docking_port/stationary/lifeboat_dock/lifeboat_dock = lifeboat.get_docked()
 			lifeboat_dock.open_dock()
 			xeno_message(SPAN_XENOANNOUNCE("We have wrested away control of one of the metal birds! They shall not escape!"), 3, xeno.hivenumber)
+			launch_initiated = FALSE
 		return XENO_NO_DELAY_ACTION
 	else
 		return ..()


### PR DESCRIPTION
# About the pull request

Resets shuttle launching state if queen stops the launch

# Explain why it's good for the game

can be important to fix this in case pilot unhacks lifeboat console (dunno if that is possible at current though?) edit: per discord it seems like no, but this will futureproof the code anyway


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: corrects lifeboat state when queen hijacks
/:cl:
