### PR TITLE
bracer buff for predators

### DIFF
--- a/code/modules/cm_preds/yaut_bracers.dm
+++ b/code/modules/cm_preds/yaut_bracers.dm
@@ -87,9 +87,9 @@
 	if(charge < charge_max)
 		var/charge_increase = charge_rate
 		if(is_ground_level(human_holder.z))
-			charge_increase = charge_rate / 6
+			charge_increase = charge_rate / 12
 		else if(is_mainship_level(human_holder.z))
-			charge_increase = charge_rate / 3
+			charge_increase = charge_rate / 9
 
 		charge = min(charge + charge_increase, charge_max)
 		var/perc_charge = (charge / charge_max * 100)


### PR DESCRIPTION
# About the pull request

Increases the recharge rate for the Yautja bracer

# Explain why it's good for the game

It allows Yautjas to actually play the game more, bracers are very rarely used for combat if ever in a round. I don't expect my whitelistees to AFK for 10 minutes because they can't use the NVGs to play the game anymore. 

# Testing Photographs and Procedure

numberchange


# Changelog

:cl:
balance:  increased recharge for pred bracer 
/:cl:

