### PR TITLE
fix OT rocket explosions only going in one direction

### DIFF
--- a/code/datums/ammo/rocket.dm
+++ b/code/datums/ammo/rocket.dm
@@ -288,7 +288,7 @@
 		if(rocket.fuel && rocket.fuel.reagents.get_reagent_amount(rocket.fuel_type) >= rocket.fuel_requirement)
 			rocket.forceMove(projectile.loc)
 		rocket.warhead.cause_data = projectile.weapon_cause_data
-		rocket.warhead.dir = get_dir(launcher, atom)
+		rocket.warhead.hit_angle = Get_Angle(launcher, atom)
 		rocket.warhead.prime()
 		qdel(rocket)
 	smoke.set_up(1, get_turf(atom))

--- a/code/game/objects/items/explosives/explosive.dm
+++ b/code/game/objects/items/explosives/explosive.dm
@@ -26,9 +26,14 @@
 	var/falloff_mode = EXPLOSION_FALLOFF_SHAPE_LINEAR
 	/// Whether a star shape is possible when the intensity meets CHEM_FIRE_STAR_THRESHOLD
 	var/allow_star_shape = TRUE
-	var/use_dir = FALSE
+	/// Whether explosions created care about directions
+	var/explosion_use_dir = FALSE
+	/// Whether shrapnels created care about directions
+	var/shrapnel_use_dir = FALSE
+	/// Splatter angle for shrapnels
 	var/angle = 360
-	var/has_blast_wave_dampener = FALSE; //Whether or not the casing can be toggle between different falloff_mode
+	/// Whether or not the casing can be toggled between different falloff_mode
+	var/has_blast_wave_dampener = FALSE;
 	item_icons = list(
 		WEAR_L_HAND = 'icons/mob/humans/onmob/inhands/weapons/grenades_lefthand.dmi',
 		WEAR_R_HAND = 'icons/mob/humans/onmob/inhands/weapons/grenades_righthand.dmi'

--- a/code/game/objects/items/explosives/explosive.dm
+++ b/code/game/objects/items/explosives/explosive.dm
@@ -26,12 +26,12 @@
 	var/falloff_mode = EXPLOSION_FALLOFF_SHAPE_LINEAR
 	/// Whether a star shape is possible when the intensity meets CHEM_FIRE_STAR_THRESHOLD
 	var/allow_star_shape = TRUE
-	/// Whether explosions created care about directions
-	var/explosion_use_dir = FALSE
-	/// Whether shrapnels created care about directions
-	var/shrapnel_use_dir = FALSE
-	/// Splatter angle for shrapnels
-	var/angle = 360
+	/// Whether both explosions and shrapnels use directions
+	var/use_dir = FALSE
+	/// Spread angle for shrapnels
+	var/shrapnel_spread = 360
+	/// The angle that this explosive last hits the target at, applies to projectiles, this will override dir if set
+	var/hit_angle
 	/// Whether or not the casing can be toggled between different falloff_mode
 	var/has_blast_wave_dampener = FALSE;
 	item_icons = list(

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -22,7 +22,8 @@
 							"min_fire_rad" = 2, "min_fire_int" = 3, "min_fire_dur" = 3
 	)
 	angle = 60
-	use_dir = TRUE
+	explosion_use_dir = TRUE
+	shrapnel_use_dir = TRUE
 	var/iff_signal = FACTION_MARINE
 	var/triggered = FALSE
 	var/hard_iff_lock = FALSE
@@ -168,11 +169,14 @@
 	if(customizable && assembly_stage == ASSEMBLY_LOCKED)
 		if(isigniter(detonator.a_right) && isigniter(detonator.a_left))
 			set_tripwire()
-			use_dir = TRUE
+			explosion_use_dir = TRUE
+			shrapnel_use_dir = TRUE
 			return
 		else
 			..()
-			use_dir = FALSE // Claymore defaults to radial in these case. Poor man C4
+			// Claymore defaults to radial in these case. Poor man C4
+			explosion_use_dir = FALSE
+			shrapnel_use_dir = FALSE
 			triggered = TRUE // Delegating the tripwire/crossed function to the sensor.
 
 

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -21,9 +21,8 @@
 							"max_fire_rad" = 4, "max_fire_int" = 20, "max_fire_dur" = 18,
 							"min_fire_rad" = 2, "min_fire_int" = 3, "min_fire_dur" = 3
 	)
-	angle = 60
-	explosion_use_dir = TRUE
-	shrapnel_use_dir = TRUE
+	shrapnel_spread = 60
+	use_dir = TRUE
 	var/iff_signal = FACTION_MARINE
 	var/triggered = FALSE
 	var/hard_iff_lock = FALSE
@@ -169,14 +168,12 @@
 	if(customizable && assembly_stage == ASSEMBLY_LOCKED)
 		if(isigniter(detonator.a_right) && isigniter(detonator.a_left))
 			set_tripwire()
-			explosion_use_dir = TRUE
-			shrapnel_use_dir = TRUE
+			use_dir = TRUE
 			return
 		else
 			..()
 			// Claymore defaults to radial in these case. Poor man C4
-			explosion_use_dir = FALSE
-			shrapnel_use_dir = FALSE
+			use_dir = TRUE
 			triggered = TRUE // Delegating the tripwire/crossed function to the sensor.
 
 
@@ -228,7 +225,7 @@
 	set waitfor = 0
 
 	if(!customizable)
-		create_shrapnel(loc, 12, dir, angle, , cause_data)
+		create_shrapnel(loc, 12, dir, shrapnel_spread, , cause_data)
 		cell_explosion(loc, 60, 20, EXPLOSION_FALLOFF_SHAPE_LINEAR, dir, cause_data)
 		qdel(src)
 	else

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -173,7 +173,7 @@
 		else
 			..()
 			// Claymore defaults to radial in these case. Poor man C4
-			use_dir = TRUE
+			use_dir = FALSE
 			triggered = TRUE // Delegating the tripwire/crossed function to the sensor.
 
 

--- a/code/game/objects/items/explosives/plastic.dm
+++ b/code/game/objects/items/explosives/plastic.dm
@@ -326,7 +326,7 @@
 	item_state = "satchel-charge"
 	overlay_image = "satchel-active"
 	w_class = SIZE_SMALL
-	angle = 55
+	shrapnel_spread = 55
 	timer = 3
 	min_timer = 3
 	penetration = 0.60
@@ -360,7 +360,7 @@
 
 /obj/item/explosive/plastic/breaching_charge/handle_explosion(turf/target_turf, dir, cause_data)
 	var/explosion_target = get_step(target_turf, dir)
-	create_shrapnel(explosion_target, shrapnel_volume, dir, angle, shrapnel_type, cause_data)
+	create_shrapnel(explosion_target, shrapnel_volume, dir, shrapnel_spread, shrapnel_type, cause_data)
 	addtimer(CALLBACK(src, PROC_REF(trigger_explosion), target_turf, dir, cause_data), 1)
 
 /obj/item/explosive/plastic/breaching_charge/proc/trigger_explosion(turf/target_turf, dir, cause_data)
@@ -384,7 +384,7 @@
 	icon_state = "plasma-charge"
 	overlay_image = "plasma-active"
 	w_class = SIZE_SMALL
-	angle = 55
+	shrapnel_spread = 55
 	timer = 5
 	min_timer = 5
 	penetration = 0.60

--- a/code/game/objects/items/explosives/warhead.dm
+++ b/code/game/objects/items/explosives/warhead.dm
@@ -11,8 +11,7 @@
 	icon_state = "warhead_rocket"
 	max_container_volume = 210
 	allow_star_shape = FALSE
-	shrapnel_use_dir = TRUE
-	angle = 90
+	shrapnel_spread = 90
 	matter = list("metal" = 11250) //3 sheets
 	reaction_limits = list( "max_ex_power" = 220, "base_ex_falloff" = 160,"max_ex_shards" = 80,
 							"max_fire_rad" = 4, "max_fire_int" = 45, "max_fire_dur" = 48,

--- a/code/game/objects/items/explosives/warhead.dm
+++ b/code/game/objects/items/explosives/warhead.dm
@@ -11,7 +11,7 @@
 	icon_state = "warhead_rocket"
 	max_container_volume = 210
 	allow_star_shape = FALSE
-	use_dir = TRUE
+	shrapnel_use_dir = TRUE
 	angle = 90
 	matter = list("metal" = 11250) //3 sheets
 	reaction_limits = list( "max_ex_power" = 220, "base_ex_falloff" = 160,"max_ex_shards" = 80,

--- a/code/game/objects/shrapnel.dm
+++ b/code/game/objects/shrapnel.dm
@@ -1,12 +1,15 @@
 
-/proc/create_shrapnel(turf/epicenter, shrapnel_number = 10, shrapnel_direction, shrapnel_spread = 45, datum/ammo/shrapnel_type = /datum/ammo/bullet/shrapnel, datum/cause_data/cause_data, ignore_source_mob = FALSE, on_hit_coefficient = 0.15)
+/proc/create_shrapnel(turf/epicenter, shrapnel_number = 10, shrapnel_direction, shrapnel_spread = 45, datum/ammo/shrapnel_type = /datum/ammo/bullet/shrapnel, datum/cause_data/cause_data, ignore_source_mob = FALSE, on_hit_coefficient = 0.15, use_shrapnel_angle = FALSE)
 
 	epicenter = get_turf(epicenter)
 
 	var/initial_angle = 0
 	var/angle_increment = 0
 
-	if(shrapnel_direction)
+	if(use_shrapnel_angle && shrapnel_spread < 360)
+		initial_angle = shrapnel_direction - shrapnel_spread
+		angle_increment = shrapnel_spread*2/shrapnel_number
+	else if (shrapnel_direction)
 		initial_angle = dir2angle(shrapnel_direction) - shrapnel_spread
 		angle_increment = shrapnel_spread*2/shrapnel_number
 	else


### PR DESCRIPTION

# About the pull request

see title
Closes #8113

# Explain why it's good for the game

directional explosions is an unintentional devastating nerf for explosive ot rockets, this fixes that 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: fixed ot rocket's blast wave only going in one direction
/:cl:
