### PR TITLE
adds extended mk2 magazines to the ASRS RNG rotation

### DIFF
--- a/code/datums/ASRS.dm
+++ b/code/datums/ASRS.dm
@@ -18,6 +18,10 @@
 	reference_package = /datum/supply_packs/ammo_rounds_box_rifle
 	cost = ASRS_MEDIUM_WEIGHT
 
+/datum/supply_packs_asrs/ammo_rounds_box_rifle_ap
+	reference_package = /datum/supply_packs/ammo_rounds_box_rifle_ap
+	cost = ASRS_LOW_WEIGHT
+
 /datum/supply_packs_asrs/ammo_rounds_box_xm88
 	reference_package = /datum/supply_packs/ammo_rounds_box_xm88
 	cost = ASRS_LOW_WEIGHT
@@ -66,6 +70,10 @@
 
 /datum/supply_packs_asrs/ammo_m4ra_mag_box
 	reference_package = /datum/supply_packs/ammo_m4ra_mag_box
+	cost = ASRS_LOW_WEIGHT
+
+/datum/supply_packs_asrs/ammo_m4ra_mag_box_ap
+	reference_package = /datum/supply_packs/ammo_m4ra_mag_box_ap
 	cost = ASRS_VERY_LOW_WEIGHT
 
 /datum/supply_packs_asrs/ammo_xm51

--- a/code/datums/ASRS.dm
+++ b/code/datums/ASRS.dm
@@ -13,18 +13,30 @@
 	var/datum/supply_packs/reference_package
 
 //===================================
-// Rounds
+// Loose Rounds
 /datum/supply_packs_asrs/ammo_rounds_box_rifle
 	reference_package = /datum/supply_packs/ammo_rounds_box_rifle
 	cost = ASRS_MEDIUM_WEIGHT
 
-/datum/supply_packs_asrs/ammo_rounds_box_rifle_ap
-	reference_package = /datum/supply_packs/ammo_rounds_box_rifle_ap
-	cost = ASRS_LOW_WEIGHT
-
 /datum/supply_packs_asrs/ammo_rounds_box_xm88
 	reference_package = /datum/supply_packs/ammo_rounds_box_xm88
 	cost = ASRS_LOW_WEIGHT
+
+/datum/supply_packs_asrs/ammo_shell_box
+	reference_package = /datum/supply_packs/ammo_shell_box
+	cost = ASRS_VERY_LOW_WEIGHT
+
+/datum/supply_packs_asrs/ammo_shell_box_buck
+	reference_package = /datum/supply_packs/ammo_shell_box_buck
+	cost = ASRS_VERY_LOW_WEIGHT
+
+/datum/supply_packs_asrs/ammo_shell_box_flechette
+	reference_package = /datum/supply_packs/ammo_shell_box_flechette
+	cost = ASRS_VERY_LOW_WEIGHT
+
+/datum/supply_packs_asrs/ammo_shell_box_breaching
+	reference_package = /datum/supply_packs/ammo_shell_box_breaching
+	cost = ASRS_VERY_LOW_WEIGHT
 
 //===================================
 // Magazines
@@ -48,30 +60,12 @@
 	reference_package = /datum/supply_packs/ammo_mag_box
 	cost = ASRS_VERY_LOW_WEIGHT
 
-/datum/supply_packs_asrs/ammo_mag_box_ap
-	reference_package = /datum/supply_packs/ammo_mag_box_ap
+/datum/supply_packs_asrs/ammo_mag_box_ext
+	reference_package = /datum/supply_packs/ammo_mag_box_ext
+	cost = ASRS_VERY_LOW_WEIGHT
 
 /datum/supply_packs_asrs/ammo_m4ra_mag_box
 	reference_package = /datum/supply_packs/ammo_m4ra_mag_box
-	cost = ASRS_VERY_LOW_WEIGHT
-
-/datum/supply_packs_asrs/ammo_m4ra_mag_box_ap
-	reference_package = /datum/supply_packs/ammo_m4ra_mag_box_ap
-
-/datum/supply_packs_asrs/ammo_shell_box
-	reference_package = /datum/supply_packs/ammo_shell_box
-	cost = ASRS_VERY_LOW_WEIGHT
-
-/datum/supply_packs_asrs/ammo_shell_box_buck
-	reference_package = /datum/supply_packs/ammo_shell_box_buck
-	cost = ASRS_VERY_LOW_WEIGHT
-
-/datum/supply_packs_asrs/ammo_shell_box_flechette
-	reference_package = /datum/supply_packs/ammo_shell_box_flechette
-	cost = ASRS_VERY_LOW_WEIGHT
-
-/datum/supply_packs_asrs/ammo_shell_box_breaching
-	reference_package = /datum/supply_packs/ammo_shell_box_breaching
 	cost = ASRS_VERY_LOW_WEIGHT
 
 /datum/supply_packs_asrs/ammo_xm51


### PR DESCRIPTION
# About the pull request
adds extended MK2 magazines  to ASRS (RNG) rotation

# Explain why it's good for the game

I believe the free mortar shell crate removal made things that shouldn't be extremely common even more common
extended MK2 magazines are never purchased, and if you don't nab them roundstart you're never getting it 
I think it'd be good for the game to slightly decrease the chance to get AP, in exchange for a chance to get extended MK2 magazine boxes

# Changelog

:cl: stalkerino
balance: adds extended MK2 magazines
code: put loose ammo in the loose ammo category rather than mags
/:cl:

