### PR TITLE
Add WY HUD to WY Responders

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -1063,6 +1063,7 @@
 	name = "PMC-CMD headset"
 	desc = "A special headset used by corporate personnel. Channels are as follows: :o - colony, #z - command, #f - medical, #e - engineering, #o - JTAC, #p - general"
 	initial_keys = list(/obj/item/device/encryptionkey/colony, /obj/item/device/encryptionkey/pmc/command, /obj/item/device/encryptionkey/mcom/cl)
+	hud_type = MOB_HUD_FACTION_WY
 
 /obj/item/device/radio/headset/distress/pmc/command/hvh
 	initial_keys = list(/obj/item/device/encryptionkey/colony, /obj/item/device/encryptionkey/pmc/command)


### PR DESCRIPTION
# About the pull request

Basically what the title says, just lets WY Responders actually see who is who at a glance.

# Explain why it's good for the game

I like seeing which people are which roles without having to shift click each individual person, esp. in events.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/8db98e8d-0279-4193-9a69-648517bef5f7)

</details>


# Changelog
:cl:
add: WY Responder now has access to the WY HUD
/:cl:
