### PR TITLE
Limits deafness to 1 minute

### DIFF
--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -446,7 +446,7 @@
 
 /mob/living/proc/AdjustEarDeafness(amount)
 	var/prev_deaf = ear_deaf
-	ear_deaf = clamp(max(ear_deaf + amount, 0), 0, 30) //roughly 1 minute
+	ear_deaf = clamp(ear_deaf + amount, 0, 30) //roughly 1 minute
 	if(prev_deaf)
 		if(ear_deaf == 0)
 			on_deafness_loss()

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -446,7 +446,7 @@
 
 /mob/living/proc/AdjustEarDeafness(amount)
 	var/prev_deaf = ear_deaf
-	ear_deaf = max(ear_deaf + amount, 0)
+	ear_deaf = clamp(max(ear_deaf + amount, 0), 0, 30) //roughly 1 minute
 	if(prev_deaf)
 		if(ear_deaf == 0)
 			on_deafness_loss()


### PR DESCRIPTION

# About the pull request

limits being deaf to (roughly) one minute

# Explain why it's good for the game

one of the worst side effects of explosives in general is becoming deaf for a long time, with no way to judge how long it take to go away. as a marine you are already lacking a lot of information. communication is integral to make up for that lack of info, so it is extremely annoying to have that ability taken away, ESPECIALLY if multiple explosions stack on you or if a very strong one hits you. it feels like years before you can get your hearing back in some cases.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

tested with the SetEarDeafness() proc set to the max integer number

https://github.com/user-attachments/assets/ea7434ab-2e1d-4291-939b-5d48cc9ee6ba

</details>


# Changelog
:cl:
qol: Deafness is now limited to being 1 minute in length.
/:cl:
