### PR TITLE
Escape Pods can no longer be tunneled or burrowed.

### DIFF
--- a/code/game/area/shuttles.dm
+++ b/code/game/area/shuttles.dm
@@ -73,6 +73,7 @@
 /area/shuttle/escape_pod
 	icon = 'icons/turf/area_almayer.dmi'
 	icon_state = "lifeboat"
+	flags_area = AREA_NOTUNNEL
 
 /area/shuttle/escape_pod/afterShuttleMove(new_parallax_dir)
 	. = ..()


### PR DESCRIPTION

# About the pull request

Basically what the title says, tunnels cannot be made inside nor can Burrowers burrow inside of escape pods.

# Explain why it's good for the game

The Burrower shipside meta is very stinky and as it stands, this is the one thing that can make it genuinely impossible to kill a shipside burrower unless you enable evac for one bug, also lifeboats also already have this flag, pods should too.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Escape Pods can no longer be burrowed into or tunneled.
/:cl:
