### PR TITLE
LZ2 Monkey spawn fix

### DIFF
--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -7394,8 +7394,8 @@
 /area/shiva/interior/colony/research_hab)
 "dgG" = (
 /obj/effect/landmark/monkey_spawn,
-/turf/open/auto_turf/snow/layer2,
-/area/shiva/exterior/lz1_valley)
+/turf/open/auto_turf/snow/layer1,
+/area/shiva/interior/caves/cp_camp)
 "dgS" = (
 /obj/vehicle/train/cargo/engine,
 /turf/open/auto_turf/snow/layer0,
@@ -26918,7 +26918,7 @@ xAS
 xAS
 kvQ
 uqb
-dgG
+uqb
 kLM
 kLM
 kLM
@@ -27072,7 +27072,7 @@ tlB
 xAS
 aFO
 xAS
-xAS
+dgG
 oRH
 oRH
 rzw


### PR DESCRIPTION

# About the pull request

Moved a monkey spawn so that it isn't in the fog on Shiva's LZ2, fixes #7008
![monke](https://github.com/user-attachments/assets/073b7f6d-5d2c-4e25-a89f-45b736dea99b)


# Explain why it's good for the game

bug bad


# Testing Photographs and Procedure



# Changelog


:cl: BOBAMA
fix: fixed monkey spawn on Shiva's LZ2 in fog
/:cl:
