### PR TITLE
Made eggs not plantable on overextended weeds

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/egg_item.dm
+++ b/code/modules/mob/living/carbon/xenomorph/egg_item.dm
@@ -114,6 +114,10 @@
 		to_chat(user, SPAN_XENOWARNING("[src] must be planted on [lowertext(hive.prefix)]weeds."))
 		return
 
+	if(T.is_weedable() < FULLY_WEEDABLE) //no planting eggs on not originally intended tiles
+		to_chat(user, SPAN_XENOWARNING("[src] cannot be planted on overextended weeds."))
+		return
+
 	if(!hive_weeds && needs_hive_weeds)
 		to_chat(user, SPAN_XENOWARNING("[src] can only be planted on [lowertext(hive.prefix)]hive weeds."))
 		return


### PR DESCRIPTION
# About the pull request

Eggs can no longer be planted on tiles that are not supposed to be weedable (ie from a cluster).
Apearently it was not intended, but would been **really great** if this was made public knowledge. >:(

# Explain why it's good for the game

Bug? bad?


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![sad](https://github.com/user-attachments/assets/6520b4f7-0b8b-4602-8e6c-5da9909203ba)


</details>


# Changelog
:cl:
fix: Eggs can no longer be planted on overextended weeds.
/:cl:
