### PR TITLE
fixes combat android leader preset on the CL beacon

### DIFF
--- a/code/datums/emergency_calls/bodyguard.dm
+++ b/code/datums/emergency_calls/bodyguard.dm
@@ -86,7 +86,7 @@
 
 /datum/emergency_call/wy_bodyguard/android
 	equipment_preset = /datum/equipment_preset/pmc/w_y_whiteout/low_threat
-	equipment_preset = /datum/equipment_preset/pmc/w_y_whiteout/low_threat/leader
+	equipment_preset_leader = /datum/equipment_preset/pmc/w_y_whiteout/low_threat/leader
 	spawn_header = "You are a Weyland-Yutani Combat Android!"
 	spawn_header_leader = "You are a Weyland-Yutani Combat Android Leading Unit!"
 


### PR DESCRIPTION

# About the pull request

fixes a typo where the android on the CL beacon response' equipment preset was defined twice rather than having a leader preset defined

# Explain why it's good for the game

fixes a bug


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: combat android bodyguard beacon now spawns the leader android properly
/:cl:
