### PR TITLE
Fixes queen being unable to gib hosted marines

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -768,15 +768,6 @@
 		if(synthhead.status & LIMB_DESTROYED)
 			return FALSE
 
-	if(victim.status_flags & XENO_HOST)
-		var/mob/living/carbon/human/human_victim = victim
-		if(victim.stat != DEAD) //Not dead yet.
-			to_chat(src, SPAN_XENOWARNING("The host and child are still alive!"))
-			return FALSE
-		else if(istype(human_victim) && (world.time <= human_victim.timeofdeath + human_victim.revive_grace_period)) //Dead, but the host can still hatch, possibly.
-			to_chat(src, SPAN_XENOWARNING("The child may still hatch! Not yet!"))
-			return FALSE
-
 	if(isxeno(victim))
 		var/mob/living/carbon/xenomorph/xeno = victim
 		if(hivenumber == xeno.hivenumber)


### PR DESCRIPTION
# About the pull request

fixes #8167 as he forgot to remove an extra check
# Explain why it's good for the game

bugfix

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Queens can now properly gib anyone regardless of their host status.
/:cl:
