### PR TITLE
Adds MREs to the ColMarTech Food Vendor

### DIFF
--- a/code/game/machinery/vending/vendor_types/food.dm
+++ b/code/game/machinery/vending/vendor_types/food.dm
@@ -11,6 +11,7 @@
 /obj/structure/machinery/cm_vending/sorted/marine_food/populate_product_list(scale)
 	listed_products = list(
 		list("PREPARED MEALS", -1, null, null),
+		list("USCM Meal Ready to Eat", 15, /obj/item/storage/box/MRE, VENDOR_ITEM_REGULAR),
 		list("USCM Prepared Meal (Chicken)", 15, /obj/item/reagent_container/food/snacks/mre_pack/meal5, VENDOR_ITEM_REGULAR),
 		list("USCM Prepared Meal (Cornbread)", 15, /obj/item/reagent_container/food/snacks/mre_pack/meal1, VENDOR_ITEM_REGULAR),
 		list("USCM Prepared Meal (Pasta)", 15, /obj/item/reagent_container/food/snacks/mre_pack/meal3, VENDOR_ITEM_REGULAR),


### PR DESCRIPTION

# About the pull request

Adds 15 MREs to each ColMarTech Food Vendor on the Almayer

# Explain why it's good for the game

Marines basically already get infinite MREs anyways, no harm in adding them if shipside personnel like MPs want to grab food on the go and not have a whole plate of food just in their bag, which is weird.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>


https://github.com/user-attachments/assets/6a711776-d791-48b6-946f-b7495cbf8022


</details>


# Changelog
:cl:
add: All ColMarTech Food Vendors now have 15 MREs
/:cl:
