### PR TITLE
Replaces placeholder rats with real rats

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -147,7 +147,7 @@
 
 /mob/living/simple_animal/mouse/white/Doc
 	name = "Doc"
-	desc = "Senior researcher of the Almayer. Likes: cheese, experiments, explosions."
+	desc = "Senior mouse researcher of the Almayer. Likes: cheese, experiments, explosions."
 	gender = MALE
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -116,11 +116,8 @@
 	layer = 3.5;
 	pixel_y = 13
 	},
-/mob/living/simple_animal/mouse/brown{
-	name = "rat"
-	},
-/obj/structure/sign/safety/bathunisex{
-	pixel_x = -16;
+/mob/living/simple_animal/mouse/rat/brown{
+	/obj/structure/sign/safety/bathunisex{pixel_x = -16;
 	pixel_y = 8
 	},
 /turf/open/floor/almayer/plate,

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -116,8 +116,9 @@
 	layer = 3.5;
 	pixel_y = 13
 	},
-/mob/living/simple_animal/mouse/rat/brown{
-	/obj/structure/sign/safety/bathunisex{pixel_x = -16;
+/mob/living/simple_animal/mouse/rat/brown,
+/obj/structure/sign/safety/bathunisex{
+	pixel_x = -16;
 	pixel_y = 8
 	},
 /turf/open/floor/almayer/plate,

--- a/maps/templates/lazy_templates/fax_responder_base.dmm
+++ b/maps/templates/lazy_templates/fax_responder_base.dmm
@@ -1802,9 +1802,7 @@
 	pixel_y = -4;
 	pixel_x = 17
 	},
-/mob/living/simple_animal/mouse/brown{
-	name = "rat"
-	},
+/mob/living/simple_animal/mouse/rat/brown,
 /obj/effect/decal/strata_decals/catwalk/prison,
 /turf/open/gm/river/no_overlay/sewage,
 /area/adminlevel/ert_station/fax_response_station)
@@ -4540,9 +4538,7 @@
 /area/adminlevel/ert_station/fax_response_station)
 "Wt" = (
 /obj/structure/platform/metal/kutjevo_smooth/north,
-/mob/living/simple_animal/mouse/brown{
-	name = "rat"
-	},
+/mob/living/simple_animal/mouse/rat/brown,
 /obj/effect/decal/strata_decals/catwalk/prison,
 /turf/open/gm/river/no_overlay/sewage,
 /area/adminlevel/ert_station/fax_response_station)


### PR DESCRIPTION
# About the pull request

Since introduction of Hybrisa, we've got an actual rats with unique sprites and fluff, but we've had some placeholder mice with rat name slapped on it, this pr replaces those with real rats.

# Explain why it's good for the game

Oversights bad


# Changelog
:cl:
fix: replaced placeholder mouse named "rat" with an actual rats
spellcheck: specified that Doc the mouse is actually a mouse and not a rat
/:cl:
