### PR TITLE
Fixex extuingishers being able to take harmful chemicals

### DIFF
--- a/code/game/objects/items/tools/extinguisher.dm
+++ b/code/game/objects/items/tools/extinguisher.dm
@@ -83,8 +83,11 @@
 
 /obj/item/tool/extinguisher/afterattack(atom/target, mob/user , flag)
 	if(istype(target, /obj/structure/reagent_dispensers/watertank) && get_dist(user,target) <= 1)
-		var/obj/o = target
-		o.reagents.trans_to(src, 50)
+		var/obj/object = target
+		if(object.reagents.contains_harmful_substances())
+			to_chat(user, SPAN_WARNING("You cannot re-fill the extinguisher with the contents of this."))
+			return
+		object.reagents.trans_to(src, 50)
 		to_chat(user, SPAN_NOTICE(" \The [src] is now refilled"))
 		playsound(user, 'sound/effects/refill.ogg', 25, 1, 3)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

You can now only fill extuingishers with non harmful chemicals

# Explain why it's good for the game

bugfix


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Extuingishers can no longer be filled by harmful chemicals
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
