### PR TITLE
Stops dead people from removing their cuffs

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -515,6 +515,8 @@
 		if(do_after(src, 1200, INTERRUPT_NO_FLOORED^INTERRUPT_RESIST, BUSY_ICON_HOSTILE))
 			if(!buckled)
 				return
+			if(user.stat == DEAD)
+				return
 			visible_message(SPAN_DANGER("<B>[src] manages to unbuckle themself!</B>"),\
 						SPAN_NOTICE("You successfully unbuckle yourself."))
 			buckled.manual_unbuckle(src)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -515,7 +515,7 @@
 		if(do_after(src, 1200, INTERRUPT_NO_FLOORED^INTERRUPT_RESIST, BUSY_ICON_HOSTILE))
 			if(!buckled)
 				return
-			if(src.stat == DEAD)
+			if(stat == DEAD)
 				return
 			visible_message(SPAN_DANGER("<B>[src] manages to unbuckle themself!</B>"),\
 						SPAN_NOTICE("You successfully unbuckle yourself."))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -505,7 +505,7 @@
 		C.visible_message(SPAN_DANGER("[C] has successfully extinguished the fire on [src]!"), \
 		SPAN_NOTICE("You extinguished the fire on [src]."), null, 5)
 
-/mob/living/carbon/resist_buckle()
+/mob/living/carbon/resist_buckle(mob/user)
 
 	if(handcuffed)
 		next_move = world.time + 100

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -505,7 +505,7 @@
 		C.visible_message(SPAN_DANGER("[C] has successfully extinguished the fire on [src]!"), \
 		SPAN_NOTICE("You extinguished the fire on [src]."), null, 5)
 
-/mob/living/carbon/resist_buckle(mob/user)
+/mob/living/carbon/resist_buckle()
 
 	if(handcuffed)
 		next_move = world.time + 100
@@ -515,7 +515,7 @@
 		if(do_after(src, 1200, INTERRUPT_NO_FLOORED^INTERRUPT_RESIST, BUSY_ICON_HOSTILE))
 			if(!buckled)
 				return
-			if(user.stat == DEAD)
+			if(src.stat == DEAD)
 				return
 			visible_message(SPAN_DANGER("<B>[src] manages to unbuckle themself!</B>"),\
 						SPAN_NOTICE("You successfully unbuckle yourself."))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1598,7 +1598,8 @@
 			O.show_message(SPAN_DANGER("<B>[usr] attempts to remove [restraint]!</B>"), 1)
 		if(!do_after(src, breakouttime, INTERRUPT_NO_NEEDHAND^INTERRUPT_RESIST, BUSY_ICON_HOSTILE))
 			return
-
+		if(stat == DEAD)
+			return
 		if(!restraint || buckled)
 			return // time leniency for lag which also might make this whole thing pointless but the server
 		for(var/mob/O in viewers(src))//  lags so hard that 40s isn't lenient enough - Quarxink


### PR DESCRIPTION
# About the pull request

I think I just saw someone who was in the middle of removing their cuffs die, and then they finished removing their cuffs - so I'm adding a check to prevent that (also covers unbuckling when cuffed for good measure). I'm not sure if it was a niche race condition or what.

# Explain why it's good for the game

Erm actually you shouldn't be able to remove your cuffs when you're dead 🤓


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: can't remove cuffs/unbuckle self while dead anymore
/:cl:
