### PR TITLE
optimization to chat saving via indexeddb improvements

### DIFF
--- a/tgui/packages/common/storage.js
+++ b/tgui/packages/common/storage.js
@@ -107,7 +107,7 @@ class IFrameIndexedDbBackend {
   async get(key) {
     const promise = new Promise((resolve) => {
       window.addEventListener('message', (message) => {
-        if (message.data.key === key) {
+        if (message.data.key && message.data.key === key) {
           resolve(message.data.value);
         }
       });
@@ -127,6 +127,26 @@ class IFrameIndexedDbBackend {
 
   async clear() {
     this.iframeWindow.postMessage({ type: 'clear' }, '*');
+  }
+
+  async processChatMessages(messages) {
+    this.iframeWindow.postMessage(
+      { type: 'processChatMessages', messages: messages },
+      '*',
+    );
+  }
+
+  async getChatMessages() {
+    const promise = new Promise((resolve) => {
+      window.addEventListener('message', (message) => {
+        if (message.data.messages) {
+          resolve(message.data.messages);
+        }
+      });
+    });
+
+    this.iframeWindow.postMessage({ type: 'getChatMessages' }, '*');
+    return promise;
   }
 }
 

--- a/tgui/packages/tgui-panel/chat/middleware.js
+++ b/tgui/packages/tgui-panel/chat/middleware.js
@@ -36,7 +36,7 @@ import { selectChat, selectCurrentChatPage } from './selectors';
 const FORBID_TAGS = ['a', 'iframe', 'link', 'video'];
 
 const usingCdnStorage =
-  !Byond.TRIDENT && Byond.storageCdn === 'tgui:storagecdn';
+  !Byond.TRIDENT && Byond.storageCdn !== 'tgui:storagecdn';
 const storage = usingCdnStorage ? new StorageProxy(true) : realStorage;
 
 let savedTo = 0;

--- a/tgui/packages/tgui-panel/chat/middleware.js
+++ b/tgui/packages/tgui-panel/chat/middleware.js
@@ -45,7 +45,6 @@ const saveChatToStorage = async (store) => {
   if (usingCdnStorage) {
     const indexedDbBackend = await storage.backendPromise;
     indexedDbBackend.processChatMessages(chatRenderer.storeQueue);
-    chatRenderer.storeQueue = [];
   } else {
     const fromIndex = Math.max(
       0,
@@ -59,6 +58,7 @@ const saveChatToStorage = async (store) => {
     storage.set('chat-messages-cm', messages);
   }
 
+  chatRenderer.storeQueue = [];
   storage.set('chat-state-cm', state);
 };
 

--- a/tgui/packages/tgui-panel/chat/middleware.js
+++ b/tgui/packages/tgui-panel/chat/middleware.js
@@ -39,8 +39,6 @@ const usingCdnStorage =
   !Byond.TRIDENT && Byond.storageCdn !== 'tgui:storagecdn';
 const storage = usingCdnStorage ? new StorageProxy(true) : realStorage;
 
-let savedTo = 0;
-
 const saveChatToStorage = async (store) => {
   const state = selectChat(store.getState());
 

--- a/tgui/packages/tgui-panel/chat/renderer.jsx
+++ b/tgui/packages/tgui-panel/chat/renderer.jsx
@@ -452,6 +452,7 @@ class ChatRenderer {
           }
         }
       }
+      this.storeQueue.push({ ...message });
       // Store the node in the message
       message.node = node;
       // Query all possible selectors to find out the message type
@@ -468,7 +469,6 @@ class ChatRenderer {
       countByType[message.type] += 1;
       // TODO: Detect duplicates
       this.messages.push(message);
-      this.storeQueue.push(message);
       if (canPageAcceptType(this.page, message.type)) {
         fragment.appendChild(node);
         this.visibleMessages.push(message);

--- a/tgui/packages/tgui-panel/chat/renderer.jsx
+++ b/tgui/packages/tgui-panel/chat/renderer.jsx
@@ -122,6 +122,7 @@ class ChatRenderer {
     this.rootNode = null;
     this.queue = [];
     this.messages = [];
+    this.storeQueue = [];
     this.visibleMessages = [];
     this.page = null;
     this.events = new EventEmitter();
@@ -467,6 +468,7 @@ class ChatRenderer {
       countByType[message.type] += 1;
       // TODO: Detect duplicates
       this.messages.push(message);
+      this.storeQueue.push(message);
       if (canPageAcceptType(this.page, message.type)) {
         fragment.appendChild(node);
         this.visibleMessages.push(message);

--- a/tgui/public/iframe.html
+++ b/tgui/public/iframe.html
@@ -24,7 +24,7 @@
 
           req.result.createObjectStore("ring");
           req.result.createObjectStore("messages", { autoIncrement: true }).transaction.oncomplete = async () => {
-            const trans = db.transaction("messages", "readwrite").objectStore("messages");
+            const trans = req.result.transaction("messages", "readwrite").objectStore("messages");
 
             for (let index = 0; index < MAX_MESSAGES; index++) {
                 await promiseForRequest(trans.add(null));
@@ -36,7 +36,7 @@
         }
       };
       req.onsuccess = async () => {
-        const ringPos = await promiseForRequest(db.transaction("ring", "readonly").objectStore("ring").get("value"));
+        const ringPos = await promiseForRequest(req.result.transaction("ring", "readonly").objectStore("ring").get("value"));
 
         writeFrom = ringPos || 0;
 

--- a/tgui/public/iframe.html
+++ b/tgui/public/iframe.html
@@ -6,12 +6,14 @@
   <meta charset='utf-8' />
 
   <script type='text/javascript'>
-    const INDEXED_DB_VERSION = 1;
+    const INDEXED_DB_VERSION = 2;
     const INDEXED_DB_NAME = 'tgui';
     const INDEXED_DB_STORE_NAME = 'storage';
 
     const READ_ONLY = 'readonly';
     const READ_WRITE = 'readwrite';
+
+    const MAX_MESSAGES = 1000;
 
     const dbPromise = new Promise((resolve, reject) => {
       const indexedDB = window.indexedDB || window.msIndexedDB;
@@ -19,11 +21,27 @@
       req.onupgradeneeded = () => {
         try {
           req.result.createObjectStore(INDEXED_DB_STORE_NAME);
+
+          req.result.createObjectStore("ring");
+          req.result.createObjectStore("messages", { autoIncrement: true }).transaction.oncomplete = async () => {
+            const trans = db.transaction("messages", "readwrite").objectStore("messages");
+
+            for (let index = 0; index < MAX_MESSAGES; index++) {
+                await promiseForRequest(trans.add(null));
+            }
+          }
+
         } catch (err) {
           reject(new Error('Failed to upgrade IDB: ' + req.error));
         }
       };
-      req.onsuccess = () => resolve(req.result);
+      req.onsuccess = async () => {
+        const ringPos = await promiseForRequest(db.transaction("ring", "readonly").objectStore("ring").get("value"));
+
+        writeFrom = ringPos || 0;
+
+        resolve(req.result);
+      };
       req.onerror = () => {
         reject(new Error('Failed to open IDB: ' + req.error));
       };
@@ -32,8 +50,8 @@
     window.addEventListener('message', (messageEvent) => {
       switch (messageEvent.data.type) {
         case 'get':
-          get(event.data.key).then((value) => {
-            messageEvent.source.postMessage({key: messageEvent.data.key, value: value}, "*")
+          get(messageEvent.data.key).then((value) => {
+            messageEvent.source.postMessage({key: messageEvent.data.key, value: value}, "*");
           });
           break;
         case 'set':
@@ -45,10 +63,63 @@
         case 'clear':
           clear();
           break;
+        case 'processChatMessages':
+          addMessageBatch(messageEvent.data.messages);
+          break;
+        case 'getChatMessages':
+          getSavedMessages().then((messages) => {
+            messageEvent.source.postMessage({messages: messages}, "*");
+          })
         default:
           break;
       }
     });
+
+    let writeFrom = 0;
+
+    const addMessageBatch = async (messages) => {
+      const database = await dbPromise;
+
+      const trans = database.transaction("messages", "readwrite").objectStore("messages");
+
+      let cursorReq = trans.openCursor(IDBKeyRange.bound(writeFrom, writeFrom + messages.length, true));
+      let cursor = await promiseForRequest(cursorReq);
+
+      for (let index = 0; index < messages.length; index++) {
+          const message = messages[index];
+
+          cursor.update(message);
+          writeFrom = cursor.key;
+
+          if(cursor.key === MAX_MESSAGES) {
+              writeFrom = 0;
+
+              cursorReq = trans.openCursor(IDBKeyRange.bound(0, messages.length - index + 1, true));
+              cursor = await promiseForRequest(cursorReq);
+          } else {
+              cursor.continue();
+              await promiseForRequest(cursorReq);
+          }
+      }
+
+      database.transaction("ring", "readwrite").objectStore("ring").put(writeFrom, "value");
+    }
+
+    const getSavedMessages = async () => {
+      const database = await dbPromise;
+
+      const trans = database.transaction("messages", "readonly").objectStore("messages");
+      const messyMessages = await promiseForRequest(trans.getAll());
+
+      const upTo = messyMessages.splice(0, writeFrom);
+
+      if(messyMessages[0] === null) {
+          return upTo;
+      }
+
+      const messages = messyMessages.concat(upTo);
+      return messages;
+    }
 
     const getStore = async (mode) => {
       return dbPromise.then((db) => db
@@ -79,6 +150,13 @@
       const store = await getStore(READ_WRITE);
       store.clear();
     };
+
+    const promiseForRequest = (request) => {
+      return new Promise((resolve, reject) => {
+          request.onsuccess = () => { resolve(request.result); };
+          request.onerror = () => { reject(request.error); };
+      });
+    }
   </script>
 </head>
 

--- a/tgui/public/iframe.html
+++ b/tgui/public/iframe.html
@@ -18,16 +18,21 @@
     const dbPromise = new Promise((resolve, reject) => {
       const indexedDB = window.indexedDB || window.msIndexedDB;
       const req = indexedDB.open(INDEXED_DB_NAME, INDEXED_DB_VERSION);
-      req.onupgradeneeded = () => {
+      req.onupgradeneeded = (event) => {
         try {
-          req.result.createObjectStore(INDEXED_DB_STORE_NAME);
 
-          req.result.createObjectStore("ring");
-          req.result.createObjectStore("messages", { autoIncrement: true }).transaction.oncomplete = async () => {
-            const trans = req.result.transaction("messages", "readwrite").objectStore("messages");
+          if(event.oldVersion < 1) {
+            req.result.createObjectStore(INDEXED_DB_STORE_NAME);
+          }
 
-            for (let index = 0; index < MAX_MESSAGES; index++) {
-                await promiseForRequest(trans.add(null));
+          if(event.oldVersion < 2) {
+            req.result.createObjectStore("ring");
+            req.result.createObjectStore("messages", { autoIncrement: true }).transaction.oncomplete = async () => {
+              const trans = req.result.transaction("messages", READ_WRITE).objectStore("messages");
+
+              for (let index = 0; index < MAX_MESSAGES; index++) {
+                  await promiseForRequest(trans.add(null));
+              }
             }
           }
 
@@ -80,7 +85,7 @@
     const addMessageBatch = async (messages) => {
       const database = await dbPromise;
 
-      const trans = database.transaction("messages", "readwrite").objectStore("messages");
+      const trans = database.transaction("messages", READ_WRITE).objectStore("messages");
 
       let cursorReq = trans.openCursor(IDBKeyRange.bound(writeFrom, writeFrom + messages.length, true));
       let cursor = await promiseForRequest(cursorReq);
@@ -102,13 +107,13 @@
           }
       }
 
-      database.transaction("ring", "readwrite").objectStore("ring").put(writeFrom, "value");
+      database.transaction("ring", READ_WRITE).objectStore("ring").put(writeFrom, "value");
     }
 
     const getSavedMessages = async () => {
       const database = await dbPromise;
 
-      const trans = database.transaction("messages", "readonly").objectStore("messages");
+      const trans = database.transaction("messages", READ_ONLY).objectStore("messages");
       const messyMessages = await promiseForRequest(trans.getAll());
 
       const upTo = messyMessages.splice(0, writeFrom);


### PR DESCRIPTION
# About the pull request

we batch up chat messages and send them over in groups to indexeddb across the iframe, and write them in a ring which loops round at MAX_MESSAGES. when being read, we read from the start of the loop and reassemble the last MAX_MESSAGES number of messages

# Explain why it's good for the game

title if that makes sense to like anyone

# Changelog

:cl:
code: Chat saving to indexdb is reworked
/:cl: