### PR TITLE
[In need of sprites] Mangonel: Siege-oriented Sentinel Strain

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -408,6 +408,9 @@
 #define PRAETORIAN_VALKYRIE "Valkyrie"
 #define PRAETORIAN_OPPRESSOR "Oppressor"
 
+// Sentinel strain flags
+#define SENTINEL_MANGONEL "Mangonel"
+
 /////////////////////////////////////////////////////////////////////////////////////
 //
 // Modifiers

--- a/code/datums/ammo/xeno.dm
+++ b/code/datums/ammo/xeno.dm
@@ -191,6 +191,26 @@
 /datum/ammo/xeno/acid/dot
 	name = "acid spit"
 
+/datum/ammo/xeno/acid/mangonel_shotgun
+	damage = 10
+	bonus_projectiles_type = /datum/ammo/xeno/acid/mangonel_shotgun/extra
+	accurate_range = 5
+	max_range = 5
+	bonus_projectiles_amount = EXTRA_PROJECTILES_TIER_4
+
+/datum/ammo/xeno/acid/mangonel_shotgun/extra
+	scatter = SCATTER_AMOUNT_TIER_1
+	bonus_projectiles_amount = 0
+
+/datum/ammo/xeno/acid/mangonel_siege
+	name = "acid bolt"
+	icon_state = "xeno_acid_strong"
+	damage = 30
+
+/datum/ammo/xeno/acid/mangonel_siege/on_hit_obj(obj/target, obj/projectile/proj)
+	if(istype(target, /obj/structure/barricade))
+		damage = damage * 2
+
 /datum/ammo/xeno/acid/prae_nade // Used by base prae's acid nade
 	name = "acid scatter"
 	icon_state = "xeno_acid_normal"

--- a/code/modules/mob/living/carbon/xenomorph/abilities/sentinel/sentinel_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/sentinel/sentinel_abilities.dm
@@ -29,3 +29,35 @@
 	plasma_cost = 50
 
 	var/buff_duration = 50
+
+// Mangonel Abilities
+
+// Entrench
+/datum/action/xeno_action/onclick/entrench
+	name = "Entrench"
+	action_icon_state = "agility_on"
+	macro_path = /datum/action/xeno_action/verb/verb_entrench
+	action_type = XENO_ACTION_CLICK
+	ability_primacy = XENO_PRIMARY_ACTION_1
+	xeno_cooldown = 5 SECONDS
+	plasma_cost = 15
+
+// Adaptive Spit
+/datum/action/xeno_action/activable/adaptive_spit
+	name = "Adaptive Spit"
+	action_icon_state = "xeno_spit"
+	macro_path = /datum/action/xeno_action/verb/verb_adaptive_spit
+	action_type = XENO_ACTION_CLICK
+	ability_primacy = XENO_PRIMARY_ACTION_2
+	xeno_cooldown = 5 SECONDS
+	plasma_cost = 30
+
+// Gas Shroud
+/datum/action/xeno_action/onclick/gas_shroud
+	name = "Gas Shroud"
+	action_icon_state = "acid_shroud"
+	macro_path = /datum/action/xeno_action/verb/verb_gas_shroud
+	action_type = XENO_ACTION_CLICK
+	ability_primacy = XENO_PRIMARY_ACTION_3
+	xeno_cooldown = 15 SECONDS
+	plasma_cost = 20

--- a/code/modules/mob/living/carbon/xenomorph/abilities/sentinel/sentinel_macros.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/sentinel/sentinel_macros.dm
@@ -18,3 +18,26 @@
 	set hidden = TRUE
 	var/action_name = "Paralyzing Slash"
 	handle_xeno_macro(src,action_name)
+
+// Mangonel
+
+/datum/action/xeno_action/verb/verb_entrench()
+	set category = "Alien"
+	set name = "Entrench"
+	set hidden = TRUE
+	var/action_name = "Entrench"
+	handle_xeno_macro(src,action_name)
+
+/datum/action/xeno_action/verb/verb_adaptive_spit()
+	set category = "Alien"
+	set name = "Adaptive Spit"
+	set hidden = TRUE
+	var/action_name = "Adaptive Spit"
+	handle_xeno_macro(src,action_name)
+
+/datum/action/xeno_action/verb/verb_gas_shroud()
+	set category = "Alien"
+	set name = "Gas Shroud"
+	set hidden = TRUE
+	var/action_name = "Gas Shroud"
+	handle_xeno_macro(src,action_name)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Sentinel.dm
@@ -24,6 +24,7 @@
 	tacklestrength_min = 4
 	tacklestrength_max = 4
 
+	available_strains = list(/datum/xeno_strain/mangonel)
 	behavior_delegate_type = /datum/behavior_delegate/sentinel_base
 	minimap_icon = "sentinel"
 

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/sentinel/mangonel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/sentinel/mangonel.dm
@@ -1,7 +1,7 @@
 /datum/xeno_strain/mangonel
 	name = SENTINEL_MANGONEL
 	description = "Exchange your base abilities, some speed and some slash damage for increased explosive armor and abilities oriented around besieging locations, and where the strengths of your abilities alter based on what type of weeds you are standing on. Entrench roots you in place, draining your plasma to increase your armor based on the type of weeds you're standing on. Adaptive Spit switches between a low damaging scattershot to a single higher damage shot depending on Entrenchment, which also influences single shot damage. Gas Shroud creates a small, vision-blocking cloud of gas which slows those who walk through it, serving as an escape and obfuscation tool."
-	flavor_description = "Lay siege upon their walls so that their defences may crumble."
+	flavor_description = "Lay siege upon their walls, and watch their defences fall before us."
 //	icon_state_prefix = "Mangonel"
 
 	actions_to_remove = list(

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/sentinel/mangonel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/sentinel/mangonel.dm
@@ -1,0 +1,212 @@
+/datum/xeno_strain/mangonel
+	name = SENTINEL_MANGONEL
+	description = "Exchange your base abilities, some speed and some slash damage for increased explosive armor and abilities oriented around besieging locations, and where the strengths of your abilities alter based on what type of weeds you are standing on. Entrench roots you in place, draining your plasma to increase your armor based on the type of weeds you're standing on. Adaptive Spit switches between a low damaging scattershot to a single higher damage shot depending on Entrenchment, which also influences single shot damage. Gas Shroud creates a small, vision-blocking cloud of gas which slows those who walk through it, serving as an escape and obfuscation tool."
+	flavor_description = "Lay siege upon their walls so that their defences may crumble."
+//	icon_state_prefix = "Mangonel"
+
+	actions_to_remove = list(
+		/datum/action/xeno_action/activable/slowing_spit,
+		/datum/action/xeno_action/activable/scattered_spit,
+		/datum/action/xeno_action/onclick/paralyzing_slash,
+	)
+	actions_to_add = list(
+		/datum/action/xeno_action/onclick/entrench,
+		/datum/action/xeno_action/activable/adaptive_spit,
+		/datum/action/xeno_action/onclick/gas_shroud,
+	)
+
+	behavior_delegate_type = /datum/behavior_delegate/sentinel_mangonel
+
+/datum/xeno_strain/mangonel/apply_strain(mob/living/carbon/xenomorph/sentinel/sent)
+	sent.speed_modifier += XENO_SPEED_SLOWMOD_TIER_4
+	sent.damage_modifier -= XENO_DAMAGE_MOD_VERY_SMALL
+	sent.explosivearmor_modifier += XENO_EXPOSIVEARMOR_MOD_MED
+
+	sent.recalculate_everything()
+
+/datum/behavior_delegate/sentinel_mangonel
+	name = "mangonel Sentinel Behavior Delegate"
+
+	var/entrenched = FALSE // Are we currently entrenched or not
+	var/weed_strength = 0 // What is the strength of the weeds we currently are standing on, if any (0 = no weeds, 1 = weak, 2 = normal, 3 = hardy, 4 = hive)
+	var/weed_strength_message = "" // To provide feedback on weeds being stood on when Entrenching
+	var/last_armor_buff = 0 // How much armor was given last time Entrench was used?
+	var/entrench_loc = null // Where was Entrench used? For disabling Entrench if knocked back
+
+/datum/behavior_delegate/sentinel_mangonel/on_life()
+
+	if(entrench_loc && bound_xeno.loc != entrench_loc)
+		entrench_effects(FALSE)
+
+	var/obj/effect/alien/weeds/turf_weeds = locate() in bound_xeno.loc
+	if(!turf_weeds)
+		weed_strength = 0
+		weed_strength_message = "! The lack of weeds belonging to our hive makes for poor reinforcement!"
+		return
+
+	if(turf_weeds.linked_hive.hivenumber == bound_xeno.hivenumber)
+		switch(turf_weeds.weed_strength)
+			if(WEED_LEVEL_WEAK)
+				weed_strength = 1
+				weed_strength_message = "! The [turf_weeds] barely reinforce us!"
+			if(WEED_LEVEL_STANDARD)
+				weed_strength = 2
+				weed_strength_message = "! The [turf_weeds] reinforce us!"
+			if(WEED_LEVEL_HARDY)
+				weed_strength = 3
+				weed_strength_message = "! The [turf_weeds] strongly reinforce us!"
+			if(WEED_LEVEL_HIVE)
+				weed_strength = 4
+				weed_strength_message = "! The [turf_weeds] greatly reinforce us!"
+
+/datum/behavior_delegate/sentinel_mangonel/proc/entrench_effects(effects_active)
+	last_armor_buff = 5 + (5 * weed_strength)
+
+	if(effects_active)
+		RegisterSignal(bound_xeno, COMSIG_XENO_ENTER_CRIT, PROC_REF(entrench_unconscious_check))
+		RegisterSignal(bound_xeno, COMSIG_MOB_DEATH, PROC_REF(entrench_unconscious_check))
+		bound_xeno.armor_deflection += last_armor_buff
+		ADD_TRAIT(bound_xeno, TRAIT_IMMOBILIZED, TRAIT_SOURCE_ABILITY("Entrench"))
+		bound_xeno.anchored = TRUE
+		bound_xeno.small_explosives_stun = FALSE
+		entrenched = TRUE
+		entrench_loc = bound_xeno.loc
+	else
+		UnregisterSignal(bound_xeno, COMSIG_XENO_ENTER_CRIT)
+		UnregisterSignal(bound_xeno, COMSIG_MOB_DEATH)
+		bound_xeno.armor_deflection -= last_armor_buff
+		REMOVE_TRAIT(bound_xeno, TRAIT_IMMOBILIZED, TRAIT_SOURCE_ABILITY("Entrench"))
+		bound_xeno.anchored = FALSE
+		bound_xeno.small_explosives_stun = TRUE
+		entrenched = FALSE
+		entrench_loc = null
+
+/datum/behavior_delegate/sentinel_mangonel/proc/entrench_unconscious_check()
+	SIGNAL_HANDLER
+
+	if(QDELETED(bound_xeno))
+		return
+
+	entrench_effects(FALSE)
+
+// Abilities
+
+// Entrench
+/datum/action/xeno_action/onclick/entrench/use_ability(atom/target)
+	var/mob/living/carbon/xenomorph/xeno = owner
+	if(!istype(xeno))
+		return
+
+	var/datum/behavior_delegate/sentinel_mangonel/beh_del = xeno.behavior_delegate
+	if(!istype(beh_del))
+		return
+
+	if(!xeno.check_state())
+		return
+
+	if(!action_cooldown_check())
+		return
+
+	if(!check_and_use_plasma_owner())
+		return
+
+	if(!beh_del.entrenched)
+		if(!do_after(xeno, 1 SECONDS, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_HOSTILE))
+			return
+		playsound(xeno.loc, 'sound/weapons/pierce.ogg', 25, 1)
+		xeno.visible_message(SPAN_XENODANGER("[xeno] digs itself into place!"), SPAN_XENODANGER("We dig ourself into place[beh_del.weed_strength_message]"))
+		beh_del.entrench_effects(TRUE)
+		button.icon_state = "template_active"
+	else
+		beh_del.entrench_effects(FALSE)
+		button.icon_state = "template"
+		apply_cooldown()
+
+	return ..()
+
+/datum/action/xeno_action/onclick/entrench/life_tick()
+	var/mob/living/carbon/xenomorph/xeno = owner
+	if(!istype(xeno))
+		return
+
+	var/datum/behavior_delegate/sentinel_mangonel/beh_del = xeno.behavior_delegate
+	if(!istype(beh_del))
+		return
+
+	if(beh_del.entrenched)
+		. = check_and_use_plasma_owner(plasma_cost)
+		if(. == FALSE)
+			beh_del.entrench_effects(FALSE)
+		return
+	return FALSE
+
+// Adaptive Spit
+/datum/action/xeno_action/activable/adaptive_spit/use_ability(atom/target)
+	var/mob/living/carbon/xenomorph/xeno = owner
+	if(!xeno.check_state())
+		return
+
+	var/datum/behavior_delegate/sentinel_mangonel/beh_del = xeno.behavior_delegate
+	if(!istype(beh_del))
+		return
+
+	if(!action_cooldown_check())
+		return
+
+	var/turf/current_turf = get_turf(xeno)
+	if(!current_turf)
+		return
+
+	if(!check_and_use_plasma_owner())
+		return
+
+	playsound(xeno.loc, "acid_spit", 25, 1)
+
+	var/datum/ammo/ammoDatum
+
+	if(beh_del.entrenched)
+		xeno.visible_message(SPAN_XENOWARNING("[xeno] spits a bolt of acid at [target]!"),
+		SPAN_XENOWARNING("We spit a bolt of acid at [target]!"))
+		ammoDatum = new /datum/ammo/xeno/acid/mangonel_siege()
+		if(beh_del.weed_strength > 0)
+			ammoDatum.damage = ammoDatum.damage + (5 * beh_del.weed_strength)
+	else
+		xeno.visible_message(SPAN_XENOWARNING("[xeno] spits a blast of acid at [target]!"),
+		SPAN_XENOWARNING("We spit a blast of acid at [target]!"))
+		ammoDatum = new /datum/ammo/xeno/acid/mangonel_shotgun()
+
+	var/obj/projectile/proj = new /obj/projectile(current_turf, create_cause_data(initial(xeno.caste_type), xeno))
+	proj.generate_bullet(ammoDatum)
+	proj.permutated += xeno
+	proj.def_zone = xeno.get_limbzone_target()
+	proj.fire_at(target, xeno, xeno, ammoDatum.max_range, ammoDatum.shell_speed)
+
+	apply_cooldown()
+	return ..()
+
+// Gas Shroud
+/datum/action/xeno_action/onclick/gas_shroud/use_ability(atom/target)
+	var/mob/living/carbon/xenomorph/xeno = owner
+	var/datum/effect_system/smoke_spread/xeno_slow_smokescreen/smokescreen
+	smokescreen = new /datum/effect_system/smoke_spread/xeno_slow_smokescreen
+
+	if(!isxeno(owner))
+		return
+
+	if(!action_cooldown_check())
+		return
+
+	if(!xeno.check_state())
+		return
+
+	if(!check_and_use_plasma_owner())
+		return
+
+	var/datum/cause_data/cause_data = create_cause_data("acid shroud gas", owner)
+	smokescreen.set_up(1, 0, get_turf(xeno), null, 6, new_cause_data = cause_data)
+	smokescreen.start()
+	playsound(xeno, 'sound/effects/smoke.ogg', 30, 1)
+	to_chat(xeno, SPAN_XENODANGER("We dump lightly paralytic venom through our pores, creating a shroud of gas!"))
+
+	apply_cooldown()
+	return ..()

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -2191,6 +2191,7 @@
 #include "code\modules\mob\living\carbon\xenomorph\strains\castes\ravager\berserker.dm"
 #include "code\modules\mob\living\carbon\xenomorph\strains\castes\ravager\hedgehog.dm"
 #include "code\modules\mob\living\carbon\xenomorph\strains\castes\runner\acid.dm"
+#include "code\modules\mob\living\carbon\xenomorph\strains\castes\sentinel\mangonel.dm"
 #include "code\modules\mob\living\silicon\death.dm"
 #include "code\modules\mob\living\silicon\login.dm"
 #include "code\modules\mob\living\silicon\say.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Adds a strain for Sentinel called Mangonel; in exchange for a bit of movement speed, a bit of slash damage, and base abilities, gain a chunk of explosive armor and new abilities: Entrench, Adaptive Spit and Gas Shroud.

- Entrench, 15 Plasma Cost and 15 Plasma drain per life tick, 5 Second Cooldown
After a 1 second wind-up, locks you in place and in the direction you're facing in exchange for immunity to small explosive stuns and extra armor that varies based on the strength of weeds you're standing on (At minimum 5 armor when standing on no weeds and 25 when standing on Hive weeds). If you enter crit or are somehow dislodged from where you have Entrenched, the ability ends.
- Adaptive Spit, 30 Plasma Cost, 5 Second Cooldown
A damaging ranged attack that alters function based on if you are Entrenched or not. If not Entrenched, Adaptive Spit is a 5 tile ranged shotgun-like spit with 5 projectiles in total which each deal 10 damage. If Entrenched, Adaptive Spit becomes a single bolt that deals 30 damage plus extra damage when standing on weeds, amount of extra damage depending on strength of weeds (5 at minimum, 20 at most). Additionally, single bolt deals 2x damage to cades.
- Gas Shroud, 20 Plasma Cost, 15 Second Cooldown
Create a small, short-lived cloud of obscuring smoke that slightly slows those who walk through it. Meant as an escape tool and visual obfuscation tool useful in interrupting turret LOS.

# Explain why it's good for the game

Sentinel can't do much against marines hiding behind cades such as in a siege scenario, and currently has no strains. This gives Sent a strain that turns it into a sort of Siege Engine benefiting from xeno-dominated terrain and rely on clever positioning or allies able to distract opponents/soak up damage for you since you need to render yourself vulnerable to properly attack.


# Testing Photographs and Procedure

To be added later.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Killfish
add: Adds Mangonel strain for Sentinel. Exchange mobility, slash damage and stun abilities for increased endurance and damaging ranged attacks which both change depending on weeds you're standing on.
add: Entrench to immobilize yourself and increase your armor by between 5 and 25, depending on weed strength.
add: Adaptive Spit changes based on Entrenchment, being a weak scattershot when mobile and a stronger single bolt when Entrenched. The single bolt gains extra damage when on weeds influenced by their strength, and additionally deals 2x damage to cades.
add: Gas Shroud creates a small and short-lived cloud of non-lethal gas that slows people down and blocks sight. Useful as an escape tool or to obscure turret LOS.
imageadd: [This will be changed when sprites are avaliable]
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
