### PR TITLE
You can use russian warcry if you know russian

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -359,14 +359,15 @@
 	user.show_speech_bubble("warcry")
 
 /datum/emote/living/carbon/human/warcry/get_sound(mob/living/user)
+	var/default_lang = user.get_default_language()
 	if(ishumansynth_strict(user))
 		if(user.gender == MALE)
-			if(user.faction == FACTION_UPP)
+			if(default_lang == GLOB.all_languages[LANGUAGE_RUSSIAN])
 				return get_sfx("male_upp_warcry")
 			else
 				return get_sfx("male_warcry")
 		else
-			if(user.faction == FACTION_UPP)
+			if(default_lang == GLOB.all_languages[LANGUAGE_RUSSIAN])
 				return get_sfx("female_upp_warcry")
 			else
 				return get_sfx("female_warcry")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Warcry now checks for the current default language selected instead of faction, so knowing russian you can yell russian warcries, can probably be expanded to other languages later.

https://github.com/user-attachments/assets/0fd15eca-a0f8-42ed-ab70-0cf126d78d5d

Basically copypaste of chunk from this https://github.com/RU-CMSS13/RU-CMSS13/pull/225

# Explain why it's good for the game

It just logically makes sense, also solves cases where UPP survivors or UPP background roles couldn't use the proper warcries which was very awkward.



# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: russian warcries can be used if russian language is set on default
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
