### PR TITLE
Research chems now spawn with higher ODs

### DIFF
--- a/code/modules/reagents/Chemistry-Generator.dm
+++ b/code/modules/reagents/Chemistry-Generator.dm
@@ -200,9 +200,8 @@
 
 	//OD ratios
 	overdose = 5
-	for(var/i=1;i<=rand(1,11);i++) //We add 5 units to the overdose per cycle, min 5u, max 60u
-		if(prob(50 + 5*gen_tier))//Deviating from 5 gets exponentially more rare, deviation scales with chem level
-			overdose += 5
+	for(var/i=1;i<=rand(max(gen_tier*2, 4),9);i++) //We add 5 units to the overdose per cycle, min 30u, max 60u
+		overdose += 5
 	overdose_critical = overdose + 5
 	for(var/i=1;i<=rand(1,5);i++) //overdose_critical is min 5u, to max 30u + normal overdose
 		if(prob(20 + 2*gen_tier))


### PR DESCRIPTION

# About the pull request
Taken directly from #7023 

Research chems (those found in vials or in botany) now generate with significantly higher ODs (Minimum 30u), to encourage amping/relating them to make them useful instead of just ignoring them. 

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Currently chem papers are extremely hit and miss, while you may get papers with good properties, and chems that would "fit in" with the paper, the combo of them would result in an OD so low that it would be effectively worthless. With a higher OD, researchers can play around with chems more, relating/amping without making it completely useless.
# Testing Photographs and Procedure
spawned in as researcher
spammed Spawn "fancy/vials/random
scanned vials
ODs minimum 30u, typically 40-45u, with 1 50u.



# Changelog
:cl: KiVts, Private-Tristan
balance: Research chems now spawn with a significantly higher overdose threshold
/:cl:
