### PR TITLE
Refactor urange

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -438,22 +438,37 @@
 
 	return target
 
-/proc/urange(dist=0, atom/center=usr, orange=0, areas=0)
+/**
+ * An alternative to orange() that should perform better for distances >= 5 because
+ * of ORANGE_TURFS utilizing RECT_TURFS.
+ *
+ * Returns a list of turfs and those turf's contents, excluding center and
+ * ignoring visibility (like orange).
+ */
+/proc/long_orange(dist=0, atom/center)
 	if(!dist)
-		if(!orange)
-			return list(center)
-		else
-			return list()
+		return list()
 
-	var/list/turfs = RANGE_TURFS(dist, center)
-	if(orange)
-		turfs -= get_turf(center)
+	var/list/turfs = ORANGE_TURFS(dist, center)
 	. = list()
-	for(var/turf/T as anything in turfs)
-		. += T
-		. += T.contents
-		if(areas)
-			. |= T.loc
+	for(var/turf/cur_turf as anything in turfs)
+		. += cur_turf
+		. += cur_turf.contents
+	. -= center // If center isn't a turf
+
+/**
+ * An alternative to range() that should perform better for distances >= 5 because
+ * of RANGE_TURFS utilizing RECT_TURFS.
+ *
+ * Returns a list of turfs and those turf's contents, including center and
+ * ignoring visibility (like orange).
+ */
+/proc/long_range(dist=0, atom/center)
+	var/list/turfs = RANGE_TURFS(dist, center)
+	. = list()
+	for(var/turf/cur_turf as anything in turfs)
+		. += cur_turf
+		. += cur_turf.contents
 
 // returns turf relative to A in given direction at set range
 // result is bounded to map size

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -442,8 +442,8 @@
  * An alternative to orange() that should perform better for distances >= 5 because
  * of ORANGE_TURFS utilizing RECT_TURFS.
  *
- * Returns a list of turfs and those turf's contents, excluding center and
- * ignoring visibility (like orange).
+ * Returns a list of turfs and those turf's contents, excluding center (and
+ * its contents). Ignores visibility (like orange).
  */
 /proc/long_orange(dist=0, atom/center)
 	if(!dist)
@@ -460,8 +460,8 @@
  * An alternative to range() that should perform better for distances >= 5 because
  * of RANGE_TURFS utilizing RECT_TURFS.
  *
- * Returns a list of turfs and those turf's contents, including center and
- * ignoring visibility (like orange).
+ * Returns a list of turfs and those turf's contents, including center (and its
+ * contents if a turf). Ignores visibility (like range).
  */
 /proc/long_range(dist=0, atom/center)
 	var/list/turfs = RANGE_TURFS(dist, center)

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -124,7 +124,7 @@
 		if("Ghosts")
 			targets = GLOB.observer_list + GLOB.dead_mob_list
 		if("All In View Range")
-			var/list/atom/ranged_atoms = urange(usr.client.view, get_turf(usr))
+			var/list/atom/ranged_atoms = long_range(usr.client.view, get_turf(usr))
 			for(var/mob/receiver in ranged_atoms)
 				targets += receiver
 		if("Single Mob")

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -628,7 +628,7 @@
 		return
 	var/mob/living/carbon/target = null
 	var/furthest_distance = INFINITY
-	for(var/mob/living/carbon/C in urange(range, get_turf(loc)))
+	for(var/mob/living/carbon/C in long_range(range, get_turf(loc)))
 		if(!can_target(C))
 			continue
 		var/distance_between = get_dist(src, C)
@@ -712,7 +712,7 @@
 	START_PROCESSING(SSshield_pillar, src)
 
 /obj/effect/alien/resin/shield_pillar/process()
-	for(var/mob/living/carbon/xenomorph/X in urange(range, src))
+	for(var/mob/living/carbon/xenomorph/X in long_range(range, src))
 		if((X.hivenumber != hivenumber) || X.stat == DEAD)
 			continue
 		X.add_xeno_shield(shield_to_give, XENO_SHIELD_SOURCE_SHIELD_PILLAR, decay_amount_per_second = 1, add_shield_on = TRUE, duration = 1 SECONDS)
@@ -992,7 +992,7 @@
 		for(var/obj/effect/alien/resin/special/pylon/pylon as anything in hive.active_endgame_pylons)
 			pylon.protection_level = TURF_PROTECTION_OB
 			pylon.update_icon()
-		
+
 	if(hatched)
 		STOP_PROCESSING(SSobj, src)
 		return
@@ -1098,7 +1098,7 @@
 
 	if(!candidate.client)
 		return FALSE
-	
+
 	return candidate.client.prefs.be_special & BE_KING
 
 #undef KING_PLAYTIME_HOURS
@@ -1208,7 +1208,7 @@
 			rolling_candidates = FALSE
 			return
 	message_admins("Failed to find a client for the King, releasing as freed mob.")
-	
+
 
 /// Starts the hatching in twenty seconds, otherwise immediately if expedited
 /obj/effect/alien/resin/king_cocoon/proc/start_hatching(expedite = FALSE)

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -442,7 +442,7 @@
 	qdel(src)
 
 /obj/structure/ship_ammo/sentry/can_fire_at(turf/impact, mob/user)
-	for(var/obj/structure/machinery/defenses/def in urange(4, impact))
+	for(var/obj/structure/machinery/defenses/def in range(4, impact))
 		to_chat(user, SPAN_WARNING("The selected drop site is too close to another deployed defense!"))
 		return FALSE
 	if(istype(impact, /turf/closed))

--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -395,7 +395,7 @@ GLOBAL_LIST_EMPTY(orbital_cannon_cancellation)
 	message_admins(FONT_SIZE_XL("<A href='byond://?_src_=admin_holder;[HrefToken(forceGlobal = TRUE)];admincancelob=1;cancellation=[cancellation_token]'>CLICK TO CANCEL THIS OB</a>"))
 
 	var/relative_dir
-	for(var/mob/M in urange(30, target))
+	for(var/mob/M in long_range(30, target))
 		if(get_turf(M) == target)
 			relative_dir = 0
 		else
@@ -406,7 +406,7 @@ GLOBAL_LIST_EMPTY(orbital_cannon_cancellation)
 		)
 	sleep(OB_TRAVEL_TIMING/3)
 
-	for(var/mob/M in urange(25, target))
+	for(var/mob/M in long_range(25, target))
 		if(get_turf(M) == target)
 			relative_dir = 0
 		else
@@ -417,7 +417,7 @@ GLOBAL_LIST_EMPTY(orbital_cannon_cancellation)
 		)
 	sleep(OB_TRAVEL_TIMING/3)
 
-	for(var/mob/M in urange(15, target))
+	for(var/mob/M in long_range(15, target))
 		M.show_message( \
 			SPAN_HIGHDANGER("OH GOD THE SKY WILL EXPLODE!!!"), SHOW_MESSAGE_VISIBLE, \
 			SPAN_HIGHDANGER("YOU SHOULDN'T BE HERE!"), SHOW_MESSAGE_AUDIBLE \
@@ -435,7 +435,7 @@ GLOBAL_LIST_EMPTY(orbital_cannon_cancellation)
 
 	var/radius_size = 30
 
-	for(var/mob/living/user in urange(radius_size, epicenter))
+	for(var/mob/living/user in long_range(radius_size, epicenter))
 
 		var/distance = get_accurate_dist(get_turf(user), epicenter)
 		var/distance_percent = ((radius_size - distance) / radius_size)

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -94,7 +94,7 @@
 
 /obj/item/device/m56d_gun/attack_self(mob/user)
 	..()
-	for(var/obj/structure/machinery/machine in urange(defense_check_range, loc))
+	for(var/obj/structure/machinery/machine in long_range(defense_check_range, loc))
 		if(istype(machine, /obj/structure/machinery/m56d_hmg) || istype(machine, /obj/structure/machinery/m56d_post))
 			to_chat(user, SPAN_WARNING("This is too close to [machine]!"))
 			return
@@ -142,7 +142,7 @@
 
 	if(!do_after(user, 1 SECONDS, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 		return
-	for(var/obj/structure/machinery/machine in urange(defense_check_range, loc))
+	for(var/obj/structure/machinery/machine in long_range(defense_check_range, loc))
 		if(istype(machine, /obj/structure/machinery/m56d_hmg) || istype(machine, /obj/structure/machinery/m56d_post))
 			to_chat(user, SPAN_WARNING("This is too close to [machine]!"))
 			return
@@ -338,7 +338,7 @@
 
 	if(istype(O,/obj/item/device/m56d_gun)) //lets mount the MG onto the mount.
 		var/obj/item/device/m56d_gun/MG = O
-		for(var/obj/structure/machinery/machine in urange(MG.defense_check_range, loc, TRUE))
+		for(var/obj/structure/machinery/machine in long_orange(MG.defense_check_range, loc))
 			if(istype(machine, /obj/structure/machinery/m56d_hmg) || istype(machine, /obj/structure/machinery/m56d_post))
 				to_chat(user, SPAN_WARNING("This is too close to [machine]!"))
 				return

--- a/code/modules/defenses/defenses.dm
+++ b/code/modules/defenses/defenses.dm
@@ -387,7 +387,7 @@
 
 	if(!turned_on)
 		if(!can_be_near_defense)
-			for(var/obj/structure/machinery/defenses/def in urange(defense_check_range, loc))
+			for(var/obj/structure/machinery/defenses/def in long_range(defense_check_range, loc))
 				if(def != src && def.turned_on && !def.can_be_near_defense)
 					to_chat(user, SPAN_WARNING("This is too close to \a [def]!"))
 					return

--- a/code/modules/mob/living/carbon/xenomorph/resin_constructions.dm
+++ b/code/modules/mob/living/carbon/xenomorph/resin_constructions.dm
@@ -68,7 +68,7 @@
 		return FALSE
 
 	if(range_between_constructions)
-		for(var/i in urange(range_between_constructions, T))
+		for(var/i in long_range(range_between_constructions, T))
 			var/atom/A = i
 			if(A.type == build_path)
 				to_chat(X, SPAN_WARNING("This is too close to another similar structure!"))


### PR DESCRIPTION

# About the pull request

This PR refactor urange, splitting it into two procs: long_range and long_orange. It removes the behavior of adding an area to the list (nothing used this aspect), and fixes urange with dist 0 not including center contents if it was a turf.

# Explain why it's good for the game

Ultimately this was done because of confusion about what the proc does and why. That should now be clarified, and it should be the tiniest bit more performant.

# Testing Photographs and Procedure
See comment below.

# Changelog
:cl: Drathek
refactor: Refactored urange into long_range and long_orange
/:cl:
