### PR TITLE
Fullscreen improvements

### DIFF
--- a/code/__DEFINES/client_prefs.dm
+++ b/code/__DEFINES/client_prefs.dm
@@ -15,7 +15,7 @@
 #define TOGGLE_AUTOMATIC_PUNCTUATION (1<<7) // Whether your sentences will automatically be punctuated with a period
 #define TOGGLE_COMBAT_CLICKDRAG_OVERRIDE (1<<8) // Whether disarm/harm intents cause clicks to trigger immediately when the mouse button is depressed.
 #define TOGGLE_ALTERNATING_DUAL_WIELD (1<<9) // Whether dual-wielding fires both guns at once or swaps between them, OUTDATED, used to update savefiles, now dual_wield_pref
-#define TOGGLE_FULLSCREEN (1<<10) // See /client/proc/toggle_fullscreen in client_procs.dm
+#define TOGGLE_FULLSCREEN (1<<10) // See /client/proc/update_fullscreen in client_procs.dm
 #define TOGGLE_MEMBER_PUBLIC (1<<11) //determines if you get a byond logo by your name in ooc if you're a member or not
 #define TOGGLE_OOC_FLAG (1<<12) // determines if your country flag appears by your name in ooc chat
 #define TOGGLE_MIDDLE_MOUSE_SWAP_HANDS (1<<13) //Toggle whether middle click swaps your hands

--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -33,6 +33,7 @@
 //Client
 #define COMSIG_KB_CLIENT_GETHELP_DOWN "keybinding_client_gethelp_down"
 #define COMSIG_KB_CLIENT_SCREENSHOT_DOWN "keybinding_client_screenshot_down"
+#define COMSIG_KB_CLIENT_TOGGLEFULLSCREEN_DOWN "keybinding_client_togglefullscreen_down"
 #define COMSIG_KB_CLIENT_MINIMALHUD_DOWN "keybinding_client_minimalhud_down"
 
 //Communication

--- a/code/datums/keybinding/client.dm
+++ b/code/datums/keybinding/client.dm
@@ -34,6 +34,21 @@
 	winset(user, null, "command=.screenshot [!user.keys_held["shift"] ? "auto" : ""]")
 	return TRUE
 
+/datum/keybinding/client/toggle_fullscreen
+	hotkey_keys = list("F11")
+	classic_keys = list("F11")
+	name = "toggle_fullscreen"
+	full_name = "Toggle Fullscreen"
+	description = "Toggles whether the game window will be true fullscreen or normal."
+	keybind_signal = COMSIG_KB_CLIENT_TOGGLEFULLSCREEN_DOWN
+
+/datum/keybinding/client/toggle_fullscreen/down(client/user)
+	. = ..()
+	if(.)
+		return
+	user.toggle_fullscreen_preference()
+	return TRUE
+
 /datum/keybinding/client/minimal_hud
 	hotkey_keys = list("F12")
 	classic_keys = list("F12")

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -730,7 +730,7 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 					winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=whisper")
 
 /client/proc/update_fullscreen()
-	if(prefs.toggle_prefs & TOGGLE_FULLSCREEN))
+	if(prefs.toggle_prefs & TOGGLE_FULLSCREEN)
 		winset(src, "mainwindow", "is-fullscreen=true;menu=")
 	else
 		winset(src, "mainwindow", "is-fullscreen=false;menu=menu")

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -419,11 +419,7 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 	if(prefs.lastchangelog != GLOB.changelog_hash) //bolds the changelog button on the interface so we know there are updates.
 		winset(src, "infowindow.changelog", "background-color=#ED9F9B;font-style=bold")
 
-	if(prefs.toggle_prefs & TOGGLE_FULLSCREEN)
-		toggle_fullscreen(TRUE)
-	else
-		toggle_fullscreen(FALSE)
-
+	update_fullscreen()
 
 	var/file = file2text("config/donators.txt")
 	var/lines = splittext(file, "\n")
@@ -733,12 +729,16 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 				if(WHISPER_CHANNEL)
 					winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=whisper")
 
-/client/proc/toggle_fullscreen(new_value)
-	if(new_value)
-		winset(src, "mainwindow", "is-maximized=false;can-resize=false;titlebar=false;menu=menu")
+/client/proc/update_fullscreen()
+	if(CHECK_BITFIELD(prefs.toggle_prefs, TOGGLE_FULLSCREEN))
+		winset(src, "mainwindow", "is-fullscreen=true;menu=")
 	else
-		winset(src, "mainwindow", "is-maximized=false;can-resize=true;titlebar=true;menu=menu")
-	winset(src, "mainwindow", "is-maximized=true")
+		winset(src, "mainwindow", "is-fullscreen=false;menu=menu")
+
+	if(prefs.adaptive_zoom)
+		adaptive_zoom()
+	else if(prefs.auto_fit_viewport)
+		fit_viewport()
 
 /// Attempts to make the client orbit the given object, for administrative purposes.
 /// If they are not an observer, will try to aghost them.

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -730,7 +730,7 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 					winset(src, "srvkeybinds-[REF(key)]", "parent=default;name=[key];command=whisper")
 
 /client/proc/update_fullscreen()
-	if(CHECK_BITFIELD(prefs.toggle_prefs, TOGGLE_FULLSCREEN))
+	if(prefs.toggle_prefs & TOGGLE_FULLSCREEN))
 		winset(src, "mainwindow", "is-fullscreen=true;menu=")
 	else
 		winset(src, "mainwindow", "is-fullscreen=false;menu=menu")

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -224,7 +224,7 @@
 	set category = "Preferences"
 	set desc = "Toggles whether the game window will be true fullscreen or normal."
 
-	TOGGLE_BITFIELD(prefs.toggle_prefs, TOGGLE_FULLSCREEN)
+	prefs.toggle_prefs ^= TOGGLE_FULLSCREEN
 	prefs.save_preferences()
 	update_fullscreen()
 

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -224,9 +224,9 @@
 	set category = "Preferences"
 	set desc = "Toggles whether the game window will be true fullscreen or normal."
 
-	prefs.toggle_prefs ^= TOGGLE_FULLSCREEN
+	TOGGLE_BITFIELD(prefs.toggle_prefs, TOGGLE_FULLSCREEN)
 	prefs.save_preferences()
-	toggle_fullscreen(prefs.toggle_prefs & TOGGLE_FULLSCREEN)
+	update_fullscreen()
 
 /client/verb/toggle_ambient_occlusion()
 	set name = "Toggle Ambient Occlusion"


### PR DESCRIPTION

# About the pull request

Added a toggle fullscreen key, default F11.

Switched to `is-fullscreen` implementation, which preserves window size/maximized from before fullscreening. The previous `is-maximized` disable/enable dance was to avoid a BYOND issue with fullscreening a maximized window. That issue was resolved in 515.1639: https://www.byond.com/forum/post/2924219

Fullscreen now hides the menu bar.

Toggling fullscreen now triggers adaptive zoom and/or auto viewport resize if those are enabled.

Renamed the proc to `update_fullscreen` since that part wasn't actually toggling anything.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
# Testing Photographs and Procedure
Boots without issue. Preference is toggled and preserved. Fullscreening while maximized works properly *on version 1639 and above*. Non-fullscreened screen state is preserved.


# Changelog
:cl:
add: Added toggle fullscreen hotkey, default F11
qol: fullscreening hides the menu bar
fix: toggling fullscreen preserves your non-fullscreened window options
/:cl:
