### PR TITLE
Fixes lizard recursive check and infinite knockout

### DIFF
--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -132,5 +132,5 @@ GLOBAL_VAR(obfs_x)
 /// A number between -500 and 500.
 GLOBAL_VAR(obfs_y)
 
-/// The current amount of giant lizards that are alive.
-GLOBAL_VAR_INIT(giant_lizards_alive, 0)
+/// List of giant lizards that are alive.
+GLOBAL_LIST_EMPTY(giant_lizards_alive)

--- a/code/game/objects/effects/landmarks/landmarks.dm
+++ b/code/game/objects/effects/landmarks/landmarks.dm
@@ -147,7 +147,7 @@
 
 /obj/effect/landmark/lizard_spawn/proc/latespawn_lizard()
 	//if there's already a ton of lizards alive, try again later
-	if(GLOB.giant_lizards_alive > MAXIMUM_LIZARD_AMOUNT)
+	if(length(GLOB.giant_lizards_alive) > MAXIMUM_LIZARD_AMOUNT)
 		addtimer(CALLBACK(src, PROC_REF(latespawn_lizard)), rand(15 MINUTES, 25 MINUTES))
 		return
 	//if there's a living mob that can witness the spawn then try again later

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/giant_lizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/giant_lizard.dm
@@ -778,7 +778,7 @@
 	alert_others()
 
 /mob/living/simple_animal/hostile/retaliate/giant_lizard/proc/alert_others()
-	for(var/mob/living/simple_animal/hostile/retaliate/giant_lizard/pack_member in GLOB.giant_lizards_alive)
+	for(var/mob/living/simple_animal/hostile/retaliate/giant_lizard/pack_member as anything in GLOB.giant_lizards_alive)
 		if(pack_member == src || pack_member.target_mob_ref?.resolve() || get_dist(src, pack_member) > 7)
 			continue
 		pack_member.Retaliate(pack_attack = TRUE)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/giant_lizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/giant_lizard.dm
@@ -762,9 +762,11 @@
 
 	target_mob = FindTarget()
 	target_mob_ref = WEAKREF(target_mob)
-	if(target_mob_ref) // qdeleted check
-		growl(target_mob)
-		MoveToTarget()
+	if(!target_mob_ref)
+		return
+
+	growl(target_mob)
+	MoveToTarget()
 
 	//basic pack behaviour
 	for(var/mob/living/simple_animal/hostile/retaliate/giant_lizard/pack_member in view(12, src))

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/giant_lizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/giant_lizard.dm
@@ -155,7 +155,7 @@
 
 	RegisterSignal(src, COMSIG_ATOM_DIR_CHANGE, PROC_REF(change_tongue_offset))
 
-	GLOB.giant_lizards_alive++
+	GLOB.giant_lizards_alive += src
 	change_real_name(src, "[name] ([rand(1, 999)])")
 	pounce_callbacks[/mob] = DYNAMIC(/mob/living/simple_animal/hostile/retaliate/giant_lizard/proc/pounced_mob_wrapper)
 	pounce_callbacks[/turf] = DYNAMIC(/mob/living/simple_animal/hostile/retaliate/giant_lizard/proc/pounced_turf_wrapper)
@@ -309,12 +309,16 @@
 /mob/living/simple_animal/hostile/retaliate/giant_lizard/rejuvenate()
 	//if the mob was dead beforehand, it's now alive and therefore it's an extra lizard to the count
 	if(stat == DEAD)
-		GLOB.giant_lizards_alive++
+		GLOB.giant_lizards_alive += src
 	return ..()
 
 /mob/living/simple_animal/hostile/retaliate/giant_lizard/death(datum/cause_data/cause_data, gibbed = FALSE, deathmessage = "lets out a waning growl....")
 	playsound(loc, 'sound/effects/giant_lizard_death.ogg', 70)
-	GLOB.giant_lizards_alive--
+	GLOB.giant_lizards_alive -= src
+	return ..()
+
+/mob/living/simple_animal/hostile/retaliate/giant_lizard/Destroy()
+	GLOB.giant_lizards_alive -= src
 	return ..()
 
 /mob/living/simple_animal/hostile/retaliate/giant_lizard/attack_hand(mob/living/carbon/human/attacking_mob)
@@ -752,7 +756,7 @@
 	return FALSE
 
 //Immediately retaliate after being attacked.
-/mob/living/simple_animal/hostile/retaliate/giant_lizard/Retaliate()
+/mob/living/simple_animal/hostile/retaliate/giant_lizard/Retaliate(pack_attack = FALSE)
 	var/mob/living/target_mob = target_mob_ref?.resolve()
 	if(stat == DEAD || get_dist(src, target_mob) < 6 || on_fire)
 		return
@@ -768,11 +772,16 @@
 	growl(target_mob)
 	MoveToTarget()
 
-	//basic pack behaviour
-	for(var/mob/living/simple_animal/hostile/retaliate/giant_lizard/pack_member in view(12, src))
-		if(pack_member == src || pack_member.target_mob_ref?.resolve())
+	if(pack_attack)
+		return
+
+	alert_others()
+
+/mob/living/simple_animal/hostile/retaliate/giant_lizard/proc/alert_others()
+	for(var/mob/living/simple_animal/hostile/retaliate/giant_lizard/pack_member in GLOB.giant_lizards_alive)
+		if(pack_member == src || pack_member.target_mob_ref?.resolve() || get_dist(src, pack_member) > 7)
 			continue
-		pack_member.Retaliate()
+		pack_member.Retaliate(pack_attack = TRUE)
 
 ///Proc for moving to targets. walk_to() doesn't check for resting and status effects so we will do it ourselves.
 /mob/living/simple_animal/hostile/retaliate/giant_lizard/proc/MoveTo(target, distance = 1, retreat = FALSE, time = 6 SECONDS, return_to_combat = FALSE)
@@ -845,7 +854,9 @@
 
 	var/successful_attacks = 0
 	for(var/times_to_attack = 3, times_to_attack > 0, times_to_attack--)
+		//we got stunned, so we can ravage no longer
 		if(body_position == LYING_DOWN)
+			is_ravaging = FALSE
 			return
 
 		if(Adjacent(target))

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -125,6 +125,16 @@
 		return
 	return ..()
 
+/mob/living/simple_animal/update_stat()
+	if(stat == DEAD)
+		return
+
+	if(HAS_TRAIT(src, TRAIT_KNOCKEDOUT))
+		set_stat(UNCONSCIOUS)
+		return
+
+	set_stat(CONSCIOUS)
+
 /mob/living/simple_animal/update_fire()
 	if(!on_fire)
 		overlays -= fire_overlay


### PR DESCRIPTION

# About the pull request

fixes recursive loop with giant lizards that happened due to receiving damage while out of range of any enemies
fixes lizards being knocked out for all eternity due to explosives

# Explain why it's good for the game
bug fix very good.



# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>


https://github.com/user-attachments/assets/2216104c-d643-4ff5-ab70-0a8b5d16c442



</details>


# Changelog
:cl:
fix: Giant Lizards will no longer cause recursive loops (the server won't randomly decide to die anymore). They will now no longer be permanently stunned by explosions.
/:cl:
