### PR TITLE
Planted flag bugfix and warcry removal

### DIFF
--- a/code/game/objects/items/stacks/flags.dm
+++ b/code/game/objects/items/stacks/flags.dm
@@ -170,7 +170,11 @@
 	icon = 'icons/obj/structures/plantable_flag.dmi'
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
+	force = 15
+	throwforce = 5
+	hitsound = "swing_hit"
 	unacidable = TRUE
+	indestructible = TRUE
 	item_icons = list(
 		WEAR_L_HAND = 'icons/mob/humans/onmob/items_lefthand_64.dmi',
 		WEAR_R_HAND = 'icons/mob/humans/onmob/items_righthand_64.dmi'

--- a/code/game/objects/items/stacks/flags.dm
+++ b/code/game/objects/items/stacks/flags.dm
@@ -106,7 +106,7 @@
 	user.visible_message(SPAN_NOTICE("[user] starts taking [src] down..."), SPAN_NOTICE("You start taking [src] down..."))
 
 	playsound(loc, 'sound/effects/flag_raising.ogg', 30)
-	if(!do_after(user, 6 SECONDS, INTERRUPT_ALL, BUSY_ICON_GENERIC))
+	if(!do_after(user, 6 SECONDS, INTERRUPT_ALL, BUSY_ICON_GENERIC) || QDELETED(src))
 		return
 
 	playsound(loc, 'sound/effects/flag_raised.ogg', 30)
@@ -233,12 +233,10 @@
 	if(play_warcry && user.faction == faction && user.a_intent == INTENT_HARM)
 		var/allies_nearby = 0
 		if(COOLDOWN_FINISHED(src, warcry_cooldown_item))
-			for (var/mob/living/carbon/human in orange(planted_flag, 7))
-				if (human.is_dead() || human.faction != faction)
+			for(var/mob/living/carbon/human in orange(planted_flag, 7))
+				if(human.is_dead() || human.faction != faction)
 					continue
 				allies_nearby++
-				if (prob(40) && human != user)
-					human.emote("warcry")
 
 		user.show_speech_bubble("warcry")
 		if(allies_nearby >= allies_required)


### PR DESCRIPTION
# About the pull request

- Fixes the flag being able to be duplicated
- The flag does a small amount of damage when hitting someone
- Item flag is indestructable
- Removes forced warcries

# Explain why it's good for the game

- Bugs are bad etc. etc.
- You are hitting someone with a big flagpole, it's fair that it does a bit of damage.
- Stops the flag from getting annihilated by a stray nade or etc
- I talked with another maintainer about this, and I was given some fair arguments about why forcing emotes is bad. In summary, on an RP server, the player in charge of a character should ideally have as much control over what the character does as possible. While this isn't the case for things like brain damage causing forced movement, those are consequences of negative things occurring to a character that serves as a hindrance to being able to play. As such, you should try to minimize the amount of times that forced emotes occur when not as a punishment, such as here. 
- What hasn't changed:
- The flag planter still warcries
- Having >= 14 people still makes a custom warcry sound for the flag planter.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
![image](https://github.com/user-attachments/assets/953b435f-05ac-438f-97f2-1fec511e1051)

</details>


# Changelog
:cl: Zonespace, Vile Beggar
add: Handheld planted flags are now indestructible and do a small amount of damage on hit.
fix: Plantable flags can no longer be duplicated.
del: Planting a UA flag no longer forces anyone but the planter to warcry.
/:cl:
