### PR TITLE
revolver changes (goldendarkness edition)

### DIFF
--- a/code/datums/ammo/bullet/revolver.dm
+++ b/code/datums/ammo/bullet/revolver.dm
@@ -23,12 +23,14 @@
 	name = "heavy revolver bullet"
 
 	damage = 35
+	accurate_range = 4
 	penetration = ARMOR_PENETRATION_TIER_4
 	accuracy = HIT_ACCURACY_TIER_3
 
-/datum/ammo/bullet/revolver/heavy/on_hit_mob(mob/entity, obj/projectile/bullet)
-	slowdown(entity, bullet)
-	pushback(entity, bullet, 4)
+/datum/ammo/bullet/revolver/heavy/on_hit_mob(mob/M, obj/projectile/p)
+	if(p.distance_travelled > accurate_range)
+		return
+	shake_camera(M, 8, 5)
 
 /datum/ammo/bullet/revolver/incendiary
 	name = "incendiary revolver bullet"


### PR DESCRIPTION

# About the pull request

Makes m44 heavy revolver ammo give a screen shake effect. Revive and modernization of #4014 

# Explain why it's good for the game

Heavy revolver ammo is currently the worst sidearm ammo in the game. the damage is pitiful, and it's main use reason, the stun, was removed and replace with a comically bad slow. It's now at the point where it most likely helps xenos more then it hurts them. A screenshake effect allows it to be a good "fuck off" weapon without returning to toxic stun combat or being OP. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
add: Heavy revolver ammo now inflicts a screen shake effect, as opposed to a small slow. 
/:cl:

