### PR TITLE
makes synthetics unable to grab large xenomorphs

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -751,7 +751,9 @@
 	return ..()
 
 /mob/living/carbon/xenomorph/pull_response(mob/puller)
-	if(stat != DEAD && has_species(puller,"Human")) // If the Xeno is alive, fight back against a grab/pull
+	if(stat == DEAD)
+		return TRUE
+	if(has_species(puller,"Human")) // If the Xeno is alive, fight back against a grab/pull
 		var/mob/living/carbon/human/H = puller
 		if(H.ally_of_hivenumber(hivenumber))
 			return TRUE
@@ -759,7 +761,7 @@
 		playsound(puller.loc, 'sound/weapons/pierce.ogg', 25, 1)
 		puller.visible_message(SPAN_WARNING("[puller] tried to pull [src] but instead gets a tail swipe to the head!"))
 		return FALSE
-	if(stat != DEAD && issynth(puller) && (mob_size >= 4 || istype(src, /mob/living/carbon/xenomorph/warrior)))
+	if(issynth(puller) && (mob_size >= 4 || istype(src, /mob/living/carbon/xenomorph/warrior)))
 		var/mob/living/carbon/human/synthetic/puller_synth = puller
 		if(puller_synth.ally_of_hivenumber(hivenumber))
 			return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -759,6 +759,18 @@
 		playsound(puller.loc, 'sound/weapons/pierce.ogg', 25, 1)
 		puller.visible_message(SPAN_WARNING("[puller] tried to pull [src] but instead gets a tail swipe to the head!"))
 		return FALSE
+	if(stat != DEAD && (issynth(puller)) && ((mob_size >= 4) || (istype(src, /mob/living/carbon/xenomorph/warrior))))
+		var/mob/living/carbon/human/synthetic/puller_synth = puller
+		var/facing = get_dir(src, puller)
+		if(puller_synth.ally_of_hivenumber(hivenumber))
+			return TRUE
+		puller.apply_effect(1, DAZE)
+		shake_camera(puller, 2, 1)
+		playsound(puller.loc, 'sound/weapons/alien_claw_block.ogg', 25, 1)
+		src.throw_carbon(puller, facing, 1, SPEED_SLOW, shake_camera = FALSE, immobilize = FALSE)
+		puller.apply_effect(get_xeno_stun_duration(puller, 1), WEAKEN)
+		puller.visible_message(SPAN_WARNING("[puller] tried to pull [src] but instead gets whacked in the chest!"))
+		return FALSE
 	return TRUE
 
 /mob/living/carbon/xenomorph/resist_grab(moving_resist)

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -759,15 +759,15 @@
 		playsound(puller.loc, 'sound/weapons/pierce.ogg', 25, 1)
 		puller.visible_message(SPAN_WARNING("[puller] tried to pull [src] but instead gets a tail swipe to the head!"))
 		return FALSE
-	if(stat != DEAD && (issynth(puller)) && ((mob_size >= 4) || (istype(src, /mob/living/carbon/xenomorph/warrior))))
+	if(stat != DEAD && issynth(puller) && (mob_size >= 4 || istype(src, /mob/living/carbon/xenomorph/warrior)))
 		var/mob/living/carbon/human/synthetic/puller_synth = puller
-		var/facing = get_dir(src, puller)
 		if(puller_synth.ally_of_hivenumber(hivenumber))
 			return TRUE
 		puller.apply_effect(1, DAZE)
 		shake_camera(puller, 2, 1)
 		playsound(puller.loc, 'sound/weapons/alien_claw_block.ogg', 25, 1)
-		src.throw_carbon(puller, facing, 1, SPEED_SLOW, shake_camera = FALSE, immobilize = FALSE)
+		var/facing = get_dir(src, puller)
+		throw_carbon(puller, facing, 1, SPEED_SLOW, shake_camera = FALSE, immobilize = FALSE)
 		puller.apply_effect(get_xeno_stun_duration(puller, 1), WEAKEN)
 		puller.visible_message(SPAN_WARNING("[puller] tried to pull [src] but instead gets whacked in the chest!"))
 		return FALSE


### PR DESCRIPTION

# About the pull request

this PR makes synths get tailswiped if they attempt to grab a large xenomorph or a warrior

# Explain why it's good for the game

requested by council

# Testing Photographs and Procedure

<details><summary>Screenshots & Videos</summary>

https://cdn.discordapp.com/attachments/1329614188749914164/1329627707679707159/Timeline_5.mov?ex=678b07cc&is=6789b64c&hm=53deccc26696d13301ccc347f471905f8d922a1e44c3d7d6cfa75d205176bf8c&

this was recorded before adding the warrior check

https://cdn.discordapp.com/attachments/1329614188749914164/1329632525663998065/Timeline_6.mov?ex=678b0c49&is=6789bac9&hm=e732659c96b09fad8f72f4ed63ae812bdfe6f475133e9ec1756432b5296e70eb&

and after

</details>


# Changelog
:cl:
balance:synths can no longer grab large xenos or warriors
/:cl:
