### PR TITLE
Fix: Runtime when replacing/detaching whilst gun has nothing in the chamber.

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -210,13 +210,14 @@ Defined in conflicts.dm of the #defines folder.
 		detaching_gun.in_chamber._RemoveElement(L)
 
 	// Remove any leftover reference to the bullet trait
-	for(var/list/trait_list in detaching_gun.in_chamber.bullet_traits)
-		trait_list.Remove(traits_to_give)
-		if(!length(trait_list))
-			detaching_gun.in_chamber.bullet_traits.Remove(list(trait_list))
+	if(!isnull(detaching_gun.in_chamber))
+		for(var/list/trait_list in detaching_gun.in_chamber.bullet_traits)
+			trait_list.Remove(traits_to_give)
+			if(!length(trait_list))
+				detaching_gun.in_chamber.bullet_traits.Remove(list(trait_list))
 
-	if(!length(detaching_gun.in_chamber.bullet_traits))
-		detaching_gun.in_chamber.bullet_traits = null
+		if(!length(detaching_gun.in_chamber.bullet_traits))
+			detaching_gun.in_chamber.bullet_traits = null
 
 /obj/item/attachable/ui_action_click(mob/living/user, obj/item/weapon/gun/G)
 	activate_attachment(G, user)


### PR DESCRIPTION

# About the pull request
Add an isnull check for the .in_chamber before doing things with the .in_chamber
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Fixes a runtime.
# Testing Photographs and Procedure
<details>
<summary>Specifically this Runtime</summary>

![image](https://github.com/user-attachments/assets/df94ab4e-0f87-4058-a3a0-b3eb7fbaff6d)


![image](https://github.com/user-attachments/assets/8f5c5a70-2bb7-469f-b810-5a1b3a4824c6)


I can't believe you would spread falsehoods like this >:(

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MistChristmas
fix: Fixes a Runtime when detaching/replacing attachments when there is no round in the chamber.
/:cl:
