### PR TITLE
DO NOT MERGE DID BRANCHES WRONG Smoking in helmets cosmetic

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/staff_officer_armory.dm
+++ b/code/game/machinery/vending/vendor_types/crew/staff_officer_armory.dm
@@ -20,7 +20,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_staff_officer_armory, list(
 		list("Aviator Shades", 0, /obj/item/clothing/glasses/sunglasses/aviator, MARINE_CAN_BUY_GLASSES, VENDOR_ITEM_REGULAR),
 
 		list("SPECIALISATION KIT (CHOOSE 1)", 0, null, null, null),
-		list("Essential Engineer Set", 0, /obj/effect/essentials_set/engi/basic, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_RECOMMENDED),
+		list("Basic Engineer Set", 0, /obj/effect/essentials_set/engi/basic, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_RECOMMENDED),
 		list("Essential Medical Set", 0, /obj/effect/essentials_set/medic, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_RECOMMENDED),
 
 		list("BELT (CHOOSE 1)", 0, null, null, null),

--- a/code/game/machinery/vending/vendor_types/crew/staff_officer_armory.dm
+++ b/code/game/machinery/vending/vendor_types/crew/staff_officer_armory.dm
@@ -20,7 +20,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_staff_officer_armory, list(
 		list("Aviator Shades", 0, /obj/item/clothing/glasses/sunglasses/aviator, MARINE_CAN_BUY_GLASSES, VENDOR_ITEM_REGULAR),
 
 		list("SPECIALISATION KIT (CHOOSE 1)", 0, null, null, null),
-		list("Essential Engineer Set", 0, /obj/effect/essentials_set/engi, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_RECOMMENDED),
+		list("Essential Engineer Set", 0, /obj/effect/essentials_set/engi/basic, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_RECOMMENDED),
 		list("Essential Medical Set", 0, /obj/effect/essentials_set/medic, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_RECOMMENDED),
 
 		list("BELT (CHOOSE 1)", 0, null, null, null),

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_engineer.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_engineer.dm
@@ -3,10 +3,9 @@
 GLOBAL_LIST_INIT(cm_vending_gear_engi, list(
 		list("ENGINEER SET (MANDATORY)", 0, null, null, null),
 		list("Essential Engineer Set (Most Versatile)", 0, /obj/effect/essentials_set/engi/basic, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
-		list("FOB Construction Set (Most Metal)", 0, /obj/effect/essentials_set/engi/fob, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
-		list("FOB Defense Set (Extra Sentry, Little Metal)", 0, /obj/effect/essentials_set/engi/fob_defenses, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
-		list("Rapid Deployment Set (Fast Cades, Little Resiliance)", 0, /obj/effect/essentials_set/engi/rapid_deployment, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
-		list("Frontline Supply Set (Keep Your Team Supplied)", 0, /obj/effect/essentials_set/engi/frontline_supply, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("FOB Construction Set (Most Metal)", 25, /obj/effect/essentials_set/engi/fob, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("FOB Defense Set (Extra Sentry, Little Metal)", 40, /obj/effect/essentials_set/engi/fob_defenses, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("Rapid Repair Set (Best for Repairing Under Fire)", 0, /obj/effect/essentials_set/engi/rapid_repair, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
 		list("Demolitions Set (Equipped To Level The Place)", 0, /obj/effect/essentials_set/engi/demolitions, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
 
 		list("HANDHELD DEFENSE (CHOOSE 1)", 0, null, null, null),
@@ -206,55 +205,55 @@ GLOBAL_LIST_INIT(cm_vending_clothing_engi, list(
 
 //------------ESSENTIAL SETS---------------
 
-/obj/effect/essentials_set/engi/basic
+/obj/effect/essentials_set/engi/basic // 66~ points = Free to buy.
 	spawned_gear_list = list(
-		/obj/item/explosive/plastic,
-		/obj/item/stack/sandbags_empty = 25,
-		/obj/item/stack/sheet/metal/large_stack,
-		/obj/item/stack/sheet/plasteel/med_large_stack,
+		/obj/item/explosive/plastic, // 3
+		/obj/item/stack/sandbags_empty = 25, // 10
+		/obj/item/stack/sheet/metal/large_stack, // 25
+		/obj/item/stack/sheet/plasteel/med_large_stack, // 28
 		/obj/item/circuitboard/apc,
 		/obj/item/cell/high,
 		/obj/item/tool/shovel/etool/folded,
 		/obj/item/device/lightreplacer,
 	)
 
-/obj/effect/essentials_set/engi/fob
+/obj/effect/essentials_set/engi/fob // 91 points = 25 points to buy; 25 points more than basic.
 	spawned_gear_list = list(
-		/obj/item/stack/sheet/metal/large_stack,
-		/obj/item/stack/sheet/metal/large_stack,
-		/obj/item/stack/barbed_wire/full_stack,
-		/obj/item/stack/sheet/plasteel/med_large_stack,
+		/obj/item/device/encryptionkey/req, // 3
+		/obj/item/stack/sheet/metal/large_stack, // 25
+		/obj/item/stack/sheet/metal/large_stack, // 25
+		/obj/item/stack/barbed_wire/full_stack, // 10
+		/obj/item/stack/sheet/plasteel/med_large_stack, // 28
 		/obj/item/circuitboard/apc,
 		/obj/item/cell/high,
 		/obj/item/tool/shovel/etool/folded,
 		/obj/item/device/lightreplacer,
 	)
 
-/obj/effect/essentials_set/engi/fob_defenses
+/obj/effect/essentials_set/engi/fob_defenses // 80? 85 + turret = 40 points to buy. 14 points more + turret. 26 points turret? - want com techs to be able to get SOMETHING...
 	spawned_gear_list = list(
-		/obj/item/stack/sheet/metal/large_stack,
-		/obj/item/stack/barbed_wire/full_stack,
-		/obj/item/defenses/handheld/sentry,
-		/obj/item/storage/box/explosive_mines,
+		/obj/item/stack/sheet/metal/large_stack, // 25
+		/obj/item/stack/sheet/plasteel/med_small_stack = 24, //14... 16 points
+		/obj/item/stack/barbed_wire/full_stack, // 10
+		/obj/item/defenses/handheld/sentry, // unknown
+		/obj/item/storage/box/explosive_mines, // 18
+		/obj/item/storage/box/explosive_mines, // 18 - no one cares about mines anyway...
 		/obj/item/circuitboard/apc,
 		/obj/item/cell/high,
 		/obj/item/tool/shovel/etool/folded,
 		/obj/item/device/lightreplacer,
 	)
 
-/obj/effect/essentials_set/engi/rapid_deployment
+/obj/effect/essentials_set/engi/rapid_repair // 65?.. okay...  works for me! - only way to get nailgun AND new pouch. FREE!!
 	spawned_gear_list = list(
-		/obj/item/storage/pouch/folding_barricade,
-		/obj/item/storage/pouch/folding_barricade,
+		/obj/item/storage/pouch/folding_barricade, // new pouchy pouch
 		/obj/item/stack/folding_barricade/three,
 		/obj/item/stack/folding_barricade/three,
-		/obj/item/stack/folding_barricade/three,
-		/obj/item/stack/sandbags/large_stack,
-		/obj/item/stack/sandbags/large_stack,
-		/obj/item/stack/barbed_wire/full_stack,
-		/obj/item/explosive/grenade/metal_foam,
-		/obj/item/explosive/grenade/metal_foam,
-		/obj/item/explosive/grenade/metal_foam,
+		/obj/item/stack/sandbags/large_stack, // 10
+		/obj/item/stack/barbed_wire/full_stack, // 10
+		/obj/item/stack/sheet/metal/large_stack, // 5 * 5 = 25
+		/obj/item/explosive/grenade/metal_foam, // 5 points
+		/obj/item/weapon/gun/smg/nailgun/compact, // 15 points
 		/obj/item/circuitboard/apc,
 		/obj/item/cell/high,
 		/obj/item/tool/shovel/etool/folded,
@@ -262,25 +261,17 @@ GLOBAL_LIST_INIT(cm_vending_clothing_engi, list(
 		/obj/item/reagent_container/hypospray/autoinjector/emergency,
 	)
 
-/obj/effect/essentials_set/engi/frontline_supply
+/obj/effect/essentials_set/engi/demolitions // 49... 59 wit breachers... 69... nice. Free cuz 3 points more and... no one cares about the 6 points for Extinguisher and whistle otherwise it'd be 75 points, but c'mon...
 	spawned_gear_list = list(
-		/obj/item/stack/sheet/metal/large_stack,
-		/obj/item/stack/sheet/plasteel/small_stack = 16,
-		/obj/item/stack/barbed_wire/small_stack,
-		/obj/item/ammo_box/rounds,
-		/obj/item/circuitboard/apc,
-		/obj/item/cell/high,
-		/obj/item/tool/shovel/etool/folded,
-		/obj/item/device/lightreplacer,
-	)
-
-/obj/effect/essentials_set/engi/demolitions
-	spawned_gear_list = list(
-		/obj/item/explosive/plastic,
-		/obj/item/explosive/plastic,
-		/obj/item/storage/box/explosive_mines,
-		/obj/item/storage/box/packet/high_explosive,
-		/obj/item/stack/sheet/metal/large_stack,
+		/obj/item/explosive/plastic, // 3
+		/obj/item/explosive/plastic, // 3
+		/obj/item/explosive/plastic/breaching_charge, // 5
+		/obj/item/explosive/plastic/breaching_charge, // 5
+		/obj/item/storage/box/packet/high_explosive, // 18?
+		/obj/item/stack/sheet/metal/large_stack, // 25
+		/obj/item/tool/extinguisher/mini, // 3 ... cmon this is free basically anyway...
+		/obj/item/device/whistle, // 3 ... no one would ever buy this...
+		/obj/item/stack/sandbags_empty = 25, // 10 points ... fuck it, sandbags
 		/obj/item/circuitboard/apc,
 		/obj/item/cell/high,
 		/obj/item/tool/shovel/etool/folded,

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_engineer.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_engineer.dm
@@ -2,9 +2,9 @@
 
 GLOBAL_LIST_INIT(cm_vending_gear_engi, list(
 		list("ENGINEER SET (MANDATORY)", 0, null, null, null),
-		list("Essential Engineer Set (Most Versatile)", 0, /obj/effect/essentials_set/engi/basic, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("Basic Engineer Set (Most Versatile)", 0, /obj/effect/essentials_set/engi/basic, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
 		list("FOB Construction Set (Most Metal)", 25, /obj/effect/essentials_set/engi/fob, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
-		list("FOB Defense Set (Extra Sentry, Little Metal)", 40, /obj/effect/essentials_set/engi/fob_defenses, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("FOB Defense Set (Extra Sentry, Little Metal)", 35, /obj/effect/essentials_set/engi/fob_defenses, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
 		list("Rapid Repair Set (Best for Repairing Under Fire)", 0, /obj/effect/essentials_set/engi/rapid_repair, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
 		list("Demolitions Set (Equipped To Level The Place)", 0, /obj/effect/essentials_set/engi/demolitions, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
 
@@ -205,25 +205,25 @@ GLOBAL_LIST_INIT(cm_vending_clothing_engi, list(
 
 //------------ESSENTIAL SETS---------------
 
-/obj/effect/essentials_set/engi/basic // 66~ points = Free to buy.
+/obj/effect/essentials_set/engi/basic
 	spawned_gear_list = list(
-		/obj/item/explosive/plastic, // 3
-		/obj/item/stack/sandbags_empty = 25, // 10
-		/obj/item/stack/sheet/metal/large_stack, // 25
-		/obj/item/stack/sheet/plasteel/med_large_stack, // 28
+		/obj/item/explosive/plastic,
+		/obj/item/stack/sandbags_empty = 25,
+		/obj/item/stack/sheet/metal/large_stack,
+		/obj/item/stack/sheet/plasteel/med_large_stack,
 		/obj/item/circuitboard/apc,
 		/obj/item/cell/high,
 		/obj/item/tool/shovel/etool/folded,
 		/obj/item/device/lightreplacer,
 	)
 
-/obj/effect/essentials_set/engi/fob // 91 points = 25 points to buy; 25 points more than basic.
+/obj/effect/essentials_set/engi/fob
 	spawned_gear_list = list(
-		/obj/item/device/encryptionkey/req, // 3
-		/obj/item/stack/sheet/metal/large_stack, // 25
-		/obj/item/stack/sheet/metal/large_stack, // 25
-		/obj/item/stack/barbed_wire/full_stack, // 10
-		/obj/item/stack/sheet/plasteel/med_large_stack, // 28
+		/obj/item/device/encryptionkey/req,
+		/obj/item/stack/sheet/metal/large_stack,
+		/obj/item/stack/sheet/metal/large_stack,
+		/obj/item/stack/barbed_wire/full_stack,
+		/obj/item/stack/sheet/plasteel/med_large_stack,
 		/obj/item/circuitboard/apc,
 		/obj/item/cell/high,
 		/obj/item/tool/shovel/etool/folded,
@@ -244,34 +244,34 @@ GLOBAL_LIST_INIT(cm_vending_clothing_engi, list(
 		/obj/item/device/lightreplacer,
 	)
 
-/obj/effect/essentials_set/engi/rapid_repair // 65?.. okay...  works for me! - only way to get nailgun AND new pouch. FREE!!
+/obj/effect/essentials_set/engi/rapid_repair
 	spawned_gear_list = list(
-		/obj/item/storage/pouch/folding_barricade, // new pouchy pouch
+		/obj/item/storage/pouch/folding_barricade,
 		/obj/item/stack/folding_barricade/three,
 		/obj/item/stack/folding_barricade/three,
-		/obj/item/stack/sandbags/large_stack, // 10
-		/obj/item/stack/barbed_wire/full_stack, // 10
-		/obj/item/stack/sheet/metal/large_stack, // 5 * 5 = 25
-		/obj/item/explosive/grenade/metal_foam, // 5 points
-		/obj/item/weapon/gun/smg/nailgun/compact, // 15 points
+		/obj/item/stack/sandbags/large_stack,
+		/obj/item/stack/barbed_wire/full_stack,
+		/obj/item/stack/sheet/metal/large_stack,
+		/obj/item/explosive/grenade/metal_foam,
+		/obj/item/weapon/gun/smg/nailgun/compact,
 		/obj/item/circuitboard/apc,
 		/obj/item/cell/high,
 		/obj/item/tool/shovel/etool/folded,
 		/obj/item/device/lightreplacer,
-		/obj/item/reagent_container/hypospray/autoinjector/emergency,
+		// /obj/item/reagent_container/hypospray/autoinjector/emergency,
 	)
 
-/obj/effect/essentials_set/engi/demolitions // 49... 59 wit breachers... 69... nice. Free cuz 3 points more and... no one cares about the 6 points for Extinguisher and whistle otherwise it'd be 75 points, but c'mon...
+/obj/effect/essentials_set/engi/demolitions
 	spawned_gear_list = list(
-		/obj/item/explosive/plastic, // 3
-		/obj/item/explosive/plastic, // 3
-		/obj/item/explosive/plastic/breaching_charge, // 5
-		/obj/item/explosive/plastic/breaching_charge, // 5
-		/obj/item/storage/box/packet/high_explosive, // 18?
-		/obj/item/stack/sheet/metal/large_stack, // 25
-		/obj/item/tool/extinguisher/mini, // 3 ... cmon this is free basically anyway...
-		/obj/item/device/whistle, // 3 ... no one would ever buy this...
-		/obj/item/stack/sandbags_empty = 25, // 10 points ... fuck it, sandbags
+		/obj/item/explosive/plastic,
+		/obj/item/explosive/plastic,
+		/obj/item/explosive/plastic/breaching_charge,
+		/obj/item/explosive/plastic/breaching_charge,
+		/obj/item/storage/box/packet/high_explosive,
+		/obj/item/stack/sheet/metal/large_stack,
+		/obj/item/tool/extinguisher/mini,
+		/obj/item/device/whistle,
+		/obj/item/stack/sandbags_empty = 25,
 		/obj/item/circuitboard/apc,
 		/obj/item/cell/high,
 		/obj/item/tool/shovel/etool/folded,

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_engineer.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_engineer.dm
@@ -2,7 +2,12 @@
 
 GLOBAL_LIST_INIT(cm_vending_gear_engi, list(
 		list("ENGINEER SET (MANDATORY)", 0, null, null, null),
-		list("Essential Engineer Set", 0, /obj/effect/essentials_set/engi, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("Essential Engineer Set (Most Versatile)", 0, /obj/effect/essentials_set/engi/basic, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("FOB Construction Set (Most Metal)", 0, /obj/effect/essentials_set/engi/fob, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("FOB Defense Set (Extra Sentry, Little Metal)", 0, /obj/effect/essentials_set/engi/fob_defenses, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("Rapid Deployment Set (Fast Cades, Little Resiliance)", 0, /obj/effect/essentials_set/engi/rapid_deployment, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("Frontline Supply Set (Keep Your Team Supplied)", 0, /obj/effect/essentials_set/engi/frontline_supply, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("Demolitions Set (Equipped To Level The Place)", 0, /obj/effect/essentials_set/engi/demolitions, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
 
 		list("HANDHELD DEFENSE (CHOOSE 1)", 0, null, null, null),
 		list("21S Tesla Coil", 0, /obj/item/defenses/handheld/tesla_coil, MARINE_CAN_BUY_ATTACHMENT, VENDOR_ITEM_MANDATORY),
@@ -154,6 +159,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_engi, list(
 		list("Tools Pouch (Full)", 0, /obj/item/storage/pouch/tools/full, MARINE_CAN_BUY_POUCH, VENDOR_ITEM_REGULAR),
 
 		list("ACCESSORIES (CHOOSE 1)", 0, null, null, null),
+		list("Tool Webbing", 0, /obj/item/clothing/accessory/storage/tool_webbing/equipped, MARINE_CAN_BUY_ACCESSORY, VENDOR_ITEM_REGULAR),
 		list("Black Webbing Vest", 0, /obj/item/clothing/accessory/storage/black_vest, MARINE_CAN_BUY_ACCESSORY, VENDOR_ITEM_REGULAR),
 		list("Brown Webbing Vest", 0, /obj/item/clothing/accessory/storage/black_vest/brown_vest, MARINE_CAN_BUY_ACCESSORY, VENDOR_ITEM_RECOMMENDED),
 		list("Shoulder Holster", 0, /obj/item/clothing/accessory/storage/holster, MARINE_CAN_BUY_ACCESSORY, VENDOR_ITEM_REGULAR),
@@ -200,12 +206,81 @@ GLOBAL_LIST_INIT(cm_vending_clothing_engi, list(
 
 //------------ESSENTIAL SETS---------------
 
-/obj/effect/essentials_set/engi
+/obj/effect/essentials_set/engi/basic
 	spawned_gear_list = list(
 		/obj/item/explosive/plastic,
 		/obj/item/stack/sandbags_empty = 25,
 		/obj/item/stack/sheet/metal/large_stack,
 		/obj/item/stack/sheet/plasteel/med_large_stack,
+		/obj/item/circuitboard/apc,
+		/obj/item/cell/high,
+		/obj/item/tool/shovel/etool/folded,
+		/obj/item/device/lightreplacer,
+	)
+
+/obj/effect/essentials_set/engi/fob
+	spawned_gear_list = list(
+		/obj/item/stack/sheet/metal/large_stack,
+		/obj/item/stack/sheet/metal/large_stack,
+		/obj/item/stack/barbed_wire/full_stack,
+		/obj/item/stack/sheet/plasteel/med_large_stack,
+		/obj/item/circuitboard/apc,
+		/obj/item/cell/high,
+		/obj/item/tool/shovel/etool/folded,
+		/obj/item/device/lightreplacer,
+	)
+
+/obj/effect/essentials_set/engi/fob_defenses
+	spawned_gear_list = list(
+		/obj/item/stack/sheet/metal/large_stack,
+		/obj/item/stack/barbed_wire/full_stack,
+		/obj/item/defenses/handheld/sentry,
+		/obj/item/storage/box/explosive_mines,
+		/obj/item/circuitboard/apc,
+		/obj/item/cell/high,
+		/obj/item/tool/shovel/etool/folded,
+		/obj/item/device/lightreplacer,
+	)
+
+/obj/effect/essentials_set/engi/rapid_deployment
+	spawned_gear_list = list(
+		/obj/item/storage/pouch/folding_barricade,
+		/obj/item/storage/pouch/folding_barricade,
+		/obj/item/stack/folding_barricade/three,
+		/obj/item/stack/folding_barricade/three,
+		/obj/item/stack/folding_barricade/three,
+		/obj/item/stack/sandbags/large_stack,
+		/obj/item/stack/sandbags/large_stack,
+		/obj/item/stack/barbed_wire/full_stack,
+		/obj/item/explosive/grenade/metal_foam,
+		/obj/item/explosive/grenade/metal_foam,
+		/obj/item/explosive/grenade/metal_foam,
+		/obj/item/circuitboard/apc,
+		/obj/item/cell/high,
+		/obj/item/tool/shovel/etool/folded,
+		/obj/item/device/lightreplacer,
+		/obj/item/reagent_container/hypospray/autoinjector/emergency,
+	)
+
+/obj/effect/essentials_set/engi/frontline_supply
+	spawned_gear_list = list(
+		/obj/item/stack/sheet/metal/large_stack,
+		/obj/item/stack/sheet/plasteel/small_stack = 16,
+		/obj/item/stack/barbed_wire/small_stack,
+		/obj/item/ammo_box/rounds,
+		/obj/item/circuitboard/apc,
+		/obj/item/cell/high,
+		/obj/item/tool/shovel/etool/folded,
+		/obj/item/device/lightreplacer,
+	)
+
+/obj/effect/essentials_set/engi/demolitions
+	spawned_gear_list = list(
+		/obj/item/explosive/plastic,
+		/obj/item/explosive/plastic,
+		/obj/item/storage/box/explosive_mines,
+		/obj/item/storage/box/packet/high_explosive,
+		/obj/item/stack/sheet/metal/large_stack,
 		/obj/item/circuitboard/apc,
 		/obj/item/cell/high,
 		/obj/item/tool/shovel/etool/folded,

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -126,6 +126,7 @@
 	w_class = SIZE_TINY
 	throwforce = 2
 	flags_equip_slot = SLOT_WAIST
+	flags_obj = OBJ_IS_HELMET_GARB
 	max_w_class = SIZE_TINY
 	storage_slots = 20
 	can_hold = list(
@@ -269,6 +270,7 @@
 	throwforce = 2
 	w_class = SIZE_SMALL
 	flags_equip_slot = SLOT_WAIST
+	flags_obj = OBJ_IS_HELMET_GARB
 	storage_slots = 7
 	can_hold = list(/obj/item/clothing/mask/cigarette/cigar)
 	icon_type = "cigar"

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -1177,6 +1177,21 @@
 		/obj/item/weapon/gun/smg/nailgun/compact,
 	)
 
+/obj/item/storage/pouch/folding_barricade
+	name = "folding barricade pouch"
+	desc = "It's designed to hold folding barricades, sandbags, crowbars, and barbed wire. It also has two hooks for an entrenching tool and crowbar. Best for engineers that want to quickly setup defenses."
+	storage_slots = 3
+	max_w_class = SIZE_LARGE
+	icon_state = "construction"
+	can_hold = list(
+		/obj/item/stack/folding_barricade,
+		/obj/item/stack/sandbags_empty,
+		/obj/item/stack/sandbags,
+		/obj/item/stack/barbed_wire,
+		/obj/item/tool/shovel/etool,
+		/obj/item/tool/crowbar,
+	)
+
 /obj/item/storage/pouch/construction/full/fill_preset_inventory()
 	new /obj/item/stack/sheet/plasteel(src, 50)
 	new /obj/item/stack/sheet/metal(src, 50)

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -693,6 +693,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	throwforce = 4
 	flags_atom = FPRINT|CONDUCT
 	flags_equip_slot = SLOT_WAIST
+	flags_obj = OBJ_IS_HELMET_GARB
 	attack_verb = list("burnt", "singed")
 
 /obj/item/tool/lighter/zippo

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -379,8 +379,8 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 	)
 
 	var/obj/item/storage/internal/headgear/pockets
-	var/storage_slots = 2 // keep in mind, one slot is reserved for garb items
-	var/storage_slots_reserved_for_garb = 2
+	var/storage_slots = 2 // small items like injectors, bandages, etc
+	var/storage_slots_reserved_for_garb = 2 // Cosmetic items & now cigarettes and lighters for RP
 	var/storage_max_w_class = SIZE_TINY // can hold tiny items only, EXCEPT for glasses & metal flask.
 	var/storage_max_storage_space = 4
 

--- a/code/modules/gear_presets/clf.dm
+++ b/code/modules/gear_presets/clf.dm
@@ -241,7 +241,7 @@
 /datum/equipment_preset/clf/engineer/get_antag_gear_equipment()
 	return list(
 		list("MECHANIC SET (MANDATORY)", 0, null, null, null),
-		list("Essential Mechanic Set", 0, /obj/effect/essentials_set/engi/basic, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("Basic Mechanic Set", 0, /obj/effect/essentials_set/engi/basic, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
 
 		list("ENGINEERING SUPPLIES", 0, null, null, null),
 		list("Airlock Circuit Board", 2, /obj/item/circuitboard/airlock, null, VENDOR_ITEM_REGULAR),

--- a/code/modules/gear_presets/clf.dm
+++ b/code/modules/gear_presets/clf.dm
@@ -241,7 +241,7 @@
 /datum/equipment_preset/clf/engineer/get_antag_gear_equipment()
 	return list(
 		list("MECHANIC SET (MANDATORY)", 0, null, null, null),
-		list("Essential Mechanic Set", 0, /obj/effect/essentials_set/engi, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("Essential Mechanic Set", 0, /obj/effect/essentials_set/engi/basic, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
 
 		list("ENGINEERING SUPPLIES", 0, null, null, null),
 		list("Airlock Circuit Board", 2, /obj/item/circuitboard/airlock, null, VENDOR_ITEM_REGULAR),

--- a/code/modules/gear_presets/pmc.dm
+++ b/code/modules/gear_presets/pmc.dm
@@ -1752,7 +1752,7 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 /datum/equipment_preset/pmc/technician/get_antag_gear_equipment()
 	return list(
 		list("TECHNICIAN SET (MANDATORY)", 0, null, null, null),
-		list("Essential Engineer Set", 0, /obj/effect/essentials_set/engi, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("Essential Engineer Set", 0, /obj/effect/essentials_set/engi/basic, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
 
 		list("HANDHELD DEFENSE (CHOOSE 1)", 0, null, null, null),
 		list("WY Planted Flag", 0, /obj/item/defenses/handheld/planted_flag/wy, MARINE_CAN_BUY_ATTACHMENT, VENDOR_ITEM_MANDATORY),

--- a/code/modules/gear_presets/pmc.dm
+++ b/code/modules/gear_presets/pmc.dm
@@ -1752,7 +1752,7 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 /datum/equipment_preset/pmc/technician/get_antag_gear_equipment()
 	return list(
 		list("TECHNICIAN SET (MANDATORY)", 0, null, null, null),
-		list("Essential Engineer Set", 0, /obj/effect/essentials_set/engi/basic, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("Basic Engineer Set", 0, /obj/effect/essentials_set/engi/basic, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
 
 		list("HANDHELD DEFENSE (CHOOSE 1)", 0, null, null, null),
 		list("WY Planted Flag", 0, /obj/item/defenses/handheld/planted_flag/wy, MARINE_CAN_BUY_ATTACHMENT, VENDOR_ITEM_MANDATORY),

--- a/code/modules/gear_presets/upp.dm
+++ b/code/modules/gear_presets/upp.dm
@@ -488,7 +488,7 @@
 /datum/equipment_preset/upp/sapper/get_antag_gear_equipment()
 	return list(
 		list("SAPPER SET (MANDATORY)", 0, null, null, null),
-		list("Essential Sapper Set", 0, /obj/effect/essentials_set/engi, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("Essential Sapper Set", 0, /obj/effect/essentials_set/engi/basic, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
 
 		list("HANDHELD DEFENSE (CHOOSE 1)", 0, null, null, null),
 		list("UPP Planted Flag", 0, /obj/item/defenses/handheld/planted_flag/upp, MARINE_CAN_BUY_ATTACHMENT, VENDOR_ITEM_MANDATORY),

--- a/code/modules/gear_presets/upp.dm
+++ b/code/modules/gear_presets/upp.dm
@@ -488,7 +488,7 @@
 /datum/equipment_preset/upp/sapper/get_antag_gear_equipment()
 	return list(
 		list("SAPPER SET (MANDATORY)", 0, null, null, null),
-		list("Essential Sapper Set", 0, /obj/effect/essentials_set/engi/basic, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
+		list("Basic Sapper Set", 0, /obj/effect/essentials_set/engi/basic, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
 
 		list("HANDHELD DEFENSE (CHOOSE 1)", 0, null, null, null),
 		list("UPP Planted Flag", 0, /obj/item/defenses/handheld/planted_flag/upp, MARINE_CAN_BUY_ATTACHMENT, VENDOR_ITEM_MANDATORY),


### PR DESCRIPTION
# About the pull request

Allows smoking rp items to fit in helmet cosmetic slots instead of taking up "valuable" slots. 

# Explain why it's good for the game

If you fill up your slots with gear, you often cannot fit smoking items like cigarettes and lighters. This allows players to RP more with their ability to take RP items without sacrificing gameplay items. 

**please verify...**
I thought you'd use pipe equals to add bitflags in dm ie
my-bitflag |= MYNEWVALUE
This wouldn't compile though...

I saw ampersand equals removes items not on the right side of equals. 
So I used regular equals and it seems to fit into backpacks and webbing no problem. 

# Testing Photographs and Procedure

I tested by spawning using "create humans" and spawning USCM and their class. 
I verified the items fit in each of the basic helmets and also put in "game items" like bandages and an injector to assure they took the cosmetic slots, not the "item" slots. 

I also put the cigarettes into the 5 slot webbing and backpacks. 

<details>

![image](https://github.com/user-attachments/assets/7921f9a0-51af-49e1-a521-a3f9f8cd6363)

![image](https://github.com/user-attachments/assets/f37b936a-3763-4d84-b047-69116d8d9b18)

![image](https://github.com/user-attachments/assets/c56198eb-7482-4814-803b-e52193446e94)

![image](https://github.com/user-attachments/assets/adb46a73-3798-4441-b381-0ef4432df429)

![image](https://github.com/user-attachments/assets/2bfb7d21-feba-4d7a-8632-233add523e30)


</details>


# Changelog

:cl:
qol: Can roleplay easier with cigarettes, cigars, lighters counting as cosmetic for helmet storage purposes.
/:cl:


