### PR TITLE
Armor differentiation

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -8,10 +8,11 @@
 	var/armor_laser = 0
 	var/armor_energy = 0
 	var/armor_bomb = 0
-	var/armor_bio = 0
+	var/armor_bio = 0 // Protection from neuro
 	var/armor_rad = 0
-	var/armor_internaldamage = 0
-	var/movement_compensation = 0
+	var/armor_internaldamage = 0 // Protection from bonebreaks, IB, organ damage
+	var/movement_compensation = 0 // Counters slowdown from wielded guns
+	var/armor_slowdown_multiplier = 0 // Heavier armors worsen slowdown penalties
 	var/list/accessories
 	var/list/valid_accessory_slots = list()
 	var/list/restricted_accessory_slots = list()

--- a/code/modules/clothing/suits/marine_armor/_marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor/_marine_armor.dm
@@ -56,6 +56,7 @@
 	armor_rad = CLOTHING_ARMOR_MEDIUMLOW
 	armor_internaldamage = CLOTHING_ARMOR_MEDIUM
 	movement_compensation = SLOWDOWN_ARMOR_LIGHT
+	armor_slowdown_multiplier = SLOWDOWN_ARMOR_SUPER_LIGHT
 	storage_slots = 3
 	siemens_coefficient = 0.7
 	slowdown = SLOWDOWN_ARMOR_MEDIUM
@@ -284,6 +285,7 @@
 	armor_internaldamage = CLOTHING_ARMOR_MEDIUMLOW
 	storage_slots = 2
 	slowdown = SLOWDOWN_ARMOR_LIGHT
+	armor_slowdown_multiplier = SLOWDOWN_ARMOR_NONE
 	allowed = list(
 		/obj/item/weapon/gun,
 		/obj/item/tank/emergency_oxygen,
@@ -463,6 +465,7 @@
 	armor_bio = CLOTHING_ARMOR_MEDIUMLOW
 	armor_rad = CLOTHING_ARMOR_MEDIUMHIGH
 	armor_internaldamage = CLOTHING_ARMOR_LOW
+	armor_slowdown_multiplier = SLOWDOWN_ARMOR_NONE
 	storage_slots = 2
 
 /obj/item/clothing/suit/storage/marine/light/padded
@@ -621,6 +624,7 @@
 	storage_slots = 2
 	slowdown = SLOWDOWN_ARMOR_LOWHEAVY
 	movement_compensation = SLOWDOWN_ARMOR_MEDIUM
+	armor_slowdown_multiplier = SLOWDOWN_ARMOR_VERY_LIGHT
 	light_power = 4
 	light_range = 5
 
@@ -668,6 +672,7 @@
 	flags_cold_protection = BODY_FLAG_CHEST|BODY_FLAG_GROIN|BODY_FLAG_ARMS|BODY_FLAG_LEGS|BODY_FLAG_FEET
 	flags_heat_protection = BODY_FLAG_CHEST|BODY_FLAG_GROIN|BODY_FLAG_ARMS|BODY_FLAG_LEGS|BODY_FLAG_FEET
 	slowdown = SLOWDOWN_ARMOR_HEAVY
+	armor_slowdown_multiplier = SLOWDOWN_ARMOR_LIGHT
 	specialty = "B18 defensive"
 	unacidable = TRUE
 	var/injections = 4
@@ -711,6 +716,7 @@
 	flags_cold_protection = BODY_FLAG_CHEST|BODY_FLAG_GROIN|BODY_FLAG_ARMS|BODY_FLAG_LEGS|BODY_FLAG_FEET
 	flags_heat_protection = BODY_FLAG_CHEST|BODY_FLAG_GROIN|BODY_FLAG_ARMS|BODY_FLAG_LEGS|BODY_FLAG_FEET
 	slowdown = SLOWDOWN_ARMOR_HEAVY
+	armor_slowdown_multiplier = SLOWDOWN_ARMOR_LIGHT
 	specialty = "M3-G4 grenadier"
 	unacidable = TRUE
 	light_range = 5
@@ -721,6 +727,7 @@
 	icon_state = "demolitionist"
 	armor_bomb = CLOTHING_ARMOR_HIGH
 	slowdown = SLOWDOWN_ARMOR_LIGHT
+	armor_slowdown_multiplier = SLOWDOWN_ARMOR_NONE
 	specialty = "M3-T light"
 	flags_item = MOB_LOCK_ON_EQUIP|NO_CRYO_STORE
 	unacidable = TRUE
@@ -731,6 +738,7 @@
 	icon_state = "scout_armor"
 	armor_melee = CLOTHING_ARMOR_MEDIUMHIGH
 	slowdown = SLOWDOWN_ARMOR_LIGHT
+	armor_slowdown_multiplier = SLOWDOWN_ARMOR_NONE
 	specialty = "M3-S light"
 	flags_item = MOB_LOCK_ON_EQUIP|NO_CRYO_STORE
 	unacidable = TRUE

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -15,6 +15,7 @@
 
 	var/reducible_tally = 0 //Tally elements that can be reduced are put here, then we apply MST effects
 	var/wear_slowdown_reduction = 0
+	var/slowdown_multiplier
 
 	reducible_tally += max(pain.pain_slowdown, stamina.stamina_slowdown) // Get the highest slowdown and apply that
 
@@ -56,6 +57,7 @@
 	if(wear_suit)
 		reducible_tally += wear_suit.slowdown
 		wear_slowdown_reduction += wear_suit.movement_compensation
+		slowdown_multiplier = wear_suit.armor_slowdown_multiplier
 
 	reducible_tally += reagent_move_delay_modifier //Muscle-stimulating property
 
@@ -68,6 +70,8 @@
 
 	if(shield_slowdown)
 		reducible_tally += shield_slowdown
+
+	reducible_tally = reducible_tally * (1 + slowdown_multiplier)
 
 	//Compile reducible tally and send it to total tally. Cannot go more than 1 units faster from the reducible tally!
 	. += max(-0.7, reducible_tally)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -15,7 +15,7 @@
 
 	var/reducible_tally = 0 //Tally elements that can be reduced are put here, then we apply MST effects
 	var/wear_slowdown_reduction = 0
-	var/slowdown_multiplier
+	var/slowdown_multiplier = 0
 
 	reducible_tally += max(pain.pain_slowdown, stamina.stamina_slowdown) // Get the highest slowdown and apply that
 
@@ -49,16 +49,6 @@
 	if(hungry >= 50) //Level where a yellow food pip shows up, aka hunger level 3 at 250 nutrition and under
 		reducible_tally += hungry/50 //Goes from a slowdown of 1 all the way to 2 for total starvation
 
-	//Equipment slowdowns
-	if(w_uniform)
-		reducible_tally += w_uniform.slowdown
-		wear_slowdown_reduction += w_uniform.movement_compensation
-
-	if(wear_suit)
-		reducible_tally += wear_suit.slowdown
-		wear_slowdown_reduction += wear_suit.movement_compensation
-		slowdown_multiplier = wear_suit.armor_slowdown_multiplier
-
 	reducible_tally += reagent_move_delay_modifier //Muscle-stimulating property
 
 	if(bodytemperature < species.cold_level_1 && !isyautja(src))
@@ -71,7 +61,19 @@
 	if(shield_slowdown)
 		reducible_tally += shield_slowdown
 
-	reducible_tally = reducible_tally * (1 + slowdown_multiplier)
+	if(wear_suit)
+		slowdown_multiplier = wear_suit.armor_slowdown_multiplier
+
+	reducible_tally = reducible_tally * (1 + slowdown_multiplier) //Applying slowdown_multiplier after the slowdowns its supposed to apply to, and BEFORE the ones that it isnt.
+
+	//Equipment slowdowns
+	if(w_uniform)
+		reducible_tally += w_uniform.slowdown
+		wear_slowdown_reduction += w_uniform.movement_compensation
+
+	if(wear_suit)
+		reducible_tally += wear_suit.slowdown
+		wear_slowdown_reduction += wear_suit.movement_compensation
 
 	//Compile reducible tally and send it to total tally. Cannot go more than 1 units faster from the reducible tally!
 	. += max(-0.7, reducible_tally)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -94,9 +94,10 @@
 	var/mob/living/living_mob
 	if(isliving(mob))
 		living_mob = mob
-
+	to_chat(usr, "Tried to move: [world.time]") //for debugging, will be removed
 	if(world.time < next_movement)
 		return
+	to_chat(usr, "And succesfully moved: [world.time]") //for debugging, will be removed
 	if(living_mob && living_mob.body_position == LYING_DOWN && mob.crawling)
 		return
 
@@ -222,6 +223,7 @@
 		mob.move_intentionally = FALSE
 		moving = FALSE
 		next_movement = world.time + move_delay
+		to_chat(usr, "With [move_delay] of move_delay, next mimimum worldtime to move should be: [next_movement]") //for debugging, will be removed
 	return
 
 ///Process_Spacemove


### PR DESCRIPTION

# About the pull request

This comes from the desire to solve the problem of heavy armor not being any slower than medium armor in a lot of cases due to how movement delay works.

Simplified explanation of how movement (delay) works:
Every 0.5 deciseconds (aka every tick) when a movement key is held down the Move() proc gets called.
Stuff happens, eventually it calls for the movement delay to be calculated for the current move.
All penalties and bonuses to movement gets collected which then eventually end up in calculating the variable (aka move_delay).
Yadi yada, we reach the end of Move() where the next possible worldtime we can move is calculated by adding the move_delay to the current worldtime, and untill we reach that time all attempts at moving will be rejected.

The problem here is that we want to work with values that are so small that the difference between them is not enough to set them apart into different ticks in a lot of cases. (And as we stand, we cannot increase the granuality to less than 0.5.)
For example a fully health marine in heavy armor has a move_delay of 2.75 while one in medium armor has 2.55. So in this case they will effectivelly move at the same speed. However if say they both get additional slowdowns, which say raise their move_delay by 0.25, they will begin to move at different speeds due to falling on different sides of the 0.5 decisecond division.
Trying to fix this by say setting apart the native slowdown of the different armors, would just have their speed become increasingly more ridiculously apart the more cases you tried to cover with it.

My proposed solution instead is to apply a modifier that makes heavier armors amplify the logically related slowdowns more, thus allowing a more fine grained control to the movement speed behaviours of the the armors.

Currently this PR is just a proof of concept, values need to be changed (probably even the base slowdown values), and anyways I dont want to put too much work into this yet if even the idea is not gonna be accepted.

# Explain why it's good for the game

Finer granuality of control over armor slowdown.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Different armors now slow you down more if you are already have some effect slowing you.
balance: Armor slowdown values probably changed.
/:cl:
