### PR TITLE
Made big XM88 boxes behave like other handful boxes

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -365,7 +365,7 @@ Turn() or Shift() as there is virtually no overhead. ~N
 	overlay_ammo_type = "_blank"
 	overlay_gun_type = "_458"
 	overlay_content = "_458"
-	magazine_type = /obj/item/ammo_magazine/handful/lever_action/xm88
+	magazine_type = /obj/item/ammo_magazine/lever_action/xm88
 
 /obj/item/ammo_box/magazine/lever_action/xm88/empty
 	empty = TRUE


### PR DESCRIPTION

# About the pull request

Recently Blundir mentioned the XM88 boxes don't behave like the shotgun handful boxes for the purpose of restocking them in Requisitions. It was due to them referencing the handful ammo rather than the box of ammo. I made them consistent with how the shotgun ammo boxes are handled. Tested and the boxes behave properly.

# Explain why it's good for the game

More uniform code is good. Plus with this change the XM88 ammo can be almost added to Requisitions vendors if needed (can't do it without re-balancing the ammo boxes though since they are 90 vs 300 ammo pieces, so they don't divide neatly. Will probably need to lower the big box to 270 and then everything will work well).


# Testing Photographs and Procedure

Spawn the XM88 `/obj/item/ammo_box/magazine/lever_action/xm88 ` and `/obj/item/ammo_magazine/lever_action/xm88` and make sure they behave as expected.

<details>
<summary>Screenshots & Videos</summary>

NA

</details>


# Changelog
:cl: ThePiachu
refactor: Made XM88 box code more uniform with other handful boxes.
/:cl:
