### PR TITLE
Allows the Lifesaver Belt to carry information dogtags.

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -266,6 +266,7 @@
 		/obj/item/device/defibrillator/compact,
 		/obj/item/device/reagent_scanner,
 		/obj/item/device/analyzer/plant_analyzer,
+		/obj/item/dogtag,
 	)
 	flags_atom = FPRINT // has gamemode skin
 


### PR DESCRIPTION
# About the pull request

the lifesaver pattern belt can now store information dog tags.

# Explain why it's good for the game
Because how much on an emphasis is placed on having the most gear possible to play the most optimally, rarely do people gather information tags. This is reflected by most highpop rounds still only having around 3-4 collected at best. Allowing the lifesaver belt to carry them makes it more viable for medics to spare one of their 5000000 slots to carry a stack of dogtags instead of a 500000th burn kit, instead only carrying 499999 burn kits.

This hopefully means that we'll have more than 5 dead marine names on the memorial slab at roundend.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: 
qol: information dog tags can now be stored in the lifesaver belt.
/:cl: