### PR TITLE
Allow 3 character sprite labels for pill bottles and autoinjectors.

### DIFF
--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -25,9 +25,9 @@
 	var/maptext_label
 	var/custom_chem_icon
 	maptext_height = 16
-	maptext_width = 16
-	maptext_x = 18
-	maptext_y = 3
+	maptext_width = 24
+	maptext_x = 4
+	maptext_y = 2
 
 /obj/item/reagent_container/hypospray/autoinjector/Initialize()
 	. = ..()

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -608,9 +608,10 @@
 	var/display_maptext = TRUE
 	var/maptext_label
 	maptext_height = 16
-	maptext_width = 16
-	maptext_x = 18
-	maptext_y = 3
+	maptext_width = 24
+	maptext_x = 4
+	maptext_y = 2
+
 
 	var/base_icon = "pill_canister"
 	var/static/list/possible_colors = list(
@@ -807,7 +808,7 @@
 	set src in usr
 
 	if(src && ishuman(usr))
-		var/str = copytext(reject_bad_text(input(usr,"Label text? (2 CHARACTERS MAXIMUM)", "Set \the [src]'s on-sprite label", "")), 1, 3)
+		var/str = copytext(reject_bad_text(input(usr,"Label text? (3 CHARACTERS MAXIMUM)", "Set \the [src]'s on-sprite label", "")), 1, 4)
 		if(!str || !length(str))
 			to_chat(usr, SPAN_NOTICE("You clear the label off \the [src]."))
 			maptext_label = null

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -612,7 +612,6 @@
 	maptext_x = 4
 	maptext_y = 2
 
-
 	var/base_icon = "pill_canister"
 	var/static/list/possible_colors = list(
 		"Orange" = "",

--- a/code/modules/reagents/chemistry_machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_master.dm
@@ -214,7 +214,7 @@
 
 			for(var/obj/item/storage/pill_bottle/bottle in loaded_pill_bottles_to_fill)
 				bottle.AddComponent(/datum/component/label, label)
-				if(length(label) < 3)
+				if(length(label) < 4)
 					bottle.maptext_label = label
 					bottle.update_icon()
 
@@ -330,7 +330,7 @@
 
 					if(label_component_on_main_bottle != label_component_on_inputed_bottle)
 						bottle.AddComponent(/datum/component/label, label_component_on_main_bottle.label_name)
-						if(length(main_bottle.maptext_label) < 3)
+						if(length(main_bottle.maptext_label) < 4)
 							bottle.maptext_label = main_bottle.maptext_label
 							bottle.update_icon()
 					else if(label_component_on_inputed_bottle != label_component_on_main_bottle)


### PR DESCRIPTION
# About the pull request
When a pill bottle is labeled in the ChemMaster, its name is written on the sprite as an overlay. Currently, there is a 2-character limit on the sprite labels for pill bottles. This means any pill bottle with a label of 3 or more characters shows no text on its sprite.

This PR increases the limit to 3, allowing for more drugs to display labels on their pill bottle sprites. In order to do so, the label position has been moved to the bottom-left corner of the sprite (similar to the stack size label) and widened by 50%, while avoiding overlap with other labels. The position and width of autoinjector sprite labels is also changed for parity. 

Additionally, the "Set short label (on-sprite)" action's tool-tip has been updated from (2 CHARACTERS MAXIMUM) to (3 CHARACTERS MAXIMUM), and supports creating 3-character labels.

# Explain why it's good for the game
Sprite labels make identifying pills quicker for medics, especially during combat. Currently, players have to manually inspect pill bottles with longer titles to determine their contents. 

By expanding the character limit, more medicines—including ATD (as documented on the wiki), as well as custom drugs made by doctors—will display labels, which improves quality of life for medics. All existing 2-character labels still work as expected.

# Testing Screenshots

<details>
<summary>Screenshots</summary>

![old-pill-labels](https://github.com/user-attachments/assets/6aa425d9-9e7c-419a-923f-5af251368ce6)
Old labels in a lifesaver belt. Two of the six non-standard pill bottles lack visible labels, making them harder to identify.

![new-pill-labels](https://github.com/user-attachments/assets/1fc1d3f9-b060-4b20-a3cd-c954194d64a2)
New labels in a lifesaver belt. All pill bottles now display labels without overlap.

![Tooltip1](https://github.com/user-attachments/assets/1bbcb1b9-7fd2-4f87-bb1a-f959383a9c0c)
![Tooltip2](https://github.com/user-attachments/assets/1a0ddb2e-c9f6-40e6-8295-b3719366485f)
![Tooltip3](https://github.com/user-attachments/assets/d2346ce5-c235-41bb-ba4b-442b3e4c32b6)
The action to set short label on-sprite is updated accordingly.

</details>


# Changelog

:cl: BertStein
qol: Pill bottles and autoinjectors now support 3-character sprite labels.
/:cl:

