### PR TITLE
No more backpack items vanishing upon deletion

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -197,6 +197,13 @@
 		if(lock_overridable)
 			. += "This lock can be overridden with command-level access."
 
+/obj/item/storage/backpack/Destroy()
+	for (var/obj/item/I in contents)
+		I.loc = get_turf(src)
+	contents.Cut()
+
+	return ..()
+
 /*
  * Backpack Types
  */

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -202,7 +202,7 @@
 		I.loc = get_turf(src)
 	contents.Cut()
 
-	return ..()
+	. = ..()
 
 /*
  * Backpack Types


### PR DESCRIPTION
# About the pull request

Backpacks now drop their contents onto the ground when deleted (aciding for example)

# Explain why it's good for the game

I wrote the code for this in 2 minutes while playing CM when a burrower popped out and melted my backpack with the dialysis machine inside it.

Any backpack could be storing an important item, from the sadar's rocket bag full of rockets to anything else. Marines shouldn't be punished very heavily for not taking care of their backpacks 7 tiles away from the front and a lesser comes and melts it.

# Testing Photographs and Procedure


https://github.com/user-attachments/assets/7ff126ea-4828-4e26-84ea-f9d6e0cba80a


</details>


# Changelog

:cl: Ansekishoku
qol: Backpack contents no longer vanish when the backpack is destroyed (eg. melting)
/:cl:

