### PR TITLE
Xenos no longer have capped damage

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -514,6 +514,16 @@ Make sure their actual health updates immediately.*/
 		set_stat(UNCONSCIOUS)
 		SEND_SIGNAL(src, COMSIG_XENO_ENTER_CRIT)
 
+/mob/living/carbon/xenomorph/adjustBruteLoss(amount)
+	if(status_flags & GODMODE)
+		return //godmode
+	bruteloss = max(bruteloss + amount, 0)
+
+/mob/living/carbon/xenomorph/adjustFireLoss(amount)
+	if(status_flags & GODMODE)
+		return //godmode
+	fireloss = max(fireloss + amount, 0)
+
 /mob/living/carbon/xenomorph/set_stat(new_stat)
 	. = ..()
 	// Temporarily force triggering HUD updates so they apply immediately rather than on Life tick.


### PR DESCRIPTION

# About the pull request

This PR fixes an oversight where `/mob/living/proc/adjustBruteLoss` and `/mob/living/proc/adjustFireLoss` caps brute/fire damage at 2x max health, but warding changes their effective max health resulting in edge cases where the xenomorph is immortal (though forever in crit). Now xenos do not cap their brute or fire damage.

# Explain why it's good for the game

Fixes #7082 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/I2h1qd5sN8I

</details>


# Changelog
:cl: Drathek
fix: Fixed xenos sometimes becoming immortal with warding pheros (xenos do not cap brute/fire damage now)
/:cl:
