### PR TITLE
Almayer Mapping:  Psychiatric Care Unit

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -20443,6 +20443,16 @@
 	},
 /turf/open/floor/almayer/red,
 /area/almayer/command/lifeboat)
+"eto" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/door_control{
+	id = "CMO Shutters";
+	name = "Office Shutters";
+	req_access_txt = "5";
+	pixel_x = -29
+	},
+/turf/open/floor/almayer/sterile_green_side/west,
+/area/almayer/medical/upper_medical)
 "ets" = (
 /obj/structure/machinery/power/apc/almayer/east,
 /obj/effect/decal/warning_stripes{
@@ -98951,7 +98961,7 @@ ans
 axm
 ans
 aGX
-aGX
+eto
 ans
 ans
 axm

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -1463,7 +1463,13 @@
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/upper_medical)
 "akx" = (
-/turf/open/floor/almayer/sterile_green_side/north,
+/obj/structure/machinery/door/airlock/multi_tile/almayer/medidoor{
+	name = "\improper Medical Bay";
+	req_one_access = null;
+	dir = 1
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/upper_medical)
 "akz" = (
 /obj/structure/surface/table/almayer,
@@ -1565,6 +1571,11 @@
 /turf/closed/wall/almayer,
 /area/almayer/shipboard/starboard_missiles)
 "alD" = (
+/obj/item/paper_bin/uscm{
+	pixel_y = 6;
+	pixel_x = 7
+	},
+/obj/structure/surface/table/almayer,
 /turf/open/floor/almayer/sterile_green_side,
 /area/almayer/medical/upper_medical)
 "alE" = (
@@ -1763,12 +1774,8 @@
 /turf/open/floor/plating/almayer/no_build,
 /area/almayer/stair_clone)
 "anp" = (
-/obj/structure/sign/safety/hazard{
-	pixel_x = 15;
-	pixel_y = 32
-	},
-/obj/structure/closet/secure_closet/guncabinet/red/armory_m4a3_pistol,
-/turf/open/floor/almayer/redfull,
+/obj/structure/flora/bush/ausbushes/ppflowers,
+/turf/open/gm/grass/grass1,
 /area/almayer/medical/upper_medical)
 "anq" = (
 /obj/item/device/radio/intercom{
@@ -1790,12 +1797,12 @@
 /turf/open/floor/almayer/redfull,
 /area/almayer/medical/upper_medical)
 "anr" = (
-/obj/structure/sign/safety/intercom{
-	pixel_x = 8;
-	pixel_y = 32
+/obj/structure/machinery/computer/med_data,
+/obj/structure/sign/safety/terminal{
+	pixel_x = 3;
+	pixel_y = 29
 	},
-/obj/structure/closet/secure_closet/guncabinet/red/armory_m39_submachinegun,
-/turf/open/floor/almayer/redfull,
+/turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/upper_medical)
 "ans" = (
 /turf/open/floor/almayer/sterile_green_side/west,
@@ -1886,19 +1893,19 @@
 /turf/open/floor/almayer/silver/west,
 /area/almayer/command/cichallway)
 "aop" = (
-/obj/structure/closet/secure_closet/personal/patient{
-	name = "morgue closet"
+/obj/structure/machinery/shower{
+	pixel_y = 16
 	},
 /obj/structure/machinery/light{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/almayer/plate,
-/area/almayer/medical/morgue)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/medical/upper_medical)
 "aoq" = (
 /turf/open/floor/almayer/plate,
 /area/almayer/medical/morgue)
 "aor" = (
-/obj/structure/curtain/medical,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plate,
 /area/almayer/medical/morgue)
 "aos" = (
@@ -2577,18 +2584,25 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/living/briefing)
 "asu" = (
-/obj/structure/sign/safety/hazard{
-	pixel_x = 32;
-	pixel_y = -8
-	},
-/obj/structure/closet/secure_closet/guncabinet/red/armory_shotgun,
-/turf/open/floor/almayer/redfull,
-/area/almayer/medical/upper_medical)
-"asw" = (
-/obj/structure/machinery/light{
+/obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
-/turf/open/floor/almayer/sterile_green_side/west,
+/obj/structure/sign/safety/terminal{
+	pixel_x = -3;
+	pixel_y = -27
+	},
+/turf/open/floor/almayer/sterile_green_side,
+/area/almayer/medical/upper_medical)
+"asw" = (
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 8;
+	name = "ship-grade camera"
+	},
+/turf/open/floor/almayer/sterile_green_side/east,
 /area/almayer/medical/upper_medical)
 "asA" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -2652,11 +2666,17 @@
 /turf/open/floor/almayer,
 /area/almayer/engineering/upper_engineering)
 "asU" = (
-/obj/structure/morgue{
-	dir = 8
+/obj/item/device/flashlight/lamp{
+	pixel_y = 8
 	},
-/turf/open/floor/almayer/plate,
-/area/almayer/medical/morgue)
+/obj/item/clothing/glasses/science{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/device/flash,
+/obj/structure/surface/table/reinforced/almayer_B,
+/turf/open/floor/almayer/mono,
+/area/almayer/medical/upper_medical)
 "asX" = (
 /obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep,
 /turf/open/floor/almayer/plate,
@@ -3178,11 +3198,10 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/living/starboard_garden)
 "awj" = (
-/obj/structure/machinery/photocopier,
-/obj/structure/sign/safety/terminal{
-	pixel_x = -17
+/obj/structure/machinery/status_display{
+	pixel_y = -30
 	},
-/turf/open/floor/almayer/sterile_green_side/west,
+/turf/open/gm/grass/grass1,
 /area/almayer/medical/upper_medical)
 "awk" = (
 /turf/open/floor/almayer/silver,
@@ -3191,24 +3210,14 @@
 /turf/open/floor/almayer/red/northwest,
 /area/almayer/command/cic)
 "awn" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N"
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/almayer/plating/northeast,
+/turf/open/floor/almayer/sterile_green_side/east,
 /area/almayer/medical/upper_medical)
 "awp" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer{
-	dir = 4;
-	id = "Research Armory";
-	name = "\improper Armory Shutters"
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "E"
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "W"
-	},
-/turf/open/floor/almayer/test_floor4,
+/turf/open/floor/almayer/sterile_green_side/east,
 /area/almayer/medical/upper_medical)
 "awq" = (
 /obj/structure/machinery/light{
@@ -3386,14 +3395,22 @@
 /turf/open/floor/almayer/redcorner/west,
 /area/almayer/shipboard/weapon_room)
 "axl" = (
-/obj/structure/machinery/door_control{
-	dir = 1;
-	id = "Research Armory";
-	name = "Research Armory";
-	pixel_x = -27;
-	req_one_access_txt = "4;28"
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 4;
+	id = "CMO Shutters";
+	name = "\improper CMO Office Shutters"
 	},
-/turf/open/floor/almayer/sterile_green_side/southwest,
+/obj/structure/machinery/door/airlock/almayer/medical/glass{
+	access_modified = 1;
+	name = "\improper CMO's Office";
+	req_one_access = null;
+	req_one_access_txt = "1;5"
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/upper_medical)
 "axm" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -3729,15 +3746,13 @@
 /turf/open/floor/almayer/orange/north,
 /area/almayer/engineering/upper_engineering)
 "ayW" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 1;
-	name = "ship-grade camera"
+/obj/structure/morgue{
+	dir = 8
 	},
-/obj/structure/sign/safety/medical{
-	pixel_x = 8;
-	pixel_y = -32
+/obj/structure/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/almayer/plate,
+/turf/open/floor/almayer/test_floor5,
 /area/almayer/medical/morgue)
 "ayX" = (
 /obj/structure/surface/table/almayer,
@@ -4024,15 +4039,17 @@
 /turf/open/floor/almayer,
 /area/almayer/command/cic)
 "aAG" = (
-/obj/structure/machinery/door/airlock/almayer/medical{
-	access_modified = 1;
-	dir = 2;
-	name = "Morgue";
-	req_access_txt = "25";
-	req_one_access = null
+/obj/structure/platform,
+/obj/structure/platform{
+	dir = 8
 	},
-/turf/open/floor/almayer/test_floor4,
-/area/almayer/medical/morgue)
+/obj/structure/platform_decoration{
+	dir = 10;
+	layer = 3.51
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/mono,
+/area/almayer/medical/upper_medical)
 "aAK" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/camera,
@@ -4112,8 +4129,12 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/command/telecomms)
 "aBd" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 2
+	},
 /turf/open/floor/almayer/sterile_green_side/north,
-/area/almayer/medical/morgue)
+/area/almayer/medical/upper_medical)
 "aBe" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer{
 	dir = 4;
@@ -4398,18 +4419,14 @@
 /turf/open/floor/almayer/silvercorner,
 /area/almayer/command/cic)
 "aCo" = (
-/obj/structure/surface/table/almayer,
-/obj/item/paper_bin/uscm,
-/obj/item/tool/pen,
-/obj/structure/sign/safety/terminal{
-	pixel_x = 8;
-	pixel_y = 32
-	},
-/turf/open/floor/almayer/sterile_green_corner,
-/area/almayer/medical/morgue)
+/turf/open/gm/grass/grass1,
+/area/almayer/medical/upper_medical)
 "aCp" = (
-/obj/structure/machinery/power/apc/almayer/north,
-/turf/open/floor/almayer/sterile_green_side/north,
+/obj/structure/platform_decoration{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/mono,
 /area/almayer/medical/upper_medical)
 "aCt" = (
 /obj/structure/bed/sofa/south/white/right,
@@ -4424,8 +4441,21 @@
 /turf/open/floor/almayer/green/east,
 /area/almayer/hallways/lower/port_midship_hallway)
 "aCw" = (
-/obj/structure/window/framed/almayer/white,
-/turf/open/floor/plating,
+/obj/structure/surface/rack,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags,
+/obj/structure/sign/safety/medical{
+	pixel_x = 8;
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/plate,
 /area/almayer/medical/morgue)
 "aCA" = (
 /obj/structure/largecrate/random/barrel/white,
@@ -4761,22 +4791,15 @@
 /turf/open/floor/almayer,
 /area/almayer/living/numbertwobunks)
 "aEN" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4;
-	layer = 3.25
-	},
-/turf/open/floor/almayer/dark_sterile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/morgue)
 "aEO" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/med_data/laptop{
-	dir = 8
+/obj/structure/machinery/light/double/blue{
+	light_color = "#a7dbc7"
 	},
-/obj/structure/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/almayer/sterile_green_side/east,
-/area/almayer/medical/morgue)
+/turf/open/gm/grass/grass1,
+/area/almayer/medical/upper_medical)
 "aEQ" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/mono,
@@ -5096,15 +5119,12 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/living/numbertwobunks)
 "aGW" = (
-/turf/open/floor/almayer/sterile_green_side,
+/turf/closed/wall/almayer/white/reinforced,
 /area/almayer/medical/morgue)
 "aGX" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 1;
-	name = "ship-grade camera"
-	},
-/turf/open/floor/almayer/sterile_green_side,
-/area/almayer/medical/morgue)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_side/west,
+/area/almayer/medical/upper_medical)
 "aGY" = (
 /turf/open/floor/almayer/plate,
 /area/almayer/living/numbertwobunks)
@@ -5810,14 +5830,12 @@
 /turf/open/floor/almayer,
 /area/almayer/command/cic)
 "aLS" = (
-/obj/item/device/radio/intercom{
-	freerange = 1;
-	name = "General Listening Channel";
-	pixel_y = 28
-	},
-/obj/structure/bed/chair,
-/turf/open/floor/almayer/sterile_green_side/north,
-/area/almayer/medical/upper_medical)
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/tool/surgery/circular_saw,
+/obj/item/tool/surgery/retractor,
+/obj/item/tool/surgery/cautery,
+/turf/open/floor/almayer/plate,
+/area/almayer/medical/morgue)
 "aLT" = (
 /turf/closed/wall/almayer,
 /area/almayer/squads/alpha)
@@ -5825,20 +5843,9 @@
 /turf/open/floor/almayer,
 /area/almayer/shipboard/starboard_point_defense)
 "aLZ" = (
-/obj/structure/surface/table/almayer,
-/obj/item/tool/pen,
-/obj/item/paper_bin/wy,
-/obj/structure/machinery/computer/cameras/containment{
-	dir = 4;
-	layer = 2.981;
-	name = "Research Cameras";
-	pixel_y = 16
-	},
-/obj/item/clothing/accessory/stethoscope,
-/obj/structure/closet/secure_closet/professor_dummy{
-	pixel_x = -32
-	},
-/turf/open/floor/almayer/sterile_green_corner/west,
+/obj/structure/bed/sofa/south/white,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/upper_medical)
 "aMd" = (
 /obj/structure/filingcabinet/seeds{
@@ -6660,18 +6667,14 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/living/captain_mess)
 "aRF" = (
-/obj/structure/machinery/door/airlock/almayer/medical{
-	access_modified = 1;
-	dir = 2;
-	name = "Morgue Processing";
-	req_access_txt = "25";
-	req_one_access = null
+/obj/structure/toilet{
+	dir = 4
 	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
+/obj/structure/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/almayer/test_floor4,
-/area/almayer/medical/morgue)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/medical/upper_medical)
 "aRJ" = (
 /obj/structure/ladder{
 	height = 2;
@@ -6681,13 +6684,13 @@
 	pixel_x = 23;
 	pixel_y = -32
 	},
-/obj/structure/sign/safety/restrictedarea{
-	pixel_x = -17;
-	pixel_y = -8
-	},
 /obj/structure/sign/safety/refridgeration{
 	pixel_x = -17;
 	pixel_y = 7
+	},
+/obj/structure/sign/safety/restrictedarea{
+	pixel_x = -17;
+	pixel_y = -8
 	},
 /turf/open/floor/plating/almayer,
 /area/almayer/medical/upper_medical)
@@ -6719,6 +6722,8 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
 	},
+/obj/structure/machinery/light,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/sterile_green_corner/west,
 /area/almayer/medical/upper_medical)
 "aRT" = (
@@ -8659,9 +8664,12 @@
 /turf/open/floor/almayer/silver/west,
 /area/almayer/living/cryo_cells)
 "bho" = (
-/obj/structure/machinery/computer/med_data,
-/turf/open/floor/almayer/sterile_green_side,
-/area/almayer/medical/upper_medical)
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out";
+	pixel_x = 1
+	},
+/turf/open/floor/almayer/sterile_green_side/southeast,
+/area/almayer/medical/lower_medical_lobby)
 "bhq" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -9650,6 +9658,17 @@
 /obj/effect/landmark/ert_spawns/distress_cryo,
 /turf/open/floor/almayer/cargo,
 /area/almayer/living/cryo_cells)
+"bqa" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/item/device/autopsy_scanner,
+/obj/item/tool/surgery/scalpel,
+/obj/item/tool/surgery/hemostat,
+/turf/open/floor/almayer/plate,
+/area/almayer/medical/morgue)
 "bqc" = (
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/starboard_aft_hallway)
@@ -10827,7 +10846,10 @@
 /turf/open/floor/plating,
 /area/almayer/medical/lower_medical_lobby)
 "bCe" = (
-/turf/open/floor/almayer/sterile_green_side/northeast,
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/turf/open/floor/almayer/sterile_green_corner/east,
 /area/almayer/medical/lower_medical_lobby)
 "bCg" = (
 /obj/structure/machinery/light{
@@ -15211,27 +15233,62 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/command/computerlab)
 "cnV" = (
+/obj/structure/machinery/photocopier,
 /obj/structure/machinery/light{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/sterile_green_side/west,
 /area/almayer/medical/morgue)
 "cnW" = (
-/obj/structure/machinery/optable,
-/turf/open/floor/almayer/dark_sterile,
-/area/almayer/medical/morgue)
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform,
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 10;
+	layer = 3.51
+	},
+/obj/structure/platform_decoration{
+	dir = 5;
+	layer = 3.51
+	},
+/obj/structure/pipes/vents/pump{
+	dir = 4
+	},
+/turf/open/floor/almayer/mono,
+/area/almayer/medical/upper_medical)
 "cnZ" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/tool/surgery/scalpel,
-/obj/item/tool/surgery/hemostat,
-/turf/open/floor/almayer/sterile_green_corner/west,
-/area/almayer/medical/morgue)
+/obj/structure/filingcabinet/filingcabinet{
+	density = 0;
+	pixel_x = -8;
+	pixel_y = 16
+	},
+/obj/structure/filingcabinet/filingcabinet{
+	density = 0;
+	pixel_x = 7;
+	pixel_y = 16
+	},
+/obj/item/folder/white,
+/obj/item/folder/black,
+/obj/item/folder/black,
+/obj/item/clipboard,
+/obj/item/clipboard,
+/turf/open/floor/almayer/sterile_green_side/north,
+/area/almayer/medical/upper_medical)
 "coa" = (
-/obj/item/tool/surgery/circular_saw,
-/obj/item/tool/surgery/cautery,
-/obj/item/tool/surgery/retractor,
-/obj/structure/surface/table/reinforced/prison,
-/turf/open/floor/almayer/sterile_green_side,
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/med_data/laptop{
+	dir = 1;
+	pixel_y = -4
+	},
+/obj/structure/sign/safety/terminal{
+	pixel_x = -21
+	},
+/turf/open/floor/almayer/sterile_green_corner/west,
 /area/almayer/medical/morgue)
 "cod" = (
 /obj/structure/machinery/cm_vending/clothing/dress{
@@ -15732,10 +15789,10 @@
 /turf/open/floor/plating,
 /area/almayer/maint/lower/constr)
 "cyU" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 5
-	},
-/turf/open/floor/almayer/dark_sterile,
+/obj/structure/bed/sofa/south/white/left,
+/obj/structure/platform,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/mono,
 /area/almayer/medical/upper_medical)
 "cyZ" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -16945,12 +17002,13 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/mp_bunks)
 "cXW" = (
-/obj/structure/machinery/status_display{
-	pixel_y = 30
+/obj/structure/machinery/door_control{
+	dir = 1;
+	id = "Research Armory";
+	name = "Research Armory";
+	req_one_access_txt = "4;28"
 	},
-/obj/structure/surface/table/almayer,
-/obj/item/paper_bin/uscm,
-/turf/open/floor/almayer/sterile_green_side/north,
+/turf/closed/wall/almayer/white/reinforced,
 /area/almayer/medical/upper_medical)
 "cXX" = (
 /obj/structure/disposalpipe/segment,
@@ -17971,11 +18029,11 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/maint/upper/u_f_s)
 "dwA" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/sign/safety/bathunisex{
-	pixel_x = 32
+/obj/structure/closet/secure_closet/guncabinet/red/armory_m39_submachinegun,
+/obj/structure/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/almayer/mono,
+/turf/open/floor/almayer/redfull,
 /area/almayer/medical/upper_medical)
 "dwI" = (
 /obj/structure/machinery/door/airlock/almayer/engineering{
@@ -18358,14 +18416,11 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/stern)
 "dDL" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/research/main_terminal{
+/obj/structure/machinery/light/double/blue{
+	light_color = "#a7dbc7";
 	dir = 4
 	},
-/obj/structure/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/almayer/sterile_green_side/west,
+/turf/open/floor/almayer/sterile_green_corner/east,
 /area/almayer/medical/upper_medical)
 "dDM" = (
 /obj/effect/decal/cleanable/blood/oil,
@@ -19066,12 +19121,11 @@
 /turf/open/floor/almayer/bluecorner/west,
 /area/almayer/hallways/upper/midship_hallway)
 "dSJ" = (
-/obj/item/device/radio/intercom{
-	freerange = 1;
-	name = "General Listening Channel";
-	pixel_x = -28
+/obj/structure/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/almayer/plate,
 /area/almayer/medical/morgue)
 "dSX" = (
 /obj/structure/disposalpipe/segment{
@@ -20869,11 +20923,15 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/maint/upper/u_m_s)
 "eDo" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "W";
-	layer = 2.5
+/obj/structure/bed/chair/office/dark{
+	dir = 4
 	},
-/turf/open/floor/almayer/plating/northeast,
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	name = "General Listening Channel";
+	pixel_x = -28
+	},
+/turf/open/floor/almayer/sterile_green_corner/west,
 /area/almayer/medical/upper_medical)
 "eDq" = (
 /obj/structure/largecrate/random/secure,
@@ -21515,6 +21573,19 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/vehiclehangar)
+"eSN" = (
+/obj/structure/machinery/door/airlock/almayer/medical{
+	access_modified = 1;
+	dir = 2;
+	name = "Morgue";
+	req_access_txt = "25";
+	req_one_access = null
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/medical/morgue)
 "eSU" = (
 /obj/structure/prop/almayer/name_stencil{
 	icon_state = "almayer1"
@@ -22001,8 +22072,14 @@
 /turf/open/floor/almayer/sterile_green_side/northwest,
 /area/almayer/medical/lower_medical_medbay)
 "fbB" = (
-/obj/structure/pipes/standard/manifold/fourway/hidden/supply,
-/turf/open/floor/almayer/dark_sterile,
+/obj/structure/machinery/door/airlock/almayer/generic/glass{
+	name = "\improper Psychiatric Care Unit"
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/upper_medical)
 "fbC" = (
 /obj/structure/closet/toolcloset,
@@ -22471,14 +22548,16 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/living/briefing)
 "fnA" = (
-/obj/structure/surface/rack,
-/obj/item/tool/crowbar,
-/obj/item/device/radio,
-/obj/item/device/flashlight,
-/obj/structure/machinery/light{
-	dir = 8
+/obj/structure/machinery/door/airlock/almayer/research/reinforced{
+	access_modified = 1;
+	name = "\improper CMO's Bedroom";
+	req_one_access_txt = "1;5"
 	},
-/turf/open/floor/almayer/redfull,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/upper_medical)
 "fnH" = (
 /obj/structure/pipes/vents/pump{
@@ -22825,9 +22904,13 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/living/briefing)
 "fvd" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/almayer/sterile_green_corner/west,
-/area/almayer/medical/upper_medical)
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/medical/morgue)
 "fvf" = (
 /turf/open/floor/almayer/silver/north,
 /area/almayer/living/briefing)
@@ -23187,9 +23270,14 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/command/cichallway)
 "fEC" = (
-/obj/structure/machinery/power/apc/almayer/south,
-/turf/open/floor/almayer/plate,
-/area/almayer/medical/morgue)
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_x = 1;
+	pixel_y = 2
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/medical/upper_medical)
 "fEF" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -23207,10 +23295,13 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/lifeboat_pumps/south2)
 "fFh" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/device/autopsy_scanner,
-/turf/open/floor/almayer/sterile_green_side,
-/area/almayer/medical/morgue)
+/obj/structure/bed,
+/obj/item/bedsheet/green,
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/almayer/mono,
+/area/almayer/medical/upper_medical)
 "fFD" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -23232,14 +23323,9 @@
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/lower_medical_medbay)
 "fFO" = (
-/obj/structure/machinery/light{
-	dir = 4
-	},
-/obj/structure/morgue{
-	dir = 8
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/medical/morgue)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_side/northwest,
+/area/almayer/medical/upper_medical)
 "fFQ" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/spray/cleaner{
@@ -23650,6 +23736,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/sterile_green_side/southwest,
 /area/almayer/medical/upper_medical)
 "fPn" = (
@@ -23718,12 +23805,8 @@
 /turf/open/floor/almayer/plating/northeast,
 /area/almayer/engineering/lower/engine_core)
 "fQu" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	id = "CMO Shutters";
-	name = "\improper CMO Office Shutters"
-	},
-/obj/structure/window/framed/almayer/white,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_side/northeast,
 /area/almayer/medical/upper_medical)
 "fQy" = (
 /obj/structure/machinery/light/small{
@@ -23938,12 +24021,14 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/upper_engineering/port)
 "fXg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/sign/nosmoking_2{
+	pixel_x = 32
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/medical/morgue)
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer/sterile_green_side/east,
+/area/almayer/medical/upper_medical)
 "fXx" = (
 /obj/structure/surface/rack,
 /turf/open/floor/almayer/silver/southeast,
@@ -23984,6 +24069,17 @@
 /turf/open/floor/almayer/plating/northeast,
 /area/almayer/shipboard/stern_point_defense)
 "fYb" = (
+/obj/structure/filingcabinet/filingcabinet{
+	density = 0;
+	pixel_x = -8;
+	pixel_y = 16
+	},
+/obj/structure/filingcabinet/filingcabinet{
+	density = 0;
+	pixel_x = 7;
+	pixel_y = 16
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/sterile_green_side/west,
 /area/almayer/medical/morgue)
 "fYf" = (
@@ -25235,13 +25331,25 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/living/pilotbunks)
-"gzK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/open/floor/plating/plating_catwalk,
+"gzJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/morgue)
+"gzK" = (
+/obj/structure/machinery/door/airlock/almayer/generic{
+	name = "\improper Bathroom"
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	layer = 2.5;
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/medical/upper_medical)
 "gzM" = (
 /obj/effect/step_trigger/clone_cleaner,
 /obj/structure/sign/safety/stairs{
@@ -25749,11 +25857,14 @@
 /turf/open/floor/almayer/silvercorner,
 /area/almayer/hallways/lower/repair_bay)
 "gKR" = (
-/obj/structure/closet/emcloset,
-/obj/structure/machinery/light{
-	dir = 8
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 4;
+	id = "CMO Shutters";
+	name = "\improper CMO Office Shutters"
 	},
-/turf/open/floor/almayer/sterile_green_side/west,
+/obj/structure/window/framed/almayer/white,
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/turf/open/floor/plating,
 /area/almayer/medical/upper_medical)
 "gKZ" = (
 /obj/structure/surface/table/almayer,
@@ -26311,10 +26422,10 @@
 /turf/open/floor/plating,
 /area/almayer/medical/upper_medical)
 "gXl" = (
-/obj/structure/closet/secure_closet/personal/cabinet{
-	req_access_txt = "5"
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
-/turf/open/floor/almayer/mono,
+/turf/open/floor/almayer/sterile_green,
 /area/almayer/medical/upper_medical)
 "gXs" = (
 /obj/effect/step_trigger/ares_alert/terminals,
@@ -26541,12 +26652,8 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/u_a_s)
 "hbI" = (
-/obj/structure/sign/safety/ammunition{
-	pixel_x = 32;
-	pixel_y = 7
-	},
-/obj/structure/closet/secure_closet/guncabinet/red/armory_shotgun,
-/turf/open/floor/almayer/redfull,
+/obj/structure/closet/secure_closet/CMO,
+/turf/open/floor/almayer/mono,
 /area/almayer/medical/upper_medical)
 "hcf" = (
 /obj/item/bedsheet/brown{
@@ -28004,13 +28111,13 @@
 /turf/open/floor/almayer/sterile_green_side/west,
 /area/almayer/medical/medical_science)
 "hFF" = (
-/obj/structure/machinery/door/airlock/almayer/medical{
-	access_modified = 1;
-	name = "Autopsy";
-	req_access_txt = "25";
-	req_one_access = null
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out"
 	},
-/obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/machinery/door/airlock/multi_tile/almayer/medidoor/solid{
+	dir = 1;
+	name = "Morgue Processing"
+	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/morgue)
 "hGb" = (
@@ -28404,14 +28511,8 @@
 /turf/open/floor/almayer/cargo,
 /area/almayer/engineering/lower/workshop/hangar)
 "hQU" = (
-/obj/structure/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/sign/safety/intercom{
-	pixel_x = -17
-	},
-/turf/open/floor/almayer/plate,
+/obj/structure/morgue,
+/turf/open/floor/almayer/test_floor5,
 /area/almayer/medical/morgue)
 "hQW" = (
 /obj/structure/disposalpipe/segment{
@@ -28685,11 +28786,10 @@
 /turf/open/floor/almayer/sterile_green_side/southeast,
 /area/almayer/medical/medical_science)
 "hVz" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/almayer/sterile_green_side/north,
-/area/almayer/medical/upper_medical)
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/medical/morgue)
 "hVL" = (
 /obj/structure/largecrate/random/barrel/red,
 /turf/open/floor/almayer/plate,
@@ -29418,8 +29518,11 @@
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/lower_medical_lobby)
 "imp" = (
-/obj/structure/filingcabinet/filingcabinet,
-/turf/open/floor/almayer/sterile_green_side/west,
+/obj/structure/window/framed/almayer/white,
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/almayer/medical/morgue)
 "imt" = (
 /obj/structure/reagent_dispensers/water_cooler/stacks{
@@ -29712,12 +29815,10 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/lifeboat_pumps/north1)
 "isN" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/open/floor/almayer/sterile_green_side/west,
+/obj/structure/surface/table/almayer,
+/obj/item/paper_bin/uscm,
+/obj/item/tool/pen,
+/turf/open/floor/almayer/sterile_green_corner/west,
 /area/almayer/medical/morgue)
 "itg" = (
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom{
@@ -30249,6 +30350,11 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/west,
 /area/almayer/medical/operating_room_four)
+"iGA" = (
+/obj/structure/bed/sofa/south/white/left,
+/obj/structure/machinery/camera/autoname/almayer,
+/turf/open/floor/almayer/sterile_green_corner/north,
+/area/almayer/medical/upper_medical)
 "iGQ" = (
 /obj/structure/machinery/landinglight/ds2/delayone{
 	dir = 8
@@ -30458,7 +30564,7 @@
 	pixel_x = 32;
 	pixel_y = 7
 	},
-/turf/open/floor/almayer/sterile_green_corner/east,
+/turf/open/floor/plating/almayer,
 /area/almayer/medical/lower_medical_lobby)
 "iLG" = (
 /obj/structure/disposalpipe/junction{
@@ -31150,7 +31256,10 @@
 /area/almayer/living/briefing)
 "iXW" = (
 /obj/structure/machinery/power/apc/almayer/east,
-/turf/open/floor/almayer/sterile_green_corner,
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/turf/open/floor/almayer/sterile_green,
 /area/almayer/medical/lower_medical_lobby)
 "iYe" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -31825,8 +31934,10 @@
 /turf/open/floor/almayer/cargo/southwest,
 /area/almayer/engineering/starboard_atmos)
 "jkl" = (
-/obj/structure/morgue,
-/turf/open/floor/almayer/plate,
+/obj/structure/morgue{
+	dir = 8
+	},
+/turf/open/floor/almayer/test_floor5,
 /area/almayer/medical/morgue)
 "jkq" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -32665,10 +32776,7 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/engineering/upper_engineering/port)
 "jBy" = (
-/obj/structure/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/almayer/sterile_green_side/east,
+/turf/open/floor/almayer/sterile_green_side/northeast,
 /area/almayer/medical/morgue)
 "jBO" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer{
@@ -32937,7 +33045,8 @@
 	pixel_x = -24;
 	req_access_txt = "25"
 	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/plate,
 /area/almayer/medical/morgue)
 "jIs" = (
 /obj/structure/disposalpipe/segment{
@@ -33265,11 +33374,11 @@
 /turf/open/floor/almayer/orange,
 /area/almayer/engineering/lower)
 "jOG" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/sterile_green_side/east,
 /area/almayer/medical/upper_medical)
 "jPd" = (
@@ -33435,10 +33544,25 @@
 /turf/open/floor/almayer/green/west,
 /area/almayer/living/offices)
 "jTj" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "E"
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/light,
+/obj/structure/machinery/computer/cameras/containment{
+	dir = 8;
+	name = "Research Cameras";
+	pixel_y = 10
 	},
-/turf/open/floor/almayer/plating/northeast,
+/obj/structure/machinery/computer/research/main_terminal{
+	dir = 8;
+	pixel_y = -3
+	},
+/obj/structure/machinery/door_control{
+	id = "CMO Shutters";
+	name = "Office Shutters";
+	req_access_txt = "5";
+	pixel_x = -11;
+	pixel_y = -6
+	},
+/turf/open/floor/almayer/sterile_green_side,
 /area/almayer/medical/upper_medical)
 "jTt" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -33792,8 +33916,7 @@
 /turf/open/floor/almayer,
 /area/almayer/medical/containment/cell/cl)
 "jZY" = (
-/obj/structure/closet/l3closet/virology,
-/turf/open/floor/almayer/redfull,
+/turf/open/floor/almayer/sterile_green_corner/east,
 /area/almayer/medical/upper_medical)
 "kac" = (
 /obj/structure/surface/rack,
@@ -33892,6 +34015,10 @@
 /obj/structure/machinery/light,
 /turf/open/floor/plating/almayer/no_build,
 /area/almayer/hallways/upper/fore_hallway)
+"kbn" = (
+/obj/structure/flora/bush/ausbushes/grassybush,
+/turf/open/gm/grass/grass1,
+/area/almayer/medical/upper_medical)
 "kbv" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/upper/starboard)
@@ -34069,20 +34196,9 @@
 /turf/open/floor/plating,
 /area/almayer/powered/agent)
 "kgp" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/transmitter{
-	name = "CMO Office Telephone";
-	phone_category = "Offices";
-	phone_id = "CMO Office";
-	pixel_y = 29
-	},
-/obj/structure/sign/safety/commline_connection{
-	pixel_x = 23;
-	pixel_y = 32
-	},
-/turf/open/floor/almayer/sterile_green_side/north,
+/obj/structure/bed/sofa/south/white/right,
+/obj/structure/platform,
+/turf/open/floor/almayer/mono,
 /area/almayer/medical/upper_medical)
 "kgs" = (
 /obj/structure/window/framed/almayer/white,
@@ -34330,6 +34446,14 @@
 /obj/item/circuitboard/airalarm,
 /turf/open/floor/almayer/orange/north,
 /area/almayer/engineering/lower)
+"kln" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/almayer/sterile_green_side/east,
+/area/almayer/medical/upper_medical)
 "klH" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 4
@@ -34436,11 +34560,23 @@
 /turf/open/floor/almayer/cargo_arrow/west,
 /area/almayer/living/gym)
 "koB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/medical/morgue)
+/obj/structure/mirror{
+	pixel_x = -27
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/medical/upper_medical)
 "koC" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -35244,9 +35380,17 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/living/briefing)
 "kEp" = (
-/obj/structure/filingcabinet/filingcabinet,
-/turf/open/floor/almayer/sterile_green_corner/west,
-/area/almayer/medical/morgue)
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out"
+	},
+/obj/structure/machinery/power/apc/almayer/north,
+/obj/structure/sign/safety/rewire{
+	pixel_x = -20;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_corner/north,
+/area/almayer/medical/upper_medical)
 "kEq" = (
 /obj/structure/machinery/door/window/ultra{
 	dir = 8;
@@ -36558,14 +36702,8 @@
 /turf/open/floor/almayer/orange/southeast,
 /area/almayer/engineering/upper_engineering/starboard)
 "lhv" = (
-/obj/structure/machinery/door_control{
-	id = "CMO Shutters";
-	name = "Office Shutters";
-	pixel_y = -20;
-	req_access_txt = "5"
-	},
-/obj/structure/machinery/computer/crew,
-/turf/open/floor/almayer/sterile_green_corner/east,
+/obj/structure/closet/firecloset,
+/turf/open/floor/almayer/cargo,
 /area/almayer/medical/upper_medical)
 "lhB" = (
 /obj/structure/window/framed/almayer,
@@ -36808,8 +36946,10 @@
 /turf/closed/wall/almayer,
 /area/almayer/hallways/lower/starboard_umbilical)
 "lmi" = (
-/obj/structure/bed,
-/obj/item/bedsheet/green,
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/bed/sofa/south/white/left,
 /turf/open/floor/almayer/mono,
 /area/almayer/medical/upper_medical)
 "lml" = (
@@ -37689,10 +37829,8 @@
 /turf/open/floor/almayer/aicore/no_build/ai_silver/east,
 /area/almayer/command/airoom)
 "lFn" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_21"
-	},
-/turf/open/floor/almayer/sterile_green_corner/north,
+/obj/structure/machinery/optable,
+/turf/open/floor/almayer/plate,
 /area/almayer/medical/morgue)
 "lFp" = (
 /turf/closed/wall/almayer,
@@ -38568,11 +38706,10 @@
 /turf/open/floor/wood/ship,
 /area/almayer/command/corporateliaison)
 "maT" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/machinery/light{
-	dir = 4
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 8;
+	name = "ship-grade camera"
 	},
 /turf/open/floor/almayer/sterile_green_side/east,
 /area/almayer/medical/upper_medical)
@@ -38597,12 +38734,11 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/living/gym)
 "mcW" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/box/gloves,
+/obj/structure/morgue,
 /obj/structure/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/almayer/test_floor5,
 /area/almayer/medical/morgue)
 "mdk" = (
 /obj/structure/machinery/door/poddoor/railing{
@@ -39271,13 +39407,12 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/hangar)
 "mrL" = (
-/obj/structure/surface/rack,
-/obj/item/storage/box/bodybags,
-/obj/item/storage/box/bodybags,
-/obj/item/storage/box/bodybags,
-/obj/item/storage/box/bodybags,
-/turf/open/floor/almayer/plate,
-/area/almayer/medical/morgue)
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 4;
+	name = "ship-grade camera"
+	},
+/turf/open/gm/grass/grass1,
+/area/almayer/medical/upper_medical)
 "mrM" = (
 /obj/structure/closet/secure_closet/quartermaster_uscm,
 /turf/open/floor/almayer/green,
@@ -40387,13 +40522,15 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/lower/starboard_fore_hallway)
 "mNI" = (
-/obj/structure/machinery/door/window/westleft{
-	dir = 2
+/obj/structure/morgue{
+	dir = 8
 	},
-/obj/structure/machinery/shower,
-/obj/item/tool/soap,
-/turf/open/floor/almayer/sterile,
-/area/almayer/medical/upper_medical)
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 8;
+	name = "ship-grade camera"
+	},
+/turf/open/floor/almayer/test_floor5,
+/area/almayer/medical/morgue)
 "mNK" = (
 /obj/structure/closet/secure_closet/brig/restraints,
 /turf/open/floor/almayer/red/west,
@@ -42266,13 +42403,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/port_aft_hallway)
 "nzv" = (
-/obj/structure/filingcabinet/filingcabinet,
-/obj/item/clipboard,
-/obj/item/clipboard,
-/obj/item/folder/black,
-/obj/item/folder/black,
-/obj/item/folder/white,
-/turf/open/floor/almayer/sterile_green_side,
+/obj/structure/bed/sofa/south/white/right,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_corner,
 /area/almayer/medical/upper_medical)
 "nzD" = (
 /obj/effect/step_trigger/clone_cleaner,
@@ -42695,6 +42828,13 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/lower/workshop)
+"nHP" = (
+/obj/structure/machinery/light/double/blue{
+	dir = 1;
+	light_color = "#a7dbc7"
+	},
+/turf/open/gm/grass/grass1,
+/area/almayer/medical/upper_medical)
 "nHX" = (
 /obj/structure/prop/invuln/overhead_pipe{
 	pixel_x = 12
@@ -42851,10 +42991,8 @@
 /turf/open/floor/almayer/bluefull,
 /area/almayer/living/briefing)
 "nMV" = (
-/obj/structure/machinery/cm_vending/sorted/medical/wall_med{
-	pixel_y = 25
-	},
-/turf/open/floor/almayer/sterile_green_side/north,
+/obj/structure/closet/emcloset,
+/turf/open/floor/almayer/cargo,
 /area/almayer/medical/upper_medical)
 "nNg" = (
 /obj/structure/bed,
@@ -44066,7 +44204,16 @@
 /turf/open/floor/almayer_hull/outerhull_dir,
 /area/space)
 "okO" = (
-/obj/structure/machinery/cm_vending/clothing/senior_officer,
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 5;
+	layer = 3.51
+	},
 /turf/open/floor/almayer/mono,
 /area/almayer/medical/upper_medical)
 "old" = (
@@ -44074,6 +44221,12 @@
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/s_bow)
+"olz" = (
+/obj/structure/platform_decoration{
+	dir = 4
+	},
+/turf/open/floor/almayer/mono,
+/area/almayer/medical/upper_medical)
 "olF" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/almayer/cargo,
@@ -44202,11 +44355,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/charlie)
 "onQ" = (
-/obj/structure/sign/safety/rewire{
-	pixel_x = 8;
-	pixel_y = 32
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
 	},
-/turf/open/floor/almayer/sterile_green_side/northeast,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_side,
 /area/almayer/medical/upper_medical)
 "onU" = (
 /obj/effect/step_trigger/teleporter_vector{
@@ -45515,14 +45668,18 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/hydroponics)
 "oNJ" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N"
+/obj/structure/transmitter{
+	name = "CMO Office Telephone";
+	phone_category = "Offices";
+	phone_id = "CMO Office";
+	dir = 4;
+	pixel_x = -20
 	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "SW-out";
-	layer = 2.5
+/obj/structure/sign/safety/commline_connection{
+	pixel_x = -17;
+	pixel_y = 32
 	},
-/turf/open/floor/almayer/plating/northeast,
+/turf/open/floor/almayer/sterile_green_side/west,
 /area/almayer/medical/upper_medical)
 "oNK" = (
 /obj/structure/machinery/power/apc/almayer/north,
@@ -46621,11 +46778,12 @@
 /turf/closed/wall/almayer,
 /area/almayer/maint/hull/upper/p_bow)
 "pjF" = (
-/obj/structure/surface/table/almayer,
-/obj/item/paper,
-/obj/item/tool/lighter/random,
-/turf/open/floor/almayer/plate,
-/area/almayer/medical/morgue)
+/obj/structure/machinery/cm_vending/clothing/senior_officer{
+	pixel_y = 20;
+	density = 0
+	},
+/turf/open/floor/almayer/mono,
+/area/almayer/medical/upper_medical)
 "pjG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -46635,6 +46793,13 @@
 	},
 /turf/open/floor/almayer/plating_striped,
 /area/almayer/squads/req)
+"pjO" = (
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 1;
+	name = "ship-grade camera"
+	},
+/turf/open/floor/almayer/green,
+/area/almayer/hallways/upper/fore_hallway)
 "pjP" = (
 /obj/structure/machinery/firealarm{
 	pixel_y = 28
@@ -46993,13 +47158,10 @@
 /turf/open/floor/plating,
 /area/almayer/engineering/upper_engineering)
 "pth" = (
-/obj/structure/surface/table/almayer,
-/obj/item/folder/blue,
-/obj/effect/landmark/map_item,
-/obj/structure/pipes/vents/scrubber{
-	dir = 8
+/obj/structure/machinery/status_display{
+	pixel_y = 30
 	},
-/turf/open/floor/almayer/sterile_green_side/east,
+/turf/open/gm/grass/grass1,
 /area/almayer/medical/upper_medical)
 "ptj" = (
 /obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep,
@@ -47641,6 +47803,14 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/lifeboat_pumps/north1)
+"pJl" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	layer = 2.5;
+	pixel_y = 2
+	},
+/turf/open/floor/almayer/sterile_green_side/northwest,
+/area/almayer/medical/upper_medical)
 "pJq" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out";
@@ -48771,18 +48941,14 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/upper/u_f_s)
 "qhx" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_22"
+/obj/structure/closet/secure_closet/personal/cabinet{
+	req_access_txt = "5"
 	},
-/obj/structure/sign/safety/ammunition{
-	pixel_x = -17;
-	pixel_y = 7
+/obj/item/clothing/accessory/stethoscope,
+/obj/structure/machinery/light{
+	dir = 4
 	},
-/obj/structure/sign/safety/hazard{
-	pixel_x = -17;
-	pixel_y = -8
-	},
-/turf/open/floor/almayer/sterile_green_side/north,
+/turf/open/floor/almayer/mono,
 /area/almayer/medical/upper_medical)
 "qhD" = (
 /obj/structure/closet{
@@ -50550,12 +50716,8 @@
 /turf/open/floor/almayer/red,
 /area/almayer/command/lifeboat)
 "qQc" = (
-/obj/structure/closet/secure_closet/personal/patient{
-	name = "morgue closet"
-	},
-/obj/structure/machinery/alarm/almayer{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plate,
 /area/almayer/medical/morgue)
 "qQp" = (
@@ -51566,6 +51728,20 @@
 /obj/structure/pipes/vents/scrubber,
 /turf/open/floor/almayer,
 /area/almayer/living/gym)
+"rkK" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/bed/sofa/south/white/right,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/plush/therapy/random_color{
+	pixel_y = -3
+	},
+/obj/structure/sign/nosmoking_2{
+	pixel_y = 29
+	},
+/turf/open/floor/almayer/mono,
+/area/almayer/medical/upper_medical)
 "rkV" = (
 /obj/structure/window/framed/almayer/hull/hijack_bustable,
 /obj/structure/machinery/door/poddoor/shutters/almayer/open{
@@ -51720,12 +51896,8 @@
 /turf/open/floor/almayer/blue/north,
 /area/almayer/hallways/upper/midship_hallway)
 "rnN" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/sign/nosmoking_2{
-	pixel_x = 32
-	},
-/turf/open/floor/almayer/sterile_green_side/east,
-/area/almayer/medical/upper_medical)
+/turf/open/floor/almayer/greenfull,
+/area/almayer/hallways/upper/fore_hallway)
 "rob" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
@@ -51898,6 +52070,9 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/living/bridgebunks)
+"rrD" = (
+/turf/open/floor/almayer/sterile_green_side/southeast,
+/area/almayer/medical/upper_medical)
 "rrK" = (
 /obj/structure/bed/chair{
 	can_buckle = 0;
@@ -52144,6 +52319,13 @@
 /obj/structure/window/framed/almayer/hull,
 /turf/open/floor/plating,
 /area/almayer/maint/hull/upper/u_f_p)
+"rxc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/almayer/plate,
+/area/almayer/medical/morgue)
 "rxe" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/toolbox,
@@ -52559,6 +52741,13 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/southwest,
 /area/almayer/medical/lower_medical_medbay)
+"rGc" = (
+/obj/structure/flora/bush/ausbushes/ppflowers,
+/obj/structure/machinery/status_display{
+	pixel_x = -32
+	},
+/turf/open/gm/grass/grass1,
+/area/almayer/medical/upper_medical)
 "rGj" = (
 /turf/open/floor/almayer/red,
 /area/almayer/squads/alpha)
@@ -53156,6 +53345,13 @@
 	},
 /turf/open/floor/almayer/orangefull,
 /area/almayer/squads/alpha_bravo_shared)
+"rSq" = (
+/obj/structure/closet/secure_closet/guncabinet/red/armory_shotgun,
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/almayer/redfull,
+/area/almayer/medical/upper_medical)
 "rSx" = (
 /obj/structure/surface/table/almayer,
 /obj/item/stack/rods/plasteel{
@@ -53680,14 +53876,17 @@
 /turf/open/floor/almayer/red,
 /area/almayer/hallways/upper/starboard)
 "sdn" = (
-/obj/structure/sink{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/light/double/blue{
 	dir = 4;
-	pixel_x = 11
+	light_color = "#a7dbc7"
 	},
-/obj/structure/mirror{
-	pixel_x = 28
+/obj/structure/reagent_dispensers/water_cooler/stacks{
+	pixel_y = 23;
+	pixel_x = -8;
+	density = 0
 	},
-/turf/open/floor/almayer/sterile,
+/turf/open/floor/almayer/sterile_green_corner,
 /area/almayer/medical/upper_medical)
 "sdu" = (
 /obj/structure/disposalpipe/segment,
@@ -53715,7 +53914,7 @@
 	height = 1;
 	id = "med1"
 	},
-/turf/open/floor/almayer/sterile_green_side,
+/turf/open/floor/plating/almayer,
 /area/almayer/medical/lower_medical_lobby)
 "seL" = (
 /obj/structure/pipes/vents/pump{
@@ -54020,10 +54219,8 @@
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/processing)
 "skl" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/almayer/dark_sterile,
+/obj/structure/machinery/computer/crew,
+/turf/open/floor/almayer/sterile_green_corner,
 /area/almayer/medical/upper_medical)
 "skn" = (
 /turf/open/floor/almayer/plating_striped,
@@ -55211,6 +55408,10 @@
 /turf/open/floor/almayer/orange/north,
 /area/almayer/living/port_emb)
 "sKa" = (
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 8;
+	name = "ship-grade camera"
+	},
 /turf/open/floor/almayer/sterile_green_side/east,
 /area/almayer/medical/morgue)
 "sKf" = (
@@ -55407,11 +55608,24 @@
 /turf/open/floor/almayer/orange/northwest,
 /area/almayer/maint/upper/mess)
 "sOZ" = (
-/obj/structure/sign/safety/ammunition{
-	pixel_y = 32
+/obj/structure/machinery/light{
+	dir = 1
 	},
-/obj/structure/closet/secure_closet/guncabinet/red/armory_m4a3_pistol,
-/turf/open/floor/almayer/redfull,
+/obj/item/paper_bin/wy{
+	pixel_y = 8;
+	pixel_x = -7
+	},
+/obj/structure/surface/table/almayer,
+/obj/item/tool/pen{
+	pixel_y = 4;
+	pixel_x = -8
+	},
+/obj/item/folder/blue{
+	pixel_y = 5;
+	pixel_x = 6
+	},
+/obj/effect/landmark/map_item,
+/turf/open/floor/almayer/sterile_green_corner/north,
 /area/almayer/medical/upper_medical)
 "sPa" = (
 /obj/structure/surface/rack,
@@ -55809,13 +56023,11 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/shipboard/port_point_defense)
 "sYT" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 4;
-	id = "CMO Shutters";
-	name = "\improper CMO Office Shutters"
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	layer = 2.5
 	},
-/obj/structure/window/framed/almayer/white,
-/turf/open/floor/plating,
+/turf/open/floor/almayer/sterile_green_side/west,
 /area/almayer/medical/upper_medical)
 "sYU" = (
 /obj/structure/disposalpipe/segment{
@@ -56909,16 +57121,11 @@
 /turf/open/floor/almayer/bluefull,
 /area/almayer/command/cichallway)
 "tsC" = (
-/obj/item/storage/box/bodybags,
-/obj/item/storage/box/bodybags,
-/obj/item/storage/box/bodybags,
-/obj/item/storage/box/bodybags,
-/obj/structure/surface/table/almayer,
-/obj/structure/sign/poster{
-	icon_state = "poster8";
-	pixel_y = 32
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	id = "Research Armory";
+	name = "\improper Armory Shutters"
 	},
-/turf/open/floor/almayer/sterile_green_corner/north,
+/turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/upper_medical)
 "tsE" = (
 /obj/structure/largecrate/random/barrel/blue,
@@ -57216,6 +57423,13 @@
 	},
 /turf/open/floor/almayer/cargo,
 /area/almayer/engineering/lower/engine_core)
+"txW" = (
+/obj/structure/bed/chair{
+	dir = 8;
+	pixel_y = 3
+	},
+/turf/open/floor/almayer/sterile_green_side,
+/area/almayer/medical/upper_medical)
 "tyb" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -57477,17 +57691,8 @@
 /turf/open/floor/almayer/cargo,
 /area/almayer/engineering/lower/workshop/hangar)
 "tEi" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
-/obj/structure/machinery/door_control{
-	dir = 1;
-	id = "Research Armory";
-	name = "Research Armory";
-	pixel_x = 27;
-	req_one_access_txt = "4;28"
-	},
-/turf/open/floor/almayer/plating/northeast,
+/obj/structure/pipes/standard/manifold/hidden/supply,
+/turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/upper_medical)
 "tEu" = (
 /obj/structure/machinery/disposal,
@@ -58218,21 +58423,12 @@
 /turf/open/floor/almayer/silver,
 /area/almayer/hallways/lower/repair_bay)
 "tWY" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	layer = 2.5
 	},
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 4;
-	id = "CMO Shutters";
-	name = "\improper CMO Office Shutters"
-	},
-/obj/structure/machinery/door/airlock/almayer/medical/glass{
-	access_modified = 1;
-	name = "\improper CMO's Office";
-	req_one_access = null;
-	req_one_access_txt = "1;5"
-	},
-/turf/open/floor/almayer/test_floor4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_side/west,
 /area/almayer/medical/upper_medical)
 "tXa" = (
 /obj/item/storage/toolbox/mechanical{
@@ -59037,10 +59233,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/p_bow)
 "upM" = (
-/obj/structure/machinery/light{
-	dir = 4
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	layer = 2.5;
+	pixel_y = 1
 	},
-/turf/open/floor/almayer/dark_sterile,
+/turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/upper_medical)
 "upO" = (
 /obj/structure/disposalpipe/segment,
@@ -59888,6 +60086,12 @@
 	},
 /turf/open/floor/almayer/green/north,
 /area/almayer/hallways/lower/port_midship_hallway)
+"uGk" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer/mono,
+/area/almayer/medical/upper_medical)
 "uGN" = (
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/almayer,
@@ -60248,13 +60452,11 @@
 /turf/open/floor/almayer/red/northwest,
 /area/almayer/command/lifeboat)
 "uRt" = (
-/obj/structure/machinery/light{
-	dir = 8
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
 	},
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_22"
-	},
-/turf/open/floor/almayer/sterile_green_side/west,
+/turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/upper_medical)
 "uRD" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -61164,14 +61366,15 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/living/chapel)
 "vih" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/fancy/candle_box,
 /obj/structure/sign/safety/medical{
-	pixel_x = 8;
+	pixel_x = 15;
 	pixel_y = -32
 	},
-/turf/open/floor/almayer/plate,
-/area/almayer/medical/morgue)
+/obj/structure/sign/safety/restrictedarea{
+	pixel_y = -32
+	},
+/turf/open/floor/almayer/green,
+/area/almayer/hallways/upper/fore_hallway)
 "vil" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -61871,10 +62074,8 @@
 /turf/open/shuttle/dropship/light_grey_single_wide_up_to_down,
 /area/almayer/powered/agent)
 "vtx" = (
-/obj/structure/machinery/door/airlock/almayer/generic{
-	name = "\improper Bathroom"
-	},
-/turf/open/floor/almayer/test_floor4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/upper_medical)
 "vtG" = (
 /obj/structure/toilet{
@@ -62693,10 +62894,7 @@
 /turf/open/floor/almayer/redfull,
 /area/almayer/command/cic)
 "vIf" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 1;
-	name = "ship-grade camera"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/sterile_green_side,
 /area/almayer/medical/upper_medical)
 "vIg" = (
@@ -63133,11 +63331,16 @@
 /turf/open/floor/almayer,
 /area/almayer/command/computerlab)
 "vQN" = (
-/obj/structure/sign/safety/restrictedarea{
-	pixel_y = -32
+/obj/structure/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/almayer/green,
-/area/almayer/hallways/upper/fore_hallway)
+/obj/structure/surface/table/almayer,
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	pixel_y = 16
+	},
+/turf/open/floor/almayer/sterile_green_corner/east,
+/area/almayer/medical/upper_medical)
 "vQR" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/ship,
@@ -63196,15 +63399,16 @@
 /turf/open/floor/almayer/red/north,
 /area/almayer/hallways/upper/port)
 "vRX" = (
-/obj/structure/surface/table/almayer,
-/obj/item/book/manual/medical_diagnostics_manual,
-/obj/item/device/megaphone,
-/obj/item/device/radio/intercom{
-	freerange = 1;
-	name = "General Listening Channel";
-	pixel_y = 28
+/obj/structure/platform_decoration{
+	dir = 4
 	},
-/turf/open/floor/almayer/sterile_green_corner,
+/obj/structure/platform_decoration{
+	dir = 1
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/upper_medical)
 "vSl" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -63578,12 +63782,20 @@
 /turf/open/floor/almayer,
 /area/almayer/engineering/lower)
 "vXv" = (
-/obj/structure/machinery/light{
+/obj/structure/platform{
 	dir = 1
 	},
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 5;
+	layer = 3.51
+	},
 /obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_10";
-	pixel_y = 14
+	icon_state = "pottedplant_22";
+	pixel_y = 6;
+	pixel_x = 2
 	},
 /turf/open/floor/almayer/mono,
 /area/almayer/medical/upper_medical)
@@ -64156,13 +64368,11 @@
 /turf/open/floor/almayer/orangefull,
 /area/almayer/engineering/upper_engineering)
 "wjz" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N"
+/obj/structure/machinery/light{
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
-/turf/open/floor/almayer/plating/northeast,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_corner/west,
 /area/almayer/medical/upper_medical)
 "wjC" = (
 /obj/structure/closet/firecloset,
@@ -64475,17 +64685,11 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/command/cic)
 "wpu" = (
-/obj/structure/surface/table/reinforced/almayer_B,
-/obj/item/device/flashlight/lamp{
-	pixel_y = 8
+/obj/structure/sign/safety/refridgeration{
+	pixel_y = -32
 	},
-/obj/item/clothing/glasses/science{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/device/flash,
-/turf/open/floor/almayer/mono,
-/area/almayer/medical/upper_medical)
+/turf/open/floor/almayer/green,
+/area/almayer/hallways/upper/fore_hallway)
 "wpI" = (
 /turf/open/floor/almayer/green/east,
 /area/almayer/living/grunt_rnr)
@@ -64527,11 +64731,21 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/starboard_aft_hallway)
 "wqW" = (
-/obj/structure/closet/secure_closet/CMO,
-/obj/structure/machinery/light{
-	dir = 1
+/obj/structure/platform,
+/obj/structure/platform{
+	dir = 8
 	},
-/turf/open/floor/almayer/sterile_green_corner/north,
+/obj/structure/platform_decoration{
+	dir = 10;
+	layer = 3.51
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	pixel_y = 12;
+	pixel_x = 2
+	},
+/turf/open/floor/almayer/mono,
 /area/almayer/medical/upper_medical)
 "wra" = (
 /obj/structure/machinery/light/small{
@@ -65141,12 +65355,11 @@
 /turf/open/floor/almayer/green/north,
 /area/almayer/hallways/lower/port_midship_hallway)
 "wDH" = (
-/obj/structure/morgue,
-/obj/structure/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/medical/morgue)
+/obj/structure/surface/table/almayer,
+/obj/item/book/manual/medical_diagnostics_manual,
+/obj/item/device/megaphone,
+/turf/open/floor/almayer/sterile_green,
+/area/almayer/medical/upper_medical)
 "wDJ" = (
 /turf/open/floor/almayer/emerald/north,
 /area/almayer/squads/charlie_delta_shared)
@@ -65428,14 +65641,7 @@
 /turf/open/floor/plating,
 /area/almayer/shipboard/brig/cryo)
 "wJo" = (
-/obj/structure/machinery/door/airlock/almayer/research/reinforced{
-	access_modified = 1;
-	dir = 1;
-	name = "\improper CMO's Bedroom";
-	req_one_access_txt = "1;5"
-	},
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer/test_floor4,
+/turf/open/floor/almayer/sterile_green_corner/west,
 /area/almayer/medical/upper_medical)
 "wJC" = (
 /obj/structure/largecrate/random/barrel/yellow,
@@ -66024,14 +66230,8 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/living/auxiliary_officer_office)
 "wUd" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/box/gloves{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/item/storage/fancy/candle_box,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/medical/morgue)
+/turf/open/floor/almayer/mono,
+/area/almayer/medical/upper_medical)
 "wUJ" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/almayer/plate,
@@ -66577,10 +66777,7 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/living/briefing)
 "xgP" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 10
-	},
-/turf/open/floor/almayer/mono,
+/turf/open/floor/almayer/sterile_green_corner/north,
 /area/almayer/medical/upper_medical)
 "xgS" = (
 /obj/structure/disposalpipe/segment{
@@ -67114,10 +67311,13 @@
 /turf/open/floor/almayer/sterile_green_side/southeast,
 /area/almayer/medical/lower_medical_medbay)
 "xsz" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "SE-out"
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
-/turf/open/floor/almayer/plating/northeast,
+/obj/structure/machinery/photocopier{
+	layer = 2.9
+	},
+/turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/upper_medical)
 "xsQ" = (
 /obj/structure/surface/table/almayer,
@@ -67135,7 +67335,11 @@
 /area/almayer/maint/lower/constr)
 "xtM" = (
 /obj/structure/machinery/light,
-/turf/open/floor/almayer/sterile_green_side/southeast,
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/turf/open/floor/almayer/sterile_green_side/east,
 /area/almayer/medical/lower_medical_lobby)
 "xub" = (
 /obj/structure/disposalpipe/segment{
@@ -67157,6 +67361,10 @@
 /obj/structure/machinery/light,
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/port_aft_hallway)
+"xur" = (
+/obj/structure/bed/chair/office/dark,
+/turf/open/floor/almayer/sterile_green_side/southwest,
+/area/almayer/medical/morgue)
 "xuy" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -68149,11 +68357,8 @@
 /turf/open/floor/almayer/cargo,
 /area/almayer/hallways/hangar)
 "xNu" = (
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/structure/machinery/light,
-/turf/open/floor/almayer/sterile,
+/obj/structure/flora/bush/ausbushes/lavendergrass,
+/turf/open/gm/grass/grass1,
 /area/almayer/medical/upper_medical)
 "xNv" = (
 /obj/structure/bed/chair/office/dark{
@@ -68684,19 +68889,12 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/living/briefing)
 "xZt" = (
-/obj/structure/sign/safety/refridgeration{
-	pixel_y = -32
+/obj/structure/disposalpipe/segment,
+/obj/structure/machinery/light{
+	dir = 4
 	},
-/obj/structure/sign/safety/medical{
-	pixel_x = 15;
-	pixel_y = -32
-	},
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 1;
-	name = "ship-grade camera"
-	},
-/turf/open/floor/almayer/green,
-/area/almayer/hallways/upper/fore_hallway)
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/medical/morgue)
 "xZG" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -69175,13 +69373,9 @@
 /turf/open/floor/almayer,
 /area/almayer/living/synthcloset)
 "yjb" = (
-/obj/item/device/radio/intercom{
-	freerange = 1;
-	name = "General Listening Channel";
-	pixel_y = 28
-	},
-/turf/open/floor/almayer/sterile_green_side/north,
-/area/almayer/medical/morgue)
+/obj/structure/flora/bush/ausbushes/ausbush,
+/turf/open/gm/grass/grass1,
+/area/almayer/medical/upper_medical)
 "yjq" = (
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	icon_state = "almayer_pdoor";
@@ -73025,7 +73219,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+bdH
 aaa
 aab
 aaa
@@ -73209,27 +73403,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aab
 aaa
 aaa
@@ -73412,27 +73606,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aab
 aaa
 aaa
@@ -73615,27 +73809,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aab
 aaa
 aaa
@@ -73818,27 +74012,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aab
 aaa
 aaa
@@ -74021,27 +74215,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aab
 aaa
 aaa
@@ -74224,27 +74418,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aab
 aaa
 aaa
@@ -74427,27 +74621,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aab
 aaa
 aaa
@@ -74630,27 +74824,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aab
 aaa
 aaa
@@ -74833,27 +75027,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aab
 aaa
 aaa
@@ -75036,27 +75230,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aab
 aaa
 aaa
@@ -75239,27 +75433,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aab
 aaa
 aaa
@@ -75442,27 +75636,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aab
 aaa
 aaa
@@ -75645,27 +75839,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aab
 aaa
 aaa
@@ -75848,27 +76042,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aab
 aaa
 aaa
@@ -76051,27 +76245,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aab
 aaa
 aaa
@@ -76254,27 +76448,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aab
 aaa
 aaa
@@ -76457,27 +76651,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aab
 aaa
 aaa
@@ -76660,27 +76854,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aab
 aaa
 aaa
@@ -76863,27 +77057,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aab
 aaa
 aaa
@@ -77066,27 +77260,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aab
 aaa
 aaa
@@ -77270,25 +77464,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -77473,25 +77667,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -77676,25 +77870,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -77879,25 +78073,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -78082,25 +78276,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -78285,25 +78479,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -78488,25 +78682,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -78691,25 +78885,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -78894,25 +79088,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -79097,25 +79291,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -79300,25 +79494,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -79503,25 +79697,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -79706,25 +79900,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -79909,25 +80103,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -80112,25 +80306,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -80530,9 +80724,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -80729,17 +80923,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -80932,17 +81126,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -81135,17 +81329,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -81338,17 +81532,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -81540,19 +81734,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aab
 aaa
 aaa
@@ -81743,19 +81937,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aab
 aaa
 aaa
@@ -81946,19 +82140,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aab
 aaa
 aaa
@@ -82150,17 +82344,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -82353,17 +82547,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -82556,17 +82750,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -82759,17 +82953,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -82966,9 +83160,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -95706,6 +95900,7 @@ gLl
 gvu
 xCB
 tJm
+rnN
 aoe
 aoe
 aoe
@@ -95723,9 +95918,8 @@ aoe
 aoe
 aoe
 aoe
-aoe
-aoe
-hwB
+rnN
+gvu
 xCB
 kaj
 vIo
@@ -95908,27 +96102,27 @@ qhg
 gLl
 pzw
 xCB
-tJm
-aoe
-aoh
-jHQ
-jkl
-jkl
-jkl
-wDH
-dSJ
-hQU
-pjF
-mcW
 vih
 aoe
+aoe
+jHQ
+hQU
+hQU
+hQU
+hQU
+dSJ
+hQU
+hQU
+mcW
+hQU
+vbS
 imp
 fYb
 cnV
 isN
-cnZ
 aoe
-gvu
+aoe
+hwB
 xCB
 tJm
 vIo
@@ -96111,24 +96305,24 @@ gtI
 kYF
 dME
 nbH
-tJm
+wpu
 aoe
-vbS
-arb
+aoh
+aor
+aor
 aoq
 aoq
 aoq
-aoq
-arb
 ccs
 aoq
 aoq
 aoq
-aor
+aoq
+aoq
+imp
+gzJ
 aEi
-aEi
-cnW
-aEi
+xur
 coa
 aoe
 lXR
@@ -96313,26 +96507,26 @@ gxm
 gxm
 gxm
 lXR
-nbH
-tJm
-aoe
+lYS
+mzn
+hSI
 qQc
-fXg
+pMp
+xZt
+hVz
+hVz
 dfa
-dfa
-dfa
-dfa
-dfa
-gzK
+rxc
 arb
 arb
 arb
+aEN
 aor
-sKa
+eSN
 sKa
 jBy
 aEi
-fFh
+aHa
 aoe
 gvu
 nbH
@@ -96519,21 +96713,21 @@ gpp
 xCB
 tJm
 aoe
-vbS
-koB
-asU
-asU
-asU
-asU
-arb
-fEC
 aoe
 aoe
+aoe
+aoe
+aor
+aor
+aoq
+aoq
+aor
+aor
 aCw
-aoe
-aoe
-aoe
-aoe
+aGW
+aGW
+aGW
+fvd
 hFF
 aoe
 aoe
@@ -96636,7 +96830,7 @@ gGJ
 qjN
 qjN
 qjN
-qjN
+bho
 xtM
 baZ
 sbE
@@ -96720,21 +96914,21 @@ aps
 gxm
 sHC
 nbH
-tJm
-aoe
+pjO
+ajl
 aop
 koB
+aRF
+aoe
 jkl
+mNI
 jkl
-jkl
-jkl
-arb
 ayW
-aoe
+bqa
 lFn
-imp
-kEp
-aoe
+aLS
+aGW
+rSq
 tsC
 uRt
 aQz
@@ -96922,25 +97116,25 @@ aps
 aps
 gxm
 gvu
-lYS
-mzn
-hSI
-pMp
+nbH
+tJm
+ajl
+ajl
 gzK
-aoq
-aoq
-aoq
-aoq
-aoq
-aoq
-aAG
-aBd
-aEi
+ajl
+aoe
+aoe
+aoe
+aoe
+aoe
+aoe
+aoe
+aoe
 aGW
-aRF
-akx
-akw
-aQz
+anq
+tsC
+uRt
+onQ
 aRK
 ajl
 aUB
@@ -97126,23 +97320,23 @@ asm
 gxm
 gvu
 lSN
-xZt
-aoe
+tJm
+ajl
 pjF
 wUd
+wub
 asU
-asU
-asU
-fFO
+ajl
+ajl
+ajl
 mrL
-mrL
-aoe
+rGc
 yjb
-aEN
-aGX
-aoe
-aLS
-akw
+ajl
+sqf
+dwA
+tsC
+uRt
 fOL
 aRS
 ajl
@@ -97329,25 +97523,25 @@ asm
 gxm
 gvu
 nbH
-vQN
-sqf
-sqf
-sqf
-sqf
-sqf
-sqf
-sqf
+tJm
+ajl
+qhx
+hbI
+uGk
+fFh
 ajl
 ajl
-ajl
+nHP
+xNu
+cnW
 aCo
 aEO
-aHa
-aoe
+sqf
+sqf
 cXW
 upM
 akw
-alD
+vtx
 vEx
 dME
 nbH
@@ -97533,24 +97727,24 @@ gxm
 gvu
 nbH
 tJm
-sqf
-anp
-wjz
+ajl
+ajl
+ajl
 fnA
-jZY
-jZY
-sqf
-wpu
+ajl
+ajl
+xNu
+aCo
 okO
+vRX
+aAG
+kbn
+aCo
 ajl
-ajl
-ajl
-ajl
-ajl
-ajl
-ajl
-onQ
-alD
+iGA
+aos
+akw
+txW
 ajl
 bgN
 nbH
@@ -97736,26 +97930,26 @@ gxm
 gvu
 xCB
 tJm
-sqf
+ajl
 sOZ
 oNJ
+axm
 eDo
-eDo
-eDo
-sqf
-vXv
-wub
-gXl
 ajl
+pth
+vXv
+olz
+gXl
+aCp
 wqW
 awj
-dDL
+ajl
 aLZ
-ajl
-aCp
+akw
+akw
 alD
-ajl
-evM
+gWG
+gvu
 xCB
 tJm
 gxm
@@ -97939,24 +98133,24 @@ gxm
 gvu
 lSN
 kaj
-sqf
-anq
-awn
+ajl
+cnZ
+akw
 xsz
 jTj
-jTj
-sqf
+ajl
+yjb
 lmi
 xgP
-dwA
+axm
 wJo
 cyU
-eme
-skl
+anp
+ajl
 nzv
 fQu
-akx
-alD
+rrD
+vQN
 gWG
 gvu
 xCB
@@ -98142,26 +98336,26 @@ gxm
 gvu
 xCB
 tJm
-sqf
+ajl
 anr
-awn
+eme
 tEi
 asu
-hbI
-sqf
 ajl
+ajl
+rkK
 vtx
-ajl
-ajl
+axm
+akw
 kgp
-fbB
-cyU
-bho
-fQu
+ajl
+ajl
+ajl
+fEC
 akx
-alD
-gWG
-gvu
+ajl
+ajl
+evM
 xCB
 tJm
 gxm
@@ -98345,24 +98539,24 @@ gxm
 hwB
 xCB
 tJm
-sqf
-sqf
+ajl
+skl
 awp
-sqf
-sqf
-sqf
-sqf
-mNI
-sdn
-xNu
-ajl
-vRX
-pth
 axm
-lhv
+jZY
+wDH
 ajl
-hVz
-alD
+ajl
+sdn
+axm
+dDL
+ajl
+ajl
+nMV
+lhv
+aBd
+alE
+wjz
 ajl
 lXR
 xCB
@@ -98549,22 +98743,22 @@ atz
 nbH
 tyC
 ajl
-qhx
-akw
+gKR
+gKR
 axl
 gKR
-fvd
+gKR
 ajl
 ajl
 ajl
+fbB
 ajl
 ajl
-sYT
-sYT
+kEp
 tWY
 sYT
-ajl
-nMV
+pJl
+akw
 vIf
 ajl
 hwB
@@ -98752,23 +98946,23 @@ gre
 nbH
 dME
 bVE
-aos
-akw
-akw
-akw
-alE
-ans
-ans
-asw
-ans
-ans
 ans
 ans
 axm
 ans
+aGX
+aGX
 ans
-aos
-alE
+ans
+axm
+ans
+aGX
+fFO
+akw
+akw
+akw
+akw
+akw
 bVE
 dME
 nbH
@@ -98956,20 +99150,20 @@ hWa
 cEG
 aEe
 akA
-akA
-akA
+kln
+asw
 akA
 jOG
 akA
 akA
 akA
+fXg
 akA
-rnN
 akA
 akA
 maT
 akA
-akA
+awn
 oap
 aSb
 aEe

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -2588,8 +2588,11 @@
 	dir = 8
 	},
 /obj/structure/sign/safety/terminal{
-	pixel_x = -3;
+	pixel_x = -10;
 	pixel_y = -27
+	},
+/obj/structure/closet/secure_closet/professor_dummy{
+	pixel_y = -30
 	},
 /turf/open/floor/almayer/sterile_green_side,
 /area/almayer/medical/upper_medical)


### PR DESCRIPTION
# About the pull request

This PR adds a new room to the upper medical "Psychiatric Care Unit" deeply inspired by alien Dark descent this area aims to provide a place for the stressed marine to unwind

This RP also rearranges the upper medical to accommodate this new room

![jRi0vtt](https://github.com/user-attachments/assets/e572d0d2-cdc6-4b4d-a7bc-128ac0df64e3)
https://i.imgur.com/QIYsiOz.png
https://i.imgur.com/MGY6GTe.png

# Explain why it's good for the game

The room serves as both a neat nod to dark descent as well as a place for potential roleplay to accure, CMO conducting psychological evaluations for the MPs, marines stressed from the retreat from the planet trying to unwind quietly or just somewhere to relax before briefing 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: SpartanBobby
maptweak: Rearranges Almayer Upper Medical to accommodate a Psychiatric Care Unit
/:cl:
