### PR TITLE
Shivas Panic Room Insert Changes

### DIFF
--- a/code/game/objects/effects/landmarks/survivor_spawner.dm
+++ b/code/game/objects/effects/landmarks/survivor_spawner.dm
@@ -171,6 +171,17 @@
 
 	spawn_priority = SPAWN_PRIORITY_VERY_HIGH
 
+//Shivas Panic Room Survivors//
+
+/obj/effect/landmark/survivor_spawner/shivas_panic_room_pmc
+	equipment = /datum/equipment_preset/survivor/pmc/shivas
+	intro_text = list("<h2>You are the last living security element on the Colony!</h2>",\
+	"<span class='notice'>You are aware of the xenomorph threat.</span>",\
+	"<span class='danger'>Your primary objective is to survive the outbreak.</span>")
+	story_text = "You are a mercenary stationed on 'Ifrit' by Weyland-Yutani. This whole outbreak has been a giant mess, you and all other Company personnel ran to the Operations Panic Room, until you heard shooting outside and closed the shutters. You are running low on food, water and ammunition for the weapons. While you were assigned to protecting the people taking shelter in the Panic Room, the rest of your team was spread out throughout the colony. You have not seen any of them since. In their attempts at trying to breach in, the so called 'xenomorphs' have tried attacking the shutters, but to no avail. They will soon try again. You must survive and find a way to contact Weyland-Yutani."
+
+	spawn_priority = SPAWN_PRIORITY_VERY_HIGH
+
 /obj/effect/landmark/survivor_spawner/shivas_panic_room_cl
 	equipment = /datum/equipment_preset/survivor/corporate/asstmanager
 	synth_equipment = /datum/equipment_preset/synth/survivor/wy/corporate_synth
@@ -179,7 +190,7 @@
 	"<span class='danger'>Your primary objective is to survive the outbreak.</span>")
 	story_text = "You are the Assistant Operations Manager stationed on 'Ifrit' by Weyland-Yutani. This whole outbreak has been a giant mess, you and all other Company personnel ran to the Operations Panic Room, until you heard shooting outside and closed the shutters. You are running low on food, water and ammunition for the weapons you one-day said were 'useless' and a waste of Company dollars. You remember that Administrator Stahl sent out a distress beacon to any ship in range, hoping to get picked up by the Company, he ran to the Spaceport. You have not seen him since. In their attempts at trying to breach in, the so called 'xenomorphs' have tried attacking the shutters, but to no avail. They will soon try again. You must survive and find a way to contact Weyland-Yutani."
 
-	spawn_priority = SPAWN_PRIORITY_VERY_HIGH
+	spawn_priority = SPAWN_PRIORITY_HIGH
 
 /obj/effect/landmark/survivor_spawner/shivas_panic_room_doc
 	equipment = /datum/equipment_preset/survivor/doctor/shiva
@@ -191,6 +202,22 @@
 
 	spawn_priority = SPAWN_PRIORITY_HIGH
 
+/obj/effect/landmark/survivor_spawner/shivas_panic_room_doc/medium_priority
+	spawn_priority = SPAWN_PRIORITY_MEDIUM
+
+/obj/effect/landmark/survivor_spawner/shivas_panic_room_eng
+	equipment = /datum/equipment_preset/survivor/engineer/shiva
+	synth_equipment = /datum/equipment_preset/synth/survivor/engineer_synth
+	intro_text = list("<h2>You are an Engineer on the Colony!</h2>",\
+	"<span class='notice'>You are aware of the xenomorph threat.</span>",\
+	"<span class='danger'>Your primary objective is to survive the outbreak.</span>")
+	story_text = "You are an Engineer working on 'Ifrit' for Weyland-Yutani. This whole outbreak has been a giant mess, you and all other Company personnel ran to the Operations Panic Room, until you heard shooting outside and closed the shutters. You are running low on food, water and ammunition for the weapons. You remember that the xenomorphs seem to be able to see in the dark, as you saw one grab a co-worker trying to fix the generators after the power went out. In their attempts at trying to breach in, the so called 'xenomorphs' have tried attacking the shutters, but to no avail. They will soon try again. You must survive and find a way to contact Weyland-Yutani."
+
+	spawn_priority = SPAWN_PRIORITY_HIGH
+
+/obj/effect/landmark/survivor_spawner/shivas_panic_room_eng/medium_priority
+	spawn_priority = SPAWN_PRIORITY_MEDIUM
+
 /obj/effect/landmark/survivor_spawner/shivas_panic_room_sci
 	equipment = /datum/equipment_preset/survivor/scientist/shiva
 	synth_equipment = /datum/equipment_preset/synth/survivor/scientist_synth
@@ -200,6 +227,9 @@
 	story_text = "You are a Scientist working on 'Ifrit' for Weyland-Yutani. This whole outbreak has been a giant mess, you and all other Company personnel ran to the Operations Panic Room, until you heard shooting outside and closed the shutters. You are running low on food, water and ammunition for the weapons. You remember that the XX-121 species, codenamed that by Research Director Clarke, have a variety of different species, what you can assume a 'leader' of some sort and that their acid is deadly should it come in contact with you or the shutters. You ran far from the labs and have not seen some your coworkers since. In their attempts at trying to breach in, these so called 'xenomorphs' have tried attacking the shutters, but to no avail. They will soon try again. You must survive and find a way to contact Weyland-Yutani."
 
 	spawn_priority = SPAWN_PRIORITY_HIGH
+
+/obj/effect/landmark/survivor_spawner/shivas_panic_room_sci/medium_priority
+	spawn_priority = SPAWN_PRIORITY_MEDIUM
 
 /obj/effect/landmark/survivor_spawner/shivas_panic_room_civ
 	equipment = /datum/equipment_preset/survivor/civilian

--- a/code/modules/gear_presets/survivors/shivas_snowball/panic_room_insert_shivas.dm
+++ b/code/modules/gear_presets/survivors/shivas_snowball/panic_room_insert_shivas.dm
@@ -41,3 +41,55 @@
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/full(new_human), WEAR_R_STORE)
 	add_survivor_weapon_civilian(new_human)
 	..()
+
+/datum/equipment_preset/survivor/pmc/shivas
+	name = "Survivor - PMC (Shivas)"
+	flags = EQUIPMENT_PRESET_START_OF_ROUND
+	assignment = JOB_PMC_STANDARD
+	rank = JOB_PMC_STANDARD
+	faction = FACTION_PMC
+	faction_group = list(FACTION_WY, FACTION_SURVIVOR, FACTION_PMC)
+	paygrades = list(PAY_SHORT_PMC_OP = JOB_PLAYTIME_TIER_0)
+	idtype = /obj/item/card/id/pmc
+	skills = /datum/skills/civilian/survivor/pmc
+	languages = list(LANGUAGE_ENGLISH, LANGUAGE_JAPANESE)
+	minimap_icon = "private"
+	minimap_background = "background_pmc"
+
+	access = list(
+		ACCESS_WY_GENERAL,
+		ACCESS_WY_COLONIAL,
+		ACCESS_WY_MEDICAL,
+		ACCESS_WY_SECURITY,
+		ACCESS_WY_RESEARCH,
+		ACCESS_WY_ARMORY,
+		ACCESS_CIVILIAN_PUBLIC,
+		ACCESS_CIVILIAN_RESEARCH,
+		ACCESS_CIVILIAN_ENGINEERING,
+		ACCESS_CIVILIAN_LOGISTICS,
+		ACCESS_CIVILIAN_BRIG,
+		ACCESS_CIVILIAN_MEDBAY,
+		ACCESS_CIVILIAN_COMMAND,
+	)
+
+/datum/equipment_preset/survivor/pmc/shivas/load_gear(mob/living/carbon/human/new_human)
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/pmc/hvh, WEAR_L_EAR)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/veteran/pmc, WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/marine/veteran/pmc, WEAR_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/veteran/pmc, WEAR_HANDS)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/pmc, WEAR_HEAD)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/veteran/pmc/knife, WEAR_FEET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/rebreather/scarf, WEAR_FACE)
+
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/survival/full(new_human), WEAR_L_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/ert(new_human), WEAR_R_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/lightpack/five_slot, WEAR_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/baton, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/restraint/handcuffs/zip, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/fancy/cigarettes/wypacket, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/tool/lighter/zippo, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/reagent_container/food/drinks/flask/weylandyutani, WEAR_IN_BACK)
+
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/rifle/m41a/corporate, WEAR_J_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/belt/marine/m41a, WEAR_WAIST)
+

--- a/maps/Nightmare/maps/Ice_Colony_v3/nightmare.json
+++ b/maps/Nightmare/maps/Ice_Colony_v3/nightmare.json
@@ -100,7 +100,7 @@
 	{
 		"type": "map_insert",
 		"landmark": "panic_room",
-		"chance": 1,
+		"chance": 0.5,
 		"path": "standalone/panic_room_hold.dmm",
         "when": { "panic_room": "full" }
 	}

--- a/maps/Nightmare/maps/Ice_Colony_v3/nightmare.json
+++ b/maps/Nightmare/maps/Ice_Colony_v3/nightmare.json
@@ -100,7 +100,7 @@
 	{
 		"type": "map_insert",
 		"landmark": "panic_room",
-		"chance": 0.5,
+		"chance": 1,
 		"path": "standalone/panic_room_hold.dmm",
         "when": { "panic_room": "full" }
 	}

--- a/maps/map_files/Ice_Colony_v3/standalone/panic_room_hold.dmm
+++ b/maps/map_files/Ice_Colony_v3/standalone/panic_room_hold.dmm
@@ -1,4 +1,12 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/effect/landmark/survivor_spawner/shivas_panic_room_eng,
+/turf/open/floor/shiva/bluefull,
+/area/shiva/interior/colony/s_admin)
+"ab" = (
+/obj/effect/landmark/survivor_spawner/shivas_panic_room_doc/medium_priority,
+/turf/open/floor/shiva/bluefull,
+/area/shiva/interior/colony/s_admin)
 "ai" = (
 /obj/structure/largecrate/random/barrel/red,
 /turf/open/auto_turf/snow/layer2,
@@ -417,7 +425,7 @@
 /area/shiva/interior/colony/s_admin)
 "rQ" = (
 /obj/item/ammo_magazine/rifle/boltaction,
-/obj/effect/landmark/survivor_spawner/shivas_panic_room_civ,
+/obj/effect/landmark/survivor_spawner/shivas_panic_room_eng/medium_priority,
 /turf/open/floor/shiva/floor3,
 /area/shiva/interior/colony/s_admin)
 "sq" = (
@@ -455,7 +463,7 @@
 /obj/structure/bed/chair/comfy{
 	dir = 4
 	},
-/obj/effect/landmark/survivor_spawner/shivas_panic_room_doc,
+/obj/effect/landmark/survivor_spawner/shivas_panic_room_sci/medium_priority,
 /turf/open/floor/shiva/bluefull,
 /area/shiva/interior/colony/s_admin)
 "tu" = (
@@ -1098,7 +1106,7 @@
 /turf/open/floor/shiva/multi_tiles/southeast,
 /area/shiva/interior/colony/s_admin)
 "Nu" = (
-/obj/effect/landmark/survivor_spawner/shivas_panic_room_doc,
+/obj/effect/landmark/survivor_spawner/shivas_panic_room_civ,
 /turf/open/floor/shiva/floor3,
 /area/shiva/interior/colony/s_admin)
 "NC" = (
@@ -1146,7 +1154,7 @@
 /area/shiva/interior/colony/s_admin)
 "PV" = (
 /obj/structure/bed/bedroll,
-/obj/effect/landmark/survivor_spawner/shivas_panic_room_sci,
+/obj/effect/landmark/survivor_spawner/shivas_panic_room_pmc,
 /turf/open/floor/shiva/bluefull,
 /area/shiva/interior/colony/s_admin)
 "Qh" = (
@@ -1582,7 +1590,7 @@ ul
 dF
 dF
 ov
-yQ
+aa
 kB
 ce
 Ik
@@ -1707,7 +1715,7 @@ Fc
 CZ
 DY
 dF
-BU
+ab
 ce
 ce
 cS


### PR DESCRIPTION

# About the pull request

Changes the presets of the survivors that spawn in the panic room insert on Shivas. Inspired by [this scene from Aliens: Dark Descent](https://youtu.be/QMCG9A80L50&t=2074)


# Explain why it's good for the game

When I asked people what their least favorite nightmare insert was, this one was the most common answer. The most common complaints were that it was boring and could never spawn engineers. This is an attempt to give it more sovl and adding a chance for an engineer, with a guarantee of an engineer if you have at least 5 survivors.


# Testing Photographs and Procedure
<details>
<summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/62ec0177-e1b9-4c15-8dc2-a82c712a6df4)


</details>


# Changelog
:cl:
maptweak: changed the presets on the shiva's panic room insert to have an engineer and 1 pmc
/:cl:
