### PR TITLE
Lower Medbay usability tweaks

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -573,12 +573,6 @@
 /obj/structure/window/framed/almayer/hull,
 /turf/open/floor/plating,
 /area/almayer/lifeboat_pumps/north1)
-"aby" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 5
-	},
-/turf/open/floor/almayer/dark_sterile,
-/area/almayer/medical/lower_medical_medbay)
 "abz" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_y = 25
@@ -649,7 +643,7 @@
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/living/basketball)
-"abM" = (
+"abL" = (
 /turf/closed/wall/almayer/white/reinforced,
 /area/almayer/medical/lower_medical_medbay)
 "abN" = (
@@ -720,18 +714,6 @@
 	},
 /turf/open/floor/almayer/sterile_green_side,
 /area/almayer/medical/operating_room_four)
-"abW" = (
-/obj/structure/machinery/cryopod{
-	pixel_y = 6
-	},
-/turf/open/floor/almayer/cargo,
-/area/almayer/medical/lower_medical_medbay)
-"abX" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 9
-	},
-/turf/open/floor/almayer/sterile_green_side,
-/area/almayer/medical/lower_medical_medbay)
 "abY" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
@@ -1016,17 +998,31 @@
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/operating_room_four)
 "acD" = (
-/obj/structure/machinery/light{
-	dir = 8
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/storage/box/gloves{
+	pixel_x = 5;
+	pixel_y = 12
 	},
-/obj/structure/machinery/cryopod{
-	pixel_y = 6
+/obj/item/storage/box/masks{
+	pixel_x = 5
 	},
-/turf/open/floor/almayer/cargo,
-/area/almayer/medical/lower_medical_medbay)
-"acE" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer/dark_sterile,
+/obj/item/roller/surgical,
+/obj/item/roller/surgical,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/roller/surgical,
+/obj/item/reagent_container/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner"
+	},
+/obj/item/reagent_container/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner"
+	},
+/obj/item/storage/box/bodybags{
+	pixel_y = 12;
+	pixel_x = -8
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/lower_medical_medbay)
 "acF" = (
 /obj/structure/surface/rack,
@@ -1489,15 +1485,14 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/operating_room_four)
-"adx" = (
-/obj/structure/window/framed/almayer/white,
-/obj/structure/machinery/door/poddoor/shutters/almayer{
-	id = "fieldmedequipment";
-	name = "\improper Field Medical Equipment Shutters";
-	dir = 2
-	},
+"adw" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer/plating/northeast,
+/obj/structure/machinery/cm_vending/sorted/medical,
+/obj/structure/medical_supply_link/green,
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/almayer/sterile_green_side,
 /area/almayer/medical/lower_medical_medbay)
 "ady" = (
 /obj/structure/surface/table/almayer,
@@ -3583,6 +3578,15 @@
 "aiw" = (
 /turf/open/floor/almayer,
 /area/almayer/engineering/starboard_atmos)
+"aix" = (
+/obj/structure/window/framed/almayer/white,
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	id = "fieldmedequipment";
+	name = "\improper Field Medical Equipment Shutters";
+	dir = 2
+	},
+/turf/open/floor/almayer/plating/northeast,
+/area/almayer/medical/lower_medical_medbay)
 "aiy" = (
 /obj/structure/window/framed/almayer/white,
 /obj/structure/machinery/door/poddoor/shutters/almayer{
@@ -3590,6 +3594,7 @@
 	name = "\improper Field Medical Equipment Shutters";
 	dir = 2
 	},
+/obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/plating/northeast,
 /area/almayer/medical/lower_medical_medbay)
 "aiz" = (
@@ -4432,6 +4437,12 @@
 /turf/open/floor/almayer/sterile_green,
 /area/almayer/medical/lower_medical_lobby)
 "akG" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 5
+	},
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/medical/lower_medical_medbay)
+"akH" = (
 /obj/structure/sign/safety/medical{
 	pixel_y = 34
 	},
@@ -4441,24 +4452,15 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/lower_medical_medbay)
-"akH" = (
+"akI" = (
 /obj/effect/decal/medical_decals{
 	icon_state = "triagedecaldir";
 	dir = 4
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/lower_medical_medbay)
-"akI" = (
-/turf/open/floor/almayer/plate,
-/area/almayer/medical/lower_medical_medbay)
 "akJ" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/machinery/cm_vending/sorted/medical,
-/obj/structure/medical_supply_link/green,
-/obj/structure/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/almayer/sterile_green_side,
+/turf/open/floor/almayer/plate,
 /area/almayer/medical/lower_medical_medbay)
 "akK" = (
 /obj/structure/machinery/chem_dispenser/corpsman,
@@ -4478,10 +4480,29 @@
 /turf/open/floor/almayer/silver/north,
 /area/almayer/command/cichallway)
 "akM" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor/almayer/sterile_green,
+/area/almayer/medical/lower_medical_medbay)
+"akN" = (
 /obj/structure/window/framed/almayer/white,
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/lower_medical_medbay)
-"akN" = (
+"akO" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_18";
+	pixel_y = 17;
+	pixel_x = -8;
+	layer = 3.1
+	},
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/almayer/sterile_green,
+/area/almayer/medical/lower_medical_medbay)
+"akP" = (
 /obj/effect/decal/medical_decals{
 	icon_state = "triagedecaltopright"
 	},
@@ -4490,28 +4511,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer/sterile_green_side/east,
-/area/almayer/medical/lower_medical_medbay)
-"akO" = (
-/obj/structure/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/medical/lower_medical_medbay)
-"akP" = (
-/obj/structure/machinery/light{
-	dir = 4
-	},
-/obj/structure/surface/rack,
-/obj/item/storage/firstaid/adv/empty,
-/obj/item/storage/firstaid/adv/empty,
-/obj/item/storage/firstaid/adv/empty,
-/obj/item/storage/firstaid/fire/empty,
-/obj/item/storage/firstaid/fire/empty,
-/obj/item/storage/firstaid/fire/empty,
-/obj/item/storage/firstaid/o2/empty,
-/obj/item/storage/firstaid/o2/empty,
-/obj/item/storage/firstaid/o2/empty,
-/turf/open/floor/almayer/sterile_green,
 /area/almayer/medical/lower_medical_medbay)
 "akQ" = (
 /obj/structure/sign/safety/restrictedarea{
@@ -4528,6 +4527,28 @@
 /turf/open/floor/almayer/sterile_green_side/northeast,
 /area/almayer/medical/lower_medical_medbay)
 "akR" = (
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/almayer/plate,
+/area/almayer/medical/lower_medical_medbay)
+"akS" = (
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/obj/structure/surface/rack,
+/obj/item/storage/firstaid/adv/empty,
+/obj/item/storage/firstaid/adv/empty,
+/obj/item/storage/firstaid/adv/empty,
+/obj/item/storage/firstaid/fire/empty,
+/obj/item/storage/firstaid/fire/empty,
+/obj/item/storage/firstaid/fire/empty,
+/obj/item/storage/firstaid/o2/empty,
+/obj/item/storage/firstaid/o2/empty,
+/obj/item/storage/firstaid/o2/empty,
+/turf/open/floor/almayer/sterile_green,
+/area/almayer/medical/lower_medical_medbay)
+"akT" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/machinery/cm_vending/sorted/medical,
 /obj/structure/medical_supply_link/green,
@@ -4536,11 +4557,11 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/lower_medical_medbay)
-"akS" = (
+"akU" = (
 /obj/structure/machinery/chem_dispenser/corpsman,
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/lower_medical_medbay)
-"akT" = (
+"akV" = (
 /obj/structure/machinery/cm_vending/sorted/medical/blood,
 /obj/structure/medical_supply_link/green,
 /obj/structure/machinery/light{
@@ -4548,7 +4569,7 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/lower_medical_medbay)
-"akU" = (
+"akW" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	layer = 1.9
 	},
@@ -4560,13 +4581,27 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/lower_medical_medbay)
-"akV" = (
+"akX" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/red/north,
+/area/almayer/lifeboat_pumps/north2)
+"akY" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 9
+	},
+/turf/open/floor/almayer/sterile_green_side,
+/area/almayer/medical/lower_medical_medbay)
+"akZ" = (
 /obj/structure/pipes/vents/pump{
 	dir = 4
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/lower_medical_medbay)
-"akW" = (
+"ala" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/medical/lower_medical_medbay)
+"alb" = (
 /obj/structure/surface/rack,
 /obj/item/storage/syringe_case{
 	pixel_y = -5
@@ -4606,59 +4641,19 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/lower_medical_medbay)
-"akX" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/red/north,
-/area/almayer/lifeboat_pumps/north2)
-"akY" = (
+"alc" = (
 /obj/structure/machinery/gel_refiller,
 /obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/lower_medical_medbay)
-"akZ" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer/sterile_green,
-/area/almayer/medical/lower_medical_medbay)
-"ala" = (
-/turf/open/floor/almayer/sterile_green,
-/area/almayer/medical/lower_medical_medbay)
-"alb" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	pixel_x = 1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "W";
-	layer = 3.3
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/spiderling_remains{
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer/plating/northeast,
-/area/almayer/medical/lower_medical_medbay)
-"alc" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "SE-out"
-	},
-/obj/structure/closet/secure_closet/medical_doctor,
-/turf/open/floor/almayer/sterile_green_corner/west,
-/area/almayer/medical/lower_medical_medbay)
 "ald" = (
 /turf/open/floor/almayer/red,
 /area/almayer/shipboard/weapon_room)
 "ale" = (
-/obj/structure/pipes/vents/scrubber{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
-/turf/open/floor/almayer/sterile_green_side,
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer/sterile_green,
 /area/almayer/medical/lower_medical_medbay)
 "alf" = (
 /obj/structure/machinery/light{
@@ -4681,22 +4676,24 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/u_m_s)
 "ali" = (
-/obj/structure/machinery/cm_vending/clothing/medical_crew{
-	pixel_x = 30;
-	density = 0
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
-/turf/open/floor/almayer/sterile_green_corner/west,
+/turf/open/floor/almayer/sterile_green,
 /area/almayer/medical/lower_medical_medbay)
 "alj" = (
-/obj/structure/largecrate/machine/bodyscanner,
-/obj/item/folded_tent/med{
-	pixel_x = -3;
-	pixel_y = 10
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
 	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	layer = 3.3
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/spiderling_remains{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer/plating/northeast,
 /area/almayer/medical/lower_medical_medbay)
 "alk" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer{
@@ -4711,6 +4708,32 @@
 /turf/closed/wall/almayer/research/containment/wall/purple,
 /area/almayer/medical/containment/cell)
 "all" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SE-out"
+	},
+/obj/structure/closet/secure_closet/medical_doctor,
+/turf/open/floor/almayer/sterile_green_corner/west,
+/area/almayer/medical/lower_medical_medbay)
+"alm" = (
+/obj/structure/pipes/vents/scrubber{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/turf/open/floor/almayer/sterile_green_side,
+/area/almayer/medical/lower_medical_medbay)
+"aln" = (
+/obj/structure/machinery/cm_vending/clothing/medical_crew{
+	pixel_x = 30;
+	density = 0
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/turf/open/floor/almayer/sterile_green_corner/west,
+/area/almayer/medical/lower_medical_medbay)
+"alo" = (
 /obj/structure/window/framed/almayer/white,
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/poddoor/shutters/almayer{
@@ -4720,13 +4743,33 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/medical/lower_medical_medbay)
-"alm" = (
+"alp" = (
+/obj/structure/machinery/firealarm{
+	pixel_y = -28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/almayer/red,
+/area/almayer/shipboard/brig/starboard_hallway)
+"alq" = (
+/obj/structure/surface/rack,
+/obj/item/storage/backpack/marine,
+/obj/item/storage/backpack/marine,
+/obj/item/storage/backpack/marine,
+/obj/item/storage/backpack/marine,
+/obj/item/cpr_dummy{
+	pixel_y = -1
+	},
+/turf/open/floor/almayer/sterile_green_side/west,
+/area/almayer/medical/lower_medical_medbay)
+"alr" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out"
 	},
 /turf/closed/wall/almayer/white/reinforced,
 /area/almayer/medical/lower_medical_medbay)
-"aln" = (
+"als" = (
 /obj/structure/machinery/door/airlock/almayer/medical{
 	name = "\improper Debilitated's Storage";
 	req_one_access = null;
@@ -4737,7 +4780,7 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/lower_medical_lobby)
-"alo" = (
+"alt" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
 	pixel_y = 1
@@ -4770,43 +4813,7 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/medical/lower_medical_lobby)
-"alp" = (
-/obj/structure/machinery/firealarm{
-	pixel_y = -28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/almayer/red,
-/area/almayer/shipboard/brig/starboard_hallway)
-"alq" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/storage/box/gloves{
-	pixel_x = 5;
-	pixel_y = 12
-	},
-/obj/item/storage/box/masks{
-	pixel_x = 5
-	},
-/obj/item/roller/surgical,
-/obj/item/roller/surgical,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/roller/surgical,
-/obj/item/reagent_container/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner"
-	},
-/obj/item/reagent_container/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner"
-	},
-/obj/item/storage/box/bodybags{
-	pixel_y = 12;
-	pixel_x = -8
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/medical/lower_medical_medbay)
-"alr" = (
+"alu" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
 	pixel_x = 1
@@ -4823,7 +4830,7 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/plating/northeast,
 /area/almayer/medical/lower_medical_medbay)
-"als" = (
+"alv" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer/open{
 	id = "CIC_Conference";
 	name = "\improper CIC Conference Shutters"
@@ -4831,7 +4838,14 @@
 /obj/structure/window/framed/almayer,
 /turf/open/floor/plating,
 /area/almayer/command/cichallway)
-"alt" = (
+"alw" = (
+/obj/structure/machinery/door/airlock/almayer/generic{
+	dir = 2;
+	name = "\improper Pilot's Room"
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/living/pilotbunks)
+"alx" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer{
 	id = "dccbunk";
 	name = "\improper Privacy Shutters"
@@ -4841,13 +4855,6 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/almayer/living/pilotbunks)
-"alw" = (
-/obj/structure/machinery/door/airlock/almayer/generic{
-	dir = 2;
-	name = "\improper Pilot's Room"
-	},
-/turf/open/floor/almayer/test_floor4,
 /area/almayer/living/pilotbunks)
 "aly" = (
 /turf/closed/wall/almayer,
@@ -11141,15 +11148,12 @@
 /turf/open/floor/almayer/sterile_green_corner,
 /area/almayer/medical/operating_room_one)
 "bcV" = (
-/obj/structure/surface/rack,
-/obj/item/storage/backpack/marine,
-/obj/item/storage/backpack/marine,
-/obj/item/storage/backpack/marine,
-/obj/item/storage/backpack/marine,
-/obj/item/cpr_dummy{
-	pixel_y = -1
+/obj/structure/largecrate/machine/bodyscanner,
+/obj/item/folded_tent/med{
+	pixel_x = -3;
+	pixel_y = 10
 	},
-/turf/open/floor/almayer/sterile_green_side/west,
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/lower_medical_medbay)
 "bcZ" = (
 /obj/structure/machinery/chem_dispenser/corpsman{
@@ -23684,10 +23688,13 @@
 /turf/open/floor/almayer/cargo_arrow,
 /area/almayer/squads/charlie_delta_shared)
 "eBZ" = (
-/obj/structure/bed/chair{
-	dir = 4
+/obj/structure/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/almayer/sterile_green,
+/obj/structure/machinery/cryopod{
+	pixel_y = 6
+	},
+/turf/open/floor/almayer/cargo,
 /area/almayer/medical/lower_medical_medbay)
 "eCt" = (
 /obj/structure/closet/crate,
@@ -59891,17 +59898,10 @@
 /turf/open/floor/almayer/orange/east,
 /area/almayer/squads/bravo)
 "tAU" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_18";
-	pixel_y = 17;
-	pixel_x = -8;
-	layer = 3.1
+/obj/structure/machinery/cryopod{
+	pixel_y = 6
 	},
-/obj/structure/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/almayer/sterile_green,
+/turf/open/floor/almayer/cargo,
 /area/almayer/medical/lower_medical_medbay)
 "tAW" = (
 /obj/structure/disposalpipe/segment,
@@ -87908,7 +87908,7 @@ cAR
 xSz
 pEB
 jUY
-als
+alv
 sUE
 jmY
 iwW
@@ -88111,7 +88111,7 @@ xuZ
 jnD
 wsD
 jUY
-als
+alv
 iiZ
 jmY
 rHc
@@ -88518,7 +88518,7 @@ vka
 lnt
 ciN
 sUg
-als
+alv
 vYM
 fJm
 aAq
@@ -88526,7 +88526,7 @@ iah
 mGe
 dCx
 rpK
-als
+alv
 xmg
 ggt
 wIQ
@@ -94801,7 +94801,7 @@ evX
 aeZ
 aka
 aoI
-alt
+alx
 fdE
 amh
 amh
@@ -95004,7 +95004,7 @@ evX
 afr
 akc
 buc
-alt
+alx
 jMm
 pcG
 iFn
@@ -98765,7 +98765,7 @@ wKN
 qPk
 adH
 baZ
-aln
+als
 baZ
 baZ
 kan
@@ -99374,14 +99374,14 @@ hKe
 aiB
 adH
 bmn
-alo
+alt
 ahw
 kan
 agW
 sYh
 rlZ
 agh
-akP
+akS
 jXf
 aeU
 aeo
@@ -99584,9 +99584,9 @@ bst
 psK
 psK
 beW
-abM
-abM
-abM
+abL
+abL
+abL
 beW
 psK
 psK
@@ -102020,9 +102020,9 @@ xMs
 psK
 psK
 beW
-abM
-abM
-abM
+abL
+abL
+abL
 aew
 psK
 psK
@@ -102214,27 +102214,27 @@ aQF
 syj
 wKN
 aiA
-aiy
+aix
 ail
-alq
-alj
+acD
+bcV
 adm
 ahb
 cjW
 agy
 agn
-akR
+akT
 afw
-akJ
+adw
 rZB
-aby
+akG
 buu
 kan
-abW
-acD
-acD
-abW
-abM
+tAU
+eBZ
+eBZ
+tAU
+abL
 abm
 mDZ
 hkC
@@ -102417,17 +102417,17 @@ aQF
 rWv
 aiG
 aiE
-adx
+aiy
 aSO
-alr
+alu
 bZn
-alb
+alj
 bgw
-acE
+ala
 adS
-abX
-akS
-akM
+akY
+akU
+akN
 akK
 sYh
 adT
@@ -102437,7 +102437,7 @@ tgV
 dut
 dut
 aeD
-abM
+abL
 abm
 sPY
 knm
@@ -102620,17 +102620,17 @@ dqE
 htl
 vaq
 aiF
-abM
-abM
+abL
+abL
 dUS
-all
+alo
 kan
 ahd
-akW
+alb
 adT
 dTZ
-akT
-akM
+akV
+akN
 afg
 sYh
 adT
@@ -102640,7 +102640,7 @@ afz
 dut
 dut
 akr
-abM
+abL
 knm
 sPY
 knm
@@ -102823,19 +102823,19 @@ aWF
 qPk
 hKe
 qqf
-abM
-abM
+abL
+abL
 qGF
-bcV
-alc
+alq
+all
 kan
-akY
+alc
 adT
 dTZ
-abM
-abM
-abM
-akG
+abL
+abL
+abL
+akH
 adT
 pKZ
 akB
@@ -102843,7 +102843,7 @@ xIk
 xIk
 xIk
 xIk
-abM
+abL
 tzw
 sPY
 knm
@@ -103026,18 +103026,18 @@ aQF
 uNf
 hKe
 qPk
-abM
-abM
+abL
+abL
 ahX
 rlZ
-ale
+alm
 ahg
-akZ
+ale
 agC
 thP
-eBZ
-tAU
-eBZ
+akM
+akO
+akM
 bgP
 adT
 lJG
@@ -103046,7 +103046,7 @@ kan
 kan
 kan
 kan
-abM
+abL
 knm
 sPY
 knm
@@ -103229,14 +103229,14 @@ aWD
 qPk
 hKe
 qPk
-abM
-abM
+abL
+abL
 eiw
 bda
-ali
+aln
 oXY
-ala
-akV
+ali
+akZ
 rlZ
 rlZ
 dBH
@@ -103249,7 +103249,7 @@ wbP
 wbP
 wbP
 wbP
-abM
+abL
 knm
 sPY
 cbL
@@ -103432,27 +103432,27 @@ aWD
 eZC
 pSF
 eZC
-abM
-abM
-abM
-alm
-abM
-abM
+abL
+abL
+abL
+alr
+abL
+abL
 jGn
 agD
-akH
-akH
-akN
-akH
-akH
+akI
+akI
+akP
+akI
+akI
 adX
 nrN
-abM
-abM
-abM
-abM
-abM
-abM
+abL
+abL
+abL
+abL
+abL
+abL
 hBW
 ltv
 kGw
@@ -103639,19 +103639,19 @@ nyw
 iXU
 hDw
 kzb
-abM
-abM
+abL
+abL
 kan
 kan
 oKv
-akU
+akW
 kan
 oKv
 mwM
 kan
 kan
-abM
-abM
+abL
+abL
 rIO
 vEH
 tQd
@@ -103846,11 +103846,11 @@ ahr
 rRU
 agR
 kan
-akI
-akI
-akO
-akI
-akI
+akJ
+akJ
+akR
+akJ
+akJ
 kan
 neS
 ady


### PR DESCRIPTION

# About the pull request

Presents a bunch of minor tweaks to the newly designed lower medbay
- Adds eastern access back to the lobby
- Adds surgical beds and stasis bags to the nurse room
- Adds more medical vendors of all types across the lobby
- Adds more empty medkits across the lobby, instead of being in the NE medbay trash pile, where they did NOT belong
- Generally rearranges tables, crates, and racks for ease of access
- Removes one of the two ladder access routes

# Explain why it's good for the game

Ease of use is a very important aspect of mapping, particularly in an equally important department like Medbay.

All of my changes in this PR are the result of community consultation, and represent the opinions of the vast majority within the medical playerbase


# Testing Photographs and Procedure
![image](https://github.com/user-attachments/assets/16a2a9b3-9836-44fa-b8c3-b172e7cb66eb)



# Changelog
:cl:
qol: adds otherwise missing or lacking items available in lower medbay
maptweak: restores lower medbay eastern access
/:cl:
