### PR TITLE
Nuclear bomb will now kill anyone inside a vehicle on the same z-level

### DIFF
--- a/code/game/machinery/nuclearbomb.dm
+++ b/code/game/machinery/nuclearbomb.dm
@@ -413,6 +413,15 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 				continue
 			alive_mobs |= current_mob
 
+	for(var/datum/interior/interior in SSinteriors.interiors)
+		if(interior?.exterior?.z == z)
+			for(var/mob/living/passenger in interior.get_passengers())
+				if(!(passenger in (alive_mobs + dead_mobs)))
+					if(passenger.stat != DEAD)
+						passenger.death(create_cause_data("nuclear explosion"))
+					for(var/obj/item/alien_embryo/embryo in passenger)
+						qdel(embryo)
+
 	for(var/mob/current_mob in alive_mobs)
 		if(istype(current_mob.loc, /obj/structure/closet/secure_closet/freezer/fridge))
 			continue

--- a/code/game/machinery/nuclearbomb.dm
+++ b/code/game/machinery/nuclearbomb.dm
@@ -414,13 +414,15 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 			alive_mobs |= current_mob
 
 	for(var/datum/interior/interior in SSinterior.interiors)
-		if(interior?.exterior?.z == z)
-			for(var/mob/living/passenger in interior.get_passengers())
-				if(!(passenger in (alive_mobs + dead_mobs)))
-					if(passenger.stat != DEAD)
-						passenger.death(create_cause_data("nuclear explosion"))
-					for(var/obj/item/alien_embryo/embryo in passenger)
-						qdel(embryo)
+		if(!interior.exterior || interior.exterior.z != z)
+			continue
+	
+		for(var/mob/living/passenger in interior.get_passengers())
+			if(!(passenger in (alive_mobs + dead_mobs)))
+				if(passenger.stat != DEAD)
+					passenger.death(create_cause_data("nuclear explosion"))
+				for(var/obj/item/alien_embryo/embryo in passenger)
+					qdel(embryo)
 
 	for(var/mob/current_mob in alive_mobs)
 		if(istype(current_mob.loc, /obj/structure/closet/secure_closet/freezer/fridge))

--- a/code/game/machinery/nuclearbomb.dm
+++ b/code/game/machinery/nuclearbomb.dm
@@ -413,7 +413,7 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 				continue
 			alive_mobs |= current_mob
 
-	for(var/datum/interior/interior in SSinteriors.interiors)
+	for(var/datum/interior/interior in SSinterior.interiors)
 		if(interior?.exterior?.z == z)
 			for(var/mob/living/passenger in interior.get_passengers())
 				if(!(passenger in (alive_mobs + dead_mobs)))


### PR DESCRIPTION

# About the pull request

The Longstreet tank is clearly not NBC-compliant...

Means you can't hide inside a van or something to delay the nuke round-end

# Explain why it's good for the game

Nuke kills people. Makes nuke kill people more


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Nuclear bomb now checks for passengers in vehicles to ensure swift delivery of thermonuclear death
/:cl:
