### PR TITLE
Throwing&Flaming mortar shells rebalance.

### DIFF
--- a/code/modules/cm_marines/equipment/mortar/mortar_shells.dm
+++ b/code/modules/cm_marines/equipment/mortar/mortar_shells.dm
@@ -29,6 +29,8 @@
 	name = "\improper 80mm high explosive mortar shell"
 	desc = "An 80mm mortar shell, loaded with a high explosive charge."
 	icon_state = "mortar_ammo_he"
+	throw_speed = SPEED_SLOW
+	throw_range = 1
 
 /obj/item/mortar_shell/he/detonate(turf/T)
 	explosion(T, 0, 3, 5, 7, explosion_cause_data = cause_data)
@@ -37,6 +39,8 @@
 	name = "\improper 80mm fragmentation mortar shell"
 	desc = "An 80mm mortar shell, loaded with a fragmentation charge."
 	icon_state = "mortar_ammo_frag"
+	throw_speed = SPEED_SLOW
+	throw_range = 1
 
 /obj/item/mortar_shell/frag/detonate(turf/T)
 	create_shrapnel(T, 60, cause_data = cause_data)
@@ -47,6 +51,8 @@
 	name = "\improper 80mm incendiary mortar shell"
 	desc = "An 80mm mortar shell, loaded with a Type B napalm charge. Perfect for long-range area denial."
 	icon_state = "mortar_ammo_inc"
+	throw_speed = SPEED_SLOW
+	throw_range = 1
 	var/radius = 5
 	var/flame_level = BURN_TIME_TIER_5 + 5 //Type B standard, 50 base + 5 from chemfire code.
 	var/burn_level = BURN_LEVEL_TIER_2
@@ -62,6 +68,8 @@
 	name = "\improper 80mm flare/camera mortar shell"
 	desc = "An 80mm mortar shell, loaded with an illumination flare / camera combo, attached to a parachute."
 	icon_state = "mortar_ammo_flr"
+	throw_speed = SPEED_SLOW
+	throw_range = 1
 
 /obj/item/mortar_shell/flare/detonate(turf/T)
 	new /obj/item/device/flashlight/flare/on/illumination(T)
@@ -72,6 +80,8 @@
 	name = "\improper 80mm custom mortar shell"
 	desc = "An 80mm mortar shell."
 	icon_state = "mortar_ammo_custom"
+	throw_speed = SPEED_SLOW
+	throw_range = 1
 	matter = list("metal" = 18750) //5 sheets
 	var/obj/item/explosive/warhead/mortar/warhead
 	var/obj/item/reagent_container/glass/fuel
@@ -168,7 +178,7 @@
 
 /obj/item/mortar_shell/flamer_fire_act(dam, datum/cause_data/flame_cause_data)
 	addtimer(VARSET_CALLBACK(src, burning, FALSE), 5 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_DELETE_ME)
-	
+
 	if(burning)
 		return
 	burning = TRUE
@@ -200,10 +210,10 @@
 
 		addtimer(CALLBACK(src, PROC_REF(explode), cause_data), 5 SECONDS)
 		addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(qdel), (src)), 5.5 SECONDS)
-		
+
 
 /obj/item/mortar_shell/proc/explode(flame_cause_data)
-	cell_explosion(src, 100, 25, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, flame_cause_data)
+	cell_explosion(src, 175, 25, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, flame_cause_data)
 
 /obj/structure/closet/crate/secure/mortar_ammo
 	name = "\improper M402 mortar ammo crate"


### PR DESCRIPTION
# About the pull request


This rebalances the mortar shells explosions to be more dangerous. while nerfing throw range to compensate against people using them as budget OT nades on the frontline.

# Explain why it's good for the game

Cooking mortar shells by accident or on purpose is interesting and soul, but should not be a standard strategy for frontliners, this attempts to create such a space.

The 1 tile throwing range means anyone trying to use these shells to destroy walls (at 175 explosion it's not good at that) they are opening themselves up to counterplay, while it would've been much safer to have just launched a grenade.


_**It's worthwhile to note the explosion is still relatively weak.**_ 
Even at 1 tile range it cannot kill a drone or defender that were set on fire, see video.

# Testing Photographs and Procedure


<details>
<summary>Screenshots & Videos</summary>


Throwing
https://github.com/user-attachments/assets/54463748-f053-494d-8802-2ec483598eaa


Explosion
https://github.com/user-attachments/assets/74226d58-ac9b-4afa-8ca7-e6ccc5b1398e


</details>


# Changelog

:cl:

balance: Increases explosive strength of cooked mortar shells
balance: Reduces throwing range of mortar shells

/:cl:

