### PR TITLE
Adds a fax machine to requisitions

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -48140,11 +48140,6 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/structure/machinery/faxmachine/uscm{
-	desc = "The beloved fax machine of the requisitions department, for all your equipment-requesting needs";
-	gender = "female";
-	department = "Requisitions"
-	},
 /turf/open/floor/almayer/plating/northeast,
 /area/almayer/squads/req)
 "pXZ" = (

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -9046,11 +9046,7 @@
 "blw" = (
 /obj/structure/surface/table/almayer,
 /obj/item/tool/lighter,
-/obj/structure/machinery/faxmachine/uscm{
-	desc = "The beloved fax machine of the requisitions department, for all your equipment-requesting needs";
-	gender = "female";
-	department = "Requisitions"
-	},
+/obj/structure/machinery/faxmachine/uscm,
 /obj/structure/machinery/light{
 	dir = 1
 	},
@@ -20632,9 +20628,9 @@
 	pixel_y = -16
 	},
 /obj/structure/machinery/faxmachine/uscm{
-	desc = "The beloved fax machine of the requisitions department, for all your equipment-requesting needs";
-	gender = "female";
-	department = "Requisitions"
+	desc = "The beloved fax machine of the Requisitions department for all your equipment-requesting needs";
+	department = "Requisitions";
+	gender = "female"
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/req)
@@ -48918,11 +48914,7 @@
 /area/almayer/shipboard/panic)
 "qmP" = (
 /obj/structure/surface/table/almayer,
-/obj/structure/machinery/faxmachine/uscm{
-	desc = "The beloved fax machine of the requisitions department, for all your equipment-requesting needs";
-	gender = "female";
-	department = "Requisitions"
-	},
+/obj/structure/machinery/faxmachine/uscm,
 /turf/open/floor/almayer,
 /area/almayer/command/computerlab)
 "qmR" = (
@@ -62998,6 +62990,9 @@
 	},
 /obj/structure/sign/prop3{
 	pixel_x = -32
+	},
+/obj/structure/machinery/faxmachine/uscm{
+	department = "SEA"
 	},
 /turf/open/floor/strata/faux_metal,
 /area/almayer/shipboard/sea_office)

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -9046,7 +9046,11 @@
 "blw" = (
 /obj/structure/surface/table/almayer,
 /obj/item/tool/lighter,
-/obj/structure/machinery/faxmachine/uscm,
+/obj/structure/machinery/faxmachine/uscm{
+	desc = The beloved fax machine of the Requisitions department. Be sure to make a convincing argument when you ask high command for a crate of lunge mines.;
+	gender = "female";
+	department = "Requisitions"
+	},
 /obj/structure/machinery/light{
 	dir = 1
 	},
@@ -20621,13 +20625,16 @@
 /area/almayer/shipboard/brig/cic_hallway)
 "eAG" = (
 /obj/structure/surface/table/almayer,
-/obj/item/storage/firstaid/regular,
-/obj/item/clipboard,
 /obj/item/tool/pen{
 	pixel_y = -17
 	},
 /obj/item/paper_bin/uscm{
 	pixel_y = -16
+	},
+/obj/structure/machinery/faxmachine/uscm{
+	desc = The beloved fax machine of the Requisitions department. Be sure to make a convincing argument when you ask high command for a crate of lunge mines.;
+	gender = "female";
+	department = "Requisitions"
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/req)
@@ -48133,6 +48140,11 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/structure/machinery/faxmachine/uscm{
+	desc = The beloved fax machine of the Requisitions department. Be sure to make a convincing argument when you ask high command for a crate of lunge mines.;
+	gender = "female";
+	department = "Requisitions"
+	},
 /turf/open/floor/almayer/plating/northeast,
 /area/almayer/squads/req)
 "pXZ" = (
@@ -48911,7 +48923,11 @@
 /area/almayer/shipboard/panic)
 "qmP" = (
 /obj/structure/surface/table/almayer,
-/obj/structure/machinery/faxmachine/uscm,
+/obj/structure/machinery/faxmachine/uscm{
+	desc = The beloved fax machine of the Requisitions department. Be sure to make a convincing argument when you ask high command for a crate of lunge mines.;
+	gender = "female";
+	department = "Requisitions"
+	},
 /turf/open/floor/almayer,
 /area/almayer/command/computerlab)
 "qmR" = (

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -9047,7 +9047,7 @@
 /obj/structure/surface/table/almayer,
 /obj/item/tool/lighter,
 /obj/structure/machinery/faxmachine/uscm{
-	desc = The beloved fax machine of the Requisitions department. Be sure to make a convincing argument when you ask high command for a crate of lunge mines.;
+	desc = "The beloved fax machine of the requisitions department, for all your equipment-requesting needs";
 	gender = "female";
 	department = "Requisitions"
 	},
@@ -20632,7 +20632,7 @@
 	pixel_y = -16
 	},
 /obj/structure/machinery/faxmachine/uscm{
-	desc = The beloved fax machine of the Requisitions department. Be sure to make a convincing argument when you ask high command for a crate of lunge mines.;
+	desc = "The beloved fax machine of the requisitions department, for all your equipment-requesting needs";
 	gender = "female";
 	department = "Requisitions"
 	},
@@ -48141,7 +48141,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/machinery/faxmachine/uscm{
-	desc = The beloved fax machine of the Requisitions department. Be sure to make a convincing argument when you ask high command for a crate of lunge mines.;
+	desc = "The beloved fax machine of the requisitions department, for all your equipment-requesting needs";
 	gender = "female";
 	department = "Requisitions"
 	},
@@ -48924,7 +48924,7 @@
 "qmP" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/faxmachine/uscm{
-	desc = The beloved fax machine of the Requisitions department. Be sure to make a convincing argument when you ask high command for a crate of lunge mines.;
+	desc = "The beloved fax machine of the requisitions department, for all your equipment-requesting needs";
 	gender = "female";
 	department = "Requisitions"
 	},
@@ -63003,9 +63003,6 @@
 	},
 /obj/structure/sign/prop3{
 	pixel_x = -32
-	},
-/obj/structure/machinery/faxmachine/uscm{
-	department = "SEA"
 	},
 /turf/open/floor/strata/faux_metal,
 /area/almayer/shipboard/sea_office)


### PR DESCRIPTION

# About the pull request

Adds a fax machine to requisitions

# Explain why it's good for the game

I've always found it weird how an entire department doesn't have a singular fax machine. Especially since req can use them to ask for unique equipment, which they currently have to do via the public fax machine In the meeting hall.

# Testing Photographs and Procedure
<details>
<summary>

![image](https://github.com/user-attachments/assets/0bb32e94-0d25-42b0-b4ca-c2644051ce95)

</summary>


</details>


# Changelog
:cl:
add: Added a fax machine to requisitions. It's a girl, by the way.
/:cl:
