### PR TITLE
Makes you unable to pixelshift structures (barricades/sentries/others)

### DIFF
--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -154,6 +154,8 @@
 		return FALSE
 	if(grabbed_atom.anchored)
 		return FALSE
+	if(istype(grabbed_atom, /obj/structure))
+		return FALSE
 	return TRUE
 
 /datum/keybinding/human/pixel_shift/north


### PR DESCRIPTION

# About the pull request

MOST of these cases are covered by the anchored check. But some structures (like barricades) can be unanchored and re-anchored. 
This looks kinda silly, and could trick people into misjudging what the barricade is actually protecting.

# Explain why it's good for the game
Prevents hiding barricades and sentries, makes stuff look less silly.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Barricades have been covered in petroleum jelly. They can no longer be pixelshifted.
/:cl:
