### PR TITLE
Fax Responders - late spawn faxes

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -237,6 +237,8 @@ SUBSYSTEM_DEF(ticker)
 
 	// We need stats to track roundstart role distribution.
 	mode.setup_round_stats()
+	// Loads up the fax responder platform.
+	mode.load_fax_base()
 
 	//Configure mode and assign player to special mode stuff
 	if (!(mode.flags_round_type & MODE_NO_SPAWN))

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -237,8 +237,6 @@ SUBSYSTEM_DEF(ticker)
 
 	// We need stats to track roundstart role distribution.
 	mode.setup_round_stats()
-	// Loads up the fax responder platform.
-	mode.load_fax_base()
 
 	//Configure mode and assign player to special mode stuff
 	if (!(mode.flags_round_type & MODE_NO_SPAWN))

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -327,9 +327,8 @@ Additional game mode variables.
 		log_debug("Null client attempted to transform_fax_responder")
 		return FALSE
 	if(!loaded_fax_base)
-		loaded_fax_base = SSmapping.lazy_load_template(/datum/lazy_template/fax_response_base, force = TRUE)
+		load_fax_base()
 		if(!loaded_fax_base)
-			log_debug("Error loading fax response base!")
 			return FALSE
 
 	responder_candidate.client.prefs.find_assigned_slot(JOB_FAX_RESPONDER)
@@ -353,6 +352,13 @@ Additional game mode variables.
 	message_admins(FONT_SIZE_XL(SPAN_RED("([new_responder.key]) joined as a [sub_job], [new_responder.real_name].")))
 	new_responder.add_fax_responder()
 
+	return TRUE
+
+/datum/game_mode/proc/load_fax_base()
+	loaded_fax_base = SSmapping.lazy_load_template(/datum/lazy_template/fax_response_base, force = TRUE)
+	if(!loaded_fax_base)
+		log_debug("Error loading fax response base!")
+		return FALSE
 	return TRUE
 
 

--- a/code/game/machinery/fax_machine.dm
+++ b/code/game/machinery/fax_machine.dm
@@ -424,7 +424,7 @@ GLOBAL_LIST_EMPTY(all_faxcodes)
 
 /obj/structure/machinery/faxmachine/proc/outgoing_fax_message(mob/user)
 
-	var/datum/fax/faxcontents = new(fax_paper_copy.info, photo_list, fax_paper_copy.name)
+	var/datum/fax/faxcontents = new(fax_paper_copy.info, photo_list, fax_paper_copy.name, target_department, machine_id_tag)
 
 	GLOB.fax_contents += faxcontents
 
@@ -653,6 +653,20 @@ GLOBAL_LIST_EMPTY(all_faxcodes)
 	network = FAX_NET_PRESS_HC
 	target_department = "General Public"
 
+/obj/structure/machinery/faxmachine/Initialize(mapload, ...)
+	. = ..()
+
+	if(mapload && department in HIGHCOM_DEPARTMENTS)
+		for(var/datum/fax/fax as anything in GLOB.fax_contents)
+			if(fax.department != department)
+				continue
+
+			var/obj/item/paper/paper = new(get_turf(src))
+			paper.info = fax.data
+			paper.update_icon()
+
+			paper.stamps += "<hr><i>This paper has been sent by [fax.fax_id_tag].</i>"
+
 ///The deployed fax machine backpack
 /obj/structure/machinery/faxmachine/backpack
 	name = "\improper Portable Press Fax Machine"
@@ -748,13 +762,21 @@ GLOBAL_LIST_EMPTY(all_faxcodes)
 	var/list/photo_list
 	var/paper_name
 
-/datum/fax/New(new_data, new_photo_list, new_name)
+	/// Where this fax was sent to
+	var/department
+
+	/// The ID tag of the fax machine that sent this
+	var/fax_id_tag
+
+/datum/fax/New(new_data, new_photo_list, new_name, department, fax_id_tag)
 	. = ..()
 	data = new_data
 	photo_list = new_photo_list
 	if(new_name != "paper")
 		paper_name = new_name
 
+	src.department = department
+	src.fax_id_tag = fax_id_tag
 
 
 /obj/structure/machinery/faxmachine/proc/is_department_responder_awake(target_department)

--- a/code/game/machinery/fax_machine.dm
+++ b/code/game/machinery/fax_machine.dm
@@ -656,7 +656,7 @@ GLOBAL_LIST_EMPTY(all_faxcodes)
 /obj/structure/machinery/faxmachine/Initialize(mapload, ...)
 	. = ..()
 
-	if(mapload && department in HIGHCOM_DEPARTMENTS)
+	if(mapload && (department in HIGHCOM_DEPARTMENTS))
 		for(var/datum/fax/fax as anything in GLOB.fax_contents)
 			if(fax.department != department)
 				continue


### PR DESCRIPTION
# About the pull request

Thanks to Harry, spawns any faxes sent before the machines spawned in when the platform loads up.

# Explain why it's good for the game

Makes responding to faxes that were sent before any responders woke up easier.

# Testing Photographs and Procedure
Tested and confirmed loading correctly.

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Fax Responder platform now includes faxes sent before it loaded.
/:cl:
