### PR TITLE
Use RANGE_TURFS

### DIFF
--- a/code/__DEFINES/turfs.dm
+++ b/code/__DEFINES/turfs.dm
@@ -1,14 +1,15 @@
-#define RANGE_TURFS(RADIUS, CENTER) \
-	block( \
-		(CENTER).x-(RADIUS), (CENTER).y-(RADIUS), (CENTER).z, \
-		(CENTER).x+(RADIUS), (CENTER).y+(RADIUS), (CENTER).z \
-	)
-
+/// Returns a list of turfs within H_RADIUS tiles horizontally and V_RADIUS tiles vertically of CENTER.
 #define RECT_TURFS(H_RADIUS, V_RADIUS, CENTER) \
 	block( \
 		(CENTER).x-(H_RADIUS), (CENTER).y-(V_RADIUS), (CENTER).z, \
 		(CENTER).x+(H_RADIUS), (CENTER).y+(V_RADIUS), (CENTER).z \
 	)
+
+/// Returns a list of turfs within Dist tiles of Center. When Dist >= 5 faster than a `range()` filtered to `/turf`s.
+#define RANGE_TURFS(Dist, Center) RECT_TURFS(Dist, Dist, Center)
+
+/// Returns a list of turfs within Dist tiles of Center, excluding Center. When Dist >= 5 faster than an `orange()` filtered to `/turf`s.
+#define ORANGE_TURFS(Dist, Center) (RANGE_TURFS(Dist, Center) - Center)
 
 ///Returns all turfs in a zlevel
 #define Z_TURFS(ZLEVEL) block(1, 1, (ZLEVEL), world.maxx, world.maxy, (ZLEVEL))

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -45,7 +45,7 @@
 	var/list/turfs = new/list()
 	var/rsq = radius * (radius+0.5)
 
-	for(var/turf/T in range(radius, centerturf))
+	for(var/turf/T as anything in RANGE_TURFS(radius, centerturf))
 		var/dx = T.x - centerturf.x
 		var/dy = T.y - centerturf.y
 		if(dx*dx + dy*dy <= rsq)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1283,10 +1283,7 @@ GLOBAL_LIST_INIT(WALLITEMS, list(
 	origin = get_turf(origin)
 	if(!origin)
 		return
-	var/list/turfs = list()
-	for(var/turf/T in orange(origin, outer_range))
-		if(!inner_range || get_dist(origin, T) >= inner_range)
-			turfs += T
+	var/list/turfs = (RANGE_TURFS(outer_range, origin) - RANGE_TURFS(inner_range - 1, origin))
 	if(length(turfs))
 		return pick(turfs)
 

--- a/code/game/machinery/door_display/door_display.dm
+++ b/code/game/machinery/door_display/door_display.dm
@@ -203,7 +203,7 @@
 		if(F.id == id)
 			targets += F
 	if(has_wall_divider)
-		for(var/turf/closed/wall/almayer/research/containment/wall/divide/W in orange(src, 8))
+		for(var/turf/closed/wall/almayer/research/containment/wall/divide/W in ORANGE_TURFS(8, src))
 			targets += W
 
 /obj/structure/machinery/door_display/research_cell/Destroy()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -87,10 +87,7 @@
 	return located_turfs
 
 /obj/structure/machinery/door/proc/borders_space()
-	for(var/turf/target in range(1, src))
-		if(istype(target, /turf/open/space))
-			return TRUE
-	return FALSE
+	return !!(locate(/turf/open/space) in range(1, src))
 
 /obj/structure/machinery/door/Collided(atom/movable/AM)
 	if(panel_open || operating)

--- a/code/game/objects/items/devices/teleportation.dm
+++ b/code/game/objects/items/devices/teleportation.dm
@@ -152,7 +152,7 @@
 			else
 				L["[com.id] (Inactive)"] = com.locked
 	var/list/turfs = list( )
-	for(var/turf/T in orange(10))
+	for(var/turf/T as anything in ORANGE_TURFS(10, src))
 		if(T.x>world.maxx-8 || T.x<8) continue //putting them at the edge is dumb
 		if(T.y>world.maxy-8 || T.y<8) continue
 		turfs += T

--- a/code/game/objects/items/reagent_containers/food/snacks/grown.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks/grown.dm
@@ -584,19 +584,14 @@
 		src.visible_message(SPAN_NOTICE("The [src.name] has been squashed."),SPAN_MODERATE("You hear a smack."))
 		qdel(src)
 		return
-	for(var/turf/T in orange(M,outer_teleport_radius))
-		if(T in orange(M,inner_teleport_radius)) continue
+	for(var/turf/T as anything in (RANGE_TURFS(outer_teleport_radius, M) - RANGE_TURFS(inner_teleport_radius, M)))
 		if(istype(T,/turf/open/space)) continue
 		if(T.density) continue
 		if(T.x>world.maxx-outer_teleport_radius || T.x<outer_teleport_radius) continue
 		if(T.y>world.maxy-outer_teleport_radius || T.y<outer_teleport_radius) continue
 		turfs += T
 	if(!length(turfs))
-		var/list/turfs_to_pick_from = list()
-		for(var/turf/T in orange(M,outer_teleport_radius))
-			if(!(T in orange(M,inner_teleport_radius)))
-				turfs_to_pick_from += T
-		turfs += pick(/turf in turfs_to_pick_from)
+		turfs += pick(RANGE_TURFS(outer_teleport_radius, M) - RANGE_TURFS(inner_teleport_radius, M))
 	var/turf/picked = pick(turfs)
 	if(!isturf(picked)) return
 	switch(rand(1,2))//Decides randomly to teleport the thrower or the throwee.

--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -32,7 +32,7 @@
 	. = ..()
 
 	node = place_node()
-	for(var/turf/A in range(floor(cover_range*PYLON_COVERAGE_MULT), loc))
+	for(var/turf/A as anything in RANGE_TURFS(floor(cover_range*PYLON_COVERAGE_MULT), loc))
 		LAZYADD(A.linked_pylons, src)
 		linked_turfs += A
 

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -161,9 +161,7 @@
 
 /obj/structure/ship_ammo/heavygun/detonate_on(turf/impact, obj/structure/dropship_equipment/weapon/fired_from)
 	set waitfor = 0
-	var/list/turf_list = list()
-	for(var/turf/T in range(bullet_spread_range, impact))
-		turf_list += T
+	var/list/turf_list = RANGE_TURFS(bullet_spread_range, impact)
 	var/soundplaycooldown = 0
 	var/debriscooldown = 0
 
@@ -243,9 +241,7 @@
 
 /obj/structure/ship_ammo/laser_battery/detonate_on(turf/impact, obj/structure/dropship_equipment/weapon/fired_from)
 	set waitfor = 0
-	var/list/turf_list = list()
-	for(var/turf/T in range(3, impact)) //This is its area of effect
-		turf_list += T
+	var/list/turf_list = RANGE_TURFS(3, impact) //This is its area of effect
 	playsound(impact, 'sound/effects/pred_vision.ogg', 20, 1)
 	for(var/i=1 to 16) //This is how many tiles within that area of effect will be randomly ignited
 		var/turf/U = pick(turf_list)

--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -721,9 +721,7 @@
 
 	ammo_accuracy_range /= 2 //buff for basically pointblanking the ground
 
-	var/list/possible_turfs = list()
-	for(var/turf/TU in range(ammo_accuracy_range, target_turf))
-		possible_turfs += TU
+	var/list/possible_turfs = RANGE_TURFS(ammo_accuracy_range, target_turf)
 	var/turf/impact = pick(possible_turfs)
 	sleep(3)
 	SA.source_mob = user
@@ -1328,9 +1326,7 @@
 
 	ammo_accuracy_range /= 2 //buff for basically pointblanking the ground
 
-	var/list/possible_turfs = list()
-	for(var/turf/TU in range(ammo_accuracy_range, target_turf))
-		possible_turfs += TU
+	var/list/possible_turfs = RANGE_TURFS(ammo_accuracy_range, target_turf)
 	var/turf/impact = pick(possible_turfs)
 	sleep(3)
 	SA.source_mob = user

--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -554,10 +554,7 @@ GLOBAL_LIST_EMPTY(orbital_cannon_cancellation)
 	set waitfor = 0
 
 	var/range_num = 12
-	var/list/turf_list = list()
-
-	for(var/turf/T in range(range_num, target))
-		turf_list += T
+	var/list/turf_list = RANGE_TURFS(range_num, target)
 
 	for(var/i = 1 to total_amount)
 		for(var/k = 1 to instant_amount)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -164,8 +164,7 @@
 	if(pickup_recent_item_on_turf(user_turf))
 		return
 
-	var/range_list = orange(1, src)
-	for(var/turf/nearby_turf in range_list)
+	for(var/turf/nearby_turf in orange(1, src))
 		if(pickup_recent_item_on_turf(nearby_turf))
 			return
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -84,7 +84,7 @@
 			//1% chance to skitter madly away
 			if(!busy && prob(1))
 				/*var/list/move_targets = list()
-				for(var/turf/T in orange(20, src))
+				for(var/turf/T as anything in ORANGE_TURFS(20, src))
 					move_targets.Add(T)*/
 				stop_automated_movement = 1
 				walk_to(src, pick(orange(20, src)), 1, move_to_delay)

--- a/code/modules/projectiles/ammo_boxes/misc_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/misc_boxes.dm
@@ -110,9 +110,7 @@
 	if(flare_amount > 0)
 		handle_side_effects(host_box, TRUE)
 
-		var/list/turf_list = list()
-		for(var/turf/T in range(5, (host_box ? host_box : src)))
-			turf_list += T
+		var/list/turf_list = RANGE_TURFS(5, (host_box ? host_box : src))
 		for(var/i = 1, i <= flare_amount, i++)
 			addtimer(CALLBACK(src, PROC_REF(explode), (host_box ? host_box : src), turf_list), rand(1, 6) SECONDS)
 		return


### PR DESCRIPTION

# About the pull request

Switches several uses of `for(var/turf/... in range())` over to `RANGE_TURFS()` instead. Doesn't switch when the expected radius is less than 5. Where possible, removes the loop entirely.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

For finding turfs, `RANGE_TURFS` shows a slight performance benefit over `range`. This performance benefit becomes more pronounced as the radius increases.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Performance testing. All procs in question return a list of turfs.
The procs of interest:
![image](https://github.com/user-attachments/assets/c130418c-dfa3-4f8a-9bfb-54dd9f8bd2e3)

Radius 1:
![image](https://github.com/user-attachments/assets/837deddf-24cc-46d1-9c48-0c3ce0a4310a)

Radius 5:
![image](https://github.com/user-attachments/assets/146d581e-1c16-4988-837c-3422d954d8aa)

Radius 10:
![image](https://github.com/user-attachments/assets/dadaa684-816a-49b2-b3bf-f55a6fed6082)

Radius 20:
![image](https://github.com/user-attachments/assets/05463878-9d7d-4cf4-bf71-a2b0185131c5)

Results show that when able to convert away from a loop (`turftest_range_turf_direct`) that is always the best choice. For results under a radius of 5 the standard `range` (`turftest_range`) was notably faster, for a radius of 5 or more `RANGE_TURFS` (`turftest_range_turf`) was slightly faster.

</details>


# Changelog
No player facing changes.
