### PR TITLE
small refactor to hpc code and balance

### DIFF
--- a/code/datums/ammo/energy.dm
+++ b/code/datums/ammo/energy.dm
@@ -110,43 +110,75 @@
 	name = "root caster bolt"
 	icon_state = "ion"
 
-/datum/ammo/energy/yautja/caster/stun
-	name = "low power stun bolt"
-	debilitate = list(2,2,0,0,0,1,0,0)
+/datum/ammo/energy/yautja/caster/bolt/single_stun
+	name = "stun bolt"
+	var/stun_time = 3
 
 	damage = 0
 	flags_ammo_behavior = AMMO_ENERGY|AMMO_IGNORE_RESIST
 
-/datum/ammo/energy/yautja/caster/bolt
+/datum/ammo/energy/yautja/caster/bolt/single_stun/on_hit_mob(mob/all_targets, obj/projectile/P)
+	var/mob/living/carbon/any_target = all_targets
+	if(istype(any_target))
+		if(isyautja(any_target) || ispredalien(any_target))
+			return
+		to_chat(any_target, SPAN_DANGER("An electric shock ripples through your body, freezing you in place!"))
+		log_attack("[key_name(any_target)] was stunned by a high power stun bolt from [key_name(P.firer)] at [get_area(P)]")
+
+		if(ishuman(any_target))
+			stun_time++
+		any_target.apply_effect(stun_time, WEAKEN)
+		any_target.apply_effect(stun_time, STUN)
+	..()
+
+/datum/ammo/energy/yautja/caster/sphere/aoe_stun
+	name = "plasma immobilizer"
+	damage = 0
+	flags_ammo_behavior = AMMO_ENERGY|AMMO_IGNORE_RESIST
+	accurate_range = 20
+	max_range = 20
+
+	var/stun_range = 7 // Big
+	var/stun_time = 6
+
+/datum/ammo/energy/yautja/caster/sphere/aoe_stun/on_hit_mob(mob/all_targets, obj/projectile/stun_projectile)
+	do_area_stun(stun_projectile)
+
+/datum/ammo/energy/yautja/caster/sphere/aoe_stun/on_hit_turf(turf/any_turf, obj/projectile/stun_projectile)
+	do_area_stun(stun_projectile)
+
+/datum/ammo/energy/yautja/caster/sphere/aoe_stun/on_hit_obj(obj/any_object, obj/projectile/stun_projectile)
+	do_area_stun(stun_projectile)
+
+/datum/ammo/energy/yautja/caster/sphere/aoe_stun/do_at_max_range(obj/projectile/stun_projectile)
+	do_area_stun(stun_projectile)
+
+/datum/ammo/energy/yautja/caster/sphere/aoe_stun/proc/do_area_stun(obj/projectile/stun_projectile)
+	playsound(stun_projectile, 'sound/weapons/wave.ogg', 75, 1, 25)
+	for(var/mob/living/carbon/any_target in orange(stun_range, stun_projectile))
+		log_attack("[key_name(any_target)] was stunned by a plasma immobilizer from [key_name(stun_projectile.firer)] at [get_area(stun_projectile)]")
+		if (isyautja(any_target))
+			stun_time -= 2
+		if(ispredalien(any_target))
+			continue
+		to_chat(any_target, SPAN_DANGER("A powerful electric shock ripples through your body, freezing you in place!"))
+		any_target.apply_effect(stun_time, STUN)
+		any_target.apply_effect(stun_time, WEAKEN)
+
+
+// --- LETHAL AMMO --- \\
+
+/datum/ammo/energy/yautja/caster/single_lethal
 	name = "plasma bolt"
 	icon_state = "pulse1"
 	flags_ammo_behavior = AMMO_IGNORE_RESIST
 	shell_speed = AMMO_SPEED_TIER_6
-	damage = 35
+	damage = 75 // This will really only be used to kill people, so it should be decent at doing so.
 
-/datum/ammo/energy/yautja/caster/bolt/stun
-	name = "high power stun bolt"
-	var/stun_time = 2
+/datum/ammo/energy/yautja/caster/single_lethal/on_hit_mob(mob/all_targets, obj/projectile/lethal_projectile)
+	cell_explosion(lethal_projectile, 50, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, lethal_projectile.weapon_cause_data)
 
-	damage = 0
-	flags_ammo_behavior = AMMO_ENERGY|AMMO_IGNORE_RESIST
-
-/datum/ammo/energy/yautja/caster/bolt/stun/on_hit_mob(mob/M, obj/projectile/P)
-	var/mob/living/carbon/C = M
-	var/stun_time = src.stun_time
-	if(istype(C))
-		if(isyautja(C) || ispredalien(C))
-			return
-		to_chat(C, SPAN_DANGER("An electric shock ripples through your body, freezing you in place!"))
-		log_attack("[key_name(C)] was stunned by a high power stun bolt from [key_name(P.firer)] at [get_area(P)]")
-
-		if(ishuman(C))
-			stun_time++
-		C.apply_effect(stun_time, WEAKEN)
-		C.apply_effect(stun_time, STUN)
-	..()
-
-/datum/ammo/energy/yautja/caster/sphere
+/datum/ammo/energy/yautja/caster/aoe_lethal
 	name = "plasma eradicator"
 	icon_state = "bluespace"
 	flags_ammo_behavior = AMMO_EXPLOSIVE|AMMO_HITS_TARGET_TURF
@@ -160,61 +192,24 @@
 
 	var/vehicle_slowdown_time = 5 SECONDS
 
-/datum/ammo/energy/yautja/caster/sphere/on_hit_mob(mob/M, obj/projectile/P)
-	cell_explosion(P, 170, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, P.weapon_cause_data)
+/datum/ammo/energy/yautja/caster/aoe_lethal/on_hit_mob(mob/all_targets, obj/projectile/lethal_projectile)
+	cell_explosion(lethal_projectile, 170, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, lethal_projectile.weapon_cause_data)
 
-/datum/ammo/energy/yautja/caster/sphere/on_hit_turf(turf/T, obj/projectile/P)
-	cell_explosion(P, 170, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, P.weapon_cause_data)
+/datum/ammo/energy/yautja/caster/aoe_lethal/on_hit_turf(mob/all_targets, obj/projectile/lethal_projectile)
+	cell_explosion(lethal_projectile, 170, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, lethal_projectile.weapon_cause_data)
 
-/datum/ammo/energy/yautja/caster/sphere/on_hit_obj(obj/O, obj/projectile/P)
-	if(istype(O, /obj/vehicle/multitile))
-		var/obj/vehicle/multitile/multitile_vehicle = O
+/datum/ammo/energy/yautja/caster/aoe_lethal/on_hit_obj(obj/any_object, obj/projectile/lethal_projectile)
+	if(istype(any_object, /obj/vehicle/multitile))
+		var/obj/vehicle/multitile/multitile_vehicle = any_object
 		multitile_vehicle.next_move = world.time + vehicle_slowdown_time
 		playsound(multitile_vehicle, 'sound/effects/meteorimpact.ogg', 35)
-		multitile_vehicle.at_munition_interior_explosion_effect(cause_data = create_cause_data("Plasma Eradicator", P.firer))
+		multitile_vehicle.at_munition_interior_explosion_effect(cause_data = create_cause_data("Plasma Eradicator", lethal_projectile.firer))
 		multitile_vehicle.interior_crash_effect()
-		multitile_vehicle.ex_act(150, P.dir, P.weapon_cause_data, 100)
-	cell_explosion(get_turf(P), 170, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, P.weapon_cause_data)
+		multitile_vehicle.ex_act(150, lethal_projectile.dir, lethal_projectile.weapon_cause_data, 100)
+	cell_explosion(get_turf(lethal_projectile), 170, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, lethal_projectile.weapon_cause_data)
 
-/datum/ammo/energy/yautja/caster/sphere/do_at_max_range(obj/projectile/P)
-	cell_explosion(get_turf(P), 170, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, P.weapon_cause_data)
-
-
-/datum/ammo/energy/yautja/caster/sphere/stun
-	name = "plasma immobilizer"
-	damage = 0
-	flags_ammo_behavior = AMMO_ENERGY|AMMO_IGNORE_RESIST
-	accurate_range = 20
-	max_range = 20
-
-	var/stun_range = 4 // Big
-	var/stun_time = 6
-
-/datum/ammo/energy/yautja/caster/sphere/stun/on_hit_mob(mob/M, obj/projectile/P)
-	do_area_stun(P)
-
-/datum/ammo/energy/yautja/caster/sphere/stun/on_hit_turf(turf/T,obj/projectile/P)
-	do_area_stun(P)
-
-/datum/ammo/energy/yautja/caster/sphere/stun/on_hit_obj(obj/O,obj/projectile/P)
-	do_area_stun(P)
-
-/datum/ammo/energy/yautja/caster/sphere/stun/do_at_max_range(obj/projectile/P)
-	do_area_stun(P)
-
-/datum/ammo/energy/yautja/caster/sphere/stun/proc/do_area_stun(obj/projectile/P)
-	playsound(P, 'sound/weapons/wave.ogg', 75, 1, 25)
-	FOR_DVIEW(var/mob/living/carbon/M, src.stun_range, get_turf(P), HIDE_INVISIBLE_OBSERVER)
-		var/stun_time = src.stun_time
-		log_attack("[key_name(M)] was stunned by a plasma immobilizer from [key_name(P.firer)] at [get_area(P)]")
-		if (isyautja(M))
-			stun_time -= 2
-		if(ispredalien(M))
-			continue
-		to_chat(M, SPAN_DANGER("A powerful electric shock ripples through your body, freezing you in place!"))
-		M.apply_effect(stun_time, STUN)
-		M.apply_effect(stun_time, WEAKEN)
-	FOR_DVIEW_END
+/datum/ammo/energy/yautja/caster/aoe_lethal/do_at_max_range(obj/projectile/lethal_projectile)
+	cell_explosion(get_turf(lethal_projectile), 170, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, lethal_projectile.weapon_cause_data)
 
 /datum/ammo/energy/yautja/rifle/bolt
 	name = "plasma rifle bolt"

--- a/code/datums/ammo/energy.dm
+++ b/code/datums/ammo/energy.dm
@@ -168,14 +168,14 @@
 
 // --- LETHAL AMMO --- \\
 
-/datum/ammo/energy/yautja/caster/single_lethal
+/datum/ammo/energy/yautja/caster/bolt/single_lethal
 	name = "plasma bolt"
 	icon_state = "pulse1"
 	flags_ammo_behavior = AMMO_IGNORE_RESIST
 	shell_speed = AMMO_SPEED_TIER_6
 	damage = 75 // This will really only be used to kill people, so it should be decent at doing so.
 
-/datum/ammo/energy/yautja/caster/single_lethal/on_hit_mob(mob/all_targets, obj/projectile/lethal_projectile)
+/datum/ammo/energy/yautja/caster/bolt/single_lethal/on_hit_mob(mob/all_targets, obj/projectile/lethal_projectile)
 	cell_explosion(lethal_projectile, 50, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, lethal_projectile.weapon_cause_data)
 
 /datum/ammo/energy/yautja/caster/aoe_lethal

--- a/code/datums/ammo/energy.dm
+++ b/code/datums/ammo/energy.dm
@@ -117,13 +117,13 @@
 	damage = 0
 	flags_ammo_behavior = AMMO_ENERGY|AMMO_IGNORE_RESIST
 
-/datum/ammo/energy/yautja/caster/bolt/single_stun/on_hit_mob(mob/all_targets, obj/projectile/P)
+/datum/ammo/energy/yautja/caster/bolt/single_stun/on_hit_mob(mob/all_targets, obj/projectile/stun_bolt)
 	var/mob/living/carbon/any_target = all_targets
 	if(isyautja(any_target) || ispredalien(any_target))
 		return
 	if(istype(any_target))
 		to_chat(any_target, SPAN_DANGER("An electric shock ripples through your body, freezing you in place!"))
-		log_attack("[key_name(any_target)] was stunned by a high power stun bolt from [key_name(P.firer)] at [get_area(P)]")
+		log_attack("[key_name(any_target)] was stunned by a high power stun bolt from [key_name(stun_bolt.firer)] at [get_area(stun_bolt)]")
 
 		if(ishuman(any_target))
 			stun_time++

--- a/code/datums/ammo/energy.dm
+++ b/code/datums/ammo/energy.dm
@@ -119,9 +119,9 @@
 
 /datum/ammo/energy/yautja/caster/bolt/single_stun/on_hit_mob(mob/all_targets, obj/projectile/P)
 	var/mob/living/carbon/any_target = all_targets
+	if(isyautja(any_target) || ispredalien(any_target))
+		return
 	if(istype(any_target))
-		if(isyautja(any_target) || ispredalien(any_target))
-			return
 		to_chat(any_target, SPAN_DANGER("An electric shock ripples through your body, freezing you in place!"))
 		log_attack("[key_name(any_target)] was stunned by a high power stun bolt from [key_name(P.firer)] at [get_area(P)]")
 

--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -1379,7 +1379,7 @@
 					set_fire_delay(FIRE_DELAY_TIER_6 * 3)
 					fire_sound = 'sound/weapons/pred_lasercannon.ogg'
 					to_chat(user, SPAN_NOTICE("[src] will now fire [strength]."))
-					ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/single_lethal]
+					ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/bolt/single_lethal]
 
 /obj/item/weapon/gun/energy/yautja/plasma_caster/use_unique_action()
 	switch(mode)
@@ -1391,7 +1391,7 @@
 			set_fire_delay(FIRE_DELAY_TIER_6 * 3)
 			fire_sound = 'sound/weapons/pred_lasercannon.ogg'
 			to_chat(usr, SPAN_NOTICE("[src] will now fire [strength]."))
-			ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/single_lethal]
+			ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/bolt/single_lethal]
 
 		if("lethal")
 			mode = "stun"

--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -1301,7 +1301,7 @@
 		WEAR_J_STORE = "plasma_wear_off"
 	)
 	fire_sound = 'sound/weapons/pred_plasmacaster_fire.ogg'
-	ammo = /datum/ammo/energy/yautja/caster/stun
+	ammo = /datum/ammo/energy/yautja/caster/bolt/single_stun
 	muzzle_flash = "muzzle_flash_blue"
 	muzzle_flash_color = COLOR_MUZZLE_BLUE
 	w_class = SIZE_HUGE
@@ -1318,7 +1318,7 @@
 	var/obj/item/clothing/gloves/yautja/hunter/source = null
 	charge_cost = 100 //How much energy is needed to fire.
 	var/mode = "stun"//fire mode (stun/lethal)
-	var/strength = "low power stun bolts"//what it's shooting
+	var/strength = "stun bolts"//what it's shooting
 
 /obj/item/weapon/gun/energy/yautja/plasma_caster/Initialize(mapload, spawn_empty, caster_material = "ebony")
 	icon_state = "[base_icon_state]_[caster_material]"
@@ -1350,43 +1350,36 @@
 	switch(mode)
 		if("stun")
 			switch(strength)
-				if("low power stun bolts")
-					strength = "high power stun bolts"
-					charge_cost = 50
-					set_fire_delay(FIRE_DELAY_TIER_1)
-					fire_sound = 'sound/weapons/pred_lasercannon.ogg'
-					to_chat(user, SPAN_NOTICE("[src] will now fire [strength]."))
-					ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/bolt/stun]
-				if("high power stun bolts")
+				if("stun bolts")
 					strength = "plasma immobilizers"
-					charge_cost = 200
+					charge_cost = 150
 					set_fire_delay(FIRE_DELAY_TIER_2 * 8)
 					fire_sound = 'sound/weapons/pulse.ogg'
 					to_chat(user, SPAN_NOTICE("[src] will now fire [strength]."))
-					ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/sphere/stun]
+					ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/sphere/aoe_stun]
 				if("plasma immobilizers")
-					strength = "low power stun bolts"
+					strength = "stun bolts"
 					charge_cost = 30
 					set_fire_delay(FIRE_DELAY_TIER_6)
 					fire_sound = 'sound/weapons/pred_plasmacaster_fire.ogg'
 					to_chat(user, SPAN_NOTICE("[src] will now fire [strength]."))
-					ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/stun]
+					ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/bolt/single_stun]
 		if("lethal")
 			switch(strength)
 				if("plasma bolts")
-					strength = "plasma spheres"
+					strength = "plasma eradicator"
 					charge_cost = 1000
 					set_fire_delay(FIRE_DELAY_TIER_2 * 12)
 					fire_sound = 'sound/weapons/pulse.ogg'
 					to_chat(user, SPAN_NOTICE("[src] will now fire [strength]."))
-					ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/sphere]
+					ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/aoe_lethal]
 				if("plasma spheres")
 					strength = "plasma bolts"
 					charge_cost = 100
 					set_fire_delay(FIRE_DELAY_TIER_6 * 3)
 					fire_sound = 'sound/weapons/pred_lasercannon.ogg'
 					to_chat(user, SPAN_NOTICE("[src] will now fire [strength]."))
-					ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/bolt]
+					ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/single_lethal]
 
 /obj/item/weapon/gun/energy/yautja/plasma_caster/use_unique_action()
 	switch(mode)
@@ -1398,17 +1391,17 @@
 			set_fire_delay(FIRE_DELAY_TIER_6 * 3)
 			fire_sound = 'sound/weapons/pred_lasercannon.ogg'
 			to_chat(usr, SPAN_NOTICE("[src] will now fire [strength]."))
-			ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/bolt]
+			ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/single_lethal]
 
 		if("lethal")
 			mode = "stun"
 			to_chat(usr, SPAN_YAUTJABOLD("[src.source] beeps: [src] is now set to [mode] mode"))
-			strength = "low power stun bolts"
+			strength = "stun bolts"
 			charge_cost = 30
 			set_fire_delay(FIRE_DELAY_TIER_6)
 			fire_sound = 'sound/weapons/pred_plasmacaster_fire.ogg'
 			to_chat(usr, SPAN_NOTICE("[src] will now fire [strength]."))
-			ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/stun]
+			ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/bolt/single_stun]
 
 /obj/item/weapon/gun/energy/yautja/plasma_caster/get_examine_text(mob/user)
 	. = ..()

--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -1366,27 +1366,28 @@
 					ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/bolt/single_stun]
 		if("lethal")
 			switch(strength)
-				if("plasma bolts")
+				if("plasma bolt")
 					strength = "plasma eradicator"
 					charge_cost = 1000
 					set_fire_delay(FIRE_DELAY_TIER_2 * 12)
 					fire_sound = 'sound/weapons/pulse.ogg'
 					to_chat(user, SPAN_NOTICE("[src] will now fire [strength]."))
 					ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/aoe_lethal]
-				if("plasma spheres")
-					strength = "plasma bolts"
-					charge_cost = 100
+				if("plasma eradicator")
+					strength = "plasma bolt"
+					charge_cost = 500
 					set_fire_delay(FIRE_DELAY_TIER_6 * 3)
 					fire_sound = 'sound/weapons/pred_lasercannon.ogg'
 					to_chat(user, SPAN_NOTICE("[src] will now fire [strength]."))
 					ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/bolt/single_lethal]
+
 
 /obj/item/weapon/gun/energy/yautja/plasma_caster/use_unique_action()
 	switch(mode)
 		if("stun")
 			mode = "lethal"
 			to_chat(usr, SPAN_YAUTJABOLD("[src.source] beeps: [src] is now set to [mode] mode"))
-			strength = "plasma bolts"
+			strength = "plasma bolt"
 			charge_cost = 100
 			set_fire_delay(FIRE_DELAY_TIER_6 * 3)
 			fire_sound = 'sound/weapons/pred_lasercannon.ogg'


### PR DESCRIPTION
# About the pull request

This removes an unused mode that did nothing

This makes the "single target" LETHAL hpc, do explosive damage instead (only effects the tile or the person it hits with a small shockwave)

# Explain why it's good for the game
just makes caster more user friendly and removes unused modes

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Lethal "bolt" for hpc now does "75 damage", and a small explosive at the tile it effects, its deadlier.
balance: Large stun sphere now stuns people from 7 tiles away from the target it lands on instead of everything in view
refactor: Rewrote some hpc code
balance: Lowered power requirement for single target lethal bolts
code: Plasma caster now only has 2 modes for stuns, one that stuns whatever it hits, and one that stuns anything  7 tiles from it
balance: Stun bolt timer is now 3 instead of 2
/:cl:
