### PR TITLE
Reduces OT simulation cooldown from 2 minutes to 1 minute

### DIFF
--- a/code/game/sim_manager/datums/simulator.dm
+++ b/code/game/sim_manager/datums/simulator.dm
@@ -4,7 +4,7 @@
 
 	// Necessary to prevent multiple users from simulating at the same time.
 	var/static/detonation_cooldown = 0
-	var/static/detonation_cooldown_time = 2 MINUTES
+	var/static/detonation_cooldown_time = 1 MINUTES
 	var/static/sim_reboot_state = TRUE
 
 	var/dummy_mode = CLF_MODE


### PR DESCRIPTION

# About the pull request

Decrease the OT simulation cooldown

# Explain why it's good for the game

Increase how fast an OT can test their different chems, specially after the OT nerf people want to test new recipes for the m15s, rockets , shells  and 2 minutes is too long for that.

40 minutes for 20 tests before.
20 minutes for 20 tests now.


# Testing Photographs and Procedure

<details>


</details>


# Changelog


:cl:Wgtjunior743
qol:Reduces the OT simulation cooldown from 2 minutes to 1 minute

/:cl:
