### PR TITLE
Fix Xeno huds Alpha Invisibility (Lurkers and Burrowers)

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -104,6 +104,8 @@
 				I = image('icons/mob/hud/hud_yautja.dmi', src, "")
 			if(HOLOCARD_HUD)
 				I = image('icons/mob/hud/marine_hud.dmi', src, "")
+		if(hud in /datum/mob_hud/xeno::hud_icons)
+			I.appearance_flags |= RESET_ALPHA
 		I.appearance_flags |= NO_CLIENT_COLOR|KEEP_APART|RESET_COLOR
 		hud_list[hud] = I
 


### PR DESCRIPTION

# About the pull request

Makes xeno huds visible for xenos that use alpha to become invisible.

# Explain why it's good for the game

Makes xenos like lurkers more "visible" to other sisters around, now you can see their HUD's and help them when they are in critical, i seen few times that lurkers died near sisters in critical because they were invisible and hard to spot.


# Testing Photographs and Procedure
<details>
<summary>Click HERE to see Videos.</summary>

Before:

https://github.com/user-attachments/assets/b9dc2ca3-53c3-417f-8929-8a637af90acb


After: 

https://github.com/user-attachments/assets/cb9e8f06-e4fc-42d3-bd77-f1b864790cdf


</details>


# Changelog
:cl: Harry, Venuska1117
code: Makes all xeno huds ignore alpha, it makes them visible during invisibility.
/:cl:
