### PR TITLE
 Marines automatically scrape acid off items

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -437,10 +437,9 @@
 
 	if(mob)
 		var/damage = 10
-		mob.apply_damage(damage, BURN) // Apply burn damage
+		mob.apply_damage(damage, BURN)
 		to_chat(mob, SPAN_DANGER("The acid burns you as you pick up \the [acid_t]!"))
 
-	// Terminate the acid process
 	qdel(src)
 
 /obj/effect/xenomorph/boiler_bombard

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -332,6 +332,7 @@
 	handle_weather()
 	RegisterSignal(SSdcs, COMSIG_GLOB_WEATHER_CHANGE, PROC_REF(handle_weather))
 	RegisterSignal(acid_t, COMSIG_PARENT_QDELETING, PROC_REF(cleanup))
+	RegisterSignal(target, COMSIG_ITEM_PICKUP, PROC_REF(on_pickup))
 	START_PROCESSING(SSoldeffects, src)
 
 /obj/effect/xenomorph/acid/Destroy()
@@ -429,6 +430,17 @@
 		for(var/mob/mob in acid_t)
 			mob.forceMove(loc)
 		qdel(acid_t)
+	qdel(src)
+
+/obj/effect/xenomorph/acid/proc/on_pickup(datum/src, mob/living/carbon/mob)
+	SIGNAL_HANDLER
+
+	if(mob)
+		var/damage = 10
+		mob.apply_damage(damage, BURN) // Apply burn damage
+		to_chat(mob, SPAN_DANGER("The acid burns you as you pick up \the [acid_t]!"))
+
+	// Terminate the acid process
 	qdel(src)
 
 /obj/effect/xenomorph/boiler_bombard

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -432,13 +432,22 @@
 		qdel(acid_t)
 	qdel(src)
 
-/obj/effect/xenomorph/acid/proc/on_pickup(datum/src, mob/living/carbon/mob)
+/obj/effect/xenomorph/acid/proc/on_pickup(datum/source, mob/living/carbon/mob)
 	SIGNAL_HANDLER
 
-	if(mob)
-		var/damage = 10
+	if(istype(src, /obj/effect/xenomorph/acid/strong))
+		var/damage = 60
 		mob.apply_damage(damage, BURN)
-		to_chat(mob, SPAN_DANGER("The acid burns you as you pick up \the [acid_t]!"))
+		to_chat(mob, SPAN_DANGER("As you scrape the concentrated acid off \the [acid_t], it gets all over you!"))
+	else if(istype(src, /obj/effect/xenomorph/acid/weak))
+		var/damage = 20
+		mob.apply_damage(damage, BURN)
+		to_chat(mob, SPAN_DANGER("You wipe the acidic residue off \the [acid_t], but it leaves blistered and smoking burns on your body!"))
+	else if(istype(src, /obj/effect/xenomorph/acid))
+		var/damage = 40
+		mob.apply_damage(damage, BURN)
+		to_chat(mob, SPAN_DANGER("The acid sizzles as you scrape it off \the [acid_t], and eats into your skin!"))
+
 
 	qdel(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
When a mob picks an acid-drenched item off the ground, they automatically scrape off the acid, taking damage as they do which scales off the strength of the acid. 20 burn for weak acid, 40 for normal acid, 60 for strong acid.

# Explain why it's good for the game
As of right now, if you pick up an item that has been acided it continues to decay with literally no communication to the player, and that sucks. It _feels_ buggy and unfinished. This makes it so you are still being punished for picking up an item that is literally covered in acid instead of picking up some doomed ghost of an item and nothing happening.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Asmocard
balance: Marines can now retrieve items that have been covered in acid at the cost of some health.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
