### PR TITLE
Fixes egg morpher not hugging in certain situations

### DIFF
--- a/code/modules/cm_aliens/structures/special/egg_morpher.dm
+++ b/code/modules/cm_aliens/structures/special/egg_morpher.dm
@@ -223,11 +223,11 @@
 
 		to_chat(M, SPAN_XENONOTICE("You retrieve a child."))
 		stored_huggers = max(0, stored_huggers - 1)
+		if(stored_huggers == 0)
+			hide_egg_triggers()
 		var/obj/item/clothing/mask/facehugger/hugger = new(loc, linked_hive.hivenumber)
 		SEND_SIGNAL(M, COMSIG_XENO_TAKE_HUGGER_FROM_MORPHER, hugger)
 		return XENO_NONCOMBAT_ACTION
-		if(stored_huggers == 0)
-			hide_egg_triggers()
 	..()
 
 /obj/effect/alien/resin/special/eggmorph/attack_ghost(mob/dead/observer/user)

--- a/code/modules/cm_aliens/structures/special/egg_morpher.dm
+++ b/code/modules/cm_aliens/structures/special/egg_morpher.dm
@@ -127,6 +127,9 @@
 
 	HasProximity(target)
 
+/obj/effect/alien/resin/special/eggmorph/Crossed(atom/movable/AM)
+	HasProximity(AM)
+
 /obj/effect/alien/resin/special/eggmorph/HasProximity(atom/movable/AM as mob|obj)
 	if(!stored_huggers || issynth(AM))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Egg morpher was not hugging someone when a xeno dragged them one tile away (but was hugging when the huggable person moved themselves there). It was also not hugging when the victim was regurgitated directly onto the morpher. This makes it hug in those situations (assuming morpher has huggers). This doesn't fix all morpher/egg bugs but it's better than nothing.

# Explain why it's good for the game

Fixes bugs.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: fixes egg morpher not hugging when a xeno drags a victim one tile away or regurgitates them directly onto the morpher
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
