### PR TITLE
Marine primary weapons buff

### DIFF
--- a/code/datums/ammo/bullet/shotgun.dm
+++ b/code/datums/ammo/bullet/shotgun.dm
@@ -13,7 +13,7 @@
 
 	accurate_range = 8
 	max_range = 8
-	damage = 70
+	damage = 100
 	penetration = ARMOR_PENETRATION_TIER_4
 	accuracy = HIT_ACCURACY_TIER_3
 	damage_armor_punch = 2
@@ -98,7 +98,7 @@
 	accuracy_var_low = PROJECTILE_VARIANCE_TIER_6
 	accuracy_var_high = PROJECTILE_VARIANCE_TIER_6
 	max_range = 12
-	damage = 30
+	damage = 43
 	damage_var_low = PROJECTILE_VARIANCE_TIER_8
 	damage_var_high = PROJECTILE_VARIANCE_TIER_8
 	penetration = ARMOR_PENETRATION_TIER_7
@@ -113,7 +113,7 @@
 	accuracy_var_low = PROJECTILE_VARIANCE_TIER_6
 	accuracy_var_high = PROJECTILE_VARIANCE_TIER_6
 	max_range = 12
-	damage = 30
+	damage = 43
 	damage_var_low = PROJECTILE_VARIANCE_TIER_8
 	damage_var_high = PROJECTILE_VARIANCE_TIER_8
 	penetration = ARMOR_PENETRATION_TIER_7

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1676,7 +1676,8 @@
 /obj/item/weapon/gun/rifle/m4ra/set_gun_config_values()
 	..()
 	set_fire_delay(FIRE_DELAY_TIER_9)
-	set_burst_amount(0)
+	set_burst_amount(BURST_AMOUNT_TIER_2)
+	set_burst_delay(FIRE_DELAY_TIER_LMG)
 	accuracy_mult = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_5
 	accuracy_mult_unwielded = BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_4
 	damage_mult = BASE_BULLET_DAMAGE_MULT + BULLET_DAMAGE_MULT_TIER_8

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -811,7 +811,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	accuracy_mult_unwielded = BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_10
 	scatter = SCATTER_AMOUNT_TIER_10
 	scatter_unwielded = SCATTER_AMOUNT_TIER_2
-	damage_mult = BASE_BULLET_DAMAGE_MULT
+	damage_mult = BASE_BULLET_DAMAGE_MULT - BULLET_DAMAGE_MULT_TIER_6
 	recoil = RECOIL_AMOUNT_TIER_3
 	recoil_unwielded = RECOIL_AMOUNT_TIER_2
 


### PR DESCRIPTION
# About the pull request


Adds 2 round burst fire to M4RA similar to scout but with more delay.

Base slug and flechette base damage has been increased by 43% . the reasoning is to make them viable on standard m37 winout making them OP on MOU , for this reason MOU multiplier has been reduced by 30% ( same values as vefore this PR)

# Explain why it's good for the game

M4RA makes my hands hurt with single fire a 2 round burst with a similar fire rate may encourage players to try this weapon.

slugs and flechette on M37 specially the latter have been a meme for a while . MOU just overperforms on the same tasks and DPS to compensate the low firerate of M37 , Slugs and flechette have increased base damage now.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:

balance: Adds 2 round burst fire to M4RA 
balance: Flechette and Slug base damage increased by 43% 
balance: MOU damage multiplier reduced to 0.7
fix: additional shells now properly inherit damage multipliers
/:cl:
