### PR TITLE
cigarettes cigars lighters fit in helmet cosmetic

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -470,6 +470,7 @@
 	item_state = "zippo"
 	w_class = SIZE_TINY
 	flags_equip_slot = SLOT_WAIST
+	flags_obj = parent_type::flags_obj|OBJ_IS_HELMET_GARB
 	can_hold = list(/obj/item/tool/match)
 
 /obj/item/storage/box/matches/fill_preset_inventory()

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -126,6 +126,7 @@
 	w_class = SIZE_TINY
 	throwforce = 2
 	flags_equip_slot = SLOT_WAIST
+	flags_obj = OBJ_IS_HELMET_GARB
 	max_w_class = SIZE_TINY
 	storage_slots = 20
 	can_hold = list(
@@ -269,6 +270,7 @@
 	throwforce = 2
 	w_class = SIZE_SMALL
 	flags_equip_slot = SLOT_WAIST
+	flags_obj = OBJ_IS_HELMET_GARB
 	storage_slots = 7
 	can_hold = list(/obj/item/clothing/mask/cigarette/cigar)
 	icon_type = "cigar"

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -126,7 +126,7 @@
 	w_class = SIZE_TINY
 	throwforce = 2
 	flags_equip_slot = SLOT_WAIST
-	flags_obj = OBJ_IS_HELMET_GARB
+	flags_obj = parent_type::flags_obj|OBJ_IS_HELMET_GARB
 	max_w_class = SIZE_TINY
 	storage_slots = 20
 	can_hold = list(

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -270,7 +270,6 @@
 	throwforce = 2
 	w_class = SIZE_SMALL
 	flags_equip_slot = SLOT_WAIST
-	flags_obj = OBJ_IS_HELMET_GARB
 	storage_slots = 7
 	can_hold = list(/obj/item/clothing/mask/cigarette/cigar)
 	icon_type = "cigar"

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -454,6 +454,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_off = "cigar_off"
 	w_class = SIZE_SMALL
 	flags_equip_slot = SLOT_FACE
+	flags_obj = parent_type::flags_obj|OBJ_IS_HELMET_GARB
 	type_butt = /obj/item/trash/cigbutt/cigarbutt
 	throw_speed = SPEED_VERY_FAST
 	item_state = "cigar_off"

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -693,6 +693,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	throwforce = 4
 	flags_atom = FPRINT|CONDUCT
 	flags_equip_slot = SLOT_WAIST
+	flags_obj = OBJ_IS_HELMET_GARB
 	attack_verb = list("burnt", "singed")
 
 /obj/item/tool/lighter/zippo

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -177,6 +177,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	w_class = SIZE_TINY
 	flags_armor_protection = 0
 	flags_equip_slot = SLOT_EAR | SLOT_FACE
+	flags_obj = parent_type::flags_obj|OBJ_IS_HELMET_GARB
 	flags_atom = CAN_BE_SYRINGED
 	attack_verb = list("burnt", "singed")
 	blood_overlay_type = ""
@@ -454,7 +455,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_off = "cigar_off"
 	w_class = SIZE_SMALL
 	flags_equip_slot = SLOT_FACE
-	flags_obj = parent_type::flags_obj|OBJ_IS_HELMET_GARB
 	type_butt = /obj/item/trash/cigbutt/cigarbutt
 	throw_speed = SPEED_VERY_FAST
 	item_state = "cigar_off"

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -693,7 +693,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	throwforce = 4
 	flags_atom = FPRINT|CONDUCT
 	flags_equip_slot = SLOT_WAIST
-	flags_obj = OBJ_IS_HELMET_GARB
+	flags_obj = parent_type::flags_obj|OBJ_IS_HELMET_GARB
 	attack_verb = list("burnt", "singed")
 
 /obj/item/tool/lighter/zippo

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -379,8 +379,8 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 	)
 
 	var/obj/item/storage/internal/headgear/pockets
-	var/storage_slots = 2 // keep in mind, one slot is reserved for garb items
-	var/storage_slots_reserved_for_garb = 2
+	var/storage_slots = 2 // Small items like injectors, bandages, etc
+	var/storage_slots_reserved_for_garb = 2 // Cosmetic items & now cigarettes and lighters for RP
 	var/storage_max_w_class = SIZE_TINY // can hold tiny items only, EXCEPT for glasses & metal flask.
 	var/storage_max_storage_space = 4
 


### PR DESCRIPTION
# About the pull request

Allows smoking rp items to fit in helmet cosmetic slots instead of taking up "valuable" slots.

# Explain why it's good for the game

If you fill up your slots with gear, you often cannot fit smoking items like cigarettes and lighters. This allows players to RP more with their ability to take RP items without sacrificing gameplay items.

**please verify...**
I thought you'd use pipe equals to add bitflags in dm ie
my-bitflag |= MYNEWVALUE
This wouldn't compile though...

I saw ampersand equals removes items not on the right side of equals.
So I used regular equals and it seems to fit into backpacks and webbing no problem.


# Testing Photographs and Procedure

I tested by spawning using "create humans" and spawning USCM and their class.
I verified the items fit in each of the basic helmets and also put in "game items" like bandages and an injector to assure they took the cosmetic slots, not the "item" slots.

I also put the cigarettes into the 5 slot webbing and backpacks.

<details>
<summary>Screenshots & Videos</summary>

![354072752-7921f9a0-51af-49e1-a521-a3f9f8cd6363](https://github.com/user-attachments/assets/a5086670-0adb-49dc-b903-fa4180fe1d2c)

![354072765-f37b936a-3763-4d84-b047-69116d8d9b18](https://github.com/user-attachments/assets/cc928f13-e100-4e6d-8dee-828d0e6928f8)

![354072809-c56198eb-7482-4814-803b-e52193446e94](https://github.com/user-attachments/assets/91116610-9589-4c58-9871-2efd21523516)

![354073089-adb46a73-3798-4441-b381-0ef4432df429](https://github.com/user-attachments/assets/2f20364d-569e-4eb1-9fe0-4ef629e4a252)

![354073414-2bfb7d21-feba-4d7a-8632-233add523e30](https://github.com/user-attachments/assets/ee69872a-feca-420a-b3ec-1ce2087d3bc1)


</details>


# Changelog
:cl:
qol: Can roleplay easier with cigarettes, cigars, lighters counting as cosmetic for helmet storage purposes.
/:cl:
