### PR TITLE
Xenos now always bleedout even if they are inside an atom

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -174,12 +174,10 @@
 
 /mob/living/carbon/xenomorph/handle_regular_status_updates(regular_update = TRUE)
 	if(regular_update && health <= 0 && (!caste || (caste.fire_immunity & FIRE_IMMUNITY_NO_IGNITE) || !on_fire)) //Sleeping Xenos are also unconscious, but all crit Xenos are under 0 HP. Go figure
-		var/turf/T = loc
-		if(istype(T))
-			if(!check_weeds_for_healing()) //In crit, damage is maximal if you're caught off weeds
-				apply_damage(2.5 - warding_aura*0.5, BRUTE) //Warding can heavily lower the impact of bleedout. Halved at 2.5 phero, stopped at 5 phero
-			else
-				apply_damage(-warding_aura, BRUTE)
+		if(!check_weeds_for_healing()) //In crit, damage is maximal if you're caught off weeds
+			apply_damage(2.5 - warding_aura*0.5, BRUTE) //Warding can heavily lower the impact of bleedout. Halved at 2.5 phero, stopped at 5 phero
+		else
+			apply_damage(-warding_aura, BRUTE)
 
 	updatehealth()
 

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -9,7 +9,7 @@
 		return
 
 	if(banished)
-		apply_armoured_damage(ceil(health / XENO_BANISHMENT_DMG_DIVISOR))
+		apply_armoured_damage(max(ceil(health / XENO_BANISHMENT_DMG_DIVISOR), 1))
 
 	..()
 


### PR DESCRIPTION

# About the pull request

This PR fixes two things:
- Xenos now can bleed out inside atoms (e.g. pipes)
- Xeno banishment damage can no longer try to heal xenos (always does 1 damage rather than doing negative dmg aka healing)

# Explain why it's good for the game

Sort of related to #9097 in that xenos shouldn't be able to avoid punishment from queen by going into pipes.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Before: https://youtu.be/qp807OO9-bA

After: https://youtu.be/gZCiFPuHbAY

</details>


# Changelog
:cl: Drathek
fix: Xenos can now bleed out when inside atoms (e.g. pipes)
fix: Xenos now always take atleast 1 dmg from queen banishment (rather than healing when in crit)
/:cl:
