### PR TITLE
Fixes synth wl check on UPP synth

### DIFF
--- a/code/modules/gear_presets/upp.dm
+++ b/code/modules/gear_presets/upp.dm
@@ -2661,6 +2661,13 @@
 	gear_preset = /datum/equipment_preset/upp/synth
 
 	flags_whitelist =  WHITELIST_SYNTHETIC
+	flags_startup_parameters = ROLE_WHITELISTED
+
+/datum/job/antag/upp/synth/check_whitelist_status(mob/user)
+	if(user.client.check_whitelist_status(WHITELIST_SYNTHETIC))
+		return TRUE
+
+	return ..()
 
 /datum/equipment_preset/upp/synth
 	name = "UPP Synthetic (Cryo)"


### PR DESCRIPTION

# About the pull request

Title, intended for UPP hvh mode and god knows that else

![P3AMlTB06O](https://github.com/user-attachments/assets/3203453a-3fc8-4a4f-822c-68493be90569)

# Changelog
:cl:
fix: fixed wl check on UPP synth not working
/:cl:
