### PR TITLE
Portable Cades Can Be Melted

### DIFF
--- a/code/game/objects/structures/barricade/deployable.dm
+++ b/code/game/objects/structures/barricade/deployable.dm
@@ -1,6 +1,6 @@
 /obj/structure/barricade/deployable
 	name = "portable composite barricade"
-	desc = "A plasteel-carbon composite barricade. Resistant to most acids while being simple to repair. There are two pushplates that allow this barricade to fold into a neat package. Use a blowtorch to repair."
+	desc = "A plasteel-carbon composite barricade. This MB-6 model is simple to repair. There are two pushplates that allow this barricade to fold into a neat package. Use a blowtorch to repair."
 	icon_state = "folding_0"
 	health = 350
 	maxhealth = 350
@@ -13,7 +13,6 @@
 	can_wire = FALSE
 	can_change_dmg_state = 1
 	climbable = FALSE
-	unacidable = TRUE
 	anchored = TRUE
 	repair_materials = list("metal" = 0.3, "plasteel" = 0.45)
 	var/build_state = BARRICADE_BSTATE_SECURED //Look at __game.dm for barricade defines


### PR DESCRIPTION
# About the pull request

Enables xenos to melt m-6 portable composite barricades.  Did some quick tests to ensure it worked and didn't insta-die under acid (It doesn't- a base barricade and portable cade take about the same amount of acid to destroy). 

# Explain why it's good for the game

When portable cades were added 6 years ago, they were much stronger, but also a more limited resource. Now, portable cades are worse than normal cades, albeit usable by everyone and in greater supply than they were. It doesn't make a lot of sense that you can melt barricades but not a subpar portable version, so this brings it in line with that.

# Testing Photographs and Procedure

<details>

![image](https://github.com/user-attachments/assets/5137c29e-cd14-4b56-a0fb-053af9f59314)

![image](https://github.com/user-attachments/assets/8c700764-55da-4d08-ba14-1eefee719c9c)

</details>


# Changelog

:cl:
balance: portable composite barricades are now meltable
/:cl:
