### PR TITLE
Fix: Clear label off pill bottle icon when putting a new label in ChemMaster that is longer than the limit.

### DIFF
--- a/code/modules/reagents/chemistry_machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_master.dm
@@ -217,6 +217,9 @@
 				if(length(label) < 3)
 					bottle.maptext_label = label
 					bottle.update_icon()
+				else
+					bottle.maptext_label = ""
+					bottle.update_icon()
 
 			return TRUE
 


### PR DESCRIPTION
# About the pull request
This PR fixes a bug with labels on icons that are created when using the ChemMaster.

Currently, if a pill bottle with an existing label that is visible on the sprite is renamed in the ChemMaster to a longer name, the old name remains on the sprite, while the bottle itself is renamed. 
For example, if a pill bottle labeled (KD) is renamed to (ATD), the sprite will continue to have (KD) written on it, while inspecting the bottle will say (ATD). 

Now, instead, when using a longer name the icon will be cleared of any labels, to avoid confusion, while regular "under-the-limit" renaming (currently fewer than 3 letters) works just fine.

# Explain why it's good for the game
Current behavior of the code leads to a mismatch between the icon label and the actual name of the pill bottle. 
Fixing the bug removes this discrepancy.

# Testing Photographs and Procedure

<details>
<summary>Old bugged behavior</summary>

![Bugged1](https://github.com/user-attachments/assets/c9bd9b06-35f9-489a-a599-5a792706208e)

![Bugged2](https://github.com/user-attachments/assets/72fd0d84-d84d-4d33-804f-63885d6a5aac)

![Bugged3](https://github.com/user-attachments/assets/3367fbac-4fc7-4c50-aaf7-236e306a7e4d)

![Bugged4](https://github.com/user-attachments/assets/9f177e4f-9fc3-4b1c-8e02-c3ff6e7b6d73)

</details>
<details>
<summary>New behavior</summary>

![Fixed1](https://github.com/user-attachments/assets/7179907d-f45f-4cd2-a995-19ce1b9f6fa0)

![Fixed2](https://github.com/user-attachments/assets/d4c04dc9-b655-4eb6-a583-b3b178154968)

![Fixed3](https://github.com/user-attachments/assets/91b5db81-238b-43b1-9346-ddd85b6a5dec)

![Fixed4](https://github.com/user-attachments/assets/0724f4b9-6183-4414-aa6c-98c8fae97886)

</details>



# Changelog

:cl: BertStein
fix: fixed a bug leaving the old pill bottle label on the icon when renaming to a longer label.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
