### PR TITLE
Removes Chem points from the Biomatter shop

### DIFF
--- a/code/datums/research_upgrade_datum.dm
+++ b/code/datums/research_upgrade_datum.dm
@@ -89,17 +89,6 @@
 	name = "Items"
 	behavior = RESEARCH_UPGRADE_CATEGORY
 
-/datum/research_upgrades/item/research_credits
-	name = "Research Credits"
-	desc = "Sell the data acquired to the nearest Weyland-Yutani Science division team for 8 or 9 points."
-	value_upgrade = 2000
-	behavior = RESEARCH_UPGRADE_ITEM
-	upgrade_type = ITEM_ACCESSORY_UPGRADE
-	item_reference = /obj/item/research_upgrades/credits
-	change_purchase = 500
-	maximum_price = 5000
-	clearance_req = 5
-
 /datum/research_upgrades/item/laser_scalpel
 	name = "Laser Scalpel"
 	desc = "An advanced, robust version of the normal scalpel, allowing it to pierce through thick skin and chitin alike with extreme ease."

--- a/code/game/objects/items/research_upgrades.dm
+++ b/code/game/objects/items/research_upgrades.dm
@@ -44,6 +44,7 @@
 /obj/item/research_upgrades/autodoc/Initialize(mapload, value)
 	. = ..()
 	src.value = value
+	name = "AutoDoc Upgrade ([get_upgrade_name()])."
 	desc = "Research upgrade for an AutoDoc. The technology on this disk is used [get_upgrade_text()]. Insert it in an AutoDoc to use it."
 
 /obj/item/research_upgrades/autodoc/proc/get_upgrade_text()
@@ -56,6 +57,17 @@
 			return "for treating internal organ damage"
 		if(RESEARCH_UPGRADE_TIER_4)
 			return "for extracting unknown parasites"
+
+/obj/item/research_upgrades/autodoc/proc/get_upgrade_name()
+	switch(value)
+		if(RESEARCH_UPGRADE_TIER_1)
+			return "Internal Bleeding"
+		if(RESEARCH_UPGRADE_TIER_2)
+			return "Bone Fracture"
+		if(RESEARCH_UPGRADE_TIER_3)
+			return "Organ Repair"
+		if(RESEARCH_UPGRADE_TIER_4)
+			return "Embryo Removal"
 
 /obj/item/research_upgrades/sleeper
 	name = "Research Upgrade (Sleeper)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

* Removes The option to buy chem points from the Biomatter printer
* Adds the name of the upgrade to the item name of AudoDoc Upgrade Disks.

# Explain why it's good for the game

The Biomatter point shop is a very interesting tool, with lots of great options you can choose to help marines.
To bad nobody ever buys anything but chem points from it. There are genuinly uniqe choices to make and most people ask for "just more chem points" to creat the same stim that everyone else does. Every single time.

Its the old truth of "Players will min/max the fun out of everything, if you let them"
So im no longer letting you. Your going to be forced to have to take interesting choices, and to actually have fun.

Research was fine before before they had the ability to buy additional chempoints via biomatter, so there is zero reason why they would suddently not be fine. The nerfs propertys got, would have happend regardless.
You survived years without it, you will again.

Also AutoDoc upgrade disks now say in their item name, what upgrade they have. So you no longer need to inspect the darn things if you want to know what it does. Bugged the hell out of me.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog


:cl:TheManWithNoHands
add: Adds upgrade name to autodoc upgrade disk
del: Removes chem points from Biomater printer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
