### PR TITLE
colony boozeomats no longer spawn full

### DIFF
--- a/code/game/machinery/vending/vendor_types/food.dm
+++ b/code/game/machinery/vending/vendor_types/food.dm
@@ -107,6 +107,32 @@
 		list("Vacuum Flask", 5, /obj/item/reagent_container/food/drinks/flask/vacuumflask, VENDOR_ITEM_REGULAR)
 	)
 
+/obj/structure/machinery/cm_vending/sorted/boozeomat/populate_product_list_and_boxes(scale)
+	. = ..()
+
+	// If this is groundside and isn't dynamically changing we will spawn with stock randomly removed from it
+	if(vend_flags & VEND_STOCK_DYNAMIC)
+		return
+	if(Check_WO())
+		return
+	var/turf/location = get_turf(src)
+	if(location && is_ground_level(location.z))
+		random_unstock()
+
+/// Randomly removes amounts of listed_products and reagents
+/obj/structure/machinery/cm_vending/sorted/boozeomat/proc/random_unstock()
+	for(var/list/vendspec as anything in listed_products)
+		var/amount = vendspec[2]
+		if(amount <= 0)
+			continue
+
+		// Chance to just be empty
+		if(prob(25))
+			vendspec[2] = 0
+			continue
+
+		// Otherwise its some amount between 1 and the original amount
+		vendspec[2] = rand(1, 3)
 
 /obj/structure/machinery/cm_vending/sorted/boozeomat/chess
 	name = "\improper Chess-O-Mat"


### PR DESCRIPTION
# About the pull request

colony side boozeomats now use the same system as weymeds to randomly unstock some of their contents

part of the atomization of #8373 
# Explain why it's good for the game

part of the reason molotov spam is so bad right now is that for flavor reasons we have like 90000 types of booze in the vendor each with a few bottles, reducing the count of bottles in the vendor reduces the amount of molotovs that can be made and nudges survivors towards thinking about when and where to use them.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/6453e64d-d0f7-47d4-b080-d0cc55d29e26)

</details>


# Changelog
:cl:
balance: colony boozeomats are no longer always full
/:cl:

