### PR TITLE
Fix box cramming under platforms

### DIFF
--- a/code/modules/projectiles/ammo_boxes/ammo_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/ammo_boxes.dm
@@ -167,6 +167,13 @@
 			to_chat(user, SPAN_WARNING("You can't cram any more boxes in here!"))
 			return
 
+	// Make sure a platform wouldn't block it
+	if(box_on_tile * 2 >= limit_per_tile) // Allow 2 if limit is 4
+		var/obj/structure/platform/platform = locate() in T
+		if(platform?.dir == NORTH)
+			to_chat(user, SPAN_WARNING("You can't cram any more boxes in here!"))
+			return
+
 	var/obj/structure/magazine_box/M = new /obj/structure/magazine_box(T)
 	M.icon_state = icon_state_deployed ? icon_state_deployed : icon_state
 	M.name = name


### PR DESCRIPTION
# About the pull request

This PR fixes ammo boxes getting crammed under north facing platforms. If there are other scenarios where box cramming would place the box under something let me know and I can see about preventing that too.

# Explain why it's good for the game

It is difficult to interact or even see an ammo box if it gets placed under a platform. The best you can do is alt+click the tile to interact with it.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/cLMYTBpOGI0

</details>


# Changelog
:cl: Drathek
fix: Fixed ammo boxes allowing cramming under north facing platforms
/:cl:
