### PR TITLE
forensic spray can no longer generate randomly

### DIFF
--- a/code/modules/reagents/chemistry_reagents/other.dm
+++ b/code/modules/reagents/chemistry_reagents/other.dm
@@ -1071,6 +1071,7 @@
 	reagent_state = LIQUID
 	color = "#79847a"
 	chemclass = CHEM_CLASS_RARE
+	flags = REAGENT_NO_GENERATION
 
 /datum/reagent/forensic_spray/reaction_obj(obj/reacting_on, volume)
 	if(!istype(reacting_on, /obj/effect/decal/prints))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Forensic spray can no longer generate in recipes, mutated plants and colony vials.

# Explain why it's good for the game
Doesn't make sense for this to show up in plants and just makes recipes needlessly harder.

# Testing Photographs and Procedure
Probably works

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Forensic spray can no longer generate in recipes, mutated plants and colony vials.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
