### PR TITLE
Makes survivor doctors use doctor paygrade

### DIFF
--- a/code/modules/gear_presets/colonist.dm
+++ b/code/modules/gear_presets/colonist.dm
@@ -75,6 +75,7 @@
 	name = "Colonist - Doctor"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = "Colonial Doctor"
+	paygrades = list(PAY_SHORT_CDOC = JOB_PLAYTIME_TIER_0)
 
 	//Marine access is required to use chem dispensers...
 	access = list(ACCESS_CIVILIAN_PUBLIC, ACCESS_CIVILIAN_RESEARCH, ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_MORGUE)

--- a/code/modules/gear_presets/survivors/survivors.dm
+++ b/code/modules/gear_presets/survivors/survivors.dm
@@ -132,6 +132,7 @@ Standart Survivors :	/datum/equipment_preset/survivor/scientist,
 	flags = EQUIPMENT_PRESET_START_OF_ROUND
 	idtype = /obj/item/card/id/silver/clearance_badge/scientist
 	access = list(ACCESS_CIVILIAN_PUBLIC, ACCESS_CIVILIAN_RESEARCH, ACCESS_CIVILIAN_MEDBAY)
+	paygrades = list(PAY_SHORT_CDOC = JOB_PLAYTIME_TIER_0)
 
 	survivor_variant = SCIENTIST_SURVIVOR
 
@@ -160,6 +161,7 @@ Standart Survivors :	/datum/equipment_preset/survivor/scientist,
 	flags = EQUIPMENT_PRESET_START_OF_ROUND
 	idtype = /obj/item/card/id/silver/clearance_badge
 	access = list(ACCESS_CIVILIAN_PUBLIC, ACCESS_CIVILIAN_RESEARCH, ACCESS_CIVILIAN_MEDBAY, ACCESS_CIVILIAN_COMMAND)
+	paygrades = list(PAY_SHORT_CDOC = JOB_PLAYTIME_TIER_0)
 
 	survivor_variant = MEDICAL_SURVIVOR
 
@@ -324,6 +326,7 @@ Standart Survivors :	/datum/equipment_preset/survivor/scientist,
 	flags = EQUIPMENT_PRESET_START_OF_ROUND
 	idtype = /obj/item/card/id/data
 	access = list(ACCESS_CIVILIAN_PUBLIC,ACCESS_CIVILIAN_BRIG,ACCESS_CIVILIAN_COMMAND)
+	paygrades = list(PAY_SHORT_CPO = JOB_PLAYTIME_TIER_0)
 
 	survivor_variant = SECURITY_SURVIVOR
 


### PR DESCRIPTION

# About the pull request

As title

# Explain why it's good for the game

We have a civilian doctor paygrade & prefix, but it's basically never seen anymore. Makes sense for civilian doctors to be using it.
Same for civilian security officers.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Makes survivor doctors now use doctor title, and security survivors now use Officer title.
/:cl:
