### PR TITLE
Fix Missing Null UPP Synth Vendor

### DIFF
--- a/code/game/machinery/vending/vendor_types/antag/antag_clothing.dm
+++ b/code/game/machinery/vending/vendor_types/antag/antag_clothing.dm
@@ -250,8 +250,8 @@ GLOBAL_LIST_INIT(cm_vending_clothing_synth_upp, list(
 	list("Grey Vest", 12, /obj/item/clothing/suit/storage/jacket/marine/vest/grey, null, VENDOR_ITEM_REGULAR),
 
 	list("BACKPACK", 0, null, null, null),
-	list("Combat Pack", 12, /obj/item/storage/backpack/lightpack/upp, VENDOR_ITEM_REGULAR),
-	list("UPP Sapper Welderpack", 12, /obj/item/storage/backpack/marine/engineerpack/upp, VENDOR_ITEM_REGULAR),
+	list("Combat Pack", 12, /obj/item/storage/backpack/lightpack/upp, null, VENDOR_ITEM_REGULAR),
+	list("UPP Sapper Welderpack", 12, /obj/item/storage/backpack/marine/engineerpack/upp, null, VENDOR_ITEM_REGULAR),
 	list("Satchel, Leather", 12, /obj/item/storage/backpack/satchel, null, VENDOR_ITEM_REGULAR),
 	list("Satchel, Medical", 12, /obj/item/storage/backpack/satchel/med, null, VENDOR_ITEM_REGULAR),
 


### PR DESCRIPTION

# About the pull request

Fixes a missing null on the Synth Snowflake Vendor. 

# Explain why it's good for the game

Bug fix


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fix bug on UPP Synth Snowflake Vendor that prevented some items being vended. 
/:cl:
