### PR TITLE
516 byondstorage can fail to appear for a bit for some reason

### DIFF
--- a/tgui/packages/common/storage.js
+++ b/tgui/packages/common/storage.js
@@ -148,7 +148,17 @@ class IndexedDbBackend {
 class StorageProxy {
   constructor() {
     this.backendPromise = (async () => {
-      if (!Byond.TRIDENT && testHubStorage()) {
+      if (!Byond.TRIDENT) {
+        if (!testHubStorage()) {
+          return new Promise((resolve) => {
+            const listener = () => {
+              document.removeEventListener('byondstorageupdated', listener);
+              resolve(new HubStorageBackend());
+            };
+
+            document.addEventListener('byondstorageupdated', listener);
+          });
+        }
         return new HubStorageBackend();
       }
       // TODO: Remove with 516


### PR DESCRIPTION
so we just wait for it to appear instead

:cl:
fix: on 516, sometimes the storage backend would not find your preferences correctly. this is fixed, but you still need to be on version 516.1650+
/:cl: