### PR TITLE
Fixes airlock assemblies being unslashable

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -534,19 +534,20 @@
 
 //airlock assemblies
 /obj/structure/airlock_assembly/attack_alien(mob/living/carbon/xenomorph/xeno)
+	. = XENO_ATTACK_ACTION
 
 	xeno.animation_attack_on(src)
 	playsound(src, 'sound/effects/metalhit.ogg', 25, 1)
 	update_health(rand(xeno.melee_damage_lower, xeno.melee_damage_upper))
 	if(health <= 0)
-		xeno.visible_message(SPAN_DANGER("[xeno] slices \the [src] apart!"),
-		SPAN_DANGER("We slice \the [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+		xeno.visible_message(SPAN_DANGER("[xeno] slices [src] apart!"),
+		SPAN_DANGER("We slice [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 		if(!unacidable)
 			qdel(src)
-	else
-		xeno.visible_message(SPAN_DANGER("[xeno] [xeno.slashes_verb] \the [src]!"),
-		SPAN_DANGER("We [xeno.slash_verb] \the [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
-	return XENO_ATTACK_ACTION
+		return
+
+	xeno.visible_message(SPAN_DANGER("[xeno] [xeno.slashes_verb] [src]!"),
+	SPAN_DANGER("We [xeno.slash_verb] [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 
 
 //Prying open doors

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -531,6 +531,24 @@
 		shatter()
 	return XENO_ATTACK_ACTION
 
+
+//airlock assemblies
+/obj/structure/airlock_assembly/attack_alien(mob/living/carbon/xenomorph/xeno)
+
+	xeno.animation_attack_on(src)
+	playsound(src, 'sound/effects/metalhit.ogg', 25, 1)
+	update_health(rand(xeno.melee_damage_lower, xeno.melee_damage_upper))
+	if(health <= 0)
+		xeno.visible_message(SPAN_DANGER("[xeno] slices \the [src] apart!"),
+		SPAN_DANGER("We slice \the [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+		if(!unacidable)
+			qdel(src)
+	else
+		xeno.visible_message(SPAN_DANGER("[xeno] [xeno.slashes_verb] \the [src]!"),
+		SPAN_DANGER("We [xeno.slash_verb] \the [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+	return XENO_ATTACK_ACTION
+
+
 //Prying open doors
 /obj/structure/machinery/door/airlock/attack_alien(mob/living/carbon/xenomorph/M)
 	var/turf/cur_loc = M.loc


### PR DESCRIPTION

# About the pull request

fixes #7287
You can now slash airlock assemblies apart

# Explain why it's good for the game
bugfix

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Airlock assemblies are no longer unslashable.
/:cl:
