### PR TITLE
Whiskey Outpost tile fixes

### DIFF
--- a/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
+++ b/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
@@ -134,12 +134,6 @@
 	},
 /turf/open/floor/asteroidfloor/north,
 /area/whiskey_outpost/outside/north)
-"at" = (
-/obj/structure/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/prison/kitchen/southwest,
-/area/whiskey_outpost/inside/living)
 "au" = (
 /obj/structure/closet/secure_closet/commander,
 /turf/open/floor/wood,
@@ -301,7 +295,7 @@
 /obj/structure/machinery/shower{
 	dir = 4
 	},
-/turf/open/floor/prison/kitchen/southwest,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/whiskey_outpost/inside/living)
 "aX" = (
 /obj/structure/machinery/light{
@@ -505,9 +499,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/jungle,
 /area/whiskey_outpost/outside/lane/two_north)
-"bG" = (
-/turf/open/floor/prison/kitchen/southwest,
-/area/whiskey_outpost/inside/living)
 "bH" = (
 /obj/structure/mirror{
 	pixel_y = 30
@@ -621,7 +612,7 @@
 	dir = 8;
 	layer = 3.3
 	},
-/turf/open/floor/prison/kitchen/southwest,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/whiskey_outpost/inside/living)
 "ce" = (
 /turf/open/gm/dirt,
@@ -915,7 +906,7 @@
 /obj/structure/machinery/shower{
 	dir = 4
 	},
-/turf/open/floor/prison/kitchen,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/whiskey_outpost/inside/cic)
 "du" = (
 /turf/open/floor/prison/cell_stripe/west,
@@ -1918,7 +1909,7 @@
 /area/whiskey_outpost/outside/north/platform)
 "hK" = (
 /obj/effect/landmark/start/whiskey/marine,
-/turf/open/gm/dirtgrassborder/north,
+/turf/open/gm/dirtgrassborder/south,
 /area/whiskey_outpost/outside/lane/one_north)
 "hL" = (
 /turf/open/gm/dirtgrassborder/east,
@@ -3386,7 +3377,7 @@
 /area/whiskey_outpost/outside/river/east)
 "od" = (
 /obj/structure/curtain/shower,
-/turf/open/floor/prison/sterile_white,
+/turf/open/floor/prison,
 /area/whiskey_outpost/inside/living)
 "oe" = (
 /obj/structure/sign/safety/medical{
@@ -3486,10 +3477,6 @@
 /obj/structure/largecrate/supply/explosives/mortar_he,
 /turf/open/gm/dirt,
 /area/whiskey_outpost/inside/caves/caverns)
-"oF" = (
-/obj/structure/machinery/light/small,
-/turf/open/floor/prison/kitchen/southwest,
-/area/whiskey_outpost/inside/living)
 "oG" = (
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 1;
@@ -3585,7 +3572,7 @@
 /area/whiskey_outpost/inside/supply)
 "pj" = (
 /obj/effect/landmark/start/whiskey/engineer,
-/turf/open/gm/dirtgrassborder/north,
+/turf/open/gm/dirtgrassborder/south,
 /area/whiskey_outpost/outside/lane/two_south)
 "pk" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -6244,7 +6231,7 @@
 /area/whiskey_outpost/outside/river/west)
 "Bj" = (
 /obj/structure/fence,
-/turf/open/gm/dirtgrassborder/north,
+/turf/open/gm/dirtgrassborder/south,
 /area/whiskey_outpost/inside/caves/caverns/west)
 "Bk" = (
 /obj/structure/platform/metal/almayer/north,
@@ -7394,7 +7381,7 @@
 /area/whiskey_outpost/inside/bunker/bunker/front)
 "Hp" = (
 /obj/structure/machinery/colony_floodlight,
-/turf/open/gm/dirtgrassborder/north,
+/turf/open/gm/dirtgrassborder/south,
 /area/whiskey_outpost/outside/lane/one_north)
 "Hq" = (
 /obj/structure/pipes/standard/manifold/visible,
@@ -7594,7 +7581,7 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/turf/open/gm/dirtgrassborder/south,
+/turf/open/gm/dirtgrassborder/north,
 /area/whiskey_outpost/outside/south)
 "Im" = (
 /obj/structure/cargo_container/watatsumi/rightmid,
@@ -7760,7 +7747,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/open/gm/dirtgrassborder/south,
+/turf/open/gm/dirtgrassborder/north,
 /area/whiskey_outpost/outside/north/northwest)
 "Jg" = (
 /obj/effect/spawner/gibspawner/human,
@@ -7914,7 +7901,7 @@
 /turf/open/gm/coast/south,
 /area/whiskey_outpost/outside/lane/four_south)
 "JX" = (
-/turf/open/gm/dirtgrassborder/south,
+/turf/open/gm/dirtgrassborder/north,
 /area/whiskey_outpost/outside/lane/four_south)
 "JY" = (
 /obj/structure/platform_decoration/metal/almayer,
@@ -8010,7 +7997,7 @@
 /turf/open/floor/whitegreencorner,
 /area/whiskey_outpost/inside/hospital/triage)
 "Ky" = (
-/turf/open/gm/dirtgrassborder/south,
+/turf/open/gm/dirtgrassborder/north,
 /area/whiskey_outpost/inside/caves/caverns)
 "KB" = (
 /obj/structure/disposalpipe/segment,
@@ -8525,7 +8512,7 @@
 /area/whiskey_outpost/outside/lane/four_south)
 "NE" = (
 /obj/item/stool,
-/turf/open/gm/dirtgrassborder/south,
+/turf/open/gm/dirtgrassborder/north,
 /area/whiskey_outpost/outside/lane/two_south)
 "NF" = (
 /obj/structure/flora/bush/ausbushes/grassybush,
@@ -8567,7 +8554,7 @@
 /turf/open/gm/dirt,
 /area/whiskey_outpost/outside/lane/four_north)
 "NX" = (
-/turf/open/gm/dirtgrassborder/south,
+/turf/open/gm/dirtgrassborder/north,
 /area/whiskey_outpost/outside/north/northwest)
 "NY" = (
 /turf/open/gm/dirtgrassborder/grassdirt_corner/north_west,
@@ -8688,7 +8675,7 @@
 /area/whiskey_outpost/outside/north/beach)
 "OC" = (
 /obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/gm/dirtgrassborder/north,
+/turf/open/gm/dirtgrassborder/south,
 /area/whiskey_outpost/outside/lane/two_south)
 "OD" = (
 /obj/structure/barricade/metal/wired,
@@ -9205,7 +9192,7 @@
 /area/whiskey_outpost/inside/bunker/pillbox/three)
 "RS" = (
 /obj/structure/flora/bush/ausbushes/var3/stalkybush,
-/turf/open/gm/dirtgrassborder/south,
+/turf/open/gm/dirtgrassborder/north,
 /area/whiskey_outpost/outside/lane/one_north)
 "RT" = (
 /obj/structure/platform_decoration/metal/almayer/east,
@@ -9546,7 +9533,7 @@
 /turf/open/floor/prison/floor_plate/southwest,
 /area/whiskey_outpost/inside/bunker/pillbox/one)
 "TL" = (
-/turf/open/gm/dirtgrassborder/south,
+/turf/open/gm/dirtgrassborder/north,
 /area/whiskey_outpost/outside/north)
 "TP" = (
 /obj/structure/surface/table/almayer,
@@ -9866,7 +9853,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/open/gm/dirtgrassborder/north,
+/turf/open/gm/dirtgrassborder/south,
 /area/whiskey_outpost/outside/north)
 "Vu" = (
 /obj/structure/disposalpipe/segment{
@@ -10185,7 +10172,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/gm/dirtgrassborder/north,
+/turf/open/gm/dirtgrassborder/south,
 /area/whiskey_outpost/outside/north)
 "WM" = (
 /turf/closed/wall/r_wall/unmeltable,
@@ -10442,7 +10429,7 @@
 /area/whiskey_outpost/outside/lane/three_south)
 "Yc" = (
 /obj/structure/flora/bush/ausbushes/var3/leafybush,
-/turf/open/gm/dirtgrassborder/north,
+/turf/open/gm/dirtgrassborder/south,
 /area/whiskey_outpost/outside/north)
 "Yd" = (
 /obj/structure/barricade/sandbags/wired{
@@ -10672,7 +10659,7 @@
 	pixel_y = 2
 	},
 /obj/effect/decal/cleanable/blood/oil,
-/turf/open/gm/dirtgrassborder/south,
+/turf/open/gm/dirtgrassborder/north,
 /area/whiskey_outpost/outside/south)
 "Zm" = (
 /obj/structure/machinery/cm_vending/sorted/medical/chemistry,
@@ -13153,7 +13140,7 @@ Zf
 Zf
 mT
 mT
-Hr
+ko
 PL
 CD
 Kn
@@ -13355,7 +13342,7 @@ ES
 ES
 Ci
 vK
-Hr
+ko
 PL
 CD
 Kn
@@ -13374,7 +13361,7 @@ Hp
 Ci
 vK
 Ci
-Hr
+ko
 Vo
 Ro
 Ro
@@ -13557,7 +13544,7 @@ YI
 ES
 Uy
 vK
-Hr
+ko
 LT
 CD
 Kn
@@ -13572,11 +13559,11 @@ ve
 ve
 wR
 wR
-ko
+Hr
 Ci
 vK
 Ci
-Hr
+ko
 Vo
 Vo
 Vo
@@ -13759,7 +13746,7 @@ Tw
 ZE
 Uy
 vK
-Hr
+ko
 PL
 CD
 Kn
@@ -13774,11 +13761,11 @@ KZ
 ve
 BS
 wR
-ko
+Hr
 RM
 vK
 Ci
-Hr
+ko
 Vo
 Vo
 Ro
@@ -13961,7 +13948,7 @@ Tw
 ZE
 Uy
 vK
-Hr
+ko
 PL
 CD
 Kn
@@ -13976,11 +13963,11 @@ KJ
 LU
 wR
 wR
-ko
+Hr
 Ci
 Wx
 Ci
-Hr
+ko
 Vo
 Ro
 Vo
@@ -14163,7 +14150,7 @@ Tw
 ZI
 Uy
 vK
-Hr
+ko
 PL
 HW
 Kn
@@ -14178,11 +14165,11 @@ KZ
 ve
 wR
 wR
-ko
+Hr
 Ci
 vK
 Ci
-Hr
+ko
 Vo
 Vo
 Vo
@@ -14196,7 +14183,7 @@ Zs
 Ro
 Vo
 Vo
-WO
+HI
 mT
 mT
 uJ
@@ -14365,7 +14352,7 @@ cn
 ZI
 Uy
 Wx
-Hr
+ko
 PL
 CD
 Kn
@@ -14384,7 +14371,7 @@ hK
 Uy
 vK
 Ci
-Hr
+ko
 Vo
 Vo
 Vo
@@ -14398,7 +14385,7 @@ Zs
 Ro
 Ro
 Ro
-WO
+HI
 uJ
 Kt
 uJ
@@ -14567,7 +14554,7 @@ Tw
 ZI
 Uy
 Th
-Hr
+ko
 PL
 CD
 Kn
@@ -14586,7 +14573,7 @@ hK
 Uy
 vK
 Ci
-Hr
+ko
 Vo
 Vo
 Vo
@@ -14769,7 +14756,7 @@ Tw
 ZE
 Uy
 vK
-Hr
+ko
 PL
 Ob
 Kn
@@ -14788,7 +14775,7 @@ hK
 Uy
 QA
 Ci
-Hr
+ko
 Vo
 Vo
 Ro
@@ -14803,7 +14790,7 @@ Vo
 Ro
 Vo
 Ro
-WO
+HI
 Kt
 uJ
 uJ
@@ -14971,7 +14958,7 @@ Tw
 ZE
 Uy
 vK
-Hr
+ko
 PL
 CD
 Kn
@@ -14990,7 +14977,7 @@ hK
 Uy
 vK
 Ci
-Hr
+ko
 Vo
 Vo
 Ro
@@ -15192,7 +15179,7 @@ hK
 Ci
 Wx
 Ci
-Hr
+ko
 Vo
 Vo
 Vo
@@ -15375,7 +15362,7 @@ ES
 ES
 mT
 mT
-Hr
+ko
 PL
 PX
 Kn
@@ -15394,7 +15381,7 @@ hK
 Uy
 Wx
 Ci
-Hr
+ko
 Vo
 Vo
 Ro
@@ -15577,7 +15564,7 @@ mT
 mT
 mT
 mT
-Hr
+ko
 PL
 CD
 Kn
@@ -15596,7 +15583,7 @@ hK
 Uy
 vK
 Ci
-Hr
+ko
 Vo
 Vo
 Vo
@@ -15611,7 +15598,7 @@ Ro
 Ro
 Ro
 Vo
-WO
+HI
 Kt
 uJ
 uJ
@@ -15798,7 +15785,7 @@ hK
 Uy
 QA
 Ci
-Hr
+ko
 Vo
 Vo
 Vo
@@ -15813,7 +15800,7 @@ Ro
 Ro
 Vo
 Vo
-WO
+HI
 Kt
 uJ
 uJ
@@ -15854,7 +15841,7 @@ mT
 mT
 mT
 uJ
-HI
+WO
 EP
 Vh
 gz
@@ -16000,7 +15987,7 @@ hK
 Uy
 vK
 Ci
-Hr
+ko
 Vo
 Vo
 Ro
@@ -16056,7 +16043,7 @@ mT
 mT
 uJ
 uJ
-HI
+WO
 EP
 Vh
 gz
@@ -16198,11 +16185,11 @@ bl
 wR
 wR
 wR
-ko
+Hr
 Ci
 vK
 Ci
-Hr
+ko
 Vo
 Vo
 Ro
@@ -16216,49 +16203,49 @@ Zs
 Vo
 Ro
 Vo
-WO
-uJ
-mT
-uJ
-uJ
-uJ
-uJ
-uJ
-uJ
-uJ
-uJ
-uJ
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-Zf
-Zf
-Zf
-Zf
-mT
-mT
-Zf
-Zf
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-uJ
-uJ
-uJ
-uJ
 HI
+uJ
+mT
+uJ
+uJ
+uJ
+uJ
+uJ
+uJ
+uJ
+uJ
+uJ
+mT
+mT
+mT
+mT
+mT
+mT
+mT
+mT
+Zf
+Zf
+Zf
+Zf
+mT
+mT
+Zf
+Zf
+mT
+mT
+mT
+mT
+mT
+mT
+mT
+mT
+mT
+mT
+uJ
+uJ
+uJ
+uJ
+WO
 EP
 Vh
 gz
@@ -16400,11 +16387,11 @@ bl
 bl
 wR
 wR
-ko
+Hr
 Ci
 Wx
 Ci
-Hr
+ko
 Vo
 Vo
 HM
@@ -16418,49 +16405,49 @@ Zs
 Ro
 Ro
 dB
-WO
-mT
-mT
-mT
-mT
-uJ
-uJ
-uJ
-mT
-mT
-uJ
-uJ
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-Zf
-Zf
-Zf
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-mT
-uJ
-uJ
-uJ
-uJ
-uJ
 HI
+mT
+mT
+mT
+mT
+uJ
+uJ
+uJ
+mT
+mT
+uJ
+uJ
+mT
+mT
+mT
+mT
+mT
+mT
+mT
+mT
+Zf
+Zf
+Zf
+mT
+mT
+mT
+mT
+mT
+mT
+mT
+mT
+mT
+mT
+mT
+mT
+mT
+mT
+uJ
+uJ
+uJ
+uJ
+uJ
+WO
 EP
 Vh
 VE
@@ -16602,11 +16589,11 @@ bl
 bl
 bl
 wR
-ko
+Hr
 RM
 vK
 Ci
-Hr
+ko
 Vo
 Vo
 Ro
@@ -16804,11 +16791,11 @@ wR
 bl
 wR
 bl
-ko
+Hr
 Ci
 vK
 Ci
-Hr
+ko
 Vo
 Vo
 Vo
@@ -17010,7 +16997,7 @@ Hp
 Ci
 vK
 Ci
-Hr
+ko
 ep
 qY
 Me
@@ -17212,7 +17199,7 @@ ZP
 mT
 vK
 Ci
-Hr
+ko
 vQ
 Uf
 mT
@@ -18070,7 +18057,7 @@ uJ
 uJ
 uJ
 uJ
-HI
+WO
 mf
 EP
 BK
@@ -18272,7 +18259,7 @@ uJ
 uJ
 uJ
 uJ
-HI
+WO
 EP
 EP
 EP
@@ -19596,7 +19583,7 @@ fy
 fy
 jU
 fy
-Gb
+AK
 FZ
 mT
 mT
@@ -19753,12 +19740,12 @@ dO
 ak
 mT
 mT
-mT
-mT
+VM
+VM
 kh
 kh
 kh
-lA
+mG
 mG
 lZ
 mh
@@ -19955,7 +19942,7 @@ cr
 cr
 mT
 mT
-mT
+VM
 je
 oW
 oW
@@ -20023,7 +20010,7 @@ mT
 mT
 mT
 OD
-gu
+QB
 mT
 Zf
 Zf
@@ -20225,7 +20212,7 @@ mT
 mT
 Db
 OD
-gu
+QB
 Xq
 mT
 mT
@@ -20427,7 +20414,7 @@ mT
 mT
 Db
 OD
-gu
+QB
 GJ
 GJ
 GJ
@@ -20629,7 +20616,7 @@ mT
 Db
 Db
 OD
-gu
+QB
 GJ
 GJ
 GJ
@@ -20650,7 +20637,7 @@ GJ
 QB
 CG
 CN
-UY
+Vd
 Zx
 Ua
 NY
@@ -20831,7 +20818,7 @@ QO
 QO
 Db
 OD
-gu
+QB
 Xq
 Xq
 Xq
@@ -20852,7 +20839,7 @@ GJ
 QB
 CG
 CN
-UY
+Vd
 wv
 Df
 CJ
@@ -21033,7 +21020,7 @@ Am
 QO
 Db
 OD
-gu
+QB
 Xq
 Xq
 Xq
@@ -21054,7 +21041,7 @@ Xq
 QB
 VH
 CN
-UY
+Vd
 wv
 cZ
 CJ
@@ -21062,7 +21049,7 @@ Tv
 lX
 ZA
 oz
-UY
+Vd
 wv
 Df
 Df
@@ -21235,7 +21222,7 @@ ZU
 Pu
 Db
 OD
-gu
+QB
 Xq
 Xq
 Xq
@@ -21256,7 +21243,7 @@ Xq
 QB
 CG
 CN
-UY
+Vd
 wv
 NY
 Zv
@@ -21264,7 +21251,7 @@ Tv
 ah
 Sj
 iL
-UY
+Vd
 wv
 wv
 wv
@@ -21272,7 +21259,7 @@ wv
 NY
 Rz
 Mk
-Si
+gr
 kV
 kV
 lf
@@ -21474,7 +21461,7 @@ aK
 SF
 CG
 cw
-Si
+gr
 kV
 lf
 lf
@@ -21676,7 +21663,7 @@ Iv
 Iv
 Iv
 cw
-Si
+gr
 kV
 lf
 lf
@@ -21878,7 +21865,7 @@ Iv
 Iv
 tR
 Of
-Si
+gr
 kV
 lf
 lf
@@ -22080,7 +22067,7 @@ Iv
 Iv
 Iv
 iA
-Si
+gr
 kV
 lf
 OF
@@ -22282,7 +22269,7 @@ CG
 CG
 CG
 iA
-Si
+gr
 kV
 kV
 kV
@@ -22455,11 +22442,11 @@ Xq
 Xq
 Xq
 GJ
-QB
-Db
-Db
-Db
 gu
+Db
+Db
+Db
+QB
 Xq
 Xq
 GJ
@@ -22468,7 +22455,7 @@ Xq
 QB
 CG
 CN
-UY
+Vd
 Ws
 Xr
 gn
@@ -22484,7 +22471,7 @@ tA
 tA
 tA
 cw
-Si
+gr
 lf
 Oc
 lf
@@ -22650,18 +22637,18 @@ YN
 IB
 CK
 IB
-fS
-MX
-bF
-bF
-MX
-bF
-bF
 de
+MX
+bF
+bF
+MX
+bF
+bF
+fS
 IB
 IB
 sb
-gu
+QB
 Xq
 GJ
 GJ
@@ -22670,23 +22657,23 @@ Xq
 QB
 VH
 CN
-UY
+Vd
 Xg
 CJ
 CG
 CG
 gn
-UY
+Vd
 Df
 wv
 Df
-Vd
+UY
 CG
 CG
 bo
 CG
 cw
-Si
+gr
 lf
 lf
 lf
@@ -22859,11 +22846,11 @@ mT
 mT
 mT
 mT
-QB
+gu
 Db
 Db
 ky
-gu
+QB
 Xq
 Xq
 GJ
@@ -22872,7 +22859,7 @@ Xq
 QB
 CG
 CN
-UY
+Vd
 Ws
 Xd
 IV
@@ -22882,7 +22869,7 @@ VV
 wv
 Df
 Df
-Vd
+UY
 fd
 fd
 CG
@@ -23065,7 +23052,7 @@ mT
 Db
 Db
 ky
-gu
+QB
 GJ
 GJ
 GJ
@@ -23074,7 +23061,7 @@ Xq
 QB
 CG
 mT
-UY
+Vd
 Df
 Df
 mT
@@ -23233,8 +23220,8 @@ XL
 tJ
 fy
 fy
-Gb
 AK
+Gb
 Fy
 fy
 Yo
@@ -23247,7 +23234,7 @@ bW
 bW
 tO
 HT
-Rw
+MA
 bW
 bW
 mT
@@ -23378,11 +23365,11 @@ mT
 mT
 mT
 pq
-at
-bG
-bG
-bG
-oF
+oo
+Ys
+Ys
+Ys
+dh
 pq
 qz
 qw
@@ -23435,8 +23422,8 @@ XL
 jU
 fy
 fy
-Gb
 AK
+Gb
 Fy
 fy
 Yo
@@ -23583,7 +23570,7 @@ pq
 cb
 cb
 cb
-bG
+Ys
 cb
 pq
 qz
@@ -23637,8 +23624,8 @@ XL
 jU
 fy
 fy
-Gb
 AK
+Gb
 fy
 fy
 Yo
@@ -23651,7 +23638,7 @@ nJ
 SY
 qg
 Vv
-Rw
+MA
 bW
 bW
 mT
@@ -23839,8 +23826,8 @@ sj
 jU
 fy
 fy
-Gb
 AK
+Gb
 fy
 Fy
 Yo
@@ -23852,8 +23839,8 @@ RW
 bW
 fX
 bW
-MA
 Rw
+MA
 bW
 Zd
 ZV
@@ -24918,7 +24905,7 @@ kV
 kV
 kV
 lf
-gr
+Si
 kn
 kn
 kn
@@ -25120,7 +25107,7 @@ kV
 kV
 kV
 kV
-gr
+Si
 kn
 kn
 kn
@@ -25322,7 +25309,7 @@ kV
 kV
 kV
 lf
-gr
+Si
 kn
 kn
 kn
@@ -25468,8 +25455,8 @@ zX
 bW
 nJ
 Wb
-MA
 Rw
+MA
 bW
 bW
 nk
@@ -25524,7 +25511,7 @@ kV
 kV
 lf
 lf
-gr
+Si
 kn
 kn
 kn
@@ -25670,8 +25657,8 @@ zX
 bW
 bW
 fX
-MA
 Rw
+MA
 bW
 bW
 mT
@@ -25860,7 +25847,7 @@ jU
 fy
 fy
 fy
-Gb
+AK
 NL
 vg
 Fy
@@ -25872,8 +25859,8 @@ zX
 bW
 bW
 fX
-MA
 Rw
+MA
 bW
 mT
 mT
@@ -26074,8 +26061,8 @@ zX
 bW
 RN
 QU
-MA
 Rw
+MA
 bW
 mT
 mT
@@ -26276,7 +26263,7 @@ zX
 bW
 bW
 bW
-MA
+Rw
 zj
 um
 mT
@@ -26697,7 +26684,7 @@ mT
 Zw
 EV
 EV
-GK
+Ve
 BQ
 BQ
 BQ
@@ -26708,10 +26695,10 @@ Pm
 Pm
 Pm
 Pm
-GK
+Ve
 yC
 mr
-lg
+Jc
 FL
 FL
 xO
@@ -26726,7 +26713,7 @@ XP
 mT
 mT
 mT
-lg
+Jc
 xO
 lf
 kV
@@ -26893,7 +26880,7 @@ BQ
 Gn
 PA
 BQ
-Ve
+GK
 mT
 mT
 Zw
@@ -26910,10 +26897,10 @@ Pm
 SO
 SO
 Pm
-GK
+Ve
 yC
 mr
-lg
+Jc
 XR
 LG
 FL
@@ -26922,13 +26909,13 @@ FL
 FL
 FL
 xO
-Jc
+lg
 yC
 XP
 yC
 mT
 Zz
-lg
+Jc
 FL
 FL
 kV
@@ -27095,7 +27082,7 @@ BQ
 Gn
 Vu
 Ne
-Uz
+Uq
 MW
 Pc
 bc
@@ -27105,32 +27092,32 @@ Ne
 Ne
 Ne
 Ne
-Uz
-EA
-EA
-EA
-EA
-EA
-EA
 Uq
+EA
+EA
+EA
+EA
+EA
+EA
+Uz
 sL
 Yl
-VK
-XS
-XS
-Rm
-Ot
-Ot
-Ot
-Ot
-Rm
 bD
+XS
+XS
+Rm
+Ot
+Ot
+Ot
+Ot
+Rm
+VK
 TE
 wj
 yC
 Vl
 dH
-lg
+Jc
 FL
 FL
 lf
@@ -27332,7 +27319,7 @@ yC
 yC
 yC
 mr
-lg
+Jc
 FL
 FL
 FL
@@ -27534,7 +27521,7 @@ Nh
 yC
 yC
 mr
-lg
+Jc
 FL
 FL
 FL
@@ -27736,7 +27723,7 @@ Nh
 yC
 yC
 UW
-lg
+Jc
 FL
 FL
 FL
@@ -27938,7 +27925,7 @@ Nh
 yC
 yC
 UW
-lg
+Jc
 FL
 FL
 FL
@@ -28103,7 +28090,7 @@ YR
 cu
 BQ
 Gn
-Ve
+GK
 EV
 fb
 Vb
@@ -28140,7 +28127,7 @@ LQ
 XZ
 yC
 mr
-lg
+Jc
 FL
 FL
 FL
@@ -28305,7 +28292,7 @@ YR
 cu
 BQ
 Gn
-Ve
+GK
 EV
 EV
 Zw
@@ -28324,25 +28311,25 @@ Zw
 EV
 EV
 EV
-GK
+Ve
 yC
 mr
-lg
+Jc
 XR
 LG
 xO
-Jc
+lg
 ua
 ua
 ua
 yC
-lg
+Jc
 Kf
 US
-Jc
+lg
 yC
 mr
-lg
+Jc
 xO
 xO
 xO
@@ -28507,7 +28494,7 @@ HZ
 An
 BQ
 Gn
-Ve
+GK
 EV
 EV
 Zw
@@ -28526,14 +28513,14 @@ Zw
 gx
 Zw
 Zw
-GK
+Ve
 yC
 mr
-lg
+Jc
 XR
 LG
 FL
-Jc
+lg
 ua
 ua
 ua
@@ -28541,10 +28528,10 @@ Ug
 Sy
 FL
 FL
-Jc
+lg
 Vl
 dH
-lg
+Jc
 xO
 xO
 xO
@@ -28709,7 +28696,7 @@ An
 An
 mT
 Gn
-Ve
+GK
 EV
 EV
 De
@@ -28728,18 +28715,18 @@ Zw
 EV
 Zw
 EV
-GK
+Ve
 GM
 mr
-lg
+Jc
 Kf
 US
 FL
-Jc
+lg
 yC
 yC
 Jz
-lg
+Jc
 xO
 xO
 FL
@@ -28911,29 +28898,29 @@ mT
 mT
 mT
 mT
-Ve
-EV
-EV
-Zw
-EV
-Zw
-Zw
-Zw
-Zw
-Zw
-Zw
-Zw
-Zw
-Zw
-Zw
-Zw
-Zw
-Zw
-Zw
 GK
+EV
+EV
+Zw
+EV
+Zw
+Zw
+Zw
+Zw
+Zw
+Zw
+Zw
+Zw
+Zw
+Zw
+Zw
+Zw
+Zw
+Zw
+Ve
 yC
 mr
-lg
+Jc
 FL
 FL
 ox
@@ -28941,7 +28928,7 @@ LN
 XZ
 yC
 yC
-lg
+Jc
 FL
 ox
 FL
@@ -29132,10 +29119,10 @@ Pm
 Ue
 Ue
 Pm
-GK
+Ve
 yC
 mr
-lg
+Jc
 FL
 FL
 yH
@@ -30190,7 +30177,7 @@ uE
 uE
 uE
 uE
-Fu
+SE
 mT
 Zf
 EP
@@ -32011,7 +31998,7 @@ mT
 mT
 uE
 uE
-Fu
+SE
 BK
 BK
 BK
@@ -32213,7 +32200,7 @@ mT
 mT
 mT
 uE
-Fu
+SE
 BK
 BK
 BK
@@ -32415,7 +32402,7 @@ mT
 mT
 mT
 mT
-Fu
+SE
 xI
 BK
 BK
@@ -33387,7 +33374,7 @@ of
 wT
 wT
 wT
-SE
+Fu
 uE
 uE
 TX
@@ -33589,7 +33576,7 @@ of
 wT
 of
 wT
-SE
+Fu
 uE
 uE
 TX
@@ -33791,7 +33778,7 @@ wT
 of
 of
 wT
-SE
+Fu
 uE
 uE
 TX
@@ -33993,7 +33980,7 @@ wT
 wT
 wT
 wT
-SE
+Fu
 uE
 uE
 TX
@@ -34195,7 +34182,7 @@ wT
 wT
 wT
 wT
-SE
+Fu
 uE
 uE
 TX

--- a/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
+++ b/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
@@ -134,9 +134,6 @@
 	},
 /turf/open/floor/asteroidfloor/north,
 /area/whiskey_outpost/outside/north)
-"at" = (
-/turf/open/jungle/clear,
-/area/whiskey_outpost/outside/south)
 "au" = (
 /obj/structure/closet/secure_closet/commander,
 /turf/open/floor/wood,
@@ -511,6 +508,9 @@
 	},
 /turf/open/floor/prison/kitchen,
 /area/whiskey_outpost/inside/cic)
+"bI" = (
+/turf/open/jungle/clear,
+/area/whiskey_outpost/outside/south)
 "bK" = (
 /obj/structure/cargo_container/watatsumi/leftmid,
 /turf/open/jungle/clear,
@@ -22078,7 +22078,7 @@ lf
 lf
 lf
 lf
-at
+bI
 xG
 ZB
 kV
@@ -22280,7 +22280,7 @@ kV
 lf
 lf
 lf
-at
+bI
 RD
 ZB
 lf
@@ -22482,7 +22482,7 @@ oq
 kV
 lf
 lf
-at
+bI
 QH
 ZB
 lf
@@ -23899,7 +23899,7 @@ kV
 kV
 UP
 ZB
-at
+bI
 ay
 kV
 Zf
@@ -24101,7 +24101,7 @@ lf
 kV
 kV
 ZB
-at
+bI
 aa
 kV
 kV
@@ -24303,7 +24303,7 @@ lf
 lf
 kV
 ZB
-at
+bI
 Od
 kV
 kV
@@ -28340,7 +28340,7 @@ lf
 kV
 ac
 kV
-at
+bI
 bK
 ZB
 RP
@@ -28542,7 +28542,7 @@ lf
 lf
 lf
 lf
-at
+bI
 aZ
 ZB
 RP
@@ -28744,7 +28744,7 @@ lf
 kV
 lf
 lf
-at
+bI
 BM
 ZB
 RP

--- a/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
+++ b/maps/map_files/Whiskey_Outpost_v2/Whiskey_Outpost_v2.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
 /obj/structure/cargo_container/arious/rightmid,
-/turf/open/jungle,
+/turf/open/jungle/clear,
 /area/whiskey_outpost/outside/south)
 "ab" = (
 /turf/open/floor/asteroidfloor/north,
@@ -134,6 +134,9 @@
 	},
 /turf/open/floor/asteroidfloor/north,
 /area/whiskey_outpost/outside/north)
+"at" = (
+/turf/open/jungle/clear,
+/area/whiskey_outpost/outside/south)
 "au" = (
 /obj/structure/closet/secure_closet/commander,
 /turf/open/floor/wood,
@@ -155,7 +158,7 @@
 /area/whiskey_outpost/inside/cic)
 "ay" = (
 /obj/structure/cargo_container/arious/leftmid,
-/turf/open/jungle,
+/turf/open/jungle/clear,
 /area/whiskey_outpost/outside/south)
 "az" = (
 /obj/structure/platform_decoration/metal/almayer/west,
@@ -316,7 +319,7 @@
 /area/whiskey_outpost/inside/cic)
 "aZ" = (
 /obj/structure/cargo_container/watatsumi/rightmid,
-/turf/open/jungle/impenetrable,
+/turf/open/jungle/clear,
 /area/whiskey_outpost/outside/south)
 "ba" = (
 /obj/structure/machinery/vending/cigarette/koorlander,
@@ -510,7 +513,7 @@
 /area/whiskey_outpost/inside/cic)
 "bK" = (
 /obj/structure/cargo_container/watatsumi/leftmid,
-/turf/open/jungle,
+/turf/open/jungle/clear,
 /area/whiskey_outpost/outside/south)
 "bL" = (
 /obj/structure/disposalpipe/segment{
@@ -5532,7 +5535,7 @@
 /area/whiskey_outpost/inside/living)
 "xG" = (
 /obj/structure/cargo_container/grant/left,
-/turf/open/jungle,
+/turf/open/jungle/clear,
 /area/whiskey_outpost/outside/south)
 "xH" = (
 /obj/structure/sign/nosmoking_1,
@@ -6356,7 +6359,7 @@
 /area/whiskey_outpost/outside/south/very_far)
 "BM" = (
 /obj/structure/cargo_container/watatsumi/right,
-/turf/open/jungle/impenetrable,
+/turf/open/jungle/clear,
 /area/whiskey_outpost/outside/south)
 "BN" = (
 /obj/effect/landmark/start/whiskey/marine,
@@ -6375,7 +6378,7 @@
 	layer = 3.3
 	},
 /obj/effect/landmark/start/whiskey/marine,
-/turf/open/floor/asteroidfloor/north,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/whiskey_outpost/inside/bunker/bunker/front)
 "BQ" = (
 /turf/open/gm/dirt,
@@ -6542,7 +6545,7 @@
 "CJ" = (
 /obj/structure/bed/chair,
 /obj/effect/landmark/start/whiskey/marine,
-/turf/open/gm/dirtgrassborder/north,
+/turf/open/gm/dirtgrassborder/south,
 /area/whiskey_outpost/outside/lane/two_south)
 "CK" = (
 /obj/structure/disposalpipe/segment,
@@ -7022,7 +7025,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/whiskey/marine,
-/turf/open/floor/asteroidfloor/north,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/whiskey_outpost/inside/bunker/bunker/front)
 "Fj" = (
 /obj/effect/decal/cleanable/blood/writing{
@@ -8580,7 +8583,7 @@
 /area/whiskey_outpost/outside/south)
 "Od" = (
 /obj/structure/cargo_container/arious/right,
-/turf/open/jungle,
+/turf/open/jungle/clear,
 /area/whiskey_outpost/outside/south)
 "Oe" = (
 /obj/structure/machinery/colony_floodlight,
@@ -9016,7 +9019,7 @@
 /area/whiskey_outpost/inside/living)
 "QH" = (
 /obj/structure/cargo_container/grant/right,
-/turf/open/jungle,
+/turf/open/jungle/clear,
 /area/whiskey_outpost/outside/south)
 "QI" = (
 /obj/structure/platform/metal/almayer/north,
@@ -9088,7 +9091,7 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/asteroidfloor/north,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/whiskey_outpost/inside/bunker/bunker/front)
 "Rg" = (
 /obj/structure/machinery/light/small{
@@ -9147,7 +9150,7 @@
 /area/whiskey_outpost/inside/bunker/bunker/front)
 "RD" = (
 /obj/structure/cargo_container/grant/rightmid,
-/turf/open/jungle,
+/turf/open/jungle/clear,
 /area/whiskey_outpost/outside/south)
 "RG" = (
 /turf/open/gm/grass/gbcorner/north_east,
@@ -9391,7 +9394,7 @@
 /obj/structure/machinery/shower{
 	dir = 4
 	},
-/turf/open/floor/asteroidfloor/north,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/whiskey_outpost/inside/bunker/bunker/front)
 "SX" = (
 /turf/open/gm/river,
@@ -10292,7 +10295,7 @@
 /area/whiskey_outpost/outside/lane/two_north)
 "Xr" = (
 /obj/effect/landmark/start/whiskey/marine,
-/turf/open/gm/dirtgrassborder/north,
+/turf/open/gm/dirtgrassborder/south,
 /area/whiskey_outpost/outside/lane/two_south)
 "Xx" = (
 /obj/structure/flora/bush/ausbushes/var3/stalkybush,
@@ -20230,7 +20233,7 @@ Xq
 GJ
 GJ
 GJ
-QB
+gu
 Zf
 Zf
 Zf
@@ -20432,7 +20435,7 @@ GJ
 Xq
 GJ
 GJ
-QB
+gu
 Zf
 Zf
 Zf
@@ -20634,7 +20637,7 @@ GJ
 Xq
 Xq
 GJ
-QB
+gu
 CG
 CN
 Vd
@@ -20836,7 +20839,7 @@ Xq
 Xq
 Xq
 GJ
-QB
+gu
 CG
 CN
 Vd
@@ -21038,7 +21041,7 @@ Xq
 GJ
 GJ
 Xq
-QB
+gu
 VH
 CN
 Vd
@@ -21240,7 +21243,7 @@ Xq
 Xq
 Xq
 Xq
-QB
+gu
 CG
 CN
 Vd
@@ -22075,7 +22078,7 @@ lf
 lf
 lf
 lf
-kV
+at
 xG
 ZB
 kV
@@ -22277,7 +22280,7 @@ kV
 lf
 lf
 lf
-kV
+at
 RD
 ZB
 lf
@@ -22452,7 +22455,7 @@ Xq
 GJ
 Xq
 Xq
-QB
+gu
 CG
 CN
 Vd
@@ -22479,7 +22482,7 @@ oq
 kV
 lf
 lf
-kV
+at
 QH
 ZB
 lf
@@ -22654,7 +22657,7 @@ GJ
 GJ
 GJ
 Xq
-QB
+gu
 VH
 CN
 Vd
@@ -22856,7 +22859,7 @@ Xq
 GJ
 GJ
 Xq
-QB
+gu
 CG
 CN
 Vd
@@ -23058,7 +23061,7 @@ GJ
 GJ
 GJ
 Xq
-QB
+gu
 CG
 mT
 Vd
@@ -23896,7 +23899,7 @@ kV
 kV
 UP
 ZB
-lf
+at
 ay
 kV
 Zf
@@ -24098,7 +24101,7 @@ lf
 kV
 kV
 ZB
-lf
+at
 aa
 kV
 kV
@@ -24300,7 +24303,7 @@ lf
 lf
 kV
 ZB
-lf
+at
 Od
 kV
 kV
@@ -28337,7 +28340,7 @@ lf
 kV
 ac
 kV
-kV
+at
 bK
 ZB
 RP
@@ -28539,7 +28542,7 @@ lf
 lf
 lf
 lf
-kV
+at
 aZ
 ZB
 RP
@@ -28741,7 +28744,7 @@ lf
 kV
 lf
 lf
-lf
+at
 BM
 ZB
 RP
@@ -29348,7 +29351,7 @@ Zf
 mT
 EF
 EF
-SE
+Fu
 uE
 mT
 mT


### PR DESCRIPTION

# About the pull request
Fixes a bunch of broken grass tiles on WP
Prevents foliage from spawning ontop of storage containers
Places some drainage tiles in showers
Fixes random mountain walls where there are none in the WP CIC

<details>
<summary>Grass tile fixes</summary>

![WP tile issues](https://github.com/user-attachments/assets/101c7929-8115-448d-ba54-d25ede0831e8)

![fix](https://github.com/user-attachments/assets/941a82c5-7539-42c7-a26a-ed51c8912006)

</details>

<details>
<summary>Shower tiles</summary>

![drains](https://github.com/user-attachments/assets/82feb7ba-ce4d-44fb-8aa1-8281efa9b318)


</details>

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
A slight bit of love to Whiskey Outpost
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: grass tiles fixed
maptweak: foliage no longer spawns ontop of storage containers
maptweak: drainage tiles for showers
maptweak: mountain wall in WP CIC
/:cl:
