### PR TITLE
Disables New Varadero from the current map pool. 

### DIFF
--- a/map_config/maps.txt
+++ b/map_config/maps.txt
@@ -58,6 +58,7 @@ map lv522_chances_claim
 endmap
 
 map new_varadero
+	disabled
 endmap
 
 map whiskey_outpost_v2


### PR DESCRIPTION

# About the pull request
Removes varadero from the voting pool
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
In it's current state, Varadero is a fundamentally broken map seemingly made from half of a old map. It suffers from instant FOB sieges, leading to just incredibly boring rounds for both sides and there are seemingly very few people who like the map. 

My last PR was denied on grounds of a rework being in progress and "just don't vote for it", but seeing as the map vote system forces people to play it when there's 2-6 trolls voting for it every round, and the person making the rework has abandoned the rework, I think it's fair to remove it from the map pool, especially now that Chances Claim is a lowpop map.


# Changelog
:cl:

del: New Varadero can no longer be voted for 

/:cl:
