### PR TITLE
lungemines now gib the user

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -332,14 +332,13 @@
 	detonating = TRUE
 	playsound(user, 'sound/items/Wirecutter.ogg', 50, 1)
 
-	sleep(3)
+	addtimer(CALLBACK(src, PROC_REF(lungemine_detonate), target, user), 0.3 SECONDS)
 
+/obj/item/weapon/twohanded/lungemine/proc/lungemine_detonate(atom/target, mob/user)
+	var/turf/epicenter = get_turf(target)
+	cell_explosion(epicenter, detonation_force, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, create_cause_data(initial(name), user))
 	if(gib_user)
 		user.gib()
-
-	var/turf/epicenter = get_turf(target)
-	target.ex_act(400, null, src, user, 100)
-	cell_explosion(epicenter, detonation_force, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, create_cause_data(initial(name), user))
 	qdel(src)
 
 /obj/item/weapon/twohanded/lungemine/damaged

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -334,7 +334,7 @@
 
 	sleep(3)
 
-	if(gib_user == TRUE)
+	if(gib_user)
 		user.gib()
 
 	var/turf/epicenter = get_turf(target)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -281,6 +281,7 @@
 	hitsound = "swing_hit"
 
 	var/detonating = FALSE
+	var/gib_user = TRUE
 	var/wielded_attack_verb = list("charged")
 	var/wielded_hitsound = null
 	var/unwielded_attack_verb = list("whacked")
@@ -333,6 +334,9 @@
 
 	sleep(3)
 
+	if(gib_user == TRUE)
+		user.gib()
+
 	var/turf/epicenter = get_turf(target)
 	target.ex_act(400, null, src, user, 100)
 	cell_explosion(epicenter, detonation_force, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, create_cause_data(initial(name), user))
@@ -342,6 +346,7 @@
 	name = "damaged lunge mine"
 	desc = "A crude but intimidatingly bulky shaped explosive charge, fixed to the end of a pole. To use it, one must grasp it firmly in both hands, and thrust the prongs of the shaped charge into the target. That the resulting explosion occurs directly in front of the user's face was not an apparent concern of the designer. A true hero's weapon. This one seems pretty badly damaged, you probably shouldn't even pick it up from the ground."
 	detonation_force = 50
+	gib_user = FALSE
 
 /obj/item/weapon/twohanded/breacher
 	name = "\improper D2 Breaching Hammer"


### PR DESCRIPTION
# About the pull request

my main goal is to blow up
lunge mines will now gib the user on hit, this is to make it more in line with the fact that for most marine roles it will gib. i considered making it os that the user blows up with the same severity as the hit so if they have extremely heavy armour (B18 or similar) they can survive but decided to simply call gib although i can easily change it

damaged lunge mines do not gib the user, they deal relatively low damage in comparison

# Explain why it's good for the game

i don't find lunge mines to be bad for the game in their current state, BUT i think it's bad that you can use it and sometimes entirely avoid damage or die and be revived anyway, this item is niche as well. 

for further context, i think that it's fine for marines to charge into suicidal situations or OD/PB themselves to prevent being captured/dive into risky situations to secure a kill, but i DON'T think it's fine to basically guarantee a kill against a xeno/pred/whatever with zero consequences to yourself besides waiting for recovery - nothing else in the game incentivizes suiciding besides this item and everything else comes with a greater degree of risk than this item because you have to actually win the fight first for the kill and you can still be captured/dragged/flinged away.

# Testing Photographs and Procedure
n/a, i did test on local to make sure it wouldn't gib the wrong person, everything else works normally

# Changelog

:cl:
balance: undamaged lungemines now gib the user on hit, ex_act was removed due to being bugged (caused runtimes, did not do anything to xenomorphs due to checking the user for the explosive pen so ultimately won't change anything about it)
/:cl:
