### PR TITLE
RPG Ammo Type Loading Fix

### DIFF
--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -158,13 +158,13 @@
 		return
 	var/obj/item/weapon/gun/launcher/in_hand = M.get_active_hand()
 	if(!in_hand || !istype(in_hand))
-		to_chat(user, SPAN_WARNING("\The [M] isn't holding a rocket launcher in their active hand!"))
+		to_chat(user, SPAN_WARNING("[M] isn't holding a rocket launcher in their active hand!"))
 		return
 	if(!in_hand.current_mag)
-		to_chat(user, SPAN_WARNING("\The [M]'s [in_hand] is already loaded!"))
+		to_chat(user, SPAN_WARNING("[M]'s [in_hand] is already loaded!"))
 		return
 	if(!istype(in_hand, gun_type))
-		to_chat(user, SPAN_WARNING("\The [src] doesn't fit into \the [M]'s [in_hand.name]!")) // using name here because otherwise it puts an odd 'the' in front
+		to_chat(user, SPAN_WARNING("[src] doesn't fit into [M]'s [in_hand.name]!")) // using name here because otherwise it puts an odd 'the' in front
 		return
 	var/obj/item/weapon/twohanded/offhand/off_hand = M.get_inactive_hand()
 	if(!off_hand || !istype(off_hand))

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -158,8 +158,13 @@
 		return
 	var/obj/item/weapon/gun/launcher/in_hand = M.get_active_hand()
 	if(!in_hand || !istype(in_hand))
+		to_chat(user, SPAN_WARNING("\The [M] isn't holding a rocket launcher in their active hand!"))
 		return
 	if(!in_hand.current_mag)
+		to_chat(user, SPAN_WARNING("\The [M]'s [in_hand] is already loaded!"))
+		return
+	if(!istype(in_hand, gun_type))
+		to_chat(user, SPAN_WARNING("\The [src] doesn't fit into \the [M]'s [in_hand.name]!")) // using name here because otherwise it puts an odd 'the' in front
 		return
 	var/obj/item/weapon/twohanded/offhand/off_hand = M.get_inactive_hand()
 	if(!off_hand || !istype(off_hand))


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Fixes being able to load a rocket array into the standard rocket launcher if you use the buddy reload system. Also adds a little bit of feedback for if the weapon isn't in the active hand or if it's already loaded.

# Explain why it's good for the game
it insists upon itself

# Testing Photographs and Procedure
i tried loading the thing and not loading the thing and loading the thing when it was loaded and it all worked, trust me


# Changelog
:cl:
add: Added some text feedback to the RPG buddy loading system for when it isn't wielded or if it's already loaded
fix: Fixed the RPG buddy loading system being able to load invalid magazines into the launcher
/:cl:
