### PR TITLE
Adds a 5 hour MP Timelock to XO.

### DIFF
--- a/code/game/jobs/job/command/cic/executive.dm
+++ b/code/game/jobs/job/command/cic/executive.dm
@@ -20,6 +20,7 @@
 AddTimelock(/datum/job/command/executive, list(
 	JOB_COMMAND_ROLES = 20 HOURS,
 	JOB_SQUAD_LEADER = 10 HOURS,
+	JOB_POLICE_ROLES = 5 HOURS,
 ))
 
 /datum/job/command/executive/announce_entry_message(mob/living/carbon/human/H)


### PR DESCRIPTION

# About the pull request

Executive Officer now has a required 5 hour MP Timelock in order to play.

# Explain why it's good for the game

#2571 was made almost 2 years ago in a different culture of the server. MPs and Marine Law has changed. Executive Officer is *third* highest in Marine Law Authority on the ship, only behind CMP and CO.

If I am being honest, I want to see change for the role as they are already held to a high expectation, if you are so high in the ML totem pole you should atleast know the *bare minimum*. Too many times as CMP do I request an appeal from an XO and they delegate it to some brand new SO or ASO with no experience, or they inadvertently try to parole the prisoner by saying things like "It was probably a mistake", "They won't do it again" etc.

***This should change.***

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: XO now has a 5 Hour Timelock to play the role.
/:cl:
