### PR TITLE
mar-50 lmgification

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -868,7 +868,7 @@
 	reload_sound = 'sound/weapons/handling/gun_mar40_reload.ogg'
 	unload_sound = 'sound/weapons/handling/gun_mar40_unload.ogg'
 
-	starting_attachment_types = list(/obj/item/attachable/mar50barrel)
+	starting_attachment_types = list(/obj/item/attachable/mar50barrel, /obj/item/attachable/bipod)
 
 	current_mag = /obj/item/ammo_magazine/rifle/mar40/lmg
 	attachable_allowed = list(
@@ -894,12 +894,14 @@
 
 /obj/item/weapon/gun/rifle/mar40/lmg/set_gun_config_values()
 	..()
-	set_fire_delay(FIRE_DELAY_TIER_LMG)
+	set_fire_delay(FIRE_DELAY_TIER_10)
 	set_burst_amount(BURST_AMOUNT_TIER_5)
 	set_burst_delay(FIRE_DELAY_TIER_LMG)
+	fa_scatter_peak = FULL_AUTO_SCATTER_PEAK_TIER_3
+	fa_max_scatter = SCATTER_AMOUNT_TIER_4
 	accuracy_mult = BASE_ACCURACY_MULT
 	accuracy_mult_unwielded = BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_7
-	scatter = SCATTER_AMOUNT_TIER_6
+	scatter = SCATTER_AMOUNT_TIER_3
 	burst_scatter_mult = SCATTER_AMOUNT_TIER_8
 	scatter_unwielded = SCATTER_AMOUNT_TIER_2
 	damage_mult = BASE_BULLET_DAMAGE_MULT


### PR DESCRIPTION

# About the pull request

Reduces the mar-50's ROF and increases scatter and makes the bipod a starting attachment

# Explain why it's good for the game

Makes the Mar-50 LMG still effective while used defensively with the bipod while making it less effective on the move with the bipod attached. You can still remove the bipod to make it more effective offensively. higher damage per shot than the HPR with a lower ROF. Primarily designed around CLF inserts and the odd ERT that gets one.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Mar-50 is now more like the HPR
/:cl:
