### PR TITLE
Buff's Hornet shells & Star shells into relevancy

### DIFF
--- a/code/datums/ammo/misc.dm
+++ b/code/datums/ammo/misc.dm
@@ -184,7 +184,7 @@
 /datum/ammo/flare/starshell/set_bullet_traits()
 	LAZYADD(traits_to_give, list(
 		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_iff),
-		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_incendiary, stacks = 1)
+		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_incendiary, stacks = 2)
 	))
 
 /datum/ammo/souto

--- a/code/datums/ammo/shrapnel.dm
+++ b/code/datums/ammo/shrapnel.dm
@@ -39,7 +39,7 @@
 	name = ".22 hornet round"
 	icon_state = "hornet_round"
 	flags_ammo_behavior = AMMO_BALLISTIC
-	damage = 20
+	damage = 15
 	shrapnel_chance = 0
 	shell_speed = AMMO_SPEED_TIER_3//she fast af boi
 	penetration = ARMOR_PENETRATION_TIER_5

--- a/code/datums/ammo/shrapnel.dm
+++ b/code/datums/ammo/shrapnel.dm
@@ -39,7 +39,7 @@
 	name = ".22 hornet round"
 	icon_state = "hornet_round"
 	flags_ammo_behavior = AMMO_BALLISTIC
-	damage = 15
+	damage = 8
 	shrapnel_chance = 0
 	shell_speed = AMMO_SPEED_TIER_3//she fast af boi
 	penetration = ARMOR_PENETRATION_TIER_5

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -477,7 +477,7 @@
 	if(mapload)
 		return INITIALIZE_HINT_QDEL
 	. = ..()
-	fuel = rand(30 SECONDS,	60 SECONDS)
+	fuel = rand(4.5 MINUTES, 5.5 MINUTES)
 
 /obj/item/device/flashlight/flare/on/illumination/chemical
 	name = "chemical light"

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -182,10 +182,10 @@
 	desc = "Functions identically to the standard AGM-F 40mm grenade, except instead of exploding into shrapnel, the hornet shell shoots off holo-targeting .22lr rounds. The equivalent to buckshot at-range."
 	icon_state = "grenade_hornet"
 	item_state = "grenade_hornet_active"
-	shrapnel_count = 5
+	shrapnel_count = 15
 	shrapnel_type = /datum/ammo/bullet/shrapnel/hornet_rounds
 	direct_hit_shrapnel = 5
-	dispersion_angle = 15//tight cone
+	dispersion_angle = 25//tight cone
 
 /obj/item/explosive/grenade/high_explosive/airburst/starshell
 	name = "\improper M74 AGM-S Star Shell"


### PR DESCRIPTION
# About the pull request
Buffing both the Starshell shell and hornet shell. 
Giving the hornet shell more coverage, and making the starshell a weaker alternative to flares.

* Increases the Hornet shell cone from 15 degrees to 25 degrees.
* Increases hornet Shell shrapnel from 5 to 15
* Lowers Hornet Shell shrapnel dmg from 20 to 8
* Increases fuel of star shell ash from 30-60 second, to 4.5 - 5.5 minutes. Half of flares.
* Increases applyd fire stacks from starshell from 1 to 2

# Explain why it's good for the game

Both the starshell and hornet shell are basicly a noob trap. They are avalibel in every M79 kit, suggesting new players to use them. But in reality, it only tricks new players into using something worthless.
Wich is sad, because Both the starshell and Hornet shell could be very fun support tools.
So, this aims to make "support M79" a more viable thing.

Currently you have two options with the M79. Either you only use M40s and use the M79, or you use slugs wich require you to be a direct hit god. But in both cases its not viable to use he M79 as your main weapon.
With more shells at their disposal, this gives more players the ability to dedicate themself to the M79.
Support players are in general a bit under lacking in CM. So having more non lethal M79 users walk around would just be a nice thing.

Hornet Shells:
They get reduced dmg, but in exchange they can stack Holo-stacks pretty consitently even to groups. It still needs people to properly aim, but if you can aim, you can almost apply full holo stacks in one go. 9% only, not full 10%. And that takes a picture perfect hit, that will rarley happen outside of testing conditions.
Cone increase and projectile increase serve two purposes. For one making it easier to use, and also giving it more viablity against groups. Its an AOE support tool, it needs some capablity to make apply its effect to more then one target. I want the Hornet shell to serve a diffrent purpose then the HPR holo bullets.
One for groups, one for singel targets.

Hopefully this makes it into a better support tool, but it still migth need some changes.

Star Shell:
Simply increases the time the ash will be on fire. Previously each ash burned for 30 to 60 seconds. Wich is honestly kinda insane. That is unbelivably bad to the point where it feels like sabotage. The multipel ligth sources give it an advantage over the flare, but its not nearly big enough of an advantage to deserve 30 to 60 second burn time. The flares go up to 10 minutes.
Half the flares time seems more sensibel and should make it a good tool to take instead of a flare gun. 
Wich it needs to compete with even sligthly, otherwise people will just take flares instead.
It also gives it some more fire stacks to bring it close to flares, but flares get 2.5 stacks instead, so still weaker. But the ability to hit one target with each ash, gives the dmg of it a nice skill curve. Wich it deserve for taking up a slot a M40 otherwise could take.

This wont be perfect, they will definitly need a bit more tweaking later on. And maybe even have some changes in their supply. But for now this should be enough.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:TheManWithNoHands
balance: rebalances hornet shells, increasing the spread cone to 25, inceasing the projectile count to 15, lowers projectile dmg to 8. 
balance: Inceases Star shell fuel time from 30-60 seconds to 4.5- 5.5 minutes. Increases starshell applyd fire stacks from 1 to 2
/:cl:
