### PR TITLE
CAS no longer has infinite NVGs roundstart

### DIFF
--- a/code/game/machinery/computer/dropship_weapons.dm
+++ b/code/game/machinery/computer/dropship_weapons.dm
@@ -438,6 +438,9 @@
 			return TRUE
 
 		if("nvg-enable")
+			if(upgraded != MATRIX_NVG)
+				to_chat(user, SPAN_WARNING("The matrix is not upgraded with night vision."))
+				return FALSE
 			SEND_SIGNAL(src, COMSIG_CAMERA_SET_NVG, 5, "#7aff7a")
 			return TRUE
 


### PR DESCRIPTION
# About the pull request
Fixes half of #5676 
When  #4812 was merged, it gave all CAS pilots infinite, roundstart night vision with no requirements. This fixes that, making it actually check if the DS matrix is upgraded or not.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Bugs should be fixed. Having researchers run over to CAS pilots with photosensitive vials to grant NVGs was sovl and gave research something to do that wasn't AFKing for points.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/3858d1c6-304d-4112-b374-1556a5aaf8aa)

Tested, it works.

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: CAS no longer has infinite night vision, contact research for matrix upgrades today!
/:cl:
