### PR TITLE
Smartscope now uses alt IFF.

### DIFF
--- a/code/__DEFINES/dcs/signals/atom/signals_gun.dm
+++ b/code/__DEFINES/dcs/signals/atom/signals_gun.dm
@@ -4,6 +4,7 @@
 #define COMSIG_GUN_AUTOFIREDELAY_MODIFIED "gun_autofiredelay_modified"
 #define COMSIG_GUN_BURST_SHOTS_TO_FIRE_MODIFIED "gun_burst_shots_to_fire_modified"
 #define COMSIG_GUN_BURST_SHOT_DELAY_MODIFIED "gun_burst_shot_delay_modified"
+#define COMSIG_GUN_NEXT_FIRE_MODIFIED "gun_next_fire_modified"
 
 #define COMSIG_GUN_VULTURE_FIRED_ONEHAND "gun_vulture_fired_onehand"
 #define COMSIG_VULTURE_SCOPE_MOVED "vulture_scope_moved"

--- a/code/datums/components/autofire/autofire.dm
+++ b/code/datums/components/autofire/autofire.dm
@@ -38,6 +38,7 @@
 	RegisterSignal(parent, COMSIG_GUN_FIRE, PROC_REF(initiate_shot))
 	RegisterSignal(parent, COMSIG_GUN_STOP_FIRE, PROC_REF(stop_firing))
 	RegisterSignal(parent, COMSIG_GUN_INTERRUPT_FIRE, PROC_REF(hard_reset))
+	RegisterSignal(parent, COMSIG_GUN_NEXT_FIRE_MODIFIED, PROC_REF(set_next_fire))
 
 	src.auto_fire_shot_delay = auto_fire_shot_delay
 	src.burstfire_shot_delay = burstfire_shot_delay
@@ -111,6 +112,10 @@
 		callback_bursting.Invoke(FALSE)
 	shooting = FALSE
 
+///Manually sets firedelay
+/datum/component/automatedfire/autofire/proc/set_next_fire(gun, new_next_fire)
+	SIGNAL_HANDLER
+	next_fire = new_next_fire
 
 ///Ask the shooter to fire and schedule the next shot if need
 /datum/component/automatedfire/autofire/process_shot()

--- a/code/datums/components/iff_fire_prevention.dm
+++ b/code/datums/components/iff_fire_prevention.dm
@@ -88,7 +88,7 @@
 				if(iff_additional_fire_delay)
 					var/obj/item/weapon/gun/gun = firing_weapon
 					if(istype(gun))
-						LAZYSET(user.fire_delay_next_fire, gun, world.time + iff_additional_fire_delay)
+						gun.last_fired = (world.time + iff_additional_fire_delay)
 				return COMPONENT_CANCEL_GUN_BEFORE_FIRE
 
 			return //if we have a target we *can* hit and find it before any IFF targets we want to fire

--- a/code/datums/components/iff_fire_prevention.dm
+++ b/code/datums/components/iff_fire_prevention.dm
@@ -47,7 +47,9 @@
 		if(iff_additional_fire_delay)
 			var/obj/item/weapon/gun/gun = firing_weapon
 			if(istype(gun))
-				LAZYSET(user.fire_delay_next_fire, gun, world.time + iff_additional_fire_delay)
+				gun.last_fired = world.time + iff_additional_fire_delay
+				SEND_SIGNAL(gun, COMSIG_GUN_STOP_FIRE) //for autofire
+				SEND_SIGNAL(gun, COMSIG_GUN_NEXT_FIRE_MODIFIED, gun.last_fired) //for autofire
 		return COMPONENT_CANCEL_GUN_BEFORE_FIRE
 
 	//At some angles (scatter or otherwise) the original target is not in checked_turfs so we put it in there in order based on distance from user
@@ -88,7 +90,9 @@
 				if(iff_additional_fire_delay)
 					var/obj/item/weapon/gun/gun = firing_weapon
 					if(istype(gun))
-						gun.last_fired = (world.time + iff_additional_fire_delay)
+						gun.last_fired = world.time + iff_additional_fire_delay
+						SEND_SIGNAL(gun, COMSIG_GUN_STOP_FIRE) //for autofire
+						SEND_SIGNAL(gun, COMSIG_GUN_NEXT_FIRE_MODIFIED, gun.last_fired) //for autofire
 				return COMPONENT_CANCEL_GUN_BEFORE_FIRE
 
 			return //if we have a target we *can* hit and find it before any IFF targets we want to fire

--- a/code/datums/emergency_calls/supplies.dm
+++ b/code/datums/emergency_calls/supplies.dm
@@ -86,5 +86,5 @@
 					new /obj/item/ammo_magazine/rifle/l42a/ap(W)
 					new /obj/item/attachable/stock/carbine(W)
 					new /obj/item/attachable/stock/carbine(W)
-					new /obj/item/attachable/scope/mini_iff(W)
-					new /obj/item/attachable/scope/mini_iff(W)
+					new /obj/item/attachable/alt_iff_scope(W)
+					new /obj/item/attachable/alt_iff_scope(W)

--- a/code/game/machinery/vending/vendor_types/prep_upp/requisitions_upp.dm
+++ b/code/game/machinery/vending/vendor_types/prep_upp/requisitions_upp.dm
@@ -183,7 +183,7 @@
 		list("Suppressor", 6.5, /obj/item/attachable/suppressor, VENDOR_ITEM_REGULAR),
 
 		list("RAIL", -1, null, null),
-		list("B8 Smart-Scope", 3.5, /obj/item/attachable/scope/mini_iff, VENDOR_ITEM_REGULAR),
+		list("B8 Smart-Scope", 3.5, /obj/item/attachable/alt_iff_scope, VENDOR_ITEM_REGULAR),
 		list("Magnetic Harness", 8.5, /obj/item/attachable/magnetic_harness, VENDOR_ITEM_REGULAR),
 		list("Rail Flashlight", 10.5, /obj/item/attachable/flashlight, VENDOR_ITEM_REGULAR),
 		list("S4 2x Telescopic Mini-Scope", 4.5, /obj/item/attachable/scope/mini, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/prep_upp/squad_prep_upp.dm
+++ b/code/game/machinery/vending/vendor_types/prep_upp/squad_prep_upp.dm
@@ -109,7 +109,7 @@
 		list("Suppressor", 2.5, /obj/item/attachable/suppressor, VENDOR_ITEM_REGULAR),
 
 		list("RAIL", -1, null, null),
-		list("B8 Smart-Scope", 1.5, /obj/item/attachable/scope/mini_iff, VENDOR_ITEM_REGULAR),
+		list("B8 Smart-Scope", 1.5, /obj/item/attachable/alt_iff_scope, VENDOR_ITEM_REGULAR),
 		list("Magnetic Harness", 4, /obj/item/attachable/magnetic_harness, VENDOR_ITEM_REGULAR),
 		list("S4 2x Telescopic Mini-Scope", 2, /obj/item/attachable/scope/mini, VENDOR_ITEM_REGULAR),
 		list("S5 Red-Dot Sight", 3, /obj/item/attachable/reddot, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -399,7 +399,7 @@
 		list("Suppressor", 6.5, /obj/item/attachable/suppressor, VENDOR_ITEM_REGULAR),
 
 		list("RAIL", -1, null, null),
-		list("B8 Smart-Scope", 3.5, /obj/item/attachable/scope/mini_iff, VENDOR_ITEM_REGULAR),
+		list("B8 Smart-Scope", 3.5, /obj/item/attachable/alt_iff_scope, VENDOR_ITEM_REGULAR),
 		list("Magnetic Harness", 8.5, /obj/item/attachable/magnetic_harness, VENDOR_ITEM_REGULAR),
 		list("Rail Flashlight", 10.5, /obj/item/attachable/flashlight, VENDOR_ITEM_REGULAR),
 		list("S4 2x Telescopic Mini-Scope", 4.5, /obj/item/attachable/scope/mini, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
@@ -371,7 +371,7 @@
 		list("Suppressor", 2.5, /obj/item/attachable/suppressor, VENDOR_ITEM_REGULAR),
 
 		list("RAIL", -1, null, null),
-		list("B8 Smart-Scope", 1.5, /obj/item/attachable/scope/mini_iff, VENDOR_ITEM_REGULAR),
+		list("B8 Smart-Scope", 1.5, /obj/item/attachable/alt_iff_scope, VENDOR_ITEM_REGULAR),
 		list("Magnetic Harness", 4, /obj/item/attachable/magnetic_harness, VENDOR_ITEM_REGULAR),
 		list("S4 2x Telescopic Mini-Scope", 2, /obj/item/attachable/scope/mini, VENDOR_ITEM_REGULAR),
 		list("S5 Red-Dot Sight", 3, /obj/item/attachable/reddot, VENDOR_ITEM_REGULAR),

--- a/code/game/objects/effects/spawners/random.dm
+++ b/code/game/objects/effects/spawners/random.dm
@@ -137,7 +137,7 @@
 				prob(2);/obj/item/attachable/suppressor,\
 				prob(2);/obj/item/attachable/burstfire_assembly,\
 				prob(2);/obj/item/attachable/compensator,\
-				prob(1);/obj/item/attachable/scope/mini_iff,\
+				prob(1);/obj/item/attachable/alt_iff_scope,\
 				prob(1);/obj/item/attachable/heavy_barrel,\
 				prob(1);/obj/item/attachable/scope/mini)
 

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -926,6 +926,36 @@ Defined in conflicts.dm of the #defines folder.
 			. = TRUE
 	return .
 
+/obj/item/attachable/alt_iff_scope
+	name = "B8 Smart-Scope"
+	icon = 'icons/obj/items/weapons/guns/attachments/rail.dmi'
+	icon_state = "iffbarrel"
+	attach_icon = "iffbarrel_a"
+	desc = "An experimental B8 Smart-Scope. Based on the technologies used in the Smart Gun by ARMAT, this sight has integrated IFF systems. It can only attach to the M4RA Battle Rifle and M44 Combat Revolver."
+	desc_lore = "An experimental fire-control optic capable of linking into compatible IFF systems on certain weapons, designated the XAN/PVG-110 Smart Scope. Currently programmed for usage with the M4RA battle rifle and M44 Combat Revolver, due to their relatively lower rates of fire. Experimental technology developed by Armat, who have assured that all previously reported issues with false-negative IFF recognitions have been solved. Make sure to check the sight after every op, just in case."
+	slot = "rail"
+	pixel_shift_y = 15
+
+/obj/item/attachable/alt_iff_scope/New()
+	..()
+	damage_mod = -BULLET_DAMAGE_MULT_TIER_2
+	damage_falloff_mod = 0.2
+
+/obj/item/attachable/alt_iff_scope/set_bullet_traits()
+	LAZYADD(traits_to_give, list(
+		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_iff)
+	))
+
+/obj/item/attachable/alt_iff_scope/Attach(obj/item/weapon/gun/attaching_gun)
+	. = ..()
+	if(!GetComponent(attaching_gun, /datum/component/iff_fire_prevention))
+		attaching_gun.AddComponent(/datum/component/iff_fire_prevention)
+	SEND_SIGNAL(attaching_gun, COMSIG_GUN_ALT_IFF_TOGGLED, TRUE)
+
+/obj/item/attachable/alt_iff_scope/Detach(mob/user, obj/item/weapon/gun/detaching_gun)
+	. = ..()
+	SEND_SIGNAL(detaching_gun, COMSIG_GUN_ALT_IFF_TOGGLED, FALSE)
+
 /obj/item/attachable/scope
 	name = "S8 4x telescopic scope"
 	icon = 'icons/obj/items/weapons/guns/attachments/rail.dmi'
@@ -1172,11 +1202,11 @@ Defined in conflicts.dm of the #defines folder.
 	attach_icon = icon_state
 
 /obj/item/attachable/scope/mini_iff
-	name = "B8 Smart-Scope"
+	name = "B9 Smart-Scope"
 	icon_state = "iffbarrel"
 	attach_icon = "iffbarrel_a"
-	desc = "An experimental B8 Smart-Scope. Based on the technologies used in the Smart Gun by ARMAT, this sight has integrated IFF systems. It can only attach to the M4RA Battle Rifle and M44 Combat Revolver."
-	desc_lore = "An experimental fire-control optic capable of linking into compatible IFF systems on certain weapons, designated the XAN/PVG-110 Smart Scope. Currently programmed for usage with the M4RA battle rifle and M44 Combat Revolver, due to their relatively lower rates of fire. Experimental technology developed by Armat, who have assured that all previously reported issues with false-negative IFF recognitions have been solved. Make sure to check the sight after every op, just in case."
+	desc = "An experimental B9 Smart-Scope. Based on the technologies used in the Smart Gun by ARMAT, this sight has integrated IFF systems. It can only attach to the M4RA Battle Rifle and M44 Combat Revolver."
+	desc_lore = "An experimental fire-control optic capable of linking into compatible IFF systems on certain weapons, designated the XAN/PVG-111 Smart Scope. Currently programmed for usage with the M4RA battle rifle and M44 Combat Revolver, due to their relatively lower rates of fire. Experimental technology developed by Armat, who have assured that all previously reported issues with false-negative IFF recognitions have been solved. Make sure to check the sight after every op, just in case."
 	slot = "rail"
 	zoom_offset = 6
 	zoom_viewsize = 7

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -935,6 +935,7 @@ Defined in conflicts.dm of the #defines folder.
 	desc_lore = "An experimental fire-control optic capable of linking into compatible IFF systems on certain weapons, designated the XAN/PVG-110 Smart Scope. Currently programmed for usage with the M4RA battle rifle and M44 Combat Revolver, due to their relatively lower rates of fire. Experimental technology developed by Armat, who have assured that all previously reported issues with false-negative IFF recognitions have been solved. Make sure to check the sight after every op, just in case."
 	slot = "rail"
 	pixel_shift_y = 15
+	var/had_auto = FALSE
 
 /obj/item/attachable/alt_iff_scope/New()
 	..()
@@ -951,10 +952,16 @@ Defined in conflicts.dm of the #defines folder.
 	if(!GetComponent(attaching_gun, /datum/component/iff_fire_prevention))
 		attaching_gun.AddComponent(/datum/component/iff_fire_prevention)
 	SEND_SIGNAL(attaching_gun, COMSIG_GUN_ALT_IFF_TOGGLED, TRUE)
+	if((GUN_FIREMODE_AUTOMATIC in attaching_gun.gun_firemode_list))
+		had_auto = TRUE
+		attaching_gun.do_toggle_firemode(null, null, GUN_FIREMODE_SEMIAUTO)
+		attaching_gun.remove_firemode(GUN_FIREMODE_AUTOMATIC)
 
 /obj/item/attachable/alt_iff_scope/Detach(mob/user, obj/item/weapon/gun/detaching_gun)
 	. = ..()
 	SEND_SIGNAL(detaching_gun, COMSIG_GUN_ALT_IFF_TOGGLED, FALSE)
+	if(had_auto == TRUE)
+		detaching_gun.add_firemode(GUN_FIREMODE_AUTOMATIC)
 
 /obj/item/attachable/scope
 	name = "S8 4x telescopic scope"

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -950,7 +950,7 @@ Defined in conflicts.dm of the #defines folder.
 /obj/item/attachable/alt_iff_scope/Attach(obj/item/weapon/gun/attaching_gun)
 	. = ..()
 	if(!GetComponent(attaching_gun, /datum/component/iff_fire_prevention))
-		attaching_gun.AddComponent(/datum/component/iff_fire_prevention)
+		attaching_gun.AddComponent(/datum/component/iff_fire_prevention, 5)
 	SEND_SIGNAL(attaching_gun, COMSIG_GUN_ALT_IFF_TOGGLED, TRUE)
 	if((GUN_FIREMODE_AUTOMATIC in attaching_gun.gun_firemode_list))
 		had_auto = TRUE

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -935,7 +935,6 @@ Defined in conflicts.dm of the #defines folder.
 	desc_lore = "An experimental fire-control optic capable of linking into compatible IFF systems on certain weapons, designated the XAN/PVG-110 Smart Scope. Currently programmed for usage with the M4RA battle rifle the M44 combat revolver, and the M41A MK2 pulse rifle. Experimental technology developed by Armat, who have assured that all previously reported issues with false-negative IFF recognitions have been solved. Make sure to check the sight after every op, just in case."
 	slot = "rail"
 	pixel_shift_y = 15
-	var/had_auto = FALSE
 
 /obj/item/attachable/alt_iff_scope/New()
 	..()
@@ -952,16 +951,11 @@ Defined in conflicts.dm of the #defines folder.
 	if(!GetComponent(attaching_gun, /datum/component/iff_fire_prevention))
 		attaching_gun.AddComponent(/datum/component/iff_fire_prevention, 5)
 	SEND_SIGNAL(attaching_gun, COMSIG_GUN_ALT_IFF_TOGGLED, TRUE)
-	if((GUN_FIREMODE_AUTOMATIC in attaching_gun.gun_firemode_list))
-		had_auto = TRUE
-		attaching_gun.do_toggle_firemode(null, null, GUN_FIREMODE_SEMIAUTO)
-		attaching_gun.remove_firemode(GUN_FIREMODE_AUTOMATIC)
 
 /obj/item/attachable/alt_iff_scope/Detach(mob/user, obj/item/weapon/gun/detaching_gun)
 	. = ..()
 	SEND_SIGNAL(detaching_gun, COMSIG_GUN_ALT_IFF_TOGGLED, FALSE)
-	if(had_auto == TRUE)
-		detaching_gun.add_firemode(GUN_FIREMODE_AUTOMATIC)
+	detaching_gun.GetExactComponent(/datum/component/iff_fire_prevention).RemoveComponent()
 
 /obj/item/attachable/scope
 	name = "S8 4x telescopic scope"

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -931,8 +931,8 @@ Defined in conflicts.dm of the #defines folder.
 	icon = 'icons/obj/items/weapons/guns/attachments/rail.dmi'
 	icon_state = "iffbarrel"
 	attach_icon = "iffbarrel_a"
-	desc = "An experimental B8 Smart-Scope. Based on the technologies used in the Smart Gun by ARMAT, this sight has integrated IFF systems. It can only attach to the M4RA Battle Rifle and M44 Combat Revolver."
-	desc_lore = "An experimental fire-control optic capable of linking into compatible IFF systems on certain weapons, designated the XAN/PVG-110 Smart Scope. Currently programmed for usage with the M4RA battle rifle and M44 Combat Revolver, due to their relatively lower rates of fire. Experimental technology developed by Armat, who have assured that all previously reported issues with false-negative IFF recognitions have been solved. Make sure to check the sight after every op, just in case."
+	desc = "An experimental B8 Smart-Scope. Based on the technologies used in the Smart Gun by ARMAT, this sight has integrated IFF systems. It can only attach to the M4RA Battle Rifle, the M44 Combat Revolver, and the M41A MK2 Pulse Rifle."
+	desc_lore = "An experimental fire-control optic capable of linking into compatible IFF systems on certain weapons, designated the XAN/PVG-110 Smart Scope. Currently programmed for usage with the M4RA battle rifle the M44 combat revolver, and the M41A MK2 pulse rifle. Experimental technology developed by Armat, who have assured that all previously reported issues with false-negative IFF recognitions have been solved. Make sure to check the sight after every op, just in case."
 	slot = "rail"
 	pixel_shift_y = 15
 	var/had_auto = FALSE
@@ -1207,46 +1207,6 @@ Defined in conflicts.dm of the #defines folder.
 	..()
 	select_gamemode_skin(type)
 	attach_icon = icon_state
-
-/obj/item/attachable/scope/mini_iff
-	name = "B9 Smart-Scope"
-	icon_state = "iffbarrel"
-	attach_icon = "iffbarrel_a"
-	desc = "An experimental B9 Smart-Scope. Based on the technologies used in the Smart Gun by ARMAT, this sight has integrated IFF systems. It can only attach to the M4RA Battle Rifle and M44 Combat Revolver."
-	desc_lore = "An experimental fire-control optic capable of linking into compatible IFF systems on certain weapons, designated the XAN/PVG-111 Smart Scope. Currently programmed for usage with the M4RA battle rifle and M44 Combat Revolver, due to their relatively lower rates of fire. Experimental technology developed by Armat, who have assured that all previously reported issues with false-negative IFF recognitions have been solved. Make sure to check the sight after every op, just in case."
-	slot = "rail"
-	zoom_offset = 6
-	zoom_viewsize = 7
-	pixel_shift_y = 15
-	var/dynamic_aim_slowdown = SLOWDOWN_ADS_MINISCOPE_DYNAMIC
-
-/obj/item/attachable/scope/mini_iff/New()
-	..()
-	movement_onehanded_acc_penalty_mod = MOVEMENT_ACCURACY_PENALTY_MULT_TIER_6
-	accuracy_unwielded_mod = 0
-
-	accuracy_scoped_buff = HIT_ACCURACY_MULT_TIER_1
-	delay_scoped_nerf = 0
-	damage_falloff_scoped_buff = 0
-
-/obj/item/attachable/scope/mini_iff/set_bullet_traits()
-	LAZYADD(traits_to_give, list(
-		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_iff)
-	))
-
-/obj/item/attachable/scope/mini_iff/activate_attachment(obj/item/weapon/gun/G, mob/living/carbon/user, turn_off)
-	if(do_after(user, 4, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
-		allows_movement = 1
-		. = ..()
-
-/obj/item/attachable/scope/mini_iff/apply_scoped_buff(obj/item/weapon/gun/G, mob/living/carbon/user)
-	. = ..()
-	if(G.zoom)
-		G.slowdown += dynamic_aim_slowdown
-
-/obj/item/attachable/scope/mini_iff/remove_scoped_buff(mob/living/carbon/user, obj/item/weapon/gun/G)
-	G.slowdown -= dynamic_aim_slowdown
-	..()
 
 /obj/item/attachable/scope/slavic
 	icon_state = "slavicscope"

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -932,7 +932,7 @@ Defined in conflicts.dm of the #defines folder.
 	icon_state = "iffbarrel"
 	attach_icon = "iffbarrel_a"
 	desc = "An experimental B8 Smart-Scope. Based on the technologies used in the Smart Gun by ARMAT, this sight has integrated IFF systems. It can only attach to the M4RA Battle Rifle, the M44 Combat Revolver, and the M41A MK2 Pulse Rifle."
-	desc_lore = "An experimental fire-control optic capable of linking into compatible IFF systems on certain weapons, designated the XAN/PVG-110 Smart Scope. Currently programmed for usage with the M4RA battle rifle the M44 combat revolver, and the M41A MK2 pulse rifle. Experimental technology developed by Armat, who have assured that all previously reported issues with false-negative IFF recognitions have been solved. Make sure to check the sight after every op, just in case."
+	desc_lore = "An experimental fire-control optic capable of linking into compatible IFF systems on certain weapons, designated the XAN/PVG-110 Smart Scope. Experimental technology developed by Armat, who have assured that all previously reported issues with false-negative IFF recognitions have been solved. Make sure to check the sight after every deployment, just in case."
 	slot = "rail"
 	pixel_shift_y = 15
 

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -318,7 +318,7 @@
 		/obj/item/attachable/scope,
 		/obj/item/attachable/lasersight,
 		/obj/item/attachable/scope/mini,
-		/obj/item/attachable/scope/mini_iff,
+		/obj/item/attachable/alt_iff_scope,
 	)
 	var/folded = FALSE // Used for the stock attachment, to check if we can shoot or not
 
@@ -399,7 +399,7 @@
 		/obj/item/attachable/reflex,
 		/obj/item/attachable/scope,
 		/obj/item/attachable/scope/mini,
-		/obj/item/attachable/scope/mini_iff,
+		/obj/item/attachable/alt_iff_scope,
 	)
 
 /obj/item/weapon/gun/revolver/m44/custom/pkd_special/k2049/set_gun_attachment_offsets()

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -75,6 +75,7 @@
 		/obj/item/attachable/attached_gun/flamer/advanced,
 		/obj/item/attachable/attached_gun/shotgun,
 		/obj/item/attachable/attached_gun/extinguisher,
+		/obj/item/attachable/alt_iff_scope,
 		/obj/item/attachable/scope,
 		/obj/item/attachable/scope/mini,
 	)
@@ -1618,7 +1619,7 @@
 		/obj/item/attachable/lasersight,
 		/obj/item/attachable/scope,
 		/obj/item/attachable/scope/mini,
-		/obj/item/attachable/scope/mini_iff,
+		/obj/item/attachable/alt_iff_scope,
 		/obj/item/attachable/flashlight/grip,
 	)
 
@@ -1694,7 +1695,7 @@
 		/obj/item/attachable/lasersight,
 		/obj/item/attachable/scope,
 		/obj/item/attachable/scope/mini,
-		/obj/item/attachable/scope/mini_iff,
+		/obj/item/attachable/alt_iff_scope,
 		/obj/item/attachable/flashlight/grip,
 	)
 


### PR DESCRIPTION
# About the pull request

This PR adds a new smartscope that replaces all current instances of the smartscope and uses the Alt IFF system(E.g, it prevents you from shooting at friendlies rather than firing through them.) 

the old smartscope has been removed entirely

The B8(new smartscope) now applies a 10% damage reduction modifier, and a .2 falloff modifier, but otherwise does not alter the gun's stats. 
The B8(new smartscope) Does not have the zoom feature.

The M41A MK2 can now equip the smartscope.

# Explain why it's good for the game

The smartscope largely exists as "training wheels" for newer/more casual players to play, however as it currently exists, completely destroys a weapon's stats-- making a player individually near useless, while also allowing for IFF stacking with multiple rifles, in which case it is very very strong. It is also restricted to some of the least used guns in the game, meaning the pulse rifle a newer player is often handed can't even mount it.

To remedy this, the smartscope now uses the alt IFF system, instead of being a DPS stacking item you can add to your frontline riflemen it instead acts as an assist item, similar to the recoil compensator, that allows you to trade some damage for the assist. 

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

https://github.com/user-attachments/assets/ceb47ac1-b0ba-4b57-b992-52c961248159

</details>


# Changelog
:cl: detectivegoogle, ihatethisengine
balance: The smartscope now uses alt IFF and cannot fire through friendlies.
balance: The smartscope now only applies a small damage and falloff malus to the mounted weapon.
balance: The smartscope can be mounted to the m41a MK2
balance: The smartscope has lost it's zoom functionality.
/:cl:
