### PR TITLE
Makes Sentinel's Paralyzing Slash bypass intent while active

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Sentinel.dm
@@ -102,6 +102,15 @@
 
 #undef NEURO_TOUCH_DELAY
 
+/datum/behavior_delegate/sentinel_base/override_intent(mob/living/carbon/target_carbon)
+	. = ..()
+
+	if(!isxeno_human(target_carbon))
+		return
+
+	if(next_slash_buffed)
+		return INTENT_HARM
+
 /datum/behavior_delegate/sentinel_base/proc/paralyzing_slash(mob/living/carbon/human/human_target)
 	human_target.KnockDown(2)
 	human_target.Stun(2)


### PR DESCRIPTION
# About the pull request

Steals code from Lurker's Crippling Slash to make Sentinel bypass intent while buffed Paralyzing Slash.

# Explain why it's good for the game

You are only ever going to be using this with goal of slashing someone, and considering both the short duration of the buff and the riskiness of using it in combat, whiffing it because you forgot you weren't on harm intent in the heat of the moment is a bit annoying.

# Testing Photographs and Procedure

Stole working code from Lurker. Slashed someone while on help intent. Tried again post-slash, got normal help interaction.

# Changelog

:cl: Killfish
qol: Paralyzing Slash now makes you slash regardless of intent for the duration of the buff.
/:cl:
