### PR TITLE
Removes reset key unintended medical skill lock, engi skill clarity message

### DIFF
--- a/code/game/objects/items/devices/defibrillator.dm
+++ b/code/game/objects/items/devices/defibrillator.dm
@@ -330,7 +330,7 @@
 	force = 0
 	throwforce = 0
 	skill_to_check = SKILL_ENGINEER
-	skill_level = SKILL_ENGINEER_ENGI
+	skill_level = SKILL_ENGINEER_TRAINED
 	blocked_by_suit = FALSE
 	should_spark = FALSE
 

--- a/code/game/objects/items/devices/defibrillator.dm
+++ b/code/game/objects/items/devices/defibrillator.dm
@@ -353,6 +353,10 @@
 	if(ready)
 		icon_state += "_on"
 
+/obj/item/device/defibrillator/synthetic/get_examine_text(mob/user)
+	. = ..()
+	. += SPAN_NOTICE("You need some electronics and circuitry understanding to use this.")
+
 /obj/item/device/defibrillator/synthetic/check_revive(mob/living/carbon/human/H, mob/living/carbon/human/user)
 	if(!issynth(H))
 		to_chat(user, SPAN_WARNING("You can't use a [src] on a living being!"))

--- a/code/game/objects/items/devices/defibrillator.dm
+++ b/code/game/objects/items/devices/defibrillator.dm
@@ -355,7 +355,7 @@
 
 /obj/item/device/defibrillator/synthetic/get_examine_text(mob/user)
 	. = ..()
-	. += SPAN_NOTICE("You need some electronics and circuitry understanding to use this.")
+	. += SPAN_NOTICE("You need some knowledge of electronics and circuitry to use this.")
 
 /obj/item/device/defibrillator/synthetic/check_revive(mob/living/carbon/human/H, mob/living/carbon/human/user)
 	if(!issynth(H))

--- a/code/game/objects/items/devices/defibrillator.dm
+++ b/code/game/objects/items/devices/defibrillator.dm
@@ -329,8 +329,8 @@
 	charge_cost = 1000
 	force = 0
 	throwforce = 0
-	skill_to_check_alt = SKILL_ENGINEER
-	skill_level_alt = SKILL_ENGINEER_ENGI
+	skill_to_check = SKILL_ENGINEER
+	skill_level = SKILL_ENGINEER_ENGI
 	blocked_by_suit = FALSE
 	should_spark = FALSE
 


### PR DESCRIPTION
# About the pull request

Removes medical skill lock and only leaves engineer ones, adds a message hinting what skill you need to use it

It having a medical skill lock was not intended by me when i redid the key in forest's pr

# Explain why it's good for the game

It's an engineering tool, not a medical one, also brings clarity to that

![dreamseeker_RZ40tgNsTQ](https://github.com/user-attachments/assets/d8e3d0f6-8f7e-4571-b352-438fb07602e7)


# Changelog
:cl:
add: synth reset key no longer has medical skillock and has a hint to it being engi skill locked in description
balance: change synth key skill level from engi to trained (you can use key after reading engi pamphlet)
/:cl:
