### PR TITLE
Species default iron teeth trait

### DIFF
--- a/code/modules/mob/living/carbon/human/species/synthetic.dm
+++ b/code/modules/mob/living/carbon/human/species/synthetic.dm
@@ -8,7 +8,7 @@
 	unarmed_type = /datum/unarmed_attack/punch/synthetic
 	pain_type = /datum/pain/synthetic
 	stamina_type = /datum/stamina/none
-	mob_inherent_traits = list(TRAIT_SUPER_STRONG)
+	mob_inherent_traits = list(TRAIT_SUPER_STRONG, TRAIT_IRON_TEETH)
 	rarity_value = 2
 	insulated = TRUE
 
@@ -64,7 +64,7 @@
 	name = SYNTH_GEN_ONE
 	uses_skin_color = FALSE
 	special_body_types = FALSE
-	mob_inherent_traits = list(TRAIT_SUPER_STRONG, TRAIT_INTENT_EYES)
+	mob_inherent_traits = list(TRAIT_SUPER_STRONG, TRAIT_INTENT_EYES, TRAIT_IRON_TEETH)
 
 	hair_color = "#000000"
 	icobase = 'icons/mob/humans/species/r_synthetic.dmi'
@@ -81,7 +81,7 @@
 	uses_skin_color = TRUE
 	special_body_types = TRUE
 	burn_mod = 0.8
-	mob_inherent_traits = list(TRAIT_SUPER_STRONG)
+	mob_inherent_traits = list(TRAIT_SUPER_STRONG, TRAIT_IRON_TEETH)
 
 	pain_type = /datum/pain/synthetic/colonial
 	rarity_value = 1.5
@@ -103,7 +103,7 @@
 	name = SYNTH_COLONY_GEN_ONE
 	uses_skin_color = FALSE
 	special_body_types = FALSE
-	mob_inherent_traits = list(TRAIT_SUPER_STRONG, TRAIT_INTENT_EYES)
+	mob_inherent_traits = list(TRAIT_SUPER_STRONG, TRAIT_INTENT_EYES, TRAIT_IRON_TEETH)
 	//sets colonial_gen_one synth's hair to black
 	hair_color = "#000000"
 	//sets colonial_gen_one synth's icon to WJ sprite
@@ -116,7 +116,7 @@
 	name_plural = "Combat Synthetics"
 	uses_skin_color = FALSE
 	special_body_types = FALSE
-	mob_inherent_traits = list(TRAIT_SUPER_STRONG, TRAIT_INTENT_EYES)
+	mob_inherent_traits = list(TRAIT_SUPER_STRONG, TRAIT_INTENT_EYES, TRAIT_IRON_TEETH)
 
 	burn_mod = 0.6 //made for combat
 	total_health = 250 //made for combat
@@ -137,7 +137,7 @@
 	name = SYNTH_INFILTRATOR
 	name_plural = "Infiltrator Synthetics"
 	uses_skin_color = TRUE
-	mob_inherent_traits = list(TRAIT_SUPER_STRONG, TRAIT_INFILTRATOR_SYNTH)
+	mob_inherent_traits = list(TRAIT_SUPER_STRONG, TRAIT_INFILTRATOR_SYNTH, TRAIT_IRON_TEETH)
 
 	bloodsplatter_type = /obj/effect/temp_visual/dir_setting/bloodsplatter/human
 

--- a/code/modules/mob/living/carbon/human/species/working_joe/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/working_joe/_species.dm
@@ -4,7 +4,7 @@
 	death_message = "violently gargles fluid and seizes up, the glow in their eyes dimming..."
 	uses_skin_color = FALSE
 	burn_mod = 0.65 // made for hazardous environments, withstanding temperatures up to 1210 degrees
-	mob_inherent_traits = list(TRAIT_SUPER_STRONG, TRAIT_INTENT_EYES, TRAIT_EMOTE_CD_EXEMPT, TRAIT_CANNOT_EAT, TRAIT_UNSTRIPPABLE)
+	mob_inherent_traits = list(TRAIT_SUPER_STRONG, TRAIT_INTENT_EYES, TRAIT_EMOTE_CD_EXEMPT, TRAIT_CANNOT_EAT, TRAIT_UNSTRIPPABLE, TRAIT_IRON_TEETH)
 
 	slowdown = 0.45
 	hair_color = "#000000"

--- a/code/modules/mob/living/carbon/human/species/yautja/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/yautja/_species.dm
@@ -14,6 +14,7 @@
 		TRAIT_FOREIGN_BIO,
 		TRAIT_DEXTROUS,
 		TRAIT_EMOTE_CD_EXEMPT,
+		TRAIT_IRON_TEETH,
 	)
 	unarmed_type = /datum/unarmed_attack/punch/strong
 	secondary_unarmed_type = /datum/unarmed_attack/bite/strong


### PR DESCRIPTION

# About the pull request

Gives synths and yautja iron teeth by default.
I would expect machines to have the jaw strength to maintain a grip on small items.

# Explain why it's good for the game

Makes sense, and for things like CLF/Survivor synth makes it so they don't immediately lose their knife.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Synthetics and Yautja now spawn with the Iron Teeth trait, not dropping items held in their mouth.
/:cl:
