### PR TITLE
Map conversion checks and mapmerge2 fixup rework

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -6,7 +6,7 @@ on:
   merge_group:
 jobs:
   run_linters:
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Run Linters
     runs-on: ubuntu-latest
     concurrency:
@@ -75,7 +75,7 @@ jobs:
       - run: ./DMCompiler_linux-x64/DMCompiler --suppress-unimplemented colonialmarines.dme
 
   compile_all_maps:
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Compile Maps
     runs-on: ubuntu-latest
     steps:
@@ -92,7 +92,7 @@ jobs:
           tools/build/build --ci dm -DCIBUILDING -DCITESTING -DALL_MAPS
 
   find_all_maps:
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Find Maps to Test
     runs-on: ubuntu-latest
     outputs:
@@ -117,7 +117,7 @@ jobs:
           ALTERNATE_TESTS_JSON=$(jq -nRc '[inputs | capture("^(?<major>[0-9]+)\\.(?<minor>[0-9]+): (?<map>.+)$")]' .github/alternate_byond_versions.txt)
           echo "alternate_tests=$ALTERNATE_TESTS_JSON" >> $GITHUB_OUTPUT
   run_all_tests:
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Unit Tests
     needs: [find_all_maps]
     strategy:
@@ -132,7 +132,7 @@ jobs:
       map: ${{ matrix.map }}
 
   run_alternate_tests:
-    if: "!contains(github.event.head_commit.message, '[ci skip]') && needs.find_all_maps.outputs.alternate_tests != '[]'"
+    if: ( !contains(github.event.head_commit.message, '[ci skip]') && needs.find_all_maps.outputs.alternate_tests != '[]' )
     name: Alternate Tests
     needs: [find_all_maps]
     strategy:
@@ -149,7 +149,7 @@ jobs:
       minor: ${{ matrix.setup.minor }}
 
   check_alternate_tests:
-    if: "!contains(github.event.head_commit.message, '[ci skip]') && needs.find_all_maps.outputs.alternate_tests != '[]'"
+    if: ( !contains(github.event.head_commit.message, '[ci skip]') && needs.find_all_maps.outputs.alternate_tests != '[]' )
     name: Check Alternate Tests
     needs: [run_alternate_tests]
     runs-on: ubuntu-latest
@@ -157,7 +157,7 @@ jobs:
       - run: echo Alternate tests passed.
 
   test_windows:
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Windows Build
     runs-on: windows-latest
     concurrency:

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -14,6 +14,8 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Restore SpacemanDMM cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -13,14 +13,14 @@ jobs:
       group: run_linters-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Restore SpacemanDMM cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/SpacemanDMM
           key: ${{ runner.os }}-spacemandmm-${{ secrets.CACHE_PURGE_KEY }}
       - name: Restore Yarn cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: tgui/.yarn/cache
           key: ${{ runner.os }}-yarn-${{ secrets.CACHE_PURGE_KEY }}-${{ hashFiles('tgui/yarn.lock') }}
@@ -28,7 +28,7 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
       - name: Restore Rust cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cargo
           key: ${{ runner.os }}-rust

--- a/.github/workflows/generate_documentation.yml
+++ b/.github/workflows/generate_documentation.yml
@@ -5,7 +5,7 @@ on:
     - master
 jobs:
   generate_documentation:
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     runs-on: ubuntu-latest
     concurrency: gen-docs
     steps:

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -33,6 +33,30 @@
 "aah" = (
 /turf/open/floor/almayer_hull/outerhull_dir/east,
 /area/space)
+"aai" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/structure/machinery/landinglight/ds2{
+	dir = 8
+	},
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plate,
+/area/almayer/hallways/hangar)
+"aaj" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/obj/structure/platform_decoration/metal/almayer/east,
+/obj/item/tool/warning_cone,
+/turf/open/floor/almayer/plate,
+/area/almayer/hallways/hangar)
 "aak" = (
 /obj/effect/step_trigger/teleporter/random{
 	affect_ghosts = 1;
@@ -46,6 +70,18 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"aal" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plate,
+/area/almayer/hallways/hangar)
 "aam" = (
 /obj/structure/stairs,
 /obj/effect/step_trigger/teleporter_vector{
@@ -55,6 +91,31 @@
 	},
 /turf/open/floor/plating/almayer/no_build,
 /area/almayer/stair_clone/upper)
+"aan" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/structure/machinery/landinglight/ds1/delaytwo{
+	dir = 4
+	},
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/plate,
+/area/almayer/hallways/hangar)
+"aao" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hallways/hangar)
+"aap" = (
+/obj/structure/machinery/landinglight/ds1{
+	dir = 4
+	},
+/obj/structure/platform_decoration/metal/almayer/north,
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/floor/almayer/plate,
+/area/almayer/hallways/hangar)
 "aaq" = (
 /obj/item/bedsheet/purple{
 	layer = 3.2
@@ -93,13 +154,59 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/living/port_emb)
+"aar" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/plating/northeast,
+/area/almayer/engineering/lower/engine_core)
+"aas" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer,
+/area/almayer/living/briefing)
+"aat" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer,
+/area/almayer/living/briefing)
 "aau" = (
 /turf/closed/wall/almayer/reinforced/temphull,
 /area/almayer/living/pilotbunks)
+"aav" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plating/northeast,
+/area/almayer/engineering/lower/engine_core)
+"aaw" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer,
+/area/almayer/living/briefing)
+"aax" = (
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/medical/lower_medical_medbay)
+"aay" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/plating/northeast,
+/area/almayer/engineering/lower/engine_core)
+"aaz" = (
+/obj/structure/platform_decoration/metal/almayer/west{
+	name = "testing"
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/lower/repair_bay)
+"aaA" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer,
+/area/almayer/hallways/lower/repair_bay)
+"aaB" = (
+/obj/effect/step_trigger/clone_cleaner,
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/aicore/no_build/ai_silver/west,
+/area/almayer/command/airoom)
 "aaC" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"aaD" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/maint/hull/upper/u_a_p)
 "aaE" = (
 /obj/structure/sign/safety/storage{
 	pixel_x = 8;
@@ -119,6 +226,10 @@
 	},
 /turf/open/floor/plating/almayer/no_build,
 /area/almayer/stair_clone)
+"aaG" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_p)
 "aaH" = (
 /obj/effect/step_trigger/teleporter_vector{
 	name = "Almayer_Down1";
@@ -127,6 +238,40 @@
 	},
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/stair_clone/upper)
+"aaI" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/obj/item/reagent_container/glass/bucket/mopbucket{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_p)
+"aaJ" = (
+/obj/item/stack/catwalk,
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/plating,
+/area/almayer/maint/hull/upper/u_a_p)
+"aaK" = (
+/obj/item/tool/screwdriver,
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_p)
+"aaL" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_p)
+"aaM" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/red,
+/area/almayer/lifeboat_pumps/south2)
+"aaN" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/red,
+/area/almayer/lifeboat_pumps/south1)
+"aaO" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/south2)
 "aaP" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
 	dir = 2;
@@ -142,10 +287,51 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/shipboard/brig/starboard_hallway)
+"aaQ" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/south2)
+"aaR" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/maint/hull/upper/u_a_p)
+"aaS" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/south1)
+"aaT" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/south1)
+"aaU" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/mono,
+/area/almayer/medical/upper_medical)
+"aaV" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/obj/structure/platform_decoration/metal/almayer/north,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/medical/upper_medical)
+"aaW" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/mono,
+/area/almayer/medical/upper_medical)
+"aaX" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer,
+/area/almayer/living/chapel)
 "aaY" = (
 /obj/structure/lattice,
 /turf/open/space,
 /area/space)
+"aaZ" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer,
+/area/almayer/living/chapel)
 "aba" = (
 /obj/structure/machinery/door/airlock/almayer/secure/reinforced{
 	dir = 2;
@@ -154,10 +340,30 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/powered)
+"abb" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/red,
+/area/almayer/lifeboat_pumps/north1)
+"abc" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/red,
+/area/almayer/lifeboat_pumps/north2)
+"abd" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_s)
+"abe" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_s)
 "abf" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
+"abg" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_s)
 "abh" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/lifeboat_pumps/north2)
@@ -173,12 +379,28 @@
 /obj/structure/window/reinforced/toughened,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/command/cic)
+"abl" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/north1)
+"abm" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/north1)
 "abn" = (
 /obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/almayer,
 /area/almayer/maint/hull/upper/u_f_p)
+"abo" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/north2)
+"abp" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/north2)
 "abs" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/lifeboat_pumps/north1)
@@ -1532,10 +1754,6 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/northwest,
 /area/almayer/medical/lower_medical_medbay)
-"akX" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/north2)
 "ald" = (
 /turf/open/floor/almayer/red,
 /area/almayer/shipboard/weapon_room)
@@ -13346,10 +13564,6 @@
 "bVw" = (
 /turf/open/floor/almayer/bluecorner/east,
 /area/almayer/living/briefing)
-"bVx" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/south1)
 "bVy" = (
 /obj/structure/machinery/chem_dispenser/corpsman{
 	pixel_y = 3
@@ -14070,10 +14284,6 @@
 	},
 /turf/open/floor/almayer/cargo_arrow/west,
 /area/almayer/squads/alpha)
-"cel" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer,
-/area/almayer/living/briefing)
 "ceC" = (
 /obj/structure/prop/almayer/ship_memorial,
 /turf/open/floor/plating/almayer,
@@ -17015,10 +17225,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/upper_engineering/starboard)
-"dbK" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/north2)
 "dbM" = (
 /obj/structure/machinery/door/poddoor/almayer/blended/liaison{
 	id = "RoomDivider"
@@ -17226,12 +17432,6 @@
 /obj/structure/bed/chair/bolted,
 /turf/open/floor/almayer/plating_striped,
 /area/almayer/shipboard/brig/execution)
-"dhj" = (
-/obj/structure/platform_decoration/metal/almayer/west{
-	name = "testing"
-	},
-/turf/open/floor/almayer,
-/area/almayer/hallways/lower/repair_bay)
 "dho" = (
 /obj/structure/machinery/alarm/almayer{
 	dir = 1
@@ -19297,10 +19497,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_a_p)
-"eaA" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer,
-/area/almayer/living/chapel)
 "ebd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
@@ -20633,10 +20829,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
-"eBj" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/north1)
 "eBx" = (
 /obj/structure/closet/emcloset/legacy,
 /turf/open/floor/almayer/cargo,
@@ -21665,11 +21857,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/living/briefing)
-"eYv" = (
-/obj/item/tool/screwdriver,
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_p)
 "eYD" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -22110,10 +22297,6 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/northwest,
 /area/almayer/shipboard/brig/medical)
-"fgy" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer,
-/area/almayer/hallways/lower/repair_bay)
 "fgE" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -24512,11 +24695,6 @@
 "gnv" = (
 /turf/open/floor/almayer/red/northeast,
 /area/almayer/lifeboat_pumps/south1)
-"gnG" = (
-/obj/item/stack/catwalk,
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/plating,
-/area/almayer/maint/hull/upper/u_a_p)
 "gnK" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /obj/structure/disposalpipe/junction{
@@ -26014,10 +26192,6 @@
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_m_s)
-"gST" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/hangar)
 "gTk" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/light{
@@ -26277,10 +26451,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/u_a_p)
-"gYW" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/red,
-/area/almayer/lifeboat_pumps/north1)
 "gZw" = (
 /obj/structure/bed/sofa/vert/grey/bot,
 /turf/open/floor/almayer,
@@ -26588,10 +26758,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/lower/s_bow)
-"hfy" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/plating/northeast,
-/area/almayer/engineering/lower/engine_core)
 "hfO" = (
 /obj/structure/machinery/light/small{
 	dir = 1
@@ -27488,10 +27654,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/starboard_missiles)
-"hxX" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/south1)
 "hxZ" = (
 /obj/structure/surface/rack,
 /obj/item/tool/shovel/spade{
@@ -28346,11 +28508,6 @@
 "hSk" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/upper_engineering/port)
-"hSo" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/mono,
-/area/almayer/medical/upper_medical)
 "hSt" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -28836,10 +28993,6 @@
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/lower_medical_lobby)
-"iaK" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer,
-/area/almayer/living/briefing)
 "iaO" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = 32
@@ -31944,10 +32097,6 @@
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/engineering/laundry)
-"joS" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/red,
-/area/almayer/lifeboat_pumps/south2)
 "jpl" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NE-out";
@@ -34134,10 +34283,6 @@
 /obj/structure/pipes/standard/manifold/fourway/hidden/supply,
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/lower/starboard_aft_hallway)
-"kkQ" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_p)
 "kkW" = (
 /obj/structure/surface/table/almayer,
 /obj/item/book/manual/atmospipes,
@@ -34894,10 +35039,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/living/port_emb)
-"kzQ" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_s)
 "kAh" = (
 /obj/structure/sign/safety/restrictedarea{
 	pixel_x = -17
@@ -37352,10 +37493,6 @@
 "lAl" = (
 /turf/open/floor/almayer/orange/east,
 /area/almayer/squads/bravo)
-"lAm" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_p)
 "lAu" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/engidoor{
 	dir = 1
@@ -37998,10 +38135,6 @@
 	},
 /turf/open/floor/almayer/plating/northeast,
 /area/almayer/engineering/lower/engine_core)
-"lPc" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_p)
 "lPm" = (
 /obj/structure/machinery/firealarm{
 	dir = 4;
@@ -40181,17 +40314,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/mono,
 /area/almayer/medical/upper_medical)
-"mMB" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/structure/machinery/landinglight/ds1/delaytwo{
-	dir = 4
-	},
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/plate,
-/area/almayer/hallways/hangar)
 "mMP" = (
 /obj/effect/landmark/start/intel,
 /obj/effect/landmark/late_join/intel,
@@ -43882,10 +44004,6 @@
 	},
 /turf/open/floor/almayer_hull/outerhull_dir,
 /area/space)
-"okG" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/north1)
 "old" = (
 /obj/structure/machinery/light/small,
 /obj/structure/largecrate/random/case/double,
@@ -48069,10 +48187,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/blue,
 /area/almayer/living/pilotbunks)
-"pWU" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/mono,
-/area/almayer/medical/upper_medical)
 "pXl" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -49297,16 +49411,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/cargo,
 /area/almayer/squads/charlie)
-"qwS" = (
-/obj/structure/machinery/landinglight/ds1{
-	dir = 4
-	},
-/obj/structure/platform_decoration/metal/almayer/north,
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/hallways/hangar)
 "qwU" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out"
@@ -50171,10 +50275,6 @@
 /obj/structure/platform/metal/almayer/east,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north2)
-"qMu" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_s)
 "qMD" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/box/flashbangs,
@@ -51296,10 +51396,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/upper_engineering)
-"rko" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/red,
-/area/almayer/lifeboat_pumps/south1)
 "rkz" = (
 /obj/structure/pipes/vents/scrubber,
 /turf/open/floor/almayer,
@@ -51499,10 +51595,6 @@
 	},
 /turf/open/floor/almayer/cargo,
 /area/almayer/squads/bravo)
-"roB" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/south2)
 "roG" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -53709,10 +53801,6 @@
 	},
 /turf/open/floor/almayer/cargo,
 /area/almayer/engineering/lower/engine_core)
-"sij" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/south2)
 "sin" = (
 /turf/open/floor/almayer/bluecorner,
 /area/almayer/hallways/upper/midship_hallway)
@@ -56564,10 +56652,6 @@
 /obj/structure/reagent_dispensers/fueltank/custom,
 /turf/open/floor/almayer/plating/northeast,
 /area/almayer/engineering/lower/engine_core)
-"tqG" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/red,
-/area/almayer/lifeboat_pumps/north2)
 "tqO" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -57404,10 +57488,6 @@
 /obj/structure/window/framed/almayer,
 /turf/open/floor/plating,
 /area/almayer/shipboard/brig/cells)
-"tIa" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer,
-/area/almayer/living/briefing)
 "tId" = (
 /obj/structure/machinery/recharge_station,
 /turf/open/floor/almayer/aicore/no_build/ai_cargo,
@@ -59815,10 +59895,6 @@
 /obj/item/reagent_container/food/snacks/mre_pack/xmas3,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/s_stern)
-"uLL" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plating/northeast,
-/area/almayer/engineering/lower/engine_core)
 "uMc" = (
 /obj/structure/window/framed/almayer/hull,
 /turf/open/floor/plating,
@@ -60229,10 +60305,6 @@
 	},
 /turf/open/floor/almayer/red/northeast,
 /area/almayer/shipboard/brig/perma)
-"uUy" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_p)
 "uUz" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/poddoor/shutters/almayer{
@@ -61106,10 +61178,6 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/maint/hull/upper/p_bow)
-"vkE" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer,
-/area/almayer/living/chapel)
 "vkI" = (
 /obj/item/coin/silver{
 	desc = "A small coin, bearing the falling falcons insignia.";
@@ -64448,10 +64516,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_m_p)
-"wtm" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_s)
 "wtn" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -65275,11 +65339,6 @@
 "wJH" = (
 /turf/closed/wall/almayer/research/containment/wall/east,
 /area/almayer/medical/containment/cell/cl)
-"wJI" = (
-/obj/effect/step_trigger/clone_cleaner,
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/aicore/no_build/ai_silver/west,
-/area/almayer/command/airoom)
 "wKb" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -65967,14 +66026,6 @@
 	},
 /turf/open/floor/almayer/mono,
 /area/almayer/lifeboat_pumps/north2)
-"wXo" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/obj/item/reagent_container/glass/bucket/mopbucket{
-	pixel_x = 7;
-	pixel_y = -3
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_p)
 "wXz" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -66458,14 +66509,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cells)
-"xiu" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/obj/structure/platform_decoration/metal/almayer/north,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/medical/upper_medical)
 "xiH" = (
 /obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/almayer/plate,
@@ -66476,10 +66519,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/s_bow)
-"xiQ" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/plating/northeast,
-/area/almayer/engineering/lower/engine_core)
 "xiU" = (
 /obj/structure/machinery/portable_atmospherics/hydroponics,
 /obj/item/tool/minihoe{
@@ -67378,17 +67417,6 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/engineering/upper_engineering/port)
-"xBr" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/structure/machinery/landinglight/ds2{
-	dir = 8
-	},
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plate,
-/area/almayer/hallways/hangar)
 "xBK" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer/cargo,
@@ -68020,19 +68048,6 @@
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/command/corporateliaison)
-"xOw" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	pixel_x = 1
-	},
-/obj/structure/platform_decoration/metal/almayer/east,
-/obj/item/tool/warning_cone,
-/turf/open/floor/almayer/plate,
-/area/almayer/hallways/hangar)
 "xOL" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -68423,18 +68438,6 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/shipboard/brig/perma)
-"xXk" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "W"
-	},
-/obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plate,
-/area/almayer/hallways/hangar)
 "xXl" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -88711,7 +88714,7 @@ eWs
 nVo
 qlL
 aYs
-dhj
+aaz
 vnY
 mRH
 jHt
@@ -88737,7 +88740,7 @@ vbf
 yeN
 qrp
 mUI
-xBr
+aai
 baM
 bcb
 bHB
@@ -89117,7 +89120,7 @@ eWs
 jsw
 tPh
 tPh
-fgy
+aaA
 ctQ
 wer
 pKW
@@ -89141,9 +89144,9 @@ btO
 btO
 btO
 btO
-gST
+aao
 cQy
-xOw
+aaj
 rOc
 fVz
 bHB
@@ -90361,7 +90364,7 @@ bvf
 bvf
 vwW
 iaj
-xXk
+aal
 vsF
 bGJ
 hBF
@@ -90765,9 +90768,9 @@ bkh
 ohE
 vWJ
 qUL
-qwS
+aap
 iEn
-mMB
+aan
 baS
 bGL
 bHB
@@ -93068,11 +93071,11 @@ avd
 acW
 awW
 sAn
-okG
+abl
 aTm
 cpP
 aTm
-gYW
+abb
 hzS
 awW
 acW
@@ -93114,11 +93117,11 @@ tTu
 sgU
 baw
 dsn
-hxX
+aaS
 vbB
 aqB
 vbB
-rko
+aaN
 rAT
 baw
 sgU
@@ -93271,7 +93274,7 @@ avd
 acW
 awW
 tYQ
-eBj
+abm
 aTm
 cpP
 cbM
@@ -93317,7 +93320,7 @@ goL
 sgU
 baw
 wQh
-bVx
+aaT
 vbB
 aqB
 vbB
@@ -97356,7 +97359,7 @@ ajl
 xNu
 aCo
 rHz
-xiu
+aaV
 mMg
 kbn
 aCo
@@ -97454,7 +97457,7 @@ kan
 cWm
 soK
 gDW
-rlZ
+aax
 rlZ
 pqD
 pqD
@@ -97558,9 +97561,9 @@ eDo
 ajl
 pth
 akl
-pWU
+aaW
 gXl
-hSo
+aaU
 xdS
 awj
 ajl
@@ -102817,7 +102820,7 @@ cYT
 aNm
 cYT
 jwB
-vkE
+aaX
 vif
 bhx
 aOR
@@ -103629,7 +103632,7 @@ jWr
 aNm
 jWr
 olw
-eaA
+aaZ
 bhx
 bhx
 wWg
@@ -103752,7 +103755,7 @@ pfJ
 kDY
 ufh
 fDg
-cel
+aas
 beH
 beH
 beH
@@ -104763,11 +104766,11 @@ beH
 beH
 duv
 beH
-iaK
+aaw
 lgC
 oBG
 gZz
-tIa
+aat
 beH
 duv
 beH
@@ -110322,11 +110325,11 @@ gyU
 ajk
 aeA
 lgf
-dbK
+abo
 atr
 iDK
 atr
-tqG
+abc
 kEV
 aeA
 ajk
@@ -110370,11 +110373,11 @@ lJY
 xVS
 lJY
 iyf
-roB
+aaO
 faO
 cOd
 bXe
-joS
+aaM
 leT
 lJY
 xVS
@@ -110525,7 +110528,7 @@ gyU
 ajk
 aeA
 dtE
-akX
+abp
 atr
 iDK
 atr
@@ -110573,7 +110576,7 @@ cBb
 xVS
 lJY
 tRh
-sij
+aaQ
 bXe
 cOd
 tGi
@@ -112811,7 +112814,7 @@ ump
 oWU
 oWU
 oWU
-uUy
+aaD
 jei
 fVe
 aag
@@ -113168,7 +113171,7 @@ taw
 oNK
 xgw
 jGG
-qMu
+abd
 oxy
 oQL
 hdy
@@ -113420,7 +113423,7 @@ kNq
 jcE
 jei
 fCv
-lAm
+aaG
 dhp
 fVe
 aag
@@ -113623,7 +113626,7 @@ kNq
 cke
 hqu
 xeW
-wXo
+aaI
 jei
 fVe
 aag
@@ -113978,9 +113981,9 @@ oqc
 smw
 taw
 oxy
-kzQ
+abg
 mQw
-wtm
+abe
 oxy
 aqi
 qlu
@@ -114024,12 +114027,12 @@ oHx
 aPO
 iXB
 aPO
-lPc
+aaR
 oFP
 eMb
 eMb
 eMb
-gnG
+aaJ
 jei
 fVe
 aag
@@ -114232,7 +114235,7 @@ flK
 pKx
 flK
 flK
-eYv
+aaK
 jei
 fVe
 aag
@@ -115247,7 +115250,7 @@ yat
 xQe
 jei
 fCv
-lAm
+aaG
 dhp
 fVe
 aag
@@ -115450,7 +115453,7 @@ yat
 cfm
 jei
 xeW
-kkQ
+aaL
 jei
 fVe
 aag
@@ -115856,7 +115859,7 @@ kNq
 wyb
 mIa
 oFP
-lAm
+aaG
 jei
 fVe
 aag
@@ -121408,13 +121411,13 @@ txS
 bVN
 oGJ
 iYv
-hfy
+aay
 mVr
 mZL
 mZL
 mZL
 gSa
-xiQ
+aar
 rMe
 uqh
 iAE
@@ -121814,7 +121817,7 @@ igs
 nCn
 oGJ
 knq
-uLL
+aav
 vaZ
 kYL
 hmv
@@ -122628,7 +122631,7 @@ mlF
 hsy
 hmv
 hPo
-uLL
+aav
 pzM
 dQH
 wFB
@@ -126646,7 +126649,7 @@ ktQ
 teZ
 wkM
 ege
-wJI
+aaB
 wrm
 wrm
 tOa

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -17227,9 +17227,7 @@
 /turf/open/floor/almayer/plating_striped,
 /area/almayer/shipboard/brig/execution)
 "dhj" = (
-/obj/structure/platform_decoration/metal/almayer/west{
-	name = "testing"
-	},
+/obj/structure/platform_decoration/metal/almayer/west,
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/repair_bay)
 "dho" = (

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -17227,7 +17227,9 @@
 /turf/open/floor/almayer/plating_striped,
 /area/almayer/shipboard/brig/execution)
 "dhj" = (
-/obj/structure/platform_decoration/metal/almayer/west,
+/obj/structure/platform_decoration/metal/almayer/west{
+	name = "testing"
+	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/repair_bay)
 "dho" = (

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -33,30 +33,6 @@
 "aah" = (
 /turf/open/floor/almayer_hull/outerhull_dir/east,
 /area/space)
-"aai" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/structure/machinery/landinglight/ds2{
-	dir = 8
-	},
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plate,
-/area/almayer/hallways/hangar)
-"aaj" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	pixel_x = 1
-	},
-/obj/structure/platform_decoration/metal/almayer/east,
-/obj/item/tool/warning_cone,
-/turf/open/floor/almayer/plate,
-/area/almayer/hallways/hangar)
 "aak" = (
 /obj/effect/step_trigger/teleporter/random{
 	affect_ghosts = 1;
@@ -70,18 +46,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"aal" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "W"
-	},
-/obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plate,
-/area/almayer/hallways/hangar)
 "aam" = (
 /obj/structure/stairs,
 /obj/effect/step_trigger/teleporter_vector{
@@ -91,31 +55,6 @@
 	},
 /turf/open/floor/plating/almayer/no_build,
 /area/almayer/stair_clone/upper)
-"aan" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/structure/machinery/landinglight/ds1/delaytwo{
-	dir = 4
-	},
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/plate,
-/area/almayer/hallways/hangar)
-"aao" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/hangar)
-"aap" = (
-/obj/structure/machinery/landinglight/ds1{
-	dir = 4
-	},
-/obj/structure/platform_decoration/metal/almayer/north,
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/hallways/hangar)
 "aaq" = (
 /obj/item/bedsheet/purple{
 	layer = 3.2
@@ -154,59 +93,13 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/living/port_emb)
-"aar" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/plating/northeast,
-/area/almayer/engineering/lower/engine_core)
-"aas" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer,
-/area/almayer/living/briefing)
-"aat" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer,
-/area/almayer/living/briefing)
 "aau" = (
 /turf/closed/wall/almayer/reinforced/temphull,
 /area/almayer/living/pilotbunks)
-"aav" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plating/northeast,
-/area/almayer/engineering/lower/engine_core)
-"aaw" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer,
-/area/almayer/living/briefing)
-"aax" = (
-/turf/open/floor/almayer/dark_sterile,
-/area/almayer/medical/lower_medical_medbay)
-"aay" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/plating/northeast,
-/area/almayer/engineering/lower/engine_core)
-"aaz" = (
-/obj/structure/platform_decoration/metal/almayer/west{
-	name = "testing"
-	},
-/turf/open/floor/almayer,
-/area/almayer/hallways/lower/repair_bay)
-"aaA" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer,
-/area/almayer/hallways/lower/repair_bay)
-"aaB" = (
-/obj/effect/step_trigger/clone_cleaner,
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/aicore/no_build/ai_silver/west,
-/area/almayer/command/airoom)
 "aaC" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
-"aaD" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_p)
 "aaE" = (
 /obj/structure/sign/safety/storage{
 	pixel_x = 8;
@@ -226,10 +119,6 @@
 	},
 /turf/open/floor/plating/almayer/no_build,
 /area/almayer/stair_clone)
-"aaG" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_p)
 "aaH" = (
 /obj/effect/step_trigger/teleporter_vector{
 	name = "Almayer_Down1";
@@ -238,40 +127,6 @@
 	},
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/stair_clone/upper)
-"aaI" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/obj/item/reagent_container/glass/bucket/mopbucket{
-	pixel_x = 7;
-	pixel_y = -3
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_p)
-"aaJ" = (
-/obj/item/stack/catwalk,
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/plating,
-/area/almayer/maint/hull/upper/u_a_p)
-"aaK" = (
-/obj/item/tool/screwdriver,
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_p)
-"aaL" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_p)
-"aaM" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/red,
-/area/almayer/lifeboat_pumps/south2)
-"aaN" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/red,
-/area/almayer/lifeboat_pumps/south1)
-"aaO" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/south2)
 "aaP" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
 	dir = 2;
@@ -287,51 +142,10 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/shipboard/brig/starboard_hallway)
-"aaQ" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/south2)
-"aaR" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_p)
-"aaS" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/south1)
-"aaT" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/south1)
-"aaU" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/mono,
-/area/almayer/medical/upper_medical)
-"aaV" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/obj/structure/platform_decoration/metal/almayer/north,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/medical/upper_medical)
-"aaW" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/mono,
-/area/almayer/medical/upper_medical)
-"aaX" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer,
-/area/almayer/living/chapel)
 "aaY" = (
 /obj/structure/lattice,
 /turf/open/space,
 /area/space)
-"aaZ" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer,
-/area/almayer/living/chapel)
 "aba" = (
 /obj/structure/machinery/door/airlock/almayer/secure/reinforced{
 	dir = 2;
@@ -340,30 +154,10 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/powered)
-"abb" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/red,
-/area/almayer/lifeboat_pumps/north1)
-"abc" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/red,
-/area/almayer/lifeboat_pumps/north2)
-"abd" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_s)
-"abe" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_s)
 "abf" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
-"abg" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_s)
 "abh" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/lifeboat_pumps/north2)
@@ -379,28 +173,12 @@
 /obj/structure/window/reinforced/toughened,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/command/cic)
-"abl" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/north1)
-"abm" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/north1)
 "abn" = (
 /obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/almayer,
 /area/almayer/maint/hull/upper/u_f_p)
-"abo" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/north2)
-"abp" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/north2)
 "abs" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/lifeboat_pumps/north1)
@@ -1754,6 +1532,10 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/northwest,
 /area/almayer/medical/lower_medical_medbay)
+"akX" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/north2)
 "ald" = (
 /turf/open/floor/almayer/red,
 /area/almayer/shipboard/weapon_room)
@@ -13564,6 +13346,10 @@
 "bVw" = (
 /turf/open/floor/almayer/bluecorner/east,
 /area/almayer/living/briefing)
+"bVx" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/south1)
 "bVy" = (
 /obj/structure/machinery/chem_dispenser/corpsman{
 	pixel_y = 3
@@ -14284,6 +14070,10 @@
 	},
 /turf/open/floor/almayer/cargo_arrow/west,
 /area/almayer/squads/alpha)
+"cel" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer,
+/area/almayer/living/briefing)
 "ceC" = (
 /obj/structure/prop/almayer/ship_memorial,
 /turf/open/floor/plating/almayer,
@@ -17225,6 +17015,10 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/upper_engineering/starboard)
+"dbK" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/north2)
 "dbM" = (
 /obj/structure/machinery/door/poddoor/almayer/blended/liaison{
 	id = "RoomDivider"
@@ -17432,6 +17226,12 @@
 /obj/structure/bed/chair/bolted,
 /turf/open/floor/almayer/plating_striped,
 /area/almayer/shipboard/brig/execution)
+"dhj" = (
+/obj/structure/platform_decoration/metal/almayer/west{
+	name = "testing"
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/lower/repair_bay)
 "dho" = (
 /obj/structure/machinery/alarm/almayer{
 	dir = 1
@@ -19497,6 +19297,10 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_a_p)
+"eaA" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer,
+/area/almayer/living/chapel)
 "ebd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
@@ -20829,6 +20633,10 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
+"eBj" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/north1)
 "eBx" = (
 /obj/structure/closet/emcloset/legacy,
 /turf/open/floor/almayer/cargo,
@@ -21857,6 +21665,11 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/living/briefing)
+"eYv" = (
+/obj/item/tool/screwdriver,
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_p)
 "eYD" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -22297,6 +22110,10 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/northwest,
 /area/almayer/shipboard/brig/medical)
+"fgy" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer,
+/area/almayer/hallways/lower/repair_bay)
 "fgE" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -24695,6 +24512,11 @@
 "gnv" = (
 /turf/open/floor/almayer/red/northeast,
 /area/almayer/lifeboat_pumps/south1)
+"gnG" = (
+/obj/item/stack/catwalk,
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/plating,
+/area/almayer/maint/hull/upper/u_a_p)
 "gnK" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /obj/structure/disposalpipe/junction{
@@ -26192,6 +26014,10 @@
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_m_s)
+"gST" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hallways/hangar)
 "gTk" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/light{
@@ -26451,6 +26277,10 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/u_a_p)
+"gYW" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/red,
+/area/almayer/lifeboat_pumps/north1)
 "gZw" = (
 /obj/structure/bed/sofa/vert/grey/bot,
 /turf/open/floor/almayer,
@@ -26758,6 +26588,10 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/lower/s_bow)
+"hfy" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/plating/northeast,
+/area/almayer/engineering/lower/engine_core)
 "hfO" = (
 /obj/structure/machinery/light/small{
 	dir = 1
@@ -27654,6 +27488,10 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/starboard_missiles)
+"hxX" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/south1)
 "hxZ" = (
 /obj/structure/surface/rack,
 /obj/item/tool/shovel/spade{
@@ -28508,6 +28346,11 @@
 "hSk" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/upper_engineering/port)
+"hSo" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/mono,
+/area/almayer/medical/upper_medical)
 "hSt" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -28993,6 +28836,10 @@
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/lower_medical_lobby)
+"iaK" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer,
+/area/almayer/living/briefing)
 "iaO" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = 32
@@ -32097,6 +31944,10 @@
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/engineering/laundry)
+"joS" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/red,
+/area/almayer/lifeboat_pumps/south2)
 "jpl" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NE-out";
@@ -34283,6 +34134,10 @@
 /obj/structure/pipes/standard/manifold/fourway/hidden/supply,
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/lower/starboard_aft_hallway)
+"kkQ" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_p)
 "kkW" = (
 /obj/structure/surface/table/almayer,
 /obj/item/book/manual/atmospipes,
@@ -35039,6 +34894,10 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/living/port_emb)
+"kzQ" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_s)
 "kAh" = (
 /obj/structure/sign/safety/restrictedarea{
 	pixel_x = -17
@@ -37493,6 +37352,10 @@
 "lAl" = (
 /turf/open/floor/almayer/orange/east,
 /area/almayer/squads/bravo)
+"lAm" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_p)
 "lAu" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/engidoor{
 	dir = 1
@@ -38135,6 +37998,10 @@
 	},
 /turf/open/floor/almayer/plating/northeast,
 /area/almayer/engineering/lower/engine_core)
+"lPc" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/maint/hull/upper/u_a_p)
 "lPm" = (
 /obj/structure/machinery/firealarm{
 	dir = 4;
@@ -40314,6 +40181,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/mono,
 /area/almayer/medical/upper_medical)
+"mMB" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/structure/machinery/landinglight/ds1/delaytwo{
+	dir = 4
+	},
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/plate,
+/area/almayer/hallways/hangar)
 "mMP" = (
 /obj/effect/landmark/start/intel,
 /obj/effect/landmark/late_join/intel,
@@ -44004,6 +43882,10 @@
 	},
 /turf/open/floor/almayer_hull/outerhull_dir,
 /area/space)
+"okG" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/north1)
 "old" = (
 /obj/structure/machinery/light/small,
 /obj/structure/largecrate/random/case/double,
@@ -48187,6 +48069,10 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/blue,
 /area/almayer/living/pilotbunks)
+"pWU" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/mono,
+/area/almayer/medical/upper_medical)
 "pXl" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -49411,6 +49297,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/cargo,
 /area/almayer/squads/charlie)
+"qwS" = (
+/obj/structure/machinery/landinglight/ds1{
+	dir = 4
+	},
+/obj/structure/platform_decoration/metal/almayer/north,
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/floor/almayer/plate,
+/area/almayer/hallways/hangar)
 "qwU" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out"
@@ -50275,6 +50171,10 @@
 /obj/structure/platform/metal/almayer/east,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north2)
+"qMu" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_s)
 "qMD" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/box/flashbangs,
@@ -51396,6 +51296,10 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/upper_engineering)
+"rko" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/red,
+/area/almayer/lifeboat_pumps/south1)
 "rkz" = (
 /obj/structure/pipes/vents/scrubber,
 /turf/open/floor/almayer,
@@ -51595,6 +51499,10 @@
 	},
 /turf/open/floor/almayer/cargo,
 /area/almayer/squads/bravo)
+"roB" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/south2)
 "roG" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -53801,6 +53709,10 @@
 	},
 /turf/open/floor/almayer/cargo,
 /area/almayer/engineering/lower/engine_core)
+"sij" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/south2)
 "sin" = (
 /turf/open/floor/almayer/bluecorner,
 /area/almayer/hallways/upper/midship_hallway)
@@ -56652,6 +56564,10 @@
 /obj/structure/reagent_dispensers/fueltank/custom,
 /turf/open/floor/almayer/plating/northeast,
 /area/almayer/engineering/lower/engine_core)
+"tqG" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/red,
+/area/almayer/lifeboat_pumps/north2)
 "tqO" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -57488,6 +57404,10 @@
 /obj/structure/window/framed/almayer,
 /turf/open/floor/plating,
 /area/almayer/shipboard/brig/cells)
+"tIa" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer,
+/area/almayer/living/briefing)
 "tId" = (
 /obj/structure/machinery/recharge_station,
 /turf/open/floor/almayer/aicore/no_build/ai_cargo,
@@ -59895,6 +59815,10 @@
 /obj/item/reagent_container/food/snacks/mre_pack/xmas3,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/s_stern)
+"uLL" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plating/northeast,
+/area/almayer/engineering/lower/engine_core)
 "uMc" = (
 /obj/structure/window/framed/almayer/hull,
 /turf/open/floor/plating,
@@ -60305,6 +60229,10 @@
 	},
 /turf/open/floor/almayer/red/northeast,
 /area/almayer/shipboard/brig/perma)
+"uUy" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/maint/hull/upper/u_a_p)
 "uUz" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/poddoor/shutters/almayer{
@@ -61178,6 +61106,10 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/maint/hull/upper/p_bow)
+"vkE" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer,
+/area/almayer/living/chapel)
 "vkI" = (
 /obj/item/coin/silver{
 	desc = "A small coin, bearing the falling falcons insignia.";
@@ -64516,6 +64448,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_m_p)
+"wtm" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_s)
 "wtn" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -65339,6 +65275,11 @@
 "wJH" = (
 /turf/closed/wall/almayer/research/containment/wall/east,
 /area/almayer/medical/containment/cell/cl)
+"wJI" = (
+/obj/effect/step_trigger/clone_cleaner,
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/aicore/no_build/ai_silver/west,
+/area/almayer/command/airoom)
 "wKb" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -66026,6 +65967,14 @@
 	},
 /turf/open/floor/almayer/mono,
 /area/almayer/lifeboat_pumps/north2)
+"wXo" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/obj/item/reagent_container/glass/bucket/mopbucket{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_p)
 "wXz" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -66509,6 +66458,14 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cells)
+"xiu" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/obj/structure/platform_decoration/metal/almayer/north,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/medical/upper_medical)
 "xiH" = (
 /obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/almayer/plate,
@@ -66519,6 +66476,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/s_bow)
+"xiQ" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/plating/northeast,
+/area/almayer/engineering/lower/engine_core)
 "xiU" = (
 /obj/structure/machinery/portable_atmospherics/hydroponics,
 /obj/item/tool/minihoe{
@@ -67417,6 +67378,17 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/engineering/upper_engineering/port)
+"xBr" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/structure/machinery/landinglight/ds2{
+	dir = 8
+	},
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plate,
+/area/almayer/hallways/hangar)
 "xBK" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer/cargo,
@@ -68048,6 +68020,19 @@
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/command/corporateliaison)
+"xOw" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/obj/structure/platform_decoration/metal/almayer/east,
+/obj/item/tool/warning_cone,
+/turf/open/floor/almayer/plate,
+/area/almayer/hallways/hangar)
 "xOL" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -68438,6 +68423,18 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/shipboard/brig/perma)
+"xXk" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plate,
+/area/almayer/hallways/hangar)
 "xXl" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -88714,7 +88711,7 @@ eWs
 nVo
 qlL
 aYs
-aaz
+dhj
 vnY
 mRH
 jHt
@@ -88740,7 +88737,7 @@ vbf
 yeN
 qrp
 mUI
-aai
+xBr
 baM
 bcb
 bHB
@@ -89120,7 +89117,7 @@ eWs
 jsw
 tPh
 tPh
-aaA
+fgy
 ctQ
 wer
 pKW
@@ -89144,9 +89141,9 @@ btO
 btO
 btO
 btO
-aao
+gST
 cQy
-aaj
+xOw
 rOc
 fVz
 bHB
@@ -90364,7 +90361,7 @@ bvf
 bvf
 vwW
 iaj
-aal
+xXk
 vsF
 bGJ
 hBF
@@ -90768,9 +90765,9 @@ bkh
 ohE
 vWJ
 qUL
-aap
+qwS
 iEn
-aan
+mMB
 baS
 bGL
 bHB
@@ -93071,11 +93068,11 @@ avd
 acW
 awW
 sAn
-abl
+okG
 aTm
 cpP
 aTm
-abb
+gYW
 hzS
 awW
 acW
@@ -93117,11 +93114,11 @@ tTu
 sgU
 baw
 dsn
-aaS
+hxX
 vbB
 aqB
 vbB
-aaN
+rko
 rAT
 baw
 sgU
@@ -93274,7 +93271,7 @@ avd
 acW
 awW
 tYQ
-abm
+eBj
 aTm
 cpP
 cbM
@@ -93320,7 +93317,7 @@ goL
 sgU
 baw
 wQh
-aaT
+bVx
 vbB
 aqB
 vbB
@@ -97359,7 +97356,7 @@ ajl
 xNu
 aCo
 rHz
-aaV
+xiu
 mMg
 kbn
 aCo
@@ -97457,7 +97454,7 @@ kan
 cWm
 soK
 gDW
-aax
+rlZ
 rlZ
 pqD
 pqD
@@ -97561,9 +97558,9 @@ eDo
 ajl
 pth
 akl
-aaW
+pWU
 gXl
-aaU
+hSo
 xdS
 awj
 ajl
@@ -102820,7 +102817,7 @@ cYT
 aNm
 cYT
 jwB
-aaX
+vkE
 vif
 bhx
 aOR
@@ -103632,7 +103629,7 @@ jWr
 aNm
 jWr
 olw
-aaZ
+eaA
 bhx
 bhx
 wWg
@@ -103755,7 +103752,7 @@ pfJ
 kDY
 ufh
 fDg
-aas
+cel
 beH
 beH
 beH
@@ -104766,11 +104763,11 @@ beH
 beH
 duv
 beH
-aaw
+iaK
 lgC
 oBG
 gZz
-aat
+tIa
 beH
 duv
 beH
@@ -110325,11 +110322,11 @@ gyU
 ajk
 aeA
 lgf
-abo
+dbK
 atr
 iDK
 atr
-abc
+tqG
 kEV
 aeA
 ajk
@@ -110373,11 +110370,11 @@ lJY
 xVS
 lJY
 iyf
-aaO
+roB
 faO
 cOd
 bXe
-aaM
+joS
 leT
 lJY
 xVS
@@ -110528,7 +110525,7 @@ gyU
 ajk
 aeA
 dtE
-abp
+akX
 atr
 iDK
 atr
@@ -110576,7 +110573,7 @@ cBb
 xVS
 lJY
 tRh
-aaQ
+sij
 bXe
 cOd
 tGi
@@ -112814,7 +112811,7 @@ ump
 oWU
 oWU
 oWU
-aaD
+uUy
 jei
 fVe
 aag
@@ -113171,7 +113168,7 @@ taw
 oNK
 xgw
 jGG
-abd
+qMu
 oxy
 oQL
 hdy
@@ -113423,7 +113420,7 @@ kNq
 jcE
 jei
 fCv
-aaG
+lAm
 dhp
 fVe
 aag
@@ -113626,7 +113623,7 @@ kNq
 cke
 hqu
 xeW
-aaI
+wXo
 jei
 fVe
 aag
@@ -113981,9 +113978,9 @@ oqc
 smw
 taw
 oxy
-abg
+kzQ
 mQw
-abe
+wtm
 oxy
 aqi
 qlu
@@ -114027,12 +114024,12 @@ oHx
 aPO
 iXB
 aPO
-aaR
+lPc
 oFP
 eMb
 eMb
 eMb
-aaJ
+gnG
 jei
 fVe
 aag
@@ -114235,7 +114232,7 @@ flK
 pKx
 flK
 flK
-aaK
+eYv
 jei
 fVe
 aag
@@ -115250,7 +115247,7 @@ yat
 xQe
 jei
 fCv
-aaG
+lAm
 dhp
 fVe
 aag
@@ -115453,7 +115450,7 @@ yat
 cfm
 jei
 xeW
-aaL
+kkQ
 jei
 fVe
 aag
@@ -115859,7 +115856,7 @@ kNq
 wyb
 mIa
 oFP
-aaG
+lAm
 jei
 fVe
 aag
@@ -121411,13 +121408,13 @@ txS
 bVN
 oGJ
 iYv
-aay
+hfy
 mVr
 mZL
 mZL
 mZL
 gSa
-aar
+xiQ
 rMe
 uqh
 iAE
@@ -121817,7 +121814,7 @@ igs
 nCn
 oGJ
 knq
-aav
+uLL
 vaZ
 kYL
 hmv
@@ -122631,7 +122628,7 @@ mlF
 hsy
 hmv
 hPo
-aav
+uLL
 pzM
 dQH
 wFB
@@ -126649,7 +126646,7 @@ ktQ
 teZ
 wkM
 ege
-aaB
+wJI
 wrm
 wrm
 tOa

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -33,30 +33,6 @@
 "aah" = (
 /turf/open/floor/almayer_hull/outerhull_dir/east,
 /area/space)
-"aai" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/structure/machinery/landinglight/ds2{
-	dir = 8
-	},
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plate,
-/area/almayer/hallways/hangar)
-"aaj" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	pixel_x = 1
-	},
-/obj/structure/platform_decoration/metal/almayer/east,
-/obj/item/tool/warning_cone,
-/turf/open/floor/almayer/plate,
-/area/almayer/hallways/hangar)
 "aak" = (
 /obj/effect/step_trigger/teleporter/random{
 	affect_ghosts = 1;
@@ -70,18 +46,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"aal" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "W"
-	},
-/obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plate,
-/area/almayer/hallways/hangar)
 "aam" = (
 /obj/structure/stairs,
 /obj/effect/step_trigger/teleporter_vector{
@@ -91,31 +55,6 @@
 	},
 /turf/open/floor/plating/almayer/no_build,
 /area/almayer/stair_clone/upper)
-"aan" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/structure/machinery/landinglight/ds1/delaytwo{
-	dir = 4
-	},
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/plate,
-/area/almayer/hallways/hangar)
-"aao" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/hangar)
-"aap" = (
-/obj/structure/machinery/landinglight/ds1{
-	dir = 4
-	},
-/obj/structure/platform_decoration/metal/almayer/north,
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/hallways/hangar)
 "aaq" = (
 /obj/item/bedsheet/purple{
 	layer = 3.2
@@ -154,59 +93,13 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/living/port_emb)
-"aar" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/plating/northeast,
-/area/almayer/engineering/lower/engine_core)
-"aas" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer,
-/area/almayer/living/briefing)
-"aat" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer,
-/area/almayer/living/briefing)
 "aau" = (
 /turf/closed/wall/almayer/reinforced/temphull,
 /area/almayer/living/pilotbunks)
-"aav" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plating/northeast,
-/area/almayer/engineering/lower/engine_core)
-"aaw" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer,
-/area/almayer/living/briefing)
-"aax" = (
-/turf/open/floor/almayer/dark_sterile,
-/area/almayer/medical/lower_medical_medbay)
-"aay" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/plating/northeast,
-/area/almayer/engineering/lower/engine_core)
-"aaz" = (
-/obj/structure/platform_decoration/metal/almayer/west{
-	name = "testing"
-	},
-/turf/open/floor/almayer,
-/area/almayer/hallways/lower/repair_bay)
-"aaA" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer,
-/area/almayer/hallways/lower/repair_bay)
-"aaB" = (
-/obj/effect/step_trigger/clone_cleaner,
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/aicore/no_build/ai_silver/west,
-/area/almayer/command/airoom)
 "aaC" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
-"aaD" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_p)
 "aaE" = (
 /obj/structure/sign/safety/storage{
 	pixel_x = 8;
@@ -226,10 +119,6 @@
 	},
 /turf/open/floor/plating/almayer/no_build,
 /area/almayer/stair_clone)
-"aaG" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_p)
 "aaH" = (
 /obj/effect/step_trigger/teleporter_vector{
 	name = "Almayer_Down1";
@@ -238,40 +127,6 @@
 	},
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/stair_clone/upper)
-"aaI" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/obj/item/reagent_container/glass/bucket/mopbucket{
-	pixel_x = 7;
-	pixel_y = -3
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_p)
-"aaJ" = (
-/obj/item/stack/catwalk,
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/plating,
-/area/almayer/maint/hull/upper/u_a_p)
-"aaK" = (
-/obj/item/tool/screwdriver,
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_p)
-"aaL" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_p)
-"aaM" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/red,
-/area/almayer/lifeboat_pumps/south2)
-"aaN" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/red,
-/area/almayer/lifeboat_pumps/south1)
-"aaO" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/south2)
 "aaP" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
 	dir = 2;
@@ -287,51 +142,10 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/shipboard/brig/starboard_hallway)
-"aaQ" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/south2)
-"aaR" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_p)
-"aaS" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/south1)
-"aaT" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/south1)
-"aaU" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/mono,
-/area/almayer/medical/upper_medical)
-"aaV" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/obj/structure/platform_decoration/metal/almayer/north,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/medical/upper_medical)
-"aaW" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/mono,
-/area/almayer/medical/upper_medical)
-"aaX" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer,
-/area/almayer/living/chapel)
 "aaY" = (
 /obj/structure/lattice,
 /turf/open/space,
 /area/space)
-"aaZ" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer,
-/area/almayer/living/chapel)
 "aba" = (
 /obj/structure/machinery/door/airlock/almayer/secure/reinforced{
 	dir = 2;
@@ -340,30 +154,10 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/powered)
-"abb" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/red,
-/area/almayer/lifeboat_pumps/north1)
-"abc" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/red,
-/area/almayer/lifeboat_pumps/north2)
-"abd" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_s)
-"abe" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_s)
 "abf" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
-"abg" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_s)
 "abh" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/lifeboat_pumps/north2)
@@ -379,28 +173,12 @@
 /obj/structure/window/reinforced/toughened,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/command/cic)
-"abl" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/north1)
-"abm" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/north1)
 "abn" = (
 /obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/almayer,
 /area/almayer/maint/hull/upper/u_f_p)
-"abo" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/north2)
-"abp" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/north2)
 "abs" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/lifeboat_pumps/north1)
@@ -1754,6 +1532,10 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/northwest,
 /area/almayer/medical/lower_medical_medbay)
+"akX" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/north2)
 "ald" = (
 /turf/open/floor/almayer/red,
 /area/almayer/shipboard/weapon_room)
@@ -13564,6 +13346,10 @@
 "bVw" = (
 /turf/open/floor/almayer/bluecorner/east,
 /area/almayer/living/briefing)
+"bVx" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/south1)
 "bVy" = (
 /obj/structure/machinery/chem_dispenser/corpsman{
 	pixel_y = 3
@@ -14284,6 +14070,10 @@
 	},
 /turf/open/floor/almayer/cargo_arrow/west,
 /area/almayer/squads/alpha)
+"cel" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer,
+/area/almayer/living/briefing)
 "ceC" = (
 /obj/structure/prop/almayer/ship_memorial,
 /turf/open/floor/plating/almayer,
@@ -17225,6 +17015,10 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/upper_engineering/starboard)
+"dbK" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/north2)
 "dbM" = (
 /obj/structure/machinery/door/poddoor/almayer/blended/liaison{
 	id = "RoomDivider"
@@ -17432,6 +17226,10 @@
 /obj/structure/bed/chair/bolted,
 /turf/open/floor/almayer/plating_striped,
 /area/almayer/shipboard/brig/execution)
+"dhj" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer,
+/area/almayer/hallways/lower/repair_bay)
 "dho" = (
 /obj/structure/machinery/alarm/almayer{
 	dir = 1
@@ -19497,6 +19295,10 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_a_p)
+"eaA" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer,
+/area/almayer/living/chapel)
 "ebd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
@@ -20829,6 +20631,10 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
+"eBj" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/north1)
 "eBx" = (
 /obj/structure/closet/emcloset/legacy,
 /turf/open/floor/almayer/cargo,
@@ -21857,6 +21663,11 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/living/briefing)
+"eYv" = (
+/obj/item/tool/screwdriver,
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_p)
 "eYD" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -22297,6 +22108,10 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/northwest,
 /area/almayer/shipboard/brig/medical)
+"fgy" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer,
+/area/almayer/hallways/lower/repair_bay)
 "fgE" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -24695,6 +24510,11 @@
 "gnv" = (
 /turf/open/floor/almayer/red/northeast,
 /area/almayer/lifeboat_pumps/south1)
+"gnG" = (
+/obj/item/stack/catwalk,
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/plating,
+/area/almayer/maint/hull/upper/u_a_p)
 "gnK" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /obj/structure/disposalpipe/junction{
@@ -26192,6 +26012,10 @@
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_m_s)
+"gST" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hallways/hangar)
 "gTk" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/light{
@@ -26451,6 +26275,10 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/u_a_p)
+"gYW" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/red,
+/area/almayer/lifeboat_pumps/north1)
 "gZw" = (
 /obj/structure/bed/sofa/vert/grey/bot,
 /turf/open/floor/almayer,
@@ -26758,6 +26586,10 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/lower/s_bow)
+"hfy" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/plating/northeast,
+/area/almayer/engineering/lower/engine_core)
 "hfO" = (
 /obj/structure/machinery/light/small{
 	dir = 1
@@ -27654,6 +27486,10 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/starboard_missiles)
+"hxX" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/south1)
 "hxZ" = (
 /obj/structure/surface/rack,
 /obj/item/tool/shovel/spade{
@@ -28508,6 +28344,11 @@
 "hSk" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/upper_engineering/port)
+"hSo" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/mono,
+/area/almayer/medical/upper_medical)
 "hSt" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -28993,6 +28834,10 @@
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/lower_medical_lobby)
+"iaK" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer,
+/area/almayer/living/briefing)
 "iaO" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = 32
@@ -32097,6 +31942,10 @@
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/engineering/laundry)
+"joS" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/red,
+/area/almayer/lifeboat_pumps/south2)
 "jpl" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NE-out";
@@ -34283,6 +34132,10 @@
 /obj/structure/pipes/standard/manifold/fourway/hidden/supply,
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/lower/starboard_aft_hallway)
+"kkQ" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_p)
 "kkW" = (
 /obj/structure/surface/table/almayer,
 /obj/item/book/manual/atmospipes,
@@ -35039,6 +34892,10 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/living/port_emb)
+"kzQ" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_s)
 "kAh" = (
 /obj/structure/sign/safety/restrictedarea{
 	pixel_x = -17
@@ -37493,6 +37350,10 @@
 "lAl" = (
 /turf/open/floor/almayer/orange/east,
 /area/almayer/squads/bravo)
+"lAm" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_p)
 "lAu" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/engidoor{
 	dir = 1
@@ -38135,6 +37996,10 @@
 	},
 /turf/open/floor/almayer/plating/northeast,
 /area/almayer/engineering/lower/engine_core)
+"lPc" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/maint/hull/upper/u_a_p)
 "lPm" = (
 /obj/structure/machinery/firealarm{
 	dir = 4;
@@ -40314,6 +40179,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/mono,
 /area/almayer/medical/upper_medical)
+"mMB" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/structure/machinery/landinglight/ds1/delaytwo{
+	dir = 4
+	},
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/plate,
+/area/almayer/hallways/hangar)
 "mMP" = (
 /obj/effect/landmark/start/intel,
 /obj/effect/landmark/late_join/intel,
@@ -44004,6 +43880,10 @@
 	},
 /turf/open/floor/almayer_hull/outerhull_dir,
 /area/space)
+"okG" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/north1)
 "old" = (
 /obj/structure/machinery/light/small,
 /obj/structure/largecrate/random/case/double,
@@ -48187,6 +48067,10 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/blue,
 /area/almayer/living/pilotbunks)
+"pWU" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/mono,
+/area/almayer/medical/upper_medical)
 "pXl" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -49411,6 +49295,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/cargo,
 /area/almayer/squads/charlie)
+"qwS" = (
+/obj/structure/machinery/landinglight/ds1{
+	dir = 4
+	},
+/obj/structure/platform_decoration/metal/almayer/north,
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/floor/almayer/plate,
+/area/almayer/hallways/hangar)
 "qwU" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out"
@@ -50275,6 +50169,10 @@
 /obj/structure/platform/metal/almayer/east,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north2)
+"qMu" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_s)
 "qMD" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/box/flashbangs,
@@ -51396,6 +51294,10 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/upper_engineering)
+"rko" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/red,
+/area/almayer/lifeboat_pumps/south1)
 "rkz" = (
 /obj/structure/pipes/vents/scrubber,
 /turf/open/floor/almayer,
@@ -51595,6 +51497,10 @@
 	},
 /turf/open/floor/almayer/cargo,
 /area/almayer/squads/bravo)
+"roB" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/south2)
 "roG" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -53801,6 +53707,10 @@
 	},
 /turf/open/floor/almayer/cargo,
 /area/almayer/engineering/lower/engine_core)
+"sij" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/south2)
 "sin" = (
 /turf/open/floor/almayer/bluecorner,
 /area/almayer/hallways/upper/midship_hallway)
@@ -56652,6 +56562,10 @@
 /obj/structure/reagent_dispensers/fueltank/custom,
 /turf/open/floor/almayer/plating/northeast,
 /area/almayer/engineering/lower/engine_core)
+"tqG" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/red,
+/area/almayer/lifeboat_pumps/north2)
 "tqO" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -57488,6 +57402,10 @@
 /obj/structure/window/framed/almayer,
 /turf/open/floor/plating,
 /area/almayer/shipboard/brig/cells)
+"tIa" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer,
+/area/almayer/living/briefing)
 "tId" = (
 /obj/structure/machinery/recharge_station,
 /turf/open/floor/almayer/aicore/no_build/ai_cargo,
@@ -59895,6 +59813,10 @@
 /obj/item/reagent_container/food/snacks/mre_pack/xmas3,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/s_stern)
+"uLL" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plating/northeast,
+/area/almayer/engineering/lower/engine_core)
 "uMc" = (
 /obj/structure/window/framed/almayer/hull,
 /turf/open/floor/plating,
@@ -60305,6 +60227,10 @@
 	},
 /turf/open/floor/almayer/red/northeast,
 /area/almayer/shipboard/brig/perma)
+"uUy" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/maint/hull/upper/u_a_p)
 "uUz" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/poddoor/shutters/almayer{
@@ -61178,6 +61104,10 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/maint/hull/upper/p_bow)
+"vkE" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer,
+/area/almayer/living/chapel)
 "vkI" = (
 /obj/item/coin/silver{
 	desc = "A small coin, bearing the falling falcons insignia.";
@@ -64516,6 +64446,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_m_p)
+"wtm" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_s)
 "wtn" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -65339,6 +65273,11 @@
 "wJH" = (
 /turf/closed/wall/almayer/research/containment/wall/east,
 /area/almayer/medical/containment/cell/cl)
+"wJI" = (
+/obj/effect/step_trigger/clone_cleaner,
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/aicore/no_build/ai_silver/west,
+/area/almayer/command/airoom)
 "wKb" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -66026,6 +65965,14 @@
 	},
 /turf/open/floor/almayer/mono,
 /area/almayer/lifeboat_pumps/north2)
+"wXo" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/obj/item/reagent_container/glass/bucket/mopbucket{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_p)
 "wXz" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -66509,6 +66456,14 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cells)
+"xiu" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/obj/structure/platform_decoration/metal/almayer/north,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/medical/upper_medical)
 "xiH" = (
 /obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/almayer/plate,
@@ -66519,6 +66474,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/s_bow)
+"xiQ" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/plating/northeast,
+/area/almayer/engineering/lower/engine_core)
 "xiU" = (
 /obj/structure/machinery/portable_atmospherics/hydroponics,
 /obj/item/tool/minihoe{
@@ -67417,6 +67376,17 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/engineering/upper_engineering/port)
+"xBr" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/structure/machinery/landinglight/ds2{
+	dir = 8
+	},
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plate,
+/area/almayer/hallways/hangar)
 "xBK" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer/cargo,
@@ -68048,6 +68018,19 @@
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/command/corporateliaison)
+"xOw" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/obj/structure/platform_decoration/metal/almayer/east,
+/obj/item/tool/warning_cone,
+/turf/open/floor/almayer/plate,
+/area/almayer/hallways/hangar)
 "xOL" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -68438,6 +68421,18 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/shipboard/brig/perma)
+"xXk" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plate,
+/area/almayer/hallways/hangar)
 "xXl" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -88714,7 +88709,7 @@ eWs
 nVo
 qlL
 aYs
-aaz
+dhj
 vnY
 mRH
 jHt
@@ -88740,7 +88735,7 @@ vbf
 yeN
 qrp
 mUI
-aai
+xBr
 baM
 bcb
 bHB
@@ -89120,7 +89115,7 @@ eWs
 jsw
 tPh
 tPh
-aaA
+fgy
 ctQ
 wer
 pKW
@@ -89144,9 +89139,9 @@ btO
 btO
 btO
 btO
-aao
+gST
 cQy
-aaj
+xOw
 rOc
 fVz
 bHB
@@ -90364,7 +90359,7 @@ bvf
 bvf
 vwW
 iaj
-aal
+xXk
 vsF
 bGJ
 hBF
@@ -90768,9 +90763,9 @@ bkh
 ohE
 vWJ
 qUL
-aap
+qwS
 iEn
-aan
+mMB
 baS
 bGL
 bHB
@@ -93071,11 +93066,11 @@ avd
 acW
 awW
 sAn
-abl
+okG
 aTm
 cpP
 aTm
-abb
+gYW
 hzS
 awW
 acW
@@ -93117,11 +93112,11 @@ tTu
 sgU
 baw
 dsn
-aaS
+hxX
 vbB
 aqB
 vbB
-aaN
+rko
 rAT
 baw
 sgU
@@ -93274,7 +93269,7 @@ avd
 acW
 awW
 tYQ
-abm
+eBj
 aTm
 cpP
 cbM
@@ -93320,7 +93315,7 @@ goL
 sgU
 baw
 wQh
-aaT
+bVx
 vbB
 aqB
 vbB
@@ -97359,7 +97354,7 @@ ajl
 xNu
 aCo
 rHz
-aaV
+xiu
 mMg
 kbn
 aCo
@@ -97457,7 +97452,7 @@ kan
 cWm
 soK
 gDW
-aax
+rlZ
 rlZ
 pqD
 pqD
@@ -97561,9 +97556,9 @@ eDo
 ajl
 pth
 akl
-aaW
+pWU
 gXl
-aaU
+hSo
 xdS
 awj
 ajl
@@ -102820,7 +102815,7 @@ cYT
 aNm
 cYT
 jwB
-aaX
+vkE
 vif
 bhx
 aOR
@@ -103632,7 +103627,7 @@ jWr
 aNm
 jWr
 olw
-aaZ
+eaA
 bhx
 bhx
 wWg
@@ -103755,7 +103750,7 @@ pfJ
 kDY
 ufh
 fDg
-aas
+cel
 beH
 beH
 beH
@@ -104766,11 +104761,11 @@ beH
 beH
 duv
 beH
-aaw
+iaK
 lgC
 oBG
 gZz
-aat
+tIa
 beH
 duv
 beH
@@ -110325,11 +110320,11 @@ gyU
 ajk
 aeA
 lgf
-abo
+dbK
 atr
 iDK
 atr
-abc
+tqG
 kEV
 aeA
 ajk
@@ -110373,11 +110368,11 @@ lJY
 xVS
 lJY
 iyf
-aaO
+roB
 faO
 cOd
 bXe
-aaM
+joS
 leT
 lJY
 xVS
@@ -110528,7 +110523,7 @@ gyU
 ajk
 aeA
 dtE
-abp
+akX
 atr
 iDK
 atr
@@ -110576,7 +110571,7 @@ cBb
 xVS
 lJY
 tRh
-aaQ
+sij
 bXe
 cOd
 tGi
@@ -112814,7 +112809,7 @@ ump
 oWU
 oWU
 oWU
-aaD
+uUy
 jei
 fVe
 aag
@@ -113171,7 +113166,7 @@ taw
 oNK
 xgw
 jGG
-abd
+qMu
 oxy
 oQL
 hdy
@@ -113423,7 +113418,7 @@ kNq
 jcE
 jei
 fCv
-aaG
+lAm
 dhp
 fVe
 aag
@@ -113626,7 +113621,7 @@ kNq
 cke
 hqu
 xeW
-aaI
+wXo
 jei
 fVe
 aag
@@ -113981,9 +113976,9 @@ oqc
 smw
 taw
 oxy
-abg
+kzQ
 mQw
-abe
+wtm
 oxy
 aqi
 qlu
@@ -114027,12 +114022,12 @@ oHx
 aPO
 iXB
 aPO
-aaR
+lPc
 oFP
 eMb
 eMb
 eMb
-aaJ
+gnG
 jei
 fVe
 aag
@@ -114235,7 +114230,7 @@ flK
 pKx
 flK
 flK
-aaK
+eYv
 jei
 fVe
 aag
@@ -115250,7 +115245,7 @@ yat
 xQe
 jei
 fCv
-aaG
+lAm
 dhp
 fVe
 aag
@@ -115453,7 +115448,7 @@ yat
 cfm
 jei
 xeW
-aaL
+kkQ
 jei
 fVe
 aag
@@ -115859,7 +115854,7 @@ kNq
 wyb
 mIa
 oFP
-aaG
+lAm
 jei
 fVe
 aag
@@ -121411,13 +121406,13 @@ txS
 bVN
 oGJ
 iYv
-aay
+hfy
 mVr
 mZL
 mZL
 mZL
 gSa
-aar
+xiQ
 rMe
 uqh
 iAE
@@ -121817,7 +121812,7 @@ igs
 nCn
 oGJ
 knq
-aav
+uLL
 vaZ
 kYL
 hmv
@@ -122631,7 +122626,7 @@ mlF
 hsy
 hmv
 hPo
-aav
+uLL
 pzM
 dQH
 wFB
@@ -126649,7 +126644,7 @@ ktQ
 teZ
 wkM
 ege
-aaB
+wJI
 wrm
 wrm
 tOa

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -33,6 +33,30 @@
 "aah" = (
 /turf/open/floor/almayer_hull/outerhull_dir/east,
 /area/space)
+"aai" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/structure/machinery/landinglight/ds2{
+	dir = 8
+	},
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plate,
+/area/almayer/hallways/hangar)
+"aaj" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/obj/structure/platform_decoration/metal/almayer/east,
+/obj/item/tool/warning_cone,
+/turf/open/floor/almayer/plate,
+/area/almayer/hallways/hangar)
 "aak" = (
 /obj/effect/step_trigger/teleporter/random{
 	affect_ghosts = 1;
@@ -46,6 +70,18 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"aal" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plate,
+/area/almayer/hallways/hangar)
 "aam" = (
 /obj/structure/stairs,
 /obj/effect/step_trigger/teleporter_vector{
@@ -55,6 +91,31 @@
 	},
 /turf/open/floor/plating/almayer/no_build,
 /area/almayer/stair_clone/upper)
+"aan" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/structure/machinery/landinglight/ds1/delaytwo{
+	dir = 4
+	},
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/plate,
+/area/almayer/hallways/hangar)
+"aao" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/hallways/hangar)
+"aap" = (
+/obj/structure/machinery/landinglight/ds1{
+	dir = 4
+	},
+/obj/structure/platform_decoration/metal/almayer/north,
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/floor/almayer/plate,
+/area/almayer/hallways/hangar)
 "aaq" = (
 /obj/item/bedsheet/purple{
 	layer = 3.2
@@ -93,13 +154,59 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/living/port_emb)
+"aar" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/plating/northeast,
+/area/almayer/engineering/lower/engine_core)
+"aas" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer,
+/area/almayer/living/briefing)
+"aat" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer,
+/area/almayer/living/briefing)
 "aau" = (
 /turf/closed/wall/almayer/reinforced/temphull,
 /area/almayer/living/pilotbunks)
+"aav" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plating/northeast,
+/area/almayer/engineering/lower/engine_core)
+"aaw" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer,
+/area/almayer/living/briefing)
+"aax" = (
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/medical/lower_medical_medbay)
+"aay" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/plating/northeast,
+/area/almayer/engineering/lower/engine_core)
+"aaz" = (
+/obj/structure/platform_decoration/metal/almayer/west{
+	name = "testing"
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/lower/repair_bay)
+"aaA" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer,
+/area/almayer/hallways/lower/repair_bay)
+"aaB" = (
+/obj/effect/step_trigger/clone_cleaner,
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/aicore/no_build/ai_silver/west,
+/area/almayer/command/airoom)
 "aaC" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"aaD" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/maint/hull/upper/u_a_p)
 "aaE" = (
 /obj/structure/sign/safety/storage{
 	pixel_x = 8;
@@ -119,6 +226,10 @@
 	},
 /turf/open/floor/plating/almayer/no_build,
 /area/almayer/stair_clone)
+"aaG" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_p)
 "aaH" = (
 /obj/effect/step_trigger/teleporter_vector{
 	name = "Almayer_Down1";
@@ -127,6 +238,40 @@
 	},
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/stair_clone/upper)
+"aaI" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/obj/item/reagent_container/glass/bucket/mopbucket{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_p)
+"aaJ" = (
+/obj/item/stack/catwalk,
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/plating,
+/area/almayer/maint/hull/upper/u_a_p)
+"aaK" = (
+/obj/item/tool/screwdriver,
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_p)
+"aaL" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_p)
+"aaM" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/red,
+/area/almayer/lifeboat_pumps/south2)
+"aaN" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/red,
+/area/almayer/lifeboat_pumps/south1)
+"aaO" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/south2)
 "aaP" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
 	dir = 2;
@@ -142,10 +287,51 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/shipboard/brig/starboard_hallway)
+"aaQ" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/south2)
+"aaR" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/maint/hull/upper/u_a_p)
+"aaS" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/south1)
+"aaT" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/south1)
+"aaU" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/mono,
+/area/almayer/medical/upper_medical)
+"aaV" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/obj/structure/platform_decoration/metal/almayer/north,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/medical/upper_medical)
+"aaW" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/mono,
+/area/almayer/medical/upper_medical)
+"aaX" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer,
+/area/almayer/living/chapel)
 "aaY" = (
 /obj/structure/lattice,
 /turf/open/space,
 /area/space)
+"aaZ" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer,
+/area/almayer/living/chapel)
 "aba" = (
 /obj/structure/machinery/door/airlock/almayer/secure/reinforced{
 	dir = 2;
@@ -154,10 +340,30 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/powered)
+"abb" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/red,
+/area/almayer/lifeboat_pumps/north1)
+"abc" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/red,
+/area/almayer/lifeboat_pumps/north2)
+"abd" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_s)
+"abe" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_s)
 "abf" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north1)
+"abg" = (
+/obj/structure/platform_decoration/metal/almayer/north,
+/turf/open/floor/almayer/plate,
+/area/almayer/maint/hull/upper/u_a_s)
 "abh" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/lifeboat_pumps/north2)
@@ -173,12 +379,28 @@
 /obj/structure/window/reinforced/toughened,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/command/cic)
+"abl" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/north1)
+"abm" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/north1)
 "abn" = (
 /obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/almayer,
 /area/almayer/maint/hull/upper/u_f_p)
+"abo" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/north2)
+"abp" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/north2)
 "abs" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/lifeboat_pumps/north1)
@@ -1532,10 +1754,6 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/northwest,
 /area/almayer/medical/lower_medical_medbay)
-"akX" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/north2)
 "ald" = (
 /turf/open/floor/almayer/red,
 /area/almayer/shipboard/weapon_room)
@@ -13346,10 +13564,6 @@
 "bVw" = (
 /turf/open/floor/almayer/bluecorner/east,
 /area/almayer/living/briefing)
-"bVx" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/south1)
 "bVy" = (
 /obj/structure/machinery/chem_dispenser/corpsman{
 	pixel_y = 3
@@ -14070,10 +14284,6 @@
 	},
 /turf/open/floor/almayer/cargo_arrow/west,
 /area/almayer/squads/alpha)
-"cel" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer,
-/area/almayer/living/briefing)
 "ceC" = (
 /obj/structure/prop/almayer/ship_memorial,
 /turf/open/floor/plating/almayer,
@@ -17015,10 +17225,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/upper_engineering/starboard)
-"dbK" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/north2)
 "dbM" = (
 /obj/structure/machinery/door/poddoor/almayer/blended/liaison{
 	id = "RoomDivider"
@@ -17226,10 +17432,6 @@
 /obj/structure/bed/chair/bolted,
 /turf/open/floor/almayer/plating_striped,
 /area/almayer/shipboard/brig/execution)
-"dhj" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer,
-/area/almayer/hallways/lower/repair_bay)
 "dho" = (
 /obj/structure/machinery/alarm/almayer{
 	dir = 1
@@ -19295,10 +19497,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_a_p)
-"eaA" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer,
-/area/almayer/living/chapel)
 "ebd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
@@ -20631,10 +20829,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
-"eBj" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/north1)
 "eBx" = (
 /obj/structure/closet/emcloset/legacy,
 /turf/open/floor/almayer/cargo,
@@ -21663,11 +21857,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/living/briefing)
-"eYv" = (
-/obj/item/tool/screwdriver,
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_p)
 "eYD" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -22108,10 +22297,6 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/northwest,
 /area/almayer/shipboard/brig/medical)
-"fgy" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer,
-/area/almayer/hallways/lower/repair_bay)
 "fgE" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -24510,11 +24695,6 @@
 "gnv" = (
 /turf/open/floor/almayer/red/northeast,
 /area/almayer/lifeboat_pumps/south1)
-"gnG" = (
-/obj/item/stack/catwalk,
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/plating,
-/area/almayer/maint/hull/upper/u_a_p)
 "gnK" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /obj/structure/disposalpipe/junction{
@@ -26012,10 +26192,6 @@
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_m_s)
-"gST" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/hallways/hangar)
 "gTk" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/light{
@@ -26275,10 +26451,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/u_a_p)
-"gYW" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/red,
-/area/almayer/lifeboat_pumps/north1)
 "gZw" = (
 /obj/structure/bed/sofa/vert/grey/bot,
 /turf/open/floor/almayer,
@@ -26586,10 +26758,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/lower/s_bow)
-"hfy" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/plating/northeast,
-/area/almayer/engineering/lower/engine_core)
 "hfO" = (
 /obj/structure/machinery/light/small{
 	dir = 1
@@ -27486,10 +27654,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/starboard_missiles)
-"hxX" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/south1)
 "hxZ" = (
 /obj/structure/surface/rack,
 /obj/item/tool/shovel/spade{
@@ -28344,11 +28508,6 @@
 "hSk" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/upper_engineering/port)
-"hSo" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/mono,
-/area/almayer/medical/upper_medical)
 "hSt" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -28834,10 +28993,6 @@
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/lower_medical_lobby)
-"iaK" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer,
-/area/almayer/living/briefing)
 "iaO" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = 32
@@ -31942,10 +32097,6 @@
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/engineering/laundry)
-"joS" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/red,
-/area/almayer/lifeboat_pumps/south2)
 "jpl" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NE-out";
@@ -34132,10 +34283,6 @@
 /obj/structure/pipes/standard/manifold/fourway/hidden/supply,
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/lower/starboard_aft_hallway)
-"kkQ" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_p)
 "kkW" = (
 /obj/structure/surface/table/almayer,
 /obj/item/book/manual/atmospipes,
@@ -34892,10 +35039,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/living/port_emb)
-"kzQ" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_s)
 "kAh" = (
 /obj/structure/sign/safety/restrictedarea{
 	pixel_x = -17
@@ -37350,10 +37493,6 @@
 "lAl" = (
 /turf/open/floor/almayer/orange/east,
 /area/almayer/squads/bravo)
-"lAm" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_p)
 "lAu" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/engidoor{
 	dir = 1
@@ -37996,10 +38135,6 @@
 	},
 /turf/open/floor/almayer/plating/northeast,
 /area/almayer/engineering/lower/engine_core)
-"lPc" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_p)
 "lPm" = (
 /obj/structure/machinery/firealarm{
 	dir = 4;
@@ -40179,17 +40314,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/mono,
 /area/almayer/medical/upper_medical)
-"mMB" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/structure/machinery/landinglight/ds1/delaytwo{
-	dir = 4
-	},
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/plate,
-/area/almayer/hallways/hangar)
 "mMP" = (
 /obj/effect/landmark/start/intel,
 /obj/effect/landmark/late_join/intel,
@@ -43880,10 +44004,6 @@
 	},
 /turf/open/floor/almayer_hull/outerhull_dir,
 /area/space)
-"okG" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/north1)
 "old" = (
 /obj/structure/machinery/light/small,
 /obj/structure/largecrate/random/case/double,
@@ -48067,10 +48187,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/blue,
 /area/almayer/living/pilotbunks)
-"pWU" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/mono,
-/area/almayer/medical/upper_medical)
 "pXl" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -49295,16 +49411,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/cargo,
 /area/almayer/squads/charlie)
-"qwS" = (
-/obj/structure/machinery/landinglight/ds1{
-	dir = 4
-	},
-/obj/structure/platform_decoration/metal/almayer/north,
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/hallways/hangar)
 "qwU" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out"
@@ -50169,10 +50275,6 @@
 /obj/structure/platform/metal/almayer/east,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north2)
-"qMu" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_s)
 "qMD" = (
 /obj/structure/surface/table/almayer,
 /obj/item/storage/box/flashbangs,
@@ -51294,10 +51396,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/upper_engineering)
-"rko" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/red,
-/area/almayer/lifeboat_pumps/south1)
 "rkz" = (
 /obj/structure/pipes/vents/scrubber,
 /turf/open/floor/almayer,
@@ -51497,10 +51595,6 @@
 	},
 /turf/open/floor/almayer/cargo,
 /area/almayer/squads/bravo)
-"roB" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/south2)
 "roG" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -53707,10 +53801,6 @@
 	},
 /turf/open/floor/almayer/cargo,
 /area/almayer/engineering/lower/engine_core)
-"sij" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/south2)
 "sin" = (
 /turf/open/floor/almayer/bluecorner,
 /area/almayer/hallways/upper/midship_hallway)
@@ -56562,10 +56652,6 @@
 /obj/structure/reagent_dispensers/fueltank/custom,
 /turf/open/floor/almayer/plating/northeast,
 /area/almayer/engineering/lower/engine_core)
-"tqG" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/red,
-/area/almayer/lifeboat_pumps/north2)
 "tqO" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -57402,10 +57488,6 @@
 /obj/structure/window/framed/almayer,
 /turf/open/floor/plating,
 /area/almayer/shipboard/brig/cells)
-"tIa" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer,
-/area/almayer/living/briefing)
 "tId" = (
 /obj/structure/machinery/recharge_station,
 /turf/open/floor/almayer/aicore/no_build/ai_cargo,
@@ -59813,10 +59895,6 @@
 /obj/item/reagent_container/food/snacks/mre_pack/xmas3,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/s_stern)
-"uLL" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plating/northeast,
-/area/almayer/engineering/lower/engine_core)
 "uMc" = (
 /obj/structure/window/framed/almayer/hull,
 /turf/open/floor/plating,
@@ -60227,10 +60305,6 @@
 	},
 /turf/open/floor/almayer/red/northeast,
 /area/almayer/shipboard/brig/perma)
-"uUy" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/hull/upper/u_a_p)
 "uUz" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/poddoor/shutters/almayer{
@@ -61104,10 +61178,6 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/maint/hull/upper/p_bow)
-"vkE" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer,
-/area/almayer/living/chapel)
 "vkI" = (
 /obj/item/coin/silver{
 	desc = "A small coin, bearing the falling falcons insignia.";
@@ -64446,10 +64516,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_m_p)
-"wtm" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_s)
 "wtn" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -65273,11 +65339,6 @@
 "wJH" = (
 /turf/closed/wall/almayer/research/containment/wall/east,
 /area/almayer/medical/containment/cell/cl)
-"wJI" = (
-/obj/effect/step_trigger/clone_cleaner,
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/aicore/no_build/ai_silver/west,
-/area/almayer/command/airoom)
 "wKb" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -65965,14 +66026,6 @@
 	},
 /turf/open/floor/almayer/mono,
 /area/almayer/lifeboat_pumps/north2)
-"wXo" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/obj/item/reagent_container/glass/bucket/mopbucket{
-	pixel_x = 7;
-	pixel_y = -3
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/hull/upper/u_a_p)
 "wXz" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -66456,14 +66509,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cells)
-"xiu" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/obj/structure/platform_decoration/metal/almayer/north,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/medical/upper_medical)
 "xiH" = (
 /obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/almayer/plate,
@@ -66474,10 +66519,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/s_bow)
-"xiQ" = (
-/obj/structure/platform_decoration/metal/almayer/north,
-/turf/open/floor/almayer/plating/northeast,
-/area/almayer/engineering/lower/engine_core)
 "xiU" = (
 /obj/structure/machinery/portable_atmospherics/hydroponics,
 /obj/item/tool/minihoe{
@@ -67376,17 +67417,6 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/engineering/upper_engineering/port)
-"xBr" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/structure/machinery/landinglight/ds2{
-	dir = 8
-	},
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plate,
-/area/almayer/hallways/hangar)
 "xBK" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer/cargo,
@@ -68018,19 +68048,6 @@
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/command/corporateliaison)
-"xOw" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	pixel_x = 1
-	},
-/obj/structure/platform_decoration/metal/almayer/east,
-/obj/item/tool/warning_cone,
-/turf/open/floor/almayer/plate,
-/area/almayer/hallways/hangar)
 "xOL" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -68421,18 +68438,6 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/shipboard/brig/perma)
-"xXk" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "W"
-	},
-/obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/plate,
-/area/almayer/hallways/hangar)
 "xXl" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -88709,7 +88714,7 @@ eWs
 nVo
 qlL
 aYs
-dhj
+aaz
 vnY
 mRH
 jHt
@@ -88735,7 +88740,7 @@ vbf
 yeN
 qrp
 mUI
-xBr
+aai
 baM
 bcb
 bHB
@@ -89115,7 +89120,7 @@ eWs
 jsw
 tPh
 tPh
-fgy
+aaA
 ctQ
 wer
 pKW
@@ -89139,9 +89144,9 @@ btO
 btO
 btO
 btO
-gST
+aao
 cQy
-xOw
+aaj
 rOc
 fVz
 bHB
@@ -90359,7 +90364,7 @@ bvf
 bvf
 vwW
 iaj
-xXk
+aal
 vsF
 bGJ
 hBF
@@ -90763,9 +90768,9 @@ bkh
 ohE
 vWJ
 qUL
-qwS
+aap
 iEn
-mMB
+aan
 baS
 bGL
 bHB
@@ -93066,11 +93071,11 @@ avd
 acW
 awW
 sAn
-okG
+abl
 aTm
 cpP
 aTm
-gYW
+abb
 hzS
 awW
 acW
@@ -93112,11 +93117,11 @@ tTu
 sgU
 baw
 dsn
-hxX
+aaS
 vbB
 aqB
 vbB
-rko
+aaN
 rAT
 baw
 sgU
@@ -93269,7 +93274,7 @@ avd
 acW
 awW
 tYQ
-eBj
+abm
 aTm
 cpP
 cbM
@@ -93315,7 +93320,7 @@ goL
 sgU
 baw
 wQh
-bVx
+aaT
 vbB
 aqB
 vbB
@@ -97354,7 +97359,7 @@ ajl
 xNu
 aCo
 rHz
-xiu
+aaV
 mMg
 kbn
 aCo
@@ -97452,7 +97457,7 @@ kan
 cWm
 soK
 gDW
-rlZ
+aax
 rlZ
 pqD
 pqD
@@ -97556,9 +97561,9 @@ eDo
 ajl
 pth
 akl
-pWU
+aaW
 gXl
-hSo
+aaU
 xdS
 awj
 ajl
@@ -102815,7 +102820,7 @@ cYT
 aNm
 cYT
 jwB
-vkE
+aaX
 vif
 bhx
 aOR
@@ -103627,7 +103632,7 @@ jWr
 aNm
 jWr
 olw
-eaA
+aaZ
 bhx
 bhx
 wWg
@@ -103750,7 +103755,7 @@ pfJ
 kDY
 ufh
 fDg
-cel
+aas
 beH
 beH
 beH
@@ -104761,11 +104766,11 @@ beH
 beH
 duv
 beH
-iaK
+aaw
 lgC
 oBG
 gZz
-tIa
+aat
 beH
 duv
 beH
@@ -110320,11 +110325,11 @@ gyU
 ajk
 aeA
 lgf
-dbK
+abo
 atr
 iDK
 atr
-tqG
+abc
 kEV
 aeA
 ajk
@@ -110368,11 +110373,11 @@ lJY
 xVS
 lJY
 iyf
-roB
+aaO
 faO
 cOd
 bXe
-joS
+aaM
 leT
 lJY
 xVS
@@ -110523,7 +110528,7 @@ gyU
 ajk
 aeA
 dtE
-akX
+abp
 atr
 iDK
 atr
@@ -110571,7 +110576,7 @@ cBb
 xVS
 lJY
 tRh
-sij
+aaQ
 bXe
 cOd
 tGi
@@ -112809,7 +112814,7 @@ ump
 oWU
 oWU
 oWU
-uUy
+aaD
 jei
 fVe
 aag
@@ -113166,7 +113171,7 @@ taw
 oNK
 xgw
 jGG
-qMu
+abd
 oxy
 oQL
 hdy
@@ -113418,7 +113423,7 @@ kNq
 jcE
 jei
 fCv
-lAm
+aaG
 dhp
 fVe
 aag
@@ -113621,7 +113626,7 @@ kNq
 cke
 hqu
 xeW
-wXo
+aaI
 jei
 fVe
 aag
@@ -113976,9 +113981,9 @@ oqc
 smw
 taw
 oxy
-kzQ
+abg
 mQw
-wtm
+abe
 oxy
 aqi
 qlu
@@ -114022,12 +114027,12 @@ oHx
 aPO
 iXB
 aPO
-lPc
+aaR
 oFP
 eMb
 eMb
 eMb
-gnG
+aaJ
 jei
 fVe
 aag
@@ -114230,7 +114235,7 @@ flK
 pKx
 flK
 flK
-eYv
+aaK
 jei
 fVe
 aag
@@ -115245,7 +115250,7 @@ yat
 xQe
 jei
 fCv
-lAm
+aaG
 dhp
 fVe
 aag
@@ -115448,7 +115453,7 @@ yat
 cfm
 jei
 xeW
-kkQ
+aaL
 jei
 fVe
 aag
@@ -115854,7 +115859,7 @@ kNq
 wyb
 mIa
 oFP
-lAm
+aaG
 jei
 fVe
 aag
@@ -121406,13 +121411,13 @@ txS
 bVN
 oGJ
 iYv
-hfy
+aay
 mVr
 mZL
 mZL
 mZL
 gSa
-xiQ
+aar
 rMe
 uqh
 iAE
@@ -121812,7 +121817,7 @@ igs
 nCn
 oGJ
 knq
-uLL
+aav
 vaZ
 kYL
 hmv
@@ -122626,7 +122631,7 @@ mlF
 hsy
 hmv
 hPo
-uLL
+aav
 pzM
 dQH
 wFB
@@ -126644,7 +126649,7 @@ ktQ
 teZ
 wkM
 ege
-wJI
+aaB
 wrm
 wrm
 tOa

--- a/tools/maplint/source/dmm.py
+++ b/tools/maplint/source/dmm.py
@@ -94,7 +94,12 @@ class DMMParser:
                 break
             elif content_end == "{":
                 while (var_edit := self.parse_var_edit()) is not None:
+                    if var_edit[0] == None and var_edit[1] == None:
+                        break
                     content.var_edits[var_edit[0]] = var_edit[1]
+                else:
+                    continue # inner loop didn't break
+                break # inner loop did break indicating a })
             elif content_end == ",":
                 continue
 
@@ -106,6 +111,8 @@ class DMMParser:
         line = self.next_line()
         if line == "\t},":
             return None
+        if line == "\t})":
+            return None, None
 
         var_edit_match = REGEX_VAR_EDIT.match(line)
         self.expect(var_edit_match is not None, "Var edits ended too early, expected a newline in between.")
@@ -128,6 +135,8 @@ class DMMParser:
             return Filename(constant[1:-1])
         elif (list_match := re.match(r'^list\((?P<contents>.*)\)$', constant)):
             return ["NYI: list"]
+        elif (list_match := re.match(r'^newlist\((?P<contents>.*)\)$', constant)):
+            return ["NYI: newlist"]
         else:
             self.raise_error(f"Unknown constant type: {constant}")
 

--- a/tools/mapmerge2/dmm.py
+++ b/tools/mapmerge2/dmm.py
@@ -11,7 +11,7 @@ ENCODING = 'utf-8'
 Coordinate = namedtuple('Coordinate', ['x', 'y', 'z'])
 
 class DMM:
-    __slots__ = ['key_length', 'size', 'dictionary', 'grid', 'header']
+    __slots__ = ['key_length', 'size', 'dictionary', 'grid', 'header', 'lowest_free']
 
     def __init__(self, key_length, size):
         self.key_length = key_length
@@ -19,6 +19,7 @@ class DMM:
         self.dictionary = bidict.bidict()
         self.grid = {}
         self.header = None
+        self.lowest_free = 0
 
     @staticmethod
     def from_file(fname):
@@ -60,10 +61,14 @@ class DMM:
     def generate_new_key(self):
         self._ensure_free_keys(1)
         max_key = max_key_for(self.key_length)
-        # choose one of the free keys at random
-        key = random.randint(0, max_key - 1)
+        # choose one of the free keys
+        key = self.lowest_free
         while key in self.dictionary:
-            key = random.randint(0, max_key - 1)
+            key = key + 1
+            if key >= max_key:
+                print("The value for lowest_free was invalid!")
+                key = 0
+        self.lowest_free = key
         return key
 
     def overwrite_key(self, key, fixed, bad_keys):
@@ -90,6 +95,7 @@ class DMM:
                 unused_keys.remove(key)
         for key in unused_keys:
             del self.dictionary[key]
+        self.lowest_free = 0
 
     def _presave_checks(self):
         # last-second handling of bogus keys to help prevent and fix broken maps

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -14,7 +14,7 @@ def _self_test():
     repo = pygit2.Repository(pygit2.discover_repository(os.getcwd()))
 
     # Read the ancestor commit.
-    ancestor = repo.merge_base(repo.head.target, repo.revparse_single("origin/master").id)
+    ancestor = repo.merge_base(repo.head.target, repo.branches.remote.get('origin/master').target)
     ancestor_commit = None
     if not ancestor:
         print("Unable to determine merge base!")

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -5,6 +5,12 @@ import pygit2
 from .dmm import *
 from .mapmerge import merge_map
 
+def green(text):
+    return "\033[32m" + str(text) + "\033[0m"
+
+def red(text):
+    return "\033[31m" + str(text) + "\033[0m"
+
 def has_tgm_header(fname):
     with open(fname, 'r', encoding=ENCODING) as f:
         data = f.read(len(TGM_HEADER))
@@ -63,14 +69,14 @@ def _self_test():
                             if original_bytes != merged_bytes:
                                 raise LintException('Map is pending updates! Please run `/tools/mapmerge2/I Forgot To Map Merge.bat`')
                 except LintException as error:
-                    print('Failed on:', path)
+                    print(red(f'Failed on: {path}'))
                     print(error)
                 except Exception:
-                    print('Failed on:', path)
+                    print(red(f'Failed on: {path}'))
                     raise
                 count += 1
 
-    print(f"{os.path.relpath(__file__)}: successfully parsed {count} .dmm files")
+    print(f"{os.path.relpath(__file__)}: {green(f'successfully parsed {count} .dmm files')}")
 
 
 def _usage():

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -33,6 +33,7 @@ def _self_test():
         print("Determined ancestor commit SHA to be:", ancestor)
 
     count = 0
+    failed = 0
     for dirpath, dirnames, filenames in os.walk('.'):
         if '.git' in dirnames:
             dirnames.remove('.git')
@@ -69,14 +70,19 @@ def _self_test():
                             if original_bytes != merged_bytes:
                                 raise LintException('Map is pending updates! Please run `/tools/mapmerge2/I Forgot To Map Merge.bat`')
                 except LintException as error:
+                    failed += 1
                     print(red(f'Failed on: {path}'))
                     print(error)
                 except Exception:
+                    failed += 1
                     print(red(f'Failed on: {path}'))
                     raise
                 count += 1
 
-    print(f"{os.path.relpath(__file__)}: {green(f'successfully parsed {count} .dmm files')}")
+    print(f"{os.path.relpath(__file__)}: {green(f'successfully parsed {count-failed} .dmm files')}")
+    if failed > 0:
+        print(f"{os.path.relpath(__file__)}: {red(f'failed to parse {failed} .dmm files')}")
+        exit(1)
 
 
 def _usage():

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -15,7 +15,7 @@ def _self_test():
 
     # Read the ancestor commit.
     repo.remotes["origin"].fetch()
-    ancestor = repo.merge_base(repo.head.target, repo.branches.remote.get('origin/master').target)
+    ancestor = repo.merge_base(repo.head.target, repo.revparse_single("refs/remotes/origin/master").id)
     ancestor_commit = None
     if not ancestor:
         print("Unable to determine merge base!")

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -14,7 +14,7 @@ def _self_test():
     repo = pygit2.Repository(pygit2.discover_repository(os.getcwd()))
 
     # Read the ancestor commit.
-    ancestor = repo.merge_base(repo.head.target, repo.revparse_single("refs/remotes/origin/master").id)
+    ancestor = repo.merge_base(repo.head.target, repo.revparse_single("origin/master").id)
     ancestor_commit = None
     if not ancestor:
         print("Unable to determine merge base!")

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -14,8 +14,10 @@ def _self_test():
     repo = pygit2.Repository(pygit2.discover_repository(os.getcwd()))
 
     # Set up upstream remote if needed
-    if not repo.remotes["upstream"]:
+    try:
         repo.remotes.create("upstream", "https://github.com/cmss13-devs/cmss13.git")
+    except ValueError:
+        pass
 
     # Read the ancestor commit.
     ancestor = repo.merge_base(repo.head.target, repo.revparse_single("refs/remotes/upstream/master").id)

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -10,6 +10,9 @@ def has_tgm_header(fname):
         data = f.read(len(TGM_HEADER))
         return data.startswith(TGM_HEADER)
 
+class LintException(Exception):
+    pass
+
 def _self_test():
     repo = pygit2.Repository(pygit2.discover_repository(os.getcwd()))
 
@@ -37,7 +40,7 @@ def _self_test():
 
                     # test: is every DMM in TGM format
                     if not has_tgm_header(fullpath):
-                        raise Exception('Map is not in TGM format! Please run `/tools/mapmerge2/I Forgot To Map Merge.bat`')
+                        raise LintException('Map is not in TGM format! Please run `/tools/mapmerge2/I Forgot To Map Merge.bat`')
 
                     # test: does every DMM convert cleanly
                     if ancestor_commit:
@@ -50,7 +53,7 @@ def _self_test():
                             original_bytes = index_map.to_bytes()
                             merged_bytes = merged_map.to_bytes()
                             if original_bytes != merged_bytes:
-                                raise Exception('New map is pending updates! Please run `/tools/mapmerge2/I Forgot To Map Merge.bat`')
+                                raise LintException('New map is pending updates! Please run `/tools/mapmerge2/I Forgot To Map Merge.bat`')
                         else:
                             # Entry in HEAD, merge the index over it
                             ancestor_map = DMM.from_bytes(ancestor_blob.read_raw())
@@ -58,9 +61,12 @@ def _self_test():
                             original_bytes = index_map.to_bytes()
                             merged_bytes = merged_map.to_bytes()
                             if original_bytes != merged_bytes:
-                                raise Exception('Map is pending updates! Please run `/tools/mapmerge2/I Forgot To Map Merge.bat`')
+                                raise LintException('Map is pending updates! Please run `/tools/mapmerge2/I Forgot To Map Merge.bat`')
+                except LintException as error:
+                    print('Failed on:', path)
+                    print(error)
                 except Exception:
-                    print('Failed on:', fullpath)
+                    print('Failed on:', path)
                     raise
                 count += 1
 

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -13,15 +13,8 @@ def has_tgm_header(fname):
 def _self_test():
     repo = pygit2.Repository(pygit2.discover_repository(os.getcwd()))
 
-    # Set up upstream remote if needed
-    try:
-        repo.remotes.create("upstream", "https://github.com/cmss13-devs/cmss13.git")
-    except ValueError:
-        pass
-
     # Read the ancestor commit.
-    repo.remotes["upstream"].fetch(repo.remotes["upstream"].fetch_refspecs)
-    ancestor = repo.merge_base(repo.head.target, repo.revparse_single("refs/remotes/upstream/master").id)
+    ancestor = repo.merge_base(repo.head.target, repo.revparse_single("refs/remotes/origin/master").id)
     ancestor_commit = None
     if not ancestor:
         print("Unable to determine merge base!")

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -27,7 +27,7 @@ def _self_test():
         print("Unable to determine merge base!")
     else:
         ancestor_commit = repo[ancestor]
-        print("Determined ancestor commit SHA to be:", ancestor)
+        print("Determined ancestor commit SHA to be:", ancestor, ancestor_commit)
 
     count = 0
     for dirpath, dirnames, filenames in os.walk('.'):
@@ -36,7 +36,7 @@ def _self_test():
         for filename in filenames:
             if filename.endswith('.dmm'):
                 fullpath = os.path.join(dirpath, filename)
-                path = fullpath.removeprefix(".\\").replace("\\", "/")
+                path = fullpath.replace("\\", "/").removeprefix("./")
                 try:
                     # test: can we load every DMM in the tree
                     index_map = DMM.from_file(fullpath)
@@ -50,6 +50,7 @@ def _self_test():
                         try:
                             ancestor_blob = ancestor_commit.tree[path]
                         except KeyError:
+                            print("keyerror for", path, fullpath)
                             # New map, no entry in HEAD
                             merged_map = merge_map(index_map, index_map)
                             original_bytes = index_map.to_bytes()
@@ -57,6 +58,7 @@ def _self_test():
                             if original_bytes != merged_bytes:
                                 raise Exception('New map is pending updates! Please run `/tools/mapmerge2/I Forgot To Map Merge.bat`')
                         else:
+                            print("found", path, fullpath)
                             # Entry in HEAD, merge the index over it
                             ancestor_map = DMM.from_bytes(ancestor_blob.read_raw())
                             merged_map = merge_map(index_map, ancestor_map)

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -21,6 +21,7 @@ def _self_test():
         print("Unable to determine merge base!")
     else:
         ancestor_commit = repo[ancestor]
+        print("Determined ancestor commit SHA to be:", ancestor)
 
     count = 0
     for dirpath, dirnames, filenames in os.walk('.'):

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -7,7 +7,7 @@ from .mapmerge import merge_map
 
 def has_tgm_header(fname):
     with open(fname, 'r', encoding=ENCODING) as f:
-        data = f.read()
+        data = f.read(len(TGM_HEADER))
         return data.startswith(TGM_HEADER)
 
 def _self_test():
@@ -34,17 +34,17 @@ def _self_test():
                     except KeyError:
                         # New map, no entry in HEAD
                         merged_map = merge_map(index_map, index_map)
-                        originalBytes = index_map.to_bytes()
-                        mergedBytes = merged_map.to_bytes()
-                        if originalBytes != mergedBytes:
+                        original_bytes = index_map.to_bytes()
+                        merged_bytes = merged_map.to_bytes()
+                        if original_bytes != merged_bytes:
                             raise Exception('New map is pending updates! Please run `/tools/mapmerge2/I Forgot To Map Merge.bat`')
                     else:
                         # Entry in HEAD, merge the index over it
                         head_map = DMM.from_bytes(head_blob.read_raw())
                         merged_map = merge_map(index_map, head_map)
-                        originalBytes = index_map.to_bytes()
-                        mergedBytes = merged_map.to_bytes()
-                        if originalBytes != mergedBytes:
+                        original_bytes = index_map.to_bytes()
+                        merged_bytes = merged_map.to_bytes()
+                        if original_bytes != merged_bytes:
                             raise Exception('Map is pending updates! Please run `/tools/mapmerge2/I Forgot To Map Merge.bat`')
                 except Exception:
                     print('Failed on:', fullpath)

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -42,7 +42,7 @@ def _self_test():
                 fullpath = os.path.join(dirpath, filename)
                 path = fullpath.replace("\\", "/").removeprefix("./")
                 try:
-                    # test: can we load every DMM in the tree
+                    # test: can we load every DMM
                     index_map = DMM.from_file(fullpath)
 
                     # test: is every DMM in TGM format
@@ -54,15 +54,15 @@ def _self_test():
                         try:
                             ancestor_blob = ancestor_commit.tree[path]
                         except KeyError:
+                            # New map, no entry in ancestor
                             print("New map? Could not find ancestor version of", path)
-                            # New map, no entry in HEAD
-                            merged_map = merge_map(index_map, index_map)
+                            merged_map = merge_map(index_map, index_map) # basically only tests unused keys
                             original_bytes = index_map.to_bytes()
                             merged_bytes = merged_map.to_bytes()
                             if original_bytes != merged_bytes:
                                 raise LintException('New map is pending updates! Please run `/tools/mapmerge2/I Forgot To Map Merge.bat`')
                         else:
-                            # Entry in HEAD, merge the index over it
+                            # Entry in ancestor, merge the index over it
                             ancestor_map = DMM.from_bytes(ancestor_blob.read_raw())
                             merged_map = merge_map(index_map, ancestor_map)
                             original_bytes = index_map.to_bytes()

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -13,9 +13,15 @@ def has_tgm_header(fname):
 def _self_test():
     repo = pygit2.Repository(pygit2.discover_repository(os.getcwd()))
 
+    # Set up upstream remote if needed
+    try:
+        repo.remotes.create("upstream", "https://github.com/cmss13-devs/cmss13.git")
+    except ValueError:
+        pass
+
     # Read the ancestor commit.
-    repo.remotes["origin"].fetch()
-    ancestor = repo.merge_base(repo.head.target, repo.revparse_single("refs/remotes/origin/master").id)
+    repo.remotes["upstream"].fetch()
+    ancestor = repo.merge_base(repo.head.target, repo.revparse_single("refs/remotes/upstream/master").id)
     ancestor_commit = None
     if not ancestor:
         print("Unable to determine merge base!")

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -14,6 +14,7 @@ def _self_test():
     repo = pygit2.Repository(pygit2.discover_repository(os.getcwd()))
 
     # Read the ancestor commit.
+    repo.remotes["origin"].fetch()
     ancestor = repo.merge_base(repo.head.target, repo.branches.remote.get('origin/master').target)
     ancestor_commit = None
     if not ancestor:

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -1,10 +1,17 @@
 import os
 import sys
-from .dmm import *
+import pygit2
 
+from .dmm import *
+from .mapmerge import merge_map
+
+def has_tgm_header(fname):
+    with open(fname, 'r', encoding=ENCODING) as f:
+        data = f.read()
+        return data.startswith(TGM_HEADER)
 
 def _self_test():
-    # test: can we load every DMM in the tree
+    repo = pygit2.Repository(pygit2.discover_repository(os.getcwd()))
     count = 0
     for dirpath, dirnames, filenames in os.walk('.'):
         if '.git' in dirnames:
@@ -12,8 +19,33 @@ def _self_test():
         for filename in filenames:
             if filename.endswith('.dmm'):
                 fullpath = os.path.join(dirpath, filename)
+                path = fullpath.removeprefix(".\\").replace("\\", "/")
                 try:
-                    DMM.from_file(fullpath)
+                    # test: can we load every DMM in the tree
+                    index_map = DMM.from_file(fullpath)
+
+                    # test: is every DMM in TGM format
+                    if not has_tgm_header(fullpath):
+                        raise Exception('Map is not in TGM format! Please run `/tools/mapmerge2/I Forgot To Map Merge.bat`')
+
+                    # test: does every DMM convert cleanly
+                    try:
+                        head_blob = repo[repo[repo.head.target].tree[path].id]
+                    except KeyError:
+                        # New map, no entry in HEAD
+                        merged_map = merge_map(index_map, index_map)
+                        originalBytes = index_map.to_bytes()
+                        mergedBytes = merged_map.to_bytes()
+                        if originalBytes != mergedBytes:
+                            raise Exception('New map is pending updates! Please run `/tools/mapmerge2/I Forgot To Map Merge.bat`')
+                    else:
+                        # Entry in HEAD, merge the index over it
+                        head_map = DMM.from_bytes(head_blob.read_raw())
+                        merged_map = merge_map(index_map, head_map)
+                        originalBytes = index_map.to_bytes()
+                        mergedBytes = merged_map.to_bytes()
+                        if originalBytes != mergedBytes:
+                            raise Exception('Map is pending updates! Please run `/tools/mapmerge2/I Forgot To Map Merge.bat`')
                 except Exception:
                     print('Failed on:', fullpath)
                     raise

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -20,6 +20,7 @@ def _self_test():
         pass
 
     # Read the ancestor commit.
+    repo.remotes["upstream"].fetch()
     ancestor = repo.merge_base(repo.head.target, repo.revparse_single("refs/remotes/upstream/master").id)
     ancestor_commit = None
     if not ancestor:

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -20,7 +20,7 @@ def _self_test():
         pass
 
     # Read the ancestor commit.
-    repo.remotes["upstream"].fetch()
+    repo.remotes["upstream"].fetch(repo.remotes["upstream"].fetch_refspecs)
     ancestor = repo.merge_base(repo.head.target, repo.revparse_single("refs/remotes/upstream/master").id)
     ancestor_commit = None
     if not ancestor:

--- a/tools/mapmerge2/fixup.py
+++ b/tools/mapmerge2/fixup.py
@@ -124,7 +124,7 @@ def main(repo : pygit2.Repository):
         repo.head.name,
         signature,  # author
         signature,  # committer
-        f'Convert maps to TGM\n\n{joined}\n\nAutomatically commited by: {os.path.relpath(__file__, repo.workdir)}',
+        f'Fixup maps in TGM format\n\n{joined}\n\nAutomatically commited by: {os.path.relpath(__file__, repo.workdir)}',
         tree_builder.write(),
         [head_commit.id],
     )

--- a/tools/mapmerge2/fixup.py
+++ b/tools/mapmerge2/fixup.py
@@ -68,7 +68,7 @@ def main(repo : pygit2.Repository):
 
     # Read the HEAD and ancestor commits.
     head_commit = repo[repo.head.target]
-    repo.remotes["upstream"].fetch(repo.remotes["upstream"].fetch_refspecs)
+    repo.remotes["upstream"].fetch()
     ancestor = repo.merge_base(repo.head.target, repo.revparse_single("refs/remotes/upstream/master").id)
     if not ancestor:
         print("Unable to automatically fix anything because merge base could not be determined.")

--- a/tools/mapmerge2/fixup.py
+++ b/tools/mapmerge2/fixup.py
@@ -74,6 +74,7 @@ def main(repo : pygit2.Repository):
         print("Unable to automatically fix anything because merge base could not be determined.")
         return 1
     ancestor_commit = repo[ancestor]
+    print("Determined ancestor commit SHA to be:", ancestor)
 
     # Walk the head commit tree and convert as needed
     converted = {}

--- a/tools/mapmerge2/fixup.py
+++ b/tools/mapmerge2/fixup.py
@@ -68,7 +68,7 @@ def main(repo : pygit2.Repository):
 
     # Read the HEAD and ancestor commits.
     head_commit = repo[repo.head.target]
-    repo.remotes["upstream"].fetch()
+    repo.remotes["upstream"].fetch(repo.remotes["upstream"].fetch_refspecs)
     ancestor = repo.merge_base(repo.head.target, repo.revparse_single("refs/remotes/upstream/master").id)
     if not ancestor:
         print("Unable to automatically fix anything because merge base could not be determined.")

--- a/tools/mapmerge2/fixup.py
+++ b/tools/mapmerge2/fixup.py
@@ -59,9 +59,12 @@ def main(repo : pygit2.Repository):
             return 1
 
     # Set up upstream remote if needed
-    if not repo.remotes["upstream"]:
-        print("Adding upstream remote...")
+    try:
         repo.remotes.create("upstream", "https://github.com/cmss13-devs/cmss13.git")
+    except ValueError:
+        pass
+    else:
+        print("Adding upstream remote...")
 
     # Read the HEAD and ancestor commits.
     head_commit = repo[repo.head.target]

--- a/tools/mapmerge2/fixup.py
+++ b/tools/mapmerge2/fixup.py
@@ -68,6 +68,7 @@ def main(repo : pygit2.Repository):
 
     # Read the HEAD and ancestor commits.
     head_commit = repo[repo.head.target]
+    repo.remotes["upstream"].fetch()
     ancestor = repo.merge_base(repo.head.target, repo.revparse_single("refs/remotes/upstream/master").id)
     if not ancestor:
         print("Unable to automatically fix anything because merge base could not be determined.")

--- a/tools/mapmerge2/mapmerge.py
+++ b/tools/mapmerge2/mapmerge.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from . import frontend
 from .dmm import *
 
-def merge_map(new_map, old_map, delete_unused=False):
+def merge_map(new_map, old_map, delete_unused=True, suppress_notices=False):
     if new_map.key_length != old_map.key_length:
         print("Warning: Key lengths differ, taking new map")
         print(f"  Old: {old_map.key_length}")
@@ -65,8 +65,9 @@ def merge_map(new_map, old_map, delete_unused=False):
             select_key(fresh_key)
 
     # step two: delete unused keys
-    if unused_keys:
-        #print(f"Notice: Trimming {len(unused_keys)} unused dictionary keys.")
+    if unused_keys and delete_unused:
+        if not suppress_notices:
+            print(f"Notice: Trimming {len(unused_keys)} unused dictionary keys.")
         for key in unused_keys:
             del merged.dictionary[key]
 


### PR DESCRIPTION
# About the pull request

This PR is an experimental change to mapmerge2 where now free keys are gotten in sequential order rather than random, the map linter now attempts to merge all maps to determine if mapmerge2 would want to alter the maps (to detect a failure of using hooks or non-tgm format), and hopefully a more robust fixup script.

The other changes to maplint are to allow it to more gracefully handle var edits to areas (we already lint against this but it won't be properly handled), and var edits as [newlist](https://www.byond.com/docs/ref/#/proc/newlist).

Fixup now forces the upstream remote to be added to their repo (I don't know of a different way to get the merge_base I want),  merges based off of the merge_base version of the map (rather than really only looking at the HEAD commit), detects mapmerge2 changes for any map the HEAD tree is altering, and performs them. However, fixup does take significantly more time, but it really only checked for TGM format previously...

I also tweaked all [ci skip] checks to suppress the errors linted in VSC.

# Explain why it's good for the game
Hopefully less mapping conflicts in the scenario when a contributor is not using the [hooks](https://github.com/cmss13-devs/cmss13/tree/master/tools/hooks).

# Testing Photographs and Procedure
See the commit history of me testing changes as well as images below...

<details>
<summary>Screenshots & Videos</summary>

Commiting a map w/o hooks (and various commits in between):
![image](https://github.com/user-attachments/assets/23f7b5d1-dd43-4796-965c-826f8e41bccc)

Fixup script:
![image](https://github.com/user-attachments/assets/61db20ef-bb9c-43d5-a39b-80908dfb7986)

And then again:
![image](https://github.com/user-attachments/assets/b58c26c1-9b1b-43e2-be19-a9f114bbd4b0)

A new map in DMM format:
![image](https://github.com/user-attachments/assets/a7ab03d7-f7fd-468b-9845-d6e3c65e873c)
![image](https://github.com/user-attachments/assets/f96cfdc2-238c-47b2-8230-ef916593af89)

</details>

# Changelog
:cl:
code: dmm_test now checks if there are pending mapmerge2 conversions.
code: Improved dmm_test error handling
code: mapmerge2 now uses keys sequentially rather than randomly.
code: mapmerge2 fixup script now assigns upstream remote if needed, and checks/fixes pending mapmerge2 conversions.
/:cl:
