### PR TITLE
Fixes Uniform Vendor shutters

### DIFF
--- a/code/game/machinery/doors/poddoor/shutters/shutters.dm
+++ b/code/game/machinery/doors/poddoor/shutters/shutters.dm
@@ -152,7 +152,7 @@
 		return
 
 /obj/structure/machinery/door/poddoor/shutters/almayer/uniform_vendors/attackby(obj/item/attacking_item, mob/user)
-	if(HAS_TRAIT(attacking_item, TRAIT_TOOL_CROWBAR) || attacking_item.pry_capable < IS_PRY_CAPABLE_FORCE)
+	if(HAS_TRAIT(attacking_item, TRAIT_TOOL_CROWBAR) || attacking_item.pry_capable)
 		return
 	..()
 

--- a/code/game/machinery/doors/poddoor/shutters/shutters.dm
+++ b/code/game/machinery/doors/poddoor/shutters/shutters.dm
@@ -152,7 +152,7 @@
 		return
 
 /obj/structure/machinery/door/poddoor/shutters/almayer/uniform_vendors/attackby(obj/item/attacking_item, mob/user)
-	if(HAS_TRAIT(attacking_item, TRAIT_TOOL_CROWBAR))
+	if(HAS_TRAIT(attacking_item, TRAIT_TOOL_CROWBAR) || attacking_item.pry_capable < IS_PRY_CAPABLE_FORCE)
 		return
 	..()
 


### PR DESCRIPTION

# About the pull request

They're not meant to be forced open.

# Explain why it's good for the game

Prevents people breaking into the uniform vendors.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixes uniform vendor shutters being openable without access.
/:cl:
