### PR TITLE
Fixes HTML Entity Codes In bug reports

### DIFF
--- a/code/datums/bug_report.dm
+++ b/code/datums/bug_report.dm
@@ -56,7 +56,7 @@
 
 /datum/tgui_bug_report_form/proc/sanitize_payload(list/params)
 	for(var/param in params)
-		params[param] = sanitize(params[param], list("\t"=" ","�"=" "))
+		params[param] = sanitize(params[param], list("\t"=" ","�"=" ","<"=" ",">"=" ","&"=" "))
 
 	return params
 


### PR DESCRIPTION
# About the pull request

Fixes #7449

HTML Entity Codes should not be displayed in bug reports the <, >, and & symbols are safely discarded during the sanitization process before the payload is sent through the API. 

This change is untested, if it needs further improvement in the future lmk. We probably have some decent existing procs to help sanitize text and could just use those instead. 

# Explain why it's good 
Whoever is reviewing and fixing bugs shouldn't have their eyes burdened by html entity codes. 
I makea dah buga, I fixa dah bug.

Edit: Seems to be working, no HTML Entity Codes: #7476.

# Changelog

:cl:
fix: Special characters are now properly sanitized and removed in bug reports.  
/:cl:

