### PR TITLE
Reaction fixes, refactoring, and flash powder retune

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -488,7 +488,7 @@
 	if(amount < 1)
 		return INITIALIZE_HINT_QDEL
 	var/square_amount = sqrt(amount)
-	// Fuel quickly ramps up to about 14.5 mins then tapers off the more volume there is (6s min)
+	// Fuel quickly ramps up to about 15.5 mins then tapers off the more volume there is (6s min)
 	fuel = max(((-150 / square_amount) - 2 * sqrt(amount + 2000) + 120), 0.1) MINUTES
 	// Range gradually ramps up from 1 to 15
 	light_range = max(min(square_amount - 3, 15), MINIMUM_USEFUL_LIGHT_RANGE)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -485,11 +485,17 @@
 
 /obj/item/device/flashlight/flare/on/illumination/chemical/Initialize(mapload, amount)
 	. = ..()
-	light_range = floor(amount * 0.04)
-	if(!light_range)
+	if(amount < 1)
 		return INITIALIZE_HINT_QDEL
-	set_light(light_range)
-	fuel = amount * 5 SECONDS
+	var/square_amount = sqrt(amount)
+	// Fuel quickly ramps up to about 14.5 mins then tapers off the more volume there is (6s min)
+	fuel = max(((-150 / square_amount) - 2 * sqrt(amount + 2000) + 120), 0.1) MINUTES
+	// Range gradually ramps up from 1 to 15
+	light_range = max(min(square_amount - 3, 15), MINIMUM_USEFUL_LIGHT_RANGE)
+	// Power slowly ramps up from 1 to 5
+	light_power = min(0.1 * square_amount + 1, 5)
+	set_light(light_range, light_power)
+
 
 /obj/item/device/flashlight/slime
 	gender = PLURAL

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -231,9 +231,9 @@
 	if(!my_atom) return
 	if(my_atom.flags_atom & NOREACT) return //Yup, no reactions here. No siree.
 
-	var/reaction_occurred = 0
+	var/reaction_occurred = FALSE
 	do
-		reaction_occurred = 0
+		reaction_occurred = FALSE
 		for(var/datum/reagent/R in reagent_list) // Usually a small list
 			if(R.original_id) //Prevent synthesised chem variants from being mixed
 				for(var/datum/reagent/O in reagent_list)
@@ -258,8 +258,7 @@
 				if(C.required_catalysts)
 					total_required_catalysts = length(C.required_catalysts)
 				var/total_matching_catalysts= 0
-				var/matching_container = 0
-				var/matching_other = 0
+				var/matching_container = FALSE
 				var/list/multipliers = new/list()
 
 				for(var/B in C.required_reagents)
@@ -279,16 +278,11 @@
 					continue
 
 				if(!C.required_container)
-					matching_container = 1
+					matching_container = TRUE
+				else if(ispath(my_atom.type, C.required_container))
+					matching_container = TRUE
 
-				else
-					if(my_atom.type == C.required_container)
-						matching_container = 1
-
-				if(!C.required_other)
-					matching_other = 1
-
-				if(total_matching_reagents == total_required_reagents && total_matching_catalysts == total_required_catalysts && matching_container && matching_other)
+				if(total_matching_reagents == total_required_reagents && total_matching_catalysts == total_required_catalysts && matching_container)
 					var/multiplier = min(multipliers)
 					var/preserved_data = null
 					for(var/B in C.required_reagents)
@@ -314,7 +308,7 @@
 					playsound(get_turf(my_atom), 'sound/effects/bubbles.ogg', 15, 1)
 
 					C.on_reaction(src, created_volume)
-					reaction_occurred = 1
+					reaction_occurred = TRUE
 					break
 
 	while(reaction_occurred)

--- a/code/modules/reagents/Chemistry-Reactions.dm
+++ b/code/modules/reagents/Chemistry-Reactions.dm
@@ -6,15 +6,17 @@
 	var/list/required_reagents = new/list()
 	var/list/required_catalysts = new/list()
 
-	var/mob_react = TRUE //Determines if a chemical reaction can occur inside a mob
+	/// Determines if a chemical reaction can occur inside a mob
+	var/mob_react = TRUE
+	/// The container path required for the reaction to happen
+	var/required_container = null
 
-	// both vars below are currently unused
-	var/atom/required_container = null // the container required for the reaction to happen
-	var/required_other = 0 // an integer required for the reaction to happen
-
-	var/result_amount = 0 //I recommend you set the result amount to the total volume of all components.
-	var/secondary = 0 // set to nonzero if secondary reaction
-	var/list/secondary_results = list() //additional reagents produced by the reaction
+	/// The resulting amount: Recommended to be set to the total volume of all components
+	var/result_amount = 0
+	/// set to nonzero if secondary reaction
+	var/secondary = 0
+	/// additional reagents produced by the reaction
+	var/list/secondary_results = list()
 	var/requires_heating = 0
 
 /datum/chemical_reaction/proc/on_reaction(datum/reagents/holder, created_volume)

--- a/code/modules/reagents/chemistry_reactions/other.dm
+++ b/code/modules/reagents/chemistry_reactions/other.dm
@@ -156,13 +156,27 @@
 	result = null
 	required_reagents = list("aluminum" = 1, "potassium" = 1, "sulfur" = 1 )
 	result_amount = 3
+	mob_react = FALSE
 
 /datum/chemical_reaction/flash_powder/on_reaction(datum/reagents/holder, created_volume)
-	var/location = get_turf(holder.my_atom)
-	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
-	s.set_up(2, 1, location)
-	s.start()
-	new /obj/item/device/flashlight/flare/on/illumination/chemical(location, created_volume)
+	var/turf/location = get_turf(holder.my_atom)
+	var/datum/effect_system/spark_spread/sparker = new /datum/effect_system/spark_spread
+	sparker.set_up(2, 1, location)
+	sparker.start()
+	var/obj/item/device/flashlight/flare/on/illumination/chemical/light = new(holder.my_atom, created_volume)
+
+	//Admin messaging
+	var/area/area = get_area(location)
+	var/where = "[area.name]|[location.x], [location.y]"
+	var/whereLink = "<A HREF='?_src_=admin_holder;[HrefToken(forceGlobal = TRUE)];adminplayerobservecoodjump=1;X=[location.x];Y=[location.y];Z=[location.z]'>[where]</a>"
+	var/data = " [created_volume] volume -> fuel: [light.fuel] range: [light.light_range] power: [light.light_power]"
+
+	if(holder.my_atom.fingerprintslast)
+		msg_admin_niche("[src] reaction has taken place in ([whereLink])[data]. Last associated key is [holder.my_atom.fingerprintslast].")
+		log_game("[src] reaction has taken place in ([where])[data]. Last associated key is [holder.my_atom.fingerprintslast].")
+	else
+		msg_admin_niche("[src] reaction has taken place in ([whereLink])[data]. No associated key.")
+		log_game("[src] reaction has taken place in ([where])[data]. No associated key.")
 
 /datum/chemical_reaction/chemfire
 	name = "Napalm"

--- a/code/modules/reagents/chemistry_reactions/other.dm
+++ b/code/modules/reagents/chemistry_reactions/other.dm
@@ -160,7 +160,7 @@
 
 /datum/chemical_reaction/flash_powder/on_reaction(datum/reagents/holder, created_volume)
 	var/turf/location = get_turf(holder.my_atom)
-	var/datum/effect_system/spark_spread/sparker = new /datum/effect_system/spark_spread
+	var/datum/effect_system/spark_spread/sparker = new
 	sparker.set_up(2, 1, location)
 	sparker.start()
 	var/obj/item/device/flashlight/flare/on/illumination/chemical/light = new(holder.my_atom, created_volume)

--- a/code/modules/reagents/chemistry_reactions/other.dm
+++ b/code/modules/reagents/chemistry_reactions/other.dm
@@ -33,6 +33,7 @@
 	result = null
 	required_reagents = list("uranium" = 1, "iron" = 1) // Yes, laugh, it's the best recipe I could think of that makes a little bit of sense
 	result_amount = 2
+	mob_react = FALSE
 
 /datum/chemical_reaction/emp_pulse/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -373,6 +374,7 @@
 	result = null
 	required_reagents = list("fluorosurfactant" = 1, "water" = 1)
 	result_amount = 2
+	mob_react = FALSE
 
 /datum/chemical_reaction/foam/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)


### PR DESCRIPTION

# About the pull request

This PR refactors a bit of chemistry code (var cleanup, removal of required_other, rework required_container to do path checking), disables mob reaction for several reactions, and retunes the flash power effect.

Flash powder now creates a chemical light in the contents of its reagent holder (allowing it to be destroyed), has some additional logging, and has had its duration, range, and power retuned:
![image](https://github.com/user-attachments/assets/cd4cff2a-3b5c-4760-986f-d708c8ba58f3)

# Explain why it's good for the game
This hopefully gives a bit of experimentation to using this reaction, tones down how excessive it can be, and introduces a bit of counterplay now that it is now destroyable.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/HSCVT3V1saQ

</details>


# Changelog
:cl: Drathek
balance: emp_pulse, flash_powder, and foam reactions are no longer possible in mobs
balance: flash_powder has been reworked to attach to its holder (so it can be destroyed), and values retuned/capped.
refactor: Refactored the metabolize proc for chemistry reactors (removed required_other and changed required_container to use a path check instead)
/:cl:
