### PR TITLE
Fix gamemode runtimes

### DIFF
--- a/code/controllers/subsystem/item_cleanup.dm
+++ b/code/controllers/subsystem/item_cleanup.dm
@@ -40,21 +40,31 @@ SUBSYSTEM_DEF(item_cleanup)
 
 	log_debug("item_cleanup deleted [deleted] garbage out of total [total_items]")
 
-/datum/controller/subsystem/item_cleanup/proc/delete_almayer()
-	//Should only be called for Whiskey Outpost!
+/datum/controller/subsystem/item_cleanup/proc/delete_almayer(ensure_observer_landmark_ground = TRUE)
 	delete_z_level(SSmapping.levels_by_trait(ZTRAIT_MARINE_MAIN_SHIP))
+	if(ensure_observer_landmark_ground && !length(GLOB.observer_starts))
+		var/turf/center = SSmapping.get_ground_center()
+		new /obj/effect/landmark/observer_start(center)
 
-/datum/controller/subsystem/item_cleanup/proc/delete_surface()
+/datum/controller/subsystem/item_cleanup/proc/delete_surface(ensure_observer_landmark_ship = TRUE)
 	//Should only be called when lag is really bad and everyone is off the surface, including the dropships
 	delete_z_level(SSmapping.levels_by_trait(ZTRAIT_GROUND))
+	if(ensure_observer_landmark_ship && !length(GLOB.observer_starts))
+		var/turf/center = SSmapping.get_mainship_center()
+		new /obj/effect/landmark/observer_start(center)
 
 /datum/controller/subsystem/item_cleanup/proc/delete_z_level(list/z_levels)
 	set background = 1
-	for(var/obj/o in world)
-		if(QDELETED(o) || isnull(o.loc))
+	for(var/obj/thing in world)
+		if(QDELETED(thing) || isnull(thing.loc))
 			continue
-		if(o.loc.z in z_levels) //item is on the proper Z-level
-			qdel(o)
+		if(thing.loc.z in z_levels) //obj is on the proper Z-level
+			qdel(thing)
+	for(var/mob/moob as anything in GLOB.living_mob_list)
+		if(QDELETED(moob) || isnull(moob.loc))
+			continue
+		if(moob.loc.z in z_levels) //living mob is on the proper Z-level
+			qdel(moob)
 
 /proc/add_to_garbage(atom/a)
 	addToListNoDupe(GLOB.item_cleanup_list, a)

--- a/code/modules/mapping/space_management/traits.dm
+++ b/code/modules/mapping/space_management/traits.dm
@@ -76,3 +76,8 @@
 /datum/controller/subsystem/mapping/proc/get_mainship_center()
 	var/mainship_z = levels_by_trait(ZTRAIT_MARINE_MAIN_SHIP)[1]
 	return locate(round(world.maxx * 0.5, 1), round(world.maxy * 0.5, 1), mainship_z)
+
+// Prefer not to use this one too often
+/datum/controller/subsystem/mapping/proc/get_ground_center()
+	var/ground_z = levels_by_trait(ZTRAIT_GROUND)[1]
+	return locate(round(world.maxx * 0.5, 1), round(world.maxy * 0.5, 1), ground_z)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -255,7 +255,7 @@
 
 	if(!client.prefs?.preview_dummy)
 		client.prefs.update_preview_icon()
-	var/mob/dead/observer/observer = new(get_turf(pick(GLOB.latejoin)), client.prefs.preview_dummy)
+	var/mob/dead/observer/observer = new(get_turf(pick(GLOB.observer_starts + GLOB.latejoin)), client.prefs.preview_dummy)
 	observer.set_lighting_alpha_from_pref(client)
 	spawning = TRUE
 	observer.started_as_observer = TRUE
@@ -267,7 +267,7 @@
 		to_chat(src, SPAN_NOTICE("Now teleporting."))
 		observer.forceMove(spawn_point.loc)
 	else
-		to_chat(src, SPAN_DANGER("Could not locate an observer spawn point. Use the Teleport verb to jump to the station map."))
+		to_chat(src, SPAN_DANGER("Could not locate an observer spawn point. Use the Teleport verbs to jump if needed."))
 	observer.icon = 'icons/mob/humans/species/r_human.dmi'
 	observer.icon_state = "anglo_example"
 	observer.alpha = 127

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -27,9 +27,11 @@
 
 /datum/internal_organ/process()
 	if(!owner && !organ_holder)
+		if(QDELETED(src))
+			stack_trace("[src] is still processing without an owner nor an organ_holder!")
+			return PROCESS_KILL
 		qdel(src)
-
-	return FALSE
+		return PROCESS_KILL
 
 /datum/internal_organ/proc/rejuvenate()
 	damage=0
@@ -147,7 +149,10 @@
 	robotic_type = /obj/item/organ/lungs/prosthetic
 
 /datum/internal_organ/lungs/process()
-	..()
+	. = ..()
+	if(. == PROCESS_KILL)
+		return // Parent implemention qdeleted us
+
 	if(owner.chem_effect_flags & CHEM_EFFECT_ORGAN_STASIS)
 		return
 	if(organ_status >= ORGAN_BRUISED)
@@ -174,7 +179,9 @@
 	robotic_type = /obj/item/organ/liver/prosthetic
 
 /datum/internal_organ/liver/process()
-	..()
+	. = ..()
+	if(. == PROCESS_KILL)
+		return // Parent implemention qdeleted us
 
 	if(owner.life_tick % PROCESS_ACCURACY == 0)
 
@@ -232,7 +239,10 @@
 	robotic_type = /obj/item/organ/kidneys/prosthetic
 
 /datum/internal_organ/kidneys/process()
-	..()
+	. = ..()
+	if(. == PROCESS_KILL)
+		return // Parent implemention qdeleted us
+
 	//Deal toxin damage if damaged
 	if(owner.chem_effect_flags & CHEM_EFFECT_ORGAN_STASIS)
 		return
@@ -254,7 +264,9 @@
 	vital = 1
 
 /datum/internal_organ/brain/process(delta_time)
-	..()
+	. = ..()
+	if(. == PROCESS_KILL)
+		return // Parent implemention qdeleted us
 
 	if(owner.chem_effect_flags & CHEM_EFFECT_ORGAN_STASIS)
 		return
@@ -289,8 +301,12 @@
 
 /datum/internal_organ/eyes/process() //Eye damage replaces the old eye_stat var.
 	. = ..()
+	if(. == PROCESS_KILL)
+		return // Parent implemention qdeleted us
+
 	if(owner.chem_effect_flags & CHEM_EFFECT_ORGAN_STASIS)
 		return
+
 	if(organ_status >= ORGAN_BRUISED)
 		owner.SetEyeBlur(20)
 	if(organ_status >= ORGAN_BROKEN)
@@ -312,6 +328,11 @@
 	return removed_organ
 
 /datum/internal_organ/Destroy()
+	if(owner)
+		owner.internal_organs -= src
+		for(var/organ_name in owner.internal_organs_by_name)
+			if(owner.internal_organs_by_name[organ_name] == src)
+				owner.internal_organs_by_name -= organ_name
 	owner = null
 	organ_holder = null
 

--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -189,7 +189,7 @@
 
 /obj/docking_port/mobile/marine_dropship/proc/automated_check()
 	var/obj/structure/machinery/computer/shuttle/dropship/flight/root_console = getControlConsole()
-	if(root_console.dropship_control_lost)
+	if(!root_console || root_console.dropship_control_lost)
 		automated_hangar_id = null
 		automated_lz_id = null
 		automated_delay = null


### PR DESCRIPTION

# About the pull request

This PR fixes several issues I encountered when testing a few different game modes:
- Internal organs if deleted will now remove themselves from their owner human
- Internal organs will properly interrupt their processing call if they are deleted mid process
- An observer waypoint is now ensured when a z-level is deleted (such as for hive wars)
- Living mobs are now destroyed if their z-level is deleted
- The `/obj/docking_port/mobile/marine_dropship` will no longer spam runtimes if its console gets deleted

# Explain why it's good for the game

Runtimes generally need to be addressed, and these were particularly glaring issues preventing hive wars from being functional.

# Changelog
:cl: Drathek
fix: Internal organs now delete properly
fix: An observer waypoint is ensured when a z-level is destroyed (such as for Hivewars)
fix: Fixed various runtimes when a z-level is destroyed
/:cl:
