### PR TITLE
restore old confirmation message when joining as xeno

### DIFF
--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -169,7 +169,10 @@
 			if(SSticker.mode.check_xeno_late_join(src))
 				var/mob/new_xeno = SSticker.mode.attempt_to_join_as_xeno(src, FALSE)
 				if(!new_xeno)
-					lobby_confirmation_message = "Are you sure you wish to observe to be a xeno candidate? When you observe, you will not be able to join as marine. It might also take some time to become a xeno or responder!"
+					lobby_confirmation_message = list(
+						"Are you sure you wish to observe to be a xeno candidate?",
+						"When you observe, you will not be able to join as marine.",
+						"It might also take some time to become a xeno or responder!")
 					execute_on_confirm = CALLBACK(src, PROC_REF(observe_for_xeno))
 
 				else if(!istype(new_xeno, /mob/living/carbon/xenomorph/larva))
@@ -210,7 +213,7 @@
 			return TRUE
 
 		if("ready")
-			if( (SSticker.current_state <= GAME_STATE_PREGAME) && !ready) // Make sure we don't ready up after the round has started
+			if((SSticker.current_state <= GAME_STATE_PREGAME) && !ready) // Make sure we don't ready up after the round has started
 				ready = TRUE
 				GLOB.readied_players++
 
@@ -225,13 +228,13 @@
 
 		if("confirm")
 			lobby_confirmation_message = null
-			execute_on_confirm.Invoke()
-
+			execute_on_confirm?.Invoke()
 			execute_on_confirm = null
 			return TRUE
 
 		if("unconfirm")
 			lobby_confirmation_message = null
+			execute_on_confirm = null
 			return TRUE
 
 		if("keyboard")

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -237,6 +237,7 @@
 		if("keyboard")
 			playsound_client(client, get_sfx("keyboard"), vol = 20)
 
+/// Join as a 'xeno' - set us up in the larva queue
 /mob/new_player/proc/observe_for_xeno()
 	if(client.prefs && !(client.prefs.be_special & BE_ALIEN_AFTER_DEATH))
 		client.prefs.be_special |= BE_ALIEN_AFTER_DEATH

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -1,5 +1,3 @@
-/mob/new_player/var/datum/tgui_window/lobby_window
-
 /mob/new_player/Login()
 	if(!mind)
 		mind = new /datum/mind(key, ckey)
@@ -65,6 +63,8 @@
 	.["tutorials_ready"] = SSticker?.current_state == GAME_STATE_PLAYING
 	.["round_start"] = !SSticker || !SSticker.mode || SSticker.current_state <= GAME_STATE_PREGAME
 	.["readied"] = ready
+
+	.["confirmation_message"] = lobby_confirmation_message
 
 	.["upp_enabled"] = GLOB.master_mode == /datum/game_mode/extended/faction_clash/cm_vs_upp::name
 	.["xenomorph_enabled"] = GLOB.master_mode == /datum/game_mode/colonialmarines::name && client.prefs && (client.prefs.get_job_priority(JOB_XENOMORPH) || client.prefs.get_job_priority(JOB_XENOMORPH_QUEEN))
@@ -169,21 +169,8 @@
 			if(SSticker.mode.check_xeno_late_join(src))
 				var/mob/new_xeno = SSticker.mode.attempt_to_join_as_xeno(src, FALSE)
 				if(!new_xeno)
-					if(!client)
-						return FALSE
-
-					if(tgui_alert(
-						src,
-						"Are you sure you wish to observe to be a xeno candidate? When you observe, you will not be able to join as marine. It might also take some time to become a xeno or responder!",
-						"Player Setup",
-						list("Yes", "No")) != "Yes")
-
-						return
-
-					if(client.prefs && !(client.prefs.be_special & BE_ALIEN_AFTER_DEATH))
-						client.prefs.be_special |= BE_ALIEN_AFTER_DEATH
-						to_chat(src, SPAN_BOLDNOTICE("You will now be considered for Xenomorph after unrevivable death events (where possible)."))
-					attempt_observe()
+					lobby_confirmation_message = "Are you sure you wish to observe to be a xeno candidate? When you observe, you will not be able to join as marine. It might also take some time to become a xeno or responder!"
+					execute_on_confirm = CALLBACK(src, PROC_REF(observe_for_xeno))
 
 				else if(!istype(new_xeno, /mob/living/carbon/xenomorph/larva))
 					SSticker.mode.transfer_xeno(src, new_xeno)
@@ -236,8 +223,25 @@
 
 			return TRUE
 
+		if("confirm")
+			lobby_confirmation_message = null
+			execute_on_confirm.Invoke()
+
+			execute_on_confirm = null
+			return TRUE
+
+		if("unconfirm")
+			lobby_confirmation_message = null
+			return TRUE
+
 		if("keyboard")
 			playsound_client(client, get_sfx("keyboard"), vol = 20)
+
+/mob/new_player/proc/observe_for_xeno()
+	if(client.prefs && !(client.prefs.be_special & BE_ALIEN_AFTER_DEATH))
+		client.prefs.be_special |= BE_ALIEN_AFTER_DEATH
+		to_chat(src, SPAN_BOLDNOTICE("You will now be considered for Xenomorph after unrevivable death events (where possible)."))
+	attempt_observe()
 
 /mob/new_player/proc/lobby()
 	if(!client)

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -172,6 +172,14 @@
 					if(!client)
 						return FALSE
 
+					if(tgui_alert(
+						src,
+						"Are you sure you wish to observe to be a xeno candidate? When you observe, you will not be able to join as marine. It might also take some time to become a xeno or responder!",
+						"Player Setup",
+						list("Yes", "No")) != "Yes")
+
+						return
+
 					if(client.prefs && !(client.prefs.be_special & BE_ALIEN_AFTER_DEATH))
 						client.prefs.be_special |= BE_ALIEN_AFTER_DEATH
 						to_chat(src, SPAN_BOLDNOTICE("You will now be considered for Xenomorph after unrevivable death events (where possible)."))

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -13,6 +13,15 @@
 	///The time when the larva_queue_cached_message should be considered stale
 	var/larva_queue_message_stale_time
 
+	/// The window that we display the main menu in
+	var/datum/tgui_window/lobby_window
+
+	/// The message that we are displaying to the user
+	var/lobby_confirmation_message
+
+	/// The callback that we will execute when the user confirms the message
+	var/datum/callback/execute_on_confirm
+
 /mob/new_player/Initialize()
 	. = ..()
 	GLOB.dead_mob_list -= src

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -16,7 +16,7 @@
 	/// The window that we display the main menu in
 	var/datum/tgui_window/lobby_window
 
-	/// The message that we are displaying to the user
+	/// The message that we are displaying to the user. If a list, each list element is displayed on its own line
 	var/lobby_confirmation_message
 
 	/// The callback that we will execute when the user confirms the message

--- a/tgui/packages/tgui/interfaces/LobbyMenu.tsx
+++ b/tgui/packages/tgui/interfaces/LobbyMenu.tsx
@@ -36,7 +36,7 @@ type LobbyData = {
   round_start: BooleanLike;
   readied: BooleanLike;
 
-  confirmation_message?: string;
+  confirmation_message?: string | string[];
 
   upp_enabled: BooleanLike;
   xenomorph_enabled: BooleanLike;
@@ -101,11 +101,16 @@ export const LobbyMenu = () => {
         }
         p={3}
         title={'Confirm'}
-        width="600px"
       >
         <Box>
           <Stack vertical>
-            <Stack.Item>{confirmation_message}</Stack.Item>
+            {Array.isArray(confirmation_message) ? (
+              confirmation_message.map((element, index) => (
+                <Stack.Item key={index}>{element}</Stack.Item>
+              ))
+            ) : (
+              <Stack.Item>{confirmation_message}</Stack.Item>
+            )}
           </Stack>
           <Stack justify="center">
             <Stack.Item>

--- a/tgui/packages/tgui/interfaces/LobbyMenu.tsx
+++ b/tgui/packages/tgui/interfaces/LobbyMenu.tsx
@@ -101,6 +101,7 @@ export const LobbyMenu = () => {
         }
         p={3}
         title={'Confirm'}
+        width="600px"
       >
         <Box>
           <Stack vertical>

--- a/tgui/packages/tgui/interfaces/LobbyMenu.tsx
+++ b/tgui/packages/tgui/interfaces/LobbyMenu.tsx
@@ -36,6 +36,8 @@ type LobbyData = {
   round_start: BooleanLike;
   readied: BooleanLike;
 
+  confirmation_message?: string;
+
   upp_enabled: BooleanLike;
   xenomorph_enabled: BooleanLike;
   predator_enabled: BooleanLike;
@@ -56,7 +58,7 @@ const LobbyContext = createContext<LobbyContextType>({
 export const LobbyMenu = () => {
   const { act, data } = useBackend<LobbyData>();
 
-  const { lobby_author, upp_enabled } = data;
+  const { lobby_author, upp_enabled, confirmation_message } = data;
 
   const onLoadPlayer = useRef<HTMLAudioElement>(null);
 
@@ -81,6 +83,38 @@ export const LobbyMenu = () => {
       setDisableAnimations(true);
     }, 10000);
   }, []);
+
+  useEffect(() => {
+    if (!confirmation_message) return;
+
+    setModal(
+      <Section
+        buttons={
+          <Button
+            mb={5}
+            onClick={() => {
+              setModal!(false);
+              act('unconfirm');
+            }}
+            icon={'x'}
+          />
+        }
+        p={3}
+        title={'Confirm'}
+      >
+        <Box>
+          <Stack vertical>
+            <Stack.Item>{confirmation_message}</Stack.Item>
+          </Stack>
+          <Stack justify="center">
+            <Stack.Item>
+              <Button onClick={() => act('confirm')}>Confirm</Button>
+            </Stack.Item>
+          </Stack>
+        </Box>
+      </Section>,
+    );
+  }, [confirmation_message]);
 
   const [hidden, setHidden] = useState<boolean>(false);
 
@@ -410,27 +444,7 @@ const LobbyButtons = (props: {
                   <LobbyButton
                     index={6}
                     icon="viruses"
-                    onClick={() => {
-                      setModal(
-                        <ModalConfirm>
-                          <Box>
-                            <Stack vertical>
-                              <Stack.Item>
-                                Are you sure want to attempt joining as a
-                                Xenomorph?
-                              </Stack.Item>
-                            </Stack>
-                            <Stack justify="center">
-                              <Stack.Item>
-                                <Button onClick={() => act('late_join_xeno')}>
-                                  Confirm
-                                </Button>
-                              </Stack.Item>
-                            </Stack>
-                          </Box>
-                        </ModalConfirm>,
-                      );
-                    }}
+                    onClick={() => act('late_join_xeno')}
                   >
                     Join the Hive
                   </LobbyButton>


### PR DESCRIPTION
~~this isn't displayed in the lobby screen ui - and it would be an absolute pain to do so, all the checks done in attempt_to_join_as_xeno are quite stateful~~ did it anyway

:cl:
fix: you can't accidentally end up ghosting when trying to join as xeno when no larva are available
/:cl:

closes #7988
closes #7994