### PR TITLE
Makes all mateba ammo subtypes be capable of BE

### DIFF
--- a/code/datums/ammo/bullet/revolver.dm
+++ b/code/datums/ammo/bullet/revolver.dm
@@ -151,6 +151,10 @@
 	penetration = ARMOR_PENETRATION_TIER_4
 	bullet_duramage = BULLET_DURABILITY_DAMAGE_INSUBSTANTIAL
 
+/datum/ammo/bullet/revolver/mateba/New()
+	..()
+	RegisterSignal(src, COMSIG_AMMO_POINT_BLANK, PROC_REF(handle_battlefield_execution))
+
 /datum/ammo/bullet/revolver/mateba/highimpact
 	name = ".454 heavy high-impact revolver bullet"
 	debilitate = list(0,2,0,0,0,1,0,0)
@@ -165,10 +169,6 @@
 	damage = 45
 	bullet_duraloss = BULLET_DURABILITY_LOSS_MEDIUM
 	bullet_duramage = BULLET_DURABILITY_DAMAGE_FAIR
-
-/datum/ammo/bullet/revolver/mateba/highimpact/New()
-	..()
-	RegisterSignal(src, COMSIG_AMMO_POINT_BLANK, PROC_REF(handle_battlefield_execution))
 
 /datum/ammo/bullet/revolver/mateba/highimpact/on_hit_mob(mob/M, obj/projectile/P)
 	knockback(M, P, 4)


### PR DESCRIPTION

# About the pull request

Title, normal ammo wasn't doing that, something i forgot to do in https://github.com/cmss13-devs/cmss13/pull/8835

# Explain why it's good for the game

Oversight bad

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![dreamseeker_idg1d6OEfH](https://github.com/user-attachments/assets/6398446e-a1bf-44f5-a850-3c90061c3880)


</details>


# Changelog
:cl:
add: normal mateba ammo can now battle execute
/:cl:
