### PR TITLE
fixes dragging sometimes being offset weirdly

### DIFF
--- a/tgui/packages/tgui/backend.ts
+++ b/tgui/packages/tgui/backend.ts
@@ -204,7 +204,7 @@ export const backendMiddleware = (store) => {
       // Signal renderer that we have resumed
       resumeRenderer();
       // Setup drag
-      setupDrag();
+      setupDrag(payload.config?.window?.fancy);
       // We schedule this for the next tick here because resizing and unhiding
       // during the same tick will flash with a white background.
       setTimeout(() => {

--- a/tgui/packages/tgui/drag.ts
+++ b/tgui/packages/tgui/drag.ts
@@ -164,7 +164,12 @@ export const recallWindowGeometry = async (
 };
 
 // Setup draggable window
-export const setupDrag = async () => {
+export const setupDrag = async (fancy: boolean) => {
+  if (fancy) {
+    screenOffset = [0, 0];
+    return;
+  }
+
   // Calculate screen offset caused by the windows taskbar
   let windowPosition = getWindowPosition();
 


### PR DESCRIPTION
this whole block of code existed to offset the window bar at the top of tgui windows when we're not using fancy mode

but if we're not using fancy mode, we don't need to bother calculating this stuff anyway, because we don't use that drag mode

and if we are using fancy mode, the offset will always be 0,0

:cl:
fix: fixes tgui windows sometimes offsetting weirdly
/:cl:

weird!