### PR TITLE
Boiler strain retaining neuro-tail bugfix + some sanity for spit types

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Boiler.dm
@@ -22,7 +22,7 @@
 	caste_desc = "Gross!"
 	acid_level = 3
 	caste_luminosity = 2
-	spit_types = list(/datum/ammo/xeno/boiler_gas, /datum/ammo/xeno/boiler_gas/acid)
+	spit_types = list(/datum/ammo/xeno/boiler_gas/acid, /datum/ammo/xeno/boiler_gas)
 	fire_immunity = FIRE_VULNERABILITY
 	// 3x fire damage
 	fire_vulnerability_mult = FIRE_MULTIPLIER_DEADLY
@@ -84,8 +84,6 @@
 	smoke.attach(src)
 	smoke.cause_data = create_cause_data(initial(caste_type), src)
 	see_in_dark = 20
-	ammo = GLOB.ammo_list[/datum/ammo/xeno/boiler_gas/acid]
-	spit_types = list(/datum/ammo/xeno/boiler_gas/acid, /datum/ammo/xeno/boiler_gas)
 
 	update_icon_source()
 

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/boiler/trapper.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/boiler/trapper.dm
@@ -29,6 +29,7 @@
 	boiler.tileoffset = 0
 	boiler.viewsize = TRAPPER_VIEWRANGE
 	boiler.plasma_types -= PLASMA_NEUROTOXIN
+	boiler.ammo = GLOB.ammo_list[boiler.caste.spit_types[1]]
 	boiler.armor_modifier -= XENO_ARMOR_MOD_LARGE // no armor
 	boiler.health_modifier -= XENO_HEALTH_MOD_MED
 


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

- Fixes the Trapper strain not resetting spit type to acid, which allowed neuro-tail be available for Trapper strain.
- Swaps spit types around in caste datum to not swap it in xeno's mob Initialize().

# Explain why it's good for the game
Going Trapper is Full Acid build, having an ability to have neuro-tail is strange and inconsistent.
Sanity is good. Why spit types are swapped in xeno's mob?

# Testing Photographs and Procedure
Spit acid ball on spawn, swapping gas types and balls have correct gas types 

# Changelog
:cl:
fix: Boiler - Purchasing Trapper strain will forcefully change spit type to acid, which makes acid-tail variant the only one. No more neuro-tails on Trappers.
refactor: Boiler - swapped spit types in caste dastum, removed swapping types in xeno's mob. Shouldn't change anything.
/:cl:
