### PR TITLE
Makes Resin Salve only go on CD after successful activations, not attempted ones

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/drone/healer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/drone/healer.dm
@@ -61,11 +61,11 @@
 	xeno_cooldown = 0.5 SECONDS
 
 /datum/action/xeno_action/activable/apply_salve/use_ability(atom/target_atom)
+	no_cooldown_msg = TRUE
 	if(!action_cooldown_check())
 		return
 	var/mob/living/carbon/xenomorph/xeno = owner
 	xeno.xeno_apply_salve(target_atom, health_transfer_amount, max_range, damage_taken_mod)
-	apply_cooldown()
 	return ..()
 
 /datum/action/xeno_action/verb/verb_apply_salve()
@@ -124,6 +124,8 @@
 	if(target_is_healer)
 		damage_taken_mod = 1
 
+	for(var/datum/action/xeno_action/activable/apply_salve/source_action in usr.actions)
+		source_action.apply_cooldown()
 	face_atom(target_xeno)
 	adjustBruteLoss(amount * damage_taken_mod)
 	use_plasma(amount * 2)

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/drone/healer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/drone/healer.dm
@@ -124,7 +124,7 @@
 	if(target_is_healer)
 		damage_taken_mod = 1
 
-	for(var/datum/action/xeno_action/activable/apply_salve/source_action in usr.actions)
+	for(var/datum/action/xeno_action/activable/apply_salve/source_action in actions)
 		source_action.apply_cooldown()
 	face_atom(target_xeno)
 	adjustBruteLoss(amount * damage_taken_mod)


### PR DESCRIPTION

# About the pull request

#6847 introduced a cooldown to the healer drone's salve ability. Specifically, it was set to apply on an attempted activation of the ability, not just on a successful activation of it. 

This has made the usage of the ability, and thus healer in general, feel more clunky. It's not an ability like warrior's lunge where the way the cooldown is applied has considerable balancing concerns, so this moves the cooldown to successful activations only.

Also removes the notification for the resin salve cooldown expiring. It's a 0.5 second cooldown, it doesn't need a notification.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

QoL. Makes the main ability of the healer caste feel less clunky and overall nicer to use.
Considering that the old version of this ability didn't even have a cooldown, I don't see this affecting balance in any meaningful way.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://streamable.com/wuyf3t

</details>


# Changelog
:cl:
qol: Makes Resin Salve only go on CD after successful activations, not attempted ones
qol: Removes the chat notification for Resin Salve going off CD (it's a 0.5 second CD)
/:cl:
