### PR TITLE
Tackle Rework

### DIFF
--- a/code/datums/components/tackle_counter.dm
+++ b/code/datums/components/tackle_counter.dm
@@ -1,0 +1,31 @@
+/datum/component/tackle_counter
+	var/tackles = 0
+	var/reset_timer
+
+/datum/component/tackle_counter/Initialize()
+	if(!isliving(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	reset_timer = addtimer(CALLBACK(src, PROC_REF(reset_tackle)), 4 SECONDS, TIMER_UNIQUE | TIMER_STOPPABLE)
+	RegisterSignal(parent, COMSIG_LIVING_SET_BODY_POSITION, PROC_REF(tackle_handle_lying_changed))
+
+/datum/component/tackle_counter/proc/tackle_handle_lying_changed(mob/living/target, body_position)
+	SIGNAL_HANDLER
+	if(body_position != LYING_DOWN)
+		return
+
+	// Infected mobs do not have their tackle counter reset if
+	// they get knocked down or get up from a knockdown
+	if(target.status_flags & XENO_HOST)
+		return
+
+	reset_tackle()
+
+/datum/component/tackle_counter/proc/reset_tackle()
+	UnregisterSignal(parent, COMSIG_LIVING_SET_BODY_POSITION)
+	qdel(src)
+
+/datum/component/tackle_counter/proc/tackle()
+	tackles++
+	deltimer(reset_timer)
+	reset_timer = addtimer(CALLBACK(src, PROC_REF(reset_tackle)), 4 SECONDS, TIMER_UNIQUE | TIMER_STOPPABLE)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Boiler.dm
@@ -27,11 +27,11 @@
 	// 3x fire damage
 	fire_vulnerability_mult = FIRE_MULTIPLIER_DEADLY
 
-	tackle_min = 2
-	tackle_max = 6
+	tackle_min = 3
+	tackle_max = 7
 	tackle_chance = 25
-	tacklestrength_min = 3
-	tacklestrength_max = 4
+	tacklestrength_min = 2
+	tacklestrength_max = 3
 
 	minimum_evolve_time = 15 MINUTES
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Burrower.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Burrower.dm
@@ -22,11 +22,11 @@
 
 	behavior_delegate_type = /datum/behavior_delegate/burrower_base
 
-	tackle_min = 3
-	tackle_max = 5
+	tackle_min = 4
+	tackle_max = 6
 	tackle_chance = 40
-	tacklestrength_min = 4
-	tacklestrength_max = 5
+	tacklestrength_min = 3
+	tacklestrength_max = 4
 
 	burrow_cooldown = 20
 	tunnel_cooldown = 70

--- a/code/modules/mob/living/carbon/xenomorph/castes/Carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Carrier.dm
@@ -28,11 +28,11 @@
 	huggers_max = 16
 	eggs_max = 8
 
-	tackle_min = 2
-	tackle_max = 4
+	tackle_min = 4
+	tackle_max = 6
 	tackle_chance = 50
-	tacklestrength_min = 4
-	tacklestrength_max = 5
+	tacklestrength_min = 2
+	tacklestrength_max = 2
 
 	aura_strength = 2
 	hugger_delay = 20

--- a/code/modules/mob/living/carbon/xenomorph/castes/Crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Crusher.dm
@@ -19,8 +19,10 @@
 
 	minimum_evolve_time = 15 MINUTES
 
-	tackle_min = 2
-	tackle_max = 6
+	tackle_min = 3
+	tackle_max = 7
+	tacklestrength_min = 1
+	tacklestrength_max = 2
 	tackle_chance = 25
 
 	evolution_allowed = FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/Defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Defender.dm
@@ -21,8 +21,10 @@
 	available_strains = list(/datum/xeno_strain/steel_crest)
 	behavior_delegate_type = /datum/behavior_delegate/defender_base
 
-	tackle_min = 2
-	tackle_max = 4
+	tackle_min = 3
+	tackle_max = 5
+	tacklestrength_min = 1
+	tacklestrength_max = 2
 
 	minimum_evolve_time = 4 MINUTES
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Drone.dm
@@ -28,10 +28,10 @@
 	weed_level = WEED_LEVEL_STANDARD
 	max_build_dist = 1
 
-	tackle_min = 2
-	tackle_max = 4
-	tacklestrength_min = 3
-	tacklestrength_max = 4
+	tackle_min = 4
+	tackle_max = 6
+	tacklestrength_min = 2
+	tacklestrength_max = 2
 
 	aura_strength = 2
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Hivelord.dm
@@ -26,11 +26,11 @@
 	behavior_delegate_type = /datum/behavior_delegate/hivelord_base
 	max_build_dist = 1
 
-	tackle_min = 2
-	tackle_max = 4
+	tackle_min = 4
+	tackle_max = 6
 	tackle_chance = 45
-	tacklestrength_min = 4
-	tacklestrength_max = 5
+	tacklestrength_min = 2
+	tacklestrength_max = 2
 
 	aura_strength = 2.5
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
@@ -22,6 +22,11 @@
 	caste_desc = "A fast, powerful backline combatant."
 	evolves_to = list(XENO_CASTE_RAVAGER)
 
+	tackle_min = 3
+	tackle_max = 7
+	tacklestrength_min = 1
+	tacklestrength_max = 2
+
 	heal_resting = 1.5
 
 	minimum_evolve_time = 9 MINUTES

--- a/code/modules/mob/living/carbon/xenomorph/castes/Praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Praetorian.dm
@@ -22,8 +22,11 @@
 	aura_strength = 3
 	spit_delay = 20
 
-	tackle_min = 2
-	tackle_max = 5
+	tackle_min = 3
+	tackle_max = 6
+
+	tacklestrength_min = 1
+	tacklestrength_max = 2
 	tackle_chance = 45
 
 	available_strains = list(

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -34,13 +34,13 @@
 
 	spit_delay = 25
 
-	tackle_min = 2
-	tackle_max = 6
+	tackle_min = 3
+	tackle_max = 7
 	tackle_chance = 55
 
 	aura_strength = 4
-	tacklestrength_min = 5
-	tacklestrength_max = 6
+	tacklestrength_min = 4
+	tacklestrength_max = 5
 
 	minimum_xeno_playtime = 9 HOURS
 	minimum_evolve_time = 0

--- a/code/modules/mob/living/carbon/xenomorph/castes/Ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Ravager.dm
@@ -14,11 +14,11 @@
 	speed = XENO_SPEED_TIER_3
 	heal_standing = 0.66
 
-	tackle_min = 2
-	tackle_max = 5
+	tackle_min = 3
+	tackle_max = 6
 	tackle_chance = 35
-	tacklestrength_min = 4
-	tacklestrength_max = 5
+	tacklestrength_min = 3
+	tacklestrength_max = 4
 
 	evolution_allowed = FALSE
 	deevolves_to = list(XENO_CASTE_LURKER)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Runner.dm
@@ -19,11 +19,11 @@
 	evolves_to = list(XENO_CASTE_LURKER)
 	deevolves_to = list(XENO_CASTE_LARVA)
 
-	tackle_min = 4
-	tackle_max = 5
+	tackle_min = 8
+	tackle_max = 10
 	tackle_chance = 40
-	tacklestrength_min = 4
-	tacklestrength_max = 4
+	tacklestrength_min = 2
+	tacklestrength_max = 2
 
 	heal_resting = 1.75
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Sentinel.dm
@@ -18,11 +18,11 @@
 	deevolves_to = list(XENO_CASTE_LARVA)
 	acid_level = 1
 
-	tackle_min = 4
-	tackle_max = 4
+	tackle_min = 6
+	tackle_max = 6
 	tackle_chance = 50
-	tacklestrength_min = 4
-	tacklestrength_max = 4
+	tacklestrength_min = 3
+	tacklestrength_max = 3
 
 	behavior_delegate_type = /datum/behavior_delegate/sentinel_base
 	minimap_icon = "sentinel"

--- a/code/modules/mob/living/carbon/xenomorph/castes/Spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Spitter.dm
@@ -21,11 +21,11 @@
 
 	spit_delay = 2.5 SECONDS
 
-	tackle_min = 2
-	tackle_max = 6
+	tackle_min = 3
+	tackle_max = 7
 	tackle_chance = 45
-	tacklestrength_min = 4
-	tacklestrength_max = 5
+	tacklestrength_min = 3
+	tacklestrength_max = 4
 
 	minimum_evolve_time = 9 MINUTES
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -20,8 +20,11 @@
 	caste_desc = "A powerful front line combatant."
 	can_vent_crawl = 0
 
-	tackle_min = 2
-	tackle_max = 4
+	tackle_min = 3
+	tackle_max = 5
+
+	tacklestrength_min = 1
+	tacklestrength_max = 2
 
 	agility_speed_increase = -0.9
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
@@ -25,8 +25,8 @@
 	weed_level = WEED_LEVEL_STANDARD
 	max_build_dist = 1
 
-	tackle_min = 4
-	tackle_max = 5
+	tackle_min = 7
+	tackle_max = 8
 
 	aura_strength = 1
 

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -429,6 +429,7 @@
 #include "code\datums\components\shimmy_around.dm"
 #include "code\datums\components\speed_modifier.dm"
 #include "code\datums\components\status_effect_component.dm"
+#include "code\datums\components\tackle_counter.dm"
 #include "code\datums\components\temporary_mute.dm"
 #include "code\datums\components\toxin_buildup.dm"
 #include "code\datums\components\tutorial_status.dm"


### PR DESCRIPTION

# About the pull request
Reworks tackle to be more teamplay based than solo
Tackles from multiple xenos on the same person will now stack rather than being separate counters, Xenomorph tackle min and max increased across the board as well as lowering tackle strengths (duration of the tackle stun), Some problematic xenos got harsher treatment (Runner, Drone, Carrier, Hivelord)
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
I think everyone can agree the current tackle system is bad and cheesy, You can call it salt but no one enjoys being dragged forever by a drone or a runner because you have been clicked X amount of times
In an attempt to change the focus of tackle from solo to team based I think the system would be much more rewarding when xenos work together and much less frustrating to play against overall.
Values can be adjusted accordingly if xeno capping increases or decreases significantly as that is a non-goal of this pr (whatever was previously being capped solo should turn into team caps)
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Tackles from multiple xenos now stack rather than having their own separate counters
balance: Increased min and max amount of attempts xenos need to tackle across the board
balance: Decreased duration of tackle stun across the board
/:cl:
