### PR TITLE
Neuraline no longer generates/is required for chem

### DIFF
--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -188,7 +188,7 @@
 	custom_metabolism = AMOUNT_PER_TIME(1, 5 SECONDS)
 	overdose = 2
 	overdose_critical = 3
-	chemclass = CHEM_CLASS_SPECIAL
+	chemclass = CHEM_CLASS_RARE
 	properties = list(PROPERTY_NERVESTIMULATING = 5)
 	flags = REAGENT_TYPE_MEDICAL | REAGENT_NO_GENERATION
 

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -190,7 +190,7 @@
 	overdose_critical = 3
 	chemclass = CHEM_CLASS_SPECIAL
 	properties = list(PROPERTY_NERVESTIMULATING = 5)
-	flags = REAGENT_TYPE_MEDICAL
+	flags = REAGENT_TYPE_MEDICAL | REAGENT_NO_GENERATION
 
 /datum/reagent/medical/arithrazine
 	name = "Arithrazine"


### PR DESCRIPTION

# About the pull request
taken directly from #7023 

 #7249 didn't make it impossible to get

![image](https://github.com/user-attachments/assets/dc9bfc49-2fb3-4ffe-8f10-411a4637ca1b)

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
neuraline very hard to get, removes the ability to get it or for it to generate as a requirement for chems so that researchers can be happy.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Neuraline no longer generates in recipes, and is unobtainable from botany.
/:cl:
