### PR TITLE
spike launcher wall damage buff

### DIFF
--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -948,7 +948,7 @@
 
 /obj/item/weapon/gun/launcher/spike/set_bullet_traits()
 	LAZYADD(traits_to_give, list(
-		BULLET_TRAIT_ENTRY_ID("turfs", /datum/element/bullet_trait_damage_boost, 25, GLOB.damage_boost_turfs),
+		BULLET_TRAIT_ENTRY_ID("turfs", /datum/element/bullet_trait_damage_boost, 50, GLOB.damage_boost_turfs),
 		BULLET_TRAIT_ENTRY_ID("breaching", /datum/element/bullet_trait_damage_boost, 25, GLOB.damage_boost_breaching)
 	))
 


### PR DESCRIPTION


# About the pull request

As title says, doubles the damage done to walls from spike launcher spikes

# Explain why it's good for the game

previously the spike launcher took 6 shots to kill a single non-reinforced wall. That's half your clip spent on a single wall. That makes clearing out an area for a lodge super tedious and time consuming. Now it takes 3 shots to kill an unreinforced wall, and 4 for reinforced. Now you can take down 4 walls in a single clip. Much better.


# Testing Photographs and Procedure


<details>
<summary>Screenshots & Videos</summary>



</details>


# Changelog



:cl: Nomoresolvalou

balance: doubled spike launcher damage to walls

/:cl:

