### PR TITLE
Adds a staff button to check for whitelisted players.

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -142,7 +142,8 @@ GLOBAL_LIST_INIT(admin_verbs_minor_event, list(
 	/client/proc/toggle_hardcore_perma,
 	/client/proc/toggle_bypass_joe_restriction,
 	/client/proc/toggle_joe_respawns,
-	/datum/admins/proc/open_shuttlepanel
+	/datum/admins/proc/open_shuttlepanel,
+	/client/proc/get_whitelisted_clients,
 ))
 
 GLOBAL_LIST_INIT(admin_verbs_major_event, list(

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -52,6 +52,9 @@
 	for(var/client/test_client in GLOB.clients)
 		if(test_client.check_whitelist_status(GLOB.bitfields["whitelist_status"][flag]))
 			ckeys += test_client.ckey
+	if(!length(ckeys))
+		to_chat(src, SPAN_NOTICE("There are no players with that whitelist online"))
+		return
 	to_chat(src, SPAN_NOTICE("Whitelist holders: [ckeys.Join(", ")]."))
 
 /client/proc/change_security_level()

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -45,7 +45,10 @@
 /client/proc/get_whitelisted_clients()
 	set name = "Find Whitelisted Players"
 	set category = "Admin.Events"
-
+	if(!admin_holder)
+		to_chat(usr, "Only administrators may use this command.")
+		return
+	
 	var/flag = tgui_input_list(src, "Which flag?", "Whitelist Flags", GLOB.bitfields["whitelist_status"])
 
 	var/list/ckeys = list()

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -46,7 +46,6 @@
 	set name = "Find Whitelisted Players"
 	set category = "Admin.Events"
 	if(!admin_holder)
-		to_chat(usr, "Only administrators may use this command.")
 		return
 	
 	var/flag = tgui_input_list(src, "Which flag?", "Whitelist Flags", GLOB.bitfields["whitelist_status"])

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -42,6 +42,18 @@
 
 	CEI.handle_event_info_update(faction)
 
+/client/proc/get_whitelisted_clients()
+	set name = "Find Whitelisted Players"
+	set category = "Admin.Events"
+
+	var/flag = tgui_input_list(src, "Which flag?", "Whitelist Flags", GLOB.bitfields["whitelist_status"])
+
+	var/list/ckeys = list()
+	for(var/client/test_client in GLOB.clients)
+		if(test_client.check_whitelist_status(GLOB.bitfields["whitelist_status"][flag]))
+			ckeys += test_client.ckey
+	to_chat(src, SPAN_NOTICE("Whitelist holders: [ckeys.Join(", ")]."))
+
 /client/proc/change_security_level()
 	if(!check_rights(R_ADMIN))
 		return


### PR DESCRIPTION

# About the pull request

It's not uncommon for events to be run with whitelisted roles, and this will make it much easier to check if someone with the right whitelist is online.

# Changelog
:cl:
add: Added a staff event verb to check for a particular whitelist and report online players that have it. Code for the proc from HarryOB
/:cl:
