### PR TITLE
researchvivors can access research database

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1063,7 +1063,7 @@
 		to_chat(src, "The game appears to have misplaced your mind datum.")
 		return
 
-	if(!skillcheck(usr, SKILL_RESEARCH, SKILL_RESEARCH_TRAINED) ||!(FACTION_MARINE in get_id_faction_group()))
+	if(!skillcheck(usr, SKILL_RESEARCH, SKILL_RESEARCH_TRAINED) || !(FACTION_MARINE in get_id_faction_group()))
 		to_chat(usr, SPAN_WARNING("You have no access to the [MAIN_SHIP_NAME] research network."))
 		return
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1063,7 +1063,7 @@
 		to_chat(src, "The game appears to have misplaced your mind datum.")
 		return
 
-	if(!skillcheck(usr, SKILL_RESEARCH, SKILL_RESEARCH_TRAINED) || faction != FACTION_MARINE && !(faction in FACTION_LIST_WY))
+	if(!skillcheck(usr, SKILL_RESEARCH, SKILL_RESEARCH_TRAINED) ||!(FACTION_MARINE in get_id_faction_group()))
 		to_chat(usr, SPAN_WARNING("You have no access to the [MAIN_SHIP_NAME] research network."))
 		return
 


### PR DESCRIPTION

# About the pull request

allows survivors, synthvivors, and anyone that has research skill, to use the "view research objectives" verb if they also have USCM IFF

# Explain why it's good for the game

allows survivors that want to help research have a much better time doing so. the view research objectives verb is invaluable, as it shows how many points they have and all the chems they have yet to scan right on the fly. it is very hard to keep track of your points and what you've scanned using solely the research terminals, especially when you're joining the research team mid round. this should help researchers get up to speed with how things are going, and have a generally better time in research.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Nomoresolvalou

qol: scientist survivors that get IFF will be able to view research objectives

/:cl:
