### PR TITLE
Increase XO Hour Requirements

### DIFF
--- a/code/game/jobs/job/command/cic/executive.dm
+++ b/code/game/jobs/job/command/cic/executive.dm
@@ -19,7 +19,7 @@
 
 AddTimelock(/datum/job/command/executive, list(
 	JOB_COMMAND_ROLES = 20 HOURS,
-	JOB_SQUAD_LEADER = 10 HOURS
+	JOB_SQUAD_LEADER = 10 HOURS,
 ))
 
 /obj/effect/landmark/start/executive

--- a/code/game/jobs/job/command/cic/executive.dm
+++ b/code/game/jobs/job/command/cic/executive.dm
@@ -19,6 +19,7 @@
 
 AddTimelock(/datum/job/command/executive, list(
 	JOB_COMMAND_ROLES = 20 HOURS,
+	JOB_SQUAD_LEADER = 10 HOURS
 ))
 
 /obj/effect/landmark/start/executive

--- a/code/game/jobs/job/command/cic/executive.dm
+++ b/code/game/jobs/job/command/cic/executive.dm
@@ -18,7 +18,7 @@
 	GLOB.marine_leaders -= JOB_XO
 
 AddTimelock(/datum/job/command/executive, list(
-	JOB_COMMAND_ROLES = 5 HOURS,
+	JOB_COMMAND_ROLES = 20 HOURS,
 ))
 
 /obj/effect/landmark/start/executive


### PR DESCRIPTION
# About the pull request

Increases XO hour requirements from 5 hours in CIC to 20. 
Increases XO hour requirements from 0 hours as SL to 10. 

# Explain why it's good for the game

CIC is one of the most mentally taxing jobs in the game. Nearly 2 hours of constant situational observation and communication.

With up to 200 players depending on this role, learning about CIC to a higher degree will help protect players from being supremely overburdened. 

Knowing how to make plans, and coordinate squads is a massive change compared to playing Rifleman. 
Additionally, CIC has a lot of one-off instances one may need to have time to learn about, such as pardoning prisoners, and RP events. 


Recently, a newer member to CIC was in the XO position. An event was scheduled for this round. 
Making a plan was a bit difficult for said individual to begin with, so the mutiny that almost occurred was also quite harsh.
Finally, Provost came and arrested said individual. 

This horrible set of circumstances happening to a new aspirational CIC member was horrible to watch with so many people degrading said person over the radio. Luckily, the round didn't get as bad as it could, with some members able to uphold things, but it had the potential for much worse results. 
Nothing incompetent XOs haven't seen, but this individual was not experienced, hereby making this series of events _our_ fault. 


Forcing players to get more acquainted with a role with such high responsibility will protect players from so many things resting on one player's shoulders. The players need the experience to not be ridiculed so harshly for simple lack of qualification. 

The step from Rifleman to SL is 10 hours.
**Squad Leaders are responsible for 10~20 people.** 

The step to Staff Officer is 15 marine hours, and 1 SL hour. I did not adjust this because CIC is often lesser-occupied, especially during Lowpop. Getting people excited about CIC is a good idea to retain. 
**Staff Officers are responsible for 10~40 people.**

Making the step 20 hours from Staff Officer to XO from 5 hours will give players the time they need to get well acquainted.
Additionally, 10 Squad Leader Hours will assure the XO has intimate understanding of the communication of CIC to ground forces. 
**Executive Officers are responsible for 80~230 people.** 


Staff Officers can still make plans and have the chance to be the "Acting CO" when low population, but the main concern is being able to watch what multiple XOs do so players can be confident in leading CIC. 
These changes are intended to make XOs very qualified. The entire game rests on his shoulders. Staff Officers, and raw skill of marines can carry a game pretty far, but it's a lot to handle. 


In conclusion, I want to make sure that if people take the XO role, they're experienced enough to be qualified to prevent excess degradation. 
Many people in CIC do believe a good amount of SO hours are required for XO.
Finally, some XO/CO do let SO lead operations under their guidance to prevent catastrophic mishaps to help aspiring leaders get the required experience. 

# Testing Photographs and Procedure

:)

# Changelog

:cl:
config: Adjusted XO Hour Requirements. 
/:cl:
