### PR TITLE
anchored decals

### DIFF
--- a/code/game/objects/effects/decals/misc.dm
+++ b/code/game/objects/effects/decals/misc.dm
@@ -1,5 +1,6 @@
 /obj/effect/decal
 	plane = FLOOR_PLANE
+	anchored = TRUE
 
 // Used for spray that you spray at walls, tables, hydrovats etc
 /obj/effect/decal/spraystill


### PR DESCRIPTION

# About the pull request

mappers use decals for stuff like catwalks spray stuff and so on, none of the decals should be moveable

# Explain why it's good for the game
moving catwalk sprayed on stuff and such is not intended


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: anchors decals
/:cl:
