### PR TITLE
Fixes pill shaking correctly

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -502,6 +502,11 @@
 		to_chat(user, SPAN_WARNING("The [name] is empty."))
 		return
 
+/obj/item/storage/pill_bottle/shake(mob/user, turf/tile)
+	if(skilllock && !skillcheck(user, SKILL_MEDICAL, SKILL_MEDICAL_MEDIC))
+		error_idlock(user)
+		return
+	return ..()
 
 /obj/item/storage/pill_bottle/attackby(obj/item/storage/pill_bottle/W, mob/user)
 	if(istype(W))

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -763,14 +763,6 @@ W is always an item. stop_warning prevents messaging. user may be null.**/
 			SPAN_NOTICE("You shake \the [src] but nothing falls out."))
 		return
 
-	var/obj/item/storage/pill_bottle/shook_bottle
-	shook_bottle = src
-	if(istype(shook_bottle))
-		if(!skillcheck(user, SKILL_MEDICAL, SKILL_MEDICAL_MEDIC))
-			user.visible_message(SPAN_NOTICE("[user] shakes \the [src] but nothing falls out."),
-				SPAN_NOTICE("You shake \the [src] but nothing falls out, it seems to have some kind of safety lid"))
-			return
-
 	storage_close(user)
 	var/obj/item/item_obj
 	if(storage_flags & STORAGE_USING_FIFO_DRAWING)


### PR DESCRIPTION
# About the pull request

Basically supersedes #8838

# Explain why it's good for the game

Well:
- `istype(src)` is NEAR-UNIVERSALLY a sign that you're doing something wrong in OOP.
- The skillcheck didn't account for skilllock.
- The text wasn't spellchecked.
- The text was unnecessary, when we have a dedicated `error_idlock()` proc for that.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/2485e8b0-6ec7-472b-a7c2-7d6f58c0f5c4)

</details>
