### PR TITLE
Fixes girders not being deconstructable/wallable post repair

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -363,6 +363,7 @@
 
 /obj/structure/girder/proc/repair()
 	health = initial(health)
+	state = STATE_STANDARD
 	update_state()
 
 /obj/structure/girder/proc/update_state()


### PR DESCRIPTION
# About the pull request

title, basically girders wouldnt properly update its state after repair

fixes: #8600
# Explain why it's good for the game

bugfix

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Girders are now able to be deconstructed/dismantled etc post repair
/:cl:
