### PR TITLE
Fix of auto shove for dancer/lying&dead zenos

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -764,3 +764,9 @@
 	SetRoot(0)
 	SetEyeBlur(0)
 	updatehealth()
+
+/mob/living/carbon/xenomorph/BlockedPassDirs(atom/movable/mover, target_dir)
+	var/mob/living/carbon/xenomorph/xeno = mover
+	if(istype(xeno) && (pass_flags.flags_pass & PASS_MOB_THRU || flags_pass_temp & PASS_MOB_THRU) && xeno.hivenumber == hivenumber)
+		return NO_BLOCKED_MOVEMENT
+	return ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/King.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/King.dm
@@ -85,12 +85,12 @@
 			var/mob/living/carbon/xenomorph/xeno = carbon
 			if(carbon.body_position == LYING_DOWN)
 				continue
-			if(xeno.pass_flags.flags_pass & PASS_MOB_THRU_XENO || xeno.flags_pass_temp & PASS_MOB_THRU)
+			if(xeno.pass_flags.flags_pass & PASS_MOB_THRU || xeno.flags_pass_temp & PASS_MOB_THRU)
 				continue
-			if(xeno.hivenumber == src.hivenumber && !(king.client?.prefs?.toggle_prefs & TOGGLE_AUTO_SHOVE_OFF))
+			if(xeno.hivenumber == hivenumber && !(king.client?.prefs?.toggle_prefs & TOGGLE_AUTO_SHOVE_OFF))
 				xeno.KnockDown((5 DECISECONDS) / GLOBAL_STATUS_MULTIPLIER)
 				playsound(src, 'sound/weapons/alien_knockdown.ogg', 25, 1)
-			else if(xeno.hivenumber != src.hivenumber)
+			else if(xeno.hivenumber != hivenumber)
 				xeno.KnockDown((1 SECONDS) / GLOBAL_STATUS_MULTIPLIER)
 				playsound(src, 'sound/weapons/alien_knockdown.ogg', 25, 1)
 		else
@@ -98,6 +98,7 @@
 				carbon.apply_armoured_damage(20)
 				carbon.KnockDown((1 SECONDS) / GLOBAL_STATUS_MULTIPLIER)
 				playsound(src, 'sound/weapons/alien_knockdown.ogg', 25, 1)
+
 /mob/living/carbon/xenomorph/king/gib(datum/cause_data/cause = create_cause_data("gibbing", src))
 	death(cause, 1)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/King.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/King.dm
@@ -83,6 +83,10 @@
 	for(var/mob/living/carbon/carbon in new_loc.contents)
 		if(isxeno(carbon))
 			var/mob/living/carbon/xenomorph/xeno = carbon
+			if(carbon.body_position == LYING_DOWN)
+				continue
+			if(xeno.pass_flags.flags_pass & (PASS_MOB_THRU_XENO|PASS_MOB_THRU) && !(xeno.flags_pass_temp & PASS_MOB_THRU))
+				continue
 			if(xeno.hivenumber == src.hivenumber && !(king.client?.prefs?.toggle_prefs & TOGGLE_AUTO_SHOVE_OFF))
 				xeno.KnockDown((5 DECISECONDS) / GLOBAL_STATUS_MULTIPLIER)
 				playsound(src, 'sound/weapons/alien_knockdown.ogg', 25, 1)

--- a/code/modules/mob/living/carbon/xenomorph/castes/King.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/King.dm
@@ -85,7 +85,7 @@
 			var/mob/living/carbon/xenomorph/xeno = carbon
 			if(carbon.body_position == LYING_DOWN)
 				continue
-			if(xeno.pass_flags.flags_pass & (PASS_MOB_THRU_XENO|PASS_MOB_THRU) && !(xeno.flags_pass_temp & PASS_MOB_THRU))
+			if(xeno.pass_flags.flags_pass & PASS_MOB_THRU_XENO || xeno.flags_pass_temp & PASS_MOB_THRU)
 				continue
 			if(xeno.hivenumber == src.hivenumber && !(king.client?.prefs?.toggle_prefs & TOGGLE_AUTO_SHOVE_OFF))
 				xeno.KnockDown((5 DECISECONDS) / GLOBAL_STATUS_MULTIPLIER)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -445,7 +445,7 @@
 	for(var/mob/living/carbon/xenomorph/xeno in new_loc.contents)
 		if(xeno.body_position == LYING_DOWN)
 			continue
-		if(xeno.pass_flags.flags_pass & PASS_MOB_THRU_XENO || xeno.flags_pass_temp & PASS_MOB_THRU)
+		if(xeno.pass_flags.flags_pass & PASS_MOB_THRU || xeno.flags_pass_temp & PASS_MOB_THRU)
 			continue
 		if(xeno.hivenumber == hivenumber && !(queen.client?.prefs?.toggle_prefs & TOGGLE_AUTO_SHOVE_OFF))
 			xeno.KnockDown((5 DECISECONDS) / GLOBAL_STATUS_MULTIPLIER)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -445,7 +445,7 @@
 	for(var/mob/living/carbon/xenomorph/xeno in new_loc.contents)
 		if(xeno.body_position == LYING_DOWN)
 			continue
-		if(xeno.pass_flags.flags_pass & (PASS_MOB_THRU_XENO|PASS_MOB_THRU) && !(xeno.flags_pass_temp & PASS_MOB_THRU))
+		if(xeno.pass_flags.flags_pass & PASS_MOB_THRU_XENO || xeno.flags_pass_temp & PASS_MOB_THRU)
 			continue
 		if(xeno.hivenumber == hivenumber && !(queen.client?.prefs?.toggle_prefs & TOGGLE_AUTO_SHOVE_OFF))
 			xeno.KnockDown((5 DECISECONDS) / GLOBAL_STATUS_MULTIPLIER)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -443,6 +443,8 @@
 /mob/living/carbon/xenomorph/queen/proc/check_block(mob/queen, turf/new_loc)
 	SIGNAL_HANDLER
 	for(var/mob/living/carbon/xenomorph/xeno in new_loc.contents)
+		if(xeno.body_position == LYING_DOWN)
+			continue
 		if(xeno.pass_flags.flags_pass & (PASS_MOB_THRU_XENO|PASS_MOB_THRU) && !(xeno.flags_pass_temp & PASS_MOB_THRU))
 			continue
 		if(xeno.hivenumber == hivenumber && !(queen.client?.prefs?.toggle_prefs & TOGGLE_AUTO_SHOVE_OFF))


### PR DESCRIPTION

# About the pull request
We simply solve issue, nothing more... we don't shove dead zenomorphs and lying down zenomorphs, and dancer in his "DODGE" effect

# Explain why it's good for the game
Less bugs and "distracting" things.

# Changelog

:cl: BlackCrystalic
fix: Auto shove ignore dead/lying xenomorphs
fix: Dancer can now safely play around queen/king with auto shove enabled
/:cl:

Closes #7362
