### PR TITLE
Increases the ChemMaster reagent buffer size from 300 to 500

### DIFF
--- a/code/modules/reagents/chemistry_machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_master.dm
@@ -27,7 +27,7 @@
 
 /obj/structure/machinery/chem_master/Initialize()
 	. = ..()
-	create_reagents(300)
+	create_reagents(500)
 	connect_smartfridge()
 
 /obj/structure/machinery/chem_master/Destroy()


### PR DESCRIPTION

# About the pull request

Increases the ChemMaster maximum reagent volume from 300 to 500.

While a somewhat uncommon occurrence, there are reasons for which you might want to batch craft pills that contain a combined reagent amount greater than 300 - the current maximum volume for the buffer. Currently, this can still be done by making the pills in multiple batches, i.e: half the pills with half the reagents, done twice. However, it's added tedium to an already pretty tedius process.

Increasing the maximum to 500 - chosen because it's the amount that janitorial buckets can hold - makes this process less tedious, while ultimately not affecting anything else. 


# Explain why it's good for the game

QoL. Doesn't negatively impact anything.
See the above PR description.


# Testing Photographs and Procedure
<details>

![image](https://github.com/user-attachments/assets/ff1d0d00-e5c6-4edb-94eb-c1b7a723e857)

</details>


# Changelog
:cl:
qol: Increased the ChemMaster reagent buffer from 300 to 500
/:cl:
