### PR TITLE
Fix UPP CO Vendor Access

### DIFF
--- a/code/game/machinery/vending/vendor_types/antag/antag_upp_commanding_officer.dm
+++ b/code/game/machinery/vending/vendor_types/antag/antag_upp_commanding_officer.dm
@@ -46,7 +46,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_upp_commanding_officer, list(
 	name = "\improper UnionAraratCorp Commanding Officer Weapon Rack"
 	desc = "An automated weapons rack for the Commanding Officer. It features a robust selection of weaponry meant only for the UPP's top officers."
 	req_access = list(ACCESS_UPP_LEADERSHIP)
-	vendor_role = list(JOB_UPP_MAY_OFFICER, JOB_UPP_LTKOL_OFFICER, JOB_UPP_KOL_OFFICER)
+	vendor_role = list(JOB_UPP_CO_OFFICER, JOB_UPP_MAY_OFFICER, JOB_UPP_LTKOL_OFFICER, JOB_UPP_KOL_OFFICER)
 	icon_state = "guns"
 	use_snowflake_points = TRUE
 	vendor_theme = VENDOR_THEME_UPP
@@ -112,7 +112,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_upp_commanding_officer, list(
 	name = "\improper UnionAraratCorp Commanding Officer Equipment Rack"
 	desc = "An automated equipment vendor for the Commanding Officer. Contains a prime selection of equipment for only the UPP's top officers."
 	req_access = list(ACCESS_UPP_LEADERSHIP)
-	vendor_role = list(JOB_UPP_MAY_OFFICER, JOB_UPP_LTKOL_OFFICER, JOB_UPP_KOL_OFFICER)
+	vendor_role = list(JOB_UPP_CO_OFFICER, JOB_UPP_MAY_OFFICER, JOB_UPP_LTKOL_OFFICER, JOB_UPP_KOL_OFFICER)
 	vendor_theme = VENDOR_THEME_UPP
 
 /obj/structure/machinery/cm_vending/clothing/upp_commanding_officer/get_listed_products(mob/user)


### PR DESCRIPTION

# About the pull request

https://github.com/cmss13-devs/cmss13/pull/7644 changed UPP CO rank which has unintentionally resulted in the UPP CO losing access to their personnel vendor. This PR fixes the issue. 

# Explain why it's good for the game

Fixes an oversight. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixed accidental loss of UPP Commanding Officer access to their personal equipment vendors. 
/:cl:
