### PR TITLE
Fixes many equipment presets spawning in without a proper rank. Leading up to them showing up on the radio as ???.

### DIFF
--- a/code/modules/gear_presets/other.dm
+++ b/code/modules/gear_presets/other.dm
@@ -1,6 +1,7 @@
 /datum/equipment_preset/other
 	name = "Other"
 	languages = list(LANGUAGE_ENGLISH)
+	paygrades = list(PAY_SHORT_CIV = JOB_PLAYTIME_TIER_0)
 
 //*****************************************************************************************************/
 


### PR DESCRIPTION
Fixes many equipment presets spawning in without a proper rank. Leading up to them showing up on the radio as ???.
# About the pull request

Fixes some equipment presets spawning in without a proper rank. Leading up to them showing up on the radio as ???.
For example 4 gladiator gearsets, the pizza one, a non w-y corporate representive, souto man and such.
(If you have suggestions on what gladiators/elite mercs should have as radio prefixes let me know. Now they would no longer be ??? but instead have mr or ms.)
It's mostly a bug fix. The presets that inherit from /other/ are almost all civilian or presets that have their own (custom) logic already. (mutineers and zombies). Somewhere along the line these presets ended up without a paygrade hence they would not get a rank/prefix on the radio. Instead, it would say ??? now it will say mr/ms. 


# Explain why it's good for the game

It's a bugfix.
https://github.com/cmss13-devs/cmss13/issues/7508


# Testing Photographs and Procedure

I have looked at all presets that inherit from here.
The ones that are not civilian already have properly been setup.
(Freelancers,professor dummy,a special tank crew and tank trainee.)
Mutineers/xeno cultists and zombies have their own custom logic already.
And I checked my changes ingame.
<details>
<summary>Screenshots & Videos</summary>

[Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.](https://github.com/cmss13-devs/cmss13/issues/7508)

</details>


# Changelog

:cl:Awan
fix: Fixed some gearsets having improper radio/chat prefixes.
/:cl:

