### PR TITLE
Nerfs playable huggers

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -9,7 +9,7 @@
 #define TUNNEL_ENTER_LARVA_DELAY 10
 
 /// The duration it takes a player controlled facehugger to leap or hug adjacently
-#define FACEHUGGER_WINDUP_DURATION 1 SECONDS
+#define FACEHUGGER_WINDUP_DURATION 2 SECONDS
 
 // Defines for action types and click delays used by xenomorph/unarmedattack() and attack_alien().
 

--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -8,8 +8,10 @@
 #define TUNNEL_ENTER_BIG_XENO_DELAY 120
 #define TUNNEL_ENTER_LARVA_DELAY 10
 
-/// The duration it takes a player controlled facehugger to leap or hug adjacently
-#define FACEHUGGER_WINDUP_DURATION 2 SECONDS
+/// The duration it takes a player controlled facehugger to leap
+#define FACEHUGGER_LEAP_DURATION 2 SECONDS
+/// The duration is takes a player contorlled facehugger to hug adjcaently
+#define FACEHUGGER_CLIMB_DURATION 1 SECONDS
 
 // Defines for action types and click delays used by xenomorph/unarmedattack() and attack_alien().
 

--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -10,7 +10,7 @@
 
 /// The duration it takes a player controlled facehugger to leap
 #define FACEHUGGER_LEAP_DURATION 2 SECONDS
-/// The duration is takes a player contorlled facehugger to hug adjcaently
+/// The duration is takes a player contorlled facehugger to hug a target lying down by clicking on it
 #define FACEHUGGER_CLIMB_DURATION 1 SECONDS
 
 // Defines for action types and click delays used by xenomorph/unarmedattack() and attack_alien().

--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -10,7 +10,7 @@
 
 /// The duration it takes a player controlled facehugger to leap
 #define FACEHUGGER_LEAP_DURATION 2 SECONDS
-/// The duration is takes a player contorlled facehugger to hug a target lying down by clicking on it
+/// The duration it takes a player controlled facehugger to hug a target lying down by clicking on it
 #define FACEHUGGER_CLIMB_DURATION 1 SECONDS
 
 // Defines for action types and click delays used by xenomorph/unarmedattack() and attack_alien().

--- a/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_abilities.dm
@@ -12,7 +12,7 @@
 	knockdown = TRUE
 	knockdown_duration = 0.5
 	windup = TRUE
-	windup_duration = FACEHUGGER_WINDUP_DURATION
+	windup_duration = FACEHUGGER_LEAP_DURATION
 	freeze_self = TRUE
 	freeze_time = 5
 	freeze_play_sound = FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -145,7 +145,7 @@
 			to_chat(src, SPAN_WARNING("You can't infect \the [human]..."))
 			return
 		visible_message(SPAN_WARNING("\The [src] starts climbing onto \the [human]'s face..."), SPAN_XENONOTICE("You start climbing onto \the [human]'s face..."))
-		if(!do_after(src, FACEHUGGER_HUG_DURATION, INTERRUPT_ALL, BUSY_ICON_HOSTILE, human, INTERRUPT_MOVED, BUSY_ICON_HOSTILE))
+		if(!do_after(src, FACEHUGGER_CLIMB_DURATION, INTERRUPT_ALL, BUSY_ICON_HOSTILE, human, INTERRUPT_MOVED, BUSY_ICON_HOSTILE))
 			return
 		if(human.body_position != LYING_DOWN)
 			to_chat(src, SPAN_WARNING("You can't reach \the [human], they need to be lying down."))

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -145,7 +145,7 @@
 			to_chat(src, SPAN_WARNING("You can't infect \the [human]..."))
 			return
 		visible_message(SPAN_WARNING("\The [src] starts climbing onto \the [human]'s face..."), SPAN_XENONOTICE("You start climbing onto \the [human]'s face..."))
-		if(!do_after(src, FACEHUGGER_WINDUP_DURATION, INTERRUPT_ALL, BUSY_ICON_HOSTILE, human, INTERRUPT_MOVED, BUSY_ICON_HOSTILE))
+		if(!do_after(src, FACEHUGGER_HUG_DURATION, INTERRUPT_ALL, BUSY_ICON_HOSTILE, human, INTERRUPT_MOVED, BUSY_ICON_HOSTILE))
 			return
 		if(human.body_position != LYING_DOWN)
 			to_chat(src, SPAN_WARNING("You can't reach \the [human], they need to be lying down."))
@@ -265,4 +265,4 @@
 
 /datum/behavior_delegate/facehugger_base/on_life()
 	if(!(locate(/obj/effect/alien/weeds) in get_turf(bound_xeno)))
-		bound_xeno.adjustBruteLoss(5)
+		bound_xeno.adjustBruteLoss(2)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -264,5 +264,5 @@
 	name = "Base Facehugger Behavior Delegate"
 
 /datum/behavior_delegate/facehugger_base/on_life()
-	if(bound_xeno.body_position == STANDING_UP && !(locate(/obj/effect/alien/weeds) in get_turf(bound_xeno)))
-		bound_xeno.adjustBruteLoss(1)
+	if(!(locate(/obj/effect/alien/weeds) in get_turf(bound_xeno)))
+		bound_xeno.adjustBruteLoss(5)

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/facehugger/watcher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/facehugger/watcher.dm
@@ -26,4 +26,4 @@
 		return
 	if(locate(/obj/effect/alien/weeds) in get_turf(bound_xeno))
 		return
-	bound_xeno.adjustBruteLoss(5)
+	bound_xeno.adjustBruteLoss(2)

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/facehugger/watcher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/facehugger/watcher.dm
@@ -22,10 +22,8 @@
 
 /datum/behavior_delegate/facehugger_watcher/on_life()
 	// Sap health if we're standing, not on weeds, and not zoomed out
-	if(bound_xeno.body_position != STANDING_UP)
-		return
 	if(bound_xeno.is_zoomed)
 		return
 	if(locate(/obj/effect/alien/weeds) in get_turf(bound_xeno))
 		return
-	bound_xeno.adjustBruteLoss(1)
+	bound_xeno.adjustBruteLoss(5)


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Playable huggers are supposed to help xenos cap on the frontline and be comparable to an egg morpher \ carrier, they aren't supposed to go off on solo missions and you shouldn't need to react to a hugger within 1 second or be removed from the round for 30 minutes.
This puts their hug time inline with carrier (which I still think is stupid since a carrier literally slams hugger into your face but w/e)
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Increased facehugger leap windup time from 1 second to 2 seconds (crawling hug time unchanged)
balance: Increased facehugger health loss off weeds from 1 to 2
balance: Facehuggers now lose health off weeds regardless of if resting or not (exception is watcher in watch mode)
/:cl:
