### PR TITLE
 fixes plasteel braicade disasembly mats

### DIFF
--- a/code/game/objects/structures/barricade/non_folding.dm
+++ b/code/game/objects/structures/barricade/non_folding.dm
@@ -290,6 +290,7 @@
 	force_level_absorption = 20
 	stack_type = /obj/item/stack/sheet/plasteel
 	debris = list(/obj/item/stack/sheet/plasteel)
+	stack_amount = 6
 	destroyed_stack_amount = 3
 	barricade_type = "new_plasteel"
 	repair_materials = list("plasteel" = 0.45)


### PR DESCRIPTION

# About the pull request

redifines badly inherited variable

# Explain why it's good for the game

reciving only half of mats that you should is bad


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: taking apart plasteel baricade gives back 8 not 4 plasteel
/:cl:
