### PR TITLE
Fixes squad engineers being able to commit alchemy by turning metal into plasteel

### DIFF
--- a/code/game/objects/structures/barricade/non_folding.dm
+++ b/code/game/objects/structures/barricade/non_folding.dm
@@ -18,6 +18,7 @@
 	repair_materials = list("metal" = 0.3, "plasteel" = 0.45)
 	var/build_state = BARRICADE_BSTATE_SECURED //Look at __game.dm for barricade defines
 	var/upgrade = null
+	var/refund_type = /obj/item/stack/sheet/metal
 
 	welder_lower_damage_limit = BARRICADE_DMG_HEAVY
 
@@ -188,7 +189,7 @@
 				brute_projectile_multiplier = initial(brute_projectile_multiplier)
 				burn_multiplier = initial(burn_multiplier)
 				burn_flame_multiplier = initial(burn_flame_multiplier)
-				new stack_type (loc, 1)
+				new refund_type (loc, 1)
 				update_icon()
 				return
 


### PR DESCRIPTION
Fixes #7928

# About the pull request
Plasteel cades used to refund 1 plasteel sheet when you remove the upgrade via multitools. This is because it used stack_type. I have made var/refund_type, which instead will ONLY refund metal.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Bugfixman good. Also, no more Edward Elric in my damn Corps!
# Testing Photographs and Procedure

Compiled, and worked on USS Runtime.

![image](https://i.gyazo.com/04e0e3a42e253b8b3e02d0f721c684a6.png)
![image](https://i.gyazo.com/29cd082ed53205cb0be4629380dbbc78.png)
![image](https://i.gyazo.com/fca518804dd6e7f60f651022b386eef9.png)

# Changelog
:cl: Yayyay007
fix: Fixed metal to plasteel alchemy via disassembling upgraded plasteel cades
/:cl:
