### PR TITLE
Unnest fixes

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
@@ -275,8 +275,6 @@
 		return
 	resisting = FALSE
 	resisting_ready = FALSE
-	buckled_mob.pixel_y = 0
-	buckled_mob.old_y = 0
 	REMOVE_TRAIT(buckled_mob, TRAIT_NESTED, TRAIT_SOURCE_BUCKLE)
 	REMOVE_TRAIT(buckled_mob, TRAIT_NO_STRAY, TRAIT_SOURCE_BUCKLE)
 	var/mob/living/carbon/human/buckled_human = buckled_mob

--- a/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
@@ -50,6 +50,8 @@
 	if(buckled_mob == current_mob)
 		current_mob.pixel_y = buckling_y["[dir]"]
 		current_mob.pixel_x = buckling_x["[dir]"]
+		current_mob.old_y = buckling_y["[dir]"]
+		current_mob.old_x = buckling_x["[dir]"]
 		current_mob.dir = turn(dir, 180)
 		ADD_TRAIT(current_mob, TRAIT_UNDENSE, XENO_NEST_TRAIT)
 		pixel_y = buckling_y["[dir]"]

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -103,7 +103,7 @@
 		var/list/turf/cardinal_neighbors = list(get_step(src, NORTH), get_step(src, SOUTH), get_step(src, EAST), get_step(src, WEST))
 		for(var/turf/cardinal_turf as anything in cardinal_neighbors)
 			for(var/obj/structure/bed/nest/found_nest in cardinal_turf)
-				if(found_nest.dir == get_dir(found_nest, src))
+				if(found_nest.dir == get_dir(found_nest, src) && !istype(.,/turf/closed/wall/resin/))
 					qdel(found_nest) //nests are built on walls, no walls, no nest
 
 /turf/closed/wall/MouseDrop_T(mob/current_mob, mob/user)

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -103,7 +103,7 @@
 		var/list/turf/cardinal_neighbors = list(get_step(src, NORTH), get_step(src, SOUTH), get_step(src, EAST), get_step(src, WEST))
 		for(var/turf/cardinal_turf as anything in cardinal_neighbors)
 			for(var/obj/structure/bed/nest/found_nest in cardinal_turf)
-				if(found_nest.dir == get_dir(found_nest, src) && !istype(.,/turf/closed/wall/resin/))
+				if(found_nest.dir == get_dir(found_nest, src) && !src.density)
 					qdel(found_nest) //nests are built on walls, no walls, no nest
 
 /turf/closed/wall/MouseDrop_T(mob/current_mob, mob/user)

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -103,7 +103,7 @@
 		var/list/turf/cardinal_neighbors = list(get_step(src, NORTH), get_step(src, SOUTH), get_step(src, EAST), get_step(src, WEST))
 		for(var/turf/cardinal_turf as anything in cardinal_neighbors)
 			for(var/obj/structure/bed/nest/found_nest in cardinal_turf)
-				if(found_nest.dir == get_dir(found_nest, src) && !src.density)
+				if(found_nest.dir == get_dir(found_nest, src) && !density)
 					qdel(found_nest) //nests are built on walls, no walls, no nest
 
 /turf/closed/wall/MouseDrop_T(mob/current_mob, mob/user)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -624,19 +624,17 @@ note dizziness decrements automatically in the mob's Life() proc.
 
 // Typo from the oriignal coder here, below lies the jitteriness process. So make of his code what you will, the previous comment here was just a copypaste of the above.
 /mob/proc/jittery_process()
-	var/jittering_old_x = pixel_x
-	var/jittering_old_y = pixel_y
 	is_jittery = 1
 	while(jitteriness > 100)
 		var/amplitude = min(4, jitteriness / 100)
-		pixel_x = jittering_old_x + rand(-amplitude, amplitude)
-		pixel_y = jittering_old_y + rand(-amplitude/3, amplitude/3)
+		pixel_x = old_x + rand(-amplitude, amplitude)
+		pixel_y = old_y + rand(-amplitude/3, amplitude/3)
 
 		sleep(1)
 	//endwhile - reset the pixel offsets to zero
 	is_jittery = 0
-	pixel_x = jittering_old_x
-	pixel_y = jittering_old_y
+	pixel_x = old_x
+	pixel_y = old_y
 
 //handles up-down floaty effect in space
 /mob/proc/make_floating(n)


### PR DESCRIPTION
# About the pull request

1. Fixed mobs getting unnested due to the wall they are on being upgraded by checking if there is still a nestable surface there after the turf change.

2. Fixed mobs not regaining their original pixel offset after being unnested while jittering (ie. from late stage larva).
During the last change of related code the original offset was simply never stored.
Technically we aren't preserving the mob type's intended offset like this, but I am just replicating the behaviour of the parent proc (/obj/structure/bed/afterbuckle), but fixing that I consider out of scope here.

Also cleaned up a couple of redundant pieces of code.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Mobs no longer get unnested when the wall that they are on gets upgraded.
fix: Mobs now regain their original pixel offset upon being unnested even when jittering.

/:cl:
