### PR TITLE
Revert "Universal speak works now. (#8868)"

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -104,19 +104,29 @@
 		langchat_speech(message, langchat_listeners, GLOB.all_languages, skip_language_check = TRUE)
 
 /mob/proc/say_understands(mob/other, datum/language/speaking = null)
-	if(stat == DEAD) //Dead
-		return TRUE
+	if (src.stat == 2) //Dead
+		return 1
 
-	if(universal_understand)
-		return TRUE
-	if(other?.universal_speak)
-		return TRUE
+	//Universal speak makes everything understandable, for obvious reasons.
+	else if(src.universal_speak || src.universal_understand)
+		return 1
+
+	//Languages are handled after.
+	if (!speaking)
+		if(!other)
+			return 1
+		if(other.universal_speak)
+			return 1
+		if (istype(other, src.type) || istype(src, other.type))
+			return 1
+		return 0
+
 	//Language check.
-	for(var/datum/language/L in languages)
-		if(speaking?.name == L.name)
-			return TRUE
+	for(var/datum/language/L in src.languages)
+		if(speaking.name == L.name)
+			return 1
 
-	return FALSE
+	return 0
 
 /*
 ***Deprecated***


### PR DESCRIPTION
This reverts commit b46ee09facc4b127a5c62e1b73ed16532ed7c834.
# About the pull request

tm until fixed, it bricks names in chat

![dreamseeker_pjAWesdjrI](https://github.com/user-attachments/assets/cc3280b5-1bf3-43cc-8ec1-6a501cd96c27)


# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: reverted bug thing
/:cl:
