### PR TITLE
buff armored vest and bulletproof vest

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -39,7 +39,7 @@
 	item_state = "armor"
 	blood_overlay_type = "armor"
 	flags_armor_protection = BODY_FLAG_CHEST|BODY_FLAG_GROIN
-	armor_melee = CLOTHING_ARMOR_MEDIUMLOW
+	armor_melee = CLOTHING_ARMOR_MEDIUM
 	armor_bullet = CLOTHING_ARMOR_MEDIUM
 	armor_laser = CLOTHING_ARMOR_LOW
 	armor_energy = CLOTHING_ARMOR_LOW

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -211,12 +211,17 @@
 	armor_internaldamage = CLOTHING_ARMOR_MEDIUM
 	allowed = list(
 		/obj/item/weapon/gun/,
+		/obj/item/tank/emergency_oxygen,
 		/obj/item/device/flashlight,
 		/obj/item/ammo_magazine/,
+		/obj/item/device/binoculars,
+		/obj/item/storage/large_holster/machete,
+		/obj/item/storage/belt/gun/m4a3,
+		/obj/item/storage/belt/gun/m44,
 		/obj/item/device/motiondetector,
+		/obj/item/storage/backpack/general_belt,
 		/obj/item/weapon/baseballbat,
 		/obj/item/weapon/baseballbat/metal,
-		/obj/item/storage/backpack/general_belt,
 	)
 
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -52,12 +52,14 @@
 		/obj/item/tank/emergency_oxygen,
 		/obj/item/device/flashlight,
 		/obj/item/ammo_magazine/,
-		/obj/item/weapon/baton,
-		/obj/item/restraint/handcuffs,
 		/obj/item/device/binoculars,
 		/obj/item/storage/large_holster/machete,
 		/obj/item/storage/belt/gun/m4a3,
 		/obj/item/storage/belt/gun/m44,
+		/obj/item/device/motiondetector,
+		/obj/item/storage/backpack/general_belt,
+		/obj/item/weapon/baseballbat,
+		/obj/item/weapon/baseballbat/metal,
 	)
 
 /obj/item/clothing/suit/armor/vest/pilot
@@ -150,6 +152,18 @@
 	armor_bio = CLOTHING_ARMOR_MEDIUM
 	armor_rad = CLOTHING_ARMOR_LOW
 	valid_accessory_slots = list(ACCESSORY_SLOT_ARMOR_A, ACCESSORY_SLOT_ARMOR_L, ACCESSORY_SLOT_ARMOR_S, ACCESSORY_SLOT_ARMOR_M)
+	allowed = list(
+		/obj/item/weapon/gun/,
+		/obj/item/device/flashlight,
+		/obj/item/ammo_magazine/,
+		/obj/item/weapon/baton,
+		/obj/item/restraint/handcuffs,
+		/obj/item/device/binoculars,
+		/obj/item/storage/belt/gun/m4a3,
+		/obj/item/storage/belt/gun/m44,
+		/obj/item/device/motiondetector,
+		/obj/item/storage/backpack/general_belt,
+	)
 
 /obj/item/clothing/suit/armor/vest/warden
 	name = "Warden's jacket"
@@ -195,6 +209,15 @@
 	armor_bio = CLOTHING_ARMOR_MEDIUM
 	armor_rad = CLOTHING_ARMOR_NONE
 	armor_internaldamage = CLOTHING_ARMOR_MEDIUM
+	allowed = list(
+		/obj/item/weapon/gun/,
+		/obj/item/device/flashlight,
+		/obj/item/ammo_magazine/,
+		/obj/item/device/motiondetector,
+		/obj/item/weapon/baseballbat,
+		/obj/item/weapon/baseballbat/metal,
+		/obj/item/storage/backpack/general_belt,
+	)
 
 
 /obj/item/clothing/suit/armor/bulletproof/badge


### PR DESCRIPTION
# About the pull request

gives the armored vest and bulletproof vest a back slot 
slightly buffs armored vest slash damage resistance
also gives the W-Y sec vest a back slot

# Explain why it's good for the game

the armored vest and bulletproof vest are usually only worn by clf survivors (they have a chance to spawn with them instead of the militia armor) and are pretty weak due to only protecting chest and groin so this should make clf survs use them more and not instantly drop them to loot a hauberk

this pr was mostly made in mind with having https://github.com/cmss13-devs/cmss13/pull/7816 merged as most of the inserts have dead clf soldiers which you can loot for their better armor (hauberks)


# Testing Photographs and Procedure


# Changelog

:cl:
balance: The armored vest, W-Y sec vest and BPV now all have back slots
balance: The armored vest is now slightly more resistant against slash damage
/:cl:

