### PR TITLE
Colors some lights

### DIFF
--- a/code/__DEFINES/colours.dm
+++ b/code/__DEFINES/colours.dm
@@ -120,16 +120,18 @@
 #define LIGHT_COLOR_FIRE    "#FAA019"
 /// Very warm yellow, leaning slightly towards orange. rgb(196, 138, 24)
 #define LIGHT_COLOR_LAVA    "#C48A18"
+/// Very warm yellowish-white color for candlelight. rgb(255, 187, 110)
+#define LIGHT_COLOR_CANDLE "#FFBB6E"
 /// Bright, non-saturated red. Leaning slightly towards pink for visibility. rgb(250, 100, 75)
 #define LIGHT_COLOR_FLARE   "#FA644B"
 /// Weird color, between yellow and green, very slimy. rgb(175, 200, 75)
 #define LIGHT_COLOR_SLIME_LAMP "#AFC84B"
-/// Extremely diluted yellow, close to skin color (for some reason). rgb(250, 225, 175)
-#define LIGHT_COLOR_TUNGSTEN   "#FAE1AF"
+/// Incandascent warm white, for usage in lights. rgb(255, 239, 210)
+#define LIGHT_COLOR_TUNGSTEN "#FFEFD2"
 /// Barely visible cyan-ish hue, as the doctor prescribed. rgb(240, 250, 250)
 #define LIGHT_COLOR_HALOGEN "#F0FAFA"
-/// Bluish cyan color for blue lights. rgb(186, 237, 247)
-#define LIGHT_COLOR_XENON "#BAEDF7"
+/// Bluish cyan color for blue lights. rgb(210, 227, 236)
+#define LIGHT_COLOR_XENON "#D2E3EC"
 
 /// The default color for admin say, used as a fallback when the preference is not enabled
 

--- a/code/__DEFINES/colours.dm
+++ b/code/__DEFINES/colours.dm
@@ -128,6 +128,8 @@
 #define LIGHT_COLOR_TUNGSTEN   "#FAE1AF"
 /// Barely visible cyan-ish hue, as the doctor prescribed. rgb(240, 250, 250)
 #define LIGHT_COLOR_HALOGEN "#F0FAFA"
+/// Bluish cyan color for blue lights. rgb(186, 237, 247)
+#define LIGHT_COLOR_XENON "#BAEDF7"
 
 /// The default color for admin say, used as a fallback when the preference is not enabled
 

--- a/code/game/machinery/hybrisa_lights.dm
+++ b/code/game/machinery/hybrisa_lights.dm
@@ -48,6 +48,7 @@
 	icon = 'icons/obj/structures/props/streetlights.dmi'
 	icon_state = "street_off"
 	layer = BILLBOARD_LAYER
+	light_color = LIGHT_COLOR_XENON
 
 /obj/structure/machinery/colony_floodlight/street/Initialize(mapload, ...)
 	. = ..()

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -259,6 +259,7 @@
 	icon_state = "menorah"
 	item_state = "menorah"
 	light_range = 2
+	light_color = LIGHT_COLOR_CANDLE
 	w_class = SIZE_LARGE
 	on = 1
 	breaking_sound = null
@@ -270,6 +271,7 @@
 	icon_state = "candelabra"
 	force = 15
 	on = TRUE
+	light_color = LIGHT_COLOR_CANDLE
 
 	breaking_sound = null
 
@@ -285,6 +287,7 @@
 	desc = "An emergency light tube mounted onto a tripod. It seemingly lasts forever."
 	icon_state = "tripod_lamp"
 	light_range = 6//pretty good
+	light_color = LIGHT_COLOR_XENON
 	w_class = SIZE_LARGE
 	on = 1
 

--- a/code/modules/clothing/suits/marine_armor/_marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor/_marine_armor.dm
@@ -85,6 +85,7 @@
 
 	light_power = 3
 	light_range = 4
+	light_color = LIGHT_COLOR_TUNGSTEN
 	light_system = MOVABLE_LIGHT
 
 	var/flashlight_cooldown = 0 //Cooldown for toggling the light

--- a/code/modules/lighting/lighting_mask/lighting_mask.dm
+++ b/code/modules/lighting/lighting_mask/lighting_mask.dm
@@ -6,7 +6,7 @@
 /atom/movable/lighting_mask
 	name = ""
 	icon = LIGHTING_ICON_BIG
-	icon_state  = "light_big"
+	icon_state  = "light_normalized"
 
 	anchored = TRUE
 	plane = LIGHTING_PLANE

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -147,7 +147,7 @@
 	light_color = LIGHT_COLOR_TUNGSTEN
 	var/on = 0 // 1 if on, 0 if off
 	var/on_gs = 0
-	var/brightness = 8 // luminosity when on, also used in power calculation
+	var/brightness = 6 // luminosity when on, also used in power calculation
 	var/status = LIGHT_OK // LIGHT_OK, _EMPTY, _BURNED or _BROKEN
 	var/flickering = 0
 	var/light_type = /obj/item/light_bulb/tube // the type of light item
@@ -796,6 +796,7 @@
 	power_channel = POWER_CHANNEL_LIGHT //Lights are calc'd via area so they dont need to be in the machine list
 	unslashable = TRUE
 	unacidable = TRUE
+	light_color = LIGHT_COLOR_FLARE
 	var/obj/docking_port/stationary/marine_dropship/linked_port = null
 
 //Don't allow blowing those up, so Marine nades don't fuck them

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -144,6 +144,7 @@
 	active_power_usage = 20
 	power_channel = POWER_CHANNEL_LIGHT //Lights are calc'd via area so they dont need to be in the machine list
 	light_system = STATIC_LIGHT
+	light_color = LIGHT_COLOR_HALOGEN
 	var/on = 0 // 1 if on, 0 if off
 	var/on_gs = 0
 	var/brightness = 8 // luminosity when on, also used in power calculation
@@ -171,6 +172,7 @@
 	icon_state = "btube1"
 	base_state = "btube"
 	desc = "A lighting fixture that is fitted with a bright blue fluorescent light tube. Looking at it for too long makes your eyes go watery."
+	light_color = LIGHT_COLOR_XENON
 
 // the smaller bulb light fixture
 
@@ -189,6 +191,7 @@
 	brightness = 4
 	desc = "A small lighting fixture that is fitted with a bright blue fluorescent light bulb. Looking at it for too long makes your eyes go watery."
 	light_type = /obj/item/light_bulb/bulb
+	light_color = LIGHT_COLOR_XENON
 
 /obj/structure/machinery/light/double
 	icon_state = "ptube1"
@@ -199,6 +202,7 @@
 	icon_state = "bptube1"
 	base_state = "bptube"
 	desc = "A lighting fixture that can be fitted with two bright fluorescent light tubes for that extra eye-watering goodness."
+	light_color = LIGHT_COLOR_XENON
 
 /obj/structure/machinery/light/spot
 	name = "spotlight"
@@ -217,6 +221,7 @@
 	fitting = "large tube"
 	light_type = /obj/item/light_bulb/tube/large/
 	brightness = 12
+	light_color = LIGHT_COLOR_XENON
 
 // Dropship lights that use no power
 /obj/structure/machinery/light/dropship
@@ -233,17 +238,20 @@
 /obj/structure/machinery/light/dropship/green
 	icon_state = "gtube1"
 	base_state = "gtube"
-	desc = "A lighting fixture that is fitted with a bright green fluorescent light tube. Looking at it for too long makes your eyes go watery. Used by aircraft vehicles"
+	desc = "A lighting fixture that is fitted with a bright green fluorescent light tube. Looking at it for too long makes your eyes go watery. Used by aircraft vehicles."
+	light_color = LIGHT_COLOR_GREEN
 
 /obj/structure/machinery/light/dropship/red
 	icon_state = "rtube1"
 	base_state = "rtube"
-	desc = "A lighting fixture that is fitted with a bright red fluorescent light tube. Looking at it for too long makes your eyes go watery. Used by aircraft vehicles"
+	desc = "A lighting fixture that is fitted with a bright red fluorescent light tube. Looking at it for too long makes your eyes go watery. Used by aircraft vehicles."
+	light_color = LIGHT_COLOR_RED
 
 /obj/structure/machinery/light/dropship/blue
 	icon_state = "btube1"
 	base_state = "btube"
-	desc = "A lighting fixture that is fitted with a bright blue fluorescent light tube. Looking at it for too long makes your eyes go watery. Used by aircraft vehicles"
+	desc = "A lighting fixture that is fitted with a bright blue fluorescent light tube. Looking at it for too long makes your eyes go watery. Used by aircraft vehicles."
+	light_color = LIGHT_COLOR_BLUE
 
 /obj/structure/machinery/light/built/Initialize()
 	. = ..()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -144,7 +144,7 @@
 	active_power_usage = 20
 	power_channel = POWER_CHANNEL_LIGHT //Lights are calc'd via area so they dont need to be in the machine list
 	light_system = STATIC_LIGHT
-	light_color = LIGHT_COLOR_HALOGEN
+	light_color = LIGHT_COLOR_TUNGSTEN
 	var/on = 0 // 1 if on, 0 if off
 	var/on_gs = 0
 	var/brightness = 8 // luminosity when on, also used in power calculation


### PR DESCRIPTION

# About the pull request

Colors (stationary) lights in-game to be shades of warm white and blue, depending on their bulb color, rather than the pure white they currently are. Tinted lights (like those on dropships) also have their own colors now, visible especially in places like the hangar or on a landing pad.

Normal lights (whose bulbs are tinted yellow) now have a warm white, incandascent look to them, while blue lights give off a harsher bluish tint.

# Explain why it's good for the game

Adds that sort of retro look to the game while leveraging the new lighting system's full potential. Colored lighting is in the game (as we've seen with things like flares) but the game doesn't do a whole lot to make use of it. Maybe this'll change that.

This PR also has the side-effect of making the game less straining on the eyes, like a sort of blue light filter.

Other lights like floodlights or flashlights still remain white (for now).

# Screenshots
Actual colors may vary ingame due to slight adjustments.

<details>
<summary>Almayer (Click to show/hide)</summary>

![image](https://github.com/user-attachments/assets/8b313a3a-55be-40db-98c4-2b161a664a17)
![image](https://github.com/user-attachments/assets/8e3b5bc0-a48f-41d8-9f00-d206c1e35152)
![image](https://github.com/user-attachments/assets/81a70a7b-c84c-4495-a2b1-ed04e9cbc2f6)
![image](https://github.com/user-attachments/assets/6c529d5e-0560-4900-8c9c-092caf69b316)
![image](https://github.com/user-attachments/assets/14b6a5aa-9379-4749-bbe6-e829f85a2fbe)
![image](https://github.com/user-attachments/assets/0f2ff550-12cf-47d4-8798-21e8c1245e90)


</details>

<details>
<summary>Hybrisa (Click to show/hide)</summary>

![image](https://github.com/user-attachments/assets/a01a9bae-1398-4e6f-914b-49c69de749bf)
![image](https://github.com/user-attachments/assets/d02d6814-c6df-4896-b1c2-6724d30c76cc)
![image](https://github.com/user-attachments/assets/b7c2807f-acfa-4f46-ba94-c63d1a740e5e)
![image](https://github.com/user-attachments/assets/e5592d5b-fa38-443b-b58c-3ebd2ec68e67)
![image](https://github.com/user-attachments/assets/e24a700c-194b-42ca-b6e3-f811cef7a293)
![image](https://github.com/user-attachments/assets/ab46f2a0-e629-4992-a02f-8d7a2ef2072f)
![image](https://github.com/user-attachments/assets/081c5982-094e-4c3f-b6df-59e89828ab77)


</details>

<details>
<summary>Fiorina (Click to show/hide)</summary>

![image](https://github.com/user-attachments/assets/d9f27419-460b-4264-aa83-c8b69ea9446f)
![image](https://github.com/user-attachments/assets/20a6ec43-8858-47f6-8372-d557298a70a1)
![image](https://github.com/user-attachments/assets/18112173-6099-4fca-8971-cec3ab8390d0)

</details>

# Changelog
:cl:
add: Changed most structure lights in the game to be either an incandascent warm white/yellow, or a cold blue, depending on their bulb color.
/:cl:
