### PR TITLE
Stops structures from being built on dense objects

### DIFF
--- a/code/game/objects/items/frames/table_rack.dm
+++ b/code/game/objects/items/frames/table_rack.dm
@@ -59,7 +59,10 @@
 	if(istype(get_area(loc), /area/shuttle))  //HANGAR/SHUTTLE BUILDING
 		to_chat(user, SPAN_WARNING("No. This area is needed for the dropship."))
 		return
-
+	for(var/obj/object in OT)
+		if(object.density)
+			to_chat(user, SPAN_WARNING("[object] is blocking you from constructing the table!"))
+			return
 	if(!do_after(user, 3 SECONDS, INTERRUPT_ALL, BUSY_ICON_BUILD))
 		to_chat(user, SPAN_WARNING("Hold still while you're constructing a table!"))
 		return

--- a/code/game/objects/items/frames/table_rack.dm
+++ b/code/game/objects/items/frames/table_rack.dm
@@ -61,7 +61,7 @@
 		return
 	for(var/obj/object in OT)
 		if(object.density)
-			to_chat(user, SPAN_WARNING("[object] is blocking you from constructing the table!"))
+			to_chat(user, SPAN_WARNING("[object] is blocking you from constructing [src]!"))
 			return
 	if(!do_after(user, 3 SECONDS, INTERRUPT_ALL, BUSY_ICON_BUILD))
 		to_chat(user, SPAN_WARNING("Hold still while you're constructing a table!"))

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -197,6 +197,12 @@ Also change the icon to reflect the amount of sheets, if possible.*/
 				to_chat(usr, SPAN_WARNING("The [R.title] cannot be constructed on a tunnel!"))
 				return
 
+			if(R.one_per_turf != ONE_TYPE_PER_BORDER) //all barricade-esque structures utilize this define and have their own check for object density. checking twice is unneeded.
+				for(var/obj/object in usr.loc)
+					if(object.density)
+						to_chat(usr, SPAN_WARNING("[object] is blocking you from constructing \the [R.title]."))
+						return
+
 		if((R.flags & RESULT_REQUIRES_SNOW) && !(istype(usr.loc, /turf/open/snow) || istype(usr.loc, /turf/open/auto_turf/snow)))
 			to_chat(usr, SPAN_WARNING("The [R.title] must be built on snow!"))
 			return

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -199,8 +199,8 @@ Also change the icon to reflect the amount of sheets, if possible.*/
 
 			if(R.one_per_turf != ONE_TYPE_PER_BORDER) //all barricade-esque structures utilize this define and have their own check for object density. checking twice is unneeded.
 				for(var/obj/object in usr.loc)
-					if(object.density)
-						to_chat(usr, SPAN_WARNING("[object] is blocking you from constructing \the [R.title]."))
+					if(object.density || istype(object, /obj/structure/machinery/door))
+						to_chat(usr, SPAN_WARNING("[object] is blocking you from constructing \the [R.title]!"))
 						return
 
 		if((R.flags & RESULT_REQUIRES_SNOW) && !(istype(usr.loc, /turf/open/snow) || istype(usr.loc, /turf/open/auto_turf/snow)))

--- a/code/game/objects/structures/airlock_assembly.dm
+++ b/code/game/objects/structures/airlock_assembly.dm
@@ -111,6 +111,11 @@
 		qdel(src)
 		return
 
+	for(var/obj/object in loc)
+		if(object.density && object != src)
+			to_chat(user, SPAN_WARNING("[object] is blocking you from interacting with [src]!"))
+			return
+
 	switch(state)
 		if(STATE_STANDARD)
 			if(HAS_TRAIT(attacking_item, TRAIT_TOOL_WRENCH))

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -110,6 +110,10 @@
 		if(!HAS_TRAIT(W, TRAIT_TOOL_BLOWTORCH))
 			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
 			return
+		for(var/obj/object in loc)
+			if(object.density)
+				to_chat(user, SPAN_WARNING("[object] is blocking you from welding [src] together!"))
+				return
 		if(do_after(user,30, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 			if(QDELETED(src))
 				return
@@ -334,7 +338,6 @@
 	else
 		dmg = floor(P.damage * 0.5)
 	if(dmg)
-		health -= dmg
 		take_damage(dmg)
 		bullet_ping(P)
 	if(health <= 0)
@@ -342,7 +345,9 @@
 	return TRUE
 
 /obj/structure/girder/proc/take_damage(damage)
-	health = max(health - damage, 0)
+	health -= damage
+	if(health <= -100)
+		qdel(src)
 	if(health <= 0)
 		update_state()
 
@@ -356,10 +361,11 @@
 	update_state()
 
 /obj/structure/girder/proc/update_state()
-	if (health <= 0)
+	if(health <= 0 && density)
 		icon_state = "[icon_state]_damaged"
 		density = FALSE
-	else
+
+	else if(health > 0 && !density)
 		var/underscore_position =  findtext(icon_state,"_")
 		var/new_state = copytext(icon_state, 1, underscore_position)
 		icon_state = new_state


### PR DESCRIPTION

# About the pull request

stops structures like girders, beds, chairs and tables from being able to be built on top of dense objects (like tables and window frames)
fixes #6436

# Explain why it's good for the game


![stop this](https://github.com/user-attachments/assets/a98e0d88-6f85-4e1c-acb4-d37251a6a3a6)

stops weird things like this from being able to be constructed.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

i tested it very lightly with some generic constructions and it seems to work fine

https://github.com/user-attachments/assets/76a790dd-4e2c-41b4-b11a-6193b13fb6cc


</details>


# Changelog
:cl:
fix: You can no longer build structures on top of dense objects. This prevents weird layering happening with walls and tables, window frames, etc.
/:cl:
