### PR TITLE
Adjusts minimum ages for many roles.

### DIFF
--- a/code/modules/gear_presets/_select_equipment.dm
+++ b/code/modules/gear_presets/_select_equipment.dm
@@ -95,7 +95,7 @@
 /datum/equipment_preset/proc/load_age(mob/living/carbon/human/new_human, client/mob_client)
 	if(minimum_age && new_human.age < minimum_age)
 		new_human.age = minimum_age + 2
-	else(minimum_age && age < minimum_age)
+	if(minimum_age && age < minimum_age)
 		age = minimum_age + 2
 
 /datum/equipment_preset/proc/load_rank(mob/living/carbon/human/new_human, client/mob_client)//Beagle-Code

--- a/code/modules/gear_presets/_select_equipment.dm
+++ b/code/modules/gear_presets/_select_equipment.dm
@@ -15,6 +15,7 @@
 	var/list/access = list()
 	var/assignment
 	var/rank
+	var/age
 	var/list/paygrades = list("???")
 	var/role_comm_title
 	var/minimum_age
@@ -93,7 +94,9 @@
 
 /datum/equipment_preset/proc/load_age(mob/living/carbon/human/new_human, client/mob_client)
 	if(minimum_age && new_human.age < minimum_age)
-		new_human.age = minimum_age
+		new_human.age = minimum_age + 2
+	else(minimum_age && age < minimum_age)
+		age = minimum_age + 2
 
 /datum/equipment_preset/proc/load_rank(mob/living/carbon/human/new_human, client/mob_client)//Beagle-Code
 	if(paygrades.len == 1)

--- a/code/modules/gear_presets/_select_equipment.dm
+++ b/code/modules/gear_presets/_select_equipment.dm
@@ -15,7 +15,6 @@
 	var/list/access = list()
 	var/assignment
 	var/rank
-	var/age
 	var/list/paygrades = list("???")
 	var/role_comm_title
 	var/minimum_age
@@ -95,8 +94,6 @@
 /datum/equipment_preset/proc/load_age(mob/living/carbon/human/new_human, client/mob_client)
 	if(minimum_age && new_human.age < minimum_age)
 		new_human.age = minimum_age + 2
-	if(minimum_age && age < minimum_age)
-		age = minimum_age + 2
 
 /datum/equipment_preset/proc/load_rank(mob/living/carbon/human/new_human, client/mob_client)//Beagle-Code
 	if(paygrades.len == 1)

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -435,7 +435,7 @@
 	rank = JOB_SQUAD_LEADER
 	paygrades = list(PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME6 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME7 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "SL"
-	minimum_age = 27
+	minimum_age = 25
 	skills = /datum/skills/SL
 
 	minimap_icon = "leader"
@@ -512,7 +512,7 @@
 	rank = JOB_SQUAD_LEADER
 	paygrades = list(PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME6 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME7 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "SL"
-	minimum_age = 27
+	minimum_age = 25
 	skills = /datum/skills/SL
 
 	minimap_icon = "leader"

--- a/code/modules/gear_presets/uscm_police.dm
+++ b/code/modules/gear_presets/uscm_police.dm
@@ -2,7 +2,7 @@
 	name = "USCM (police roles)"
 	faction = FACTION_MARINE
 	minimap_background = "background_mp"
-	minimum_age = 27
+	minimum_age = 21
 
 //*****************************************************************************************************/
 
@@ -88,6 +88,7 @@
 	rank = JOB_WARDEN
 	paygrades = list(PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME6 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME7 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "MW"
+	minimum_age = 25
 	skills = /datum/skills/MW
 
 	minimap_icon = "warden"
@@ -148,6 +149,7 @@
 	assignment = JOB_CHIEF_POLICE
 	rank = JOB_CHIEF_POLICE
 	paygrades = list(PAY_SHORT_MO1 = JOB_PLAYTIME_TIER_0, PAY_SHORT_MO2 = JOB_PLAYTIME_TIER_1)
+	minimum_age = 23
 	role_comm_title = "CMP"
 	skills = /datum/skills/CMP
 

--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -253,7 +253,7 @@
 	rank = JOB_CHIEF_ENGINEER
 	paygrades = list(PAY_SHORT_MO1 = JOB_PLAYTIME_TIER_0, PAY_SHORT_MO2 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "CE"
-	minimum_age = 27
+	minimum_age = 25
 	skills = /datum/skills/CE
 
 	minimap_icon = "ce"
@@ -370,7 +370,7 @@
 	rank = JOB_CHIEF_REQUISITION
 	paygrades = list(PAY_SHORT_ME6 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME7 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME8 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "QM"
-	minimum_age = 27
+	minimum_age = 25
 	skills = /datum/skills/RO
 
 	minimap_icon = "cargo"
@@ -557,7 +557,7 @@
 	rank = JOB_XO
 	paygrades = list(PAY_SHORT_MO3 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "XO"
-	minimum_age = 35
+	minimum_age = 27
 	skills = /datum/skills/XO
 
 	minimap_icon = "xo"
@@ -596,7 +596,7 @@
 	rank = JOB_SO
 	paygrades = list(PAY_SHORT_MO1 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "SO"
-	minimum_age = 25
+	minimum_age = 23
 	skills = /datum/skills/SO
 
 	minimap_icon = "so"
@@ -675,7 +675,7 @@
 	rank = JOB_AUXILIARY_OFFICER
 	paygrades = list(PAY_SHORT_MO2 = JOB_PLAYTIME_TIER_0, PAY_SHORT_MO3 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "ASO"
-	minimum_age = 27
+	minimum_age = 25
 	skills = /datum/skills/auxiliary_officer
 
 	minimap_icon = "aso"
@@ -734,6 +734,7 @@
 	rank = JOB_CAS_PILOT
 	paygrades = list(PAY_SHORT_MO1 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "GP"
+	minimum_age = 23
 	skills = /datum/skills/pilot
 
 	minimap_icon = "gp"
@@ -785,6 +786,7 @@
 	rank = JOB_DROPSHIP_PILOT
 	paygrades = list(PAY_SHORT_MO1 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "DP"
+	minimum_age = 23
 	skills = /datum/skills/pilot
 
 	minimap_icon = "pilot"
@@ -890,7 +892,7 @@
 	rank = "USCM Officer"
 	paygrades = list(PAY_SHORT_MO3 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "Cpt"
-	minimum_age = 40
+	minimum_age = 25
 	skills = /datum/skills/commander
 
 	utility_hat = list(/obj/item/clothing/head/beret/cm)


### PR DESCRIPTION
# About the pull request

Adjusts the minimum age for many shipside roles.
read the changed files for the specifics

# Explain why it's good for the game

Many of the ages were legacy for when the roles were of much higher rank, and others haven't been in comparison to other changes, for instance XO currently has a higher min-age than CO.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Some roles have lower minimum ages to represent their ranks better, no gameplay changes.
add: Being below the minimum age for a role now sets you to that minimum age, plus two years.
/:cl:
