### PR TITLE
Fixes new players being teleported into ground z level

### DIFF
--- a/code/game/turfs/space.dm
+++ b/code/game/turfs/space.dm
@@ -77,6 +77,9 @@
 
 /turf/open/space/Entered(atom/movable/A)
 	..()
+	if(isnewplayer(A))
+		return
+
 	if ((!(A) || src != A.loc)) return
 
 	inertial_drift(A)


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
They should stay in admin z level (an example of why this is problematic is evo screeches being heard in lobby)
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixes new players being teleported into the ground z level
/:cl:
