### PR TITLE
Door Stuck Pt2: Fix doors thinking the doors are blocking the doors

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -251,7 +251,7 @@
 
 	for(var/turf/turf_tile in locs)
 		for(var/obj/structure/blocking_structure in turf_tile)
-			if(blocking_structure.density || istype(blocking_structure, /obj/structure/closet))
+			if((blocking_structure.density && blocking_structure != src) || istype(blocking_structure, /obj/structure/closet))
 				addtimer(CALLBACK(src, PROC_REF(close), forced), 6 SECONDS + openspeed, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 				return FALSE
 


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #7727 where a check to prevent closing doors was added, but this meant that the doors would be blocking the doors from closing when trying to be forced closed...

# Explain why it's good for the game

We want #7709 to remain fixed.

# Changelog
:cl: Drathek
fix: Fix airlock door spam allowing doors to remain open again
/:cl:
