### PR TITLE
Preds craft more things with sandstone

### DIFF
--- a/code/game/machinery/doors/runed_sandstone.dm
+++ b/code/game/machinery/doors/runed_sandstone.dm
@@ -251,3 +251,6 @@
 	name = "\improper Runed Sandstone Airlock"
 	unacidable = FALSE //Destroyable version of the temple doors
 	damage_cap = HEALTH_WALL
+
+/obj/structure/machinery/door/airlock/sandstone/runed/dark
+	color = "#2E1E21"

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -21,17 +21,32 @@ GLOBAL_LIST_INIT(sandstone_recipes, list ( \
 	new/datum/stack_recipe("sandstone wall", /turf/closed/wall/mineral/sandstone, 5, time = 50, skill_req = SKILL_CONSTRUCTION, skill_lvl = SKILL_CONSTRUCTION_ENGI, one_per_turf = ONE_TYPE_PER_TURF, on_floor = 1), \
 	new/datum/stack_recipe("sandstone floor", /turf/open/floor/sandstone/runed, 1, on_floor = 1), \
 	new/datum/stack_recipe("sandstone handrail (crenellations)", /obj/structure/barricade/handrail/sandstone, 2, time = 2 SECONDS, one_per_turf = ONE_TYPE_PER_BORDER, on_floor = 1, skill_req = SKILL_CONSTRUCTION, skill_lvl = SKILL_CONSTRUCTION_TRAINED, min_time = 1 SECONDS), \
-	new/datum/stack_recipe("sandstone handrail (flat)", /obj/structure/barricade/handrail/sandstone/b, 2, time = 2 SECONDS, one_per_turf = ONE_TYPE_PER_BORDER, on_floor = 1, skill_req = SKILL_CONSTRUCTION, skill_lvl = SKILL_CONSTRUCTION_TRAINED, min_time = 1 SECONDS),
+	new/datum/stack_recipe("sandstone handrail (flat)", /obj/structure/barricade/handrail/sandstone/b, 2, time = 2 SECONDS, one_per_turf = ONE_TYPE_PER_BORDER, on_floor = 1, skill_req = SKILL_CONSTRUCTION, skill_lvl = SKILL_CONSTRUCTION_TRAINED, min_time = 1 SECONDS), \
+	new/datum/stack_recipe("dark sandstone handrail (cren.)", /obj/structure/barricade/handrail/sandstone/dark, 2, time = 2 SECONDS, one_per_turf = ONE_TYPE_PER_BORDER, on_floor = 1, skill_req = SKILL_CONSTRUCTION, skill_lvl = SKILL_CONSTRUCTION_TRAINED, min_time = 1 SECONDS), \
+	new/datum/stack_recipe("dark sandstone handrail (flat)", /obj/structure/barricade/handrail/sandstone/b/dark, 2, time = 2 SECONDS, one_per_turf = ONE_TYPE_PER_BORDER, on_floor = 1, skill_req = SKILL_CONSTRUCTION, skill_lvl = SKILL_CONSTRUCTION_TRAINED, min_time = 1 SECONDS),
 	))
 
 GLOBAL_LIST_INIT(runedsandstone_recipes, list ( \
 	new/datum/stack_recipe("temple door", /obj/structure/machinery/door/airlock/sandstone/runed, 15, time = 10, skill_req = SKILL_ANTAG, skill_lvl = SKILL_ANTAG_HUNTER, one_per_turf = ONE_TYPE_PER_TURF, on_floor = 1), \
-	new/datum/stack_recipe("temple wall", /turf/closed/wall/mineral/sandstone/runed, 5, time = 50, skill_req = SKILL_ANTAG, skill_lvl = SKILL_ANTAG_HUNTER, one_per_turf = ONE_TYPE_PER_TURF, on_floor = 1), \
-	new/datum/stack_recipe("runed temple wall", /turf/closed/wall/mineral/sandstone/runed/decor, 5, time = 50, skill_req = SKILL_ANTAG, skill_lvl = SKILL_ANTAG_HUNTER, one_per_turf = ONE_TYPE_PER_TURF, on_floor = 1), \
-	new/datum/stack_recipe("temple floor", /turf/open/floor/sandstone/runed, 1, on_floor = 1), \
+	new/datum/stack_recipe("dark temple door", /obj/structure/machinery/door/airlock/sandstone/runed/dark, 15, time = 10, skill_req = SKILL_ANTAG, skill_lvl = SKILL_ANTAG_HUNTER, one_per_turf = ONE_TYPE_PER_TURF, on_floor = 1), \
+	new/datum/stack_recipe_list("temple walls",list( \
+		new/datum/stack_recipe("temple wall", /turf/closed/wall/mineral/sandstone/runed, 5, time = 50, skill_req = SKILL_ANTAG, skill_lvl = SKILL_ANTAG_HUNTER, one_per_turf = ONE_TYPE_PER_TURF, on_floor = 1), \
+		new/datum/stack_recipe("runed temple wall", /turf/closed/wall/mineral/sandstone/runed/decor, 5, time = 50, skill_req = SKILL_ANTAG, skill_lvl = SKILL_ANTAG_HUNTER, one_per_turf = ONE_TYPE_PER_TURF, on_floor = 1), \
+		new/datum/stack_recipe("dark engraved wall", /turf/closed/wall/cult, 5, time = 50, skill_req = SKILL_ANTAG, skill_lvl = SKILL_ANTAG_HUNTER, one_per_turf = ONE_TYPE_PER_TURF, on_floor = 1), \
+		), 5), \
+	new/datum/stack_recipe_list("temple floors",list( \
+		new/datum/stack_recipe("tan floor", /turf/open/floor/sandstone/runed, 1, on_floor = 1), \
+		new/datum/stack_recipe("engraved floor", /turf/open/floor/sandstone/cult, 1, on_floor = 1), \
+		new/datum/stack_recipe("dark red floor", /turf/open/floor/sandstone/red, 1, on_floor = 1), \
+		new/datum/stack_recipe("sun runed floor", /turf/open/floor/sandstone/red2, 1, on_floor = 1), \
+		new/datum/stack_recipe("square runed floor", /turf/open/floor/sandstone/red3, 1, on_floor = 1), \
+		), 1), \
 	new/datum/stack_recipe("brazier frame", /obj/structure/prop/brazier/frame, 5, time = 5 SECONDS, skill_req = SKILL_ANTAG, skill_lvl = SKILL_ANTAG_HUNTER, one_per_turf = ONE_TYPE_PER_TURF, on_floor = 1), \
 	new/datum/stack_recipe("wall torch frame", /obj/item/prop/torch_frame, 2, time = 2 SECONDS, skill_req = SKILL_ANTAG, skill_lvl = SKILL_ANTAG_HUNTER, one_per_turf = ONE_TYPE_PER_TURF, on_floor = 1), \
 	new/datum/stack_recipe("alien chair", /obj/structure/bed/chair/comfy/yautja, 2, time = 2 SECONDS, skill_req = SKILL_ANTAG, skill_lvl = SKILL_ANTAG_HUNTER, one_per_turf = ONE_TYPE_PER_TURF, on_floor = 1), \
+	new/datum/stack_recipe("alien bed", /obj/structure/bed/alien/yautja, 3, time = 3 SECONDS, skill_req = SKILL_ANTAG, skill_lvl = SKILL_ANTAG_HUNTER, one_per_turf = ONE_TYPE_PER_TURF, on_floor = 1), \
+	new/datum/stack_recipe("tan statue", /obj/structure/showcase/yautja, 10, time = 30, skill_req = SKILL_ANTAG, skill_lvl = SKILL_ANTAG_HUNTER, one_per_turf = ONE_TYPE_PER_TURF, on_floor = 1), \
+	new/datum/stack_recipe("grey statue", /obj/structure/showcase/yautja/alt, 10, time = 30, skill_req = SKILL_ANTAG, skill_lvl = SKILL_ANTAG_HUNTER, one_per_turf = ONE_TYPE_PER_TURF, on_floor = 1), \
 	))
 
 GLOBAL_LIST_INIT(silver_recipes, list ( \

--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -248,6 +248,12 @@
 /obj/structure/barricade/handrail/sandstone/b
 	icon_state = "hr_sandstone_b"
 
+/obj/structure/barricade/handrail/sandstone/dark
+	color = "#2E1E21"
+
+/obj/structure/barricade/handrail/sandstone/b/dark
+	color = "#2E1E21"
+
 /obj/structure/barricade/handrail/pizza
 	name = "\improper diner half-wall"
 	icon_state = "hr_sandstone" //temp, getting sprites soontm

--- a/code/game/turfs/floor.dm
+++ b/code/game/turfs/floor.dm
@@ -189,3 +189,22 @@
 /turf/open/floor/sandstone/runed
 	name = "sandstone temple floor"
 	icon_state = "runedsandstone"
+
+/turf/open/floor/sandstone/cult
+	icon = 'icons/turf/floors/floors.dmi'
+	icon_state = "cult"
+
+/turf/open/floor/sandstone/red
+	name = "carved red temple floor"
+	icon = 'icons/turf/floors/hunter_floors.dmi'
+	icon_state = "hunter_red"
+
+/turf/open/floor/sandstone/red2
+	name = "carved red temple floor"
+	icon = 'icons/turf/floors/hunter_floors.dmi'
+	icon_state = "hunter_red_2"
+
+/turf/open/floor/sandstone/red3
+	name = "carved red temple floor"
+	icon = 'icons/turf/floors/hunter_floors.dmi'
+	icon_state = "hunter_red_3"


### PR DESCRIPTION
# About the pull request

All additions have been tested and should work.

This PR allows Yautja to build more things with their materials, as well as some extra recolored sprite options. Usually Yautja are forced to ask admins for things like yautja beds or statues, being able to build them is much preferable IMO. It also adds in some dark themed temple walls and flooring since seeing tan floor all the time gets kind of stale.

Some floor paths were created because the original paths either restricted building entirely (for shipside sake) or were reinforced which needed a wrench and windup to remove. I figured it would be easier to handle the flooring there by making them a subtype of sandstone tiles so that each can be removed by a crowbar and built upon.

Walls/floors were moved into their own lists within the runed sandstone recipe menu to reduce clutter, much like how squad chairs are sorted.

-- Things added to the recipe lists --
Runed Sandstone:
- Dark Temple Door (15 Material)
- Dark Engraved Wall (5 Material)
- Alien Bed (3 Material)
- Tan Statue (10 Material)
- Grey Statue (10 Material)

Runed Sandstone Flooring: [1 material each]
- Engraved Floor
- Dark Red Floor
- Sun Runed Floor
- Square Runed Floor

Regular Sandstone:
- Dark Sandstone Handrail (cren.) (2 Material)
- Dark Sandstone Handrail (flat) (2 Material)

# Explain why it's good for the game

Less ahelps asking for pred stuff, more design options for lodges and temple/shrine constructions. I'd like to add extra things in the future if this is accepted and merged. 

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/36d41a00-d808-4db6-900e-7025a1f86e26)

</details>


# Changelog

:cl:
add: Preds can craft more things.
/:cl:
