### PR TITLE
fix spec icons not showing up correctly on orbit panel and squad panel

### DIFF
--- a/code/game/jobs/job/marine/squad_info.dm
+++ b/code/game/jobs/job/marine/squad_info.dm
@@ -245,7 +245,17 @@
 					if(JOB_SQUAD_SMARTGUN)
 						rank = "SG"
 					if(JOB_SQUAD_SPECIALIST)
-						rank = "Spc"
+						switch(H.rank_override)
+							if("spec_demo")
+								rank = "SpcDem"
+							if("spec_sniper")
+								rank = "SpcSn"
+							if("spec_grenadier")
+								rank = "SpcGr"
+							if("spec_pyro")
+								rank = "SpcPy"
+							else
+								rank = "Spc"
 					if(JOB_SQUAD_TEAM_LEADER)
 						rank = "TL"
 					if(JOB_SQUAD_LEADER)

--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -270,6 +270,10 @@
 		list("medk9", "hudsquad_medk9"),
 		list("SG", "hudsquad_gun"),
 		list("Spc", "hudsquad_spec"),
+		list("SpcDem", "hudsquad_spec_demo"),
+		list("SpcSn", "hudsquad_spec_sniper"),
+		list("SpcGr", "hudsquad_spec_grenadier"),
+		list("SpcPy", "hudsquad_spec_pyro"),
 		list("TL", "hudsquad_tl"),
 		list("SL", "hudsquad_leader"),
 	)

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -142,6 +142,8 @@
 					for(var/key in icon)
 						icon = key
 						break
+				if(human.rank_override)
+					icon = human.rank_override
 				serialized["icon"] = icon ? icon : "private"
 
 				if(human.assigned_squad)


### PR DESCRIPTION

# About the pull request

title

# Explain why it's good for the game
its a fix


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: fixed spec icons on orbit panel
fix: fixed spec icons on squad info panel
/:cl:
