### PR TITLE
Adds muzzle flash light colors

### DIFF
--- a/code/__DEFINES/colours.dm
+++ b/code/__DEFINES/colours.dm
@@ -150,3 +150,8 @@
 #define COLOR_G_ICE "#C7EDDE" //faded cyan
 #define COLOR_G_DES "#FF7C1C" //bright orange
 #define COLOR_G_JUNG "#64AA6E" //faded green
+
+/// Gun muzzle colors
+#define COLOR_LASER_RED "#FF8D8D"
+#define COLOR_MUZZLE_BLUE "#2CB2E8"
+

--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -893,6 +893,8 @@
 	icon = 'icons/obj/items/hunter/pred_gear.dmi'
 	icon_state = null
 	works_in_recharger = FALSE
+	muzzle_flash = "muzzle_flash_blue"
+	muzzle_flash_color = COLOR_MAGENTA
 	item_icons = list(
 		WEAR_BACK = 'icons/mob/humans/onmob/hunter/pred_gear.dmi',
 		WEAR_L_HAND = 'icons/mob/humans/onmob/hunter/items_lefthand.dmi',
@@ -907,7 +909,6 @@
 	unacidable = TRUE
 	fire_sound = 'sound/weapons/pred_plasma_shot.ogg'
 	ammo = /datum/ammo/energy/yautja/rifle/bolt
-	muzzle_flash = null // TO DO, add a decent one.
 	zoomdevicename = "scope"
 	flags_equip_slot = SLOT_BACK
 	w_class = SIZE_HUGE
@@ -992,6 +993,7 @@
 
 #define FIRE_MODE_STANDARD "Standard"
 #define FIRE_MODE_INCENDIARY "Incendiary"
+
 /obj/item/weapon/gun/energy/yautja/plasmapistol
 	name = "plasma pistol"
 	desc = "A plasma pistol capable of rapid fire. It has an integrated battery. Can be used to set fires, either to braziers or on people."
@@ -1002,7 +1004,8 @@
 	fire_sound = 'sound/weapons/pulse3.ogg'
 	flags_equip_slot = SLOT_WAIST
 	ammo = /datum/ammo/energy/yautja/pistol
-	muzzle_flash = null // TO DO, add a decent one.
+	muzzle_flash = "muzzle_flash_blue"
+	muzzle_flash_color = COLOR_MUZZLE_BLUE
 	w_class = SIZE_MEDIUM
 	/// Max amount of shots
 	var/charge_time = 40
@@ -1127,7 +1130,8 @@
 	)
 	fire_sound = 'sound/weapons/pred_plasmacaster_fire.ogg'
 	ammo = /datum/ammo/energy/yautja/caster/stun
-	muzzle_flash = null // TO DO, add a decent one.
+	muzzle_flash = "muzzle_flash_blue"
+	muzzle_flash_color = COLOR_MUZZLE_BLUE
 	w_class = SIZE_HUGE
 	force = 0
 	fire_delay = 3

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -33,6 +33,8 @@
 	var/muzzle_flash = "muzzle_flash"
 	///muzzle flash brightness
 	var/muzzle_flash_lum = 3
+	///Color of the muzzle flash light effect.
+	var/muzzle_flash_color = COLOR_VERY_SOFT_YELLOW
 
 	var/fire_sound = 'sound/weapons/Gunshot.ogg'
 	/// If fire_sound is null, it will pick a sound from the list here instead.
@@ -1780,6 +1782,7 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 	if(!light_on && (light_range <= muzzle_flash_lum))
 		set_light_range(muzzle_flash_lum)
 		set_light_on(TRUE)
+		set_light_color(muzzle_flash_color)
 		addtimer(CALLBACK(src, PROC_REF(reset_light_range), prev_light), 0.5 SECONDS)
 
 	var/image/I = image('icons/obj/items/weapons/projectiles.dmi', user, muzzle_flash, user.dir == NORTH ? ABOVE_LYING_MOB_LAYER : FLOAT_LAYER)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -117,6 +117,7 @@
 	icon_state = "rxfm5_eva"
 	item_state = "eva"
 	muzzle_flash = "muzzle_laser"
+	muzzle_flash_color = COLOR_LASER_RED
 	fire_sound = 'sound/weapons/Laser4.ogg'
 	w_class = SIZE_MEDIUM
 	gun_category = GUN_CATEGORY_HANDGUN
@@ -174,6 +175,7 @@
 	icon_state = "laz_uzi"
 	item_state = "laz_uzi"
 	muzzle_flash = "muzzle_laser"
+	muzzle_flash_color = COLOR_LASER_RED
 	gun_category = GUN_CATEGORY_SMG
 	flags_equip_slot = SLOT_WAIST
 	charge_cost = 200

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -653,6 +653,7 @@
 	current_mag = /obj/item/ammo_magazine/pistol/es4
 	force = 8
 	muzzle_flash = "muzzle_flash_blue"
+	muzzle_flash_color = COLOR_MUZZLE_BLUE
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK|GUN_ONE_HAND_WIELDED|GUN_AMMO_COUNTER
 	attachable_allowed = list(
 		/obj/item/attachable/flashlight,


### PR DESCRIPTION

# About the pull request

Adds support for a gun to have a custom color of muzzle flash light.

Changes standard color to be yellow tinted (just as the muzzle flash itself).

![dreamseeker_r0xYJ8Cdce](https://github.com/user-attachments/assets/3f418ef8-4f05-4902-8b0a-e692b3d0bb9b)

Adds some colors to other guns that have unique ones.

![dreamseeker_od15UYkH08](https://github.com/user-attachments/assets/ca4ba204-86ac-44d7-ba48-8056cb2366f1)

![dreamseeker_5dPzjGioH7](https://github.com/user-attachments/assets/285ee139-5931-4002-addb-2f296a17f1aa)

![dreamseeker_jELx3PIws4](https://github.com/user-attachments/assets/3e5949d8-bd61-481b-ad2b-8bf87d63a850)


# Explain why it's good for the game

More visuals - good, also standard muzzle flare being snow white never made much sense anyway.

# Testing Photographs and Procedure
# Changelog

:cl:
add: Guns now support custom muzzle flash light color, some guns have a new color of it now, standard color is yellow tinted now instead of white
/:cl:
