### PR TITLE
Adjusts Yautja health from 175 to 200

### DIFF
--- a/code/modules/mob/living/carbon/human/species/yautja/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/yautja/_species.dm
@@ -28,7 +28,7 @@
 	default_lighting_alpha = LIGHTING_PLANE_ALPHA_YAUTJA
 	flags_sight = SEE_MOBS
 	slowdown = -0.5
-	total_health = 175 //more health than regular humans
+	total_health = 200 //more health than regular humans
 	timed_hug = FALSE
 
 	bloodsplatter_type = /obj/effect/temp_visual/dir_setting/bloodsplatter/yautjasplatter


### PR DESCRIPTION
# About the pull request
This itsy bitsy PR changes the total_health of predators from 175 to a very nice number of 200.
_The practical effects of this are as follows;_
Using regular M41A to shoot until critical
**_52 shots --> 56 shots_**
Using M41A AP to shoot until critical
**_28 shots --> 30 shots_**
Slashes by a warrior to the face until critical (with demask at 8 slashes on both 175 health and 200 health)
_**52 --> 58 slashes**_ 

It's important to note especially for the xeno section that this doesn't reflect real world performance, considering the usage of xeno abilities, in particular tail stab and wall-slams via the use of fling or other similiar abilities can do a significant amount of additional damage.
# Explain why it's good for the game
Predators are in a weird spot when it comes to the current state of balance. This is more to test how an increase to health will affect preds in actuality rather than in theory. At the moment it's a generally wide consensus (from what I have learnt talking to people on the discord, at least) that predators in regards to fighting against marines are a fair bit squisher than before. It's in my opinion rather safe to say that a good marine will usually win against a good pred, all things equal on the 'skill-field'. This state is, depending on your opinion, perfectly fine or sliding towards 'bit too easy'. It's not rewarding to kill something if it's too easy to deal with, really.

This honestly might have more effect on xenos than it does marines, despite the goal in mind is to make marines have a bit of a harder time downing a pred, whilst limiting any effect on xenos, whom at the moment can't really 1v1 a predator and only have a good chance in numbers. Hopefully the difference isn't too impactful there, though part of this PR is to figure out if health changes will have a significant effect on xeno v pred, so others can account for it in any future attempts at balancing preds.

I think however, being able to take even just a few more shots can help against the current state. It's not too hard to kill a 7ft monster. It's easier than you think, considering that this 7ft monster has to move towards you to do damage in most circumstances. Especially when you can (usually without consequence), run up to said creature and magdump it from the get-go, getting a few free shots before they can react and begin dodging.

Is this a bit of a bandaid PR? Yeah, pretty much. We gotta start somewhere and sticking a hand into the puddle of values and variables to see what happens probably won't go horribly. Right? There's very few ideas floating around in regards to addressing some of the issues preds currently face, so seeing how small changes like this affect the real game might give us a bit of insight on what we _can_ do.

tldr; who doesn't like round numbers? :3


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Yautja total_health changed from 175 to 200
/:cl:
