### PR TITLE
Fixes praetorian acid ball using plasma if you cancelled the do_after, again

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_powers.dm
@@ -741,9 +741,6 @@
 
 	if (!action_cooldown_check())
 		return
-	if (!check_and_use_plasma_owner())
-		return
-
 	var/turf/current_turf = get_turf(acidball_user)
 
 	if (!current_turf)
@@ -753,6 +750,8 @@
 		to_chat(acidball_user, SPAN_XENODANGER("We cancel our acid ball."))
 		return
 
+	if (!check_and_use_plasma_owner())
+		return
 
 	apply_cooldown()
 


### PR DESCRIPTION
# About the pull request

Fixes praetorian acid ball using plasma if you cancelled the do_after unlike #5486 whoever made that sucked
# Explain why it's good for the game

bugfix


# Testing Photographs and Procedure
<details>

![image](https://github.com/user-attachments/assets/e54c19a8-8c8a-4aba-aebc-c4e5530d7e4d)

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Praetorian's acid ball no longer uses plasma if you cancel / do not use it.
/:cl:
