### PR TITLE
More OD pragmas: Pointless positional argument, ambiguous in order, and proc argument global

### DIFF
--- a/code/__pragmas.dm
+++ b/code/__pragmas.dm
@@ -22,6 +22,9 @@
 #pragma DanglingVarType error
 #pragma MissingInterpolatedExpression error
 #pragma InvalidIndexOperation error
+#pragma PointlessPositionalArgument error
+#pragma ProcArgumentGlobal error
 
 //3000-3999
 #pragma EmptyBlock error
+#pragma AmbiguousInOrder error

--- a/code/controllers/subsystem/objectives_controller.dm
+++ b/code/controllers/subsystem/objectives_controller.dm
@@ -314,7 +314,7 @@ SUBSYSTEM_DEF(objectives)
 	for(var/datum/cm_objective/objective in medium_value)
 		while(LAZYLEN(objective.required_objectives) < objective.number_of_clues_to_generate && LAZYLEN(low_value))
 			var/datum/cm_objective/req = pick(low_value)
-			if(req in objective.required_objectives || (req.objective_flags & OBJECTIVE_DEAD_END))
+			if((req in objective.required_objectives) || (req.objective_flags & OBJECTIVE_DEAD_END))
 				continue //don't want to pick the same thing twice OR use a dead-end objective.
 			link_objectives(req, objective)
 
@@ -327,7 +327,7 @@ SUBSYSTEM_DEF(objectives)
 	for(var/datum/cm_objective/objective in high_value)
 		while(LAZYLEN(objective.required_objectives) < objective.number_of_clues_to_generate && LAZYLEN(medium_value))
 			var/datum/cm_objective/req = pick(medium_value)
-			if(req in objective.required_objectives || (req.objective_flags & OBJECTIVE_DEAD_END))
+			if((req in objective.required_objectives) || (req.objective_flags & OBJECTIVE_DEAD_END))
 				continue //don't want to pick the same thing twice OR use a dead-end objective.
 			link_objectives(req, objective)
 
@@ -340,7 +340,7 @@ SUBSYSTEM_DEF(objectives)
 	for(var/datum/cm_objective/objective in extreme_value)
 		while(LAZYLEN(objective.required_objectives) < objective.number_of_clues_to_generate && LAZYLEN(high_value))
 			var/datum/cm_objective/req = pick(high_value)
-			if(req in objective.required_objectives || (req.objective_flags & OBJECTIVE_DEAD_END))
+			if((req in objective.required_objectives) || (req.objective_flags & OBJECTIVE_DEAD_END))
 				continue //don't want to pick the same thing twice OR use a dead-end objective.
 			link_objectives(req, objective)
 
@@ -353,7 +353,7 @@ SUBSYSTEM_DEF(objectives)
 	for(var/datum/cm_objective/objective in absolute_value)
 		while(LAZYLEN(objective.required_objectives) < objective.number_of_clues_to_generate && LAZYLEN(extreme_value))
 			var/datum/cm_objective/req = pick(extreme_value)
-			if(req in objective.required_objectives || (req.objective_flags & OBJECTIVE_DEAD_END))
+			if((req in objective.required_objectives) || (req.objective_flags & OBJECTIVE_DEAD_END))
 				continue //don't want to pick the same thing twice OR use a dead-end objective.
 			link_objectives(req, objective)
 

--- a/code/datums/global_variables.dm
+++ b/code/datums/global_variables.dm
@@ -211,7 +211,7 @@
 			to_chat(src, "A variable with this name ([param_var_name]) doesn't exist among global variables")
 			return
 
-		if(param_var_name in locked && !check_rights(R_DEBUG))
+		if((param_var_name in locked) && !check_rights(R_DEBUG))
 			return
 
 		variable = param_var_name
@@ -270,7 +270,7 @@
 		if(!variable) return
 		var_value = global.vars[variable]
 
-		if(variable in locked && !check_rights(R_DEBUG))
+		if((variable in locked) && !check_rights(R_DEBUG))
 			return
 
 	if(!autodetect_class)

--- a/code/game/gamemodes/cm_process.dm
+++ b/code/game/gamemodes/cm_process.dm
@@ -254,7 +254,7 @@ GLOBAL_VAR_INIT(next_admin_bioscan, 30 MINUTES)
 	for(var/mob/living/carbon/human/current_human as anything in GLOB.alive_human_list)
 		if(!(current_human.z && (current_human.z in z_levels) && !istype(current_human.loc, /turf/open/space)))
 			continue
-		if(current_human.faction in FACTION_LIST_WY || current_human.job == "Corporate Liaison") //The CL is assigned the USCM faction for gameplay purposes
+		if((current_human.faction in FACTION_LIST_WY) || current_human.job == "Corporate Liaison") //The CL is assigned the USCM faction for gameplay purposes
 			num_WY++
 			num_headcount++
 			continue

--- a/code/game/machinery/robot_fabricator.dm
+++ b/code/game/machinery/robot_fabricator.dm
@@ -112,7 +112,7 @@ Please wait until completion...</TT><BR>
 					build_cost = 75000
 
 			var/building = build_type
-			if (building in subtypesof(/obj/item/robot_parts) + /obj/item/fake_robot_head)
+			if (building in (subtypesof(/obj/item/robot_parts) + /obj/item/fake_robot_head))
 				if (src.metal_amount >= build_cost)
 					src.operating = 1
 					src.update_use_power(USE_POWER_ACTIVE)

--- a/code/modules/buildmode/submodes/variable_edit.dm
+++ b/code/modules/buildmode/submodes/variable_edit.dm
@@ -27,7 +27,7 @@
 	var/list/locked = list("vars", "key", "ckey", "client", "icon")
 
 	selected_key = input(usr,"Enter variable name:" ,"Name", "name")
-	if(selected_key in locked && !check_rights(R_DEBUG,0))
+	if((selected_key in locked) && !check_rights(R_DEBUG, FALSE))
 		return TRUE
 	var/type = tgui_input_list(usr,"Select variable type:", "Type", list(TYPE_TEXT, TYPE_NUMBER, TYPE_MOB_REFERENCE, TYPE_OBJ_REFERENCE, TYPE_TURF_REFERENCE))
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -905,7 +905,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 			conga_line += S.buckled
 	while(!end_of_conga)
 		var/atom/movable/A = S.pulling
-		if(A in conga_line || A.anchored) //No loops, nor moving anchored things.
+		if((A in conga_line) || A.anchored) //No loops, nor moving anchored things.
 			end_of_conga = TRUE
 			break
 		conga_line += A


### PR DESCRIPTION
# About the pull request

This PR adds more open dream pragmas to lint for logic errors:
- PointlessPositionalArgument: A new pragma has been added for detecting pointless positional arguments in procs, not lists
- AmbiguousInOrder: A new pragma has been added for detecting ambiguous uses of `in` with unexpected behavior, similar to the lint in SpacemanDMM/DreamChecker. An example is `"a" in a || "b" in b` being parsed as `("a" in (a || "b")) in b`.
- ProcArgumentGlobal: A new pragma has been added for detecting this BYOND bug: https://www.byond.com/forum/post/2830750
When a proc argument begins with /var/ instead of var/, it creates a global variable instead of an argument.

# Explain why it's good for the game

More robust code.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
code: Enabled 3 more OD pragmas for linting and fixed some ambiguous usage of In 
/:cl:
