### PR TITLE
Belt and EOD buff

### DIFF
--- a/code/modules/clothing/suits/marine_armor/_marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor/_marine_armor.dm
@@ -80,6 +80,8 @@
 		/obj/item/storage/belt/gun/m39,
 		/obj/item/storage/belt/gun/m10,
 		/obj/item/storage/belt/gun/xm51,
+		/obj/item/storage/belt/knifepouch,
+		/obj/item/storage/belt/utility/construction,
 	)
 	valid_accessory_slots = list(ACCESSORY_SLOT_MEDAL, ACCESSORY_SLOT_PONCHO)
 

--- a/code/modules/clothing/suits/marine_armor/_marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor/_marine_armor.dm
@@ -82,6 +82,7 @@
 		/obj/item/storage/belt/gun/xm51,
 		/obj/item/storage/belt/knifepouch,
 		/obj/item/storage/belt/utility/construction,
+		/obj/item/storage/belt/gun/mortarbelt,
 	)
 	valid_accessory_slots = list(ACCESSORY_SLOT_MEDAL, ACCESSORY_SLOT_PONCHO)
 

--- a/code/modules/clothing/suits/marine_armor/_marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor/_marine_armor.dm
@@ -620,6 +620,22 @@
 	storage_slots = 2
 	slowdown = SLOWDOWN_ARMOR_LOWHEAVY
 	movement_compensation = SLOWDOWN_ARMOR_MEDIUM
+	allowed = list(
+		/obj/item/weapon/gun,
+		/obj/item/prop/prop_gun,
+		/obj/item/tank/emergency_oxygen,
+		/obj/item/storage/backpack/general_belt,
+		/obj/item/storage/large_holster/machete,
+		/obj/item/storage/belt,
+		/obj/item/device/motiondetector,
+		/obj/item/device/walkman,
+		/obj/item/device/flashlight,
+		/obj/item/storage/bible,
+		/obj/item/storage/fancy/cigarettes,
+		/obj/item/tool/lighter,
+		/obj/item/attachable/bayonet,
+		/obj/item/weapon/sword/machete,
+	)
 	light_power = 4
 	light_range = 5
 

--- a/code/modules/clothing/suits/marine_armor/_marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor/_marine_armor.dm
@@ -464,6 +464,29 @@
 	armor_rad = CLOTHING_ARMOR_MEDIUMHIGH
 	armor_internaldamage = CLOTHING_ARMOR_LOW
 	storage_slots = 2
+	allowed = list(
+		/obj/item/weapon/gun,
+		/obj/item/prop/prop_gun,
+		/obj/item/tank/emergency_oxygen,
+		/obj/item/device/flashlight,
+		/obj/item/storage/fancy/cigarettes,
+		/obj/item/tool/lighter,
+		/obj/item/storage/bible,
+		/obj/item/attachable/bayonet,
+		/obj/item/storage/backpack/general_belt,
+		/obj/item/storage/large_holster/machete,
+		/obj/item/storage/belt/gun/type47,
+		/obj/item/storage/belt/gun/m4a3,
+		/obj/item/storage/belt/gun/m44,
+		/obj/item/storage/belt/gun/smartpistol,
+		/obj/item/storage/belt/gun/flaregun,
+		/obj/item/device/motiondetector,
+		/obj/item/device/walkman,
+		/obj/item/storage/belt/gun/m39,
+		/obj/item/storage/belt/gun/m10,
+		/obj/item/storage/belt/gun/xm51,
+		/obj/item/storage/belt/knifepouch,
+	)
 
 /obj/item/clothing/suit/storage/marine/light/padded
 	icon_state = "L1"


### PR DESCRIPTION
# About the pull request

* Adds the ability to medium armor to carry knife rig and construction rig on your armor slot.
* Adds the ability to heavy EOD armor to carry every belt marines have access to on the armor slot.

# Explain why it's good for the game

EOD always been a bit lacking. Its been tried to buff it, but it usually just where atempts to just ive it more protection.
Wich doesnt matter too much in a game where speed is key.
Furthermore, ligth armors advantage is its speed, even back when it had higher bio protection, the speed was the strongest part of it.

So, why not try a similar attempt with the EOD.
Instead of making it better by buffing flat numbers for its armor, make it the armor you chose if you want to carry tons of stuff.
Sacrificing your speed for a second belt slot basicly.
I think its a far more interesting way to make the EOD a viabel armor then simply to adjust the armor.
On that note, if armor should be adjusted acordingly with this buff, i would agree. I just didnt because im not 100% sure if it needs to, and rather hear second opinions about that.

Also i gave medium ligth armor acces to some extra rigs for their armor. Knife rig on armor is purley for dumb fun builds, dont pretend like thats good. That isnt a balance concern.
Construction belt and mortar belt on medium and ligth armor, is more so to give comtecs and mortar operators some more freedom for build options. Basicly a buff to construction and mortar belt.

Discord for balance discussion: NHC

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:NHC
balance: rebalanced EOD armor to be able to carry every belt on its armor slot
balance: rebalanced knife rig, construction rig, and mortar belt to fit on medium and heavy marine armor.
/:cl:
