### PR TITLE
predator buffs

### DIFF
--- a/code/modules/cm_preds/yaut_items.dm
+++ b/code/modules/cm_preds/yaut_items.dm
@@ -123,7 +123,7 @@
 	armor_bio = CLOTHING_ARMOR_HIGH
 	armor_rad = CLOTHING_ARMOR_HIGH
 	armor_internaldamage = CLOTHING_ARMOR_HIGH
-	slowdown = 1
+	slowdown = 0.75
 	var/speed_timer = 0
 	item_state_slots = list(WEAR_JACKET = "fullarmor")
 	allowed = list(
@@ -282,7 +282,7 @@
 	min_cold_protection_temperature = ICE_PLANET_MIN_COLD_PROT
 
 	armor_melee = CLOTHING_ARMOR_LOW
-	armor_bullet = CLOTHING_ARMOR_LOW
+	armor_bullet = CLOTHING_ARMOR_MEDIUMLOW
 	armor_laser = CLOTHING_ARMOR_MEDIUM
 	armor_energy = CLOTHING_ARMOR_MEDIUM
 	armor_bomb = CLOTHING_ARMOR_MEDIUMHIGH
@@ -295,7 +295,7 @@
 	desc = "A set of very fine chainlink in a meshwork for comfort and utility."
 
 	armor_melee = CLOTHING_ARMOR_LOW
-	armor_bullet = CLOTHING_ARMOR_LOW
+	armor_bullet = CLOTHING_ARMOR_MEDIUM
 	armor_laser = CLOTHING_ARMOR_MEDIUMHIGH
 	armor_energy = CLOTHING_ARMOR_MEDIUMHIGH
 	armor_bomb = CLOTHING_ARMOR_HIGH


### PR DESCRIPTION
# About the pull request

It's a nudge in the right direction for the predator WL, as they've been severely underpowered ever since the "glass cannon" idea. The glass cannon idea is simply too weird for us, as we were supposed to give more damage but the rework got abandoned and we were stuck with low armor. In it's current state, any above average marine can very easily kill a predator. This change will hopefully turn them into something more than a loot pinata.

# Explain why it's good for the game

As apart of the glass cannon predator rework, predators had their armor reduced; although the rework got abandoned and we were stuck with low survivability and low damage. This PR is good for the game as it'll make the fights last longer, the predators will cornerslime (and slime in general) less and make predators pose an actual threat instead of being easier to kill than xenomorphs
I also increased the armor of thralls because they've been completely abandoned as one marine with 2 bullets could easily ruin their round. Now it takes around 3-4 🗡️ 
I fully intend to revisit this when the xeno buff (to preds) comes along, @Git-Nivrak get on ittttt
I'll be closely maintaining an eye in case of a testmerge.

# Testing Photographs and Procedure

its a numberchange

# Changelog

:cl: stalkerino
balance: Buffed predator armor, thrall armor,  bullet resistance has been raised. Heavy clan armor has slightly less slowdown (by 1 tier)
/:cl:
