### PR TITLE
Autowiki: Gun templates now omit unwielded stats for two handers

### DIFF
--- a/code/modules/autowiki/pages/guns.dm
+++ b/code/modules/autowiki/pages/guns.dm
@@ -170,6 +170,12 @@
 			upload_icon(generated_icon, filename)
 			gun_data["icon"] = filename
 
+		// If its a two hander, don't include unwielded data
+		if(gun_data["two_handed_only"])
+			gun_data["unwielded_recoil"] = "N/A"
+			gun_data["unwielded_scatter"] = "N/A"
+			gun_data["unwielded_accuracy"] = "N/A"
+
 		var/page_name = SANITIZE_FILENAME(replacetext(strip_improper(generating_gun.name), " ", "_"))
 		var/to_add = list(title = "Template:Autowiki/Content/Gun/[page_name]", text = include_template("Autowiki/Gun", gun_data))
 		output += list(to_add)

--- a/code/modules/autowiki/pages/xeno_stats.dm
+++ b/code/modules/autowiki/pages/xeno_stats.dm
@@ -65,7 +65,7 @@
 
 		for(var/stat_comparison in xeno_data)
 			if(xeno_data[stat_comparison] != strain_data[stat_comparison])
-				var/difference = strain_data[stat_comparison] - xeno_data[stat_comparison]
+				var/difference = round(strain_data[stat_comparison] - xeno_data[stat_comparison], 0.01)
 				if(difference > 0)
 					difference = "<span style='color:green'>+[difference]</span>"
 				else


### PR DESCRIPTION
# About the pull request

This PR makes it so unwielded gun stats for the autowiki are overrided to "N/A" for weapons that are two handers (the in game UI already omits this data).

I also made it so the new xeno comparisons round to the nearest 0.01 because vampire wanted to round special. 
![image](https://github.com/user-attachments/assets/db6baaf6-4c6e-48f6-9729-3be6f9d6acb5)

# Explain why it's good for the game

Less confusion for autowiki gun templates.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/01a4053d-005d-403c-9fa5-7e5725752bfe)
[autowiki_edits.txt](https://github.com/user-attachments/files/19811666/autowiki_edits.txt)

</details>

# Changelog
:cl: Drathek
code: Autowiki gun templates now lists unwielded stats as N/A for two handers
code: Autowiki xeno comparisons now round to the nearest hundredth
/:cl:
