### PR TITLE
COs can now vend windbreakers from their clothing vendor 

### DIFF
--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -425,7 +425,6 @@
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/general/medium(new_human), WEAR_R_STORE)
 
 //*****************************************************************************************************/
-
 /datum/equipment_preset/uscm_ship/commander
 	name = "USCM Commanding Officer (CO)"
 	flags = EQUIPMENT_PRESET_START_OF_ROUND|EQUIPMENT_PRESET_MARINE
@@ -444,7 +443,7 @@
 
 	utility_under = list(/obj/item/clothing/under/marine, /obj/item/clothing/under/marine/officer/command, /obj/item/clothing/under/marine/officer/boiler)
 	utility_hat = list(/obj/item/clothing/head/cmcap,/obj/item/clothing/head/beret/cm/tan)
-	utility_extra = list(/obj/item/clothing/glasses/sunglasses,/obj/item/clothing/glasses/sunglasses/big,/obj/item/clothing/glasses/sunglasses/aviator,/obj/item/clothing/glasses/mbcg)
+	utility_extra = list(/obj/item/clothing/glasses/sunglasses,/obj/item/clothing/glasses/sunglasses/big,/obj/item/clothing/glasses/sunglasses/aviator,/obj/item/clothing/glasses/mbcg, /obj/item/clothing/suit/storage/windbreaker/windbreaker_green, /obj/item/clothing/suit/storage/windbreaker/windbreaker_brown, /obj/item/clothing/suit/storage/windbreaker/windbreaker_gray)
 
 	service_under = list(/obj/item/clothing/under/marine/officer/formal/white, /obj/item/clothing/under/marine/officer/formal/black)
 	service_shoes = list(/obj/item/clothing/shoes/dress/commander)

--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -425,6 +425,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/general/medium(new_human), WEAR_R_STORE)
 
 //*****************************************************************************************************/
+
 /datum/equipment_preset/uscm_ship/commander
 	name = "USCM Commanding Officer (CO)"
 	flags = EQUIPMENT_PRESET_START_OF_ROUND|EQUIPMENT_PRESET_MARINE


### PR DESCRIPTION
# About the pull request

This PR adds green, brown, and grey windbreakers to the CO clothing vendor, under the 'utilities extra' section. 

# Explain why it's good for the game

The windbreakers look good and fit for commanding officers, I see no reason for them to /not/ be in the CO's clothing options. Personally I think it goes nicely as a more utilitarian alternative to the more flashy bomber jacket. 

# Testing Photographs and Procedure

Booted it up on a private server, vendor stuff was there, I didn't see anything break. 

<details>
<summary>Screenshots & Videos</summary>
</details>


# Changelog

:cl:
add: COs can now vend windbreakers from their clothing vendor
/:cl:
