### PR TITLE
Using a multitool to find an APC now highlights the APC

### DIFF
--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -58,8 +58,7 @@
 		user.balloon_alert(user, "[get_dist(src, APC)] units [dir2text(Get_Compass_Dir(src, APC))]")
 		if(user.client)
 			//Create the appearance so we have something to apply the filter to.
-			var/mutable_appearance/apc_appearance = new /mutable_appearance()
-			apc_appearance.appearance = APC
+			var/mutable_appearance/apc_appearance = new(APC)
 			apc_appearance.filters += list("type" = "outline", "size" = 1, "color" = COLOR_GREEN)
 			//Make it an image we can give to the client
 			var/image/final_image = image(apc_appearance)

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -68,8 +68,9 @@
 			final_image.plane = GAME_PLANE
 			final_image.loc = get_turf(APC)
 			final_image.dir = apc_appearnce.dir
+			final_image.alpha = 225
 			user.client.images += final_image
-			addtimer(CALLBACK(src, PROC_REF(remove_apc_highlight), user.client, final_image), 2 SECONDS)
+			addtimer(CALLBACK(src, PROC_REF(remove_apc_highlight), user.client, final_image), 1.4 SECONDS)
 
 
 	else

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -58,16 +58,16 @@
 		user.balloon_alert(user, "[get_dist(src, APC)] units [dir2text(Get_Compass_Dir(src, APC))]")
 		if(user.client)
 			//Create the appearance so we have something to apply the filter to.
-			var/mutable_appearance/apc_appearnce = new /mutable_appearance()
-			apc_appearnce.appearance = APC
-			apc_appearnce.filters += list("type" = "outline", "size" = 1, "color" = COLOR_GREEN)
-			var/image/final_image = image(apc_appearnce)
+			var/mutable_appearance/apc_appearance = new /mutable_appearance()
+			apc_appearance.appearance = APC
+			apc_appearance.filters += list("type" = "outline", "size" = 1, "color" = COLOR_GREEN)
 			//Make it an image we can give to the client
+			var/image/final_image = image(apc_appearance)
 
 			final_image.layer = WALL_OBJ_LAYER
 			final_image.plane = GAME_PLANE
 			final_image.loc = get_turf(APC)
-			final_image.dir = apc_appearnce.dir
+			final_image.dir = apc_appearance.dir
 			final_image.alpha = 225
 			user.client.images += final_image
 			addtimer(CALLBACK(src, PROC_REF(remove_apc_highlight), user.client, final_image), 1.4 SECONDS)


### PR DESCRIPTION
# About the pull request

Makes the find-APC function more useful.

# Explain why it's good for the game

Very convenient. Lasts for 1.4 seconds (scan cooldown is 1.5 seconds)
Clientside, respects darkness.
You still get the 'X units in Y direction' thing

![image](https://github.com/user-attachments/assets/5049bc9d-1cf1-401a-8e4f-2a02732fc6f9)


# Testing Photographs and Procedure

Spawned in, tried to use multitool, saw green.
Turned off lights, did not see green.
Joined with second client, used multitool. Only saw it on 1 client.
Left after clicking multitool, rejoined to make sure highlight is gone. (Client gets deleted when disconnecting)



# Changelog
:cl:
add: APCs are now highlighted when found via a Multitool/Security Access Tuner. 
/:cl:
