### PR TITLE
Increases Mortar Belt and Mortar Backpack Storage

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -782,7 +782,7 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	desc = "A backpack specifically designed to hold ammunition for the M402 mortar."
 	icon_state = "mortarpack"
 	max_w_class = SIZE_HUGE
-	storage_slots = 8
+	storage_slots = 12
 	can_hold = list(/obj/item/mortar_shell)
 	xeno_types = null
 

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -2222,6 +2222,7 @@
 	name="\improper M276 pattern mortar operator belt"
 	desc="An M276 load-bearing rig configured to carry ammunition for the M402 mortar, along with a sidearm."
 	icon_state="mortarbelt"
+	storage_slots = 9
 	holster_slots = list("1" = list("icon_x" = 11))
 	can_hold = list(
 		/obj/item/weapon/gun/pistol,


### PR DESCRIPTION
# About the pull request

Increases the number of shells able to be carried in both the mortar belt and backpack.
Mortar belt storage: 4 > 8
Mortar backpack storage: 8 >12
While my initial focus was on the belt, it didn't make sense for the belt and backpack to be on the same level.
# Explain why it's good for the game
These storages were not altered alongside the mortar rework and were already useless beforehand. Since the mortar is now mobile, these storage items should be viable.

# Testing Photographs and Procedure
I fit more shells in them
# Changelog
:cl:
balance: Increased shell storage capacity of the mortar belt and mortar shell backpack
/:cl:

