### PR TITLE
Varadero, Strata, Kutjevo, Shiva energy fix

### DIFF
--- a/code/game/area/kutjevo.dm
+++ b/code/game/area/kutjevo.dm
@@ -7,6 +7,7 @@
 	//ambience = list('figuresomethingout.ogg')
 	icon_state = "kutjevo"
 	can_build_special = TRUE //T-Comms structure
+	powernet_name = "ground"
 	temperature = 308.7 //kelvin, 35c, 95f
 	minimap_color = MINIMAP_AREA_ENGI
 

--- a/code/game/area/shiva.dm
+++ b/code/game/area/shiva.dm
@@ -6,6 +6,7 @@
 	//ambience = list('figuresomethingout.ogg')
 	icon_state = "shiva"
 	can_build_special = TRUE //T-Comms structure
+	powernet_name = "ground"
 	temperature = ICE_COLONY_TEMPERATURE
 	minimap_color = MINIMAP_AREA_COLONY
 

--- a/code/game/area/strata.dm
+++ b/code/game/area/strata.dm
@@ -12,6 +12,7 @@ EXTERIOR is FUCKING FREEZING, and refers to areas out in the open and or exposed
 	//ambience = list('figuresomethingout.ogg')
 	icon_state = "strata"
 	can_build_special = TRUE //T-Comms structure
+	powernet_name = "ground"
 	temperature = SOROKYNE_TEMPERATURE //If not in a building, it'll be cold. All interior areas are set to T20C
 	minimap_color = MINIMAP_AREA_COLONY
 

--- a/code/game/area/varadero.dm
+++ b/code/game/area/varadero.dm
@@ -7,6 +7,7 @@
 	ambience_exterior = AMBIENCE_NV
 	icon_state = "varadero"
 	can_build_special = TRUE //T-Comms structure
+	powernet_name = "ground"
 	temperature = TROPICAL_TEMP
 	minimap_color = MINIMAP_AREA_COLONY
 

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -12692,11 +12692,11 @@
 /turf/open/auto_turf/snow/layer0,
 /area/shiva/interior/warehouse/caves)
 "jWL" = (
-/obj/structure/machinery/space_heater,
 /obj/structure/machinery/light/double{
 	dir = 1;
 	pixel_y = 9
 	},
+/obj/structure/machinery/power/smes/buildable,
 /turf/open/floor/shiva/yellowfull/west,
 /area/shiva/interior/aux_power)
 "jXD" = (
@@ -15502,6 +15502,10 @@
 	},
 /turf/open/auto_turf/ice/layer1,
 /area/shiva/interior/caves/research_caves)
+"niD" = (
+/obj/structure/machinery/space_heater,
+/turf/open/floor/shiva/floor3,
+/area/shiva/interior/aux_power)
 "niL" = (
 /obj/structure/platform/strata{
 	dir = 8
@@ -19149,6 +19153,9 @@
 /obj/structure/machinery/light/double{
 	dir = 1;
 	pixel_y = 9
+	},
+/obj/structure/machinery/power/smes/buildable{
+	pixel_x = 1
 	},
 /turf/open/floor/shiva/yellowfull/west,
 /area/shiva/interior/aux_power)
@@ -23648,6 +23655,10 @@
 /obj/item/tool/warning_cone,
 /turf/open/floor/shiva,
 /area/shiva/interior/colony/research_hab)
+"xEU" = (
+/obj/structure/machinery/power/smes/buildable,
+/turf/open/floor/shiva/yellowfull/west,
+/area/shiva/interior/garage)
 "xFp" = (
 /obj/structure/bed/chair/comfy/orange{
 	dir = 4
@@ -33924,7 +33935,7 @@ puZ
 puZ
 anc
 anc
-ctz
+niD
 cJu
 cJu
 nTC
@@ -50679,11 +50690,11 @@ ktd
 ktd
 ktd
 ktd
-ktd
+xEU
 tXd
 ado
 pSD
-ktd
+xEU
 ktd
 ktd
 ktd


### PR DESCRIPTION
# About the pull request

Areas on this maps pull energy from default, and has energy when generators off
SMES added on Shiva generators points.

# Explain why it's good for the game

Fixes always good


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Tested.

</details>


# Changelog

:cl:
fix: Varadero, Strata, Kutjevo, Shiva maps now don't have infinity energy
add: Added SMES on Shiva generators points
/:cl:
