### PR TITLE
Adds and expands on the descriptions of tank hardpoints & magazins

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
+++ b/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
@@ -353,7 +353,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_vehicle_crew, list(
 
 //Not essentials sets but fuck it the code's here
 /obj/effect/essentials_set/tank/ltb
-	desc = "A giant canon firing explosive 86mm shells. You be lucky if this even leaves dust of whatever you hit with it."
+	desc = "A giant cannon firing explosive 86mm shells. You'd be lucky if this even leaves the dust of whatever you hit with it."
 	spawned_gear_list = list(
 		/obj/item/hardpoint/primary/cannon,
 		/obj/item/ammo_magazine/hardpoint/ltb_cannon,

--- a/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
+++ b/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
@@ -412,7 +412,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_vehicle_crew, list(
 	)
 
 /obj/effect/essentials_set/tank/tankgl
-	desc = "A magazin feed grenade launcher capable of holding 10 grenades. This model loads M40 grenades."
+	desc = "A magazine feed grenade launcher capable of holding 10 grenades. This model loads M40 grenades."
 	spawned_gear_list = list(
 		/obj/item/hardpoint/secondary/grenade_launcher,
 		/obj/item/ammo_magazine/hardpoint/tank_glauncher,

--- a/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
+++ b/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
@@ -151,7 +151,7 @@ GLOBAL_LIST_INIT(cm_vending_vehicle_crew_tank, list(
 
 	list("TREADS", 0, null, null, null),
 	list("Reinforced Treads", 0, /obj/item/hardpoint/locomotion/treads/robust, VEHICLE_TREADS_AVAILABLE, VENDOR_ITEM_REGULAR),
-	list("Treads", 0, /obj/item/hardpoint/locomotion/treads, VEHICLE_TREADS_AVAILABLE, VENDOR_ITEM_REGULAR)))
+	list("Treads", 0, /obj/item/hardpoint/locomotion/robust, VEHICLE_TREADS_AVAILABLE, VENDOR_ITEM_REGULAR)))
 
 GLOBAL_LIST_INIT(cm_vending_vehicle_crew_apc, list(
 	list("STARTING KIT SELECTION:", 0, null, null, null),
@@ -397,7 +397,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_vehicle_crew, list(
 	)
 
 /obj/effect/essentials_set/tank/tow
-	desc = "A quad rocket launcher capable of firing four rockets in quick succession."
+	desc = "A quint rocket launcher capable of firing four rockets in quick succession."
 	spawned_gear_list = list(
 		/obj/item/hardpoint/secondary/towlauncher,
 		/obj/item/ammo_magazine/hardpoint/towlauncher,

--- a/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
+++ b/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
@@ -380,7 +380,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_vehicle_crew, list(
 	)
 
 /obj/effect/essentials_set/tank/autocannon
-	desc = "An Automatic Canon for tanks. Capable of firing precise even at long ranges. Loads 20mm explosive shells."
+	desc = "An automatic cannon for tanks, capable of firing precisely even at long ranges. Loads 20mm explosive shells."
 	spawned_gear_list = list(
 		/obj/item/hardpoint/primary/autocannon,
 		/obj/item/ammo_magazine/hardpoint/ace_autocannon,

--- a/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
+++ b/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
@@ -364,7 +364,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_vehicle_crew, list(
 	)
 
 /obj/effect/essentials_set/tank/gatling
-	desc = "A primary LTAA Minigun utelizing AP ammo for tanks. The barrel spins up as it is fired, improving its fire rate and accuracy dramaticly. Capable of shreeding apart even the thickest walls in seconds."
+	desc = "A primary LTAA Minigun utilizing AP ammo for tanks. The barrel spins up as it is fired, improving its fire rate and accuracy dramatically. Capable of shredding apart even the thickest walls in seconds."
 	spawned_gear_list = list(
 		/obj/item/hardpoint/primary/minigun,
 		/obj/item/ammo_magazine/hardpoint/ltaaap_minigun,

--- a/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
+++ b/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
@@ -390,7 +390,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_vehicle_crew, list(
 	)
 
 /obj/effect/essentials_set/tank/tankflamer
-	desc = "A small LZR-N Flamer Unit. Essentially a modified version of your bog standart flamer."
+	desc = "A small LZR-N Flamer Unit - a modified version of your bog standard flamer."
 	spawned_gear_list = list(
 		/obj/item/hardpoint/secondary/small_flamer,
 		/obj/item/ammo_magazine/hardpoint/secondary_flamer,

--- a/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
+++ b/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
@@ -151,7 +151,7 @@ GLOBAL_LIST_INIT(cm_vending_vehicle_crew_tank, list(
 
 	list("TREADS", 0, null, null, null),
 	list("Reinforced Treads", 0, /obj/item/hardpoint/locomotion/treads/robust, VEHICLE_TREADS_AVAILABLE, VENDOR_ITEM_REGULAR),
-	list("Treads", 0, /obj/item/hardpoint/locomotion/robust, VEHICLE_TREADS_AVAILABLE, VENDOR_ITEM_REGULAR)))
+	list("Treads", 0, /obj/item/hardpoint/locomotion/treads, VEHICLE_TREADS_AVAILABLE, VENDOR_ITEM_REGULAR)))
 
 GLOBAL_LIST_INIT(cm_vending_vehicle_crew_apc, list(
 	list("STARTING KIT SELECTION:", 0, null, null, null),

--- a/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
+++ b/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
@@ -353,6 +353,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_vehicle_crew, list(
 
 //Not essentials sets but fuck it the code's here
 /obj/effect/essentials_set/tank/ltb
+	desc = "A giant canon firing explosive 86mm shells. You be lucky if this even leaves dust of whatever you hit with it."
 	spawned_gear_list = list(
 		/obj/item/hardpoint/primary/cannon,
 		/obj/item/ammo_magazine/hardpoint/ltb_cannon,
@@ -363,6 +364,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_vehicle_crew, list(
 	)
 
 /obj/effect/essentials_set/tank/gatling
+	desc = "A primary LTAA Minigun utelizing AP ammo for tanks. The barrel spins up as it is fired, improving its fire rate and accuracy dramaticly. Capable of shreeding apart even the thickest walls in seconds."
 	spawned_gear_list = list(
 		/obj/item/hardpoint/primary/minigun,
 		/obj/item/ammo_magazine/hardpoint/ltaaap_minigun,
@@ -370,6 +372,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_vehicle_crew, list(
 	)
 
 /obj/effect/essentials_set/tank/dragonflamer
+	desc = "A heavy flamer that spews out high-combustion napalm in a wide radius. The fuel burns intensely and quickly, which allows for it to be used offensively by armoured vehicles."
 	spawned_gear_list = list(
 		/obj/item/hardpoint/primary/flamer,
 		/obj/item/ammo_magazine/hardpoint/primary_flamer,
@@ -377,6 +380,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_vehicle_crew, list(
 	)
 
 /obj/effect/essentials_set/tank/autocannon
+	desc = "An Automatic Canon for tanks. Capable of firing precise even at long ranges. Loads 20mm explosive shells."
 	spawned_gear_list = list(
 		/obj/item/hardpoint/primary/autocannon,
 		/obj/item/ammo_magazine/hardpoint/ace_autocannon,
@@ -386,12 +390,14 @@ GLOBAL_LIST_INIT(cm_vending_clothing_vehicle_crew, list(
 	)
 
 /obj/effect/essentials_set/tank/tankflamer
+	desc = "A small LZR-N Flamer Unit. Essentially a modified version of your bog standart flamer."
 	spawned_gear_list = list(
 		/obj/item/hardpoint/secondary/small_flamer,
 		/obj/item/ammo_magazine/hardpoint/secondary_flamer,
 	)
 
 /obj/effect/essentials_set/tank/tow
+	desc = "A quad rocket launcher capable of firing four rockets in quick succession."
 	spawned_gear_list = list(
 		/obj/item/hardpoint/secondary/towlauncher,
 		/obj/item/ammo_magazine/hardpoint/towlauncher,
@@ -399,12 +405,14 @@ GLOBAL_LIST_INIT(cm_vending_clothing_vehicle_crew, list(
 	)
 
 /obj/effect/essentials_set/tank/m56cupola
+	desc = "A permantly fixed M56D, firing standart issue 10x28mm rounds."
 	spawned_gear_list = list(
 		/obj/item/hardpoint/secondary/m56cupola,
 		/obj/item/ammo_magazine/hardpoint/m56_cupola,
 	)
 
 /obj/effect/essentials_set/tank/tankgl
+	desc = "A magazin feed grenade launcher capable of holding 10 grenades. This model loads M40 grenades."
 	spawned_gear_list = list(
 		/obj/item/hardpoint/secondary/grenade_launcher,
 		/obj/item/ammo_magazine/hardpoint/tank_glauncher,

--- a/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
+++ b/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
@@ -405,7 +405,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_vehicle_crew, list(
 	)
 
 /obj/effect/essentials_set/tank/m56cupola
-	desc = "A permantly fixed M56D, firing standart issue 10x28mm rounds."
+	desc = "A permanently fixed M56D, firing standard issue 10x28mm rounds."
 	spawned_gear_list = list(
 		/obj/item/hardpoint/secondary/m56cupola,
 		/obj/item/ammo_magazine/hardpoint/m56_cupola,

--- a/code/modules/vehicles/hardpoints/armor/snowplow.dm
+++ b/code/modules/vehicles/hardpoints/armor/snowplow.dm
@@ -1,6 +1,6 @@
 /obj/item/hardpoint/armor/snowplow
 	name = "\improper Snowplow"
-	desc = "Clears a path in the snow for friendlies. It doesnt seem to have much use beyond that."
+	desc = "Clears a path in the snow for friendlies. It doesn't seem to have much use beyond that."
 
 	icon_state = "snowplow"
 	disp_icon = "tank"

--- a/code/modules/vehicles/hardpoints/armor/snowplow.dm
+++ b/code/modules/vehicles/hardpoints/armor/snowplow.dm
@@ -1,6 +1,6 @@
 /obj/item/hardpoint/armor/snowplow
 	name = "\improper Snowplow"
-	desc = "Clears a path in the snow for friendlies"
+	desc = "Clears a path in the snow for friendlies. It doesnt seem to have much use beyond that."
 
 	icon_state = "snowplow"
 	disp_icon = "tank"

--- a/code/modules/vehicles/hardpoints/hardpoint_ammo/autocannon_ammo.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint_ammo/autocannon_ammo.dm
@@ -1,6 +1,6 @@
 /obj/item/ammo_magazine/hardpoint/ace_autocannon
-	name = "Tank Autocannon Magazine"
-	desc = "A primary armament autocannon magazine"
+	name = "AC3-E Autocannon Magazine"
+	desc = "A 40 round magazin holding 20mm shells for the AC3-E autocanon"
 	caliber = "20mm"
 	icon_state = "ace_autocannon"
 	w_class = SIZE_LARGE

--- a/code/modules/vehicles/hardpoints/hardpoint_ammo/autocannon_ammo.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint_ammo/autocannon_ammo.dm
@@ -1,6 +1,6 @@
 /obj/item/ammo_magazine/hardpoint/ace_autocannon
 	name = "AC3-E Autocannon Magazine"
-	desc = "A 40 round magazin holding 20mm shells for the AC3-E autocanon"
+	desc = "A 40 round magazine holding 20mm shells for the AC3-E autocannon."
 	caliber = "20mm"
 	icon_state = "ace_autocannon"
 	w_class = SIZE_LARGE

--- a/code/modules/vehicles/hardpoints/hardpoint_ammo/cupola_ammo.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint_ammo/cupola_ammo.dm
@@ -1,6 +1,6 @@
 /obj/item/ammo_magazine/hardpoint/m56_cupola
 	name = "M56 Cupola Magazine"
-	desc = "A secondary armament MG magazine"
+	desc = "A box of 500, 10x28mm caseless tungsten rounds for the M56D heavy machine gun system."
 	caliber = "10x28mm" //Correlates to smartguns
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/uscm.dmi'
 	icon_state = "cupola_1"

--- a/code/modules/vehicles/hardpoints/hardpoint_ammo/gl_ammo.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint_ammo/gl_ammo.dm
@@ -1,6 +1,6 @@
 /obj/item/ammo_magazine/hardpoint/tank_glauncher
 	name = "M92T Grenade Launcher Magazine"
-	desc = "A magazin loaded with M40 grenades. Used to reaload the Magazin feed M92T Grenade launcher."
+	desc = "A magazine loaded with M40 grenades. Used to reload the magazine fed M92T Grenade launcher."
 	caliber = "grenade"
 	icon_state = "glauncher_2"
 	w_class = SIZE_LARGE

--- a/code/modules/vehicles/hardpoints/hardpoint_ammo/gl_ammo.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint_ammo/gl_ammo.dm
@@ -1,6 +1,6 @@
 /obj/item/ammo_magazine/hardpoint/tank_glauncher
 	name = "M92T Grenade Launcher Magazine"
-	desc = "A secondary armament grenade magazine."
+	desc = "A magazin loaded with M40 grenades. Used to reaload the Magazin feed M92T Grenade launcher."
 	caliber = "grenade"
 	icon_state = "glauncher_2"
 	w_class = SIZE_LARGE

--- a/code/modules/vehicles/hardpoints/hardpoint_ammo/minigun_ammo.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint_ammo/minigun_ammo.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_magazine/hardpoint/ltaaap_minigun
 	name = "LTAA-AP Minigun Magazine"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/uscm.dmi'
-	desc = "A primary armament minigun magazine."
+	desc = "A magazin of 7.62x51mm AP ammo for a heavy minigun. Filled to the brimm with highly precice armor-penetration rounds."
 	caliber = "7.62x51mm" //Correlates to miniguns
 	icon_state = "ltaa"
 	w_class = SIZE_LARGE //Primary weapon ammo should probably all be the same w_class

--- a/code/modules/vehicles/hardpoints/hardpoint_ammo/minigun_ammo.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint_ammo/minigun_ammo.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_magazine/hardpoint/ltaaap_minigun
 	name = "LTAA-AP Minigun Magazine"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/uscm.dmi'
-	desc = "A magazin of 7.62x51mm AP ammo for a heavy minigun. Filled to the brimm with highly precice armor-penetration rounds."
+	desc = "A magazine of 7.62x51mm AP ammo for a heavy minigun. Filled to the brim with highly precise armor-penetrating rounds."
 	caliber = "7.62x51mm" //Correlates to miniguns
 	icon_state = "ltaa"
 	w_class = SIZE_LARGE //Primary weapon ammo should probably all be the same w_class

--- a/code/modules/vehicles/hardpoints/hardpoint_ammo/primary_flamer_ammo.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint_ammo/primary_flamer_ammo.dm
@@ -1,6 +1,6 @@
 /obj/item/ammo_magazine/hardpoint/primary_flamer
 	name = "DRG-N Offensive Flamer Unit Fuel Tank"
-	desc = "A primary armament flamethrower magazine."
+	desc = "Fuel tanks for the DRG-N Offensive Flamer. It contains a high-combustion napalm, capabale of burning through nearly anything."
 	caliber = "High-Combustion Napalm" //correlates to flamer mags
 	icon_state = "drgn_flametank"
 	w_class = SIZE_LARGE

--- a/code/modules/vehicles/hardpoints/hardpoint_ammo/secondary_flamer_ammo.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint_ammo/secondary_flamer_ammo.dm
@@ -1,6 +1,6 @@
 /obj/item/ammo_magazine/hardpoint/secondary_flamer
 	name = "LZR-N Flamer Unit Fuel Tank"
-	desc = "A secondary armament flamethrower magazine."
+	desc = "A napalm tank fitted to be accepted by the LZR-N Flamer."
 	caliber = "UT-Napthal Fuel" //correlates to flamer mags
 	icon_state = "flametank_large"
 	w_class = SIZE_LARGE

--- a/code/modules/vehicles/hardpoints/primary/autocannon.dm
+++ b/code/modules/vehicles/hardpoints/primary/autocannon.dm
@@ -1,6 +1,6 @@
 /obj/item/hardpoint/primary/autocannon
 	name = "\improper AC3-E Autocannon"
-	desc = "A primary autocannon for tanks that shoots explosive flak rounds"
+	desc = "A primary autocannon for tanks that shoots explosive flak rounds."
 
 	icon_state = "ace_autocannon"
 	disp_icon = "tank"

--- a/code/modules/vehicles/hardpoints/primary/minigun.dm
+++ b/code/modules/vehicles/hardpoints/primary/minigun.dm
@@ -1,6 +1,6 @@
 /obj/item/hardpoint/primary/minigun
 	name = "\improper LTAA-AP Minigun"
-	desc = "A primary weapon for tanks that spews bullets"
+	desc = "A primary LTAA Minigun utelizing AP ammo for tanks. Its six barrels are heavy and take a bit to fully spin up."
 
 	icon_state = "ltaaap_minigun"
 	disp_icon = "tank"
@@ -26,7 +26,7 @@
 		"8" = list(-77, 0)
 	)
 
-	scatter = 18
+	scatter = 18 //base scatter, modified by stake_delay_mult
 	gun_firemode = GUN_FIREMODE_AUTOMATIC
 	gun_firemode_list = list(
 		GUN_FIREMODE_AUTOMATIC,

--- a/code/modules/vehicles/hardpoints/secondary/cupola.dm
+++ b/code/modules/vehicles/hardpoints/secondary/cupola.dm
@@ -1,6 +1,6 @@
 /obj/item/hardpoint/secondary/m56cupola
 	name = "\improper M56 Cupola"
-	desc = "A secondary weapon for tanks that shoots bullets"
+	desc = "A secondary weapon for tanks. It's a M56D that was adjusted to be permanantly fixed to its mount. You swear you can still see some weld tacks."
 
 	icon_state = "m56_cupola"
 	disp_icon = "tank"

--- a/code/modules/vehicles/hardpoints/secondary/cupola.dm
+++ b/code/modules/vehicles/hardpoints/secondary/cupola.dm
@@ -1,6 +1,6 @@
 /obj/item/hardpoint/secondary/m56cupola
 	name = "\improper M56 Cupola"
-	desc = "A secondary weapon for tanks. It's a M56D that was adjusted to be permanantly fixed to its mount. You swear you can still see some weld tacks."
+	desc = "A secondary weapon for tanks. It's a M56D that was adjusted to be permanently fixed to its mount. You swear you can still see some weld tacks."
 
 	icon_state = "m56_cupola"
 	disp_icon = "tank"

--- a/code/modules/vehicles/hardpoints/secondary/grenade_launcher.dm
+++ b/code/modules/vehicles/hardpoints/secondary/grenade_launcher.dm
@@ -1,6 +1,6 @@
 /obj/item/hardpoint/secondary/grenade_launcher
 	name = "\improper M92T Grenade Launcher"
-	desc = "A magazin feed secondary grenade launcher for tanks that shoots M40 grenades."
+	desc = "A magazine fed secondary grenade launcher for tanks that shoots M40 grenades."
 
 	icon_state = "glauncher"
 	disp_icon = "tank"

--- a/code/modules/vehicles/hardpoints/secondary/grenade_launcher.dm
+++ b/code/modules/vehicles/hardpoints/secondary/grenade_launcher.dm
@@ -1,6 +1,6 @@
 /obj/item/hardpoint/secondary/grenade_launcher
 	name = "\improper M92T Grenade Launcher"
-	desc = "A secondary weapon for tanks that shoots grenades."
+	desc = "A magazin feed secondary grenade launcher for tanks that shoots M40 grenades."
 
 	icon_state = "glauncher"
 	disp_icon = "tank"

--- a/code/modules/vehicles/hardpoints/secondary/tow.dm
+++ b/code/modules/vehicles/hardpoints/secondary/tow.dm
@@ -1,6 +1,6 @@
 /obj/item/hardpoint/secondary/towlauncher
 	name = "\improper TOW Launcher"
-	desc = "A secondary weapon for tanks that shoots rockets"
+	desc = "A secondary weapon for tanks that shoots rockets. It loads multiple rockets at once."
 
 	icon_state = "tow_launcher"
 	disp_icon = "tank"

--- a/code/modules/vehicles/hardpoints/wheels/treads.dm
+++ b/code/modules/vehicles/hardpoints/wheels/treads.dm
@@ -1,6 +1,6 @@
 /obj/item/hardpoint/locomotion/treads
 	name = "\improper Treads"
-	desc = "Integral to the movement of the vehicle."
+	desc = "Integral to the movement of the vehicle. Steel reinforced rubber tracks, they allow the tank to move faster but in turn need repairs more often."
 
 	icon_state = "treads"
 	disp_icon = "tank"
@@ -18,7 +18,7 @@
 
 /obj/item/hardpoint/locomotion/treads/robust
 	name = "\improper Reinforced Treads"
-	desc = "These treads are made of a tougher material and are more durable. However, the extra weight slows the tank down."
+	desc = "These treads are made of soldi steel plates and are more durable. However, the extra weight slows the tank down."
 
 	health = 500
 	acid_resistant = TRUE

--- a/code/modules/vehicles/hardpoints/wheels/treads.dm
+++ b/code/modules/vehicles/hardpoints/wheels/treads.dm
@@ -18,7 +18,7 @@
 
 /obj/item/hardpoint/locomotion/treads/robust
 	name = "\improper Reinforced Treads"
-	desc = "These treads are made of soldi steel plates and are more durable. However, the extra weight slows the tank down."
+	desc = "These treads are made of solid steel plates and are more durable. However, the extra weight slows the tank down."
 
 	health = 500
 	acid_resistant = TRUE


### PR DESCRIPTION
# About the pull request

* Adds descriptions in the vehicle vendor to tank hardpoint weapon options. Giving a small description to how the guns work.
* Gives the magazins and hardpoints item descriptions a more flavorfull description, being that most where literally placeholders.


# Explain why it's good for the game

Currently you dont really know what the gun does you select for the tank. Wich is kinda shit.
Your lucky, and finally get to play tank crew for the first time... and you have no clue what any of the guns do. This should help with that.
Being that, you know, you can now read what the gun does your commiting to.

Also, a lot of descriptions where 100% placeholders of the items. The tank is really in dire need of some updates.
So i gave most of them description with some more flavor to them then just "Its a tank primary".

Also, im kinda unsure what type of changelog this applys to.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:TheManWithNoHands
add: Added vendor description to: AC3-E autocanon, LTAA-AP Minigun, DRG-N Flamer, LTB canon, LZR-N Flamer, TOW launcher, M56cupola, and M92T Grenade Launcher.
add: Expanded the description of: LTAA-AP Minigun, TOW launcher, M56cupola, M92T Grenade Launcher and the magazins of the AC3-E autocanon, LTAA-AP Minigun, DRG-N Flamer, LZR-N Flamer, and M92T Grenade Launcher. As well as for the snowplow hardpoint and heavy and ligth treads.
/:cl:
