### PR TITLE
Fixes skill lock bypass

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -438,12 +438,12 @@
 
 /obj/item/storage/pill_bottle/Initialize()
 	. = ..()
-	if(display_maptext == FALSE)
+	if(!display_maptext)
 		verbs -= /obj/item/storage/pill_bottle/verb/set_maptext
 
 /obj/item/storage/pill_bottle/fill_preset_inventory()
 	if(pill_type_to_fill)
-		for(var/i=1 to max_storage_space)
+		for(var/i in 1 to max_storage_space)
 			new pill_type_to_fill(src)
 
 /obj/item/storage/pill_bottle/update_icon()
@@ -485,7 +485,7 @@
 	if(user.get_inactive_hand())
 		to_chat(user, SPAN_WARNING("You need an empty hand to take out a pill."))
 		return
-	if(skilllock && !skillcheck(user, SKILL_MEDICAL, SKILL_MEDICAL_MEDIC))
+	if(!can_storage_interact(user))
 		error_idlock(user)
 		return
 	if(length(contents))
@@ -502,6 +502,11 @@
 		to_chat(user, SPAN_WARNING("The [name] is empty."))
 		return
 
+/obj/item/storage/pill_bottle/shake(mob/user, turf/tile)
+	if(!can_storage_interact(user))
+		error_idlock(user)
+		return
+	return ..()
 
 /obj/item/storage/pill_bottle/attackby(obj/item/storage/pill_bottle/W, mob/user)
 	if(istype(W))
@@ -514,7 +519,7 @@
 
 
 /obj/item/storage/pill_bottle/open(mob/user)
-	if(skilllock && !skillcheck(user, SKILL_MEDICAL, SKILL_MEDICAL_MEDIC))
+	if(!can_storage_interact(user))
 		error_idlock(user)
 		return
 	..()
@@ -522,7 +527,7 @@
 /obj/item/storage/pill_bottle/can_be_inserted(obj/item/W, mob/user, stop_messages = FALSE)
 	. = ..()
 	if(.)
-		if(skilllock && !skillcheck(usr, SKILL_MEDICAL, SKILL_MEDICAL_MEDIC))
+		if(!can_storage_interact(user))
 			error_idlock(usr)
 			return
 
@@ -534,7 +539,7 @@
 	var/obj/item/storage/belt/medical/M = loc
 	if(!M.mode)
 		return FALSE
-	if(skilllock && !skillcheck(user, SKILL_MEDICAL, SKILL_MEDICAL_MEDIC))
+	if(!can_storage_interact(user))
 		error_idlock(user)
 		return FALSE
 	if(user.get_active_hand())
@@ -580,7 +585,7 @@
 	if(!ishuman(user))
 		return ..()
 
-	if(skilllock && !skillcheck(user, SKILL_MEDICAL, SKILL_MEDICAL_MEDIC))
+	if(!can_storage_interact(user))
 		error_idlock(user)
 		return FALSE
 
@@ -618,6 +623,11 @@
 		maptext_label = str
 		to_chat(usr, SPAN_NOTICE("You label \the [src] with '[str]' in big, blocky letters."))
 		update_icon()
+
+/obj/item/storage/pill_bottle/can_storage_interact(mob/user)
+	if(skilllock && !skillcheck(user, SKILL_MEDICAL, SKILL_MEDICAL_MEDIC))
+		return FALSE
+	return ..()
 
 /obj/item/storage/pill_bottle/kelotane
 	name = "\improper Kelotane pill bottle"

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -27,7 +27,7 @@
 		if(src.broken)
 			to_chat(user, SPAN_DANGER("It appears to be broken."))
 			return
-		if(src.allowed(user))
+		if(can_storage_interact(user))
 			src.locked = !( src.locked )
 			if(src.locked)
 				src.icon_state = src.icon_locked

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -763,14 +763,6 @@ W is always an item. stop_warning prevents messaging. user may be null.**/
 			SPAN_NOTICE("You shake \the [src] but nothing falls out."))
 		return
 
-	var/obj/item/storage/pill_bottle/shook_bottle
-	shook_bottle = src
-	if(istype(shook_bottle))
-		if(!skillcheck(user, SKILL_MEDICAL, SKILL_MEDICAL_MEDIC))
-			user.visible_message(SPAN_NOTICE("[user] shakes \the [src] but nothing falls out."),
-				SPAN_NOTICE("You shake \the [src] but nothing falls out, it seems to have some kind of safety lid"))
-			return
-
 	storage_close(user)
 	var/obj/item/item_obj
 	if(storage_flags & STORAGE_USING_FIFO_DRAWING)

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -698,7 +698,7 @@ W is always an item. stop_warning prevents messaging. user may be null.**/
 	if (!isturf(T) || get_dist(src, T) > 1)
 		T = get_turf(src)
 
-	if(!allowed(user))
+	if(!can_storage_interact(user))
 		to_chat(user, SPAN_WARNING("Access denied."))
 		return
 
@@ -753,7 +753,7 @@ W is always an item. stop_warning prevents messaging. user may be null.**/
 				SPAN_NOTICE("You shake \the [src] but nothing falls out. It feels empty."))
 		return
 
-	if(!allowed(user))
+	if(!can_storage_interact(user))
 		user.visible_message(SPAN_NOTICE("[user] shakes \the [src] but nothing falls out."),
 			SPAN_NOTICE("You shake \the [src] but nothing falls out. Access denied."))
 		return
@@ -965,6 +965,11 @@ W is always an item. stop_warning prevents messaging. user may be null.**/
 ///Things to be done after selecting a map skin (if any) and before adding inventory and updating icon for the first time. Most likely saving basic icon state.
 /obj/item/storage/proc/post_skin_selection()
 	return
+
+/obj/item/storage/proc/can_storage_interact(mob/user)
+	if(!allowed(user))
+		return FALSE
+	return TRUE
 
 /**Returns the storage depth of an atom. This is the number of items the atom is nested in before reaching the designated container, counted inclusively.
 Returning 1 == directly inside the container's contents, 2 == inside something which is itself inside the container, etc.

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -128,6 +128,8 @@
 
 	if(isstorage(I))
 		var/obj/item/storage/S = I
+		if(!S.can_storage_interact(user))
+			return
 		if(length(S.contents) > 0)
 			to_chat(user, SPAN_NOTICE("You empty [S] into [src]."))
 			for(var/obj/item/O in S.contents)


### PR DESCRIPTION
# About the pull request

Fixes https://github.com/cmss13-devs/cmss13/issues/8648

Also integrates #8854 

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: You can no longer bypass storage locks by using a disposal bin.
/:cl:
