### PR TITLE
highpop maps can now be voted at 120 pop

### DIFF
--- a/code/__DEFINES/__game.dm
+++ b/code/__DEFINES/__game.dm
@@ -40,7 +40,7 @@
 #define GAMEMODE_HIVE_WARS "Hive Wars"
 
 /// Number of players before we switch to lowpop maps only (LV, BR, Prison).
-#define PLAYERCOUNT_LOWPOP_MAP_LIMIT 130
+#define PLAYERCOUNT_LOWPOP_MAP_LIMIT 120
 /// Time before the round starts.
 #define PREROUND_TIME 360
 

--- a/map_config/maps.txt
+++ b/map_config/maps.txt
@@ -24,21 +24,21 @@ map prison_station_fop
 endmap
 
 map fiorina_sciannex
-	minplayers 130
+	minplayers 120
 endmap
 
 map corsat
-	minplayers 130
+	minplayers 120
 	voteweight 0
 	disabled
 endmap
 
 map desert_dam
-	minplayers 130
+	minplayers 120
 endmap
 
 map ice_colony_v2
-	minplayers 130
+	minplayers 120
 	voteweight 0
 	disabled
 endmap
@@ -50,14 +50,14 @@ map kutjevo
 endmap
 
 map sorokyne_strata
-	minplayers 130
+	minplayers 120
 endmap
 
 map lv522_chances_claim
 endmap
 
 map lv759_hybrisa_prospera
-	minplayers 130
+	minplayers 120
 endmap
 
 map new_varadero


### PR DESCRIPTION

# About the pull request
changes the amount of players needed for highpop maps to be voteable from 130 to 120

# Explain why it's good for the game

a lot of europeans like me can't play highpop maps a good amount of the time soo hopefully this will be enough for big maps to be available during eu hours


# Testing Photographs and Procedure

# Changelog

:cl:
config: Highpop maps can now be played at 120 players instead of 130.
/:cl:


