### PR TITLE
Queen cannot forfeit in a tunnel

### DIFF
--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -53,7 +53,6 @@ Additional game mode variables.
 	var/xeno_required_num = 0 //We need at least one. You can turn this off in case we don't care if we spawn or don't spawn xenos.
 	var/xeno_starting_num = 0 //To clamp starting xenos.
 	var/xeno_bypass_timer = 0 //Bypass the five minute timer before respawning.
-	var/xeno_queen_deaths = 0 //How many times the alien queen died.
 	var/surv_starting_num = 0 //To clamp starting survivors.
 	var/merc_starting_num = 0 //PMC clamp.
 	var/marine_starting_num = 0 //number of players not in something special

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -521,22 +521,39 @@
 	else if(!num_humans && !num_xenos)
 		round_finished = MODE_INFESTATION_DRAW_DEATH //Both were somehow destroyed.
 
+/datum/game_mode/colonialmarines/count_humans_and_xenos(list/z_levels)
+	. = ..()
+	if(.[2] != 0) // index 2 = num_xenos
+		return .
+
+	// Ensure there is no queen
+	var/datum/hive_status/hive
+	for(var/hive_number in GLOB.hive_datum)
+		hive = GLOB.hive_datum[hive_number]
+		if(hive.living_xeno_queen && !should_block_game_interaction(hive.living_xeno_queen.loc))
+			//Some Queen is alive, we shouldn't end the game yet
+			.[2]++
+	return .
+
 /datum/game_mode/colonialmarines/check_queen_status(hivenumber)
 	set waitfor = 0
-	if(!(flags_round_type & MODE_INFESTATION)) return
+
+	if(!(flags_round_type & MODE_INFESTATION))
+		return
+
 	xeno_queen_deaths++
 	var/num_last_deaths = xeno_queen_deaths
 	sleep(QUEEN_DEATH_COUNTDOWN)
 	//We want to make sure that another queen didn't die in the interim.
 
 	if(xeno_queen_deaths == num_last_deaths && !round_finished)
-		var/datum/hive_status/HS
-		for(var/HN in GLOB.hive_datum)
-			HS = GLOB.hive_datum[HN]
-			if(HS.living_xeno_queen && !should_block_game_interaction(HS.living_xeno_queen.loc))
+		var/datum/hive_status/hive
+		for(var/hive_number in GLOB.hive_datum)
+			hive = GLOB.hive_datum[hive_number]
+			if(hive.living_xeno_queen && !should_block_game_interaction(hive.living_xeno_queen.loc))
 				//Some Queen is alive, we shouldn't end the game yet
 				return
-		if(length(HS.totalXenos) <= 3)
+		if(length(hive.totalXenos) <= 3)
 			round_finished = MODE_INFESTATION_M_MAJOR
 		else
 			round_finished = MODE_INFESTATION_M_MINOR

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -528,35 +528,43 @@
 
 	// Ensure there is no queen
 	var/datum/hive_status/hive
-	for(var/hive_number in GLOB.hive_datum)
-		hive = GLOB.hive_datum[hive_number]
+	for(var/cur_number in GLOB.hive_datum)
+		hive = GLOB.hive_datum[cur_number]
+		if(hive.need_round_end_check && !hive.can_delay_round_end())
+			continue
 		if(hive.living_xeno_queen && !should_block_game_interaction(hive.living_xeno_queen.loc))
 			//Some Queen is alive, we shouldn't end the game yet
 			.[2]++
 	return .
 
-/datum/game_mode/colonialmarines/check_queen_status(hivenumber)
-	set waitfor = 0
-
+/datum/game_mode/colonialmarines/check_queen_status(hivenumber, immediately = FALSE)
 	if(!(flags_round_type & MODE_INFESTATION))
 		return
 
-	xeno_queen_deaths++
-	var/num_last_deaths = xeno_queen_deaths
-	sleep(QUEEN_DEATH_COUNTDOWN)
-	//We want to make sure that another queen didn't die in the interim.
+	var/datum/hive_status/hive = GLOB.hive_datum[hivenumber]
+	if(hive.need_round_end_check && !hive.can_delay_round_end())
+		return
 
-	if(xeno_queen_deaths == num_last_deaths && !round_finished)
-		var/datum/hive_status/hive
-		for(var/hive_number in GLOB.hive_datum)
-			hive = GLOB.hive_datum[hive_number]
-			if(hive.living_xeno_queen && !should_block_game_interaction(hive.living_xeno_queen.loc))
-				//Some Queen is alive, we shouldn't end the game yet
-				return
-		if(length(hive.totalXenos) <= 3)
-			round_finished = MODE_INFESTATION_M_MAJOR
-		else
-			round_finished = MODE_INFESTATION_M_MINOR
+	if(!immediately)
+		//We want to make sure that another queen didn't die in the interim.
+		addtimer(CALLBACK(src, PROC_REF(check_queen_status), hivenumber, TRUE), QUEEN_DEATH_COUNTDOWN, TIMER_UNIQUE|TIMER_OVERRIDE)
+		return
+
+	if(round_finished)
+		return
+
+	for(var/cur_number in GLOB.hive_datum)
+		hive = GLOB.hive_datum[cur_number]
+		if(hive.need_round_end_check && !hive.can_delay_round_end())
+			continue
+		if(hive.living_xeno_queen && !should_block_game_interaction(hive.living_xeno_queen.loc))
+			//Some Queen is alive, we shouldn't end the game yet
+			return
+
+	if(length(hive.totalXenos) <= 3)
+		round_finished = MODE_INFESTATION_M_MAJOR
+	else
+		round_finished = MODE_INFESTATION_M_MINOR
 
 ///////////////////////////////
 //Checks if the round is over//


### PR DESCRIPTION

# About the pull request

This PR adds an exception to the xeno count for distress signal where if no xenos were counted, then the living queen(s) are checked. I also fixed/refactored check_queen_status (used to check if xenos fail to evolve to queen in 10 minutes) to properly check hives that would count towards round.

# Explain why it's good for the game

Fixes #7762

Doesn't make any sense why a queen would cower in a tunnel in hopes of making the marines go away. But it is likely if the hive is abandoning the old hive core they could potentially all be in a tunnel and mistakenly trigger this.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/b2697343-4a2c-4ab7-8e78-6a03f885eaf8)

</details>


# Changelog
:cl:
balance: Queen prevents round end even when in a tunnel
fix: Fixed check_queen_status checking any queen not just queens that matter to round end
/:cl:
