### PR TITLE
Breaching nerfs

### DIFF
--- a/code/datums/elements/bullet_trait/damage_boost.dm
+++ b/code/datums/elements/bullet_trait/damage_boost.dm
@@ -22,7 +22,30 @@ GLOBAL_LIST_INIT(damage_boost_pylons, typecacheof(list(
 
 GLOBAL_LIST_INIT(damage_boost_vehicles, typecacheof(/obj/vehicle/multitile))
 
-GLOBAL_LIST_INIT(daamge_boost_rwall, typecacheof(/turf/closed/wall/r_wall))
+GLOBAL_LIST_INIT(daamge_boost_rwall, typecacheof(list(
+	/turf/closed/wall/hybrisa/research/ribbed,
+	/turf/closed/wall/hybrisa/research/reinforced,
+	/turf/closed/wall/hybrisa/colony/ribbed,
+	/turf/closed/wall/hybrisa/colony/reinforced,
+	/turf/closed/wall/hybrisa/colony/hospital/ribbed,
+	/turf/closed/wall/hybrisa/colony/hospital/reinforced,
+	/turf/closed/wall/hybrisa/colony/office/ribbed,
+	/turf/closed/wall/hybrisa/colony/office/reinforced,
+	/turf/closed/wall/hybrisa/colony/engineering/ribbed,
+	/turf/closed/wall/hybrisa/colony/engineering/reinforced,
+	/turf/closed/wall/r_wall,
+	/turf/closed/wall/almayer/reinforced,
+	/turf/closed/wall/almayer/reinforced/temphull,
+	/turf/closed/wall/almayer/white/reinforced,
+	/turf/closed/wall/almayer/aicore/reinforced,
+	/turf/closed/wall/almayer/aicore/white/reinforced,
+	/turf/closed/wall/mineral/sandstone/runed,
+	/turf/closed/wall/strata_outpost_ribbed,
+	/turf/closed/wall/strata_outpost/reinforced,
+	/turf/closed/wall/solaris/reinforced,
+	/turf/closed/wall/dev/reinforced,
+	/turf/closed/wall/kutjevo/colony/reinforced,
+)))
 
 /datum/element/bullet_trait_damage_boost
 	element_flags = ELEMENT_DETACH|ELEMENT_BESPOKE

--- a/code/datums/elements/bullet_trait/damage_boost.dm
+++ b/code/datums/elements/bullet_trait/damage_boost.dm
@@ -2,6 +2,8 @@ GLOBAL_LIST_INIT(damage_boost_turfs, typecacheof(/turf))
 
 GLOBAL_LIST_INIT(damage_boost_turfs_xeno, typecacheof(/turf/closed/wall/resin))
 
+GLOBAL_LIST_INIT(damage_boost_doors_xeno, typecacheof(/obj/structure/mineral_door/resin))
+
 GLOBAL_LIST_INIT(damage_boost_breaching, typecacheof(list(
 	/obj/structure/machinery/door,
 	/obj/structure/mineral_door,
@@ -19,6 +21,8 @@ GLOBAL_LIST_INIT(damage_boost_pylons, typecacheof(list(
 )))
 
 GLOBAL_LIST_INIT(damage_boost_vehicles, typecacheof(/obj/vehicle/multitile))
+
+GLOBAL_LIST_INIT(daamge_boost_rwall, typecacheof(/turf/closed/wall/r_wall))
 
 /datum/element/bullet_trait_damage_boost
 	element_flags = ELEMENT_DETACH|ELEMENT_BESPOKE

--- a/code/datums/supply_packs/ammo.dm
+++ b/code/datums/supply_packs/ammo.dm
@@ -231,11 +231,11 @@
 	group = "Ammo"
 
 /datum/supply_packs/ammo_shell_box_breaching
-	name = "Shell box (16g) (120x breaching shells)"
+	name = "Shell box (16g) (60x breaching shells)"
 	contains = list(
 		/obj/item/ammo_box/magazine/shotgun/light/breaching,
 	)
-	cost = 40
+	cost = 30
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "\improper shotgun breaching crate"
 	group = "Ammo"

--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -310,7 +310,7 @@
 		list("Shotgun Shell Box (Buckshot x 100)", 0, /obj/item/ammo_box/magazine/shotgun/buckshot, VENDOR_ITEM_REGULAR),
 		list("Shotgun Shell Box (Flechette x 100)", 0, /obj/item/ammo_box/magazine/shotgun/flechette, VENDOR_ITEM_REGULAR),
 		list("Shotgun Shell Box (Slugs x 100)", 0, /obj/item/ammo_box/magazine/shotgun, VENDOR_ITEM_REGULAR),
-		list("Shotgun Shell Box (16g) (Breaching x 120)", 0, /obj/item/ammo_box/magazine/shotgun/light/breaching, VENDOR_ITEM_REGULAR),
+		list("Shotgun Shell Box (16g) (Breaching x 60)", 0, /obj/item/ammo_box/magazine/shotgun/light/breaching, VENDOR_ITEM_REGULAR),
 		list("Magazine Box (88 Mod 4 AP x 16)", 0, /obj/item/ammo_box/magazine/mod88, VENDOR_ITEM_REGULAR),
 		list("Magazine Box (SU-6 x 16)", 0, /obj/item/ammo_box/magazine/su6, VENDOR_ITEM_REGULAR),
 		list("Magazine Box (VP78 x 16)", 0, /obj/item/ammo_box/magazine/vp78, VENDOR_ITEM_REGULAR),

--- a/code/modules/projectiles/ammo_boxes/handful_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/handful_boxes.dm
@@ -120,11 +120,11 @@
 //-----------------------16 GAUGE SHOTGUN SHELL BOXES-----------------------
 
 /obj/item/ammo_box/magazine/shotgun/light/breaching
-	name = "\improper 16-gauge shotgun shell box (Breaching x 120)"
+	name = "\improper 16-gauge shotgun shell box (Breaching x 60)"
 	icon_state = "base_breach"
 	overlay_content = "_breach"
 	magazine_type = /obj/item/ammo_magazine/shotgun/light/breaching
-	num_of_magazines = 120 //10 full mag reloads.
+	num_of_magazines = 60 //5 full mag reloads.
 	can_explode = FALSE
 
 /obj/item/ammo_box/magazine/shotgun/light/breaching/empty

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -3205,7 +3205,6 @@ Defined in conflicts.dm of the #defines folder.
 		BULLET_TRAIT_ENTRY_ID("turfs", /datum/element/bullet_trait_damage_boost, 5, GLOB.damage_boost_turfs),
 		BULLET_TRAIT_ENTRY_ID("breaching", /datum/element/bullet_trait_damage_boost, 10.8, GLOB.damage_boost_breaching), // 1242 damage
 		BULLET_TRAIT_ENTRY_ID("pylons", /datum/element/bullet_trait_damage_boost, 5, GLOB.damage_boost_pylons),
-		BULLET_TRAIT_ENTRY_ID("xeno_door", /datum/element/bullet_trait_damage_boost, 0.4, GLOB.damage_boost_doors_xeno) // 496.8 two tap for normal three tap for thick  
 	))
 
 /obj/item/attachable/attached_gun/shotgun/reload_attachment(obj/item/ammo_magazine/handful/mag, mob/user)

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -3205,7 +3205,7 @@ Defined in conflicts.dm of the #defines folder.
 		BULLET_TRAIT_ENTRY_ID("turfs", /datum/element/bullet_trait_damage_boost, 5, GLOB.damage_boost_turfs),
 		BULLET_TRAIT_ENTRY_ID("breaching", /datum/element/bullet_trait_damage_boost, 10.8, GLOB.damage_boost_breaching), // 1242 damage
 		BULLET_TRAIT_ENTRY_ID("pylons", /datum/element/bullet_trait_damage_boost, 5, GLOB.damage_boost_pylons),
-		BULLET_TRAIT_ENTRY_ID("xeno_door", /datum/element/bullet_trait_damage_boost, 0.5, GLOB.damage_boost_doors_xeno) // 621 one tap for normal two tap for thick  
+		BULLET_TRAIT_ENTRY_ID("xeno_door", /datum/element/bullet_trait_damage_boost, 0.4, GLOB.damage_boost_doors_xeno) // 496.8 two tap for normal three tap for thick  
 	))
 
 /obj/item/attachable/attached_gun/shotgun/reload_attachment(obj/item/ammo_magazine/handful/mag, mob/user)

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -3203,8 +3203,9 @@ Defined in conflicts.dm of the #defines folder.
 /obj/item/attachable/attached_gun/shotgun/set_bullet_traits()
 	LAZYADD(traits_to_give_attached, list(
 		BULLET_TRAIT_ENTRY_ID("turfs", /datum/element/bullet_trait_damage_boost, 5, GLOB.damage_boost_turfs),
-		BULLET_TRAIT_ENTRY_ID("breaching", /datum/element/bullet_trait_damage_boost, 10.8, GLOB.damage_boost_breaching),
-		BULLET_TRAIT_ENTRY_ID("pylons", /datum/element/bullet_trait_damage_boost, 5, GLOB.damage_boost_pylons)
+		BULLET_TRAIT_ENTRY_ID("breaching", /datum/element/bullet_trait_damage_boost, 10.8, GLOB.damage_boost_breaching), // 1242 damage
+		BULLET_TRAIT_ENTRY_ID("pylons", /datum/element/bullet_trait_damage_boost, 5, GLOB.damage_boost_pylons),
+		BULLET_TRAIT_ENTRY_ID("xeno_door", /datum/element/bullet_trait_damage_boost, 0.5, GLOB.damage_boost_doors_xeno) // 621 one tap for normal two tap for thick  
 	))
 
 /obj/item/attachable/attached_gun/shotgun/reload_attachment(obj/item/ammo_magazine/handful/mag, mob/user)

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -2060,9 +2060,11 @@
 
 /obj/item/weapon/gun/rifle/xm51/set_bullet_traits()
 	LAZYADD(traits_to_give, list(
-		BULLET_TRAIT_ENTRY_ID("turfs", /datum/element/bullet_trait_damage_boost, 30, GLOB.damage_boost_turfs), //2550, 2 taps colony walls, 4 taps reinforced walls
+		BULLET_TRAIT_ENTRY_ID("turfs", /datum/element/bullet_trait_damage_boost, 30, GLOB.damage_boost_turfs), //2550, 2 taps colony walls
+		BULLET_TRAIT_ENTRY_ID("rwalls", /datum/element/bullet_trait_damage_boost, 0.4, GLOB.daamge_boost_rwall), // 1020, 9 taps for rwall
 		BULLET_TRAIT_ENTRY_ID("xeno turfs", /datum/element/bullet_trait_damage_boost, 0.23, GLOB.damage_boost_turfs_xeno), //2550*0.23 = 586, 2 taps resin walls, 3 taps thick resin
 		BULLET_TRAIT_ENTRY_ID("breaching", /datum/element/bullet_trait_damage_boost, 15, GLOB.damage_boost_breaching), //1275, enough to 1 tap airlocks
+		BULLET_TRAIT_ENTRY_ID("xeno_door", /datum/element/bullet_trait_damage_boost, 0.5, GLOB.damage_boost_doors_xeno), // 637.5 one tap normal resin door 2 tap thick resin door
 		BULLET_TRAIT_ENTRY_ID("pylons", /datum/element/bullet_trait_damage_boost, 6, GLOB.damage_boost_pylons) //510, 4 shots to take out a pylon
 	))
 

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -2061,7 +2061,7 @@
 /obj/item/weapon/gun/rifle/xm51/set_bullet_traits()
 	LAZYADD(traits_to_give, list(
 		BULLET_TRAIT_ENTRY_ID("turfs", /datum/element/bullet_trait_damage_boost, 30, GLOB.damage_boost_turfs), //2550, 2 taps colony walls
-		BULLET_TRAIT_ENTRY_ID("rwalls", /datum/element/bullet_trait_damage_boost, 0.4, GLOB.daamge_boost_rwall), // 1020, 9 taps for rwall
+		BULLET_TRAIT_ENTRY_ID("rwalls", /datum/element/bullet_trait_damage_boost, 0.44, GLOB.daamge_boost_rwall), // 1147, 7 taps for rwall
 		BULLET_TRAIT_ENTRY_ID("xeno turfs", /datum/element/bullet_trait_damage_boost, 0.23, GLOB.damage_boost_turfs_xeno), //2550*0.23 = 586, 2 taps resin walls, 3 taps thick resin
 		BULLET_TRAIT_ENTRY_ID("breaching", /datum/element/bullet_trait_damage_boost, 15, GLOB.damage_boost_breaching), //1275, enough to 1 tap airlocks
 		BULLET_TRAIT_ENTRY_ID("xeno_door", /datum/element/bullet_trait_damage_boost, 0.5, GLOB.damage_boost_doors_xeno), // 637.5 one tap normal resin door 2 tap thick resin door

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -2064,7 +2064,6 @@
 		BULLET_TRAIT_ENTRY_ID("rwalls", /datum/element/bullet_trait_damage_boost, 0.44, GLOB.daamge_boost_rwall), // 1147, 7 taps for rwall
 		BULLET_TRAIT_ENTRY_ID("xeno turfs", /datum/element/bullet_trait_damage_boost, 0.23, GLOB.damage_boost_turfs_xeno), //2550*0.23 = 586, 2 taps resin walls, 3 taps thick resin
 		BULLET_TRAIT_ENTRY_ID("breaching", /datum/element/bullet_trait_damage_boost, 15, GLOB.damage_boost_breaching), //1275, enough to 1 tap airlocks
-		BULLET_TRAIT_ENTRY_ID("xeno_door", /datum/element/bullet_trait_damage_boost, 0.5, GLOB.damage_boost_doors_xeno), // 637.5 one tap normal resin door 2 tap thick resin door
 		BULLET_TRAIT_ENTRY_ID("pylons", /datum/element/bullet_trait_damage_boost, 6, GLOB.damage_boost_pylons) //510, 4 shots to take out a pylon
 	))
 

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -2061,7 +2061,7 @@
 /obj/item/weapon/gun/rifle/xm51/set_bullet_traits()
 	LAZYADD(traits_to_give, list(
 		BULLET_TRAIT_ENTRY_ID("turfs", /datum/element/bullet_trait_damage_boost, 30, GLOB.damage_boost_turfs), //2550, 2 taps colony walls
-		BULLET_TRAIT_ENTRY_ID("rwalls", /datum/element/bullet_trait_damage_boost, 0.44, GLOB.daamge_boost_rwall), // 1147, 7 taps for rwall
+		BULLET_TRAIT_ENTRY_ID("rwalls", /datum/element/bullet_trait_damage_boost, 0.51, GLOB.daamge_boost_rwall), // 1147, 7 taps for rwall
 		BULLET_TRAIT_ENTRY_ID("xeno turfs", /datum/element/bullet_trait_damage_boost, 0.23, GLOB.damage_boost_turfs_xeno), //2550*0.23 = 586, 2 taps resin walls, 3 taps thick resin
 		BULLET_TRAIT_ENTRY_ID("breaching", /datum/element/bullet_trait_damage_boost, 15, GLOB.damage_boost_breaching), //1275, enough to 1 tap airlocks
 		BULLET_TRAIT_ENTRY_ID("pylons", /datum/element/bullet_trait_damage_boost, 6, GLOB.damage_boost_pylons) //510, 4 shots to take out a pylon


### PR DESCRIPTION
# About the pull request
Nerfs XM51 breaching power
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
The map have become too destructible, get two or three guys with XM51 and the entire frontline becomes an open field while previously you had to use precious C4, Breaching charges or even deconstruct which takes a *lot* of time, to this end the damage to rwalls for XM51 has been reduced significantly, increasing the amounts of shots you need from 4 to 7 and the amount of breacing shells you can carry has been reduced (by nerfing the ammo box max capacity)
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Nerfed XM51 bonus damage against reinforced walls.
balance: Reduced amount of breaching shells its ammo box can carry from 120 to 60.
/:cl:
