### PR TITLE
Trapper's empower overlay fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/boiler/trapper.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/boiler/trapper.dm
@@ -54,11 +54,6 @@
 	. = list()
 	var/datum/action/xeno_action/activable/boiler_trap/trap_ability = get_action(bound_xeno, /datum/action/xeno_action/activable/boiler_trap)
 	. += "Insight Amount: [trap_ability.empowering_charge_counter]/[trap_ability.empower_charge_max]"
-	if(trap_ability.empowered)
-		. += "Your next [trap_ability.name] will be empowered."
-	var/datum/action/xeno_action/activable/acid_mine/mine_ability = get_action(bound_xeno, /datum/action/xeno_action/activable/acid_mine)
-	if(mine_ability.empowered)
-		. += "Your next [mine_ability.name] will be empowered."
 
 /datum/behavior_delegate/boiler_trapper/on_hitby_projectile(ammo)
 	if (temp_movespeed_usable)

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/boiler/trapper.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/boiler/trapper.dm
@@ -50,6 +50,16 @@
 	var/temp_movespeed_usable = FALSE
 	var/temp_movespeed_messaged = FALSE
 
+/datum/behavior_delegate/boiler_trapper/append_to_stat()
+	. = list()
+	var/datum/action/xeno_action/activable/boiler_trap/trap_ability = get_action(bound_xeno, /datum/action/xeno_action/activable/boiler_trap)
+	. += "Insight Amount: [trap_ability.empowering_charge_counter]/[trap_ability.empower_charge_max]"
+	if(trap_ability.empowered)
+		. += "Your next [trap_ability.name] will be empowered."
+	var/datum/action/xeno_action/activable/acid_mine/mine_ability = get_action(bound_xeno, /datum/action/xeno_action/activable/acid_mine)
+	if(mine_ability.empowered)
+		. += "Your next [mine_ability.name] will be empowered."
+
 /datum/behavior_delegate/boiler_trapper/on_hitby_projectile(ammo)
 	if (temp_movespeed_usable)
 		temp_movespeed_time_used = world.time
@@ -84,7 +94,7 @@
 
 	if(!trap_ability.empowered && trap_ability.empowering_charge_counter >= trap_ability.empower_charge_max)
 		trap_ability.empowered = TRUE
-		trap_ability.button.overlays += "+empowered"
+		trap_ability.button.overlays += image('icons/mob/hud/actions_xeno.dmi', "+empowered")
 		to_chat(bound_xeno, SPAN_XENODANGER("You have gained sufficient insight in your prey to empower your next [trap_ability.name]."))
 
 	if(trap_ability.empowering_charge_counter > trap_ability.empower_charge_max)
@@ -104,7 +114,7 @@
 		xeno.speed_modifier += temp_movespeed_amount
 		xeno.recalculate_speed()
 		temp_movespeed_messaged = FALSE
-	
+
 /datum/action/xeno_action/activable/boiler_trap/use_ability(atom/affected_atom)
 	var/mob/living/carbon/xenomorph/xeno = owner
 
@@ -158,11 +168,11 @@
 	if(empowered)
 		empowered = FALSE
 		empowering_charge_counter = 0
-		button.overlays -= "+empowered"
+		button.overlays -= image('icons/mob/hud/actions_xeno.dmi', "+empowered")
 		var/datum/action/xeno_action/activable/acid_mine/mine = get_action(xeno, /datum/action/xeno_action/activable/acid_mine)
 		if(!mine.empowered)
 			mine.empowered = TRUE
-			mine.button.overlays += "+empowered"
+			mine.button.overlays += image('icons/mob/hud/actions_xeno.dmi', "+empowered")
 			to_chat(xeno, SPAN_XENODANGER("We tap into our reserves to prepare a stronger [mine.name]!"))
 
 	apply_cooldown()
@@ -203,7 +213,7 @@
 
 	if(empowered)
 		empowered = FALSE
-		button.overlays -= "+empowered"
+		button.overlays -= image('icons/mob/hud/actions_xeno.dmi', "+empowered")
 
 	apply_cooldown()
 	return ..()


### PR DESCRIPTION
# About the pull request

When Trapper "Insight" meter is full, it should add an overlay for ability buttons
Now it actually does

Also i added a meter for counting insight stacks to stat panel

# Explain why it's good for the game

You can see when and how much insight is gained, as well as check whenever your abilities are actually empowered
(without looking at chat)

# Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/fd60a558-241b-408e-923e-7eb330236e6e)

# Changelog

:cl:
qol: Trappers can now see how much "Insight" they currently have.
fix: Trapper abilities empowered overlay is now shown.
/:cl:
