### PR TITLE
prevents harmful spray on ceasefire

### DIFF
--- a/code/game/objects/items/reagent_containers/spray.dm
+++ b/code/game/objects/items/reagent_containers/spray.dm
@@ -78,6 +78,9 @@
 		if(!human_user.allow_gun_usage && reagents.contains_harmful_substances())
 			to_chat(user, SPAN_WARNING("Your programming prevents you from using this!"))
 			return FALSE
+		if(MODE_HAS_MODIFIER(/datum/gamemode_modifier/ceasefire))
+			to_chat(user, SPAN_WARNING("You will not break the ceasefire by doing that!"))
+			return FALSE
 
 	var/obj/effect/decal/chempuff/D = new /obj/effect/decal/chempuff(get_turf(src))
 	D.create_reagents(amount_per_transfer_from_this)


### PR DESCRIPTION

# About the pull request

updates it so you can not use harmful sprays on ceasefire as intended

# Explain why it's good for the game

Unintended behavior, stop trying to bypass IC stuff so we do not have to enforce it in code...


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: prevents harmful spray during ceasefire
/:cl:
