### PR TITLE
You can no longer half understand random stuff xenos say

### DIFF
--- a/code/modules/mob/language/languages.dm
+++ b/code/modules/mob/language/languages.dm
@@ -134,6 +134,7 @@
 	ask_verb = "hisses"
 	exclaim_verb = "hisses"
 	key = "x"
+	syllables = list("sss", "sSs", "SSS")
 	flags = RESTRICTED
 
 /datum/language/xenos


### PR DESCRIPTION
# About the pull request

Replaces this:

![5IRs48htXc](https://github.com/user-attachments/assets/63b0e037-56b7-4a77-a137-bad6022da1e7)

With this:
![dreamseeker_RxAMijpc8Z](https://github.com/user-attachments/assets/8c9ad9c5-c7b9-48d8-a1d7-026506d7dc02)


# Explain why it's good for the game

Their "speech" isn't supposed to be understood in a coherent way, this fixes that

</details>


# Changelog
:cl:
fix: people that don't understand xeno speech won't see random letters from the words xenos say
/:cl:
