### PR TITLE
UI: Supply Console Scalability

### DIFF
--- a/tgui/packages/tgui/interfaces/SupplyComputer.tsx
+++ b/tgui/packages/tgui/interfaces/SupplyComputer.tsx
@@ -636,7 +636,7 @@ const BlackMarketMenu = () => {
       >
         WY${dollars}
       </Box>
-      <Stack.Item height="25%" width="80%">
+      <Stack.Item height="25%" width="75%">
         {blackmarketCategory ? (
           <Section fill scrollable width="100%">
             <Box>
@@ -704,14 +704,14 @@ const MendozaDialogue = () => {
 
   if (!mendoza_status) {
     return (
-      <Stack vertical justify="space-around">
+      <Stack vertical fill justify="space-around">
         <Stack.Item>.......</Stack.Item>
       </Stack>
     );
   }
 
   return stateFirst ? (
-    <Stack vertical justify="space-around">
+    <Stack vertical fill justify="space-around">
       <Stack.Item>
         {
           "Hold on- holy shit, what? Hey, hey! Finally! I've set THAT circuit board for replacement shipping off god knows who long ago. I had totally given up on it."
@@ -744,7 +744,7 @@ const MendozaDialogue = () => {
       </Stack.Item>
     </Stack>
   ) : (
-    <Stack vertical justify="space-around">
+    <Stack vertical fill justify="space-around">
       <Stack.Item>{pickedDialogue}</Stack.Item>
     </Stack>
   );

--- a/tgui/packages/tgui/interfaces/SupplyComputer.tsx
+++ b/tgui/packages/tgui/interfaces/SupplyComputer.tsx
@@ -627,15 +627,13 @@ const BlackMarketMenu = () => {
 
   return (
     <Stack vertical fill align="center" justify="space-evenly">
-      <Box
-        position="absolute"
-        right="20px"
-        top="20px"
-        p={2}
-        style={{ border: '1px solid' }}
-      >
-        WY${dollars}
-      </Box>
+      <Stack.Item mr="3%" align="end">
+        <Stack justify="space-evenly">
+          <Box p={2} style={{ border: '1px solid' }}>
+            WY${dollars}
+          </Box>
+        </Stack>
+      </Stack.Item>
       <Stack.Item height="25%" width="75%">
         {blackmarketCategory ? (
           <Section fill scrollable width="100%">

--- a/tgui/packages/tgui/interfaces/SupplyComputer.tsx
+++ b/tgui/packages/tgui/interfaces/SupplyComputer.tsx
@@ -150,8 +150,8 @@ export const SupplyComputer = () => {
     <Window width={1050} height={700} theme={theme}>
       <Window.Content>
         {!!modal && <Modal>{modal}</Modal>}
-        <Stack>
-          <Stack.Item>
+        <Stack fill>
+          <Stack.Item width="200px">
             <SideButtons
               menu={menu}
               selectedCategory={selectedCategory}
@@ -213,10 +213,10 @@ const SideButtons = (props: {
   };
 
   return (
-    <Stack vertical>
+    <Stack vertical fill>
       <Stack.Item>
-        <Section>
-          <Stack vertical>
+        <Section fill>
+          <Stack vertical fill>
             <Stack.Item>
               <Stack justify="space-between">
                 <Stack.Item>Supply Budget: ${points * 100}</Stack.Item>
@@ -330,9 +330,9 @@ const SideButtons = (props: {
           </Stack>
         </Section>
       </Stack.Item>
-      <Stack.Item>
-        <Section scrollable height="470px">
-          <Stack vertical height="450px">
+      <Stack.Item grow>
+        <Section scrollable fill>
+          <Stack vertical>
             <Input
               placeholder="Search..."
               fluid
@@ -347,7 +347,7 @@ const SideButtons = (props: {
               }}
             />
             {valid_categories.sort().map((category) => (
-              <Stack.Item key={category}>
+              <Stack.Item key={category} grow>
                 <Button
                   fluid
                   onClick={() => {
@@ -395,9 +395,9 @@ const Options = (props: {
         <Section
           title={categories.includes(category!) ? category : 'Search'}
           scrollable
-          height="650px"
+          fill
         >
-          <Box height="610px">
+          <Box>
             <RenderCategory category={category!} categories={categories} />
           </Box>
         </Section>
@@ -407,11 +407,7 @@ const Options = (props: {
       return <CurrentOrder />;
 
     case MenuOptions.BlackMarket:
-      return (
-        <Stack vertical justify="space-around" align="center" height="100%">
-          <BlackMarketMenu />
-        </Stack>
-      );
+      return <BlackMarketMenu />;
 
     case MenuOptions.Pending:
       return <PendingOrder />;
@@ -434,7 +430,7 @@ const CurrentOrder = () => {
     <Section
       title="Current Order"
       scrollable
-      height="650px"
+      fill
       buttons={
         <Stack>
           {requester && (
@@ -477,7 +473,7 @@ const PendingOrder = () => {
   const { pending } = data;
 
   return (
-    <Section title="Pending Orders" scrollable height="650px">
+    <Section title="Pending Orders" scrollable fill>
       <Stack vertical height="610px">
         {pending!.map((order) => (
           <RenderOrder order={order} key={order.order_num} />
@@ -493,7 +489,7 @@ const Requests = () => {
   const { requests } = data;
 
   return (
-    <Section title="Requests" scrollable height="650px">
+    <Section title="Requests" scrollable fill>
       <Stack vertical height="610px">
         {requests!.map((order) => (
           <RenderOrder order={order} key={order.order_num} request />
@@ -630,7 +626,7 @@ const BlackMarketMenu = () => {
   }
 
   return (
-    <>
+    <Stack vertical fill align="center" justify="space-evenly">
       <Box
         position="absolute"
         right="20px"
@@ -640,10 +636,10 @@ const BlackMarketMenu = () => {
       >
         WY${dollars}
       </Box>
-      <Stack.Item>
+      <Stack.Item height="25%" width="70%">
         {blackmarketCategory ? (
-          <Section fitted height="330px" scrollable>
-            <Box height="310px">
+          <Section fill scrollable>
+            <Box>
               <RenderCategory
                 category={blackmarketCategory}
                 categories={contraband_categories}
@@ -672,7 +668,7 @@ const BlackMarketMenu = () => {
           </Stack>
         </Stack.Item>
       )}
-    </>
+    </Stack>
   );
 };
 
@@ -708,14 +704,14 @@ const MendozaDialogue = () => {
 
   if (!mendoza_status) {
     return (
-      <Stack vertical justify="center" width="400px">
+      <Stack vertical justify="space-around">
         <Stack.Item>.......</Stack.Item>
       </Stack>
     );
   }
 
   return stateFirst ? (
-    <Stack vertical justify="center" width="400px">
+    <Stack vertical justify="space-around">
       <Stack.Item>
         {
           "Hold on- holy shit, what? Hey, hey! Finally! I've set THAT circuit board for replacement shipping off god knows who long ago. I had totally given up on it."
@@ -748,7 +744,7 @@ const MendozaDialogue = () => {
       </Stack.Item>
     </Stack>
   ) : (
-    <Stack vertical justify="center" width="400px">
+    <Stack vertical justify="space-around">
       <Stack.Item>{pickedDialogue}</Stack.Item>
     </Stack>
   );
@@ -789,7 +785,7 @@ const RenderCategory = (props: {
       );
 
   return (
-    <Stack vertical>
+    <Stack vertical fill>
       {relevant_items.map((item) => (
         <>
           <RenderPack key={item.name} pack={item} />

--- a/tgui/packages/tgui/interfaces/SupplyComputer.tsx
+++ b/tgui/packages/tgui/interfaces/SupplyComputer.tsx
@@ -636,9 +636,9 @@ const BlackMarketMenu = () => {
       >
         WY${dollars}
       </Box>
-      <Stack.Item height="25%" width="70%">
+      <Stack.Item height="25%" width="80%">
         {blackmarketCategory ? (
-          <Section fill scrollable>
+          <Section fill scrollable width="100%">
             <Box>
               <RenderCategory
                 category={blackmarketCategory}
@@ -864,8 +864,8 @@ const RenderPack = (props: {
   }
 
   return (
-    <Stack.Item key={item.name}>
-      <Stack>
+    <Stack.Item grow key={item.name}>
+      <Stack fill>
         {orderedQuantity ? (
           <Stack.Item>
             <Box p={1} width="30px" textAlign="right" inline>
@@ -922,12 +922,12 @@ const RenderPack = (props: {
           {item.dollar_cost ? `WY$${item.dollar_cost}` : `$${item.cost * 100}`}
         </Stack.Item>
 
-        <Stack.Item p={1}>
-          <Stack vertical>
-            <Stack.Item>
-              <Stack justify="space-between">
-                <Stack.Item>
-                  <Stack>
+        <Stack.Item grow p={1}>
+          <Stack fill vertical>
+            <Stack.Item grow>
+              <Stack fill justify="space-between">
+                <Stack.Item grow>
+                  <Stack fill>
                     <Stack.Item>
                       {item.icon && (
                         <DmIcon
@@ -937,9 +937,7 @@ const RenderPack = (props: {
                         />
                       )}
                     </Stack.Item>
-                    <Stack.Item width={orderedQuantity ? '575px' : '500px'}>
-                      {item.name}
-                    </Stack.Item>
+                    <Stack.Item grow>{item.name}</Stack.Item>
                   </Stack>
                 </Stack.Item>
                 {item.contains.length > 0 && (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
_Fixes being under 100 PRs - Oh god. We're fucked_
More UI stuff.
Mostly shoving a bunch of fills and grows everywhere so you can resize the Supply Console Window without being disappointed
Also as a consequence fixes the minor misalignment of somethings that you can see like 1px out of alignment at the bottom of the window with the categories and selected category element.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Looks betterer when you resize the window to your own preferences. Slight change that stuff isn't misaligned at the bottom when you don't.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

Examples below, you can also squish the UI to some extent.

<details>
<summary>Before & After Screenshots</summary>

Before:

![Screenshot 2025-04-11 020854](https://github.com/user-attachments/assets/0eb2fbdb-f248-49f1-96b7-202b5835f6e9)

After:

![Screenshot 2025-04-11 020940](https://github.com/user-attachments/assets/4a3ed341-cebf-45fd-8e0c-a16aa468a4b7)

Before:

![Screenshot 2025-04-11 020857](https://github.com/user-attachments/assets/2f226928-2e15-48dc-b883-06c088504f32)

After:

![Screenshot 2025-04-11 020943](https://github.com/user-attachments/assets/81d301df-e6f7-4468-97da-84338feec634)

Before:

![Screenshot 2025-04-11 020904](https://github.com/user-attachments/assets/ef3cb50a-5335-4ab7-9c9f-8b4a6b489b00)

After:

![Screenshot 2025-04-11 021114](https://github.com/user-attachments/assets/bae66bc1-4ff4-4b14-8cd9-3dc4cdf06812)

Before:

![Screenshot 2025-04-11 020909](https://github.com/user-attachments/assets/4fed4249-24ee-470a-9a14-d04f37913915)

After:

![Screenshot 2025-04-11 021118](https://github.com/user-attachments/assets/3be14625-cc9e-4c39-8862-3e1e434b76db)

Before:

![Screenshot 2025-04-11 020919](https://github.com/user-attachments/assets/cb0d97cc-2e9a-4fcb-af41-aa46b8aa9503)

After:

![Screenshot 2025-04-11 021128](https://github.com/user-attachments/assets/d1e61d03-3bf2-4389-9e88-03e780d6f2eb)

Before:

![Screenshot 2025-04-11 020923](https://github.com/user-attachments/assets/14d4ccfa-42c7-4907-9f29-2e4244d715c0)

After:

![Screenshot 2025-04-11 021133](https://github.com/user-attachments/assets/719eef57-595e-490d-ae43-55556b89d13d)



Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
ui: Adds scalability to the Supply Console so it can be resized and the elements will resize with the window.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
