### PR TITLE
Removes explosive implant case from new varadero

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/king/king_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/king/king_abilities.dm
@@ -29,7 +29,7 @@
 	name = "Destroy"
 	action_icon_state = "charge"
 	macro_path = /datum/action/xeno_action/verb/verb_destroy
-	action_type = XENO_ACTION_ACTIVATE
+	action_type = XENO_ACTION_CLICK
 	xeno_cooldown = 60 SECONDS
 	plasma_cost = 0
 	ability_primacy = XENO_PRIMARY_ACTION_3

--- a/code/modules/mob/living/carbon/xenomorph/abilities/king/king_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/king/king_abilities.dm
@@ -29,7 +29,7 @@
 	name = "Destroy"
 	action_icon_state = "charge"
 	macro_path = /datum/action/xeno_action/verb/verb_destroy
-	action_type = XENO_ACTION_CLICK
+	action_type = XENO_ACTION_ACTIVATE
 	xeno_cooldown = 60 SECONDS
 	plasma_cost = 0
 	ability_primacy = XENO_PRIMARY_ACTION_3

--- a/maps/map_files/New_Varadero/New_Varadero.dmm
+++ b/maps/map_files/New_Varadero/New_Varadero.dmm
@@ -6483,6 +6483,10 @@
 	pixel_x = 7;
 	pixel_y = 13
 	},
+/obj/item/implantcase/death_alarm{
+		pixel_y = -3;
+		pixel_x = 3
+	},
 /turf/open/floor/shiva/purplefull/west,
 /area/varadero/interior/research)
 "fek" = (

--- a/maps/map_files/New_Varadero/New_Varadero.dmm
+++ b/maps/map_files/New_Varadero/New_Varadero.dmm
@@ -6484,8 +6484,8 @@
 	pixel_y = 13
 	},
 /obj/item/implantcase/death_alarm{
-		pixel_y = -3;
-		pixel_x = 3
+	pixel_y = -3;
+	pixel_x = 3
 	},
 /turf/open/floor/shiva/purplefull/west,
 /area/varadero/interior/research)

--- a/maps/map_files/New_Varadero/New_Varadero.dmm
+++ b/maps/map_files/New_Varadero/New_Varadero.dmm
@@ -6483,10 +6483,6 @@
 	pixel_x = 7;
 	pixel_y = 13
 	},
-/obj/item/implantcase/explosive{
-	pixel_x = -3;
-	pixel_y = 3
-	},
 /turf/open/floor/shiva/purplefull/west,
 /area/varadero/interior/research)
 "fek" = (

--- a/maps/map_files/New_Varadero/standalone/clfraid.dmm
+++ b/maps/map_files/New_Varadero/standalone/clfraid.dmm
@@ -139,6 +139,10 @@
 	pixel_x = 7;
 	pixel_y = 13
 	},
+/obj/item/implantcase/death_alarm{
+	pixel_x = -3;
+	pixel_y = 3
+	},
 /obj/item/reagent_container/food/drinks/coffeecup/uscm{
 	pixel_x = 7;
 	pixel_y = 5

--- a/maps/map_files/New_Varadero/standalone/clfraid.dmm
+++ b/maps/map_files/New_Varadero/standalone/clfraid.dmm
@@ -139,10 +139,6 @@
 	pixel_x = 7;
 	pixel_y = 13
 	},
-/obj/item/implantcase/explosive{
-	pixel_x = -3;
-	pixel_y = 3
-	},
 /obj/item/reagent_container/food/drinks/coffeecup/uscm{
 	pixel_x = 7;
 	pixel_y = 5


### PR DESCRIPTION
# About the pull request
title

# Explain why it's good for the game
bringing somebody to hive then them blowing up with a maxcap is probably not good also old ass unused item/code


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
del: New varadero no longer has explosive implant cases, they are now replaced with death alarms
/:cl:
