### PR TITLE
Chem property fixes

### DIFF
--- a/code/modules/reagents/chemistry_properties/prop_negative.dm
+++ b/code/modules/reagents/chemistry_properties/prop_negative.dm
@@ -6,7 +6,7 @@
 /datum/chem_property/negative/process(mob/living/M, potency = 1, delta_time)
 	M.last_damage_data = create_cause_data("Harmful substance", holder.last_source_mob?.resolve())
 
-	return TRUE
+	return ..()
 
 /datum/chem_property/negative/can_cause_harm()
 	return TRUE

--- a/code/modules/reagents/chemistry_properties/prop_negative.dm
+++ b/code/modules/reagents/chemistry_properties/prop_negative.dm
@@ -6,6 +6,8 @@
 /datum/chem_property/negative/process(mob/living/M, potency = 1, delta_time)
 	M.last_damage_data = create_cause_data("Harmful substance", holder.last_source_mob?.resolve())
 
+	return TRUE
+
 /datum/chem_property/negative/can_cause_harm()
 	return TRUE
 

--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -833,7 +833,7 @@
 	category = PROPERTY_TYPE_TOXICANT
 	max_level = 1
 
-/datum/chem_property/positive/photosensetive/process(mob/living/M, potency = 1)
+/datum/chem_property/positive/photosensitive/process(mob/living/M, potency = 1)
 	to_chat(M, SPAN_WARNING("Your feel a horrible migraine!"))
 	M.apply_internal_damage(potency, "brain")
 

--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -576,10 +576,10 @@
 		return
 	M.apply_internal_damage(0.5 * potency * delta_time, "heart")
 
-/datum/chem_property/positive/defibrillating/process_dead(mob/living/M, potency = 1, delta_time)
-	if(!ishuman(M))
+/datum/chem_property/positive/defibrillating/process_dead(mob/living/affected_mob, potency = 1, delta_time)
+	if(!ishuman(affected_mob))
 		return
-	var/mob/living/carbon/human/dead = M
+	var/mob/living/carbon/human/dead = affected_mob
 	var/revivable = dead.check_tod() && dead.is_revivable()
 	if(!revivable)
 		return
@@ -588,13 +588,13 @@
 		if(dead.health <= HEALTH_THRESHOLD_DEAD) //If the mob got damaged to below the threshold while the timer was ticking then we reset
 			deltimer(revivetimerid)
 			revivetimerid = null
-		return;
+		return
 
-	for(var/datum/reagent/electrogenetic_reagent in M.reagents.reagent_list)
+	for(var/datum/reagent/electrogenetic_reagent in affected_mob.reagents.reagent_list)
 		var/datum/chem_property/property = electrogenetic_reagent.get_property(PROPERTY_ELECTROGENETIC) //Adrenaline helps greatly at restarting the heart
 		if(property)
-			property.trigger(M)
-			M.reagents.remove_reagent(electrogenetic_reagent.id, 1)
+			property.trigger(affected_mob)
+			affected_mob.reagents.remove_reagent(electrogenetic_reagent.id, 1)
 			break
 	if(dead.health > HEALTH_THRESHOLD_DEAD)
 		revivetimerid = addtimer(CALLBACK(dead, TYPE_PROC_REF(/mob/living/carbon/human, handle_revive)), 5 SECONDS, TIMER_STOPPABLE)

--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -553,6 +553,7 @@
 	value = 3
 	cost_penalty = FALSE
 	var/revivetimerid
+	COOLDOWN_DECLARE(revive_notif)
 
 /datum/chem_property/positive/defibrillating/on_delete(mob/living/M)
 	..()
@@ -597,6 +598,9 @@
 			break
 	if(dead.health > HEALTH_THRESHOLD_DEAD)
 		revivetimerid = addtimer(CALLBACK(dead, TYPE_PROC_REF(/mob/living/carbon/human, handle_revive)), 5 SECONDS, TIMER_STOPPABLE)
+		if(!COOLDOWN_FINISHED(src, revive_notif))
+			return
+		COOLDOWN_START(src, revive_notif, 10 SECONDS)
 		to_chat(dead, SPAN_NOTICE("You feel your heart struggling as you suddenly feel a spark, making it desperately try to continue pumping."))
 		playsound_client(dead.client, 'sound/effects/heart_beat_short.ogg', 35)
 		var/mob/dead/observer/ghost = dead.get_ghost()

--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -602,15 +602,13 @@
 			dead.apply_damage(-potency * POTENCY_MULTIPLIER_LOW, BURN)
 			dead.apply_damage(-potency * POTENCY_MULTIPLIER_LOW, TOX)
 			dead.apply_damage(-potency * POTENCY_MULTIPLIER_LOW, CLONE)
-		if(dead.health < HEALTH_THRESHOLD_DEAD)
-			return
-		if(!COOLDOWN_FINISHED(src, ghost_notif))
-			return
-		var/mob/dead/observer/ghost = dead.get_ghost()
-		if(ghost?.client)
-			COOLDOWN_START(src, ghost_notif, 30 SECONDS)
-			playsound_client(ghost.client, 'sound/effects/adminhelp_new.ogg')
-			to_chat(ghost, SPAN_BOLDNOTICE("Your heart is struggling to pump! There is a chance you might get up!(Verbs -> Ghost -> Re-enter corpse, or <a href='byond://?src=\ref[ghost];reentercorpse=1'>click here!</a>)"))
+	if(!COOLDOWN_FINISHED(src, ghost_notif))
+		return
+	var/mob/dead/observer/ghost = dead.get_ghost()
+	if(ghost?.client)
+		COOLDOWN_START(src, ghost_notif, 30 SECONDS)
+		playsound_client(ghost.client, 'sound/effects/adminhelp_new.ogg')
+		to_chat(ghost, SPAN_BOLDNOTICE("Your heart is struggling to pump! There is a chance you might get up!(Verbs -> Ghost -> Re-enter corpse, or <a href='byond://?src=\ref[ghost];reentercorpse=1'>click here!</a>)"))
 	return TRUE
 
 /datum/chem_property/positive/hyperdensificating


### PR DESCRIPTION
# About the pull request

Defibrillation property:
-Notification of the person being revived was in a branch, causing it to often never get reached. This caused marines to get revived without them ever realizing it. Solution: Reviving and the notification are in one branch now
-Kept triggering healing and sound notification even after the mob was above the dead treshold, causing them to often get healed to full health, which is not intended. Solution: Once the revive timer is underway it will not attempt to do anything anymore
-If the mob got damaged to below the dead threshold while the revive timer was already underway it would still revive them, causing them to inmidietly die again. Solution: If the mob gets damaged to below threshold again we just cancel the revive, and start the whole process over.


Paining would never apply pain because it was expecting a TRUE return from a proc that didnt return anything ಠ_ಠ

Photosensitive's process proc was typoed, so it never got triggered.

# Explain why it's good for the game

Xeno benefiting bugs bad


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Defibrillation chems now always notify the player that they are being revived
fix: Defibrillation property no longer keeps healing the patient once its above -100 health
fix: Fixed a case where defibrillation property would prematurely revive a patient despite them being below -100 health
fix: Paining chem property now causes pain
fix: Photosensitive chem property is no longer harmless
/:cl:
