### PR TITLE
Fire stops Xeno regen (Berserker) 

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/ravager/berserker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/ravager/berserker.dm
@@ -73,7 +73,8 @@
 			to_chat(bound_xeno, SPAN_XENOHIGHDANGER("We feel a euphoric rush as we reach max rage! We are LOCKED at max Rage!"))
 
 	// HP vamp
-	bound_xeno.gain_health((0.05*rage + hp_vamp_ratio)*((bound_xeno.melee_damage_upper - bound_xeno.melee_damage_lower)/2 + bound_xeno.melee_damage_lower))
+	if(!bound_xeno.on_fire)
+		bound_xeno.gain_health((0.05*rage + hp_vamp_ratio)*((bound_xeno.melee_damage_upper - bound_xeno.melee_damage_lower)/2 + bound_xeno.melee_damage_lower))
 
 /datum/behavior_delegate/ravager_berserker/append_to_stat()
 	. = list()


### PR DESCRIPTION
# About the pull request

Optional changes for #7135

Beserker Ravs no longer heals while on fire

Bezerker ravs clothesline and eviscerate already doesnt heal while on fire, this PR makes zerker rav slashes not heal while on fire

# Changelog

:cl: ghostsheet
balance: Beserker Ravs no longer heals while on fire.
/:cl:
