### PR TITLE
Sentinel buffs

### DIFF
--- a/code/__DEFINES/weapon_stats.dm
+++ b/code/__DEFINES/weapon_stats.dm
@@ -66,7 +66,7 @@ It DOES NOT control where your bullets go, that's scatter and projectile varianc
 ////SCATTER////
 */
 
-#define SCATTER_AMOUNT_NEURO 60
+#define SCATTER_AMOUNT_NEURO 45
 #define SCATTER_AMOUNT_TIER_1 15
 #define SCATTER_AMOUNT_TIER_2 10
 #define SCATTER_AMOUNT_TIER_3 8

--- a/code/datums/ammo/xeno.dm
+++ b/code/datums/ammo/xeno.dm
@@ -55,7 +55,7 @@
 				return
 
 		if(ishuman(M))
-			M.apply_effect(2.5, SUPERSLOW)
+			M.apply_effect(4, SUPERSLOW)
 			M.visible_message(SPAN_DANGER("[M]'s movements are slowed."))
 
 		var/no_clothes_neuro = FALSE

--- a/code/datums/ammo/xeno.dm
+++ b/code/datums/ammo/xeno.dm
@@ -55,7 +55,7 @@
 				return
 
 		if(ishuman(M))
-			M.apply_effect(3, SUPERSLOW)
+			M.apply_effect(4, SUPERSLOW)
 			M.visible_message(SPAN_DANGER("[M]'s movements are slowed."))
 
 		var/no_clothes_neuro = FALSE

--- a/code/datums/ammo/xeno.dm
+++ b/code/datums/ammo/xeno.dm
@@ -55,7 +55,7 @@
 				return
 
 		if(ishuman(M))
-			M.apply_effect(4, SUPERSLOW)
+			M.apply_effect(3, SUPERSLOW)
 			M.visible_message(SPAN_DANGER("[M]'s movements are slowed."))
 
 		var/no_clothes_neuro = FALSE

--- a/code/modules/mob/living/carbon/xenomorph/abilities/sentinel/sentinel_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/sentinel/sentinel_abilities.dm
@@ -6,7 +6,7 @@
 	macro_path = /datum/action/xeno_action/verb/verb_slowing_spit
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_1
-	xeno_cooldown = 1.5 SECONDS
+	xeno_cooldown = 2 SECONDS
 	plasma_cost = 20
 
 // Scatterspit
@@ -17,7 +17,7 @@
 	macro_path = /datum/action/xeno_action/verb/verb_scattered_spit
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_2
-	xeno_cooldown = 8 SECONDS
+	xeno_cooldown = 6 SECONDS
 	plasma_cost = 30
 
 // Paralyzing slash
@@ -32,3 +32,19 @@
 	plasma_cost = 50
 
 	var/buff_duration = 50
+
+/datum/action/xeno_action/activable/hibernate
+	name = "hibernate"
+	action_icon_state = "warden_heal"
+	ability_name = "hibernate"
+	macro_path = /datum/action/xeno_action/verb/verb_hibernate
+	action_type = XENO_ACTION_CLICK
+	ability_primacy = XENO_PRIMARY_ACTION_4
+	xeno_cooldown = 50 SECONDS
+	plasma_cost = 150
+
+	var/regeneration_amount_total = 500
+	var/regeneration_ticks = 10
+	var/plasma_amount = 400
+	var/plasma_time = 10
+	var/time_between_plasmas = 1

--- a/code/modules/mob/living/carbon/xenomorph/abilities/sentinel/sentinel_macros.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/sentinel/sentinel_macros.dm
@@ -18,3 +18,10 @@
 	set hidden = TRUE
 	var/action_name = "Paralyzing Slash"
 	handle_xeno_macro(src,action_name)
+
+/datum/action/xeno_action/verb/verb_hibernate()
+	set category = "Alien"
+	set name = "hibernate"
+	set hidden = TRUE
+	var/action_name = "hibernate"
+	handle_xeno_macro(src,action_name)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Sentinel.dm
@@ -11,15 +11,15 @@
 	xeno_explosion_resistance = XENO_EXPLOSIVE_ARMOR_TIER_1
 	armor_deflection = XENO_NO_ARMOR
 	evasion = XENO_EVASION_NONE
-	speed = XENO_SPEED_TIER_7
+	speed = XENO_SPEED_HELLHOUND
 
 	caste_desc = "A weak ranged combat alien."
 	evolves_to = list(XENO_CASTE_SPITTER)
 	deevolves_to = list("Larva")
 	acid_level = 1
 
-	tackle_min = 4
-	tackle_max = 4
+	tackle_min = 3
+	tackle_max = 3
 	tackle_chance = 50
 	tacklestrength_min = 4
 	tacklestrength_max = 4
@@ -49,6 +49,7 @@
 		/datum/action/xeno_action/activable/slowing_spit, //first macro
 		/datum/action/xeno_action/activable/scattered_spit, //second macro
 		/datum/action/xeno_action/onclick/paralyzing_slash, //third macro
+		/datum/action/xeno_action/activable/hibernate, //fourth macro
 		/datum/action/xeno_action/onclick/tacmap,
 	)
 	inherent_verbs = list(
@@ -68,7 +69,7 @@
 	// State
 	var/next_slash_buffed = FALSE
 
-#define NEURO_TOUCH_DELAY 4 SECONDS
+#define NEURO_TOUCH_DELAY 3 SECONDS
 
 /datum/behavior_delegate/sentinel_base/melee_attack_modify_damage(original_damage, mob/living/carbon/carbon_target)
 	if (!next_slash_buffed)
@@ -103,6 +104,6 @@
 #undef NEURO_TOUCH_DELAY
 
 /datum/behavior_delegate/sentinel_base/proc/paralyzing_slash(mob/living/carbon/human/human_target)
-	human_target.KnockDown(2)
-	human_target.Stun(2)
+	human_target.KnockDown(2.5)
+	human_target.Stun(2.5)
 	to_chat(human_target, SPAN_XENOHIGHDANGER("You fall over, paralyzed by the toxin!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Revives https://github.com/cmss13-devs/cmss13/pull/4023 - was never told what the problem with it was and the sentinel issues are undeniably still present. Would rather not leave a rework that I started unfinished.

Follows-up on my old sentinel rework to buff its ability to 1v1 and address a bunch of other issues.
The initial design goal was to turn the annoying bodyblocker into an offensive support caste with strong abilities for a t1 - but unable to make good use of them by itself, thus heavily reliant on teamwork.
I initially worried about them being too strong and overdid the necessity for perfect play in 1v1 scenarios, leading to them struggling too much to the point where capturing even a lone out of position marine is way too difficult.

# Explain why it's good for the game

- Hibernate ability (see videos section)

Their entire kit is about supporting and working with other caste, which requires them walking out with bulkier t2s and t3s and leads to them eating a ton of bullets that they’re ill-suited to tank.
Compounded with said teamwork often being unreliable (either because the damage was too high for sent to follow, the players just didn’t mesh very well or the spit was blocked by xenos) and their super slow healing it can be frustrating to play when on such a bad streak of achieving nothing and having to rest.
Therefore the "hibernate" ability, to mitigate the downtime somewhat and better allow it to actually support the tankier frontline xenos.
Also considering sentinels are supposed to guard the hive I think it’s cool and fitting to have an ability centered on hibernating somewhere.

- Speed increase

To let and encourage them to support backliners aswell as make it easier to work near the front, getting into a position from which you can spit without getting blocked and avoiding damage since sent has has 0 armor.

- Tackle and paralyzing slash buffs 

Currently the window to tackle successfully off the slash stun is extremely tight, you’d have to start tackling the moment the marine falls down which in practice just almost never happens. Current proc timer also gives too much leeway in getting away before getting downed. Might still be too much

- Neuro

Less spammy, more impactful and easier to chain with other abilities.

- Scatter spit

The spread cone was too wide and more unreliable at hitting than intended. Technically a nerf since it won't hit as wide of an area anymore. Cooldown lowered to give more impact when things are going well and reward taking the risk of staying in combat.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>


https://github.com/user-attachments/assets/12946cd7-12a8-4d4d-b74f-cb4fcd396cfc



</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Sentinel new ability - "Hibernate" - causes them to enter a 10 second sleep that restores their health and plasma to full. Requires weeds. 50 second cd and 150 plasma cost.
balance: Sentinel neuro spit cooldown raised 1.5 to 2s, superslow 2.5 to 4s
balance: Sentinel scatter spit scatter lowered 60 to 45, cooldown lowered 8s to 6s
balance: Sentinel paralyzing slash stuns after 3 seconds instead of 4 and lasts 2.5 seconds from 2.
balance: Sentinel speed raised from -0.8 to -1
balance: Sentinel tackle now requires 3 attempts instead of 4.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
