### PR TITLE
Update donator example config & Refactoring

### DIFF
--- a/code/modules/cm_marines/custom_items.dm
+++ b/code/modules/cm_marines/custom_items.dm
@@ -38,7 +38,7 @@ GLOBAL_LIST_EMPTY(donator_items)
 
 		var/split_line = splittext(current_line, ":")
 
-		donor_key = trim(split_line[1])
+		donor_key = ckey(trim(split_line[1]))
 		if(length(split_line) > 2) //if someone has multiple kits, name them
 			kit_name = trim(split_line[2])
 

--- a/code/modules/cm_marines/custom_items.dm
+++ b/code/modules/cm_marines/custom_items.dm
@@ -1,11 +1,11 @@
-GLOBAL_LIST_FILE_LOAD(custom_items, "config/custom_items.txt")
 GLOBAL_LIST_INIT(donator_items, generate_donor_kits(FALSE))
-GLOBAL_LIST_INIT(random_personal_possessions, generate_random_possessions(FALSE))
+GLOBAL_LIST_INIT(random_personal_possessions, generate_random_possessions())
 
 /proc/generate_donor_kits(assign_to_glob = TRUE)
 	. = list()
 
-	for(var/current_line in GLOB.custom_items)
+	var/list/custom_items = file2list("config/custom_items.txt")
+	for(var/current_line in custom_items)
 		if(!length(current_line)) //empty line
 			continue
 		if(copytext(current_line, 1, 2) == "#") //comment line
@@ -43,16 +43,13 @@ GLOBAL_LIST_INIT(random_personal_possessions, generate_random_possessions(FALSE)
 
 	return .
 
-/proc/generate_random_possessions(assign_to_glob = TRUE)
+/proc/generate_random_possessions()
 	. = list()
 
 	for(var/datum/gear/current_gear as anything in subtypesof(/datum/gear))
 		if(!initial(current_gear.display_name))
 			continue
 		. += initial(current_gear.path)
-
-	if(assign_to_glob)
-		GLOB.random_personal_possessions = .
 
 	return .
 

--- a/config/example/custom_items.txt
+++ b/config/example/custom_items.txt
@@ -1,1 +1,9 @@
-ckey: name: /path/to/obj
+# Ckey: Variant: Typepath, Typepath, ...
+# Variant is used if there are multiple kits for one ckey
+# Multiple typepaths can be used to make a kit with multiple items
+
+# For example...
+# CKEY: /obj/item/toy/plush/random_plushie
+# CKEY2: /obj/item/toy/plush/farwa, /obj/item/toy/plush/shark
+# CKEY3: Kit1: /obj/item/toy/plush/moth
+# CKEY3: Kit2: /obj/item/toy/plush/therapy/red, /obj/item/reagent_container/food/drinks/cans/waterbottle


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #7306 updating the example config, makes the ckey entry in the config a bit more resilient to stuff like case sensitivity by using the [ckey proc](https://www.byond.com/docs/ref/#/proc/ckey), and refactors the two master lists to GLOBs that automatically initialize. Also makes it possible to reload the custom_items config at runtime via advanced proc call.

# Explain why it's good for the game

More flexible config, and an accurate example.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/916effc5-7c92-4fa4-acdb-2faa25e98cf6)
![image](https://github.com/user-attachments/assets/df9eb536-89fc-411c-bd14-b9c03948064b)

</details>


# Changelog
:cl:
code: Refactored donator lists to GLOBs that automatically initialize and made ckeys in custom_items.txt more flexible
config: Updated example config for custom_items.txt
/:cl:
