### PR TITLE
Fixes non humans being given psychic whisper.

### DIFF
--- a/code/modules/reagents/chemistry_properties/prop_neutral.dm
+++ b/code/modules/reagents/chemistry_properties/prop_neutral.dm
@@ -535,8 +535,12 @@
 	to_chat(chem_host, SPAN_NOTICE("The pain in your head subsides, and you are left feeling strangely alone."))
 
 /datum/chem_property/neutral/encephalophrasive/reaction_mob(mob/chem_host, method=INGEST, volume, potency)
-	give_action(chem_host, /datum/action/human_action/psychic_whisper)
-	to_chat(chem_host, SPAN_NOTICE("A terrible headache manifests, and suddenly it feels as though your mind is outside of your skull."))
+	if(method==TOUCH)
+		return
+	if(ishuman_strict(chem_host))
+		give_action(chem_host, /datum/action/human_action/psychic_whisper)
+		to_chat(chem_host, SPAN_NOTICE("A terrible headache manifests, and suddenly it feels as though your mind is outside of your skull."))
+	return
 
 /datum/chem_property/neutral/encephalophrasive/process(mob/living/chem_host, potency = 1, delta_time)
 	chem_host.pain.apply_pain(1 * potency)

--- a/code/modules/reagents/chemistry_properties/prop_neutral.dm
+++ b/code/modules/reagents/chemistry_properties/prop_neutral.dm
@@ -535,12 +535,13 @@
 	to_chat(chem_host, SPAN_NOTICE("The pain in your head subsides, and you are left feeling strangely alone."))
 
 /datum/chem_property/neutral/encephalophrasive/reaction_mob(mob/chem_host, method=INGEST, volume, potency)
-	if(method==TOUCH)
+	if(method == TOUCH)
 		return
-	if(ishuman_strict(chem_host))
-		give_action(chem_host, /datum/action/human_action/psychic_whisper)
-		to_chat(chem_host, SPAN_NOTICE("A terrible headache manifests, and suddenly it feels as though your mind is outside of your skull."))
-	return
+	if(!ishuman_strict(chem_host))
+		return
+
+	give_action(chem_host, /datum/action/human_action/psychic_whisper)
+	to_chat(chem_host, SPAN_NOTICE("A terrible headache manifests, and suddenly it feels as though your mind is outside of your skull."))
 
 /datum/chem_property/neutral/encephalophrasive/process(mob/living/chem_host, potency = 1, delta_time)
 	chem_host.pain.apply_pain(1 * potency)


### PR DESCRIPTION
# About the pull request

fixes #7587
fixes #8108
# Explain why it's good for the game

fixes


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Synthetics and non-humans can no longer get psychic whisper through research.
code: encephalophrasive no longer applies on touch since it lasts forever otherwise
/:cl:
