### PR TITLE
fixes small announcements bug

### DIFF
--- a/code/defines/procs/announcement.dm
+++ b/code/defines/procs/announcement.dm
@@ -146,7 +146,7 @@
 	announcement_helper(message, title, targets, sound_to_play, quiet)
 
 /proc/all_hands_on_deck(message, title = MAIN_AI_SYSTEM, sound_to_play = sound('sound/misc/sound_misc_boatswain.ogg'))
-	shipwide_ai_announcement(message, title, sound_to_play, signature, ares_logging, FALSE)
+	shipwide_ai_announcement(message, title, sound_to_play, signature, ARES_LOG_MAIN, FALSE)
 
 /proc/announcement_helper(message, title, list/targets, sound_to_play, quiet)
 	if(!message || !title || !targets) //Shouldn't happen

--- a/code/defines/procs/announcement.dm
+++ b/code/defines/procs/announcement.dm
@@ -146,7 +146,7 @@
 	announcement_helper(message, title, targets, sound_to_play, quiet)
 
 /proc/all_hands_on_deck(message, title = MAIN_AI_SYSTEM, sound_to_play = sound('sound/misc/sound_misc_boatswain.ogg'))
-	shipwide_ai_announcement(message, title, null, ARES_LOG_MAIN, sound_to_play, FALSE)
+	shipwide_ai_announcement(message, title, sound_to_play, signature, ares_logging, FALSE)
 
 /proc/announcement_helper(message, title, list/targets, sound_to_play, quiet)
 	if(!message || !title || !targets) //Shouldn't happen

--- a/code/defines/procs/announcement.dm
+++ b/code/defines/procs/announcement.dm
@@ -146,7 +146,7 @@
 	announcement_helper(message, title, targets, sound_to_play, quiet)
 
 /proc/all_hands_on_deck(message, title = MAIN_AI_SYSTEM, sound_to_play = sound('sound/misc/sound_misc_boatswain.ogg'))
-	shipwide_ai_announcement(message, title, sound_to_play, signature, ARES_LOG_MAIN, FALSE)
+	shipwide_ai_announcement(message, title, sound_to_play, null, ARES_LOG_MAIN, FALSE)
 
 /proc/announcement_helper(message, title, list/targets, sound_to_play, quiet)
 	if(!message || !title || !targets) //Shouldn't happen


### PR DESCRIPTION

# About the pull request

https://github.com/cmss13-devs/cmss13/pull/8349 causes the boatswain sound announcements to get signed by '1' - woops - this aims to fix that

# Explain why it's good for the game

i hate 1


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: minor signature bug fixed with 'all hands on deck' announcements
/:cl:
