### PR TITLE
Re: Alter Xeno Evolution: Larva -> Drone Mandatory.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Evolution.dm
@@ -46,7 +46,7 @@
 	if(!evolve_checks())
 		return
 
-	if((!hive.living_xeno_queen) && castepick != XENO_CASTE_QUEEN && !islarva(src) && !hive.allow_no_queen_evo)
+	if((!hive.living_xeno_queen) && castepick != XENO_CASTE_QUEEN && !islarva(src) && !hive.allow_no_queen_evo && castepick != XENO_CASTE_RUNNER && castepick != XENO_CASTE_DEFENDER && castepick != XENO_CASTE_SENTINEL)
 		to_chat(src, SPAN_WARNING("The Hive is shaken by the death of the last Queen. We can't find the strength to evolve."))
 		return
 
@@ -66,9 +66,9 @@
 		else
 			to_chat(src, SPAN_WARNING("Nuh-uhh."))
 			return
-	if(evolution_threshold && castepick != XENO_CASTE_QUEEN) //Does the caste have an evolution timer? Then check it
-		if(evolution_stored < evolution_threshold)
-			to_chat(src, SPAN_WARNING("We must wait before evolving. Currently at: [evolution_stored] / [evolution_threshold]."))
+	if(caste_datum.evolution_cost && castepick != XENO_CASTE_QUEEN) //Does the caste have an evolution timer? Then check it
+		if(evolution_stored < caste_datum.evolution_cost)
+			to_chat(src, SPAN_WARNING("We must wait before evolving. Currently at: [evolution_stored] / [caste_datum.evolution_cost]."))
 			return
 
 	// Used for restricting benos to evolve to drone/queen when they're the only potential queen
@@ -128,8 +128,8 @@
 	else if(!can_evolve(castepick, potential_queens))
 		return
 
-	// subtract the threshold, keep the stored amount
-	evolution_stored -= evolution_threshold
+	// subtract the evolution cost, keep the stored amount
+	evolution_stored -= caste_datum.evolution_cost
 	var/obj/item/organ/xeno/organ = locate() in src
 	if(!isnull(organ))
 		qdel(organ)

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -151,6 +151,7 @@
 	var/show_only_numbers = FALSE
 	var/evolution_stored = 0 //How much evolution they have stored
 	var/evolution_threshold = 200
+	var/evolution_cost = 30 //How much evolution to caste will cost
 	var/tier = 1 //This will track their "tier" to restrict/limit evolutions
 	var/time_of_birth
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Boiler.dm
@@ -34,6 +34,7 @@
 	tacklestrength_max = 4
 
 	minimum_evolve_time = 15 MINUTES
+	evolution_cost = 500
 
 	minimap_icon = "boiler"
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Burrower.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Burrower.dm
@@ -34,6 +34,7 @@
 	tremor_cooldown = 450
 
 	minimum_evolve_time = 7 MINUTES
+	evolution_cost = 200
 
 	minimap_icon = "burrower"
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Carrier.dm
@@ -39,6 +39,7 @@
 	egg_cooldown = 250
 
 	minimum_evolve_time = 5 MINUTES
+	evolution_cost = 200
 
 	minimap_icon = "carrier"
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Crusher.dm
@@ -18,6 +18,7 @@
 	behavior_delegate_type = /datum/behavior_delegate/crusher_base
 
 	minimum_evolve_time = 15 MINUTES
+	evolution_cost = 500
 
 	tackle_min = 2
 	tackle_max = 6

--- a/code/modules/mob/living/carbon/xenomorph/castes/Defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Defender.dm
@@ -25,6 +25,7 @@
 	tackle_max = 4
 
 	minimum_evolve_time = 4 MINUTES
+	evolution_cost = 30
 
 	minimap_icon = "defender"
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Drone.dm
@@ -20,7 +20,7 @@
 	build_time_mult = BUILD_TIME_MULT_BUILDER
 
 	caste_desc = "A builder of hives. Only drones may evolve into Queens."
-	evolves_to = list(XENO_CASTE_QUEEN, XENO_CASTE_BURROWER, XENO_CASTE_CARRIER, XENO_CASTE_HIVELORD) //Add more here separated by commas
+	evolves_to = list(XENO_CASTE_RUNNER, XENO_CASTE_SENTINEL, XENO_CASTE_DEFENDER, XENO_CASTE_QUEEN, XENO_CASTE_CARRIER, XENO_CASTE_HIVELORD, XENO_CASTE_BURROWER) //Add more here separated by commas
 	deevolves_to = list("Larva")
 	can_hold_facehuggers = 1
 	can_hold_eggs = CAN_HOLD_TWO_HANDS
@@ -36,6 +36,7 @@
 	aura_strength = 2
 
 	minimum_evolve_time = 1 MINUTES
+	evolution_cost = 30
 
 	minimap_icon = "drone"
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Hivelord.dm
@@ -35,6 +35,7 @@
 	aura_strength = 2.5
 
 	minimum_evolve_time = 3 MINUTES
+	evolution_cost = 200
 
 	minimap_icon = "hivelord"
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
@@ -10,7 +10,7 @@
 	caste_desc = "D'awwwww, so cute!"
 	speed = XENO_SPEED_TIER_10
 	innate_healing = TRUE //heals even outside weeds so you're not stuck unable to evolve when hiding on the ship wounded.
-	evolves_to = XENO_T1_CASTES
+	evolves_to = list(XENO_CASTE_DRONE)
 
 	evolve_without_queen = TRUE
 	can_be_revived = FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
@@ -25,6 +25,7 @@
 	heal_resting = 1.5
 
 	minimum_evolve_time = 9 MINUTES
+	evolution_cost = 200
 
 	minimap_icon = "lurker"
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Praetorian.dm
@@ -35,6 +35,7 @@
 	behavior_delegate_type = /datum/behavior_delegate/praetorian_base
 
 	minimum_evolve_time = 15 MINUTES
+	evolution_cost = 500
 
 	minimap_icon = "praetorian"
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -48,6 +48,7 @@
 	minimap_icon = "xenoqueen"
 
 	royal_caste = TRUE
+	evolution_cost = 0
 
 /proc/update_living_queens() // needed to update when you change a queen to a different hive
 	outer_loop:

--- a/code/modules/mob/living/carbon/xenomorph/castes/Ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Ravager.dm
@@ -33,6 +33,7 @@
 	behavior_delegate_type = /datum/behavior_delegate/ravager_base
 
 	minimum_evolve_time = 15 MINUTES
+	evolution_cost = 500
 
 	minimap_icon = "ravager"
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Runner.dm
@@ -28,6 +28,7 @@
 	heal_resting = 1.75
 
 	minimum_evolve_time = 5 MINUTES
+	evolution_cost = 30
 
 	minimap_icon = "runner"
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Sentinel.dm
@@ -28,6 +28,7 @@
 	minimap_icon = "sentinel"
 
 	minimum_evolve_time = 5 MINUTES
+	evolution_cost = 30
 
 /mob/living/carbon/xenomorph/sentinel
 	caste_type = XENO_CASTE_SENTINEL

--- a/code/modules/mob/living/carbon/xenomorph/castes/Spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Spitter.dm
@@ -28,6 +28,7 @@
 	tacklestrength_max = 5
 
 	minimum_evolve_time = 9 MINUTES
+	evolution_cost = 200
 
 	minimap_icon = "spitter"
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -28,6 +28,7 @@
 	heal_resting = 1.4
 
 	minimum_evolve_time = 9 MINUTES
+	evolution_cost = 200
 
 	minimap_icon = "warrior"
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/caste_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/caste_datum.dm
@@ -21,6 +21,10 @@
 	var/evolution_allowed = 1
 	///Threshold to next evolution
 	var/evolution_threshold = 0
+	///How much evolution is stored
+	var/evolution_stored = 0
+	///How much caste cost in evo points
+	var/evolution_cost = 0
 	/// whether they can get evo points without needing an ovi queen
 	var/evolve_without_queen = FALSE
 	///This is where you add castes to evolve into. "Separated", "by", "commas"

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -57,11 +57,31 @@
 				evolution_stored -= progress_amount
 				return
 
+		if(evolution_stored >= evolution_cost)
+			if(!got_evolution_message)
+				early_evolve_message()
+				got_evolution_message = TRUE
+
+			if(ROUND_TIME < XENO_ROUNDSTART_PROGRESS_TIME_2)
+				evolution_stored += progress_amount
+				return
+
+			if(evolution_stored > evolution_threshold + progress_amount)
+				evolution_stored -= progress_amount
+				return
+
 		else
 			evolution_stored += progress_amount
 
 /mob/living/carbon/xenomorph/proc/evolve_message()
-	to_chat(src, SPAN_XENODANGER("Our carapace crackles and our tendons strengthen. We are ready to <a href='?src=\ref[src];evolve=1;'>evolve</a>!")) //Makes this bold so the Xeno doesn't miss it
+	to_chat(src, SPAN_XENODANGER("Our carapace crackles and we become matured. We are ready to <a href='?src=\ref[src];evolve=1;'>evolve</a>!")) //Makes this bold so the Xeno doesn't miss it
+	playsound_client(client, sound('sound/effects/xeno_evolveready.ogg'))
+
+	var/datum/action/xeno_action/onclick/evolve/evolve_action = new()
+	evolve_action.give_to(src)
+
+/mob/living/carbon/xenomorph/proc/early_evolve_message()
+	to_chat(src, SPAN_XENODANGER("Your tendons strengthen, you can now <a href='?src=\ref[src];evolve=1;'>evolve</a> to young castes!")) //Placeholder evo message, someone can improve it.
 	playsound_client(client, sound('sound/effects/xeno_evolveready.ogg'))
 
 	var/datum/action/xeno_action/onclick/evolve/evolve_action = new()


### PR DESCRIPTION
# About the pull request

This PR focus on making Drone as universal evolving caste, and add new evolution system based on how much evolution points each caste cost, now drone caste cost 30 evolution points, and other T1 castes cost 30 evolution points too. (default 60 evo points needed to evolve to T1, same cost as pre-add)

De-evolving as any T1 caste will bring you back to larva stage.

P.S. person behind this idea was @Steelpoint , i just made this to reality, just work slightly different for balance:
https://forum.cm-ss13.com/t/alter-xeno-evolution-larva-drone-mandatory/8075

# Explain why it's good for the game

Allow xenos to evolve quicker to T1 drone caste, this change make new players get used to playing as Xenos (new XX players), additionally it prevent people from missing out on evolution, you got too immersed in building as drone (doing drone tax) and you missed your evolution to T2 at 14 minute? now this will not be issue anymore, now you don't need to de-evolve and evolve again to become other branch of xeno to just get that Warrior or other castes.


# Testing Photographs and Procedure

Fully unlocked Evolution choices:
![image](https://github.com/cmss13-devs/cmss13/assets/89580971/baeec7dd-5c41-4cff-8b64-0f39068d6b72)


# Changelog
:cl: Venuska1117
balance: Larva evolve only to Drone, Now Drones are "Basic" Caste, they now can evolve to: Runner, Sentiel, Defender, Queen, Burrower and Carrier.
balance: Evolving from: Larva to drone and drone to other T1 castes cost 30 evolution.
/:cl:
