### PR TITLE
disables OB on HvH

### DIFF
--- a/code/game/gamemodes/extended/cm_vs_upp.dm
+++ b/code/game/gamemodes/extended/cm_vs_upp.dm
@@ -2,7 +2,7 @@
 	name = "Faction Clash UPP CM"
 	config_tag = "Faction Clash UPP CM"
 	flags_round_type = MODE_THUNDERSTORM|MODE_FACTION_CLASH
-	starting_round_modifiers = list(/datum/gamemode_modifier/blood_optimization, /datum/gamemode_modifier/defib_past_armor, /datum/gamemode_modifier/disable_combat_cas, /datum/gamemode_modifier/disable_ib, /datum/gamemode_modifier/disable_attacking_corpses, /datum/gamemode_modifier/disable_long_range_sentry, /datum/gamemode_modifier/disable_stripdrag_enemy, /datum/gamemode_modifier/indestructible_splints, /datum/gamemode_modifier/mortar_laser_warning, /datum/gamemode_modifier/no_body_c4)
+	starting_round_modifiers = list(/datum/gamemode_modifier/blood_optimization, /datum/gamemode_modifier/defib_past_armor, /datum/gamemode_modifier/disable_combat_cas, /datum/gamemode_modifier/disable_ib,/datum/gamemode_modifier/disable_ob, /datum/gamemode_modifier/disable_attacking_corpses, /datum/gamemode_modifier/disable_long_range_sentry, /datum/gamemode_modifier/disable_stripdrag_enemy, /datum/gamemode_modifier/indestructible_splints, /datum/gamemode_modifier/mortar_laser_warning, /datum/gamemode_modifier/no_body_c4)
 	taskbar_icon = 'icons/taskbar/gml_hvh.png'
 
 /datum/game_mode/extended/faction_clash/cm_vs_upp/get_roles_list()

--- a/code/game/gamemodes/extended/cm_vs_upp.dm
+++ b/code/game/gamemodes/extended/cm_vs_upp.dm
@@ -3,17 +3,17 @@
 	config_tag = "Faction Clash UPP CM"
 	flags_round_type = MODE_THUNDERSTORM|MODE_FACTION_CLASH
 	starting_round_modifiers = list(
-		/datum/gamemode_modifier/blood_optimization,
-		/datum/gamemode_modifier/defib_past_armor,
-		/datum/gamemode_modifier/disable_combat_cas,
-		/datum/gamemode_modifier/disable_ib,
-		/datum/gamemode_modifier/disable_ob,
-		/datum/gamemode_modifier/disable_attacking_corpses,
-		/datum/gamemode_modifier/disable_long_range_sentry,
-		/datum/gamemode_modifier/disable_stripdrag_enemy,
-		/datum/gamemode_modifier/indestructible_splints,
-		/datum/gamemode_modifier/mortar_laser_warning,
-		/datum/gamemode_modifier/no_body_c4
+			/datum/gamemode_modifier/blood_optimization,
+			/datum/gamemode_modifier/defib_past_armor,
+			/datum/gamemode_modifier/disable_combat_cas,
+			/datum/gamemode_modifier/disable_ib,
+			/datum/gamemode_modifier/disable_ob,
+			/datum/gamemode_modifier/disable_attacking_corpses,
+			/datum/gamemode_modifier/disable_long_range_sentry,
+			/datum/gamemode_modifier/disable_stripdrag_enemy,
+			/datum/gamemode_modifier/indestructible_splints,
+			/datum/gamemode_modifier/mortar_laser_warning,
+			/datum/gamemode_modifier/no_body_c4
 	)
 
 	taskbar_icon = 'icons/taskbar/gml_hvh.png'

--- a/code/game/gamemodes/extended/cm_vs_upp.dm
+++ b/code/game/gamemodes/extended/cm_vs_upp.dm
@@ -13,7 +13,8 @@
 	/datum/gamemode_modifier/disable_stripdrag_enemy,
 	/datum/gamemode_modifier/indestructible_splints,
 	/datum/gamemode_modifier/mortar_laser_warning,
-	/datum/gamemode_modifier/no_body_c4)
+	/datum/gamemode_modifier/no_body_c4
+	)
 
 	taskbar_icon = 'icons/taskbar/gml_hvh.png'
 

--- a/code/game/gamemodes/extended/cm_vs_upp.dm
+++ b/code/game/gamemodes/extended/cm_vs_upp.dm
@@ -13,7 +13,7 @@
 		/datum/gamemode_modifier/disable_stripdrag_enemy,
 		/datum/gamemode_modifier/indestructible_splints,
 		/datum/gamemode_modifier/mortar_laser_warning,
-		/datum/gamemode_modifier/no_body_c4
+		/datum/gamemode_modifier/no_body_c4,
 	)
 
 	taskbar_icon = 'icons/taskbar/gml_hvh.png'

--- a/code/game/gamemodes/extended/cm_vs_upp.dm
+++ b/code/game/gamemodes/extended/cm_vs_upp.dm
@@ -3,17 +3,17 @@
 	config_tag = "Faction Clash UPP CM"
 	flags_round_type = MODE_THUNDERSTORM|MODE_FACTION_CLASH
 	starting_round_modifiers = list(
-			/datum/gamemode_modifier/blood_optimization,
-			/datum/gamemode_modifier/defib_past_armor,
-			/datum/gamemode_modifier/disable_combat_cas,
-			/datum/gamemode_modifier/disable_ib,
-			/datum/gamemode_modifier/disable_ob,
-			/datum/gamemode_modifier/disable_attacking_corpses,
-			/datum/gamemode_modifier/disable_long_range_sentry,
-			/datum/gamemode_modifier/disable_stripdrag_enemy,
-			/datum/gamemode_modifier/indestructible_splints,
-			/datum/gamemode_modifier/mortar_laser_warning,
-			/datum/gamemode_modifier/no_body_c4
+		/datum/gamemode_modifier/blood_optimization,
+		/datum/gamemode_modifier/defib_past_armor,
+		/datum/gamemode_modifier/disable_combat_cas,
+		/datum/gamemode_modifier/disable_ib,
+		/datum/gamemode_modifier/disable_ob,
+		/datum/gamemode_modifier/disable_attacking_corpses,
+		/datum/gamemode_modifier/disable_long_range_sentry,
+		/datum/gamemode_modifier/disable_stripdrag_enemy,
+		/datum/gamemode_modifier/indestructible_splints,
+		/datum/gamemode_modifier/mortar_laser_warning,
+		/datum/gamemode_modifier/no_body_c4
 	)
 
 	taskbar_icon = 'icons/taskbar/gml_hvh.png'

--- a/code/game/gamemodes/extended/cm_vs_upp.dm
+++ b/code/game/gamemodes/extended/cm_vs_upp.dm
@@ -3,17 +3,17 @@
 	config_tag = "Faction Clash UPP CM"
 	flags_round_type = MODE_THUNDERSTORM|MODE_FACTION_CLASH
 	starting_round_modifiers = list(
-	/datum/gamemode_modifier/blood_optimization,
-	/datum/gamemode_modifier/defib_past_armor,
-	/datum/gamemode_modifier/disable_combat_cas,
-	/datum/gamemode_modifier/disable_ib,
-	/datum/gamemode_modifier/disable_ob,
-	/datum/gamemode_modifier/disable_attacking_corpses,
-	/datum/gamemode_modifier/disable_long_range_sentry,
-	/datum/gamemode_modifier/disable_stripdrag_enemy,
-	/datum/gamemode_modifier/indestructible_splints,
-	/datum/gamemode_modifier/mortar_laser_warning,
-	/datum/gamemode_modifier/no_body_c4
+		/datum/gamemode_modifier/blood_optimization,
+		/datum/gamemode_modifier/defib_past_armor,
+		/datum/gamemode_modifier/disable_combat_cas,
+		/datum/gamemode_modifier/disable_ib,
+		/datum/gamemode_modifier/disable_ob,
+		/datum/gamemode_modifier/disable_attacking_corpses,
+		/datum/gamemode_modifier/disable_long_range_sentry,
+		/datum/gamemode_modifier/disable_stripdrag_enemy,
+		/datum/gamemode_modifier/indestructible_splints,
+		/datum/gamemode_modifier/mortar_laser_warning,
+		/datum/gamemode_modifier/no_body_c4
 	)
 
 	taskbar_icon = 'icons/taskbar/gml_hvh.png'

--- a/code/game/gamemodes/extended/cm_vs_upp.dm
+++ b/code/game/gamemodes/extended/cm_vs_upp.dm
@@ -2,7 +2,19 @@
 	name = "Faction Clash UPP CM"
 	config_tag = "Faction Clash UPP CM"
 	flags_round_type = MODE_THUNDERSTORM|MODE_FACTION_CLASH
-	starting_round_modifiers = list(/datum/gamemode_modifier/blood_optimization, /datum/gamemode_modifier/defib_past_armor, /datum/gamemode_modifier/disable_combat_cas, /datum/gamemode_modifier/disable_ib,/datum/gamemode_modifier/disable_ob, /datum/gamemode_modifier/disable_attacking_corpses, /datum/gamemode_modifier/disable_long_range_sentry, /datum/gamemode_modifier/disable_stripdrag_enemy, /datum/gamemode_modifier/indestructible_splints, /datum/gamemode_modifier/mortar_laser_warning, /datum/gamemode_modifier/no_body_c4)
+	starting_round_modifiers = list(
+	/datum/gamemode_modifier/blood_optimization,
+	/datum/gamemode_modifier/defib_past_armor,
+	/datum/gamemode_modifier/disable_combat_cas,
+	/datum/gamemode_modifier/disable_ib,
+	/datum/gamemode_modifier/disable_ob,
+	/datum/gamemode_modifier/disable_attacking_corpses,
+	/datum/gamemode_modifier/disable_long_range_sentry,
+	/datum/gamemode_modifier/disable_stripdrag_enemy,
+	/datum/gamemode_modifier/indestructible_splints,
+	/datum/gamemode_modifier/mortar_laser_warning,
+	/datum/gamemode_modifier/no_body_c4)
+
 	taskbar_icon = 'icons/taskbar/gml_hvh.png'
 
 /datum/game_mode/extended/faction_clash/cm_vs_upp/get_roles_list()


### PR DESCRIPTION

# About the pull request

title, the flag was already in game but not placed on any gamemode

# Explain why it's good for the game

OB is meant to be disabled for HvH


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: OB disabled for HvH events
/:cl:
