### PR TITLE
Fixes being able to buckle yourself to rollerbeds/evacbeds while in a stasis bed

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -137,6 +137,8 @@
 
 /obj/structure/bed/MouseDrop_T(atom/dropping, mob/user)
 	if(accepts_bodybag && !buckled_bodybag && !buckled_mob && istype(dropping,/obj/structure/closet/bodybag) && ishuman(user))
+		if(isturf(loc) && !isturf(user.loc)) // so they do not buckle themselves
+			return
 		var/obj/structure/closet/bodybag/B = dropping
 		if(!B.roller_buckled)
 			do_buckle_bodybag(B, user)

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -137,7 +137,7 @@
 
 /obj/structure/bed/MouseDrop_T(atom/dropping, mob/user)
 	if(accepts_bodybag && !buckled_bodybag && !buckled_mob && istype(dropping,/obj/structure/closet/bodybag) && ishuman(user))
-		if(isturf(loc) && !isturf(user.loc)) // so they do not buckle themselves
+		if(!isturf(user.loc)) // so they do not buckle themselves
 			return
 		var/obj/structure/closet/bodybag/B = dropping
 		if(!B.roller_buckled)


### PR DESCRIPTION
# About the pull request

fixes #6767

# Explain why it's good for the game

fix

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix:Fixes being able to buckle yourself to rollerbeds/evacbeds while in a stasis bed
/:cl:
