### PR TITLE
Young Blood Prefrence Menu

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -3,6 +3,7 @@
 #define MENU_CO "co"
 #define MENU_SYNTHETIC "synth"
 #define MENU_YAUTJA "yautja"
+#define MENU_YOUNGBLOOD "youngblood"
 #define MENU_MENTOR "mentor"
 #define MENU_SETTINGS "settings"
 #define MENU_SPECIAL "special"
@@ -42,6 +43,8 @@ GLOBAL_LIST_INIT(be_special_flags, list(
 	var/static/datum/loadout_picker/loadout_picker = new
 
 	var/static/datum/pred_picker/pred_picker = new
+
+	var/static/datum/young_blood_picker/young_blood_picker = new
 
 	//doohickeys for savefiles
 	var/path
@@ -357,6 +360,8 @@ GLOBAL_LIST_INIT(be_special_flags, list(
 		dat += "<a[current_menu == MENU_SYNTHETIC ? " class='linkOff'" : ""] href=\"byond://?src=\ref[user];preference=change_menu;menu=[MENU_SYNTHETIC]\"><b>Synthetic</b></a> - "
 	if(owner.check_whitelist_status(WHITELIST_YAUTJA))
 		dat += "<a[current_menu == MENU_YAUTJA ? " class='linkOff'" : ""] href=\"byond://?src=\ref[user];preference=yautja\"><b>Yautja</b></a> - "
+	if(!owner.check_whitelist_status(WHITELIST_YAUTJA))
+		dat += "<a[current_menu == MENU_YOUNGBLOOD ? " class='linkOff'" : ""] href=\"byond://?src=\ref[user];preference=youngblood\"><b>Young Blood</b></a> - "
 	if(owner.check_whitelist_status(WHITELIST_MENTOR))
 		dat += "<a[current_menu == MENU_MENTOR ? " class='linkOff'" : ""] href=\"byond://?src=\ref[user];preference=change_menu;menu=[MENU_MENTOR]\"><b>Mentor</b></a> - "
 	dat += "<a[current_menu == MENU_SETTINGS ? " class='linkOff'" : ""] href=\"byond://?src=\ref[user];preference=change_menu;menu=[MENU_SETTINGS]\"><b>Settings</b></a> - "
@@ -1979,6 +1984,13 @@ GLOBAL_LIST_INIT(be_special_flags, list(
 					pred_picker.tgui_interact(user)
 					return
 
+				if("youngblood")
+					if(owner.check_whitelist_status(WHITELIST_PREDATOR))
+						return
+
+					young_blood_picker.tgui_interact(user)
+					return
+
 	ShowChoices(user)
 	return 1
 
@@ -2305,6 +2317,7 @@ GLOBAL_LIST_INIT(be_special_flags, list(
 #undef MENU_CO
 #undef MENU_SYNTHETIC
 #undef MENU_YAUTJA
+#undef MENU_YOUNGBLOOD
 #undef MENU_MENTOR
 #undef MENU_SETTINGS
 #undef MENU_SPECIAL

--- a/code/modules/client/young_blood_picker.dm
+++ b/code/modules/client/young_blood_picker.dm
@@ -1,0 +1,198 @@
+/datum/young_blood_picker
+	var/list/skin_color_to_codes = list()
+
+/datum/young_blood_picker/New()
+	. = ..()
+
+	for(var/color in PRED_SKIN_COLOR)
+		var/pred_icon = /datum/species/yautja::icobase
+
+		var/icon/icon = icon(pred_icon, "[color]_torso_pred_m")
+		var/hex = icon.GetPixel(icon.Width() / 2, icon.Height() / 2)
+
+		if(!hex)
+			CRASH("Unable to get the skin color code for [color] in [pred_icon].")
+
+		skin_color_to_codes[color] = hex
+
+
+/datum/young_blood_picker/ui_static_data(mob/user)
+	. = ..()
+
+	var/datum/entity/player/player = user.client?.player_data
+	if(!player)
+		return
+
+	.["hair_icon"] = /datum/sprite_accessory/yautja_hair::icon
+
+	.["hair_styles"] = list()
+	for(var/key in GLOB.yautja_hair_styles_list)
+		var/datum/sprite_accessory/yautja_hair/hair = GLOB.yautja_hair_styles_list[key]
+		if(!hair.selectable)
+			continue
+
+		.["hair_styles"] += list(
+			list("name" = hair.name, "icon" = hair.icon_state)
+		)
+
+	.["skin_colors"] = skin_color_to_codes
+
+	.["armor_icon"] = /obj/item/clothing/suit/armor/yautja::icon
+	.["armor_types"] = PRED_ARMOR_TYPE_MAX
+
+	.["mask_icon"] = /obj/item/clothing/mask/gas/yautja/hunter::icon
+	.["mask_types"] = PRED_MASK_TYPE_MAX
+
+	.["greave_icon"] = /obj/item/clothing/shoes/yautja/hunter::icon
+	.["greave_types"] = PRED_GREAVE_TYPE_MAX
+
+	.["mask_accessory_icon"] = /obj/item/clothing/accessory/mask::icon
+	.["mask_accessory_types"] = PRED_MASK_ACCESSORY_TYPE_MAX
+
+	.["materials"] = PRED_MATERIALS
+	.["translators"] = PRED_TRANSLATORS
+
+
+/datum/young_blood_picker/ui_data(mob/user)
+	. = ..()
+
+	var/datum/preferences/prefs = user.client?.prefs
+	if(!prefs)
+		return
+
+	.["gender"] = prefs.predator_gender
+	.["age"] = prefs.predator_age
+	.["hair_style"] = prefs.predator_h_style
+	.["skin_color"] = prefs.predator_skin_color
+
+	.["translator_type"] = prefs.predator_translator_type
+
+	.["armor_type"] = prefs.predator_armor_type
+	.["armor_material"] = prefs.predator_armor_material
+
+	.["greave_type"] = prefs.predator_boot_type
+	.["greave_material"] = prefs.predator_greave_material
+
+	.["mask_type"] = prefs.predator_mask_type
+	.["mask_material"] = prefs.predator_mask_material
+
+	.["mask_accessory_type"] = prefs.predator_accessory_type
+
+/datum/young_blood_picker/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+
+	var/datum/preferences/prefs = ui.user.client?.prefs
+	if(!prefs)
+		return
+
+	switch(action)
+
+		if("gender")
+			prefs.predator_gender = prefs.predator_gender == FEMALE ? MALE : FEMALE
+
+		if("age")
+			var/age = params["age"]
+			if(!isnum(age))
+				return
+
+			age = clamp(age, 100, 150)
+			if(!age)
+				return
+
+			prefs.predator_age = age
+
+		if("skin_color")
+			var/skin_color = params["color"]
+			if(!skin_color || !(skin_color in PRED_SKIN_COLOR))
+				return
+
+			prefs.predator_skin_color = skin_color
+
+		if("hair_style")
+			var/picked = params["name"]
+			if(!picked)
+				return
+
+			var/datum/sprite_accessory/yautja_hair/hair = GLOB.yautja_hair_styles_list[picked]
+			if(!hair)
+				return
+
+			prefs.predator_h_style = picked
+
+		if("armor_type")
+			var/armor = params["type"]
+			if(!armor || !isnum(armor))
+				return
+
+			armor = clamp(armor, 1, PRED_ARMOR_TYPE_MAX)
+			prefs.predator_armor_type = armor
+
+		if("armor_material")
+			var/material = params["material"]
+			if(!material || !(material in PRED_MATERIALS))
+				return
+
+			prefs.predator_armor_material = material
+
+		if("mask_type")
+			var/mask = params["type"]
+			if(!mask || !isnum(mask))
+				return
+
+			mask = clamp(mask, 1, PRED_MASK_TYPE_MAX)
+			prefs.predator_mask_type = mask
+
+		if("mask_material")
+			var/material = params["material"]
+			if(!material || !(material in PRED_MATERIALS))
+				return
+
+			prefs.predator_mask_material = material
+
+		if("greaves_type")
+			var/greaves = params["type"]
+			if(!greaves || !isnum(greaves))
+				return
+
+			greaves = clamp(greaves, 1, PRED_GREAVE_TYPE_MAX)
+			prefs.predator_boot_type = greaves
+
+		if("greaves_material")
+			var/material = params["material"]
+			if(!material || !(material in PRED_MATERIALS))
+				return
+
+			prefs.predator_greave_material = material
+
+		if("mask_accessory")
+			var/accessory = params["type"]
+			if(isnull(accessory) || !isnum(accessory))
+				return
+
+			accessory = clamp(accessory, 0, PRED_MASK_ACCESSORY_TYPE_MAX)
+			prefs.predator_accessory_type = accessory
+
+		if("translator_type")
+			var/selected = params["selected"]
+			if(!selected || !(selected in PRED_TRANSLATORS))
+				return
+
+			prefs.predator_translator_type = selected
+
+	prefs.update_preview_icon()
+	return TRUE
+
+/datum/young_blood_picker/tgui_interact(mob/user, datum/tgui/ui)
+	. = ..()
+
+	ui = SStgui.try_update_ui(user, src, ui)
+
+	if(!ui)
+		ui = new(user, src, "YoungBloodPicker", "Young Blood Preferences")
+		ui.open()
+		ui.set_autoupdate(FALSE)
+
+	winset(user, ui.window.id, "focus=true")
+
+/datum/young_blood_picker/ui_state(mob/user)
+	return GLOB.always_state

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -1629,6 +1629,7 @@
 #include "code\modules\client\statbrowser_options.dm"
 #include "code\modules\client\tgui_macro.dm"
 #include "code\modules\client\traits_picker.dm"
+#include "code\modules\client\young_blood_picker.dm"
 #include "code\modules\clothing\clothing.dm"
 #include "code\modules\clothing\clothing_accessories.dm"
 #include "code\modules\clothing\clothing_helpers.dm"

--- a/tgui/packages/tgui/interfaces/YoungBloodPicker.tsx
+++ b/tgui/packages/tgui/interfaces/YoungBloodPicker.tsx
@@ -1,0 +1,495 @@
+import { capitalizeFirst } from 'common/string';
+import { useState } from 'react';
+
+import { useBackend } from '../backend';
+import {
+  Button,
+  ColorBox,
+  DmIcon,
+  Icon,
+  LabeledList,
+  Modal,
+  NumberInput,
+  Section,
+  Stack,
+} from '../components';
+import { Window } from '../layouts';
+import { HairPickerElement } from './HairPicker';
+
+type YoungbloodData = {
+  gender: string;
+  age: number;
+  hair_style: string;
+  skin_color: string;
+
+  translator_type: string;
+
+  armor_icon: string;
+  armor_type: number;
+  armor_types: number;
+  armor_material: string;
+
+  mask_icon: string;
+  mask_type: number;
+  mask_types: number;
+  mask_material: string;
+
+  greave_icon: string;
+  greave_type: number;
+  greave_types: number;
+  greave_material: string;
+
+  mask_accessory_icon: string;
+  mask_accessory_type: number;
+  mask_accessory_types: number;
+
+  hair_icon: string;
+  hair_styles: { name: string; icon: string }[];
+
+  skin_colors: { [key: string]: string };
+
+  materials: string[];
+  translators: string[];
+};
+
+type ModalOptions =
+  | 'hair'
+  | 'skin'
+  | 'armor'
+  | 'greaves'
+  | 'mask'
+  | 'mask_accessory';
+
+export const YoungBloodPicker = () => {
+  const { data, act } = useBackend<YoungbloodData>();
+
+  const {
+    gender,
+    age,
+    hair_icon,
+    hair_style,
+    hair_styles,
+    skin_colors,
+    skin_color,
+  } = data;
+
+  const selectedHair = hair_styles.filter(
+    (hair) => hair.name === hair_style,
+  )[0];
+
+  const [modal, setModal] = useState<ModalOptions | false>(false);
+
+  return (
+    <Window height={600} width={700} theme="ntos_spooky">
+      <Window.Content className="YoungBloodPicker">
+        <Section title="Young Blood Information">
+          <Stack>
+            <Stack.Item>
+              <LabeledList>
+                <LabeledList.Item label="Gender">
+                  <Button onClick={() => act('gender')}>
+                    {capitalizeFirst(gender)}
+                  </Button>
+                </LabeledList.Item>
+                <LabeledList.Item label="Age">
+                  <NumberInput
+                    value={age}
+                    minValue={100}
+                    maxValue={150}
+                    onChange={(val) => act('age', { age: val })}
+                  />
+                </LabeledList.Item>
+              </LabeledList>
+            </Stack.Item>
+            <Stack.Item>
+              <LabeledList>
+                <LabeledList.Item label="Skin Color">
+                  <Button onClick={() => setModal('skin')}>
+                    <ColorBox color={skin_colors[skin_color]} />
+                  </Button>
+                </LabeledList.Item>
+              </LabeledList>
+            </Stack.Item>
+            <Stack.Item>
+              <Button tooltip="Select Quill" onClick={() => setModal('hair')}>
+                <DmIcon
+                  icon={hair_icon}
+                  icon_state={`${selectedHair.icon}_s`}
+                  width="64px"
+                />
+              </Button>
+            </Stack.Item>
+          </Stack>
+        </Section>
+
+        <Section title="Equipment">
+          <PredEquipment pick={setModal} />
+        </Section>
+        {modal && (
+          <Modal>
+            <PredModal type={modal} close={() => setModal(false)} />
+          </Modal>
+        )}
+      </Window.Content>
+    </Window>
+  );
+};
+
+const PredEquipment = (props: { readonly pick: (_: ModalOptions) => void }) => {
+  const { pick } = props;
+
+  const { act, data } = useBackend<YoungbloodData>();
+
+  const {
+    armor_icon,
+    armor_type,
+    armor_material,
+
+    mask_icon,
+    mask_type,
+    mask_material,
+
+    greave_icon,
+    greave_type,
+    greave_material,
+
+    mask_accessory_icon,
+    mask_accessory_type,
+    mask_accessory_types,
+
+    translators,
+    translator_type,
+  } = data;
+
+  return (
+    <Stack vertical>
+      <Stack.Item>
+        <Stack fill>
+          <Stack.Item grow>
+            <Button
+              fluid
+              tooltip="Customize Armor"
+              onClick={() => pick('armor')}
+            >
+              <Stack justify="center">
+                <Stack.Item>
+                  <DmIcon
+                    icon={armor_icon}
+                    icon_state={`halfarmor${armor_type}_${armor_material}`}
+                    height="128px"
+                  />
+                </Stack.Item>
+              </Stack>
+            </Button>
+          </Stack.Item>
+          <Stack.Item grow>
+            <Button fluid tooltip="Customize Mask" onClick={() => pick('mask')}>
+              <Stack justify="center">
+                <Stack.Item>
+                  <DmIcon
+                    icon={mask_icon}
+                    icon_state={`pred_mask${mask_type}_${mask_material}`}
+                    height="128px"
+                  />
+                </Stack.Item>
+              </Stack>
+            </Button>
+          </Stack.Item>
+          <Stack.Item grow>
+            <Button
+              fluid
+              tooltip="Customize Greaves"
+              onClick={() => pick('greaves')}
+            >
+              <Stack justify="center">
+                <Stack.Item>
+                  <DmIcon
+                    icon={greave_icon}
+                    icon_state={`y-boots${greave_type}_${greave_material}`}
+                    height="128px"
+                  />
+                </Stack.Item>
+              </Stack>
+            </Button>
+          </Stack.Item>
+        </Stack>
+      </Stack.Item>
+
+      <Stack.Item>
+        <Stack fill>
+          <Stack.Item grow>
+            <Button
+              fluid
+              height={11}
+              tooltip="Select Mask Accessory"
+              onClick={() => pick('mask_accessory')}
+            >
+              <Stack justify="center">
+                <Stack.Item>
+                  {mask_accessory_type > 0 ? (
+                    <DmIcon
+                      icon={mask_accessory_icon}
+                      icon_state={`pred_accessory${mask_accessory_types}_${mask_material}`}
+                      height="128px"
+                    />
+                  ) : (
+                    <Icon name="x" size={5} mt={5} />
+                  )}
+                </Stack.Item>
+              </Stack>
+            </Button>
+          </Stack.Item>
+        </Stack>
+      </Stack.Item>
+    </Stack>
+  );
+};
+
+const PredItem = (props: {
+  readonly title: string;
+  readonly icon: string;
+  readonly selected_type: number;
+  readonly selected_material: string;
+  readonly available_types: number;
+  readonly prefix: string;
+  readonly close: () => void;
+  readonly action: string;
+}) => {
+  const { act, data } = useBackend<YoungbloodData>();
+
+  const {
+    icon,
+    selected_type,
+    selected_material,
+    available_types,
+    prefix,
+    title,
+    close,
+    action,
+  } = props;
+
+  const { materials } = data;
+
+  return (
+    <Section
+      title={title}
+      buttons={<Button icon="x" onClick={() => close()} />}
+    >
+      <Stack>
+        <Stack.Item style={{ backgroundColor: '#66031C' }}>
+          <DmIcon
+            icon={icon}
+            icon_state={`${prefix}${selected_type}_${selected_material}`}
+            height="128px"
+          />
+        </Stack.Item>
+        <Stack.Item>
+          <Stack vertical>
+            <Stack.Item>
+              <Stack wrap width="500px">
+                {Array.from({ length: available_types }).map((num, i) => (
+                  <Button
+                    tooltip={i + 1}
+                    selected={selected_type === i + 1}
+                    key={i}
+                    onClick={() => act(`${action}_type`, { type: i + 1 })}
+                  >
+                    <DmIcon
+                      icon={icon}
+                      icon_state={`${prefix}${i + 1}_${selected_material}`}
+                      height="64px"
+                    />
+                  </Button>
+                ))}
+              </Stack>
+            </Stack.Item>
+            <Stack.Item>
+              <Stack>
+                {materials.map((material) => (
+                  <Button
+                    key={material}
+                    tooltip={capitalizeFirst(material)}
+                    selected={selected_material === material}
+                    onClick={() =>
+                      act(`${action}_material`, { material: material })
+                    }
+                  >
+                    <DmIcon
+                      icon={icon}
+                      icon_state={`${prefix}${selected_type}_${material}`}
+                      height="64px"
+                    />
+                  </Button>
+                ))}
+              </Stack>
+            </Stack.Item>
+          </Stack>
+        </Stack.Item>
+      </Stack>
+    </Section>
+  );
+};
+
+const PredModal = (props: {
+  readonly type: ModalOptions;
+  readonly close: () => void;
+}) => {
+  const { type, close } = props;
+
+  const { data, act } = useBackend<YoungbloodData>();
+
+  const {
+    hair_icon,
+    hair_style,
+    hair_styles,
+
+    armor_icon,
+    armor_type,
+    armor_material,
+    armor_types,
+
+    mask_icon,
+    mask_type,
+    mask_material,
+    mask_types,
+
+    greave_icon,
+    greave_type,
+    greave_material,
+    greave_types,
+
+    mask_accessory_icon,
+    mask_accessory_type,
+    mask_accessory_types,
+
+    materials,
+  } = data;
+
+  switch (type) {
+    case 'hair':
+      return (
+        <HairPickerElement
+          name="Quill Style"
+          icon={hair_icon}
+          active={
+            hair_styles.filter((hair) => hair.name === hair_style)[0].icon
+          }
+          hair={hair_styles}
+          action={(style) => act('hair_style', style)}
+          close={() => close()}
+        />
+      );
+
+    case 'skin':
+      return <SkinColorPicker close={close} />;
+
+    case 'armor':
+      return (
+        <PredItem
+          title="Armor"
+          icon={armor_icon}
+          selected_type={armor_type}
+          selected_material={armor_material}
+          available_types={armor_types}
+          prefix="halfarmor"
+          close={close}
+          action="armor"
+        />
+      );
+    case 'greaves':
+      return (
+        <PredItem
+          title="Greaves"
+          icon={greave_icon}
+          selected_type={greave_type}
+          selected_material={greave_material}
+          available_types={greave_types}
+          prefix="y-boots"
+          close={close}
+          action="greaves"
+        />
+      );
+    case 'mask':
+      return (
+        <PredItem
+          title="Mask"
+          icon={mask_icon}
+          selected_type={mask_type}
+          selected_material={mask_material}
+          available_types={mask_types}
+          prefix="pred_mask"
+          close={close}
+          action="mask"
+        />
+      );
+
+    case 'mask_accessory':
+      return (
+        <Section
+          title="Mask Accessory"
+          width={40}
+          buttons={<Button icon="x" onClick={() => close()} />}
+        >
+          <Stack>
+            {Array.from({ length: mask_accessory_types + 1 }).map(
+              (_, index) => (
+                <Stack.Item key={index}>
+                  <Button
+                    tooltip={index === 0 ? 'Unequipped' : index}
+                    selected={mask_accessory_type === index}
+                    onClick={() => act('mask_accessory', { type: index })}
+                  >
+                    <Stack align="center">
+                      <Stack.Item width="96px" height="96px">
+                        {index === 0 ? (
+                          <Icon name="x" size={5} p={3} pl={6.5} />
+                        ) : (
+                          <DmIcon
+                            icon={mask_accessory_icon}
+                            icon_state={`pred_accessory${index}_${mask_material}`}
+                            width="96px"
+                          />
+                        )}
+                      </Stack.Item>
+                    </Stack>
+                  </Button>
+                </Stack.Item>
+              ),
+            )}
+          </Stack>
+        </Section>
+      );
+
+    default:
+      break;
+  }
+};
+
+const SkinColorPicker = (props: { readonly close: () => void }) => {
+  const { close } = props;
+
+  const { act, data } = useBackend<YoungbloodData>();
+  const { skin_colors, skin_color } = data;
+
+  return (
+    <Section
+      title="Skin Color"
+      buttons={<Button icon="x" onClick={() => close()} />}
+      p={2}
+    >
+      <Stack>
+        {Object.keys(skin_colors).map((color) => (
+          <Stack.Item key={color}>
+            <Button
+              p={1}
+              tooltip={capitalizeFirst(color)}
+              onClick={() => act('skin_color', { color: color })}
+            >
+              <ColorBox p={2} color={skin_colors[color]} />
+            </Button>
+          </Stack.Item>
+        ))}
+      </Stack>
+    </Section>
+  );
+};

--- a/tgui/packages/tgui/styles/interfaces/YoungBloodPicker.scss
+++ b/tgui/packages/tgui/styles/interfaces/YoungBloodPicker.scss
@@ -1,0 +1,13 @@
+.YoungBloodPicker {
+  .Stack--horizontal > .Picker:first-of-type {
+    margin-left: 6px;
+  }
+
+  .Picker.Active {
+    outline: 4px solid #aa2828;
+  }
+
+  .Picker img {
+    background: rgb(124, 37, 37);
+  }
+}


### PR DESCRIPTION

# About the pull request

* Adds a restricted menu in the lobby character setup for non WL Yautja, to customize their Yautja. Allowing youngbloods to customize themself. 

# Explain why it's good for the game

Customization is good. Youngbloods currently cant customize their pred at all.
This changes that whith giving non-WL a menu to customize their own Yautja.
WL Yautja, cannot see this menu. They get their full thing.

This menu is heavily restricted. Not allowing players to name themself or write a flavor text.
What this specificly allows is:
* Age between 100-150
* Skin color
* Gender
* Hair style
* Style for armor; mask; graves
* Color for armor; mask; graves
* Mask accessory

This Menu shares players prefrence saves with the proper WL Yautja menu.
What this means, is that all customisation done in the youngblood menue, will carry over to the WL Yautja menue if the player gains the WL.
Or: Both Menus use the same save slot.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![grafik](https://github.com/user-attachments/assets/154b9ce8-c6bc-4fb7-bfc3-0be473d9c226)


</details>


# Changelog
:cl:NHC
ui: Added a menu in character setup for non-wl to customize their youngblood yautja
/:cl:
