### PR TITLE
SMES units made explosion proof

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -39,7 +39,7 @@
 	var/building_terminal = 0 //Suggestions about how to avoid clickspam building several terminals accepted!
 	var/should_be_mapped = 0 // If this is set to 0 it will send out warning on New()
 	power_machine = TRUE
-	explo_proof = TRUE
+	var/explosion_proof = TRUE
 
 /obj/structure/machinery/power/smes/Initialize()
 	. = ..()
@@ -62,6 +62,12 @@
 		warning("Non-buildable or Non-magical SMES at [src.x]X [src.y]Y [src.z]Z")
 
 	return INITIALIZE_HINT_ROUNDSTART
+
+/obj/structure/machinery/power/smes/ex_act(severity)
+	if(explosion_proof)
+		return
+	else
+		.=..()
 
 /obj/structure/machinery/power/smes/LateInitialize()
 	. = ..()

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -39,6 +39,7 @@
 	var/building_terminal = 0 //Suggestions about how to avoid clickspam building several terminals accepted!
 	var/should_be_mapped = 0 // If this is set to 0 it will send out warning on New()
 	power_machine = TRUE
+	explo_proof = TRUE
 
 /obj/structure/machinery/power/smes/Initialize()
 	. = ..()


### PR DESCRIPTION

# About the pull request

SMES can be exploaded to be removed unlike any other of main intel objectives, that is not unitended as they can not be repaired or rebuild in any way

# Explain why it's good for the game

intel objectives are not ment to be removeable, especialy such a big one, also no SMES mean no lights on colony and stuff them being removable is unintentional


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: SMES units made explosion proof
/:cl:
