### PR TITLE
516: Fix TGUI Asset Loading

### DIFF
--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -346,6 +346,18 @@
       if (!sync) {
         node.media = 'only x';
       }
+      var removeNodeAndRetry = function () {
+        node.parentNode.removeChild(node);
+        node = null;
+        retry();
+      }
+      // 516: Chromium won't call onload() if there is a 404 error
+      // Legacy IE doesn't use onerror, so we retain that
+      // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#stylesheet_load_events
+      node.onerror = function () {
+        node.onerror = null;
+        removeNodeAndRetry();
+      }
       node.onload = function () {
         node.onload = null;
         if (isStyleSheetLoaded(node, url)) {
@@ -353,10 +365,7 @@
           node.media = 'all';
           return;
         }
-        // Try again
-        node.parentNode.removeChild(node);
-        node = null;
-        retry();
+        removeNodeAndRetry();
       };
       injectNode(node);
       return;


### PR DESCRIPTION

# About the pull request

This PR ports https://github.com/tgstation/tgstation/pull/89956 and may be why after clearing cache sometimes stuff like stylesheets has not been loading w/o reconnecting.

# Explain why it's good for the game

Changing browsers has so many little weird nuances to fix...

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

It launches lobby fine locally?
![image](https://github.com/user-attachments/assets/d9c540e8-8ae3-4452-bada-9e5bd80f9ee4)

</details>

# Changelog
:cl: itsmeow
fix: Fixed TGUI assets and icons sometimes not showing up until you refreshed the page on 516 clients
/:cl:
