### PR TITLE
Makes the vendor inflation announcements silent

### DIFF
--- a/code/defines/procs/announcement.dm
+++ b/code/defines/procs/announcement.dm
@@ -155,7 +155,7 @@
 		if(istype(target, /mob/new_player))
 			continue
 
-	to_chat_spaced(target, html = "[SPAN_ANNOUNCEMENT_HEADER(title)]<br><br>[SPAN_ANNOUNCEMENT_BODY(message)]", type = MESSAGE_TYPE_RADIO)
+		to_chat_spaced(target, html = "[SPAN_ANNOUNCEMENT_HEADER(title)]<br><br>[SPAN_ANNOUNCEMENT_BODY(message)]", type = MESSAGE_TYPE_RADIO)
 		if(!quiet)
 			if(isobserver(target) && !(target.client?.prefs?.toggles_sound & SOUND_OBSERVER_ANNOUNCEMENTS))
 				continue

--- a/code/defines/procs/announcement.dm
+++ b/code/defines/procs/announcement.dm
@@ -127,36 +127,36 @@
 
 //AI shipside announcement, that uses announcement mechanic instead of talking into comms
 //to ensure that all humans on ship hear it regardless of comms and power
-/proc/shipwide_ai_announcement(message, title = MAIN_AI_SYSTEM, signature, ares_logging = ARES_LOG_MAIN, sound_to_play = sound('sound/misc/interference.ogg'), quiet = FALSE)
-    var/list/targets = GLOB.human_mob_list + GLOB.dead_mob_list
-    for(var/mob/target in targets)
-        if(isobserver(target))
-            continue
-        if(!ishuman(target) || isyautja(target) || !is_mainship_level(target.z))
-            targets.Remove(target)
+/proc/shipwide_ai_announcement(message, title = MAIN_AI_SYSTEM, signature, ares_logging = ARES_LOG_MAIN, sound_to_play = sound('sound/misc/interference.ogg'), quiet = FALSE) // Declare quiet here with a default value
+	var/list/targets = GLOB.human_mob_list + GLOB.dead_mob_list
+	for(var/mob/target in targets)
+		if(isobserver(target))
+			continue
+		if(!ishuman(target) || isyautja(target) || !is_mainship_level(target.z))
+			targets.Remove(target)
 
-    if(!isnull(signature))
-        message += "<br><br><i> Signed by, <br> [signature]</i>"
-    switch(ares_logging)
-        if(ARES_LOG_MAIN)
-            log_ares_announcement(title, message, signature)
-        if(ARES_LOG_SECURITY)
-            log_ares_security(title, message, signature)
+	if(!isnull(signature))
+		message += "<br><br><i> Signed by, <br> [signature]</i>"
+	switch(ares_logging)
+		if(ARES_LOG_MAIN)
+			log_ares_announcement(title, message, signature)
+		if(ARES_LOG_SECURITY)
+			log_ares_security(title, message, signature)
 
-    announcement_helper(message, title, targets, sound_to_play, quiet)
+	announcement_helper(message, title, targets, sound_to_play, quiet)
 
 /proc/all_hands_on_deck(message, title = MAIN_AI_SYSTEM, sound_to_play = sound('sound/misc/sound_misc_boatswain.ogg'))
-    shipwide_ai_announcement(message, title, null, ARES_LOG_MAIN, sound_to_play, FALSE)
+	shipwide_ai_announcement(message, title, null, ARES_LOG_MAIN, sound_to_play, FALSE)
 
 /proc/announcement_helper(message, title, list/targets, sound_to_play, quiet)
-    if(!message || !title || !targets) //Shouldn't happen
-        return
-    for(var/mob/target in targets)
-        if(istype(target, /mob/new_player))
-            continue
+	if(!message || !title || !targets) //Shouldn't happen
+		return
+	for(var/mob/target in targets)
+		if(istype(target, /mob/new_player))
+			continue
 
-        to_chat_spaced(target, html = "[SPAN_ANNOUNCEMENT_HEADER(title)]<br><br>[SPAN_ANNOUNCEMENT_BODY(message)]", type = MESSAGE_TYPE_RADIO)
-        if(!quiet)
-            if(isobserver(target) && !(target.client?.prefs?.toggles_sound & SOUND_OBSERVER_ANNOUNCEMENTS))
-                continue
-            playsound_client(target.client, sound_to_play, target, vol = 45)
+	to_chat_spaced(target, html = "[SPAN_ANNOUNCEMENT_HEADER(title)]<br><br>[SPAN_ANNOUNCEMENT_BODY(message)]", type = MESSAGE_TYPE_RADIO)
+		if(!quiet)
+			if(isobserver(target) && !(target.client?.prefs?.toggles_sound & SOUND_OBSERVER_ANNOUNCEMENTS))
+				continue
+			playsound_client(target.client, sound_to_play, target, vol = 45)

--- a/code/defines/procs/announcement.dm
+++ b/code/defines/procs/announcement.dm
@@ -127,7 +127,7 @@
 
 //AI shipside announcement, that uses announcement mechanic instead of talking into comms
 //to ensure that all humans on ship hear it regardless of comms and power
-/proc/shipwide_ai_announcement(message, title = MAIN_AI_SYSTEM, signature, ares_logging = ARES_LOG_MAIN, sound_to_play = sound('sound/misc/interference.ogg'), quiet = FALSE)
+/proc/shipwide_ai_announcement(message, title = MAIN_AI_SYSTEM, sound_to_play = sound('sound/misc/interference.ogg'), signature, ares_logging = ARES_LOG_MAIN, quiet = FALSE)
 	var/list/targets = GLOB.human_mob_list + GLOB.dead_mob_list
 	for(var/mob/target in targets)
 		if(isobserver(target))

--- a/code/defines/procs/announcement.dm
+++ b/code/defines/procs/announcement.dm
@@ -129,11 +129,11 @@
 //to ensure that all humans on ship hear it regardless of comms and power
 /proc/shipwide_ai_announcement(message, title = MAIN_AI_SYSTEM, sound_to_play = sound('sound/misc/interference.ogg'), signature, ares_logging = ARES_LOG_MAIN)
 	var/list/targets = GLOB.human_mob_list + GLOB.dead_mob_list
-	for(var/mob/Target in targets)
-		if(isobserver(Target))
+	for(var/mob/target in targets)
+		if(isobserver(target))
 			continue
-		if(!ishuman(Target) || isyautja(Target) || !is_mainship_level(Target.z))
-			targets.Remove(Target)
+		if(!ishuman(target) || isyautja(target) || !is_mainship_level(target.z))
+			targets.Remove(target)
 
 	if(!isnull(signature))
 		message += "<br><br><i> Signed by, <br> [signature]</i>"
@@ -147,11 +147,11 @@
 
 /proc/shipwide_quiet_ai_announcement(message, title = MAIN_AI_SYSTEM, signature, ares_logging = ARES_LOG_MAIN)
 	var/list/targets = GLOB.human_mob_list + GLOB.dead_mob_list
-	for(var/mob/Target in targets)
-		if(isobserver(Target))
+	for(var/mob/target in targets)
+		if(isobserver(target))
 			continue
-		if(!ishuman(Target) || isyautja(Target) || !is_mainship_level(Target.z))
-			targets.Remove(Target)
+		if(!ishuman(target) || isyautja(target) || !is_mainship_level(target.z))
+			targets.Remove(target)
 
 	if(!isnull(signature))
 		message += "<br><br><i> Signed by, <br> [signature]</i>"
@@ -166,11 +166,11 @@
 //Subtype of AI shipside announcement for "All Hands On Deck" alerts (COs and SEAs joining the game)
 /proc/all_hands_on_deck(message, title = MAIN_AI_SYSTEM, sound_to_play = sound('sound/misc/sound_misc_boatswain.ogg'))
 	var/list/targets = GLOB.human_mob_list + GLOB.dead_mob_list
-	for(var/mob/Target in targets)
-		if(isobserver(Target))
+	for(var/mob/target in targets)
+		if(isobserver(target))
 			continue
-		if(!ishuman(Target) || isyautja(Target) || !is_mainship_level((get_turf(Target))?.z))
-			targets.Remove(Target)
+		if(!ishuman(target) || isyautja(target) || !is_mainship_level((get_turf(target))?.z))
+			targets.Remove(target)
 
 	log_ares_announcement("Shipwide Update", message, title)
 
@@ -180,19 +180,19 @@
 /proc/announcement_helper(message, title, list/targets, sound_to_play)
 	if(!message || !title || !sound_to_play || !targets) //Shouldn't happen
 		return
-	for(var/mob/Target in targets)
-		if(istype(Target, /mob/new_player))
+	for(var/mob/target in targets)
+		if(istype(target, /mob/new_player))
 			continue
 
-		to_chat_spaced(Target, html = "[SPAN_ANNOUNCEMENT_HEADER(title)]<br><br>[SPAN_ANNOUNCEMENT_BODY(message)]", type = MESSAGE_TYPE_RADIO)
-		if(isobserver(Target) && !(Target.client?.prefs?.toggles_sound & SOUND_OBSERVER_ANNOUNCEMENTS))
+		to_chat_spaced(target, html = "[SPAN_ANNOUNCEMENT_HEADER(title)]<br><br>[SPAN_ANNOUNCEMENT_BODY(message)]", type = MESSAGE_TYPE_RADIO)
+		if(isobserver(target) && !(target.client?.prefs?.toggles_sound & SOUND_OBSERVER_ANNOUNCEMENTS))
 			continue
-		playsound_client(Target.client, sound_to_play, Target, vol = 45)
+		playsound_client(target.client, sound_to_play, target, vol = 45)
 /proc/announcement_helper_quiet(message, title, list/targets)
 	if(!message || !title || !targets) //Shouldn't happen
 		return
-	for(var/mob/Target in targets)
-		if(istype(Target, /mob/new_player))
+	for(var/mob/target in targets)
+		if(istype(target, /mob/new_player))
 			continue
 
-		to_chat_spaced(Target, html = "[SPAN_ANNOUNCEMENT_HEADER(title)]<br><br>[SPAN_ANNOUNCEMENT_BODY(message)]", type = MESSAGE_TYPE_RADIO)
+		to_chat_spaced(target, html = "[SPAN_ANNOUNCEMENT_HEADER(title)]<br><br>[SPAN_ANNOUNCEMENT_BODY(message)]", type = MESSAGE_TYPE_RADIO)

--- a/code/defines/procs/announcement.dm
+++ b/code/defines/procs/announcement.dm
@@ -145,7 +145,7 @@
 
 	announcement_helper(message, title, targets, sound_to_play)
 
-/proc/quiet_shipwide_ai_announcement(message, title = MAIN_AI_SYSTEM, signature, ares_logging = ARES_LOG_MAIN)
+/proc/shipwide_quiet_ai_announcement(message, title = MAIN_AI_SYSTEM, signature, ares_logging = ARES_LOG_MAIN)
 	var/list/targets = GLOB.human_mob_list + GLOB.dead_mob_list
 	for(var/mob/Target in targets)
 		if(isobserver(Target))

--- a/code/defines/procs/announcement.dm
+++ b/code/defines/procs/announcement.dm
@@ -127,7 +127,7 @@
 
 //AI shipside announcement, that uses announcement mechanic instead of talking into comms
 //to ensure that all humans on ship hear it regardless of comms and power
-/proc/shipwide_ai_announcement(message, title = MAIN_AI_SYSTEM, signature, ares_logging = ARES_LOG_MAIN, sound_to_play = sound('sound/misc/interference.ogg'), quiet = FALSE) // Declare quiet here with a default value
+/proc/shipwide_ai_announcement(message, title = MAIN_AI_SYSTEM, signature, ares_logging = ARES_LOG_MAIN, sound_to_play = sound('sound/misc/interference.ogg'), quiet = FALSE)
 	var/list/targets = GLOB.human_mob_list + GLOB.dead_mob_list
 	for(var/mob/target in targets)
 		if(isobserver(target))

--- a/code/defines/procs/announcement.dm
+++ b/code/defines/procs/announcement.dm
@@ -129,11 +129,11 @@
 //to ensure that all humans on ship hear it regardless of comms and power
 /proc/shipwide_ai_announcement(message, title = MAIN_AI_SYSTEM, sound_to_play = sound('sound/misc/interference.ogg'), signature, ares_logging = ARES_LOG_MAIN)
 	var/list/targets = GLOB.human_mob_list + GLOB.dead_mob_list
-	for(var/mob/T in targets)
-		if(isobserver(T))
+	for(var/mob/Target in targets)
+		if(isobserver(Target))
 			continue
-		if(!ishuman(T) || isyautja(T) || !is_mainship_level(T.z))
-			targets.Remove(T)
+		if(!ishuman(Target) || isyautja(Target) || !is_mainship_level(Target.z))
+			targets.Remove(Target)
 
 	if(!isnull(signature))
 		message += "<br><br><i> Signed by, <br> [signature]</i>"
@@ -145,14 +145,32 @@
 
 	announcement_helper(message, title, targets, sound_to_play)
 
+/proc/quiet_shipwide_ai_announcement(message, title = MAIN_AI_SYSTEM, signature, ares_logging = ARES_LOG_MAIN)
+	var/list/targets = GLOB.human_mob_list + GLOB.dead_mob_list
+	for(var/mob/Target in targets)
+		if(isobserver(Target))
+			continue
+		if(!ishuman(Target) || isyautja(Target) || !is_mainship_level(Target.z))
+			targets.Remove(Target)
+
+	if(!isnull(signature))
+		message += "<br><br><i> Signed by, <br> [signature]</i>"
+	switch(ares_logging)
+		if(ARES_LOG_MAIN)
+			log_ares_announcement(title, message, signature)
+		if(ARES_LOG_SECURITY)
+			log_ares_security(title, message, signature)
+
+	announcement_helper_quiet(message, title, targets)
+
 //Subtype of AI shipside announcement for "All Hands On Deck" alerts (COs and SEAs joining the game)
 /proc/all_hands_on_deck(message, title = MAIN_AI_SYSTEM, sound_to_play = sound('sound/misc/sound_misc_boatswain.ogg'))
 	var/list/targets = GLOB.human_mob_list + GLOB.dead_mob_list
-	for(var/mob/T in targets)
-		if(isobserver(T))
+	for(var/mob/Target in targets)
+		if(isobserver(Target))
 			continue
-		if(!ishuman(T) || isyautja(T) || !is_mainship_level((get_turf(T))?.z))
-			targets.Remove(T)
+		if(!ishuman(Target) || isyautja(Target) || !is_mainship_level((get_turf(Target))?.z))
+			targets.Remove(Target)
 
 	log_ares_announcement("Shipwide Update", message, title)
 
@@ -162,11 +180,19 @@
 /proc/announcement_helper(message, title, list/targets, sound_to_play)
 	if(!message || !title || !sound_to_play || !targets) //Shouldn't happen
 		return
-	for(var/mob/T in targets)
-		if(istype(T, /mob/new_player))
+	for(var/mob/Target in targets)
+		if(istype(Target, /mob/new_player))
 			continue
 
-		to_chat_spaced(T, html = "[SPAN_ANNOUNCEMENT_HEADER(title)]<br><br>[SPAN_ANNOUNCEMENT_BODY(message)]", type = MESSAGE_TYPE_RADIO)
-		if(isobserver(T) && !(T.client?.prefs?.toggles_sound & SOUND_OBSERVER_ANNOUNCEMENTS))
+		to_chat_spaced(Target, html = "[SPAN_ANNOUNCEMENT_HEADER(title)]<br><br>[SPAN_ANNOUNCEMENT_BODY(message)]", type = MESSAGE_TYPE_RADIO)
+		if(isobserver(Target) && !(Target.client?.prefs?.toggles_sound & SOUND_OBSERVER_ANNOUNCEMENTS))
 			continue
-		playsound_client(T.client, sound_to_play, T, vol = 45)
+		playsound_client(Target.client, sound_to_play, Target, vol = 45)
+/proc/announcement_helper_quiet(message, title, list/targets)
+	if(!message || !title || !targets) //Shouldn't happen
+		return
+	for(var/mob/Target in targets)
+		if(istype(Target, /mob/new_player))
+			continue
+
+		to_chat_spaced(Target, html = "[SPAN_ANNOUNCEMENT_HEADER(title)]<br><br>[SPAN_ANNOUNCEMENT_BODY(message)]", type = MESSAGE_TYPE_RADIO)

--- a/code/defines/procs/announcement.dm
+++ b/code/defines/procs/announcement.dm
@@ -127,72 +127,36 @@
 
 //AI shipside announcement, that uses announcement mechanic instead of talking into comms
 //to ensure that all humans on ship hear it regardless of comms and power
-/proc/shipwide_ai_announcement(message, title = MAIN_AI_SYSTEM, sound_to_play = sound('sound/misc/interference.ogg'), signature, ares_logging = ARES_LOG_MAIN)
-	var/list/targets = GLOB.human_mob_list + GLOB.dead_mob_list
-	for(var/mob/target in targets)
-		if(isobserver(target))
-			continue
-		if(!ishuman(target) || isyautja(target) || !is_mainship_level(target.z))
-			targets.Remove(target)
+/proc/shipwide_ai_announcement(message, title = MAIN_AI_SYSTEM, signature, ares_logging = ARES_LOG_MAIN, sound_to_play = sound('sound/misc/interference.ogg'), quiet = FALSE)
+    var/list/targets = GLOB.human_mob_list + GLOB.dead_mob_list
+    for(var/mob/target in targets)
+        if(isobserver(target))
+            continue
+        if(!ishuman(target) || isyautja(target) || !is_mainship_level(target.z))
+            targets.Remove(target)
 
-	if(!isnull(signature))
-		message += "<br><br><i> Signed by, <br> [signature]</i>"
-	switch(ares_logging)
-		if(ARES_LOG_MAIN)
-			log_ares_announcement(title, message, signature)
-		if(ARES_LOG_SECURITY)
-			log_ares_security(title, message, signature)
+    if(!isnull(signature))
+        message += "<br><br><i> Signed by, <br> [signature]</i>"
+    switch(ares_logging)
+        if(ARES_LOG_MAIN)
+            log_ares_announcement(title, message, signature)
+        if(ARES_LOG_SECURITY)
+            log_ares_security(title, message, signature)
 
-	announcement_helper(message, title, targets, sound_to_play)
+    announcement_helper(message, title, targets, sound_to_play, quiet)
 
-/proc/shipwide_quiet_ai_announcement(message, title = MAIN_AI_SYSTEM, signature, ares_logging = ARES_LOG_MAIN)
-	var/list/targets = GLOB.human_mob_list + GLOB.dead_mob_list
-	for(var/mob/target in targets)
-		if(isobserver(target))
-			continue
-		if(!ishuman(target) || isyautja(target) || !is_mainship_level(target.z))
-			targets.Remove(target)
-
-	if(!isnull(signature))
-		message += "<br><br><i> Signed by, <br> [signature]</i>"
-	switch(ares_logging)
-		if(ARES_LOG_MAIN)
-			log_ares_announcement(title, message, signature)
-		if(ARES_LOG_SECURITY)
-			log_ares_security(title, message, signature)
-
-	announcement_helper_quiet(message, title, targets)
-
-//Subtype of AI shipside announcement for "All Hands On Deck" alerts (COs and SEAs joining the game)
 /proc/all_hands_on_deck(message, title = MAIN_AI_SYSTEM, sound_to_play = sound('sound/misc/sound_misc_boatswain.ogg'))
-	var/list/targets = GLOB.human_mob_list + GLOB.dead_mob_list
-	for(var/mob/target in targets)
-		if(isobserver(target))
-			continue
-		if(!ishuman(target) || isyautja(target) || !is_mainship_level((get_turf(target))?.z))
-			targets.Remove(target)
+    shipwide_ai_announcement(message, title, null, ARES_LOG_MAIN, sound_to_play, FALSE)
 
-	log_ares_announcement("Shipwide Update", message, title)
+/proc/announcement_helper(message, title, list/targets, sound_to_play, quiet)
+    if(!message || !title || !targets) //Shouldn't happen
+        return
+    for(var/mob/target in targets)
+        if(istype(target, /mob/new_player))
+            continue
 
-	announcement_helper(message, title, targets, sound_to_play)
-
-//the announcement proc that handles announcing for each mob in targets list
-/proc/announcement_helper(message, title, list/targets, sound_to_play)
-	if(!message || !title || !sound_to_play || !targets) //Shouldn't happen
-		return
-	for(var/mob/target in targets)
-		if(istype(target, /mob/new_player))
-			continue
-
-		to_chat_spaced(target, html = "[SPAN_ANNOUNCEMENT_HEADER(title)]<br><br>[SPAN_ANNOUNCEMENT_BODY(message)]", type = MESSAGE_TYPE_RADIO)
-		if(isobserver(target) && !(target.client?.prefs?.toggles_sound & SOUND_OBSERVER_ANNOUNCEMENTS))
-			continue
-		playsound_client(target.client, sound_to_play, target, vol = 45)
-/proc/announcement_helper_quiet(message, title, list/targets)
-	if(!message || !title || !targets) //Shouldn't happen
-		return
-	for(var/mob/target in targets)
-		if(istype(target, /mob/new_player))
-			continue
-
-		to_chat_spaced(target, html = "[SPAN_ANNOUNCEMENT_HEADER(title)]<br><br>[SPAN_ANNOUNCEMENT_BODY(message)]", type = MESSAGE_TYPE_RADIO)
+        to_chat_spaced(target, html = "[SPAN_ANNOUNCEMENT_HEADER(title)]<br><br>[SPAN_ANNOUNCEMENT_BODY(message)]", type = MESSAGE_TYPE_RADIO)
+        if(!quiet)
+            if(isobserver(target) && !(target.client?.prefs?.toggles_sound & SOUND_OBSERVER_ANNOUNCEMENTS))
+                continue
+            playsound_client(target.client, sound_to_play, target, vol = 45)

--- a/code/modules/events/inflation.dm
+++ b/code/modules/events/inflation.dm
@@ -32,7 +32,7 @@
 	/* You may be thinking 'Why the fuck would W-Y directly send a broadcast to a in-operation vessel and reveal their location to any hostiles nearby?'
 	The answer is they don't, it's a signal sent across entire sectors for every UA-affiliated vessel and colony to take note of when it passes by.
 	Colony vendors aren't updated because the colony's network has collapsed. */
-	shipwide_ai_announcement("An encrypted broadband signal from Weyland-Yutani has been received notifying the sector of sudden changes in the UA's economy during cryosleep, due to [get_random_story()], and have requested UA vessels to increase the prices of [product_type] products by [get_percentage()]%. This change will come into effect in [time_to_update] minutes.")
+	shipwide_quiet_ai_announcement("An encrypted broadband signal from Weyland-Yutani has been received notifying the sector of sudden changes in the UA's economy during cryosleep, due to [get_random_story()], and have requested UA vessels to increase the prices of [product_type] products by [get_percentage()]%. This change will come into effect in [time_to_update] minutes.")
 
 /datum/round_event/economy_inflation/start()
 	for(var/obj/structure/machinery/vending/vending_machine as anything in GLOB.total_vending_machines)

--- a/code/modules/events/inflation.dm
+++ b/code/modules/events/inflation.dm
@@ -32,7 +32,7 @@
 	/* You may be thinking 'Why the fuck would W-Y directly send a broadcast to a in-operation vessel and reveal their location to any hostiles nearby?'
 	The answer is they don't, it's a signal sent across entire sectors for every UA-affiliated vessel and colony to take note of when it passes by.
 	Colony vendors aren't updated because the colony's network has collapsed. */
-	shipwide_quiet_ai_announcement("An encrypted broadband signal from Weyland-Yutani has been received notifying the sector of sudden changes in the UA's economy during cryosleep, due to [get_random_story()], and have requested UA vessels to increase the prices of [product_type] products by [get_percentage()]%. This change will come into effect in [time_to_update] minutes.")
+	shipwide_ai_announcement("An encrypted broadband signal from Weyland-Yutani has been received notifying the sector of sudden changes in the UA's economy during cryosleep, due to [get_random_story()], and have requested UA vessels to increase the prices of [product_type] products by [get_percentage()]%. This change will come into effect in [time_to_update] minutes.", quiet = TRUE)
 
 /datum/round_event/economy_inflation/start()
 	for(var/obj/structure/machinery/vending/vending_machine as anything in GLOB.total_vending_machines)


### PR DESCRIPTION
# About the pull request

Makes the frequent announcements about souto being 5% more expensive or whatever not play sound for anyone. (Also tried to improve the one letter var situation)

# Explain why it's good for the game

I feel like playing interference.ogg for such a frequent fluff-RP "event" a little annoying and pointless. (If the consensus is that I'm being a grinch then you can reject this PR, no problem.)


# Testing Photographs and Procedure

I did test it on local and it worked.


# Changelog
:cl:
sounddel: the vendor inflation event no longer plays sound
/:cl:
