### PR TITLE
reduces binocular zoom for HvH

### DIFF
--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -14,7 +14,10 @@
 	throw_speed = SPEED_VERY_FAST
 	/// If FALSE won't change icon_state to a camo marine bino.
 	var/uses_camo = TRUE
-
+	var/tile_offset = 11
+	var/viewsize = 12
+	var/hvh_tile_offset = 6 //same as miniscopes
+	var/hvh_zoom_viewsize = 7
 
 	//matter = list("metal" = 50,"glass" = 50)
 
@@ -29,8 +32,10 @@
 
 	if(SEND_SIGNAL(user, COMSIG_BINOCULAR_ATTACK_SELF, src))
 		return
-
-	zoom(user, 11, 12)
+	if(SSticker.mode && MODE_HAS_TOGGLEABLE_FLAG(MODE_NO_SNIPER_SENTRY))
+		zoom(user, hvh_tile_offset, hvh_zoom_viewsize)
+	else
+		zoom(user, tile_offset, viewsize)
 
 /obj/item/device/binoculars/dropped(/obj/item/item, mob/user)
 	. = ..()


### PR DESCRIPTION

# About the pull request
reduces binocular zoom to miniscope level when no scope flag is on

# Explain why it's good for the game
# Testing Photographs and Procedure
binoculars give HUGE advantage on HvH, this reduces their zoom to miniscope level from full scope level

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: binoculars have miniscope level zoom on HvH
/:cl:
