### PR TITLE
Fixes weapon accidental discharges on disarm

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -144,16 +144,17 @@
 					if (prob(chance))
 						visible_message(SPAN_DANGER("[attacking_mob] accidentally makes [src]'s [held_weapon.name] go off during the struggle!"), SPAN_DANGER("You accidentally make [src]'s [held_weapon.name] go off during the struggle!"), null, 5)
 						var/list/turfs = list()
-						for(var/turf/T in view())
-							turfs += T
+						for(var/turf/turfs_to_discharge in view())
+							turfs += turfs_to_discharge
 						var/turf/target = pick(turfs)
 						count_niche_stat(STATISTICS_NICHE_DISCHARGE)
+						held_weapon.handle_fire(target, src)
 
 						attack_log += "\[[time_stamp()]\] <b>[key_name(src)]</b> accidentally fired <b>[held_weapon.name]</b> in [get_area(src)] triggered by <b>[key_name(attacking_mob)]</b>."
 						attacking_mob.attack_log += "\[[time_stamp()]\] <b>[key_name(src)]</b> accidentally fired <b>[held_weapon.name]</b> in [get_area(src)] triggered by <b>[key_name(attacking_mob)]</b>."
 						msg_admin_attack("[key_name(src)] accidentally fired <b>[held_weapon.name]</b> in [get_area(attacking_mob)] ([attacking_mob.loc.x],[attacking_mob.loc.y],[attacking_mob.loc.z]) triggered by <b>[key_name(attacking_mob)]</b>.", attacking_mob.loc.x, attacking_mob.loc.y, attacking_mob.loc.z)
 
-						return held_weapon.afterattack(target,src)
+						return
 
 			var/disarm_chance = rand(1, 100)
 			var/attacker_skill_level = attacking_mob.skills ? attacking_mob.skills.get_skill_level(SKILL_CQC) : SKILL_CQC_MAX // No skills, so assume max

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -142,7 +142,7 @@
 						chance = !hand ? 40 : 20
 
 					if (prob(chance))
-						visible_message(SPAN_DANGER("[attacking_mob] accidentally makes [src]'s [held_weapon.name] go off during the struggle!"), SPAN_DANGER("You accidentally make [src]'s [held_weapon.name] go off during the struggle!"), null, 5)
+						visible_message(SPAN_DANGER("[attacking_mob] accidentally discharges [src]'s [held_weapon.name] during the struggle!"), SPAN_DANGER("You accidentally discharge [src]'s [held_weapon.name] during the struggle!"), null, 5)
 						var/list/turfs = list()
 						for(var/turf/turfs_to_discharge in view())
 							turfs += turfs_to_discharge


### PR DESCRIPTION

# About the pull request

You ever see those messages about guns accidentally firing whenever someone holding a gun is shoved or disarmed?
Yeah, this PR revives this feature

Don't shove wielded sadars

# Explain why it's good for the game

Fixes a long-time bug by calling handle_fire proc instead of whatever held_weapon.afterattack(target,src) is supposed to do. Much friendlier than having to check proximity each time it returns since you're literally next to someone if you disarm them anyway.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

https://cdn.discordapp.com/attachments/604397850675380234/1352305339315388416/Desktop_2025.03.20_-_23.37.08.02.mp4?ex=67de30bd&is=67dcdf3d&hm=58d99935e09beb4ef772bee50ba3d03bd7247503b35d48a539f7416df056c399&

</details>


# Changelog
:cl:
fix: You can now *accidentally* discharge a weapon once more. Try not to abuse this with your nearest specialist.
/:cl:
