### PR TITLE
Gives researchers access to the Kitchen

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -32955,7 +32955,7 @@
 /obj/structure/machinery/door/airlock/almayer/generic{
 	access_modified = 1;
 	name = "Kitchen";
-	req_one_access_txt = "30;19"
+	req_one_access_txt = "30;28;19"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer{
@@ -74609,7 +74609,7 @@
 	access_modified = 1;
 	dir = 1;
 	name = "\improper Kitchen Hydroponics";
-	req_one_access_txt = "30;19"
+	req_one_access_txt = "30;28;19"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -80273,7 +80273,7 @@
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	access_modified = 1;
 	name = "\improper Main Kitchen";
-	req_one_access_txt = "30;19"
+	req_one_access_txt = "30;28;19"
 	},
 /turf/open/floor/prison{
 	icon_state = "kitchen"


### PR DESCRIPTION

# About the pull request

Gives researchers access to the Kitchen

# Explain why it's good for the game

There's not always someone with Kitchen access nearby or a Mess Tech awake when you need to grab something like universal enzyme for a research chem. And if there is someone with access on the ship, it's like pulling teeth to try to get them to open the door for you. This makes it so researchers no longer have to stand around like sad puppies in front of the kitchen waiting for someone to walk by.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Asmocard
qol: Gave researchers access to Almayer kitchen
/:cl:
