### PR TITLE
Surgical case buff

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -321,6 +321,9 @@
 		/obj/item/tool/surgery/scalpel,
 		/obj/item/tool/surgery/hemostat,
 		/obj/item/tool/surgery/retractor,
+		/obj/item/tool/surgery/surgical_line,
+		/obj/item/tool/surgery/synthgraft,
+		/obj/item/tool/surgery/FixOVein,
 	)
 
 /obj/item/storage/surgical_case/regular


### PR DESCRIPTION

# About the pull request

Allows the surgical case used by nurses and (rarely) corpsman to be able to hold Surgical Line, Synth-Graft, and Fix-O-Vein.



# Explain why it's good for the game

The surgical case in its current state is borderline useless and isn't taken by a lot of people for this reason. This makes it not useless, and it also makes sense for it to be able to hold other small, simple surgical items.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/3563e368-f881-43d7-abb2-88e8fbc1c43f)
</details>


# Changelog
:cl:
balance: The surgical case can now hold Surgical Line, Synthetic-Graft, and Fix-O-Vein (for real this time)
/:cl:
