### PR TITLE
Smartgunners can carry folding cades on their backs

### DIFF
--- a/code/game/objects/structures/barricade/deployable.dm
+++ b/code/game/objects/structures/barricade/deployable.dm
@@ -95,6 +95,7 @@
 
 	w_class = SIZE_LARGE
 	flags_equip_slot = SLOT_BACK|SLOT_SUIT_STORE
+	flags_item = SMARTGUNNER_BACKPACK_OVERRIDE
 	icon_state = "folding-1"
 	item_state = "folding"
 	item_state_slots = list(


### PR DESCRIPTION

# About the pull request
Lets smartgunners carry folding cades on their backs, just like they can wear parachutes.

# Explain why it's good for the game
No one asked for this, but I think this adds a nice little utility.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: ihatethisengine2
balance: Smartgunners can wear folding barricades on their backs.
/:cl:
