### PR TITLE
Remove unused variables for dancer behavior delegate

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/dancer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/dancer.dm
@@ -31,15 +31,8 @@
 /datum/behavior_delegate/praetorian_dancer
 	name = "Praetorian Dancer Behavior Delegate"
 
-	var/evasion_buff_amount = 40
-	var/evasion_buff_ttl = 25  // 2.5 seconds seems reasonable
-
 	// State
-	var/next_slash_buffed = FALSE
-	var/slash_evasion_buffed = FALSE
-	var/slash_evasion_timer = TIMER_ID_NULL
 	var/dodge_activated = FALSE
-
 
 /datum/behavior_delegate/praetorian_dancer/melee_attack_additional_effects_target(mob/living/carbon/target_carbon)
 	if (!isxeno_human(target_carbon))


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #2244 and confusion resulting in #8578 from the lingering unused variables for the dancer behavior delegate. I have already updated the wiki passive template.

# Explain why it's good for the game

Less confusion in the code.

# Changelog
:cl: Drathek
code: Removed unused variables in dancer behavior delegate
/:cl:
