### PR TITLE
Predators can no longer set off OT claymores 

### DIFF
--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -326,6 +326,11 @@
 	matter = list("metal" = 3750)
 	has_blast_wave_dampener = TRUE
 
+/obj/item/explosive/mine/custom/try_to_prime(mob/living/carbon/hunter)
+	if(isyautja(hunter))
+		to_chat(hunter, SPAN_NOTICE("You carefully avoid stepping on the human hunting trap."))
+		return
+
 /obj/item/explosive/mine/sebb
 	name = "\improper G2 Electroshock grenade"
 	icon_state = "grenade_sebb_planted"

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -38,6 +38,11 @@
 /obj/item/device/assembly/prox_sensor/HasProximity(atom/movable/AM)
 	if((!holder && !secured) || !scanning || cooldown>0 || delaying)
 		return
+
+	if(isyautja(AM))
+		to_chat(src, "prox")
+		return
+
 	if(has_moved_recently(AM))
 		sense()
 
@@ -49,6 +54,11 @@
 
 
 /obj/item/device/assembly/prox_sensor/proc/sense()
+
+	if(isyautja(src))
+		to_chat(src, "sense")
+		return
+
 	var/turf/mainloc = get_turf(src)
 	mainloc.visible_message(SPAN_DANGER("You hear a proximity sensor beep!"), SPAN_DANGER("You hear a proximity sensor beep!"))
 	playsound(mainloc, 'sound/machines/twobeep.ogg', 50, 1)

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -40,7 +40,6 @@
 		return
 
 	if(isyautja(AM))
-		to_chat(src, "prox")
 		return
 
 	if(has_moved_recently(AM))
@@ -56,7 +55,6 @@
 /obj/item/device/assembly/prox_sensor/proc/sense()
 
 	if(isyautja(src))
-		to_chat(src, "sense")
 		return
 
 	var/turf/mainloc = get_turf(src)


### PR DESCRIPTION
# About the pull request
Predators can no longer trigger OT claymores or prox sensors.

Removing OT claymores or just simply removing OT from the game entirely would also work but that is not up to me.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Dying instantly as a one life role is not fun. 

Zero counter play is not fun.
# Testing Photographs and Procedure
<details>
I tested both for xenos and any other mob without the marine IFF tag and it set off so it should work


</details>


# Changelog
:cl: Joe Lampost
balance: Predators can no longer trigger OT claymores or prox sensors 
/:cl:
