### PR TITLE
Gibbed ghosts appear as their character instead of a brain

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -1,5 +1,6 @@
 /mob/living/carbon/human/gib(datum/cause_data/cause = create_cause_data("gibbing", src))
 	var/is_a_synth = issynth(src)
+	ghostize() 
 	for(var/obj/limb/E in limbs)
 		if(istype(E, /obj/limb/chest))
 			continue
@@ -131,5 +132,5 @@
 	else if(death_data?.cause_name == "existing")
 		// Corpses spawn as gibbed true to avoid sfx, even though they aren't actually gibbed...
 		AddComponent(/datum/component/weed_food)
-	
+
 	update_execute_hud()


### PR DESCRIPTION
# About the pull request

The ghost can still re-enter the body if theyre recoverable from gibbing (like synths)

# Explain why it's good for the game

I think it looks better than just being a brain

# Changelog

:cl:
add: When gibbed, the ghost will stay as the character instead of turning into a brain
/:cl:
