### PR TITLE
Updates xeno wounds on updatehealth

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -509,6 +509,8 @@ Make sure their actual health updates immediately.*/
 	if(!gibbing)
 		med_hud_set_health()
 
+	update_wounds()
+
 /mob/living/carbon/xenomorph/proc/handle_crit()
 	if(stat <= CONSCIOUS && !gibbing)
 		set_stat(UNCONSCIOUS)

--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -328,20 +328,26 @@
 
 	var/health_threshold
 	health_threshold = max(ceil((health * 4) / (maxHealth)), 0) //From 0 to 4, in 25% chunks
+
+	var/new_icon_state
+
 	if(health > HEALTH_THRESHOLD_DEAD)
 		if(health_threshold > 3)
-			wound_icon_holder.icon_state = "none"
+			new_icon_state = "none"
 		else if(body_position == LYING_DOWN)
 			if(!HAS_TRAIT(src, TRAIT_INCAPACITATED) && !HAS_TRAIT(src, TRAIT_FLOORED))
-				wound_icon_holder.icon_state = "[caste.caste_type]_rest_[health_threshold]"
+				new_icon_state = "[caste.caste_type]_rest_[health_threshold]"
 			else
-				wound_icon_holder.icon_state = "[caste.caste_type]_downed_[health_threshold]"
+				new_icon_state = "[caste.caste_type]_downed_[health_threshold]"
 		else if(!handle_special_state())
-			wound_icon_holder.icon_state = "[caste.caste_type]_walk_[health_threshold]"
+			new_icon_state = "[caste.caste_type]_walk_[health_threshold]"
 		else
-			wound_icon_holder.icon_state = handle_special_wound_states(health_threshold)
+			new_icon_state = handle_special_wound_states(health_threshold)
 	if(organ_removed)
-		wound_icon_holder.icon_state = "[caste.caste_type]_dissection"
+		new_icon_state = "[caste.caste_type]_dissection"
+
+	if(new_icon_state != wound_icon_holder.icon_state)
+		wound_icon_holder.icon_state = new_icon_state
 
 ///Used to display the xeno wounds/backpacks without rapidly switching overlays
 /atom/movable/vis_obj


### PR DESCRIPTION

# About the pull request
Updates xeno wounds on update health instead of on life tick
optimized updatewounds a bit but regardless it shouldn't have any performance impact
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Visual clarity good
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
code: Xeno wounds now update every time they take damage
/:cl:
