### PR TITLE
CL vendor cash is now legal

### DIFF
--- a/code/game/objects/items/devices/portable_vendor.dm
+++ b/code/game/objects/items/devices/portable_vendor.dm
@@ -273,7 +273,7 @@
 		list("Ultrazine Injector", 25, /obj/item/reagent_container/hypospray/autoinjector/ultrazine/liaison, "white", "Highly-addictive stimulant. Enhances short-term physical performance, particularly running speed. Effects last approximately 10 minutes per injection. More than two injections at a time will result in overdose. Withdrawal causes extreme discomfort and hallucinations. Long-term use results in halluciations and organ failure. Conditional distribution secures subject compliance. Not for personal use."),
 		list("Cyanide Pill", 20, /obj/item/reagent_container/pill/cyanide, "white", "A cyanide pill, also known as a suicide pill. For the easy way out."),
 		list("Ceramic Plate", 10, /obj/item/trash/ceramic_plate, "white", "A ceramic plate, useful in a variety of situations."),
-		list("Cash", 5, /obj/item/spacecash/c1000/counterfeit, "white", "$1000 USD, unmarked bills"),
+		list("Cash", 5, /obj/item/spacecash/c1000, "white", "$1000 USD, in bills"),
 		list("WY Encryption Key", 5, /obj/item/device/encryptionkey/WY, "white", "WY private comms encryption key, for conducting private business."),
 
 		list("SMOKABLES", 0, null, null, null),


### PR DESCRIPTION
# About the pull request
changes the CL’s 1000 dollar cash incentive from unmarked bills to legitimate money.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
1. it doesn’t make sense for the CL to be given illegal cash as an incentive.
2. unmarked bills was able to be converted into marked bills by combining two stacks of cash together anyways.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: The Space IRS has sued W-Y for offering counterfeit cash to their employees, All cash incentives offered are now legitimate.
/:cl:
