### PR TITLE
[ided] Predators are alerted on abom evo, not burst.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Embryo.dm
@@ -243,8 +243,6 @@
 
 	if(isyautja(affected_mob) || (flags_embryo & FLAG_EMBRYO_PREDATOR))
 		new_xeno = new /mob/living/carbon/xenomorph/larva/predalien(affected_mob)
-		yautja_announcement(SPAN_YAUTJABOLDBIG("WARNING!\n\nAn abomination has been detected at [get_area_name(new_xeno)]. It is a stain upon our purity and is unfit for life. Exterminate it immediately.\n\nHeavy Armory unlocked."))
-		SEND_GLOBAL_SIGNAL(COMSIG_GLOB_YAUTJA_ARMORY_OPENED)
 	else
 		new_xeno = new(affected_mob)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Predalien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Predalien.dm
@@ -91,6 +91,9 @@
 	if(!loc)
 		return FALSE
 
+	yautja_announcement(SPAN_YAUTJABOLDBIG("WARNING!\n\nAn abomination has been detected at [get_area_name(loc)]. It is a stain upon our purity and is unfit for life. Exterminate it immediately.\n\nHeavy Armory unlocked."))
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_YAUTJA_ARMORY_OPENED)
+
 	to_chat(src, {"
 <span class='role_body'>|______________________|</span>
 <span class='role_header'>You are a yautja-alien hybrid!</span>

--- a/code/modules/mob/living/carbon/xenomorph/castes/Predalien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Predalien.dm
@@ -126,6 +126,8 @@ You must still listen to the queen.
 /mob/living/carbon/xenomorph/predalien/tutorial/gib(datum/cause_data/cause = create_cause_data("gibbing", src))
 	death(cause, gibbed = TRUE)
 
+/mob/living/carbon/xenomorph/predalien/noannounce /// To not alert preds
+	should_announce_spawn = FALSE
 
 /datum/behavior_delegate/predalien_base
 	name = "Base Predalien Behavior Delegate"


### PR DESCRIPTION

# About the pull request

Abominations (predaliens) no longer alert preds that they exist the moment that they spawn, instead it occurs when the larva evos.

This also means that any adminspawned aboms will cause the alert to play, so I added a noannounce version of predalien for adminspawns

[ided] I made this PR because I had a round as researcher where we created a corrupted predalien only for preds to kill it before it even had a chance to evolve in containment.

![image](https://github.com/user-attachments/assets/58868eac-56c9-45b2-83c4-d6b94f236a8e)

# Explain why it's good for the game

If a abom bursts it should at least get a chance to evo before 2-3 preds shot up to HPC it.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Tested and works.

</details>


# Changelog
:cl:
balance: Abominations (predaliens) now alert preds when they EVO, instead of when they are created.
/:cl:
