### PR TITLE
Xenos are now warned about Reactor SD

### DIFF
--- a/code/controllers/subsystem/hijack.dm
+++ b/code/controllers/subsystem/hijack.dm
@@ -336,6 +336,7 @@ SUBSYSTEM_DEF(hijack)
 			to_chat(current_mob, SPAN_BOLDWARNING("You feel the heat of the room increase as the fusion engines whirr louder."))
 
 /datum/controller/subsystem/hijack/proc/superheat_engine_room()
+	xeno_announcement("Every sense in our form is screaming... the ship's reactors are almost ready to explode!")
 	engine_room_superheated = TRUE
 	var/area/engine_room = GLOB.areas_by_type[/area/almayer/engineering/lower/engine_core]
 	engine_room.firealert()
@@ -347,6 +348,7 @@ SUBSYSTEM_DEF(hijack)
 
 /datum/controller/subsystem/hijack/proc/announce_sd_halfway()
 	ares_sd_announced = TRUE
+	xeno_announcement("A shiver goes down our carapace as we feel the approaching end... The ship's reactors are halfway prepared to explode!")
 	marine_announcement("ALERT: Fusion reactor meltdown has reached fifty percent.", HIJACK_ANNOUNCE)
 
 /datum/controller/subsystem/hijack/proc/detonate_sd()
@@ -364,6 +366,7 @@ SUBSYSTEM_DEF(hijack)
 	sleep(7 SECONDS)
 	shakeship(2, 10, TRUE)
 
+	xeno_announcement("DISABLE IT! NOW!")
 	marine_announcement("ALERT: Fusion reactors dangerously overloaded. Runaway meltdown in reactor core imminent.", HIJACK_ANNOUNCE)
 	sleep(5 SECONDS)
 

--- a/code/controllers/subsystem/hijack.dm
+++ b/code/controllers/subsystem/hijack.dm
@@ -336,7 +336,7 @@ SUBSYSTEM_DEF(hijack)
 			to_chat(current_mob, SPAN_BOLDWARNING("You feel the heat of the room increase as the fusion engines whirr louder."))
 
 /datum/controller/subsystem/hijack/proc/superheat_engine_room()
-	xeno_announcement("Every sense in our form is screaming... the ship's reactors are almost ready to explode!")
+	span_xeno_announce("Every sense in our form is screaming... the ship's reactors are almost ready to explode!")
 	engine_room_superheated = TRUE
 	var/area/engine_room = GLOB.areas_by_type[/area/almayer/engineering/lower/engine_core]
 	engine_room.firealert()
@@ -348,7 +348,7 @@ SUBSYSTEM_DEF(hijack)
 
 /datum/controller/subsystem/hijack/proc/announce_sd_halfway()
 	ares_sd_announced = TRUE
-	xeno_announcement("A shiver goes down our carapace as we feel the approaching end... The ship's reactors are halfway prepared to explode!")
+	span_xeno_announce("A shiver goes down our carapace as we feel the approaching end... The ship's reactors are halfway prepared to explode!")
 	marine_announcement("ALERT: Fusion reactor meltdown has reached fifty percent.", HIJACK_ANNOUNCE)
 
 /datum/controller/subsystem/hijack/proc/detonate_sd()
@@ -366,7 +366,7 @@ SUBSYSTEM_DEF(hijack)
 	sleep(7 SECONDS)
 	shakeship(2, 10, TRUE)
 
-	xeno_announcement("DISABLE IT! NOW!")
+	span_xeno_announce("DISABLE IT! NOW!")
 	marine_announcement("ALERT: Fusion reactors dangerously overloaded. Runaway meltdown in reactor core imminent.", HIJACK_ANNOUNCE)
 	sleep(5 SECONDS)
 

--- a/code/controllers/subsystem/hijack.dm
+++ b/code/controllers/subsystem/hijack.dm
@@ -336,7 +336,7 @@ SUBSYSTEM_DEF(hijack)
 			to_chat(current_mob, SPAN_BOLDWARNING("You feel the heat of the room increase as the fusion engines whirr louder."))
 
 /datum/controller/subsystem/hijack/proc/superheat_engine_room()
-	span_xeno_announce("Every sense in our form is screaming... the ship's reactors are almost ready to explode!")
+	span_xenoannounce("Every sense in our form is screaming... the ship's reactors are almost ready to explode!")
 	engine_room_superheated = TRUE
 	var/area/engine_room = GLOB.areas_by_type[/area/almayer/engineering/lower/engine_core]
 	engine_room.firealert()
@@ -348,7 +348,7 @@ SUBSYSTEM_DEF(hijack)
 
 /datum/controller/subsystem/hijack/proc/announce_sd_halfway()
 	ares_sd_announced = TRUE
-	span_xeno_announce("A shiver goes down our carapace as we feel the approaching end... The ship's reactors are halfway prepared to explode!")
+	span_xenoannounce("A shiver goes down our carapace as we feel the approaching end... The ship's reactors are halfway prepared to explode!")
 	marine_announcement("ALERT: Fusion reactor meltdown has reached fifty percent.", HIJACK_ANNOUNCE)
 
 /datum/controller/subsystem/hijack/proc/detonate_sd()
@@ -366,7 +366,7 @@ SUBSYSTEM_DEF(hijack)
 	sleep(7 SECONDS)
 	shakeship(2, 10, TRUE)
 
-	span_xeno_announce("DISABLE IT! NOW!")
+	span_xenoannounce("DISABLE IT! NOW!")
 	marine_announcement("ALERT: Fusion reactors dangerously overloaded. Runaway meltdown in reactor core imminent.", HIJACK_ANNOUNCE)
 	sleep(5 SECONDS)
 


### PR DESCRIPTION

# About the pull request
xenos are now warned when reactor is:
* 50% done
* 75% done
* and exploding

previously xenos were only warned the moment that SD started, and if you weren't paying attention to the announcements you had no idea that SD was occuring, and even if you did, you had no idea how long it would take before SD explodes.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Xenos should be warned that they're about to lose the round (Tie, but everyone considers it a marine major) so that they can go prevent it.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Xenos are now warned about reactor self destruct.
/:cl:
