### PR TITLE
removes stun from grabbing xeno

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -755,9 +755,16 @@
 		var/mob/living/carbon/human/H = puller
 		if(H.ally_of_hivenumber(hivenumber))
 			return TRUE
-		puller.apply_effect(rand(caste.tacklestrength_min,caste.tacklestrength_max), WEAKEN)
-		playsound(puller.loc, 'sound/weapons/pierce.ogg', 25, 1)
-		puller.visible_message(SPAN_WARNING("[puller] tried to pull [src] but instead gets a tail swipe to the head!"))
+		playsound(H, 'sound/weapons/alien_tail_attack.ogg', 25, 1)
+		if(H.hand)
+			H.apply_armoured_damage(rand(caste.melee_damage_lower, caste.melee_damage_upper), ARMOR_MELEE, BRUTE, "r_hand")
+		else
+			H.apply_armoured_damage(rand(caste.melee_damage_lower, caste.melee_damage_upper), ARMOR_MELEE, BRUTE, "l_hand")
+		puller.visible_message(SPAN_WARNING("[puller] tried to pull [src] but instead gets a tail swipe to their hand!"))
+		if(body_position == STANDING_UP)
+			animation_attack_on(H)
+			emote("hiss")
+		flick_attack_overlay(H, "tail")
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION

# About the pull request
instead of stunning you for half an hour you get damaged when trying to grab a living xeno

# Explain why it's good for the game
every time i got stunned this way was when i tried to grab a dude from under an attacking xeno and it just felt awful and undeserved
also some lurkers are abusing this feature by standing invis on top of revivable corpses/dropped weapons in order to trick marines into grabbing them and getting stunned forever ever

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Grabbing a living xeno no longer stuns you. Instead, your hand gets damaged a little.
/:cl:
