### PR TITLE
reverts #7979 , makes WP grenades work again

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -329,11 +329,6 @@
 	var/applied_fire_stacks = 5
 	var/xeno_yautja_reduction = 0.75
 
-/obj/effect/particle_effect/smoke/phosphorus/Initialize(mapload, oldamount, datum/cause_data/new_cause_data, intensity, max_intensity)
-	burn_damage = min(burn_damage, max_intensity - intensity) // Applies reaction limits
-
-	. = ..()
-
 /obj/effect/particle_effect/smoke/phosphorus/weak
 	time_to_live = 2
 	smokeranking = SMOKE_RANK_MED
@@ -776,15 +771,6 @@
 
 /datum/effect_system/smoke_spread/phosphorus
 	smoke_type = /obj/effect/particle_effect/smoke/phosphorus
-
-/datum/effect_system/smoke_spread/phosphorus/start(intensity, max_intensity)
-	if(holder)
-		location = get_turf(holder)
-	var/obj/effect/particle_effect/smoke/phosphorus/smoke = new smoke_type(location, amount+1, cause_data, intensity, max_intensity)
-	if(lifetime)
-		smoke.time_to_live = lifetime
-	if(smoke.amount > 0)
-		smoke.spread_smoke(direction)
 
 /datum/effect_system/smoke_spread/phosphorus/weak
 	smoke_type = /obj/effect/particle_effect/smoke/phosphorus/weak

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -699,7 +699,7 @@
 	if(smokerad)
 		var/datum/effect_system/smoke_spread/phosphorus/smoke = new /datum/effect_system/smoke_spread/phosphorus
 		smoke.set_up(max(smokerad, 1), 0, sourceturf, null, 6)
-		smoke.start(intensity, max_fire_int)
+		smoke.start()
 		smoke = null
 
 	exploded = TRUE // clears reagents after all reactions processed


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

reverts #7979 

makes WP grenades work again

# Explain why it's good for the game
WP grenades have been completely broken since january , they just ignited you . doing 0 dmg

regarding OT , phosphorus from what i am aware is suposed to do 40 dmg . the actual bug is smoke and fire spawning at the same time but that can be fixed on another PR with a better implementation

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: WP smoke grenades work properly again.
/:cl:
