### PR TITLE
Cleanup istype(src) usage in wall leaning

### DIFF
--- a/code/__DEFINES/dcs/signals/atom/mob/living/signals_human.dm
+++ b/code/__DEFINES/dcs/signals/atom/mob/living/signals_human.dm
@@ -86,6 +86,3 @@
 
 /// From /mob/living/carbon/human/UnarmedAttack()
 #define COMSIG_HUMAN_UNARMED_ATTACK "human_unarmed_attack"
-
-/// from /modules/animations/animations_library.dm
-#define COMSIG_HUMAN_ANIMATING "human_animating"

--- a/code/__DEFINES/dcs/signals/atom/mob/signals_mob.dm
+++ b/code/__DEFINES/dcs/signals/atom/mob/signals_mob.dm
@@ -188,3 +188,6 @@
 
 /// From /obj/item/roller/proc/deploy_roller() : (mob/user, obj/structure/bed/roller/roller)
 #define COMSIG_MOB_ITEM_ROLLER_DEPLOYED "mob_roller_deployed"
+
+/// From /modules/animations/animations_library.dm and /code/modules/mob/mob.dm
+#define COMSIG_MOB_ANIMATING "mob_animating"

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -172,7 +172,7 @@
 	if(direction == NORTH)
 		hiding_human.add_filter("cutout", 1, alpha_mask_filter(icon = icon('icons/effects/effects.dmi', "cutout")))
 	ADD_TRAIT(hiding_human, TRAIT_UNDENSE, WALL_HIDING_TRAIT)
-	RegisterSignal(hiding_human, list(COMSIG_MOVABLE_MOVED, COMSIG_LIVING_SET_BODY_POSITION, COMSIG_MOB_RESISTED, COMSIG_HUMAN_ANIMATING), PROC_REF(unhide_human), hiding_human)
+	RegisterSignal(hiding_human, list(COMSIG_MOVABLE_MOVED, COMSIG_LIVING_SET_BODY_POSITION, COMSIG_MOB_RESISTED, COMSIG_MOB_ANIMATING), PROC_REF(unhide_human), hiding_human)
 	..()
 
 /turf/closed/wall/proc/unhide_human(mob/living/carbon/human/to_unhide)
@@ -187,8 +187,7 @@
 	to_unhide.apply_effect(1, SUPERSLOW)
 	to_unhide.apply_effect(2, SLOW)
 	hiding_humans -= to_unhide
-	UnregisterSignal(to_unhide, list(COMSIG_MOVABLE_MOVED, COMSIG_LIVING_SET_BODY_POSITION, COMSIG_MOB_RESISTED))
-	UnregisterSignal(to_unhide, list(COMSIG_HUMAN_ANIMATING))
+	UnregisterSignal(to_unhide, list(COMSIG_MOVABLE_MOVED, COMSIG_LIVING_SET_BODY_POSITION, COMSIG_MOB_RESISTED, COMSIG_MOB_ANIMATING))
 	to_chat(to_unhide, SPAN_WARNING("You couldn't sit still so you stop leaning on the wall!"))
 	to_unhide.remove_filter("cutout")
 

--- a/code/modules/animations/animation_library.dm
+++ b/code/modules/animations/animation_library.dm
@@ -10,11 +10,6 @@ Instead of being uniform, it starts out a littler slower, goes fast in the middl
 4 ticks * 5 = 2 seconds. Doesn't loop on default, and spins right.
 */
 
-/proc/send_animating_signal(atom/A) //following code is intended for signalling pixel shifting animations, unsure of function to others
-	if(istype(A, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = A
-		SEND_SIGNAL(H, COMSIG_HUMAN_ANIMATING)
-
 /proc/animation_wrist_flick(atom/A, direction = 1, loop_num = 0) //-1 for a left spin.
 	animate(A, transform = matrix(120 * direction, MATRIX_ROTATE), time = 1, loop = loop_num, easing = SINE_EASING|EASE_IN)
 	animate(transform = matrix(240 * direction, MATRIX_ROTATE), time = 1)
@@ -180,12 +175,12 @@ Can look good elsewhere as well.*/
 
 
 /mob/living/proc/animation_attack_on(atom/A, pixel_offset = 8)
-	send_animating_signal(src)
+	SEND_SIGNAL(src, COMSIG_MOB_ANIMATING)
 	if(A.clone)
 		if(src.Adjacent(A.clone))
 			A = A.clone
 	if(buckled || anchored || HAS_TRAIT(src, TRAIT_HAULED)) //it would look silly.
-		return 
+		return
 	var/pixel_x_diff = 0
 	var/pixel_y_diff = 0
 	var/direction = get_dir(src, A)
@@ -246,12 +241,15 @@ Can look good elsewhere as well.*/
 
 /atom/proc/sway_jitter(times = 3, steps = 3, strength = 3, sway = 5)
 	var/sway_dir = 1 //left to right
-	send_animating_signal(src)
 	animate(src, transform = turn(matrix(transform), sway * (sway_dir *= -1)), pixel_x = rand(-strength,strength), pixel_y = rand(-strength/3,strength/3), time = times, easing = JUMP_EASING, flags = ANIMATION_PARALLEL)
 	for(var/i in 1 to steps)
 		animate(transform = turn(matrix(transform), sway*2 * (sway_dir *= -1)), pixel_x = rand(-strength,strength), pixel_y = rand(-strength/3,strength/3), time = times, easing = JUMP_EASING)
 
 	animate(transform = turn(matrix(transform), sway * (sway_dir *= -1)), pixel_x = 0, pixel_y = 0, time = 0)//ease it back
+
+/mob/sway_jitter(times = 3, steps = 3, strength = 3, sway = 5)
+	SEND_SIGNAL(src, COMSIG_MOB_ANIMATING)
+	return ..()
 
 /mob/living/carbon/human/proc/animation_rappel()
 	var/pre_rappel_alpha = alpha

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -614,7 +614,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 /mob/proc/dizzy_process()
 	is_dizzy = 1
 	while(dizziness > 100)
-		SEND_SIGNAL(src, COMSIG_HUMAN_ANIMATING)
+		SEND_SIGNAL(src, COMSIG_MOB_ANIMATING)
 		if(client)
 			if(buckled || resting)
 				client.pixel_x = 0
@@ -655,7 +655,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 /mob/proc/jittery_process()
 	is_jittery = 1
 	while(jitteriness > 100)
-		SEND_SIGNAL(src, COMSIG_HUMAN_ANIMATING)
+		SEND_SIGNAL(src, COMSIG_MOB_ANIMATING)
 		var/amplitude = min(4, jitteriness / 100)
 		pixel_x = old_x + rand(-amplitude, amplitude)
 		pixel_y = old_y + rand(-amplitude/3, amplitude/3)


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #8579 addressing some issues not caught in review.

- istype(src) is never necessary - just properly subtype
- Doesn't make sense to *sometimes* typecheck for humans for an animating signal

Of note the PR also ported a signal for `COMSIG_HUMAN_UNARMED_ATTACK` but didn't utilize it which I'm guessing `COMSIG_MOB_ANIMATING` *should* cover, though needs testing to see if that's true.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/gSRtFZJknK4

</details>


# Changelog
:cl: Drathek
code: Cleaned up signal usage for wall leaning
/:cl:
