### PR TITLE
Fix CIC Dropship Console

### DIFF
--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -465,7 +465,7 @@
 			to_chat(user, SPAN_WARNING("The dropship isn't responding to controls."))
 			return
 
-	if(use_factions && shuttle.faction != faction) //someone trying href
+	if(use_factions && shuttle && shuttle.faction != faction) //someone trying href
 		return FALSE
 
 	switch(action)


### PR DESCRIPTION
# About the pull request

Fixes #7846 and fixes #7872
Remote navigation computers that don't start with a default shuttleId defined by the map (CIC, left hangar control) were throwing null pointer errors and not allowing changes.

# Explain why it's good for the game

Allows CIC remote computer to control the dropships and autopilot again.


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

![CIC_console_fix](https://github.com/user-attachments/assets/22071281-824e-4c2a-9558-ec50a78319ed)

</details>

Confirmed I could enable and disable autopilot from CIC and hangar consoles

# Changelog

:cl: 
fix: Added a missing reference check to flight/ui_act
/:cl:
