### PR TITLE
Actually fix Colonial Space Grunts runtimes when mapped in

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -916,13 +916,16 @@
 	name = "Colonial Space Grunts"
 	desc = "A tabletop game based around the USCM, easy to get into, simple to play, and most inportantly fun for the whole squad."
 
+/obj/item/paper/colonial_grunts/Initialize(mapload, photo_list)
+	..()
+	return INITIALIZE_HINT_ROUNDSTART
+
+/obj/item/paper/colonial_grunts/LateInitialize()
+	. = ..()
+	info = "<div> <img style='align:middle' src='[SSassets.transport.get_asset_url("colonialspacegruntsEZ.png")]'>"
+
 /obj/item/paper/colonial_grunts/update_icon()
 	return // Keep original icon_state
-
-/obj/item/paper/colonial_grunts/read_paper(mob/user, scramble)
-	if(!info)
-		info = "<div> <img style='align:middle' src='[SSassets.transport.get_asset_url("colonialspacegruntsEZ.png")]'>"
-	return ..()
 
 /obj/item/paper/liaison_brief
 	name = "Liaison Colony Briefing"

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -916,14 +916,13 @@
 	name = "Colonial Space Grunts"
 	desc = "A tabletop game based around the USCM, easy to get into, simple to play, and most inportantly fun for the whole squad."
 
-/obj/item/paper/colonial_grunts/Initialize(mapload, photo_list)
-	. = ..()
-	return INITIALIZE_HINT_LATELOAD
+/obj/item/paper/colonial_grunts/update_icon()
+	return // Keep original icon_state
 
-/obj/item/paper/colonial_grunts/LateInitialize()
-	. = ..()
-	info = "<div> <img style='align:middle' src='[SSassets.transport.get_asset_url("colonialspacegruntsEZ.png")]'>"
-	update_icon()
+/obj/item/paper/colonial_grunts/read_paper(mob/user, scramble)
+	if(!info)
+		info = "<div> <img style='align:middle' src='[SSassets.transport.get_asset_url("colonialspacegruntsEZ.png")]'>"
+	return ..()
 
 /obj/item/paper/liaison_brief
 	name = "Liaison Colony Briefing"


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #7829 where if mapped in, space grunts will still cause a runtime. So lets only load it when the round starts.

# Explain why it's good for the game

Allows you to map this in without runtimes.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/6bca371e-312d-442d-848a-e4bf60128622)

</details>


# Changelog
:cl: Drathek
fix: Actually fixed asset transport errors if the space grunts paper is mapped in.
/:cl:
