### PR TITLE
Moves the acid ball code from dancer to base prae

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
@@ -240,6 +240,41 @@
 	var/activation_delay = 1 SECONDS
 	var/prime_delay = 1 SECONDS
 
+/datum/action/xeno_action/activable/prae_acid_ball/use_ability(atom/A)
+	if (!A)
+		return
+
+	var/mob/living/carbon/xenomorph/acidball_user = owner
+	if (!acidball_user.check_state() || acidball_user.action_busy)
+		return
+
+	if (!action_cooldown_check())
+		return
+	var/turf/current_turf = get_turf(acidball_user)
+
+	if (!current_turf)
+		return
+
+	if (!do_after(acidball_user, activation_delay, INTERRUPT_ALL | BEHAVIOR_IMMOBILE, BUSY_ICON_HOSTILE))
+		to_chat(acidball_user, SPAN_XENODANGER("We cancel our acid ball."))
+		return
+
+	if (!check_and_use_plasma_owner())
+		return
+
+	apply_cooldown()
+
+	to_chat(acidball_user, SPAN_XENOWARNING("We lob a compressed ball of acid into the air!"))
+
+	var/obj/item/explosive/grenade/xeno_acid_grenade/grenade = new /obj/item/explosive/grenade/xeno_acid_grenade
+	grenade.cause_data = create_cause_data(initial(acidball_user.caste_type), acidball_user)
+	grenade.forceMove(get_turf(acidball_user))
+	grenade.throw_atom(A, 5, SPEED_SLOW, acidball_user, TRUE)
+	addtimer(CALLBACK(grenade, TYPE_PROC_REF(/obj/item/explosive, prime)), prime_delay)
+
+	return ..()
+
+
 /datum/action/xeno_action/activable/spray_acid/base_prae_spray_acid
 	name = "Spray Acid"
 	action_icon_state = "spray_acid"

--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
@@ -240,8 +240,8 @@
 	var/activation_delay = 1 SECONDS
 	var/prime_delay = 1 SECONDS
 
-/datum/action/xeno_action/activable/prae_acid_ball/use_ability(atom/A)
-	if (!A)
+/datum/action/xeno_action/activable/prae_acid_ball/use_ability(atom/target)
+	if (!target)
 		return
 
 	var/mob/living/carbon/xenomorph/acidball_user = owner
@@ -269,7 +269,7 @@
 	var/obj/item/explosive/grenade/xeno_acid_grenade/grenade = new /obj/item/explosive/grenade/xeno_acid_grenade
 	grenade.cause_data = create_cause_data(initial(acidball_user.caste_type), acidball_user)
 	grenade.forceMove(get_turf(acidball_user))
-	grenade.throw_atom(A, 5, SPEED_SLOW, acidball_user, TRUE)
+	grenade.throw_atom(target, 5, SPEED_SLOW, acidball_user, TRUE)
 	addtimer(CALLBACK(grenade, TYPE_PROC_REF(/obj/item/explosive, prime)), prime_delay)
 
 	return ..()

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/dancer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/dancer.dm
@@ -264,37 +264,3 @@
 
 	apply_cooldown()
 	return ..()
-
-/datum/action/xeno_action/activable/prae_acid_ball/use_ability(atom/A)
-	if (!A)
-		return
-
-	var/mob/living/carbon/xenomorph/acidball_user = owner
-	if (!acidball_user.check_state() || acidball_user.action_busy)
-		return
-
-	if (!action_cooldown_check())
-		return
-	var/turf/current_turf = get_turf(acidball_user)
-
-	if (!current_turf)
-		return
-
-	if (!do_after(acidball_user, activation_delay, INTERRUPT_ALL | BEHAVIOR_IMMOBILE, BUSY_ICON_HOSTILE))
-		to_chat(acidball_user, SPAN_XENODANGER("We cancel our acid ball."))
-		return
-
-	if (!check_and_use_plasma_owner())
-		return
-
-	apply_cooldown()
-
-	to_chat(acidball_user, SPAN_XENOWARNING("We lob a compressed ball of acid into the air!"))
-
-	var/obj/item/explosive/grenade/xeno_acid_grenade/grenade = new /obj/item/explosive/grenade/xeno_acid_grenade
-	grenade.cause_data = create_cause_data(initial(acidball_user.caste_type), acidball_user)
-	grenade.forceMove(get_turf(acidball_user))
-	grenade.throw_atom(A, 5, SPEED_SLOW, acidball_user, TRUE)
-	addtimer(CALLBACK(grenade, TYPE_PROC_REF(/obj/item/explosive, prime)), prime_delay)
-
-	return ..()


### PR DESCRIPTION
# About the pull request

When the abilities for each strain got moved to their respective dm, for some reason dancer got the acid ball, despite dancer never having an acid ball ability. Has been tested.

# Testing Photographs and Procedure

# Changelog

:cl:
code: Moves the acid ball ability from the dancer strain to its actual home in base praetorian abilities.
/:cl:

