### PR TITLE
Allows gold medal SO to rank up to 1LT

### DIFF
--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -594,7 +594,7 @@
 	access = list(ACCESS_MARINE_COMMAND, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_DATABASE, ACCESS_MARINE_MEDBAY)
 	assignment = JOB_SO
 	rank = JOB_SO
-	paygrades = list(PAY_SHORT_MO1 = JOB_PLAYTIME_TIER_0)
+	paygrades = list(PAY_SHORT_MO1 = JOB_PLAYTIME_TIER_0, PAY_SHORT_MO2 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "SO"
 	minimum_age = 25
 	skills = /datum/skills/SO


### PR DESCRIPTION

# About the pull request

Playtime LVL 3 Staff Officers can rank up to 1LT

# Explain why it's good for the game

Something tangible to show off playtime, all other officer roles(except XO and CO) can already rank up, including ASO ranking up to equal XO showing equaling a higher COC is not an issue for officers


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Playtime Level 3 Staff Officers can now be First Lieutenants
/:cl:
