### PR TITLE
Medicomp heals full on finish

### DIFF
--- a/code/modules/surgery/mcomp_tendwounds.dm
+++ b/code/modules/surgery/mcomp_tendwounds.dm
@@ -166,7 +166,7 @@
 			SPAN_NOTICE("[user] begns to clamp the treated wounds on [target]'s body with [tool]."))
 
 /datum/surgery_step/cauterize/mclamp_wound/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, tool_type, datum/surgery/surgery)
-	target.heal_overall_damage(65,65) //makes sure that all damage is healed
+	target.heal_overall_damage(125,125) //makes sure that all damage is healed
 
 	if(user == target)
 		user.visible_message(SPAN_NOTICE("[user] finshes closing the treated wounds on their body with [tool]."),


### PR DESCRIPTION
# About the pull request

As stated by Dots, Strobia, and with the blessings of Stalkerino, I am fixing the fact that old medicomp doesn't heal fully. This wasn't a problem when people were leaving open surgical sites on them, but as we move away from that, people really hate deciding between leaving damage on yourself or repeating the whole process again.

# Explain why it's good for the game

Improves QoL for predators. 

# Testing Photographs and Procedure
Tested, completing all the steps will put you at full health from being in crit. Preds fall over at ~221 damage. All steps of Medicomp will now heal 225 damage compared to the previous 165

# Changelog

:cl: An A Jay
balance: Made Medicomp heal to full for predators.
/:cl:
