### PR TITLE
Tank nerf

### DIFF
--- a/code/modules/vehicles/hardpoints/primary/flamer.dm
+++ b/code/modules/vehicles/hardpoints/primary/flamer.dm
@@ -23,7 +23,7 @@
 	use_muzzle_flash = FALSE
 
 	scatter = 5
-	fire_delay = 2.0 SECONDS
+	fire_delay = 4.0 SECONDS
 
 /obj/item/hardpoint/primary/flamer/set_bullet_traits()
 	..()

--- a/code/modules/vehicles/tank/tank.dm
+++ b/code/modules/vehicles/tank/tank.dm
@@ -65,7 +65,7 @@
 
 	dmg_multipliers = list(
 		"all" = 1,
-		"acid" = 1.5, // Acid melts the tank
+		"acid" = 1.6, // Acid melts the tank
 		"slash" = 0.7, // Slashing a massive, solid chunk of metal does very little except leave scratches
 		"bullet" = 0.4,
 		"explosive" = 0.8,

--- a/code/modules/vehicles/tank/tank.dm
+++ b/code/modules/vehicles/tank/tank.dm
@@ -65,7 +65,7 @@
 
 	dmg_multipliers = list(
 		"all" = 1,
-		"acid" = 1.6, // Acid melts the tank
+		"acid" = 1.5, // Acid melts the tank
 		"slash" = 0.7, // Slashing a massive, solid chunk of metal does very little except leave scratches
 		"bullet" = 0.4,
 		"explosive" = 0.8,


### PR DESCRIPTION
# About the pull request

* DRG-N Rate of fire has been lowerd. Only letting it fire once every 4 seconds instead of once every 2 seconds.

# Explain why it's good for the game

Tank needs a bit of tweaking. 
DRG-N is basicly a flamer mashine gun currently, non of that. Its shot needs to be more planned, the fact that spamming with it works is bad.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:NHC
balance: change DRG-N fire delay from 2 seconds to 4 seconds
/:cl:
