### PR TITLE
Nerfs exploitable room on Chances Claim.

### DIFF
--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -45325,18 +45325,14 @@
 "xLr" = (
 /obj/structure/machinery/door/poddoor/almayer{
 	dir = 2;
-	id = "map_corpo";
-	explo_proof = 1;
+	id = "map_corpo2";
 	name = "Emergency Blast Door";
-	unacidable = 1;
 	use_power = 0
 	},
 /obj/structure/machinery/door/poddoor/almayer{
 	dir = 2;
-	id = "map_corpo2";
-	explo_proof = 1;
+	id = "map_corpo";
 	name = "Emergency Blast Door";
-	unacidable = 1;
 	use_power = 0
 	},
 /turf/open/floor/corsat/marked,
@@ -72523,9 +72519,9 @@ fwo
 hTd
 xZE
 xZE
-alI
-alI
-alI
+wUp
+wUp
+abo
 bel
 ftd
 gok
@@ -72728,10 +72724,10 @@ yld
 saC
 saC
 xZE
-alI
-alI
+wUp
+wUp
 gib
-alI
+abo
 btP
 eJR
 eJR
@@ -72934,7 +72930,7 @@ saC
 saC
 xZE
 xZE
-alI
+wUp
 caV
 pcV
 xLr
@@ -73140,10 +73136,10 @@ saC
 xZE
 xZE
 xZE
-alI
-alI
+wUp
+wUp
 tyb
-alI
+abo
 iJE
 gok
 rtX
@@ -73347,9 +73343,9 @@ xZE
 xZE
 xZE
 xZE
-alI
-alI
-alI
+wUp
+wUp
+abo
 rtX
 iJE
 rtX


### PR DESCRIPTION
# About the pull request

Nerfs pointlessly fortified room/micro-area on Chances Claim to make it less exploitable.

# Explain why it's good for the game

Stops ridiculous cheese like this video below; there's no reason why a room with seemingly no purpose has an un-acidable, un-explodable and un-pryable double shutter, hull walls and a ladder that people can hide behind, barricade and camp inside of. 

They literally just sat there and camped while calling down a crate and camping near the sensor tower - a player shouldn't be forced to babysit this one area should a marine/group just set up camp inside of this incredibly safe kill-box that is impossible for Xenomorph players to break into.

There is nothing actually inside the room to justify such tough walls and shutters as the total contents of the room amount to a bedroll, some bloody gauze, some wrappers, some Souto, a single (normal) blowtorch and exactly two small crates. There is zero reason why this warrants hull walls and an invincible shutter which can be opened and closed from inside.

https://github.com/user-attachments/assets/ebbc75d2-8649-4204-98c5-92a92d42f3d0

![image](https://github.com/user-attachments/assets/df7997a2-f85d-48f9-86b9-19e191209970)

# Changelog

:cl:
maptweak: Lowered overall toughness (removed immunities*) of two shutters on Chance's Claim.
maptweak: Adjusts adjacent walls to be normal, non-hull walls which can actually be broken.
/:cl:
