### PR TITLE
fixes check status namecalling

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1014,7 +1014,7 @@
 	var/msg
 	///Is the target the user or somebody else?
 	var/self = (target == src)
-	to_chat(usr,SPAN_NOTICE("You [self ? "take a moment to analyze yourself." : "start analyzing [src]."]"))
+	to_chat(usr,SPAN_NOTICE("You [self ? "take a moment to analyze yourself." : "start analyzing [target.name]."]"))
 
 	if(self)
 		var/list/broken_limbs = target.get_broken_limbs() - list("chest","head","groin")


### PR DESCRIPTION
# About the pull request
Fixes #7530
This was because when it doing it's check, it is checking src, who is you. We want to check target.name, who is not us. Only when it is self (us), do we want it to refer to us as the target for that nuance.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Bugfixman good
# Testing Photographs and Procedure
There are a lot of checks for the status, so I admittedly did not go thru all of them, but when I manually deleted unknown's heart, it still was working as intended. I believe the rest works fine; since this only affects the [name] call during the Check Status proc, so it should have no effect on the rest of it.

![image](https://i.gyazo.com/61dbbe7f45b192152680fbbcf612af52.png)
![image](https://i.gyazo.com/358564aaffb5fe8d9fb374c2cde90dfe.png)
![image](https://i.gyazo.com/6f526b79ca8fab19983be3aaa3876d93.png)
![image](https://i.gyazo.com/2dc70752d8ff63cb2da0d4cf8bdee3a6.png)


## Changelog
:cl: Yayyay007
fix: Fixes check status using your own name when using it on others
/:cl:
