### PR TITLE
The M276 Pattern Lifesaver Bag can now carry CRITICAL MEDICAL ITEMS (blahaj plushie)

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -287,6 +287,7 @@
 		/obj/item/device/defibrillator/compact,
 		/obj/item/device/reagent_scanner,
 		/obj/item/device/analyzer/plant_analyzer,
+		/obj/item/toy/plush/shark,
 	)
 	flags_atom = FPRINT // has gamemode skin
 


### PR DESCRIPTION
# About the pull request

The lifesaver bag and its children can now carry the shark plushie.

# Explain why it's good for the game

medics are strapped for space in their bags/webbing with all those medical supplies, and the blahaj - while critical, generally is forced to take a backseat to other considerations. this fixes the issue by more easily allowing space in the medic loadout for a blahaj.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: cark
qol: the shark plushie can now fit in the lifesaver bag belt.
/:cl: