### PR TITLE
Fixes heal nodes infinietly adding the aura/heal to resting dead xenomorphs

### DIFF
--- a/code/modules/cm_aliens/structures/special/recovery_node.dm
+++ b/code/modules/cm_aliens/structures/special/recovery_node.dm
@@ -22,7 +22,7 @@
 		if(xeno_in_range.health >= xeno_in_range.maxHealth || !xeno_in_range.resting || xeno_in_range.hivenumber != linked_hive.hivenumber)
 			continue
 		if(xeno_in_range.stat == DEAD)
-			return
+			continue
 		heal_candidates += xeno_in_range
 	last_healed = world.time
 	if(!length(heal_candidates))

--- a/code/modules/cm_aliens/structures/special/recovery_node.dm
+++ b/code/modules/cm_aliens/structures/special/recovery_node.dm
@@ -18,10 +18,12 @@
 	if(last_healed && world.time < last_healed + heal_cooldown)
 		return
 	var/list/heal_candidates = list()
-	for(var/mob/living/carbon/xenomorph/X in orange(src, 1))
-		if(X.health >= X.maxHealth || !X.resting || X.hivenumber != linked_hive.hivenumber)
+	for(var/mob/living/carbon/xenomorph/xeno_in_range in orange(src, 1))
+		if(xeno_in_range.health >= xeno_in_range.maxHealth || !xeno_in_range.resting || xeno_in_range.hivenumber != linked_hive.hivenumber)
 			continue
-		heal_candidates += X
+		if(xeno_in_range.stat == DEAD)
+			return
+		heal_candidates += xeno_in_range
 	last_healed = world.time
 	if(!length(heal_candidates))
 		return


### PR DESCRIPTION

# About the pull request

fixes the healing / aura effect from recovery nodes applying to dead xenos / xenos who died while resting

# Explain why it's good for the game

bugfix


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: fixes the healing / aura effect from recovery nodes applying to dead xenos / xenos who died while resting
/:cl:
