### PR TITLE
Door Stuck Pt3: Shutter Handling

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -9,6 +9,8 @@
 	throwpass = FALSE
 	layer = DOOR_OPEN_LAYER
 	minimap_color = MINIMAP_DOOR
+	dir = EAST //So multitile doors are directioned properly
+
 	var/open_layer = DOOR_OPEN_LAYER
 	var/closed_layer = DOOR_CLOSED_LAYER
 	var/id = ""
@@ -31,7 +33,6 @@
 	/// Resistance to masterkey
 	var/masterkey_resist = FALSE
 	var/masterkey_mod = 0.1
-	dir = EAST //So multitile doors are directioned properly
 
 /obj/structure/machinery/door/Initialize(mapload, ...)
 	. = ..()
@@ -251,9 +252,16 @@
 
 	for(var/turf/turf_tile in locs)
 		for(var/obj/structure/blocking_structure in turf_tile)
-			if((blocking_structure.density && blocking_structure != src) || istype(blocking_structure, /obj/structure/closet))
-				addtimer(CALLBACK(src, PROC_REF(close), forced), 6 SECONDS + openspeed, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
-				return FALSE
+			if(blocking_structure == src)
+				continue // Don't block ourselves (only applicable when opening)
+			if(!blocking_structure.density && !istype(blocking_structure, /obj/structure/closet))
+				continue // Don't block if non-dense and not a closet (they toggle density)
+			if(blocking_structure.anchored && istype(blocking_structure, /obj/structure/machinery/door))
+				continue // Don't block because of other doors (shutters) also in this location
+
+			// Try again later
+			addtimer(CALLBACK(src, PROC_REF(close), forced), 6 SECONDS + openspeed, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
+			return FALSE
 
 	operating = DOOR_OPERATING_CLOSING
 	density = TRUE


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #7749 and #7727 adding another exemption to what should not block a door closing: shutters. I am assuming any anchored door in the locs of the door can be deemed a shutter, but need be we can explicitly check for pod doors.

# Explain why it's good for the game

Fixes #7769 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/5TWtsn3tDX4

</details>


# Changelog
:cl: Drathek
fix: Fixed doors considering shutters as blocking
/:cl:
