### PR TITLE
Corporate Liaison Wardrobe Additions

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/corporate_liaison.dm
+++ b/code/game/machinery/vending/vendor_types/crew/corporate_liaison.dm
@@ -20,6 +20,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_dress_corporate_liaison, list(
 	list("Khaki Workwear", 0, /obj/item/clothing/under/colonist/workwear/khaki, MARINE_CAN_BUY_UNIFORM, VENDOR_ITEM_REGULAR),
 	list("Pink Workwear", 0, /obj/item/clothing/under/colonist/workwear/pink, MARINE_CAN_BUY_UNIFORM, VENDOR_ITEM_REGULAR),
 	list("Green Workwear", 0, /obj/item/clothing/under/colonist/workwear/green, MARINE_CAN_BUY_UNIFORM, VENDOR_ITEM_REGULAR),
+	list("Blue Workwear", 0, /obj/item/clothing/under/colonist/workwear/blue, MARINE_CAN_BUY_UNIFORM, VENDOR_ITEM_REGULAR),
 
 	list("SUIT", 0, null, null, null),
 	list("Black Suit Jacket", 0, /obj/item/clothing/suit/storage/jacket/marine/corporate/black, MARINE_CAN_BUY_ARMOR, VENDOR_ITEM_RECOMMENDED),
@@ -32,6 +33,10 @@ GLOBAL_LIST_INIT(cm_vending_clothing_dress_corporate_liaison, list(
 	list("Khaki Bomber Jacket", 0, /obj/item/clothing/suit/storage/jacket/marine/bomber, MARINE_CAN_BUY_ARMOR, VENDOR_ITEM_REGULAR),
 	list("Brown Bomber Jacket", 0, /obj/item/clothing/suit/storage/bomber, MARINE_CAN_BUY_ARMOR, VENDOR_ITEM_REGULAR),
 	list("Black Bomber Jacket", 0, /obj/item/clothing/suit/storage/bomber/alt, MARINE_CAN_BUY_ARMOR, VENDOR_ITEM_REGULAR),
+	list("Brown Windbreaker", 0, /obj/item/clothing/suit/storage/windbreaker/windbreaker_brown, MARINE_CAN_BUY_ARMOR, VENDOR_ITEM_REGULAR),
+	list("Grey Windbreaker", 0, /obj/item/clothing/suit/storage/windbreaker/windbreaker_gray, MARINE_CAN_BUY_ARMOR, VENDOR_ITEM_REGULAR),
+	list("Green Windbreaker", 0, /obj/item/clothing/suit/storage/windbreaker/windbreaker_green, MARINE_CAN_BUY_ARMOR, VENDOR_ITEM_REGULAR),
+	list("Expedition Windbreaker", 0, /obj/item/clothing/suit/storage/windbreaker/windbreaker_covenant, MARINE_CAN_BUY_ARMOR, VENDOR_ITEM_REGULAR),
 	list("Liaison's Winter Coat", 0, /obj/item/clothing/suit/storage/snow_suit/liaison, MARINE_CAN_BUY_ARMOR, VENDOR_ITEM_REGULAR),
 	list("Labcoat", 0, /obj/item/clothing/suit/storage/labcoat, MARINE_CAN_BUY_ARMOR, VENDOR_ITEM_REGULAR),
 	list("Grey Vest", 0, /obj/item/clothing/suit/storage/jacket/marine/vest/grey, MARINE_CAN_BUY_ARMOR, VENDOR_ITEM_REGULAR),

--- a/code/modules/gear_presets/survivors/survivors.dm
+++ b/code/modules/gear_presets/survivors/survivors.dm
@@ -37,6 +37,7 @@
 		/obj/item/clothing/under/colonist/workwear/khaki,
 		/obj/item/clothing/under/colonist/workwear/pink,
 		/obj/item/clothing/under/colonist/workwear/green,
+		/obj/item/clothing/under/colonist/workwear/blue,
 	)
 	dress_over = list(
 		/obj/item/clothing/suit/storage/jacket/marine/corporate/black,
@@ -55,6 +56,10 @@
 		/obj/item/clothing/suit/storage/jacket/marine/vest,
 		/obj/item/clothing/suit/storage/jacket/marine/vest/tan,
 		/obj/item/clothing/suit/storage/webbing,
+		/obj/item/clothing/suit/storage/windbreaker/windbreaker_brown,
+		/obj/item/clothing/suit/storage/windbreaker/windbreaker_gray,
+		/obj/item/clothing/suit/storage/windbreaker/windbreaker_green,
+		/obj/item/clothing/suit/storage/windbreaker/windbreaker_covenant,
 	)
 	dress_extra = list(
 		/obj/item/clothing/accessory/black,

--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -90,6 +90,10 @@
 		/obj/item/clothing/suit/storage/jacket/marine/vest,
 		/obj/item/clothing/suit/storage/jacket/marine/vest/tan,
 		/obj/item/clothing/suit/storage/webbing,
+		/obj/item/clothing/suit/storage/windbreaker/windbreaker_brown,
+		/obj/item/clothing/suit/storage/windbreaker/windbreaker_gray,
+		/obj/item/clothing/suit/storage/windbreaker/windbreaker_green,
+		/obj/item/clothing/suit/storage/windbreaker/windbreaker_covenant,
 	)
 	dress_extra = list(
 		/obj/item/clothing/accessory/black,

--- a/code/modules/gear_presets/wy.dm
+++ b/code/modules/gear_presets/wy.dm
@@ -29,6 +29,7 @@
 		/obj/item/clothing/under/colonist/workwear/khaki,
 		/obj/item/clothing/under/colonist/workwear/pink,
 		/obj/item/clothing/under/colonist/workwear/green,
+		/obj/item/clothing/under/colonist/workwear/blue,
 	)
 	dress_over = list(
 		/obj/item/clothing/suit/storage/jacket/marine/corporate/black,
@@ -47,6 +48,10 @@
 		/obj/item/clothing/suit/storage/jacket/marine/vest,
 		/obj/item/clothing/suit/storage/jacket/marine/vest/tan,
 		/obj/item/clothing/suit/storage/webbing,
+		/obj/item/clothing/suit/storage/windbreaker/windbreaker_brown,
+		/obj/item/clothing/suit/storage/windbreaker/windbreaker_gray,
+		/obj/item/clothing/suit/storage/windbreaker/windbreaker_green,
+		/obj/item/clothing/suit/storage/windbreaker/windbreaker_covenant,
 	)
 	dress_extra = list(
 		/obj/item/clothing/accessory/black,

--- a/code/modules/gear_presets/wy_goons.dm
+++ b/code/modules/gear_presets/wy_goons.dm
@@ -185,6 +185,7 @@
 		/obj/item/clothing/under/colonist/workwear/khaki,
 		/obj/item/clothing/under/colonist/workwear/pink,
 		/obj/item/clothing/under/colonist/workwear/green,
+		/obj/item/clothing/under/colonist/workwear/blue,
 	)
 	dress_over = list(
 		/obj/item/clothing/suit/storage/jacket/marine/corporate/black,
@@ -203,6 +204,10 @@
 		/obj/item/clothing/suit/storage/jacket/marine/vest,
 		/obj/item/clothing/suit/storage/jacket/marine/vest/tan,
 		/obj/item/clothing/suit/storage/webbing,
+		/obj/item/clothing/suit/storage/windbreaker/windbreaker_brown,
+		/obj/item/clothing/suit/storage/windbreaker/windbreaker_gray,
+		/obj/item/clothing/suit/storage/windbreaker/windbreaker_green,
+		/obj/item/clothing/suit/storage/windbreaker/windbreaker_covenant,
 	)
 	dress_extra = list(
 		/obj/item/clothing/accessory/black,


### PR DESCRIPTION

# About the pull request

This PR adds windbreakers and blue workwear to the Liaison's wardrobe. It includes the Brown, Gray, Green, and Explorer windbreakers. They all look very cool and are super useful when mixing with outfits (as shown in screenshots). I specifically omitted the First Responder windbreaker for... somewhat obvious reasons, it's for special people. I included the Explorer one because it's got a bit of flair, but its description still keeps it pretty generic. Nothing lore breaking.

The blue workwear was just to finish the set. I thought the corporate casual was literally the same as the blue workwear, but they are slightly different. So I added it.

I tested all the changes, as you can see those are in-game screenshots.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

More clothing items mean more people can express themselves in cool ways, and the Liaison benefits greatly from these specific items (as shown below).
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

Deckard
![Screenshot 2024-10-04 221955](https://github.com/user-attachments/assets/e41c49ed-9fba-4f29-b728-e24287d00e6a)

Aleksii Jorgen
![Screenshot 2024-10-04 221916](https://github.com/user-attachments/assets/8e11d7b4-823e-4238-a742-518d3adece72)

Nerd
![Screenshot 2024-10-04 221753](https://github.com/user-attachments/assets/f242f914-520c-4a7a-aebf-94d469442e15)

Gray
![Screenshot 2024-10-03 194247](https://github.com/user-attachments/assets/13beac4c-61de-46bc-bec7-34d35e10f418)

Explorer
![Screenshot 2024-10-03 194434](https://github.com/user-attachments/assets/11248efc-2d6c-4357-b06d-5213c76ad560)
![Screenshot 2024-10-03 194518](https://github.com/user-attachments/assets/c223c201-8fc1-4119-b9d7-2fb955dadfa9)

"It is an expression of pain..."
![Screenshot 2024-10-04 221829](https://github.com/user-attachments/assets/c55cc3b2-4ab2-4ba3-8900-8b5fc235f1a7)

Vendor
![Screenshot 2024-10-03 192452](https://github.com/user-attachments/assets/34633d7a-b172-484d-a4c7-a6dd622ed224)

</details>


# Changelog
:cl:
add: added 4 wind breakers to the Liaison's wardrobe
add: added the blue workwear to the Liaison's wardrobe
/:cl:
