### PR TITLE
annoying messy throwables

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -303,6 +303,9 @@ Contains most of the procs that are called when a mob is attacked by something
 	var/obj/limb/affecting = get_limb(zone)
 	var/hit_area = affecting.display_name
 
+	if (istype(O, /obj/item/reagent_container/food/snacks/grown/tomato) || (istype(O, /obj/item/reagent_container/food/snacks/egg))) //if the object is messy, large message
+		to_chat(src, SPAN_HIGHDANGER("The [O] splats messily on your [hit_area]!"))
+
 	src.visible_message(SPAN_DANGER("[src] has been hit in the [hit_area] by [O]."), null, null, 5)
 
 	var/armor = getarmor(affecting, ARMOR_MELEE)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -304,7 +304,7 @@ Contains most of the procs that are called when a mob is attacked by something
 	var/hit_area = affecting.display_name
 
 	if (istype(O, /obj/item/reagent_container/food/snacks/grown/tomato) || (istype(O, /obj/item/reagent_container/food/snacks/egg))) //if the object is messy, large message
-		to_chat(src, SPAN_HIGHDANGER("The [O] splats messily on your [hit_area]!"))
+		to_chat(src, SPAN_HIGHDANGER("\The [O] splats messily on your [hit_area]!"))
 
 	src.visible_message(SPAN_DANGER("[src] has been hit in the [hit_area] by [O]."), null, null, 5)
 


### PR DESCRIPTION
# About the pull request

makes getting hit by eggs and tomatoes more annoying by showing a more distinct chat message to the target (HIGHDANGER)

# Explain why it's good for the game

higher rp needs more RP opportunities
getting hit by eggs and tomatoes was almost unnoticeable previously

# Testing Photographs and Procedure
![image](https://github.com/user-attachments/assets/6faef3f9-ddfe-4d66-b94d-bc428f947cc8)

now:
![image](https://github.com/user-attachments/assets/13a9f0c6-8101-48e3-9d0d-79c3605eba4a)

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Zaniff
add: getting hit by eggs and tomatoes is now more annoying
/:cl:
