### PR TITLE
roundstart xenomorph burst bodies ensoulification

### DIFF
--- a/code/game/jobs/job/antag/xeno/xenomorph.dm
+++ b/code/game/jobs/job/antag/xeno/xenomorph.dm
@@ -34,12 +34,7 @@
 	human_to_transform.set_stat(UNCONSCIOUS)
 	human_to_transform.forceMove(get_turf(pick(GLOB.xeno_spawns)))
 
-	var/list/survivor_types = list(
-		/datum/equipment_preset/survivor/scientist,
-		/datum/equipment_preset/survivor/doctor,
-		/datum/equipment_preset/survivor/security,
-		/datum/equipment_preset/survivor/engineer
-	)
+	var/list/survivor_types = SSmapping.configs[GROUND_MAP].survivor_types
 	arm_equipment(human_to_transform, pick(survivor_types), FALSE, FALSE)
 
 	for(var/obj/item/device/radio/radio in human_to_transform.contents_recursive())


### PR DESCRIPTION

# About the pull request

makes roundstart xenomorph players burst out of the map's survivor presets instead of 1 of 4 generic presets

# Explain why it's good for the game

soul

# Testing Photographs and Procedure
![burst](https://github.com/user-attachments/assets/1840aac8-8d0a-4235-9b15-b826fb071443)



# Changelog
:cl:
add: Roundstart Xenomorph players will now burst out of map-specific bodies instead of generic ones
/:cl:
