### PR TITLE
Remove Double Shotgun From Solaris

### DIFF
--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -38778,10 +38778,6 @@
 	pixel_x = 7
 	},
 /obj/structure/surface/table/woodentable,
-/obj/item/weapon/gun/shotgun/double/sawn{
-	pixel_x = 1;
-	pixel_y = 10
-	},
 /turf/open/floor/wood,
 /area/bigredv2/outside/bar)
 "xJX" = (


### PR DESCRIPTION

# About the pull request

Removes a double shotgun from Solaris

# Explain why it's good for the game

I was unaware as to how extremely powerful this weapon is. 600 damage in one shot is a bit excessive. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: Removes a overpowered shotgun from Solaris. 
/:cl:
