### PR TITLE
nerf Mou53

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -912,7 +912,7 @@ can cause issues with ammo types getting mixed up during the burst.
 /obj/item/weapon/gun/shotgun/double/mou53/set_gun_config_values()
 	..()
 	set_burst_amount(BURST_AMOUNT_TIER_1)
-	set_fire_delay(FIRE_DELAY_TIER_11)
+	set_fire_delay(FIRE_DELAY_TIER_6)
 	if(SSticker.mode && MODE_HAS_FLAG(MODE_FACTION_CLASH))
 		set_fire_delay(FIRE_DELAY_TIER_1)
 	accuracy_mult = BASE_ACCURACY_MULT


### PR DESCRIPTION

# About the pull request

Nerfs OP MOU53  shotgun.

# Explain why it's good for the game

This nerf adds a noticeable delay between MOU 53 shots, removing the ability to kill anything in a second in 2 volleys.
At the moment, the MOU53 shotgun is an OP weapon, its ability to almost instantly fire 3 shots. Each shot is a flechette for 120 damage, armor-piercing ammunition that can be found in UNEXHAUSTIBLE quantities everywhere. The very existence of a weapon in the game that can kill a T3 xenomorph in 2 volleys sounds crazy, for a similar reason we removed the double-barreled shotgun, m707 and tank cannon from the build. Literally now this shotgun looks more like an autocannon. In the attached video you can see the changes in the rate of fire of the MOU, as well as the fatal damage that this weapon is capable of inflicting. Damage was tested on a ravager with a hedgehog strain and a full charge of bone fragments.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>


https://github.com/user-attachments/assets/d5f164d3-01ba-45c5-b33c-f3b52955b4f6



</details>


# Changelog
:cl:

balance: nerfed MOU-53

/:cl:
