### PR TITLE
Suppress fit_viewport div by 0 error

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -232,7 +232,8 @@
 	if(split_width - desired_width < 240)
 		desired_width = split_width - 240
 
-	if (text2num(map_size[1]) == desired_width)
+	if (text2num(map_size[1]) == desired_width || split_width == 0)
+		// If split_width is 0, it likely means they are minimized and we don't know what the window size would be
 		// Nothing to do
 		return
 


### PR DESCRIPTION

# About the pull request

This PR simply early returns if the window size is 0 (occurs when the game is minimized when autofit viewport tries to fit the viewport).

# Explain why it's good for the game

Less runtimes.

# Changelog
:cl: Drathek
fix: Suppressed a div by 0 error when autofit viewport tries to fit the window while minimized
/:cl:
