### PR TITLE
Cryopods can now get shipside announcements

### DIFF
--- a/code/defines/procs/announcement.dm
+++ b/code/defines/procs/announcement.dm
@@ -129,10 +129,11 @@
 //to ensure that all humans on ship hear it regardless of comms and power
 /proc/shipwide_ai_announcement(message, title = MAIN_AI_SYSTEM, sound_to_play = sound('sound/misc/interference.ogg'), signature, ares_logging = ARES_LOG_MAIN, quiet = FALSE)
 	var/list/targets = GLOB.human_mob_list + GLOB.dead_mob_list
-	for(var/mob/target in targets)
+	for(var/mob/target as anything in targets)
 		if(isobserver(target))
 			continue
-		if(!ishuman(target) || isyautja(target) || !is_mainship_level(target.z))
+		var/turf/target_turf = get_turf(target)
+		if(!ishuman(target) || isyautja(target) || !is_mainship_level(target_turf?.z))
 			targets.Remove(target)
 
 	if(!isnull(signature))
@@ -156,7 +157,7 @@
 			continue
 
 		to_chat_spaced(target, html = "[SPAN_ANNOUNCEMENT_HEADER(title)]<br><br>[SPAN_ANNOUNCEMENT_BODY(message)]", type = MESSAGE_TYPE_RADIO)
-		if(!quiet)
+		if(!quiet && sound_to_play)
 			if(isobserver(target) && !(target.client?.prefs?.toggles_sound & SOUND_OBSERVER_ANNOUNCEMENTS))
 				continue
 			playsound_client(target.client, sound_to_play, target, vol = 45)


### PR DESCRIPTION

# About the pull request

This PR tweaks announcements so they now use get_turf to determine the z the target is on. If they're in a cryopod for example, they aren't considered on the ship's z.

# Explain why it's good for the game

Shipside announcements should always work shipside.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/3e916fc5-72f5-4686-9d46-ac35e3270ee9)
![image](https://github.com/user-attachments/assets/f6b2ede5-8c2c-4345-b251-f84bd95a815d)

</details>


# Changelog
:cl: Drathek
fix: Being in a locker or cryopod shipside now can receive shipside announcements
/:cl:
