### PR TITLE
Adds surv tracking metrics

### DIFF
--- a/code/datums/_ndatabase/code/entity/entity.dm
+++ b/code/datums/_ndatabase/code/entity/entity.dm
@@ -87,3 +87,7 @@
 	for(var/F in metadata.field_types)
 		if(!(ignore.Find(F)))
 			vars[F] = values[F]
+
+/// Called in the entity_meta's make_new() after metadata and ID is assigned
+/datum/entity/proc/post_creation()
+	return

--- a/code/datums/_ndatabase/code/entity/entity_meta.dm
+++ b/code/datums/_ndatabase/code/entity/entity_meta.dm
@@ -81,6 +81,8 @@
 		if(invalidate)
 			ET.invalidate()
 
+	ET.post_creation()
+
 	return ET
 
 /datum/entity_meta/proc/make_new_by_key(key_value)

--- a/code/datums/statistics/entities/survivor_survival.dm
+++ b/code/datums/statistics/entities/survivor_survival.dm
@@ -1,0 +1,38 @@
+/datum/entity/survivor_survival
+	/// Round ID that we're storing data on
+	var/round_id
+	/// How many minutes after roundstart we're recording this
+	var/time_after_roundstart
+	/// How many survivors there were this round total
+	var/total_survivors
+	/// How many survivors are currently alive
+	var/remaining_survivors = 0
+	/// How many xenos have died
+	var/xeno_deaths
+
+/datum/entity/survivor_survival/New()
+	. = ..()
+	round_id = GLOB.round_id || -1
+	time_after_roundstart = floor((world.time - SSticker.mode.round_time_lobby) / 600)
+	total_survivors = /datum/job/civilian/survivor::total_spawned
+	for(var/mob/living/carbon/human/human as anything in GLOB.alive_human_list)
+		if(QDELETED(human))
+			continue
+
+		if(issurvivorjob(human.job))
+			remaining_survivors++
+	xeno_deaths = GLOB.total_dead_xenos
+
+/datum/entity/survivor_survival/post_creation()
+	save()
+
+/datum/entity_meta/survivor_survival
+	entity_type = /datum/entity/survivor_survival
+	table_name = "survivor_survival"
+	field_types = list(
+		"round_id" = DB_FIELDTYPE_INT,
+		"time_after_roundstart" = DB_FIELDTYPE_INT,
+		"total_survivors" = DB_FIELDTYPE_INT,
+		"remaining_survivors" = DB_FIELDTYPE_INT,
+		"xeno_deaths" = DB_FIELDTYPE_INT,
+	)

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -137,6 +137,7 @@
 	addtimer(CALLBACK(src, PROC_REF(ares_online)), 5 SECONDS)
 	addtimer(CALLBACK(src, PROC_REF(map_announcement)), 20 SECONDS)
 	addtimer(CALLBACK(src, PROC_REF(start_lz_hazards)), DISTRESS_LZ_HAZARD_START)
+	addtimer(CALLBACK(SSentity_manager, TYPE_PROC_REF(/datum/controller/subsystem/entity_manager, select), /datum/entity/survivor_survival), 7 MINUTES)
 
 	return ..()
 
@@ -492,6 +493,8 @@
 /datum/game_mode/colonialmarines/ds_first_drop(obj/docking_port/mobile/marine_dropship)
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_blurb_uscm)), DROPSHIP_DROP_MSG_DELAY)
 	addtimer(CALLBACK(src, PROC_REF(warn_resin_clear), marine_dropship), DROPSHIP_DROP_FIRE_DELAY)
+	DB_ENTITY(/datum/entity/survivor_survival) // Record surv survival right now
+	addtimer(CALLBACK(SSentity_manager, TYPE_PROC_REF(/datum/controller/subsystem/entity_manager, select), /datum/entity/survivor_survival), 7 MINUTES) // And 7 minutes after drop. By then, marines will have found them, most likely
 
 	add_current_round_status_to_end_results("First Drop")
 	clear_lz_hazards()

--- a/code/game/jobs/job/civilians/other/survivors.dm
+++ b/code/game/jobs/job/civilians/other/survivors.dm
@@ -12,6 +12,8 @@
 	var/story_text
 	/// Whether or not the survivor is an inherently hostile to marines.
 	var/hostile = FALSE
+	/// How many survs have been spawned total
+	var/static/total_spawned = 0
 
 /datum/job/civilian/survivor/set_spawn_positions(count)
 	spawn_positions = clamp((floor(count * SURVIVOR_TO_TOTAL_SPAWN_RATIO)), 2, 8)
@@ -34,6 +36,8 @@
 
 /datum/job/civilian/survivor/spawn_in_player(mob/new_player/NP)
 	. = ..()
+	total_spawned++
+
 	var/mob/living/carbon/human/H = .
 
 	var/list/potential_spawners = list()

--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -1,5 +1,8 @@
 #define DELETE_TIME 1800
 
+/// Doesn't count tier 0
+GLOBAL_VAR_INIT(total_dead_xenos, 0)
+
 /mob/living/carbon/xenomorph/death(cause, gibbed)
 	var/msg = "lets out a waning guttural screech, green blood bubbling from its maw."
 	. = ..(cause, gibbed, msg)
@@ -15,6 +18,9 @@
 		ghostize()
 
 	set_light_range(0)
+
+	if(!(caste.caste_type in XENO_T0_CASTES))
+		GLOB.total_dead_xenos++
 
 	if(pulledby)
 		pulledby.stop_pulling()

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -681,6 +681,7 @@
 #include "code\datums\statistics\entities\player_stats.dm"
 #include "code\datums\statistics\entities\round_caste_picks.dm"
 #include "code\datums\statistics\entities\round_stats.dm"
+#include "code\datums\statistics\entities\survivor_survival.dm"
 #include "code\datums\statistics\entities\weapon_stats.dm"
 #include "code\datums\statistics\entities\xeno_death.dm"
 #include "code\datums\statistics\entities\xeno_stats.dm"


### PR DESCRIPTION

# About the pull request

Tracks how many survs there are, how many there were total, and how many xenoes have died. Called 7 minutes after roundstart, at drop, and 7 minutes after drop.

# Explain why it's good for the game

Numbers good

![image](https://github.com/user-attachments/assets/dd0928a1-c04b-4a5d-bf01-88797cefca8b)

(NULL has been cleaned up)
