### PR TITLE
De-freakifies and removes one letter vars from regurgitate code

### DIFF
--- a/code/modules/admin/autoreply.dm
+++ b/code/modules/admin/autoreply.dm
@@ -146,7 +146,7 @@ Laser Designators have a second mode (produces a RED laser) that allows highligh
 
 /datum/autoreply/mentor/devour
 	title = "X: Devour as Xeno"
-	message = "Devouring is useful to quickly transport incapacitated hosts from one place to another. In order to devour a host as a Xeno, grab the mob (CTRL+Click) and then click on yourself to begin devouring. The host can break out of your belly, which will result in your death so make sure your target is incapacitated. After approximately 1 minute host will be automatically regurgitated. To release your target voluntary, click 'Regurgitate' on the HUD to throw them back up."
+	message = "Devouring is useful to quickly transport incapacitated hosts from one place to another. In order to devour a host as a Xeno, grab the mob (CTRL+Click) and then click on yourself to begin devouring. The host can break out of your stomach, which will result in your death so make sure your target is incapacitated. After approximately 1 minute host will be automatically regurgitated. To release your target voluntary, click 'Regurgitate' on the HUD to throw them back up."
 
 /datum/autoreply/mentor/plasma
 	title = "X: No plasma regen"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -43,34 +43,34 @@
 		if(user.client)
 			user.client.next_movement = world.time + 20
 		if(prob(30))
-			for(var/mob/M in hearers(4, src))
-				if(M.client)
-					M.show_message(SPAN_DANGER("You hear something rumbling inside [src]'s stomach..."), SHOW_MESSAGE_AUDIBLE)
-		var/obj/item/I = user.get_active_hand()
-		if(I && I.force)
-			var/d = rand(floor(I.force / 4), I.force)
+			for(var/mob/mobs_can_hear in hearers(4, src))
+				if(mobs_can_hear.client)
+					mobs_can_hear.show_message(SPAN_DANGER("You hear something rumbling inside [src]'s stomach..."), SHOW_MESSAGE_AUDIBLE)
+		var/obj/item/item_in_hand = user.get_active_hand()
+		if(item_in_hand && item_in_hand.force)
+			var/damage_of_item = rand(floor(item_in_hand.force / 4), item_in_hand.force)
 			if(istype(src, /mob/living/carbon/human))
-				var/mob/living/carbon/human/H = src
-				var/organ = H.get_limb("chest")
+				var/mob/living/carbon/human/human_mob = src
+				var/organ = human_mob.get_limb("chest")
 				if(istype(organ, /obj/limb))
-					var/obj/limb/temp = organ
-					if(temp.take_damage(d, 0))
-						H.UpdateDamageIcon()
-				H.updatehealth()
+					var/obj/limb/organs_in_human = organ
+					if(organs_in_human.take_damage(damage_of_item, 0))
+						human_mob.UpdateDamageIcon()
+				human_mob.updatehealth()
 			else
-				src.take_limb_damage(d)
-			for(var/mob/M as anything in viewers(user, null))
-				if(M.client)
-					M.show_message(text(SPAN_DANGER("<B>[user] attacks [src]'s stomach wall with the [I.name]!")), SHOW_MESSAGE_AUDIBLE)
-			user.track_hit(initial(I.name))
+				src.take_limb_damage(damage_of_item)
+			for(var/mob/mobs_in_view as anything in viewers(user, null))
+				if(mobs_in_view.client)
+					mobs_in_view.show_message(text(SPAN_DANGER("<B>[user] attacks [src]'s stomach wall with the [item_in_hand.name]!")), SHOW_MESSAGE_AUDIBLE)
+			user.track_hit(initial(item_in_hand.name))
 			playsound(user.loc, 'sound/effects/attackblob.ogg', 25, 1)
 
 			if(prob(max(4*(100*getBruteLoss()/maxHealth - 75),0))) //4% at 24% health, 80% at 5% health
 				last_damage_data = create_cause_data("chestbursting", user)
 				gib(last_damage_data)
 	else if(!chestburst && (status_flags & XENO_HOST) && islarva(user))
-		var/mob/living/carbon/xenomorph/larva/L = user
-		L.chest_burst(src)
+		var/mob/living/carbon/xenomorph/larva/larva_burst = user
+		larva_burst.chest_burst(src)
 
 /mob/living/carbon/ex_act(severity, direction, datum/cause_data/cause_data)
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/boiler/boiler_abilities.dm
@@ -50,7 +50,7 @@
 /datum/action/xeno_action/activable/xeno_spit/bombard
 	name = "Bombard"
 	action_icon_state = "bombard"
-	cooldown_message = "Our belly fills with another gas glob. We are ready to bombard again."
+	cooldown_message = "Our stomach fills with another gas glob. We are ready to bombard again."
 	sound_to_play = 'sound/effects/blobattack.ogg'
 	aim_turf = TRUE
 	/// These are actions that will be placed on cooldown for the cooldown_duration when activates. Added acid shroud for now because it can be abused

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -108,10 +108,10 @@
 	victim.Move(user.loc, get_dir(victim.loc, user.loc))
 	victim.update_transform(TRUE)
 
-/obj/item/grab/attack(mob/living/M, mob/living/user)
-	if(M == grabbed_thing)
+/obj/item/grab/attack(mob/living/dragged_mob, mob/living/user)
+	if(dragged_mob == grabbed_thing)
 		attack_self(user)
-	else if(M == user && user.pulling && isxeno(user))
+	else if(dragged_mob == user && user.pulling && isxeno(user))
 		var/mob/living/carbon/xenomorph/xeno = user
 		var/mob/living/carbon/pulled = xeno.pulling
 		if(!istype(pulled))
@@ -126,7 +126,7 @@
 			to_chat(xeno, SPAN_WARNING("Ew, [pulled] is already starting to rot."))
 			return 0
 		if(length(xeno.stomach_contents)) //Only one thing in the stomach at a time, please
-			to_chat(xeno, SPAN_WARNING("You already have something in your belly, there's no way that will fit."))
+			to_chat(xeno, SPAN_WARNING("We already have something in our stomach, there's no way that will fit."))
 			return 0
 			/* Saving this in case we want to allow devouring of dead bodies UNLESS their client is still online somewhere
 			if(pulled.client) //The client is still inside the body


### PR DESCRIPTION
# About the pull request

Remvoes some one letter vars, and changes around some text from devouring people.

# Explain why it's good for the game

we dont need to be this freaky.
one letter vars bad


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
code: Replacces some one letter vars in carbon.dm
spellcheck: Replaces mentions of "belly" with "stomach" in game the tutorial(s).
/:cl:
