### PR TITLE
Fix unintended reagent refilling via vendors

### DIFF
--- a/code/game/machinery/vending/vendor_types/medical.dm
+++ b/code/game/machinery/vending/vendor_types/medical.dm
@@ -257,6 +257,8 @@
 		/obj/item/reagent_container/hypospray/autoinjector/tramadol/skillless,
 		/obj/item/reagent_container/hypospray/autoinjector/tricord/skillless,
 
+		/obj/item/reagent_container/hypospray/tricordrazine,
+
 		/obj/item/reagent_container/glass/bottle/bicaridine,
 		/obj/item/reagent_container/glass/bottle/antitoxin,
 		/obj/item/reagent_container/glass/bottle/dexalin,

--- a/code/game/machinery/vending/vendor_types/medical.dm
+++ b/code/game/machinery/vending/vendor_types/medical.dm
@@ -326,8 +326,6 @@
 	if(missing_reagents <= 0)
 		return TRUE
 	if(!LAZYLEN(chem_refill) || !(container.type in chem_refill))
-		if(container.reagents.total_volume == initial(container.reagents.total_volume))
-			return TRUE
 		to_chat(user, SPAN_WARNING("[src] cannot refill [container]."))
 		return FALSE
 	if(chem_refill_volume < missing_reagents)

--- a/code/game/machinery/vending/vendor_types/medical.dm
+++ b/code/game/machinery/vending/vendor_types/medical.dm
@@ -242,7 +242,7 @@
 	var/list/chem_refill = list(
 		/obj/item/reagent_container/hypospray/autoinjector/bicaridine,
 		/obj/item/reagent_container/hypospray/autoinjector/dexalinp,
-		/obj/item/reagent_container/hypospray/autoinjector/adrenaline,,
+		/obj/item/reagent_container/hypospray/autoinjector/adrenaline,
 		/obj/item/reagent_container/hypospray/autoinjector/inaprovaline,
 		/obj/item/reagent_container/hypospray/autoinjector/kelotane,
 		/obj/item/reagent_container/hypospray/autoinjector/oxycodone,


### PR DESCRIPTION
# About the pull request

This PR fixes injectors & crystals that were fully emptied from being refilled in any medical vendor. I'm not sure if initial volume for injectors changed, or what situation exactly this check was trying to handle, but as far as I can tell it can be removed to patch this exploit without issue.

Of note, emergency injectors did not used to be refilled prior to #6103, nor was it my intention to allow them to. The chem_refill list for each vendor is what whitelists items that can be refilled. However I am aware that this bug has existed a significant amount of time so I will be evaluating if it should return in some way.

# Explain why it's good for the game

Reagents are intended to be withdrawn from vendors, and only from vendors that refill those reagents.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/QpDpRhtcQuM

</details>


# Changelog
:cl: Drathek
fix: Fixed autoinjectors not reducing vendor reagents on refill if they were fully emptied.
fix: Fixed crystals (and any other reagent container not whitelisted) from being refilled in vendors
balance: This means emergency injectors do not refill again.
balance: Added tricord hypospray chem refill support to Wey-Med Plus
/:cl:
