### PR TITLE
Medic qol: Build Your Own Revival Mix!

### DIFF
--- a/code/modules/reagents/chemistry_machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_dispenser.dm
@@ -214,7 +214,7 @@
 		if(accept_beaker_only && istype(attacking_object,/obj/item/reagent_container/food))
 			to_chat(user, SPAN_NOTICE("This machine only accepts beakers"))
 			return
-		if(pressurized_only && !istype(attacking_object,/obj/item/reagent_container/glass/pressurized_canister))
+		if(pressurized_only && !istype(attacking_object, /obj/item/reagent_container/glass/pressurized_canister))
 			to_chat(user, SPAN_NOTICE("This machine only accepts pressurized canisters"))
 			return
 		if(user.drop_inv_item_to_loc(attacking_object, src))

--- a/code/modules/reagents/chemistry_machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_dispenser.dm
@@ -276,7 +276,6 @@
 	name = "pressurized chemical dispenser"
 	desc = "A more basic chemical dispenser, designed for use with pressurized reagent canisters. A Wey-Yu product."
 	icon_state = "mixer0"
-	var/base_state = "mixer"
 	ui_title = "Chem Dispenser 4000"
 	req_skill_level = SKILL_MEDICAL_MEDIC
 	accept_beaker_only = FALSE
@@ -292,6 +291,8 @@
 		"tramadol",
 		"tricordrazine",
 	)
+	
+	var/base_state = "mixer"
 
 /obj/structure/machinery/chem_dispenser/soda
 	icon_state = "soda_dispenser"

--- a/code/modules/reagents/chemistry_machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_dispenser.dm
@@ -92,11 +92,11 @@
 
 /obj/structure/machinery/chem_dispenser/corpsman/update_icon()
 	if(stat & BROKEN)
-		icon_state = (beaker?"mixer1_b":"mixer0_b")
+		icon_state = (beaker ? "mixer1_b" : "mixer0_b")
 	else if(stat & NOPOWER)
-		icon_state = (beaker?"[base_state]1_nopower":"[base_state]0_nopower")
+		icon_state = (beaker ? "[base_state]1_nopower" : "[base_state]0_nopower")
 	else
-		icon_state = (beaker?"[base_state]1":"[base_state]0")
+		icon_state = (beaker ? "[base_state]1" : "[base_state]0")
 
 /obj/structure/machinery/chem_dispenser/on_stored_atom_del(atom/movable/AM)
 	if(AM == beaker)

--- a/code/modules/reagents/chemistry_machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_dispenser.dm
@@ -290,7 +290,7 @@
 		"adrenaline",
 		"peridaxon",
 		"tramadol",
-		"tricordrazine"
+		"tricordrazine",
 	)
 
 /obj/structure/machinery/chem_dispenser/soda

--- a/code/modules/reagents/chemistry_machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_dispenser.dm
@@ -20,6 +20,7 @@
 	var/network = "Ground"
 	var/amount = 30
 	var/accept_beaker_only = TRUE
+	var/pressurized_only = FALSE
 	var/obj/item/reagent_container/beaker = null
 	var/ui_check = 0
 	var/static/list/possible_transfer_amounts = list(5,10,20,30,40)
@@ -88,6 +89,14 @@
 		overlays += "+beaker[rand(1, 5)]"
 		if(!inoperable())
 			overlays += "+onlight"
+
+/obj/structure/machinery/chem_dispenser/corpsman/update_icon()
+	if(stat & BROKEN)
+		icon_state = (beaker?"mixer1_b":"mixer0_b")
+	else if(stat & NOPOWER)
+		icon_state = (beaker?"[base_state]1_nopower":"[base_state]0_nopower")
+	else
+		icon_state = (beaker?"[base_state]1":"[base_state]0")
 
 /obj/structure/machinery/chem_dispenser/on_stored_atom_del(atom/movable/AM)
 	if(AM == beaker)
@@ -204,6 +213,10 @@
 	if(istype(attacking_object, /obj/item/reagent_container/glass) || istype(attacking_object, /obj/item/reagent_container/food))
 		if(accept_beaker_only && istype(attacking_object,/obj/item/reagent_container/food))
 			to_chat(user, SPAN_NOTICE("This machine only accepts beakers"))
+			return
+		if(pressurized_only && !istype(attacking_object,/obj/item/reagent_container/glass/pressurized_canister))
+			to_chat(user, SPAN_NOTICE("This machine only accepts pressurized canisters"))
+			return
 		if(user.drop_inv_item_to_loc(attacking_object, src))
 			var/obj/item/old_beaker = beaker
 			beaker = attacking_object
@@ -258,6 +271,27 @@
 		to_chat(user, SPAN_WARNING("You don't have the training to use [src]."))
 		return
 	tgui_interact(user)
+
+/obj/structure/machinery/chem_dispenser/corpsman
+	name = "pressurized chemical dispenser"
+	desc = "A more basic chemical dispenser, designed for use with pressurized reagent canisters. A Wey-Yu product."
+	icon_state = "mixer0"
+	var/base_state = "mixer"
+	ui_title = "Chem Dispenser 4000"
+	req_skill_level = SKILL_MEDICAL_MEDIC
+	accept_beaker_only = FALSE
+	pressurized_only = TRUE
+	dispensable_reagents = list(
+		"bicaridine",
+		"kelotane",
+		"anti_toxin",
+		"dexalin",
+		"inaprovaline",
+		"adrenaline",
+		"peridaxon",
+		"tramadol",
+		"tricordrazine"
+	)
 
 /obj/structure/machinery/chem_dispenser/soda
 	icon_state = "soda_dispenser"

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -8004,8 +8004,9 @@
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/operating_room_two)
 "bcZ" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/box/masks,
+/obj/structure/machinery/chem_dispenser/corpsman{
+	pixel_y = 3
+	},
 /turf/open/floor/almayer/red/north,
 /area/almayer/squads/alpha)
 "bda" = (
@@ -8229,8 +8230,9 @@
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/operating_room_one)
 "bew" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/box/masks,
+/obj/structure/machinery/chem_dispenser/corpsman{
+	pixel_y = 3
+	},
 /turf/open/floor/almayer/orange,
 /area/almayer/squads/bravo)
 "bez" = (
@@ -11966,8 +11968,9 @@
 /turf/open/floor/wood/ship,
 /area/almayer/shipboard/sea_office)
 "bKX" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/box/masks,
+/obj/structure/machinery/chem_dispenser/corpsman{
+	pixel_y = 3
+	},
 /turf/open/floor/almayer/emerald/north,
 /area/almayer/squads/charlie)
 "bLc" = (
@@ -13372,8 +13375,9 @@
 /turf/open/floor/almayer/bluecorner/east,
 /area/almayer/living/briefing)
 "bVy" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/box/masks,
+/obj/structure/machinery/chem_dispenser/corpsman{
+	pixel_y = 3
+	},
 /turf/open/floor/almayer/blue,
 /area/almayer/squads/delta)
 "bVE" = (
@@ -45284,12 +45288,11 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/maint/hull/upper/u_f_s)
 "oRy" = (
+/obj/structure/machinery/cm_vending/sorted/medical/blood/bolted,
 /obj/structure/sign/safety/autodoc{
 	pixel_x = 20;
 	pixel_y = -32
 	},
-/obj/structure/machinery/cm_vending/sorted/medical/bolted,
-/obj/structure/medical_supply_link/green,
 /turf/open/floor/almayer/sterile_green_side,
 /area/almayer/medical/lower_medical_medbay)
 "oRJ" = (
@@ -46285,7 +46288,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cells)
 "pnC" = (
-/obj/structure/machinery/cm_vending/sorted/medical/blood/bolted,
+/obj/structure/machinery/chem_dispenser/corpsman,
 /turf/open/floor/almayer/sterile_green_side,
 /area/almayer/medical/lower_medical_medbay)
 "pnL" = (
@@ -63983,6 +63986,10 @@
 "wsS" = (
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/hallways/lower/starboard_midship_hallway)
+"wti" = (
+/obj/structure/machinery/chem_dispenser/corpsman,
+/turf/open/floor/almayer/sterile_green_side/north,
+/area/almayer/medical/lower_medical_medbay)
 "wtk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -97966,9 +97973,9 @@ bkE
 bQM
 rlZ
 izY
-rlZ
-rlZ
-rlZ
+xsw
+bZn
+kFv
 izY
 rlZ
 hZN
@@ -98169,9 +98176,9 @@ bkE
 bRP
 rlZ
 rlZ
-xsw
-bZn
-kFv
+kSC
+kan
+wti
 rlZ
 rlZ
 siW
@@ -98981,7 +98988,7 @@ vhX
 gDW
 rlZ
 rlZ
-wYr
+pnC
 dBH
 bky
 ryt
@@ -99184,7 +99191,7 @@ xMs
 cjW
 rlZ
 rlZ
-kSC
+wYr
 kan
 quv
 rZB
@@ -99387,9 +99394,9 @@ bgw
 eXb
 rlZ
 rlZ
-thP
-beW
-bgP
+kSC
+kan
+wti
 rlZ
 rlZ
 hAU
@@ -99590,9 +99597,9 @@ bgw
 fbw
 rlZ
 rlZ
-pqD
-pqD
-pqD
+thP
+beW
+bgP
 rlZ
 rlZ
 rFH
@@ -99793,9 +99800,9 @@ bgy
 fxZ
 rlZ
 aZK
-vYt
-fDj
-eBZ
+pqD
+pqD
+pqD
 hBc
 rlZ
 pKZ
@@ -99996,9 +100003,9 @@ bgw
 icw
 qni
 klH
-tgV
-tgV
-tgV
+vYt
+fDj
+eBZ
 klH
 qni
 uah
@@ -100199,9 +100206,9 @@ bgw
 jxi
 rlZ
 rlZ
-rlZ
-rlZ
-rlZ
+tgV
+tgV
+tgV
 rlZ
 rlZ
 nrN

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -8744,11 +8744,6 @@
 /area/almayer/medical/chemistry)
 "biy" = (
 /obj/structure/pipes/unary/freezer,
-/obj/structure/machinery/power/apc/almayer/north,
-/obj/structure/sign/safety/autodoc{
-	pixel_x = 20;
-	pixel_y = 32
-	},
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/cryo_tubes)
 "biA" = (
@@ -17766,6 +17761,10 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/almayer/orange/north,
 /area/almayer/engineering/upper_engineering/port)
+"duO" = (
+/obj/structure/machinery/chem_dispenser/corpsman,
+/turf/open/floor/almayer/sterile_green_side,
+/area/almayer/medical/lower_medical_medbay)
 "duT" = (
 /obj/structure/bed,
 /obj/structure/machinery/flasher{
@@ -21379,6 +21378,14 @@
 	},
 /turf/open/floor/almayer/green/north,
 /area/almayer/hallways/lower/port_aft_hallway)
+"eTB" = (
+/obj/structure/machinery/power/apc/almayer/north,
+/obj/structure/sign/safety/autodoc{
+	pixel_x = 20;
+	pixel_y = 32
+	},
+/turf/open/floor/almayer/sterile_green_side/north,
+/area/almayer/medical/lower_medical_medbay)
 "eTC" = (
 /obj/structure/machinery/cm_vending/sorted/medical/bolted,
 /obj/structure/medical_supply_link,
@@ -45288,12 +45295,11 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/maint/hull/upper/u_f_s)
 "oRy" = (
-/obj/structure/machinery/cm_vending/sorted/medical/blood/bolted,
-/obj/structure/sign/safety/autodoc{
-	pixel_x = 20;
-	pixel_y = -32
+/obj/structure/sign/safety/med_cryo{
+	pixel_x = -6;
+	pixel_y = 32
 	},
-/turf/open/floor/almayer/sterile_green_side,
+/turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/lower_medical_medbay)
 "oRJ" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -46115,6 +46121,15 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/processing)
+"phW" = (
+/obj/structure/machinery/cm_vending/sorted/medical/bolted,
+/obj/structure/medical_supply_link/green,
+/obj/structure/sign/safety/autodoc{
+	pixel_x = 20;
+	pixel_y = -32
+	},
+/turf/open/floor/almayer/sterile_green_side,
+/area/almayer/medical/lower_medical_medbay)
 "pij" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1
@@ -46288,7 +46303,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cells)
 "pnC" = (
-/obj/structure/machinery/chem_dispenser/corpsman,
+/obj/structure/machinery/cm_vending/sorted/medical/blood/bolted,
 /turf/open/floor/almayer/sterile_green_side,
 /area/almayer/medical/lower_medical_medbay)
 "pnL" = (
@@ -48916,10 +48931,6 @@
 /area/almayer/living/briefing)
 "quv" = (
 /obj/structure/pipes/standard/tank/oxygen,
-/obj/structure/sign/safety/med_cryo{
-	pixel_x = -6;
-	pixel_y = 32
-	},
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/cryo_tubes)
 "quJ" = (
@@ -63986,10 +63997,6 @@
 "wsS" = (
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/hallways/lower/starboard_midship_hallway)
-"wti" = (
-/obj/structure/machinery/chem_dispenser/corpsman,
-/turf/open/floor/almayer/sterile_green_side/north,
-/area/almayer/medical/lower_medical_medbay)
 "wtk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -98176,9 +98183,9 @@ bkE
 bRP
 rlZ
 rlZ
-kSC
+phW
 kan
-wti
+eTB
 rlZ
 rlZ
 siW
@@ -98379,8 +98386,8 @@ bst
 cjW
 rlZ
 rlZ
-oRy
-kan
+pnC
+dBH
 biy
 boX
 rlZ
@@ -98582,7 +98589,7 @@ vhX
 akQ
 rlZ
 rlZ
-pnC
+duO
 dBH
 bky
 ryt
@@ -98988,7 +98995,7 @@ vhX
 gDW
 rlZ
 rlZ
-pnC
+duO
 dBH
 bky
 ryt
@@ -99192,7 +99199,7 @@ cjW
 rlZ
 rlZ
 wYr
-kan
+dBH
 quv
 rZB
 rlZ
@@ -99396,7 +99403,7 @@ rlZ
 rlZ
 kSC
 kan
-wti
+oRy
 rlZ
 rlZ
 hAU


### PR DESCRIPTION
# About the pull request
Adds a new type of chem dispenser around the Almayer, usable by Medics to fill their own custom revival mix canisters.

Places 2 pressurized chem dispensers in Medbay lobby, and one in each squad HM prep rooms

Vendors stock basic chemicals, and only allow pressurized reagent canisters to be connected

# Explain why it's good for the game

Pressurized reagent canisters are an extremely important aspect of HM gameplay, and this PR acts to remedy the following issues:
- Reagent canisters are really annoying to refill during an operation (since you need a Doctor to do it for you), and are even more annoying to customize before drop, since Medbay staff are usually extremely busy
- Serves to reduce gear overcrowding in HM vendors, eliminating the need to stock a dozen different varieties of Revival Mix, allowing Medics to build their own canister types with ease, and to match their own unique playstyle 


# Testing Photographs and Procedure

![Screenshot 2024-10-16 174055](https://github.com/user-attachments/assets/3ac29c91-49f6-4122-b5f3-0bb9e3f18cd8)

![Screenshot 2024-10-16 174430](https://github.com/user-attachments/assets/cb9d36ce-824f-476f-84b5-97ba4d872d16)

# Changelog
:cl:
add: Pressurized Chemical Dispenser
/:cl:
