### PR TITLE
Fix asset transport errors if space grunts is included in a map

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -916,6 +916,10 @@
 	name = "Colonial Space Grunts"
 	desc = "A tabletop game based around the USCM, easy to get into, simple to play, and most inportantly fun for the whole squad."
 
+/obj/item/paper/colonial_grunts/Initialize(mapload, photo_list)
+	. = ..()
+	return INITIALIZE_HINT_LATELOAD
+
 /obj/item/paper/colonial_grunts/LateInitialize()
 	. = ..()
 	info = "<div> <img style='align:middle' src='[SSassets.transport.get_asset_url("colonialspacegruntsEZ.png")]'>"

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -916,7 +916,7 @@
 	name = "Colonial Space Grunts"
 	desc = "A tabletop game based around the USCM, easy to get into, simple to play, and most inportantly fun for the whole squad."
 
-/obj/item/paper/colonial_grunts/Initialize(mapload, ...)
+/obj/item/paper/colonial_grunts/LateInitialize()
 	. = ..()
 	info = "<div> <img style='align:middle' src='[SSassets.transport.get_asset_url("colonialspacegruntsEZ.png")]'>"
 	update_icon()


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #4884 where if the paper is included in the map, it is attempted to be loaded prior to asset transport so throws errors like https://github.com/cmss13-devs/cmss13-pve/actions/runs/12336824155/job/34446215652?pr=609#step:7:48

# Explain why it's good for the game

Allows this item to be mapped in without causing issues.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/fd8e5850-ac9a-41df-8f64-d95b6cf6f8ad)

</details>

# Changelog
:cl: Drathek
fix: Fixed asset transport errors if the space grunts paper is mapped in
/:cl:
