### PR TITLE
More attack logs for choking and fence/window slamming

### DIFF
--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -153,6 +153,10 @@
 					M.apply_damage(20)
 					health -= 50
 
+			M.attack_log += text("\[[time_stamp()]\] <font color='orange'>was slammed against [src] by [key_name(user)]</font>")
+			user.attack_log += text("\[[time_stamp()]\] <font color='red'>slammed [key_name(M)] against [src]</font>")
+			msg_admin_attack("[key_name(user)] slammed [key_name(M)] against [src] at [get_area_name(M)]", M.loc.x, M.loc.y, M.loc.z)
+
 			healthcheck(1, 1, M) //The person thrown into the window literally shattered it
 		return
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -247,6 +247,10 @@
 					if(!not_damageable) //Impossible to destroy
 						health -= 50
 
+			M.attack_log += text("\[[time_stamp()]\] <font color='orange'>was slammed against [src] by [key_name(user)]</font>")
+			user.attack_log += text("\[[time_stamp()]\] <font color='red'>slammed [key_name(M)] against [src]</font>")
+			msg_admin_attack("[key_name(user)] slammed [key_name(M)] against [src] at [get_area_name(M)]", M.loc.x, M.loc.y, M.loc.z)
+
 			healthcheck(1, 1, 1, M) //The person thrown into the window literally shattered it
 		return
 

--- a/code/modules/mob/living/carbon/human/life/handle_grabbed.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_grabbed.dm
@@ -9,3 +9,7 @@
 	if(pulledby.grab_level >= GRAB_CHOKE)
 		apply_damage(3, OXY)
 		apply_stamina_damage(5)
+
+		log_attack("[key_name(pulledby)] choked [key_name(src)] at [get_area_name(src)]")
+		attack_log += text("\[[time_stamp()]\] <font color='orange'>was choked by [key_name(pulledby)]</font>")
+		pulledby.attack_log += text("\[[time_stamp()]\] <font color='red'>choked [key_name(src)]</font>")

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -97,8 +97,9 @@
 
 /obj/item/grab/proc/progress_aggressive(mob/living/carbon/human/user, mob/living/victim)
 	user.grab_level = GRAB_CHOKE
-	playsound(src.loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
+	playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
 	user.visible_message(SPAN_WARNING("[user] holds [victim] by the neck and starts choking them!"), null, null, 5)
+	msg_admin_attack("[key_name(user)] started to choke [key_name(victim)] at [get_area_name(victim)]", victim.loc.x, victim.loc.y, victim.loc.z)
 	victim.Move(user.loc, get_dir(victim.loc, user.loc))
 	victim.update_transform(TRUE)
 


### PR DESCRIPTION

# About the pull request

This PR simply adds more attack logging, namely for choking, window slams, and fence slams.

# Explain why it's good for the game

More tools for admins to investigate player actions.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/e78e7980-6fe9-4b94-b5dd-6e190e182854)

</details>


# Changelog
No player facing changes.
