### PR TITLE
Add check for GLOBAL_SUBTYPE_INDEXED index trampling

### DIFF
--- a/code/__DEFINES/_globals.dm
+++ b/code/__DEFINES/_globals.dm
@@ -15,6 +15,8 @@
 	##X = list();\
 	for(var/t in subtypesof(TypePath)){\
 		var##TypePath/A = new t;\
+		var##TypePath/existing = ##X[A.##Index];\
+		if(existing) stack_trace("'[A.##Index]' index for [t] overlaps with [existing.type]! It must have a unique index for lookup!");\
 		##X[A.##Index] = A;\
 	}\
 	gvars_datum_init_order += #X;\

--- a/code/__DEFINES/_globals.dm
+++ b/code/__DEFINES/_globals.dm
@@ -16,7 +16,7 @@
 	for(var/t in subtypesof(TypePath)){\
 		var##TypePath/A = new t;\
 		var##TypePath/existing = ##X[A.##Index];\
-		if(existing) stack_trace("'[A.##Index]' index for [t] overlaps with [existing.type]! It must have a unique index for lookup!");\
+		if(existing) stack_trace("'[A.##Index]' index for [t] in [#X] overlaps with [existing.type]! It must have a unique index for lookup!");\
 		##X[A.##Index] = A;\
 	}\
 	gvars_datum_init_order += #X;\

--- a/code/__DEFINES/_globals.dm
+++ b/code/__DEFINES/_globals.dm
@@ -16,7 +16,7 @@
 	for(var/t in subtypesof(TypePath)){\
 		var##TypePath/A = new t;\
 		var##TypePath/existing = ##X[A.##Index];\
-		if(existing) stack_trace("'[A.##Index]' index for [t] in [#X] overlaps with [existing.type]! It must have a unique index for lookup!");\
+		if(existing && !isnull(A.##Index)) stack_trace("'[A.##Index]' index for [t] in [#X] overlaps with [existing.type]! It must have a unique index for lookup!");\
 		##X[A.##Index] = A;\
 	}\
 	gvars_datum_init_order += #X;\

--- a/code/__DEFINES/job.dm
+++ b/code/__DEFINES/job.dm
@@ -167,7 +167,7 @@ GLOBAL_LIST_INIT(job_command_roles, JOB_COMMAND_ROLES_LIST)
 #define JOB_WO_REQUISITION "Bunker Crew Logistics"
 
 #define JOB_WO_CMO "Head Surgeon"
-#define JOB_WO_DOCTOR "Field Doctor"
+#define JOB_WO_DOCTOR "Field Surgeon"
 #define JOB_WO_RESEARCHER "Chemist"
 
 #define JOB_WO_CORPORATE_LIAISON "Combat Reporter"

--- a/code/datums/origin/uscm.dm
+++ b/code/datums/origin/uscm.dm
@@ -40,6 +40,9 @@
 		name_to_check = generate_human_name(gender)
 	return name_to_check
 
+/datum/origin/uscm/convict
+	name = null // Abstract type
+
 /datum/origin/uscm/convict/minor
 	name = ORIGIN_USCM_CONVICT_MINOR
 	desc = "Where you were born is irrelevant, as far as anyone is concerned you are were convicted for numerous minor crimes and offered a way out: the USCM."

--- a/code/game/jobs/job/antag/other/pred.dm
+++ b/code/game/jobs/job/antag/other/pred.dm
@@ -74,9 +74,6 @@
 
 	handle_spawn_and_equip = TRUE
 
-/datum/job/antag/young_blood/leader
-	gear_preset = /datum/equipment_preset/yautja/non_wl_leader
-
 /datum/job/antag/young_blood/generate_entry_conditions(mob/living/hunter)
 	. = ..()
 

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -1,7 +1,7 @@
 /datum/job
 	//The name of the job
-	var/title = ""  //The internal title for the job, used for the job ban system and so forth. Don't change these, change the disp_title instead.
-	var/disp_title  //Determined on new(). Usually the same as the title, but doesn't have to be. Set this to override what the player sees in the game as their title.
+	var/title = null //The internal title for the job, used for the job ban system and so forth. Don't change these, change the disp_title instead.
+	var/disp_title //Determined on new(). Usually the same as the title, but doesn't have to be. Set this to override what the player sees in the game as their title.
 	var/role_ban_alternative // If the roleban title needs to be an extra check, like Xenomorphs = Alien.
 
 	var/total_positions = 0 //How many players can be this job

--- a/code/game/jobs/job/special/weyland_yutani.dm
+++ b/code/game/jobs/job/special/weyland_yutani.dm
@@ -1,6 +1,5 @@
-/datum/job/special/wey_yu
+/datum/job/special/wey_yu // Abstract type (null title)
 	supervisors = "Weyland-Yutani Corporate Office"
-	title = "Weyland-Yutani Representative"
 	selection_class = "job_cl"
 	flags_startup_parameters = ROLE_CUSTOM_SPAWN
 	gear_preset = /datum/equipment_preset/wy/trainee
@@ -55,7 +54,7 @@
 
 
 // PMCS //
-/datum/job/special/wey_yu/pmc
+/datum/job/special/wey_yu/pmc // Abstract type (null title)
 	supervisors = "Weyland-Yutani PMC Dispatch"
 
 /datum/job/special/wey_yu/pmc/standard

--- a/code/modules/gear_presets/upp.dm
+++ b/code/modules/gear_presets/upp.dm
@@ -6,9 +6,8 @@
 	name = "UPP late join"
 	job_list = UPP_JOB_LIST
 
-/datum/job/antag/upp
+/datum/job/antag/upp // Abstract type (null title)
 	allow_additional = TRUE
-	title = FACTION_UPP
 	selection_class = "job_synth" //setup colour
 	total_positions = 1
 	spawn_positions = 1
@@ -280,7 +279,7 @@
 //*****************************************************************************************************/
 
 
-/datum/job/antag/upp/cryo/medic
+/datum/job/antag/upp/medic
 	title = JOB_UPP_MEDIC
 	gear_preset = /datum/equipment_preset/upp/medic
 	flags_startup_parameters = ROLE_ADD_TO_SQUAD
@@ -1669,7 +1668,6 @@
 
 
 /datum/job/antag/upp/officer //this is placeholder for stuff that is supposed to be the same for all officers
-	title = JOB_UPP_SRLT_OFFICER
 	selection_class = "job_command"
 
 /datum/equipment_preset/upp/officer/load_gear(mob/living/carbon/human/new_human)
@@ -2193,10 +2191,10 @@
 
 //*****************************************************************************************************/
 /datum/job/antag/upp/officer/co_whitelist
-	flags_startup_parameters = ROLE_ADMIN_NOTIFY|ROLE_WHITELISTED
-	flags_whitelist = WHITELIST_COMMANDER
 	title = JOB_UPP_CO_OFFICER
 	gear_preset = /datum/equipment_preset/upp/officer/major/co
+	flags_startup_parameters = ROLE_ADMIN_NOTIFY|ROLE_WHITELISTED
+	flags_whitelist = WHITELIST_COMMANDER
 
 /datum/job/antag/upp/officer/co_whitelist/New()
 	. = ..()
@@ -2207,10 +2205,10 @@
 	)
 
 /datum/job/antag/upp/officer/major
-	flags_startup_parameters = ROLE_ADMIN_NOTIFY|ROLE_WHITELISTED
-	flags_whitelist = WHITELIST_COMMANDER
 	title = JOB_UPP_MAY_OFFICER
 	gear_preset = /datum/equipment_preset/upp/officer/major
+	flags_startup_parameters = ROLE_ADMIN_NOTIFY|ROLE_WHITELISTED
+	flags_whitelist = WHITELIST_COMMANDER
 
 /datum/equipment_preset/upp/officer/major
 	name = "UPP Mayjor (Cryo)"
@@ -2391,11 +2389,10 @@
 
 //*****************************************************************************************************/
 /datum/job/antag/upp/officer/podpolkovnik
-	flags_startup_parameters = ROLE_ADMIN_NOTIFY|ROLE_WHITELISTED
-	flags_whitelist =  WHITELIST_COMMANDER_COUNCIL
 	title = JOB_UPP_LTKOL_OFFICER
 	gear_preset = /datum/equipment_preset/upp/officer/flag/podpolkovnik
-
+	flags_startup_parameters = ROLE_ADMIN_NOTIFY|ROLE_WHITELISTED
+	flags_whitelist =  WHITELIST_COMMANDER_COUNCIL
 
 /datum/equipment_preset/upp/officer/flag/podpolkovnik
 	name = "UPP Podpolkovnik (Cryo)"
@@ -2587,11 +2584,10 @@
 
 
 /datum/job/antag/upp/officer/kolonel
-	flags_startup_parameters = ROLE_ADMIN_NOTIFY|ROLE_WHITELISTED
-	flags_whitelist = WHITELIST_COMMANDER_COLONEL|WHITELIST_COMMANDER_LEADER
 	title = JOB_UPP_KOL_OFFICER
 	gear_preset = /datum/equipment_preset/upp/officer/flag/podpolkovnik
-
+	flags_startup_parameters = ROLE_ADMIN_NOTIFY|ROLE_WHITELISTED
+	flags_whitelist = WHITELIST_COMMANDER_COLONEL|WHITELIST_COMMANDER_LEADER
 
 /datum/equipment_preset/upp/officer/flag/polkovnik
 	name = "UPP Polkovnik (Cryo)"
@@ -2654,7 +2650,6 @@
 /datum/job/antag/upp/officer/ley_gen
 	title = JOB_UPP_LT_GENERAL
 	gear_preset = /datum/equipment_preset/upp/officer/flag/ley_gen
-
 	flags_whitelist =  WHITELIST_COMMANDER
 
 /datum/equipment_preset/upp/officer/flag/ley_gen

--- a/code/modules/paperwork/prefab_papers.dm
+++ b/code/modules/paperwork/prefab_papers.dm
@@ -109,13 +109,12 @@ GLOBAL_REFERENCE_LIST_INDEXED(prefab_papers, /obj/item/paper/prefab, document_ti
 //########################################
 //########################################
 //########################################
-/obj/item/paper/prefab
+/obj/item/paper/prefab // Abstract type (document_title and doc_datum_type are null)
 	is_prefab = TRUE
-	document_title = "BLANK"
 
 /obj/item/paper/prefab/Initialize()
 	. = ..()
-	name = document_title
+	name = document_title || "BLANK"
 
 // ########## Provost MP Forms  ########## \\
 


### PR DESCRIPTION

# About the pull request

This PR ensures all usage of `GLOBAL_SUBTYPE_INDEXED` (includes `GLOBAL_REFERENCE_LIST_INDEXED` and `GLOBAL_REFERENCE_LIST_INDEXED_SORTED`) can uniquely index every subtype it is given. Use a null indexer to not error on abstract types (but the last of its kind will still be indexed with that value).

# Explain why it's good for the game

Much like https://github.com/cmss13-devs/cmss13/pull/6421 these GLOBs are expected to be indexed, so we need to know if we are mistakenly trampling an entry.

# Testing Photographs and Procedure
See checks.

# Changelog
:cl: Drathek
fix: Fixed WO doctor job overlapping with new Field Doctor
code: Added a check to ensure all usage of GLOBAL_SUBTYPE_INDEXED has uniquely indexed entries
del: Removed unused young blood leader job datum
/:cl:
