### PR TITLE
Alchemist Spitter Strain: 100% Pain in a Bottle

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -407,6 +407,9 @@
 #define PRAETORIAN_WARDEN "Warden"
 #define PRAETORIAN_OPPRESSOR "Oppressor"
 
+// Spitter strain flags
+#define SPITTER_ALCHEMIST "Alchemist"
+
 /////////////////////////////////////////////////////////////////////////////////////
 //
 // Modifiers

--- a/code/modules/mob/living/carbon/xenomorph/abilities/spitter/spitter_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/spitter/spitter_abilities.dm
@@ -42,3 +42,40 @@
 
 /datum/action/xeno_action/activable/tail_stab/spitter
 	name = "Corrosive Tail Stab"
+
+// Alchemist Abilities
+
+/datum/action/xeno_action/activable/tail_inject
+	name = "Tail Injection"
+	action_icon_state = "tail_attack"
+	macro_path = /datum/action/xeno_action/verb/verb_tail_injection
+	ability_primacy = XENO_PRIMARY_ACTION_1
+	action_type = XENO_ACTION_ACTIVATE
+	plasma_cost = 50
+	xeno_cooldown = 12 SECONDS
+
+/datum/action/xeno_action/onclick/select_alchem
+	name = "Select Chemical"
+	action_icon_state = "emit_pheromones"
+	macro_path = /datum/action/xeno_action/verb/verb_select_alchem
+	ability_primacy = XENO_PRIMARY_ACTION_2
+	action_type = XENO_ACTION_CLICK
+
+/datum/action/xeno_action/onclick/produce_alchem
+	name = "Produce Chemical"
+	action_icon_state = "emit_pheromones"
+	macro_path = /datum/action/xeno_action/verb/verb_produce_alchem
+	ability_primacy = XENO_PRIMARY_ACTION_3
+	action_type = XENO_ACTION_CLICK
+	plasma_cost = 50
+	xeno_cooldown = 3 SECONDS
+
+	var/amount = 2
+
+/datum/action/xeno_action/onclick/remove_alchem
+	name = "Remove Chemical"
+	action_icon_state = "emit_pheromones"
+	macro_path = /datum/action/xeno_action/verb/verb_remove_alchem
+	ability_primacy = XENO_PRIMARY_ACTION_4
+	action_type = XENO_ACTION_CLICK
+	plasma_cost = 25

--- a/code/modules/mob/living/carbon/xenomorph/abilities/spitter/spitter_macros.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/spitter/spitter_macros.dm
@@ -4,3 +4,33 @@
 	set hidden = TRUE
 	var/action_name = "Dodge"
 	handle_xeno_macro(src, action_name)
+
+// Alchemist Macros
+
+/datum/action/xeno_action/verb/verb_tail_injection()
+	set category = "Alien"
+	set name = "Tail Injection"
+	set hidden = TRUE
+	var/action_name = "Tail Injection"
+	handle_xeno_macro(src, action_name)
+
+/datum/action/xeno_action/verb/verb_select_alchem()
+	set category = "Alien"
+	set name = "Select Chemical"
+	set hidden = TRUE
+	var/action_name = "Select Chemical"
+	handle_xeno_macro(src, action_name)
+
+/datum/action/xeno_action/verb/verb_produce_alchem()
+	set category = "Alien"
+	set name = "Produce Chemical"
+	set hidden = TRUE
+	var/action_name = "Produce Chemical"
+	handle_xeno_macro(src, action_name)
+
+/datum/action/xeno_action/verb/verb_remove_alchem()
+	set category = "Alien"
+	set name = "Remove Chemical"
+	set hidden = TRUE
+	var/action_name = "Remove Chemical"
+	handle_xeno_macro(src, action_name)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/spitter/spitter_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/spitter/spitter_powers.dm
@@ -151,7 +151,7 @@
 	carbon.last_damage_data = create_cause_data(xeno.caste_type, xeno)
 	log_attack("[key_name(xeno)] attacked [key_name(carbon)] with Tail Injection")
 
-	apply_cooldown(1 * (alchemist.total_pool * 0.05))
+	apply_cooldown(1 * round(alchemist.total_pool * 0.07))
 	return ..()
 
 /datum/action/xeno_action/activable/tail_inject/proc/reset_direction(mob/living/carbon/xenomorph/xeno, last_dir, new_dir)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Spitter.dm
@@ -15,6 +15,8 @@
 
 	caste_desc = "Ptui!"
 	spit_types = list(/datum/ammo/xeno/acid, /datum/ammo/xeno/acid/spatter)
+	available_strains = list(/datum/xeno_strain/alchemist)
+	behavior_delegate_type = /datum/behavior_delegate/spitter_base
 	evolves_to = list(XENO_CASTE_PRAETORIAN, XENO_CASTE_BOILER)
 	deevolves_to = list(XENO_CASTE_SENTINEL)
 	acid_level = 2
@@ -63,3 +65,6 @@
 	weed_food_icon = 'icons/mob/xenos/weeds_48x48.dmi'
 	weed_food_states = list("Drone_1","Drone_2","Drone_3")
 	weed_food_states_flipped = list("Drone_1","Drone_2","Drone_3")
+
+/datum/behavior_delegate/spitter_base
+	name = "Base Spitter Behavior Delegate"

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/drone/gardener.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/drone/gardener.dm
@@ -253,7 +253,7 @@
 			to_chat(xeno, SPAN_WARNING("That's too far away!"))
 			return
 
-	if (!check_and_use_plasma_owner())
+	if(!check_and_use_plasma_owner())
 		return
 
 	var/turf/target_turf = get_turf(target_atom)

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/spitter/alchemist.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/spitter/alchemist.dm
@@ -1,0 +1,232 @@
+/datum/xeno_strain/alchemist
+	name = SPITTER_ALCHEMIST
+	description = "In exchange for your acid, normal tail stab and base abilities, gain the ability to select, produce or remove three toxic chemicals into a stockpile and inject the entirety of it into opponents at once, with the effect depending on chemical pairing. Based on Tail Stab, Tail Injection takes all chemicals in your stockpile and injects them all into your opponent, with cooldown depending on how much you have injected at once. Select Chemical allows you to select a chemical to produce, Produce Chemical has a 1.5 second channel to add a little bit to your stockpile, and Remove Chemical allows you to remove the entirety of whatever chemical you have selected from your stockpile."
+	flavor_description = "This one shall be the cauldron in which draughts of suffering shall be brewed and given to our enemies."
+	icon_state_prefix = "Alchemist"
+
+	actions_to_remove = list(
+		/datum/action/xeno_action/activable/tail_stab/spitter,
+		/datum/action/xeno_action/activable/corrosive_acid,
+		/datum/action/xeno_action/activable/xeno_spit,
+		/datum/action/xeno_action/onclick/charge_spit,
+		/datum/action/xeno_action/activable/spray_acid/spitter,
+	)
+	actions_to_add = list(
+		/datum/action/xeno_action/activable/tail_inject,
+		/datum/action/xeno_action/onclick/select_alchem,
+		/datum/action/xeno_action/onclick/produce_alchem,
+		/datum/action/xeno_action/onclick/remove_alchem,
+	)
+
+	behavior_delegate_type = /datum/behavior_delegate/spitter_alchemist
+
+/datum/xeno_strain/alchemist/apply_strain(mob/living/carbon/xenomorph/spitter/spitter)
+	spitter.speed_modifier += XENO_SPEED_SLOWMOD_TIER_3
+	spitter.plasma_types -= PLASMA_NEUROTOXIN
+	spitter.plasma_types += PLASMA_PHEROMONE // Alchemist Spitter got some funky shit in their alien bloodstream
+
+	spitter.recalculate_everything()
+
+/datum/behavior_delegate/spitter_alchemist
+	name = "Alchemist Spitter Behavior Delegate"
+
+	var/total_pool = 0
+	var/total_pool_cap = 30
+	var/sagunine_pool = 0
+	var/cholinine_pool = 0
+	var/noctine_pool = 0
+
+	var/current_alchem = null
+	var/producing_alchem = FALSE
+
+	var/sagunine_present = 1
+	var/cholinine_present = 2
+	var/noctine_present = 3
+	var/alchem_combination = 0
+	var/final_alchem_name = null
+	var/final_alchem_reagent = null
+	var/final_alchem_source = null
+	var/alchem_xeno_effect = null
+
+/datum/behavior_delegate/spitter_alchemist/append_to_stat()
+	. = list()
+	. += "Stockpiled chemicals: [total_pool] / [total_pool_cap]"
+	if(sagunine_pool > 0)
+		. += "Sagunine stockpiled: [sagunine_pool]"
+	if(cholinine_pool > 0)
+		. += "Cholinine stockpiled: [cholinine_pool]"
+	if(noctine_pool > 0)
+		. += "Noctine stockpiled: [noctine_pool]"
+
+/datum/behavior_delegate/spitter_alchemist/proc/choose_alchem(alchem)
+	if(!alchem)
+		if(current_alchem)
+			current_alchem = null
+			to_chat(bound_xeno, SPAN_XENOWARNING("We relax our body from producing chemicals!"))
+		else
+			if(bound_xeno.client.prefs && bound_xeno.client.prefs.no_radials_preference)
+				alchem = tgui_input_list(bound_xeno, "Choose a pheromone", "Pheromone Menu", "sagunine" + "cholinine" + "noctine" + "help" + "cancel", theme="hive_status")
+				if(alchem == "help")
+					to_chat(bound_xeno, SPAN_NOTICE("<br>You can choose between three unique toxic chemicals to produce with Stockpile and inject into humanoid targets with Injection, with varying effects:<br><B>Sagunine</B> - Deals brute damage and purges Bicardine and Meralyne.<br><B>Cholinine</B> - Deals burn damage and purges Kelotane and Dermaline.<br><B>Noctine</B> - Induces a fair bit of pain and purges Paracetamol, Tramadol and Oxycodone.<br>Stockpiling different chemicals causes them blend together upon Injecting someone to produce a different effect. This happens automatically and regardless of amount stored.<br><B>Experiment!</B><br>"))
+					return
+				if(!alchem || alchem == "cancel" || current_alchem || !bound_xeno.check_state(1)) //If they are stacking windows, disable all input
+					return
+			else
+				var/static/list/alchem_selections = list("Help" = image(icon = 'icons/mob/radial.dmi', icon_state = "radial_help"), "Sagunine" = image(icon = 'icons/mob/radial.dmi', icon_state = "phero_frenzy"), "Cholinine" = image(icon = 'icons/mob/radial.dmi', icon_state = "phero_warding"), "Noctine" = image(icon = 'icons/mob/radial.dmi', icon_state = "phero_recov"))
+				alchem = lowertext(show_radial_menu(bound_xeno, bound_xeno.client?.eye, alchem_selections))
+				if(alchem == "help")
+					to_chat(bound_xeno, SPAN_NOTICE("<br>You can choose between three unique toxic chemicals to produce with Stockpile and inject into humanoid targets with Injection, with varying effects:<br><B>Sagunine</B> - Deals brute damage and purges Bicardine and Meralyne.<br><B>Cholinine</B> - Deals burn damage and purges Kelotane and Dermaline.<br><B>Noctine</B> - Induces a fair bit of pain and purges Paracetamol, Tramadol and Oxycodone.<br>Stockpiling different chemicals causes them blend together upon Injecting someone to produce a different effect. This happens automatically and regardless of amount stored.<br><B>Experiment!</B><br>"))
+					return
+				if(!alchem || current_alchem || !bound_xeno.check_state(1)) //If they are stacking windows, disable all input
+					return
+	if(alchem)
+		if(alchem == current_alchem)
+			to_chat(bound_xeno, SPAN_XENOWARNING("We're already producing [alchem]!"))
+			return
+		current_alchem = alchem
+		to_chat(bound_xeno, SPAN_XENOWARNING("We shift our body to produce [alchem]!"))
+		playsound(bound_xeno.loc, "alien_drool", 25)
+
+/datum/behavior_delegate/spitter_alchemist/proc/stockpile_alchem(amount = 2, alchem = current_alchem)
+	switch(alchem)
+		if("sagunine")
+			sagunine_pool += amount
+		if("cholinine")
+			cholinine_pool += amount
+		if("noctine")
+			noctine_pool += amount
+
+	total_pool += amount
+	to_chat(bound_xeno, SPAN_XENOWARNING("We produce [alchem] and add it to our chemical stockpile!"))
+	playsound(bound_xeno.loc, "alien_drool", 25)
+
+/datum/behavior_delegate/spitter_alchemist/proc/remove_alchem(alchem = current_alchem)
+	switch(alchem)
+		if("sagunine")
+			total_pool -= sagunine_pool
+			sagunine_pool = 0
+		if("cholinine")
+			total_pool -= cholinine_pool
+			cholinine_pool = 0
+		if("noctine")
+			total_pool -= noctine_pool
+			noctine_pool = 0
+
+	to_chat(bound_xeno, SPAN_XENOWARNING("We purge all [alchem] from our chemical stockpile!"))
+	playsound(bound_xeno.loc, "alien_drool", 25)
+
+/datum/behavior_delegate/spitter_alchemist/proc/empty_entire_stockpile()
+	sagunine_pool = 0
+	cholinine_pool = 0
+	noctine_pool = 0
+	total_pool = 0
+	alchem_combination = 0
+	final_alchem_name = null
+	final_alchem_reagent = null
+	final_alchem_source = null
+
+/datum/behavior_delegate/spitter_alchemist/proc/parse_final_alchem()
+	if(sagunine_pool > 0)
+		alchem_combination += 1
+
+	if(cholinine_pool > 0)
+		alchem_combination += 2
+
+	if(noctine_pool > 0)
+		alchem_combination += 4
+
+	switch(alchem_combination)
+		if(1) // Sagunine
+			final_alchem_name = "Saguinine"
+			final_alchem_reagent = "xenoalch_brute"
+			final_alchem_source = /datum/reagent/toxin/alchemic/sagunine
+		if(2) // Cholinine
+			final_alchem_name = "Cholinine"
+			final_alchem_reagent = "xenoalch_burn"
+			final_alchem_source = /datum/reagent/toxin/alchemic/cholinine
+		if(3) // Sagunine + Cholinine = Pyrinine
+			final_alchem_name = "Pyrinine"
+			final_alchem_reagent = "xenoalch_fire"
+			final_alchem_source = /datum/reagent/toxin/alchemic/pyrinine
+		if(4) // Noctine
+			final_alchem_name = "Noctine"
+			final_alchem_reagent = "xenoalch_pain"
+			final_alchem_source = /datum/reagent/toxin/alchemic/noctine
+		if(5) // Noctine + Sagunine = Vapinine
+			final_alchem_name = "Vapinine"
+			final_alchem_reagent = "xenoalch_bloodloss"
+			final_alchem_source = /datum/reagent/toxin/alchemic/vapinine
+		if(6) // Noctine + Cholinine = Crynine
+			final_alchem_name = "Crynine"
+			final_alchem_reagent = "xenoalch_freeze"
+			final_alchem_source = /datum/reagent/toxin/alchemic/crynine
+		if(7) // Noctine + Sagunine + Cholinine = Xenosterine
+			final_alchem_name = "Xenosterine"
+			final_alchem_reagent = "xenoalch_purge"
+			final_alchem_source = /datum/reagent/toxin/alchemic/xenosterine
+
+/datum/behavior_delegate/spitter_alchemist/proc/final_alchem_info()
+	switch(final_alchem_name)
+		if("Saguinine")
+			to_chat(bound_xeno, SPAN_XENOWARNING("We catalyzed Saguinine! It will deal brute damage and purge most chemicals that recover it!"))
+		if("Cholinine")
+			to_chat(bound_xeno, SPAN_XENOWARNING("We catalyzed Cholinine! It will deal burn damage and purge most chemicals that recover it!"))
+		if("Noctine")
+			to_chat(bound_xeno, SPAN_XENOWARNING("We catalyzed Noctine! It will induce large amounts of pain and purge most chemicals that alleviate it!"))
+		if("Pyrinine")
+			to_chat(bound_xeno, SPAN_XENOWARNING("We catalyzed Pyrinine! It will increase body temperature to almost burning!"))
+		if("Vapinine")
+			to_chat(bound_xeno, SPAN_XENOWARNING("We catalyzed Vapinine! It will drain blood!"))
+		if("Crynine")
+			to_chat(bound_xeno, SPAN_XENOWARNING("We catalyzed Crynine! It will decrease body temperature to almost freezing!"))
+		if("Xenosterine")
+			to_chat(bound_xeno, SPAN_XENOWARNING("We catalyzed Xenosterine! It will rapidly purge any chemical that isn't a toxin!"))
+
+/datum/behavior_delegate/spitter_alchemist/proc/alchem_xeno_reaction(mob/living/carbon/xenomorph/target)
+	switch(final_alchem_name)
+		if("Saguinine") // Just does bonus damage
+			to_chat(target, SPAN_XENOWARNING("You feel like something has just ruptured!"))
+			target.apply_damage(total_pool * XVX_UNIVERSAL_DAMAGEMULT)
+		if("Cholinine") // Also just does bonus damage
+			to_chat(target, SPAN_XENOWARNING("You feel like you're burning!"))
+			target.apply_damage(total_pool * XVX_UNIVERSAL_DAMAGEMULT)
+		if("Noctine") // Weakens armor
+			to_chat(target, SPAN_XENOWARNING("You feel your chitin soften!"))
+			xeno_stat_debuff(target, "armor")
+		if("Pyrinine") // Weakens slash damage
+			to_chat(target, SPAN_XENOWARNING("You feel your claws weaken!"))
+			xeno_stat_debuff(target, "slash")
+		if("Vapinine") // Drains plasma
+			target.plasma_stored = max(target.plasma_stored - (target.plasma_max * (total_pool / 100)), 0)
+			to_chat(target, SPAN_WARNING("You feel your plasma reserves being drained!"))
+		if("Crynine") // Slows down
+			to_chat(target, SPAN_XENOWARNING("You suddenly feel lethargic!"))
+			xeno_stat_debuff(target, "speed")
+		if("Xenosterine") // Blocks hivemind
+			to_chat(target, SPAN_WARNING("Your mind has suddenly gone quiet!"))
+			target.AddComponent(/datum/component/status_effect/interference, 3 * total_pool, 15)
+
+/datum/behavior_delegate/spitter_alchemist/proc/xeno_stat_debuff(mob/living/carbon/xenomorph/victim, effect)
+	switch(effect)
+		if("slash")
+			victim.damage_modifier -= XENO_DAMAGE_MOD_SMALL
+			victim.recalculate_damage()
+		if("armor")
+			victim.armor_modifier -= XENO_ARMOR_MOD_SMALL
+			victim.recalculate_armor()
+		if("speed")
+			victim.speed_modifier += XENO_SPEED_SLOWMOD_TIER_3
+			victim.recalculate_speed()
+	addtimer(CALLBACK(victim, PROC_REF(xeno_stat_debuff_remove), effect), total_pool)
+
+/datum/behavior_delegate/spitter_alchemist/proc/xeno_stat_debuff_remove(mob/living/carbon/xenomorph/victim, effect)
+	switch(effect)
+		if("slash")
+			victim.damage_modifier += XENO_DAMAGE_MOD_SMALL
+			victim.recalculate_damage()
+		if("armor")
+			victim.armor_modifier += XENO_ARMOR_MOD_SMALL
+			victim.recalculate_armor()
+		if("speed")
+			victim.speed_modifier -= XENO_SPEED_SLOWMOD_TIER_3
+			victim.recalculate_speed()

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/spitter/alchemist.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/spitter/alchemist.dm
@@ -197,8 +197,9 @@
 			to_chat(target, SPAN_XENOWARNING("You feel your claws weaken!"))
 			xeno_stat_debuff(target, "slash")
 		if("Vapinine") // Drains plasma
-			target.plasma_stored = max(target.plasma_stored - (target.plasma_max * (total_pool / 100)), 0)
-			to_chat(target, SPAN_WARNING("You feel your plasma reserves being drained!"))
+			if(target.plasma_max > 0)
+				target.plasma_stored = max(target.plasma_stored - (target.plasma_max * (total_pool / 100)), 0)
+				to_chat(target, SPAN_WARNING("You feel your plasma reserves being drained!"))
 		if("Crynine") // Slows down
 			to_chat(target, SPAN_XENOWARNING("You suddenly feel lethargic!"))
 			xeno_stat_debuff(target, "speed")

--- a/code/modules/reagents/chemistry_reagents/toxin.dm
+++ b/code/modules/reagents/chemistry_reagents/toxin.dm
@@ -312,7 +312,7 @@
 	id = "xenoalch_brute"
 	description = "A blood red chemical compound of Xenomorph origin. Has cytotoxic properties resulting in necrosis of tissue, and appears to purge certain chemicals with neogenetic properties."
 	color = "#880808"
-	properties = list(PROPERTY_CROSSMETABOLIZING = 3, PROPERTY_BIOCIDIC = 2)
+	properties = list(PROPERTY_CROSSMETABOLIZING = 3, PROPERTY_BIOCIDIC = 1)
 	purges_specific_chems = TRUE
 	specific_chem_purge = list(/datum/reagent/medical/bicaridine, /datum/reagent/medical/meralyne)
 
@@ -321,7 +321,7 @@
 	id = "xenoalch_burn"
 	description = "A sickly yellow chemical compound of Xenomorph origin. Has caustic properties resulting in internal chemical burns, and appears to purge certain chemicals with anti-corrosive properties."
 	color = "#FDFD96"
-	properties = list(PROPERTY_CROSSMETABOLIZING = 3, PROPERTY_CORROSIVE = 2)
+	properties = list(PROPERTY_CROSSMETABOLIZING = 3, PROPERTY_CORROSIVE = 1)
 	purges_specific_chems = TRUE
 	specific_chem_purge = list(/datum/reagent/medical/kelotane, /datum/reagent/medical/dermaline)
 
@@ -339,7 +339,7 @@
 	id = "xenoalch_fire"
 	description = "."
 	color = "#CC5500"
-	properties = list(PROPERTY_CROSSMETABOLIZING = 3, PROPERTY_HYPERTHERMIC = 2)
+	properties = list(PROPERTY_CROSSMETABOLIZING = 3, PROPERTY_HYPERTHERMIC = 3)
 
 /datum/reagent/toxin/alchemic/vapinine
 	name = "Vapinine"
@@ -353,7 +353,7 @@
 	id = "xenoalch_freeze"
 	description = "."
 	color = "#003b38"
-	properties = list(PROPERTY_CROSSMETABOLIZING = 3, PROPERTY_HYPOTHERMIC = 2)
+	properties = list(PROPERTY_CROSSMETABOLIZING = 3, PROPERTY_HYPOTHERMIC = 3)
 	purges_specific_chems = TRUE
 	specific_chem_purge = list(/datum/reagent/medical/cryoxadone, /datum/reagent/medical/clonexadone)
 

--- a/code/modules/reagents/chemistry_reagents/toxin.dm
+++ b/code/modules/reagents/chemistry_reagents/toxin.dm
@@ -283,3 +283,86 @@
 	reagent_state = LIQUID
 	chemclass = CHEM_CLASS_NONE
 	properties = list(PROPERTY_CORROSIVE = 2, PROPERTY_TOXIC = 1, PROPERTY_CROSSMETABOLIZING = 3)
+
+// Spitter Alchemist Chemicals
+/datum/reagent/toxin/alchemic
+	name = "Unknown Catalyst"
+	id = "xenoalch_base"
+	description = "A highly bizarre chemical compound of Xenomorph origin. What it does exactly is seemingly impossible to discern, and it probably shouldn't exist."
+	color = "#ffffff"
+	reagent_state = LIQUID
+	chemclass = CHEM_CLASS_NONE
+	custom_metabolism = AMOUNT_PER_TIME(1, 5 SECONDS)
+	properties = list(PROPERTY_CROSSMETABOLIZING = 3)
+	// Decides if this chem purges specific chems or not
+	var/purges_specific_chems = FALSE
+	// What chems this chem purges specifically
+	var/specific_chem_purge = list()
+	var/purge_amount = 0.2
+
+/datum/reagent/toxin/alchemic/on_mob_life(mob/living/victim)
+	. = ..()
+	if(!.)
+		return
+	if(purges_specific_chems)
+		victim.reagents.remove_all_type(specific_chem_purge, purge_amount, 0, 1)
+
+/datum/reagent/toxin/alchemic/sagunine
+	name = "Sagunine"
+	id = "xenoalch_brute"
+	description = "A blood red chemical compound of Xenomorph origin. Has cytotoxic properties resulting in necrosis of tissue, and appears to purge certain chemicals with neogenetic properties."
+	color = "#880808"
+	properties = list(PROPERTY_CROSSMETABOLIZING = 3, PROPERTY_BIOCIDIC = 2)
+	purges_specific_chems = TRUE
+	specific_chem_purge = list(/datum/reagent/medical/bicaridine, /datum/reagent/medical/meralyne)
+
+/datum/reagent/toxin/alchemic/cholinine
+	name = "Cholinine"
+	id = "xenoalch_burn"
+	description = "A sickly yellow chemical compound of Xenomorph origin. Has caustic properties resulting in internal chemical burns, and appears to purge certain chemicals with anti-corrosive properties."
+	color = "#FDFD96"
+	properties = list(PROPERTY_CROSSMETABOLIZING = 3, PROPERTY_CORROSIVE = 2)
+	purges_specific_chems = TRUE
+	specific_chem_purge = list(/datum/reagent/medical/kelotane, /datum/reagent/medical/dermaline)
+
+/datum/reagent/toxin/alchemic/noctine
+	name = "Noctine"
+	id = "xenoalch_pain"
+	description = "A dark chemical compound of Xenomorph origin. Has neuropathic properties resulting in high pain induction, and appears to purge certain chemicals with painkilling properties."
+	color = "#280138"
+	properties = list(PROPERTY_CROSSMETABOLIZING = 3, PROPERTY_PAINING = 2)
+	purges_specific_chems = TRUE
+	specific_chem_purge = list(/datum/reagent/medical/paracetamol, /datum/reagent/medical/tramadol, /datum/reagent/medical/oxycodone)
+
+/datum/reagent/toxin/alchemic/pyrinine
+	name = "Pyrinine"
+	id = "xenoalch_fire"
+	description = "."
+	color = "#CC5500"
+	properties = list(PROPERTY_CROSSMETABOLIZING = 3, PROPERTY_HYPERTHERMIC = 2)
+
+/datum/reagent/toxin/alchemic/vapinine
+	name = "Vapinine"
+	id = "xenoalch_bloodloss"
+	description = "."
+	color = "#45192b"
+	properties = list(PROPERTY_CROSSMETABOLIZING = 3, PROPERTY_HEMOLYTIC = 0.5)
+
+/datum/reagent/toxin/alchemic/crynine
+	name = "Crynine"
+	id = "xenoalch_freeze"
+	description = "."
+	color = "#003b38"
+	properties = list(PROPERTY_CROSSMETABOLIZING = 3, PROPERTY_HYPOTHERMIC = 2)
+	purges_specific_chems = TRUE
+	specific_chem_purge = list(/datum/reagent/medical/cryoxadone, /datum/reagent/medical/clonexadone)
+
+/datum/reagent/toxin/alchemic/xenosterine
+	name = "Xenosterine"
+	id = "xenoalch_purge"
+	description = "."
+	color = "#e3dac9"
+	properties = list(PROPERTY_CROSSMETABOLIZING = 3)
+	purges_specific_chems = TRUE
+	specific_chem_purge = list(/datum/reagent/medical, /datum/reagent/generated, /datum/reagent/stimulant)
+	purge_amount = 1

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -2175,6 +2175,7 @@
 #include "code\modules\mob\living\carbon\xenomorph\strains\castes\ravager\berserker.dm"
 #include "code\modules\mob\living\carbon\xenomorph\strains\castes\ravager\hedgehog.dm"
 #include "code\modules\mob\living\carbon\xenomorph\strains\castes\runner\acid.dm"
+#include "code\modules\mob\living\carbon\xenomorph\strains\castes\spitter\alchemist.dm"
 #include "code\modules\mob\living\silicon\death.dm"
 #include "code\modules\mob\living\silicon\login.dm"
 #include "code\modules\mob\living\silicon\say.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

**[THIS PR IS MAINLY FOR DEMONSTRATION AND OPINION GATHERING AS I GOT CARRIED AWAY AND MADE THIS THING'S BALANCE PROBABLY WELL OFF FOR A T2]**

Adds Alchemist strain for Spitter. Ditches base abilities plus Corrosive Acid and normal Tail Stab for a group of abilities oriented around stockpiling three unique toxins and injecting marines with them, with the toxins being combined based on stockpile pairing.

Abilities:
- Tail Injection: A gimped Tail Stab like ability. Does significantly less damage on its own but injects the entirety of your chemical stockpile into your target (stockpile max is 30, so 30u is injected). You will be informed what resultant toxin you have injected into your targets. Cooldown is the same as Tail Stab but is modified by how much you had in your stockpile for a maximum of 25 seconds cooldown.
- Select Chemical: Lets you choose between three chemicals to add to your stockpile (they'll be expanded upon later). You get to see how many of what chem is in your stockpile, although individual amounts don't matter too much outside of keeping track.
- Produce Chemical: Adds 2 points of your selected chemical to your stockpile after a 1.5 second channel [could be 2 seconds instead, but that felt too long]. Has a 3 second cooldown to prevent filling your stockpile too rapidly: it should be a time investment.
- Remove Chemical: Removes all points of your selected chemical from your stockpile. Useful in case you change your mind over which chem you want to use.

Chemicals:
These chems overall have faster metabolisms compared to normal toxins (instead of 0.05 a tick for toxins and 0.1 a tick for normal reagents to a tick to 0.2 a tick), and each one has different effects and also induce different effects if your target is a xeno.
- Sangunine: One of your selectable chems. Has Biocidic 1 and purges Bicaridine and Meralyne. Xenos simply take damage, amount dependant on total stockpiled chems.
- Cholinine: One of your selectable chems. Has Corrosive 1 and purges Kelotane and Dermaline. Xenos simply take damage, amount dependant on total stockpiled chems.
- Noctine: One of your selectable chems. Has Paining 2 and purges Paracetamol, Tramadol and Oxycodone. Xenos have their armor reduced by 10 for an amount of time dependant on total stockpiled chems.
- Pyrinine: Combination of Sangunine and Cholinine. Has Hyperthermic 3.  Xenos have their slash damage reduced by 10 for an amount of time dependant on total stockpiled chems.
- Vapinine: Combination of Sangunine and Noctine. Has Hemolytic 0.5. Xenos lose a percentage of their current plasma based on total stockpiled chems.
- Crynine: Combination of Cholinine and Noctine. Has Hypothermic 3 and also purges Cryoxadone and Clonexadone. Xenos are slowed by 0.15 for an amount of time dependant on total stockpiled chems.
- Xenosterine: Combination of all three chems. Doesn't do damage but purges all medical, generated and stimulant chemicals at rapid pace [may be bugged, isn't removing as fast as wanted although it is removing]. Xenos get cut off from hivemind for an amount of time influenced by total stockpiled chems.

# Explain why it's good for the game

To be real, in it's current state I don't think it'd be added because it is way overtuned for a T2, and also I'm still deliberating on what stats Spitter should gain/lose. But if iI were serious about getting it merged...

Gives Spitter a strain that is still mainly aggressive support oriented and provides quite a unique experience. You might not do a lot of damage and it will take a bit to get the impactful numbers, but what an impact you'll have in making the lives of marines (and xenos in the rare XvX moments we have) an absolute misery.


# Testing Photographs and Procedure
Ain't got no new sprites, everything is placeholder! If this gets seriously considered for merging at some point, the following are needed:
- Radial icons for the three base chemicals
- Sprites for Select, Produce and Remove
- Sprites to make Alchemist Spitter visually distinct enough from base Spitter


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Adds Alchemist Strain for Spitter. Take time to mix n' match three chemicals in a stockpile, then inject the entire stockpile into targets in the form of a toxin. End toxin will vary depend on chemical combination, with up to 7 options, and all of them may make life painful for whatever poor sod you just shanked.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
