### PR TITLE
Code for Strata tilesets missing and restructure 

### DIFF
--- a/code/game/turfs/strata.dm
+++ b/code/game/turfs/strata.dm
@@ -57,21 +57,6 @@
 /turf/open/floor/strata/white_cyan3/southwest
 	dir = SOUTHWEST
 
-/turf/open/floor/strata/blue4
-	icon_state = "blue4"
-
-/turf/open/floor/strata/blue4/north
-	dir = NORTH
-
-/turf/open/floor/strata/blue4/east
-	dir = EAST
-
-/turf/open/floor/strata/red3
-	icon_state = "red3"
-
-/turf/open/floor/strata/red3/north
-	dir = NORTH
-
 /turf/open/floor/strata/white_cyan3/north
 	dir = NORTH
 
@@ -81,23 +66,13 @@
 /turf/open/floor/strata/white_cyan4/north
 	dir = NORTH
 
-/turf/open/floor/strata/red3/south
-	dir = SOUTH
-
 /turf/open/floor/strata/white_cyan3/south
 	dir = SOUTH
 
 /turf/open/floor/strata/white_cyan4/south
 	dir = SOUTH
 
-/turf/open/floor/strata/blue3
-	icon_state = "blue3"
-
-/turf/open/floor/strata/blue3/southwest
-	dir = SOUTHWEST
-
-/turf/open/floor/strata/blue3/east
-	dir = EAST
+////strata - cyan////
 
 /turf/open/floor/strata/cyan1
 	icon_state = "cyan1"
@@ -114,8 +89,26 @@
 /turf/open/floor/strata/cyan3
 	icon_state = "cyan3"
 
+/turf/open/floor/strata/cyan3/west
+	dir = WEST
+
 /turf/open/floor/strata/cyan3/east
 	dir = EAST
+
+/turf/open/floor/strata/cyan3/north
+	dir = NORTH
+
+/turf/open/floor/strata/cyan3/northeast
+	dir = NORTHEAST
+
+/turf/open/floor/strata/cyan3/northwest
+	dir = NORTHWEST
+
+/turf/open/floor/strata/cyan3/southeast
+	dir = SOUTHEAST
+
+/turf/open/floor/strata/cyan3/southwest
+	dir = SOUTHWEST
 
 /turf/open/floor/strata/cyan4
 	icon_state = "cyan4"
@@ -123,11 +116,19 @@
 /turf/open/floor/strata/cyan4/east
 	dir = EAST
 
+/turf/open/floor/strata/cyan4/north
+	dir = NORTH
+
+/turf/open/floor/strata/cyan4/west
+	dir = WEST
+
 /turf/open/floor/strata/floor3
 	icon_state = "floor3"
 
 /turf/open/floor/strata/floor3/east
 	dir = EAST
+
+////strata - orange////
 
 /turf/open/floor/strata/orange_edge
 	icon_state = "orange_edge"
@@ -135,8 +136,43 @@
 /turf/open/floor/strata/orange_edge/east
 	dir = EAST
 
-/turf/open/floor/strata/red3/east
+/turf/open/floor/strata/orange_edge/west
+	dir = WEST
+
+/turf/open/floor/strata/orange_edge/north
+	dir = NORTH
+
+/turf/open/floor/strata/orange_edge/northeast
+	dir = NORTHEAST
+
+/turf/open/floor/strata/orange_edge/northwest
+	dir = NORTHWEST
+
+/turf/open/floor/strata/orange_edge/southwest
+	dir = SOUTHWEST
+
+/turf/open/floor/strata/orange_edge/southeast
+	dir = SOUTHEAST
+
+/turf/open/floor/strata/orange_cover
+	icon_state = "orange_cover"
+
+/turf/open/floor/strata/orange_icorner
+	icon_state = "orange_icorner"
+
+/turf/open/floor/strata/orange_icorner/north
+	dir = NORTH
+
+/turf/open/floor/strata/orange_icorner/west
+	dir = WEST
+
+/turf/open/floor/strata/orange_icorner/east
 	dir = EAST
+
+//------------//
+
+/turf/open/floor/strata/orange_tile
+	icon_state = "orange_tile"
 
 /turf/open/floor/strata/white_cyan1
 	icon_state = "white_cyan1"
@@ -159,19 +195,7 @@
 /turf/open/floor/strata/white_cyan3/southeast
 	dir = SOUTHEAST
 
-/turf/open/floor/strata/blue3/west
-	dir = WEST
-
-/turf/open/floor/strata/cyan3/west
-	dir = WEST
-
 /turf/open/floor/strata/multi_tiles/west
-	dir = WEST
-
-/turf/open/floor/strata/orange_edge/west
-	dir = WEST
-
-/turf/open/floor/strata/red3/west
 	dir = WEST
 
 /turf/open/floor/strata/white_cyan2
@@ -189,11 +213,49 @@
 /turf/open/floor/strata/white_cyan3/northwest
 	dir = NORTHWEST
 
+////strata - blue////
+
 /turf/open/floor/strata/blue1
 	icon_state = "blue1"
 
+/turf/open/floor/strata/blue2
+	icon_state = "blue2"
+
+/turf/open/floor/strata/blue3
+	icon_state = "blue3"
+
+/turf/open/floor/strata/blue3/east
+	dir = EAST
+
 /turf/open/floor/strata/blue3/north
 	dir = NORTH
+
+/turf/open/floor/strata/blue3/west
+	dir = WEST
+
+/turf/open/floor/strata/blue3/southwest
+	dir = SOUTHWEST
+
+/turf/open/floor/strata/blue3/southeast
+	dir = SOUTHEAST
+
+/turf/open/floor/strata/blue3/northeast
+	dir = NORTHEAST
+
+/turf/open/floor/strata/blue3/northwest
+	dir = NORTHWEST
+
+/turf/open/floor/strata/blue4
+	icon_state = "blue4"
+
+/turf/open/floor/strata/blue4/north
+	dir = NORTH
+
+/turf/open/floor/strata/blue4/east
+	dir = EAST
+
+/turf/open/floor/strata/blue4/west
+	dir = WEST
 
 /turf/open/floor/strata/damaged3
 	icon_state = "damaged3"
@@ -210,8 +272,13 @@
 /turf/open/floor/strata/floorscorched2
 	icon_state = "floorscorched2"
 
+////strata - green////
+
 /turf/open/floor/strata/green1
 	icon_state = "green1"
+
+/turf/open/floor/strata/green2
+	icon_state = "green2"
 
 /turf/open/floor/strata/green3
 	icon_state = "green3"
@@ -222,14 +289,20 @@
 /turf/open/floor/strata/green3/east
 	dir = EAST
 
-/turf/open/floor/strata/green3/northeast
-	dir = NORTHEAST
-
 /turf/open/floor/strata/green3/west
 	dir = WEST
 
 /turf/open/floor/strata/green3/northwest
 	dir = NORTHWEST
+
+/turf/open/floor/strata/green3/northeast
+	dir = NORTHEAST
+
+/turf/open/floor/strata/green3/southeast
+	dir = SOUTHEAST
+
+/turf/open/floor/strata/green3/southwest
+	dir = SOUTHWEST
 
 /turf/open/floor/strata/green4
 	icon_state = "green4"
@@ -243,20 +316,7 @@
 /turf/open/floor/strata/green4/west
 	dir = WEST
 
-/turf/open/floor/strata/orange_cover
-	icon_state = "orange_cover"
-
-/turf/open/floor/strata/orange_icorner
-	icon_state = "orange_icorner"
-
-/turf/open/floor/strata/orange_icorner/north
-	dir = NORTH
-
-/turf/open/floor/strata/orange_icorner/west
-	dir = WEST
-
-/turf/open/floor/strata/orange_tile
-	icon_state = "orange_tile"
+////strata - purple////
 
 /turf/open/floor/strata/purp1
 	icon_state = "purp1"
@@ -270,11 +330,70 @@
 /turf/open/floor/strata/purp3/east
 	dir = EAST
 
+/turf/open/floor/strata/purp3/north
+	dir = NORTH
+
+/turf/open/floor/strata/purp3/west
+	dir = WEST
+
+/turf/open/floor/strata/purp3/northeast
+	dir = NORTHEAST
+
+/turf/open/floor/strata/purp3/northwest
+	dir = NORTHWEST
+
+/turf/open/floor/strata/purp3/southeast
+	dir = SOUTHEAST
+
+/turf/open/floor/strata/purp3/southwest
+	dir = SOUTHWEST
+
+/turf/open/floor/strata/purp4
+	icon_state = "purp4"
+
+/turf/open/floor/strata/purp4/north
+	dir = NORTH
+
+/turf/open/floor/strata/purp4/east
+	dir = EAST
+
+/turf/open/floor/strata/purp4/west
+	dir = WEST
+
+////strata - red////
+
 /turf/open/floor/strata/red1
 	icon_state = "red1"
 
 /turf/open/floor/strata/red2
 	icon_state = "red2"
+
+/turf/open/floor/strata/red3
+	icon_state = "red3"
+
+/turf/open/floor/strata/red3/west
+	dir = WEST
+
+/turf/open/floor/strata/red3/east
+	dir = EAST
+
+/turf/open/floor/strata/red3/north
+	dir = NORTH
+
+/turf/open/floor/strata/red3/south
+	dir = SOUTH
+
+/turf/open/floor/strata/red3/northeast
+	dir = NORTHEAST
+
+/turf/open/floor/strata/red3/northwest
+	dir = NORTHWEST
+
+/turf/open/floor/strata/red3/southeast
+	dir = SOUTHEAST
+
+/turf/open/floor/strata/red3/southwest
+	dir = SOUTHWEST
 
 /turf/open/floor/strata/red4
 	icon_state = "red4"


### PR DESCRIPTION

# About the pull request
Adds the missing code needed for the strata tilesets so the tiles and sprites are accessible to be used.

# Explain why it's good for the game
Adds the missing code needed for the strata tilesets so the tiles and sprites are accessible to be used.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Steelpoint, Nanu
code: Adds missing strata tile-set to be available to mappers. Code originally done by Steelpoint.
/:cl:
