### PR TITLE
Yautja marks can be used appropriately

### DIFF
--- a/code/modules/cm_preds/yaut_hudprocs.dm
+++ b/code/modules/cm_preds/yaut_hudprocs.dm
@@ -187,7 +187,7 @@
 
 	var/list/target_list = list()
 	for(var/mob/living/carbon/target in view(7, usr.client))
-		if(ishuman_strict(target) && (target.stat != DEAD))
+		if(ishuman_strict(target))
 			if(target.hunter_data.honored)
 				target_list += target
 
@@ -264,7 +264,7 @@
 
 	var/list/target_list = list()
 	for(var/mob/living/carbon/target in view(7, usr.client))
-		if((ishuman_strict(target) || isxeno(target)) && target.stat != DEAD)
+		if(ishuman_strict(target) || isxeno(target))
 			if(target.job != "Predalien" && target.job != "Predalien Larva")
 				if(target.hunter_data.dishonored)
 					target_list += target
@@ -305,7 +305,7 @@
 
 	var/list/target_list = list()
 	for(var/mob/living/carbon/target in view(7, usr.client))
-		if((ishuman_strict(target) && target.stat != DEAD))
+		if(ishuman(target))
 			target_list += target
 
 	var/mob/living/carbon/T = tgui_input_list(usr, "Target", "Choose a target.", target_list)
@@ -336,7 +336,7 @@
 
 	var/list/target_list = list()
 	for(var/mob/living/carbon/target in view(7, usr.client))
-		if((ishuman_strict(target) && target.stat != DEAD))
+		if(ishuman(target))
 			if(target.hunter_data.gear)
 				target_list += target
 
@@ -347,17 +347,14 @@
 		to_chat(src, SPAN_YAUTJABOLD("[T] is not marked as a gear carrier!"))
 		return
 
-	if(!T.hunter_data.gear_set || src == T.hunter_data.gear_set)
 
-		log_interact(src, T, "[key_name(src)] has un-marked [key_name(T)] as a Gear Carrier!")
-		message_all_yautja("[real_name] has un-marked [T] as a Gear Carrier!'.")
+	log_interact(src, T, "[key_name(src)] has un-marked [key_name(T)] as a Gear Carrier!")
+	message_all_yautja("[real_name] has un-marked [T] as a Gear Carrier!'.")
 
-		T.hunter_data.gear_set = null
-		hunter_data.gear_targets -= T
-		T.hunter_data.gear = FALSE
-		T.hud_set_hunter()
-	else
-		to_chat(src, SPAN_YAUTJABOLD("You cannot undo the actions of a living brother or sister!"))
+	T.hunter_data.gear_set = null
+	hunter_data.gear_targets -= T
+	T.hunter_data.gear = FALSE
+	T.hud_set_hunter()
 
 
 /mob/living/carbon/human/proc/mark_thralled()
@@ -416,7 +413,7 @@
 	// We only target living humans
 	var/list/target_list = list()
 	for(var/mob/living/carbon/target in view(7, usr.client))
-		if(ishuman_strict(target) && target.stat != DEAD)
+		if(ishuman_strict(target))
 			if(target.hunter_data.thralled)
 				target_list += target
 


### PR DESCRIPTION

# About the pull request

This PR allows Yautja to correctly un-mark dead people, and to mark the dead as gear carriers.

# Explain why it's good for the game

The inability to unmark dead people has caused issues and was not intentional.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Yautja can now correctly un-mark dead people.
/:cl:
