### PR TITLE
[s] Adds a wrapper for icon_states for debugging

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -266,6 +266,13 @@
 /proc/_turn(dir, angle)
 	return turn(dir, angle)
 
+/proc/_icon_states(icon/thing, mode)
+	if(istype(thing))
+		return icon_states(thing, mode)
+	if(isatom(thing))
+		var/atom/atom_thing = thing
+		return icon_states(atom_thing.icon, mode)
+
 /// Auxtools REALLY doesn't know how to handle filters as values;
 /// when passed as arguments to auxtools-called procs, they aren't simply treated as nulls -
 /// they don't even count towards the length of args.


### PR DESCRIPTION

# About the pull request

This PR simply adds a wrapper for icon_states so it can be called via adv proccall.

# Explain why it's good for the game

Debugging!

# Changelog

No player facing changes.
