### PR TITLE
Fix zip cuffs size

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -463,6 +463,7 @@
 /obj/item/storage/box/zipcuffs
 	name = "box of zip cuffs"
 	desc = "A box full of zip cuffs."
+	w_class = SIZE_MEDIUM
 	icon_state = "handcuff"
 	item_state = "handcuff"
 


### PR DESCRIPTION
## What this PR does
Adds a size property for box of zip cuffs with a value of MEDIUM (normal)
## Why this is good for the game
Adds atmosphere and RP playability to Squad Leader, such as in situations with surviving colonists.
## Change Images
![image](https://github.com/user-attachments/assets/cbca0e25-b021-4d2f-9b36-2566523144d0)
## Testing
On a local server. Interacting with: B12 pattern marine armor, G8-A general, M11 pattern marine helmet
## Changelog

:cl:
fix: added size property for box of zip cuffs with value MEDIUM (normal)
/:cl:
