### PR TITLE
Follow Menu Tweaks

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -71,6 +71,7 @@
 	var/list/npcs = list()
 	var/list/vehicles = list()
 	var/list/escaped = list()
+	var/list/in_thunderdome = list()
 
 	var/is_admin = FALSE
 	if(user && user.client)
@@ -84,32 +85,32 @@
 
 		serialized["ref"] = REF(poi)
 
-		var/mob/M = poi
-		if(!istype(M))
-			if(isVehicleMultitile(M))
+		var/mob/poi_mob = poi
+		if(!istype(poi_mob))
+			if(isVehicleMultitile(poi_mob))
 				vehicles += list(serialized)
 			else
 				misc += list(serialized)
 			continue
 
-		var/number_of_orbiters = length(M.get_all_orbiters())
+		var/number_of_orbiters = length(poi_mob.get_all_orbiters())
 		if(number_of_orbiters)
 			serialized["orbiters"] = number_of_orbiters
 
-		if(isobserver(M))
+		if(isobserver(poi_mob))
 			ghosts += list(serialized)
 			continue
 
-		if(M.stat == DEAD)
+		if(poi_mob.stat == DEAD)
 			dead += list(serialized)
 			continue
 
-		if(M.ckey == null)
+		if(poi_mob.ckey == null)
 			npcs += list(serialized)
 			continue
 
-		if(isliving(M))
-			var/mob/living/player = M
+		if(isliving(poi_mob))
+			var/mob/living/player = poi_mob
 			serialized["health"] = floor(player.health / player.maxHealth * 100)
 
 			if(isxeno(player))
@@ -144,7 +145,9 @@
 				else
 					serialized["background_color"] = human.assigned_equipment_preset?.minimap_background
 
-				if(SSticker.mode.is_in_endgame == TRUE && !is_mainship_level(M.z) && !(human.faction in FACTION_LIST_ERT_ALL))
+				if(istype(get_area(human), /area/tdome))
+					in_thunderdome += list(serialized)
+				else if(SSticker.mode.is_in_endgame == TRUE && !is_mainship_level(human.z) && !(human.faction in FACTION_LIST_ERT_ALL) && !(isyautja(human)))
 					escaped += list(serialized)
 				else if(human.faction in FACTION_LIST_WY)
 					wy += list(serialized)
@@ -203,6 +206,7 @@
 	data["npcs"] = npcs
 	data["vehicles"] = vehicles
 	data["escaped"] = escaped
+	data["in_thunderdome"] = in_thunderdome
 	data["icons"] = GLOB.minimap_icons
 
 	return data

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -120,6 +120,7 @@
 					serialized["caste"] = caste.caste_type
 					serialized["icon"] = caste.minimap_icon
 					serialized["hivenumber"] = xeno.hivenumber
+					serialized["area_name"] = get_area_name(xeno)
 				xenos += list(serialized)
 				continue
 

--- a/tgui/packages/tgui/interfaces/Orbit/index.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/index.tsx
@@ -127,13 +127,16 @@ const ObservableSearch = () => {
 };
 
 const xenoSplitter = (members: Array<Observable>) => {
+  const tdomeHive: Array<Observable> = [];
   const primeHive: Array<Observable> = [];
   const corruptedHive: Array<Observable> = [];
   const forsakenHive: Array<Observable> = [];
   const otherHives: Array<Observable> = [];
 
   members.forEach((x) => {
-    if (x.hivenumber?.includes('normal')) {
+    if (x.area_name?.includes('Thunderdome')) {
+      tdomeHive.push(x);
+    } else if (x.hivenumber?.includes('normal')) {
       primeHive.push(x);
     } else if (x.hivenumber?.includes('corrupted')) {
       corruptedHive.push(x);
@@ -144,6 +147,7 @@ const xenoSplitter = (members: Array<Observable>) => {
     }
   });
   const squads = [
+    buildSquadObservable('Thunderdome', 'xeno', tdomeHive),
     buildSquadObservable('Prime', 'xeno', primeHive),
     buildSquadObservable('Corrupted', 'green', corruptedHive),
     buildSquadObservable('Forsaken', 'grey', forsakenHive),

--- a/tgui/packages/tgui/interfaces/Orbit/index.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/index.tsx
@@ -305,6 +305,7 @@ const ObservableContent = () => {
     npcs = [],
     vehicles = [],
     escaped = [],
+    in_thunderdome = [],
   } = data;
 
   return (
@@ -373,6 +374,11 @@ const ObservableContent = () => {
       />
       <ObservableSection color="green" section={predators} title="Predators" />
       <ObservableSection color="olive" section={escaped} title="Escaped" />
+      <ObservableSection
+        color="orange"
+        section={in_thunderdome}
+        title="Thunderdome"
+      />
       <ObservableSection section={vehicles} title="Vehicles" />
       <ObservableSection section={animals} title="Animals" />
       <ObservableSection section={dead} title="Dead" />

--- a/tgui/packages/tgui/interfaces/Orbit/types.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/types.ts
@@ -25,6 +25,7 @@ export type OrbitData = {
   npcs: Observable[];
   vehicles: Observable[];
   escaped: Observable[];
+  in_thunderdome: Observable[];
   icons?: string[];
 };
 

--- a/tgui/packages/tgui/interfaces/Orbit/types.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/types.ts
@@ -40,6 +40,7 @@ export type Observable = {
   orbiters?: number;
   ref: string;
   hivenumber: string;
+  area_name: string;
 };
 
 export type SquadObservable = {


### PR DESCRIPTION

# About the pull request

Prevents Yautja from being moved to 'Escaped' after hijack.
Adds TDome as a category, stopping admin-spawns from cluttering the normal follow menu places.
Changes one letter var

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
code: Changes a one letter var in follow menu code.
add: Mobs in Thunder Dome now populate their own category, instead of being confused with live-round mobs.
fix: Yautja no longer appear in the Escaped category of follow menu after round end.
/:cl:
