### PR TITLE
Fixes Funny Wall Bug

### DIFF
--- a/code/datums/elements/bullet_trait/damage_boost.dm
+++ b/code/datums/elements/bullet_trait/damage_boost.dm
@@ -55,6 +55,7 @@ GLOBAL_LIST_INIT(damage_boost_vehicles, typecacheof(/obj/vehicle/multitile))
 
 /datum/element/bullet_trait_damage_boost/proc/check_type(atom/A)
 	if(istype(A, /obj/structure/machinery/door)) return "door"
+	else if(istype(A, /turf/closed/wall)) return "wall"
 	//add more cases for other interactions (switch doesn't seem to work with istype)
 	else return 0
 
@@ -71,6 +72,12 @@ GLOBAL_LIST_INIT(damage_boost_vehicles, typecacheof(/obj/vehicle/multitile))
 					active_damage_mult = damage_mult * hit_door.masterkey_mod
 				else
 					active_damage_mult = 1 //no bonus damage
+			else
+				active_damage_mult = damage_mult
+		if("wall")
+			var/turf/closed/wall/hit_wall = hit_atom
+			if(locate(/mob/living) in hit_wall)
+				active_damage_mult = 1 //block bonus damage reflected on mobs from wall turfs
 			else
 				active_damage_mult = damage_mult
 		//add more cases for other interactions


### PR DESCRIPTION
# About the pull request

This PR stops wall turfs from reflecting bonus damage to mobs. This PR is tested and makes sure the damage multiplier isn't accounted for when damage gets reflected. 

# Explain why it's good for the game

Yesterday I got one shot by a XM51 as hivelord at close if not full health. I was wondering what happened and remembered that XM51 does bonus damage on walls and I build one under myself as hivelord. It turns out you can kill a queen in one shot with XM51 if they are in a resin wall.


# Testing Photographs and Procedure
I would make a video if I knew how to but you can test it for yourself pretty easily.

# Changelog
:cl:
fix: Fixes wall damage multipliers from reflecting to mobs.
/:cl:
