### PR TITLE
Gives USCM Flag Officers TSL Language, plus some QOL for MARSOC

### DIFF
--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -808,7 +808,7 @@
 	assignment = "Marine Raider"
 	rank = JOB_MARINE_RAIDER
 	role_comm_title = "Op."
-	languages = list(LANGUAGE_ENGLISH, LANGUAGE_TSL)
+	languages = list(LANGUAGE_TSL, LANGUAGE_ENGLISH)
 	skills = /datum/skills/commando/deathsquad
 	auto_squad_name = SQUAD_SOF
 	ert_squad = TRUE

--- a/code/modules/gear_presets/uscm_event.dm
+++ b/code/modules/gear_presets/uscm_event.dm
@@ -67,7 +67,7 @@
 	minimap_icon = "deputy"
 	minimap_background = "background_command"
 	skills = /datum/skills/general
-	languages = ALL_HUMAN_LANGUAGES //Know your enemy.
+	languages = list(LANGUAGE_ENGLISH, LANGUAGE_JAPANESE, LANGUAGE_CHINESE, LANGUAGE_RUSSIAN, LANGUAGE_GERMAN, LANGUAGE_SCANDINAVIAN, LANGUAGE_SPANISH, LANGUAGE_TSL) //Know your enemy.
 
 	service_under = list(/obj/item/clothing/under/marine/officer/general, /obj/item/clothing/under/marine/officer/bridge)
 	service_over = list(/obj/item/clothing/suit/storage/jacket/marine/dress/general, /obj/item/clothing/suit/storage/jacket/marine/service, /obj/item/clothing/suit/storage/jacket/marine/service/mp)


### PR DESCRIPTION

# About the pull request

Gives USCM Flag Officers TSL Language, so they can understand MARSOC Raiders
In addition, TSL is now the *default* language for all MARSOC when they are spawned.

# Explain why it's good for the game

Being able to understand your death minions is pretty good, also having TSL enabled by default for MARSOC is generally pretty good as most that play it usually don't know it even exists (plus the advantages of being able to communicate on comms without people snooping on your super secret plans)


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: All USCM Flag Officers now understand and can use Tactical Sign Language.
qol: Tactical Sign Language is now the default language for all MARSOC spawned.
/:cl:
