### PR TITLE
Fix Boarding Shuttle

### DIFF
--- a/code/modules/shuttle/shuttles/ert.dm
+++ b/code/modules/shuttle/shuttles/ert.dm
@@ -169,6 +169,7 @@
 	port_direction = NORTH
 	width = 17
 	height = 29
+	dwidth = 8
 	var/port_door
 	var/starboard_door
 

--- a/maps/shuttles/ert_shuttle_big.dmm
+++ b/maps/shuttles/ert_shuttle_big.dmm
@@ -625,9 +625,7 @@
 /turf/closed/wall/almayer/white/hull,
 /area/shuttle/ert)
 "Qb" = (
-/obj/docking_port/mobile/emergency_response/big{
-	dwidth = 8
-	},
+/obj/docking_port/mobile/emergency_response/big,
 /turf/closed/wall/almayer/white/hull,
 /area/shuttle/ert)
 "Qr" = (

--- a/maps/shuttles/ert_shuttle_big.dmm
+++ b/maps/shuttles/ert_shuttle_big.dmm
@@ -625,7 +625,9 @@
 /turf/closed/wall/almayer/white/hull,
 /area/shuttle/ert)
 "Qb" = (
-/obj/docking_port/mobile/emergency_response/big,
+/obj/docking_port/mobile/emergency_response/big{
+	dwidth = 8
+	},
 /turf/closed/wall/almayer/white/hull,
 /area/shuttle/ert)
 "Qr" = (


### PR DESCRIPTION

# About the pull request



Allows the `ert_shuttle_big` aka boarding shuttle to spawn and dock properly.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Bug bad.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Master, spawning:
![image](https://github.com/user-attachments/assets/a505e63c-8bb1-4a8d-bce6-5174a398fa06)

Master, docking:
![image](https://github.com/user-attachments/assets/61b1ca6a-9fb7-4c9e-8071-e40d51f4d34a)


PR, ERT station:
![image](https://github.com/user-attachments/assets/2a98eca7-3c3f-4538-acd8-11e7c682b3dd)

PR, Almayer port dock:
![image](https://github.com/user-attachments/assets/7d3c29d0-185f-4139-a5dd-b7f68378b599)

PR, Almayer starboard dock:
![image](https://github.com/user-attachments/assets/e889322e-5e0e-4031-9ec5-9f41b021c7b5)

</details>


# Changelog
:cl:
fix: fixed ERT boarding shuttle able to spawn and dock
/:cl:
