### PR TITLE
Scout Cloak fix

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -748,10 +748,6 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 
 	. = ..()
 
-/obj/item/storage/backpack/marine/satchel/scout_cloak/attack_self(mob/user)
-	..()
-	camouflage()
-
 /obj/item/storage/backpack/marine/satchel/scout_cloak/verb/camouflage()
 	set name = "Activate Cloak"
 	set desc = "Activate your cloak's camouflage."


### PR DESCRIPTION
# About the pull request
Fixes scout keybind

This is sure one of a rabbit hole, Due to abominations tutorial, all actions call parent now, that calls parent action_activate, that calls ui_action_click, That calls parent ui_action_click on item type, and item type calls attack_self on itself, which activates the cloak again. we fix it by tactically nuking the camouflaging part in self attack.

fixes #6732 
# Explain why it's good for the game

Keybind working good
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Scout cloak is working again.
/:cl:
