### PR TITLE
makes synth heads that are intel items that spawn on maps a more recognizable, different sprite

### DIFF
--- a/maps/map_files/FOP_v3_Sciannex/sprinkles/30.repairpanelslz.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/sprinkles/30.repairpanelslz.dmm
@@ -55,7 +55,7 @@
 "l" = (
 /obj/item/limb/head/synth{
 	pixel_x = -9;
-	icon_state = "scandinavian_head_m"
+	icon_state = "head_f"
 	},
 /obj/structure/platform_decoration/metal/kutjevo/north,
 /turf/open/space/basic,

--- a/maps/map_files/LV624/hydro/30.destroyed.dmm
+++ b/maps/map_files/LV624/hydro/30.destroyed.dmm
@@ -150,7 +150,7 @@
 	name = "shattered synthetic head";
 	pixel_x = 9;
 	pixel_y = 3;
-	icon_state = "scandinavian_head_m"
+	icon_state = "head_f"
 	},
 /obj/item/robot_parts/arm/l_arm,
 /turf/open/floor/green/northwest,


### PR DESCRIPTION

# About the pull request

makes synth heads into a gen1 synth head sprite rather than just a normal guy head
only applies to prison station and LV nightmare inserts

# Explain why it's good for the game

I think it being easier to identify would be nice, and it'd be cool to see more gen1 representation
I don't know if I did it right
# Changelog
:cl: stalkerino
maptweak: changed intel item synth head sprites to be a gen1 synth head
/:cl:
