### PR TITLE
Fix Werror handling in build script

### DIFF
--- a/code/datums/factions/upp.dm
+++ b/code/datums/factions/upp.dm
@@ -5,7 +5,6 @@
 /datum/faction/upp/modify_hud_holder(image/holder, mob/living/carbon/human/H)
 	var/hud_icon_state
 	var/obj/item/card/id/ID = H.get_idcard()
-	var/datum/squad/squad = H.assigned_squad
 	var/_role
 	if(H.mind)
 		_role = H.job


### PR DESCRIPTION
# About the pull request

This PR partially ports https://github.com/tgstation/tgstation/pull/83015 fixing warnings not getting treated as errors due to a regex error. We want Werror to catch common things like unused variables in CI testing.

Removes an unused squad var causing warnings.

# Explain why it's good for the game

More robust code

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

https://github.com/cmss13-devs/cmss13/actions/runs/11770975974/job/32784168250?pr=7562

# Changelog
No player facing changes.
