### PR TITLE
Night vision optic buff

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
@@ -37,7 +37,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_leader, list(
 		list("HELMET OPTICS", 0, null, null, null),
 		list("Welding Visor", 5, /obj/item/device/helmet_visor/welding_visor, null, VENDOR_ITEM_REGULAR),
 		list("Medical Helmet Optic", 4, /obj/item/device/helmet_visor/medical, null, VENDOR_ITEM_RECOMMENDED),
-		list("Night Vision Optic", 20, /obj/item/device/helmet_visor/night_vision, null, VENDOR_ITEM_RECOMMENDED),
+		list("Night Vision Optic", 25, /obj/item/device/helmet_visor/night_vision, null, VENDOR_ITEM_RECOMMENDED),
 
 		list("ENGINEERING SUPPLIES", 0, null, null, null),
 		list("Insulated Gloves", 3, /obj/item/clothing/gloves/yellow, null, VENDOR_ITEM_REGULAR),

--- a/code/game/objects/items/devices/helmet_visors.dm
+++ b/code/game/objects/items/devices/helmet_visors.dm
@@ -201,9 +201,9 @@
 	toggle_off_sound = 'sound/handling/toggle_nv2.ogg'
 
 	/// The internal battery for the visor
-	var/obj/item/cell/high/power_cell
+	var/obj/item/cell/super/power_cell
 
-	/// About 5 minutes active use charge (hypothetically)
+	/// About 10 minutes active use charge (hypothetically)
 	var/power_use = 33
 
 	/// The alpha of darkness we set to for the mob while the visor is on, not completely fullbright but see-able


### PR DESCRIPTION
# About the pull request

Night Vision Optic integrated battery now works 2 times longer (5 ->10 minutes)

Night Vision Optic recharging 2 times longer (because battery is 2 times better)

Squad Leader NVO price increased 20 -> 25, he cannot buy a second NVO anymore.

# Explain why it's good for the game

Alright, let's be fair, current NVO is totally junk.
1 - Old NVG's was rechargeable (battery cells could recharge them). Current NVO can be recharged only by working recharger station. Some maps doesn't have a recharger (for example - LV624 doesnt have even a single recharger, so, you MUST dismantle and take a recharger from Almayer with you, and set it on FOB). And 5 minutes REALLY NOT ENOUGH to feel yourself comfortable with NVO, because people just using NVO, and after a few steps from FOB checking their NVO battery and said - oh, looks like my NVO gonna die soon, ill be back, gotta recharge it, again. People's just turning on, and then immediately turning off NVO cuz they cant play normally with current battery... That sucks.

2 - Old NVG's was totally invisible in the dark, so, hostiles without a night vision (like humans) didnt saw you, and you could use this to take advantage HVH combat. For now, NVO shows you in the dark, and human hostiles can easily kill you, so, you loosing a tactical advantage (Spec Ops NVO doesnt show you in the dark, but they're unobtainable in 99% of gameplay, so, we forgetting about them)

3 - Old NVG's was buyable in REQ (as i remember, 3 NVG's for 6000 bucks). Current NVO, again, unobtainable in REQ, and very limited, because only a few roles can take them (FTL, SL, IO).

4 - NVO using your optic slot, people withot M12 cant use other optics, like SL's, SL's choosing between med optic and night vision optic right now (welding visors not exist cuz they can be easily replaced with welding goggles).

5 - You cannot use your NVO with binoculars and scopes (old NVO, not NVG, was one of the main reasons, why people take it, cuz you could use binoculars with NVO and, again, take a tactical advantage)

6 - Dirty green filter, really hard to spot a lurker, or xeno traps, and, sometimes, MD/IO detector pings.

7 - Helmet required. NVG's was usable with caps and other headdresses, now you must be in helmet

Now it's just an expensive thing for limited roles with BIG minuses and all what it can gives you - night vision on your screen for about 5 minutes, that all.
This is absurdly, cuz you have a SG's, specs like a snipers and scouts who have an unlimited, invisible night vision without any restrictions such as binoculars/scopes.

I know, it's a game balance, cuz i dont believe in 5 minute NVO in 2182, in military forces, but for now, with all these restrictions, i dont see any issues with a 10 minute battery.

People paying about 25-30 (more then half) their points to buy this thing, they deserve this.

</details>


# Changelog
:cl:
balance: Night Vision Optic now works 2 times longer, and recharge 2 times longer. Squad Leader NVO prices changed, from 20 to 25.
/:cl:
