### PR TITLE
Revert "Sentinel buffs"

### DIFF
--- a/code/__DEFINES/weapon_stats.dm
+++ b/code/__DEFINES/weapon_stats.dm
@@ -66,7 +66,7 @@ It DOES NOT control where your bullets go, that's scatter and projectile varianc
 ////SCATTER////
 */
 
-#define SCATTER_AMOUNT_NEURO 45
+#define SCATTER_AMOUNT_NEURO 60
 #define SCATTER_AMOUNT_TIER_1 15
 #define SCATTER_AMOUNT_TIER_2 10
 #define SCATTER_AMOUNT_TIER_3 8

--- a/code/datums/ammo/xeno.dm
+++ b/code/datums/ammo/xeno.dm
@@ -61,7 +61,7 @@
 				return
 
 		if(ishuman(M))
-			M.apply_effect(4, SUPERSLOW)
+			M.apply_effect(2.5, SUPERSLOW)
 			M.visible_message(SPAN_DANGER("[M]'s movements are slowed."))
 
 		var/no_clothes_neuro = FALSE

--- a/code/modules/mob/living/carbon/xenomorph/abilities/sentinel/sentinel_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/sentinel/sentinel_abilities.dm
@@ -6,7 +6,7 @@
 	macro_path = /datum/action/xeno_action/verb/verb_slowing_spit
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_1
-	xeno_cooldown = 2 SECONDS
+	xeno_cooldown = 1.5 SECONDS
 	plasma_cost = 20
 
 // Scatterspit
@@ -17,7 +17,7 @@
 	macro_path = /datum/action/xeno_action/verb/verb_scattered_spit
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_2
-	xeno_cooldown = 6 SECONDS
+	xeno_cooldown = 8 SECONDS
 	plasma_cost = 30
 
 // Paralyzing slash

--- a/code/modules/mob/living/carbon/xenomorph/castes/Sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Sentinel.dm
@@ -68,7 +68,7 @@
 	// State
 	var/next_slash_buffed = FALSE
 
-#define NEURO_TOUCH_DELAY 3 SECONDS
+#define NEURO_TOUCH_DELAY 4 SECONDS
 
 /datum/behavior_delegate/sentinel_base/melee_attack_modify_damage(original_damage, mob/living/carbon/carbon_target)
 	if (!next_slash_buffed)
@@ -112,6 +112,6 @@
 		return INTENT_HARM
 
 /datum/behavior_delegate/sentinel_base/proc/paralyzing_slash(mob/living/carbon/human/human_target)
-	human_target.KnockDown(2.5)
-	human_target.Stun(2.5)
+	human_target.KnockDown(2)
+	human_target.Stun(2)
 	to_chat(human_target, SPAN_XENOHIGHDANGER("You fall over, paralyzed by the toxin!"))


### PR DESCRIPTION
### **About the Pull Request**

Reverts the Sentinel Buffs made by GoldenDarkness, no changes made by me.

### **Explain why it's good for the game**

Due to the lack of testing and review on the "sentinel buffs" PR, the caste Sentinel has went from being a support T1 caste which was relatively strong due to its stun and long range slow to a one man machine.

As it currently stands: 
1. One Paralyzing slash guarantees you a capture 100% of the time
2. Due to the buffs, you can superslow somebody for even longer despite it previously requiring you to keep attacking the target; making it very, very strong at least in my opinion
3. You get stunned faster due to "Sentinel paralyzing slash stuns after 3 seconds instead of 4 and lasts 2.5 seconds from 2."

TL;DR It has made sentinel into an unbeatable machine that with one ability can win an engagement.

### **Changelog**

:cl: stalkerino
balance: reverts sentinel buffs
/:cl: