### PR TITLE
Adds check status and stethoscope usage to examining

### DIFF
--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -106,56 +106,60 @@
 	icon_state = "stethoscope"
 
 /obj/item/clothing/accessory/stethoscope/attack(mob/living/carbon/human/being, mob/living/user)
-	if(ishuman(being) && isliving(user))
-		if(user.a_intent == INTENT_HELP)
-			var/body_part = parse_zone(user.zone_selected)
-			if(body_part)
-				var/sound = null
-				if(being.stat == DEAD || (being.status_flags&FAKEDEATH))
-					sound = "can't hear anything at all, they must have kicked the bucket"
-				else
-					switch(body_part)
-						if("chest")
-							if(skillcheck(user, SKILL_MEDICAL, SKILL_MEDICAL_MEDIC)) // only medical personnel can take advantage of it
-								if(!ishuman(being))
-									return // not a human; only humans have the variable internal_organs_by_name // "cast" it a human type since we confirmed it is one
-								if(isnull(being.internal_organs_by_name))
-									return // they have no organs somehow
-								var/datum/internal_organ/heart/heart = being.internal_organs_by_name["heart"]
-								if(heart)
-									switch(heart.organ_status)
-										if(ORGAN_LITTLE_BRUISED)
-											sound = "hear <font color='yellow'>small murmurs with each heart beat</font>, it is possible that [being.p_their()] heart is <font color='yellow'>subtly damaged</font>"
-										if(ORGAN_BRUISED)
-											sound = "hear <font color='orange'>deviant heart beating patterns</font>, result of probable <font color='orange'>heart damage</font>"
-										if(ORGAN_BROKEN)
-											sound = "hear <font color='red'>irregular and additional heart beating patterns</font>, probably caused by impaired blood pumping, [being.p_their()] heart is certainly <font color='red'>failing</font>"
-										else
-											sound = "hear <font color='green'>normal heart beating patterns</font>, [being.p_their()] heart is surely <font color='green'>healthy</font>"
-								var/datum/internal_organ/lungs/lungs = being.internal_organs_by_name["lungs"]
-								if(lungs)
-									if(sound)
-										sound += ". You also "
-									switch(lungs.organ_status)
-										if(ORGAN_LITTLE_BRUISED)
-											sound += "hear <font color='yellow'>some crackles when [being.p_they()] breath</font>, [being.p_they()] is possibly suffering from <font color='yellow'>a small damage to the lungs</font>"
-										if(ORGAN_BRUISED)
-											sound += "hear <font color='orange'>unusual respiration sounds</font> and noticeable difficulty to breath, possibly signalling <font color='orange'>ruptured lungs</font>"
-										if(ORGAN_BROKEN)
-											sound += "<font color='red'>barely hear any respiration sounds</font> and a lot of difficulty to breath, [being.p_their()] lungs are <font color='red'>heavily failing</font>"
-										else
-											sound += "hear <font color='green'>normal respiration sounds</font> aswell, that means [being.p_their()] lungs are <font color='green'>healthy</font>, probably"
-								else
-									sound = "can't hear. Really, anything at all, how weird"
-							else
-								sound = "hear a lot of sounds... it's quite hard to distinguish, really"
-						if("eyes","mouth")
-							sound = "can't hear anything. Maybe that isn't the smartest idea"
+	if(!ishuman(being) || !isliving(user))
+		return
+
+	var/body_part = parse_zone(user.zone_selected)
+	if(!body_part)
+		return
+
+	var/sound = null
+	if(being.stat == DEAD || (being.status_flags & FAKEDEATH))
+		sound = "can't hear anything at all, they must have kicked the bucket"
+		user.visible_message("[user] places [src] against [being]'s [body_part] and listens attentively.", "You place [src] against [being.p_their()] [body_part] and... you [sound].")
+		return
+
+	switch(body_part)
+		if("chest")
+			if(skillcheck(user, SKILL_MEDICAL, SKILL_MEDICAL_MEDIC)) // only medical personnel can take advantage of it
+				if(!ishuman(being))
+					return // not a human; only humans have the variable internal_organs_by_name // "cast" it a human type since we confirmed it is one
+				if(isnull(being.internal_organs_by_name))
+					return // they have no organs somehow
+				var/datum/internal_organ/heart/heart = being.internal_organs_by_name["heart"]
+				if(heart)
+					switch(heart.organ_status)
+						if(ORGAN_LITTLE_BRUISED)
+							sound = "hear <font color='yellow'>small murmurs with each heart beat</font>, it is possible that [being.p_their()] heart is <font color='yellow'>subtly damaged</font>"
+						if(ORGAN_BRUISED)
+							sound = "hear <font color='orange'>deviant heart beating patterns</font>, result of probable <font color='orange'>heart damage</font>"
+						if(ORGAN_BROKEN)
+							sound = "hear <font color='red'>irregular and additional heart beating patterns</font>, probably caused by impaired blood pumping, [being.p_their()] heart is certainly <font color='red'>failing</font>"
 						else
-							sound = "hear a sound here and there, but none of them give you any good information"
-				user.visible_message("[user] places [src] against [being]'s [body_part] and listens attentively.", "You place [src] against [being.p_their()] [body_part] and... you [sound].")
-				return
-	return ..(being,user)
+							sound = "hear <font color='green'>normal heart beating patterns</font>, [being.p_their()] heart is surely <font color='green'>healthy</font>"
+				var/datum/internal_organ/lungs/lungs = being.internal_organs_by_name["lungs"]
+				if(lungs)
+					if(sound)
+						sound += ". You also "
+					switch(lungs.organ_status)
+						if(ORGAN_LITTLE_BRUISED)
+							sound += "hear <font color='yellow'>some crackles when [being.p_they()] breath</font>, [being.p_they()] is possibly suffering from <font color='yellow'>a small damage to the lungs</font>"
+						if(ORGAN_BRUISED)
+							sound += "hear <font color='orange'>unusual respiration sounds</font> and noticeable difficulty to breath, possibly signalling <font color='orange'>ruptured lungs</font>"
+						if(ORGAN_BROKEN)
+							sound += "<font color='red'>barely hear any respiration sounds</font> and a lot of difficulty to breath, [being.p_their()] lungs are <font color='red'>heavily failing</font>"
+						else
+							sound += "hear <font color='green'>normal respiration sounds</font> aswell, that means [being.p_their()] lungs are <font color='green'>healthy</font>, probably"
+				else
+					sound = "can't hear. Really, anything at all, how weird"
+			else
+				sound = "hear a lot of sounds... it's quite hard to distinguish, really"
+		if("eyes","mouth")
+			sound = "can't hear anything. Maybe that isn't the smartest idea"
+		else
+			sound = "hear a sound here and there, but none of them give you any good information"
+	user.visible_message("[user] places [src] against [being]'s [body_part] and listens attentively.", "You place [src] against [being.p_their()] [body_part] and... you [sound].")
+
 
 //Medals
 /obj/item/clothing/accessory/medal

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -497,6 +497,12 @@
 			if(assigned_squad == H.assigned_squad) //same squad
 				msg += "<a href='?src=\ref[src];squadfireteam=1'>\[Manage Fireteams.\]</a>\n"
 
+	if(user.Adjacent(src) && ishuman(user))
+		var/mob/living/carbon/human/human_user = user
+		var/temp_msg = "<a href='?src=\ref[src];check_status=1'>\[Check Status\]</a>"
+		if(skillcheck(user, SKILL_MEDICAL, SKILL_MEDICAL_MEDIC) && locate(/obj/item/clothing/accessory/stethoscope) in human_user.w_uniform)
+			temp_msg += " <a href='?src=\ref[src];use_stethoscope=1'>\[Use Stethoscope\]</a>"
+		msg += "\n<span class = 'deptradio'>Medical actions: [temp_msg]\n"
 
 	if(print_flavor_text())
 		msg += "[print_flavor_text()]\n"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -772,6 +772,21 @@
 					if(R.fields["last_scan_time"] && R.fields["last_scan_result"])
 						tgui_interact(usr)
 					break
+
+	if(href_list["check_status"])
+		if(!usr.Adjacent(src))
+			return
+		var/mob/living/carbon/human/user = usr
+		user.check_status(src)
+
+	if(href_list["use_stethoscope"])
+		var/mob/living/carbon/human/user = usr
+		var/obj/item/clothing/accessory/stethoscope/stethoscope = locate() in user.w_uniform
+		if(!stethoscope || !user.Adjacent(src))
+			return
+
+		stethoscope.attack(src, user)
+
 	..()
 	return
 
@@ -990,45 +1005,44 @@
 		if(prob(30)) // Spam chat less
 			to_chat(src, SPAN_HIGHDANGER("Your movement jostles [W] in your [organ.display_name] painfully."))
 
-/mob/living/carbon/human/verb/check_status()
-	set category = "Object"
-	set name = "Check Status"
-	set src in view(1)
-	var/self = (usr == src)
-	var/msg = ""
-
-
-	if(usr.stat > 0 || usr.is_mob_restrained() || !ishuman(usr)) return
+/mob/living/carbon/human/proc/check_status(mob/living/carbon/human/target)
+	if(is_dead() || is_mob_restrained())
+		return
+	///Final message detailing injuries on the target.
+	var/msg
+	///Is the target the user or somebody else?
+	var/self = (target == src)
+	to_chat(usr,SPAN_NOTICE("You [self ? "take a moment to analyze yourself." : "start analyzing [src]."]"))
 
 	if(self)
-		var/list/L = get_broken_limbs() - list("chest","head","groin")
-		if(length(L) > 0)
-			msg += "Your [english_list(L)] [length(L) > 1 ? "are" : "is"] broken\n"
-	to_chat(usr,SPAN_NOTICE("You [self ? "take a moment to analyze yourself":"start analyzing [src]"]"))
-	if(toxloss > 20)
-		msg += "[self ? "Your" : "Their"] skin is slightly green\n"
-	if(is_bleeding())
-		msg += "[self ? "You" : "They"] have bleeding wounds on [self ? "your" : "their"] body\n"
+		var/list/broken_limbs = target.get_broken_limbs() - list("chest","head","groin")
+		if(length(broken_limbs))
+			msg += "Your [english_list(broken_limbs)] [length(broken_limbs) > 1 ? "are" : "is"] broken.\n"
+	if(target.toxloss > 20)
+		msg += "[self ? "Your" : "Their"] skin is slightly green.\n"
+
+	if(target.is_bleeding())
+		msg += "[self ? "You" : "They"] have bleeding wounds on [self ? "your" : "their"] body.\n"
 
 	if(!self && skillcheck(usr, SKILL_SURGERY, SKILL_SURGERY_NOVICE))
-		for(var/datum/effects/bleeding/internal/internal_bleed in effects_list)
-			msg += "They have bloating and discoloration on their [internal_bleed.limb.display_name]\n"
+		for(var/datum/effects/bleeding/internal/internal_bleed in target.effects_list)
+			msg += "They have bloating and discoloration on their [internal_bleed.limb.display_name].\n"
 
-	if(stat == UNCONSCIOUS)
-		msg += "They seem to be unconscious\n"
-	else if(stat == DEAD)
-		if(src.check_tod() && is_revivable())
-			msg += "They're not breathing"
-		else
-			if(has_limb("head"))
-				msg += "Their eyes have gone blank, there are no signs of life"
+	switch(target.stat)
+		if(DEAD)
+			if(target.check_tod() && target.is_revivable())
+				msg += "They're not breathing."
 			else
-				msg += "They are definitely dead"
-	else
-		msg += "[self ? "You're":"They're"] alive and breathing"
+				if(has_limb("head"))
+					msg += "Their eyes have gone blank, there are no signs of life."
+				else
+					msg += "They are definitely dead."
+		if(UNCONSCIOUS)
+			msg += "They seem to be unconscious.\n"
+		if(CONSCIOUS)
+			msg += "[self ? "You're" : "They're"] alive and breathing."
 
-
-	to_chat(usr,SPAN_WARNING(msg))
+	to_chat(src, SPAN_WARNING(msg))
 
 
 /mob/living/carbon/human/verb/view_manifest()


### PR DESCRIPTION

# About the pull request

human mobs can now directly use check status/the stethoscope attached to their uniform if they examine a mob

# Explain why it's good for the game

stethoscope is pretty good but having to fiddle around with your uniform to take it off constantly is annoying. check status is a pretty informational verb but the problem is that it's a verb, so it's stuck behind a right click menu. this is more direct and lets people use them a tad more easily

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>


https://github.com/user-attachments/assets/17b99ed0-38d3-4c0f-8913-bfde24af82f0



</details>


# Changelog
:cl:
qol: You can now use the 'check status' verb and any stethoscope you might have attached to your uniform directly by examining an adjacent human.
/:cl:
