### PR TITLE
Chat Filter

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -19,7 +19,7 @@
 	var/motd
 	var/policy
 
-	var/static/regex/ic_filter_regex
+	var/static/regex/word_filter_regex
 
 	var/is_loaded = FALSE
 
@@ -315,21 +315,21 @@
 
 
 /datum/controller/configuration/proc/LoadChatFilter()
-	var/list/in_character_filter = list()
+	var/list/word_filter = list()
 
-	if(!fexists("[directory]/in_character_filter.txt"))
+	if(!fexists("[directory]/word_filter.txt"))
 		return
 
-	log_config("Loading config file in_character_filter.txt...")
+	log_config("Loading config file word_filter.txt...")
 
-	for(var/line in file2list("[directory]/in_character_filter.txt"))
+	for(var/line in file2list("[directory]/word_filter.txt"))
 		if(!line)
 			continue
 		if(findtextEx(line,"#",1,2))
 			continue
-		in_character_filter += REGEX_QUOTE(line)
+		word_filter += REGEX_QUOTE(line)
 
-	ic_filter_regex = length(in_character_filter) ? regex("\\b([jointext(in_character_filter, "|")])\\b", "i") : null
+	word_filter_regex = length(word_filter) ? regex("\\b([jointext(word_filter, "|")])\\b", "i") : null
 
 //Message admins when you can.
 /datum/controller/configuration/proc/DelayedMessageAdmins(text)

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -673,4 +673,4 @@ This maintains a list of ip addresses that are able to bypass topic filtering.
 
 /datum/config_entry/string/org
 
-/datum/config_entry/str_list/word_filter
+/datum/config_entry/string/word_filter

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -672,5 +672,3 @@ This maintains a list of ip addresses that are able to bypass topic filtering.
 /datum/config_entry/string/repo_name
 
 /datum/config_entry/string/org
-
-/datum/config_entry/string/word_filter

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -672,3 +672,5 @@ This maintains a list of ip addresses that are able to bypass topic filtering.
 /datum/config_entry/string/repo_name
 
 /datum/config_entry/string/org
+
+/datum/config_entry/str_list/word_filter

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -7,6 +7,9 @@
 		to_chat(src, "Guests may not use OOC.")
 		return
 
+	if(!filter_message(src, msg))
+		return
+
 	msg = trim(strip_html(msg))
 	if(!msg) return
 
@@ -99,6 +102,9 @@
 	if(!mob) return
 	if(IsGuestKey(key))
 		to_chat(src, "Guests may not use LOOC.")
+		return
+
+	if(!filter_message(src, msg))
 		return
 
 	msg = trim(strip_html(msg))

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -12,6 +12,9 @@
 		if (src.client.handle_spam_prevention(message, MUTE_DEADCHAT))
 			return
 
+	if(!filter_message(src, message))
+		return
+
 	. = src.say_dead(message)
 
 

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -12,7 +12,7 @@
 		if (src.client.handle_spam_prevention(message, MUTE_DEADCHAT))
 			return
 
-	if(!filter_message(src, message))
+	if(!filter_message(client, message))
 		return
 
 	. = src.say_dead(message)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -62,12 +62,12 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 /proc/prefix_to_channel(prefix)
 	return GLOB.department_radio_keys[prefix]
 
-/proc/filter_message(user, message)
+/proc/filter_message(client/user, message)
 	var/filter = CONFIG_GET(string/word_filter)
 	var/message_lowercase = lowertext(message)
 	if(!filter)
 		return TRUE
-		
+
 	if(findtext(message_lowercase, regex(filter)))
 		to_chat(user,
 			html = "\n<font color='red' size='4'><b>-- Word Filter Message --</b></font>",
@@ -77,9 +77,9 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			html = "\n<font color='red' size='4'><b>Your message has been automatically filtered due to its contents. Trying to circumvent this filter will get you banned.</b></font>",
 			)
 		SEND_SOUND(user, sound('sound/effects/adminhelp_new.ogg'))
-		log_admin("[user.client] triggered the chat filter with the following message: [message].")
+		log_admin("[user.ckey] triggered the chat filter with the following message: [message].")
 		return FALSE
-	
+
 	return TRUE
 
 ///Shows custom speech bubbles for screaming, *warcry etc.

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -63,20 +63,21 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	return GLOB.department_radio_keys[prefix]
 
 /proc/filter_message(user, message)
-	var/list/banned_words = CONFIG_GET(str_list/word_filter)
+	var/filter = CONFIG_GET(string/word_filter)
 	var/message_lowercase = lowertext(message)
-
-	for(var/word in banned_words)
-		if(findtext(message_lowercase, regex(lowertext(word))))
-			to_chat(user,
-				html = "\n<font color='red' size='4'><b>-- Word Filter Message --</b></font>",
-				)
-			to_chat(user,
-				type = MESSAGE_TYPE_ADMINPM,
-				html = "\n<font color='red' size='4'><b>Your message has been automatically filtered due to its contents. Trying to circumvent this filter will get you banned.</b></font>",
-				)
-			SEND_SOUND(user, sound('sound/effects/adminhelp_new.ogg'))
-			return FALSE
+	if(!filter)
+		return TRUE
+		
+	if(findtext(message_lowercase, regex(filter)))
+		to_chat(user,
+			html = "\n<font color='red' size='4'><b>-- Word Filter Message --</b></font>",
+			)
+		to_chat(user,
+			type = MESSAGE_TYPE_ADMINPM,
+			html = "\n<font color='red' size='4'><b>Your message has been automatically filtered due to its contents. Trying to circumvent this filter will get you banned.</b></font>",
+			)
+		SEND_SOUND(user, sound('sound/effects/adminhelp_new.ogg'))
+		return FALSE
 	
 	return TRUE
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -63,12 +63,10 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	return GLOB.department_radio_keys[prefix]
 
 /proc/filter_message(client/user, message)
-	var/filter = CONFIG_GET(string/word_filter)
-	var/message_lowercase = lowertext(message)
-	if(!filter)
+	if(!config.word_filter_regex)
 		return TRUE
 
-	if(findtext(message_lowercase, regex(filter)))
+	if(config.word_filter_regex.Find(message))
 		to_chat(user,
 			html = "\n<font color='red' size='4'><b>-- Word Filter Message --</b></font>",
 			)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -77,6 +77,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			html = "\n<font color='red' size='4'><b>Your message has been automatically filtered due to its contents. Trying to circumvent this filter will get you banned.</b></font>",
 			)
 		SEND_SOUND(user, sound('sound/effects/adminhelp_new.ogg'))
+		log_admin("[user.client] triggered the chat filter with the following message: [message].")
 		return FALSE
 	
 	return TRUE

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -67,7 +67,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	var/message_lowercase = lowertext(message)
 
 	for(var/word in banned_words)
-		if(findtext(message_lowercase, lowertext(word)))
+		if(findtext(message_lowercase, regex(lowertext(word))))
 			to_chat(user,
 				html = "\n<font color='red' size='4'><b>-- Word Filter Message --</b></font>",
 				)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -62,6 +62,24 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 /proc/prefix_to_channel(prefix)
 	return GLOB.department_radio_keys[prefix]
 
+/proc/filter_message(user, message)
+	var/list/banned_words = CONFIG_GET(str_list/word_filter)
+	var/message_lowercase = lowertext(message)
+
+	for(var/word in banned_words)
+		if(findtext(message_lowercase, lowertext(word)))
+			to_chat(user,
+				html = "\n<font color='red' size='4'><b>-- Word Filter Message --</b></font>",
+				)
+			to_chat(user,
+				type = MESSAGE_TYPE_ADMINPM,
+				html = "\n<font color='red' size='4'><b>Your message has been automatically filtered due to its contents. Trying to circumvent this filter will get you banned.</b></font>",
+				)
+			SEND_SOUND(user, sound('sound/effects/adminhelp_new.ogg'))
+			return FALSE
+	
+	return TRUE
+
 ///Shows custom speech bubbles for screaming, *warcry etc.
 /mob/living/proc/show_speech_bubble(bubble_name, bubble_type = bubble_icon)
 
@@ -80,6 +98,9 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	var/turf/T
 
 	if(SEND_SIGNAL(src, COMSIG_LIVING_SPEAK, message, speaking, verb, alt_name, italics, message_range, speech_sound, sound_vol, nolog, message_mode) & COMPONENT_OVERRIDE_SPEAK) return
+
+	if(!filter_message(src, message))
+		return
 
 	message = process_chat_markup(message, list("~", "_"))
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -5,6 +5,7 @@
 # $include resources.txt
 # $include icon_source.txt
 # $include relays.txt
+$include word_filter.txt
 
 ## Server name: This appears at the top of the screen in-game. In this case it will read "tgstation: station_name" where station_name is the randomly generated name of the station for the round. Remove the # infront of SERVERNAME and replace 'tgstation' with the name of your choice
 # SERVERNAME spacestation13

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -5,7 +5,6 @@
 # $include resources.txt
 # $include icon_source.txt
 # $include relays.txt
-# $include word_filter.txt
 
 ## Server name: This appears at the top of the screen in-game. In this case it will read "tgstation: station_name" where station_name is the randomly generated name of the station for the round. Remove the # infront of SERVERNAME and replace 'tgstation' with the name of your choice
 # SERVERNAME spacestation13

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -5,7 +5,7 @@
 # $include resources.txt
 # $include icon_source.txt
 # $include relays.txt
-$include word_filter.txt
+# $include word_filter.txt
 
 ## Server name: This appears at the top of the screen in-game. In this case it will read "tgstation: station_name" where station_name is the randomly generated name of the station for the round. Remove the # infront of SERVERNAME and replace 'tgstation' with the name of your choice
 # SERVERNAME spacestation13

--- a/config/example/word_filter.txt
+++ b/config/example/word_filter.txt
@@ -1,0 +1,1 @@
+# Words that should be filtered from being said, both IC and OOC, should be included here, one per line. Case insensitive.

--- a/config/example/word_filter.txt
+++ b/config/example/word_filter.txt
@@ -1,3 +1,0 @@
-## Word filter
-## WORD_FILTER <regex_expression>
-## Case sensitive

--- a/config/example/word_filter.txt
+++ b/config/example/word_filter.txt
@@ -1,6 +1,4 @@
 ## Word filter
-## WORD_FILTER <word>
-## Case insensitive, Uses regex
-#WORD_FILTER wordToBan
-#WORD_FILTER otherwordtoban
-#WORD_FILTER wordtoban.*withregex
+## WORD_FILTER <regex_expression>
+## Case sensitive
+WORD_FILTER retard

--- a/config/example/word_filter.txt
+++ b/config/example/word_filter.txt
@@ -1,4 +1,3 @@
 ## Word filter
 ## WORD_FILTER <regex_expression>
 ## Case sensitive
-WORD_FILTER retard

--- a/config/example/word_filter.txt
+++ b/config/example/word_filter.txt
@@ -1,0 +1,4 @@
+## Word filter
+## WORD_FILTER <word>
+## Case insensitive
+#WORD_FILTER wordToBan

--- a/config/example/word_filter.txt
+++ b/config/example/word_filter.txt
@@ -1,4 +1,6 @@
 ## Word filter
 ## WORD_FILTER <word>
-## Case insensitive
+## Case insensitive, Uses regex
 #WORD_FILTER wordToBan
+#WORD_FILTER otherwordtoban
+#WORD_FILTER wordtoban.*withregex


### PR DESCRIPTION

# About the pull request
Adds a chat filter which automatically prevents messages in-character, OOC, LOOC or dchat from being sent if they contain certain words, this will notify the user and warn them that they will be banned should they try to circumvent it.

This is obviously just a config option so if this is merged the config will have to be edited accordingly.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Instead of instantly banning people for saying certain words, simply prevents them from saying them in the first place - this way no harm is done to anyone who might be offended as well as the player which (possibly mistakenly) said the word not being banned and instead let know the word is not allowed.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
config: Added config options for filtering out certain words
/:cl:
