### PR TITLE
Changes the M44 heavy speed loader to be more clear

### DIFF
--- a/code/modules/projectiles/magazines/revolvers.dm
+++ b/code/modules/projectiles/magazines/revolvers.dm
@@ -24,7 +24,7 @@
 
 /obj/item/ammo_magazine/revolver/heavy
 	name = "\improper M44 heavy speed loader (.44)"
-	desc = "A revolver speed loader containing heavy bullets. While less heavy hitting than the traditional roundsS, these are more accurate."
+	desc = "A revolver speed loader containing heavy bullets. While less damaging overall than the traditional rounds, these are more accurate."
 	default_ammo = /datum/ammo/bullet/revolver/heavy
 	caliber = ".44"
 	ammo_band_color = REVOLVER_TIP_COLOR_HEAVY

--- a/code/modules/projectiles/magazines/revolvers.dm
+++ b/code/modules/projectiles/magazines/revolvers.dm
@@ -24,7 +24,7 @@
 
 /obj/item/ammo_magazine/revolver/heavy
 	name = "\improper M44 heavy speed loader (.44)"
-	desc = "A revolver speed loader containing heavy bullets. While less heavy hitting, these are more accurate than the traditional rounds."
+	desc = "A revolver speed loader containing heavy bullets. While less heavy hitting than the traditional roundsS, these are more accurate."
 	default_ammo = /datum/ammo/bullet/revolver/heavy
 	caliber = ".44"
 	ammo_band_color = REVOLVER_TIP_COLOR_HEAVY

--- a/code/modules/projectiles/magazines/revolvers.dm
+++ b/code/modules/projectiles/magazines/revolvers.dm
@@ -24,6 +24,7 @@
 
 /obj/item/ammo_magazine/revolver/heavy
 	name = "\improper M44 heavy speed loader (.44)"
+	desc = "A revolver speed loader containing heavy bullets. While less heavy hitting, these are more accurate than the traditional rounds."
 	default_ammo = /datum/ammo/bullet/revolver/heavy
 	caliber = ".44"
 	ammo_band_color = REVOLVER_TIP_COLOR_HEAVY

--- a/code/modules/projectiles/magazines/revolvers.dm
+++ b/code/modules/projectiles/magazines/revolvers.dm
@@ -24,7 +24,7 @@
 
 /obj/item/ammo_magazine/revolver/heavy
 	name = "\improper M44 heavy speed loader (.44)"
-	desc = "A revolver speed loader containing heavy bullets. While less damaging overall than the traditional rounds, these are more accurate."
+	desc = "A revolver speed loader containing heavy bullets. While less damaging overall than the traditional rounds, they are more accurate."
 	default_ammo = /datum/ammo/bullet/revolver/heavy
 	caliber = ".44"
 	ammo_band_color = REVOLVER_TIP_COLOR_HEAVY


### PR DESCRIPTION
# About the pull request

Changes the M44 heavy speed loader to be more clear on what the round actually does, since the name "heavy" can be easily mistaken for an AP round. (imo Marksman and Heavy damage values should be swapped but eh)

# Explain why it's good for the game

Having clear descriptions of what bullets do is good.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Changes the M44 heavy speed loader description to reflect it's actual use-case.
/:cl:
