### PR TITLE
more solaris insert fixes and tweaks

### DIFF
--- a/code/game/machinery/computer/groundside_operations.dm
+++ b/code/game/machinery/computer/groundside_operations.dm
@@ -17,7 +17,7 @@
 	var/is_announcement_active = TRUE
 	var/announcement_title = COMMAND_ANNOUNCE
 	var/announcement_faction = FACTION_MARINE
-	var/add_pmcs = TRUE
+	var/add_pmcs = FALSE
 	var/lz_selection = TRUE
 	var/has_squad_overwatch = TRUE
 	var/faction = FACTION_MARINE
@@ -385,6 +385,7 @@
 /obj/structure/machinery/computer/groundside_operations/pmc
 	announcement_title = PMC_COMMAND_ANNOUNCE
 	announcement_faction = FACTION_PMC
+	add_pmcs = TRUE
 	lz_selection = FALSE
 	has_squad_overwatch = FALSE
 	minimap_type = MINIMAP_FLAG_PMC

--- a/code/game/objects/items/devices/cictablet.dm
+++ b/code/game/objects/items/devices/cictablet.dm
@@ -15,7 +15,7 @@
 
 	var/announcement_title = COMMAND_ANNOUNCE
 	var/announcement_faction = FACTION_MARINE
-	var/add_pmcs = TRUE
+	var/add_pmcs = FALSE
 
 	var/datum/tacmap/tacmap
 	var/minimap_type = MINIMAP_FLAG_USCM
@@ -175,7 +175,7 @@
 
 	announcement_title = PMC_COMMAND_ANNOUNCE
 	announcement_faction = FACTION_PMC
-
+	add_pmcs = TRUE
 	minimap_type = MINIMAP_FLAG_PMC
 
 /obj/item/device/cotablet/upp

--- a/maps/Nightmare/maps/BigRed/scenario.json
+++ b/maps/Nightmare/maps/BigRed/scenario.json
@@ -3,7 +3,7 @@
     "type": "pick", "name": "pmccrash",
     "choices": [
         { "weight": 10, "type": "def", "values": { "lvevent": "none" } },
-        { "weight": 4, "type": "def", "values": { "lvevent": "pmccrash" } }
+        { "weight": 2, "type": "def", "values": { "lvevent": "pmccrash" } }
     ]
     }
 ]


### PR DESCRIPTION

# About the pull request

reduces PMC insert chance
actually prevents all PMCs everywhere from getting all marine announcements 

# Explain why it's good for the game

I originally kept the odds fairly high so I could observe players messing around with the changes in the wild. (will they be able to find the second ship, do the changes make them too strong/weak...) The map is too common for the insert to be a ~30 percent chance.

PMCs should not automatically get every marine announcement, including groundside PMC survivors. They still get them when they are shipside like everyone else does.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: bobama
balance: solaris pmc insert is less common now
fix: pmcs actually no longer get all marine announcements
/:cl:
