### PR TITLE
88 nerf

### DIFF
--- a/code/datums/ammo/bullet/lever_action.dm
+++ b/code/datums/ammo/bullet/lever_action.dm
@@ -54,21 +54,23 @@
 /datum/ammo/bullet/lever_action/xm88
 	name = ".458 SOCOM round"
 
-	damage = 104
+	damage = 85
 	penetration = ARMOR_PENETRATION_TIER_2
 	accuracy = HIT_ACCURACY_TIER_1
 	shell_speed = AMMO_SPEED_TIER_6
-	accurate_range = 14
+	effective_range_max = 7
+	damage_falloff = DAMAGE_FALLOFF_TIER_6
+	accurate_range = 12
 	handful_state = "boomslang_bullet"
 
 /datum/ammo/bullet/lever_action/xm88/pen20
 	penetration = ARMOR_PENETRATION_TIER_4
 
 /datum/ammo/bullet/lever_action/xm88/pen30
-	penetration = ARMOR_PENETRATION_TIER_6
+	penetration = ARMOR_PENETRATION_TIER_5
 
 /datum/ammo/bullet/lever_action/xm88/pen40
-	penetration = ARMOR_PENETRATION_TIER_8
+	penetration = ARMOR_PENETRATION_TIER_7
 
 /datum/ammo/bullet/lever_action/xm88/pen50
-	penetration = ARMOR_PENETRATION_TIER_10
+	penetration = ARMOR_PENETRATION_TIER_9


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Nerfs xm88 as its dps output is quite literally insane

# Explain why it's good for the game
xenos already have to deal with so much damage, one  weapon adding this much dps to the pool is not ok

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: XM88 bullet damage lowered to 85
balance: xm88 bullets now get fall-off after 7 tiles 
balance: xm88 bullets now lose accuracy past 12 tiles.
balance: xm88 bullets now lose 5 damage per tile past the effective 7 tiles.
balance: Lowered all bullseye extra armor pen by 1 tier
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
