### PR TITLE
[QOL] add laser designator to mortar kit

### DIFF
--- a/code/modules/cm_marines/equipment/kit_boxes.dm
+++ b/code/modules/cm_marines/equipment/kit_boxes.dm
@@ -234,7 +234,7 @@
 	new /obj/item/mortar_shell/flare(src)
 	new /obj/item/tool/wrench(src)
 	new /obj/item/device/binoculars/range(src)
-	new /obj/item/device/binoculars/range(src)
+	new /obj/item/device/binoculars/range/designator(src)
 
 
 //-----------------SPEC KIT BOX------------------


### PR DESCRIPTION
# About the Pull Request

Replaces the one rangefinder in the mortar kit with a laser designator, making it easier for second mortar operator to acquire it. Since recently the mortar has acquired laser guidance https://github.com/cmss13-devs/cmss13/commit/c554042399eb1fbe235dd6cfdf2444819192f178
# Why It's Good for the Game

- Improves quality of life for mortar users by giving them the more useful and accurate tool by default.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

No visual changes to show — tested locally by spawning the mortar kit and confirming it contains a laser designator instead of the second rangefinder.

</details>

# Changelog

:cl:
qol: Replaced second rangefinder in the mortar kit with a laser designator for improved usability.
/:cl:
