### PR TITLE
Fix warrior decap of infected

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -802,14 +802,6 @@
 			return FALSE
 		if(!check_plasma(200))
 			return FALSE
-		if(victim.status_flags & XENO_HOST)
-			var/mob/living/carbon/human/human_victim = victim
-			if(victim.stat != DEAD) //Not dead yet.
-				to_chat(src, SPAN_XENOWARNING("The host and child are still alive!"))
-				return FALSE
-			else if(istype(human_victim) && (world.time <= human_victim.timeofdeath + human_victim.revive_grace_period)) //Dead, but the host can still hatch, possibly.
-				to_chat(src, SPAN_XENOWARNING("The child may still hatch! Not yet!"))
-				return FALSE
 
 		use_plasma(200)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -769,6 +769,7 @@
 			return FALSE
 
 	if(victim.status_flags & XENO_HOST)
+		var/mob/living/carbon/human/human_victim = victim
 		if(victim.stat != DEAD) //Not dead yet.
 			to_chat(src, SPAN_XENOWARNING("The host and child are still alive!"))
 			return FALSE
@@ -802,6 +803,7 @@
 		if(!check_plasma(200))
 			return FALSE
 		if(victim.status_flags & XENO_HOST)
+			var/mob/living/carbon/human/human_victim = victim
 			if(victim.stat != DEAD) //Not dead yet.
 				to_chat(src, SPAN_XENOWARNING("The host and child are still alive!"))
 				return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -768,15 +768,13 @@
 		if(synthhead.status & LIMB_DESTROYED)
 			return FALSE
 
-	if(locate(/obj/item/alien_embryo) in victim) //Maybe they ate it??
-		var/mob/living/carbon/human/human_victim = victim
-		if(human_victim.status_flags & XENO_HOST)
-			if(victim.stat != DEAD) //Not dead yet.
-				to_chat(src, SPAN_XENOWARNING("The host and child are still alive!"))
-				return FALSE
-			else if(istype(human_victim) && (world.time <= human_victim.timeofdeath + human_victim.revive_grace_period)) //Dead, but the host can still hatch, possibly.
-				to_chat(src, SPAN_XENOWARNING("The child may still hatch! Not yet!"))
-				return FALSE
+	if(victim.status_flags & XENO_HOST)
+		if(victim.stat != DEAD) //Not dead yet.
+			to_chat(src, SPAN_XENOWARNING("The host and child are still alive!"))
+			return FALSE
+		else if(istype(human_victim) && (world.time <= human_victim.timeofdeath + human_victim.revive_grace_period)) //Dead, but the host can still hatch, possibly.
+			to_chat(src, SPAN_XENOWARNING("The child may still hatch! Not yet!"))
+			return FALSE
 
 	if(isxeno(victim))
 		var/mob/living/carbon/xenomorph/xeno = victim
@@ -803,6 +801,13 @@
 			return FALSE
 		if(!check_plasma(200))
 			return FALSE
+		if(victim.status_flags & XENO_HOST)
+			if(victim.stat != DEAD) //Not dead yet.
+				to_chat(src, SPAN_XENOWARNING("The host and child are still alive!"))
+				return FALSE
+			else if(istype(human_victim) && (world.time <= human_victim.timeofdeath + human_victim.revive_grace_period)) //Dead, but the host can still hatch, possibly.
+				to_chat(src, SPAN_XENOWARNING("The child may still hatch! Not yet!"))
+				return FALSE
 
 		use_plasma(200)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -197,9 +197,6 @@
 		to_chat(src, SPAN_XENOWARNING("We can't rip off that limb."))
 		return FALSE
 
-	if(mob.status_flags & XENO_HOST)
-		to_chat(src, SPAN_NOTICE("We detect an embryo inside [mob] which overwhelms our instinct to rip."))
-
 	var/limb_time = rand(40,60)
 	if(limb.body_part == BODY_FLAG_HEAD)
 		limb_time = rand(90,110)
@@ -212,7 +209,7 @@
 		return FALSE
 
 	if(mob.status_flags & XENO_HOST)
-		to_chat(src, SPAN_XENOWARNING("This would harm the embryo!"))
+		to_chat(src, SPAN_NOTICE("We detect an embryo inside [mob] which overwhelms our instinct to rip."))
 		return FALSE
 
 	if(limb.status & LIMB_DESTROYED)
@@ -237,7 +234,7 @@
 		return FALSE
 
 	if(mob.status_flags & XENO_HOST)
-		to_chat(src, SPAN_XENOWARNING("This would harm the embryo!"))
+		to_chat(src, SPAN_NOTICE("We detect an embryo inside [mob] which overwhelms our instinct to rip."))
 		return FALSE
 
 	if(limb.status & LIMB_DESTROYED)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -212,7 +212,8 @@
 		return FALSE
 
 	if(mob.status_flags & XENO_HOST)
-		to_chat(src, SPAN_NOTICE("We detect an embryo inside [mob] which overwhelms our instinct to rip."))
+		to_chat(src, SPAN_XENOWARNING("This would harm the embryo!"))
+		return
 
 	if(limb.status & LIMB_DESTROYED)
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -213,7 +213,7 @@
 
 	if(mob.status_flags & XENO_HOST)
 		to_chat(src, SPAN_XENOWARNING("This would harm the embryo!"))
-		return
+		return FALSE
 
 	if(limb.status & LIMB_DESTROYED)
 		return FALSE
@@ -234,6 +234,10 @@
 
 	if(!do_after(src, limb_time, INTERRUPT_ALL|INTERRUPT_DIFF_SELECT_ZONE, BUSY_ICON_HOSTILE)  || mob.stat == DEAD || iszombie(mob))
 		to_chat(src, SPAN_NOTICE("We stop ripping off the limb."))
+		return FALSE
+
+	if(mob.status_flags & XENO_HOST)
+		to_chat(src, SPAN_XENOWARNING("This would harm the embryo!"))
 		return FALSE
 
 	if(limb.status & LIMB_DESTROYED)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Warrior.dm
@@ -196,8 +196,11 @@
 	if(!limb || limb.body_part == BODY_FLAG_CHEST || limb.body_part == BODY_FLAG_GROIN || (limb.status & LIMB_DESTROYED)) //Only limbs and head.
 		to_chat(src, SPAN_XENOWARNING("We can't rip off that limb."))
 		return FALSE
-	var/limb_time = rand(40,60)
 
+	if(mob.status_flags & XENO_HOST)
+		to_chat(src, SPAN_NOTICE("We detect an embryo inside [mob] which overwhelms our instinct to rip."))
+
+	var/limb_time = rand(40,60)
 	if(limb.body_part == BODY_FLAG_HEAD)
 		limb_time = rand(90,110)
 
@@ -206,9 +209,10 @@
 
 	if(!do_after(src, limb_time, INTERRUPT_ALL|INTERRUPT_DIFF_SELECT_ZONE, BUSY_ICON_HOSTILE) || mob.stat == DEAD || mob.status_flags & XENO_HOST)
 		to_chat(src, SPAN_NOTICE("We stop ripping off the limb."))
-		if(mob.status_flags & XENO_HOST)
-			to_chat(src, SPAN_NOTICE("We detect an embryo inside [mob] which overwhelms our instinct to rip."))
 		return FALSE
+
+	if(mob.status_flags & XENO_HOST)
+		to_chat(src, SPAN_NOTICE("We detect an embryo inside [mob] which overwhelms our instinct to rip."))
 
 	if(limb.status & LIMB_DESTROYED)
 		return FALSE


### PR DESCRIPTION
# About the pull request
Warriro decap, I'm not sure, but seems check been placed in wrong place for same purpose too

# Explain why it's good for the game
Less... bugs? arent it features?


# Changelog

:cl: BlackCrystalic
fix: Warrior no more decap infected marines that infected within do_after duration (there two stages for decap, all two got check)
/:cl:

Closes #6087
