### PR TITLE
adds extended m4ra extended magazine crate for req to buyyyyy

### DIFF
--- a/code/datums/supply_packs/ammo.dm
+++ b/code/datums/supply_packs/ammo.dm
@@ -134,6 +134,16 @@
 	containername = "\improper M4RA AP magazines crate"
 	group = "Ammo"
 
+/datum/supply_packs/ammo_m4ra_mag_box_ext
+	name = "Magazine box (M4RA, 12x extended mags)"
+	contains = list(
+		/obj/item/ammo_box/magazine/m4ra/ext,
+	)
+	cost = 30
+	containertype = /obj/structure/closet/crate/ammo
+	containername = "\improper M4RA extended magazines crate"
+	group = "Ammo"
+
 //------------------------For  M44----------------
 
 /datum/supply_packs/ammo_m44_mag_box


### PR DESCRIPTION
# About the pull request

adds the ability to purchase m4ra extended magazine crate

# Explain why it's good for the game

its an oversight, you can buy every other magazine crate except this one



# Changelog

:cl: stalkerino
add: added m4ra extended magazine box for req to buy
/:cl:
