### PR TITLE
Xeno Trap Restrictions

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -562,36 +562,39 @@
 	to_chat(X, SPAN_XENONOTICE("We place a resin hole on the weeds, it still needs a sister to fill it with acid."))
 	return ..()
 
-/turf/proc/check_xeno_trap_placement(mob/living/carbon/xenomorph/X)
+/turf/proc/check_xeno_trap_placement(mob/living/carbon/xenomorph/xeno)
 	if(is_weedable() < FULLY_WEEDABLE || !can_xeno_build(src))
-		to_chat(X, SPAN_XENOWARNING("We can't do that here."))
+		to_chat(xeno, SPAN_XENOWARNING("We can't do that here."))
 		return FALSE
 
 	var/obj/effect/alien/weeds/alien_weeds = locate() in src
 	if(!alien_weeds)
-		to_chat(X, SPAN_XENOWARNING("We can only shape on weeds. We must find some resin before we start building!"))
+		to_chat(xeno, SPAN_XENOWARNING("We can only shape on weeds. We must find some resin before we start building!"))
 		return FALSE
 
 	// This snowflake check exists because stairs specifically are indestructable, tile-covering, and cannot be moved, which allows resin holes to be
 	// planted under them without any possible counterplay. In the future if resin holes stop being able to be hidden under objects, remove this check.
-	var/obj/structure/stairs/staircase = locate() in src
-	if(staircase)
-		to_chat(X, SPAN_XENOWARNING("We cannot make a hole beneath a staircase!"))
+	if(locate(/obj/structure/stairs) in src)
+		to_chat(xeno, SPAN_XENOWARNING("We cannot make a hole on a staircase!"))
 		return FALSE
 
-	if(alien_weeds.linked_hive.hivenumber != X.hivenumber)
-		to_chat(X, SPAN_XENOWARNING("These weeds don't belong to our hive!"))
+	if(locate(/obj/structure/monorail) in src)
+		to_chat(xeno, SPAN_XENOWARNING("We cannot make a hole on a track!"))
 		return FALSE
 
-	if(!X.check_alien_construction(src, check_doors = TRUE))
+	if(alien_weeds.linked_hive.hivenumber != xeno.hivenumber)
+		to_chat(xeno, SPAN_XENOWARNING("These weeds don't belong to our hive!"))
+		return FALSE
+
+	if(!xeno.check_alien_construction(src, check_doors = TRUE))
 		return FALSE
 
 	if(locate(/obj/effect/alien/resin/trap) in orange(1, src)) // obj/effect/alien/resin presence is checked on turf by check_alien_construction, so we just check orange.
-		to_chat(X, SPAN_XENOWARNING("This is too close to another resin hole!"))
+		to_chat(xeno, SPAN_XENOWARNING("This is too close to another resin hole!"))
 		return FALSE
 
 	if(locate(/obj/effect/alien/resin/fruit) in orange(1, src))
-		to_chat(X, SPAN_XENOWARNING("This is too close to a fruit!"))
+		to_chat(xeno, SPAN_XENOWARNING("This is too close to a fruit!"))
 		return FALSE
 
 	return alien_weeds

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -597,6 +597,11 @@
 		to_chat(xeno, SPAN_XENOWARNING("This is too close to a fruit!"))
 		return FALSE
 
+	for(var/mob/living/body in src)
+		if(body.stat == DEAD)
+			to_chat(xeno, SPAN_XENOWARNING("The body is in the way!"))
+			return FALSE
+
 	return alien_weeds
 
 /datum/action/xeno_action/activable/place_construction/use_ability(atom/A)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -572,23 +572,28 @@
 		to_chat(xeno, SPAN_XENOWARNING("We can only shape on weeds. We must find some resin before we start building!"))
 		return FALSE
 
-	// This snowflake check exists because stairs specifically are indestructable, tile-covering, and cannot be moved, which allows resin holes to be
-	// planted under them without any possible counterplay. In the future if resin holes stop being able to be hidden under objects, remove this check.
-	if(locate(/obj/structure/stairs) in src)
-		to_chat(xeno, SPAN_XENOWARNING("We cannot make a hole on a staircase!"))
-		return FALSE
-
-	if(locate(/obj/structure/monorail) in src)
-		to_chat(xeno, SPAN_XENOWARNING("We cannot make a hole on a track!"))
-		return FALSE
-
-	if(locate(/obj/structure/machinery/conveyor) in src)
-		to_chat(xeno, SPAN_XENOWARNING("We cannot make a hole on a conveyor!"))
-		return FALSE
-
 	if(alien_weeds.linked_hive.hivenumber != xeno.hivenumber)
 		to_chat(xeno, SPAN_XENOWARNING("These weeds don't belong to our hive!"))
 		return FALSE
+
+	// This snowflake check exists because stairs specifically are indestructable, tile-covering, and cannot be moved, which allows resin holes to be
+	// planted under them without any possible counterplay. In the future if resin holes stop being able to be hidden under objects, remove this check.
+	if(locate(/obj/structure) in src)
+		if(locate(/obj/structure/stairs) in src)
+			to_chat(xeno, SPAN_XENOWARNING("We cannot make a hole on a staircase!"))
+			return FALSE
+
+		if(locate(/obj/structure/monorail) in src)
+			to_chat(xeno, SPAN_XENOWARNING("We cannot make a hole on a track!"))
+			return FALSE
+
+		if(locate(/obj/structure/machinery/conveyor) in src)
+			to_chat(xeno, SPAN_XENOWARNING("We cannot make a hole on a conveyor!"))
+			return FALSE
+
+		if(locate(/obj/structure/machinery/colony_floodlight) in src)
+			to_chat(xeno, SPAN_XENOWARNING("We cannot make a hole on a light!"))
+			return FALSE
 
 	if(!xeno.check_alien_construction(src, check_doors = TRUE))
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -582,6 +582,10 @@
 		to_chat(xeno, SPAN_XENOWARNING("We cannot make a hole on a track!"))
 		return FALSE
 
+	if(locate(/obj/structure/machinery/conveyor) in src)
+		to_chat(xeno, SPAN_XENOWARNING("We cannot make a hole on a conveyor!"))
+		return FALSE
+
 	if(alien_weeds.linked_hive.hivenumber != xeno.hivenumber)
 		to_chat(xeno, SPAN_XENOWARNING("These weeds don't belong to our hive!"))
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -297,7 +297,7 @@
 	return TRUE
 
 /mob/living/carbon/human/is_xeno_grabbable()
-	if(stat != DEAD || chestburst)
+	if(stat != DEAD)
 		return TRUE
 
 	if(status_flags & XENO_HOST)

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -306,8 +306,8 @@
 				return FALSE
 		if(world.time > timeofdeath + revive_grace_period)
 			return FALSE // they ain't gonna burst now
-	else
-		return FALSE // leave the dead alone
+		return TRUE
+	return FALSE // leave the dead alone
 
 //This proc is here to prevent Xenomorphs from picking up objects (default attack_hand behaviour)
 //Note that this is overridden by every proc concerning a child of obj unless inherited


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #7226 that never came to fruition: There is no longer any intended reason to drag burst bodies now. They cannot go into morphers nor can they go into pools.

Additionally, traps should no longer be able to be placed under a:
- Dead body
- Rail (launch track/monorail)
- Conveyor
- Engineer circular light

Trapping bodies likely can return once trap searching walk is implemented.

Let me know if there are other indestructible entirely overlaying turf objects like monorails that are also allowing traps.

# Explain why it's good for the game

Xenos have ample ways to hide traps and this constantly is brought up as an issue.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/mUg-oFBkCEU

</details>


# Changelog
:cl: Drathek
fix: Dead bodies that have larva that can burst soon can be dragged
balance: Bursted bodies can no longer be dragged by xenos
balance: Xeno traps can no longer be placed under monorail tracks, conveyors, engineer lights, and dead bodies
/:cl:
