### PR TITLE
Allows ME3 blowtorch to do blowtorch things

### DIFF
--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -458,7 +458,6 @@
 	desc = "A compact, handheld welding torch used by the marines of the United States Colonial Marine Corps for cutting and welding jobs on the field."
 	max_fuel = 5
 	has_welding_screen = TRUE
-	//inherent_traits = list(TRAIT_TOOL_SIMPLE_BLOWTORCH)
 	icon_state = "welder_b"
 
 /*

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -455,10 +455,10 @@
 
 /obj/item/tool/weldingtool/simple
 	name = "\improper ME3 hand welder"
-	desc = "A compact, handheld welding torch used by the marines of the United States Colonial Marine Corps for cutting and welding jobs on the field. Due to the small size and slow strength, its function is limited compared to a full-sized technician's blowtorch."
+	desc = "A compact, handheld welding torch used by the marines of the United States Colonial Marine Corps for cutting and welding jobs on the field."
 	max_fuel = 5
 	has_welding_screen = TRUE
-	inherent_traits = list(TRAIT_TOOL_SIMPLE_BLOWTORCH)
+	//inherent_traits = list(TRAIT_TOOL_SIMPLE_BLOWTORCH)
 	icon_state = "welder_b"
 
 /*


### PR DESCRIPTION

# About the pull request

Removes the simple welder trait from the ME3 torch, disallowing it from doing anything but welding shut doors/vents.

# Explain why it's good for the game

I see this thing barely used, which is a shame since its a neat looking item. Most of the tasks aren't balance-disrupting, and the one that is, repairing cades, is already locked to engineering skill and comtechs have normal welders and welding goggles.

In addition, the existing tasks, welding shut doors and vents are also essentially useless, as its better for marines to wrench pipes at the entrance to marine fortifications than to let vent xenos scout out defenses, with both of these preventing xeno access to the backline via pipes, and any T2 can doorslash welded doors making that essentially useless

By removing the restriction, I hope to see it taken as a more of a utility item for things like melting down metal lattices and floor tiles, than the essential non-existence it has now.

# Changelog
:cl:
balance: The ME3 welding tool can now be used for most tasks now.
/:cl:
