### PR TITLE
fixes holograms triggering ares sensors

### DIFF
--- a/code/__DEFINES/typecheck/mobs_generic.dm
+++ b/code/__DEFINES/typecheck/mobs_generic.dm
@@ -20,3 +20,5 @@
 #define isnewplayer(A) (istype(A, /mob/new_player))
 #define isHellhound(A) (istype(A, /mob/living/carbon/xenomorph/hellhound))
 #define isaghost(A) (copytext(A.key, 1, 2) == "@")
+
+#define ishologram(A) (istype(A, /mob/hologram))

--- a/code/game/machinery/ARES/ARES_step_triggers.dm
+++ b/code/game/machinery/ARES/ARES_step_triggers.dm
@@ -111,7 +111,7 @@
 
 
 /obj/effect/step_trigger/ares_alert/access_control/Crossed(atom/passer as mob|obj)
-	if(isobserver(passer) || isxeno(passer))
+	if(isobserver(passer) || isxeno(passer) || ishologram(passer))
 		return FALSE
 	if(!passer)
 		return FALSE


### PR DESCRIPTION

# About the pull request

As title

# Explain why it's good for the game

Holograms that no one can see shouldn't be triggering ares.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Hologram mobs no longer trigger ares sensors.
/:cl:
