### PR TITLE
516: only use byondstorage as a fallback if github pages is down

### DIFF
--- a/.github/workflows/generate_documentation.yml
+++ b/.github/workflows/generate_documentation.yml
@@ -28,5 +28,5 @@ jobs:
           BRANCH: gh-pages
           CLEAN: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SINGLE_COMMIT: true
+          TARGET_FOLDER: docs
           FOLDER: dmdoc

--- a/.github/workflows/generate_static_cdn.yml
+++ b/.github/workflows/generate_static_cdn.yml
@@ -1,0 +1,23 @@
+name: Generate static assets
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - "tgui/public/**"
+
+jobs:
+  generate_static_cdn:
+    if: ( !contains(github.event.head_commit.message, '[ci skip]') )
+    runs-on: ubuntu-latest
+    concurrency: gen-static-assets
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          BRANCH: gh-pages
+          CLEAN: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_FOLDER: assets
+          FOLDER: tgui/public

--- a/code/controllers/configuration/entries/resources.dm
+++ b/code/controllers/configuration/entries/resources.dm
@@ -28,3 +28,7 @@
 	if (str_var && str_var[length(str_var)] != "/")
 		str_var += "/"
 	return ..(str_var)
+
+/datum/config_entry/string/storage_cdn_iframe
+	config_entry_value = "https://cmss13-devs.github.io/cmss13/assets/iframe.html"
+	protection = CONFIG_ENTRY_LOCKED

--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -35,11 +35,15 @@ SUBSYSTEM_DEF(tgui)
 	basehtml = replacetext(basehtml, "tgui:stylesheet", MAP_STYLESHEET)
 
 /datum/controller/subsystem/tgui/OnConfigLoad()
+	var/storage_iframe = CONFIG_GET(string/storage_cdn_iframe)
+
 	if(CONFIG_GET(string/asset_transport) == "webroot")
 		var/datum/asset_transport/webroot/webroot = SSassets.transport
 
 		var/datum/asset_cache_item/item = webroot.register_asset("iframe.html", file("tgui/public/iframe.html"))
 		basehtml = replacetext(basehtml, "tgui:storagecdn", webroot.get_asset_url("iframe.html", item))
+	else if(storage_iframe)
+		basehtml = replacetext(basehtml, "tgui:storagecdn", storage_iframe)
 
 /datum/controller/subsystem/tgui/Shutdown()
 	close_all_uis()

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -358,7 +358,8 @@
 		return
 
 	to_chat(src, SPAN_INFO("You can now right click to use inspect on browsers."))
-	winset(src, "", "browser-options=byondstorage,find,devtools")
+	winset(src, null, list("browser-options" = "+devtools"))
+	winset(src, null, list("browser-options" = "+find"))
 
 #ifdef TESTING
 GLOBAL_LIST_EMPTY(dirty_vars)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -286,9 +286,6 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 	GLOB.clients += src
 	GLOB.directory[ckey] = src
 
-	if(byond_version >= 516) // Enable 516 compat browser storage mechanisms
-		winset(src, "", "browser-options=byondstorage")
-
 	// Instantiate stat panel
 	stat_panel = new(src, "statbrowser")
 	stat_panel.subscribe(src, PROC_REF(on_stat_panel_message))

--- a/tgui/packages/tgui-panel/chat/middleware.js
+++ b/tgui/packages/tgui-panel/chat/middleware.js
@@ -4,7 +4,7 @@
  * @license MIT
  */
 
-import { storage as realStorage, StorageProxy } from 'common/storage';
+import { storage } from 'common/storage';
 import DOMPurify from 'dompurify';
 
 import {
@@ -34,9 +34,6 @@ import { selectChat, selectCurrentChatPage } from './selectors';
 
 // List of blacklisted tags
 const FORBID_TAGS = ['a', 'iframe', 'link', 'video'];
-
-const storage =
-  Byond.storageCdn === 'tgui:storagecdn' ? realStorage : new StorageProxy(true);
 
 const saveChatToStorage = async (store) => {
   const state = selectChat(store.getState());

--- a/tgui/public/iframe.html
+++ b/tgui/public/iframe.html
@@ -31,6 +31,9 @@
 
     window.addEventListener('message', (messageEvent) => {
       switch (messageEvent.data.type) {
+        case 'ping':
+          messageEvent.source.postMessage(true, "*");
+          break;
         case 'get':
           get(event.data.key).then((value) => {
             messageEvent.source.postMessage({key: messageEvent.data.key, value: value}, "*")


### PR DESCRIPTION
title really

no playerfacing changes

this works by uploading the iframe page to github pages, which we use as our iframe in game to be able to access a persistent indexeddb in 516

in production, we don't actually use this, so if github pages does down, only people developing locally (or forks without a cdn) will be impacted

if github pages *does* go down, we instead just fall back to using byondstorage