### PR TITLE
buffs synth biosuit to have xeno dissection burn protection

### DIFF
--- a/code/modules/surgery/xeno.dm
+++ b/code/modules/surgery/xeno.dm
@@ -70,7 +70,7 @@
 			SPAN_NOTICE("[user] successfully destroys your carapace into bits and pieces using [tool]."),,
 			SPAN_NOTICE("[user] successfully destroys [target.caste_type] carapace into bits and pieces using [tool]."))
 	for(var/mob/living/carbon/human/victim in orange(1, target))
-		if(istype(victim.wear_suit, /obj/item/clothing/suit/bio_suit) && istype(victim.head, /obj/item/clothing/head/bio_hood))
+		if((istype(victim.wear_suit, /obj/item/clothing/suit/bio_suit) || istype(victim.wear_suit, /obj/item/clothing/suit/storage/synthbio)) && (istype(victim.head, /obj/item/clothing/head/bio_hood) || istype(victim.head, /obj/item/clothing/head/bio_hood/synth)))
 			continue
 		to_chat(victim, SPAN_HIGHDANGER("You are covered in acid as you feel agonizing pain!"))
 		victim.apply_damage(rand(75, 125), BURN) // you WILL wear biosuit.


### PR DESCRIPTION

# About the pull request

the bio hood and biosuit found inside the synthetic snowflake vendor will now provide burn protection against xeno dissections. they can be mix and matched with the normal research biosuit as well.

# Explain why it's good for the game

It is very annoying to constantly have to switch out your jacket for the research jacket every time you want to do a dissection on a xenomorph. This change will remove that annoyance for synths that wanna rock the biosuit.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Nomoresolvalou

balance: synth biosuit now has xeno dissection burn protection.

/:cl:
