### PR TITLE
cannot join as certain ERTs if you dont have enough relavent playtime.

### DIFF
--- a/code/controllers/subsystem/sound.dm
+++ b/code/controllers/subsystem/sound.dm
@@ -19,7 +19,7 @@ SUBSYSTEM_DEF(sound)
 		if(!run_hearers) // Initialize for handling next template
 			run_hearers = run_queue[run_template] // get base hearers
 			if(run_template.range) // ranging
-				run_hearers |= SSquadtree.players_in_range(SQUARE(run_template.x, run_template.y, run_template.range), run_template.z)
+				run_hearers |= SSquadtree.players_in_range(SQUARE(run_template.x, run_template.y, run_template.range * 2), run_template.z)
 			if(MC_TICK_CHECK)
 				return
 		while(length(run_hearers)) // Output sound to hearers

--- a/code/controllers/subsystem/sound.dm
+++ b/code/controllers/subsystem/sound.dm
@@ -19,7 +19,7 @@ SUBSYSTEM_DEF(sound)
 		if(!run_hearers) // Initialize for handling next template
 			run_hearers = run_queue[run_template] // get base hearers
 			if(run_template.range) // ranging
-				run_hearers |= SSquadtree.players_in_range(SQUARE(run_template.x, run_template.y, run_template.range * 2), run_template.z)
+				run_hearers |= SSquadtree.players_in_range(SQUARE(run_template.x, run_template.y, run_template.range), run_template.z)
 			if(MC_TICK_CHECK)
 				return
 		while(length(run_hearers)) // Output sound to hearers

--- a/code/datums/emergency_calls/cryo_spec.dm
+++ b/code/datums/emergency_calls/cryo_spec.dm
@@ -11,7 +11,7 @@
 /datum/emergency_call/cryo_spec/remove_nonqualifiers(list/datum/mind/candidates_list)
 	var/list/datum/mind/candidates_clean = list()
 	for(var/datum/mind/single_candidate in candidates_list)
-		if(check_timelock(single_candidate?.current?.client, JOB_SQUAD_SPECIALIST, time_required_for_job))
+		if(check_timelock(single_candidate?.current?.client, JOB_SQUAD_ROLES_LIST, time_required_for_job))
 			candidates_clean.Add(single_candidate)
 			continue
 		if(single_candidate.current)

--- a/code/datums/emergency_calls/cryo_spec.dm
+++ b/code/datums/emergency_calls/cryo_spec.dm
@@ -11,7 +11,7 @@
 /datum/emergency_call/cryo_spec/remove_nonqualifiers(list/datum/mind/candidates_list)
 	var/list/datum/mind/candidates_clean = list()
 	for(var/datum/mind/single_candidate in candidates_list)
-		if(check_timelock(single_candidate?.current?.client, JOB_SQUAD_ROLES_LIST, time_required_for_job))
+		if(check_timelock(single_candidate.current?.client, JOB_SQUAD_ROLES_LIST, time_required_for_job))
 			candidates_clean.Add(single_candidate)
 			continue
 		if(single_candidate.current)

--- a/code/datums/emergency_calls/cryo_spec.dm
+++ b/code/datums/emergency_calls/cryo_spec.dm
@@ -8,6 +8,16 @@
 	shuttle_id = ""
 	spawn_max_amount = TRUE
 
+/datum/emergency_call/cryo_spec/remove_nonqualifiers(list/datum/mind/candidates_list)
+	var/list/datum/mind/candidates_clean = list()
+	for(var/datum/mind/single_candidate in candidates_list)
+		if(check_timelock(single_candidate?.current?.client, JOB_SQUAD_SPECIALIST, time_required_for_job))
+			candidates_clean.Add(single_candidate)
+			continue
+		if(single_candidate.current)
+			to_chat(single_candidate.current, SPAN_WARNING("You didn't qualify for the ERT beacon because you dont have the specialist job unlocked!"))
+	return candidates_clean
+
 /datum/emergency_call/cryo_spec/create_member(datum/mind/mind, turf/override_spawn_loc)
 	set waitfor = FALSE
 	if(SSmapping.configs[GROUND_MAP].map_name == MAP_WHISKEY_OUTPOST)

--- a/code/datums/emergency_calls/cryo_spec.dm
+++ b/code/datums/emergency_calls/cryo_spec.dm
@@ -15,7 +15,7 @@
 			candidates_clean.Add(single_candidate)
 			continue
 		if(single_candidate.current)
-			to_chat(single_candidate.current, SPAN_WARNING("You didn't qualify for the ERT beacon because you dont have the specialist job unlocked!"))
+			to_chat(single_candidate.current, SPAN_WARNING("You didn't qualify for the ERT beacon because you don't have the specialist job unlocked!"))
 	return candidates_clean
 
 /datum/emergency_call/cryo_spec/create_member(datum/mind/mind, turf/override_spawn_loc)

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -225,7 +225,7 @@
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/datum/emergency_call, spawn_candidates), quiet_launch, announce_incoming, override_spawn_loc), 30 SECONDS)
 
 /datum/emergency_call/proc/remove_nonqualifiers(list/datum/mind/candidates_list)
-	return candidates
+	return candidates_list
 
 /datum/emergency_call/proc/spawn_candidates(quiet_launch = FALSE, announce_incoming = TRUE, override_spawn_loc)
 	if(SSticker.mode)
@@ -233,6 +233,7 @@
 
 	SEND_SIGNAL(src, COMSIG_ERT_SETUP)
 	candidates = remove_nonqualifiers(candidates)
+
 	if(length(candidates) < mob_min && !spawn_max_amount)
 		message_admins("Aborting distress beacon, not enough candidates: found [length(candidates)].")
 		members = list() //Empty the members list.
@@ -241,6 +242,7 @@
 		if(!quiet_launch)
 			marine_announcement("The distress signal has not received a response, the launch tubes are now recalibrating.", "Distress Beacon", logging = ARES_LOG_SECURITY)
 		return
+
 	//We've got enough!
 	//Trim down the list
 	var/list/datum/mind/picked_candidates = list()

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -225,7 +225,7 @@
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/datum/emergency_call, spawn_candidates), quiet_launch, announce_incoming, override_spawn_loc), 30 SECONDS)
 
 /datum/emergency_call/proc/remove_nonqualifiers(list/datum/mind/candidates_list)
-	return candidates_list
+	return candidates_list //everyone gets selected on 99% of distress beacons.
 
 /datum/emergency_call/proc/spawn_candidates(quiet_launch = FALSE, announce_incoming = TRUE, override_spawn_loc)
 	if(SSticker.mode)

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -224,12 +224,15 @@
 
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/datum/emergency_call, spawn_candidates), quiet_launch, announce_incoming, override_spawn_loc), 30 SECONDS)
 
+/datum/emergency_call/proc/remove_nonqualifiers(list/datum/mind/candidates_list)
+	return candidates
+
 /datum/emergency_call/proc/spawn_candidates(quiet_launch = FALSE, announce_incoming = TRUE, override_spawn_loc)
 	if(SSticker.mode)
 		SSticker.mode.picked_calls -= src
 
 	SEND_SIGNAL(src, COMSIG_ERT_SETUP)
-
+	candidates = remove_nonqualifiers(candidates)
 	if(length(candidates) < mob_min && !spawn_max_amount)
 		message_admins("Aborting distress beacon, not enough candidates: found [length(candidates)].")
 		members = list() //Empty the members list.
@@ -238,7 +241,6 @@
 		if(!quiet_launch)
 			marine_announcement("The distress signal has not received a response, the launch tubes are now recalibrating.", "Distress Beacon", logging = ARES_LOG_SECURITY)
 		return
-
 	//We've got enough!
 	//Trim down the list
 	var/list/datum/mind/picked_candidates = list()

--- a/code/datums/emergency_calls/inspection.dm
+++ b/code/datums/emergency_calls/inspection.dm
@@ -9,6 +9,15 @@
 	..()
 	objectives = "Investigate any issues with ML enforcement on the [MAIN_SHIP_NAME]."
 
+/datum/emergency_call/inspection_provost/remove_nonqualifiers(list/datum/mind/candidates_list)
+	var/list/datum/mind/candidates_clean = list()
+	for(var/datum/mind/single_candidate in candidates_list)
+		if(check_timelock(single_candidate?.current?.client, JOB_POLICE, time_required_for_job))
+			candidates_clean.Add(single_candidate)
+			continue
+		if(single_candidate.current)
+			to_chat(single_candidate.current, SPAN_WARNING("You didn't qualify for the ERT beacon because you dont have enough playtime as military police!"))
+	return candidates_clean
 
 /datum/emergency_call/inspection_provost/create_member(datum/mind/M, turf/override_spawn_loc)
 	var/turf/T = override_spawn_loc ? override_spawn_loc : get_spawn_point()

--- a/code/datums/emergency_calls/inspection.dm
+++ b/code/datums/emergency_calls/inspection.dm
@@ -16,7 +16,7 @@
 			candidates_clean.Add(single_candidate)
 			continue
 		if(single_candidate.current)
-			to_chat(single_candidate.current, SPAN_WARNING("You didn't qualify for the ERT beacon because you dont have enough playtime (5 Hours) as military police!"))
+			to_chat(single_candidate.current, SPAN_WARNING("You didn't qualify for the ERT beacon because you don't have enough playtime (5 Hours) as military police!"))
 	return candidates_clean
 
 /datum/emergency_call/inspection_provost/create_member(datum/mind/M, turf/override_spawn_loc)

--- a/code/datums/emergency_calls/inspection.dm
+++ b/code/datums/emergency_calls/inspection.dm
@@ -12,7 +12,7 @@
 /datum/emergency_call/inspection_provost/remove_nonqualifiers(list/datum/mind/candidates_list)
 	var/list/datum/mind/candidates_clean = list()
 	for(var/datum/mind/single_candidate in candidates_list)
-		if(check_timelock(single_candidate?.current?.client, JOB_POLICE, time_required_for_job))
+		if(check_timelock(single_candidate.current?.client, JOB_POLICE, time_required_for_job))
 			candidates_clean.Add(single_candidate)
 			continue
 		if(single_candidate.current)

--- a/code/datums/emergency_calls/inspection.dm
+++ b/code/datums/emergency_calls/inspection.dm
@@ -1,6 +1,6 @@
 //USCM Provost
 /datum/emergency_call/inspection_provost
-	name = "Inspection - USCM Provost - ML knowledge required."
+	name = "Inspection - USCM Provost - ML knowledge and MP playtime required."
 	mob_max = 2
 	mob_min = 1
 	probability = 0
@@ -16,7 +16,7 @@
 			candidates_clean.Add(single_candidate)
 			continue
 		if(single_candidate.current)
-			to_chat(single_candidate.current, SPAN_WARNING("You didn't qualify for the ERT beacon because you dont have enough playtime as military police!"))
+			to_chat(single_candidate.current, SPAN_WARNING("You didn't qualify for the ERT beacon because you dont have enough playtime (5 Hours) as military police!"))
 	return candidates_clean
 
 /datum/emergency_call/inspection_provost/create_member(datum/mind/M, turf/override_spawn_loc)


### PR DESCRIPTION

# About the pull request

You cannot get foxrot spec ERT if you dont have specialist job unlocked
you cannot get Provost ERT if you dont have 5 hours as MP.

# Explain why it's good for the game

For spec, when command buys the spec they're expecting at least some form of gameplay knowledge. Foxrot squad ert already does this, defaulting PVTs to PFC and will not give them engie, etc. Now they cant get it if they couldnt roll it roundstart.

For provost, this beacon (there is another beacon which is without the "ML knowledge required") Will ensure admins can rely on the players to be at least somewhat familiar with MP role.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Players will not get picked at certain ERT beacons if they dont have enough playtime in relevant area.
/:cl:
