### PR TITLE
Fixes teslas in fiorina

### DIFF
--- a/code/modules/defenses/tesla_coil.dm
+++ b/code/modules/defenses/tesla_coil.dm
@@ -84,11 +84,13 @@
 		targets += M
 	FOR_DOVIEW_END
 
-	if(attack_defenses)
-		FOR_DOVIEW(var/obj/structure/machinery/defenses/D, tesla_range, src, HIDE_INVISIBLE_OBSERVER)
-			if(D.turned_on)
-				targets += D
-		FOR_DOVIEW_END
+	if(!attack_defenses)
+		return
+
+	FOR_DOVIEW(var/obj/structure/machinery/defenses/D, tesla_range, src, HIDE_INVISIBLE_OBSERVER)
+		if(D.turned_on)
+			targets += D
+	FOR_DOVIEW_END
 
 /obj/structure/machinery/defenses/tesla_coil/proc/fire(atoms)
 	if(!(world.time - last_fired >= fire_delay) || !turned_on)

--- a/code/modules/defenses/tesla_coil.dm
+++ b/code/modules/defenses/tesla_coil.dm
@@ -11,6 +11,7 @@
 	var/last_fired = 0
 	var/tesla_range = TESLA_COIL_RANGE
 	var/fire_delay = TESLA_COIL_FIREDELAY
+	var/attack_defenses = TRUE
 	handheld_type = /obj/item/defenses/handheld/tesla_coil
 	disassemble_time = 10
 	health = 150
@@ -83,10 +84,11 @@
 		targets += M
 	FOR_DOVIEW_END
 
-	FOR_DOVIEW(var/obj/structure/machinery/defenses/D, tesla_range, src, HIDE_INVISIBLE_OBSERVER)
-		if(D.turned_on)
-			targets += D
-	FOR_DOVIEW_END
+	if(attack_defenses)
+		FOR_DOVIEW(var/obj/structure/machinery/defenses/D, tesla_range, src, HIDE_INVISIBLE_OBSERVER)
+			if(D.turned_on)
+				targets += D
+		FOR_DOVIEW_END
 
 /obj/structure/machinery/defenses/tesla_coil/proc/fire(atoms)
 	if(!(world.time - last_fired >= fire_delay) || !turned_on)
@@ -158,6 +160,17 @@
 		targets = null
 
 	. = ..()
+
+// For mapping
+/obj/structure/machinery/defenses/tesla_coil/premade
+	turned_on = TRUE
+	static = TRUE
+
+/obj/structure/machinery/defenses/tesla_coil/premade/attackby(obj/item/O, mob/user)
+	return
+
+/obj/structure/machinery/defenses/tesla_coil/premade/smart
+	attack_defenses = FALSE
 
 #define TESLA_COIL_STUN_FIRE_DELAY 3 SECONDS
 #define TESLA_COIL_STUN_EFFECT 1

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -845,7 +845,7 @@
 /turf/open/floor/prison/floor_plate,
 /area/fiorina/station/telecomm/lz1_cargo)
 "aFp" = (
-/obj/structure/machinery/defenses/tesla_coil{
+/obj/structure/machinery/defenses/tesla_coil/premade/smart{
 	faction_group = list("CLF")
 	},
 /turf/open/floor/plating/plating_catwalk,
@@ -30182,7 +30182,7 @@
 /turf/open/floor/corsat/squares,
 /area/fiorina/station/medbay)
 "xgx" = (
-/obj/structure/machinery/defenses/tesla_coil{
+/obj/structure/machinery/defenses/tesla_coil/premade{
 	faction_group = list("USCM")
 	},
 /turf/open/organic/grass/astroturf,


### PR DESCRIPTION

# About the pull request
Closes #1090 
Makes the tesla on the scavenger ship unhackable for consistency as well as not shoot the sentry right next to it due to how crowded the space is
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Fixes a bug
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixed the premade tesla coils on Fiorina

/:cl:
