### PR TITLE
Fix: Roller beds deploy where you click, and not under you.

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -290,7 +290,7 @@
 	if(!length(contents))
 		new rollertype(src)
 	var/obj/structure/bed/roller/roller = locate(rollertype) in contents
-	roller.forceMove(user.loc)
+	roller.forceMove(location)
 	to_chat(user, SPAN_NOTICE("You deploy [roller]."))
 	roller.add_fingerprint(user)
 	user.temp_drop_inv_item(src)


### PR DESCRIPTION

# About the pull request
resolves: #9132

Use the location passed instead of user.loc because that's where we want it.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Is fix
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MistChristmas
fix: Roller beds deploy where clicked.
/:cl:
