### PR TITLE
Unique observer submenus for non-standard marine squads

### DIFF
--- a/tgui/packages/tgui/interfaces/Orbit/index.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/index.tsx
@@ -158,6 +158,10 @@ const marineSplitter = (members: Array<Observable>) => {
   const charlieSquad: Array<Observable> = [];
   const deltaSquad: Array<Observable> = [];
   const foxtrotSquad: Array<Observable> = [];
+  const echoSquad: Array<Observable> = [];
+  const CBRNSquad: Array<Observable> = [];
+  const FORECONSquad: Array<Observable> = [];
+  const SOFSquad: Array<Observable> = [];
   const other: Array<Observable> = [];
 
   members.forEach((x) => {
@@ -171,6 +175,14 @@ const marineSplitter = (members: Array<Observable>) => {
       deltaSquad.push(x);
     } else if (x.job?.includes('Foxtrot')) {
       foxtrotSquad.push(x);
+    } else if (x.job?.includes('Echo')) {
+      echoSquad.push(x);
+    } else if (x.job?.includes('CBRN')) {
+      CBRNSquad.push(x);
+    } else if (x.job?.includes('FORECON')) {
+      FORECONSquad.push(x);
+    } else if (x.job?.includes('SOF')) {
+      SOFSquad.push(x);
     } else {
       other.push(x);
     }
@@ -181,7 +193,11 @@ const marineSplitter = (members: Array<Observable>) => {
     buildSquadObservable('Bravo', 'yellow', bravoSquad),
     buildSquadObservable('Charlie', 'purple', charlieSquad),
     buildSquadObservable('Delta', 'blue', deltaSquad),
-    buildSquadObservable('Foxtrot', 'teal', foxtrotSquad),
+    buildSquadObservable('Foxtrot', 'brown', foxtrotSquad),
+    buildSquadObservable('Echo', 'teal', echoSquad),
+    buildSquadObservable('CBRN', 'dark-blue', CBRNSquad),
+    buildSquadObservable('FORECON', 'green', FORECONSquad),
+    buildSquadObservable('SOF', 'red', SOFSquad),
     buildSquadObservable('Other', 'grey', other),
   ];
   return squads;


### PR DESCRIPTION

# About the pull request

This PR adds sub-menus for most non-standard marine squads. This includes SOF (Marine Raiders), CBRN, Echo Squad, and Forecon (ERT only, not survivors). This also changes the colour of Foxtrot from Teal to a similar brownish colour. 

# Explain why it's good for the game

Better tracking of non-standard squads for when they appear. 


# Testing Photographs and Procedure
![Screenshot 2024-07-10 17 57 12](https://github.com/cmss13-devs/cmss13/assets/6595389/8d199deb-f184-415b-847c-1b5dacd33252)



# Changelog
:cl:
add: Marine Special Forces, Forecon, Echo Squad and CBRN will now appear in their own sub-menu for observers. 
ui: Foxtrot's colour in the observe menu now reflects the squads true colour scheme. 
/:cl:
