### PR TITLE
Xenos no more killing crit allies by dragging/devouring them

### DIFF
--- a/code/datums/pain/_pain.dm
+++ b/code/datums/pain/_pain.dm
@@ -286,14 +286,19 @@
 /datum/pain/proc/oxyloss_drag(mob/living/source, mob/puller)
 	SIGNAL_HANDLER
 	if(isxeno(puller) && source.stat == UNCONSCIOUS)
+		var/mob/living/carbon/xenomorph/xeno_puller = puller
+		if(source.ally_of_hivenumber(xeno_puller.hivenumber))
+			return
 		if(source.get_species())
 			var/mob/living/carbon/human/H = source
 			if(H.species.flags & HAS_HARDCRIT)
 				source.apply_damage(20, OXY)
 
-/datum/pain/proc/handle_devour(mob/living/source)
+/datum/pain/proc/handle_devour(mob/living/source, mob/living/carbon/xenomorph/devourer)
 	SIGNAL_HANDLER
 	if(source.chestburst)
+		return
+	if(source.ally_of_hivenumber(devourer.hivenumber))
 		return
 	oxy_kill(source)
 	return COMPONENT_CANCEL_DEVOUR


### PR DESCRIPTION
# About the pull request

Currently, xenos allied to a faction or an individual person will accidentally kill them if they happen to drag or devour them when they are in critical state. This PR seeks to fix that.

# Explain why it's good for the game

It's great not accidentally killing your allies when you are trying to save them!

# Testing Photographs and Procedure

Just tested it with allied factions and individuals, both work! 

Enemies of the hive still die like usual if they are dragged/devoured in crit (as the poor CLF showcases)

<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/bff213a2-d8b7-4832-9ab5-578c1b3b40da)

</details>


# Changelog

:cl: SubjectD9341

add: xenos don't kill crit allies by dragging/devouring anymore

/:cl:
