### PR TITLE
Fix race condition for mob logout on connect_mob_behalf

### DIFF
--- a/code/datums/components/connect_mob_behalf.dm
+++ b/code/datums/components/connect_mob_behalf.dm
@@ -41,9 +41,9 @@
 	if(QDELETED(tracked?.mob))
 		return
 	tracked_mob = tracked.mob
-	RegisterSignal(tracked_mob, COMSIG_MOB_LOGOUT, PROC_REF(on_logout))
 	for (var/signal in connections)
 		parent.RegisterSignal(tracked_mob, signal, connections[signal])
+	RegisterSignal(tracked_mob, COMSIG_MOB_LOGOUT, PROC_REF(on_logout))
 
 /datum/component/connect_mob_behalf/proc/unregister_signals()
 	if(isnull(tracked_mob))


### PR DESCRIPTION

# About the pull request

This PR fixes a runtime if you ever have alt+click examine active for a tile and ghost/logout. Basically what looks like was happening is the component connect_mob_behalf was running its logout signal prior to the connections, and its logout signal unregisters all signals. So this sort of created a race condition where before the connections ran their logout signal(s), it would unregister the signal making a runtime because the signal we're trying to execute was just unregistered a moment ago. You will either get bad index (situation the mob has no signals) or it tries to execute the proc null (mob has signals, but not the logout signal anymore). Now we just make sure the `connections` signals run prior to `connect_mob_behalf` re-registering signals.

# Explain why it's good for the game

Less runtimes!

# Testing Photographs and Procedure
1. Spawn in
2. alt click an adjacent tile
3. aghost/ghost


# Changelog
:cl: Drathek
fix: Fixed a runtime for stat panel examine whenever ghosting/logging out
/:cl:
