### PR TITLE
changes formatting of auto pistol name

### DIFF
--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -888,7 +888,7 @@ Unlike other pistols, it can be equipped with limited mods (small muzzle, underb
 */
 
 /obj/item/weapon/gun/pistol/m10
-	name = "\improper M10 Auto Pistol"
+	name = "\improper M10 auto pistol"
 	desc = "The Armat Battlefield Systems M10 Auto Pistol, a compact, rapid-firing sidearm designed for close-quarters defense. With a 40-round magazine, it emphasizes fire rate over precision, providing effective suppressive fire in short-range engagements."
 	icon = 'icons/obj/items/weapons/guns/guns_by_map/classic/guns_obj.dmi'
 	icon_state = "m10"


### PR DESCRIPTION
ye
# About the pull request

changes M10 Auto Pistol to M10 auto pistol to be in line with other gunz
# Explain why it's good for the game

consistent formatting is le good


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
spellcheck: Formatting of M10 auto pistol.
/:cl:
