### PR TITLE
fixes cancelling items from the parts fabricator queue

### DIFF
--- a/code/modules/cm_marines/vehicle_part_fabricator.dm
+++ b/code/modules/cm_marines/vehicle_part_fabricator.dm
@@ -171,7 +171,6 @@
 			var/datum/build_queue_entry/entry = build_queue[index]
 
 			build_queue.Remove(entry)
-			add_to_point_store(entry.cost)
 			return TRUE
 
 	else


### PR DESCRIPTION
:cl:
fix: stops a crisis in the part fabricator point economy by preventing infinite money generation through cancelling items in the queue
/:cl:

yea i got no idea how i missed this either, the points removal now happens AFTER the item is processed in the queue, so we don't need to refund any points when removing items from the queue

closes #7416