### PR TITLE
Add UPP Shotgun Boxes To UPP Vendors

### DIFF
--- a/code/game/machinery/vending/vendor_types/prep_upp/requisitions_upp.dm
+++ b/code/game/machinery/vending/vendor_types/prep_upp/requisitions_upp.dm
@@ -137,9 +137,9 @@
 		list("REGULAR AMMUNITION", -1, null, null),
 		list("Type 71 Magazine (5.45x39mm)", floor(scale * 100), /obj/item/ammo_magazine/rifle/type71, VENDOR_ITEM_REGULAR),
 		list("Type 64 Helical Magazine (7.62x19mm)", floor(scale * 100), /obj/item/ammo_magazine/smg/bizon, VENDOR_ITEM_REGULAR),
-		list("Handful of Heavy Buckshot Shells (8g)", floor(scale * 100), /obj/item/ammo_magazine/handful/shotgun/heavy/buckshot, VENDOR_ITEM_REGULAR),
-		list("Handful of Heavy Slug Shells (8g)", floor(scale * 100), /obj/item/ammo_magazine/handful/shotgun/heavy/slug, VENDOR_ITEM_REGULAR),
-		list("Handful of Heavy Flechette Shells (8g)", floor(scale * 100), /obj/item/ammo_magazine/handful/shotgun/heavy/flechette, VENDOR_ITEM_REGULAR),
+		list("Handful of Heavy Buckshot Shells (8g)", floor(scale * 300), /obj/item/ammo_magazine/handful/shotgun/heavy/buckshot, VENDOR_ITEM_REGULAR),
+		list("Handful of Heavy Slug Shells (8g)", floor(scale * 300), /obj/item/ammo_magazine/handful/shotgun/heavy/slug, VENDOR_ITEM_REGULAR),
+		list("Handful of Heavy Flechette Shells (8g)", floor(scale * 300), /obj/item/ammo_magazine/handful/shotgun/heavy/flechette, VENDOR_ITEM_REGULAR),
 		list("Type 73 Magazine (7.62x25mm Tokarev)", floor(scale * 40), /obj/item/ammo_magazine/pistol/t73, VENDOR_ITEM_REGULAR),
 		list("ZHNK-72 Speed Loader (7.62x38mmR)", floor(scale * 40), /obj/item/ammo_magazine/revolver/upp, VENDOR_ITEM_REGULAR),
 		list("NP92 Magazine (9x18mm Makarov)", floor(scale * 40), /obj/item/ammo_magazine/pistol/np92, VENDOR_ITEM_REGULAR),
@@ -156,6 +156,9 @@
 		list("Magazine box (Type 64 Bizon x 10)", 0, /obj/item/ammo_box/magazine/type64, VENDOR_ITEM_REGULAR),
 		list("Magazine box (Type 73 Pistol x 16)", 0, /obj/item/ammo_box/magazine/type73, VENDOR_ITEM_REGULAR),
 		list("Speed loaders box (ZhNK-72 x 12)", 0, /obj/item/ammo_box/magazine/zhnk, VENDOR_ITEM_REGULAR),
+		list("Shotgun Shell Box (Slugs 8g x 100)", 0, /obj/item/ammo_box/magazine/shotgun/upp, VENDOR_ITEM_REGULAR),
+		list("Shotgun Shell Box (Buckshot 8g x 100)", 0, /obj/item/ammo_box/magazine/shotgun/upp/buckshot, VENDOR_ITEM_REGULAR),
+		list("Shotgun Shell Box (Flechette 8g x 100)", 0, /obj/item/ammo_box/magazine/shotgun/upp/flechette, VENDOR_ITEM_REGULAR),
 		list("Flamer Tank Box (UT-Napthal Fuel x 8)", 0, /obj/item/ammo_box/magazine/flamer, VENDOR_ITEM_REGULAR),
 		)
 


### PR DESCRIPTION

# About the pull request

Adds UPP shotgun shell boxes to the UPP requisition vendors. 

# Explain why it's good for the game

Improves UPP requisition significantly and makes sending of UPP shotgun ammo far more user friendly. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: UPP Requisition Vendors may now vend UPP shotgun ammo boxes.
/:cl:
