### PR TITLE
Revert "Removes non combat click delay"

### DIFF
--- a/code/__DEFINES/_click.dm
+++ b/code/__DEFINES/_click.dm
@@ -1,4 +1,4 @@
-//Defines file for click related parameters
+//Defines file for byond click related parameters
 //this is mostly for ease of use and for finding all the things that use say RIGHT_CLICK rather then just searching "right"
 
 //Mouse buttons held
@@ -35,8 +35,3 @@
 
 //Pixel coordinates in screen_loc format ("[tile_x]:[pixel_x],[tile_y]:[pixel_y]")
 #define SCREEN_LOC "screen-loc"
-
-/// From /mob/proc/click_adjacent() : (atom/A, obj/item/W, mods) makes it so the affterattack proc isn't called
-#define ATTACKBY_HINT_NO_AFTERATTACK (1 << 0) 
-/// From /mob/proc/click_adjacent() : (atom/A, obj/item/W, mods) applies the click delay to next_move
-#define ATTACKBY_HINT_UPDATE_NEXT_MOVE (1 << 1)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -146,20 +146,16 @@
 
 /mob/proc/click_adjacent(atom/A, obj/item/W, mods)
 	if(W)
-		var/attackby_result = A.attackby(W, src, mods)
-		var/afterattack_result
-		if(!QDELETED(A) && !(attackby_result & ATTACKBY_HINT_NO_AFTERATTACK))
+		if(W.attack_speed && !src.contains(A)) //Not being worn or carried in the user's inventory somewhere, including internal storages.
+			next_move += W.attack_speed
+
+		if(!A.attackby(W, src, mods) && A && !QDELETED(A))
 			// in case the attackby slept
 			if(!W)
-				if(!isitem(A) && !issurface(A))
-					next_move += 4
 				UnarmedAttack(A, 1, mods)
 				return
 
-			afterattack_result = W.afterattack(A, src, 1, mods)
-
-		if(W.attack_speed && !src.contains(A) && (attackby_result & ATTACKBY_HINT_UPDATE_NEXT_MOVE) || (afterattack_result & ATTACKBY_HINT_UPDATE_NEXT_MOVE))
-			next_move += W.attack_speed
+			W.afterattack(A, src, 1, mods)
 	else
 		if(!isitem(A) && !issurface(A))
 			next_move += 4

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -22,7 +22,6 @@
 			visible_message(SPAN_DANGER("[src] has been hit by [user] with [W]."), null, null, 5, CHAT_TYPE_MELEE_HIT)
 			user.animation_attack_on(src)
 			user.flick_attack_overlay(src, "punch")
-			return ATTACKBY_HINT_UPDATE_NEXT_MOVE
 
 /mob/living/attackby(obj/item/I, mob/user)
 	/* Commented surgery code, proof of concept. Would need to tweak human attackby to prevent duplication; mob/living don't have separate limb objects.
@@ -122,5 +121,5 @@
 		var/hit = H.attacked_by(src, user)
 		if (hit && hitsound)
 			playsound(loc, hitsound, 25, 1)
-		return (hit|ATTACKBY_HINT_UPDATE_NEXT_MOVE)
-	return (ATTACKBY_HINT_NO_AFTERATTACK|ATTACKBY_HINT_UPDATE_NEXT_MOVE)
+		return hit
+	return TRUE

--- a/code/datums/agents/tools/chloroform.dm
+++ b/code/datums/agents/tools/chloroform.dm
@@ -45,8 +45,6 @@
 
 	uses--
 
-	return (ATTACKBY_HINT_NO_AFTERATTACK|ATTACKBY_HINT_UPDATE_NEXT_MOVE)
-
 /obj/item/weapon/chloroform/proc/grab_stun(mob/living/M, mob/living/user)
 	M.anchored = TRUE
 	ADD_TRAIT(M, TRAIT_IMMOBILIZED, CHLOROFORM_TRAIT)

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -104,7 +104,7 @@ update_flag
 		visible_message(SPAN_DANGER("[user] hits [src] with [W]!"))
 		update_health(W.force)
 		src.add_fingerprint(user)
-	. = ..()
+	..()
 
 	SSnano.nanomanager.update_uis(src) // Update all NanoUIs attached to src
 

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -48,5 +48,5 @@
 		cell = null
 		return
 
-	. = ..()
+	..()
 

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -92,7 +92,7 @@
 	if(istype(I, /obj/item/tank))
 		return
 
-	. = ..()
+	..()
 
 
 /obj/structure/machinery/portable_atmospherics/powered/scrubber/huge/stationary
@@ -103,4 +103,4 @@
 		to_chat(user, SPAN_NOTICE(" The bolts are too tight for you to unscrew!"))
 		return
 
-	. = ..()
+	..()

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -87,10 +87,10 @@
 					health -= W.force * W.demolition_mod * fire_dam_coeff
 				if("brute")
 					health -= W.force * W.demolition_mod * brute_dam_coeff
-			. = ..()
+			..()
 			healthcheck()
 		else
-			. = ..()
+			..()
 
 /obj/structure/machinery/bot/bullet_act(obj/projectile/Proj)
 	health -= Proj.ammo.damage

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -95,7 +95,7 @@
 				to_chat(user, SPAN_WARNING("Access denied."))
 		src.updateUsrDialog()
 	else
-		. = ..()
+		..()
 
 /obj/structure/machinery/bot/floorbot/Topic(href, href_list)
 	if(..())

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -211,7 +211,7 @@
 		return
 
 	else
-		. = ..()
+		..()
 		if (health < maxhealth && !HAS_TRAIT(W, TRAIT_TOOL_SCREWDRIVER) && W.force)
 			step_to(src, (get_step_away(src,user)))
 

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -157,7 +157,7 @@
 		else
 			to_chat(user, "You hit [src] with \the [I] but to no effect.")
 	else
-		. = ..()
+		..()
 	return
 
 

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -197,7 +197,7 @@ GLOBAL_LIST_EMPTY_TYPED(all_cameras, /obj/structure/machinery/camera)
 					to_chat(O, "[U] holds \a [itemname] up to one of the cameras ...")
 					show_browser(O, info, itemname, itemname)
 	else
-		. = ..()
+		..()
 	return
 
 /obj/structure/machinery/camera/proc/toggle_cam_status(mob/user, silent)

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -83,7 +83,7 @@
 		to_chat(user, "It's a holotable!  There are no bolts!")
 		return
 
-	. = ..()
+	..()
 
 /obj/structure/surface/table/holotable/wood
 	name = "table"

--- a/code/game/machinery/computer/camera_console.dm
+++ b/code/game/machinery/computer/camera_console.dm
@@ -253,7 +253,7 @@
 			return TRUE
 		toggle_anchored(wrench, user)
 		return TRUE
-	. = ..()
+	..()
 
 /obj/structure/machinery/computer/cameras/wooden_tv/broadcast/toggle_anchored(obj/item/wrench, mob/user)
 	. = ..()

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -44,7 +44,7 @@
 			last_user_name = scan.registered_name
 			last_user_rank = scan.rank
 			to_chat(user, "You insert [O].")
-	. = ..()
+	..()
 
 /obj/structure/machinery/computer/med_data/attack_remote(user as mob)
 	return src.attack_hand(user)

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -35,7 +35,7 @@
 			scanner = O
 			to_chat(user, "You insert [O].")
 
-	. = ..()
+	..()
 
 /obj/structure/machinery/computer/secure_data/attack_remote(mob/user as mob)
 	return attack_hand(user)

--- a/code/game/machinery/computer/sentencing.dm
+++ b/code/game/machinery/computer/sentencing.dm
@@ -242,4 +242,4 @@
 					incident.criminal_gid = add_zero(num2hex(id.registered_gid), 6)
 					ping("\The [src] pings, \"Criminal [id.registered_name] verified.\"")
 
-	. = ..()
+	..()

--- a/code/game/machinery/computer/skills.dm
+++ b/code/game/machinery/computer/skills.dm
@@ -28,7 +28,7 @@
 			O.forceMove(src)
 			scan = O
 			to_chat(user, "You insert [O].")
-	. = ..()
+	..()
 
 /obj/structure/machinery/computer/skills/attack_remote(mob/user as mob)
 	return attack_hand(user)

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -56,7 +56,7 @@
 				health -= W.force * W.demolition_mod * 0.5
 		if (health <= 0)
 			explode()
-		. = ..()
+		..()
 
 /obj/structure/machinery/deployable/barrier/ex_act(severity)
 	src.health -= severity/2

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -235,7 +235,7 @@
 	if (istype(I, /obj/item/card/id))
 		attack_hand(user)
 		return
-	. = ..()
+	..()
 
 /obj/structure/machinery/access_button/attack_hand(mob/user)
 	add_fingerprint(usr)

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -268,7 +268,7 @@
 		control.status = SHUTTLE_DOOR_UNLOCKED
 		to_chat(user, SPAN_WARNING("You successfully restored the remote connection to [src]."))
 		return
-	. = ..()
+	..()
 
 /obj/structure/machinery/door/airlock/multi_tile/almayer/dropshiprear/unlock(forced = FALSE)
 	if(is_reserved_level(z) && !forced)

--- a/code/game/machinery/doors/poddoor/almayer.dm
+++ b/code/game/machinery/doors/poddoor/almayer.dm
@@ -62,7 +62,7 @@
 /obj/structure/machinery/door/poddoor/almayer/locked/attackby(obj/item/C as obj, mob/user as mob)
 	if(HAS_TRAIT(C, TRAIT_TOOL_CROWBAR))
 		return
-	. = ..()
+	..()
 
 /obj/structure/machinery/door/poddoor/almayer/closed
 	density = TRUE

--- a/code/game/machinery/doors/poddoor/shutters/shutters.dm
+++ b/code/game/machinery/doors/poddoor/shutters/shutters.dm
@@ -177,7 +177,7 @@
 /obj/structure/machinery/door/poddoor/shutters/almayer/uniform_vendors/attackby(obj/item/attacking_item, mob/user)
 	if(HAS_TRAIT(attacking_item, TRAIT_TOOL_CROWBAR) || attacking_item.pry_capable)
 		return
-	. = ..()
+	..()
 
 /obj/structure/machinery/door/poddoor/shutters/almayer/uniform_vendors/antitheft
 	name = "Anti-Theft Shutters"

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -11,7 +11,7 @@
 /obj/structure/machinery/door/unpowered/attackby(obj/item/I as obj, mob/user as mob)
 	if(src.locked)
 		return
-	. = ..()
+	..()
 	return
 
 /obj/structure/machinery/door/unpowered/shuttle

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -215,7 +215,7 @@
 		visible_message(SPAN_DANGER("<B>[src] was hit by [I].</B>"))
 		if(I.damtype == BRUTE || I.damtype == BURN)
 			take_damage(aforce)
-		return (ATTACKBY_HINT_NO_AFTERATTACK|ATTACKBY_HINT_UPDATE_NEXT_MOVE)
+		return 1
 	else
 		return try_to_activate_door(user)
 

--- a/code/game/machinery/fire_alarm.dm
+++ b/code/game/machinery/fire_alarm.dm
@@ -140,7 +140,7 @@ FIRE ALARM
 					qdel(src)
 		return
 
-	. = ..()
+	..()
 	return
 
 /obj/structure/machinery/firealarm/attack_hand(mob/user as mob)

--- a/code/game/machinery/nuclearbomb.dm
+++ b/code/game/machinery/nuclearbomb.dm
@@ -95,7 +95,7 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 			disable()
 			playsound(loc, 'sound/items/Wirecutter.ogg', 100, 1)
 		return
-	. = ..()
+	..()
 
 /obj/structure/machinery/nuclearbomb/attack_hand(mob/user as mob)
 	if(user.is_mob_incapacitated() || get_dist(src, user) > 1 || isRemoteControlling(user))

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -72,7 +72,7 @@
 			close_browser(user, "spaceheater")
 			user.unset_interaction()
 	else
-		. = ..()
+		..()
 	return
 
 /obj/structure/machinery/space_heater/attack_hand(mob/user as mob)

--- a/code/game/machinery/telecomms/portable_comms.dm
+++ b/code/game/machinery/telecomms/portable_comms.dm
@@ -38,5 +38,5 @@
 		return
 	if(istype(I, /obj/item/circuitboard/machine) && !istype(I, /obj/item/circuitboard/machine/telecomms/relay/tower))
 		return
-	. = ..()
+	..()
 

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -76,7 +76,7 @@
 
 			src.add_fingerprint(usr)
 	else
-		. = ..()
+		..()
 
 	return
 

--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -767,7 +767,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 		. = redeem_token(W, user)
 		return
 
-	. = ..()
+	..()
 
 /obj/structure/machinery/cm_vending/proc/get_listed_products(mob/user)
 	return listed_products

--- a/code/game/machinery/vending/vending.dm
+++ b/code/game/machinery/vending/vending.dm
@@ -333,7 +333,7 @@ GLOBAL_LIST_EMPTY_TYPED(total_vending_machines, /obj/structure/machinery/vending
 		tgui_interact(user)
 		return
 
-	. = ..()
+	..()
 
 /obj/structure/machinery/vending/proc/scan_card(obj/item/card/card)
 	if(!currently_vending) return

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -80,9 +80,9 @@
 				if(user.drop_inv_item_to_loc(crayon, src))
 					crayon = W
 			else
-				. = ..()
+				..()
 		else
-			. = ..()
+			..()
 
 	else if(istype(W,/obj/item/stack/sheet/hairlesshide) || \
 		istype(W,/obj/item/clothing/under) || \
@@ -137,7 +137,7 @@
 		else
 			to_chat(user, SPAN_NOTICE(" The washing machine is full."))
 	else
-		. = ..()
+		..()
 	update_icon()
 
 /obj/structure/machinery/washing_machine/attack_hand(mob/user as mob)

--- a/code/game/objects/effects/effect_system/foam.dm
+++ b/code/game/objects/effects/effect_system/foam.dm
@@ -207,7 +207,7 @@
 			take_damage(I.force * I.sharp * FOAMED_METAL_ITEM_MELEE) //human advantage, sharper items do more damage
 		else
 			take_damage(I.force * FOAMED_METAL_ITEM_MELEE) //blunt items can damage it still
-		return (ATTACKBY_HINT_NO_AFTERATTACK|ATTACKBY_HINT_UPDATE_NEXT_MOVE)
+		return TRUE
 
 	return FALSE
 

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -134,8 +134,6 @@
 
 		do_flash(M, user, FALSE)
 
-		return (ATTACKBY_HINT_NO_AFTERATTACK|ATTACKBY_HINT_UPDATE_NEXT_MOVE)
-
 //AOE flash
 
 /obj/item/device/flash/attack_self(mob/living/carbon/user as mob, flag = 0, emp = 0)

--- a/code/game/objects/items/fulton.dm
+++ b/code/game/objects/items/fulton.dm
@@ -62,7 +62,7 @@ GLOBAL_LIST_EMPTY(deployed_fultons)
 		return
 
 /obj/item/stack/fulton/attack(mob/M as mob, mob/user as mob)
-	return ATTACKBY_HINT_UPDATE_NEXT_MOVE 
+	return
 
 /obj/item/stack/fulton/attack_hand(mob/user as mob)
 	if (attached_atom)

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -30,7 +30,6 @@
 		if(SLOT_LEGS)
 			if(!attacked_carbon.legcuffed)
 				apply_legcuffs(attacked_carbon, user)
-	return ATTACKBY_HINT_UPDATE_NEXT_MOVE
 
 /obj/item/restraint/proc/place_handcuffs(mob/living/carbon/target, mob/user)
 	playsound(src.loc, cuff_sound, 25, 1, 4)

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -232,7 +232,7 @@
 			to_chat(user, SPAN_NOTICE("[trans] units injected. [reagents.total_volume] units remaining in [src]'s [mag.name]."))
 		else
 			to_chat(user, SPAN_NOTICE("[trans] units injected. [reagents.total_volume] units remaining in [src]."))
-	return (ATTACKBY_HINT_NO_AFTERATTACK|ATTACKBY_HINT_UPDATE_NEXT_MOVE)
+	return TRUE
 
 /obj/item/reagent_container/hypospray/Initialize()
 	. = ..()

--- a/code/game/objects/items/tools/cleaning_tools.dm
+++ b/code/game/objects/items/tools/cleaning_tools.dm
@@ -77,7 +77,7 @@
 /obj/effect/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/tool/mop) || istype(I, /obj/item/tool/soap))
 		return
-	. = ..()
+	..()
 
 
 

--- a/code/game/objects/items/tools/extinguisher.dm
+++ b/code/game/objects/items/tools/extinguisher.dm
@@ -77,7 +77,7 @@
 
 /obj/item/tool/extinguisher/attack(mob/living/M, mob/living/user)
 	if (M == user && !safety && reagents && reagents.total_volume > EXTINGUISHER_WATER_USE_AMT)
-		return ATTACKBY_HINT_UPDATE_NEXT_MOVE
+		return FALSE
 	else
 		return ..()
 

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -125,10 +125,10 @@
 	var/target_zone = check_zone(user.zone_selected)
 	if(user.a_intent == INTENT_HARM)
 		if (!..()) //item/attack() does it's own messaging and logs
-			return ATTACKBY_HINT_UPDATE_NEXT_MOVE // item/attack() will return TRUE if they hit, 0 if they missed.
+			return FALSE // item/attack() will return TRUE if they hit, 0 if they missed.
 
 		if(!status)
-			return (ATTACKBY_HINT_NO_AFTERATTACK|ATTACKBY_HINT_UPDATE_NEXT_MOVE)
+			return TRUE
 
 	else
 		//copied from human_defense.dm - human defence code should really be refactored some time.
@@ -136,20 +136,20 @@
 
 			if(!target_zone) //shouldn't ever happen
 				human_target.visible_message(SPAN_DANGER("<B>[user] misses [human_target] with \the [src]!"))
-				return ATTACKBY_HINT_UPDATE_NEXT_MOVE
+				return FALSE
 
 			var/mob/living/carbon/human/H = human_target
 			var/obj/limb/affecting = H.get_limb(target_zone)
 			if (affecting)
 				if(!status)
 					human_target.visible_message(SPAN_WARNING("[human_target] has been prodded in the [affecting.display_name] with [src] by [user]. Luckily it was off."))
-					return (ATTACKBY_HINT_NO_AFTERATTACK|ATTACKBY_HINT_UPDATE_NEXT_MOVE)
+					return TRUE
 				else
 					H.visible_message(SPAN_DANGER("[human_target] has been prodded in the [affecting.display_name] with [src] by [user]!"))
 		else
 			if(!status)
 				human_target.visible_message(SPAN_WARNING("[human_target] has been prodded with [src] by [user]. Luckily it was off."))
-				return (ATTACKBY_HINT_NO_AFTERATTACK|ATTACKBY_HINT_UPDATE_NEXT_MOVE)
+				return TRUE
 			else
 				human_target.visible_message(SPAN_DANGER("[human_target] has been prodded with [src] by [user]!"))
 
@@ -174,7 +174,7 @@
 
 	deductcharge(hitcost)
 
-	return (ATTACKBY_HINT_NO_AFTERATTACK|ATTACKBY_HINT_UPDATE_NEXT_MOVE)
+	return TRUE
 
 /obj/item/weapon/baton/emp_act(severity)
 	. = ..()

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -31,8 +31,7 @@
 	force = MELEE_FORCE_NORMAL
 
 /obj/item/weapon/classic_baton/attack(mob/M as mob, mob/living/user as mob)
-	. = ..()
-	if(.)
+	if(!..())
 		return
 
 	if(M.stuttering < 8)
@@ -64,7 +63,6 @@
 		return ..()
 	else
 		stun(target, user)
-		return ATTACKBY_HINT_UPDATE_NEXT_MOVE
 
 /obj/item/weapon/telebaton/attack_self(mob/user as mob)
 	..()

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -375,4 +375,4 @@
 	if(!HAS_TRAIT(user, TRAIT_SUPER_STRONG))
 		to_chat(user, SPAN_WARNING("\The [src] is too heavy for you to use as a weapon!"))
 		return
-	. = ..()
+	..()

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -43,7 +43,7 @@
 			return TRUE
 		toggle_anchored(W, user)
 		return TRUE
-	. = ..()
+	..()
 
 /obj/structure/ex_act(severity, direction)
 	if(explo_proof)

--- a/code/game/objects/structures/airlock_assembly.dm
+++ b/code/game/objects/structures/airlock_assembly.dm
@@ -239,7 +239,7 @@
 				electronics.forceMove(door)
 				qdel(src)
 				return
-	. = ..()
+	..()
 
 /obj/structure/airlock_assembly/update_icon()
 	icon_state = "door_as_[state]"

--- a/code/game/objects/structures/barricade/barricade.dm
+++ b/code/game/objects/structures/barricade/barricade.dm
@@ -250,7 +250,7 @@
 		return
 
 	if(item.force > force_level_absorption)
-		. = ..()
+		..()
 		if(barricade_hitsound)
 			playsound(src, barricade_hitsound, 35, 1)
 		hit_barricade(item)

--- a/code/game/objects/structures/bookcase.dm
+++ b/code/game/objects/structures/bookcase.dm
@@ -51,7 +51,7 @@
 				"You deconstruct [src].", "You hear a noise.")
 			deconstruct(FALSE)
 	else
-		. = ..()
+		..()
 
 /obj/structure/bookcase/attack_hand(mob/user as mob)
 	if(length(contents))

--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -32,7 +32,7 @@
 			return
 	var/turf/T = get_turf(src)
 	T.attackby(W, user)
-	. = ..()
+	..()
 
 /obj/structure/catwalk/prison
 	icon = 'icons/turf/floors/prison.dmi'

--- a/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
@@ -50,7 +50,7 @@
 					src.locked = 0
 					src.localopened = 1
 			update_icon()
-		return ATTACKBY_HINT_UPDATE_NEXT_MOVE
+		return
 	if (istype(O, /obj/item/weapon/twohanded/fireaxe) && src.localopened)
 		if(!fireaxe)
 			if(O.flags_item & WIELDED)

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -74,7 +74,7 @@
 /obj/structure/largecrate/lisa/attackby(obj/item/W as obj, mob/user as mob) //ugly but oh well
 	if(HAS_TRAIT(W, TRAIT_TOOL_CROWBAR))
 		new /mob/living/simple_animal/corgi/Lisa(loc)
-	. = ..()
+	..()
 
 /obj/structure/largecrate/cow
 	name = "cow crate"
@@ -83,7 +83,7 @@
 /obj/structure/largecrate/cow/attackby(obj/item/W as obj, mob/user as mob)
 	if(HAS_TRAIT(W, TRAIT_TOOL_CROWBAR))
 		new /mob/living/simple_animal/cow(loc)
-	. = ..()
+	..()
 
 /obj/structure/largecrate/goat
 	name = "goat crate"
@@ -92,7 +92,7 @@
 /obj/structure/largecrate/goat/attackby(obj/item/W as obj, mob/user as mob)
 	if(HAS_TRAIT(W, TRAIT_TOOL_CROWBAR))
 		new /mob/living/simple_animal/hostile/retaliate/goat(loc)
-	. = ..()
+	..()
 
 /obj/structure/largecrate/chick
 	name = "chicken crate"
@@ -103,7 +103,7 @@
 		var/num = rand(4, 6)
 		for(var/i = 0, i < num, i++)
 			new /mob/living/simple_animal/chick(loc)
-	. = ..()
+	..()
 
 
 // CM largecrates
@@ -367,7 +367,7 @@ GLOBAL_LIST_INIT(rbarrel_color_list, list(COLOR_SILVER,
 
 /obj/structure/largecrate/random/secure/attackby(obj/item/W as obj, mob/user as mob)
 	if (!strapped)
-		. = ..()
+		..()
 		return
 
 	if (!W.sharp)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -59,7 +59,7 @@
 /obj/structure/displaycase/attackby(obj/item/W as obj, mob/user as mob)
 	src.health -= W.force * W.demolition_mod
 	src.healthcheck()
-	. = ..()
+	..()
 	return
 
 /obj/structure/displaycase/attack_hand(mob/user as mob)

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -189,7 +189,7 @@
 			if("brute")
 				health -= W.force * W.demolition_mod * 0.1
 		healthcheck(1, 1, user, W)
-		. = ..()
+		..()
 
 /obj/structure/fence/deconstruct(disassembled = TRUE)
 	if(disassembled)

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -56,7 +56,6 @@ PLANT_CUT_MACHETE = 3 = Needs at least a machete to be cut down
 		playsound(src, 'sound/effects/vegetation_hit.ogg', 25, 1)
 		if(cut_hits <= 0)
 			qdel(src)
-		return ATTACKBY_HINT_UPDATE_NEXT_MOVE
 	else
 		. = ..()
 

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -120,7 +120,7 @@
 			to_chat(user, SPAN_NOTICE("You weld the girder together!"))
 			repair()
 			return
-	. = ..()
+	..()
 
 /obj/structure/girder/proc/change_state(obj/item/W, mob/user)
 	switch(state)

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -91,7 +91,7 @@
 		deflate(1)
 	if(W.damtype == BRUTE || W.damtype == BURN)
 		hit(W.force)
-		. = ..()
+		..()
 	return
 
 /obj/structure/inflatable/proc/hit(damage, sound_effect = 1)

--- a/code/game/objects/structures/lamarr_cage.dm
+++ b/code/game/objects/structures/lamarr_cage.dm
@@ -55,7 +55,7 @@
 /obj/structure/lamarr/attackby(obj/item/W as obj, mob/user as mob)
 	health -= W.force * W.demolition_mod
 	healthcheck()
-	. = ..()
+	..()
 	return
 
 /obj/structure/lamarr/attack_hand(mob/user as mob)

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -201,7 +201,7 @@
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.remove_fuel(0, user))
 			TemperatureAct(100)
-	. = ..()
+	..()
 
 /obj/structure/mineral_door/transparent/phoron/fire_act(exposed_temperature, exposed_volume)
 	if(exposed_temperature > 300)

--- a/code/game/objects/structures/pipes/binary_misc.dm
+++ b/code/game/objects/structures/pipes/binary_misc.dm
@@ -93,7 +93,7 @@
 			else if(dir & (EAST|WEST))
 				valid_directions = list(EAST, WEST)
 	else
-		. = ..()
+		..()
 
 /obj/structure/pipes/binary/circulator/verb/rotate_clockwise()
 	set category = "Object"

--- a/code/game/objects/structures/props.dm
+++ b/code/game/objects/structures/props.dm
@@ -1025,7 +1025,7 @@
 		return
 
 	if(user.a_intent == INTENT_HARM)
-		. = ..()
+		..()
 		if(W.force && !(W.flags_item & NOBLUDGEON))
 			playsound(src, 'sound/effects/woodhit.ogg', 25, 1)
 			update_health(W.force)

--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -141,7 +141,7 @@
 /obj/structure/reagent_dispensers/attackby(obj/item/hit_item, mob/living/user)
 	if(istype(hit_item, /obj/item/reagent_container))
 		return
-	. = ..()
+	..()
 
 //Dispensers
 /obj/structure/reagent_dispensers/watertank

--- a/code/game/objects/structures/sink.dm
+++ b/code/game/objects/structures/sink.dm
@@ -118,5 +118,5 @@
 
 /obj/structure/sink/puddle/attackby(obj/item/O as obj, mob/user as mob)
 	icon_state = "puddle-splash"
-	. = ..()
+	..()
 	icon_state = "puddle"

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -519,7 +519,7 @@
 				chair_state = DROPSHIP_CHAIR_FOLDED
 				return
 	else
-		. = ..()
+		..()
 
 
 
@@ -570,7 +570,6 @@
 	if(flags_item & WIELDED)
 		M.apply_stamina_damage(17, check_zone(user.zone_selected))
 	playsound(get_turf(user), 'sound/weapons/metal_chair_clang.ogg', 20, 1)
-	return ATTACKBY_HINT_UPDATE_NEXT_MOVE
 
 /obj/item/weapon/twohanded/folded_metal_chair/afterattack(atom/target, mob/user, proximity)
 	if(flags_item & WIELDED)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -279,7 +279,6 @@
 					user.visible_message(SPAN_DANGER("<B>[user] slams [M]'s face against [src]!</B>"),
 					SPAN_DANGER("<B>You slam [M]'s face against [src]!</B>"))
 					playsound(src.loc, 'sound/weapons/tablehit1.ogg', 25, 1)
-					return ATTACKBY_HINT_UPDATE_NEXT_MOVE
 				else
 					to_chat(user, SPAN_WARNING("You need a better grip to do that!"))
 					return
@@ -290,7 +289,6 @@
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
 				user.visible_message(SPAN_DANGER("<B>[user] throws [M] on [src], stunning them!</B>"),
 				SPAN_DANGER("<B>You throw [M] on [src], stunning them!</B>"))
-				return ATTACKBY_HINT_UPDATE_NEXT_MOVE
 		return
 
 	if(HAS_TRAIT(W, TRAIT_TOOL_WRENCH) && !(user.a_intent == INTENT_HELP))
@@ -325,7 +323,7 @@
 	//clicking the table
 	if(flipped)
 		return
-	. = ..()
+	..()
 
 /// Checks whether a table is a straight line along a given axis
 /obj/structure/surface/table/proc/straight_table_check(direction)
@@ -580,7 +578,7 @@
 	if(HAS_TRAIT(W, TRAIT_TOOL_WRENCH) && !(user.a_intent == INTENT_HELP) && status == RTABLE_NORMAL)
 		return
 
-	. = ..()
+	..()
 
 /obj/structure/surface/table/reinforced/prison
 	desc = "A square metal surface resting on four legs. This one has side panels, making it useful as a desk, but impossible to flip."
@@ -676,7 +674,7 @@
 		return
 	if(W.flags_item & ITEM_ABSTRACT)
 		return
-	. = ..()
+	..()
 
 /obj/structure/surface/rack/Crossed(atom/movable/O)
 	..()

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -128,7 +128,7 @@
 						else
 							src.name = "Wired Windoor Assembly"
 			else
-				. = ..()
+				..()
 
 		if("02")
 
@@ -241,7 +241,7 @@
 
 
 			else
-				. = ..()
+				..()
 
 	//Update to reflect changes(if applicable)
 	update_icon()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -252,7 +252,6 @@
 			msg_admin_attack("[key_name(user)] slammed [key_name(M)] against [src] at [get_area_name(M)]", M.loc.x, M.loc.y, M.loc.z)
 
 			healthcheck(1, 1, 1, M) //The person thrown into the window literally shattered it
-			return ATTACKBY_HINT_UPDATE_NEXT_MOVE
 		return
 
 	if(W.flags_item & NOBLUDGEON) return
@@ -297,7 +296,7 @@
 				update_nearby_icons()
 				step(src, get_dir(user, src))
 		healthcheck(1, 1, 1, user, W)
-		return ..()
+		..()
 	return
 
 /obj/structure/window/proc/is_full_window()

--- a/code/game/objects/structures/window_frame.dm
+++ b/code/game/objects/structures/window_frame.dm
@@ -193,7 +193,7 @@
 	if(istype(W, sheet_type))
 		to_chat(user, SPAN_WARNING("You can't repair this window."))
 		return
-	. = ..()
+	..()
 
 /obj/structure/window_frame/colony
 	icon_state = "col_window0_frame"

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -400,7 +400,7 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 		else
 			to_chat(user, SPAN_NOTICE("You find a small horizontal slot at the bottom of the console. You try to feed \the [hit_item] into it, but it's seemingly blocked off from the inside."))
 			return
-	. = ..()
+	..()
 
 /obj/structure/machinery/computer/supply/asrs/contraband_buyable()
 	return can_order_contraband && !black_market_lockout

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -1271,7 +1271,6 @@
 		user.animation_attack_on(src)
 		take_damage(W.force*RESIN_MELEE_DAMAGE_MULTIPLIER*W.demolition_mod, user)
 		playsound(src, "alien_resin_break", 25)
-		return ATTACKBY_HINT_UPDATE_NEXT_MOVE
 	else
 		return attack_hand(user)
 

--- a/code/modules/almayer/machinery.dm
+++ b/code/modules/almayer/machinery.dm
@@ -270,7 +270,7 @@
 
 //What is this even doing? Why is it making a new item?
 /obj/structure/machinery/cryobag_recycler/attackby(obj/item/W, mob/user) //Hope this works. Don't see why not.
-	. = ..()
+	..()
 	if (istype(W, /obj/item))
 		if(W.name == "used stasis bag") //possiblity for abuse, but fairly low considering its near impossible to rename something without VV
 			var/obj/item/bodybag/cryobag/R = new /obj/item/bodybag/cryobag //lets give them the bag considering having it unfolded would be a pain in the ass.
@@ -279,7 +279,7 @@
 			qdel(W)
 			user.put_in_hands(R)
 			return TRUE
-	. = ..()
+	..()
 
 /obj/structure/closet/basketball
 	name = "athletic wardrobe"

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -406,7 +406,6 @@
 		to_chat(user, "You hit the [name] with your [W.name]!")
 		playsound(loc, "alien_resin_move", 25)
 		healthcheck()
-		return ATTACKBY_HINT_UPDATE_NEXT_MOVE
 	else
 		return attack_hand(user)
 

--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -303,8 +303,6 @@
 	health -= damage
 	healthcheck()
 
-	return ATTACKBY_HINT_UPDATE_NEXT_MOVE
-
 /obj/effect/alien/egg/proc/healthcheck()
 	if(health <= 0)
 		Burst(TRUE)

--- a/code/modules/cm_aliens/weeds.dm
+++ b/code/modules/cm_aliens/weeds.dm
@@ -397,7 +397,7 @@
 	user.animation_attack_on(src)
 
 	take_damage(damage)
-	return (ATTACKBY_HINT_NO_AFTERATTACK|ATTACKBY_HINT_UPDATE_NEXT_MOVE)
+	return TRUE //don't call afterattack
 
 /obj/effect/alien/weeds/proc/take_damage(damage)
 	if(explo_proof)

--- a/code/modules/cm_marines/marines_consoles.dm
+++ b/code/modules/cm_marines/marines_consoles.dm
@@ -433,7 +433,7 @@
 			else
 				to_chat(user, "Both slots are full already. Remove a card first.")
 	else
-		. = ..()
+		..()
 
 /obj/structure/machinery/computer/card/attack_remote(mob/user as mob)
 	return attack_hand(user)
@@ -656,7 +656,7 @@
 				if(!isxenos)
 					person_to_modify = G.grabbed_thing
 	else
-		. = ..()
+		..()
 
 
 /obj/structure/machinery/computer/squad_changer/attack_remote(mob/user as mob)

--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -249,7 +249,7 @@
 	unacidable = TRUE
 
 /obj/item/weapon/yautja/scythe/attack(mob/living/target as mob, mob/living/carbon/human/user as mob)
-	. = ..()
+	..()
 	if((human_adapted || isyautja(user)) && isxeno(target))
 		var/mob/living/carbon/xenomorph/xenomorph = target
 		xenomorph.AddComponent(/datum/component/status_effect/interference, 15, 15)
@@ -258,6 +258,8 @@
 		user.visible_message(SPAN_DANGER("An opening in combat presents itself!"),SPAN_DANGER("You manage to strike at your foe once more!"))
 		user.spin(5, 1)
 		..() //Do it again! CRIT! This will be replaced by a bleed effect.
+
+	return
 
 /obj/item/weapon/yautja/scythe/alt
 	name = "double war scythe"
@@ -602,7 +604,7 @@
 		SEND_SIGNAL(victim, COMSIG_HUMAN_FLAY_ATTEMPT, user, src, TRUE)
 	else
 		to_chat(user, SPAN_WARNING("You were interrupted before you could finish your work!"))
-	return (ATTACKBY_HINT_NO_AFTERATTACK|ATTACKBY_HINT_UPDATE_NEXT_MOVE)
+	return TRUE
 
 ///Records status of flaying attempts and handles progress.
 /datum/flaying_datum

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -87,7 +87,7 @@ log transactions
 			src.attack_hand(user)
 			qdel(I)
 	else
-		. = ..()
+		..()
 
 /obj/structure/machinery/atm/proc/drop_money(turf)
 		playsound(turf, "sound/machines/ping.ogg", 15)

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -729,7 +729,7 @@
 	else if(istype(O,/obj/item/tool/shovel) || istype(O,/obj/item/tank))
 		return
 	else
-		. = ..()
+		..()
 
 #undef HYDRO_SPEED_MULTIPLIER
 #undef HYDRO_WATER_CONSUMPTION_MULTIPLIER

--- a/code/modules/hydroponics/seed_machines/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines/seed_machines.dm
@@ -90,4 +90,4 @@
 			to_chat(user, SPAN_NOTICE("You load \the [W] into [src]."))
 
 		return
-	. = ..()
+	..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/Burrower.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Burrower.dm
@@ -96,7 +96,7 @@
 /mob/living/carbon/xenomorph/burrower/attackby()
 	if(HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
 		return
-	. = ..()
+	..()
 
 /mob/living/carbon/xenomorph/burrower/get_projectile_hit_chance()
 	. = ..()

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -50,7 +50,6 @@
 			var/mob/living/pmob = user.pulling
 			if(istype(pmob))
 				SEND_SIGNAL(pmob, COMSIG_MOB_MOVE_OR_LOOK, TRUE, move_dir, move_dir)
-			return ATTACKBY_HINT_UPDATE_NEXT_MOVE
 
 
 /obj/item/grab/attack_self(mob/user)

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -49,7 +49,7 @@
 
 /obj/structure/filingcabinet/attackby(obj/item/P as obj, mob/user as mob)
 	if(HAS_TRAIT(P, TRAIT_TOOL_WRENCH))
-		. = ..()
+		..()
 	else
 		for(var/allowed_type in allowed_types)
 			if(istype(P, allowed_type))

--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -98,7 +98,7 @@
 
 
 /obj/structure/machinery/power/smes/batteryrack/attackby(obj/item/W as obj, mob/user as mob) //these can only be moved by being reconstructed, solves having to remake the powernet.
-	. = ..() //SMES attackby for now handles screwdriver, cable coils and wirecutters, no need to repeat that here
+	..() //SMES attackby for now handles screwdriver, cable coils and wirecutters, no need to repeat that here
 	if(open_hatch)
 		if(HAS_TRAIT(W, TRAIT_TOOL_CROWBAR))
 			if (charge < (capacity / 100))

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -20,7 +20,7 @@
 		coil.turf_place(T, user)
 		return
 	else
-		. = ..()
+		..()
 	return
 
 // the power cable object

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -118,7 +118,7 @@
 			src.transfer_fingerprints_to(newlight)
 			qdel(src)
 			return
-	. = ..()
+	..()
 
 /obj/structure/machinery/light_construct/small
 	name = "small light fixture frame"

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -187,8 +187,7 @@
 	// If parent returned 1:
 	// - Hatch is open, so we can modify the SMES
 	// - No action was taken in parent function (terminal de/construction atm).
-	. = ..()
-	if (.)
+	if (..())
 
 		// Charged above 1% and safeties are enabled.
 		if((charge > (capacity/100)) && safeties_enabled && !HAS_TRAIT(W, TRAIT_TOOL_MULTITOOL))

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1295,7 +1295,7 @@ and you're good to go.
 	if(active_attachable && (active_attachable.flags_attach_features & ATTACH_MELEE)) //this is expected to do something in melee.
 		active_attachable.last_fired = world.time
 		active_attachable.fire_attachment(attacked_mob, src, user)
-		return (ATTACKBY_HINT_NO_AFTERATTACK|ATTACKBY_HINT_UPDATE_NEXT_MOVE)
+		return TRUE
 
 	if(!(flags_gun_features & GUN_CAN_POINTBLANK)) // If it can't point blank, you can't suicide and such.
 		return ..()
@@ -1303,8 +1303,7 @@ and you're good to go.
 	if(attacked_mob == user && user.zone_selected == "mouth" && ishuman(user))
 		var/mob/living/carbon/human/HM = user
 		if(!able_to_fire(user))
-			return (ATTACKBY_HINT_NO_AFTERATTACK|ATTACKBY_HINT_UPDATE_NEXT_MOVE)
-
+			return TRUE
 
 		var/ffl = " [ADMIN_JMP(user)] [ADMIN_PM(user)]"
 
@@ -1318,8 +1317,7 @@ and you're good to go.
 		if(!do_after(user, 2 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE) || !able_to_fire(user))
 			attacked_mob.visible_message(SPAN_NOTICE("[user] decided life was worth living."))
 			flags_gun_features ^= GUN_CAN_POINTBLANK //Reset this.
-			return (ATTACKBY_HINT_NO_AFTERATTACK|ATTACKBY_HINT_UPDATE_NEXT_MOVE)
-
+			return TRUE
 
 		if(active_attachable && !(active_attachable.flags_attach_features & ATTACH_PROJECTILE))
 			active_attachable.activate_attachment(src, null, TRUE)//We're not firing off a nade into our mouth.
@@ -1377,8 +1375,7 @@ and you're good to go.
 				msg_admin_niche("[key_name(user)] played live Russian Roulette with \a [name] in [get_area(user)] [ffl]") //someone might want to know anyway...
 
 		flags_gun_features ^= GUN_CAN_POINTBLANK //Reset this.
-		return (ATTACKBY_HINT_NO_AFTERATTACK|ATTACKBY_HINT_UPDATE_NEXT_MOVE)
-
+		return TRUE
 
 	if(EXECUTION_CHECK) //Execution
 		if(!able_to_fire(user)) //Can they actually use guns in the first place?
@@ -1387,8 +1384,7 @@ and you're good to go.
 			return ..()
 		user.visible_message(SPAN_DANGER("[user] puts [src] up to [attacked_mob], steadying their aim."), SPAN_WARNING("You put [src] up to [attacked_mob], steadying your aim."),null, null, CHAT_TYPE_COMBAT_ACTION)
 		if(!do_after(user, 3 SECONDS, INTERRUPT_ALL|INTERRUPT_DIFF_INTENT, BUSY_ICON_HOSTILE))
-			return (ATTACKBY_HINT_NO_AFTERATTACK|ATTACKBY_HINT_UPDATE_NEXT_MOVE)
-
+			return TRUE
 	else if(user.a_intent != INTENT_HARM) //Thwack them
 		return ..()
 
@@ -1399,8 +1395,7 @@ and you're good to go.
 
 	//Point blanking doesn't actually fire the projectile. Instead, it simulates firing the bullet proper.
 	if(flags_gun_features & GUN_BURST_FIRING || !able_to_fire(user)) //If it's a valid PB aside from that you can't fire the gun, do nothing.
-		return (ATTACKBY_HINT_NO_AFTERATTACK|ATTACKBY_HINT_UPDATE_NEXT_MOVE)
-
+		return TRUE
 
 	//The following relating to bursts was borrowed from Fire code.
 	var/check_for_attachment_fire = FALSE
@@ -1453,14 +1448,12 @@ and you're good to go.
 
 		if(SEND_SIGNAL(projectile_to_fire.ammo, COMSIG_AMMO_POINT_BLANK, attacked_mob, projectile_to_fire, user, src) & COMPONENT_CANCEL_AMMO_POINT_BLANK)
 			flags_gun_features &= ~GUN_BURST_FIRING
-			return (ATTACKBY_HINT_NO_AFTERATTACK|ATTACKBY_HINT_UPDATE_NEXT_MOVE)
-
+			return TRUE
 
 		//We actually have a projectile, let's move on. We're going to simulate the fire cycle.
 		if(projectile_to_fire.ammo.on_pointblank(attacked_mob, projectile_to_fire, user, src))
 			flags_gun_features &= ~GUN_BURST_FIRING
-			return (ATTACKBY_HINT_NO_AFTERATTACK|ATTACKBY_HINT_UPDATE_NEXT_MOVE)
-
+			return TRUE
 
 		var/damage_buff = BASE_BULLET_DAMAGE_MULT
 		//if target is lying or unconscious - add damage bonus
@@ -1564,8 +1557,7 @@ and you're good to go.
 	if(PB_burst_bullets_fired)
 		Fire(get_turf(attacked_mob), user, reflex = TRUE) //Reflex prevents dual-wielding.
 
-	return (ATTACKBY_HINT_NO_AFTERATTACK|ATTACKBY_HINT_UPDATE_NEXT_MOVE)
-
+	return TRUE
 
 #undef EXECUTION_CHECK
 //----------------------------------------------------------

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -968,7 +968,7 @@ can cause issues with ammo types getting mixed up during the burst.
 		target_angle = get_dir(user, M)
 
 	var/prefire_rounds = current_mag.current_rounds //How many rounds do we have before we fire?
-	. = ..()
+	..()
 	if(current_mag.current_rounds == prefire_rounds) //We didn't fire a shot.
 		return
 	fired_shots++

--- a/code/modules/reagents/chemistry_machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry_machinery/pandemic.dm
@@ -252,5 +252,5 @@
 		update_icon()
 
 	else
-		. = ..()
+		..()
 	return

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1106,8 +1106,7 @@
 		name = initial(name)
 
 /obj/structure/disposalpipe/tagger/attackby(obj/item/I, mob/user)
-	. = ..()
-	if(.)
+	if(..())
 		return
 
 	if(istype(I, /obj/item/device/destTagger))


### PR DESCRIPTION
Reverts cmss13-devs/cmss13#7802
This PR clearly states removing NON COMBAT click delay and that is misleading due to the fact that it HEAVILY affects combat and the current balance of the Yautja whitelist/all melee weapons + point blanks as marine.

🆑  LOLVAX1
Balance: Reverts the ''non combat'' click delay change due to it affecting combat heavily.

🆑