### PR TITLE
Fixes CO pistols being melted or exploded

### DIFF
--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -244,6 +244,8 @@
 	item_state = "c_deagle"
 	current_mag = /obj/item/ammo_magazine/pistol/heavy/super/highimpact
 	black_market_value = 100
+	unacidable = TRUE
+	explo_proof = TRUE
 
 /obj/item/weapon/gun/pistol/heavy/co/set_gun_config_values()
 	..()

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -598,6 +598,7 @@
 	)
 	starting_attachment_types = list(/obj/item/attachable/mateba)
 	unacidable = TRUE
+	explo_proof = TRUE
 	black_market_value = 100
 	var/is_locked = TRUE
 	var/can_change_barrel = TRUE


### PR DESCRIPTION
# About the pull request

Title

# Explain why it's good for the game

COs really shouldn't be losing these things. Just because it's unlikely that a BE would happen doesn't mean you should be locked out of it for the round.

Just so we are clear, the Mateba has always never been able to be melted, this just standardizes the logic.


# Testing Photographs and Procedure

Line change, should work

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: CO Pistols no longer get melted or blown up.
/:cl:
