### PR TITLE
Clears invalid loadout gear/restricts to actual point value.

### DIFF
--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -77,3 +77,23 @@
 			if(65 to 70) . += ascii2text(ascii+32) //letters A to F - translates to lowercase
 			else return default
 	return .
+
+/proc/sanitize_gear(list/gear, client/user)
+	var/list/sanitized_gear = list()
+	var/running_cost = 0
+
+	for(var/gear_option in gear)
+		if(!GLOB.gear_datums_by_name[gear_option])
+			continue
+
+		var/datum/gear/gear_datum = GLOB.gear_datums_by_name[gear_option]
+		var/new_total = running_cost + gear_datum.cost
+
+		if(new_total > MAX_GEAR_COST)
+			to_chat(user, SPAN_WARNING("Your [gear_option] was removed from your loadout as it exceeded the point limit."))
+			continue
+
+		running_cost = new_total
+		sanitized_gear += gear_option
+
+	return sanitized_gear

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -648,7 +648,7 @@
 	if(!organ_data)
 		organ_data = list()
 
-	gear = sanitize_list(gear)
+	gear = sanitize_gear(gear, owner)
 
 	traits = sanitize_list(traits)
 	read_traits = FALSE


### PR DESCRIPTION

# About the pull request
If you're above the cap when it comes to points used in the loadout, now the loadout item/gear will be removed.

# Explain why it's good for the game
You have a set amount of points for a reason, this hinders people staying above the point cap after changes are made to cost or even new/old things are added or removed.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Nanu, HarryOb
code: Adds some code so if you're above the pointcap on your loadout, items will be removed to put you at the point cap limit.
/:cl:
