### PR TITLE
Ammo box explosion caps at 3k bullets

### DIFF
--- a/code/modules/projectiles/ammo_boxes/ammo_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/ammo_boxes.dm
@@ -220,7 +220,7 @@
 	else
 		for(var/obj/item/ammo_magazine/AM in contents)
 			severity += AM.current_rounds
-		severity = floor(severity / 150)
+		severity = clamp(severity / 150, 0, 20) // explosion caps at 3k bullets
 	return severity
 
 /obj/item/ammo_box/magazine/process_burning(datum/cause_data/flame_cause_data)


### PR DESCRIPTION

# About the pull request
Ammo box explosions max out at 3k bullets, previously you can toss an entire box of m56 and create an earth-shattering kaboom. Now the explosions are caped at 3k bullets. 

Previously: M56D box detonated center of briefing (5.6k bullets)
![image](https://github.com/user-attachments/assets/ebd74d66-2317-4fb2-b0f6-54c4a92e6dc8)

After 3k bullet cap:

![image](https://github.com/user-attachments/assets/6b457e34-1f22-4dd6-90ee-edfc6a3f1731)

Did some testing, does 350~ damage to adjacent xenos, enough to kill base runners but leave acid runners alive on a sliver of health (and stunned).
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Players shouldn't be able to create explosions that big just by filling up a few m56d boxes from their preps (which nobody takes anyway).
# Testing Photographs and Procedure
see above


# Changelog
:cl:
balance: Ammo box explosions are capped at 3k bullets.
/:cl:
