### PR TITLE
Adds logging for joining as facehugger or lesser

### DIFF
--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -731,6 +731,8 @@ Additional game mode variables.
 		var/obj/effect/alien/resin/special/eggmorph/morpher = facehugger_choice
 		morpher.join_as_facehugger_from_this(xeno_candidate)
 
+	msg_admin_niche("[xeno_candidate.key] has joined as a facehugger.")
+
 	return TRUE
 
 /datum/game_mode/proc/attempt_to_join_as_lesser_drone(mob/xeno_candidate)
@@ -787,6 +789,8 @@ Additional game mode variables.
 	var/obj/effect/alien/resin/special/pylon/selected_structure = selection_list_structure[selection_list.Find(prompt)]
 
 	selected_structure.spawn_lesser_drone(xeno_candidate)
+
+	msg_admin_niche("[xeno_candidate.key] has joined as a lesser drone.")
 
 	return TRUE
 


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Already exists for normal xenos, was missing for lessers and huggers
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
admin: Added logging for joing as facehugger or lesser drone
/:cl:
