### PR TITLE
Fixes synthetic limbs being named wrong

### DIFF
--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -179,10 +179,10 @@
 	title = "synthetic right arm"
 	path = /obj/item/robot_parts/arm/r_arm
 
-/datum/bioprinter_recipe/l_leg
+/datum/bioprinter_recipe/r_leg
 	title = "synthetic right leg"
 	path = /obj/item/robot_parts/leg/l_leg
 
-/datum/bioprinter_recipe/r_leg
+/datum/bioprinter_recipe/l_leg
 	title = "synthetic left leg"
 	path = /obj/item/robot_parts/leg/r_leg

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -181,8 +181,8 @@
 
 /datum/bioprinter_recipe/r_leg
 	title = "synthetic right leg"
-	path = /obj/item/robot_parts/leg/l_leg
+	path = /obj/item/robot_parts/leg/r_leg
 
 /datum/bioprinter_recipe/l_leg
 	title = "synthetic left leg"
-	path = /obj/item/robot_parts/leg/r_leg
+	path = /obj/item/robot_parts/leg/l_leg

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -180,9 +180,9 @@
 	path = /obj/item/robot_parts/arm/r_arm
 
 /datum/bioprinter_recipe/l_leg
-	title = "synthetic left leg"
+	title = "synthetic right leg"
 	path = /obj/item/robot_parts/leg/l_leg
 
 /datum/bioprinter_recipe/r_leg
-	title = "synthetic right leg"
+	title = "synthetic left leg"
 	path = /obj/item/robot_parts/leg/r_leg

--- a/code/game/objects/items/reagent_containers/robot_parts.dm
+++ b/code/game/objects/items/reagent_containers/robot_parts.dm
@@ -24,17 +24,17 @@
 	icon_state = "r_arm"
 	part = list("r_arm","r_hand")
 
-/obj/item/robot_parts/leg/l_leg
-	name = "robot left leg"
-	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
-	icon_state = "l_leg"
-	part = list("l_leg","l_foot")
-
 /obj/item/robot_parts/leg/r_leg
 	name = "robot right leg"
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
-	icon_state = "r_leg"
+	icon_state = "l_leg" // put yourself in the eyes of the character, its your left leg.
 	part = list("r_leg","r_foot")
+
+/obj/item/robot_parts/leg/l_leg
+	name = "robot left leg"
+	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
+	icon_state = "r_leg"
+	part = list("l_leg","l_foot")
 
 /obj/item/robot_parts/hand/l_hand
 	name = "robot left hand"


### PR DESCRIPTION

# About the pull request

fixes : #6923

# Explain why it's good for the game

bugfix

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Synthetic limbs are now named properly
/:cl:
