### PR TITLE
Typescript React Files Only

### DIFF
--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -161,6 +161,12 @@ if grep -P '^(?:[^\/\n]|\/[^\/\n])*(&[ \t]*\w+[ \t]*\|[ \t]*\w+)' $code_files; t
 	st=1
 fi;
 
+part "typescript react files"
+if ls tgui/**/*.jsx; then
+	echo
+	echo -e "${RED}ERROR: JSX file detected, these must be converted to typescript (TSX).${NC}"
+	st=1
+fi;
 
 part "map json naming"
 if ls maps/*.json | grep -P "[A-Z]"; then

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -162,9 +162,9 @@ if grep -P '^(?:[^\/\n]|\/[^\/\n])*(&[ \t]*\w+[ \t]*\|[ \t]*\w+)' $code_files; t
 fi;
 
 part "typescript react files"
-if ls tgui/**/*.jsx; then
+if ls -1 tgui/**/*.jsx 2>/dev/null; then
 	echo
-	echo -e "${RED}ERROR: JSX file detected, these must be converted to typescript (TSX).${NC}"
+	echo -e "${RED}ERROR: JSX file(s) detected, these must be converted to typescript (TSX).${NC}"
 	st=1
 fi;
 


### PR DESCRIPTION
# About the pull request

This PR adds a lint to check for jsx files since we want the additional checks that typescript performs.

# Explain why it's good for the game

Brief explainer: https://www.typescriptlang.org/why-create-typescript/

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/b6335186-f631-42b6-9de0-2b30a9871d98)

</details>


# Changelog
:cl: Drathek
add: JSX files are now linted against in favor of typescript files (TSX)
/:cl:
