### PR TITLE
HPR Starts With Bipod Attached

### DIFF
--- a/code/modules/cm_marines/equipment/guncases.dm
+++ b/code/modules/cm_marines/equipment/guncases.dm
@@ -67,7 +67,6 @@
 	new /obj/item/ammo_magazine/rifle/lmg(src)
 	new /obj/item/ammo_magazine/rifle/lmg/holo_target(src)
 	new /obj/item/attachable/flashlight
-	new /obj/item/attachable/bipod
 
 //------------
 /obj/item/storage/box/guncase/m41aMK1

--- a/code/modules/cm_marines/equipment/kit_boxes.dm
+++ b/code/modules/cm_marines/equipment/kit_boxes.dm
@@ -425,7 +425,6 @@
 	new /obj/item/weapon/gun/rifle/lmg(src)
 	new /obj/item/ammo_magazine/rifle/lmg(src)
 	new /obj/item/ammo_magazine/rifle/lmg/holo_target(src)
-	new /obj/item/attachable/bipod(src)
 	new /obj/item/stack/folding_barricade/three(src)
 	new /obj/item/clothing/glasses/welding(src)
 	new /obj/item/tool/weldingtool(src)

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1227,6 +1227,7 @@
 	fire_sound = 'sound/weapons/gun_hpr.ogg'
 	aim_slowdown = SLOWDOWN_ADS_LMG
 	current_mag = /obj/item/ammo_magazine/rifle/lmg
+	starting_attachment_types = list(/obj/item/attachable/bipod)
 	attachable_allowed = list(
 		/obj/item/attachable/suppressor,
 		/obj/item/attachable/reddot,


### PR DESCRIPTION

# About the pull request

See title. The HPR will now spawn in with a Bipod attached to it. 

# Explain why it's good for the game

The concept of the HPR having access to a unique auto-fire function, with a very high ROF, is not at all advertised to the average player, this is a concept wherein many people are left unaware of this function until it is revealed to them by a third party. This is common testimony from those who discuss the HPR and its bipod function.

Forcing the HPR to spawn with a bipod attached to it, will resolve the manner as it will expose far more people to the ability for the weapon to fire on auto-fire and thus reveal an entirely new and unique way to make usage of the firearm to people who may never have discovered it.

Considering the bipod is a fairly common attachment that is not often selected, and the Almayer has a very limited supply of HPRs, I do not believe this will have any real impact on attachment availability.  

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: The Heavy Pulse Rifle (M41AE2) will now start with a pre-attached bipod. To better inform players of its unique auto-fire function. 
/:cl:
