### PR TITLE
fixes being able to put marks down at hyperspace

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Powers.dm
@@ -189,6 +189,9 @@
 /mob/living/carbon/xenomorph/proc/make_marker(turf/target_turf)
 	if(!target_turf)
 		return FALSE
+	if(istype(target_turf, /turf/open/space/transit))
+		to_chat(src, SPAN_NOTICE("What would that achieve?!"))
+		return
 	var/found_weeds = FALSE
 	if(!selected_mark)
 		to_chat(src, SPAN_NOTICE("We must have a meaning for the mark before you can make it."))


### PR DESCRIPTION

# About the pull request

tiitle

# Explain why it's good for the game

fix


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: You can no longer put down xeno resin marks in hyperspace
/:cl:
