### PR TITLE
Fixes WO CO not being able to use the SG pamphlet

### DIFF
--- a/code/game/objects/items/pamphlets.dm
+++ b/code/game/objects/items/pamphlets.dm
@@ -115,7 +115,7 @@
 	trait = /datum/character_trait/skills/cosmartgun
 
 /obj/item/pamphlet/skill/cosmartgun/can_use(mob/living/carbon/human/user)
-	if(user.job != JOB_CO)
+	if(user.job != JOB_CO && user.job != JOB_WO_CO)
 		to_chat(user, SPAN_WARNING("Only the Commanding Officer can use this."))
 		return
 	return ..()


### PR DESCRIPTION

# About the pull request

fixes #8475


# Explain why it's good for the game

bugfix


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: WO commanding officer can now use the sg pamphlet
/:cl:
