### PR TITLE
All TGUI input is now search type to offer clearing

### DIFF
--- a/tgui/packages/tgui/components/Input.tsx
+++ b/tgui/packages/tgui/components/Input.tsx
@@ -172,6 +172,7 @@ export function Input(props: Props) {
       <div className="Input__baseline">.</div>
       <input
         className="Input__input"
+        type="search"
         disabled={disabled}
         maxLength={maxLength}
         onBlur={(event) => onChange?.(event, event.target.value)}


### PR DESCRIPTION
# About the pull request

This PR tweaks the `<Input>` TGUI component to now always be a "search" type so that it will offer the same clear button in 516 as it did in 515 on trident.

Let me know if there's any repercussions from just doing this globally and I can instead turn it into a prop.

# Explain why it's good for the game

Restore the buttons that 516 removed!

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![search](https://github.com/user-attachments/assets/1316c57e-2a07-4737-a4d5-92ccf2564d2d)

</details>


# Changelog
:cl: Drathek
ui: TGUI Input fields now have their clear button restored on 516
/:cl:
