### PR TITLE
Character Setup Displays UPP Role Image

### DIFF
--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -238,6 +238,7 @@
 			high_priority = job
 
 	switch(high_priority)
+		// USCM JOBS
 		if(JOB_SQUAD_MARINE)
 			return /datum/equipment_preset/uscm/private_equipped
 		if(JOB_SQUAD_ENGI)
@@ -308,6 +309,36 @@
 			return /datum/equipment_preset/uscm_ship/uscm_medical/nurse
 		if(JOB_MESS_SERGEANT)
 			return /datum/equipment_preset/uscm_ship/chef
+		// UPP JOBS
+		if(JOB_UPP)
+			return /datum/equipment_preset/upp/soldier/dressed
+		if(JOB_UPP_ENGI)
+			return /datum/equipment_preset/upp/sapper/dressed
+		if(JOB_UPP_MEDIC)
+			return /datum/equipment_preset/upp/medic/dressed
+		if(JOB_UPP_SPECIALIST)
+			return /datum/equipment_preset/upp/specialist/dressed
+		if(JOB_UPP_LEADER)
+			return /datum/equipment_preset/upp/leader/dressed
+		if(JOB_UPP_POLICE)
+			return /datum/equipment_preset/upp/military_police/dressed
+		if(JOB_UPP_LT_OFFICER)
+			return /datum/equipment_preset/upp/officer/dressed
+		if(JOB_UPP_SUPPLY)
+			return /datum/equipment_preset/upp/supply/dressed
+		if(JOB_UPP_LT_DOKTOR)
+			return /datum/equipment_preset/upp/doctor/dressed
+		if(JOB_UPP_SRLT_OFFICER)
+			return /datum/equipment_preset/upp/officer/senior/dressed
+		if(JOB_UPP_KPT_OFFICER)
+			return /datum/equipment_preset/upp/officer/kapitan/dressed
+		if(JOB_UPP_CO_OFFICER)
+			return /datum/equipment_preset/upp/officer/major/dressed
+		if(JOB_UPP_COMMISSAR)
+			return /datum/equipment_preset/upp/commissar/dressed
+		if(JOB_UPP_SUPPORT_SYNTH)
+			return /datum/equipment_preset/upp/synth/dressed
+		// MISC-JOBS
 		if(JOB_SURVIVOR)
 			var/list/survivor_types = pref_special_job_options[JOB_SURVIVOR] != ANY_SURVIVOR && length(SSmapping.configs[GROUND_MAP].survivor_types_by_variant[pref_special_job_options[JOB_SURVIVOR]]) ? SSmapping.configs[GROUND_MAP].survivor_types_by_variant[pref_special_job_options[JOB_SURVIVOR]] : SSmapping.configs[GROUND_MAP].survivor_types
 			if(length(survivor_types))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

The Character Setup page will now display a UPP player appearance if they select a UPP job role for any HvH game mode that allows you to select a UPP job role. . 

# Explain why it's good for the game

Better help people see how their character will look in the standard UPP uniform. Helps with immersion. 


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

![Screenshot 2024-12-04 21 22 51](https://github.com/user-attachments/assets/005ca0ef-7382-4a01-88bd-a0dfd22f4f14)


</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: The character setup page will now display your character wearing the correct uniform for the UPP job you have selected as your job preference. This should only occur during the faction clash game mode.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
