### PR TITLE
MPs now latejoin in the Brig

### DIFF
--- a/code/game/objects/effects/landmarks/landmarks.dm
+++ b/code/game/objects/effects/landmarks/landmarks.dm
@@ -434,6 +434,18 @@
 	name = "Intelligence Officer late join"
 	job = JOB_INTEL
 
+/obj/effect/landmark/late_join/police
+	name = "Military Police late join"
+	job = JOB_POLICE
+
+/obj/effect/landmark/late_join/warden
+	name = "Military Warden late join"
+	job = JOB_WARDEN
+
+/obj/effect/landmark/late_join/chief_police
+	name = "Chief Military Police late join"
+	job = JOB_CHIEF_POLICE
+
 /obj/effect/landmark/late_join/Initialize(mapload, ...)
 	. = ..()
 	if(squad)

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -23597,6 +23597,7 @@
 	icon_state = "E";
 	pixel_x = 1
 	},
+/obj/effect/landmark/late_join/warden,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cryo)
 "fSl" = (
@@ -53061,6 +53062,7 @@
 	icon_state = "W";
 	layer = 2.5
 	},
+/obj/effect/landmark/late_join/police,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cryo)
 "sbZ" = (
@@ -57390,6 +57392,7 @@
 	icon_state = "E";
 	pixel_x = 1
 	},
+/obj/effect/landmark/late_join/chief_police,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cryo)
 "tQL" = (
@@ -63259,6 +63262,7 @@
 	icon_state = "E";
 	pixel_x = 1
 	},
+/obj/effect/landmark/late_join/police,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cryo)
 "wei" = (


### PR DESCRIPTION

# About the pull request

MPs now latejoin in the Brig as opposed to cryo.

# Explain why it's good for the game

Alot of other shipside roles have dedicated latejoin spots, (and most others like Marines having ones close to prep) and having one as MP in cryo, more than anything is a hassle as you have to run across the *entire* ship just to gear up, esp on Red Alert.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: MPs now latejoin in the Brig
/:cl:
