### PR TITLE
Lessens burstscream meta

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Embryo.dm
@@ -133,6 +133,7 @@
 					affected_mob.apply_effect(2, PARALYZE)
 					affected_mob.make_jittery(105)
 					affected_mob.take_limb_damage(1)
+					affected_mob.emote("scream")
 		if(4)
 			if(prob(2))
 				affected_mob.pain.apply_pain(PAIN_CHESTBURST_WEAK)
@@ -140,7 +141,7 @@
 				message = SPAN_WARNING("[message].")
 				to_chat(affected_mob, message)
 				if(prob(50))
-					affected_mob.emote("scream")
+					affected_mob.emote("burstscream")
 			if(prob(6))
 				if(!HAS_TRAIT(src, TRAIT_KNOCKEDOUT))
 					affected_mob.pain.apply_pain(PAIN_CHESTBURST_WEAK)
@@ -307,8 +308,6 @@
 	if(loc != victim)
 		victim.chestburst = 0
 		return
-	if(ishuman(victim) || isyautja(victim))
-		victim.emote("burstscream")
 	sleep(25) //Sound delay
 	victim.update_burst()
 	sleep(10) //Sprite delay

--- a/code/modules/mob/living/carbon/xenomorph/Embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Embryo.dm
@@ -308,7 +308,6 @@
 	if(loc != victim)
 		victim.chestburst = 0
 		return
-	sleep(25) //Sound delay
 	victim.update_burst()
 	sleep(10) //Sprite delay
 	if(!victim || !victim.loc)


### PR DESCRIPTION
# About the pull request

Gets rid of the emote that immediately precedes the burst, instead has random chance of screams and burstscreams in later stages of larva development.

# Explain why it's good for the game

The burstscream change has been out long enough now that people are using it to meta when a larva is about to emerge, they hear it and immediately get out weapons and aim at the still-unbursted-marine, ready to execute the larva. I've even seen someone flame the marine right before the burst so that the larva is forced to be in fire when they emerge. This frankly sucks for the person playing the larva.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: randomizes late-stage hugged screams to lessen people meta'ing when a larva is about to emerge
/:cl:
