### PR TITLE
Fixes staff access to Fax Responder

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -886,6 +886,9 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 	if((flag_to_check & WHITELIST_JOE) && CLIENT_IS_STAFF(src))
 		return TRUE
 
+	if((flag_to_check & WHITELIST_FAX_RESPONDER) && CLIENT_IS_STAFF(src))
+		return TRUE
+
 	if(!player_data)
 		load_player_data()
 	if(!player_data)


### PR DESCRIPTION

# About the pull request

As title

# Explain why it's good for the game

Staff can already do it manually. Just an oversight.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Staff can properly access Fax Responder WL.
/:cl:
