### PR TITLE
marsochelmet removal shiva

### DIFF
--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -209,7 +209,6 @@
 /area/shiva/exterior/cp_colony_grounds)
 "aaQ" = (
 /obj/effect/spider/stickyweb,
-/obj/item/clothing/head/helmet/marine/sof,
 /turf/open/auto_turf/ice/layer1,
 /area/shiva/interior/caves/right_spiders)
 "aaR" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

removes marsoc helmet

# Explain why it's good for the game

#9066 

Survivors shouldn't be running around with light armor, marsoc helmet with unlimited night vision, a MK1, a subdermal armor implant

The nvgs are so easy to get that there's no point contesting it, because by the time you get there they already have that and a flamer so you die

survivors shouldn't have the same power as specialists, or marines

# Testing Photographs and Procedure




# Changelog
:cl: stalkerino
balance: removed marsoc helmet from shiva
/:cl:
