### PR TITLE
Shield onmob sprite pathing fix

### DIFF
--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -74,7 +74,7 @@
 	item_icons = list(
 		WEAR_L_HAND = 'icons/mob/humans/onmob/inhands/weapons/melee/shields_lefthand.dmi',
 		WEAR_R_HAND = 'icons/mob/humans/onmob/inhands/weapons/melee/shields_righthand.dmi',
-		WEAR_BACK = 'icons/mob/humans/onmob/clothing/back/misc.dmi'
+		WEAR_BACK = 'icons/mob/humans/onmob/clothing/back/melee_weapons.dmi'
 	)
 
 	attack_verb = list("shoved", "bashed")


### PR DESCRIPTION

# About the pull request

Fixes code for fetching onmob sprites for wearing shields on the back.

# Explain why it's good for the game

Shields show up on your back. Lets people correctly gauge your equipment.


# Testing Photographs and Procedure


<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/93782919-ff1a-475f-90b3-fab51d035925)


Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog


:cl:
fix: puts correct path in wear_back function of shields.
/:cl:

