### PR TITLE
makes launchbay useable on transport

### DIFF
--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -841,6 +841,7 @@
 	bound_height = 32
 	equip_categories = list(DROPSHIP_CREW_WEAPON) //fits inside the central spot of the dropship
 	point_cost = 200
+	fire_mission_only = FALSE
 	shorthand = "LCH"
 
 /obj/structure/dropship_equipment/weapon/launch_bay/update_equipment()


### PR DESCRIPTION

# About the pull request

allows launchbay to be used on transport run

# Explain why it's good for the game

gives transport pilot stuff they can possibly do and they can already use any otehr attchemnt on transport run that need you to be still for way longer then launchbay and it is on wiki that it is useable


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: launchbay is now useable on transport run
/:cl:
