### PR TITLE
Stop phones from going in lockers/crates

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -127,6 +127,8 @@
 			var/obj/item/explosive/plastic/P = I
 			if(P.active)
 				continue
+		if(istype(I, /obj/item/phone))
+			continue
 		var/item_size = ceil(I.w_class / 2)
 		if(stored_units + item_size > storage_capacity)
 			continue

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -90,6 +90,8 @@
 			var/obj/structure/bed/B = O
 			if(B.buckled_mob)
 				continue
+		if(istype(O, /obj/item/phone))
+			continue
 		O.forceMove(src)
 		itemcount++
 


### PR DESCRIPTION

# About the pull request

stops phones from going in lockers/crates, which prevents players from exploiting the phone drag feature.
fixes #6201

i tried making it so the phones would bust out of the crate, but it would look really odd as reset_tether() would get called and the phone would magically teleported and become attached to the backpack. i couldn't find a way to make it smoothly pop out of the crate, and i think this is a decent enough alternative, as i don't know if a single situation where a player would need to store a phone.

this also stops the phone tether from becoming destroyed if you put it in an anchored closet.

# Explain why it's good for the game

fixes a (funny) exploit and another niche issue


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

https://github.com/user-attachments/assets/addca004-27b1-4a8d-887e-c7600d7851a2



</details>


# Changelog
:cl:
fix: Phones can no longer be stored in closets/crates, which prevents players from dragging crates with their phones and other weird issues that can occur.
/:cl:
