### PR TITLE
Forecon SMG ammo is moved to their belt

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -1307,6 +1307,16 @@
 			"icon_x" = -11,
 			"icon_y" = -5))
 
+/obj/item/storage/belt/gun/m39/full/fill_preset_inventory()
+	handle_item_insertion(new /obj/item/weapon/gun/smg/m39(src))
+	for(var/i = 1 to storage_slots - 1)
+		new /obj/item/ammo_magazine/smg/m39(src)
+
+/obj/item/storage/belt/gun/m39/full/extended/fill_preset_inventory()
+	handle_item_insertion(new /obj/item/weapon/gun/smg/m39(src))
+	for(var/i = 1 to storage_slots - 1)
+		new /obj/item/ammo_magazine/smg/m39/extended(src)
+
 #define MAXIMUM_MAGAZINE_COUNT 2
 
 /obj/item/storage/belt/gun/xm51

--- a/code/modules/gear_presets/survivors/lv_522/forcon_survivors.dm
+++ b/code/modules/gear_presets/survivors/lv_522/forcon_survivors.dm
@@ -72,10 +72,7 @@
 			new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/m1911(new_human), WEAR_IN_BELT)
 			new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/m1911(new_human), WEAR_IN_BELT)
 		if(3 , 4)
-			new_human.equip_to_slot_or_del(new /obj/item/storage/large_holster/m39, WEAR_WAIST)
-			new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/smg/m39(new_human), WEAR_IN_BELT)
-			new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m39/extended(new_human), WEAR_IN_BACK)
-			new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m39/extended(new_human), WEAR_IN_BACK)
+			new_human.equip_to_slot_or_del(new /obj/item/storage/belt/gun/m39/full/extended, WEAR_WAIST)
 		if(5)
 			new_human.equip_to_slot_or_del(new /obj/item/device/motiondetector(new_human),WEAR_WAIST)
 

--- a/code/modules/gear_presets/uscm_forecon.dm
+++ b/code/modules/gear_presets/uscm_forecon.dm
@@ -73,10 +73,7 @@
 			new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/m1911(new_human), WEAR_IN_BELT)
 			new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/m1911(new_human), WEAR_IN_BELT)
 		if(3 , 4)
-			new_human.equip_to_slot_or_del(new /obj/item/storage/belt/gun/m39, WEAR_WAIST)
-			new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/smg/m39(new_human), WEAR_IN_BELT)
-			new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m39/extended(new_human), WEAR_IN_BELT)
-			new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m39/extended(new_human), WEAR_IN_BELT)
+			new_human.equip_to_slot_or_del(new /obj/item/storage/belt/gun/m39/full/extended, WEAR_WAIST)
 		if(5)
 			new_human.equip_to_slot_or_del(new /obj/item/device/motiondetector(new_human),WEAR_WAIST)
 


### PR DESCRIPTION

# About the pull request
Forecon now gets a rig filled with their m39 and mags, instead of having just the m39 rig itself. This touches on both the survivor and adminspawn ERT variants.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

being forced to toss away all your sidearm mags just so that you can have space to hold stuff kinda sucks, especially when every other sidearm spawn that forecon has keeps its' mags in the belt

# Testing Photographs and Procedure
Inventory before, note how there's no storage unless you toss out mags (or move your radio)

![image](https://github.com/user-attachments/assets/23c57f3b-6863-4ecb-b265-1a48be299fb8)

Inventory after:

![image](https://github.com/user-attachments/assets/f4866b94-2cdb-43dc-a62f-881f8d0fef39)

# Changelog
:cl:
balance: Forecon M39 spawn now has its spawn ammo in belt, instead of in satchel.
/:cl:
