### PR TITLE
Bump orphan egg time from 5 mins to 6 mins

### DIFF
--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -444,7 +444,7 @@ SPECIAL EGG USED BY EGG CARRIER
 SPECIAL EGG USED WHEN WEEDS LOST
 */
 
-#define ORPHAN_EGG_MAXIMUM_LIFE 6 MINUTES
+#define ORPHAN_EGG_MAXIMUM_LIFE 6 MINUTES // Should be longer than HIVECORE_COOLDOWN
 
 /obj/effect/alien/egg/carrier_egg/orphan/Initialize(mapload, hivenumber, weed_strength_required)
 	src.weed_strength_required = weed_strength_required

--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -444,6 +444,8 @@ SPECIAL EGG USED BY EGG CARRIER
 SPECIAL EGG USED WHEN WEEDS LOST
 */
 
+#define ORPHAN_EGG_MAXIMUM_LIFE 6 MINUTES
+
 /obj/effect/alien/egg/carrier_egg/orphan/Initialize(mapload, hivenumber, weed_strength_required)
 	src.weed_strength_required = weed_strength_required
 
@@ -453,7 +455,7 @@ SPECIAL EGG USED WHEN WEEDS LOST
 		return .
 
 	if(hivenumber != XENO_HIVE_FORSAKEN)
-		life_timer = addtimer(CALLBACK(src, PROC_REF(start_unstoppable_decay)), CARRIER_EGG_MAXIMUM_LIFE, TIMER_STOPPABLE)
+		life_timer = addtimer(CALLBACK(src, PROC_REF(start_unstoppable_decay)), ORPHAN_EGG_MAXIMUM_LIFE, TIMER_STOPPABLE)
 
 	var/my_turf = get_turf(src)
 	if(my_turf)


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #7554 bumping the timer from 6 mins (from 5 mins) since the hive core reconstruction time (`HIVECORE_COOLDOWN`) is 5 mins (to allow 1 minute window to restore a hive w/o all eggs popping).

# Explain why it's good for the game

Should xenos manage to hold their original hive location to rebuild a hive core, this should make it possible to recover most eggs planted there.

# Changelog
:cl: Drathek
balance: Increased orphan egg time from 5 mins to 6 mins.
/:cl:
