### PR TITLE
Deletes-empty-pill-packets-on-empty-drop

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -762,6 +762,24 @@
 	storage_flags = STORAGE_FLAGS_BOX
 	display_maptext = FALSE
 
+/obj/item/storage/pill_bottle/packet/Initialize()
+	. = ..()
+	RegisterSignal(src, COMSIG_ITEM_DROPPED, PROC_REF(try_forced_folding))
+
+/obj/item/storage/pill_bottle/packet/proc/try_forced_folding(datum/source, mob/user)
+	SIGNAL_HANDLER
+
+	if(!isturf(loc))
+		return
+
+	if(locate(/obj/item/reagent_container/pill) in src)
+		return
+
+	UnregisterSignal(src, COMSIG_ITEM_DROPPED)
+	storage_close(user)
+	to_chat(user, SPAN_NOTICE("You throw away [src]."))
+	qdel(src)
+
 /obj/item/storage/pill_bottle/packet/tricordrazine
 	name = "Tricordazine pill packet"
 	icon_state = "tricordrazine_packet"


### PR DESCRIPTION
# About the pull request

Deletes empty pill packets (the 4 pill packets) when dropped and empty. 
Used code from: https://github.com/cmss13-devs/cmss13/pull/5761

# Explain why it's good for the game

has less pointless garbage on the ground. 
they can't be refilled anyway. 

# Testing Photographs and Procedure

emptied pill packets and a pill bottle. verified pill packet only deleted when dropped or thrown.

Pill bottles persisted. Packets persisted so long as remained in inventory. IE put into another pouch. 
<details>

https://github.com/user-attachments/assets/1736dedd-4c22-4d7a-9957-29361c320d45

</details>


# Changelog

:cl:
qol: Deletes empty pill packets when dropped. 
/:cl: