### PR TITLE
Moves the orbital cannon controls to the groundside operations console

### DIFF
--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -205,7 +205,7 @@ GLOBAL_LIST_EMPTY(orbital_cannon_cancellation)
 			return abs(GLOB.ob_type_fuel_requirements[3] - tray.fuel_amt)
 	return 0
 
-/obj/structure/orbital_cannon/proc/fire_ob_cannon(turf/T, mob/user, squad_behalf)
+/obj/structure/orbital_cannon/proc/fire_ob_cannon(turf/T, mob/user)
 	set waitfor = 0
 
 	if(!chambered_tray || !loaded_tray || !tray || !tray.warhead || ob_cannon_busy)
@@ -232,12 +232,12 @@ GLOBAL_LIST_EMPTY(orbital_cannon_cancellation)
 	var/turf/target = locate(target_x, target_y, T.z)
 	var/area/target_area = get_area(target)
 
-	message_admins(FONT_SIZE_HUGE("ALERT: [key_name(user)] fired an orbital bombardment in '[target_area]' for squad '[squad_behalf]' landing at ([target.x],[target.y],[target.z])"), target.x, target.y, target.z)
+	message_admins(FONT_SIZE_HUGE("ALERT: [key_name(user)] fired an orbital bombardment in '[target_area]' landing at ([target.x],[target.y],[target.z])"), target.x, target.y, target.z)
 	var/message = "Orbital bombardment original target was ([T.x],[T.y],[T.z]) - offset by [abs(off_x)+abs(off_y)]"
 	if(inaccurate_fuel)
 		message += " - It was misfueled by [inaccurate_fuel] units!"
 	message_admins(message, T.x, T.y, T.z)
-	log_attack("[key_name(user)] fired an orbital bombardment in [area.name] for squad '[squad_behalf]'")
+	log_attack("[key_name(user)] fired an orbital bombardment in [area.name]")
 
 	if(user)
 		tray.warhead.source_mob = user

--- a/tgui/packages/tgui/interfaces/OverwatchConsole.jsx
+++ b/tgui/packages/tgui/interfaces/OverwatchConsole.jsx
@@ -107,15 +107,6 @@ const SquadPanel = (props) => {
               Supply Drop
             </Tabs.Tab>
           )}
-          {!!data.can_launch_obs && (
-            <Tabs.Tab
-              selected={category === 'ob'}
-              icon="bomb"
-              onClick={() => setCategory('ob')}
-            >
-              Orbital Bombardment
-            </Tabs.Tab>
-          )}
           <Tabs.Tab icon="map" onClick={() => act('tacmap_unpin')}>
             Tactical Map
           </Tabs.Tab>
@@ -124,7 +115,6 @@ const SquadPanel = (props) => {
       <Stack.Item grow>
         {category === 'monitor' && <SquadMonitor />}
         {category === 'supply' && data.can_launch_crates && <SupplyDrop />}
-        {category === 'ob' && data.can_launch_obs && <OrbitalBombardment />}
       </Stack.Item>
     </Stack>
   );
@@ -668,110 +658,20 @@ const SupplyDrop = (props) => {
   );
 };
 
-const OrbitalBombardment = (props) => {
-  const { act, data } = useBackend();
-
-  const [OBX, setOBX] = useSharedState('obx', 0);
-  const [OBY, setOBY] = useSharedState('oby', 0);
-  const [OBZ, setOBZ] = useSharedState('obz', 0);
-
-  let ob_status = 'Ready';
-  let ob_color = 'green';
-  if (data.ob_cooldown) {
-    ob_status = 'Cooldown - ' + data.ob_cooldown / 10 + ' seconds';
-    ob_color = 'yellow';
-  } else if (!data.ob_loaded) {
-    ob_status = 'Not chambered';
-    ob_color = 'red';
-  }
-
-  return (
-    <Section fill fontSize="14px" title="Orbital Bombardment">
-      <Stack justify={'space-between'} m="10px">
-        <Stack.Item fontSize="14px">
-          <LabeledControls mb="5px">
-            <LabeledControls.Item label="LONGITUDE">
-              <NumberInput
-                value={OBX}
-                onChange={(value) => setOBX(value)}
-                width="75px"
-              />
-            </LabeledControls.Item>
-            <LabeledControls.Item label="LATITUDE">
-              <NumberInput
-                value={OBY}
-                onChange={(value) => setOBY(value)}
-                width="75px"
-              />
-            </LabeledControls.Item>
-            <LabeledControls.Item label="HEIGHT">
-              <NumberInput
-                value={OBZ}
-                onChange={(value) => setOBZ(value)}
-                width="75px"
-              />
-            </LabeledControls.Item>
-
-            <LabeledControls.Item label="STATUS">
-              <Box color={ob_color} bold>
-                {ob_status}
-              </Box>
-            </LabeledControls.Item>
-          </LabeledControls>
-          <Box textAlign="center">
-            <Button
-              fontSize="20px"
-              width="100%"
-              icon="bomb"
-              color="red"
-              onClick={() => act('dropbomb', { x: OBX, y: OBY, z: OBZ })}
-            >
-              Fire
-            </Button>
-            <Button
-              fontSize="20px"
-              width="100%"
-              icon="save"
-              color="yellow"
-              onClick={() =>
-                act('save_coordinates', { x: OBX, y: OBY, z: OBZ })
-              }
-            >
-              Save
-            </Button>
-          </Box>
-        </Stack.Item>
-        <Stack.Item>
-          <Divider vertical />
-        </Stack.Item>
-        <SavedCoordinates forOB />
-      </Stack>
-      <Divider horizontal />
-    </Section>
-  );
-};
-
 const SavedCoordinates = (props) => {
   const { act, data } = useBackend();
 
-  const [OBX, setOBX] = useSharedState('obx', 0);
-  const [OBY, setOBY] = useSharedState('oby', 0);
-  const [OBZ, setOBZ] = useSharedState('obz', 0);
   const [supplyX, setSupplyX] = useSharedState('supplyx', 0);
   const [supplyY, setSupplyY] = useSharedState('supply', 0);
   const [supplyZ, setSupplyZ] = useSharedState('supplyz', 0);
 
-  const { forOB, forSupply } = props;
+  const { forSupply } = props;
 
   let transferCoords = (x, y, z) => {
     if (forSupply) {
       setSupplyX(x);
       setSupplyY(y);
       setSupplyZ(z);
-    } else if (forOB) {
-      setOBX(x);
-      setOBY(y);
-      setOBZ(z);
     }
   };
 


### PR DESCRIPTION
# About the pull request
Removes it from overwatch consoles, moves it to the GOC
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
The orbital cannon has repeatedly proved itself too much of a responsibility for staff officers (which you can play with like 10 hours in the game so it is not really their fault), Also having it under the supervision of the XO seems more logical.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
del: Removed OB controls from overwatch consoles
add: Added OB controls to the groundside operations console
/:cl:
