### PR TITLE
Helmet garb fix (lingering squad stripe)

### DIFF
--- a/code/__DEFINES/human.dm
+++ b/code/__DEFINES/human.dm
@@ -116,48 +116,49 @@
 #define ORDER_FOCUS_MAX_LEVEL   50
 
 //Human Overlays Indexes used in update_icons/////////
-#define BODYPARTS_LAYER 42
-#define DAMAGE_LAYER 41
+#define BODYPARTS_LAYER 43
+#define DAMAGE_LAYER 42
 
-#define UNDERWEAR_LAYER 40
-#define UNDERSHIRT_LAYER 39
-#define MUTANTRACE_LAYER 38
+#define UNDERWEAR_LAYER 41
+#define UNDERSHIRT_LAYER 40
+#define MUTANTRACE_LAYER 39
 
 /// For use by Hunter Flay
-#define FLAY_LAYER 37
-#define UNIFORM_LAYER 36
+#define FLAY_LAYER 38
+#define UNIFORM_LAYER 37
 
 /// bs12 specific. this hack is probably gonna come back to haunt me
-#define TAIL_LAYER 35
+#define TAIL_LAYER 36
 
-#define ID_LAYER 34
-#define SHOES_LAYER 33
-#define GLOVES_LAYER 32
+#define ID_LAYER 35
+#define SHOES_LAYER 34
+#define GLOVES_LAYER 33
 
 /// For splint and gauze overlays
-#define MEDICAL_LAYER 31
+#define MEDICAL_LAYER 32
 
-#define SUIT_LAYER 30
-#define SUIT_GARB_LAYER 29
-#define SUIT_SQUAD_LAYER 28
-#define GLASSES_LAYER 27
-#define BELT_LAYER 26
-#define BACK_LAYER 25
-#define HAIR_LAYER 24
-#define HAIR_GRADIENT_LAYER 23
-#define SUIT_STORE_LAYER 22
-#define FACIAL_LAYER 21
-#define EARS_LAYER 20
-#define FACEMASK_LAYER 19
+#define SUIT_LAYER 31
+#define SUIT_GARB_LAYER 30
+#define SUIT_SQUAD_LAYER 29
+#define GLASSES_LAYER 28
+#define BELT_LAYER 27
+#define BACK_LAYER 26
+#define HAIR_LAYER 25
+#define HAIR_GRADIENT_LAYER 24
+#define SUIT_STORE_LAYER 23
+#define FACIAL_LAYER 22
+#define EARS_LAYER 21
+#define FACEMASK_LAYER 20
 
 /// Unrevivable headshot overlays, suicide/execution.
-#define HEADSHOT_LAYER 18
-#define HEAD_LAYER 17
-#define HEAD_SQUAD_LAYER 16
-#define HEAD_GARB_LAYER_2 15 // These actual defines are unused but this space within the overlays list is
-#define HEAD_GARB_LAYER_3 14 //  |
-#define HEAD_GARB_LAYER_4 13 //  |
-#define HEAD_GARB_LAYER_5 12 // End here
+#define HEADSHOT_LAYER 19
+#define HEAD_LAYER 18
+#define HEAD_SQUAD_LAYER 17
+#define HEAD_GARB_LAYER_6 16 // These actual defines are unused but this space within the overlays list is
+#define HEAD_GARB_LAYER_5 15 //  |
+#define HEAD_GARB_LAYER_4 14 //  |
+#define HEAD_GARB_LAYER_3 13 //  |
+#define HEAD_GARB_LAYER_2 12 // End here
 #define HEAD_GARB_LAYER 11
 
 /// For backpacks when mob is facing north
@@ -177,7 +178,7 @@
 /// If you're hit by an acid DoT
 #define EFFECTS_LAYER 1
 
-#define TOTAL_LAYERS 42
+#define TOTAL_LAYERS 43
 //////////////////////////////////
 
 //Synthetic Defines

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -634,11 +634,9 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 	if(active_visor)
 		. += active_visor.get_helmet_examine_text()
 
-/obj/item/clothing/head/helmet/marine/proc/add_hugger_damage() //This is called in XenoFacehuggers.dm to first add the overlay and set the var.
+/obj/item/clothing/head/helmet/marine/proc/add_hugger_damage() //This is called in XenoFacehuggers.dm to first add the desc and set the var.
 	if(flags_marine_helmet & HELMET_DAMAGE_OVERLAY && !(flags_marine_helmet & HELMET_IS_DAMAGED))
-		helmet_overlays["damage"] = image('icons/obj/items/clothing/cm_hats.dmi',icon_state = "hugger_damage")
 		flags_marine_helmet |= HELMET_IS_DAMAGED
-		update_icon()
 		desc += "\n<b>This helmet seems to be scratched up and damaged, particularly around the face area...</b>"
 
 /obj/item/clothing/head/helmet/marine/get_pockets()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -462,7 +462,7 @@ Applied by gun suicide and high impact bullet executions, removed by rejuvenate,
 		apply_overlay(SUIT_STORE_LAYER)
 
 
-#define MAX_HEAD_GARB_ITEMS 5
+#define MAX_HEAD_GARB_ITEMS 6
 
 /mob/living/carbon/human/update_inv_head()
 	remove_overlay(HEAD_LAYER)


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #5573 which increased the amount of inventory slots in helmets, which meant more overlays were possible. It also removes some dead code attempting to add a hugger damage overlay to a helmet when the icon_state doesn't exist anywhere in cm and update_icons would just immediately clear the item from the helmet_overlays.

# Explain why it's good for the game

Fixes #5912 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/PtsCM_MHHoA

</details>


# Changelog
:cl: Drathek
fix: Fix squad overlay sometimes not getting removed when helmet exceeded its helmet garb overlay slots
del: Remove some effectively dead code attempting to add hugger damage to helmets
/:cl:
