### PR TITLE
Reorders the Essential SG Kit

### DIFF
--- a/code/modules/cm_marines/equipment/weapons.dm
+++ b/code/modules/cm_marines/equipment/weapons.dm
@@ -12,10 +12,10 @@
 
 /obj/item/storage/box/m56_system/Initialize()
 	. = ..()
-	new /obj/item/clothing/glasses/night/m56_goggles(src)
-	new /obj/item/weapon/gun/smartgun(src)
-	new /obj/item/smartgun_battery(src)
 	new /obj/item/clothing/suit/storage/marine/smartgunner(src)
+	new /obj/item/weapon/gun/smartgun(src)
+	new /obj/item/clothing/glasses/night/m56_goggles(src)
+	new /obj/item/smartgun_battery(src)
 	for(var/i in 1 to 3)
 		new /obj/item/ammo_magazine/smartgun(src)
 	update_icon()


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->
Reorders the Essential SG Kit
OLD: Goggles, Gun, Battery, Armor, 3 Ammo
NEW: Armor, Gun, Goggles, Battery, 3 Ammo

# Explain why it's good for the game
Goggles require the gun, gun requires the armor. By placing them in this order, it becomes easier for new players to learn this requirement and equip the kit.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Reorders the Essential SG Kit in order of Armor, Smartgun, Goggles
/:cl:
