### PR TITLE
AMR Charge Nerf

### DIFF
--- a/code/datums/ammo/bullet/sniper.dm
+++ b/code/datums/ammo/bullet/sniper.dm
@@ -160,14 +160,10 @@
 
 	return stopping_power
 
-/datum/ammo/bullet/sniper/anti_materiel/on_hit_mob(mob/target_mob,obj/projectile/aimed_projectile)
-
+/datum/ammo/bullet/sniper/anti_materiel/on_hit_mob(mob/target_mob, obj/projectile/aimed_projectile)
 	var/mob/living/living_target = target_mob
 
-	var/stopping_power = stopping_power_knockback(living_target, aimed_projectile)
-
 	if((aimed_projectile.projectile_flags & PROJECTILE_BULLSEYE) && target_mob == aimed_projectile.original)
-
 		var/amr_counter = 0
 		var/datum/weakref/old_target = null // This is used to let xenos know when they're no longer targeted.
 
@@ -187,7 +183,7 @@
 			old_target = amr.focused_fire_target
 
 			if(target_mob == (amr.focused_fire_target?.resolve()))
-				if(amr.focused_fire_counter < 3) // Can stack up to twice.
+				if(amr.focused_fire_counter < 2) // Can stack up to twice (0, 1).
 					amr.focused_fire_counter += 1
 				else
 					amr.focused_fire_counter = 0
@@ -202,6 +198,11 @@
 			amr_counter = min(amr.focused_fire_counter + 1, 3)
 			amr.focused_fire_target = WEAKREF(target_mob)
 
+		var/stopping_power = 0
+		if(amr_counter > 1)
+			// Only if this is the 2nd or 3rd hit do we apply daze or slow or knockdown
+			stopping_power = stopping_power_knockback(living_target, aimed_projectile)
+
 		var/size_damage_mod = 0.8 // 1.8x vs Non-Xenos (225)
 		var/size_current_health_damage = 0 // % Current Health calculation, only used for Xeno calculations at the moment.
 		var/focused_fire_active = 0 // Whether to try and use focused fire calculations or not, for that kind of target.
@@ -210,7 +211,9 @@
 		if(slow_duration <= 2) // Must be over 60 base damage.
 			slow_duration = 0
 
-		if(isxeno(target_mob))
+		if(!isxeno(target_mob))
+			living_target.apply_armoured_damage((damage*size_damage_mod), ARMOR_BULLET, BRUTE, null, penetration)
+		else
 			var/mob/living/carbon/xenomorph/target = target_mob
 			size_damage_mod -= 0.2 // Down to 1.6x damage, 200.
 			size_current_health_damage = 0.1 // 1.6x Damage + 10% current health (200 + 10%, 223 vs Runners)
@@ -238,13 +241,11 @@
 
 			living_target.apply_armoured_damage((final_xeno_damage), ARMOR_BULLET, BRUTE, null, penetration)
 
-		else
-			living_target.apply_armoured_damage((damage*size_damage_mod), ARMOR_BULLET, BRUTE, null, penetration)
-
 		if(slow_duration && (living_target.mob_size != MOB_SIZE_XENO_SMALL) && !(HAS_TRAIT(living_target, TRAIT_CHARGING))) // Runners and Charging Crushers are not slowed.
 			living_target.Slow((slow_duration / 2))
 			if(slow_duration >= 2)
 				living_target.Superslow((slow_duration / 4))
+
 		if(stopping_power > 3)
 			living_target.Daze(0.1) // Visual cue that you got hit by something HARD.
 

--- a/code/modules/projectiles/guns/specialist/sniper.dm
+++ b/code/modules/projectiles/guns/specialist/sniper.dm
@@ -138,7 +138,7 @@
 
 	if(istype(sniper_rifle, /obj/item/weapon/gun/rifle/sniper/XM43E1))
 		var/obj/item/weapon/gun/rifle/sniper/XM43E1/amr = sniper_rifle
-		if((amr.focused_fire_counter >= 1 && amr.focused_fire_counter < 3) && (target == amr.focused_fire_target?.resolve()))
+		if(amr.focused_fire_counter == 1 && target == amr.focused_fire_target?.resolve())
 			sniper_rifle.enable_aimed_shot_icon_alt = TRUE
 		else
 			sniper_rifle.enable_aimed_shot_icon_alt = FALSE


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #6311 doing a couple things:
- You no longer get two fully charged shots before the counter resets back to 0
- You only daze/slow/superslow/knockdown on 2nd and 3rd aimed shot

Assuming you have a target like a crusher that can handle 4 aim shots in a row (going crit on the 4th):
- First aimed shot applies bullet dmg + aimed shot dmg
- Second aimed shot applies daze/slow/superslow/knockdown, bullet dmg + aimed shot dmg
- Third aimed shot applies daze/slow/superslow/knockdown, bullet dmg + aimed shot dmg
- Fourth aimed shot applies bullet dmg + aimed shot dmg
...

See testing for numbers.

# Explain why it's good for the game

AMR has a very high pick rate at the moment, so this is a nudge towards making it more of a sidegrade but still keeping the utility of interrupting a target if you actually have them pinned down.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/c29dc538-c198-4620-9f41-b9a50148499e)
![image](https://github.com/user-attachments/assets/8e9ece02-c2b0-46f8-8b26-b55755f60b04)

</details>


# Changelog
:cl:
balance: AMR now resets aimed shot count every 3rd shot (rather than 4th)
balance: AMR no longer applies daze/slow/superslow/knockdown on first aimed shot
/:cl:
