### PR TITLE
Fix youngblood job ban check, objectives, and end game note

### DIFF
--- a/code/datums/emergency_calls/pred_hunt/hunting_calls.dm
+++ b/code/datums/emergency_calls/pred_hunt/hunting_calls.dm
@@ -185,14 +185,14 @@
 /datum/emergency_call/young_bloods/remove_nonqualifiers(list/datum/mind/candidates_list)
 	var/list/datum/mind/youngblood_candidates_clean = list()
 	for(var/datum/mind/youngblood_candidate in candidates_list)
-		if(youngblood_candidate.current?.client?.check_whitelist_status(WHITELIST_YAUTJA) || jobban_isbanned(youngblood_candidate.current?.client, ERT_JOB_YOUNGBLOOD))
+		if(youngblood_candidate.current?.client?.check_whitelist_status(WHITELIST_YAUTJA) || jobban_isbanned(youngblood_candidate.current, ERT_JOB_YOUNGBLOOD))
 			to_chat(youngblood_candidate.current, SPAN_WARNING("You didn't qualify for the ERT beacon because you are already whitelisted for predator or you are job banned from youngblood."))
 			continue
 		if(check_timelock(youngblood_candidate.current?.client, JOB_SQUAD_ROLES_LIST, time_required_for_job) && (youngblood_candidate.current?.client.get_total_xeno_playtime() >= time_required_for_job))
 			youngblood_candidates_clean.Add(youngblood_candidate)
 			continue
 		if(youngblood_candidate.current)
-			to_chat(youngblood_candidate.current, SPAN_WARNING("You didn't qualify for the ERT beacon because you did not meet the required hours for this role [round(time_required_for_job / 36000)] hours on both squad roles and xenomorph roles ."))
+			to_chat(youngblood_candidate.current, SPAN_WARNING("You didn't qualify for the ERT beacon because you did not meet the required hours for this role [round(time_required_for_job / 36000)] hours on both squad roles and xenomorph roles."))
 	return youngblood_candidates_clean
 
 /datum/emergency_call/young_bloods/hunting_party

--- a/code/datums/emergency_calls/pred_hunt/hunting_calls.dm
+++ b/code/datums/emergency_calls/pred_hunt/hunting_calls.dm
@@ -227,7 +227,6 @@
 				break
 		FOR_DVIEW_END
 
-
 	if(!leader && HAS_FLAG(hunter?.client.prefs.toggles_ert, PLAY_LEADER)) // If someone wants to play as the dominant youngblood, they can. The role is purely roleplay-oriented with no mechanical advantage
 		leader = hunter
 		arm_equipment(hunter, /datum/equipment_preset/yautja/non_wl_leader, TRUE, TRUE)
@@ -238,4 +237,7 @@
 		to_chat(hunter, SPAN_ROLE_HEADER("You are a Yautja Youngblood!"))
 		to_chat(hunter, SPAN_YAUTJABOLDBIG("You are expected to remain in character at all times, follow all commands given to you by whitelisted players, and adhere to the honor code. If you fail to comply with any of these, you will be dispatched via a kill switch embedded within all Youngbloods. You may also face OOC repercussions. Good luck and have fun."))
 
-		addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), hunter, SPAN_YAUTJABOLD("Objectives:</b> [objectives]")), 30 SECONDS)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), hunter, SPAN_YAUTJABOLD("Objectives:</b> [objectives]")), 30 SECONDS)
+
+	if(SSticker.mode)
+		SSticker.mode.initialize_predator(hunter, ignore_pred_num = TRUE)

--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -25,25 +25,25 @@ GLOBAL_LIST_EMPTY(jobban_keylist)
 	rank = check_jobban_path(rank)
 	GLOB.jobban_keylist[rank][ckey] = "Reason Unspecified"
 
-//returns a reason if M is banned from rank, returns 0 otherwise
-/proc/jobban_isbanned(mob/M, rank, datum/entity/player/P = null)
+/// Returns a reason if player (mob) is banned from rank, returns null otherwise
+/proc/jobban_isbanned(mob/player, rank, datum/entity/player/player_entity = null)
 	if(!rank)
 		return "Non-existant job"
 	rank = ckey(rank)
-	if(P)
+	if(player_entity)
 		// asking for a friend
-		if(!P.jobbans_loaded)
+		if(!player_entity.jobbans_loaded)
 			return "Not yet loaded"
-		var/datum/entity/player_job_ban/PJB = P.job_bans[rank]
-		return PJB ? PJB.text : null
-	if(M)
-		if(!M.client || !M.client.player_data || !M.client.player_data.jobbans_loaded)
+		var/datum/entity/player_job_ban/job_ban = player_entity.job_bans[rank]
+		return job_ban ? job_ban.text : null
+	if(player)
+		if(!player.client || !player.client.player_data || !player.client.player_data.jobbans_loaded)
 			return "Not yet loaded"
 		if(guest_jobbans(rank))
-			if(CONFIG_GET(flag/guest_jobban) && IsGuestKey(M.key))
+			if(CONFIG_GET(flag/guest_jobban) && IsGuestKey(player.key))
 				return "Guest Job-ban"
-		var/datum/entity/player_job_ban/PJB = M.client.player_data.job_bans[rank]
-		return PJB ? PJB.text : null
+		var/datum/entity/player_job_ban/job_ban = player.client.player_data.job_bans[rank]
+		return job_ban ? job_ban.text : null
 
 /proc/jobban_loadbanfile()
 	var/savefile/S=new("data/job_new.ban")


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #7925 fixing three things:
- Job bans were not handled correctly (would just runtime) for young bloods
- End game results didn't list young blood players in the line "The Predators were:"
- Objectives did not ever display for young blood leaders

I also cleaned up the `jobban_isbanned` proc.

# Explain why it's good for the game

Fixes the above issues, autodoc coverage, and code that doesn't meet code standards.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/30083456-0f79-4472-907d-0931947ac159)
![image](https://github.com/user-attachments/assets/43251292-ac42-47b1-83d2-a7b74dfc9a13)

</details>


# Changelog
:cl: Drathek
fix: Fixed young blood job ban check and end game note who played as Predator
fix: Fixed young blood leader objectives
code: Cleaned up the jobban_isbanned proc
/:cl:
