### PR TITLE
fix: toggling drop pouch storage draw method now works correctly

### DIFF
--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -838,7 +838,7 @@
 		/obj/item/storage/bible,
 		/obj/item/storage/toolkit,
 		)
-	storage_flags = NONE //no verb, no quick draw, no tile gathering
+	storage_flags = STORAGE_ALLOW_DRAWING_METHOD_TOGGLE
 
 /obj/item/clothing/accessory/storage/holster
 	name = "shoulder holster"


### PR DESCRIPTION

# About the pull request
Drop pouches currently show the option to toggle storage drawing method but when you click it, it does nothing.  You can already alt-click drop pouches to draw the last item but there isn't a way to make it so that the default click draws the last item (or first item).

I have tested this locally and it correctly lets you toggle the storage mode after making this change.

fixes https://github.com/cmss13-devs/cmss13/issues/6089

# Explain why it's good for the game

Since you can already alt-click drop pouches to draw the last item, this just makes it slightly more convenient so that you can set the default to that behaviour like you can with most other pouches.  This also lets you toggle between the FIFO mode as well which is something you can't do via alt click.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
fix: drop pouch's switch storage drawing method now works correctly instead of doing nothing
/:cl:

