### PR TITLE
Fix flyby triggering first drop

### DIFF
--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -87,7 +87,7 @@
 
 /obj/docking_port/mobile/marine_dropship/enterTransit()
 	. = ..()
-	if(SSticker?.mode && !(SSticker.mode.flags_round_type & MODE_DS_LANDED)) //Launching on first drop.
+	if(SSticker?.mode && !(SSticker.mode.flags_round_type & MODE_DS_LANDED) && !in_flyby && is_ground_level(destination?.z)) //Launching on first drop.
 		SSticker.mode.ds_first_drop(src)
 
 /obj/docking_port/mobile/marine_dropship/beforeShuttleMove(turf/newT, rotation, move_mode, obj/docking_port/mobile/moving_dock)

--- a/code/modules/shuttles/marine_ferry.dm
+++ b/code/modules/shuttles/marine_ferry.dm
@@ -255,7 +255,8 @@
 
 	close_doors(turfs_int) // adding this for safety.
 
-	if(SSticker?.mode && !(SSticker.mode.flags_round_type & MODE_DS_LANDED)) //Launching on first drop.
+	// Ever a flyby is possible this way it needs to check for such
+	if(SSticker?.mode && !(SSticker.mode.flags_round_type & MODE_DS_LANDED) && is_ground_level(destination?.z)) //Launching on first drop.
 		SSticker.mode.ds_first_drop()
 
 	in_transit_time_left = travel_time


### PR DESCRIPTION

# About the pull request

This PR makes the check for first drop stricter (now requires the dropship to not be in flyby mode and for the destination to be the ground z.

# Explain why it's good for the game

Fixes #8399 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Normal launch:
![image](https://github.com/user-attachments/assets/febdd81c-a54e-4f79-9932-d955edc5a9cd)

Flyby launch:
![image](https://github.com/user-attachments/assets/46294c98-18b5-4d80-8ac7-908625fb5636)

</details>


# Changelog
:cl: Drathek
fix: Fixed flyby and flight to non-ground triggering first drop events
/:cl:
