### PR TITLE
Makes fax responder listening bugs shut up

### DIFF
--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -80,3 +80,8 @@
 
 #define RADIO_CHANNEL_YAUTJA "Yautja"
 
+
+// Listening bug broadcast setting. Whether or not it plays only to ghosts with preferences, or doesn't show to ghosts at all.
+#define NOT_LISTENING_BUG 0
+#define LISTENING_BUG_PREF 1
+#define LISTENING_BUG_NEVER 2

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -83,7 +83,7 @@
 						vmask, vmessage, obj/item/device/radio/radio,
 						message, name, job, realname, vname,
 						data, compression, list/level, freq, verbage = "says",
-						datum/language/speaking = null, volume = RADIO_VOLUME_QUIET, listening_device = FALSE)
+						datum/language/speaking = null, volume = RADIO_VOLUME_QUIET, listening_device = NOT_LISTENING_BUG)
 
 	/* ###### Prepare the radio connection ###### */
 	var/display_freq = freq
@@ -182,7 +182,7 @@
 		// Ghosts hearing all radio chat don't want to hear syndicate intercepts, they're duplicates
 		if(data == 3 && is_ghost && R.client && (R.client.prefs.toggles_chat & CHAT_GHOSTRADIO))
 			continue
-		if(is_ghost && listening_device && !(R.client.prefs.toggles_chat & CHAT_LISTENINGBUG))
+		if(is_ghost && ((listening_device && !(R.client.prefs.toggles_chat & CHAT_LISTENINGBUG)) || listening_device == LISTENING_BUG_NEVER))
 			continue
 		// --- Check for compression ---
 		if(compression > 0)

--- a/code/game/objects/items/devices/radio/listening_bugs.dm
+++ b/code/game/objects/items/devices/radio/listening_bugs.dm
@@ -1,14 +1,3 @@
-#define DISGUISE_REMOVE "remove disguise"
-#define DISGUISE_RADIO "radio"
-#define DISGUISE_PEN "pen"
-#define DISGUISE_FOUNTAIN_PEN "fountain pen"
-#define DISGUISE_ACCESS_TUNER "access tuner"
-#define DISGUISE_WHISTLE "whistle"
-#define DISGUISE_MASS_SPEC "mass-spectrometer"
-#define DISGUISE_CAMERA "camera"
-#define DISGUISE_ZIPPO "zippo lighter"
-#define DISGUISE_TAPE_RECORDER "tape recorder"
-
 /obj/item/device/radio/listening_bug
 	name = "listening device"
 	desc = "A small, and disguisable, listening device."
@@ -33,6 +22,8 @@
 	/// The ID tag of the device, for identification.
 	var/nametag = "Device"
 	inherent_traits = list(TRAIT_HEARS_FROM_CONTENTS)
+	/// Whether or not this listening bug plays to ghosts depending on preferences or not at all.
+	var/bug_broadcast_level = LISTENING_BUG_PREF
 
 /obj/item/device/radio/listening_bug/ui_data(mob/user)
 	var/list/data = list()
@@ -91,7 +82,7 @@
 	var/processed_verb = "[SPAN_RED("\[LSTN [nametag]\]")] [verb]"
 	if(broadcasting)
 		if(get_dist(src, M) <= 7)
-			talk_into(M, msg, null, processed_verb, speaking, listening_device = TRUE)
+			talk_into(M, msg, null, processed_verb, speaking, listening_device = bug_broadcast_level)
 
 /obj/item/device/radio/listening_bug/afterattack(atom/target_atom, mob/user as mob, proximity)
 	if(!ready_to_disguise)
@@ -287,6 +278,7 @@
 	name = "Comms Relay Device"
 	subspace_switchable = FALSE
 	broadcasting = TRUE
+	bug_broadcast_level = LISTENING_BUG_NEVER //Don't want fax responder devices broadcasting to ghosts because it will duplicate a lot of messages every round all the time.
 
 /obj/item/device/radio/listening_bug/radio_linked/fax/wy
 	frequency = FAX_WY_FREQ

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -206,7 +206,7 @@
 	// If we were to send to a channel we don't have, drop it.
 	return null
 
-/obj/item/device/radio/talk_into(mob/living/M as mob, message, channel, verb = "says", datum/language/speaking = null, listening_device = FALSE)
+/obj/item/device/radio/talk_into(mob/living/M as mob, message, channel, verb = "says", datum/language/speaking = null, listening_device = NOT_LISTENING_BUG)
 	if(!on) return // the device has to be on
 	//  Fix for permacell radios, but kinda eh about actually fixing them.
 	if(!M || !message) return


### PR DESCRIPTION

# About the pull request

As title. Fax responder listening bugs won't broadcast to ghosts anymore.

# Explain why it's good for the game

They duplicate a lot of messages due to being in key locations every round, fax responder or not. They're only relevant to the responders usually unlike manually placed listening bugs that may have relevance to spectators.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Fax responder preset listening bugs no longer broadcast to ghosts.
/:cl:
