### PR TITLE
Halves the untrained pointing cooldown

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -385,7 +385,7 @@
 	if(ishuman(mob))
 		squad = mob.assigned_squad
 	if(!check_improved_pointing()) //Squad Leaders and above have reduced cooldown and get a bigger arrow
-		recently_pointed_to = world.time + 50
+		recently_pointed_to = world.time + 25
 		new /obj/effect/overlay/temp/point(T, src, A)
 	else
 		recently_pointed_to = world.time + 10

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -385,7 +385,7 @@
 	if(ishuman(mob))
 		squad = mob.assigned_squad
 	if(!check_improved_pointing()) //Squad Leaders and above have reduced cooldown and get a bigger arrow
-		recently_pointed_to = world.time + 25
+		recently_pointed_to = world.time + 2.5 SECONDS
 		new /obj/effect/overlay/temp/point(T, src, A)
 	else
 		recently_pointed_to = world.time + 10


### PR DESCRIPTION
# About the pull request

pointing cooldown now = 25 vs 50 ticks prior, leadership cooldown remains at 10 and with big arrows

# Explain why it's good for the game

as it stands, the pointing cooldown of 50 is awkwardly long, and while it prevents spamming it also negatively impacts tactical awareness and easy non-verbal communication

halved cooldown should still prevent spamming, shouldn't outclass the pointing abilities of leaders, but allow for more efficient communication (especially for indicating cross-referencing between 2 pointed-at objects)

# Testing Photographs and Procedure

its just a constant edit

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: halved the untrained pointing cooldown
/:cl:
