### PR TITLE
Kutjevo/Fiorina Liaison Survivors (Plus Minor Additions)

### DIFF
--- a/code/modules/gear_presets/survivors/fiorina_sciannex/preset_fiorina_sciannex.dm
+++ b/code/modules/gear_presets/survivors/fiorina_sciannex/preset_fiorina_sciannex.dm
@@ -12,6 +12,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/science(new_human), WEAR_EYES)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/tox(new_human), WEAR_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/laceup(new_human), WEAR_FEET)
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/WY(new_human), WEAR_L_EAR)
 	..()
 
 
@@ -22,6 +23,7 @@
 /datum/equipment_preset/survivor/doctor/fiorina/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/rank/medical/lightblue(new_human), WEAR_BODY)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/pmc(new_human), WEAR_HEAD)
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/WY(new_human), WEAR_L_EAR)
 	..()
 
 /datum/equipment_preset/survivor/security/fiorina
@@ -33,6 +35,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/holobadge(new_human), WEAR_ACCESSORY)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/sec(new_human), WEAR_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/armor/vest/security(new_human), WEAR_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/WY(new_human), WEAR_L_EAR)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/soft/sec/corp(new_human), WEAR_HEAD)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/veteran(new_human), WEAR_HANDS)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots(new_human), WEAR_FEET)
@@ -63,4 +66,15 @@
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/eng(new_human), WEAR_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots(new_human), WEAR_FEET)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/hardhat/orange(new_human), WEAR_HEAD)
+	..()
+
+/datum/equipment_preset/survivor/corporate/fiorina
+	name = "Survivor - Fiorina Corporate Liaison"
+	assignment = "Fiorina Corporate Liaison"
+
+/datum/equipment_preset/survivor/corporate/fiorina/load_gear(mob/living/carbon/human/new_human)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/liaison_suit(new_human), WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/regular/hipster(new_human), WEAR_EYES)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/armor/vest/security, WEAR_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/laceup/brown(new_human), WEAR_FEET)
 	..()

--- a/code/modules/gear_presets/survivors/kutjevo/preset_kutjevo.dm
+++ b/code/modules/gear_presets/survivors/kutjevo/preset_kutjevo.dm
@@ -73,3 +73,17 @@
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/yellow(new_human), WEAR_HANDS)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel(new_human), WEAR_BACK)
 	..()
+
+/datum/equipment_preset/survivor/corporate/kutjevo
+	name = "Survivor - Kutjevo Corporate Liaison"
+	assignment = "Kutjevo Corporate Liaison"
+
+/datum/equipment_preset/survivor/corporate/kutjevo/load_gear(mob/living/carbon/human/new_human)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/liaison_suit/orange(new_human), WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/kutjevo(new_human), WEAR_EYES)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/kutjevo (new_human), WEAR_FACE)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(new_human), WEAR_HANDS)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/armor/vest, WEAR_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/kutjevo(new_human), WEAR_HEAD)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/corporate(new_human), WEAR_FEET)
+	..()

--- a/maps/fiorina_sciannex.json
+++ b/maps/fiorina_sciannex.json
@@ -13,6 +13,7 @@
         "/datum/equipment_preset/survivor/prisoner",
         "/datum/equipment_preset/survivor/gangleader",
         "/datum/equipment_preset/survivor/engineer/fiorina",
+        "/datum/equipment_preset/survivor/corporate/fiorina",
         "/datum/equipment_preset/survivor/clf",
         "/datum/equipment_preset/survivor/civilian"
     ],

--- a/maps/kutjevo.json
+++ b/maps/kutjevo.json
@@ -11,6 +11,7 @@
         "/datum/equipment_preset/survivor/colonial_marshal/kutjevo",
         "/datum/equipment_preset/survivor/trucker/kutjevo",
         "/datum/equipment_preset/survivor/security/kutjevo",
+        "/datum/equipment_preset/survivor/corporate/kutjevo",
         "/datum/equipment_preset/survivor/clf",
         "/datum/equipment_preset/survivor/civilian"
     ],


### PR DESCRIPTION
# About the pull request

Adds two new survivor presets to the game, the Fiorina Corporate Liaison and the Kutjevo Corporate Liaison.
It's pretty self-explanatory, they spawn on Fiorina and Kutjevo respectively. 
I also gave them nice, unique outfits for the maps they spawn on. Fiorina gets a tan-suited NERD, and Kutjevo gets an orange-wearing field worker with proper Kutjevo PPE.

In addition to the liaisons, I also gave all the WY roles on Fiorina WY headsets (as they should). The doctors are literally wearing PMC hats, and they don't get access to WY comms. It was dumb, now they all have WY headsets. All being the Fiorina Prison Guard (WY Security), Fiorina Doctor, and Fiorina Researcher.

I tested all of these ingame, they all work. Screenshots below.

Includes no mapping changes, no sprite changes, and hopefully nothing that conflicts with other PRs 👍 

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Fiorina and Kutjevo completely lacked liaison roles previously. It was weird. Now they have em! 
It was especially weird considering how important they are as WY facilities, it made no sense why they specifically got the short end of the stick.

And the fact that the WY roles did not have WY comms was weird. WY guards usually have WY comms (LV-624, Trijent Dam, standard goon survivors, etc). The doctors are also wearing PMC caps, it only makes sense. The engineers also seem to be WY-hired, but they're just general contractors, so nothing for them.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Fiorina Liaison
![image](https://github.com/user-attachments/assets/dc30c93e-da2b-41c7-8d07-4878044c10ea)
![image](https://github.com/user-attachments/assets/bc13c891-f30c-4782-bfa0-2d8bce43283b)

Kutjevo Liaison
![image](https://github.com/user-attachments/assets/d2154cd2-1696-429c-b1e1-f97e6532e816)
![image](https://github.com/user-attachments/assets/bc644c1e-723e-4d9d-a97f-8434714f2e76)

</details>


# Changelog
:cl:
add: Fiorina Corporate Liaison
add: Kutjevo Corporate Liaison
add: WY Headsets to WY roles on Fiorina
/:cl:
