### PR TITLE
Replaces armor break with effective range in weapon stats

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -622,7 +622,6 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 	var/scatter = 0
 	var/list/damage_armor_profile_xeno = list()
 	var/list/damage_armor_profile_marine = list()
-	var/list/damage_armor_profile_armorbreak = list()
 	var/list/damage_armor_profile_headers = list()
 
 	var/datum/ammo/in_ammo
@@ -658,11 +657,6 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 			damage_armor_profile_headers.Add(i)
 			damage_armor_profile_marine.Add(floor(armor_damage_reduction(GLOB.marine_ranged_stats, damage, i, penetration)))
 			damage_armor_profile_xeno.Add(floor(armor_damage_reduction(GLOB.xeno_ranged_stats, damage, i, penetration)))
-			if(!GLOB.xeno_general.armor_ignore_integrity)
-				if(i != 0)
-					damage_armor_profile_armorbreak.Add("[floor(armor_break_calculation(GLOB.xeno_ranged_stats, damage, i, penetration, in_ammo.pen_armor_punch, armor_punch)/i)]%")
-				else
-					damage_armor_profile_armorbreak.Add("N/A")
 
 	var/rpm = max(fire_delay, 1)
 	var/burst_rpm = max((fire_delay * 1.5 + (burst_amount - 1) * burst_delay)/max(burst_amount, 1), 0.0001)
@@ -696,14 +690,15 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 	data["accuracy"] = accuracy * accuracy_mult
 	data["unwielded_accuracy"] = accuracy * accuracy_mult_unwielded
 	data["min_accuracy"] = min_accuracy
+	data["min_accuracy"] = min_accuracy
 	data["max_range"] = max_range
+	data["effective_range"] = ammo.effective_range_max
 
 	// damage table data
 
 	data["damage_armor_profile_headers"] = damage_armor_profile_headers
 	data["damage_armor_profile_marine"] = damage_armor_profile_marine
 	data["damage_armor_profile_xeno"] = damage_armor_profile_xeno
-	data["damage_armor_profile_armorbreak"] = damage_armor_profile_armorbreak
 
 	return data
 
@@ -718,10 +713,10 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 	data["damage_max"] = 100
 	data["accuracy_max"] = 32
 	data["range_max"] = 32
+	data["effective_range_max"] = EFFECTIVE_RANGE_MAX_TIER_4
 	data["falloff_max"] = DAMAGE_FALLOFF_TIER_1
 	data["penetration_max"] = ARMOR_PENETRATION_TIER_10
 	data["punch_max"] = 5
-	data["glob_armourbreak"] = GLOB.xeno_general.armor_ignore_integrity
 	data["automatic"] = (GUN_FIREMODE_AUTOMATIC in gun_firemode_list)
 	data["auto_only"] = ((length(gun_firemode_list) == 1) && (GUN_FIREMODE_AUTOMATIC in gun_firemode_list))
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -615,10 +615,10 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 		gun_recoil = recoil_buildup
 
 	var/penetration = 0
-	var/armor_punch = 0
 	var/accuracy = 0
 	var/min_accuracy = 0
 	var/max_range = 0
+	var/effective_range = 0
 	var/scatter = 0
 	var/list/damage_armor_profile_xeno = list()
 	var/list/damage_armor_profile_marine = list()
@@ -644,13 +644,13 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 		falloff = in_ammo.damage_falloff * damage_falloff_mult
 
 		penetration = in_ammo.penetration
-		armor_punch = in_ammo.damage_armor_punch
 
 		accuracy = in_ammo.accurate_range
 
 		min_accuracy = in_ammo.accurate_range_min
 
 		max_range = in_ammo.max_range
+		effective_range = in_ammo.effective_range_max
 		scatter = in_ammo.scatter
 
 		for(var/i = 0; i<=CODEX_ARMOR_MAX; i+=CODEX_ARMOR_STEP)
@@ -685,14 +685,13 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 	data["damage"] = damage
 	data["falloff"] = falloff
 	data["total_projectile_amount"] = bonus_projectile_amount+1
-	data["armor_punch"] = armor_punch
 	data["penetration"] = penetration
 	data["accuracy"] = accuracy * accuracy_mult
 	data["unwielded_accuracy"] = accuracy * accuracy_mult_unwielded
 	data["min_accuracy"] = min_accuracy
 	data["min_accuracy"] = min_accuracy
 	data["max_range"] = max_range
-	data["effective_range"] = ammo.effective_range_max
+	data["effective_range"] = effective_range
 
 	// damage table data
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -689,7 +689,6 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 	data["accuracy"] = accuracy * accuracy_mult
 	data["unwielded_accuracy"] = accuracy * accuracy_mult_unwielded
 	data["min_accuracy"] = min_accuracy
-	data["min_accuracy"] = min_accuracy
 	data["max_range"] = max_range
 	data["effective_range"] = effective_range
 

--- a/tgui/packages/tgui/interfaces/WeaponStats.jsx
+++ b/tgui/packages/tgui/interfaces/WeaponStats.jsx
@@ -281,11 +281,25 @@ const Accuracy = (props) => {
 
 const Range = (props) => {
   const { data } = useBackend();
-  const { max_range, range_max, falloff, falloff_max } = data;
+  const {
+    max_range,
+    range_max,
+    falloff,
+    falloff_max,
+    effective_range,
+    effective_range_max,
+  } = data;
   return (
     <>
       <ProgressBar value={max_range / range_max} ranges={RedGreenRange}>
         Max range: {max_range} / {range_max}
+      </ProgressBar>
+      <Box height="5px" />
+      <ProgressBar
+        value={effective_range / effective_range_max}
+        ranges={RedGreenRange}
+      >
+        Effective range: {effective_range}
       </ProgressBar>
       <Box height="5px" />
       <ProgressBar value={falloff / falloff_max} ranges={GreedRedRange}>
@@ -298,16 +312,13 @@ const Range = (props) => {
 
 const ArmourPen = (props) => {
   const { data } = useBackend();
-  const { penetration, penetration_max, armor_punch, punch_max } = data;
+  const { penetration, penetration_max } = data;
   return (
     <>
       <ProgressBar value={penetration / penetration_max} ranges={RedGreenRange}>
         Armour penetration: {penetration} / {penetration_max}
       </ProgressBar>
       <Box height="5px" />
-      <ProgressBar value={armor_punch / punch_max} ranges={RedGreenRange}>
-        Armour punch: {armor_punch} / {punch_max}
-      </ProgressBar>
     </>
   );
 };
@@ -317,9 +328,7 @@ const DamageTable = (props) => {
   const {
     damage_armor_profile_marine,
     damage_armor_profile_xeno,
-    damage_armor_profile_armorbreak,
     damage_armor_profile_headers,
-    glob_armourbreak,
   } = data;
   return (
     <Section title="Damage table">
@@ -346,14 +355,6 @@ const DamageTable = (props) => {
             <Table.Cell key={i}>{entry}</Table.Cell>
           ))}
         </Table.Row>
-        {!glob_armourbreak ? (
-          <Table.Row>
-            <Table.Cell textAlign="left">Armor break</Table.Cell>
-            {map(damage_armor_profile_armorbreak, (entry, i) => (
-              <Table.Cell key={i}>{entry}</Table.Cell>
-            ))}
-          </Table.Row>
-        ) : null}
       </Table>
     </Section>
   );


### PR DESCRIPTION

# About the pull request

replaces the armor break stat in the weapons stats screen with effective range

# Explain why it's good for the game

armor break has not been in the normal gameplay loop for ages. it just serves as a decorative progress bar in its current state. effective range is something that is much more integral for marines to know.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
it compiled and i didn't get any runtimes when lightly testing it

![wepaon stats](https://github.com/user-attachments/assets/553ca9c4-d1f4-4c11-abfc-d2a511e558de)



</details>


# Changelog
:cl:
add: The weapon stats screen now shows the effective range of ammo, instead of its armor punch value.
/:cl:
