### PR TITLE
Weak Neuro - Survivor Immunity

### DIFF
--- a/code/datums/ammo/xeno.dm
+++ b/code/datums/ammo/xeno.dm
@@ -22,87 +22,87 @@
 	max_range = 12
 
 /datum/ammo/xeno/toxin
-    name = "neurotoxic spit"
-    damage_falloff = 0
-    flags_ammo_behavior = AMMO_XENO|AMMO_IGNORE_RESIST
-    spit_cost = 25
-    var/effect_power = XENO_NEURO_TIER_4
-    var/datum/callback/neuro_callback
+	name = "neurotoxic spit"
+	damage_falloff = 0
+	flags_ammo_behavior = AMMO_XENO|AMMO_IGNORE_RESIST
+	spit_cost = 25
+	var/effect_power = XENO_NEURO_TIER_4
+	var/datum/callback/neuro_callback
 
-    shell_speed = AMMO_SPEED_TIER_3
-    max_range = 7
+	shell_speed = AMMO_SPEED_TIER_3
+	max_range = 7
 
 /datum/ammo/xeno/toxin/New()
-    ..()
+	..()
 
-    neuro_callback = CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(apply_neuro))
+	neuro_callback = CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(apply_neuro))
 
 /proc/apply_neuro(mob/living/M, power, insta_neuro)
-    if(skillcheck(M, SKILL_ENDURANCE, SKILL_ENDURANCE_MAX) && !insta_neuro)
-        M.visible_message(SPAN_DANGER("[M] withstands the neurotoxin!"))
-        return //endurance 5 makes you immune to weak neurotoxin
+	if(skillcheck(M, SKILL_ENDURANCE, SKILL_ENDURANCE_MAX) && !insta_neuro)
+		M.visible_message(SPAN_DANGER("[M] withstands the neurotoxin!"))
+		return //endurance 5 makes you immune to weak neurotoxin
 
-    if(skillcheck(M, SKILL_ENDURANCE, SKILL_ENDURANCE_SURVIVOR) && !insta_neuro)
-        M.visible_message(SPAN_DANGER("[M] withstands the neurotoxin!"))
-        return // survivors should be immune to weak neurotoxin
+	if(skillcheck(M, SKILL_ENDURANCE, SKILL_ENDURANCE_SURVIVOR) && !insta_neuro)
+		M.visible_message(SPAN_DANGER("[M] withstands the neurotoxin!"))
+		return // survivors should be immune to weak neurotoxin
 
-    if(ishuman(M))
-        var/mob/living/carbon/human/H = M
-        if(H.chem_effect_flags & CHEM_EFFECT_RESIST_NEURO || H.species.flags & NO_NEURO)
-            H.visible_message(SPAN_DANGER("[M] shrugs off the neurotoxin!"))
-            return //species like zombies or synths are immune to neurotoxin
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.chem_effect_flags & CHEM_EFFECT_RESIST_NEURO || H.species.flags & NO_NEURO)
+			H.visible_message(SPAN_DANGER("[M] shrugs off the neurotoxin!"))
+			return //species like zombies or synths are immune to neurotoxin
 
-    if(!isxeno(M))
-        if(insta_neuro)
-            if(M.GetKnockDownDuration() < 3)
-                M.KnockDown(power)
-                M.Stun(power)
-                return
+	if(!isxeno(M))
+		if(insta_neuro)
+			if(M.GetKnockDownDuration() < 3)
+				M.KnockDown(power)
+				M.Stun(power)
+				return
 
-        if(ishuman(M))
-            M.apply_effect(2.5, SUPERSLOW)
-            M.visible_message(SPAN_DANGER("[M]'s movements are slowed."))
+		if(ishuman(M))
+			M.apply_effect(2.5, SUPERSLOW)
+			M.visible_message(SPAN_DANGER("[M]'s movements are slowed."))
 
-        var/no_clothes_neuro = FALSE
+			var/no_clothes_neuro = FALSE
 
-        if(ishuman(M))
-            var/mob/living/carbon/human/H = M
-            if(!H.wear_suit || H.wear_suit.slowdown == 0)
-                no_clothes_neuro = TRUE
+			if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			if(!H.wear_suit || H.wear_suit.slowdown == 0)
+				no_clothes_neuro = TRUE
 
-        if(no_clothes_neuro)
-            if(M.GetKnockDownDuration() < 5)
-                M.KnockDown(power)
-                M.Stun(power)
-                M.visible_message(SPAN_DANGER("[M] falls prone."))
+		if(no_clothes_neuro)
+			if(M.GetKnockDownDuration() < 5)
+				M.KnockDown(power)
+				M.Stun(power)
+				M.visible_message(SPAN_DANGER("[M] falls prone."))
 
 /proc/apply_scatter_neuro(mob/living/M)
-    if (ishuman(M))
-        var/mob/living/carbon/human/H = M
-        if (skillcheck(M, SKILL_ENDURANCE, SKILL_ENDURANCE_MAX))
-            H.visible_message(SPAN_DANGER("[H] withstands the neurotoxin!"))
-            return // Endurance 5 makes you immune to weak neuro
+	if (ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if (skillcheck(M, SKILL_ENDURANCE, SKILL_ENDURANCE_MAX))
+			H.visible_message(SPAN_DANGER("[H] withstands the neurotoxin!"))
+			return // Endurance 5 makes you immune to weak neuro
 
-        if (skillcheck(M, SKILL_ENDURANCE, SKILL_ENDURANCE_SURVIVOR))
-            H.visible_message(SPAN_DANGER("[H] withstands the neurotoxin!"))
-            return // Survivors should be immune to weak neurotoxin
+		if (skillcheck(M, SKILL_ENDURANCE, SKILL_ENDURANCE_SURVIVOR))
+			H.visible_message(SPAN_DANGER("[H] withstands the neurotoxin!"))
+			return // Survivors should be immune to weak neurotoxin
 
-        if (H.chem_effect_flags & CHEM_EFFECT_RESIST_NEURO || H.species.flags & NO_NEURO)
-            H.visible_message(SPAN_DANGER("[H] shrugs off the neurotoxin!"))
-            return
+		if (H.chem_effect_flags & CHEM_EFFECT_RESIST_NEURO || H.species.flags & NO_NEURO)
+			H.visible_message(SPAN_DANGER("[H] shrugs off the neurotoxin!"))
+			return
 
-        H.KnockDown(0.7) // Completely arbitrary values from another time where stun timers incorrectly stacked. Adjust as needed.
-        H.Stun(0.7)
-        H.visible_message(SPAN_DANGER("[H] falls prone."))
+		H.KnockDown(0.7) // Completely arbitrary values from another time where stun timers incorrectly stacked. Adjust as needed.
+		H.Stun(0.7)
+		H.visible_message(SPAN_DANGER("[H] falls prone."))
 
 /datum/ammo/xeno/toxin/on_hit_mob(mob/M, obj/projectile/P)
-    if (ishuman(M))
-        var/mob/living/carbon/human/H = M
-        if (H.status_flags & XENO_HOST)
-            neuro_callback.Invoke(H, effect_power, TRUE)
-            return
+	if (ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if (H.status_flags & XENO_HOST)
+			neuro_callback.Invoke(H, effect_power, TRUE)
+			return
 
-    neuro_callback.Invoke(M, effect_power, FALSE)
+	neuro_callback.Invoke(M, effect_power, FALSE)
 
 /datum/ammo/xeno/toxin/medium //Spitter
 	name = "neurotoxic spatter"

--- a/code/datums/ammo/xeno.dm
+++ b/code/datums/ammo/xeno.dm
@@ -54,7 +54,7 @@
 
 	if(!isxeno(M))
 		if(insta_neuro)
-			if(M.GetKnockDownDuration() < 3)
+			if(M.GetKnockDownDuration() < 3) // Why are you not using KnockDown(3) ? Do you even know 3 is SIX seconds ? So many questions left unanswered.
 				M.KnockDown(power)
 				M.Stun(power)
 				return
@@ -63,7 +63,7 @@
 			M.apply_effect(2.5, SUPERSLOW)
 			M.visible_message(SPAN_DANGER("[M]'s movements are slowed."))
 
-	var/no_clothes_neuro = FALSE
+		var/no_clothes_neuro = FALSE
 
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
@@ -79,24 +79,24 @@
 /proc/apply_scatter_neuro(mob/living/M)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if (skillcheck(M, SKILL_ENDURANCE, SKILL_ENDURANCE_MAX))
-			H.visible_message(SPAN_DANGER("[H] withstands the neurotoxin!"))
-			return // Endurance 5 makes you immune to weak neuro
+		if(skillcheck(M, SKILL_ENDURANCE, SKILL_ENDURANCE_MAX))
+			M.visible_message(SPAN_DANGER("[M] withstands the neurotoxin!"))
+			return //endurance 5 makes you immune to weak neuro
 
 		if(skillcheck(M, SKILL_ENDURANCE, SKILL_ENDURANCE_SURVIVOR))
-			H.visible_message(SPAN_DANGER("[H] withstands the neurotoxin!"))
+			H.visible_message(SPAN_DANGER("[M] withstands the neurotoxin!"))
 			return // Survivors should be immune to weak neurotoxin
 
 		if(H.chem_effect_flags & CHEM_EFFECT_RESIST_NEURO || H.species.flags & NO_NEURO)
-			H.visible_message(SPAN_DANGER("[H] shrugs off the neurotoxin!"))
+			H.visible_message(SPAN_DANGER("[M] shrugs off the neurotoxin!"))
 			return
 
-		H.KnockDown(0.7) // Completely arbitrary values from another time where stun timers incorrectly stacked. Kill as needed.
-		H.Stun(0.7)
-		H.visible_message(SPAN_DANGER("[H] falls prone."))
+		M.KnockDown(0.7) // Completely arbitrary values from another time where stun timers incorrectly stacked. Kill as needed.
+		M.Stun(0.7)
+		M.visible_message(SPAN_DANGER("[M] falls prone."))
 
 /datum/ammo/xeno/toxin/on_hit_mob(mob/M,obj/projectile/P)
-	if (ishuman(M))
+	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.status_flags & XENO_HOST)
 			neuro_callback.Invoke(H, effect_power, TRUE)

--- a/code/datums/ammo/xeno.dm
+++ b/code/datums/ammo/xeno.dm
@@ -65,7 +65,7 @@
 
 	var/no_clothes_neuro = FALSE
 
-			if(ishuman(M))
+		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(!H.wear_suit || H.wear_suit.slowdown == 0)
 				no_clothes_neuro = TRUE
@@ -77,17 +77,17 @@
 				M.visible_message(SPAN_DANGER("[M] falls prone."))
 
 /proc/apply_scatter_neuro(mob/living/M)
-	if (ishuman(M))
+	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if (skillcheck(M, SKILL_ENDURANCE, SKILL_ENDURANCE_MAX))
 			H.visible_message(SPAN_DANGER("[H] withstands the neurotoxin!"))
 			return // Endurance 5 makes you immune to weak neuro
 
-		if (skillcheck(M, SKILL_ENDURANCE, SKILL_ENDURANCE_SURVIVOR))
+		if(skillcheck(M, SKILL_ENDURANCE, SKILL_ENDURANCE_SURVIVOR))
 			H.visible_message(SPAN_DANGER("[H] withstands the neurotoxin!"))
 			return // Survivors should be immune to weak neurotoxin
 
-		if (H.chem_effect_flags & CHEM_EFFECT_RESIST_NEURO || H.species.flags & NO_NEURO)
+		if(H.chem_effect_flags & CHEM_EFFECT_RESIST_NEURO || H.species.flags & NO_NEURO)
 			H.visible_message(SPAN_DANGER("[H] shrugs off the neurotoxin!"))
 			return
 
@@ -95,10 +95,10 @@
 		H.Stun(0.7)
 		H.visible_message(SPAN_DANGER("[H] falls prone."))
 
-/datum/ammo/xeno/toxin/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/xeno/toxin/on_hit_mob(mob/M,obj/projectile/P)
 	if (ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if (H.status_flags & XENO_HOST)
+		if(H.status_flags & XENO_HOST)
 			neuro_callback.Invoke(H, effect_power, TRUE)
 			return
 

--- a/code/datums/ammo/xeno.dm
+++ b/code/datums/ammo/xeno.dm
@@ -63,7 +63,7 @@
 			M.apply_effect(2.5, SUPERSLOW)
 			M.visible_message(SPAN_DANGER("[M]'s movements are slowed."))
 
-			var/no_clothes_neuro = FALSE
+	var/no_clothes_neuro = FALSE
 
 			if(ishuman(M))
 			var/mob/living/carbon/human/H = M
@@ -71,7 +71,7 @@
 				no_clothes_neuro = TRUE
 
 		if(no_clothes_neuro)
-			if(M.GetKnockDownDuration() < 5)
+			if(M.GetKnockDownDuration() < 5) // Nobody actually knows what this means. Supposedly it means less than 10 seconds. Frankly if you get locked into 10s of knockdown to begin with there are bigger issues.
 				M.KnockDown(power)
 				M.Stun(power)
 				M.visible_message(SPAN_DANGER("[M] falls prone."))
@@ -91,7 +91,7 @@
 			H.visible_message(SPAN_DANGER("[H] shrugs off the neurotoxin!"))
 			return
 
-		H.KnockDown(0.7) // Completely arbitrary values from another time where stun timers incorrectly stacked. Adjust as needed.
+		H.KnockDown(0.7) // Completely arbitrary values from another time where stun timers incorrectly stacked. Kill as needed.
 		H.Stun(0.7)
 		H.visible_message(SPAN_DANGER("[H] falls prone."))
 


### PR DESCRIPTION
Changes some weak neuro values to give survivors immunity to both normal and scatter.
# About the pull request

Basically this will nerf Sentinel "Neuro" spam for survivors only. A while ago survivors had "Endurance 5" which gave them an immunity to "Weak-Neuro". This will revive that without giving them the insanely overpowered "Endurance 5".

Tested and should be good.

# Explain why it's good for the game

There's nothing worse then gameplay where you instantly lose, have zero chances of escaping at all or chances to actually do a single thing. I'm pretty sure when they removed the "Endurance 5" they forgot to take into account how powerful sentinel neuro spam can be against "unarmored opponents" (aka-survivors). It's a lot like how back in the day Lurkers could pounce and instantly stun you giving you zero opportunity to do anything. Just horrible gameplay and sucks the fun out of the role completely. It also forces survivors to rush somewhere to "hold", gives no opportunities to "roam" or "loot" if there's one or two decent Sentinel players around. This is especially true for maps where you can spawn without armor completely, such as "Chances". Don't get me wrong I understand playing a survivor should be hard, and that you should be with other people, but sometimes (especially if you've just spawned far away) you'll be alone, and getting insta-stunned, from range, in the dark, is just not fun, puts people off from even attempting to play survivor when you know there's sweaty Sentinel players who'll suck out all of the fun.

I hope you'll take what I've said into consideration, I know how much the Devs dislike survivors, but this isn't that big of a change, you can still have your meta-rushing tackle spamming drones, since they at least have to get into melee range and actually have to click your sprite, not just shoot infinitely (with Queen spamming plasma) from the dark with no counter or opportunity to do anything.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: gives survivors weak neuro immunity
/:cl:
