### PR TITLE
Attempts to fix permanent zoom, 2025 edition

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -201,6 +201,11 @@
 	if(ismob(loc))
 		dropped(loc)
 
+	if(zoom)
+		for(var/mob/living/user in viewers(src, GLOB.world_view_size))
+			if(user.client && user.interactee == src) // user.interactee is necessary here to prevent everyone else zooming in from being unzoomed
+				unzoom(user)
+
 	return ..()
 
 /obj/item/ex_act(severity, explosion_direction)

--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -11,7 +11,6 @@
 	force = 5
 	w_class = SIZE_SMALL
 	throwforce = 5
-	throw_range = 15
 	throw_speed = SPEED_VERY_FAST
 	/// If FALSE won't change icon_state to a camo marine bino.
 	var/uses_camo = TRUE
@@ -232,7 +231,7 @@
 
 	data["xcoord"] = src.last_x
 	data["ycoord"] = src.last_y
-	data["zcoord"] = src.last_z 
+	data["zcoord"] = src.last_z
 
 	return data
 
@@ -551,7 +550,6 @@
 	force = 5
 	w_class = SIZE_SMALL
 	throwforce = 5
-	throw_range = 15
 	throw_speed = SPEED_VERY_FAST
 	var/atom/target = null // required for lazing at things.
 	var/las_r = 0 //Red Laser, Used to Replace the IR. 0 is not active, 1 is cool down, 2 is actively Lazing the target


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Title. 
Honest to god I really shouldn't have wasted my time on this niche ass bug.

# Explain why it's good for the game

Rather than using signals like what morrow attempted, checks instead for zoom in the destroy proc and attempts to unzoom the user before qdeleting.

user.interactee is still gonna return null but I think thats gonna be a permanent problem.

Also fixes binocular throw range, while funny, is still a bug.
Would not want to throw my binoculars to a group of bugs 1 screen away.


# Testing Photographs and Procedure
By God I hope it works.

I've looped around 200 HE OBs trying to replicate this bug.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Attempts to fix permanent zoom bugs once more.
fix: Fixes binocular throw range.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
