### PR TITLE
Nukes Le'pro

### DIFF
--- a/code/_globalvars/lists/names.dm
+++ b/code/_globalvars/lists/names.dm
@@ -38,5 +38,5 @@ GLOBAL_LIST_INIT(monkey_names, list("Abu", "Aldo", "Bear", "Bingo", "Clyde", "Cr
 
 GLOBAL_LIST_INIT(weapon_surnames, list("Adze", "Axe", "Bagh Nakha", "Bo", "Bola", "Bow", "Bowman", "Cannon", "Carbine", "Cestus", "Club", "Culverin", "Dagger", "Dao", "Derringer", "Dha", "Dussack", "Emeici", "Falchion", "Fan", "Flyssa", "Gauntlet", "Hammer", "Halberd", "Harquebus", "Hatchet", "Hwando", "Katar", "Kampilan", "Knuckles", "Lance", "Lancer", "Larim", "Maduvu", "Mace", "Maru", "Mauser", "Messer", "Mine", "Mubucae", "Nyepel", "Onager", "Pata", "Pike", "Ram", "Saber", "Seax", "Shamsir", "Sickle", "Sling", "Spear", "Spears", "Staff", "Sword", "Tekko"))
 
-GLOBAL_LIST_INIT(pred_names, list("Nu'koir", "Za-ai'stba", "Au'stbep", "Gihn'thih-thill", "Au'stbep", "Tud'tab", "Gehtu-a", "U-dan'dchu", "Bua'dtu", "A'ytein", "Yu-thwuahtou", "Yon'ta", "Pan'teiat", "Ban'ti", "Ve'thiad", "Ga-aiteith", "A'kah", "Dachande"))
-GLOBAL_LIST_INIT(pred_last_names, list("Tha'jo", "ba'ytui", "Thwa'dtei-t'all", "vah'ka"))
+GLOBAL_LIST_INIT(pred_names, list("Nu'koir", "Za-ai'stba", "Au'stbep", "Gihn'thill", "Au'stbep", "Tud'tab", "Gehtu-a", "U-dan'dchu", "Bua'dtu", "A'ytein", "Yu-thwuahtou", "Yon'ta", "Pan'teiat", "Ban'ti", "Ve'thiad", "Ga-aiteith", "A'kah", "Dachande"))
+GLOBAL_LIST_INIT(pred_last_names, list("Tha'jo", "Ba'ytui", "Thwa'dtei", "Vah'ka"))

--- a/code/_globalvars/lists/names.dm
+++ b/code/_globalvars/lists/names.dm
@@ -37,3 +37,6 @@ GLOBAL_LIST_INIT(first_names_female_dutch, list("Chelsea", "Mira", "Jessica", "C
 GLOBAL_LIST_INIT(monkey_names, list("Abu", "Aldo", "Bear", "Bingo", "Clyde", "Crystal", "Gordo", "George", "Koko", "Marcel", "Nim", "Rafiki", "Spike", "Banana", "Boots", "Bubbles", "Smiley", "Winston"))
 
 GLOBAL_LIST_INIT(weapon_surnames, list("Adze", "Axe", "Bagh Nakha", "Bo", "Bola", "Bow", "Bowman", "Cannon", "Carbine", "Cestus", "Club", "Culverin", "Dagger", "Dao", "Derringer", "Dha", "Dussack", "Emeici", "Falchion", "Fan", "Flyssa", "Gauntlet", "Hammer", "Halberd", "Harquebus", "Hatchet", "Hwando", "Katar", "Kampilan", "Knuckles", "Lance", "Lancer", "Larim", "Maduvu", "Mace", "Maru", "Mauser", "Messer", "Mine", "Mubucae", "Nyepel", "Onager", "Pata", "Pike", "Ram", "Saber", "Seax", "Shamsir", "Sickle", "Sling", "Spear", "Spears", "Staff", "Sword", "Tekko"))
+
+GLOBAL_LIST_INIT(pred_names, list("Nu'koir", "Za-ai'stba", "Au'stbep", "Gihn'thih-thill", "Au'stbep", "Tud'tab", "Gehtu-a", "U-dan'dchu", "Bua'dtu", "A'ytein", "Yu-thwuahtou", "Yon'ta", "Pan'teiat", "Ban'ti", "Ve'thiad", "Ga-aiteith", "A'kah", "Dachande"))
+GLOBAL_LIST_INIT(pred_last_names, list("Tha'jo", "ba'ytui", "Thwa'dtei-t'all", "vah'ka"))

--- a/code/modules/gear_presets/yautja.dm
+++ b/code/modules/gear_presets/yautja.dm
@@ -44,7 +44,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/yautja/hunter(new_human, translator_type, caster_material, clan_rank), WEAR_HANDS)
 
 /datum/equipment_preset/yautja/load_name(mob/living/carbon/human/new_human, randomise)
-	var/final_name = "Le'pro"
+	var/final_name = capitalize(pick(GLOB.pred_names)) + " " + capitalize(pick(GLOB.pred_last_names))
 	new_human.gender = MALE
 	new_human.age = 100
 	new_human.flavor_text = ""
@@ -57,7 +57,7 @@
 		new_human.flavor_text = new_human.client.prefs.predator_flavor_text
 		new_human.flavor_texts["general"] = new_human.flavor_text
 		if(!final_name || final_name == "Undefined") //In case they don't have a name set or no prefs, there's a name.
-			final_name = "Le'pro"
+			final_name = capitalize(pick(GLOB.pred_names)) + " " + capitalize(pick(GLOB.pred_last_names))
 	new_human.change_real_name(new_human, final_name)
 
 // YOUNG BLOOD


### PR DESCRIPTION

# About the pull request
Removes Le'pro from code adds random names for admin spawned preds

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Having names for preds spawned by admins is better than it being le'pro
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Added first names for spawned preds
add: Added last names for spawned preds
/:cl:
