### PR TITLE
Fixes neuraline being in research chem recipes 

### DIFF
--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -186,7 +186,7 @@
 	custom_metabolism = AMOUNT_PER_TIME(1, 5 SECONDS)
 	overdose = 2
 	overdose_critical = 3
-	chemclass = CHEM_CLASS_RARE
+	chemclass = CHEM_CLASS_SPECIAL
 	properties = list(PROPERTY_NERVESTIMULATING = 5)
 	flags = REAGENT_TYPE_MEDICAL
 


### PR DESCRIPTION
# About the pull request

Neuraline is a special chem only found in CL's implant, and it cannot be extracted or obtained by other means (except pure gamble of botany mutations), which makes recipes containing it being impossible to fulfill.

![D5gWUYCMSz](https://github.com/user-attachments/assets/37f88758-1f08-4052-bea5-2c3785366dc6)


# Changelog
:cl:
fix: fixed neuraline being a potential part of a chem recipe
/:cl:
