### PR TITLE
Fix Supply Drop Console like OW Console for zero.

### DIFF
--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -495,21 +495,21 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 	switch(action)
 		if("set_x")
 			var/new_x = text2num(params["set_x"])
-			if(!new_x)
+			if(isnull(new_x))
 				return
 			x_supply = new_x
 			. = TRUE
 
 		if("set_y")
 			var/new_y = text2num(params["set_y"])
-			if(!new_y)
+			if(isnull(new_y))
 				return
 			y_supply = new_y
 			. = TRUE
 
 		if("set_z")
 			var/new_z = text2num(params["set_z"])
-			if(!new_z)
+			if(isnull(new_z))
 				return
 			z_supply = new_z
 			. = TRUE

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -512,7 +512,7 @@
 					handle_supplydrop()
 
 		if("save_coordinates")
-			if(!params["x"] || !params["y"] || !params["z"])
+			if(isnull(params["x"]) || isnull(params["y"]) || isnull(params["z"]))
 				return
 			if(length(saved_coordinates) >= MAX_SAVED_COORDINATES)
 				popleft(saved_coordinates)

--- a/tgui/packages/tgui/interfaces/SupplyDropConsole.tsx
+++ b/tgui/packages/tgui/interfaces/SupplyDropConsole.tsx
@@ -72,8 +72,8 @@ export const SupplyDropConsole = () => {
               <NumberInput
                 width="4em"
                 step={1}
-                minValue={-1000}
-                maxValue={1000}
+                minValue={-Infinity}
+                maxValue={Infinity}
                 value={data.x_offset}
                 onChange={(value) => act('set_x', { set_x: `${value}` })}
               />
@@ -82,8 +82,8 @@ export const SupplyDropConsole = () => {
               <NumberInput
                 width="4em"
                 step={1}
-                minValue={-1000}
-                maxValue={1000}
+                minValue={-Infinity}
+                maxValue={Infinity}
                 value={data.y_offset}
                 onChange={(value) => act('set_y', { set_y: `${value}` })}
               />
@@ -92,8 +92,8 @@ export const SupplyDropConsole = () => {
               <NumberInput
                 width="4em"
                 step={1}
-                minValue={-1000}
-                maxValue={1000}
+                minValue={-Infinity}
+                maxValue={Infinity}
                 value={data.z_offset}
                 onChange={(value) => act('set_z', { set_z: `${value}` })}
               />


### PR DESCRIPTION
# About the pull request
Does the same thing for Supply Drop Console as was done for OW to allow for zero values, also brings the max and min in line with OW console with infinities
Also allows OW Consoles to accept 0 values when saving coords.
fixes #8760
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Supply can change the height and change it back to zero.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MistChristmas
fix: Allows Supply Drop Console to accept 0 values. Allows OW consoles to save coords with 0 values.
/:cl:
