### PR TITLE
Makes Sentinel's Scatter Spit a bit more consistent

### DIFF
--- a/code/datums/ammo/xeno.dm
+++ b/code/datums/ammo/xeno.dm
@@ -127,7 +127,6 @@
 	accuracy_var_high = PROJECTILE_VARIANCE_TIER_6
 	accurate_range = 5
 	max_range = 5
-	scatter = SCATTER_AMOUNT_NEURO
 	bonus_projectiles_amount = EXTRA_PROJECTILES_TIER_4
 
 /datum/ammo/xeno/toxin/shotgun/New()
@@ -138,6 +137,7 @@
 /datum/ammo/xeno/toxin/shotgun/additional
 	name = "additional neurotoxic droplets"
 
+	scatter = SCATTER_AMOUNT_NEURO
 	bonus_projectiles_amount = 0
 
 /datum/ammo/xeno/acid


### PR DESCRIPTION
# About the pull request

Moves scatter value from Scatter Spits main projectile to its bonus projectiles.

# Explain why it's good for the game

Since Scatter Spits scatter normally applies its scatter to every projectile including the main one, it means you can completely miss whoever it is you're actaully targeting, and in practice this feels like it happens more often than not. This gives consistency by ensuring at least 1 of your total 5 projectiles will go in the direction you want it to, as opposed to currently where it's damn a near coin toss if they hit who you're targeting or veer of around them instead.

Balance tag may be warrented at maintainer discretion.

# Testing Photographs and Procedure

Found Scatter Spit projectile code, moved scatter value from main projectile to additional projectile. Debated adding comparatively minor scatter (15) to main projectile too, but found it was not meaningfully inaccurate enough to justify having that over no scatter at all.

# Changelog

:cl: Killfish
balance: Improved consistency of Scatter Spits accuracy. Now one of your projectiles is guaranteed to to go in the direction you're aiming at, instead of potentially going everywhere except where you're aiming and missing everything.
/:cl:
