### PR TITLE
fixes the unbuckled message to other viewers

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -263,7 +263,7 @@
 					SPAN_NOTICE("You hear metal clanking."))
 			else
 				buckled_mob.visible_message(\
-					SPAN_NOTICE("[buckled_mob.name] unbuckled \himself!"),\
+					SPAN_NOTICE("[buckled_mob.name] unbuckled [buckled_mob.p_them()]self!"),\
 					SPAN_NOTICE("You unbuckle yourself from [src]."),\
 					SPAN_NOTICE("You hear metal clanking"))
 			unbuckle(buckled_mob)


### PR DESCRIPTION
i hate the "[x] unbuckled !" so much

![dreamseeker_dlR2FNQA4Q](https://github.com/user-attachments/assets/d5f6e54e-1101-468a-941a-60d154679817)

no more

:cl:
fix: the unbuckled message is now slightly more accurate
/:cl: