### PR TITLE
Buffs cades against projectiles

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -23,6 +23,8 @@
 
 	/// an object's "projectile_coverage" var indicates the maximum probability of blocking a projectile, assuming density and throwpass. Used by barricades, tables and window frames
 	var/projectile_coverage = 0
+	/// How many tiles away from this object that a shooter needs to be to maximize this barricade's projectile coverage
+	var/projectile_coverage_distance_limit = 6
 	/// set to true if the item is garbage and should be deleted after awhile
 	var/garbage = FALSE
 

--- a/code/game/objects/structures/barricade/barricade.dm
+++ b/code/game/objects/structures/barricade/barricade.dm
@@ -34,6 +34,7 @@
 	var/is_wired = FALSE
 	flags_barrier = HANDLE_BARRIER_CHANCE
 	projectile_coverage = PROJECTILE_COVERAGE_HIGH
+	projectile_coverage_distance_limit = 2
 	var/upgraded
 	var/brute_multiplier = 1
 	var/burn_multiplier = 1

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -30,6 +30,7 @@
 	var/flip_cooldown = 0 //If flip cooldown exists, don't allow flipping or putting back. This carries a WORLD.TIME value
 	health = 100
 	projectile_coverage = 20 //maximum chance of blocking a projectile
+	var/flipped_projectile_coverage_distance_limit = 2
 	var/flipped_projectile_coverage = PROJECTILE_COVERAGE_HIGH
 	var/upright_projectile_coverage = PROJECTILE_COVERAGE_LOW
 	surgery_duration_multiplier = SURGERY_SURFACE_MULT_UNSUITED
@@ -42,6 +43,7 @@
 			qdel(T)
 	if(flipped)
 		projectile_coverage = flipped_projectile_coverage
+		projectile_coverage_distance_limit = flipped_projectile_coverage_distance_limit
 	else
 		projectile_coverage = upright_projectile_coverage
 
@@ -446,6 +448,7 @@
 			INVOKE_ASYNC(movable_on_table, TYPE_PROC_REF(/atom/movable, throw_atom), pick(targets), 1, SPEED_FAST)
 
 	projectile_coverage = flipped_projectile_coverage
+	projectile_coverage_distance_limit = flipped_projectile_coverage_distance_limit
 
 	setDir(direction)
 	if(dir != NORTH)
@@ -473,6 +476,7 @@
 	verbs += /obj/structure/surface/table/verb/do_flip
 
 	projectile_coverage = upright_projectile_coverage
+	projectile_coverage_distance_limit = src::projectile_coverage_distance_limit
 
 	layer = initial(layer)
 	flipped = FALSE

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -660,7 +660,7 @@
 
 //Used by machines and structures to calculate shooting past cover
 /obj/proc/calculate_cover_hit_boolean(obj/projectile/P, distance = 0, cade_direction_correct = FALSE)
-	if(istype(P.shot_from, /obj/item/hardpoint)) //anything shot from a tank gets a bonus to bypassing cover
+	if(istype(P.shot_from, /obj/item/hardpoint) || istype(P.ammo, /datum/ammo/xeno)) //anything shot from a tank or a xeno gets a bonus to bypassing cover
 		distance -= 3
 
 	if(distance < 1 || (distance > 3 && cade_direction_correct))

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -668,10 +668,9 @@
 
 	//an object's "projectile_coverage" var indicates the maximum probability of blocking a projectile
 	var/effective_accuracy = P.get_effective_accuracy()
-	var/distance_limit = 6 //number of tiles needed to max out block probability
 	var/accuracy_factor = 50 //degree to which accuracy affects probability   (if accuracy is 100, probability is unaffected. Lower accuracies will increase block chance)
 
-	var/hitchance = min(projectile_coverage, (projectile_coverage * distance/distance_limit) + accuracy_factor * (1 - effective_accuracy/100))
+	var/hitchance = min(projectile_coverage, (projectile_coverage * distance / projectile_coverage_distance_limit) + accuracy_factor * (1 - effective_accuracy/100))
 
 	#if DEBUG_HIT_CHANCE
 	to_world(SPAN_DEBUG("([name] as cover) Distance travelled: [P.distance_travelled]  |  Effective accuracy: [effective_accuracy]  |  Hit chance: [hitchance]"))

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -670,7 +670,7 @@
 	var/effective_accuracy = P.get_effective_accuracy()
 	var/accuracy_factor = 50 //degree to which accuracy affects probability   (if accuracy is 100, probability is unaffected. Lower accuracies will increase block chance)
 
-	var/hitchance = min(projectile_coverage, (projectile_coverage * distance / projectile_coverage_distance_limit) + accuracy_factor * (1 - effective_accuracy/100))
+	var/hitchance = min(projectile_coverage, (projectile_coverage * distance / (projectile_coverage_distance_limit * (cade_direction_correct ? 3 : 1))) + accuracy_factor * (1 - effective_accuracy/100))
 
 	#if DEBUG_HIT_CHANCE
 	to_world(SPAN_DEBUG("([name] as cover) Distance travelled: [P.distance_travelled]  |  Effective accuracy: [effective_accuracy]  |  Hit chance: [hitchance]"))


### PR DESCRIPTION
# About the pull request

Barricades and tables are now better against projectiles.
Assuming a standard rifleman with an unmodified m41a vs. a barricade, the probabilities of hitting are:

| Dist | Old | New | New (Xeno)
|---|---|---|---|
|  1 |  0 | 0   | 0|
|  2 |  -0.1833 |  0.0045 |0|
|  3 | -0.0466  |  0.52 |0|
|  4 |  0.0550 |  0.85 |0|
|  5 |  0.2367  |  0.85 |0.0045|
|  [6, ∞) | 0.3383  | 0.85  |0.52|

# Explain why it's good for the game

Cades are completely worthless in hvh situations, because they fail to block the overwhelming majority of bullets (especially in cqc, where most gunfights happen). This makes them better while still allowing people who get within 2 tiles to attack easier.

# Changelog
:cl:
balance: Barricades are now far better at blocking bullets from the front. They will not block most bullets if the shooter is within 2 tiles, however.
/:cl:
