### PR TITLE
Add black market items to TGUI req

### DIFF
--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -204,7 +204,7 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 		if(isnull(pack.contains) && isnull(pack.containertype))
 			continue
 
-		if(!(pack.group in linked_supply_controller.all_supply_groups))
+		if(!(pack.group in list() + linked_supply_controller.all_supply_groups + linked_supply_controller.contraband_supply_groups))
 			continue
 
 		if(!pack.contraband && length(pack.group))
@@ -1125,31 +1125,6 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 	. = ..()
 
 	.["contraband_categories"] = linked_supply_controller.contraband_supply_groups
-	for(var/pack_type in GLOB.supply_packs_datums)
-		var/datum/supply_packs/pack = GLOB.supply_packs_datums[pack_type]
-
-		if(!pack.buyable)
-			continue
-
-		if(isnull(pack.contains) && isnull(pack.containertype))
-			continue
-
-		if(!(pack.group in linked_supply_controller.contraband_supply_groups))
-			continue
-
-		var/list_pack = pack.get_list_representation()
-
-		if(length(pack.group))
-			if(!.["categories_to_objects"][pack.group])
-				.["categories_to_objects"][pack.group] = list()
-
-			.["categories_to_objects"][pack.group] += list(
-				list_pack
-			)
-
-		.["all_items"] += list(
-			list_pack
-		)
 
 /obj/structure/machinery/computer/supply/asrs/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -407,7 +407,7 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 
 /obj/structure/machinery/computer/supply/asrs/proc/toggle_contraband(contraband_enabled = FALSE)
 	can_order_contraband = contraband_enabled
-	for(var/obj/structure/machinery/computer/supply/asrs/computer as anything in linked_supply_controller.bound_supply_computer_list)
+	for(var/obj/structure/machinery/computer/supply/asrs/computer in linked_supply_controller.bound_supply_computer_list)
 		if(computer.can_order_contraband)
 			linked_supply_controller.black_market_enabled = TRUE
 			return
@@ -417,7 +417,7 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 
 /// Prevents use of black market, even if it is otherwise enabled. If any computer has black market locked out, it applies across all of the currently established ones.
 /obj/structure/machinery/computer/supply/asrs/proc/lock_black_market(market_locked = FALSE)
-	for(var/obj/structure/machinery/computer/supply/asrs/computer as anything in linked_supply_controller.bound_supply_computer_list)
+	for(var/obj/structure/machinery/computer/supply/asrs/computer in linked_supply_controller.bound_supply_computer_list)
 		if(market_locked)
 			computer.black_market_lockout = TRUE
 

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -1125,6 +1125,31 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 	. = ..()
 
 	.["contraband_categories"] = linked_supply_controller.contraband_supply_groups
+	for(var/pack_type in GLOB.supply_packs_datums)
+		var/datum/supply_packs/pack = GLOB.supply_packs_datums[pack_type]
+
+		if(!pack.buyable)
+			continue
+
+		if(isnull(pack.contains) && isnull(pack.containertype))
+			continue
+
+		if(!(pack.group in linked_supply_controller.contraband_supply_groups))
+			continue
+
+		var/list_pack = pack.get_list_representation()
+
+		if(length(pack.group))
+			if(!.["categories_to_objects"][pack.group])
+				.["categories_to_objects"][pack.group] = list()
+
+			.["categories_to_objects"][pack.group] += list(
+				list_pack
+			)
+
+		.["all_items"] += list(
+			list_pack
+		)
 
 /obj/structure/machinery/computer/supply/asrs/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -204,7 +204,7 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 		if(isnull(pack.contains) && isnull(pack.containertype))
 			continue
 
-		if(!(pack.group in list() + linked_supply_controller.all_supply_groups + linked_supply_controller.contraband_supply_groups))
+		if(!(pack.group in (list() + linked_supply_controller.all_supply_groups + linked_supply_controller.contraband_supply_groups)))
 			continue
 
 		if(!pack.contraband && length(pack.group))


### PR DESCRIPTION
# About the pull request

Fixes #8067 
Adds the black market supply packs to the tgui_static_data, which also prevents a window crash.
Removed a cast from toggle_contraband that was preventing sales to the black market.

# Explain why it's good for the game

Re-allows use of the black market on the new interface

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

![ASRS_TGUI_black_market](https://github.com/user-attachments/assets/ff5081eb-b0df-404c-b7c8-373dc90c4b5a)

</details>
Enabled the black market; bought and sold items.

# Changelog

:cl:
fix: Fixes black market TGUI crash
/:cl:
