### PR TITLE
Fix underbarrel flamethrower refilling

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -2996,9 +2996,16 @@ Defined in conflicts.dm of the #defines folder.
 			to_chat(user, SPAN_WARNING("[src] is full."))
 			return
 
-		var/datum/reagent/to_remove
-		if(length(fuel_holder.reagents.reagent_list))
-			to_remove = fuel_holder.reagents.reagent_list[1]
+		if(!fuel_holder.reagents || length(fuel_holder.reagents.reagent_list) < 1)
+			to_chat(user, SPAN_WARNING("[fuel_holder] is empty!"))
+			return
+
+		var/datum/reagent/to_remove = fuel_holder.reagents.reagent_list[1]
+
+		var/flamer_chem = "utnapthal"
+		if(!istype(to_remove) || flamer_chem != to_remove.id || length(fuel_holder.reagents.reagent_list) > 1)
+			to_chat(user, SPAN_WARNING("You can't mix fuel mixtures!"))
+			return
 
 		var/fuel_amt
 		if(to_remove)


### PR DESCRIPTION
# About the pull request

This PR adds some additional checks when refilling an underbarrel attachment flamethrower to ensure the reagent being reloaded is naptha from a flamer tank. Currently welder packs should still allow refilling it since they use their own implementation.

# Explain why it's good for the game

Fixes #7462 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/030dbea0-e185-450b-9da2-ff5b2bd8ac7c)

</details>


# Changelog
:cl: Drathek
fix: Fix reloading under barrel flamers with any reagent from a flamer tank
/:cl:
