### PR TITLE
Make facehugger limit visible to xenos

### DIFF
--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -55,7 +55,7 @@
 	. = ..()
 	if(isxeno(user) && status == EGG_GROWN)
 		. += "Ctrl + Click egg to retrieve child into your empty hand if you can carry it."
-	if(isobserver(user) && status == EGG_GROWN)
+	if(isobserver(user) || isxeno(user) && status == EGG_GROWN)
 		var/datum/hive_status/hive = GLOB.hive_datum[hivenumber]
 		var/current_hugger_count = hive.get_current_playable_facehugger_count();
 		. += "There are currently [SPAN_NOTICE("[current_hugger_count]")] facehuggers in the hive. The hive can support a total of [SPAN_NOTICE("[hive.playable_hugger_limit]")] facehuggers at present."

--- a/code/modules/cm_aliens/structures/special/egg_morpher.dm
+++ b/code/modules/cm_aliens/structures/special/egg_morpher.dm
@@ -44,7 +44,7 @@
 	. = ..()
 	if(isxeno(user) || isobserver(user))
 		. += "It has [stored_huggers] facehuggers within, with [huggers_to_grow] more to grow (reserved: [huggers_reserved])."
-	if(isobserver(user))
+	if(isxeno(user) || isobserver(user))
 		var/current_hugger_count = linked_hive.get_current_playable_facehugger_count();
 		. += "There are currently [SPAN_NOTICE("[current_hugger_count]")] facehuggers in the hive. The hive can support a total of [SPAN_NOTICE("[linked_hive.playable_hugger_limit]")] facehuggers at present."
 


### PR DESCRIPTION
# About the pull request

I kinda screwed up when adding this at https://github.com/cmss13-devs/cmss13/pull/6386 - there's no reason to have the facehugger limit hidden from xenos, the lesser drone limit is already visible to xenos when examining hive core.

# Explain why it's good for the game

Parity with lesser drone limit visibility.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: facehugger limit is visible when examining eggs/morpher as xeno, akin to lesser drone limit when examining hive core
/:cl:
