### PR TITLE
Makes Working Joe's eyes glow in a dark + tweaks wj eye colors

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -323,13 +323,13 @@
 				g_eyes = 255
 				b_eyes = 0
 			if(INTENT_DISARM) //Blue
-				r_eyes = 0
-				g_eyes = 0
-				b_eyes = 255
+				r_eyes = 90
+				g_eyes = 90
+				b_eyes = 253
 			if(INTENT_GRAB) //Orange, since yellow doesn't show at all!
-				r_eyes = 248
-				g_eyes = 243
-				b_eyes = 43
+				r_eyes = 239
+				g_eyes = 167
+				b_eyes = 0
 			if(INTENT_HARM) //RED!
 				r_eyes = 255
 				g_eyes = 0

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -1460,6 +1460,9 @@ treat_grafted var tells it to apply to grafted but unsalved wounds, for burn kit
 	eyes.color = list(null, null, null, null, rgb(owner.r_eyes, owner.g_eyes, owner.b_eyes))
 	. += eyes
 
+	if(HAS_TRAIT(owner, TRAIT_INTENT_EYES))
+		. += emissive_appearance(icon = 'icons/mob/humans/onmob/human_face.dmi', icon_state = species.eyes)
+
 	if(lip_style && (species && species.flags & HAS_LIPS))
 		var/image/lips = image('icons/mob/humans/onmob/human_face.dmi', "paint_[lip_style]", layer = -BODYPARTS_LAYER)
 		. += lips


### PR DESCRIPTION
# About the pull request

Title, tho it also applies to early gen synths

![dreamseeker_emnOXJsyc6](https://github.com/user-attachments/assets/12191bc9-8050-43d0-ac65-beaabd31e28a)

![dreamseeker_NoFpUITKOx](https://github.com/user-attachments/assets/2a90ab1e-f16f-4036-abf5-2b5196d0393e)

Tweaked WJ eye color on disarm and grab, disarm was too dark and saturated, grab was blending into wj skin color badly

![dreamseeker_PaKtk5XfYa](https://github.com/user-attachments/assets/167a3cb7-e864-4272-acca-da3d6befb600)

![dreamseeker_4020BIk5hR](https://github.com/user-attachments/assets/3e63f515-1392-4ee3-abbb-5e067980ba6c)

![dreamseeker_AHWvN0Lhmz](https://github.com/user-attachments/assets/444d7301-97e5-4a17-99e2-ad6313e6fd67)



# Explain why it's good for the game

Immersion good

![image](https://github.com/user-attachments/assets/7b79ab31-0553-4075-9f8a-fdd0419b69ff)


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: working joe's and early gen synth's eyes now glow in a dark 
add: working joe's and early gen synth's eyes color tweak on disarm and grab
/:cl:
