### PR TITLE
Banishment now does damage per tick 

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -200,6 +200,7 @@
 /// The time against away_timer when an AFK xeno gets listed in the available list so ghosts can get ready
 #define XENO_AVAILABLE_TIMER 60 //60 seconds
 
+/// The damage that xeno health gets divided by for banish tick damage
 #define XENO_BANISHMENT_DMG_DIVISOR 23
 
 /// Between 2% to 10% of explosion severity

--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -200,6 +200,8 @@
 /// The time against away_timer when an AFK xeno gets listed in the available list so ghosts can get ready
 #define XENO_AVAILABLE_TIMER 60 //60 seconds
 
+#define XENO_BANISHMENT_DMG_DIVISOR 23
+
 /// Between 2% to 10% of explosion severity
 #define WEED_EXPLOSION_DAMAGEMULT rand(2, 10)*0.01
 

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -9,7 +9,7 @@
 		return
 
 	if(banished)
-		apply_armoured_damage(ceil(health / 23))
+		apply_armoured_damage(ceil(health / XENO_BANISHMENT_DMG_DIVISOR))
 
 	..()
 

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -9,8 +9,7 @@
 		return
 
 	if(banished)
-		var/current_health = health
-		apply_armoured_damage(current_health / 23)
+		apply_armoured_damage(ceil(health / 23))
 
 	..()
 

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -8,6 +8,10 @@
 	if(!loc)
 		return
 
+	if(banished == TRUE)
+		var/current_health = src.health
+		src.apply_armoured_damage(current_health / 23)
+
 	..()
 
 	// replace this by signals or trait signals

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -8,9 +8,9 @@
 	if(!loc)
 		return
 
-	if(banished == TRUE)
-		var/current_health = src.health
-		src.apply_armoured_damage(current_health / 23)
+	if(banished)
+		var/current_health = health
+		apply_armoured_damage(current_health / 23)
 
 	..()
 


### PR DESCRIPTION
# About the pull request
Banishment does damage per tick, scaling at a health / 23 per tick (23 damage per tick for a drone for reference)

# Explain why it's good for the game

Alot of ways to circumvent  dying after banishment, this prevents that.
Makes it so banishment forces people to fallback and listen to queen instead of just sit there and wait and hope somebody kill sthem


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Banishment now does damage per tick
/:cl:
