### PR TITLE
Grants the ASO the senior command headset (Same as XO)

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/senior_officers.dm
+++ b/code/game/machinery/vending/vendor_types/crew/senior_officers.dm
@@ -483,7 +483,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_auxiliary_officer, list(
 		list("STANDARD EQUIPMENT (TAKE ALL)", 0, null, null, null),
 		list("Insulated Gloves", 0, /obj/item/clothing/gloves/yellow, MARINE_CAN_BUY_GLOVES, VENDOR_ITEM_MANDATORY),
 		list("Officer Uniform", 0, /obj/item/clothing/under/marine/officer/bridge, MARINE_CAN_BUY_UNIFORM, VENDOR_ITEM_MANDATORY),
-		list("Headset", 0, /obj/item/device/radio/headset/almayer/qm, MARINE_CAN_BUY_EAR, VENDOR_ITEM_MANDATORY),
+		list("Headset", 0, /obj/item/device/radio/headset/almayer/mcom/cdrcom, MARINE_CAN_BUY_EAR, VENDOR_ITEM_MANDATORY),
 		list("Auxiliary Support Officer Jacket", 0, /obj/item/clothing/suit/storage/jacket/marine/service/aso, MARINE_CAN_BUY_MRE, VENDOR_ITEM_MANDATORY),
 
 		list("BAG (CHOOSE 1)", 0, null, null, null),

--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -698,7 +698,7 @@
 	if (new_human.client && new_human.client.prefs && (new_human.client.prefs.backbag == 1))
 		back_item = /obj/item/storage/backpack/marine
 
-	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/mcom/alt(new_human), WEAR_L_EAR)
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/mcom/cdrcom(new_human), WEAR_L_EAR)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/officer/bridge(new_human), WEAR_BODY)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/jacket/marine/service/aso(new_human), WEAR_JACKET)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine(new_human), WEAR_FEET)


### PR DESCRIPTION

# About the pull request

This pull request grants the ASO the senior command headset similarly to the XO and also allows him to dispense one from his locker, granting him access to the MP channel.

# Explain why it's good for the game

The ASO is the third in command in the ship, and carries substantial weight not only in ship-side affairs, but also in taking command of the operation when the XO is absent in CiC.

It is clear enough that the ASO carries substantial authority, to the point that it is one of the non-MP roles that has access to the brig, and a high playtime ASO gains the rank of Captain, same as the XO.

Additionally, the ASO tends to be the prime subject for delegation of appeals when the XO is too busy with their head in the op.

Despite all of this, the ASO has no access to the MP channel on their radio. I believe this should change (and perhaps, we should also change the default SOP to allow the ASO to take initiative to step in for appeals instead of the XO if the XO is unable to attend the appeal without requiring delegation. I've seen enough appeals time out and XOs be hit with DoD because they were too distracted processing the flood of information that goes on constantly in the CiC.)

# Testing Photographs and Procedure

Shouldn't be necessary, but feel free to look at the code in case I may have done something wrong.

# Changelog

:cl:
add: ASO now starts with a senior command headset (and thus access to the MP radio channel.) and can also get a new one from their locker.
/:cl: