### PR TITLE
Fixes Survivor Synth not being in faction follow menu

### DIFF
--- a/code/__DEFINES/typecheck/humanoids.dm
+++ b/code/__DEFINES/typecheck/humanoids.dm
@@ -34,4 +34,4 @@
 
 //job/role helpers
 #define ismarinejob(J) (istype(J, /datum/job/marine))
-#define issurvivorjob(J) (J == JOB_SURVIVOR)
+#define issurvivorjob(J) ((J == JOB_SURVIVOR) || (J == JOB_SYNTH_SURVIVOR))


### PR DESCRIPTION

# About the pull request

As title

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixes Synthetic Survivor not appearing in the Survivor follow group.
/:cl:
