### PR TITLE
Make Resin Doors Ignore DEAD mobs.

### DIFF
--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -452,7 +452,7 @@
 				continue // Ignore dead mobs for blocking checks
 
 			if(!HAS_TRAIT(living_mob, TRAIT_MERGED_WITH_WEEDS))
-				return TRUE // Block closing if a valid living mob exists
+				return TRUE
 
 	// Adjust door layer dynamically based on dead mob presence
 	if(has_dead)

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -450,16 +450,13 @@
 			if(living_mob.stat == DEAD)
 				has_dead = TRUE // Found a dead mob
 				continue // Ignore dead mobs for blocking checks
-
 			if(!HAS_TRAIT(living_mob, TRAIT_MERGED_WITH_WEEDS))
 				return TRUE
 
-	// Adjust door layer dynamically based on dead mob presence
 	if(has_dead)
 		layer = MOB_LAYER + 0.1 // Ensure door appears above dead mobs
 	else
 		layer = OBJ_LAYER // Reset to default when no dead mobs are present
-
 	return FALSE
 
 /obj/structure/mineral_door/resin/close()

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -444,7 +444,6 @@
 
 /obj/structure/mineral_door/resin/proc/close_blocked()
 	var/has_dead = FALSE // Track if there's a dead mob under the door
-
 	for(var/turf/turf in locs)
 		for(var/mob/living/living_mob in turf)
 			if(living_mob.stat == DEAD)

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -443,10 +443,23 @@
 	addtimer(CALLBACK(src, PROC_REF(close)), close_delay, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 
 /obj/structure/mineral_door/resin/proc/close_blocked()
+	var/has_dead = FALSE // Track if there's a dead mob under the door
+
 	for(var/turf/turf in locs)
 		for(var/mob/living/living_mob in turf)
+			if(living_mob.stat == DEAD)
+				has_dead = TRUE // Found a dead mob
+				continue // Ignore dead mobs for blocking checks
+
 			if(!HAS_TRAIT(living_mob, TRAIT_MERGED_WITH_WEEDS))
-				return TRUE
+				return TRUE // Block closing if a valid living mob exists
+
+	// Adjust door layer dynamically based on dead mob presence
+	if(has_dead)
+		layer = MOB_LAYER + 0.1 // Ensure door appears above dead mobs
+	else
+		layer = OBJ_LAYER // Reset to default when no dead mobs are present
+
 	return FALSE
 
 /obj/structure/mineral_door/resin/close()

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -443,19 +443,12 @@
 	addtimer(CALLBACK(src, PROC_REF(close)), close_delay, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 
 /obj/structure/mineral_door/resin/proc/close_blocked()
-	var/has_dead = FALSE // Track if there's a dead mob under the door
 	for(var/turf/turf in locs)
 		for(var/mob/living/living_mob in turf)
 			if(living_mob.stat == DEAD)
-				has_dead = TRUE // Found a dead mob
-				continue // Ignore dead mobs for blocking checks
+				continue
 			if(!HAS_TRAIT(living_mob, TRAIT_MERGED_WITH_WEEDS))
 				return TRUE
-
-	if(has_dead)
-		layer = MOB_LAYER + 0.1 // Ensure door appears above dead mobs
-	else
-		layer = OBJ_LAYER // Reset to default when no dead mobs are present
 	return FALSE
 
 /obj/structure/mineral_door/resin/close()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -9,6 +9,7 @@
 	if(undefibbable && stat == DEAD || spawned_corpse)
 		GLOB.data_core.manifest_modify(real_name, WEAKREF(src), null, null, "*Deceased*")
 		SShuman.processable_human_list -= src
+		layer = OBJ_LAYER
 		if(hardcore)
 			qdel(src) //We just delete the corpse on WO to keep things simple and lag-free
 		return

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -9,7 +9,6 @@
 	if(undefibbable && stat == DEAD || spawned_corpse)
 		GLOB.data_core.manifest_modify(real_name, WEAKREF(src), null, null, "*Deceased*")
 		SShuman.processable_human_list -= src
-		layer = OBJ_LAYER
 		if(hardcore)
 			qdel(src) //We just delete the corpse on WO to keep things simple and lag-free
 		return


### PR DESCRIPTION
# About the pull request

Make resin doors ignore living mobs with DEAD state.

# Explain why it's good for the game

Lets be honest, that is one of annoying thing that you can experience as xeno (especially as builder) is, when you accidently kill marine in door or they die inside door, as downsite you now need to deal with non-stop open door, unless they get "consumed by weeds" with can take a looong time.

# Testing Video Below
<details>
<summary>Click to see video HERE:</summary>

https://github.com/user-attachments/assets/27c43cff-bbea-4839-9674-3d06621c0950

</details>


# Changelog
:cl: Venuska1117
qol: Resin Doors now Ignore living mobs with DEAD state.
/:cl:
