### PR TITLE
Adds a proper warning dot to thermobaric missile direct fire

### DIFF
--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -701,7 +701,7 @@
 
 	if(ammo_travelling_time && istype(SA, /obj/structure/ship_ammo/rocket/thermobaric))
 		playsound(impact, ammo_warn_sound, ammo_warn_sound_volume, 1, 15)
-		var/total_seconds = max(floor(ammo_travelling_time/10),1)
+		var/total_seconds = max(floor(ammo_travelling_time / 10), 1)
 		for(var/i in 0 to total_seconds)
 			sleep(1 SECONDS)
 			new /obj/effect/overlay/temp/blinking_laser (impact) //no decreased accuracy if laser dissapears, it will land where it is telegraphed to land

--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -686,9 +686,9 @@
 			break
 
 	msg_admin_niche("[key_name(user)] is direct-firing [SA] onto [selected_target] at ([target_turf.x],[target_turf.y],[target_turf.z]) [ADMIN_JMP(target_turf)]")
-	if(ammo_travelling_time)
+	if(ammo_travelling_time && !istype(SA, /obj/structure/ship_ammo/rocket/thermobaric))
 		var/total_seconds = max(floor(ammo_travelling_time/10),1)
-		for(var/i = 0 to total_seconds)
+		for(var/i in 0 to total_seconds)
 			sleep(10)
 			if(!selected_target || !selected_target.loc)//if laser disappeared before we reached the target,
 				ammo_accuracy_range++ //accuracy decreases
@@ -698,6 +698,14 @@
 
 	var/list/possible_turfs = RANGE_TURFS(ammo_accuracy_range, target_turf)
 	var/turf/impact = pick(possible_turfs)
+
+	if(ammo_travelling_time && istype(SA, /obj/structure/ship_ammo/rocket/custom_missile))
+		playsound(impact, ammo_warn_sound, ammo_warn_sound_volume, 1,15)
+		var/total_seconds = max(floor(ammo_travelling_time/10),1)
+		for(var/i in 0 to total_seconds)
+			sleep(10)
+			new /obj/effect/overlay/temp/blinking_laser (impact) //no decreased accuracy if laser dissapears, it will land where it is telegraphed to land
+
 	if(ammo_warn_sound)
 		playsound(impact, ammo_warn_sound, ammo_warn_sound_volume, 1,15)
 	new /obj/effect/overlay/temp/blinking_laser (impact)

--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -703,7 +703,7 @@
 		playsound(impact, ammo_warn_sound, ammo_warn_sound_volume, 1,15)
 		var/total_seconds = max(floor(ammo_travelling_time/10),1)
 		for(var/i in 0 to total_seconds)
-			sleep(10)
+			sleep(1 SECONDS)
 			new /obj/effect/overlay/temp/blinking_laser (impact) //no decreased accuracy if laser dissapears, it will land where it is telegraphed to land
 
 	if(ammo_warn_sound)

--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -700,7 +700,7 @@
 	var/turf/impact = pick(possible_turfs)
 
 	if(ammo_travelling_time && istype(SA, /obj/structure/ship_ammo/rocket/thermobaric))
-		playsound(impact, ammo_warn_sound, ammo_warn_sound_volume, 1,15)
+		playsound(impact, ammo_warn_sound, ammo_warn_sound_volume, 1, 15)
 		var/total_seconds = max(floor(ammo_travelling_time/10),1)
 		for(var/i in 0 to total_seconds)
 			sleep(1 SECONDS)

--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -699,7 +699,7 @@
 	var/list/possible_turfs = RANGE_TURFS(ammo_accuracy_range, target_turf)
 	var/turf/impact = pick(possible_turfs)
 
-	if(ammo_travelling_time && istype(SA, /obj/structure/ship_ammo/rocket/custom_missile))
+	if(ammo_travelling_time && istype(SA, /obj/structure/ship_ammo/rocket/thermobaric))
 		playsound(impact, ammo_warn_sound, ammo_warn_sound_volume, 1,15)
 		var/total_seconds = max(floor(ammo_travelling_time/10),1)
 		for(var/i in 0 to total_seconds)


### PR DESCRIPTION

# About the pull request

Stole code from https://github.com/cmss13-devs/cmss13/pull/5957 to add a proper warning dot.


# Explain why it's good for the game

Thermobaric is currently the only CAS direct fire missile that cannot be dodged through the warning intended to make it possible because you cannot clear the AoE before it pulls you back in. This fixes that.
Essentially the same kinda issue that caused the FATTY rocket to be removed in the past. No warning = bad. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>


https://github.com/user-attachments/assets/a736acb2-9413-436e-932f-f908d881bee1



</details>


# Changelog
:cl:
add: Added a warning to thermobaric missile direct fire.
/:cl:
