### PR TITLE
Boiler neuro purges stim, buffs neuro tailstab duration, reduce dizziness 

### DIFF
--- a/code/datums/effects/neurotoxin.dm
+++ b/code/datums/effects/neurotoxin.dm
@@ -20,6 +20,8 @@
 	var/chat_cd = 0
 	/// Stamina damage per tick. Major balance number.
 	var/stam_dam = 7
+	/// Stimulant drain per tick.
+	var/stim_drain = 2
 
 /datum/effects/neurotoxin/New(atom/thing, mob/from = null)
 	..(thing, from, effect_name)
@@ -45,6 +47,8 @@
 	affected_mob.last_damage_data = cause_data
 	affected_mob.apply_stamina_damage(stam_dam)
 	affected_mob.make_dizzy(12)
+	for(var/datum/reagent/generated/stim in affected_mob.reagents.reagent_list)
+		affected_mob.reagents.remove_reagent(stim.id, stim_drain, TRUE)
 
 // Effect levels (shit that doesn't stack)
 	switch(duration)

--- a/code/datums/effects/neurotoxin.dm
+++ b/code/datums/effects/neurotoxin.dm
@@ -46,7 +46,7 @@
 // General effects
 	affected_mob.last_damage_data = cause_data
 	affected_mob.apply_stamina_damage(stam_dam)
-	affected_mob.make_dizzy(12)
+	affected_mob.make_dizzy(8)
 	for(var/datum/reagent/generated/stim in affected_mob.reagents.reagent_list)
 		affected_mob.reagents.remove_reagent(stim.id, stim_drain, TRUE)
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_powers.dm
@@ -330,7 +330,7 @@
 			var/datum/effects/neurotoxin/neuro_effect = locate() in carbon_target.effects_list
 			if(!neuro_effect)
 				neuro_effect = new(carbon_target, owner)
-			neuro_effect.duration += 16
+			neuro_effect.duration += 20
 			to_chat(carbon_target,SPAN_HIGHDANGER("You are injected with something from [stabbing_xeno]'s tailstab!"))
 		else
 			CRASH("Globber has unknown ammo [stabbing_xeno.ammo]! Oh no!")


### PR DESCRIPTION
# About the pull request
Boiler neurotoxin now purges 2u of stim per tick of the effect
Boiler Tailstab now adds 20 duration*** of neuro (from 16).

Decreases the amount of dizziness inflicted per tick by neuro from 12 to 8

***Note that neurotailstab won't inflict blindness despite adding 20 duration, as it ticks down once(?) before taking effect (Plus, an instant 5 second blind on toxic tailstab would be crazy).
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Xenos should have more way to purge stims (especially godstims) that don't include being the weakest T1 in the game.

As for the neuro tailstab buff, I think that it's very underused and underpowered compared to the 90(!) DOT from acidic tailstab.

The dizziness nerf is because it's such an annoying  effect, it lingers for a LONG time after the neuro ends, I'd rather it ended a bit quicker.
# Testing Photographs and Procedure

made a custom stim with no effects, injected 100u, boiler tailstab, watch stims get drained.
works.


# Changelog
:cl:
add: Boiler neurotoxin now quickly purges research stimulants.
balance: Boiler's neurotoxin tailstab now inflicts 4 more neurotoxin duration (16 to 20). Acid Tailstab is unaffected.
qol: Duration of dizziness caused by neurotoxin has been reduced.
/:cl:
