### PR TITLE
Fix predator limit

### DIFF
--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -58,7 +58,7 @@ Additional game mode variables.
 	var/marine_starting_num = 0 //number of players not in something special
 	var/pred_current_num = 0 //How many are there now?
 	var/pred_per_players = 80 //Preds per player
-	var/pred_start_count = 4 //The initial count of predators
+	var/pred_start_count = 0 //The initial count of predators
 
 	var/pred_additional_max = 0
 	var/pred_leader_count = 0 //How many Leader preds are active
@@ -184,7 +184,7 @@ Additional game mode variables.
 	return floor(length(GLOB.player_list) / pred_per_players) + pred_additional_max + pred_start_count
 
 /datum/game_mode/proc/check_predator_late_join(mob/pred_candidate, show_warning = TRUE)
-	if(!pred_candidate.client)
+	if(!pred_candidate?.client)
 		return
 
 	var/datum/job/pred_job = GLOB.RoleAuthority.roles_by_name[JOB_PREDATOR]
@@ -194,7 +194,7 @@ Additional game mode variables.
 			to_chat(pred_candidate, SPAN_WARNING("Something went wrong!"))
 		return FALSE
 
-	if(!(pred_candidate?.client.check_whitelist_status(WHITELIST_PREDATOR)))
+	if(!pred_candidate.client.check_whitelist_status(WHITELIST_PREDATOR))
 		if(show_warning)
 			to_chat(pred_candidate, SPAN_WARNING("You are not whitelisted! You may apply on the forums to be whitelisted as a predator."))
 		return FALSE
@@ -209,10 +209,10 @@ Additional game mode variables.
 			to_chat(pred_candidate, SPAN_WARNING("You already were a Yautja! Give someone else a chance."))
 		return FALSE
 
-	if(show_warning && tgui_alert(pred_candidate, "Confirm joining the hunt. You will join as \a [lowertext(pred_job.get_whitelist_status(pred_candidate.client))] predator", "Confirmation", list("Yes", "No"), 10 SECONDS) != "Yes")
+	if(show_warning && tgui_alert(pred_candidate, "Confirm joining the hunt. You will join as \a [lowertext(pred_job.get_whitelist_status(pred_candidate.client))] predator.", "Confirmation", list("Yes", "No"), 10 SECONDS) != "Yes")
 		return FALSE
 
-	if(pred_job.get_whitelist_status(pred_candidate.client) == WHITELIST_NORMAL)
+	if(!pred_candidate.client.check_whitelist_status(WHITELIST_YAUTJA_LEADER|WHITELIST_YAUTJA_COUNCIL))
 		var/pred_max = calculate_pred_max()
 		if(pred_current_num >= pred_max)
 			if(show_warning)

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -58,7 +58,7 @@ Additional game mode variables.
 	var/marine_starting_num = 0 //number of players not in something special
 	var/pred_current_num = 0 //How many are there now?
 	var/pred_per_players = 80 //Preds per player
-	var/pred_start_count = 0 //The initial count of predators
+	var/pred_start_count = 4 //The initial count of predators
 
 	var/pred_additional_max = 0
 	var/pred_leader_count = 0 //How many Leader preds are active

--- a/code/game/jobs/job/antag/other/pred.dm
+++ b/code/game/jobs/job/antag/other/pred.dm
@@ -61,4 +61,5 @@
 	. = ..()
 
 	if(SSticker.mode)
-		SSticker.mode.initialize_predator(M, whitelist_status == CLAN_RANK_ADMIN)
+		var/ignore_slot_count = whitelist_status == CLAN_RANK_ADMIN || M?.client?.check_whitelist_status(WHITELIST_YAUTJA_LEADER|WHITELIST_YAUTJA_COUNCIL)
+		SSticker.mode.initialize_predator(M, ignore_slot_count)

--- a/code/modules/admin/tabs/round_tab.dm
+++ b/code/modules/admin/tabs/round_tab.dm
@@ -13,7 +13,8 @@
 	var/cur_extra = SSticker.mode.pred_additional_max
 	var/cur_count = SSticker.mode.pred_current_num
 	var/cur_max = SSticker.mode.calculate_pred_max()
-	var/value = tgui_input_number(src, "How many additional predators can join? Current predator count: [cur_count]/[cur_max] Current setting: [cur_extra]", "Input:", default = cur_extra, min_value = 0, integer_only = TRUE)
+	var/real_count = length(SSticker.mode.predators)
+	var/value = tgui_input_number(src, "How many additional predators can join? Current predator count: [cur_count]/[cur_max] (Real: [real_count]) Current setting: [cur_extra]", "Input:", default = cur_extra, min_value = 0, integer_only = TRUE)
 
 	if(isnull(value))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR fixes an oversight where predator limit was not working because for whatever reason predators are the only whitelist where `get_whitelist_status` doesn't return the defines in mode.dm and instead it uses the ranks from clans.dm. It also was only skipping the slot tally for ancients. Now predators will properly be limited in slots at 4 + 1 per 80 clients + 0 (admin adjustment). Council do not check for a slot, and both ancient & council do not consume a slot.

# Explain why it's good for the game

Always intended for there to be a limit, thus the issue where aboms get swamped with late joining predators.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Tests were conducted where starting count was 0.

![testing](https://github.com/user-attachments/assets/d3d6990f-ee7f-495e-8100-c663c771925b)

As council/ancient:
![image](https://github.com/user-attachments/assets/92349ae1-fe84-468b-a405-ca234a353b04)

Non ancient: 
![image](https://github.com/user-attachments/assets/dc839121-a1bf-4940-af1b-b7bcc937546c)

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Drathek
fix: Fixed predators having unlimited slots
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
