### PR TITLE
Hugger prevents you from seeing and talking, blinding fixes

### DIFF
--- a/code/__DEFINES/equipment.dm
+++ b/code/__DEFINES/equipment.dm
@@ -178,7 +178,9 @@
 /// 2 tiles of full and 2 of partial impairment
 #define VISION_IMPAIR_STRONG 5
 /// 3 tiles of full and 2 of partial impairment (original one)
-#define VISION_IMPAIR_MAX 6
+#define VISION_IMPAIR_ULTRA 6
+/// Full blindness, 1 tile visibility
+#define VISION_IMPAIR_MAX 7
 
 //VISION IMPAIRMENT LEVELS===========================================================================
 

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -294,6 +294,9 @@
 		if(istype(user.wear_mask, /obj/item/clothing/mask/muzzle))
 			return FALSE
 
+		if(istype(user.wear_mask, /obj/item/clothing/mask/facehugger))
+			return FALSE
+
 	if(only_forced_audio && intentional)
 		return FALSE
 	return TRUE

--- a/code/game/objects/items/devices/helmet_visors.dm
+++ b/code/game/objects/items/devices/helmet_visors.dm
@@ -169,7 +169,7 @@
 	helmet_overlay = "weld_visor"
 
 /obj/item/device/helmet_visor/welding_visor/activate_visor(obj/item/clothing/head/helmet/marine/attached_helmet, mob/living/carbon/human/user)
-	attached_helmet.vision_impair = VISION_IMPAIR_MAX
+	attached_helmet.vision_impair = VISION_IMPAIR_ULTRA
 	attached_helmet.flags_inventory |= COVEREYES|COVERMOUTH
 	attached_helmet.flags_inv_hide |= HIDEEYES|HIDEFACE
 	attached_helmet.eye_protection = EYE_PROTECTION_WELDING

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -551,8 +551,8 @@
 	flags_inv_hide = HIDEEYES
 	eye_protection = EYE_PROTECTION_WELDING
 	has_tint = TRUE
-	vision_impair = VISION_IMPAIR_MAX
-	var/vision_impair_on = VISION_IMPAIR_MAX
+	vision_impair = VISION_IMPAIR_ULTRA
+	var/vision_impair_on = VISION_IMPAIR_ULTRA
 	var/vision_impair_off = VISION_IMPAIR_NONE
 
 /obj/item/clothing/glasses/welding/attack_self()
@@ -632,7 +632,7 @@
 	desc = "Covers the eyes, preventing sight."
 	icon_state = "blindfold"
 	item_state = "blindfold"
-	//vision_flags = DISABILITY_BLIND // This flag is only supposed to be used if it causes permanent blindness, not temporary because of glasses
+	vision_impair = VISION_IMPAIR_MAX
 
 /obj/item/clothing/glasses/sunglasses/prescription
 	desc = "A mixture of coolness and the inherent nerdiness of a prescription. Somehow manages to conceal both."

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -33,7 +33,7 @@
 	siemens_coefficient = 0.9
 	w_class = SIZE_MEDIUM
 	eye_protection = EYE_PROTECTION_WELDING
-	vision_impair = VISION_IMPAIR_MAX
+	vision_impair = VISION_IMPAIR_ULTRA
 
 /obj/item/clothing/head/welding/attack_self(mob/user)
 	..()
@@ -49,7 +49,7 @@
 		return
 
 	if(up)
-		vision_impair = VISION_IMPAIR_MAX
+		vision_impair = VISION_IMPAIR_ULTRA
 		flags_inventory |= COVEREYES|COVERMOUTH|BLOCKSHARPOBJ
 		flags_inv_hide |= HIDEEARS|HIDEEYES|HIDEFACE
 		icon_state = initial(icon_state)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1350,11 +1350,14 @@
 	if(wear_mask && wear_mask.vision_impair)
 		tint_level += wear_mask.vision_impair
 
-	if(tint_level > VISION_IMPAIR_STRONG)
-		tint_level = VISION_IMPAIR_STRONG
+	if(tint_level > VISION_IMPAIR_MAX)
+		tint_level = VISION_IMPAIR_MAX
 
 	if(tint_level)
-		overlay_fullscreen("tint", /atom/movable/screen/fullscreen/impaired, tint_level)
+		if(tint_level == VISION_IMPAIR_MAX)
+			overlay_fullscreen("tint", /atom/movable/screen/fullscreen/blind)
+		else
+			overlay_fullscreen("tint", /atom/movable/screen/fullscreen/impaired, tint_level)
 		return TRUE
 	else
 		clear_fullscreen("tint", 0)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -119,6 +119,9 @@
 	if (istype(wear_mask, /obj/item/clothing/mask/muzzle))
 		return
 
+	if (istype(wear_mask, /obj/item/clothing/mask/facehugger))
+		return
+
 	message = capitalize(trim(message))
 	message = process_chat_markup(message, list("~", "_"))
 

--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -58,6 +58,9 @@
 	if (istype(src.wear_mask, /obj/item/clothing/mask/muzzle))
 		return
 
+	if (istype(src.wear_mask, /obj/item/clothing/mask/facehugger))
+		return
+
 	//TODO: handle_speech_problems
 	if (src.stuttering)
 		message = stutter(message, stuttering)

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -16,6 +16,7 @@
 	flags_atom = NO_FLAGS
 	flags_item = NOBLUDGEON
 	throw_range = 1
+	vision_impair = VISION_IMPAIR_MAX
 	layer = FACEHUGGER_LAYER
 	black_market_value = 20
 


### PR DESCRIPTION

# About the pull request

If you have a hugger on your face but you recovered from the sleep somehow, you'd still be blind and wouldn't be able to talk and to use audio emotes.

Fixed blindfold not doing anything at all.

Fixed welding protection having incorrect level of tint.

# Explain why it's good for the game

Mostly fixing oversights.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![dreamseeker_jx6rtZvC9h](https://github.com/user-attachments/assets/a0ae39b5-5874-4899-8e5f-54cbd20a9f87)

![dreamseeker_qkQQGgw7xV](https://github.com/user-attachments/assets/8592cb73-2ffe-4629-a5f0-078e4b7e7a57)


</details>


# Changelog
:cl:
add: you can no longer see or talk with a hugger on your face
fix: welding protection now adds correct amount of vision impairment
fix: blindfold now actually blinds
/:cl:
