### PR TITLE
Fixes King trampling things forever through cades

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/King.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/King.dm
@@ -100,7 +100,7 @@
 				playsound(src, 'sound/weapons/alien_knockdown.ogg', 25, 1)
 			else if(xeno.hivenumber != src.hivenumber)
 				xeno.KnockDown((1 SECONDS) / GLOBAL_STATUS_MULTIPLIER)
-			playsound(src, 'sound/weapons/alien_knockdown.ogg', 25, 1)
+				playsound(src, 'sound/weapons/alien_knockdown.ogg', 25, 1)
 		else
 			if(carbon.stat != DEAD)
 				carbon.apply_armoured_damage(20)

--- a/code/modules/mob/living/carbon/xenomorph/castes/King.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/King.dm
@@ -76,11 +76,23 @@
 /mob/living/carbon/xenomorph/king/Initialize()
 	. = ..()
 	AddComponent(/datum/component/footstep, 2 , 35, 11, 4, "alien_footstep_large")
-	RegisterSignal(src, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(check_block))
+	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(post_move))
 
-/mob/living/carbon/xenomorph/king/proc/check_block(mob/king, turf/new_loc)
+/mob/living/carbon/xenomorph/king/initialize_pass_flags(datum/pass_flags_container/pass_flags)
+	. = ..()
+	if(!pass_flags)
+		return
+
+	pass_flags.flags_pass |= PASS_MOB_THRU
+
+/mob/living/carbon/xenomorph/king/proc/post_move(mob/king)
 	SIGNAL_HANDLER
+
+	var/turf/new_loc = get_turf(src)
+
 	for(var/mob/living/carbon/carbon in new_loc.contents)
+		if(carbon == src)
+			continue
 		if(isxeno(carbon))
 			var/mob/living/carbon/xenomorph/xeno = carbon
 			if(xeno.hivenumber == src.hivenumber && !(king.client?.prefs?.toggle_prefs & TOGGLE_AUTO_SHOVE_OFF))
@@ -88,12 +100,13 @@
 				playsound(src, 'sound/weapons/alien_knockdown.ogg', 25, 1)
 			else if(xeno.hivenumber != src.hivenumber)
 				xeno.KnockDown((1 SECONDS) / GLOBAL_STATUS_MULTIPLIER)
-				playsound(src, 'sound/weapons/alien_knockdown.ogg', 25, 1)
+			playsound(src, 'sound/weapons/alien_knockdown.ogg', 25, 1)
 		else
 			if(carbon.stat != DEAD)
 				carbon.apply_armoured_damage(20)
 				carbon.KnockDown((1 SECONDS) / GLOBAL_STATUS_MULTIPLIER)
 				playsound(src, 'sound/weapons/alien_knockdown.ogg', 25, 1)
+
 /mob/living/carbon/xenomorph/king/gib(datum/cause_data/cause = create_cause_data("gibbing", src))
 	death(cause, 1)
 


### PR DESCRIPTION

# About the pull request

fixes #7622
and kings being able to infinetly trample things via cades

# Explain why it's good for the game

bugfix

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: King can no longer infinetly stun mobs via cade
/:cl:
