### PR TITLE
ignore mouse 4/5

### DIFF
--- a/code/__DEFINES/_click.dm
+++ b/code/__DEFINES/_click.dm
@@ -10,6 +10,9 @@
 ///if(modifiers[BUTTON] == LEFT_CLICK)
 #define BUTTON "button"
 
+#define BUTTON4 "xbutton1"
+#define BUTTON5 "xbutton2"
+
 //Keys held down during the mouse action
 #define CTRL_CLICK "ctrl"
 #define ALT_CLICK "alt"
@@ -37,6 +40,6 @@
 #define SCREEN_LOC "screen-loc"
 
 /// From /mob/proc/click_adjacent() : (atom/A, obj/item/W, mods) makes it so the affterattack proc isn't called
-#define ATTACKBY_HINT_NO_AFTERATTACK (1 << 0) 
+#define ATTACKBY_HINT_NO_AFTERATTACK (1 << 0)
 /// From /mob/proc/click_adjacent() : (atom/A, obj/item/W, mods) applies the click delay to next_move
 #define ATTACKBY_HINT_UPDATE_NEXT_MOVE (1 << 1)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -82,8 +82,10 @@
 		return
 
 	face_atom(A)
-	if(mods["middle"])
+
+	if(mods[MIDDLE_CLICK] || mods[BUTTON4] || mods[BUTTON5])
 		return
+
 	// Special type of click.
 	if (is_mob_restrained())
 		RestrainedClickOn(A)


### PR DESCRIPTION
516 finally implemented mouse 4/5 correctly, but we assume that every click is always this

closes #8873

eventually we should make this rebindable to stuff but uhh not today man

:cl:
fix: mouse 4/5 presses no longer count as mouse 1 presses
/:cl: