### PR TITLE
Fix edgecase with ghostize

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -499,8 +499,8 @@ Works together with spawning an observer, noted above.
 		if(ghost.client.player_data)
 			ghost.client.player_data.load_timestat_data()
 
+	if(ghost.client?.player_details)
 		ghost.client.player_details.larva_queue_time = max(ghost.client.player_details.larva_queue_time, new_tod)
-
 	else if(persistent_ckey)
 		var/datum/player_details/details = GLOB.player_details[persistent_ckey]
 		if(details)


### PR DESCRIPTION

# About the pull request

Somehow an AFK xeno had no player_details but did have a client, otherwise this runtime shouldn't be possible. But lets just grab from the GLOB in this case anyways.

# Explain why it's good for the game

Should fix
```
runtime error: Cannot read null.larva_queue_time
proc name: ghostize (/mob/proc/ghostize)
  source file: code/modules/mob/dead/observer/observer.dm,502
  usr: SOMEXENO (/mob/dead/observer)
  src: SOMEOTHERXENO (/mob/living/carbon/xenomorph/runner)
  usr.loc:  red dirt (68,94,2) (/turf/open/auto_turf/sand/layer0)
  src.loc:  red dirt (196,114,2) (/turf/open/auto_turf/sand/layer0)
  call stack:
SOMEOTHERXENO (/mob/living/carbon/xenomorph/runner): ghostize(0, 0)
SOMEOTHERXENO (/mob/living/carbon/xenomorph/runner): ghostize(0, 0)
Distress Signal (/datum/game_mode/colonialmarines): transfer xeno(SOMEXENO (/mob/dead/observer), SOMEOTHERXENO (/mob/living/carbon/xenomorph/runner))
Distress Signal (/datum/game_mode/colonialmarines): attempt to join as xeno(SOMEXENO (/mob/dead/observer), 0)
Join as Xeno (/datum/action/observer_action/join_xeno): action activate()
Join as Xeno (/atom/movable/screen/action_button): clicked(SOMEXENO (/mob/dead/observer), /list (/list), null, "icon-x=11;icon-y=17;left=1;but...")
SOMEXENO (/mob/dead/observer): do click(Join as Xeno (/atom/movable/screen/action_button), null, "icon-x=11;icon-y=17;left=1;but...")
SOMEONE (/client): Click(Join as Xeno (/atom/movable/screen/action_button), null, "mapwindow.map", "icon-x=11;icon-y=17;left=1;but...")
```


# Changelog
:cl: Drathek
fix: Fix runtime edgecase when ghostizing something that has no player_details somehow
/:cl:
