### PR TITLE
stops dead people using their human keybinds

### DIFF
--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -3,7 +3,7 @@
 	weight = WEIGHT_MOB
 
 /datum/keybinding/human/can_use(client/user)
-	return ishuman(user.mob)
+	return ishuman(user.mob) && user.mob.stat == CONSCIOUS
 
 /datum/keybinding/human/issue_order
 	hotkey_keys = list("Unbound")


### PR DESCRIPTION
fixes #7358

also: fixes people being able to show-held-item when they're dead through the keybind (like if they're a pred and can't drop their wristblades)

:cl:
fix: fixes being able to use hotkeys for humans when you're a dead human
/:cl: