### PR TITLE
stops people from buckling others when they shouldn't be able to

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -277,7 +277,7 @@
 
 //trying to buckle a mob
 /obj/proc/buckle_mob(mob/M, mob/user)
-	if (!ismob(M) || (get_dist(src, user) > 1) || user.is_mob_restrained() || HAS_TRAIT(src, (TRAIT_IMMOBILIZED || TRAIT_INCAPACITATED || TRAIT_FLOORED)) || user.stat || buckled_mob || M.buckled || !isturf(user.loc))
+	if (!ismob(M) || (get_dist(src, user) > 1) || user.is_mob_restrained() || HAS_TRAIT(user, (TRAIT_IMMOBILIZED || TRAIT_INCAPACITATED || TRAIT_FLOORED)) || user.stat || buckled_mob || M.buckled || !isturf(user.loc))
 		return
 
 	if (isxeno(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -277,7 +277,11 @@
 
 //trying to buckle a mob
 /obj/proc/buckle_mob(mob/M, mob/user)
-	if (!ismob(M) || (get_dist(src, user) > 1) || user.is_mob_restrained() || HAS_TRAIT(user, (TRAIT_IMMOBILIZED || TRAIT_INCAPACITATED || TRAIT_FLOORED)) || user.stat || buckled_mob || M.buckled || !isturf(user.loc))
+	if (!ismob(M) || (get_dist(src, user) > 1) || user.is_mob_incapacitated() || user.stat || buckled_mob || M.buckled || !isturf(user.loc))
+		return
+
+	if (HAS_TRAIT(user, TRAIT_IMMOBILIZED) || HAS_TRAIT(user, TRAIT_FLOORED))
+		to_chat(user, SPAN_WARNING("You can't do this right now."))
 		return
 
 	if (isxeno(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -277,7 +277,7 @@
 
 //trying to buckle a mob
 /obj/proc/buckle_mob(mob/M, mob/user)
-	if (!ismob(M) || (get_dist(src, user) > 1) || user.is_mob_restrained() || HASTRAIT(src, (TRAIT_IMMOBILIZED || TRAIT_INCAPACITATED || TRAIT_FLOORED)) || user.stat || buckled_mob || M.buckled || !isturf(user.loc))
+	if (!ismob(M) || (get_dist(src, user) > 1) || user.is_mob_restrained() || HAS_TRAIT(src, (TRAIT_IMMOBILIZED || TRAIT_INCAPACITATED || TRAIT_FLOORED)) || user.stat || buckled_mob || M.buckled || !isturf(user.loc))
 		return
 
 	if (isxeno(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -277,10 +277,10 @@
 
 //trying to buckle a mob
 /obj/proc/buckle_mob(mob/M, mob/user)
-	if (!ismob(M) || (get_dist(src, user) > 1) || user.is_mob_incapacitated() || user.stat || buckled_mob || M.buckled || !isturf(user.loc))
+	if (!ismob(M) || (get_dist(src, user) > 1) || user.stat || buckled_mob || M.buckled || !isturf(user.loc))
 		return
 
-	if (HAS_TRAIT(user, TRAIT_IMMOBILIZED) || HAS_TRAIT(user, TRAIT_FLOORED))
+	if (user.is_mob_incapacitated() || HAS_TRAIT(user, TRAIT_IMMOBILIZED) || HAS_TRAIT(user, TRAIT_FLOORED))
 		to_chat(user, SPAN_WARNING("You can't do this right now."))
 		return
 
@@ -288,11 +288,6 @@
 		to_chat(user, SPAN_WARNING("You don't have the dexterity to do that, try a nest."))
 		return
 	if (iszombie(user))
-		return
-
-	// mobs that become immobilized should not be able to buckle themselves.
-	if(M == user && HAS_TRAIT(user, TRAIT_IMMOBILIZED))
-		to_chat(user, SPAN_WARNING("You are unable to do this in your current state."))
 		return
 
 	if(density)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -277,7 +277,7 @@
 
 //trying to buckle a mob
 /obj/proc/buckle_mob(mob/M, mob/user)
-	if (!ismob(M) || (get_dist(src, user) > 1) || user.is_mob_restrained() || user.stat || buckled_mob || M.buckled || !isturf(user.loc))
+	if (!ismob(M) || (get_dist(src, user) > 1) || user.is_mob_restrained() || HASTRAIT(src, (TRAIT_IMMOBILIZED || TRAIT_INCAPACITATED || TRAIT_FLOORED)) || user.stat || buckled_mob || M.buckled || !isturf(user.loc))
 		return
 
 	if (isxeno(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))


### PR DESCRIPTION

# About the pull request

adds checks to stop people from buckling others when they are knocked out etc.

# Explain why it's good for the game

fixes bug


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: stops people from buckling others when they are knocked out etc.
/:cl:
