### PR TITLE
Fix runtime with preview dummy related to signals

### DIFF
--- a/code/modules/character_traits/character_trait.dm
+++ b/code/modules/character_traits/character_trait.dm
@@ -1,18 +1,18 @@
-/// The list of traits a client will gives its human mob upon spawn
-/// Store as typepaths
-/datum/preferences/var/list/traits
-/// State var for preferences to track trait points
-/// Change this value to set the amount of trait points you start with
+/// The list of traits a client will gives its human mob upon spawn.
+/// Store as typepaths.
+/datum/preferences/var/list/datum/character_trait/traits
+/// State var for preferences to track trait points.
+/// Change this value to set the amount of trait points you start with.
 /datum/preferences/var/trait_points = 2
-/// State var to check if traits have been read in to modify
-/// trait points
+/// State var to check if traits have been read in to modify.
+/// trait points.
 /datum/preferences/var/read_traits = FALSE
-/// The list of traits a human has
-/// Store as typepaths
-/mob/living/carbon/human/var/list/traits
+/// The list of traits a human has.
+/// Store as typepaths.
+/mob/living/carbon/human/var/list/datum/character_trait/traits
 
 /** Global lists
- * character_trait_groups should be defined BEFORE character_traits because of dependencies
+ * character_trait_groups should be defined BEFORE character_traits because of dependencies.
  * When trying to reference specific traits or trait groups, reference these lists, which
  * store character traits and character trait groups by their type paths
  *
@@ -23,8 +23,8 @@
 GLOBAL_REFERENCE_LIST_INDEXED(character_trait_groups, /datum/character_trait_group, type)
 GLOBAL_REFERENCE_LIST_INDEXED(character_traits, /datum/character_trait, type)
 
-/// Character traits
-/// Similar to the traits from Project Zomboid
+/// Character traits.
+/// Similar to the traits from Project Zomboid.
 /datum/character_trait
 	var/trait_name = "Character Trait"
 	var/trait_desc = "A character trait"
@@ -52,7 +52,7 @@ GLOBAL_REFERENCE_LIST_INDEXED(character_traits, /datum/character_trait, type)
 		CRASH("Invalid trait_group set for character trait [type]")
 	trait_group.traits += src
 
-/// A wrapper to check if the trait can be applied first
+/// A function to check if the trait can be applied (prior to getting it)
 /datum/character_trait/proc/can_give_trait(datum/preferences/target)
 	if(type in target.traits)
 		return FALSE
@@ -105,9 +105,11 @@ GLOBAL_REFERENCE_LIST_INDEXED(character_traits, /datum/character_trait, type)
 
 /// Character trait groups for constraints (if any)
 /datum/character_trait_group
-	/// For player prefs menu
+	// For player prefs menu
+	/// Group name as shown in the preferences menu
 	var/trait_group_name = "Trait Group"
-	var/group_visible = TRUE //Set this to false so the group doesn't show up in preferences
+	/// Whether the group will show up in the preferences menu
+	var/group_visible = TRUE
 
 	// CONSTRAINTS
 	// MODIFY THESE VARS FOR SETTING CONSTRAINTS FOR TRAIT GROUPS

--- a/code/modules/gear_presets/_select_equipment.dm
+++ b/code/modules/gear_presets/_select_equipment.dm
@@ -282,8 +282,8 @@
 		return
 
 	for(var/trait in real_client.prefs.traits)
-		var/datum/character_trait/CT = GLOB.character_traits[trait]
-		CT.apply_trait(new_human, src)
+		var/datum/character_trait/character_trait = GLOB.character_traits[trait]
+		character_trait.apply_trait(new_human, src)
 
 /datum/equipment_preset/proc/get_minimap_icon(mob/living/carbon/human/user)
 	var/image/background = mutable_appearance('icons/ui_icons/map_blips.dmi', "background")

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -188,10 +188,10 @@
 	var/J = job_pref_to_gear_preset()
 	if(isnull(preview_dummy))
 		preview_dummy = new()
-	
+
 	preview_dummy.blocks_emissive = FALSE
 	preview_dummy.update_emissive_block()
-	
+
 	clear_equipment()
 	if(refresh_limb_status)
 		for(var/obj/limb/L in preview_dummy.limbs)
@@ -200,7 +200,8 @@
 	copy_appearance_to(preview_dummy)
 	preview_dummy.update_body()
 	preview_dummy.update_hair()
-
+	for (var/datum/character_trait/character_trait as anything in preview_dummy.traits)
+		character_trait.unapply_trait(preview_dummy)
 	arm_equipment(preview_dummy, J, FALSE, FALSE, owner, show_job_gear)
 
 	// If the dummy was equipped with marine armor.


### PR DESCRIPTION
- Preview dummy will throw a stack_trace if a trait applies any signals since it applies all traits on update without clearing them

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixed a potential runtime for any character traits that want to register signals.

Also some minor formatting changes.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Fix runtime

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->
Tested with a signal-adding trait I was experimenting with

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

This is just a fix for a potential issue so not playerfacing

<!-- Both :cl:'s are required for the changelog to work! -->
