### PR TITLE
Put players with no squad preference in random squads again

### DIFF
--- a/code/game/jobs/job/marine/squads.dm
+++ b/code/game/jobs/job/marine/squads.dm
@@ -1,8 +1,6 @@
 //This datum keeps track of individual squads. New squads can be added without any problem but to give them
 //access you must add them individually to access.dm with the other squads. Just look for "access_alpha" and add the new one
 
-//Note: some important procs are held by the job controller, in job_controller.dm.
-//In particular, get_lowest_squad() and randomize_squad()
 /datum/squad_type //Majority of this is for a follow-on PR to fully flesh the system out and add more bits for other factions.
 	var/name = "Squad Type"
 	var/lead_name

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -545,6 +545,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 	for(var/datum/squad/squad in squads)
 		if(squad.roundstart && squad.usable && squad.faction == human.faction && squad.name != "Root")
 			mixed_squads += squad
+	mixed_squads = shuffle(mixed_squads)
 
 	var/preferred_squad
 	if(human?.client?.prefs?.preferred_squad)
@@ -556,11 +557,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 			if(squad.roles_in[slot_check] >= squad.roles_cap[slot_check])
 				continue
 
-		if(preferred_squad == "None")
-			if(squad.put_marine_in_squad(human))
-				return
-
-		else if(squad.name == preferred_squad || squad.equivalent_name == preferred_squad) //fav squad or faction equivalent has a spot for us, no more searching needed.
+		if(squad.name == preferred_squad || squad.equivalent_name == preferred_squad) //fav squad or faction equivalent has a spot for us, no more searching needed.
 			if(squad.put_marine_in_squad(human))
 				return
 


### PR DESCRIPTION

# About the pull request
This fixes a problem introduced in #6588, where marines with no squad preference started to get assigned squads in a deterministic order, where if Alpha has a job slot open, you always get assigned to it, then to Bravo and so on... And since there's no cap on riflemen, all riflemen with no squad preference would always be assigned to Alpha.

Before I fully understood that such a minimalist change would work, I actually [did a bigger rewrite](https://github.com/cmss13-devs/cmss13/commit/d31d22a4fe897dbe5fd62eb0e986de64720e8f90). That version is more computationally complex, but may be simpler to understand, due to being somewhat better abstracted. Just giving that as an option for maintainers too, if they're interested.

I did a bit of testing on the local server, seems to work fine.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Do we really want Alpha to suffer me as their SL every single round?
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: sg2002
fix: players with no squad preference get correctly put into random squads
/:cl:
