### PR TITLE
Guest Pass Terminal Removal

### DIFF
--- a/maps/map_files/CORSAT/Corsat.dmm
+++ b/maps/map_files/CORSAT/Corsat.dmm
@@ -2269,7 +2269,6 @@
 "aiR" = (
 /obj/structure/surface/table/reinforced,
 /obj/structure/machinery/computer/card,
-/obj/structure/machinery/computer/guestpass,
 /turf/open/floor/corsat/red/northeast,
 /area/corsat/gamma/hangar/security)
 "aiS" = (
@@ -6108,7 +6107,6 @@
 /area/corsat/sigma/hangar/id)
 "ayr" = (
 /obj/structure/surface/table/reinforced,
-/obj/structure/machinery/computer/guestpass,
 /obj/structure/machinery/light{
 	dir = 1
 	},
@@ -6840,7 +6838,6 @@
 /area/corsat/sigma/airlock/south)
 "aAS" = (
 /obj/structure/surface/table/reinforced,
-/obj/structure/machinery/computer/guestpass,
 /turf/open/floor/corsat/red/east,
 /area/corsat/gamma/hangar/security)
 "aAT" = (
@@ -14652,9 +14649,6 @@
 /area/corsat/sigma/hangar/security)
 "bcw" = (
 /obj/structure/surface/table/reinforced,
-/obj/structure/machinery/computer/guestpass{
-	dir = 1
-	},
 /obj/structure/machinery/light,
 /turf/open/floor/corsat/redcorner,
 /area/corsat/sigma/hangar/checkpoint)
@@ -22197,7 +22191,6 @@
 /area/corsat/gamma/engineering)
 "bJx" = (
 /obj/structure/surface/table/reinforced,
-/obj/structure/machinery/computer/guestpass,
 /turf/open/floor/corsat/red/north,
 /area/corsat/gamma/hangar/cargo)
 "bJA" = (
@@ -24329,7 +24322,6 @@
 /area/corsat/sigma/hangar/checkpoint)
 "bSK" = (
 /obj/structure/surface/table/reinforced,
-/obj/structure/machinery/computer/guestpass,
 /turf/open/floor/corsat/redcorner,
 /area/corsat/sigma/hangar/checkpoint)
 "bSM" = (
@@ -25801,9 +25793,6 @@
 "bZz" = (
 /obj/structure/machinery/light,
 /obj/structure/surface/table/reinforced,
-/obj/structure/machinery/computer/guestpass{
-	dir = 1
-	},
 /turf/open/floor/corsat/red,
 /area/corsat/gamma/hangar/cargo)
 "bZD" = (
@@ -36155,9 +36144,6 @@
 /area/corsat/sigma/biodome)
 "mJm" = (
 /obj/structure/surface/table/reinforced,
-/obj/structure/machinery/computer/guestpass{
-	reason = "Visitor"
-	},
 /turf/open/floor/corsat/purplewhite/west,
 /area/corsat/theta/biodome/complex)
 "mJq" = (

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -3249,7 +3249,6 @@
 /area/desert_dam/exterior/valley/bar_valley_dam)
 "aoA" = (
 /obj/structure/surface/table/reinforced,
-/obj/structure/machinery/computer/guestpass,
 /turf/open/floor/prison/darkred2/north,
 /area/desert_dam/interior/lab_northeast/east_lab_security_armory)
 "aoB" = (
@@ -4066,11 +4065,6 @@
 "asg" = (
 /turf/open/floor/prison/darkbrown2/northwest,
 /area/desert_dam/interior/dam_interior/hanger)
-"asm" = (
-/obj/structure/surface/table/reinforced,
-/obj/structure/machinery/computer/guestpass,
-/turf/open/floor/prison/darkred2/west,
-/area/desert_dam/interior/lab_northeast/east_lab_security_armory)
 "asn" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison/bright_clean/southwest,
@@ -5529,7 +5523,6 @@
 /area/desert_dam/interior/lab_northeast/east_lab_RND)
 "ayF" = (
 /obj/structure/surface/table,
-/obj/structure/machinery/computer/guestpass,
 /turf/open/floor/prison/blue/north,
 /area/desert_dam/interior/lab_northeast/east_lab_RND)
 "ayG" = (
@@ -35004,7 +34997,6 @@
 /turf/open/floor/carpet15_15/west,
 /area/desert_dam/building/administration/office)
 "duo" = (
-/obj/structure/machinery/computer/guestpass,
 /obj/structure/surface/table/woodentable/fancy,
 /turf/open/floor/carpet11_12/west,
 /area/desert_dam/building/administration/office)
@@ -35087,7 +35079,6 @@
 /turf/open/floor/wood,
 /area/desert_dam/building/administration/office)
 "duV" = (
-/obj/structure/machinery/computer/guestpass,
 /obj/structure/machinery/light{
 	dir = 1
 	},
@@ -98796,7 +98787,7 @@ apn
 aqQ
 ark
 aqk
-asm
+aqL
 asH
 anQ
 auF

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -18657,7 +18657,6 @@
 /area/fiorina/tumor/ice_lab)
 "omb" = (
 /obj/structure/surface/table/woodentable/fancy,
-/obj/structure/machinery/computer/guestpass,
 /turf/open/floor/carpet,
 /area/fiorina/station/security/wardens)
 "omh" = (
@@ -26753,14 +26752,6 @@
 	},
 /turf/open/floor/prison/floor_plate,
 /area/fiorina/tumor/aux_engi)
-"uEh" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/structure/machinery/computer/guestpass{
-	dir = 4;
-	reason = "Visitor"
-	},
-/turf/open/floor/prison/bluefull,
-/area/fiorina/station/power_ring)
 "uEj" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating/prison,
@@ -66468,7 +66459,7 @@ oMW
 goG
 dYq
 chg
-uEh
+chg
 gZx
 goG
 fAf

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -12827,9 +12827,6 @@
 /turf/open/auto_turf/sand/layer1,
 /area/kutjevo/exterior/lz_dunes)
 "tMH" = (
-/obj/structure/machinery/computer/guestpass{
-	dir = 4
-	},
 /obj/structure/surface/table/reinforced/prison,
 /turf/open/floor/kutjevo/colors/red,
 /area/kutjevo/interior/complex/med)
@@ -14861,10 +14858,6 @@
 "wXV" = (
 /obj/structure/window/reinforced{
 	dir = 8
-	},
-/obj/structure/machinery/computer/guestpass{
-	dir = 4;
-	pixel_y = 7
 	},
 /obj/structure/machinery/computer/cameras{
 	dir = 4;

--- a/maps/map_files/New_Varadero/New_Varadero.dmm
+++ b/maps/map_files/New_Varadero/New_Varadero.dmm
@@ -10629,9 +10629,6 @@
 /area/varadero/exterior/lz2_near)
 "iFm" = (
 /obj/structure/surface/table/reinforced/prison,
-/obj/structure/machinery/computer/guestpass{
-	dir = 1
-	},
 /obj/item/ammo_magazine/shotgun/buckshot{
 	pixel_x = 17;
 	pixel_y = -4
@@ -27752,9 +27749,6 @@
 /area/varadero/exterior/farocean)
 "wfS" = (
 /obj/structure/surface/table/reinforced/prison,
-/obj/structure/machinery/computer/guestpass{
-	dir = 1
-	},
 /obj/item/card/id/silver/clearance_badge{
 	pixel_x = 14
 	},

--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -2015,11 +2015,6 @@
 /obj/structure/surface/table/reinforced/prison,
 /turf/open/floor/strata/red1,
 /area/strata/ug/interior/jungle/structures/research)
-"aii" = (
-/obj/structure/machinery/computer/guestpass,
-/obj/structure/surface/table/reinforced/prison,
-/turf/open/floor/strata/red1,
-/area/strata/ug/interior/jungle/structures/research)
 "aij" = (
 /obj/item/device/flashlight/lamp,
 /obj/structure/surface/table/reinforced/prison,
@@ -13105,10 +13100,6 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 1
 	},
-/obj/structure/machinery/computer/guestpass{
-	dir = 4;
-	reason = "Visitor"
-	},
 /obj/structure/surface/table/reinforced/prison,
 /turf/open/floor/strata/blue1,
 /area/strata/ag/interior/outside/administration)
@@ -19405,7 +19396,6 @@
 /area/strata/ag/exterior/landing_zones/near_lz2)
 "eNz" = (
 /obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/guestpass,
 /turf/open/floor/strata/red1,
 /area/strata/ag/interior/outside/checkpoints/north)
 "eNF" = (
@@ -71063,7 +71053,7 @@ bon
 bon
 bon
 adz
-aii
+aeB
 aiV
 ajC
 aiV


### PR DESCRIPTION


# Guest Pass Terminal Removal

This PR aims to remove the guest pass terminals from every map they occur in. 

# Explain why it's good for the game

Ingame shenanigans bad.


# Testing Photographs and Procedure
N/A



<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog



:cl:

maptweak: Removed all guest pass terminals

/:cl:
