### PR TITLE
Stops the queen from resting while on an ovipositor

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -361,6 +361,10 @@
 /mob/living/carbon/xenomorph/queen/can_destroy_special()
 	return TRUE
 
+/mob/living/carbon/xenomorph/queen/set_resting(new_resting, silent, instant)
+	if(ovipositor)
+		return
+	. = ..()
 
 /mob/living/carbon/xenomorph/queen/get_organ_icon()
 	return "heart_t3"

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -364,7 +364,7 @@
 /mob/living/carbon/xenomorph/queen/set_resting(new_resting, silent, instant)
 	if(ovipositor)
 		return
-	. = ..()
+	return ..()
 
 /mob/living/carbon/xenomorph/queen/get_organ_icon()
 	return "heart_t3"
@@ -813,10 +813,10 @@
 /mob/living/carbon/xenomorph/queen/proc/mount_ovipositor()
 	if(ovipositor)
 		return //sanity check
-	ovipositor = TRUE
 	ADD_TRAIT(src, TRAIT_IMMOBILIZED, OVIPOSITOR_TRAIT)
 	set_body_position(STANDING_UP)
 	set_resting(FALSE)
+	ovipositor = TRUE
 
 	set_resin_build_order(GLOB.resin_build_order_ovipositor) // This needs to occur before we update the abilities so we can update the choose resin icon
 	for(var/datum/action/xeno_action/action in actions)


### PR DESCRIPTION

# About the pull request

stops the queen from resting while on ovi.
Fixes #6685

# Explain why it's good for the game

it's a bug. you should not be able to rest on ovi as it doesn't make sense and only ends up making half of your abilities unusable.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

kinda hard to show this but here's me mashing the rest verb with my mouse

https://github.com/user-attachments/assets/103f3f0f-966b-4084-8888-b948fbc2bee0



</details>


# Changelog
:cl:
fix: You can no longer rest while on ovi as a Queen, which made half of your abilities unusable if you did so.
/:cl:
