### PR TITLE
fixes CO council not getting their jackets

### DIFF
--- a/code/modules/gear_presets/uscm_co.dm
+++ b/code/modules/gear_presets/uscm_co.dm
@@ -113,7 +113,7 @@
 	paygrades = list(PAY_SHORT_MO5 = JOB_PLAYTIME_TIER_0)
 	whitelist_level = WHITELIST_COUNCIL
 
-	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander)
+	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander, /obj/item/clothing/suit/storage/jacket/marine/dress/officer/bomber)
 
 /datum/equipment_preset/uscm_co/infantry/council/plus
 	name = "Shipside - CO - Infantry - SENATOR"
@@ -121,7 +121,7 @@
 	paygrades = list(PAY_SHORT_MO6 = JOB_PLAYTIME_TIER_0)
 	whitelist_level = WHITELIST_LEADER
 
-	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander)
+	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander, /obj/item/clothing/suit/storage/jacket/marine/dress/officer/bomber)
 
 /datum/equipment_preset/uscm_co/intel
 
@@ -143,7 +143,7 @@
 	paygrades = list(PAY_SHORT_MO5 = JOB_PLAYTIME_TIER_0)
 	whitelist_level = WHITELIST_COUNCIL
 
-	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander)
+	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander, /obj/item/clothing/suit/storage/jacket/marine/dress/officer/bomber)
 
 /datum/equipment_preset/uscm_co/intel/council/plus
 	name = "Shipside - CO - Intel - SENATOR"
@@ -151,7 +151,7 @@
 	paygrades = list(PAY_SHORT_MO6 = JOB_PLAYTIME_TIER_0)
 	whitelist_level = WHITELIST_LEADER
 
-	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander)
+	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander, /obj/item/clothing/suit/storage/jacket/marine/dress/officer/bomber)
 
 /datum/equipment_preset/uscm_co/medical
 
@@ -172,7 +172,7 @@
 	paygrades = list(PAY_SHORT_MO5 = JOB_PLAYTIME_TIER_0)
 	whitelist_level = WHITELIST_COUNCIL
 
-	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander)
+	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander, /obj/item/clothing/suit/storage/jacket/marine/dress/officer/bomber)
 
 /datum/equipment_preset/uscm_co/medical/council/plus
 	name = "Shipside - CO - Medical - SENATOR"
@@ -180,7 +180,7 @@
 	paygrades = list(PAY_SHORT_MO6 = JOB_PLAYTIME_TIER_0)
 	whitelist_level = WHITELIST_LEADER
 
-	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander)
+	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander, /obj/item/clothing/suit/storage/jacket/marine/dress/officer/bomber)
 
 /datum/equipment_preset/uscm_co/aviation
 
@@ -204,7 +204,7 @@
 	paygrades = list(PAY_SHORT_MO5 = JOB_PLAYTIME_TIER_0)
 	whitelist_level = WHITELIST_COUNCIL
 
-	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander)
+	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander, /obj/item/clothing/suit/storage/jacket/marine/dress/officer/bomber)
 
 /datum/equipment_preset/uscm_co/aviation/council/plus
 	name = "Shipside - CO - Aviation - SENATOR"
@@ -212,7 +212,7 @@
 	paygrades = list(PAY_SHORT_MO6 = JOB_PLAYTIME_TIER_0)
 	whitelist_level = WHITELIST_LEADER
 
-	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander)
+	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander, /obj/item/clothing/suit/storage/jacket/marine/dress/officer/bomber)
 
 /datum/equipment_preset/uscm_co/tanker
 
@@ -235,7 +235,7 @@
 	paygrades = list(PAY_SHORT_MO5 = JOB_PLAYTIME_TIER_0)
 	whitelist_level = WHITELIST_COUNCIL
 
-	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander)
+	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander, /obj/item/clothing/suit/storage/jacket/marine/dress/officer/bomber)
 
 
 /datum/equipment_preset/uscm_co/tanker/council/plus
@@ -245,7 +245,7 @@
 	whitelist_level = WHITELIST_LEADER
 
 
-	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander)
+	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander, /obj/item/clothing/suit/storage/jacket/marine/dress/officer/bomber)
 
 /datum/equipment_preset/uscm_co/engineering
 
@@ -268,7 +268,7 @@
 	paygrades = list(PAY_SHORT_MO5 = JOB_PLAYTIME_TIER_0)
 	whitelist_level = WHITELIST_COUNCIL
 
-	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander)
+	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander, /obj/item/clothing/suit/storage/jacket/marine/dress/officer/bomber)
 
 /datum/equipment_preset/uscm_co/engineering/council/plus
 	name = "Shipside - CO - Engineering - SENATOR"
@@ -276,7 +276,7 @@
 	paygrades = list(PAY_SHORT_MO6 = JOB_PLAYTIME_TIER_0)
 	whitelist_level = WHITELIST_LEADER
 
-	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander)
+	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander, /obj/item/clothing/suit/storage/jacket/marine/dress/officer/bomber)
 
 /datum/equipment_preset/uscm_co/logistics
 	name = "Shipside - CO - Logistics"
@@ -298,7 +298,7 @@
 	paygrades = list(PAY_SHORT_MO5 = JOB_PLAYTIME_TIER_0)
 	whitelist_level = WHITELIST_COUNCIL
 
-	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander)
+	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander, /obj/item/clothing/suit/storage/jacket/marine/dress/officer/bomber)
 
 /datum/equipment_preset/uscm_co/logistics/council/plus
 	name = "Shipside - CO - Logistics - SENATOR"
@@ -306,7 +306,7 @@
 	paygrades = list(PAY_SHORT_MO6 = JOB_PLAYTIME_TIER_0)
 	whitelist_level = WHITELIST_LEADER
 
-	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander)
+	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander, /obj/item/clothing/suit/storage/jacket/marine/dress/officer/bomber)
 
 /datum/equipment_preset/uscm_co/visitor
 	name = "USCM Observer (Major) (VO)"
@@ -334,7 +334,7 @@
 		/obj/item/clothing/suit/storage/jacket/marine/dress,
 	)
 
-	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander)
+	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander, /obj/item/clothing/suit/storage/jacket/marine/dress/officer/bomber)
 
 /datum/equipment_preset/uscm_co/council/plus
 	name = "USCM Commanding Officer (CO++)"
@@ -342,4 +342,4 @@
 	paygrades = list(PAY_SHORT_MO6 = JOB_PLAYTIME_TIER_0)
 	dress_under = list(/obj/item/clothing/under/marine/dress/blues/senior, /obj/item/clothing/under/marine/dress/blues/general)
 
-	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander)
+	service_extra = list(/obj/item/clothing/suit/storage/jacket/marine/dress/officer/commander, /obj/item/clothing/suit/storage/jacket/marine/dress/officer/bomber)


### PR DESCRIPTION

# About the pull request

#8893 accidentally removed the ability for council CO to get their bomber jackets when it added the new version of the other jacket with a patch. The senator said this is a bug and asked me to fix it so I did

# Explain why it's good for the game

fixes a bug

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![NVIDIA_Overlay_1K6ohOpI2f](https://github.com/user-attachments/assets/a199bd0d-daff-4585-8e44-34c0083b892d)

tested as CO & CO council job, both could vend their respective jackets

</details>


# Changelog

:cl:
fix: CO council can vend bomber jackets again
/:cl:
