### PR TITLE
Fix tank secondary flamer abnormal stoppage

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1100,25 +1100,17 @@ GLOBAL_DATUM(action_purple_power_up, /image)
 			else
 				air_master.tiles_to_update += T2*/
 
-/// Returns the cardinal dir between two atoms. Favors clockwise on perfect diagonals. Consistent and reversible.
-/proc/get_cardinal_dir(atom/start, atom/end)
+/// Returns the nearest cardinal dir between two atoms. Favors NORTH/SOUTH on perfect diagonals. Consistent and reversible.
+/proc/get_cardinal_dir(atom/start, atom/end) as num
 	var/dx = end.x - start.x
 	var/dy = end.y - start.y
-	if(!(dx|dy))
-		return NONE //returns 0 when on same tile, consistent with get_dir()
+	if(!(dx || dy))
+		return 0 //returns 0 when on same x/y, consistent with get_dir()
 
-	var/angle = arctan(dy, dx)
-	switch(angle)
-		if (135 to 180)
-			return SOUTH
-		if (45 to 135)
-			return EAST
-		if (-45 to 45)
-			return NORTH
-		if (-135 to -45)
-			return WEST
-		else
-			return SOUTH
+	if(abs(dx) > abs(dy))
+		return dx < 0 ? WEST : EAST
+	else
+		return dy < 0 ? SOUTH : NORTH
 
 //Returns the 2 dirs perpendicular to the arg
 /proc/get_perpen_dir(dir)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1100,11 +1100,25 @@ GLOBAL_DATUM(action_purple_power_up, /image)
 			else
 				air_master.tiles_to_update += T2*/
 
-/proc/get_cardinal_dir(atom/A, atom/B)
-	var/dx = abs(B.x - A.x)
-	var/dy = abs(B.y - A.y)
-	return get_dir(A, B) & (rand() * (dx+dy) < dy ? 3 : 12)
+/// Returns the cardinal dir between two atoms. Favors clockwise on perfect diagonals. Consistent and reversible.
+/proc/get_cardinal_dir(atom/start, atom/end)
+	var/dx = end.x - start.x
+	var/dy = end.y - start.y
+	if(!(dx|dy))
+		return NONE //returns 0 when on same tile, consistent with get_dir()
 
+	var/angle = arctan(dy, dx)
+	switch(angle)
+		if (135 to 180)
+			return SOUTH
+		if (45 to 135)
+			return EAST
+		if (-45 to 45)
+			return NORTH
+		if (-135 to -45)
+			return WEST
+		else
+			return SOUTH
 
 //Returns the 2 dirs perpendicular to the arg
 /proc/get_perpen_dir(dir)

--- a/code/modules/projectiles/guns/flamer/flameshape.dm
+++ b/code/modules/projectiles/guns/flamer/flameshape.dm
@@ -113,13 +113,7 @@
 /datum/flameshape/line/handle_fire_spread(obj/flamer_fire/F, fire_spread_amount, burn_dam, fuel_pressure = 1)
 	var/turf/source_turf = get_turf(F.loc)
 
-	var/turf/prev_T = F.loc
-
-	var/mob/user
-	if(F.weapon_cause_data)
-		user = F.weapon_cause_data.resolve_mob()
-	if(user)
-		prev_T = user.loc
+	var/turf/prev_T
 
 	var/distance = 1
 	var/stop_at_turf = FALSE
@@ -135,7 +129,7 @@
 		if(T.density)
 			T.flamer_fire_act(burn_dam, F.weapon_cause_data)
 			stop_at_turf = TRUE
-		else
+		else if(prev_T)
 			var/obj/flamer_fire/temp = new()
 			var/atom/A = LinkBlocked(temp, prev_T, T)
 
@@ -145,7 +139,7 @@
 					break
 				stop_at_turf = TRUE
 
-		if(T == F.loc || (user && T == user.loc))
+		if(T == F.loc)
 			if(stop_at_turf)
 				break
 			prev_T = T
@@ -168,16 +162,11 @@
 /datum/flameshape/triangle/handle_fire_spread(obj/flamer_fire/F, fire_spread_amount, burn_dam, fuel_pressure = 1)
 	set waitfor = 0
 
-	var/mob/user
-
-	if(F.weapon_cause_data)
-		user = F.weapon_cause_data.resolve_mob()
-
-	var/unleash_dir = user.dir
+	var/unleash_dir = get_cardinal_dir(F, F.target_clicked)
 	var/list/turf/turfs = get_line(F, F.target_clicked)
 	var/distance = 1
 	var/hit_dense_atom_mid = FALSE
-	var/turf/prev_T = user.loc
+	var/turf/prev_T
 
 	for(var/turf/T in turfs)
 		if(distance > fire_spread_amount)


### PR DESCRIPTION
# About the pull request

Fixes https://github.com/cmss13-devs/cmss13/issues/6536 , the tank's secondary flamer stopping after one tile.

As a side effect, flamers can now fire streams over a barricade that's immediately adjacent to them. Stream is still stopped if it hits the "wrong" side of a barricade after that first tile.

`get_cardinal_dir()` now returns a consistent direction.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

The tank flamer shouldn't get hung up on random objects.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Before:
![image](https://github.com/user-attachments/assets/1fafe5e7-d213-4cc2-9782-958e0faf6c58)
The stream is being blocked by the air pipe below. It is getting stopped because the flameshape tries to trace from the user (firer) on the first tile, and in this case the user is on an entirely different z-level (the tank).

Flameshape's `user` removed, using current `get_cardinal_dir`:
![image](https://github.com/user-attachments/assets/3e06ec23-557d-452a-a4de-8011e304cf0d)
![image](https://github.com/user-attachments/assets/f30fc64a-5ca6-47dc-a668-b5d15e0d5b1e)
Removing reliance on the user makes the tank flamer work, but replacing the user with `get_cardinal_dir` causes issues with the triangular shape of B-gel. Namely `get_cardinal_dir` *randomly* picks which cardinal to get from a diagonal, potentially causing an obliquely fired stream to orient on top of itself.

After, with fixed `get_cardinal_dir`:
![image](https://github.com/user-attachments/assets/78af8dff-f3b8-47d3-b1f7-7fed02b1484c)

</details>


# Changelog
:cl:
fix: fixed tank secondary flamer stopping after one tile
balance: flamers can now fire streams over the "wrong" side of a barricade, when adjacent
/:cl:
