### PR TITLE
VP78 Improve Fire Range

### DIFF
--- a/code/datums/ammo/bullet/pistol.dm
+++ b/code/datums/ammo/bullet/pistol.dm
@@ -180,10 +180,13 @@
 	headshot_state = HEADSHOT_OVERLAY_MEDIUM
 	debilitate = list(0,0,0,0,0,0,0,2)
 
+effective_range_max = 6
+
 	accuracy = HIT_ACCURACY_TIER_4
 	damage = 45
 	penetration= ARMOR_PENETRATION_TIER_6
 	shrapnel_chance = SHRAPNEL_CHANCE_TIER_2
+	damage_falloff = DAMAGE_FALLOFF_TIER_6
 
 /datum/ammo/bullet/pistol/squash/toxin
 	name = "toxic squash-head pistol bullet"

--- a/code/datums/ammo/bullet/pistol.dm
+++ b/code/datums/ammo/bullet/pistol.dm
@@ -180,8 +180,7 @@
 	headshot_state = HEADSHOT_OVERLAY_MEDIUM
 	debilitate = list(0,0,0,0,0,0,0,2)
 
-effective_range_max = 6
-
+	effective_range_max = 6
 	accuracy = HIT_ACCURACY_TIER_4
 	damage = 45
 	penetration= ARMOR_PENETRATION_TIER_6

--- a/code/datums/ammo/bullet/pistol.dm
+++ b/code/datums/ammo/bullet/pistol.dm
@@ -180,12 +180,10 @@
 	headshot_state = HEADSHOT_OVERLAY_MEDIUM
 	debilitate = list(0,0,0,0,0,0,0,2)
 
-	effective_range_max = 3
 	accuracy = HIT_ACCURACY_TIER_4
 	damage = 45
 	penetration= ARMOR_PENETRATION_TIER_6
 	shrapnel_chance = SHRAPNEL_CHANCE_TIER_2
-	damage_falloff = DAMAGE_FALLOFF_TIER_6 //"VP78 - the only pistol viable as a primary."-Vampmare, probably.
 
 /datum/ammo/bullet/pistol/squash/toxin
 	name = "toxic squash-head pistol bullet"


### PR DESCRIPTION
# About the pull request

This PR sets the maximum range of the VP78 to 6 tiles, up from 3, before it experiences damage fall off. 

# Explain why it's good for the game

Despite the buffs to the VP78 that raised its overall DPS from terrible to average, by pistol standards, the weapon continues to flounder amongst the community, its hard cap of 3 tiles before it experiences horrible damage falloff, to the point the gun is dealing pitiful damage at 5 to 6 tiles, makes the weapon anathema to much of the community, to the point even Maintainers have pointed out how subpar the weapon is and suggesting players use alternatives. 

This state of affairs stands in stark contrast to the fact virtually every single other pistol option Marines have access to feature a low level of falloff at an identical value. The overall DPS of the VP78 is, at optimal range, comparable to weapons like the Mod88 or the Revolver, ergo I do not see any reason why the VP78 demands such a harsh penalty to its damage at any range beyond close quarters, especially true of the fact this weapon is in limited circulation and suffers very limited ammo resupply possibilities. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: The VP78 pistol will now deal maximum damage up to 6 tiles from the shooters position before experiencing gradual damage falloff. This is up from a previous maximum range of 3 tiles. 
/:cl:
