### PR TITLE
Medical scans will now show heartbroken status

### DIFF
--- a/code/datums/mob_hud.dm
+++ b/code/datums/mob_hud.dm
@@ -475,7 +475,7 @@ GLOBAL_LIST_INIT_TYPED(huds, /datum/mob_hud, list(
 						holder3.icon_state = "huddead"
 						holder2_set = 1
 			else
-				if(heart && (heart.organ_status >= ORGAN_BROKEN && check_tod())) // broken heart icon
+				if(heart && (heart.organ_status >= ORGAN_BROKEN && check_tod() && is_revivable(ignore_heart = TRUE))) // broken heart icon
 					holder.icon_state = "huddeadheart"
 					if(!holder2_set)
 						holder2.icon_state = "huddeadheart"
@@ -784,7 +784,7 @@ GLOBAL_DATUM(hud_icon_hudfocus, /image)
 // Vampire Execute HUD
 /mob/living/carbon/human/proc/update_execute_hud()
 	var/image/execute_holder = hud_list[XENO_EXECUTE]
-	
+
 	execute_holder.icon_state = "hudblank"
 	execute_holder.overlays.Cut()
 

--- a/code/datums/mob_hud.dm
+++ b/code/datums/mob_hud.dm
@@ -475,7 +475,7 @@ GLOBAL_LIST_INIT_TYPED(huds, /datum/mob_hud, list(
 						holder3.icon_state = "huddead"
 						holder2_set = 1
 			else
-				if(heart && (heart.organ_status >= ORGAN_BROKEN && check_tod() && is_revivable(ignore_heart = TRUE))) // broken heart icon
+				if(is_heart_broken()) // broken heart icon
 					holder.icon_state = "huddeadheart"
 					if(!holder2_set)
 						holder2.icon_state = "huddeadheart"

--- a/code/game/objects/items/devices/defibrillator.dm
+++ b/code/game/objects/items/devices/defibrillator.dm
@@ -108,13 +108,13 @@
 			if(ghost && (!check_client || ghost.client) && (!check_can_reenter || ghost.can_reenter_corpse))
 				return ghost
 
-/mob/living/carbon/human/proc/is_revivable()
+/mob/living/carbon/human/proc/is_revivable(ignore_heart = FALSE)
 	if(isnull(internal_organs_by_name) || isnull(internal_organs_by_name["heart"]))
 		return FALSE
 	var/datum/internal_organ/heart/heart = internal_organs_by_name["heart"]
 	var/obj/limb/head = get_limb("head")
 
-	if(chestburst || !head || head.status & LIMB_DESTROYED || !heart || heart.organ_status >= ORGAN_BROKEN || !has_brain() || status_flags & PERMANENTLY_DEAD)
+	if(chestburst || !head || head.status & LIMB_DESTROYED || !ignore_heart && (!heart || heart.organ_status >= ORGAN_BROKEN) || !has_brain() || status_flags & PERMANENTLY_DEAD)
 		return FALSE
 	return TRUE
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -943,6 +943,10 @@
 
 	..()
 
+/mob/living/carbon/human/proc/is_heart_broken()
+	var/datum/internal_organ/heart/heart = internal_organs_by_name["heart"]
+	return heart && heart.organ_status >= ORGAN_BROKEN
+
 /mob/living/carbon/human/proc/is_lung_ruptured()
 	var/datum/internal_organ/lungs/L = internal_organs_by_name["lungs"]
 	return L && L.organ_status >= ORGAN_BRUISED
@@ -953,7 +957,6 @@
 	if(L && !L.organ_status >= ORGAN_BRUISED)
 		src.custom_pain("You feel a stabbing pain in your chest!", 1)
 		L.damage = L.min_bruised_damage
-
 
 /mob/living/carbon/human/get_visible_implants(class = 0)
 	var/list/visible_objects = list()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -945,7 +945,7 @@
 
 /mob/living/carbon/human/proc/is_heart_broken()
 	var/datum/internal_organ/heart/heart = internal_organs_by_name["heart"]
-	return heart && heart.organ_status >= ORGAN_BROKEN
+	return heart && heart.organ_status >= ORGAN_BROKEN && check_tod()
 
 /mob/living/carbon/human/proc/is_lung_ruptured()
 	var/datum/internal_organ/lungs/L = internal_organs_by_name["lungs"]

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -943,9 +943,10 @@
 
 	..()
 
+/// Returns whether this person has a broken heart but is otherwise revivable
 /mob/living/carbon/human/proc/is_heart_broken()
 	var/datum/internal_organ/heart/heart = internal_organs_by_name["heart"]
-	return heart && heart.organ_status >= ORGAN_BROKEN && check_tod()
+	return heart && heart.organ_status >= ORGAN_BROKEN && check_tod() && is_revivable(ignore_heart = TRUE)
 
 /mob/living/carbon/human/proc/is_lung_ruptured()
 	var/datum/internal_organ/lungs/L = internal_organs_by_name["lungs"]

--- a/code/modules/mob/living/living_healthscan.dm
+++ b/code/modules/mob/living/living_healthscan.dm
@@ -159,6 +159,7 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 
 		//snowflake :3
 		data["lung_ruptured"] = human_target_mob.is_lung_ruptured()
+		data["heart_broken"] = human_target_mob.is_heart_broken()
 
 		//shrapnel, limbs, limb damage, limb statflags, cyber limbs
 		var/core_fracture_detected = FALSE

--- a/tgui/packages/tgui/interfaces/HealthScan.jsx
+++ b/tgui/packages/tgui/interfaces/HealthScan.jsx
@@ -45,6 +45,7 @@ export const HealthScan = (props) => {
     hugged,
     detail_level,
     permadead,
+    heart_broken,
     advice,
     species,
     holocard,
@@ -115,9 +116,11 @@ export const HealthScan = (props) => {
               <LabeledList.Item label="Condition">
                 <Box color={permadead ? 'red' : 'green'} bold={1}>
                   {permadead
-                    ? 'Permanently deceased'
+                    ? heart_broken
+                      ? 'Myocardial rupture, surgical intervention required'
+                      : 'Permanently deceased'
                     : Synthetic
-                      ? 'Central power system shutdown, reboot possible.'
+                      ? 'Central power system shutdown, reboot possible'
                       : 'Cardiac arrest, defibrillation possible'}
                 </Box>
               </LabeledList.Item>


### PR DESCRIPTION
# About the pull request

heartbroken patients will now be shown as having a "mycardial rupture" instead of being marked as permadead
fixes #6743

# Explain why it's good for the game

medical players with low playtime might be confused by the current reading and could ignore recoverable marines on accident. this will help them figure out what the marine actually needs to get back up

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>


https://github.com/user-attachments/assets/509121cb-97fc-48d3-a129-f7bfdec06831



</details>


# Changelog
:cl:
fix: Health scans will now display the heartbroken status if applicable.
/:cl:
