### PR TITLE
Adds the preference to trigger xeno/human abilities with right click instead of middle click or shift click

### DIFF
--- a/code/__DEFINES/client_prefs.dm
+++ b/code/__DEFINES/client_prefs.dm
@@ -1,10 +1,21 @@
 #define BE_ALIEN_AFTER_DEATH (1<<0)
 #define BE_AGENT (1<<1)
 
+/// Determines how abilities are activated, whether they're activated via middle click, shift click or right click.
+#define XENO_ABILITY_CLICK_MIDDLE 1
+#define XENO_ABILITY_CLICK_SHIFT 2
+#define XENO_ABILITY_CLICK_RIGHT 3
+
+/// Update this to whatever the largest value of the XENO_ABILITY_CLICK_* defines is.
+#define XENO_ABILITY_CLICK_MAX 3
+
 //toggle_prefs bits from /datum/preferences
 #define TOGGLE_IGNORE_SELF (1<<0) // Determines whether you will not hurt yourself when clicking yourself
 #define TOGGLE_HELP_INTENT_SAFETY (1<<1) // Determines whether help intent will be completely harmless
-#define TOGGLE_MIDDLE_MOUSE_CLICK (1<<2) // This toggles whether selected ability for xeno uses middle mouse clicking or shift clicking
+// Deprecated. Can't remove this or bitshift values down because it would fuck up the savefiles
+// Feel free to replace this whatever you want, if you can find a useful toggle for it. Alternatively, don't because savefiles using flags
+// Is a complete and utter mistake.
+#define TOGGLE_FREE_PLACE_YOUR_OWN_TOGGLE_HERE (1<<2)
 #define TOGGLE_DIRECTIONAL_ATTACK (1<<3) // This toggles whether attacks for xeno use directional attacks
 #define TOGGLE_AUTO_EJECT_MAGAZINE_OFF (1<<4) // This toggles whether guns with auto ejectors will not auto eject their magazines
 												   // MUTUALLY EXCLUSIVE TO TOGGLE_AUTO_EJECT_MAGAZINE_TO_HAND

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1436,7 +1436,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	if(isRemoteControlling(user))
 		return TRUE
 	// If the user is not a xeno (with active ability) with the shift click pref on, we examine. God forgive me for snowflake
-	if(user.client?.prefs && !(user.client?.prefs?.toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK))
+	if(user.get_ability_mouse_key() == XENO_ABILITY_CLICK_SHIFT)
 		if(isxeno(user))
 			var/mob/living/carbon/xenomorph/X = user
 			if(X.selected_ability)

--- a/code/_onclick/human.dm
+++ b/code/_onclick/human.dm
@@ -12,22 +12,28 @@
 
 
 /mob/living/carbon/human/click(atom/A, list/mods)
-	if(mods["shift"] && !mods["middle"])
-		if(selected_ability && client && client.prefs && !(client.prefs.toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK))
-			selected_ability.use_ability(A)
-			return TRUE
+	var/use_ability = FALSE
+	switch(get_ability_mouse_key())
+		if(XENO_ABILITY_CLICK_SHIFT)
+			if(mods[SHIFT_CLICK] && mods[LEFT_CLICK])
+				use_ability = TRUE
+		if(XENO_ABILITY_CLICK_MIDDLE)
+			if(mods[MIDDLE_CLICK])
+				use_ability = TRUE
+		if(XENO_ABILITY_CLICK_RIGHT)
+			if(mods[RIGHT_CLICK])
+				use_ability = TRUE
 
-	if(mods["middle"] && !mods["shift"])
-		if(selected_ability && client && client.prefs && client.prefs.toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK)
-			selected_ability.use_ability(A)
-			return TRUE
+	if(selected_ability && use_ability)
+		selected_ability.use_ability(A)
+		return TRUE
 
 	if(interactee)
 		var/result = interactee.handle_click(src, A, mods)
 		if(result != HANDLE_CLICK_PASS_THRU)
 			return result
 
-	if (mods["middle"] && !mods["shift"] && ishuman(A) && get_dist(src, A) <= 1)
+	if (mods[MIDDLE_CLICK] && !mods[SHIFT_CLICK] && ishuman(A) && get_dist(src, A) <= 1)
 		var/mob/living/carbon/human/H = A
 		H.receive_from(src)
 		return TRUE

--- a/code/_onclick/human.dm
+++ b/code/_onclick/human.dm
@@ -18,7 +18,7 @@
 			if(mods[SHIFT_CLICK] && mods[LEFT_CLICK])
 				use_ability = TRUE
 		if(XENO_ABILITY_CLICK_MIDDLE)
-			if(mods[MIDDLE_CLICK])
+			if(mods[MIDDLE_CLICK] && !mods[SHIFT_CLICK])
 				use_ability = TRUE
 		if(XENO_ABILITY_CLICK_RIGHT)
 			if(mods[RIGHT_CLICK])

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -132,7 +132,7 @@ so that it doesn't double up on the delays) so that it applies the delay immedia
 	var/activate_ability = FALSE
 	switch(preference)
 		if(XENO_ABILITY_CLICK_MIDDLE)
-			activate_ability = middle_pressed
+			activate_ability = middle_pressed && !shift_pressed
 		if(XENO_ABILITY_CLICK_RIGHT)
 			activate_ability = right_pressed
 		if(XENO_ABILITY_CLICK_SHIFT)

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -114,9 +114,11 @@ so that it doesn't double up on the delays) so that it applies the delay immedia
 		handle_queued_action(target)
 		return TRUE
 
-	var/alt_pressed = mods["alt"] == "1"
-	var/shift_pressed = mods["shift"] == "1"
-	var/middle_pressed = mods["middle"] == "1"
+	var/left_pressed = mods[LEFT_CLICK] == "1"
+	var/alt_pressed = mods[ALT_CLICK] == "1"
+	var/shift_pressed = mods[SHIFT_CLICK] == "1"
+	var/middle_pressed = mods[MIDDLE_CLICK] == "1"
+	var/right_pressed = mods[RIGHT_CLICK] == "1"
 
 	if(alt_pressed && shift_pressed)
 		if(istype(target, /mob/living/carbon/xenomorph))
@@ -126,15 +128,24 @@ so that it doesn't double up on the delays) so that it applies the delay immedia
 				next_move = world.time + 3 // Some minimal delay so this isn't crazy spammy
 				return TRUE
 
-	var/middle_pref = client.prefs && (client.prefs.toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK) != 0 // client is already tested to be non-null by caller
-	if(selected_ability && shift_pressed == !middle_pref && middle_pressed == middle_pref)
+	var/preference = get_ability_mouse_key() // client is already tested to be non-null by caller
+	var/activate_ability = FALSE
+	switch(preference)
+		if(XENO_ABILITY_CLICK_MIDDLE)
+			activate_ability = middle_pressed
+		if(XENO_ABILITY_CLICK_RIGHT)
+			activate_ability = right_pressed
+		if(XENO_ABILITY_CLICK_SHIFT)
+			activate_ability = left_pressed && shift_pressed
+
+	if(activate_ability && selected_ability)
 		if(istype(target, /atom/movable/screen))
 			// Click through the UI: Currently this won't attempt to sprite click any mob there, just the turf
 			var/turf/turf = params2turf(mods["screen-loc"], get_turf(client.eye), client)
 			if(turf)
 				target = turf
-		if(selected_ability.use_ability_wrapper(target, mods))
-			return TRUE
+		selected_ability.use_ability_wrapper(target, mods)
+		return TRUE
 
 	if(next_move >= world.time)
 		return FALSE

--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -408,18 +408,16 @@
 		return
 	var/mob/living/carbon/human/human = owner
 	if(human.selected_ability == src)
-		to_chat(human, "You will no longer use [name] with \
-			[human.client && human.client.prefs && human.client.prefs.toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK ? "middle-click" : "shift-click"].")
+		to_chat(human, "You will no longer use [name] with [human.get_ability_mouse_name()].")
 		button.icon_state = "template"
-		human.selected_ability = null
+		human.set_selected_ability(null)
 	else
-		to_chat(human, "You will now use [name] with \
-			[human.client && human.client.prefs && human.client.prefs.toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK ? "middle-click" : "shift-click"].")
+		to_chat(human, "You will now use [name] with [human.get_ability_mouse_name()].")
 		if(human.selected_ability)
 			human.selected_ability.button.icon_state = "template"
-			human.selected_ability = null
+			human.set_selected_ability(null)
 		button.icon_state = "template_on"
-		human.selected_ability = src
+		human.set_selected_ability(src)
 
 /datum/action/item_action/specialist/spotter_target/can_use_action()
 	var/mob/living/carbon/human/human = owner

--- a/code/game/objects/items/hoverpack.dm
+++ b/code/game/objects/items/hoverpack.dm
@@ -211,18 +211,16 @@
 	. = ..()
 	var/mob/living/carbon/human/H = owner
 	if(H.selected_ability == src)
-		to_chat(H, "You will no longer use [name] with \
-			[H.client && H.client.prefs && H.client.prefs.toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK ? "middle-click" : "shift-click"].")
+		to_chat(H, "You will no longer use [name] with [H.get_ability_mouse_name()].")
 		button.icon_state = "template"
-		H.selected_ability = null
+		H.set_selected_ability(null)
 	else
-		to_chat(H, "You will now use [name] with \
-			[H.client && H.client.prefs && H.client.prefs.toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK ? "middle-click" : "shift-click"].")
+		to_chat(H, "You will now use [name] with [H.get_ability_mouse_name()].")
 		if(H.selected_ability)
 			H.selected_ability.button.icon_state = "template"
-			H.selected_ability = null
+			H.set_selected_ability(null)
 		button.icon_state = "template_on"
-		H.selected_ability = src
+		H.set_selected_ability(src)
 
 /datum/action/item_action/hover/update_button_icon()
 	var/obj/item/hoverpack/HP = holder_item
@@ -246,7 +244,7 @@
 /datum/action/item_action/hover/remove_from(mob/living/carbon/human/H)
 	..()
 	if(H.selected_ability == src)
-		H.selected_ability = null
+		H.set_selected_ability(null)
 		update_button_icon()
 		button.icon_state = "template"
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -44,7 +44,6 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 	/client/proc/toggle_eject_to_hand,
 	/client/proc/toggle_automatic_punctuation,
 	/client/proc/toggle_ammo_display_type,
-	/client/proc/toggle_middle_mouse_click,
 	/client/proc/toggle_ability_deactivation,
 	/client/proc/toggle_clickdrag_override,
 	/client/proc/toggle_dualwield,
@@ -912,3 +911,13 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 		return TRUE
 
 	return FALSE
+
+/client/proc/set_right_click_menu_mode(shift_only)
+	if(shift_only)
+		winset(src, "mapwindow.map", "right-click=true")
+		winset(src, "ShiftUp", "is-disabled=false")
+		winset(src, "Shift", "is-disabled=false")
+	else
+		winset(src, "mapwindow.map", "right-click=false")
+		winset(src, "default.Shift", "is-disabled=true")
+		winset(src, "default.ShiftUp", "is-disabled=true")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -51,7 +51,8 @@ GLOBAL_LIST_INIT(bgstate_options, list(
 	var/lastchangelog = "" // Saved changlog filesize to detect if there was a change
 	var/ooccolor
 	var/be_special = 0 // Special role selection
-	var/toggle_prefs = TOGGLE_MIDDLE_MOUSE_CLICK|TOGGLE_DIRECTIONAL_ATTACK|TOGGLE_MEMBER_PUBLIC|TOGGLE_AMBIENT_OCCLUSION|TOGGLE_VEND_ITEM_TO_HAND // flags in #define/mode.dm
+	var/toggle_prefs = TOGGLE_DIRECTIONAL_ATTACK|TOGGLE_MEMBER_PUBLIC|TOGGLE_AMBIENT_OCCLUSION|TOGGLE_VEND_ITEM_TO_HAND // flags in #define/mode.dm
+	var/xeno_ability_click_mode = XENO_ABILITY_CLICK_MIDDLE
 	var/auto_fit_viewport = FALSE
 	var/adaptive_zoom = 0
 	var/UI_style = "midnight"
@@ -604,6 +605,7 @@ GLOBAL_LIST_INIT(bgstate_options, list(
 			dat += "<b>Play Lobby Music:</b> <a href='?_src_=prefs;preference=lobby_music'><b>[(toggles_sound & SOUND_LOBBY) ? "Yes" : "No"]</b></a><br>"
 			dat += "<b>Play VOX Announcements:</b> <a href='?_src_=prefs;preference=sound_vox'><b>[(hear_vox) ? "Yes" : "No"]</b></a><br>"
 			dat += "<b>Default Ghost Night Vision Level:</b> <a href='?_src_=prefs;preference=ghost_vision_pref;task=input'><b>[ghost_vision_pref]</b></a><br>"
+			dat += "<b>Button To Activate Xenomorph Abilities:</b> <a href='?_src_=prefs;preference=mouse_button_activation;task=input'><b>[xeno_ability_mouse_pref_to_string(xeno_ability_click_mode)]</b></a><br>"
 			dat += "<a href='?src=\ref[src];action=proccall;procpath=/client/proc/receive_random_tip'>Read Random Tip of the Round</a><br>"
 			if(CONFIG_GET(flag/allow_Metadata))
 				dat += "<b>OOC Notes:</b> <a href='?_src_=prefs;preference=metadata;task=input'> Edit </a>"
@@ -615,8 +617,6 @@ GLOBAL_LIST_INIT(bgstate_options, list(
 					</b> <a href='?_src_=prefs;preference=toggle_prefs;flag=[TOGGLE_IGNORE_SELF]'><b>[toggle_prefs & TOGGLE_IGNORE_SELF ? "Off" : "On"]</b></a><br>"
 			dat += "<b>Toggle Help Intent Safety: \
 					</b> <a href='?_src_=prefs;preference=toggle_prefs;flag=[TOGGLE_HELP_INTENT_SAFETY]'><b>[toggle_prefs & TOGGLE_HELP_INTENT_SAFETY ? "On" : "Off"]</b></a><br>"
-			dat += "<b>Toggle Middle Mouse Ability Activation: \
-					</b> <a href='?_src_=prefs;preference=toggle_prefs;flag=[TOGGLE_MIDDLE_MOUSE_CLICK]'><b>[toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK ? "On" : "Off"]</b></a><br>"
 			dat += "<b>Toggle Ability Deactivation: \
 					</b> <a href='?_src_=prefs;preference=toggle_prefs;flag=[TOGGLE_ABILITY_DEACTIVATION_OFF]'><b>[toggle_prefs & TOGGLE_ABILITY_DEACTIVATION_OFF ? "Off" : "On"]</b></a><br>"
 			dat += "<b>Toggle Directional Assist: \
@@ -1249,7 +1249,31 @@ GLOBAL_LIST_INIT(bgstate_options, list(
 					if(!choice)
 						return
 					ghost_vision_pref = choice
-
+				if("mouse_button_activation")
+					var/static/list/mouse_button_list = list(
+						xeno_ability_mouse_pref_to_string(XENO_ABILITY_CLICK_MIDDLE) = XENO_ABILITY_CLICK_MIDDLE,
+						xeno_ability_mouse_pref_to_string(XENO_ABILITY_CLICK_SHIFT) = XENO_ABILITY_CLICK_SHIFT,
+						xeno_ability_mouse_pref_to_string(XENO_ABILITY_CLICK_RIGHT) = XENO_ABILITY_CLICK_RIGHT
+					)
+					var/choice = tgui_input_list(user, "Choose how you will activate your xenomorph and human abilities.", "Mouse Activation Button", mouse_button_list)
+					if(!choice)
+						return
+					xeno_ability_click_mode = mouse_button_list[choice]
+					// This isn't that great of a way to do it, but ability code is already not that modular considering
+					// the fact that we have two datums for xeno/human abilities. Might need to refactor abilities as a whole in the future
+					// so that the `activable` type is the parent of both xeno/human abilities - it would get rid of this headache in an instant.
+					if(isxeno(user))
+						var/mob/living/carbon/xenomorph/xeno = user
+						if(xeno.selected_ability)
+							var/datum/action/xeno_action/activable/ability = xeno.selected_ability
+							xeno.set_selected_ability(null)
+							xeno.set_selected_ability(ability)
+					if(ishuman(user))
+						var/mob/living/carbon/human/human = user
+						if(human.selected_ability)
+							var/datum/action/human_action/activable/ability = human.selected_ability
+							human.set_selected_ability(null)
+							human.set_selected_ability(ability)
 				if("synth_name")
 					var/raw_name = input(user, "Choose your Synthetic's name:", "Character Preference")  as text|null
 					if(raw_name) // Check to ensure that the user entered text (rather than cancel.)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -1,5 +1,5 @@
 #define SAVEFILE_VERSION_MIN 8
-#define SAVEFILE_VERSION_MAX 25
+#define SAVEFILE_VERSION_MAX 26
 
 //handles converting savefiles to new formats
 //MAKE SURE YOU KEEP THIS UP TO DATE!
@@ -152,6 +152,15 @@
 		S["nanotrasen_relation"] >> relation
 		S["weyland_yutani_relation"] << relation
 
+	if(savefile_version < 26)
+		// Removes TOGGLE_MIDDLE_MOUSE_CLICK (1<<2) and replaces it with a new pref
+		var/toggle_prefs = 0
+		S["toggle_prefs"] >> toggle_prefs
+		if(toggle_prefs & (1<<2))
+			S["xeno_ability_click_mode"] << XENO_ABILITY_CLICK_MIDDLE
+		else
+			S["xeno_ability_click_mode"] << XENO_ABILITY_CLICK_SHIFT
+
 	savefile_version = SAVEFILE_VERSION_MAX
 	return 1
 
@@ -197,6 +206,7 @@
 	S["toggles_langchat"] >> toggles_langchat
 	S["toggles_sound"] >> toggles_sound
 	S["toggle_prefs"] >> toggle_prefs
+	S["xeno_ability_click_mode"] >> xeno_ability_click_mode
 	S["dual_wield_pref"] >> dual_wield_pref
 	S["toggles_flashing"] >> toggles_flashing
 	S["toggles_ert"] >> toggles_ert
@@ -284,6 +294,7 @@
 	toggles_langchat = sanitize_integer(toggles_langchat, 0, SHORT_REAL_LIMIT, initial(toggles_langchat))
 	toggles_sound = sanitize_integer(toggles_sound, 0, SHORT_REAL_LIMIT, initial(toggles_sound))
 	toggle_prefs = sanitize_integer(toggle_prefs, 0, SHORT_REAL_LIMIT, initial(toggle_prefs))
+	xeno_ability_click_mode = sanitize_integer(xeno_ability_click_mode, 1, XENO_ABILITY_CLICK_MAX, initial(xeno_ability_click_mode))
 	dual_wield_pref = sanitize_integer(dual_wield_pref, 0, 2, initial(dual_wield_pref))
 	toggles_flashing= sanitize_integer(toggles_flashing, 0, SHORT_REAL_LIMIT, initial(toggles_flashing))
 	toggles_ert = sanitize_integer(toggles_ert, 0, SHORT_REAL_LIMIT, initial(toggles_ert))
@@ -399,6 +410,7 @@
 	S["toggles_langchat"] << toggles_langchat
 	S["toggles_sound"] << toggles_sound
 	S["toggle_prefs"] << toggle_prefs
+	S["xeno_ability_click_mode"] << xeno_ability_click_mode
 	S["dual_wield_pref"] << dual_wield_pref
 	S["toggles_flashing"] << toggles_flashing
 	S["toggles_ert"] << toggles_ert

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -275,7 +275,6 @@
 		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_ammo_display_type'>Toggle Semi-Auto Ammo Counter</a><br>",
 		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_eject_to_hand'>Toggle 'Unload Weapon' Ejecting Magazines to Your Hands</a><br>",
 		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_automatic_punctuation'>Toggle Automatic Punctuation</a><br>",
-		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_middle_mouse_click'>Toggle Middle Mouse Ability Activation</a><br>",
 		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_ability_deactivation'>Toggle Ability Deactivation</a><br>",
 		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_clickdrag_override'>Toggle Combat Click-Drag Override</a><br>",
 		"<a href='?src=\ref[src];action=proccall;procpath=/client/proc/toggle_dualwield'>Toggle Alternate-Fire Dual Wielding</a><br>",
@@ -356,14 +355,6 @@
 		to_chat(src, SPAN_BOLDNOTICE("Your messages will automatically be punctuated if they are not punctuated already."))
 	else
 		to_chat(src, SPAN_BOLDNOTICE("Your messages will no longer be automatically punctuated if they are not punctuated already."))
-	prefs.save_preferences()
-
-/client/proc/toggle_middle_mouse_click() // Toggle whether abilities should use middle or shift clicking
-	prefs.toggle_prefs ^= TOGGLE_MIDDLE_MOUSE_CLICK
-	if (prefs.toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK)
-		to_chat(src, SPAN_NOTICE("Your selected ability will now be activated with middle clicking."))
-	else
-		to_chat(src, SPAN_NOTICE("Your selected ability will now be activated with shift clicking."))
 	prefs.save_preferences()
 
 /client/proc/toggle_ability_deactivation() // Toggle whether the current ability can be deactivated when re-selected

--- a/code/modules/mob/living/carbon/human/human_abilities.dm
+++ b/code/modules/mob/living/carbon/human/human_abilities.dm
@@ -144,12 +144,12 @@
 
 	var/list/target_list = list()
 	for(var/mob/living/carbon/possible_target in view(7, human_owner))
-		if(possible_target == human_owner || !possible_target.client)
+		if(possible_target == human_owner || !possible_target.client) 
 			continue
 		target_list += possible_target
 
 	var/mob/living/carbon/target_mob = tgui_input_list(human_owner, "Target", "Send a Psychic Whisper to whom?", target_list, theme = "hive_status")
-	if(!target_mob)
+	if(!target_mob) 
 		return
 
 	human_owner.psychic_whisper(target_mob)

--- a/code/modules/mob/living/carbon/human/human_abilities.dm
+++ b/code/modules/mob/living/carbon/human/human_abilities.dm
@@ -1,3 +1,12 @@
+/mob/living/carbon/human/proc/set_selected_ability(datum/action/human_action/activable/ability)
+	if(!ability)
+		selected_ability = null
+		client?.set_right_click_menu_mode(shift_only = FALSE)
+		return
+	selected_ability = ability
+	if(get_ability_mouse_key() == XENO_ABILITY_CLICK_RIGHT)
+		client?.set_right_click_menu_mode(shift_only = TRUE)
+
 /datum/action/human_action/update_button_icon()
 	if(action_cooldown_check())
 		button.color = rgb(120,120,120,200)
@@ -135,12 +144,12 @@
 
 	var/list/target_list = list()
 	for(var/mob/living/carbon/possible_target in view(7, human_owner))
-		if(possible_target == human_owner || !possible_target.client) 
+		if(possible_target == human_owner || !possible_target.client)
 			continue
 		target_list += possible_target
 
 	var/mob/living/carbon/target_mob = tgui_input_list(human_owner, "Target", "Send a Psychic Whisper to whom?", target_list, theme = "hive_status")
-	if(!target_mob) 
+	if(!target_mob)
 		return
 
 	human_owner.psychic_whisper(target_mob)
@@ -163,23 +172,21 @@ CULT
 		return
 	var/mob/living/carbon/human/H = owner
 	if(H.selected_ability == src)
-		to_chat(H, "You will no longer use [name] with \
-			[H.client && H.client.prefs && H.client.prefs.toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK ? "middle-click" : "shift-click"].")
+		to_chat(H, "You will no longer use [name] with [H.get_ability_mouse_name()].")
 		button.icon_state = "template"
-		H.selected_ability = null
+		H.set_selected_ability(null)
 	else
-		to_chat(H, "You will now use [name] with \
-			[H.client && H.client.prefs && H.client.prefs.toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK ? "middle-click" : "shift-click"].")
+		to_chat(H, "You will now use [name] with [H.get_ability_mouse_name()].")
 		if(H.selected_ability)
 			H.selected_ability.button.icon_state = "template"
-			H.selected_ability = null
+			H.set_selected_ability(null)
 		button.icon_state = "template_on"
-		H.selected_ability = src
+		H.set_selected_ability(src)
 
 /datum/action/human_action/activable/remove_from(mob/living/carbon/human/H)
 	..()
 	if(H.selected_ability == src)
-		H.selected_ability = null
+		H.set_selected_ability(null)
 
 /datum/action/human_action/activable/proc/use_ability(mob/M)
 	return

--- a/code/modules/mob/living/carbon/human/login.dm
+++ b/code/modules/mob/living/carbon/human/login.dm
@@ -1,3 +1,6 @@
 /mob/living/carbon/human/Login()
 	..()
-	if(species) species.handle_login_special(src)
+	if(species)
+		species.handle_login_special(src)
+	if(selected_ability)
+		set_selected_ability(null)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
@@ -7,6 +7,15 @@
 	plasma internally. Bear that in mind. -4khan
 */
 
+/mob/living/carbon/xenomorph/proc/set_selected_ability(datum/action/xeno_action/activable/ability)
+	if(!ability)
+		selected_ability = null
+		client?.set_right_click_menu_mode(shift_only = FALSE)
+		return
+	selected_ability = ability
+	if(get_ability_mouse_key() == XENO_ABILITY_CLICK_RIGHT)
+		client?.set_right_click_menu_mode(shift_only = TRUE)
+
 /datum/action/xeno_action/onclick/plant_weeds
 	name = "Plant Weeds (75)"
 	ability_name = "Plant Weeds"

--- a/code/modules/mob/living/carbon/xenomorph/abilities/xeno_action.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/xeno_action.dm
@@ -169,21 +169,19 @@
 			return // We clicked the same ability in a very short time
 		if(xeno.client && xeno.client.prefs && xeno.client.prefs.toggle_prefs & TOGGLE_ABILITY_DEACTIVATION_OFF)
 			return
-		to_chat(xeno, "You will no longer use [ability_name] with \
-			[xeno.client && xeno.client.prefs && xeno.client.prefs.toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK ? "middle-click" : "shift-click"].")
+		to_chat(xeno, "You will no longer use [ability_name] with [xeno.get_ability_mouse_name()].")
 		button.icon_state = "template"
-		xeno.selected_ability = null
+		xeno.set_selected_ability(null)
 		if(charge_time)
 			stop_charging_ability()
 	else
-		to_chat(xeno, "You will now use [ability_name] with \
-			[xeno.client && xeno.client.prefs && xeno.client.prefs.toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK ? "middle-click" : "shift-click"].")
+		to_chat(xeno, "You will now use [ability_name] with [xeno.get_ability_mouse_name()].")
 		if(xeno.selected_ability)
 			xeno.selected_ability.action_deselect()
 			if(xeno.selected_ability.charge_time)
 				xeno.selected_ability.stop_charging_ability()
 		button.icon_state = "template_on"
-		xeno.selected_ability = src
+		xeno.set_selected_ability(src)
 		xeno.deselect_timer = world.time + 5 // Half a second
 		if(charges != NO_ACTION_CHARGES)
 			to_chat(xeno, SPAN_INFO("It has [charges] uses left."))
@@ -198,7 +196,7 @@
 /datum/action/xeno_action/activable/remove_from(mob/living/carbon/xenomorph/xeno)
 	..()
 	if(xeno.selected_ability == src)
-		xeno.selected_ability = null
+		xeno.set_selected_ability(null)
 	if(macro_path)
 		remove_verb(xeno, macro_path)
 

--- a/code/modules/mob/living/carbon/xenomorph/login.dm
+++ b/code/modules/mob/living/carbon/xenomorph/login.dm
@@ -6,3 +6,5 @@
 			generate_name()
 	if(SSticker.mode)
 		SSticker.mode.xenomorphs |= mind
+	if(selected_ability)
+		set_selected_ability(null)

--- a/code/modules/mob/living/carbon/xenomorph/xeno_verbs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_verbs.dm
@@ -102,22 +102,6 @@
 
 	xeno_hostile_hud = !xeno_hostile_hud
 
-
-/mob/living/carbon/xenomorph/verb/middle_mouse_toggle()
-	set name = "Toggle Middle/Shift Clicking"
-	set desc = "Toggles between using middle mouse click and shift click for selected ability use."
-	set category = "Alien"
-
-	if (!client || !client.prefs)
-		return
-
-	client.prefs.toggle_prefs ^= TOGGLE_MIDDLE_MOUSE_CLICK
-	client.prefs.save_preferences()
-	if (client.prefs.toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK)
-		to_chat(src, SPAN_NOTICE("The selected xeno ability will now be activated with middle mouse clicking."))
-	else
-		to_chat(src, SPAN_NOTICE("The selected xeno ability will now be activated with shift clicking."))
-
 /mob/living/carbon/xenomorph/verb/ability_deactivation_toggle()
 	set name = "Toggle Ability Deactivation"
 	set desc = "Toggles whether you can deactivate your currently active ability when re-selecting it."

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/giant_lizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/giant_lizard.dm
@@ -171,7 +171,7 @@
 		desc = "A large, wolf-like reptile."
 		if(user == src)
 			. += SPAN_NOTICE("\nRest on the ground to restore 5% of your health every second.")
-			. += SPAN_NOTICE("You're able to pounce targets by using [client && client.prefs && client.prefs.toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK ? "middle-click" : "shift-click"].")
+			. += SPAN_NOTICE("You're able to pounce targets by using [get_ability_mouse_name()].")
 			. += SPAN_NOTICE("You will aggressively maul targets that are prone. Any click on yourself will be passed down to mobs below you, so feel free to click on your sprite in order to attack pounced targets.")
 	else if((user.faction in faction_group))
 		desc = "[initial(desc)] There's a hint of warmth in them."
@@ -718,15 +718,22 @@
 
 //Middle mouse button/shift click to pounce.
 /mob/living/simple_animal/hostile/retaliate/giant_lizard/click(atom/clicked_atom, list/mods)
-	if(mods["shift"] && !mods["middle"])
-		if(client && client.prefs && !(client.prefs.toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK))
-			pounce(clicked_atom)
-			return TRUE
+	var/should_pounce = FALSE
+	switch(get_ability_mouse_key())
+		if(XENO_ABILITY_CLICK_MIDDLE)
+			if(mods[MIDDLE_CLICK] && mods[LEFT_CLICK])
+				should_pounce = TRUE
+		if(XENO_ABILITY_CLICK_RIGHT)
+			if(mods[RIGHT_CLICK])
+				should_pounce = TRUE
+		if(XENO_ABILITY_CLICK_MIDDLE)
+			if(mods[MIDDLE_CLICK])
+				should_pounce = TRUE
 
-	if(mods["middle"] && !mods["shift"])
-		if(client && client.prefs && client.prefs.toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK)
-			pounce(clicked_atom)
-			return TRUE
+	if(should_pounce)
+		pounce(clicked_atom)
+		return TRUE
+
 	return ..()
 
 

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -59,6 +59,7 @@
 			CB.Invoke()
 
 	client.init_verbs()
+	client.set_right_click_menu_mode(shift_only = FALSE)
 
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_MOB_LOGGED_IN, src)
 	SEND_SIGNAL(client, COMSIG_CLIENT_MOB_LOGGED_IN, src)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -615,3 +615,24 @@ GLOBAL_LIST_INIT(limb_types_by_name, list(
 
 	lighting_alpha = LIGHTING_PLANE_ALPHA_VISIBLE
 	sync_lighting_plane_alpha()
+
+/mob/proc/get_ability_mouse_key()
+	if(!client)
+		return XENO_ABILITY_CLICK_MIDDLE
+
+	return client.prefs.xeno_ability_click_mode
+
+/proc/xeno_ability_mouse_pref_to_string(preference_value)
+	switch(preference_value)
+		if(XENO_ABILITY_CLICK_MIDDLE)
+			return "middle click"
+		if(XENO_ABILITY_CLICK_RIGHT)
+			return "right click"
+		if(XENO_ABILITY_CLICK_SHIFT)
+			return "shift click"
+	return "middle click"
+
+/mob/proc/get_ability_mouse_name()
+	var/ability = get_ability_mouse_key()
+
+	return xeno_ability_mouse_pref_to_string(ability)

--- a/code/modules/projectiles/guns/specialist/sniper.dm
+++ b/code/modules/projectiles/guns/specialist/sniper.dm
@@ -67,18 +67,16 @@
 		return
 	var/mob/living/carbon/human/H = owner
 	if(H.selected_ability == src)
-		to_chat(H, "You will no longer use [name] with \
-			[H.client && H.client.prefs && H.client.prefs.toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK ? "middle-click" : "shift-click"].")
+		to_chat(H, "You will no longer use [name] with [H.get_ability_mouse_name()].")
 		button.icon_state = "template"
-		H.selected_ability = null
+		H.set_selected_ability(null)
 	else
-		to_chat(H, "You will now use [name] with \
-			[H.client && H.client.prefs && H.client.prefs.toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK ? "middle-click" : "shift-click"].")
+		to_chat(H, "You will now use [name] with [H.get_ability_mouse_name()].")
 		if(H.selected_ability)
 			H.selected_ability.button.icon_state = "template"
-			H.selected_ability = null
+			H.set_selected_ability(null)
 		button.icon_state = "template_on"
-		H.selected_ability = src
+		H.set_selected_ability(src)
 
 /datum/action/item_action/specialist/aimed_shot/can_use_action()
 	var/mob/living/carbon/human/H = owner

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1,4 +1,12 @@
 macro "default"
+	elem ".winset :map.right-click=false"
+		name = "SHIFT+Shift"
+	elem "Shift"
+		name = "SHIFT"
+		command = ".winset :map.right-click=false"
+	elem "ShiftUp"
+		name = "SHIFT+UP"
+		command = ".winset :map.right-click=true"
 
 menu "menu"
 	elem


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

As the title says. Adds a new preference option that can be toggled between middle clicking and shift clicking. When enabled, if you have a xeno ability active, the right mouse button will trigger the ability where you click.

This'll disable the context menu when pressing right click if the ability is active, but you can hold shift before right clicking to re-enable the context menu if you need it for some specific purpose without having to deactivate the ability or switch your preferences.

# Explain why it's good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->
Right mouse button is just a lot more convenient for me and I'm sure this'll be useful for other players too. This is primarily a quality of life change, the preference to use the middle mouse button or the left mouse button with shift click will still exist.

It's a big problem for me since the middle mouse button on my mouse is somewhat faulty and doesn't always register clicks correctly. Shiftclick is also really awkward for me to use because I don't want to have to hold down multiple buttons to use my abilities. Adding a new option on the rmb makes sense here.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

Tested on my local and seems to work fine. You can rightclick normally when the ability is disabled or if you have the preference off, but rightclick to proc ability works fine.

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Adds a new preference option for activating xeno abilities: Right click. Prevents the context menu from opening whenever you have an ability active, and the ability can then be triggered with right click. Context menu can still be forced open by holding shift before right clicking, even if the ability is active.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
