### PR TITLE
vaiso and chem retrieval erts can now use their shuttles

### DIFF
--- a/code/datums/emergency_calls/contractor.dm
+++ b/code/datums/emergency_calls/contractor.dm
@@ -115,9 +115,7 @@
 		check_objective_info()
 
 	var/mob/living/carbon/human/H = new(spawn_loc)
-	H.key = M.key
-	if(H.client)
-		H.client.change_view(GLOB.world_view_size)
+	M.transfer_to(H)
 
 	if(!leader && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(H.client, JOB_SQUAD_LEADER, time_required_for_job))    //First one spawned is always the leader.
 		leader = H

--- a/code/datums/emergency_calls/contractor.dm
+++ b/code/datums/emergency_calls/contractor.dm
@@ -115,7 +115,7 @@
 		check_objective_info()
 
 	var/mob/living/carbon/human/H = new(spawn_loc)
-	M.transfer_to(H)
+	M.transfer_to(H, TRUE)
 
 	if(!leader && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(H.client, JOB_SQUAD_LEADER, time_required_for_job))    //First one spawned is always the leader.
 		leader = H

--- a/code/datums/emergency_calls/pmc.dm
+++ b/code/datums/emergency_calls/pmc.dm
@@ -119,9 +119,7 @@
 		check_objective_info()
 
 	var/mob/living/carbon/human/H = new(spawn_loc)
-	H.key = M.key
-	if(H.client)
-		H.client.change_view(GLOB.world_view_size)
+	M.transfer_to(H)
 
 	if(!leader && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(H.client, JOB_SQUAD_LEADER, time_required_for_job))    //First one spawned is always the leader.
 		leader = H

--- a/code/datums/emergency_calls/pmc.dm
+++ b/code/datums/emergency_calls/pmc.dm
@@ -119,7 +119,7 @@
 		check_objective_info()
 
 	var/mob/living/carbon/human/H = new(spawn_loc)
-	M.transfer_to(H)
+	M.transfer_to(H, TRUE)
 
 	if(!leader && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(H.client, JOB_SQUAD_LEADER, time_required_for_job))    //First one spawned is always the leader.
 		leader = H


### PR DESCRIPTION
thanks drathek for cracking open the debugger for me

:cl:
fix: pmc goon squads and vaiso squads can now correctly use their shuttles to return home
/:cl:

closes https://github.com/cmss13-devs/cmss13/issues/7723