### PR TITLE
Makes ammo box bullet transfer time shorter

### DIFF
--- a/code/modules/projectiles/ammo_boxes/ammo_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/ammo_boxes.dm
@@ -348,7 +348,7 @@
 				// Half-Loop 1: Start transfering
 				else if(!transfering)
 					transfering = min(transferable, 48) // Max per transfer
-					if(!do_after(user, 1.5 SECONDS, INTERRUPT_ALL, dumping ? BUSY_ICON_HOSTILE : BUSY_ICON_FRIENDLY))
+					if(!do_after(user, 1 SECONDS, INTERRUPT_ALL, dumping ? BUSY_ICON_HOSTILE : BUSY_ICON_FRIENDLY))
 						to_chat(user, SPAN_NOTICE("You stop transferring rounds."))
 						transferable = 0
 


### PR DESCRIPTION

# About the pull request
Makes the ammo transfer take 1 second instead of 1.5 seconds
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Slowly transfering bullets is mind numbingly boring, this should make it a little bit better.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Transfering bullets to/from ammo boxes is now quicker
/:cl:
