### PR TITLE
Fixes the `rounds` DB table

### DIFF
--- a/code/datums/statistics/entities/round_stats.dm
+++ b/code/datums/statistics/entities/round_stats.dm
@@ -93,7 +93,6 @@
 
 /datum/game_mode/proc/setup_round_stats()
 	if(!round_stats)
-		var/datum/entity/mc_round/mc_round = SSentity_manager.select(/datum/entity/mc_round)
 		var/operation_name
 		operation_name = "[pick(GLOB.operation_titles)]"
 		operation_name += " [pick(GLOB.operation_prefixes)]"
@@ -102,7 +101,7 @@
 		// Round stats
 		round_stats = DB_ENTITY(/datum/entity/statistic/round)
 		round_stats.round_name = operation_name
-		round_stats.round_id = mc_round.id
+		round_stats.round_id = GLOB.round_id
 		round_stats.map_name = SSmapping.configs[GROUND_MAP].map_name
 		round_stats.game_mode = name
 		round_stats.real_time_start = world.realtime
@@ -242,7 +241,6 @@
 			track_final_participant(M.faction)
 
 	save()
-	detach()
 
 /datum/entity/statistic/round/proc/track_hijack_participant(faction, amount = 1)
 	if(!faction)

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -656,6 +656,8 @@
 	add_current_round_status_to_end_results("Round End")
 	handle_round_results_statistics_output()
 
+	GLOB.round_statistics?.save()
+
 	return 1
 
 // for the toolbox

--- a/code/game/gamemodes/colonialmarines/huntergames.dm
+++ b/code/game/gamemodes/colonialmarines/huntergames.dm
@@ -419,7 +419,7 @@
 		GLOB.round_statistics.end_round_player_population = count_humans()
 
 		GLOB.round_statistics.log_round_statistics()
-
+		GLOB.round_statistics.save()
 
 	return 1
 

--- a/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
+++ b/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
@@ -298,11 +298,10 @@
 		GLOB.round_statistics.game_mode = name
 		GLOB.round_statistics.round_length = world.time
 		GLOB.round_statistics.end_round_player_population = length(GLOB.clients)
-
 		GLOB.round_statistics.log_round_statistics()
+		GLOB.round_statistics.save()
 
-		round_finished = 1
-
+	round_finished = 1
 	calculate_end_statistics()
 
 

--- a/code/game/gamemodes/colonialmarines/xenovsxeno.dm
+++ b/code/game/gamemodes/colonialmarines/xenovsxeno.dm
@@ -277,6 +277,7 @@
 	calculate_end_statistics()
 	declare_fun_facts()
 
+	GLOB.round_statistics?.save()
 
 	return TRUE
 

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -47,5 +47,6 @@
 	declare_completion_announce_predators()
 	declare_completion_announce_medal_awards()
 
+	GLOB.round_statistics?.save()
 
 	return TRUE

--- a/code/game/gamemodes/extended/infection.dm
+++ b/code/game/gamemodes/extended/infection.dm
@@ -128,5 +128,6 @@
 	declare_completion_announce_predators()
 	declare_completion_announce_medal_awards()
 
+	GLOB.round_statistics?.save()
 
 	return 1


### PR DESCRIPTION

# About the pull request

This thing was entirely broken. `round_id`, `real_time_end`, `round_result`, and `end_round_player_population` weren't being filled correctly.

This solution sets the value of anything 0 to NULL in the row and I have not a clue why. I can work around this w/ my queries but if anyone knows why this happens please tell me.

![image](https://github.com/user-attachments/assets/d0d2a20b-6436-4b6e-bc6b-c0d3044b47f0)
