### PR TITLE
Fix skipped queen wiki template

### DIFF
--- a/code/modules/autowiki/pages/xeno_stats.dm
+++ b/code/modules/autowiki/pages/xeno_stats.dm
@@ -27,10 +27,6 @@
 
 /datum/autowiki/xeno_stats/proc/template_from_xeno(mob/living/carbon/xenomorph/xeno, datum/xeno_strain/strain)
 	var/name = xeno.caste_type
-	if(istype(xeno, /mob/living/carbon/xenomorph/queen))
-		var/mob/living/carbon/xenomorph/queen/queen = xeno
-		if(!queen.queen_aged)
-			name = queen.real_name
 	if(!isnull(strain))
 		strain.apply_strain(xeno)
 		name = "[strain.name] [name]"

--- a/code/modules/autowiki/pages/xeno_stats.dm
+++ b/code/modules/autowiki/pages/xeno_stats.dm
@@ -27,6 +27,10 @@
 
 /datum/autowiki/xeno_stats/proc/template_from_xeno(mob/living/carbon/xenomorph/xeno, datum/xeno_strain/strain)
 	var/name = xeno.caste_type
+	if(istype(xeno, /mob/living/carbon/xenomorph/queen))
+		var/mob/living/carbon/xenomorph/queen/queen = xeno
+		if(!queen.queen_aged)
+			name = queen.real_name
 	if(!isnull(strain))
 		strain.apply_strain(xeno)
 		name = "[strain.name] [name]"

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -252,6 +252,8 @@
 	return ..()
 
 /mob/living/carbon/xenomorph/queen
+	AUTOWIKI_SKIP(TRUE)
+
 	caste_type = XENO_CASTE_QUEEN
 	name = XENO_CASTE_QUEEN
 	desc = "A huge, looming alien creature. The biggest and the baddest."
@@ -411,6 +413,7 @@
 	hivenumber = XENO_HIVE_MUTATED
 
 /mob/living/carbon/xenomorph/queen/combat_ready
+	AUTOWIKI_SKIP(FALSE)
 	queen_aged = TRUE
 
 /mob/living/carbon/xenomorph/queen/Initialize()

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -252,8 +252,6 @@
 	return ..()
 
 /mob/living/carbon/xenomorph/queen
-	AUTOWIKI_SKIP(TRUE)
-
 	caste_type = XENO_CASTE_QUEEN
 	name = XENO_CASTE_QUEEN
 	desc = "A huge, looming alien creature. The biggest and the baddest."


### PR DESCRIPTION

# About the pull request

Fixes the Queen being entirely skipped over when generating autowiki xeno stats.
I didn't realize that mature (`/queen/combat_ready`) would inherit the `AUTOWIKI_SKIP` from the immature queen (`/queen`).

# Explain why it's good for the game

All the templates should work perfectly™ for real this time 🙏 

# Testing Photographs and Procedure
<details>

Queen template output:
```
{"title":"Template:Autowiki/Content/XenoStats/Queen","text":"{{Autowiki/XenoStats|name=Queen|health=1000|armor=25|plasma=1000|plasma_regeneration=4|minimum_slash_damage=35|maximum_slash_damage=45|claw_strength=3|evasion=0|speed=0.4|explosion_resistance=100}}"}
```
Content template output: 
```
{"title":"Template:Autowiki/Content/XenoStats","text":"{{Template:Autowiki/Content/XenoStats/Carrier}} {{Template:Autowiki/Content/XenoStats/Eggsac_Carrier}} {{Template:Autowiki/Content/XenoStats/Ravager}} {{Template:Autowiki/Content/XenoStats/Berserker_Ravager}} {{Template:Autowiki/Content/XenoStats/Hedgehog_Ravager}} {{Template:Autowiki/Content/XenoStats/Queen}} {{Template:Autowiki/Content/XenoStats/Praetorian}} {{Template:Autowiki/Content/XenoStats/Dancer_Praetorian}} {{Template:Autowiki/Content/XenoStats/Oppressor_Praetorian}} {{Template:Autowiki/Content/XenoStats/Vanguard_Praetorian}} {{Template:Autowiki/Content/XenoStats/Warden_Praetorian}} {{Template:Autowiki/Content/XenoStats/Hivelord}} {{Template:Autowiki/Content/XenoStats/Resin_Whisperer_Hivelord}} {{Template:Autowiki/Content/XenoStats/Defender}} {{Template:Autowiki/Content/XenoStats/Steelcrest_Defender}} {{Template:Autowiki/Content/XenoStats/Warrior}} {{Template:Autowiki/Content/XenoStats/Crusher}} {{Template:Autowiki/Content/XenoStats/Charger_Crusher}} {{Template:Autowiki/Content/XenoStats/Runner}} {{Template:Autowiki/Content/XenoStats/Acider_Runner}} {{Template:Autowiki/Content/XenoStats/Boiler}} {{Template:Autowiki/Content/XenoStats/Trapper_Boiler}} {{Template:Autowiki/Content/XenoStats/Burrower}} {{Template:Autowiki/Content/XenoStats/Drone}} {{Template:Autowiki/Content/XenoStats/Gardener_Drone}} {{Template:Autowiki/Content/XenoStats/Healer_Drone}} {{Template:Autowiki/Content/XenoStats/Lesser_Drone}} {{Template:Autowiki/Content/XenoStats/Lurker}} {{Template:Autowiki/Content/XenoStats/Vampire_Lurker}} {{Template:Autowiki/Content/XenoStats/Sentinel}} {{Template:Autowiki/Content/XenoStats/Spitter}}"}
```

</details>
