### PR TITLE
Increases pred round chance whenever it isn't a pred round

### DIFF
--- a/code/datums/entities/predround_chance.dm
+++ b/code/datums/entities/predround_chance.dm
@@ -6,7 +6,7 @@
 	entity_type = /datum/entity/predround_chance
 	table_name = "predround_chance"
 	field_types = list(
-		"chance"=DB_FIELDTYPE_BIGINT,
+		"chance" = DB_FIELDTYPE_BIGINT,
 	)
 
 /datum/view_record/predround_chance

--- a/code/datums/entities/predround_chance.dm
+++ b/code/datums/entities/predround_chance.dm
@@ -18,5 +18,5 @@
 	destination_entity = /datum/view_record/predround_chance
 	fields = list(
 		"id",
-		"chance"
+		"chance",
 	)

--- a/code/datums/entities/predround_chance.dm
+++ b/code/datums/entities/predround_chance.dm
@@ -1,0 +1,22 @@
+/datum/entity/predround_chance
+	var/chance
+
+
+/datum/entity_meta/predround_chance
+	entity_type = /datum/entity/predround_chance
+	table_name = "predround_chance"
+	field_types = list(
+		"chance"=DB_FIELDTYPE_BIGINT,
+	)
+
+/datum/view_record/predround_chance
+	var/id
+	var/chance
+
+/datum/entity_view_meta/stickyban
+	root_record_type = /datum/entity/predround_chance
+	destination_entity = /datum/view_record/predround_chance
+	fields = list(
+		"id",
+		"chance"
+	)

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -209,13 +209,27 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 	if(istype(CO_surv_job))
 		CO_surv_job.set_spawn_positions(GLOB.players_preassigned)
 
-	if(SSnightmare.get_scenario_value("predator_round") && !Check_WO())
+	var/chance
+	var/pred_round = FALSE
+	var/datum/view_record/predround_chance/meta = locate() in DB_VIEW(/datum/view_record/predround_chance, DB_COMP("id", DB_EQUALS, 1))
+	if(!meta)
+		var/datum/entity/predround_chance/entity = DB_ENTITY(/datum/entity/predround_chance, 1)
+		entity.chance = 0 // This is 0 instead of 20 because it is going to get increased in modify_pred_round_chance
+		chance = 20
+		entity.save()
+	else
+		chance = meta.chance
+
+	if(prob(chance) && !Check_WO())
+		pred_round = TRUE
 		SSticker.mode.flags_round_type |= MODE_PREDATOR
 		// Set predators starting amount based on marines assigned
 		var/datum/job/PJ = temp_roles_for_mode[JOB_PREDATOR]
 		if(istype(PJ))
 			PJ.set_spawn_positions(GLOB.players_preassigned)
-		REDIS_PUBLISH("byond.round", "type" = "predator-round", "map" = SSmapping.configs[GROUND_MAP].map_name)
+		REDIS_PUBLISH("byond.round", "type" = "predator-round", "map" = SSmapping.configs[GROUND_MAP].map_name)		
+
+	DB_FILTER(/datum/entity/predround_chance, DB_COMP("id", DB_EQUALS, 1), CALLBACK(src, PROC_REF(modify_pred_round_chance), pred_round))
 
 	// Assign the roles, this time for real, respecting limits we have established.
 	var/list/roles_left = assign_roles(temp_roles_for_mode, unassigned_players)
@@ -823,3 +837,8 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 			if(new_squad.num_tl >= new_squad.max_tl)
 				return TRUE
 	return FALSE
+
+/datum/authority/branch/role/proc/modify_pred_round_chance(pred_round, list/datum/entity/predround_chance/entities)
+	var/datum/entity/predround_chance/entity = locate() in entities
+	entity.chance = pred_round ? 20 : entity.chance + 20
+	entity.save()

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -563,6 +563,7 @@
 #include "code\datums\entities\player_stat.dm"
 #include "code\datums\entities\player_sticky_ban.dm"
 #include "code\datums\entities\player_times.dm"
+#include "code\datums\entities\predround_chance.dm"
 #include "code\datums\entities\ticket.dm"
 #include "code\datums\entities\logs\player_times_log.dm"
 #include "code\datums\factions\clf.dm"

--- a/maps/Nightmare/scenario.json
+++ b/maps/Nightmare/scenario.json
@@ -1,3 +1,2 @@
 [
-    { "type": "def", "values": { "predator_round": true }, "chance": 0.2 }
 ]


### PR DESCRIPTION
# About the pull request
Increases pred round chance by 20% every time it isn't a pred round (and resets it back to 20% whenever it is a pred round)
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Better than pure RNG, It is annoying when you only get one pred round a day and it's in 3 AM
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Pred round chance now increases by 20% whenever it isn't a pred round and resets back to 20% when it is a pred round
/:cl:
