### PR TITLE
Steelcrest soak macro fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_abilities.dm
@@ -63,7 +63,7 @@
 	ability_name = "soak"
 	macro_path = /datum/action/xeno_action/verb/verb_soak
 	action_type = XENO_ACTION_ACTIVATE
-	ability_primacy = XENO_PRIMARY_ACTION_5
+	ability_primacy = XENO_PRIMARY_ACTION_3
 	plasma_cost = 20
 	xeno_cooldown = 17 SECONDS
 

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/defender/steel_crest.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/defender/steel_crest.dm
@@ -11,8 +11,8 @@
 	)
 	actions_to_add = list(
 		/datum/action/xeno_action/activable/headbutt/steel_crest,
-		/datum/action/xeno_action/activable/fortify/steel_crest,
 		/datum/action/xeno_action/onclick/soak,
+		/datum/action/xeno_action/activable/fortify/steel_crest,
 	)
 
 /datum/xeno_strain/steel_crest/apply_strain(mob/living/carbon/xenomorph/defender/defender)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Sets soak ability macro and icon position to primary ability 3, instead of 5.

# Explain why it's good for the game

Steelcrest has 4 abilities and 3rd ability key isn't mapped to anything with soak using the 5th one, makes no sense. How did this persist for half a year?

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Steelcrest soak now uses primary ability 3 hotkey instead of ability 5.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
