### PR TITLE
Replaces a Security Cabinet on LV624

### DIFF
--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -9753,13 +9753,10 @@
 /turf/open/floor/dark,
 /area/lv624/lazarus/engineering)
 "aZz" = (
-/obj/structure/filingcabinet/security{
-	desc = "A large cabinet with hard copy security records.";
-	name = "Security Records"
-	},
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/filingcabinet,
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/redcorner/north,
 /area/lv624/lazarus/security)


### PR DESCRIPTION

# About the pull request

fixes #8285 

replaces the Security Cabinet in the Office with a regular one.

# Explain why it's good for the game

Colony cabinets magically spawning with USS Almayer information is bad.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: Replaced the Security Cabinet in the Security Office on LV624 with a regular Cabinet. Almayer Crew Records should no longer spawn.
/:cl:
