### PR TITLE
Makes it so Burrower cannot use Burrow or Tunnel when on the Almayer

### DIFF
--- a/code/game/area/almayer.dm
+++ b/code/game/area/almayer.dm
@@ -14,6 +14,7 @@
 	// soundscape_playlist = list('sound/effects/xylophone1.ogg', 'sound/effects/xylophone2.ogg', 'sound/effects/xylophone3.ogg')
 	ambience_exterior = AMBIENCE_ALMAYER
 	ceiling_muffle = FALSE
+	flags_area = AREA_NOTUNNEL
 
 	///Whether this area is used for hijack evacuation progress
 	var/hijack_evacuation_area = FALSE


### PR DESCRIPTION
# About the pull request

Simply makes it so any areas in the `/area/almayer` tree cannot be burrowed into or tunneled.

# Explain why it's good for the game

As it stands, the current meta for basically ANY xeno shipside is to instantly evo into a burrower and melt half the ship with no repercussions. 
This is mainly due to the fact that; 

One, Burrow has ***ZERO*** cooldown and almost zero channel time.
Two, Burrow was allowed from the start to illogically burrow into metal, which allowed them to harass the ship, and non combat personnel on ship whilst not putting themselves in danger unless the WHOLE lobby is chasing them, and even then.

Even during hijack, this can arguably be an issue since they can just burrow up to a turret, smack it a couple times and fuck off out of range if they get too low.

Logically speaking even, a xenomorph that can't break a barricade easily but can burrow through solid metal/steel ship hull does not add up for continuity.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/4cb3bcce-3018-403d-95f4-39d312f5ca15)

</details>


# Changelog
:cl:
balance: Burrowers can no longer use the Burrow or Tunnel ability shipside.
/:cl:
