### PR TITLE
mags to loose ammo boxes linked

### DIFF
--- a/code/modules/projectiles/ammo_boxes/ammo_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/ammo_boxes.dm
@@ -18,6 +18,9 @@
 	var/handfuls_icon = 'icons/obj/items/weapons/guns/ammo_boxes/handfuls.dmi'
 	var/magazines_icon = 'icons/obj/items/weapons/guns/ammo_boxes/magazines.dmi'
 	var/flames_icon = 'icons/obj/items/weapons/guns/ammo_boxes/misc.dmi'
+	var/obj/item/ammo_magazine/magazine_type = /obj/item/ammo_magazine/rifle //moving it here so that spare rounds also inherit it
+	var/num_of_magazines = 10
+	var/handfuls = FALSE
 
 //---------------------GENERAL PROCS
 
@@ -81,9 +84,6 @@
 	var/overlay_ammo_type = "_reg" //used for ammo type color overlay
 	var/overlay_gun_type = "_m41" //used for text overlay
 	var/overlay_content = "_reg"
-	var/obj/item/ammo_magazine/magazine_type = /obj/item/ammo_magazine/rifle
-	var/num_of_magazines = 10
-	var/handfuls = FALSE
 	var/icon_state_deployed = null
 	var/handful = "shells" //used for 'magazine' boxes that give handfuls to determine what kind for the sprite
 	can_explode = TRUE
@@ -276,6 +276,7 @@
 	var/bullet_amount = 600
 	var/max_bullet_amount = 600
 	var/caliber = "10x24mm"
+	num_of_magazines = 15
 	can_explode = TRUE
 
 /obj/item/ammo_box/rounds/empty

--- a/code/modules/projectiles/ammo_boxes/round_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/round_boxes.dm
@@ -7,6 +7,7 @@
 	desc = "A 10x24mm armor-piercing ammunition box. Used to refill M41A MK2, and M4RA AP magazines. It comes with a leather strap allowing to wear it on the back."
 	overlay_content = "_ap"
 	default_ammo = /datum/ammo/bullet/rifle/ap
+	magazine_type =/obj/item/ammo_magazine/rifle/ap
 
 /obj/item/ammo_box/rounds/ap/empty
 	empty = TRUE
@@ -16,6 +17,7 @@
 	desc = "A 10x24mm armor-shredding ammunition box. Used to refill M41A MK2 LE magazines. It comes with a leather strap allowing to wear it on the back."
 	overlay_content = "_le"
 	default_ammo = /datum/ammo/bullet/rifle/le
+	magazine_type =/obj/item/ammo_magazine/rifle/le
 
 /obj/item/ammo_box/rounds/le/empty
 	empty = TRUE
@@ -27,6 +29,8 @@
 	default_ammo = /datum/ammo/bullet/rifle/incendiary
 	bullet_amount = 400 //Incen is OP
 	max_bullet_amount = 400
+	magazine_type =/obj/item/ammo_magazine/rifle/incendiary
+	num_of_magazines = 10
 
 /obj/item/ammo_box/rounds/incen/empty
 	empty = TRUE
@@ -36,19 +40,22 @@
 	desc = "A 10x24mm high-explosive armor-piercing ammunition box. Used to refill magazines. It comes with a leather strap allowing to wear it on the back."
 	overlay_content = "_heap"
 	default_ammo = /datum/ammo/bullet/rifle/heap
+	magazine_type =/obj/item/ammo_magazine/rifle/heap
 
 /obj/item/ammo_box/rounds/heap/empty
 	empty = TRUE
 
-//----------------10x20mm Ammunition Boxes (for M39 SMG)------------------
+//----------------10x20mm Ammunition Boxes (for M10/M39 SMG)------------------
 
 /obj/item/ammo_box/rounds/smg
 	name = "\improper SMG HV ammunition box (10x20mm)"
-	desc = "A 10x20mm ammunition box. Used to refill M39 HV and extended magazines. It comes with a leather strap allowing to wear it on the back."
+	desc = "A 10x20mm HV ammunition box. Used to refill M10 and M39 standard, extended, and M10 drum magazines. It comes with a leather strap allowing to wear it on the back."
 	caliber = "10x20mm"
 	icon_state = "base_m39"
 	overlay_content = "_hv"
 	default_ammo = /datum/ammo/bullet/smg/m39
+	magazine_type = /obj/item/ammo_magazine/pistol/m10 // Uses M10 mags since they are an even 15 to the 12.5 of M39 Mags
+	num_of_magazines = 15
 
 /obj/item/ammo_box/rounds/smg/empty
 	empty = TRUE
@@ -59,6 +66,8 @@
 	caliber = "10x20mm"
 	overlay_content = "_ap"
 	default_ammo = /datum/ammo/bullet/smg/ap
+	magazine_type = /obj/item/ammo_magazine/smg/m39/ap
+	num_of_magazines = 13 // 600/48 = 12.5 so either lose half a mag, or have a possible duplication issue.
 
 /obj/item/ammo_box/rounds/smg/ap/empty
 	empty = TRUE
@@ -68,7 +77,10 @@
 	desc = "A 10x20mm armor-shredding ammunition box. Used to refill M39 LE magazines. It comes with a leather strap allowing to wear it on the back."
 	caliber = "10x20mm"
 	overlay_content = "_le"
+	num_of_magazines = 13
 	default_ammo = /datum/ammo/bullet/smg/le
+	magazine_type = /obj/item/ammo_magazine/smg/m39/le
+	num_of_magazines = 13
 
 /obj/item/ammo_box/rounds/smg/le/empty
 	empty = TRUE
@@ -81,6 +93,8 @@
 	default_ammo = /datum/ammo/bullet/smg/incendiary
 	bullet_amount = 400 //Incen is OP
 	max_bullet_amount = 400
+	magazine_type = /obj/item/ammo_magazine/smg/m39/incendiary
+	num_of_magazines = 8
 
 /obj/item/ammo_box/rounds/smg/incen/empty
 	empty = TRUE
@@ -91,6 +105,8 @@
 	caliber = "10x20mm"
 	overlay_content = "_heap"
 	default_ammo = /datum/ammo/bullet/smg/heap
+	magazine_type = /obj/item/ammo_magazine/smg/m39/heap
+	num_of_magazines = 13
 
 /obj/item/ammo_box/rounds/smg/heap/empty
 	empty = TRUE
@@ -105,6 +121,8 @@
 	overlay_content = "_type71_reg"
 	caliber = "5.45x39mm"
 	default_ammo = /datum/ammo/bullet/rifle/type71
+	magazine_type = /obj/item/ammo_magazine/rifle/type71
+	num_of_magazines = 10
 
 /obj/item/ammo_box/rounds/type71/empty
 	empty = TRUE
@@ -116,6 +134,8 @@
 	overlay_gun_type = "_rounds_type71"
 	overlay_content = "_type71_ap"
 	default_ammo = /datum/ammo/bullet/rifle/type71/ap
+	magazine_type = /obj/item/ammo_magazine/rifle/type71/ap
+	num_of_magazines = 10
 
 /obj/item/ammo_box/rounds/type71/ap/empty
 	empty = TRUE
@@ -127,6 +147,8 @@
 	overlay_gun_type = "_rounds_type71"
 	overlay_content = "_type71_heap"
 	default_ammo = /datum/ammo/bullet/rifle/type71/heap
+	magazine_type = /obj/item/ammo_magazine/rifle/type71/heap
+	num_of_magazines = 10
 
 /obj/item/ammo_box/rounds/type71/heap/empty
 	empty = TRUE
@@ -140,6 +162,8 @@
 	icon_state = "base_m4a3"
 	overlay_content = "_reg"
 	default_ammo = /datum/ammo/bullet/pistol
+	magazine_type = /obj/item/ammo_magazine/pistol
+	num_of_magazines = 50
 
 /obj/item/ammo_box/rounds/pistol/empty
 	empty = TRUE
@@ -149,6 +173,8 @@
 	desc = "A 9mm armor-piercing ammunition box. Used to refill mod88 and M4A3 magazines. It comes with a leather strap allowing to wear it on the back."
 	overlay_content = "_ap"
 	default_ammo = /datum/ammo/bullet/pistol/ap
+	magazine_type = /obj/item/ammo_magazine/pistol/ap
+	num_of_magazines = 50
 
 /obj/item/ammo_box/rounds/pistol/ap/empty
 	empty = TRUE
@@ -158,6 +184,8 @@
 	desc = "A 9mm hollow-point ammunition box. Used to refill M4A3 magazines. It comes with a leather strap allowing to wear it on the back."
 	overlay_content = "_hp"
 	default_ammo = /datum/ammo/bullet/pistol/hollow
+	magazine_type = /obj/item/ammo_magazine/pistol/hp
+	num_of_magazines = 50
 
 /obj/item/ammo_box/rounds/pistol/hp/empty
 	empty = TRUE
@@ -167,6 +195,10 @@
 	desc = "A 9mm incendiary ammunition box. Used to refill M4A3 magazines. It comes with a leather strap allowing to wear it on the back."
 	overlay_content = "_incen"
 	default_ammo = /datum/ammo/bullet/pistol/incendiary
+	bullet_amount = 400 //Incen is OP
+	max_bullet_amount = 400
+	magazine_type = /obj/item/ammo_magazine/pistol/incendiary
+	num_of_magazines = 34
 
 /obj/item/ammo_box/rounds/pistol/incen/empty
 	empty = TRUE

--- a/code/modules/projectiles/item_to_box_mapping.dm
+++ b/code/modules/projectiles/item_to_box_mapping.dm
@@ -29,7 +29,7 @@
 
 /datum/item_to_box_mapping/New()
 	//Ammo magazine boxes, minus loose ammo boxes
-	for(var/obj/item/ammo_box/magazine/ammo_box as anything in typesof(/obj/item/ammo_box/magazine) - /obj/item/ammo_box/magazine/misc - /obj/item/ammo_box/magazine/shotgun/light)
+	for(var/obj/item/ammo_box/ammo_box as anything in typesof(/obj/item/ammo_box) - /obj/item/ammo_box/magazine/misc - /obj/item/ammo_box/magazine/shotgun/light)
 		if(initial(ammo_box.empty))
 			//Ignore all the empty boxes
 			continue

--- a/code/modules/projectiles/item_to_box_mapping.dm
+++ b/code/modules/projectiles/item_to_box_mapping.dm
@@ -28,7 +28,7 @@
 	item_to_box_list[item_box_pairing.item].item_box_pairings += item_box_pairing
 
 /datum/item_to_box_mapping/New()
-	//Ammo magazine boxes, minus loose ammo boxes
+	//Ammo magazine boxes and loose ammo boxes
 	for(var/obj/item/ammo_box/ammo_box as anything in typesof(/obj/item/ammo_box) - /obj/item/ammo_box/magazine/misc - /obj/item/ammo_box/magazine/shotgun/light)
 		if(initial(ammo_box.empty))
 			//Ignore all the empty boxes


### PR DESCRIPTION
# About the pull request

links loose ammo boxes to mags in req vendor, need correct mag links and counts

# Explain why it's good for the game
this was promissed change for a long while aperently


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:cuberound; Canyew
qol: loose boxes with mag ratio added to requestion ammo vendor
/:cl:
