### PR TITLE
No more T0 triggering claymore

### DIFF
--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -202,6 +202,10 @@
 /obj/item/explosive/mine/proc/try_to_prime(mob/living/L)
 	if(!active || triggered || (customizable && !detonator))
 		return
+	if(isxeno(L))
+		var/mob/living/carbon/xenomorph/xeno = L
+		if(xeno.mob_size <= MOB_SIZE_XENO_VERY_SMALL)
+			return
 	if(!istype(L))
 		return
 	if(L.stat == DEAD)
@@ -241,6 +245,11 @@
 	if(M.a_intent == INTENT_HELP)
 		to_chat(M, SPAN_XENONOTICE("If you hit this hard enough, it would probably explode."))
 		return XENO_NO_DELAY_ACTION
+
+	if(tripwire)
+		if(M.mob_size <= MOB_SIZE_XENO_VERY_SMALL)
+			to_chat(M, SPAN_XENONOTICE("You are too weak to slash this claymore."))
+			return XENO_NO_DELAY_ACTION
 
 	M.animation_attack_on(src)
 	M.visible_message(SPAN_DANGER("[M] has slashed [src]!"),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Title

# Explain why it's good for the game

This prevents hugger and lesser drones from triggering mines. A hugger or lesser drone triggering a minefield by thier own (one person clearing the minefield) shouldnt be possible. They could still trigger proxy claymores

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

</details>


# Changelog
:cl:
balance: Claymore cant be trigger by huggers and Lesser drones
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
