### PR TITLE
Adds a webhook for sending the top 10 overtiming procs to discord

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -523,6 +523,8 @@ This maintains a list of ip addresses that are able to bypass topic filtering.
 
 /datum/config_entry/string/regular_adminhelp_webhook_url
 
+/datum/config_entry/string/profiler_webhook_url
+
 /datum/config_entry/string/adminhelp_webhook_pfp
 
 /datum/config_entry/string/adminhelp_webhook_name

--- a/code/controllers/subsystem/profiler.dm
+++ b/code/controllers/subsystem/profiler.dm
@@ -36,6 +36,8 @@ SUBSYSTEM_DEF(profiler)
 	if(CONFIG_GET(flag/auto_profile))
 		DumpFile(allow_yield = FALSE)
 		world.Profile(PROFILE_CLEAR, type = "sendmaps")
+	if(CONFIG_GET(string/profiler_webhook_url))
+		SendInfoToDiscord()
 	return ..()
 
 /datum/controller/subsystem/profiler/proc/StartProfiling()
@@ -69,6 +71,22 @@ SUBSYSTEM_DEF(profiler)
 	WRITE_FILE(prof_file, current_profile_data)
 	WRITE_FILE(sendmaps_file, current_sendmaps_data)
 	write_cost = MC_AVERAGE(write_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
+
+/proc/sort_overtime_data(list/A, list/B)
+	return B["over"] - A["over"]
+
+/datum/controller/subsystem/profiler/proc/SendInfoToDiscord()
+	var/current_profile_data = world.Profile(PROFILE_REFRESH, format = "json")
+	var/list/data = json_decode(current_profile_data)
+
+	sortTim(data, GLOBAL_PROC_REF(sort_overtime_data))
+
+	var/datum/discord_embed/embed = new()
+	embed.title = "Profile of Round #[GLOB.round_id] - Highest Overtiming Procs"
+	for(var/i in 1 to 10)
+		var/list/entry = data[i]
+		embed.description += "### [i] - [entry["name"]]\n**Overtime:** [entry["over"]]\n**Self Cost:** [entry["self"]]\n**Total Cost:** [entry["total"]]\n**Calls:** [entry["calls"]]\n"
+	send2webhook(embed, CONFIG_GET(string/profiler_webhook_url))
 
 #undef PROFILER_FILENAME
 #undef SENDMAPS_FILENAME

--- a/code/controllers/subsystem/profiler.dm
+++ b/code/controllers/subsystem/profiler.dm
@@ -83,9 +83,10 @@ SUBSYSTEM_DEF(profiler)
 
 	var/datum/discord_embed/embed = new()
 	embed.title = "Profile of Round #[GLOB.round_id] - Highest Overtiming Procs"
+	embed.fields = list()
 	for(var/i in 1 to 10)
 		var/list/entry = data[i]
-		embed.description += "### [i] - [entry["name"]]\n**Overtime:** [entry["over"]]\n**Self Cost:** [entry["self"]]\n**Total Cost:** [entry["total"]]\n**Calls:** [entry["calls"]]\n"
+		embed.fields[entry["name"]] = "**Overtime:** [entry["over"]], **Self Cost:** [entry["self"]], **Total Cost:** [entry["total"]], **Calls:** [entry["calls"]]"
 	send2webhook(embed, CONFIG_GET(string/profiler_webhook_url))
 
 #undef PROFILER_FILENAME

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -319,7 +319,9 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	var/webhook = CONFIG_GET(string/urgent_adminhelp_webhook_url)
 	if(!urgent)
 		webhook = CONFIG_GET(string/regular_adminhelp_webhook_url)
+	send2webhook(message_or_embed, webhook)
 
+/proc/send2webhook(message_or_embed, webhook)
 	if(!webhook)
 		return
 	var/list/webhook_info = list()


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->
As the title says. Will list out the 10 most overtiming procs. Happens at the end of a round.

Some important documentation here: Overtime is the time that a proc runs over tick for. Any amount of overtime is typically bad and, if high enough, needs to have a `CHECK_TICK` call within itself or it needs to run on a subsystem.

High amounts of overtime directly links to any of the large lagspikes you might see during gameplay. If you notice that everyone freezes for a few seconds during gameplay, that's because a proc suddenly spiked in overtime.

Incremental amounts of overtime can lead to gameplay stutters as well. It's impossible to completely eliminate overtime but it provides a good performance target for which procs have the most dangerous serverside cost, depending on how much average overtime they typically have.

# Explain why it's good for the game
Might get more visibility on procs that actually cause performance issues. Since profiler information is probably not easily available to players and contributors, this might provide an optimization goal for them, and a clear idea of what might be causing serverside lagspikes during gameplay.

# Testing Photographs and Procedure
![image](https://github.com/user-attachments/assets/6ded10e6-19c2-4bb9-9770-dfc0b28edcdb)

# Changelog
:cl:
add: Added a webhook to send the top 10 most overtiming procs to a discord webhook on server shutdown.
/:cl:
