### PR TITLE
Mil CC gets access to the broadcasting camera

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/combat_correspondent.dm
+++ b/code/game/machinery/vending/vendor_types/crew/combat_correspondent.dm
@@ -7,7 +7,6 @@ GLOBAL_LIST_INIT(cm_vending_clothing_combat_correspondent, list(
 
 		list("CIVILIAN EQUIPMENT (TAKE ALL)", 0, null, null, null),
 		list("Portable Press Fax Machine", 0, /obj/item/device/fax_backpack, CIVILIAN_CAN_BUY_BACKPACK, VENDOR_ITEM_RECOMMENDED),
-		list("Press Broadcasting Camera", 0, /obj/item/device/camera/broadcasting, CIVILIAN_CAN_BUY_UTILITY, VENDOR_ITEM_RECOMMENDED),
 
 		list("UNIFORM (CHOOSE 1)", 0, null, null, null),
 		list("Black Uniform", 0, /obj/item/clothing/under/marine/reporter/black, MARINE_CAN_BUY_UNIFORM, VENDOR_ITEM_REGULAR),
@@ -50,4 +49,5 @@ GLOBAL_LIST_INIT(cm_vending_clothing_combat_correspondent, list(
 		/obj/item/device/binoculars,
 		/obj/item/notepad,
 		/obj/item/device/taperecorder,
+		/obj/item/device/camera/broadcasting,
 	)

--- a/code/game/machinery/vending/vendor_types/crew/combat_correspondent.dm
+++ b/code/game/machinery/vending/vendor_types/crew/combat_correspondent.dm
@@ -4,6 +4,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_combat_correspondent, list(
 		list("STANDARD EQUIPMENT (TAKE ALL)", 0, null, null, null),
 		list("Essential Reporter's Set", 0, /obj/effect/essentials_set/cc, MARINE_CAN_BUY_ESSENTIALS, VENDOR_ITEM_MANDATORY),
 		list("Leather Satchel", 0, /obj/item/storage/backpack/satchel, MARINE_CAN_BUY_BACKPACK, VENDOR_ITEM_REGULAR),
+		list("Press Broadcasting Camera", 0, /obj/item/device/camera/broadcasting, MARINE_CAN_BUY_SECONDARY, VENDOR_ITEM_RECOMMENDED),
 
 		list("CIVILIAN EQUIPMENT (TAKE ALL)", 0, null, null, null),
 		list("Portable Press Fax Machine", 0, /obj/item/device/fax_backpack, CIVILIAN_CAN_BUY_BACKPACK, VENDOR_ITEM_RECOMMENDED),
@@ -49,5 +50,4 @@ GLOBAL_LIST_INIT(cm_vending_clothing_combat_correspondent, list(
 		/obj/item/device/binoculars,
 		/obj/item/notepad,
 		/obj/item/device/taperecorder,
-		/obj/item/device/camera/broadcasting,
 	)


### PR DESCRIPTION

# About the pull request
Mil CC gets access to the broadcasting camera

# Explain why it's good for the game
There were huge plans for CC expansion that were never finished. Mil CC was meant to get his own special camera. Maybe one day I or someone else will make something cooler, but I think for now this will suffice. It kinda sucks that you don't get access to camera if you decide to play mil CC. And if you don't want the camera you don't have to take it or use it so there is no harm.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: ihatethisengine
add: Military CC now can take broadcasting camera from CC vendor.
/:cl:
