### PR TITLE
SG falloff rebalance and far sight removal

### DIFF
--- a/code/datums/ammo/bullet/special_ammo.dm
+++ b/code/datums/ammo/bullet/special_ammo.dm
@@ -9,6 +9,7 @@
 	icon_state = "redbullet"
 	flags_ammo_behavior = AMMO_BALLISTIC
 
+	damage_falloff = DAMAGE_FALLOFF_TIER_7
 	max_range = 12
 	accuracy = HIT_ACCURACY_TIER_4
 	damage = 30
@@ -31,6 +32,7 @@
 	shrapnel_chance = SHRAPNEL_CHANCE_TIER_7
 	accurate_range = 32
 	accuracy = HIT_ACCURACY_TIER_3
+	damage_falloff = 0
 	damage = 40
 	penetration = 0
 

--- a/code/datums/ammo/bullet/special_ammo.dm
+++ b/code/datums/ammo/bullet/special_ammo.dm
@@ -14,6 +14,7 @@
 	accuracy = HIT_ACCURACY_TIER_4
 	damage = 30
 	penetration = 0
+	effective_range_max = 7
 
 /datum/ammo/bullet/smartgun/armor_piercing
 	name = "armor-piercing smartgun bullet"

--- a/code/datums/ammo/bullet/special_ammo.dm
+++ b/code/datums/ammo/bullet/special_ammo.dm
@@ -32,7 +32,7 @@
 	shrapnel_chance = SHRAPNEL_CHANCE_TIER_7
 	accurate_range = 32
 	accuracy = HIT_ACCURACY_TIER_3
-	damage_falloff = 0
+	damage_falloff = DAMAGE_FALLOFF_TIER_10
 	damage = 40
 	penetration = 0
 

--- a/code/modules/clothing/glasses/night.dm
+++ b/code/modules/clothing/glasses/night.dm
@@ -94,7 +94,7 @@
 	icon_state = "m56_goggles"
 	deactive_state = "m56_goggles_0"
 	toggleable = TRUE
-	actions_types = list(/datum/action/item_action/toggle, /datum/action/item_action/m56_goggles/far_sight)
+	actions_types = list(/datum/action/item_action/toggle)
 	vision_flags = SEE_TURFS
 	fullscreen_vision = null
 	req_skill = SKILL_SPEC_WEAPONS

--- a/code/modules/clothing/glasses/night.dm
+++ b/code/modules/clothing/glasses/night.dm
@@ -203,6 +203,7 @@
 	name = "\improper M56T head mounted sight"
 	desc = "A headset and goggles system for the M56T 'Terminator' Smartgun. Has a low-light vision processor as well as a system allowing detection of thermal signatures though solid surfaces."
 	vision_flags = SEE_TURFS|SEE_MOBS
+	actions_types = list(/datum/action/item_action/toggle, /datum/action/item_action/m56_goggles/far_sight)
 
 /obj/item/clothing/glasses/night/yautja
 	name = "bio-mask nightvision"

--- a/code/modules/projectiles/guns/smartgun.dm
+++ b/code/modules/projectiles/guns/smartgun.dm
@@ -18,7 +18,6 @@
 	force = 20
 	wield_delay = WIELD_DELAY_FAST
 	aim_slowdown = SLOWDOWN_ADS_SPECIALIST
-	effective_range_max = 7
 	var/obj/item/smartgun_battery/battery = null
 	/// Whether the smartgun drains the battery (Ignored if requires_battery is false)
 	var/requires_power = TRUE

--- a/code/modules/projectiles/guns/smartgun.dm
+++ b/code/modules/projectiles/guns/smartgun.dm
@@ -18,6 +18,7 @@
 	force = 20
 	wield_delay = WIELD_DELAY_FAST
 	aim_slowdown = SLOWDOWN_ADS_SPECIALIST
+	effective_range_max = 7
 	var/obj/item/smartgun_battery/battery = null
 	/// Whether the smartgun drains the battery (Ignored if requires_battery is false)
 	var/requires_power = TRUE


### PR DESCRIPTION
# About the pull request
This PR:
1. Removes far-sight
2. Increases falloff to 4 (from 1)
3. Increases effective range to 7 (from 0) - This means falloff starts counting at the 7th tile (edge of the screen)
4. Needs testing
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Getting hit by bullets offscreen as well as dealing no damage on your own screen is rather annoying.
On a more serious note SGs are currently encouraged to go as close as possible in order to actually deal damage properly which is in contrast to the purpose of the role of providing suppressing fire from the back (AP bullets for example losing around 50% of their damage at the edge of the screen)
As for far-sight that was a rubber-band to try to fix the above (SGs going melee range) but just ended up being annoying to play against.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Removed far-sight from SG sights
balance: Increased smartgun bullet falloff to 4 from 1
balance: Increased smartgun bullet effective range to 7 from 0
/:cl:
