### PR TITLE
Xeno ammo no longer pushes items

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1205,7 +1205,7 @@
 
 /obj/item/bullet_act(obj/projectile/P)
 	bullet_ping(P)
-	if(P.ammo.damage_type == BRUTE)
+	if(P.ammo.damage_type == BRUTE && !(P.ammo.flags_ammo_behavior & AMMO_XENO))
 		explosion_throw(P.damage/2, P.dir, 4)
 	return TRUE
 


### PR DESCRIPTION

# About the pull request

This PR makes it so XENO_AMMO that is brute type no longer pushes items (namely Oppressor Tail Seize). There may be other ways items are pushed/pulled, but this is all I could find.

# Explain why it's good for the game

Behaviors like pushing weapons around to hide them need to be discouraged.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
balance: Xeno ammo can no longer push items (e.g. Oppressor Tail Seize)
/:cl:
