### PR TITLE
COs now get large text when groundside.

### DIFF
--- a/code/game/jobs/job/command/cic/captain.dm
+++ b/code/game/jobs/job/command/cic/captain.dm
@@ -30,6 +30,7 @@
 
 /datum/job/command/commander/announce_entry_message(mob/living/carbon/human/H)
 	addtimer(CALLBACK(src, PROC_REF(do_announce_entry_message), H), 1.5 SECONDS)
+	RegisterSignal(H, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(commander_switched_z_level))
 	return ..()
 
 /datum/job/command/commander/generate_entry_conditions(mob/living/M, whitelist_status)
@@ -40,6 +41,13 @@
 /datum/job/command/commander/proc/cleanup_leader_candidate(mob/M)
 	SIGNAL_HANDLER
 	GLOB.marine_leaders -= JOB_CO
+
+/datum/job/command/commander/proc/commander_switched_z_level(mob/living/CO)
+	SIGNAL_HANDLER
+	if(is_ground_level(CO.z))
+		CO.langchat_styles = "langchat_bolded"
+	else
+		CO.langchat_styles = initial(CO.langchat_styles)
 
 /datum/job/command/commander/proc/do_announce_entry_message(mob/living/carbon/human/H)
 		all_hands_on_deck("Attention all hands, [H.get_paygrade(0)] [H.real_name] on deck!")


### PR DESCRIPTION
# About the pull request

COs now automatically get large above head text when they're groundside. Just like Squad Leaders.

Old PR, https://github.com/cmss13-devs/cmss13/pull/3618
asked CO council about it

# Explain why it's good for the game

The word of a groundside CO should probably take up just as much space as that of a squad leader.

This is obviously a whitelist thing, but I'm making this PR to promote discussion I guess.


# Testing Photographs and Procedure


# Changelog

:cl:
add: COs are now granted large abovehead text when groundside.
/:cl:
