### PR TITLE
Egg orphans and fragile egg fixes

### DIFF
--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -375,5 +375,5 @@ SPECIAL EGG USED BY EGG CARRIER
 	if(owner)
 		var/datum/behavior_delegate/carrier_eggsac/behavior = owner.behavior_delegate
 		behavior.remove_egg_owner(src)
-	if(life_timer)
+	if(kill && life_timer)
 		deltimer(life_timer)

--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -452,7 +452,8 @@ SPECIAL EGG USED WHEN WEEDS LOST
 	if(isnull(weed_strength_required))
 		return .
 
-	life_timer = addtimer(CALLBACK(src, PROC_REF(start_unstoppable_decay)), CARRIER_EGG_MAXIMUM_LIFE, TIMER_STOPPABLE)
+	if(hivenumber != XENO_HIVE_FORSAKEN)
+		life_timer = addtimer(CALLBACK(src, PROC_REF(start_unstoppable_decay)), CARRIER_EGG_MAXIMUM_LIFE, TIMER_STOPPABLE)
 
 	var/my_turf = get_turf(src)
 	if(my_turf)
@@ -471,6 +472,11 @@ SPECIAL EGG USED WHEN WEEDS LOST
 		return
 
 	convert()
+
+/obj/effect/alien/egg/carrier_egg/orphan/forsaken_handling()
+	. = ..()
+	if(life_timer)
+		deltimer(life_timer)
 
 /obj/effect/alien/egg/carrier_egg/orphan/can_convert()
 	if(!..())

--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -92,14 +92,16 @@
 	return XENO_NONCOMBAT_ACTION
 
 /obj/effect/alien/egg/clicked(mob/user, list/mods)
+	if(..())
+		return TRUE
+
 	if(isobserver(user) || get_dist(src, user) > 1)
 		return
+
 	var/mob/living/carbon/xenomorph/X = user
 	if(istype(X) && status == EGG_GROWN && mods["ctrl"] && X.caste.can_hold_facehuggers)
 		Burst(FALSE, FALSE, X)
 		return TRUE
-
-	return ..()
 
 /obj/effect/alien/egg/proc/Grow()
 	if(status == EGG_GROWING)

--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -76,6 +76,9 @@
 
 	var/turf/my_turf = get_turf(src)
 	var/obj/effect/alien/egg/carrier_egg/orphan/newegg = new(my_turf, hivenumber, weed_strength_required)
+	newegg.flags_embryo = flags_embryo
+	newegg.fingerprintshidden = fingerprintshidden
+	newegg.fingerprintslast = fingerprintslast
 	switch(status)
 		if(EGG_GROWN)
 			newegg.Grow()
@@ -491,6 +494,9 @@ SPECIAL EGG USED WHEN WEEDS LOST
 
 	var/turf/my_turf = get_turf(src)
 	var/obj/effect/alien/egg/newegg = new(my_turf, hivenumber)
+	newegg.flags_embryo = flags_embryo
+	newegg.fingerprintshidden = fingerprintshidden
+	newegg.fingerprintslast = fingerprintslast
 	switch(status)
 		if(EGG_GROWN)
 			newegg.Grow()

--- a/code/modules/mob/living/carbon/xenomorph/egg_item.dm
+++ b/code/modules/mob/living/carbon/xenomorph/egg_item.dm
@@ -135,8 +135,9 @@
 	var/plant_time = 35
 	if(isdrone(user))
 		plant_time = 25
-	if(iscarrier(user))
+	else if(iscarrier(user))
 		plant_time = 10
+
 	if(!do_after(user, plant_time, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 		return
 	if(!user.check_alien_construction(T, ignore_nest = TRUE))


### PR DESCRIPTION
# About the pull request

This PR fixes a couple bugs with xeno eggs and also adds a mechanic where eggs that have lost their weeds will become fragile. These eggs use the `CARRIER_EGG_MAXIMUM_LIFE` value (5 mins) but will convert back to normal eggs if their hive weeds are restored. If this doesn't discourage the weird behavior of placing and destroying pylons, we can just entirely remove the logic that restores the eggs to normal eggs.

For fixes, there was a check on egg/click that prevented egg interaction if you weren't close or are a ghost, but it needed to first call parent first for examine logic. Then there was an issue where the timer for egg carrier eggs would get deleted if called the Burst proc (but it failed to check if the burst was from just someone retrieving the hugger)

Forsaken variants of the new eggs will last indefinitely.

# Explain why it's good for the game

- Fixes #7405 
- Fixes #6017 
- Fixes being unable to examine eggs unless 1 tile away from them.

Right now its possible to make eggs even on semi-weedable surfaces. This PR still allows this but they will only last 5 minutes if they don't have their weeds restored in time. In general I am okay with xenos creating traps for marines to get hugged, but doing so through weird mechanics like cycling a pylon construction needs to be discouraged.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/Hbyk6OikyjU

</details>


# Changelog
:cl: Drathek
balance: Eggs that lose their hive weeds will now turn fragile (like egg carrier eggs) lasting 5 minutes.
fix: Fixed an exploit allowing egg carrier eggs to last indefinitely.
fix: Fixed the inability to examine planted eggs from further than one tile.
/:cl:
