### PR TITLE
Revert "Buffs cades against projectiles"

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -23,8 +23,6 @@
 
 	/// an object's "projectile_coverage" var indicates the maximum probability of blocking a projectile, assuming density and throwpass. Used by barricades, tables and window frames
 	var/projectile_coverage = 0
-	/// How many tiles away from this object that a shooter needs to be to maximize this barricade's projectile coverage
-	var/projectile_coverage_distance_limit = 6
 	/// set to true if the item is garbage and should be deleted after awhile
 	var/garbage = FALSE
 

--- a/code/game/objects/structures/barricade/barricade.dm
+++ b/code/game/objects/structures/barricade/barricade.dm
@@ -34,7 +34,6 @@
 	var/is_wired = FALSE
 	flags_barrier = HANDLE_BARRIER_CHANCE
 	projectile_coverage = PROJECTILE_COVERAGE_HIGH
-	projectile_coverage_distance_limit = 2
 	var/upgraded
 	var/brute_multiplier = 1
 	var/burn_multiplier = 1

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -30,7 +30,6 @@
 	var/flip_cooldown = 0 //If flip cooldown exists, don't allow flipping or putting back. This carries a WORLD.TIME value
 	health = 100
 	projectile_coverage = 20 //maximum chance of blocking a projectile
-	var/flipped_projectile_coverage_distance_limit = 2
 	var/flipped_projectile_coverage = PROJECTILE_COVERAGE_HIGH
 	var/upright_projectile_coverage = PROJECTILE_COVERAGE_LOW
 	surgery_duration_multiplier = SURGERY_SURFACE_MULT_UNSUITED
@@ -43,7 +42,6 @@
 			qdel(T)
 	if(flipped)
 		projectile_coverage = flipped_projectile_coverage
-		projectile_coverage_distance_limit = flipped_projectile_coverage_distance_limit
 	else
 		projectile_coverage = upright_projectile_coverage
 
@@ -448,7 +446,6 @@
 			INVOKE_ASYNC(movable_on_table, TYPE_PROC_REF(/atom/movable, throw_atom), pick(targets), 1, SPEED_FAST)
 
 	projectile_coverage = flipped_projectile_coverage
-	projectile_coverage_distance_limit = flipped_projectile_coverage_distance_limit
 
 	setDir(direction)
 	if(dir != NORTH)
@@ -476,7 +473,6 @@
 	verbs += /obj/structure/surface/table/verb/do_flip
 
 	projectile_coverage = upright_projectile_coverage
-	projectile_coverage_distance_limit = src::projectile_coverage_distance_limit
 
 	layer = initial(layer)
 	flipped = FALSE

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -660,7 +660,7 @@
 
 //Used by machines and structures to calculate shooting past cover
 /obj/proc/calculate_cover_hit_boolean(obj/projectile/P, distance = 0, cade_direction_correct = FALSE)
-	if(istype(P.shot_from, /obj/item/hardpoint) || istype(P.ammo, /datum/ammo/xeno)) //anything shot from a tank or a xeno gets a bonus to bypassing cover
+	if(istype(P.shot_from, /obj/item/hardpoint)) //anything shot from a tank gets a bonus to bypassing cover
 		distance -= 3
 
 	if(distance < 1 || (distance > 3 && cade_direction_correct))
@@ -668,9 +668,10 @@
 
 	//an object's "projectile_coverage" var indicates the maximum probability of blocking a projectile
 	var/effective_accuracy = P.get_effective_accuracy()
+	var/distance_limit = 6 //number of tiles needed to max out block probability
 	var/accuracy_factor = 50 //degree to which accuracy affects probability   (if accuracy is 100, probability is unaffected. Lower accuracies will increase block chance)
 
-	var/hitchance = min(projectile_coverage, (projectile_coverage * distance / (projectile_coverage_distance_limit * (cade_direction_correct ? 3 : 1))) + accuracy_factor * (1 - effective_accuracy/100))
+	var/hitchance = min(projectile_coverage, (projectile_coverage * distance/distance_limit) + accuracy_factor * (1 - effective_accuracy/100))
 
 	#if DEBUG_HIT_CHANCE
 	to_world(SPAN_DEBUG("([name] as cover) Distance travelled: [P.distance_travelled]  |  Effective accuracy: [effective_accuracy]  |  Hit chance: [hitchance]"))


### PR DESCRIPTION
Reverts cmss13-devs/cmss13#6727

This has had a few too many knock-on effects (see below) and I'm a bit too burned out to properly fix this; will re-introduce this later when properly adjusted.

- Not happy with xeno cade hit % adjustments
- I've heard there's issues with cades getting shredded on diagonals
- You can now do what's seen in the image without issue, and you couldn't previously 
![image](https://github.com/user-attachments/assets/97b137cd-f982-4848-9aea-4fd0f61987a9)
