### PR TITLE
Fixes accidental border dragging

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -25,8 +25,8 @@ window "mainwindow"
 		menu = "menu"
 	elem "split"
 		type = CHILD
-		pos = 3,0
-		size = 634x440
+		pos = 0,0
+		size = 640x440
 		anchor1 = 0,0
 		anchor2 = 100,100
 		saved-params = "splitter"


### PR DESCRIPTION

# About the pull request
Fixes accidental border dragging by removing the side padding.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Prevents accidentally dragging the border and resizing the client window. See video for an example.
Literal ided issue as I've killed myself several times by doing this when trying to dash out of CAS etc.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

https://github.com/user-attachments/assets/8aee5f1f-a37e-47c7-a8b1-eb63a054ff2f

</details>


# Changelog
:cl: thebleh
qol: Removed client window side padding to prevent accidental dragging
/:cl:
