### PR TITLE
Fix Stat Browser not restoring font size

### DIFF
--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -418,7 +418,7 @@ SUBSYSTEM_DEF(statpanels)
 	set hidden = TRUE
 
 	if (!current_fontsize)
-		current_fontsize = 12
+		current_fontsize = 14
 
 	var/datum/statbrowser_options/options_panel = statbrowser_options
 	if(!options_panel)

--- a/html/statbrowser.js
+++ b/html/statbrowser.js
@@ -14,20 +14,51 @@ if (!String.prototype.trim) {
 	};
 }
 
+// Storage.js stuff ------------------------------------------------
+function testHubStorage() {
+	try {
+		return Boolean(window.hubStorage && window.hubStorage.getItem);
+	} catch (error) {
+		return false;
+	}
+}
+
+function loadFontSize() {
+	current_fontsize = parseInt(window.hubStorage.getItem("fontsize"));
+	if (isNaN(current_fontsize) || current_fontsize <= 0) {
+		current_fontsize = 14;
+	}
+	statcontentdiv.style.fontSize = current_fontsize + "px";
+	tab_change(current_tab, true); // Redraw the current tab
+}
+
+function onByondStorageLoad(event) {
+	document.removeEventListener('byondstorageupdated', onByondStorageLoad);
+	setTimeout(loadFontSize, 0); // Unfortunately its STILL not ready yet
+}
+
 // Status panel implementation ------------------------------------------------
 var status_tab_parts = ["Loading..."];
 var current_tab = null;
-var local_fontsize;
+var current_fontsize = 14; // in px, also determines line height and category header sizes for the verb menus
 // Per `storage.js` for tgui:
 // Localstorage can sometimes throw an error, even if DOM storage is not
 // disabled in IE11 settings.
 // See: https://superuser.com/questions/1080011
 try {
-	local_fontsize = localStorage.getItem("fontsize");
+	if (!Byond.TRIDENT) {
+		// Unfortunately byond storage isn't available immediately
+		if (!testHubStorage()) {
+			document.addEventListener('byondstorageupdated', onByondStorageLoad);
+		} else {
+			current_fontsize = parseInt(window.hubStorage.getItem("fontsize"));
+		}
+	} else { // TODO: Remove with 516
+		current_fontsize = parseInt(window.localStorage.getItem("fontsize"));
+	}
 } catch (error) {
-	local_fontsize = 14;
+	current_fontsize = 14;
 }
-var current_fontsize = local_fontsize ? parseInt(local_fontsize) : 14; // in px, also determines line height and category header sizes for the verb menus
 var mc_tab_parts = [["Loading...", ""]];
 var href_token = null;
 var spells = [];
@@ -1346,7 +1377,11 @@ function openOptionsMenu() {
 
 Byond.subscribeTo("change_fontsize", function (new_fontsize) {
 	current_fontsize = parseInt(new_fontsize);
-	localStorage.setItem("fontsize", current_fontsize.toString());
+	if (!Byond.TRIDENT) {
+		window.hubStorage.setItem("fontsize", current_fontsize.toString());
+	} else { // TODO: Remove with 516
+		window.localStorage.setItem("fontsize", current_fontsize.toString());
+	}
 	statcontentdiv.style.fontSize = current_fontsize + "px";
 	tab_change(current_tab, true); // Redraw the current tab
 });

--- a/html/statbrowser.js
+++ b/html/statbrowser.js
@@ -59,6 +59,9 @@ try {
 } catch (error) {
 	current_fontsize = 14;
 }
+if (isNaN(current_fontsize) || current_fontsize <= 0) {
+	current_fontsize = 14;
+}
 var mc_tab_parts = [["Loading...", ""]];
 var href_token = null;
 var spells = [];


### PR DESCRIPTION
# About the pull request

This PR updates statbrowser to utilize byondstorage (516) to restore and save the font size.

Also of note, this PR requires 516.1652+ because of https://www.byond.com/forum/post/2961371 buuut that version has rendering issues soo hopefully that'll eventually be fixed. Otherwise the changes will just be trampled by chat.

Unfortunately I can't properly reuse storage.js here because its not a proper TGUI window (I guess for compatibility reasons) so I had to reimplement all the extras nuances to reading a value...

# Explain why it's good for the game

Preferences should be saved and restored properly.

# Changelog
:cl: Drathek
fix: Fixed stat browser not saving/restoring font size value on 516
/:cl:
