### PR TITLE
Players now get visual 'Balloon' Alert when Defender Crest is Lowered.

### DIFF
--- a/code/datums/balloon_alerts/balloon_alerts.dm
+++ b/code/datums/balloon_alerts/balloon_alerts.dm
@@ -37,7 +37,7 @@
 	for(var/mob/hearer in hearers)
 		if(is_blind(hearer))
 			continue
-		balloon_alert(hearer, (hearer == src && self_message) || message, text_color, delay)
+		balloon_alert(hearer, (hearer == src && self_message) || message, text_color)
 
 // Do not use.
 // MeasureText blocks. I have no idea for how long.

--- a/code/datums/balloon_alerts/balloon_alerts.dm
+++ b/code/datums/balloon_alerts/balloon_alerts.dm
@@ -8,11 +8,12 @@
 /// The amount of characters needed before this increase takes into effect
 #define BALLOON_TEXT_CHAR_LIFETIME_INCREASE_MIN 10
 
-var/list/last_balloon_alert = list()
+// Define the last alert times as an atom-level variable
+/atom/var/last_balloon_alert_time = 0 // i dont think its good idea... but checks are killing me...
 
 /proc/can_display_balloon_alert(atom/source, delay)
-	var/last_time = last_balloon_alert[source]
-	if (last_time && (world.time - last_time < delay))
+	// Check if enough time has passed since the last alert
+	if (source.last_balloon_alert_time && (world.time - source.last_balloon_alert_time < delay))
 		return FALSE
 	return TRUE
 
@@ -22,7 +23,7 @@ var/list/last_balloon_alert = list()
 	if (delay > 0 && !can_display_balloon_alert(src, delay))
 		return
 
-	last_balloon_alert[src] = world.time
+	src.last_balloon_alert_time = world.time
 	INVOKE_ASYNC(src, PROC_REF(balloon_alert_perform), viewer, text, text_color)
 
 /// Create balloon alerts (text that floats up) to everything within range.

--- a/code/datums/balloon_alerts/balloon_alerts.dm
+++ b/code/datums/balloon_alerts/balloon_alerts.dm
@@ -9,7 +9,7 @@
 #define BALLOON_TEXT_CHAR_LIFETIME_INCREASE_MIN 10
 
 // Define the last alert times as an atom-level variable
-/atom/var/last_balloon_alert_time = 0 // i dont think its good idea... but checks are killing me...
+/atom/var/last_balloon_alert_time = 0
 
 /proc/can_display_balloon_alert(atom/source, delay)
 	// Check if enough time has passed since the last alert

--- a/code/datums/balloon_alerts/balloon_alerts.dm
+++ b/code/datums/balloon_alerts/balloon_alerts.dm
@@ -8,7 +8,7 @@
 /// The amount of characters needed before this increase takes into effect
 #define BALLOON_TEXT_CHAR_LIFETIME_INCREASE_MIN 10
 
-// Define the last alert times as an atom-level variable
+/// The world.time the last balloon alert was displayed
 /atom/var/last_balloon_alert_time = 0
 
 /proc/can_display_balloon_alert(atom/source, delay)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/defender/defender_powers.dm
@@ -113,7 +113,7 @@
 		return
 
 	if(xeno.crest_defense)
-		to_chat(src, SPAN_XENOWARNING("We cannot use tail swipe with our crest lowered."))
+		xeno.balloon_alert(xeno, "our crest is lowered!", text_color = "#7d32bb", delay = 1 SECONDS)
 		return
 
 	xeno.visible_message(SPAN_XENOWARNING("[xeno] sweeps its tail in a wide circle!"), \
@@ -155,7 +155,7 @@
 		return
 
 	if(xeno.crest_defense)
-		to_chat(src, SPAN_XENOWARNING("We cannot use fortify with our crest lowered."))
+		xeno.balloon_alert(xeno, "our crest is lowered!", text_color = "#7d32bb", delay = 1 SECONDS)
 		return
 
 	if(!xeno.check_state())


### PR DESCRIPTION
**TM before Merging**

# About the pull request

This PR add "balloon alert" above defender, warning them that crest is lowered and cannot use other ability. 
(check video to see what balloon alert is)

# Explain why it's good for the game

I am not only person who had this issue, when crest was lowered and didn't notice that during "heat of battle" and try to use tail swing or fortify to only get killed by that mistake, there is no big chat alert to make people realize they have it lowered.

This PR changes that by adding "Balloon Alert" (the ones that spitters have when using 'charge_spit' ability.


# Testing Photographs and Procedure
<details>
<summary>Click HERE to see that Video:</summary>

https://github.com/user-attachments/assets/9ca5d86f-7b88-4c6a-9da3-e81a08f250fb


</details>


# Changelog
:cl: Venuska1117
code: Add "Delay" option for balloon alerts to prevent notification spam.
qol: Added Balloon Alerts to notify player that crest is lowered when trying to use Tail Swing or Fortify.
/:cl: