### PR TITLE
base rav slight buff

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Ravager.dm
@@ -74,7 +74,7 @@
 /datum/behavior_delegate/ravager_base
 	var/shield_decay_time = 15 SECONDS // Time in deciseconds before our shield decays
 	var/slash_charge_cdr = 3 SECONDS // Amount to reduce charge cooldown by per slash
-	var/knockdown_amount = 2
+	var/knockdown_amount = 1.6
 	var/fling_distance = 3
 	var/empower_targets = 0
 	var/super_empower_threshold = 3

--- a/code/modules/mob/living/carbon/xenomorph/castes/Ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Ravager.dm
@@ -74,7 +74,7 @@
 /datum/behavior_delegate/ravager_base
 	var/shield_decay_time = 15 SECONDS // Time in deciseconds before our shield decays
 	var/slash_charge_cdr = 3 SECONDS // Amount to reduce charge cooldown by per slash
-	var/knockdown_amount = 1.3
+	var/knockdown_amount = 2 SECONDS
 	var/fling_distance = 3
 	var/empower_targets = 0
 	var/super_empower_threshold = 3

--- a/code/modules/mob/living/carbon/xenomorph/castes/Ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Ravager.dm
@@ -74,7 +74,7 @@
 /datum/behavior_delegate/ravager_base
 	var/shield_decay_time = 15 SECONDS // Time in deciseconds before our shield decays
 	var/slash_charge_cdr = 3 SECONDS // Amount to reduce charge cooldown by per slash
-	var/knockdown_amount = 2 SECONDS
+	var/knockdown_amount = 2
 	var/fling_distance = 3
 	var/empower_targets = 0
 	var/super_empower_threshold = 3


### PR DESCRIPTION
# About the pull request

increases the stun from the base ravager dash

# Explain why it's good for the game
Base ravager is very single target, the only target you knockdown infront of suppressing fire getting up too fast isnt really a fun time for an alleged tier 3 supposed to take on multiple targets,

This should allow you to have an easier time to kill the target you have atleast dashed.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: base ravager empowered charge stun is increased from 1.3 to 1.6
/:cl:
