### PR TITLE
Fixes maintainer access to the profiler and clears profiler access whenever admins are loaded.

### DIFF
--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -64,6 +64,10 @@ GLOBAL_LIST_EMPTY(admin_ranks) //list of all ranks with associated rights
 		C.admin_holder = null
 	GLOB.admins.Cut()
 
+	//Clear profile access
+	for(var/admin in world.GetConfig("admin"))
+		world.SetConfig("APP/admin", admin, null)
+
 	load_admin_ranks()
 
 		//load text from file

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -66,6 +66,7 @@ GLOBAL_LIST_EMPTY(admin_ranks) //list of all ranks with associated rights
 
 	//Clear profile access
 	for(var/admin in world.GetConfig("admin"))
+		debug_log("Clearing [admin] from APP/admin.")
 		world.SetConfig("APP/admin", admin, null)
 
 	load_admin_ranks()

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -66,7 +66,7 @@ GLOBAL_LIST_EMPTY(admin_ranks) //list of all ranks with associated rights
 
 	//Clear profile access
 	for(var/admin in world.GetConfig("admin"))
-		debug_log("Clearing [admin] from APP/admin.")
+		log_debug("Clearing [admin] from APP/admin.")
 		world.SetConfig("APP/admin", admin, null)
 
 	load_admin_ranks()

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -32,6 +32,7 @@ GLOBAL_PROTECT(href_token)
 	GLOB.admin_datums[ckey] = src
 	extra_titles = new_extra_titles
 	if(rights & R_PROFILER)
+		debug_log("Adding [ckey] to APP/admin.")
 		world.SetConfig("APP/admin", ckey, "role=admin")
 
 // Letting admins edit their own permission giver is a poor idea

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -45,8 +45,7 @@ GLOBAL_PROTECT(href_token)
 		owner.update_special_keybinds()
 		GLOB.admins |= C
 		if(owner.admin_holder.rights & R_PROFILER)
-			if(!world.GetConfig("admin", C.ckey))
-				world.SetConfig("APP/admin", C.ckey, "role=admin")
+			world.SetConfig("APP/admin", C.ckey, "role=admin")
 
 /datum/admins/proc/disassociate()
 	if(owner)

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -32,7 +32,7 @@ GLOBAL_PROTECT(href_token)
 	GLOB.admin_datums[ckey] = src
 	extra_titles = new_extra_titles
 	if(rights & R_PROFILER)
-		world.SetConfig("APP/admin", C.ckey, "role=admin")
+		world.SetConfig("APP/admin", ckey, "role=admin")
 
 // Letting admins edit their own permission giver is a poor idea
 /datum/admins/vv_edit_var(var_name, var_value)

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -46,7 +46,7 @@ GLOBAL_PROTECT(href_token)
 		GLOB.admins |= C
 		if(owner.admin_holder.rights & R_PROFILER)
 			if(!world.GetConfig("admin", C.ckey))
-				world.SetConfig("APP/admin", C.ckey, "role = coder")
+				world.SetConfig("APP/admin", C.ckey, "role=admin")
 
 /datum/admins/proc/disassociate()
 	if(owner)

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -31,6 +31,8 @@ GLOBAL_PROTECT(href_token)
 	href_token = GenerateToken()
 	GLOB.admin_datums[ckey] = src
 	extra_titles = new_extra_titles
+	if(owner.admin_holder.rights & R_PROFILER)
+		world.SetConfig("APP/admin", C.ckey, "role=admin")
 
 // Letting admins edit their own permission giver is a poor idea
 /datum/admins/vv_edit_var(var_name, var_value)
@@ -44,8 +46,6 @@ GLOBAL_PROTECT(href_token)
 		owner.tgui_say.load()
 		owner.update_special_keybinds()
 		GLOB.admins |= C
-		if(owner.admin_holder.rights & R_PROFILER)
-			world.SetConfig("APP/admin", C.ckey, "role=admin")
 
 /datum/admins/proc/disassociate()
 	if(owner)

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -31,7 +31,7 @@ GLOBAL_PROTECT(href_token)
 	href_token = GenerateToken()
 	GLOB.admin_datums[ckey] = src
 	extra_titles = new_extra_titles
-	if(owner.admin_holder.rights & R_PROFILER)
+	if(rights & R_PROFILER)
 		world.SetConfig("APP/admin", C.ckey, "role=admin")
 
 // Letting admins edit their own permission giver is a poor idea

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -32,7 +32,7 @@ GLOBAL_PROTECT(href_token)
 	GLOB.admin_datums[ckey] = src
 	extra_titles = new_extra_titles
 	if(rights & R_PROFILER)
-		debug_log("Adding [ckey] to APP/admin.")
+		log_debug("Adding [ckey] to APP/admin.")
 		world.SetConfig("APP/admin", ckey, "role=admin")
 
 // Letting admins edit their own permission giver is a poor idea


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->
As explained by the title.

# Explain why it's good for the game
Prevents a vulnerability where someone who previously had access to the profiler retains access despite no longer requiring it.

No player facing change so changelog not needed