### PR TITLE
Interference now cancels all external heals

### DIFF
--- a/code/__DEFINES/dcs/signals/atom/mob/living/signals_xeno.dm
+++ b/code/__DEFINES/dcs/signals/atom/mob/living/signals_xeno.dm
@@ -9,6 +9,7 @@
 
 #define COMSIG_XENO_PRE_HEAL "xeno_pre_heal"
 	#define COMPONENT_CANCEL_XENO_HEAL (1<<0)
+	#define COMPONENT_CANCEL_EXTERNAL_XENO_HEAL (1<<1)
 
 /// From ../xeno_action/activable/xeno_spit/use_ability
 #define COMSIG_XENO_POST_SPIT "xeno_spit"

--- a/code/datums/components/xeno/hivemind_interference.dm
+++ b/code/datums/components/xeno/hivemind_interference.dm
@@ -9,6 +9,7 @@
 	if(!isxeno(parent))
 		return COMPONENT_INCOMPATIBLE
 	ADD_TRAIT(parent, TRAIT_HIVEMIND_INTERFERENCE, TRAIT_SOURCE_HIVEMIND_INTERFERENCE)
+	RegisterSignal(parent, COMSIG_XENO_PRE_HEAL, PROC_REF(block_external_heal))
 	src.interference = interference
 	src.max_buildup = max_buildup
 	src.dissipation = dissipation
@@ -51,6 +52,11 @@
 		return
 	L += "Hivemind Interference: [interference]/[max_buildup]"
 
+/datum/component/status_effect/interference/proc/block_external_heal()
+	SIGNAL_HANDLER
+	return COMPONENT_CANCEL_EXTERNAL_XENO_HEAL
+
 /datum/component/status_effect/interference/cleanse()
 	REMOVE_TRAIT(parent, TRAIT_HIVEMIND_INTERFERENCE, TRAIT_SOURCE_HIVEMIND_INTERFERENCE)
+	UnregisterSignal(parent, COMSIG_XENO_PRE_HEAL)
 	return ..()

--- a/code/modules/mob/living/carbon/xenomorph/Abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Abilities.dm
@@ -314,7 +314,7 @@
 		to_chat(X, SPAN_XENOWARNING("This caste cannot be given plasma!"))
 		return
 
-	if(SEND_SIGNAL(target, COMSIG_XENO_PRE_HEAL) & COMPONENT_CANCEL_XENO_HEAL)
+	if(SEND_SIGNAL(target, COMSIG_XENO_PRE_HEAL) & (COMPONENT_CANCEL_XENO_HEAL|COMPONENT_CANCEL_EXTERNAL_XENO_HEAL))
 		to_chat(X, SPAN_XENOWARNING("This xeno cannot be given plasma!"))
 		return
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_powers.dm
@@ -788,7 +788,7 @@
 	var/use_plasma = FALSE
 
 	if (curr_effect_type == WARDEN_HEAL_SHIELD)
-		if (SEND_SIGNAL(targetXeno, COMSIG_XENO_PRE_HEAL) & COMPONENT_CANCEL_XENO_HEAL)
+		if (SEND_SIGNAL(targetXeno, COMSIG_XENO_PRE_HEAL) & (COMPONENT_CANCEL_XENO_HEAL|COMPONENT_CANCEL_EXTERNAL_XENO_HEAL))
 			to_chat(X, SPAN_XENOWARNING("We cannot bolster the defenses of this xeno!"))
 			return
 
@@ -828,7 +828,7 @@
 		if (!X.Adjacent(A))
 			to_chat(X, SPAN_XENODANGER("We must be within touching distance of [targetXeno]!"))
 			return
-		if (SEND_SIGNAL(targetXeno, COMSIG_XENO_PRE_HEAL) & COMPONENT_CANCEL_XENO_HEAL)
+		if (SEND_SIGNAL(targetXeno, COMSIG_XENO_PRE_HEAL) & (COMPONENT_CANCEL_XENO_HEAL|COMPONENT_CANCEL_EXTERNAL_XENO_HEAL))
 			to_chat(X, SPAN_XENOWARNING("We cannot heal this xeno!"))
 			return
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -274,7 +274,7 @@
 		if(!X.can_not_harm(Xa))
 			continue
 
-		if(SEND_SIGNAL(Xa, COMSIG_XENO_PRE_HEAL) & COMPONENT_CANCEL_XENO_HEAL)
+		if(SEND_SIGNAL(Xa, COMSIG_XENO_PRE_HEAL) & (COMPONENT_CANCEL_XENO_HEAL|COMPONENT_CANCEL_EXTERNAL_XENO_HEAL))
 			if(verbose)
 				to_chat(X, SPAN_XENOMINORWARNING("You cannot heal [Xa]!"))
 			continue

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/drone/healer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/drone/healer.dm
@@ -90,8 +90,8 @@
 	if(!check_state())
 		return
 
-	if(SEND_SIGNAL(target_xeno, COMSIG_XENO_PRE_HEAL) & COMPONENT_CANCEL_XENO_HEAL)
-		to_chat(src, SPAN_XENOWARNING("Extinguish [target_xeno] first or the flames will burn our resin salve away!"))
+	if(SEND_SIGNAL(target_xeno, COMSIG_XENO_PRE_HEAL) & (COMPONENT_CANCEL_XENO_HEAL|COMPONENT_CANCEL_EXTERNAL_XENO_HEAL))
+		to_chat(src, SPAN_XENOWARNING("We cannot heal [target_xeno]!"))
 		return
 
 	if(!can_not_harm(target_xeno)) //We don't wanna heal hostile hives, but we do want to heal our allies!


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Interference (from yautja weapons or special chemical properties) will no cancel all external heals (Queen heal, healer salve, warden heal) except sacrifice. Self-heals are unaffected (warrior slash heal or vampire healing).
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Fighting xenos with constant heals from Queen or even warden and healer drones can be extremely annoying, both for the predator and for the xeno he is fighting which might want to try his luck in a 1v1 but cannot tell them to stop mid-fight. Xeno 1v1 power against preds will be adjusted accordingly in other PRs.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: Interference (from yautja weapons or special chemical properties) now cancels all external healing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
