### PR TITLE
"Don't waste resources" Pamphlets changes QOL

### DIFF
--- a/code/game/objects/items/pamphlets.dm
+++ b/code/game/objects/items/pamphlets.dm
@@ -59,7 +59,7 @@
 			if(user.skills.get_skill_level(skill_trait.secondary_skill) < skill_trait.secondary_skill_cap)
 				return
 
-			to_chat(user, SPAN_WARNING("This pamphlet is useles for you!"))
+			to_chat(user, SPAN_WARNING("This pamphlet is useless for you!"))
 			return FALSE
 
 /obj/item/pamphlet/skill/medical

--- a/code/game/objects/items/pamphlets.dm
+++ b/code/game/objects/items/pamphlets.dm
@@ -50,17 +50,19 @@
 
 /obj/item/pamphlet/skill/can_use(mob/living/carbon/human/user)
 	. = ..()
-	if(.)
-		var/datum/character_trait/skills/skill_trait = trait
-		if(istype(skill_trait))
-			if(user.skills.get_skill_level(skill_trait.skill) < skill_trait.skill_cap)
-				return
+	if(!.)
+		return
+	
+	var/datum/character_trait/skills/skill_trait = trait
+	if(istype(skill_trait))
+		if(user.skills.get_skill_level(skill_trait.skill) < skill_trait.skill_cap)
+			return
 
-			if(user.skills.get_skill_level(skill_trait.secondary_skill) < skill_trait.secondary_skill_cap)
-				return
+		if(user.skills.get_skill_level(skill_trait.secondary_skill) < skill_trait.secondary_skill_cap)
+			return
 
-			to_chat(user, SPAN_WARNING("This pamphlet is useless for you!"))
-			return FALSE
+		to_chat(user, SPAN_WARNING("This pamphlet is useless for you!"))
+		return FALSE
 
 /obj/item/pamphlet/skill/medical
 	name = "medical instructional pamphlet"

--- a/code/game/objects/items/pamphlets.dm
+++ b/code/game/objects/items/pamphlets.dm
@@ -27,8 +27,8 @@
 
 	if(!can_use(user))
 		return
-	on_use(user)
 
+	on_use(user)
 	qdel(src)
 
 /obj/item/pamphlet/proc/can_use(mob/living/carbon/human/user)
@@ -47,6 +47,20 @@
 	trait.apply_trait(user)
 	if(!bypass_pamphlet_limit)
 		user.has_used_pamphlet = TRUE
+
+/obj/item/pamphlet/skill/can_use(mob/living/carbon/human/user)
+	. = ..()
+	if(.)
+		var/datum/character_trait/skills/skill_trait = trait
+		if(istype(skill_trait))
+			if(user.skills.get_skill_level(skill_trait.skill) < skill_trait.skill_cap)
+				return
+
+			if(user.skills.get_skill_level(skill_trait.secondary_skill) < skill_trait.secondary_skill_cap)
+				return
+
+			to_chat(user, SPAN_WARNING("This pamphlet is useles for you!"))
+			return FALSE
 
 /obj/item/pamphlet/skill/medical
 	name = "medical instructional pamphlet"

--- a/code/modules/character_traits/skills.dm
+++ b/code/modules/character_traits/skills.dm
@@ -90,8 +90,7 @@
 	trait_desc = "Gives the CO information on his smartgun"
 	skill = SKILL_SPEC_WEAPONS
 	skill_cap =  SKILL_SPEC_SMARTGUN
-	skill_increment = 7
-
+	skill_increment = SKILL_SPEC_SMARTGUN
 
 /datum/character_trait/skills/spotter
 	trait_name = "Spotter Training"


### PR DESCRIPTION
# About the pull request
No more wasting rare pamphlets without earning skills, you can't use it, if you aint getting skills

# Explain why it's good for the game
No more skill issue? Thin ref

Also, CO smartgun skill... thank for that bug sended to downstream, now I come here to krill somebody...

# Changelog

:cl:
qol: Pamphlets skill check on increase, you can't spend them if they can't increase your skills
fix: Removed magic number on CO smartgun skill
/:cl:
