### PR TITLE
UI: Changes how scrollbar color is made.

### DIFF
--- a/tgui/packages/tgui/styles/layouts/Layout.scss
+++ b/tgui/packages/tgui/styles/layouts/Layout.scss
@@ -14,7 +14,7 @@ $scrollbar-base: color.scale(
   $lightness: -25% * $scrollbar-color-multiplier
 );
 $scrollbar-face: color.scale(
-  base.$color-bg,
+  color.mix(base.$color-bg, base.$color-fg, $method: hsl, $weight: 85%),
   $lightness: if($luminance > 0.05, 30%, 10%) * $scrollbar-color-multiplier
 );
 

--- a/tgui/packages/tgui/styles/themes/crt/crt-red.scss
+++ b/tgui/packages/tgui/styles/themes/crt/crt-red.scss
@@ -1,7 +1,7 @@
 @use 'sass:meta';
 
 $light: hsl(0, 67%, 51%);
-$dark: hsl(240, 100%, 3%);
+$dark: hsl(10, 67%, 3%);
 
 @use '../../base.scss' with (
   $color-bg: $dark,


### PR DESCRIPTION

# About the pull request
Uses color mixing of the background and foreground colors to produce slightly more uniform results, most notably with the red and blue theme.
Also fixes the Red CRT using a blue background for whatever reason.

Might be weird with the other themes than aren't seen as much
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Slightly more visually perceivable.
And uses red for the red theme
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Before:

![Screenshot 2025-04-05 111254](https://github.com/user-attachments/assets/ab7255f6-1803-4376-b551-524286fd932f)

After:

![Screenshot 2025-04-05 111053](https://github.com/user-attachments/assets/160c52d6-b92b-4ea5-a6d6-f4321fe59fcc)


Before:

![Screenshot 2025-04-05 111305](https://github.com/user-attachments/assets/36b30436-5bb7-44ec-b9b7-7b6172d04cff)

After:

![Screenshot 2025-04-05 111131](https://github.com/user-attachments/assets/d9d2d31e-9bd7-4cbb-a31f-af2d0abca60b)

Before:

![Screenshot 2025-04-05 111313](https://github.com/user-attachments/assets/1baed195-5acd-41b1-8f70-0ec6577af2c0)

After:

![Screenshot 2025-04-05 111142](https://github.com/user-attachments/assets/338d83f7-2fd3-4a8a-9ccb-9e4e2fd6f593)

Before:

![Screenshot 2025-04-05 111321](https://github.com/user-attachments/assets/f150aac9-fc43-4b8f-8687-6b8ca023cb68)

After:

![Screenshot 2025-04-05 111150](https://github.com/user-attachments/assets/763b8cc1-6be8-473b-9952-fae42a7e64eb)

Before:

![Screenshot 2025-04-05 111326](https://github.com/user-attachments/assets/aba20986-f6ab-4815-abbe-ed890e8de0db)

After:

![Screenshot 2025-04-05 111157](https://github.com/user-attachments/assets/198139f3-58f4-465c-b3e2-47080b4921bf)

Before:

![Screenshot 2025-04-05 112315](https://github.com/user-attachments/assets/8b661754-9b38-4fb8-95ef-56342f28b182)

After:

![Screenshot 2025-04-05 112329](https://github.com/user-attachments/assets/41be05e4-7068-42b9-8e44-9f53eafb9780)

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MistChristmas
ui: Changes Scrollbar colors to mix from both foreground and background colours, Improving visibility. Makes CRT-Red background red instead of blue.
/:cl:
