### PR TITLE
Adds messaging for situation where larva and host both survive surgery

### DIFF
--- a/code/modules/surgery/chestburster.dm
+++ b/code/modules/surgery/chestburster.dm
@@ -171,6 +171,7 @@
 		if(L)
 			L.forceMove(target.loc)
 			qdel(A)
+			user.visible_message(SPAN_HIGHDANGER("The larva was removed just in time, but is fully grown and alive!"))
 		else
 			A.forceMove(target.loc)
 			target.status_flags &= ~XENO_HOST


### PR DESCRIPTION

# About the pull request

Adds messaging for situation where larva and host both survive surgery

# Explain why it's good for the game

The situation is quite rare for larva removal surgery to succeed after the larva has spawned but before it chestbursts causing both human and larva to survive (it's rare enough that players are typically confused about how it happened), so there should be a message.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Adds messaging when larva and host both survive surgery
/:cl:
