### PR TITLE
Disablers/batons can now stun xenomorphs

### DIFF
--- a/code/datums/ammo/energy.dm
+++ b/code/datums/ammo/energy.dm
@@ -38,6 +38,17 @@
 		var/mob/living/carbon/human/humanus = mobs
 		humanus.disable_special_items() // Disables scout cloak
 		humanus.make_jittery(40)
+	if(isxeno(mobs))
+		var/mob/living/carbon/xenomorph/beno = mobs
+		if(beno.caste.caste_type in XENO_T0_CASTES)
+			beno.apply_effect(2, WEAKEN) // shock those small critters
+			beno.xeno_jitter(2 SECONDS)
+
+		if(beno.caste.caste_type in (XENO_T1_CASTES + XENO_T2_CASTES))
+			beno.apply_effect(1, SLOW)
+			beno.xeno_jitter(1 SECONDS) // small shock to T1s and T2s xenos pretty much just for the effects
+		else
+			return
 
 /datum/ammo/energy/taser/precise
 	name = "precise taser bolt"

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -154,8 +154,17 @@
 				human_target.visible_message(SPAN_DANGER("[human_target] has been prodded with [src] by [user]!"))
 
 	//stun effects
+	if(isxeno(target))
+		var/mob/living/carbon/xenomorph/beno = target
+		if(beno.caste.caste_type in XENO_T0_CASTES)
+			beno.apply_effect(2, WEAKEN) // shock those small critters
+			beno.xeno_jitter(2 SECONDS)
 
-	if(!isyautja(human_target) && !isxeno(human_target)) //Xenos and Predators are IMMUNE to all baton stuns.
+		if(beno.caste.caste_type in (XENO_T1_CASTES + XENO_T2_CASTES))
+			beno.apply_effect(1, SLOW)
+			beno.xeno_jitter(1 SECONDS) // small shock to T1s and T2s xenos pretty much just for the effects
+
+	if(!isyautja(human_target)) //Predators are IMMUNE to all baton stuns.
 		human_target.emote("pain")
 		human_target.apply_stamina_damage(stunforce, target_zone, ARMOR_ENERGY)
 		human_target.sway_jitter(2,1)


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Tasers can now stun Larvas , facehuggers and lesser drones for a short duration. this is not really impactfull in any way but i think it feels cool that you can shock the small xenomorphs. 

on T1s and T2s it makes them jitter and slows for 1 second. (non stackable)

T3 , queen and special castes it does nothing.

# Explain why it's good for the game
i feel it a small thing that looks really cool and can be used for RP or maybe on events. doesnt really have any meaningful impact on normal play so even better.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Disablers shots can now stun small xenomorphs (T0) and slow for 1 second (T1,T2)
add: Energized baton hits stun small xenomorphs (T0) and slow for 1 second (T1 , T2)
/:cl:
