### PR TITLE
Removes burst on Scout Rifle

### DIFF
--- a/code/modules/projectiles/guns/specialist/scout.dm
+++ b/code/modules/projectiles/guns/specialist/scout.dm
@@ -73,8 +73,7 @@
 /obj/item/weapon/gun/rifle/m4ra_custom/set_gun_config_values()
 	..()
 	set_fire_delay(FIRE_DELAY_TIER_6)
-	set_burst_amount(BURST_AMOUNT_TIER_2)
-	set_burst_delay(FIRE_DELAY_TIER_12)
+	set_burst_amount(0)
 	accuracy_mult = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_2
 	scatter = SCATTER_AMOUNT_TIER_8
 	burst_scatter_mult = SCATTER_AMOUNT_TIER_8


### PR DESCRIPTION
# About the pull request

What it says on the tin.

# Explain why it's good for the game

Many people will give many different responses to "Scout Rifle needs to be nerfed", and a lot of people will defend it. It is no secrete however that the Scout Rifle is hands down one of the most powerful guns anyone can get ahold of normally and even though as a specialist Scout deserves a good gun, they don't need a gun that can let them solo literally any Xeno they want within literal seconds.

The nexus of the issue is the burst fire, being one of the absolute best burst fire's avaliable with pinpoint accuracy and near enough instant firing of two bullets, allows the gun to use it's amazing ammo types to quickly destroy just about any target the user wants; from testing, it takes ~5 seconds for the gun to kill a base Crusher with burst fire and A19 ammo, aa very good trade for one magazine.

As the ammo is what makes the rifle noteworthy, lets it retain consistency with other spec weapons having multiple ammo types and would be fine balance-wise on semi-auto fire, the next best way to hopefully settle the age old balance argument is to nix the burst fire.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Killfish
balance: Removed burst fire on the Custom M4RA.
/:cl:
