### PR TITLE
Intelligence Officers latejoin QoL

### DIFF
--- a/code/game/objects/effects/landmarks/landmarks.dm
+++ b/code/game/objects/effects/landmarks/landmarks.dm
@@ -421,6 +421,9 @@
 	name = "Nurse late join"
 	job = JOB_NURSE
 
+/obj/effect/landmark/late_join/intel
+	name = "Intelligence Officer late join"
+	job = JOB_INTEL
 
 /obj/effect/landmark/late_join/Initialize(mapload, ...)
 	. = ..()

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -39996,6 +39996,7 @@
 /area/almayer/squads/req)
 "mMP" = (
 /obj/effect/landmark/start/intel,
+/obj/effect/landmark/late_join/intel,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/port_atmos)
 "mMV" = (
@@ -44339,6 +44340,7 @@
 	pixel_y = 29;
 	serial_number = 12
 	},
+/obj/effect/landmark/late_join/intel,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/port_atmos)
 "oyO" = (
@@ -113802,7 +113804,7 @@ vub
 bPL
 bCM
 xSM
-tez
+cgE
 gsm
 bCM
 bbr
@@ -114005,7 +114007,7 @@ qlz
 tez
 bCN
 ccQ
-tez
+cgE
 ccQ
 bCN
 bbr
@@ -114208,7 +114210,7 @@ qlz
 tez
 bpV
 ccQ
-tez
+cgE
 ccQ
 cdn
 bbr
@@ -114411,7 +114413,7 @@ qlz
 tez
 bCM
 ccQ
-tez
+cgE
 ccQ
 bCM
 bbr
@@ -114614,7 +114616,7 @@ vub
 tez
 bCN
 ccQ
-tez
+cgE
 ccQ
 bCN
 jhb


### PR DESCRIPTION

# About the pull request
IOs now latejoin in the officer bunks instead of with everyone else.
Removed some "disjointed" cryo latejoin spots that didn't make much sense.

removed some latejoin indicators in cryo to prevent latejoiners from materializing out of thin air
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
IOs already spawn there at roundstart, and also new IO players spawn extremely far from their gear location, without a radio, causing them to either need to wander the halls or ask a mentor/random player to help them find the computer lab.

With this change they're just a few steps away from gearing up
![image](https://github.com/user-attachments/assets/3c00aa61-02f7-4d76-801c-1e7761660477)
# Testing Photographs and Procedure
latejoin cryo before:

![image](https://github.com/user-attachments/assets/2a334474-ef96-4c8f-8391-26e57795b682)

after:

![image](https://github.com/user-attachments/assets/d23eb173-3b1b-476b-abc2-53f796f511a0)


# Changelog
:cl:
qol: IOs now late join into their officer bunks instead of the general wakeup area
qol: Late joiners will no longer wake up in thin air in the main cryo area.
/:cl:
