### PR TITLE
changes circuit board name in vendor from auxiliar --> auxiliary power storage unit

### DIFF
--- a/code/game/machinery/vending/vendor_types/engineering.dm
+++ b/code/game/machinery/vending/vendor_types/engineering.dm
@@ -89,7 +89,7 @@
 		list("Supply Ordering Console", 2, /obj/item/circuitboard/computer/ordercomp, VENDOR_ITEM_REGULAR),
 		list("Research Data Terminal", 2, /obj/item/circuitboard/computer/research_terminal, VENDOR_ITEM_REGULAR),
 		list("P.A.C.M.A.N Generator", 1, /obj/item/circuitboard/machine/pacman, VENDOR_ITEM_REGULAR),
-		list("Auxiliar Power Storage Unit", 2, /obj/item/circuitboard/machine/ghettosmes, VENDOR_ITEM_REGULAR),
+		list("Auxiliary Power Storage Unit", 2, /obj/item/circuitboard/machine/ghettosmes, VENDOR_ITEM_REGULAR),
 		list("Air Alarm Electronics", 2, /obj/item/circuitboard/airalarm, VENDOR_ITEM_REGULAR),
 		list("Security Camera Monitor", 2, /obj/item/circuitboard/computer/cameras, VENDOR_ITEM_REGULAR),
 		list("Television Set", 4, /obj/item/circuitboard/computer/cameras/tv, VENDOR_ITEM_REGULAR),


### PR DESCRIPTION
# About the pull request

changes circuit board name in vendor from auxiliar --> auxiliary power storage unit

# Explain why it's good for the game

feels like it's missing the "y" at the end since the multi-part noun is "power storage unit" (or, basely, "unit"), and everything before it describes the unit, ie, is an adjective. so this just shifts auxiliar to adjective form.


# Testing Photographs and Procedure
tested.
so you can see it fits in the tgui button still:
![image](https://github.com/user-attachments/assets/edc7bfe6-492e-464b-ae7e-66cc9a54b09f)


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
spellcheck: Fixed spelling of auxiliary in the circuit board vendor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->