### PR TITLE
Mitigates bug with opened locked lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -45,7 +45,7 @@
 				src.req_access += pick(get_access(ACCESS_LIST_MARINE_MAIN))
 
 /obj/structure/closet/secure_closet/proc/togglelock(mob/living/user)
-	if(opened && !src.locked)
+	if(opened && locked)
 		to_chat(user, SPAN_NOTICE("Close the locker first."))
 		return
 	if(broken)

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -45,7 +45,7 @@
 				src.req_access += pick(get_access(ACCESS_LIST_MARINE_MAIN))
 
 /obj/structure/closet/secure_closet/proc/togglelock(mob/living/user)
-	if(opened && locked)
+	if(opened && !locked)
 		to_chat(user, SPAN_NOTICE("Close the locker first."))
 		return
 	if(broken)

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -45,7 +45,7 @@
 				src.req_access += pick(get_access(ACCESS_LIST_MARINE_MAIN))
 
 /obj/structure/closet/secure_closet/proc/togglelock(mob/living/user)
-	if(opened)
+	if(opened && !src.locked)
 		to_chat(user, SPAN_NOTICE("Close the locker first."))
 		return
 	if(broken)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

It's possible for lockers to be both opened and locked at the same time, and the code won't let you close or unlock them in this state. I don't know what allows them to be opened and locked in the first place (probably an issue with the automatic stuff that happens when going to and from red alert). In any case we should let people unlock if this happens.

# Explain why it's good for the game

mitigates bug


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: mitigates bug where you can't close or unlock an opened locked locker
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
