### PR TITLE
Opening a stasis bag now displays a message

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -157,7 +157,7 @@
 	if(opened && open_cooldown > world.time)
 		to_chat(user, SPAN_WARNING("\The [src] has been opened too recently!"))
 		return
-	user.visible_message(SPAN_WARNING("[user] opens the stasis bag.")
+	visible_message(SPAN_WARNING("[user] opens the bag."))
 	. = ..()
 
 

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -157,7 +157,7 @@
 	if(opened && open_cooldown > world.time)
 		to_chat(user, SPAN_WARNING("\The [src] has been opened too recently!"))
 		return
-	user.visible_message(SPAN_WARNING("[user] opens the [src]."), SPAN_NOTICE("You open the [src]."))
+	user.visible_message(SPAN_WARNING("[user] opens [src]."), SPAN_NOTICE("You open [src]."))
 	. = ..()
 
 

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -157,7 +157,7 @@
 	if(opened && open_cooldown > world.time)
 		to_chat(user, SPAN_WARNING("\The [src] has been opened too recently!"))
 		return
-	user.visible_message(SPAN_WARNING("[user] opens the stasis bag."),
+	user.visible_message(SPAN_WARNING("[user] opens the stasis bag.")
 	. = ..()
 
 

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -157,6 +157,7 @@
 	if(opened && open_cooldown > world.time)
 		to_chat(user, SPAN_WARNING("\The [src] has been opened too recently!"))
 		return
+	user.visible_message(SPAN_WARNING("[user] opens the stasis bag."),
 	. = ..()
 
 

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -157,7 +157,7 @@
 	if(opened && open_cooldown > world.time)
 		to_chat(user, SPAN_WARNING("\The [src] has been opened too recently!"))
 		return
-	visible_message(SPAN_WARNING("[user] opens the bag."))
+	user.visible_message(SPAN_WARNING("[user] opens the [src]."), SPAN_NOTICE("You open the [src]."))
 	. = ..()
 
 


### PR DESCRIPTION

# About the pull request

Opening a stasis bag now displays a message about who opened it.

# Explain why it's good for the game

Actions that could be grief (like opening a stasis bag when someone is hugged inside it) should display a message. This will settle any debate of "who opened the bag". Besides, there's already a cooldown to prevent spam.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: message added when someone opens a stasis bag
/:cl:
