### PR TITLE
fix of Issue with tests, very rare timing based issue xeno strains

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
@@ -527,6 +527,7 @@
 
 /datum/action/xeno_action/onclick/tacmap/remove_from(mob/living/carbon/xenomorph/xeno)
 	. = ..()
+	tracked_queen = null
 	UnregisterSignal(GLOB.hive_datum[hivenumber], COMSIG_HIVE_NEW_QUEEN)
 
 /// handles the addition of a new queen, hiding if appropriate

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/warden.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/warden.dm
@@ -10,7 +10,6 @@
 		/datum/action/xeno_action/activable/pounce/base_prae_dash,
 		/datum/action/xeno_action/activable/prae_acid_ball,
 		/datum/action/xeno_action/activable/spray_acid/base_prae_spray_acid,
-		/datum/action/xeno_action/onclick/tacmap,
 	)
 	actions_to_add = list(
 		/datum/action/xeno_action/onclick/emit_pheromones,
@@ -19,7 +18,6 @@
 		/datum/action/xeno_action/activable/warden_heal,
 		/datum/action/xeno_action/activable/prae_retrieve,
 		/datum/action/xeno_action/onclick/prae_switch_heal_type,
-		/datum/action/xeno_action/onclick/tacmap,
 	)
 
 	behavior_delegate_type = /datum/behavior_delegate/praetorian_warden


### PR DESCRIPTION
# About the pull request

basic: we don't want to take away ability and then give it back, also we want to clear ref right in time

What heppened: when I tried to add strain to queen... I got this>
```
Young Queen (/mob/living/carbon/xenomorph/queen/combat_ready): find references(null)
  ImmediateInvokeAsync(Young Queen (/mob/living/carbon/xenomorph/queen/combat_ready), "find_references")
  Garbage (/datum/controller/subsystem/garbage): HandleQueue(2)
  Garbage (/datum/controller/subsystem/garbage): fire(0)
  Garbage (/datum/controller/subsystem/garbage): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop(2)
  Master (/datum/controller/master): StartProcessing(0)
  ## TESTING: GC: -- [0x3000042] | /mob/living/carbon/xenomorph/queen/combat_ready was unable to be GC'd -- (ref count of 6)
  ## REF SEARCH Finished searching atoms
  ## REF SEARCH Found /mob/living/carbon/xenomorph/queen/combat_ready [0x3000042] in list Datums -> /datum/controller/subsystem/garbage [0x21000040] -> queues (list) -> /list (list) -> /list (list).
  ## REF SEARCH List contents: 1055,Young Queen,924,
  ## REF SEARCH Found /mob/living/carbon/xenomorph/queen/combat_ready [0x3000042] in /datum/action/xeno_action/onclick/tacmap's [0x21025dff] tracked_queen var. Datums -> /datum/action/xeno_action/onclick/tacmap
  ## REF SEARCH Finished searching datums
  ## REF SEARCH Finished searching clients
  ## REF SEARCH Completed search for references to 'Young Queen' a /mob/living/carbon/xenomorph/queen/combat_ready.
  Error: /mob/living/carbon/xenomorph/queen/combat_ready hard deleted 1 times out of a total del count of 3
  	FAILURE #1: /mob/living/carbon/xenomorph/queen/combat_ready hard deleted 1 times out of a total del count of 3 at 
```

# Explain why it's good for the game
Bugs is baaaad

# Changelog

No player facing changes

