### PR TITLE
Fix typo in king roar ability

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/king/king_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/king/king_powers.dm
@@ -39,7 +39,7 @@
 	XENO_ACTION_CHECK_USE_PLASMA(xeno)
 
 	playsound(xeno, 'sound/voice/deep_alien_screech2.ogg', 75, 0, status = 0)
-	xeno.visible_message(SPAN_XENOHIGHDANGER("[xeno] emits an raspy guttural roar!"))
+	xeno.visible_message(SPAN_XENOHIGHDANGER("[xeno] emits a raspy guttural roar!"))
 	xeno.create_shriekwave()
 
 	var/datum/effect_system/smoke_spread/king_doom/smoke_gas = new()


### PR DESCRIPTION
# About the pull request
fixes a typo in king roar ability
from "Emits an raspy guttural roar" to "Emits a raspy guttural roar"


# Explain why it's good for the game

bug


# Testing Photographs and Procedure

# Changelog

:cl:
spellcheck: fixed a 1 letter typo in king ability
/:cl:
