### PR TITLE
Increases shotgun slug accuracy

### DIFF
--- a/code/datums/ammo/bullet/shotgun.dm
+++ b/code/datums/ammo/bullet/shotgun.dm
@@ -11,10 +11,11 @@
 	name = "shotgun slug"
 	handful_state = "slug_shell"
 
-	accurate_range = 6
+	accurate_range = 8
 	max_range = 8
 	damage = 70
 	penetration = ARMOR_PENETRATION_TIER_4
+	accuracy = HIT_ACCURACY_TIER_3
 	damage_armor_punch = 2
 	handful_state = "slug_shell"
 
@@ -65,7 +66,7 @@
 	damage_type = BURN
 	flags_ammo_behavior = AMMO_BALLISTIC
 
-	accuracy = -HIT_ACCURACY_TIER_2
+	accuracy = HIT_ACCURACY_TIER_2
 	max_range = 12
 	damage = 55
 	penetration= ARMOR_PENETRATION_TIER_1


### PR DESCRIPTION
# About the pull request

- increases shotgun slug accuracy by 10 points (from 5 to 15) and its accurate range by 2 tiles (from 6 to 8)
- increases incin slug accuracy by 5 points (from 5 to 10) -- this is something i changed just to make it more consistent with the other slug ammo types

bullet code is pretty enigmatic to me so increasing its accurate range and accuracy seemed like the best way to assure that anything you click on will get hit. i increased the accurate range because even at 6 tiles it still kept randomly missing. it's something to do with the relationship with accurate range and accuracy but i don't really get it :/
 
i don't think it's much of an issue since the main selling point of slugs is their stun (and that's locked at 6 tiles), their damage is pretty lackluster. still, they're just random numbers i thought of and lightly tested, so i'm not 100% sure about them.

# Explain why it's good for the game

here's some in-game footage of slugs missing at ranges where you wouldn't expect it to
(yes, this is a bit of a cope PR but i'm doing this for all us sluggers out there)

https://github.com/user-attachments/assets/313279b1-c2f0-46e0-a5b2-9edeecf93dca


RNG should not have a place in this game's combat system to this degree. with an effective range of 6, a player is lead to believe that anything they shoot at in that range would get hit. that isn't true in a decent amount of cases. slugs are pretty punishing if you miss, and require other marines to take advantage of your hit target to make the most of it. players who are able to land good clicks on their enemies should be rewarded for it, and not punished by arbitrary RNG that decides that you'll miss your target from 1 tile away.

![image](https://github.com/user-attachments/assets/8f98021d-8a06-4928-91cd-2bbdbf2a2f0a)

this DOES NOT change the range from which you are able to stun mobs. it's still locked at 6. if you hit a target beyond that range you'll just lightly damage them. the bullet completely disappears at 8 tiles, as before. 

# Testing Photographs and Procedure
i clicked on a lurker from 6 tiles away with 50 slugs and all of the shots hit it (incredible testing procedure).

# Changelog
:cl:
balance: shotgun slugs have had their accurate range increased to 8, and their accuracy tripled. any targets shot within 8 tiles will always be hit. incendiary have had a milder accuracy increase.
/:cl:
