### PR TITLE
Banished can now alt click to exit a tunnel

### DIFF
--- a/code/modules/cm_aliens/structures/tunnel.dm
+++ b/code/modules/cm_aliens/structures/tunnel.dm
@@ -198,14 +198,22 @@
 
 //Used for controling tunnel exiting and returning
 /obj/structure/tunnel/clicked(mob/user, list/mods)
-	if(!isxeno(user) || !isfriendly(user))
+	if(!isxeno(user))
 		return ..()
-	var/mob/living/carbon/xenomorph/X = user
-	if(mods[CTRL_CLICK] && pick_tunnel(X))//Returning to original tunnel
+
+	var/mob/living/carbon/xenomorph/xeno_user = user
+
+	if(!isfriendly(user))
+		if(mods[ALT_CLICK] && exit_tunnel(xeno_user))
+			return TRUE
+		return ..()
+
+	if(mods[CTRL_CLICK] && pick_tunnel(xeno_user))//Returning to original tunnel
 		return TRUE
-	else if(mods[ALT_CLICK] && exit_tunnel(X))//Exiting the tunnel
+	else if(mods[ALT_CLICK] && exit_tunnel(xeno_user))//Exiting the tunnel
 		return TRUE
-	. = ..()
+
+	return ..()
 
 /obj/structure/tunnel/attack_larva(mob/living/carbon/xenomorph/M)
 	. = attack_alien(M)


### PR DESCRIPTION
# About the pull request

This PR fixes some confusion on an edge case if you get banished while in a tunnel. Prior to this change: when banished, alt click and ctrl clicking on a tunnel is disabled. Alt clicking a tunnel is a way to exit a tunnel. Even though there's a separate verb that would allow you to exit the tunnel in this situation (Exit-Tunnel), now alt click will still work to exit the tunnel.

# Explain why it's good for the game

Less confusion for the banished player I guess? E.g. https://github.com/cmss13-devs/cmss13/issues/9097#issuecomment-2819753196

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/_A94bJBXok0

</details>


# Changelog
:cl: Drathek
qol: Banished xenos in a tunnel can now exit using alt+click (they could have used the exit-tunnel verb however)
/:cl:
