### PR TITLE
Kutjevo Synth Survivors

### DIFF
--- a/code/modules/clothing/suits/marine_armor/ert.dm
+++ b/code/modules/clothing/suits/marine_armor/ert.dm
@@ -142,6 +142,14 @@
 	flags_marine_armor |= SYNTH_ALLOWED
 	return ..()
 
+/obj/item/clothing/suit/storage/marine/veteran/pmc/light/synth/corporate
+	name = "\improper M1 pattern corporate synthetic armor"
+	desc = "A basic synthetic personnel vest with a Weyland-Yutani badge on the right breast. This is a rare sight, as low-level security units often aren't afforded the luxury of an accompanying synthetic. It has all of the armor inserts removed."
+	icon_state = "armor"
+	item_state = "armor"
+	storage_slots = 2
+	item_state_slots = list(WEAR_JACKET = "armor")
+
 /obj/item/clothing/suit/storage/marine/smartgunner/veteran/pmc
 	name = "\improper PMC gunner armor"
 	desc = "A modification of the standard Armat Systems M3 armor. Hooked up with harnesses and straps allowing the user to carry an M56 Smartgun."

--- a/code/modules/gear_presets/survivors/kutjevo/preset_kutjevo.dm
+++ b/code/modules/gear_presets/survivors/kutjevo/preset_kutjevo.dm
@@ -192,6 +192,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/kutjevo(new_human), WEAR_EYES)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/CMB(new_human), WEAR_JACKET)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(new_human), WEAR_HANDS)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/sec(new_human), WEAR_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/weapon/telebaton(new_human), WEAR_L_HAND)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/belt/security/MP/CMB/synth(new_human), WEAR_WAIST)
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/CMB/limited(new_human), WEAR_L_EAR)

--- a/code/modules/gear_presets/survivors/kutjevo/preset_kutjevo.dm
+++ b/code/modules/gear_presets/survivors/kutjevo/preset_kutjevo.dm
@@ -83,3 +83,160 @@
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/pmc/corporate/kutjevo, WEAR_HEAD)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/kutjevo, WEAR_EYES)
 	..()
+
+// Synths
+
+/datum/equipment_preset/synth/survivor/kutjevo
+	flags = EQUIPMENT_PRESET_STUB
+
+/datum/equipment_preset/synth/survivor/kutjevo/civilian
+	name = "Survivor - Kutjevo - Synthetic - Civilian"
+	flags = EQUIPMENT_PRESET_START_OF_ROUND
+
+	survivor_variant = CIVILIAN_SURVIVOR
+
+/datum/equipment_preset/synth/survivor/kutjevo/civilian/load_gear(mob/living/carbon/human/new_human)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/kutjevo(new_human), WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/kutjevo(new_human), WEAR_HEAD)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/kutjevo(new_human), WEAR_EYES)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots(new_human), WEAR_FEET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(new_human), WEAR_HANDS)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/norm(new_human), WEAR_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/twohanded/fireaxe, WEAR_L_HAND)
+	..()
+
+/datum/equipment_preset/synth/survivor/kutjevo/engineer
+	name = "Survivor - Kutjevo - Synthetic - Engineer"
+	flags = EQUIPMENT_PRESET_START_OF_ROUND
+
+	survivor_variant = ENGINEERING_SURVIVOR
+
+/datum/equipment_preset/synth/survivor/kutjevo/engineer/load_gear(mob/living/carbon/human/new_human)
+	var/choice = rand(1,2)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/kutjevo(new_human), WEAR_HEAD)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/kutjevo(new_human), WEAR_EYES)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots(new_human), WEAR_FEET)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/eng(new_human), WEAR_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/yellow(new_human), WEAR_HANDS)
+
+	switch(choice)
+		if(1)
+			new_human.equip_to_slot_or_del(new /obj/item/clothing/under/kutjevo/drysuit(new_human), WEAR_BODY)
+			new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/kutjevo (new_human), WEAR_FACE)
+			new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/hazardvest/black(new_human), WEAR_JACKET)
+		if(2)
+			new_human.equip_to_slot_or_del(new /obj/item/clothing/under/liaison_suit/brown(new_human), WEAR_BODY)
+			new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/hazardvest/yellow(new_human), WEAR_JACKET)
+			new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/smg/nailgun(new_human), WEAR_L_HAND)
+			new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/nailgun(new_human), WEAR_IN_JACKET)
+			new_human.equip_to_slot_or_del(new /obj/item/stack/sheet/metal/med_small_stack(new_human), WEAR_IN_BACK)
+	..()
+
+/datum/equipment_preset/synth/survivor/kutjevo/medical
+	name = "Survivor - Kutjevo - Synthetic - Medical"
+	flags = EQUIPMENT_PRESET_START_OF_ROUND
+
+	survivor_variant = MEDICAL_SURVIVOR
+
+/datum/equipment_preset/synth/survivor/kutjevo/medical/load_gear(mob/living/carbon/human/new_human)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/kutjevo(new_human), WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/kutjevo(new_human), WEAR_HEAD)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/health(new_human), WEAR_EYES)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/surgical(new_human), WEAR_FACE)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots(new_human), WEAR_FEET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/hazardvest/medical_red(new_human), WEAR_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/latex(new_human), WEAR_HANDS)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/med(new_human), WEAR_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/belt/medical/lifesaver/full(new_human), WEAR_WAIST)
+	new_human.equip_to_slot_or_del(new /obj/item/device/healthanalyzer(new_human), WEAR_IN_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/twohanded/fireaxe, WEAR_L_HAND)
+	..()
+
+/datum/equipment_preset/synth/survivor/kutjevo/corporate_security
+	name = "Survivor - Kutjevo - Synthetic - Corporate Security"
+	flags = EQUIPMENT_PRESET_START_OF_ROUND
+	idtype = /obj/item/card/id/silver/cl
+	role_comm_title = "WY Syn"
+
+	survivor_variant = SECURITY_SURVIVOR
+
+/datum/equipment_preset/synth/survivor/kutjevo/corporate_security/load_gear(mob/living/carbon/human/new_human)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/veteran/pmc/corporate/kutjevo(new_human), WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/pmc/corporate/kutjevo(new_human), WEAR_HEAD)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/kutjevo(new_human), WEAR_EYES)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/marine/veteran/pmc/light/synth/corporate(new_human), WEAR_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/corporate(new_human), WEAR_FEET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(new_human), WEAR_HANDS)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/lightpack/five_slot(new_human), WEAR_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/WY(new_human), WEAR_L_EAR)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/telebaton(new_human), WEAR_L_HAND)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/belt/security/MP/full/synth(new_human), WEAR_WAIST)
+	..()
+
+/datum/equipment_preset/synth/survivor/kutjevo/cmb_synth
+	name = "Survivor - Kutjevo - Synthetic - CMB"
+	flags = EQUIPMENT_PRESET_START_OF_ROUND
+	idtype = /obj/item/card/id/deputy
+	role_comm_title = "CMB Syn"
+	assignment = JOB_CMB_SYN
+	rank = JOB_CMB_SYN
+	paygrades = list(PAY_SHORT_CMBS = JOB_PLAYTIME_TIER_0)
+	faction = FACTION_MARSHAL
+	faction_group = list(FACTION_MARSHAL, FACTION_MARINE, FACTION_SURVIVOR)
+
+	survivor_variant = SECURITY_SURVIVOR
+
+/datum/equipment_preset/synth/survivor/kutjevo/cmb_synth/load_gear(mob/living/carbon/human/new_human)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/kutjevo(new_human), WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/kutjevo(new_human), WEAR_HEAD)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/kutjevo(new_human), WEAR_EYES)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/CMB(new_human), WEAR_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(new_human), WEAR_HANDS)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/telebaton(new_human), WEAR_L_HAND)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/belt/security/MP/CMB/synth(new_human), WEAR_WAIST)
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/CMB/limited(new_human), WEAR_L_EAR)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/holobadge/cord(new_human), WEAR_ACCESSORY)
+	..()
+
+/datum/equipment_preset/synth/survivor/kutjevo/scientist
+	name = "Survivor - Kutjevo - Synthetic - Scientist"
+	flags = EQUIPMENT_PRESET_START_OF_ROUND
+
+	survivor_variant = SCIENTIST_SURVIVOR
+
+/datum/equipment_preset/synth/survivor/kutjevo/scientist/load_gear(mob/living/carbon/human/new_human)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/kutjevo(new_human), WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/kutjevo(new_human), WEAR_HEAD)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/science(new_human), WEAR_EYES)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/labcoat/wy(new_human), WEAR_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/laceup(new_human), WEAR_FEET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/latex(new_human), WEAR_HANDS)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/tox(new_human), WEAR_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/belt/medical/full(new_human), WEAR_WAIST)
+	new_human.equip_to_slot_or_del(new /obj/item/device/motiondetector(new_human), WEAR_R_HAND)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/twohanded/fireaxe, WEAR_L_HAND)
+	new_human.equip_to_slot_or_del(new /obj/item/paper/research_notes/good(new_human), WEAR_IN_BACK)
+	..()
+
+/datum/equipment_preset/synth/survivor/kutjevo/corporate
+	name = "Survivor - Kutjevo - Synthetic - Corporate Assistant"
+	flags = EQUIPMENT_PRESET_START_OF_ROUND
+	idtype = /obj/item/card/id/silver/cl
+	role_comm_title = "WY Syn"
+
+	survivor_variant = CORPORATE_SURVIVOR
+
+/datum/equipment_preset/synth/survivor/kutjevo/corporate/load_gear(mob/living/carbon/human/new_human)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/liaison_suit/orange(new_human), WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/kutjevo(new_human), WEAR_HEAD)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/sunglasses(new_human), WEAR_EYES)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/jacket/marine/vest(new_human), WEAR_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/laceup(new_human), WEAR_FEET)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/lockable(new_human), WEAR_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/device/taperecorder(new_human), WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(new_human), WEAR_HANDS)
+	new_human.equip_to_slot_or_del(new /obj/item/tool/pen/clicky(new_human), WEAR_R_EAR)
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/WY(new_human), WEAR_L_EAR)
+	new_human.equip_to_slot_or_del(new /obj/item/notepad(new_human), WEAR_R_HAND)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/twohanded/fireaxe, WEAR_L_HAND)
+	..()

--- a/code/modules/gear_presets/survivors/kutjevo/preset_kutjevo.dm
+++ b/code/modules/gear_presets/survivors/kutjevo/preset_kutjevo.dm
@@ -102,7 +102,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots(new_human), WEAR_FEET)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(new_human), WEAR_HANDS)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/norm(new_human), WEAR_BACK)
-	new_human.equip_to_slot_or_del(new /obj/item/weapon/twohanded/fireaxe, WEAR_L_HAND)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/twohanded/fireaxe(new_human), WEAR_L_HAND)
 	..()
 
 /datum/equipment_preset/synth/survivor/kutjevo/engineer
@@ -122,7 +122,7 @@
 	switch(choice)
 		if(1)
 			new_human.equip_to_slot_or_del(new /obj/item/clothing/under/kutjevo/drysuit(new_human), WEAR_BODY)
-			new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/kutjevo (new_human), WEAR_FACE)
+			new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/kutjevo(new_human), WEAR_FACE)
 			new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/hazardvest/black(new_human), WEAR_JACKET)
 		if(2)
 			new_human.equip_to_slot_or_del(new /obj/item/clothing/under/liaison_suit/brown(new_human), WEAR_BODY)
@@ -149,7 +149,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/med(new_human), WEAR_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/belt/medical/lifesaver/full(new_human), WEAR_WAIST)
 	new_human.equip_to_slot_or_del(new /obj/item/device/healthanalyzer(new_human), WEAR_IN_JACKET)
-	new_human.equip_to_slot_or_del(new /obj/item/weapon/twohanded/fireaxe, WEAR_L_HAND)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/twohanded/fireaxe(new_human), WEAR_L_HAND)
 	..()
 
 /datum/equipment_preset/synth/survivor/kutjevo/corporate_security
@@ -214,7 +214,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/satchel/tox(new_human), WEAR_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/belt/medical/full(new_human), WEAR_WAIST)
 	new_human.equip_to_slot_or_del(new /obj/item/device/motiondetector(new_human), WEAR_R_HAND)
-	new_human.equip_to_slot_or_del(new /obj/item/weapon/twohanded/fireaxe, WEAR_L_HAND)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/twohanded/fireaxe(new_human), WEAR_L_HAND)
 	new_human.equip_to_slot_or_del(new /obj/item/paper/research_notes/good(new_human), WEAR_IN_BACK)
 	..()
 
@@ -238,5 +238,5 @@
 	new_human.equip_to_slot_or_del(new /obj/item/tool/pen/clicky(new_human), WEAR_R_EAR)
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/WY(new_human), WEAR_L_EAR)
 	new_human.equip_to_slot_or_del(new /obj/item/notepad(new_human), WEAR_R_HAND)
-	new_human.equip_to_slot_or_del(new /obj/item/weapon/twohanded/fireaxe, WEAR_L_HAND)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/twohanded/fireaxe(new_human), WEAR_L_HAND)
 	..()

--- a/maps/kutjevo.json
+++ b/maps/kutjevo.json
@@ -15,6 +15,15 @@
         "/datum/equipment_preset/survivor/clf",
         "/datum/equipment_preset/survivor/civilian"
     ],
+    "synth_survivor_types": [
+        "/datum/equipment_preset/synth/survivor/kutjevo/civilian",
+        "/datum/equipment_preset/synth/survivor/kutjevo/engineer",
+        "/datum/equipment_preset/synth/survivor/kutjevo/medical",
+        "/datum/equipment_preset/synth/survivor/kutjevo/corporate_security",
+        "/datum/equipment_preset/synth/survivor/kutjevo/cmb_synth",
+        "/datum/equipment_preset/synth/survivor/kutjevo/scientist",
+        "/datum/equipment_preset/synth/survivor/kutjevo/corporate"
+    ],
     "defcon_triggers": [
         4250,
         2950,


### PR DESCRIPTION

# About the pull request

This adds unique synthetic survivors to Kutjevo Refinery, as well as a subtype of PMC synth armor that uses the sprite of the goon vest and has one less storage slot, making it a direct downgrade from its higher quality counterpart. This subtype is only used for the corporate security synth survivor in this PR and nowhere else. Haven't done this in a while and I wouldn't be surprised if I made a few errors while writing this all, so I apologize in advance.

# Explain why it's good for the game

Having consistency with the survivors on a map is good, Kutjevo's survivors all have the map-specific standardized jumpsuits and helmet/goggle/mask combos, so the colony synthetics should also have these standardized outfits. For the most part I've tried to make them standard Kutjevo jumpsuits with a few exceptions where I thought the sprites fit well and added a bit of variety to the loadouts. Some of them may look same-y, but that's kind of the point. All of the regular human survivors also mostly look the same on account of the standard uniform.

I think the Corporate Security synth having the unique vest isn't an earth-shattering balance change, it's essentially a straight downgrade from just having a hazard vest or external webbing except for the fact it has a mounted light and can hold a general utility pouch. It's also not on par with its higher grade counterpart since it has one less storage slot. I intend for this to be used here and not for any ERTs or anything. Fits with the map's scattered goon corpses and the goon survivors that can also spawn.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![synths](https://github.com/user-attachments/assets/e16bbdb8-acbd-462c-a7a3-eee43cfaec6c)

Standard civilian, 2 engineer variants, medical, scientist, corporate security, liaison's assistant, CMB synth.

</details>


# Changelog

:cl: IowaPotatoFarmer
add: Added unique map-specific synthetic survivors to Kutjevo Refinery.
add: Added a lower quality goon squad synthetic vest, only used by the Kutjevo Refinery corporate security synth for now.
/:cl:
