### PR TITLE
Plasma Caster Fix

### DIFF
--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -1229,7 +1229,7 @@
 	force = 0
 	fire_delay = 3
 	flags_atom = FPRINT|QUICK_DRAWABLE|CONDUCT
-	flags_item = NOBLUDGEON|DELONDROP|IGNITING_ITEM //Can't bludgeon with this.
+	flags_item = NOBLUDGEON|IGNITING_ITEM //Can't bludgeon with this.
 	flags_gun_features = GUN_UNUSUAL_DESIGN
 	has_empty_icon = FALSE
 	explo_proof = TRUE
@@ -1353,7 +1353,6 @@
 	if(source)
 		forceMove(source)
 		source.caster_deployed = FALSE
-		return
 	..()
 
 /obj/item/weapon/gun/energy/yautja/plasma_caster/able_to_fire(mob/user)


### PR DESCRIPTION
# About the pull request

The plasma caster properly unequips, where previously it would fail to unregister the firing signals

# Explain why it's good for the game

The game thought you would fire the plasma caster whenever you clicked even if it was stored

# Changelog

:cl:
fix: Fixes chat showing "You fire the plasma caster" when firing an energy weapon after equipping the plasma caster
/:cl:
