### PR TITLE
Lobby xeno late join queue information

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -234,6 +234,7 @@
  * Arguments:
  * * hive - The hive we're filling a slot for to check if the player is banished
  * * sorted - Whether to sort by larva_queue_time (default TRUE) or leave unsorted
+ * * abomination - Whether the potential larva is for an abomination
  */
 /proc/get_alien_candidates(datum/hive_status/hive = null, sorted = TRUE, abomination = FALSE)
 	var/list/candidates = list()

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -410,7 +410,7 @@ Additional game mode variables.
 						break
 					position++
 				candidate_new_player.larva_queue_message_stale_time = world.time + 3 MINUTES // spam prevention
-				candidate_new_player.larva_queue_cached_message = "Your position would be [position]\th in the larva queue if you observed and were elgible to be a xeno. \
+				candidate_new_player.larva_queue_cached_message = "Your position would be [position]\th in the larva queue if you observed and were eligible to be a xeno. \
 					The ordering is based on your time of death or the time you joined. When you have been dead long enough and are not inactive, \
 					you will periodically receive messages where you are in the queue relative to other currently valid xeno candidates. \
 					Your current position will shift as others change their preferences or go inactive, but your relative position compared to all observers is the same. \

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -389,15 +389,39 @@ Additional game mode variables.
 			available_xenos[larva_option] = list(hive)
 
 	if(!length(available_xenos) || (instant_join && !length(available_xenos_non_ssd)))
-		if(!xeno_candidate.client?.prefs || !(xeno_candidate.client.prefs.be_special & BE_ALIEN_AFTER_DEATH))
+		var/is_new_player = isnewplayer(xeno_candidate)
+		if(!xeno_candidate.client?.prefs || (!(xeno_candidate.client.prefs.be_special & BE_ALIEN_AFTER_DEATH) && !is_new_player))
 			to_chat(xeno_candidate, SPAN_WARNING("There aren't any available xenomorphs or burrowed larvae. \
 				You can try getting spawned as a chestburster larva by toggling your Xenomorph candidacy in \
 				Preferences -> Toggle SpecialRole Candidacy."))
 			return FALSE
 		to_chat(xeno_candidate, SPAN_WARNING("There aren't any available xenomorphs or burrowed larvae."))
 
+		// If a lobby player is trying to join as xeno, estimate their possible position
+		if(is_new_player)
+			var/mob/new_player/candidate_new_player = xeno_candidate
+			if(candidate_new_player.larva_queue_message_stale_time <= world.time)
+				// No cached/current lobby message, determine the position
+				var/list/valid_candidates = get_alien_candidates()
+				var/candidate_time = candidate_new_player.client.player_details.larva_queue_time
+				var/position = 1
+				for(var/mob/dead/observer/current in valid_candidates)
+					if(current.client.player_details.larva_queue_time >= candidate_time)
+						break
+					position++
+				candidate_new_player.larva_queue_message_stale_time = world.time + 3 MINUTES // spam prevention
+				candidate_new_player.larva_queue_cached_message = "Your position would be [position]\th in the larva queue if you observed and were elgible to be a xeno. \
+					The ordering is based on your time of death or the time you joined. When you have been dead long enough and are not inactive, \
+					you will periodically receive messages where you are in the queue relative to other currently valid xeno candidates. \
+					Your current position will shift as others change their preferences or go inactive, but your relative position compared to all observers is the same. \
+					Note: Playing as a facehugger or in the thunderdome will not alter your time of death. \
+					This means you won't lose your relative place in queue if you step away, disconnect, play as a facehugger, or play in the thunderdome."
+			to_chat(candidate_new_player, SPAN_XENONOTICE(candidate_new_player.larva_queue_cached_message))
+			return FALSE
+
 		if(!isobserver(xeno_candidate))
 			return FALSE
+
 		var/mob/dead/observer/candidate_observer = xeno_candidate
 
 		// If an observing mod wants to join as a xeno, disable their larva protection so that they can enter the queue.
@@ -414,7 +438,7 @@ Additional game mode variables.
 
 		// If we aren't in the queue yet, let's teach them about the queue
 		if(!candidate_observer.larva_queue_cached_message)
-			candidate_observer.larva_queue_cached_message = "You are currently awaiting assignment in the larva queue. \
+			candidate_observer.larva_queue_cached_message = "You are currently ineligible to be a larva but have a position in queue. \
 				The ordering is based on your time of death or the time you joined. When you have been dead long enough and are not inactive, \
 				you will periodically receive messages where you are in the queue relative to other currently valid xeno candidates. \
 				Your current position will shift as others change their preferences or go inactive, but your relative position compared to all observers is the same. \

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -414,8 +414,8 @@ Additional game mode variables.
 					The ordering is based on your time of death or the time you joined. When you have been dead long enough and are not inactive, \
 					you will periodically receive messages where you are in the queue relative to other currently valid xeno candidates. \
 					Your current position will shift as others change their preferences or go inactive, but your relative position compared to all observers is the same. \
-					Note: Playing as a facehugger or in the thunderdome will not alter your time of death. \
-					This means you won't lose your relative place in queue if you step away, disconnect, play as a facehugger, or play in the thunderdome."
+					Note: Playing as a facehugger/lesser or in the thunderdome will not alter your time of death. \
+					This means you won't lose your relative place in queue if you step away, disconnect, play as a facehugger/lesser, or play in the thunderdome."
 			to_chat(candidate_new_player, SPAN_XENONOTICE(candidate_new_player.larva_queue_cached_message))
 			return FALSE
 
@@ -449,8 +449,8 @@ Additional game mode variables.
 				The ordering is based on your time of death or the time you joined. When you have been dead long enough and are not inactive, \
 				you will periodically receive messages where you are in the queue relative to other currently valid xeno candidates. \
 				Your current position will shift as others change their preferences or go inactive, but your relative position compared to all observers is the same. \
-				Note: Playing as a facehugger or in the thunderdome will not alter your time of death. \
-				This means you won't lose your relative place in queue if you step away, disconnect, play as a facehugger, or play in the thunderdome."
+				Note: Playing as a facehugger/lesser or in the thunderdome will not alter your time of death. \
+				This means you won't lose your relative place in queue if you step away, disconnect, play as a facehugger/lesser, or play in the thunderdome."
 			to_chat(candidate_observer, SPAN_XENONOTICE(candidate_observer.larva_queue_cached_message))
 			return FALSE
 

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -434,11 +434,18 @@ Additional game mode variables.
 			return FALSE
 
 		// No cache, lets check now then
-		message_alien_candidates(get_alien_candidates(), dequeued = 0, cache_only = TRUE)
+		var/list/valid_candidates = get_alien_candidates()
+		message_alien_candidates(valid_candidates, dequeued = 0, cache_only = TRUE)
 
 		// If we aren't in the queue yet, let's teach them about the queue
 		if(!candidate_observer.larva_queue_cached_message)
-			candidate_observer.larva_queue_cached_message = "You are currently ineligible to be a larva but have a position in queue. \
+			var/candidate_time = candidate_observer.client.player_details.larva_queue_time
+			var/position = 1
+			for(var/mob/dead/observer/current in valid_candidates)
+				if(current.client.player_details.larva_queue_time >= candidate_time)
+					break
+				position++
+			candidate_observer.larva_queue_cached_message = "You are currently ineligible to be a larva but would be [position]\th in queue. \
 				The ordering is based on your time of death or the time you joined. When you have been dead long enough and are not inactive, \
 				you will periodically receive messages where you are in the queue relative to other currently valid xeno candidates. \
 				Your current position will shift as others change their preferences or go inactive, but your relative position compared to all observers is the same. \

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -61,6 +61,7 @@
 	var/own_orbit_size = 0
 	var/observer_actions = list(/datum/action/observer_action/join_xeno, /datum/action/observer_action/join_lesser_drone)
 	var/datum/action/minimap/observer/minimap
+	///The last message for this player with their larva queue information
 	var/larva_queue_cached_message
 	///Used to bypass time of death checks such as when being selected for larva.
 	var/bypass_time_of_death_checks = FALSE

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -154,7 +154,6 @@
 				return TRUE
 
 		if("late_join")
-
 			if(SSticker.current_state != GAME_STATE_PLAYING || !SSticker.mode)
 				to_chat(src, SPAN_WARNING("The round is either not ready, or has already finished..."))
 				return
@@ -202,7 +201,6 @@
 			ViewHiveLeaders()
 
 		if("SelectedJob")
-
 			if(!GLOB.enter_allowed)
 				to_chat(usr, SPAN_WARNING("There is an administrative lock on entering the game! (The dropship likely crashed into the Almayer. This should take at most 20 minutes.)"))
 				return

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -222,17 +222,17 @@
 
 	if(!client.prefs?.preview_dummy)
 		client.prefs.update_preview_icon()
-	var/mob/dead/observer/observer = new /mob/dead/observer(get_turf(pick(GLOB.latejoin)), client.prefs.preview_dummy)
+	var/mob/dead/observer/observer = new(get_turf(pick(GLOB.latejoin)), client.prefs.preview_dummy)
 	observer.set_lighting_alpha_from_pref(client)
 	spawning = TRUE
 	observer.started_as_observer = TRUE
 
 	close_spawn_windows()
 
-	var/obj/effect/landmark/observer_start/O = SAFEPICK(GLOB.observer_starts)
-	if(istype(O))
+	var/obj/effect/landmark/observer_start/spawn_point = SAFEPICK(GLOB.observer_starts)
+	if(istype(spawn_point))
 		to_chat(src, SPAN_NOTICE("Now teleporting."))
-		observer.forceMove(O.loc)
+		observer.forceMove(spawn_point.loc)
 	else
 		to_chat(src, SPAN_DANGER("Could not locate an observer spawn point. Use the Teleport verb to jump to the station map."))
 	observer.icon = 'icons/mob/humans/species/r_human.dmi'

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -120,7 +120,7 @@
 			if(!SSticker || SSticker.current_state == GAME_STATE_STARTUP)
 				to_chat(src, SPAN_WARNING("The game is still setting up, please try again later."))
 				return
-			if(alert(src,"Are you sure you wish to observe? When you observe, you will not be able to join as marine. It might also take some time to become a xeno or responder!","Player Setup","Yes","No") == "Yes")
+			if(tgui_alert(src, "Are you sure you wish to observe? When you observe, you will not be able to join as marine. It might also take some time to become a xeno or responder!", "Player Setup", list("Yes", "No")) == "Yes")
 				attempt_observe()
 				return TRUE
 
@@ -145,13 +145,13 @@
 				to_chat(src, SPAN_WARNING("The round is either not ready, or has already finished..."))
 				return
 
-			if(alert(src,"Are you sure you want to attempt joining as a xenomorph?","Confirmation","Yes","No") == "Yes" )
+			if(tgui_alert(src, "Are you sure you want to attempt joining as a xenomorph?", "Confirmation", list("Yes", "No")) == "Yes")
 				if(!client)
 					return TRUE
 				if(SSticker.mode.check_xeno_late_join(src))
 					var/mob/new_xeno = SSticker.mode.attempt_to_join_as_xeno(src, FALSE)
 					if(!new_xeno)
-						if(alert(src,"Do you sure you wish to observe to be a xeno candidate? When you observe, you will not be able to join as marine. It might also take some time to become a xeno or responder!","Player Setup","Yes","No") == "Yes")
+						if(tgui_alert(src, "Do you sure you wish to observe to be a xeno candidate? When you observe, you will not be able to join as marine. It might also take some time to become a xeno or responder!", "Player Setup", list("Yes", "No")) == "Yes")
 							if(!client)
 								return TRUE
 							if(client.prefs && !(client.prefs.be_special & BE_ALIEN_AFTER_DEATH))
@@ -167,7 +167,7 @@
 				to_chat(src, SPAN_WARNING("The round is either not ready, or has already finished..."))
 				return
 
-			if(alert(src,"Are you sure you want to attempt joining as a predator?","Confirmation","Yes","No") == "Yes" )
+			if(tgui_alert(src, "Are you sure you want to attempt joining as a predator?", "Confirmation", list("Yes", "No")) == "Yes")
 				if(SSticker.mode.check_predator_late_join(src,0))
 					close_spawn_windows()
 					SSticker.mode.attempt_to_join_as_predator(src)
@@ -264,7 +264,7 @@
 		to_chat(usr, SPAN_WARNING("There is an administrative lock on entering the game! (The dropship likely crashed into the Almayer. This should take at most 20 minutes.)"))
 		return
 	if(!GLOB.RoleAuthority.assign_role(src, player_rank, 1))
-		to_chat(src, alert("[rank] is not available. Please try another."))
+		to_chat(src, SPAN_WARNING("[rank] is not available. Please try another."))
 		return
 
 	spawning = TRUE

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -117,40 +117,7 @@
 				to_chat(src, SPAN_WARNING("The game is still setting up, please try again later."))
 				return
 			if(alert(src,"Are you sure you wish to observe? When you observe, you will not be able to join as marine. It might also take some time to become a xeno or responder!","Player Setup","Yes","No") == "Yes")
-				if(!client)
-					return TRUE
-				if(!client.prefs?.preview_dummy)
-					client.prefs.update_preview_icon()
-				var/mob/dead/observer/observer = new /mob/dead/observer(get_turf(pick(GLOB.latejoin)), client.prefs.preview_dummy)
-				observer.set_lighting_alpha_from_pref(client)
-				spawning = TRUE
-				observer.started_as_observer = TRUE
-
-				close_spawn_windows()
-
-				var/obj/effect/landmark/observer_start/O = SAFEPICK(GLOB.observer_starts)
-				if(istype(O))
-					to_chat(src, SPAN_NOTICE("Now teleporting."))
-					observer.forceMove(O.loc)
-				else
-					to_chat(src, SPAN_DANGER("Could not locate an observer spawn point. Use the Teleport verb to jump to the station map."))
-				observer.icon = 'icons/mob/humans/species/r_human.dmi'
-				observer.icon_state = "anglo_example"
-				observer.alpha = 127
-
-				if(client.prefs.be_random_name)
-					client.prefs.real_name = random_name(client.prefs.gender)
-				observer.real_name = client.prefs.real_name
-				observer.name = observer.real_name
-
-				mind.transfer_to(observer, TRUE)
-
-				if(observer.client)
-					observer.client.change_view(GLOB.world_view_size)
-
-				observer.set_huds_from_prefs()
-
-				qdel(src)
+				attemptObserve()
 				return TRUE
 
 		if("late_join")
@@ -229,6 +196,48 @@
 
 	var/datum/tutorial_menu/menu = new(src)
 	menu.ui_interact(src)
+
+/mob/new_player/proc/attemptObserve()
+	if(src != usr)
+		return
+	if(!client)
+		return
+	if(!SSticker || SSticker.current_state == GAME_STATE_STARTUP)
+		to_chat(src, SPAN_WARNING("The game is still setting up, please try again later."))
+		return
+
+	if(!client.prefs?.preview_dummy)
+		client.prefs.update_preview_icon()
+	var/mob/dead/observer/observer = new /mob/dead/observer(get_turf(pick(GLOB.latejoin)), client.prefs.preview_dummy)
+	observer.set_lighting_alpha_from_pref(client)
+	spawning = TRUE
+	observer.started_as_observer = TRUE
+
+	close_spawn_windows()
+
+	var/obj/effect/landmark/observer_start/O = SAFEPICK(GLOB.observer_starts)
+	if(istype(O))
+		to_chat(src, SPAN_NOTICE("Now teleporting."))
+		observer.forceMove(O.loc)
+	else
+		to_chat(src, SPAN_DANGER("Could not locate an observer spawn point. Use the Teleport verb to jump to the station map."))
+	observer.icon = 'icons/mob/humans/species/r_human.dmi'
+	observer.icon_state = "anglo_example"
+	observer.alpha = 127
+
+	if(client.prefs.be_random_name)
+		client.prefs.real_name = random_name(client.prefs.gender)
+	observer.real_name = client.prefs.real_name
+	observer.name = observer.real_name
+
+	mind.transfer_to(observer, TRUE)
+
+	if(observer.client)
+		observer.client.change_view(GLOB.world_view_size)
+
+	observer.set_huds_from_prefs()
+
+	qdel(src)
 
 /mob/new_player/proc/AttemptLateSpawn(rank)
 	var/datum/job/player_rank = GLOB.RoleAuthority.roles_for_mode[rank]

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -121,7 +121,7 @@
 				to_chat(src, SPAN_WARNING("The game is still setting up, please try again later."))
 				return
 			if(alert(src,"Are you sure you wish to observe? When you observe, you will not be able to join as marine. It might also take some time to become a xeno or responder!","Player Setup","Yes","No") == "Yes")
-				attemptObserve()
+				attempt_observe()
 				return TRUE
 
 		if("late_join")
@@ -157,7 +157,7 @@
 							if(client.prefs && !(client.prefs.be_special & BE_ALIEN_AFTER_DEATH))
 								client.prefs.be_special |= BE_ALIEN_AFTER_DEATH
 								to_chat(src, SPAN_BOLDNOTICE("You will now be considered for Xenomorph after unrevivable death events (where possible)."))
-							attemptObserve()
+							attempt_observe()
 					else if(!istype(new_xeno, /mob/living/carbon/xenomorph/larva))
 						SSticker.mode.transfer_xeno(src, new_xeno)
 						close_spawn_windows()
@@ -211,7 +211,7 @@
 	var/datum/tutorial_menu/menu = new(src)
 	menu.ui_interact(src)
 
-/mob/new_player/proc/attemptObserve()
+/mob/new_player/proc/attempt_observe()
 	if(src != usr)
 		return
 	if(!client)


### PR DESCRIPTION
# About the pull request

This PR adds some xeno queue information when late joining as a xeno from the lobby. It also streamlines the late join xeno from lobby process somewhat (automatically offers observation if there are no afk xenos, and automatically turns on xeno candidacy preference if done so). It also adds the same position estimate to your first cached message if you were to press the join as xeno button when you are presently ineligible.

There is also misc refactoring and additional autodoc comments for related variables.

# Explain why it's good for the game

Better new player experience and a bit more information for a player on the lobby to determine whether they want to wait in the xeno queue or late join as a marine.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

original implementation:
![example](https://github.com/user-attachments/assets/1293a06e-af0e-40a6-b65d-47ffd9d58227)

Addition to ineligible blub:
![image](https://github.com/user-attachments/assets/9e54a29a-cfbb-4447-bd3d-f543383e88bb)

tgui_alert change:
![example2](https://github.com/user-attachments/assets/8a65217d-3873-4e08-9952-79bc8c7fb740)

</details>


# Changelog
:cl: Drathek
add: Added xeno queue information when attempting a xeno late join while inelgible (from the lobby and first time after death)
qol: Streamlined the xeno late join process from lobby (offers observation and sets xeno preference)
ui: Changed some alerts on main menu to tgui_alert
/:cl:
