### PR TITLE
Decreases time required to print dropship equipment

### DIFF
--- a/code/modules/cm_marines/vehicle_part_fabricator.dm
+++ b/code/modules/cm_marines/vehicle_part_fabricator.dm
@@ -65,7 +65,7 @@
 		omnisentry_price += omnisentry_price_scale
 	icon_state = "drone_fab_active"
 	busy = TRUE
-	addtimer(CALLBACK(src, PROC_REF(do_build_part), part_type), 10 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(do_build_part), part_type), 3 SECONDS)
 
 /obj/structure/machinery/part_fabricator/proc/do_build_part(part_type)
 	busy = FALSE


### PR DESCRIPTION


# About the pull request
Decreases the time required to print dropship equipment to 3 seconds from 10. 

# Explain why it's good for the game

10 seconds of waiting per piece of equipment can be kind of mind-numbing over the course of multiple rounds if you're trying to print multiple modules or weapons for the dropships. It also cuts down on time you can be about the ship pre-drop roleplaying or otherwise. Should make things less annoying. I don't consider this a balance change because CAS points already exist, though feel free to correct the tags if I'm wrong. 


# Testing Photographs and Procedure
Booted up server, printed CAS missile. It takes 3 seconds 

<details>
<summary>Screenshots & Videos</summary>

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Decreased dropship equipment printing time to 3 seconds from 10 seconds. 
/:cl:

