### PR TITLE
Fix Xenos Without Thumbs Using Cards & M56D Reload & Closets

### DIFF
--- a/code/game/objects/items/toys/cards.dm
+++ b/code/game/objects/items/toys/cards.dm
@@ -108,7 +108,7 @@
 	if(usr.stat || !Adjacent(usr))
 		return
 
-	if(!ishuman(usr))
+	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
 		return
 
 	var/mob/living/carbon/human/user = usr
@@ -133,11 +133,12 @@
 
 	handle_draw_cards(usr)
 
-/obj/item/toy/deck/proc/handle_draw_cards(mob/mob)
-	if(mob.stat || !ishuman(mob) || !Adjacent(mob))
+/obj/item/toy/deck/proc/handle_draw_cards(mob/living/carbon/user)
+	if(user.stat || !Adjacent(user))
 		return
 
-	var/mob/living/carbon/human/user = usr
+	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
+		return
 
 	var/cards_length = length(cards)
 	if(!cards_length)
@@ -179,10 +180,13 @@
 	set category = "Object"
 	set src in view(1)
 
-	if(usr.stat || !ishuman(usr) || !Adjacent(usr))
+	if(usr.stat || !Adjacent(usr))
 		return
 
-	var/mob/living/carbon/human/user = usr
+	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
+		return
+
+	var/mob/living/carbon/user = usr
 
 	var/cards_length = length(cards)
 	if(!cards_length)
@@ -209,6 +213,9 @@
 	set src in view(1)
 
 	if(usr.stat || !Adjacent(usr))
+		return
+
+	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
 		return
 
 	if(!length(cards))
@@ -258,7 +265,10 @@
 	if(!usr || !over)
 		return
 
-	if(!ishuman(over) || get_dist(usr, over) > 3)
+	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
+		return
+
+	if(get_dist(usr, over) > 3)
 		return
 
 	if(!length(cards))
@@ -321,7 +331,10 @@
 	set category = "Object"
 	set src in usr
 
-	if(usr.stat || !ishuman(usr))
+	if(usr.stat)
+		return
+
+	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
 		return
 
 	pile_state = !pile_state
@@ -334,7 +347,10 @@
 	set desc = "Sort this hand by deck's initial order."
 	set src in usr
 
-	if(usr.stat || !ishuman(usr))
+	if(usr.stat)
+		return
+
+	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
 		return
 
 	//fuck any qsorts and merge sorts. This needs to be brutally easy
@@ -419,9 +435,13 @@
 	user.visible_message(SPAN_NOTICE("\The [user] [concealed ? "conceals" : "reveals"] their hand."), SPAN_NOTICE("You [concealed ? "conceal" : "reveal"] your hand."))
 
 /obj/item/toy/handcard/MouseDrop(atom/over)
-	if(usr != over || !Adjacent(usr))
+	if(usr != over || !Adjacent(over))
 		return
 	if(ismob(loc))
+		return
+	if(usr.stat)
+		return
+	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
 		return
 
 	if(isstorage(loc))

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -293,6 +293,8 @@
 		return
 	if(O.anchored || get_dist(user, src) > 1 || get_dist(user, O) > 1)
 		return
+	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
+		return
 	if(!isturf(user.loc))
 		return
 	if(ismob(O))
@@ -353,8 +355,6 @@
 	if(ishuman(usr))
 		src.add_fingerprint(usr)
 		src.toggle(usr)
-	else
-		to_chat(usr, SPAN_WARNING("This mob type can't use this verb."))
 
 /obj/structure/closet/update_icon()//Putting the welded stuff in updateicon() so it's easy to overwrite for special cases (Fridges, cabinets, and whatnot)
 	overlays.Cut()

--- a/code/modules/cm_marines/m2c.dm
+++ b/code/modules/cm_marines/m2c.dm
@@ -481,7 +481,7 @@
 	// If the user is unconscious or dead.
 	if(user.stat)
 		return
-	if(!ishuman(user)  && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
+	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
 		return
 
 	if(over_object == user && in_range(src, user))

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -76,7 +76,7 @@
 	return
 
 /obj/item/device/m56d_gun/attackby(obj/item/O as obj, mob/user as mob)
-	if(!ishuman(user) || !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
+	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
 		return
 
 	if(QDELETED(O))


### PR DESCRIPTION
# About the pull request

This PR fixes several cases where xenos could interact with cards (when they didn't have thumbs). But now the xeno thumbs trait is recognized for cards/decks. Same for mousedrop w/ closets.

I also fixed an oversight with the m56d in gun form where the check for xeno thumbs was making it so humans couldn't reload the gun either.

# Explain why it's good for the game

Fixes: #7870 
Fixes: #7871 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/SlEDFREZRyo
https://youtu.be/TwY-7ULjsus

</details>

# Changelog
:cl: Drathek
fix: Fixed xenos being able to interact with cards (at least without thumbs)
fix: Fixed m56d being unable to be reloaded in gun form
fix: Fixed xenos being able to mousedrop mob/items into closets/crates/lockers
del: Removed a to_chat for failing to toggle_open verb
/:cl:
