### PR TITLE
Only Show Discord Certify Verb When No Link

### DIFF
--- a/code/datums/entities/player.dm
+++ b/code/datums/entities/player.dm
@@ -509,6 +509,8 @@ BSQL_PROTECT_DATUM(/datum/entity/player)
 		error("ALARM: MISMATCH. Loaded player data for client [ckey], player data ckey is [player.ckey], id: [player.id]")
 	player_data = player
 	player_data.owning_client = src
+	if(!player_data.discord_link_id)
+		add_verb(src, /client/proc/discord_connect)
 	if(!player_data.last_login)
 		player_data.first_join_date = "[time2text(world.realtime, "YYYY-MM-DD hh:mm:ss")]"
 	if(!player_data.first_join_date)

--- a/code/game/verbs/discord.dm
+++ b/code/game/verbs/discord.dm
@@ -1,4 +1,4 @@
-/client/verb/discord_connect()
+/client/proc/discord_connect()
 	set name = "Discord Certify"
 	set category = "OOC"
 

--- a/code/game/verbs/discord.dm
+++ b/code/game/verbs/discord.dm
@@ -8,13 +8,6 @@
 		to_chat(src, SPAN_ALERTWARNING("You don't have enough minutes - [CONFIG_GET(number/certification_minutes) - total_playtime] remaining."))
 		return
 
-	if(!player_data)
-		load_player_data()
-
-	if(player_data.discord_link)
-		to_chat(src, SPAN_ALERTWARNING("You already have a linked Discord. Ask an Admin to remove it."))
-		return
-
 	var/datum/view_record/discord_identifier/ident = locate() in DB_VIEW(/datum/view_record/discord_identifier, DB_AND(
 		DB_COMP("playerid", DB_EQUALS, player_data.id),
 		DB_COMP("realtime", DB_GREATER, world.realtime - 4 HOURS),


### PR DESCRIPTION
# About the pull request

A lil bit of qol


# Changelog
:cl: BlackCrystalic
qol: Discord Certify only visible if you don't have linked discord acc
/:cl:

