### PR TITLE
Multi faction hud support for headsets

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/sea.dm
+++ b/code/game/machinery/vending/vendor_types/crew/sea.dm
@@ -32,7 +32,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_sea, list(
 		list("Officer Uniform", 0, /obj/item/clothing/under/marine/dress, MARINE_CAN_BUY_UNIFORM, VENDOR_ITEM_MANDATORY),
 		list("USCM Service Jacket", 0, /obj/item/clothing/suit/storage/jacket/marine/service, MARINE_CAN_BUY_ARMOR, VENDOR_ITEM_REGULAR),
 		list("Marine Combat Boots", 0, /obj/item/clothing/shoes/marine/knife, MARINE_CAN_BUY_SHOES, VENDOR_ITEM_MANDATORY),
-		list("Headset", 0, /obj/item/device/radio/headset/almayer/mcom/cdrcom, MARINE_CAN_BUY_EAR, VENDOR_ITEM_MANDATORY),
+		list("Headset", 0, /obj/item/device/radio/headset/almayer/mcom/sea, MARINE_CAN_BUY_EAR, VENDOR_ITEM_MANDATORY),
 		list("Satchel", 0, /obj/item/storage/backpack/satchel/lockable, MARINE_CAN_BUY_BACKPACK, VENDOR_ITEM_MANDATORY),
 		list("MRE", 0, /obj/item/storage/box/MRE, MARINE_CAN_BUY_MRE, VENDOR_ITEM_MANDATORY),
 

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -39,7 +39,8 @@
 	var/headset_hud_on = FALSE
 	var/locate_setting = TRACKER_SL
 	var/misc_tracking = FALSE
-	var/hud_type = MOB_HUD_FACTION_MARINE
+	var/hud_type = MOB_HUD_FACTION_MARINE //Main faction hud. This determines minimap icons and tracking stuff
+	var/list/additional_hud_types = list() //Additional faction huds, doesn't change minimap icon or similar
 	var/default_freq
 
 	///The type of minimap this headset is added to
@@ -263,6 +264,9 @@
 		if(headset_hud_on)
 			var/datum/mob_hud/H = GLOB.huds[hud_type]
 			H.add_hud_to(user, src)
+			for(var/per_faction_hud in additional_hud_types)
+				var/datum/mob_hud/alt_hud = GLOB.huds[per_faction_hud]
+				alt_hud.add_hud_to(user, src)
 			//squad leader locator is no longer invisible on our player HUD.
 			if(user.mind && (user.assigned_squad || misc_tracking) && user.hud_used && user.hud_used.locate_leader)
 				user.show_hud_tracker()
@@ -282,6 +286,10 @@
 	if(istype(user) && user.has_item_in_ears(src)) //dropped() is called before the inventory reference is update.
 		var/datum/mob_hud/H = GLOB.huds[hud_type]
 		H.remove_hud_from(user, src)
+		for(var/per_faction_hud in additional_hud_types)
+			var/datum/mob_hud/alt_hud = GLOB.huds[per_faction_hud]
+			alt_hud.remove_hud_from(user, src)
+
 		//squad leader locator is invisible again
 		if(user.hud_used && user.hud_used.locate_leader)
 			user.hide_hud_tracker()
@@ -315,6 +323,9 @@
 			var/datum/mob_hud/H = GLOB.huds[hud_type]
 			if(headset_hud_on)
 				H.add_hud_to(usr, src)
+				for(var/per_faction_hud in additional_hud_types)
+					var/datum/mob_hud/alt_hud = GLOB.huds[per_faction_hud]
+					alt_hud.add_hud_to(usr, src)
 				if(user.mind && (misc_tracking || user.assigned_squad) && user.hud_used?.locate_leader)
 					user.show_hud_tracker()
 				if(misc_tracking)
@@ -322,6 +333,9 @@
 				update_minimap_icon()
 			else
 				H.remove_hud_from(usr, src)
+				for(var/per_faction_hud in additional_hud_types)
+					var/datum/mob_hud/alt_hud = GLOB.huds[per_faction_hud]
+					alt_hud.remove_hud_from(usr, src)
 				if(user.hud_used?.locate_leader)
 					user.hide_hud_tracker()
 				if(misc_tracking)
@@ -583,7 +597,7 @@
 	icon_state = "wy_headset"
 	maximum_keys = 5
 	initial_keys = list(/obj/item/device/encryptionkey/mcom/cl)
-
+	additional_hud_types = list(MOB_HUD_FACTION_WY, MOB_HUD_FACTION_PMC)
 	spy_bug_type = /obj/item/device/radio/listening_bug/radio_linked/fax/wy
 
 /obj/item/device/radio/headset/almayer/mcl/Initialize()
@@ -606,6 +620,7 @@
 	desc = "Issued only to senior command staff. Channels are as follows: :v - marine command, :p - military police, :a - alpha squad, :b - bravo squad, :c - charlie squad, :d - delta squad, :n - engineering, :m - medbay, :u - requisitions, :j - JTAC,  :t - intel"
 	icon_state = "mco_headset"
 	initial_keys = list(/obj/item/device/encryptionkey/cmpcom/cdrcom)
+	additional_hud_types = list(MOB_HUD_FACTION_WY, MOB_HUD_FACTION_CMB)
 	volume = RADIO_VOLUME_CRITICAL
 
 /obj/item/device/radio/headset/almayer/mcom/sea
@@ -1016,6 +1031,7 @@
 	inbuilt_tracking_options = list(
 		"Corporate Liaison" = TRACKER_CL
 	)
+	additional_hud_types = list(MOB_HUD_FACTION_WY)
 
 /obj/item/device/radio/headset/distress/cbrn
 	name = "\improper CBRN headset"
@@ -1060,10 +1076,12 @@
 	name = "PMC-CMD headset"
 	desc = "A special headset used by corporate personnel. Channels are as follows: :o - colony, #z - command, #f - medical, #e - engineering, #o - JTAC, #p - general"
 	initial_keys = list(/obj/item/device/encryptionkey/colony, /obj/item/device/encryptionkey/pmc/command, /obj/item/device/encryptionkey/mcom/cl)
+	additional_hud_types = list(MOB_HUD_FACTION_MARINE, MOB_HUD_FACTION_WY)
 
 /obj/item/device/radio/headset/distress/pmc/command/hvh
 	initial_keys = list(/obj/item/device/encryptionkey/colony, /obj/item/device/encryptionkey/pmc/command)
 	misc_tracking = FALSE
+	additional_hud_types = list(MOB_HUD_FACTION_WY)
 
 /obj/item/device/radio/headset/distress/pmc/command/director
 	name = "WY director headset"
@@ -1175,6 +1193,7 @@
 	initial_keys = list(/obj/item/device/encryptionkey/cmb)
 	has_hud = TRUE
 	hud_type = MOB_HUD_FACTION_CMB
+	additional_hud_types = MOB_HUD_FACTION_MARINE
 
 /obj/item/device/radio/headset/distress/CMB/limited
 	name = "\improper Damaged CMB Earpiece"
@@ -1195,6 +1214,7 @@
 	initial_keys = list(/obj/item/device/encryptionkey/public, /obj/item/device/encryptionkey/royal_marine)
 	has_hud = TRUE
 	hud_type = MOB_HUD_FACTION_NSPA
+	additional_hud_types = MOB_HUD_FACTION_TWE
 	volume = RADIO_VOLUME_IMPORTANT
 
 /obj/item/device/radio/headset/almayer/highcom

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -540,6 +540,12 @@
 	icon_state = "sec_headset"
 	additional_hud_types = list(MOB_HUD_FACTION_CMB)
 	initial_keys = list(/obj/item/device/encryptionkey/mmpo)
+	locate_setting = TRACKER_CMP
+	misc_tracking = TRUE
+
+	inbuilt_tracking_options = list(
+		"Chief MP" = TRACKER_CMP,
+	)
 
 /obj/item/device/radio/headset/almayer/marine/mp_honor
 	name = "marine honor guard radio headset"
@@ -553,6 +559,7 @@
 
 	inbuilt_tracking_options = list(
 		"Commanding Officer" = TRACKER_CO,
+		"Chief MP" = TRACKER_CMP,
 		"Executive Officer" = TRACKER_XO
 	)
 

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -538,6 +538,7 @@
 	name = "marine military police radio headset"
 	desc = "This is used by marine military police members. Channels are as follows: :p - military police, :v - marine command. :a - alpha squad, :b - bravo squad, :c - charlie squad, :d - delta squad."
 	icon_state = "sec_headset"
+	additional_hud_types = list(MOB_HUD_FACTION_CMB)
 	initial_keys = list(/obj/item/device/encryptionkey/mmpo)
 
 /obj/item/device/radio/headset/almayer/marine/mp_honor
@@ -545,6 +546,7 @@
 	desc = "This is used by members of the marine honor guard. Channels are as follows: :p - military police, :v - marine command. :a - alpha squad, :b - bravo squad, :c - charlie squad, :d - delta squad."
 	icon_state = "sec_headset"
 	initial_keys = list(/obj/item/device/encryptionkey/mmpo)
+	additional_hud_types = list(MOB_HUD_FACTION_CMB)
 	volume = RADIO_VOLUME_RAISED
 	locate_setting = TRACKER_CO
 	misc_tracking = TRUE
@@ -558,6 +560,7 @@
 	name = "marine chief MP radio headset"
 	desc = "For discussing the purchase of donuts and arresting of hooligans. Channels are as follows: :v - marine command, :p - military police, :n - engineering, :m - medbay, :u - requisitions, :a - alpha squad, :b - bravo squad, :c - charlie squad, :d - delta squad."
 	icon_state = "sec_headset"
+	additional_hud_types = list(MOB_HUD_FACTION_CMB, MOB_HUD_FACTION_WY)
 	initial_keys = list(/obj/item/device/encryptionkey/cmpcom)
 	volume = RADIO_VOLUME_CRITICAL
 
@@ -1204,6 +1207,7 @@
 	name = "\improper ICC Liaison Headset"
 	desc = "An expensive headset used by The Interstellar Commerce Commission. This one in particular has a liaison chip with the CMB. Featured channels include: ; - CMB, :o - Colony, :g - public, :v - marine command, :m - medbay, :t - intel, :y - Weyland-Yutani."
 	icon_state = "wy_headset"
+	additional_hud_types = list(MOB_HUD_FACTION_WY)
 	initial_keys = list(/obj/item/device/encryptionkey/WY, /obj/item/device/encryptionkey/cmb)
 
 /obj/item/device/radio/headset/distress/NSPA
@@ -1223,6 +1227,7 @@
 	icon_state = "mhc_headset"
 	frequency = HC_FREQ
 	initial_keys = list(/obj/item/device/encryptionkey/highcom)
+	additional_hud_types = list(MOB_HUD_FACTION_WY, MOB_HUD_FACTION_CMB, MOB_HUD_FACTION_TWE)
 	volume = RADIO_VOLUME_CRITICAL
 
 /obj/item/device/radio/headset/almayer/provost
@@ -1231,6 +1236,7 @@
 	icon_state = "pvst_headset"
 	frequency = PVST_FREQ
 	initial_keys = list(/obj/item/device/encryptionkey/provost)
+	additional_hud_types = list(MOB_HUD_FACTION_CMB)
 	volume = RADIO_VOLUME_CRITICAL
 
 /obj/item/device/radio/headset/almayer/sof
@@ -1239,6 +1245,7 @@
 	icon_state = "soc_headset"
 	frequency = SOF_FREQ
 	initial_keys = list(/obj/item/device/encryptionkey/soc)
+	additional_hud_types = list(MOB_HUD_FACTION_WY, MOB_HUD_FACTION_CMB, MOB_HUD_FACTION_TWE)
 	volume = RADIO_VOLUME_IMPORTANT
 
 /obj/item/device/radio/headset/almayer/sof/survivor_forecon

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -1193,7 +1193,7 @@
 	initial_keys = list(/obj/item/device/encryptionkey/cmb)
 	has_hud = TRUE
 	hud_type = MOB_HUD_FACTION_CMB
-	additional_hud_types = MOB_HUD_FACTION_MARINE
+	additional_hud_types = list(MOB_HUD_FACTION_MARINE)
 
 /obj/item/device/radio/headset/distress/CMB/limited
 	name = "\improper Damaged CMB Earpiece"
@@ -1214,7 +1214,7 @@
 	initial_keys = list(/obj/item/device/encryptionkey/public, /obj/item/device/encryptionkey/royal_marine)
 	has_hud = TRUE
 	hud_type = MOB_HUD_FACTION_NSPA
-	additional_hud_types = MOB_HUD_FACTION_TWE
+	additional_hud_types = list(MOB_HUD_FACTION_TWE)
 	volume = RADIO_VOLUME_IMPORTANT
 
 /obj/item/device/radio/headset/almayer/highcom

--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -51,7 +51,7 @@
 	skills = /datum/skills/civilian
 
 	minimap_icon = "cl"
-	minimap_background = "background_civillian"
+	minimap_background = "background_goon"
 
 	dress_under = list(
 		/obj/item/clothing/under/liaison_suit/black,


### PR DESCRIPTION
# About the pull request

Adds support for a headset to have additional faction huds, currently list as follows:

CL can see Marine, PMC, WY

XO, CO can see Marine, WY, CMB

All CMB can see Marine, CMB

All NSPA can see TWE, NSPA

All PMCs can see WY, PMC

PMC command can see Marine, PMC, WY (they can't see Marine in hvh preset)

All MP and HG can see CMB, CMP can also see WY

This pr is a nice additon to https://github.com/cmss13-devs/cmss13/pull/8088 , especially to CL, since CL has a hud icon themselves now

All credit for code to bibby01 aka Thomas Neumann, big thank to him

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![dreamseeker_SZeuLzwct7](https://github.com/user-attachments/assets/375bdb8a-3047-4962-b3e1-6debc1a1e2dd)


</details>


# Changelog
:cl:
add: adds support for a headset to have multiple faction huds, instead of being harcoded to one main one
add: some headsets can now see multiple huds: CL can see USCM, WY, PMC; CO, XO can see USCM, WY, CMB, etc
add: mp and hg headsets can now track cmp
fix: cl having incorrect minimap/orbit icon
/:cl:
