### PR TITLE
Fixes working joe not being able to use ai lockdown/nerve gas in pda

### DIFF
--- a/tgui/packages/tgui/interfaces/WorkingJoe.jsx
+++ b/tgui/packages/tgui/interfaces/WorkingJoe.jsx
@@ -251,7 +251,7 @@ const MainMenu = (props) => {
           </Stack>
         )}
       </Section>
-      {(access_level === 4 || access_level >= 6) && (
+      {(access_level === 4 || access_level >= 5) && (
         <Section>
           <h1 align="center">Core Security Protocols</h1>
           <Stack>

--- a/tgui/packages/tgui/interfaces/WorkingJoe.jsx
+++ b/tgui/packages/tgui/interfaces/WorkingJoe.jsx
@@ -251,7 +251,7 @@ const MainMenu = (props) => {
           </Stack>
         )}
       </Section>
-      {(access_level === 4 || access_level >= 5) && (
+      {access_level >= 4 && (
         <Section>
           <h1 align="center">Core Security Protocols</h1>
           <Stack>


### PR DESCRIPTION

# About the pull request

Title

![iR6puUmRUG](https://github.com/user-attachments/assets/4e18b79c-e501-4e37-a0a9-903d3109a44b)


# Changelog
:cl:
fix: fixed working joe not being able to use ai lockdown/nerve gas
/:cl:
