### PR TITLE
Removes an unneeded var in mob_hud.dm

### DIFF
--- a/code/datums/mob_hud.dm
+++ b/code/datums/mob_hud.dm
@@ -408,7 +408,6 @@ GLOBAL_LIST_INIT_TYPED(huds, /datum/mob_hud, list(
 		var/revive_enabled = stat == DEAD && check_tod() && is_revivable()
 		if(stat == DEAD)
 			revive_enabled = check_tod() && is_revivable()
-		var/datum/internal_organ/heart/heart = islist(internal_organs_by_name) ? internal_organs_by_name["heart"] : null
 
 		var/holder2_set = 0
 		if(hivenumber)


### PR DESCRIPTION

# About the pull request


removes an unneeded var in mob_hud.dm. this got missed in my heartbreak scan PR as i did not compile after adding the suggested changes

# Explain why it's good for the game

removes a warning when compiling the game

# Changelog
:cl:
code: removed an unneeded var in mob_hud.dm
/:cl:
