### PR TITLE
Fixes Queen being unable to stomp xenos

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -443,8 +443,8 @@
 /mob/living/carbon/xenomorph/queen/proc/check_block(mob/queen, turf/new_loc)
 	SIGNAL_HANDLER
 	for(var/mob/living/carbon/xenomorph/xeno in new_loc.contents)
-		if(xeno.pass_flags.flags_pass & PASS_MOB_THRU_XENO|PASS_MOB_THRU && !(xeno.flags_pass_temp & PASS_MOB_THRU))
-			return
+		if(xeno.pass_flags.flags_pass & (PASS_MOB_THRU_XENO|PASS_MOB_THRU) && !(xeno.flags_pass_temp & PASS_MOB_THRU))
+			continue
 		if(xeno.hivenumber == hivenumber)
 			xeno.KnockDown((5 DECISECONDS) / GLOBAL_STATUS_MULTIPLIER)
 			playsound(src, 'sound/weapons/alien_knockdown.ogg', 25, 1)


### PR DESCRIPTION

# About the pull request

Queen was unable to stomp *any* other xeno after https://github.com/cmss13-devs/cmss13/pull/7228

We want to OR the two conditions first, and then AND them. Currently we were AND'ing the first 2 parameters (giving 0 in most cases), and then OR'ing them. (giving non-zero)

Adds a continue instead of a return in the case that we have multiple xenos on the tile, some of which we want to stomp

Fixed now.

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixes being unable to stomp xenos as Queen
/:cl:
