### PR TITLE
Renegade Hive is now a different color

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -1199,8 +1199,8 @@
 	reporting_id = "renegade"
 	hivenumber = XENO_HIVE_RENEGADE
 	prefix = "Renegade "
-	color = "#9c7a4d"
-	ui_color ="#80705c"
+	color = "#ffae00"
+	ui_color ="#ad732c"
 
 	dynamic_evolution = FALSE
 	allow_queen_evolve = FALSE


### PR DESCRIPTION
# About the pull request

I've come to notice during rounds where a Renegade hive comes into existence (xenos with USCM IFF tags who decide to permanently ally with marines after corrupted queen dies/betrays). The marines shoot them way too often on first glance and clear their weeds despite the weeds not affecting them and the renegades being incapable of ever hurting marines. I've assume this is due to their colors looking way too similiar to the original hive since at first glance, you might think its just a regular xeno. I've decided to change the hive color to be more visually distinct at a glance. 

old look: https://files.catbox.moe/1umkgx.png, new look: https://files.catbox.moe/srs3gd.png. 
Its now only similar to the Bravo hive now.

Is this going to stop marines from executing Renegades? Probably not, they need a better way to show "DO NOT SHOOT, THEY CANT HURT YOU EVER" but this isnt the scope of the PR. This should decrease the incidents of accidental shootings and weed/structure clears.

# Explain why it's good for the game

To make Renegades and their structures less likely to be attacked due to being misidentified as regular xenos from visuals, considering they are supposed to be permanently friendly to marines and killing them is nothing but a net negative for marines.


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:Unknownity
code: The renegade hive is now more visually distinct from the normal hive to decrease the chance of marines accidentally attacking them.
/:cl:

