### PR TITLE
Shrapnell adjustments

### DIFF
--- a/code/datums/ammo/shrapnel.dm
+++ b/code/datums/ammo/shrapnel.dm
@@ -24,8 +24,8 @@
 	if(!shrapnel_chance) // no shrapnell , no special effects
 		return
 	if(isxeno(xeno))
-		xeno.apply_effect(4, SLOW) // multiple hits dont stack they just renew the duration
-		xeno.apply_armoured_damage(damage * 0.6, ARMOR_BULLET, BRUTE, , penetration) // xenos have a lot of HP
+		if(xeno.slowed > 4)
+			xeno.adjust_effect(0.5, SLOW) // multiple hits dont stack they just renew the duration
 
 /datum/ammo/bullet/shrapnel/breaching/set_bullet_traits()
 	. = ..()
@@ -86,11 +86,13 @@
 
 	shell_speed = AMMO_SPEED_TIER_1
 	damage = 30
+	damage_type = BURN // acid
 	penetration = ARMOR_PENETRATION_TIER_4
 
+
 /datum/ammo/bullet/shrapnel/neuro/on_hit_mob(mob/living/mob, obj/projectile/projectile)
-	if(mob.slowed < 6)
-		mob.adjust_effect(0.8, SLOW)
+	if(mob.superslowed < 4)
+		mob.adjust_effect(0.5, SUPERSLOW)
 
 /datum/ammo/bullet/shrapnel/metal
 	name = "metal shrapnel"

--- a/code/datums/ammo/shrapnel.dm
+++ b/code/datums/ammo/shrapnel.dm
@@ -25,7 +25,7 @@
 		return
 	if(isxeno(xeno))
 		if(xeno.slowed > 4)
-			xeno.adjust_effect(0.5, SLOW) // multiple hits dont stack they just renew the duration
+			xeno.adjust_effect(0.5, SLOW)
 
 /datum/ammo/bullet/shrapnel/breaching/set_bullet_traits()
 	. = ..()

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -145,7 +145,7 @@
 	item_state = "grenade_m74_airburst_f_active"
 	explosion_power = 0
 	explosion_falloff = 25
-	shrapnel_count = 16
+	shrapnel_count = 12
 	det_time = 0 // Unused, because we don't use prime.
 	hand_throwable = FALSE
 	falloff_mode = EXPLOSION_FALLOFF_SHAPE_LINEAR

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -115,7 +115,7 @@
 	throw_range = 6
 	underslug_launchable = FALSE
 	explosion_power = 120
-	shrapnel_count = 48
+	shrapnel_count = 40
 	falloff_mode = EXPLOSION_FALLOFF_SHAPE_LINEAR
 
 
@@ -129,7 +129,7 @@
 	throw_range = 6
 	underslug_launchable = FALSE
 	explosion_power = 60
-	shrapnel_count = 56
+	shrapnel_count = 40
 	falloff_mode = EXPLOSION_FALLOFF_SHAPE_LINEAR
 
 /*

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -169,6 +169,7 @@
 		if(isigniter(detonator.a_right) && isigniter(detonator.a_left))
 			set_tripwire()
 			use_dir = TRUE
+			reaction_limits["max_ex_shards"] = round(reaction_limits["max_ex_shards"]/2)
 			return
 		else
 			..()

--- a/code/game/objects/items/explosives/plastic.dm
+++ b/code/game/objects/items/explosives/plastic.dm
@@ -335,7 +335,7 @@
 	min_timer = 3
 	penetration = 0.60
 	deploying_time = 10
-	var/shrapnel_volume = 40
+	var/shrapnel_volume = 20
 	var/shrapnel_type = /datum/ammo/bullet/shrapnel/metal
 	var/explosion_strength = 60
 


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->
-removes shrapnell aditional damage to xenos.
-lowers shrapnell slow from 4 second to 0.5 seconds stackable up to 4 seconds
-neuro shrapnell is now superslow instead of just slow.
-reduces the amount of shrapnel in OT mines depending if you are using directional mode , directional mode now halves the maximun amount of shrapnel to prevent crazy damages.
- reduces the amount of shrapnell on AGM-F.
- reduces the amount of shrapnell on breaching charges.


# Explain why it's good for the game
shrapnell damage seems to be too high currently as i forgot to account for bcharges and others . i have removed the aditional damage and now we just stick a standard 30 DMG .  all explosives with shrapnell have been tweaked. 

OT mines now only spew half the amount of shrapnel if they are being used on directional mode . this is to prevent 360 mode from being useless while reducing the amount of shrapnell available.

neuro now superslows instead of normal slow . the reason for this is because it was basically worse shrapnell . since normal shrapnell does slow already.

breaching charge amount has been halved to prevent instakill . it should now be relatively safe for xenos unless they are exactly behind of it.



# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Reduces the amount of shrapnel on breaching charge and AGM-F
balance: Removes the shrapnel additional damage to xenomorphs
balance: OT mines now have halved shrapnell if they use directional mode.
balance: Neurotoxic shrapnel now superslows for 0.5 seconds each ( up to 4 seconds)
balance: Shrapnel slow reduced to 0.5 seconds each (up to 4 seconds)

/:cl:
