### PR TITLE
Xeno overwatch QOL

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -550,7 +550,11 @@
 		return FALSE
 	if(HAS_TRAIT(user, TRAIT_ABILITY_BURROWED) || user.is_mob_incapacitated() || user.buckled)
 		return FALSE
-	user.overwatch(user.hive.living_xeno_queen)
+	//Xenos should not be able to track tunnels. Queen's weakref is equal to null if selected.
+	if(tracker_type != TRACKER_LEADER || !tracking_ref)
+		user.overwatch(user.hive.living_xeno_queen)
+		return
+	user.overwatch(tracking_ref.resolve())
 
 // Reset to the defaults
 /atom/movable/screen/queen_locator/proc/reset_tracking()

--- a/code/modules/mob/living/carbon/xenomorph/XenoOverwatch.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoOverwatch.dm
@@ -66,7 +66,7 @@
 // Third var is only for custom event handlers for OW hud indicators, currently only used for the Queen icon
 // If you use it, be sure to manually specify the second var, even if its the default value.
 /mob/living/carbon/xenomorph/proc/overwatch(mob/living/carbon/xenomorph/targetXeno, stop_overwatch = FALSE)
-	if(stop_overwatch)
+	if(stop_overwatch || (observed_xeno && targetXeno && observed_xeno == targetXeno))
 		var/mob/living/carbon/xenomorph/oldXeno = observed_xeno
 		observed_xeno = null
 
@@ -100,13 +100,6 @@
 
 		if(HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
 			to_chat(src, SPAN_XENOWARNING("We cannot do this in our current state!"))
-			return
-
-		if(observed_xeno && targetXeno && observed_xeno == targetXeno)
-			if(istype(targetXeno, /obj/effect/alien/resin/marker))
-				to_chat(src, SPAN_XENOWARNING("We are already watching that mark!"))
-				return
-			to_chat(src, SPAN_XENOWARNING("We are already watching that sister!"))
 			return
 
 		if(caste_type != XENO_CASTE_QUEEN && is_zoomed)


### PR DESCRIPTION

# About the pull request

changes the following things:

1. trying to overwatch a xeno you are already watching will make you stop watching themo
2. the hive tracker will now overwatch whatever leader you're currently tracking. trying to overwatch a tunnel will make you overwatch the queen instead. 

# Explain why it's good for the game

it's just a little bit of QOL. the watch button making you exit is something i'd expect it to already do, but it doesn't and it forces you to either click the ability button to exit or move around which is kind of annoying.
the hive tracker change makes personally makes sense to me, because if a player has it set to a leader they're going to be curious about where and what they're doing, more so than what the queen is doing (she's probably on ovi if you're choosing to track a leader)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>



https://github.com/user-attachments/assets/73e8358b-8557-4e71-a4b1-7deb6f7e1449







</details>


# Changelog
:cl:
qol: Clicking 'Watch' while already overwatching a xeno will now make you exit overwatch. You can now overwatch leader xenos with the hive tracker, instead of only being able to see the Queen.
/:cl:
