### PR TITLE
Fix: prevent tank movement if no treads are installed

### DIFF
--- a/code/modules/vehicles/tank/tank.dm
+++ b/code/modules/vehicles/tank/tank.dm
@@ -144,13 +144,8 @@
 /obj/vehicle/multitile/tank/relaymove(mob/user, direction)
 	if(user == seats[VEHICLE_DRIVER])
 		// Check if treads are installed
-		var/has_treads = FALSE
-		for(var/obj/item/hardpoint/locomotion/treads/treads in hardpoints)
-			if(istype(treads, /obj/item/hardpoint/locomotion/treads))
-				has_treads = TRUE
-				break
-		if(!has_treads)
-			return FALSE // Block movement if no treads installed
+		if(!(locate(/obj/item/hardpoint/locomotion/treads) in hardpoints))
+			return FALSE
 
 		return ..()
 

--- a/code/modules/vehicles/tank/tank.dm
+++ b/code/modules/vehicles/tank/tank.dm
@@ -143,6 +143,15 @@
 //Another wrapper for try_move()
 /obj/vehicle/multitile/tank/relaymove(mob/user, direction)
 	if(user == seats[VEHICLE_DRIVER])
+		// Check if treads are installed
+		var/has_treads = FALSE
+		for(var/obj/item/hardpoint/locomotion/treads/treads in hardpoints)
+			if(istype(treads, /obj/item/hardpoint/locomotion/treads))
+				has_treads = TRUE
+				break
+		if(!has_treads)
+			return FALSE // Block movement if no treads installed
+
 		return ..()
 
 	if(user != seats[VEHICLE_GUNNER])


### PR DESCRIPTION
# About the pull request

Its a duplicate of https://github.com/cmss13-devs/cmss13/pull/9079 because i messed it up, i'm sorry :_(

This PR fixes a bug where tanks could move one tile without any treads installed, then become frozen and unable to move — even after installing treads.

The fix adds a check to ensure the tank has treads installed before allowing any movement.

Tested locally — everything works as expected.

# Explain why it's good for the game

Prevents tanks from getting softlocked due to missing treads.
Fixes an edge case that could brick a vehicle permanently.

# Testing Photographs and Procedure

Tested locally — everything works as expected.

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
fix: Tanks will no longer attempt to move without treads installed.
/:cl:
