### PR TITLE
Synthetic Maintenance Station is now constructable, Nerfs max charge

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -12,9 +12,9 @@
 	/// the borg inside
 	var/mob/living/occupant = null
 	/// Two charged borgs in a row with default cell
-	var/max_internal_charge = 7500
+	var/max_internal_charge = 12500
 	/// Starts charged, to prevent power surges on round start
-	var/current_internal_charge = 7500
+	var/current_internal_charge = 12500
 	/// Active Cap - When cyborg is inside
 	var/charging_cap_active = 25000
 	/// Passive Cap - Recharging internal capacitor when no cyborg is inside
@@ -33,6 +33,7 @@
 		/obj/item/stock_parts/capacitor,
 		/obj/item/stock_parts/capacitor,
 	)
+
 
 
 /obj/structure/machinery/recharge_station/Initialize(mapload, ...)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -12,9 +12,9 @@
 	/// the borg inside
 	var/mob/living/occupant = null
 	/// Two charged borgs in a row with default cell
-	var/max_internal_charge = 15000
+	var/max_internal_charge = 7500
 	/// Starts charged, to prevent power surges on round start
-	var/current_internal_charge = 15000
+	var/current_internal_charge = 7500
 	/// Active Cap - When cyborg is inside
 	var/charging_cap_active = 25000
 	/// Passive Cap - Recharging internal capacitor when no cyborg is inside
@@ -25,6 +25,14 @@
 	var/known_implants = list(/obj/item/implant/chem, /obj/item/implant/death_alarm, /obj/item/implant/loyalty, /obj/item/implant/tracking, /obj/item/implant/neurostim)
 	///stun time upon exiting, if at all
 	var/exit_stun = 2
+	/// Components
+	var/list/components = list(
+		/obj/item/stock_parts/manipulator
+		/obj/item/stock_parts/micro_laser
+		/obj/item/stock_parts/scanning_module
+		/obj/item/stock_parts/capacitor
+		/obj/item/stock_parts/capacitor
+	)
 
 
 /obj/structure/machinery/recharge_station/Initialize(mapload, ...)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -27,11 +27,11 @@
 	var/exit_stun = 2
 	/// Components
 	var/list/components = list(
-		/obj/item/stock_parts/manipulator
-		/obj/item/stock_parts/micro_laser
-		/obj/item/stock_parts/scanning_module
-		/obj/item/stock_parts/capacitor
-		/obj/item/stock_parts/capacitor
+		/obj/item/stock_parts/manipulator,
+		/obj/item/stock_parts/micro_laser,
+		/obj/item/stock_parts/scanning_module,
+		/obj/item/stock_parts/capacitor,
+		/obj/item/stock_parts/capacitor,
 	)
 
 

--- a/code/game/machinery/vending/vendor_types/engineering.dm
+++ b/code/game/machinery/vending/vendor_types/engineering.dm
@@ -96,6 +96,7 @@
 		list("Station Alerts", 2, /obj/item/circuitboard/computer/stationalert, VENDOR_ITEM_REGULAR),
 		list("Arcade", 2, /obj/item/circuitboard/computer/arcade, VENDOR_ITEM_REGULAR),
 		list("Atmospheric Monitor", 2, /obj/item/circuitboard/computer/air_management, VENDOR_ITEM_REGULAR),
+		list("Synthetic Maintenence Station", 2, /obj/item/circuitboard/machine/recharge_station, VENDOR_ITEM_REGULAR"),
 	)
 
 /obj/structure/machinery/cm_vending/sorted/tech/tool_storage/antag

--- a/code/game/machinery/vending/vendor_types/engineering.dm
+++ b/code/game/machinery/vending/vendor_types/engineering.dm
@@ -96,7 +96,7 @@
 		list("Station Alerts", 2, /obj/item/circuitboard/computer/stationalert, VENDOR_ITEM_REGULAR),
 		list("Arcade", 2, /obj/item/circuitboard/computer/arcade, VENDOR_ITEM_REGULAR),
 		list("Atmospheric Monitor", 2, /obj/item/circuitboard/computer/air_management, VENDOR_ITEM_REGULAR),
-		list("Synthetic Maintenence Station", 2, /obj/item/circuitboard/machine/recharge_station, VENDOR_ITEM_REGULAR"),
+		list("Synthetic Maintenence Station", 2, /obj/item/circuitboard/machine/recharge_station, VENDOR_ITEM_REGULAR),
 	)
 
 /obj/structure/machinery/cm_vending/sorted/tech/tool_storage/antag

--- a/code/game/objects/items/circuitboards/machine.dm
+++ b/code/game/objects/items/circuitboards/machine.dm
@@ -20,6 +20,19 @@ to destroy them and players will be able to make replacements.
 		/obj/item/stock_parts/micro_laser = 1,
 	)
 
+/obj/item/circuitboard/machine/recharge_station
+
+	name = "Circuit board (Synthetic maintenance station)"
+	build_path = /obj/structure/machinery/recharge_station
+
+	frame_desc = "Requires 1 Micro Manipulator, 1 Micro-Laser, 1 Scanning Module, and 2 Capacitors."
+	req_components = list(
+		/obj/item/stock_parts/manipulator = 1,
+		/obj/item/stock_parts/micro_laser = 1,
+		/obj/item/stock_parts/scanning_module = 1,
+		/obj/item/stock_parts/capacitor = 2,
+	)
+
 /obj/item/circuitboard/machine/autolathe
 	name = "Circuit board (Autolathe)"
 	build_path = /obj/structure/machinery/autolathe


### PR DESCRIPTION
# About the pull request

Synthetic maintenance stations are now constructable with components (1 Micro manipulator, 1 Micro laser, 1 Scanning module and 2 Capacitors), 2 of the boards for these machines also spawn in circuit board vendors.

# Explain why it's good for the game

Synthetic maintenance stations on some maps are basically inaccessible, and while this would usually be a mapping issue, xenos also tend to rush to all of the spots of maintenance stations on the colony and destroy them either way. It's kind of hit-or-miss. With internal components being feasibly impossible to repair otherwise, this leaves the only option for internal damage repairs to be returning to the ship. which is a lengthy process and kind of annoying. This PR will allow these machines to be constructed in the FOB or elsewhere. 

I think it's a valid change because now in order for these machines to really work, the area it's in has to be powered - I've reduced the original base charge from 15000 to 12500, and testing locally a synthetic at around 100~(?) damage will take almost half the charge of the station in total. Without power, they'll be quickly drained and become useless. Additionally, burrowers or a cheeky runner can still get into the FOB and destroy them while someone isn't looking, and with there being only 2 boards on the Almayer, it could be something else for Bravo to keep watch over. Amount of base power might need tweaking at some point, will do that if necessary. 

# Testing Photographs and Procedure
All changes tested locally. Station is constructable, all part requirements show up correctly, nothing broke as far as I could tell. 

<details>
<summary>Screenshots & Videos</summary>
</details>


# Changelog

:cl:
balance: Synthetic maintenance stations are now constructable 
balance: Synthetic maintenance stations now have 12500 base charge instead of 15000 base charge. 
/:cl:
