### PR TITLE
Adds a few items to SecTech and fixes ads/slogans.

### DIFF
--- a/code/game/machinery/vending/vending_types.dm
+++ b/code/game/machinery/vending/vending_types.dm
@@ -439,8 +439,8 @@
 		/obj/item/tape/regulation = 5,
 		/obj/item/device/taperecorder = 3,
 		/obj/item/device/clue_scanner = 3,
-		/obj/item/device/camera = 3,
-		/obj/item/device/camera_film = 3,
+		/obj/item/device/camera = 8,
+		/obj/item/device/camera_film = 8,
 	)
 	contraband = list(/obj/item/clothing/glasses/sunglasses = 2,/obj/item/storage/donut_box = 2)
 

--- a/code/game/machinery/vending/vending_types.dm
+++ b/code/game/machinery/vending/vending_types.dm
@@ -440,7 +440,7 @@
 		/obj/item/device/taperecorder = 3,
 		/obj/item/device/clue_scanner = 3,
 		/obj/item/device/camera = 3,
-		/obj/item/device/camera_film = 3
+		/obj/item/device/camera_film = 3,
 	)
 	contraband = list(/obj/item/clothing/glasses/sunglasses = 2,/obj/item/storage/donut_box = 2)
 

--- a/code/game/machinery/vending/vending_types.dm
+++ b/code/game/machinery/vending/vending_types.dm
@@ -411,6 +411,7 @@
 	name = "\improper SecTech"
 	desc = "A security equipment vendor."
 	product_ads = "Crack capitalist skulls!;Beat some heads in!;Don't forget - harm is good!;Your weapons are right here.;Handcuffs!;Freeze, scumbag!;Don't tase me bro!;Tase them, bro.;Why not have a donut?"
+	product_slogans = "Crack capitalist skulls!;Beat some heads in!;Don't forget - harm is good!;Your weapons are right here.;Handcuffs!;Freeze, scumbag!;Don't tase me bro!;Tase them, bro.;Why not have a donut?"
 	icon_state = "sec"
 	icon_deny = "sec-deny"
 	req_access = list(ACCESS_MARINE_BRIG)

--- a/code/game/machinery/vending/vending_types.dm
+++ b/code/game/machinery/vending/vending_types.dm
@@ -437,6 +437,10 @@
 		/obj/item/clothing/glasses/sunglasses/sechud = 3,
 		/obj/item/device/radio/headset = 6,
 		/obj/item/tape/regulation = 5,
+		/obj/item/device/taperecorder = 3,
+		/obj/item/device/clue_scanner = 3,
+		/obj/item/device/camera = 3,
+		/obj/item/device/camera_film = 3
 	)
 	contraband = list(/obj/item/clothing/glasses/sunglasses = 2,/obj/item/storage/donut_box = 2)
 


### PR DESCRIPTION
# About the pull request

Adds camera, camera film, tape recorder, clue scanner to SecTech. Changes ads/slogans to be in line with the coding of other vendors (well, with the Eat an EAT vendor anyways, I know that vendor works).

# Explain why it's good for the game

I feel like these items are all things that lead to HRP behavior, and so I don't think any of these additions would be controversial - am I wrong? Also shoutout to https://github.com/cmss13-devs/cmss13/pull/8191 for making it so adding photos to security records works! It's very cool, and it's what led me to make this PR. And the ads/slogans thing is a bug, I think these are never broadcasting.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Adds camera, camera film, tape recorder, clue scanner to SecTech.
fix: Code fixed for sectech machine ads/slogans.
/:cl:
