### PR TITLE
Lifeboat launch now checks for held ID

### DIFF
--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -416,9 +416,10 @@
 
 				var/mob/living/carbon/human/human_user = user
 				var/obj/item/card/id/card1 = human_user.get_idcard()
+				var/obj/item/card/id/card2 = human_user.get_idcard()
 
 				if(!card1 || (!(ACCESS_MARINE_SENIOR in card1.access) && !(ACCESS_MARINE_DROPSHIP in card1.access))) // if no card or not enough access, check for held id
-					var/obj/item/card/id/card2 = locate(/obj/item/card/id) in human_user
+					card2 = locate(/obj/item/card/id) in human_user
 
 				if(!card2 || (!(ACCESS_MARINE_SENIOR in card2.access) && !(ACCESS_MARINE_DROPSHIP in card2.access))) // still no valid card found?
 					to_chat(user, SPAN_NOTICE("[src]'s screen says \"Unauthorized access. Please inform your supervisor\"."))

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -415,13 +415,12 @@
 					return
 
 				var/mob/living/carbon/human/human_user = user
-				var/obj/item/card/id/card1 = human_user.get_idcard()
-				var/obj/item/card/id/card2 = human_user.get_idcard()
+				var/obj/item/card/id/card = human_user.get_idcard()
 
-				if(!card1 || (!(ACCESS_MARINE_SENIOR in card1.access) && !(ACCESS_MARINE_DROPSHIP in card1.access))) // if no card or not enough access, check for held id
-					card2 = locate(/obj/item/card/id) in human_user
+				if(!card || (!(ACCESS_MARINE_SENIOR in card.access) && !(ACCESS_MARINE_DROPSHIP in card.access))) // if no card or not enough access, check for held id
+					card = locate(/obj/item/card/id) in human_user
 
-				if(!card2 || (!(ACCESS_MARINE_SENIOR in card2.access) && !(ACCESS_MARINE_DROPSHIP in card2.access))) // still no valid card found?
+				if(!card || (!(ACCESS_MARINE_SENIOR in card.access) && !(ACCESS_MARINE_DROPSHIP in card.access))) // still no valid card found?
 					to_chat(user, SPAN_NOTICE("[src]'s screen says \"Unauthorized access. Please inform your supervisor\"."))
 					return
 

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -418,10 +418,7 @@
 				var/obj/item/card/id/card = human_user.get_idcard()
 
 				if(!card) // if no card is worn, check for held id
-					for(var/obj/item/held_item in human_user.contents)
-						if(istype(held_item, /obj/item/card/id))
-							card = held_item // held id is set as the card
-							break
+					card = locate(/obj/item/card/id) in human_user
 
 				if(!card) // still no card found?
 					to_chat(user, SPAN_NOTICE("[src]'s screen says \"Unauthorized access. Please inform your supervisor\"."))

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -417,7 +417,13 @@
 				var/mob/living/carbon/human/human_user = user
 				var/obj/item/card/id/card = human_user.get_idcard()
 
-				if(!card)
+				if(!card) // if no card is worn, check for held id
+					for(var/obj/item/held_item in human_user.contents)
+						if(istype(held_item, /obj/item/card/id))
+							card = held_item // held id is set as the card
+							break
+
+				if(!card) // still no card found?
 					to_chat(user, SPAN_NOTICE("[src]'s screen says \"Unauthorized access. Please inform your supervisor\"."))
 					return
 

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -415,16 +415,12 @@
 					return
 
 				var/mob/living/carbon/human/human_user = user
-				var/obj/item/card/id/card = human_user.get_idcard()
+				var/obj/item/card/id/card1 = human_user.get_idcard()
 
-				if(!card) // if no card is worn, check for held id
-					card = locate(/obj/item/card/id) in human_user
+				if(!card1 || (!(ACCESS_MARINE_SENIOR in card1.access) && !(ACCESS_MARINE_DROPSHIP in card1.access))) // if no card or not enough access, check for held id
+					var/obj/item/card/id/card2 = locate(/obj/item/card/id) in human_user
 
-				if(!card) // still no card found?
-					to_chat(user, SPAN_NOTICE("[src]'s screen says \"Unauthorized access. Please inform your supervisor\"."))
-					return
-
-				if(!(ACCESS_MARINE_SENIOR in card.access) && !(ACCESS_MARINE_DROPSHIP in card.access))
+				if(!card2 || (!(ACCESS_MARINE_SENIOR in card2.access) && !(ACCESS_MARINE_DROPSHIP in card2.access))) // still no valid card found?
 					to_chat(user, SPAN_NOTICE("[src]'s screen says \"Unauthorized access. Please inform your supervisor\"."))
 					return
 


### PR DESCRIPTION

# About the pull request

Previously you had to be wearing the ID properly, now you can also hold the ID

# Explain why it's good for the game

edge cases accounted for


# Testing Photographs and Procedure
tested it on local, worked

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Previously you had to be wearing a valid ID to launch a lifeboat, now you can also hold it in hand
/:cl:
