### PR TITLE
No more multiple patient surgeries on one tile

### DIFF
--- a/code/modules/surgery/surgery_procedure.dm
+++ b/code/modules/surgery/surgery_procedure.dm
@@ -98,7 +98,7 @@
 	for(var/mob/living/potential_blocker in get_turf(target))
 		if(potential_blocker == user || potential_blocker == target)
 			continue
-		to_chat(user, SPAN_WARNING("You can't operate, when there's small amount of space! Remove everybody else."))
+		to_chat(user, SPAN_WARNING("You can't operate when you don't have enough space! Remove everybody else."))
 		return FALSE
 
 	if(user == target)

--- a/code/modules/surgery/surgery_procedure.dm
+++ b/code/modules/surgery/surgery_procedure.dm
@@ -94,6 +94,13 @@
 	if(lying_required && target.body_position != LYING_DOWN)
 		to_chat(user, SPAN_WARNING("[user == target ? "You need" : "[target] needs"] to be lying down for this operation!"))
 		return FALSE
+
+	for(var/mob/living/potential_blocker in get_turf(target))
+		if(potential_blocker == user || potential_blocker == target)
+			continue
+		to_chat(user, SPAN_WARNING("You can't operate, when there's small amount of space! Remove everybody else."))
+		return FALSE
+
 	if(user == target)
 		if(!self_operable)
 			to_chat(user, SPAN_WARNING("You can't perform this operation on yourself!"))


### PR DESCRIPTION
# About the pull request
When you do surgery on somebody who shares space with someone else (likely living being), you can't do as expected surgery, exception only you and patient on same turf

I have no clue what wrong with that, but okay, if it's marked as bug, because you can't do multiple surgeries steps at ONCE, so you need finish one action, then do another in another surgery... but yea, you can have multiple surgeries ongoing at same time...

# Changelog

:cl: BlackCrystalic
fix: No more multiple surgeries on same operation table for 2x and more patients at same time
/:cl:

Closes #5516
