### PR TITLE
Allow donators with more than 1 kit to retrieve additional kits from the personal gear vendor

### DIFF
--- a/code/modules/cm_marines/custom_items.dm
+++ b/code/modules/cm_marines/custom_items.dm
@@ -79,18 +79,18 @@ GLOBAL_LIST_EMPTY(donator_items)
 	if(user.ckey in GLOB.donator_items)
 		possible_kits += GLOB.donator_items[user.ckey]
 
-    if(user.ckey in ckeys_redeemed_kits)
-        if(length(possible_kits) <= 1)
-            to_chat(user, SPAN_NOTICE("You have already retrieved your kit."))
-            return TRUE
-        if(length(possible_kits) >= 2)
-            var/redeemed_kit_count = 0
-            for(var/U in ckeys_redeemed_kits)
-                if(U == user.ckey)
-                    redeemed_kit_count++
-            if(redeemed_kit_count >= length(possible_kits))
-                to_chat(user, SPAN_NOTICE("You have already retrieved your kits."))
-                return TRUE
+	if(user.ckey in ckeys_redeemed_kits)
+		if(length(possible_kits) <= 1)
+			to_chat(user, SPAN_NOTICE("You have already retrieved your kit."))
+			return TRUE
+		if(length(possible_kits) >= 2)
+			var/redeemed_kit_count = 0
+			for(var/U in ckeys_redeemed_kits)
+				if(U == user.ckey)
+					redeemed_kit_count++
+			if(redeemed_kit_count >= length(possible_kits))
+				to_chat(user, SPAN_NOTICE("You have already retrieved your kits."))
+				return TRUE
 
 	if(length(possible_kits) == 0) //if no donor kit they can get something else
 		var/random_item = pick(random_personal_possessions)

--- a/code/modules/cm_marines/custom_items.dm
+++ b/code/modules/cm_marines/custom_items.dm
@@ -75,13 +75,22 @@ GLOBAL_LIST_EMPTY(donator_items)
 	if(!ishuman(user))
 		return FALSE
 
-	if(user.ckey in ckeys_redeemed_kits)
-		to_chat(user, SPAN_NOTICE("You have already retrieved your kit."))
-		return TRUE
-
 	var/list/possible_kits = list()
 	if(user.ckey in GLOB.donator_items)
 		possible_kits += GLOB.donator_items[user.ckey]
+
+    if(user.ckey in ckeys_redeemed_kits)
+        if(length(possible_kits) <= 1)
+            to_chat(user, SPAN_NOTICE("You have already retrieved your kit."))
+            return TRUE
+        if(length(possible_kits) >= 2)
+            var/redeemed_kit_count = 0
+            for(var/U in ckeys_redeemed_kits)
+                if(U == user.ckey)
+                    redeemed_kit_count++
+            if(redeemed_kit_count >= length(possible_kits))
+                to_chat(user, SPAN_NOTICE("You have already retrieved your kits."))
+                return TRUE
 
 	if(length(possible_kits) == 0) //if no donor kit they can get something else
 		var/random_item = pick(random_personal_possessions)


### PR DESCRIPTION
# About the pull request

Adds code to the Personal Gear Vendor to check if a user has additional kits and allow them to retrieve additional kits until they have retrieved all kits.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Allows donators who had multiple kits to still keep the kits they would have normally spawned with in their backpacks, by getting them from the personal gear vendor.
# Changelog
:cl:
add: Personal Gear Vendor allows retrieval of additional kits for multi-kit donators
/:cl:
