### PR TITLE
Revert #6903

### DIFF
--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -1,6 +1,6 @@
 /obj/structure/machinery/keycard_auth
 	name = "Keycard Authentication Device"
-	desc = "This device is used to trigger station functions, which require more than one ID card to authenticate."
+	desc = "This device is used to trigger station functions, which require multiple swipes of an ID card to authenticate."
 	icon = 'icons/obj/structures/machinery/monitors.dmi'
 	icon_state = "auth_off"
 	unacidable = TRUE

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -36,11 +36,8 @@
 			if(active == 1)
 				//This is not the device that made the initial request. It is the device confirming the request.
 				if(event_source)
-					if(event_source.event_triggered_by == user)
-						user.visible_message(SPAN_DANGER("Your ID is rejected, as it is the one that triggered the event!"))
-						return
 					event_source.confirmed = 1
-					event_source.event_confirmed_by = user
+					event_source.event_confirmed_by = usr
 			else if(screen == 2)
 				event_triggered_by = usr
 				broadcast_request() //This is the device making the initial event request. It needs to broadcast to other devices

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -37,7 +37,7 @@
 				//This is not the device that made the initial request. It is the device confirming the request.
 				if(event_source)
 					event_source.confirmed = 1
-					event_source.event_confirmed_by = usr
+					event_source.event_confirmed_by = user
 			else if(screen == 2)
 				event_triggered_by = usr
 				broadcast_request() //This is the device making the initial event request. It needs to broadcast to other devices


### PR DESCRIPTION
Reverts cmss13-devs/cmss13#6903

On lowpop red alert and other actions requiring keycards can become impossible due to lack of CIC staff, along with the fact of if you are not a commander you cannot use ares to activate red alert and there will likely not be a joe

# Changelog
:cl:
balance: Keycard swipers no longer require two unique keycards to function.
fix: fixed the description text for the card swipe to reduce confusion
/:cl:
