### PR TITLE
Reverts #8425, makes active claymores layer above (almost) all items so they cannot be hidden.

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -54,6 +54,10 @@
 #define COMSIG_KB_HUMAN_ROTATE_CHAIR "keybinding_human_rotate_chair"
 #define COMSIG_KB_HUMAN_SHOW_HELD_ITEM "keybinding_human_show_held_item"
 #define COMSIG_KB_HUMAN_CYCLE_HELMET_HUD "keybinding_human_cycle_helmet_hud"
+#define COMSIG_KB_HUMAN_PIXEL_SHIFT_GRABBED_NORTH "keybinding_human_pixel_shift_grabbed_north"
+#define COMSIG_KB_HUMAN_PIXEL_SHIFT_GRABBED_SOUTH "keybinding_human_pixel_shift_grabbed_south"
+#define COMSIG_KB_HUMAN_PIXEL_SHIFT_GRABBED_EAST "keybinding_human_pixel_shift_grabbed_east"
+#define COMSIG_KB_HUMAN_PIXEL_SHIFT_GRABBED_WEST "keybinding_human_pixel_shift_grabbed_west"
 
 // Human Inventory Navigation
 #define COMSIG_KB_HUMAN_INTERACT_OTHER_HAND "keybinding_human_interact_other_hand"

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -135,3 +135,97 @@
 	cycle_action?.set_action_overlay(cycled_hud)
 
 	return TRUE
+
+/datum/keybinding/human/pixel_shift
+	hotkey_keys = list("Unbound")
+	classic_keys = list("Unbound")
+
+/datum/keybinding/human/pixel_shift/can_use(client/user)
+	. = ..()
+	if(!.)
+		return
+
+	var/mob/living/carbon/human/human_user = user.mob
+	var/obj/item/grab/grab = human_user.get_active_hand()
+	if(!istype(grab))
+		return FALSE
+	var/obj/grabbed_atom = grab.grabbed_thing
+	if(ismob(grabbed_atom))
+		return FALSE
+	if(grabbed_atom.anchored)
+		return FALSE
+	if(istype(grabbed_atom, /obj/structure))
+		return FALSE
+	return TRUE
+
+/datum/keybinding/human/pixel_shift/north
+	name = "pixel_shift_grabbed_north"
+	full_name = "Pixel Shift Grabbed - North"
+	keybind_signal = COMSIG_KB_HUMAN_PIXEL_SHIFT_GRABBED_NORTH
+
+/datum/keybinding/human/pixel_shift/north/down(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/living/carbon/human/human_user = user.mob
+	var/obj/item/grab/grab = human_user.get_active_hand()
+	var/obj/grabbed = grab.grabbed_thing
+
+	if(grabbed.pixel_y >= 16)
+		return
+	grabbed.pixel_y += 1
+	return TRUE
+
+/datum/keybinding/human/pixel_shift/south
+	name = "pixel_shift_grabbed_south"
+	full_name = "Pixel Shift Grabbed - South"
+	keybind_signal = COMSIG_KB_HUMAN_PIXEL_SHIFT_GRABBED_SOUTH
+
+/datum/keybinding/human/pixel_shift/south/down(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/living/carbon/human/human_user = user.mob
+	var/obj/item/grab/grab = human_user.get_active_hand()
+	var/obj/grabbed = grab.grabbed_thing
+
+	if(grabbed.pixel_y <= -16)
+		return
+	grabbed.pixel_y -= 1
+	return TRUE
+
+/datum/keybinding/human/pixel_shift/east
+	name = "pixel_shift_grabbed_east"
+	full_name = "Pixel Shift Grabbed - East"
+	keybind_signal = COMSIG_KB_HUMAN_PIXEL_SHIFT_GRABBED_EAST
+
+/datum/keybinding/human/pixel_shift/east/down(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/living/carbon/human/human_user = user.mob
+	var/obj/item/grab/grab = human_user.get_active_hand()
+	var/obj/grabbed = grab.grabbed_thing
+
+	if(grabbed.pixel_x >= 16)
+		return
+	grabbed.pixel_x += 1
+	return TRUE
+
+/datum/keybinding/human/pixel_shift/west
+	name = "pixel_shift_grabbed_west"
+	full_name = "Pixel Shift Grabbed - West"
+	keybind_signal = COMSIG_KB_HUMAN_PIXEL_SHIFT_GRABBED_WEST
+
+/datum/keybinding/human/pixel_shift/west/down(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/living/carbon/human/human_user = user.mob
+	var/obj/item/grab/grab = human_user.get_active_hand()
+	var/obj/grabbed = grab.grabbed_thing
+
+	if(grabbed.pixel_x <= -16)
+		return
+	grabbed.pixel_x -= 1
+	return TRUE

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -8,7 +8,7 @@
 	icon_state = "m20"
 	force = 5
 	w_class = SIZE_SMALL
-	//layer = MOB_LAYER - 0.1 //You can't just randomly hide claymores under boxes. Booby-trapping bodies is fine though
+	layer = MOB_LAYER - 0.1 //You can't just randomly hide claymores under boxes. Booby-trapping bodies is fine though
 	throwforce = 5
 	throw_range = 6
 	throw_speed = SPEED_VERY_FAST
@@ -299,7 +299,6 @@
 	icon_state = "m20_active"
 	base_icon_state = "m20"
 	map_deployed = TRUE
-	layer = 4 //layer is this high so that hopefully:tm: you cannot hide it and pixel shift items on top of it
 
 /obj/item/explosive/mine/no_iff
 	iff_signal = null

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -299,6 +299,7 @@
 	icon_state = "m20_active"
 	base_icon_state = "m20"
 	map_deployed = TRUE
+	layer = 4 //layer is this high so that hopefully:tm: you cannot hide it and pixel shift items on top of it
 
 /obj/item/explosive/mine/no_iff
 	iff_signal = null


### PR DESCRIPTION

# About the pull request

Re-adds pixel shifting and makes it so claymores only appear under mobs (and whatever else is layered above mobs)

# Explain why it's good for the game

Nuking an entire feature because you died and not even looking to see how you can fix the root problem is bad, which is basically what  #8425 did.
While I am not disparaging the idea behind the PR, it *was* a good idea, you shouldn't be able to hide claymores, it's scummy.
The issue I have with the PR is that it took the nuclear route and the execution was near-abysmal.

On top of this, there is a PR up right now reworking Yautja Ship that utilizes, dare i say requires pixel shifting as a mechanic for the trophy racks.

There is no reason this should have been nuked when we apparently ALREADY had commented out code that would solve this instantly.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/c0da405b-0596-4b73-af25-2d0c427aa91b)

</details>


# Changelog
:cl:
add: Re-Added Pixel Shifting.
balance: Claymores will now appear above all items and cannot be hidden by them, you can however still trap bodies and tall grass.
/:cl:
