### PR TITLE
automatically connect people via selected relay

### DIFF
--- a/code/__DEFINES/client_prefs.dm
+++ b/code/__DEFINES/client_prefs.dm
@@ -53,3 +53,6 @@
 #define DUAL_WIELD_SWAP 1
 ///Do nothing when dual wielding
 #define DUAL_WIELD_NONE 2
+
+#define RELAY_UNSELECTED "unselected"
+#define RELAY_SELECTED_NONE "none selected"

--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -77,3 +77,13 @@
 			if(65 to 70) . += ascii2text(ascii+32) //letters A to F - translates to lowercase
 			else return default
 	return .
+
+/proc/sanitize_relay(selected_relay)
+	if(selected_relay == RELAY_SELECTED_NONE || selected_relay == RELAY_UNSELECTED)
+		return selected_relay
+
+	for(var/key in CONFIG_GET(keyed_list/connection_relay_con))
+		if(selected_relay == key)
+			return selected_relay
+
+	return RELAY_UNSELECTED

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -321,6 +321,8 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 	prefs.last_id = computer_id //these are gonna be used for banning
 	fps = prefs.fps
 
+	check_connection_url()
+
 	notify_login()
 
 	load_xeno_name()
@@ -921,3 +923,37 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 		winset(src, "mapwindow.map", "right-click=false")
 		winset(src, "default.Shift", "is-disabled=true")
 		winset(src, "default.ShiftUp", "is-disabled=true")
+
+/client/proc/check_connection_url()
+	set waitfor = FALSE
+
+	if(prefs.selected_relay == RELAY_SELECTED_NONE)
+		return
+
+	var/relay_con_conf = CONFIG_GET(keyed_list/connection_relay_con)
+
+	if(!length(relay_con_conf))
+		return
+
+	var/url = winget(src, null, "url")
+
+	var/connected_relay
+
+	for(var/key in relay_con_conf)
+		var/value = relay_con_conf[key]
+
+		if(value == url)
+			connected_relay = value
+			break
+
+	if(connected_relay == prefs.selected_relay)
+		to_chat(src, SPAN_INFO("You are currently connected to the [connected_relay] relay!"))
+		return
+
+	if(!connected_relay)
+		if(prefs.selected_relay == RELAY_UNSELECTED)
+			to_chat(src, SPAN_LARGE(SPAN_WARNING("You are not connected via a relay, and you have not selected one in Character Setup. Disable this message in Character Setup, or pick a relay close to your location via the Ping button.")))
+			return
+
+		to_chat_immediate(src, SPAN_NOTICE("Redirecting your connection via your selected relay, please wait to reconnect..."))
+		src << link(relay_con_conf[prefs.selected_relay])

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -288,6 +288,7 @@
 	S["adaptive_zoom"] >> adaptive_zoom
 	S["tooltips"] >> tooltips
 	S["key_bindings"] >> key_bindings
+	S["selected_relay"] >> selected_relay
 
 	var/list/remembered_key_bindings
 	S["remembered_key_bindings"] >> remembered_key_bindings
@@ -361,6 +362,7 @@
 	custom_cursors = sanitize_integer(custom_cursors, FALSE, TRUE, TRUE)
 	pref_special_job_options = sanitize_islist(pref_special_job_options, list())
 	pref_job_slots = sanitize_islist(pref_job_slots, list())
+	selected_relay = sanitize_relay(selected_relay)
 	vars["fps"] = fps
 
 	check_keybindings()
@@ -487,6 +489,7 @@
 	S["no_radials_preference"] << no_radials_preference
 	S["no_radial_labels_preference"] << no_radial_labels_preference
 	S["custom_cursors"] << custom_cursors
+	S["selected_relay"] << selected_relay
 
 	return TRUE
 


### PR DESCRIPTION
prompts people to connect to a relay instead of directly if available. can opt out of the warning by intentionally selecting no relay in settings

:cl:
server: if relays have been set up, the server will prompt people to select a preferred relay, and connect them over the relay when possible
/:cl:
