### PR TITLE
Adds (likely) missed burst fire-delay for IFF M46C

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -611,6 +611,7 @@
 	. = ..()
 	if(iff_enabled)
 		modify_fire_delay(FIRE_DELAY_TIER_12)
+		modify_burst_delay(FIRE_DELAY_TIER_12)
 
 /obj/item/weapon/gun/rifle/m46c/proc/name_after_co(mob/living/carbon/human/H)
 	linked_human = H


### PR DESCRIPTION

# About the pull request

This was missed I think. Normally you couldn't use burst on IFF, but you can now.

# Explain why it's good for the game

oversights bad


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: M46C has slower fire-rate on burst IFF mode
/:cl:
