### PR TITLE
Disallows Scout In HvH

### DIFF
--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -581,8 +581,13 @@ GLOBAL_LIST_EMPTY(vending_products)
 							var/specialist_assignment
 							switch(p_name)
 								if("Scout Set")
-									user.skills.set_skill(SKILL_SPEC_WEAPONS, SKILL_SPEC_SCOUT)
-									specialist_assignment = "Scout"
+									if(MODE_HAS_FLAG(MODE_FACTION_CLASH))
+										to_chat(user, SPAN_WARNING("No scout on HvH."))
+										vend_fail()
+										return FALSE
+									else
+										user.skills.set_skill(SKILL_SPEC_WEAPONS, SKILL_SPEC_SCOUT)
+										specialist_assignment = "Scout"
 								if("Sniper Set")
 									user.skills.set_skill(SKILL_SPEC_WEAPONS, SKILL_SPEC_SNIPER)
 									specialist_assignment = "Sniper"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR makes it that you can not select the Scout Specialist during the 'Faction Clash' HvH game mode. 

# Explain why it's good for the game

Whilst its night vision is powerful, the cloaking ability, versus humans who suffer poorer eye-sight than xenomorphs, plus the extreme power of the Scouts Rifle against humans, makes for a fairly frustrating experience for whoever comes across this kit. 

There are still sufficient alternative spec kits such that the removal of Scout from HvH will not leave anyone without a specialization. 


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: The USCM Specialist can no longer select the Scout kit during 'Faction Clash', the Human versus Human game mode. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
