### PR TITLE
[FIX] Buckled mob no longer gets bugged when walking on a trap

### DIFF
--- a/code/modules/cm_aliens/structures/trap.dm
+++ b/code/modules/cm_aliens/structures/trap.dm
@@ -344,6 +344,16 @@
 	..()
 
 /obj/effect/alien/resin/trap/Crossed(atom/A)
+	if((isStructure(A) && istype(A, /obj/structure/bed)) || (isVehicle(A) && !isVehicleMultitile(A)))
+		if(O.buckled_mob)
+			var/mob/living/M = O.buckled_mob
+			O.unbuckle()
+			M.forceMove(get_turf(O))
+			HasProximity(M)
+			to_chat(M, SPAN_XENOHIGHDANGER("You've fallen into a pit full of resin!"))
+	if(trap_type == RESIN_TRAP_EMPTY)
+		return
+
 	if(ismob(A) || isVehicleMultitile(A))
 		HasProximity(A)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

There was a situation where if a MOB was riding a wheelchair, a Souto-mobile or any other "bed" based ride (like a wheeled chair or a medical wheelchair), then riding it would trigger a bug.

The bug is that you continue to control the vehicle (not the multiz vehicle), even if the trap has hooked you.
Now getting into a "hole" throws you off and punishes you.

# Explain why it's good for the game

Fixes are good.
No more abuse on strollers and chairs.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>
Fixed:

![image](https://github.com/user-attachments/assets/c96e1675-372b-428c-a366-72945878fcc4)

![image](https://github.com/user-attachments/assets/6a8a1c4d-a6d3-4327-8061-d597702d2e2b)

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Traps now activate correctly on buckled_mob
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
