### PR TITLE
Automatic emotes are no longer are affected by emote cooldown (baton edition for now)

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -150,7 +150,9 @@
 	//stun effects
 
 	if(!isyautja(human_target) && !isxeno(human_target)) //Xenos and Predators are IMMUNE to all baton stuns.
+		ADD_TRAIT(human_target, TRAIT_EMOTE_CD_EXEMPT, "Batoned")
 		human_target.emote("pain")
+		REMOVE_TRAIT(human_target, TRAIT_EMOTE_CD_EXEMPT, "Batoned")
 		human_target.apply_stamina_damage(stunforce, target_zone, ARMOR_ENERGY)
 		human_target.sway_jitter(2,1)
 


### PR DESCRIPTION

# About the pull request

The intent behind this is to not have automatic emotes trigger, and be affected by, emote cooldown. Starting with automatic baton emote for now. Might change this if someone points out a better way to fix this for all automatic emotes.

# Explain why it's good for the game

Emote cooldown is designed to stop players spamming them and being LRP, it should never affect automatic emotes. It doesn't make sense that automatic emotes can't happen because you did a manual one a few seconds ago.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
sounddel: automatic emotes are not affected by emote cooldown (baton edition for now)
/:cl:
