### PR TITLE
Throwing Knives now surgery capable

### DIFF
--- a/code/__DEFINES/surgery.dm
+++ b/code/__DEFINES/surgery.dm
@@ -95,6 +95,7 @@ See also /datum/surgery_step/cut_larval_pseudoroots, /datum/surgery_step/retract
 	/obj/item/tool/surgery/scalpel/pict_system = SURGERY_TOOL_MULT_SUBOPTIMAL,\
 	/obj/item/attachable/bayonet = SURGERY_TOOL_MULT_SUBSTITUTE,\
 	/obj/item/tool/kitchen/knife = SURGERY_TOOL_MULT_SUBSTITUTE,\
+	/obj/item/weapon/throwing_knife = SURGERY_TOOL_MULT_AWFUL,\
 	/obj/item/shard = SURGERY_TOOL_MULT_AWFUL\
 	)
 

--- a/code/modules/surgery/chestburster.dm
+++ b/code/modules/surgery/chestburster.dm
@@ -33,6 +33,7 @@
 		/obj/item/tool/surgery/scalpel/pict_system = SURGERY_TOOL_MULT_IDEAL,
 		/obj/item/attachable/bayonet = SURGERY_TOOL_MULT_SUBSTITUTE,
 		/obj/item/tool/kitchen/knife = SURGERY_TOOL_MULT_SUBSTITUTE,
+		/obj/item/weapon/throwing_knife = SURGERY_TOOL_MULT_AWFUL,
 		/obj/item/shard = SURGERY_TOOL_MULT_AWFUL,
 	)
 	time = 5 SECONDS

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -223,6 +223,7 @@
 		/obj/item/attachable/bayonet = SURGERY_TOOL_MULT_AWFUL,
 		/obj/item/tool/surgery/scalpel = SURGERY_TOOL_MULT_AWFUL,
 		/obj/item/tool/kitchen/knife = SURGERY_TOOL_MULT_AWFUL,
+		/obj/item/weapon/throwing_knife = SURGERY_TOOL_MULT_AWFUL,
 		/obj/item/shard = SURGERY_TOOL_MULT_AWFUL
 		)
 	preop_sound = 'sound/surgery/retractor1.ogg'

--- a/code/modules/surgery/xeno.dm
+++ b/code/modules/surgery/xeno.dm
@@ -133,6 +133,7 @@
 		/obj/item/tool/surgery/scalpel/pict_system = SURGERY_TOOL_MULT_IDEAL,
 		/obj/item/attachable/bayonet = SURGERY_TOOL_MULT_SUBSTITUTE,
 		/obj/item/tool/kitchen/knife = SURGERY_TOOL_MULT_SUBSTITUTE,
+		/obj/item/weapon/throwing_knife = SURGERY_TOOL_MULT_AWFUL,
 		/obj/item/shard = SURGERY_TOOL_MULT_AWFUL,
 	)
 	time = 4 SECONDS


### PR DESCRIPTION

# About the pull request

Gives throwing knives the capacity to perform alternative surgery, it is a knife after all

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Never made sense why they couldn't perform surgery in the first place

Made sure they shared the same capabilities as a glass shard as throwing knives would be light enough, but not strong enough to break bones like a standard bayonet would
These things probably don't have sharp edges either, meaning you would have to hold it awkwardly to perform surgery from the tip
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
https://cdn.discordapp.com/attachments/604397850675380234/1280934278884098079/Desktop_2024.09.05_-_00.53.02.02.mp4?ex=66d9e282&is=66d89102&hm=3ba30869856e7bc3e6c54215ba52e7c2f12152e854a35d20a3eba3af46f0eba4&
</details>


# Changelog
:cl:
qol: Throwing Knives can now perform basic surgery on par with glass shards
/:cl:
