### PR TITLE
Stacks inserted into storages will now try to fill other stacks first

### DIFF
--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -395,8 +395,19 @@ GLOBAL_LIST_EMPTY_TYPED(item_storage_box_cache, /datum/item_storage_box)
 
 ///Returns TRUE if there is room for the given item. W_class_override allows checking for just a generic W_class, meant for checking shotgun handfuls without having to spawn and delete one just to check.
 /obj/item/storage/proc/has_room(obj/item/new_item, W_class_override = null)
+	for(var/obj/item/cur_item in contents)
+		if(!istype(cur_item, /obj/item/stack) || !istype(new_item, /obj/item/stack))
+			continue
+
+		var/obj/item/stack/cur_stack = cur_item
+		var/obj/item/stack/new_stack = new_item
+
+		if(cur_stack.amount < cur_stack.max_amount && new_stack.stack_id == cur_stack.stack_id)
+			return TRUE
+	
 	if(storage_slots != null && length(contents) < storage_slots)
 		return TRUE //At least one open slot.
+	
 	//calculate storage space only for containers that don't have slots
 	if (storage_slots == null)
 		var/sum_storage_cost = W_class_override ? W_class_override : new_item.get_storage_cost() //Takes the override if there is one, the given item otherwise.
@@ -490,7 +501,27 @@ user can be null, it refers to the potential mob doing the insertion.**/
 /obj/item/storage/proc/handle_item_insertion(obj/item/new_item, prevent_warning = FALSE, mob/user)
 	if(!istype(new_item))
 		return FALSE
+
 	if(user && new_item.loc == user)
+		if(istype(new_item, /obj/item/stack))
+			var/obj/item/stack/new_stack = new_item
+
+			for(var/obj/item/cur_item in contents)
+				if(!istype(cur_item, /obj/item/stack))
+					continue
+				var/obj/item/stack/cur_stack = cur_item
+				
+				if(cur_stack.amount < cur_stack.max_amount && new_stack.stack_id == cur_stack.stack_id)
+					var/amount = min(cur_stack.max_amount - cur_stack.amount, new_stack.amount)
+					new_stack.use(amount)
+					cur_stack.add(amount)
+			
+			if(!QDELETED(new_stack) && can_be_inserted(new_stack, user))
+				if(!user.drop_inv_item_to_loc(new_item, src))
+					return FALSE
+			else
+				return TRUE
+
 		if(!user.drop_inv_item_to_loc(new_item, src))
 			return FALSE
 	else

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -215,32 +215,46 @@
 	if(!has_limb_for_slot(slot))
 		return
 
-	if(equipping_item == l_hand)
-		if(equipping_item.flags_item & NODROP)
-			return
-		l_hand = null
-		update_inv_l_hand()
-		//removes item's actions, may be readded once re-equipped to the new slot
-		for(var/item_actions in equipping_item.actions)
-			var/datum/action/action = item_actions
-			action.remove_from(src)
+	// Already handled within the proc, usually storages that force move the item themselves
+	var/static/list/no_update = list(
+		WEAR_IN_BACK,
+		WEAR_IN_SCABBARD,
+		WEAR_IN_JACKET,
+		WEAR_IN_HELMET,
+		WEAR_IN_ACCESSORY,
+		WEAR_IN_BELT,
+		WEAR_IN_J_STORE,
+		WEAR_IN_L_STORE,
+		WEAR_IN_R_STORE
+	)
 
-	else if(equipping_item == r_hand)
-		if(equipping_item.flags_item & NODROP)
-			return
-		r_hand = null
-		update_inv_r_hand()
-		//removes item's actions, may be readded once re-equipped to the new slot
-		for(var/item_actions in equipping_item.actions)
-			var/datum/action/action = item_actions
-			action.remove_from(src)
+	if(!(slot in no_update))
+		if(equipping_item == l_hand)
+			if(equipping_item.flags_item & NODROP)
+				return
+			l_hand = null
+			update_inv_l_hand()
+			//removes item's actions, may be readded once re-equipped to the new slot
+			for(var/item_actions in equipping_item.actions)
+				var/datum/action/action = item_actions
+				action.remove_from(src)
 
-	equipping_item.screen_loc = null
-	if(equipping_item.loc != src)
-		equipping_item.pickup(src, disable_warning)
-	equipping_item.forceMove(src)
-	equipping_item.layer = ABOVE_HUD_LAYER
-	equipping_item.plane = ABOVE_HUD_PLANE
+		else if(equipping_item == r_hand)
+			if(equipping_item.flags_item & NODROP)
+				return
+			r_hand = null
+			update_inv_r_hand()
+			//removes item's actions, may be readded once re-equipped to the new slot
+			for(var/item_actions in equipping_item.actions)
+				var/datum/action/action = item_actions
+				action.remove_from(src)
+
+		equipping_item.screen_loc = null
+		if(equipping_item.loc != src)
+			equipping_item.pickup(src, disable_warning)
+		equipping_item.forceMove(src)
+		equipping_item.layer = ABOVE_HUD_LAYER
+		equipping_item.plane = ABOVE_HUD_PLANE
 
 	switch(slot)
 		if(WEAR_BACK)


### PR DESCRIPTION
# About the pull request
E.g you insert metal into a construction pouch, it will first try to fill existing metal stacks first.

This also allows you to quick equip into storages that are full but have stacks with extra space in them

P.S during local testing this had a lot of bugs so this needs TMing first
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
qol
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Stacks inserted into storages will now try to fill other stacks
/:cl:
