### PR TITLE
Tank Artillery Module Buff

### DIFF
--- a/code/modules/vehicles/hardpoints/support/artillery.dm
+++ b/code/modules/vehicles/hardpoints/support/artillery.dm
@@ -12,7 +12,11 @@
 
 	var/is_active = 0
 	var/view_buff = 10 //This way you can VV for more or less fun
-	var/view_tile_offset = 7
+	var/view_tile_offset = 8
+
+	buff_multipliers = list(
+		"accuracy" = 2
+	)
 
 /obj/item/hardpoint/support/artillery_module/handle_fire(atom/target, mob/living/user, params)
 	if(!user.client)

--- a/code/modules/vehicles/hardpoints/support/artillery.dm
+++ b/code/modules/vehicles/hardpoints/support/artillery.dm
@@ -15,7 +15,7 @@
 	var/view_tile_offset = 8
 
 	buff_multipliers = list(
-		"accuracy" = 2
+		"accuracy" = 2,
 	)
 
 /obj/item/hardpoint/support/artillery_module/handle_fire(atom/target, mob/living/user, params)


### PR DESCRIPTION
# About the pull request

This PR aims to make the artillery module feel slightly better to use by increasing the view distance to be that comparable of a sniper specialist whilst also doubling hardpoint accuracy for use with weapons such as the minigun or cupola at longer ranges.

# Explain why it's good for the game

Pushes the idea of mixing and matching various tank builds together. Makes the artillery module slightly more satisfying to use.

# Testing Photographs and Procedure

https://github.com/user-attachments/assets/6c0e1059-6d7d-408f-a22a-b1cd4a1b3fd5

https://github.com/user-attachments/assets/a30aa934-82c6-4384-a450-db343004f7c4

# Changelog

:cl: MarpleJones
balance: The tank's artillery module now doubles hardpoint accuracy.
balance: Changes the tank's artillery module's view_tile offset from 7 to 8.
/:cl:
