### PR TITLE
Pipes under constructed walls maplint

### DIFF
--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -8,6 +8,10 @@
 	icon_state = "pwall"
 	},
 /area/space)
+"aac" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/asphalt/cement_sunbleached/cement_sunbleached1,
+/area/bigredv2/outside/c)
 "aad" = (
 /turf/open/mars_cave/mars_cave_2,
 /area/bigredv2/caves_north)
@@ -167,6 +171,15 @@
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/dark,
 /area/bigredv2/outside/space_port)
+"aaM" = (
+/obj/effect/decal/strata_decals/grime/grime1{
+	dir = 1
+	},
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/asphalt/cement_sunbleached/cement_sunbleached12,
+/area/bigredv2/outside/c)
 "aaN" = (
 /obj/structure/surface/table,
 /obj/effect/spawner/random/powercell,
@@ -242,10 +255,30 @@
 	},
 /turf/open/floor/asteroidwarning/east,
 /area/bigredv2/outside/space_port)
+"abb" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/structure/pipes/standard/manifold/hidden/green{
+	dir = 1
+	},
+/turf/open/asphalt/cement_sunbleached,
+/area/bigredv2/outside/c)
 "abc" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
+"abd" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
+/turf/open/asphalt/cement_sunbleached,
+/area/bigredv2/outside/c)
+"abe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/pipes/standard/manifold/hidden/green,
+/turf/open/floor/asteroidwarning/west,
+/area/bigredv2/outside/c)
 "abf" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/dark,
@@ -352,6 +385,13 @@
 	},
 /turf/open/floor/dark,
 /area/bigredv2/landing/console)
+"abz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 10
+	},
+/turf/open/floor/asteroidfloor/north,
+/area/bigredv2/outside/c)
 "abA" = (
 /obj/structure/bed/chair/office/dark,
 /obj/effect/decal/cleanable/blood/gibs/core,
@@ -411,6 +451,10 @@
 /obj/effect/spawner/random/tool,
 /turf/open/floor/darkgreen2/southeast,
 /area/bigredv2/outside/space_port)
+"abL" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor/delivery,
+/area/bigredv2/outside/general_offices)
 "abM" = (
 /turf/open/mars_cave/mars_cave_5,
 /area/bigredv2/caves_north)
@@ -421,6 +465,9 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
 	pixel_x = 1
+	},
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
 	},
 /turf/open/asphalt/cement_sunbleached/cement_sunbleached12,
 /area/bigredv2/outside/c)
@@ -459,6 +506,13 @@
 /obj/structure/window_frame/solaris,
 /turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
+"abU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 6
+	},
+/turf/open/floor,
+/area/bigredv2/outside/general_offices)
 "abV" = (
 /turf/open/mars_cave/mars_cave_11,
 /area/bigredv2/caves_north)
@@ -469,6 +523,12 @@
 	},
 /turf/open/asphalt/cement_sunbleached/cement_sunbleached2,
 /area/bigredv2/outside/e)
+"abX" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor,
+/area/bigredv2/outside/general_offices)
 "abY" = (
 /obj/structure/barricade/wooden{
 	desc = "This barricade is heavily reinforced. Nothing short of blasting it open seems like it'll do the trick, that or melting the breams supporting it...";
@@ -2661,12 +2721,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/redcorner/east,
 /area/bigredv2/outside/marshal_office)
-"amh" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/turf/closed/wall/solaris,
-/area/bigredv2/outside/general_offices)
 "amj" = (
 /obj/structure/window/framed/solaris,
 /turf/open/floor/plating,
@@ -2675,11 +2729,6 @@
 /turf/closed/wall/solaris/reinforced,
 /area/bigredv2/caves/lambda/breakroom)
 "aml" = (
-/obj/structure/window/framed/solaris,
-/turf/open/floor/plating,
-/area/bigredv2/outside/general_offices)
-"amm" = (
-/obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/window/framed/solaris,
 /turf/open/floor/plating,
 /area/bigredv2/outside/general_offices)
@@ -2874,10 +2923,6 @@
 	},
 /turf/open/floor/plating,
 /area/bigredv2/caves/lambda/breakroom)
-"amZ" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/closed/wall/solaris,
-/area/bigredv2/outside/general_offices)
 "anb" = (
 /obj/structure/pipes/vents/pump{
 	dir = 1
@@ -3501,23 +3546,17 @@
 /turf/open/floor/freezerfloor,
 /area/bigredv2/outside/general_offices)
 "apO" = (
-/obj/structure/pipes/standard/manifold/hidden/green,
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 9
+	},
 /turf/open/floor/freezerfloor,
 /area/bigredv2/outside/general_offices)
 "apQ" = (
 /obj/structure/window/framed/solaris,
 /turf/open/floor/plating,
 /area/bigredv2/outside/general_store)
-"apR" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/bigredv2/outside/general_offices)
 "apS" = (
-/obj/structure/pipes/standard/manifold/hidden/green{
-	dir = 4
-	},
+/obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/plating,
 /area/bigredv2/outside/general_offices)
 "apT" = (
@@ -3532,20 +3571,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/dark,
 /area/bigredv2/outside/general_offices)
-"apW" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/dark,
-/area/bigredv2/outside/general_offices)
 "apX" = (
 /obj/structure/surface/rack,
 /obj/item/stack/sheet/mineral/phoron{
 	amount = 25
 	},
-/turf/open/floor/dark,
-/area/bigredv2/outside/general_offices)
-"apY" = (
-/obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/dark,
 /area/bigredv2/outside/general_offices)
 "apZ" = (
@@ -3743,6 +3773,7 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
+/obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
 "aqR" = (
@@ -4302,9 +4333,7 @@
 "atF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/crap_item,
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 5
-	},
+/obj/structure/pipes/standard/manifold/hidden/green,
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
 "atG" = (
@@ -4315,8 +4344,8 @@
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
 "atH" = (
-/obj/structure/pipes/standard/manifold/hidden/green{
-	dir = 4
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 9
 	},
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
@@ -4444,7 +4473,6 @@
 	name = "General Listening Channel";
 	pixel_x = 30
 	},
-/obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
 "aue" = (
@@ -12838,28 +12866,6 @@
 /obj/item/prop/helmetgarb/gunoil,
 /turf/open/mars_cave/mars_dirt_4,
 /area/bigredv2/outside/c)
-"bhO" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 6
-	},
-/turf/open/mars,
-/area/bigredv2/outside/c)
-"bhP" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/turf/open/mars,
-/area/bigredv2/outside/c)
-"bhQ" = (
-/obj/structure/pipes/standard/manifold/hidden/green,
-/turf/open/floor/asteroidwarning/west,
-/area/bigredv2/outside/c)
-"bhR" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/turf/open/floor/asteroidfloor/north,
-/area/bigredv2/outside/c)
 "bhT" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "gib6"
@@ -12986,10 +12992,10 @@
 /turf/open/floor/greengrid,
 /area/bigredv2/outside/telecomm)
 "biV" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 10
-	},
 /obj/item/stack/cable_coil/cut,
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/c)
 "bja" = (
@@ -13062,16 +13068,7 @@
 /turf/open/mars/mars_dirt_8,
 /area/bigredv2/outside/s)
 "bjC" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 5
-	},
 /turf/closed/wall/solaris/reinforced,
-/area/bigredv2/outside/s)
-"bjD" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/turf/open/mars_cave/mars_dirt_4,
 /area/bigredv2/outside/s)
 "bjH" = (
 /turf/open/mars/mars_dirt_10,
@@ -18899,13 +18896,11 @@
 /turf/open/floor/dark,
 /area/bigredv2/outside/engineering)
 "dsn" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/effect/decal/cleanable/blood{
 	icon_state = "xgib4"
 	},
+/obj/structure/pipes/standard/manifold/hidden/green,
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
 "dsU" = (
@@ -20686,6 +20681,9 @@
 /area/bigredv2/outside/virology)
 "fia" = (
 /obj/effect/landmark/crap_item,
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
 /turf/open/asphalt/cement_sunbleached,
 /area/bigredv2/outside/c)
 "fik" = (
@@ -21221,6 +21219,9 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
 	},
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
 /turf/open/asphalt/cement_sunbleached,
 /area/bigredv2/outside/c)
 "fPe" = (
@@ -21598,9 +21599,6 @@
 /turf/open/floor/wood,
 /area/bigredv2/outside/general_offices)
 "giY" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
 /obj/structure/barricade/handrail/wire{
 	dir = 1
 	},
@@ -21789,10 +21787,6 @@
 	},
 /turf/open/floor/whitegreen/north,
 /area/bigredv2/outside/medical)
-"gsb" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/asphalt/cement_sunbleached/cement_sunbleached3,
-/area/bigredv2/outside/c)
 "gsM" = (
 /obj/structure/fence,
 /turf/open/asphalt/cement,
@@ -22308,6 +22302,9 @@
 "gUA" = (
 /obj/item/tool/warning_cone,
 /obj/structure/flora/grass/desert/lightgrass_1,
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
 /turf/open/asphalt/cement_sunbleached/cement_sunbleached12,
 /area/bigredv2/outside/c)
 "gVl" = (
@@ -23395,6 +23392,9 @@
 /obj/effect/decal/cleanable/vomit{
 	icon_state = "vomit_4"
 	},
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
 /turf/open/asphalt/cement_sunbleached/cement_sunbleached12,
 /area/bigredv2/outside/c)
 "igD" = (
@@ -23750,6 +23750,9 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
 	},
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
 /turf/open/asphalt/cement_sunbleached/cement_sunbleached12,
 /area/bigredv2/outside/c)
 "izT" = (
@@ -23896,6 +23899,7 @@
 	pixel_x = -11;
 	pixel_y = 12
 	},
+/obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/dark,
 /area/bigredv2/outside/general_offices)
 "iJF" = (
@@ -25496,10 +25500,8 @@
 /turf/open/floor,
 /area/bigredv2/outside/dorms)
 "krR" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/blood,
+/obj/structure/pipes/standard/manifold/hidden/green,
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
 "krV" = (
@@ -26375,6 +26377,7 @@
 	pixel_x = 7;
 	pixel_y = -9
 	},
+/obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/dark,
 /area/bigredv2/outside/general_offices)
 "luA" = (
@@ -27116,8 +27119,8 @@
 "mgX" = (
 /obj/structure/surface/table,
 /obj/item/paper_bin,
-/obj/structure/pipes/standard/manifold/hidden/green{
-	dir = 8
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
 	},
 /turf/open/floor/dark,
 /area/bigredv2/outside/general_offices)
@@ -27471,6 +27474,9 @@
 /area/bigredv2/outside/n)
 "mAv" = (
 /obj/item/ammo_casing/bullet,
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 5
+	},
 /turf/open/floor/dark,
 /area/bigredv2/outside/general_offices)
 "mAY" = (
@@ -27587,6 +27593,7 @@
 	icon_state = "door_open";
 	density = 0
 	},
+/obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/delivery,
 /area/bigredv2/outside/general_offices)
 "mGS" = (
@@ -28587,9 +28594,6 @@
 /turf/open/floor/almayer/test_floor4,
 /area/bigredv2/outside/engineering)
 "nIx" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/blood/oil/streak,
 /turf/open/asphalt/cement_sunbleached/cement_sunbleached3,
 /area/bigredv2/outside/s)
@@ -28979,12 +28983,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/asphalt/cement_sunbleached/cement_sunbleached3,
 /area/bigredv2/outside/se)
-"ofX" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/turf/closed/wall/solaris/reinforced,
-/area/bigredv2/outside/s)
 "ogt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
@@ -29874,6 +29872,9 @@
 /area/bigredv2/outside/general_offices)
 "oXv" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
 /turf/open/asphalt/cement_sunbleached/cement_sunbleached15,
 /area/bigredv2/outside/c)
 "oXH" = (
@@ -30010,10 +30011,10 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/bar)
 "pdT" = (
-/obj/structure/surface/table,
 /obj/structure/pipes/vents/pump{
 	dir = 8
 	},
+/obj/structure/surface/table,
 /turf/open/floor/dark,
 /area/bigredv2/outside/general_offices)
 "pdW" = (
@@ -30177,9 +30178,6 @@
 /obj/structure/bedsheetbin{
 	pixel_y = 10;
 	pixel_x = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
 	},
 /turf/open/floor/freezerfloor,
 /area/bigredv2/outside/general_offices)
@@ -32107,9 +32105,6 @@
 /turf/open/floor/darkyellowcorners2/north,
 /area/bigredv2/outside/engineering)
 "ria" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
 /obj/item/shard/shrapnel/bone_chips,
 /turf/open/floor/freezerfloor,
 /area/bigredv2/outside/general_offices)
@@ -32244,11 +32239,6 @@
 	},
 /turf/open/mars_cave/mars_cave_19,
 /area/bigredv2/caves/mining)
-"rre" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/asphalt/cement_sunbleached/cement_sunbleached4,
-/area/bigredv2/outside/c)
 "rrV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/asphalt/cement/cement12,
@@ -33792,10 +33782,6 @@
 	},
 /turf/open/floor/plating/platebotc,
 /area/bigredv2/outside/space_port)
-"sIY" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor/delivery,
-/area/bigredv2/outside/c)
 "sKK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/asphalt/cement_sunbleached/cement_sunbleached1,
@@ -33831,12 +33817,6 @@
 	},
 /turf/open/mars_cave/mars_dirt_4,
 /area/bigredv2/outside/nw)
-"sNJ" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 9
-	},
-/turf/open/asphalt/cement_sunbleached/cement_sunbleached3,
-/area/bigredv2/outside/s)
 "sNP" = (
 /obj/structure/window/framed/solaris,
 /turf/open/floor/plating/panelscorched,
@@ -34727,12 +34707,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/mars/mars_dirt_10,
 /area/bigredv2/outside/c)
-"tHB" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 10
-	},
-/turf/open/floor/asteroidfloor/north,
-/area/bigredv2/outside/c)
 "tHH" = (
 /obj/item/clothing/suit/armor/riot{
 	pixel_y = -5;
@@ -34809,12 +34783,6 @@
 	},
 /turf/open/mars_cave/mars_dirt_4,
 /area/bigredv2/caves/mining)
-"tKq" = (
-/obj/structure/pipes/standard/manifold/hidden/green{
-	dir = 1
-	},
-/turf/open/asphalt/cement_sunbleached/cement_sunbleached1,
-/area/bigredv2/outside/s)
 "tKr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair{
@@ -35062,10 +35030,10 @@
 /turf/open/mars_cave/mars_cave_15,
 /area/bigredv2/caves/mining)
 "tVE" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 5
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/pipes/standard/manifold/hidden/green{
+	dir = 8
+	},
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
 "tWf" = (
@@ -35929,9 +35897,6 @@
 /obj/structure/bedsheetbin{
 	pixel_y = 8;
 	pixel_x = 7
-	},
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
 	},
 /obj/effect/landmark/objective_landmark/far,
 /turf/open/floor/freezerfloor,
@@ -36963,6 +36928,7 @@
 /obj/item/tool/crowbar{
 	pixel_x = -13
 	},
+/obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
 "vVF" = (
@@ -37185,6 +37151,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
 "whp" = (
@@ -38383,9 +38350,6 @@
 /turf/open/floor/plating/platingdmg3/west,
 /area/bigredv2/caves/mining)
 "xtB" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
 /obj/item/tool/warning_cone,
 /obj/structure/barricade/handrail/wire{
 	dir = 1
@@ -38444,6 +38408,9 @@
 	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
+	},
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
 	},
 /turf/open/asphalt/cement_sunbleached/cement_sunbleached12,
 /area/bigredv2/outside/c)
@@ -38561,6 +38528,9 @@
 /area/space)
 "xCX" = (
 /obj/effect/decal/cleanable/blood/xeno,
+/obj/structure/pipes/standard/manifold/hidden/green{
+	dir = 8
+	},
 /turf/open/floor/dark,
 /area/bigredv2/outside/general_offices)
 "xDO" = (
@@ -56054,7 +56024,7 @@ lBc
 eRI
 mxC
 biV
-sIY
+eRI
 bjC
 bjB
 bkq
@@ -56270,9 +56240,9 @@ aBR
 aVo
 aIn
 bhF
-oxP
+cdI
 aIn
-bjD
+bjy
 bka
 bjA
 bjH
@@ -56489,7 +56459,7 @@ bhI
 oqY
 gUA
 aIn
-bjD
+bjy
 jdQ
 bjA
 bjH
@@ -56704,9 +56674,9 @@ bhi
 bhi
 raQ
 gtt
-xPT
+aaM
 dGw
-bjD
+bjy
 bka
 bjA
 bjH
@@ -56923,7 +56893,7 @@ dex
 fyo
 xvW
 aIn
-bjD
+bjy
 bka
 bjA
 bjH
@@ -57140,7 +57110,7 @@ stZ
 qeC
 izJ
 eRI
-ofX
+bjC
 bjy
 bkr
 bjy
@@ -57572,9 +57542,9 @@ dbi
 kjY
 dZL
 olK
-fOV
-xNI
-tKq
+abb
+aac
+ykB
 ykB
 vNk
 ykB
@@ -57791,7 +57761,7 @@ unC
 wup
 izJ
 eRI
-ofX
+bjC
 bjy
 bjy
 bjy
@@ -58659,7 +58629,7 @@ dgy
 umN
 abN
 dgy
-ofX
+bjC
 ssI
 bkp
 bjA
@@ -58874,9 +58844,9 @@ bhi
 wGr
 aBR
 bhF
-oxP
+cdI
 aIn
-bjD
+bjy
 bjy
 bjA
 bkq
@@ -59093,7 +59063,7 @@ aBR
 jYb
 igb
 aIn
-bjD
+bjy
 bjy
 bjB
 bjA
@@ -59306,11 +59276,11 @@ ixB
 aBR
 aBR
 aBR
-bhO
-rre
-kRT
-gsb
-sNJ
+aBR
+oYO
+abd
+htb
+rIu
 bGP
 iEw
 rIu
@@ -59523,7 +59493,7 @@ aBR
 aBR
 uuB
 uuB
-bhP
+aBR
 oYO
 fia
 xNI
@@ -59740,7 +59710,7 @@ aIm
 aBR
 aBR
 aBR
-bhP
+aBR
 lQb
 oXv
 sWp
@@ -59957,9 +59927,9 @@ bfI
 bfI
 bfI
 bfI
-bhQ
-aFM
-aCN
+bfI
+bfI
+abe
 aCN
 aCN
 bhU
@@ -60174,9 +60144,9 @@ aNw
 aNw
 aHF
 reB
-bhR
+aHF
 bhU
-bhU
+beC
 bhU
 bhU
 cZW
@@ -60391,9 +60361,9 @@ aIn
 aKt
 aMc
 aHF
-tHB
-aVp
-vIQ
+aHF
+aHF
+abz
 vIQ
 aVp
 vIQ
@@ -65324,11 +65294,11 @@ aoq
 apd
 tVE
 whb
-vWt
-apc
-apc
-apc
-apc
+abX
+apd
+apd
+apd
+apd
 aqQ
 vVt
 krR
@@ -66846,10 +66816,10 @@ kGK
 wnl
 ako
 vjW
-atE
-atE
-ovq
-apc
+abU
+tTd
+abL
+apd
 dsn
 atE
 ako
@@ -67275,7 +67245,7 @@ aao
 ako
 ako
 ako
-amh
+ako
 ako
 ako
 ako
@@ -67492,7 +67462,7 @@ smh
 pmS
 aou
 aph
-apR
+aou
 uzD
 iXD
 ako
@@ -67716,9 +67686,9 @@ gdy
 tNa
 atH
 aud
-amZ
-tTd
-atH
+ako
+atE
+aoq
 myu
 ako
 ako
@@ -68793,7 +68763,7 @@ pnL
 aao
 ako
 aov
-apk
+apl
 iJu
 lun
 xCX
@@ -69010,12 +68980,12 @@ akX
 aao
 ako
 aox
-apl
-apW
-apY
+apk
+apU
+aoB
 mgX
-amm
-apY
+aml
+apn
 wAd
 asY
 aml

--- a/maps/map_files/CORSAT/Corsat.dmm
+++ b/maps/map_files/CORSAT/Corsat.dmm
@@ -10548,12 +10548,6 @@
 /obj/structure/reagent_dispensers/water_cooler/stacks,
 /turf/open/floor/corsat/purplewhite/west,
 /area/corsat/sigma/south/complex)
-"aOQ" = (
-/obj/structure/pipes/standard/simple/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall/biodome/biodome_unmeltable,
-/area/corsat/inaccessible)
 "aOR" = (
 /obj/structure/prop/almayer/computers/sensor_computer2,
 /obj/structure/platform_decoration/metal/almayer/north{
@@ -80593,7 +80587,7 @@ ylo
 ylo
 ylo
 qIU
-aOQ
+qIU
 qIU
 ylo
 ylo

--- a/maps/map_files/FOP_v2_Cellblocks/Prison_Station_FOP.dmm
+++ b/maps/map_files/FOP_v2_Cellblocks/Prison_Station_FOP.dmm
@@ -35,6 +35,13 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating,
 /area/prison/research/secret/testing)
+"aag" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/open/floor/prison/yellow/east,
+/area/prison/cellblock/mediumsec/south)
 "aah" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -97,6 +104,12 @@
 /obj/structure/machinery/door/window/northright,
 /turf/open/floor/plating,
 /area/prison/research/secret/testing)
+"aan" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 9
+	},
+/turf/open/floor/prison/darkred2/west,
+/area/prison/security/monitoring/medsec/central)
 "aao" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -353,6 +366,17 @@
 /obj/structure/surface/table/reinforced,
 /turf/open/floor/prison/sterile_white/southwest,
 /area/prison/research/secret/testing)
+"aba" = (
+/obj/structure/pipes/standard/manifold/hidden/supply,
+/turf/open/floor/wood,
+/area/prison/library)
+"abb" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/open/floor/prison/blue/east,
+/area/prison/cellblock/protective)
 "abc" = (
 /obj/structure/surface/table/reinforced,
 /obj/item/clothing/suit/chef/classic,
@@ -425,6 +449,13 @@
 /obj/structure/surface/table/reinforced,
 /turf/open/floor/prison/sterile_white/southwest,
 /area/prison/research/secret/testing)
+"abm" = (
+/obj/structure/machinery/door/airlock/almayer/maint/colony,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/prison/library)
 "abn" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/prison/sterile_white/southwest,
@@ -692,6 +723,12 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/prison/whitepurple/northwest,
 /area/prison/research/secret/bioengineering)
+"aci" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 6
+	},
+/turf/open/floor/prison/sterile_white/southwest,
+/area/prison/residential/central)
 "acj" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -14961,9 +14998,6 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
 "beD" = (
@@ -18005,7 +18039,9 @@
 /turf/open/floor/plating,
 /area/prison/hanger/main)
 "bqI" = (
-/obj/structure/pipes/standard/manifold/hidden/supply,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 5
+	},
 /turf/open/floor/prison/sterile_white/southwest,
 /area/prison/residential/central)
 "bqJ" = (
@@ -23867,9 +23903,6 @@
 /area/prison/cellblock/protective)
 "bPH" = (
 /obj/structure/bed/stool,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
 /turf/open/floor/wood,
 /area/prison/library)
 "bPI" = (
@@ -23877,9 +23910,6 @@
 /area/prison/library)
 "bPJ" = (
 /obj/structure/machinery/power/apc/no_power/north,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
 /turf/open/floor/wood,
 /area/prison/library)
 "bPP" = (
@@ -25067,7 +25097,9 @@
 /turf/open/floor/wood,
 /area/prison/library)
 "bUj" = (
-/obj/structure/pipes/standard/manifold/fourway/hidden/supply,
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/prison/library)
 "bUk" = (
@@ -26300,6 +26332,9 @@
 /area/prison/recreation/medsec)
 "bYY" = (
 /obj/effect/decal/cleanable/blood,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/prison/library)
 "bYZ" = (
@@ -26310,7 +26345,9 @@
 /area/prison/library)
 "bZb" = (
 /obj/effect/landmark/good_item,
-/obj/structure/pipes/standard/manifold/hidden/supply,
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/prison/library)
 "bZc" = (
@@ -27084,6 +27121,9 @@
 /area/prison/cellblock/mediumsec/north)
 "cci" = (
 /obj/effect/landmark/yautja_teleport,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/prison/library)
 "ccj" = (
@@ -28356,8 +28396,8 @@
 /turf/open/floor/prison/bluefull/west,
 /area/prison/cellblock/protective)
 "chA" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 1
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
 /turf/open/floor/prison/blue/west,
 /area/prison/cellblock/protective)
@@ -28647,23 +28687,9 @@
 /area/prison/cellblock/mediumsec/north)
 "ciH" = (
 /obj/effect/decal/cleanable/blood,
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 8
-	},
+/obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/prison/yellow/east,
 /area/prison/cellblock/mediumsec/north)
-"ciI" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/prison/bluefull/west,
-/area/prison/cellblock/protective)
-"ciJ" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 9
-	},
-/turf/open/floor/prison/blue/southwest,
-/area/prison/cellblock/protective)
 "ciK" = (
 /turf/open/floor/prison/blue,
 /area/prison/cellblock/protective)
@@ -31644,6 +31670,9 @@
 /obj/structure/machinery/door/airlock/almayer/security/glass/colony{
 	name = "Security Booth"
 	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
 /turf/open/floor/prison/darkredfull2/southwest,
 /area/prison/security/monitoring/medsec/central)
 "cvh" = (
@@ -32924,13 +32953,6 @@
 	},
 /turf/open/floor/prison/yellowfull,
 /area/prison/cellblock/mediumsec/north)
-"dni" = (
-/obj/structure/bed,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/prison/floor_plate,
-/area/prison/cellblock/mediumsec/north)
 "dnt" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -33378,12 +33400,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating,
 /area/prison/monorail/west)
-"ftG" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/closed/wall/prison,
-/area/prison/cellblock/protective)
 "fxr" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 8
@@ -33784,12 +33800,6 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/ne)
-"gSg" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/closed/wall/prison,
-/area/prison/residential/central)
 "gWT" = (
 /obj/structure/largecrate/random/case,
 /turf/open/floor/plating,
@@ -34990,8 +35000,8 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 1
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 10
 	},
 /turf/open/floor/prison/blue/northeast,
 /area/prison/cellblock/protective)
@@ -35253,25 +35263,11 @@
 	},
 /turf/open/floor/prison/yellow,
 /area/prison/cellblock/mediumsec/south)
-"mLi" = (
-/obj/structure/machinery/door/airlock/prison{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/prison/yellowfull,
-/area/prison/cellblock/mediumsec/north)
 "mLG" = (
 /turf/open/floor/prison/green/east,
 /area/prison/hallway/central/south)
 "mMO" = (
 /obj/structure/machinery/light{
-	dir = 4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -35524,12 +35520,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/asteroid,
 /area/prison/residential/south)
-"nLC" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/closed/wall/prison,
-/area/prison/library)
 "nLD" = (
 /obj/structure/window/framed/prison/reinforced/hull,
 /turf/open/floor/plating,
@@ -35571,12 +35561,6 @@
 /obj/structure/reagent_dispensers/water_cooler/stacks,
 /turf/open/floor/prison/darkred2,
 /area/prison/security/monitoring/highsec)
-"nUH" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 8
-	},
-/turf/open/floor/prison/yellow/east,
-/area/prison/cellblock/mediumsec/south)
 "nVg" = (
 /turf/open/floor/prison/damaged2/southwest,
 /area/prison/hallway/central/east)
@@ -37184,15 +37168,6 @@
 /obj/item/ammo_magazine/rifle/m16,
 /turf/open/floor/prison/yellow,
 /area/prison/cellblock/mediumsec/north)
-"uXn" = (
-/obj/structure/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/prison/cellblock/mediumsec/north)
 "uZm" = (
 /turf/open/floor/prison/yellowfull,
 /area/prison/cellblock/mediumsec/north)
@@ -37203,12 +37178,6 @@
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/highsec/north/south)
-"vbh" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 10
-	},
-/turf/open/floor/wood,
-/area/prison/library)
 "vda" = (
 /obj/structure/surface/rack,
 /turf/open/floor/plating,
@@ -37249,12 +37218,6 @@
 "vix" = (
 /turf/closed/wall/prison,
 /area/prison/security/monitoring/protective)
-"viU" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/prison/cell_stripe/west,
-/area/prison/cellblock/mediumsec/north)
 "vmX" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 8
@@ -37440,12 +37403,6 @@
 /obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
-"wty" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/closed/wall/r_wall/prison,
-/area/prison/security/monitoring/medsec/central)
 "wvp" = (
 /obj/structure/machinery/shower{
 	dir = 1
@@ -42804,7 +42761,7 @@ odp
 odp
 aRZ
 odp
-aRZ
+odp
 odp
 odp
 odp
@@ -42819,7 +42776,7 @@ bvX
 bvX
 bvX
 bvX
-vmX
+bvX
 bvX
 bvX
 bvX
@@ -43228,7 +43185,7 @@ aWr
 aWr
 aWr
 aWr
-gSg
+aWr
 aWr
 aWr
 aWr
@@ -43243,7 +43200,7 @@ aWr
 aWr
 aWr
 aWr
-gSg
+aWr
 aWr
 aWr
 aWr
@@ -43440,7 +43397,7 @@ baK
 aYR
 aYQ
 aWr
-lIk
+beJ
 beJ
 baU
 baU
@@ -43455,7 +43412,7 @@ bbG
 baU
 baU
 beJ
-lIk
+beJ
 aWr
 aYQ
 aYR
@@ -43652,7 +43609,7 @@ bsi
 bbJ
 bbJ
 aWr
-aHj
+aci
 aoH
 bgc
 bgc
@@ -61744,8 +61701,8 @@ obV
 cxc
 cxc
 cxc
-nUH
-cwJ
+cxc
+aag
 obV
 cxc
 cyj
@@ -61956,7 +61913,7 @@ csF
 csF
 csF
 cub
-wty
+cub
 cvf
 csF
 csF
@@ -62169,7 +62126,7 @@ cts
 ctG
 cuc
 cuE
-cuc
+aan
 cvx
 csF
 cxF
@@ -69145,7 +69102,7 @@ ccV
 uZm
 dnf
 ccV
-mLi
+cuy
 cby
 eRY
 cuy
@@ -69357,7 +69314,7 @@ ccV
 uZm
 uZm
 ccV
-viU
+cao
 cbz
 ccV
 cao
@@ -69569,7 +69526,7 @@ ccV
 xVH
 hEK
 ccV
-uXn
+xVH
 cbA
 ccV
 xVH
@@ -69781,7 +69738,7 @@ ccV
 uZm
 uZm
 ccV
-dni
+caq
 cbB
 ccV
 caq
@@ -69993,7 +69950,7 @@ aFA
 rjx
 vwc
 aFA
-ftG
+cht
 vix
 vix
 vix
@@ -70205,7 +70162,7 @@ bWW
 cgt
 cgt
 chz
-ciI
+cgt
 vix
 ckJ
 clr
@@ -70417,7 +70374,7 @@ ceD
 bWX
 bRk
 chA
-ciJ
+bSM
 cjQ
 ckK
 cls
@@ -70833,7 +70790,7 @@ bUg
 bPG
 bRl
 bYb
-bRl
+abb
 caL
 bRl
 bRl
@@ -71038,14 +70995,14 @@ acL
 acL
 bOD
 bNU
-nLC
+bPZ
 bPZ
 bPZ
 bPZ
 bPZ
 bPZ
 bNU
-cbC
+abm
 bNU
 bPZ
 bPZ
@@ -71257,7 +71214,7 @@ bPI
 bPI
 bPI
 bRm
-bPI
+bUi
 bPI
 bPI
 bPI
@@ -71462,7 +71419,7 @@ aAO
 aAO
 bOD
 bNV
-bUi
+bPI
 bPI
 bSO
 bPI
@@ -71893,7 +71850,7 @@ bPI
 bSO
 bWZ
 bSO
-bPI
+bUi
 bSO
 bPI
 bSO
@@ -72098,16 +72055,16 @@ aAO
 aAO
 aAO
 puK
-bUi
+bPI
 bPI
 bSO
 bUh
 bSO
 bPI
 bSO
-bYZ
+bUi
 bSO
-bPI
+bYZ
 bSO
 bPZ
 cfl
@@ -72310,7 +72267,7 @@ aAO
 aAO
 aAO
 puK
-bUi
+bPI
 bPI
 bPI
 bUi
@@ -72522,16 +72479,16 @@ aAO
 aAO
 aAO
 puK
-vbh
-bRn
-bRn
+bPI
+bPI
+bPI
 bUj
 bRn
 bRn
 bRn
 bZb
-bPI
-bPI
+bRn
+aba
 bPI
 bPZ
 cfl
@@ -72741,9 +72698,9 @@ bUk
 bSO
 bPI
 bSO
-bZc
-bSO
 bPI
+bSO
+bZc
 bSO
 bNU
 cht

--- a/maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -577,6 +577,10 @@
 "acz" = (
 /turf/closed/wall/r_wall,
 /area/ice_colony/surface/engineering/electric)
+"acA" = (
+/obj/structure/pipes/standard/simple/hidden/green,
+/turf/open/floor/plating,
+/area/ice_colony/surface/research)
 "acB" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
@@ -766,6 +770,12 @@
 	},
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/surface/requesitions)
+"adm" = (
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/ice_colony/surface/research)
 "adn" = (
 /obj/structure/shuttle/diagonal{
 	icon_state = "swall0"
@@ -10722,7 +10732,9 @@
 /turf/open/floor/plating,
 /area/ice_colony/surface/research)
 "aNk" = (
-/obj/structure/pipes/vents/pump,
+/obj/structure/pipes/vents/pump{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ice_colony/surface/research)
 "aNl" = (
@@ -10880,7 +10892,6 @@
 /area/ice_colony/surface/research)
 "aNU" = (
 /obj/structure/machinery/light/small,
-/obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/plating,
 /area/ice_colony/surface/research)
 "aNW" = (
@@ -10965,6 +10976,7 @@
 	dir = 1;
 	name = "\improper Omicron Custodial Storage"
 	},
+/obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/plating,
 /area/ice_colony/surface/research)
 "aOu" = (
@@ -11503,12 +11515,12 @@
 /turf/open/floor/darkbrown2/west,
 /area/ice_colony/surface/research)
 "aQk" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/structure/pipes/standard/manifold/hidden/green{
+	dir = 8
 	},
 /turf/open/floor/dark2,
 /area/ice_colony/surface/research)
@@ -26394,7 +26406,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/pipes/standard/manifold/hidden/green,
+/obj/structure/pipes/standard/simple/hidden/green{
+	dir = 4
+	},
 /turf/open/floor/dark2,
 /area/ice_colony/surface/research)
 "cBQ" = (
@@ -26560,10 +26574,6 @@
 	},
 /turf/open/shuttle/can_surgery/red,
 /area/ice_colony/surface/hangar/alpha)
-"gXP" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/open/floor/darkbrown2/north,
-/area/ice_colony/surface/research)
 "hfj" = (
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/ice,
@@ -26718,10 +26728,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/dark2,
 /area/ice_colony/surface/dorms)
-"kRw" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/closed/wall,
-/area/ice_colony/surface/research)
 "lqY" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating/icefloor,
@@ -46451,10 +46457,10 @@ asi
 asi
 aLN
 aMD
-aNj
-aNj
+adm
+acA
 aOp
-aPl
+aUg
 aQk
 aRf
 aRV
@@ -46735,8 +46741,8 @@ aLN
 aME
 aNk
 aNU
-kRw
-gXP
+aOo
+aPm
 csl
 aPl
 aPl

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -8481,12 +8481,6 @@
 /obj/structure/largecrate,
 /turf/open/floor/plating,
 /area/lv522/landing_zone_1/tunnel)
-"exZ" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 4
-	},
-/turf/closed/wall/r_wall/biodome/biodome_unmeltable,
-/area/lv522/oob)
 "eym" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 9
@@ -51089,7 +51083,7 @@ tiQ
 tiQ
 tiQ
 tiQ
-exZ
+tiQ
 tiQ
 tiQ
 vtc

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -13,6 +13,25 @@
 	icon_state = "pwall"
 	},
 /area/space)
+"aad" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 5
+	},
+/turf/open/floor/white,
+/area/lv624/lazarus/main_hall)
+"aae" = (
+/obj/item/stack/sheet/wood,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/white,
+/area/lv624/lazarus/main_hall)
+"aaf" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/kitchen)
 "aag" = (
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/north_east_caves)
@@ -26,10 +45,33 @@
 "aaj" = (
 /turf/open/gm/coast/west,
 /area/lv624/ground/caves/north_central_caves)
+"aak" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 6
+	},
+/turf/open/floor/freezerfloor,
+/area/lv624/lazarus/kitchen)
+"aal" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 5
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/hop)
 "aam" = (
 /obj/structure/flora/bush/ausbushes/var3/fernybush,
 /turf/open/gm/river,
 /area/lv624/ground/caves/north_central_caves)
+"aan" = (
+/obj/structure/flora/bush/ausbushes/var3/leafybush,
+/obj/structure/pipes/standard/manifold/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/lv624/lazarus/main_hall)
+"aao" = (
+/obj/structure/pipes/standard/simple/hidden/cyan,
+/turf/open/floor/wood,
+/area/lv624/lazarus/hop)
 "aap" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner2/south_east,
 /area/lv624/ground/caves/north_central_caves)
@@ -70,6 +112,10 @@
 "aaA" = (
 /turf/open/gm/coast/beachcorner/south_west,
 /area/lv624/ground/caves/north_central_caves)
+"aaB" = (
+/obj/effect/landmark/crap_item,
+/turf/open/floor/freezerfloor,
+/area/lv624/lazarus/kitchen)
 "aaC" = (
 /turf/open/gm/coast/beachcorner2/south_west,
 /area/lv624/ground/caves/north_central_caves)
@@ -92,6 +138,13 @@
 "aaH" = (
 /turf/open/gm/dirtgrassborder/south,
 /area/lv624/ground/caves/north_central_caves)
+"aaI" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/pipes/standard/simple/hidden/cyan,
+/turf/open/floor/bar,
+/area/lv624/lazarus/canteen)
 "aaJ" = (
 /obj/structure/flora/bush/ausbushes/var3/fullgrass,
 /turf/open/gm/dirtgrassborder/north,
@@ -99,6 +152,10 @@
 "aaK" = (
 /turf/open/gm/dirtgrassborder/north,
 /area/lv624/ground/caves/north_central_caves)
+"aaL" = (
+/obj/structure/pipes/standard/simple/hidden/cyan,
+/turf/open/floor/bar,
+/area/lv624/lazarus/canteen)
 "aaM" = (
 /obj/effect/landmark/crap_item,
 /obj/effect/landmark/structure_spawner/xvx_hive/xeno_door,
@@ -210,6 +267,19 @@
 /obj/structure/largecrate/supply/ammo/shotgun,
 /turf/open/floor/wood,
 /area/lv624/ground/caves/north_central_caves)
+"abq" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/whiteyellowfull/east,
+/area/lv624/lazarus/main_hall)
+"abr" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/whiteyellowfull/east,
+/area/lv624/lazarus/main_hall)
 "abs" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/gm/dirt,
@@ -219,6 +289,12 @@
 /obj/item/weapon/gun/rifle/lmg,
 /turf/open/floor/vault2/west,
 /area/lv624/ground/barrens/north_east_barrens/ceiling)
+"abu" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/whiteyellowcorner/north,
+/area/lv624/lazarus/main_hall)
 "abv" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/gm/dirt,
@@ -229,6 +305,12 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/central_caves)
+"abx" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/whiteyellowcorner/east,
+/area/lv624/lazarus/main_hall)
 "aby" = (
 /obj/effect/landmark/xeno_hive_spawn,
 /obj/effect/landmark/ert_spawns/groundside_xeno,
@@ -246,6 +328,18 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/north_west_caves)
+"abC" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/whiteyellow/north,
+/area/lv624/lazarus/main_hall)
+"abD" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 10
+	},
+/turf/open/floor/white,
+/area/lv624/lazarus/main_hall)
 "abE" = (
 /obj/effect/landmark/xeno_hive_spawn,
 /obj/effect/landmark/ert_spawns/groundside_xeno,
@@ -277,6 +371,23 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/central_caves)
+"abJ" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/structure/pipes/standard/simple/hidden/cyan,
+/turf/open/floor/whiteyellowfull/east,
+/area/lv624/lazarus/main_hall)
+"abK" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 5
+	},
+/turf/open/floor/whiteyellowcorner,
+/area/lv624/lazarus/main_hall)
+"abL" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/whiteyellow,
+/area/lv624/lazarus/main_hall)
 "abM" = (
 /turf/closed/wall/rock/brown,
 /area/lv624/ground/caves/north_west_caves)
@@ -287,13 +398,32 @@
 /obj/effect/landmark/crap_item,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/west_caves)
+"abP" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/whiteyellowcorner/west,
+/area/lv624/lazarus/main_hall)
 "abQ" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/north_west_caves)
+"abR" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/lazarus/main_hall)
 "abS" = (
 /turf/closed/wall/rock/brown,
 /area/lv624/ground/caves/south_central_caves)
+"abT" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/lazarus/main_hall)
 "abU" = (
 /turf/open/floor/wood/wood_broken3,
 /area/lv624/ground/caves/north_central_caves)
@@ -307,6 +437,10 @@
 /obj/effect/landmark/hunter_primary,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/central_caves)
+"abX" = (
+/obj/structure/pipes/standard/simple/hidden/cyan,
+/turf/open/floor/freezerfloor,
+/area/lv624/lazarus/toilet)
 "abY" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -323,13 +457,25 @@
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating/platebotc,
 /area/lv624/lazarus/quartstorage)
-"acc" = (
+"acd" = (
+/obj/structure/pipes/standard/manifold/hidden/cyan{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/lv624/lazarus/main_hall)
+"ace" = (
+/obj/structure/machinery/door/airlock/almayer/engineering/colony{
+	density = 0;
+	icon_state = "door_open";
+	name = "\improper Nexus Cargo Storage";
+	req_access_txt = "100";
+	req_one_access = null
+	},
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
 	},
-/obj/structure/window/framed/colony,
-/turf/open/floor/plating,
-/area/lv624/lazarus/chapel)
+/turf/open/floor/whiteyellowfull/east,
+/area/lv624/lazarus/quart)
 "acf" = (
 /turf/closed/wall/rock/brown,
 /area/lv624/ground/caves/central_caves)
@@ -345,6 +491,12 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/north_east_caves)
+"acj" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 9
+	},
+/turf/open/floor/whiteyellowfull/east,
+/area/lv624/lazarus/quart)
 "ack" = (
 /obj/structure/surface/table/woodentable/poor,
 /obj/item/tool/kitchen/knife/butcher{
@@ -394,6 +546,7 @@
 	req_access_txt = "100";
 	req_one_access = null
 	},
+/obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/open/floor/bar,
 /area/lv624/lazarus/canteen)
 "act" = (
@@ -415,10 +568,27 @@
 /obj/structure/foamed_metal,
 /turf/open/shuttle/bright_red,
 /area/lv624/lazarus/crashed_ship_containers)
+"acx" = (
+/obj/structure/pipes/standard/simple/hidden/cyan,
+/turf/open/floor/plating,
+/area/lv624/lazarus/toilet)
 "acy" = (
 /obj/effect/decal/remains/xeno,
 /turf/open/floor/cult,
 /area/lv624/ground/caves/west_caves)
+"acz" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 6
+	},
+/turf/open/floor/bluecorner,
+/area/lv624/lazarus/sleep_male)
+"acA" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/pipes/standard/manifold/hidden/cyan{
+	dir = 8
+	},
+/turf/open/floor/bluecorner,
+/area/lv624/lazarus/sleep_male)
 "acB" = (
 /obj/structure/machinery/constructable_frame{
 	icon_state = "box_1"
@@ -453,10 +623,23 @@
 "acF" = (
 /turf/closed/wall/sulaco,
 /area/lv624/ground/barrens/north_east_barrens)
+"acG" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/bluecorner,
+/area/lv624/lazarus/sleep_male)
 "acH" = (
 /obj/structure/foamed_metal,
 /turf/open/gm/dirt,
 /area/lv624/lazarus/crashed_ship_containers)
+"acI" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/bluecorner,
+/area/lv624/lazarus/sleep_male)
 "acJ" = (
 /turf/open/shuttle/bright_red,
 /area/lv624/ground/barrens/north_east_barrens)
@@ -486,10 +669,23 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_central_caves)
+"acP" = (
+/obj/effect/decal/cleanable/vomit,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/white,
+/area/lv624/lazarus/main_hall)
 "acQ" = (
 /obj/item/device/flashlight/on,
 /turf/open/shuttle/bright_red,
 /area/lv624/lazarus/crashed_ship_containers)
+"acR" = (
+/obj/structure/pipes/standard/manifold/hidden/cyan{
+	dir = 1
+	},
+/turf/open/floor/white,
+/area/lv624/lazarus/main_hall)
 "acS" = (
 /obj/effect/landmark/hunter_primary,
 /turf/open/gm/dirt,
@@ -541,6 +737,12 @@
 	},
 /turf/open/shuttle/bright_red,
 /area/lv624/lazarus/crashed_ship_containers)
+"adb" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/purple/northwest,
+/area/lv624/lazarus/sleep_female)
 "adc" = (
 /obj/effect/landmark/crap_item,
 /turf/open/gm/dirt,
@@ -569,6 +771,15 @@
 /obj/structure/girder,
 /turf/open/gm/dirt,
 /area/lv624/ground/barrens/north_east_barrens)
+"adj" = (
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/purple/northwest,
+/area/lv624/lazarus/sleep_female)
 "adk" = (
 /obj/structure/machinery/constructable_frame{
 	icon_state = "box_1"
@@ -4767,6 +4978,9 @@
 /obj/structure/bed/chair/office/light{
 	dir = 1
 	},
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/open/floor/bluecorner,
 /area/lv624/lazarus/sleep_male)
 "aBA" = (
@@ -4787,7 +5001,9 @@
 /turf/open/floor/purple/northwest,
 /area/lv624/lazarus/sleep_female)
 "aBE" = (
-/obj/structure/pipes/standard/simple/hidden/cyan,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 9
+	},
 /turf/open/floor/purple/northwest,
 /area/lv624/lazarus/sleep_female)
 "aBF" = (
@@ -4866,11 +5082,16 @@
 /area/lv624/lazarus/sleep_male)
 "aBV" = (
 /obj/effect/decal/cleanable/blood,
-/obj/structure/pipes/standard/simple/hidden/cyan,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 9
+	},
 /turf/open/floor/bluecorner,
 /area/lv624/lazarus/sleep_male)
 "aBW" = (
 /obj/item/stack/medical/advanced/bruise_pack,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 9
+	},
 /turf/open/floor/bluecorner,
 /area/lv624/lazarus/sleep_male)
 "aBY" = (
@@ -4885,9 +5106,6 @@
 	},
 /turf/open/floor/bluecorner,
 /area/lv624/lazarus/sleep_male)
-"aCa" = (
-/turf/open/floor/whitegreen,
-/area/lv624/lazarus/main_hall)
 "aCb" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	dir = 1;
@@ -4987,10 +5205,6 @@
 "aCw" = (
 /turf/open/floor/whitegreencorner,
 /area/lv624/lazarus/main_hall)
-"aCx" = (
-/obj/structure/flora/bush/ausbushes/grassybush,
-/turf/open/floor/grass,
-/area/lv624/lazarus/main_hall)
 "aCy" = (
 /turf/open/floor/whitegreencorner/west,
 /area/lv624/lazarus/main_hall)
@@ -5011,7 +5225,6 @@
 "aCB" = (
 /obj/structure/bed,
 /obj/item/bedsheet/purple,
-/obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/effect/landmark/objective_landmark/medium,
 /turf/open/floor/purple/northwest,
 /area/lv624/lazarus/sleep_female)
@@ -5104,9 +5317,6 @@
 /obj/structure/flora/bush/ausbushes/lavendergrass,
 /turf/open/gm/grass/grass1,
 /area/lv624/ground/jungle/central_jungle)
-"aCX" = (
-/turf/open/floor/grass,
-/area/lv624/lazarus/main_hall)
 "aCY" = (
 /obj/structure/closet{
 	density = 0;
@@ -5133,7 +5343,6 @@
 "aDa" = (
 /obj/structure/bed,
 /obj/item/bedsheet/mime,
-/obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/open/floor/purple/northwest,
 /area/lv624/lazarus/sleep_female)
 "aDb" = (
@@ -5170,6 +5379,9 @@
 	dir = 1
 	},
 /obj/effect/landmark/survivor_spawner,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/open/floor/bluecorner,
 /area/lv624/lazarus/sleep_male)
 "aDq" = (
@@ -5203,6 +5415,7 @@
 /area/lv624/lazarus/landing_zones/lz2)
 "aDw" = (
 /obj/structure/flora/bush/ausbushes/ywflowers,
+/obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/open/floor/grass,
 /area/lv624/lazarus/main_hall)
 "aDx" = (
@@ -5217,12 +5430,6 @@
 "aDz" = (
 /obj/structure/bed,
 /obj/structure/machinery/light,
-/turf/open/floor/purple/northwest,
-/area/lv624/lazarus/sleep_female)
-"aDA" = (
-/obj/structure/bed,
-/obj/structure/machinery/light,
-/obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/open/floor/purple/northwest,
 /area/lv624/lazarus/sleep_female)
 "aDB" = (
@@ -5284,10 +5491,6 @@
 "aDT" = (
 /turf/open/floor/plating,
 /area/lv624/lazarus/toilet)
-"aDU" = (
-/obj/structure/pipes/standard/simple/hidden/cyan,
-/turf/closed/wall,
-/area/lv624/lazarus/toilet)
 "aDV" = (
 /turf/open/floor/plating/asteroidwarning/southwest,
 /area/lv624/lazarus/landing_zones/lz2)
@@ -5310,10 +5513,6 @@
 /turf/open/floor/white,
 /area/lv624/lazarus/main_hall)
 "aDY" = (
-/turf/closed/wall,
-/area/lv624/lazarus/quart)
-"aEa" = (
-/obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/closed/wall,
 /area/lv624/lazarus/quart)
 "aEb" = (
@@ -5400,20 +5599,12 @@
 /obj/effect/landmark/crap_item,
 /turf/open/floor/freezerfloor,
 /area/lv624/lazarus/toilet)
-"aEC" = (
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/lv624/lazarus/toilet)
 "aED" = (
 /obj/structure/machinery/shower{
 	dir = 4
 	},
 /obj/effect/glowshroom,
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
+/obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/open/floor/freezerfloor,
 /area/lv624/lazarus/toilet)
 "aEE" = (
@@ -5424,14 +5615,7 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
 /turf/open/floor/freezerfloor,
-/area/lv624/lazarus/toilet)
-"aEF" = (
-/obj/structure/pipes/standard/manifold/hidden/cyan,
-/turf/closed/wall,
 /area/lv624/lazarus/toilet)
 "aEG" = (
 /obj/structure/closet/coffin{
@@ -5440,9 +5624,6 @@
 	opened = 1
 	},
 /obj/effect/landmark/survivor_spawner,
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
 /turf/open/floor/chapel/north,
 /area/lv624/lazarus/chapel)
 "aEH" = (
@@ -5451,9 +5632,6 @@
 	frequency = 1469;
 	name = "General Listening Channel";
 	pixel_y = 30
-	},
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
 	},
 /turf/open/floor/chapel/east,
 /area/lv624/lazarus/chapel)
@@ -5465,30 +5643,12 @@
 /turf/open/floor/wood/wood_broken6,
 /area/lv624/ground/caves/north_central_caves)
 "aEK" = (
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
 /obj/structure/machinery/power/apc/no_power/north,
 /turf/open/floor/chapel/north,
-/area/lv624/lazarus/chapel)
-"aEL" = (
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
-/turf/open/floor/chapel/east,
 /area/lv624/lazarus/chapel)
 "aEM" = (
 /turf/open/gm/coast/beachcorner2/north_east,
 /area/lv624/ground/jungle/west_jungle)
-"aEO" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
-/turf/open/floor/white,
-/area/lv624/lazarus/main_hall)
 "aEP" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -5501,32 +5661,19 @@
 	},
 /turf/open/floor/whitegreencorner,
 /area/lv624/lazarus/main_hall)
-"aER" = (
-/obj/structure/flora/bush/ausbushes/var3/leafybush,
-/obj/structure/pipes/standard/manifold/hidden/cyan{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/lv624/lazarus/main_hall)
 "aES" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
 	},
 /turf/open/floor/whitegreencorner/west,
 /area/lv624/lazarus/main_hall)
-"aET" = (
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/lv624/lazarus/quart)
 "aEU" = (
 /obj/structure/largecrate/random,
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
 /obj/structure/machinery/light{
 	dir = 1
+	},
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 6
 	},
 /turf/open/floor/whiteyellowfull/east,
 /area/lv624/lazarus/quart)
@@ -5558,11 +5705,6 @@
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/open/floor/whiteyellowfull/east,
-/area/lv624/lazarus/quart)
-"aEY" = (
-/obj/structure/largecrate/random,
-/obj/structure/pipes/standard/manifold/hidden/cyan,
 /turf/open/floor/whiteyellowfull/east,
 /area/lv624/lazarus/quart)
 "aEZ" = (
@@ -5613,6 +5755,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/survivor_spawner,
+/obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/open/floor/freezerfloor,
 /area/lv624/lazarus/toilet)
 "aFl" = (
@@ -5757,6 +5900,7 @@
 /obj/structure/machinery/shower{
 	dir = 4
 	},
+/obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/open/floor/freezerfloor,
 /area/lv624/lazarus/toilet)
 "aFP" = (
@@ -5857,6 +6001,7 @@
 	name = "\improper Nexus Dome Bathroom";
 	req_access_txt = "100"
 	},
+/obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/open/floor/freezerfloor,
 /area/lv624/lazarus/toilet)
 "aGp" = (
@@ -5928,10 +6073,16 @@
 /obj/structure/sink{
 	pixel_y = 30
 	},
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 6
+	},
 /turf/open/floor/freezerfloor,
 /area/lv624/lazarus/toilet)
 "aGJ" = (
 /obj/effect/landmark/crap_item,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 9
+	},
 /turf/open/floor/freezerfloor,
 /area/lv624/lazarus/toilet)
 "aGK" = (
@@ -6381,12 +6532,17 @@
 "aJd" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/pipes/standard/manifold/hidden/cyan{
+	dir = 1
+	},
 /turf/open/floor/whiteyellowfull/east,
 /area/lv624/lazarus/main_hall)
 "aJe" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/blood/gibs,
-/obj/structure/pipes/standard/simple/hidden/cyan,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 9
+	},
 /turf/open/floor/whiteyellowfull/east,
 /area/lv624/lazarus/main_hall)
 "aJf" = (
@@ -6503,7 +6659,6 @@
 /turf/open/floor/whiteyellowfull/east,
 /area/lv624/lazarus/main_hall)
 "aJJ" = (
-/obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/closed/wall/mineral/gold{
 	desc = "Here sits a golden statue of the sun, meant to praise the sky in it's benevolence.";
 	name = "Statue of the Sky"
@@ -6671,7 +6826,9 @@
 /obj/effect/decal/cleanable/blood{
 	pixel_y = 12
 	},
-/obj/structure/pipes/standard/simple/hidden/cyan,
+/obj/structure/pipes/standard/manifold/hidden/cyan{
+	dir = 1
+	},
 /turf/open/floor,
 /area/lv624/lazarus/main_hall)
 "aKB" = (
@@ -7379,9 +7536,6 @@
 "aOF" = (
 /obj/structure/surface/table/woodentable/fancy,
 /obj/item/reagent_container/food/drinks/bottle/whiskey,
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
 /turf/open/floor,
 /area/lv624/lazarus/chapel)
 "aOG" = (
@@ -7424,6 +7578,9 @@
 /obj/structure/surface/table,
 /obj/item/trash/plate,
 /obj/effect/landmark/objective_landmark/close,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 6
+	},
 /turf/open/floor/bar,
 /area/lv624/lazarus/canteen)
 "aOQ" = (
@@ -7436,6 +7593,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/crap_item,
+/obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/open/floor/bar,
 /area/lv624/lazarus/canteen)
 "aOS" = (
@@ -7573,6 +7731,9 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 9
+	},
 /turf/open/floor/bar,
 /area/lv624/lazarus/canteen)
 "aPE" = (
@@ -7586,9 +7747,6 @@
 /obj/item/storage/bible,
 /obj/structure/machinery/light/small{
 	dir = 1
-	},
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
 	},
 /obj/effect/landmark/good_item,
 /turf/open/floor,
@@ -7979,21 +8137,15 @@
 /turf/open/floor/mech_bay_recharge_floor/shuttle_landing_lights,
 /area/lv624/lazarus/landing_zones/lz2)
 "aRI" = (
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
 /obj/effect/landmark/good_item,
-/turf/open/floor/wood,
-/area/lv624/lazarus/hop)
-"aRK" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
+	dir = 10
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/wood,
 /area/lv624/lazarus/hop)
 "aRN" = (
 /obj/structure/flora/bush,
-/obj/structure/pipes/standard/manifold/fourway/hidden/cyan,
+/obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/open/floor/grass,
 /area/lv624/lazarus/main_hall)
 "aRO" = (
@@ -8005,9 +8157,6 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
 /turf/open/floor/white,
 /area/lv624/lazarus/main_hall)
 "aRR" = (
@@ -8017,16 +8166,10 @@
 	dir = 8
 	},
 /obj/item/tool/kitchen/rollingpin,
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
 /turf/open/floor/freezerfloor,
 /area/lv624/lazarus/kitchen)
 "aRU" = (
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
@@ -8036,18 +8179,12 @@
 /obj/structure/flora/bush/ausbushes/var3/sparsegrass,
 /turf/open/gm/grass/grass2,
 /area/lv624/ground/jungle/north_jungle)
-"aRW" = (
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
-/turf/open/floor/bar,
-/area/lv624/lazarus/canteen)
 "aRX" = (
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
 /obj/structure/pipes/vents/pump{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/bar,
 /area/lv624/lazarus/canteen)
@@ -8234,6 +8371,9 @@
 /obj/structure/machinery/door/airlock/almayer/command/colony{
 	name = "\improper Nexus Dome Command Quarter";
 	req_access_txt = "100"
+	},
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/hop)
@@ -8614,22 +8754,11 @@
 /turf/open/floor/plating,
 /area/lv624/lazarus/hop)
 "aUH" = (
-/obj/structure/pipes/standard/manifold/hidden/cyan,
-/turf/open/floor/white,
-/area/lv624/lazarus/main_hall)
-"aUI" = (
-/obj/structure/largecrate/random,
-/obj/structure/pipes/standard/simple/hidden/cyan{
+/obj/structure/pipes/standard/manifold/hidden/cyan{
 	dir = 4
 	},
 /turf/open/floor/white,
 /area/lv624/lazarus/main_hall)
-"aUJ" = (
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/lv624/lazarus/kitchen)
 "aUL" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -8645,7 +8774,7 @@
 /area/lv624/lazarus/kitchen)
 "aUN" = (
 /obj/structure/pipes/vents/pump{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/freezerfloor,
 /area/lv624/lazarus/kitchen)
@@ -8737,6 +8866,9 @@
 /area/lv624/lazarus/hop)
 "aVr" = (
 /mob/living/simple_animal/mouse,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 9
+	},
 /turf/open/floor/freezerfloor,
 /area/lv624/lazarus/kitchen)
 "aVs" = (
@@ -9712,9 +9844,6 @@
 /area/lv624/lazarus/canteen)
 "aZD" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
 /turf/open/floor/freezerfloor,
 /area/lv624/lazarus/kitchen)
 "aZE" = (
@@ -14202,6 +14331,9 @@
 "jNR" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/landmark/objective_landmark/far,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 5
+	},
 /turf/open/floor/whiteyellowfull/east,
 /area/lv624/lazarus/main_hall)
 "jQj" = (
@@ -45301,15 +45433,15 @@ aBA
 aCP
 aAU
 aDy
-aEC
+aDT
 aDy
 aDy
 aDy
 aGI
-aGH
+abX
 aGo
-azt
-aJg
+aHK
+abK
 aJB
 aHZ
 azt
@@ -45527,8 +45659,8 @@ azq
 aBT
 aCq
 aAP
-aAU
-aDT
+acz
+acx
 aED
 aFk
 aFO
@@ -45537,7 +45669,7 @@ aGJ
 aGH
 aDy
 azt
-aJh
+abL
 aJC
 aKv
 azt
@@ -45765,7 +45897,7 @@ aPs
 aHb
 aDy
 aHp
-aJh
+abL
 aJD
 aKv
 azt
@@ -45980,12 +46112,12 @@ oUy
 azq
 aXc
 aBy
-aBV
+acA
 aCr
 aCR
 aBV
-aDU
-aEF
+aDy
+aDy
 aDT
 aDy
 aDy
@@ -45993,7 +46125,7 @@ aDy
 aDy
 aDy
 aIg
-aJh
+abL
 aJE
 aKv
 aKK
@@ -46207,7 +46339,7 @@ oUy
 oUy
 azq
 aGZ
-aAU
+acz
 aBW
 azP
 azP
@@ -46221,7 +46353,7 @@ aQy
 aRh
 aGW
 aIh
-aJh
+abL
 aJD
 aKv
 aKL
@@ -46449,7 +46581,7 @@ aFR
 aFn
 acl
 aIi
-aJh
+abL
 aJG
 aKv
 azt
@@ -46663,7 +46795,7 @@ oUy
 azp
 aAv
 aAU
-aBA
+acG
 aAU
 aCt
 aCT
@@ -46677,7 +46809,7 @@ aFo
 aFo
 aHH
 azt
-aJj
+abP
 aJH
 aJK
 azt
@@ -46891,7 +47023,7 @@ azp
 azp
 azP
 azP
-aAU
+acI
 aBY
 azP
 azP
@@ -46905,7 +47037,7 @@ aFo
 aFo
 aHI
 azt
-azt
+aEP
 azt
 azt
 azt
@@ -47119,7 +47251,7 @@ azq
 azN
 aAw
 aAW
-aAU
+acI
 aAU
 aCu
 aCU
@@ -47133,7 +47265,7 @@ aGs
 aGs
 aGs
 azt
-aJa
+abr
 aHZ
 azt
 azt
@@ -47347,13 +47479,13 @@ azq
 azO
 aAx
 aAX
-aBA
+acG
 aAU
 aCv
 aJZ
 aDt
 azP
-aEL
+aFR
 aFn
 aFR
 aFn
@@ -47361,7 +47493,7 @@ aGs
 aHe
 aHJ
 azt
-aJa
+abr
 aJa
 aHZ
 azt
@@ -47374,8 +47506,8 @@ aZz
 aLl
 akh
 aRI
-aSA
-aSA
+aao
+aal
 aTC
 aQM
 jQX
@@ -47575,13 +47707,13 @@ azp
 azP
 azP
 azP
-aAU
+acI
 aBZ
 azP
 azP
 azP
 azP
-acc
+acl
 aFq
 acl
 acl
@@ -47589,7 +47721,7 @@ aGs
 aHf
 azt
 azt
-aJb
+abR
 aJa
 aJa
 aHZ
@@ -47601,7 +47733,7 @@ aKQ
 aLl
 aLl
 aQM
-aRK
+aQM
 aSB
 aSU
 aSB
@@ -47803,13 +47935,13 @@ azr
 azt
 aAy
 azt
-azt
+aEP
 azt
 azt
 azt
 aDu
 aDW
-aEO
+aQN
 azt
 azt
 azt
@@ -47817,7 +47949,7 @@ azt
 azt
 azt
 aIj
-aJb
+abR
 aJc
 aJf
 aJa
@@ -47829,9 +47961,9 @@ aIe
 aDu
 aPZ
 aQN
+azt
+azt
 aEP
-azt
-azt
 azt
 aTZ
 aEP
@@ -48031,21 +48163,21 @@ azt
 azt
 azQ
 azt
+acP
+azt
+azt
+azt
+azt
+azt
+azt
+azt
+azt
+azt
+azt
+azt
 aBB
 azt
-azt
-azt
-azt
-azt
-aEP
-azt
-azt
-azt
-azt
-azt
-aBB
-azt
-aJc
+abT
 aJI
 aKx
 aJf
@@ -48057,9 +48189,9 @@ azt
 azt
 azt
 azt
-aEP
-aIe
 azt
+aIe
+aEP
 azt
 azt
 aEP
@@ -48259,13 +48391,13 @@ azt
 azt
 azQ
 aAY
+aEP
 azt
-azt
 aCw
 aCw
 aCw
 aCw
-aEQ
+aCw
 aCw
 aCw
 aCw
@@ -48274,7 +48406,7 @@ aHg
 azt
 aWj
 aJd
-aJI
+abJ
 jNR
 aJc
 azt
@@ -48285,9 +48417,9 @@ aCw
 aCw
 aCw
 aCw
+aCw
+aCw
 aEQ
-aCw
-aCw
 azt
 azt
 aEP
@@ -48487,14 +48619,14 @@ azu
 azu
 azt
 azt
-azt
-aCa
-aCx
-aCX
-aDw
-aCX
-aER
+acR
+aMh
+aFT
 aFt
+aDw
+aFt
+aSV
+acd
 aFT
 aFt
 aGN
@@ -48515,11 +48647,11 @@ aQa
 aFt
 aRN
 aFt
-aSV
+aan
 aHh
 aUa
 aUH
-azt
+aad
 azt
 azt
 aWM
@@ -48715,8 +48847,9 @@ azu
 azt
 azQ
 aAZ
+aEP
 azt
-azt
+aCy
 aCy
 aCy
 aCy
@@ -48725,13 +48858,12 @@ aES
 aCy
 aCy
 aCy
-aCy
 azt
 azt
 aWj
 aJf
 aJf
-aJI
+abq
 aJc
 azt
 azt
@@ -48741,13 +48873,13 @@ aCy
 aCy
 aCy
 aCy
-aES
 aCy
 aCy
+aCy
+azt
 azt
 azt
 aEP
-azt
 aVN
 aVN
 aWL
@@ -48943,6 +49075,7 @@ azu
 azQ
 azt
 azt
+aEP
 azt
 azt
 azt
@@ -48956,10 +49089,9 @@ azt
 azt
 azt
 azt
-azt
 aJc
 aJf
-aJa
+abr
 aJf
 azt
 aHg
@@ -48969,13 +49101,13 @@ azt
 azt
 azt
 azt
-aEP
 azt
 azt
 azt
 azt
-aEP
-azu
+azt
+azt
+aae
 aVO
 aWj
 azt
@@ -49171,14 +49303,14 @@ azv
 azu
 aAz
 azt
-azt
+aEP
 azt
 azt
 azt
 aDu
 aDX
-aEO
-azt
+aQN
+aEP
 azt
 azt
 azt
@@ -49187,7 +49319,7 @@ azt
 azt
 aJb
 aJb
-aJa
+abr
 aJa
 azt
 azt
@@ -49202,8 +49334,8 @@ azt
 azt
 azt
 azt
-aUI
-azt
+aHL
+aEP
 azt
 azt
 aWK
@@ -49399,14 +49531,14 @@ azw
 azR
 azR
 azR
-aBC
+adb
 aCb
 azR
 azR
 azR
 aDY
-aET
-aFu
+aDY
+ace
 aFu
 aDY
 aDY
@@ -49415,7 +49547,7 @@ azt
 azt
 aJb
 aJa
-aJa
+abr
 aJK
 azt
 aMf
@@ -49425,13 +49557,13 @@ acv
 act
 act
 act
-aUJ
 aNk
 aNk
 aNk
 aNk
-aUJ
-aTb
+aNk
+aNk
+aaf
 aNk
 aVu
 ayP
@@ -49627,14 +49759,14 @@ azx
 aIB
 aAA
 aBa
-aBD
+adj
 aBD
 aCz
 aCY
 aDx
 aDY
 aEU
-aFv
+acj
 aFv
 aGp
 aDY
@@ -49643,7 +49775,7 @@ aHJ
 azt
 aJa
 aJa
-aJK
+abu
 azt
 aLn
 aMi
@@ -49659,7 +49791,7 @@ aSW
 aNk
 aUb
 aZD
-aSE
+aUL
 aVP
 aVu
 dZp
@@ -49855,7 +49987,7 @@ azy
 azT
 aAB
 aBb
-aBC
+adb
 aBC
 aCA
 aAB
@@ -49871,7 +50003,7 @@ aDY
 aIl
 aJa
 aJK
-azt
+aEP
 aIl
 aLp
 aLp
@@ -49881,12 +50013,12 @@ aNZ
 aNZ
 aNZ
 aNZ
-aUL
+aSE
 aSD
 aSY
 aNk
 aUc
-aUL
+aak
 aVr
 aZs
 aVu
@@ -50083,7 +50215,7 @@ azw
 azw
 azR
 azR
-aBD
+adj
 aCc
 azR
 azR
@@ -50099,7 +50231,7 @@ aDY
 aIp
 azt
 azt
-azt
+aEP
 aIp
 acm
 aMj
@@ -50109,7 +50241,7 @@ aNZ
 aPz
 aQd
 aNZ
-aUM
+aaB
 aSE
 aSZ
 aNk
@@ -50311,7 +50443,7 @@ fjM
 azw
 aAC
 aBc
-aBC
+adb
 aBC
 aIB
 aNd
@@ -50327,7 +50459,7 @@ aDY
 aIr
 aJg
 aJB
-aHZ
+abx
 aIi
 acm
 aMk
@@ -50540,12 +50672,12 @@ azw
 azw
 aBd
 aBE
-aBE
+aBC
 aCB
 aDa
-aDA
-aEa
-aEY
+aDz
+aDY
+aEV
 aFy
 aFv
 eYh
@@ -50555,7 +50687,7 @@ aDY
 aIs
 aJh
 aJL
-aKv
+abC
 azt
 acn
 aMl
@@ -50565,7 +50697,7 @@ aNZ
 aNZ
 aNZ
 aQO
-aUJ
+aNk
 aNk
 aTb
 aNk
@@ -50783,7 +50915,7 @@ aDY
 aIt
 aJh
 aJM
-aKv
+abC
 aIe
 aMl
 aMl
@@ -50793,7 +50925,7 @@ fsa
 aPA
 aQe
 aQP
-aUJ
+aNk
 aSG
 aOO
 aTE
@@ -51011,7 +51143,7 @@ aDY
 aIc
 aJh
 aJN
-aKv
+abC
 azt
 acm
 aMl
@@ -51021,7 +51153,7 @@ aMl
 aNk
 aNk
 aNk
-aUJ
+aNk
 aSH
 aTc
 aTF
@@ -51239,7 +51371,7 @@ aDY
 aIu
 aJh
 aJM
-aKv
+abC
 aBB
 acm
 aMm
@@ -51249,7 +51381,7 @@ aMl
 aMl
 aQf
 aQQ
-aRW
+aMl
 aMl
 aTd
 aTd
@@ -51467,7 +51599,7 @@ aDY
 azt
 aJh
 aJP
-aKv
+abC
 azt
 aLp
 aLp
@@ -51477,7 +51609,7 @@ aOO
 aOO
 aQg
 aOO
-aRW
+aMl
 aOd
 aMl
 aMl
@@ -51695,7 +51827,7 @@ azt
 azt
 aJj
 aJH
-aJK
+abu
 azt
 azt
 aMn
@@ -51705,7 +51837,7 @@ kPY
 aPB
 xFf
 oEE
-aRW
+aMl
 aMl
 aOd
 aMl
@@ -51923,7 +52055,7 @@ azt
 aIv
 azt
 azt
-azt
+aEP
 azt
 azt
 azt
@@ -52151,15 +52283,15 @@ azt
 azt
 azv
 azt
-azt
-azt
-azt
-azt
+abD
+aHK
+aHK
+aHK
 acs
-aMl
+aaL
 aOR
-aPD
-aPD
+aaI
+aaI
 aPD
 aNo
 aNo

--- a/maps/map_files/LV624/sprinkles/30.nexuscenter_barricaded.dmm
+++ b/maps/map_files/LV624/sprinkles/30.nexuscenter_barricaded.dmm
@@ -78,6 +78,12 @@
 /obj/item/ammo_casing,
 /turf/open/floor/damaged5,
 /area/lv624/lazarus/main_hall)
+"ao" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/damaged5,
+/area/lv624/lazarus/main_hall)
 "ap" = (
 /obj/item/weapon/twohanded/fireaxe,
 /obj/item/ammo_casing,
@@ -233,11 +239,17 @@
 /obj/structure/barricade/wooden{
 	dir = 8
 	},
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/open/floor/damaged2,
 /area/lv624/lazarus/main_hall)
 "aN" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/open/floor/damaged5,
 /area/lv624/lazarus/main_hall)
 "aO" = (
@@ -254,6 +266,9 @@
 /obj/item/ammo_casing,
 /obj/item/ammo_casing,
 /obj/item/ammo_casing,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/open/floor/damaged3,
 /area/lv624/lazarus/main_hall)
 "aR" = (
@@ -261,6 +276,9 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/item/ammo_casing,
 /obj/item/ammo_casing,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/open/floor/damaged4,
 /area/lv624/lazarus/main_hall)
 "aS" = (
@@ -268,6 +286,9 @@
 /obj/effect/landmark/corpsespawner/doctor,
 /obj/item/frame/table,
 /obj/item/ammo_casing,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/open/floor,
 /area/lv624/lazarus/main_hall)
 "aT" = (
@@ -280,6 +301,9 @@
 /obj/item/ammo_casing,
 /obj/item/ammo_casing,
 /obj/item/ammo_casing,
+/obj/structure/pipes/standard/manifold/hidden/cyan{
+	dir = 1
+	},
 /turf/open/floor/damaged4,
 /area/lv624/lazarus/main_hall)
 "aV" = (
@@ -293,8 +317,10 @@
 "aX" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/blood/gibs,
-/obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/item/ammo_casing,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 9
+	},
 /turf/open/floor/floorscorched1,
 /area/lv624/lazarus/main_hall)
 "aY" = (
@@ -317,6 +343,9 @@
 /area/lv624/lazarus/main_hall)
 "ba" = (
 /obj/structure/barricade/metal{
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
 	},
 /turf/open/floor/floorscorched2,
@@ -371,6 +400,7 @@
 /obj/item/ammo_casing,
 /obj/item/ammo_casing,
 /obj/item/ammo_casing,
+/obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/open/floor/damaged5,
 /area/lv624/lazarus/main_hall)
 "bj" = (
@@ -391,12 +421,14 @@
 /turf/open/floor/floorscorched2,
 /area/lv624/lazarus/main_hall)
 "bn" = (
-/obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/item/ammo_casing,
 /turf/closed/wall/mineral/gold,
 /area/lv624/lazarus/main_hall)
 "bo" = (
 /obj/item/stack/barbed_wire,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/open/floor/damaged2,
 /area/lv624/lazarus/main_hall)
 "bp" = (
@@ -458,6 +490,9 @@
 /turf/open/floor/damaged5,
 /area/lv624/lazarus/main_hall)
 "bx" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/open/floor/wall_thermite,
 /area/lv624/lazarus/main_hall)
 "by" = (
@@ -484,16 +519,21 @@
 /obj/item/ammo_casing,
 /obj/item/ammo_casing,
 /obj/effect/landmark/objective_landmark/far,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 5
+	},
 /turf/open/floor/floorscorched1,
 /area/lv624/lazarus/main_hall)
 "bC" = (
 /obj/effect/decal/cleanable/blood{
 	pixel_y = 12
 	},
-/obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/item/limb/hand/l_hand,
 /obj/item/ammo_casing,
 /obj/item/ammo_casing,
+/obj/structure/pipes/standard/manifold/hidden/cyan{
+	dir = 1
+	},
 /turf/open/floor/floorscorched1,
 /area/lv624/lazarus/main_hall)
 "bD" = (
@@ -502,6 +542,9 @@
 /obj/item/ammo_casing,
 /obj/item/ammo_casing,
 /obj/item/ammo_casing,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/open/floor/platingdmg3,
 /area/lv624/lazarus/main_hall)
 "bE" = (
@@ -511,16 +554,25 @@
 	flipped = 1
 	},
 /obj/item/ammo_casing,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/open/floor/whiteyellowfull/east,
 /area/lv624/lazarus/main_hall)
 "bF" = (
 /obj/item/ammo_casing,
 /obj/item/ammo_casing,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/open/floor/floorscorched1,
 /area/lv624/lazarus/main_hall)
 "bG" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/item/ammo_casing,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/open/floor/floorscorched2,
 /area/lv624/lazarus/main_hall)
 "bH" = (
@@ -638,6 +690,12 @@
 /obj/item/ammo_casing,
 /turf/open/floor/white,
 /area/lv624/lazarus/main_hall)
+"bY" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/open/floor/white,
+/area/lv624/lazarus/main_hall)
 "zt" = (
 /turf/open/floor/white,
 /area/lv624/lazarus/main_hall)
@@ -733,6 +791,9 @@
 /turf/open/floor/white,
 /area/lv624/lazarus/main_hall)
 "IY" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/open/floor/whiteyellowcorner/west,
 /area/lv624/lazarus/main_hall)
 "Jf" = (
@@ -831,7 +892,7 @@ OK
 OK
 HI
 zt
-zt
+bY
 aa
 ac
 zt
@@ -1088,7 +1149,7 @@ DY
 Ir
 ac
 by
-aa
+ao
 Ii
 Lq
 OK

--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -1,4 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aaa" = (
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 9
+	},
+/turf/open/floor/strata/orange_tile,
+/area/strata/ag/interior/mining_outpost/central)
 "aab" = (
 /turf/closed/shuttle{
 	dir = 1;
@@ -11,6 +17,14 @@
 "aad" = (
 /turf/closed/wall/strata_ice/jungle,
 /area/strata/ug/interior)
+"aae" = (
+/obj/structure/machinery/door/airlock/almayer/medical/glass/colony{
+	dir = 2;
+	name = "\improper Airlock"
+	},
+/obj/structure/pipes/standard/simple/hidden/cyan,
+/turf/open/floor/strata/multi_tiles/southeast,
+/area/strata/ag/interior/mining_outpost/central)
 "aaf" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/strata/multi_tiles/southwest,
@@ -2925,9 +2939,6 @@
 /turf/open/auto_turf/snow/brown_base/layer4,
 /area/strata/ag/exterior/paths/flight_control_exterior)
 "anq" = (
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
 /obj/structure/machinery/power/apc/no_power/south,
 /turf/open/floor/strata/white_cyan1/east,
 /area/strata/ag/interior/mining_outpost/canteen)
@@ -3405,12 +3416,6 @@
 	},
 /turf/open/floor/strata/multi_tiles,
 /area/strata/ag/interior/mining_outpost/central)
-"aqd" = (
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
-/turf/open/floor/prison/darkredfull2,
-/area/strata/ag/interior/mining_outpost/canteen)
 "aqe" = (
 /obj/structure/machinery/light/small{
 	dir = 8
@@ -3431,13 +3436,6 @@
 /obj/structure/machinery/power/port_gen/pacman/super,
 /turf/open/floor/strata/orange_cover,
 /area/strata/ag/interior/mining_outpost/central)
-"aqi" = (
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
-/obj/item/stool,
-/turf/open/floor/strata/white_cyan1,
-/area/strata/ag/interior/mining_outpost/canteen)
 "aqj" = (
 /obj/structure/machinery/door/airlock/almayer/security/glass/colony{
 	dir = 2
@@ -3508,9 +3506,6 @@
 "aqA" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/reagent_container/food/condiment/saltshaker,
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
 /turf/open/floor/strata/white_cyan1,
 /area/strata/ag/interior/mining_outpost/canteen)
 "aqB" = (
@@ -3550,12 +3545,6 @@
 	},
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/paths/flight_control_exterior)
-"aqT" = (
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
-/turf/open/floor/strata/white_cyan1,
-/area/strata/ag/interior/mining_outpost/canteen)
 "aqU" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/strata/floor3,
@@ -3983,9 +3972,6 @@
 /turf/open/floor/interior/tatami,
 /area/strata/ag/interior/outpost/canteen)
 "asX" = (
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 9
@@ -4237,12 +4223,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/asphalt/cement/cement15,
 /area/strata/ug/interior/jungle/structures/research)
-"aui" = (
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
-/turf/closed/wall/strata_outpost/reinforced,
-/area/strata/ag/interior/mining_outpost/maintenance)
 "auj" = (
 /obj/structure/machinery/landinglight/ds1/delaytwo{
 	dir = 4
@@ -5058,10 +5038,6 @@
 /obj/effect/decal/strata_decals/catwalk/prison,
 /turf/open/floor/greengrid,
 /area/strata/ag/interior/mining_outpost/central)
-"ayo" = (
-/obj/structure/pipes/standard/simple/hidden/cyan,
-/turf/closed/wall/strata_outpost,
-/area/strata/ag/interior/mining_outpost/central)
 "ayp" = (
 /obj/structure/machinery/weather_siren{
 	dir = 4;
@@ -5327,7 +5303,9 @@
 /obj/structure/mirror{
 	pixel_y = 24
 	},
-/obj/structure/pipes/standard/simple/hidden/cyan,
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 6
+	},
 /turf/open/floor/strata/orange_tile,
 /area/strata/ag/interior/mining_outpost/central)
 "azO" = (
@@ -8781,12 +8759,10 @@
 /turf/open/auto_turf/snow/brown_base/layer1,
 /area/strata/ag/exterior/paths/flight_control_exterior)
 "aTW" = (
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 5
-	},
 /obj/structure/machinery/door/airlock/almayer/generic{
 	dir = 2
 	},
+/obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/open/floor/strata/multi_tiles/southeast,
 /area/strata/ag/interior/outpost/canteen/bar)
 "aTX" = (
@@ -9039,6 +9015,9 @@
 "aVx" = (
 /obj/structure/barricade/wooden{
 	dir = 8
+	},
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 5
 	},
 /turf/open/floor/strata/cyan2/east,
 /area/strata/ag/interior/outpost/canteen/bar)
@@ -16971,12 +16950,6 @@
 	},
 /turf/open/floor/strata/multi_tiles/southwest,
 /area/strata/ag/interior/outpost/med)
-"cnm" = (
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 10
-	},
-/turf/closed/wall/strata_outpost,
-/area/strata/ag/interior/outpost/canteen/bar)
 "cnp" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/strata/cyan2/east,
@@ -17060,9 +17033,11 @@
 /turf/open/floor/almayer/plate,
 /area/strata/ag/interior/outpost/engi/drome/shuttle)
 "coh" = (
-/obj/structure/pipes/standard/simple/hidden/cyan,
 /obj/structure/machinery/light/small{
 	dir = 1
+	},
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 10
 	},
 /turf/open/floor/strata/cyan2/east,
 /area/strata/ag/interior/outpost/canteen/bar)
@@ -22976,12 +22951,6 @@
 /obj/effect/decal/strata_decals/catwalk/prison,
 /turf/open/floor/greengrid,
 /area/strata/ug/interior/jungle/structures/monitoring)
-"jEB" = (
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
-/turf/closed/wall/strata_outpost/reinforced,
-/area/strata/ag/interior/outpost/security)
 "jEO" = (
 /obj/structure/machinery/weather_siren{
 	pixel_y = -8
@@ -28550,13 +28519,6 @@
 /obj/structure/blocker/invisible_wall,
 /turf/open/auto_turf/ice/layer1,
 /area/strata/ag/interior/restricted)
-"rhg" = (
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
-/obj/structure/window/framed/strata/reinforced,
-/turf/open/floor/strata/white_cyan1,
-/area/strata/ag/interior/mining_outpost/canteen)
 "rhk" = (
 /obj/structure/machinery/landinglight/ds1/delaythree{
 	dir = 4
@@ -30133,8 +30095,8 @@
 /turf/open/gm/coast/beachcorner/north_east,
 /area/strata/ug/interior/jungle/tearlake)
 "tpo" = (
-/obj/structure/pipes/standard/manifold/hidden/cyan{
-	dir = 1
+/obj/structure/pipes/standard/simple/hidden/cyan{
+	dir = 10
 	},
 /turf/open/floor/strata/white_cyan1/east,
 /area/strata/ag/interior/mining_outpost/canteen)
@@ -41155,7 +41117,7 @@ xSJ
 nnO
 nnO
 xSJ
-bUs
+qUW
 bLw
 bWy
 bWy
@@ -41330,7 +41292,7 @@ xSJ
 egf
 xSJ
 mgM
-bUs
+qUW
 ctB
 bXW
 aqf
@@ -41680,7 +41642,7 @@ xSJ
 nnO
 nnO
 xSJ
-bUs
+qUW
 axK
 crY
 fwi
@@ -41855,7 +41817,7 @@ akw
 alL
 qUW
 qUW
-bUs
+qUW
 jyE
 aqg
 arh
@@ -41864,8 +41826,8 @@ asf
 atu
 aLl
 cbj
-bZW
-ayo
+bZV
+ctC
 azM
 aBs
 ctC
@@ -42030,7 +41992,7 @@ alp
 jOl
 anl
 apl
-rhg
+anl
 jOl
 jOl
 ari
@@ -42039,9 +42001,9 @@ bXe
 atv
 crY
 avz
-bZV
-pEF
-aMB
+bZW
+aae
+aaa
 aBt
 ctC
 aDO
@@ -42205,7 +42167,7 @@ bRY
 aky
 bRY
 aky
-aqd
+bRY
 aky
 jOl
 crY
@@ -42380,7 +42342,7 @@ alq
 and
 alq
 and
-aqi
+alq
 brS
 jOl
 bWi
@@ -42730,7 +42692,7 @@ aky
 bRY
 aky
 bRY
-aqT
+aky
 brS
 jOl
 crY
@@ -43080,7 +43042,7 @@ xdE
 xdE
 xdE
 xdE
-aui
+xdE
 avv
 xdE
 xdE
@@ -43255,7 +43217,7 @@ cpo
 cpo
 cpo
 cpo
-akA
+cpo
 aos
 aos
 aos
@@ -55860,7 +55822,7 @@ ijo
 ijo
 ijo
 ijo
-jEB
+ijo
 bYk
 ijo
 ijo
@@ -58856,7 +58818,7 @@ ckb
 ckK
 nJh
 aMn
-cnm
+ckK
 coh
 aXc
 aYW

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -140,9 +140,32 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/command/cic)
+"aat" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 5
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/hallways/hangar)
 "aau" = (
 /turf/closed/wall/almayer/reinforced/temphull,
 /area/almayer/living/pilotbunks)
+"aav" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer/cargo,
+/area/almayer/hallways/hangar)
+"aaw" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 6
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/hallways/hangar)
+"aax" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 10
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/hallways/hangar)
 "aaC" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -2945,10 +2968,6 @@
 	},
 /obj/effect/step_trigger/ares_alert/access_control,
 /turf/open/floor/almayer/no_build/test_floor4,
-/area/almayer/command/airoom)
-"auf" = (
-/obj/structure/pipes/standard/simple/hidden/supply/no_boom,
-/turf/closed/wall/almayer/aicore/hull,
 /area/almayer/command/airoom)
 "aui" = (
 /obj/structure/machinery/telecomms/hub/preset,
@@ -5954,6 +5973,9 @@
 /area/almayer/command/lifeboat)
 "aMY" = (
 /obj/effect/decal/cleanable/blood,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 9
+	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/hallways/hangar)
 "aNc" = (
@@ -9643,6 +9665,7 @@
 /area/almayer/hallways/lower/starboard_fore_hallway)
 "bqF" = (
 /obj/structure/dropship_equipment/fuel/fuel_enhancer,
+/obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/cargo,
 /area/almayer/hallways/hangar)
 "bqH" = (
@@ -10968,10 +10991,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/shipboard/weapon_room)
-"bDn" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/closed/wall/almayer,
-/area/almayer/hallways/hangar)
 "bDs" = (
 /turf/open/floor/prison/kitchen,
 /area/almayer/living/grunt_rnr)
@@ -11423,8 +11442,10 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/hangar)
 "bGu" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
 	},
 /turf/open/floor/plating/plating_catwalk,
@@ -18533,12 +18554,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom,
 /turf/open/floor/plating/plating_catwalk/aicore,
 /area/almayer/command/airoom)
-"dIn" = (
-/obj/structure/pipes/standard/simple/hidden/supply/no_boom{
-	dir = 5
-	},
-/turf/open/floor/almayer/aicore/no_build,
-/area/almayer/command/airoom)
 "dID" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -20935,7 +20950,6 @@
 /turf/open/floor/almayer/green/east,
 /area/almayer/hallways/lower/port_midship_hallway)
 "eGr" = (
-/obj/structure/pipes/standard/simple/hidden/supply/no_boom,
 /obj/structure/machinery/camera/autoname/almayer/containment/ares{
 	autoname = 0;
 	c_tag = "AI - Records";
@@ -27478,10 +27492,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/command/cic)
-"hvw" = (
-/obj/structure/pipes/standard/simple/hidden/supply/no_boom,
-/turf/open/floor/plating,
-/area/almayer/powered/agent)
 "hvx" = (
 /obj/structure/machinery/door/airlock/almayer/maint,
 /obj/structure/machinery/door/poddoor/almayer/open{
@@ -28467,7 +28477,6 @@
 	name = "server tower";
 	pixel_y = 16
 	},
-/obj/structure/pipes/standard/simple/hidden/supply/no_boom,
 /turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "hTt" = (
@@ -32139,12 +32148,6 @@
 /obj/structure/machinery/vending/hydronutrients,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/upper/u_a_s)
-"jrH" = (
-/obj/structure/pipes/standard/manifold/hidden/supply/no_boom{
-	dir = 8
-	},
-/turf/open/floor/almayer/aicore/no_build,
-/area/almayer/command/airoom)
 "jrI" = (
 /obj/structure/filingcabinet{
 	density = 0;
@@ -46559,7 +46562,6 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/living/briefing)
 "pmV" = (
-/obj/structure/pipes/standard/simple/hidden/supply/no_boom,
 /obj/structure/machinery/computer/tech_control{
 	density = 0;
 	pixel_y = 16
@@ -56804,12 +56806,6 @@
 	},
 /turf/open/floor/almayer/orange/east,
 /area/almayer/engineering/upper_engineering/port)
-"tte" = (
-/obj/structure/pipes/vents/pump/no_boom{
-	welded = 1
-	},
-/turf/open/floor/plating,
-/area/almayer/powered/agent)
 "ttB" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating/plating_catwalk,
@@ -57825,8 +57821,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/cryo)
 "tQL" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/machinery/light,
+/obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/hangar)
 "tQV" = (
@@ -89589,9 +89585,9 @@ oZp
 eXq
 vvp
 aYd
-aMY
+aaw
 bqF
-gHZ
+aat
 pcl
 oRJ
 fTm
@@ -89793,7 +89789,7 @@ dRD
 bdV
 bvf
 tQL
-bDn
+bcm
 bGu
 bvf
 fKt
@@ -89995,8 +89991,8 @@ lkf
 eXq
 ooh
 pcl
-gHZ
-pcl
+aax
+aav
 aMY
 pcl
 xNb
@@ -126079,13 +126075,13 @@ daz
 daz
 daz
 daz
-tte
-hvw
-auf
+kfU
+kfU
+daz
 pmV
 eGr
-xDC
-dIn
+qQS
+qQS
 rby
 bIp
 euN
@@ -126288,7 +126284,7 @@ daz
 ebN
 ebN
 lnS
-uVv
+mIJ
 flf
 ebN
 rOz
@@ -127703,11 +127699,11 @@ daz
 daz
 daz
 daz
-tte
-hvw
-auf
+kfU
+kfU
+daz
 hTl
-jrH
+mIJ
 xDC
 yaQ
 vLz

--- a/maps/templates/lazy_templates/clf_ert_station.dmm
+++ b/maps/templates/lazy_templates/clf_ert_station.dmm
@@ -173,10 +173,6 @@
 /obj/structure/machinery/light/small/built,
 /turf/open/floor/prison/kitchen,
 /area/adminlevel/ert_station/clf_station)
-"fk" = (
-/obj/structure/pipes/vents/pump,
-/turf/closed/wall/wood,
-/area/adminlevel/ert_station/clf_station)
 "fx" = (
 /obj/structure/largecrate/supply/medicine/blood,
 /turf/open/floor/wood,
@@ -3418,7 +3414,7 @@ ZI
 AP
 vn
 ZI
-fk
+ZI
 cx
 xM
 ZI

--- a/maps/templates/lazy_templates/weyland_ert_station.dmm
+++ b/maps/templates/lazy_templates/weyland_ert_station.dmm
@@ -1303,12 +1303,6 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/corsat/cargo,
 /area/adminlevel/ert_station/weyland_station)
-"uF" = (
-/obj/structure/pipes/standard/simple/hidden/green{
-	dir = 9
-	},
-/turf/closed/wall/r_wall/biodome,
-/area/adminlevel/ert_station/weyland_station)
 "uG" = (
 /obj/structure/machinery/cm_vending/sorted/medical/no_access{
 	req_access = null
@@ -2600,10 +2594,6 @@
 	name = "\improper Aft Medbay Shutters"
 	},
 /turf/open/floor/corsat/marked,
-/area/adminlevel/ert_station/weyland_station)
-"PI" = (
-/obj/structure/pipes/standard/simple/hidden/green,
-/turf/closed/wall/r_wall/biodome,
 /area/adminlevel/ert_station/weyland_station)
 "PL" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
@@ -4214,8 +4204,8 @@ IQ
 eQ
 Dr
 HM
-PI
-uF
+fX
+fX
 fX
 fX
 QT

--- a/tools/maplint/lints/pipes_under_walls.yml
+++ b/tools/maplint/lints/pipes_under_walls.yml
@@ -1,0 +1,3 @@
+/obj/structure/pipes:
+  banned_neighbors:
+  - CONSTRUCT_WALLS: { pattern: ^/turf/closed/wall(?!(/resin($|/)))(/.*)?$ }

--- a/tools/maplint/lints/pipes_under_walls.yml
+++ b/tools/maplint/lints/pipes_under_walls.yml
@@ -1,3 +1,3 @@
 /obj/structure/pipes:
   banned_neighbors:
-  - CONSTRUCT_WALLS: { pattern: ^/turf/closed/wall(?!(/resin($|/)))(/.*)?$ }
+    CONSTRUCT_WALLS: { pattern: "^/turf/closed/wall(?!(/resin($|/)))(/.*)?$" }


### PR DESCRIPTION
# About the pull request

This PR is a lint against pipes under walls (if they aren't resin).

# Explain why it's good for the game
Pipes are a travel method for xenos, so running pipes under walls makes that path safer for them and harder for marines to deal with. In general maintenance of pipes (IC) should be accessible.

# Changelog
:cl: Drathek Nanu
add: Added maplint to check whether pipes run under constructed walls
/:cl:
