### PR TITLE
Fixes memorial ghosts not facing the right direction

### DIFF
--- a/code/modules/almayer/ship_memorial.dm
+++ b/code/modules/almayer/ship_memorial.dm
@@ -235,8 +235,6 @@
 	if(!person)
 		return
 
-	var/obj/effect/client_image_holder/memorial_ghost/ghost = new(user, user, person)
-
 	///All acceptable turfs where the ghost could spawn.
 	var/list/ghost_turf = list()
 	for(var/turf/turf in range(user.loc, range))
@@ -248,7 +246,7 @@
 			continue
 
 		for(var/obj/object in turf)
-			if(object.density || (object != ghost && istype(object, /obj/effect/client_image_holder/memorial_ghost)))
+			if(object.density || istype(object, /obj/effect/client_image_holder/memorial_ghost))
 				bad_turf = TRUE
 				break
 
@@ -262,11 +260,11 @@
 		ghost_turf += turf
 
 	if(!length(ghost_turf))
-		qdel(ghost)
 		return
 
-	ghost.loc = pick(ghost_turf)
-	ghost.dir = get_dir(ghost.loc, user.loc)
+	var/turf/spawn_loc = pick(ghost_turf)
+	var/dir_to_face = get_dir(spawn_loc, user.loc)
+	var/obj/effect/client_image_holder/memorial_ghost/ghost = new(spawn_loc, user, person, dir_to_face)
 
 	return ghost
 
@@ -360,6 +358,7 @@
 #undef REQUIRED_DEAD_SQUADDIES
 
 /obj/effect/client_image_holder/memorial_ghost
+	desc = "May we never forget freedom isn't free."
 	var/mob/living/mob_reference
 
 /obj/effect/client_image_holder/memorial_ghost/proc/disappear()
@@ -367,21 +366,19 @@
 	animate(shown_image, alpha = 0, QUAD_EASING, time = time_to_disappear)
 	QDEL_IN(src, time_to_disappear)
 
-/obj/effect/client_image_holder/memorial_ghost/Initialize(mapload, list/mobs_which_see_us, mob/living/reference = null)
+/obj/effect/client_image_holder/memorial_ghost/Initialize(mapload, list/mobs_which_see_us, mob/living/reference = null, direction_to_face)
 	mob_reference = reference
 	if(!mob_reference)
 		return INITIALIZE_HINT_QDEL
 
-	. = ..()
+	dir = direction_to_face
 	name = mob_reference.name
-	desc = "May we never forget freedom isn't free."
+	return ..()
 
 /obj/effect/client_image_holder/memorial_ghost/generate_image()
-	var/image/created = image(null, src, null, image_layer, dir = src.dir)
+	var/image/created = image(null, src, null, image_layer, src.dir, image_pixel_x, image_pixel_y)
 	created.appearance = mob_reference.appearance
 	created.transform = matrix(mob_reference.base_transform)
-	created.pixel_x = image_pixel_x
-	created.pixel_y = image_pixel_y
 	created.alpha = 0
 	if(image_color)
 		created.color = image_color


### PR DESCRIPTION

# About the pull request

fixes memorial ghosts always facing south. now they face the player as intended
i have no idea what the exact issue was. mobs that were spawned in and were not moved always faced the right direction, but if they got moved they'd only face south. now it should work a-ok (i hope)

# Explain why it's good for the game
bug fix :D


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>


https://github.com/user-attachments/assets/65bef2b9-504d-48ce-8cbc-738e49cf1312



</details>


# Changelog
:cl:
fix: Memorial ghosts will now face the user instead of facing south.
/:cl:
