### PR TITLE
Sacrifice ability buff — now guarantees to get the target out of crit on top of the heal

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/drone/healer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/drone/healer.dm
@@ -257,6 +257,9 @@
 
 	xeno.say(";MY LIFE FOR THE QUEEN!!!")
 
+	if(target.health < 0)
+		target.gain_health(abs(target.health)) // gets them out of crit first
+
 	target.gain_health(xeno.health * transfer_mod)
 	target.updatehealth()
 


### PR DESCRIPTION
# About the pull request
Now on top of transferring 75% of the healer's health the ability first "uncrits" the target, i.e. sets a critted xeno health to zero (if health was lower than zero) prior to the actual health transfer.

# Explain why it's good for the game
Sacrifice is generally not very impressive, because when you use it on a xeno that have been critted (the obvious target for your Sacrifice ability), you often end up spending a lot of your sacrifice healing trying to get them out of the crit state (and sometimes it might not even be enough to actually get them out of the crit state, due to warding making them have a very huge negative health threshold), which ends up in leaving your target at extremely low health, still stunned from crit, and often without their source of warding (which is usually you). This basically makes a lot of sacrifices be in vain, which is pretty upsetting.

Now negative health is basically irrelevant for the sacrifice, as you are guaranteed to put them out of crit. It still shouldn't be overpowered, because even a full sacrifice heal will leave a critted xeno with no more than 375 hp and this change doesn't affect sacrificing for not critted xenos.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
Yes, I tested this by bombing queen into -150, then sacrificing with full health. Result is 375 hp.
</details>


# Changelog
:cl: ihatethisengine2
balance: sacrifice ability now guarantees to get the target out of crit on top of the heal
/:cl:
