### PR TITLE
Fixes ability to build over/under fire doors.

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -199,7 +199,7 @@ Also change the icon to reflect the amount of sheets, if possible.*/
 
 			if(R.one_per_turf != ONE_TYPE_PER_BORDER) //all barricade-esque structures utilize this define and have their own check for object density. checking twice is unneeded.
 				for(var/obj/object in usr.loc)
-					if(object.density || istype(object, /obj/structure/machinery/door))
+					if(object.density || (istype(object, /obj/structure/machinery/door) && !istype(object, /obj/structure/machinery/door/firedoor)))
 						to_chat(usr, SPAN_WARNING("[object] is blocking you from constructing \the [R.title]!"))
 						return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

You can now build things on tiles that have fire doors again.

# Explain why it's good for the game

Unintentional that you can't rebuild the windows/doors etc. under a fire door.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: You can build on tiles with fire doors again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
