### PR TITLE
Tweak Ping Browser Gauges

### DIFF
--- a/tgui/packages/tgui/interfaces/PingRelaysPanel.tsx
+++ b/tgui/packages/tgui/interfaces/PingRelaysPanel.tsx
@@ -146,7 +146,8 @@ class PingApp extends Component<PingAppProps> {
                       value={result.ping}
                       maxValue={1000}
                       minValue={50}
-                      minWidth={4}
+                      minWidth={3.8}
+                      pr={1}
                       ranges={{
                         good: [0, 200],
                         average: [200, 500],


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #5777 where 516 seems to have caused the gauges to become slightly larger than I would like.

# Explain why it's good for the game

Looks a little less wonky.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

150% scaling using small pref:
![image](https://github.com/user-attachments/assets/3452b8a6-797d-4f66-b12b-392f714d2ad5)

100% scaling: 
![image](https://github.com/user-attachments/assets/2cbc1527-6142-4beb-b80d-896af099f6da)


</details>


# Changelog
:cl: Drathek
ui: Tweaked the size of gauges in the ping relay browser
/:cl:
