### PR TITLE
fixes an attachment bug

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -2501,6 +2501,7 @@ Defined in conflicts.dm of the #defines folder.
 		icon_state = initial(icon_state)
 		UnregisterSignal(G, COMSIG_GUN_RECALCULATE_ATTACHMENT_BONUSES)
 		G.recalculate_attachment_bonuses()
+		G.last_fired = world.time
 	else if(!turn_off)
 		if(user)
 			to_chat(user, SPAN_NOTICE("You are now using [src]."))
@@ -2509,6 +2510,7 @@ Defined in conflicts.dm of the #defines folder.
 		G.damage_mult = 1
 		RegisterSignal(G, COMSIG_GUN_RECALCULATE_ATTACHMENT_BONUSES, PROC_REF(reset_damage_mult))
 		icon_state += "-on"
+		G.last_fired = world.time
 
 	SEND_SIGNAL(G, COMSIG_GUN_INTERRUPT_FIRE)
 


### PR DESCRIPTION


# About the pull request

fixes swapping to an underbarrel attachment resetting a weapon's fire cd by effectively telling the gun it has "fired" whenever the swap happens and starting a new CD

# Explain why it's good for the game

not a very elegant solution but I hate it less than removing items because they have a bug I haven't been able to track down

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>


pinky promise I tested it for a couple minutes in local.

</details>


# Changelog

:cl:
fix:attached guns no longer cause gun fire delay issues
/:cl:

