### PR TITLE
Fix sentry additional shots and sentry flamer cause_data

### DIFF
--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -313,7 +313,7 @@
 	new_projectile.damage *= damage_mult
 	new_projectile.accuracy *= accuracy_mult
 	GIVE_BULLET_TRAIT(new_projectile, /datum/element/bullet_trait_iff, faction_group)
-	new_projectile.fire_at(target, src, owner_mob, new_projectile.ammo.max_range, new_projectile.ammo.shell_speed, null, FALSE)
+	new_projectile.fire_at(target, owner_mob, src, new_projectile.ammo.max_range, new_projectile.ammo.shell_speed, null, FALSE)
 	muzzle_flash(Get_Angle(get_turf(src), target))
 	ammo.current_rounds--
 	track_shot()

--- a/code/modules/defenses/sentry_flamer.dm
+++ b/code/modules/defenses/sentry_flamer.dm
@@ -32,7 +32,7 @@
 	var/obj/projectile/P = new(create_cause_data(initial(name), owner_mob))
 	P.generate_bullet(new ammo.default_ammo)
 	GIVE_BULLET_TRAIT(P, /datum/element/bullet_trait_iff, faction_group)
-	P.fire_at(A, src, owner_mob, P.ammo.max_range, P.ammo.shell_speed, null)
+	P.fire_at(A, owner_mob, src, P.ammo.max_range, P.ammo.shell_speed, null)
 	ammo.current_rounds--
 	track_shot()
 	if(ammo.current_rounds == 0)

--- a/code/modules/defenses/sentry_flamer.dm
+++ b/code/modules/defenses/sentry_flamer.dm
@@ -28,11 +28,11 @@
 			accuracy_mult = 0.1
 			fire_delay = 0.5
 
-/obj/structure/machinery/defenses/sentry/flamer/actual_fire(atom/A)
-	var/obj/projectile/P = new(create_cause_data(initial(name), owner_mob))
-	P.generate_bullet(new ammo.default_ammo)
-	GIVE_BULLET_TRAIT(P, /datum/element/bullet_trait_iff, faction_group)
-	P.fire_at(A, owner_mob, src, P.ammo.max_range, P.ammo.shell_speed, null)
+/obj/structure/machinery/defenses/sentry/flamer/actual_fire(atom/target)
+	var/obj/projectile/new_projectile = new(src, create_cause_data(initial(name), owner_mob, src))
+	new_projectile.generate_bullet(new ammo.default_ammo)
+	GIVE_BULLET_TRAIT(new_projectile, /datum/element/bullet_trait_iff, faction_group)
+	new_projectile.fire_at(target, owner_mob, src, new_projectile.ammo.max_range, new_projectile.ammo.shell_speed, null, FALSE)
 	ammo.current_rounds--
 	track_shot()
 	if(ammo.current_rounds == 0)


### PR DESCRIPTION

# About the pull request

This PR is a follow-up to #7406 correcting an issue where sentries swapped the shooter and firer vars to fix #7045. It also corrects the erroneous initialization for flamer sentries so now they will actually attribute kills to the sentry and explain in the death message both the sentry and owner.

# Explain why it's good for the game

Fixes additional projectiles being fired from humans that placed a shotgun sentry; the shots are supposed to be from the sentry not magically from the player somewhere else. Also improves the death messages for flamer sentry kills and actually attributes kills to the sentry.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![sentry](https://github.com/user-attachments/assets/aae7c676-216b-4c18-a7df-9781c5e83c26)
![image](https://github.com/user-attachments/assets/e7db396c-b36d-4ec8-b952-7f623a29b735)

</details>

# Changelog
:cl: Drathek
fix: Fixes additional projectiles being fired from humans that placed a shotgun sentry instead of the sentry.
fix: Fixes cause_data for flamer sentries so now kills they make are explained in the message and attributed to the kill counter for the sentry.
/:cl:
