### PR TITLE
Option 2 for OT rockets

### DIFF
--- a/code/game/objects/items/explosives/warhead.dm
+++ b/code/game/objects/items/explosives/warhead.dm
@@ -9,11 +9,11 @@
 	name = "84mm rocket warhead"
 	desc = "A custom warhead meant for 84mm rocket shells."
 	icon_state = "warhead_rocket"
-	max_container_volume = 210
+	max_container_volume = 180
 	allow_star_shape = FALSE
 	matter = list("metal" = 11250) //3 sheets
-	reaction_limits = list( "max_ex_power" = 240, "base_ex_falloff" = 90,"max_ex_shards" = 64,
-							"max_fire_rad" = 6, "max_fire_int" = 40, "max_fire_dur" = 48,
+	reaction_limits = list( "max_ex_power" = 180, "base_ex_falloff" = 90,"max_ex_shards" = 64,
+							"max_fire_rad" = 3, "max_fire_int" = 30, "max_fire_dur" = 36,
 							"min_fire_rad" = 2, "min_fire_int" = 4, "min_fire_dur" = 5
 	)
 	has_blast_wave_dampener = TRUE

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -238,7 +238,7 @@
 	desc = "An 84mm custom rocket."
 	icon_state = "custom_rocket"
 	default_ammo = /datum/ammo/rocket/custom
-	matter = list("metal" = 7500) //2 sheets
+	matter = list("metal" = 3750) //1 sheet
 	var/obj/item/explosive/warhead/rocket/warhead
 	var/obj/item/reagent_container/glass/fuel
 	var/fuel_requirement = 60


### PR DESCRIPTION
# About the pull request
Reduces overall effectiveness of OT rockets to be more in line with what is already available to the demo spec
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
reasons stated in https://github.com/cmss13-devs/cmss13/pull/7070

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
balance: reduced overall effectiveness of OT rockets to be a minor amount stronger than standard rockets available
balance: reduced metal cost by 3750 for both components of the rocket, now needing 3 metal sheets total to make 1 set
/:cl:

