### PR TITLE
Reverts Suppressor Stat Removals

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -260,8 +260,15 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/suppressor/New()
 	..()
-	damage_falloff_mod = 0.1
+	accuracy_mod = HIT_ACCURACY_MULT_TIER_3
+	damage_mod = -BULLET_DAMAGE_MULT_TIER_1
+	recoil_mod = -RECOIL_AMOUNT_TIER_5
+	scatter_mod = -SCATTER_AMOUNT_TIER_10
 	attach_icon = pick("suppressor_a","suppressor2_a")
+
+	recoil_unwielded_mod = -RECOIL_AMOUNT_TIER_5
+	scatter_unwielded_mod = -SCATTER_AMOUNT_TIER_10
+	damage_falloff_mod = 0.4
 
 /obj/item/attachable/suppressor/xm40_integral
 	name = "\improper XM40 integral suppressor"
@@ -270,6 +277,13 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/suppressor/xm40_integral/New()
 	..()
+	accuracy_mod = HIT_ACCURACY_MULT_TIER_3
+	damage_mod = -BULLET_DAMAGE_MULT_TIER_1
+	recoil_mod = -RECOIL_AMOUNT_TIER_5
+	scatter_mod = -SCATTER_AMOUNT_TIER_10
+	recoil_unwielded_mod = -RECOIL_AMOUNT_TIER_5
+	scatter_unwielded_mod = -SCATTER_AMOUNT_TIER_10
+	damage_falloff_mod = 0.1
 	attach_icon = "m40sd_suppressor_a"
 
 /obj/item/attachable/bayonet


### PR DESCRIPTION
# About the pull request
Reverts #3159

# Explain why it's good for the game

Reverts the changes done to suppressor.
Although hiding muzzle flash and silencing is nice, it's unfortunate that in most cases this  was, and still is, the worse extended barrel. 
There's no reason to pick up this attachment. It's become cosmetic. Before, it had downsides and upsides, and was one of a few attachments that added variety, now it's just... filler. Even if it's intended for backliners, why pick this over EB? 

(Pardon if I mess up anything in the PR, this is my first time doing a PR by myself)
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
balance: reverts the previous change to the suppressor that removed all stat changes and buffed it's damage fall off (still in the negative). 
/:cl:

