### PR TITLE
Don't delete queen by gibber

### DIFF
--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -64,7 +64,7 @@
 		to_chat(user, SPAN_WARNING("This item is not suitable for the gibber!"))
 		return
 
-	if( !iscarbon(grabbed.grabbed_thing) && !istype(grabbed.grabbed_thing, /mob/living/simple_animal) )
+	if(!iscarbon(grabbed.grabbed_thing) && !istype(grabbed.grabbed_thing, /mob/living/simple_animal) && !istype(grabbed.grabbed_thing, /mob/living/carbon/xenomorph/queen))
 		to_chat(user, SPAN_WARNING("This item is not suitable for the gibber!"))
 		return
 

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -64,7 +64,7 @@
 		to_chat(user, SPAN_WARNING("This item is not suitable for the gibber!"))
 		return
 
-	if((!iscarbon(grabbed.grabbed_thing) && !istype(grabbed.grabbed_thing, /mob/living/simple_animal)) || istype(grabbed.grabbed_thing, /mob/living/carbon/xenomorph/queen))
+	if((!iscarbon(grabbed.grabbed_thing) && !istype(grabbed.grabbed_thing, /mob/living/simple_animal)) || isqueen(grabbed.grabbed_thing))
 		to_chat(user, SPAN_WARNING("This item is not suitable for the gibber!"))
 		return
 

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -64,7 +64,7 @@
 		to_chat(user, SPAN_WARNING("This item is not suitable for the gibber!"))
 		return
 
-	if(!iscarbon(grabbed.grabbed_thing) && !istype(grabbed.grabbed_thing, /mob/living/simple_animal) && !istype(grabbed.grabbed_thing, /mob/living/carbon/xenomorph/queen))
+	if((!iscarbon(grabbed.grabbed_thing) && !istype(grabbed.grabbed_thing, /mob/living/simple_animal)) || istype(grabbed.grabbed_thing, /mob/living/carbon/xenomorph/queen))
 		to_chat(user, SPAN_WARNING("This item is not suitable for the gibber!"))
 		return
 


### PR DESCRIPTION
# About the pull request
probably that don't supposed to happen, I assume, because when do we it this way, we won't see that queen in end round log and also all ways to gib queen removed, so I'll asume that right to prohibit it from deleting via gibber

# Explain why it's good for the game
Less bugs always better

# Changelog

:cl: BlackCrystalic
fix: You can't delete queen via gibber now
/:cl:
