### PR TITLE
Another NERF to heavy revolver ammo

### DIFF
--- a/code/datums/ammo/ammo.dm
+++ b/code/datums/ammo/ammo.dm
@@ -173,8 +173,10 @@
 		living_mob.apply_stamina_damage(fired_projectile.ammo.damage, fired_projectile.def_zone, ARMOR_BULLET)
 
 /datum/ammo/proc/slowdown(mob/living/living_mob, obj/projectile/fired_projectile)
-	if(living_mob.mob_size >= MOB_SIZE_BIG)
-		return //Big mobs are not affected.
+	if(isxeno(living_mob))
+		var/mob/living/carbon/xenomorph/xeno = living_mob
+		if(xeno.caste.tier > 2)
+				return //tier 3 are not affected
 	if(iscarbonsizexeno(living_mob))
 		var/mob/living/carbon/xenomorph/target = living_mob
 		target.apply_effect(1, SUPERSLOW)

--- a/code/datums/ammo/ammo.dm
+++ b/code/datums/ammo/ammo.dm
@@ -175,8 +175,8 @@
 /datum/ammo/proc/slowdown(mob/living/living_mob, obj/projectile/fired_projectile)
 	if(isxeno(living_mob))
 		var/mob/living/carbon/xenomorph/xeno = living_mob
-		if(xeno.caste.tier > 2)
-			return //tier 3 are not affected
+		if(xeno.caste.tier > 2 || (xeno.caste.tier == 0 && xeno.mob_size >= MOB_SIZE_BIG))
+			return //tier 3 and big tier 0 (like queen) are not affected
 	if(iscarbonsizexeno(living_mob))
 		var/mob/living/carbon/xenomorph/target = living_mob
 		target.apply_effect(1, SUPERSLOW)

--- a/code/datums/ammo/ammo.dm
+++ b/code/datums/ammo/ammo.dm
@@ -173,6 +173,8 @@
 		living_mob.apply_stamina_damage(fired_projectile.ammo.damage, fired_projectile.def_zone, ARMOR_BULLET)
 
 /datum/ammo/proc/slowdown(mob/living/living_mob, obj/projectile/fired_projectile)
+	if(living_mob.mob_size >= MOB_SIZE_BIG)
+        return //Big mobs are not affected.
 	if(iscarbonsizexeno(living_mob))
 		var/mob/living/carbon/xenomorph/target = living_mob
 		target.apply_effect(1, SUPERSLOW)

--- a/code/datums/ammo/ammo.dm
+++ b/code/datums/ammo/ammo.dm
@@ -176,7 +176,7 @@
 	if(isxeno(living_mob))
 		var/mob/living/carbon/xenomorph/xeno = living_mob
 		if(xeno.caste.tier > 2)
-				return //tier 3 are not affected
+			return //tier 3 are not affected
 	if(iscarbonsizexeno(living_mob))
 		var/mob/living/carbon/xenomorph/target = living_mob
 		target.apply_effect(1, SUPERSLOW)

--- a/code/datums/ammo/ammo.dm
+++ b/code/datums/ammo/ammo.dm
@@ -174,7 +174,7 @@
 
 /datum/ammo/proc/slowdown(mob/living/living_mob, obj/projectile/fired_projectile)
 	if(living_mob.mob_size >= MOB_SIZE_BIG)
-        return //Big mobs are not affected.
+		return //Big mobs are not affected.
 	if(iscarbonsizexeno(living_mob))
 		var/mob/living/carbon/xenomorph/target = living_mob
 		target.apply_effect(1, SUPERSLOW)


### PR DESCRIPTION

# About the pull request
https://github.com/cmss13-devs/cmss13/pull/4706
So this PR replaced knockdown with slow+knockback, but unlike the knockdown proc the slow proc didn't check for the mob size, so you became able to slow down T3s and even Queen with heavy revolver ammo, which clearly wasn't intended. This wasn't noticed until recently.

# Explain why it's good for the game
Free slows with no telegraph on T3s is not something we need in the game.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: ihatethisengine2
balance: heavy revolver ammo cannot slowdown t3s anymore.
/:cl:
