### PR TITLE
Working Chinook Shuttle Landmark

### DIFF
--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -143,3 +143,4 @@
 #define ADMIN_LANDING_PAD_3 "base-ert3"
 #define ADMIN_LANDING_PAD_4 "base-ert4"
 #define ADMIN_LANDING_PAD_5 "base-ert5"
+#define ADMIN_LANDING_PAD_6 "base-ert6"

--- a/code/modules/shuttle/shuttles/ert.dm
+++ b/code/modules/shuttle/shuttles/ert.dm
@@ -333,6 +333,12 @@
 	height = 29
 	roundstart_template = /datum/map_template/shuttle/twe_ert
 
+/obj/docking_port/stationary/emergency_response/chinook_port
+	name = "Chinook Station Landing Pad 1"
+	dir = NORTH
+	id = ADMIN_LANDING_PAD_6
+	roundstart_template = /datum/map_template/shuttle/response_ert
+
 /datum/map_template/shuttle/response_ert
 	name = "Response Shuttle"
 	shuttle_id = MOBILE_SHUTTLE_ID_ERT1

--- a/maps/templates/Chinook.dmm
+++ b/maps/templates/Chinook.dmm
@@ -35,12 +35,6 @@
 "ai" = (
 /turf/open/floor/almayer_hull/outerhull_dir/southwest,
 /area/space)
-"aj" = (
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 4
-	},
-/turf/open/shuttle/dropship/medium_grey_single_wide_up_to_down,
-/area/adminlevel/chinook/shuttle/unpowered)
 "al" = (
 /turf/open/floor/almayer_hull,
 /area/space)
@@ -946,6 +940,10 @@
 /obj/structure/closet/crate,
 /turf/open/floor/almayer/cargo,
 /area/adminlevel/chinook/cargo)
+"do" = (
+/obj/docking_port/stationary/emergency_response/chinook_port,
+/turf/open/floor/plating,
+/area/adminlevel/chinook/shuttle)
 "dp" = (
 /obj/item/reagent_container/food/drinks/bottle/whiskey{
 	pixel_x = 5;
@@ -1492,12 +1490,6 @@
 /obj/structure/machinery/disposal,
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/adminlevel/chinook/medical)
-"fw" = (
-/obj/structure/machinery/door/airlock/almayer/generic{
-	dir = 2
-	},
-/turf/open/shuttle/dropship/medium_grey_single_wide_up_to_down,
-/area/adminlevel/chinook/shuttle/unpowered)
 "fx" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -1552,11 +1544,6 @@
 	},
 /turf/open/floor/wood,
 /area/adminlevel/chinook/offices)
-"fD" = (
-/turf/closed/shuttle/ert{
-	icon_state = "stan_leftengine"
-	},
-/area/adminlevel/chinook/shuttle/unpowered)
 "fE" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -1621,11 +1608,6 @@
 	},
 /turf/open/floor/wood,
 /area/adminlevel/chinook/offices)
-"fP" = (
-/turf/closed/shuttle/ert{
-	icon_state = "rightengine_3"
-	},
-/area/adminlevel/chinook/shuttle/unpowered)
 "fQ" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N"
@@ -1764,11 +1746,6 @@
 	},
 /turf/open/floor/carpet,
 /area/adminlevel/chinook)
-"gy" = (
-/turf/closed/shuttle/ert{
-	icon_state = "stan20"
-	},
-/area/adminlevel/chinook/shuttle/unpowered)
 "gz" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_container/food/snacks/creamcheesebreadslice,
@@ -1920,9 +1897,6 @@
 	},
 /turf/open/floor/prison/kitchen,
 /area/adminlevel/chinook/event)
-"hc" = (
-/turf/open/shuttle/dropship/light_grey_top_left,
-/area/adminlevel/chinook/shuttle/unpowered)
 "hd" = (
 /obj/structure/largecrate/random,
 /obj/item/circuitboard/airlock,
@@ -2500,8 +2474,9 @@
 /turf/open/floor/almayer/plating/northeast,
 /area/adminlevel/chinook/engineering)
 "jq" = (
-/turf/closed/wall/almayer/outer,
-/area/adminlevel/chinook/shuttle/unpowered)
+/obj/docking_port/stationary/emergency_response/idle_port1,
+/turf/closed/wall/almayer/white,
+/area/adminlevel/chinook/medical)
 "jr" = (
 /obj/structure/cargo_container/arious/right,
 /turf/open/floor/corsat/squares,
@@ -2622,11 +2597,6 @@
 	},
 /turf/open/floor/almayer/silver/north,
 /area/adminlevel/chinook)
-"jR" = (
-/turf/closed/shuttle/ert{
-	icon_state = "stan3"
-	},
-/area/adminlevel/chinook/shuttle/unpowered)
 "jS" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_y = 25
@@ -3337,9 +3307,6 @@
 	},
 /turf/open/floor/wood,
 /area/adminlevel/chinook/offices)
-"mX" = (
-/turf/open/shuttle/dropship/light_grey_single_wide_left_to_right,
-/area/adminlevel/chinook/shuttle/unpowered)
 "mY" = (
 /obj/structure/surface/table/reinforced/black,
 /obj/structure/machinery/computer/emails{
@@ -3805,12 +3772,6 @@
 	},
 /turf/open/floor/almayer/red,
 /area/adminlevel/chinook/sec)
-"oD" = (
-/turf/closed/shuttle/ert{
-	icon_state = "leftengine_2";
-	opacity = 0
-	},
-/area/adminlevel/chinook/shuttle/unpowered)
 "oE" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -30
@@ -3961,11 +3922,6 @@
 "ph" = (
 /turf/open/floor/almayer/sterile_green_side,
 /area/adminlevel/chinook/medical)
-"pi" = (
-/turf/closed/shuttle/ert{
-	icon_state = "stan8"
-	},
-/area/adminlevel/chinook/shuttle/unpowered)
 "pj" = (
 /obj/item/trash/burger,
 /turf/open/floor/plating/plating_catwalk,
@@ -4093,12 +4049,6 @@
 	},
 /turf/open/floor/almayer/red/north,
 /area/adminlevel/chinook/sec)
-"pG" = (
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 8
-	},
-/turf/open/shuttle/dropship/medium_grey_single_wide_up_to_down,
-/area/adminlevel/chinook/shuttle/unpowered)
 "pH" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/comdoor{
 	name = "\improper Command Offices"
@@ -4504,12 +4454,6 @@
 /obj/structure/machinery/cm_vending/sorted/medical/chemistry,
 /turf/open/floor/almayer/dark_sterile,
 /area/adminlevel/chinook/medical)
-"ri" = (
-/turf/closed/shuttle/ert{
-	icon_state = "leftengine_1";
-	opacity = 0
-	},
-/area/adminlevel/chinook/shuttle/unpowered)
 "rj" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -4986,11 +4930,6 @@
 /obj/item/storage/fancy/cigarettes/lucky_strikes,
 /turf/open/floor/almayer/cargo,
 /area/adminlevel/chinook/cargo)
-"tf" = (
-/turf/closed/shuttle/ert{
-	icon_state = "stan22"
-	},
-/area/adminlevel/chinook/shuttle/unpowered)
 "tj" = (
 /obj/structure/machinery/door/airlock/almayer/engineering{
 	dir = 1;
@@ -5128,11 +5067,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/adminlevel/chinook)
-"tN" = (
-/turf/closed/shuttle/ert{
-	icon_state = "stan25"
-	},
-/area/adminlevel/chinook/shuttle/unpowered)
 "tO" = (
 /obj/structure/target/syndicate,
 /turf/open/floor/almayer/redfull,
@@ -5404,7 +5338,7 @@
 "uR" = (
 /obj/structure/machinery/floodlight/landing,
 /turf/open/floor/plating,
-/area/adminlevel/chinook/shuttle/unpowered)
+/area/adminlevel/chinook/shuttle)
 "uS" = (
 /obj/structure/desertdam/decals/road_edge{
 	pixel_x = 2;
@@ -5582,9 +5516,6 @@
 	},
 /turf/open/floor/almayer/emerald,
 /area/adminlevel/chinook/shuttle)
-"vC" = (
-/turf/open/shuttle/dropship/light_grey_top_right,
-/area/adminlevel/chinook/shuttle/unpowered)
 "vE" = (
 /obj/structure/sign/safety/ammunition{
 	pixel_x = 32;
@@ -6070,11 +6001,6 @@
 	},
 /turf/open/floor/almayer/red,
 /area/adminlevel/chinook/sec)
-"xK" = (
-/turf/closed/shuttle/ert{
-	icon_state = "stan23"
-	},
-/area/adminlevel/chinook/shuttle/unpowered)
 "xL" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_18"
@@ -6117,9 +6043,6 @@
 /obj/structure/machinery/autolathe/full,
 /turf/open/floor/almayer/sterile_green,
 /area/adminlevel/chinook/medical)
-"xW" = (
-/turf/open/shuttle/dropship/light_grey_bottom_left,
-/area/adminlevel/chinook/shuttle/unpowered)
 "xY" = (
 /obj/structure/bed/chair/comfy,
 /turf/open/floor/strata/faux_wood,
@@ -6154,11 +6077,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/adminlevel/chinook/event)
-"yh" = (
-/turf/closed/shuttle/ert{
-	icon_state = "stan27"
-	},
-/area/adminlevel/chinook/shuttle/unpowered)
 "yi" = (
 /obj/structure/prop/ice_colony/tiger_rug{
 	pixel_x = -16
@@ -6553,11 +6471,6 @@
 	},
 /turf/open/floor/almayer/red,
 /area/adminlevel/chinook/offices)
-"Ad" = (
-/turf/closed/shuttle/ert{
-	icon_state = "stan1"
-	},
-/area/adminlevel/chinook/shuttle/unpowered)
 "Ae" = (
 /obj/structure/machinery/computer/crew,
 /turf/open/floor/almayer/red,
@@ -6582,11 +6495,6 @@
 /obj/structure/surface/table/reinforced/black,
 /turf/open/floor/carpet,
 /area/adminlevel/chinook/sec)
-"Ai" = (
-/turf/closed/shuttle/ert{
-	icon_state = "stan2"
-	},
-/area/adminlevel/chinook/shuttle/unpowered)
 "Aj" = (
 /obj/structure/bed/sofa/vert/grey/top,
 /turf/open/floor/almayer/emeraldfull,
@@ -6748,11 +6656,6 @@
 /obj/structure/reagent_dispensers/water_cooler/stacks,
 /turf/open/floor/almayer/plate,
 /area/adminlevel/chinook/sec)
-"AU" = (
-/turf/closed/shuttle/ert{
-	icon_state = "stan9"
-	},
-/area/adminlevel/chinook/shuttle/unpowered)
 "AV" = (
 /obj/structure/platform{
 	dir = 8
@@ -7021,12 +6924,6 @@
 	},
 /turf/open/floor/wood,
 /area/adminlevel/chinook)
-"Cb" = (
-/turf/closed/shuttle/ert{
-	icon_state = "leftengine_3";
-	opacity = 0
-	},
-/area/adminlevel/chinook/shuttle/unpowered)
 "Cd" = (
 /obj/structure/surface/table/reinforced/black,
 /obj/item/storage/fancy/cigar{
@@ -7184,9 +7081,6 @@
 /obj/structure/machinery/medical_pod/sleeper,
 /turf/open/floor/almayer/sterile_green_side,
 /area/adminlevel/chinook/medical)
-"CP" = (
-/turf/open/shuttle/dropship/light_grey_bottom_right,
-/area/adminlevel/chinook/shuttle/unpowered)
 "CQ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/almayer/plating/northeast,
@@ -7367,11 +7261,6 @@
 	},
 /turf/open/floor/almayer,
 /area/adminlevel/chinook)
-"Dy" = (
-/turf/closed/shuttle/ert{
-	icon_state = "rightengine_2"
-	},
-/area/adminlevel/chinook/shuttle/unpowered)
 "Dz" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal8";
@@ -7425,9 +7314,6 @@
 	},
 /turf/open/floor/carpet,
 /area/adminlevel/chinook/offices)
-"DJ" = (
-/turf/closed/shuttle/ert,
-/area/adminlevel/chinook/shuttle/unpowered)
 "DL" = (
 /obj/structure/surface/table/almayer,
 /obj/effect/spawner/random/tool,
@@ -7540,10 +7426,6 @@
 	},
 /turf/open/floor/wood,
 /area/adminlevel/chinook/offices)
-"El" = (
-/obj/structure/bed/chair/dropship/passenger,
-/turf/open/shuttle/dropship/medium_grey_single_wide_up_to_down,
-/area/adminlevel/chinook/shuttle/unpowered)
 "Em" = (
 /turf/open/floor/kutjevo,
 /area/adminlevel/chinook/offices)
@@ -8044,10 +7926,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/adminlevel/chinook/sec)
-"GD" = (
-/obj/structure/machinery/door/airlock/almayer/generic,
-/turf/open/shuttle/dropship/light_grey_single_wide_up_to_down,
-/area/adminlevel/chinook/shuttle/unpowered)
 "GE" = (
 /obj/structure/largecrate/supply/medicine/blood,
 /turf/open/floor/almayer/plate,
@@ -8559,11 +8437,6 @@
 /obj/structure/machinery/disposal,
 /turf/open/floor/almayer/orange/east,
 /area/adminlevel/chinook/engineering)
-"IK" = (
-/turf/closed/shuttle/ert{
-	icon_state = "rightengine_1"
-	},
-/area/adminlevel/chinook/shuttle/unpowered)
 "IL" = (
 /obj/structure/machinery/disposal,
 /turf/open/floor/almayer/green/north,
@@ -9461,11 +9334,6 @@
 /obj/structure/machinery/iv_drip,
 /turf/open/floor/almayer/sterile_green_side/west,
 /area/adminlevel/chinook/medical)
-"Ms" = (
-/turf/closed/shuttle/ert{
-	icon_state = "stan5"
-	},
-/area/adminlevel/chinook/shuttle/unpowered)
 "Mt" = (
 /obj/structure/surface/table/reinforced/black,
 /obj/item/book/manual/marine_law{
@@ -10010,13 +9878,6 @@
 /obj/structure/machinery/vending/snack,
 /turf/open/floor/kutjevo/plate,
 /area/adminlevel/chinook/offices)
-"OS" = (
-/obj/structure/prop/pred_flight{
-	icon_state = "syndishuttle";
-	name = "shuttle control console"
-	},
-/turf/open/shuttle/dropship/medium_grey_single_wide_up_to_down,
-/area/adminlevel/chinook/shuttle/unpowered)
 "OT" = (
 /obj/structure/machinery/cm_vending/clothing/synth/snowflake,
 /obj/structure/machinery/light{
@@ -10277,7 +10138,7 @@
 	name = "\improper Chinook Shuttle Airlock"
 	},
 /turf/open/floor/almayer/plating/northeast,
-/area/adminlevel/chinook/shuttle/unpowered)
+/area/adminlevel/chinook/shuttle)
 "PM" = (
 /turf/open/floor/almayer/green/west,
 /area/adminlevel/chinook)
@@ -10389,11 +10250,6 @@
 /obj/item/tool/soap,
 /turf/open/floor/almayer/plate,
 /area/adminlevel/chinook/engineering)
-"Qk" = (
-/turf/closed/shuttle/ert{
-	icon_state = "stan21"
-	},
-/area/adminlevel/chinook/shuttle/unpowered)
 "Qm" = (
 /turf/open/floor/almayer/blue/west,
 /area/adminlevel/chinook/offices)
@@ -10710,6 +10566,10 @@
 	},
 /obj/structure/prop/invuln/fusion_reactor,
 /turf/open/floor/almayer/plating/northeast,
+/area/adminlevel/chinook/engineering)
+"Ru" = (
+/obj/docking_port/stationary/emergency_response/idle_port3,
+/turf/open/floor/almayer/orange,
 /area/adminlevel/chinook/engineering)
 "Rw" = (
 /obj/structure/machinery/disposal,
@@ -11098,9 +10958,6 @@
 	},
 /turf/open/floor/almayer/plating/northeast,
 /area/adminlevel/chinook/engineering)
-"Ti" = (
-/turf/open/shuttle/dropship/medium_grey_single_wide_up_to_down,
-/area/adminlevel/chinook/shuttle/unpowered)
 "Tj" = (
 /turf/open/floor/almayer/bluecorner/west,
 /area/adminlevel/chinook)
@@ -11499,11 +11356,6 @@
 /obj/item/clothing/glasses/sunglasses/blindfold,
 /turf/open/floor/almayer/cargo,
 /area/adminlevel/chinook/sec)
-"UV" = (
-/turf/closed/shuttle/ert{
-	icon_state = "stan_rightengine"
-	},
-/area/adminlevel/chinook/shuttle/unpowered)
 "UW" = (
 /obj/structure/surface/table/reinforced/black,
 /obj/item/reagent_container/food/drinks/coffeecup/uscm{
@@ -11537,10 +11389,6 @@
 /obj/structure/closet/secure_closet/brig,
 /turf/open/floor/almayer/cargo,
 /area/adminlevel/chinook/sec)
-"Va" = (
-/obj/structure/surface/rack,
-/turf/open/shuttle/dropship/medium_grey_single_wide_up_to_down,
-/area/adminlevel/chinook/shuttle/unpowered)
 "Vb" = (
 /turf/open/floor/almayer/blue/west,
 /area/adminlevel/chinook)
@@ -12084,7 +11932,7 @@
 /area/adminlevel/chinook)
 "Xl" = (
 /turf/open/floor/plating,
-/area/adminlevel/chinook/shuttle/unpowered)
+/area/adminlevel/chinook/shuttle)
 "Xm" = (
 /obj/structure/window/framed/almayer/hull,
 /turf/open/floor/plating,
@@ -12646,9 +12494,6 @@
 /obj/structure/machinery/constructable_frame,
 /turf/open/floor/almayer,
 /area/adminlevel/chinook/engineering)
-"Zt" = (
-/turf/open/shuttle/dropship/light_grey_single_wide_up_to_down,
-/area/adminlevel/chinook/shuttle/unpowered)
 "Zu" = (
 /turf/open/floor/almayer_hull/outerhull_dir/north,
 /area/space)
@@ -19621,7 +19466,7 @@ UK
 bz
 jI
 pp
-RM
+Ru
 XH
 df
 df
@@ -20890,7 +20735,7 @@ Iv
 Zc
 Iv
 Iv
-Iv
+jq
 Iv
 KI
 Iv
@@ -25725,18 +25570,18 @@ Br
 Xl
 Xl
 Xl
-gy
-DJ
-GD
-DJ
-DJ
-DJ
-GD
-DJ
-fD
-Cb
-oD
-ri
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+do
 Xl
 Xl
 hM
@@ -25852,18 +25697,18 @@ Br
 Xl
 Xl
 Xl
-Qk
-Va
-Ti
-aj
-aj
-aj
-Ti
-Va
-pi
-DJ
-DJ
-Ad
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
 Xl
 Xl
 hM
@@ -25978,19 +25823,19 @@ Mh
 Br
 Xl
 Xl
-gy
-tf
-hc
-Zt
-Zt
-Zt
-Zt
-Zt
-xW
-Ti
-Ti
-Ti
-fw
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
 Xl
 Xl
 hM
@@ -26105,19 +25950,19 @@ Br
 Br
 Xl
 Xl
-yh
-OS
-mX
-El
-El
-El
-El
-El
-mX
-Zt
-Zt
-Zt
-Ai
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
 Xl
 Xl
 hM
@@ -26232,19 +26077,19 @@ mu
 Br
 Xl
 Xl
-tN
-xK
-vC
-Zt
-Zt
-Zt
-Zt
-Zt
-CP
-Ti
-Ti
-Ti
-fw
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
 Xl
 Xl
 hM
@@ -26360,18 +26205,18 @@ Br
 Xl
 Xl
 Xl
-Qk
-Va
-Ti
-pG
-pG
-pG
-Ti
-Va
-AU
-Ms
-Ms
-jR
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
 Xl
 Xl
 hM
@@ -26487,18 +26332,18 @@ Br
 Xl
 Xl
 Xl
-tN
-Ms
-GD
-Ms
-Ms
-Ms
-GD
-Ms
-UV
-fP
-Dy
-IK
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
+Xl
 Xl
 Xl
 hM
@@ -26738,7 +26583,7 @@ Se
 yy
 kk
 Br
-jq
+tC
 PL
 PL
 PL
@@ -26754,7 +26599,7 @@ PL
 PL
 PL
 PL
-jq
+tC
 tC
 af
 oi


### PR DESCRIPTION

# About the pull request

Adds a landmark from which admins can move working shuttles to and from.

# Explain why it's good for the game

Previous map version had a static shuttle that didn't do anything, this was bad for obvious reasons.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
fix: Chinook Dock now works.
/:cl:
