### PR TITLE
Folding Barricades now display the correct message for closed/opened

### DIFF
--- a/code/game/objects/structures/barricade/folding.dm
+++ b/code/game/objects/structures/barricade/folding.dm
@@ -219,8 +219,8 @@
 		if(recentlyflipped)
 			to_chat(user, SPAN_NOTICE("[src] has been flipped too recently!"))
 			return
-		user.visible_message(SPAN_NOTICE("[user] flips [src] open."),
-		SPAN_NOTICE("You flip [src] open."))
+		user.visible_message(SPAN_NOTICE("[user] flips [src] closed."),
+		SPAN_NOTICE("You flip [src] closed."))
 		open(src)
 		recentlyflipped = TRUE
 		spawn(10)
@@ -231,8 +231,8 @@
 		if(recentlyflipped)
 			to_chat(user, SPAN_NOTICE("[src] has been flipped too recently!"))
 			return
-		user.visible_message(SPAN_NOTICE("[user] flips [src] closed."),
-		SPAN_NOTICE("You flip [src] closed."))
+		user.visible_message(SPAN_NOTICE("[user] flips [src] open."),
+		SPAN_NOTICE("You flip [src] open."))
 		close(src)
 		recentlyflipped = TRUE
 		spawn(10)


### PR DESCRIPTION
# About the pull request

see title
# Explain why it's good for the game

fixes #8640 

# Testing Photographs and Procedure
good first issue rings true

# Changelog

:cl:
fix: barricades now display the correct open/close message
/:cl:
