### PR TITLE
stims healing nerf

### DIFF
--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -28,7 +28,6 @@
 	rarity = PROPERTY_COMMON
 	starter = TRUE
 	value = 1
-	cost_penalty = FALSE
 
 /datum/chem_property/positive/anticorrosive/process(mob/living/M, potency = 1)
 	M.heal_limb_damage(0, potency)
@@ -48,7 +47,6 @@
 	rarity = PROPERTY_COMMON
 	starter = TRUE
 	value = 1
-	cost_penalty = FALSE
 
 /datum/chem_property/positive/neogenetic/process(mob/living/M, potency = 1)
 	M.heal_limb_damage(potency, 0)
@@ -227,6 +225,7 @@
 	rarity = PROPERTY_COMMON
 	category = PROPERTY_TYPE_STIMULANT
 	value = 1
+	cost_penalty = FALSE
 
 /datum/chem_property/positive/painkilling/on_delete(mob/living/M)
 	..()
@@ -535,6 +534,7 @@
 	rarity = PROPERTY_COMMON
 	category = PROPERTY_TYPE_REACTANT
 	value = 1
+	cost_penalty = FALSE
 
 /datum/chem_property/positive/electrogenetic/trigger(A)
 	if(isliving(A))


### PR DESCRIPTION
# About the pull request

removes the discount on extreme levels of NGN/ACR (brute/burn heal)
adds the same discount to underrepresented properties EGN/PNK (defib heal, like epinephrine, and painkilling)

this doesn't affect any chemicals already in the game or made with the random chemical generator, just ones made by researchers in create mode.

# Explain why it's good for the game

Loopers implemented the tag in #6225 to encourage researchers to make chemicals other than godstims 24/7. It's worked for fire and chemical weapons fairly well, but the NGN/ACR buff (meant to let them make healing chemicals easier) has just meant that every marine with stims in them is now also wolverine. It's too cheap.

Moves the tags over to EGN and PNK to hopefully encourage some diversity: EGN is rarely used because it's so expensive to make at high levels, and epinephrine is already level 5. PNK is the same, except oxycodone is level 8, so it's even worse.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
balance: Research stim healing properties made more expensive, epinephrine-like and painkilling properties made cheaper.
/:cl:
