### PR TITLE
upp squad chat color

### DIFF
--- a/code/datums/factions/upp.dm
+++ b/code/datums/factions/upp.dm
@@ -2,15 +2,15 @@
 	name = "Union of Progressive Peoples"
 	faction_tag = FACTION_UPP
 
-/datum/faction/upp/modify_hud_holder(image/holder, mob/living/carbon/human/H)
+/datum/faction/upp/modify_hud_holder(image/holder, mob/living/carbon/human/human)
 	var/hud_icon_state
-	var/obj/item/card/id/ID = H.get_idcard()
+	var/obj/item/card/id/ID = human.get_idcard()
 	var/default_color = FALSE //so squad units get red icons as survs and ERT
-	var/datum/squad/squad = H.assigned_squad
+	var/datum/squad/squad = human.assigned_squad
 
 	var/_role
-	if(H.mind)
-		_role = H.job
+	if(human.mind)
+		_role = human.job
 	else if(ID)
 		_role = ID.rank
 	switch(_role)
@@ -57,14 +57,14 @@
 		if(JOB_UPP_COMMISSAR)
 			hud_icon_state = "commi"
 	if(hud_icon_state)
-		holder.overlays += image('icons/mob/hud/marine_hud.dmi', H, "upp_background")
-		var/image/rank_icon_image = image('icons/mob/hud/marine_hud.dmi', H, "upp_[hud_icon_state]")
+		holder.overlays += image('icons/mob/hud/marine_hud.dmi', human, "upp_background")
+		var/image/rank_icon_image = image('icons/mob/hud/marine_hud.dmi', human, "upp_[hud_icon_state]")
 		if(istype(squad))
+			human.langchat_color = human.assigned_squad.chat_color
 			rank_icon_image.color = squad.equipment_color
-			var/image/squad_circle = image('icons/mob/hud/marine_hud.dmi', H, "upp_squad_circle")
+			var/image/squad_circle = image('icons/mob/hud/marine_hud.dmi', human, "upp_squad_circle")
 			squad_circle.color = squad.equipment_color
 			holder.overlays += squad_circle
-			H.langchat_color = H.assigned_squad.chat_color
 		else
 			if(default_color)
 				rank_icon_image.color = "#e61919"

--- a/code/datums/factions/upp.dm
+++ b/code/datums/factions/upp.dm
@@ -64,6 +64,7 @@
 			var/image/squad_circle = image('icons/mob/hud/marine_hud.dmi', H, "upp_squad_circle")
 			squad_circle.color = squad.equipment_color
 			holder.overlays += squad_circle
+			H.langchat_color = H.assigned_squad.chat_color
 		else
 			if(default_color)
 				rank_icon_image.color = "#e61919"


### PR DESCRIPTION

# About the pull request

above head upp chats use their chat color

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: UPP abovehead text respects squad color
/:cl:
