### PR TITLE
"Dark" HUD indicators adjust with view size

### DIFF
--- a/code/datums/custom_hud.dm
+++ b/code/datums/custom_hud.dm
@@ -115,10 +115,11 @@
 /datum/custom_hud/dark
 	ui_style_icon = 'icons/mob/hud/human_dark.dmi'
 
-	UI_OXYGEN_LOC = "EAST-2:16,14:15"
-	UI_NUTRITION_LOC = "EAST-2:33,14:15"
-	UI_TEMP_LOC = "EAST-1:26,15:-7"
-	UI_HEALTH_LOC = "EAST-1:27,15:-8"
+	UI_FRAME_LOC = "EAST-3:0,NORTH-1:15"
+	UI_OXYGEN_LOC = "EAST-2:16,NORTH-1:15"
+	UI_NUTRITION_LOC = "EAST-2:33,NORTH-1:15"
+	UI_TEMP_LOC = "EAST-1:26,NORTH-0:-7"
+	UI_HEALTH_LOC = "EAST-1:27,NORTH-0:-8"
 	UI_SL_LOCATOR_LOC = "EAST-1:27,12:22"
 
 /datum/custom_hud/dark/get_status_loc(placement)


### PR DESCRIPTION

# About the pull request

"Dark" HUD indicators are now anchored to the top of the viewport, and so are positioned appropriately for various view sizes.

Before:
![image](https://github.com/user-attachments/assets/9363d65c-b9e8-45bb-919f-acc80d36590d)
After:
![image](https://github.com/user-attachments/assets/65eff05a-cf51-42d1-9636-24e1f86b9ba3)

Before, binocs:
![image](https://github.com/user-attachments/assets/cbbbfeb7-4e14-444e-97b7-62f3f56be8ae)
After, binocs:
![image](https://github.com/user-attachments/assets/fe3dc17f-f2ff-40d3-ac79-a94ab7af3732)

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Looks better.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
ui: dark HUD indicators stay anchored to the viewport edge
/:cl:
