### PR TITLE
improvements to research datum

### DIFF
--- a/code/datums/research_upgrade_datum.dm
+++ b/code/datums/research_upgrade_datum.dm
@@ -9,6 +9,8 @@
 	var/value_upgrade = 1000
 	///In which tab the upgrade should be.
 	var/upgrade_type
+	///Path to the item, upgrade, if any.
+	var/item_reference
 	///Clearance requirment to buy this upgrade. 5x is level 6. Why is it not that way? no one knows.
 	var/clearance_req = 5
 	///The change of price for item per purchase, recommended for mass producing stuff or limited upgrade.
@@ -18,8 +20,11 @@
 	///the maximum price which we cant go any more expensive, usually dont need to set this if change price is 0 or negative
 	var/maximum_price = INFINITY
 
-///gets called once the product is purchased, spawn items, etc.
+///gets called once the product is purchased, override if you need to pass any special arguments or have special behavior on purchase.
 /datum/research_upgrades/proc/on_purchase(turf/machine_loc)
+	if(isnull(item_reference))
+		return
+	new item_reference(machine_loc)
 	return
 
 /datum/research_upgrades/machinery
@@ -77,11 +82,9 @@
 	desc = "Research upgrade for Sleeper system, technology on this disk is used on a sleeper to allow wider spectrum of chemicals to be administered, as well as upgrading dialysis software."
 	behavior = RESEARCH_UPGRADE_ITEM
 	value_upgrade = 500
+	item_reference = /obj/item/research_upgrades/sleeper
 	upgrade_type = ITEM_MACHINERY_UPGRADE
 	clearance_req = 1
-
-/datum/research_upgrades/machinery/sleeper/on_purchase(turf/machine_loc)
-	new /obj/item/research_upgrades/sleeper(machine_loc)
 
 /datum/research_upgrades/item
 	name = "Items"
@@ -93,12 +96,10 @@
 	value_upgrade = 2000
 	behavior = RESEARCH_UPGRADE_ITEM
 	upgrade_type = ITEM_ACCESSORY_UPGRADE
+	item_reference = /obj/item/research_upgrades/credits
 	change_purchase = 500
 	maximum_price = 5000
 	clearance_req = 5
-
-/datum/research_upgrades/item/research_credits/on_purchase(turf/machine_loc)
-	new /obj/item/research_upgrades/credits(machine_loc)
 
 /datum/research_upgrades/item/laser_scalpel
 	name = "Laser Scalpel"
@@ -106,10 +107,8 @@
 	value_upgrade = 3000
 	behavior = RESEARCH_UPGRADE_ITEM
 	upgrade_type = ITEM_ACCESSORY_UPGRADE
+	item_reference = /obj/item/tool/surgery/scalpel/laser/advanced
 	clearance_req = 3
-
-/datum/research_upgrades/item/laser_scalpel/on_purchase(turf/machine_loc)
-	new /obj/item/tool/surgery/scalpel/laser/advanced(machine_loc)
 
 /datum/research_upgrades/item/incision_management
 	name = "Incision Management System"
@@ -118,9 +117,8 @@
 	behavior = RESEARCH_UPGRADE_ITEM
 	upgrade_type = ITEM_ACCESSORY_UPGRADE
 	clearance_req = 4
+	item_reference = /obj/item/tool/surgery/scalpel/manager
 
-/datum/research_upgrades/item/incision_management/on_purchase(turf/machine_loc)
-	new /obj/item/tool/surgery/scalpel/manager(machine_loc)
 
 /datum/research_upgrades/item/nanosplints
 	name = "Reinforced Fiber Splints"
@@ -145,9 +143,7 @@
 	maximum_price = 1000
 	behavior = RESEARCH_UPGRADE_ITEM
 	upgrade_type = ITEM_ACCESSORY_UPGRADE
-
-/datum/research_upgrades/item/flamer_tank/on_purchase(turf/machine_loc)
-	new /obj/item/ammo_magazine/flamer_tank/custom/upgraded(machine_loc)
+	item_reference = /obj/item/ammo_magazine/flamer_tank/custom/upgraded
 
 /datum/research_upgrades/item/flamer_tank/smoke
 	name = "Upgraded Incinerator Smoke Tank"
@@ -157,9 +153,7 @@
 	change_purchase = 50
 	minimum_price = 100
 	maximum_price = 500
-
-/datum/research_upgrades/item/flamer_tank/smoke/on_purchase(turf/machine_loc)
-	new /obj/item/ammo_magazine/flamer_tank/smoke/upgraded(machine_loc)
+	item_reference = /obj/item/ammo_magazine/flamer_tank/smoke/upgraded
 
 /datum/research_upgrades/armor
 	name = "Armor"
@@ -172,9 +166,7 @@
 	behavior = RESEARCH_UPGRADE_ITEM
 	clearance_req = 6
 	upgrade_type = ITEM_ARMOR_UPGRADE
-
-/datum/research_upgrades/armor/translator/on_purchase(turf/machine_loc)
-	new /obj/item/clothing/accessory/health/research_plate/translator(machine_loc)
+	item_reference = /obj/item/clothing/accessory/health/research_plate/translator
 
 /datum/research_upgrades/armor/coagulator
 	name = "Active Blood Coagulator Plate"
@@ -185,9 +177,8 @@
 	change_purchase = -200
 	minimum_price = 200
 	upgrade_type = ITEM_ARMOR_UPGRADE
+	item_reference = /obj/item/clothing/accessory/health/research_plate/coagulator
 
-/datum/research_upgrades/armor/coagulator/on_purchase(turf/machine_loc)
-	new /obj/item/clothing/accessory/health/research_plate/coagulator(machine_loc)
 
 /datum/research_upgrades/armor/emergency_injector
 	name = "Medical Emergency Injector"
@@ -198,9 +189,7 @@
 	change_purchase = -100
 	minimum_price = 100
 	upgrade_type = ITEM_ARMOR_UPGRADE
-
-/datum/research_upgrades/armor/emergency_injector/on_purchase(turf/machine_loc)
-	new /obj/item/clothing/accessory/health/research_plate/emergency_injector(machine_loc)
+	item_reference = /obj/item/clothing/accessory/health/research_plate/emergency_injector
 
 /datum/research_upgrades/armor/ceramic
 	name = "Ceramic Armor Plate"
@@ -211,9 +200,7 @@
 	upgrade_type = ITEM_ARMOR_UPGRADE
 	change_purchase = -50
 	minimum_price = 200
-
-/datum/research_upgrades/armor/ceramic/on_purchase(turf/machine_loc)
-	new /obj/item/clothing/accessory/health/ceramic_plate(machine_loc)
+	item_reference = /obj/item/clothing/accessory/health/ceramic_plate
 
 /datum/research_upgrades/armor/preservation
 	name = "Death Preservation Plate"
@@ -224,6 +211,4 @@
 	upgrade_type = ITEM_ARMOR_UPGRADE
 	change_purchase = -100
 	minimum_price = 100
-
-/datum/research_upgrades/armor/preservation/on_purchase(turf/machine_loc)
-	new /obj/item/clothing/accessory/health/research_plate/anti_decay(machine_loc)
+	item_reference = /obj/item/clothing/accessory/health/research_plate/anti_decay

--- a/code/datums/research_upgrade_datum.dm
+++ b/code/datums/research_upgrade_datum.dm
@@ -5,12 +5,8 @@
 	var/desc = "something is broken. yippee!!"
 	///which behavior should this type follow. Should this be completely excluded from the buy menu? should it be one of the dropdown options? or a normal item?
 	var/behavior = RESEARCH_UPGRADE_EXCLUDE_BUY // should this be on the list?
-	//This is what gets passed to the initizialize of an item, RESEARCH_UPGRADE_NOTHING_TO_PASS to not pass anything.
-	var/on_init_argument = RESEARCH_UPGRADE_NOTHING_TO_PASS
 	/// the price of the upgrade, refer to this: 500 is a runner, 8k is queen. T3 is usually 3k, woyer is 2k.
 	var/value_upgrade = 1000
-	/// actual path to the item.(upgrade)
-	var/item_reference
 	///In which tab the upgrade should be.
 	var/upgrade_type
 	///Clearance requirment to buy this upgrade. 5x is level 6. Why is it not that way? no one knows.
@@ -22,6 +18,10 @@
 	///the maximum price which we cant go any more expensive, usually dont need to set this if change price is 0 or negative
 	var/maximum_price = INFINITY
 
+///gets called once the product is purchased, spawn items, etc.
+/datum/research_upgrades/proc/on_purchase(turf/machine_loc)
+	return
+
 /datum/research_upgrades/machinery
 	name = "Machinery"
 	behavior = RESEARCH_UPGRADE_CATEGORY // one on the dropdown choices you get
@@ -29,51 +29,59 @@
 /datum/research_upgrades/machinery/autodoc
 	name = "AutoDoc Upgrade"
 	behavior = RESEARCH_UPGRADE_EXCLUDE_BUY
-	item_reference = /obj/item/research_upgrades/autodoc
 	upgrade_type = ITEM_MACHINERY_UPGRADE
 
 /datum/research_upgrades/machinery/autodoc/internal_bleed
 	name = "AutoDoc Internal Bleeding Repair"
 	desc = "A data and instruction set for the AutoDoc, making it capable of rapidly fixing internal bleeding."
-	on_init_argument = RESEARCH_UPGRADE_TIER_1
 	behavior = RESEARCH_UPGRADE_ITEM
 	value_upgrade = 200
 	clearance_req = 1
 
+/datum/research_upgrades/machinery/autodoc/internal_bleed/on_purchase(turf/machine_loc)
+	new /obj/item/research_upgrades/autodoc(machine_loc, RESEARCH_UPGRADE_TIER_1)
+
 /datum/research_upgrades/machinery/autodoc/broken_bone
 	name = "AutoDoc Bone Fracture Repair"
 	desc = "A data instruction set for the AutoDoc, making it capable of setting fractures and applying bonegel."
-	on_init_argument = RESEARCH_UPGRADE_TIER_2
 	behavior = RESEARCH_UPGRADE_ITEM
 	value_upgrade = 2000
 	clearance_req = 3
 
+/datum/research_upgrades/machinery/autodoc/broken_bone/on_purchase(turf/machine_loc)
+	new /obj/item/research_upgrades/autodoc(machine_loc, RESEARCH_UPGRADE_TIER_2)
+
 /datum/research_upgrades/machinery/autodoc/organ_damage
 	name = "AutoDoc Broken Organ Repair"
 	desc = "A data and instruction set for the AutoDoc, making it capable of fixing organ damage."
-	on_init_argument = RESEARCH_UPGRADE_TIER_3
 	behavior = RESEARCH_UPGRADE_ITEM
 	value_upgrade = 1500
 	clearance_req = 2
 
+/datum/research_upgrades/machinery/autodoc/organ_damage/on_purchase(turf/machine_loc)
+	new /obj/item/research_upgrades/autodoc(machine_loc, RESEARCH_UPGRADE_TIER_3)
+
 /datum/research_upgrades/machinery/autodoc/larva_removal
 	name = "AutoDoc Embryo Removal"
 	desc = "Data and instruction set for AutoDoc making it mildly proficient in removing parasites left by unknown organism."
-	on_init_argument = RESEARCH_UPGRADE_TIER_4
 	behavior = RESEARCH_UPGRADE_ITEM
 	value_upgrade = 4000
 	clearance_req = 6
+
+/datum/research_upgrades/machinery/autodoc/larva_removal/on_purchase(turf/machine_loc)
+	new /obj/item/research_upgrades/autodoc(machine_loc, RESEARCH_UPGRADE_TIER_4)
 
 
 /datum/research_upgrades/machinery/sleeper
 	name = "Sleeper Upgrade"
 	desc = "Research upgrade for Sleeper system, technology on this disk is used on a sleeper to allow wider spectrum of chemicals to be administered, as well as upgrading dialysis software."
-	on_init_argument = RESEARCH_UPGRADE_NOTHING_TO_PASS
 	behavior = RESEARCH_UPGRADE_ITEM
 	value_upgrade = 500
-	item_reference = /obj/item/research_upgrades/sleeper
 	upgrade_type = ITEM_MACHINERY_UPGRADE
 	clearance_req = 1
+
+/datum/research_upgrades/machinery/sleeper/on_purchase(turf/machine_loc)
+	new /obj/item/research_upgrades/sleeper(machine_loc)
 
 /datum/research_upgrades/item
 	name = "Items"
@@ -83,33 +91,36 @@
 	name = "Research Credits"
 	desc = "Sell the data acquired to the nearest Weyland-Yutani Science division team for 8 or 9 points."
 	value_upgrade = 2000
-	item_reference = /obj/item/research_upgrades/credits
-	on_init_argument = RESEARCH_UPGRADE_NOTHING_TO_PASS
 	behavior = RESEARCH_UPGRADE_ITEM
 	upgrade_type = ITEM_ACCESSORY_UPGRADE
 	change_purchase = 500
 	maximum_price = 5000
 	clearance_req = 5
 
+/datum/research_upgrades/item/research_credits/on_purchase(turf/machine_loc)
+	new /obj/item/research_upgrades/credits(machine_loc)
+
 /datum/research_upgrades/item/laser_scalpel
 	name = "Laser Scalpel"
 	desc = "An advanced, robust version of the normal scalpel, allowing it to pierce through thick skin and chitin alike with extreme ease."
 	value_upgrade = 3000
-	item_reference = /obj/item/tool/surgery/scalpel/laser/advanced
-	on_init_argument = RESEARCH_UPGRADE_NOTHING_TO_PASS
 	behavior = RESEARCH_UPGRADE_ITEM
 	upgrade_type = ITEM_ACCESSORY_UPGRADE
 	clearance_req = 3
+
+/datum/research_upgrades/item/laser_scalpel/on_purchase(turf/machine_loc)
+	new /obj/item/tool/surgery/scalpel/laser/advanced(machine_loc)
 
 /datum/research_upgrades/item/incision_management
 	name = "Incision Management System"
 	desc = "A true extension of the surgeon's body, this marvel instantly and completely prepares an incision, allowing for the immediate commencement of therapeutic steps."
 	value_upgrade = 3000
-	item_reference = /obj/item/tool/surgery/scalpel/manager
-	on_init_argument = RESEARCH_UPGRADE_NOTHING_TO_PASS
 	behavior = RESEARCH_UPGRADE_ITEM
 	upgrade_type = ITEM_ACCESSORY_UPGRADE
 	clearance_req = 4
+
+/datum/research_upgrades/item/incision_management/on_purchase(turf/machine_loc)
+	new /obj/item/tool/surgery/scalpel/manager(machine_loc)
 
 /datum/research_upgrades/item/nanosplints
 	name = "Reinforced Fiber Splints"
@@ -118,10 +129,11 @@
 	clearance_req = 3
 	change_purchase = -200
 	minimum_price = 200
-	item_reference = /obj/item/stack/medical/splint/nano/research
-	on_init_argument = RESEARCH_UPGRADE_TIER_5 //adjust this to change amount of nanosplints in a stack, cant be higher than five, go change max_amount in the nanosplint itself, then change it.
 	behavior = RESEARCH_UPGRADE_ITEM
 	upgrade_type = ITEM_ACCESSORY_UPGRADE
+
+/datum/research_upgrades/item/nanosplints/on_purchase(turf/machine_loc)
+	new /obj/item/stack/medical/splint/nano/research(machine_loc, 5)//adjust this to change amount of nanosplints in a stack, cant be higher than five, go change max_amount in the nanosplint itself, then change it.
 
 /datum/research_upgrades/item/flamer_tank
 	name = "Upgraded Incinerator Tank"
@@ -131,20 +143,23 @@
 	change_purchase = 100
 	minimum_price = 100
 	maximum_price = 1000
-	item_reference = /obj/item/ammo_magazine/flamer_tank/custom/upgraded
-	on_init_argument = RESEARCH_UPGRADE_NOTHING_TO_PASS
 	behavior = RESEARCH_UPGRADE_ITEM
 	upgrade_type = ITEM_ACCESSORY_UPGRADE
+
+/datum/research_upgrades/item/flamer_tank/on_purchase(turf/machine_loc)
+	new /obj/item/ammo_magazine/flamer_tank/custom/upgraded(machine_loc)
 
 /datum/research_upgrades/item/flamer_tank/smoke
 	name = "Upgraded Incinerator Smoke Tank"
 	desc = "An upgraded incinerator smoke tank with a larger capacity."
 	value_upgrade = 100 //not useful enough to be expensive
 	clearance_req = 1
-	item_reference = /obj/item/ammo_magazine/flamer_tank/smoke/upgraded
 	change_purchase = 50
 	minimum_price = 100
 	maximum_price = 500
+
+/datum/research_upgrades/item/flamer_tank/smoke/on_purchase(turf/machine_loc)
+	new /obj/item/ammo_magazine/flamer_tank/smoke/upgraded(machine_loc)
 
 /datum/research_upgrades/armor
 	name = "Armor"
@@ -154,58 +169,61 @@
 	name = "Universal Translator Plate"
 	desc = "A uniform-attachable plate capable of translating any unknown language heard by the wearer."
 	value_upgrade = 2000
-	on_init_argument = RESEARCH_UPGRADE_NOTHING_TO_PASS
 	behavior = RESEARCH_UPGRADE_ITEM
 	clearance_req = 6
 	upgrade_type = ITEM_ARMOR_UPGRADE
-	item_reference = /obj/item/clothing/accessory/health/research_plate/translator
 
+/datum/research_upgrades/armor/translator/on_purchase(turf/machine_loc)
+	new /obj/item/clothing/accessory/health/research_plate/translator(machine_loc)
 
 /datum/research_upgrades/armor/coagulator
 	name = "Active Blood Coagulator Plate"
 	desc = "A uniform-attachable plate capable of coagulating any bleeding wounds the user possesses."
 	value_upgrade = 1200
-	on_init_argument = RESEARCH_UPGRADE_NOTHING_TO_PASS
 	behavior = RESEARCH_UPGRADE_ITEM
 	clearance_req = 2
 	change_purchase = -200
 	minimum_price = 200
 	upgrade_type = ITEM_ARMOR_UPGRADE
-	item_reference = /obj/item/clothing/accessory/health/research_plate/coagulator
+
+/datum/research_upgrades/armor/coagulator/on_purchase(turf/machine_loc)
+	new /obj/item/clothing/accessory/health/research_plate/coagulator(machine_loc)
 
 /datum/research_upgrades/armor/emergency_injector
 	name = "Medical Emergency Injector"
 	desc = "A medical plate with two buttons on the sides and a hefty chemical tank. Attached to a uniform and on a simultaneous press, it injects an emergency dose of medical chemicals much larger than a normal emergency autoinjector. Single time use and is recycled in biomass printer. Features overdose protection."
 	value_upgrade = 250
 	clearance_req = 1
-	on_init_argument = RESEARCH_UPGRADE_NOTHING_TO_PASS
 	behavior = RESEARCH_UPGRADE_ITEM
 	change_purchase = -100
 	minimum_price = 100
 	upgrade_type = ITEM_ARMOR_UPGRADE
-	item_reference = /obj/item/clothing/accessory/health/research_plate/emergency_injector
+
+/datum/research_upgrades/armor/emergency_injector/on_purchase(turf/machine_loc)
+	new /obj/item/clothing/accessory/health/research_plate/emergency_injector(machine_loc)
 
 /datum/research_upgrades/armor/ceramic
 	name = "Ceramic Armor Plate"
 	desc = "A strong trauma plate, able to protect the user from a large amount of bullets. Completely useless against sharp objects."
 	value_upgrade = 500
 	clearance_req = 4
-	on_init_argument = RESEARCH_UPGRADE_NOTHING_TO_PASS
 	behavior = RESEARCH_UPGRADE_ITEM
 	upgrade_type = ITEM_ARMOR_UPGRADE
 	change_purchase = -50
 	minimum_price = 200
-	item_reference = /obj/item/clothing/accessory/health/ceramic_plate
+
+/datum/research_upgrades/armor/ceramic/on_purchase(turf/machine_loc)
+	new /obj/item/clothing/accessory/health/ceramic_plate(machine_loc)
 
 /datum/research_upgrades/armor/preservation
 	name = "Death Preservation Plate"
 	desc = "Preservation plate which activates once the user is dead, uses variety of different substances and sensors to slow down the decay and increase the time before the user is permanently dead, due to small tank of preservatives, it needs to be replaced on each death. Extends time to permadeath by around four minutes."
 	value_upgrade = 500
 	clearance_req = 4
-	on_init_argument = RESEARCH_UPGRADE_NOTHING_TO_PASS
 	behavior = RESEARCH_UPGRADE_ITEM
 	upgrade_type = ITEM_ARMOR_UPGRADE
 	change_purchase = -100
 	minimum_price = 100
-	item_reference = /obj/item/clothing/accessory/health/research_plate/anti_decay
 
+/datum/research_upgrades/armor/preservation/on_purchase(turf/machine_loc)
+	new /obj/item/clothing/accessory/health/research_plate/anti_decay(machine_loc)

--- a/code/datums/research_upgrade_datum.dm
+++ b/code/datums/research_upgrade_datum.dm
@@ -25,7 +25,6 @@
 	if(isnull(item_reference))
 		return
 	new item_reference(machine_loc)
-	return
 
 /datum/research_upgrades/machinery
 	name = "Machinery"

--- a/code/modules/reagents/chemistry_machinery/xenomorph_analyzer.dm
+++ b/code/modules/reagents/chemistry_machinery/xenomorph_analyzer.dm
@@ -143,7 +143,7 @@
 	busy = FALSE
 
 
-/obj/structure/machinery/xenoanalyzer/proc/start_print_upgrade(produce_path, mob/user, variation)
+/obj/structure/machinery/xenoanalyzer/proc/start_print_upgrade(produce_path, mob/user)
 	if(stat & NOPOWER)
 		icon_state = "xeno_analyzer_off"
 		return

--- a/code/modules/reagents/chemistry_machinery/xenomorph_analyzer.dm
+++ b/code/modules/reagents/chemistry_machinery/xenomorph_analyzer.dm
@@ -96,9 +96,8 @@
 		data["upgrades"] += list(list(
 			"name" = capitalize_first_letters(upgrade.name),
 			"desc" = upgrade.desc,
-			"vari" = upgrade.on_init_argument,
 			"cost" = price_adjustment,
-			"ref" = upgrade.item_reference,
+			"ref" = upgrade_type,
 			"category" = upgrade.upgrade_type,
 			"clearance" = upgrade.clearance_req,
 			"price_change" = upgrade.change_purchase,
@@ -125,7 +124,7 @@
 				. = TRUE
 		if("produce")
 			if(!busy)
-				start_print_upgrade(text2path(params["ref"]), usr, text2num(params["vari"]))
+				start_print_upgrade(text2path(params["ref"]), usr)
 	playsound(src, 'sound/machines/keyboard2.ogg', 25, TRUE)
 
 /obj/structure/machinery/xenoanalyzer/proc/eject_biomass(mob/user)
@@ -158,7 +157,7 @@
 		upgrade = datum_upgrades
 		if(upgrade.behavior == RESEARCH_UPGRADE_CATEGORY || upgrade.behavior == RESEARCH_UPGRADE_EXCLUDE_BUY)
 			continue
-		if(produce_path == upgrade.item_reference && upgrade.on_init_argument == variation)
+		if(produce_path == datum_upgrades)
 			path_exists = TRUE
 			break
 	if(!path_exists)
@@ -174,12 +173,10 @@
 	busy = TRUE
 	biomass_points -= clamp(upgrade.value_upgrade + upgrade.change_purchase * technology_purchased[datum_upgrades], upgrade.minimum_price, upgrade.maximum_price)
 	technology_purchased[datum_upgrades] += 1
-	addtimer(CALLBACK(src, PROC_REF(print_upgrade), produce_path, variation), 3 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(print_upgrade), produce_path), 3 SECONDS)
 
-/obj/structure/machinery/xenoanalyzer/proc/print_upgrade(produce_path, variation)
+/obj/structure/machinery/xenoanalyzer/proc/print_upgrade(produce_path)
 	busy = FALSE
-	if(variation != RESEARCH_UPGRADE_NOTHING_TO_PASS)
-		new produce_path(get_turf(src), variation)
-		return
-	new produce_path(get_turf(src))
+	var/datum/research_upgrades/item = new produce_path()
+	item.on_purchase(get_turf(src))
 

--- a/tgui/packages/tgui/interfaces/XenomorphExtractor.jsx
+++ b/tgui/packages/tgui/interfaces/XenomorphExtractor.jsx
@@ -1,5 +1,6 @@
-import { useBackend } from '../backend';
 import { useState } from 'react';
+
+import { useBackend } from '../backend';
 import {
   Box,
   Button,
@@ -107,7 +108,6 @@ export const XenomorphExtractor = () => {
                                 onClick={() =>
                                   act('produce', {
                                     ref: upgrades.ref,
-                                    vari: upgrades.vari,
                                   })
                                 }
                               >


### PR DESCRIPTION
# About the pull request
Ever since the init argument pr I had common sense take over and understand how goofy that was, so we are now here. This makes it *much* easier to add technology that doesnt spawn something. eg techtree upgrades while also stopping the init var nonsense, THIS is how it should have been.

Merge after anti caustic armor so I can adapt it easily
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
If someone adds upgrade that does something that requires non physical items, they can now.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
code: Research datum now supports more broad ideas in the future.
/:cl:
