### PR TITLE
Door Stuck! More door checks & fix edgecase with vehicle door pushing

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -249,6 +249,12 @@
 	if(!loc)
 		return FALSE
 
+	for(var/turf/turf_tile in locs)
+		for(var/obj/structure/blocking_structure in turf_tile)
+			if(blocking_structure.density || istype(blocking_structure, /obj/structure/closet))
+				addtimer(CALLBACK(src, PROC_REF(close), forced), 6 SECONDS + openspeed, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
+				return FALSE
+
 	operating = DOOR_OPERATING_CLOSING
 	density = TRUE
 	layer = closed_layer

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -7,9 +7,8 @@
 /obj/structure/machinery/door/airlock/multi_tile/close(forced = FALSE) //Nasty as hell O(n^2) code but unfortunately necessary
 	for(var/turf/turf_tile in locs)
 		for(var/obj/vehicle/multitile/vehicle_tile in turf_tile)
-			if(vehicle_tile)
-				addtimer(CALLBACK(src, PROC_REF(close), forced), 6 SECONDS + openspeed, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
-				return FALSE
+			addtimer(CALLBACK(src, PROC_REF(close), forced), 6 SECONDS + openspeed, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
+			return FALSE
 
 	return ..()
 

--- a/code/modules/shuttle/helpers.dm
+++ b/code/modules/shuttle/helpers.dm
@@ -167,12 +167,12 @@
 			var/list/vehicle_dimensions = vehicle.get_dimensions()
 			var/height = vehicle_dimensions["height"]
 			var/width = vehicle_dimensions["width"]
-			if(vehicle.dir & EAST|WEST)
+			if(vehicle.dir & (EAST|WEST))
 				height = vehicle_dimensions["width"]
 				width = vehicle_dimensions["height"]
 			var/dir_to_push = get_dir(door_turf, target_turf)
 			// half width/height because the vehicle loc is centered
-			if(door.dir & EAST|WEST)
+			if(door.dir & (EAST|WEST))
 				switch(dir_to_push)
 					if(NORTH, NORTHEAST, NORTHWEST)
 						target_turf = locate(vehicle.x, door.y + ceil(height*0.5), vehicle.z)

--- a/code/modules/shuttle/helpers.dm
+++ b/code/modules/shuttle/helpers.dm
@@ -170,17 +170,28 @@
 			if(vehicle.dir & EAST|WEST)
 				height = vehicle_dimensions["width"]
 				width = vehicle_dimensions["height"]
-			var/dir_to_push = get_dir(blocking_obj.loc, target_turf)
-			switch(dir_to_push)
-				// half width/height because the vehicle loc is centered
-				if(NORTH, NORTHEAST, NORTHWEST)
-					target_turf = locate(vehicle.x, door.y + ceil(height*0.5), vehicle.z)
-				if(SOUTH, SOUTHEAST, SOUTHWEST)
-					target_turf = locate(vehicle.x, door.y - ceil(height*0.5), vehicle.z)
-				if(EAST)
-					target_turf = locate(door.x + ceil(width*0.5), vehicle.y, vehicle.z)
-				else
-					target_turf = locate(door.x - ceil(width*0.5), vehicle.y, vehicle.z)
+			var/dir_to_push = get_dir(door_turf, target_turf)
+			// half width/height because the vehicle loc is centered
+			if(door.dir & EAST|WEST)
+				switch(dir_to_push)
+					if(NORTH, NORTHEAST, NORTHWEST)
+						target_turf = locate(vehicle.x, door.y + ceil(height*0.5), vehicle.z)
+					if(SOUTH, SOUTHEAST, SOUTHWEST)
+						target_turf = locate(vehicle.x, door.y - ceil(height*0.5), vehicle.z)
+					if(EAST)
+						target_turf = locate(door.x + ceil(width*0.5), vehicle.y, vehicle.z)
+					else
+						target_turf = locate(door.x - ceil(width*0.5), vehicle.y, vehicle.z)
+			else // otherwise door opens east/west so favor those directions
+				switch(dir_to_push)
+					if(NORTH)
+						target_turf = locate(vehicle.x, door.y + ceil(height*0.5), vehicle.z)
+					if(SOUTH)
+						target_turf = locate(vehicle.x, door.y - ceil(height*0.5), vehicle.z)
+					if(EAST, NORTHEAST, SOUTHEAST)
+						target_turf = locate(door.x + ceil(width*0.5), vehicle.y, vehicle.z)
+					else
+						target_turf = locate(door.x - ceil(width*0.5), vehicle.y, vehicle.z)
 
 		// Now actually push it
 		blocking_obj.forceMove(target_turf)


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #7712 fixing an edgecase where the door when pushing a vehicle would incorrectly attempt a west push instead because of the direction comparison. It should also now properly support east/west pushes ever we have a dropship with large enough port/starboard doors.

This PR also makes it so dense structures (or closets regardless of density) will keep doors open (though they will keep trying to close).

# Explain why it's good for the game

Doesn't make a lot of sense for an entire coffin to fit within a closed doorway and to expect that to completely obscure you.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Doors:
https://youtu.be/5eytmPGNBKQ

Vehicle pushing again:
![short push](https://github.com/user-attachments/assets/f980d9c6-13dc-4f38-8c10-527a77a35850)

</details>


# Changelog
:cl: Drathek
add: Dense structures (and coffins) now prevent machinery doors from closing.
fix: Fixed an edgecase with pushing vehicles by dropship launch would incorrectly push west if it was only 1 tile in.
/:cl:
