### PR TITLE
Containers can be dumped into seed extractor

### DIFF
--- a/code/game/machinery/seed_extractor.dm
+++ b/code/game/machinery/seed_extractor.dm
@@ -6,32 +6,61 @@
 	density = TRUE
 	anchored = TRUE
 
-/obj/structure/machinery/seed_extractor/attackby(obj/item/O as obj, mob/user as mob)
+/obj/structure/machinery/seed_extractor/attackby(obj/item/object as obj, mob/user as mob)
 
+		// Plant bag and other storage containers.
+	if(istype(object,/obj/item/storage))
+		var/obj/item/storage/container = object
+		if(length(container.contents) == 0)
+			to_chat(user, SPAN_NOTICE("[container] is empty."))
+			return
+
+		to_chat(user, SPAN_NOTICE("You start dumping the contents of [container] into [src]."))
+		if(!do_after(user, 1.5 SECONDS, INTERRUPT_ALL, BUSY_ICON_GENERIC))
+			return
+
+		for(var/obj/item/item as anything in container)
+			if(extract(item, user))
+				// Bandaid to update the container contents and delete "ghosts" of items after they're been processed
+				container.remove_from_storage(item)
+				item.moveToNullspace()
+
+		playsound(user.loc, "rustle", 15, 1, 6)
+	else
+		extract(object, user)
+
+
+
+/obj/structure/machinery/seed_extractor/proc/extract(obj/item/object as obj, mob/user as mob)
 	// Fruits and vegetables.
-	if(istype(O, /obj/item/reagent_container/food/snacks/grown) || istype(O, /obj/item/grown))
-		if(user.temp_drop_inv_item(O))
+	if(istype(object, /obj/item/reagent_container/food/snacks/grown) || istype(object, /obj/item/grown))
+		if(user.temp_drop_inv_item(object))
 			var/datum/seed/new_seed_type
-			if(istype(O, /obj/item/grown))
-				var/obj/item/grown/F = O
-				new_seed_type = GLOB.seed_types[F.plantname]
+			if(istype(object, /obj/item/grown))
+				var/obj/item/grown/plant = object
+				new_seed_type = GLOB.seed_types[plant.plantname]
 			else
-				var/obj/item/reagent_container/food/snacks/grown/F = O
-				new_seed_type = GLOB.seed_types[F.plantname]
+				var/obj/item/reagent_container/food/snacks/grown/plant = object
+				new_seed_type = GLOB.seed_types[plant.plantname]
 
 			if(new_seed_type)
-				to_chat(user, SPAN_NOTICE("You extract some seeds from [O]."))
+				to_chat(user, SPAN_NOTICE("You extract some seeds from [object]."))
 				var/produce = rand(1,4)
 				for(var/i = 0;i<=produce;i++)
 					var/obj/item/seeds/seeds = new(get_turf(src))
 					seeds.seed_type = new_seed_type.name
 					seeds.update_seed()
 			else
-				to_chat(user, "[O] doesn't seem to have any usable seeds inside it.")
-			qdel(O)
+				to_chat(user, "[object] doesn't seem to have any usable seeds inside it.")
+			qdel(object)
+			return TRUE
 	//Grass.
-	else if(istype(O, /obj/item/stack/tile/grass))
-		var/obj/item/stack/tile/grass/S = O
-		if (S.use(1))
+	else if(istype(object, /obj/item/stack/tile/grass))
+		var/obj/item/stack/tile/grass/grass = object
+		if (grass.use(1))
 			to_chat(user, SPAN_NOTICE("You extract some seeds from the grass tile."))
 			new /obj/item/seeds/grassseed(loc)
+			return TRUE
+	else
+		to_chat(user, SPAN_WARNING("Cannot get seeds from [object]."))
+		return FALSE

--- a/code/game/machinery/seed_extractor.dm
+++ b/code/game/machinery/seed_extractor.dm
@@ -21,7 +21,7 @@
 
 		for(var/obj/item/item as anything in container)
 			if(extract(item, user))
-				// Bandaid to update the container contents and delete "ghosts" of items after they're been processed
+				// Properly deletes container contents after they've been processed
 				container.remove_from_storage(item)
 				item.moveToNullspace()
 


### PR DESCRIPTION
# About the pull request

Allows you to dump storage containers into the seed extractor and cleans up the file as a whole.

# Explain why it's good for the game

Some nice QOL so you don't have to individually place in 40 different plants one by one into the seed extractor.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

https://streamable.com/6ter1w

</details>


# Changelog
:cl: Asmocard
qol: Can now dump containers into the seed extractor
/:cl: