### PR TITLE
Fixes nailgun having no inhands, makes nailgun belt slot carriable

### DIFF
--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -728,6 +728,7 @@
 		WEAR_L_HAND = 'icons/mob/humans/onmob/inhands/weapons/guns/misc_weapons_lefthand.dmi',
 		WEAR_R_HAND = 'icons/mob/humans/onmob/inhands/weapons/guns/misc_weapons_righthand.dmi'
 	)
+	flags_equip_slot = SLOT_WAIST
 
 	reload_sound = 'sound/weapons/handling/smg_reload.ogg'
 	unload_sound = 'sound/weapons/handling/smg_unload.ogg'

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -725,8 +725,8 @@
 	item_icons = list(
 		WEAR_WAIST = 'icons/mob/humans/onmob/clothing/belts/guns.dmi',
 		WEAR_J_STORE = 'icons/mob/humans/onmob/clothing/suit_storage/guns_by_type/misc_weapons.dmi',
-		WEAR_L_HAND = 'icons/mob/humans/onmob/inhands/weapons/guns/pistols_lefthand.dmi',
-		WEAR_R_HAND = 'icons/mob/humans/onmob/inhands/weapons/guns/pistols_righthand.dmi'
+		WEAR_L_HAND = 'icons/mob/humans/onmob/inhands/weapons/guns/misc_weapons_lefthand.dmi',
+		WEAR_R_HAND = 'icons/mob/humans/onmob/inhands/weapons/guns/misc_weapons_righthand.dmi'
 	)
 
 	reload_sound = 'sound/weapons/handling/smg_reload.ogg'


### PR DESCRIPTION

# About the pull request

Title

![dreamseeker_FlQomRhgOg](https://github.com/user-attachments/assets/68b2f598-997f-4de6-a0f5-68dfcd80f18a)


# Explain why it's good for the game

It's more of a tool than a gun, having extra slot to put it won't hurt



# Changelog
:cl:
add: nailgun can now be held on belt slot
fix: fixed nailgun having no inhand sprites
/:cl:
