### PR TITLE
Huggers now convert on ghostize/dc rather than idle for afk

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -197,8 +197,6 @@
 #define XENO_LEAVE_TIMER_LARVA 80 //80 seconds
 /// The time against away_timer when an AFK xeno (not larva) can be replaced
 #define XENO_LEAVE_TIMER 300 //300 seconds
-/// The time against away_timer when an AFK facehugger converts to a npc
-#define XENO_FACEHUGGER_LEAVE_TIMER 420 //420 seconds
 /// The time against away_timer when an AFK xeno gets listed in the available list so ghosts can get ready
 #define XENO_AVAILABLE_TIMER 60 //60 seconds
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -92,16 +92,6 @@
 		PF.flags_pass = PASS_MOB_THRU|PASS_FLAGS_CRAWLER
 		PF.flags_can_pass_all = PASS_ALL^PASS_OVER_THROW_ITEM
 
-/mob/living/carbon/xenomorph/facehugger/Life(delta_time)
-	if(stat == DEAD)
-		return ..()
-
-	if(!client && !aghosted && away_timer > XENO_FACEHUGGER_LEAVE_TIMER)
-		// Become a npc once again
-		new /obj/item/clothing/mask/facehugger(loc, hivenumber)
-		qdel(src)
-	return ..()
-
 /mob/living/carbon/xenomorph/facehugger/update_icons()
 	. = ..()
 	if(throwing)
@@ -173,6 +163,12 @@
 	return did_hug
 
 /mob/living/carbon/xenomorph/facehugger/ghostize(can_reenter_corpse, aghosted)
+	if(!aghosted && !can_reenter_corpse && !QDELETED(src))
+		// Become a npc once again
+		new /obj/item/clothing/mask/facehugger(loc, hivenumber)
+		qdel(src)
+		return
+
 	var/mob/dead/observer/ghost = ..()
 	ghost?.bypass_time_of_death_checks_hugger = hug_successful
 	return ghost

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -174,7 +174,7 @@
 	return did_hug
 
 /mob/living/carbon/xenomorph/facehugger/ghostize(can_reenter_corpse, aghosted)
-	if(!aghosted && !can_reenter_corpse && !QDELETED(src))
+	if(!aghosted && !can_reenter_corpse && !QDELETED(src) && stat != DEAD)
 		// Become a npc once again
 		new /obj/item/clothing/mask/facehugger(loc, hivenumber)
 		qdel(src)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -92,6 +92,17 @@
 		PF.flags_pass = PASS_MOB_THRU|PASS_FLAGS_CRAWLER
 		PF.flags_can_pass_all = PASS_ALL^PASS_OVER_THROW_ITEM
 
+/mob/living/carbon/xenomorph/facehugger/Logout()
+	. = ..()
+
+	if(stat == DEAD)
+		return
+
+	if(!aghosted)
+		// Become a npc once again
+		new /obj/item/clothing/mask/facehugger(loc, hivenumber)
+		qdel(src)
+
 /mob/living/carbon/xenomorph/facehugger/update_icons()
 	. = ..()
 	if(throwing)


### PR DESCRIPTION

# About the pull request

This PR makes it so huggers now immediately convert on ghostize/dc rather than having a 420 second timer where they can be taken over.

# Explain why it's good for the game

Huggers no longer really are a semi-limited resource as of https://github.com/cmss13-devs/cmss13/pull/7226 so we don't need to clog up the xeno away list with facehuggers.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/gRF3-DURpZY

</details>


# Changelog
:cl: Drathek
balance: Huggers now immediately convert to npc huggers on ghostize/dc
/:cl:
