### PR TITLE
No more trapped Larva in Lambda Solaris

### DIFF
--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -16021,7 +16021,7 @@
 /turf/open/floor/darkblue2/northeast,
 /area/bigredv2/caves/eta/research)
 "bzJ" = (
-/obj/item/weapon/gun/smg/m39,
+/obj/item/weapon/gun/smg/m39/corporate/no_lock,
 /obj/structure/closet/secure_closet/guncabinet/wy,
 /turf/open/floor/redfull/northwest,
 /area/bigredv2/caves/eta/research)

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -3082,12 +3082,6 @@
 /obj/effect/landmark/monkey_spawn,
 /turf/open/floor/plating/warnplate/north,
 /area/bigredv2/caves/lambda/xenobiology)
-"anR" = (
-/obj/structure/machinery/door/poddoor/almayer{
-	dir = 4
-	},
-/turf/open/floor/plating/warnplate/northeast,
-/area/bigredv2/caves/lambda/xenobiology)
 "anS" = (
 /obj/item/tool/warning_cone,
 /turf/open/floor/warnwhite/west,
@@ -16027,7 +16021,7 @@
 /turf/open/floor/darkblue2/northeast,
 /area/bigredv2/caves/eta/research)
 "bzJ" = (
-/obj/item/weapon/gun/smg/m39/corporate/no_lock,
+/obj/item/weapon/gun/smg/m39,
 /obj/structure/closet/secure_closet/guncabinet/wy,
 /turf/open/floor/redfull/northwest,
 /area/bigredv2/caves/eta/research)
@@ -77682,7 +77676,7 @@ adZ
 alO
 amM
 adZ
-anR
+alO
 amM
 adZ
 adZ


### PR DESCRIPTION

# About the pull request

Adds a resin door to the bottom containment cell inside of Lambda (Solaris), since apperently bursting corpses can spawn there, hardtrapping xenos until they evo or queen melts the shutters

# Explain why it's good for the game

Trapped xenos aint good.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: Replaced a shutter in Lambda on Solaris Ridge so Larva aren't hard trapped on roundstart.
/:cl:
