### PR TITLE
Smoke Minirockets for HvH CAS

### DIFF
--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -375,8 +375,9 @@
 	travelling_time = 80 //faster than 30mm cannon, slower than real rockets
 	transferable_ammo = TRUE
 	point_cost = 300
-	fire_mission_delay = 3 //high cooldown
-	 var/rocket_name = "minirocket"
+	fire_mission_delay =3 //high cooldown
+
+	var/rocket_name = " minirocket"
 
 /obj/structure/ship_ammo/minirocket/detonate_on(turf/impact, obj/structure/dropship_equipment/weapon/fired_from)
 	impact.ceiling_debris_check(2)
@@ -407,7 +408,7 @@
 	icon_state = "minirocket_inc"
 	point_cost = 500
 	fire_mission_delay = 3 //high cooldown
-	/rocket_name = incendiary minirocket
+	rocket_name = " incendiary minirocket"
 
 
 /obj/structure/ship_ammo/minirocket/incendiary/detonate_on(turf/impact, obj/structure/dropship_equipment/weapon/fired_from)
@@ -450,33 +451,31 @@
 
 /obj/structure/ship_ammo/minirocket/smoke
 	name = "\improper 1FW-AH Smoke shell 'Fog'"
-	desc = "The Type 1FW-AH Smoke shell 'Fog' though it lacks a targeting system, its high ammo count and low cost of production means it is a effective way to block enemy visuals, each individual pod contains a chemical mix that produces thick, harmless smoke, or "fog" on impact. Can be loaded into the LAU-229 Rocket Pod."
+	desc = "The Type 1FW-AH Smoke shell, also known as 'Fog', lacks a targeting system, but its high ammo count and low cost of production means it is a effective way to block enemy visuals, each individual pod contains a chemical mix that produces thick, harmless smoke, or 'fog' on impact. Can be loaded into the LAU-229 Rocket Pod."
 	icon_state = "minirocket"
 	icon = 'icons/obj/structures/props/almayer_props.dmi'
 	equipment_type = /obj/structure/dropship_equipment/weapon/minirocket_pod
 	ammo_count = 12
 	max_ammo_count = 12
 	ammo_name = "Smoke shells"
-	travelling_time = 70 //Slightly faster than their mini-mike siblings.
+	travelling_time = 50 //Slightly faster than their mini-mike siblings.
 	transferable_ammo = TRUE
-	point_cost = 200
-	fire_mission_delay = 1 //Low cooldown, as the effect is relatively harmless.
-	rocket_name= "smoke shell"
+	point_cost = 100
+	fire_mission_delay = 1  //Low cooldown, as the effect is relatively harmless.
+	rocket_name= " smoke shell"
 
 /obj/structure/ship_ammo/minirocket/smoke/detonate_on(turf/impact, obj/structure/dropship_equipment/weapon/fired_from)
 	impact.ceiling_debris_check(2)
 	spawn(5)
 
-			var/datum/effect_system/smoke_spread/S = new/datum/effect_system/smoke_spread()
-			S.set_up(10,0,impact,null,5)
-			S.start()
+		var/datum/effect_system/smoke_spread/S = new/datum/effect_system/smoke_spread()
+		S.set_up(7,0,impact,null,70)
+		S.start()
 		if(!ammo_count && loc)
 			qdel(src) //deleted after last Smole shell is fired and impacts the ground.
 
 /obj/structure/ship_ammo/minirocket/smoke/show_loaded_desc(mob/user)
 	if(ammo_count)
-		return "It's loaded with \a [src] containing [ammo_count] Smoke Shells.\s."
+		return "It's loaded with \a [src] containing [ammo_count] [rocket_name]\s."
 
-/obj/structure/ship_ammo/minirocket/smoke/get_examine_text(mob/user)
-	. = ..()
-	. += "It has [ammo_count] [rocket_name]\s."
+//A note from the guy that made this. this was my first project, and it probally sort of sucks. its effectively modified from the core Minirockets. But i oddly had a blast doing it, and hope i can look back of this with fondness later. I love this community and wanted to give more than my character.

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -376,6 +376,7 @@
 	transferable_ammo = TRUE
 	point_cost = 300
 	fire_mission_delay = 3 //high cooldown
+	 var/rocket_name = "minirocket"      
 
 /obj/structure/ship_ammo/minirocket/detonate_on(turf/impact, obj/structure/dropship_equipment/weapon/fired_from)
 	impact.ceiling_debris_check(2)
@@ -393,11 +394,11 @@
 
 /obj/structure/ship_ammo/minirocket/show_loaded_desc(mob/user)
 	if(ammo_count)
-		return "It's loaded with \a [src] containing [ammo_count] minirocket\s."
+		return "It's loaded with \a [src] containing [ammo_count] [rocket_name]\s."
 
 /obj/structure/ship_ammo/minirocket/get_examine_text(mob/user)
 	. = ..()
-	. += "It has [ammo_count] minirocket\s."
+	. += "It has [ammo_count][rocket_name]\s."
 
 
 /obj/structure/ship_ammo/minirocket/incendiary
@@ -406,6 +407,8 @@
 	icon_state = "minirocket_inc"
 	point_cost = 500
 	fire_mission_delay = 3 //high cooldown
+	rocket_name = incendiary minirocket
+	
 
 /obj/structure/ship_ammo/minirocket/incendiary/detonate_on(turf/impact, obj/structure/dropship_equipment/weapon/fired_from)
 	..()

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -376,7 +376,7 @@
 	transferable_ammo = TRUE
 	point_cost = 300
 	fire_mission_delay = 3 //high cooldown
-	 var/rocket_name = "minirocket"      
+	 var/rocket_name = "minirocket"
 
 /obj/structure/ship_ammo/minirocket/detonate_on(turf/impact, obj/structure/dropship_equipment/weapon/fired_from)
 	impact.ceiling_debris_check(2)
@@ -407,8 +407,8 @@
 	icon_state = "minirocket_inc"
 	point_cost = 500
 	fire_mission_delay = 3 //high cooldown
-	rocket_name = incendiary minirocket
-	
+	/rocket_name = incendiary minirocket
+
 
 /obj/structure/ship_ammo/minirocket/incendiary/detonate_on(turf/impact, obj/structure/dropship_equipment/weapon/fired_from)
 	..()
@@ -446,3 +446,37 @@
 		to_chat(user, SPAN_WARNING("The selected drop site is a sheer wall!"))
 		return FALSE
 	return TRUE
+
+
+/obj/structure/ship_ammo/minirocket/smoke
+	name = "\improper 1FW-AH Smoke shell 'Fog'"
+	desc = "The Type 1FW-AH Smoke shell 'Fog' though it lacks a targeting system, its high ammo count and low cost of production means it is a effective way to block enemy visuals, each individual pod contains a chemical mix that produces thick, harmless smoke, or "fog" on impact. Can be loaded into the LAU-229 Rocket Pod."
+	icon_state = "minirocket"
+	icon = 'icons/obj/structures/props/almayer_props.dmi'
+	equipment_type = /obj/structure/dropship_equipment/weapon/minirocket_pod
+	ammo_count = 12
+	max_ammo_count = 12
+	ammo_name = "Smoke shells"
+	travelling_time = 70 //Slightly faster than their mini-mike siblings.
+	transferable_ammo = TRUE
+	point_cost = 200
+	fire_mission_delay = 1 //Low cooldown, as the effect is relatively harmless.
+	rocket_name= "smoke shell"
+
+/obj/structure/ship_ammo/minirocket/smoke/detonate_on(turf/impact, obj/structure/dropship_equipment/weapon/fired_from)
+	impact.ceiling_debris_check(2)
+	spawn(5)
+
+			var/datum/effect_system/smoke_spread/S = new/datum/effect_system/smoke_spread()
+			S.set_up(10,0,impact,null,5)
+			S.start()
+		if(!ammo_count && loc)
+			qdel(src) //deleted after last Smole shell is fired and impacts the ground.
+
+/obj/structure/ship_ammo/minirocket/smoke/show_loaded_desc(mob/user)
+	if(ammo_count)
+		return "It's loaded with \a [src] containing [ammo_count] Smoke Shells.\s."
+
+/obj/structure/ship_ammo/minirocket/smoke/get_examine_text(mob/user)
+	. = ..()
+	. += "It has [ammo_count] [rocket_name]\s."

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -375,7 +375,7 @@
 	travelling_time = 80 //faster than 30mm cannon, slower than real rockets
 	transferable_ammo = TRUE
 	point_cost = 300
-	fire_mission_delay =3 //high cooldown
+	fire_mission_delay = 3 //high cooldown
 
 	var/rocket_name = " minirocket"
 

--- a/code/modules/projectiles/magazines/shotguns.dm
+++ b/code/modules/projectiles/magazines/shotguns.dm
@@ -284,6 +284,7 @@ GLOBAL_LIST_INIT(shotgun_handfuls_12g, list(
 
 /obj/item/ammo_magazine/handful/shotgun/heavy/beanbag
 	name = "handful of heavy beanbag shells (8g)"
+	desc = "A non-lethal type of shotgun ammo."
 	icon_state = "heavy_beanbag_4"
 	handful_state = "heavy_beanbag"
 	default_ammo = /datum/ammo/bullet/shotgun/heavy/beanbag


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Added Smoke Minirockets ammo for CAS, for the UPP vs USCM game mode in dev. This was my first project so please excuse the odd coding choices if there are any.

Its been tested, and others agreed it was semi-reasonable but figures are easily changed if players disagree.


# Explain why it's good for the game

CAS is a fun part of the standard game mode, and the main gameplay loop of a few roles includes firing CAS. However, for HvH some non-lethal CAS options were desired by the team. Hence, smoke.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>



</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->
:cl: Tobias_reaper
 add: Added Smoke MiniRockets for CAS in HvH.
 add: Heavy Beanbag round description.
/:cl:
 
