### PR TITLE
Fix m81 riot grenade launcher not having onmob icons

### DIFF
--- a/code/modules/projectiles/guns/specialist/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/specialist/launcher/grenade_launcher.dm
@@ -328,6 +328,7 @@
 	desc = "A lightweight, multiple-shot variant of the M81 grenade launcher retrofitted to launch non-lethal or concussive ammunition. Used by the Colonial Marines Military Police during riots."
 	icon = 'icons/obj/items/weapons/guns/guns_by_faction/colony/grenade_launchers.dmi'
 	icon_state = "m81"
+	item_state = "m81"
 	valid_munitions = list(
 		/obj/item/explosive/grenade/custom/teargas,
 		/obj/item/explosive/grenade/slug/baton,


### PR DESCRIPTION

# About the pull request

Title

![dreamseeker_1ZaAXCb6XS](https://github.com/user-attachments/assets/390b3017-3a5b-4e03-8552-01564318a088)

# Changelog
:cl:
fix: fixed m81 riot grenade launcher not having onmob icons
/:cl:
