### PR TITLE
Update ordnance_tech.dm

### DIFF
--- a/code/game/jobs/job/logistics/engi/ordnance_tech.dm
+++ b/code/game/jobs/job/logistics/engi/ordnance_tech.dm
@@ -1,10 +1,10 @@
 //Ordnance Technician
 /datum/job/logistics/otech
 	title = JOB_ORDNANCE_TECH
-	total_positions = 3
-	spawn_positions = 3
-	allow_additional = 1
-	scaled = 1
+	total_positions = 0
+	spawn_positions = 0
+	allow_additional = 0
+	scaled = 0
 	supervisors = "the chief engineer"
 	selection_class = "job_ot"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT


### PR DESCRIPTION
Temporary balance change, doesn't allow OT to be a spawnable role from roundstart. Not sure if this is all there is to it, please forgive any errors as I don't really know how to code. 
# About the pull request

This PR is a temporary balance change that disables the ability for players to spawn as ordnance technicians. The office and everything pertaining to the role remains, it just won't be accessible as something playable for the time being. I hope this would only be implemented long enough for the role to be properly balanced/reworked, since hosts don't want to remove features anymore, but until that day comes I hope this alleviates a major balance concern and prevents a lot of players from having rounds ruined by unbalanced mechanics.

Have not tested changes

# Explain why it's good for the game

Why it's good:
Presently absolutely nothing is balanced around the existence of a half decent OT, it throws the whole game out of wack. CM's current balance state is already fickle as it is, this role simply isn't good for the game in its present state. The damage output it enables for marines relative to xeno survivability and counterplay is severely unbalanced. I believe shaman was also removed for a similar reason; the xeno survivability it enabled relative to marine damage output tipped the scales of balance well beyond what the game is designed for. But at least shaman added more to the game, it encouraged more teamwork, and kept people playing in the round. Sure, not being able to frag enemies isn't super fun, but being instantly fragged/permakilled with no warning or counterplay is exponentially worse. 
Presently lots of the things an OT is enabled to provide marines for relatively little to no cost in time or resources do just that; the xeno equivalent would be like if burrower acid traps instantly gibbed you and melted everything you had. That's it, your round is over because you walked into the wrong bush or within a tile of something invisible. But since the majority of the community is centered around the marine side of the game, most people don't care or will likely protest a change to this. Having been on the receiving end of it though, lots of ordnance is comprised of extremely unbalanced and unfair mechanics.

OT sadar rockets come with no warning and can instakill most castes from offscreen.
OT claymores will one-shot runners, lurkers, defenders, warriors, spitters, sentinels, boilers and praetorians if made right. I’ve been gibbed from full HP by claymores as all of these castes.

Judging from all the cope about how a queen screech can “take you out of the round in one click” (which it can’t, at least that requires the teamwork of a hive to drag you away or kill you), how is anyone able to argue OT ordnance adds anything of substance to the game? 

I've seen a plethora of people, both marine and xeno players, who want OT gone altogether. 

tldr; it’s bad for the game, should be removed.

------
Of course, despite a massive chunk of the community on both sides of the aisle agreeing that the removal of OT would be objectively better for the gamestate, staff have currently adopted an "improve not remove" policy.

Before someone slaps "improve not remove" on this PR and immediately shuts it down, please consider this:

With all due respect to hosts, devs, staff or anyone who embraces that ideology, I don't think such a policy works well with the current developmental state of the game. It's an idealistic take at best, or delusional at worst. I don't believe there's any contributors willing to tackle a project of this magnitude and complexity, and until there is, I don't believe it justifies leaving completely unbalanced, blatantly unfair mechanics in the game that add nothing to the experience. If it does justify it, where was the "improve not remove" mentality for shaman, or the APC?

Furthermore, this PR is not only an improvement to the overall game/balance state, but it's also not a permanent removal, it is a temporary fix until a more permanent one can be made. The OT's lab is there, codewise nothing has been deleted, it can be re-implemented at any point once someone competent at code balances the ordnance. I don't believe players should have their experiences consistently ruined by unbalanced mechanics _until_ such a change happens (which may never occur).

There were some good suggestions in this discussion thread https://forum.cm-ss13.com/t/ot-removal/10648, and I would implement them myself but I don't have the skill. Until someone is willing to undertake such a project, I think temporarily disabling this role would have a net positive effect on the game as a whole.


# Testing Photographs and Procedure
N/A

# Changelog
I changed all values in:
total_positions = 3
	spawn_positions = 3
	allow_additional = 1
	scaled = 1
to zero. I'm not sure if that alone will be sufficient. Not sure if this will hide the role from the job list altogether. Also not sure if this counts as being observable by players or admins, so please let me know if this is uneccessary or if I need to fix it at all.

:cl:

del: disables OT as a job that can be rolled roundstart

/:cl:
