### PR TITLE
Lift more weed restrictions

### DIFF
--- a/code/game/area/BigRed.dm
+++ b/code/game/area/BigRed.dm
@@ -313,7 +313,7 @@
 	icon = 'icons/turf/area_kutjevo.dmi'
 	icon_state = "oob"
 	is_resin_allowed = FALSE
-	flags_area = AREA_NOTUNNEL
+	flags_area = AREA_NOTUNNEL|AREA_UNWEEDABLE
 	can_build_special = FALSE
 	soundscape_interval = 0
 

--- a/code/game/area/BigRed.dm
+++ b/code/game/area/BigRed.dm
@@ -653,7 +653,6 @@
 	minimap_color = MINIMAP_AREA_LZ
 	icon_state = "tcomsatcham"
 	requires_power = FALSE
-	is_resin_allowed = FALSE
 
 /area/bigredv2/landing/console
 	name = "\improper LZ1 'Telecomms'"

--- a/code/game/area/Corsat.dm
+++ b/code/game/area/Corsat.dm
@@ -30,12 +30,10 @@
 /area/corsat/sigma/north
 	name = "\improper Sigma Sector North Hallway"
 	icon_state = "sigma_hallway_north"
-	is_resin_allowed = FALSE
 
 /area/corsat/sigma/hangar
 	name = "\improper Landing Bay Sigma"
 	icon_state = "sigma_hangar"
-	is_resin_allowed = FALSE
 	is_landing_zone = TRUE
 
 /area/corsat/sigma/hangar/monorail
@@ -104,22 +102,18 @@
 /area/corsat/sigma/cargo
 	name = "\improper Sigma Cargo"
 	icon_state = "sigma_cargo"
-	is_resin_allowed = FALSE
 
 /area/corsat/sigma/laundry
 	name = "\improper Sigma Laundry"
 	icon_state = "sigma_laundry"
-	is_resin_allowed = FALSE
 
 /area/corsat/sigma/lavatory
 	name = "\improper Sigma Lavatory"
 	icon_state = "sigma_lavatory"
-	is_resin_allowed = FALSE
 
 /area/corsat/sigma/cafe
 	name = "\improper Sigma Cafe"
 	icon_state = "sigma_cafe"
-	is_resin_allowed = FALSE
 
 /area/corsat/sigma/dorms
 	name = "\improper Sigma Residential Module"
@@ -216,7 +210,6 @@
 /area/corsat/gamma/hangar
 	name = "\improper Landing Bay Gamma"
 	icon_state = "gamma_hangar"
-	is_resin_allowed = FALSE
 	is_landing_zone = TRUE
 
 /area/corsat/gamma/hangar/monorail
@@ -260,7 +253,6 @@
 /area/corsat/gamma/foyer
 	name = "\improper Gamma Foyer"
 	icon_state = "gamma_foyer"
-	is_resin_allowed = FALSE
 
 /area/corsat/gamma/hallwaymain
 	name = "\improper Gamma Sector West Hallway"
@@ -309,8 +301,6 @@
 /area/corsat/gamma/cargo
 	name = "\improper Gamma Cargo"
 	icon_state = "gamma_cargo"
-	is_resin_allowed = FALSE
-
 /area/corsat/gamma/cargo/lobby
 	name = "\improper Gamma Cargo Lobby"
 	icon_state = "gamma_cargo_lobby"
@@ -378,12 +368,10 @@
 /area/corsat/gamma/rnr/bar
 	name = "\improper CORSAT Bar"
 	icon_state = "corsat_bar"
-	is_resin_allowed = FALSE
 
 /area/corsat/gamma/rnr/arcade
 	name = "\improper CORSAT Arcade"
 	icon_state = "corsat_arcade"
-	is_resin_allowed = FALSE
 
 /area/corsat/gamma/rnr/library
 	name = "\improper CORSAT Library"

--- a/code/game/area/Corsat.dm
+++ b/code/game/area/Corsat.dm
@@ -301,6 +301,7 @@
 /area/corsat/gamma/cargo
 	name = "\improper Gamma Cargo"
 	icon_state = "gamma_cargo"
+
 /area/corsat/gamma/cargo/lobby
 	name = "\improper Gamma Cargo Lobby"
 	icon_state = "gamma_cargo_lobby"

--- a/code/game/area/IceColony.dm
+++ b/code/game/area/IceColony.dm
@@ -56,7 +56,6 @@
 /area/ice_colony/exterior/surface/landing_pad
 	name = "\improper Aerodrome Landing Pad"
 	icon_state = "landing_pad"
-	is_resin_allowed = FALSE
 	minimap_color = MINIMAP_AREA_LZ
 
 //Landing Pad for the Vindi. THIS IS NOT THE SHUTTLE AREA
@@ -64,14 +63,12 @@
 	name = "\improper Emergency Landing Pad"
 	icon_state = "landing_pad"
 	minimap_color = MINIMAP_AREA_LZ
-	is_resin_allowed = FALSE
 
 
 //Everything around the physical landing pad
 /area/ice_colony/exterior/surface/landing_pad_external
 	name = "\improper Aerodrome Landing Valley"
 	icon_state = "landing_pad_ext"
-	is_resin_allowed = FALSE
 	minimap_color = MINIMAP_AREA_LZ
 
 //Aerodrome Container Yard
@@ -79,7 +76,6 @@
 	name = "\improper Aerodrome Container Yard"
 	icon_state = "container_yard"
 	minimap_color = MINIMAP_AREA_LZ
-	is_resin_allowed = FALSE
 
 //
 // Valleys
@@ -357,7 +353,6 @@
 
 /area/ice_colony/surface/hangar/hallway
 	name = "\improper Aerodrome Hangar Hallway"
-	is_resin_allowed = FALSE
 
 /area/ice_colony/surface/hangar/alpha
 	name = "\improper Aerodrome Hangar 'Alpha'"
@@ -366,7 +361,6 @@
 /area/ice_colony/surface/hangar/beta
 	name = "\improper Aerodrome Hangar 'Beta'"
 	icon_state = "hangar_beta"
-	is_resin_allowed = FALSE
 
 /area/ice_colony/surface/hangar/checkpoint
 	name = "\improper Aerodrome Hangar Security Checkpoint"
@@ -631,7 +625,6 @@
 /area/ice_colony/underground/maintenance/north
 	name = "\improper Underground Northern Maintenance"
 	icon_state = "asmaint"
-	is_resin_allowed = FALSE
 
 /*
  * Underground - Medbay
@@ -692,7 +685,6 @@
 /area/ice_colony/underground/requesition
 	name = "\improper Underground Requesitions"
 	icon_state = "quart"
-	is_resin_allowed = FALSE
 
 /area/ice_colony/underground/requesition/lobby
 	name = "\improper Underground Requesitions Lobby"
@@ -705,7 +697,6 @@
 /area/ice_colony/underground/requesition/sec_storage
 	name = "\improper Underground Requesitions Secure Storage"
 	icon_state = "storage"
-	is_resin_allowed = TRUE
 
 /*
  * Underground - Research
@@ -773,7 +764,6 @@
 	name = "\improper Underground Hangar"
 	icon_state = "hangar"
 	ceiling = CEILING_NONE
-	is_resin_allowed = FALSE
 
 /*
  * Underground - Storage

--- a/code/game/area/LV522_Chances_Claim.dm
+++ b/code/game/area/LV522_Chances_Claim.dm
@@ -26,7 +26,7 @@
 	icon_state = "unknown"
 	ceiling = CEILING_MAX
 	is_resin_allowed = FALSE
-	flags_area = AREA_NOTUNNEL
+	flags_area = AREA_NOTUNNEL|AREA_UNWEEDABLE
 
 /area/lv522/oob/w_y_vault
 	name = "LV522 - Weyland Secure Vault"

--- a/code/game/area/LV522_Chances_Claim.dm
+++ b/code/game/area/LV522_Chances_Claim.dm
@@ -37,7 +37,6 @@
 /area/lv522/landing_zone_1
 	name = "Chance's Claim - Landing Zone One"
 	icon_state = "explored"
-	is_resin_allowed =  FALSE
 	is_landing_zone = TRUE
 	minimap_color = MINIMAP_AREA_LZ
 	linked_lz = DROPSHIP_LZ1
@@ -70,7 +69,6 @@
 /area/lv522/landing_zone_2
 	name = "Chance's Claim - Landing Zone Two"
 	icon_state = "explored"
-	is_resin_allowed =  FALSE
 	is_landing_zone = TRUE
 	minimap_color = MINIMAP_AREA_LZ
 	linked_lz = DROPSHIP_LZ2
@@ -199,7 +197,6 @@
 	name = "North LZ1 - Spaceport"
 	icon_state = "red"
 	minimap_color = MINIMAP_AREA_LZ
-	is_resin_allowed = FALSE
 
 /area/lv522/indoors/lone_buildings/outdoor_bot
 	name = "East LZ1 - Outdoor T-Comms"

--- a/code/game/area/LV624.dm
+++ b/code/game/area/LV624.dm
@@ -285,7 +285,6 @@
 
 /area/lv624/lazarus/landing_zones
 	ceiling = CEILING_NONE
-	is_resin_allowed = FALSE
 	is_landing_zone = TRUE
 
 /area/lv624/lazarus/landing_zones/lz1

--- a/code/game/area/Prison_Station_FOP.dm
+++ b/code/game/area/Prison_Station_FOP.dm
@@ -10,7 +10,6 @@
 /area/prison/security
 	name = "\improper Security Department"
 	icon_state = "security"
-	is_resin_allowed = FALSE
 	minimap_color = MINIMAP_AREA_SEC
 
 /area/prison/security/briefing
@@ -35,7 +34,6 @@
 
 /area/prison/security/monitoring
 	icon_state = "sec_prison"
-	is_resin_allowed = TRUE
 
 /area/prison/security/monitoring/lowsec/ne
 	name = "\improper Northeast Low-Security Monitoring"
@@ -64,7 +62,6 @@
 
 /area/prison/security/checkpoint
 	icon_state = "checkpoint1"
-	is_resin_allowed = TRUE
 
 /area/prison/security/checkpoint/medsec
 	name = "\improper Medium-Security Checkpoint"
@@ -89,7 +86,6 @@
 
 /area/prison/security/checkpoint/hangar
 	name = "\improper Main Hangar Traffic Control"
-	is_resin_allowed = FALSE
 	is_landing_zone = TRUE
 
 /area/prison/storage
@@ -168,7 +164,6 @@
 
 /area/prison/toilet/security
 	name = "\improper Security Restooms"
-	is_resin_allowed = FALSE
 
 /area/prison/toilet/research
 	name = "\improper Research Restooms"
@@ -202,7 +197,6 @@
 /area/prison/maintenance/staff_research
 	name = "\improper Staff-Research Maintenance"
 	icon_state = "maint_research_starboard"
-	is_resin_allowed = FALSE
 
 /area/prison/maintenance/research_medbay
 	name = "\improper Research-Infirmary Maintenance"
@@ -211,7 +205,6 @@
 /area/prison/maintenance/hangar_barracks
 	name = "\improper Hangar-Barracks Maintenance"
 	icon_state = "maint_e_shuttle"
-	is_resin_allowed = FALSE
 	is_landing_zone = TRUE
 
 /area/prison/canteen
@@ -262,7 +255,6 @@
 /area/prison/hallway/entrance
 	name = "\improper Entrance Hallway"
 	icon_state = "entry"
-	is_resin_allowed = FALSE
 
 /area/prison/hallway/central
 	name = "\improper Central Ring"
@@ -409,17 +401,14 @@
 /area/prison/research
 	name = "\improper Biological Research Department"
 	icon_state = "research"
-	is_resin_allowed = FALSE
 
 /area/prison/research/RD
 	name = "\improper Research Director's office"
 	icon_state = "disposal"
-	is_resin_allowed = FALSE
 
 /area/prison/research/secret
 	name = "\improper Classified Research"
 	icon_state = "toxlab"
-	is_resin_allowed = TRUE
 
 /area/prison/research/secret/dissection
 	name = "\improper Dissection"
@@ -458,14 +447,10 @@
 
 /area/prison/monorail/east
 	name = "\improper East Monorail Station"
-	is_resin_allowed = FALSE
 	is_landing_zone = TRUE
 
 /area/prison/monorail/west
 	name = "\improper West Monorail Station"
-
-/area/prison/hanger
-	is_resin_allowed = FALSE
 
 /area/prison/hanger/main
 	name = "\improper Main Hanger"
@@ -484,7 +469,6 @@
 /area/prison/hangar_storage/research
 	name = "\improper Research Hangar Storage"
 	icon_state = "toxstorage"
-	is_resin_allowed = FALSE
 	is_landing_zone = TRUE
 
 /area/prison/hangar_storage/research/shuttle
@@ -494,7 +478,6 @@
 /area/prison/telecomms
 	name = "\improper Telecommunications"
 	icon_state = "tcomsatcham"
-	is_resin_allowed = FALSE
 
 /area/prison/pirate
 	name = "Tramp Freighter \"Rocinante\""

--- a/code/game/area/Sulaco.dm
+++ b/code/game/area/Sulaco.dm
@@ -10,7 +10,6 @@
 /area/shuttle/drop1
 	//soundscape_playlist = list('sound/soundscape/drum1.ogg')
 	soundscape_interval = 30 //seconds
-	is_resin_allowed = FALSE
 	flags_area = AREA_NOTUNNEL
 	is_landing_zone = TRUE
 	ceiling = CEILING_REINFORCED_METAL
@@ -69,7 +68,6 @@
 /area/shuttle/drop2
 	//soundscape_playlist = list('sound/soundscape/drum1.ogg')
 	soundscape_interval = 30 //seconds
-	is_resin_allowed = FALSE
 	flags_area = AREA_NOTUNNEL
 	is_landing_zone = TRUE
 	ceiling = CEILING_REINFORCED_METAL
@@ -123,7 +121,6 @@
 /area/shuttle/drop3
 	//soundscape_playlist = list('sound/soundscape/drum1.ogg')
 	soundscape_interval = 30 //seconds
-	is_resin_allowed = FALSE
 	flags_area = AREA_NOTUNNEL
 	is_landing_zone = TRUE
 	ceiling = CEILING_REINFORCED_METAL
@@ -177,7 +174,6 @@
 
 /area/shuttle/drop_upp
 	soundscape_interval = 30 //seconds
-	is_resin_allowed = FALSE
 	flags_area = AREA_NOTUNNEL
 	is_landing_zone = TRUE
 	ceiling = CEILING_REINFORCED_METAL

--- a/code/game/area/Sulaco.dm
+++ b/code/game/area/Sulaco.dm
@@ -25,6 +25,7 @@
 	icon_state = "shuttlered"
 	base_muffle = MUFFLE_HIGH
 	base_lighting_alpha = 255
+	is_resin_allowed = FALSE
 
 /area/shuttle/drop1/LV624
 	name = "\improper Dropship Alamo"
@@ -78,6 +79,7 @@
 	icon_state = "shuttle"
 	base_muffle = MUFFLE_HIGH
 	base_lighting_alpha = 255
+	is_resin_allowed = FALSE
 
 /area/shuttle/drop2/LV624
 	name = "\improper Dropship Normandy"

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -115,6 +115,10 @@
 	if(unoviable_timer)
 		SSticker.OnRoundstart(CALLBACK(src, PROC_REF(handle_ovi_timer)))
 
+	if((flags_area & AREA_UNWEEDABLE) && is_resin_allowed)
+		is_resin_allowed = FALSE
+		log_mapping("[src] has AREA_UNWEEDABLE flag but has is_resin_allowed as true! Forcing is_resin_allowed false...")
+
 /area/proc/initialize_power(override_power)
 	if(requires_power)
 		if(override_power) //Reset everything if you want to override.

--- a/code/game/area/kutjevo.dm
+++ b/code/game/area/kutjevo.dm
@@ -36,16 +36,14 @@
 	requires_power = 1
 
 /area/kutjevo/interior/oob
-	name = "Kutjevo -  Out Of Bounds"
+	name = "Kutjevo - Out Of Bounds"
 	ceiling = CEILING_MAX
 	icon_state = "oob"
 	is_resin_allowed = FALSE
-	flags_area = AREA_NOTUNNEL
+	flags_area = AREA_NOTUNNEL|AREA_UNWEEDABLE
 
 /area/kutjevo/interior/oob/dev_room
 	name = "Kutjevo - Credits Room"
-	is_resin_allowed = FALSE
-	flags_area = AREA_NOTUNNEL
 	icon_state = "kutjevo"
 
 //exterior map areas

--- a/code/game/area/kutjevo.dm
+++ b/code/game/area/kutjevo.dm
@@ -54,17 +54,15 @@
 	name = "Kutjevo Auxilliary Landing Zone"
 	icon_state = "lz_pad"
 	weather_enabled = FALSE
-	unlimited_power = 1//ds computer
-	is_resin_allowed = FALSE
+	unlimited_power = 1 //ds computer
 	is_landing_zone = TRUE
 	linked_lz = DROPSHIP_LZ2
 
 /area/kutjevo/exterior/lz_dunes
 	name = "Kutjevo - Landing Zone Dunes"
 	icon_state = "lz_dunes"
-	is_resin_allowed = FALSE
 	weather_enabled =  FALSE
-	unlimited_power = 1//DS Computer
+	unlimited_power = 1 //DS Computer
 	is_landing_zone = TRUE
 	linked_lz = DROPSHIP_LZ1
 

--- a/code/game/area/prison_v3_fiorina.dm
+++ b/code/game/area/prison_v3_fiorina.dm
@@ -72,17 +72,14 @@
 	name = "Fiorina - LZ"
 	is_landing_zone = TRUE
 	minimap_color = MINIMAP_AREA_LZ
-	is_resin_allowed = FALSE
 
 /area/fiorina/lz/near_lzI
 	name = "Fiorina - LZ1 Aux Port"
 	linked_lz = DROPSHIP_LZ1
-	is_resin_allowed = null
 
 /area/fiorina/lz/near_lzII
 	name = "Fiorina - LZ2 Prison Port"
 	linked_lz = DROPSHIP_LZ2
-	is_resin_allowed = null
 
 /area/fiorina/lz/console_I
 	name = "Fiorina - LZ1 Control Console"

--- a/code/game/area/prison_v3_fiorina.dm
+++ b/code/game/area/prison_v3_fiorina.dm
@@ -16,7 +16,7 @@
 	icon_state = "oob"
 	ceiling = CEILING_MAX
 	is_resin_allowed = FALSE
-	flags_area = AREA_NOTUNNEL
+	flags_area = AREA_NOTUNNEL|AREA_UNWEEDABLE
 
 /area/fiorina/maintenance
 	name = "Fiorina - Maintenance"

--- a/code/game/area/shiva.dm
+++ b/code/game/area/shiva.dm
@@ -48,12 +48,10 @@
 	ceiling = CEILING_MAX
 	icon_state = "oob"
 	is_resin_allowed = FALSE
-	flags_area = AREA_NOTUNNEL
+	flags_area = AREA_NOTUNNEL|AREA_UNWEEDABLE
 
 /area/shiva/interior/oob/dev_room
 	name = "Shiva's Snowball - Secret Room"
-	is_resin_allowed = FALSE
-	flags_area = AREA_NOTUNNEL
 	icon_state = "shiva"
 
 //telecomms areas - exterior

--- a/code/game/area/space_station_13_areas.dm
+++ b/code/game/area/space_station_13_areas.dm
@@ -24,8 +24,9 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	power_environ = FALSE
 	temperature = TCMB
 	pressure = 0
-	flags_area = AREA_NOTUNNEL
+	flags_area = AREA_NOTUNNEL|AREA_UNWEEDABLE
 	weather_enabled = FALSE
+	is_resin_allowed = FALSE
 
 	//fix for issue https://github.com/cmss13-devs/cmss13/issues/2191
 	base_muffle = AREA_MUTED

--- a/code/game/area/strata.dm
+++ b/code/game/area/strata.dm
@@ -41,7 +41,6 @@ EXTERIOR is FUCKING FREEZING, and refers to areas out in the open and or exposed
 /area/strata/ag
 	name = "Above Ground Area"
 	icon_state = "ag"
-	is_resin_allowed = TRUE
 
 /area/strata/ag/exterior
 	name = "Exterior Above Ground Area"
@@ -62,7 +61,6 @@ EXTERIOR is FUCKING FREEZING, and refers to areas out in the open and or exposed
 /area/strata/ug
 	name = "Under Ground Area"
 	icon_state = "ug"
-	is_resin_allowed = TRUE
 	ceiling = CEILING_UNDERGROUND_ALLOW_CAS
 
 /area/strata/ug/interior

--- a/code/game/area/strata.dm
+++ b/code/game/area/strata.dm
@@ -564,5 +564,5 @@ EXTERIOR is FUCKING FREEZING, and refers to areas out in the open and or exposed
 	name = "Super Secret Credits Room"
 	icon_state = "marshwater"
 	is_resin_allowed = FALSE
-	flags_area = AREA_NOTUNNEL
+	flags_area = AREA_NOTUNNEL|AREA_UNWEEDABLE
 

--- a/code/game/area/varadero.dm
+++ b/code/game/area/varadero.dm
@@ -85,14 +85,12 @@
 /area/varadero/exterior/lz1_console
 	name = "New Varadero - Pontoon Dock"
 	requires_power = FALSE
-	is_resin_allowed = FALSE
 	minimap_color = MINIMAP_AREA_LZ
 	is_landing_zone = TRUE
 
 /area/varadero/exterior/lz1_console/two
 	name = "New Varadero - Palm Airfield"
 	requires_power = FALSE
-	is_resin_allowed = FALSE
 	minimap_color = MINIMAP_AREA_LZ
 
 //exterior areas
@@ -146,7 +144,6 @@
 
 /area/varadero/exterior/farocean
 	name = "New Varadero - Far Ocean"
-	is_resin_allowed = FALSE
 	flags_area = AREA_NOTUNNEL
 	icon_state = "varadero3"
 	minimap_color = MINIMAP_AREA_CONTESTED_ZONE

--- a/code/game/area/varadero.dm
+++ b/code/game/area/varadero.dm
@@ -78,7 +78,7 @@
 	ceiling = CEILING_MAX
 	icon_state = "oob"
 	is_resin_allowed = FALSE
-	flags_area = AREA_NOTUNNEL
+	flags_area = AREA_NOTUNNEL|AREA_UNWEEDABLE
 
 //landing zone computers
 

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -766,6 +766,11 @@ INITIALIZE_IMMEDIATE(/turf/closed/wall/indestructible/splashscreen)
 	if(hivenumber == XENO_HIVE_NORMAL)
 		RegisterSignal(SSdcs, COMSIG_GLOB_GROUNDSIDE_FORSAKEN_HANDLING, PROC_REF(forsaken_handling))
 
+	if(!hull)
+		var/area/area = get_area(src)
+		if(area && area.linked_lz)
+			AddComponent(/datum/component/resin_cleanup)
+
 /turf/closed/wall/resin/proc/forsaken_handling()
 	SIGNAL_HANDLER
 	if(is_ground_level(z))

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -380,6 +380,10 @@
 	if(hivenumber == XENO_HIVE_NORMAL)
 		RegisterSignal(SSdcs, COMSIG_GLOB_GROUNDSIDE_FORSAKEN_HANDLING, PROC_REF(forsaken_handling))
 
+	var/area/area = get_area(src)
+	if(area && area.linked_lz)
+		AddComponent(/datum/component/resin_cleanup)
+
 /obj/structure/mineral_door/resin/flamer_fire_act(dam = BURN_LEVEL_TIER_1)
 	health -= dam
 	healthcheck()

--- a/code/modules/mob/living/carbon/xenomorph/Abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Abilities.dm
@@ -55,7 +55,7 @@
 	var/area/AR = get_area(T)
 
 	if(isnull(AR) || !(AR.is_resin_allowed))
-		if(AR?.flags_area & AREA_UNWEEDABLE)
+		if(!AR || AR.flags_area & AREA_UNWEEDABLE)
 			to_chat(X, SPAN_XENOWARNING("This area is unsuited to host the hive!"))
 			return
 		to_chat(X, SPAN_XENOWARNING("It's too early to spread the hive this far."))

--- a/code/modules/mob/living/carbon/xenomorph/Abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Abilities.dm
@@ -55,7 +55,7 @@
 	var/area/AR = get_area(T)
 
 	if(isnull(AR) || !(AR.is_resin_allowed))
-		if(AR.flags_area & AREA_UNWEEDABLE)
+		if(AR?.flags_area & AREA_UNWEEDABLE)
 			to_chat(X, SPAN_XENOWARNING("This area is unsuited to host the hive!"))
 			return
 		to_chat(X, SPAN_XENOWARNING("It's too early to spread the hive this far."))

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -52,7 +52,7 @@
 
 	var/area/area = get_area(turf)
 	if(isnull(area) || !(area.is_resin_allowed))
-		if(area.flags_area & AREA_UNWEEDABLE)
+		if(area?.flags_area & AREA_UNWEEDABLE)
 			to_chat(xeno, SPAN_XENOWARNING("This area is unsuited to host the hive!"))
 			return
 		to_chat(xeno, SPAN_XENOWARNING("It's too early to spread the hive this far."))
@@ -614,7 +614,7 @@
 
 	var/area/AR = get_area(T)
 	if(isnull(AR) || !(AR.is_resin_allowed))
-		if(AR.flags_area & AREA_UNWEEDABLE)
+		if(AR?.flags_area & AREA_UNWEEDABLE)
 			to_chat(X, SPAN_XENOWARNING("This area is unsuited to host the hive!"))
 			return
 		to_chat(X, SPAN_XENOWARNING("It's too early to spread the hive this far."))

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -52,7 +52,7 @@
 
 	var/area/area = get_area(turf)
 	if(isnull(area) || !(area.is_resin_allowed))
-		if(area?.flags_area & AREA_UNWEEDABLE)
+		if(!area || area.flags_area & AREA_UNWEEDABLE)
 			to_chat(xeno, SPAN_XENOWARNING("This area is unsuited to host the hive!"))
 			return
 		to_chat(xeno, SPAN_XENOWARNING("It's too early to spread the hive this far."))
@@ -614,7 +614,7 @@
 
 	var/area/AR = get_area(T)
 	if(isnull(AR) || !(AR.is_resin_allowed))
-		if(AR?.flags_area & AREA_UNWEEDABLE)
+		if(!AR || AR.flags_area & AREA_UNWEEDABLE)
 			to_chat(X, SPAN_XENOWARNING("This area is unsuited to host the hive!"))
 			return
 		to_chat(X, SPAN_XENOWARNING("It's too early to spread the hive this far."))

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -673,7 +673,7 @@
 
 	var/area/AR = get_area(T)
 	if(isnull(AR) || !AR.is_resin_allowed)
-		if(AR?.flags_area & AREA_UNWEEDABLE)
+		if(!AR || AR.flags_area & AREA_UNWEEDABLE)
 			to_chat(X, SPAN_XENOWARNING("This area is unsuited to host the hive!"))
 			return
 		to_chat(X, SPAN_XENOWARNING("It's too early to spread the hive this far."))

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -672,7 +672,7 @@
 		return
 
 	var/area/AR = get_area(T)
-	if(!AR.is_resin_allowed)
+	if(isnull(AR) || !AR.is_resin_allowed)
 		if(AR.flags_area & AREA_UNWEEDABLE)
 			to_chat(X, SPAN_XENOWARNING("This area is unsuited to host the hive!"))
 			return

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -673,7 +673,7 @@
 
 	var/area/AR = get_area(T)
 	if(isnull(AR) || !AR.is_resin_allowed)
-		if(AR.flags_area & AREA_UNWEEDABLE)
+		if(AR?.flags_area & AREA_UNWEEDABLE)
 			to_chat(X, SPAN_XENOWARNING("This area is unsuited to host the hive!"))
 			return
 		to_chat(X, SPAN_XENOWARNING("It's too early to spread the hive this far."))

--- a/code/modules/mob/living/carbon/xenomorph/resin_constructions.dm
+++ b/code/modules/mob/living/carbon/xenomorph/resin_constructions.dm
@@ -31,7 +31,7 @@ GLOBAL_VAR_INIT(resin_lz_allowed, FALSE)
 
 	var/area/AR = get_area(T)
 	if(isnull(AR) || !(AR.is_resin_allowed))
-		if(AR.flags_area & AREA_UNWEEDABLE)
+		if(AR?.flags_area & AREA_UNWEEDABLE)
 			to_chat(X, SPAN_XENOWARNING("This area is unsuited to host the hive!"))
 			return
 		to_chat(X, SPAN_XENOWARNING("It's too early to spread the hive this far."))

--- a/code/modules/mob/living/carbon/xenomorph/resin_constructions.dm
+++ b/code/modules/mob/living/carbon/xenomorph/resin_constructions.dm
@@ -31,7 +31,7 @@ GLOBAL_VAR_INIT(resin_lz_allowed, FALSE)
 
 	var/area/AR = get_area(T)
 	if(isnull(AR) || !(AR.is_resin_allowed))
-		if(AR?.flags_area & AREA_UNWEEDABLE)
+		if(!AR || AR.flags_area & AREA_UNWEEDABLE)
 			to_chat(X, SPAN_XENOWARNING("This area is unsuited to host the hive!"))
 			return
 		to_chat(X, SPAN_XENOWARNING("It's too early to spread the hive this far."))


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #7363 #7556 and #7535 which have been changing where xenos are allowed to weed. This should be the final update to allow xenos weeding capabilities anywhere but OOB and the AI Core (atleast until marines land then there is a temporary restriction).

Also fixes an oversight where resin walls and doors were not getting weed killed.

# Explain why it's good for the game

Fixes #7583

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/0qA55ZizGoE

Weed killer on structures:
![example](https://github.com/user-attachments/assets/fe56de81-8381-45b1-93e1-6d06612cde5c)

</details>

# Changelog
:cl: Drathek
code: Added sanity checks for whenever AREA_UNWEEDABLE is used or when an area is somehow null
balance: All maps have their round start is_resin_allowed restriction lifted unless out of bounds
maptweak: All maps with OOB areas have now AREA_UNWEEDABLE set to make the restriction permanent
fix: Resin walls and doors will now properly get weed killed
/:cl:
