### PR TITLE
increases bullet hit accuracy to  CL’s ES-4

### DIFF
--- a/code/datums/ammo/bullet/pistol.dm
+++ b/code/datums/ammo/bullet/pistol.dm
@@ -94,6 +94,8 @@
 	name = "stun pistol bullet"
 	sound_override = null
 
+	accuracy = HIT_ACCURACY_TIER_4
+
 // Used by M1911, Deagle and KT-42
 /datum/ammo/bullet/pistol/heavy
 	name = "heavy pistol bullet"


### PR DESCRIPTION
# About the pull request
this PR increases the hit accuracy of the CL’s Sidearm, with this change the bullets it fires will have hit accuracy tier 4.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Due to CL being a pleb and having 0 firearms skill, the accuracy of the ES-4 was severely decreased causing most of your shots missing due to RNG making it almost useless when compared to pepper spray. additionally the ES-4 was advertised as being very accurate in its description when that wasn’t the case.

By the way I am completely open to change so if you have any complaints I’ll take them to heart ❤️.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: buffed the stun subtype of rubber bullets to have hit accuracy tier 4
/:cl:
