### PR TITLE
Fixes unpowered doors with proximity doors crushing xenos / people

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -786,6 +786,8 @@ GLOBAL_LIST_INIT(airlock_wire_descriptions, list(
 
 	for(var/turf/turf in locs)
 		for(var/mob/living/crushed in turf)
+			if(!arePowerSystemsOn() && forced)
+				return
 			if(HAS_TRAIT(crushed, TRAIT_SUPER_STRONG))
 				crushed.apply_damage(DOOR_CRUSH_DAMAGE, BRUTE)
 			else


### PR DESCRIPTION
# About the pull request
title

fixes: #8454


# Explain why it's good for the game

fix


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: You can no longer crush people with unpowered doors via crowbar
/:cl:
