### PR TITLE
Fixes a few cases of round() being floor()

### DIFF
--- a/code/datums/tutorial/marine/reqs_line.dm
+++ b/code/datums/tutorial/marine/reqs_line.dm
@@ -228,7 +228,7 @@
 	for(var/agent_i in 1 to agents_to_spawn)
 		var/items_requested = 1 + survival_wave * survival_difficulty * 0.5
 		items_requested *= (1 + survival_request_random_factor * rand())
-		spawn_survival_agent(round(items_requested))
+		spawn_survival_agent(round(items_requested, 1))
 
 /// Called to generate a single agent and request
 /datum/tutorial/marine/reqs_line/proc/spawn_survival_agent(items_to_request)

--- a/code/game/machinery/computer/hybrisa_slotmachine.dm
+++ b/code/game/machinery/computer/hybrisa_slotmachine.dm
@@ -78,7 +78,7 @@
 	if(!.)
 		return .
 
-	prize_money += round(seconds_per_tick / 2) //SPESSH MAJICKS
+	prize_money += round(seconds_per_tick / 2, 1) //SPESSH MAJICKS
 
 /obj/structure/machinery/computer/hybrisa/misc/slotmachine/update_icon()
 	..()

--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -56,7 +56,7 @@
 		list("M74 AGM-Smoke Airburst Grenade", floor(scale * 4), /obj/item/explosive/grenade/smokebomb/airburst, VENDOR_ITEM_REGULAR),
 		list("M74 AGM-Star Shell", floor(scale * 2), /obj/item/explosive/grenade/high_explosive/airburst/starshell, VENDOR_ITEM_REGULAR),
 		list("M74 AGM-Hornet Shell", floor(scale * 4), /obj/item/explosive/grenade/high_explosive/airburst/hornet_shell, VENDOR_ITEM_REGULAR),
-		list("G2 Electroshock Grenade", round(scale * 5), /obj/item/explosive/grenade/sebb, VENDOR_ITEM_REGULAR),
+		list("G2 Electroshock Grenade", floor(scale * 5), /obj/item/explosive/grenade/sebb, VENDOR_ITEM_REGULAR),
 		list("M40 HIRR Baton Slug", floor(scale * 8), /obj/item/explosive/grenade/slug/baton, VENDOR_ITEM_REGULAR),
 		list("M40 MFHS Metal Foam Grenade", floor(scale * 6), /obj/item/explosive/grenade/metal_foam, VENDOR_ITEM_REGULAR),
 		list("Plastic Explosives", floor(scale * 3), /obj/item/explosive/plastic, VENDOR_ITEM_REGULAR),

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1709,7 +1709,7 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 			var/scatter_debuff = 1 + (SETTLE_SCATTER_MULTIPLIER - 1) * pct_settled
 			projectile_to_fire.scatter *= scatter_debuff
 
-	projectile_to_fire.damage = round(projectile_to_fire.damage * damage_mult) // Apply gun damage multiplier to projectile damage
+	projectile_to_fire.damage = round(projectile_to_fire.damage * damage_mult, 0.1) // Apply gun damage multiplier to projectile damage
 
 	// Apply effective range and falloffs/buildups
 	projectile_to_fire.damage_falloff = damage_falloff_mult * projectile_to_fire.ammo.damage_falloff


### PR DESCRIPTION

# About the pull request

So, `round()`, if only provided 1 arg, is actually `floor()`. This behavior is kept in solely because it's legacy behavior that code may depend on. As such, I'm moving our 4 cases of it to not use this behavior.

A thank you to Kapu for providing the regex `\bround\s*\((\s*[^,()]*\s*\))` to help find these cases.

# Explain why it's good for the game

Clarifies a few edge cases to be less ambiguous and depend less on deprecated legacy behavior.
