### PR TITLE
Add check for GLOBAL_SUBTYPE_PATH_INDEXED trampling

### DIFF
--- a/code/__DEFINES/_globals.dm
+++ b/code/__DEFINES/_globals.dm
@@ -28,6 +28,8 @@
 	##X = list();\
 	for(var/t in subtypesof(TypePath)){\
 		var##TypePath/A = t;\
+		var##TypePath/existing = ##X[initial(A.##Index)];\
+		if(existing && !isnull(initial(A.##Index))) stack_trace("'[initial(A.##Index)]' index for [t] in [#X] overlaps with [existing]! It must have a unique index for lookup!");\
 		##X[initial(A.##Index)] = t;\
 	}\
 	gvars_datum_init_order += #X;\

--- a/code/datums/supply_packs/_supply_packs.dm
+++ b/code/datums/supply_packs/_supply_packs.dm
@@ -7,7 +7,7 @@
 // The lists of supply groups and contraband groups have been moved to /obj/structure/machinery/computer/supply/asrs definition as static variables.
 
 /datum/supply_packs
-	var/name = "Basic supply pack."
+	var/name = null // Abstract type
 	/// If this variable is null (not if it's an empty list), *and* so is containertype, it won't show up on the order computer.
 	var/list/contains = list()
 	var/manifest = ""

--- a/code/datums/supply_packs/black_market.dm
+++ b/code/datums/supply_packs/black_market.dm
@@ -16,8 +16,7 @@ black market prices are NOT based on real or in-universe costs. they are based o
 
 */
 
-/datum/supply_packs/contraband //base
-	name = "contraband crate"
+/datum/supply_packs/contraband // Abstract type (null name)
 	contains = null
 	containertype = null
 	containername = "large crate"

--- a/code/datums/supply_packs/upp_ammo.dm
+++ b/code/datums/supply_packs/upp_ammo.dm
@@ -1,5 +1,5 @@
 /datum/supply_packs/upp/ammo_rounds_box_5_45x39mm
-	name = "ammo box crate (5.45x39mm) (x600 rounds)"
+	name = "UPP ammo box crate (5.45x39mm) (x600 rounds)"
 	contains = list(
 		/obj/item/ammo_box/rounds/type71,
 	)
@@ -9,7 +9,7 @@
 	group = "UPP Ammo"
 
 /datum/supply_packs/upp/ammo_rounds_box_5_45x39mm_ap
-	name = "ammo box crate (5.45x39mm AP) (x600 rounds)"
+	name = "UPP ammo box crate (5.45x39mm AP) (x600 rounds)"
 	contains = list(
 		/obj/item/ammo_box/rounds/type71/ap,
 	)
@@ -20,7 +20,7 @@
 
 
 /datum/supply_packs/upp/ammo_8g_slug
-	name = "Magazine box (Type 23, 20x slug)"
+	name = "UPP Magazine box (Type 23, 20x slug)"
 	contains = list(
 		/obj/item/ammo_magazine/handful/shotgun/heavy/slug,
 		/obj/item/ammo_magazine/handful/shotgun/heavy/slug,
@@ -69,7 +69,7 @@
 
 
 /datum/supply_packs/upp/ammo_Type64_x10
-	name = "Magazine box (Type 64, 10x regular mags)"
+	name = "UPP Magazine box (Type 64, 10x regular mags)"
 	contains = list(
 		/obj/item/ammo_box/magazine/type64,
 	)
@@ -79,7 +79,7 @@
 	group = "UPP Ammo"
 
 /datum/supply_packs/upp/ammo_Type71_box
-	name = "Magazine box (Type 71, 10x regular mags)"
+	name = "UPP Magazine box (Type 71, 10x regular mags)"
 	contains = list(
 		/obj/item/ammo_box/magazine/type71,
 	)
@@ -89,7 +89,7 @@
 	group = "UPP Ammo"
 
 /datum/supply_packs/upp/ammo_Type71_box_ap
-	name = "Magazine box (Type 71, 10x AP mags)"
+	name = "UPP Magazine box (Type 71, 10x AP mags)"
 	contains = list(
 		/obj/item/ammo_box/magazine/type71/ap,
 	)
@@ -99,7 +99,7 @@
 	group = "UPP Ammo"
 
 /datum/supply_packs/upp/ammo_m2c_upp
-	name = "M2C ammunition crate (x2)"
+	name = "UPP M2C ammunition crate (x2)"
 	contains = list(
 		/obj/item/ammo_magazine/m2c,
 		/obj/item/ammo_magazine/m2c,
@@ -110,7 +110,7 @@
 	group = "UPP Ammo"
 
 /datum/supply_packs/upp/ammo_pkp_mags
-	name = "Magazines (QYJ-72, 4x mags)"
+	name = "UPP Magazines (QYJ-72, 4x mags)"
 	contains = list(
 		/obj/item/ammo_magazine/pkp,
 		/obj/item/ammo_magazine/pkp,
@@ -123,7 +123,7 @@
 	group = "UPP Ammo"
 
 /datum/supply_packs/upp/ammo_minigun_mags
-	name = "Magazines (GSh-7.62, 4x mags)"
+	name = "UPP Magazines (GSh-7.62, 4x mags)"
 	contains = list(
 		/obj/item/ammo_magazine/minigun,
 		/obj/item/ammo_magazine/minigun,
@@ -136,7 +136,7 @@
 	group = "UPP Special Ammo"
 
 /datum/supply_packs/upp/ammo_rpg_he
-	name = "HJRA-12 HE Rocket Crate (x3)"
+	name = "UPP HJRA-12 HE Rocket Crate (x3)"
 	contains = list(
 		/obj/item/ammo_magazine/rocket/upp,
 		/obj/item/ammo_magazine/rocket/upp,
@@ -148,7 +148,7 @@
 	group = "UPP Special Ammo"
 
 /datum/supply_packs/upp/ammo_rpg_ap
-	name = "HJRA-12 AP Rocket Crate (x3)"
+	name = "UPP HJRA-12 AP Rocket Crate (x3)"
 	contains = list(
 		/obj/item/ammo_magazine/rocket/upp/at,
 		/obj/item/ammo_magazine/rocket/upp/at,
@@ -160,7 +160,7 @@
 	group = "UPP Special Ammo"
 
 /datum/supply_packs/upp/ammo_rpg_wp
-	name = "HJRA-12 Extreme-Intensity Incendiary Rocket Crate (x3)"
+	name = "UPP HJRA-12 Extreme-Intensity Incendiary Rocket Crate (x3)"
 	contains = list(
 		/obj/item/ammo_magazine/rocket/upp/incen,
 		/obj/item/ammo_magazine/rocket/upp/incen,

--- a/code/datums/supply_packs/upp_attachments.dm
+++ b/code/datums/supply_packs/upp_attachments.dm
@@ -1,5 +1,5 @@
-/datum/supply_packs/upp/rail_reddot_upp
-	name = "red-dot sight attachment crate (x8)"
+/datum/supply_packs/upp/rail_reddot
+	name = "UPP red-dot sight attachment crate (x8)"
 	contains = list(
 		/obj/item/attachable/reddot,
 		/obj/item/attachable/reddot,
@@ -15,8 +15,8 @@
 	containername = "red-dot sight attachment crate"
 	group = "UPP Attachments"
 
-/datum/supply_packs/upp/rail_scope_upp
-	name = "railscope attachment crate (x2)"
+/datum/supply_packs/upp/rail_scope
+	name = "UPP railscope attachment crate (x2)"
 	contains = list(
 		/obj/item/attachable/scope,
 		/obj/item/attachable/scope,
@@ -26,8 +26,8 @@
 	containername = "scope attachment crate"
 	group = "UPP Attachments"
 
-/datum/supply_packs/upp/rail_miniscope_upp
-	name = "mini railscope attachment crate (x2)"
+/datum/supply_packs/upp/rail_miniscope
+	name = "UPP mini railscope attachment crate (x2)"
 	contains = list(
 		/obj/item/attachable/scope/mini,
 		/obj/item/attachable/scope/mini,
@@ -37,8 +37,8 @@
 	containername = "mini scope attachment crate"
 	group = "UPP Attachments"
 
-/datum/supply_packs/upp/rail_magneticharness_upp
-	name = "magnetic harness attachment crate (x6)"
+/datum/supply_packs/upp/rail_magneticharness
+	name = "UPP magnetic harness attachment crate (x6)"
 	contains = list(
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/magnetic_harness,
@@ -52,8 +52,8 @@
 	containername = "magnetic harness attachment crate"
 	group = "UPP Attachments"
 
-/datum/supply_packs/upp/muzzle_suppressor_upp
-	name = "suppressor attachment crate (x8)"
+/datum/supply_packs/upp/muzzle_suppressor
+	name = "UPP suppressor attachment crate (x8)"
 	contains = list(
 		/obj/item/attachable/suppressor,
 		/obj/item/attachable/suppressor,
@@ -69,8 +69,8 @@
 	containername = "suppressor attachment crate"
 	group = "UPP Attachments"
 
-/datum/supply_packs/upp/muzzle_extended_upp
-	name = "extended barrel attachment crate (x6)"
+/datum/supply_packs/upp/muzzle_extended
+	name = "UPP extended barrel attachment crate (x6)"
 	contains = list(
 		/obj/item/attachable/extended_barrel,
 		/obj/item/attachable/extended_barrel,
@@ -84,8 +84,8 @@
 	containername = "extended barrel attachment crate"
 	group = "UPP Attachments"
 
-/datum/supply_packs/upp/muzzle_compensator_upp
-	name = "compensator attachment crate (x6)"
+/datum/supply_packs/upp/muzzle_compensator
+	name = "UPP compensator attachment crate (x6)"
 	contains = list(
 		/obj/item/attachable/compensator,
 		/obj/item/attachable/compensator,
@@ -99,8 +99,8 @@
 	containername = "compensator attachment crate"
 	group = "UPP Attachments"
 
-/datum/supply_packs/upp/underbarrel_foregrip_upp
-	name = "foregrip attachment crate (x8)"
+/datum/supply_packs/upp/underbarrel_foregrip
+	name = "UPP foregrip attachment crate (x8)"
 	contains = list(
 		/obj/item/attachable/verticalgrip,
 		/obj/item/attachable/verticalgrip,
@@ -116,8 +116,8 @@
 	containername = "foregrip attachment crate"
 	group = "UPP Attachments"
 
-/datum/supply_packs/upp/underbarrel_gyro_upp
-	name = "gyroscopic stabilizer attachment crate (x2)"
+/datum/supply_packs/upp/underbarrel_gyro
+	name = "UPP gyroscopic stabilizer attachment crate (x2)"
 	contains = list(
 		/obj/item/attachable/gyro,
 		/obj/item/attachable/gyro,
@@ -127,8 +127,8 @@
 	containername = "gyro attachment crate"
 	group = "UPP Attachments"
 
-/datum/supply_packs/upp/underbarrel_bipod_upp
-	name = "bipod attachment crate (x6)"
+/datum/supply_packs/upp/underbarrel_bipod
+	name = "UPP bipod attachment crate (x6)"
 	contains = list(
 		/obj/item/attachable/bipod,
 		/obj/item/attachable/bipod,
@@ -142,8 +142,8 @@
 	containername = "bipod attachment crate"
 	group = "UPP Attachments"
 
-/datum/supply_packs/upp/underbarrel_shotgun_upp
-	name = "underbarrel shotgun attachment crate (x4)"
+/datum/supply_packs/upp/underbarrel_shotgun
+	name = "UPP underbarrel shotgun attachment crate (x4)"
 	contains = list(
 		/obj/item/attachable/attached_gun/shotgun,
 		/obj/item/attachable/attached_gun/shotgun,
@@ -155,8 +155,8 @@
 	containername = "shotgun attachment crate"
 	group = "UPP Attachments"
 
-/datum/supply_packs/upp/underbarrel_extinguisher_upp
-	name = "underbarrel extinguisher attachment crate (x4)"
+/datum/supply_packs/upp/underbarrel_extinguisher
+	name = "UPP underbarrel extinguisher attachment crate (x4)"
 	contains = list(
 		/obj/item/attachable/attached_gun/extinguisher,
 		/obj/item/attachable/attached_gun/extinguisher,
@@ -168,8 +168,8 @@
 	containername = "shotgun attachment crate"
 	group = "UPP Attachments"
 
-/datum/supply_packs/upp/underbarrel_flamer_upp
-	name = "underbarrel flamer attachment crate (x4)"
+/datum/supply_packs/upp/underbarrel_flamer
+	name = "UPP underbarrel flamer attachment crate (x4)"
 	contains = list(
 		/obj/item/attachable/attached_gun/flamer,
 		/obj/item/attachable/attached_gun/flamer,
@@ -181,8 +181,8 @@
 	containername = "flamer attachment crate"
 	group = "UPP Attachments"
 
-/datum/supply_packs/upp/underbarrel_burstfire_assembly_upp
-	name = "burstfire assembly attachment crate (x2)"
+/datum/supply_packs/upp/underbarrel_burstfire_assembly
+	name = "UPP burstfire assembly attachment crate (x2)"
 	contains = list(
 		/obj/item/attachable/burstfire_assembly,
 		/obj/item/attachable/burstfire_assembly,
@@ -192,8 +192,8 @@
 	containername = "burstfire assembly attachment crate"
 	group = "UPP Attachments"
 
-/datum/supply_packs/upp/s_attachables_upp
-	name = "stock attachments crate (x3 each , 1 paratroopers)"
+/datum/supply_packs/upp/s_attachables
+	name = "UPP stock attachments crate (x3 each , 1 paratroopers)"
 	contains = list(
 		/obj/item/attachable/stock/revolver,
 		/obj/item/attachable/stock/revolver,
@@ -217,8 +217,8 @@
 	containername = "stocks crate"
 	group = "UPP Attachments"
 
-/datum/supply_packs/upp/stock_revolver_upp
-	name = "revolver stock attachment crate (x4)"
+/datum/supply_packs/upp/stock_revolver
+	name = "UPP revolver stock attachment crate (x4)"
 	contains = list(
 		/obj/item/attachable/stock/revolver,
 		/obj/item/attachable/stock/revolver,
@@ -230,8 +230,8 @@
 	containername = "stock revolver attachment crate"
 	group = "UPP Attachments"
 
-/datum/supply_packs/upp/stock_rifle_upp
-	name = "rifle stock attachment crate (x4)"
+/datum/supply_packs/upp/stock_rifle
+	name = "UPP rifle stock attachment crate (x4)"
 	contains = list(
 		/obj/item/attachable/stock/rifle,
 		/obj/item/attachable/stock/rifle,
@@ -243,8 +243,8 @@
 	containername = "stock rifle attachment crate"
 	group = "UPP Attachments"
 
-/datum/supply_packs/upp/stock_shotgun_upp
-	name = "shotgun stock attachment crate (x4)"
+/datum/supply_packs/upp/stock_shotgun
+	name = "UPP shotgun stock attachment crate (x4)"
 	contains = list(
 		/obj/item/attachable/stock/shotgun,
 		/obj/item/attachable/stock/shotgun,
@@ -256,8 +256,8 @@
 	containername = "stock shotgun attachment crate"
 	group = "UPP Attachments"
 
-/datum/supply_packs/upp/stock_smg_upp
-	name = "submachinegun stock attachment crate (x4)"
+/datum/supply_packs/upp/stock_smg
+	name = "UPP submachinegun stock attachment crate (x4)"
 	contains = list(
 		/obj/item/attachable/stock/smg,
 		/obj/item/attachable/stock/smg,

--- a/code/datums/supply_packs/upp_clothing.dm
+++ b/code/datums/supply_packs/upp_clothing.dm
@@ -1,5 +1,5 @@
 /datum/supply_packs/upp/ushanka_crate
-	name = "Ushanka crate (x10)"
+	name = "UPP Ushanka crate (x10)"
 	contains = list(
 		/obj/item/clothing/head/uppcap/ushanka,
 		/obj/item/clothing/head/uppcap/ushanka,

--- a/code/datums/supply_packs/upp_crates.dm
+++ b/code/datums/supply_packs/upp_crates.dm
@@ -1,12 +1,11 @@
-/datum/supply_packs/upp //base
-	name = "UPP crate"
+/datum/supply_packs/upp // Abstract type (null name)
 	contains = null
 	containertype = null
 	containername = "large crate"
 	group = "UPP"
 
 /datum/supply_packs/upp/random_weapon
-	name = "Old supplies (Weapon)"
+	name = "UPP Old supplies (Weapon)"
 	cost = 5
 	containertype = /obj/structure/closet/crate/weapon
 	containername = "Old supplies crate (Weapon)"

--- a/code/datums/supply_packs/upp_engineering.dm
+++ b/code/datums/supply_packs/upp_engineering.dm
@@ -1,13 +1,13 @@
-/datum/supply_packs/upp/sandbags_upp
-	name = "empty sandbags crate (x50)"
+/datum/supply_packs/upp/sandbags
+	name = "UPP empty sandbags crate (x50)"
 	contains = list(/obj/item/stack/sandbags_empty/full)
 	cost = 20
 	containertype = /obj/structure/closet/crate/supply
 	containername = "empty sandbags crate"
 	group = "UPP Engineering"
 
-/datum/supply_packs/upp/sandbagskit_upp
-	name = "sandbags construction kit (sandbags x50, etool x2)"
+/datum/supply_packs/upp/sandbagskit
+	name = "UPP sandbags construction kit (sandbags x50, etool x2)"
 	contains = list(
 		/obj/item/stack/sandbags_empty/full,
 		/obj/item/tool/shovel/etool,
@@ -18,58 +18,58 @@
 	containername = "sandbags construction kit"
 	group = "UPP Engineering"
 
-/datum/supply_packs/upp/metal_upp
-	name = "metal sheets (x50)"
+/datum/supply_packs/upp/metal
+	name = "UPP metal sheets (x50)"
 	contains = list(/obj/item/stack/sheet/metal/large_stack)
 	cost = 20
 	containertype = /obj/structure/closet/crate/supply
 	containername = "metal sheets crate"
 	group = "UPP Engineering"
 
-/datum/supply_packs/upp/plas_upp
-	name = "plasteel sheets (x40)"
+/datum/supply_packs/upp/plas
+	name = "UPP plasteel sheets (x40)"
 	contains = list(/obj/item/stack/sheet/plasteel/med_large_stack)
 	cost = 30
 	containertype = /obj/structure/closet/crate/supply
 	containername = "plasteel sheets crate"
 	group = "UPP Engineering"
 
-/datum/supply_packs/upp/glass_upp
-	name = "glass sheets (x50)"
+/datum/supply_packs/upp/glass
+	name = "UPP glass sheets (x50)"
 	contains = list(/obj/item/stack/sheet/glass/large_stack)
 	cost = 20
 	containertype = /obj/structure/closet/crate/supply
 	containername = "glass sheets crate"
 	group = "UPP Engineering"
 
-/datum/supply_packs/upp/wood50_upp
-	name = "wooden planks (x50)"
+/datum/supply_packs/upp/wood50
+	name = "UPP wooden planks (x50)"
 	contains = list(/obj/item/stack/sheet/wood/large_stack)
 	cost = 20
 	containertype = /obj/structure/closet/crate/supply
 	containername = "wooden planks crate"
 	group = "UPP Engineering"
 
-/datum/supply_packs/upp/folding_barricades_upp
+/datum/supply_packs/upp/folding_barricades
+	name = "UPP Folding Barricades (x3)"
 	contains = list(
 		/obj/item/stack/folding_barricade/three,
 	)
-	name = "Folding Barricades (x3)"
 	cost = 20
 	containertype = /obj/structure/closet/crate/supply
 	containername = "folding barricades crate"
 	group = "UPP Engineering"
 
-/datum/supply_packs/upp/smescoil_upp
-	name = "superconducting magnetic coil crate (x1)"
+/datum/supply_packs/upp/smescoil
+	name = "UPP superconducting magnetic coil crate (x1)"
 	contains = list(/obj/item/stock_parts/smes_coil)
 	cost = 30
 	containertype = /obj/structure/closet/crate/construction
 	containername = "superconducting magnetic coil crate"
 	group = "UPP Engineering"
 
-/datum/supply_packs/upp/flashlights_upp
-	name = "Flashlights (x8)"
+/datum/supply_packs/upp/flashlights
+	name = "UPP Flashlights (x8)"
 	contains = list(
 		/obj/item/ammo_box/magazine/misc/flashlight,
 	)
@@ -78,8 +78,8 @@
 	containername = "flashlights crate"
 	group = "UPP Engineering"
 
-/datum/supply_packs/upp/batteries_upp
-	name = "High-Capacity Power Cells (x8)"
+/datum/supply_packs/upp/batteries
+	name = "UPP High-Capacity Power Cells (x8)"
 	contains = list(
 		/obj/item/ammo_box/magazine/misc/power_cell,
 	)

--- a/code/datums/supply_packs/upp_explosives.dm
+++ b/code/datums/supply_packs/upp_explosives.dm
@@ -1,5 +1,5 @@
-/datum/supply_packs/upp/explosives_smoke_upp
-	name = "Smoke grenades crate (x10)"
+/datum/supply_packs/upp/explosives_smoke
+	name = "UPP Smoke grenades crate (x10)"
 	contains = list(
 		/obj/item/explosive/grenade/smokebomb,
 		/obj/item/explosive/grenade/smokebomb,
@@ -17,8 +17,8 @@
 	containername = "\improper smoke grenades crate (WARNING)"
 	group = "UPP Explosives"
 
-/datum/supply_packs/upp/explosives_type_6_upp
-	name = "Type 6 Shrapnel Grenade crate (x25)"
+/datum/supply_packs/upp/explosives_type_6
+	name = "UPP Type 6 Shrapnel Grenade crate (x25)"
 	contains = list(
 		/obj/item/explosive/grenade/high_explosive/upp,
 		/obj/item/explosive/grenade/high_explosive/upp,
@@ -51,8 +51,8 @@
 	containername = "\improper Type 6 Shrapnel Grenade crate (WARNING)"
 	group = "UPP Explosives"
 
-/datum/supply_packs/upp/explosives_type_8_upp
-	name = "Type 8 WP Grenade crate (x20)"
+/datum/supply_packs/upp/explosives_type_8
+	name = "UPP Type 8 WP Grenade crate (x20)"
 	contains = list(
 		/obj/item/explosive/grenade/phosphorus/upp,
 		/obj/item/explosive/grenade/phosphorus/upp,
@@ -80,8 +80,8 @@
 	containername = "\improper Type 8 WP Grenade crate (WARNING)"
 	group = "UPP Explosives"
 
-/datum/supply_packs/upp/explosives_plastic_upp
-	name = "plastic explosives crate (x3)"
+/datum/supply_packs/upp/explosives_plastic
+	name = "UPP plastic explosives crate (x3)"
 	contains = list(
 		/obj/item/explosive/plastic,
 		/obj/item/explosive/plastic,
@@ -92,8 +92,8 @@
 	containername = "\improper plastic explosives crate (WARNING)"
 	group = "UPP Explosives"
 
-/datum/supply_packs/upp/explosives_breaching_charge_upp
-	name = "breaching charge crate (x4)"
+/datum/supply_packs/upp/explosives_breaching_charge
+	name = "UPP breaching charge crate (x4)"
 	contains = list(
 		/obj/item/explosive/plastic/breaching_charge,
 		/obj/item/explosive/plastic/breaching_charge,

--- a/code/datums/supply_packs/upp_food.dm
+++ b/code/datums/supply_packs/upp_food.dm
@@ -1,5 +1,5 @@
 /datum/supply_packs/upp/potato_crate
-	name = "Surplus boxes of potato (x10 boxes) (x700 potatos)"
+	name = "UPP Surplus boxes of potato (x10 boxes) (x700 potatos)"
 	contains = list(
 		/obj/item/storage/box/potato,
 		/obj/item/storage/box/potato,

--- a/code/datums/supply_packs/upp_gear.dm
+++ b/code/datums/supply_packs/upp_gear.dm
@@ -1,5 +1,5 @@
-/datum/supply_packs/upp/binocs_upp
-	name = "Mixed Binoculars Crate (x2 per, x6 total)"
+/datum/supply_packs/upp/binocs
+	name = "UPP Mixed Binoculars Crate (x2 per, x6 total)"
 	cost = 20
 	containertype = /obj/structure/closet/crate/green
 	containername = "Mixed Binoculars Crate"
@@ -13,8 +13,8 @@
 		/obj/item/device/binoculars,
 	)
 
-/datum/supply_packs/upp/flares_upp
-	name = "flare packs crate (x20)"
+/datum/supply_packs/upp/flares
+	name = "UPP flare packs crate (x20)"
 	contains = list(
 		/obj/item/ammo_box/magazine/misc/flares,
 		/obj/item/ammo_box/magazine/misc/flares,
@@ -25,8 +25,8 @@
 	group = "UPP Gear"
 
 
-/datum/supply_packs/upp/motiondetector_upp
-	name = "Motion Detector (x2)"
+/datum/supply_packs/upp/motiondetector
+	name = "UPP Motion Detector (x2)"
 	contains = list(
 		/obj/item/device/motiondetector/hacked,
 		/obj/item/device/motiondetector/hacked,
@@ -36,8 +36,8 @@
 	containername = "Motion Detector crate"
 	group = "UPP Gear"
 
-/datum/supply_packs/upp/signal_flares_upp
-	name = "signal flare packs crate (x4)"
+/datum/supply_packs/upp/signal_flares
+	name = "UPP signal flare packs crate (x4)"
 	contains = list(
 		/obj/item/storage/box/m94/signal,
 		/obj/item/storage/box/m94/signal,
@@ -49,8 +49,8 @@
 	containername = "signal flare pack crate"
 	group = "UPP Gear"
 
-/datum/supply_packs/upp/fulton_upp
-	name = "fulton recovery device crate (x4)"
+/datum/supply_packs/upp/fulton
+	name = "UPP fulton recovery device crate (x4)"
 	contains = list(
 		/obj/item/stack/fulton,
 		/obj/item/stack/fulton,
@@ -62,8 +62,8 @@
 	containername = "fulton recovery device crate"
 	group = "UPP Gear"
 
-/datum/supply_packs/upp/parachute_upp
-	name = "parachute crate (x20)"
+/datum/supply_packs/upp/parachute
+	name = "UPP parachute crate (x20)"
 	contains = list(
 		/obj/item/parachute,
 		/obj/item/parachute,

--- a/code/datums/supply_packs/upp_medical.dm
+++ b/code/datums/supply_packs/upp_medical.dm
@@ -1,5 +1,5 @@
-/datum/supply_packs/upp/medical_upp
-	name = "medical crate"
+/datum/supply_packs/upp/medical
+	name = "UPP medical crate"
 	contains = list(
 		/obj/item/storage/box/syringes,
 		/obj/item/reagent_container/glass/bottle/inaprovaline,
@@ -22,8 +22,8 @@
 	containername = "medical crate"
 	group = "UPP Medical"
 
-/datum/supply_packs/upp/medical_restock_cart_upp
-	name = "medical restock cart"
+/datum/supply_packs/upp/medical_restock_cart
+	name = "UPP medical restock cart"
 	contains = list(
 		/obj/structure/restock_cart/medical,
 	)
@@ -32,8 +32,8 @@
 	containername = "medical restock cart"
 	group = "UPP Medical"
 
-/datum/supply_packs/upp/medical_reagent_cart_upp
-	name = "medical reagent restock cart"
+/datum/supply_packs/upp/medical_reagent_cart
+	name = "UPP medical reagent restock cart"
 	contains = list(
 		/obj/structure/restock_cart/medical/reagent,
 	)
@@ -42,8 +42,8 @@
 	containername = "medical reagent restock cart"
 	group = "UPP Medical"
 
-/datum/supply_packs/upp/pillbottle_upp
-	name = "pill bottle crate (x2 each)"
+/datum/supply_packs/upp/pillbottle
+	name = "UPP pill bottle crate (x2 each)"
 	contains = list(
 		/obj/item/storage/pill_bottle/inaprovaline,
 		/obj/item/storage/pill_bottle/antitox,
@@ -67,8 +67,8 @@
 	containername = "medical crate"
 	group = "UPP Medical"
 
-/datum/supply_packs/upp/firstaid_upp
-	name = "first aid kit crate (x2 each)"
+/datum/supply_packs/upp/firstaid
+	name = "UPP first aid kit crate (x2 each)"
 	contains = list(
 		/obj/item/storage/firstaid/regular,
 		/obj/item/storage/firstaid/regular,
@@ -86,8 +86,8 @@
 	containername = "medical crate"
 	group = "UPP Medical"
 
-/datum/supply_packs/upp/bodybag_upp
-	name = "body bag crate (x28)"
+/datum/supply_packs/upp/bodybag
+	name = "UPP body bag crate (x28)"
 	contains = list(
 		/obj/item/storage/box/bodybags,
 		/obj/item/storage/box/bodybags,
@@ -99,8 +99,8 @@
 	containername = "body bag crate"
 	group = "UPP Medical"
 
-/datum/supply_packs/upp/cryobag_upp
-	name = "stasis bag crate (x3)"
+/datum/supply_packs/upp/cryobag
+	name = "UPP stasis bag crate (x3)"
 	contains = list(
 		/obj/item/bodybag/cryobag,
 		/obj/item/bodybag/cryobag,
@@ -111,8 +111,8 @@
 	containername = "stasis bag crate"
 	group = "UPP Medical"
 
-/datum/supply_packs/upp/surgery_upp
-	name = "surgery crate(tray,anesthetic,surgeon gear)"
+/datum/supply_packs/upp/surgery
+	name = "UPP surgery crate(tray,anesthetic,surgeon gear)"
 	contains = list(
 		/obj/item/storage/surgical_tray,
 		/obj/item/clothing/mask/breath/medical,
@@ -127,8 +127,8 @@
 	access = ACCESS_MARINE_MEDBAY
 	group = "UPP Medical"
 
-/datum/supply_packs/upp/upgraded_medical_kits_upp
-	name = "upgraded medical equipment crate (x4)"
+/datum/supply_packs/upp/upgraded_medical_kits
+	name = "UPP upgraded medical equipment crate (x4)"
 	contains = list(
 		/obj/item/storage/box/czsp/medic_upgraded_kits,
 		/obj/item/storage/box/czsp/medic_upgraded_kits,

--- a/code/datums/supply_packs/upp_mortar.dm
+++ b/code/datums/supply_packs/upp_mortar.dm
@@ -1,5 +1,5 @@
 /datum/supply_packs/upp/ammo_mortar_he
-	name = "M402 mortar shells crate (x6 HE)"
+	name = "UPP M402 mortar shells crate (x6 HE)"
 	cost = 20
 	contains = list(
 		/obj/item/mortar_shell/he,
@@ -14,7 +14,7 @@
 	group = "UPP Mortar"
 
 /datum/supply_packs/upp/ammo_mortar_incend
-	name = "M402 mortar shells crate (x6 Incend)"
+	name = "UPP M402 mortar shells crate (x6 Incend)"
 	cost = 20
 	contains = list(
 		/obj/item/mortar_shell/incendiary,
@@ -29,7 +29,7 @@
 	group = "UPP Mortar"
 
 /datum/supply_packs/upp/ammo_mortar_flare
-	name = "M402 mortar shells crate (x6 Flare/Camera)"
+	name = "UPP M402 mortar shells crate (x6 Flare/Camera)"
 	cost = 20
 	contains = list(
 		/obj/item/mortar_shell/flare,

--- a/code/datums/supply_packs/upp_weapons.dm
+++ b/code/datums/supply_packs/upp_weapons.dm
@@ -1,5 +1,5 @@
 /datum/supply_packs/upp/Type64_x10
-	name = "Type 64 Submachinegun (x10)"
+	name = "UPP Type 64 Submachinegun (x10)"
 	contains = list(
 		/obj/item/weapon/gun/smg/bizon/upp,
 		/obj/item/weapon/gun/smg/bizon/upp,
@@ -18,7 +18,7 @@
 	group = "UPP Weapons"
 
 /datum/supply_packs/upp/Type23_x10
-	name = "Type 23 riot shotgun (x10)"
+	name = "UPP Type 23 riot shotgun (x10)"
 	contains = list(
 		/obj/item/weapon/gun/shotgun/type23,
 		/obj/item/weapon/gun/shotgun/type23,
@@ -37,7 +37,7 @@
 	group = "UPP Weapons"
 
 /datum/supply_packs/upp/Type71_x10
-	name = "Type 71 Pulse Rifle (x10)"
+	name = "UPP Type 71 Pulse Rifle (x10)"
 	contains = list(
 		/obj/item/weapon/gun/rifle/type71,
 		/obj/item/weapon/gun/rifle/type71,
@@ -56,7 +56,7 @@
 	group = "UPP Weapons"
 
 /datum/supply_packs/upp/Type71_carbine_x10
-	name = "Type 71 Pulse Rifle Carbine (x10)"
+	name = "UPP Type 71 Pulse Rifle Carbine (x10)"
 	contains = list(
 		/obj/item/weapon/gun/rifle/type71/carbine,
 		/obj/item/weapon/gun/rifle/type71/carbine,
@@ -75,7 +75,7 @@
 	group = "UPP Weapons"
 
 /datum/supply_packs/upp/m2c_hmg_upp
-	name = "M2C Heavy Machine Gun (x1)"
+	name = "UPP M2C Heavy Machine Gun (x1)"
 	contains = list(
 		/obj/item/storage/box/guncase/m2c,
 	)
@@ -85,7 +85,7 @@
 	group = "UPP Weapons"
 
 /datum/supply_packs/upp/pkp
-	name = "QYJ-72 General Purpose Machine Gun (x2)"
+	name = "UPP QYJ-72 General Purpose Machine Gun (x2)"
 	contains = list(
 		/obj/item/weapon/gun/pkp,
 		/obj/item/weapon/gun/pkp,
@@ -98,7 +98,7 @@
 	group = "UPP Weapons"
 
 /datum/supply_packs/upp/minigun
-	name = "GSh-7.62 Rotary Machine Gun (x2)"
+	name = "UPP GSh-7.62 Rotary Machine Gun (x2)"
 	contains = list(
 		/obj/item/weapon/gun/minigun/upp,
 		/obj/item/weapon/gun/minigun/upp,
@@ -111,7 +111,7 @@
 	group = "UPP Special Weapon"
 
 /datum/supply_packs/upp/Type88_marksman_rifle_x10
-	name = "Type 88 designated marksman rifle (x2)"
+	name = "UPP Type 88 designated marksman rifle (x2)"
 	contains = list(
 		/obj/item/weapon/gun/rifle/sniper/svd,
 		/obj/item/weapon/gun/rifle/sniper/svd,
@@ -124,7 +124,7 @@
 	group = "UPP Special Weapon"
 
 /datum/supply_packs/upp/Type71_carbine_commando_x10
-	name = "Type 71 'Commando' pulse carbine (x2)"
+	name = "UPP Type 71 'Commando' pulse carbine (x2)"
 	contains = list(
 		/obj/item/weapon/gun/rifle/type71/carbine/commando,
 		/obj/item/weapon/gun/rifle/type71/carbine/commando,


### PR DESCRIPTION

# About the pull request

This PR ensures all usage of GLOBAL_SUBTYPE_PATH_INDEXED can uniquely index every subtype it is given. Use a null indexer to not error on abstract types (but the last of its kind will still be indexed with that value).

# Explain why it's good for the game

Much like https://github.com/cmss13-devs/cmss13/pull/6421 and https://github.com/cmss13-devs/cmss13/pull/8538 these GLOBs are expected to be indexed, so we need to know if we are mistakenly trampling an entry.

# Testing Photographs and Procedure
See checks

# Changelog
:cl: Drathek
fix: Fixed UPP supply packs overriding all normal variant supply packs
code: Added a check to ensure all usage of GLOBAL_SUBTYPE_PATH_INDEXED has uniquely indexed entries
/:cl:
