### PR TITLE
Brig Detainment Cameras now have their own Console

### DIFF
--- a/code/__DEFINES/camera.dm
+++ b/code/__DEFINES/camera.dm
@@ -3,6 +3,7 @@
 #define CAMERA_NET_CONTAINMENT "Containment"
 #define CAMERA_NET_CONTAINMENT_HIDDEN "Containment Hidden"
 #define CAMERA_NET_RESEARCH "Research"
+#define CAMERA_NET_BRIG "Brig"
 #define CAMERA_NET_ALAMO "Alamo"
 #define CAMERA_NET_NORMANDY "Normandy"
 #define CAMERA_NET_COLONY "Colony"

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -99,6 +99,10 @@
 	name = "ares core camera"
 	network = list(CAMERA_NET_ARES)
 
+/obj/structure/machinery/camera/autoname/almayer/brig
+	name = "brig camera"
+	network = list(CAMERA_NET_BRIG)
+
 //used by the landing camera dropship equipment. Do not place them right under where the dropship lands.
 //Should place them near each corner of your LZs.
 /obj/structure/machinery/camera/autoname/lz_camera

--- a/code/game/machinery/computer/camera_console.dm
+++ b/code/game/machinery/computer/camera_console.dm
@@ -352,6 +352,10 @@
 /obj/structure/machinery/computer/cameras/almayer_network/vehicle
 	network = list(CAMERA_NET_ALMAYER, CAMERA_NET_VEHICLE)
 
+/obj/structure/machinery/computer/cameras/almayer_brig
+	name = "Brig Cameras Console"
+	network = list(CAMERA_NET_BRIG)
+
 /obj/structure/machinery/computer/cameras/mortar
 	name = "Mortar Camera Interface"
 	alpha = 0

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -19918,7 +19918,14 @@
 "ekZ" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/secure_data{
-	dir = 4
+	dir = 4;
+	pixel_y = 10
+	},
+/obj/structure/machinery/computer/cameras/almayer_brig{
+	dir = 4;
+	desc = "Used to access the various cameras in the security brig.";
+	name = "brig cameras console";
+	pixel_y = -11
 	},
 /turf/open/floor/almayer/red/west,
 /area/almayer/shipboard/brig/warden_office)
@@ -33768,7 +33775,7 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/machinery/camera/autoname/almayer,
+/obj/structure/machinery/camera/autoname/almayer/brig,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cells)
 "kcg" = (
@@ -34442,6 +34449,7 @@
 	id = "Perma 1";
 	pixel_y = 24
 	},
+/obj/structure/machinery/camera/autoname/almayer/brig,
 /turf/open/floor/almayer/plate,
 /area/almayer/shipboard/brig/perma)
 "krA" = (
@@ -34630,7 +34638,8 @@
 "kvL" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/cameras/almayer_network{
-	dir = 4
+	dir = 4;
+	pixel_y = 0
 	},
 /turf/open/floor/almayer/red/west,
 /area/almayer/shipboard/brig/warden_office)
@@ -40493,6 +40502,9 @@
 "mTN" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/structure/machinery/computer/cameras/almayer_brig{
+	dir = 4
+	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/processing)
 "mUq" = (
@@ -50456,6 +50468,12 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/command/cichallway)
+"qWm" = (
+/obj/structure/machinery/computer/cameras/almayer_brig{
+	dir = 4
+	},
+/turf/open/floor/almayer/red,
+/area/almayer/shipboard/brig/lobby)
 "qWt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -61350,9 +61368,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/stern)
 "vsz" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 8;
-	name = "ship-grade camera"
+/obj/structure/machinery/camera/autoname/almayer/brig{
+	dir = 8
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cells)
@@ -61882,10 +61899,8 @@
 /turf/open/floor/almayer/silver,
 /area/almayer/shipboard/brig/cic_hallway)
 "vCy" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 4;
-	name = "ship-grade camera";
-	pixel_y = 6
+/obj/structure/machinery/camera/autoname/almayer/brig{
+	dir = 4
 	},
 /turf/open/floor/almayer/green/west,
 /area/almayer/shipboard/brig/cells)
@@ -63920,6 +63935,7 @@
 	id = "Perma 2";
 	pixel_y = 24
 	},
+/obj/structure/machinery/camera/autoname/almayer/brig,
 /turf/open/floor/almayer/plate,
 /area/almayer/shipboard/brig/perma)
 "wnL" = (
@@ -66191,9 +66207,6 @@
 	dir = 1
 	},
 /obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/secure_data{
-	dir = 4
-	},
 /obj/structure/sign/safety/terminal{
 	pixel_x = 3;
 	pixel_y = 27
@@ -66201,6 +66214,11 @@
 /obj/structure/sign/safety/rewire{
 	pixel_x = 15;
 	pixel_y = 27
+	},
+/obj/structure/machinery/computer/cameras/almayer_brig{
+	dir = 4;
+	desc = "Used to access the various cameras in the security brig.";
+	name = "brig cameras console"
 	},
 /turf/open/floor/almayer/red/west,
 /area/almayer/shipboard/brig/processing)
@@ -68586,10 +68604,8 @@
 /turf/open/floor/almayer/cargo,
 /area/almayer/engineering/lower/engine_core)
 "yhg" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 4;
-	name = "ship-grade camera";
-	pixel_y = 6
+/obj/structure/machinery/camera/autoname/almayer/brig{
+	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cells)
@@ -82204,7 +82220,7 @@ cDN
 oFY
 cQL
 npO
-ncl
+qWm
 jcf
 bju
 cMW

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -3320,6 +3320,14 @@
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/machinery/faxmachine/uscm/command,
 /obj/item/device/megaphone,
+/obj/structure/machinery/computer/cameras/almayer_brig{
+	dir = 8;
+	desc = "Used to access the various cameras in the security brig.";
+	name = "brig cameras console";
+	pixel_y = 12;
+	pixel_x = 17;
+	layer = 2.99
+	},
 /turf/open/floor/almayer/plate,
 /area/almayer/command/cic)
 "awQ" = (
@@ -31597,7 +31605,16 @@
 "jhI" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/secure_data{
-	dir = 4
+	dir = 4;
+	pixel_y = 19;
+	layer = 2.99
+	},
+/obj/structure/machinery/computer/cameras/almayer_brig{
+	dir = 4;
+	desc = "Used to access the various cameras in the security brig.";
+	name = "brig cameras console";
+	pixel_y = 5;
+	layer = 2.99
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/chief_mp_office)
@@ -64329,7 +64346,8 @@
 "wvE" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/cameras/almayer_network{
-	dir = 4
+	dir = 4;
+	pixel_y = 1
 	},
 /obj/structure/machinery/light{
 	dir = 1

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -40502,9 +40502,6 @@
 "mTN" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/structure/machinery/computer/cameras/almayer_brig{
-	dir = 4
-	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/processing)
 "mUq" = (
@@ -50468,12 +50465,6 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/command/cichallway)
-"qWm" = (
-/obj/structure/machinery/computer/cameras/almayer_brig{
-	dir = 4
-	},
-/turf/open/floor/almayer/red,
-/area/almayer/shipboard/brig/lobby)
 "qWt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -82220,7 +82211,7 @@ cDN
 oFY
 cQL
 npO
-qWm
+ncl
 jcf
 bju
 cMW


### PR DESCRIPTION
# About the pull request

All cameras in the "detainment" area of the Brig now get their own console
Also adds cameras to each of the Perma Brig cells, one each respectively.

# Explain why it's good for the game

Generally a good QOL Update so that MPs dont have to type in or scroll *every single time* they want to check in on inmates, now they have a dedicated console for it.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/3ca5b68a-10d3-4c67-ba54-9212231fcc17)
![image](https://github.com/user-attachments/assets/13a1eaa6-4a8e-4464-bcaa-f2d0a50817cb)


</details>


# Changelog

:cl:
add: All Brig Detainment Cameras are now linked to a new Brig Camera Console Computer, available in the Brig Lobby, Warden's Office, CIC, and CMP Office.
maptweak: Removed one of the Security Records Consoles in the Brig Lobby in place for a Brig Camera Console.
mapadd: Both Brig Perma Cells now have brig cameras in them.
/:cl:
