### PR TITLE
Psychic Whisper/Radiance flavour.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_abilities.dm
+++ b/code/modules/mob/living/carbon/human/human_abilities.dm
@@ -135,11 +135,13 @@
 
 	var/list/target_list = list()
 	for(var/mob/living/carbon/possible_target in view(7, human_owner))
-		if(possible_target == human_owner || !possible_target.client) continue
+		if(possible_target == human_owner || !possible_target.client) 
+			continue
 		target_list += possible_target
 
-	var/mob/living/carbon/target_mob = tgui_input_list(usr, "Target", "Send a Psychic Whisper to whom?", target_list, theme="hive_status")
-	if(!target_mob) return
+	var/mob/living/carbon/target_mob = tgui_input_list(human_owner, "Target", "Send a Psychic Whisper to whom?", target_list, theme = "hive_status")
+	if(!target_mob) 
+		return
 
 	human_owner.psychic_whisper(target_mob)
 

--- a/code/modules/mob/living/carbon/human/human_abilities.dm
+++ b/code/modules/mob/living/carbon/human/human_abilities.dm
@@ -118,6 +118,31 @@
 /datum/action/human_action/smartpack/repair_form/cooldown_check(obj/item/storage/backpack/marine/smartpack/S)
 	return S.repairing
 
+
+/datum/action/human_action/psychic_whisper
+	name = "Psychic Whipser"
+	action_icon_state = "cultist_channel_hivemind"
+
+/datum/action/human_action/psychic_whisper/action_activate()
+	. = ..()
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/human_owner = owner
+
+	if(human_owner.client.prefs.muted & MUTE_IC)
+		to_chat(human_owner, SPAN_DANGER("You cannot whisper (muted)."))
+		return
+
+	var/list/target_list = list()
+	for(var/mob/living/carbon/possible_target in view(7, human_owner))
+		if(possible_target == human_owner || !possible_target.client) continue
+		target_list += possible_target
+
+	var/mob/living/carbon/target_mob = tgui_input_list(usr, "Target", "Send a Psychic Whisper to whom?", target_list, theme="hive_status")
+	if(!target_mob) return
+
+	human_owner.psychic_whisper(target_mob)
+
 /*
 CULT
 */

--- a/code/modules/mob/living/carbon/human/powers/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/powers/human_powers.dm
@@ -186,7 +186,7 @@
 	var/whisper = strip_html(input("Message:", "Psychic Whisper") as text|null)
 	if(whisper)
 		log_say("PsychicWhisper: [key_name(src)]->[target_mob.key] : [whisper] (AREA: [get_area_name(loc)])")
-		to_chat(target_mob, SPAN_XENOWARNING(" You hear a strange, alien voice in your head... <i>[whisper]</i>"))
+		to_chat(target_mob, SPAN_XENOWARNING(" You hear a strange, alien voice in your head... <i>[SPAN_PSYTALK(whisper)]</i>"))
 		to_chat(src, SPAN_XENOWARNING(" You said: \"[whisper]\" to [target_mob]"))
 		for (var/mob/dead/observer/ghost as anything in GLOB.observer_list)
 			if(!ghost.client || isnewplayer(ghost))
@@ -195,7 +195,7 @@
 				var/rendered_message
 				var/human_track = "(<a href='byond://?src=\ref[ghost];track=\ref[src]'>F</a>)"
 				var/target_track = "(<a href='byond://?src=\ref[ghost];track=\ref[target_mob]'>F</a>)"
-				rendered_message = SPAN_XENOLEADER("PsychicWhisper: [real_name][human_track] to [target_mob.real_name][target_track], <span class='normal'>'[whisper]'</span>")
+				rendered_message = SPAN_XENOLEADER("PsychicWhisper: [real_name][human_track] to [target_mob.real_name][target_track], <span class='normal'>'[SPAN_PSYTALK(whisper)]'</span>")
 				ghost.show_message(rendered_message, SHOW_MESSAGE_AUDIBLE)
 	return
 

--- a/code/modules/mob/living/carbon/xenomorph/Abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Abilities.dm
@@ -210,9 +210,9 @@
 	if(whisper)
 		log_say("PsychicWhisper: [key_name(xeno_player)]->[target_mob.key] : [whisper] (AREA: [get_area_name(target_mob)])")
 		if(!istype(target_mob, /mob/living/carbon/xenomorph))
-			to_chat(target_mob, SPAN_XENOQUEEN("You hear a strange, alien voice in your head. \"[whisper]\""))
+			to_chat(target_mob, SPAN_XENOQUEEN("You hear a strange, alien voice in your head. \"[SPAN_PSYTALK(whisper)]\""))
 		else
-			to_chat(target_mob, SPAN_XENOQUEEN("You hear the voice of [xeno_player] resonate in your head. \"[whisper]\""))
+			to_chat(target_mob, SPAN_XENOQUEEN("You hear the voice of [xeno_player] resonate in your head. \"[SPAN_PSYTALK(whisper)]\""))
 		to_chat(xeno_player, SPAN_XENONOTICE("You said: \"[whisper]\" to [target_mob]"))
 
 		for(var/mob/dead/observer/ghost as anything in GLOB.observer_list)
@@ -222,7 +222,7 @@
 				var/rendered_message
 				var/xeno_track = "(<a href='byond://?src=\ref[ghost];track=\ref[xeno_player]'>F</a>)"
 				var/target_track = "(<a href='byond://?src=\ref[ghost];track=\ref[target_mob]'>F</a>)"
-				rendered_message = SPAN_XENOLEADER("PsychicWhisper: [xeno_player.real_name][xeno_track] to [target_mob.real_name][target_track], <span class='normal'>'[whisper]'</span>")
+				rendered_message = SPAN_XENOLEADER("PsychicWhisper: [xeno_player.real_name][xeno_track] to [target_mob.real_name][target_track], <span class='normal'>'[SPAN_PSYTALK(whisper)]'</span>")
 				ghost.show_message(rendered_message, SHOW_MESSAGE_AUDIBLE)
 
 	return ..()
@@ -254,9 +254,9 @@
 			continue
 		target_list += possible_target
 		if(!istype(possible_target, /mob/living/carbon/xenomorph))
-			to_chat(possible_target, SPAN_XENOQUEEN("You hear a strange, alien voice in your head. \"[whisper]\""))
+			to_chat(possible_target, SPAN_XENOQUEEN("You hear a strange, alien voice in your head. \"[SPAN_PSYTALK(whisper)]\""))
 		else
-			to_chat(possible_target, SPAN_XENOQUEEN("You hear the voice of [xeno_player] resonate in your head. \"[whisper]\""))
+			to_chat(possible_target, SPAN_XENOQUEEN("You hear the voice of [xeno_player] resonate in your head. \"[SPAN_PSYTALK(whisper)]\""))
 	FOR_DVIEW_END
 	if(!length(target_list))
 		return
@@ -269,7 +269,7 @@
 		if(ghost.client.prefs.toggles_chat & CHAT_GHOSTHIVEMIND)
 			var/rendered_message
 			var/xeno_track = "(<a href='byond://?src=\ref[ghost];track=\ref[xeno_player]'>F</a>)"
-			rendered_message = SPAN_XENOLEADER("PsychicRadiance: [xeno_player.real_name][xeno_track] to [targetstring], <span class='normal'>'[whisper]'</span>")
+			rendered_message = SPAN_XENOLEADER("PsychicRadiance: [xeno_player.real_name][xeno_track] to [targetstring], <span class='normal'>'[SPAN_PSYTALK(whisper)]'</span>")
 			ghost.show_message(rendered_message, SHOW_MESSAGE_AUDIBLE)
 	return ..()
 

--- a/code/modules/reagents/chemistry_properties/prop_neutral.dm
+++ b/code/modules/reagents/chemistry_properties/prop_neutral.dm
@@ -531,11 +531,11 @@
 	..()
 
 	chem_host.pain.recalculate_pain()
-	remove_verb(chem_host, /mob/living/carbon/human/proc/psychic_whisper)
+	remove_action(chem_host, /datum/action/human_action/psychic_whisper)
 	to_chat(chem_host, SPAN_NOTICE("The pain in your head subsides, and you are left feeling strangely alone."))
 
 /datum/chem_property/neutral/encephalophrasive/reaction_mob(mob/chem_host, method=INGEST, volume, potency)
-	add_verb(chem_host, /mob/living/carbon/human/proc/psychic_whisper)
+	give_action(chem_host, /datum/action/human_action/psychic_whisper)
 	to_chat(chem_host, SPAN_NOTICE("A terrible headache manifests, and suddenly it feels as though your mind is outside of your skull."))
 
 /datum/chem_property/neutral/encephalophrasive/process(mob/living/chem_host, potency = 1, delta_time)

--- a/code/span_macros.dm
+++ b/code/span_macros.dm
@@ -19,6 +19,8 @@
 #define SPAN_XENOWARNING(X) "<span class='xenowarning'>[X]</span>"
 #define SPAN_XENOMINORWARNING(X) "<span class='xenominorwarning'>[X]</span>"
 
+#define SPAN_PSYTALK(X) "<span class='psy_talk'>[X]</span>"
+
 // Yautja related
 #define SPAN_YAUTJABOLD(X) "<span class='yautjabold'>[X]</span>"
 #define SPAN_YAUTJABOLDBIG(X) "<span class='yautjaboldbig'>[X]</span>"

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -123,6 +123,8 @@ h1.alert, h2.alert {color: #000000;}
 .xeno {color: #900090; font-style: italic;}
 .xenoleader {color: #730d73; font-style: italic; font-size: 3;}
 .xenoqueen {color: #730d73; font-style: italic; font-weight: bold; font-size: 3;}
+.psy_talk {color: #a70090; font-style: italic; font-weight: bold; font-size: 3;}
+
 .newscaster {color: #800000;}
 
 .role_header {color: #db0000 text-align: center; font-weight: bold; font-family: trebuchet-ms; font-size: 2;}

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -1449,6 +1449,14 @@ em {
   animation: glitch 0.5s infinite;
 }
 
+.psy_talk {
+  color: #c400aa;
+  font-weight: bold;
+
+  /*Animation*/
+  animation: psy_glitch 0.5s infinite;
+}
+
 /*Keyframes*/
 
 @keyframes glitch {
@@ -1469,6 +1477,28 @@ em {
 
   100% {
     color: #830000;
+    transform: translate(1px, 1px);
+  }
+}
+
+@keyframes psy_glitch {
+  25% {
+    color: #c400aa;
+    transform: translate(-2px, -1px);
+  }
+
+  50% {
+    color: #91007d;
+    transform: translate(1px, -2px);
+  }
+
+  75% {
+    color: #750066;
+    transform: translate(-1px, 2px);
+  }
+
+  100% {
+    color: #7c016c;
     transform: translate(1px, 1px);
   }
 }

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -1471,6 +1471,14 @@ h2.alert {
   animation: glitch 0.5s infinite;
 }
 
+.psy_talk {
+  color: #a70090;
+  font-weight: bold;
+
+  /*Animation*/
+  animation: psy_glitch 0.5s infinite;
+}
+
 /*Keyframes*/
 
 @keyframes glitch {
@@ -1491,6 +1499,28 @@ h2.alert {
 
   100% {
     color: #830000;
+    transform: translate(1px, 1px);
+  }
+}
+
+@keyframes psy_glitch {
+  25% {
+    color: #a70090;
+    transform: translate(-2px, -1px);
+  }
+
+  50% {
+    color: #91007d;
+    transform: translate(1px, -2px);
+  }
+
+  75% {
+    color: #750066;
+    transform: translate(-1px, 2px);
+  }
+
+  100% {
+    color: #7c016c;
     transform: translate(1px, 1px);
   }
 }


### PR DESCRIPTION

# About the pull request

Adds some flavour to psychic speech, made the whisper and radiance flicker around like Yautja Translator, but purple.
Also added an ability button for human psychic whisper because the ESP chem doesn't always make it clear someone has been given the ability. This should help. Icon to come, maybe?

# Explain why it's good for the game

Bit of flavour is a good thing, and in this case draws attention to something people habitually don't notice is being used.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Added visual flavour to use of psychic whisper or radiance. It now flickers in the chat window like the Yautja Translator.
add: Added an ability button for the human version of psychic whisper, and replaces the existing verb for it in the ESP chem property.
/:cl:
