### PR TITLE
Ignore out of rotation maps in CI

### DIFF
--- a/.github/alternate_byond_versions.txt
+++ b/.github/alternate_byond_versions.txt
@@ -6,4 +6,4 @@
 # Example:
 # 500.1337: runtimestation
 
-516.1648: runtime
+516.1655: runtime

--- a/.github/maps_to_ignore.txt
+++ b/.github/maps_to_ignore.txt
@@ -1,0 +1,4 @@
+chinook
+corsat
+ice_colony_v2
+prison_station_fop

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -114,6 +114,8 @@ jobs:
           shopt -s extglob
           echo "$(ls -mw0 maps/!(*override*).json)" > maps_output.txt
           sed -i -e s+maps/+\"+g -e s+.json+\"+g maps_output.txt
+          echo "Ignored Maps: $(cat .github/maps_to_ignore.txt)"
+          cat .github/maps_to_ignore.txt | sed -r 's/\s*//g' | xargs -i sed -ri 's/(, "{}")|("{}", )//g' maps_output.txt
           echo "Maps: $(cat maps_output.txt)"
           echo "maps={\"paths\":[$(cat maps_output.txt)]}" >> $GITHUB_OUTPUT
       - name: Find Alternate Tests


### PR DESCRIPTION

# About the pull request

This PR adds a map_to_ignore text file which is used to limit the maps_output result for the "Find Maps to Test" portion of CI.

I have also updated the alternate test to latest 516.

# Explain why it's good for the game

We no longer want to maintain maps that are not in rotation.

# Testing Photographs and Procedure
See checks.

# Changelog

No player facing changes.
