### PR TITLE
Fixes uprooted fruits being indestructable

### DIFF
--- a/code/modules/cm_aliens/structures/fruit.dm
+++ b/code/modules/cm_aliens/structures/fruit.dm
@@ -369,6 +369,12 @@
 	SIGNAL_HANDLER
 	bound_xeno = null
 
+
+/obj/item/reagent_container/food/snacks/resin_fruit/attackby(obj/item/item_in_hand, mob/user)
+	if(item_in_hand == IS_SHARP_ITEM_ACCURATE || user.a_intent == INTENT_HARM)
+		playsound(src, "alien_resin_break", 25, FALSE)
+		qdel(src)
+
 /obj/item/reagent_container/food/snacks/resin_fruit/Destroy()
 	delete_fruit()
 	return ..()


### PR DESCRIPTION

# About the pull request

title

# Explain why it's good for the game

bugfix


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Uprooted fruit are now destroyable with the right melee.
/:cl:
