### PR TITLE
Fix reverse_direction() macro

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -46,8 +46,8 @@
 #define format_frequency(f) "[floor((f) / 10)].[(f) % 10]"
 
 #define reverse_direction(direction) ( \
-											( dir & (NORTH|SOUTH) ? ~dir & (NORTH|SOUTH) : 0 ) | \
-											( dir & (EAST|WEST) ? ~dir & (EAST|WEST) : 0 ) \
+											( direction & (NORTH|SOUTH) ? ~direction & (NORTH|SOUTH) : 0 ) | \
+											( direction & (EAST|WEST) ? ~direction & (EAST|WEST) : 0 ) \
 										)
 
 // The sane, counter-clockwise angle to turn to get from /direction/ A to /direction/ B


### PR DESCRIPTION

# About the pull request
Despite taking an argument for a direction, reverse_direction() used the `dir` of `src` at all times. This isn't intended and has been fixed.

# Explain why it's good for the game
Bug fix. No current uses of reverse_direction() will be affected by this change, as they all already were looking for `src.dir`[^1]

[^1]: There is one exception but it still works fine