### PR TITLE
Fixes queens being able to leader dead xenos

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -164,7 +164,7 @@
 		if(!length(hive.open_xeno_leader_positions) && xeno.observed_xeno.hive_pos == NORMAL_XENO)
 			to_chat(xeno, SPAN_XENOWARNING("You currently have [length(hive.xeno_leader_list)] promoted leaders. You may not maintain additional leaders until your power grows."))
 			return
-		var/mob/living/carbon/xenomorph/targetted_xeno = xeno.observed_xeno
+		var/mob/living/carbon/xenomorph/targeted_xeno = xeno.observed_xeno
 		if(targetted_xeno == xeno)
 			to_chat(xeno, SPAN_XENOWARNING("You cannot add yourself as a leader!"))
 			return

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -165,27 +165,27 @@
 			to_chat(xeno, SPAN_XENOWARNING("You currently have [length(hive.xeno_leader_list)] promoted leaders. You may not maintain additional leaders until your power grows."))
 			return
 		var/mob/living/carbon/xenomorph/targeted_xeno = xeno.observed_xeno
-		if(targetted_xeno == xeno)
+		if(targeted_xeno == xeno)
 			to_chat(xeno, SPAN_XENOWARNING("You cannot add yourself as a leader!"))
 			return
 		apply_cooldown()
-		if(targetted_xeno.hive_pos == NORMAL_XENO)
-			if(!hive.add_hive_leader(targetted_xeno))
+		if(targeted_xeno.hive_pos == NORMAL_XENO)
+			if(!hive.add_hive_leader(targeted_xeno))
 				to_chat(xeno, SPAN_XENOWARNING("Unable to add the leader."))
 				return
-			if(targetted_xeno.stat == DEAD)
+			if(targeted_xeno.stat == DEAD)
 				to_chat(xeno, SPAN_XENOWARNING("You cannot leader the dead."))
 				return
-			to_chat(xeno, SPAN_XENONOTICE("You've selected [targetted_xeno] as a Hive Leader."))
-			to_chat(targetted_xeno, SPAN_XENOANNOUNCE("[xeno] has selected you as a Hive Leader. The other Xenomorphs must listen to you. You will also act as a beacon for the Queen's pheromones."))
+			to_chat(xeno, SPAN_XENONOTICE("You've selected [targeted_xeno] as a Hive Leader."))
+			to_chat(targeted_xeno, SPAN_XENOANNOUNCE("[xeno] has selected you as a Hive Leader. The other Xenomorphs must listen to you. You will also act as a beacon for the Queen's pheromones."))
 		else
-			hive.remove_hive_leader(targetted_xeno)
-			to_chat(xeno, SPAN_XENONOTICE("You've demoted [targetted_xeno] from Hive Leader."))
-			to_chat(targetted_xeno, SPAN_XENOANNOUNCE("[xeno] has demoted you from Hive Leader. Your leadership rights and abilities have waned."))
+			hive.remove_hive_leader(targeted_xeno)
+			to_chat(xeno, SPAN_XENONOTICE("You've demoted [targeted_xeno] from Hive Leader."))
+			to_chat(targeted_xeno, SPAN_XENOANNOUNCE("[xeno] has demoted you from Hive Leader. Your leadership rights and abilities have waned."))
 	else
 		var/list/possible_xenos = list()
-		for(var/mob/living/carbon/xenomorph/targetted_xeno in hive.xeno_leader_list)
-			possible_xenos += targetted_xeno
+		for(var/mob/living/carbon/xenomorph/targeted_xeno in hive.xeno_leader_list)
+			possible_xenos += targeted_xeno
 
 		if(length(possible_xenos) > 1)
 			var/mob/living/carbon/xenomorph/selected_xeno = tgui_input_list(xeno, "Target", "Watch which leader?", possible_xenos, theme="hive_status")

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -153,46 +153,49 @@
 	return ..()
 
 /datum/action/xeno_action/onclick/set_xeno_lead/use_ability(atom/A)
-	var/mob/living/carbon/xenomorph/queen/X = owner
-	if(!X.check_state())
+	var/mob/living/carbon/xenomorph/queen/xeno = owner
+	if(!xeno.check_state())
 		return
 
 	if(!action_cooldown_check())
 		return
-	var/datum/hive_status/hive = X.hive
-	if(X.observed_xeno)
-		if(!length(hive.open_xeno_leader_positions) && X.observed_xeno.hive_pos == NORMAL_XENO)
-			to_chat(X, SPAN_XENOWARNING("You currently have [length(hive.xeno_leader_list)] promoted leaders. You may not maintain additional leaders until your power grows."))
+	var/datum/hive_status/hive = xeno.hive
+	if(xeno.observed_xeno)
+		if(!length(hive.open_xeno_leader_positions) && xeno.observed_xeno.hive_pos == NORMAL_XENO)
+			to_chat(xeno, SPAN_XENOWARNING("You currently have [length(hive.xeno_leader_list)] promoted leaders. You may not maintain additional leaders until your power grows."))
 			return
-		var/mob/living/carbon/xenomorph/T = X.observed_xeno
-		if(T == X)
-			to_chat(X, SPAN_XENOWARNING("You cannot add yourself as a leader!"))
+		var/mob/living/carbon/xenomorph/targetted_xeno = xeno.observed_xeno
+		if(targetted_xeno == xeno)
+			to_chat(xeno, SPAN_XENOWARNING("You cannot add yourself as a leader!"))
 			return
 		apply_cooldown()
-		if(T.hive_pos == NORMAL_XENO)
-			if(!hive.add_hive_leader(T))
-				to_chat(X, SPAN_XENOWARNING("Unable to add the leader."))
+		if(targetted_xeno.hive_pos == NORMAL_XENO)
+			if(!hive.add_hive_leader(targetted_xeno))
+				to_chat(xeno, SPAN_XENOWARNING("Unable to add the leader."))
 				return
-			to_chat(X, SPAN_XENONOTICE("You've selected [T] as a Hive Leader."))
-			to_chat(T, SPAN_XENOANNOUNCE("[X] has selected you as a Hive Leader. The other Xenomorphs must listen to you. You will also act as a beacon for the Queen's pheromones."))
+			if(targetted_xeno.stat == DEAD)
+				to_chat(xeno, SPAN_XENOWARNING("You cannot leader the dead."))
+				return
+			to_chat(xeno, SPAN_XENONOTICE("You've selected [targetted_xeno] as a Hive Leader."))
+			to_chat(targetted_xeno, SPAN_XENOANNOUNCE("[xeno] has selected you as a Hive Leader. The other Xenomorphs must listen to you. You will also act as a beacon for the Queen's pheromones."))
 		else
-			hive.remove_hive_leader(T)
-			to_chat(X, SPAN_XENONOTICE("You've demoted [T] from Hive Leader."))
-			to_chat(T, SPAN_XENOANNOUNCE("[X] has demoted you from Hive Leader. Your leadership rights and abilities have waned."))
+			hive.remove_hive_leader(targetted_xeno)
+			to_chat(xeno, SPAN_XENONOTICE("You've demoted [targetted_xeno] from Hive Leader."))
+			to_chat(targetted_xeno, SPAN_XENOANNOUNCE("[xeno] has demoted you from Hive Leader. Your leadership rights and abilities have waned."))
 	else
 		var/list/possible_xenos = list()
-		for(var/mob/living/carbon/xenomorph/T in hive.xeno_leader_list)
-			possible_xenos += T
+		for(var/mob/living/carbon/xenomorph/targetted_xeno in hive.xeno_leader_list)
+			possible_xenos += targetted_xeno
 
 		if(length(possible_xenos) > 1)
-			var/mob/living/carbon/xenomorph/selected_xeno = tgui_input_list(X, "Target", "Watch which leader?", possible_xenos, theme="hive_status")
-			if(!selected_xeno || selected_xeno.hive_pos == NORMAL_XENO || selected_xeno == X.observed_xeno || selected_xeno.stat == DEAD || selected_xeno.z != X.z || !X.check_state())
+			var/mob/living/carbon/xenomorph/selected_xeno = tgui_input_list(xeno, "Target", "Watch which leader?", possible_xenos, theme="hive_status")
+			if(!selected_xeno || selected_xeno.hive_pos == NORMAL_XENO || selected_xeno == xeno.observed_xeno || selected_xeno.stat == DEAD || selected_xeno.z != xeno.z || !xeno.check_state())
 				return
-			X.overwatch(selected_xeno)
+			xeno.overwatch(selected_xeno)
 		else if(length(possible_xenos))
-			X.overwatch(possible_xenos[1])
+			xeno.overwatch(possible_xenos[1])
 		else
-			to_chat(X, SPAN_XENOWARNING("There are no Xenomorph leaders. Overwatch a Xenomorph to make it a leader."))
+			to_chat(xeno, SPAN_XENOWARNING("There are no Xenomorph leaders. Overwatch a Xenomorph to make it a leader."))
 	return ..()
 
 /datum/action/xeno_action/activable/queen_heal/use_ability(atom/A, verbose)


### PR DESCRIPTION

# About the pull request

fixes #7309
Queens can no longer leader the dead

# Explain why it's good for the game

bugfix

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Queens can no longer leader the dead.
code: Removes one letter vars
/:cl:
