### PR TITLE
Makes JAS consoles indestructible

### DIFF
--- a/code/game/machinery/computer/sentencing.dm
+++ b/code/game/machinery/computer/sentencing.dm
@@ -9,6 +9,11 @@
 	var/current_menu = "main"
 	var/static/paper_counter = 0
 	unacidable = TRUE
+	breakable = FALSE
+	unslashable = TRUE
+	
+/obj/structure/machinery/computer/sentencing/ex_act(severity)
+	return
 
 /obj/structure/machinery/computer/sentencing/attack_hand(mob/user as mob)
 	if(..() || !allowed(usr) || inoperable())

--- a/code/game/machinery/computer/sentencing.dm
+++ b/code/game/machinery/computer/sentencing.dm
@@ -8,6 +8,7 @@
 	var/datum/crime_incident/incident
 	var/current_menu = "main"
 	var/static/paper_counter = 0
+	unacidable = TRUE
 
 /obj/structure/machinery/computer/sentencing/attack_hand(mob/user as mob)
 	if(..() || !allowed(usr) || inoperable())


### PR DESCRIPTION
# About the pull request

Title

# Explain why it's good for the game

JAS consoles are not replaceable and MP work is a disaster without them. Keeps shipside xenos from causing bureaucratic disasters.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: XQ
fix: JAS consoles are now indestructible.
/:cl:
