### PR TITLE
Change runechat font from Small fonts to MS Serif

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -215,7 +215,7 @@ window "mapwindow"
 		font-size = 7
 		is-default = true
 		saved-params = "zoom;letterbox;zoom-mode"
-		style = ".maptext { font-family: 'Small Fonts'; font-size: 7px; -dm-text-outline: 1px black; color: white; line-height: 1.1; } .center { text-align: center; } .langchat { font-family: 'Small Fonts'; font-size: 7px; -dm-text-outline: 1px black; } .langchat_small { font-size: 6px; } .langchat_yell { font-weight: bold; font-size: 10px; } .langchat_bolded { font-weight: bold; font-size: 8px; } .langchat_announce { font-weight: bold; font-size: 12px; } .langchat_bolditalicbig {font-weight: bold; font-size: 24px; font-style: italic; } .langchat_italic {font-style: italic; }"
+		style = ".maptext { font-family: 'MS Serif'; font-size: 7px; -dm-text-outline: 1px black; color: white; line-height: 1.1; } .center { text-align: center; } .langchat { font-family: 'MS Serif'; font-size: 7px; -dm-text-outline: 1px black; } .langchat_small { font-size: 6px; } .langchat_yell { font-weight: bold; font-size: 10px; } .langchat_bolded { font-weight: bold; font-size: 8px; } .langchat_announce { font-weight: bold; font-size: 12px; } .langchat_bolditalicbig {font-weight: bold; font-size: 24px; font-style: italic; } .langchat_italic {font-style: italic; }"
 	elem "status_bar"
 		type = LABEL
 		pos = 0,464


### PR DESCRIPTION
# About the pull request


Swaps fonts for runechat

Before:
![dreamseeker_1HqQxjyTtY](https://github.com/cmss13-devs/cmss13/assets/100090741/7596e89b-f452-44f2-8277-2c47466c0126)

![dreamseeker_SyCSzBL0hJ](https://github.com/cmss13-devs/cmss13/assets/100090741/55b1776c-2d89-4ce7-acca-ec0f76865903)

![dreamseeker_F5uOv0blMR](https://github.com/cmss13-devs/cmss13/assets/100090741/37622e73-2785-4468-b98a-e577f817d351)



After:

![dreamseeker_uwE0JWu48m](https://github.com/cmss13-devs/cmss13/assets/100090741/14dd88d0-d31a-416a-82d6-5adb1c2ddcbe)

![dreamseeker_jftdTaUyNm](https://github.com/cmss13-devs/cmss13/assets/100090741/d5cb699e-0505-4b98-b8f6-5f1caa865eef)

![dreamseeker_dUQTn3nfCb](https://github.com/cmss13-devs/cmss13/assets/100090741/35dfc705-f418-42b0-b868-de25fb16dd2c)




# Explain why it's good for the game

More visually pleasing font, that is also less big, which would support longer messages, as well as this font supporting wider range of letters.



# Changelog
:cl:
ui: changed runechat font from Small fonts to MS Serif
/:cl:
