### PR TITLE
Eggs now cleanup via linked lz weed killer

### DIFF
--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -24,7 +24,7 @@
 /obj/effect/alien/egg/Initialize(mapload, hive)
 	. = ..()
 	create_egg_triggers()
-	if (hive)
+	if(hive)
 		hivenumber = hive
 
 	if(hivenumber == XENO_HIVE_NORMAL)
@@ -37,6 +37,10 @@
 	var/turf/my_turf = get_turf(src)
 	if(my_turf?.weeds && !isnull(weed_strength_required))
 		RegisterSignal(my_turf.weeds, COMSIG_PARENT_QDELETING, PROC_REF(on_weed_deletion))
+
+	var/area/area = get_area(src)
+	if(area && area.linked_lz)
+		AddComponent(/datum/component/resin_cleanup)
 
 /obj/effect/alien/egg/proc/forsaken_handling()
 	SIGNAL_HANDLER


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #7363 making it so eggs now also will get weed killed if they are in a linked lz area to the primary LZ.

# Explain why it's good for the game

Fixes #7797 and further mitigates the early round effects of #7554 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![egg](https://github.com/user-attachments/assets/6b90cc8b-3eea-437d-bc3e-45d2590a4a69)

</details>


# Changelog
:cl: Drathek
balance: Eggs that are in a linked lz area can now get weed killed by the initial dropship
/:cl:
