### PR TITLE
Medical vendor Create&Destroy fix

### DIFF
--- a/code/game/machinery/vending/vendor_types/medical.dm
+++ b/code/game/machinery/vending/vendor_types/medical.dm
@@ -268,6 +268,7 @@
 	)
 
 /obj/structure/machinery/cm_vending/sorted/medical/Destroy()
+	STOP_PROCESSING(SSslowobj, src)
 	QDEL_NULL(last_health_display)
 	. = ..()
 


### PR DESCRIPTION
# About the pull request

Medical vendors are added to the slowobj subsystem but not removed on Destroy(). This fixes that.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Lint fails bad.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Before, from PvE:
![image](https://github.com/user-attachments/assets/c585c054-7e87-45ec-82e3-b4e9078efaad)
![image](https://github.com/user-attachments/assets/d5737ead-4370-4c01-994e-87471f80ed38)

</details>


# Changelog
No player facing changes.
