### PR TITLE
Fixes boiler speed being stuck if you buy a strain while zoomed in

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/xeno_strain.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/xeno_strain.dm
@@ -141,6 +141,10 @@
 		to_chat(src, SPAN_WARNING("You must first pick a strain before resetting it."))
 		return FALSE
 
+	if(is_zoomed)
+		to_chat(src, SPAN_WARNING("We can't do that while looking far away."))
+		return FALSE
+
 	if(is_ventcrawling)
 		to_chat(src, SPAN_WARNING("This place is too constraining to take a strain."))
 		return FALSE


### PR DESCRIPTION
# About the pull request

fixes: #8339

cant buy strains while zooming anymore


# Explain why it's good for the game
bugfix


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixes boiler speed being stuck if you buy a strain while zoomed in
/:cl:
