### PR TITLE
Xenothumbs, but for cards [Bonus: Forsaken Hive Can Play Cards]

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -185,6 +185,8 @@
 #define TRAIT_HIVEMIND_INTERFERENCE "t_interference"
 /// If the hive or xeno can use objects.
 #define TRAIT_OPPOSABLE_THUMBS "t_thumbs"
+/// If the hive or xeno can use playing cards.
+#define TRAIT_CARDPLAYING_THUMBS "t_card_thumbs"
 /// If the Hive delays round end (this is overridden for some hives). Does not occur naturally. Must be applied in events.
 #define TRAIT_NO_HIVE_DELAY "t_no_hive_delay"
 /// If the Hive uses it's colors on the mobs. Does not occur naturally, excepting the Mutated hive.
@@ -374,6 +376,7 @@ GLOBAL_LIST_INIT(traits_by_type, list(
 		"TRAIT_ABILITY_NO_PLASMA_TRANSFER" = TRAIT_ABILITY_NO_PLASMA_TRANSFER,
 		"TRAIT_ABILITY_OVIPOSITOR" = TRAIT_ABILITY_OVIPOSITOR,
 		"TRAIT_OPPOSABLE_THUMBS" = TRAIT_OPPOSABLE_THUMBS,
+		"TRAIT_CARDPLAYING_THUMBS" = TRAIT_CARDPLAYING_THUMBS,
 		"TRAIT_INTERFERENCE" = TRAIT_HIVEMIND_INTERFERENCE,
 	),
 	/datum/hive_status = list(

--- a/code/game/objects/items/toys/cards.dm
+++ b/code/game/objects/items/toys/cards.dm
@@ -49,6 +49,12 @@
 		for(var/number in list("ace", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "jack", "queen", "king"))
 			cards += new /datum/playing_card("[number] of [suit]", "[suit]_[number]", "back_[base_icon]", card_id++)
 
+/obj/item/toy/deck/attack_alien(mob/living/carbon/xenomorph/xeno)
+	if(HAS_TRAIT(xeno, TRAIT_CARDPLAYING_THUMBS))
+		attack_hand(xeno)
+		return XENO_NONCOMBAT_ACTION
+	return
+
 /obj/item/toy/deck/uno
 	name = "deck of UNO cards"
 	desc = "A simple deck of the Weyland-Yutani classic UNO playing cards."
@@ -108,7 +114,7 @@
 	if(usr.stat || !Adjacent(usr))
 		return
 
-	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
+	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_CARDPLAYING_THUMBS))
 		return
 
 	var/mob/living/carbon/human/user = usr
@@ -137,7 +143,7 @@
 	if(user.stat || !Adjacent(user))
 		return
 
-	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_OPPOSABLE_THUMBS))
+	if(!ishuman(user) && !HAS_TRAIT(user, TRAIT_CARDPLAYING_THUMBS))
 		return
 
 	var/cards_length = length(cards)
@@ -183,7 +189,7 @@
 	if(usr.stat || !Adjacent(usr))
 		return
 
-	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
+	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_CARDPLAYING_THUMBS))
 		return
 
 	var/mob/living/carbon/user = usr
@@ -215,7 +221,7 @@
 	if(usr.stat || !Adjacent(usr))
 		return
 
-	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
+	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_CARDPLAYING_THUMBS))
 		return
 
 	if(!length(cards))
@@ -265,7 +271,7 @@
 	if(!usr || !over)
 		return
 
-	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
+	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_CARDPLAYING_THUMBS))
 		return
 
 	if(get_dist(usr, over) > 3)
@@ -299,6 +305,12 @@
 /obj/item/toy/handcard/Destroy(force)
 	. = ..()
 	QDEL_NULL_LIST(cards)
+
+/obj/item/toy/handcard/attack_alien(mob/living/carbon/xenomorph/xeno)
+	if(HAS_TRAIT(xeno, TRAIT_CARDPLAYING_THUMBS))
+		attack_hand(xeno)
+		return XENO_NONCOMBAT_ACTION
+	return
 
 /obj/item/toy/handcard/aceofspades
 	icon_state = "spades_ace"
@@ -334,7 +346,7 @@
 	if(usr.stat)
 		return
 
-	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
+	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_CARDPLAYING_THUMBS))
 		return
 
 	pile_state = !pile_state
@@ -350,7 +362,7 @@
 	if(usr.stat)
 		return
 
-	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
+	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_CARDPLAYING_THUMBS))
 		return
 
 	//fuck any qsorts and merge sorts. This needs to be brutally easy
@@ -441,7 +453,7 @@
 		return
 	if(usr.stat)
 		return
-	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
+	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_CARDPLAYING_THUMBS))
 		return
 
 	if(isstorage(loc))

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -819,6 +819,7 @@
 		<A href='byond://?src=\ref[src];[HrefToken()];events=pmcguns'>Toggle PMC gun restrictions</A><BR>
 		<A href='byond://?src=\ref[src];[HrefToken()];events=monkify'>Turn everyone into monkies</A><BR>
 		<A href='byond://?src=\ref[src];[HrefToken()];events=xenothumbs'>Give or take opposable thumbs and gun permits from xenos</A><BR>
+		<A href='byond://?src=\ref[src];[HrefToken()];events=xenocards'>Give or take card playing abilities from xenos</A><BR>
 		<BR>
 		"}
 

--- a/code/modules/admin/topic/topic_events.dm
+++ b/code/modules/admin/topic/topic_events.dm
@@ -151,6 +151,60 @@
 					[length(permit_hives) > 1 ? " in all hives, and from any new xenos." : "[length(permit_hives) == 1 ? " in [permit_hives[1]], and from any new xenos in that hive." : "."]"]")
 
 
+		if("xenocards")
+			var/grant = alert(usr, "Do you wish to grant or revoke Xenomorph card playing abilities?", "Give or Take", "Grant", "Revoke", "Cancel")
+			if(grant == "Cancel")
+				return
+
+			var/list/mob/living/carbon/xenomorph/permit_recipients = list()
+			var/list/datum/hive_status/permit_hives = list()
+			switch(alert(usr, "Do you wish to do this for one Xeno or an entire hive?", "Recipients", "Xeno", "Hive", "All Xenos"))
+				if("Xeno")
+					permit_recipients += tgui_input_list(usr, "Select recipient Xenomorph:", "Ace Xenomorph", GLOB.living_xeno_list)
+					if(isnull(permit_recipients[1])) //Cancel button.
+						return
+				if("Hive")
+					permit_hives += GLOB.hive_datum[tgui_input_list(usr, "Select recipient hive:", "Ace Hive", GLOB.hive_datum)]
+					if(isnull(permit_hives[1])) //Cancel button.
+						return
+					permit_recipients = permit_hives[1].totalXenos.Copy()
+				if("All Xenos")
+					permit_recipients = GLOB.living_xeno_list.Copy()
+					for(var/H in GLOB.hive_datum)
+						permit_hives += GLOB.hive_datum[H]
+
+			var/list/handled_xenos = list()
+
+			for(var/mob/living/carbon/xenomorph/xeno as anything in permit_recipients)
+				if(QDELETED(xeno) || xeno.stat == DEAD) //Xenos might die before the admin picks them.
+					to_chat(usr, SPAN_HIGHDANGER("[xeno] died before she could get a royal flush!"))
+					continue
+				if(HAS_TRAIT(xeno, TRAIT_CARDPLAYING_THUMBS))
+					if(grant == "Revoke")
+						REMOVE_TRAIT(xeno, TRAIT_CARDPLAYING_THUMBS, TRAIT_SOURCE_HIVE)
+						to_chat(xeno, SPAN_XENOANNOUNCE("You forget how cards work. You feel a terrible sense of loss."))
+						handled_xenos += xeno
+				else if(grant == "Grant")
+					ADD_TRAIT(xeno, TRAIT_CARDPLAYING_THUMBS, TRAIT_SOURCE_HIVE)
+					to_chat(xeno, SPAN_XENOANNOUNCE("You suddenly comprehend the magic of playing cards along with a little kinesthetic intelligence. You could do... <b><i>very little</b></i> with this knowledge."))
+					handled_xenos += xeno
+
+			for(var/datum/hive_status/permit_hive as anything in permit_hives)
+				//Give or remove the trait from newly-born xenos in this hive.
+				if(grant == "Grant")
+					LAZYADD(permit_hive.hive_inherant_traits, TRAIT_CARDPLAYING_THUMBS)
+				else
+					LAZYREMOVE(permit_hive.hive_inherant_traits, TRAIT_CARDPLAYING_THUMBS)
+
+			if(!length(handled_xenos) && !length(permit_hives))
+				return
+
+			if(grant == "Grant")
+				message_admins("[usr] granted card playing rights to [length(handled_xenos) > 1 ? "[length(handled_xenos)] xenos" : "[length(handled_xenos) == 1 ? "[handled_xenos[1]]" : "no xenos"]"]\
+					[length(permit_hives) > 1 ? " in all hives, and to any new xenos. Quite possibly we will all enjoy this." : "[length(permit_hives) == 1 ? " in [permit_hives[1]], and to any new xenos in that hive." : "."]"]")
+			else
+				message_admins("[usr] revoked card playing rights from [length(handled_xenos) > 1 ? "[length(handled_xenos)] xenos" : "[length(handled_xenos) == 1 ? "[handled_xenos[1]]" : "no xenos"]"]\
+					[length(permit_hives) > 1 ? " in all hives, and from any new xenos." : "[length(permit_hives) == 1 ? " in [permit_hives[1]], and from any new xenos in that hive." : "."]"]")
 
 /datum/admins/proc/create_humans_list(href_list)
 	if(SSticker?.current_state < GAME_STATE_PLAYING)

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -1108,6 +1108,8 @@
 
 	need_round_end_check = TRUE
 
+	hive_inherant_traits = list(TRAIT_CARDPLAYING_THUMBS)
+
 /datum/hive_status/forsaken/can_delay_round_end(mob/living/carbon/xenomorph/xeno)
 	return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Adds TRAIT_CARDPLAYING_THUMBS, which allows xenos to use and manipulate cards. Admins can use the event panel to grant to xenos similarly to their 2nd amendment rights.

Forsaken hive starts with the trait, so that they can play cards (at least until a maint says otherwise). You can now finally play UNO with man-eating monsters! yipee!


<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Xenos playing cards with marines was very funny. 

![image](https://github.com/user-attachments/assets/deca2acc-5bd7-492d-bf59-bd3d9f34562a)


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

works!

![image](https://github.com/user-attachments/assets/b2db73d0-0103-470a-a808-41dd9da455fd)



# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: TRAIT_CARD_PLAYING_THUMBS to the event panel, allowing xenos to play cards.
add: Forsaken Xenos will know how to play cards intrinsically.
admin: ability grant or revoke card playing thumbs to xenos through the event panel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
