### PR TITLE
adds distinct color to CLF and UPP special channels

### DIFF
--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -287,6 +287,17 @@ SUBSYSTEM_DEF(radio)
 		"[COLONY_FREQ]" = "deptradio",
 		"[BUG_A_FREQ]" = "airadio",
 		"[BUG_B_FREQ]" = "aiprivradio",
+		"[UPP_FREQ]" = "syndradio",
+		"[UPP_CMD_FREQ]" = "opforcmd",
+		"[UPP_ENGI_FREQ]" = "opforeng",
+		"[UPP_MED_FREQ]" = "opformed",
+		"[UPP_CCT_FREQ]" = "opforcct",
+		"[UPP_KDO_FREQ]" = "opforspe",
+		"[CLF_FREQ]" = "clfradio",
+		"[CLF_CMD_FREQ]" = "opforcmd",
+		"[CLF_ENGI_FREQ]" = "opforeng",
+		"[CLF_MED_FREQ]" = "opformed",
+		"[CLF_CCT_FREQ]" = "opforcct",
 	)
 
 /datum/controller/subsystem/radio/proc/add_object(obj/device as obj, new_frequency as num, filter = null as text|null)
@@ -359,10 +370,6 @@ SUBSYSTEM_DEF(radio)
 		return freq_span
 	if(frequency in PMC_FREQS)
 		return "pmcradio"
-	if(frequency in UPP_FREQS)
-		return "syndradio"
-	if(frequency in CLF_FREQS)
-		return "clfradio"
 	if(frequency in ERT_FREQS)
 		return "centradio"
 	if(frequency in DEPT_FREQS)

--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -272,7 +272,6 @@ SUBSYSTEM_DEF(radio)
 		"[VAI_FREQ]" = "vairadio",
 		"[RMC_FREQ]" = "rmcradio",
 		"[CMB_FREQ]" = "cmbradio",
-		"[CLF_FREQ]" = "clfradio",
 		"[ALPHA_FREQ]" = "alpharadio",
 		"[BRAVO_FREQ]" = "bravoradio",
 		"[CHARLIE_FREQ]" = "charlieradio",

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -1040,6 +1040,26 @@ em {
   color: #3eb489;
 }
 
+.opforcmd {
+  color: #68bcec;
+}
+
+.opformed {
+  color: #52c724;
+}
+
+.opforeng {
+  color: #e9812d;
+}
+
+.opforcct {
+  color: #ec3018;
+}
+
+.opforspe {
+  color: #7221cf;
+}
+
 .medium {
   font-size: 110%;
 }

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -1072,6 +1072,26 @@ h2.alert {
   color: #3a7e65;
 }
 
+.opforcmd {
+  color: #568dad;
+}
+
+.opformed {
+  color: #3e921d;
+}
+
+.opforeng {
+  color: #b16222;
+}
+
+.opforcct {
+  color: #c42b17;
+}
+
+.opforspe {
+  color: #611fad;
+}
+
 .medium {
   font-size: 110%;
 }

--- a/tgui/packages/tgui/constants.ts
+++ b/tgui/packages/tgui/constants.ts
@@ -149,27 +149,27 @@ export const RADIO_CHANNELS = [
   {
     name: 'UPP CMD',
     freq: 1252,
-    color: '#8f4a4b',
+    color: '#4a768f',
   },
   {
     name: 'UPP ENG',
     freq: 1253,
-    color: '#8f4a4b',
+    color: '#8c5223',
   },
   {
     name: 'UPP MED',
     freq: 1254,
-    color: '#8f4a4b',
+    color: '#159e73',
   },
   {
     name: 'UPP CCT',
     freq: 1255,
-    color: '#8f4a4b',
+    color: '#b3222e',
   },
   {
     name: 'UPP KDO',
     freq: 1259,
-    color: '#8f4a4b',
+    color: '#789e18',
   },
   {
     name: 'CLF',
@@ -179,22 +179,22 @@ export const RADIO_CHANNELS = [
   {
     name: 'CLF CMD',
     freq: 1272,
-    color: '#8e83ca',
+    color: '#4a768f',
   },
   {
     name: 'CLF ENG',
     freq: 1273,
-    color: '#8e83ca',
+    color: '#8c5223',
   },
   {
     name: 'CLF MED',
     freq: 1274,
-    color: '#8e83ca',
+    color: '#159e73',
   },
   {
     name: 'CLF CCT',
     freq: 1275,
-    color: '#8e83ca',
+    color: '#b3222e',
   },
   {
     name: 'LSTN BUG A',


### PR DESCRIPTION

# About the pull request

Gives the unique CLF and UPP department channels unique colors.

# Explain why it's good for the game

This will hopefully incentivize the use of these special channels by making them distinct and harder to tune out compared to the previous system of them being the exact same color.

# Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/044732ce-5606-4f13-b8b6-8a6f6aec8940)


# Changelog
:cl:
add: UPP and CLF department channels now have distinct chat colors
/:cl:
