### PR TITLE
Fixes the lockdown button working after dropship being locked by Queen

### DIFF
--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -61,7 +61,8 @@
 	var/obj/docking_port/mobile/marine_dropship/shuttle = SSshuttle.getShuttle(ship_id)
 	if (!istype(shuttle))
 		return
-	if(shuttle.dropship_control_lost)
+	var/obj/structure/machinery/computer/shuttle/dropship/flight/comp = shuttle.getControlConsole()
+	if(comp?.dropship_control_lost)
 		return
 	if(is_mainship_level(z)) // on the almayer
 		return

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -61,6 +61,8 @@
 	var/obj/docking_port/mobile/marine_dropship/shuttle = SSshuttle.getShuttle(ship_id)
 	if (!istype(shuttle))
 		return
+	if(shuttle.dropship_control_lost)
+		return
 	if(is_mainship_level(z)) // on the almayer
 		return
 


### PR DESCRIPTION

# About the pull request
Fixes the lockdown button working after dropship being locked by Queen

# Explain why it's good for the game
Bug bad

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: ihatethisengine2
fix: fixed the lockdown button working after dropship being locked by Queen
/:cl:
