### PR TITLE
fixes mateba and type 47 storage flags

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -2068,6 +2068,7 @@
 	item_state = "upp_belt"
 	icon = 'icons/obj/items/clothing/belts/belts_by_faction/UPP.dmi'
 	item_icons = list(
+		WEAR_J_STORE = 'icons/mob/humans/onmob/clothing/belts/belts_by_faction/UPP.dmi',
 		WEAR_WAIST = 'icons/mob/humans/onmob/clothing/belts/belts_by_faction/UPP.dmi',
 		WEAR_L_HAND = 'icons/mob/humans/onmob/inhands/clothing/belts_lefthand.dmi',
 		WEAR_R_HAND = 'icons/mob/humans/onmob/inhands/clothing/belts_righthand.dmi'

--- a/code/modules/clothing/suits/marine_armor/_marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor/_marine_armor.dm
@@ -73,6 +73,7 @@
 		/obj/item/storage/belt/gun/type47,
 		/obj/item/storage/belt/gun/m4a3,
 		/obj/item/storage/belt/gun/m44,
+		/obj/item/storage/belt/gun/mateba,
 		/obj/item/storage/belt/gun/smartpistol,
 		/obj/item/storage/belt/gun/flaregun,
 		/obj/item/device/motiondetector,

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -268,6 +268,7 @@
 		/obj/item/storage/belt/gun/m44,
 		/obj/item/storage/belt/gun/mateba,
 		/obj/item/storage/belt/gun/smartpistol,
+		/obj/item/storage/belt/gun/type47,
 		/obj/item/weapon/gun,
 
 		/obj/item/device/flashlight,


### PR DESCRIPTION

# About the pull request
fixes #9064 
and lets marine armor take mateba rig

# Explain why it's good for the game

fixes 2 oversights
if this somehow counts as a balance PR: if a CO doesn't like CO armor, he shouldn't have to use it 

# Testing Photographs and Procedure
localhost work

# Changelog

:cl: stalkerino
fix: type47 UPP rig fits on external webbing, mateba rig fits on marine armor
/:cl:
