### PR TITLE
fixes bug in roof master node Destroy

### DIFF
--- a/code/game/objects/structures/roof.dm
+++ b/code/game/objects/structures/roof.dm
@@ -111,7 +111,7 @@
 	if(connected_nodes)
 		for(var/obj/effect/roof_node/roof_node in connected_nodes)
 			qdel(roof_node)
-	if(connected_nodes)
+	if(connected_roof)
 		for(var/obj/structure/roof/roof in connected_roof)
 			qdel(roof)
 	return ..()


### PR DESCRIPTION
# About the pull request

I have used up wrong var there, silly me

# Explain why it's good for the game
hopefuly corrests create and destroy when it comes to inserts that remove roof


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: corrects destroy on roof master node
/:cl:
