### PR TITLE
Lesser Nerf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/XenoAttacks.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoAttacks.dm
@@ -100,7 +100,7 @@
 	if(HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
 		return XENO_NO_DELAY_ACTION
 
-	if(islarva(M) || islesserdrone(M)) //Larvas can't eat people, now neither can Lessers
+	if(islarva(M)) //Larvas can't eat people
 		M.visible_message(SPAN_DANGER("[M] nudges its head against \the [src]."), \
 		SPAN_DANGER("We nudge our head against \the [src]."), null, null, CHAT_TYPE_XENO_FLUFF)
 		return

--- a/code/modules/mob/living/carbon/xenomorph/XenoAttacks.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoAttacks.dm
@@ -100,7 +100,7 @@
 	if(HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
 		return XENO_NO_DELAY_ACTION
 
-	if(islarva(M)) //Larvas can't eat people
+	if(islarva(M) || islesserdrone(M)) //Larvas can't eat people, now neither can Lessers
 		M.visible_message(SPAN_DANGER("[M] nudges its head against \the [src]."), \
 		SPAN_DANGER("We nudge our head against \the [src]."), null, null, CHAT_TYPE_XENO_FLUFF)
 		return

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -1037,9 +1037,10 @@
 		stabbing_xeno.behavior_delegate.melee_attack_additional_effects_self()
 		damage = stabbing_xeno.behavior_delegate.melee_attack_modify_damage(damage, target)
 
-	target.apply_armoured_damage(get_xeno_damage_slash(target, damage), ARMOR_MELEE, BRUTE, limb ? limb.name : "chest")
-	target.apply_effect(3, DAZE)
-	shake_camera(target, 2, 1)
+	if (stabbing_xeno.caste_type != XENO_CASTE_LESSER_DRONE)
+		target.apply_armoured_damage(get_xeno_damage_slash(target, damage), ARMOR_MELEE, BRUTE, limb ? limb.name : "chest")
+		target.apply_effect(3, DAZE)
+		shake_camera(target, 2, 1)
 
 	target.handle_blood_splatter(get_dir(owner.loc, target.loc))
 	return target

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -1037,8 +1037,9 @@
 		stabbing_xeno.behavior_delegate.melee_attack_additional_effects_self()
 		damage = stabbing_xeno.behavior_delegate.melee_attack_modify_damage(damage, target)
 
+	target.apply_armoured_damage(get_xeno_damage_slash(target, damage), ARMOR_MELEE, BRUTE, limb ? limb.name : "chest")
+
 	if (stabbing_xeno.caste_type != XENO_CASTE_LESSER_DRONE)
-		target.apply_armoured_damage(get_xeno_damage_slash(target, damage), ARMOR_MELEE, BRUTE, limb ? limb.name : "chest")
 		target.apply_effect(3, DAZE)
 		shake_camera(target, 2, 1)
 

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -111,6 +111,7 @@
 		var/mob/living/carbon/pulled = xeno.pulling
 		if(islarva(M) || islesserdrone(M))
 			to_chat(xeno, SPAN_WARNING("We aren't big enough to devour that."))
+			return 0
 		if(!istype(pulled))
 			return
 		if(isxeno(pulled) || issynth(pulled))

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -109,6 +109,8 @@
 	else if(M == user && user.pulling && isxeno(user))
 		var/mob/living/carbon/xenomorph/xeno = user
 		var/mob/living/carbon/pulled = xeno.pulling
+		if(islarva(M) || islesserdrone(M))
+			to_chat(xeno, SPAN_WARNING("We aren't big enough to devour that."))
 		if(!istype(pulled))
 			return
 		if(isxeno(pulled) || issynth(pulled))


### PR DESCRIPTION
# About the pull request

Removes Lesser ability to vore.
Removes the stun effect on tailstab for lesser drones. 

# Explain why it's good for the game

Just makes lessers less protagonistic. 

Because lessers can just walts into a base, and respawn so swiftly, removing the lesser's ability to stun only allows lessers to assist in damage dealing.

Lessers being unable to devour makes lesser capping more in line with the free respawns. 
I left regurgitate power in incase of problems. 

# Testing Photographs and Procedure
I'm not sure how to test the tailstab since I cannot be both the tail stabber, and the person being tail stabbed to see the effects. 

<details>
<summary>Screenshots & Videos</summary>

Drone can vore, lesser cannot. 

https://github.com/user-attachments/assets/07132727-3e51-4766-8829-8f2009cfb870

</details>

# Changelog

:cl:
balance: Lesser nerfs tail stab no stun
balance: Lesser nerfs cannot devour/vore
/:cl:
