### PR TITLE
Fixing UPP loudout oversights

### DIFF
--- a/code/game/machinery/vending/vendor_types/antag/antag_gear.dm
+++ b/code/game/machinery/vending/vendor_types/antag/antag_gear.dm
@@ -49,13 +49,6 @@
 		/obj/structure/bed/medevac_stretcher/upp,
 	)
 
-/obj/effect/essentials_set/upp_heavy
-	spawned_gear_list = list(
-		/obj/item/weapon/gun/pkp,
-		/obj/item/ammo_magazine/pkp,
-		/obj/item/ammo_magazine/pkp,
-	)
-
 /obj/effect/essentials_set/leader/upp
 	spawned_gear_list = list(
 		/obj/item/explosive/plastic,

--- a/code/game/machinery/vending/vendor_types/antag/antag_guns_snowflake.dm
+++ b/code/game/machinery/vending/vendor_types/antag/antag_guns_snowflake.dm
@@ -36,14 +36,6 @@
 
 //--------------ESSENTIALS------------------------
 
-/obj/effect/essentials_set/medic/upp
-	spawned_gear_list = list(
-		/obj/item/bodybag/cryobag,
-		/obj/item/device/defibrillator,
-		/obj/item/storage/firstaid/adv,
-		/obj/item/device/healthanalyzer,
-		/obj/item/roller,
-	)
 
 /obj/effect/essentials_set/upp_heavy
 	spawned_gear_list = list(

--- a/code/modules/gear_presets/upp.dm
+++ b/code/modules/gear_presets/upp.dm
@@ -653,7 +653,7 @@
 	flags_startup_parameters = ROLE_ADD_TO_SQUAD
 
 /datum/equipment_preset/upp/specialist
-	name = "UPP Specialist (Cryo)"
+	name = "UPP Specialist minigun (Cryo)"
 
 	skills = /datum/skills/upp/specialist
 	assignment = JOB_UPP_SPECIALIST


### PR DESCRIPTION

# About the pull request

there were dupe objects left in code that messed up spawns and wrong UPP spec was being chosen with minigun rather then pkp

# Explain why it's good for the game

fixes good


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: removes dupe definitions and corrects items i UPP Loudouts
/:cl:
