### PR TITLE
Fixes smartpack light not turning off on death and removes some one letter vars

### DIFF
--- a/code/game/objects/items/storage/smartpack.dm
+++ b/code/game/objects/items/storage/smartpack.dm
@@ -30,20 +30,20 @@
 	if(user)
 		user.update_inv_back()
 
-	for(var/datum/action/A in actions)
-		A.update_button_icon()
+	for(var/datum/action/backpack_actions in actions)
+		backpack_actions.update_button_icon()
 
 	if(issynth(user))
-		var/mob/living/M = user
-		for(var/datum/action/A in M.actions)
-			A.update_button_icon()
+		var/mob/living/living_mob = user
+		for(var/datum/action/living_mob_actions in living_mob.actions)
+			living_mob_actions.update_button_icon()
 
 	if(content_watchers) //If someone's looking inside it, don't close the flap.
 		return
 
 	var/sum_storage_cost = 0
-	for(var/obj/item/I in contents)
-		sum_storage_cost += I.get_storage_cost()
+	for(var/obj/item/items_in_bag in contents)
+		sum_storage_cost += items_in_bag.get_storage_cost()
 	if(!sum_storage_cost)
 		return
 	else if(sum_storage_cost <= max_storage_space * 0.5)
@@ -90,6 +90,12 @@
 
 	playsound(src, 'sound/handling/light_on_1.ogg', 50, TRUE)
 	update_icon(user)
+
+/obj/item/storage/backpack/marine/smartpack/dropped(mob/living/synthetic)
+
+	if(light_on && loc != synthetic)
+		turn_light(synthetic, toggle_on = FALSE)
+	..()
 
 
 /obj/item/storage/backpack/marine/smartpack/green

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -273,6 +273,9 @@
 		if(istype(wear_suit, /obj/item/clothing/suit/storage/marine))
 			if(wear_suit.turn_light(src, toggle_on = FALSE))
 				light_off++
+		if(istype(back, /obj/item/storage/backpack/marine/smartpack))
+			if(back.turn_light(src, toggle_on = FALSE))
+				light_off++
 		for(var/obj/item/clothing/head/helmet/marine/H in contents)
 			for(var/obj/item/attachable/flashlight/FL in H.pockets)
 				if(FL.activate_attachment(H, src, TRUE))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

fixes #8326

# Explain why it's good for the game

bug fix


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix:Synthetic backpack light now properly turns off on death.
code: Removes some one letter vars from smartpack code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
