### PR TITLE
Fix hooks too: Bump python

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -18,4 +18,4 @@ export NODE_VERSION_LTS=20.12.0
 export SPACEMAN_DMM_VERSION=suite-1.8
 
 # Python version for mapmerge and other tools
-export PYTHON_VERSION=3.9.0
+export PYTHON_VERSION=3.11.9


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #7840 which bumps python since pygit2 1.16.0 requires python to be >= 3.10.

# Explain why it's good for the game

Working hooks.

# Changelog

No player facing changes.
