### PR TITLE
Remote building nerfs

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -241,7 +241,7 @@
 	switch(X.build_resin(A, thick, make_message, plasma_cost != 0, build_speed_mod))
 		if(SECRETE_RESIN_INTERRUPT)
 			if(xeno_cooldown)
-				apply_cooldown_override(xeno_cooldown * 2)
+				apply_cooldown_override(xeno_cooldown * 3)
 			return FALSE
 		if(SECRETE_RESIN_FAIL)
 			if(xeno_cooldown)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_abilities.dm
@@ -50,11 +50,11 @@
 	action_icon_state = "secrete_resin"
 	ability_name = "projected resin"
 	plasma_cost = 100
-	xeno_cooldown = 2 SECONDS
+	xeno_cooldown = 4 SECONDS
 	ability_primacy = XENO_PRIMARY_ACTION_5
 
 	care_about_adjacency = FALSE
-	build_speed_mod = 1
+	build_speed_mod = 1.5
 
 	var/boosted = FALSE
 
@@ -75,11 +75,12 @@
 		boosted = TRUE
 		xeno_cooldown = 0
 		plasma_cost = 0
+		build_speed_mod = 1
 		RegisterSignal(owner, COMSIG_XENO_THICK_RESIN_BYPASS, PROC_REF(override_secrete_thick_resin))
 		addtimer(CALLBACK(src, PROC_REF(disable_boost)), boost_duration)
 
 /datum/action/xeno_action/activable/secrete_resin/remote/queen/proc/disable_boost()
-	xeno_cooldown = 2 SECONDS
+	xeno_cooldown = 4 SECONDS
 	plasma_cost = 100
 	boosted = FALSE
 	UnregisterSignal(owner, COMSIG_XENO_THICK_RESIN_BYPASS)

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/hivelord/resin_whisperer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/hivelord/resin_whisperer.dm
@@ -44,13 +44,13 @@
 	name = "Coerce Resin (100)"
 	action_icon_state = "secrete_resin"
 	ability_name = "coerce resin"
-	xeno_cooldown = 1 SECONDS
+	xeno_cooldown = 2.5 SECONDS
 	thick = FALSE
 	make_message = FALSE
 
 	no_cooldown_msg = TRUE
 
-	build_speed_mod = 2 // the actual building part takes twice as long
+	build_speed_mod = 2.5 // the actual building part takes twice as long
 
 	macro_path = /datum/action/xeno_action/verb/verb_coerce_resin
 	action_type = XENO_ACTION_CLICK
@@ -91,8 +91,10 @@
 	if(care_about_adjacency)
 		if(owner.Adjacent(target_turf))
 			build_speed_mod = 1
+			xeno_cooldown = 1 SECONDS
 		else
 			build_speed_mod = initial(build_speed_mod)
+			xeno_cooldown = initial(xeno_cooldown)
 
 	var/mob/living/carbon/xenomorph/hivelord = owner
 	if(!..())


### PR DESCRIPTION
# About the pull request

See video section for changed values in practice.

Adjusted queen remote building cooldown because it had none (it began the moment building started and finished when building was done) and raised the build time modifier by half to give players more time to react.
Slightly raised resin whisperer build time for the same reason.
Raised the cooldown multiplier for interrupting remote building so interrupting it is finally a valid counterplay that stops it for a time.

Initial 30 minute building buff is unchanged. Notable that hivelord and queen's building modifiers seem to function differently as they're around the same time in practice despite different values.

# Explain why it's good for the game

Queen's remote building was designed to help with building up defenses, but ended up as an incredibly cancerous ability constantly used on the frontline. Most of the time this is enough to almost by itself push the entire marine force back, because cleaning these weeds and fighting at the same time isn't possible.

Even if people dedicated themselves to breaking weeds to prevent it, both the build duration and cooldown made this incredibly difficult/impossible, turning their game into a 24/7 whack-a-mole until they got inevitably killed by one of the nearby xenos cause they were too preoccupied trying to halt the wall onslaught.

The very quick built time also sometimes leads to xenos dying because by the time they realize a wall's being built it's already finished.
It is simply not fun for either side and im confident there isn't a single good reason to keep it in current state. I'd rather deal with screech having a 14 tile range than something this anti-fun.

With proposed changes there is slightly more time to react, the wall spam itself is slower and interrupting it does put it on a reasonable cooldown. Should make this possible to play against if queens choose to use it offensively, without making the ability useless for its intended purposes.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>


https://github.com/user-attachments/assets/485f8e4f-ee52-4fdc-82f0-4712fce01b97



</details>


# Changelog
:cl:
balance: Cooldown multiplier for interrupting remote building raised from 2 to 3
balance: Queen remote building modifier raised from 1 to 1.5 (slower, around 2.3-2.5s), cooldown raised from 2s to 4s
balance: Resin Whisperer remote building modifier raised from 2 to 2.5 (slower, around 2.5s), cooldown raised from 1s to 2.5s
/:cl:
