### PR TITLE
Tier 1 Queen Evolution and Evolution Fixes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Evolution.dm
@@ -31,15 +31,16 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 	if(!length(castes_available))
 		to_chat(src, SPAN_WARNING("The Hive is not capable of supporting any castes we can evolve to yet."))
 		return
+
 	var/castepick
 	if((client.prefs && client.prefs.no_radials_preference) || !hive.evolution_menu_images)
-		castepick = tgui_input_list(usr, "You are growing into a beautiful alien! It is time to choose a caste.", "Evolve", castes_available, theme="hive_status")
+		castepick = tgui_input_list(src, "You are growing into a beautiful alien! It is time to choose a caste.", "Evolve", castes_available, theme="hive_status")
 	else
 		var/list/fancy_caste_list = list()
 		for(var/caste in castes_available)
 			fancy_caste_list[caste] = hive.evolution_menu_images[caste]
 
-		castepick = show_radial_menu(src, src.client?.eye, fancy_caste_list)
+		castepick = show_radial_menu(src, client?.eye, fancy_caste_list)
 	if(!castepick) //Changed my mind
 		return
 
@@ -88,7 +89,7 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 	xeno_type = GLOB.RoleAuthority.get_caste_by_text(castepick)
 
 	if(isnull(xeno_type))
-		to_chat(usr, SPAN_WARNING("[castepick] is not a valid caste! If you're seeing this message, tell a coder!"))
+		to_chat(src, SPAN_WARNING("[castepick] is not a valid caste! If you're seeing this message, tell a coder!"))
 		return
 
 	// Used for restricting benos to evolve to drone/queen when they're the only potential queen
@@ -140,7 +141,7 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 
 	if(!istype(new_xeno))
 		//Something went horribly wrong!
-		to_chat(usr, SPAN_WARNING("Something went terribly wrong here. Your new xeno is null! Tell a coder immediately!"))
+		to_chat(src, SPAN_WARNING("Something went terribly wrong here. Your new xeno is null! Tell a coder immediately!"))
 		stack_trace("Xeno evolution failed: [src] attempted to evolve into \'[castepick]\'")
 		if(new_xeno)
 			qdel(new_xeno)
@@ -158,7 +159,7 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 	if(mind)
 		mind.transfer_to(new_xeno)
 	else
-		new_xeno.key = src.key
+		new_xeno.key = key
 		if(new_xeno.client)
 			new_xeno.client.change_view(GLOB.world_view_size)
 
@@ -167,8 +168,8 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 	if(new_xeno.client)
 		new_xeno.set_lighting_alpha(level_to_switch_to)
 	if(new_xeno.health - getBruteLoss(src) - getFireLoss(src) > 0) //Cmon, don't kill the new one! Shouldnt be possible though
-		new_xeno.bruteloss = src.bruteloss //Transfers the damage over.
-		new_xeno.fireloss = src.fireloss //Transfers the damage over.
+		new_xeno.bruteloss = bruteloss //Transfers the damage over.
+		new_xeno.fireloss = fireloss //Transfers the damage over.
 		new_xeno.updatehealth()
 
 	if(plasma_max == 0)
@@ -180,14 +181,14 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 
 	built_structures = null
 
-	new_xeno.visible_message(SPAN_XENODANGER("A [new_xeno.caste.caste_type] emerges from the husk of \the [src]."),
+	new_xeno.visible_message(SPAN_XENODANGER("A [new_xeno.caste.caste_type] emerges from the husk of [src]."),
 	SPAN_XENODANGER("We emerge in a greater form from the husk of our old body. For the hive!"))
 
 	if(hive.living_xeno_queen && hive.living_xeno_queen.observed_xeno == src)
 		hive.living_xeno_queen.overwatch(new_xeno)
 
-	src.transfer_observers_to(new_xeno)
-	new_xeno._status_traits = src._status_traits
+	transfer_observers_to(new_xeno)
+	new_xeno._status_traits = _status_traits
 
 	qdel(src)
 	new_xeno.xeno_jitter(25)

--- a/code/modules/mob/living/carbon/xenomorph/Evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Evolution.dm
@@ -238,7 +238,7 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 		to_chat(src, SPAN_WARNING("The restraints are too restricting to allow us to evolve."))
 		return FALSE
 
-	if(isnull(caste.evolves_to))
+	if(isnull(caste.evolves_to) || !length(caste.evolves_to))
 		to_chat(src, SPAN_WARNING("We are already the apex of form and function. Go forth and spread the hive!"))
 		return FALSE
 

--- a/code/modules/mob/living/carbon/xenomorph/Evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Evolution.dm
@@ -54,8 +54,11 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 	if(!evolve_checks())
 		return
 
-	if((!hive.living_xeno_queen) && castepick != XENO_CASTE_QUEEN && !islarva(src) && !hive.allow_no_queen_evo)
-		to_chat(src, SPAN_WARNING("The Hive is shaken by the death of the last Queen. We can't find the strength to evolve."))
+	if(!hive.living_xeno_queen && castepick != XENO_CASTE_QUEEN && !islarva(src) && !hive.allow_no_queen_evo)
+		if(hive.xeno_queen_timer > world.time)
+			to_chat(src, SPAN_WARNING("The Hive is shaken by the death of the last Queen. We can't find the strength to evolve."))
+		else
+			to_chat(src, SPAN_XENONOTICE("The hive currently has no Queen! We can't find the strength to evolve."))
 		return
 
 	if(castepick == XENO_CASTE_QUEEN) //Special case for dealing with queenae

--- a/code/modules/mob/living/carbon/xenomorph/Evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Evolution.dm
@@ -18,7 +18,7 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 	if(!evolve_checks())
 		return
 
-	var/castes_available = caste.evolves_to.Copy()
+	var/list/castes_available = caste.evolves_to.Copy()
 
 	// Also offer queen to any tier 1 that can evolve at all if there isn't a queen
 	if(tier == 1 && hive.allow_queen_evolve && !hive.living_xeno_queen)
@@ -84,11 +84,10 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 			to_chat(src, SPAN_WARNING("We must wait before evolving. Currently at: [evolution_stored] / [evolution_threshold]."))
 			return
 
-	var/mob/living/carbon/xenomorph/M = null
+	var/mob/living/carbon/xenomorph/xeno_type = null
+	xeno_type = GLOB.RoleAuthority.get_caste_by_text(castepick)
 
-	M = GLOB.RoleAuthority.get_caste_by_text(castepick)
-
-	if(isnull(M))
+	if(isnull(xeno_type))
 		to_chat(usr, SPAN_WARNING("[castepick] is not a valid caste! If you're seeing this message, tell a coder!"))
 		return
 
@@ -99,7 +98,7 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 		return
 	to_chat(src, SPAN_XENONOTICE("It looks like the hive can support our evolution to [SPAN_BOLD(castepick)]!"))
 
-	visible_message(SPAN_XENONOTICE("\The [src] begins to twist and contort."),
+	visible_message(SPAN_XENONOTICE("[src] begins to twist and contort."),
 	SPAN_XENONOTICE("We begin to twist and contort."))
 	xeno_jitter(25)
 	evolving = TRUE
@@ -107,7 +106,6 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 
 	if(!do_after(src, 2.5 SECONDS, INTERRUPT_INCAPACITATED|INTERRUPT_CHANGED_LYING, BUSY_ICON_HOSTILE)) // Can evolve while moving, resist or rest to cancel it.
 		to_chat(src, SPAN_WARNING("We quiver, but nothing happens. Our evolution has ceased for now..."))
-
 		evolving = FALSE
 		return
 
@@ -130,11 +128,14 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 
 	// subtract the threshold, keep the stored amount
 	evolution_stored -= evolution_threshold
+
+	// don't drop their organ
 	var/obj/item/organ/xeno/organ = locate() in src
 	if(!isnull(organ))
 		qdel(organ)
+
 	//From there, the new xeno exists, hopefully
-	var/mob/living/carbon/xenomorph/new_xeno = new M(get_turf(src), src)
+	var/mob/living/carbon/xenomorph/new_xeno = new xeno_type(get_turf(src), src)
 	new_xeno.creation_time = creation_time
 
 	if(!istype(new_xeno))

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -421,6 +421,22 @@
 	for(var/mob/living/carbon/xenomorph/L in xeno_leader_list)
 		L.handle_xeno_leader_pheromones()
 
+/// Returns a count of xenos that can potentially evolve to queen (larva and tier 1 that aren't job banned)
+/datum/hive_status/proc/get_potential_queen_count()
+	var/potential_queens = 0
+	for(var/mob/living/carbon/xenomorph/xeno as anything in totalXenos)
+		if(xeno.stat == DEAD)
+			continue
+		switch(xeno.tier)
+			if(0)
+				if(islarva(xeno) && !ispredalienlarva(xeno))
+					if(xeno.client && xeno.ckey && !jobban_isbanned(xeno, XENO_CASTE_QUEEN))
+						potential_queens++
+			if(1)
+				if(xeno.client && xeno.ckey && !jobban_isbanned(xeno, XENO_CASTE_QUEEN))
+					potential_queens++
+	return potential_queens
+
 /*
  * Helper procs for the Hive Status UI
  * These are all called by the hive status UI manager to update its data

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -230,7 +230,7 @@
 		if(issynth(current_mob))
 			to_chat(current_mob, SPAN_HIGHDANGER("You hear the distant call of an unknown bioform, it sounds like they're informing others to change form. You begin to analyze and decrypt the strange vocalization."))
 
-// Adds a xeno to this hive
+/// Adds a xeno to this hive
 /datum/hive_status/proc/add_xeno(mob/living/carbon/xenomorph/X)
 	if(!X || !istype(X))
 		return
@@ -267,7 +267,7 @@
 	// Xenos are a fuckfest of cross-dependencies of different datums that are initialized at different times
 	// So don't even bother trying updating UI here without large refactors
 
-// Removes the xeno from the hive
+/// Removes the xeno from the hive
 /datum/hive_status/proc/remove_xeno(mob/living/carbon/xenomorph/xeno, hard = FALSE, light_mode = FALSE)
 	if(!xeno || !istype(xeno))
 		return
@@ -418,8 +418,8 @@
 	hive_ui.update_xeno_keys()
 
 /datum/hive_status/proc/handle_xeno_leader_pheromones()
-	for(var/mob/living/carbon/xenomorph/L in xeno_leader_list)
-		L.handle_xeno_leader_pheromones()
+	for(var/mob/living/carbon/xenomorph/xeno as anything in totalXenos)
+		xeno.handle_xeno_leader_pheromones()
 
 /// Returns a count of xenos that can potentially evolve to queen (larva and tier 1 that aren't job banned)
 /datum/hive_status/proc/get_potential_queen_count()
@@ -442,7 +442,7 @@
  * These are all called by the hive status UI manager to update its data
  */
 
-// Returns a list of how many of each caste of xeno there are, sorted by tier
+/// Returns a list of how many of each caste of xeno there are, sorted by tier
 /datum/hive_status/proc/get_xeno_counts()
 	// Every caste is manually defined here so you get
 	var/list/xeno_counts = list(
@@ -453,42 +453,44 @@
 		list(XENO_CASTE_BOILER = 0, XENO_CASTE_CRUSHER = 0, XENO_CASTE_PRAETORIAN = 0, XENO_CASTE_RAVAGER = 0)
 	)
 
-	for(var/mob/living/carbon/xenomorph/X in totalXenos)
+	for(var/mob/living/carbon/xenomorph/xeno as anything in totalXenos)
 		//don't show xenos in the thunderdome when admins test stuff.
-		if(should_block_game_interaction(X))
-			var/area/A = get_area(X)
-			if(!(A.flags_atom & AREA_ALLOW_XENO_JOIN))
+		if(should_block_game_interaction(xeno))
+			var/area/cur_area = get_area(xeno)
+			if(!(cur_area.flags_atom & AREA_ALLOW_XENO_JOIN))
 				continue
 
-		if(X.caste && X.counts_for_slots)
-			xeno_counts[X.caste.tier+1][X.caste.caste_type]++
+		if(xeno.caste && xeno.counts_for_slots)
+			xeno_counts[xeno.caste.tier+1][xeno.caste.caste_type]++
 
 	return xeno_counts
 
-// Returns a sorted list of some basic info (stuff that's needed for sorting) about all the xenos in the hive
-// The idea is that we sort this list, and use it as a "key" for all the other information (especially the nicknumber)
-// in the hive status UI. That way we can minimize the amount of sorts performed by only calling this when xenos are created/disposed
+/**
+ * Returns a sorted list of some basic info (stuff that's needed for sorting) about all the xenos in the hive
+ * The idea is that we sort this list, and use it as a "key" for all the other information (especially the nicknumber)
+ * in the hive status UI. That way we can minimize the amount of sorts performed by only calling this when xenos are created/disposed
+ */
 /datum/hive_status/proc/get_xeno_keys()
 	var/list/xenos = list()
 
-	for(var/mob/living/carbon/xenomorph/X in totalXenos)
-		if(should_block_game_interaction(X))
-			var/area/A = get_area(X)
-			if(!(A.flags_atom & AREA_ALLOW_XENO_JOIN))
+	for(var/mob/living/carbon/xenomorph/xeno as anything in totalXenos)
+		if(should_block_game_interaction(xeno))
+			var/area/cur_area = get_area(xeno)
+			if(!(cur_area.flags_atom & AREA_ALLOW_XENO_JOIN))
 				continue
 
-		if(!(X in GLOB.living_xeno_list))
+		if(!(xeno in GLOB.living_xeno_list))
 			continue
 
 		// This looks weird, but in DM adding List A to List B actually adds each item in List B to List A, not List B itself.
 		// Having a nested list like this sort of tricks it into adding the list instead.
 		// In this case this results in an array of different 'xeno' dictionaries, rather than just a dictionary.
 		xenos += list(list(
-			"nicknumber" = X.nicknumber,
-			"tier" = X.tier, // This one is only important for sorting
-			"is_leader" = (IS_XENO_LEADER(X)),
-			"is_queen" = istype(X.caste, /datum/caste_datum/queen),
-			"caste_type" = X.caste_type
+			"nicknumber" = xeno.nicknumber,
+			"tier" = xeno.tier, // This one is only important for sorting
+			"is_leader" = (IS_XENO_LEADER(xeno)),
+			"is_queen" = istype(xeno.caste, /datum/caste_datum/queen),
+			"caste_type" = xeno.caste_type
 		))
 
 	// Make it all nice and fancy by sorting the list before returning it
@@ -497,11 +499,13 @@
 		return sorted_keys
 	return xenos
 
-// This sorts the xeno info list by multiple criteria. Prioritized in order:
-// 1. Queen
-// 2. Leaders
-// 3. Tier
-// It uses a slightly modified insertion sort to accomplish this
+/**
+ * This sorts the xeno info list by multiple criteria. Prioritized in order:
+ * 1. Queen
+ * 2. Leaders
+ * 3. Tier
+ * It uses a slightly modified insertion sort to accomplish this
+ */
 /datum/hive_status/proc/sort_xeno_keys(list/xenos)
 	if(!length(xenos))
 		return
@@ -550,25 +554,25 @@
 
 	return sorted_list
 
-// Returns a list with some more info about all xenos in the hive
+/// Returns a list with some more info about all xenos in the hive
 /datum/hive_status/proc/get_xeno_info()
 	var/list/xenos = list()
 
-	for(var/mob/living/carbon/xenomorph/X in totalXenos)
-		if(should_block_game_interaction(X))
-			var/area/A = get_area(X)
-			if(!(A.flags_atom & AREA_ALLOW_XENO_JOIN))
+	for(var/mob/living/carbon/xenomorph/xeno as anything in totalXenos)
+		if(should_block_game_interaction(xeno))
+			var/area/cur_area = get_area(xeno)
+			if(!(cur_area.flags_atom & AREA_ALLOW_XENO_JOIN))
 				continue
 
-		var/xeno_name = X.name
+		var/xeno_name = xeno.name
 		// goddamn fucking larvas with their weird ass maturing system
 		// its name updates with its icon, unlike other castes which only update the mature/elder, etc. prefix on evolve
-		if(istype(X, /mob/living/carbon/xenomorph/larva))
-			xeno_name = "Larva ([X.nicknumber])"
-		xenos["[X.nicknumber]"] = list(
+		if(istype(xeno, /mob/living/carbon/xenomorph/larva))
+			xeno_name = "Larva ([xeno.nicknumber])"
+		xenos["[xeno.nicknumber]"] = list(
 			"name" = xeno_name,
-			"strain" = X.get_strain_name(),
-			"ref" = "\ref[X]"
+			"strain" = xeno.get_strain_name(),
+			"ref" = "\ref[xeno]"
 		)
 
 	return xenos
@@ -581,28 +585,28 @@
 	hive_location = C
 	hive_ui.update_hive_location()
 
-// Returns a list of xeno healths and locations
+/// Returns a list of xeno healths and locations
 /datum/hive_status/proc/get_xeno_vitals()
 	var/list/xenos = list()
 
-	for(var/mob/living/carbon/xenomorph/X in totalXenos)
-		if(should_block_game_interaction(X))
-			var/area/A = get_area(X)
-			if(!(A.flags_atom & AREA_ALLOW_XENO_JOIN))
+	for(var/mob/living/carbon/xenomorph/xeno as anything in totalXenos)
+		if(should_block_game_interaction(xeno))
+			var/area/cur_area = get_area(xeno)
+			if(!(cur_area.flags_atom & AREA_ALLOW_XENO_JOIN))
 				continue
 
-		if(!(X in GLOB.living_xeno_list))
+		if(!(xeno in GLOB.living_xeno_list))
 			continue
 
-		var/area/A = get_area(X)
+		var/area/cur_area = get_area(xeno)
 		var/area_name = "Unknown"
-		if(A)
-			area_name = A.name
+		if(cur_area)
+			area_name = cur_area.name
 
-		xenos["[X.nicknumber]"] = list(
-			"health" = round((X.health / X.maxHealth) * 100, 1),
+		xenos["[xeno.nicknumber]"] = list(
+			"health" = round((xeno.health / xeno.maxHealth) * 100, 1),
 			"area" = area_name,
-			"is_ssd" = (!X.client)
+			"is_ssd" = (!xeno.client)
 		)
 
 	return xenos
@@ -612,7 +616,7 @@
 #define OPEN_SLOTS "open_slots"
 #define GUARANTEED_SLOTS "guaranteed_slots"
 
-// Returns an assoc list of open slots and guaranteed slots left
+/// Returns an assoc list of open slots and guaranteed slots left
 /datum/hive_status/proc/get_tier_slots()
 	var/list/slots = list(
 		TIER_3 = list(
@@ -1002,7 +1006,7 @@
 
 	return TRUE
 
-// Get amount of real xenos, don't count lessers/huggers
+/// Get amount of real xenos, don't count lessers/huggers
 /datum/hive_status/proc/get_real_total_xeno_count()
 	var/count = 0
 	for(var/mob/living/carbon/xenomorph/xeno as anything in totalXenos)
@@ -1010,7 +1014,7 @@
 			count++
 	return count
 
-// Checks if we hit larva limit
+/// Checks if we hit larva limit
 /datum/hive_status/proc/check_if_hit_larva_from_pylon_limit()
 	var/groundside_humans_weighted_count = 0
 	for(var/mob/living/carbon/human/current_human as anything in GLOB.alive_human_list)
@@ -1350,7 +1354,7 @@
 	if(!(faction in FACTION_LIST_HUMANOID))
 		return
 
-	for(var/mob/living/carbon/xenomorph/xeno in totalXenos) // handle defecting xenos on betrayal
+	for(var/mob/living/carbon/xenomorph/xeno as anything in totalXenos) // handle defecting xenos on betrayal
 		if(!xeno.iff_tag)
 			continue
 		if(!(faction in xeno.iff_tag.faction_groups))
@@ -1378,7 +1382,7 @@
 	xeno.iff_tag = null
 
 /datum/hive_status/corrupted/proc/handle_defectors(faction)
-	for(var/mob/living/carbon/xenomorph/xeno in totalXenos)
+	for(var/mob/living/carbon/xenomorph/xeno as anything in totalXenos)
 		if(!xeno.iff_tag)
 			continue
 		if(xeno in defectors)
@@ -1436,7 +1440,7 @@
 	if(!length(personal_allies))
 		return
 	clear_personal_allies(TRUE)
-/// Hive buffs
+
 
 /// Get a list of hivebuffs which can be bought now.
 /datum/hive_status/proc/get_available_hivebuffs()

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -429,10 +429,13 @@
 			continue
 		switch(xeno.tier)
 			if(0)
-				if(islarva(xeno) && !ispredalienlarva(xeno))
-					if(xeno.client && xeno.ckey && !jobban_isbanned(xeno, XENO_CASTE_QUEEN))
-						potential_queens++
+				if(!islarva(xeno) || ispredalienlarva(xeno))
+					continue
+				if(xeno.client && xeno.ckey && !jobban_isbanned(xeno, XENO_CASTE_QUEEN))
+					potential_queens++
 			if(1)
+				if(isnull(xeno.caste.evolves_to) || !length(xeno.caste.evolves_to))
+					continue
 				if(xeno.client && xeno.ckey && !jobban_isbanned(xeno, XENO_CASTE_QUEEN))
 					potential_queens++
 	return potential_queens


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #7633 allowing all tier 1s that can evolve (so excludes predalien which some reason is a tier 1) an option to evolve to queen. I also fixed various evolve messaging issues, cleaned up evolve and hive_status code, and added some missing `as anything` usage to totalXenos in hive_status (half of the code already used `as anything`). See changelog for more details.

We could just add queen as an option to defender, sentinel, and runner always in the caste datum, but I figure only offering it when there is no queen is a middle ground between old behavior and shoring up the argument issued to me below.

# Explain why it's good for the game

It was argued that you could be in a situation where you de-evolve from say runner to become drone, but by the time you attempt to evolve to queen, someone else already evolved to queen, and now you are locked out from returning to your previous caste. So now de-evolution is no longer necessary if you are a runner defender or sentinel to become queen.

Also some messaging fixes and code cleanup.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/0QaKxqahTXk

</details>


# Changelog
:cl: Drathek
add: Defenders, Sentinels, and Runners can now also evolve to Queen if there is no queen (no need to de-evolve)
fix: Fixed incorrect evolve messaging when there is no queen (always would say queen had died recently)
fix: Fixed incorrect evolve messaging when the caste cannot evolve any further (would say there were no castes to evolve to currently)
fix: Fixed do_evolve considering queen job banned players as potential queen candidates
code: Cleaned up code in do_evolve and hive_status
/:cl:
