### PR TITLE
Adds a dedicated IO Prep Room

### DIFF
--- a/code/game/area/almayer.dm
+++ b/code/game/area/almayer.dm
@@ -628,6 +628,11 @@
 	icon_state = "livingspace"
 	fake_zlevel = 1 // upperdeck
 
+/area/almayer/living/iobunks
+	name = "\improper Intelligence Officer Bunks"
+	icon_state = "livingspace"
+	fake_zlevel = 1
+
 /area/almayer/living/commandbunks
 	name = "\improper Commanding Officer's Bunk"
 	icon_state = "livingspace"

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -131,13 +131,96 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/upper_engineering/starboard)
+"aas" = (
+/obj/structure/sign/poster{
+	desc = "This poster features Audrey Rainwater standing in a jacuzzi. She was the July 2182 centerfold in House Bunny Gentleman's Magazine. Don't ask how you know that.";
+	icon_state = "poster16";
+	layer = 3.3;
+	name = "'Miss July' Pinup";
+	pixel_y = 29;
+	serial_number = 16
+	},
+/obj/structure/machinery/vending/coffee,
+/turf/open/floor/almayer/silver/northwest,
+/area/almayer/engineering/port_atmos)
+"aat" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	name = "General Listening Channel";
+	pixel_x = -8;
+	pixel_y = 28
+	},
+/obj/structure/sign/safety/intercom{
+	pixel_x = 14;
+	pixel_y = 32
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/upper/midship_hallway)
 "aau" = (
 /turf/closed/wall/almayer/reinforced/temphull,
 /area/almayer/living/pilotbunks)
+"aav" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/hallways/upper/midship_hallway)
+"aaw" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/obj/structure/window/framed/almayer,
+/turf/open/floor/plating,
+/area/almayer/living/iobunks)
+"aax" = (
+/obj/structure/surface/table/almayer,
+/turf/open/floor/almayer/silver,
+/area/almayer/living/iobunks)
+"aay" = (
+/obj/structure/surface/table/almayer,
+/obj/item/paper_bin/uscm{
+	pixel_y = 6
+	},
+/obj/item/tool/pen{
+	pixel_y = 3
+	},
+/turf/open/floor/almayer/plate,
+/area/almayer/living/iobunks)
+"aaz" = (
+/obj/structure/machinery/cm_vending/clothing/intelligence_officer{
+	density = 0;
+	pixel_x = -32
+	},
+/turf/open/floor/almayer/silver/west,
+/area/almayer/living/iobunks)
+"aaA" = (
+/obj/structure/surface/table/almayer,
+/obj/item/folder/black,
+/turf/open/floor/almayer/plate,
+/area/almayer/living/iobunks)
+"aaB" = (
+/obj/item/clipboard,
+/obj/item/paper{
+	pixel_y = 7;
+	pixel_x = 3
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/almayer/silver/east,
+/area/almayer/living/iobunks)
 "aaC" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"aaD" = (
+/obj/structure/pipes/vents/pump,
+/turf/open/floor/almayer,
+/area/almayer/living/iobunks)
 "aaE" = (
 /obj/structure/sign/safety/storage{
 	pixel_x = 8;
@@ -157,6 +240,11 @@
 	},
 /turf/open/floor/plating/almayer/no_build,
 /area/almayer/stair_clone)
+"aaG" = (
+/obj/effect/landmark/start/intel,
+/obj/effect/landmark/late_join/intel,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/living/iobunks)
 "aaH" = (
 /obj/effect/step_trigger/teleporter_vector{
 	name = "Almayer_Down1";
@@ -694,11 +782,7 @@
 /turf/closed/wall/almayer,
 /area/almayer/living/officer_study)
 "ael" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/obj/structure/window/framed/almayer,
-/turf/open/floor/plating,
+/turf/closed/wall/almayer,
 /area/almayer/living/iobunks)
 "aep" = (
 /turf/closed/wall/almayer,
@@ -905,6 +989,17 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/offices/flight)
+"afE" = (
+/obj/structure/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/structure/machinery/light{
+	dir = 8;
+	pixel_y = 0
+	},
+/turf/open/floor/almayer/silver/west,
+/area/almayer/living/iobunks)
 "afF" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/offices/flight)
@@ -917,6 +1012,26 @@
 /obj/item/tool/pen,
 /turf/open/floor/almayer/plate,
 /area/almayer/living/officer_study)
+"afH" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer,
+/area/almayer/living/iobunks)
+"afJ" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/emails{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/almayer/living/iobunks)
+"afK" = (
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/turf/open/floor/almayer,
+/area/almayer/living/iobunks)
+"afL" = (
+/turf/open/floor/almayer/silver/east,
+/area/almayer/living/iobunks)
 "afM" = (
 /obj/structure/surface/table/almayer,
 /obj/effect/spawner/random/tool,
@@ -1084,15 +1199,31 @@
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/living/iobunks)
+"agT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/almayer/silver/west,
+/area/almayer/living/iobunks)
+"agV" = (
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/open/floor/almayer,
+/area/almayer/living/iobunks)
+"agY" = (
+/obj/structure/pipes/vents/scrubber,
+/turf/open/floor/almayer,
+/area/almayer/living/iobunks)
+"ahc" = (
+/turf/open/floor/almayer,
+/area/almayer/living/iobunks)
 "ahe" = (
-/obj/structure/surface/table/almayer,
-/obj/item/paper_bin/uscm{
-	pixel_y = 6
+/obj/structure/machinery/light{
+	dir = 4;
+	pixel_y = 0
 	},
-/obj/item/tool/pen{
-	pixel_y = 3
-	},
-/turf/open/floor/almayer/plate,
+/turf/open/floor/almayer/silver/east,
 /area/almayer/living/iobunks)
 "ahf" = (
 /obj/structure/surface/table/almayer,
@@ -1215,6 +1346,29 @@
 	dir = 4
 	},
 /turf/open/floor/almayer/test_floor4,
+/area/almayer/living/iobunks)
+"aij" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_y = 8
+	},
+/turf/open/floor/almayer/silver/southeast,
+/area/almayer/living/iobunks)
+"ain" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 9
+	},
+/turf/open/floor/almayer/silver,
+/area/almayer/living/iobunks)
+"aiq" = (
+/turf/open/floor/almayer/silver,
+/area/almayer/living/iobunks)
+"air" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_y = 8
+	},
+/turf/open/floor/almayer/silver,
 /area/almayer/living/iobunks)
 "ais" = (
 /turf/open/floor/almayer/bluecorner/west,
@@ -6664,10 +6818,6 @@
 /obj/structure/machinery/chem_dispenser/soda,
 /turf/open/floor/prison/kitchen,
 /area/almayer/living/captain_mess)
-"aSr" = (
-/obj/structure/surface/table/almayer,
-/turf/open/floor/almayer/silver,
-/area/almayer/living/iobunks)
 "aSt" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/machinery/chem_dispenser/soda/beer,
@@ -7384,27 +7534,38 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/hangar)
 "aXx" = (
-/obj/structure/sign/poster{
-	desc = "This poster features Audrey Rainwater standing in a jacuzzi. She was the July 2182 centerfold in House Bunny Gentleman's Magazine. Don't ask how you know that.";
-	icon_state = "poster16";
-	layer = 3.3;
-	name = "'Miss July' Pinup";
-	pixel_y = 29;
-	serial_number = 16
+/obj/structure/sign/safety/hvac_old{
+	pixel_x = 8;
+	pixel_y = -32
 	},
-/obj/structure/machinery/vending/coffee,
-/turf/open/floor/almayer/silver/northwest,
-/area/almayer/engineering/port_atmos)
-"aXA" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/machinery/light,
+/obj/structure/bed{
+	can_buckle = 0
+	},
+/obj/item/bedsheet/brown{
+	layer = 3.2
+	},
+/obj/structure/barricade/handrail{
 	dir = 8;
-	icon_state = "pipe-c"
+	layer = 3.3;
+	pixel_x = -1;
+	pixel_y = 3
 	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
+/obj/structure/barricade/handrail{
+	dir = 4;
+	layer = 3.3;
+	pixel_y = 3
+	},
+/obj/structure/bed{
+	buckling_y = 13;
+	layer = 3.5;
+	pixel_y = 13
+	},
+/obj/item/bedsheet/brown{
+	pixel_y = 13
 	},
 /turf/open/floor/almayer/silver/southwest,
-/area/almayer/living/iobunks)
+/area/almayer/engineering/port_atmos)
 "aXD" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment,
@@ -14135,10 +14296,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/charlie)
-"cfy" = (
-/obj/structure/pipes/vents/pump,
-/turf/open/floor/almayer,
-/area/almayer/living/iobunks)
 "cfE" = (
 /turf/open/floor/almayer/red/west,
 /area/almayer/shipboard/starboard_missiles)
@@ -16402,10 +16559,6 @@
 /obj/structure/platform/metal/almayer/west,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/hangar)
-"cQC" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer,
-/area/almayer/living/iobunks)
 "cQF" = (
 /obj/structure/sign/safety/ladder{
 	pixel_x = 8;
@@ -16826,13 +16979,6 @@
 /obj/item/tool/wet_sign,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/upper/u_f_s)
-"cZu" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/emails{
-	dir = 4
-	},
-/turf/open/floor/almayer,
-/area/almayer/living/iobunks)
 "cZB" = (
 /obj/structure/machinery/door/airlock/almayer/maint,
 /turf/open/floor/almayer/test_floor4,
@@ -16898,9 +17044,6 @@
 /obj/structure/machinery/power/apc/almayer/north,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_f_p)
-"daI" = (
-/turf/closed/wall/almayer,
-/area/almayer/living/iobunks)
 "dbc" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -17178,6 +17321,16 @@
 	},
 /turf/open/floor/almayer/red/north,
 /area/almayer/squads/alpha)
+"dgI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer/silver/southwest,
+/area/almayer/living/iobunks)
 "dha" = (
 /turf/open/floor/almayer/plate,
 /area/almayer/command/combat_correspondent)
@@ -19537,10 +19690,6 @@
 /obj/structure/bed/stool,
 /turf/open/floor/almayer/green/west,
 /area/almayer/hallways/lower/port_midship_hallway)
-"egS" = (
-/obj/structure/machinery/vending/snack,
-/turf/open/floor/almayer/silver/north,
-/area/almayer/living/iobunks)
 "ehc" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 1;
@@ -22745,10 +22894,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/charlie_delta_shared)
-"fxs" = (
-/obj/structure/pipes/vents/scrubber,
-/turf/open/floor/almayer,
-/area/almayer/living/iobunks)
 "fxI" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -25941,13 +26086,6 @@
 	},
 /turf/open/floor/almayer/plating/northeast,
 /area/almayer/engineering/lower/engine_core)
-"gSj" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/filingcabinet/chestdrawer{
-	pixel_y = 8
-	},
-/turf/open/floor/almayer/silver/southeast,
-/area/almayer/living/iobunks)
 "gSk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27834,12 +27972,6 @@
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
-"hFe" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 9
-	},
-/turf/open/floor/almayer/silver,
-/area/almayer/living/iobunks)
 "hFw" = (
 /obj/structure/machinery/disposal/broken,
 /turf/open/floor/almayer/orange,
@@ -32057,11 +32189,6 @@
 /obj/structure/machinery/vending/hydronutrients,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/upper/u_a_s)
-"jrG" = (
-/obj/effect/landmark/start/intel,
-/obj/effect/landmark/late_join/intel,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/living/iobunks)
 "jrH" = (
 /obj/structure/pipes/standard/manifold/hidden/supply/no_boom{
 	dir = 8
@@ -33108,12 +33235,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_m_p)
-"jPV" = (
-/obj/structure/bed/chair/comfy{
-	dir = 8
-	},
-/turf/open/floor/almayer,
-/area/almayer/living/iobunks)
 "jQt" = (
 /turf/open/floor/almayer/research/containment/floor2/west,
 /area/almayer/medical/containment/cell)
@@ -33442,6 +33563,10 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/lower_medical_medbay)
+"jXk" = (
+/obj/structure/machinery/vending/coffee,
+/turf/open/floor/almayer/silver/north,
+/area/almayer/living/iobunks)
 "jXN" = (
 /obj/docking_port/stationary/escape_pod/south,
 /turf/open/floor/plating,
@@ -33716,17 +33841,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/prison/kitchen,
 /area/almayer/engineering/upper_engineering)
-"kbz" = (
-/obj/structure/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/obj/structure/machinery/light{
-	dir = 8;
-	pixel_y = 0
-	},
-/turf/open/floor/almayer/silver/west,
-/area/almayer/living/iobunks)
 "kbJ" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -34924,6 +35038,13 @@
 /obj/structure/machinery/light,
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/hydroponics)
+"kCl" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/structure/machinery/power/apc/almayer/north,
+/turf/open/floor/almayer/silver/north,
+/area/almayer/living/iobunks)
 "kCm" = (
 /obj/structure/sign/safety/fire_haz{
 	pixel_x = 15;
@@ -35682,39 +35803,6 @@
 	},
 /turf/open/floor/almayer/aicore/glowing/no_build/ai_floor3,
 /area/almayer/command/airoom)
-"kSi" = (
-/obj/structure/sign/safety/hvac_old{
-	pixel_x = 8;
-	pixel_y = -32
-	},
-/obj/structure/machinery/light,
-/obj/structure/bed{
-	can_buckle = 0
-	},
-/obj/item/bedsheet/brown{
-	layer = 3.2
-	},
-/obj/structure/barricade/handrail{
-	dir = 8;
-	layer = 3.3;
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/structure/barricade/handrail{
-	dir = 4;
-	layer = 3.3;
-	pixel_y = 3
-	},
-/obj/structure/bed{
-	buckling_y = 13;
-	layer = 3.5;
-	pixel_y = 13
-	},
-/obj/item/bedsheet/brown{
-	pixel_y = 13
-	},
-/turf/open/floor/almayer/silver/southwest,
-/area/almayer/engineering/port_atmos)
 "kSn" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 4;
@@ -36851,13 +36939,6 @@
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/living/basketball)
-"loW" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
-/obj/structure/machinery/power/apc/almayer/north,
-/turf/open/floor/almayer/silver/north,
-/area/almayer/living/iobunks)
 "loY" = (
 /turf/open/floor/almayer/green/west,
 /area/almayer/living/grunt_rnr)
@@ -37292,6 +37373,13 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/charlie_delta_shared)
+"lzt" = (
+/obj/structure/machinery/cm_vending/gear/intelligence_officer{
+	density = 0;
+	pixel_x = -32
+	},
+/turf/open/floor/almayer/silver/west,
+/area/almayer/living/iobunks)
 "lzA" = (
 /obj/structure/bed/chair/comfy{
 	dir = 5
@@ -38870,13 +38958,6 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/command/corporateliaison)
-"mmn" = (
-/obj/structure/machinery/cm_vending/gear/intelligence_officer{
-	density = 0;
-	pixel_x = -32
-	},
-/turf/open/floor/almayer/silver/west,
-/area/almayer/living/iobunks)
 "mmN" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 1
@@ -39520,16 +39601,6 @@
 	},
 /turf/open/floor/almayer/bluefull,
 /area/almayer/squads/charlie_delta_shared)
-"mBd" = (
-/obj/structure/machinery/cm_vending/clothing/intelligence_officer{
-	density = 0;
-	pixel_x = -32
-	},
-/obj/structure/sign/poster/pinup{
-	pixel_y = 32
-	},
-/turf/open/floor/almayer/silver/northwest,
-/area/almayer/living/iobunks)
 "mBe" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -40424,9 +40495,6 @@
 /obj/item/clothing/glasses/mgoggles,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/upper/u_a_s)
-"mSo" = (
-/turf/open/floor/almayer,
-/area/almayer/living/iobunks)
 "mSr" = (
 /obj/effect/landmark/crap_item,
 /turf/open/floor/almayer,
@@ -40476,13 +40544,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/medical_science)
-"mTe" = (
-/obj/structure/machinery/light{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/open/floor/almayer/silver/east,
-/area/almayer/living/iobunks)
 "mTi" = (
 /obj/structure/machinery/cryopod/right,
 /turf/open/floor/almayer/cargo,
@@ -40759,15 +40820,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/shipboard/port_point_defense)
-"mZy" = (
-/obj/item/clipboard,
-/obj/item/paper{
-	pixel_y = 7;
-	pixel_x = 3
-	},
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/almayer/silver/east,
-/area/almayer/living/iobunks)
 "mZF" = (
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	icon_state = "almayer_pdoor";
@@ -41865,12 +41917,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north2)
-"nuk" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 8
-	},
-/turf/open/floor/almayer,
-/area/almayer/living/iobunks)
 "nux" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/poddoor/almayer/open{
@@ -44452,10 +44498,6 @@
 "owg" = (
 /turf/open/floor/almayer/mono,
 /area/almayer/engineering/upper_engineering/starboard)
-"oww" = (
-/obj/structure/machinery/vending/coffee,
-/turf/open/floor/almayer/silver/north,
-/area/almayer/living/iobunks)
 "owU" = (
 /obj/structure/machinery/light/small{
 	dir = 8
@@ -47465,6 +47507,10 @@
 	},
 /turf/open/floor/almayer/orangecorner,
 /area/almayer/hallways/upper/aft_hallway)
+"pKL" = (
+/obj/structure/machinery/vending/snack,
+/turf/open/floor/almayer/silver/north,
+/area/almayer/living/iobunks)
 "pKU" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -49425,19 +49471,6 @@
 "qyo" = (
 /turf/open/floor/almayer/blue/north,
 /area/almayer/command/cichallway)
-"qyu" = (
-/obj/structure/machinery/cm_vending/clothing/intelligence_officer{
-	density = 0;
-	pixel_x = -32
-	},
-/turf/open/floor/almayer/silver/west,
-/area/almayer/living/iobunks)
-"qyA" = (
-/obj/structure/machinery/cryopod{
-	pixel_y = 6
-	},
-/turf/open/floor/almayer/cargo,
-/area/almayer/living/iobunks)
 "qyD" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/recharger,
@@ -51012,15 +51045,6 @@
 	},
 /turf/open/floor/almayer/plating/northeast,
 /area/almayer/squads/req)
-"reI" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/almayer/test_floor4,
-/area/almayer/hallways/upper/midship_hallway)
 "reL" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/food/snacks/sliceable/bread{
@@ -52091,11 +52115,6 @@
 /obj/structure/machinery/processor,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/grunt_rnr)
-"rBu" = (
-/obj/structure/surface/table/almayer,
-/obj/item/folder/black,
-/turf/open/floor/almayer/plate,
-/area/almayer/living/iobunks)
 "rBv" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/almayer/cargo,
@@ -52908,9 +52927,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/cargo_arrow/west,
 /area/almayer/squads/delta)
-"rQS" = (
-/turf/open/floor/almayer/silver/east,
-/area/almayer/living/iobunks)
 "rQV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54340,13 +54356,6 @@
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/floor/plating/almayer/no_build,
 /area/almayer/hallways/lower/starboard_midship_hallway)
-"suY" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/filingcabinet/chestdrawer{
-	pixel_y = 8
-	},
-/turf/open/floor/almayer/silver,
-/area/almayer/living/iobunks)
 "svf" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -55220,6 +55229,12 @@
 /obj/effect/landmark/map_item,
 /turf/open/floor/almayer/sterile_green_corner/north,
 /area/almayer/medical/upper_medical)
+"sPa" = (
+/obj/structure/machinery/cryopod{
+	pixel_y = 6
+	},
+/turf/open/floor/almayer/cargo,
+/area/almayer/living/iobunks)
 "sPb" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -57806,6 +57821,18 @@
 /obj/structure/bed/chair/comfy/delta,
 /turf/open/floor/almayer/plate,
 /area/almayer/living/briefing)
+"tSX" = (
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/intelligence_officer{
+	density = 0;
+	pixel_x = -32
+	},
+/obj/structure/machinery/light{
+	alpha = 0;
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/open/floor/almayer/silver/west,
+/area/almayer/living/iobunks)
 "tTk" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -57972,6 +57999,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/sterile_green_side/west,
 /area/almayer/medical/upper_medical)
+"tXa" = (
+/obj/structure/machinery/cm_vending/clothing/intelligence_officer{
+	density = 0;
+	pixel_x = -32
+	},
+/obj/structure/sign/poster/pinup{
+	pixel_y = 32
+	},
+/turf/open/floor/almayer/silver/northwest,
+/area/almayer/living/iobunks)
 "tXb" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/bed/chair/comfy/charlie{
@@ -58671,12 +58708,6 @@
 	},
 /turf/open/floor/almayer/orange/northeast,
 /area/almayer/engineering/upper_engineering/starboard)
-"umC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/almayer/silver/west,
-/area/almayer/living/iobunks)
 "umI" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer/test_floor4,
@@ -63554,22 +63585,6 @@
 /obj/item/device/cotablet,
 /turf/open/floor/almayer/silver/north,
 /area/almayer/command/cic)
-"wci" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	freerange = 1;
-	name = "General Listening Channel";
-	pixel_x = -8;
-	pixel_y = 28
-	},
-/obj/structure/sign/safety/intercom{
-	pixel_x = 14;
-	pixel_y = 32
-	},
-/turf/open/floor/almayer,
-/area/almayer/hallways/upper/midship_hallway)
 "wcm" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out";
@@ -63988,6 +64003,12 @@
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer/sterile_green,
 /area/almayer/medical/lockerroom)
+"wks" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 6
+	},
+/turf/open/floor/almayer,
+/area/almayer/living/iobunks)
 "wky" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -66260,18 +66281,6 @@
 /obj/structure/platform/metal/almayer/east,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/u_a_p)
-"xfm" = (
-/obj/structure/machinery/cm_vending/sorted/cargo_guns/intelligence_officer{
-	density = 0;
-	pixel_x = -32
-	},
-/obj/structure/machinery/light{
-	alpha = 0;
-	dir = 8;
-	pixel_x = -32
-	},
-/turf/open/floor/almayer/silver/west,
-/area/almayer/living/iobunks)
 "xfq" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -67294,12 +67303,6 @@
 /obj/structure/largecrate/random/barrel/green,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/s_bow)
-"xze" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 6
-	},
-/turf/open/floor/almayer,
-/area/almayer/living/iobunks)
 "xzf" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -69053,9 +69056,6 @@
 /obj/effect/landmark/late_join/delta,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/delta)
-"ylf" = (
-/turf/open/floor/almayer/silver,
-/area/almayer/living/iobunks)
 "ylh" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/almayer/test_floor5,
@@ -106061,7 +106061,7 @@ lIY
 gxn
 aMy
 kNV
-reI
+aav
 wlr
 xyp
 mnf
@@ -106255,16 +106255,16 @@ njn
 hZE
 sVV
 oON
-daI
-daI
-daI
-daI
-daI
-daI
-daI
+ael
+ael
+ael
+ael
+ael
+ael
+ael
 agQ
 aih
-daI
+ael
 hyT
 lGh
 iCg
@@ -106458,17 +106458,17 @@ njn
 xVe
 sVV
 mbx
-daI
-mBd
-mmn
-xfm
-mmn
-qyu
-kbz
-umC
-aXA
-daI
-wci
+ael
+tXa
+lzt
+tSX
+lzt
+aaz
+afE
+agT
+dgI
+ael
+aat
 yiu
 xIj
 xIj
@@ -106661,16 +106661,16 @@ njn
 hHe
 gxn
 ioH
-daI
-oww
-mSo
-xze
-cQC
-cQC
-cQC
-nuk
-hFe
 ael
+jXk
+ahc
+wks
+afH
+afH
+afH
+agV
+ain
+aaw
 xIj
 poD
 rjr
@@ -106864,16 +106864,16 @@ aba
 aGA
 kbv
 fZo
-daI
-egS
-mSo
-cfy
-mSo
-mSo
-mSo
-fxs
-ylf
 ael
+pKL
+ahc
+aaD
+ahc
+ahc
+ahc
+agY
+aiq
+aaw
 xIj
 qdJ
 iCg
@@ -107067,16 +107067,16 @@ njn
 mAF
 ilq
 pjj
-daI
-loW
-mSo
-mSo
-mSo
-rBu
-cZu
-ahe
-aSr
-daI
+ael
+kCl
+ahc
+ahc
+ahc
+aaA
+afJ
+aay
+aax
+ael
 xIj
 qdJ
 xIj
@@ -107270,16 +107270,16 @@ njn
 hZE
 kbv
 mbx
-daI
-jrG
-jrG
-jrG
-mSo
-mSo
-jPV
-mSo
-suY
-daI
+ael
+aaG
+aaG
+aaG
+ahc
+ahc
+afK
+ahc
+air
+ael
 sgH
 qdJ
 xIj
@@ -107473,16 +107473,16 @@ njn
 laM
 kbv
 nkH
-daI
-qyA
-qyA
-qyA
-rQS
-mZy
-rQS
-mTe
-gSj
-daI
+ael
+sPa
+sPa
+sPa
+afL
+aaB
+afL
+ahe
+aij
+ael
 xIj
 yiu
 xIj
@@ -107911,9 +107911,9 @@ xXd
 qdJ
 iCg
 aUH
-aXx
+aas
 jKI
-kSi
+aXx
 nIN
 aGm
 gNo

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -165,9 +165,6 @@
 	},
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/stair_clone/upper)
-"aaM" = (
-/turf/open/floor/almayer/silver/east,
-/area/almayer/living/iobunks)
 "aaP" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
 	dir = 2;
@@ -1088,8 +1085,14 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/living/iobunks)
 "ahe" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer,
+/obj/structure/surface/table/almayer,
+/obj/item/paper_bin/uscm{
+	pixel_y = 6
+	},
+/obj/item/tool/pen{
+	pixel_y = 3
+	},
+/turf/open/floor/almayer/plate,
 /area/almayer/living/iobunks)
 "ahf" = (
 /obj/structure/surface/table/almayer,
@@ -6661,6 +6664,10 @@
 /obj/structure/machinery/chem_dispenser/soda,
 /turf/open/floor/prison/kitchen,
 /area/almayer/living/captain_mess)
+"aSr" = (
+/obj/structure/surface/table/almayer,
+/turf/open/floor/almayer/silver,
+/area/almayer/living/iobunks)
 "aSt" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/machinery/chem_dispenser/soda/beer,
@@ -7377,43 +7384,26 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/hangar)
 "aXx" = (
-/obj/structure/sign/safety/hvac_old{
-	pixel_x = 8;
-	pixel_y = -32
-	},
-/obj/structure/machinery/light,
-/obj/structure/bed{
-	can_buckle = 0
-	},
-/obj/item/bedsheet/brown{
-	layer = 3.2
-	},
-/obj/structure/barricade/handrail{
-	dir = 8;
+/obj/structure/sign/poster{
+	desc = "This poster features Audrey Rainwater standing in a jacuzzi. She was the July 2182 centerfold in House Bunny Gentleman's Magazine. Don't ask how you know that.";
+	icon_state = "poster16";
 	layer = 3.3;
-	pixel_x = -1;
-	pixel_y = 3
+	name = "'Miss July' Pinup";
+	pixel_y = 29;
+	serial_number = 16
 	},
-/obj/structure/barricade/handrail{
-	dir = 4;
-	layer = 3.3;
-	pixel_y = 3
-	},
-/obj/structure/bed{
-	buckling_y = 13;
-	layer = 3.5;
-	pixel_y = 13
-	},
-/obj/item/bedsheet/brown{
-	pixel_y = 13
-	},
-/turf/open/floor/almayer/silver/southwest,
+/obj/structure/machinery/vending/coffee,
+/turf/open/floor/almayer/silver/northwest,
 /area/almayer/engineering/port_atmos)
 "aXA" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/turf/open/floor/almayer/silver,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer/silver/southwest,
 /area/almayer/living/iobunks)
 "aXD" = (
 /obj/structure/disposalpipe/segment,
@@ -14145,6 +14135,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/charlie)
+"cfy" = (
+/obj/structure/pipes/vents/pump,
+/turf/open/floor/almayer,
+/area/almayer/living/iobunks)
 "cfE" = (
 /turf/open/floor/almayer/red/west,
 /area/almayer/shipboard/starboard_missiles)
@@ -14973,8 +14967,7 @@
 /area/almayer/command/computerlab)
 "cnH" = (
 /obj/structure/machinery/door/airlock/almayer/secure/reinforced{
-	name = "\improper Computer Lab";
-	req_access = ssssss
+	name = "\improper Computer Lab"
 	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -16410,11 +16403,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/hangar)
 "cQC" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/filingcabinet/chestdrawer{
-	pixel_y = 8
-	},
-/turf/open/floor/almayer/silver/southeast,
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer,
 /area/almayer/living/iobunks)
 "cQF" = (
 /obj/structure/sign/safety/ladder{
@@ -16836,6 +16826,13 @@
 /obj/item/tool/wet_sign,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/upper/u_f_s)
+"cZu" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/emails{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/almayer/living/iobunks)
 "cZB" = (
 /obj/structure/machinery/door/airlock/almayer/maint,
 /turf/open/floor/almayer/test_floor4,
@@ -16902,14 +16899,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_f_p)
 "daI" = (
-/obj/structure/surface/table/almayer,
-/obj/item/paper_bin/uscm{
-	pixel_y = 6
-	},
-/obj/item/tool/pen{
-	pixel_y = 3
-	},
-/turf/open/floor/almayer/plate,
+/turf/closed/wall/almayer,
 /area/almayer/living/iobunks)
 "dbc" = (
 /obj/effect/decal/warning_stripes{
@@ -19547,6 +19537,10 @@
 /obj/structure/bed/stool,
 /turf/open/floor/almayer/green/west,
 /area/almayer/hallways/lower/port_midship_hallway)
+"egS" = (
+/obj/structure/machinery/vending/snack,
+/turf/open/floor/almayer/silver/north,
+/area/almayer/living/iobunks)
 "ehc" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 1;
@@ -20893,12 +20887,6 @@
 	},
 /turf/open/floor/almayer/plating_striped/east,
 /area/almayer/maint/hull/lower/l_a_p)
-"eHF" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 6
-	},
-/turf/open/floor/almayer,
-/area/almayer/living/iobunks)
 "eHX" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	req_one_access = null;
@@ -21573,17 +21561,6 @@
 /obj/structure/machinery/medical_pod/bodyscanner,
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/lower_medical_medbay)
-"eXp" = (
-/obj/structure/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/obj/structure/machinery/light{
-	dir = 8;
-	pixel_y = 0
-	},
-/turf/open/floor/almayer/silver/west,
-/area/almayer/living/iobunks)
 "eXq" = (
 /turf/closed/wall/almayer,
 /area/almayer/living/offices/flight)
@@ -22467,16 +22444,6 @@
 /obj/structure/machinery/light,
 /turf/open/floor/almayer/bluefull,
 /area/almayer/command/cichallway)
-"fql" = (
-/obj/structure/machinery/cm_vending/clothing/intelligence_officer{
-	density = 0;
-	pixel_x = -32
-	},
-/obj/structure/sign/poster/pinup{
-	pixel_y = 32
-	},
-/turf/open/floor/almayer/silver/northwest,
-/area/almayer/living/iobunks)
 "fqw" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4;
@@ -22778,6 +22745,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/charlie_delta_shared)
+"fxs" = (
+/obj/structure/pipes/vents/scrubber,
+/turf/open/floor/almayer,
+/area/almayer/living/iobunks)
 "fxI" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -23527,13 +23498,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
-"fOt" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
-/obj/structure/machinery/power/apc/almayer/north,
-/turf/open/floor/almayer/silver/north,
-/area/almayer/living/iobunks)
 "fOv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24107,10 +24071,6 @@
 	},
 /turf/open/floor/almayer/silver/east,
 /area/almayer/shipboard/brig/cic_hallway)
-"gdm" = (
-/obj/structure/machinery/vending/snack,
-/turf/open/floor/almayer/silver/north,
-/area/almayer/living/iobunks)
 "gdp" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -25982,10 +25942,11 @@
 /turf/open/floor/almayer/plating/northeast,
 /area/almayer/engineering/lower/engine_core)
 "gSj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
+/obj/structure/surface/table/almayer,
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_y = 8
 	},
-/turf/open/floor/almayer/silver/west,
+/turf/open/floor/almayer/silver/southeast,
 /area/almayer/living/iobunks)
 "gSk" = (
 /obj/structure/disposalpipe/segment{
@@ -27873,6 +27834,12 @@
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
+"hFe" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 9
+	},
+/turf/open/floor/almayer/silver,
+/area/almayer/living/iobunks)
 "hFw" = (
 /obj/structure/machinery/disposal/broken,
 /turf/open/floor/almayer/orange,
@@ -30970,18 +30937,6 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/shipboard/panic)
-"iXs" = (
-/obj/structure/machinery/cm_vending/sorted/cargo_guns/intelligence_officer{
-	density = 0;
-	pixel_x = -32
-	},
-/obj/structure/machinery/light{
-	alpha = 0;
-	dir = 8;
-	pixel_x = -32
-	},
-/turf/open/floor/almayer/silver/west,
-/area/almayer/living/iobunks)
 "iXA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30994,13 +30949,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/u_a_p)
-"iXR" = (
-/obj/structure/machinery/cm_vending/clothing/intelligence_officer{
-	density = 0;
-	pixel_x = -32
-	},
-/turf/open/floor/almayer/silver/west,
-/area/almayer/living/iobunks)
 "iXT" = (
 /obj/item/trash/uscm_mre,
 /turf/open/floor/almayer,
@@ -31204,18 +31152,6 @@
 /obj/effect/spawner/random/tool,
 /turf/open/floor/almayer/mono,
 /area/almayer/lifeboat_pumps/south2)
-"jbu" = (
-/obj/structure/sign/poster{
-	desc = "This poster features Audrey Rainwater standing in a jacuzzi. She was the July 2182 centerfold in House Bunny Gentleman's Magazine. Don't ask how you know that.";
-	icon_state = "poster16";
-	layer = 3.3;
-	name = "'Miss July' Pinup";
-	pixel_y = 29;
-	serial_number = 16
-	},
-/obj/structure/machinery/vending/coffee,
-/turf/open/floor/almayer/silver/northwest,
-/area/almayer/engineering/port_atmos)
 "jbH" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -32121,6 +32057,11 @@
 /obj/structure/machinery/vending/hydronutrients,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/upper/u_a_s)
+"jrG" = (
+/obj/effect/landmark/start/intel,
+/obj/effect/landmark/late_join/intel,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/living/iobunks)
 "jrH" = (
 /obj/structure/pipes/standard/manifold/hidden/supply/no_boom{
 	dir = 8
@@ -32890,15 +32831,6 @@
 	},
 /turf/open/floor/almayer/cargo_arrow/west,
 /area/almayer/squads/charlie)
-"jLp" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/almayer/test_floor4,
-/area/almayer/hallways/upper/midship_hallway)
 "jLs" = (
 /obj/structure/machinery/vending/cola,
 /turf/open/floor/prison/kitchen,
@@ -33176,6 +33108,12 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_m_p)
+"jPV" = (
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/turf/open/floor/almayer,
+/area/almayer/living/iobunks)
 "jQt" = (
 /turf/open/floor/almayer/research/containment/floor2/west,
 /area/almayer/medical/containment/cell)
@@ -33778,6 +33716,17 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/prison/kitchen,
 /area/almayer/engineering/upper_engineering)
+"kbz" = (
+/obj/structure/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/structure/machinery/light{
+	dir = 8;
+	pixel_y = 0
+	},
+/turf/open/floor/almayer/silver/west,
+/area/almayer/living/iobunks)
 "kbJ" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -33945,9 +33894,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/starboard_fore_hallway)
-"kgu" = (
-/turf/open/floor/almayer/silver,
-/area/almayer/living/iobunks)
 "kgD" = (
 /obj/structure/sign/safety/cryo{
 	pixel_x = 35
@@ -34149,10 +34095,6 @@
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/almayer/mono,
 /area/almayer/lifeboat_pumps/south2)
-"kkB" = (
-/obj/structure/pipes/vents/pump,
-/turf/open/floor/almayer,
-/area/almayer/living/iobunks)
 "kkN" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/manifold/fourway/hidden/supply,
@@ -35741,12 +35683,38 @@
 /turf/open/floor/almayer/aicore/glowing/no_build/ai_floor3,
 /area/almayer/command/airoom)
 "kSi" = (
-/obj/structure/machinery/cm_vending/gear/intelligence_officer{
-	density = 0;
-	pixel_x = -32
+/obj/structure/sign/safety/hvac_old{
+	pixel_x = 8;
+	pixel_y = -32
 	},
-/turf/open/floor/almayer/silver/west,
-/area/almayer/living/iobunks)
+/obj/structure/machinery/light,
+/obj/structure/bed{
+	can_buckle = 0
+	},
+/obj/item/bedsheet/brown{
+	layer = 3.2
+	},
+/obj/structure/barricade/handrail{
+	dir = 8;
+	layer = 3.3;
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/structure/barricade/handrail{
+	dir = 4;
+	layer = 3.3;
+	pixel_y = 3
+	},
+/obj/structure/bed{
+	buckling_y = 13;
+	layer = 3.5;
+	pixel_y = 13
+	},
+/obj/item/bedsheet/brown{
+	pixel_y = 13
+	},
+/turf/open/floor/almayer/silver/southwest,
+/area/almayer/engineering/port_atmos)
 "kSn" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 4;
@@ -36883,6 +36851,13 @@
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/living/basketball)
+"loW" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/structure/machinery/power/apc/almayer/north,
+/turf/open/floor/almayer/silver/north,
+/area/almayer/living/iobunks)
 "loY" = (
 /turf/open/floor/almayer/green/west,
 /area/almayer/living/grunt_rnr)
@@ -38896,8 +38871,11 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/command/corporateliaison)
 "mmn" = (
-/obj/structure/machinery/vending/coffee,
-/turf/open/floor/almayer/silver/north,
+/obj/structure/machinery/cm_vending/gear/intelligence_officer{
+	density = 0;
+	pixel_x = -32
+	},
+/turf/open/floor/almayer/silver/west,
 /area/almayer/living/iobunks)
 "mmN" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -39542,6 +39520,16 @@
 	},
 /turf/open/floor/almayer/bluefull,
 /area/almayer/squads/charlie_delta_shared)
+"mBd" = (
+/obj/structure/machinery/cm_vending/clothing/intelligence_officer{
+	density = 0;
+	pixel_x = -32
+	},
+/obj/structure/sign/poster/pinup{
+	pixel_y = 32
+	},
+/turf/open/floor/almayer/silver/northwest,
+/area/almayer/living/iobunks)
 "mBe" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -40488,6 +40476,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/medical_science)
+"mTe" = (
+/obj/structure/machinery/light{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/open/floor/almayer/silver/east,
+/area/almayer/living/iobunks)
 "mTi" = (
 /obj/structure/machinery/cryopod/right,
 /turf/open/floor/almayer/cargo,
@@ -40764,6 +40759,15 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/shipboard/port_point_defense)
+"mZy" = (
+/obj/item/clipboard,
+/obj/item/paper{
+	pixel_y = 7;
+	pixel_x = 3
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/almayer/silver/east,
+/area/almayer/living/iobunks)
 "mZF" = (
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	icon_state = "almayer_pdoor";
@@ -41370,13 +41374,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/almayer/cargo,
 /area/almayer/lifeboat_pumps/south1)
-"njH" = (
-/obj/structure/machinery/light{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/open/floor/almayer/silver/east,
-/area/almayer/living/iobunks)
 "njJ" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -41868,6 +41865,12 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north2)
+"nuk" = (
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/open/floor/almayer,
+/area/almayer/living/iobunks)
 "nux" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/poddoor/almayer/open{
@@ -42046,16 +42049,6 @@
 /obj/structure/machinery/light,
 /turf/open/floor/almayer/orange,
 /area/almayer/engineering/lower)
-"nxD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer/silver/southwest,
-/area/almayer/living/iobunks)
 "nyj" = (
 /obj/effect/decal/medical_decals{
 	icon_state = "docdecal2"
@@ -43878,22 +43871,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/command/lifeboat)
-"okm" = (
-/obj/structure/machinery/light{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	freerange = 1;
-	name = "General Listening Channel";
-	pixel_x = -8;
-	pixel_y = 28
-	},
-/obj/structure/sign/safety/intercom{
-	pixel_x = 14;
-	pixel_y = 32
-	},
-/turf/open/floor/almayer,
-/area/almayer/hallways/upper/midship_hallway)
 "okD" = (
 /obj/structure/prop/almayer/name_stencil{
 	icon_state = "almayer6"
@@ -44475,6 +44452,10 @@
 "owg" = (
 /turf/open/floor/almayer/mono,
 /area/almayer/engineering/upper_engineering/starboard)
+"oww" = (
+/obj/structure/machinery/vending/coffee,
+/turf/open/floor/almayer/silver/north,
+/area/almayer/living/iobunks)
 "owU" = (
 /obj/structure/machinery/light/small{
 	dir = 8
@@ -49444,6 +49425,13 @@
 "qyo" = (
 /turf/open/floor/almayer/blue/north,
 /area/almayer/command/cichallway)
+"qyu" = (
+/obj/structure/machinery/cm_vending/clothing/intelligence_officer{
+	density = 0;
+	pixel_x = -32
+	},
+/turf/open/floor/almayer/silver/west,
+/area/almayer/living/iobunks)
 "qyA" = (
 /obj/structure/machinery/cryopod{
 	pixel_y = 6
@@ -51024,6 +51012,15 @@
 	},
 /turf/open/floor/almayer/plating/northeast,
 /area/almayer/squads/req)
+"reI" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/hallways/upper/midship_hallway)
 "reL" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/food/snacks/sliceable/bread{
@@ -52094,6 +52091,11 @@
 /obj/structure/machinery/processor,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/grunt_rnr)
+"rBu" = (
+/obj/structure/surface/table/almayer,
+/obj/item/folder/black,
+/turf/open/floor/almayer/plate,
+/area/almayer/living/iobunks)
 "rBv" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/almayer/cargo,
@@ -52118,10 +52120,6 @@
 /obj/item/tool/soap,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/upper/u_a_s)
-"rCe" = (
-/obj/structure/pipes/vents/scrubber,
-/turf/open/floor/almayer,
-/area/almayer/living/iobunks)
 "rCh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -52910,6 +52908,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/cargo_arrow/west,
 /area/almayer/squads/delta)
+"rQS" = (
+/turf/open/floor/almayer/silver/east,
+/area/almayer/living/iobunks)
 "rQV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54339,6 +54340,13 @@
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/floor/plating/almayer/no_build,
 /area/almayer/hallways/lower/starboard_midship_hallway)
+"suY" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_y = 8
+	},
+/turf/open/floor/almayer/silver,
+/area/almayer/living/iobunks)
 "svf" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -55391,11 +55399,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cells)
-"sUu" = (
-/obj/effect/landmark/start/intel,
-/obj/effect/landmark/late_join/intel,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/living/iobunks)
 "sUE" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /turf/open/floor/almayer/bluefull,
@@ -55553,10 +55556,6 @@
 	},
 /turf/open/floor/almayer/green/northeast,
 /area/almayer/shipboard/brig/cells)
-"sXT" = (
-/obj/structure/surface/table/almayer,
-/turf/open/floor/almayer/silver,
-/area/almayer/living/iobunks)
 "sYh" = (
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/lower_medical_medbay)
@@ -55757,12 +55756,6 @@
 	},
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/hallways/upper/starboard)
-"tbC" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 8
-	},
-/turf/open/floor/almayer,
-/area/almayer/living/iobunks)
 "tcd" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/radio{
@@ -56728,13 +56721,6 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/medical_science)
-"tsO" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/filingcabinet/chestdrawer{
-	pixel_y = 8
-	},
-/turf/open/floor/almayer/silver,
-/area/almayer/living/iobunks)
 "tsX" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/shipboard/brig/lobby)
@@ -57532,11 +57518,6 @@
 	},
 /turf/open/floor/almayer/cargo,
 /area/almayer/living/bridgebunks)
-"tKy" = (
-/obj/structure/surface/table/almayer,
-/obj/item/folder/black,
-/turf/open/floor/almayer/plate,
-/area/almayer/living/iobunks)
 "tKY" = (
 /obj/structure/bed/chair{
 	dir = 8;
@@ -58690,6 +58671,12 @@
 	},
 /turf/open/floor/almayer/orange/northeast,
 /area/almayer/engineering/upper_engineering/starboard)
+"umC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/almayer/silver/west,
+/area/almayer/living/iobunks)
 "umI" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer/test_floor4,
@@ -63567,6 +63554,22 @@
 /obj/item/device/cotablet,
 /turf/open/floor/almayer/silver/north,
 /area/almayer/command/cic)
+"wci" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	name = "General Listening Channel";
+	pixel_x = -8;
+	pixel_y = 28
+	},
+/obj/structure/sign/safety/intercom{
+	pixel_x = 14;
+	pixel_y = 32
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/upper/midship_hallway)
 "wcm" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out";
@@ -64025,15 +64028,6 @@
 /obj/structure/machinery/door/poddoor/almayer/blended/ai_lockdown/aicore,
 /turf/open/floor/almayer/no_build/test_floor4,
 /area/almayer/command/airoom)
-"wkS" = (
-/obj/item/clipboard,
-/obj/item/paper{
-	pixel_y = 7;
-	pixel_x = 3
-	},
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/almayer/silver/east,
-/area/almayer/living/iobunks)
 "wkX" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 6
@@ -65925,12 +65919,6 @@
 "wWC" = (
 /turf/open/floor/almayer/blue/southwest,
 /area/almayer/living/pilotbunks)
-"wWM" = (
-/obj/structure/bed/chair/comfy{
-	dir = 8
-	},
-/turf/open/floor/almayer,
-/area/almayer/living/iobunks)
 "wWP" = (
 /obj/structure/prop/cash_register/broken,
 /obj/structure/machinery/light/small,
@@ -66273,7 +66261,16 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/u_a_p)
 "xfm" = (
-/turf/closed/wall/almayer,
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/intelligence_officer{
+	density = 0;
+	pixel_x = -32
+	},
+/obj/structure/machinery/light{
+	alpha = 0;
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/open/floor/almayer/silver/west,
 /area/almayer/living/iobunks)
 "xfq" = (
 /obj/structure/sign/safety/hvac_old{
@@ -66620,13 +66617,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_f_p)
-"xmF" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/computer/emails{
-	dir = 4
-	},
-/turf/open/floor/almayer,
-/area/almayer/living/iobunks)
 "xmJ" = (
 /obj/structure/closet,
 /obj/structure/sign/safety/bathunisex{
@@ -67304,6 +67294,12 @@
 /obj/structure/largecrate/random/barrel/green,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/s_bow)
+"xze" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 6
+	},
+/turf/open/floor/almayer,
+/area/almayer/living/iobunks)
 "xzf" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -69057,6 +69053,9 @@
 /obj/effect/landmark/late_join/delta,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/delta)
+"ylf" = (
+/turf/open/floor/almayer/silver,
+/area/almayer/living/iobunks)
 "ylh" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/almayer/test_floor5,
@@ -106062,7 +106061,7 @@ lIY
 gxn
 aMy
 kNV
-jLp
+reI
 wlr
 xyp
 mnf
@@ -106256,16 +106255,16 @@ njn
 hZE
 sVV
 oON
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
+daI
+daI
+daI
+daI
+daI
+daI
+daI
 agQ
 aih
-xfm
+daI
 hyT
 lGh
 iCg
@@ -106459,17 +106458,17 @@ njn
 xVe
 sVV
 mbx
+daI
+mBd
+mmn
 xfm
-fql
-kSi
-iXs
-kSi
-iXR
-eXp
-gSj
-nxD
-xfm
-okm
+mmn
+qyu
+kbz
+umC
+aXA
+daI
+wci
 yiu
 xIj
 xIj
@@ -106662,15 +106661,15 @@ njn
 hHe
 gxn
 ioH
-xfm
-mmn
+daI
+oww
 mSo
-eHF
-ahe
-ahe
-ahe
-tbC
-aXA
+xze
+cQC
+cQC
+cQC
+nuk
+hFe
 ael
 xIj
 poD
@@ -106865,15 +106864,15 @@ aba
 aGA
 kbv
 fZo
-xfm
-gdm
+daI
+egS
 mSo
-kkB
+cfy
 mSo
 mSo
 mSo
-rCe
-kgu
+fxs
+ylf
 ael
 xIj
 qdJ
@@ -107068,16 +107067,16 @@ njn
 mAF
 ilq
 pjj
-xfm
-fOt
-mSo
-mSo
-mSo
-tKy
-xmF
 daI
-sXT
-xfm
+loW
+mSo
+mSo
+mSo
+rBu
+cZu
+ahe
+aSr
+daI
 xIj
 qdJ
 xIj
@@ -107271,16 +107270,16 @@ njn
 hZE
 kbv
 mbx
-xfm
-sUu
-sUu
-sUu
+daI
+jrG
+jrG
+jrG
 mSo
 mSo
-wWM
+jPV
 mSo
-tsO
-xfm
+suY
+daI
 sgH
 qdJ
 xIj
@@ -107474,16 +107473,16 @@ njn
 laM
 kbv
 nkH
-xfm
+daI
 qyA
 qyA
 qyA
-aaM
-wkS
-aaM
-njH
-cQC
-xfm
+rQS
+mZy
+rQS
+mTe
+gSj
+daI
 xIj
 yiu
 xIj
@@ -107912,9 +107911,9 @@ xXd
 qdJ
 iCg
 aUH
-jbu
-jKI
 aXx
+jKI
+kSi
 nIN
 aGm
 gNo

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -165,6 +165,9 @@
 	},
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/stair_clone/upper)
+"aaM" = (
+/turf/open/floor/almayer/silver/east,
+/area/almayer/living/iobunks)
 "aaP" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/secdoor/glass/reinforced{
 	dir = 2;
@@ -694,8 +697,12 @@
 /turf/closed/wall/almayer,
 /area/almayer/living/officer_study)
 "ael" = (
-/turf/closed/wall/almayer,
-/area/almayer/living/cafeteria_officer)
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/obj/structure/window/framed/almayer,
+/turf/open/floor/plating,
+/area/almayer/living/iobunks)
 "aep" = (
 /turf/closed/wall/almayer,
 /area/almayer/engineering/airmix)
@@ -901,13 +908,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/offices/flight)
-"afE" = (
-/obj/structure/machinery/vending/dinnerware,
-/obj/structure/machinery/firealarm{
-	pixel_y = 28
-	},
-/turf/open/floor/prison/kitchen,
-/area/almayer/living/cafeteria_officer)
 "afF" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/offices/flight)
@@ -920,32 +920,6 @@
 /obj/item/tool/pen,
 /turf/open/floor/almayer/plate,
 /area/almayer/living/officer_study)
-"afH" = (
-/obj/structure/machinery/vending/cola,
-/turf/open/floor/prison/kitchen,
-/area/almayer/living/cafeteria_officer)
-"afI" = (
-/obj/structure/machinery/vending/snack,
-/turf/open/floor/prison/kitchen,
-/area/almayer/living/cafeteria_officer)
-"afJ" = (
-/obj/structure/machinery/power/apc/almayer/north,
-/turf/open/floor/almayer/plate,
-/area/almayer/living/cafeteria_officer)
-"afK" = (
-/obj/structure/bed/chair,
-/obj/structure/machinery/status_display{
-	pixel_y = 30
-	},
-/turf/open/floor/almayer,
-/area/almayer/living/cafeteria_officer)
-"afL" = (
-/obj/structure/bed/chair,
-/obj/structure/machinery/alarm/almayer{
-	dir = 1
-	},
-/turf/open/floor/almayer/silver/east,
-/area/almayer/living/cafeteria_officer)
 "afM" = (
 /obj/structure/surface/table/almayer,
 /obj/effect/spawner/random/tool,
@@ -1112,31 +1086,11 @@
 "agQ" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer/test_floor4,
-/area/almayer/living/cafeteria_officer)
-"agT" = (
-/turf/open/floor/prison/kitchen,
-/area/almayer/living/cafeteria_officer)
-"agV" = (
-/obj/structure/pipes/vents/pump,
-/turf/open/floor/almayer/plate,
-/area/almayer/living/cafeteria_officer)
-"agY" = (
-/turf/open/floor/almayer/plate,
-/area/almayer/living/cafeteria_officer)
-"ahc" = (
-/obj/structure/surface/table/almayer,
-/obj/item/storage/box/wy_mre,
-/obj/item/storage/box/wy_mre,
-/turf/open/floor/almayer,
-/area/almayer/living/cafeteria_officer)
+/area/almayer/living/iobunks)
 "ahe" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/light{
-	dir = 4
-	},
-/obj/item/storage/box/donkpockets,
-/turf/open/floor/almayer/silver/east,
-/area/almayer/living/cafeteria_officer)
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer,
+/area/almayer/living/iobunks)
 "ahf" = (
 /obj/structure/surface/table/almayer,
 /obj/effect/spawner/random/tool,
@@ -1248,39 +1202,17 @@
 "aih" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/comdoor{
 	dir = 2;
-	name = "\improper Officer's Cafeteria"
+	name = "\improper Intelligence Officer Bunks"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/almayer/test_floor4,
-/area/almayer/living/cafeteria_officer)
-"aij" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	dir = 8;
-	name = "ship-grade camera"
-	},
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/open/floor/almayer/silver/east,
-/area/almayer/living/cafeteria_officer)
-"ain" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 9
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/living/cafeteria_officer)
-"aiq" = (
-/turf/open/floor/almayer,
-/area/almayer/living/cafeteria_officer)
-"air" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/open/floor/almayer,
-/area/almayer/living/cafeteria_officer)
+/area/almayer/living/iobunks)
 "ais" = (
 /turf/open/floor/almayer/bluecorner/west,
 /area/almayer/living/offices/flight)
@@ -7445,23 +7377,44 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/hangar)
 "aXx" = (
-/obj/structure/machinery/cryopod{
-	pixel_y = 6
-	},
-/turf/open/floor/almayer/cargo,
-/area/almayer/engineering/port_atmos)
-"aXA" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
 	pixel_y = -32
 	},
 /obj/structure/machinery/light,
-/obj/effect/decal/warning_stripes{
-	icon_state = "W";
-	pixel_x = -1
+/obj/structure/bed{
+	can_buckle = 0
+	},
+/obj/item/bedsheet/brown{
+	layer = 3.2
+	},
+/obj/structure/barricade/handrail{
+	dir = 8;
+	layer = 3.3;
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/structure/barricade/handrail{
+	dir = 4;
+	layer = 3.3;
+	pixel_y = 3
+	},
+/obj/structure/bed{
+	buckling_y = 13;
+	layer = 3.5;
+	pixel_y = 13
+	},
+/obj/item/bedsheet/brown{
+	pixel_y = 13
 	},
 /turf/open/floor/almayer/silver/southwest,
 /area/almayer/engineering/port_atmos)
+"aXA" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 9
+	},
+/turf/open/floor/almayer/silver,
+/area/almayer/living/iobunks)
 "aXD" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment,
@@ -13412,10 +13365,6 @@
 /obj/structure/pipes/vents/scrubber,
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/lower/engine_core)
-"bVR" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/upper/u_m_s)
 "bVU" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/shipboard/port_point_defense)
@@ -15024,7 +14973,8 @@
 /area/almayer/command/computerlab)
 "cnH" = (
 /obj/structure/machinery/door/airlock/almayer/secure/reinforced{
-	name = "\improper Computer Lab"
+	name = "\improper Computer Lab";
+	req_access = ssssss
 	},
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -15628,10 +15578,6 @@
 /turf/open/floor/almayer/orange/southeast,
 /area/almayer/maint/upper/mess)
 "cyP" = (
-/obj/structure/machinery/cm_vending/clothing/intelligence_officer{
-	density = 0;
-	pixel_x = -32
-	},
 /turf/open/floor/almayer/silver/west,
 /area/almayer/command/securestorage)
 "cyR" = (
@@ -16464,18 +16410,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/hangar)
 "cQC" = (
-/obj/item/device/radio/intercom{
-	freerange = 1;
-	name = "General Listening Channel";
-	pixel_x = -8;
-	pixel_y = 28
+/obj/structure/surface/table/almayer,
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_y = 8
 	},
-/obj/structure/sign/safety/intercom{
-	pixel_x = 14;
-	pixel_y = 32
-	},
-/turf/open/floor/almayer,
-/area/almayer/hallways/upper/midship_hallway)
+/turf/open/floor/almayer/silver/southeast,
+/area/almayer/living/iobunks)
 "cQF" = (
 /obj/structure/sign/safety/ladder{
 	pixel_x = 8;
@@ -16962,12 +16902,15 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_f_p)
 "daI" = (
-/obj/structure/machinery/door/airlock/almayer/secure/reinforced{
-	name = "\improper Armourer's Workshop";
-	req_access = null
+/obj/structure/surface/table/almayer,
+/obj/item/paper_bin/uscm{
+	pixel_y = 6
 	},
-/turf/open/floor/almayer/test_floor4,
-/area/almayer/maint/upper/u_m_s)
+/obj/item/tool/pen{
+	pixel_y = 3
+	},
+/turf/open/floor/almayer/plate,
+/area/almayer/living/iobunks)
 "dbc" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -17245,12 +17188,6 @@
 	},
 /turf/open/floor/almayer/red/north,
 /area/almayer/squads/alpha)
-"dgI" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/prison/kitchen,
-/area/almayer/living/cafeteria_officer)
 "dha" = (
 /turf/open/floor/almayer/plate,
 /area/almayer/command/combat_correspondent)
@@ -20956,6 +20893,12 @@
 	},
 /turf/open/floor/almayer/plating_striped/east,
 /area/almayer/maint/hull/lower/l_a_p)
+"eHF" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 6
+	},
+/turf/open/floor/almayer,
+/area/almayer/living/iobunks)
 "eHX" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	req_one_access = null;
@@ -21231,10 +21174,6 @@
 	},
 /turf/open/floor/almayer/orange/west,
 /area/almayer/hallways/lower/starboard_umbilical)
-"ePz" = (
-/obj/structure/largecrate/supply/weapons/pistols,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/maint/upper/u_m_s)
 "ePM" = (
 /obj/structure/sign/safety/distribution_pipes{
 	pixel_x = 32
@@ -21634,6 +21573,17 @@
 /obj/structure/machinery/medical_pod/bodyscanner,
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/lower_medical_medbay)
+"eXp" = (
+/obj/structure/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/structure/machinery/light{
+	dir = 8;
+	pixel_y = 0
+	},
+/turf/open/floor/almayer/silver/west,
+/area/almayer/living/iobunks)
 "eXq" = (
 /turf/closed/wall/almayer,
 /area/almayer/living/offices/flight)
@@ -22517,6 +22467,16 @@
 /obj/structure/machinery/light,
 /turf/open/floor/almayer/bluefull,
 /area/almayer/command/cichallway)
+"fql" = (
+/obj/structure/machinery/cm_vending/clothing/intelligence_officer{
+	density = 0;
+	pixel_x = -32
+	},
+/obj/structure/sign/poster/pinup{
+	pixel_y = 32
+	},
+/turf/open/floor/almayer/silver/northwest,
+/area/almayer/living/iobunks)
 "fqw" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4;
@@ -23567,6 +23527,13 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
+"fOt" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/structure/machinery/power/apc/almayer/north,
+/turf/open/floor/almayer/silver/north,
+/area/almayer/living/iobunks)
 "fOv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24140,6 +24107,10 @@
 	},
 /turf/open/floor/almayer/silver/east,
 /area/almayer/shipboard/brig/cic_hallway)
+"gdm" = (
+/obj/structure/machinery/vending/snack,
+/turf/open/floor/almayer/silver/north,
+/area/almayer/living/iobunks)
 "gdp" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -25605,10 +25576,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/maint/hull/upper/u_f_s)
-"gJg" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/upper/u_m_s)
 "gJp" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/emails{
@@ -26015,12 +25982,11 @@
 /turf/open/floor/almayer/plating/northeast,
 /area/almayer/engineering/lower/engine_core)
 "gSj" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "W";
-	pixel_x = -1
+/obj/structure/disposalpipe/segment{
+	dir = 1
 	},
 /turf/open/floor/almayer/silver/west,
-/area/almayer/engineering/port_atmos)
+/area/almayer/living/iobunks)
 "gSk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31004,6 +30970,18 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/shipboard/panic)
+"iXs" = (
+/obj/structure/machinery/cm_vending/sorted/cargo_guns/intelligence_officer{
+	density = 0;
+	pixel_x = -32
+	},
+/obj/structure/machinery/light{
+	alpha = 0;
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/open/floor/almayer/silver/west,
+/area/almayer/living/iobunks)
 "iXA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31016,6 +30994,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/u_a_p)
+"iXR" = (
+/obj/structure/machinery/cm_vending/clothing/intelligence_officer{
+	density = 0;
+	pixel_x = -32
+	},
+/turf/open/floor/almayer/silver/west,
+/area/almayer/living/iobunks)
 "iXT" = (
 /obj/item/trash/uscm_mre,
 /turf/open/floor/almayer,
@@ -31219,6 +31204,18 @@
 /obj/effect/spawner/random/tool,
 /turf/open/floor/almayer/mono,
 /area/almayer/lifeboat_pumps/south2)
+"jbu" = (
+/obj/structure/sign/poster{
+	desc = "This poster features Audrey Rainwater standing in a jacuzzi. She was the July 2182 centerfold in House Bunny Gentleman's Magazine. Don't ask how you know that.";
+	icon_state = "poster16";
+	layer = 3.3;
+	name = "'Miss July' Pinup";
+	pixel_y = 29;
+	serial_number = 16
+	},
+/obj/structure/machinery/vending/coffee,
+/turf/open/floor/almayer/silver/northwest,
+/area/almayer/engineering/port_atmos)
 "jbH" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -32752,15 +32749,6 @@
 /obj/structure/machinery/power/apc/almayer/east,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/u_m_s)
-"jFM" = (
-/obj/structure/surface/table/almayer,
-/obj/item/attachable/lasersight,
-/obj/item/reagent_container/food/drinks/cans/souto/vanilla{
-	pixel_x = 10;
-	pixel_y = 11
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/upper/u_m_s)
 "jFY" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer/cargo,
@@ -32885,13 +32873,7 @@
 /turf/open/floor/plating,
 /area/almayer/command/cichallway)
 "jKI" = (
-/obj/structure/machinery/cryopod{
-	pixel_y = 6
-	},
-/obj/structure/sign/safety/cryo{
-	pixel_x = -17
-	},
-/turf/open/floor/almayer/cargo,
+/turf/open/floor/almayer/silver/west,
 /area/almayer/engineering/port_atmos)
 "jKK" = (
 /obj/structure/surface/table/almayer,
@@ -32908,6 +32890,15 @@
 	},
 /turf/open/floor/almayer/cargo_arrow/west,
 /area/almayer/squads/charlie)
+"jLp" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/hallways/upper/midship_hallway)
 "jLs" = (
 /obj/structure/machinery/vending/cola,
 /turf/open/floor/prison/kitchen,
@@ -33513,18 +33504,6 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/lower_medical_medbay)
-"jXk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/largecrate/supply/weapons/m39{
-	pixel_x = 2
-	},
-/obj/structure/largecrate/supply/weapons/m41a{
-	layer = 3.1;
-	pixel_x = 6;
-	pixel_y = 17
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/upper/u_m_s)
 "jXN" = (
 /obj/docking_port/stationary/escape_pod/south,
 /turf/open/floor/plating,
@@ -33966,6 +33945,9 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/starboard_fore_hallway)
+"kgu" = (
+/turf/open/floor/almayer/silver,
+/area/almayer/living/iobunks)
 "kgD" = (
 /obj/structure/sign/safety/cryo{
 	pixel_x = 35
@@ -34167,6 +34149,10 @@
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/almayer/mono,
 /area/almayer/lifeboat_pumps/south2)
+"kkB" = (
+/obj/structure/pipes/vents/pump,
+/turf/open/floor/almayer,
+/area/almayer/living/iobunks)
 "kkN" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/manifold/fourway/hidden/supply,
@@ -34996,34 +34982,6 @@
 /obj/structure/machinery/light,
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/hydroponics)
-"kCl" = (
-/obj/structure/surface/rack,
-/obj/item/ammo_magazine/rifle/l42a/ap{
-	current_rounds = 0;
-	pixel_x = -6;
-	pixel_y = 7
-	},
-/obj/item/ammo_magazine/rifle/l42a/ap{
-	current_rounds = 0;
-	pixel_x = -6;
-	pixel_y = -3
-	},
-/obj/item/ammo_magazine/rifle/l42a/ap{
-	current_rounds = 0;
-	pixel_x = 5;
-	pixel_y = 9
-	},
-/obj/item/ammo_magazine/rifle/l42a/ap{
-	current_rounds = 0;
-	pixel_x = 5;
-	pixel_y = -3
-	},
-/obj/structure/noticeboard{
-	desc = "The note is haphazardly attached to the cork board by what looks like a bent firing pin. 'The order has come in to perform end of life service checks on all L42A service rifles, any that are defective are to be dis-assembled and packed into a crate and sent to to the cargo hold. L42A service rifles that are in working order after servicing, are to be locked in secure cabinets ready to be off-loaded at Chinook. Scheduled end of life service for the L42A -  Complete'";
-	pixel_y = 29
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/upper/u_m_s)
 "kCm" = (
 /obj/structure/sign/safety/fire_haz{
 	pixel_x = 15;
@@ -35573,6 +35531,10 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/open/floor/almayer/mono,
 /area/almayer/hallways/upper/starboard)
 "kNX" = (
@@ -35784,7 +35746,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/almayer/silver/west,
-/area/almayer/command/computerlab)
+/area/almayer/living/iobunks)
 "kSn" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 4;
@@ -37355,19 +37317,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/charlie_delta_shared)
-"lzt" = (
-/obj/structure/surface/table/almayer,
-/obj/item/tool/screwdriver,
-/obj/item/prop/helmetgarb/gunoil{
-	pixel_x = -7;
-	pixel_y = 12
-	},
-/obj/item/weapon/gun/rifle/l42a{
-	pixel_x = 17;
-	pixel_y = 6
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/upper/u_m_s)
 "lzA" = (
 /obj/structure/bed/chair/comfy{
 	dir = 5
@@ -38947,17 +38896,9 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/command/corporateliaison)
 "mmn" = (
-/obj/structure/machinery/cm_vending/sorted/cargo_guns/intelligence_officer{
-	density = 0;
-	pixel_x = -32
-	},
-/obj/structure/machinery/light{
-	alpha = 0;
-	dir = 8;
-	pixel_x = -32
-	},
-/turf/open/floor/almayer/silver/west,
-/area/almayer/command/computerlab)
+/obj/structure/machinery/vending/coffee,
+/turf/open/floor/almayer/silver/north,
+/area/almayer/living/iobunks)
 "mmN" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 1
@@ -40231,9 +40172,17 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/hangar)
 "mMP" = (
-/obj/effect/landmark/start/intel,
-/obj/effect/landmark/late_join/intel,
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/surface/table/reinforced/almayer_B,
+/obj/item/ammo_magazine/pistol/mod88/incendiary{
+	current_rounds = 0;
+	pixel_y = 5;
+	pixel_x = 3
+	},
+/obj/item/weapon/gun/pistol/mod88{
+	pixel_y = 4;
+	current_mag = null
+	},
+/turf/open/floor/almayer/silver,
 /area/almayer/engineering/port_atmos)
 "mMV" = (
 /obj/structure/pipes/vents/scrubber,
@@ -40488,10 +40437,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/upper/u_a_s)
 "mSo" = (
-/obj/structure/surface/rack,
-/obj/item/facepaint/sniper,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/upper/u_m_s)
+/turf/open/floor/almayer,
+/area/almayer/living/iobunks)
 "mSr" = (
 /obj/effect/landmark/crap_item,
 /turf/open/floor/almayer,
@@ -41423,6 +41370,13 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/almayer/cargo,
 /area/almayer/lifeboat_pumps/south1)
+"njH" = (
+/obj/structure/machinery/light{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/open/floor/almayer/silver/east,
+/area/almayer/living/iobunks)
 "njJ" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -42092,6 +42046,16 @@
 /obj/structure/machinery/light,
 /turf/open/floor/almayer/orange,
 /area/almayer/engineering/lower)
+"nxD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer/silver/southwest,
+/area/almayer/living/iobunks)
 "nyj" = (
 /obj/effect/decal/medical_decals{
 	icon_state = "docdecal2"
@@ -43914,6 +43878,22 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/command/lifeboat)
+"okm" = (
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	name = "General Listening Channel";
+	pixel_x = -8;
+	pixel_y = 28
+	},
+/obj/structure/sign/safety/intercom{
+	pixel_x = 14;
+	pixel_y = 32
+	},
+/turf/open/floor/almayer,
+/area/almayer/hallways/upper/midship_hallway)
 "okD" = (
 /obj/structure/prop/almayer/name_stencil{
 	icon_state = "almayer6"
@@ -44570,17 +44550,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/starboard_hallway)
 "oyE" = (
-/obj/effect/landmark/start/intel,
-/obj/structure/sign/poster{
-	desc = "One of those hot, tanned babes back the beaches of good ol' Earth.";
-	icon_state = "poster12";
-	name = "Beach Babe Pinup";
-	pixel_x = 6;
-	pixel_y = 29;
-	serial_number = 12
-	},
-/obj/effect/landmark/late_join/intel,
-/turf/open/floor/plating/plating_catwalk,
+/obj/structure/machinery/vending/snack,
+/turf/open/floor/almayer/silver/north,
 /area/almayer/engineering/port_atmos)
 "oyG" = (
 /obj/structure/disposalpipe/segment,
@@ -47513,16 +47484,6 @@
 	},
 /turf/open/floor/almayer/orangecorner,
 /area/almayer/hallways/upper/aft_hallway)
-"pKL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/largecrate/random/secure{
-	pixel_x = -5
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/upper/u_m_s)
 "pKU" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -49484,12 +49445,11 @@
 /turf/open/floor/almayer/blue/north,
 /area/almayer/command/cichallway)
 "qyA" = (
-/obj/structure/machinery/cm_vending/clothing/intelligence_officer{
-	density = 0;
-	pixel_x = -32
+/obj/structure/machinery/cryopod{
+	pixel_y = 6
 	},
-/turf/open/floor/almayer/silver/west,
-/area/almayer/command/computerlab)
+/turf/open/floor/almayer/cargo,
+/area/almayer/living/iobunks)
 "qyD" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/recharger,
@@ -50490,12 +50450,6 @@
 	},
 /turf/open/floor/almayer/red/southeast,
 /area/almayer/lifeboat_pumps/south1)
-"qTi" = (
-/obj/structure/closet/crate,
-/obj/item/ammo_box/magazine/l42a,
-/obj/item/ammo_box/magazine/l42a,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/upper/u_m_s)
 "qTu" = (
 /obj/structure/machinery/power/apc/almayer/north,
 /turf/open/floor/almayer/plate,
@@ -52164,6 +52118,10 @@
 /obj/item/tool/soap,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/upper/u_a_s)
+"rCe" = (
+/obj/structure/pipes/vents/scrubber,
+/turf/open/floor/almayer,
+/area/almayer/living/iobunks)
 "rCh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -54983,19 +54941,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/p_bow)
 "sIA" = (
-/obj/structure/sign/poster{
-	desc = "This poster features Audrey Rainwater standing in a jacuzzi. She was the July 2182 centerfold in House Bunny Gentleman's Magazine. Don't ask how you know that.";
-	icon_state = "poster16";
-	layer = 3.3;
-	name = "'Miss July' Pinup";
-	pixel_y = 29;
-	serial_number = 16
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "W";
-	pixel_x = -1
-	},
-/turf/open/floor/almayer/silver/northwest,
+/turf/open/floor/almayer/silver/north,
 /area/almayer/engineering/port_atmos)
 "sII" = (
 /obj/effect/step_trigger/clone_cleaner,
@@ -55266,15 +55212,6 @@
 /obj/effect/landmark/map_item,
 /turf/open/floor/almayer/sterile_green_corner/north,
 /area/almayer/medical/upper_medical)
-"sPa" = (
-/obj/structure/surface/rack,
-/obj/item/stack/cable_coil,
-/obj/item/attachable/flashlight/grip,
-/obj/item/ammo_box/magazine/l42a{
-	pixel_y = 14
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/upper/u_m_s)
 "sPb" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -55454,6 +55391,11 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cells)
+"sUu" = (
+/obj/effect/landmark/start/intel,
+/obj/effect/landmark/late_join/intel,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/living/iobunks)
 "sUE" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /turf/open/floor/almayer/bluefull,
@@ -55611,6 +55553,10 @@
 	},
 /turf/open/floor/almayer/green/northeast,
 /area/almayer/shipboard/brig/cells)
+"sXT" = (
+/obj/structure/surface/table/almayer,
+/turf/open/floor/almayer/silver,
+/area/almayer/living/iobunks)
 "sYh" = (
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/lower_medical_medbay)
@@ -55811,6 +55757,12 @@
 	},
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/hallways/upper/starboard)
+"tbC" = (
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/open/floor/almayer,
+/area/almayer/living/iobunks)
 "tcd" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/radio{
@@ -56776,6 +56728,13 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/medical_science)
+"tsO" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_y = 8
+	},
+/turf/open/floor/almayer/silver,
+/area/almayer/living/iobunks)
 "tsX" = (
 /turf/closed/wall/almayer/reinforced,
 /area/almayer/shipboard/brig/lobby)
@@ -57573,6 +57532,11 @@
 	},
 /turf/open/floor/almayer/cargo,
 /area/almayer/living/bridgebunks)
+"tKy" = (
+/obj/structure/surface/table/almayer,
+/obj/item/folder/black,
+/turf/open/floor/almayer/plate,
+/area/almayer/living/iobunks)
 "tKY" = (
 /obj/structure/bed/chair{
 	dir = 8;
@@ -57861,14 +57825,6 @@
 /obj/structure/bed/chair/comfy/delta,
 /turf/open/floor/almayer/plate,
 /area/almayer/living/briefing)
-"tSX" = (
-/obj/structure/surface/table/almayer,
-/obj/item/weapon/gun/rifle/l42a{
-	pixel_y = 6
-	},
-/obj/item/weapon/gun/rifle/l42a,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/upper/u_m_s)
 "tTk" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -58035,13 +57991,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/sterile_green_side/west,
 /area/almayer/medical/upper_medical)
-"tXa" = (
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 13
-	},
-/obj/structure/machinery/power/apc/almayer/north,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/upper/u_m_s)
 "tXb" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/bed/chair/comfy/charlie{
@@ -58918,15 +58867,6 @@
 "uqo" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
-"uqs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/guncabinet,
-/obj/item/weapon/gun/rifle/m41a{
-	pixel_y = 6
-	},
-/obj/item/weapon/gun/rifle/m41a,
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/upper/u_m_s)
 "uqA" = (
 /obj/structure/machinery/firealarm{
 	dir = 8;
@@ -64045,13 +63985,6 @@
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer/sterile_green,
 /area/almayer/medical/lockerroom)
-"wks" = (
-/obj/structure/bed/chair{
-	dir = 8;
-	pixel_y = 3
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/maint/upper/u_m_s)
 "wky" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -64092,6 +64025,15 @@
 /obj/structure/machinery/door/poddoor/almayer/blended/ai_lockdown/aicore,
 /turf/open/floor/almayer/no_build/test_floor4,
 /area/almayer/command/airoom)
+"wkS" = (
+/obj/item/clipboard,
+/obj/item/paper{
+	pixel_y = 7;
+	pixel_x = 3
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/almayer/silver/east,
+/area/almayer/living/iobunks)
 "wkX" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 6
@@ -64142,6 +64084,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/req)
 "wlr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
 /turf/open/floor/almayer/silver/northeast,
 /area/almayer/hallways/upper/midship_hallway)
 "wlD" = (
@@ -65980,6 +65925,12 @@
 "wWC" = (
 /turf/open/floor/almayer/blue/southwest,
 /area/almayer/living/pilotbunks)
+"wWM" = (
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/turf/open/floor/almayer,
+/area/almayer/living/iobunks)
 "wWP" = (
 /obj/structure/prop/cash_register/broken,
 /obj/structure/machinery/light/small,
@@ -66322,12 +66273,8 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/u_a_p)
 "xfm" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/almayer/living/cafeteria_officer)
+/turf/closed/wall/almayer,
+/area/almayer/living/iobunks)
 "xfq" = (
 /obj/structure/sign/safety/hvac_old{
 	pixel_x = 8;
@@ -66673,6 +66620,13 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_f_p)
+"xmF" = (
+/obj/structure/surface/table/almayer,
+/obj/structure/machinery/computer/emails{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/almayer/living/iobunks)
 "xmJ" = (
 /obj/structure/closet,
 /obj/structure/sign/safety/bathunisex{
@@ -67287,8 +67241,9 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/open/floor/almayer/silver/east,
 /area/almayer/hallways/upper/midship_hallway)
@@ -106107,7 +106062,7 @@ lIY
 gxn
 aMy
 kNV
-wNC
+jLp
 wlr
 xyp
 mnf
@@ -106301,16 +106256,16 @@ njn
 hZE
 sVV
 oON
-njn
-njn
-daI
-njn
-njn
-ael
-ael
+xfm
+xfm
+xfm
+xfm
+xfm
+xfm
+xfm
 agQ
 aih
-ael
+xfm
 hyT
 lGh
 iCg
@@ -106504,17 +106459,17 @@ njn
 xVe
 sVV
 mbx
-njn
-tXa
-gJg
-tSX
-lzt
-ael
-afE
-agT
-dgI
-ael
-ogT
+xfm
+fql
+kSi
+iXs
+kSi
+iXR
+eXp
+gSj
+nxD
+xfm
+okm
 yiu
 xIj
 xIj
@@ -106707,17 +106662,17 @@ njn
 hHe
 gxn
 ioH
-njn
-jXk
-cGR
-wks
-jFM
+xfm
+mmn
+mSo
+eHF
+ahe
+ahe
+ahe
+tbC
+aXA
 ael
-afH
-agV
-ain
-ael
-cQC
+xIj
 poD
 rjr
 aMl
@@ -106910,16 +106865,16 @@ aba
 aGA
 kbv
 fZo
-njn
-pKL
-jsA
-jsA
-qTi
-ael
-afI
-agY
-aiq
 xfm
+gdm
+mSo
+kkB
+mSo
+mSo
+mSo
+rCe
+kgu
+ael
 xIj
 qdJ
 iCg
@@ -107113,15 +107068,15 @@ njn
 mAF
 ilq
 pjj
-njn
-kCl
-cGR
-jsA
-uqs
-ael
-afJ
-agY
-aiq
+xfm
+fOt
+mSo
+mSo
+mSo
+tKy
+xmF
+daI
+sXT
 xfm
 xIj
 qdJ
@@ -107316,16 +107271,16 @@ njn
 hZE
 kbv
 mbx
-njn
-ePz
-cGR
-jsA
-uqs
-ael
-afK
-ahc
-air
-ael
+xfm
+sUu
+sUu
+sUu
+mSo
+mSo
+wWM
+mSo
+tsO
+xfm
 sgH
 qdJ
 xIj
@@ -107519,16 +107474,16 @@ njn
 laM
 kbv
 nkH
-njn
-bVR
-gJg
-sPa
-mSo
-ael
-afL
-ahe
-aij
-ael
+xfm
+qyA
+qyA
+qyA
+aaM
+wkS
+aaM
+njH
+cQC
+xfm
 xIj
 yiu
 xIj
@@ -107723,7 +107678,7 @@ hZE
 kbv
 mbx
 njn
-daI
+njn
 njn
 njn
 njn
@@ -107957,7 +107912,7 @@ xXd
 qdJ
 iCg
 aUH
-aXx
+jbu
 jKI
 aXx
 nIN
@@ -108161,7 +108116,7 @@ poD
 xIj
 aUH
 oyE
-mMP
+mQC
 mMP
 nIN
 xzh
@@ -108364,8 +108319,8 @@ qdJ
 xIj
 aUH
 sIA
-gSj
-aXA
+mQC
+hcf
 nIN
 xzh
 gNo
@@ -108755,10 +108710,10 @@ qyZ
 wTd
 cmK
 cyP
-kSi
-mmn
-kSi
-qyA
+kXu
+kXu
+kXu
+kXu
 kXu
 jHC
 liJ


### PR DESCRIPTION

# About the pull request
IOs now have their own dedicated prep room, with all the same vendors as they had in the Intel Processing Room, their Spawn location has also been moved.

# Explain why it's good for the game
Mostly QOL for ASOs but it's a combination of not wanting to have to deal with IOs leaving heaps of gear in Intel and not cleaning up after themselves, and just that in my opinion, a prep area and work area shouldn't really be merged together as it usually leads to problems with one or the other causing problems for each other, be it one side lying gear on the floor or the other throwing it away.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/db3d6bcd-4031-4c14-ab85-2c0697eef79a)

</details>


# Changelog
:cl:
mapadd: Added an IO Prep Room
/:cl:
