### PR TITLE
Fixes vehicle lights not turning back on after it is fixed

### DIFF
--- a/code/modules/vehicles/multitile/multitile.dm
+++ b/code/modules/vehicles/multitile/multitile.dm
@@ -384,6 +384,9 @@
 	//vehicle is dead, no more lights
 	if(health <= 0 && lighting_holder.light_range)
 		lighting_holder.set_light_on(FALSE)
+	else
+		if(!lighting_holder.light)
+			lighting_holder.set_light_on(TRUE)
 	update_icon()
 
 /*

--- a/code/modules/vehicles/multitile/multitile_interaction.dm
+++ b/code/modules/vehicles/multitile/multitile_interaction.dm
@@ -196,6 +196,8 @@
 			return
 
 		health = min(health + max_hp/100 * (5 / amount_fixed_adjustment), max_hp)
+		if(!lighting_holder.light)
+			lighting_holder.set_light_on(TRUE)
 
 		if(WT)
 			WT.remove_fuel(1, user)


### PR DESCRIPTION

# About the pull request

when vehicle health goes to 0 lights go off, but never turn back on, this fixes it

# Explain why it's good for the game

having permanently broken lights is bad


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: vehicle light turns back on after the vehicle is fixed
/:cl:
