### PR TITLE
Allows non yaujta mobs to use hotkeys on yautja equipment 

### DIFF
--- a/code/modules/cm_preds/yaut_actions.dm
+++ b/code/modules/cm_preds/yaut_actions.dm
@@ -25,7 +25,7 @@
 	mask = null
 
 	var/mob/living/carbon/human/mob = owner
-	if(!isyautja(mob))
+	if(!ishuman(mob))
 		return FALSE
 	if(mob.is_mob_incapacitated())
 		return FALSE


### PR DESCRIPTION
# About the pull request
 
Oversight in the addition to Yaujta buttons and hotkeys locked the activation of things like mask zoom for humans to VERBS/BYOND MACROS only ( this allows you to use hotkeys to activate things like toggle mask zoom but still locks out every other pred activation as intended ) 

# Explain why it's good for the game

Byond macros suck and have been actively being replaced by hotkeys for the last year.


# Testing Photographs and Procedure


<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog



🆑 lolvax1
fix: fixes oversight in addition of Yautja hotkeys
/🆑
