### PR TITLE
Fire stops Xeno regen (Weed&Phero)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -338,7 +338,7 @@ Make sure their actual health updates immediately.*/
 
 	if(caste)
 		if(caste.innate_healing || check_weeds_for_healing())
-			if(!hive) return // can't heal if you have no hive, sorry bud
+			if(!hive || on_fire) return // can't heal if you have no hive, sorry bud
 			plasma_stored += plasma_gain * plasma_max / 100
 			if(recovery_aura)
 				plasma_stored += floor(plasma_gain * plasma_max / 100 * recovery_aura/4) //Divided by four because it gets massive fast. 1 is equivalent to weed regen! Only the strongest pheromones should bypass weeds


### PR DESCRIPTION
# About the pull request

Optional changes for #7135

removes weed and phero regen while on fire

# Changelog

:cl: ghostsheet
balance: Weed and Pheromones regeneration no longer heals while on fire.
/:cl:
