### PR TITLE
Minor Base Prae Buffs

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
@@ -240,6 +240,41 @@
 	var/activation_delay = 1 SECONDS
 	var/prime_delay = 1 SECONDS
 
+/datum/action/xeno_action/activable/prae_acid_ball/use_ability(atom/A)
+	if (!A)
+		return
+
+	var/mob/living/carbon/xenomorph/acidball_user = owner
+	if (!acidball_user.check_state() || acidball_user.action_busy)
+		return
+
+	if (!action_cooldown_check())
+		return
+	var/turf/current_turf = get_turf(acidball_user)
+
+	if (!current_turf)
+		return
+
+	if (!do_after(acidball_user, activation_delay, INTERRUPT_ALL | BEHAVIOR_IMMOBILE, BUSY_ICON_HOSTILE))
+		to_chat(acidball_user, SPAN_XENODANGER("We cancel our acid ball."))
+		return
+
+	if (!check_and_use_plasma_owner())
+		return
+
+	apply_cooldown()
+
+	to_chat(acidball_user, SPAN_XENOWARNING("We lob a compressed ball of acid into the air!"))
+
+	var/obj/item/explosive/grenade/xeno_acid_grenade/grenade = new /obj/item/explosive/grenade/xeno_acid_grenade
+	grenade.cause_data = create_cause_data(initial(acidball_user.caste_type), acidball_user)
+	grenade.forceMove(get_turf(acidball_user))
+	grenade.throw_atom(A, 5, SPEED_SLOW, acidball_user, TRUE)
+	addtimer(CALLBACK(grenade, TYPE_PROC_REF(/obj/item/explosive, prime)), prime_delay)
+
+	return ..()
+
+
 /datum/action/xeno_action/activable/spray_acid/base_prae_spray_acid
 	name = "Spray Acid"
 	action_icon_state = "spray_acid"

--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
@@ -242,8 +242,8 @@
 
 	var/prime_delay = 1 SECONDS
 
-/datum/action/xeno_action/activable/prae_acid_ball/use_ability(atom/A)
-	if (!A)
+/datum/action/xeno_action/activable/prae_acid_ball/use_ability(atom/target)
+	if (!target)
 		return
 
 	var/mob/living/carbon/xenomorph/acidball_user = owner
@@ -267,7 +267,7 @@
 	var/obj/item/explosive/grenade/xeno_acid_grenade/grenade = new /obj/item/explosive/grenade/xeno_acid_grenade
 	grenade.cause_data = create_cause_data(initial(acidball_user.caste_type), acidball_user)
 	grenade.forceMove(get_turf(acidball_user))
-	grenade.throw_atom(A, 5, SPEED_SLOW, acidball_user, TRUE)
+	grenade.throw_atom(target, 5, SPEED_SLOW, acidball_user, TRUE)
 	addtimer(CALLBACK(grenade, TYPE_PROC_REF(/obj/item/explosive, prime)), prime_delay)
 
 	return ..()

--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
@@ -228,6 +228,9 @@
 	slash = FALSE
 	freeze_self = FALSE
 
+/datum/action/xeno_action/activable/pounce/base_prae_dash/initialize_pounce_pass_flags()
+	pounce_pass_flags = PASS_MOB_THRU|PASS_OVER_THROW_MOB
+
 /datum/action/xeno_action/activable/prae_acid_ball
 	name = "Acid Ball"
 	action_icon_state = "prae_acid_ball"
@@ -237,7 +240,6 @@
 	xeno_cooldown = 18 SECONDS
 	plasma_cost = 80
 
-	var/activation_delay = 1 SECONDS
 	var/prime_delay = 1 SECONDS
 
 /datum/action/xeno_action/activable/prae_acid_ball/use_ability(atom/A)
@@ -253,10 +255,6 @@
 	var/turf/current_turf = get_turf(acidball_user)
 
 	if (!current_turf)
-		return
-
-	if (!do_after(acidball_user, activation_delay, INTERRUPT_ALL | BEHAVIOR_IMMOBILE, BUSY_ICON_HOSTILE))
-		to_chat(acidball_user, SPAN_XENODANGER("We cancel our acid ball."))
 		return
 
 	if (!check_and_use_plasma_owner())
@@ -289,8 +287,6 @@
 	spray_type = ACID_SPRAY_LINE
 	spray_distance = 7
 	spray_effect_type = /obj/effect/xenomorph/spray/praetorian
-	activation_delay = TRUE
-	activation_delay_length = 5
 
 ///////////////////////// VALKYRIE PRAE
 

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/dancer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/dancer.dm
@@ -264,37 +264,3 @@
 
 	apply_cooldown()
 	return ..()
-
-/datum/action/xeno_action/activable/prae_acid_ball/use_ability(atom/A)
-	if (!A)
-		return
-
-	var/mob/living/carbon/xenomorph/acidball_user = owner
-	if (!acidball_user.check_state() || acidball_user.action_busy)
-		return
-
-	if (!action_cooldown_check())
-		return
-	var/turf/current_turf = get_turf(acidball_user)
-
-	if (!current_turf)
-		return
-
-	if (!do_after(acidball_user, activation_delay, INTERRUPT_ALL | BEHAVIOR_IMMOBILE, BUSY_ICON_HOSTILE))
-		to_chat(acidball_user, SPAN_XENODANGER("We cancel our acid ball."))
-		return
-
-	if (!check_and_use_plasma_owner())
-		return
-
-	apply_cooldown()
-
-	to_chat(acidball_user, SPAN_XENOWARNING("We lob a compressed ball of acid into the air!"))
-
-	var/obj/item/explosive/grenade/xeno_acid_grenade/grenade = new /obj/item/explosive/grenade/xeno_acid_grenade
-	grenade.cause_data = create_cause_data(initial(acidball_user.caste_type), acidball_user)
-	grenade.forceMove(get_turf(acidball_user))
-	grenade.throw_atom(A, 5, SPEED_SLOW, acidball_user, TRUE)
-	addtimer(CALLBACK(grenade, TYPE_PROC_REF(/obj/item/explosive, prime)), prime_delay)
-
-	return ..()


### PR DESCRIPTION
# About the pull request

This pull request hopefully makes the base strain of praetorian more viable without unbalancing it.

1. Removes the wind up from acid spray, it's now instant like spitter's or boiler's
2. Removes the wind up from acid ball, while firing it is now instant, the throw speed and detonation speed are the same
3. The dash can now pass over mobs instead of getting stuck if there's one in the way

Everything's tested and should be good to go.

# Explain why it's good for the game

Base prae needs a little bit of love. It and dancer are consistently overshadowed and outperformed by vanguard, oppressor, and valkyrie. These changes should make it a little less clunky to play and  feel a little smoother. The wind up removal owes itself to the fact that prae's acid spray doesn't stun or do insane amounts of damage, and its acid ball still takes time to land and detonate- meaning it can still be dodged or ducked. Base prae is supposed to be better than the other strains for survivability, so its dash ability passing over mobs brings it in line with that idea. No more will your retreat path be blocked by a boiler; bodyblock begone!

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

https://github.com/user-attachments/assets/53a3660d-423f-4028-b5bc-f76becbf1019

</details>


# Changelog

:cl:
balance: Base prae's acid spray/ball no longer have a wind up, its dash can now pass over mobs
/:cl:
