### PR TITLE
removes duplicate rank pins off USCM recruiter survivor (for #7011)

### DIFF
--- a/code/modules/gear_presets/survivors/survivors.dm
+++ b/code/modules/gear_presets/survivors/survivors.dm
@@ -473,7 +473,6 @@ Everything bellow is a parent used as a base for one or multiple maps.
 
 /datum/equipment_preset/survivor/uscm/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine(new_human), WEAR_BODY)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/ranks/marine/e2(new_human), WEAR_ACCESSORY)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/marine/light(new_human), WEAR_JACKET)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/marine/satchel(new_human), WEAR_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(new_human), WEAR_FEET)


### PR DESCRIPTION

# About the pull request

fixes #7011 by removing ME2 rank pins off the jacket
tested and works


# Explain why it's good for the game
oversight fix

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

</details>


# Changelog

:cl:
del: removed ME2 rank pins off the recruiter's service jacket
/:cl:

