### PR TITLE
Special Shrapnel fixes, Flaming shrapnel AP nerf.

### DIFF
--- a/code/datums/ammo/shrapnel.dm
+++ b/code/datums/ammo/shrapnel.dm
@@ -63,7 +63,7 @@
 	flags_ammo_behavior = AMMO_STOPPED_BY_COVER
 	shell_speed = AMMO_SPEED_TIER_1
 	damage = 30
-	penetration = ARMOR_PENETRATION_TIER_10 //molten metal pierces your armor
+	penetration = ARMOR_PENETRATION_TIER_4
 
 /datum/ammo/bullet/shrapnel/incendiary/set_bullet_traits()
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -596,7 +596,7 @@
 		return FALSE
 
 	if(caste.fire_immunity & FIRE_IMMUNITY_NO_DAMAGE)
-		burn_amount *= 0.5
+		return
 
 	apply_damage(burn_amount, BURN)
 	to_chat(src, SPAN_DANGER("Our flesh, it melts!"))

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -596,7 +596,7 @@
 		return FALSE
 
 	if(caste.fire_immunity & FIRE_IMMUNITY_NO_DAMAGE)
-		return
+		burn_amount *= 0.5
 
 	apply_damage(burn_amount, BURN)
 	to_chat(src, SPAN_DANGER("Our flesh, it melts!"))

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -633,9 +633,9 @@
 			shards = max_ex_shards
 		if(ispath(shard_type, /datum/ammo/bullet/shrapnel/incendiary) && shards > max_ex_shards / INCENDIARY_SHARDS_MAX_REDUCTION) // less max incendiary shards
 			shards = max_ex_shards / INCENDIARY_SHARDS_MAX_REDUCTION
-		if(ispath(shard_type, /datum/ammo/bullet/shrapnel/hornet_rounds) && shards > max_ex_shards / HORNET_SHARDS_MAX_REDUCTION)
+		else if(ispath(shard_type, /datum/ammo/bullet/shrapnel/hornet_rounds) && shards > max_ex_shards / HORNET_SHARDS_MAX_REDUCTION)
 			shards = max_ex_shards / HORNET_SHARDS_MAX_REDUCTION
-		if(ispath(shard_type, /datum/ammo/bullet/shrapnel/neuro) && shards > max_ex_shards / NEURO_SHARDS_MAX_REDUCTION)
+		else if(ispath(shard_type, /datum/ammo/bullet/shrapnel/neuro) && shards > max_ex_shards / NEURO_SHARDS_MAX_REDUCTION)
 			shards = max_ex_shards / NEURO_SHARDS_MAX_REDUCTION
 		if(ex_power > max_ex_power)
 			ex_power = max_ex_power

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -631,11 +631,11 @@
 		// some upper limits
 		if(shards > max_ex_shards)
 			shards = max_ex_shards
-		if(istype(shard_type, /datum/ammo/bullet/shrapnel/incendiary) && shards > max_ex_shards / INCENDIARY_SHARDS_MAX_REDUCTION) // less max incendiary shards
+		if(ispath(shard_type, /datum/ammo/bullet/shrapnel/incendiary) && shards > max_ex_shards / INCENDIARY_SHARDS_MAX_REDUCTION) // less max incendiary shards
 			shards = max_ex_shards / INCENDIARY_SHARDS_MAX_REDUCTION
-		if(istype(shard_type, /datum/ammo/bullet/shrapnel/hornet_rounds) && shards > max_ex_shards / HORNET_SHARDS_MAX_REDUCTION)
+		if(ispath(shard_type, /datum/ammo/bullet/shrapnel/hornet_rounds) && shards > max_ex_shards / HORNET_SHARDS_MAX_REDUCTION)
 			shards = max_ex_shards / HORNET_SHARDS_MAX_REDUCTION
-		if(istype(shard_type, /datum/ammo/bullet/shrapnel/neuro) && shards > max_ex_shards / NEURO_SHARDS_MAX_REDUCTION)
+		if(ispath(shard_type, /datum/ammo/bullet/shrapnel/neuro) && shards > max_ex_shards / NEURO_SHARDS_MAX_REDUCTION)
 			shards = max_ex_shards / NEURO_SHARDS_MAX_REDUCTION
 		if(ex_power > max_ex_power)
 			ex_power = max_ex_power


### PR DESCRIPTION

# About the pull request
special shrapnel now use the correct check, meaning that max shrapnel is now properly reduced. Thanks to watermelon for noticing it and telling me how to fix it

In practice this means that flaming/neuro/hornets are now capped at 16 total (From 32).

AP from incind shrapnel reduced from 50 to 20


# Explain why it's good for the game
Currently the incind shrapnel does 665 damage to a queen (before counting phosphor smoke)

<details>
<summary>Current Shrapnel Against Queen (Combat Ready/Mature)</summary>

https://github.com/user-attachments/assets/4651c6e3-de65-4438-b32c-41b97315e526

</details>



This is enough damage to 1shot every single caste up to and including non-hedge ravs (both base and berz), as base has 650 health while berz has 590. Even having max rage, which brings you to 45(!!) armor, isn't enough to save you, as flaming shrapnel has 50 ap.

<details>
<summary>Against a berz rav on the frontline</summary>

https://github.com/user-attachments/assets/0432dbd8-a897-4c51-9c19-aa268c91a035


</details>


Shrapnel mines probably shouldn't have the killing power of pre nerf OT rockets?
# Testing Photographs and Procedure
<details>
<summary>New Damage test against drone</summary>
It does around 460 damage total.

https://github.com/user-attachments/assets/59ba7435-1569-41ac-8a76-1f3f3b3dc5e3




</details>


# Changelog
:cl:
balance: Flaming Shrapnel now has 20 AP (from 50)
fix: OT special shrapnel is now properly affected by the cap, meaning that you can only have 16 shrapnel (from 32)
/:cl:
