### PR TITLE
Removed duplicate nightmare insert on big red

### DIFF
--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -27995,9 +27995,6 @@
 /area/bigredv2/caves/mining)
 "mYo" = (
 /obj/effect/decal/strata_decals/grime/grime3,
-/obj/effect/landmark/nightmare{
-	insert_tag = "cargo_containers"
-	},
 /turf/open/asphalt/cement_sunbleached/cement_sunbleached1,
 /area/bigredv2/outside/w)
 "mYp" = (


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #7856 where it looks like an extra nightmare insert was unintentionally added.

# Explain why it's good for the game

Inserts are intended to be inserted in specific locations, not arbitrarily.

# Changelog
:cl: Drathek
maptweak: Removed an erronous nightmare insert on BigRed
/:cl:
