### PR TITLE
Fixes carriers being able to put eggs into a morpher from infinite distances

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Carrier.dm
@@ -373,6 +373,13 @@
 		return
 
 /mob/living/carbon/xenomorph/carrier/proc/store_eggs_into_egg_morpher(obj/effect/alien/resin/special/eggmorph/morpher)
+
+	var/dist = get_dist(src, morpher)
+
+	if(dist > 1)
+		to_chat(src, SPAN_XENOWARNING("We need to be closer to do that."))
+		return
+
 	if(action_busy)
 		return FALSE
 


### PR DESCRIPTION
# About the pull request

title
fixes: #8514
# Explain why it's good for the game
bugfix


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Carriers can no longer refills morpher from infinite range
/:cl:
