### PR TITLE
Fixes being able to use telekinesis to make paper appear in your hand

### DIFF
--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -53,7 +53,9 @@
 				P = new /obj/item/paper/uscm
 
 
-
+		if(get_dist(user, src) > 1)
+			to_chat(user, SPAN_WARNING("You are too far away."))
+			return
 		P.forceMove(user.loc)
 		user.put_in_hands(P)
 		to_chat(user, SPAN_NOTICE("You take [P] out of [src]."))


### PR DESCRIPTION

# About the pull request

fixes #6963


# Explain why it's good for the game

bugfix

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: You can no longer use telekinesis to grab paper from far away.
/:cl:
