### PR TITLE
Suppress runtime for imaginary friend SEA

### DIFF
--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -652,7 +652,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/device/whistle(new_human), WEAR_R_HAND)
 
 /datum/equipment_preset/uscm_ship/sea/load_rank(mob/living/carbon/human/rankee, client/mob_client)
-	mob_client.toggle_newplayer_ic_hud(TRUE)
+	mob_client?.toggle_newplayer_ic_hud(TRUE)
 	if(rankee?.client?.prefs?.pref_special_job_options[rank])
 		var/paygrade_choice = get_paygrade_id_by_name(rankee.client.prefs.pref_special_job_options[rank])
 		return paygrade_choice


### PR DESCRIPTION

# About the pull request

This PR just adds a nullcheck to `mob_client` for SEA's new player hud. In this case a flat icon is being generated for a SEA with no client, so a HUD is not applicable. There isn't an effect by this change though that I can tell (appearance would be made fine just before and after).

# Explain why it's good for the game
Less runtimes.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/f1d2a0d1-9b2b-4157-b7d4-36f160d16280)

</details>


# Changelog
:cl: Drathek
fix: Fixed a runtime when generating SEA appearance for an imaginary friend
/:cl:
