### PR TITLE
Fix non-weapon weapons: They don't get fire mission offsets

### DIFF
--- a/tgui/packages/tgui/interfaces/MfdPanels/FiremissionPanel.tsx
+++ b/tgui/packages/tgui/interfaces/MfdPanels/FiremissionPanel.tsx
@@ -374,7 +374,7 @@ const OffsetDetailed = (
     readonly equipment: DropshipEquipment;
   },
 ) => {
-  const availableGimbals = gimbals[props.equipment.mount_point];
+  const availableGimbals = gimbals[props.equipment.mount_point] ?? gimbals[0];
   const weaponFm = props.fm.records.find(
     (x) => x.weapon === props.equipment.mount_point,
   );
@@ -455,7 +455,7 @@ const FMOffsetStack = (
   )?.offsets;
 
   const { editFm } = fmEditState(props.panelStateId);
-  const availableGimbals = gimbals[props.equipment.mount_point];
+  const availableGimbals = gimbals[props.equipment.mount_point] ?? gimbals[0];
 
   const firemissionOffsets = props.equipment.firemission_delay ?? 0;
 


### PR DESCRIPTION
# About the pull request

This PR adds a fallback to weapons trying to load gimbals that are undefined. In this situation a `/obj/structure/dropship_equipment/weapon/launch_bay` doesn't get equipped to a weapon mount point so it uses mount points that didn't have gimbal offsets defined. Now the default gimbal offset will be used in the situation where a weapon is using a mount point that has no defined offsets. Effectively this means it cannot be used in a fire mission - though it is still displayed in the FM panel since it is a weapon.

# Explain why it's good for the game

Fixes #8863 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/7caea109-268a-4224-91a2-294d72b8a5e8)

</details>


# Changelog
:cl: Drathek
fix: Dropship equipment weapons that aren't in a weapon slot now get defaulted gimbal offsets (none) instead of crashing
/:cl:
