### PR TITLE
Blood Vendor Medlink Restock

### DIFF
--- a/code/game/machinery/vending/vendor_types/medical.dm
+++ b/code/game/machinery/vending/vendor_types/medical.dm
@@ -719,7 +719,7 @@
 	wrenchable = TRUE
 	hackable = TRUE
 	healthscan = FALSE
-	allow_supply_link_restock = FALSE
+	allow_supply_link_restock = TRUE
 	chem_refill = null
 
 /obj/structure/machinery/cm_vending/sorted/medical/blood/bolted

--- a/code/game/machinery/vending/vendor_types/medical.dm
+++ b/code/game/machinery/vending/vendor_types/medical.dm
@@ -276,8 +276,12 @@
 
 /obj/structure/machinery/cm_vending/sorted/medical/get_examine_text(mob/living/carbon/human/user)
 	. = ..()
+	if(inoperable())
+		return .
 	if(healthscan)
 		. += SPAN_NOTICE("[src] offers assisted medical scans, for ease of use with minimal training. Present the target in front of the scanner to scan.")
+	if(allow_supply_link_restock && get_supply_link())
+		. += SPAN_NOTICE("A supply link is connected.")
 
 /obj/structure/machinery/cm_vending/sorted/medical/ui_data(mob/user)
 	. = ..()

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -29212,6 +29212,7 @@
 /area/almayer/maint/lower/constr)
 "ihw" = (
 /obj/structure/machinery/cm_vending/sorted/medical/blood,
+/obj/structure/medical_supply_link/green,
 /turf/open/floor/almayer/sterile_green_corner/north,
 /area/almayer/medical/lower_medical_medbay)
 "ihI" = (
@@ -46722,6 +46723,7 @@
 /area/almayer/shipboard/brig/cells)
 "pnC" = (
 /obj/structure/machinery/cm_vending/sorted/medical/blood/bolted,
+/obj/structure/medical_supply_link/green,
 /turf/open/floor/almayer/sterile_green_side,
 /area/almayer/medical/lower_medical_medbay)
 "pnL" = (
@@ -57255,6 +57257,7 @@
 	unslashable = 1
 	},
 /obj/structure/machinery/cm_vending/sorted/medical/blood/bolted,
+/obj/structure/medical_supply_link/green,
 /turf/open/floor/almayer/sterile_green_side,
 /area/almayer/medical/lockerroom)
 "tzF" = (
@@ -59999,6 +60002,7 @@
 /area/almayer/shipboard/starboard_point_defense)
 "uLE" = (
 /obj/structure/machinery/cm_vending/sorted/medical/blood,
+/obj/structure/medical_supply_link,
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/shipboard/brig/medical)
 "uLG" = (
@@ -66540,6 +66544,7 @@
 	dir = 1
 	},
 /obj/structure/machinery/cm_vending/sorted/medical/blood/bolted,
+/obj/structure/medical_supply_link,
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/lockerroom)
 "xgN" = (


### PR DESCRIPTION

# About the pull request

This PR enables the ability for blood vendors to restock via medlinks (takes 20 minutes from roundstart to begin) and adds med links to most blood vendor locations on the Almayer. At one point I had it disabled wanting to encourage more use of the restock carts and possibly for players to make blood drives in game, but this never became a norm likely because of the bug that was allowing blood bag reagents to be refilled by vendors. I will likely explore this again in the future with the req rework.

# Explain why it's good for the game

At least for the moment, supplies shipside should generally not be limited. Supply attrition should generally be a result of failing to transport supplies shipside to groundside.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/7f40be38-199f-4a05-951b-fb220fb21e21)
![restock](https://github.com/user-attachments/assets/ee556437-b936-44be-b061-dc70cdde297b)

</details>


# Changelog
:cl: Drathek
qol: Added examine text to vendors that are connected via medlink
balance: Blood vendors restock blood bags when connected via medlink (requires 20 mins from round start)
maptweak: Added more medlinks to the Almayer
/:cl:
