### PR TITLE
Chairs dont stun xenos

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -133,8 +133,9 @@
 	if(istype(AM, /mob/living) && stacked_size)
 		var/mob/living/M = AM
 		stack_collapse()
-		M.apply_effect(2, STUN)
-		M.apply_effect(2, WEAKEN)
+		if(ishumansynth_strict(M))
+			M.apply_effect(2, STUN)
+			M.apply_effect(2, WEAKEN)
 	else if(stacked_size > 8 && prob(50))
 		stack_collapse()
 


### PR DESCRIPTION

# About the pull request

fixes chairs stunning xenos for 3 years if they jump onto stacks of chairs

# Explain why it's good for the game
title


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Stacked chairs no longer stun xenos on collide anymore
/:cl:
