### PR TITLE
[FIX] propelled chair when not wheeled chair

### DIFF
--- a/code/game/objects/items/tools/extinguisher.dm
+++ b/code/game/objects/items/tools/extinguisher.dm
@@ -123,6 +123,8 @@
 			var/obj/structure/bed/chair/C = null
 			if(istype(user.buckled, /obj/structure/bed/chair))
 				C = user.buckled
+			if(!C)
+				return
 			var/obj/B = user.buckled
 			var/movementdirection = turn(direction,180)
 			if(C)


### PR DESCRIPTION

# About the pull request
There was a bug where a chair that wasn't a movable chair could be moved by a fire extinguisher. This fixes that.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
It is still possible to ride office chairs and wheelchairs.
# Changelog
:cl:
fix: fix propelled chair when not wheeled chair
/:cl:
