### PR TITLE
Fixes absurdly high item weight in arcade machines

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -16,7 +16,8 @@
 	var/gameover = 0
 	var/blocked = 0 //Player cannot attack/heal while set
 	var/list/prizes = list( /obj/item/tool/lighter/zippo = 4,
-							/obj/item/spacecash/ewallet = 100,	worth = 25,
+							/obj/item/spacecash/ewallet = 3,
+								worth = 25,
 							/obj/item/facepaint/sniper = 4,
 							/obj/item/toy/gun = 4,
 							/obj/item/toy/crossbow = 4,


### PR DESCRIPTION

# About the pull request

Changes the ewallet to be 3 weight from 100

# Explain why it's good for the game

As funny as money grinding is, not good for people that want to get plushies and cool shit.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixes Arcade Machines almost only ever giving money cards as a reward.
/:cl:
