### PR TITLE
Infinity Fuel Glitch Fix (for underbarel flamer)

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -2989,24 +2989,30 @@ Defined in conflicts.dm of the #defines folder.
 /obj/item/attachable/attached_gun/flamer/handle_pre_break_attachment_description(base_description_text as text)
 	return base_description_text + " It is on [intense_mode ? "intense" : "normal"] mode."
 
-/obj/item/attachable/attached_gun/flamer/reload_attachment(obj/item/ammo_magazine/flamer_tank/FT, mob/user)
-	if(istype(FT))
-		if(current_rounds >= max_rounds)
+/obj/item/attachable/attached_gun/flamer/reload_attachment(obj/item/ammo_magazine/flamer_tank/fuel_holder, mob/user)
+	if(istype(fuel_holder))
+		var/amt_to_refill = max_rounds - current_rounds
+		if(!amt_to_refill)
 			to_chat(user, SPAN_WARNING("[src] is full."))
-		else if(FT.current_rounds <= 0)
-			to_chat(user, SPAN_WARNING("[FT] is empty!"))
-		else
-			playsound(user, 'sound/effects/refill.ogg', 25, 1, 3)
-			to_chat(user, SPAN_NOTICE("You refill [src] with [FT]."))
-			var/transfered_rounds = min(max_rounds - current_rounds, FT.current_rounds)
-			current_rounds += transfered_rounds
-			FT.current_rounds -= transfered_rounds
+			return
 
-			var/amount_of_reagents = length(FT.reagents.reagent_list)
-			var/amount_removed_per_reagent = transfered_rounds / amount_of_reagents
-			for(var/datum/reagent/R in FT.reagents.reagent_list)
-				R.volume -= amount_removed_per_reagent
-			FT.update_icon()
+		var/datum/reagent/to_remove
+		if(length(fuel_holder.reagents.reagent_list))
+			to_remove = fuel_holder.reagents.reagent_list[1]
+
+		var/fuel_amt
+		if(to_remove)
+			fuel_amt = to_remove.volume < amt_to_refill ? to_remove.volume : amt_to_refill
+
+		if(!fuel_amt)
+			to_chat(user, SPAN_WARNING("[fuel_holder] is empty!"))
+			return
+
+		playsound(user, 'sound/effects/refill.ogg', 25, 1, 3)
+		to_chat(user, SPAN_NOTICE("You refill [src] with [fuel_holder]."))
+		current_rounds += fuel_amt
+		fuel_holder.reagents.remove_reagent(to_remove.id, fuel_amt)
+		fuel_holder.update_icon()
 	else
 		to_chat(user, SPAN_WARNING("[src] can only be refilled with an incinerator tank."))
 


### PR DESCRIPTION
# About the pull request
Fix?

# Changelog

:cl: BlackCrystalic
fix: Underbarel flamer no more can drain fuel from empty tanks
/:cl:
Closes #7245
