### PR TITLE
This PR fixes broken buttons on LV522 and provides more equipment to the area between dorms and sec

### DIFF
--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -605,6 +605,14 @@
 	},
 /turf/open/floor/corsat/squares,
 /area/lv522/atmos/east_reactor/south)
+"aco" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_magazine/rifle/ap,
+/turf/open/floor/prison/darkredfull2,
+/area/lv522/outdoors/colony_streets/north_street)
 "acp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
@@ -690,6 +698,35 @@
 "acK" = (
 /turf/open/floor/prison/floor_plate,
 /area/lv522/outdoors/colony_streets/central_streets)
+"acL" = (
+/obj/item/ammo_magazine/rifle/ap,
+/turf/open/asphalt/cement/cement1,
+/area/lv522/outdoors/colony_streets/north_street)
+"acM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_magazine/rifle/ap,
+/turf/open/asphalt/cement/cement3,
+/area/lv522/outdoors/colony_streets/north_street)
+"acN" = (
+/obj/item/ammo_magazine/rifle/extended,
+/turf/open/asphalt/cement/cement1,
+/area/lv522/outdoors/colony_streets/north_street)
+"acO" = (
+/obj/item/ammo_magazine/rifle/ap,
+/turf/open/asphalt/cement/cement4,
+/area/lv522/outdoors/colony_streets/north_street)
+"acP" = (
+/obj/structure/machinery/door_control/brbutton{
+	id = "Reactor_e_entry_3"
+	},
+/turf/closed/wall/strata_outpost/reinforced,
+/area/lv522/atmos/east_reactor/south)
+"acQ" = (
+/obj/structure/machinery/door_control/brbutton{
+	id = "Reactor_e_entry_4"
+	},
+/turf/closed/wall/strata_outpost/reinforced,
+/area/lv522/atmos/filt)
 "adk" = (
 /obj/structure/surface/table/almayer,
 /obj/item/trash/plate,
@@ -1774,6 +1811,7 @@
 /area/lv522/indoors/a_block/medical)
 "aQf" = (
 /obj/structure/surface/table/almayer,
+/obj/item/ammo_magazine/rifle/extended,
 /turf/open/asphalt/cement/cement3,
 /area/lv522/outdoors/colony_streets/north_street)
 "aQs" = (
@@ -8248,6 +8286,7 @@
 /obj/structure/barricade/metal{
 	dir = 1
 	},
+/obj/item/ammo_magazine/rifle/ap,
 /turf/open/floor/prison/darkredfull2,
 /area/lv522/outdoors/colony_streets/north_street)
 "eov" = (
@@ -10036,12 +10075,6 @@
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/outdoors/colony_streets/central_streets)
 "fts" = (
-/obj/structure/machinery/door_display/research_cell{
-	dir = 8;
-	id = "Reactor_entry_2";
-	pixel_x = 16;
-	req_access = null
-	},
 /obj/item/prop/alien/hugger,
 /obj/structure/machinery/light{
 	dir = 1
@@ -11973,15 +12006,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/corsat/plate,
 /area/lv522/atmos/reactor_garage)
-"gzF" = (
-/obj/structure/machinery/door_display/research_cell{
-	dir = 4;
-	id = "Reactor_e_entry_4";
-	pixel_x = -16;
-	req_access = null
-	},
-/turf/open/asphalt/cement/cement1,
-/area/lv522/atmos/filt)
 "gzS" = (
 /obj/structure/pipes/unary/freezer{
 	dir = 1;
@@ -12499,15 +12523,6 @@
 /obj/item/reagent_container/spray/cleaner,
 /turf/open/floor/prison/darkredfull2,
 /area/lv522/indoors/a_block/security/glass)
-"gOG" = (
-/obj/structure/machinery/door_display/research_cell{
-	dir = 4;
-	id = "Reactor_e_entry_3";
-	pixel_x = -16;
-	req_access = null
-	},
-/turf/open/floor/corsat/brown,
-/area/lv522/atmos/filt)
 "gOJ" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -18231,7 +18246,7 @@
 /turf/open/floor/prison/darkredfull2,
 /area/lv522/outdoors/colony_streets/north_street)
 "jUg" = (
-/obj/item/ammo_box/magazine/l42a/ap/empty,
+/obj/item/ammo_box/magazine/l42a/ap,
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/security)
 "jUk" = (
@@ -25821,7 +25836,7 @@
 "nMt" = (
 /obj/structure/surface/table/almayer,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/ammo_box/magazine/l42a,
+/obj/item/ammo_box/magazine/l42a/ext,
 /turf/open/floor/prison/darkredfull2,
 /area/lv522/indoors/a_block/security)
 "nMv" = (
@@ -27835,7 +27850,7 @@
 /turf/open/floor/strata/white_cyan2,
 /area/lv522/indoors/a_block/dorms)
 "oMX" = (
-/obj/item/storage/belt/grenade,
+/obj/item/storage/belt/grenade/full,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/lv522/outdoors/colony_streets/north_street)
@@ -31408,6 +31423,9 @@
 /turf/open/floor/strata/white_cyan2,
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "qHD" = (
+/obj/structure/machinery/door_control/brbutton{
+	id = "Reactor_entry_2"
+	},
 /turf/closed/wall/r_wall/biodome/biodome_unmeltable,
 /area/lv522/atmos/way_in_command_centre)
 "qHI" = (
@@ -62078,7 +62096,7 @@ nQk
 rYu
 siB
 hqB
-oXd
+acM
 nXM
 sjb
 biZ
@@ -62288,7 +62306,7 @@ rah
 lmW
 cVR
 iRW
-ovC
+aco
 szh
 rLk
 epe
@@ -63104,7 +63122,7 @@ fjr
 fjr
 fGw
 lHk
-nRK
+acO
 ksO
 qFc
 vBV
@@ -63313,10 +63331,10 @@ gwH
 hhD
 jYc
 hhD
-jYc
+acN
 sPU
 pUf
-hhD
+acL
 hhD
 vqF
 muB
@@ -75015,7 +75033,7 @@ xZE
 xZE
 xZE
 xZE
-xZE
+acP
 gRV
 gRV
 gRV
@@ -75221,7 +75239,7 @@ cpy
 cpy
 xZE
 eWn
-gOG
+gUv
 sYl
 sYl
 sYl
@@ -76251,7 +76269,7 @@ cpy
 cpy
 cpy
 shD
-shD
+acQ
 fzK
 fzK
 fzK
@@ -76457,7 +76475,7 @@ cpy
 cpy
 cpy
 acG
-gzF
+acG
 acG
 acG
 acG


### PR DESCRIPTION

# About the pull request

PR title

Items added
GL belt replaced with GL belt (full)
x4 M41A mk2 AP magazines
x1 M41A mk2 Ext magazine
L42A AP magazine box (empty) replaced with L42A AP full
L42A magazine box (empty) replaced with L42A ext magazine box, full

# Explain why it's good for the game
bugfix is a bugfix this area was lacking in the equipment side of things should help FORECON out a tiny bit while I think about a better system for loot

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:SpartanBobby
maptweak: Fixes bugs in LV522 buttons, adds more ammo
/:cl:
