### PR TITLE
Fix dropship door stuck and door refactoring

### DIFF
--- a/code/__DEFINES/machinery.dm
+++ b/code/__DEFINES/machinery.dm
@@ -6,6 +6,12 @@
 #define USE_POWER_IDLE 1
 #define USE_POWER_ACTIVE 2
 
+// door defines
+
+#define DOOR_OPERATING_IDLE 0
+#define DOOR_OPERATING_OPENING 1
+#define DOOR_OPERATING_CLOSING 2
+
 // used by the simulator to select mob type
 
 #define HUMAN_MODE "Unarmoured Humans"

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -232,7 +232,7 @@
 		if(do_after(user, 3 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE) && D.density)
 			user.visible_message(SPAN_DANGER("[user] forces [D] open with their [name]."),
 			SPAN_DANGER("You force [D] open with your [name]."))
-			D.Open()
+			D.open()
 
 /obj/item/reagent_container/food/drinks/bottle/black_goo
 	name = "strange bottle"

--- a/code/game/machinery/door_display/door_display.dm
+++ b/code/game/machinery/door_display/door_display.dm
@@ -321,7 +321,8 @@
 		if(!D.density)
 			continue
 		D.unlock(force)
-		D.open(force)
+		if(D.operating != DOOR_OPERATING_OPENING)
+			D.open(force)
 		open = TRUE
 
 	return TRUE

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -78,6 +78,7 @@ GLOBAL_LIST_INIT(airlock_wire_descriptions, list(
 		/obj/effect/alien/resin/fruit,
 		/obj/effect/alien/resin/special,
 		/obj/effect/alien/resin/construction,
+		/obj/item/reagent_container/food/snacks/resin_fruit,
 	)
 
 /obj/structure/machinery/door/airlock/Destroy()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -44,7 +44,10 @@ GLOBAL_LIST_INIT(airlock_wire_descriptions, list(
 	var/assembly_type = /obj/structure/airlock_assembly
 	var/mineral = null
 	var/justzap = 0
+	/// Whether to delay closing when a mob is present
 	var/safe = 1
+	/// Whether a safe close is queued
+	var/pending_safe_close = FALSE
 	normalspeed = 1
 	var/obj/item/circuitboard/airlock/electronics = null
 	var/hasShocked = 0 //Prevents multiple shocks from happening
@@ -88,7 +91,7 @@ GLOBAL_LIST_INIT(airlock_wire_descriptions, list(
 				spawn (openspeed)
 					justzap = 0
 				return
-		else if(user.hallucination > 50 && prob(10) && operating == 0)
+		else if(user.hallucination > 50 && prob(10) && !operating)
 			to_chat(user, SPAN_DANGER("<B>You feel a powerful shock course through your body!</B>"))
 			user.halloss += 10
 			user.apply_effect(10, STUN)
@@ -689,7 +692,7 @@ GLOBAL_LIST_INIT(airlock_wire_descriptions, list(
 				if(operating == -1)
 					airlock_electronics.fried = TRUE
 					airlock_electronics.update_icon()
-					operating = 0
+					operating = DOOR_OPERATING_IDLE
 
 				msg_admin_niche("[key_name(user)] deconstructed [src] in [get_area(user)] ([user.loc.x],[user.loc.y],[user.loc.z])")
 				SEND_SIGNAL(user, COMSIG_MOB_DISASSEMBLE_AIRLOCK, src)
@@ -723,12 +726,22 @@ GLOBAL_LIST_INIT(airlock_wire_descriptions, list(
 		return ..()
 
 
-/obj/structure/machinery/door/airlock/open(forced=0)
-	if( operating || welded || locked || !loc)
+/obj/structure/machinery/door/airlock/open(forced = FALSE)
+	if(operating && !forced)
 		return FALSE
+	if(welded)
+		return FALSE
+	if(locked)
+		return FALSE
+	if(!density)
+		return TRUE
+	if(!loc)
+		return FALSE
+
 	if(!forced)
-		if( !arePowerSystemsOn() || isWireCut(AIRLOCK_WIRE_OPEN_DOOR) )
+		if(!arePowerSystemsOn() || isWireCut(AIRLOCK_WIRE_OPEN_DOOR))
 			return FALSE
+
 	use_power(360) //360 W seems much more appropriate for an actuator moving an industrial door capable of crushing people
 	if(istype(src, /obj/structure/machinery/door/airlock/glass))
 		playsound(loc, 'sound/machines/windowdoor.ogg', 25, 1)
@@ -736,37 +749,54 @@ GLOBAL_LIST_INIT(airlock_wire_descriptions, list(
 		playsound(loc, 'sound/machines/airlock.ogg', 25, 0)
 	if(closeOther != null && istype(closeOther, /obj/structure/machinery/door/airlock/) && !closeOther.density)
 		closeOther.close()
-	return ..(forced)
+
+	. = ..()
+
+	if(!forced)
+		send_status()
+	return .
 
 /obj/structure/machinery/door/airlock/close(forced = FALSE)
-	if(operating || welded || locked || !loc)
-		return
+	if(operating && !forced)
+		return FALSE
+	if(welded)
+		return FALSE
+	if(locked)
+		return FALSE
+	if(pending_safe_close && !forced)
+		return FALSE
+	if(!loc)
+		return FALSE
+
 	if(!forced)
-		if( !arePowerSystemsOn() || isWireCut(AIRLOCK_WIRE_DOOR_BOLTS) )
-			return
+		if(!arePowerSystemsOn() || isWireCut(AIRLOCK_WIRE_DOOR_BOLTS))
+			return FALSE
+
 	if(safe)
 		for(var/turf/turf in locs)
 			if(locate(/mob/living) in turf)
 			// playsound(loc, 'sound/machines/buzz-two.ogg', 25, 0) //THE BUZZING IT NEVER STOPS -Pete
-				spawn (60 + openspeed)
-					close()
-				return
+				pending_safe_close = TRUE
+				spawn(60 + openspeed)
+					pending_safe_close = FALSE
+					close(forced)
+				return FALSE
 
 	for(var/turf/turf in locs)
-		for(var/mob/living/M in turf)
-			if(HAS_TRAIT(M, TRAIT_SUPER_STRONG))
-				M.apply_damage(DOOR_CRUSH_DAMAGE, BRUTE)
+		for(var/mob/living/crushed in turf)
+			if(HAS_TRAIT(crushed, TRAIT_SUPER_STRONG))
+				crushed.apply_damage(DOOR_CRUSH_DAMAGE, BRUTE)
 			else
-				M.apply_damage(DOOR_CRUSH_DAMAGE, BRUTE)
-				M.set_effect(5, STUN)
-				M.set_effect(5, WEAKEN)
-				if(ishuman(M))
-					var/mob/living/carbon/human/H = M
-					if(H.pain.feels_pain)
-						M.emote("pain")
+				crushed.apply_damage(DOOR_CRUSH_DAMAGE, BRUTE)
+				crushed.set_effect(5, STUN)
+				crushed.set_effect(5, WEAKEN)
+				if(ishuman(crushed))
+					var/mob/living/carbon/human/crushed_human = crushed
+					if(crushed_human.pain.feels_pain)
+						crushed.emote("pain")
 			var/turf/location = loc
 			if(istype(location, /turf))
-				location.add_mob_blood(M)
+				location.add_mob_blood(crushed)
 
 	break_resin_objects()
 
@@ -779,28 +809,38 @@ GLOBAL_LIST_INIT(airlock_wire_descriptions, list(
 		var/obj/structure/window/killthis = (locate(/obj/structure/window) in turf)
 		if(killthis)
 			killthis.ex_act(EXPLOSION_THRESHOLD_LOW)//Smashin windows
-	..()
-	return
+
+	. = ..()
+
+	if(!forced)
+		send_status()
+	return .
 
 /obj/structure/machinery/door/airlock/proc/lock(forced = FALSE)
-	if((operating && !forced) || locked)
-		return
+	if(operating && !forced)
+		return FALSE
+	if(locked)
+		return FALSE
 
 	playsound(loc, 'sound/machines/hydraulics_1.ogg', 25)
 	locked = TRUE
-	visible_message(SPAN_NOTICE("\The [src] airlock emits a loud thunk, then a click."))
+	visible_message(SPAN_NOTICE("[src] airlock emits a loud thunk, then a click."))
 	update_icon()
+	return TRUE
 
-/obj/structure/machinery/door/airlock/proc/unlock(forced=0)
-	if(operating || !locked) return
+/obj/structure/machinery/door/airlock/proc/unlock(forced = FALSE)
+	if(operating && !forced)
+		return FALSE
+	if(!locked)
+		return FALSE
 
-	if(forced || (arePowerSystemsOn())) //only can raise bolts if power's on
+	if(forced || arePowerSystemsOn()) //only can raise bolts if power's on
 		locked = FALSE
-
 		playsound(loc, 'sound/machines/hydraulics_2.ogg', 25)
-		visible_message(SPAN_NOTICE("\The [src] airlock emits a click, then hums slightly."))
+		visible_message(SPAN_NOTICE("[src] airlock emits a click, then hums slightly."))
 		update_icon()
 		return TRUE
+
 	return FALSE
 
 /obj/structure/machinery/door/airlock/Initialize()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -70,9 +70,14 @@ GLOBAL_LIST_INIT(airlock_wire_descriptions, list(
 		/obj/effect/alien/resin/spike,
 		/obj/effect/alien/resin/acid_pillar,
 		/obj/effect/alien/resin/shield_pillar,
+		/obj/effect/alien/resin/resin_pillar,
 		/obj/item/explosive/grenade/alien/acid,
 		/obj/structure/alien/movable_wall,
 		/turf/closed/wall/resin,
+		/obj/effect/alien/egg,
+		/obj/effect/alien/resin/fruit,
+		/obj/effect/alien/resin/special,
+		/obj/effect/alien/resin/construction,
 	)
 
 /obj/structure/machinery/door/airlock/Destroy()

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -122,19 +122,6 @@
 
 		radio_connection.post_signal(src, signal, range = AIRLOCK_CONTROL_RANGE, filter = RADIO_AIRLOCK)
 
-
-/obj/structure/machinery/door/airlock/open(forced)
-	. = ..()
-	if(!forced)
-		send_status()
-
-
-/obj/structure/machinery/door/airlock/close(forced)
-	. = ..()
-	if(!forced)
-		send_status()
-
-
 /obj/structure/machinery/door/airlock/proc/set_frequency(new_frequency)
 	SSradio.remove_object(src, frequency)
 	if(new_frequency)

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -860,10 +860,10 @@
 /obj/structure/machinery/door/airlock/dropship_hatch/ex_act(severity)
 	return
 
-/obj/structure/machinery/door/airlock/dropship_hatch/unlock()
-	if(is_reserved_level(z)) // in flight
-		return
-	..()
+/obj/structure/machinery/door/airlock/dropship_hatch/unlock(forced = FALSE)
+	if(is_reserved_level(z) && !forced) // in flight
+		return FALSE
+	return ..()
 
 /obj/structure/machinery/door/airlock/dropship_hatch/attack_alien(mob/living/carbon/xenomorph/xeno)
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -17,7 +17,7 @@
 	var/secondsElectrified = 0
 	var/visible = TRUE
 	var/panel_open = FALSE
-	var/operating = FALSE
+	var/operating = DOOR_OPERATING_IDLE
 	var/autoclose = FALSE
 	var/glass = FALSE
 	/// If FALSE it speeds up the autoclosing timing.
@@ -211,49 +211,59 @@
 			flick("door_deny", src)
 	return
 
-/obj/structure/machinery/door/proc/open(forced)
+/obj/structure/machinery/door/proc/open(forced = FALSE)
 	if(!density)
 		return TRUE
-	if(operating || !loc)
+	if(operating && !forced)
+		return FALSE
+	if(!loc)
 		return FALSE
 
-	operating = TRUE
+	operating = DOOR_OPERATING_OPENING
 	do_animate("opening")
 	set_opacity(FALSE)
 	if(length(filler_turfs))
 		change_filler_opacity(opacity)
-	addtimer(CALLBACK(src, PROC_REF(finish_open)), openspeed)
+	addtimer(CALLBACK(src, PROC_REF(finish_open)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE)
 	return TRUE
 
 /obj/structure/machinery/door/proc/finish_open()
+	if(operating != DOOR_OPERATING_OPENING)
+		return
+
 	layer = open_layer
 	density = FALSE
 	update_icon()
 
-	if(operating)
-		operating = FALSE
+	operating = DOOR_OPERATING_IDLE
 	if(autoclose)
-		addtimer(CALLBACK(src, PROC_REF(autoclose)), normalspeed ? 150 + openspeed : 5)
+		addtimer(CALLBACK(src, PROC_REF(autoclose)), normalspeed ? 150 + openspeed : 5, TIMER_UNIQUE|TIMER_OVERRIDE)
 
-/obj/structure/machinery/door/proc/close()
-	if(density)
+/obj/structure/machinery/door/proc/close(forced = FALSE)
+	if(density && !operating)
 		return TRUE
-	if(operating)
+	if(operating && !forced)
+		return FALSE
+	if(!loc)
 		return FALSE
 
-	operating = TRUE
-	src.density = TRUE
-	src.layer = closed_layer
+	operating = DOOR_OPERATING_CLOSING
+	density = TRUE
+	layer = closed_layer
 	do_animate("closing")
-	addtimer(CALLBACK(src, PROC_REF(finish_close)), openspeed)
+	addtimer(CALLBACK(src, PROC_REF(finish_close)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE)
+	return TRUE
 
 /obj/structure/machinery/door/proc/finish_close()
+	if(operating != DOOR_OPERATING_CLOSING)
+		return
+
 	update_icon()
 	if(visible && !glass)
 		set_opacity(TRUE)
 		if(length(filler_turfs))
 			change_filler_opacity(opacity)
-	operating = FALSE
+	operating = DOOR_OPERATING_IDLE
 
 /obj/structure/machinery/door/proc/requiresID()
 	return TRUE

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -224,12 +224,14 @@
 	set_opacity(FALSE)
 	if(length(filler_turfs))
 		change_filler_opacity(opacity)
-	addtimer(CALLBACK(src, PROC_REF(finish_open)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, PROC_REF(finish_open)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 	return TRUE
 
 /obj/structure/machinery/door/proc/finish_open()
 	if(operating != DOOR_OPERATING_OPENING)
 		return
+	if(QDELETED(src))
+		return // Specifically checked because of the possiible addtimer
 
 	layer = open_layer
 	density = FALSE
@@ -237,7 +239,7 @@
 
 	operating = DOOR_OPERATING_IDLE
 	if(autoclose)
-		addtimer(CALLBACK(src, PROC_REF(autoclose)), normalspeed ? 150 + openspeed : 5, TIMER_UNIQUE|TIMER_OVERRIDE)
+		addtimer(CALLBACK(src, PROC_REF(autoclose)), normalspeed ? 15 SECONDS + openspeed : 5 DECISECONDS, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 
 /obj/structure/machinery/door/proc/close(forced = FALSE)
 	if(density && !operating)
@@ -251,7 +253,7 @@
 	density = TRUE
 	layer = closed_layer
 	do_animate("closing")
-	addtimer(CALLBACK(src, PROC_REF(finish_close)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, PROC_REF(finish_close)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 	return TRUE
 
 /obj/structure/machinery/door/proc/finish_close()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -232,6 +232,7 @@
 /obj/structure/machinery/door/firedoor/proc/latetoggle()
 	if(operating || !nextstate)
 		return
+
 	switch(nextstate)
 		if(OPEN)
 			nextstate = null
@@ -248,7 +249,7 @@
 /obj/structure/machinery/door/firedoor/open(forced = FALSE)
 	if(!forced)
 		if(inoperable())
-			return //needs power to open unless it was forced
+			return FALSE //needs power to open unless it was forced
 		else
 			use_power(360)
 	latetoggle()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -242,7 +242,7 @@
 			close()
 	return
 
-/obj/structure/machinery/door/firedoor/close()
+/obj/structure/machinery/door/firedoor/close(forced = FALSE)
 	latetoggle()
 	return ..()
 

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -7,7 +7,8 @@
 /obj/structure/machinery/door/airlock/multi_tile/close() //Nasty as hell O(n^2) code but unfortunately necessary
 	for(var/turf/turf_tile in locs)
 		for(var/obj/vehicle/multitile/vehicle_tile in turf_tile)
-			if(vehicle_tile) return 0
+			if(vehicle_tile)
+				return FALSE
 
 	return ..()
 
@@ -272,7 +273,7 @@
 /obj/structure/machinery/door/airlock/multi_tile/almayer/dropshiprear/unlock(forced=FALSE)
 	if(is_reserved_level(z) && !forced)
 		return // in orbit
-	..()
+	return ..()
 
 /obj/structure/machinery/door/airlock/multi_tile/almayer/dropshiprear/attack_alien(mob/living/carbon/xenomorph/xeno)
 	if(xeno.hive_pos != XENO_QUEEN)

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -4,10 +4,11 @@
 	damage_cap = 650 // Bigger = more endurable
 	assembly_type = /obj/structure/airlock_assembly/multi_tile
 
-/obj/structure/machinery/door/airlock/multi_tile/close() //Nasty as hell O(n^2) code but unfortunately necessary
+/obj/structure/machinery/door/airlock/multi_tile/close(forced = FALSE) //Nasty as hell O(n^2) code but unfortunately necessary
 	for(var/turf/turf_tile in locs)
 		for(var/obj/vehicle/multitile/vehicle_tile in turf_tile)
 			if(vehicle_tile)
+				addtimer(CALLBACK(src, PROC_REF(close), forced), 6 SECONDS + openspeed, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 				return FALSE
 
 	return ..()
@@ -270,7 +271,7 @@
 		return
 	..()
 
-/obj/structure/machinery/door/airlock/multi_tile/almayer/dropshiprear/unlock(forced=FALSE)
+/obj/structure/machinery/door/airlock/multi_tile/almayer/dropshiprear/unlock(forced = FALSE)
 	if(is_reserved_level(z) && !forced)
 		return // in orbit
 	return ..()
@@ -388,7 +389,7 @@
 	open(TRUE)
 	lock(TRUE)
 
-/obj/structure/machinery/door/airlock/multi_tile/almayer/dropshiprear/lifeboat/close()
+/obj/structure/machinery/door/airlock/multi_tile/almayer/dropshiprear/lifeboat/close(forced = FALSE)
 	. = ..()
 	for(var/turf/self_turf as anything in locs)
 		var/turf/projected = get_ranged_target_turf(self_turf, throw_dir, 1)

--- a/code/game/machinery/doors/poddoor/poddoor.dm
+++ b/code/game/machinery/doors/poddoor/poddoor.dm
@@ -71,7 +71,7 @@
 /obj/structure/machinery/door/poddoor/try_to_activate_door(mob/user)
 	return
 
-/obj/structure/machinery/door/poddoor/open()
+/obj/structure/machinery/door/poddoor/open(forced = FALSE)
 	if(operating) //doors can still open when emag-disabled
 		return FALSE
 	if(!opacity)
@@ -84,10 +84,10 @@
 	icon_state = "[base_icon_state]0"
 	set_opacity(0)
 
-	addtimer(CALLBACK(src, PROC_REF(finish_open)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, PROC_REF(finish_open)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 	return TRUE
 
-/obj/structure/machinery/door/poddoor/close()
+/obj/structure/machinery/door/poddoor/close(forced = FALSE)
 	if(operating)
 		return FALSE
 	if(opacity == initial(opacity))
@@ -102,7 +102,7 @@
 	density = TRUE
 	set_opacity(initial(opacity))
 
-	addtimer(CALLBACK(src, PROC_REF(finish_close)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, PROC_REF(finish_close)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 	return TRUE
 
 /obj/structure/machinery/door/poddoor/finish_close()

--- a/code/game/machinery/doors/poddoor/poddoor.dm
+++ b/code/game/machinery/doors/poddoor/poddoor.dm
@@ -38,13 +38,13 @@
 		return
 	if(density && (stat & NOPOWER) && !operating && !unacidable)
 		spawn(0)
-			operating = 1
+			operating = DOOR_OPERATING_OPENING
 			flick("[base_icon_state]c0", src)
 			icon_state = "[base_icon_state]0"
 			set_opacity(0)
 			sleep(15)
 			density = FALSE
-			operating = 0
+			operating = DOOR_OPERATING_IDLE
 
 /obj/structure/machinery/door/poddoor/attack_alien(mob/living/carbon/xenomorph/X)
 	if((stat & NOPOWER) && density && !operating && !unacidable)
@@ -73,28 +73,27 @@
 
 /obj/structure/machinery/door/poddoor/open()
 	if(operating) //doors can still open when emag-disabled
-		return
-
+		return FALSE
 	if(!opacity)
 		return TRUE
 
-	operating = TRUE
+	operating = DOOR_OPERATING_OPENING
 
 	playsound(loc, 'sound/machines/blastdoor.ogg', 20, 0)
 	flick("[base_icon_state]c0", src)
 	icon_state = "[base_icon_state]0"
 	set_opacity(0)
 
-	addtimer(CALLBACK(src, PROC_REF(finish_open)), openspeed)
+	addtimer(CALLBACK(src, PROC_REF(finish_open)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE)
 	return TRUE
 
 /obj/structure/machinery/door/poddoor/close()
 	if(operating)
-		return
+		return FALSE
 	if(opacity == initial(opacity))
-		return
+		return TRUE
 
-	operating = TRUE
+	operating = DOOR_OPERATING_CLOSING
 	playsound(loc, 'sound/machines/blastdoor.ogg', 20, 0)
 
 	layer = closed_layer
@@ -103,11 +102,14 @@
 	density = TRUE
 	set_opacity(initial(opacity))
 
-	addtimer(CALLBACK(src, PROC_REF(finish_close)), openspeed)
-	return
+	addtimer(CALLBACK(src, PROC_REF(finish_close)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE)
+	return TRUE
 
 /obj/structure/machinery/door/poddoor/finish_close()
-	operating = FALSE
+	if(operating != DOOR_OPERATING_CLOSING)
+		return
+
+	operating = DOOR_OPERATING_IDLE
 
 /obj/structure/machinery/door/poddoor/filler_object
 	name = ""

--- a/code/game/machinery/doors/poddoor/shutters/shutters.dm
+++ b/code/game/machinery/doors/poddoor/shutters/shutters.dm
@@ -20,44 +20,46 @@
 	if(!C.pry_capable)
 		return
 	if(density && (stat & NOPOWER) && !operating && !unacidable)
-		operating = 1
+		operating = DOOR_OPERATING_OPENING
 		spawn(-1)
 			flick("[base_icon_state]c0", src)
 			icon_state = "[base_icon_state]0"
 			sleep(15)
 			density = FALSE
 			set_opacity(0)
-			operating = 0
+			operating = DOOR_OPERATING_IDLE
 			return
 	return
 
 /obj/structure/machinery/door/poddoor/shutters/open()
 	if(operating) //doors can still open when emag-disabled
-		return
+		return FALSE
 
-	operating = TRUE
+	operating = DOOR_OPERATING_OPENING
 	flick("[base_icon_state]c0", src)
 	icon_state = "[base_icon_state]0"
 	playsound(loc, 'sound/machines/blastdoor.ogg', 25)
 
-	addtimer(CALLBACK(src, PROC_REF(finish_open)), openspeed)
+	addtimer(CALLBACK(src, PROC_REF(finish_open)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE)
 	return TRUE
 
 /obj/structure/machinery/door/poddoor/shutters/finish_open()
+	if(operating != DOOR_OPERATING_OPENING)
+		return
+
 	density = FALSE
 	layer = open_layer
 	set_opacity(0)
 
-	if(operating) //emag again
-		operating = FALSE
+	operating = DOOR_OPERATING_IDLE
 	if(autoclose)
-		addtimer(CALLBACK(src, PROC_REF(autoclose)), 150)
+		addtimer(CALLBACK(src, PROC_REF(autoclose)), 15 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
 
 /obj/structure/machinery/door/poddoor/shutters/close()
 	if(operating)
-		return
+		return FALSE
 
-	operating = TRUE
+	operating = DOOR_OPERATING_CLOSING
 	flick("[base_icon_state]c1", src)
 	icon_state = "[base_icon_state]1"
 	layer = closed_layer
@@ -66,11 +68,14 @@
 		set_opacity(1)
 	playsound(loc, 'sound/machines/blastdoor.ogg', 25)
 
-	addtimer(CALLBACK(src, PROC_REF(finish_close)), openspeed)
-	return
+	addtimer(CALLBACK(src, PROC_REF(finish_close)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE)
+	return TRUE
 
 /obj/structure/machinery/door/poddoor/shutters/finish_close()
-	operating = FALSE
+	if(operating != DOOR_OPERATING_CLOSING)
+		return
+
+	operating = DOOR_OPERATING_IDLE
 
 /obj/structure/machinery/door/poddoor/shutters/almayer
 	icon = 'icons/obj/structures/doors/blastdoors_shutters.dmi'

--- a/code/game/machinery/doors/poddoor/shutters/shutters.dm
+++ b/code/game/machinery/doors/poddoor/shutters/shutters.dm
@@ -31,7 +31,7 @@
 			return
 	return
 
-/obj/structure/machinery/door/poddoor/shutters/open()
+/obj/structure/machinery/door/poddoor/shutters/open(forced = FALSE)
 	if(operating) //doors can still open when emag-disabled
 		return FALSE
 
@@ -40,12 +40,14 @@
 	icon_state = "[base_icon_state]0"
 	playsound(loc, 'sound/machines/blastdoor.ogg', 25)
 
-	addtimer(CALLBACK(src, PROC_REF(finish_open)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, PROC_REF(finish_open)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 	return TRUE
 
 /obj/structure/machinery/door/poddoor/shutters/finish_open()
 	if(operating != DOOR_OPERATING_OPENING)
 		return
+	if(QDELETED(src))
+		return // Specifically checked because of the possiible addtimer
 
 	density = FALSE
 	layer = open_layer
@@ -53,9 +55,9 @@
 
 	operating = DOOR_OPERATING_IDLE
 	if(autoclose)
-		addtimer(CALLBACK(src, PROC_REF(autoclose)), 15 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
+		addtimer(CALLBACK(src, PROC_REF(autoclose)), 15 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 
-/obj/structure/machinery/door/poddoor/shutters/close()
+/obj/structure/machinery/door/poddoor/shutters/close(forced = FALSE)
 	if(operating)
 		return FALSE
 
@@ -68,7 +70,7 @@
 		set_opacity(1)
 	playsound(loc, 'sound/machines/blastdoor.ogg', 25)
 
-	addtimer(CALLBACK(src, PROC_REF(finish_close)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, PROC_REF(finish_close)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 	return TRUE
 
 /obj/structure/machinery/door/poddoor/shutters/finish_close()

--- a/code/game/machinery/doors/poddoor/two_tile.dm
+++ b/code/game/machinery/doors/poddoor/two_tile.dm
@@ -21,14 +21,14 @@
 	QDEL_NULL(f2)
 	return ..()
 
-/obj/structure/machinery/door/poddoor/two_tile/open()
+/obj/structure/machinery/door/poddoor/two_tile/open(forced = FALSE)
 	if(operating) //doors can still open when emag-disabled
 		return FALSE
 
 	operating = DOOR_OPERATING_OPENING
 	start_opening()
 
-	addtimer(CALLBACK(src, PROC_REF(open_fully)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, PROC_REF(open_fully)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 	return TRUE
 
 /obj/structure/machinery/door/poddoor/two_tile/proc/start_opening()
@@ -50,19 +50,19 @@
 
 	operating = DOOR_OPERATING_IDLE
 	if(autoclose)
-		addtimer(CALLBACK(src, PROC_REF(autoclose)), 15 SECONDS)
+		addtimer(CALLBACK(src, PROC_REF(autoclose)), 15 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 
 /obj/structure/machinery/door/poddoor/two_tile/four_tile/open_fully()
 	f3.density = FALSE
 	f4.density = FALSE
 	..()
 
-/obj/structure/machinery/door/poddoor/two_tile/close()
+/obj/structure/machinery/door/poddoor/two_tile/close(forced = FALSE)
 	if(operating)
 		return FALSE
 
 	start_closing()
-	addtimer(CALLBACK(src, PROC_REF(close_fully)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, PROC_REF(close_fully)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 	return TRUE
 
 /obj/structure/machinery/door/poddoor/two_tile/proc/start_closing()

--- a/code/game/machinery/doors/poddoor/two_tile.dm
+++ b/code/game/machinery/doors/poddoor/two_tile.dm
@@ -23,12 +23,12 @@
 
 /obj/structure/machinery/door/poddoor/two_tile/open()
 	if(operating) //doors can still open when emag-disabled
-		return
+		return FALSE
 
-	operating = TRUE
+	operating = DOOR_OPERATING_OPENING
 	start_opening()
 
-	addtimer(CALLBACK(src, PROC_REF(open_fully)), openspeed)
+	addtimer(CALLBACK(src, PROC_REF(open_fully)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE)
 	return TRUE
 
 /obj/structure/machinery/door/poddoor/two_tile/proc/start_opening()
@@ -48,8 +48,7 @@
 	f1.density = FALSE
 	f2.density = FALSE
 
-	if(operating == 1) //emag again
-		operating = 0
+	operating = DOOR_OPERATING_IDLE
 	if(autoclose)
 		addtimer(CALLBACK(src, PROC_REF(autoclose)), 15 SECONDS)
 
@@ -60,13 +59,14 @@
 
 /obj/structure/machinery/door/poddoor/two_tile/close()
 	if(operating)
-		return
+		return FALSE
+
 	start_closing()
-	addtimer(CALLBACK(src, PROC_REF(close_fully)), openspeed)
-	return
+	addtimer(CALLBACK(src, PROC_REF(close_fully)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE)
+	return TRUE
 
 /obj/structure/machinery/door/poddoor/two_tile/proc/start_closing()
-	operating = 1
+	operating = DOOR_OPERATING_CLOSING
 	flick("[base_icon_state]c1", src)
 	icon_state = "[base_icon_state]1"
 
@@ -83,7 +83,7 @@
 	set_opacity(initial(opacity))
 	f1.set_opacity(initial(opacity))
 	f2.set_opacity(initial(opacity))
-	operating = 0
+	operating = DOOR_OPERATING_IDLE
 
 /obj/structure/machinery/door/poddoor/two_tile/four_tile/close_fully()
 	f3.set_opacity(initial(opacity))

--- a/code/game/machinery/doors/railing.dm
+++ b/code/game/machinery/doors/railing.dm
@@ -35,35 +35,45 @@
 	if (PF)
 		PF.flags_can_pass_all = (PASS_OVER^PASS_OVER_FIRE)|PASS_CRUSHER_CHARGE
 
-/obj/structure/machinery/door/poddoor/railing/open()
-	if(operating) //doors can still open when emag-disabled
+/obj/structure/machinery/door/poddoor/railing/open(forced = FALSE)
+	if(operating && !forced) //doors can still open when emag-disabled
+		return FALSE
+	if(!loc)
 		return FALSE
 
-	operating = TRUE
+	operating = DOOR_OPERATING_OPENING
 	flick("railingc0", src)
 	icon_state = "railing0"
 	layer = open_layer
 
-	addtimer(CALLBACK(src, PROC_REF(finish_open)), 1.2 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(finish_open)), 1.2 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
 	return TRUE
 
 /obj/structure/machinery/door/poddoor/railing/finish_open()
+	if(operating != DOOR_OPERATING_OPENING)
+		return
+
 	density = FALSE
-	if(operating) //emag again
-		operating = FALSE
+	operating = DOOR_OPERATING_IDLE
 
 /obj/structure/machinery/door/poddoor/railing/close()
 	if(operating)
 		return FALSE
 
 	density = TRUE
-	operating = TRUE
+	operating = DOOR_OPERATING_CLOSING
 	layer = closed_layer
 	flick("railingc1", src)
 	icon_state = "railing1"
 
-	addtimer(VARSET_CALLBACK(src, operating, FALSE), 1.2 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(finish_close)), 1.2 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
 	return TRUE
+
+/obj/structure/machinery/door/poddoor/finish_close()
+	if(operating != DOOR_OPERATING_CLOSING)
+		return
+
+	operating = DOOR_OPERATING_IDLE
 
 /obj/structure/machinery/door/poddoor/railing/open
 	density = FALSE

--- a/code/game/machinery/doors/railing.dm
+++ b/code/game/machinery/doors/railing.dm
@@ -46,7 +46,7 @@
 	icon_state = "railing0"
 	layer = open_layer
 
-	addtimer(CALLBACK(src, PROC_REF(finish_open)), 1.2 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, PROC_REF(finish_open)), 1.2 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 	return TRUE
 
 /obj/structure/machinery/door/poddoor/railing/finish_open()
@@ -56,7 +56,7 @@
 	density = FALSE
 	operating = DOOR_OPERATING_IDLE
 
-/obj/structure/machinery/door/poddoor/railing/close()
+/obj/structure/machinery/door/poddoor/railing/close(forced = FALSE)
 	if(operating)
 		return FALSE
 
@@ -66,7 +66,7 @@
 	flick("railingc1", src)
 	icon_state = "railing1"
 
-	addtimer(CALLBACK(src, PROC_REF(finish_close)), 1.2 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, PROC_REF(finish_close)), 1.2 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 	return TRUE
 
 /obj/structure/machinery/door/poddoor/finish_close()

--- a/code/game/machinery/doors/runed_sandstone.dm
+++ b/code/game/machinery/doors/runed_sandstone.dm
@@ -110,7 +110,7 @@
 	icon_state = "door0"
 	set_opacity(0)
 
-	addtimer(CALLBACK(src, PROC_REF(finish_open)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, PROC_REF(finish_open)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 	return TRUE
 
 /obj/structure/machinery/door/airlock/sandstone/runed/finish_open()
@@ -135,18 +135,13 @@
 		return FALSE
 	if(density && !operating)
 		return TRUE
-	if(pending_safe_close && !forced)
-		return FALSE
 	if(!loc)
 		return FALSE
 
 	if(safe)
 		for(var/turf/turf in locs)
 			if(locate(/mob/living) in turf)
-				pending_safe_close = TRUE
-				spawn (60 + openspeed)
-					pending_safe_close = FALSE
-					close()
+				addtimer(CALLBACK(src, PROC_REF(close), forced), 6 SECONDS + openspeed, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 				return FALSE
 	playsound(loc, 'sound/effects/runedsanddoor.ogg', 25, 0)
 	visible_message(SPAN_NOTICE("[src] makes a loud grating sound as hidden workings force it shut."))
@@ -157,7 +152,7 @@
 	layer = closed_layer
 	do_animate("closing")
 
-	addtimer(CALLBACK(src, PROC_REF(finish_close)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, PROC_REF(finish_close)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 	return TRUE
 
 /obj/structure/machinery/door/airlock/sandstone/runed/finish_close()
@@ -181,22 +176,29 @@
 		if(killthis)
 			killthis.ex_act(EXPLOSION_THRESHOLD_LOW)
 
-/obj/structure/machinery/door/airlock/sandstone/runed/lock(forced=0)
-	if(operating || locked) return
+/obj/structure/machinery/door/airlock/sandstone/runed/lock(forced = FALSE)
+	if(operating && !forced)
+		return FALSE
+	if(locked)
+		return FALSE
 
 	playsound(loc, 'sound/effects/stonedoor_openclose.ogg', 25)
 	locked = TRUE
 	if(density)
-		visible_message(SPAN_NOTICE("\The [src] makes a loud grating sound as heavy stone bolts seal it shut."))
+		visible_message(SPAN_NOTICE("[src] makes a loud grating sound as heavy stone bolts seal it shut."))
 	else
-		visible_message(SPAN_NOTICE("\The [src] makes a loud grating sound as heavy stone bolts seal it open."))
+		visible_message(SPAN_NOTICE("[src] makes a loud grating sound as heavy stone bolts seal it open."))
 	update_icon()
 
-/obj/structure/machinery/door/airlock/sandstone/runed/unlock(forced=0)
-	if(operating || !locked) return
+/obj/structure/machinery/door/airlock/sandstone/runed/unlock(forced = FALSE)
+	if(operating && !forced)
+		return FALSE
+	if(!locked)
+		return FALSE
+
 	locked = FALSE
 	playsound(loc, 'sound/effects/stonedoor_openclose.ogg', 25)
-	visible_message(SPAN_NOTICE("\The [src] makes a loud grating sound as heavy stone bolts retract."))
+	visible_message(SPAN_NOTICE("[src] makes a loud grating sound as heavy stone bolts retract."))
 	update_icon()
 	return TRUE
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -64,35 +64,39 @@
 	if(operating) //doors can still open when emag-disabled
 		return FALSE
 
-	operating = TRUE
+	operating = DOOR_OPERATING_OPENING
 	flick(text("[]opening", base_state), src)
 	playsound(loc, 'sound/machines/windowdoor.ogg', 25, 1)
 	icon_state = text("[]open", base_state)
 
-	addtimer(CALLBACK(src, PROC_REF(finish_open)), openspeed)
+	addtimer(CALLBACK(src, PROC_REF(finish_open)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE)
 	return TRUE
 
 /obj/structure/machinery/door/window/finish_open()
-	density = FALSE
+	if(operating != DOOR_OPERATING_OPENING)
+		return
 
-	if(operating) //emag again
-		operating = FALSE
+	density = FALSE
+	operating = DOOR_OPERATING_IDLE
 
 /obj/structure/machinery/door/window/close()
-	if (operating)
+	if(operating)
 		return FALSE
 
-	operating = TRUE
+	operating = DOOR_OPERATING_CLOSING
 	flick(text("[]closing", src.base_state), src)
 	playsound(loc, 'sound/machines/windowdoor.ogg', 25, 1)
 	icon_state = base_state
 	density = TRUE
 
-	addtimer(CALLBACK(src, PROC_REF(finish_close)), openspeed)
+	addtimer(CALLBACK(src, PROC_REF(finish_close)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE)
 	return TRUE
 
 /obj/structure/machinery/door/window/finish_close()
-	operating = FALSE
+	if(operating != DOOR_OPERATING_CLOSING)
+		return
+
+	operating = DOOR_OPERATING_IDLE
 
 /obj/structure/machinery/door/window/proc/take_damage(damage)
 	src.health = max(0, src.health - damage)
@@ -117,7 +121,7 @@
 		if(operating == -1)
 			ae.fried = TRUE
 			ae.update_icon()
-			operating = 0
+			operating = DOOR_OPERATING_IDLE
 		src.density = FALSE
 		qdel(src)
 		return
@@ -162,11 +166,11 @@
 /obj/structure/machinery/door/window/attackby(obj/item/I, mob/user)
 
 	//If it's in the process of opening/closing, ignore the click
-	if (src.operating == 1)
+	if (operating)
 		return
 
 	//If it's emagged, crowbar can pry electronics out.
-	if (src.operating == -1 && HAS_TRAIT(I, TRAIT_TOOL_CROWBAR))
+	if (operating == -1 && HAS_TRAIT(I, TRAIT_TOOL_CROWBAR))
 		playsound(src.loc, 'sound/items/Crowbar.ogg', 25, 1)
 		user.visible_message("[user] removes the electronics from the windoor.", "You start to remove electronics from the windoor.")
 		if (do_after(user, 40, INTERRUPT_ALL, BUSY_ICON_BUILD))
@@ -201,7 +205,7 @@
 			ae.fried = TRUE
 			ae.update_icon()
 
-			operating = 0
+			operating = DOOR_OPERATING_IDLE
 			qdel(src)
 			return
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -60,7 +60,7 @@
 		close()
 	return
 
-/obj/structure/machinery/door/window/open()
+/obj/structure/machinery/door/window/open(forced = FALSE)
 	if(operating) //doors can still open when emag-disabled
 		return FALSE
 
@@ -69,7 +69,7 @@
 	playsound(loc, 'sound/machines/windowdoor.ogg', 25, 1)
 	icon_state = text("[]open", base_state)
 
-	addtimer(CALLBACK(src, PROC_REF(finish_open)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, PROC_REF(finish_open)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 	return TRUE
 
 /obj/structure/machinery/door/window/finish_open()
@@ -79,7 +79,7 @@
 	density = FALSE
 	operating = DOOR_OPERATING_IDLE
 
-/obj/structure/machinery/door/window/close()
+/obj/structure/machinery/door/window/close(forced = FALSE)
 	if(operating)
 		return FALSE
 
@@ -89,7 +89,7 @@
 	icon_state = base_state
 	density = TRUE
 
-	addtimer(CALLBACK(src, PROC_REF(finish_close)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, PROC_REF(finish_close)), openspeed, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 	return TRUE
 
 /obj/structure/machinery/door/window/finish_close()

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -654,7 +654,7 @@
 
 				user.visible_message(SPAN_DANGER("[user] forces [resin_door] open with [src]."),
 				SPAN_DANGER("You force [resin_door] open with [src]."))
-				resin_door.Open()
+				resin_door.open()
 				return
 
 	else if(istype(attacked_obj, /turf/open/floor))

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -173,8 +173,8 @@
 	icon = 'icons/obj/items/inflatable.dmi'
 	icon_state = "door_closed"
 
-	var/state = 0 //closed, 1 == open
-	var/isSwitchingStates = 0
+	var/open = FALSE
+	var/isSwitchingStates = FALSE
 
 /obj/structure/inflatable/door/attack_remote(mob/user as mob) //those aren't machinery, they're just big fucking slabs of a mineral
 	if(isRemoteControlling(user)) //so the AI can't open it
@@ -197,36 +197,43 @@
 				SwitchState()
 
 /obj/structure/inflatable/door/proc/SwitchState()
-	if(state)
-		Close()
+	if(open)
+		close()
 	else
-		Open()
+		open()
 
-
-/obj/structure/inflatable/door/proc/Open()
-	isSwitchingStates = 1
+/obj/structure/inflatable/door/proc/open()
+	isSwitchingStates = TRUE
 	//playsound(loc, 'sound/effects/stonedoor_openclose.ogg', 25, 1)
 	flick("door_opening",src)
-	sleep(10)
+	addtimer(CALLBACK(src, PROC_REF(finish_open)), 1 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
+
+/obj/structure/inflatable/door/proc/finish_open()
+	if(!loc)
+		return
 	density = FALSE
 	opacity = FALSE
-	state = 1
+	open = TRUE
 	update_icon()
-	isSwitchingStates = 0
+	isSwitchingStates = FALSE
 
-/obj/structure/inflatable/door/proc/Close()
-	isSwitchingStates = 1
+/obj/structure/inflatable/door/proc/close()
+	isSwitchingStates = TRUE
 	//playsound(loc, 'sound/effects/stonedoor_openclose.ogg', 25, 1)
 	flick("door_closing",src)
-	sleep(10)
+	addtimer(CALLBACK(src, PROC_REF(finish_close)), 1 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
+
+/obj/structure/inflatable/door/proc/finish_close()
+	if(!loc)
+		return
 	density = TRUE
 	opacity = FALSE
-	state = 0
+	open = FALSE
 	update_icon()
-	isSwitchingStates = 0
+	isSwitchingStates = FALSE
 
 /obj/structure/inflatable/door/update_icon()
-	if(state)
+	if(open)
 		icon_state = "door_open"
 	else
 		icon_state = "door_closed"

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -12,8 +12,8 @@
 	icon_state = "metal"
 
 	var/mineralType = "metal"
-	var/state = 0 //closed, 1 == open
-	var/isSwitchingStates = 0
+	var/open = FALSE
+	var/isSwitchingStates = FALSE
 	var/hardness = 1
 	var/oreAmount = 7
 
@@ -25,7 +25,7 @@
 
 /obj/structure/mineral_door/Collided(atom/user)
 	..()
-	if(!state)
+	if(!open)
 		return TryToSwitchState(user)
 	return
 
@@ -58,37 +58,44 @@
 				SwitchState()
 
 /obj/structure/mineral_door/proc/SwitchState()
-	if(state)
-		Close()
+	if(open)
+		close()
 	else
-		Open()
+		open()
 
-/obj/structure/mineral_door/proc/Open()
-	isSwitchingStates = 1
+/obj/structure/mineral_door/proc/open()
+	isSwitchingStates = TRUE
 	playsound(loc, 'sound/effects/stonedoor_openclose.ogg', 25, 1)
 	flick("[mineralType]opening",src)
-	sleep(10)
+	addtimer(CALLBACK(src, PROC_REF(finish_open)), 1 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
+
+/obj/structure/mineral_door/proc/finish_open()
+	if(!loc)
+		return
 	density = FALSE
 	opacity = FALSE
-	state = 1
+	open = TRUE
 	update_icon()
-	isSwitchingStates = 0
+	isSwitchingStates = FALSE
 
-
-/obj/structure/mineral_door/proc/Close()
-	isSwitchingStates = 1
+/obj/structure/mineral_door/proc/close()
+	isSwitchingStates = TRUE
 	playsound(loc, 'sound/effects/stonedoor_openclose.ogg', 25, 1)
 	flick("[mineralType]closing",src)
-	sleep(10)
+	addtimer(CALLBACK(src, PROC_REF(finish_close)), 1 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
+
+/obj/structure/mineral_door/proc/finish_close()
+	if(!loc)
+		return
 	density = TRUE
 	opacity = TRUE
-	state = 0
+	open = FALSE
 	update_icon()
-	isSwitchingStates = 0
+	isSwitchingStates = FALSE
 
 
 /obj/structure/mineral_door/update_icon()
-	if(state)
+	if(open)
 		icon_state = "[mineralType]open"
 	else
 		icon_state = mineralType
@@ -173,7 +180,7 @@
 /obj/structure/mineral_door/transparent
 	opacity = FALSE
 
-/obj/structure/mineral_door/transparent/Close()
+/obj/structure/mineral_door/transparent/finish_close()
 	..()
 	opacity = FALSE
 
@@ -202,27 +209,35 @@
 	mineralType = "wood"
 	hardness = 1
 
-/obj/structure/mineral_door/wood/Open()
-	isSwitchingStates = 1
+/obj/structure/mineral_door/wood/open()
+	isSwitchingStates = TRUE
 	playsound(loc, 'sound/effects/doorcreaky.ogg', 25, 1)
 	flick("[mineralType]opening",src)
-	sleep(10)
+	addtimer(CALLBACK(src, PROC_REF(finish_open)), 1 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
+
+/obj/structure/mineral_door/wood/finish_open()
+	if(!loc)
+		return
 	density = FALSE
 	opacity = FALSE
-	state = 1
+	open = TRUE
 	update_icon()
-	isSwitchingStates = 0
+	isSwitchingStates = FALSE
 
-/obj/structure/mineral_door/wood/Close()
-	isSwitchingStates = 1
+/obj/structure/mineral_door/wood/close()
+	isSwitchingStates = TRUE
 	playsound(loc, 'sound/effects/doorcreaky.ogg', 25, 1)
 	flick("[mineralType]closing",src)
-	sleep(10)
+	addtimer(CALLBACK(src, PROC_REF(finish_close)), 1 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
+
+/obj/structure/mineral_door/wood/finish_close()
+	if(!loc)
+		return
 	density = TRUE
 	opacity = TRUE
-	state = 0
+	open = FALSE
 	update_icon()
-	isSwitchingStates = 0
+	isSwitchingStates = FALSE
 
 /obj/structure/mineral_door/wood/Dismantle(devastated = 0)
 	if(!devastated)
@@ -234,5 +249,5 @@
 /obj/structure/mineral_door/wood/open
 	density = FALSE
 	opacity = FALSE
-	state = 1
+	open = TRUE
 	icon_state = "woodopen"

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -420,19 +420,24 @@
 		if (C.ally_of_hivenumber(hivenumber))
 			return ..()
 
-/obj/structure/mineral_door/resin/Open()
-	if(state || !loc) return //already open
-	isSwitchingStates = 1
+/obj/structure/mineral_door/resin/open()
+	if(open || !loc)
+		return //already open
+	isSwitchingStates = TRUE
 	playsound(loc, "alien_resin_move", 25)
 	flick("[mineralType]opening",src)
-	sleep(3)
+	addtimer(CALLBACK(src, PROC_REF(finish_open)), 3 DECISECONDS, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
+
+/obj/structure/mineral_door/resin/finish_open()
+	if(!loc || QDELETED(src))
+		return
 	density = FALSE
 	opacity = FALSE
-	state = 1
+	open = TRUE
 	update_icon()
-	isSwitchingStates = 0
+	isSwitchingStates = FALSE
 	layer = DOOR_OPEN_LAYER
-	addtimer(CALLBACK(src, PROC_REF(Close)), close_delay, TIMER_UNIQUE|TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, PROC_REF(close)), close_delay, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 
 /obj/structure/mineral_door/resin/proc/close_blocked()
 	for(var/turf/turf in locs)
@@ -441,28 +446,31 @@
 				return TRUE
 	return FALSE
 
-/obj/structure/mineral_door/resin/Close()
-	if(!state || !loc || isSwitchingStates)
+/obj/structure/mineral_door/resin/close()
+	if(!open || !loc || isSwitchingStates)
 		return //already closed or changing
 	//Can't close if someone is blocking it
 	if(close_blocked())
-		addtimer(CALLBACK(src, PROC_REF(Close)), close_delay, TIMER_UNIQUE|TIMER_OVERRIDE)
+		addtimer(CALLBACK(src, PROC_REF(close)), close_delay, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 		return
 
-	isSwitchingStates = 1
+	isSwitchingStates = TRUE
 	playsound(loc, "alien_resin_move", 25)
 	flick("[mineralType]closing",src)
-	sleep(3)
+	addtimer(CALLBACK(src, PROC_REF(finish_close)), 3 DECISECONDS, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
+
+/obj/structure/mineral_door/resin/finish_close()
+	if(!loc || QDELETED(src))
+		return
 	density = TRUE
 	opacity = TRUE
-	state = 0
+	open = FALSE
 	update_icon()
-	isSwitchingStates = 0
+	isSwitchingStates = FALSE
 	layer = DOOR_CLOSED_LAYER
 
 	if(close_blocked())
-		Open()
-		return
+		open()
 
 /obj/structure/mineral_door/resin/Dismantle(devastated = 0)
 	qdel(src)

--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -103,13 +103,13 @@
 			playsound(user, 'sound/weapons/wristblades_hit.ogg', 15, TRUE)
 			if(do_after(user, 1.5 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE) && door.density)
 				user.visible_message(SPAN_DANGER("[user] forces [door] open using the [name]!"), SPAN_DANGER("You force [door] open with your [name]."))
-				door.Open()
+				door.open()
 		else
 			user.visible_message(SPAN_DANGER("[user] pushes [door] with their [name] to force it closed..."), SPAN_DANGER("You push [door] with your [name] to force it closed..."))
 			playsound(user, 'sound/weapons/wristblades_hit.ogg', 15, TRUE)
 			if(do_after(user, 2 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE) && !door.density)
 				user.visible_message(SPAN_DANGER("[user] forces [door] closed using the [name]!"), SPAN_DANGER("You force [door] closed with your [name]."))
-				door.Close()
+				door.close()
 
 /obj/item/weapon/bracer_attachment/attack_self(mob/living/carbon/human/user)
 	..()

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/hivelord/resin_whisperer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/hivelord/resin_whisperer.dm
@@ -80,7 +80,7 @@
 	if(istype(target_atom, /obj/structure/mineral_door/resin))
 		var/obj/structure/mineral_door/resin/resin_door = target_atom
 		resin_door.TryToSwitchState(owner)
-		if(resin_door.state)
+		if(resin_door.open)
 			to_chat(owner, SPAN_XENONOTICE("We focus our connection to the resin and remotely close the resin door."))
 		else
 			to_chat(owner, SPAN_XENONOTICE("We focus our connection to the resin and remotely open the resin door."))

--- a/code/modules/shuttle/helpers.dm
+++ b/code/modules/shuttle/helpers.dm
@@ -153,11 +153,13 @@
 	for(var/obj/blocking_obj in door_turf)
 		if(blocking_obj == door)
 			continue
+		if(istype(blocking_obj, /obj/effect/alien/weeds))
+			continue // No need to push
+
+		// Skip anything that'd just get crushed instead
 		if(istype(door, /obj/structure/machinery/door/airlock))
-			if(blocking_obj.type in door:resin_smushables) // Done this way because of https://www.byond.com/forum/post/2954294
-				continue // Will get crushed instead
-			if(istype(blocking_obj, /obj/effect/alien/weeds))
-				continue // No need to push
+			if(is_type_in_list(blocking_obj, door:resin_smushables)) // Done with : because of https://www.byond.com/forum/post/2954294
+				continue
 
 		// Vehicles need a much more specific location to push to
 		if(istype(blocking_obj, /obj/vehicle/multitile))

--- a/code/modules/shuttles/marine_ferry.dm
+++ b/code/modules/shuttles/marine_ferry.dm
@@ -58,7 +58,7 @@
 		for(var/obj/vehicle/multitile/M in D.loc)
 			if(M) return 0
 
-		for(var/turf/T in D.locate_filler_turfs())
+		for(var/turf/T in D.locs)
 			for(var/obj/vehicle/multitile/M in T)
 				if(M) return 0
 

--- a/code/modules/vehicles/multitile/multitile_bump.dm
+++ b/code/modules/vehicles/multitile/multitile_bump.dm
@@ -299,7 +299,8 @@
 	// Driver needs access
 		var/mob/living/driver = V.get_seat_mob(VEHICLE_DRIVER)
 		if(!requiresID() || (driver && allowed(driver)))
-			open(TRUE)
+			if(operating != DOOR_OPERATING_OPENING)
+				open(TRUE)
 			return FALSE
 	if(!unacidable)
 		visible_message(SPAN_DANGER("\The [V] pushes [src] over!"))


### PR DESCRIPTION
# About the pull request

This PR fixes a multitude of oversights with doors and makes it so dropship doors closing now also throws objects. There's a lot of code touched by this so there's very likely further changes that need to be made (e.g. ~~how do vehicles behave with it, how do resin constructions behave with it~~, are there weird prying issues now, etc).

# Explain why it's good for the game

Fixes #7709 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Airlock spamming:
https://youtu.be/U9icC16jJcA

Objects in airlock:
![throw](https://github.com/user-attachments/assets/893c33f8-08ac-4ca9-ac74-6ffc758b7362)

Vehicle in airlock:
![arc](https://github.com/user-attachments/assets/00bfab6b-e5fc-4d14-b7e8-0cda6ec9bcec)

Resin in airlock:
![resin](https://github.com/user-attachments/assets/fa75c3b2-3dfe-45dc-aa71-edf39f2e0015)

</details>


# Changelog
:cl: Drathek
add: Dropship airlocks that force close now also throw objects (and vehicles) out of their way
add: Airlocks can crush more xeno structures if they somehow got placed there
fix: Fix doors sometimes ignoring force call (namely dropship airlocks)
fix: Fix doors not checking their turfs correctly (for example it wouldn't throw mobs in its own turf)
refactor: Refactor some door code
fix: Fix vehicles in airlocks not being handled correctly (never autoclosing again)
/:cl:
