### PR TITLE
Bracer Attachment Fixes

### DIFF
--- a/code/modules/cm_preds/yaut_bracers.dm
+++ b/code/modules/cm_preds/yaut_bracers.dm
@@ -342,6 +342,8 @@
 /obj/item/clothing/gloves/yautja/hunter/Destroy()
 	QDEL_NULL(caster)
 	QDEL_NULL(embedded_id)
+	QDEL_NULL(left_bracer_attachment)
+	QDEL_NULL(right_bracer_attachment)
 	return ..()
 
 /obj/item/clothing/gloves/yautja/hunter/process()
@@ -490,6 +492,10 @@
 
 		if(selected == "Right") //its right, left because in-game itll show up as left, right
 			attach_to_left = FALSE
+
+	if(attacking_item.loc != user)
+		to_chat(user, SPAN_WARNING("You cannot attach [attacking_item] without holding it."))
+		return
 
 	var/bracer_attached = FALSE
 	if(attach_to_left && !left_bracer_attachment)


### PR DESCRIPTION
# About the pull request

Makes it so you cant put one bracer attachment in both slots

# Explain why it's good for the game

Bugs bad

# Changelog

:cl:
fix: Bracer attachments get properly deleted on bracer destruction
fix: One bracer attachment cannot be attached to both bracer attachment slots
/:cl:
