### PR TITLE
Fixes sandbags not having damage states (examine)

### DIFF
--- a/code/game/objects/structures/barricade/sandbags.dm
+++ b/code/game/objects/structures/barricade/sandbags.dm
@@ -43,21 +43,25 @@
 		changed = TRUE
 		build_stage = BARRICADE_SANDBAG_4
 		maxhealth = BARRICADE_SANDBAG_TRESHOLD_4
+		damage_state = BARRICADE_DMG_NONE
 		stack_amount = 4
 	if(health <= BARRICADE_SANDBAG_TRESHOLD_3 && build_stage != BARRICADE_SANDBAG_3)
 		changed = TRUE
 		build_stage = BARRICADE_SANDBAG_3
 		maxhealth = BARRICADE_SANDBAG_TRESHOLD_3
+		damage_state = BARRICADE_DMG_SLIGHT
 		stack_amount = 3
 	if(health <= BARRICADE_SANDBAG_TRESHOLD_2 && build_stage != BARRICADE_SANDBAG_2)
 		changed = TRUE
 		build_stage = BARRICADE_SANDBAG_2
 		maxhealth = BARRICADE_SANDBAG_TRESHOLD_2
+		damage_state = BARRICADE_DMG_MODERATE
 		stack_amount = 2
 	if(health <= BARRICADE_SANDBAG_TRESHOLD_1 && build_stage != BARRICADE_SANDBAG_1)
 		changed = TRUE
 		build_stage = BARRICADE_SANDBAG_1
 		maxhealth = BARRICADE_SANDBAG_TRESHOLD_1
+		damage_state = BARRICADE_DMG_HEAVY
 		stack_amount = 1
 	if(changed && is_wired)
 		maxhealth += 50


### PR DESCRIPTION
# About the pull request

title

# Explain why it's good for the game

title
fixes: #9060

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Sandbags will now properly show damage on examine
/:cl:
