### PR TITLE
add cobalt tools media provider, refactor providers to be more OOP

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -369,6 +369,12 @@ The default value assumes youtube-dl is in your system PATH
 /datum/config_entry/string/invoke_youtubedl
 	protection = CONFIG_ENTRY_LOCKED | CONFIG_ENTRY_HIDDEN
 
+/datum/config_entry/string/cobalt_base_api
+	protection = CONFIG_ENTRY_LOCKED | CONFIG_ENTRY_HIDDEN
+
+
+/datum/config_entry/string/cobalt_api_key
+	protection = CONFIG_ENTRY_LOCKED | CONFIG_ENTRY_HIDDEN
 
 /datum/config_entry/number/error_cooldown // The "cooldown" time for each occurrence of a unique error
 	config_entry_value = 600

--- a/code/datums/internet_media.dm
+++ b/code/datums/internet_media.dm
@@ -44,8 +44,8 @@
 
 	try
 		data = json_decode(stdout)
-	catch(var/exception/e)
-		error = "Youtube-dl JSON parsing FAILED: [e]: [stdout]"
+	catch(var/exception/decode_error)
+		error = "Youtube-dl JSON parsing FAILED: [decode_error]: [stdout]"
 		return
 
 	return new /datum/media_response(data["url"], data["title"], data["start_time"], data["end_time"])
@@ -83,8 +83,8 @@
 	var/list/response
 	try
 		response = json_decode(response_raw.body)
-	catch(var/exception/e)
-		error = "cobalt.tools JSON parsing FAILED: [e]: [response_raw.body]"
+	catch(var/exception/decode_error)
+		error = "cobalt.tools JSON parsing FAILED: [decode_error]: [response_raw.body]"
 		return
 
 	if(!(response["status"] in list("redirect", "tunnel")))

--- a/code/datums/internet_media.dm
+++ b/code/datums/internet_media.dm
@@ -45,7 +45,7 @@
 	request.prepare(RUSTG_HTTP_METHOD_POST, CONFIG_GET(string/cobalt_base_api), json_encode(list(
 		"url" = url,
 		"downloadMode" = "audio"
-	)), json_encode(headers))
+	)), headers)
 
 	request.execute_blocking()
 

--- a/code/datums/internet_media.dm
+++ b/code/datums/internet_media.dm
@@ -3,10 +3,16 @@
  * clients to play audio via [/datum/tgui_panel/proc/play_music], from a provided URL
  */
 /datum/internet_media
+	/**
+	 * If we have encountered an error while attempting to retrieve the URL
+	 */
+	var/error
 
 /**
  * Handles a request for an audio file, from a provided media URL
  * Must return a [/datum/media_response], which must have at least the [/datum/media_response/var/url] filled out
+ *
+ * If we are not returning a media_response, set the [/datum/internet_media/var/error] to be an error
  */
 /datum/internet_media/proc/get_media(url)
 	RETURN_TYPE(/datum/media_response)
@@ -18,6 +24,7 @@
 /datum/internet_media/yt_dlp/get_media(url)
 	var/ytdl = CONFIG_GET(string/invoke_youtubedl)
 	if(!ytdl)
+		error = "Youtube-dl FAILED: Not configured"
 		return
 
 	if(findtext(url, ":") && !findtext(url, GLOB.is_http_protocol))
@@ -29,20 +36,27 @@
 	var/stderr = output[SHELLEO_STDERR]
 
 	if(errorlevel)
-		CRASH("Youtube-dl URL retrieval FAILED: [stderr]")
+		error = "Youtube-dl URL retrieval FAILED: [stderr]"
+		return
 
 	var/data
 
 	try
 		data = json_decode(stdout)
 	catch(var/exception/e)
-		CRASH("Youtube-dl JSON parsing FAILED: [e]: [stdout]")
+		error = "Youtube-dl JSON parsing FAILED: [e]: [stdout]"
+		return
 
 	return new /datum/media_response(data["url"], data["title"], data["start_time"], data["end_time"])
 
 /datum/internet_media/cobalt
 
 /datum/internet_media/cobalt/get_media(url)
+	var/cobalt = CONFIG_GET(string/cobalt_base_api)
+	if(!cobalt)
+		error = "cobalt.tools FAILED: Not configured"
+		return
+
 	var/list/headers = list()
 	headers["Accept"] = "application/json"
 	headers["Content-Type"] = "application/json"
@@ -52,7 +66,7 @@
 		headers["Authorization"] = "Api-Key [auth_key]"
 
 	var/datum/http_request/request = new
-	request.prepare(RUSTG_HTTP_METHOD_POST, CONFIG_GET(string/cobalt_base_api), json_encode(list(
+	request.prepare(RUSTG_HTTP_METHOD_POST, cobalt, json_encode(list(
 		"url" = url,
 		"downloadMode" = "audio"
 	)), headers)
@@ -62,16 +76,20 @@
 	var/datum/http_response/response_raw = request.into_response()
 
 	if(response_raw.errored)
-		CRASH("cobalt.tools web request FAILED: [response_raw.error]")
+		error = "cobalt.tools web request FAILED: [response_raw.error]"
+		return
 
 	var/list/response
 	try
 		response = json_decode(response_raw.body)
 	catch(var/exception/e)
-		CRASH("cobalt.tools JSON parsing FAILED: [e]: [response_raw.body]")
+		error = "cobalt.tools JSON parsing FAILED: [e]: [response_raw.body]"
+		return
 
 	if(!(response["status"] in list("redirect", "tunnel")))
-		CRASH("cobalt.tools request FAILED - invalid response: [response_raw.body]")
+		error = "cobalt.tools request FAILED - invalid response: [response_raw.body]"
+		return
+
 	return new /datum/media_response(response["url"])
 
 /datum/media_response

--- a/code/datums/internet_media.dm
+++ b/code/datums/internet_media.dm
@@ -1,0 +1,80 @@
+/datum/internet_media
+
+/datum/internet_media/proc/get_media(url)
+	RETURN_TYPE(/datum/media_response)
+
+/datum/internet_media/yt_dlp
+
+/datum/internet_media/yt_dlp/get_media(url)
+	var/ytdl = CONFIG_GET(string/invoke_youtubedl)
+	if(!ytdl)
+		return
+
+	if(findtext(url, ":") && !findtext(url, GLOB.is_http_protocol))
+		return
+
+	var/list/output = world.shelleo("[ytdl] --geo-bypass --format \"bestaudio\[ext=mp3]/best\[ext=mp4]\[height<=360]/bestaudio\[ext=m4a]/bestaudio\[ext=aac]\" --dump-single-json --no-playlist -- \"[shell_url_scrub(url)]\"")
+	var/errorlevel = output[SHELLEO_ERRORLEVEL]
+	var/stdout = output[SHELLEO_STDOUT]
+	var/stderr = output[SHELLEO_STDERR]
+
+	if(errorlevel)
+		CRASH("Youtube-dl URL retrieval FAILED: [stderr]")
+
+	var/data
+
+	try
+		data = json_decode(stdout)
+	catch(var/exception/e)
+		CRASH("Youtube-dl JSON parsing FAILED: [e]: [stdout]")
+
+	return new /datum/media_response(data["url"], data["title"], data["start_time"], data["end_time"])
+
+/datum/internet_media/cobalt
+
+/datum/internet_media/cobalt/get_media(url)
+	var/list/headers = list()
+	headers["Accept"] = "application/json"
+	headers["Content-Type"] = "application/json"
+
+	var/auth_key = CONFIG_GET(string/cobalt_api_key)
+	if(auth_key)
+		headers["Authorization"] = "Api-Key [auth_key]"
+
+	var/datum/http_request/request = new
+	request.prepare(RUSTG_HTTP_METHOD_POST, CONFIG_GET(string/cobalt_base_api), json_encode(list(
+		"url" = url,
+		"downloadMode" = "audio"
+	)), json_encode(headers))
+
+	request.execute_blocking()
+
+	var/datum/http_response/response_raw = request.into_response()
+
+	if(response_raw.errored)
+		CRASH("cobalt.tools web request FAILED: [response_raw.error]")
+
+	var/list/response
+	try
+		response = json_decode(response_raw.body)
+	catch(var/exception/e)
+		CRASH("cobalt.tools JSON parsing FAILED: [e]: [response_raw.body]")
+
+	if(!(response["status"] in list("redirect", "tunnel")))
+		CRASH("cobalt.tools request FAILED - invalid response: [response_raw.body]")
+	return new /datum/media_response(response["url"])
+
+/datum/media_response
+	var/url
+	var/title
+	var/start_time
+	var/end_time
+
+/datum/media_response/New(url, title, start_time, end_time)
+	src.url = url
+	src.title = title
+	src.start_time = start_time
+	src.end_time = end_time
+
+/datum/media_response/proc/get_list()
+	return list("url" = url, "title" = title, "start_time" = start_time, "end_time" = end_time)

--- a/code/datums/internet_media.dm
+++ b/code/datums/internet_media.dm
@@ -1,7 +1,17 @@
+/**
+ * Generic implementation to get a URL that can be sent to
+ * clients to play audio via [/datum/tgui_panel/proc/play_music], from a provided URL
+ */
 /datum/internet_media
 
+/**
+ * Handles a request for an audio file, from a provided media URL
+ * Must return a [/datum/media_response], which must have at least the [/datum/media_response/var/url] filled out
+ */
 /datum/internet_media/proc/get_media(url)
 	RETURN_TYPE(/datum/media_response)
+
+	CRASH("[type] does not override [nameof(__PROC__)].")
 
 /datum/internet_media/yt_dlp
 
@@ -71,6 +81,9 @@
 	var/end_time
 
 /datum/media_response/New(url, title, start_time, end_time)
+	if(isnull(url))
+		CRASH("/datum/media_response created without a URL field.")
+
 	src.url = url
 	src.title = title
 	src.start_time = start_time

--- a/code/datums/internet_media.dm
+++ b/code/datums/internet_media.dm
@@ -28,6 +28,7 @@
 		return
 
 	if(findtext(url, ":") && !findtext(url, GLOB.is_http_protocol))
+		error = "Youtube-dl FAILED: Non-http(s) URIs are not allowed. For youtube-dl shortcuts like ytsearch: please use the appropriate full url from the website."
 		return
 
 	var/list/output = world.shelleo("[ytdl] --geo-bypass --format \"bestaudio\[ext=mp3]/best\[ext=mp4]\[height<=360]/bestaudio\[ext=m4a]/bestaudio\[ext=aac]\" --dump-single-json --no-playlist -- \"[shell_url_scrub(url)]\"")

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -19,10 +19,10 @@
 		var/list/datum/internet_media/media_players = list()
 
 		if(CONFIG_GET(string/invoke_youtubedl))
-			media_players = new /datum/internet_media/yt_dlp
+			media_players += new /datum/internet_media/yt_dlp
 
 		if(CONFIG_GET(string/cobalt_base_api))
-			media_players = new /datum/internet_media/cobalt
+			media_players += new /datum/internet_media/cobalt
 
 		if(!length(media_players))
 			to_chat(src, SPAN_BOLDWARNING("Your server host has not set up any web media players."))

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -74,7 +74,7 @@
 		music_extra_data["start"] = data["start_time"]
 		music_extra_data["end"] = data["end_time"]
 
-		if(isnull[data["title"]])
+		if(isnull(data["title"]))
 			data["title"] = tgui_input_text(src, "What is the title of this media?", "Media Title")
 		title = data["title"]
 		music_extra_data["title"] = data["title"]

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -349,6 +349,7 @@
 #include "code\datums\fluff_emails.dm"
 #include "code\datums\global_variables.dm"
 #include "code\datums\http.dm"
+#include "code\datums\internet_media.dm"
 #include "code\datums\lazy_template.dm"
 #include "code\datums\map_config.dm"
 #include "code\datums\matrix_editor.dm"

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -236,6 +236,11 @@ AUTOOOCMUTE
 ## The default value assumes youtube-dl is in your system PATH
 # INVOKE_YOUTUBEDL youtube-dl
 
+## cobalt.tools is an alternative player used by Play Internet Sound, if
+## both INVOKE_YOUTUBEDL and COBALT_BASE_API are specified. If only
+## COBALT_BASE_API is specified, it will exclusively cobalt.tools.
+# COBALT_BASE_API https://api.cobalt.tools/
+
 ## Default gamemode to auto-switch back to after a round has concluded
 GAMEMODE_DEFAULT Extended
 


### PR DESCRIPTION
:cl:
server: server hosts can now configure a cobalt.tools api to provide media playing with "COBALT_BASE_API" and "COBALT_API_KEY"
/:cl: