### PR TITLE
Lets COs (or XOs if they're brave) fire their protag sidearms into the air

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -2081,3 +2081,43 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 /// Getter for gun_user
 /obj/item/weapon/gun/proc/get_gun_user()
 	return gun_user
+
+/obj/item/weapon/gun/proc/fire_into_air(mob/user)
+	if(!user || !isturf(user.loc) || !current_mag || !current_mag.current_rounds)
+		return
+
+	var/turf/gun_turf = user.loc
+	var/area/gun_area = gun_turf.loc
+
+	if(user.a_intent < INTENT_GRAB)
+		return TRUE
+
+	if(!skillcheck(user, SKILL_LEADERSHIP, SKILL_LEAD_MASTER)) // XO and CO
+		return TRUE
+
+	if(user.action_busy)
+		return
+
+	if(!do_after(user, 1.5 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
+		return
+
+	if(!current_mag || !current_mag.current_rounds)
+		return
+
+	current_mag.current_rounds--
+
+	if(gun_area.ceiling <= CEILING_GLASS)
+		gun_turf.ceiling_debris()
+
+	user.visible_message(SPAN_HIGHDANGER(uppertext("[user] FIRES THEIR [name] INTO THE AIR!")),
+	SPAN_HIGHDANGER(uppertext("YOU FIRE YOUR [name] INTO THE AIR!")))
+
+	playsound(user, fire_sound, 120, FALSE)
+
+	FOR_DVIEW(var/mob/mob, world.view, user, HIDE_INVISIBLE_OBSERVER)
+		if(mob && mob.client)
+			if(ishuman(mob))
+				shake_camera(mob, 3, 4)
+	FOR_DVIEW_END
+
+	update_icon()

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -257,6 +257,10 @@
 	recoil = RECOIL_AMOUNT_TIER_3
 	recoil_unwielded = RECOIL_AMOUNT_TIER_2
 
+/obj/item/weapon/gun/pistol/heavy/co/unique_action(mob/user)
+	if(fire_into_air(user))
+		return ..()
+
 /obj/item/weapon/gun/pistol/heavy/co/gold
 	name = "golden vintage Desert Eagle"
 	desc = "A Desert Eagle anodized in gold and adorned with rosewood grips. The living definition of ostentatious, it's flashy, unwieldy, tremendously heavy, and kicks like a mule. But as a symbol of power, there's nothing like it."

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -631,41 +631,8 @@
 	. = ..()
 
 /obj/item/weapon/gun/revolver/mateba/unique_action(mob/user)
-	if(!user || !isturf(user.loc) || !current_mag || !current_mag.current_rounds)
-		return
-
-	var/turf/mateba_turf = user.loc
-	var/area/mateba_area = mateba_turf.loc
-
-	if(user.a_intent < INTENT_GRAB)
+	if(fire_into_air(user))
 		return ..()
-
-	if(user.action_busy)
-		return
-
-	if(!do_after(user, 1.5 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
-		return
-
-	if(!current_mag || !current_mag.current_rounds)
-		return
-
-	current_mag.current_rounds--
-
-	if(mateba_area.ceiling <= CEILING_GLASS)
-		mateba_turf.ceiling_debris()
-
-	user.visible_message(SPAN_HIGHDANGER(uppertext("[user] FIRES THEIR [name] INTO THE AIR!")),
-	SPAN_HIGHDANGER(uppertext("YOU FIRE YOUR [name] INTO THE AIR!")))
-
-	playsound(user, fire_sound, 120, FALSE)
-
-	FOR_DVIEW(var/mob/mob, world.view, user, HIDE_INVISIBLE_OBSERVER)
-		if(mob && mob.client)
-			if(ishuman(mob))
-				shake_camera(mob, 3, 4)
-	FOR_DVIEW_END
-
-	update_icon()
 
 /obj/item/weapon/gun/revolver/mateba/set_gun_attachment_offsets()
 	attachable_offset = list("muzzle_x" = 25, "muzzle_y" = 20,"rail_x" = 11, "rail_y" = 24, "under_x" = 19, "under_y" = 17, "stock_x" = 19, "stock_y" = 17, "special_x" = 23, "special_y" = 22)

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -630,6 +630,42 @@
 			return
 	. = ..()
 
+/obj/item/weapon/gun/revolver/mateba/unique_action(mob/user)
+	if(!user || !isturf(user.loc) || !current_mag || !current_mag.current_rounds)
+		return
+
+	var/turf/mateba_turf = user.loc
+	var/area/mateba_area = mateba_turf.loc
+
+	if(user.a_intent < INTENT_GRAB)
+		return ..()
+
+	if(user.action_busy)
+		return
+
+	if(!do_after(user, 1.5 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
+		return
+
+	if(!current_mag || !current_mag.current_rounds)
+		return
+
+	current_mag.current_rounds--
+
+	if(mateba_area.ceiling <= CEILING_GLASS)
+		mateba_turf.ceiling_debris()
+
+	user.visible_message(SPAN_HIGHDANGER(uppertext("[user] FIRES THEIR [name] INTO THE AIR!")),
+	SPAN_HIGHDANGER(uppertext("YOU FIRE YOUR [name] INTO THE AIR!")))
+
+	playsound(user, fire_sound, 120, FALSE)
+
+	FOR_DVIEW(var/mob/mob, world.view, user, HIDE_INVISIBLE_OBSERVER)
+		if(mob && mob.client)
+			if(ishuman(mob))
+				shake_camera(mob, 3, 4)
+	FOR_DVIEW_END
+
+	update_icon()
 
 /obj/item/weapon/gun/revolver/mateba/set_gun_attachment_offsets()
 	attachable_offset = list("muzzle_x" = 25, "muzzle_y" = 20,"rail_x" = 11, "rail_y" = 24, "under_x" = 19, "under_y" = 17, "stock_x" = 19, "stock_y" = 17, "special_x" = 23, "special_y" = 22)


### PR DESCRIPTION
# About the pull request
Adds a new unique ability to the Mateba and deagle that lets it be fired into the air like the flare gun. Does NOT replace spinning the barrel, and can only be used on grab or harm intent.

# Explain why it's good for the game

Effective method of crowd control


# Testing Photographs and Procedure
https://github.com/user-attachments/assets/f064e102-5ebc-45eb-bbce-06bed8e7c3a0
# Changelog
:cl:
add: Mateba and CO Deagle unique ability 'fire into the air'
/:cl:
