### PR TITLE
emp act on human fix

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -154,15 +154,7 @@ Contains most of the procs that are called when a mob is attacked by something
 		return TRUE
 	return FALSE
 
-/mob/living/carbon/human/emp_act(severity)
-	. = ..()
-	for(var/obj/limb/O in limbs)
-		if(O.status & LIMB_DESTROYED)
-			continue
-		for(var/datum/internal_organ/I in O.internal_organs)
-			if(I.robotic == FALSE)
-				continue
-			I.emp_act(severity)
+
 
 //Returns 1 if the attack hit, 0 if it missed.
 /mob/living/carbon/human/proc/attacked_by(obj/item/I, mob/living/user)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -154,6 +154,15 @@ Contains most of the procs that are called when a mob is attacked by something
 		return TRUE
 	return FALSE
 
+/mob/living/carbon/human/emp_act(severity)
+	. = ..()
+	for(var/obj/limb/O in limbs)
+		if(O.status & LIMB_DESTROYED)
+			continue
+		for(var/datum/internal_organ/I in O.internal_organs)
+			if(I.robotic == FALSE)
+				continue
+			I.emp_act(severity)
 
 //Returns 1 if the attack hit, 0 if it missed.
 /mob/living/carbon/human/proc/attacked_by(obj/item/I, mob/living/user)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -154,21 +154,6 @@ Contains most of the procs that are called when a mob is attacked by something
 		return TRUE
 	return FALSE
 
-/mob/living/carbon/human/emp_act(severity)
-	. = ..()
-	for(var/obj/O in src)
-		if(!O)
-			continue
-		O.emp_act(severity)
-	for(var/obj/limb/O in limbs)
-		if(O.status & LIMB_DESTROYED)
-			continue
-		O.emp_act(severity)
-		for(var/datum/internal_organ/I in O.internal_organs)
-			if(I.robotic == FALSE)
-				continue
-			I.emp_act(severity)
-
 
 //Returns 1 if the attack hit, 0 if it missed.
 /mob/living/carbon/human/proc/attacked_by(obj/item/I, mob/living/user)

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -186,6 +186,10 @@
 		droplimb(0, 0, "EMP")
 	else
 		take_damage(damage, 0, 1, 1, used_weapon = "EMP")
+		for(var/datum/internal_organ/internal_organ in internal_organs)
+			if(internal_organ.robotic == FALSE)
+				continue
+			internal_organ.emp_act(severity)
 
 /// If this limb can be dropped as a result of an EMP
 /obj/limb/proc/can_emp_delimb()


### PR DESCRIPTION

# About the pull request

fixes emp_act being called three times on each limb human (this includes synths) has and two times on every object in their inventory. being called once is handeled on mob/living already

# Explain why it's good for the game

this extreame bug increased delimb chance of emp on each synth (robotic) bodypart from 30% to 70% and increased the dmg from emp 3 times and also doubled emp effect on any object in human possestion. this is pure fix not balance


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: emp act is called once on each limb not three time
/:cl:
