### PR TITLE
Smartgun-slap-mags

### DIFF
--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -99,6 +99,7 @@
 	w_class = SIZE_MEDIUM
 	default_ammo = /datum/ammo/bullet/smartgun
 	gun_type = /obj/item/weapon/gun/smartgun
+	flags_magazine = AMMUNITION_CANNOT_REMOVE_BULLETS|AMMUNITION_REFILLABLE|AMMUNITION_SLAP_TRANSFER
 
 /obj/item/ammo_magazine/smartgun/dirty
 	name = "irradiated smartgun drum"
@@ -106,6 +107,7 @@
 	icon_state = "m56_drum_dirty"
 	default_ammo = /datum/ammo/bullet/smartgun/dirty
 	gun_type = /obj/item/weapon/gun/smartgun/dirty
+	flags_magazine = AMMUNITION_CANNOT_REMOVE_BULLETS|AMMUNITION_REFILLABLE|AMMUNITION_SLAP_TRANSFER
 
 /obj/item/ammo_magazine/smartgun/holo_targetting
 	name = "holotargetting smartgun drum"
@@ -113,6 +115,7 @@
 	icon_state = "m56_drum"
 	default_ammo = /datum/ammo/bullet/smartgun/holo_target
 	gun_type = /obj/item/weapon/gun/smartgun/rmc
+	flags_magazine = AMMUNITION_CANNOT_REMOVE_BULLETS|AMMUNITION_REFILLABLE|AMMUNITION_SLAP_TRANSFER
 //-------------------------------------------------------
 //Flare gun. Close enough?
 /obj/item/ammo_magazine/internal/flare

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -99,7 +99,7 @@
 	w_class = SIZE_MEDIUM
 	default_ammo = /datum/ammo/bullet/smartgun
 	gun_type = /obj/item/weapon/gun/smartgun
-	flags_magazine = AMMUNITION_CANNOT_REMOVE_BULLETS|AMMUNITION_REFILLABLE|AMMUNITION_SLAP_TRANSFER
+	flags_magazine = AMMUNITION_REFILLABLE|AMMUNITION_SLAP_TRANSFER
 
 /obj/item/ammo_magazine/smartgun/dirty
 	name = "irradiated smartgun drum"
@@ -107,7 +107,7 @@
 	icon_state = "m56_drum_dirty"
 	default_ammo = /datum/ammo/bullet/smartgun/dirty
 	gun_type = /obj/item/weapon/gun/smartgun/dirty
-	flags_magazine = AMMUNITION_CANNOT_REMOVE_BULLETS|AMMUNITION_REFILLABLE|AMMUNITION_SLAP_TRANSFER
+	flags_magazine = AMMUNITION_REFILLABLE|AMMUNITION_SLAP_TRANSFER
 
 /obj/item/ammo_magazine/smartgun/holo_targetting
 	name = "holotargetting smartgun drum"
@@ -115,7 +115,7 @@
 	icon_state = "m56_drum"
 	default_ammo = /datum/ammo/bullet/smartgun/holo_target
 	gun_type = /obj/item/weapon/gun/smartgun/rmc
-	flags_magazine = AMMUNITION_CANNOT_REMOVE_BULLETS|AMMUNITION_REFILLABLE|AMMUNITION_SLAP_TRANSFER
+	flags_magazine = AMMUNITION_REFILLABLE|AMMUNITION_SLAP_TRANSFER
 //-------------------------------------------------------
 //Flare gun. Close enough?
 /obj/item/ammo_magazine/internal/flare


### PR DESCRIPTION
# About the pull request

Gives all smartgun magazines the 'slap mag' quality used by HPR magazines.

'Slap mags' essentially allow for magazines to transfer ammunition between one another instantaneously, exceptionally useful when you have mags that hold a LOT of ammunition.

You can still reload the old-fashioned way for the masochists who find pleasure in self-inflicted psychological trauma.

I have tested my changes. It's just one line of code, so I doubt anything bad will happen! (I'll eat my words later)

# Explain why it's good for the game

This is a much simpler and sophisticated solution than the one I did for PR #8238, which added loose ammo boxes and such for SGs to reload with.

The root cause of the problem was the fact that 6 months in Guantanamo is currently more preferable than manually reloading partially-filled SG drums. Right now, if you want to reload a partially filled 100-round drum with other drums, you'd need to click  a grand total of **100** times to fully reload that drum back to 500 bullets.

Adding loose ammo boxes would NOT have solved this issue- It would have added a potential avenue to sidestep it, but the problem would still exist- Unless req explicitly dropped loose ammo boxes for SGs, they'd still be stuck clicking hundreds of times to reload a single mag.

As such, I've decided to close that PR and replace it with this one.

# Testing Photographs and Procedure

WIP

# Changelog

add: SG drums now have the 'slap mag' property, allowing you to transfer bullets between SG drums directly, instead of reloading them one handful at a time.

<!-- Both :cl:'s are required for the changelog to work! -->
