### PR TITLE
Saving of the volume preferences

### DIFF
--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -6,6 +6,12 @@
 			return number
 	return default
 
+/proc/sanitize_float(number, min = 0, max = 1, default = 0)
+	if(isnum(number))
+		if(min <= number && number <= max)
+			return number
+	return default
+
 /proc/sanitize_text(text, default="")
 	if(istext(text))
 		return text

--- a/code/datums/soundOutput.dm
+++ b/code/datums/soundOutput.dm
@@ -26,7 +26,7 @@
 
 /datum/soundOutput/proc/process_sound(datum/sound_template/T)
 	var/sound/S = sound(T.file, T.wait, T.repeat)
-	S.volume = owner.volume_preferences[T.volume_cat] * T.volume
+	S.volume = owner.prefs.volume_preferences[T.volume_cat] * T.volume
 	if(T.channel == 0)
 		S.channel = get_free_channel()
 	else
@@ -91,7 +91,7 @@
 		ambience = target_ambience
 
 
-	S.volume = 100 * owner.volume_preferences[VOLUME_AMB]
+	S.volume = 100 * owner.prefs.volume_preferences[VOLUME_AMB]
 	S.status = status_flags
 
 	if(target_area)
@@ -117,7 +117,7 @@
 		if(length(soundscape_playlist))
 			var/sound/S = sound()
 			S.file = pick(soundscape_playlist)
-			S.volume = 100 * owner.volume_preferences[VOLUME_AMB]
+			S.volume = 100 * owner.prefs.volume_preferences[VOLUME_AMB]
 			S.x = pick(1,-1)
 			S.z = pick(1,-1)
 			S.y = 1
@@ -186,15 +186,18 @@
 	update_mob_environment_override()
 
 /client/proc/adjust_volume_prefs(volume_key, prompt = "", channel_update = 0)
-	volume_preferences[volume_key] = (tgui_input_number(src, prompt, "Volume", volume_preferences[volume_key]*100)) / 100
-	if(volume_preferences[volume_key] > 1)
-		volume_preferences[volume_key] = 1
-	if(volume_preferences[volume_key] < 0)
-		volume_preferences[volume_key] = 0
+	prefs.volume_preferences[volume_key] = (tgui_input_number(src, prompt, "Volume", prefs.volume_preferences[volume_key]*100)) / 100
+	if(prefs.volume_preferences[volume_key] > 1)
+		prefs.volume_preferences[volume_key] = 1
+	if(prefs.volume_preferences[volume_key] < 0)
+		prefs.volume_preferences[volume_key] = 0
+
+	prefs.save_preferences()
+
 	if(channel_update)
 		var/sound/S = sound()
 		S.channel = channel_update
-		S.volume = 100 * volume_preferences[volume_key]
+		S.volume = 100 * prefs.volume_preferences[volume_key]
 		S.status = SOUND_UPDATE
 		sound_to(src, S)
 

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -42,7 +42,6 @@
 	var/played = 0
 	var/midi_silenced = 0
 	var/datum/soundOutput/soundOutput
-	var/list/volume_preferences = list(1, 0.5, 1, 0.6)//Game, music, admin midis, lobby music
 
 		////////////
 		//SECURITY//

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -69,6 +69,7 @@ GLOBAL_LIST_INIT(bgstate_options, list(
 	var/toggles_flashing = TOGGLES_FLASHING_DEFAULT
 	var/toggles_ert = TOGGLES_ERT_DEFAULT
 	var/toggles_ert_pred = TOGGLES_ERT_GROUNDS
+	var/list/volume_preferences = list(1, 0.5, 1, 0.6) // Game, music, admin midis, lobby music (this is also set in sanitize_volume_preferences() call)
 	var/chat_display_preferences = CHAT_TYPE_ALL
 	var/item_animation_pref_level = SHOW_ITEM_ANIMATIONS_ALL
 	var/pain_overlay_pref_level = PAIN_OVERLAY_BLURRY

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -210,6 +210,15 @@
 			base_bindings -= key
 	return base_bindings
 
+/proc/sanitize_volume_preferences(list/pref_list, list/default_volume_preferences)
+	var/list/volume_preferences = sanitize_islist(pref_list, default_volume_preferences)
+	if(length(volume_preferences) != length(default_volume_preferences))
+		volume_preferences = default_volume_preferences
+	for(var/i in 1 to length(volume_preferences))
+		var/num = sanitize_float(volume_preferences[i], 0, 1, 1)
+		volume_preferences[i] = num
+	return volume_preferences
+
 /datum/preferences/proc/load_preferences()
 	if(!path) return 0
 	if(!fexists(path)) return 0
@@ -236,6 +245,7 @@
 	S["toggles_ghost"] >> toggles_ghost
 	S["toggles_langchat"] >> toggles_langchat
 	S["toggles_sound"] >> toggles_sound
+	S["volume_preferences"] >> volume_preferences
 	S["toggle_prefs"] >> toggle_prefs
 	S["xeno_ability_click_mode"] >> xeno_ability_click_mode
 	S["dual_wield_pref"] >> dual_wield_pref
@@ -434,6 +444,8 @@
 	if(!observer_huds)
 		observer_huds = list("Medical HUD" = FALSE, "Security HUD" = FALSE, "Squad HUD" = FALSE, "Xeno Status HUD" = FALSE, HUD_MENTOR_SIGHT = FALSE)
 
+	volume_preferences = sanitize_volume_preferences(volume_preferences, list(1, 0.5, 1, 0.6)) // Game, music, admin midis, lobby music
+
 	return 1
 
 /datum/preferences/proc/save_preferences()
@@ -465,6 +477,7 @@
 	S["toggles_ghost"] << toggles_ghost
 	S["toggles_langchat"] << toggles_langchat
 	S["toggles_sound"] << toggles_sound
+	S["volume_preferences"] << volume_preferences
 	S["toggle_prefs"] << toggle_prefs
 	S["xeno_ability_click_mode"] << xeno_ability_click_mode
 	S["dual_wield_pref"] << dual_wield_pref


### PR DESCRIPTION
# About the pull request

Adds saving of the volume preferences for ambience/lobby music/game, etc.

# Explain why it's good for the game

Several players voiced their annoyance with the need of volume adjustment after every restart. Now you won't need to adjust the volume every time you join the game.


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Idk what to put here, you can have a slugcat staring at you,

![1081895599571472484](https://github.com/user-attachments/assets/04e6a1f1-d683-48b5-8092-742961617542)


</details>


# Changelog

:cl:
add: Added saving of the preferences for ambience/lobby music/game volume.
/:cl:

