### PR TITLE
Standardises unmeltable SG & Specialist Gear, and removes the (now-legacy) SG kit from req.

### DIFF
--- a/code/datums/supply_packs/weapons.dm
+++ b/code/datums/supply_packs/weapons.dm
@@ -1,13 +1,3 @@
-/datum/supply_packs/m56b_smartgun
-	name = "M56B Smartgun System Package (x1)"
-	contains = list(
-		/obj/item/storage/box/m56_system,
-	)
-	cost = 100
-	containertype = /obj/structure/closet/crate/weapon
-	containername = "M56B Smartgun System Package"
-	group = "Weapons"
-
 /datum/supply_packs/m56_hmg
 	name = "M56D Heavy Machine Gun (x1)"
 	contains = list(

--- a/code/modules/clothing/suits/marine_armor/ghillie.dm
+++ b/code/modules/clothing/suits/marine_armor/ghillie.dm
@@ -11,6 +11,7 @@
 	specialty = "M45 pattern ghillie"
 	valid_accessory_slots = list(ACCESSORY_SLOT_ARMBAND, ACCESSORY_SLOT_DECOR, ACCESSORY_SLOT_MEDAL, ACCESSORY_SLOT_PONCHO)
 	restricted_accessory_slots = list(ACCESSORY_SLOT_ARMBAND)
+	unacidable = TRUE
 
 	var/camo_active = FALSE
 	var/hide_in_progress = FALSE

--- a/code/modules/clothing/suits/marine_armor/smartgunner.dm
+++ b/code/modules/clothing/suits/marine_armor/smartgunner.dm
@@ -9,6 +9,7 @@
 	storage_slots = 2
 	slowdown = SLOWDOWN_ARMOR_LIGHT
 	flags_inventory = BLOCKSHARPOBJ|SMARTGUN_HARNESS
+	unacidable = TRUE
 	allowed = list(
 		/obj/item/tank/emergency_oxygen,
 		/obj/item/device/flashlight,


### PR DESCRIPTION
# About the pull request
This PR makes the M56 Combat Harness & the M45 Ghillie Suit unmeltable, and removes the $10K SG kit from requisitions, now that there is no need for SGs to buy it if their shit gets melted.

The purpose of this PR is to standardise the ongoing trend of unmeltable unique marine gear, and serves to patch up the stragglers that were left behind during the initial un-meltification of specialist & SG equipment.

I have tested all my changes- I can confirm the SG kit is no longer in req, and that you can no longer melt the M56 Combat Harness, nor the M45 Ghillie Suit. I have also tested for any spec kits that are still meltable, and found none (besides the sniper, which I fixed.)

# Explain why it's good for the game

The pain of losing your unique gear to Young Drone (XX-420) while your fellow protagonists have unmeltable gear is well-felt across the playerbase. John Marine strips your ass of your gear to defib you on the frontline, the xenos overrun your position, you go back to retrieve it, but it's been melted to shit because a sentinel took the 0.5 microseconds needed to melt it down. Congrats. You rolled SG, and you are now useless, because whilst your gun is unmeltable, for some strange reason your armour isn't.
If you're the sniper, it sucks a bit less since you don't need the armour to fire your gun- But still, you've lost your sweet camo armour and are now dripless.

I removed the SG kit from req because it's useless now, plus no one used it anyways because it costs 10K (and also Drathek told me to)


# Testing Photographs and Procedure
![Screenshot 2024-08-07 144616](https://github.com/user-attachments/assets/e229e4ea-2b3b-4422-8977-264dc4a1e268)
(The SG kit has been thanos snapped from req)
![Screenshot 2024-08-07 143618](https://github.com/user-attachments/assets/d0df683a-3fff-4a9b-a71a-81d74a5a7c43)
(The M45 Ghillie Suit is no longer meltable now, despite what the image says)
# Changelog

:cl:
del: removed the M56B Smartgun Kit from requisitions.
balance: made the M56 Combat Harness unmeltable.
balance: made the M45 Ghillie Suit unmeltable.
/:cl:
