### PR TITLE
incend mag removal for CO

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/commanding_officer.dm
+++ b/code/game/machinery/vending/vendor_types/crew/commanding_officer.dm
@@ -24,7 +24,6 @@ GLOBAL_LIST_INIT(cm_vending_gear_commanding_officer, list(
 		list("Flechette Shells", 20, /obj/item/ammo_magazine/shotgun/flechette, null, VENDOR_ITEM_REGULAR),
 
 		list("SPECIAL AMMUNITION", 0, null, null, null),
-		list("M41A Incendiary Magazine", 65, /obj/item/ammo_magazine/rifle/incendiary, null, VENDOR_ITEM_REGULAR),
 		list("M41A Rubber Shot Magazine", 10, /obj/item/ammo_magazine/rifle/rubber, null, VENDOR_ITEM_REGULAR),
 		list("Beanbag Slugs", 10, /obj/item/ammo_magazine/shotgun/beanbag, null, VENDOR_ITEM_REGULAR),
 

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -500,7 +500,7 @@
 	fire_sound = "gun_pulse"
 	reload_sound = 'sound/weapons/handling/m41_reload.ogg'
 	unload_sound = 'sound/weapons/handling/m41_unload.ogg'
-	current_mag = /obj/item/ammo_magazine/rifle/incendiary
+	current_mag = /obj/item/ammo_magazine/rifle/m41aMK1
 
 	accepted_ammo = list(
 		/obj/item/ammo_magazine/rifle,


### PR DESCRIPTION
# About the pull request

It removes the 40 round incendiary MK2 magazines from the CO 

# Explain why it's good for the game

The Commanding Officer should be better equipped than an average marine, but not by this caliber. The Commanding Officer gets the best armor, the best weapon (MK1 with IFF), the best sidearm (with stuns that can kill a lurker with 2 clicks if done right). They don't need the MK2 incendiary mags. It's also very overpowered to say the least.



# Changelog

:cl: stalkerino
balance: removed 40 round incendiary mags from CO
/:cl:

