### PR TITLE
Changes /area/yautja checks to look for a flag

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -47,6 +47,8 @@
 #define AREA_CONTAINMENT (1<<3)
 /// Flags the area as permanently unweedable. Still requires is_resin_allowed = FALSE
 #define AREA_UNWEEDABLE (1<<4)
+/// Flags the area as having purpose by the Yautja, and exempt from gear tracking.
+#define AREA_YAUTJA_GROUNDS (1<<5)
 /// Default number of ticks for do_after
 #define DA_DEFAULT_NUM_TICKS 5
 

--- a/code/modules/cm_preds/thrall_procs.dm
+++ b/code/modules/cm_preds/thrall_procs.dm
@@ -18,7 +18,8 @@
 		to_chat(wearer, SPAN_WARNING("You're not able to do that right now."))
 		return
 
-	if(!istype(get_area(wearer), /area/yautja))
+	var/area/location = get_area(wearer)
+	if(!(location.flags_area & AREA_YAUTJA_GROUNDS))
 		to_chat(wearer, SPAN_WARNING("Not here. Only on the ship."))
 		return
 

--- a/code/modules/cm_preds/yaut_bracers.dm
+++ b/code/modules/cm_preds/yaut_bracers.dm
@@ -478,7 +478,7 @@
 	if(.)
 		return
 
-	var/mob/living/carbon/human/M = caller
+	var/mob/living/carbon/human/hunter = caller
 
 	var/dead_on_planet = 0
 	var/dead_on_almayer = 0
@@ -497,7 +497,8 @@
 			continue
 		if(is_honorable_carrier(recursive_holder_check(tracked_item)))
 			continue
-		if(istype(get_area(tracked_item), /area/yautja))
+		var/area/location = get_area(tracked_item)
+		if(location.flags_area & AREA_YAUTJA_GROUNDS)
 			continue
 		if(is_reserved_level(loc.z))
 			gear_low_orbit++
@@ -505,47 +506,48 @@
 			gear_on_almayer++
 		else if(is_ground_level(loc.z))
 			gear_on_planet++
-		if(M.z == loc.z)
-			var/dist = get_dist(M,loc)
+		if(hunter.z == loc.z)
+			var/dist = get_dist(hunter, loc)
 			if(dist < closest)
 				closest = dist
 				closest_item = tracked_item
-				direction = Get_Compass_Dir(M,loc)
+				direction = Get_Compass_Dir(hunter, loc)
 				areaLoc = loc
-	for(var/mob/living/carbon/human/Y as anything in GLOB.yautja_mob_list)
-		if(Y.stat != DEAD)
+	for(var/mob/living/carbon/human/dead_yautja as anything in GLOB.yautja_mob_list)
+		if(dead_yautja.stat != DEAD)
 			continue
-		if(istype(get_area(Y), /area/yautja))
+		var/area/location = get_area(dead_yautja)
+		if(location.flags_area & AREA_YAUTJA_GROUNDS)
 			continue
-		if(is_reserved_level(Y.z))
+		if(is_reserved_level(dead_yautja.z))
 			dead_low_orbit++
-		else if(is_mainship_level(Y.z))
+		else if(is_mainship_level(dead_yautja.z))
 			dead_on_almayer++
-		else if(is_ground_level(Y.z))
+		else if(is_ground_level(dead_yautja.z))
 			dead_on_planet++
-		if(M.z == Y.z)
-			var/dist = get_dist(M,Y)
+		if(hunter.z == dead_yautja.z)
+			var/dist = get_dist(hunter, dead_yautja)
 			if(dist < closest)
 				closest = dist
-				direction = Get_Compass_Dir(M,Y)
+				direction = Get_Compass_Dir(hunter, dead_yautja)
 				areaLoc = loc
 
 	var/output = FALSE
 	if(dead_on_planet || dead_on_almayer || dead_low_orbit)
 		output = TRUE
-		to_chat(M, SPAN_NOTICE("Your bracer shows a readout of deceased Yautja bio signatures[dead_on_planet ? ", <b>[dead_on_planet]</b> in the hunting grounds" : ""][dead_on_almayer ? ", <b>[dead_on_almayer]</b> in orbit" : ""][dead_low_orbit ? ", <b>[dead_low_orbit]</b> in low orbit" : ""]."))
+		to_chat(hunter, SPAN_NOTICE("Your bracer shows a readout of deceased Yautja bio signatures[dead_on_planet ? ", <b>[dead_on_planet]</b> in the hunting grounds" : ""][dead_on_almayer ? ", <b>[dead_on_almayer]</b> in orbit" : ""][dead_low_orbit ? ", <b>[dead_low_orbit]</b> in low orbit" : ""]."))
 	if(gear_on_planet || gear_on_almayer || gear_low_orbit)
 		output = TRUE
-		to_chat(M, SPAN_NOTICE("Your bracer shows a readout of Yautja technology signatures[gear_on_planet ? ", <b>[gear_on_planet]</b> in the hunting grounds" : ""][gear_on_almayer ? ", <b>[gear_on_almayer]</b> in orbit" : ""][gear_low_orbit ? ", <b>[gear_low_orbit]</b> in low orbit" : ""]."))
+		to_chat(hunter, SPAN_NOTICE("Your bracer shows a readout of Yautja technology signatures[gear_on_planet ? ", <b>[gear_on_planet]</b> in the hunting grounds" : ""][gear_on_almayer ? ", <b>[gear_on_almayer]</b> in orbit" : ""][gear_low_orbit ? ", <b>[gear_low_orbit]</b> in low orbit" : ""]."))
 	if(closest < 900)
 		output = TRUE
 		var/areaName = get_area_name(areaLoc)
 		if(closest == 0)
-			to_chat(M, SPAN_NOTICE("You are directly on top of the[closest_item ? " <b>[closest_item.name]</b>'s" : ""] signature."))
+			to_chat(hunter, SPAN_NOTICE("You are directly on top of the[closest_item ? " <b>[closest_item.name]</b>'s" : ""] signature."))
 		else
-			to_chat(M, SPAN_NOTICE("The closest signature[closest_item ? ", a <b>[closest_item.name]</b>" : ""], is [closest > 10 ? "approximately <b>[round(closest, 10)]</b>" : "<b>[closest]</b>"] paces <b>[dir2text(direction)]</b> in <b>[areaName]</b>."))
+			to_chat(hunter, SPAN_NOTICE("The closest signature[closest_item ? ", a <b>[closest_item.name]</b>" : ""], is [closest > 10 ? "approximately <b>[round(closest, 10)]</b>" : "<b>[closest]</b>"] paces <b>[dir2text(direction)]</b> in <b>[areaName]</b>."))
 	if(!output)
-		to_chat(M, SPAN_NOTICE("There are no signatures that require your attention."))
+		to_chat(hunter, SPAN_NOTICE("There are no signatures that require your attention."))
 	return TRUE
 
 

--- a/code/modules/cm_preds/yaut_procs.dm
+++ b/code/modules/cm_preds/yaut_procs.dm
@@ -226,6 +226,7 @@
 	ceiling = CEILING_METAL
 	requires_power = FALSE
 	base_lighting_alpha = 255
+	flags_area = AREA_YAUTJA_GROUNDS
 
 /mob/living/carbon/human/proc/pred_buy()
 	set category = "Yautja.Misc"
@@ -243,8 +244,8 @@
 	if(!isyautja(src))
 		to_chat(src, SPAN_WARNING("How did you get this verb?"))
 		return
-
-	if(!istype(get_area(src), /area/yautja))
+	var/area/location = get_area(src)
+	if(!(location.flags_area & AREA_YAUTJA_GROUNDS))
 		to_chat(src, SPAN_WARNING("Not here. Only on the ship."))
 		return
 


### PR DESCRIPTION

# About the pull request

Stops the few places that typecheck for /area/yautja to look for a flags_area flag instead, this will allow more flexibility in the future, and gets rid of some loathesome typechecking.

# Explain why it's good for the game

Future flexibility. Less typechecking.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
code: Yautja gear claim and tracking now checks for an area flag instead of area typechecking.
/:cl:
