### PR TITLE
Locking Dropships now resets Ovipositor timer instead of after hijack.

### DIFF
--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -254,6 +254,14 @@
 			set_lz_resin_allowed(TRUE)
 		stop_playing_launch_announcement_alarm()
 
+		var/hivenumber = XENO_HIVE_NORMAL
+		if(istype(xeno))
+			hivenumber = xeno.hivenumber
+		var/datum/hive_status/hive = GLOB.hive_datum[hivenumber]
+		if(hive.living_xeno_queen)
+			var/datum/action/xeno_action/onclick/grow_ovipositor/ovi_ability = get_action(hive.living_xeno_queen, /datum/action/xeno_action/onclick/grow_ovipositor)
+			ovi_ability.reduce_cooldown(ovi_ability.xeno_cooldown)
+
 		to_chat(xeno, SPAN_XENONOTICE("You override the doors."))
 		xeno_message(SPAN_XENOANNOUNCE("The doors of the metal bird have been overridden! Rejoice!"), 3, xeno.hivenumber)
 		message_admins("[key_name(xeno)] has locked the dropship '[dropship]'", xeno.x, xeno.y, xeno.z)
@@ -313,9 +321,6 @@
 	hive.abandon_on_hijack()
 	var/original_evilution = hive.evolution_bonus
 	hive.override_evilution(XENO_HIJACK_EVILUTION_BUFF, TRUE)
-	if(hive.living_xeno_queen)
-		var/datum/action/xeno_action/onclick/grow_ovipositor/ovi_ability = get_action(hive.living_xeno_queen, /datum/action/xeno_action/onclick/grow_ovipositor)
-		ovi_ability.reduce_cooldown(ovi_ability.xeno_cooldown)
 	addtimer(CALLBACK(hive, TYPE_PROC_REF(/datum/hive_status, override_evilution), original_evilution, FALSE), XENO_HIJACK_EVILUTION_TIME)
 
 	// Notify the yautja too so they stop the hunt


### PR DESCRIPTION
# About the pull request

This PR focus on solving issue, where queen would deovi so she can go to ship and lock it, only to wait 5 minutes for no reason for ovi or hijack and get ovi afterwards, but xenos are losing free evo points because of shuttle launch stun.

# Explain why it's good for the game

It moves reset ovi timer after Hijack to before hijack, allowing getting ovipositor after successfully locking ship, allowing queen to instantly go to ovi instead of need to start hijack sequence.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Cuberound, Venuska1117
balance: Queen ovipositor timer reset after locking dropship instead of after hijack.
/:cl:
