### PR TITLE
voteweight on br lv cc

### DIFF
--- a/map_config/maps.txt
+++ b/map_config/maps.txt
@@ -56,6 +56,7 @@ map sorokyne_strata
 endmap
 
 map lv522_chances_claim
+	voteweight 0.5
 endmap
 
 map lv759_hybrisa_prospera

--- a/map_config/maps.txt
+++ b/map_config/maps.txt
@@ -14,9 +14,11 @@ endmap
 
 map lv624
 	default
+	voteweight 0.5
 endmap
 
 map bigredv2
+	voteweight 0.5
 endmap
 
 map prison_station_fop


### PR DESCRIPTION

# About the pull request

each vote is 0.5 vote when it comes to lv 624 big red and chances claim

# Explain why it's good for the game

Stats of last two months show that the picked three maps get picked twice as often as other maps. Often the reason given is that players do not know the other maps and how can they when they do not get played. This aims to get players to learn and enjoy other maps. This might get reverted in few months 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
config: 0.5 voteweight on lv 624, big red and chances claim
/:cl:
