### PR TITLE
fixes ASO jacket vendor icon showing up as a bloodbag

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/senior_officers.dm
+++ b/code/game/machinery/vending/vendor_types/crew/senior_officers.dm
@@ -12,6 +12,7 @@
 		combined += GLOB.cm_vending_clothing_req_officer
 		combined += GLOB.cm_vending_clothing_cmo
 		combined += GLOB.cm_vending_clothing_military_police_chief
+		combined += GLOB.cm_vending_clothing_auxiliary_officer
 		return combined
 	if(user.job == JOB_XO)
 		return GLOB.cm_vending_clothing_xo


### PR DESCRIPTION
# About the pull request
Fixes #7198 

# Explain why it's good for the game
We are vending the ASO Jacket, not a bloodbag

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/60ff79e0-7357-42d9-86c4-2b5b6034b04a)
</details>


# Changelog
:cl: Mikrel0712
fix: ASO Jacket icon in the vendor now shows up as the actual jacket instead of a bloodbag
/:cl:
