### PR TITLE
fixes synth NVGs bugging out and breaking

### DIFF
--- a/code/modules/mob/living/carbon/human/species/synthetic.dm
+++ b/code/modules/mob/living/carbon/human/species/synthetic.dm
@@ -10,6 +10,7 @@
 	mob_inherent_traits = list(TRAIT_SUPER_STRONG, TRAIT_IRON_TEETH)
 	rarity_value = 2
 	insulated = TRUE
+	darksight = 20
 
 	bloodsplatter_type = /obj/effect/bloodsplatter/synthsplatter
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

 fixes #7702 

# Explain why it's good for the game

synths having their NVGs bug out and blind them is unintended

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

https://cdn.discordapp.com/attachments/490668342357786645/1335745530692894852/Timeline_24.mov?ex=67a14977&is=679ff7f7&hm=60d04e89b300a0fe6019e4dc288d646c5d7450061a3f9f8996885c73437387ca&

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix:Synth NVGs no longer bug out and blind them
/:cl:

