### PR TITLE
Flashlights, lamps, candles no longer rotate on throw

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -23,7 +23,8 @@
 	var/on = FALSE
 	var/raillight_compatible = TRUE //Can this be turned into a rail light ?
 	var/toggleable = TRUE
-	var/rotation_on_throw = FALSE //Should the flashlight rotate when thrown?
+	/// Should the flashlight rotate when thrown?
+	var/rotation_on_throw = FALSE
 
 	var/can_be_broken = TRUE //can xenos swipe at this to break it/turn it off?
 	var/breaking_sound = 'sound/handling/click_2.ogg' //sound used when this happens

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -23,6 +23,7 @@
 	var/on = FALSE
 	var/raillight_compatible = TRUE //Can this be turned into a rail light ?
 	var/toggleable = TRUE
+	var/rotation_on_throw = FALSE //Should the flashlight rotate when thrown?
 
 	var/can_be_broken = TRUE //can xenos swipe at this to break it/turn it off?
 	var/breaking_sound = 'sound/handling/click_2.ogg' //sound used when this happens
@@ -40,8 +41,9 @@
 		icon_state = initial(icon_state)
 
 /obj/item/device/flashlight/animation_spin(speed = 5, loop_amount = -1, clockwise = TRUE, sections = 3, angular_offset = 0, pixel_fuzz = 0)
-	clockwise = pick(TRUE, FALSE)
-	angular_offset = rand(360)
+	if(rotation_on_throw)
+		clockwise = pick(TRUE, FALSE)
+		angular_offset = rand(360)
 	return ..()
 
 /obj/item/device/flashlight/proc/update_brightness(mob/user = null)
@@ -324,6 +326,7 @@
 	actions = list() //just pull it manually, neckbeard.
 	raillight_compatible = 0
 	can_be_broken = FALSE
+	rotation_on_throw = TRUE
 	var/burnt_out = FALSE
 	var/fuel = 16 MINUTES
 	var/fuel_rate = AMOUNT_PER_TIME(1 SECONDS, 1 SECONDS)


### PR DESCRIPTION

# About the pull request

Title, only flares do that now

# Explain why it's good for the game

It just looks better and it's a lot less annoying to deal with

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![dreamseeker_v786Ylz7xb](https://github.com/user-attachments/assets/49e06ccb-9719-42a6-82ae-88acca519ce6)

</details>


# Changelog
:cl:
qol: flashlight, lamps, candles don't rotate when being thrown
/:cl:
