### PR TITLE
Shrapnel smooth movement [WIP]

### DIFF
--- a/code/datums/ammo/shrapnel.dm
+++ b/code/datums/ammo/shrapnel.dm
@@ -122,16 +122,36 @@
 	name = "glass shrapnel"
 	icon_state = "shrapnel_glass"
 
-/datum/ammo/bullet/shrapnel/light/effect/ // no damage, but looks bright and neat
-	name = "sparks"
-
-	damage = 1 // Tickle tickle
-
-/datum/ammo/bullet/shrapnel/light/effect/ver1
-	icon_state = "shrapnel_bright1"
-
-/datum/ammo/bullet/shrapnel/light/effect/ver2
+/particles/shrapnel
+	icon = 'icons/obj/items/weapons/projectiles.dmi'
 	icon_state = "shrapnel_bright2"
+	width = 1000
+	height = 1000
+	count = 100
+	spawning = 0
+	lifespan = 0.6 SECONDS
+	fadein = 0.2 SECONDS
+	velocity = generator("square", 32 * 0.85, 32 * 1.15)
+	rotation = generator("num", 0, 359)
+
+/obj/shrapnel_effect
+	anchored = TRUE
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	unacidable = TRUE
+	blocks_emissive = EMISSIVE_BLOCK_GENERIC
+
+/obj/shrapnel_effect/New()
+	. = ..()
+	particles = new /particles/shrapnel
+	particles.spawning = rand(5,9) + rand(5,9)
+	addtimer(CALLBACK(src, PROC_REF(stop)), 0.1 SECONDS)
+	QDEL_IN(src, 0.9 SECONDS)
+
+/obj/shrapnel_effect/proc/stop()
+	particles.spawning = 0
+
+/obj/shrapnel_effect/get_applying_acid_time()
+	return -1
 
 /datum/ammo/bullet/shrapnel/jagged
 	shrapnel_chance = SHRAPNEL_CHANCE_TIER_2

--- a/code/datums/autocells/explosion.dm
+++ b/code/datums/autocells/explosion.dm
@@ -295,8 +295,7 @@ as having entered the turf.
 
 	if(power >= 100) // powerful explosions send out some special effects
 		epicenter = get_turf(epicenter) // the ex_acts might have changed the epicenter
-		create_shrapnel(epicenter, rand(5,9), , ,/datum/ammo/bullet/shrapnel/light/effect/ver1, explosion_cause_data)
-		create_shrapnel(epicenter, rand(5,9), , ,/datum/ammo/bullet/shrapnel/light/effect/ver2, explosion_cause_data)
+		new /obj/shrapnel_effect(epicenter)
 
 /proc/log_explosion(atom/A, datum/automata_cell/explosion/E)
 	if(isliving(A))

--- a/code/game/objects/explosion_recursive.dm
+++ b/code/game/objects/explosion_recursive.dm
@@ -86,9 +86,7 @@ explosion resistance exactly as much as their health
 
 	if(power >= 100) // powerful explosions send out some special effects
 		epicenter = get_turf(epicenter) // the ex_acts might have changed the epicenter
-		create_shrapnel(epicenter, rand(5,9), , ,/datum/ammo/bullet/shrapnel/light/effect/ver1, explosion_cause_data)
-		sleep(1)
-		create_shrapnel(epicenter, rand(5,9), , ,/datum/ammo/bullet/shrapnel/light/effect/ver2, explosion_cause_data)
+		new /obj/shrapnel_effect(epicenter)
 
 	spawn(2) //just in case something goes wrong
 		if(explosion_in_progress)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -304,14 +304,10 @@
 
 	//Change the bullet angle to its visual path
 
-	var/mutable_appearance/new_appearance = new(appearance)
-	new_appearance.invisibility = invisibility
-	new_appearance.plane = plane
-
 	var/vis_angle = delta_to_angle(pixel_x_target - pixel_x_source, pixel_y_target - pixel_y_source)
 	var/matrix/rotate = matrix()
 	rotate.Turn(vis_angle)
-	new_appearance.transform = rotate
+	apply_transform(rotate)
 
 	//Determine apparent position along visual path, then lerp between start and end positions
 
@@ -330,22 +326,19 @@
 
 	//Set pixel offset as from current loc to old position, so it appears to start in the old position
 
-	new_appearance.pixel_x = (start_turf.x - current_turf.x) * world.icon_size + start_pixel_x
-	new_appearance.pixel_y = (start_turf.y - current_turf.y) * world.icon_size + start_pixel_y
+	pixel_x = (start_turf.x - current_turf.x) * world.icon_size + start_pixel_x
+	pixel_y = (start_turf.y - current_turf.y) * world.icon_size + start_pixel_y
+
+	//Determine apparent distance travelled, then lerp for projectile fade-in
+
+	var/dist_current = distance_travelled + speed * (time_carry * 0.1) //speed * (time_carry * 0.1) for remainder time fade-in
+	var/alpha_interpolant = dist_current - 1 //-1 so it transitions from transparent to opaque between dist 1-2
+	var/alpha_new = LERP(0, 255, alpha_interpolant)
 
 	//Animate the visuals from starting position to new position
 
-	appearance = new_appearance
-
 	var/anim_time = delta_time * 0.1
-	if(alpha < 255) //Determine apparent distance travelled, then lerp for projectile fade-in
-		var/dist_current = distance_travelled + speed * (time_carry * 0.1) //speed * (time_carry * 0.1) for remainder time fade-in
-		var/alpha_interpolant = dist_current - 1 //-1 so it transitions from transparent to opaque between dist 1-2
-		var/alpha_new = LERP(0, 255, alpha_interpolant)
-
-		animate(src, pixel_x = pixel_x_rel_new, pixel_y = pixel_y_rel_new, alpha = alpha_new, time = anim_time, flags = ANIMATION_END_NOW)
-	else
-		animate(src, pixel_x = pixel_x_rel_new, pixel_y = pixel_y_rel_new, time = anim_time, flags = ANIMATION_END_NOW)
+	animate(src, pixel_x = pixel_x_rel_new, pixel_y = pixel_y_rel_new, alpha = alpha_new, time = anim_time, flags = ANIMATION_END_NOW)
 
 /// Flies the projectile forward one single turf
 /obj/projectile/proc/fly()

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -304,10 +304,14 @@
 
 	//Change the bullet angle to its visual path
 
+	var/mutable_appearance/new_appearance = new(appearance)
+	new_appearance.invisibility = invisibility
+	new_appearance.plane = plane
+
 	var/vis_angle = delta_to_angle(pixel_x_target - pixel_x_source, pixel_y_target - pixel_y_source)
 	var/matrix/rotate = matrix()
 	rotate.Turn(vis_angle)
-	apply_transform(rotate)
+	new_appearance.transform = rotate
 
 	//Determine apparent position along visual path, then lerp between start and end positions
 
@@ -326,25 +330,22 @@
 
 	//Set pixel offset as from current loc to old position, so it appears to start in the old position
 
-	pixel_x = (start_turf.x - current_turf.x) * world.icon_size + start_pixel_x
-	pixel_y = (start_turf.y - current_turf.y) * world.icon_size + start_pixel_y
-
-	//Determine apparent distance travelled, then lerp for projectile fade-in
-
-	var/dist_current = distance_travelled + speed * (time_carry * 0.1) //speed * (time_carry * 0.1) for remainder time fade-in
-	var/alpha_interpolant = dist_current - 1 //-1 so it transitions from transparent to opaque between dist 1-2
-	var/alpha_new = LERP(0, 255, alpha_interpolant)
+	new_appearance.pixel_x = (start_turf.x - current_turf.x) * world.icon_size + start_pixel_x
+	new_appearance.pixel_y = (start_turf.y - current_turf.y) * world.icon_size + start_pixel_y
 
 	//Animate the visuals from starting position to new position
 
-	if(projectile_flags & PROJECTILE_SHRAPNEL) //there can be a LOT of shrapnel especially from a cluster OB, not important enough for the expense of an animate()
-		alpha = alpha_new
-		pixel_x = pixel_x_rel_new
-		pixel_y = pixel_y_rel_new
-		return
+	appearance = new_appearance
 
 	var/anim_time = delta_time * 0.1
-	animate(src, pixel_x = pixel_x_rel_new, pixel_y = pixel_y_rel_new, alpha = alpha_new, time = anim_time, flags = ANIMATION_END_NOW)
+	if(alpha < 255) //Determine apparent distance travelled, then lerp for projectile fade-in
+		var/dist_current = distance_travelled + speed * (time_carry * 0.1) //speed * (time_carry * 0.1) for remainder time fade-in
+		var/alpha_interpolant = dist_current - 1 //-1 so it transitions from transparent to opaque between dist 1-2
+		var/alpha_new = LERP(0, 255, alpha_interpolant)
+
+		animate(src, pixel_x = pixel_x_rel_new, pixel_y = pixel_y_rel_new, alpha = alpha_new, time = anim_time, flags = ANIMATION_END_NOW)
+	else
+		animate(src, pixel_x = pixel_x_rel_new, pixel_y = pixel_y_rel_new, time = anim_time, flags = ANIMATION_END_NOW)
 
 /// Flies the projectile forward one single turf
 /obj/projectile/proc/fly()


### PR DESCRIPTION
# About the pull request

Shrapnel movement is now smoothed by an `animate()`.

This is a follow on from https://github.com/cmss13-devs/cmss13/pull/4986 , attempting to resolve the performance issue that forced shrapnel to be excluded: https://github.com/cmss13-devs/cmss13/pull/4986#issuecomment-1827089416

Replaced the visual-effect-only shrapnel `/datum/ammo/bullet/shrapnel/light/effect` with a particle system that imitates their look. The two main differences are the particles don't collide with anything and all are using the "sparks" icon instead of the "tracer" icon because the tracer has a clear direction to it and particles can't easily coordinate angle and facing.

tracer on left, sparks on right
![image](https://github.com/user-attachments/assets/c1aea971-6f75-40b8-b34e-985bd57e27af)

TM yes, full merge no. The current particles implementation is single-purpose for testing. Assuming all works well and its not causing client performance issues, will bring in a more robust solution such as in TGMC.

Surely using a purely visual effect is less taxing than using full-up objects. Surely BYOND is sensible in that regard.

Right?

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Smoother apparent movement for shrapnel gives a more appealing look.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Server memory stats and average client render.

baseline:
```
Server mem usage:
prototypes:
	obj: 3.75 MB (19,601)
	mob: 2.08 KB (133)
	proc: 15.3 MB (31,429)
	str: 9.86 MB (163,347)
	appearance: 180 KB (4,807)
	filter: 16.4 KB (7)
	id array: 38.6 MB (76,961)
	map: 6.37 MB (100,150,5)
objects:
	mobs: 5.59 KB (5)
	objs: 2.7 MB (8,520)
	datums: 3.39 MB (29,822)
	images: 2.62 MB (11,562)
	lists: 13 MB (86,256)
	procs: 7.18 KB (23)
```
![image](https://github.com/user-attachments/assets/21e78b1c-1dcb-4181-8b1e-4385498465fd)

after cluster OB, current master:
```
Server mem usage:
prototypes:
	obj: 3.75 MB (19,601)
	mob: 2.08 KB (133)
	proc: 15.3 MB (31,429)
	str: 9.88 MB (163,347)
	appearance: 295 KB (9,027)
	filter: 16.4 KB (7)
	id array: 38.6 MB (81,772)
	map: 6.53 MB (100,150,5)
objects:
	mobs: 5.59 KB (5)
	objs: 7.75 MB (17,446)
	datums: 4.08 MB (32,403)
	images: 2.63 MB (11,601)
	lists: 13.5 MB (95,057)
	procs: 6.89 KB (22)
```
![image](https://github.com/user-attachments/assets/840ba919-84bf-4d7a-9732-43c6a996b8ac)

after cluster OB, initial commit:
```
Server mem usage:
prototypes:
	obj: 3.75 MB (19,601)
	mob: 2.08 KB (133)
	proc: 15.3 MB (31,429)
	str: 9.88 MB (163,348)
	appearance: 1.34 MB (43,820)
	filter: 16.4 KB (7)
	id array: 38.6 MB (76,960)
	map: 6.53 MB (100,150,5)
objects:
	mobs: 5.59 KB (5)
	objs: 7.95 MB (17,524)
	datums: 3.54 MB (30,401)
	images: 2.63 MB (11,599)
	lists: 13.5 MB (95,167)
	procs: 6.89 KB (22)
```
![image](https://github.com/user-attachments/assets/00016b04-47b5-47f2-8be6-1a7295fb6cf4)

after cluster OB, particles experiment commit:
```
Server mem usage:
prototypes:
	obj: 3.75 MB (19,589)
	mob: 2.08 KB (133)
	proc: 15.2 MB (31,190)
	str: 9.87 MB (163,299)
	appearance: 209 KB (6,457)
	filter: 16.4 KB (7)
	id array: 38.3 MB (76,816)
	map: 6.53 MB (100,150,5)
objects:
	mobs: 5.59 KB (5)
	objs: 5.88 MB (15,559)
	datums: 3.56 MB (30,860)
	images: 2.62 MB (11,571)
	lists: 13.3 MB (92,035)
	procs: 6.89 KB (22)
```
![image](https://github.com/user-attachments/assets/cdc95284-59b0-445a-abb0-09b32a69864f)

On master gains about 120KB in appearances.
On initial commit gains about 1.2MB in appearances. Unsure why. Maybe the `mutable_appearances` count and aren't being discarded?
On particles experiment commit gains about 40KB in appearances. Presumably the reduction is due to the client handling generating some of those appearances instead.

No significant difference on average render times for baseline, master, or initial commit.
Particles cause a moderate render time increase for particles experiment commit during a cluster OB.

</details>

Works without issue on my local machine. Unable to test at appropriate scale. One TM and one cluster OB should give a definitive answer.


# Changelog
:cl:
code: shrapnel smoothly animates their movement
code: visual-effect-only shrapnel replaced by clientside particles
/:cl:
