### PR TITLE
Reverts shrapnel damage changes from #7581

### DIFF
--- a/code/datums/ammo/shrapnel.dm
+++ b/code/datums/ammo/shrapnel.dm
@@ -6,26 +6,24 @@
 /datum/ammo/bullet/shrapnel
 	name = "shrapnel"
 	icon_state = "buckshot"
+	accurate_range_min = 5
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_STOPPED_BY_COVER
-	accuracy = HIT_ACCURACY_TIER_4
-	accurate_range = 7
-	max_range = 10
-	damage = 30
-	penetration = ARMOR_PENETRATION_TIER_2
+	accuracy = HIT_ACCURACY_TIER_3
+	accurate_range = 32
+	max_range = 8
+	damage = 25
+	damage_var_low = -PROJECTILE_VARIANCE_TIER_6
+	damage_var_high = PROJECTILE_VARIANCE_TIER_6
+	penetration = ARMOR_PENETRATION_TIER_4
 	shell_speed = AMMO_SPEED_TIER_2
+	shrapnel_chance = 5
 
 /datum/ammo/bullet/shrapnel/on_hit_obj(obj/O, obj/projectile/P)
 	if(istype(O, /obj/structure/barricade))
 		var/obj/structure/barricade/B = O
-		B.health -= rand(5, 10)
+		B.health -= rand(2, 5)
 		B.update_health(1)
 
-/datum/ammo/bullet/shrapnel/on_hit_mob(mob/living/carbon/xeno, obj/projectile/projectile, mob/user)
-	if(!shrapnel_chance) // no shrapnell , no special effects
-		return
-	if(isxeno(xeno))
-		xeno.apply_effect(4, SLOW) // multiple hits dont stack they just renew the duration
-		xeno.apply_armoured_damage(damage * 0.6, ARMOR_BULLET, BRUTE, , penetration) // xenos have a lot of HP
 
 /datum/ammo/bullet/shrapnel/breaching/set_bullet_traits()
 	. = ..()
@@ -49,7 +47,7 @@
 	name = ".22 hornet round"
 	icon_state = "hornet_round"
 	flags_ammo_behavior = AMMO_BALLISTIC
-	damage = 10
+	damage = 8
 	shrapnel_chance = 0
 	shell_speed = AMMO_SPEED_TIER_3//she fast af boi
 	penetration = ARMOR_PENETRATION_TIER_5
@@ -70,7 +68,7 @@
 	icon_state = "beanbag" // looks suprisingly a lot like flaming shrapnel chunks
 	flags_ammo_behavior = AMMO_STOPPED_BY_COVER
 	shell_speed = AMMO_SPEED_TIER_1
-	damage = 30
+	damage = 20
 	penetration = ARMOR_PENETRATION_TIER_4
 
 /datum/ammo/bullet/shrapnel/incendiary/set_bullet_traits()
@@ -95,6 +93,7 @@
 /datum/ammo/bullet/shrapnel/metal
 	name = "metal shrapnel"
 	icon_state = "shrapnelshot_bit"
+	flags_ammo_behavior = AMMO_STOPPED_BY_COVER|AMMO_BALLISTIC
 	shell_speed = AMMO_SPEED_TIER_1
 	damage = 30
 	shrapnel_chance = 15


### PR DESCRIPTION
# About the pull request
Title
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Changes were untested, over-tuned and a net negative for the game, numerous interaction changes such as all shrapnel from a NON OT claymore can deal upwards of 400 damage under the circumstances of all shrapnel hitting, possibly killing a majority of t2s without a chance to dispute said damage, this among every single other thing that uses shrapnel, breach charges, grenades, etc, make it unfun and quite frankly just stupid to fight.

# Testing Photographs and Procedure


https://streamable.com/kplvey

https://streamable.com/xkt19k</summary>




# Changelog

:cl:
balance: reverted all direct shrapnel buffs from #7581
/:cl:

