### PR TITLE
Elite Mercenaries Correction

### DIFF
--- a/code/datums/emergency_calls/mercs.dm
+++ b/code/datums/emergency_calls/mercs.dm
@@ -85,7 +85,7 @@
 	max_medics = 3
 
 /datum/emergency_call/heavy_mercs
-	name = "Elite Mercenaries (Random Alignment)"
+	name = "Elite Mercenaries (!DEATHSQUAD! Random Alignment)"
 	mob_min = 4
 	mob_max = 8
 	probability = 0
@@ -103,7 +103,7 @@
 		objectives = "Help the crew of the [MAIN_SHIP_NAME] in exchange for payment, and choose your payment well. Do what your Captain says. Ensure your survival at all costs."
 
 /datum/emergency_call/heavy_mercs/hostile
-	name = "Elite Mercenaries (HOSTILE to USCM)"
+	name = "Elite Mercenaries (!DEATHSQUAD! HOSTILE to USCM)"
 
 /datum/emergency_call/heavy_mercs/hostile/New()
 	. = ..()
@@ -112,7 +112,7 @@
 	objectives = "Ransack the [MAIN_SHIP_NAME] and kill anyone who gets in your way. Do what your Captain says. Ensure your survival at all costs."
 
 /datum/emergency_call/heavy_mercs/friendly
-	name = "Elite Mercenaries (Friendly)"
+	name = "Elite Mercenaries (!DEATHSQUAD! Friendly)"
 
 /datum/emergency_call/heavy_mercs/friendly/New()
 	. = ..()


### PR DESCRIPTION

# About the pull request
Makes people realize that Elite Mercs are a Deathsquad
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
3 Deathsquad sent against a skeleton crew or rag-tag team is NO FUN AT ALL

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: LTNTS
spellcheck: added deathsquad next to Elite Mercs so people stop thinking they're a normal ERT
/:cl:

