### PR TITLE
Fix typo in Robotech Deluxe

### DIFF
--- a/code/game/machinery/vending/vendor_types/engineering.dm
+++ b/code/game/machinery/vending/vendor_types/engineering.dm
@@ -205,7 +205,7 @@
 		list("Proximity Sensor", 4, /obj/item/device/assembly/prox_sensor, VENDOR_ITEM_REGULAR),
 		list("Signaller", 4, /obj/item/device/assembly/signaller, VENDOR_ITEM_REGULAR),
 
-		list("MISCELLANOUS", -1, null, null),
+		list("MISCELLANEOUS", -1, null, null),
 		list("Anesthetic Tank", 2, /obj/item/tank/anesthetic, VENDOR_ITEM_REGULAR),
 		list("Health Analyzer", 2, /obj/item/device/healthanalyzer, VENDOR_ITEM_REGULAR)
 	)


### PR DESCRIPTION
# About the pull request

Fixes typo in section title.
From MISCELLANOUS to MISCELLAN**E**OUS

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

# Changelog
just a typo fix, no need for cl.