### PR TITLE
Flare Rework: Dying Light

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -302,7 +302,7 @@
 	/// Factor of duration between acid progression
 	var/acid_delay = 1
 	/// How much fuel the acid drains from the flare every acid tick
-	var/flare_damage = 500
+	var/flare_damage = 600
 	var/barricade_damage = 40
 	var/in_weather = FALSE
 
@@ -311,7 +311,7 @@
 	name = "weak acid"
 	acid_delay = 2.5 //250% delay (40% speed)
 	barricade_damage = 20
-	flare_damage = 150
+	flare_damage = 180
 	icon_state = "acid_weak"
 
 //Superacid
@@ -319,7 +319,7 @@
 	name = "strong acid"
 	acid_delay = 0.4 //40% delay (250% speed)
 	barricade_damage = 100
-	flare_damage = 1875
+	flare_damage = 2250
 	icon_state = "acid_strong"
 
 /obj/effect/xenomorph/acid/Initialize(mapload, atom/target)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -302,7 +302,7 @@
 	desc = "A red USCM issued flare. There are instructions on the side, it reads 'pull cord, make light'."
 	w_class = SIZE_SMALL
 	light_power = 2
-	light_range = 5
+	light_range = 7
 	icon_state = "flare"
 	item_state = "flare"
 	actions = list() //just pull it manually, neckbeard.
@@ -327,7 +327,7 @@
 
 /obj/item/device/flashlight/flare/Initialize()
 	. = ..()
-	fuel = rand(9.5 MINUTES, 10.5 MINUTES)
+	fuel = 15 MINUTES
 	set_light_color(flame_tint)
 
 /obj/item/device/flashlight/flare/update_icon()
@@ -362,6 +362,19 @@
 
 /obj/item/device/flashlight/flare/process(delta_time)
 	fuel -= fuel_rate * delta_time
+	switch(fuel) //The code belows controls the timing on a flares burn out, and the corresponding reduction in effective range.
+		if( 14.25 MINUTES to 15 MINUTES)
+			set_light_range(7)
+		if(13.5 MINUTES to 14.24 MINUTES)
+			set_light_range(6)
+		if(3.5 MINUTES to 13.49 MINUTES)
+			set_light_range(5)
+		if(2.5 MINUTES to 3.49 MINUTES)
+			set_light_range(4)
+		if(1.5 MINUTES to 2.49 MINUTES)
+			set_light_range(3)
+		if(0 MINUTES to 1.49 MINUTES)
+			set_light_range(2)
 	if(fuel <= 0 || !on)
 		burn_out()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

I've always imagined what it'd feel like to play CM with more dynamic flares, and this PR aims to accomplish that. Flares will now behave more like their real life counterparts, starting off strong and slowly fading to darkness. This gives flares around 20% more total staying power, and to compensate, I have increased xenomorph flare damage via acid by 20% across the board. 

In total: ~45 second burst of 7 tile radius, ~45 seconds of 6 tile radius, ~10 minutes of 5 tile(current strength) radius, ~1 minute of 4 tile radius, ~1minute of 3 tile radius, and finally ~1.5 minutes of 2 tile radius. 

# Explain why it's good for the game

Flare support is a VITAL part of the game, but frankly feels unrewarding with its current state. Having to chuck 4-5 flares to cover an area that you're only passing through feels wrong. This PR makes active flare use in a combat situation MUCH more rewarding in both gamefeel and tactical value, while also enhancing the atmosphere of a slowly darkening marine line. I've tweaked the timings to what I think both feels good and is balanced. Numbers and timings totally up for change. 

# Testing Photographs and Procedure

I rigorously tested flare timings, flaregun usage, and xeno acid dousing on local and found no issues. 

A showcase of what I want dying light feels like. 

<details>

![7](https://github.com/user-attachments/assets/6e576402-e3e5-4940-aac8-26899f94e80e)

![6](https://github.com/user-attachments/assets/67cee68a-758b-412c-a4f8-5d3165166e29)

![5](https://github.com/user-attachments/assets/380c9968-5f42-4d1d-9375-261668ed59e4)

![4](https://github.com/user-attachments/assets/9b85be27-016b-41ea-b8b6-b81cec653fc3)

![3](https://github.com/user-attachments/assets/b975623f-eec2-42fe-a778-88f50a5d14b6)

![2](https://github.com/user-attachments/assets/b7305f3b-fe53-41ce-b19e-24687bdd74cc)

<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog



:cl: MaximusRex


balance: Increased flare duration from a variable 9.5 --> 10.5 minute length to 15 minutes flat. 
balance: Flares start out strong (7 radius) and burn down to nothingness.
balance: Increased flare_damage from acid by 20% across the board. 

Weak Acid: 150-->180
Medium Acid: 500-->600
Strong Acid: 1875 -->2250 (RIP flare)

code: In flashlight.dm, added switch code to control flare burnout.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
