### PR TITLE
disables cade building after alamo smacks into almayer (HIJACK)

### DIFF
--- a/code/modules/shuttle/dropship_hijack.dm
+++ b/code/modules/shuttle/dropship_hijack.dm
@@ -152,7 +152,10 @@
 
 	addtimer(CALLBACK(src, PROC_REF(do_dropship_incoming_sound)), 13 SECONDS)
 
+	addtimer(CALLBACK(src, PROC_REF(disable_cadebuilding_hijack)), 13 SECONDS)
+
 	addtimer(CALLBACK(src, PROC_REF(disable_latejoin)), 3 MINUTES) // latejoin cryorines have 3 minutes to get the hell out
+
 
 /datum/dropship_hijack/almayer/proc/do_dropship_incoming_sound()
 	for(var/area/internal_area in shuttle.shuttle_areas)
@@ -161,11 +164,16 @@
 
 	addtimer(CALLBACK(src, PROC_REF(do_dropship_collision_sound)), 7 SECONDS)
 
+
 /datum/dropship_hijack/almayer/proc/do_dropship_collision_sound()
 	playsound_z(SSmapping.levels_by_any_trait(list(ZTRAIT_MARINE_MAIN_SHIP)), 'sound/effects/dropship_crash.ogg', volume = 75)
 
 /datum/dropship_hijack/almayer/proc/disable_latejoin()
 	GLOB.enter_allowed = FALSE
+
+/datum/dropship_hijack/almayer/proc/disable_cadebuilding_hijack()
+	for(var/area/almayer/locations)
+		locations.allow_construction = FALSE
 
 /datum/dropship_hijack/almayer/proc/get_crashsite_turf(ship_section)
 	var/list/turfs = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Disables cade building on Almayer hijack 

# Explain why it's good for the game

@thwomper requested the PR to be made
Marines are starting to see hijack as a viable fallback option, and evacuating early to recouperate and then fight on hijack.
Hijack gameplay with the gauss sentries wasn't fun, and neither is FOB siege 2 (but with exploding pipes)
This PR still allows them to build barricades for around 3 minutes-ish, and then disables it AFTER the dropship crashes into the almayer. With this, I believe that rudimentary fortifications will still be possible but not a "FOB".
I kept the ability of using tables as fortifications, because I think it's cool and it doesn't make much of a difference. 


# Testing Photographs and Procedure
I tested it in local and it worked :D

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: stalkerino
balance: disables cade building after alamo crashes into almayer
/:cl:
