### PR TITLE
Fixes duplicate badges on marine recruiter surv

### DIFF
--- a/code/modules/gear_presets/survivors/solaris/preset_solaris.dm
+++ b/code/modules/gear_presets/survivors/solaris/preset_solaris.dm
@@ -85,7 +85,6 @@
 
 /datum/equipment_preset/survivor/uscm/solaris/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/officer/bridge(new_human), WEAR_BODY)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/ranks/marine/e5(new_human), WEAR_ACCESSORY)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/marine/satchel(new_human), WEAR_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/jacket/marine/service(new_human), WEAR_JACKET)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/belt/gun/m4a3/full(new_human), WEAR_WAIST)


### PR DESCRIPTION

# About the pull request

fixes issue #7011
removes extra rank pin

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: fixes duplicate rank pins on marine recruiter survivor
/:cl:
