### PR TITLE
Weapon Stats now list "single fire" as "fire rate"

### DIFF
--- a/tgui/packages/tgui/interfaces/WeaponStats.jsx
+++ b/tgui/packages/tgui/interfaces/WeaponStats.jsx
@@ -199,11 +199,11 @@ const Firerate = (props) => {
   return (
     <>
       <ProgressBar value={firerate / firerate_max} ranges={RedGreenRange}>
-        Single fire: {firerate}rpm, {firerate_second} per second
+        Fire rate: {firerate}rpm, {firerate_second} per second
       </ProgressBar>
       <Box height="5px" />
       <ProgressBar value={burst_firerate / firerate_max} ranges={RedGreenRange}>
-        Burst fire: {burst_firerate}rpm, {burst_firerate_second} per second
+        Burst fire rate: {burst_firerate}rpm, {burst_firerate_second} per second
       </ProgressBar>
       <Box height="5px" />
       {burst_amount > 1 ? (


### PR DESCRIPTION

# About the pull request
See Title
![image](https://github.com/user-attachments/assets/31686429-d185-46af-835d-73a82fa57880)

Also changes "burst fire" to "burst fire rate"

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

When I first opened up gun stats I wondered why it didn't list the full auto ROF of the gun, and only listed burst and single fire, it turned out that single fire WAS the full auto ROF, for some reason. With this change hopefully people looking at gun stats for the first time will know that fire rate coresponds to th
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Gun stats now list "single fire" as "fire rate"
/:cl:
