### PR TITLE
Changes 'view objectives' verb to 'view intel objectives' verb, in line with 'view research objectives'

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1042,7 +1042,7 @@
 	show_browser(src, dat, "Crew Manifest", "manifest", "size=400x750")
 
 /mob/living/carbon/human/verb/view_objective_memory()
-	set name = "View objectives"
+	set name = "View intel objectives"
 	set category = "IC"
 
 	if(!mind)


### PR DESCRIPTION

# About the pull request

Changes the IC verb 'view objectives' to 'view intel objectives'

# Explain why it's good for the game

'View objectives' is not intuitive as to it's purpose, could be interpreted as view personal objectives (or traitor objectives by new players from other codebases)

This change makes it in line with the more recently added 'view research objectives', and makes the purpose of the verb more clear.

I have not tested this, as I can't see how the text change would affect anything else.

# Testing Photographs and Procedure

N/A

# Changelog

:cl:
qol: Changed 'View objectives' verb to 'View intel objectives'.
/:cl: