### PR TITLE
Adds AMR ammo to WO

### DIFF
--- a/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
+++ b/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
@@ -614,6 +614,7 @@
 		"Explosives and grenades",
 		"Rocket ammo",
 		"Sniper ammo",
+		"Anti-Material Sniper ammo",
 		"Pyrotechnician tanks",
 		"Scout ammo",
 		"Smartgun ammo",
@@ -634,14 +635,17 @@
 		if("Sniper ammo")
 			supply_drop = 3
 			to_chat(usr, SPAN_NOTICE("Sniper ammo will now drop!"))
-		if("Explosives and grenades")
+		if("Anti-Material Sniper ammo")
 			supply_drop = 4
+			to_chat(usr, SPAN_NOTICE("Anti-Material Sniper ammo will now drop!"))
+		if("Explosives and grenades")
+			supply_drop = 5
 			to_chat(usr, SPAN_NOTICE("Explosives and grenades will now drop!"))
 		if("Pyrotechnician tanks")
-			supply_drop = 5
+			supply_drop = 6
 			to_chat(usr, SPAN_NOTICE("Pyrotechnician tanks will now drop!"))
 		if("Scout ammo")
-			supply_drop = 6
+			supply_drop = 7
 			to_chat(usr, SPAN_NOTICE("Scout ammo will now drop!"))
 		else
 			return
@@ -734,15 +738,21 @@
 							/obj/item/ammo_magazine/sniper,
 							/obj/item/ammo_magazine/sniper/incendiary,
 							/obj/item/ammo_magazine/sniper/flak)
-		if(4) // Give them explosives + Grenades for the Grenade spec. Might be too many grenades, but we'll find out.
+		if(4) //Amr sniper ammo.
+			spawnitems = list(/obj/item/ammo_magazine/sniper/anti_materiel,
+							/obj/item/ammo_magazine/sniper/anti_materiel,
+							/obj/item/ammo_magazine/sniper/anti_materiel,
+							/obj/item/ammo_magazine/sniper/anti_materiel,
+							/obj/item/ammo_magazine/sniper/anti_materiel)
+		if(5) // Give them explosives + Grenades for the Grenade spec. Might be too many grenades, but we'll find out.
 			spawnitems = list(/obj/item/storage/box/explosive_mines,
 							/obj/item/storage/belt/grenade/full)
-		if(5) // Pyrotech
+		if(6) // Pyrotech
 			var/fuel = pick(/obj/item/ammo_magazine/flamer_tank/large/B, /obj/item/ammo_magazine/flamer_tank/large/X)
 			spawnitems = list(/obj/item/ammo_magazine/flamer_tank/large,
 							/obj/item/ammo_magazine/flamer_tank/large,
 							fuel)
-		if(6) // Scout
+		if(7) // Scout
 			spawnitems = list(/obj/item/ammo_magazine/rifle/m4ra/custom,
 							/obj/item/ammo_magazine/rifle/m4ra/custom,
 							/obj/item/ammo_magazine/rifle/m4ra/custom/incendiary,

--- a/code/game/machinery/vending/vendor_types/wo_vendors.dm
+++ b/code/game/machinery/vending/vendor_types/wo_vendors.dm
@@ -178,6 +178,7 @@
 		list("M42A Flak Magazine (10x28mm)", floor(scale * 1), /obj/item/ammo_magazine/sniper/flak, VENDOR_ITEM_REGULAR),
 		list("M42A Incendiary Magazine (10x28mm)", floor(scale * 1), /obj/item/ammo_magazine/sniper/incendiary, VENDOR_ITEM_REGULAR),
 		list("M42A Marksman Magazine (10x28mm Caseless)", floor(scale * 1.5), /obj/item/ammo_magazine/sniper, VENDOR_ITEM_REGULAR),
+		list("XM43E1 Marksman Magazine (10x28mm Caseless)", floor(scale * 3), /obj/item/ammo_magazine/sniper/anti_materiel, VENDOR_ITEM_REGULAR),
 
 		list("EXTRA DEMOLITIONIST AMMUNITION", -1, null, null, null),
 		list("84mm Anti-Armor Rocket", floor(scale * 1), /obj/item/ammo_magazine/rocket/ap, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/wo_vendors.dm
+++ b/code/game/machinery/vending/vendor_types/wo_vendors.dm
@@ -178,7 +178,7 @@
 		list("M42A Flak Magazine (10x28mm)", floor(scale * 1), /obj/item/ammo_magazine/sniper/flak, VENDOR_ITEM_REGULAR),
 		list("M42A Incendiary Magazine (10x28mm)", floor(scale * 1), /obj/item/ammo_magazine/sniper/incendiary, VENDOR_ITEM_REGULAR),
 		list("M42A Marksman Magazine (10x28mm Caseless)", floor(scale * 1.5), /obj/item/ammo_magazine/sniper, VENDOR_ITEM_REGULAR),
-		list("XM43E1 Marksman Magazine (10x28mm Caseless)", floor(scale * 3), /obj/item/ammo_magazine/sniper/anti_materiel, VENDOR_ITEM_REGULAR),
+		list("XM43E1 Marksman Magazine (10x99mm Caseless)", floor(scale * 3), /obj/item/ammo_magazine/sniper/anti_materiel, VENDOR_ITEM_REGULAR),
 
 		list("EXTRA DEMOLITIONIST AMMUNITION", -1, null, null, null),
 		list("84mm Anti-Armor Rocket", floor(scale * 1), /obj/item/ammo_magazine/rocket/ap, VENDOR_ITEM_REGULAR),


### PR DESCRIPTION

# About the pull request

Adds amr ammo to req wo vendor, also adds amr ammo pack to ammo supply drop beacon.

# Explain why it's good for the game

Oversight - bad.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![RYnlXOZsvM](https://github.com/user-attachments/assets/5cb05a88-2408-4069-99e8-4666624911c9)


</details>


# Changelog
:cl:
add: added amr ammo to WO req vendor and to WO ammo beacons
/:cl:
