### PR TITLE
Gibs show on weeds

### DIFF
--- a/code/game/objects/effects/decals/cleanable/blood/blood.dm
+++ b/code/game/objects/effects/decals/cleanable/blood/blood.dm
@@ -129,7 +129,7 @@
 	gender = PLURAL
 	density = FALSE
 	anchored = TRUE
-	layer = TURF_LAYER
+	layer = ABOVE_WEED_LAYER
 	icon = 'icons/effects/blood.dmi'
 	icon_state = ""
 	random_icon_states = list("gib1", "gib2", "gib3", "gib4", "gib5", "gib6")


### PR DESCRIPTION
# About the pull request

Changes gibs to show up on weeds. When someone bursts, they create gibs, but because of the layer, the gibs are always hidden. This changes that.

Gibs, like blood, still disappears from weeds after a short amount of time. I'm unsure if this is intentional, so I'm leaving it for now

# Explain why it's good for the game

soul, or something

# Testing Photographs and Procedure

<details>

No gib (sc randomly stolen)
![image](https://github.com/user-attachments/assets/db325467-3146-4602-a865-919a07bf4f07)

Yes gib
![image](https://github.com/user-attachments/assets/76077c3b-a89e-4166-b323-d53485093357)

<summary>Screenshots & Videos</summary>



</details>


# Changelog

:cl:
fix: gibs now show up on weeds, including the gibs from larva bursts.
/:cl:

