### PR TITLE
Clarifies VAIPO interaction with Weyland-Yutani

### DIFF
--- a/code/datums/emergency_calls/contractor.dm
+++ b/code/datums/emergency_calls/contractor.dm
@@ -71,7 +71,7 @@
 	to_chat(M, SPAN_BOLD("Under the directive of the VAI executive board, you have been assist in riot control, military aid, and to assist USCMC forces wherever possible."))
 	to_chat(M, SPAN_BOLD("The USCSS Inheritor is staffed with crew of roughly three hundred military contractors, and fifty support personnel."))
 	to_chat(M, SPAN_BOLD("Assist the USCMC Force of the [MAIN_SHIP_NAME] however you can."))
-	to_chat(M, SPAN_BOLD("As a side-objective, VAI has been hired by an unknown benefactor to engage in corporate espionage and sabotage against Weyland-Yutani, avoid direct conflict; you aren't VAISO; but attempt to recover Wey-Yu secrets and plans if possible."))
+	to_chat(M, SPAN_BOLD("As a side-objective, VAI has been hired by an unknown benefactor to engage in corporate espionage and sabotage against Weyland-Yutani, do not get into a fight, but attempt to recover Wey-Yu secrets and plans if possible."))
 
 
 /datum/emergency_call/contractors/platoon
@@ -85,7 +85,7 @@
 	max_synths = 2
 
 /datum/emergency_call/contractors/covert
-	name = "Military Contractors (Covert) (Hostile to WY)"
+	name = "Military Contractors (Covert) (Friendly)"
 	mob_max = 7
 	probability = 20
 	max_medics = 1


### PR DESCRIPTION

# About the pull request

As title

# Explain why it's good for the game

Will hopefully stop friendly ERTs getting into a shooting match by randomly deciding to murder the onboard liaison for no reason.
Note: AT NO POINT SHOULD VAIPO HAVE BEEN SHOOTING WY PEOPLE.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Clarifies that VAI should not be shooting WY or getting into fights with them outside of authorized events.
/:cl:
