### PR TITLE
Create_member no longer gets called twice

### DIFF
--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -324,7 +324,7 @@
 
 
 	if(spawn_max_amount && i < mob_max)
-		for(var/c in i to mob_max-1)
+		for(var/c in i to mob_max - 1)
 			create_member(null, override_spawn_loc)
 
 	candidates = list()

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -324,7 +324,7 @@
 
 
 	if(spawn_max_amount && i < mob_max)
-		for(var/c in i to mob_max)
+		for(var/c in i to mob_max-1)
 			create_member(null, override_spawn_loc)
 
 	candidates = list()


### PR DESCRIPTION

# About the pull request

mob_max is inclusive, and we start at zero.
# Explain why it's good for the game
 resolves #7053 
![image](https://github.com/user-attachments/assets/1d732615-e305-4b74-8d9f-68232abaead0)

It was kinda sad....
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: ERT no longer gets one extra free member in freed mobs if the beacon wasnt completely taken
/:cl:
