### PR TITLE
Almayer Squad Hypersleep Changes (removing 1x1s and adding decals)

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -6013,7 +6013,11 @@
 /area/almayer/hallways/hangar)
 "aNc" = (
 /obj/structure/bed/chair{
-	dir = 4
+	dir = 8;
+	pixel_y = 3
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
 	},
 /turf/open/floor/almayer/red/north,
 /area/almayer/squads/alpha)
@@ -6076,21 +6080,15 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/surface/table/almayer,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/alpha)
 "aNT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
 	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/squads/alpha)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/plate,
+/area/almayer/squads/delta)
 "aNW" = (
 /turf/open/floor/almayer/redcorner,
 /area/almayer/shipboard/brig/starboard_hallway)
@@ -6204,8 +6202,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 9
 	},
-/obj/structure/surface/table/almayer,
-/obj/item/facepaint/green,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/alpha)
 "aOM" = (
@@ -6832,10 +6828,15 @@
 /turf/open/floor/almayer/red/southwest,
 /area/almayer/lifeboat_pumps/north1)
 "aSE" = (
-/obj/structure/bed/chair{
-	dir = 4
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
 	},
-/turf/open/floor/almayer,
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/plate,
 /area/almayer/squads/bravo)
 "aSH" = (
 /obj/structure/machinery/light,
@@ -7802,6 +7803,13 @@
 "bbs" = (
 /turf/closed/wall/almayer,
 /area/almayer/living/cryo_cells)
+"bbu" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out";
+	pixel_x = -1
+	},
+/turf/open/floor/almayer/blue/north,
+/area/almayer/squads/delta)
 "bby" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out"
@@ -7955,6 +7963,17 @@
 /obj/structure/machinery/cm_vending/gear/engi,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/alpha)
+"bcH" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/plate,
+/area/almayer/squads/bravo)
 "bcK" = (
 /obj/structure/machinery/smartfridge/chemistry,
 /obj/structure/machinery/door/firedoor/border_only/almayer,
@@ -8840,6 +8859,14 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/upper/fore_hallway)
 "bjA" = (
+/obj/structure/surface/table/almayer,
+/obj/item/trash/USCMtray{
+	pixel_y = 7
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
+	pixel_x = 1
+	},
 /turf/open/floor/almayer/red/northwest,
 /area/almayer/squads/alpha)
 "bjD" = (
@@ -9404,8 +9431,8 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/structure/bed/chair{
-	dir = 4
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/bravo)
@@ -9792,9 +9819,6 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/structure/bed/chair{
-	dir = 4
-	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/bravo)
 "brH" = (
@@ -9803,6 +9827,14 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
+	pixel_x = 1
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/bravo)
@@ -9942,9 +9974,9 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/bravo)
 "bsU" = (
-/obj/structure/surface/table/almayer,
-/obj/item/trash/USCMtray{
-	pixel_y = 7
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out";
+	pixel_x = -1
 	},
 /turf/open/floor/almayer/red/northeast,
 /area/almayer/squads/alpha)
@@ -9960,14 +9992,11 @@
 /turf/open/floor/plating,
 /area/almayer/maint/upper/u_a_s)
 "btc" = (
-/obj/structure/bed/chair{
-	dir = 8;
-	pixel_y = 3
-	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out";
 	pixel_x = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/redfull,
 /area/almayer/squads/alpha)
 "bti" = (
@@ -10242,9 +10271,9 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/surface/table/almayer,
-/obj/item/trash/USCMtray{
-	pixel_y = 7
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
 	},
 /turf/open/floor/almayer/red/east,
 /area/almayer/squads/alpha)
@@ -10254,10 +10283,6 @@
 	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
-	},
-/obj/structure/bed/chair{
-	dir = 8;
-	pixel_y = 3
 	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -10573,6 +10598,10 @@
 	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 6
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
 	},
 /turf/open/floor/almayer/redcorner/north,
 /area/almayer/squads/alpha)
@@ -10909,8 +10938,11 @@
 /turf/open/floor/almayer/cargo,
 /area/almayer/living/cryo_cells)
 "bCP" = (
-/obj/structure/bed/chair{
-	dir = 1
+/obj/structure/bed/chair,
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_x = -1;
+	pixel_y = 2
 	},
 /turf/open/floor/almayer/red/southeast,
 /area/almayer/squads/alpha)
@@ -10921,6 +10953,11 @@
 "bCS" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 9
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_x = 1;
+	pixel_y = 1
 	},
 /turf/open/floor/almayer/red,
 /area/almayer/squads/alpha)
@@ -11190,6 +11227,7 @@
 /turf/open/floor/almayer/redcorner,
 /area/almayer/shipboard/weapon_room)
 "bEG" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/red/southeast,
 /area/almayer/squads/alpha)
 "bEK" = (
@@ -11802,12 +11840,25 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_x = 1;
+	pixel_y = 1
+	},
 /turf/open/floor/almayer/orangecorner/north,
 /area/almayer/squads/bravo)
 "bJH" = (
 /obj/structure/surface/table/almayer,
 /obj/item/facepaint/black{
 	pixel_x = -4
+	},
+/obj/item/reagent_container/food/condiment/hotsauce/cholula{
+	pixel_x = 10;
+	pixel_y = 22
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/bravo)
@@ -11923,6 +11974,13 @@
 "bKC" = (
 /obj/structure/surface/table/almayer,
 /obj/item/facepaint/green,
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
+	},
 /turf/open/floor/almayer,
 /area/almayer/squads/bravo)
 "bKD" = (
@@ -12220,6 +12278,10 @@
 /turf/open/floor/almayer/emerald/north,
 /area/almayer/squads/charlie)
 "bMC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/mirror{
+	pixel_x = -32
+	},
 /turf/open/floor/almayer/emerald/northwest,
 /area/almayer/squads/charlie)
 "bMD" = (
@@ -12505,17 +12567,15 @@
 /turf/open/floor/almayer/orange,
 /area/almayer/hallways/hangar)
 "bOG" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out";
+	pixel_x = -1
 	},
-/obj/structure/surface/table/almayer,
-/obj/item/trash/USCMtray{
-	pixel_y = 7
-	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/almayer/orange/north,
 /area/almayer/squads/bravo)
 "bOJ" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
@@ -12573,7 +12633,13 @@
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/food/condiment/hotsauce/sriracha{
 	pixel_x = 7;
-	pixel_y = 7
+	pixel_y = 17
+	},
+/obj/item/facepaint/green{
+	pixel_y = 2
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/charlie)
@@ -12875,8 +12941,16 @@
 /area/almayer/shipboard/sea_office)
 "bRf" = (
 /obj/structure/surface/table/almayer,
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/item/toy/deck{
+	pixel_x = 8;
+	pixel_y = 8
+	},
 /obj/item/reagent_container/food/condiment/hotsauce/sriracha{
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 8
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/charlie)
@@ -12887,7 +12961,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/surface/table/almayer,
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
+	},
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/bravo)
 "bRo" = (
@@ -13024,6 +13101,7 @@
 	density = 0;
 	pixel_y = 16
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/delta)
 "bTa" = (
@@ -13031,6 +13109,7 @@
 	density = 0;
 	pixel_y = 16
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/delta)
 "bTb" = (
@@ -13119,6 +13198,10 @@
 	density = 0;
 	pixel_y = 16
 	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
+	pixel_x = 1
+	},
 /turf/open/floor/almayer/blue/north,
 /area/almayer/squads/delta)
 "bTM" = (
@@ -13129,8 +13212,10 @@
 /turf/open/floor/almayer/blue/north,
 /area/almayer/squads/delta)
 "bTN" = (
-/obj/structure/bed/chair{
-	dir = 4
+/obj/structure/surface/table/almayer,
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/delta)
@@ -13232,42 +13317,34 @@
 /turf/open/floor/almayer/redfull,
 /area/almayer/squads/req)
 "bUp" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/reagent_container/food/condiment/hotsauce/franks{
-	pixel_x = 2;
-	pixel_y = 10
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/squads/delta)
+/obj/effect/landmark/start/marine/alpha,
+/obj/effect/landmark/late_join/alpha,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/plate,
+/area/almayer/squads/alpha)
 "bUq" = (
-/obj/structure/bed/chair{
-	dir = 8;
-	pixel_y = 3
-	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out";
+	pixel_x = -1
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/delta)
 "bUr" = (
-/obj/structure/bed/chair{
-	dir = 8;
-	pixel_y = 3
-	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
 	},
 /turf/open/floor/almayer/blue/north,
 /area/almayer/squads/delta)
@@ -13295,11 +13372,7 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_m_p)
 "bUN" = (
-/obj/structure/surface/table/almayer,
-/obj/item/trash/USCMtray{
-	pixel_x = 6;
-	pixel_y = 7
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/delta)
 "bUO" = (
@@ -13323,6 +13396,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/delta)
 "bVb" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 2
+	},
 /turf/open/floor/almayer/blue,
 /area/almayer/squads/delta)
 "bVd" = (
@@ -14229,6 +14306,14 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out";
+	pixel_x = -1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
+	pixel_x = 1
+	},
 /turf/open/floor/almayer,
 /area/almayer/squads/charlie)
 "cgA" = (
@@ -14320,10 +14405,19 @@
 	dir = 8;
 	pixel_y = 3
 	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
 /turf/open/floor/almayer,
 /area/almayer/squads/bravo)
 "chq" = (
-/obj/structure/surface/table/almayer,
+/obj/structure/bed/chair,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/charlie)
 "chv" = (
@@ -14420,6 +14514,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/cargo_arrow/west,
 /area/almayer/squads/alpha)
 "cif" = (
@@ -14521,6 +14616,10 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
 	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 2
+	},
 /turf/open/floor/almayer/emerald,
 /area/almayer/squads/charlie)
 "cji" = (
@@ -14556,13 +14655,10 @@
 	density = 0;
 	pixel_y = 16
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/charlie)
 "cjE" = (
-/obj/structure/bed/chair{
-	dir = 8;
-	pixel_y = 3
-	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1
 	},
@@ -14573,6 +14669,10 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
 	pixel_x = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
 	},
 /turf/open/floor/almayer/emerald/east,
 /area/almayer/squads/charlie)
@@ -15295,10 +15395,12 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_f_s)
 "cqz" = (
-/obj/structure/surface/table/almayer,
-/obj/item/facepaint/black,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/squads/delta)
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/plate,
+/area/almayer/squads/alpha)
 "cqH" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 4
@@ -15393,6 +15495,9 @@
 	icon_state = "NW-out";
 	pixel_x = -1;
 	pixel_y = 1
+	},
+/obj/structure/mirror{
+	pixel_y = 32
 	},
 /turf/open/floor/almayer/cargo_arrow/west,
 /area/almayer/squads/bravo)
@@ -15727,11 +15832,11 @@
 /turf/open/floor/almayer/cargo,
 /area/almayer/engineering/upper_engineering/port)
 "cBs" = (
-/obj/structure/bed/chair,
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
 	pixel_y = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/cargo_arrow,
 /area/almayer/squads/alpha)
 "cBw" = (
@@ -16194,6 +16299,18 @@
 "cKL" = (
 /turf/open/floor/almayer/orangecorner/west,
 /area/almayer/engineering/upper_engineering/port)
+"cLc" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/plate,
+/area/almayer/squads/charlie)
 "cLd" = (
 /obj/structure/closet,
 /obj/item/clothing/glasses/mgoggles/prescription,
@@ -17234,6 +17351,14 @@
 /obj/structure/surface/table/almayer,
 /turf/open/floor/almayer/red/west,
 /area/almayer/shipboard/brig/chief_mp_office)
+"dgE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out";
+	pixel_x = -1
+	},
+/turf/open/floor/almayer/red/north,
+/area/almayer/squads/alpha)
 "dgI" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -17408,6 +17533,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/upper/starboard)
+"dlu" = (
+/obj/effect/landmark/start/marine/bravo,
+/obj/effect/landmark/late_join/bravo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/squads/bravo)
 "dlT" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer/mono,
@@ -17774,6 +17905,9 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "W";
 	pixel_x = -1
+	},
+/obj/structure/bed/chair{
+	dir = 4
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/alpha)
@@ -18244,6 +18378,15 @@
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/stern)
+"dEk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/turf/open/floor/almayer/orange,
+/area/almayer/squads/bravo)
 "dEm" = (
 /obj/structure/machinery/power/apc/almayer/south,
 /obj/effect/decal/warning_stripes{
@@ -18597,6 +18740,14 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/s_bow)
+"dKX" = (
+/obj/structure/machinery/cryopod/right{
+	layer = 3.1;
+	pixel_y = 13
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/cargo,
+/area/almayer/squads/alpha)
 "dLc" = (
 /obj/structure/surface/table/almayer,
 /obj/item/paper_bin/uscm,
@@ -19465,6 +19616,10 @@
 	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/alpha)
@@ -20453,6 +20608,14 @@
 "exQ" = (
 /turf/open/floor/almayer/greencorner,
 /area/almayer/hallways/lower/starboard_midship_hallway)
+"eyl" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/turf/open/floor/almayer/orange/east,
+/area/almayer/squads/bravo)
 "eyD" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/shipboard/brig/starboard_hallway)
@@ -20926,6 +21089,12 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/upper/u_f_s)
+"eIG" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/turf/open/floor/almayer/blue/north,
+/area/almayer/squads/delta)
 "eIN" = (
 /obj/item/tool/kitchen/utensil/pfork,
 /turf/open/floor/almayer/plate,
@@ -21770,6 +21939,13 @@
 /obj/structure/machinery/firealarm{
 	pixel_y = 28
 	},
+/obj/structure/surface/table/almayer,
+/obj/item/trash/USCMtray{
+	pixel_y = 7
+	},
+/obj/item/reagent_container/food/condiment/hotsauce/tabasco{
+	pixel_x = 11
+	},
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/alpha)
 "fbe" = (
@@ -21873,6 +22049,7 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/hydroponics)
 "fcB" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/emerald/west,
 /area/almayer/squads/charlie)
 "fcE" = (
@@ -24219,6 +24396,7 @@
 	icon_state = "N";
 	pixel_y = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/orange/north,
 /area/almayer/squads/bravo)
 "giD" = (
@@ -24294,6 +24472,13 @@
 	},
 /turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
+"gjy" = (
+/obj/structure/machinery/cryopod{
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/cargo,
+/area/almayer/squads/alpha)
 "gjB" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -24306,6 +24491,12 @@
 	},
 /turf/open/floor/almayer/sterile_green_corner/west,
 /area/almayer/medical/lower_medical_medbay)
+"gkd" = (
+/obj/effect/landmark/start/marine/charlie,
+/obj/effect/landmark/late_join/charlie,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/squads/charlie)
 "gkr" = (
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/s_bow)
@@ -24388,10 +24579,16 @@
 /turf/open/floor/almayer/orange/southeast,
 /area/almayer/engineering/upper_engineering/port)
 "gnu" = (
-/obj/structure/surface/table/almayer,
-/obj/item/facepaint/green,
-/turf/open/floor/almayer,
-/area/almayer/squads/charlie)
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/turf/open/floor/almayer/blue,
+/area/almayer/squads/delta)
 "gnv" = (
 /turf/open/floor/almayer/red/northeast,
 /area/almayer/lifeboat_pumps/south1)
@@ -25859,6 +26056,18 @@
 /obj/structure/machinery/power/apc/almayer/north,
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/hangar)
+"gRS" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/structure/bed/chair{
+	dir = 8;
+	pixel_y = 3
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/plate,
+/area/almayer/squads/alpha)
 "gSa" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NE-out";
@@ -26650,8 +26859,9 @@
 /turf/open/floor/almayer/greencorner/east,
 /area/almayer/hallways/lower/starboard_midship_hallway)
 "hji" = (
-/obj/structure/bed/chair{
-	dir = 4
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
 	},
 /turf/open/floor/almayer/blue/west,
 /area/almayer/squads/delta)
@@ -26893,6 +27103,7 @@
 /obj/structure/machinery/light{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/delta)
 "hmF" = (
@@ -27197,6 +27408,10 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
 	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
+	pixel_x = 1
 	},
 /turf/open/floor/almayer/orange/northwest,
 /area/almayer/squads/bravo)
@@ -27674,6 +27889,12 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
+"hDx" = (
+/obj/effect/landmark/start/marine/tl/delta,
+/obj/effect/landmark/late_join/delta,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/squads/delta)
 "hDR" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/storage/syringe_case{
@@ -27708,6 +27929,7 @@
 "hEb" = (
 /obj/effect/landmark/start/marine/medic/bravo,
 /obj/effect/landmark/late_join/bravo,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/bravo)
 "hEg" = (
@@ -28009,6 +28231,13 @@
 /obj/structure/machinery/power/apc/almayer/south,
 /turf/open/floor/almayer/sterile_green_side,
 /area/almayer/medical/operating_room_three)
+"hMX" = (
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/orange/west,
+/area/almayer/squads/bravo)
 "hNh" = (
 /obj/structure/machinery/light/small,
 /turf/open/floor/almayer/plate,
@@ -28287,9 +28516,14 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/morgue)
+"hSV" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/orange,
+/area/almayer/squads/bravo)
 "hTc" = (
-/obj/structure/machinery/firealarm{
-	pixel_y = 28
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/mirror{
+	pixel_y = 32
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/delta)
@@ -28716,6 +28950,7 @@
 /area/almayer/squads/alpha)
 "iaq" = (
 /obj/structure/machinery/vending/cola,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/bravo)
 "iat" = (
@@ -29316,6 +29551,12 @@
 /obj/effect/step_trigger/message/memorial,
 /turf/open/floor/almayer/plate,
 /area/almayer/living/starboard_garden)
+"ipM" = (
+/obj/effect/landmark/start/marine/tl/alpha,
+/obj/effect/landmark/late_join/alpha,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/squads/alpha)
 "ipQ" = (
 /obj/structure/surface/rack,
 /obj/item/storage/fancy/vials/empty,
@@ -29422,6 +29663,16 @@
 	},
 /turf/open/floor/almayer/sterile_green_side,
 /area/almayer/medical/medical_science)
+"isa" = (
+/obj/structure/machinery/cryopod{
+	layer = 3.1;
+	pixel_y = 13
+	},
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/almayer/cargo,
+/area/almayer/squads/bravo)
 "ish" = (
 /turf/open/floor/almayer/orange/east,
 /area/almayer/engineering/lower/workshop)
@@ -29653,6 +29904,11 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out"
 	},
+/obj/structure/surface/table/almayer,
+/obj/item/trash/USCMtray{
+	pixel_x = 6;
+	pixel_y = 7
+	},
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/delta)
 "ixN" = (
@@ -29823,6 +30079,12 @@
 /obj/structure/largecrate/supply/supplies/tables_racks,
 /turf/open/floor/almayer/red/southwest,
 /area/almayer/maint/upper/u_a_p)
+"iDf" = (
+/obj/effect/landmark/start/marine/alpha,
+/obj/effect/landmark/late_join/alpha,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/squads/alpha)
 "iDk" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/almayer/plate,
@@ -30011,6 +30273,13 @@
 	},
 /turf/open/floor/prison/kitchen,
 /area/almayer/living/grunt_rnr)
+"iIO" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 2
+	},
+/turf/open/floor/almayer/red,
+/area/almayer/squads/alpha)
 "iIP" = (
 /obj/structure/toilet{
 	pixel_y = 16
@@ -30026,16 +30295,13 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/port_emb)
 "iIR" = (
-/obj/structure/surface/table/almayer,
-/obj/item/trash/USCMtray{
-	pixel_y = 7
+/obj/structure/machinery/cm_vending/sorted/marine_food{
+	density = 0;
+	pixel_y = 16
 	},
-/obj/item/reagent_container/food/condiment/hotsauce/cholula{
-	pixel_x = 10;
-	pixel_y = 22
-	},
-/turf/open/floor/almayer,
-/area/almayer/squads/bravo)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/plate,
+/area/almayer/squads/delta)
 "iIU" = (
 /obj/structure/largecrate/random/barrel/red,
 /obj/structure/machinery/light/small,
@@ -30564,14 +30830,9 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/maint/hull/upper/u_a_p)
 "iSZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/surface/table/almayer,
-/obj/item/facepaint/black,
+/obj/effect/landmark/start/marine/engineer/alpha,
+/obj/effect/landmark/late_join/alpha,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/alpha)
 "iTd" = (
@@ -30768,12 +31029,19 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/stern)
 "iWc" = (
-/obj/structure/surface/table/almayer,
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/delta)
@@ -31123,16 +31391,13 @@
 /turf/open/floor/almayer/aicore/no_build/ai_silver/east,
 /area/almayer/command/airoom)
 "jdm" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 2
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/trash/USCMtray,
-/turf/open/floor/almayer/blue/north,
-/area/almayer/squads/delta)
+/turf/open/floor/almayer/orange,
+/area/almayer/squads/bravo)
 "jdn" = (
 /obj/structure/surface/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -31974,6 +32239,13 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/east,
 /area/almayer/medical/medical_science)
+"jrR" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/cargo_arrow/north,
+/area/almayer/squads/delta)
 "jsa" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -32614,6 +32886,9 @@
 	icon_state = "W";
 	pixel_x = -1
 	},
+/obj/structure/bed/chair{
+	dir = 4
+	},
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/delta)
 "jHh" = (
@@ -32721,6 +32996,11 @@
 	},
 /turf/open/floor/almayer/cargo,
 /area/almayer/engineering/port_atmos)
+"jKK" = (
+/obj/structure/surface/table/almayer,
+/obj/item/facepaint/green,
+/turf/open/floor/almayer/plate,
+/area/almayer/squads/alpha)
 "jLg" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/almayer/cargo,
@@ -32884,6 +33164,17 @@
 /obj/effect/spawner/random/balaclavas,
 /turf/open/floor/plating,
 /area/almayer/maint/lower/constr)
+"jNK" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/structure/bed/chair{
+	dir = 8;
+	pixel_y = 3
+	},
+/turf/open/floor/almayer/plate,
+/area/almayer/squads/alpha)
 "jNT" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/execution)
@@ -32894,10 +33185,6 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4;
 	icon_state = "pipe-j2"
-	},
-/obj/structure/bed/chair{
-	dir = 8;
-	pixel_y = 3
 	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "NE-out";
@@ -33048,6 +33335,13 @@
 	},
 /turf/open/floor/almayer/orange/east,
 /area/almayer/engineering/upper_engineering/port)
+"jRH" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/turf/open/floor/almayer,
+/area/almayer/squads/bravo)
 "jRK" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer/cargo,
@@ -33924,9 +34218,8 @@
 /turf/open/floor/almayer/orange,
 /area/almayer/squads/bravo)
 "kiV" = (
-/obj/structure/surface/table/almayer,
-/obj/item/reagent_container/food/condiment/hotsauce/tabasco{
-	pixel_x = 11
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
 	},
 /turf/open/floor/almayer/red/north,
 /area/almayer/squads/alpha)
@@ -34144,6 +34437,10 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/bravo)
+"koI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/plate,
+/area/almayer/squads/delta)
 "kph" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/airlock/multi_tile/almayer/engidoor{
@@ -35027,6 +35324,7 @@
 	density = 0;
 	pixel_y = 16
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/emerald/north,
 /area/almayer/squads/charlie)
 "kGQ" = (
@@ -35117,6 +35415,14 @@
 /area/almayer/hallways/lower/starboard_fore_hallway)
 "kJi" = (
 /obj/structure/machinery/light,
+/obj/structure/surface/table/almayer,
+/obj/item/reagent_container/food/condiment/hotsauce/tabasco{
+	pixel_x = 14;
+	pixel_y = 20
+	},
+/obj/item/trash/USCMtray{
+	pixel_y = 7
+	},
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/alpha)
 "kJm" = (
@@ -35659,6 +35965,10 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/living/pilotbunks)
+"kUo" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/squads/charlie)
 "kUA" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
@@ -36013,6 +36323,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/charlie)
 "lcg" = (
@@ -36105,6 +36423,7 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/emerald/north,
 /area/almayer/squads/charlie)
 "leg" = (
@@ -36333,6 +36652,7 @@
 "ljs" = (
 /obj/effect/landmark/start/marine/spec/bravo,
 /obj/effect/landmark/late_join/bravo,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/bravo)
 "ljv" = (
@@ -37173,6 +37493,11 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
 	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_x = 1;
+	pixel_y = 2
+	},
 /turf/open/floor/almayer/emerald/southwest,
 /area/almayer/squads/charlie)
 "lCg" = (
@@ -37554,7 +37879,10 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/surface/table/almayer,
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
+	},
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/alpha)
 "lJY" = (
@@ -37609,7 +37937,7 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/hallways/upper/midship_hallway)
 "lLC" = (
-/obj/structure/surface/table/almayer,
+/obj/structure/bed/chair,
 /turf/open/floor/almayer,
 /area/almayer/squads/charlie)
 "lLO" = (
@@ -37825,6 +38153,7 @@
 /area/almayer/maint/hull/lower/l_f_p)
 "lQz" = (
 /obj/structure/machinery/vending/coffee,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/bravo)
 "lQB" = (
@@ -38032,6 +38361,15 @@
 /obj/effect/landmark/yautja_teleport,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/u_m_s)
+"lWG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/almayer,
+/area/almayer/squads/alpha)
 "lWO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/machinery/light/small{
@@ -38450,20 +38788,14 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/command/lifeboat)
 "mhI" = (
-/obj/structure/machinery/vending/cigarette{
-	density = 0;
-	pixel_x = -5;
-	pixel_y = 16
-	},
-/obj/structure/reagent_dispensers/water_cooler/stacks{
-	density = 0;
-	pixel_x = 13;
-	pixel_y = 15
-	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "NE-out";
 	pixel_x = 1;
 	pixel_y = 1
+	},
+/obj/structure/surface/table/almayer,
+/obj/structure/mirror{
+	pixel_y = 32
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/alpha)
@@ -38834,6 +39166,12 @@
 /obj/structure/surface/table/almayer,
 /turf/open/floor/almayer/redfull,
 /area/almayer/living/briefing)
+"mpJ" = (
+/obj/effect/landmark/start/marine/medic/charlie,
+/obj/effect/landmark/late_join/charlie,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/squads/charlie)
 "mpP" = (
 /obj/structure/machinery/door/airlock/almayer/maint,
 /turf/open/floor/almayer/test_floor4,
@@ -39056,6 +39394,7 @@
 "muy" = (
 /obj/effect/landmark/start/marine/engineer/alpha,
 /obj/effect/landmark/late_join/alpha,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/alpha)
 "muQ" = (
@@ -39099,6 +39438,12 @@
 	name = "ship-grade camera"
 	},
 /turf/open/floor/almayer/bluecorner,
+/area/almayer/squads/delta)
+"mvy" = (
+/obj/effect/landmark/start/marine/delta,
+/obj/effect/landmark/late_join/delta,
+/obj/structure/machinery/light,
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/delta)
 "mvI" = (
 /obj/structure/machinery/camera/autoname/almayer{
@@ -39607,6 +39952,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
 /turf/open/floor/almayer/orange/west,
 /area/almayer/squads/bravo)
 "mFP" = (
@@ -39959,18 +40308,11 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/living/pilotbunks)
 "mLF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/surface/table/almayer,
-/obj/item/trash/USCMtray{
-	pixel_y = 7
-	},
+/obj/effect/landmark/start/marine/medic/bravo,
+/obj/effect/landmark/late_join/bravo,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/squads/alpha)
+/area/almayer/squads/bravo)
 "mLN" = (
 /obj/structure/machinery/light/small,
 /obj/structure/disposalpipe/segment{
@@ -40363,6 +40705,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_f_s)
+"mUP" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/turf/open/floor/almayer/orange/north,
+/area/almayer/squads/bravo)
 "mUY" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/tool,
@@ -40808,6 +41160,14 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/upper_engineering/starboard)
+"nex" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/turf/open/floor/almayer/red,
+/area/almayer/squads/alpha)
 "neC" = (
 /obj/structure/bed/chair/bolted,
 /turf/open/floor/almayer/red/north,
@@ -41216,6 +41576,14 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/command/lifeboat)
+"nks" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_y = 2;
+	pixel_x = 1
+	},
+/turf/open/floor/almayer/orange,
+/area/almayer/squads/bravo)
 "nkx" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_y = 25
@@ -41562,6 +41930,10 @@
 "nrw" = (
 /obj/structure/bed/chair{
 	dir = 4
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
+	pixel_x = 1
 	},
 /turf/open/floor/almayer/emeraldcorner/west,
 /area/almayer/squads/charlie)
@@ -42142,6 +42514,9 @@
 /obj/item/storage/donut_box{
 	pixel_x = 6;
 	pixel_y = 6
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/charlie)
@@ -42753,6 +43128,11 @@
 /turf/open/floor/almayer,
 /area/almayer/command/computerlab)
 "nTl" = (
+/obj/structure/surface/table/almayer,
+/obj/item/facepaint/black,
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
 /turf/open/floor/almayer/red/north,
 /area/almayer/squads/alpha)
 "nTo" = (
@@ -42865,6 +43245,14 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/u_a_s)
+"nVa" = (
+/obj/structure/bed/chair,
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 2
+	},
+/turf/open/floor/almayer/red,
+/area/almayer/squads/alpha)
 "nVi" = (
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/living/briefing)
@@ -43008,6 +43396,7 @@
 	icon_state = "N";
 	pixel_y = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/cargo_arrow/west,
 /area/almayer/squads/bravo)
 "nYd" = (
@@ -43787,13 +44176,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_f_s)
 "onN" = (
-/obj/structure/surface/table/almayer,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/toy/deck{
-	pixel_x = 8;
-	pixel_y = 8
+/obj/structure/bed/chair{
+	dir = 8;
+	pixel_y = 3
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/charlie)
@@ -44077,6 +44465,7 @@
 	icon_state = "N";
 	pixel_y = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/bravo)
 "osI" = (
@@ -44344,6 +44733,20 @@
 /obj/effect/landmark/late_join/intel,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/port_atmos)
+"oyG" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/plate,
+/area/almayer/squads/bravo)
 "oyO" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/sign/safety/water{
@@ -44401,6 +44804,11 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out";
 	pixel_x = -1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_x = -1;
+	pixel_y = 2
 	},
 /turf/open/floor/almayer/emerald/southeast,
 /area/almayer/squads/charlie)
@@ -45046,6 +45454,14 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/living/auxiliary_officer_office)
+"oMr" = (
+/obj/structure/machinery/cm_vending/sorted/marine_food{
+	density = 0;
+	pixel_y = 16
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/plate,
+/area/almayer/squads/charlie)
 "oMs" = (
 /obj/structure/machinery/computer/cameras/almayer{
 	dir = 1
@@ -45241,6 +45657,16 @@
 	},
 /turf/open/floor/almayer/orangecorner/north,
 /area/almayer/hallways/lower/port_umbilical)
+"oQB" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/structure/bed/chair{
+	dir = 8;
+	pixel_y = 3
+	},
+/turf/open/floor/almayer/plate,
+/area/almayer/squads/delta)
 "oQH" = (
 /turf/open/floor/almayer/cargo_arrow,
 /area/almayer/living/briefing)
@@ -45350,6 +45776,16 @@
 /obj/item/tank/emergency_oxygen/double,
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/upper_engineering/port)
+"oSy" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor/almayer/plate,
+/area/almayer/squads/alpha)
 "oSC" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -47676,14 +48112,15 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/command/computerlab)
 "pUf" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
 	},
 /turf/open/floor/almayer/bluecorner/west,
 /area/almayer/squads/delta)
@@ -47848,6 +48285,7 @@
 	icon_state = "E";
 	pixel_x = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/alpha)
 "pXx" = (
@@ -48280,14 +48718,15 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/command/combat_correspondent)
 "qgN" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
+	pixel_x = 1
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/delta)
@@ -48547,14 +48986,15 @@
 /turf/open/floor/plating,
 /area/almayer/hallways/lower/repair_bay)
 "qmk" = (
-/obj/structure/surface/table/almayer,
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/facepaint/green,
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
 /turf/open/floor/almayer/bluecorner/east,
 /area/almayer/squads/delta)
 "qmq" = (
@@ -49050,6 +49490,13 @@
 	},
 /turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
+"qwL" = (
+/obj/structure/machinery/cryopod/right{
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/cargo,
+/area/almayer/squads/charlie)
 "qwU" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out"
@@ -49168,6 +49615,10 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out";
+	pixel_x = -1
 	},
 /turf/open/floor/almayer/blue/northeast,
 /area/almayer/squads/delta)
@@ -49608,6 +50059,11 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer/cargo,
 /area/almayer/lifeboat_pumps/south2)
+"qHe" = (
+/obj/structure/machinery/cryopod/right,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/cargo,
+/area/almayer/squads/alpha)
 "qHg" = (
 /turf/open/floor/almayer/cargo_arrow/north,
 /area/almayer/squads/alpha_bravo_shared)
@@ -50324,6 +50780,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/delta)
 "qWx" = (
@@ -50806,6 +51263,7 @@
 "rfa" = (
 /obj/effect/landmark/start/marine/medic/alpha,
 /obj/effect/landmark/late_join/alpha,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/alpha)
 "rfb" = (
@@ -51120,13 +51578,17 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/shipboard/starboard_point_defense)
 "rll" = (
-/obj/structure/machinery/light,
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out"
 	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
 	pixel_x = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/delta)
@@ -51361,6 +51823,7 @@
 	icon_state = "E";
 	pixel_x = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/delta)
 "rqQ" = (
@@ -52465,6 +52928,12 @@
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/living/port_emb)
+"rNd" = (
+/obj/effect/landmark/start/marine/engineer/delta,
+/obj/effect/landmark/late_join/delta,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/squads/delta)
 "rNK" = (
 /obj/structure/surface/table/almayer,
 /turf/open/floor/almayer/orange,
@@ -52525,8 +52994,11 @@
 /area/almayer/engineering/ce_room)
 "rPE" = (
 /obj/structure/bed/chair{
-	dir = 8;
-	pixel_y = 3
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/delta)
@@ -52534,6 +53006,20 @@
 /turf/open/floor/almayer/red,
 /area/almayer/shipboard/brig/starboard_hallway)
 "rPO" = (
+/obj/structure/surface/table/almayer,
+/obj/item/reagent_container/food/condiment/hotsauce/franks{
+	pixel_x = -6;
+	pixel_y = 16
+	},
+/obj/item/facepaint/black{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_x = 1;
+	pixel_y = 2
+	},
 /turf/open/floor/almayer/blue/southwest,
 /area/almayer/squads/delta)
 "rPQ" = (
@@ -52583,6 +53069,7 @@
 /turf/closed/wall/almayer/white/reinforced,
 /area/almayer/medical/hydroponics)
 "rQA" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/cargo_arrow/west,
 /area/almayer/squads/delta)
 "rQV" = (
@@ -52934,6 +53421,7 @@
 "rYp" = (
 /obj/effect/landmark/start/marine/medic/delta,
 /obj/effect/landmark/late_join/delta,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/delta)
 "rYv" = (
@@ -53193,8 +53681,12 @@
 /turf/open/floor/almayer/red/northwest,
 /area/almayer/hallways/upper/starboard)
 "sdC" = (
-/obj/structure/bed/chair{
-	dir = 4
+/obj/structure/surface/table/almayer,
+/obj/item/trash/USCMtray,
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_x = 1;
+	pixel_y = 2
 	},
 /turf/open/floor/almayer/blue,
 /area/almayer/squads/delta)
@@ -53328,6 +53820,11 @@
 /obj/item/toy/deck{
 	pixel_x = 8;
 	pixel_y = 8
+	},
+/obj/item/facepaint/green,
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 2
 	},
 /turf/open/floor/almayer/blue,
 /area/almayer/squads/delta)
@@ -53715,6 +54212,10 @@
 /area/almayer/maint/hull/lower/l_a_s)
 "snR" = (
 /obj/structure/surface/table/almayer,
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 2
+	},
 /turf/open/floor/almayer/blue,
 /area/almayer/squads/delta)
 "snX" = (
@@ -53798,6 +54299,10 @@
 "spS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
 	},
 /turf/open/floor/almayer/emerald/west,
 /area/almayer/squads/charlie)
@@ -54242,6 +54747,10 @@
 	dir = 8;
 	pixel_y = 3
 	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 2
+	},
 /turf/open/floor/almayer/blue,
 /area/almayer/squads/delta)
 "sAw" = (
@@ -54318,6 +54827,17 @@
 	pixel_x = -1;
 	pixel_y = 1
 	},
+/obj/structure/machinery/vending/cigarette{
+	density = 0;
+	pixel_x = -5;
+	pixel_y = 16
+	},
+/obj/structure/reagent_dispensers/water_cooler/stacks{
+	density = 0;
+	pixel_x = 13;
+	pixel_y = 15
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/alpha)
 "sCI" = (
@@ -54965,6 +55485,12 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/lifeboat_pumps/south2)
 "sSC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_x = -1;
+	pixel_y = 2
+	},
 /turf/open/floor/almayer/blue/southeast,
 /area/almayer/squads/delta)
 "sSG" = (
@@ -55039,6 +55565,7 @@
 	pixel_x = 1;
 	pixel_y = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/bluefull,
 /area/almayer/squads/delta)
 "sUk" = (
@@ -55480,6 +56007,13 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/hangar)
+"tdf" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
+	},
+/turf/open/floor/almayer/blue/east,
+/area/almayer/squads/delta)
 "tdi" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4;
@@ -55736,10 +56270,13 @@
 /turf/open/floor/almayer/red/southeast,
 /area/almayer/maint/upper/u_a_p)
 "tig" = (
-/obj/structure/surface/table/almayer,
-/obj/item/reagent_container/food/condiment/hotsauce/tabasco{
-	pixel_x = 14;
-	pixel_y = 20
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 2
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/alpha)
@@ -56020,6 +56557,16 @@
 "tni" = (
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/operating_room_three)
+"tnz" = (
+/obj/structure/machinery/cryopod{
+	pixel_y = 6
+	},
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/cargo,
+/area/almayer/squads/bravo)
 "tnY" = (
 /obj/structure/machinery/cryopod{
 	pixel_y = 6
@@ -56027,6 +56574,7 @@
 /obj/structure/machinery/light{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/cargo,
 /area/almayer/squads/alpha)
 "tob" = (
@@ -56681,6 +57229,20 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/shipboard/brig/processing)
+"tzr" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 2
+	},
+/turf/open/floor/almayer/emerald,
+/area/almayer/squads/charlie)
 "tzw" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -56951,6 +57513,13 @@
 /obj/structure/largecrate/supply/supplies/flares,
 /turf/open/floor/almayer/red/north,
 /area/almayer/maint/upper/u_a_p)
+"tFP" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 2
+	},
+/turf/open/floor/almayer/orange,
+/area/almayer/squads/bravo)
 "tFS" = (
 /obj/structure/machinery/computer/supplycomp,
 /obj/structure/sign/safety/terminal{
@@ -57129,6 +57698,7 @@
 	icon_state = "N";
 	pixel_y = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/alpha)
 "tIS" = (
@@ -57190,6 +57760,13 @@
 	},
 /turf/open/floor/almayer/cargo,
 /area/almayer/living/bridgebunks)
+"tKY" = (
+/obj/structure/bed/chair{
+	dir = 8;
+	pixel_y = 3
+	},
+/turf/open/floor/almayer/plate,
+/area/almayer/squads/alpha)
 "tLa" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -57364,6 +57941,10 @@
 	},
 /turf/open/floor/almayer/bluefull,
 /area/almayer/living/briefing)
+"tPD" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/emerald/north,
+/area/almayer/squads/charlie)
 "tPI" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -57987,6 +58568,7 @@
 	icon_state = "N";
 	pixel_y = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/alpha)
 "udK" = (
@@ -58525,6 +59107,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/orange/southwest,
 /area/almayer/squads/bravo)
 "uqI" = (
@@ -58653,8 +59236,12 @@
 	pixel_x = 5
 	},
 /obj/item/reagent_container/food/condiment/hotsauce/cholula{
-	pixel_x = -8;
-	pixel_y = 22
+	pixel_x = -12;
+	pixel_y = 14
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out";
+	pixel_x = -1
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/bravo)
@@ -58863,6 +59450,17 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out";
 	pixel_x = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_x = 1;
+	pixel_y = 2
 	},
 /turf/open/floor/almayer/emerald,
 /area/almayer/squads/charlie)
@@ -59316,9 +59914,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/hangar)
 "uIJ" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/red,
 /area/almayer/squads/alpha)
 "uIT" = (
@@ -59612,9 +60208,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/port_emb)
 "uRo" = (
-/obj/structure/surface/table/almayer,
-/obj/item/trash/USCMtray{
-	pixel_y = 7
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_x = -1;
+	pixel_y = 2
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/alpha)
@@ -59739,10 +60336,10 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/maint/hull/upper/p_bow)
 "uTv" = (
-/obj/structure/surface/table/almayer,
-/obj/item/trash/USCMtray{
-	pixel_x = 6;
-	pixel_y = 4
+/obj/structure/bed/chair,
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out";
+	pixel_x = -1
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/bravo)
@@ -60078,6 +60675,12 @@
 	},
 /turf/open/floor/almayer/orange/north,
 /area/almayer/engineering/lower)
+"uYH" = (
+/obj/effect/landmark/start/marine/medic/delta,
+/obj/effect/landmark/late_join/delta,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/squads/delta)
 "uYM" = (
 /obj/structure/machinery/status_display{
 	pixel_y = -30
@@ -60339,6 +60942,20 @@
 	},
 /turf/open/floor/almayer/red/northwest,
 /area/almayer/lifeboat_pumps/south2)
+"vej" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/plate,
+/area/almayer/squads/charlie)
 "ven" = (
 /obj/structure/bed/chair,
 /turf/open/floor/almayer/green,
@@ -60549,6 +61166,12 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/bravo)
+"vio" = (
+/obj/effect/landmark/start/marine/delta,
+/obj/effect/landmark/late_join/delta,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/squads/delta)
 "vit" = (
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/operating_room_four)
@@ -60799,7 +61422,10 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/alpha_bravo_shared)
 "vme" = (
-/obj/structure/bed/chair,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
 /turf/open/floor/almayer/red/north,
 /area/almayer/squads/alpha)
 "vml" = (
@@ -61071,6 +61697,10 @@
 	},
 /turf/open/floor/almayer/sterile_green_side,
 /area/almayer/medical/medical_science)
+"vqY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/squads/bravo)
 "vqZ" = (
 /obj/structure/machinery/shower{
 	pixel_y = 16
@@ -62192,6 +62822,7 @@
 	icon_state = "E";
 	pixel_x = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/cargo_arrow/west,
 /area/almayer/squads/charlie)
 "vMb" = (
@@ -62287,6 +62918,9 @@
 /obj/structure/bed/chair{
 	dir = 8;
 	pixel_y = 3
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/charlie)
@@ -63033,6 +63667,14 @@
 	},
 /turf/closed/wall/almayer,
 /area/almayer/engineering/lower)
+"vZt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 2
+	},
+/turf/open/floor/almayer/redcorner,
+/area/almayer/squads/alpha)
 "vZv" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/almayer,
@@ -63777,6 +64419,7 @@
 /obj/structure/machinery/light{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/charlie)
 "woy" = (
@@ -64129,6 +64772,17 @@
 	},
 /turf/open/floor/almayer/orange/southwest,
 /area/almayer/engineering/upper_engineering/starboard)
+"wuU" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/plate,
+/area/almayer/squads/charlie)
 "wvb" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -64350,6 +65004,16 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/port_umbilical)
+"wBr" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
+	pixel_x = 1
+	},
+/turf/open/floor/almayer/red/north,
+/area/almayer/squads/alpha)
 "wBw" = (
 /obj/structure/pipes/vents/pump,
 /obj/structure/machinery/status_display{
@@ -64767,6 +65431,10 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
 	pixel_x = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out";
+	pixel_x = -1
 	},
 /turf/open/floor/almayer/emerald/east,
 /area/almayer/squads/charlie)
@@ -66083,7 +66751,7 @@
 /turf/open/floor/almayer/greencorner/east,
 /area/almayer/hallways/lower/starboard_fore_hallway)
 "xlk" = (
-/obj/structure/surface/table/almayer,
+/obj/structure/bed/chair,
 /turf/open/floor/almayer,
 /area/almayer/squads/bravo)
 "xlC" = (
@@ -67603,10 +68271,6 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/p_stern)
 "xRj" = (
-/obj/structure/bed/chair{
-	dir = 8;
-	pixel_y = 3
-	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1
 	},
@@ -67681,6 +68345,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/cryo_cells)
 "xSW" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
 /turf/open/floor/almayer/red/west,
 /area/almayer/squads/alpha)
 "xSY" = (
@@ -112962,17 +113630,17 @@ ikT
 aLT
 vZb
 tnY
-rAN
+gjy
 tIQ
 cic
 ceg
 mdo
 mJj
-tDZ
+tnz
 nYc
 bnB
 aVd
-aUZ
+hMX
 uqA
 bES
 kcl
@@ -113175,8 +113843,8 @@ ljs
 hsW
 mFO
 bJE
-aSE
-aVf
+aRT
+hSV
 bES
 kcl
 bqc
@@ -113207,15 +113875,15 @@ udf
 iyC
 pOW
 hNw
-sZq
-jZv
-cgy
+oMr
+tPD
+bJD
 nrw
 spS
 lBv
 pXZ
 hNw
-bNC
+iIR
 sDM
 clr
 nvT
@@ -113375,11 +114043,11 @@ bgY
 mdo
 mJj
 byn
-gip
+mUP
 bnt
 bJH
-iIR
-aVf
+aRT
+hSV
 bES
 kcl
 bqc
@@ -113411,8 +114079,8 @@ ekM
 pOW
 hNw
 sZq
-jZv
-gnu
+tPD
+bJD
 bOQ
 chR
 cjg
@@ -113578,11 +114246,11 @@ bCS
 aLT
 aLT
 ksp
-gip
+bOG
 brH
 chp
-chp
-aVf
+jRH
+nks
 aQL
 aQL
 lhs
@@ -113615,10 +114283,10 @@ pmd
 bJC
 bJC
 bMD
-vND
+bJD
 vND
 chR
-cjg
+tzr
 kIP
 bJC
 bSJ
@@ -113773,11 +114441,11 @@ vPv
 oTA
 vPv
 rAN
-tIQ
-vme
+gRS
+aNc
 aNQ
 aOL
-uIJ
+iIO
 hRd
 aLT
 aQL
@@ -113785,7 +114453,7 @@ bmh
 bnX
 aRo
 brA
-aVf
+tFP
 lQz
 aQL
 bqc
@@ -113818,18 +114486,18 @@ pOW
 bJC
 jht
 jZv
-cgy
+bJD
 cgy
 lbX
 uxp
 bJC
 bJC
 bSZ
-ckX
-bUp
+eIG
+cll
 bUN
-bVb
-ivM
+sAc
+oQB
 mAV
 hzu
 qNd
@@ -113974,21 +114642,21 @@ aLT
 nuN
 nuN
 rfa
+ipM
 ehx
-ehx
-tVq
+cBs
 vme
-mLF
+bwf
 tig
-uIJ
+nex
 aPi
 aLT
 tDZ
 gip
 uTv
 bKC
-bOG
-aVf
+bnt
+jdm
 iaq
 aQL
 bqc
@@ -114024,20 +114692,20 @@ jZv
 lLC
 nEo
 nZy
-cjg
+tzr
 lbf
 bJC
 bTa
-ckX
+bbu
 iWc
-cqz
+bUN
 bVb
 wty
 pWb
-pWb
+hDx
 rYp
 oEo
-oEo
+uYH
 bSJ
 xhO
 lMO
@@ -114175,12 +114843,12 @@ oPF
 jEM
 aLT
 vug
-vug
+iSZ
 muy
 vug
 vug
 tVq
-vme
+dgE
 lJO
 uRo
 uIJ
@@ -114191,7 +114859,7 @@ gip
 xlk
 uuj
 bRg
-aVf
+dEk
 aQL
 aQL
 ylN
@@ -114234,13 +114902,13 @@ bSJ
 bTM
 bUq
 rPE
-bVb
+gnu
 wty
 wWX
 wWX
 yle
-wWX
-wWX
+rNd
+rNd
 bSJ
 xhO
 xHa
@@ -114382,16 +115050,16 @@ vAE
 iKw
 vAE
 wMG
-tIQ
-nTl
+oSy
+wBr
 efK
-aMz
-rGj
+lWG
+uIJ
 mdo
 mJj
 bHp
 bIU
-tAN
+eyl
 tAN
 jOi
 aVf
@@ -114425,7 +115093,7 @@ uPE
 ekM
 pOW
 hNw
-sZq
+oMr
 lef
 xRj
 wJD
@@ -114588,7 +115256,7 @@ aLT
 fbb
 nTl
 bwf
-aMP
+vZt
 bEG
 mdo
 mJj
@@ -114628,7 +115296,7 @@ kAj
 bFX
 hza
 hNw
-sZq
+oMr
 ltI
 vfa
 wdz
@@ -114636,7 +115304,7 @@ wdz
 nCf
 nCf
 hNw
-bNC
+iIR
 uMS
 qmk
 rtV
@@ -114788,17 +115456,17 @@ vPv
 oTA
 vPv
 rAN
-tIQ
+jNK
 aNc
-aNT
-rGj
-bdC
+bwf
+iIO
+cqz
 mdo
 mJj
 sEd
 wDK
-iMr
-wuq
+sEd
+wDK
 bRV
 bSe
 bES
@@ -114839,12 +115507,12 @@ yiW
 oaW
 yiW
 hNw
-bNC
-clK
-jdm
+iIR
+koI
+bUr
 pQN
 snR
-ivM
+aNT
 qNd
 hzu
 mAV
@@ -114986,15 +115654,15 @@ emA
 efP
 ikT
 aLT
-cjc
-cjc
+iDf
+iDf
 vUb
 nuN
 nuN
-cBs
+tVq
 kiV
-iSZ
-uIJ
+bwf
+nVa
 kJi
 aLT
 aLT
@@ -115047,12 +115715,12 @@ hTc
 bUr
 ycd
 sAc
-wty
-oEo
+jrR
+uYH
 oEo
 yfm
-fXN
-fXN
+vio
+vio
 bSJ
 gEh
 xhO
@@ -115190,21 +115858,21 @@ uzv
 ikT
 aLT
 cjc
-cjc
-vUb
+iDf
+bUp
 cjc
 cjc
 cBs
 bsU
 bwg
 bCP
-bdC
+jKK
 aLT
 pqK
 uAW
 pqK
-uAW
-tDZ
+isa
+qZX
 vil
 bpC
 qZX
@@ -115248,10 +115916,10 @@ lbf
 bSJ
 gGf
 qyi
-hXY
+tdf
 sSC
 wty
-fXN
+vio
 fXN
 yfm
 fXN
@@ -115401,10 +116069,10 @@ tIQ
 btc
 bwh
 uMl
-bdC
+tKY
 dII
-fZZ
-fZZ
+mLF
+mLF
 viS
 sXw
 sXw
@@ -115446,14 +116114,14 @@ rQV
 wdz
 wdz
 fDJ
-bKM
-bKM
+mpJ
+mpJ
 bZU
-clK
+koI
 qFK
 pmq
 sUj
-ivM
+aNT
 vSW
 scy
 gEo
@@ -115606,7 +116274,7 @@ bxB
 uWY
 wEd
 jvp
-gBc
+oyG
 gBc
 gBc
 gBc
@@ -115650,7 +116318,7 @@ lNw
 lNw
 lNw
 lNw
-lNw
+vej
 erh
 rqE
 qWt
@@ -115806,13 +116474,13 @@ aLT
 cjc
 cjc
 uJU
-cjc
+iDf
 cjc
 aLT
 lDV
 fZZ
 hEb
-qDq
+dlu
 qDq
 jOx
 bpC
@@ -115846,7 +116514,7 @@ gyw
 uNQ
 gyw
 bJC
-oXb
+gkd
 cfo
 lkM
 oXb
@@ -115859,7 +116527,7 @@ fXN
 fXN
 kPJ
 fXN
-fXN
+mvy
 bSJ
 enY
 srl
@@ -116006,17 +116674,17 @@ jEM
 ikT
 jEM
 aLT
-iPS
-vAE
+qHe
+dKX
 meY
-iPS
-vAE
+qHe
+dKX
 aLT
 iMr
 wDK
 iMr
-wDK
-rou
+wuq
+ksp
 jOx
 bpC
 ksp
@@ -116049,8 +116717,8 @@ ddL
 eZR
 uPE
 bJC
-kIP
-cfo
+qwL
+kUo
 lkM
 oaW
 yiW
@@ -116421,9 +117089,9 @@ ikT
 jEM
 aQL
 qZX
-qZX
 tDZ
-jOx
+qZX
+aSE
 bpC
 qZX
 aQL
@@ -116457,7 +117125,7 @@ uPE
 bJC
 lbf
 cfo
-lkM
+wuU
 lbf
 lbf
 lbf
@@ -116623,11 +117291,11 @@ jEM
 jEM
 jEM
 aQL
+dlu
+dlu
 qDq
-qDq
-qDq
-jOx
-bpC
+aSE
+vqY
 qDq
 bTb
 bqc
@@ -116660,8 +117328,8 @@ uPE
 xSw
 oXb
 cfo
-lkM
-oXb
+wuU
+gkd
 oXb
 oXb
 bJC
@@ -116826,11 +117494,11 @@ emA
 ikT
 jEM
 aQL
-qDq
+dlu
 qDq
 qDq
 osA
-cHl
+bcH
 cHl
 bTb
 lhs
@@ -116861,10 +117529,10 @@ gyw
 uNQ
 gyw
 xSw
-ejo
+cLc
 ejo
 niY
-oXb
+gkd
 oXb
 oXb
 bJC
@@ -117033,8 +117701,8 @@ ksp
 ksp
 rou
 qDq
-qDq
-qDq
+dlu
+dlu
 bTb
 bqc
 ubQ
@@ -117064,7 +117732,7 @@ uPE
 vuV
 uPE
 xSw
-oXb
+gkd
 oXb
 oXb
 kIP


### PR DESCRIPTION

# About the pull request

This PR edits and moves some of the tables in Almayer hypersleep to prevent the shuffling masses of marines from getting clogged up

This PR also adds a mirror to hypersleep aswell as some dirt decals and warning stripe decals to make things look a bit better

# Explain why it's good for the game

read about this PR

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: SpartanBobby
maptweak: Reshuffles tables in squad hypersleep bay adds some new decals
/:cl:
