### PR TITLE
Slightly increases the amount of time it takes to exit ventcrawling from disconnected pipes

### DIFF
--- a/code/game/objects/structures/pipes/pipes.dm
+++ b/code/game/objects/structures/pipes/pipes.dm
@@ -136,7 +136,10 @@
 		to_chat(user, SPAN_NOTICE("You begin to climb out of [src]"))
 		animate_ventcrawl()
 		user.remove_specific_pipe_image(src)
-		if(!do_after(user, 20, INTERRUPT_NO_NEEDHAND))
+		var/exit_time = 20 //So that exiting through a destroyed pipe segment takes longer than a proper vent
+		if(!istype(src, /obj/structure/pipes/vents))
+			exit_time += 10
+		if(!do_after(user, exit_time, INTERRUPT_NO_NEEDHAND))
 			animate_ventcrawl_reset()
 			return
 


### PR DESCRIPTION
# About the pull request

This PR slightly increases the time it takes to exit ventcrawling from a disconnected pipe segment (doesn't affect exiting via vents/scrubbers), from 2 seconds to 3.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Unlike vents and scrubbers, pipe segments have the possbility of being completely hidden (more often than not this is the case, due to how explosions work); in which case they have no visible cue for when something is emerging from them, and the potential threat isn't something you can easily identify in advance. Thus, I think it's fair for there to be slightly more leeway in the amount of time you get to react when something *does* try to emerge from it. This primarily concerns player controlled huggers, which can begin channeling a pounce *immediately* upon exiting a vent.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://streamable.com/q8inq2

</details>


# Changelog
:cl:
balance: Slightly increased the time it takes to exit ventcrawling from disconnected pipe segments (this doesn't affect exiting through a vent/scrubber)
/:cl:
