### PR TITLE
Revives "Stops Queen from stomping on Xenos with relevant pass flags (Lessers/Huggers/Larva) "

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -443,7 +443,7 @@
 /mob/living/carbon/xenomorph/queen/proc/check_block(mob/queen, turf/new_loc)
 	SIGNAL_HANDLER
 	for(var/mob/living/carbon/xenomorph/xeno in new_loc.contents)
-		if(xeno.pass_flags.flags_pass & PASS_MOB_THRU_XENO|PASS_MOB_THRU &! xeno.flags_pass_temp & PASS_MOB_THRU)
+		if(xeno.pass_flags.flags_pass & PASS_MOB_THRU_XENO|PASS_MOB_THRU && !(xeno.flags_pass_temp & PASS_MOB_THRU))
 			return
 		if(xeno.hivenumber == hivenumber)
 			xeno.KnockDown((5 DECISECONDS) / GLOBAL_STATUS_MULTIPLIER)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -443,6 +443,8 @@
 /mob/living/carbon/xenomorph/queen/proc/check_block(mob/queen, turf/new_loc)
 	SIGNAL_HANDLER
 	for(var/mob/living/carbon/xenomorph/xeno in new_loc.contents)
+		if(xeno.pass_flags.flags_pass & PASS_MOB_THRU_XENO|PASS_MOB_THRU &! xeno.flags_pass_temp & PASS_MOB_THRU)
+			return
 		if(xeno.hivenumber == hivenumber)
 			xeno.KnockDown((5 DECISECONDS) / GLOBAL_STATUS_MULTIPLIER)
 			playsound(src, 'sound/weapons/alien_knockdown.ogg', 25, 1)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -388,20 +388,23 @@
 			if(loc && !loc.Adjacent(L.loc))
 				now_pushing = FALSE
 				return
-			var/oldloc = loc
-			var/oldLloc = L.loc
 
-			L.add_temp_pass_flags(PASS_MOB_THRU)
-			add_temp_pass_flags(PASS_MOB_THRU)
+			if(!(L.pass_flags.flags_pass & PASS_MOB_THRU)) //if they already pass through mob thi stuff is unnecessary
 
-			L.Move(oldloc)
-			Move(oldLloc)
+				var/oldloc = loc
+				var/oldLloc = L.loc
 
-			remove_temp_pass_flags(PASS_MOB_THRU)
-			L.remove_temp_pass_flags(PASS_MOB_THRU)
+				L.add_temp_pass_flags(PASS_MOB_THRU)
+				add_temp_pass_flags(PASS_MOB_THRU)
 
-			now_pushing = FALSE
-			return
+				L.Move(oldloc)
+				Move(oldLloc)
+
+				remove_temp_pass_flags(PASS_MOB_THRU)
+				L.remove_temp_pass_flags(PASS_MOB_THRU)
+
+				now_pushing = FALSE
+				return
 
 	now_pushing = FALSE
 


### PR DESCRIPTION
# About the pull request

Revives the best PR ever made: #6618

It was closed because of GrrrKitten inactivity.

# Explain why it's good for the game

Getting stomp by queen when you do your task as lesser/facehugger/larva can be frustrating, it removes inconvinience. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: GrrrKitten
qol: Stops Queen from stomping on xenos with relevant pass flags (Larva, Hugger, Lesser)
/:cl:
