### PR TITLE
Impact ammo changes for scout

### DIFF
--- a/code/datums/ammo/bullet/rifle.dm
+++ b/code/datums/ammo/bullet/rifle.dm
@@ -179,8 +179,8 @@
 	if(iscarbonsizexeno(living_mob))
 		var/mob/living/carbon/xenomorph/target = living_mob
 		to_chat(target, SPAN_XENODANGER("You are shaken by the sudden impact!"))
-		target.KnockDown(0.5-fired_projectile.distance_travelled/200) // purely for visual effect, noone actually cares
-		target.Stun(0.5-fired_projectile.distance_travelled/200)
+		target.KnockDown(0.5-fired_projectile.distance_travelled/100) // purely for visual effect, noone actually cares
+		target.Stun(0.5-fired_projectile.distance_travelled/100)
 	else
 		if(!isyautja(living_mob)) //Not predators.
 			living_mob.apply_effect(0.5, SUPERSLOW)

--- a/code/datums/ammo/bullet/rifle.dm
+++ b/code/datums/ammo/bullet/rifle.dm
@@ -140,7 +140,6 @@
 	shrapnel_chance = 0
 	damage_falloff = 0
 	flags_ammo_behavior = AMMO_BALLISTIC
-	accurate_range_min = 4
 
 	damage = 55
 	scatter = -SCATTER_AMOUNT_TIER_8
@@ -170,7 +169,7 @@
 	damage = 40
 	accuracy = -HIT_ACCURACY_TIER_2
 	scatter = -SCATTER_AMOUNT_TIER_8
-	penetration = ARMOR_PENETRATION_TIER_10
+	penetration = ARMOR_PENETRATION_TIER_5
 	shell_speed = AMMO_SPEED_TIER_6
 
 /datum/ammo/bullet/rifle/m4ra/impact/on_hit_mob(mob/M, obj/projectile/P)
@@ -179,15 +178,13 @@
 /datum/ammo/bullet/rifle/m4ra/impact/knockback_effects(mob/living/living_mob, obj/projectile/fired_projectile)
 	if(iscarbonsizexeno(living_mob))
 		var/mob/living/carbon/xenomorph/target = living_mob
-		to_chat(target, SPAN_XENODANGER("You are shaken and slowed by the sudden impact!"))
-		target.KnockDown(0.5-fired_projectile.distance_travelled/100) // purely for visual effect, noone actually cares
-		target.Stun(0.5-fired_projectile.distance_travelled/100)
-		target.apply_effect(2-fired_projectile.distance_travelled/20, SUPERSLOW)
-		target.apply_effect(5-fired_projectile.distance_travelled/10, SLOW)
+		to_chat(target, SPAN_XENODANGER("You are shaken by the sudden impact!"))
+		target.KnockDown(0.5-fired_projectile.distance_travelled/200) // purely for visual effect, noone actually cares
+		target.Stun(0.5-fired_projectile.distance_travelled/200)
 	else
 		if(!isyautja(living_mob)) //Not predators.
-			living_mob.apply_effect(1, SUPERSLOW)
-			living_mob.apply_effect(2, SLOW)
+			living_mob.apply_effect(0.5, SUPERSLOW)
+			living_mob.apply_effect(1, SLOW)
 			to_chat(living_mob, SPAN_HIGHDANGER("The impact knocks you off-balance!"))
 		living_mob.apply_stamina_damage(fired_projectile.ammo.damage, fired_projectile.def_zone, ARMOR_BULLET)
 

--- a/code/datums/ammo/bullet/rifle.dm
+++ b/code/datums/ammo/bullet/rifle.dm
@@ -179,8 +179,8 @@
 	if(iscarbonsizexeno(living_mob))
 		var/mob/living/carbon/xenomorph/target = living_mob
 		to_chat(target, SPAN_XENODANGER("You are shaken by the sudden impact!"))
-		target.KnockDown(0.5-fired_projectile.distance_travelled/100) // purely for visual effect, noone actually cares
-		target.Stun(0.5-fired_projectile.distance_travelled/100)
+		target.KnockDown(0.5-fired_projectile.distance_travelled/50) // purely for visual effect, noone actually cares
+		target.Stun(0.5-fired_projectile.distance_travelled/50)
 	else
 		if(!isyautja(living_mob)) //Not predators.
 			living_mob.apply_effect(0.5, SUPERSLOW)


### PR DESCRIPTION

# About the pull request
Stun time reduced over distance, slowdown reduced for humans, slowdown removed for xenos, AP values reduced to incendiary levels
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Scout is good, very good, if you aren't running up to doors without a clue whats behind it then realistically you can avoid 9/10 fights you don't want to take, add onto this a very powerful gun then it becomes insanely good.

As it stands the solution people give for scouts is have someone near you, only that its a bad faith answer considering the fact scouts can 1v2 depending on castes, this is due to the fact that stun time barely changes for on screen mobs and superslow is applied to those hit, leaving them borderline immobile allowing the scout to just switch between targets and kill both. 

Yes scout should be strong due to the risks they can choose to take, however I feel like they should have to commit more to a fight and be less effective shooting at range to allow those stunlocked to escape should other xenos push scout away.

On paper scout should still be able to 1v1 xenos and have the edge, just that 1 landed hit doesn't ensure victory and they will have to be within closer proximity to the xeno to avoid them escaping.

AP being brought down because this is not a sniper caliber, it does not need 50 AP.

for anyone saying cope pr this is from experience as scout, its stupid as is.
https://imgur.com/Mp6GqMT

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
balance: M4RA custom impact ammo no longer slows xenos, stuns reduced over range, AP brought down to that of incendiary ammo
/:cl:

