### PR TITLE
UPP skill  changes for HvH and WL fix

### DIFF
--- a/code/modules/gear_presets/upp.dm
+++ b/code/modules/gear_presets/upp.dm
@@ -92,7 +92,7 @@
 	name = "UPP Soldier (Cryo)"
 	flags = EQUIPMENT_PRESET_START_OF_ROUND
 
-	skills = /datum/skills/upp
+	skills = /datum/skills/pfc
 	assignment = JOB_UPP
 	rank = JOB_UPP
 	role_comm_title = "Sol"
@@ -107,6 +107,7 @@
 /datum/equipment_preset/upp/soldier/dressed
 	name = "UPP Soldier"
 	flags = EQUIPMENT_PRESET_EXTRA
+	skills = /datum/skills/upp
 
 /datum/equipment_preset/upp/soldier/dressed/load_gear(mob/living/carbon/human/new_human)
 	//face
@@ -296,7 +297,7 @@
 /datum/equipment_preset/upp/medic
 	name = "UPP Medic (Cryo)"
 
-	skills = /datum/skills/upp/combat_medic
+	skills = /datum/skills/combat_medic
 	assignment = JOB_UPP_MEDIC
 	rank = JOB_UPP_MEDIC
 	role_comm_title = "Med"
@@ -305,6 +306,8 @@
 
 /datum/equipment_preset/upp/medic/dressed
 	name = "UPP Medic"
+
+	skills = /datum/skills/upp/combat_medic
 	flags = EQUIPMENT_PRESET_EXTRA
 
 /datum/equipment_preset/upp/medic/dressed/load_gear(mob/living/carbon/human/new_human)
@@ -491,7 +494,7 @@
 /datum/equipment_preset/upp/sapper
 	name = "UPP Sapper (Cryo)"
 
-	skills = /datum/skills/upp/combat_engineer
+	skills = /datum/skills/combat_engineer
 	assignment = JOB_UPP_ENGI
 	rank = JOB_UPP_ENGI
 	role_comm_title = "Sap"
@@ -500,6 +503,8 @@
 
 /datum/equipment_preset/upp/sapper/dressed
 	name = "UPP Sapper"
+
+	skills = /datum/skills/upp/combat_engineer
 	flags = EQUIPMENT_PRESET_EXTRA
 
 /datum/equipment_preset/upp/sapper/dressed/load_gear(mob/living/carbon/human/new_human)
@@ -647,10 +652,6 @@
 	)
 
 //*****************************************************************************************************/
-/datum/job/antag/upp/specialist
-	title = JOB_UPP_SPECIALIST
-	gear_preset = /datum/equipment_preset/upp/specialist
-	flags_startup_parameters = ROLE_ADD_TO_SQUAD
 
 /datum/equipment_preset/upp/specialist
 	name = "UPP Specialist minigun (Cryo)"
@@ -950,7 +951,7 @@
 /datum/equipment_preset/upp/leader
 	name = "UPP Squad Leader (Cryo)"
 
-	skills = /datum/skills/upp/SL
+	skills = /datum/skills/SL
 	assignment = JOB_UPP_LEADER
 	rank = JOB_UPP_LEADER
 	role_comm_title = "SL"
@@ -959,6 +960,8 @@
 
 /datum/equipment_preset/upp/leader/dressed
 	name = "UPP Squad Leader"
+
+	skills = /datum/skills/upp/SL
 	flags = EQUIPMENT_PRESET_EXTRA
 
 /datum/equipment_preset/upp/leader/dressed/load_gear(mob/living/carbon/human/new_human)
@@ -2819,7 +2822,7 @@
 
 //*****************************************************************************************************/
 /datum/job/antag/upp/officer/ley_gen
-	title = JOB_UPP_LT_GENERAL
+	title = JOB_UPP_KOL_OFFICER
 	gear_preset = /datum/equipment_preset/upp/officer/ley_gen
 
 /datum/equipment_preset/upp/officer/ley_gen
@@ -2992,7 +2995,7 @@
 
 //*****************************************************************************************************/
 /datum/job/antag/upp/officer/gen
-	title = JOB_UPP_GENERAL
+	title = JOB_UPP_KOL_OFFICER
 	gear_preset = /datum/equipment_preset/upp/officer/gen
 
 /datum/equipment_preset/upp/officer/gen
@@ -3204,11 +3207,6 @@
 //===================//
 //  UPP Synthetics  //
 //================//
-
-/datum/job/antag/upp/synth
-	title = JOB_UPP_SUPPORT_SYNTH
-	gear_preset = /datum/equipment_preset/upp/synth
-
 /datum/equipment_preset/upp/synth
 	name = "UPP Synthetic (Cryo)"
 
@@ -3355,7 +3353,7 @@
 
 		list("BELT (CHOOSE 1)", 0, null, null, null),
 		list("G8-A General Utility Pouch", 0, /obj/item/storage/backpack/general_belt, MARINE_CAN_BUY_BELT, VENDOR_ITEM_REGULAR),
-		list("M276 Lifesaver Bag", 0, /obj/item/storage/belt/medical/lifesaver/full, MARINE_CAN_BUY_BELT, VENDOR_ITEM_REGULAR),
+		list("M276 Lifesaver Bag", 0, /obj/item/storage/belt/medical/lifesaver/upp/full, MARINE_CAN_BUY_BELT, VENDOR_ITEM_REGULAR),
 		list("M276 Medical Storage Belt", 0, /obj/item/storage/belt/medical/full, MARINE_CAN_BUY_BELT, VENDOR_ITEM_REGULAR),
 		list("M276 Toolbelt Rig (Full)", 0, /obj/item/storage/belt/utility/full, MARINE_CAN_BUY_BELT, VENDOR_ITEM_REGULAR),
 

--- a/code/modules/gear_presets/upp.dm
+++ b/code/modules/gear_presets/upp.dm
@@ -3230,6 +3230,7 @@
 	minimap_icon = "upp_synth"
 	paygrades = list(PAY_SHORT_SYN = JOB_PLAYTIME_TIER_0)
 	idtype = /obj/item/card/id/dogtag
+	flags_whitelist =  WHITELIST_SYNTHETIC
 
 
 /datum/equipment_preset/upp/synth/dressed

--- a/code/modules/gear_presets/upp.dm
+++ b/code/modules/gear_presets/upp.dm
@@ -1943,6 +1943,7 @@
 /datum/job/antag/upp/officer/kapitan
 	title = JOB_UPP_KPT_OFFICER
 	gear_preset = /datum/equipment_preset/upp/officer/kapitan
+	flags_whitelist =  WHITELIST_COMMANDER
 
 /datum/equipment_preset/upp/officer/kapitan
 	name = "UPP Kapitan (Cryo)"
@@ -1952,7 +1953,7 @@
 	minimap_icon = "upp_xo"
 	paygrades = list(PAY_SHORT_UO3 = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/upp/kapitan
-	flags_whitelist =  WHITELIST_COMMANDER
+
 
 /datum/equipment_preset/upp/officer/kapitan/dressed
 	name = "UPP Kapitan"
@@ -2118,6 +2119,7 @@
 	flags_whitelist =  WHITELIST_COMMANDER
 	title = JOB_UPP_MAY_OFFICER
 	gear_preset = /datum/equipment_preset/upp/officer/major
+	flags_whitelist =  WHITELIST_COMMANDER
 
 /datum/equipment_preset/upp/officer/major
 	name = "UPP Mayjor (Cryo)"
@@ -2127,7 +2129,6 @@
 	minimap_icon = "upp_co"
 	paygrades = list(PAY_SHORT_UO4 = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/upp/commander
-	flags_whitelist =  WHITELIST_COMMANDER
 
 /datum/equipment_preset/upp/officer/major/dressed
 	name = "UPP Major"
@@ -2292,11 +2293,10 @@
 	)
 
 //*****************************************************************************************************/
-/datum/job/antag/upp/officer/lt_kolonel
+/datum/job/antag/upp/officer/podpolkovnik
 	flags_whitelist =  WHITELIST_COMMANDER_COUNCIL
 	title = JOB_UPP_LTKOL_OFFICER
 	gear_preset = /datum/equipment_preset/upp/officer/podpolkovnik
-
 
 
 /datum/equipment_preset/upp/officer/podpolkovnik
@@ -2307,7 +2307,6 @@
 	minimap_icon = "upp_co"
 	paygrades = list(PAY_SHORT_UO5 = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/upp/commander
-	flags_whitelist =  WHITELIST_COMMANDER
 
 /datum/equipment_preset/upp/officer/podpolkovnik/dressed
 	name = "UPP Leytenant Kolonel"
@@ -2481,6 +2480,8 @@
 	title = JOB_UPP_KOL_OFFICER
 	gear_preset = /datum/equipment_preset/upp/officer/podpolkovnik
 
+	flags_whitelist =  WHITELIST_COMMANDER
+
 /datum/equipment_preset/upp/officer/polkovnik
 	name = "UPP General Mayjor (Cryo)"
 	assignment = JOB_UPP_BRIG_GENERAL
@@ -2489,7 +2490,6 @@
 	minimap_icon = "upp_co"
 	paygrades = list(PAY_SHORT_UO7 = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/upp/commander
-	flags_whitelist =  WHITELIST_COMMANDER
 
 
 /datum/equipment_preset/upp/officer/polkovnik/dressed
@@ -2664,7 +2664,6 @@
 	minimap_icon = "upp_co"
 	paygrades = list(PAY_SHORT_UO7 = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/upp/commander
-	flags_whitelist =  WHITELIST_COMMANDER
 
 /datum/equipment_preset/upp/officer/may_gen/dressed
 	name = "UPP Mayjor General"
@@ -2831,6 +2830,8 @@
 	title = JOB_UPP_LT_GENERAL
 	gear_preset = /datum/equipment_preset/upp/officer/ley_gen
 
+	flags_whitelist =  WHITELIST_COMMANDER
+
 /datum/equipment_preset/upp/officer/ley_gen
 	name = "UPP General Polkovnik (Cryo)"
 	assignment = JOB_UPP_LT_GENERAL
@@ -2839,7 +2840,6 @@
 	minimap_icon = "upp_co"
 	paygrades = list(PAY_SHORT_UO8 = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/upp/commander
-	flags_whitelist =  WHITELIST_COMMANDER
 
 /datum/equipment_preset/upp/officer/ley_gen/dressed
 	name = "UPP Leytenant General"
@@ -3219,6 +3219,8 @@
 	title = JOB_UPP_SUPPORT_SYNTH
 	gear_preset = /datum/equipment_preset/upp/synth
 
+	flags_whitelist =  WHITELIST_SYNTHETIC
+
 /datum/equipment_preset/upp/synth
 	name = "UPP Synthetic (Cryo)"
 
@@ -3230,7 +3232,6 @@
 	minimap_icon = "upp_synth"
 	paygrades = list(PAY_SHORT_SYN = JOB_PLAYTIME_TIER_0)
 	idtype = /obj/item/card/id/dogtag
-	flags_whitelist =  WHITELIST_SYNTHETIC
 
 
 /datum/equipment_preset/upp/synth/dressed

--- a/code/modules/gear_presets/upp.dm
+++ b/code/modules/gear_presets/upp.dm
@@ -1952,6 +1952,7 @@
 	minimap_icon = "upp_xo"
 	paygrades = list(PAY_SHORT_UO3 = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/upp/kapitan
+	flags_whitelist =  WHITELIST_COMMANDER
 
 /datum/equipment_preset/upp/officer/kapitan/dressed
 	name = "UPP Kapitan"
@@ -2126,6 +2127,7 @@
 	minimap_icon = "upp_co"
 	paygrades = list(PAY_SHORT_UO4 = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/upp/commander
+	flags_whitelist =  WHITELIST_COMMANDER
 
 /datum/equipment_preset/upp/officer/major/dressed
 	name = "UPP Major"
@@ -2296,6 +2298,7 @@
 	gear_preset = /datum/equipment_preset/upp/officer/podpolkovnik
 
 
+
 /datum/equipment_preset/upp/officer/podpolkovnik
 	name = "UPP Podpolkovnik (Cryo)"
 	assignment = JOB_UPP_LTKOL_OFFICER
@@ -2304,6 +2307,7 @@
 	minimap_icon = "upp_co"
 	paygrades = list(PAY_SHORT_UO5 = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/upp/commander
+	flags_whitelist =  WHITELIST_COMMANDER
 
 /datum/equipment_preset/upp/officer/podpolkovnik/dressed
 	name = "UPP Leytenant Kolonel"
@@ -2485,6 +2489,7 @@
 	minimap_icon = "upp_co"
 	paygrades = list(PAY_SHORT_UO7 = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/upp/commander
+	flags_whitelist =  WHITELIST_COMMANDER
 
 
 /datum/equipment_preset/upp/officer/polkovnik/dressed
@@ -2659,6 +2664,7 @@
 	minimap_icon = "upp_co"
 	paygrades = list(PAY_SHORT_UO7 = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/upp/commander
+	flags_whitelist =  WHITELIST_COMMANDER
 
 /datum/equipment_preset/upp/officer/may_gen/dressed
 	name = "UPP Mayjor General"
@@ -2822,7 +2828,7 @@
 
 //*****************************************************************************************************/
 /datum/job/antag/upp/officer/ley_gen
-	title = JOB_UPP_KOL_OFFICER
+	title = JOB_UPP_LT_GENERAL
 	gear_preset = /datum/equipment_preset/upp/officer/ley_gen
 
 /datum/equipment_preset/upp/officer/ley_gen
@@ -2833,6 +2839,7 @@
 	minimap_icon = "upp_co"
 	paygrades = list(PAY_SHORT_UO8 = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/upp/commander
+	flags_whitelist =  WHITELIST_COMMANDER
 
 /datum/equipment_preset/upp/officer/ley_gen/dressed
 	name = "UPP Leytenant General"
@@ -2995,7 +3002,7 @@
 
 //*****************************************************************************************************/
 /datum/job/antag/upp/officer/gen
-	title = JOB_UPP_KOL_OFFICER
+	title = JOB_UPP_GENERAL
 	gear_preset = /datum/equipment_preset/upp/officer/gen
 
 /datum/equipment_preset/upp/officer/gen
@@ -3207,6 +3214,11 @@
 //===================//
 //  UPP Synthetics  //
 //================//
+
+/datum/job/antag/upp/synth
+	title = JOB_UPP_SUPPORT_SYNTH
+	gear_preset = /datum/equipment_preset/upp/synth
+
 /datum/equipment_preset/upp/synth
 	name = "UPP Synthetic (Cryo)"
 
@@ -3218,6 +3230,7 @@
 	minimap_icon = "upp_synth"
 	paygrades = list(PAY_SHORT_SYN = JOB_PLAYTIME_TIER_0)
 	idtype = /obj/item/card/id/dogtag
+
 
 /datum/equipment_preset/upp/synth/dressed
 	name = "UPP Synthetic"

--- a/code/modules/gear_presets/upp.dm
+++ b/code/modules/gear_presets/upp.dm
@@ -1943,7 +1943,6 @@
 /datum/job/antag/upp/officer/kapitan
 	title = JOB_UPP_KPT_OFFICER
 	gear_preset = /datum/equipment_preset/upp/officer/kapitan
-	flags_whitelist =  WHITELIST_COMMANDER
 
 /datum/equipment_preset/upp/officer/kapitan
 	name = "UPP Kapitan (Cryo)"
@@ -2119,7 +2118,6 @@
 	flags_whitelist =  WHITELIST_COMMANDER
 	title = JOB_UPP_MAY_OFFICER
 	gear_preset = /datum/equipment_preset/upp/officer/major
-	flags_whitelist =  WHITELIST_COMMANDER
 
 /datum/equipment_preset/upp/officer/major
 	name = "UPP Mayjor (Cryo)"
@@ -2476,11 +2474,9 @@
 
 //*****************************************************************************************************/
 /datum/job/antag/upp/officer/kolonel
-	flags_whitelist =  WHITELIST_COMMANDER_COLONEL
+	flags_whitelist = WHITELIST_COMMANDER_COLONEL
 	title = JOB_UPP_KOL_OFFICER
 	gear_preset = /datum/equipment_preset/upp/officer/podpolkovnik
-
-	flags_whitelist =  WHITELIST_COMMANDER
 
 /datum/equipment_preset/upp/officer/polkovnik
 	name = "UPP General Mayjor (Cryo)"


### PR DESCRIPTION
# About the pull request

sets engi, medic, rifleman and SL skills to be on pair with the USCM coutnerparts for HvH events

# Explain why it's good for the game
the units are ment to be similar this is step in that direction


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: changes UPP rifleman, medic,engi and squad leader skills to be the same as USCM coutnerparts for HvH events
fix: UPP CO and synth whitelists work on lobby joning
/:cl:
