### PR TITLE
Fire stops Xeno regen (Main - Vamp)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_powers.dm
@@ -199,6 +199,8 @@
 		target_turfs += current_turfs
 		telegraph_atom_list += new /obj/effect/xenomorph/xeno_telegraph/red(current_turfs, 2)
 
+	var/can_heal = !(SEND_SIGNAL(xeno, COMSIG_XENO_PRE_HEAL) & COMPONENT_CANCEL_XENO_HEAL)
+
 	for (var/turf/current_turfs in target_turfs)
 		for (var/mob/living/carbon/target in current_turfs)
 			if (target.stat == DEAD)
@@ -214,11 +216,13 @@
 			log_attack("[key_name(xeno)] attacked [key_name(target)] with Flurry")
 			target.apply_armoured_damage(get_xeno_damage_slash(target, xeno.caste.melee_damage_upper), ARMOR_MELEE, BRUTE, rand_zone())
 			playsound(get_turf(target), 'sound/weapons/alien_claw_flesh4.ogg', 30, TRUE)
-			xeno.flick_heal_overlay(1 SECONDS, "#00B800")
-			xeno.gain_health(30)
 			xeno.animation_attack_on(target)
+			if(can_heal)
+				xeno.flick_heal_overlay(1 SECONDS, "#00B800")
+				xeno.gain_health(30)
 
-	xeno.emote("roar")
+	if(can_heal)//No heals = No Roar
+		xeno.emote("roar")
 	return ..()
 
 /datum/action/xeno_action/activable/tail_jab/use_ability(atom/targeted_atom)
@@ -374,10 +378,11 @@
 	xeno.animation_attack_on(target_carbon, pixel_offset = 16)
 	target_carbon.apply_armoured_damage(60, ARMOR_MELEE, BRUTE, "head", 5) //DIE
 	target_carbon.death(create_cause_data("headbite execution", xeno), FALSE)
-	xeno.gain_health(150)
-	xeno.xeno_jitter(1 SECONDS)
-	xeno.flick_heal_overlay(3 SECONDS, "#00B800")
-	xeno.emote("roar")
+	if(!(SEND_SIGNAL(xeno, COMSIG_XENO_PRE_HEAL) & COMPONENT_CANCEL_XENO_HEAL))
+		xeno.gain_health(150)
+		xeno.xeno_jitter(1 SECONDS)
+		xeno.flick_heal_overlay(3 SECONDS, "#00B800")
+		xeno.emote("roar")
 	log_attack("[key_name(xeno)] was executed by [key_name(target_carbon)] with a headbite!")
 	apply_cooldown()
 	return ..()

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/drone/healer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/drone/healer.dm
@@ -264,6 +264,7 @@
 	if(target.health < 0)
 		target.gain_health(abs(target.health)) // gets them out of crit first
 
+	target.ExtinguishMob()
 	target.gain_health(xeno.health * transfer_mod)
 	target.updatehealth()
 


### PR DESCRIPTION
# About the pull request

Fires now stops all forms of xenos regen, don't expect to gain health while on fire

This was supposedly an intended effect but was poorly implemented.
Now it properly checks and prevents all form of xeno regen.
Don't waste your heals on a burning xeno.

As requested seperated the changes for easier decisions:

Beserker Ravs no longer heals while on fire #7137

Weed and Pheromones regeneration no longer heals while on fire #7136

# Explain why it's good for the game

Gives good and interesting counter-play to Zerker ravs and Vamp lurkers and some other healing caste
Increases the effectiveness of the underperforming flamers without it being a number change.

Giving fire slightly more importance promotes good counterplay from both sides.
Allowing marines to counter healing xenos
While giving more importance to other xenos who can extinguish fires, like acid pillar, spitter, prae and boiler's spit and generally working together.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

https://streamable.com/idpec6

![ezgif-7-be831f7f30](https://github.com/user-attachments/assets/33e21afa-ea10-4d42-9bad-1acd6f2abf91)

</details>


# Changelog

:cl: ghostsheet
balance: Vamp Lurkers no longer heals while on fire.
balance: Healer Drone sacrifice abilities now also extinguishes the target before healing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
