### PR TITLE
Shotguns can no longer mount the underbarrel flamer.

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -473,8 +473,6 @@ can cause issues with ammo types getting mixed up during the burst.
 		/obj/item/attachable/bayonet/upp,
 		/obj/item/attachable/verticalgrip, // Underbarrel
 		/obj/item/attachable/flashlight/grip,
-		/obj/item/attachable/attached_gun/flamer,
-		/obj/item/attachable/attached_gun/flamer/advanced,
 		/obj/item/attachable/attached_gun/extinguisher,
 		/obj/item/attachable/burstfire_assembly,
 		/obj/item/attachable/stock/type23, // Stock
@@ -1233,8 +1231,6 @@ can cause issues with ammo types getting mixed up during the burst.
 		/obj/item/attachable/shotgun_choke,
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/attached_gun/extinguisher,
-		/obj/item/attachable/attached_gun/flamer,
-		/obj/item/attachable/attached_gun/flamer/advanced,
 		/obj/item/attachable/stock/shotgun,
 	)
 	map_specific_decoration = TRUE
@@ -1456,8 +1452,6 @@ can cause issues with ammo types getting mixed up during the burst.
 		/obj/item/attachable/compensator,
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/attached_gun/extinguisher,
-		/obj/item/attachable/attached_gun/flamer,
-		/obj/item/attachable/attached_gun/flamer/advanced,
 	)
 
 	pixel_x = -5


### PR DESCRIPTION
# About the pull request

This PR removes the underbarrel flamer and it's advanced subtype from the allowed attachments list on shotguns.

# Explain why it's good for the game

- Shotguns and flamethrowers are both short range, high burst damage weapons largely balanced by the infrequency with which you can fire them. 

- Most skirmisher/backline castes can just about survive one hit from either, and have a chance to escape/fight back/etc.

- Combining the two burst damage weapons lead to effective instant kills in 1v1s where a caste like a warrior or lurker is meant to have heavy advantage, with no extra risk or requirement of much skill from the player using it.

- This undermines the purpose of those castes, and is un-fun for the players playing them.

# Changelog
:cl:
balance: underbarrel flamethrowers no longer fit onto shotguns.
/:cl: