### PR TITLE
Hunting grounds is now exempt from affecting larva queue

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -49,6 +49,9 @@
 #define AREA_UNWEEDABLE (1<<4)
 /// Flags the area as having purpose by the Yautja, and exempt from gear tracking.
 #define AREA_YAUTJA_GROUNDS (1<<5)
+/// Flags the area as a hunting grounds for the Yautja, sometimes blocking game interaction.
+#define AREA_YAUTJA_HUNTING_GROUNDS (1<<6)
+
 /// Default number of ticks for do_after
 #define DA_DEFAULT_NUM_TICKS 5
 

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1694,12 +1694,15 @@ GLOBAL_LIST_INIT(duplicate_forbidden_vars,list(
 
 /// Returns TRUE if the target is somewhere that the game should not interact with if possible
 /// In this case, admin Zs and tutorial areas
-/proc/should_block_game_interaction(atom/target)
+/proc/should_block_game_interaction(atom/target, include_hunting_grounds = FALSE)
 	if(is_admin_level(target.z))
 		return TRUE
 
 	var/area/target_area = get_area(target)
 	if(target_area?.block_game_interaction)
+		return TRUE
+
+	if(include_hunting_grounds && target_area?.flags_area & AREA_YAUTJA_HUNTING_GROUNDS)
 		return TRUE
 
 	return FALSE

--- a/code/game/area/hunting_preserve.dm
+++ b/code/game/area/hunting_preserve.dm
@@ -5,7 +5,7 @@
 	icon_state = "green"
 	ambience_exterior = AMBIENCE_JUNGLE
 	weather_enabled = FALSE
-	flags_area = AREA_NOTUNNEL|AREA_AVOID_BIOSCAN|AREA_YAUTJA_GROUNDS
+	flags_area = AREA_NOTUNNEL|AREA_AVOID_BIOSCAN|AREA_YAUTJA_GROUNDS|AREA_YAUTJA_HUNTING_GROUNDS
 	resin_construction_allowed = FALSE
 	can_build_special = FALSE
 	is_resin_allowed = TRUE

--- a/code/modules/cm_preds/yaut_bracers.dm
+++ b/code/modules/cm_preds/yaut_bracers.dm
@@ -939,7 +939,7 @@
 	if(boomer.stat)
 		to_chat(boomer, SPAN_WARNING("Not while you're unconscious..."))
 		return
-	if(istype(grounds, /area/yautja_grounds)) //Hunted need mask to escape
+	if(grounds?.flags_area & AREA_YAUTJA_HUNTING_GROUNDS) //Hunted need mask to escape
 		to_chat(boomer, SPAN_WARNING("Your bracer will not allow you to activate a self-destruction sequence in order to protect the hunting preserve."))
 		return
 
@@ -1007,7 +1007,7 @@
 		if(boomer.stat)
 			to_chat(boomer, SPAN_WARNING("Not while you're unconscious..."))
 			return
-		if(istype(grounds, /area/yautja_grounds)) // Hunted need mask to escape
+		if(grounds?.flags_area & AREA_YAUTJA_HUNTING_GROUNDS) // Hunted need mask to escape
 			to_chat(boomer, SPAN_WARNING("Your bracer will not allow you to activate a self-destruction sequence in order to protect the hunting preserve."))
 			return
 		if(exploding)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -480,7 +480,8 @@ Works together with spawning an observer, noted above.
 	mind = null
 
 	// Larva queue: We use the larger of their existing queue time or the new timeofdeath except for facehuggers or lesser drone
-	var/new_tod = (isfacehugger(src) || islesserdrone(src)) ? 1 : ghost.timeofdeath
+	var/exempt_tod = isfacehugger(src) || islesserdrone(src) || should_block_game_interaction(src, include_hunting_grounds=TRUE)
+	var/new_tod = exempt_tod ? 1 : ghost.timeofdeath
 
 	// if they died as facehugger or lesser drone, bypass typical TOD checks
 	ghost.bypass_time_of_death_checks = (isfacehugger(src) || islesserdrone(src))
@@ -547,7 +548,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		log_game("[key_name_admin(client)] has ghosted.")
 		var/mob/dead/observer/ghost = ghostize((is_nested && nest && !QDELETED(nest))) //FALSE parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
 		SEND_SIGNAL(src, COMSIG_LIVING_GHOSTED, ghost)
-		if(ghost && !should_block_game_interaction(src))
+		if(ghost && !should_block_game_interaction(src, include_hunting_grounds=TRUE))
 			ghost.timeofdeath = world.time
 
 			// Larva queue: We use the larger of their existing queue time or the new timeofdeath except for facehuggers or lesser drone

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -89,7 +89,8 @@
 	GLOB.dead_mob_list += src
 
 	// Larva queue: We use the larger of their existing queue time or the new timeofdeath except for facehuggers or lesser drone
-	var/new_tod = (should_block_game_interaction(src) || isfacehugger(src) || islesserdrone(src)) ? 1 : timeofdeath
+	var/exempt_tod = isfacehugger(src) || islesserdrone(src) || should_block_game_interaction(src, include_hunting_grounds=TRUE)
+	var/new_tod = exempt_tod ? 1 : timeofdeath
 	if(client)
 		client.player_details.larva_queue_time = max(client.player_details.larva_queue_time, new_tod)
 	else if(persistent_ckey)


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #7486 which now flags the hunting grounds with `AREA_YAUTJA_HUNTING_GROUNDS` and can optionally be tested against in `should_block_game_interaction` which is now checked as far as the ToD for larva queue.

# Explain why it's good for the game

Generally ghost activities should not penalize you from rejoining the main game.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
balance: Hunting ground deaths no longer counts against larva queue
/:cl:
