### PR TITLE
[CONFIG] Block nuclear device invocation until marines still alive.

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -135,6 +135,6 @@
 
 /datum/config_entry/number/nuclear_lock_marines_percentage
 	min_val = 0
-	config_entry_value = 50	// Type 0 to disable lock
+	config_entry_value = 0	// Type 0 to disable lock
 	max_val = 100
 	integer = TRUE

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -132,3 +132,9 @@
 	min_val = 0
 	config_entry_value = 140
 	integer = TRUE
+
+/datum/config_entry/number/nuclear_lock_marines_percentage
+	min_val = 0
+	config_entry_value = 50	// Type 0 to disable lock
+	max_val = 100
+	integer = TRUE

--- a/code/game/machinery/ARES/ARES_interface.dm
+++ b/code/game/machinery/ARES/ARES_interface.dm
@@ -431,6 +431,14 @@
 				to_chat(user, SPAN_WARNING("The ordnance request frequency is garbled, wait for reset!"))
 				playsound(src, 'sound/machines/buzz-two.ogg', 15, 1)
 				return FALSE
+			var/nuclear_lock = CONFIG_GET(number/nuclear_lock_marines_percentage)
+			if(nuclear_lock > 0 && nuclear_lock != 100)
+				var/marines_count = SSticker.mode.count_marines() // Counting marines on land and on the ship
+				var/marines_peak = GLOB.peak_humans * nuclear_lock / 100
+				if(marines_count >= marines_peak)
+					to_chat(user, SPAN_WARNING("There are still too many Marines and USCM crew alive on this operation!"))
+					playsound(src, 'sound/machines/buzz-two.ogg', 15, 1)
+					return FALSE
 			if(GLOB.security_level == SEC_LEVEL_DELTA || SSticker.mode.is_in_endgame)
 				to_chat(user, SPAN_WARNING("The mission has failed catastrophically, what do you want a nuke for?!"))
 				playsound(src, 'sound/machines/buzz-two.ogg', 15, 1)

--- a/code/modules/cm_tech/techs/marine/tier4/nuke.dm
+++ b/code/modules/cm_tech/techs/marine/tier4/nuke.dm
@@ -44,7 +44,7 @@
 		var/marines_count = SSticker.mode.count_marines() // Counting marines on land and on the ship
 		var/marines_peak = GLOB.peak_humans * nuclear_lock / 100
 		if(marines_count >= marines_peak)
-			to_chat(user, SPAN_WARNING("You cannot purchase this while there are more than [marines_peak] Marines and USCM crew alive on this operation."))
+			to_chat(unlocking_mob, SPAN_WARNING("You cannot purchase this while there are more than [marines_peak] Marines and USCM crew alive on this operation."))
 			return FALSE
 
 	return TRUE

--- a/code/modules/cm_tech/techs/marine/tier4/nuke.dm
+++ b/code/modules/cm_tech/techs/marine/tier4/nuke.dm
@@ -44,7 +44,7 @@
 		var/marines_count = SSticker.mode.count_marines() // Counting marines on land and on the ship
 		var/marines_peak = GLOB.peak_humans * nuclear_lock / 100
 		if(marines_count >= marines_peak)
-			to_chat(unlocking_mob, SPAN_WARNING("You cannot purchase this while there are more than [marines_peak] Marines and USCM crew alive on this operation."))
+			to_chat(unlocking_mob, SPAN_WARNING("You cannot purchase this while there are more than [nuclear_lock]% Marines and USCM crew alive on this operation."))
 			return FALSE
 
 	return TRUE

--- a/code/modules/cm_tech/techs/marine/tier4/nuke.dm
+++ b/code/modules/cm_tech/techs/marine/tier4/nuke.dm
@@ -39,6 +39,14 @@
 		to_chat(unlocking_mob, SPAN_WARNING("You cannot purchase this node before [ceil((NUKE_UNLOCK_TIME + SSticker.round_start_time) / (1 MINUTES))] minutes into the operation."))
 		return FALSE
 
+	var/nuclear_lock = CONFIG_GET(number/nuclear_lock_marines_percentage)
+	if(nuclear_lock > 0 && nuclear_lock != 100)
+		var/marines_count = SSticker.mode.count_marines() // Counting marines on land and on the ship
+		var/marines_peak = GLOB.peak_humans * nuclear_lock / 100
+		if(marines_count >= marines_peak)
+			to_chat(user, SPAN_WARNING("You cannot purchase this while there are more than [marines_peak] Marines and USCM crew alive on this operation."))
+			return FALSE
+
 	return TRUE
 
 /datum/tech/nuke/proc/handle_description()

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -58,3 +58,6 @@ ANIMAL_DELAY 0
 
 ## Remove the # in front of this config option to have loyalty implants spawn by default on your server.
 #USE_LOYALTY_IMPLANTS
+
+## Block nuclear device invocation until more marines than this percentage are alive. (0-100)
+nuclear_lock_marines_percentage

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -60,4 +60,4 @@ ANIMAL_DELAY 0
 #USE_LOYALTY_IMPLANTS
 
 ## Block nuclear device invocation until more marines than this percentage are alive. (0-100)
-nuclear_lock_marines_percentage 50
+nuclear_lock_marines_percentage 0

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -60,4 +60,4 @@ ANIMAL_DELAY 0
 #USE_LOYALTY_IMPLANTS
 
 ## Block nuclear device invocation until more marines than this percentage are alive. (0-100)
-nuclear_lock_marines_percentage
+nuclear_lock_marines_percentage 50


### PR DESCRIPTION
# About the pull request
Sometimes there are situations where there are enough combat marines on the ground and they decide to call in a nuke too early instead of finishing off the xenomorphs. We now stop the command in such cases so that they lead the marines instead of wanting to abruptly end the game.

# Explain why it's good for the game
Through the config you can control what percentage of marines you want in the game.

# Test
Was tested on BandaMarines (https://github.com/ss220club/BandaMarines/pull/242).
Works fine. 

# Changelog

:cl:
config: Add to Config - Block nuclear device invocation until more marines than this percentage are alive. (0-100)
/:cl:
