### PR TITLE
Fixes flashlight medical use being broken

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -107,7 +107,7 @@
 		if((user.getBrainLoss() >= 60) && prob(50)) //too dumb to use flashlight properly
 			return ..() //just hit them in the head
 
-		if((!ishuman(user) || SSticker) && SSticker.mode.name != "monkey") //don't have dexterity
+		if((!(ishuman(user) || SSticker) && SSticker.mode.name != "monkey"))
 			to_chat(user, SPAN_NOTICE("You don't have the dexterity to do this!"))
 			return
 


### PR DESCRIPTION

# About the pull request

makes it so you can check eyes with flashlights instead of being told that "You don't have the dexterity for this."
fixes #6769
fixes #5353 

# Explain why it's good for the game

bug fix!

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>


https://github.com/user-attachments/assets/97bd2147-ce75-4800-a6d5-17f59c918a65


</details>


# Changelog
:cl:
fix: You can use flashlights to check if mobs are dead once again
/:cl:
