### PR TITLE
Fixes Oppressor Praetorian being able to pull from outside of view range.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
@@ -124,7 +124,7 @@
 	plasma_cost = 180
 
 	// Config
-	var/max_distance = 7
+	var/max_distance = 6
 	var/windup = 8 DECISECONDS
 
 /datum/action/xeno_action/activable/oppressor_punch


### PR DESCRIPTION

# About the pull request

oppressor praetorian can no longer pull outside of view range

# Explain why it's good for the game

due to how oppressor praetorian range is counted, it does not include your starting tile - this PR does not nerf the ability to pull on-screen (you can still reach the edge of the screen diagonally or in any other combination), but it does prevent you from being able to pull marines OFF-SCREEN by clicking on parts of their sprite that are sticking onto the next tile.


# Testing Photographs and Procedure
i tested this and tested the bug, 6 tile range still allows for grabbing anything within view but does not let you grab outside of your screen

# Changelog
:cl:
fix: oppressor praetorian can no longer click on marine muzzle flashes to grab you from off-screen
/:cl:
