### PR TITLE
Nerfs sentinel

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/sentinel/sentinel_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/sentinel/sentinel_abilities.dm
@@ -15,7 +15,7 @@
 	macro_path = /datum/action/xeno_action/verb/verb_scattered_spit
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_2
-	xeno_cooldown = 6 SECONDS
+	xeno_cooldown = 7 SECONDS
 	plasma_cost = 30
 
 // Paralyzing slash

--- a/code/modules/mob/living/carbon/xenomorph/castes/Sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Sentinel.dm
@@ -68,7 +68,7 @@
 	// State
 	var/next_slash_buffed = FALSE
 
-#define NEURO_TOUCH_DELAY 3 SECONDS
+#define NEURO_TOUCH_DELAY 4 SECONDS
 
 /datum/behavior_delegate/sentinel_base/melee_attack_modify_damage(original_damage, mob/living/carbon/carbon_target)
 	if (!next_slash_buffed)
@@ -112,6 +112,6 @@
 		return INTENT_HARM
 
 /datum/behavior_delegate/sentinel_base/proc/paralyzing_slash(mob/living/carbon/human/human_target)
-	human_target.KnockDown(2.5)
-	human_target.Stun(2.5)
+	human_target.KnockDown(2)
+	human_target.Stun(2)
 	to_chat(human_target, SPAN_XENOHIGHDANGER("You fall over, paralyzed by the toxin!"))


### PR DESCRIPTION
# About the pull request

Nerfs sentinels knockdown back to 2 instead of 2.5
Nerfs sentinels scatterspit cd to 7, not 8 like the old one but 7 where its a middle ground.
Nerfs sentinels para slash drop back to 4 seconds.
# Explain why it's good for the game

#7483
#7197
These two prs made sentinel very overpowered.
I believe that a 2.5 stun (as long as a lurker, off by .5) is NOT good for a tier one, there is quite literally no other caste that is as safe and as strong as sentinel right now, sentinel could reliably capture without these buffs and they most certainly still will be able to. With the difference now that you wont instnatly go down and forever, meaning the sentinel has to actually have a funcitoning strategy instead of just run at you.

The scatter spit is still VERY accurate, it will still always hit unless youre spitting at edge of the screen, meaning you can still follow up with a slash.

Also the goldendarkness55 pr was not closed even though he was CBANNED


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance : Nerfs sentinels knockdown back to 2 instead of 2.5
balance : Nerfs sentinels scatterspit cd to 7, not 8 like the old one but 7 where its a middle ground.
balance : Nerfs sentinels para slash drop back to 4 seconds.
/:cl:
