### PR TITLE
Fixes evolutio button being taken away if you reset your strain while at full evo

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/xeno_strain.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/xeno_strain.dm
@@ -124,6 +124,9 @@
 		return
 
 	new_xeno.xeno_jitter(1.5 SECONDS)
+	if(evolution_stored == evolution_threshold)
+		give_action(new_xeno, /datum/action/xeno_action/onclick/evolve)
+
 	// If it applied successfully, add it to the logs.
 	log_strain("[new_xeno.name] reset their strain.")
 	COOLDOWN_START(new_xeno, next_strain_reset, 40 MINUTES)


### PR DESCRIPTION

# About the pull request
Fixes #8036 (probably) i tested it to the best of my abilities and it worked

# Explain why it's good for the game

bugfix


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Evolution button no longer gets deleted when you reset your strain while at full evo.
/:cl:
