### PR TITLE
Notifies when intel points are maxed for non-xeno non-yautja corpses.

### DIFF
--- a/code/modules/objectives/mob_objectives.dm
+++ b/code/modules/objectives/mob_objectives.dm
@@ -122,7 +122,7 @@
 		return OBJECTIVE_LOW_VALUE
 
 	else if(ishumansynth_strict(target) && length(scored_humansynth_corpses) == 49)
-		announcement_helper("Maximum intel points for non-xenomorph corpses has been achieved.", "[MAIN_AI_SYSTEM] Intel Tracker", humans_uscm, 'sound/misc/notice2.ogg')
+		marine_announcement("Maximum intel points for non-xenomorph corpses has been achieved.", "Intel Announcement", 'sound/misc/notice2.ogg')
 		return OBJECTIVE_LOW_VALUE
 
 	return value

--- a/code/modules/objectives/mob_objectives.dm
+++ b/code/modules/objectives/mob_objectives.dm
@@ -122,7 +122,7 @@
 		return OBJECTIVE_LOW_VALUE
 
 	else if(ishumansynth_strict(target) && length(scored_humansynth_corpses) = 49)
-		announcement_helper("Maximum intel points for non-xenomorph corpses has been achieved.", "[MAIN_AI_SYSTEM] Intel Tracker", humans_uscm, 'sound/misc/notice1.ogg')
+		announcement_helper("Maximum intel points for non-xenomorph corpses has been achieved.", "[MAIN_AI_SYSTEM] Intel Tracker", humans_uscm, 'sound/misc/notice2.ogg')
 		return OBJECTIVE_LOW_VALUE
 
 	return value

--- a/code/modules/objectives/mob_objectives.dm
+++ b/code/modules/objectives/mob_objectives.dm
@@ -118,7 +118,11 @@
 				if(isqueen(X)) //Queen is Tier 0 for some reason...
 					value = OBJECTIVE_ABSOLUTE_VALUE
 
-	else if(ishumansynth_strict(target) && length(scored_humansynth_corpses) <= 49) // Limit human corpse recovery to 5 total points (.1 each)
+	else if(ishumansynth_strict(target) && length(scored_humansynth_corpses) <= 48) // Limit human corpse recovery to 5 total points (.1 each)
+		return OBJECTIVE_LOW_VALUE
+
+	else if(ishumansynth_strict(target) && length(scored_humansynth_corpses) = 49)
+		announcement_helper("Maximum intel points for non-xenomorph corpses has been achieved.", "[MAIN_AI_SYSTEM] Intel Tracker", humans_uscm, 'sound/misc/notice1.ogg')
 		return OBJECTIVE_LOW_VALUE
 
 	return value

--- a/code/modules/objectives/mob_objectives.dm
+++ b/code/modules/objectives/mob_objectives.dm
@@ -121,7 +121,7 @@
 	else if(ishumansynth_strict(target) && length(scored_humansynth_corpses) <= 48) // Limit human corpse recovery to 5 total points (.1 each)
 		return OBJECTIVE_LOW_VALUE
 
-	else if(ishumansynth_strict(target) && length(scored_humansynth_corpses) = 49)
+	else if(ishumansynth_strict(target) && length(scored_humansynth_corpses) == 49)
 		announcement_helper("Maximum intel points for non-xenomorph corpses has been achieved.", "[MAIN_AI_SYSTEM] Intel Tracker", humans_uscm, 'sound/misc/notice2.ogg')
 		return OBJECTIVE_LOW_VALUE
 


### PR DESCRIPTION
# About the pull request

Notifies when intel points are maxed for non-xeno non-yautja corpses.

# Explain why it's good for the game

If we're gonna limit intel points for corpses to 50 bodies, then there should at least be a notice sent so that people aren't trying to recover bodies for points when it's not possible.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: USCM notice sent when intel points for non-xeno non-yautja corpses are maxed out
/:cl:
