### PR TITLE
Removes hunt/stalk from xeno ui

### DIFF
--- a/code/_onclick/hud/alien.dm
+++ b/code/_onclick/hud/alien.dm
@@ -6,7 +6,6 @@
 	ui_alien_datum = GLOB.custom_huds_list[HUD_ALIEN]
 
 	draw_act_intent(ui_alien_datum)
-	draw_mov_intent(ui_alien_datum)
 	draw_drop(ui_alien_datum)
 	draw_right_hand(ui_alien_datum)
 	draw_left_hand(ui_alien_datum)
@@ -76,7 +75,6 @@
 	..()
 	var/datum/custom_hud/alien/ui_alien_datum = GLOB.custom_huds_list[HUD_ALIEN]
 
-	draw_mov_intent(ui_alien_datum)
 	draw_healths(ui_alien_datum)
 	draw_alien_nightvision(ui_alien_datum)
 	draw_alien_locate_queen(ui_alien_datum)


### PR DESCRIPTION
# About the pull request

I dont think anybody uses this, im assuming this is leftover from pre moba era / agility mode

# Explain why it's good for the game
cleaner ui


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
del: Removes stalk/hunt mode ui button from xeno hud
/:cl:
