### PR TITLE
cryogenics on ERT stations and yautja ships no longer send gear to the Almayer

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -175,6 +175,10 @@ GLOBAL_LIST_INIT(frozen_items, list(SQUAD_MARINE_1 = list(), SQUAD_MARINE_2 = li
 	var/time_entered = 0 //Used to keep track of the safe period.
 	var/silent_exit = FALSE
 	var/obj/item/device/radio/intercom/announce //Intercom for cryo announcements
+	var/no_store_pod = FALSE
+
+/obj/structure/machinery/cryopod/no_store
+	no_store_pod = TRUE
 
 /obj/structure/machinery/cryopod/right
 	dir = WEST
@@ -226,12 +230,13 @@ GLOBAL_LIST_INIT(frozen_items, list(SQUAD_MARINE_1 = list(), SQUAD_MARINE_2 = li
 		switch(H.job)
 			if(JOB_POLICE, JOB_WARDEN, JOB_CHIEF_POLICE)
 				dept_console = GLOB.frozen_items["MP"]
-			if("Nurse", "Doctor","Researcher","Chief Medical Officer")
+			if(JOB_NURSE, JOB_DOCTOR, JOB_RESEARCHER, JOB_CMO)
 				dept_console = GLOB.frozen_items["Med"]
-			if("Maintenance Technician", "Ordnance Technician","Chief Engineer")
+			if(JOB_MAINT_TECH, JOB_ORDNANCE_TECH, JOB_CHIEF_ENGINEER)
 				dept_console = GLOB.frozen_items["Eng"]
-			if("Predator")
+			if(JOB_PREDATOR)
 				dept_console = GLOB.frozen_items["Yautja"]
+
 		H.species.handle_cryo(H)
 
 	var/list/deleteempty = list(/obj/item/storage/backpack/marine/satchel)
@@ -254,7 +259,7 @@ GLOBAL_LIST_INIT(frozen_items, list(SQUAD_MARINE_1 = list(), SQUAD_MARINE_2 = li
 
 	item_loop:
 		for(var/obj/item/W in items)
-			if(((W.flags_inventory & CANTSTRIP) || (W.flags_item & NODROP) || (W.flags_item & NO_CRYO_STORE)) && !isyautja(occupant)) //We don't keep donor items, undroppable/unremovable items, and specifically filtered items
+			if(((W.flags_inventory & CANTSTRIP) || (W.flags_item & NODROP) || (W.flags_item & NO_CRYO_STORE)) && !gearless_role(occupant)) //We don't keep donor items, undroppable/unremovable items, and specifically filtered items
 				if(istype(W, /obj/item/clothing/suit/storage))
 					var/obj/item/clothing/suit/storage/SS = W
 					for(var/obj/item/I in SS.pockets) //But we keep stuff inside them
@@ -359,7 +364,7 @@ GLOBAL_LIST_INIT(frozen_items, list(SQUAD_MARINE_1 = list(), SQUAD_MARINE_2 = li
 	//Make an announcement and log the person entering storage.
 	GLOB.frozen_crew += "[occupant.real_name] ([occupant.job])"
 
-	if(!isyautja(occupant))
+	if(!gearless_role(occupant))
 		ai_silent_announcement("[occupant.real_name], [occupant.job], has entered long-term hypersleep storage. Belongings moved to hypersleep inventory.")
 	visible_message(SPAN_NOTICE("[src] hums and hisses as it moves [occupant.real_name] into hypersleep storage."))
 
@@ -538,6 +543,13 @@ GLOBAL_LIST_INIT(frozen_items, list(SQUAD_MARINE_1 = list(), SQUAD_MARINE_2 = li
 		return
 
 	move_inside(target)
+
+/obj/structure/machinery/cryopod/proc/gearless_role(mob/occupant)
+	if(isyautja(occupant))
+		return TRUE
+	if(no_store_pod)
+		return TRUE
+	return FALSE
 
 
 /obj/structure/machinery/cryopod/tutorial

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -177,10 +177,13 @@ GLOBAL_LIST_INIT(frozen_items, list(SQUAD_MARINE_1 = list(), SQUAD_MARINE_2 = li
 	var/obj/item/device/radio/intercom/announce //Intercom for cryo announcements
 	var/no_store_pod = FALSE
 
+/obj/structure/machinery/cryopod/right
+	dir = WEST
+
 /obj/structure/machinery/cryopod/no_store
 	no_store_pod = TRUE
 
-/obj/structure/machinery/cryopod/right
+/obj/structure/machinery/cryopod/no_store/right
 	dir = WEST
 
 /obj/structure/machinery/cryopod/Initialize()

--- a/maps/map_files/generic/Admin_level.dmm
+++ b/maps/map_files/generic/Admin_level.dmm
@@ -427,7 +427,7 @@
 /turf/open/floor/almayer/silver,
 /area/adminlevel/ert_station)
 "op" = (
-/obj/structure/machinery/cryopod,
+/obj/structure/machinery/cryopod/no_store,
 /obj/structure/sign/safety/cryo{
 	pixel_x = 36
 	},

--- a/maps/predship/huntership.dmm
+++ b/maps/predship/huntership.dmm
@@ -430,7 +430,7 @@
 /turf/open/floor/corsat/squareswood/north,
 /area/yautja)
 "bc" = (
-/obj/structure/machinery/cryopod{
+/obj/structure/machinery/cryopod/no_store{
 	dir = 1
 	},
 /turf/open/floor/strata/grey_multi_tiles,
@@ -1473,7 +1473,7 @@
 /turf/open/floor/corsat/squareswood/north,
 /area/yautja)
 "fj" = (
-/obj/structure/machinery/cryopod,
+/obj/structure/machinery/cryopod/no_store,
 /turf/open/shuttle/predship,
 /area/yautja)
 "fo" = (
@@ -2286,7 +2286,7 @@
 /turf/open/floor/corsat/squareswood/north,
 /area/yautja)
 "Be" = (
-/obj/structure/machinery/cryopod/right,
+/obj/structure/machinery/cryopod/no_store/right,
 /turf/open/shuttle/predship,
 /area/yautja)
 "Bg" = (
@@ -3011,7 +3011,7 @@
 /turf/open/gm/dirtgrassborder/grassdirt_corner/north_east,
 /area/yautja)
 "XP" = (
-/obj/structure/machinery/cryopod,
+/obj/structure/machinery/cryopod/no_store,
 /turf/open/floor/strata/grey_multi_tiles,
 /area/yautja)
 "Ys" = (

--- a/maps/templates/Chinook.dmm
+++ b/maps/templates/Chinook.dmm
@@ -5479,7 +5479,7 @@
 /turf/open/floor/almayer/silver,
 /area/adminlevel/chinook)
 "ve" = (
-/obj/structure/machinery/cryopod/right,
+/obj/structure/machinery/cryopod/no_store/right,
 /turf/open/floor/almayer/cargo,
 /area/adminlevel/chinook/cryo)
 "vf" = (
@@ -6262,7 +6262,7 @@
 /turf/open/floor/corsat/squares,
 /area/adminlevel/chinook/cargo)
 "yM" = (
-/obj/structure/machinery/cryopod,
+/obj/structure/machinery/cryopod/no_store,
 /obj/structure/machinery/light{
 	dir = 1
 	},
@@ -7192,7 +7192,7 @@
 /turf/open/floor/almayer/plating/northeast,
 /area/adminlevel/chinook/engineering)
 "CS" = (
-/obj/structure/machinery/cryopod,
+/obj/structure/machinery/cryopod/no_store,
 /turf/open/floor/almayer/sterile_green,
 /area/adminlevel/chinook/medical)
 "CT" = (
@@ -7467,7 +7467,7 @@
 /turf/open/floor/corsat/squares,
 /area/adminlevel/chinook/offices)
 "DT" = (
-/obj/structure/machinery/cryopod,
+/obj/structure/machinery/cryopod/no_store,
 /obj/structure/machinery/light{
 	dir = 8
 	},
@@ -8769,7 +8769,7 @@
 /turf/open/floor/carpet,
 /area/adminlevel/chinook/sec)
 "JH" = (
-/obj/structure/machinery/cryopod,
+/obj/structure/machinery/cryopod/no_store,
 /obj/structure/machinery/light,
 /turf/open/floor/almayer/sterile_green,
 /area/adminlevel/chinook/medical)
@@ -11164,7 +11164,7 @@
 /turf/open/floor/almayer/cargo,
 /area/adminlevel/chinook/engineering)
 "TD" = (
-/obj/structure/machinery/cryopod/right,
+/obj/structure/machinery/cryopod/no_store/right,
 /obj/structure/machinery/light{
 	dir = 4
 	},
@@ -11884,7 +11884,7 @@
 /turf/open/floor/almayer/green/southeast,
 /area/adminlevel/chinook)
 "WB" = (
-/obj/structure/machinery/cryopod,
+/obj/structure/machinery/cryopod/no_store,
 /turf/open/floor/almayer/cargo,
 /area/adminlevel/chinook/cryo)
 "WD" = (

--- a/maps/templates/lazy_templates/freelancer_ert_station.dmm
+++ b/maps/templates/lazy_templates/freelancer_ert_station.dmm
@@ -8,7 +8,7 @@
 /turf/open/floor/almayer/plating/northeast,
 /area/adminlevel/ert_station)
 "aj" = (
-/obj/structure/machinery/cryopod,
+/obj/structure/machinery/cryopod/no_store,
 /obj/structure/sign/safety/cryo{
 	pixel_x = 36
 	},

--- a/maps/templates/lazy_templates/twe_ert_station.dmm
+++ b/maps/templates/lazy_templates/twe_ert_station.dmm
@@ -521,7 +521,7 @@
 /turf/open/floor/plating/kutjevo,
 /area/adminlevel/ert_station/royal_marines_station)
 "lX" = (
-/obj/structure/machinery/cryopod{
+/obj/structure/machinery/cryopod/no_store{
 	layer = 3.1;
 	pixel_y = 7
 	},
@@ -591,7 +591,7 @@
 /obj/structure/machinery/light{
 	dir = 8
 	},
-/obj/structure/machinery/cryopod{
+/obj/structure/machinery/cryopod/no_store{
 	layer = 3.1;
 	pixel_y = 7
 	},
@@ -662,7 +662,7 @@
 /turf/open/floor/almayer/orange/northwest,
 /area/adminlevel/ert_station/royal_marines_station)
 "pk" = (
-/obj/structure/machinery/cryopod/right,
+/obj/structure/machinery/cryopod/no_store/right,
 /turf/open/floor/almayer/cargo,
 /area/adminlevel/ert_station/royal_marines_station)
 "ps" = (
@@ -774,7 +774,7 @@
 /area/adminlevel/ert_station/royal_marines_station)
 "rP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/machinery/cryopod{
+/obj/structure/machinery/cryopod/no_store{
 	dir = 1;
 	pixel_y = 7
 	},
@@ -846,7 +846,7 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
-/obj/structure/machinery/cryopod{
+/obj/structure/machinery/cryopod/no_store{
 	dir = 1;
 	pixel_y = 7
 	},
@@ -941,7 +941,7 @@
 /turf/open/floor/almayer,
 /area/adminlevel/ert_station/royal_marines_station)
 "wF" = (
-/obj/structure/machinery/cryopod/right{
+/obj/structure/machinery/cryopod/no_store/right{
 	layer = 3.1;
 	pixel_y = 13
 	},
@@ -1298,7 +1298,7 @@
 /turf/open/floor/almayer/plate,
 /area/adminlevel/ert_station/royal_marines_station)
 "Gd" = (
-/obj/structure/machinery/cryopod,
+/obj/structure/machinery/cryopod/no_store,
 /turf/open/floor/almayer/cargo,
 /area/adminlevel/ert_station/royal_marines_station)
 "GM" = (
@@ -1692,14 +1692,14 @@
 /turf/open/floor/almayer/sterile_green,
 /area/adminlevel/ert_station/royal_marines_station)
 "Ok" = (
-/obj/structure/machinery/cryopod{
+/obj/structure/machinery/cryopod/no_store{
 	dir = 1;
 	pixel_y = 7
 	},
 /turf/open/floor/almayer/cargo,
 /area/adminlevel/ert_station/royal_marines_station)
 "Or" = (
-/obj/structure/machinery/cryopod{
+/obj/structure/machinery/cryopod/no_store{
 	layer = 3.1;
 	pixel_y = 13
 	},

--- a/maps/templates/lazy_templates/upp_ert_station.dmm
+++ b/maps/templates/lazy_templates/upp_ert_station.dmm
@@ -895,7 +895,7 @@
 /turf/open/floor/strata/blue1,
 /area/adminlevel/ert_station/upp_station)
 "rk" = (
-/obj/structure/machinery/cryopod/right{
+/obj/structure/machinery/cryopod/no_store/right{
 	pixel_y = 6
 	},
 /turf/open/floor/prison/floor_marked/west,
@@ -2267,7 +2267,7 @@
 /turf/open/floor/greengrid,
 /area/adminlevel/ert_station/upp_station)
 "Sx" = (
-/obj/structure/machinery/cryopod/right{
+/obj/structure/machinery/cryopod/no_store/right{
 	layer = 3.1;
 	pixel_y = 13
 	},
@@ -2386,7 +2386,7 @@
 /turf/open/floor/strata/white_cyan4/south,
 /area/adminlevel/ert_station/upp_station)
 "TE" = (
-/obj/structure/machinery/cryopod/right,
+/obj/structure/machinery/cryopod/no_store/right,
 /obj/structure/machinery/light/double/blue{
 	dir = 4
 	},

--- a/maps/templates/lazy_templates/uscm_ert_station.dmm
+++ b/maps/templates/lazy_templates/uscm_ert_station.dmm
@@ -4150,7 +4150,7 @@
 /turf/open/floor/almayer,
 /area/adminlevel/ert_station/uscm_station)
 "Yb" = (
-/obj/structure/machinery/cryopod/right,
+/obj/structure/machinery/cryopod/no_store/right,
 /obj/structure/sign/safety/cryo{
 	pixel_y = 30
 	},

--- a/maps/templates/lazy_templates/weyland_ert_station.dmm
+++ b/maps/templates/lazy_templates/weyland_ert_station.dmm
@@ -729,7 +729,7 @@
 /turf/open/floor/corsat/green/northeast,
 /area/adminlevel/ert_station/weyland_station)
 "lT" = (
-/obj/structure/machinery/cryopod/right{
+/obj/structure/machinery/cryopod/no_store/right{
 	layer = 3.1;
 	pixel_y = 13
 	},
@@ -1344,7 +1344,7 @@
 /turf/open/floor/corsat/sterileplate,
 /area/adminlevel/ert_station/weyland_station)
 "vX" = (
-/obj/structure/machinery/cryopod/right,
+/obj/structure/machinery/cryopod/no_store/right,
 /turf/open/floor/corsat/cargo,
 /area/adminlevel/ert_station/weyland_station)
 "wa" = (
@@ -2730,7 +2730,7 @@
 /turf/open/floor/wood/ship,
 /area/adminlevel/ert_station/weyland_station)
 "SO" = (
-/obj/structure/machinery/cryopod/right{
+/obj/structure/machinery/cryopod/no_store/right{
 	pixel_y = 6
 	},
 /turf/open/floor/corsat/cargo,


### PR DESCRIPTION
# About the pull request

Stops ERT stations and Yautja ship sending gear to the Almayer.

# Explain why it's good for the game

Teleporting equipment silly.


# Changelog


:cl:
fix: ERT station cryo pods no longer send gear to the Almayer.
/:cl:
Closes #7244
Closes #6709
