### PR TITLE
Adds xeno cooldown timer on abilities

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -85,6 +85,8 @@
 
 /atom/movable/screen/action_button/proc/set_maptext(new_maptext, new_maptext_x, new_maptext_y)
 	overlays -= maptext_overlay
+	if(!new_maptext)
+		return
 	maptext_overlay = image(null, null, null, layer + 0.1)
 	maptext_overlay.maptext = new_maptext
 	if(new_maptext_x)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/xeno_action.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/xeno_action.dm
@@ -34,6 +34,13 @@
 		charge_ready = FALSE
 	update_button_icon()
 
+/datum/action/xeno_action/Destroy()
+	STOP_PROCESSING(SSfasteffects, src)
+	. = ..()
+
+/datum/action/xeno_action/process(delta_time)
+	return update_cooldown_visual()
+
 /datum/action/xeno_action/proc/remove_charge()
 	SIGNAL_HANDLER
 	charges--
@@ -243,6 +250,7 @@
 	cooldown_timer_id = addtimer(CALLBACK(src, PROC_REF(on_cooldown_end)), cooldown_to_apply, TIMER_UNIQUE|TIMER_STOPPABLE)
 	current_cooldown_duration = cooldown_to_apply
 	current_cooldown_start_time = world.time
+	START_PROCESSING(SSfasteffects, src)
 
 	// Update our button
 	update_button_icon()
@@ -263,6 +271,7 @@
 	cooldown_timer_id = addtimer(CALLBACK(src, PROC_REF(on_cooldown_end)), cooldown_duration, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_STOPPABLE)
 	current_cooldown_duration = cooldown_duration
 	current_cooldown_start_time = world.time
+	START_PROCESSING(SSfasteffects, src)
 
 // Checks whether the action is on cooldown. Should not be overridden.
 // Returns TRUE if the action can be used and FALSE otherwise.
@@ -450,6 +459,14 @@
 	track_xeno_ability_stats()
 	if(action_start_message)
 		to_chat(owner, SPAN_NOTICE(action_start_message))
+
+/datum/action/xeno_action/proc/update_cooldown_visual()
+	var/time_left = max(current_cooldown_start_time + current_cooldown_duration - world.time, 0)
+	if(!owner || time_left <= 0 || cooldown_timer_id == TIMER_ID_NULL)
+		button.set_maptext()
+		return PROCESS_KILL
+	else
+		button.set_maptext(SMALL_FONTS(7, round(time_left/10, 0.1)), 4, 4)
 
 #define XENO_ACTION_CHECK(X) if(!X.check_state() || !action_cooldown_check() || !check_plasma_owner(src.plasma_cost)) return
 #define XENO_ACTION_CHECK_USE_PLASMA(X) if(!X.check_state() || !action_cooldown_check() || !check_and_use_plasma_owner(src.plasma_cost)) return


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Adds a visual timer for cooldowns of Xeno Abilities. It uses SSfasteffects.

I could go further and remove timers on stat panel, messages informing about cooldown being complete and create a new subsystem independent from status effects. 1ds delay of SSobj_tab_items seems a bit too much, 5ds delay of SSfastobj may be a little too slow.

~~I could also add a proc/update_maptext(), which would just update a var/maptext instead of removing-adding an overlay. Not sure how expensive the operation is.~~ Oh, it seems that you can't update maptext that way, huh?

# Explain why it's good for the game
Seeing a number on ability is much better than just doing a skillcheck in your head about "feeling" the cooldown or looking at stat panel. Simple QoL.

# Testing Photographs and Procedure
SS didn't seem to be overloaded with 250+ concurrent players, it stayed, as I was told, 30-40% at its peak.

<details>
<summary>Screenshots & Videos</summary>

https://github.com/user-attachments/assets/570f89ad-b820-44cf-8034-8480db96c044

</details>

# Changelog
:cl:
qol: Added a visual timer for cooldowns of Xeno Abilities
/:cl:
