### PR TITLE
No more Forklift man

### DIFF
--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -29888,7 +29888,7 @@
 /obj/item/card/id/silver/clearance_badge/cl{
 	desc = "Wow sorry, didn't mean to drop that in front of you, it's real, btw.";
 	name = "certified powerloader operator card";
-	registered_name = "John Forklift"
+	registered_name = "John Smith"
 	},
 /turf/open/floor/prison/bluefull,
 /area/fiorina/station/power_ring)

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -10318,7 +10318,7 @@
 	desc = "Wow sorry, didn't mean to drop that in front of you, it's real, btw.";
 	name = "certified powerloader operator card";
 	pixel_x = 5;
-	registered_name = "John Forklift"
+	registered_name = "John Smith"
 	},
 /obj/effect/landmark/lv624/fog_blocker/short,
 /turf/open/floor/prison/greenfull/east,
@@ -32646,7 +32646,7 @@
 	desc = "Wow sorry, didn't mean to drop that in front of you, it's real, btw.";
 	name = "certified powerloader operator card";
 	pixel_x = 5;
-	registered_name = "John Forklift"
+	registered_name = "John Smith"
 	},
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison/darkbrownfull2,


### PR DESCRIPTION

# About the pull request

Changes all forklift ID names to generic names.

# Explain why it's good for the game

Joke names are not allowed. If using these items is a bannable offense, then they need to be either removed or changed.

# Testing Photographs and Procedure

N/A


# Changelog
:cl: Laser9
maptweak: Replaced all forklift ID names with generic names.
/:cl:
