### PR TITLE
FIX Kutjevo Botany APC that can't be fixed

### DIFF
--- a/html/changelogs/majchroo-pr-6909.yml
+++ b/html/changelogs/majchroo-pr-6909.yml
@@ -1,0 +1,4 @@
+author: "majchroo"
+delete-after: True
+changes:
+  - maptweak: "Moved the unfixable APC at Kutjevo Botany to make it fixable again."

--- a/html/changelogs/majchroo-pr-6909.yml
+++ b/html/changelogs/majchroo-pr-6909.yml
@@ -1,4 +1,0 @@
-author: "majchroo"
-delete-after: True
-changes:
-  - maptweak: "Moved the unfixable APC at Kutjevo Botany to make it fixable again."

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -11208,9 +11208,8 @@
 /turf/open/gm/river/desert/deep/toxic,
 /area/kutjevo/interior/oob)
 "qwT" = (
-/obj/item/tool/wirecutters/clippers,
 /obj/structure/machinery/power/apc/no_power/north,
-/turf/open/auto_turf/sand/layer0,
+/turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/interior/complex/botany)
 "qxc" = (
 /obj/structure/barricade/metal/wired{
@@ -33382,7 +33381,7 @@ lHs
 kDS
 xQM
 mbS
-nCM
+qwT
 bds
 qGA
 mbS
@@ -33884,7 +33883,7 @@ kDS
 alh
 mbS
 mbS
-qwT
+qGA
 xfW
 nCM
 mbS


### PR DESCRIPTION
# About the pull request

**TL;DR APC can't be fixed, moved to a place where it can be fixed.**

Kutjevo Botany APC is placed on a "dirt" tile (auto_turf to be precise) and so it means that engineers can't use crowbar on that tile and rewire the terminal underneath.

# Explain why it's good for the game

Engineers will be able to fix power in botany on Kutjevo.

# Testing Photographs and Procedure
Moved the APC using StrongDMM. Booted up the server and made sure I can fix it as a spawned engineer.

<details>
<summary>Screenshots & Videos</summary>

Before:
![image](https://github.com/user-attachments/assets/12b384d8-2a02-4065-9470-c36bc1356857)

After:
![image](https://github.com/user-attachments/assets/1f00e1c9-cbd2-4127-be35-583ba5bb99b9)

Proof of testing:
![image](https://github.com/user-attachments/assets/bc48dfd6-6381-4f59-a407-398bf40d4db6)

</details>

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:Adamix147
maptweak: Moved the unfixable APC at Kutjevo Botany to make it fixable again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
