### PR TITLE
Makes dropship medevac equipment screen able to see stasis bags

### DIFF
--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -1083,8 +1083,18 @@
 		target_data["ref"] = stretcher_ref
 
 		var/mob/living/carbon/human/occupant = stretcher.buckled_mob
+		var/obj/structure/closet/bodybag/cryobag = stretcher.buckled_bodybag
+		if(!occupant && cryobag)
+			for(var/atom/movable/AM in cryobag)
+				if(ishuman(AM))
+					occupant = AM
+					break
+			target_data["occupant"] = "(Empty stasis bag)"
 		if(occupant)
-			target_data["occupant"] = occupant.name
+			if(cryobag)
+				target_data["occupant"] = "(Stasis bag) " + occupant.name
+			else
+				target_data["occupant"] = occupant.name
 			target_data["time_of_death"] = occupant.tod
 			target_data["damage"] = list(
 				"hp" = occupant.health,

--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -1085,10 +1085,7 @@
 		var/mob/living/carbon/human/occupant = stretcher.buckled_mob
 		var/obj/structure/closet/bodybag/cryobag = stretcher.buckled_bodybag
 		if(!occupant && cryobag)
-			for(var/atom/movable/AM in cryobag)
-				if(ishuman(AM))
-					occupant = AM
-					break
+			occupant = locate(/mob/living/carbon/human) in cryobag
 			target_data["occupant"] = "(Empty stasis bag)"
 		if(occupant)
 			if(cryobag)


### PR DESCRIPTION
# About the pull request

Lets dropship pilot see which stretchers have stasis bags from the console. These are currently incorrectly showing as "Empty"
Fixes #7232 

# Explain why it's good for the game

Fixes a bug and inconsistency with the manual picklist. Avoids one argument between pilots and medics.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

![Dropship_equipment_medevac_compare](https://github.com/user-attachments/assets/e630f3cf-9e7a-4c5c-af16-479a80c0bdca)

</details>
Tested that medevac system could see and fly to stretchers, whether loaded with humans or cryobags.

# Changelog

:cl:
fix: Dropship weapon console can see stasis bags in activated stretchers instead of "Empty"
/:cl:
