### PR TITLE
decal burning fix for negative offsets

### DIFF
--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -17,6 +17,13 @@
 /obj/effect/decal/LateInitialize()
 	. = ..()
 	var/turf/applied_turf = get_turf(src)
+	while(pixel_x < 0) //we offset east and walk west to display the decal on correct place, it NEEDS positive offsets
+		pixel_x += 32
+		applied_turf = get_step(applied_turf, WEST)
+	while(pixel_y < 0)
+		pixel_y += 32
+		applied_turf = get_step(applied_turf, SOUTH)
+
 
 	if(!applied_turf)
 		qdel(src)


### PR DESCRIPTION

# About the pull request

negative offsets made decals disapear, pr walks to nearest tile taht gives positive offsets while keeping the decal on the exact same place

# Explain why it's good for the game

no more voided decals


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: fixes voiding of decals with negative values
/:cl:
