### PR TITLE
Adds Intel SL tracking and default tracking to XO/CO headsets

### DIFF
--- a/code/__DEFINES/mob_hud.dm
+++ b/code/__DEFINES/mob_hud.dm
@@ -70,6 +70,7 @@
 #define TRACKER_DSL "_dsl" // Delta Squad Leader
 #define TRACKER_ESL "_esl" // Echo Squad Leader
 #define TRACKER_FSL "_fsl" // Cryo Squad Leader
+#define TRACKER_ISL "_isl" // Intel Squad Leader
 
 //for tracking the queen/hivecore on xeno locator huds
 #define TRACKER_QUEEN "Queen"

--- a/code/game/machinery/vending/vendor_types/crew/commanding_officer.dm
+++ b/code/game/machinery/vending/vendor_types/crew/commanding_officer.dm
@@ -73,7 +73,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_commanding_officer, list(
 
 GLOBAL_LIST_INIT(cm_vending_clothing_commanding_officer, list(
 		list("STANDARD EQUIPMENT (TAKE ALL)", 0, null, null, null),
-		list("Headset", 0, /obj/item/device/radio/headset/almayer/mcom/cdrcom, MARINE_CAN_BUY_EAR, VENDOR_ITEM_MANDATORY),
+		list("Headset", 0, /obj/item/device/radio/headset/almayer/mcom/cdrcom/co, MARINE_CAN_BUY_EAR, VENDOR_ITEM_MANDATORY),
 		list("MRE", 0, /obj/item/storage/box/mre, MARINE_CAN_BUY_MRE, VENDOR_ITEM_MANDATORY),
 
 		list("COMMANDING OFFICER ESSENTIALS KIT (TAKE ALL)", 0, null, null, null),

--- a/code/game/machinery/vending/vendor_types/crew/senior_officers.dm
+++ b/code/game/machinery/vending/vendor_types/crew/senior_officers.dm
@@ -409,7 +409,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_xo, list(
 		list("Marine Combat Gloves", 0, /obj/item/clothing/gloves/marine, MARINE_CAN_BUY_GLOVES, VENDOR_ITEM_MANDATORY),
 
 		list("STANDARD EQUIPMENT (TAKE ALL)", 0, null, null, null),
-		list("Headset", 0, /obj/item/device/radio/headset/almayer/mcom/cdrcom, MARINE_CAN_BUY_EAR, VENDOR_ITEM_MANDATORY),
+		list("Headset", 0, /obj/item/device/radio/headset/almayer/mcom/cdrcom/xo, MARINE_CAN_BUY_EAR, VENDOR_ITEM_MANDATORY),
 		list("Satchel", 0, /obj/item/storage/backpack/satchel, MARINE_CAN_BUY_BACKPACK, VENDOR_ITEM_MANDATORY),
 		list("MRE", 0, /obj/item/storage/box/mre, MARINE_CAN_BUY_MRE, VENDOR_ITEM_MANDATORY),
 

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -478,6 +478,7 @@
 		"Delta SL" = TRACKER_DSL,
 		"Echo SL" = TRACKER_ESL,
 		"Foxtrot SL" = TRACKER_FSL,
+		"Intel SL" = TRACKER_ISL
 	)
 
 /obj/item/device/radio/headset/almayer/cmo
@@ -596,6 +597,21 @@
 	initial_keys = list(/obj/item/device/encryptionkey/mcom)
 	volume = RADIO_VOLUME_CRITICAL
 	multibroadcast_cooldown = LOW_MULTIBROADCAST_COOLDOWN
+	misc_tracking = TRUE
+	locate_setting = TRACKER_CO
+
+	inbuilt_tracking_options = list(
+		"Commanding Officer" = TRACKER_CO,
+		"Executive Officer" = TRACKER_XO,
+		"Landing Zone" = TRACKER_LZ,
+		"Alpha SL" = TRACKER_ASL,
+		"Bravo SL" = TRACKER_BSL,
+		"Charlie SL" = TRACKER_CSL,
+		"Delta SL" = TRACKER_DSL,
+		"Echo SL" = TRACKER_ESL,
+		"Foxtrot SL" = TRACKER_FSL,
+		"Intel SL" = TRACKER_ISL
+	)
 
 /obj/item/device/radio/headset/almayer/mcom/alt
 	initial_keys = list(/obj/item/device/encryptionkey/mcom/alt)
@@ -651,6 +667,36 @@
 	additional_hud_types = list(MOB_HUD_FACTION_WY, MOB_HUD_FACTION_CMB)
 	volume = RADIO_VOLUME_CRITICAL
 
+/obj/item/device/radio/headset/almayer/mcom/cdrcom/xo
+	locate_setting = TRACKER_CO
+
+	inbuilt_tracking_options = list(
+		"Commanding Officer" = TRACKER_CO,
+		"Landing Zone" = TRACKER_LZ,
+		"Alpha SL" = TRACKER_ASL,
+		"Bravo SL" = TRACKER_BSL,
+		"Charlie SL" = TRACKER_CSL,
+		"Delta SL" = TRACKER_DSL,
+		"Echo SL" = TRACKER_ESL,
+		"Foxtrot SL" = TRACKER_FSL,
+		"Intel SL" = TRACKER_ISL
+	)
+
+/obj/item/device/radio/headset/almayer/mcom/cdrcom/co
+	locate_setting = TRACKER_XO
+
+	inbuilt_tracking_options = list(
+		"Executive Officer" = TRACKER_XO,
+		"Landing Zone" = TRACKER_LZ,
+		"Alpha SL" = TRACKER_ASL,
+		"Bravo SL" = TRACKER_BSL,
+		"Charlie SL" = TRACKER_CSL,
+		"Delta SL" = TRACKER_DSL,
+		"Echo SL" = TRACKER_ESL,
+		"Foxtrot SL" = TRACKER_FSL,
+		"Intel SL" = TRACKER_ISL
+	)
+
 /obj/item/device/radio/headset/almayer/mcom/sea
 	name = "marine senior enlisted advisor headset"
 	desc = "Issued only to senior enlisted advisors. Channels are as follows: :v - marine command, :p - military police, :a - alpha squad, :b - bravo squad, :c - charlie squad, :d - delta squad, :n - engineering, :m - medbay, :u - requisitions, :j - JTAC,  :t - intel"
@@ -672,20 +718,6 @@
 	icon_state = "ms_headset"
 	initial_keys = list(/obj/item/device/encryptionkey/cmpcom/synth)
 	volume = RADIO_VOLUME_CRITICAL
-	misc_tracking = TRUE
-	locate_setting = TRACKER_CO
-
-	inbuilt_tracking_options = list(
-		"Commanding Officer" = TRACKER_CO,
-		"Executive Officer" = TRACKER_XO,
-		"Landing Zone" = TRACKER_LZ,
-		"Alpha SL" = TRACKER_ASL,
-		"Bravo SL" = TRACKER_BSL,
-		"Charlie SL" = TRACKER_CSL,
-		"Delta SL" = TRACKER_DSL,
-		"Echo SL" = TRACKER_ESL,
-		"Foxtrot SL" = TRACKER_FSL
-	)
 
 /obj/item/device/radio/headset/almayer/mcom/ai
 	initial_keys = list(/obj/item/device/encryptionkey/cmpcom/synth/ai)
@@ -724,7 +756,8 @@
 		"Charlie SL" = TRACKER_CSL,
 		"Delta SL" = TRACKER_DSL,
 		"Echo SL" = TRACKER_ESL,
-		"Foxtrot SL" = TRACKER_FSL
+		"Foxtrot SL" = TRACKER_FSL,
+		"Intel SL" = TRACKER_ISL
 	)
 
 /obj/item/device/radio/headset/almayer/marine/alpha/tl
@@ -766,7 +799,8 @@
 		"Charlie SL" = TRACKER_CSL,
 		"Delta SL" = TRACKER_DSL,
 		"Echo SL" = TRACKER_ESL,
-		"Foxtrot SL" = TRACKER_FSL
+		"Foxtrot SL" = TRACKER_FSL,
+		"Intel SL" = TRACKER_ISL
 	)
 
 /obj/item/device/radio/headset/almayer/marine/bravo/tl
@@ -808,7 +842,8 @@
 		"Bravo SL" = TRACKER_BSL,
 		"Delta SL" = TRACKER_DSL,
 		"Echo SL" = TRACKER_ESL,
-		"Foxtrot SL" = TRACKER_FSL
+		"Foxtrot SL" = TRACKER_FSL,
+		"Intel SL" = TRACKER_ISL
 	)
 
 /obj/item/device/radio/headset/almayer/marine/charlie/tl
@@ -850,7 +885,8 @@
 		"Bravo SL" = TRACKER_BSL,
 		"Charlie SL" = TRACKER_CSL,
 		"Echo SL" = TRACKER_ESL,
-		"Foxtrot SL" = TRACKER_FSL
+		"Foxtrot SL" = TRACKER_FSL,
+		"Intel SL" = TRACKER_ISL
 	)
 
 /obj/item/device/radio/headset/almayer/marine/delta/tl
@@ -892,7 +928,8 @@
 		"Bravo SL" = TRACKER_BSL,
 		"Charlie SL" = TRACKER_CSL,
 		"Delta SL" = TRACKER_DSL,
-		"Foxtrot SL" = TRACKER_FSL
+		"Foxtrot SL" = TRACKER_FSL,
+		"Intel SL" = TRACKER_ISL
 	)
 
 /obj/item/device/radio/headset/almayer/marine/echo/tl

--- a/code/modules/gear_presets/uscm_co.dm
+++ b/code/modules/gear_presets/uscm_co.dm
@@ -15,7 +15,7 @@
 
 
 	var/list/equipment_to_spawn = list(
-		WEAR_L_EAR = /obj/item/device/radio/headset/almayer/mcom/cdrcom,
+		WEAR_L_EAR = /obj/item/device/radio/headset/almayer/mcom/cdrcom/co,
 		WEAR_BODY = /obj/item/clothing/under/marine/officer/bridge,
 		WEAR_L_STORE = /obj/item/storage/pouch/pistol/command,
 		WEAR_R_STORE = /obj/item/storage/pouch/general/large,
@@ -83,7 +83,7 @@
 	for(var/equipment in equipment_to_spawn)
 		var/equipment_path = islist(equipment_to_spawn[equipment]) ? pick(equipment_to_spawn[equipment]) : equipment_to_spawn[equipment]
 		new_human.equip_to_slot_or_del(new equipment_path(new_human), equipment)
-	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/mcom/cdrcom(new_human), WEAR_L_EAR)
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/mcom/cdrcom/co(new_human), WEAR_L_EAR)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/officer/bridge(new_human), WEAR_BODY)
 	new_human.equip_to_slot_or_del(new back_item(new_human), WEAR_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/pistol/command(new_human), WEAR_L_STORE)
@@ -97,7 +97,7 @@
 	name = "Shipside - CO - Infantry"
 	equipment_to_spawn = list(
 		WEAR_HEAD = /obj/item/clothing/head/cmcap/req/ro,
-		WEAR_L_EAR = /obj/item/device/radio/headset/almayer/mcom/cdrcom,
+		WEAR_L_EAR = /obj/item/device/radio/headset/almayer/mcom/cdrcom/co,
 		WEAR_HANDS = /obj/item/clothing/gloves/black,
 		WEAR_FEET = /obj/item/clothing/shoes/marine/knife,
 		WEAR_L_HAND = /obj/item/device/binoculars/range/designator,
@@ -128,7 +128,7 @@
 	name = "Shipside - CO - Intel"
 	equipment_to_spawn = list(
 		WEAR_HEAD = /obj/item/clothing/head/beret/marine/commander/black,
-		WEAR_L_EAR = /obj/item/device/radio/headset/almayer/mcom/cdrcom,
+		WEAR_L_EAR = /obj/item/device/radio/headset/almayer/mcom/cdrcom/co,
 		WEAR_BODY = /obj/item/clothing/under/marine/officer/formal/turtleneck,
 		WEAR_FACE = /obj/item/clothing/mask/rebreather/scarf/tacticalmask/black,
 		WEAR_JACKET = /obj/item/clothing/suit/storage/utility_vest,
@@ -158,7 +158,7 @@
 	name = "Shipside - CO - Medical"
 	equipment_to_spawn = list(
 		WEAR_HEAD =	/obj/item/clothing/head/beret/marine/commander/dress,
-		WEAR_L_EAR = /obj/item/device/radio/headset/almayer/mcom/cdrcom,
+		WEAR_L_EAR = /obj/item/device/radio/headset/almayer/mcom/cdrcom/co,
 		WEAR_BODY = /obj/item/clothing/under/marine/officer/command,
 		WEAR_JACKET = /obj/item/clothing/suit/storage/jacket/marine/dress/officer/patchless,
 		WEAR_FEET = /obj/item/clothing/shoes/white,
@@ -186,7 +186,7 @@
 
 	name = "Shipside - CO - Aviation"
 	equipment_to_spawn = list(
-		WEAR_L_EAR = /obj/item/device/radio/headset/almayer/mcom/cdrcom,
+		WEAR_L_EAR = /obj/item/device/radio/headset/almayer/mcom/cdrcom/co,
 		WEAR_BODY = /obj/item/clothing/under/marine/officer/formal/turtleneck,
 		WEAR_L_STORE = /obj/item/storage/pouch/pistol/command,
 		WEAR_R_STORE = /obj/item/storage/pouch/general/large,
@@ -218,7 +218,7 @@
 
 	name = "Shipside - CO - Tanker"
 	equipment_to_spawn = list(
-		WEAR_L_EAR = /obj/item/device/radio/headset/almayer/mcom/cdrcom,
+		WEAR_L_EAR = /obj/item/device/radio/headset/almayer/mcom/cdrcom/co,
 		WEAR_L_STORE = /obj/item/storage/pouch/pistol/command,
 		WEAR_R_STORE = /obj/item/storage/pouch/general/large,
 		WEAR_FEET =	/obj/item/clothing/shoes/marine/knife,
@@ -251,7 +251,7 @@
 
 	name = "Shipside - CO - Engineering"
 	equipment_to_spawn = list(
-		WEAR_L_EAR = /obj/item/device/radio/headset/almayer/mcom/cdrcom,
+		WEAR_L_EAR = /obj/item/device/radio/headset/almayer/mcom/cdrcom/co,
 		WEAR_L_STORE = /obj/item/storage/pouch/pistol/command,
 		WEAR_R_STORE = /obj/item/storage/pouch/general/large,
 		WEAR_FEET =	/obj/item/clothing/shoes/marine/knife,
@@ -281,7 +281,7 @@
 /datum/equipment_preset/uscm_co/logistics
 	name = "Shipside - CO - Logistics"
 	equipment_to_spawn = list(
-		WEAR_L_EAR = /obj/item/device/radio/headset/almayer/mcom/cdrcom,
+		WEAR_L_EAR = /obj/item/device/radio/headset/almayer/mcom/cdrcom/co,
 		WEAR_L_STORE = /obj/item/storage/pouch/pistol/command,
 		WEAR_R_STORE = /obj/item/storage/pouch/general/large,
 		WEAR_FEET =	/obj/item/clothing/shoes/marine/knife,

--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -388,7 +388,7 @@
 	if (new_human.client && new_human.client.prefs && (new_human.client.prefs.backbag == 1))
 		back_item = /obj/item/storage/backpack/marine
 
-	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/mcom/cdrcom(new_human), WEAR_L_EAR)
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/mcom/cdrcom/xo(new_human), WEAR_L_EAR)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/officer/bridge(new_human), WEAR_BODY)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/jacket/marine/service(new_human), WEAR_JACKET)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/dress(new_human), WEAR_FEET)

--- a/code/modules/gear_presets/wo.dm
+++ b/code/modules/gear_presets/wo.dm
@@ -72,7 +72,7 @@
 		new_human.equip_to_slot_or_del(new kit(new_human), WEAR_IN_BACK)
 	//head
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/beret/cm(new_human), WEAR_HEAD)
-	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/mcom/cdrcom(new_human), WEAR_L_EAR)
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/mcom/cdrcom/co(new_human), WEAR_L_EAR)
 	//uniform
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/officer/command(new_human), WEAR_BODY)
 	//jacket
@@ -120,7 +120,7 @@
 	new_human.equip_to_slot_or_del(new back_item(new_human), WEAR_BACK)
 	//head
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/cmcap(new_human), WEAR_HEAD)
-	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/mcom/cdrcom(new_human), WEAR_L_EAR)
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/mcom/cdrcom/xo(new_human), WEAR_L_EAR)
 	//uniform
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/officer/bridge(new_human), WEAR_BODY)
 	//jacket

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1266,7 +1266,8 @@
 		TRACKER_CSL = /datum/squad/marine/charlie,
 		TRACKER_DSL = /datum/squad/marine/delta,
 		TRACKER_ESL = /datum/squad/marine/echo,
-		TRACKER_FSL = /datum/squad/marine/cryo
+		TRACKER_FSL = /datum/squad/marine/cryo,
+		TRACKER_ISL = /datum/squad/marine/intel
 	)
 	switch(tracker_setting)
 		if(TRACKER_SL)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

As title

# Explain why it's good for the game

It's nice to be able to track the Intel SL, and it makes no sense that the command headsets can't track anyone.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Added tracking to command headsets.
add: Added a tracker for Intel Squad Lead.
add: Added XO and CO subtypes for the senior command headset. This has no identifying features aside from different tracking options.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
