### PR TITLE
Added Fax Machines to the ERT Response Stations

### DIFF
--- a/maps/templates/lazy_templates/clf_ert_station.dmm
+++ b/maps/templates/lazy_templates/clf_ert_station.dmm
@@ -9,10 +9,6 @@
 	},
 /turf/open/floor/wood,
 /area/adminlevel/ert_station/clf_station)
-"ab" = (
-/obj/structure/machinery/faxmachine/corporate,
-/turf/open/auto_turf/strata_grass/layer1,
-/area/adminlevel/ert_station/clf_station)
 "ac" = (
 /obj/structure/target/syndicate,
 /turf/open/auto_turf/strata_grass/layer1,
@@ -2847,7 +2843,7 @@ FD
 FD
 FD
 zO
-ab
+zO
 FD
 FD
 FD

--- a/maps/templates/lazy_templates/clf_ert_station.dmm
+++ b/maps/templates/lazy_templates/clf_ert_station.dmm
@@ -1,4 +1,18 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/structure/surface/table/woodentable/poor,
+/obj/item/paper_bin/wy{
+	pixel_y = 8
+	},
+/obj/item/tool/pen/clicky{
+	pixel_y = 3
+	},
+/turf/open/floor/wood,
+/area/adminlevel/ert_station/clf_station)
+"ab" = (
+/obj/structure/machinery/faxmachine/corporate,
+/turf/open/auto_turf/strata_grass/layer1,
+/area/adminlevel/ert_station/clf_station)
 "ac" = (
 /obj/structure/target/syndicate,
 /turf/open/auto_turf/strata_grass/layer1,
@@ -443,10 +457,10 @@
 /area/adminlevel/ert_station/clf_station)
 "ma" = (
 /obj/structure/surface/table/woodentable/poor,
-/obj/item/storage/fancy/cigarettes/lucky_strikes_4,
 /obj/structure/machinery/light/small/built{
 	dir = 1
 	},
+/obj/structure/machinery/faxmachine/clf,
 /turf/open/floor/wood,
 /area/adminlevel/ert_station/clf_station)
 "mp" = (
@@ -811,6 +825,7 @@
 /obj/item/reagent_container/syringe/drugs{
 	pixel_y = 8
 	},
+/obj/item/storage/fancy/cigarettes/lucky_strikes_4,
 /turf/open/floor/wood,
 /area/adminlevel/ert_station/clf_station)
 "vy" = (
@@ -2832,7 +2847,7 @@ FD
 FD
 FD
 zO
-zO
+ab
 FD
 FD
 FD
@@ -3049,7 +3064,7 @@ qM
 FD
 vn
 eP
-Ns
+aa
 Bn
 mw
 Ns

--- a/maps/templates/lazy_templates/twe_ert_station.dmm
+++ b/maps/templates/lazy_templates/twe_ert_station.dmm
@@ -2008,7 +2008,7 @@
 "VA" = (
 /obj/structure/surface/table/almayer,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/machinery/faxmachine/uscm/brig,
+/obj/structure/machinery/faxmachine/twe,
 /turf/open/floor/almayer/plate,
 /area/adminlevel/ert_station/royal_marines_station)
 "VG" = (

--- a/maps/templates/lazy_templates/upp_ert_station.dmm
+++ b/maps/templates/lazy_templates/upp_ert_station.dmm
@@ -2480,6 +2480,7 @@
 	pixel_y = -3;
 	pixel_x = 16
 	},
+/obj/structure/machinery/faxmachine/upp,
 /turf/open/floor/strata/green3/north,
 /area/adminlevel/ert_station/upp_station)
 "UB" = (

--- a/maps/templates/lazy_templates/uscm_ert_station.dmm
+++ b/maps/templates/lazy_templates/uscm_ert_station.dmm
@@ -1,4 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/surface/table/reinforced/almayer_B,
+/turf/open/floor/almayer/plate,
+/area/adminlevel/ert_station/uscm_station)
 "ab" = (
 /obj/structure/machinery/door/airlock/almayer/engineering{
 	name = "\improper Engineering Hallway";
@@ -11,6 +16,18 @@
 /area/adminlevel/ert_station/uscm_station)
 "ac" = (
 /obj/structure/morgue,
+/turf/open/floor/almayer/plate,
+/area/adminlevel/ert_station/uscm_station)
+"ad" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/bolted{
+	dir = 4
+	},
+/turf/open/floor/almayer/plate,
+/area/adminlevel/ert_station/uscm_station)
+"ae" = (
+/obj/structure/surface/table/reinforced/almayer_B,
+/obj/structure/machinery/faxmachine/uscm,
 /turf/open/floor/almayer/plate,
 /area/adminlevel/ert_station/uscm_station)
 "af" = (
@@ -27,6 +44,13 @@
 /area/adminlevel/ert_station/uscm_station)
 "ah" = (
 /turf/open/floor/almayer/plating_striped,
+/area/adminlevel/ert_station/uscm_station)
+"ai" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/surface/table/reinforced/almayer_B,
+/obj/item/paper_bin/wy,
+/obj/item/tool/pen/clicky,
+/turf/open/floor/almayer/plate,
 /area/adminlevel/ert_station/uscm_station)
 "ak" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7395,9 +7419,9 @@ Zp
 Zp
 qE
 zK
-Hc
-Hc
-Hc
+MJ
+ad
+MJ
 MJ
 Ky
 Qv
@@ -7447,9 +7471,9 @@ Zp
 Zp
 qE
 zK
-Lo
-Lo
-Hc
+ai
+ae
+aa
 MJ
 Ky
 PH


### PR DESCRIPTION

# About the pull request

Adds a faction's fax machine to their respective Response Stations, with paper bins and pens.

# Explain why it's good for the game

Adds good RP between factions and their Fax Responders when they are done with their mission and return back home.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
mapadd: All Faction ERT Stations now have a Fax Machine linked to their respective faction.
/:cl:
