### PR TITLE
Makes the Combat Correspondent camera unmeltable and indestructible.

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -353,6 +353,8 @@
 	desc = "Actively document everything you see, from the mundanity of shipside to the brutal battlefields below. Has a built-in printer for action shots."
 	icon_state = "broadcastingcamera"
 	item_state = "broadcastingcamera"
+	unacidable = TRUE
+	indestructible = TRUE
 	pictures_left = 20
 	pictures_max = 20
 	w_class = SIZE_HUGE


### PR DESCRIPTION

# About the pull request

Makes the Combat Correspondent camera unmeltable and indestructible.

# Explain why it's good for the game

The combat correspondent camera is solely an RP item. It serves no combative function, it's worse in every way to overwatch cameras, and it is solely a way for people to have fun as a small benefit for picking the civilian version of combat correspondent and losing out on skills. More importantly, it's something for shipside players to watch and can enable roleplay.

It's not very fun or engaging for the camera to be blown up because somebody fired a HEDP near you or for someone to walk up and melt it because you decided to go for an awesome action shot. Sure, it isn't unmeltable or unacidable in lore or realistically - but it's nothing but a cool flavour and gimmick item. It deserves an exception to the 1984 patrol coming and removing it from your grasp.


# Testing Photographs and Procedure

I tested this by trying to melt it and trying to blow it up (and getting somewhat carried away.) From what I can see all functions work for the camera and it was indestructible by normal means.


# Changelog
:cl:
balance: The combat correspondents camera is no longer meltable or explodable.
/:cl:
