### PR TITLE
Buffs L42A damage to the same number as M4RA

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1642,7 +1642,7 @@
 	set_burst_amount(0)
 	accuracy_mult = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_5
 	accuracy_mult_unwielded = BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_4
-	damage_mult = BASE_BULLET_DAMAGE_MULT + BULLET_DAMAGE_MULT_TIER_6
+	damage_mult = BASE_BULLET_DAMAGE_MULT + BULLET_DAMAGE_MULT_TIER_8
 	recoil_unwielded = RECOIL_AMOUNT_TIER_4
 	damage_falloff_mult = 0
 	scatter = SCATTER_AMOUNT_TIER_8


### PR DESCRIPTION

# About the pull request

L42A and M4RA now have the same damage

# Explain why it's good for the game

L42A is a reskin and shouldn't differ stats wise, when M4RA damage was buffed, L42A was left behind because it wasn't easily obtainable at that moment, that changed.

Now L42A and M4RA have identical stats.



# Changelog
:cl:

balance: L42A and M4RA now have the same damage (and all other stats)
/:cl:
