### PR TITLE
Fix corrupted not getting English/Common

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -347,11 +347,11 @@
 	var/cannot_slash = FALSE
 
 /mob/living/carbon/xenomorph/Initialize(mapload, mob/living/carbon/xenomorph/old_xeno, hivenumber)
-
 	if(old_xeno && old_xeno.hivenumber)
 		src.hivenumber = old_xeno.hivenumber
 	else if(hivenumber)
 		src.hivenumber = hivenumber
+
 	//putting the organ in for research
 	if(organ_value != 0)
 		var/obj/item/organ/xeno/organ = new() //give
@@ -360,15 +360,14 @@
 		organ.caste_origin = caste_type
 		organ.icon_state = get_organ_icon()
 
-	var/datum/hive_status/hive = GLOB.hive_datum[src.hivenumber]
+	set_languages(list(LANGUAGE_XENOMORPH, LANGUAGE_HIVEMIND)) // The hive may alter this list
 
+	var/datum/hive_status/hive = GLOB.hive_datum[src.hivenumber]
 	if(hive)
 		hive.add_xeno(src)
 
 	wound_icon_holder = new(null, src)
 	vis_contents += wound_icon_holder
-
-	set_languages(list(LANGUAGE_XENOMORPH, LANGUAGE_HIVEMIND))
 
 	///Handle transferring things from the old Xeno if we have one in the case of evolve, devolve etc.
 	if(old_xeno)


### PR DESCRIPTION
# About the pull request

This PR fixes an oversight with language modification where corrupted were getting English prior to their initial language list (so would then undo the English addition).

# Explain why it's good for the game

Fixes #5783 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![example](https://github.com/user-attachments/assets/094faa77-76bb-4cf8-acd9-4ef44967c94e)

</details>


# Changelog
:cl: Drathek
fix: Fixed corrupted xenos not getting the English language
/:cl:
