### PR TITLE
Splits the civ-only combat reporter gear into their own category.

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/combat_correspondent.dm
+++ b/code/game/machinery/vending/vendor_types/crew/combat_correspondent.dm
@@ -3,9 +3,11 @@
 GLOBAL_LIST_INIT(cm_vending_clothing_combat_correspondent, list(
 		list("STANDARD EQUIPMENT (TAKE ALL)", 0, null, null, null),
 		list("Essential Reporter's Set", 0, /obj/effect/essentials_set/cc, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("Leather Satchel", 0, /obj/item/storage/backpack/satchel, MARINE_CAN_BUY_BACKPACK, VENDOR_ITEM_REGULAR),
+
+		list("CIVILIAN EQUIPMENT (TAKE ALL)", 0, null, null, null),
 		list("Portable Press Fax Machine", 0, /obj/item/device/fax_backpack, CIVILIAN_CAN_BUY_BACKPACK, VENDOR_ITEM_RECOMMENDED),
 		list("Press Broadcasting Camera", 0, /obj/item/device/camera/broadcasting, CIVILIAN_CAN_BUY_UTILITY, VENDOR_ITEM_RECOMMENDED),
-		list("Leather Satchel", 0, /obj/item/storage/backpack/satchel, MARINE_CAN_BUY_BACKPACK, VENDOR_ITEM_REGULAR),
 
 		list("UNIFORM (CHOOSE 1)", 0, null, null, null),
 		list("Black Uniform", 0, /obj/item/clothing/under/marine/reporter/black, MARINE_CAN_BUY_UNIFORM, VENDOR_ITEM_REGULAR),


### PR DESCRIPTION

# About the pull request

Title

# Explain why it's good for the game

We get a lot of ahelps from first-time players of the combat correspondant role, asking why they can't get these equipment pieces. This should make it clearer.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: The Combat Correspondant's civilian equipment is now in it's own category to make it easier to tell why you can't click it as the military version.
/:cl:
