### PR TITLE
Squad Gear Racks now autoequip armors, belts etc.

### DIFF
--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -844,7 +844,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 	icon_state = "gear"
 	use_points = TRUE
 	vendor_theme = VENDOR_THEME_USCM
-	vend_flags = VEND_CLUTTER_PROTECTION|VEND_CATEGORY_CHECK|VEND_TO_HAND
+	vend_flags = VEND_CLUTTER_PROTECTION|VEND_CATEGORY_CHECK|VEND_UNIFORM_AUTOEQUIP
 
 /obj/structure/machinery/cm_vending/gear/ui_static_data(mob/user)
 	. = ..(user)


### PR DESCRIPTION
# About the pull request

Squad Gear racks now autoequip purchased B12, M4 armors, purchased belts et cetera. Same QoL that was implemented for rifleman vendors but not extended to gear racks.

# Explain why it's good for the game

quality of life

# Testing Photographs and Procedure
i tested it and it works

this is my first serious pr let me know if it's fucked up 😛 

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: squad gear vendors now autoequip gear when possible
/:cl:
