### PR TITLE
fixes the sticky keys

### DIFF
--- a/tgui/packages/tgui/layouts/Window.tsx
+++ b/tgui/packages/tgui/layouts/Window.tsx
@@ -57,6 +57,8 @@ export const Window = (props: Props) => {
   const { debugLayout = false } = useDebug();
 
   useEffect(() => {
+    if (suspended) return;
+
     const updateGeometry = () => {
       const options = {
         ...config.window,


### PR DESCRIPTION
the window was still keeping focus because it reset its geometries after being closed. stupid

:cl:
fix: tgui windows closing should no longer cause sticky keys
/:cl: