### PR TITLE
Ports PVE IFF Examine system

### DIFF
--- a/code/datums/components/iff_fire_prevention.dm
+++ b/code/datums/components/iff_fire_prevention.dm
@@ -77,8 +77,6 @@
 		for(var/mob/living/checked_living in checked_turf)
 			if(checked_living == user) // sometimes it still happens
 				continue
-			if(checked_living.loc == user.loc) //essentially allows firing on the same tile with an IFF'd character, so it behaves like everyother gun, the bullets physically can't hit them anyway
-				continue
 			if(checked_living.body_position == LYING_DOWN && projectile_to_fire.original != checked_living)
 				continue
 

--- a/code/datums/components/iff_fire_prevention.dm
+++ b/code/datums/components/iff_fire_prevention.dm
@@ -77,6 +77,8 @@
 		for(var/mob/living/checked_living in checked_turf)
 			if(checked_living == user) // sometimes it still happens
 				continue
+			if(checked_living.loc == user.loc) //essentially allows firing on the same tile with an IFF'd character, so it behaves like everyother gun, the bullets physically can't hit them anyway
+				continue
 			if(checked_living.body_position == LYING_DOWN && projectile_to_fire.original != checked_living)
 				continue
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -167,9 +167,7 @@
 			var/obj/item/weapon/gun/gun_with_iff
 			var/found_iff = FALSE
 			gun_with_iff = human_with_gun.get_active_hand()
-			if(gun_with_iff)
-						if(gun_with_iff.GetComponent(/datum/component/iff_fire_prevention))
-									found_iff = TRUE
+			if(gun_with_iff.GetComponent(/datum/component/iff_fire_prevention))
 				for(var/obj/item/attachable/attachment in gun_with_iff.contents)
 					if(locate(/datum/element/bullet_trait_iff) in attachment.traits_to_give)
 						found_iff = TRUE
@@ -185,7 +183,6 @@
 						msg += SPAN_HELPFUL("[capitalize(t_He)] is compatible with your weapon's IFF.\n")
 					else
 						msg += SPAN_DANGER("[capitalize(t_He)] is not compatible with your weapon's IFF. They will be shot by your weapon!\n")
-
 	//Restraints
 	if(handcuffed)
 		msg += SPAN_ORANGE("[capitalize(t_his)] arms are restrained by [handcuffed].\n")

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -160,6 +160,32 @@
 	if(wear_id)
 		msg += "[t_He] [t_is] [wear_id.get_examine_location(src, user, WEAR_ID, t_He, t_his, t_him, t_has, t_is)].\n"
 
+	//Inform user if their weapon's IFF will or won't hit src, code by The32bitguy from PVE
+	if(ishuman(user))
+		var/mob/living/carbon/human/human_with_gun = user
+		if(istype(human_with_gun.r_hand, /obj/item/weapon/gun) || istype(human_with_gun.l_hand, /obj/item/weapon/gun))
+			var/obj/item/weapon/gun/gun_with_iff
+			var/found_iff = FALSE
+			gun_with_iff = human_with_gun.get_active_hand()
+			if(gun_with_iff)
+						if(gun_with_iff.GetComponent(/datum/component/iff_fire_prevention))
+									found_iff = TRUE
+				for(var/obj/item/attachable/attachment in gun_with_iff.contents)
+					if(locate(/datum/element/bullet_trait_iff) in attachment.traits_to_give)
+						found_iff = TRUE
+						break
+				if(gun_with_iff.traits_to_give != null)
+					if(gun_with_iff.traits_to_give.Find("iff"))
+						found_iff = TRUE
+				if(gun_with_iff.in_chamber != null && gun_with_iff.in_chamber.bullet_traits != null )
+					if(gun_with_iff.in_chamber.bullet_traits.Find("iff"))
+						found_iff = TRUE
+				if(found_iff)
+					if(get_target_lock(human_with_gun.get_id_faction_group()) > 0)
+						msg += SPAN_HELPFUL("[capitalize(t_He)] is compatible with your weapon's IFF.\n")
+					else
+						msg += SPAN_DANGER("[capitalize(t_He)] is not compatible with your weapon's IFF. They will be shot by your weapon!\n")
+
 	//Restraints
 	if(handcuffed)
 		msg += SPAN_ORANGE("[capitalize(t_his)] arms are restrained by [handcuffed].\n")


### PR DESCRIPTION
# About the pull request

Title

# Explain why it's good for the game

Examining someone with an IFF weapon now tells you if you can shoot through them or not.
Very handful for those without an MD and wish to know if they can fire through a non-iff'd greeno or PMC.

# Testing Photographs and Procedure
It runs and does as intended.

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: You can now examine someone with your IFF weapon to check if the bullet passes through or not.
/:cl:
