### PR TITLE
Flashing Lights Pref Toggle

### DIFF
--- a/code/__DEFINES/client_prefs.dm
+++ b/code/__DEFINES/client_prefs.dm
@@ -1,57 +1,123 @@
+//=================================================
 #define BE_ALIEN_AFTER_DEATH (1<<0)
 #define BE_AGENT (1<<1)
 #define BE_KING (1<<2)
+//=================================================
 
-/// Determines how abilities are activated, whether they're activated via middle click, shift click or right click.
+// Determines how abilities are activated, whether they're activated via middle click, shift click or right click.
+//=================================================
+///Xeno abilities are activated using middle mouse
 #define XENO_ABILITY_CLICK_MIDDLE 1
+///Xeno abilities are activated using shift right click
 #define XENO_ABILITY_CLICK_SHIFT 2
+///Xeno abilities are activated using right click
 #define XENO_ABILITY_CLICK_RIGHT 3
+//=================================================
 
 /// Update this to whatever the largest value of the XENO_ABILITY_CLICK_* defines is.
 #define XENO_ABILITY_CLICK_MAX 3
 
 //toggle_prefs bits from /datum/preferences
-#define TOGGLE_IGNORE_SELF (1<<0) // Determines whether you will not hurt yourself when clicking yourself
-#define TOGGLE_HELP_INTENT_SAFETY (1<<1) // Determines whether help intent will be completely harmless
+//=================================================
+///Determines whether you will not hurt yourself when clicking yourself
+#define TOGGLE_IGNORE_SELF (1<<0)
+///Determines whether help intent will be completely harmless
+#define TOGGLE_HELP_INTENT_SAFETY (1<<1)
 // Deprecated. Can't remove this or bitshift values down because it would fuck up the savefiles
 // Feel free to replace this whatever you want, if you can find a useful toggle for it. Alternatively, don't because savefiles using flags
 // Is a complete and utter mistake.
+///UNUSED CURRENTLY
 #define TOGGLE_FREE_PLACE_YOUR_OWN_TOGGLE_HERE (1<<2)
-#define TOGGLE_DIRECTIONAL_ATTACK (1<<3) // This toggles whether attacks for xeno use directional attacks
-#define TOGGLE_AUTO_EJECT_MAGAZINE_OFF (1<<4) // This toggles whether guns with auto ejectors will not auto eject their magazines
-												   // MUTUALLY EXCLUSIVE TO TOGGLE_AUTO_EJECT_MAGAZINE_TO_HAND
-#define TOGGLE_AUTO_EJECT_MAGAZINE_TO_HAND (1<<5) // This toggles whether guns with auto ejectors will cause you to unwield your gun and put the empty magazine in your hand
-												   // MUTUALLY EXCLUSIVE TO TOGGLE_AUTO_EJECT_MAGAZINE
-#define TOGGLE_EJECT_MAGAZINE_TO_HAND (1<<6) // This toggles whether manuallye jecting magazines from guns will cause you to unwield your gun
-												   // and put the empty magazine in your hand
-#define TOGGLE_AUTOMATIC_PUNCTUATION (1<<7) // Whether your sentences will automatically be punctuated with a period
-#define TOGGLE_COMBAT_CLICKDRAG_OVERRIDE (1<<8) // Whether disarm/harm intents cause clicks to trigger immediately when the mouse button is depressed.
-#define TOGGLE_ALTERNATING_DUAL_WIELD (1<<9) // Whether dual-wielding fires both guns at once or swaps between them, OUTDATED, used to update savefiles, now dual_wield_pref
-#define TOGGLE_FULLSCREEN (1<<10) // See /client/proc/update_fullscreen in client_procs.dm
-#define TOGGLE_MEMBER_PUBLIC (1<<11) //determines if you get a byond logo by your name in ooc if you're a member or not
-#define TOGGLE_OOC_FLAG (1<<12) // determines if your country flag appears by your name in ooc chat
-#define TOGGLE_MIDDLE_MOUSE_SWAP_HANDS (1<<13) //Toggle whether middle click swaps your hands
-#define TOGGLE_AMBIENT_OCCLUSION (1<<14) // toggles if ambient occlusion is turned on or off
-#define TOGGLE_VEND_ITEM_TO_HAND (1<<15) // This toggles whether items from vendors will be automatically put into your hand.
-#define TOGGLE_START_JOIN_CURRENT_SLOT (1<<16) // Whether joining at roundstart ignores assigned character slot for the job and uses currently selected slot.
-#define TOGGLE_LATE_JOIN_CURRENT_SLOT (1<<17) //Whether joining during the round ignores assigned character slot for the job and uses currently selected slot.
-#define TOGGLE_ABILITY_DEACTIVATION_OFF (1<<18) // This toggles whether selecting the same ability again can toggle it off
-#define TOGGLE_AMMO_DISPLAY_TYPE (1<<19)/// limit how often the ammo is displayed when using semi-automatic fire
-#define TOGGLE_AUTO_SHOVE_OFF (1<<20) /// Toggles between automatically shoving xenomorphs in the way as Queen.
+///This toggles whether attacks for xeno use directional attacks
+#define TOGGLE_DIRECTIONAL_ATTACK (1<<3)
+///This toggles whether guns with auto ejectors will not auto eject their magazines
+#define TOGGLE_AUTO_EJECT_MAGAZINE_OFF (1<<4)
+// MUTUALLY EXCLUSIVE TO TOGGLE_AUTO_EJECT_MAGAZINE_TO_HAND
+///This toggles whether guns with auto ejectors will cause you to unwield your gun and put the empty magazine in your hand
+#define TOGGLE_AUTO_EJECT_MAGAZINE_TO_HAND (1<<5)
+// MUTUALLY EXCLUSIVE TO TOGGLE_AUTO_EJECT_MAGAZINE
+///This toggles whether manuallye jecting magazines from guns will cause you to unwield your gun and put the empty magazine in your hand
+#define TOGGLE_EJECT_MAGAZINE_TO_HAND (1<<6)
+///Whether your sentences will automatically be punctuated with a period
+#define TOGGLE_AUTOMATIC_PUNCTUATION (1<<7)
+///Whether disarm/harm intents cause clicks to trigger immediately when the mouse button is depressed.
+#define TOGGLE_COMBAT_CLICKDRAG_OVERRIDE (1<<8)
+///Whether dual-wielding fires both guns at once or swaps between them, OUTDATED, used to update savefiles, now dual_wield_pref
+#define TOGGLE_ALTERNATING_DUAL_WIELD (1<<9)
+/// See /client/proc/update_fullscreen in client_procs.dm
+#define TOGGLE_FULLSCREEN (1<<10)
+///determines if you get a byond logo by your name in ooc if you're a member or not
+#define TOGGLE_MEMBER_PUBLIC (1<<11)
+/// determines if your country flag appears by your name in ooc chat
+#define TOGGLE_OOC_FLAG (1<<12)
+///Toggle whether middle click swaps your hands
+#define TOGGLE_MIDDLE_MOUSE_SWAP_HANDS (1<<13)
+///toggles if ambient occlusion is turned on or off
+#define TOGGLE_AMBIENT_OCCLUSION (1<<14)
+///This toggles whether items from vendors will be automatically put into your hand.
+#define TOGGLE_VEND_ITEM_TO_HAND (1<<15)
+///Whether joining at roundstart ignores assigned character slot for the job and uses currently selected slot.
+#define TOGGLE_START_JOIN_CURRENT_SLOT (1<<16)
+///Whether joining during the round ignores assigned character slot for the job and uses currently selected slot.
+#define TOGGLE_LATE_JOIN_CURRENT_SLOT (1<<17)
+///This toggles whether selecting the same ability again can toggle it off
+#define TOGGLE_ABILITY_DEACTIVATION_OFF (1<<18)
+///limit how often the ammo is displayed when using semi-automatic fire
+#define TOGGLE_AMMO_DISPLAY_TYPE (1<<19)
+///Toggles between automatically shoving xenomorphs in the way as Queen.
+#define TOGGLE_AUTO_SHOVE_OFF (1<<20)
+//=================================================
 
 #define JOB_SLOT_RANDOMISED_SLOT -1
 #define JOB_SLOT_CURRENT_SLOT 0
 #define JOB_SLOT_RANDOMISED_TEXT "Randomise name and appearance"
 #define JOB_SLOT_CURRENT_TEXT "Current character"
 
-#define AGE_MIN 19 //youngest a character can be
-#define AGE_MAX 90 //oldest a character can be //no. you are not allowed to be 160.
-#define MAX_GEAR_COST 7 //Used in chargen for loadout limit.
+///youngest a character can be
+#define AGE_MIN 19
+//oldest a character can be
+#define AGE_MAX 90
+///Used in chargen for loadout limit.
+#define MAX_GEAR_COST 7
 
-///dual_wield_pref from /datum/preferences
+//dual_wield_pref from /datum/preferences
+//=================================================
 ///Fire both weapons when dual wielding
 #define DUAL_WIELD_FIRE 0
 ///Swap to the other weapon when dual wielding
 #define DUAL_WIELD_SWAP 1
 ///Do nothing when dual wielding
 #define DUAL_WIELD_NONE 2
+//=================================================
+
+//=================================================
+///Do not show any item pickup animations
+#define SHOW_ITEM_ANIMATIONS_NONE 0
+///Toggles tg-style item animations on and off, default on.
+#define SHOW_ITEM_ANIMATIONS_HALF 1
+///Toggles being able to see animations that occur on the same tile.
+#define SHOW_ITEM_ANIMATIONS_ALL 2
+//=================================================
+
+//=================================================
+///Blurs your screen a varying amount depending on eye_blur.
+#define PAIN_OVERLAY_BLURRY 0
+///Impairs your screen like a welding helmet does depending on eye_blur.
+#define PAIN_OVERLAY_IMPAIR 1
+///Creates a legacy blurring effect over your screen if you have any eye_blur at all. Not recommended.
+#define PAIN_OVERLAY_LEGACY 2
+//=================================================
+
+//=================================================
+///Flashes your screen white.
+#define FLASH_OVERLAY_WHITE 0
+///Flashes your screen a dark grey.
+#define FLASH_OVERLAY_DARK 1
+//=================================================
+
+//=================================================
+///Overlays your screen white.
+#define CRIT_OVERLAY_WHITE 0
+///Overlays your screen a dark grey.
+#define CRIT_OVERLAY_DARK 1
+//=================================================

--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -69,34 +69,12 @@
 #define LATEJOIN_MARINES_PER_LATEJOIN_LARVA_EARLY 4
 #define LATEJOIN_MARINES_PER_LATEJOIN_LARVA 2.5
 
-//=================================================
-#define SHOW_ITEM_ANIMATIONS_NONE 0 //Do not show any item pickup animations
-#define SHOW_ITEM_ANIMATIONS_HALF 1 //Toggles tg-style item animations on and off, default on.
-#define SHOW_ITEM_ANIMATIONS_ALL 2 //Toggles being able to see animations that occur on the same tile.
-//=================================================
-
-//=================================================
-#define PAIN_OVERLAY_BLURRY 0 //Blurs your screen a varying amount depending on eye_blur.
-#define PAIN_OVERLAY_IMPAIR 1 //Impairs your screen like a welding helmet does depending on eye_blur.
-#define PAIN_OVERLAY_LEGACY 2 //Creates a legacy blurring effect over your screen if you have any eye_blur at all. Not recommended.
-//=================================================
-
-//=================================================
-#define FLASH_OVERLAY_WHITE 0 //Flashes your screen white.
-#define FLASH_OVERLAY_DARK 1 //Flashes your screen a dark grey.
-//=================================================
-
 #define NV_COLOR_GREEN "#39FF14"
 #define NV_COLOR_WHITE "#D3D3D3"
 #define NV_COLOR_ORANGE "#FFCC66"
 #define NV_COLOR_YELLOW "#FFFF66" //crazy ? i was crazy once
 #define NV_COLOR_RED "#FF3333"
 #define NV_COLOR_BLUE "#66CCFF"
-
-//=================================================
-#define CRIT_OVERLAY_WHITE 0 //Overlays your screen white.
-#define CRIT_OVERLAY_DARK 1 //Overlays your screen a dark grey.
-//=================================================
 
 /// Number of weighted marine players for 1 gear_scale. gear_scale is clamped to 1 minimum
 #define MARINE_GEAR_SCALING_NORMAL 50

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -56,6 +56,7 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 	/client/proc/set_eye_blur_type,
 	/client/proc/set_flash_type,
 	/client/proc/set_crit_type,
+	/client/proc/set_flashing_lights_pref,
 ))
 
 /client/proc/reduce_minute_count()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -83,6 +83,7 @@ GLOBAL_LIST_INIT(be_special_flags, list(
 	var/pain_overlay_pref_level = PAIN_OVERLAY_BLURRY
 	var/flash_overlay_pref = FLASH_OVERLAY_WHITE
 	var/crit_overlay_pref = CRIT_OVERLAY_WHITE
+	var/allow_flashing_lights_pref = FALSE
 	var/UI_style_color = "#ffffff"
 	var/UI_style_alpha = 255
 	var/View_MC = FALSE
@@ -569,6 +570,7 @@ GLOBAL_LIST_INIT(be_special_flags, list(
 			dat += "<b>Set Eye Blur Type:</b> <a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/set_eye_blur_type'>Set</a><br>"
 			dat += "<b>Set Flash Type:</b> <a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/set_flash_type'>Set</a><br>"
 			dat += "<b>Set Crit Type:</b> <a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/set_crit_type'>Set</a><br>"
+			dat += "<b>Allow Flashing Lights:</b> <a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/set_flashing_lights_pref'>Set</a><br>"
 			dat += "<b>Play Lobby Music:</b> <a href='byond://?_src_=prefs;preference=lobby_music'><b>[(toggles_sound & SOUND_LOBBY) ? "Yes" : "No"]</b></a><br>"
 			dat += "<b>Play VOX Announcements:</b> <a href='byond://?_src_=prefs;preference=sound_vox'><b>[(hear_vox) ? "Yes" : "No"]</b></a><br>"
 			dat += "<b>Default Ghost Night Vision Level:</b> <a href='byond://?_src_=prefs;preference=ghost_vision_pref;task=input'><b>[ghost_vision_pref]</b></a><br>"

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -271,6 +271,7 @@
 	S["pain_overlay_pref_level"] >> pain_overlay_pref_level
 	S["flash_overlay_pref"] >> flash_overlay_pref
 	S["crit_overlay_pref"] >> crit_overlay_pref
+	S["allow_flashing_lights_pref"] >> allow_flashing_lights_pref
 	S["stylesheet"] >> stylesheet
 	S["window_skin"] >> window_skin
 	S["fps"] >> fps
@@ -375,6 +376,7 @@
 	pain_overlay_pref_level = sanitize_integer(pain_overlay_pref_level, PAIN_OVERLAY_BLURRY, PAIN_OVERLAY_LEGACY, PAIN_OVERLAY_BLURRY)
 	flash_overlay_pref = sanitize_integer(flash_overlay_pref, FLASH_OVERLAY_WHITE, FLASH_OVERLAY_DARK)
 	crit_overlay_pref = sanitize_integer(crit_overlay_pref, CRIT_OVERLAY_WHITE, CRIT_OVERLAY_DARK)
+	allow_flashing_lights_pref = sanitize_integer(allow_flashing_lights_pref, FALSE, TRUE, FALSE)
 	window_skin = sanitize_integer(window_skin, 0, SHORT_REAL_LIMIT, initial(window_skin))
 	ghost_vision_pref = sanitize_inlist(ghost_vision_pref, list(GHOST_VISION_LEVEL_NO_NVG, GHOST_VISION_LEVEL_MID_NVG, GHOST_VISION_LEVEL_HIGH_NVG, GHOST_VISION_LEVEL_FULL_NVG), GHOST_VISION_LEVEL_MID_NVG)
 	ghost_orbit = sanitize_inlist(ghost_orbit, GLOB.ghost_orbits, initial(ghost_orbit))
@@ -485,6 +487,7 @@
 	S["pain_overlay_pref_level"] << pain_overlay_pref_level
 	S["flash_overlay_pref"] << flash_overlay_pref
 	S["crit_overlay_pref"] << crit_overlay_pref
+	S["allow_flashing_lights_pref"] << allow_flashing_lights_pref
 	S["stylesheet"] << stylesheet
 	S["be_special"] << be_special
 	S["default_slot"] << default_slot

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -284,6 +284,7 @@
 		"<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/set_eye_blur_type'>Set Eye Blur Type</a><br>",
 		"<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/set_flash_type'>Set Flash Type</a><br>",
 		"<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/set_crit_type'>Set Crit Type</a><br>",
+		"<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/set_flashing_lights_pref'>Set Flashing Lights</a><br>",
 	)
 
 	var/dat = ""
@@ -501,6 +502,17 @@
 		prefs.crit_overlay_pref = CRIT_OVERLAY_DARK
 		to_chat(src, SPAN_NOTICE("If in critical condition your vision will now be dark."))
 	prefs.save_preferences()
+
+/// Toggle in character preferences and toggle preferences to allow or disable flashing lights e.g. /obj/item/clothing/glasses/disco_fever
+/client/proc/set_flashing_lights_pref()
+	var/result = tgui_alert(src, "Allow effects that could trigger epilepsy?", "Allow flashing lights?", list("Allow", "Disable"))
+	if(!result)
+		return
+	prefs.allow_flashing_lights_pref = result == "Allow"
+	to_chat(src, SPAN_NOTICE("Flashing lights (e.g. AR Goggles) are now [prefs.allow_flashing_lights_pref ? "allowed" : "disabled"]."))
+	prefs.save_preferences()
+	if(!prefs.allow_flashing_lights_pref)
+		mob?.update_client_color_matrices()
 
 /client/verb/toggle_tgui_say()
 	set name = "Toggle Say Input Style"

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -503,16 +503,16 @@
 		to_chat(src, SPAN_NOTICE("If in critical condition your vision will now be dark."))
 	prefs.save_preferences()
 
-/// Toggle in character preferences and toggle preferences to allow or disable flashing lights e.g. /obj/item/clothing/glasses/disco_fever
+/// Toggle in character preferences and toggle preferences to allow or disable flashing lights e.g. /obj/item/clothing/glasses/disco_fever and druggy status
 /client/proc/set_flashing_lights_pref()
 	var/result = tgui_alert(src, "Allow effects that could trigger epilepsy?", "Allow flashing lights?", list("Allow", "Disable"))
 	if(!result)
 		return
 	prefs.allow_flashing_lights_pref = result == "Allow"
-	to_chat(src, SPAN_NOTICE("Flashing lights (e.g. AR Goggles) are now [prefs.allow_flashing_lights_pref ? "allowed" : "disabled"]."))
-	prefs.save_preferences()
+	to_chat(src, SPAN_NOTICE("Flashing lights (e.g. AR Goggles and Happy pills) are now [prefs.allow_flashing_lights_pref ? "allowed" : "disabled"]."))
 	if(!prefs.allow_flashing_lights_pref)
-		mob?.update_client_color_matrices()
+		mob?.update_client_color_matrices() // Update immediately
+	prefs.save_preferences()
 
 /client/verb/toggle_tgui_say()
 	set name = "Toggle Say Input Style"

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -477,6 +477,10 @@
 	if(!user.client) //Shouldn't happen but can't hurt to check.
 		return
 
+	if(!user.client.prefs?.allow_flashing_lights_pref)
+		to_chat(user, SPAN_NOTICE("Your preferences don't allow the effect from [src]."))
+		return
+
 	var/base_colors
 	if(!user.client.color) //No set client color.
 		base_colors = color_matrix_saturation(1.35) //Crank up the saturation and get ready to party.

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -93,7 +93,7 @@
 		else if((disabilities & NEARSIGHTED) && HAS_TRAIT(src, TRAIT_NEARSIGHTED_EQUIPMENT) && pain.current_pain < 80 && peepers.organ_status == ORGAN_HEALTHY)
 			SetEyeBlur(0)
 
-		if(druggy)
+		if(druggy && src.client?.prefs?.allow_flashing_lights_pref)
 			overlay_fullscreen("high", /atom/movable/screen/fullscreen/high)
 		else
 			clear_fullscreen("high")


### PR DESCRIPTION

# About the pull request

This PR adds a preference to opt in (as in flashing effects are disabled by default) to flashing effects like the AR goggles and the happy pills. You can set this both in character preferences and the toggle preferences menu.

I also autodoc'd most of the defines for client prefs.

# Explain why it's good for the game

More preferences for something that suddenly is contentious.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/f2526773-243f-4ec0-8b3c-e987f9053a3b)
![disco](https://github.com/user-attachments/assets/b3951017-96df-49b5-8378-97dd57187ac5)

</details>


# Changelog
:cl: Drathek
add: Added a preference to opt in for flashing lights (e.g. AR goggles and happy pills)
code: Cleanup client_prefs
/:cl:
