### PR TITLE
Larva Queue Time of Death Sanity

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -554,7 +554,13 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			// if they died as facehugger or lesser drone, bypass typical TOD checks
 			ghost.bypass_time_of_death_checks = (isfacehugger(src) || islesserdrone(src))
 
-			ghost.client?.player_details.larva_queue_time = max(ghost.client.player_details.larva_queue_time, new_tod)
+			if(ghost.client)
+				ghost.client.player_details.larva_queue_time = max(ghost.client.player_details.larva_queue_time, new_tod)
+			else if(persistent_ckey)
+				var/datum/player_details/details = GLOB.player_details[persistent_ckey]
+				if(details)
+					details.larva_queue_time = max(details.larva_queue_time, new_tod)
+
 		if(is_nested && nest && !QDELETED(nest))
 			ghost.can_reenter_corpse = FALSE
 			nest.ghost_of_buckled_mob = ghost

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -83,9 +83,19 @@
 
 	timeofdeath = world.time
 	life_time_total = world.time - life_time_start
-	if(mind) mind.store_memory("Time of death: [worldtime2text()]", 0)
+	if(mind)
+		mind?.store_memory("Time of death: [worldtime2text()]", 0)
 	GLOB.alive_mob_list -= src
 	GLOB.dead_mob_list += src
+
+	// Larva queue: We use the larger of their existing queue time or the new timeofdeath except for facehuggers or lesser drone
+	var/new_tod = (should_block_game_interaction(src) || isfacehugger(src) || islesserdrone(src)) ? 1 : timeofdeath
+	if(client)
+		client.player_details.larva_queue_time = max(client.player_details.larva_queue_time, new_tod)
+	else if(persistent_ckey)
+		var/datum/player_details/details = GLOB.player_details[persistent_ckey]
+		if(details)
+			details.larva_queue_time = max(details.larva_queue_time, new_tod)
 
 	if(client && client.player_data)
 		record_playtime(client.player_data, job, type)

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -84,7 +84,7 @@
 	timeofdeath = world.time
 	life_time_total = world.time - life_time_start
 	if(mind)
-		mind?.store_memory("Time of death: [worldtime2text()]", 0)
+		mind.store_memory("Time of death: [worldtime2text()]", 0)
 	GLOB.alive_mob_list -= src
 	GLOB.dead_mob_list += src
 


### PR DESCRIPTION

# About the pull request

This PR adds a couple probably unnecessary changes to ensure time of death gets recorded into the player_details. Now do_ghost will try to get the player_details if there is no client but there is a persistent_ckey. Additionally, mob death will immediately assign time of death into the player_details.

# Explain why it's good for the game

Fixes #7559 if assumption of what happened is correct.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
code: Added some more sanity code to ensure time of death is recorded for larva queue
/:cl:
