### PR TITLE
APC Terminal Checking

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -26,8 +26,10 @@
 
 /turf
 	icon = 'icons/turf/floors/floors.dmi'
-	var/intact_tile = 1 //used by floors to distinguish floor with/without a floortile(e.g. plating).
-	var/can_bloody = TRUE //Can blood spawn on this turf?
+	///Used by floors to indicate the floor is a tile (otherwise its plating)
+	var/intact_tile = TRUE
+	///Can blood spawn on this turf?
+	var/can_bloody = TRUE
 	var/list/linked_pylons
 	var/obj/effect/alien/weeds/weeds
 

--- a/code/modules/unit_tests/areas_unpowered.dm
+++ b/code/modules/unit_tests/areas_unpowered.dm
@@ -35,14 +35,29 @@
 		TEST_FAIL("[types_with_no_area[bad_machine_type]] ([bad_machine_type]) has no area!")
 
 	for(var/area/cur_area as anything in areas_with_machines)
-		var/apc_count = 0
+		var/list/found_apcs = list()
+		var/any_inaccessible = FALSE
 		for(var/obj/structure/machinery/power/apc/cur_apc in cur_area)
-			apc_count++
+			found_apcs += cur_apc
+			var/turf/apc_turf = cur_apc.loc
+			if(!istype(apc_turf, /turf/open/floor) && apc_turf.intact_tile)
+				any_inaccessible = TRUE
 
+		var/apc_count = length(found_apcs)
 		if(apc_count == 1)
+			if(any_inaccessible)
+				var/obj/structure/machinery/power/apc/cur_apc = found_apcs[1]
+				var/apc_notes = "APC loc: ([cur_apc.x],[cur_apc.y]) [cur_apc.loc?.type]"
+				TEST_FAIL("[cur_area] ([cur_area.type]) has an APC with an inaccessible terminal!\n\t[apc_notes]")
 			continue // Pass
 		if(apc_count > 1)
-			TEST_FAIL("[cur_area] ([cur_area.type]) has [apc_count] APCs!")
+			var/apc_notes = "APC locs: "
+			for(var/i in 1 to apc_count)
+				var/obj/structure/machinery/power/apc/cur_apc = found_apcs[i]
+				apc_notes += "([cur_apc.x],[cur_apc.y])"
+				if(i != apc_count)
+					apc_notes += ", "
+			TEST_FAIL("[cur_area] ([cur_area.type]) has [apc_count] APCs!\n\t[apc_notes]")
 			continue
 
 		if(!cur_area.requires_power)

--- a/code/modules/unit_tests/areas_unpowered.dm
+++ b/code/modules/unit_tests/areas_unpowered.dm
@@ -6,6 +6,8 @@
 	var/list/areas_with_machines = list()
 	/// Assoc list of machine.types containing notes that don't have an area
 	var/list/types_with_no_area = list()
+	/// List of floor turf types that aren't suitable for terminals
+	var/list/floor_turfs_unsuitable = list(/turf/open/floor/almayer/empty, /turf/open/floor/holofloor)
 
 /datum/unit_test/areas_unpowered/pre_game
 	stage = TEST_STAGE_PREGAME // Also run the test during pregame to test w/o nightmare inserts
@@ -41,6 +43,8 @@
 			found_apcs += cur_apc
 			var/turf/apc_turf = cur_apc.loc
 			if(!istype(apc_turf, /turf/open/floor) && apc_turf.intact_tile)
+				any_inaccessible = TRUE
+			else if(is_type_in_list(apc_turf, floor_turfs_unsuitable))
 				any_inaccessible = TRUE
 
 		var/apc_count = length(found_apcs)

--- a/code/modules/unit_tests/unit_test.dm
+++ b/code/modules/unit_tests/unit_test.dm
@@ -225,14 +225,17 @@ GLOBAL_VAR_INIT(focused_test, focused_test())
 
 	var/list/tests_to_run = list()
 	var/list/focused_tests = list()
+	var/any_focus = FALSE // Just used to detect a focus that might only apply to one stage
 	for(var/datum/unit_test/test_to_run as anything in subtypesof(/datum/unit_test))
 		if(initial(test_to_run.stage) != stage)
+			if(initial(test_to_run.focus))
+				any_focus = TRUE
 			continue
 		if(initial(test_to_run.focus))
 			focused_tests += test_to_run
 			continue
 		tests_to_run += test_to_run
-	if(length(focused_tests))
+	if(length(focused_tests) || any_focus)
 		tests_to_run = focused_tests
 
 	tests_to_run = sortTim(tests_to_run, GLOBAL_PROC_REF(cmp_unit_test_priority))

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -25422,7 +25422,7 @@
 	pixel_x = 1
 	},
 /obj/structure/machinery/power/apc/no_power/north,
-/turf/open/asphalt/cement_sunbleached/cement_sunbleached1,
+/turf/open/floor/plating,
 /area/bigredv2/outside/telecomm/lz2_cave)
 "kkF" = (
 /obj/structure/machinery/camera/autoname,
@@ -28668,7 +28668,7 @@
 "nJu" = (
 /obj/structure/flora/grass/desert/lightgrass_7,
 /obj/structure/machinery/power/apc/power/north,
-/turf/open/mars,
+/turf/open/floor/plating,
 /area/bigredv2/outside/eta)
 "nKL" = (
 /obj/structure/prop/invuln/minecart_tracks{

--- a/maps/map_files/CORSAT/Corsat.dmm
+++ b/maps/map_files/CORSAT/Corsat.dmm
@@ -26305,7 +26305,7 @@
 /obj/structure/surface/rack,
 /obj/item/device/flashlight,
 /obj/structure/machinery/power/apc/upgraded/no_power/west,
-/turf/open/shuttle/dropship/medium_grey_single_wide_up_to_down,
+/turf/open/floor/corsat/spiralplate,
 /area/prison/hangar_storage/research/shuttle)
 "cqv" = (
 /obj/structure/computerframe,

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -879,6 +879,13 @@
 "adF" = (
 /turf/open/desert/rock/deep/rock3,
 /area/desert_dam/interior/dam_interior/north_tunnel)
+"adG" = (
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 8
+	},
+/obj/structure/machinery/power/apc/no_power/north,
+/turf/open/asphalt/tile,
+/area/desert_dam/exterior/valley/valley_hydro)
 "adI" = (
 /turf/open/desert/rock/deep,
 /area/desert_dam/interior/dam_interior/north_tunnel_entrance)
@@ -6815,7 +6822,7 @@
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "aDR" = (
 /obj/structure/machinery/power/apc/no_power/east,
-/turf/open/asphalt/cement/cement15,
+/turf/open/floor/corsat/spiralplate,
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "aDS" = (
 /obj/structure/machinery/sentry_holder/colony{
@@ -9764,10 +9771,6 @@
 "aRN" = (
 /turf/open/desert/dirt/desert_transition_corner1/west,
 /area/desert_dam/exterior/valley/valley_wilderness)
-"aRO" = (
-/obj/structure/machinery/power/apc/no_power/north,
-/turf/open/asphalt/cement_sunbleached/cement_sunbleached18,
-/area/desert_dam/exterior/valley/valley_hydro)
 "aRP" = (
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 1
@@ -43938,7 +43941,7 @@
 /obj/item/reagent_container/food/snacks/stew,
 /obj/item/tool/kitchen/utensil/spoon,
 /obj/structure/machinery/power/apc/fully_broken/no_cell/north,
-/turf/open/desert/rock/deep/rock4,
+/turf/open/floor/sandstone/runed,
 /area/desert_dam/interior/caves/temple)
 "kAV" = (
 /obj/structure/machinery/door/airlock/almayer/maint/colony,
@@ -72825,7 +72828,7 @@ cRg
 cRg
 cRg
 cOH
-aRO
+hOK
 bYV
 hzC
 hzC
@@ -73527,7 +73530,7 @@ cRi
 cRi
 cSu
 cOH
-mGo
+adG
 vDJ
 hzC
 rdW

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -884,7 +884,7 @@
 	dir = 8
 	},
 /obj/structure/machinery/power/apc/no_power/north,
-/turf/open/asphalt/tile,
+/turf/open/floor/prison/bright_clean2/southwest,
 /area/desert_dam/exterior/valley/valley_hydro)
 "adI" = (
 /turf/open/desert/rock/deep,

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -43,7 +43,7 @@
 /area/fiorina/tumor/servers)
 "aaq" = (
 /obj/structure/machinery/power/apc/power/north,
-/turf/open/organic/grass/astroturf,
+/turf/open/floor/plating/prison,
 /area/fiorina/tumor/fiberbush)
 "aar" = (
 /obj/structure/machinery/power/apc/power/south,

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -142,12 +142,21 @@
 /obj/structure/surface/rack,
 /turf/open/auto_turf/ice/layer1,
 /area/shiva/exterior/cp_colony_grounds)
+"aaC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/shiva/floor3,
+/area/shiva/interior/warehouse)
 "aaD" = (
 /obj/effect/spider/cocoon{
 	icon_state = "cocoon_large1"
 	},
 /turf/open/auto_turf/ice/layer1,
 /area/shiva/interior/caves/right_spiders)
+"aaE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/shiva/floor3,
+/area/shiva/interior/warehouse)
 "aaG" = (
 /obj/structure/prop/ice_colony/surveying_device{
 	dir = 8
@@ -4198,8 +4207,7 @@
 /area/shiva/exterior/valley)
 "aKn" = (
 /obj/structure/machinery/portable_atmospherics/powered/scrubber{
-	icon_state = "psiphon:1";
-	needs_power = 0
+	icon_state = "psiphon:1"
 	},
 /turf/open/auto_turf/snow/layer1,
 /area/shiva/exterior/valley)
@@ -12897,7 +12905,7 @@
 "krU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/largecrate/random/barrel/white,
-/turf/open/asphalt/cement,
+/turf/open/floor/shiva/floor3,
 /area/shiva/interior/warehouse)
 "krZ" = (
 /obj/structure/flora/tree/dead/tree_5,
@@ -13044,7 +13052,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/largecrate/random/barrel/green,
-/turf/open/asphalt/cement,
+/turf/open/floor/shiva/floor3,
 /area/shiva/interior/warehouse)
 "kyt" = (
 /obj/item/tool/shovel/snow,
@@ -14676,7 +14684,7 @@
 "mpt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/power/apc/no_power/north,
-/turf/open/asphalt/cement,
+/turf/open/floor/shiva/floor3,
 /area/shiva/interior/warehouse)
 "mpE" = (
 /obj/structure/bed/chair/comfy/black{
@@ -31228,7 +31236,7 @@ hbY
 hbY
 hbY
 huz
-axJ
+cio
 axJ
 rBC
 rdS
@@ -32038,7 +32046,7 @@ hbY
 hbY
 hbY
 huz
-aut
+aaC
 rdS
 aCy
 tdc
@@ -32200,7 +32208,7 @@ hbY
 gdI
 aJt
 huz
-rdS
+aaE
 axJ
 amH
 tbR

--- a/maps/map_files/Ice_Colony_v3/standalone/panic_room_hold.dmm
+++ b/maps/map_files/Ice_Colony_v3/standalone/panic_room_hold.dmm
@@ -610,7 +610,7 @@
 /area/shiva/interior/colony/s_admin)
 "wY" = (
 /obj/structure/machinery/power/apc/no_power/north,
-/turf/open/auto_turf/snow/layer2,
+/turf/open/floor/plating,
 /area/shiva/exterior/junkyard/cp_bar)
 "xa" = (
 /obj/item/shard{

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -62,7 +62,7 @@
 /area/kutjevo/interior/construction/north)
 "aar" = (
 /obj/structure/machinery/power/apc/no_power/west,
-/turf/open/auto_turf/sand/layer1,
+/turf/open/floor/kutjevo/multi_tiles,
 /area/kutjevo/exterior/complex_border/med_rec)
 "aas" = (
 /turf/open/floor/kutjevo/tan,
@@ -141,6 +141,13 @@
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/floor/kutjevo/grey/plate,
 /area/kutjevo/interior/construction/north)
+"aaL" = (
+/turf/open/floor/kutjevo/plate,
+/area/kutjevo/exterior/complex_border/med_rec)
+"aaM" = (
+/obj/structure/platform_decoration/metal/kutjevo/east,
+/turf/open/floor/kutjevo/plate,
+/area/kutjevo/exterior/complex_border/med_rec)
 "aaT" = (
 /obj/structure/flora/grass/tallgrass/desert/corner{
 	dir = 6
@@ -34688,9 +34695,9 @@ msK
 msK
 hpy
 aEl
-jar
+aaM
 aar
-msK
+aaL
 msK
 msK
 nAc

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -605,14 +605,6 @@
 	},
 /turf/open/floor/corsat/squares,
 /area/lv522/atmos/east_reactor/south)
-"aco" = (
-/obj/structure/stairs/perspective{
-	dir = 8;
-	icon_state = "p_stair_full"
-	},
-/obj/structure/machinery/power/apc/power/east,
-/turf/open/asphalt/cement/cement3,
-/area/lv522/outdoors/colony_streets/south_west_street)
 "acp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
@@ -630,7 +622,7 @@
 "act" = (
 /obj/effect/landmark/lv624/fog_blocker/short,
 /obj/structure/machinery/power/apc/power/east,
-/turf/open/asphalt/cement/cement3,
+/turf/open/floor/prison/floor_plate,
 /area/lv522/landing_zone_1)
 "acu" = (
 /obj/effect/decal/warning_stripes{
@@ -658,11 +650,11 @@
 /area/lv522/indoors/b_block/hydro/glass)
 "acz" = (
 /obj/structure/machinery/power/apc/power/east,
-/turf/open/asphalt/cement,
+/turf/open/floor/prison/floor_plate,
 /area/lv522/outdoors/colony_streets/central_streets)
 "acA" = (
 /obj/structure/machinery/power/apc/power/north,
-/turf/open/asphalt/cement/cement12,
+/turf/open/floor/prison/floor_plate,
 /area/lv522/outdoors/colony_streets/north_west_street)
 "acB" = (
 /turf/closed/wall/shiva/prefabricated/reinforced,
@@ -679,7 +671,7 @@
 /area/lv522/indoors/c_block/bridge)
 "acF" = (
 /obj/structure/machinery/power/apc/power/south,
-/turf/open/asphalt/cement/cement4,
+/turf/open/floor/prison/floor_plate,
 /area/lv522/outdoors/colony_streets/north_east_street)
 "acG" = (
 /turf/open/asphalt/cement/cement1,
@@ -688,6 +680,16 @@
 /obj/structure/machinery/power/apc/power/north,
 /turf/open/floor/prison/floor_marked,
 /area/lv522/outdoors/nw_rockies)
+"acI" = (
+/obj/structure/machinery/power/apc/power/east,
+/turf/open/floor/prison/floor_plate,
+/area/lv522/outdoors/colony_streets/south_west_street)
+"acJ" = (
+/turf/open/floor/prison/floor_plate,
+/area/lv522/outdoors/colony_streets/south_street)
+"acK" = (
+/turf/open/floor/prison/floor_plate,
+/area/lv522/outdoors/colony_streets/central_streets)
 "adk" = (
 /obj/structure/surface/table/almayer,
 /obj/item/trash/plate,
@@ -12382,7 +12384,7 @@
 /obj/structure/machinery/power/apc/power/north{
 	start_charge = 20
 	},
-/turf/open/organic/grass,
+/turf/open/floor/prison/floor_plate,
 /area/lv522/indoors/a_block/garden)
 "gLg" = (
 /obj/item/prop/alien/hugger,
@@ -61323,7 +61325,7 @@ tSL
 tSL
 tSL
 fnA
-uOd
+acI
 uOd
 fnA
 wIr
@@ -61342,7 +61344,7 @@ cbR
 cbR
 cbR
 cbR
-aco
+cbR
 cbR
 cbR
 cbR
@@ -64592,31 +64594,31 @@ wdy
 rMF
 jmG
 jmG
-rMF
-rMF
+acK
+acK
 jmG
 jmG
-rMF
-rMF
+acK
+acK
 jmG
 jmG
-rMF
-rMF
+acK
+acK
 jmG
 rSX
 six
 ndK
 jmG
 acz
-rMF
+acK
 jmG
 jmG
-rMF
-rMF
+acK
+acK
 jmG
 jmG
-tOo
-tOo
+acJ
+acJ
 jmG
 jmG
 pqR

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -798,7 +798,7 @@
 "adm" = (
 /obj/structure/foamed_metal,
 /obj/structure/machinery/power/apc/no_power/north,
-/turf/open/shuttle/plating,
+/turf/open/floor/plating,
 /area/lv624/lazarus/crashed_ship_containers)
 "adn" = (
 /obj/structure/girder/displaced,

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -798,7 +798,7 @@
 "adm" = (
 /obj/structure/foamed_metal,
 /obj/structure/machinery/power/apc/no_power/north,
-/turf/open/shuttle/bright_red,
+/turf/open/shuttle/plating,
 /area/lv624/lazarus/crashed_ship_containers)
 "adn" = (
 /obj/structure/girder/displaced,
@@ -6764,7 +6764,7 @@
 "aKq" = (
 /obj/structure/flora/jungle/vines/light_1,
 /obj/structure/machinery/power/apc/no_power/north,
-/turf/open/gm/grass/grass2,
+/turf/open/floor/plating,
 /area/lv624/lazarus/yggdrasil)
 "aKr" = (
 /obj/structure/window_frame/colony,

--- a/maps/map_files/New_Varadero/New_Varadero.dmm
+++ b/maps/map_files/New_Varadero/New_Varadero.dmm
@@ -8946,7 +8946,7 @@
 "heu" = (
 /obj/item/device/flashlight/lamp/tripod,
 /obj/structure/machinery/power/apc/no_power/west,
-/turf/open/auto_turf/sand_white/layer1,
+/turf/open/floor/plating/icefloor/asteroidplating,
 /area/varadero/interior/caves/north_research)
 "hfo" = (
 /obj/structure/pipes/standard/simple/hidden/green,
@@ -13028,7 +13028,7 @@
 /area/varadero/interior/hall_SE)
 "kuE" = (
 /obj/structure/machinery/power/apc/no_power/north,
-/turf/open/auto_turf/sand_white/layer1,
+/turf/open/floor/plating/icefloor/asteroidplating,
 /area/varadero/interior_protected/maintenance/south)
 "kuX" = (
 /turf/open/floor/shiva/multi_tiles,

--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -99,7 +99,7 @@
 /area/strata/ug/interior/jungle/structures/research/old_tunnels)
 "aau" = (
 /obj/structure/machinery/power/apc/no_power/east,
-/turf/open/asphalt/cement/cement12,
+/turf/open/floor/strata/floor3/east,
 /area/strata/ag/exterior/paths/north_outpost)
 "aav" = (
 /obj/structure/largecrate/random/barrel/green,
@@ -117,6 +117,10 @@
 /obj/effect/landmark/corpsespawner/upp,
 /turf/open/auto_turf/snow/brown_base/layer0,
 /area/strata/ag/interior/outside/bball/cave)
+"aay" = (
+/obj/structure/machinery/power/apc/no_power/south,
+/turf/open/floor/plating,
+/area/strata/ug/interior/outpost/platform)
 "aaz" = (
 /obj/structure/machinery/power/monitor{
 	name = "Main Power Grid Monitoring"
@@ -425,7 +429,7 @@
 	},
 /obj/structure/barricade/handrail/strata,
 /obj/structure/machinery/power/apc/no_power/west,
-/turf/open/asphalt/cement,
+/turf/open/floor/strata/floor3/east,
 /area/strata/ag/exterior/paths/mining_outpost_exterior)
 "abM" = (
 /obj/item/stack/rods,
@@ -15169,7 +15173,7 @@
 /area/strata/ug/interior/jungle/structures/monitoring/south)
 "bRf" = (
 /obj/structure/machinery/power/apc/power/south,
-/turf/open/asphalt/cement,
+/turf/open/floor/plating,
 /area/strata/ag/exterior/tcomms/mining_caves)
 "bRg" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -18466,10 +18470,6 @@
 /obj/structure/window/framed/strata,
 /turf/open/floor/strata/multi_tiles/southeast,
 /area/strata/ag/interior/outside/checkpoints/west)
-"dCX" = (
-/obj/structure/machinery/power/apc/no_power/west,
-/turf/open/asphalt/cement/cement3,
-/area/strata/ug/interior/outpost/platform)
 "dDM" = (
 /obj/structure/platform_decoration/metal/strata/east,
 /turf/open/floor/strata/floor3,
@@ -20024,7 +20024,7 @@
 "fEW" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/landmark/objective_landmark/close,
-/turf/open/asphalt/cement,
+/turf/open/floor/strata/floor3/east,
 /area/strata/ag/exterior/caves/shed_five_caves)
 "fFy" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
@@ -20726,10 +20726,6 @@
 /obj/structure/bookcase,
 /turf/open/floor/strata/floor3/east,
 /area/strata/ag/interior/outside/engineering/parts_storage)
-"gwY" = (
-/obj/structure/platform/metal/strata/north,
-/turf/open/floor/plating,
-/area/strata/ag/exterior/paths/mining_outpost_exterior)
 "gya" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
 	dir = 4
@@ -21521,7 +21517,7 @@
 /turf/open/gm/river,
 /area/strata/ug/interior/jungle/platform/east)
 "hJT" = (
-/turf/open/asphalt/cement/cement12,
+/turf/open/floor/strata/floor3/east,
 /area/strata/ag/exterior/paths/north_outpost)
 "hKf" = (
 /obj/structure/platform/stone/strata/north,
@@ -21616,7 +21612,7 @@
 /turf/open/floor/strata/white_cyan3/east,
 /area/strata/ag/interior/outpost/med)
 "hPK" = (
-/turf/open/asphalt/cement,
+/turf/open/floor/strata/floor3/east,
 /area/strata/ag/exterior/caves/shed_five_caves)
 "hQq" = (
 /obj/effect/decal/strata_decals/catwalk/prison,
@@ -21717,7 +21713,7 @@
 "hYl" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/structure/machinery/recharge_station,
-/turf/open/asphalt/cement,
+/turf/open/floor/strata/floor3/east,
 /area/strata/ag/exterior/caves/shed_five_caves)
 "hYu" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
@@ -23192,7 +23188,7 @@
 "jVg" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/structure/machinery/power/apc/no_power/west,
-/turf/open/asphalt/cement,
+/turf/open/floor/strata/floor3/east,
 /area/strata/ag/exterior/caves/shed_five_caves)
 "jVD" = (
 /obj/effect/decal/cleanable/blood{
@@ -40612,7 +40608,7 @@ crY
 crY
 crY
 aCl
-gwY
+vAw
 aNl
 aNo
 aNl
@@ -63405,11 +63401,11 @@ wLv
 oSN
 tnM
 wZZ
-wZZ
-srk
-aad
-aad
+aay
 fBG
+aad
+aad
+srk
 aad
 aad
 wZZ
@@ -63584,7 +63580,7 @@ oPN
 oPN
 oPN
 oPN
-dCX
+oPN
 oPN
 oPN
 qrz

--- a/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
+++ b/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
@@ -3944,7 +3944,7 @@
 /area/whiskey_outpost/outside/mortar_pit)
 "qW" = (
 /obj/structure/machinery/power/apc/almayer/east,
-/turf/open/gm/dirt,
+/turf/open/floor/plating,
 /area/whiskey_outpost/inside/caves/tunnel)
 "qX" = (
 /obj/structure/machinery/line_nexter{


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #7856 adding/fixing a few things:
- APCs are now required to be on either a `/turf/open/floor` or a turf that is deemed not a `intact_tile` to try to ensure that the terminal is either exposed or exposable (technically though a floor that doesn't implement a way to expose itself would still be a problem though)
- Multiple APCs failure now has their coordinates listed out in the failure message
- Focused unit testing now will properly skip a stage if the focus testing only applied to a different stage (only really applicable to testing locally)

# Explain why it's good for the game

Fixes #8347 

# Testing Photographs and Procedure
See checks.

# Changelog
:cl: Drathek
add: Areas Unpowered unit test now checks for APCs on non-floor tiles (if they are also deemed intact aka not exposed)
fix: Focused unit testing now properly skips stages if the focus only applies to a different stage
maptweak: Fixed inaccessible APC terminals on basically all maps
/:cl: