### PR TITLE
Painkilling/Electrogenetic Value and EGN triggers on defibrillating

### DIFF
--- a/code/__DEFINES/pain.dm
+++ b/code/__DEFINES/pain.dm
@@ -7,7 +7,7 @@
 #define MOVE_REDUCTION_LIMB_SPLINTED 0.5
 
 // Traumatic shock reduction for different reagents
-#define PAIN_REDUCTION_MULTIPLIER 20
+#define PAIN_REDUCTION_MULTIPLIER 40
 #define PAIN_REDUCTION_AURA 20
 // The values below are thresholds used for surgery
 #define PAIN_REDUCTION_LIGHT 20  //inaprovaline

--- a/code/__DEFINES/pain.dm
+++ b/code/__DEFINES/pain.dm
@@ -7,6 +7,7 @@
 #define MOVE_REDUCTION_LIMB_SPLINTED 0.5
 
 // Traumatic shock reduction for different reagents
+#define PAIN_REDUCTION_MULTIPLIER_SMALL 20
 #define PAIN_REDUCTION_MULTIPLIER 40
 #define PAIN_REDUCTION_AURA 20
 // The values below are thresholds used for surgery

--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -580,11 +580,11 @@
 		return
 	var/mob/living/carbon/human/dead = M
 	var/revivable = dead.check_tod() && dead.is_revivable()
-	for(var/datum/reagent/R in M.reagents.reagent_list)
-		var/datum/chem_property/property = R.get_property(PROPERTY_ELECTROGENETIC) //Adrenaline helps greatly at restarting the heart
+	for(var/datum/reagent/electrogenetic_reagent in M.reagents.reagent_list)
+		var/datum/chem_property/property = electrogenetic_reagent.get_property(PROPERTY_ELECTROGENETIC) //Adrenaline helps greatly at restarting the heart
 		if(property)
 			property.trigger(M)
-			M.reagents.remove_reagent(R.id, 1)
+			M.reagents.remove_reagent(electrogenetic_reagent.id, 1)
 			break
 	if(revivable && (dead.health > HEALTH_THRESHOLD_DEAD))
 		addtimer(CALLBACK(dead, TYPE_PROC_REF(/mob/living/carbon/human, handle_revive)), 5 SECONDS)

--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -539,9 +539,9 @@
 /datum/chem_property/positive/electrogenetic/trigger(A)
 	if(isliving(A))
 		var/mob/living/M = A
-		M.apply_damage(-POTENCY_MULTIPLIER_VHIGH * level, BRUTE)
-		M.apply_damage(-POTENCY_MULTIPLIER_VHIGH * level, BURN)
-		M.apply_damage(-POTENCY_MULTIPLIER_VHIGH * level, TOX)
+		M.apply_damage(-POTENCY_MULTIPLIER_EXTREME * level, BRUTE)
+		M.apply_damage(-POTENCY_MULTIPLIER_EXTREME * level, BURN)
+		M.apply_damage(-POTENCY_MULTIPLIER_EXTREME * level, TOX)
 		M.updatehealth()
 
 /datum/chem_property/positive/defibrillating
@@ -580,6 +580,12 @@
 		return
 	var/mob/living/carbon/human/dead = M
 	var/revivable = dead.check_tod() && dead.is_revivable()
+	for(var/datum/reagent/R in M.reagents.reagent_list)
+		var/datum/chem_property/property = R.get_property(PROPERTY_ELECTROGENETIC) //Adrenaline helps greatly at restarting the heart
+		if(property)
+			property.trigger(M)
+			M.reagents.remove_reagent(R.id, 1)
+			break
 	if(revivable && (dead.health > HEALTH_THRESHOLD_DEAD))
 		addtimer(CALLBACK(dead, TYPE_PROC_REF(/mob/living/carbon/human, handle_revive)), 5 SECONDS)
 		to_chat(dead, SPAN_NOTICE("You feel your heart struggling as you suddenly feel a spark, making it desperately try to continue pumping."))

--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -927,7 +927,7 @@
 	if(!..())
 		return
 
-	M.pain.apply_pain_reduction(PAIN_REDUCTION_MULTIPLIER * potency)
+	M.pain.apply_pain_reduction(PAIN_REDUCTION_MULTIPLIER_SMALL * potency)
 
 	if(M.losebreath >= 10)
 		M.losebreath = max(10, M.losebreath - 2.5 * potency * delta_time)

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -35,7 +35,7 @@
 	overdose = HIGH_REAGENTS_OVERDOSE
 	overdose_critical = HIGH_REAGENTS_OVERDOSE_CRITICAL
 	chemclass = CHEM_CLASS_UNCOMMON
-	properties = list(PROPERTY_PAINKILLING = 2)
+	properties = list(PROPERTY_PAINKILLING = 1)
 
 /datum/reagent/medical/tramadol
 	name = "Tramadol"
@@ -47,7 +47,7 @@
 	overdose = REAGENTS_OVERDOSE
 	overdose_critical = REAGENTS_OVERDOSE_CRITICAL
 	chemclass = CHEM_CLASS_COMMON
-	properties = list(PROPERTY_PAINKILLING = 5)
+	properties = list(PROPERTY_PAINKILLING = 2.5)
 
 //Changed to Common so turing will dispense. definition of common chem class "Chemicals which recipe is commonly known and made". Oxycodone is such being avaliable from med dispenser
 /datum/reagent/medical/oxycodone
@@ -60,7 +60,7 @@
 	overdose = MED_REAGENTS_OVERDOSE
 	overdose_critical = MED_REAGENTS_OVERDOSE_CRITICAL
 	chemclass = CHEM_CLASS_COMMON
-	properties = list(PROPERTY_PAINKILLING = 8)
+	properties = list(PROPERTY_PAINKILLING = 4)
 
 /datum/reagent/medical/sterilizine
 	name = "Sterilizine"
@@ -283,7 +283,7 @@
 	overdose_critical = LOWM_REAGENTS_OVERDOSE_CRITICAL
 	custom_metabolism = AMOUNT_PER_TIME(1, 5 SECONDS)
 	chemclass = CHEM_CLASS_COMMON
-	properties = list(PROPERTY_PAINKILLING = 1.5, PROPERTY_ELECTROGENETIC = 4, PROPERTY_INTRAVENOUS = 1)
+	properties = list(PROPERTY_PAINKILLING = 0.75, PROPERTY_ELECTROGENETIC = 2, PROPERTY_INTRAVENOUS = 1)
 	flags = REAGENT_TYPE_MEDICAL | REAGENT_SCANNABLE
 
 /datum/reagent/medical/ultrazine

--- a/code/modules/reagents/chemistry_reagents/other.dm
+++ b/code/modules/reagents/chemistry_reagents/other.dm
@@ -168,7 +168,7 @@
 	overdose = MED_REAGENTS_OVERDOSE
 	overdose_critical = MED_REAGENTS_OVERDOSE_CRITICAL
 	chemclass = CHEM_CLASS_UNCOMMON
-	properties = list(PROPERTY_PAINKILLING = 6)
+	properties = list(PROPERTY_PAINKILLING = 3)
 
 /datum/reagent/serotrotium
 	name = "Serotrotium"

--- a/code/modules/reagents/chemistry_reagents/toxin.dm
+++ b/code/modules/reagents/chemistry_reagents/toxin.dm
@@ -185,7 +185,7 @@
 	overdose = REAGENTS_OVERDOSE
 	overdose_critical = REAGENTS_OVERDOSE_CRITICAL
 	chemclass = CHEM_CLASS_COMMON
-	properties = list(PROPERTY_SEDATIVE = 2, PROPERTY_PAINKILLING = 10)
+	properties = list(PROPERTY_SEDATIVE = 2, PROPERTY_PAINKILLING = 5)
 	flags = REAGENT_SCANNABLE
 
 /datum/reagent/toxin/chloralhydrate


### PR DESCRIPTION
# About the pull request
Painkilling and Electrogenetic (Epi) are now twice as effective, halved their property level in chems (resulting in **no difference** in base painkillers)
Cardiostabilziing isn't changed by this to prevent inap from being better from tram
Electrogenetic now works when combined with the defibrillating property, draining and triggering a heal.

Each level of painkilling now gives you 20 pain reduction, with level 10 PNK letting you run around with no painslow at -149 health.

Each level of electrogenetic now heals 10 brute/burn/tox per trigger. See clip below for egn10 testing


<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->


# Explain why it's good for the game
Both EGN and PNK are, despite buffs, still really unused, especially painkilling, which was completely useless as oxycodone existed and gave you level 8 painkilling roundstart. By halving the levels and doubling the power it means that researchers making have much impact per level if they want to use this over NST/MST godstim slop.
# Testing Photographs and Procedure
EGN10 testing on an maxburn corpse that's still burning

https://github.com/user-attachments/assets/3a2f3be8-621a-4fb0-89d2-3306672e4567



# Changelog
:cl:
add: Electrogenetic property now triggers with defibrillating.
balance: Painkilling and Electrogenetic are twice as powerful per level, halved the property levels of Painkilling and Electrogenetic in chemicals, meaning that they act the same.
/:cl:
