### PR TITLE
Adds IA as a vendor option (for more points than standard bottles)

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/synthetic.dm
+++ b/code/game/machinery/vending/vendor_types/crew/synthetic.dm
@@ -50,6 +50,7 @@
 		list("Pillbottle (Kelotane)", 5, /obj/item/storage/pill_bottle/kelotane, null, VENDOR_ITEM_RECOMMENDED),
 		list("Pillbottle (Peridaxon)", 5, /obj/item/storage/pill_bottle/peridaxon, null, VENDOR_ITEM_REGULAR),
 		list("Pillbottle (Tramadol)", 5, /obj/item/storage/pill_bottle/tramadol, null, VENDOR_ITEM_RECOMMENDED),
+		list("Pillbottle (ImiAlky)", 6, /obj/item/storage/pill_bottle/imialky, null, VENDOR_ITEM_REGULAR),
 
 		list("Injector (Bicaridine)", 1, /obj/item/reagent_container/hypospray/autoinjector/bicaridine, null, VENDOR_ITEM_REGULAR),
 		list("Injector (Dexalin+)", 1, /obj/item/reagent_container/hypospray/autoinjector/dexalinp, null, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_medic.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_medic.dm
@@ -38,6 +38,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_medic, list(
 		list("Pill Bottle (Kelotane)", 5, /obj/item/storage/pill_bottle/kelotane, null, VENDOR_ITEM_RECOMMENDED),
 		list("Pill Bottle (Peridaxon)", 5, /obj/item/storage/pill_bottle/peridaxon, null, VENDOR_ITEM_REGULAR),
 		list("Pill Bottle (Tramadol)", 5, /obj/item/storage/pill_bottle/tramadol, null, VENDOR_ITEM_RECOMMENDED),
+		list("Pillbottle (ImiAlky)", 6, /obj/item/storage/pill_bottle/imialky, null, VENDOR_ITEM_REGULAR),
 
 		list("MEDICAL UTILITIES", 0, null, null, null),
 		list("Health Analyzer", 4, /obj/item/device/healthanalyzer, null, VENDOR_ITEM_REGULAR),

--- a/code/game/objects/items/reagent_containers/pill.dm
+++ b/code/game/objects/items/reagent_containers/pill.dm
@@ -248,6 +248,11 @@
 	pill_initial_reagents = list("alkysine" = 10)
 	pill_icon_class = "alky"
 
+/obj/item/reagent_container/pill/imialky
+	pill_desc = "A pill containing Imidazoline and Alkysine. Heals eye and brain damage."
+	pill_initial_reagents = list("imidazoline" = 10, "alkysine" = 5)
+	pill_icon_class = "imialky"
+
 /obj/item/reagent_container/pill/bicaridine
 	pill_desc = "A Bicaridine pill. Heals brute damage."
 	pill_initial_reagents = list("bicaridine" = 15)

--- a/code/game/objects/items/reagent_containers/pill.dm
+++ b/code/game/objects/items/reagent_containers/pill.dm
@@ -251,7 +251,7 @@
 /obj/item/reagent_container/pill/imialky
 	pill_desc = "A pill containing Imidazoline and Alkysine. Heals eye and brain damage."
 	pill_initial_reagents = list("imidazoline" = 10, "alkysine" = 5)
-	pill_icon_class = "imialky"
+	pill_icon_class = "imi"
 
 /obj/item/reagent_container/pill/bicaridine
 	pill_desc = "A Bicaridine pill. Heals brute damage."

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -640,7 +640,7 @@
 
 //Imidazoline+Alkysine
 /obj/item/storage/pill_bottle/imialky
-	name = "\improper Imialky pill bottle"
+	name = "\improper ImiAlky pill bottle"
 	icon_state = "pill_canister11"
 	pill_type_to_fill = /obj/item/reagent_container/pill/imialky
 	maptext_label = "IA"

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -643,7 +643,7 @@
 	name = "\improper Imialky pill bottle"
 	icon_state = "pill_canister11"
 	pill_type_to_fill = /obj/item/reagent_container/pill/imialky
-	maptext_label = "Im"
+	maptext_label = "IA"
 
 /obj/item/storage/pill_bottle/imialky/skillless
 	skilllock = SKILL_MEDICAL_DEFAULT

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -638,6 +638,16 @@
 /obj/item/storage/pill_bottle/imidazoline/skillless
 	skilllock = SKILL_MEDICAL_DEFAULT
 
+//Imidazoline+Alkysine
+/obj/item/storage/pill_bottle/imialky
+	name = "\improper Imialky pill bottle"
+	icon_state = "pill_canister11"
+	pill_type_to_fill = /obj/item/reagent_container/pill/imialky
+	maptext_label = "Im"
+
+/obj/item/storage/pill_bottle/imialky/skillless
+	skilllock = SKILL_MEDICAL_DEFAULT
+
 //PERIDAXON
 /obj/item/storage/pill_bottle/peridaxon
 	name = "\improper Peridaxon pill bottle"


### PR DESCRIPTION

# About the pull request

Adds IA as a pill bottle in vendors for more points than the usual pill bottle.

# Explain why it's good for the game

I know this could be "controversial" but, in server corpsman/doctor culture, IA is pretty much mandatory to have with you. Anytime someone complains about being blind for example, you should give them an IA pill. WHY are we forcing chemistry to make pills which are basically necessary for all corpsman and all doctors every round? They are busy enough with the 8+ custom mixes listed on the chemistry wiki page - not to mention that I've seen people ask for things not on the wiki as well. In any case, they will still need to make it frequently because this change only adds it as an option for 6 points in gear vendors (more points than other pill bottles).

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: IA is now an option for points in vendors
/:cl:
