### PR TITLE
Latejoins now keep the same ratio of marines to xenomorphs

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -179,7 +179,6 @@
 
 	if(latejoin_larva_drop && SSticker.mode.latejoin_tally - SSticker.mode.latejoin_larva_used >= latejoin_larva_drop)
 		SSticker.mode.latejoin_larva_used += latejoin_larva_drop
-		var/datum/hive_status/hive
 		for(var/hivenumber in GLOB.hive_datum)
 			hive = GLOB.hive_datum[hivenumber]
 			if(hive.latejoin_burrowed == TRUE)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -149,7 +149,30 @@
 			target_squad.roles_cap[JOB_SQUAD_ENGI] = engi_slot_formula(length(GLOB.clients))
 			target_squad.roles_cap[JOB_SQUAD_MEDIC] = medic_slot_formula(length(GLOB.clients))
 
+	var/humans_weighed
+	var/xenos_weighed
+
+	for(var/mob/living/carbon/human/current_human as anything in GLOB.alive_human_list)
+		if(!(isspecieshuman(current_human) || isspeciessynth(current_human)))
+			continue
+		var/datum/job/job = GLOB.RoleAuthority.roles_for_mode[current_human.job]
+		if(!job)
+			continue
+
+		humans_weighed += GLOB.RoleAuthority.calculate_role_weight(job)
+
+	var/datum/hive_status/hive = GLOB.hive_datum[XENO_HIVE_NORMAL]
+	if(istype(hive))
+		for(var/mob/living/carbon/xenomorph/current_xeno as anything in hive.totalXenos)
+			if(isfacehugger(current_xeno) || islesserdrone(current_xeno))
+				continue
+
+			xenos_weighed += 1
+
 	var/latejoin_larva_drop = SSticker.mode.latejoin_larva_drop
+
+	if(xenos_weighed && humans_weighed)
+		latejoin_larva_drop = humans_weighed / xenos_weighed // Keep the same ratio between xenos and marines as people latejoin
 
 	if (ROUND_TIME < XENO_ROUNDSTART_PROGRESS_TIME_2)
 		latejoin_larva_drop = SSticker.mode.latejoin_larva_drop_early


### PR DESCRIPTION

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
How latejoining currently works is that every "combat" role is worth 1 latejoin and every "shipside" role is worth 0.25 latejoins,
Before 20 minutes every 4 latejoins give 1 larva and after that it is 2.5 latejoins for 1 larva.

The problem: Over the course of long rounds latejoins can tip the scales numbers wise significantly and turn either side from losing to winning

The solution: Making latejoins keep the same ratio of marines to xenos so if there are more xenos compared to marines they will get more larvae and vice versa (This keeps the static 1:4 ratio before 20 mins and 0.25 value of shipside roles)
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Latejoins now keep the same ratio of marines to xenomorphs instead of being a static 2.5
/:cl:
