### PR TITLE
Clear armor lamp overlays

### DIFF
--- a/code/modules/clothing/suits/marine_armor/_marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor/_marine_armor.dm
@@ -137,6 +137,7 @@
 
 /obj/item/clothing/suit/storage/marine/update_icon(mob/user)
 	var/image/I
+	overlays -= armor_overlays["lamp"]
 	armor_overlays["lamp"] = null
 	if(flags_marine_armor & ARMOR_LAMP_OVERLAY)
 		if(flags_marine_armor & ARMOR_LAMP_ON)


### PR DESCRIPTION

# About the pull request

Before adding a new armor lamp overlay, remove the old one.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Potentially infinitely stacking overlays bad.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Master, toggling lamp 10x:
![image](https://github.com/user-attachments/assets/4af9239c-01a3-4227-8fca-e97eb250d0d8)

PR, toggling lamp 10x:
![image](https://github.com/user-attachments/assets/2780a33b-6eed-4c7d-a20f-f3bf798ad20d)

</details>


# Changelog
No player facing changes.
