### PR TITLE
UI: Dropship Flight Control touch up.

### DIFF
--- a/tgui/packages/tgui/interfaces/DropshipFlightControl.tsx
+++ b/tgui/packages/tgui/interfaces/DropshipFlightControl.tsx
@@ -78,6 +78,7 @@ const DropshipDoorControl = () => {
             {x.value === DoorStatusEnum.SHUTTLE_DOOR_UNLOCKED && (
               <Button
                 disabled={disable_door_controls}
+                width="100%"
                 onClick={() =>
                   act('door-control', {
                     interaction: 'force-lock',
@@ -93,6 +94,7 @@ const DropshipDoorControl = () => {
             {x.value === DoorStatusEnum.SHUTTLE_DOOR_LOCKED && (
               <Button
                 disabled={disable_door_controls}
+                width="100%"
                 onClick={() =>
                   act('door-control', {
                     interaction: 'unlock',
@@ -107,22 +109,24 @@ const DropshipDoorControl = () => {
           </>
         ))}
     >
-      <Stack className="DoorControlStack">
+      <Stack justify="space-between" className="DoorControlStack">
         {data.door_status
           .filter((x) => x.id !== 'all')
           .map((x) => {
             const name = x.id.substr(0, 1).toLocaleUpperCase() + x.id.substr(1);
             return (
-              <Stack.Item key={x.id}>
+              <Stack.Item key={x.id} grow>
                 <>
                   {x.value === DoorStatusEnum.SHUTTLE_DOOR_BROKEN && (
-                    <Button disabled icon="ban">
+                    <Button disabled icon="ban" width="100%" textAlign="center">
                       No response
                     </Button>
                   )}
                   {x.value === DoorStatusEnum.SHUTTLE_DOOR_UNLOCKED && (
                     <Button
                       disabled={disable_door_controls}
+                      width="100%"
+                      textAlign="center"
                       onClick={() =>
                         act('door-control', {
                           interaction: 'force-lock',
@@ -137,6 +141,8 @@ const DropshipDoorControl = () => {
                   {x.value === DoorStatusEnum.SHUTTLE_DOOR_LOCKED && (
                     <Button
                       disabled={disable_door_controls}
+                      width="100%"
+                      textAlign="center"
                       onClick={() =>
                         act('door-control', {
                           interaction: 'unlock',

--- a/tgui/packages/tgui/interfaces/DropshipFlightControl.tsx
+++ b/tgui/packages/tgui/interfaces/DropshipFlightControl.tsx
@@ -68,6 +68,8 @@ const DropshipDoorControl = () => {
   const disable_door_controls = in_flight;
   return (
     <Section
+      m="0"
+      mb="6px"
       title="Door Controls"
       buttons={data.door_status
         .filter((x) => x.id === 'all')
@@ -163,6 +165,8 @@ export const DropshipDestinationSelection = () => {
   );
   return (
     <Section
+      m="0"
+      mb="6px"
       title="Flight Controls"
       buttons={
         <>
@@ -234,7 +238,11 @@ const DestinationSelector = (props: DestinationProps) => {
 export const TouchdownCooldown = () => {
   const { data } = useBackend<NavigationProps>();
   return (
-    <Section title={`Final Approach: ${data.target_destination}`}>
+    <Section
+      m="0"
+      mb="6px"
+      title={`Final Approach: ${data.target_destination}`}
+    >
       <div className="InFlightCountdown">
         <Stack vertical>
           <Stack.Item>
@@ -267,6 +275,8 @@ const AutopilotConfig = () => {
   );
   return (
     <Section
+      m="0"
+      mb="6px"
       title="Autopilot Control"
       buttons={
         <>
@@ -362,6 +372,8 @@ const LaunchAnnouncementAlarm = () => {
   const { data } = useBackend<DropshipNavigationProps>();
   return (
     <Section
+      m="0"
+      fitted
       title="Launch Announcement Alarm"
       buttons={
         !data.playing_launch_announcement_alarm ? (
@@ -413,8 +425,8 @@ const DropshipSelector = () => {
   }, [refreshTimeout]);
 
   return (
-    <Section title="Select Dropship">
-      <Stack>
+    <Section m="0" mb="6px" title="Select Dropship">
+      <Stack justify="space-evenly">
         {data.alternative_shuttles
           .sort((a, b) => a.id.localeCompare(b.id))
           .map((x) => (

--- a/tgui/packages/tgui/interfaces/DropshipFlightControl.tsx
+++ b/tgui/packages/tgui/interfaces/DropshipFlightControl.tsx
@@ -500,7 +500,7 @@ const DropshipDisabledScreen = () => {
 export const DropshipFlightControl = () => {
   const { data } = useBackend<DropshipNavigationProps>();
   return (
-    <Window theme="crtgreen" height={500} width={700}>
+    <Window theme="crtgreen" height={550} width={700}>
       <Window.Content className="NavigationMenu">
         {data.is_disabled === 0 ? <RenderScreen /> : <DropshipDisabledScreen />}
       </Window.Content>

--- a/tgui/packages/tgui/interfaces/DropshipFlightControl.tsx
+++ b/tgui/packages/tgui/interfaces/DropshipFlightControl.tsx
@@ -397,6 +397,8 @@ const DropshipButton = (props: {
 
   return (
     <Button
+      width="30%"
+      textAlign="center"
       disabled={match || props.disable}
       onClick={() => {
         act('change_shuttle', { new_shuttle: props.shipId });

--- a/tgui/packages/tgui/interfaces/DropshipFlightControl.tsx
+++ b/tgui/packages/tgui/interfaces/DropshipFlightControl.tsx
@@ -3,6 +3,7 @@ import { useBackend, useSharedState } from 'tgui/backend';
 import {
   Box,
   Button,
+  Divider,
   Flex,
   Icon,
   ProgressBar,
@@ -170,17 +171,19 @@ export const DropshipDestinationSelection = () => {
     undefined,
   );
   return (
-    <Section
-      m="0"
-      mb="6px"
-      title="Flight Controls"
-      buttons={
-        <>
+    <Section m="0" mb="6px" title="Flight Controls">
+      <Stack justify="space-evenly">
+        <Stack.Item align="center">
           <CancelLaunchButton />
+        </Stack.Item>
+        <Stack.Item>
+          <Divider vertical />
+        </Stack.Item>
+        <Stack.Item align="center">
           <LaunchButton />
-        </>
-      }
-    >
+        </Stack.Item>
+      </Stack>
+      <Divider />
       <Stack vertical className="DestinationSelector">
         <DestinationSelector
           options={data.destinations}

--- a/tgui/packages/tgui/interfaces/NavigationShuttle.tsx
+++ b/tgui/packages/tgui/interfaces/NavigationShuttle.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   Button,
   Dimmer,
+  Divider,
   Flex,
   Icon,
   ProgressBar,
@@ -78,15 +79,19 @@ export const DestionationSelection = () => {
     undefined,
   );
   return (
-    <Section
-      title="Select Destination"
-      buttons={
-        <>
+    <Section title="Select Destination">
+      <Stack fill justify="space-evenly">
+        <Stack.Item align="center">
           <CancelLaunchButton />
+        </Stack.Item>
+        <Stack.Item>
+          <Divider vertical />
+        </Stack.Item>
+        <Stack.Item align="center">
           <LaunchButton />
-        </>
-      }
-    >
+        </Stack.Item>
+      </Stack>
+      <Divider />
       <Stack vertical className="DestinationSelector">
         {data.destinations
           .filter((x) => x.available === 1)
@@ -237,21 +242,25 @@ const DoorControls = () => {
         </>
       }
     >
-      <Stack className="DoorControlStack">
-        <Stack.Item>
+      <Stack justify="space-evenly" align="center" className="DoorControlStack">
+        <Stack.Item grow>
           <Button
             disabled={disable_normal_control || disable_door_controls}
             onClick={() => act('open')}
             icon="door-open"
+            width="100%"
+            textAlign="center"
           >
             Force Open
           </Button>
         </Stack.Item>
-        <Stack.Item>
+        <Stack.Item grow>
           <Button
             disabled={disable_normal_control || disable_door_controls}
             onClick={() => act('close')}
             icon="door-closed"
+            width="100%"
+            textAlign="center"
           >
             Force Close
           </Button>

--- a/tgui/packages/tgui/interfaces/NavigationShuttle.tsx
+++ b/tgui/packages/tgui/interfaces/NavigationShuttle.tsx
@@ -125,7 +125,7 @@ export const DestionationSelection = () => {
 export const ShuttleRecharge = () => {
   const { data } = useBackend<NavigationProps>();
   return (
-    <Section title="Refueling in progress">
+    <Section m="0" title="Refueling in progress">
       <div className="LaunchCountdown">
         <Stack vertical>
           <Stack.Item>
@@ -150,7 +150,7 @@ export const ShuttleRecharge = () => {
 export const LaunchCountdown = () => {
   const { data } = useBackend<NavigationProps>();
   return (
-    <Section title="Launch in progress">
+    <Section m="0" title="Launch in progress">
       <div className="LaunchCountdown">
         <Stack vertical>
           <Stack.Item>
@@ -178,6 +178,7 @@ export const InFlightCountdown = () => {
   return (
     <Section
       title={`In flight: ${data.target_destination}`}
+      m="0"
       buttons={
         data.target_destination === 'Flyby' && (
           <Button onClick={() => act('cancel-flyby')}>Cancel</Button>


### PR DESCRIPTION
# About the pull request
Mostly fixes me not fixing the Sections being weird when I added the scroll bar.
Also centers the Buttons for the picking the DS and makes their size the same as well as the Door Control Buttons.
And moves the Launch control buttons out of the section title so that they're bigger as they're like important buttons or something.
Makes the default window slightly taller to accommodate the bigger launch buttons.
Adds a small amount of spacing between because uhhh Sections with m=0 will touch.
Also tweaks the Navigation Shuttle buttons as well. and adds some m=0 to the sections that get used elsewhere.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Looks slightly nicer
# Testing Photographs and Procedure
<details>
<summary>Before and after UI Screenshots</summary>

Before:

![Screenshot 2025-04-10 142044](https://github.com/user-attachments/assets/a92cd589-abb4-4559-8b25-db3e7d0341a5)

After:

![Screenshot 2025-04-10 151108](https://github.com/user-attachments/assets/0618fa55-d752-479e-89ca-f3c95234864f)

Before:

![Screenshot 2025-04-10 142058](https://github.com/user-attachments/assets/ad72b570-f01c-4bd2-a1e1-45a690a92b85)

After:

![Screenshot 2025-04-10 151113](https://github.com/user-attachments/assets/3a4d7891-b76a-41af-b670-af23aff771e4)

Before:

![Screenshot 2025-04-10 142121](https://github.com/user-attachments/assets/b1432d99-847f-4c42-9665-c669fd2cffde)

After:

![Screenshot 2025-04-10 151101](https://github.com/user-attachments/assets/c617731b-1543-439c-9316-4bf0d7054160)

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

Before:

![Screenshot 2025-04-11 025434](https://github.com/user-attachments/assets/c00caf7d-2ed9-4f07-9b00-ac7e7a136d4c)

After:

![Screenshot 2025-04-11 025415](https://github.com/user-attachments/assets/a473cfd6-4585-4e69-8c74-6ddb11b51974)


</details>


# Changelog
:cl:
ui: Centers and resizes door controls/dropship selection buttons. Does the same for launch control buttons but also moves them into the element and out the title (Does similar for ERT Shuttles). Centers the whole UI. Adjusts the spacings between elements smaller than before. Makes the default UI slightly taller to accommodate the bigger buttons. 
/:cl:
