### PR TITLE
APC Linting

### DIFF
--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -6,6 +6,7 @@
 	light_system = MOVABLE_LIGHT
 	light_range = 3
 	use_power = USE_POWER_NONE
+	needs_power = FALSE
 	var/obj/item/card/id/botcard // the ID card that the bot "holds"
 	var/on = 1
 	unslashable = TRUE

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -3,6 +3,7 @@
 	desc = "It's used to monitor rooms."
 	icon = 'icons/obj/structures/machinery/monitors.dmi'
 	icon_state = "autocam_editor"
+	needs_power = FALSE
 	use_power = USE_POWER_ACTIVE
 	idle_power_usage = 5
 	active_power_usage = 10

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -782,6 +782,7 @@
 	anchored = TRUE
 	density = FALSE
 	layer = BELOW_TABLE_LAYER
+	needs_power = FALSE
 	use_power = USE_POWER_ACTIVE
 	idle_power_usage = 2
 	active_power_usage = 20

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -78,6 +78,7 @@
 #define TRAIT_SOURCE_UNIT_TESTS "unit_tests"
 
 // Unit tests
+#include "areas_unpowered.dm"
 #include "autowiki.dm"
 #include "check_runtimes.dm"
 #include "create_and_destroy.dm"

--- a/code/modules/unit_tests/areas_unpowered.dm
+++ b/code/modules/unit_tests/areas_unpowered.dm
@@ -1,0 +1,46 @@
+/datum/unit_test/areas_unpowered
+	/// Assoc list per area containing an assoc list per machine.type containing count of that type
+	var/list/areas_with_machines = list()
+
+/datum/unit_test/areas_unpowered/proc/determine_areas_needing_power()
+	for(var/obj/structure/machinery/machine as anything in GLOB.machines)
+		if(machine.needs_power)
+			var/area/machine_area = get_step(machine, 0)?.loc // get_area without the area check
+			if(!areas_with_machines[machine_area])
+				areas_with_machines[machine_area] = list()
+			areas_with_machines[machine_area][machine.type]++
+
+/datum/unit_test/areas_unpowered/Run()
+	determine_areas_needing_power()
+
+	for(var/area/cur_area as anything in areas_with_machines)
+		if(!cur_area.requires_power)
+			continue
+		if(cur_area.unlimited_power)
+			continue
+		if(cur_area.always_unpowered)
+			continue
+
+		var/apc_count = 0
+		for(var/obj/structure/machinery/power/apc/cur_apc in cur_area)
+			apc_count++
+
+		if(apc_count == 1)
+			continue // Pass
+		if(apc_count > 1)
+			TEST_FAIL("[cur_area] ([cur_area.type]) has [apc_count] APCs!")
+			continue
+
+		// Count all machines and note the first 5 types
+		var/machine_type_count = length(areas_with_machines[cur_area])
+		var/machine_total_count = 0
+		var/i = 0
+		var/machine_notes = "Machine types: "
+		for(var/machine_type in areas_with_machines[cur_area])
+			machine_total_count += areas_with_machines[cur_area][machine_type]
+			if(++i <= 5)
+				machine_notes += "[machine_type]"
+				if(i != machine_type_count && i < 5)
+					machine_notes += ", "
+
+		TEST_FAIL("[cur_area] ([cur_area.type]) lacks an APC but requires power for [machine_total_count] machine\s!\n\t[machine_notes]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR is an experimental lint to ensure all areas have a single APC if the area has machines that require power.

# Explain why it's good for the game

When an APC is not present, it is effectively always powered. An area can explicitly allow this (or force unpowered), but if it doesn't then it ought to have a single APC.

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Drathek
add: Added maplint to check whether areas needing power have a single APC
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
