### PR TITLE
Join as freed mob no longer runtimes

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1039,6 +1039,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		for(var/freed_mob in mobs_by_role[role])
 			freed_mob_choices["[freed_mob] ([role])"] = freed_mob
 	if(!length(freed_mob_choices))
+		to_chat(src, SPAN_WARNING("There is no Freed Mobs available."))
 		return
 	var/choice = tgui_input_list(usr, "Pick a Freed Mob:", "Join as Freed Mob", freed_mob_choices)
 	if(!choice)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1039,7 +1039,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		for(var/freed_mob in mobs_by_role[role])
 			freed_mob_choices["[freed_mob] ([role])"] = freed_mob
 	if(!length(freed_mob_choices))
-		to_chat(src, SPAN_WARNING("There is no Freed Mobs available."))
+		to_chat(src, SPAN_WARNING("There are no Freed Mobs available."))
 		return
 	var/choice = tgui_input_list(usr, "Pick a Freed Mob:", "Join as Freed Mob", freed_mob_choices)
 	if(!choice)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1038,7 +1038,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	for(var/role in mobs_by_role)
 		for(var/freed_mob in mobs_by_role[role])
 			freed_mob_choices["[freed_mob] ([role])"] = freed_mob
-
+	if(!length(freed_mob_choices))
+		return
 	var/choice = tgui_input_list(usr, "Pick a Freed Mob:", "Join as Freed Mob", freed_mob_choices)
 	if(!choice)
 		return


### PR DESCRIPTION

# About the pull request

This would runtime if anyone pressed it and there is no freed mobs
found when doing the spawn_member pr
# Explain why it's good for the game

runtimes bad


# Changelog
:cl:
code: Join as freed mobs will now notify the user if there is no freed mobs to take.
/:cl:
