### PR TITLE
thunderdome cleanup system

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -112,6 +112,7 @@ GLOBAL_LIST_INIT(admin_verbs_sounds, list(
 
 GLOBAL_LIST_INIT(admin_verbs_minor_event, list(
 	/client/proc/cmd_admin_change_custom_event,
+	/client/proc/clean_thunderdome,
 	/datum/admins/proc/admin_force_distress,
 	/datum/admins/proc/admin_force_ERT_shuttle,
 	/client/proc/enable_event_mob_verbs,

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -1071,6 +1071,38 @@
 	SSticker.set_clients_taskbar_icon(taskbar_icon)
 	message_admins("[key_name_admin(usr)] has changed the taskbar icon to [taskbar_icon].")
 
+#define THUNDERDOME_TEMPLATE_FILE "thunderdome.dmm"
+
+/client/proc/clean_thunderdome()
+	set name = "Clean Thunderdome"
+	set category = "Admin.Events"
+
+	if(!check_rights(R_EVENT))
+		return
+
+	var/delete_mobs = tgui_alert(usr, "WARNING: Deleting large amounts of mobs causes lag. Clear all mobs?", "Thunderdome Reset", list("Yes", "No", "Cancel"))
+	if(!delete_mobs || delete_mobs == "Cancel")
+		return
+
+	message_admins(SPAN_ADMINNOTICE("[key_name_admin(usr)] reset the thunderdome to default with delete_mobs marked as [delete_mobs]."))
+
+	var/area/thunderdome = GLOB.areas_by_type[/area/tdome]
+	var/list/tdome_areas = list(GLOB.areas_by_type[/area/tdome], GLOB.areas_by_type[/area/tdome/tdome1], GLOB.areas_by_type[/area/tdome/tdome2])
+
+	for(var/area/current_area as anything in tdome_areas)
+		if(delete_mobs == "Yes")
+			for(var/mob/living/mob in current_area)
+				qdel(mob) //Clear mobs
+		for(var/obj/obj in current_area)
+			qdel(obj) //Clear objects
+
+	var/datum/map_template/thunderdome_template = SSmapping.map_templates[THUNDERDOME_TEMPLATE_FILE]
+	thunderdome_template.should_place_on_top = FALSE
+	var/turf/thunderdome_corner = locate(thunderdome.x - 11, thunderdome.y - 2, 1) // have to do a little bit of coord manipulation to get it in the right spot
+	thunderdome_template.load(thunderdome_corner)
+
+#undef THUNDERDOME_TEMPLATE_FILE
+
 /client/proc/change_weather()
 	set name = "Change Weather"
 	set category = "Admin.Events"

--- a/maps/templates/thunderdome.dmm
+++ b/maps/templates/thunderdome.dmm
@@ -1,0 +1,765 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/open/floor/tdome/redfull,
+/area/template_noop)
+"c" = (
+/turf/open/floor/tdome/bluefull,
+/area/template_noop)
+"d" = (
+/obj/effect/landmark/thunderdome/two,
+/obj/effect/decal/warning_stripes{
+	icon_state = "E"
+	},
+/turf/open/floor/tdome/northeast,
+/area/template_noop)
+"f" = (
+/obj/effect/landmark/thunderdome/one,
+/turf/open/floor/tdome/northeast,
+/area/template_noop)
+"h" = (
+/obj/effect/landmark/thunderdome/two,
+/turf/open/floor/tdome/northeast,
+/area/template_noop)
+"l" = (
+/turf/open/floor/tdome/w_y1/north,
+/area/template_noop)
+"m" = (
+/turf/closed/wall/almayer/outer,
+/area/template_noop)
+"o" = (
+/turf/open/floor/tdome/w_y0/north,
+/area/template_noop)
+"p" = (
+/turf/open/floor/tdome/northeast,
+/area/template_noop)
+"s" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/turf/open/floor/tdome/northeast,
+/area/template_noop)
+"z" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E"
+	},
+/turf/open/floor/tdome/northeast,
+/area/template_noop)
+"D" = (
+/turf/open/floor/tdome/tcomms,
+/area/template_noop)
+"K" = (
+/turf/open/floor/tdome/w_y2/north,
+/area/template_noop)
+"L" = (
+/obj/structure/window/framed/almayer/hull,
+/obj/structure/machinery/door/poddoor/almayer/open{
+	id = "tdome_observer";
+	name = "\improper Observer Shutters"
+	},
+/turf/open/floor/tdome/northeast,
+/area/template_noop)
+"N" = (
+/turf/template_noop,
+/area/template_noop)
+"O" = (
+/obj/structure/machinery/door/poddoor/almayer/locked{
+	dir = 4;
+	id = "tdome_t2";
+	name = "\improper Team 2 Shutters";
+	explo_proof = 1
+	},
+/turf/open/floor/tdome/test_floor4,
+/area/template_noop)
+"P" = (
+/obj/effect/step_trigger/teleporter/random{
+	affect_ghosts = 1;
+	name = "escapeshuttle_leave";
+	teleport_x = 25;
+	teleport_x_offset = 245;
+	teleport_y = 25;
+	teleport_y_offset = 245;
+	teleport_z = 1;
+	teleport_z_offset = 1
+	},
+/turf/template_noop,
+/area/template_noop)
+"T" = (
+/obj/effect/landmark/thunderdome/one,
+/obj/effect/decal/warning_stripes{
+	icon_state = "W"
+	},
+/turf/open/floor/tdome/northeast,
+/area/template_noop)
+"W" = (
+/obj/structure/machinery/door/poddoor/almayer/locked{
+	dir = 4;
+	id = "tdome_t1";
+	name = "\improper Team 1 Shutters";
+	explo_proof = 1
+	},
+/turf/open/floor/tdome/test_floor4,
+/area/template_noop)
+
+(1,1,1) = {"
+N
+P
+P
+P
+P
+P
+P
+P
+P
+P
+P
+P
+N
+N
+N
+"}
+(2,1,1) = {"
+P
+P
+N
+N
+N
+N
+N
+N
+N
+N
+N
+P
+P
+N
+N
+"}
+(3,1,1) = {"
+P
+N
+N
+m
+m
+m
+m
+m
+m
+m
+N
+N
+P
+N
+N
+"}
+(4,1,1) = {"
+P
+N
+m
+m
+a
+a
+a
+a
+a
+m
+m
+N
+P
+N
+N
+"}
+(5,1,1) = {"
+P
+N
+m
+a
+h
+h
+h
+h
+h
+a
+m
+N
+P
+N
+N
+"}
+(6,1,1) = {"
+P
+N
+m
+a
+h
+h
+h
+h
+h
+a
+m
+N
+P
+N
+N
+"}
+(7,1,1) = {"
+P
+N
+m
+a
+h
+h
+h
+h
+h
+a
+m
+N
+P
+N
+N
+"}
+(8,1,1) = {"
+P
+N
+m
+a
+h
+h
+h
+h
+h
+a
+m
+N
+P
+P
+N
+"}
+(9,1,1) = {"
+N
+N
+m
+a
+d
+d
+d
+d
+d
+a
+m
+N
+N
+P
+N
+"}
+(10,1,1) = {"
+N
+m
+m
+m
+W
+W
+W
+W
+W
+m
+m
+m
+N
+P
+P
+"}
+(11,1,1) = {"
+N
+m
+p
+p
+s
+s
+s
+s
+s
+p
+p
+m
+N
+N
+P
+"}
+(12,1,1) = {"
+m
+m
+p
+p
+p
+p
+p
+p
+p
+p
+p
+m
+m
+N
+P
+"}
+(13,1,1) = {"
+m
+p
+p
+p
+p
+p
+p
+p
+p
+p
+p
+p
+m
+N
+P
+"}
+(14,1,1) = {"
+m
+p
+p
+p
+p
+p
+p
+p
+p
+p
+p
+p
+m
+N
+P
+"}
+(15,1,1) = {"
+m
+p
+p
+p
+p
+p
+p
+p
+p
+p
+p
+p
+m
+N
+P
+"}
+(16,1,1) = {"
+m
+p
+p
+p
+p
+p
+p
+p
+p
+p
+p
+p
+m
+N
+P
+"}
+(17,1,1) = {"
+m
+p
+p
+p
+p
+p
+p
+p
+p
+p
+p
+p
+m
+N
+P
+"}
+(18,1,1) = {"
+L
+p
+p
+p
+p
+p
+D
+p
+p
+p
+p
+p
+m
+N
+P
+"}
+(19,1,1) = {"
+L
+p
+p
+p
+p
+D
+o
+D
+p
+p
+p
+p
+m
+N
+P
+"}
+(20,1,1) = {"
+L
+p
+p
+p
+p
+D
+l
+D
+p
+p
+p
+p
+m
+N
+P
+"}
+(21,1,1) = {"
+L
+p
+p
+p
+p
+D
+K
+D
+p
+p
+p
+p
+m
+N
+P
+"}
+(22,1,1) = {"
+L
+p
+p
+p
+p
+p
+D
+p
+p
+p
+p
+p
+m
+N
+P
+"}
+(23,1,1) = {"
+m
+p
+p
+p
+p
+p
+p
+p
+p
+p
+p
+p
+m
+N
+P
+"}
+(24,1,1) = {"
+m
+p
+p
+p
+p
+p
+p
+p
+p
+p
+p
+p
+m
+N
+P
+"}
+(25,1,1) = {"
+m
+p
+p
+p
+p
+p
+p
+p
+p
+p
+p
+p
+m
+N
+P
+"}
+(26,1,1) = {"
+m
+p
+p
+p
+p
+p
+p
+p
+p
+p
+p
+p
+m
+N
+P
+"}
+(27,1,1) = {"
+m
+p
+p
+p
+p
+p
+p
+p
+p
+p
+p
+p
+m
+N
+P
+"}
+(28,1,1) = {"
+m
+m
+p
+p
+p
+p
+p
+p
+p
+p
+p
+m
+m
+N
+P
+"}
+(29,1,1) = {"
+N
+m
+p
+p
+z
+z
+z
+z
+z
+p
+p
+m
+N
+N
+P
+"}
+(30,1,1) = {"
+N
+m
+m
+m
+O
+O
+O
+O
+O
+m
+m
+m
+N
+P
+P
+"}
+(31,1,1) = {"
+N
+N
+m
+c
+T
+T
+T
+T
+T
+c
+m
+N
+N
+P
+N
+"}
+(32,1,1) = {"
+P
+N
+m
+c
+f
+f
+f
+f
+f
+c
+m
+N
+P
+P
+N
+"}
+(33,1,1) = {"
+P
+N
+m
+c
+f
+f
+f
+f
+f
+c
+m
+N
+P
+N
+N
+"}
+(34,1,1) = {"
+P
+N
+m
+c
+f
+f
+f
+f
+f
+c
+m
+N
+P
+N
+N
+"}
+(35,1,1) = {"
+P
+N
+m
+c
+f
+f
+f
+f
+f
+c
+m
+N
+P
+N
+N
+"}
+(36,1,1) = {"
+P
+N
+m
+m
+c
+c
+c
+c
+c
+m
+m
+N
+P
+N
+N
+"}
+(37,1,1) = {"
+P
+N
+N
+m
+m
+m
+m
+m
+m
+m
+N
+N
+P
+N
+N
+"}
+(38,1,1) = {"
+P
+P
+N
+N
+N
+N
+N
+N
+N
+N
+N
+P
+P
+N
+N
+"}
+(39,1,1) = {"
+N
+P
+P
+P
+P
+P
+P
+P
+P
+P
+P
+P
+N
+N
+N
+"}


### PR DESCRIPTION

# About the pull request

adds an admin button to the events panel to clean the thunderdome. Allows you to select whether to delete the mobs inside, and resets the turfs by reloading the tdome as a template. 

I used tg's thunderdome cleanup as a base for this PR, I couldn't find the PR that originally added the system but this one was helpful. https://github.com/tgstation/tgstation/pull/65545

# Explain why it's good for the game

I've had multiple staff independently come request this from me; ease of clearing up loose stuff in the tdome without spamming bombs which just asks for trouble.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

https://github.com/user-attachments/assets/eec0bd37-2e56-4ad1-875b-21e4a67cde60

</details>


# Changelog

:cl:
admin: added a new button to reset the tdome
/:cl:

