### PR TITLE
Changed misleading Reinforced Treads description

### DIFF
--- a/code/modules/vehicles/hardpoints/wheels/treads.dm
+++ b/code/modules/vehicles/hardpoints/wheels/treads.dm
@@ -18,7 +18,7 @@
 
 /obj/item/hardpoint/locomotion/treads/robust
 	name = "\improper Reinforced Treads"
-	desc = "These treads are made of a tougher material and are more durable. However, the extra weight slows the tank down slightly."
+	desc = "These treads are made of a tougher material and are more durable. However, the extra weight slows the tank down."
 
 	health = 500
 	acid_resistant = TRUE


### PR DESCRIPTION
# About the pull request

Changed the description of Reinforced Treads from 'slows tank down slightly' to 'slows tank down' [not sic], less subjective and less suggestive as to the supposed superiority of reinforced treads.

# Explain why it's good for the game

'slightly' is subjective, as well as misleading. I personally do not consider the slowdown 'slight', and anybody who really thinks about it will accept a 'slight' slowdown in exchange for better treads. This way, it's less biased and allows for a more well-rounded choice for tank crews (especially newer, impressionable ones)

# Testing Photographs and Procedure

N/A
# Changelog

:cl:
qol: changed reinforced treads item description
/:cl: