### PR TITLE
NERFS scout's engineering skill to NOVICE

### DIFF
--- a/code/modules/cm_marines/specialist.dm
+++ b/code/modules/cm_marines/specialist.dm
@@ -155,8 +155,8 @@
 	if(!.)
 		return .
 
-	if(!skillcheck(redeemer, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))
-		redeemer.skills?.set_skill(SKILL_ENGINEER, SKILL_ENGINEER_TRAINED)
+	if(!skillcheck(redeemer, SKILL_ENGINEER, SKILL_ENGINEER_NOVICE))
+		redeemer.skills?.set_skill(SKILL_ENGINEER, SKILL_ENGINEER_NOVICE)
 	return TRUE
 
 /datum/specialist_set/sniper

--- a/code/modules/desert_dam/motion_sensor/sensortower.dm
+++ b/code/modules/desert_dam/motion_sensor/sensortower.dm
@@ -135,7 +135,7 @@
 			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
 			return
 		if(buildstate == SENSORTOWER_BUILDSTATE_BLOWTORCH && !is_on)
-			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
+			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))
 				to_chat(user, SPAN_WARNING("You have no clue how to repair this thing."))
 				return FALSE
 			var/obj/item/tool/weldingtool/WT = O
@@ -159,7 +159,7 @@
 
 	else if(HAS_TRAIT(O, TRAIT_TOOL_WIRECUTTERS))
 		if(buildstate == SENSORTOWER_BUILDSTATE_WIRECUTTERS && !is_on)
-			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
+			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))
 				to_chat(user, SPAN_WARNING("You have no clue how to repair this thing."))
 				return FALSE
 			playsound(loc, 'sound/items/Wirecutter.ogg', 25, 1)
@@ -176,7 +176,7 @@
 				return TRUE
 	else if(HAS_TRAIT(O, TRAIT_TOOL_WRENCH))
 		if(buildstate == SENSORTOWER_BUILDSTATE_WRENCH && !is_on)
-			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
+			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))
 				to_chat(user, SPAN_WARNING("You have no clue how to repair this thing."))
 				return FALSE
 			playsound(loc, 'sound/items/Ratchet.ogg', 25, 1)

--- a/code/modules/desert_dam/motion_sensor/sensortower.dm
+++ b/code/modules/desert_dam/motion_sensor/sensortower.dm
@@ -135,7 +135,7 @@
 			to_chat(user, SPAN_WARNING("You need a stronger blowtorch!"))
 			return
 		if(buildstate == SENSORTOWER_BUILDSTATE_BLOWTORCH && !is_on)
-			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))
+			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
 				to_chat(user, SPAN_WARNING("You have no clue how to repair this thing."))
 				return FALSE
 			var/obj/item/tool/weldingtool/WT = O
@@ -159,7 +159,7 @@
 
 	else if(HAS_TRAIT(O, TRAIT_TOOL_WIRECUTTERS))
 		if(buildstate == SENSORTOWER_BUILDSTATE_WIRECUTTERS && !is_on)
-			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))
+			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
 				to_chat(user, SPAN_WARNING("You have no clue how to repair this thing."))
 				return FALSE
 			playsound(loc, 'sound/items/Wirecutter.ogg', 25, 1)
@@ -176,7 +176,7 @@
 				return TRUE
 	else if(HAS_TRAIT(O, TRAIT_TOOL_WRENCH))
 		if(buildstate == SENSORTOWER_BUILDSTATE_WRENCH && !is_on)
-			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_TRAINED))
+			if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_ENGI))
 				to_chat(user, SPAN_WARNING("You have no clue how to repair this thing."))
 				return FALSE
 			playsound(loc, 'sound/items/Ratchet.ogg', 25, 1)


### PR DESCRIPTION
# About the pull request
Scout now have SKILL_ENGINEER_NOVICE instead of SKILL_ENGINEER_TRAINED.

# Explain why it's good for the game
The only reason for this PR is to fix the situation where it is too easy for scouts to repair the sensor tower.
 
Scouts used to carry engineers in the tarp in order to repair the sensor tower which was pretty funny. But then they found out that all they needed were tools. Anyway it's pretty lame that an invisible entity can repair the tower with little to no risks. Checking the tower every two minutes to look if it was sneaky repaired really brings me to pre-perma nesting times. It's lame. And bringing an engi was way cooler and soulful, and required some actual teamwork. I don't think scout really needs engineering skills for anything else, C4 is useable with SKILL_ENGINEER_NOVICE.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: ihatethisengine
balance: scout's engineering skill is now 1.
/:cl:
