### PR TITLE
Fix locking satchel overlay ordering

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -176,19 +176,18 @@
 		overlays += "+[icon_state]_full"
 		overlays += "+[icon_state]_locked"
 		return
-	else if(is_id_lockable)
-		overlays += "+[icon_state]_unlocked"
 
 	var/sum_storage_cost = 0
 	for(var/obj/item/I in contents)
 		sum_storage_cost += I.get_storage_cost()
-	if(!sum_storage_cost)
-		return
+	if(sum_storage_cost)
+		if(sum_storage_cost <= max_storage_space * 0.5)
+			overlays += "+[icon_state]_half"
+		else
+			overlays += "+[icon_state]_full"
 
-	else if(sum_storage_cost <= max_storage_space * 0.5)
-		overlays += "+[icon_state]_half"
-	else
-		overlays += "+[icon_state]_full"
+	if(is_id_lockable) // assumption: !locking_id
+		overlays += "+[icon_state]_unlocked"
 
 /obj/item/storage/backpack/get_examine_text(mob/user)
 	. = ..()


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #7659 that added the missing unlocked overlay to locking satchels. Now the unlocked state is overlayed above the fullness overlay.

# Explain why it's good for the game

Fixes:
![image](https://github.com/user-attachments/assets/b5705d72-0f84-4f68-8c5b-2d1be971cd05)
Now:
![image](https://github.com/user-attachments/assets/04143bcf-ef2e-4abc-a9be-481045732247)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/fwTDjN1I8Wk

</details>


# Changelog
:cl: Drathek
fix: Fixed locking satchel unlocked overlay not appearing on top
/:cl:
