### PR TITLE
Adds a synthetic reset key to every groundmap + Almayer medical bay 

### DIFF
--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -14423,7 +14423,7 @@
 /area/bigredv2/outside/engineering)
 "bpE" = (
 /obj/structure/surface/rack,
-/obj/item/device/analyzer,
+/obj/item/device/defibrillator/synthetic,
 /turf/open/floor/darkyellow2/north,
 /area/bigredv2/outside/engineering)
 "bpF" = (

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -14895,9 +14895,6 @@
 /area/bigredv2/outside/space_port_lz2)
 "bsm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/metal{
-	amount = 30
-	},
 /obj/effect/landmark/crap_item,
 /turf/open/floor/dark,
 /area/bigredv2/outside/engineering)
@@ -20493,6 +20490,11 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/asphalt/cement_sunbleached/cement_sunbleached4,
 /area/bigredv2/outside/c)
+"eQE" = (
+/obj/structure/surface/rack,
+/obj/item/device/defibrillator/synthetic,
+/turf/open/floor/darkyellow2/west,
+/area/bigredv2/outside/engineering)
 "eRc" = (
 /turf/open/floor/asteroidwarning/southeast,
 /area/bigredv2/outside/filtration_plant)
@@ -32468,6 +32470,13 @@
 	},
 /turf/open/floor/plating/platebotc,
 /area/bigredv2/outside/space_port)
+"rws" = (
+/obj/structure/surface/rack,
+/obj/item/stack/sheet/metal{
+	amount = 30
+	},
+/turf/open/floor/darkyellow2/west,
+/area/bigredv2/outside/engineering)
 "rxh" = (
 /turf/open/mars_cave/mars_cave_2,
 /area/bigredv2/caves/mining)
@@ -52859,8 +52868,8 @@ bdN
 axX
 bml
 bmR
-bnr
-bnr
+eQE
+rws
 bok
 bnr
 bpi

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -1406,6 +1406,13 @@
 /obj/effect/landmark/spycam_start,
 /turf/open/floor/asteroidwarning/west,
 /area/bigredv2/outside/space_port)
+"afq" = (
+/obj/structure/surface/rack,
+/obj/item/stack/sheet/metal{
+	amount = 30
+	},
+/turf/open/floor/darkyellow2/west,
+/area/bigredv2/outside/engineering)
 "afr" = (
 /obj/structure/machinery/camera/autoname{
 	dir = 4
@@ -1510,6 +1517,11 @@
 /obj/structure/bed/chair/office/dark,
 /turf/open/floor/dark,
 /area/bigredv2/outside/telecomm)
+"afK" = (
+/obj/structure/surface/rack,
+/obj/item/device/defibrillator/synthetic,
+/turf/open/floor/darkyellow2/west,
+/area/bigredv2/outside/engineering)
 "afL" = (
 /obj/structure/showcase{
 	icon_state = "broadcaster_send";
@@ -20490,11 +20502,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/asphalt/cement_sunbleached/cement_sunbleached4,
 /area/bigredv2/outside/c)
-"eQE" = (
-/obj/structure/surface/rack,
-/obj/item/device/defibrillator/synthetic,
-/turf/open/floor/darkyellow2/west,
-/area/bigredv2/outside/engineering)
 "eRc" = (
 /turf/open/floor/asteroidwarning/southeast,
 /area/bigredv2/outside/filtration_plant)
@@ -32470,13 +32477,6 @@
 	},
 /turf/open/floor/plating/platebotc,
 /area/bigredv2/outside/space_port)
-"rws" = (
-/obj/structure/surface/rack,
-/obj/item/stack/sheet/metal{
-	amount = 30
-	},
-/turf/open/floor/darkyellow2/west,
-/area/bigredv2/outside/engineering)
 "rxh" = (
 /turf/open/mars_cave/mars_cave_2,
 /area/bigredv2/caves/mining)
@@ -52868,8 +52868,8 @@ bdN
 axX
 bml
 bmR
-eQE
-rws
+afK
+afq
 bok
 bnr
 bpi

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -1406,13 +1406,6 @@
 /obj/effect/landmark/spycam_start,
 /turf/open/floor/asteroidwarning/west,
 /area/bigredv2/outside/space_port)
-"afq" = (
-/obj/structure/surface/rack,
-/obj/item/stack/sheet/metal{
-	amount = 30
-	},
-/turf/open/floor/darkyellow2/west,
-/area/bigredv2/outside/engineering)
 "afr" = (
 /obj/structure/machinery/camera/autoname{
 	dir = 4
@@ -1517,11 +1510,6 @@
 /obj/structure/bed/chair/office/dark,
 /turf/open/floor/dark,
 /area/bigredv2/outside/telecomm)
-"afK" = (
-/obj/structure/surface/rack,
-/obj/item/device/defibrillator/synthetic,
-/turf/open/floor/darkyellow2/west,
-/area/bigredv2/outside/engineering)
 "afL" = (
 /obj/structure/showcase{
 	icon_state = "broadcaster_send";
@@ -14907,6 +14895,9 @@
 /area/bigredv2/outside/space_port_lz2)
 "bsm" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/metal{
+	amount = 30
+	},
 /obj/effect/landmark/crap_item,
 /turf/open/floor/dark,
 /area/bigredv2/outside/engineering)
@@ -52868,8 +52859,8 @@ bdN
 axX
 bml
 bmR
-afK
-afq
+bnr
+bnr
 bok
 bnr
 bpi

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -18356,7 +18356,7 @@
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "bIx" = (
 /obj/structure/surface/rack,
-/obj/item/clothing/mask/gas,
+/obj/item/device/defibrillator/synthetic,
 /turf/open/floor/prison/green/southwest,
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "bIy" = (

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -934,6 +934,11 @@
 /obj/effect/landmark/spycam_start,
 /turf/open/asphalt,
 /area/desert_dam/exterior/landing_pad_one)
+"adQ" = (
+/obj/structure/surface/rack,
+/obj/item/device/defibrillator/synthetic,
+/turf/open/floor/prison/green,
+/area/desert_dam/interior/dam_interior/atmos_storage)
 "adR" = (
 /obj/effect/blocker/toxic_water/Group_2,
 /turf/open/desert/desert_shore/shore_edge1,
@@ -45793,11 +45798,6 @@
 /obj/structure/machinery/door/unpowered/shuttle,
 /turf/open/shuttle/can_surgery/red,
 /area/desert_dam/interior/dam_interior/hanger)
-"oAK" = (
-/obj/structure/surface/rack,
-/obj/item/device/defibrillator/synthetic,
-/turf/open/floor/prison/green,
-/area/desert_dam/interior/dam_interior/atmos_storage)
 "oAL" = (
 /obj/effect/decal/sand_overlay/sand1/corner1,
 /turf/open/asphalt/tile,
@@ -83791,7 +83791,7 @@ bDA
 bFa
 bFa
 bFa
-oAK
+adQ
 bDx
 cNW
 gQE

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -45793,6 +45793,11 @@
 /obj/structure/machinery/door/unpowered/shuttle,
 /turf/open/shuttle/can_surgery/red,
 /area/desert_dam/interior/dam_interior/hanger)
+"oAK" = (
+/obj/structure/surface/rack,
+/obj/item/device/defibrillator/synthetic,
+/turf/open/floor/prison/green,
+/area/desert_dam/interior/dam_interior/atmos_storage)
 "oAL" = (
 /obj/effect/decal/sand_overlay/sand1/corner1,
 /turf/open/asphalt/tile,
@@ -83786,7 +83791,7 @@ bDA
 bFa
 bFa
 bFa
-bIy
+oAK
 bDx
 cNW
 gQE

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -934,11 +934,6 @@
 /obj/effect/landmark/spycam_start,
 /turf/open/asphalt,
 /area/desert_dam/exterior/landing_pad_one)
-"adQ" = (
-/obj/structure/surface/rack,
-/obj/item/device/defibrillator/synthetic,
-/turf/open/floor/prison/green,
-/area/desert_dam/interior/dam_interior/atmos_storage)
 "adR" = (
 /obj/effect/blocker/toxic_water/Group_2,
 /turf/open/desert/desert_shore/shore_edge1,
@@ -83791,7 +83786,7 @@ bDA
 bFa
 bFa
 bFa
-adQ
+bIy
 bDx
 cNW
 gQE

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -1224,6 +1224,10 @@
 	},
 /turf/open/floor/prison,
 /area/fiorina/lz/near_lzII)
+"aRh" = (
+/obj/effect/landmark/corpsespawner/prisoner,
+/turf/open/floor/prison/sterile_white/southwest,
+/area/fiorina/station/medbay)
 "aRk" = (
 /obj/structure/cargo_container/grant/left,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -1243,6 +1247,12 @@
 	},
 /turf/open/floor/wood,
 /area/fiorina/station/park)
+"aSi" = (
+/obj/effect/spawner/gibspawner/robot,
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/prison/sterile_white/southwest,
+/area/fiorina/station/medbay)
 "aSm" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -10729,6 +10739,10 @@
 "ijC" = (
 /turf/open/floor/prison/darkpurplefull2,
 /area/fiorina/lz/near_lzI)
+"ijM" = (
+/obj/effect/spawner/gibspawner/robot,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
 "ika" = (
 /obj/structure/bed{
 	icon_state = "abed"
@@ -10831,6 +10845,10 @@
 "ioc" = (
 /turf/open/floor/prison/yellowfull,
 /area/fiorina/station/lowsec)
+"iok" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
 "ioE" = (
 /obj/structure/machinery/vending/cola,
 /turf/open/floor/prison/floor_plate,
@@ -11557,6 +11575,10 @@
 	},
 /turf/open/floor/prison/darkbrown2/west,
 /area/fiorina/tumor/aux_engi)
+"iRp" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/prison,
+/area/fiorina/station/medbay)
 "iRA" = (
 /obj/structure/stairs/perspective{
 	dir = 8;
@@ -12079,6 +12101,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/fiorina/lz/near_lzII)
+"jnk" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison/sterile_white/southwest,
+/area/fiorina/station/medbay)
 "jnm" = (
 /obj/structure/machinery/vending/sovietsoda,
 /turf/open/floor/prison/floor_plate,
@@ -14970,6 +14996,10 @@
 	},
 /turf/open/floor/plating/prison,
 /area/fiorina/tumor/aux_engi)
+"lyC" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
 "lyJ" = (
 /obj/item/tool/crowbar,
 /turf/open/floor/plating/prison,
@@ -16615,6 +16645,10 @@
 "mKx" = (
 /turf/open/floor/prison/blue_plate,
 /area/fiorina/station/botany)
+"mKV" = (
+/obj/item/robot_parts/arm/l_arm,
+/turf/open/floor/prison,
+/area/fiorina/station/medbay)
 "mLL" = (
 /obj/item/tool/mop,
 /turf/open/floor/prison/floor_plate,
@@ -17370,6 +17404,11 @@
 	},
 /turf/open/organic/grass/astroturf,
 /area/fiorina/station/civres_blue)
+"npT" = (
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/prison/cell_stripe/west,
+/area/fiorina/station/medbay)
 "nqL" = (
 /obj/structure/surface/rack,
 /obj/item/reagent_container/spray/cleaner,
@@ -17583,6 +17622,10 @@
 "nxC" = (
 /turf/closed/wall/r_wall/prison_unmeltable,
 /area/fiorina/station/power_ring/reactor)
+"nxU" = (
+/obj/effect/landmark/corpsespawner/prisoner,
+/turf/open/floor/prison,
+/area/fiorina/station/medbay)
 "nxW" = (
 /obj/structure/machinery/light/double/blue{
 	pixel_y = -1
@@ -17903,6 +17946,10 @@
 /obj/item/stack/rods,
 /turf/open/floor/prison,
 /area/fiorina/station/transit_hub)
+"nJO" = (
+/obj/item/clothing/under/marine/ua_riot,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
 "nJT" = (
 /obj/structure/inflatable/popped/door,
 /turf/open/floor/prison/whitegreen/west,
@@ -18257,6 +18304,10 @@
 /obj/structure/machinery/disposal,
 /turf/open/floor/prison/bluefull,
 /area/fiorina/station/power_ring)
+"nWU" = (
+/obj/item/weapon/baton,
+/turf/open/floor/prison/sterile_white/southwest,
+/area/fiorina/station/medbay)
 "nXj" = (
 /obj/structure/curtain/black,
 /turf/open/floor/plating/prison,
@@ -20042,6 +20093,10 @@
 	},
 /turf/open/floor/prison/redfull,
 /area/fiorina/station/security)
+"ppv" = (
+/obj/item/clothing/suit/storage/marine/light/synvest/grey,
+/turf/open/floor/prison/cell_stripe/west,
+/area/fiorina/station/medbay)
 "ppG" = (
 /obj/item/stack/rods/plasteel,
 /turf/open/floor/plating/prison,
@@ -20262,6 +20317,10 @@
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/prison/whitepurple/southeast,
 /area/fiorina/station/research_cells/west)
+"pyx" = (
+/obj/item/weapon/twohanded/spear,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
 "pyK" = (
 /obj/structure/machinery/door/airlock/multi_tile/elevator/freight,
 /turf/open/floor/corsat/plate,
@@ -21831,6 +21890,11 @@
 /obj/item/clothing/head/helmet/marine/veteran/ua_riot,
 /turf/open/floor/prison,
 /area/fiorina/station/security)
+"qIj" = (
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison,
+/area/fiorina/station/medbay)
 "qIq" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating/prison,
@@ -22251,6 +22315,10 @@
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating/prison,
 /area/fiorina/tumor/civres)
+"qXQ" = (
+/obj/item/device/defibrillator/synthetic,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
 "qYZ" = (
 /obj/structure/bed/chair,
 /turf/open/floor/prison/darkpurplefull2,
@@ -23549,7 +23617,13 @@
 /turf/open/floor/prison,
 /area/fiorina/lz/near_lzI)
 "sdr" = (
-/obj/effect/landmark/corpsespawner/ua_riot,
+/obj/effect/decal/cleanable/blood/gibs/robot,
+/obj/item/limb/head/synth{
+	desc = "This appears to be the head of a synthetic, though it it is so destroyed there is no way in hell anyone is going to bring it back to even basic functionality.";
+	name = "shattered synthetic head";
+	pixel_y = 3;
+	icon_state = "scandinavian_head_m"
+	},
 /turf/open/floor/prison/whitegreenfull/southwest,
 /area/fiorina/station/medbay)
 "sdE" = (
@@ -23879,7 +23953,9 @@
 /area/fiorina/lz/near_lzI)
 "soN" = (
 /obj/structure/closet/cabinet,
-/obj/effect/spawner/random/gun/special/lowchance,
+/obj/effect/spawner/random/gun/special/lowchance{
+	guns = list(/obj/item/weapon/gun/rifle/mar40/lmg = /obj/item/ammo_magazine/rifle/mar40/lmg, /obj/item/weapon/gun/shotgun/merc = null, /obj/item/weapon/gun/launcher/rocket/anti_tank/disposable = /obj/item/prop/folded_anti_tank_sadar, /obj/item/weapon/gun/rifle/m41a = /obj/item/ammo_magazine/rifle, /obj/item/weapon/gun/shotgun/combat = null, /obj/istem/weapon/gun/pistol/vp78 = /obj/item/ammo_magazine/pistol/vp78, /obj/item/weapon/gun/launcher/grenade/m81/m79 = null)
+	},
 /obj/item/clothing/suit/armor/det_suit,
 /turf/open/floor/wood,
 /area/fiorina/station/civres_blue)
@@ -28725,6 +28801,14 @@
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/prison,
 /area/fiorina/station/medbay)
+"wdA" = (
+/obj/structure/machinery/light/double/blue{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/item/weapon/twohanded/spear,
+/turf/open/floor/prison,
+/area/fiorina/station/medbay)
 "wdL" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -30147,6 +30231,10 @@
 	},
 /turf/open/floor/prison/floor_plate,
 /area/fiorina/station/civres_blue)
+"xli" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/prison/sterile_white/southwest,
+/area/fiorina/station/medbay)
 "xlk" = (
 /obj/effect/decal/medical_decals{
 	icon_state = "cryomid"
@@ -60929,8 +61017,8 @@ mEO
 hVI
 hVI
 gYM
-tja
-tja
+aRh
+xli
 tja
 tja
 tja
@@ -61357,7 +61445,7 @@ kXm
 ipM
 tja
 bLM
-esw
+npT
 aFZ
 hVI
 hVI
@@ -61565,9 +61653,9 @@ tQB
 kZu
 mAK
 hVI
-wfu
-bLM
-tja
+wdA
+nJO
+aSi
 bLM
 byY
 tEH
@@ -61777,9 +61865,9 @@ aFZ
 hUL
 tja
 hVI
-esw
-bLM
-tja
+ppv
+sdr
+nWU
 rnM
 esw
 tEH
@@ -61989,10 +62077,10 @@ aFZ
 wDK
 tja
 aif
-byY
-bLM
-tja
-bLM
+mKV
+ijM
+aRh
+lyC
 byY
 tEH
 njm
@@ -62202,8 +62290,8 @@ hVI
 hVI
 hVI
 qSy
-bLM
-tja
+qXQ
+xli
 bLM
 byY
 aFZ
@@ -62413,10 +62501,10 @@ aFZ
 chZ
 tja
 aif
-byY
-bLM
+qIj
+iok
 tja
-bLM
+pyx
 qtP
 aFZ
 fIT
@@ -62625,11 +62713,11 @@ aFZ
 bRo
 tja
 hVI
-byY
+iRp
 bLM
 tja
 bLM
-byY
+nxU
 sJu
 mEO
 sJu
@@ -62838,8 +62926,8 @@ kSd
 tja
 hVI
 ncj
-sdr
-tja
+bLM
+jnk
 bLM
 egT
 aFZ

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -74,8 +74,14 @@
 /turf/open/floor/prison/darkyellow2/north,
 /area/fiorina/lz/near_lzI)
 "aao" = (
-/obj/effect/landmark/corpsespawner/ua_riot,
+/obj/structure/largecrate/random/case/double,
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aap" = (
+/obj/structure/largecrate/cow,
+/turf/open/floor/prison,
 /area/fiorina/station/medbay)
 "aaq" = (
 /obj/structure/machinery/power/apc/power/north,
@@ -93,6 +99,209 @@
 /obj/structure/machinery/power/apc/power/west,
 /turf/open/floor/wood,
 /area/fiorina/station/security/wardens)
+"aat" = (
+/obj/effect/landmark/corpsespawner/prisoner,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aau" = (
+/obj/structure/machinery/light/double/blue{
+	dir = 4;
+	pixel_x = 10;
+	pixel_y = -3
+	},
+/obj/item/tool/scythe,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aav" = (
+/obj/structure/window_frame/prison,
+/obj/item/shard,
+/turf/open/floor/plating/prison,
+/area/fiorina/station/medbay)
+"aaw" = (
+/obj/structure/window_frame/prison,
+/obj/item/weapon/twohanded/folded_metal_chair,
+/turf/open/floor/plating/prison,
+/area/fiorina/station/medbay)
+"aax" = (
+/obj/structure/machinery/portable_atmospherics/powered/scrubber,
+/turf/open/floor/prison/cell_stripe/west,
+/area/fiorina/station/medbay)
+"aay" = (
+/obj/item/shard,
+/turf/open/floor/prison/cell_stripe/west,
+/area/fiorina/station/medbay)
+"aaz" = (
+/obj/item/ammo_magazine/handful/shotgun/beanbag{
+	current_rounds = 1
+	},
+/turf/open/floor/prison,
+/area/fiorina/station/medbay)
+"aaA" = (
+/obj/item/weapon/twohanded/spear,
+/turf/open/floor/prison,
+/area/fiorina/station/medbay)
+"aaB" = (
+/obj/item/ammo_casing/shell{
+	icon_state = "shell_9_1"
+	},
+/turf/open/floor/prison,
+/area/fiorina/station/medbay)
+"aaC" = (
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/prison,
+/area/fiorina/station/medbay)
+"aaD" = (
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aaE" = (
+/obj/item/storage/firstaid/regular/empty,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aaF" = (
+/obj/item/ammo_casing/shell,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aaG" = (
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/decal/cleanable/blood/splatter{
+	icon_state = "gibup1"
+	},
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aaH" = (
+/obj/item/explosive/grenade/custom/teargas,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aaI" = (
+/obj/structure/barricade/metal{
+	dir = 4
+	},
+/obj/item/ammo_magazine/handful/shotgun/beanbag{
+	current_rounds = 2
+	},
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aaJ" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aaK" = (
+/obj/effect/landmark/corpsespawner/prisoner,
+/turf/open/floor/prison/sterile_white/southwest,
+/area/fiorina/station/medbay)
+"aaL" = (
+/obj/item/weapon/baton,
+/turf/open/floor/prison/sterile_white/southwest,
+/area/fiorina/station/medbay)
+"aaM" = (
+/obj/effect/spawner/gibspawner/robot,
+/turf/open/floor/prison/sterile_white/southwest,
+/area/fiorina/station/medbay)
+"aaN" = (
+/obj/effect/decal/cleanable/blood/splatter{
+	icon_state = "gib5"
+	},
+/turf/open/floor/prison/sterile_white/southwest,
+/area/fiorina/station/medbay)
+"aaO" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor/prison/sterile_white/southwest,
+/area/fiorina/station/medbay)
+"aaP" = (
+/obj/item/weapon/baseballbat/metal,
+/turf/open/floor/prison/sterile_white/southwest,
+/area/fiorina/station/medbay)
+"aaQ" = (
+/obj/effect/decal/cleanable/blood/splatter{
+	icon_state = "gibup1"
+	},
+/turf/open/floor/prison/sterile_white/southwest,
+/area/fiorina/station/medbay)
+"aaR" = (
+/obj/structure/machinery/portable_atmospherics/powered/scrubber,
+/turf/open/floor/prison/sterile_white/southwest,
+/area/fiorina/station/medbay)
+"aaS" = (
+/obj/effect/spawner/gibspawner/robot,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aaT" = (
+/obj/item/limb/head/synth{
+	desc = "This appears to be the head of a synthetic, though it it is so destroyed there is no way in hell anyone is going to bring it back to even basic functionality.";
+	name = "shattered synthetic head";
+	icon_state = "scandinavian_head_m"
+	},
+/obj/effect/decal/cleanable/blood/gibs/robot,
+/obj/item/clothing/head/helmet/marine/veteran/ua_riot{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aaU" = (
+/obj/item/device/defibrillator/synthetic,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aaV" = (
+/obj/effect/landmark/corpsespawner/ua_riot,
+/obj/item/weapon/gun/rifle/m16,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aaW" = (
+/obj/effect/decal/cleanable/blood/splatter{
+	icon_state = "gib4"
+	},
+/obj/item/ammo_casing{
+	icon_state = "casing_5_1"
+	},
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aaX" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4
+	},
+/obj/item/ammo_casing{
+	dir = 6;
+	icon_state = "casing_10_1"
+	},
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aaY" = (
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/decal/cleanable/blood/splatter{
+	icon_state = "handblood"
+	},
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aaZ" = (
+/obj/structure/machinery/portable_atmospherics/powered/pump,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aba" = (
+/obj/structure/machinery/light/double/blue{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/item/clothing/suit/storage/marine/light/synvest/snow{
+	pixel_x = 11;
+	pixel_y = -12
+	},
+/turf/open/floor/prison,
+/area/fiorina/station/medbay)
+"abb" = (
+/obj/effect/spawner/gibspawner/robot,
+/turf/open/floor/prison/cell_stripe/west,
+/area/fiorina/station/medbay)
+"abc" = (
+/obj/structure/barricade/metal/wired{
+	dir = 4
+	},
+/obj/item/weapon/shield/riot,
+/turf/open/floor/prison,
+/area/fiorina/station/medbay)
 "abG" = (
 /obj/item/trash/chunk,
 /turf/open/floor/prison/whitegreen/north,
@@ -2536,7 +2745,9 @@
 /area/fiorina/oob)
 "bQW" = (
 /obj/item/frame/rack,
-/obj/item/stack/medical/bruise_pack,
+/obj/item/stack/medical/bruise_pack{
+	amount = 1
+	},
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison/redfull,
 /area/fiorina/station/security)
@@ -10471,7 +10682,7 @@
 /turf/open/floor/prison/whitegreenfull/southwest,
 /area/fiorina/station/medbay)
 "hZf" = (
-/obj/structure/machinery/portable_atmospherics/powered/scrubber,
+/obj/structure/largecrate/random/secure,
 /turf/open/floor/prison,
 /area/fiorina/station/medbay)
 "hZi" = (
@@ -10881,13 +11092,7 @@
 /turf/open/floor/prison/whitegreen/east,
 /area/fiorina/station/medbay)
 "ipM" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/ammo_magazine/pistol/heavy{
-	pixel_y = 7
-	},
-/obj/item/ammo_magazine/pistol/heavy{
-	pixel_y = 12
-	},
+/obj/item/ammo_box/magazine/shotgun/beanbag/empty,
 /turf/open/floor/prison/whitegreenfull/southwest,
 /area/fiorina/station/medbay)
 "ipV" = (
@@ -14264,8 +14469,9 @@
 /turf/open/floor/prison/whitepurple/northeast,
 /area/fiorina/station/research_cells/west)
 "kXm" = (
-/obj/structure/surface/rack,
-/obj/item/weapon/gun/pistol/heavy,
+/obj/item/weapon/twohanded/spear,
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/prison/cell_stripe/west,
 /area/fiorina/station/medbay)
 "kXs" = (
@@ -16988,11 +17194,11 @@
 /turf/open/floor/prison/darkyellow2/southeast,
 /area/fiorina/lz/near_lzI)
 "ncj" = (
-/obj/item/device/flashlight/lamp/tripod,
 /obj/structure/machinery/light/double/blue{
 	dir = 1;
 	pixel_y = 21
 	},
+/obj/structure/largecrate/random/barrel,
 /turf/open/floor/prison,
 /area/fiorina/station/medbay)
 "nck" = (
@@ -18277,7 +18483,9 @@
 /turf/open/floor/prison,
 /area/fiorina/lz/near_lzII)
 "nXX" = (
-/obj/item/stack/medical/bruise_pack,
+/obj/item/stack/medical/bruise_pack{
+	amount = 1
+	},
 /turf/open/floor/prison,
 /area/fiorina/station/security)
 "nYi" = (
@@ -20034,10 +20242,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/fiorina/oob)
-"poC" = (
-/obj/structure/machinery/photocopier,
-/turf/open/floor/prison/darkredfull2,
-/area/fiorina/station/research_cells/west)
 "ppq" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/structure/flora/pottedplant{
@@ -21448,8 +21652,7 @@
 /turf/open/floor/plating/prison,
 /area/fiorina/station/power_ring/reactor)
 "qtP" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/prop/helmetgarb/raincover,
+/obj/item/stack/sheet/metal,
 /turf/open/floor/prison,
 /area/fiorina/station/medbay)
 "qug" = (
@@ -22168,6 +22371,9 @@
 /obj/structure/reagent_dispensers/water_cooler/stacks{
 	pixel_y = 17
 	},
+/obj/effect/decal/cleanable/blood/splatter{
+	icon_state = "handblood"
+	},
 /turf/open/floor/prison,
 /area/fiorina/station/medbay)
 "qSz" = (
@@ -22574,11 +22780,6 @@
 /obj/structure/inflatable,
 /turf/open/floor/prison/yellow/southeast,
 /area/fiorina/station/lowsec/showers_laundry)
-"rnM" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/storage/fancy/crayons,
-/turf/open/floor/prison/whitegreenfull/southwest,
-/area/fiorina/station/medbay)
 "roi" = (
 /obj/structure/prop/souto_land/streamer{
 	dir = 9
@@ -25026,10 +25227,21 @@
 /turf/open/floor/prison/darkyellowfull2/east,
 /area/fiorina/lz/near_lzI)
 "tgL" = (
-/obj/structure/machinery/portable_atmospherics/powered/scrubber,
 /obj/structure/machinery/light/double/blue{
 	dir = 1;
 	pixel_y = 21
+	},
+/obj/structure/largecrate/random/mini/small_case{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/structure/largecrate/random/mini/small_case{
+	pixel_x = -7;
+	pixel_y = -4
+	},
+/obj/structure/largecrate/random/mini/small_case{
+	pixel_x = -1;
+	pixel_y = 4
 	},
 /turf/open/floor/prison,
 /area/fiorina/station/medbay)
@@ -28634,7 +28846,9 @@
 /turf/open/floor/plating/prison,
 /area/fiorina/station/telecomm/lz2_maint)
 "wam" = (
-/obj/item/stack/medical/bruise_pack,
+/obj/item/stack/medical/bruise_pack{
+	amount = 1
+	},
 /turf/open/floor/prison,
 /area/fiorina/station/lowsec/showers_laundry)
 "wat" = (
@@ -60930,7 +61144,7 @@ hVI
 hVI
 gYM
 tja
-tja
+aaR
 tja
 tja
 tja
@@ -61141,11 +61355,11 @@ mEO
 mEO
 hVI
 gYM
-bLM
+aaZ
 rfe
 tja
-bLM
-bLM
+aaD
+aEG
 bLM
 dCs
 bLM
@@ -61356,8 +61570,8 @@ hVI
 kXm
 ipM
 tja
-bLM
-esw
+aaE
+aax
 aFZ
 hVI
 hVI
@@ -61565,12 +61779,12 @@ tQB
 kZu
 mAK
 hVI
-wfu
-bLM
-tja
-bLM
+aba
+aaS
+aaK
+aaF
 byY
-tEH
+aav
 bLM
 bLM
 bLM
@@ -61777,13 +61991,13 @@ aFZ
 hUL
 tja
 hVI
-esw
+abb
+aaT
+aaL
 bLM
-tja
-rnM
-esw
-tEH
-bLM
+aay
+aaw
+aat
 uqd
 eUy
 bsR
@@ -61989,13 +62203,13 @@ aFZ
 wDK
 tja
 aif
-byY
-bLM
-tja
-bLM
-byY
+aaz
+aaU
+aaM
+aaG
+aaz
 tEH
-njm
+aau
 eLw
 eLw
 bLM
@@ -62202,10 +62416,10 @@ hVI
 hVI
 hVI
 qSy
-bLM
-tja
-bLM
-byY
+aaV
+ltd
+aaH
+aaA
 aFZ
 hVI
 hVI
@@ -62413,9 +62627,9 @@ aFZ
 chZ
 tja
 aif
-byY
-bLM
-tja
+aaC
+aaW
+aaN
 bLM
 qtP
 aFZ
@@ -62625,11 +62839,11 @@ aFZ
 bRo
 tja
 hVI
-byY
-bLM
-tja
-bLM
-byY
+abc
+aaX
+aaO
+aaI
+aaB
 sJu
 mEO
 sJu
@@ -62839,8 +63053,8 @@ tja
 hVI
 ncj
 aao
-tja
-bLM
+aaP
+hDl
 egT
 aFZ
 hVI
@@ -63051,8 +63265,8 @@ hVI
 hVI
 byY
 bLM
-tja
-bLM
+aaN
+aaJ
 byY
 aFZ
 hVI
@@ -63474,8 +63688,8 @@ hVI
 rUQ
 bLM
 bLM
-bLM
-tja
+aaY
+aaQ
 bLM
 byY
 aFZ
@@ -63689,10 +63903,10 @@ bLM
 bLM
 tja
 bLM
-byY
+aaC
 aFZ
 hVI
-fQY
+aap
 mEO
 mEO
 hVI
@@ -64531,7 +64745,7 @@ kMf
 cKa
 lUZ
 xlp
-poC
+cOF
 mvl
 sSv
 chx

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -73,6 +73,10 @@
 /obj/effect/landmark/spycam_start,
 /turf/open/floor/prison/darkyellow2/north,
 /area/fiorina/lz/near_lzI)
+"aao" = (
+/obj/effect/landmark/corpsespawner/ua_riot,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
 "aaq" = (
 /obj/structure/machinery/power/apc/power/north,
 /turf/open/floor/plating/prison,
@@ -23548,10 +23552,6 @@
 /obj/structure/largecrate/supply/supplies/mre,
 /turf/open/floor/prison,
 /area/fiorina/lz/near_lzI)
-"sdr" = (
-/obj/effect/landmark/corpsespawner/ua_riot,
-/turf/open/floor/prison/whitegreenfull/southwest,
-/area/fiorina/station/medbay)
 "sdE" = (
 /obj/item/storage/wallet/random,
 /turf/open/floor/prison/kitchen/southwest,
@@ -62838,7 +62838,7 @@ kSd
 tja
 hVI
 ncj
-sdr
+aao
 tja
 bLM
 egT

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -73,15 +73,6 @@
 /obj/effect/landmark/spycam_start,
 /turf/open/floor/prison/darkyellow2/north,
 /area/fiorina/lz/near_lzI)
-"aao" = (
-/obj/effect/landmark/corpsespawner/prisoner,
-/obj/effect/spawner/gibspawner/human,
-/turf/open/floor/prison/cell_stripe/west,
-/area/fiorina/station/medbay)
-"aap" = (
-/obj/effect/landmark/corpsespawner/prisoner,
-/turf/open/floor/prison,
-/area/fiorina/station/medbay)
 "aaq" = (
 /obj/structure/machinery/power/apc/power/north,
 /turf/open/floor/plating/prison,
@@ -98,87 +89,6 @@
 /obj/structure/machinery/power/apc/power/west,
 /turf/open/floor/wood,
 /area/fiorina/station/security/wardens)
-"aat" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/prison/whitegreenfull/southwest,
-/area/fiorina/station/medbay)
-"aau" = (
-/obj/item/weapon/twohanded/spear,
-/turf/open/floor/prison/whitegreenfull/southwest,
-/area/fiorina/station/medbay)
-"aav" = (
-/obj/effect/spawner/gibspawner/robot,
-/obj/effect/landmark/corpsespawner/prisoner,
-/obj/effect/spawner/gibspawner/human,
-/turf/open/floor/prison/sterile_white/southwest,
-/area/fiorina/station/medbay)
-"aaw" = (
-/obj/item/weapon/baton,
-/turf/open/floor/prison/sterile_white/southwest,
-/area/fiorina/station/medbay)
-"aax" = (
-/obj/effect/landmark/corpsespawner/prisoner,
-/turf/open/floor/prison/sterile_white/southwest,
-/area/fiorina/station/medbay)
-"aay" = (
-/obj/effect/spawner/gibspawner/human,
-/turf/open/floor/prison/sterile_white/southwest,
-/area/fiorina/station/medbay)
-"aaz" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/prison/sterile_white/southwest,
-/area/fiorina/station/medbay)
-"aaA" = (
-/obj/item/clothing/under/marine/ua_riot,
-/turf/open/floor/prison/whitegreenfull/southwest,
-/area/fiorina/station/medbay)
-"aaB" = (
-/obj/effect/decal/cleanable/blood/gibs/robot,
-/obj/item/limb/head/synth{
-	desc = "This appears to be the head of a synthetic, though it it is so destroyed there is no way in hell anyone is going to bring it back to even basic functionality.";
-	name = "shattered synthetic head";
-	pixel_y = 3;
-	icon_state = "scandinavian_head_m"
-	},
-/turf/open/floor/prison/whitegreenfull/southwest,
-/area/fiorina/station/medbay)
-"aaC" = (
-/obj/effect/spawner/gibspawner/robot,
-/turf/open/floor/prison/whitegreenfull/southwest,
-/area/fiorina/station/medbay)
-"aaD" = (
-/obj/item/device/defibrillator/synthetic,
-/turf/open/floor/prison/whitegreenfull/southwest,
-/area/fiorina/station/medbay)
-"aaE" = (
-/obj/effect/spawner/gibspawner/human,
-/turf/open/floor/prison/whitegreenfull/southwest,
-/area/fiorina/station/medbay)
-"aaF" = (
-/obj/structure/machinery/light/double/blue{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/item/weapon/twohanded/spear,
-/turf/open/floor/prison,
-/area/fiorina/station/medbay)
-"aaG" = (
-/obj/item/clothing/suit/storage/marine/light/synvest/grey,
-/turf/open/floor/prison/cell_stripe/west,
-/area/fiorina/station/medbay)
-"aaH" = (
-/obj/item/robot_parts/arm/l_arm,
-/turf/open/floor/prison,
-/area/fiorina/station/medbay)
-"aaI" = (
-/obj/effect/landmark/corpsespawner/prisoner,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/prison,
-/area/fiorina/station/medbay)
-"aaJ" = (
-/obj/effect/spawner/gibspawner/human,
-/turf/open/floor/prison,
-/area/fiorina/station/medbay)
 "abG" = (
 /obj/item/trash/chunk,
 /turf/open/floor/prison/whitegreen/north,
@@ -23638,6 +23548,10 @@
 /obj/structure/largecrate/supply/supplies/mre,
 /turf/open/floor/prison,
 /area/fiorina/lz/near_lzI)
+"sdr" = (
+/obj/effect/landmark/corpsespawner/ua_riot,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
 "sdE" = (
 /obj/item/storage/wallet/random,
 /turf/open/floor/prison/kitchen/southwest,
@@ -23965,9 +23879,7 @@
 /area/fiorina/lz/near_lzI)
 "soN" = (
 /obj/structure/closet/cabinet,
-/obj/effect/spawner/random/gun/special/lowchance{
-	guns = list(/obj/item/weapon/gun/rifle/mar40/lmg = /obj/item/ammo_magazine/rifle/mar40/lmg, /obj/item/weapon/gun/shotgun/merc = null, /obj/item/weapon/gun/launcher/rocket/anti_tank/disposable = /obj/item/prop/folded_anti_tank_sadar, /obj/item/weapon/gun/rifle/m41a = /obj/item/ammo_magazine/rifle, /obj/item/weapon/gun/shotgun/combat = null, /obj/istem/weapon/gun/pistol/vp78 = /obj/item/ammo_magazine/pistol/vp78, /obj/item/weapon/gun/launcher/grenade/m81/m79 = null)
-	},
+/obj/effect/spawner/random/gun/special/lowchance,
 /obj/item/clothing/suit/armor/det_suit,
 /turf/open/floor/wood,
 /area/fiorina/station/civres_blue)
@@ -61017,8 +60929,8 @@ mEO
 hVI
 hVI
 gYM
-aax
-aay
+tja
+tja
 tja
 tja
 tja
@@ -61445,7 +61357,7 @@ kXm
 ipM
 tja
 bLM
-aao
+esw
 aFZ
 hVI
 hVI
@@ -61653,9 +61565,9 @@ tQB
 kZu
 mAK
 hVI
-aaF
-aaA
-aav
+wfu
+bLM
+tja
 bLM
 byY
 tEH
@@ -61865,9 +61777,9 @@ aFZ
 hUL
 tja
 hVI
-aaG
-aaB
-aaw
+esw
+bLM
+tja
 rnM
 esw
 tEH
@@ -62077,10 +61989,10 @@ aFZ
 wDK
 tja
 aif
-aaH
-aaC
-aax
-aat
+byY
+bLM
+tja
+bLM
 byY
 tEH
 njm
@@ -62290,8 +62202,8 @@ hVI
 hVI
 hVI
 qSy
-aaD
-aay
+bLM
+tja
 bLM
 byY
 aFZ
@@ -62501,10 +62413,10 @@ aFZ
 chZ
 tja
 aif
-aaI
-aaE
+byY
+bLM
 tja
-aau
+bLM
 qtP
 aFZ
 fIT
@@ -62713,11 +62625,11 @@ aFZ
 bRo
 tja
 hVI
-aaJ
+byY
 bLM
 tja
 bLM
-aap
+byY
 sJu
 mEO
 sJu
@@ -62926,8 +62838,8 @@ kSd
 tja
 hVI
 ncj
-bLM
-aaz
+sdr
+tja
 bLM
 egT
 aFZ

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -74,14 +74,12 @@
 /turf/open/floor/prison/darkyellow2/north,
 /area/fiorina/lz/near_lzI)
 "aao" = (
-/obj/structure/largecrate/random/case/double,
-/obj/effect/landmark/corpsespawner/prisoner,
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/prison/whitegreenfull/southwest,
-/area/fiorina/station/medbay)
-"aap" = (
 /obj/structure/largecrate/cow,
 /turf/open/floor/prison,
+/area/fiorina/station/medbay)
+"aap" = (
+/obj/effect/landmark/corpsespawner/prisoner,
+/turf/open/floor/prison/whitegreenfull/southwest,
 /area/fiorina/station/medbay)
 "aaq" = (
 /obj/structure/machinery/power/apc/power/north,
@@ -100,10 +98,6 @@
 /turf/open/floor/wood,
 /area/fiorina/station/security/wardens)
 "aat" = (
-/obj/effect/landmark/corpsespawner/prisoner,
-/turf/open/floor/prison/whitegreenfull/southwest,
-/area/fiorina/station/medbay)
-"aau" = (
 /obj/structure/machinery/light/double/blue{
 	dir = 4;
 	pixel_x = 10;
@@ -112,70 +106,70 @@
 /obj/item/tool/scythe,
 /turf/open/floor/prison/whitegreenfull/southwest,
 /area/fiorina/station/medbay)
-"aav" = (
+"aau" = (
 /obj/structure/window_frame/prison,
 /obj/item/shard,
 /turf/open/floor/plating/prison,
 /area/fiorina/station/medbay)
-"aaw" = (
+"aav" = (
 /obj/structure/window_frame/prison,
 /obj/item/weapon/twohanded/folded_metal_chair,
 /turf/open/floor/plating/prison,
 /area/fiorina/station/medbay)
-"aax" = (
+"aaw" = (
 /obj/structure/machinery/portable_atmospherics/powered/scrubber,
 /turf/open/floor/prison/cell_stripe/west,
 /area/fiorina/station/medbay)
-"aay" = (
+"aax" = (
 /obj/item/shard,
 /turf/open/floor/prison/cell_stripe/west,
 /area/fiorina/station/medbay)
-"aaz" = (
+"aay" = (
 /obj/item/ammo_magazine/handful/shotgun/beanbag{
 	current_rounds = 1
 	},
 /turf/open/floor/prison,
 /area/fiorina/station/medbay)
-"aaA" = (
+"aaz" = (
 /obj/item/weapon/twohanded/spear,
 /turf/open/floor/prison,
 /area/fiorina/station/medbay)
-"aaB" = (
+"aaA" = (
 /obj/item/ammo_casing/shell{
 	icon_state = "shell_9_1"
 	},
 /turf/open/floor/prison,
 /area/fiorina/station/medbay)
-"aaC" = (
+"aaB" = (
 /obj/effect/landmark/corpsespawner/prisoner,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/prison,
 /area/fiorina/station/medbay)
-"aaD" = (
+"aaC" = (
 /obj/effect/landmark/corpsespawner/prisoner,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/prison/whitegreenfull/southwest,
 /area/fiorina/station/medbay)
-"aaE" = (
+"aaD" = (
 /obj/item/storage/firstaid/regular/empty,
 /turf/open/floor/prison/whitegreenfull/southwest,
 /area/fiorina/station/medbay)
-"aaF" = (
+"aaE" = (
 /obj/item/ammo_casing/shell,
 /turf/open/floor/prison/whitegreenfull/southwest,
 /area/fiorina/station/medbay)
-"aaG" = (
+"aaF" = (
 /obj/effect/landmark/corpsespawner/prisoner,
 /obj/effect/decal/cleanable/blood/splatter{
 	icon_state = "gibup1"
 	},
 /turf/open/floor/prison/whitegreenfull/southwest,
 /area/fiorina/station/medbay)
-"aaH" = (
+"aaG" = (
 /obj/item/explosive/grenade/custom/teargas,
 /turf/open/floor/prison/whitegreenfull/southwest,
 /area/fiorina/station/medbay)
-"aaI" = (
+"aaH" = (
 /obj/structure/barricade/metal{
 	dir = 4
 	},
@@ -184,51 +178,51 @@
 	},
 /turf/open/floor/prison/whitegreenfull/southwest,
 /area/fiorina/station/medbay)
-"aaJ" = (
+"aaI" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor/prison/whitegreenfull/southwest,
 /area/fiorina/station/medbay)
-"aaK" = (
+"aaJ" = (
 /obj/effect/landmark/corpsespawner/prisoner,
 /turf/open/floor/prison/sterile_white/southwest,
 /area/fiorina/station/medbay)
-"aaL" = (
+"aaK" = (
 /obj/item/weapon/baton,
 /turf/open/floor/prison/sterile_white/southwest,
 /area/fiorina/station/medbay)
-"aaM" = (
+"aaL" = (
 /obj/effect/spawner/gibspawner/robot,
 /turf/open/floor/prison/sterile_white/southwest,
 /area/fiorina/station/medbay)
-"aaN" = (
+"aaM" = (
 /obj/effect/decal/cleanable/blood/splatter{
 	icon_state = "gib5"
 	},
 /turf/open/floor/prison/sterile_white/southwest,
 /area/fiorina/station/medbay)
-"aaO" = (
+"aaN" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor/prison/sterile_white/southwest,
 /area/fiorina/station/medbay)
-"aaP" = (
+"aaO" = (
 /obj/item/weapon/baseballbat/metal,
 /turf/open/floor/prison/sterile_white/southwest,
 /area/fiorina/station/medbay)
-"aaQ" = (
+"aaP" = (
 /obj/effect/decal/cleanable/blood/splatter{
 	icon_state = "gibup1"
 	},
 /turf/open/floor/prison/sterile_white/southwest,
 /area/fiorina/station/medbay)
-"aaR" = (
+"aaQ" = (
 /obj/structure/machinery/portable_atmospherics/powered/scrubber,
 /turf/open/floor/prison/sterile_white/southwest,
 /area/fiorina/station/medbay)
-"aaS" = (
+"aaR" = (
 /obj/effect/spawner/gibspawner/robot,
 /turf/open/floor/prison/whitegreenfull/southwest,
 /area/fiorina/station/medbay)
-"aaT" = (
+"aaS" = (
 /obj/item/limb/head/synth{
 	desc = "This appears to be the head of a synthetic, though it it is so destroyed there is no way in hell anyone is going to bring it back to even basic functionality.";
 	name = "shattered synthetic head";
@@ -241,16 +235,16 @@
 	},
 /turf/open/floor/prison/whitegreenfull/southwest,
 /area/fiorina/station/medbay)
-"aaU" = (
+"aaT" = (
 /obj/item/device/defibrillator/synthetic,
 /turf/open/floor/prison/whitegreenfull/southwest,
 /area/fiorina/station/medbay)
-"aaV" = (
+"aaU" = (
 /obj/effect/landmark/corpsespawner/ua_riot,
 /obj/item/weapon/gun/rifle/m16,
 /turf/open/floor/prison/whitegreenfull/southwest,
 /area/fiorina/station/medbay)
-"aaW" = (
+"aaV" = (
 /obj/effect/decal/cleanable/blood/splatter{
 	icon_state = "gib4"
 	},
@@ -259,7 +253,7 @@
 	},
 /turf/open/floor/prison/whitegreenfull/southwest,
 /area/fiorina/station/medbay)
-"aaX" = (
+"aaW" = (
 /obj/structure/barricade/metal/wired{
 	dir = 4
 	},
@@ -269,18 +263,18 @@
 	},
 /turf/open/floor/prison/whitegreenfull/southwest,
 /area/fiorina/station/medbay)
-"aaY" = (
+"aaX" = (
 /obj/effect/landmark/corpsespawner/prisoner,
 /obj/effect/decal/cleanable/blood/splatter{
 	icon_state = "handblood"
 	},
 /turf/open/floor/prison/whitegreenfull/southwest,
 /area/fiorina/station/medbay)
-"aaZ" = (
+"aaY" = (
 /obj/structure/machinery/portable_atmospherics/powered/pump,
 /turf/open/floor/prison/whitegreenfull/southwest,
 /area/fiorina/station/medbay)
-"aba" = (
+"aaZ" = (
 /obj/structure/machinery/light/double/blue{
 	dir = 1;
 	pixel_y = 21
@@ -291,11 +285,11 @@
 	},
 /turf/open/floor/prison,
 /area/fiorina/station/medbay)
-"abb" = (
+"aba" = (
 /obj/effect/spawner/gibspawner/robot,
 /turf/open/floor/prison/cell_stripe/west,
 /area/fiorina/station/medbay)
-"abc" = (
+"abb" = (
 /obj/structure/barricade/metal/wired{
 	dir = 4
 	},
@@ -23753,6 +23747,12 @@
 /obj/structure/largecrate/supply/supplies/mre,
 /turf/open/floor/prison,
 /area/fiorina/lz/near_lzI)
+"sdr" = (
+/obj/structure/largecrate/random/case/double,
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
 "sdE" = (
 /obj/item/storage/wallet/random,
 /turf/open/floor/prison/kitchen/southwest,
@@ -61144,7 +61144,7 @@ hVI
 hVI
 gYM
 tja
-aaR
+aaQ
 tja
 tja
 tja
@@ -61355,10 +61355,10 @@ mEO
 mEO
 hVI
 gYM
-aaZ
+aaY
 rfe
 tja
-aaD
+aaC
 aEG
 bLM
 dCs
@@ -61570,8 +61570,8 @@ hVI
 kXm
 ipM
 tja
-aaE
-aax
+aaD
+aaw
 aFZ
 hVI
 hVI
@@ -61779,12 +61779,12 @@ tQB
 kZu
 mAK
 hVI
-aba
-aaS
-aaK
-aaF
+aaZ
+aaR
+aaJ
+aaE
 byY
-aav
+aau
 bLM
 bLM
 bLM
@@ -61991,13 +61991,13 @@ aFZ
 hUL
 tja
 hVI
-abb
-aaT
-aaL
+aba
+aaS
+aaK
 bLM
-aay
-aaw
-aat
+aax
+aav
+aap
 uqd
 eUy
 bsR
@@ -62203,13 +62203,13 @@ aFZ
 wDK
 tja
 aif
-aaz
-aaU
-aaM
-aaG
-aaz
+aay
+aaT
+aaL
+aaF
+aay
 tEH
-aau
+aat
 eLw
 eLw
 bLM
@@ -62416,10 +62416,10 @@ hVI
 hVI
 hVI
 qSy
-aaV
+aaU
 ltd
-aaH
-aaA
+aaG
+aaz
 aFZ
 hVI
 hVI
@@ -62627,9 +62627,9 @@ aFZ
 chZ
 tja
 aif
-aaC
-aaW
-aaN
+aaB
+aaV
+aaM
 bLM
 qtP
 aFZ
@@ -62839,11 +62839,11 @@ aFZ
 bRo
 tja
 hVI
-abc
-aaX
-aaO
-aaI
-aaB
+abb
+aaW
+aaN
+aaH
+aaA
 sJu
 mEO
 sJu
@@ -63052,8 +63052,8 @@ kSd
 tja
 hVI
 ncj
-aao
-aaP
+sdr
+aaO
 hDl
 egT
 aFZ
@@ -63265,8 +63265,8 @@ hVI
 hVI
 byY
 bLM
-aaN
-aaJ
+aaM
+aaI
 byY
 aFZ
 hVI
@@ -63688,8 +63688,8 @@ hVI
 rUQ
 bLM
 bLM
-aaY
-aaQ
+aaX
+aaP
 bLM
 byY
 aFZ
@@ -63903,10 +63903,10 @@ bLM
 bLM
 tja
 bLM
-aaC
+aaB
 aFZ
 hVI
-aap
+aao
 mEO
 mEO
 hVI

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -73,6 +73,15 @@
 /obj/effect/landmark/spycam_start,
 /turf/open/floor/prison/darkyellow2/north,
 /area/fiorina/lz/near_lzI)
+"aao" = (
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/prison/cell_stripe/west,
+/area/fiorina/station/medbay)
+"aap" = (
+/obj/effect/landmark/corpsespawner/prisoner,
+/turf/open/floor/prison,
+/area/fiorina/station/medbay)
 "aaq" = (
 /obj/structure/machinery/power/apc/power/north,
 /turf/open/floor/plating/prison,
@@ -89,6 +98,87 @@
 /obj/structure/machinery/power/apc/power/west,
 /turf/open/floor/wood,
 /area/fiorina/station/security/wardens)
+"aat" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aau" = (
+/obj/item/weapon/twohanded/spear,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aav" = (
+/obj/effect/spawner/gibspawner/robot,
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/prison/sterile_white/southwest,
+/area/fiorina/station/medbay)
+"aaw" = (
+/obj/item/weapon/baton,
+/turf/open/floor/prison/sterile_white/southwest,
+/area/fiorina/station/medbay)
+"aax" = (
+/obj/effect/landmark/corpsespawner/prisoner,
+/turf/open/floor/prison/sterile_white/southwest,
+/area/fiorina/station/medbay)
+"aay" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/prison/sterile_white/southwest,
+/area/fiorina/station/medbay)
+"aaz" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison/sterile_white/southwest,
+/area/fiorina/station/medbay)
+"aaA" = (
+/obj/item/clothing/under/marine/ua_riot,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aaB" = (
+/obj/effect/decal/cleanable/blood/gibs/robot,
+/obj/item/limb/head/synth{
+	desc = "This appears to be the head of a synthetic, though it it is so destroyed there is no way in hell anyone is going to bring it back to even basic functionality.";
+	name = "shattered synthetic head";
+	pixel_y = 3;
+	icon_state = "scandinavian_head_m"
+	},
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aaC" = (
+/obj/effect/spawner/gibspawner/robot,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aaD" = (
+/obj/item/device/defibrillator/synthetic,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aaE" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/prison/whitegreenfull/southwest,
+/area/fiorina/station/medbay)
+"aaF" = (
+/obj/structure/machinery/light/double/blue{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/item/weapon/twohanded/spear,
+/turf/open/floor/prison,
+/area/fiorina/station/medbay)
+"aaG" = (
+/obj/item/clothing/suit/storage/marine/light/synvest/grey,
+/turf/open/floor/prison/cell_stripe/west,
+/area/fiorina/station/medbay)
+"aaH" = (
+/obj/item/robot_parts/arm/l_arm,
+/turf/open/floor/prison,
+/area/fiorina/station/medbay)
+"aaI" = (
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison,
+/area/fiorina/station/medbay)
+"aaJ" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/prison,
+/area/fiorina/station/medbay)
 "abG" = (
 /obj/item/trash/chunk,
 /turf/open/floor/prison/whitegreen/north,
@@ -1224,10 +1314,6 @@
 	},
 /turf/open/floor/prison,
 /area/fiorina/lz/near_lzII)
-"aRh" = (
-/obj/effect/landmark/corpsespawner/prisoner,
-/turf/open/floor/prison/sterile_white/southwest,
-/area/fiorina/station/medbay)
 "aRk" = (
 /obj/structure/cargo_container/grant/left,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -1247,12 +1333,6 @@
 	},
 /turf/open/floor/wood,
 /area/fiorina/station/park)
-"aSi" = (
-/obj/effect/spawner/gibspawner/robot,
-/obj/effect/landmark/corpsespawner/prisoner,
-/obj/effect/spawner/gibspawner/human,
-/turf/open/floor/prison/sterile_white/southwest,
-/area/fiorina/station/medbay)
 "aSm" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -10739,10 +10819,6 @@
 "ijC" = (
 /turf/open/floor/prison/darkpurplefull2,
 /area/fiorina/lz/near_lzI)
-"ijM" = (
-/obj/effect/spawner/gibspawner/robot,
-/turf/open/floor/prison/whitegreenfull/southwest,
-/area/fiorina/station/medbay)
 "ika" = (
 /obj/structure/bed{
 	icon_state = "abed"
@@ -10845,10 +10921,6 @@
 "ioc" = (
 /turf/open/floor/prison/yellowfull,
 /area/fiorina/station/lowsec)
-"iok" = (
-/obj/effect/spawner/gibspawner/human,
-/turf/open/floor/prison/whitegreenfull/southwest,
-/area/fiorina/station/medbay)
 "ioE" = (
 /obj/structure/machinery/vending/cola,
 /turf/open/floor/prison/floor_plate,
@@ -11575,10 +11647,6 @@
 	},
 /turf/open/floor/prison/darkbrown2/west,
 /area/fiorina/tumor/aux_engi)
-"iRp" = (
-/obj/effect/spawner/gibspawner/human,
-/turf/open/floor/prison,
-/area/fiorina/station/medbay)
 "iRA" = (
 /obj/structure/stairs/perspective{
 	dir = 8;
@@ -12101,10 +12169,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/fiorina/lz/near_lzII)
-"jnk" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/prison/sterile_white/southwest,
-/area/fiorina/station/medbay)
 "jnm" = (
 /obj/structure/machinery/vending/sovietsoda,
 /turf/open/floor/prison/floor_plate,
@@ -14996,10 +15060,6 @@
 	},
 /turf/open/floor/plating/prison,
 /area/fiorina/tumor/aux_engi)
-"lyC" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/prison/whitegreenfull/southwest,
-/area/fiorina/station/medbay)
 "lyJ" = (
 /obj/item/tool/crowbar,
 /turf/open/floor/plating/prison,
@@ -16645,10 +16705,6 @@
 "mKx" = (
 /turf/open/floor/prison/blue_plate,
 /area/fiorina/station/botany)
-"mKV" = (
-/obj/item/robot_parts/arm/l_arm,
-/turf/open/floor/prison,
-/area/fiorina/station/medbay)
 "mLL" = (
 /obj/item/tool/mop,
 /turf/open/floor/prison/floor_plate,
@@ -17404,11 +17460,6 @@
 	},
 /turf/open/organic/grass/astroturf,
 /area/fiorina/station/civres_blue)
-"npT" = (
-/obj/effect/landmark/corpsespawner/prisoner,
-/obj/effect/spawner/gibspawner/human,
-/turf/open/floor/prison/cell_stripe/west,
-/area/fiorina/station/medbay)
 "nqL" = (
 /obj/structure/surface/rack,
 /obj/item/reagent_container/spray/cleaner,
@@ -17622,10 +17673,6 @@
 "nxC" = (
 /turf/closed/wall/r_wall/prison_unmeltable,
 /area/fiorina/station/power_ring/reactor)
-"nxU" = (
-/obj/effect/landmark/corpsespawner/prisoner,
-/turf/open/floor/prison,
-/area/fiorina/station/medbay)
 "nxW" = (
 /obj/structure/machinery/light/double/blue{
 	pixel_y = -1
@@ -17946,10 +17993,6 @@
 /obj/item/stack/rods,
 /turf/open/floor/prison,
 /area/fiorina/station/transit_hub)
-"nJO" = (
-/obj/item/clothing/under/marine/ua_riot,
-/turf/open/floor/prison/whitegreenfull/southwest,
-/area/fiorina/station/medbay)
 "nJT" = (
 /obj/structure/inflatable/popped/door,
 /turf/open/floor/prison/whitegreen/west,
@@ -18304,10 +18347,6 @@
 /obj/structure/machinery/disposal,
 /turf/open/floor/prison/bluefull,
 /area/fiorina/station/power_ring)
-"nWU" = (
-/obj/item/weapon/baton,
-/turf/open/floor/prison/sterile_white/southwest,
-/area/fiorina/station/medbay)
 "nXj" = (
 /obj/structure/curtain/black,
 /turf/open/floor/plating/prison,
@@ -20093,10 +20132,6 @@
 	},
 /turf/open/floor/prison/redfull,
 /area/fiorina/station/security)
-"ppv" = (
-/obj/item/clothing/suit/storage/marine/light/synvest/grey,
-/turf/open/floor/prison/cell_stripe/west,
-/area/fiorina/station/medbay)
 "ppG" = (
 /obj/item/stack/rods/plasteel,
 /turf/open/floor/plating/prison,
@@ -20317,10 +20352,6 @@
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/prison/whitepurple/southeast,
 /area/fiorina/station/research_cells/west)
-"pyx" = (
-/obj/item/weapon/twohanded/spear,
-/turf/open/floor/prison/whitegreenfull/southwest,
-/area/fiorina/station/medbay)
 "pyK" = (
 /obj/structure/machinery/door/airlock/multi_tile/elevator/freight,
 /turf/open/floor/corsat/plate,
@@ -21890,11 +21921,6 @@
 /obj/item/clothing/head/helmet/marine/veteran/ua_riot,
 /turf/open/floor/prison,
 /area/fiorina/station/security)
-"qIj" = (
-/obj/effect/landmark/corpsespawner/prisoner,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/prison,
-/area/fiorina/station/medbay)
 "qIq" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating/prison,
@@ -22315,10 +22341,6 @@
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating/prison,
 /area/fiorina/tumor/civres)
-"qXQ" = (
-/obj/item/device/defibrillator/synthetic,
-/turf/open/floor/prison/whitegreenfull/southwest,
-/area/fiorina/station/medbay)
 "qYZ" = (
 /obj/structure/bed/chair,
 /turf/open/floor/prison/darkpurplefull2,
@@ -23616,16 +23638,6 @@
 /obj/structure/largecrate/supply/supplies/mre,
 /turf/open/floor/prison,
 /area/fiorina/lz/near_lzI)
-"sdr" = (
-/obj/effect/decal/cleanable/blood/gibs/robot,
-/obj/item/limb/head/synth{
-	desc = "This appears to be the head of a synthetic, though it it is so destroyed there is no way in hell anyone is going to bring it back to even basic functionality.";
-	name = "shattered synthetic head";
-	pixel_y = 3;
-	icon_state = "scandinavian_head_m"
-	},
-/turf/open/floor/prison/whitegreenfull/southwest,
-/area/fiorina/station/medbay)
 "sdE" = (
 /obj/item/storage/wallet/random,
 /turf/open/floor/prison/kitchen/southwest,
@@ -28801,14 +28813,6 @@
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/prison,
 /area/fiorina/station/medbay)
-"wdA" = (
-/obj/structure/machinery/light/double/blue{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/item/weapon/twohanded/spear,
-/turf/open/floor/prison,
-/area/fiorina/station/medbay)
 "wdL" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -30231,10 +30235,6 @@
 	},
 /turf/open/floor/prison/floor_plate,
 /area/fiorina/station/civres_blue)
-"xli" = (
-/obj/effect/spawner/gibspawner/human,
-/turf/open/floor/prison/sterile_white/southwest,
-/area/fiorina/station/medbay)
 "xlk" = (
 /obj/effect/decal/medical_decals{
 	icon_state = "cryomid"
@@ -61017,8 +61017,8 @@ mEO
 hVI
 hVI
 gYM
-aRh
-xli
+aax
+aay
 tja
 tja
 tja
@@ -61445,7 +61445,7 @@ kXm
 ipM
 tja
 bLM
-npT
+aao
 aFZ
 hVI
 hVI
@@ -61653,9 +61653,9 @@ tQB
 kZu
 mAK
 hVI
-wdA
-nJO
-aSi
+aaF
+aaA
+aav
 bLM
 byY
 tEH
@@ -61865,9 +61865,9 @@ aFZ
 hUL
 tja
 hVI
-ppv
-sdr
-nWU
+aaG
+aaB
+aaw
 rnM
 esw
 tEH
@@ -62077,10 +62077,10 @@ aFZ
 wDK
 tja
 aif
-mKV
-ijM
-aRh
-lyC
+aaH
+aaC
+aax
+aat
 byY
 tEH
 njm
@@ -62290,8 +62290,8 @@ hVI
 hVI
 hVI
 qSy
-qXQ
-xli
+aaD
+aay
 bLM
 byY
 aFZ
@@ -62501,10 +62501,10 @@ aFZ
 chZ
 tja
 aif
-qIj
-iok
+aaI
+aaE
 tja
-pyx
+aau
 qtP
 aFZ
 fIT
@@ -62713,11 +62713,11 @@ aFZ
 bRo
 tja
 hVI
-iRp
+aaJ
 bLM
 tja
 bLM
-nxU
+aap
 sJu
 mEO
 sJu
@@ -62927,7 +62927,7 @@ tja
 hVI
 ncj
 bLM
-jnk
+aaz
 bLM
 egT
 aFZ

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -197,6 +197,11 @@
 /obj/effect/landmark/spycam_start,
 /turf/open/floor/shiva/floor3,
 /area/shiva/exterior/lz2_fortress)
+"aaM" = (
+/obj/structure/surface/table,
+/obj/item/device/defibrillator/synthetic,
+/turf/open/floor/shiva/north,
+/area/shiva/interior/garage)
 "aaN" = (
 /obj/item/weapon/gun/flamer/survivor,
 /obj/structure/surface/rack,
@@ -18063,11 +18068,6 @@
 "qrY" = (
 /turf/closed/wall/shiva/prefabricated/reinforced,
 /area/shiva/exterior/junkyard)
-"qsf" = (
-/obj/structure/surface/table,
-/obj/item/device/defibrillator/synthetic,
-/turf/open/floor/shiva/north,
-/area/shiva/interior/garage)
 "qsN" = (
 /obj/structure/machinery/light/double{
 	dir = 4;
@@ -46433,7 +46433,7 @@ qep
 arX
 ktd
 azg
-qsf
+aaM
 kjt
 ver
 ver

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -197,6 +197,11 @@
 /obj/effect/landmark/spycam_start,
 /turf/open/floor/shiva/floor3,
 /area/shiva/exterior/lz2_fortress)
+"aaM" = (
+/obj/structure/surface/table,
+/obj/item/device/defibrillator/synthetic,
+/turf/open/floor/shiva/north,
+/area/shiva/interior/garage)
 "aaN" = (
 /obj/item/weapon/gun/flamer/survivor,
 /obj/structure/surface/rack,
@@ -46428,7 +46433,7 @@ qep
 arX
 ktd
 azg
-kjt
+aaM
 kjt
 ver
 ver

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -197,11 +197,6 @@
 /obj/effect/landmark/spycam_start,
 /turf/open/floor/shiva/floor3,
 /area/shiva/exterior/lz2_fortress)
-"aaM" = (
-/obj/structure/surface/table,
-/obj/item/device/defibrillator/synthetic,
-/turf/open/floor/shiva/north,
-/area/shiva/interior/garage)
 "aaN" = (
 /obj/item/weapon/gun/flamer/survivor,
 /obj/structure/surface/rack,
@@ -46433,7 +46428,7 @@ qep
 arX
 ktd
 azg
-aaM
+kjt
 kjt
 ver
 ver

--- a/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
+++ b/maps/map_files/Ice_Colony_v3/Shivas_Snowball.dmm
@@ -18063,6 +18063,11 @@
 "qrY" = (
 /turf/closed/wall/shiva/prefabricated/reinforced,
 /area/shiva/exterior/junkyard)
+"qsf" = (
+/obj/structure/surface/table,
+/obj/item/device/defibrillator/synthetic,
+/turf/open/floor/shiva/north,
+/area/shiva/interior/garage)
 "qsN" = (
 /obj/structure/machinery/light/double{
 	dir = 4;
@@ -46428,7 +46433,7 @@ qep
 arX
 ktd
 azg
-kjt
+qsf
 kjt
 ver
 ver

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -8349,6 +8349,7 @@
 	pixel_x = -2;
 	pixel_y = 5
 	},
+/obj/item/device/defibrillator/synthetic,
 /turf/open/floor/kutjevo/multi_tiles/southeast,
 /area/kutjevo/interior/complex/med/locks)
 "mHJ" = (

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -5597,7 +5597,6 @@
 /area/kutjevo/interior/construction/north)
 "isV" = (
 /obj/structure/surface/rack,
-/obj/item/device/defibrillator/synthetic,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction/signal_tower)
 "itr" = (

--- a/maps/map_files/Kutjevo/Kutjevo.dmm
+++ b/maps/map_files/Kutjevo/Kutjevo.dmm
@@ -5597,6 +5597,7 @@
 /area/kutjevo/interior/construction/north)
 "isV" = (
 /obj/structure/surface/rack,
+/obj/item/device/defibrillator/synthetic,
 /turf/open/floor/plating/kutjevo,
 /area/kutjevo/interior/construction/signal_tower)
 "itr" = (

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -5314,7 +5314,8 @@
 /turf/open/floor/vault2,
 /area/lv624/lazarus/robotics)
 "aCn" = (
-/obj/structure/ore_box,
+/obj/item/device/defibrillator/synthetic,
+/obj/structure/surface/table,
 /turf/open/floor/plating/platebot,
 /area/lv624/lazarus/robotics)
 "aCo" = (

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -5314,7 +5314,8 @@
 /turf/open/floor/vault2,
 /area/lv624/lazarus/robotics)
 "aCn" = (
-/obj/structure/ore_box,
+/obj/structure/surface/table,
+/obj/item/device/defibrillator/synthetic,
 /turf/open/floor/plating/platebot,
 /area/lv624/lazarus/robotics)
 "aCo" = (

--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -5314,8 +5314,7 @@
 /turf/open/floor/vault2,
 /area/lv624/lazarus/robotics)
 "aCn" = (
-/obj/structure/surface/table,
-/obj/item/device/defibrillator/synthetic,
+/obj/structure/ore_box,
 /turf/open/floor/plating/platebot,
 /area/lv624/lazarus/robotics)
 "aCo" = (

--- a/maps/map_files/New_Varadero/New_Varadero.dmm
+++ b/maps/map_files/New_Varadero/New_Varadero.dmm
@@ -6409,6 +6409,7 @@
 /area/varadero/exterior/pontoon_beach)
 "faX" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
+/obj/item/device/defibrillator/synthetic,
 /turf/open/floor/shiva/yellow/north,
 /area/varadero/interior/electrical)
 "fbw" = (

--- a/maps/map_files/New_Varadero/New_Varadero.dmm
+++ b/maps/map_files/New_Varadero/New_Varadero.dmm
@@ -10926,7 +10926,6 @@
 	dir = 4
 	},
 /obj/structure/surface/table,
-/obj/item/device/defibrillator/synthetic,
 /turf/open/floor/shiva/multi_tiles,
 /area/varadero/interior/electrical)
 "iIL" = (

--- a/maps/map_files/New_Varadero/New_Varadero.dmm
+++ b/maps/map_files/New_Varadero/New_Varadero.dmm
@@ -10926,6 +10926,7 @@
 	dir = 4
 	},
 /obj/structure/surface/table,
+/obj/item/device/defibrillator/synthetic,
 /turf/open/floor/shiva/multi_tiles,
 /area/varadero/interior/electrical)
 "iIL" = (

--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -4438,7 +4438,6 @@
 /area/strata/ag/interior/outpost/engi)
 "auB" = (
 /obj/structure/surface/table/reinforced/prison,
-/obj/item/device/defibrillator/synthetic/hyperdyne,
 /turf/open/floor/strata/multi_tiles/southwest,
 /area/strata/ag/interior/outpost/engi)
 "auD" = (

--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -7443,6 +7443,7 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
+/obj/item/device/defibrillator/synthetic,
 /turf/open/floor/strata,
 /area/strata/ag/interior/outpost/engi)
 "aLH" = (

--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -4438,6 +4438,7 @@
 /area/strata/ag/interior/outpost/engi)
 "auB" = (
 /obj/structure/surface/table/reinforced/prison,
+/obj/item/device/defibrillator/synthetic/hyperdyne,
 /turf/open/floor/strata/multi_tiles/southwest,
 /area/strata/ag/interior/outpost/engi)
 "auD" = (

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -17646,10 +17646,6 @@
 /obj/item/weapon/pole/wooden_cane{
 	pixel_y = 3
 	},
-/obj/item/device/defibrillator/synthetic/noskill{
-	pixel_x = 2;
-	pixel_y = -3
-	},
 /turf/open/floor/almayer/plate,
 /area/almayer/medical/lower_medical_medbay)
 "bym" = (

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -17646,6 +17646,10 @@
 /obj/item/weapon/pole/wooden_cane{
 	pixel_y = 3
 	},
+/obj/item/device/defibrillator/synthetic{
+	pixel_y = -3;
+	pixel_x = 3
+	},
 /turf/open/floor/almayer/plate,
 /area/almayer/medical/lower_medical_medbay)
 "bym" = (

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -17646,6 +17646,10 @@
 /obj/item/weapon/pole/wooden_cane{
 	pixel_y = 3
 	},
+/obj/item/device/defibrillator/synthetic/noskill{
+	pixel_x = 2;
+	pixel_y = -3
+	},
 /turf/open/floor/almayer/plate,
 /area/almayer/medical/lower_medical_medbay)
 "bym" = (


### PR DESCRIPTION
# About the pull request

(take two) 
This PR adds synthetic reset keys to every groundmap currently in rotation, primarily located in engineering or engineering-adjacent areas, as well as in the synthetic repair bay thing (???) in the Almayer medical bay 

Additionally (I don't think it's worth mentioning in the PR title, but) a small tweak was made to Fiorina that adds a synthetic armor vest as well. I couldn't find anywhere better to put the key 

Also moved a stack of metal in Solaris' engineering complex I forget why but it's only like 5 tiles north so 
# Explain why it's good for the game

probably a better version of #9231

Shipside medical now has a less convoluted/annoying way of reviving synthetics (medical always handles them anyways) 
Survivors now also have the option to get a reset key if they go out of their way to. 

# Testing Photographs and Procedure

prayed for good fortune before PRing

# Changelog

:cl:
balance: Synthetic reset keys now spawn on all in-rotation groundmaps 
balance: A synthetic reset key starts in the Almayer's medical bay, in one of the backrooms 
maptweak: Fiorina Science Annex has 2% more powercreep (synthetic vest) 
/:cl:
