### PR TITLE
covers a few more stickykey cases

### DIFF
--- a/tgui/packages/tgui/backend.ts
+++ b/tgui/packages/tgui/backend.ts
@@ -17,6 +17,11 @@ import { createAction } from 'common/redux';
 import { setupDrag } from './drag';
 import { globalEvents } from './events';
 import { focusMap } from './focus';
+import {
+  releaseHeldKeys,
+  startKeyPassthrough,
+  stopKeyPassthrough,
+} from './hotkeys';
 import { createLogger } from './logging';
 import { resumeRenderer, suspendRenderer } from './renderer';
 
@@ -177,6 +182,8 @@ export const backendMiddleware = (store) => {
       Byond.winset(Byond.windowId, {
         'is-visible': false,
       });
+      stopKeyPassthrough();
+      releaseHeldKeys();
       setTimeout(() => focusMap());
     }
 
@@ -203,6 +210,7 @@ export const backendMiddleware = (store) => {
       logger.log('backend/update', payload);
       // Signal renderer that we have resumed
       resumeRenderer();
+      startKeyPassthrough();
       // Setup drag
       setupDrag(payload.config?.window?.fancy);
       // We schedule this for the next tick here because resizing and unhiding

--- a/tgui/packages/tgui/hotkeys.ts
+++ b/tgui/packages/tgui/hotkeys.ts
@@ -192,12 +192,22 @@ export const setupHotKeys = () => {
   globalEvents.on('window-blur', () => {
     releaseHeldKeys();
   });
-  globalEvents.on('key', (key: KeyEvent) => {
-    for (const keyListener of keyListeners) {
-      keyListener(key);
-    }
-    handlePassthrough(key);
-  });
+  startKeyPassthrough();
+};
+
+export const startKeyPassthrough = () => {
+  globalEvents.on('key', keyEvent);
+};
+
+export const stopKeyPassthrough = () => {
+  globalEvents.off('key', keyEvent);
+};
+
+const keyEvent = (key: KeyEvent) => {
+  for (const keyListener of keyListeners) {
+    keyListener(key);
+  }
+  handlePassthrough(key);
 };
 
 /**


### PR DESCRIPTION
stickykeys could also occur by the browser sending more key events /after/ it stopped rendering itself

:cl:
fix: fixes sticky keys (even more)
/:cl: