### PR TITLE
loyalist equivalent to mutineers

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -190,6 +190,7 @@
 #define MUTINEER (1<<4)  // Part of the Mutiny Gang
 #define GIVING (1<<5) // Is currently trying to give an item to someone
 #define NOBIOSCAN (1<<6)
+#define LOYALIST (1<<7) // Part of the Loyalist Gang
 
 //=================================================
 

--- a/code/modules/admin/player_panel/actions/antag.dm
+++ b/code/modules/admin/player_panel/actions/antag.dm
@@ -19,6 +19,22 @@
 	var/title = params["leader"]? "mutineer leader" : "mutineer"
 	message_admins("[key_name_admin(user)] has made [key_name_admin(H)] into a [title].")
 
+
+// LOYALIST
+/datum/player_action/make_loyalist/act(client/user, mob/target, list/params)
+	if(!ishuman(target))
+		to_chat(user, SPAN_WARNING("This can only be done to instances of type /mob/living/carbon/human"))
+		return
+
+	var/mob/living/carbon/human/H = target
+	var/datum/equipment_preset/preset = GLOB.gear_path_presets_list[/datum/equipment_preset/other/loyalist]
+	if(params["leader"])
+		preset = GLOB.gear_path_presets_list[/datum/equipment_preset/other/loyalist/leader]
+
+	preset.load_status(H)
+	var/title = params["leader"]? "loyalist leader" : "loyalist"
+	message_admins("[key_name_admin(user)] has made [key_name_admin(H)] into a [title].")
+
 // XENO
 /datum/player_action/change_hivenumber
 	action_tag = "xeno_change_hivenumber"

--- a/code/modules/admin/topic/topic.dm
+++ b/code/modules/admin/topic/topic.dm
@@ -858,6 +858,24 @@
 
 		message_admins("[key_name_admin(usr)] has made [key_name_admin(H)] into a mutineer leader.")
 
+	else if(href_list["makeloyalist"])
+		if(!check_rights(R_DEBUG|R_SPAWN))
+			return
+
+		var/mob/living/carbon/human/H = locate(href_list["makeloyalist"])
+		if(!istype(H))
+			to_chat(usr, "This can only be done to instances of type /mob/living/carbon/human")
+			return
+
+		if(H.faction != FACTION_MARINE)
+			to_chat(usr, "This player's faction must equal '[FACTION_MARINE]' to make them a loyalist.")
+			return
+
+		var/datum/equipment_preset/other/loyalist/leader/leader_preset = new()
+		leader_preset.load_status(H)
+
+		message_admins("[key_name_admin(usr)] has made [key_name_admin(H)] into a loyalist leader.")
+
 	else if(href_list["makecultist"] || href_list["makecultistleader"])
 		if(!check_rights(R_DEBUG|R_SPAWN))
 			return

--- a/code/modules/gear_presets/other.dm
+++ b/code/modules/gear_presets/other.dm
@@ -28,6 +28,30 @@
 	for(var/type in abilities)
 		give_action(new_human, type)
 
+/datum/equipment_preset/other/loyalist
+	name = "Loyalist"
+	flags = EQUIPMENT_PRESET_EXTRA
+
+/datum/equipment_preset/other/loyalist/load_status(mob/living/carbon/human/new_human)
+	. = ..()
+	new_human.mob_flags |= LOYALIST
+	new_human.hud_set_squad()
+
+	to_chat(new_human, SPAN_HIGHDANGER("<hr>You are now a Loyalist!"))
+	to_chat(new_human, SPAN_DANGER("Please check the rules to see what you can and can't do as a loyalist.<hr>"))
+
+/datum/equipment_preset/other/loyalist/leader
+	name = "Loyalist Leader"
+	flags = EQUIPMENT_PRESET_EXTRA
+
+/datum/equipment_preset/other/loyalist/leader/load_status(mob/living/carbon/human/new_human)
+	for(var/datum/action/human_action/activable/loyalist/A in new_human.actions)
+		A.remove_from(new_human)
+
+	var/list/abilities = subtypesof(/datum/action/human_action/activable/loyalist)
+	for(var/type in abilities)
+		give_action(new_human, type)
+
 /datum/equipment_preset/other/freelancer
 	name = "Freelancer"
 

--- a/code/modules/mob/living/carbon/human/human_abilities.dm
+++ b/code/modules/mob/living/carbon/human/human_abilities.dm
@@ -135,12 +135,12 @@
 
 	var/list/target_list = list()
 	for(var/mob/living/carbon/possible_target in view(7, human_owner))
-		if(possible_target == human_owner || !possible_target.client) 
+		if(possible_target == human_owner || !possible_target.client)
 			continue
 		target_list += possible_target
 
 	var/mob/living/carbon/target_mob = tgui_input_list(human_owner, "Target", "Send a Psychic Whisper to whom?", target_list, theme = "hive_status")
-	if(!target_mob) 
+	if(!target_mob)
 		return
 
 	human_owner.psychic_whisper(target_mob)
@@ -567,6 +567,39 @@ CULT
 
 	message_admins("[key_name_admin(H)] has begun the mutiny.")
 	remove_from(H)
+
+
+/datum/action/human_action/activable/loyalist
+	name = "Loyalist abilities"
+
+/datum/action/human_action/activable/loyalist/loyalist_convert
+	name = "Convert"
+	action_icon_state = "mutineer_convert" //need someone to sprite icon
+
+
+/datum/action/human_action/activable/loyalist/loyalist_convert/use_ability(mob/M)
+	if(!can_use_action())
+		return
+
+	var/mob/living/carbon/human/H = owner
+	var/mob/living/carbon/human/chosen = M
+
+	if(!istype(chosen))
+		return
+
+	to_chat(H, SPAN_NOTICE("Loyalist join request sent to [chosen]!"))
+
+	if(tgui_alert(chosen, "Do you want to be a loyalist?", "Become Loyalist", list("Yes", "No")) != "Yes")
+		return
+	var/datum/equipment_preset/other/loyalist/XC = new()
+	XC.load_status(chosen)
+	to_chat(chosen, SPAN_WARNING("You'll become a loyalist when the mutiny begins. Prepare yourself and do not cause any harm until you've been made into a loyalist."))
+
+	message_admins("[key_name_admin(chosen)] has been converted into a loyalist by [key_name_admin(H)].")
+
+
+
+
 
 
 /datum/action/human_action/cancel_view // cancel-camera-view, but a button

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1119,7 +1119,7 @@
 	if(SEND_SIGNAL(src, COMSIG_XENO_BULLET_ACT, damage_result, ammo_flags, P) & COMPONENT_CANCEL_BULLET_ACT)
 		return
 
-	if(damage_result)
+	if(damage)
 		//only apply the blood splatter if we do damage
 		handle_blood_splatter(get_dir(P.starting, loc))
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1119,7 +1119,7 @@
 	if(SEND_SIGNAL(src, COMSIG_XENO_BULLET_ACT, damage_result, ammo_flags, P) & COMPONENT_CANCEL_BULLET_ACT)
 		return
 
-	if(damage)
+	if(damage_result)
 		//only apply the blood splatter if we do damage
 		handle_blood_splatter(get_dir(P.starting, loc))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
I NEED SPRITE FOR LOYALIS ICON PLEASE HELP
adds support to create loyalist eqivalent to mutineers to make mutinees more readable so both sides know who is with them

# Explain why it's good for the game

not knowing who is with you during mutiny is kinda shit, same reason as the mutineers have their stuff

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Loyalists and loyalist leader added to make mutiny better
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
