### PR TITLE
Xeno Special Stuctures now ignore Nests.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -457,7 +457,7 @@
 			has_obstacle = TRUE
 			break
 
-	if(current_turf.density || has_obstacle )
+	if(current_turf.density || has_obstacle)
 		if(!silent)
 			to_chat(src, SPAN_WARNING("There's something built here already."))
 		return

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -408,7 +408,7 @@
 	else
 		to_chat(src, SPAN_WARNING("There's nothing in our belly that needs regurgitating."))
 
-/mob/living/carbon/xenomorph/proc/check_alien_construction(turf/current_turf, check_blockers = TRUE, silent = FALSE, check_doors = TRUE)
+/mob/living/carbon/xenomorph/proc/check_alien_construction(turf/current_turf, check_blockers = TRUE, silent = FALSE, check_doors = TRUE, ignore_nest = FALSE)
 	var/has_obstacle
 	for(var/obj/O in current_turf)
 		if(check_blockers && istype(O, /obj/effect/build_blocker))
@@ -447,6 +447,8 @@
 				if(P.chair_state != DROPSHIP_CHAIR_BROKEN)
 					has_obstacle = TRUE
 					break
+			else if(istype(O, /obj/structure/bed/nest) && ignore_nest)
+				continue
 			else
 				has_obstacle = TRUE
 				break
@@ -455,7 +457,7 @@
 			has_obstacle = TRUE
 			break
 
-	if(current_turf.density || has_obstacle)
+	if(current_turf.density || has_obstacle )
 		if(!silent)
 			to_chat(src, SPAN_WARNING("There's something built here already."))
 		return

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -709,11 +709,11 @@
 /datum/action/xeno_action/activable/place_construction/proc/spacecheck(mob/living/carbon/xenomorph/X, turf/T, datum/construction_template/xenomorph/tem)
 	if(tem.block_range)
 		for(var/turf/TA in range(tem.block_range, T))
-			if(!X.check_alien_construction(TA, FALSE, TRUE))
+			if(!X.check_alien_construction(TA, FALSE, TRUE, ignore_nest = TRUE))
 				to_chat(X, SPAN_WARNING("We need more open space to build here."))
 				qdel(tem)
 				return FALSE
-		if(!X.check_alien_construction(T))
+		if(!X.check_alien_construction(T, ignore_nest = TRUE))
 			to_chat(X, SPAN_WARNING("We need more open space to build here."))
 			qdel(tem)
 			return FALSE


### PR DESCRIPTION
# About the pull request

Allow to place special xenos structures nearby nested people, because of previous code, you were not able to place anything nearby nest, i know its leftover from previous nest code, where nest were "on ground" but after they become "Wall nest" it kinda dont make sense for them to block special structures.

# Explain why it's good for the game

Allow you to build structures near nested people, before that it required to unnest capture to just place structure with was just inconvinience.


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

I will add GIF later.

</details>


# Changelog

:cl: Cuberound, Venuska1117
qol: You can build Special Structures nearby nested people.
/:cl:
