### PR TITLE
The weeds... they crave for more....

### DIFF
--- a/code/modules/cm_aliens/weeds.dm
+++ b/code/modules/cm_aliens/weeds.dm
@@ -229,6 +229,7 @@
 			continue
 		if(!spread_on_semiweedable && is_weedable < FULLY_WEEDABLE)
 			continue
+		T.clean_cleanables()
 
 		var/obj/effect/alien/resin/fruit/old_fruit
 


### PR DESCRIPTION
Concept Inspired: #3644

# About the pull request

This PR add ability for weeds to "clear" turf from any cleanable objects/effects (anything defined as cleanable), oryginal idea was from noticing that weeds somehow appear "under" blood with kinda look strange from "realistic" view, and wanted to give them ability to clean blood from dense battlefield places, where rendering whole screen of red & green blood everywhere made me have hard time (as xeno) to see enemy if they were covered in blood/have same or similar color as background mess.

# Explain why it's good for the game

When weeds spread, they will now "cover" (clean) blood and any other cleanable, it will reduce amount of stuff like blood to render on client side and increase visibility/readability on what you are looking at.


# Testing Video
<details>
<summary>press HERE to see video</summary>

Video showing how weeds clear floor from blood:

https://github.com/user-attachments/assets/3f4ebe3a-bc30-4a05-84f1-fca9118bc947

</details>


# Changelog
:cl: Venuska1117
code: weeds now clean turf when they spread.
/:cl:
