### PR TITLE
adds more xenos to OT simulator

### DIFF
--- a/code/__DEFINES/machinery.dm
+++ b/code/__DEFINES/machinery.dm
@@ -16,3 +16,6 @@
 #define DEFENDER_MODE "Xenomorph Defenders"
 #define RAVAGER_MODE "Xenomorph Ravagers"
 #define CRUSHER_MODE "Xenomorph Crushers"
+#define WARRIOR_MODE "Xenomorph Warriors"
+#define PRAETORIAN_MODE "Xenomorph Praetorians"
+#define BOILER_MODE "Xenomorph Boilers"

--- a/code/game/sim_manager/datums/simulator.dm
+++ b/code/game/sim_manager/datums/simulator.dm
@@ -28,6 +28,9 @@
 		DEFENDER_MODE = /mob/living/carbon/xenomorph/defender,
 		RAVAGER_MODE = /mob/living/carbon/xenomorph/ravager,
 		CRUSHER_MODE = /mob/living/carbon/xenomorph/crusher,
+		WARRIOR_MODE = /mob/living/carbon/xenomorph/warrior,
+		PRAETORIAN_MODE = /mob/living/carbon/xenomorph/praetorian,
+		BOILER_MODE = /mob/living/carbon/xenomorph/boiler,
 	)
 
 /datum/simulator/proc/start_watching(mob/living/user)


### PR DESCRIPTION

# About the pull request
adds praes, warriors and boilers to the OT demolitions simulator

# Explain why it's good for the game
variety

# Testing Photographs and Procedure
works

# Changelog
:cl:
add: Added more xenos to the demolitions simulator.
/:cl:
