### PR TITLE
Human deathcheck

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -23,6 +23,11 @@
 	med_hud_set_armor()
 	med_hud_set_status()
 
+	if(health <= HEALTH_THRESHOLD_DEAD || (species.has_organ["brain"] && !has_brain()))
+		death(last_damage_data)
+		blinded = TRUE
+		silent = 0
+		return
 
 
 /mob/living/carbon/human/adjustBrainLoss(amount)

--- a/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
@@ -9,12 +9,6 @@
 		blinded = TRUE
 		silent = 0
 	else //ALIVE. LIGHTS ARE ON
-		if(health <= HEALTH_THRESHOLD_DEAD || (species.has_organ["brain"] && !has_brain()))
-			death(last_damage_data)
-			blinded = TRUE
-			silent = 0
-			return 1
-
 		if(regular_update)
 			if(hallucination)
 				if(hallucination >= 20)


### PR DESCRIPTION

# About the pull request
#582 but for humans
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Delayed deaths on a laggy server isn't very great (same reasoning as #582 )
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
code: Humans now check for death on updatehealth, meaning they die as soon as they cross the 200 damage mark.
/:cl:
