### PR TITLE
Nerfs synthetic stun resistance.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/synthetic.dm
+++ b/code/modules/mob/living/carbon/human/species/synthetic.dm
@@ -88,8 +88,8 @@
 
 	default_lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 
-	knock_down_reduction = 3.5
-	stun_reduction = 3.5
+	knock_down_reduction = 2.5
+	stun_reduction = 2.5
 
 
 /datum/species/synthetic/colonial/colonial_gen_two

--- a/code/modules/mob/living/carbon/human/species/synthetic.dm
+++ b/code/modules/mob/living/carbon/human/species/synthetic.dm
@@ -38,8 +38,8 @@
 		"brain" = /datum/internal_organ/brain/prosthetic,
 		)
 
-	knock_down_reduction = 5
-	stun_reduction = 5
+	knock_down_reduction = 2.5
+	stun_reduction = 2.5
 	acid_blood_dodge_chance = 25
 
 	inherent_verbs = list(


### PR DESCRIPTION
# About the pull request
Reduces synthetic stun resistance by 'half'

# Explain why it's good for the game

Requested by the synth senator

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: The base synthetic stun resistances have been cut in half, from 5 to 2.5
/:cl:
