### PR TITLE
fixes shaking bypassing pill skill locks

### DIFF
--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -763,6 +763,14 @@ W is always an item. stop_warning prevents messaging. user may be null.**/
 			SPAN_NOTICE("You shake \the [src] but nothing falls out."))
 		return
 
+	var/obj/item/storage/pill_bottle/shook_bottle
+	shook_bottle = src
+	if(istype(shook_bottle))
+		if(!skillcheck(user, SKILL_MEDICAL, SKILL_MEDICAL_MEDIC))
+			user.visible_message(SPAN_NOTICE("[user] shakes \the [src] but nothing falls out."),
+				SPAN_NOTICE("You shake \the [src] but nothing falls out, it seems to have some kind of safety lid"))
+			return
+
 	storage_close(user)
 	var/obj/item/item_obj
 	if(storage_flags & STORAGE_USING_FIFO_DRAWING)


### PR DESCRIPTION

# About the pull request

using the shake verb currently allows you to reliably bypass the skill lock intended for pills

# Explain why it's good for the game
fixes an exploit

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/de36b3ee-fbd0-4769-b095-d59cb6d52ab3)

</details>


# Changelog



:cl:
fix: pill bottle skill locks can't be bypassed by shaking anymore
/:cl:


