### PR TITLE
Fix button.confirm not displaying anything if it has no confirm content

### DIFF
--- a/tgui/packages/tgui/components/Button.tsx
+++ b/tgui/packages/tgui/components/Button.tsx
@@ -256,7 +256,7 @@ const ButtonConfirm = (props: ConfirmProps) => {
       }}
       {...rest}
     >
-      {clickedOnce ? confirmContent : children}
+      {clickedOnce && confirmContent ? confirmContent : children}
     </Button>
   );
 };


### PR DESCRIPTION
# About the pull request

This PR is a follow-up to #5777 and #6244 because Button.Confirm was changed how its confirm content was displayed. It used to display the children always, but TG since changed it to display either the confirm content or the children. Now the children will be displayed if there is no confirm content set.

# Explain why it's good for the game

Fixes confusing buttons in the ping relay browser.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Before:
![image](https://github.com/user-attachments/assets/a48b01e9-ca8d-4521-9ac5-8f4cfb07f6eb)

After:
![image](https://github.com/user-attachments/assets/46151d2f-139c-4f30-b4fb-0892572bf64f)

</details>

# Changelog
:cl: Drathek
ui: Fixed the ping relay buttons not displaying anything when clicked on the first time. Now Button.Confirm.confirmContent will only replace children if it is truthy.
/:cl:
