### PR TITLE
sg nerf

### DIFF
--- a/code/datums/ammo/bullet/special_ammo.dm
+++ b/code/datums/ammo/bullet/special_ammo.dm
@@ -14,7 +14,7 @@
 	accuracy = HIT_ACCURACY_TIER_4
 	damage = 30
 	penetration = 0
-	effective_range_max = 7
+	effective_range_max = 5
 
 /datum/ammo/bullet/smartgun/armor_piercing
 	name = "armor-piercing smartgun bullet"

--- a/code/datums/ammo/bullet/special_ammo.dm
+++ b/code/datums/ammo/bullet/special_ammo.dm
@@ -9,12 +9,12 @@
 	icon_state = "redbullet"
 	flags_ammo_behavior = AMMO_BALLISTIC
 
-	damage_falloff = DAMAGE_FALLOFF_TIER_7
+	damage_falloff = DAMAGE_FALLOFF_TIER_6
 	max_range = 12
 	accuracy = HIT_ACCURACY_TIER_4
 	damage = 30
 	penetration = 0
-	effective_range_max = 4
+	effective_range_max = 5
 
 /datum/ammo/bullet/smartgun/armor_piercing
 	name = "armor-piercing smartgun bullet"

--- a/code/datums/ammo/bullet/special_ammo.dm
+++ b/code/datums/ammo/bullet/special_ammo.dm
@@ -14,7 +14,7 @@
 	accuracy = HIT_ACCURACY_TIER_4
 	damage = 30
 	penetration = 0
-	effective_range_max = 3
+	effective_range_max = 4
 
 /datum/ammo/bullet/smartgun/armor_piercing
 	name = "armor-piercing smartgun bullet"

--- a/code/datums/ammo/bullet/special_ammo.dm
+++ b/code/datums/ammo/bullet/special_ammo.dm
@@ -14,7 +14,7 @@
 	accuracy = HIT_ACCURACY_TIER_4
 	damage = 30
 	penetration = 0
-	effective_range_max = 5
+	effective_range_max = 3
 
 /datum/ammo/bullet/smartgun/armor_piercing
 	name = "armor-piercing smartgun bullet"


### PR DESCRIPTION
# About the pull request
nefs sg so they are a bit less effective at having full screen considering they have IFF and are a constant suppressing fire elemetn

# Explain why it's good for the game


Xenos have too much stupid firerate stuff to deal with already, sg was buffed way too much, having full control over your entire screen adds way too much dps for xenos to survive with the recent marine changes either fire rate needs to be moderated (hpr, m2c) or xenos health need to be buffed, and i dont want to make xenos even spongier

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: sg effective range nerfed to 5
balance: sg falloff increased 
/:cl:
