### PR TITLE
Allows Drones to evolve into any T2 before first drop

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Evolution.dm
@@ -28,6 +28,10 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 	if(tier == 1 && hive.allow_queen_evolve && !hive.living_xeno_queen)
 		castes_available |= XENO_CASTE_QUEEN
 
+	// Allow drones to evo into any T2 before first drop
+	if(caste_type == XENO_CASTE_DRONE && !SSobjectives.first_drop_complete)
+		castes_available = caste.early_evolves_to.Copy()
+
 	for(var/caste in castes_available)
 		if(GLOB.xeno_datum_list[caste].minimum_evolve_time > ROUND_TIME)
 			castes_available -= caste

--- a/code/modules/mob/living/carbon/xenomorph/castes/Drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Drone.dm
@@ -20,7 +20,8 @@
 	build_time_mult = BUILD_TIME_MULT_BUILDER
 
 	caste_desc = "A builder of hives. Only drones may evolve into Queens."
-	evolves_to = list(XENO_CASTE_QUEEN, XENO_CASTE_BURROWER, XENO_CASTE_CARRIER, XENO_CASTE_HIVELORD, XENO_CASTE_LURKER, XENO_CASTE_WARRIOR, XENO_CASTE_SPITTER) //Add more here separated by commas
+	evolves_to = list(XENO_CASTE_QUEEN, XENO_CASTE_BURROWER, XENO_CASTE_CARRIER, XENO_CASTE_HIVELORD) //Add more here separated by commas
+	early_evolves_to =list(XENO_CASTE_QUEEN, XENO_CASTE_BURROWER, XENO_CASTE_CARRIER, XENO_CASTE_HIVELORD, XENO_CASTE_LURKER, XENO_CASTE_WARRIOR, XENO_CASTE_SPITTER) //list of castes that can be evolved too prior to 20 minutes.
 	deevolves_to = list(XENO_CASTE_LARVA)
 	can_hold_facehuggers = 1
 	can_hold_eggs = CAN_HOLD_TWO_HANDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/Drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Drone.dm
@@ -21,7 +21,7 @@
 
 	caste_desc = "A builder of hives. Only drones may evolve into Queens."
 	evolves_to = list(XENO_CASTE_QUEEN, XENO_CASTE_BURROWER, XENO_CASTE_CARRIER, XENO_CASTE_HIVELORD) //Add more here separated by commas
-	early_evolves_to =list(XENO_CASTE_QUEEN, XENO_CASTE_BURROWER, XENO_CASTE_CARRIER, XENO_CASTE_HIVELORD, XENO_CASTE_LURKER, XENO_CASTE_WARRIOR, XENO_CASTE_SPITTER) //list of castes that can be evolved too prior to 20 minutes.
+	early_evolves_to = list(XENO_CASTE_QUEEN, XENO_CASTE_BURROWER, XENO_CASTE_CARRIER, XENO_CASTE_HIVELORD, XENO_CASTE_LURKER, XENO_CASTE_WARRIOR, XENO_CASTE_SPITTER) //list of castes that can be evolved too prior to 20 minutes.
 	deevolves_to = list(XENO_CASTE_LARVA)
 	can_hold_facehuggers = 1
 	can_hold_eggs = CAN_HOLD_TWO_HANDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/Drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Drone.dm
@@ -20,7 +20,7 @@
 	build_time_mult = BUILD_TIME_MULT_BUILDER
 
 	caste_desc = "A builder of hives. Only drones may evolve into Queens."
-	evolves_to = list(XENO_CASTE_QUEEN, XENO_CASTE_BURROWER, XENO_CASTE_CARRIER, XENO_CASTE_HIVELORD) //Add more here separated by commas
+	evolves_to = list(XENO_CASTE_QUEEN, XENO_CASTE_BURROWER, XENO_CASTE_CARRIER, XENO_CASTE_HIVELORD, XENO_CASTE_LURKER, XENO_CASTE_WARRIOR, XENO_CASTE_SPITTER) //Add more here separated by commas
 	deevolves_to = list(XENO_CASTE_LARVA)
 	can_hold_facehuggers = 1
 	can_hold_eggs = CAN_HOLD_TWO_HANDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/caste_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/caste_datum.dm
@@ -27,6 +27,8 @@
 	var/list/evolves_to = list()
 	/// what caste or castes to de-evolve to.
 	var/list/deevolves_to = list()
+	///This is where you add castes drones can evolve too before first drop.
+	var/list/early_evolves_to
 	///If they can use consoles, etc. Set on Queen
 	var/is_intelligent = 0
 	var/caste_desc = null

--- a/code/modules/mob/living/carbon/xenomorph/castes/caste_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/caste_datum.dm
@@ -27,7 +27,7 @@
 	var/list/evolves_to = list()
 	/// what caste or castes to de-evolve to.
 	var/list/deevolves_to = list()
-	///This is where you add castes drones can evolve too before first drop.
+	///This is where you add castes drones can evolve to before first drop.
 	var/list/early_evolves_to
 	///If they can use consoles, etc. Set on Queen
 	var/is_intelligent = 0


### PR DESCRIPTION
# About the pull request

This PR allows drones to evolve into any T2 caste (now allowing them to evolve into spitter, warrior, lurker) before the marines first drop.

# Explain why it's good for the game

As discussed earlier on the forums, as well as in coding chat I feel that this could eliminate risk of missing t2/t3 evo as a result of paying drone tax. Players wanting to evo into a combat caste can provide building/support to the hive for a little while they wait, as opposed to just sitting in the hive or throwing themselves at survs

While I don't think this will solve the issue of xenos chronically needing builders in the early game, I do feel its a step in the right direction, and wont make early game building be as punishing to players that also wish to partake in combat later in the round.


# Testing Photographs and Procedure
Code complies,

Became drone, evolved into all possible castes. Became sent, evolved into spitter, devo'd back into sent. Became drone, set first drop variable to true. Unable to evo into spitter/lurker/warrior.


# Changelog
:cl:
balance: Drones can now evolve into any T2 caste before first drop
/:cl:
