### PR TITLE
King Fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/King.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/King.dm
@@ -80,6 +80,8 @@
 
 /mob/living/carbon/xenomorph/king/proc/check_block(mob/king, turf/new_loc)
 	SIGNAL_HANDLER
+	if(stat == DEAD)
+		return
 	for(var/mob/living/carbon/carbon in new_loc.contents)
 		if(isxeno(carbon))
 			var/mob/living/carbon/xenomorph/xeno = carbon
@@ -94,6 +96,7 @@
 				carbon.apply_armoured_damage(20)
 				carbon.KnockDown((1 SECONDS) / GLOBAL_STATUS_MULTIPLIER)
 				playsound(src, 'sound/weapons/alien_knockdown.ogg', 25, 1)
+
 /mob/living/carbon/xenomorph/king/gib(datum/cause_data/cause = create_cause_data("gibbing", src))
 	death(cause, 1)
 


### PR DESCRIPTION
Adds a statement for when the King is dead it will not trigger the code stunning xenomorphs or humans
# About the pull request

fixes: #6464 
Adds a check for when the king is dead it will not trigger the procs that stun xenomorphs and marines.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

getting stunned by Dead corpse == bad
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: fixes the issue with king tackling humans and xenomorphs while dead
/:cl:
