### PR TITLE
fixes back sprite for the glass spear and synth hammer

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -253,7 +253,7 @@
 	item_icons = list(
 		WEAR_L_HAND = 'icons/mob/humans/onmob/inhands/weapons/melee/spears_lefthand.dmi',
 		WEAR_R_HAND = 'icons/mob/humans/onmob/inhands/weapons/melee/spears_righthand.dmi',
-		WEAR_BACK = 'icons/mob/humans/onmob/clothing/back/misc.dmi'
+		WEAR_BACK = 'icons/mob/humans/onmob/clothing/back/melee_weapons.dmi'
 	)
 	w_class = SIZE_LARGE
 	flags_equip_slot = SLOT_BACK
@@ -350,7 +350,7 @@
 	item_icons = list(
 		WEAR_L_HAND = 'icons/mob/humans/onmob/inhands/equipment/tools_lefthand.dmi',
 		WEAR_R_HAND = 'icons/mob/humans/onmob/inhands/equipment/tools_righthand.dmi',
-		WEAR_BACK = 'icons/mob/humans/onmob/clothing/back/misc.dmi'
+		WEAR_BACK = 'icons/mob/humans/onmob/clothing/back/melee_weapons.dmi'
 	)
 	icon_state = "d2_breacher"
 	item_state = "d2_breacher"


### PR DESCRIPTION

# About the pull request
fixes #8703 which broke during sprite reorg


# Explain why it's good for the game
bug


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

![NVIDIA_Overlay_l8po4hhVhD](https://github.com/user-attachments/assets/7c4922ab-981f-47f4-854f-bd74e33f7144)
![NVIDIA_Overlay_HctWXG9ZVd](https://github.com/user-attachments/assets/d833fab5-fa6d-4869-a5ef-7d530da7e666)


</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: detectivegoogle
fix: the backworn sprites for spears and breaching hammers are fixed
/:cl:

