### PR TITLE
Adds a Bomb Suit/EOD Locker to the MP Armory

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -18318,7 +18318,7 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/obj/structure/closet/bombcloset,
+/obj/structure/closet/bombclosetsecurity,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
 "dFk" = (

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -18315,13 +18315,10 @@
 /turf/open/floor/almayer/redfull,
 /area/almayer/living/briefing)
 "dEX" = (
-/obj/structure/closet/secure_closet/guncabinet/riot_control,
-/obj/item/weapon/shield/riot,
-/obj/item/weapon/shield/riot,
-/obj/item/weapon/shield/riot,
 /obj/structure/machinery/light{
 	dir = 1
 	},
+/obj/structure/closet/bombcloset,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
 "dFk" = (
@@ -22861,12 +22858,7 @@
 /turf/open/floor/almayer/red/northwest,
 /area/almayer/living/offices/flight)
 "fAr" = (
-/obj/structure/closet/secure_closet/guncabinet/red{
-	name = "red level EOD cabinet"
-	},
-/obj/item/clothing/suit/bomb_suit/security,
-/obj/item/clothing/head/bomb_hood/security,
-/obj/item/storage/toolbox/mechanical,
+/obj/structure/closet/secure_closet/guncabinet/red/mp_armory_m39_submachinegun,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
 "fBi" = (

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -22861,7 +22861,11 @@
 /turf/open/floor/almayer/red/northwest,
 /area/almayer/living/offices/flight)
 "fAr" = (
-/obj/structure/closet/secure_closet/guncabinet/red/mp_armory_m39_submachinegun,
+/obj/structure/closet/secure_closet/guncabinet/red{
+	name = "red level EOD cabinet"
+	},
+/obj/item/clothing/suit/bomb_suit/security,
+/obj/item/clothing/head/bomb_hood/security,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
 "fBi" = (

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -22866,6 +22866,7 @@
 	},
 /obj/item/clothing/suit/bomb_suit/security,
 /obj/item/clothing/head/bomb_hood/security,
+/obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
 "fBi" = (


### PR DESCRIPTION

# About the pull request

Replaces one of the Riot Lockers in the Armory with one EOD Locker. (Same one found in OT Room but the Sec variant)

# Explain why it's good for the game

As it stands, if MPs, or even the ship receives a bomb threat, the only relatively safe way of dealing with it is breaking into OT for their Bomb Suit Locker. MPs should have their own way of dealing with bomb threats without taking things from unrelated crew.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Added an EOD Locker in the MP Armory.
/:cl:
