### PR TITLE
Stops Crawling whilst being grabbed. Adds a notice as well.

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -148,7 +148,7 @@
 		return
 	if(living_mob.body_position == LYING_DOWN && !living_mob.can_crawl)
 		return
-	if(living_mob.body_position == LYING_DOWN && mob.pulledby && mob.pulledby.grab_level >= GRAB_AGGRESSIVE || living_mob.body_position == LYING_DOWN && isxeno(mob.pulledby))
+	if(living_mob.body_position == LYING_DOWN && (mob.pulledby?.grab_level >= GRAB_AGGRESSIVE || isxeno(mob.pulledby)))
 		next_movement = world.time + 20 //Good Idea
 		to_chat(src, SPAN_NOTICE("You can not crawl right now."))
 		return

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -146,7 +146,9 @@
 
 	if(!(living_mob.mobility_flags & MOBILITY_MOVE))
 		return
-	if(living_mob.body_position == LYING_DOWN && !living_mob.can_crawl || living_mob.body_position == LYING_DOWN && mob.pulledby)
+	if(living_mob.body_position == LYING_DOWN && !living_mob.can_crawl)
+		return
+	if(living_mob.body_position == LYING_DOWN && mob.pulledby)
 		next_movement = world.time + 20 //Good Idea
 		to_chat(usr, SPAN_NOTICE("You can not crawl right now."))
 		return

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -148,9 +148,9 @@
 		return
 	if(living_mob.body_position == LYING_DOWN && !living_mob.can_crawl)
 		return
-	if(living_mob.body_position == LYING_DOWN && mob.pulledby)
+	if(living_mob.body_position == LYING_DOWN && mob.pulledby && mob.pulledby.grab_level >= GRAB_AGGRESSIVE || living_mob.body_position == LYING_DOWN && isxeno(mob.pulledby))
 		next_movement = world.time + 20 //Good Idea
-		to_chat(usr, SPAN_NOTICE("You can not crawl right now."))
+		to_chat(src, SPAN_NOTICE("You can not crawl right now."))
 		return
 
 	//Check if you are being grabbed and if so attemps to break it

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -146,7 +146,9 @@
 
 	if(!(living_mob.mobility_flags & MOBILITY_MOVE))
 		return
-	if(living_mob.body_position == LYING_DOWN && !living_mob.can_crawl)
+	if(living_mob.body_position == LYING_DOWN && !living_mob.can_crawl || living_mob.body_position == LYING_DOWN && mob.pulledby)
+		next_movement = world.time + 20 //Good Idea
+		to_chat(usr, SPAN_NOTICE("You can not crawl right now."))
 		return
 
 	//Check if you are being grabbed and if so attemps to break it

--- a/html/changelogs/AutoChangeLog-pr-7027.yml
+++ b/html/changelogs/AutoChangeLog-pr-7027.yml
@@ -1,0 +1,6 @@
+author: "realforest2001"
+delete-after: True
+changes:
+  - admin: "All staff now have Admin Announcement and Toggle Remote Control verbs."
+  - admin: "Moved shuttle manipulator to minor event perms rather than admin."
+  - code_imp: "Changed rights check on Toggle Remote Control and Shuttle Manipulator to check for mod/minor event perms respectively, or debug."


### PR DESCRIPTION
# About the pull request
Addresses #6842
Stops crawling if you're being aggressive grabbed or grabbed by a xeno.

Meaning people being carried or aggressively grabbed can't crawl and look silly whilst you're carrying them or be mildly annoying whilst you're not.

This previously also let you crawl if a xeno grabbed you. Which seems silly but actually useful because they'd just shove you down and that would stop you moving anyway.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Fixes an oversight on crawling. Doesn't let you crawl away whilst a xeno has you. Doesn't let you crawl whilst you're being fireman carried.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MistChristmas
fix: Stops crawling whilst grabbed
/:cl:
