### PR TITLE
Early Game: Remote Queen Building Buff.

### DIFF
--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -46,16 +46,25 @@
 	return ..()
 
 /obj/structure/mineral_door/proc/TryToSwitchState(atom/user)
-	if(isSwitchingStates) return
-	if(ismob(user))
-		var/mob/M = user
-		if(M.client)
-			if(iscarbon(M))
-				var/mob/living/carbon/C = M
-				if(!C.handcuffed)
-					SwitchState()
-			else
-				SwitchState()
+	if(isSwitchingStates)
+		return FALSE
+	if(!ismob(user))
+		return FALSE
+
+	var/mob/user_mob = user
+	if(!user_mob.client)
+		return FALSE
+
+	if(iscarbon(user_mob))
+		var/mob/living/carbon/user_carbon = user_mob
+		if(!user_carbon.handcuffed)
+			SwitchState()
+			return TRUE
+	else
+		SwitchState()
+		return TRUE
+
+	return FALSE
 
 /obj/structure/mineral_door/proc/SwitchState()
 	if(open)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_abilities.dm
@@ -85,8 +85,7 @@
 		xeno_cooldown = 0
 		plasma_cost = 0
 		build_speed_mod = 1
-		// Allow queen to remotely thicken structures.
-		thick = TRUE
+		thick = TRUE // Allow queen to remotely thicken structures.
 		RegisterSignal(owner, COMSIG_XENO_THICK_RESIN_BYPASS, PROC_REF(override_secrete_thick_resin))
 		addtimer(CALLBACK(src, PROC_REF(disable_boost)), boost_duration)
 
@@ -94,8 +93,7 @@
 	xeno_cooldown = 4 SECONDS
 	plasma_cost = 100
 	boosted = FALSE
-	// Boost Ended, remove remote wall thickening.
-	thick = FALSE // Assuming `owner` is the queen, this resets the thick status
+	thick = FALSE
 	UnregisterSignal(owner, COMSIG_XENO_THICK_RESIN_BYPASS)
 
 	if(owner)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_abilities.dm
@@ -85,6 +85,8 @@
 		xeno_cooldown = 0
 		plasma_cost = 0
 		build_speed_mod = 1
+		// Allow queen to remotely thicken structures.
+		thick = TRUE
 		RegisterSignal(owner, COMSIG_XENO_THICK_RESIN_BYPASS, PROC_REF(override_secrete_thick_resin))
 		addtimer(CALLBACK(src, PROC_REF(disable_boost)), boost_duration)
 
@@ -92,6 +94,8 @@
 	xeno_cooldown = 4 SECONDS
 	plasma_cost = 100
 	boosted = FALSE
+	// Boost Ended, remove remote wall thickening.
+	thick = FALSE // Assuming `owner` is the queen, this resets the thick status
 	UnregisterSignal(owner, COMSIG_XENO_THICK_RESIN_BYPASS)
 
 	if(owner)

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/hivelord/resin_whisperer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/hivelord/resin_whisperer.dm
@@ -77,14 +77,16 @@
 		return
 
 	/// Check if the target is a resin door and open or close it
+
 	if(istype(target_atom, /obj/structure/mineral_door/resin))
-		var/obj/structure/mineral_door/resin/resin_door = target_atom
-		resin_door.TryToSwitchState(owner)
-		if(resin_door.open)
-			to_chat(owner, SPAN_XENONOTICE("We focus our connection to the resin and remotely close the resin door."))
-		else
-			to_chat(owner, SPAN_XENONOTICE("We focus our connection to the resin and remotely open the resin door."))
-		return
+		if(!(thick))
+			var/obj/structure/mineral_door/resin/resin_door = target_atom
+			resin_door.TryToSwitchState(owner)
+			if(resin_door.open)
+				to_chat(owner, SPAN_XENONOTICE("We focus our connection to the resin and remotely close the resin door."))
+			else
+				to_chat(owner, SPAN_XENONOTICE("We focus our connection to the resin and remotely open the resin door."))
+			return
 
 	// since actions are instanced per hivelord, and only one construction can be made at a time, tweaking the datum on the fly here is fine. you're going to have to figure something out if these conditions change, though
 	if(care_about_adjacency)

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/hivelord/resin_whisperer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/hivelord/resin_whisperer.dm
@@ -79,13 +79,14 @@
 	/// Check if the target is a resin door and open or close it
 
 	if(istype(target_atom, /obj/structure/mineral_door/resin))
-		if(!(thick))
+		// Either we can't remotely reinforce the door, or its already reinforced
+		if(!thick || istype(target_atom, /obj/structure/mineral_door/resin/thick))
 			var/obj/structure/mineral_door/resin/resin_door = target_atom
-			resin_door.TryToSwitchState(owner)
-			if(resin_door.open)
-				to_chat(owner, SPAN_XENONOTICE("We focus our connection to the resin and remotely close the resin door."))
-			else
-				to_chat(owner, SPAN_XENONOTICE("We focus our connection to the resin and remotely open the resin door."))
+			if(resin_door.TryToSwitchState(owner))
+				if(resin_door.open)
+					to_chat(owner, SPAN_XENONOTICE("We focus our connection to the resin and remotely close the resin door."))
+				else
+					to_chat(owner, SPAN_XENONOTICE("We focus our connection to the resin and remotely open the resin door."))
 			return
 
 	// since actions are instanced per hivelord, and only one construction can be made at a time, tweaking the datum on the fly here is fine. you're going to have to figure something out if these conditions change, though


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Give Queen ability to remote "Thicken" walls during first 30min of game.

# Explain why it's good for the game

When game starts, and people want to do Hive reinfocement as drones, they are not allowed by queens (most of time) to build inside hive, its because queen cannot make them "Thicker" and often lack of people going hivelord to do that, queen most of time chooses to do it by itself, slowing down creation of early game defences, this PR aim to change that, now queen can remote upgrade structures for first 30min of buff duration, this should make people doing "Drone Tax" and want to contribute to hive building be actually usefull, instead of be seen as "obstacles".

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Click HERE to see video:</summary>

My cute drones builded hive for me! lets apprieciete their hard work by upgrading it!

https://github.com/user-attachments/assets/7b27549f-c869-48df-a1d0-fe377a31e0e2


</details>


# Changelog

:cl: Venuska1117, Drathek
balance: Early game Queen Building Buff, now allows queen to upgrade structures to "Thicker" version.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
