### PR TITLE
Moves the sensor tower on Solaris Ridge

### DIFF
--- a/code/game/turfs/floor_types.dm
+++ b/code/game/turfs/floor_types.dm
@@ -148,6 +148,9 @@
 /turf/open/floor/plating/asteroidwarning/west
 	dir = WEST
 
+/turf/open/floor/plating/asteroidwarning/south
+	dir = SOUTH
+
 /turf/open/floor/plating/platingdmg2
 	icon_state = "platingdmg2"
 

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -557,9 +557,6 @@
 	},
 /turf/open/mars_cave/mars_cave_2,
 /area/bigredv2/caves_north)
-"acc" = (
-/turf/open/floor/asteroidwarning/southwest,
-/area/bigredv2/caves_research)
 "acd" = (
 /obj/effect/landmark/good_item,
 /turf/open/floor/plating,
@@ -579,20 +576,12 @@
 "ach" = (
 /turf/open/floor/plating/warnplate,
 /area/bigredv2/outside/space_port)
-"aci" = (
-/turf/open/floor/asteroidwarning/west{
-	dir = 2
-	},
-/area/bigredv2/caves_research)
 "acj" = (
 /obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plating/warnplate,
 /area/bigredv2/outside/space_port)
-"ack" = (
-/turf/open/floor/asteroidwarning/southeast,
-/area/bigredv2/caves_research)
 "acl" = (
 /obj/structure/filingcabinet,
 /obj/effect/landmark/objective_landmark/medium,
@@ -632,9 +621,6 @@
 /obj/structure/window_frame/solaris/reinforced,
 /turf/open/floor/plating,
 /area/bigredv2/outside/marshal_office)
-"act" = (
-/turf/open/floor/asteroidwarning/west,
-/area/bigredv2/caves_research)
 "acu" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
@@ -654,21 +640,12 @@
 /obj/effect/landmark/crap_item,
 /turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
-"acy" = (
-/obj/structure/machinery/sensortower{
-	pixel_x = -9
-	},
-/turf/open/floor/asteroidwarning,
-/area/bigredv2/caves_research)
 "acz" = (
 /turf/open/floor/whitegreen/north,
 /area/bigredv2/outside/marshal_office)
 "acA" = (
 /turf/closed/wall/solaris/reinforced,
 /area/bigredv2/outside/telecomm)
-"acB" = (
-/turf/open/floor/asteroidwarning/east,
-/area/bigredv2/caves_research)
 "acC" = (
 /turf/open/floor/white,
 /area/bigredv2/outside/marshal_office)
@@ -676,17 +653,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/white,
 /area/bigredv2/outside/marshal_office)
-"acE" = (
-/turf/open/floor/asteroidwarning/northwest,
-/area/bigredv2/caves_research)
 "acF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/white,
 /area/bigredv2/outside/marshal_office)
-"acG" = (
-/turf/open/floor/asteroidwarning/north,
-/area/bigredv2/caves_research)
 "acH" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 6
@@ -714,13 +685,16 @@
 	},
 /turf/open/floor/asteroidwarning/east,
 /area/bigredv2/outside/space_port)
-"acL" = (
-/turf/open/floor/asteroidwarning/northeast,
-/area/bigredv2/caves_research)
 "acM" = (
 /obj/structure/surface/table,
 /turf/open/floor/white,
 /area/bigredv2/outside/marshal_office)
+"acN" = (
+/turf/open/floor/asteroidwarning/southwest,
+/area/bigredv2/outside/filtration_cave_cas)
+"acO" = (
+/turf/open/floor/plating/asteroidwarning/south,
+/area/bigredv2/outside/filtration_cave_cas)
 "acP" = (
 /turf/open/mars,
 /area/bigredv2/outside/n)
@@ -759,6 +733,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/white,
 /area/bigredv2/outside/marshal_office)
+"acW" = (
+/turf/open/floor/asteroidwarning/southeast,
+/area/bigredv2/outside/filtration_cave_cas)
 "acX" = (
 /obj/structure/machinery/washing_machine,
 /turf/open/floor/white,
@@ -771,6 +748,9 @@
 "acZ" = (
 /turf/open/floor/greengrid,
 /area/bigredv2/outside/telecomm)
+"ada" = (
+/turf/open/floor/asteroidwarning/west,
+/area/bigredv2/outside/filtration_cave_cas)
 "adb" = (
 /obj/structure/surface/table,
 /obj/item/tool/hand_labeler,
@@ -826,6 +806,21 @@
 /obj/structure/machinery/computer/arcade,
 /turf/open/floor/white,
 /area/bigredv2/outside/marshal_office)
+"adn" = (
+/obj/structure/machinery/sensortower{
+	pixel_x = -9
+	},
+/turf/open/floor/asteroidwarning,
+/area/bigredv2/outside/filtration_cave_cas)
+"ado" = (
+/turf/open/floor/asteroidwarning/east,
+/area/bigredv2/outside/filtration_cave_cas)
+"adp" = (
+/turf/open/floor/asteroidwarning/northwest,
+/area/bigredv2/outside/filtration_cave_cas)
+"adq" = (
+/turf/open/floor/asteroidwarning/north,
+/area/bigredv2/outside/filtration_cave_cas)
 "adr" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -862,6 +857,9 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/asteroidwarning/east,
 /area/bigredv2/outside/space_port)
+"adx" = (
+/turf/open/floor/asteroidwarning/northeast,
+/area/bigredv2/outside/filtration_cave_cas)
 "ady" = (
 /obj/structure/bed/chair,
 /turf/open/floor/darkish,
@@ -68229,9 +68227,9 @@ aao
 jrD
 jrD
 jrD
-acE
-act
-acc
+jrD
+jrD
+jrD
 jcR
 jrD
 jrD
@@ -68446,9 +68444,9 @@ aao
 jrD
 jrD
 jrD
-acG
-acy
-aci
+jrD
+jrD
+jrD
 jrD
 jrD
 jrD
@@ -68663,9 +68661,9 @@ aao
 jrD
 jrD
 jrD
-acL
-acB
-ack
+jrD
+jrD
+jrD
 jrD
 jrD
 jrD
@@ -70169,9 +70167,9 @@ fOx
 fOx
 fOx
 fOx
-fOx
-fOx
-fOx
+adp
+ada
+acN
 fOx
 fOx
 fOx
@@ -70386,9 +70384,9 @@ fOx
 fOx
 fOx
 fOx
-fOx
-fOx
-fOx
+adq
+adn
+acO
 fOx
 fOx
 fOx
@@ -70603,9 +70601,9 @@ fOx
 fOx
 fOx
 fOx
-fOx
-fOx
-fOx
+adx
+ado
+acW
 fOx
 dov
 fOx

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -557,6 +557,9 @@
 	},
 /turf/open/mars_cave/mars_cave_2,
 /area/bigredv2/caves_north)
+"acc" = (
+/turf/open/floor/asteroidwarning/southwest,
+/area/bigredv2/caves_research)
 "acd" = (
 /obj/effect/landmark/good_item,
 /turf/open/floor/plating,
@@ -576,12 +579,20 @@
 "ach" = (
 /turf/open/floor/plating/warnplate,
 /area/bigredv2/outside/space_port)
+"aci" = (
+/turf/open/floor/asteroidwarning/west{
+	dir = 2
+	},
+/area/bigredv2/caves_research)
 "acj" = (
 /obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plating/warnplate,
 /area/bigredv2/outside/space_port)
+"ack" = (
+/turf/open/floor/asteroidwarning/southeast,
+/area/bigredv2/caves_research)
 "acl" = (
 /obj/structure/filingcabinet,
 /obj/effect/landmark/objective_landmark/medium,
@@ -621,6 +632,9 @@
 /obj/structure/window_frame/solaris/reinforced,
 /turf/open/floor/plating,
 /area/bigredv2/outside/marshal_office)
+"act" = (
+/turf/open/floor/asteroidwarning/west,
+/area/bigredv2/caves_research)
 "acu" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
@@ -640,12 +654,21 @@
 /obj/effect/landmark/crap_item,
 /turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
+"acy" = (
+/obj/structure/machinery/sensortower{
+	pixel_x = -9
+	},
+/turf/open/floor/asteroidwarning,
+/area/bigredv2/caves_research)
 "acz" = (
 /turf/open/floor/whitegreen/north,
 /area/bigredv2/outside/marshal_office)
 "acA" = (
 /turf/closed/wall/solaris/reinforced,
 /area/bigredv2/outside/telecomm)
+"acB" = (
+/turf/open/floor/asteroidwarning/east,
+/area/bigredv2/caves_research)
 "acC" = (
 /turf/open/floor/white,
 /area/bigredv2/outside/marshal_office)
@@ -653,11 +676,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/white,
 /area/bigredv2/outside/marshal_office)
+"acE" = (
+/turf/open/floor/asteroidwarning/northwest,
+/area/bigredv2/caves_research)
 "acF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/white,
 /area/bigredv2/outside/marshal_office)
+"acG" = (
+/turf/open/floor/asteroidwarning/north,
+/area/bigredv2/caves_research)
 "acH" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 6
@@ -685,6 +714,9 @@
 	},
 /turf/open/floor/asteroidwarning/east,
 /area/bigredv2/outside/space_port)
+"acL" = (
+/turf/open/floor/asteroidwarning/northeast,
+/area/bigredv2/caves_research)
 "acM" = (
 /obj/structure/surface/table,
 /turf/open/floor/white,
@@ -8308,12 +8340,6 @@
 "aMR" = (
 /turf/open/mars/mars_dirt_13,
 /area/bigredv2/outside/e)
-"aMT" = (
-/turf/open/floor/asteroidwarning,
-/area/bigredv2/caves_lambda)
-"aMV" = (
-/turf/open/floor/asteroidwarning/southeast,
-/area/bigredv2/caves_lambda)
 "aMW" = (
 /obj/effect/landmark/monkey_spawn,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
@@ -9684,9 +9710,6 @@
 "aSi" = (
 /turf/open/floor/asteroidwarning/northwest,
 /area/bigredv2/outside/e)
-"aSm" = (
-/turf/open/floor/asteroidwarning/northeast,
-/area/bigredv2/caves_lambda)
 "aSn" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/mars_cave/mars_cave_6,
@@ -9953,9 +9976,6 @@
 "aTu" = (
 /turf/open/floor/asteroidwarning/west,
 /area/bigredv2/outside/e)
-"aTv" = (
-/turf/open/floor/asteroidfloor/north,
-/area/bigredv2/caves_lambda)
 "aTy" = (
 /obj/structure/flora/grass/desert/lightgrass_6,
 /turf/open/mars,
@@ -26727,12 +26747,6 @@
 	},
 /turf/open/floor/darkish,
 /area/bigredv2/outside/medical)
-"lMw" = (
-/obj/structure/machinery/sensortower{
-	pixel_x = -9
-	},
-/turf/open/floor/asteroidfloor/north,
-/area/bigredv2/caves_lambda)
 "lMC" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -28553,10 +28567,6 @@
 /obj/item/ammo_magazine/rifle/m16,
 /turf/open/mars_cave/mars_cave_3,
 /area/bigredv2/caves/mining)
-"nFH" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
-/turf/open/floor/asteroidwarning/north,
-/area/bigredv2/caves_lambda)
 "nGl" = (
 /obj/structure/bed/bedroll{
 	dir = 10
@@ -68219,9 +68229,9 @@ aao
 jrD
 jrD
 jrD
-jrD
-jrD
-jrD
+acE
+act
+acc
 jcR
 jrD
 jrD
@@ -68436,9 +68446,9 @@ aao
 jrD
 jrD
 jrD
-jrD
-jrD
-jrD
+acG
+acy
+aci
 jrD
 jrD
 jrD
@@ -68653,9 +68663,9 @@ aao
 jrD
 jrD
 jrD
-jrD
-jrD
-jrD
+acL
+acB
+ack
 jrD
 jrD
 jrD
@@ -78563,9 +78573,9 @@ tQw
 ahw
 tQw
 tQw
-nFH
-aTv
-aMT
+aSn
+gXp
+gXp
 tQw
 tQw
 ujC
@@ -78780,9 +78790,9 @@ tQw
 tQw
 xFZ
 xFZ
-aSm
-lMw
-aMT
+gXp
+gXp
+gXp
 tQw
 tQw
 ujC
@@ -78998,8 +79008,8 @@ eFh
 aao
 aao
 aao
-aSm
-aMV
+tQw
+tQw
 tQw
 aao
 aao

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -557,6 +557,9 @@
 	},
 /turf/open/mars_cave/mars_cave_2,
 /area/bigredv2/caves_north)
+"acc" = (
+/turf/open/floor/asteroidwarning/southwest,
+/area/bigredv2/outside/filtration_cave_cas)
 "acd" = (
 /obj/effect/landmark/good_item,
 /turf/open/floor/plating,
@@ -576,12 +579,18 @@
 "ach" = (
 /turf/open/floor/plating/warnplate,
 /area/bigredv2/outside/space_port)
+"aci" = (
+/turf/open/floor/plating/asteroidwarning/south,
+/area/bigredv2/outside/filtration_cave_cas)
 "acj" = (
 /obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plating/warnplate,
 /area/bigredv2/outside/space_port)
+"ack" = (
+/turf/open/floor/asteroidwarning/southeast,
+/area/bigredv2/outside/filtration_cave_cas)
 "acl" = (
 /obj/structure/filingcabinet,
 /obj/effect/landmark/objective_landmark/medium,
@@ -621,6 +630,9 @@
 /obj/structure/window_frame/solaris/reinforced,
 /turf/open/floor/plating,
 /area/bigredv2/outside/marshal_office)
+"act" = (
+/turf/open/floor/asteroidwarning/west,
+/area/bigredv2/outside/filtration_cave_cas)
 "acu" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/effect/landmark/item_pool_spawner/survivor_ammo/buckshot,
@@ -640,12 +652,21 @@
 /obj/effect/landmark/crap_item,
 /turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
+"acy" = (
+/obj/structure/machinery/sensortower{
+	pixel_x = -9
+	},
+/turf/open/floor/asteroidwarning,
+/area/bigredv2/outside/filtration_cave_cas)
 "acz" = (
 /turf/open/floor/whitegreen/north,
 /area/bigredv2/outside/marshal_office)
 "acA" = (
 /turf/closed/wall/solaris/reinforced,
 /area/bigredv2/outside/telecomm)
+"acB" = (
+/turf/open/floor/asteroidwarning/east,
+/area/bigredv2/outside/filtration_cave_cas)
 "acC" = (
 /turf/open/floor/white,
 /area/bigredv2/outside/marshal_office)
@@ -653,11 +674,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/white,
 /area/bigredv2/outside/marshal_office)
+"acE" = (
+/turf/open/floor/asteroidwarning/northwest,
+/area/bigredv2/outside/filtration_cave_cas)
 "acF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/white,
 /area/bigredv2/outside/marshal_office)
+"acG" = (
+/turf/open/floor/asteroidwarning/north,
+/area/bigredv2/outside/filtration_cave_cas)
 "acH" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 6
@@ -685,16 +712,13 @@
 	},
 /turf/open/floor/asteroidwarning/east,
 /area/bigredv2/outside/space_port)
+"acL" = (
+/turf/open/floor/asteroidwarning/northeast,
+/area/bigredv2/outside/filtration_cave_cas)
 "acM" = (
 /obj/structure/surface/table,
 /turf/open/floor/white,
 /area/bigredv2/outside/marshal_office)
-"acN" = (
-/turf/open/floor/asteroidwarning/southwest,
-/area/bigredv2/outside/filtration_cave_cas)
-"acO" = (
-/turf/open/floor/plating/asteroidwarning/south,
-/area/bigredv2/outside/filtration_cave_cas)
 "acP" = (
 /turf/open/mars,
 /area/bigredv2/outside/n)
@@ -733,9 +757,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/white,
 /area/bigredv2/outside/marshal_office)
-"acW" = (
-/turf/open/floor/asteroidwarning/southeast,
-/area/bigredv2/outside/filtration_cave_cas)
 "acX" = (
 /obj/structure/machinery/washing_machine,
 /turf/open/floor/white,
@@ -748,9 +769,6 @@
 "acZ" = (
 /turf/open/floor/greengrid,
 /area/bigredv2/outside/telecomm)
-"ada" = (
-/turf/open/floor/asteroidwarning/west,
-/area/bigredv2/outside/filtration_cave_cas)
 "adb" = (
 /obj/structure/surface/table,
 /obj/item/tool/hand_labeler,
@@ -806,21 +824,6 @@
 /obj/structure/machinery/computer/arcade,
 /turf/open/floor/white,
 /area/bigredv2/outside/marshal_office)
-"adn" = (
-/obj/structure/machinery/sensortower{
-	pixel_x = -9
-	},
-/turf/open/floor/asteroidwarning,
-/area/bigredv2/outside/filtration_cave_cas)
-"ado" = (
-/turf/open/floor/asteroidwarning/east,
-/area/bigredv2/outside/filtration_cave_cas)
-"adp" = (
-/turf/open/floor/asteroidwarning/northwest,
-/area/bigredv2/outside/filtration_cave_cas)
-"adq" = (
-/turf/open/floor/asteroidwarning/north,
-/area/bigredv2/outside/filtration_cave_cas)
 "adr" = (
 /obj/structure/machinery/light{
 	dir = 4
@@ -857,9 +860,6 @@
 /obj/structure/pipes/standard/simple/hidden/green,
 /turf/open/floor/asteroidwarning/east,
 /area/bigredv2/outside/space_port)
-"adx" = (
-/turf/open/floor/asteroidwarning/northeast,
-/area/bigredv2/outside/filtration_cave_cas)
 "ady" = (
 /obj/structure/bed/chair,
 /turf/open/floor/darkish,
@@ -70167,9 +70167,9 @@ fOx
 fOx
 fOx
 fOx
-adp
-ada
-acN
+acE
+act
+acc
 fOx
 fOx
 fOx
@@ -70384,9 +70384,9 @@ fOx
 fOx
 fOx
 fOx
-adq
-adn
-acO
+acG
+acy
+aci
 fOx
 fOx
 fOx
@@ -70601,9 +70601,9 @@ fOx
 fOx
 fOx
 fOx
-adx
-ado
-acW
+acL
+acB
+ack
 fOx
 dov
 fOx


### PR DESCRIPTION
# About the pull request
Moves the Sensor Tower on Solaris Ridge
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
I am honestly tired of the only viable hive location being lambda caves ever since the sensor tower was added, Fighting on the same shitty choke etc. etc.
Moved it to a position which is still xeno favored but is closer to all hive locations (Lambda, SE caves, Eta and Mining) so we should hopefully see them being used more
# Testing Photographs and Procedure
<summary>Screenshots & Videos</summary>

New Location:

![image](https://github.com/user-attachments/assets/dfab8542-754b-4926-a97a-25a4021042a2)

Old Location:

![image](https://github.com/user-attachments/assets/0ffd1c50-4e80-4c05-88c7-6d459a4e6405)



# Changelog
:cl:
maptweak: Moved the sensor tower on Solaris Ridge
/:cl:
