### PR TITLE
Playing cards are vanity accessories for helmets

### DIFF
--- a/code/game/objects/items/toys/cards.dm
+++ b/code/game/objects/items/toys/cards.dm
@@ -266,6 +266,7 @@
 	icon = 'icons/obj/items/playing_cards.dmi'
 	icon_state = "empty"
 	w_class = SIZE_TINY
+	flags_obj = parent_type::flags_obj|OBJ_IS_HELMET_GARB
 
 	var/concealed = FALSE
 	var/pile_state = FALSE


### PR DESCRIPTION

# About the pull request

Adds helmet garb flags to playing cards

# Explain why it's good for the game

Flavor and vanity is cool, you shouldnt have to sacrifice storage for something so minor

# Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/eff1445f-c063-4b56-beaf-5f48eebc2e78)
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

![image](https://github.com/user-attachments/assets/b19ebb15-6ddc-4795-8969-86f9e71bef91)


</details>


# Changelog
:cl: Asmocard
qol: Playing cards no longer take a storage slot from your helmet, they take a vanity slot now.
/:cl:
