### PR TITLE
Adds laser designator targetting to mortar

### DIFF
--- a/code/__DEFINES/dcs/signals/atom/signals_obj.dm
+++ b/code/__DEFINES/dcs/signals/atom/signals_obj.dm
@@ -60,3 +60,7 @@
 #define COMSIG_DROPSHIP_REMOVE_EQUIPMENT "dropship_remove_equipment"
 
 #define COMSIG_STRUCTURE_CRATE_SQUAD_LAUNCHED "structure_crate_squad_launched"
+
+// from /obj/item/device/binoculars/range/designator/acquire_target()
+#define COMSIG_DESIGNATOR_LASE "comsig_designator_lase"
+#define COMSIG_DESIGNATOR_LASE_OFF "comsig_designator_lase_off"

--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -232,7 +232,7 @@
 
 	data["xcoord"] = src.last_x
 	data["ycoord"] = src.last_y
-	data["zcoord"] = src.last_z 
+	data["zcoord"] = src.last_z
 
 	return data
 
@@ -375,6 +375,7 @@
 		to_chat(user, SPAN_NOTICE("TARGET ACQUIRED. LASER TARGETING IS ONLINE. DON'T MOVE."))
 		var/obj/effect/overlay/temp/laser_target/LT = new (TU, las_name, user, tracking_id)
 		laser = LT
+		SEND_SIGNAL(src, COMSIG_DESIGNATOR_LASE)
 
 		var/turf/userloc = get_turf(user)
 		msg_admin_niche("Laser target [las_name] has been designated by [key_name(user, 1)] at ([TU.x], [TU.y], [TU.z]). [ADMIN_JMP(userloc)]")
@@ -384,6 +385,7 @@
 		while(laser)
 			if(!do_after(user, 30, INTERRUPT_ALL, BUSY_ICON_GENERIC))
 				QDEL_NULL(laser)
+				SEND_SIGNAL(src, COMSIG_DESIGNATOR_LASE_OFF)
 				break
 
 //IMPROVED LASER DESIGNATER, faster cooldown, faster target acquisition, can be found only in scout spec kit

--- a/code/modules/cm_marines/equipment/mortar/mortars.dm
+++ b/code/modules/cm_marines/equipment/mortar/mortars.dm
@@ -276,7 +276,7 @@
 	SIGNAL_HANDLER
 	if(!lase_mode)
 		return
-	src.visible_message(SPAN_NOTICE("[icon2html(src, viewers(src))] \The [src] has detected a target and beings calibrating..."))
+	visible_message(SPAN_NOTICE("[icon2html(src, viewers(src))] \The [src] has detected a target and beings calibrating..."))
 	aiming = TRUE
 	aimed = FALSE
 	playsound(loc, "sound/machines/scanning.ogg", 25, 1)
@@ -288,7 +288,7 @@
 	SIGNAL_HANDLER
 	if(!lase_mode)
 		return
-	src.visible_message(SPAN_NOTICE("[icon2html(src, viewers(src))] \The [src] has lost the laser target and returns to it's normal position."))
+	visible_message(SPAN_NOTICE("[icon2html(src, viewers(src))] \The [src] has lost the laser target and returns to it's normal position."))
 	aiming = FALSE
 	aimed = FALSE
 	playsound(loc, "sound/machines/scanning.ogg", 25, 1)
@@ -303,7 +303,7 @@
 		aiming = FALSE
 		aimed = FALSE
 		return
-	src.visible_message(SPAN_NOTICE("[icon2html(src, viewers(src))] \The [src] is ready to fire!"))
+	visible_message(SPAN_NOTICE("[icon2html(src, viewers(src))] \The [src] is ready to fire!"))
 	aiming = FALSE
 	aimed = TRUE
 
@@ -353,7 +353,7 @@
 			if(linked_designator) // Unregister the pervious laser designator signal, if switching linked laser designator
 				UnregisterSignal(linked_designator, COMSIG_DESIGNATOR_LASE)
 				UnregisterSignal(linked_designator, COMSIG_DESIGNATOR_LASE_OFF)
-			src.linked_designator = item
+			linked_designator = item
 			RegisterSignal(linked_designator, COMSIG_DESIGNATOR_LASE, PROC_REF(retrieve_laser_target))
 			RegisterSignal(linked_designator, COMSIG_DESIGNATOR_LASE_OFF, PROC_REF(lost_laser_target))
 			verbs += /obj/structure/mortar/proc/unlink_designator
@@ -558,7 +558,7 @@
 		if(user)
 			to_chat(user, attempt_info)
 		else
-			src.visible_message(attempt_info)
+			visible_message(attempt_info)
 	return can_fire
 
 /obj/structure/mortar/fixed

--- a/code/modules/cm_marines/equipment/mortar/mortars.dm
+++ b/code/modules/cm_marines/equipment/mortar/mortars.dm
@@ -2,7 +2,7 @@
 // Works like a contemporary crew weapon mortar
 /obj/structure/mortar
 	name = "\improper M402 mortar"
-	desc = "A manual, crew-operated mortar system intended to rain down 80mm goodness on anything it's aimed at. Uses an advanced targeting computer. Insert round to fire."
+	desc = "A manual, crew-operated mortar system intended to rain down 80mm goodness on anything it's aimed at. Uses an advanced targeting computer, which can toggle between coordinate and laser targetting. Insert round to fire. Alt + Click to switch targetting modes."
 	icon = 'icons/obj/structures/mortar.dmi'
 	icon_state = "mortar_m402"
 	anchored = TRUE
@@ -38,7 +38,17 @@
 	var/max_range = 75
 	/// The min range the mortar can fire at
 	var/min_range = 25
+	// True if in lase mode, else in coordinate mode
+	var/lase_mode = FALSE
+	// Used for lase mode aiming, busy but not used by someone else.
+	var/aiming = FALSE
+	// True if mortar is ready to fire on lase mode.
+	var/aimed = FALSE
 
+	// Linked laser designator to be used in lase mode, null if one isn't linked
+	var/obj/item/device/binoculars/range/designator/linked_designator
+	var/image/busy_image_aim
+	var/image/busy_image_return
 	var/obj/structure/machinery/computer/cameras/mortar/internal_camera
 
 /obj/structure/mortar/Initialize()
@@ -120,15 +130,74 @@
 	add_fingerprint(user)
 
 	if(computer_enabled)
-		tgui_interact(user)
+		if(lase_mode)
+			internal_camera.tgui_interact(user)
+		else
+			tgui_interact(user)
 	else
-		var/choice = alert(user, "Would you like to set the mortar's target coordinates, or dial the mortar? Setting coordinates will make you lose your fire adjustment.", "Mortar Dialing", "Target", "Dial", "Cancel")
-		if(choice == "Cancel")
-			return
-		if(choice == "Target")
-			handle_target(user, manual = TRUE)
-		if(choice == "Dial")
-			handle_dial(user, manual = TRUE)
+		if(!lase_mode)
+			var/choice = alert(user, "Would you like to set the mortar's target coordinates, or dial the mortar? Setting coordinates will make you lose your fire adjustment.", "Mortar Dialing", "Target", "Dial", "Cancel")
+			if(choice == "Cancel")
+				return
+			if(choice == "Target")
+				handle_target(user, manual = TRUE)
+			if(choice == "Dial")
+				handle_dial(user, manual = TRUE)
+
+/obj/structure/mortar/clicked(mob/user, list/mods)
+	. = ..()
+	if(mods["alt"] && user.Adjacent(src))
+		if(skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_NOVICE))
+			toggle_lase_mode(user)
+
+/obj/structure/mortar/proc/toggle_lase_mode(mob/user)
+	lase_mode = !lase_mode
+	if(lase_mode)
+		to_chat(user, SPAN_NOTICE("You toggle \the [src] to laser targetting mode."))
+		reset_dials()
+		if(linked_designator)
+			RegisterSignal(linked_designator, COMSIG_DESIGNATOR_LASE, PROC_REF(retrieve_laser_target))
+			RegisterSignal(linked_designator, COMSIG_DESIGNATOR_LASE_OFF, PROC_REF(lost_laser_target))
+	else
+		to_chat(user, SPAN_NOTICE("You toggle \the [src] to coordinate targetting mode."))
+		if(aimed || aiming)
+			lost_laser_target()
+		if(linked_designator)
+			UnregisterSignal(linked_designator, COMSIG_DESIGNATOR_LASE)
+			UnregisterSignal(linked_designator, COMSIG_DESIGNATOR_LASE_OFF)
+		reset_dials()
+	playsound(src, "sound/machines/click.ogg", 15, 1)
+
+/obj/structure/mortar/proc/unlink_designator()
+	set name = "Unlink Designator"
+	set desc = "Unlinks a linked designator."
+	set category = "Object"
+	set src in oview(1)
+
+	aiming = FALSE
+	aimed = FALSE
+	UnregisterSignal(linked_designator, COMSIG_DESIGNATOR_LASE)
+	UnregisterSignal(linked_designator, COMSIG_DESIGNATOR_LASE_OFF)
+	linked_designator = null
+	verbs -= /obj/structure/mortar/proc/unlink_designator
+	balloon_alert(usr, "unlinked")
+
+/obj/structure/mortar/proc/reset_dials()
+	dial_x = 0
+	dial_y = 0
+	targ_x = deobfuscate_x(0)
+	targ_y = deobfuscate_y(0)
+
+/obj/structure/mortar/get_examine_text(mob/user)
+	. = ..()
+	if(linked_designator)
+		. += SPAN_NOTICE("It's currently linked to a laser designator with \the [linked_designator.serial_number] serial number.")
+	if(lase_mode)
+		. += SPAN_NOTICE("It's in laser targetting mode.")
+		if(aimed)
+			. += SPAN_NOTICE("It's aimed on target and ready to fire!")
+	else
+		. += SPAN_NOTICE("It's in coordinate targetting mode.")
 
 /obj/structure/mortar/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -167,6 +236,9 @@
 			internal_camera.tgui_interact(user)
 
 /obj/structure/mortar/proc/handle_target(mob/user, temp_targ_x = 0, temp_targ_y = 0, temp_targ_z = 0, manual = FALSE)
+	if(lase_mode)
+		user.visible_message(SPAN_WARNING("\The [src] is set to laser targetting mode, switch to coordinate targetting in order to dial coordinates!"))
+		return
 	if(manual)
 		temp_targ_x = tgui_input_real_number(user, "Input the longitude of the target.")
 		temp_targ_y = tgui_input_real_number(user, "Input the latitude of the target.")
@@ -200,7 +272,45 @@
 
 	SStgui.update_uis(src)
 
+/obj/structure/mortar/proc/retrieve_laser_target()
+	SIGNAL_HANDLER
+	if(!lase_mode)
+		return
+	src.visible_message(SPAN_NOTICE("[icon2html(src, viewers(src))] \The [src] has detected a target and beings calibrating..."))
+	aiming = TRUE
+	aimed = FALSE
+	playsound(loc, "sound/machines/scanning.ogg", 25, 1)
+	addtimer(CALLBACK(src, PROC_REF(set_laser_target)), 1.5 SECONDS)
+	busy_image_aim = image('icons/mob/do_afters.dmi', src, "busy_generic")
+	busy_image_aim.flick_overlay(src, 1.5 SECONDS)
+
+/obj/structure/mortar/proc/lost_laser_target()
+	SIGNAL_HANDLER
+	if(!lase_mode)
+		return
+	src.visible_message(SPAN_NOTICE("[icon2html(src, viewers(src))] \The [src] has lost the laser target and returns to it's normal position."))
+	aiming = FALSE
+	aimed = FALSE
+	playsound(loc, "sound/machines/scanning.ogg", 25, 1)
+	busy_image_aim = image('icons/mob/do_afters.dmi', src, "busy_build")
+	busy_image_aim.flick_overlay(src, 1 SECONDS)
+
+/obj/structure/mortar/proc/set_laser_target()
+	if(!aiming) // If lase went down before mortar has aimed, we cancel
+		return
+	var/obj/effect/overlay/temp/laser_target = linked_designator.laser
+	if(!can_fire_at(null, laser_target.x, laser_target.y, laser_target.z, 0, 0))
+		aiming = FALSE
+		aimed = FALSE
+		return
+	src.visible_message(SPAN_NOTICE("[icon2html(src, viewers(src))] \The [src] is ready to fire!"))
+	aiming = FALSE
+	aimed = TRUE
+
 /obj/structure/mortar/proc/handle_dial(mob/user, temp_dial_x = 0, temp_dial_y = 0, manual = FALSE)
+	if(lase_mode)
+		user.visible_message(SPAN_WARNING("\The [src] is set to laser targetting mode, switch to coordinate targetting in order to dial coordinates!"))
+		return
 	if(manual)
 		temp_dial_x = tgui_input_number(user, "Set longitude adjustement from -10 to 10.", "Longitude", 0, 10, -10)
 		temp_dial_y = tgui_input_number(user, "Set latitude adjustement from -10 to 10.", "Latitude", 0, 10, -10)
@@ -229,9 +339,41 @@
 	SStgui.update_uis(src)
 
 /obj/structure/mortar/attackby(obj/item/item, mob/user)
+	if(istype(item, /obj/item/device/binoculars/range/designator))
+		if(!skillcheck(user, SKILL_JTAC, SKILL_JTAC_TRAINED))
+			to_chat(user, SPAN_WARNING("You don't know how to link your laser designator to \the [src]."))
+			return
+		if(!lase_mode)
+			to_chat(user, SPAN_WARNING("You need to switch \the [src] to laser targetting before linking your laser designator!"))
+			return
+		if(aimed)
+			to_chat(user, SPAN_WARNING("\The [src] is currently targetting something!"))
+		to_chat(user, SPAN_NOTICE("You begin linking your laser designator to \the [src].."))
+		if(do_after(user, 2 SECONDS, INTERRUPT_ALL, BUSY_ICON_FRIENDLY))
+			if(linked_designator) // Unregister the pervious laser designator signal, if switching linked laser designator
+				UnregisterSignal(linked_designator, COMSIG_DESIGNATOR_LASE)
+				UnregisterSignal(linked_designator, COMSIG_DESIGNATOR_LASE_OFF)
+			src.linked_designator = item
+			RegisterSignal(linked_designator, COMSIG_DESIGNATOR_LASE, PROC_REF(retrieve_laser_target))
+			RegisterSignal(linked_designator, COMSIG_DESIGNATOR_LASE_OFF, PROC_REF(lost_laser_target))
+			verbs += /obj/structure/mortar/proc/unlink_designator
+			balloon_alert(user, "linked")
+		return
+
 	if(istype(item, /obj/item/mortar_shell))
 		var/obj/item/mortar_shell/mortar_shell = item
 		var/turf/target_turf = locate(targ_x + dial_x + offset_x, targ_y + dial_y + offset_y, targ_z)
+		if(lase_mode)
+			if(!linked_designator)
+				to_chat(user, SPAN_WARNING("\The [src] is in laser targetting mode, but there is no laser designator linked!"))
+				return
+			if(!aimed)
+				to_chat(user, SPAN_WARNING("Cannot find valid laser target!"))
+				return
+			if(aiming)
+				to_chat(user, SPAN_WARNING("\The [src] is still calibrating!"))
+			else
+				target_turf = linked_designator.laser.loc
 		var/area/target_area = get_area(target_turf)
 		if(!skillcheck(user, SKILL_ENGINEER, SKILL_ENGINEER_NOVICE))
 			to_chat(user, SPAN_WARNING("You don't have the training to fire [src]."))
@@ -240,7 +382,7 @@
 			to_chat(user, SPAN_WARNING("Someone else is currently using [src]."))
 			return
 		if(!ship_side)
-			if(targ_x == 0 && targ_y == 0 && targ_z == 0) //Mortar wasn't set
+			if(targ_x == 0 && targ_y == 0 && targ_z == 0 && !lase_mode) //Mortar wasn't set
 				to_chat(user, SPAN_WARNING("[src] needs to be aimed first."))
 				return
 			if(!target_turf)
@@ -267,7 +409,7 @@
 				return
 		else
 			var/turf/deviation_turf = locate(target_turf.x + pick(-1,0,0,1), target_turf.y + pick(-1,0,0,1), target_turf.z) //Small amount of spread so that consecutive mortar shells don't all land on the same tile
-			if(deviation_turf)
+			if(deviation_turf && !lase_mode) // Mortar is accurate in lase mode
 				target_turf = deviation_turf
 
 		user.visible_message(SPAN_NOTICE("[user] starts loading \a [mortar_shell.name] into [src]."),
@@ -383,33 +525,41 @@
 	qdel(shell)
 	firing = FALSE
 
-/obj/structure/mortar/proc/can_fire_at(mob/user, test_targ_x = targ_x, test_targ_y = targ_y, test_targ_z = targ_z, test_dial_x, test_dial_y)
+/obj/structure/mortar/proc/can_fire_at(mob/user = null, test_targ_x = targ_x, test_targ_y = targ_y, test_targ_z = targ_z, test_dial_x, test_dial_y)
 	var/dialing = test_dial_x || test_dial_y
+	var/attempt_info
+	var/can_fire = TRUE
 	if(ship_side)
-		to_chat(user, SPAN_WARNING("You cannot aim the mortar while on a ship."))
-		return FALSE
+		attempt_info = SPAN_WARNING(("[user ? "You" : "\The [src]"] cannot aim the mortar while on a ship."))
+		can_fire = FALSE
 	if(test_dial_x + test_targ_x > world.maxx || test_dial_x + test_targ_x < 0)
-		to_chat(user, SPAN_WARNING("You cannot [dialing ? "dial to" : "aim at"] this coordinate, it is outside of the area of operations."))
-		return FALSE
+		attempt_info = SPAN_WARNING("[user ? "You" : "\The [src]"] cannot [dialing ? "dial to" : "aim at"] this [lase_mode ? "target" : "coordinate"], it is outside of the area of operations.")
+		can_fire = FALSE
 	if(test_dial_x < -10 || test_dial_x > 10 || test_dial_y < -10 || test_dial_y > 10)
-		to_chat(user, SPAN_WARNING("You cannot [dialing ? "dial to" : "aim at"] this coordinate, it is too far away from the original target."))
-		return FALSE
+		attempt_info = SPAN_WARNING("[user ? "You" : "\The [src]"] cannot [dialing ? "dial to" : "aim at"] this [lase_mode ? "target" : "coordinate"], it is too far away from the original target.")
+		can_fire = FALSE
 	if(test_dial_y + test_targ_y > world.maxy || test_dial_y + test_targ_y < 0)
-		to_chat(user, SPAN_WARNING("You cannot [dialing ? "dial to" : "aim at"] this coordinate, it is outside of the area of operations."))
-		return FALSE
+		attempt_info = SPAN_WARNING("[user ? "You" : "\The [src]"] cannot [dialing ? "dial to" : "aim at"] this [lase_mode ? "target" : "coordinate"], it is outside of the area of operations.")
+		can_fire = FALSE
 	if(get_dist(src, locate(test_targ_x + test_dial_x, test_targ_y + test_dial_y, z)) < min_range)
-		to_chat(user, SPAN_WARNING("You cannot [dialing ? "dial to" : "aim at"] this coordinate, it is too close to your mortar."))
-		return FALSE
+		attempt_info = SPAN_WARNING("[user ? "You" : "\The [src]"] cannot [dialing ? "dial to" : "aim at"] this [lase_mode ? "target" : "coordinate"], it is too close to [user ? "your" : "the"] mortar.")
+		can_fire = FALSE
 	if(!is_ground_level(test_targ_z))
-		to_chat(user, SPAN_WARNING("You cannot [dialing ? "dial to" : "aim at"] this coordinate, it is outside of the area of operations."))
-		return FALSE
+		attempt_info = SPAN_WARNING("[user ? "You" : "\The [src]"] cannot [dialing ? "dial to" : "aim at"] this [lase_mode ? "target" : "coordinate"], it is outside of the area of operations.")
+		can_fire = FALSE
 	if(get_dist(src, locate(test_targ_x + test_dial_x, test_targ_y + test_dial_y, z)) > max_range)
-		to_chat(user, SPAN_WARNING("You cannot [dialing ? "dial to" : "aim at"] this coordinate, it is too far from your mortar."))
-		return FALSE
+		attempt_info = SPAN_WARNING("[user ? "You" : "\The [src]"] cannot [dialing ? "dial to" : "aim at"] this [lase_mode ? "target" : "coordinate"], it is too far from [user ? "your" : "the"] mortar.")
+		can_fire = FALSE
 	if(busy)
-		to_chat(user, SPAN_WARNING("Someone else is currently using this mortar."))
-		return FALSE
-	return TRUE
+		attempt_info = SPAN_WARNING("Someone else is currently using this mortar.")
+		can_fire = FALSE
+
+	if(!can_fire)
+		if(user)
+			to_chat(user, attempt_info)
+		else
+			src.visible_message(attempt_info)
+	return can_fire
 
 /obj/structure/mortar/fixed
 	desc = "A manual, crew-operated mortar system intended to rain down 80mm goodness on anything it's aimed at. Uses manual targeting dials. Insert round to fire. This one is bolted and welded into the ground."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Adds an aiming toggle to the mortar, which lets users link a laser designator, and fire directly on that laser designators lases as an alternative to firing on coordinates.

# Explain why it's good for the game

This addition gives mortar operators a a second choice on how they can fire on a target in order to give them more flexibility.

"Lase mode", toggleable with Alt+Clicking on the mortar, lets mortar operators link any laser designator to the mortar. The mortar then will automatically aim at any target lased by the laser designator after a short delay, just like for CAS targets. The benefits of this mode is that the mortar operator can fire on targets much faster, and the mortar shells have 100% accuracy in this mode. The drawbacks compared to coordinate mode, is that a lase has to be active for the mortar operator to fire on the target. The mortar operator also cannot offset the mortar, so it is strictly direct fire. If the laser designator stops the lasing, the mortar will automatically reset, unable to fire until a laser target is acquired again. The mortar operator cannot lase and try to fire the mortar at the same time, so they will need to find a buddy that can lase targets for them. 

The aim is for the "laser designator targetting" mode to not be a direct upgrade or downgrade to coordinate firing mode, but a sidegrade, where the mortar operator can switch modes if needed.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

https://github.com/user-attachments/assets/490fb4a5-4edd-4d02-a236-7658b7f4edba

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Mikrel0712
add: Added a laser targetting mode to the M402 Mortar. You can now link a laser designator to the mortar, and fire directly on laser targets as an alternative to firing on coordinates.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
