### PR TITLE
Synthkey Description Fix

### DIFF
--- a/code/game/objects/items/devices/defibrillator.dm
+++ b/code/game/objects/items/devices/defibrillator.dm
@@ -355,7 +355,8 @@
 
 /obj/item/device/defibrillator/synthetic/get_examine_text(mob/user)
 	. = ..()
-	. += SPAN_NOTICE("You need some knowledge of electronics and circuitry to use this.")
+	if(!noskill)
+		. += SPAN_NOTICE("You need some knowledge of electronics and circuitry to use this.")
 
 /obj/item/device/defibrillator/synthetic/check_revive(mob/living/carbon/human/H, mob/living/carbon/human/user)
 	if(!issynth(H))


### PR DESCRIPTION

# About the pull request

Makes it so the prompt about needing engineering skill only appears when it's true.

# Explain why it's good for the game

Misleading prompts bad


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Synthetic Reset Key description now only says you need engineering knowledge when you actually do.
/:cl:
