### PR TITLE
CMB Fax Responders start as a Deputy now

### DIFF
--- a/code/modules/gear_presets/fax_responders.dm
+++ b/code/modules/gear_presets/fax_responders.dm
@@ -219,7 +219,7 @@
 	faction_group = list(FACTION_FAX, FACTION_MARINE, FACTION_MARSHAL)
 	headset_type = /obj/item/device/radio/headset/distress/CMB
 	idtype = /obj/item/card/id/marshal
-	paygrades = list(PAY_SHORT_CMBM = JOB_PLAYTIME_TIER_0)
+	paygrades = list(PAY_SHORT_CMBD = JOB_PLAYTIME_TIER_0, PAY_SHORT_CMBM = JOB_PLAYTIME_TIER_2)
 
 /datum/equipment_preset/fax_responder/cmb/New()
 	. = ..()


### PR DESCRIPTION

# About the pull request

CMB Fax Responders start as a Deputy, then rank up to Marshal at 25 Hours (Silver Medal for you ungabrains)

# Explain why it's good for the game

Rank Consistency is good, Fax Responders should start as a relatively lower rank, THEN get the big dick rank once they actually play it for a while, this is already done for the WY, UA, UPP, and TWE Responders, why not CMB too?


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: CMB Fax Responders now start as a Deputy, then rank up to Marshal at 25 Hours of Playtime.
/:cl:
