### PR TITLE
OD2001 Pragma for ScopeOperandNamedType

### DIFF
--- a/code/__pragmas.dm
+++ b/code/__pragmas.dm
@@ -24,6 +24,7 @@
 #pragma InvalidIndexOperation error
 #pragma PointlessPositionalArgument error
 #pragma ProcArgumentGlobal error
+#pragma ScopeOperandNamedType error
 
 //3000-3999
 #pragma EmptyBlock error


### PR DESCRIPTION

# About the pull request

Sets OD2001 as an error. Unlikely there's any current bad usage of this.

> Using scope operator :: on a variable named "type" or "parent_type" is ambiguous. Consider changing the variable name from "type".

# Explain why it's good for the game

More lints!

# Testing Photographs and Procedure
See checks.


# Changelog
:cl: Drathek
code: Set ScopeOperandNamedType to be an error
/:cl:
