### PR TITLE
Acid runner acid visible on examine to xenos

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/runner/acid.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/runner/acid.dm
@@ -199,7 +199,7 @@
 	. = ..()
 	var/datum/behavior_delegate/runner_acider/behavior = behavior_delegate
 	if(istype(behavior) && isxeno(user))
-		. += "it has [behavior.acid_amount] acid!"
+		. += "it has [SPAN_GREEN(behavior.acid_amount)] acid!"
 
 /datum/behavior_delegate/runner_acider/proc/combat_gen_end() //This proc is triggerd once the combat acid timer runs out.
 	combat_gen_active = FALSE //turns combat acid off


### PR DESCRIPTION

# About the pull request

title
# Explain why it's good for the game

I think its a neat little addition that lets you see how close they are to boomin


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Xenos can now examine an acid runner to see how much acid they have.
/:cl:
