### PR TITLE
removes commando ERT from random ERT selection

### DIFF
--- a/code/datums/emergency_calls/wy_commando.dm
+++ b/code/datums/emergency_calls/wy_commando.dm
@@ -3,7 +3,7 @@
 /datum/emergency_call/wy_commando
 	name = "Weyland-Yutani Commando (Squad)"
 	mob_max = 6
-	probability = 5
+	probability = 0
 	shuttle_id = MOBILE_SHUTTLE_ID_ERT2
 	home_base = /datum/lazy_template/ert/weyland_station
 	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_pmc


### PR DESCRIPTION

# About the pull request

lowers commando ERT prob from 5 to 0

# Explain why it's good for the game
there has been a very gradual and slow progression of every ERT becoming more and more powerful - originally PMCs used to be one of the few good and strong ERTs marines had. it's not wrong for ERTs to be equivalent in strength to marines, however this ERT has -
1. M41A/2 MK2 rifles with barrel chargers
2. ultrazine stimulants and redemption stimulants
3. incendiary ammunition for the smartgunners pistol
4. the ability to battlefield execute
5. extremely good equipment and armor in general, nanosplints upgraded trauma kits etc etc


# Testing Photographs and Procedure
n/a

# Changelog
:cl:
balance: weyland-yutani commandos can no longer come as a random ert due to budget cuts aboard the USCSS Nisshoku
/:cl:
