### PR TITLE
fixes nuke spawning

### DIFF
--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -501,10 +501,10 @@
 /client/proc/give_nuke()
 	if(!check_rights(R_ADMIN))
 		return
-	var/nukename = "Decrypted Operational Nuke"
+	var/nukename = "Decrypted Operational Blockbuster"
 	var/encrypt = tgui_alert(src, "Do you want the nuke to be already decrypted?", "Nuke Type", list("Encrypted", "Decrypted"), 20 SECONDS)
 	if(encrypt == "Encrypted")
-		nukename = "Encrypted Operational Nuke"
+		nukename = "Encrypted Operational Blockbuster"
 	var/prompt = tgui_alert(src, "THIS CAN BE USED TO END THE ROUND. Are you sure you want to spawn a nuke? The nuke will be put onto the ASRS Lift.", "DEFCON 1", list("No", "Yes"), 30 SECONDS)
 	if(prompt != "Yes")
 		return

--- a/code/modules/admin/topic/topic.dm
+++ b/code/modules/admin/topic/topic.dm
@@ -2005,10 +2005,10 @@
 		var/mob/ref_person = locate(href_list["nukeapprove"])
 		if(!istype(ref_person))
 			return FALSE
-		var/nukename = "Encrypted Operational Nuke"
+		var/nukename = "Encrypted Operational Blockbuster"
 		var/prompt = tgui_alert(usr, "Do you want the nuke to be Encrypted?", "Nuke Type", list("Encrypted", "Decrypted"), 20 SECONDS)
 		if(prompt == "Decrypted")
-			nukename = "Decrypted Operational Nuke"
+			nukename = "Decrypted Operational Blockbuster"
 		prompt = tgui_alert(usr, "Are you sure you want to authorize '[nukename]' to the marines? This will greatly affect the round!", "DEFCON 1", list("No", "Yes"))
 		if(prompt != "Yes")
 			return

--- a/code/modules/cm_tech/techs/marine/tier4/nuke.dm
+++ b/code/modules/cm_tech/techs/marine/tier4/nuke.dm
@@ -22,7 +22,7 @@
 
 	var/datum/supply_order/new_order = new()
 	new_order.ordernum = GLOB.supply_controller.ordernum++
-	var/actual_type = GLOB.supply_packs_types["Encrypted Operational Nuke"]
+	var/actual_type = GLOB.supply_packs_types["Encrypted Operational Blockbuster"]
 	new_order.objects = list(GLOB.supply_packs_datums[actual_type])
 	new_order.orderedby = MAIN_AI_SYSTEM
 	new_order.approvedby = MAIN_AI_SYSTEM


### PR DESCRIPTION

# About the pull request

#8351 renamed nukes, some backend stuff relied on the old name, so it was causing a runtime that was making the nuke not spawn when purchased. This fixes it.

# Explain why it's good for the game

bug, see above


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>


</details>


# Changelog

:cl:
fix: nukes can be bought again
/:cl:

