### PR TITLE
Prevents C4 being placed on explosion proof atoms.

### DIFF
--- a/code/game/objects/items/explosives/plastic.dm
+++ b/code/game/objects/items/explosives/plastic.dm
@@ -180,6 +180,9 @@
 	if(istype(target, /obj/structure/ladder) || istype(target, /obj/item) || istype(target, /turf/open) || istype(target, /obj/structure/barricade) || istype(target, /obj/structure/closet/crate))
 		return FALSE
 
+	if(target.explo_proof)
+		return FALSE
+
 	if(istype(target, /obj/structure/closet))
 		var/obj/structure/closet/C = target
 		if(C.opened)

--- a/code/game/objects/items/explosives/plastic.dm
+++ b/code/game/objects/items/explosives/plastic.dm
@@ -181,6 +181,7 @@
 		return FALSE
 
 	if(target.explo_proof)
+		to_chat(user, SPAN_WARNING("[name] would do nothing to [target]!"))
 		return FALSE
 
 	if(istype(target, /obj/structure/closet))
@@ -341,6 +342,10 @@
 /obj/item/explosive/plastic/breaching_charge/can_place(mob/user, atom/target)
 	if(!is_type_in_list(target, breachable))//only items on the list are allowed
 		to_chat(user, SPAN_WARNING("You cannot plant [name] on [target]!"))
+		return FALSE
+
+	if(target.explo_proof)
+		to_chat(user, SPAN_WARNING("[name] would do nothing to [target]!"))
 		return FALSE
 
 	if(SSinterior.in_interior(target))// vehicle checks again JUST IN CASE


### PR DESCRIPTION

# About the pull request

As title

# Explain why it's good for the game

Makes no sense to be able to put explosives onto an object that cannot be harmed by explosives.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: You can no longer place C4 or Breaching Charges onto objects that are explosion proof.
/:cl:
