### PR TITLE
reinforces the pipes in evac, again

### DIFF
--- a/code/game/objects/structures/pipes/standard/manifolds.dm
+++ b/code/game/objects/structures/pipes/standard/manifolds.dm
@@ -107,6 +107,7 @@
 /obj/structure/pipes/standard/manifold/hidden/supply/no_boom
 	name = "Reinforced Air supply pipe manifold"
 	explodey = FALSE
+	color = PIPE_COLOR_PURPLE
 
 /obj/structure/pipes/standard/manifold/hidden/yellow
 	color = PIPE_COLOR_YELLOW
@@ -189,6 +190,7 @@
 /obj/structure/pipes/standard/manifold/fourway/hidden/supply/no_boom
 	name = "reinforced 4-way air supply pipe manifold"
 	explodey = FALSE
+	color = PIPE_COLOR_PURPLE
 
 /obj/structure/pipes/standard/manifold/fourway/hidden/yellow
 	color = PIPE_COLOR_YELLOW

--- a/code/game/objects/structures/pipes/standard/simple.dm
+++ b/code/game/objects/structures/pipes/standard/simple.dm
@@ -107,6 +107,7 @@
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom
 	name = "Reinforced Air supply pipe"
 	explodey = FALSE
+	color = PIPE_COLOR_PURPLE
 
 /obj/structure/pipes/standard/simple/hidden/yellow
 	color = PIPE_COLOR_YELLOW

--- a/code/game/objects/structures/pipes/standard/standard_misc.dm
+++ b/code/game/objects/structures/pipes/standard/standard_misc.dm
@@ -110,6 +110,7 @@
 /obj/structure/pipes/standard/cap/hidden/supply/no_boom
 	name = "reinforced supply pipe endcap"
 	explodey = FALSE
+	color = PIPE_COLOR_PURPLE
 
 
 /obj/structure/pipes/standard/tank

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -33,6 +33,18 @@
 "aah" = (
 /turf/open/floor/almayer_hull/outerhull_dir/east,
 /area/space)
+"aai" = (
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/almayer/engineering/upper_engineering/port)
+"aaj" = (
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/engineering/upper_engineering/port)
 "aak" = (
 /obj/effect/step_trigger/teleporter/random{
 	affect_ghosts = 1;
@@ -46,6 +58,12 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"aal" = (
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/almayer/command/lifeboat)
 "aam" = (
 /obj/structure/stairs,
 /obj/effect/step_trigger/teleporter_vector{
@@ -55,6 +73,20 @@
 	},
 /turf/open/floor/plating/almayer/no_build,
 /area/almayer/stair_clone/upper)
+"aan" = (
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom,
+/turf/open/floor/almayer,
+/area/almayer/command/lifeboat)
+"aao" = (
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/command/lifeboat)
+"aap" = (
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/almayer/engineering/upper_engineering/starboard)
 "aaq" = (
 /obj/item/bedsheet/purple{
 	layer = 3.2
@@ -93,6 +125,12 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/living/port_emb)
+"aar" = (
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/engineering/upper_engineering/starboard)
 "aau" = (
 /turf/closed/wall/almayer/reinforced/temphull,
 /area/almayer/living/pilotbunks)
@@ -11345,7 +11383,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/hallways/upper/starboard)
 "bGc" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 4
 	},
 /turf/open/floor/almayer/red/west,
@@ -15892,7 +15930,7 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/shipboard/weapon_room)
 "cFn" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
+/obj/structure/pipes/standard/manifold/hidden/supply/no_boom{
 	dir = 8
 	},
 /turf/open/floor/almayer/red,
@@ -16235,7 +16273,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/upper/u_a_s)
 "cMN" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 4
 	},
 /turf/open/floor/almayer/orange/west,
@@ -16811,7 +16849,7 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/s_bow)
 "cYu" = (
-/obj/structure/pipes/vents/pump{
+/obj/structure/pipes/vents/pump/no_boom{
 	dir = 1
 	},
 /turf/open/floor/almayer/plate,
@@ -17148,12 +17186,12 @@
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_22"
 	},
-/obj/structure/pipes/vents/pump{
-	dir = 1
-	},
 /obj/item/tool/mop{
 	pixel_x = -6;
 	pixel_y = 24
+	},
+/obj/structure/pipes/vents/pump/no_boom{
+	dir = 1
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/upper_engineering/starboard)
@@ -17884,7 +17922,7 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/lower/port_fore_hallway)
 "dxK" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
+/obj/structure/pipes/standard/manifold/hidden/supply/no_boom{
 	dir = 8
 	},
 /turf/open/floor/almayer/red/north,
@@ -18774,7 +18812,7 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/lower/starboard_umbilical)
 "dPm" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 4
 	},
 /turf/open/floor/almayer/plate,
@@ -18788,7 +18826,7 @@
 /turf/open/floor/plating,
 /area/almayer/maint/lower/constr)
 "dPC" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 9
 	},
 /turf/open/floor/plating/plating_catwalk,
@@ -20597,7 +20635,7 @@
 /turf/open/floor/almayer/orangecorner/west,
 /area/almayer/engineering/lower/engine_core)
 "eAL" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom,
 /turf/open/floor/almayer/red/north,
 /area/almayer/command/lifeboat)
 "eAN" = (
@@ -21701,7 +21739,7 @@
 /turf/open/floor/almayer,
 /area/almayer/living/synthcloset)
 "eYR" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 5
 	},
 /turf/open/floor/almayer/orangecorner/east,
@@ -22956,7 +22994,7 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/u_m_p)
 "fCp" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 5
 	},
 /turf/open/floor/plating/plating_catwalk,
@@ -24493,7 +24531,7 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/shipboard/starboard_point_defense)
 "gms" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom,
 /turf/open/floor/almayer/orange/southeast,
 /area/almayer/engineering/upper_engineering/port)
 "gnu" = (
@@ -26306,7 +26344,7 @@
 /turf/open/floor/almayer/red/east,
 /area/almayer/hallways/lower/port_fore_hallway)
 "had" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom,
 /turf/open/floor/almayer/red,
 /area/almayer/command/lifeboat)
 "hal" = (
@@ -28350,7 +28388,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/medical/upper_medical)
 "hSt" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 4
 	},
 /turf/open/floor/almayer/orange/west,
@@ -30265,7 +30303,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/engineering/port_atmos)
 "iKZ" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 4
 	},
 /turf/open/floor/almayer/orange/east,
@@ -30431,7 +30469,7 @@
 /turf/open/floor/almayer/silver/southwest,
 /area/almayer/living/briefing)
 "iPD" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
+/obj/structure/pipes/standard/manifold/hidden/supply/no_boom{
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
@@ -30818,10 +30856,10 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/u_a_s)
 "iUW" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/item/tool/crowbar/red,
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 4
 	},
-/obj/item/tool/crowbar/red,
 /turf/open/floor/almayer/orange/west,
 /area/almayer/engineering/upper_engineering/starboard)
 "iUX" = (
@@ -32512,7 +32550,7 @@
 /turf/open/floor/almayer/green/east,
 /area/almayer/squads/req)
 "jAJ" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 4
 	},
 /turf/open/floor/almayer/test_floor4,
@@ -33176,7 +33214,7 @@
 /turf/closed/wall/almayer/outer,
 /area/space)
 "jRC" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 10
 	},
 /turf/open/floor/almayer/orange/east,
@@ -35253,13 +35291,13 @@
 /turf/open/floor/almayer/red/west,
 /area/almayer/shipboard/brig/starboard_hallway)
 "kHS" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 4
 	},
 /turf/open/floor/almayer/orange/east,
 /area/almayer/engineering/upper_engineering/port)
 "kHY" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 10
 	},
 /turf/open/floor/almayer/orange/north,
@@ -35488,7 +35526,7 @@
 /turf/open/floor/almayer/plating/northeast,
 /area/almayer/shipboard/panic)
 "kNk" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 4
 	},
 /turf/open/floor/plating/almayer,
@@ -36191,7 +36229,7 @@
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cells)
 "lbB" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 4
 	},
 /turf/open/floor/almayer/orange/north,
@@ -37120,7 +37158,7 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/living/grunt_rnr)
 "luY" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom,
 /turf/open/floor/almayer/orange/east,
 /area/almayer/engineering/upper_engineering/starboard)
 "luZ" = (
@@ -38669,7 +38707,7 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/living/briefing)
 "mhG" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 10
 	},
 /turf/open/floor/plating/plating_catwalk,
@@ -40944,7 +40982,7 @@
 /turf/open/floor/almayer/red,
 /area/almayer/shipboard/brig/lobby)
 "ncp" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 9
 	},
 /turf/open/floor/almayer/orange/southeast,
@@ -41189,10 +41227,10 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/hallways/lower/repair_bay)
 "ngU" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/effect/decal/cleanable/blood/oil/streak,
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/blood/oil/streak,
 /turf/open/floor/almayer,
 /area/almayer/engineering/upper_engineering/starboard)
 "nhi" = (
@@ -41418,7 +41456,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_f_s)
 "nkn" = (
-/obj/structure/pipes/vents/pump{
+/obj/structure/pipes/vents/pump/no_boom{
 	dir = 8
 	},
 /turf/open/floor/almayer,
@@ -41501,8 +41539,8 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/upper/u_f_s)
 "nlW" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/largecrate/random/barrel/green,
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom,
 /turf/open/floor/almayer/orange/northeast,
 /area/almayer/engineering/upper_engineering/starboard)
 "nme" = (
@@ -43493,7 +43531,7 @@
 /turf/open/floor/almayer/cargo,
 /area/almayer/hallways/lower/vehiclehangar)
 "odu" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 4
 	},
 /turf/open/floor/almayer/red/southeast,
@@ -43523,7 +43561,7 @@
 /turf/open/floor/plating,
 /area/almayer/shipboard/sea_office)
 "odV" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 4
 	},
 /turf/open/floor/almayer/red/northeast,
@@ -43574,13 +43612,13 @@
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/shipboard/brig/medical)
 "ofH" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
+/obj/structure/pipes/standard/manifold/hidden/supply/no_boom{
 	dir = 1
 	},
 /turf/open/floor/almayer/orange/east,
 /area/almayer/engineering/upper_engineering/port)
 "ofK" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 4
 	},
 /turf/open/floor/almayer/orange,
@@ -43750,10 +43788,10 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/maint/hull/upper/u_m_p)
 "oir" = (
-/obj/structure/pipes/vents/pump{
+/obj/structure/machinery/power/apc/almayer/hardened/east,
+/obj/structure/pipes/vents/pump/no_boom{
 	dir = 8
 	},
-/obj/structure/machinery/power/apc/almayer/hardened/east,
 /turf/open/floor/almayer,
 /area/almayer/command/lifeboat)
 "oit" = (
@@ -45416,7 +45454,7 @@
 /turf/open/floor/almayer/red/west,
 /area/almayer/hallways/upper/aft_hallway)
 "oPf" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
+/obj/structure/pipes/standard/manifold/hidden/supply/no_boom{
 	dir = 8
 	},
 /turf/open/floor/plating/plating_catwalk,
@@ -46117,9 +46155,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/upper/fore_hallway)
 "pcv" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 1
-	},
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom,
 /turf/open/floor/almayer/orange/east,
 /area/almayer/engineering/upper_engineering/port)
 "pcE" = (
@@ -46199,7 +46235,7 @@
 /obj/structure/machinery/door/airlock/multi_tile/almayer/engidoor{
 	dir = 1
 	},
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 4
 	},
 /turf/open/floor/almayer/test_floor4,
@@ -47082,7 +47118,7 @@
 /turf/open/floor/almayer/plating/northeast,
 /area/almayer/shipboard/starboard_point_defense)
 "pzJ" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom,
 /turf/open/floor/almayer/plate,
 /area/almayer/command/lifeboat)
 "pzM" = (
@@ -48404,7 +48440,6 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/command/lifeboat)
 "qeK" = (
-/obj/structure/pipes/vents/scrubber,
 /obj/structure/surface/table/reinforced/black,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/stack/cable_coil{
@@ -48415,6 +48450,7 @@
 	pixel_x = 8;
 	pixel_y = 13
 	},
+/obj/structure/pipes/vents/scrubber/no_boom,
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/upper_engineering/port)
 "qeY" = (
@@ -48673,7 +48709,7 @@
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/lower_medical_lobby)
 "qjV" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 9
 	},
 /turf/open/floor/almayer/orange,
@@ -49686,7 +49722,7 @@
 	name = "\improper Lifeboat Control Bubble";
 	req_access = null
 	},
-/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom,
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/command/lifeboat)
 "qDB" = (
@@ -50700,7 +50736,7 @@
 /turf/open/floor/plating/almayer/no_build,
 /area/almayer/stair_clone/upper)
 "qYu" = (
-/obj/structure/pipes/vents/pump,
+/obj/structure/pipes/vents/pump/no_boom,
 /turf/open/floor/almayer/plate,
 /area/almayer/command/lifeboat)
 "qYz" = (
@@ -51396,7 +51432,7 @@
 /turf/open/floor/almayer/sterile_green_side/east,
 /area/almayer/medical/medical_science)
 "rmf" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 6
 	},
 /turf/open/floor/almayer/orangecorner,
@@ -52066,7 +52102,7 @@
 /turf/open/floor/almayer/cargo,
 /area/almayer/squads/alpha)
 "rAP" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom,
 /turf/open/floor/almayer/orange/northeast,
 /area/almayer/engineering/upper_engineering/starboard)
 "rAS" = (
@@ -52144,7 +52180,7 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 10
 	},
 /turf/open/floor/almayer/orange/east,
@@ -52162,7 +52198,7 @@
 /turf/open/floor/plating,
 /area/almayer/maint/upper/u_m_s)
 "rDb" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 6
 	},
 /turf/open/floor/plating/plating_catwalk,
@@ -54116,10 +54152,10 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/lower)
 "spK" = (
-/obj/structure/pipes/vents/scrubber{
+/obj/structure/largecrate/random/secure,
+/obj/structure/pipes/vents/scrubber/no_boom{
 	dir = 1
 	},
-/obj/structure/largecrate/random/secure,
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/upper_engineering/starboard)
 "spS" = (
@@ -54250,7 +54286,7 @@
 /turf/open/floor/almayer/redfull,
 /area/almayer/command/cic)
 "ssX" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 6
 	},
 /turf/open/floor/plating/plating_catwalk,
@@ -54350,7 +54386,7 @@
 /turf/open/floor/almayer,
 /area/almayer/command/lifeboat)
 "svl" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
+/obj/structure/pipes/standard/manifold/hidden/supply/no_boom{
 	dir = 1
 	},
 /turf/open/floor/almayer/plate,
@@ -55281,7 +55317,7 @@
 /turf/open/floor/almayer/red,
 /area/almayer/shipboard/port_missiles)
 "sQO" = (
-/obj/structure/pipes/standard/manifold/hidden/supply,
+/obj/structure/pipes/standard/manifold/hidden/supply/no_boom,
 /turf/open/floor/almayer/plate,
 /area/almayer/command/lifeboat)
 "sRZ" = (
@@ -56029,7 +56065,7 @@
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/warden_office)
 "tgK" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 4
 	},
 /turf/open/floor/almayer/orange/northwest,
@@ -58558,7 +58594,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
 "uhM" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 5
 	},
 /turf/open/floor/plating/plating_catwalk,
@@ -60494,7 +60530,7 @@
 /turf/open/floor/almayer,
 /area/almayer/engineering/lower/workshop)
 "uZH" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 9
 	},
 /turf/open/floor/almayer/orange/east,
@@ -61471,7 +61507,7 @@
 /turf/open/floor/almayer,
 /area/almayer/squads/charlie_delta_shared)
 "vqK" = (
-/obj/structure/pipes/standard/manifold/hidden/supply,
+/obj/structure/pipes/standard/manifold/hidden/supply/no_boom,
 /turf/open/floor/almayer/orange/east,
 /area/almayer/engineering/upper_engineering/starboard)
 "vqL" = (
@@ -66069,7 +66105,7 @@
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/perma)
 "wZX" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
@@ -68066,7 +68102,7 @@
 /turf/open/floor/almayer/orange/north,
 /area/almayer/engineering/lower/workshop/hangar)
 "xPZ" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
 	dir = 10
 	},
 /turf/open/floor/almayer/orange/northeast,
@@ -68716,11 +68752,9 @@
 /turf/open/floor/almayer/blue/north,
 /area/almayer/squads/delta)
 "ydh" = (
-/obj/structure/pipes/vents/pump{
-	dir = 1
-	},
 /obj/structure/surface/table/reinforced/black,
 /obj/item/tank/oxygen,
+/obj/structure/pipes/vents/pump/no_boom,
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/upper_engineering/port)
 "ydz" = (
@@ -119277,7 +119311,7 @@ fLl
 fLl
 eky
 eky
-aNl
+aal
 eky
 uNV
 aHe
@@ -119287,7 +119321,7 @@ aDQ
 aHe
 uNV
 eky
-aNl
+aal
 eky
 rqj
 eZm
@@ -120295,11 +120329,11 @@ aMT
 svl
 pzJ
 qDt
-uYg
-vsh
+aan
+aao
 oPf
-vsh
-uYg
+aao
+aan
 qDt
 pzJ
 sQO
@@ -120481,7 +120515,7 @@ bdH
 bdH
 uMc
 bNM
-rtd
+aap
 ptQ
 aqZ
 aqZ
@@ -120519,7 +120553,7 @@ ksw
 ksw
 ksw
 hbp
-uWV
+aai
 uIv
 pql
 bdH
@@ -121497,7 +121531,7 @@ bdH
 aad
 cuC
 mkH
-rtd
+aap
 fcP
 cuC
 ajZ
@@ -121533,7 +121567,7 @@ xVk
 aad
 bYn
 kcA
-uWV
+aai
 uIv
 bYn
 ajZ
@@ -121736,7 +121770,7 @@ xVk
 aad
 bYn
 thV
-uWV
+aai
 uIv
 bYn
 ajZ
@@ -121903,7 +121937,7 @@ bdH
 aad
 uMc
 gbs
-iEr
+aar
 hFw
 uMc
 ajZ
@@ -121939,7 +121973,7 @@ xVk
 aad
 pql
 thV
-fCL
+aaj
 uIv
 pql
 ajZ
@@ -122106,7 +122140,7 @@ bdH
 aad
 uMc
 nrO
-iEr
+aar
 fcP
 uMc
 ajZ
@@ -122142,7 +122176,7 @@ xVk
 aad
 pql
 thV
-fCL
+aaj
 uIv
 pql
 ajZ
@@ -122309,7 +122343,7 @@ bdH
 aad
 uMc
 aVC
-iEr
+aar
 fcP
 uMc
 ajZ
@@ -122327,7 +122361,7 @@ uRs
 aDO
 qqu
 eky
-aNl
+aal
 eky
 dFk
 aDO
@@ -122345,7 +122379,7 @@ xVk
 aad
 pql
 thV
-fCL
+aaj
 uIv
 pql
 ajZ
@@ -122512,7 +122546,7 @@ bdH
 aad
 cuC
 mJx
-rtd
+aap
 odb
 cuC
 ajZ
@@ -122530,7 +122564,7 @@ dID
 eky
 eky
 nJu
-aNl
+aal
 eky
 eky
 eky
@@ -122548,7 +122582,7 @@ xVk
 aad
 bYn
 thV
-uWV
+aai
 oCf
 bYn
 ajZ
@@ -122715,7 +122749,7 @@ bdH
 cuC
 cuC
 dqg
-rtd
+aap
 fcP
 cuC
 cOK
@@ -122733,7 +122767,7 @@ mRQ
 eky
 eky
 eky
-aNl
+aal
 eky
 eky
 eky
@@ -122751,7 +122785,7 @@ xVk
 wZv
 bYn
 thV
-uWV
+aai
 uIv
 bYn
 bYn
@@ -122936,7 +122970,7 @@ aDO
 atK
 eky
 eky
-aNl
+aal
 eky
 eky
 atM
@@ -123121,7 +123155,7 @@ aaa
 uMc
 cIG
 vqD
-iEr
+aar
 fcP
 blJ
 jcP
@@ -123138,9 +123172,9 @@ avu
 arV
 aMU
 ssX
-vsh
+aao
 iPD
-vsh
+aao
 fCp
 avu
 arV
@@ -123157,7 +123191,7 @@ xVk
 dbq
 gIJ
 thV
-fCL
+aaj
 lne
 wEI
 pql
@@ -123527,7 +123561,7 @@ aaa
 cuC
 ptK
 bSD
-iEr
+aar
 xKM
 cuC
 uiR
@@ -123563,7 +123597,7 @@ xVk
 kMK
 bYn
 gEv
-fCL
+aaj
 lol
 jWh
 bYn
@@ -123730,7 +123764,7 @@ aaa
 cuC
 ptK
 new
-iEr
+aar
 paI
 cuC
 cOK
@@ -123766,7 +123800,7 @@ xVk
 wZv
 bYn
 vVw
-fCL
+aaj
 tNP
 jWh
 bYn
@@ -124172,7 +124206,7 @@ xVk
 dbq
 gIJ
 thV
-fCL
+aaj
 lne
 wWq
 pql


### PR DESCRIPTION

# About the pull request

I did this quite a while ago but it got overwritten in a merge conflict so here's round two. This makes all pipes in the main evac area (from the right of the cameras in picture below) not explode during hijack. It also applies the same to the maintenance access corridors for the lifeboats.

# Explain why it's good for the game

Everyone takes all the pipes out of these areas anyway, and I've made this change previously it just got overwritten. It does make sense that the evacuation area would have some degree of protection from disastrous overpressure.

I could apply the same logic to CIC and reactor room, but I'm choosing not to.


# Testing Photographs and Procedure
![image](https://github.com/user-attachments/assets/c64610dd-0a11-42f1-8d97-17524c154f57)
![image](https://github.com/user-attachments/assets/61d927f8-4fff-4108-929b-047e214e11f3)


<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: Lifeboat air pipes are now reinforced (again) and no longer explode.
/:cl:
