### PR TITLE
Removes grab and throw animation + sound

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -388,13 +388,9 @@
 			if(!do_after(src, 1 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
 				to_chat(src, SPAN_WARNING("You need to set up the high toss!"))
 				return
-			animation_attack_on(target)
-			playsound(src, 'sound/weapons/punchmiss.ogg', 25, 1, 7)
 			drop_inv_item_on_ground(I, TRUE)
 			thrown_thing.throw_atom(target, thrown_thing.throw_range, SPEED_SLOW, src, spin_throw, HIGH_LAUNCH)
 		else
-			animation_attack_on(target)
-			playsound(src, 'sound/weapons/punchmiss.ogg', 25, 1, 7)
 			drop_inv_item_on_ground(I, TRUE)
 			thrown_thing.throw_atom(target, thrown_thing.throw_range, thrown_thing.throw_speed, src, spin_throw)
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -471,9 +471,6 @@
 			return
 	else if(istype(AM, /obj))
 		AM.add_fingerprint(src)
-		animation_attack_on(AM)
-		playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
-		flick_attack_overlay(AM, "grab")
 
 	if(!QDELETED(AM.pulledby) && !QDELETED(M))
 		visible_message(SPAN_WARNING("[src] has broken [AM.pulledby]'s grip on [M]!"), null, null, 5)
@@ -537,7 +534,6 @@
 		msg_admin_attack("[key_name(src)] grabbed [key_name(M)] in [get_area(src)] ([src.loc.x],[src.loc.y],[src.loc.z]).", src.loc.x, src.loc.y, src.loc.z)
 
 		if(!no_msg)
-			animation_attack_on(M)
 			visible_message(SPAN_WARNING("[src] has grabbed [M] passively!"), null, null, 5)
 
 		if(M.mob_size > MOB_SIZE_HUMAN || !(M.status_flags & CANPUSH))


### PR DESCRIPTION

# About the pull request

Removes small animation and sound when throwing things.

Grabbing items will no longer have the sound and grab visual effect identical to the one when grabbing mobs.

Grabbing items and mobs will no longer have a small animation.

# Explain why it's good for the game

The "new" sounds and animations look bad and are irritating. The audiovisual clutter and random sounds when you're just equipping yourself in prep room do not improve immersion and serve no point. The "disarm" sound on throw makes you think that someone is fighting, when in reality John Private has just thrown an ointment from his first aid pouch in the prep room.



# Changelog
:cl:
del: Removed item grabbing/throwing mob animations and sounds.
/:cl:
