### PR TITLE
Removes the option to produce OT rockets

### DIFF
--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -291,16 +291,6 @@
 	path = /obj/item/explosive/plastic/custom
 	category = AUTOLATHE_CATEGORY_EXPLOSIVES
 
-/datum/autolathe/recipe/armylathe/rocket_tube
-	name = "88mm Rocket Tube"
-	path = /obj/item/ammo_magazine/rocket/custom
-	category = AUTOLATHE_CATEGORY_EXPLOSIVES
-
-/datum/autolathe/recipe/armylathe/rocket_warhead
-	name = "88mm Rocket Warhead"
-	path = /obj/item/explosive/warhead/rocket
-	category = AUTOLATHE_CATEGORY_EXPLOSIVES
-
 /datum/autolathe/recipe/armylathe/mortar_shell
 	name = "80mm Mortar Shell"
 	path = /obj/item/mortar_shell/custom


### PR DESCRIPTION

# About the pull request
As the title says, removes the option to create custom rockets utilising OT
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
For the longest time there has been an issue with both OT and research due to the power they withhold, the main issue with OT though that many have addressed is the fact of the ability to create custom rockets. It has almost become standard to have an infinite supply of insta gib rockets funnelled to FOB to be used until sadar kicks the bucket.

In no sense of the game is it fun to see a sadar, begin to act to avoid a punish yet have yourself and anyone near you gibbed after a rocket hit 3 tiles away from you, mind you normal rockets would have a quarter second stun and you're back on your feet.

Attempts to balance have been made with very little success, and so I feel until a proper solution is formed, OT rockets should be removed from standard play for the time being.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
balance: removed the ability to create Custom rockets in standard play
/:cl:

