### PR TITLE
Loader Pamphlet Endurance Limit

### DIFF
--- a/code/modules/character_traits/skills.dm
+++ b/code/modules/character_traits/skills.dm
@@ -94,8 +94,8 @@
 	trait_name = "Loader Training"
 	trait_desc = "Boosts the endurance skill by 1."
 	skill = SKILL_ENDURANCE
-	skill_cap = SKILL_ENDURANCE_MASTER
-	skill_increment = SKILL_ENDURANCE_MASTER
+	skill_cap = SKILL_ENDURANCE_TRAINED
+	skill_increment = 1
 
 /datum/character_trait/skills/k9_handler
 	trait_name = "K9 Handler Training"


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #7887 making the loader pamphlet only increment the skill by 1 (capped to 2) to have the same endurance skill as the demo.

# Explain why it's good for the game

Pamphlet only mentions increasing the skill by 1, and there isn't really any inherent need for exceptionally high endurance in order to do their job.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![pamphlet](https://github.com/user-attachments/assets/d35f2903-7eda-4481-939b-8724713ecced)

</details>

# Changelog

:cl: Drathek
balance: Loader pamphlet now only increases endurance to 2
/:cl:
