### PR TITLE
Typos

### DIFF
--- a/code/game/machinery/vending/vending_types.dm
+++ b/code/game/machinery/vending/vending_types.dm
@@ -277,8 +277,8 @@
 	)
 
 /obj/structure/machinery/vending/sea
-	name = "\improper SeaTech"
-	desc = "An equipment vendor designed to save lives"
+	name = "\improper SEATech"
+	desc = "An equipment vendor designed to save lives."
 	product_ads = "Semper Fi!;First to Fight!;Ooh Rah.;Leathernecks!;The Few. The Proud.;Esprit de Corps;Jarhead.;Devil Dogs."
 	icon_state = "sec"
 	icon_deny = "sec-deny"

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -116,7 +116,7 @@
 
 //Chef
 /obj/item/clothing/suit/chef/classic
-	name = "A classic chef's apron."
+	name = "A classic chef's apron"
 	desc = "A basic, dull, white chef's apron."
 	icon_state = "apronchef"
 	item_state = "apronchef"


### PR DESCRIPTION
John Typo Reaction

# Changelog
:cl:
spellcheck: fixed typos in the names of the SEATech vendor and the chef's apron 
/:cl:

