### PR TITLE
Fix floating Aerodome APC on Shivas

### DIFF
--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -13865,7 +13865,7 @@
 /turf/open/auto_turf/snow/layer0,
 /area/shiva/interior/bar)
 "lro" = (
-/obj/structure/machinery/power/apc/no_power/west{
+/obj/structure/machinery/power/apc/no_power/east{
 	name = "telecomms relay power controller"
 	},
 /turf/open/floor/shiva/floor3,


### PR DESCRIPTION

# About the pull request

This PR fixes the rotation of the aerodome telecoms APC on Shivas.

# Explain why it's good for the game

Fixes #7564 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/f0378e96-cd12-47d3-b00a-acbcb54c7237)
![image](https://github.com/user-attachments/assets/39b7982f-e000-4c65-b783-b33c0de467d3)


</details>


# Changelog
:cl: Drathek
maptweak: Fixed the rotation of the telecoms APC in the Aerodome on Shivas
/:cl:
