### PR TITLE
Synth reset key fits in tool webbing, engineer kit pouch and construction belt

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -156,6 +156,7 @@
 		/obj/item/defenses/handheld/sentry,
 		/obj/item/stack/rods,
 		/obj/item/stack/tile,
+		/obj/item/device/defibrillator/synthetic,
 	)
 
 	bypass_w_limit = list(

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -831,6 +831,7 @@
 		/obj/item/device/assembly = list(SKILL_ENGINEER, SKILL_ENGINEER_TRAINED),
 		/obj/item/stock_parts = list(SKILL_ENGINEER, SKILL_ENGINEER_TRAINED),
 		/obj/item/explosive/plastic = list(SKILL_ENGINEER, SKILL_ENGINEER_TRAINED),
+		/obj/item/device/defibrillator/synthetic = list(SKILL_ENGINEER, SKILL_ENGINEER_TRAINED),
 	)
 	can_hold_skill_only = TRUE
 

--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -684,6 +684,7 @@
 		/obj/item/device/multitool,
 		/obj/item/tool/shovel/etool,
 		/obj/item/weapon/gun/smg/nailgun/compact,
+		/obj/item/device/defibrillator/synthetic,
 	)
 
 /obj/item/storage/internal/accessory/tool_webbing/small


### PR DESCRIPTION

# About the pull request

The synthetic reset key can now fit into small tool webbing, construction belt, and engineer kit pouch.

# Explain why it's good for the game

The reset key already fits in engineering kits and normal toolbelts, I don't see why it shouldn't fit in tool webbings and kit pouches. Added the construction belt to the list because it holds general tools.

# Testing Photographs and Procedure
N/A

</details>


# Changelog

:cl: Stakeyng
add: Synth reset key fits in construction belt, tool webbing, and engineer kit pouch
/:cl:

