### PR TITLE
Hands-only CPR

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -28,12 +28,6 @@
 				help_shake_act(attacking_mob)
 				return 1
 
-			if(attacking_mob.head && (attacking_mob.head.flags_inventory & COVERMOUTH) || attacking_mob.wear_mask && (attacking_mob.wear_mask.flags_inventory & COVERMOUTH) && !(attacking_mob.wear_mask.flags_inventory & ALLOWCPR))
-				to_chat(attacking_mob, SPAN_NOTICE("<B>Remove your mask!</B>"))
-				return 0
-			if(head && (head.flags_inventory & COVERMOUTH) || wear_mask && (wear_mask.flags_inventory & COVERMOUTH) && !(wear_mask.flags_inventory & ALLOWCPR))
-				to_chat(attacking_mob, SPAN_NOTICE("<B>Remove [src.gender==MALE?"his":"her"] mask!</B>"))
-				return 0
 			if(cpr_attempt_timer >= world.time)
 				to_chat(attacking_mob, SPAN_NOTICE("<B>CPR is already being performed on [src]!</B>"))
 				return 0


### PR DESCRIPTION

# About the pull request

Allows for hands-only CPR.

# Explain why it's good for the game

Mask restrictions preventing CPR doesn't make sense. 
![Screenshot 2024-09-05 123549](https://github.com/user-attachments/assets/62f71803-f0c5-4c26-a77d-7abafec2d4bc)

Also I've seen a ship doctor insist on doing surgery on someone before reviving which led to the guy going perma - audience wanted to do CPR but couldn't cause of anesthesia mask. RIP Harvest Singe.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: hands-only CPR now possible
/:cl:
