### PR TITLE
Ventcrawl notification fix

### DIFF
--- a/code/game/objects/structures/pipes/pipes.dm
+++ b/code/game/objects/structures/pipes/pipes.dm
@@ -132,7 +132,8 @@
 
 		ventcrawl_message_busy = world.time + 20
 		playsound(src, pick('sound/effects/alien_ventcrawl1.ogg', 'sound/effects/alien_ventcrawl2.ogg'), 25, 1)
-		visible_message(SPAN_HIGHDANGER("You hear something squeezing through the ducts."))
+		var/turf/alert_turf = get_turf(src) //Pipe segments aren't guaranteed to be visible
+		alert_turf.visible_message(SPAN_HIGHDANGER("You hear something squeezing through the ducts."))
 		to_chat(user, SPAN_NOTICE("You begin to climb out of [src]"))
 		animate_ventcrawl()
 		user.remove_specific_pipe_image(src)


### PR DESCRIPTION

# About the pull request
Fixes exiting through a pipe segment that's hidden underneath a floor tile not sending a warning message to nearby mobs. 
This allowed for practically unreactable surprise attacks, namely from huggers.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Bugs are bad for the game, especially if they are conveniently (and unknowingly) exploitable
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://streamable.com/qk3b3s

</details>


# Changelog
:cl:
fix: Fixed exiting ventcrawling through a covered pipe segment not triggering a warning notification for nearby mobs
/:cl:
