### PR TITLE
Makes egg-sac eggs not support playable huggers 

### DIFF
--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -457,6 +457,11 @@ SPECIAL EGG USED WHEN WEEDS LOST
 
 #define ORPHAN_EGG_MAXIMUM_LIFE 6 MINUTES // Should be longer than HIVECORE_COOLDOWN
 
+/obj/effect/alien/egg/carrier_egg/orphan
+	huggers_can_spawn = TRUE
+
+
+
 /obj/effect/alien/egg/carrier_egg/orphan/Initialize(mapload, hivenumber, weed_strength_required)
 	src.weed_strength_required = weed_strength_required
 

--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -20,6 +20,7 @@
 	var/weed_strength_required = WEED_LEVEL_HIVE
 	/// Whether to convert/orphan once EGG_BURSTING is complete
 	var/convert_on_release = FALSE
+	var/huggers_can_spawn = TRUE
 
 /obj/effect/alien/egg/Initialize(mapload, hive)
 	. = ..()
@@ -338,6 +339,9 @@
 	if(status != EGG_GROWN)
 		to_chat(user, SPAN_WARNING("\The [src] doesn't have any facehuggers to inhabit."))
 		return
+	if(!huggers_can_spawn)
+		to_chat(user, SPAN_WARNING("This egg cannot support active facehuggers!"))
+		return
 
 	if(!GLOB.hive_datum[hivenumber].can_spawn_as_hugger(user))
 		return
@@ -395,6 +399,7 @@ SPECIAL EGG USED BY EGG CARRIER
 	var/last_refreshed = null
 	/// Timer holder for the maximum lifetime of the egg as defined CARRIER_EGG_MAXIMUM_LIFE
 	var/life_timer = null
+	huggers_can_spawn = FALSE
 
 /obj/effect/alien/egg/carrier_egg/Initialize(mapload, hivenumber, planter = null)
 	. = ..()


### PR DESCRIPTION

# About the pull request

If there is eggs BEFORE you put a cluster down as a carrier, the eggs will not support a playable hugger.  However any egg put after a cluster was placed will still support huggers(eggsac only)

# Explain why it's good for the game

Alot of people were complaining about how an oppressor + eggsac combo, or eggs designated to trap people by carrier players were being used up by playable huggers, this should remedy that while still allowing some huggers to spawn out of correct eggs.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Eggsac carrier eggs no longer support playable huggers IF there is no cluster BEFORE they are placed, eggs put on clustered/hive weeds still allow huggers
/:cl:
