### PR TITLE
Fix Mod Remote Control

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -74,6 +74,7 @@ GLOBAL_LIST_INIT(admin_verbs_default, list(
 	/client/proc/cmd_admin_tacmaps_panel,
 	/client/proc/other_records,
 	/client/proc/toggle_admin_afk_safety,
+	/client/proc/toogle_door_control,
 	))
 
 GLOBAL_LIST_INIT(admin_verbs_admin, list(
@@ -156,7 +157,6 @@ GLOBAL_LIST_INIT(admin_verbs_major_event, list(
 	/client/proc/set_autoreplacer,
 	/client/proc/deactivate_autoreplacer,
 	/client/proc/rerun_decorators,
-	/client/proc/toogle_door_control,
 	/client/proc/map_template_load,
 	/client/proc/load_event_level,
 	/client/proc/cmd_fun_fire_ob,


### PR DESCRIPTION

# About the pull request

Fixes mods not having access to remote control. The permission check was changed but the verb wasn't moved.


# Changelog

:cl:
admin: Moderators now have access to remote control as intended.
/:cl:
