### PR TITLE
Fixes Typo in Paygrade Prefix for Executive Supervisor

### DIFF
--- a/code/datums/paygrades/factions/wy/wy.dm
+++ b/code/datums/paygrades/factions/wy/wy.dm
@@ -41,7 +41,7 @@
 /datum/paygrade/wy_ranks/wyc6
 	paygrade = PAY_SHORT_WYC6
 	name = "Executive Supervisor"
-	prefix = "Exec. Suvp."
+	prefix = "Exec. Spvsr."
 	ranking = 5
 	pay_multiplier = 6
 	officer_grade = GRADE_OFFICER


### PR DESCRIPTION

# About the pull request

Changes the old "Exec. Suvp." to "Exec. Spvsr."

# Explain why it's good for the game

It was both a typo and generally unclear as to what it was meant to be a prefix for, this should clear up what the role is meant to be.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
spellcheck: Changed the old "Exec. Suvp." Paygrade Prefix to "Exec. Spvsr."
/:cl:
