### PR TITLE
Buff to Smartgunner AP ammo

### DIFF
--- a/code/datums/ammo/bullet/special_ammo.dm
+++ b/code/datums/ammo/bullet/special_ammo.dm
@@ -20,6 +20,7 @@
 	name = "armor-piercing smartgun bullet"
 	icon_state = "bullet"
 
+	damage_falloff = DAMAGE_FALLOFF_TIER_7
 	accurate_range = 12
 	accuracy = HIT_ACCURACY_TIER_2
 	damage = 20

--- a/code/datums/ammo/bullet/special_ammo.dm
+++ b/code/datums/ammo/bullet/special_ammo.dm
@@ -20,7 +20,7 @@
 	name = "armor-piercing smartgun bullet"
 	icon_state = "bullet"
 
-	damage_falloff = DAMAGE_FALLOFF_TIER_7
+	damage_falloff = DAMAGE_FALLOFF_TIER_8
 	accurate_range = 12
 	accuracy = HIT_ACCURACY_TIER_2
 	damage = 20


### PR DESCRIPTION

# About the pull request

This PR is a follow-up to #7428 where AP ammo didn't get adjusted since fall off values are flat not percentage.

Essentially now SG regular ammo will be at 0.667% power on screen edge (20) and armor penetrating ammo will be at 0.7% power on screen edge (14). Prior to this change, armor penetrating ammo would be at 50% power on screen edge (10).

# Explain why it's good for the game

Was not intended for one ammo type to be nerfed heavier than the other for SG.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
balance: Buffed SG armor penetration ammo damage falloff from 5 to 3.
/:cl:
