### PR TITLE
UPP squad selection

### DIFF
--- a/code/game/jobs/job/marine/squads.dm
+++ b/code/game/jobs/job/marine/squads.dm
@@ -27,6 +27,8 @@
 /datum/squad
 	/// Name of the squad
 	var/name
+	/// Eqivalent name so that loby prefered squad gets used for toehr factions
+	var/eqivalent_name
 	/// Squads ID that is set on New()
 	var/tracking_id = null //Used for the tracking subsystem
 	/// Maximum number allowed in a squad. Defaults to infinite
@@ -271,21 +273,25 @@
 
 /datum/squad/upp/one
 	name = SQUAD_UPP_1
+	eqivalent_name =SQUAD_MARINE_1
 	equipment_color = "#e61919"
 	chat_color = "#e67d7d"
 
-/datum/squad/upp/twp
+/datum/squad/upp/two
 	name = SQUAD_UPP_2
+	eqivalent_name =SQUAD_MARINE_2
 	equipment_color = "#ffc32d"
 	chat_color = "#ffe650"
 
 /datum/squad/upp/three
 	name = SQUAD_UPP_3
+	eqivalent_name =SQUAD_MARINE_3
 	equipment_color = "#c864c8"
 	chat_color = "#ff96ff"
 
 /datum/squad/upp/four
 	name = SQUAD_UPP_4
+	eqivalent_name =SQUAD_MARINE_4
 	equipment_color = "#4148c8"
 	chat_color = "#828cff"
 

--- a/code/game/jobs/job/marine/squads.dm
+++ b/code/game/jobs/job/marine/squads.dm
@@ -27,7 +27,7 @@
 /datum/squad
 	/// Name of the squad
 	var/name
-	/// Equivalent name so that loby prefered squad gets used for toehr factions
+	/// Equivalent name so that loby prefered squad gets used for other factions
 	var/equivalent_name
 	/// Squads ID that is set on New()
 	var/tracking_id = null //Used for the tracking subsystem

--- a/code/game/jobs/job/marine/squads.dm
+++ b/code/game/jobs/job/marine/squads.dm
@@ -27,7 +27,7 @@
 /datum/squad
 	/// Name of the squad
 	var/name
-	/// Equivalent name so that loby prefered squad gets used for other factions
+	/// Equivalent name so that lobby prefered squad gets used for other factions
 	var/equivalent_name
 	/// Squads ID that is set on New()
 	var/tracking_id = null //Used for the tracking subsystem

--- a/code/game/jobs/job/marine/squads.dm
+++ b/code/game/jobs/job/marine/squads.dm
@@ -27,8 +27,8 @@
 /datum/squad
 	/// Name of the squad
 	var/name
-	/// Eqivalent name so that loby prefered squad gets used for toehr factions
-	var/eqivalent_name
+	/// Equivalent name so that loby prefered squad gets used for toehr factions
+	var/equivalent_name
 	/// Squads ID that is set on New()
 	var/tracking_id = null //Used for the tracking subsystem
 	/// Maximum number allowed in a squad. Defaults to infinite
@@ -273,25 +273,25 @@
 
 /datum/squad/upp/one
 	name = SQUAD_UPP_1
-	eqivalent_name =SQUAD_MARINE_1
+	equivalent_name =SQUAD_MARINE_1
 	equipment_color = "#e61919"
 	chat_color = "#e67d7d"
 
 /datum/squad/upp/two
 	name = SQUAD_UPP_2
-	eqivalent_name =SQUAD_MARINE_2
+	equivalent_name =SQUAD_MARINE_2
 	equipment_color = "#ffc32d"
 	chat_color = "#ffe650"
 
 /datum/squad/upp/three
 	name = SQUAD_UPP_3
-	eqivalent_name =SQUAD_MARINE_3
+	equivalent_name =SQUAD_MARINE_3
 	equipment_color = "#c864c8"
 	chat_color = "#ff96ff"
 
 /datum/squad/upp/four
 	name = SQUAD_UPP_4
-	eqivalent_name =SQUAD_MARINE_4
+	equivalent_name =SQUAD_MARINE_4
 	equipment_color = "#4148c8"
 	chat_color = "#828cff"
 

--- a/code/game/jobs/job/marine/squads.dm
+++ b/code/game/jobs/job/marine/squads.dm
@@ -273,25 +273,25 @@
 
 /datum/squad/upp/one
 	name = SQUAD_UPP_1
-	equivalent_name =SQUAD_MARINE_1
+	equivalent_name = SQUAD_MARINE_1
 	equipment_color = "#e61919"
 	chat_color = "#e67d7d"
 
 /datum/squad/upp/two
 	name = SQUAD_UPP_2
-	equivalent_name =SQUAD_MARINE_2
+	equivalent_name = SQUAD_MARINE_2
 	equipment_color = "#ffc32d"
 	chat_color = "#ffe650"
 
 /datum/squad/upp/three
 	name = SQUAD_UPP_3
-	equivalent_name =SQUAD_MARINE_3
+	equivalent_name = SQUAD_MARINE_3
 	equipment_color = "#c864c8"
 	chat_color = "#ff96ff"
 
 /datum/squad/upp/four
 	name = SQUAD_UPP_4
-	equivalent_name =SQUAD_MARINE_4
+	equivalent_name = SQUAD_MARINE_4
 	equipment_color = "#4148c8"
 	chat_color = "#828cff"
 

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -562,13 +562,10 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 			if(squad.put_marine_in_squad(human))
 				return
 
-		else if(squad.name == preferred_squad) //fav squad has a spot for us, no more searching needed.
+		else if(squad.name == preferred_squad || squad.equivalent_name == preferred_squad) //fav squad or faction equivalent has a spot for us, no more searching needed.
 			if(squad.put_marine_in_squad(human))
 				return
 
-		else if(squad.equivalent_name == preferred_squad) //equivalent names so that USCM names are used for squads of other factions
-			if(squad.put_marine_in_squad(human))
-				return
 		if(!lowest)
 			lowest = squad
 

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -566,6 +566,9 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 			if(squad.put_marine_in_squad(human))
 				return
 
+		else if(squad.eqivalent_name == preferred_squad) //eqivalent names so that USCM names are used for squads of other factions
+			if(squad.put_marine_in_squad(human))
+				return
 		if(!lowest)
 			lowest = squad
 

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -566,7 +566,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 			if(squad.put_marine_in_squad(human))
 				return
 
-		else if(squad.eqivalent_name == preferred_squad) //eqivalent names so that USCM names are used for squads of other factions
+		else if(squad.equivalent_name == preferred_squad) //equivalent names so that USCM names are used for squads of other factions
 			if(squad.put_marine_in_squad(human))
 				return
 		if(!lowest)


### PR DESCRIPTION

# About the pull request

adds eqivalent name var to squad, this allows to assing squads of other factions to prefered USCM squad eqivalent aka charlie = cheka

# Explain why it's good for the game

UPP command will not have to spear marines manualy allows for UPP and in future otehr faction squad RP and identity


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: when lobby joining as UPP you getassigned to equivalen of prefered USCM squad if possible
/:cl:
