### PR TITLE
Fix Tackle Counter resetting when not forcibly floored

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -633,6 +633,11 @@
 	if(M.status_flags & XENO_HOST)
 		return
 
+	// If they were not forcibly floored, don't reset
+	// Resting should not reset the counter
+	if(!HAS_TRAIT(M, TRAIT_FLOORED))
+		return
+
 	reset_tackle(M)
 
 /mob/living/carbon/xenomorph/proc/reset_tackle(mob/M)


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Adds check for Tackle Counter if the target was actually Floored (forcibly changed body position) and not Resting.

How it works before this PR, is that Rest actually resets Tackle Counter.

# Explain why it's good for the game
Lying-Standing-Lying in front of the xenomorph should not make you more or less immune to tackles.

# Testing Photographs and Procedure
- Tackle Counter resets when the target was KnockedDown by someone else (ie other xeno tackled the standing target, so your tackles are reset now)
- Tackle Counter doesn't reset when the floored target was KnockedDown again by someone else (ie multiple xenos tackling already floored target)
- Tackle Counter doesn't reset when target rests (fixed oversight)

# Changelog
:cl:
fix: Resting doesn't reset Tackle Counter anymore. No more Rest Tech.
/:cl:
