### PR TITLE
Fixes phonebox "realiable" into "reliable"

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/phonebox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/phonebox.dm
@@ -1,6 +1,6 @@
 /obj/structure/closet/phonebox
 	name = "phonebox"
-	desc = "It's a phonebox, outdated but realiable technology. These are used to communicate throughout the colony and connected colonies without interference. As reliable as they are, it seems the line is down."
+	desc = "It's a phonebox, outdated but reliable technology. These are used to communicate throughout the colony and connected colonies without interference. As reliable as they are, it seems the line is down."
 	icon = 'icons/obj/structures/props/phonebox.dmi'
 	icon_state = "phonebox_on_empty_closed"
 	density = TRUE
@@ -24,7 +24,7 @@
 
 /obj/structure/closet/phonebox/off
 	name = "phonebox"
-	desc = "It's a phonebox, outdated but realiable technology. These are used to communicate throughout the colony and connected colonies without interference. As reliable as they are, the bulb has been smashed and it seems the line is down."
+	desc = "It's a phonebox, outdated but reliable technology. These are used to communicate throughout the colony and connected colonies without interference. As reliable as they are, the bulb has been smashed and it seems the line is down."
 	icon = 'icons/obj/structures/props/phonebox.dmi'
 	icon_state = "phonebox_off_empty_closed"
 	density = TRUE
@@ -77,7 +77,7 @@
 	name = "phonebox"
 	icon = 'icons/obj/structures/props/phonebox.dmi'
 	icon_state = "phonebox_off_empty_closed"
-	desc = "It's a phonebox, outdated but realiable technology. These are used to communicate throughout the colony and connected colonies without interference. As reliable as they are, it seems the line is down."
+	desc = "It's a phonebox, outdated but reliable technology. These are used to communicate throughout the colony and connected colonies without interference. As reliable as they are, it seems the line is down."
 	bound_width = 32
 	bound_height = 64
 	density = TRUE

--- a/code/game/objects/structures/hybrisa_props.dm
+++ b/code/game/objects/structures/hybrisa_props.dm
@@ -2474,7 +2474,7 @@
 
 /obj/structure/prop/hybrisa/misc/phonebox
 	name = "wrecked phonebox"
-	desc = "It's a phonebox, outdated but realiable technology. These are used to communicate throughout the colony and connected colonies without interference. It seems it's completely wrecked, the glass is smashed, hiding inside would be pointless."
+	desc = "It's a phonebox, outdated but reliable technology. These are used to communicate throughout the colony and connected colonies without interference. It seems it's completely wrecked, the glass is smashed, hiding inside would be pointless."
 	icon = 'icons/obj/structures/props/phonebox.dmi'
 	icon_state = "phonebox_off_broken"
 	layer = ABOVE_MOB_LAYER
@@ -2485,7 +2485,7 @@
 
 /obj/structure/prop/hybrisa/misc/phonebox/bloody
 	name = "wrecked phonebox"
-	desc = "It's a phonebox, outdated but realiable technology. These are used to communicate throughout the colony and connected colonies without interference. It seems it's completely wrecked, covered in blood and the glass is smashed. Hiding inside would be pointless."
+	desc = "It's a phonebox, outdated but reliable technology. These are used to communicate throughout the colony and connected colonies without interference. It seems it's completely wrecked, covered in blood and the glass is smashed. Hiding inside would be pointless."
 	icon_state = "phonebox_bloody_off_broken"
 
 /obj/structure/prop/hybrisa/misc/phonebox/bullet_act(obj/projectile/P)


### PR DESCRIPTION

# About the pull request
fixes #8642
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
typo bad, no typo best

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
spellcheck: realiable replaced with reliable on phonebox
/:cl:

