### PR TITLE
Burrower and Carrier max plasma buff

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
@@ -418,9 +418,9 @@
 		button.icon_state = "template_active"
 
 /datum/action/xeno_action/onclick/place_trap
-	name = "Place resin hole (200)"
+	name = "Place resin hole (300)"
 	action_icon_state = "place_trap"
-	plasma_cost = 200
+	plasma_cost = 300
 	macro_path = /datum/action/xeno_action/verb/verb_resin_hole
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_2

--- a/code/modules/mob/living/carbon/xenomorph/castes/Burrower.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Burrower.dm
@@ -8,7 +8,7 @@
 	melee_vehicle_damage = XENO_DAMAGE_TIER_3
 	max_health = XENO_HEALTH_TIER_6
 	plasma_gain = XENO_PLASMA_GAIN_TIER_8
-	plasma_max = XENO_PLASMA_TIER_6
+	plasma_max = XENO_PLASMA_TIER_10
 	xeno_explosion_resistance = XENO_EXPLOSIVE_ARMOR_TIER_4
 	armor_deflection = XENO_ARMOR_TIER_2
 	evasion = XENO_EVASION_NONE

--- a/code/modules/mob/living/carbon/xenomorph/castes/Carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Carrier.dm
@@ -8,7 +8,7 @@
 	melee_vehicle_damage = XENO_DAMAGE_TIER_3
 	max_health = XENO_HEALTH_TIER_9
 	plasma_gain = XENO_PLASMA_GAIN_TIER_6
-	plasma_max = XENO_PLASMA_TIER_5
+	plasma_max = XENO_PLASMA_TIER_10
 	xeno_explosion_resistance = XENO_EXPLOSIVE_ARMOR_TIER_2
 	armor_deflection = XENO_NO_ARMOR
 	evasion = XENO_EVASION_NONE


### PR DESCRIPTION
# About the pull request

Increases the max plasma of burrower and carrier castes to match drone. 

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

80% of the gameplay involves resting and waiting for plasma pool to regenerate. Burrower only has 600 and carrier 500. It burns through very fast and is not that very engaging. You should not be punished from evolving into a T2 with limited slots (technically 1 reserved slot) while drone enjoys playing around with 1000 plasma. It is also a pain making hive structures, I believe they cost more than the current max plasma pools of either of these castes. 

I expect as a consequence of this that there will be more resin traps, but I think that is manageable coming from a someone that plays marine mainly.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Carrier max plasma increased 500>1000, Burrrower max plasma increased 600>1000
/:cl:
