### PR TITLE
Stricter DMM Test [MDB IGNORE]

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -21,6 +21,9 @@
 "aad" = (
 /turf/open/floor/almayer_hull/outerhull_dir/north,
 /area/space)
+"aae" = (
+/turf/open/floor/almayer_hull/outerhull_dir/northwest,
+/area/space)
 "aaf" = (
 /turf/open/floor/almayer_hull/outerhull_dir/west,
 /area/space)
@@ -99219,7 +99222,7 @@ aaa
 aaa
 aab
 bdH
-aac
+aae
 aah
 aah
 aah
@@ -101935,7 +101938,7 @@ jtU
 vpf
 woU
 aaa
-aac
+aae
 aah
 aah
 aah
@@ -110384,7 +110387,7 @@ aaa
 aaa
 aab
 aaa
-aac
+aae
 aah
 aah
 aah
@@ -110592,7 +110595,7 @@ aaa
 aaa
 bdH
 aaa
-aac
+aae
 aah
 aah
 aah
@@ -116483,7 +116486,7 @@ aaa
 aaa
 aaa
 aaa
-aac
+aae
 aah
 aah
 aah
@@ -117299,7 +117302,7 @@ aaa
 aaa
 aaa
 aaa
-aac
+aae
 aah
 aah
 aah
@@ -118931,7 +118934,7 @@ bdH
 bdH
 bdH
 bdH
-aac
+aae
 aah
 aah
 aah
@@ -119645,7 +119648,7 @@ aaa
 aaa
 aaa
 aaa
-aac
+aae
 aah
 aah
 vgw
@@ -121679,7 +121682,7 @@ aaa
 aaa
 aaa
 bdH
-aac
+aae
 aah
 aag
 aag
@@ -125850,7 +125853,7 @@ xVk
 xVk
 xVk
 xVk
-aac
+aae
 aah
 aag
 jbq
@@ -125944,7 +125947,7 @@ aaa
 aaa
 aaa
 bdH
-aac
+aae
 aah
 aah
 aah
@@ -126258,7 +126261,7 @@ xVk
 xVk
 aaa
 aaa
-aac
+aae
 aah
 aah
 aah

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -21,9 +21,6 @@
 "aad" = (
 /turf/open/floor/almayer_hull/outerhull_dir/north,
 /area/space)
-"aae" = (
-/turf/open/floor/almayer_hull/outerhull_dir/northwest,
-/area/space)
 "aaf" = (
 /turf/open/floor/almayer_hull/outerhull_dir/west,
 /area/space)
@@ -99222,7 +99219,7 @@ aaa
 aaa
 aab
 bdH
-aae
+aac
 aah
 aah
 aah
@@ -101938,7 +101935,7 @@ jtU
 vpf
 woU
 aaa
-aae
+aac
 aah
 aah
 aah
@@ -110387,7 +110384,7 @@ aaa
 aaa
 aab
 aaa
-aae
+aac
 aah
 aah
 aah
@@ -110595,7 +110592,7 @@ aaa
 aaa
 bdH
 aaa
-aae
+aac
 aah
 aah
 aah
@@ -116486,7 +116483,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+aac
 aah
 aah
 aah
@@ -117302,7 +117299,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+aac
 aah
 aah
 aah
@@ -118934,7 +118931,7 @@ bdH
 bdH
 bdH
 bdH
-aae
+aac
 aah
 aah
 aah
@@ -119648,7 +119645,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+aac
 aah
 aah
 vgw
@@ -121682,7 +121679,7 @@ aaa
 aaa
 aaa
 bdH
-aae
+aac
 aah
 aag
 aag
@@ -125853,7 +125850,7 @@ xVk
 xVk
 xVk
 xVk
-aae
+aac
 aah
 aag
 jbq
@@ -125947,7 +125944,7 @@ aaa
 aaa
 aaa
 bdH
-aae
+aac
 aah
 aah
 aah
@@ -126261,7 +126258,7 @@ xVk
 xVk
 aaa
 aaa
-aae
+aac
 aah
 aah
 aah

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -22,7 +22,7 @@
 /turf/open/floor/almayer_hull/outerhull_dir/north,
 /area/space)
 "aae" = (
-/turf/open/floor/almayer_hull/outerhull_dir/northwest,
+/turf/open/floor/almayer_hull/outerhull_dir/northeast,
 /area/space)
 "aaf" = (
 /turf/open/floor/almayer_hull/outerhull_dir/west,

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -22,7 +22,7 @@
 /turf/open/floor/almayer_hull/outerhull_dir/north,
 /area/space)
 "aae" = (
-/turf/open/floor/almayer_hull/outerhull_dir/northeast,
+/turf/open/floor/almayer_hull/outerhull_dir/northwest,
 /area/space)
 "aaf" = (
 /turf/open/floor/almayer_hull/outerhull_dir/west,

--- a/tools/mapmerge2/dmm.py
+++ b/tools/mapmerge2/dmm.py
@@ -27,6 +27,11 @@ class DMM:
             return _parse(f.read())
 
     @staticmethod
+    def from_file_bytes(fname):
+        with open(fname, 'r', encoding=ENCODING) as f:
+            return f.read().encode(ENCODING)
+
+    @staticmethod
     def from_bytes(bytes):
         return _parse(bytes.decode(ENCODING))
 

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -50,7 +50,8 @@ def _self_test():
                 path = fullpath.replace("\\", "/").removeprefix("./")
                 try:
                     # test: can we load every DMM
-                    index_map = DMM.from_file(fullpath)
+                    index_data = DMM.from_file_bytes(fullpath)
+                    index_map = DMM.from_bytes(index_data)
 
                     # test: is every DMM in TGM format
                     if not has_tgm_header(fullpath):
@@ -64,18 +65,17 @@ def _self_test():
                             # New map, no entry in ancestor
                             print("New map? Could not find ancestor version of", path)
                             merged_map = merge_map(index_map, index_map) # basically only tests unused keys
-                            original_bytes = index_map.to_bytes()
                             merged_bytes = merged_map.to_bytes()
-                            if original_bytes != merged_bytes:
+                            if index_data != merged_bytes:
                                 raise LintException('New map is pending updates! Please run `/tools/mapmerge2/I Forgot To Map Merge.bat`')
                         else:
                             # Entry in ancestor, merge the index over it
                             ancestor_map = DMM.from_bytes(ancestor_blob.read_raw())
                             merged_map = merge_map(index_map, ancestor_map)
-                            original_bytes = index_map.to_bytes()
                             merged_bytes = merged_map.to_bytes()
-                            if original_bytes != merged_bytes:
+                            if index_data != merged_bytes:
                                 raise LintException('Map is pending updates! Please run `/tools/mapmerge2/I Forgot To Map Merge.bat`')
+
                 except LintException as error:
                     failed += 1
                     print(red(f'Failed on: {path}'))

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -24,15 +24,16 @@ def _self_test():
 
     # Read the HEAD and ancestor commits
     # Assumption: origin on the runner is what we'd normally call upstream
-    head = None
+    head = repo.head.target
+    head_commit = repo[head]
     ancestor_commit = None
-    try:
-        # if HEAD is a merge commit:
-        head = repo.revparse_single("HEAD^2").id
-    except KeyError:
-        # if HEAD isn't a merge commit:
-        head = repo.head.target
-        pass
+    if len(head_commit.parents) != 1: # if HEAD is a merge commit:
+        try:
+            head = repo.revparse_single("HEAD^2").id
+        except KeyError:
+            print("Unable to determine correct head!")
+            head = repo.head.target
+            pass
     ancestor = repo.merge_base(head, repo.revparse_single("refs/remotes/origin/master").id)
     if not ancestor:
         print("Unable to determine merge base!")

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -25,16 +25,17 @@ def _self_test():
     # Read the HEAD and ancestor commits
     # Assumption: origin on the runner is what we'd normally call upstream
     head = repo.head.target
-    head_commit = repo[head]
+    initial_head_commit = repo[head]
+    upstream = repo.revparse_single("refs/remotes/origin/master").id
+    ancestor = repo.merge_base(head, upstream)
     ancestor_commit = None
-    if len(head_commit.parents) != 1: # if HEAD is a merge commit:
-        try:
-            head = repo.revparse_single("HEAD^2").id
-        except KeyError:
-            print("Unable to determine correct head!")
-            head = repo.head.target
-            pass
-    ancestor = repo.merge_base(head, repo.revparse_single("refs/remotes/origin/master").id)
+    if len(initial_head_commit.parent_ids) != 1: # if HEAD is a merge commit:
+        for parent in initial_head_commit.parent_ids:
+            if parent != upstream:
+                break
+            head = parent
+            ancestor = repo.merge_base(head, upstream)
+
     if not ancestor:
         print("Unable to determine merge base!")
     else:

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -24,15 +24,16 @@ def _self_test():
 
     # Read the HEAD and ancestor commits
     # Assumption: origin on the runner is what we'd normally call upstream
-    ancestor = None
+    head = None
     ancestor_commit = None
     try:
         # if HEAD is a merge commit:
-        ancestor = repo.merge_base(repo.revparse_single("HEAD^2").id, repo.revparse_single("refs/remotes/origin/master").id)
+        head = repo.revparse_single("HEAD^2").id
     except KeyError:
         # if HEAD isn't a merge commit:
-        ancestor = repo.merge_base(repo.head.target, repo.revparse_single("refs/remotes/origin/master").id)
+        head = repo.head.target
         pass
+    ancestor = repo.merge_base(head, repo.revparse_single("refs/remotes/origin/master").id)
     if not ancestor:
         print("Unable to determine merge base!")
     else:

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -31,8 +31,8 @@ def _self_test():
     ancestor_commit = None
     if len(initial_head_commit.parent_ids) != 1: # if HEAD is a merge commit:
         for parent in initial_head_commit.parent_ids:
-            if parent != upstream:
-                break
+            if parent == upstream:
+                continue
             head = parent
             ancestor = repo.merge_base(head, upstream)
 

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -42,7 +42,7 @@ def _self_test():
 
     # Figure out what maps have been modified
     modified_maps = []
-    diff = repo.diff(repo.head.target, ancestor)
+    diff = repo.diff(head, ancestor)
     for delta in diff.deltas:
         cur_path = delta.new_file.path
         if cur_path.endswith('.dmm'):

--- a/tools/mapmerge2/merge_driver.py
+++ b/tools/mapmerge2/merge_driver.py
@@ -95,7 +95,8 @@ def three_way_merge(base, left, right):
 
         merged.set_tile(coord, merged_movables + merged_turfs + merged_areas)
 
-    merged = mapmerge.merge_map(merged, base)
+    merged = mapmerge.merge_map(merged, base) # is this necessary or correct?
+    merged = mapmerge.merge_map(merged, right)
     return trouble, merged
 
 

--- a/tools/mapmerge2/merge_driver.py
+++ b/tools/mapmerge2/merge_driver.py
@@ -95,8 +95,7 @@ def three_way_merge(base, left, right):
 
         merged.set_tile(coord, merged_movables + merged_turfs + merged_areas)
 
-    merged = mapmerge.merge_map(merged, base) # is this necessary or correct?
-    merged = mapmerge.merge_map(merged, left)
+    merged = mapmerge.merge_map(merged, base)
     return trouble, merged
 
 

--- a/tools/mapmerge2/merge_driver.py
+++ b/tools/mapmerge2/merge_driver.py
@@ -95,7 +95,8 @@ def three_way_merge(base, left, right):
 
         merged.set_tile(coord, merged_movables + merged_turfs + merged_areas)
 
-    merged = mapmerge.merge_map(merged, base)
+    merged = mapmerge.merge_map(merged, base) # is this necessary or correct?
+    merged = mapmerge.merge_map(merged, left)
     return trouble, merged
 
 


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #7936 Basically what's changing is that we're now comparing the map bytes for the index unchanged so that the lint will more reliably flag the person who isn't committing the map with hooks. Instead its been getting flagged by other PRs as changes to maps get made on master.

I have also opted to just for loop the parents in the situation of a merge commit. Previously this was sometimes just making it go back two commits when I intended it to be handling for merge commits specifically. I just am not confident that the parent I want is always HEAD^2 anymore.

Additionally, the testing should only now be performed if the diff indicates that a map has been changed.

The change to the merge driver is because it seems the end result of a merge isn't the same as what the pre-commit hook or fixup does. I'm not sure the line `merged = mapmerge.merge_map(merged, base)` is necessary, but it doesn't hurt to keep it.

MDB ignore just because I also did some testing on github runners.

# Explain why it's good for the game

Hopefully more accurate testing for mappers and PRs that don't touch maps should not be flagged.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

See commit/action history for results of Run Linters actions. Force pushes were to undo merge tests.

Scenarios I attempted to recreate on runner:
- Bad map change (no hooks) -> Fixup -> Merge (no hooks)
- Bad map change (no hooks) -> Merge (no hooks) -> Fixup

# Changelog

No player facing changes.
