### PR TITLE
Fix typo

### DIFF
--- a/code/modules/autowiki/pages/xeno_stats.dm
+++ b/code/modules/autowiki/pages/xeno_stats.dm
@@ -48,7 +48,7 @@
 	)
 
 	var/sanitized_name = url_encode(replacetext(name, " ", "_"))
-	return list(list(title = "Tempalte:AutoWiki/Content/XenoStats/[sanitized_name]", text = include_template("Autowiki/XenoStats", xeno_data)))
+	return list(list(title = "Template:Autowiki/Content/XenoStats/[sanitized_name]", text = include_template("Autowiki/XenoStats", xeno_data)))
 
 /datum/autowiki/xeno_stats/proc/humanize_speed(speed)
 	return speed * -1 + 1


### PR DESCRIPTION

# About the pull request

Misspelled two parts of the URL, causing the autowiki to not hit the wiki-side template.
- Typo: "Tempalte" -> "Template"
- De-collision: "AutoWiki" -> "Autowiki"

I really hope that's everything.

# Explain why it's good for the game

Makes the original PR actually do something :)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

