### PR TITLE
nerf mp gear

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -95,8 +95,8 @@
 		if(iscarbon(M))
 			flashfail = !M.flash_eyes()
 			if(!flashfail)
-				M.KnockDown(10)
-				M.Stun(10)
+				M.KnockDown(5)
+				M.Stun(5)
 
 		else if(isSilicon(M))
 			M.apply_effect(rand(5,10), WEAKEN)

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -95,8 +95,8 @@
 		if(iscarbon(M))
 			flashfail = !M.flash_eyes()
 			if(!flashfail)
-				M.KnockDown(5)
-				M.Stun(5)
+				M.KnockDown(3)
+				M.Stun(3)
 
 		else if(isSilicon(M))
 			M.apply_effect(rand(5,10), WEAKEN)

--- a/code/game/objects/items/explosives/grenades/flashbang.dm
+++ b/code/game/objects/items/explosives/grenades/flashbang.dm
@@ -52,10 +52,10 @@
 	..()
 
 	var/turf/T = get_turf(src)
-	for(var/obj/structure/closet/L in hear(7, T))
+	for(var/obj/structure/closet/L in hear(4, T))
 		SEND_SIGNAL(L, COMSIG_CLOSET_FLASHBANGED, src)
 
-	for(var/mob/living/carbon/M in hear(7, T))
+	for(var/mob/living/carbon/M in hear(4, T))
 		bang(T, M)
 
 	playsound(src.loc, 'sound/effects/bang.ogg', 50, 1)
@@ -322,8 +322,8 @@
 			M.ear_damage += rand(1, 10)
 
 	if(HAS_TRAIT(M, TRAIT_EAR_PROTECTION))
-		daze_amount *= 0.85
-		paralyze_amount *= 0.85
+		daze_amount *= 0.50
+		paralyze_amount *= 0.50
 		deafen_amount = 0
 		to_chat(M, SPAN_HELPFUL("Your gear protects you from the worst of the 'bang'."))
 

--- a/code/game/objects/items/explosives/grenades/flashbang.dm
+++ b/code/game/objects/items/explosives/grenades/flashbang.dm
@@ -52,10 +52,10 @@
 	..()
 
 	var/turf/T = get_turf(src)
-	for(var/obj/structure/closet/L in hear(4, T))
+	for(var/obj/structure/closet/L in hear(3, T))
 		SEND_SIGNAL(L, COMSIG_CLOSET_FLASHBANGED, src)
 
-	for(var/mob/living/carbon/M in hear(4, T))
+	for(var/mob/living/carbon/M in hear(3, T))
 		bang(T, M)
 
 	playsound(src.loc, 'sound/effects/bang.ogg', 50, 1)

--- a/code/game/objects/items/explosives/grenades/flashbang.dm
+++ b/code/game/objects/items/explosives/grenades/flashbang.dm
@@ -15,7 +15,7 @@
 
 	//doesn't deal damage to eyes and ears (for cluster)
 	var/no_damage = FALSE
-	var/strength = 50
+	var/strength = 35
 
 /obj/item/explosive/grenade/flashbang/Initialize()
 	if(type == /obj/item/explosive/grenade/flashbang) // ugly but we only want to change base level flashbangs
@@ -100,14 +100,14 @@
 
 	if(M.flash_eyes())
 		weaken_amount += 2
-		paralyze_amount += 10
+		paralyze_amount += 6
 
 	if((get_dist(M, T) <= 2 || src.loc == M.loc || src.loc == M))
 		if(trained_human)
 			weaken_amount += 2
 			paralyze_amount += 1
 		else
-			weaken_amount += 10
+			weaken_amount += 6
 			paralyze_amount += 3
 			deafen_amount += 15
 			if(!no_damage)
@@ -118,14 +118,14 @@
 
 	else if(get_dist(M, T) <= 5)
 		if(!trained_human)
-			weaken_amount += 8
-			deafen_amount += 10
+			weaken_amount += 6
+			deafen_amount += 7
 			if(!no_damage)
 				M.ear_damage += rand(0, 3)
 
 	else if(!trained_human)
-		weaken_amount += 4
-		deafen_amount += 5
+		weaken_amount += 3
+		deafen_amount += 4
 		if(!no_damage)
 			M.ear_damage += rand(0, 1)
 
@@ -280,18 +280,18 @@
 		H.apply_damage(5, BURN)
 
 		if(lying)
-			bang_effect = 4
+			bang_effect = 2
 		else
-			bang_effect = 5
+			bang_effect = 3
 
 	else if(get_dist(H, T) <= 5)
 		if(lying)
-			bang_effect = 3
+			bang_effect = 2
 		else
 			bang_effect = 4
 
 	else
-		bang_effect = 2
+		bang_effect = 3
 
 
 	var/flash_amount
@@ -301,24 +301,24 @@
 
 	switch(bang_effect)
 		if(1)
-			deafen_amount = 2
+			deafen_amount = 1
 		if(2)
-			daze_amount = 2
-			deafen_amount = 3
+			daze_amount = 1
+			deafen_amount = 2
 		if(3)
-			flash_amount = 10
-			daze_amount = 5
-			deafen_amount = 5
+			flash_amount = 4
+			daze_amount = 3
+			deafen_amount = 3
 		if(4)
-			flash_amount = 20
-			daze_amount = 5
-			deafen_amount = 7
+			flash_amount = 15
+			daze_amount = 4
+			deafen_amount = 5
 			M.ear_damage += rand(1, 5)
 		if(5)
-			flash_amount = 50
-			daze_amount = 10
-			paralyze_amount = 5
-			deafen_amount = 10
+			flash_amount = 35
+			daze_amount = 7
+			paralyze_amount = 3
+			deafen_amount = 6
 			M.ear_damage += rand(1, 10)
 
 	if(HAS_TRAIT(M, TRAIT_EAR_PROTECTION))

--- a/code/modules/reagents/chemistry_reagents/food.dm
+++ b/code/modules/reagents/chemistry_reagents/food.dm
@@ -195,10 +195,10 @@
 			if(victim.pain.feels_pain)
 				victim.emote("scream")
 				to_chat(victim, SPAN_WARNING("You're sprayed directly in the eyes with pepperspray!"))
-				victim.AdjustEyeBlur(25)
-				victim.AdjustEyeBlind(10)
-				victim.apply_effect(3, STUN)
-				victim.apply_effect(3, WEAKEN)
+				victim.AdjustEyeBlur(10)
+				victim.AdjustEyeBlind(5)
+				victim.apply_effect(1, STUN)
+				victim.apply_effect(2, WEAKEN)
 
 /datum/reagent/frostoil
 	name = "Frost Oil"


### PR DESCRIPTION
# About the pull request

nerfs MP flashbangs by a decent amount (they no longer screenwide stun for 25 seconds)
the stun is now not 5 years long and they stun in a 3 tile radius
pepperspray stats overall nerfed
flashes stun for 6 seconds on spriteclick instead of 16

# Explain why it's good for the game

screenwide super long stuns which you can throw and even GL aren't fun to fight against 
pepperspray 1 tap stun also isn't fun
16 second stun dawggg

# Testing Photographs and Procedure

# Changelog

:cl:
balance: Flashbangs are now much weaker.
balance: Pepperspray is decently weaker.
balance: Handheld flashes now stun for 6 seconds on spriteclick.
/:cl:

