### PR TITLE
Fix bitwise ops (including sentry flamer ammo)

### DIFF
--- a/code/datums/matrix_editor.dm
+++ b/code/datums/matrix_editor.dm
@@ -7,7 +7,7 @@
 	set name = "Matrix Editor"
 	set category = "Debug"
 
-	if(!usr.client || !usr.client.admin_holder || !(usr.client.admin_holder.rights & R_DEBUG|R_ADMIN))
+	if(!usr.client || !usr.client.admin_holder || !(usr.client.admin_holder.rights & (R_DEBUG|R_ADMIN)))
 		to_chat(usr, SPAN_DANGER("develop man only >:("))
 		return
 
@@ -49,7 +49,7 @@
 	show_browser(usr, data, "Matrix Editor", "matrixeditor\ref[src]", "size=600x450")
 
 /client/proc/matrix_editor_Topic(href, href_list)
-	if(!usr.client || !usr.client.admin_holder || !(usr.client.admin_holder.rights & R_DEBUG|R_ADMIN))
+	if(!usr.client || !usr.client.admin_holder || !(usr.client.admin_holder.rights & (R_DEBUG|R_ADMIN)))
 		to_chat(usr, SPAN_DANGER("develop man only >:("))
 		return
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1070,7 +1070,7 @@
 
 	var/ammo_flags = P.ammo.flags_ammo_behavior | P.projectile_override_flags
 
-	if((ammo_flags & AMMO_FLAME) && (src.caste.fire_immunity & FIRE_IMMUNITY_NO_IGNITE|FIRE_IMMUNITY_NO_DAMAGE))
+	if((ammo_flags & AMMO_FLAME) && (caste.fire_immunity & (FIRE_IMMUNITY_NO_IGNITE|FIRE_IMMUNITY_NO_DAMAGE)))
 		to_chat(src, SPAN_AVOIDHARM("You shrug off the glob of flame."))
 		bullet_message(P, damaging = FALSE)
 		return

--- a/code/modules/shuttle/docking.dm
+++ b/code/modules/shuttle/docking.dm
@@ -194,7 +194,7 @@
 
 	for(var/i in 1 to length(old_turfs))
 		CHECK_TICK
-		if(!(old_turfs[old_turfs[i]] & MOVE_CONTENTS | MOVE_TURF))
+		if(!(old_turfs[old_turfs[i]] & (MOVE_CONTENTS|MOVE_TURF)))
 			continue
 		var/turf/oldT = old_turfs[i]
 		var/turf/newT = new_turfs[i]

--- a/code/modules/shuttle/helpers.dm
+++ b/code/modules/shuttle/helpers.dm
@@ -167,7 +167,7 @@
 			var/list/vehicle_dimensions = vehicle.get_dimensions()
 			var/height = vehicle_dimensions["height"]
 			var/width = vehicle_dimensions["width"]
-			if(vehicle.dir & EAST|WEST)
+			if(vehicle.dir & (EAST|WEST))
 				height = vehicle_dimensions["width"]
 				width = vehicle_dimensions["height"]
 			var/dir_to_push = get_dir(blocking_obj.loc, target_turf)

--- a/code/modules/vehicles/multitile/multitile_interaction.dm
+++ b/code/modules/vehicles/multitile/multitile_interaction.dm
@@ -297,7 +297,7 @@
 	if(P.runtime_iff_group && get_target_lock(P.runtime_iff_group))
 		return
 
-	if(ammo_flags & AMMO_ANTISTRUCT|AMMO_ANTIVEHICLE)
+	if(ammo_flags & (AMMO_ANTISTRUCT|AMMO_ANTIVEHICLE))
 		// Multiplier based on tank railgun relationship, so might have to reconsider multiplier for AMMO_SIEGE in general
 		damage = floor(damage*ANTISTRUCT_DMG_MULT_TANK)
 	if(ammo_flags & AMMO_ACIDIC)

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -154,6 +154,13 @@ if grep -P '^/*var/' $code_files; then
 	st=1
 fi;
 
+part "ambiguous bitwise or"
+if grep -P '^(?:[^\/\n]|\/[^\/\n])*(&[ \t]*\w+[ \t]*\|[ \t]*\w+)' $code_files; then
+	echo
+	echo -e "${RED}ERROR: Likely operator order mistake with bitwise OR. Use parentheses to specify intention.${NC}"
+	st=1
+fi;
+
 
 part "map json naming"
 if ls maps/*.json | grep -P "[A-Z]"; then


### PR DESCRIPTION
# About the pull request

This PR corrects a few bitwise ops I found using `&[^\|\(]*\|[^\|]` because of operation order. Basically `flag & ALPHA|BRAVO` is going to always be a truthy result (depends on the actual value for `BRAVO`) since its resolved as `(flag & ALPHA)|BRAVO`. The fixes to matrix editor would have already been caught by checking the admin holder. I don't know about dropship runway. But a potentially concerning one is w/ flame ammo.

Adds a grep lint to find ambiguous bitwise ORs like this using `^(?:[^\/\n]|\/[^\/\n])*(&[ \t]*\w+[ \t]*\|[ \t]*\w+)` (complication came from supporting `//` though block quotes will still trip it which IMO is fine)

# Explain why it's good for the game

These are clear mistakes, but this may make sentry flamer ammo more effective on non-immune xenos.

Fixes: 
![image](https://github.com/user-attachments/assets/86cab12d-c274-4848-ac04-af75715cb4ca)


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![fire](https://github.com/user-attachments/assets/824e9c72-878e-4b21-a962-a6eb78cdf7f2)

Linter: https://github.com/cmss13-devs/cmss13/actions/runs/12153015470/job/33890398213?pr=7729#step:7:36

</details>


# Changelog
:cl: Drathek
fix: Fix code mistakes involving bitwise OR
balance: Sentry flamer ammo now actually applies its initial damage (~30) to non-immune xenos
balance: AMMO_ANTISTRUCT|AMMO_ANTIVEHICLE are now actually required for a vehicle damage multiplier
code: Bitwise OR mistakes like this are now linted against
/:cl: