### PR TITLE
When 2 Chargers Collide, they cause a tremor

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/crusher/charger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/crusher/charger.dm
@@ -382,11 +382,20 @@
 			charger_ability.stop_momentum() // antigrief
 			return
 		if(HAS_TRAIT(src, TRAIT_CHARGING))
-			apply_effect(2, WEAKEN)
-			xeno.apply_effect(2, WEAKEN)
+			apply_effect(1, WEAKEN)
+			xeno.apply_effect(1, WEAKEN)
 			throw_atom(get_step(src, pick(GLOB.cardinals)), 1, 3, xeno, TRUE)
 			xeno.throw_atom(get_step(xeno, pick(GLOB.cardinals)), 1, 3, xeno, TRUE)
 			charger_ability.stop_momentum() // We assume the other crusher'sparks handle_charge_collision() kicks in and stuns us too.
+			for(var/mob/living/carbon/carbon_target in range(7, xeno))
+				to_chat(carbon_target, SPAN_WARNING("The chargers colliding causes the ground to shake!"))
+				shake_camera(carbon_target, 2, 3)
+				if(get_dist(xeno, carbon_target) <= 3 && !xeno.can_not_harm(carbon_target))
+					if(carbon_target.mob_size >= MOB_SIZE_BIG)
+						carbon_target.apply_effect(1, SLOW)
+					else
+						carbon_target.apply_effect(1, WEAKEN)
+						to_chat(carbon_target, SPAN_WARNING("The violent tremors make you lose your footing!"))
 			playsound(get_turf(xeno), 'sound/effects/bang.ogg', 25, 0)
 			return
 		var/list/ram_dirs = get_perpen_dir(xeno.dir)


### PR DESCRIPTION
# About the pull request
When 2 chargers with the TRAIT_CHARGING (actively charging) hit eachother, it causes a tremor to all nearby marines (1s stun/slow).

Reduced the stun from 2 seconds to 1 second for both chargers.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Currently, if 2 charger crushers collide on the frontline, they're stunned for 2 seconds and generally immediately die to bullets because of a fellow T3 STUNNING FOR TWO SECONDS (For reference, AP direct hit is a 3 second stun), typically right infront of the marine deathball.

With this change, it stuns/slows nearby marines to give chargers a chance to escape (as well as looking neat)
# Testing Photographs and Procedure
Note: In the tests the charger has TRAIT_CHARGING so that I could test it, there is not a stun if you hit a stationary charger crusher or base strain crusher.


https://github.com/user-attachments/assets/dcc5a1d1-448a-497c-89f0-b41f8bd29387




# Changelog
:cl:
add: When 2 charger crushers collide, they now cause a tremor, knocking down and slowing nearby enemies
balance: reduced charger collision weaken (to the charger crushers) by 1 second
/:cl:
