### PR TITLE
Remove `ability_name` var from xeno_actions

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Abilities.dm
@@ -105,7 +105,6 @@
 /datum/action/xeno_action/onclick/screech
 	name = "Screech (250)"
 	action_icon_state = "screech"
-	ability_name = "screech"
 	macro_path = /datum/action/xeno_action/verb/verb_screech
 	action_type = XENO_ACTION_CLICK
 	xeno_cooldown = 50 SECONDS
@@ -168,7 +167,6 @@
 /datum/action/xeno_action/activable/gut
 	name = "Gut (200)"
 	action_icon_state = "gut"
-	ability_name = "gut"
 	macro_path = /datum/action/xeno_action/verb/verb_gut
 	action_type = XENO_ACTION_CLICK
 	xeno_cooldown = 15 MINUTES
@@ -282,7 +280,6 @@
 /datum/action/xeno_action/activable/queen_give_plasma
 	name = "Give Plasma (400)"
 	action_icon_state = "queen_give_plasma"
-	ability_name = "give plasma"
 	plasma_cost = 400
 	macro_path = /datum/action/xeno_action/verb/verb_plasma_xeno
 	action_type = XENO_ACTION_CLICK

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -310,7 +310,7 @@
 				return
 
 
-	visible_message(SPAN_DANGER("[src] [pounceAction.ability_name] onto [M]!"), SPAN_XENODANGER("We [pounceAction.ability_name] onto [M]!"), null, 5)
+	visible_message(SPAN_DANGER("[src] [pounceAction.action_text] onto [M]!"), SPAN_XENODANGER("We [pounceAction.action_text] onto [M]!"), null, 5)
 
 	if (pounceAction.knockdown)
 		M.KnockDown(pounceAction.knockdown_duration)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ability_macro_framework.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ability_macro_framework.dm
@@ -20,8 +20,8 @@
 			handle_xeno_macro_actionqueue(xeno, action)
 
 		else
-			log_debug("Xeno action [action.ability_name] is misconfigured. Code: XENO_ACTION_MACRO_1")
-			log_admin("Xeno action [action.ability_name] is misconfigured. Tell the devs. Code: XENO_ACTION_MACRO_1")
+			log_debug("Xeno action [action.name] is misconfigured. Code: XENO_ACTION_MACRO_1")
+			log_admin("Xeno action [action.name] is misconfigured. Tell the devs. Code: XENO_ACTION_MACRO_1")
 
 
 /proc/handle_xeno_macro_click(mob/living/carbon/xenomorph/xeno, datum/action/xeno_action/action)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_abilities.dm
@@ -7,7 +7,6 @@
 
 /datum/action/xeno_action/activable/acid_lance
 	name = "Acid Lance"
-	ability_name = "acid lance"
 	action_icon_state = "acid_lance"
 	plasma_cost = 50
 	macro_path = /datum/action/xeno_action/verb/verb_acid_lance
@@ -50,7 +49,6 @@
 
 /datum/action/xeno_action/activable/xeno_spit/bombard
 	name = "Bombard"
-	ability_name = "Bombard"
 	action_icon_state = "bombard"
 	cooldown_message = "Our belly fills with another gas glob. We are ready to bombard again."
 	sound_to_play = 'sound/effects/blobattack.ogg'
@@ -65,7 +63,6 @@
 
 /datum/action/xeno_action/onclick/acid_shroud  // acid dump alternative
 	name = "Acid Shroud"
-	ability_name = "Acid Shroud"
 	action_icon_state = "acid_shroud"
 	action_type = XENO_ACTION_ACTIVATE
 	ability_primacy = XENO_PRIMARY_ACTION_5
@@ -90,7 +87,6 @@
 
 /datum/action/xeno_action/activable/boiler_trap
 	name = "Deploy Trap"
-	ability_name = "deploy trap"
 	action_icon_state = "resin_pit"
 	plasma_cost = 60
 	macro_path = /datum/action/xeno_action/verb/verb_boiler_trap
@@ -106,7 +102,6 @@
 
 /datum/action/xeno_action/activable/acid_mine
 	name = "Acid Mine"
-	ability_name = "acid mine"
 	action_icon_state = "acid_mine"
 	plasma_cost = 40
 	macro_path = /datum/action/xeno_action/verb/verb_acid_mine
@@ -121,7 +116,6 @@
 
 /datum/action/xeno_action/activable/acid_shotgun
 	name = "Acid Shotgun"
-	ability_name = "acid shotgun"
 	action_icon_state = "acid_shotgun"
 	plasma_cost = 60
 	macro_path = /datum/action/xeno_action/verb/verb_acid_shotgun

--- a/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/burrower/burrower_abilities.dm
@@ -4,7 +4,6 @@
 /datum/action/xeno_action/activable/burrow
 	name = "Burrow"
 	action_icon_state = "agility_on"
-	ability_name = "burrow"
 	macro_path = /datum/action/xeno_action/verb/verb_burrow
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_3
@@ -25,7 +24,6 @@
 /datum/action/xeno_action/onclick/tremor
 	name = "Tremor (100)"
 	action_icon_state = "stomp"
-	ability_name = "tremor"
 	macro_path = /datum/action/xeno_action/verb/verb_tremor
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_4

--- a/code/modules/mob/living/carbon/xenomorph/abilities/carrier/carrier_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/carrier/carrier_abilities.dm
@@ -1,7 +1,6 @@
 /datum/action/xeno_action/activable/throw_hugger
 	name = "Use/Throw Facehugger"
 	action_icon_state = "throw_hugger"
-	ability_name = "throw facehugger"
 	macro_path = /datum/action/xeno_action/verb/verb_throw_facehugger
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_3
@@ -15,7 +14,6 @@
 /datum/action/xeno_action/activable/retrieve_egg
 	name = "Retrieve Egg"
 	action_icon_state = "retrieve_egg"
-	ability_name = "retrieve egg"
 	macro_path = /datum/action/xeno_action/verb/verb_retrieve_egg
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_4

--- a/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
@@ -1,7 +1,7 @@
 /datum/action/xeno_action/activable/pounce/crusher_charge
 	name = "Charge"
 	action_icon_state = "ready_charge"
-	ability_name = "charge"
+	action_text = "charge"
 	macro_path = /datum/action/xeno_action/verb/verb_crusher_charge
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_1
@@ -35,7 +35,6 @@
 /datum/action/xeno_action/onclick/crusher_stomp
 	name = "Stomp"
 	action_icon_state = "stomp"
-	ability_name = "stomp"
 	macro_path = /datum/action/xeno_action/verb/verb_crusher_stomp
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_2
@@ -63,7 +62,6 @@
 /datum/action/xeno_action/onclick/crusher_shield
 	name = "Defensive Shield"
 	action_icon_state = "empower"
-	ability_name = "defensive shield"
 	macro_path = /datum/action/xeno_action/verb/verb_crusher_charge
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_3
@@ -74,7 +72,6 @@
 /datum/action/xeno_action/activable/fling/charger
 	name = "Headbutt"
 	action_icon_state = "ram"
-	ability_name = "Headbutt"
 	macro_path = /datum/action/xeno_action/verb/verb_fling
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_4
@@ -253,7 +250,6 @@
 
 /datum/action/xeno_action/activable/tumble
 	name = "Tumble"
-	ability_name = "tumble"
 	action_icon_state = "tumble"
 	macro_path = /datum/action/xeno_action/verb/verb_crusher_tumble
 	action_type = XENO_ACTION_CLICK

--- a/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_abilities.dm
@@ -1,7 +1,6 @@
 /datum/action/xeno_action/onclick/toggle_crest
 	name = "Toggle Crest Defense"
 	action_icon_state = "crest_defense"
-	ability_name = "toggle crest defense"
 	macro_path = /datum/action/xeno_action/verb/verb_toggle_crest
 	action_type = XENO_ACTION_ACTIVATE
 	xeno_cooldown = 1.5 SECONDS
@@ -14,7 +13,6 @@
 /datum/action/xeno_action/activable/headbutt
 	name = "Headbutt"
 	action_icon_state = "headbutt"
-	ability_name = "headbutt"
 	macro_path = /datum/action/xeno_action/verb/verb_headbutt
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_2
@@ -30,7 +28,6 @@
 /datum/action/xeno_action/onclick/tail_sweep
 	name = "Tail Sweep"
 	action_icon_state = "tail_sweep"
-	ability_name = "tail sweep"
 	macro_path = /datum/action/xeno_action/verb/verb_tail_sweep
 	action_type = XENO_ACTION_ACTIVATE
 	ability_primacy = XENO_PRIMARY_ACTION_3
@@ -40,7 +37,6 @@
 /datum/action/xeno_action/activable/fortify
 	name = "Fortify"
 	action_icon_state = "fortify"
-	ability_name = "fortify"
 	macro_path = /datum/action/xeno_action/verb/verb_fortify
 	action_type = XENO_ACTION_ACTIVATE
 	ability_primacy = XENO_PRIMARY_ACTION_4
@@ -54,13 +50,11 @@
 
 /datum/action/xeno_action/activable/tail_stab/slam
 	name = "Tail Slam"
-	ability_name = "tail slam"
 	blunt_stab = TRUE
 
 /datum/action/xeno_action/onclick/soak
 	name = "Soak"
 	action_icon_state = "soak"
-	ability_name = "soak"
 	macro_path = /datum/action/xeno_action/verb/verb_soak
 	action_type = XENO_ACTION_ACTIVATE
 	ability_primacy = XENO_PRIMARY_ACTION_3

--- a/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_abilities.dm
@@ -1,7 +1,7 @@
 /datum/action/xeno_action/activable/pounce/facehugger
 	name = "Leap"
 	action_icon_state = "pounce"
-	ability_name = "leap"
+	action_text = "leap"
 	macro_path = /datum/action/xeno_action/verb/verb_pounce
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_1

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
@@ -18,7 +18,6 @@
 
 /datum/action/xeno_action/onclick/plant_weeds
 	name = "Plant Weeds (75)"
-	ability_name = "Plant Weeds"
 	action_icon_state = "plant_weeds"
 	plasma_cost = 75
 	macro_path = /datum/action/xeno_action/verb/verb_plant_weeds
@@ -84,7 +83,6 @@
 /datum/action/xeno_action/activable/secrete_resin
 	name = "Secrete Resin"
 	action_icon_state = "secrete_resin"
-	ability_name = "secrete resin"
 	var/thick = FALSE
 	var/make_message = TRUE
 	macro_path = /datum/action/xeno_action/verb/verb_secrete_resin
@@ -117,7 +115,6 @@
 /datum/action/xeno_action/activable/info_marker
 	name = "Mark Resin"
 	action_icon_state = "mark"
-	ability_name = "mark resin"
 	macro_path = /datum/action/xeno_action/verb/verb_mark_resin
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_NOT_PRIMARY_ACTION
@@ -138,7 +135,6 @@
 /datum/action/xeno_action/activable/corrosive_acid
 	name = "Corrosive Acid (100)"
 	action_icon_state = "corrosive_acid"
-	ability_name = "corrosive acid"
 	var/acid_plasma_cost = 100
 	var/level = 2 //level of the acid strength
 	var/acid_type = /obj/effect/xenomorph/acid
@@ -194,7 +190,7 @@
 /datum/action/xeno_action/activable/pounce
 	name = "Pounce"
 	action_icon_state = "pounce"
-	ability_name = "pounce"
+	var/action_text = "pounce"
 	macro_path = /datum/action/xeno_action/verb/verb_pounce
 	action_type = XENO_ACTION_CLICK
 	xeno_cooldown = 40
@@ -357,7 +353,7 @@
 /datum/action/xeno_action/activable/spray_acid
 	name = "Spray Acid"
 	action_icon_state = "spray_acid"
-	ability_name = "spray acid"
+	var/action_text = "spray acid"
 	macro_path = /datum/action/xeno_action/verb/verb_spray_acid
 	action_type = XENO_ACTION_CLICK
 
@@ -378,7 +374,6 @@
 /datum/action/xeno_action/activable/transfer_plasma
 	name = "Transfer Plasma"
 	action_icon_state = "transfer_plasma"
-	ability_name = "transfer plasma"
 	var/plasma_transfer_amount = 50
 	var/transfer_delay = 20
 	var/max_range = 2
@@ -433,7 +428,6 @@
 /datum/action/xeno_action/activable/place_construction
 	name = "Order Construction (400)"
 	action_icon_state = "morph_resin"
-	ability_name = "order construction"
 	macro_path = /datum/action/xeno_action/verb/place_construction
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_5
@@ -444,7 +438,6 @@
 /datum/action/xeno_action/activable/xeno_spit
 	name = "Xeno Spit"
 	action_icon_state = "xeno_spit"
-	ability_name = "xeno spit"
 	macro_path = /datum/action/xeno_action/verb/verb_xeno_spit
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_1
@@ -461,7 +454,6 @@
 
 /datum/action/xeno_action/activable/bombard
 	name = "Bombard"
-	ability_name = "bombard"
 	action_icon_state = "bombard"
 	plasma_cost = 75
 	macro_path = /datum/action/xeno_action/verb/verb_bombard
@@ -479,7 +471,6 @@
 /datum/action/xeno_action/activable/tail_stab
 	name = "Tail Stab"
 	action_icon_state = "tail_attack"
-	ability_name = "tail stab"
 	action_type = XENO_ACTION_CLICK
 	charge_time = 1 SECONDS
 	xeno_cooldown = 10 SECONDS
@@ -510,7 +501,6 @@
 /datum/action/xeno_action/onclick/tacmap
 	name = "View Tactical Map"
 	action_icon_state = "toggle_queen_zoom"
-	ability_name = "view tacmap"
 
 	var/mob/living/carbon/xenomorph/queen/tracked_queen
 	var/hivenumber

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -384,14 +384,14 @@
 		return
 
 	if(!isturf(X.loc))
-		to_chat(X, SPAN_XENOWARNING("We can't [ability_name] from here!"))
+		to_chat(X, SPAN_XENOWARNING("We can't [action_text] from here!"))
 		return
 
 	if(!X.check_state())
 		return
 
 	if(X.legcuffed)
-		to_chat(X, SPAN_XENODANGER("We can't [ability_name] with that thing on our leg!"))
+		to_chat(X, SPAN_XENODANGER("We can't [action_text] with that thing on our leg!"))
 		return
 
 	if(!check_and_use_plasma_owner())
@@ -418,7 +418,7 @@
 		pre_windup_effects()
 
 		if (!do_after(X, windup_duration, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE))
-			to_chat(X, SPAN_XENODANGER("We cancel our [ability_name]!"))
+			to_chat(X, SPAN_XENODANGER("We cancel our [action_text]!"))
 			if (!windup_interruptable)
 				REMOVE_TRAIT(X, TRAIT_IMMOBILIZED, TRAIT_SOURCE_ABILITY("Pounce"))
 				X.anchored = FALSE
@@ -430,7 +430,7 @@
 			X.anchored = FALSE
 		post_windup_effects()
 
-	X.visible_message(SPAN_XENOWARNING("\The [X] [ability_name][findtext(ability_name, "e", -1) || findtext(ability_name, "p", -1) ? "s" : "es"] at [A]!"), SPAN_XENOWARNING("We [ability_name] at [A]!"))
+	X.visible_message(SPAN_XENOWARNING("\The [X] [action_text][findtext(action_text, "e", -1) || findtext(action_text, "p", -1) ? "s" : "es"] at [A]!"), SPAN_XENOWARNING("We [action_text] at [A]!"))
 
 	pre_pounce_effects()
 
@@ -456,7 +456,7 @@
 		return
 
 	if(!isturf(X.loc))
-		to_chat(X, SPAN_XENOWARNING("We can't [ability_name] from here!"))
+		to_chat(X, SPAN_XENOWARNING("We can't [action_text] from here!"))
 		return
 
 	if(!X.check_state() || X.action_busy)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/lurker/lurker_abilities.dm
@@ -14,7 +14,6 @@
 /datum/action/xeno_action/onclick/lurker_invisibility
 	name = "Turn Invisible"
 	action_icon_state = "lurker_invisibility"
-	ability_name = "turn invisible"
 	macro_path = /datum/action/xeno_action/verb/verb_lurker_invisibility
 	ability_primacy = XENO_PRIMARY_ACTION_2
 	action_type = XENO_ACTION_CLICK
@@ -29,7 +28,6 @@
 /datum/action/xeno_action/onclick/lurker_assassinate
 	name = "Crippling Strike"
 	action_icon_state = "lurker_inject_neuro"
-	ability_name = "crippling strike"
 	macro_path = /datum/action/xeno_action/verb/verb_crippling_strike
 	ability_primacy = XENO_PRIMARY_ACTION_3
 	action_type = XENO_ACTION_ACTIVATE
@@ -43,7 +41,7 @@
 /datum/action/xeno_action/activable/pounce/rush
 	name = "Rush"
 	action_icon_state = "pounce"
-	ability_name = "rush"
+	action_text = "rush"
 	macro_path = /datum/action/xeno_action/verb/verb_rush
 	ability_primacy = XENO_PRIMARY_ACTION_1
 	action_type = XENO_ACTION_CLICK
@@ -58,7 +56,6 @@
 /datum/action/xeno_action/activable/flurry
 	name = "Flurry"
 	action_icon_state = "rav_spike"
-	ability_name = "flurry"
 	macro_path = /datum/action/xeno_action/verb/verb_flurry
 	ability_primacy = XENO_PRIMARY_ACTION_2
 	action_type = XENO_ACTION_CLICK
@@ -67,7 +64,6 @@
 /datum/action/xeno_action/activable/tail_jab
 	name = "Tail Jab"
 	action_icon_state = "prae_pierce"
-	ability_name = "tail jab"
 	macro_path = /datum/action/xeno_action/verb/verb_tail_jab
 	ability_primacy = XENO_PRIMARY_ACTION_3
 	action_type = XENO_ACTION_CLICK
@@ -76,7 +72,6 @@
 /datum/action/xeno_action/activable/headbite
 	name = "Headbite"
 	action_icon_state = "headbite"
-	ability_name = "headbite"
 	macro_path = /datum/action/xeno_action/verb/verb_headbite
 	ability_primacy = XENO_PRIMARY_ACTION_4
 	action_type = XENO_ACTION_CLICK

--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
@@ -6,7 +6,6 @@
 /datum/action/xeno_action/activable/pierce
 	name = "Pierce"
 	action_icon_state = "prae_pierce"
-	ability_name = "pierce"
 	macro_path = /datum/action/xeno_action/verb/verb_pierce
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_1
@@ -21,7 +20,7 @@
 /datum/action/xeno_action/activable/pounce/prae_dash
 	name = "Dash"
 	action_icon_state = "prae_dash"
-	ability_name = "dash"
+	action_text = "dash"
 	macro_path = /datum/action/xeno_action/verb/verb_dash
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_2
@@ -47,7 +46,6 @@
 /datum/action/xeno_action/activable/cleave
 	name = "Cleave"
 	action_icon_state = "prae_cleave_action"
-	ability_name = "cleave"
 	macro_path = /datum/action/xeno_action/verb/verb_cleave
 	ability_primacy = XENO_PRIMARY_ACTION_3
 	action_type = XENO_ACTION_CLICK
@@ -111,7 +109,6 @@
 /datum/action/xeno_action/activable/tail_stab/tail_seize //no verbmacrohotkey, its just tail stab.
 	name = "Tail Seize"
 	action_icon_state = "tail_seize"
-	ability_name = "tail seize"
 	action_type = XENO_ACTION_CLICK
 	charge_time = 0.5 SECONDS
 	xeno_cooldown = 15 SECONDS
@@ -120,7 +117,6 @@
 /datum/action/xeno_action/activable/prae_abduct
 	name = "Abduct"
 	action_icon_state = "abduct"
-	ability_name = "abduct"
 	macro_path = /datum/action/xeno_action/verb/verb_prae_abduct
 	ability_primacy = XENO_PRIMARY_ACTION_1
 	action_type = XENO_ACTION_CLICK
@@ -134,7 +130,6 @@
 /datum/action/xeno_action/activable/oppressor_punch
 	name = "Dislocate"
 	action_icon_state = "punch"
-	ability_name = "dislocate"
 	macro_path = /datum/action/xeno_action/verb/verb_oppressor_punch
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_2
@@ -150,7 +145,7 @@
 /*datum/action/xeno_action/onclick/crush
 	name = "Crush"
 	action_icon_state = "prae_crush"
-	ability_name = "crush"
+	action_text = "crush"
 	macro_path = /datum/action/xeno_action/verb/verb_crush
 	action_type = XENO_ACTION_ACTIVATE
 	xeno_cooldown = 100
@@ -160,7 +155,6 @@
 /datum/action/xeno_action/activable/tail_lash
 	name = "Tail Lash"
 	action_icon_state = "prae_tail_lash"
-	ability_name = "tail lash"
 	macro_path = /datum/action/xeno_action/verb/verb_crush
 	ability_primacy = XENO_PRIMARY_ACTION_3
 	action_type = XENO_ACTION_CLICK
@@ -176,7 +170,6 @@
 /datum/action/xeno_action/activable/prae_impale
 	name = "Impale"
 	action_icon_state = "prae_impale"
-	ability_name = "impale"
 	macro_path = /datum/action/xeno_action/verb/verb_prae_impale
 	ability_primacy = XENO_PRIMARY_ACTION_1
 	action_type = XENO_ACTION_CLICK
@@ -186,7 +179,6 @@
 /datum/action/xeno_action/onclick/prae_dodge
 	name = "Dodge"
 	action_icon_state = "prae_dodge"
-	ability_name = "dodge"
 	macro_path = /datum/action/xeno_action/verb/verb_prae_dodge
 	ability_primacy = XENO_PRIMARY_ACTION_2
 	action_type = XENO_ACTION_CLICK
@@ -200,7 +192,6 @@
 /datum/action/xeno_action/activable/prae_tail_trip
 	name = "Tail Trip"
 	action_icon_state = "prae_tail_trip"
-	ability_name = "tail trip"
 	macro_path = /datum/action/xeno_action/verb/verb_prae_tail_trip
 	ability_primacy = XENO_PRIMARY_ACTION_3
 	action_type = XENO_ACTION_CLICK
@@ -220,7 +211,7 @@
 /datum/action/xeno_action/activable/pounce/base_prae_dash
 	name = "Dash"
 	action_icon_state = "prae_dash"
-	ability_name = "dash"
+	action_text = "dash"
 	macro_path = /datum/action/xeno_action/verb/verb_dash
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_2
@@ -236,7 +227,6 @@
 /datum/action/xeno_action/activable/prae_acid_ball
 	name = "Acid Ball"
 	action_icon_state = "prae_acid_ball"
-	ability_name = "acid ball"
 	macro_path = /datum/action/xeno_action/verb/verb_acid_ball
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_3
@@ -249,7 +239,6 @@
 /datum/action/xeno_action/activable/spray_acid/base_prae_spray_acid
 	name = "Spray Acid"
 	action_icon_state = "spray_acid"
-	ability_name = "spray acid"
 	macro_path = /datum/action/xeno_action/verb/verb_spray_acid
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_4
@@ -284,7 +273,6 @@
 /datum/action/xeno_action/activable/warden_heal
 	name = "Aid Xenomorph"
 	action_icon_state = "prae_aid"
-	ability_name = "aid"
 	// todo: macro
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_3
@@ -349,7 +337,6 @@
 /datum/action/xeno_action/activable/prae_retrieve
 	name = "Retrieve"
 	action_icon_state = "retrieve"
-	ability_name = "retrieve"
 	macro_path = /datum/action/xeno_action/verb/verb_prae_retrieve
 	ability_primacy = XENO_PRIMARY_ACTION_4
 	action_type = XENO_ACTION_CLICK

--- a/code/modules/mob/living/carbon/xenomorph/abilities/predalien/predalien_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/predalien/predalien_abilities.dm
@@ -2,7 +2,6 @@
 /datum/action/xeno_action/onclick/feralrush
 	name = "Feral Rush"
 	action_icon_state = "charge_spit"
-	ability_name = "toughen up"
 	macro_path = /datum/action/xeno_action/verb/verb_feralrush
 	ability_primacy = XENO_PRIMARY_ACTION_1
 	action_type = XENO_ACTION_ACTIVATE
@@ -21,7 +20,6 @@
 /datum/action/xeno_action/onclick/predalien_roar
 	name = "Roar"
 	action_icon_state = "screech"
-	ability_name = "roar"
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_2
 	macro_path = /datum/action/xeno_action/verb/verb_predalien_roar
@@ -32,7 +30,6 @@
 
 /datum/action/xeno_action/activable/feral_smash
 	name = "Feral Smash"
-	ability_name = "Feral Smash"
 	action_icon_state = "lunge"
 	action_type = XENO_ACTION_CLICK
 	macro_path = /datum/action/xeno_action/verb/feral_smash
@@ -49,7 +46,6 @@
 /datum/action/xeno_action/activable/feralfrenzy
 	name = "Feral Frenzy"
 	action_icon_state = "rav_eviscerate"
-	ability_name = "Feral Frenzy"
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_4
 	macro_path = /datum/action/xeno_action/verb/verb_feralfrenzy

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_abilities.dm
@@ -20,7 +20,6 @@
 /datum/action/xeno_action/activable/queen_heal
 	name = "Heal Xenomorph (600)"
 	action_icon_state = "heal_xeno"
-	ability_name = "xenomorph heal"
 	plasma_cost = 600
 	macro_path = /datum/action/xeno_action/verb/verb_heal_xeno
 	ability_primacy = XENO_PRIMARY_ACTION_1
@@ -30,7 +29,6 @@
 /datum/action/xeno_action/activable/expand_weeds
 	name = "Expand Weeds (50)"
 	action_icon_state = "plant_weeds"
-	ability_name = "weed expansion"
 	plasma_cost = 50
 	ability_primacy = XENO_PRIMARY_ACTION_3
 	action_type = XENO_ACTION_CLICK
@@ -48,7 +46,6 @@
 /datum/action/xeno_action/activable/secrete_resin/remote/queen
 	name = "Projected Resin (100)"
 	action_icon_state = "secrete_resin"
-	ability_name = "projected resin"
 	plasma_cost = 100
 	xeno_cooldown = 4 SECONDS
 	ability_primacy = XENO_PRIMARY_ACTION_5
@@ -129,7 +126,6 @@
 /datum/action/xeno_action/activable/place_queen_beacon
 	name = "Place Queen Beacon"
 	action_icon_state = "place_queen_beacon"
-	ability_name = "place queen beacon"
 	plasma_cost = 0
 	action_type = XENO_ACTION_CLICK
 
@@ -166,7 +162,6 @@
 /datum/action/xeno_action/activable/blockade
 	name = "Place Blockade"
 	action_icon_state = "place_blockade"
-	ability_name = "place blockade"
 	plasma_cost = 300
 	action_type = XENO_ACTION_CLICK
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
@@ -3,7 +3,7 @@
 /datum/action/xeno_action/activable/pounce/charge
 	name = "Charge"
 	action_icon_state = "charge"
-	ability_name = "charge"
+	action_text = "charge"
 	macro_path = /datum/action/xeno_action/verb/verb_charge_rav
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_1
@@ -21,7 +21,6 @@
 /datum/action/xeno_action/onclick/empower
 	name = "Empower"
 	action_icon_state = "empower"
-	ability_name = "empower"
 	macro_path = /datum/action/xeno_action/verb/verb_empower
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_2
@@ -42,7 +41,6 @@
 // Rav "Scissor Cut"
 /datum/action/xeno_action/activable/scissor_cut
 	name = "Scissor Cut"
-	ability_name = "scissor cut"
 	action_icon_state = "rav_scissor_cut"
 	macro_path = /datum/action/xeno_action/verb/verb_scissorcut
 	action_type = XENO_ACTION_CLICK
@@ -60,7 +58,6 @@
 /datum/action/xeno_action/onclick/apprehend
 	name = "Apprehend"
 	action_icon_state = "rav_enrage"
-	ability_name = "apprehend"
 	macro_path = /datum/action/xeno_action/verb/verb_apprehend
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_1
@@ -75,7 +72,6 @@
 /datum/action/xeno_action/activable/clothesline
 	name = "Clothesline"
 	action_icon_state = "rav_clothesline"
-	ability_name = "clothesline"
 	macro_path = /datum/action/xeno_action/verb/verb_clothesline
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_2
@@ -92,7 +88,6 @@
 /datum/action/xeno_action/activable/eviscerate
 	name = "Eviscerate"
 	action_icon_state = "rav_eviscerate"
-	ability_name = "eviscerate"
 	macro_path = /datum/action/xeno_action/verb/verb_eviscerate
 	action_type = XENO_ACTION_ACTIVATE
 	ability_primacy = XENO_PRIMARY_ACTION_3
@@ -113,7 +108,6 @@
 /datum/action/xeno_action/onclick/spike_shield
 	name = "Spike Shield (150 shards)"
 	action_icon_state = "rav_shard_shield"
-	ability_name = "spike shield"
 	macro_path = /datum/action/xeno_action/verb/verb_spike_shield
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_1
@@ -131,7 +125,6 @@
 /datum/action/xeno_action/activable/rav_spikes
 	name = "Fire Spikes (75 shards)"
 	action_icon_state = "rav_spike"
-	ability_name = "fire spikes"
 	macro_path = /datum/action/xeno_action/verb/verb_fire_spikes
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_2
@@ -145,7 +138,6 @@
 /datum/action/xeno_action/onclick/spike_shed
 	name = "Spike Shed (50 shards)"
 	action_icon_state = "rav_shard_shed"
-	ability_name = "spike shed"
 	macro_path = /datum/action/xeno_action/verb/verb_shed_spikes
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_3

--- a/code/modules/mob/living/carbon/xenomorph/abilities/runner/runner_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/runner/runner_abilities.dm
@@ -1,7 +1,6 @@
 /datum/action/xeno_action/activable/pounce/runner
 	name = "Pounce"
 	action_icon_state = "pounce"
-	ability_name = "pounce"
 	macro_path = /datum/action/xeno_action/verb/verb_pounce
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_1
@@ -24,7 +23,6 @@
 /datum/action/xeno_action/activable/runner_skillshot
 	name = "Bone Spur"
 	action_icon_state = "runner_bonespur"
-	ability_name = "bone spur"
 	macro_path = /datum/action/xeno_action/verb/verb_runner_bonespurs
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_2
@@ -36,7 +34,6 @@
 /datum/action/xeno_action/activable/acider_acid
 	name = "Corrosive Acid"
 	action_icon_state = "corrosive_acid"
-	ability_name = "acider acid"
 	var/acid_type = /obj/effect/xenomorph/acid/strong
 	macro_path = /datum/action/xeno_action/verb/verb_acider_acid
 	ability_primacy = XENO_PRIMARY_ACTION_1
@@ -46,7 +43,6 @@
 /datum/action/xeno_action/activable/acider_for_the_hive
 	name = "For the Hive!"
 	action_icon_state = "screech"
-	ability_name = "for the hive"
 	macro_path = /datum/action/xeno_action/verb/verb_acider_sacrifice
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_2

--- a/code/modules/mob/living/carbon/xenomorph/abilities/sentinel/sentinel_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/sentinel/sentinel_abilities.dm
@@ -2,7 +2,6 @@
 /datum/action/xeno_action/activable/slowing_spit
 	name = "Slowing Spit"
 	action_icon_state = "xeno_spit"
-	ability_name = "slowing spit"
 	macro_path = /datum/action/xeno_action/verb/verb_slowing_spit
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_1
@@ -13,7 +12,6 @@
 /datum/action/xeno_action/activable/scattered_spit
 	name = "Scattered Spit"
 	action_icon_state = "acid_shotgun"
-	ability_name = "scattered spit"
 	macro_path = /datum/action/xeno_action/verb/verb_scattered_spit
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_2
@@ -24,7 +22,6 @@
 /datum/action/xeno_action/onclick/paralyzing_slash
 	name = "Paralyzing Slash"
 	action_icon_state = "lurker_inject_neuro"
-	ability_name = "paralyzing slash"
 	macro_path = /datum/action/xeno_action/verb/verb_paralyzing_slash
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_3

--- a/code/modules/mob/living/carbon/xenomorph/abilities/spitter/spitter_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/spitter/spitter_abilities.dm
@@ -4,7 +4,6 @@
 /datum/action/xeno_action/activable/xeno_spit/spitter
 	name = "Spit Acid"
 	action_icon_state = "xeno_spit"
-	ability_name = "spit acid"
 	macro_path = /datum/action/xeno_action/verb/verb_xeno_spit
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_1
@@ -14,7 +13,6 @@
 /datum/action/xeno_action/onclick/charge_spit
 	name = "Charge Spit"
 	action_icon_state = "charge_spit"
-	ability_name = "charge spit"
 	macro_path = /datum/action/xeno_action/verb/verb_charge_spit
 	ability_primacy = XENO_PRIMARY_ACTION_2
 	action_type = XENO_ACTION_ACTIVATE

--- a/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/warrior/warrior_abilities.dm
@@ -2,7 +2,6 @@
 /datum/action/xeno_action/activable/fling
 	name = "Fling"
 	action_icon_state = "fling"
-	ability_name = "Fling"
 	macro_path = /datum/action/xeno_action/verb/verb_fling
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_3
@@ -18,7 +17,6 @@
 /datum/action/xeno_action/activable/lunge
 	name = "Lunge"
 	action_icon_state = "lunge"
-	ability_name = "lunge"
 	macro_path = /datum/action/xeno_action/verb/verb_lunge
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_2
@@ -32,7 +30,6 @@
 /datum/action/xeno_action/activable/warrior_punch
 	name = "Punch"
 	action_icon_state = "punch"
-	ability_name = "punch"
 	macro_path = /datum/action/xeno_action/verb/verb_punch
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_1

--- a/code/modules/mob/living/carbon/xenomorph/abilities/xeno_action.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/xeno_action.dm
@@ -1,7 +1,5 @@
 /datum/action/xeno_action
 	icon_file = 'icons/mob/hud/actions_xeno.dmi'
-	var/ability_name // Our name
-
 	var/plasma_cost = 0
 	var/macro_path
 	var/action_type = XENO_ACTION_CLICK // Determines how macros interact with this action. Defines are in xeno.dm in the defines folder.
@@ -63,10 +61,10 @@
 /datum/action/xeno_action/proc/track_xeno_ability_stats()
 	if(!owner)
 		return
-	var/mob/living/carbon/xenomorph/X = owner
-	if (ability_name && GLOB.round_statistics)
-		GLOB.round_statistics.track_ability_usage(ability_name)
-		X.track_ability_usage(ability_name, X.caste_type)
+	var/mob/living/carbon/xenomorph/xeno = owner
+	if (name && GLOB.round_statistics)
+		GLOB.round_statistics.track_ability_usage(name)
+		xeno.track_ability_usage(name, xeno.caste_type)
 
 /datum/action/xeno_action/can_use_action()
 	if(!owner)
@@ -169,13 +167,13 @@
 			return // We clicked the same ability in a very short time
 		if(xeno.client && xeno.client.prefs && xeno.client.prefs.toggle_prefs & TOGGLE_ABILITY_DEACTIVATION_OFF)
 			return
-		to_chat(xeno, "You will no longer use [ability_name] with [xeno.get_ability_mouse_name()].")
+		to_chat(xeno, "You will no longer use [name] with [xeno.get_ability_mouse_name()].")
 		button.icon_state = "template"
 		xeno.set_selected_ability(null)
 		if(charge_time)
 			stop_charging_ability()
 	else
-		to_chat(xeno, "You will now use [ability_name] with [xeno.get_ability_mouse_name()].")
+		to_chat(xeno, "You will now use [name] with [xeno.get_ability_mouse_name()].")
 		if(xeno.selected_ability)
 			xeno.selected_ability.action_deselect()
 			if(xeno.selected_ability.charge_time)

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/carrier/eggsac.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/carrier/eggsac.dm
@@ -91,7 +91,6 @@
 /datum/action/xeno_action/active_toggle/generate_egg
 	name = "Generate Eggs (50)"
 	action_icon_state = "lay_egg"
-	ability_name = "generate egg"
 	action_type = XENO_ACTION_CLICK
 	plasma_cost = 50
 	plasma_use_per_tick = 15

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/drone/gardener.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/drone/gardener.dm
@@ -40,7 +40,6 @@
 /datum/action/xeno_action/onclick/plant_resin_fruit
 	name = "Plant Resin Fruit (50)"
 	action_icon_state = "gardener_plant"
-	ability_name = "plant resin fruit"
 	plasma_cost = 50
 	macro_path = /datum/action/xeno_action/verb/plant_resin_fruit
 	action_type = XENO_ACTION_CLICK
@@ -123,7 +122,6 @@
 /datum/action/xeno_action/onclick/change_fruit
 	name = "Change Fruit"
 	action_icon_state = "blank"
-	ability_name = "change fruit"
 	plasma_cost = 0
 	xeno_cooldown = 0
 	macro_path = /datum/action/xeno_action/verb/verb_resin_surge
@@ -224,7 +222,6 @@
 /datum/action/xeno_action/activable/resin_surge
 	name = "Resin Surge (75)"
 	action_icon_state = "gardener_resin_surge"
-	ability_name = "resin surge"
 	plasma_cost = 75
 	xeno_cooldown = 10 SECONDS
 	macro_path = /datum/action/xeno_action/verb/verb_resin_surge
@@ -338,7 +335,6 @@
 
 /datum/action/xeno_action/onclick/plant_weeds/gardener
 	name = "Plant Hardy Weeds (125)"
-	ability_name = "Plant Hardy Weeds"
 	action_icon_state = "plant_gardener_weeds"
 	plasma_cost = 125
 	macro_path = /datum/action/xeno_action/verb/verb_plant_gardening_weeds

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/drone/healer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/drone/healer.dm
@@ -51,7 +51,6 @@
 /datum/action/xeno_action/activable/apply_salve
 	name = "Apply Resin Salve"
 	action_icon_state = "apply_salve"
-	ability_name = "Apply Resin Salve"
 	var/health_transfer_amount = 100
 	var/max_range = 1
 	var/damage_taken_mod = 0.75
@@ -207,7 +206,6 @@
 /datum/action/xeno_action/activable/healer_sacrifice
 	name = "Sacrifice"
 	action_icon_state = "screech"
-	ability_name = "sacrifice"
 	var/max_range = 1
 	var/transfer_mod = 0.75 // only transfers 75% of current healer's health
 	macro_path = /datum/action/xeno_action/verb/verb_healer_sacrifice

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/hivelord/resin_whisperer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/hivelord/resin_whisperer.dm
@@ -43,7 +43,6 @@
 /datum/action/xeno_action/activable/secrete_resin/remote
 	name = "Coerce Resin (100)"
 	action_icon_state = "secrete_resin"
-	ability_name = "coerce resin"
 	xeno_cooldown = 2.5 SECONDS
 	thick = FALSE
 	make_message = FALSE


### PR DESCRIPTION

# About the pull request

Part of planned change to factor out a lot of functionality from `xeno_actions` into `actions`.

`ability_name` is only used in some chat messages and for xeno stats, so thought it would be worth removing it to remove a somewhat redundant variable to make xeno actions and human actions work more similarly.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Removes snowflake var that will help make working actions in the future simpler.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>



https://github.com/user-attachments/assets/ddcbb4e9-47ec-459b-8251-efa10e7a9a62


https://github.com/user-attachments/assets/427744a4-c319-47b8-99de-39b1bac26bb6

![gKxJNTt](https://github.com/user-attachments/assets/68cb4f68-baf9-4c8a-8693-36c1a97535bd)


</details>


# Changelog
:cl: TheDonkified
code: Xeno ability names in chat and stats page changed to match the names for xeno ability buttons
/:cl:
