### PR TITLE
Allows BFA on M4RA

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1758,6 +1758,7 @@
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/extended_barrel,
 		/obj/item/attachable/magnetic_harness,
+		/obj/item/attachable/burstfire_assembly,
 		/obj/item/attachable/bipod,
 		/obj/item/attachable/verticalgrip,
 		/obj/item/attachable/angledgrip,

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1780,6 +1780,7 @@
 /obj/item/weapon/gun/rifle/m4ra/set_gun_config_values()
 	..()
 	set_fire_delay(FIRE_DELAY_TIER_9)
+	set_burst_delay(FIRE_DELAY_TIER_9)
 	set_burst_amount(0)
 	accuracy_mult = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_5
 	if(SSticker.mode && MODE_HAS_FLAG(MODE_FACTION_CLASH))


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->
allows the burst fire assembly to be used on the M4RA
adds base burst fire delay to M4RA ( only affects BFA)

# Explain why it's good for the game
provides burst fire to your battle rifle with the proper downsides of using the attachment slot , alternative version of #8048
gives you an alternative way of using the M4RA for closer encounters.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Burst fire assembly now fits on the M4RA
balance: Adds burst fire delay for M4RA
/:cl:
