### PR TITLE
allows predators to make plasma breach charges + makes them actually stun and makes them better

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -186,6 +186,7 @@
 #define COMSIG_KB_YAUTJA_ACTIVATE_SUICIDE "keybinding_yautja_activate_suicide"
 #define COMSIG_KB_YAUTJA_INJECTORS "keybinding_yautja_injectors"
 #define COMSIG_KB_YAUTJA_CAPSULE "keybinding_yautja_capsule"
+#define COMSIG_KB_YAUTJA_BCHARGE "keybinding_yautja_bcharge"
 #define COMSIG_KB_YAUTJA_CALL_DISC "keybinding_yautja_call_disc"
 #define COMSIG_KB_YAUTJA_REMOVE_TRACKED_ITEM "keybinding_yautja_remove_tracked_item"
 #define COMSIG_KB_YAUTJA_ADD_TRACKED_ITEM "keybinding_yautja_add_tracked_item"

--- a/code/datums/ammo/energy.dm
+++ b/code/datums/ammo/energy.dm
@@ -104,9 +104,6 @@
 	icon_state = "ion"
 	damage_type = BURN
 
-/datum/ammo/bullet/shrapnel/plasma/on_hit_mob(mob/living/hit_mob, obj/projectile/hit_projectile)
-	hit_mob.Stun(2)
-
 /datum/ammo/energy/yautja/caster
 	name = "root caster bolt"
 	icon_state = "ion"

--- a/code/datums/ammo/energy.dm
+++ b/code/datums/ammo/energy.dm
@@ -96,11 +96,12 @@
 
 /datum/ammo/bullet/shrapnel/plasma
 	name = "plasma wave"
+	debilitate = list(2,2,0,0,0,1,0,0)
 	shrapnel_chance = 0
 	penetration = ARMOR_PENETRATION_TIER_10
 	accuracy = HIT_ACCURACY_TIER_MAX
 	damage = 15
-	icon_state = "shrapnel_plasma"
+	icon_state = "ion"
 	damage_type = BURN
 
 /datum/ammo/bullet/shrapnel/plasma/on_hit_mob(mob/living/hit_mob, obj/projectile/hit_projectile)

--- a/code/datums/keybinding/yautja.dm
+++ b/code/datums/keybinding/yautja.dm
@@ -206,6 +206,13 @@
 	full_name = "Create Healing Capsule"
 	keybind_signal = COMSIG_KB_YAUTJA_CAPSULE
 
+/datum/keybinding/yautja/bracer_hunter/breaching_charge
+	hotkey_keys = list("Unbound")
+	classic_keys = list("Unbound")
+	name = "bcharge"
+	full_name = "Create Breaching Charge"
+	keybind_signal = COMSIG_KB_YAUTJA_BCHARGE
+
 /datum/keybinding/yautja/bracer_hunter/call_disc
 	hotkey_keys = list("Unbound")
 	classic_keys = list("Unbound")

--- a/code/game/objects/items/explosives/plastic.dm
+++ b/code/game/objects/items/explosives/plastic.dm
@@ -385,12 +385,12 @@
 	overlay_image = "plasma-active"
 	w_class = SIZE_SMALL
 	angle = 55
-	timer = 5
-	min_timer = 5
+	timer = 3
+	min_timer = 3
 	penetration = 0.60
 	deploying_time = 10
 	flags_item = NOBLUDGEON|ITEM_PREDATOR
-	shrapnel_volume = 10
+	shrapnel_volume = 20
 	shrapnel_type = /datum/ammo/bullet/shrapnel/plasma
 	explosion_strength = 90
 

--- a/code/modules/cm_preds/yaut_actions.dm
+++ b/code/modules/cm_preds/yaut_actions.dm
@@ -217,6 +217,16 @@
 	. = ..()
 	bracers.healing_capsule()
 
+/datum/action/predator_action/bracer/breachcharge
+	name = "Create Breaching Charge"
+	action_icon_state = "claim_equipment"
+	listen_signal = COMSIG_KB_YAUTJA_BCHARGE
+	active = PREDATOR_ACTION_ON_CLICK
+
+/datum/action/predator_action/bracer/breachcharge/action_activate()
+	. = ..()
+	bracers.breaching_charge()
+
 /datum/action/predator_action/bracer/translator
 	name = "Use Translator"
 	action_icon_state = "translator"

--- a/code/modules/cm_preds/yaut_bracers.dm
+++ b/code/modules/cm_preds/yaut_bracers.dm
@@ -1104,6 +1104,43 @@
 	return TRUE
 #undef YAUTJA_CREATE_CAPSULE_COOLDOWN
 
+/obj/item/clothing/gloves/yautja/hunter/verb/breaching_charge()
+	set name = "Create Breaching Charge"
+	set category = "Yautja.Utility"
+	set desc = "Create a breaching charge for destroying structures."
+	set src in usr
+	. = breaching_charge_internal(usr, FALSE)
+
+#define YAUTJA_CREATE_CHARGE_COOLDOWN "yautja_create_charge_cooldown"
+/obj/item/clothing/gloves/yautja/hunter/proc/breaching_charge_internal(mob/caller, forced = FALSE)
+	if(caller.is_mob_incapacitated())
+		return FALSE
+
+	. = check_random_function(caller, forced)
+	if(.)
+		return
+
+	if(caller.get_active_hand())
+		to_chat(caller, SPAN_WARNING("Your active hand must be empty!"))
+		return FALSE
+
+	if(TIMER_COOLDOWN_CHECK(src, YAUTJA_CREATE_CHARGE_COOLDOWN))
+		var/remaining_time = DisplayTimeText(S_TIMER_COOLDOWN_TIMELEFT(src, YAUTJA_CREATE_CHARGE_COOLDOWN))
+		to_chat(caller, SPAN_WARNING("You recently synthesized a breaching charge. A new breaching charge will be available in [remaining_time]."))
+		return FALSE
+
+	if(!drain_power(caller, 1000))
+		return FALSE
+
+	S_TIMER_COOLDOWN_START(src, YAUTJA_CREATE_CHARGE_COOLDOWN, 4 MINUTES)
+
+	to_chat(caller, SPAN_NOTICE("You feel your bracer vibrate as it produces a breaching charge."))
+	var/obj/item/explosive/plastic/breaching_charge/plasma/O = new(caller)
+	caller.put_in_active_hand(O)
+	playsound(src, 'sound/machines/click.ogg', 15, 1)
+	return TRUE
+#undef YAUTJA_CREATE_CHARGE_COOLDOWN
+
 /obj/item/clothing/gloves/yautja/hunter/verb/call_disc()
 	set name = "Call Smart-Disc"
 	set category = "Yautja.Weapons"

--- a/code/modules/cm_preds/yaut_bracers.dm
+++ b/code/modules/cm_preds/yaut_bracers.dm
@@ -280,7 +280,7 @@
 	var/obj/item/bracer_attachments/right_bracer_attachment
 
 	///A list of all intrinsic bracer actions
-	var/list/bracer_actions = list(/datum/action/predator_action/bracer/wristblade, /datum/action/predator_action/bracer/caster, /datum/action/predator_action/bracer/cloak, /datum/action/predator_action/bracer/thwei, /datum/action/predator_action/bracer/capsule, /datum/action/predator_action/bracer/translator, /datum/action/predator_action/bracer/self_destruct, /datum/action/predator_action/bracer/smartdisc)
+	var/list/bracer_actions = list(/datum/action/predator_action/bracer/wristblade, /datum/action/predator_action/bracer/caster, /datum/action/predator_action/bracer/cloak, /datum/action/predator_action/bracer/thwei, /datum/action/predator_action/bracer/capsule, /datum/action/predator_action/bracer/breachcharge, /datum/action/predator_action/bracer/translator, /datum/action/predator_action/bracer/self_destruct, /datum/action/predator_action/bracer/smartdisc)
 
 /obj/item/clothing/gloves/yautja/hunter/get_examine_text(mob/user)
 	. = ..()


### PR DESCRIPTION
# About the pull request

allows predators to make plasma breaching charges from their bracer on a 4 minute cooldown with an energy cost of 1000, and buffs the charges to actually stun as is intended + gives them more shrapnel (20 instead of 10) and uses a different icon to communicate that it is actually a plasma wave

the icon for the plasma breach charge is the old claim equipment icon from beaglegaming1s pr

# Explain why it's good for the game

better options for removing environmental obstacles + better shipside gear recovery, will need to be added to hc if it is supposed to be dishonourable etc etc


# Testing Photographs and Procedure
![image](https://github.com/user-attachments/assets/5f88ea69-e60b-48e7-8b32-605713ab2cef)
tested on local and everything seemed to work fine, unless i'm an idiot

<details>
<summary>Screenshots & Videos</summary>

n/a

</details>


# Changelog

:cl:
balance: predators can produce plasma breaching charges from their bracer
balance: plasma breaching charges now actually stun when the shrapnel hits and they detonate in 3 seconds rather than 5, alongside having additional shrapnel - this does not impact xenos
/:cl:

