### PR TITLE
Provost and Survivor CL rank fixes

### DIFF
--- a/code/game/objects/effects/landmarks/survivor_spawner.dm
+++ b/code/game/objects/effects/landmarks/survivor_spawner.dm
@@ -87,7 +87,7 @@
 //Weyland-Yutani Survivors//
 
 /obj/effect/landmark/survivor_spawner/lv624_corporate_dome_cl
-	equipment = /datum/equipment_preset/survivor/wy/executive
+	equipment = /datum/equipment_preset/survivor/corporate/executive
 	synth_equipment = /datum/equipment_preset/synth/survivor/wy/security_synth
 	intro_text = list("<h2>You are the last alive Executive of Lazarus Landing!</h2>",\
 	"<span class='notice'>You are aware of the xenomorph threat.</span>",\
@@ -146,7 +146,7 @@
 	spawn_priority = SPAWN_PRIORITY_VERY_HIGH
 
 /obj/effect/landmark/survivor_spawner/bigred_crashed_cl
-	equipment = /datum/equipment_preset/survivor/wy/manager
+	equipment = /datum/equipment_preset/survivor/corporate/manager
 	synth_equipment = /datum/equipment_preset/synth/survivor/pmc
 	intro_text = list("<h2>You are a survivor of a crash landing!</h2>",\
 	"<span class='notice'>You are NOT aware of the xenomorph threat.</span>",\
@@ -159,7 +159,7 @@
 	spawn_priority = SPAWN_PRIORITY_VERY_HIGH
 
 /obj/effect/landmark/survivor_spawner/shivas_panic_room_cl
-	equipment = /datum/equipment_preset/survivor/wy/asstmanager
+	equipment = /datum/equipment_preset/survivor/corporate/asstmanager
 	synth_equipment = /datum/equipment_preset/synth/survivor/wy/corporate_synth
 	intro_text = list("<h2>You are the last alive Senior Administrator on the Colony!</h2>",\
 	"<span class='notice'>You are aware of the xenomorph threat.</span>",\

--- a/code/modules/gear_presets/survivors/lv_624/corporate_dome_insert_lv624.dm
+++ b/code/modules/gear_presets/survivors/lv_624/corporate_dome_insert_lv624.dm
@@ -1,7 +1,7 @@
 // /obj/effect/landmark/survivor_spawner/lv624_corporate_dome/cl
 // corporatedomehold.dmm
 
-/datum/equipment_preset/survivor/wy/executive
+/datum/equipment_preset/survivor/corporate/executive
 	name = "Survivor - LV-624 Paranoid Corporate Liaison"
 	flags = EQUIPMENT_PRESET_START_OF_ROUND
 	paygrades = list(PAY_SHORT_WYC5 = JOB_PLAYTIME_TIER_0)
@@ -28,7 +28,7 @@
 
 	survivor_variant = CORPORATE_SURVIVOR
 
-/datum/equipment_preset/survivor/wy/executive/load_gear(mob/living/carbon/human/new_human)
+/datum/equipment_preset/survivor/corporate/executive/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/liaison_suit/field(new_human), WEAR_BODY)
 	if(SSmapping.configs[GROUND_MAP].environment_traits[MAP_COLD])
 		add_ice_colony_survivor_equipment(new_human)

--- a/code/modules/gear_presets/survivors/shivas_snowball/panic_room_insert_shivas.dm
+++ b/code/modules/gear_presets/survivors/shivas_snowball/panic_room_insert_shivas.dm
@@ -1,7 +1,7 @@
 // /obj/effect/landmark/survivor_spawner/shivas_assistant_manager
 // panic_room_insert_shivas.dmm
 
-/datum/equipment_preset/survivor/wy/asstmanager
+/datum/equipment_preset/survivor/corporate/asstmanager
 	name = "Survivor - Corporate Assistant Manager"
 	flags = EQUIPMENT_PRESET_EXTRA
 	paygrades = list(PAY_SHORT_WYC7 = JOB_PLAYTIME_TIER_0)
@@ -28,7 +28,7 @@
 
 	survivor_variant = CORPORATE_SURVIVOR
 
-/datum/equipment_preset/survivor/wy/asstmanager/load_gear(mob/living/carbon/human/new_human)
+/datum/equipment_preset/survivor/corporate/asstmanager/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/suit_jacket/manager(new_human), WEAR_BODY)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/lockable/liaison, WEAR_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/reagent_container/glass/beaker/vial/random/good(new_human), WEAR_IN_BACK)

--- a/code/modules/gear_presets/survivors/solaris/crashlanding-offices_insert_bigred.dm
+++ b/code/modules/gear_presets/survivors/solaris/crashlanding-offices_insert_bigred.dm
@@ -77,7 +77,7 @@
 
 // /obj/effect/landmark/survivor_spawner/bigred_crashed_cl
 
-/datum/equipment_preset/survivor/wy/manager
+/datum/equipment_preset/survivor/corporate/manager
 	name = "Survivor - Corporate Supervisor"
 	flags = EQUIPMENT_PRESET_EXTRA
 	paygrades = list(PAY_SHORT_WYC6 = JOB_PLAYTIME_TIER_0)
@@ -106,7 +106,7 @@
 
 	survivor_variant = CORPORATE_SURVIVOR
 
-/datum/equipment_preset/survivor/wy/manager/load_gear(mob/living/carbon/human/new_human)
+/datum/equipment_preset/survivor/corporate/manager/load_gear(mob/living/carbon/human/new_human)
 
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/suit_jacket/manager(new_human), WEAR_BODY)
 	if(SSmapping.configs[GROUND_MAP].environment_traits[MAP_COLD])

--- a/code/modules/gear_presets/survivors/survivors.dm
+++ b/code/modules/gear_presets/survivors/survivors.dm
@@ -370,8 +370,29 @@ Everything bellow is a parent used as a base for one or multiple maps.
 		ACCESS_WY_EXEC,
 	)
 	languages = list(LANGUAGE_ENGLISH, LANGUAGE_JAPANESE)
-
 	survivor_variant = CORPORATE_SURVIVOR
+
+/datum/equipment_preset/survivor/corporate/load_rank(mob/living/carbon/human/new_human, client/mob_client)
+	if(paygrades.len == 1)
+		return paygrades[1]
+	var/playtime
+	if(!mob_client)
+		playtime = JOB_PLAYTIME_TIER_1
+	else
+		playtime = get_job_playtime(mob_client, JOB_CORPORATE_LIAISON)
+		if((playtime >= JOB_PLAYTIME_TIER_1) && !mob_client.prefs.playtime_perks)
+			playtime = JOB_PLAYTIME_TIER_1
+	var/final_paygrade
+	for(var/current_paygrade as anything in paygrades)
+		var/required_time = paygrades[current_paygrade]
+		if(required_time - playtime > 0)
+			break
+		final_paygrade = current_paygrade
+	if(!final_paygrade)
+		. = "???"
+		CRASH("[key_name(new_human)] spawned with no valid paygrade.")
+
+	return final_paygrade
 
 /datum/equipment_preset/survivor/corporate/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/liaison_suit/field(new_human), WEAR_BODY)

--- a/code/modules/gear_presets/uscm_event.dm
+++ b/code/modules/gear_presets/uscm_event.dm
@@ -197,10 +197,9 @@
 
 /datum/equipment_preset/uscm_event/provost/enforcer
 	name = "Provost Enforcer"
-
 	assignment = JOB_PROVOST_ENFORCER
-	rank = "Provost Enforcer"
-	paygrades = list(PAY_SHORT_CPO = JOB_PLAYTIME_TIER_0)
+	rank = JOB_PROVOST_ENFORCER
+	paygrades = list(PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME6 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME7 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "PvE"
 	flags = EQUIPMENT_PRESET_EXTRA
 
@@ -243,10 +242,9 @@
 /datum/equipment_preset/uscm_event/provost/tml
 	name = "Provost Team Leader"
 	skills = /datum/skills/CMP
-
 	assignment = JOB_PROVOST_TML
-	rank = "Provost Team Leader"
-	paygrades = list(PAY_SHORT_CSPO = JOB_PLAYTIME_TIER_0)
+	rank = JOB_PROVOST_TML
+	paygrades = list(PAY_SHORT_ME8 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME9 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "PvTML"
 	flags = EQUIPMENT_PRESET_EXTRA
 
@@ -289,9 +287,8 @@
 
 /datum/equipment_preset/uscm_event/provost/inspector
 	name = "Provost Inspector"
-
 	assignment = JOB_PROVOST_INSPECTOR
-	rank = "Provost Inspector"
+	rank = JOB_PROVOST_INSPECTOR
 	paygrades = list(PAY_SHORT_PVI = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "PvI"
 	flags = EQUIPMENT_PRESET_EXTRA
@@ -330,7 +327,6 @@
 
 /datum/equipment_preset/uscm_event/provost/inspector/chief
 	name = "Provost Chief Inspector"
-
 	assignment = JOB_PROVOST_CINSPECTOR
 	rank = JOB_PROVOST_CINSPECTOR
 	paygrades = list(PAY_SHORT_PVCI = JOB_PLAYTIME_TIER_0)
@@ -370,10 +366,9 @@
 
 /datum/equipment_preset/uscm_event/provost/inspector/advisor
 	name = "Provost Advisor"
-
 	assignment = JOB_PROVOST_ADVISOR
-	rank = "Provost Advisor"
-	paygrades = list(PAY_SHORT_CSPO = JOB_PLAYTIME_TIER_0)
+	rank = JOB_PROVOST_ADVISOR
+	paygrades = list(PAY_SHORT_ME8E = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME9E = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "PvA"
 	flags = EQUIPMENT_PRESET_EXTRA
 


### PR DESCRIPTION

# About the pull request

As title this fixes the ranks used by Provost and Survivor CLs.
In my previous PR I changed some Provost Ranks to civilian titles, and this was a silly idea.

# Explain why it's good for the game

(Mostly) No more high ranking WY people who never played CL.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Survivor CL now draws ranks from CL playtime as previously.
add: Provost Advisor, Team Lead and Enforcer now use military ranks again.
/:cl:
