### PR TITLE
Changes Xenos Strain Alert() to tgui_alert()

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/xeno_strain.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/xeno_strain.dm
@@ -85,7 +85,7 @@
 	if(!can_take_strain())
 		return
 	// Show the user the strain's description, and double check that they want it.
-	if(tgui_alert(usr, "[initial(chosen_strain.description)]\n\nConfirm mutation?", "Choose Strain", list("Yes", "No")) != "Yes")
+	if(tgui_alert(usr, "[initial(chosen_strain.description)]", "Choose Strain", list("Confirm Mutation", "Cancel")) != "Confirm Mutation")
 		return
 	// One more time after they confirm.
 	if(!can_take_strain())

--- a/code/modules/mob/living/carbon/xenomorph/strains/xeno_strain.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/xeno_strain.dm
@@ -110,6 +110,7 @@
 	if(!COOLDOWN_FINISHED(src, next_strain_reset))
 		to_chat(src, SPAN_WARNING("We lack the strength to reset our strain. We will be able to reset it in [round((next_strain_reset - world.time) / 600, 1)] minutes"))
 		return
+
 	// Show the user the strain's description, and double check that they want it.
 	if(tgui_alert(src, "Are you sure?", "Reset Strain", list("Yes", "No")) != "Yes")
 		return

--- a/code/modules/mob/living/carbon/xenomorph/strains/xeno_strain.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/xeno_strain.dm
@@ -85,7 +85,7 @@
 	if(!can_take_strain())
 		return
 	// Show the user the strain's description, and double check that they want it.
-	if(alert(usr, "[initial(chosen_strain.description)]\n\nConfirm mutation?", "Choose Strain", "Yes", "No") != "Yes")
+	if(tgui_alert(usr, "[initial(chosen_strain.description)]\n\nConfirm mutation?", "Choose Strain", list("Yes", "No")) != "Yes")
 		return
 	// One more time after they confirm.
 	if(!can_take_strain())
@@ -110,7 +110,6 @@
 	if(!COOLDOWN_FINISHED(src, next_strain_reset))
 		to_chat(src, SPAN_WARNING("We lack the strength to reset our strain. We will be able to reset it in [round((next_strain_reset - world.time) / 600, 1)] minutes"))
 		return
-	
 	// Show the user the strain's description, and double check that they want it.
 	if(tgui_alert(src, "Are you sure?", "Reset Strain", list("Yes", "No")) != "Yes")
 		return


### PR DESCRIPTION
# About the pull request

Changes Xenos Strain Alert() to tgui_alert(), "Yes" and "No"  changed to: "Confirm Mutation" and "Cancel"

# Explain why it's good for the game

Changing from alert window to tgui_alert make it look way better, and for some reason choosing strain is tgui, but alert is not.


# Testing Photographs and Procedure
<details>
<summary>Before (press here to see)</summary>

![image](https://github.com/user-attachments/assets/c781c53b-2682-4493-82e2-f8358f00c205)

</details>

<details>
<summary>After (press here to see)</summary>

![image](https://github.com/user-attachments/assets/4f6188b2-fcfd-4811-8f9e-1573de271c67)

</details>


# Changelog
:cl:
code: changed strain alert() to tgui_alert(), "Yes" and "No" got changed to "Confirm Mutation" and "Cancel".
/:cl:
