### PR TITLE
Autowiki Tweaks. Skips/Armour damage table 0s/Xeno strain comparison

### DIFF
--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -908,11 +908,15 @@
 // abstract grenades used for hijack explosions
 
 /obj/item/explosive/grenade/high_explosive/bursting_pipe
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "bursting pipe"
 	alpha = 0
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /obj/item/explosive/grenade/incendiary/bursting_pipe
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "bursting pipe"
 	alpha = 0
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -909,14 +909,12 @@
 
 /obj/item/explosive/grenade/high_explosive/bursting_pipe
 	AUTOWIKI_SKIP(TRUE)
-
 	name = "bursting pipe"
 	alpha = 0
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /obj/item/explosive/grenade/incendiary/bursting_pipe
 	AUTOWIKI_SKIP(TRUE)
-
 	name = "bursting pipe"
 	alpha = 0
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -909,12 +909,14 @@
 
 /obj/item/explosive/grenade/high_explosive/bursting_pipe
 	AUTOWIKI_SKIP(TRUE)
+
 	name = "bursting pipe"
 	alpha = 0
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /obj/item/explosive/grenade/incendiary/bursting_pipe
 	AUTOWIKI_SKIP(TRUE)
+
 	name = "bursting pipe"
 	alpha = 0
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT

--- a/code/modules/autowiki/pages/guns.dm
+++ b/code/modules/autowiki/pages/guns.dm
@@ -73,7 +73,7 @@
 			var/iterator = 1
 			for(var/header in gun_ammo_data["damage_armor_profile_headers"])
 				var/damage = gun_ammo_data["damage_armor_profile_marine"][iterator]
-				if(!damage)
+				if(isnull(damage))
 					break
 				armor_data["armor-[header]"] = damage
 				iterator++
@@ -143,6 +143,9 @@
 
 			for(var/attachment_typepath in attachments_by_slot[slot])
 				var/obj/item/attachable/generating_attachment = new attachment_typepath()
+
+				if(IS_AUTOWIKI_SKIP(generating_attachment))
+					continue
 
 				var/attachment_filename = SANITIZE_FILENAME(escape_value(format_text(generating_attachment.name)))
 

--- a/code/modules/autowiki/pages/xeno_stats.dm
+++ b/code/modules/autowiki/pages/xeno_stats.dm
@@ -27,10 +27,6 @@
 
 /datum/autowiki/xeno_stats/proc/template_from_xeno(mob/living/carbon/xenomorph/xeno, datum/xeno_strain/strain)
 	var/name = xeno.caste_type
-	if(!isnull(strain))
-		strain.apply_strain(xeno)
-		name = "[strain.name] [name]"
-
 	var/xeno_data = list(
 		"name" = name,
 		"health" = xeno.maxHealth,
@@ -46,6 +42,35 @@
 		"speed" = humanize_speed(xeno.speed),
 		"explosion_resistance" = xeno.caste.xeno_explosion_resistance,
 	)
+
+	if(!isnull(strain))
+		strain.apply_strain(xeno)
+		name = "[strain.name] [name]"
+		xeno_data["name"] = name
+		var/strain_data = list (
+			"name" = name,
+			"health" = xeno.maxHealth,
+			"armor" = xeno.armor_deflection,
+			"plasma" = xeno.plasma_max,
+			"plasma_regeneration" = xeno.plasma_gain,
+			"minimum_slash_damage" = xeno.melee_damage_lower,
+			"maximum_slash_damage" = xeno.melee_damage_upper,
+			"claw_strength" = xeno.claw_type,
+			"evasion" = xeno.evasion,
+			// Mob speed is relatively non-obvious, we we convert it into a very intuitive
+			// range for wiki-readability.
+			"speed" = humanize_speed(xeno.speed),
+			"explosion_resistance" = xeno.caste.xeno_explosion_resistance,
+		)
+
+		for(var/stat_comparison in xeno_data)
+			if(xeno_data[stat_comparison] != strain_data[stat_comparison])
+				var/difference = strain_data[stat_comparison] - xeno_data[stat_comparison]
+				if(difference > 0)
+					difference = "<span style='color:green'>+[difference]</span>"
+				else
+					difference = "<span style='color:red'>[difference]</span>"
+				xeno_data[stat_comparison] = "[strain_data[stat_comparison]] ([difference])"
 
 	var/sanitized_name = url_encode(replacetext(name, " ", "_"))
 	return list(list(title = "Template:Autowiki/Content/XenoStats/[sanitized_name]", text = include_template("Autowiki/XenoStats", xeno_data)))

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -336,6 +336,8 @@ Defined in conflicts.dm of the #defines folder.
 	accuracy_unwielded_mod = -HIT_ACCURACY_MULT_TIER_1
 
 /obj/item/attachable/bayonet/upp_replica
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "\improper Type 80 bayonet"
 	desc = "The standard-issue bayonet of the UPP, it's dulled from heavy use."
 	icon_state = "upp_bayonet"
@@ -343,6 +345,8 @@ Defined in conflicts.dm of the #defines folder.
 	attach_icon = "upp_bayonet_a"
 
 /obj/item/attachable/bayonet/wy
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "\improper SA120 L7 bayonet"
 	desc = "The standard-issue bayonet of the W-Y Commandos and PMCs, has a better ergonomic carbon finish grip and corrosion proof blade."
 	icon_state = "wy_bayonet"
@@ -350,6 +354,8 @@ Defined in conflicts.dm of the #defines folder.
 	unacidable = TRUE
 
 /obj/item/attachable/bayonet/upp
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "\improper Type 80 bayonet"
 	desc = "The standard-issue bayonet of the UPP, the Type 80 is balanced to also function as an effective throwing knife."
 	icon_state = "upp_bayonet"
@@ -361,6 +367,8 @@ Defined in conflicts.dm of the #defines folder.
 	pry_delay = 1 SECONDS
 
 /obj/item/attachable/bayonet/co2
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "\improper M8 cartridge bayonet"
 	desc = "A back issue USCM approved exclusive for Boots subscribers found in issue #255 'Inside the Night Raider - morale breaking alternatives with 2nd LT. Juliane Gerd'. A pressurized tube runs along the inside of the blade, and a button allows one to inject compressed CO2 into the stab wound. It feels cheap to the touch. Faulty even."
 	icon_state = "co2_knife"
@@ -368,6 +376,8 @@ Defined in conflicts.dm of the #defines folder.
 	var/filled = FALSE
 
 /obj/item/attachable/bayonet/rmc
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "\improper L5 bayonet"
 	desc = "The standard-issue bayonet of the RMC, the L5 is balanced to also function as an effective throwing knife."
 	icon_state = "twe_bayonet"
@@ -379,6 +389,8 @@ Defined in conflicts.dm of the #defines folder.
 	pry_delay = 1 SECONDS
 
 /obj/item/attachable/bayonet/antique
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "\improper antique bayonet"
 	desc = "An antique-style bayonet, has a long blade, wooden handle with brass fittings, reflecting historical craftsmanship."
 	icon_state = "antique_bayonet"
@@ -386,6 +398,8 @@ Defined in conflicts.dm of the #defines folder.
 	attach_icon = "antique_bayonet_a"
 
 /obj/item/attachable/bayonet/rmc_replica
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "\improper L5 bayonet"
 	desc = "The standard-issue bayonet of the RMC, it's dulled from heavy use."
 	icon_state = "twe_bayonet"
@@ -393,6 +407,8 @@ Defined in conflicts.dm of the #defines folder.
 	attach_icon = "twe_bayonet_a"
 
 /obj/item/attachable/bayonet/custom
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "\improper M5 'Raven's Claw' tactical bayonet"
 	desc = "A prototype bayonet-combat knife hybrid, engineered for close-quarters engagements and urban operations. Its rugged construction, quick-detach mechanism and deadly versatility make it a formidable tool."
 	icon_state = "bayonet_custom"
@@ -400,24 +416,32 @@ Defined in conflicts.dm of the #defines folder.
 	attach_icon = "bayonet_custom_a"
 
 /obj/item/attachable/bayonet/custom/red
+	AUTOWIKI_SKIP(TRUE)
+
 	desc = "A prototype bayonet-combat knife hybrid, engineered for close-quarters engagements and urban operations. Its rugged construction, quick-detach mechanism and deadly versatility make it a formidable tool. This version has been customized with a red grip and gold detailing, giving it a unique and distinctive appearance."
 	icon_state = "bayonet_custom_red"
 	item_state = "combat_knife"
 	attach_icon = "bayonet_custom_red_a"
 
 /obj/item/attachable/bayonet/custom/blue
+	AUTOWIKI_SKIP(TRUE)
+
 	desc = "A prototype bayonet-combat knife hybrid, engineered for close-quarters engagements and urban operations. Its rugged construction, quick-detach mechanism and deadly versatility make it a formidable tool. This version has been customized with a blue grip and gold detailing, giving it a unique and distinctive appearance."
 	icon_state = "bayonet_custom_blue"
 	item_state = "combat_knife"
 	attach_icon = "bayonet_custom_blue_a"
 
 /obj/item/attachable/bayonet/custom/black
+	AUTOWIKI_SKIP(TRUE)
+
 	desc = "A prototype bayonet-combat knife hybrid, engineered for close-quarters engagements and urban operations. Its rugged construction, quick-detach mechanism and deadly versatility make it a formidable tool. This version has been customized with a black grip and gold detailing, giving it a unique and distinctive appearance."
 	icon_state = "bayonet_custom_black"
 	item_state = "combat_knife"
 	attach_icon = "bayonet_custom_black_a"
 
 /obj/item/attachable/bayonet/tanto
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "\improper T9 tactical bayonet"
 	desc = "Preferred by TWE colonial military forces in the Neroid Sector, the T9 is designed for urban combat with a durable tanto blade and quick-attach system, reflecting traditional Japanese blade influences. Occasionally seen in the hands of Colonial Liberation Front (CLF) forces, often stolen from TWE detatchments and outposts across the sector."
 	icon_state = "bayonet_tanto"
@@ -425,11 +449,15 @@ Defined in conflicts.dm of the #defines folder.
 	attach_icon = "bayonet_tanto_a"
 
 /obj/item/attachable/bayonet/tanto/blue
+	AUTOWIKI_SKIP(TRUE)
+
 	icon_state = "bayonet_tanto_alt"
 	item_state = "combat_knife"
 	attach_icon = "bayonet_tanto_alt_a"
 
 /obj/item/attachable/bayonet/van_bandolier
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "\improper Fairbairn-Sykes fighting knife"
 	desc = "This isn't for dressing game or performing camp chores. It's almost certainly not an original. Almost."
 
@@ -602,6 +630,7 @@ Defined in conflicts.dm of the #defines folder.
 	size_mod = 0
 
 /obj/item/attachable/l56a2_smartgun
+	AUTOWIKI_SKIP(TRUE)
 	name = "l56a2 barrel"
 	desc = "This isn't supposed to be separated from the gun, how'd this happen?"
 	icon_state = "magsg_barrel_a"
@@ -674,6 +703,7 @@ Defined in conflicts.dm of the #defines folder.
 	scatter_mod = -SCATTER_AMOUNT_TIER_8
 
 /obj/item/attachable/smartbarrel
+	AUTOWIKI_SKIP(TRUE)
 	name = "smartgun barrel"
 	icon = 'icons/obj/items/weapons/guns/attachments/barrel.dmi'
 	icon_state = "m56_barrel"
@@ -2331,6 +2361,7 @@ Defined in conflicts.dm of the #defines folder.
 	return .
 
 /obj/item/attachable/stock/mod88
+	AUTOWIKI_SKIP(TRUE)
 	name = "\improper Mod 88 burst stock"
 	desc = "Increases the fire rate and burst amount on the Mod 88. Some versions act as a holster for the weapon when un-attached. This is a test item and should not be used in normal gameplay (yet)."
 	icon_state = "mod88_stock"

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -337,6 +337,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/upp_replica
 	AUTOWIKI_SKIP(TRUE)
+
 	name = "\improper Type 80 bayonet"
 	desc = "The standard-issue bayonet of the UPP, it's dulled from heavy use."
 	icon_state = "upp_bayonet"
@@ -345,6 +346,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/wy
 	AUTOWIKI_SKIP(TRUE)
+
 	name = "\improper SA120 L7 bayonet"
 	desc = "The standard-issue bayonet of the W-Y Commandos and PMCs, has a better ergonomic carbon finish grip and corrosion proof blade."
 	icon_state = "wy_bayonet"
@@ -353,6 +355,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/upp
 	AUTOWIKI_SKIP(TRUE)
+
 	name = "\improper Type 80 bayonet"
 	desc = "The standard-issue bayonet of the UPP, the Type 80 is balanced to also function as an effective throwing knife."
 	icon_state = "upp_bayonet"
@@ -365,6 +368,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/co2
 	AUTOWIKI_SKIP(TRUE)
+
 	name = "\improper M8 cartridge bayonet"
 	desc = "A back issue USCM approved exclusive for Boots subscribers found in issue #255 'Inside the Night Raider - morale breaking alternatives with 2nd LT. Juliane Gerd'. A pressurized tube runs along the inside of the blade, and a button allows one to inject compressed CO2 into the stab wound. It feels cheap to the touch. Faulty even."
 	icon_state = "co2_knife"
@@ -373,6 +377,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/rmc
 	AUTOWIKI_SKIP(TRUE)
+
 	name = "\improper L5 bayonet"
 	desc = "The standard-issue bayonet of the RMC, the L5 is balanced to also function as an effective throwing knife."
 	icon_state = "twe_bayonet"
@@ -385,6 +390,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/antique
 	AUTOWIKI_SKIP(TRUE)
+
 	name = "\improper antique bayonet"
 	desc = "An antique-style bayonet, has a long blade, wooden handle with brass fittings, reflecting historical craftsmanship."
 	icon_state = "antique_bayonet"
@@ -393,6 +399,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/rmc_replica
 	AUTOWIKI_SKIP(TRUE)
+
 	name = "\improper L5 bayonet"
 	desc = "The standard-issue bayonet of the RMC, it's dulled from heavy use."
 	icon_state = "twe_bayonet"
@@ -401,6 +408,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/custom
 	AUTOWIKI_SKIP(TRUE)
+
 	name = "\improper M5 'Raven's Claw' tactical bayonet"
 	desc = "A prototype bayonet-combat knife hybrid, engineered for close-quarters engagements and urban operations. Its rugged construction, quick-detach mechanism and deadly versatility make it a formidable tool."
 	icon_state = "bayonet_custom"
@@ -409,6 +417,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/custom/red
 	AUTOWIKI_SKIP(TRUE)
+
 	desc = "A prototype bayonet-combat knife hybrid, engineered for close-quarters engagements and urban operations. Its rugged construction, quick-detach mechanism and deadly versatility make it a formidable tool. This version has been customized with a red grip and gold detailing, giving it a unique and distinctive appearance."
 	icon_state = "bayonet_custom_red"
 	item_state = "combat_knife"
@@ -416,6 +425,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/custom/blue
 	AUTOWIKI_SKIP(TRUE)
+
 	desc = "A prototype bayonet-combat knife hybrid, engineered for close-quarters engagements and urban operations. Its rugged construction, quick-detach mechanism and deadly versatility make it a formidable tool. This version has been customized with a blue grip and gold detailing, giving it a unique and distinctive appearance."
 	icon_state = "bayonet_custom_blue"
 	item_state = "combat_knife"
@@ -423,6 +433,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/custom/black
 	AUTOWIKI_SKIP(TRUE)
+
 	desc = "A prototype bayonet-combat knife hybrid, engineered for close-quarters engagements and urban operations. Its rugged construction, quick-detach mechanism and deadly versatility make it a formidable tool. This version has been customized with a black grip and gold detailing, giving it a unique and distinctive appearance."
 	icon_state = "bayonet_custom_black"
 	item_state = "combat_knife"
@@ -430,6 +441,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/tanto
 	AUTOWIKI_SKIP(TRUE)
+
 	name = "\improper T9 tactical bayonet"
 	desc = "Preferred by TWE colonial military forces in the Neroid Sector, the T9 is designed for urban combat with a durable tanto blade and quick-attach system, reflecting traditional Japanese blade influences. Occasionally seen in the hands of Colonial Liberation Front (CLF) forces, often stolen from TWE detatchments and outposts across the sector."
 	icon_state = "bayonet_tanto"
@@ -438,12 +450,14 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/tanto/blue
 	AUTOWIKI_SKIP(TRUE)
+
 	icon_state = "bayonet_tanto_alt"
 	item_state = "combat_knife"
 	attach_icon = "bayonet_tanto_alt_a"
 
 /obj/item/attachable/bayonet/van_bandolier
 	AUTOWIKI_SKIP(TRUE)
+
 	name = "\improper Fairbairn-Sykes fighting knife"
 	desc = "This isn't for dressing game or performing camp chores. It's almost certainly not an original. Almost."
 
@@ -577,6 +591,8 @@ Defined in conflicts.dm of the #defines folder.
 	return ..()
 
 /obj/item/attachable/slavicbarrel
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "sniper barrel"
 	icon = 'icons/obj/items/weapons/guns/attachments/barrel.dmi'
 	icon_state = "slavicbarrel"
@@ -617,6 +633,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/l56a2_smartgun
 	AUTOWIKI_SKIP(TRUE)
+
 	name = "l56a2 barrel"
 	desc = "This isn't supposed to be separated from the gun, how'd this happen?"
 	icon_state = "magsg_barrel_a"
@@ -628,6 +645,8 @@ Defined in conflicts.dm of the #defines folder.
 	size_mod = 0
 
 /obj/item/attachable/sniperbarrel
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "sniper barrel"
 	icon = 'icons/obj/items/weapons/guns/attachments/barrel.dmi'
 	icon_state = "sniperbarrel"
@@ -642,6 +661,8 @@ Defined in conflicts.dm of the #defines folder.
 	scatter_mod = -SCATTER_AMOUNT_TIER_8
 
 /obj/item/attachable/pmc_sniperbarrel
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "sniper barrel"
 	icon = 'icons/obj/items/weapons/guns/attachments/barrel.dmi'
 	icon_state = "pmc_sniperbarrel"
@@ -661,6 +682,8 @@ Defined in conflicts.dm of the #defines folder.
 	hud_offset_mod = -1
 
 /obj/item/attachable/m60barrel
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "M60 barrel"
 	icon = 'icons/obj/items/weapons/guns/attachments/barrel.dmi'
 	icon_state = "m60barrel"
@@ -675,6 +698,8 @@ Defined in conflicts.dm of the #defines folder.
 	scatter_mod = -SCATTER_AMOUNT_TIER_8
 
 /obj/item/attachable/mar50barrel
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "MAR-50 barrel"
 	icon = 'icons/obj/items/weapons/guns/attachments/barrel.dmi'
 	icon_state = "mar50barrel"
@@ -690,6 +715,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/smartbarrel
 	AUTOWIKI_SKIP(TRUE)
+
 	name = "smartgun barrel"
 	icon = 'icons/obj/items/weapons/guns/attachments/barrel.dmi'
 	icon_state = "m56_barrel"
@@ -2064,6 +2090,8 @@ Defined in conflicts.dm of the #defines folder.
 	scatter_unwielded_mod = -SCATTER_AMOUNT_TIER_10
 
 /obj/item/attachable/stock/hunting
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "wooden stock"
 	desc = "The non-detachable stock of a Basira-Armstrong rifle."
 	icon_state = "huntingstock"
@@ -2085,6 +2113,8 @@ Defined in conflicts.dm of the #defines folder.
 	scatter_unwielded_mod = SCATTER_AMOUNT_TIER_8
 
 /obj/item/attachable/stock/hg3712
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "hg3712 stock"
 	desc = "The non-detachable stock of a HG 37-12 pump shotgun."
 	icon_state = "hg3712_stock"
@@ -2108,6 +2138,7 @@ Defined in conflicts.dm of the #defines folder.
 	wield_delay_mod = WIELD_DELAY_NONE
 
 /obj/item/attachable/stock/hg3712/m3717
+	AUTOWIKI_SKIP(TRUE)
 	name = "hg3717 stock"
 	desc = "The non-detachable stock of a M37-17 pump shotgun."
 	icon_state = "hg3717_stock"
@@ -2348,6 +2379,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/stock/mod88
 	AUTOWIKI_SKIP(TRUE)
+
 	name = "\improper Mod 88 burst stock"
 	desc = "Increases the fire rate and burst amount on the Mod 88. Some versions act as a holster for the weapon when un-attached. This is a test item and should not be used in normal gameplay (yet)."
 	icon_state = "mod88_stock"
@@ -2450,6 +2482,8 @@ Defined in conflicts.dm of the #defines folder.
 	hud_offset_mod = 10 //A sprite long enough to touch the Moon.
 
 /obj/item/attachable/m4ra_barrel
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "M4RA barrel"
 	desc = "This isn't supposed to be separated from the gun, how'd this happen?"
 	icon_state = "m4ra_barrel"
@@ -2483,6 +2517,8 @@ Defined in conflicts.dm of the #defines folder.
 	return .
 
 /obj/item/attachable/m4ra_barrel_custom
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "custom M4RA barrel"
 	desc = "This isn't supposed to be separated from the gun, how'd this happen?"
 	icon_state = "m4ra_custom_barrel"
@@ -2516,6 +2552,8 @@ Defined in conflicts.dm of the #defines folder.
 	return .
 
 /obj/item/attachable/upp_rpg_breech
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "HJRA-12 Breech"
 	desc = "This isn't supposed to be separated from the gun, how'd this happen?"
 	icon = 'icons/obj/items/weapons/guns/attachments/stock.dmi'
@@ -2528,6 +2566,8 @@ Defined in conflicts.dm of the #defines folder.
 	size_mod = 0
 
 /obj/item/attachable/pkpbarrel
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "QYJ-72 Barrel"
 	desc = "This isn't supposed to be separated from the gun, how'd this happen?"
 	icon = 'icons/obj/items/weapons/guns/attachments/barrel.dmi'
@@ -2540,6 +2580,8 @@ Defined in conflicts.dm of the #defines folder.
 	size_mod = 0
 
 /obj/item/attachable/stock/pkpstock
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "QYJ-72 Stock"
 	desc = "This isn't supposed to be separated from the gun, how'd this happen?"
 	icon = 'icons/obj/items/weapons/guns/attachments/stock.dmi'
@@ -2552,6 +2594,8 @@ Defined in conflicts.dm of the #defines folder.
 	size_mod = 0
 
 /obj/item/attachable/type88_barrel
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "Type-88 Barrel"
 	desc = "This isn't supposed to be separated from the gun, how'd this happen?"
 	icon = 'icons/obj/items/weapons/guns/attachments/barrel.dmi'
@@ -2564,6 +2608,8 @@ Defined in conflicts.dm of the #defines folder.
 	size_mod = 0
 
 /obj/item/attachable/type73suppressor
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "Type 73 Integrated Suppressor"
 	desc = "This isn't supposed to be separated from the gun, how'd this happen?"
 	icon = 'icons/obj/items/weapons/guns/attachments/barrel.dmi'
@@ -2576,6 +2622,8 @@ Defined in conflicts.dm of the #defines folder.
 	size_mod = 0
 
 /obj/item/attachable/stock/type71
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "Type 71 Stock"
 	desc = "This isn't supposed to be separated from the gun, how'd this happen?"
 	icon = 'icons/obj/items/weapons/guns/attachments/stock.dmi'
@@ -2591,6 +2639,8 @@ Defined in conflicts.dm of the #defines folder.
 	..()
 
 /obj/item/attachable/stock/m60
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "M60 stock"
 	desc = "This isn't supposed to be separated from the gun, how'd this happen?"
 	icon = 'icons/obj/items/weapons/guns/attachments/stock.dmi'
@@ -2604,6 +2654,8 @@ Defined in conflicts.dm of the #defines folder.
 
 
 /obj/item/attachable/stock/ppsh
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "PPSh-17b stock"
 	desc = "This isn't supposed to be separated from the gun, how'd this happen?"
 	icon = 'icons/obj/items/weapons/guns/attachments/stock.dmi'
@@ -2869,6 +2921,8 @@ Defined in conflicts.dm of the #defines folder.
 		R.flags_equip_slot |= SLOT_WAIST
 
 /obj/item/attachable/stock/nsg23
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "NSG 23 stock"
 	desc = "If you can read this, someone screwed up. Go Github this and bug a coder."
 	icon_state = "nsg23_stock"
@@ -2881,6 +2935,8 @@ Defined in conflicts.dm of the #defines folder.
 	hud_offset_mod = 2
 
 /obj/item/attachable/stock/l23
+	AUTOWIKI_SKIP(TRUE)
+
 	name = "L23 stock"
 	desc = "If you can read this, someone screwed up. Go Github this and bug a coder."
 	icon_state = "l23_stock"

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -337,7 +337,6 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/upp_replica
 	AUTOWIKI_SKIP(TRUE)
-
 	name = "\improper Type 80 bayonet"
 	desc = "The standard-issue bayonet of the UPP, it's dulled from heavy use."
 	icon_state = "upp_bayonet"
@@ -346,7 +345,6 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/wy
 	AUTOWIKI_SKIP(TRUE)
-
 	name = "\improper SA120 L7 bayonet"
 	desc = "The standard-issue bayonet of the W-Y Commandos and PMCs, has a better ergonomic carbon finish grip and corrosion proof blade."
 	icon_state = "wy_bayonet"
@@ -355,7 +353,6 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/upp
 	AUTOWIKI_SKIP(TRUE)
-
 	name = "\improper Type 80 bayonet"
 	desc = "The standard-issue bayonet of the UPP, the Type 80 is balanced to also function as an effective throwing knife."
 	icon_state = "upp_bayonet"
@@ -368,7 +365,6 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/co2
 	AUTOWIKI_SKIP(TRUE)
-
 	name = "\improper M8 cartridge bayonet"
 	desc = "A back issue USCM approved exclusive for Boots subscribers found in issue #255 'Inside the Night Raider - morale breaking alternatives with 2nd LT. Juliane Gerd'. A pressurized tube runs along the inside of the blade, and a button allows one to inject compressed CO2 into the stab wound. It feels cheap to the touch. Faulty even."
 	icon_state = "co2_knife"
@@ -377,7 +373,6 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/rmc
 	AUTOWIKI_SKIP(TRUE)
-
 	name = "\improper L5 bayonet"
 	desc = "The standard-issue bayonet of the RMC, the L5 is balanced to also function as an effective throwing knife."
 	icon_state = "twe_bayonet"
@@ -390,7 +385,6 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/antique
 	AUTOWIKI_SKIP(TRUE)
-
 	name = "\improper antique bayonet"
 	desc = "An antique-style bayonet, has a long blade, wooden handle with brass fittings, reflecting historical craftsmanship."
 	icon_state = "antique_bayonet"
@@ -399,7 +393,6 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/rmc_replica
 	AUTOWIKI_SKIP(TRUE)
-
 	name = "\improper L5 bayonet"
 	desc = "The standard-issue bayonet of the RMC, it's dulled from heavy use."
 	icon_state = "twe_bayonet"
@@ -408,7 +401,6 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/custom
 	AUTOWIKI_SKIP(TRUE)
-
 	name = "\improper M5 'Raven's Claw' tactical bayonet"
 	desc = "A prototype bayonet-combat knife hybrid, engineered for close-quarters engagements and urban operations. Its rugged construction, quick-detach mechanism and deadly versatility make it a formidable tool."
 	icon_state = "bayonet_custom"
@@ -417,7 +409,6 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/custom/red
 	AUTOWIKI_SKIP(TRUE)
-
 	desc = "A prototype bayonet-combat knife hybrid, engineered for close-quarters engagements and urban operations. Its rugged construction, quick-detach mechanism and deadly versatility make it a formidable tool. This version has been customized with a red grip and gold detailing, giving it a unique and distinctive appearance."
 	icon_state = "bayonet_custom_red"
 	item_state = "combat_knife"
@@ -425,7 +416,6 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/custom/blue
 	AUTOWIKI_SKIP(TRUE)
-
 	desc = "A prototype bayonet-combat knife hybrid, engineered for close-quarters engagements and urban operations. Its rugged construction, quick-detach mechanism and deadly versatility make it a formidable tool. This version has been customized with a blue grip and gold detailing, giving it a unique and distinctive appearance."
 	icon_state = "bayonet_custom_blue"
 	item_state = "combat_knife"
@@ -433,7 +423,6 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/custom/black
 	AUTOWIKI_SKIP(TRUE)
-
 	desc = "A prototype bayonet-combat knife hybrid, engineered for close-quarters engagements and urban operations. Its rugged construction, quick-detach mechanism and deadly versatility make it a formidable tool. This version has been customized with a black grip and gold detailing, giving it a unique and distinctive appearance."
 	icon_state = "bayonet_custom_black"
 	item_state = "combat_knife"
@@ -441,7 +430,6 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/tanto
 	AUTOWIKI_SKIP(TRUE)
-
 	name = "\improper T9 tactical bayonet"
 	desc = "Preferred by TWE colonial military forces in the Neroid Sector, the T9 is designed for urban combat with a durable tanto blade and quick-attach system, reflecting traditional Japanese blade influences. Occasionally seen in the hands of Colonial Liberation Front (CLF) forces, often stolen from TWE detatchments and outposts across the sector."
 	icon_state = "bayonet_tanto"
@@ -450,14 +438,12 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/tanto/blue
 	AUTOWIKI_SKIP(TRUE)
-
 	icon_state = "bayonet_tanto_alt"
 	item_state = "combat_knife"
 	attach_icon = "bayonet_tanto_alt_a"
 
 /obj/item/attachable/bayonet/van_bandolier
 	AUTOWIKI_SKIP(TRUE)
-
 	name = "\improper Fairbairn-Sykes fighting knife"
 	desc = "This isn't for dressing game or performing camp chores. It's almost certainly not an original. Almost."
 


### PR DESCRIPTION

# About the pull request

Skips some things like bursting pipes which are a... subtype of grenade.

SG barrels? These aren't removable it's not really an attachment ugh.
88 Burst Stock ??

Other barrels and stocks that are basically just the weapon because they're not removable.

14 different kinds of bayonet which are basically the same. The urge to add some sort of generic bayonet for just autowiki is high but my effort is low. Cause I'd need to add it to every gun that has bayonets.

Armour damage table thingie uses isnull to allow 0 values in the table.

Implement Drathek's thingie for looking at the differences for strains and base. Though just using a loop and adding colour.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Uhhhh wiki shouldn't be flooded with bayonets, and random attachies. And grenades that pretend they're bursting pipes. Armour damage tables shouldn't say armour-40 when it should be 0.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MistChristmas, Drathek
qol: Autowiki: Ignores most bayonets, and other misc. attachments. Compares difference in base vs strain stats. Switches to using isnull so armour damage table populates 0s.
/:cl:
