### PR TITLE
Normalized Queen's build range to match every other building xeno

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Powers.dm
@@ -24,7 +24,7 @@
 
 	var/turf/current_turf = get_turf(A)
 
-	if(extra_build_dist != IGNORE_BUILD_DISTANCE && get_dist(src, A) > src.caste.max_build_dist + extra_build_dist) // Hivelords and eggsac carriers have max_build_dist of 1, drones and queens 0
+	if(extra_build_dist != IGNORE_BUILD_DISTANCE && get_dist(src, A) > src.caste.max_build_dist + extra_build_dist) // Default is 0 for non-builders, builders should be normalized to 1
 		to_chat(src, SPAN_XENOWARNING("We can't build from that far!"))
 		return SECRETE_RESIN_FAIL
 	else if(thick) //hivelords can thicken existing resin structures.

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -29,6 +29,7 @@
 	acid_level = 2
 	weed_level = WEED_LEVEL_STANDARD
 	can_be_revived = FALSE
+	max_build_dist = 1
 
 	behavior_delegate_type = /datum/behavior_delegate/queen
 


### PR DESCRIPTION
# About the pull request
Changes the Queen's build range when not on ovi from 0 to 1 and updated a very old note regarding it.

# Explain why it's good for the game
Consistency with other building castes plus 0 range building is very awkward. This doesn't affect building when on ovi because ovi building ignores build range.


# Testing Photographs and Procedure
Added single line of code that works with other xenos.


# Changelog

:cl: Killfish
qol: Queen now has a build range of 1 instead of 0. Does not affect building on ovi.
/:cl:
