### PR TITLE
trijent LZs now powerable

### DIFF
--- a/code/game/area/DesertDam.dm
+++ b/code/game/area/DesertDam.dm
@@ -691,6 +691,10 @@
 	linked_lz = DROPSHIP_LZ1
 	is_landing_zone = TRUE
 	minimap_color = MINIMAP_AREA_LZ
+	always_unpowered = FALSE
+	power_light = TRUE
+	power_equip = TRUE
+	power_environ = TRUE
 
 //Landing Pad for the Normandy. THIS IS NOT THE SHUTTLE AREA
 /area/desert_dam/exterior/landing_pad_two
@@ -699,6 +703,10 @@
 	linked_lz = DROPSHIP_LZ2
 	is_landing_zone = TRUE
 	minimap_color = MINIMAP_AREA_LZ
+	always_unpowered = FALSE
+	power_light = TRUE
+	power_equip = TRUE
+	power_environ = TRUE
 
 //Valleys
 //Near LZ

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -32483,6 +32483,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
 	},
+/obj/structure/machinery/power/apc/power/north,
 /turf/open/floor/plating,
 /area/desert_dam/exterior/landing_pad_two)
 "dax" = (
@@ -48796,6 +48797,10 @@
 /obj/effect/blocker/toxic_water/Group_2,
 /turf/open/desert/desert_shore/desert_shore1/west,
 /area/desert_dam/exterior/river/riverside_central_north)
+"upv" = (
+/obj/structure/machinery/power/apc/power/east,
+/turf/open/floor/plating,
+/area/desert_dam/exterior/landing_pad_one)
 "upP" = (
 /obj/effect/spawner/gibspawner/xeno,
 /turf/open/asphalt,
@@ -61971,7 +61976,7 @@ aVG
 wpr
 qlr
 mZb
-mZb
+upv
 mZb
 aPB
 aSx


### PR DESCRIPTION

# About the pull request

the LZs on trijent had UNPOWERABLE set to 1 which caused confusion as this was a departure from other maps where the expectation is that the marine FOB can be powered.

# Explain why it's good for the game

the marine FOB being able to be powered is standard, and is part of the incentive for controlling power generation as the marine faction, arbitrarily disallowing power from applying to this area is confusing.




# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
maptweak: trijent LZs can now be powered
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
