### PR TITLE
Allow dropship autopilot changes during refuel

### DIFF
--- a/tgui/packages/tgui/interfaces/DropshipFlightControl.tsx
+++ b/tgui/packages/tgui/interfaces/DropshipFlightControl.tsx
@@ -450,6 +450,9 @@ const RenderScreen = () => {
       {data.shuttle_mode === 'igniting' && <LaunchCountdown />}
       {data.shuttle_mode === 'pre-arrival' && <TouchdownCooldown />}
       {data.shuttle_mode === 'recharging' && <ShuttleRecharge />}
+      {data.shuttle_mode === 'recharging' && data.can_set_automated === 1 && (
+        <AutopilotConfig />
+      )}
       {data.shuttle_mode === 'called' && data.target_destination && (
         <InFlightCountdown />
       )}


### PR DESCRIPTION
# About the pull request

Changes dropship remote interface to show Autopilot controls during the refuel/recharge.
Closes #8001

# Explain why it's good for the game

Currently to disable the autopilot you only have the 30 seconds between refuel and ignition each cycle to get to the consoles. Adds another 1-2 minutes to the window, meaning less waiting around or scrambling.

While it could be changed to be enabled all the time, having it on during the ignition state could cause confusion (hitting disable and the ship still launching) so an active/inactive split makes sense.

# Testing Photographs and Procedure

Checked autopilot could be enabled and disabled from multiple consoles in both states. 
Checked autopilot launch timing was unchanged (no early launch).
<details>
<summary>Screenshots & Videos</summary>

![Dropship_console_refuel_disable](https://github.com/user-attachments/assets/27228b0e-bcb3-4255-beb9-6331cc7f5a49)

</details>

# Changelog

:cl:
qol: Dropship autopilot settings can be modified during refuel/recharge
/:cl:
