### PR TITLE
XM51 across the board nerfs

### DIFF
--- a/code/datums/supply_packs/ammo.dm
+++ b/code/datums/supply_packs/ammo.dm
@@ -231,11 +231,11 @@
 	group = "Ammo"
 
 /datum/supply_packs/ammo_shell_box_breaching
-	name = "Shell box (16g) (120x breaching shells)"
+	name = "Shell box (16g) (60x breaching shells)"
 	contains = list(
 		/obj/item/ammo_box/magazine/shotgun/light/breaching,
 	)
-	cost = 40
+	cost = 35
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "\improper shotgun breaching crate"
 	group = "Ammo"

--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -323,7 +323,7 @@
 		list("Shotgun Shell Box (Buckshot x 100)", 0, /obj/item/ammo_box/magazine/shotgun/buckshot, VENDOR_ITEM_REGULAR),
 		list("Shotgun Shell Box (Flechette x 100)", 0, /obj/item/ammo_box/magazine/shotgun/flechette, VENDOR_ITEM_REGULAR),
 		list("Shotgun Shell Box (Slugs x 100)", 0, /obj/item/ammo_box/magazine/shotgun, VENDOR_ITEM_REGULAR),
-		list("Shotgun Shell Box (16g) (Breaching x 120)", 0, /obj/item/ammo_box/magazine/shotgun/light/breaching, VENDOR_ITEM_REGULAR),
+		list("Shotgun Shell Box (16g) (Breaching x 60)", 0, /obj/item/ammo_box/magazine/shotgun/light/breaching, VENDOR_ITEM_REGULAR),
 		list("Magazine Box (88 Mod 4 AP x 16)", 0, /obj/item/ammo_box/magazine/mod88, VENDOR_ITEM_REGULAR),
 		list("Magazine Box (SU-6 x 16)", 0, /obj/item/ammo_box/magazine/su6, VENDOR_ITEM_REGULAR),
 		list("Magazine Box (VP78 x 16)", 0, /obj/item/ammo_box/magazine/vp78, VENDOR_ITEM_REGULAR),

--- a/code/modules/projectiles/ammo_boxes/handful_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/handful_boxes.dm
@@ -120,12 +120,12 @@
 //-----------------------16 GAUGE SHOTGUN SHELL BOXES-----------------------
 
 /obj/item/ammo_box/magazine/shotgun/light/breaching
-	name = "\improper 16-gauge shotgun shell box (Breaching x 120)"
+	name = "\improper 16-gauge shotgun shell box (Breaching x 60)"
 	icon_state = "base_breach"
 	overlay_content = "_breach"
 	magazine_type = /obj/item/ammo_magazine/shotgun/light/breaching
-	num_of_magazines = 120 //10 full mag reloads.
-	can_explode = FALSE
+	num_of_magazines = 60 //5 full mag reloads.
+	can_explode = TRUE
 
 /obj/item/ammo_box/magazine/shotgun/light/breaching/empty
 	empty = TRUE

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -2554,9 +2554,9 @@
 
 /obj/item/weapon/gun/rifle/xm51/set_bullet_traits()
 	LAZYADD(traits_to_give, list(
-		BULLET_TRAIT_ENTRY_ID("turfs", /datum/element/bullet_trait_damage_boost, 30, GLOB.damage_boost_turfs), //2550, 2 taps colony walls, 4 taps reinforced walls
-		BULLET_TRAIT_ENTRY_ID("xeno turfs", /datum/element/bullet_trait_damage_boost, 0.23, GLOB.damage_boost_turfs_xeno), //2550*0.23 = 586, 2 taps resin walls, 3 taps thick resin
-		BULLET_TRAIT_ENTRY_ID("breaching", /datum/element/bullet_trait_damage_boost, 15, GLOB.damage_boost_breaching), //1275, enough to 1 tap airlocks
+		BULLET_TRAIT_ENTRY_ID("turfs", /datum/element/bullet_trait_damage_boost, 15, GLOB.damage_boost_turfs), //1275, 4 taps colony walls, 8 taps reinforced walls
+		BULLET_TRAIT_ENTRY_ID("xeno turfs", /datum/element/bullet_trait_damage_boost, 0.23, GLOB.damage_boost_turfs_xeno), //1275*0.23 = 293, 4 taps resin walls, 5 taps thick resin
+		BULLET_TRAIT_ENTRY_ID("breaching", /datum/element/bullet_trait_damage_boost, 4, GLOB.damage_boost_breaching), //340, enough to 4 tap airlocks, 2 normal resin door, 3 for thick resin door
 		BULLET_TRAIT_ENTRY_ID("pylons", /datum/element/bullet_trait_damage_boost, 6, GLOB.damage_boost_pylons) //510, 4 shots to take out a pylon
 	))
 


### PR DESCRIPTION
# About the pull request

Nerfs the undeniable presence of an XM51. It is now an alternative to the U7 rather than a full upgrade. The drawback of the U7 is the range, which the XM51 does not suffer from.

# Explain why it's good for the game

Xeno builders already suffer both from numbers and quality. 
The U7 can oneshot resin doors, and resin doors from close range.
The XM51 can still one burst doors, from a safe range although with more limited ammo usage.


# Testing Photographs and Procedure
N/A

</details>


# Changelog
:cl: stalkerino
balance: nerfs the XM51, taking roughly double the shots to take down structures
balance: halves the amount of ammo you get in a breaching box to 60, slightly decreases the price via req
/:cl:
