### PR TITLE
fix dark theme getting set everytime a payload doesn't touch theme

### DIFF
--- a/tgui/packages/tgui-panel/settings/middleware.js
+++ b/tgui/packages/tgui-panel/settings/middleware.js
@@ -47,16 +47,17 @@ export const settingsMiddleware = (store) => {
       type === updateHighlightSetting.type
     ) {
       // Set client theme
-      let theme = payload?.theme;
-      if (!theme) {
+      const theme = payload?.theme;
+      if (theme) {
+        setClientTheme(theme);
+      } else if (type === loadSettings.type) {
         store.dispatch(
           updateSettings({
             theme: THEMES[0],
           }),
         );
-        theme = THEMES[0];
+        setClientTheme(THEMES[0]);
       }
-      setClientTheme(theme);
       // Pass action to get an updated state
       next(action);
       const settings = selectSettings(store.getState());


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR is a follow up to #7716 fixing the below issue. Not every payload will have theme info, so we only want to default the theme when loading the settings, not on every payload.

# Explain why it's good for the game

Fixes #8583 

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

![theme](https://github.com/user-attachments/assets/1147b260-bec6-42a3-9b21-e56d49cd8257)

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Drathek
fix: Fixed chat theme always defaulting to dark on a setting change
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
