### PR TITLE
Buff Helmets/Gloves/Boots During HvH

### DIFF
--- a/code/datums/decorators/gamemode_decorator.dm
+++ b/code/datums/decorators/gamemode_decorator.dm
@@ -119,4 +119,31 @@ GAMEMODE_DECORATOR(/obj/item/clothing/suit/storage/marine/M35, /datum/game_mode/
 	ARMOR_EDIT(armor_internaldamage, CLOTHING_ARMOR_HIGH)
 ))
 
+//************ USCM Helmet Values ************//
+
+GAMEMODE_DECORATOR(/obj/item/clothing/head/helmet/marine, /datum/game_mode/extended/faction_clash, list(
+	ARMOR_EDIT(armor_bullet, CLOTHING_ARMOR_HIGH),
+	ARMOR_EDIT(armor_bomb, CLOTHING_ARMOR_MEDIUM),
+	ARMOR_EDIT(armor_internaldamage, CLOTHING_ARMOR_HIGH)
+))
+
+GAMEMODE_DECORATOR(/obj/item/clothing/head/helmet/marine/specialist, /datum/game_mode/extended/faction_clash, list(
+	ARMOR_EDIT(armor_bomb, CLOTHING_ARMOR_ULTRAHIGH),
+))
+
+//************ Shoe Values ************//
+
+GAMEMODE_DECORATOR(/obj/item/clothing/shoes/marine, /datum/game_mode/extended/faction_clash, list(
+	ARMOR_EDIT(armor_bullet, CLOTHING_ARMOR_HIGHPLUS),
+	ARMOR_EDIT(armor_bomb, CLOTHING_ARMOR_MEDIUM),
+	ARMOR_EDIT(armor_internaldamage, CLOTHING_ARMOR_MEDIUMHIGH)
+))
+
+//************ Glove Values ************//
+
+GAMEMODE_DECORATOR(/obj/item/clothing/gloves/marine, /datum/game_mode/extended/faction_clash, list(
+	ARMOR_EDIT(armor_bullet, CLOTHING_ARMOR_HIGH),
+	ARMOR_EDIT(armor_internaldamage, CLOTHING_ARMOR_HIGH)
+))
+
 //*********************** ------------------ ***********************//


### PR DESCRIPTION

# About the pull request

A continuation of my original PR. This will buff all helmets, gloves and boots to be comparable to the armour values of the UPP equilivants. 

# Explain why it's good for the game

I've found it important from event running HvH that the USCM need equilivant feet/hand/head protection to the UPP. This PR buffs these items to be comparable to their UPP counterparts. 

The chest area will continue to be variable, and will now be the ideal place to try to land your shots. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: During the 'Faction Clash' (HvH) game mode. Marine Helmets, gloves and boots will have similar armour values to their UPP counterparts. 
/:cl:
