### PR TITLE
Reorders Groundside Operations console sorting

### DIFF
--- a/code/game/machinery/computer/groundside_operations.dm
+++ b/code/game/machinery/computer/groundside_operations.dm
@@ -113,7 +113,7 @@
 	if(show_command_squad)
 		dat += format_list_of_marines(list(GLOB.marine_leaders[JOB_CO], GLOB.marine_leaders[JOB_XO]) + GLOB.marine_leaders[JOB_SO], list(JOB_CO, JOB_XO, JOB_SO))
 	else if(current_squad)
-		dat += format_list_of_marines(current_squad.marines_list, list(JOB_SQUAD_LEADER, JOB_SQUAD_SPECIALIST, JOB_SQUAD_MEDIC, JOB_SQUAD_ENGI, JOB_SQUAD_SMARTGUN, JOB_SQUAD_MARINE))
+		dat += format_list_of_marines(current_squad.marines_list, list(JOB_SQUAD_LEADER, JOB_SQUAD_TEAM_LEADER, JOB_SQUAD_SPECIALIST, JOB_SQUAD_SMARTGUN, JOB_SQUAD_MEDIC, JOB_SQUAD_ENGI, JOB_SQUAD_MARINE))
 	else
 		dat += "No Squad selected!<BR>"
 	dat += "<br><hr>"


### PR DESCRIPTION

# About the pull request

FTLs are now below SLs
SGs are now below specs, instead of medics.

FTLs were not getting sorted. (Unintentional revert in earlier PR)

# Explain why it's good for the game
ASL priority is: SL -> FTL -> Spec/SG, let's sort according to that

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: CIC groundside operations console now correctly sorts FTLs and SGs
/:cl:
