### PR TITLE
Xeno traps and bodies interactions

### DIFF
--- a/code/datums/components/weed_food.dm
+++ b/code/datums/components/weed_food.dm
@@ -130,6 +130,9 @@
 	else
 		RegisterSignal(parent_turf, COMSIG_WEEDNODE_GROWTH, PROC_REF(on_update))
 
+	if(locate(/obj/effect/alien/resin/trap) in parent_mob.loc)
+		UnregisterSignal(parent_turf, COMSIG_WEEDNODE_GROWTH)
+
 	// We moved, restart or start the proccess
 	if(stop() || !merged)
 		start()

--- a/code/datums/components/weed_food.dm
+++ b/code/datums/components/weed_food.dm
@@ -130,9 +130,6 @@
 	else
 		RegisterSignal(parent_turf, COMSIG_WEEDNODE_GROWTH, PROC_REF(on_update))
 
-	if(locate(/obj/effect/alien/resin/trap) in parent_mob.loc)
-		UnregisterSignal(parent_turf, COMSIG_WEEDNODE_GROWTH)
-
 	// We moved, restart or start the proccess
 	if(stop() || !merged)
 		start()

--- a/code/datums/components/weed_food.dm
+++ b/code/datums/components/weed_food.dm
@@ -237,6 +237,9 @@
 	if(SEND_SIGNAL(parent_mob, COMSIG_ATTEMPT_MOB_PULL) & COMPONENT_CANCEL_MOB_PULL)
 		return FALSE
 
+	if(locate(/obj/effect/alien/resin/trap) in parent_mob.loc)
+		return FALSE
+
 	if(unmerged_time == world.time)
 		return merge_with_weeds() // Weeds upgraded, re-merge now re-using the apperance
 	QDEL_NULL(weed_appearance)
@@ -320,6 +323,10 @@
 		weed_appearance = new(null, is_flipped, parent_mob.weed_food_icon, parent_mob.weed_food_states, parent_mob.weed_food_states_flipped)
 	weed_appearance.color = absorbing_weeds.color
 	parent_mob.vis_contents += weed_appearance
+
+	var/obj/effect/alien/resin/trap/resin_trap = locate() in parent_mob.loc //failsafe! deletes the resin trap if body still merges with weeds
+	if(resin_trap)
+		qdel(resin_trap)
 
 	return TRUE
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -607,8 +607,8 @@
 		return FALSE
 
 	for(var/mob/living/body in src)
-		if(body.stat == DEAD)
-			to_chat(xeno, SPAN_XENOWARNING("The body is in the way!"))
+		if(HAS_TRAIT(src, TRAIT_MERGED_WITH_WEEDS))
+			to_chat(xeno, SPAN_XENOWARNING("We cannot make a hole on merged bodies!"))
 			return FALSE
 
 	return alien_weeds

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -606,8 +606,9 @@
 		to_chat(xeno, SPAN_XENOWARNING("This is too close to a fruit!"))
 		return FALSE
 
-	for(var/mob/living/body in src)
-		if(HAS_TRAIT(src, TRAIT_MERGED_WITH_WEEDS))
+	var/turf = get_turf(src)
+	for(var/mob/living/body in turf)
+		if(HAS_TRAIT(body, TRAIT_MERGED_WITH_WEEDS))
 			to_chat(xeno, SPAN_XENOWARNING("We cannot make a hole on merged bodies!"))
 			return FALSE
 

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -297,7 +297,7 @@
 	return TRUE
 
 /mob/living/carbon/human/is_xeno_grabbable()
-	if(stat != DEAD)
+	if(stat != DEAD || chestburst)
 		return TRUE
 
 	if(status_flags & XENO_HOST)
@@ -306,8 +306,8 @@
 				return FALSE
 		if(world.time > timeofdeath + revive_grace_period)
 			return FALSE // they ain't gonna burst now
-		return TRUE
-	return FALSE // leave the dead alone
+	else
+		return FALSE // leave the dead alone
 
 //This proc is here to prevent Xenomorphs from picking up objects (default attack_hand behaviour)
 //Note that this is overridden by every proc concerning a child of obj unless inherited

--- a/strings/xenotips.txt
+++ b/strings/xenotips.txt
@@ -57,3 +57,4 @@ Some smaller Xenomorphs such as Runners can hide behind barricades by resting ag
 Defenders with a lowered crest can open existing holes in walls.
 As a Defender, you can deal an additional stage of damage to an APC by lowering your crest and then attacking it.
 Any Xenomorph with acid can melt any kind of window frame; you may use this to create additional paths.
+As a Burrower or Carrier, you can drag bursted bodies and hide your traps with them.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Returns the functionality of xenomorphs being able to drag bursted corpses and planting traps on dead bodies.

Implemented a restriction on planting traps on bodies already merged with weeds.

Made bodies unable to merge with weeds if there's a trap underneath them. (still fails in some weird conditions I cannot explain nor fix)

Implemented a failsafe if above fails by deleting the resin trap once the body merges with the weeds, preventing completely invisible traps that are nearly impossible to locate before you trigger them.

Added a xeno tip for carriers and burrowers to encourage using bursted corpses as movable trap hiders, just like they can already do with pushable crates etc.

# Explain why it's good for the game

Following our core principle of **"Improve, not remove"**, I have decided to bring back xenos being able to drag bursted and use them and other dead bodies as trap hiding places. We shouldn't be removing features, especially ones creative as using bodies of the fallen as traps (which something xenos would do). Despite being unable to use bursted corpses anymore for morphers and pools, they still have a purpose, being available for Carriers and Burrowers to use for whatever they deem fit in their trapping or even other xenomorphs in using it as bait for marines to try to take. This is one of the most interesting creative ways of combat you could do.

The main issue regarding traps and bodies wasn't due to bodies hiding them, it was due to bodies eventually merging with weeds and completely making the body nearly invisible and the trap nearly invisible. The second issue was xenos still being able to place traps on merged bodies. This PR fixes both of these issues while also keeping BOTH SIDES happy. Marines for not getting slimed by invisible traps and xenomorphs for still being able to use bodies as traps/bait, even if temporarily.
In fact, there is a sacrifice in using bodies as traps, in exchange for being able to place traps under them, the body will not be merged and make it easier for marines to find the body and recover it.

As stated again, the majority of complaining was due to trapped bodies **that were already merged with weeds**, NOT trapped bodies themselves. Those still have counterplay in the same sense as other similiar hiding places who hide the hole sprite but not the entire sprite, the sense being you can still shoot to trigger it.

Major issues fixed regarding merged bodies and traps, xenos and marines both happy. all is well with the world.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Unknownity
balance: Xenomorphs can once again drag bursted bodies and plant resin traps on dead bodies.
balance: Dead bodies will try to stop merging with weeds if there's a resin trap underneath them.
add: Added a tip for burrowers and carriers that they can use bursted bodies as movable trap hiders.
fix: Resin traps can no longer be planted on bodies merged with weeds.
fix: Resin traps will be deleted if the dead body still merges with weeds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
