### PR TITLE
Fixes perma holocards being appliable to non-perma

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -831,7 +831,7 @@
 		holo_card_color = null
 		to_chat(user, SPAN_NOTICE("You remove the holo card on [src]."))
 	else if(newcolor != holo_card_color)
-		if(newcolor == ("black") & src.is_revivable())
+		if(newcolor == "black" && is_revivable())
 			to_chat(user, SPAN_WARNING("They are yet saveable."))
 			return
 		holo_card_color = newcolor

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -831,6 +831,9 @@
 		holo_card_color = null
 		to_chat(user, SPAN_NOTICE("You remove the holo card on [src]."))
 	else if(newcolor != holo_card_color)
+		if(newcolor == ("black") & src.is_revivable())
+			to_chat(user, SPAN_WARNING("They are yet saveable."))
+			return
 		holo_card_color = newcolor
 		to_chat(user, SPAN_NOTICE("You add a [newcolor] holo card on [src]."))
 	hud_set_holocard()


### PR DESCRIPTION
# About the pull request

fixes #8319
You can no longer apply the black holocard to people who are still revivable

# Explain why it's good for the game

bugfix


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: You can no longer apply the black holocard to people who are still revivable
/:cl:
