### PR TITLE
reduce the amount of times you have to fix chat

### DIFF
--- a/code/modules/tgui_panel/external.dm
+++ b/code/modules/tgui_panel/external.dm
@@ -19,9 +19,7 @@
 	// Failed to fix
 	action = alert(src, "Did that work?", "", "Yes", "No, switch to old ui")
 	if (action == "No, switch to old ui")
-		winset(src, "output", "on-show=&is-disabled=0&is-visible=1")
-		winset(src, "browseroutput", "is-disabled=1;is-visible=0")
-		log_tgui(src, "Failed to fix.", context = "verb/fix_tgui_panel")
+		use_old_chat()
 
 /client/proc/nuke_chat()
 	// Catch all solution (kick the whole thing in the pants)
@@ -35,6 +33,11 @@
 	// Force show the panel to see if there are any errors
 	winset(src, "output", "is-disabled=1&is-visible=0")
 	winset(src, "browseroutput", "is-disabled=0;is-visible=1")
+
+/client/proc/use_old_chat()
+	winset(src, "output", "on-show=&is-disabled=0&is-visible=1")
+	winset(src, "browseroutput", "is-disabled=1;is-visible=0")
+	log_tgui(src, "Failed to fix.", context = "verb/fix_tgui_panel")
 
 /client/verb/refresh_tgui()
 	set name = "Refresh TGUI"

--- a/code/modules/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui_panel/tgui_panel.dm
@@ -1,3 +1,5 @@
+#define REPAIRING 2
+
 /*!
  * Copyright (c) 2020 Aleksej Komarov
  * SPDX-License-Identifier: MIT
@@ -10,7 +12,7 @@
 /datum/tgui_panel
 	var/client/client
 	var/datum/tgui_window/window
-	var/broken = FALSE
+	var/broken = TRUE
 	var/initialized_at
 
 /datum/tgui_panel/New(client/client, id)
@@ -52,7 +54,9 @@
 	window.send_asset(get_asset_datum(/datum/asset/spritesheet/chat))
 	// Other setup
 	request_telemetry()
-	addtimer(CALLBACK(src, PROC_REF(on_initialize_timed_out)), 5 SECONDS)
+
+	sleep(3 SECONDS)
+	on_initialize_timed_out()
 
 /**
  * private
@@ -62,6 +66,16 @@
 /datum/tgui_panel/proc/on_initialize_timed_out()
 	// Currently does nothing but sending a message to old chat.
 	SEND_TEXT(client, "<span class=\"userdanger\">Failed to load fancy chat, click <a href='?src=[REF(src)];reload_tguipanel=1'>HERE</a> to attempt to reload it.</span>")
+
+	if(!broken)
+		return
+
+	if(broken == REPAIRING)
+		if(tgui_alert(src, "Your chat has failed to load twice - try again?", "Chat Repair", list("Yes", "No")) == "No")
+			client?.use_old_chat()
+			return
+
+	client?.nuke_chat()
 
 /**
  * private
@@ -103,3 +117,5 @@
  */
 /datum/tgui_panel/proc/send_roundrestart()
 	window.send_message("roundrestart")
+
+#undef REPAIRING

--- a/code/modules/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui_panel/tgui_panel.dm
@@ -76,6 +76,7 @@
 			return
 
 	client?.nuke_chat()
+	broken = REPAIRING
 
 /**
  * private


### PR DESCRIPTION
this never loads, and we can detect when it hasn't loaded, so why not automatically reload it for players

:cl:
fix: fixes chat never loading correctly, by just rebooting it when it fails to load
/:cl: