### PR TITLE
I cast: Bullshit rocks BE GONE IN ACID.

### DIFF
--- a/code/game/objects/structures/props.dm
+++ b/code/game/objects/structures/props.dm
@@ -202,8 +202,6 @@
 	icon_state = "boulder1"
 	desc = "A large rock. It's not cooking anything."
 	icon = 'icons/obj/structures/props/dam.dmi'
-	unslashable = TRUE
-	unacidable = TRUE
 /obj/structure/prop/dam/boulder/boulder1
 	icon_state = "boulder1"
 /obj/structure/prop/dam/boulder/boulder2
@@ -218,8 +216,6 @@
 	icon = 'icons/obj/structures/props/boulder_large.dmi'
 	bound_height = 64
 	bound_width = 64
-	unslashable = TRUE
-	unacidable = TRUE
 /obj/structure/prop/dam/large_boulder/boulder1
 	icon_state = "boulder_large1"
 /obj/structure/prop/dam/large_boulder/boulder2


### PR DESCRIPTION
# About the pull request

I am working on Kutjevo Rework: #6971

I have plans of adding large quantities of boulders to area called "Stony Fields".

# Explain why it's good for the game

Some person was sadistic, because for some reason, you can melt wide boulders 1x2, but you are unable to melt 1x1 boulders or large 2x2 boulders, this PR allow you to melt this rocks, if you are not convinced, there is photo of one bullshit spot  on trijent dam below.

And to be serious, it just don't make sense you can melt wide boulders, but other variants are unmeltable, if its made from same rock, make them all equal, and not some wierd "this one can be melted but other do not" type of logic.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/9cd6cbb1-7484-413b-9e7d-046814bcc2f9)

</details>


# Changelog
:cl:
code: Removed code for some boudlers, removed code makes boulders meltable and destructable by large explosions.
/:cl:
