### PR TITLE
Instant delimb nerf (for real this time)

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -277,6 +277,7 @@
 
 	var/previous_brute = brute_dam
 	var/previous_burn = burn_dam
+	var/previous_bonebreak = (status & LIMB_BROKEN)
 
 	var/is_ff = FALSE
 	if(istype(attack_source) && attack_source.faction == owner.faction)
@@ -370,7 +371,7 @@
 	var/no_perma_damage = owner.status_flags & NO_PERMANENT_DAMAGE
 	var/no_bone_break = owner.chem_effect_flags & CHEM_EFFECT_RESIST_FRACTURE
 	if(previous_brute > 0 && !is_ff && body_part != BODY_FLAG_CHEST && body_part != BODY_FLAG_GROIN && !no_limb_loss && !no_perma_damage && !no_bone_break)
-		if(CONFIG_GET(flag/limbs_can_break) && brute_dam >= max_damage * CONFIG_GET(number/organ_health_multiplier) && (status & LIMB_BROKEN))
+		if(CONFIG_GET(flag/limbs_can_break) && brute_dam >= max_damage * CONFIG_GET(number/organ_health_multiplier) && previous_bonebreak) //delimbable only if broken before this hit
 			var/cut_prob = brute/max_damage * 5
 			if(prob(cut_prob))
 				limb_delimb(damage_source)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
1) I got two tap delimbed :sob: 
2) https://github.com/cmss13-devs/cmss13/pull/6240 failed to solve the issue as Nivrak failed to read the code properly. As the delimb check happens AFTER the frac check, you just can get frac & delimb with the same hit. While this indeed reduced the chance of getting delimbed (as now you need to roll both for frac and delimb), it is still pure RNG which that PR wanted to avoid. (Also the only thing that KIND OF saves you from first tap delimb is previous_brute > 0 check, but as long as you have 0.000001 brute on the limb it's irrelevant)

# Explain why it's good for the game

1) I got two tap delimbed :sob: 
2) Instant delimbs based on nothing but rng from one slash (yeah technically it's not true as you need at least 0.000001 brute on the limb, but it was so when Nivrak made his PR too) are unfun to play against


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>
I did test it by spawning myself as rav and slashing 100 naked humans.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: ihatethisengine
balance: limbs are now only be delimb-able if they were fractured BEFORE the hit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
