### PR TITLE
leveled riflemen slots are no longer used up by dummies

### DIFF
--- a/code/modules/gear_presets/_select_equipment.dm
+++ b/code/modules/gear_presets/_select_equipment.dm
@@ -99,7 +99,7 @@
 	if(paygrades.len == 1)
 		return paygrades[1]
 	var/playtime
-	if(!mob_client)
+	if(!mob_client || new_human.client != mob_client)
 		playtime = JOB_PLAYTIME_TIER_1
 	else
 		playtime = get_job_playtime(mob_client, rank)


### PR DESCRIPTION
title

:cl:
fix: leveled riflemen slots are no longer used up by dummies
/:cl:

leveled riflemen slots are no longer used up by dummies