### PR TITLE
Add automatic General Quarters announcement on hijack

### DIFF
--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -359,7 +359,7 @@
 
 	marine_announcement("Unscheduled dropship departure detected from operational area. Hijack likely. Shutting down autopilot.", "Dropship Alert", 'sound/AI/hijack.ogg', logging = ARES_LOG_SECURITY)
 	log_ares_flight("Unknown", "Unscheduled dropship departure detected from operational area. Hijack likely. Shutting down autopilot.")
-
+	addtimer(CALLBACK(src, PROC_REF(hijack_general_quarters)), 10 SECONDS)
 	var/mob/living/carbon/xenomorph/xeno = user
 	var/hivenumber = XENO_HIVE_NORMAL
 	if(istype(xeno))
@@ -382,6 +382,11 @@
 	if(istype(SSticker.mode, /datum/game_mode/colonialmarines))
 		var/datum/game_mode/colonialmarines/colonial_marines = SSticker.mode
 		colonial_marines.add_current_round_status_to_end_results("Hijack")
+
+/obj/structure/machinery/computer/shuttle/dropship/flight/proc/hijack_general_quarters()
+	if(GLOB.security_level < SEC_LEVEL_RED)
+		set_security_level(SEC_LEVEL_RED, no_sound = TRUE, announce = FALSE)
+	shipwide_ai_announcement("ATTENTION! GENERAL QUARTERS. ALL HANDS, MAN YOUR BATTLESTATIONS.", MAIN_AI_SYSTEM, 'sound/effects/GQfullcall.ogg')
 
 /obj/structure/machinery/computer/shuttle/dropship/flight/proc/remove_door_lock()
 	if(door_control_cooldown)


### PR DESCRIPTION

# About the pull request
This PR makes it so that General Quarters are called whenever a hijack happens, after the hijack announcement ends.

# Explain why it's good for the game

Soul. General Quarters is already sometimes called on hijack by the admins I believe, and the only other way to call it is by venturing down to ARES. A hijack is a "oh shit!" moment so having general quarters alarm blaring adds to the atmosphere as everyone rushes to whatever spot they decide to hold.

# Testing Photographs and Procedure

I've called a hijack, a General Quarters announcement is made two seconds after the hijack announcement audio ends.


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Mikrel0712
add: Hijack now automatically calls General Quarters
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
