### PR TITLE
DMI merge driver now anchors icons for new additions

### DIFF
--- a/tools/dmi/merge_driver.py
+++ b/tools/dmi/merge_driver.py
@@ -39,6 +39,25 @@ def key_of(state):
     return (state.name, state.movement)
 
 
+def index_of(state, list):
+    index = 0
+    for item in list:
+        if item.name == state.name:
+            return index
+        index += 1
+    return -1
+
+
+def determine_insert_index(state, old_sheet, new_sheet):
+    old_index = old_sheet.states.index(state)
+    for i in range(old_index - 1, -1, -1):
+        # figure out the new index it ought to be by trying to find a common earlier state in the new list
+        new_index = index_of(old_sheet.states[i], new_sheet)
+        if new_index > -1:
+            return new_index + 1
+    return 0
+
+
 def dictify(sheet):
     result = {}
     for state in sheet.states:
@@ -133,18 +152,21 @@ def three_way_merge(base, left, right):
 
     # add states which both left and right added the same
     for key, state in new_both.items():
+        insert_index = determine_insert_index(state, left, final_states)
+        final_states.insert(insert_index, state)
         print(f"    {state.name!r}: added same in both")
-        final_states.append(state)
 
     # add states that are brand-new in the left
     for key, state in new_left.items():
+        insert_index = determine_insert_index(state, left, final_states)
+        final_states.insert(insert_index, state)
         print(f"    {state.name!r}: added in left")
-        final_states.append(state)
 
     # add states that are brand-new in the right
     for key, state in new_right.items():
+        insert_index = determine_insert_index(state, right, final_states)
+        final_states.insert(insert_index, state)
         print(f"    {state.name!r}: added in right")
-        final_states.append(state)
 
     final_states.extend(conflicts)
     merged = dmi.Dmi(base.width, base.height)


### PR DESCRIPTION
# About the pull request

This PR makes it so in general new additions to dmi files should better retain their ordering when using the DMI merge hook driver. When left or right add a new state, the previous behavior would be to just append them to the end of the dmi. Now, it will attempt to find a state that exists in the new dmi that came before the new state to place it after that state. This does mean however if no anchor is found, you can expect states to be appended to the front of the dmi rather than the end.

Other conflicts (e.g. both modifying the same state) will still be appended to the end.

Blundir has already been utilizing these changes for a little over a week. See testing below for an example.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

For example if I have a branch that adds a state to the left of the legacy_bay state (essentially anchors to ancient_shield_alt_ready in this case):
![image](https://github.com/user-attachments/assets/579d2741-88f3-4a27-b32f-c5205dd537fd)
And another branch adds a state to the right of the legacy_bay state (so anchored to it in this case):
![image](https://github.com/user-attachments/assets/d2dbba56-c8f9-47c3-93a9-0627b8db1dd3)
The resulting merge will be (with right as "ours"):
![image](https://github.com/user-attachments/assets/d6774c11-687d-4d1b-9225-3a5e9ffecbf7)
Instead of this (with right as "ours"):
![image](https://github.com/user-attachments/assets/b6959315-5d1b-4eda-9c5d-7536992ff23b)

</details>


# Changelog
:cl: Drathek
code: DMI merge hook will now try to retain positioning of sprites when handling some conflicts
/:cl:
