### PR TITLE
fixes a say_understand runtime

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -110,12 +110,13 @@
 	if(universal_understand)
 		return TRUE
 
-	if(istype(other) && other?.universal_speak)
+	if(istype(other) && other.universal_speak)
 		return TRUE
 	//Language check.
-	for(var/datum/language/L in languages)
-		if(speaking?.name == L.name)
-			return TRUE
+	if(speaking)
+		for(var/datum/language/known_languages in languages)
+			if(speaking.name == known_languages.name)
+				return TRUE
 
 	return FALSE
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -114,7 +114,7 @@
 		return TRUE
 	//Language check.
 	if(speaking)
-		for(var/datum/language/known_languages in languages)
+		for(var/datum/language/known_languages as anything in languages)
 			if(speaking.name == known_languages.name)
 				return TRUE
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -109,7 +109,8 @@
 
 	if(universal_understand)
 		return TRUE
-	if(other?.universal_speak)
+
+	if(istype(other) && other?.universal_speak)
 		return TRUE
 	//Language check.
 	for(var/datum/language/L in languages)


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->
TV calls say_understands with first argument as itself. We always expect Mob there, so theres  a typecheck now.
# Explain why it's good for the game
1k runtimes every round bad

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fix spammed runtimes related to tvs relaying messages
/:cl:
