### PR TITLE
stop economy inflation announcements during red/delta alert

### DIFF
--- a/code/modules/events/inflation.dm
+++ b/code/modules/events/inflation.dm
@@ -32,7 +32,10 @@
 	/* You may be thinking 'Why the fuck would W-Y directly send a broadcast to a in-operation vessel and reveal their location to any hostiles nearby?'
 	The answer is they don't, it's a signal sent across entire sectors for every UA-affiliated vessel and colony to take note of when it passes by.
 	Colony vendors aren't updated because the colony's network has collapsed. */
-	shipwide_ai_announcement("An encrypted broadband signal from Weyland-Yutani has been received notifying the sector of sudden changes in the UA's economy during cryosleep, due to [get_random_story()], and have requested UA vessels to increase the prices of [product_type] products by [get_percentage()]%. This change will come into effect in [time_to_update] minutes.", quiet = TRUE)
+	if(SShijack)
+		return
+	else
+		shipwide_ai_announcement("An encrypted broadband signal from Weyland-Yutani has been received notifying the sector of sudden changes in the UA's economy during cryosleep, due to [get_random_story()], and have requested UA vessels to increase the prices of [product_type] products by [get_percentage()]%. This change will come into effect in [time_to_update] minutes.", quiet = TRUE)
 
 /datum/round_event/economy_inflation/start()
 	for(var/obj/structure/machinery/vending/vending_machine as anything in GLOB.total_vending_machines)

--- a/code/modules/events/inflation.dm
+++ b/code/modules/events/inflation.dm
@@ -32,10 +32,9 @@
 	/* You may be thinking 'Why the fuck would W-Y directly send a broadcast to a in-operation vessel and reveal their location to any hostiles nearby?'
 	The answer is they don't, it's a signal sent across entire sectors for every UA-affiliated vessel and colony to take note of when it passes by.
 	Colony vendors aren't updated because the colony's network has collapsed. */
-	if(SShijack)
+	if((SShijack.hijack_status >= HIJACK_OBJECTIVES_STARTED) || (SShijack.evac_status == EVACUATION_STATUS_INITIATED))
 		return
-	else
-		shipwide_ai_announcement("An encrypted broadband signal from Weyland-Yutani has been received notifying the sector of sudden changes in the UA's economy during cryosleep, due to [get_random_story()], and have requested UA vessels to increase the prices of [product_type] products by [get_percentage()]%. This change will come into effect in [time_to_update] minutes.", quiet = TRUE)
+	shipwide_ai_announcement("An encrypted broadband signal from Weyland-Yutani has been received notifying the sector of sudden changes in the UA's economy during cryosleep, due to [get_random_story()], and have requested UA vessels to increase the prices of [product_type] products by [get_percentage()]%. This change will come into effect in [time_to_update] minutes.", quiet = TRUE)
 
 /datum/round_event/economy_inflation/start()
 	for(var/obj/structure/machinery/vending/vending_machine as anything in GLOB.total_vending_machines)

--- a/code/modules/events/inflation.dm
+++ b/code/modules/events/inflation.dm
@@ -32,7 +32,7 @@
 	/* You may be thinking 'Why the fuck would W-Y directly send a broadcast to a in-operation vessel and reveal their location to any hostiles nearby?'
 	The answer is they don't, it's a signal sent across entire sectors for every UA-affiliated vessel and colony to take note of when it passes by.
 	Colony vendors aren't updated because the colony's network has collapsed. */
-	if((SShijack.hijack_status >= HIJACK_OBJECTIVES_STARTED) || (SShijack.evac_status == EVACUATION_STATUS_INITIATED))
+	if(GLOB.security_level >= SEC_LEVEL_RED)
 		return
 	shipwide_ai_announcement("An encrypted broadband signal from Weyland-Yutani has been received notifying the sector of sudden changes in the UA's economy during cryosleep, due to [get_random_story()], and have requested UA vessels to increase the prices of [product_type] products by [get_percentage()]%. This change will come into effect in [time_to_update] minutes.", quiet = TRUE)
 


### PR DESCRIPTION
# About the pull request

stops the economy inflation announcements during red/delta alert

# Explain why it's good for the game

i believe nobody really wants a fairly long announcement cluttering chat about cigarettes being more expensive during these times


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: stops the economy inflation announcements during red/delta alert
/:cl:
