### PR TITLE
Duplicate Platforms Maplint

### DIFF
--- a/maps/map_files/CORSAT/Corsat.dmm
+++ b/maps/map_files/CORSAT/Corsat.dmm
@@ -3379,15 +3379,11 @@
 /turf/open/floor/wood,
 /area/corsat/gamma/residential/researcher)
 "anl" = (
-/obj/structure/platform_decoration/metal/almayer/east{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/east,
 /turf/open/floor/corsat/whitecorner/north,
 /area/corsat/sigma/dorms)
 "anm" = (
-/obj/structure/platform_decoration/metal/almayer/west{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/west,
 /turf/open/floor/corsat/whitecorner/east,
 /area/corsat/sigma/dorms)
 "ann" = (
@@ -10550,9 +10546,7 @@
 /area/corsat/sigma/south/complex)
 "aOR" = (
 /obj/structure/prop/almayer/computers/sensor_computer2,
-/obj/structure/platform_decoration/metal/almayer/north{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/north,
 /turf/open/floor/corsat/plate,
 /area/corsat/sigma/south/complex)
 "aOS" = (
@@ -10561,9 +10555,7 @@
 	icon = 'icons/obj/structures/props/server_equipment.dmi';
 	name = "Processor Unit"
 	},
-/obj/structure/platform_decoration/metal/almayer/east{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/east,
 /turf/open/floor/corsat/plate,
 /area/corsat/sigma/south/complex)
 "aOT" = (
@@ -13523,9 +13515,7 @@
 /turf/open/gm/grass/grass1/weedable,
 /area/corsat/theta/biodome)
 "aZn" = (
-/obj/structure/platform_decoration/metal/almayer/west{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/west,
 /turf/open/floor/corsat/tan/north,
 /area/corsat/gamma/residential/west)
 "aZo" = (
@@ -13682,9 +13672,7 @@
 /area/corsat/omega/offices)
 "aZK" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/obj/structure/platform_decoration/metal/almayer/east{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/east,
 /turf/open/floor/corsat/tan/north,
 /area/corsat/gamma/residential/west)
 "aZL" = (
@@ -13723,9 +13711,7 @@
 /turf/open/floor/corsat/squares,
 /area/corsat/sigma/southeast/datamaint)
 "aZT" = (
-/obj/structure/platform_decoration/metal/almayer/east{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/east,
 /turf/open/floor/corsat/tan/north,
 /area/corsat/gamma/residential/west)
 "aZV" = (
@@ -26574,9 +26560,7 @@
 /turf/open/floor/corsat/yellow/east,
 /area/corsat/gamma/engineering)
 "cJU" = (
-/obj/structure/platform_decoration/metal/almayer/east{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/east,
 /turf/open/floor/corsat/whitecorner/north,
 /area/corsat/sigma/south)
 "cJW" = (
@@ -28558,9 +28542,7 @@
 /turf/open/floor/almayer/research/containment/corner/north,
 /area/corsat/sigma/south/complex)
 "eNI" = (
-/obj/structure/platform_decoration/metal/almayer{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer,
 /turf/open/floor/corsat/whitecorner,
 /area/corsat/sigma/south)
 "eNM" = (
@@ -31232,9 +31214,7 @@
 /turf/open/floor/corsat/redcorner,
 /area/corsat/omega/security)
 "hwV" = (
-/obj/structure/platform_decoration/metal/almayer/east{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/east,
 /turf/open/floor/corsat/plate,
 /area/corsat/sigma/north)
 "hwW" = (
@@ -32616,9 +32596,7 @@
 /turf/open/floor/corsat/purplewhite/north,
 /area/corsat/gamma/biodome/toxins)
 "iPn" = (
-/obj/structure/platform_decoration/metal/almayer{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer,
 /turf/open/floor/corsat/white/east,
 /area/corsat/gamma/residential/east)
 "iPo" = (
@@ -32680,9 +32658,7 @@
 /turf/open/floor/plating,
 /area/corsat/sigma/hangar/arrivals)
 "iTt" = (
-/obj/structure/platform_decoration/metal/almayer/north{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/north,
 /turf/open/floor/corsat/whitecorner/west,
 /area/corsat/gamma/hallwaysouth)
 "iTL" = (
@@ -32784,9 +32760,7 @@
 /turf/open/floor/corsat/whitetan/north,
 /area/corsat/sigma/dorms)
 "jai" = (
-/obj/structure/platform_decoration/metal/almayer{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer,
 /turf/open/floor/corsat/whitecorner,
 /area/corsat/gamma/hallwaysouth)
 "jaJ" = (
@@ -33300,9 +33274,7 @@
 /turf/open/floor/corsat/whitetan/southwest,
 /area/corsat/sigma/dorms)
 "jGd" = (
-/obj/structure/platform_decoration/metal/almayer/north{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/north,
 /turf/open/floor/corsat/white/west,
 /area/corsat/gamma/hallwaysouth)
 "jGk" = (
@@ -34232,9 +34204,7 @@
 /turf/open/floor/corsat/squares,
 /area/corsat/sigma/hangar/security)
 "kMZ" = (
-/obj/structure/platform_decoration/metal/almayer/east{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/east,
 /turf/open/floor/corsat/whitecorner/north,
 /area/corsat/gamma/residential/east)
 "kNB" = (
@@ -34548,9 +34518,7 @@
 /obj/structure/sign/safety/laser{
 	pixel_x = 32
 	},
-/obj/structure/platform_decoration/metal/almayer/east{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/east,
 /turf/open/floor/corsat/purplewhite/east,
 /area/corsat/theta/biodome/complex)
 "leI" = (
@@ -34609,9 +34577,7 @@
 /turf/open/floor/almayer/tcomms,
 /area/corsat/sigma/southeast/datalab)
 "lgt" = (
-/obj/structure/platform_decoration/metal/almayer/east{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/east,
 /turf/open/floor/corsat/whitecorner/north,
 /area/corsat/gamma/hallwaysouth)
 "lgv" = (
@@ -35165,11 +35131,6 @@
 /obj/item/phone,
 /turf/open/floor/corsat/purplewhite,
 /area/corsat/sigma/south/complex)
-"lIY" = (
-/obj/structure/platform/metal/almayer/north,
-/obj/structure/platform/metal/almayer/north,
-/turf/open/floor/corsat/white/north,
-/area/corsat/sigma/south)
 "lJj" = (
 /obj/structure/bookcase{
 	icon_state = "book-5"
@@ -35672,9 +35633,7 @@
 /area/corsat/sigma/checkpoint)
 "mhq" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/obj/structure/platform_decoration/metal/almayer/west{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/west,
 /turf/open/floor/corsat/whitecorner/east,
 /area/corsat/sigma/south)
 "mim" = (
@@ -35924,9 +35883,7 @@
 /turf/open/floor/corsat/lightplate,
 /area/corsat/gamma/biodome/virology)
 "mxa" = (
-/obj/structure/platform_decoration/metal/almayer{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer,
 /turf/open/floor/corsat/plate,
 /area/corsat/sigma/north)
 "mxc" = (
@@ -36267,9 +36224,7 @@
 /turf/open/floor/corsat/purplewhite/southwest,
 /area/corsat/gamma/sigmaremote)
 "mQU" = (
-/obj/structure/platform_decoration/metal/almayer/west{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/west,
 /turf/open/floor/corsat/whitecorner/east,
 /area/corsat/gamma/residential/east)
 "mRl" = (
@@ -40063,9 +40018,7 @@
 /area/corsat/gamma/sigmaremote)
 "qTd" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/structure/platform_decoration/metal/almayer/west{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/west,
 /turf/open/floor/corsat/whitecorner/east,
 /area/corsat/gamma/hallwaysouth)
 "qTe" = (
@@ -40120,9 +40073,7 @@
 /turf/open/floor/corsat/plate,
 /area/corsat/omega/biodome)
 "qVF" = (
-/obj/structure/platform_decoration/metal/almayer/north{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/north,
 /turf/open/floor/corsat/plate,
 /area/corsat/sigma/north)
 "qVJ" = (
@@ -40555,9 +40506,7 @@
 /turf/open/gm/dirt,
 /area/corsat/theta/biodome)
 "rws" = (
-/obj/structure/platform_decoration/metal/almayer/north{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/north,
 /turf/open/floor/corsat/white/west,
 /area/corsat/gamma/residential/east)
 "rwF" = (
@@ -41431,9 +41380,7 @@
 /turf/open/floor/corsat/darkgreen/north,
 /area/corsat/sigma/hangar)
 "snP" = (
-/obj/structure/platform_decoration/metal/almayer{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer,
 /turf/open/floor/corsat/white/east,
 /area/corsat/gamma/hallwaysouth)
 "snS" = (
@@ -44859,9 +44806,7 @@
 /turf/open/floor/corsat/white,
 /area/corsat/gamma/residential/researcher)
 "vXy" = (
-/obj/structure/platform_decoration/metal/almayer/west{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/west,
 /turf/open/floor/corsat/whitecorner/east,
 /area/corsat/sigma/south)
 "vYe" = (
@@ -45467,9 +45412,7 @@
 /turf/open/floor/corsat/yellow/east,
 /area/corsat/sigma/airlock/control)
 "wDw" = (
-/obj/structure/platform_decoration/metal/almayer/east{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/east,
 /turf/open/floor/corsat/whitecorner/north,
 /area/corsat/gamma/residential)
 "wDC" = (
@@ -45892,9 +45835,7 @@
 /turf/open/floor/corsat/whitecorner,
 /area/corsat/gamma/residential/east)
 "wZC" = (
-/obj/structure/platform_decoration/metal/almayer/west{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/west,
 /turf/open/floor/corsat/whitecorner/east,
 /area/corsat/gamma/residential)
 "xap" = (
@@ -45915,9 +45856,7 @@
 /turf/open/floor/corsat/white/northeast,
 /area/corsat/gamma/hallwaysouth)
 "xbu" = (
-/obj/structure/platform_decoration/metal/almayer/west{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/west,
 /turf/open/floor/corsat/whitecorner/east,
 /area/corsat/gamma/hallwaysouth)
 "xbW" = (
@@ -46751,9 +46690,7 @@
 /turf/open/floor/corsat/white/east,
 /area/corsat/gamma/hallwaysouth)
 "ybJ" = (
-/obj/structure/platform_decoration/metal/almayer/west{
-	density = 0
-	},
+/obj/structure/platform_decoration/metal/almayer/west,
 /turf/open/floor/corsat/plate,
 /area/corsat/sigma/north)
 "ybP" = (
@@ -92195,7 +92132,7 @@ ylo
 arJ
 arJ
 hYo
-lIY
+llM
 ahu
 nJC
 aje

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -49069,7 +49069,6 @@
 "uKX" = (
 /obj/structure/platform/metal/almayer/east,
 /obj/structure/stairs,
-/obj/structure/platform/metal/almayer/east,
 /obj/structure/disposalpipe/segment,
 /turf/open/asphalt/cement/cement1,
 /area/desert_dam/interior/dam_interior/central_tunnel)
@@ -50301,7 +50300,6 @@
 "xlt" = (
 /obj/structure/platform/metal/almayer/east,
 /obj/structure/stairs,
-/obj/structure/platform/metal/almayer/east,
 /turf/open/asphalt/cement/cement1,
 /area/desert_dam/interior/dam_interior/west_tunnel)
 "xlE" = (

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -10549,12 +10549,6 @@
 /obj/structure/bed/chair/comfy,
 /turf/open/floor/prison,
 /area/fiorina/tumor/servers)
-"ifB" = (
-/obj/structure/platform/metal/kutjevo_smooth,
-/obj/structure/platform/metal/kutjevo_smooth/east,
-/obj/structure/platform/metal/kutjevo_smooth/east,
-/turf/open/space/basic,
-/area/fiorina/oob)
 "ifJ" = (
 /obj/structure/bed/chair/dropship/pilot{
 	dir = 1
@@ -59013,7 +59007,7 @@ mEO
 oou
 aFZ
 blI
-ifB
+axW
 pFE
 uFx
 lud

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -2128,7 +2128,6 @@
 	bound_height = 32;
 	icon_state = "solo_tank_empty"
 	},
-/obj/structure/platform/metal/kutjevo_smooth/west,
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor/kutjevo/multi_tiles/southwest,
 /area/kutjevo/interior/colony_South/power2)

--- a/maps/templates/lazy_templates/upp_ert_station.dmm
+++ b/maps/templates/lazy_templates/upp_ert_station.dmm
@@ -622,7 +622,6 @@
 /area/adminlevel/ert_station/upp_station)
 "lg" = (
 /obj/structure/platform/metal/kutjevo_smooth/north,
-/obj/structure/platform/metal/kutjevo_smooth/north,
 /obj/structure/barricade/handrail{
 	dir = 1;
 	icon_state = "hr_kutjevo";

--- a/tools/maplint/lints/multiple_platforms.yml
+++ b/tools/maplint/lints/multiple_platforms.yml
@@ -1,0 +1,4 @@
+/obj/structure/platform:
+  banned_neighbors:
+    /obj/structure/platform:
+      identical: true


### PR DESCRIPTION

# About the pull request

This PR adds a maplint for duplicate identical platforms.

# Explain why it's good for the game

Fixes #7968 and many other duplicate platforms

# Testing Photographs and Procedure
See checks.

# Changelog
:cl: Drathek
add: Added a maplint for duplicate identical platforms
maptweak: Fixed duplicate platforms on CORSAT, Desert_Dam, Fiorina, Kutjevo, Hybrisa, and the UPP ERT station
/:cl:
