### PR TITLE
Revive research card swiping rework

### DIFF
--- a/code/game/machinery/computer/research.dm
+++ b/code/game/machinery/computer/research.dm
@@ -64,9 +64,9 @@
 		return
 	var/obj/item/card/id/silver/clearance_badge/card = B
 	if(!istype(card))
-		visible_message(SPAN_NOTICE("[user] swipes their ID card on \the [src], but it is refused."))
+		visible_message(SPAN_NOTICE("[user] swipes their ID card on [src], but it is refused."))
 		return
-	if(user.real_name != card.registered_name)
+	if(!card.check_biometrics(user))
 		visible_message(SPAN_WARNING("WARNING: ILLEGAL CLEARANCE USER DETECTED. ABORTING."))
 		return
 

--- a/code/game/machinery/computer/research.dm
+++ b/code/game/machinery/computer/research.dm
@@ -71,11 +71,12 @@
 		return
 
 	var/credits_to_add = max(card.credits_to_give - GLOB.chemical_data.credits_gained, 0)
-	GLOB.chemical_data.update_credits(credits_to_add)
-	GLOB.chemical_data.credits_gained = max(GLOB.chemical_data.credits_gained, card.credits_to_give)
+	if(credits_to_add)
+		GLOB.chemical_data.update_credits(credits_to_add)
+		GLOB.chemical_data.credits_gained += credits_to_add
 
-	visible_message(SPAN_NOTICE("[user] swipes their ID card on \the [src], granting [credits_to_add] credits."))
-	msg_admin_niche("[key_name(user)] has swiped a clearance card and given [credits_to_add] credits to research.")
+	visible_message(SPAN_NOTICE("[user] swipes their ID card on [src], granting [credits_to_add] credits."))
+	msg_admin_niche("[key_name(user)] has swiped a clearance card to give [credits_to_add] credits to research.")
 	return
 
 /obj/structure/machinery/computer/research/ui_state(mob/user)

--- a/code/game/machinery/computer/research.dm
+++ b/code/game/machinery/computer/research.dm
@@ -160,6 +160,9 @@
 		if("broker_clearance")
 			if(!photocopier)
 				return
+			if(!SSobjectives.first_drop_complete)
+				visible_message(SPAN_NOTICE("Clearance access increase denied, first deployment necessary for purchase."))
+				return
 			if(GLOB.chemical_data.clearance_level < 5)
 				var/cost = max(RESEARCH_LEVEL_INCREASE_MULTIPLIER*(GLOB.chemical_data.clearance_level + 1), 1)
 				if(cost <= GLOB.chemical_data.rsc_credits)

--- a/code/game/machinery/computer/research.dm
+++ b/code/game/machinery/computer/research.dm
@@ -59,36 +59,23 @@
 		GLOB.chemical_data.update_credits(cred.credit_value)
 		visible_message(SPAN_NOTICE("[user] inserts [cred] in [src], collecting [cred.credit_value] points from sales."))
 		qdel(cred)
-	//Clearance Updating
+	//Clearance Card Updating
 	if(!istype(B, /obj/item/card/id))
 		return
 	var/obj/item/card/id/silver/clearance_badge/card = B
 	if(!istype(card))
 		visible_message(SPAN_NOTICE("[user] swipes their ID card on \the [src], but it is refused."))
 		return
-	if(card.clearance_access <= GLOB.chemical_data.clearance_level || (card.clearance_access == 6 && GLOB.chemical_data.clearance_level >= 5 && GLOB.chemical_data.clearance_x_access))
-		visible_message(SPAN_NOTICE("[user] swipes the clearance card on [src], but nothing happens."))
-		return
 	if(user.real_name != card.registered_name)
-		visible_message(SPAN_WARNING("WARNING: ILLEGAL CLEARANCE USER DETECTED. CARD DATA HAS BEEN WIPED."))
-		card.clearance_access = 0
+		visible_message(SPAN_WARNING("WARNING: ILLEGAL CLEARANCE USER DETECTED. ABORTING."))
 		return
 
-	var/give_level
-	var/give_x = FALSE
-	if(card.clearance_access == 6)
-		give_level = 5
-		give_x = TRUE
-	else
-		give_level = card.clearance_access
+	var/credits_to_add = max(card.credits_to_give - GLOB.chemical_data.credits_gained, 0)
+	GLOB.chemical_data.update_credits(credits_to_add)
+	GLOB.chemical_data.credits_gained = max(GLOB.chemical_data.credits_gained, card.credits_to_give)
 
-	GLOB.chemical_data.clearance_level = give_level
-	if(give_x)
-		GLOB.chemical_data.clearance_x_access = TRUE
-		GLOB.chemical_data.reached_x_access = TRUE
-
-	visible_message(SPAN_NOTICE("[user] swipes their ID card on \the [src], updating the clearance to level [give_level][give_x ? "X" : ""]."))
-	msg_admin_niche("[key_name(user)] has updated the research clearance to level [give_level][give_x ? "X" : ""].")
+	visible_message(SPAN_NOTICE("[user] swipes their ID card on \the [src], granting [credits_to_add] credits."))
+	msg_admin_niche("[key_name(user)] has swiped a clearance card and given [credits_to_add] credits to research.")
 	return
 
 /obj/structure/machinery/computer/research/ui_state(mob/user)
@@ -160,9 +147,6 @@
 		if("broker_clearance")
 			if(!photocopier)
 				return
-			if(!SSobjectives.first_drop_complete)
-				visible_message(SPAN_NOTICE("Clearance access increase denied, first deployment necessary for purchase."))
-				return
 			if(GLOB.chemical_data.clearance_level < 5)
 				var/cost = max(RESEARCH_LEVEL_INCREASE_MULTIPLIER*(GLOB.chemical_data.clearance_level + 1), 1)
 				if(cost <= GLOB.chemical_data.rsc_credits)
@@ -184,30 +168,6 @@
 							if(5)
 								new /obj/item/paper/research_notes/unique/tier_five/(photocopier.loc)
 								max_clearance = 5
-		if("purchase_document")
-			if(!photocopier)
-				return
-			var/purchase_tier = floor(text2num(params["purchase_document"]))
-			if(purchase_tier <= 0 || purchase_tier > 5)
-				return
-			if(purchase_tier > GLOB.chemical_data.clearance_level)
-				return
-			var/purchase_cost = base_purchase_cost + purchase_tier * 2
-			if(purchase_cost <= GLOB.chemical_data.rsc_credits)
-				GLOB.chemical_data.update_credits(purchase_cost * -1)
-				var/obj/item/paper/research_notes/unique/N
-				switch(purchase_tier)
-					if(1)
-						N = new /obj/item/paper/research_notes/unique/tier_one/(photocopier.loc)
-					if(2)
-						N = new /obj/item/paper/research_notes/unique/tier_two/(photocopier.loc)
-					if(3)
-						N = new /obj/item/paper/research_notes/unique/tier_three/(photocopier.loc)
-					if(4)
-						N = new /obj/item/paper/research_notes/unique/tier_four/(photocopier.loc)
-					else
-						N = new /obj/item/paper/research_notes/unique/tier_five/(photocopier.loc)
-				visible_message(SPAN_NOTICE("Research report for [N.data.name] has been purchased."))
 		if("publish_document")
 			var/print_type = params["print_type"]
 			var/print_title = params["print_title"]

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -171,24 +171,24 @@
 	name = "corporate doctor badge"
 	desc = "A corporate holo-badge. It is fingerprint locked with clearance level 3 access. It is commonly held by corporate doctors."
 	icon_state = "clearance"
-	var/clearance_access = 3
+	var/credits_to_give = 15 //gives the equivalent clearance access in credits
 
 /obj/item/card/id/silver/clearance_badge/scientist
 	name = "corporate scientist badge"
 	desc = "A corporate holo-badge. It is fingerprint locked with clearance level 4 access. It is commonly held by corporate scientists."
-	clearance_access = 4
+	credits_to_give = 27
 
 /obj/item/card/id/silver/clearance_badge/cl
 	name = "corporate liaison badge"
 	desc = "A corporate holo-badge in unique corporate orange and white. It is fingerprint locked with clearance level 5 access. It is commonly held by corporate liaisons."
 	icon_state = "cl"
-	clearance_access = 5
+	credits_to_give = 42
 
 /obj/item/card/id/silver/clearance_badge/manager
 	name = "corporate manager badge"
 	desc = "A corporate holo-badge in standard corporate orange and white. It has a unique uncapped bottom. It is fingerprint locked with 5-X clearance level. Commonly held by corporate managers."
 	icon_state = "pmc"
-	clearance_access = 6
+	credits_to_give = 47
 
 /obj/item/card/id/pizza
 	name = "pizza guy badge"

--- a/code/modules/reagents/chemical_research/Chemical-Research.dm
+++ b/code/modules/reagents/chemical_research/Chemical-Research.dm
@@ -3,7 +3,8 @@ GLOBAL_DATUM_INIT(chemical_data, /datum/chemical_data, new)
 /datum/chemical_data
 	var/rsc_credits = 0
 	var/clearance_level = 1
-	var/credits_gained = 0 //credits gained from survivor clearance cards
+	///credits gained from survivor clearance cards
+	var/credits_gained = 0
 	var/clearance_x_access = FALSE
 	var/reached_x_access = FALSE
 	var/has_new_properties = FALSE

--- a/code/modules/reagents/chemical_research/Chemical-Research.dm
+++ b/code/modules/reagents/chemical_research/Chemical-Research.dm
@@ -3,6 +3,7 @@ GLOBAL_DATUM_INIT(chemical_data, /datum/chemical_data, new)
 /datum/chemical_data
 	var/rsc_credits = 0
 	var/clearance_level = 1
+	var/credits_gained = 0 //credits gained from survivor clearance cards
 	var/clearance_x_access = FALSE
 	var/reached_x_access = FALSE
 	var/has_new_properties = FALSE

--- a/tgui/packages/tgui/interfaces/ResearchTerminal.tsx
+++ b/tgui/packages/tgui/interfaces/ResearchTerminal.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 
-import { classes } from '../../common/react';
 import { useBackend } from '../backend';
 import { Box, Button, Flex, Section, Stack, Tabs } from '../components';
 import { BoxProps } from '../components/Box';
@@ -31,69 +30,6 @@ interface TerminalProps {
   photocopier_error: number;
   printer_toner: number;
 }
-
-const PurchaseDocs = () => {
-  const { data, act } = useBackend<TerminalProps>();
-  const [purchaseSelection, setPurchaseSelection] = useState('0');
-  const clearance_level = data.clearance_level;
-  const all_levels = ['1', '2', '3', '4', '5'];
-  const costs = { '1': 7, '2': 9, '3': 11, '4': 13, '5': 15 };
-  const available_levels = Array.from(Array(clearance_level).keys()).map((x) =>
-    (x + 1).toString(),
-  );
-
-  return (
-    <Stack vertical>
-      <Stack.Item>
-        <span>Purchase Reports</span>
-        <hr />
-      </Stack.Item>
-
-      <Stack.Item>
-        <Flex justify="space-between" fill={1} className="purchase-flex">
-          {all_levels.map((x) => {
-            const isDisabled =
-              !available_levels.includes(x) || costs[x] > data.rsc_credits;
-            return (
-              <Flex.Item key={x}>
-                <Button
-                  className={classes([
-                    !available_levels.includes(x) && 'HiddenButton',
-                  ])}
-                  disabled={isDisabled}
-                  onClick={() => setPurchaseSelection(x)}
-                >
-                  Level {x} {costs[x]}CR
-                </Button>
-              </Flex.Item>
-            );
-          })}
-        </Flex>
-      </Stack.Item>
-      <hr />
-      {purchaseSelection !== '0' && (
-        <Flex.Item>
-          <ConfirmationDialogue
-            onConfirm={() => {
-              act('purchase_document', {
-                purchase_document: purchaseSelection,
-              });
-              setPurchaseSelection('0');
-            }}
-            onCancel={() => setPurchaseSelection('0')}
-          >
-            <span>
-              Are you sure you want to purchase a level{' '}
-              <u>{purchaseSelection}</u> document?
-              <br />
-              It will cost <u>{costs[purchaseSelection]}</u> credits.
-            </span>
-          </ConfirmationDialogue>
-        </Flex.Item>
-      )}
-    </Stack>
-  );
-};
 
 interface ConfirmationProps extends BoxProps {
   readonly onConfirm: () => any;
@@ -486,7 +422,6 @@ const ResearchManager = (props: {
         </Stack.Item>
       </Stack>
       <hr />
-      <PurchaseDocs />
       <ImproveClearanceConfirmation
         isConfirm={isConfirm}
         setConfirm={setConfirm}


### PR DESCRIPTION

# About the pull request

This PR revives #6625 

# Explain why it's good for the game

More intuitive credit reward for research getting a survivor to swipe their card so there isn't a meta strategy for the best utilization of credits. Now at most 47 credits can be awarded (for a manager survivor's card; only allowed to be swiped by them) regardless of whatever the current research clearance is at.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek iloveloopers
del: Removed ability to buy clearance papers.
balance: Clearance cards now give their equivalent clearance in credits.
balance: Clearance cards no longer lose their value when scanned by the wrong person.
/:cl:
