### PR TITLE
The yearly gau rework

### DIFF
--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -158,7 +158,7 @@
 	fire_mission_delay = 2
 	var/bullet_spread_range = 4 //how far from the real impact turf can bullets land
 	var/shrapnel_type = /datum/ammo/bullet/shrapnel/gau //For siming 30mm bullet impacts.
-	var/directhit_damage = 90 //how much damage is to be inflicted to a mob, this is here so that we can hit resting mobs.
+	var/directhit_damage = 75 //how much damage is to be inflicted to a mob, this is here so that we can hit resting mobs.
 	var/penetration = 10 //AP value pretty much
 
 /obj/structure/ship_ammo/heavygun/get_examine_text(mob/user)
@@ -214,7 +214,7 @@
 	point_cost = 325
 	fire_mission_delay = 2
 	shrapnel_type = /datum/ammo/bullet/shrapnel/gau/at
-	directhit_damage = 60 //how much damage is to be inflicted to a mob, this is here so that we can hit resting mobs.
+	directhit_damage = 55 //how much damage is to be inflicted to a mob, this is here so that we can hit resting mobs.
 	penetration = 40 //AP value pretty much
 
 //laser battery

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -214,7 +214,7 @@
 	point_cost = 325
 	fire_mission_delay = 2
 	shrapnel_type = /datum/ammo/bullet/shrapnel/gau/at
-	directhit_damage = 55 //how much damage is to be inflicted to a mob, this is here so that we can hit resting mobs.
+	directhit_damage = 50 //how much damage is to be inflicted to a mob, this is here so that we can hit resting mobs.
 	penetration = 40 //AP value pretty much
 
 //laser battery

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -156,9 +156,9 @@
 	ammo_used_per_firing = 40
 	point_cost = 275
 	fire_mission_delay = 2
-	var/bullet_spread_range = 3 //how far from the real impact turf can bullets land
+	var/bullet_spread_range = 4 //how far from the real impact turf can bullets land
 	var/shrapnel_type = /datum/ammo/bullet/shrapnel/gau //For siming 30mm bullet impacts.
-	var/directhit_damage = 105 //how much damage is to be inflicted to a mob, this is here so that we can hit resting mobs.
+	var/directhit_damage = 90 //how much damage is to be inflicted to a mob, this is here so that we can hit resting mobs.
 	var/penetration = 10 //AP value pretty much
 
 /obj/structure/ship_ammo/heavygun/get_examine_text(mob/user)
@@ -179,26 +179,25 @@
 
 	for(var/i = 1 to ammo_used_per_firing)
 		sleep(1)
-		var/turf/impact_tile = pick(turf_list)
-		var/datum/cause_data/cause_data = create_cause_data(fired_from.name, source_mob)
-		impact_tile.ex_act(EXPLOSION_THRESHOLD_VLOW, pick(GLOB.alldirs), cause_data)
-		create_shrapnel(impact_tile,1,0,0,shrapnel_type,cause_data,FALSE,100) //simulates a bullet
-		for(var/atom/movable/explosion_effect in impact_tile)
-			if(iscarbon(explosion_effect))
-				var/mob/living/carbon/bullet_effect = explosion_effect
-				explosion_effect.ex_act(EXPLOSION_THRESHOLD_VLOW, null, cause_data)
-				bullet_effect.apply_armoured_damage(directhit_damage,ARMOR_BULLET,BRUTE,null,penetration)
-			else
-				explosion_effect.ex_act(EXPLOSION_THRESHOLD_VLOW)
-		new /obj/effect/particle_effect/expl_particles(impact_tile)
-		if(!soundplaycooldown) //so we don't play the same sound 20 times very fast.
-			playsound(impact_tile, 'sound/effects/gauimpact.ogg',40,1,20)
-			soundplaycooldown = 3
-		soundplaycooldown--
-		if(!debriscooldown)
-			impact_tile.ceiling_debris_check(1)
-			debriscooldown = 6
-		debriscooldown--
+		for(var/j in 1 to 3)
+			var/turf/impact_tile = pick(turf_list)
+			var/datum/cause_data/cause_data = create_cause_data(fired_from.name, source_mob)
+			create_shrapnel(impact_tile,1,0,0,shrapnel_type,cause_data,FALSE,100) //simulates a bullet
+			for(var/atom/movable/explosion_effect in impact_tile)
+				if(iscarbon(explosion_effect))
+					var/mob/living/carbon/bullet_effect = explosion_effect
+					bullet_effect.apply_armoured_damage(directhit_damage,ARMOR_BULLET,BRUTE,null,penetration, def_zone = rand_zone() )
+				else
+					explosion_effect.ex_act(EXPLOSION_THRESHOLD_VLOW)
+			new /obj/effect/particle_effect/expl_particles(impact_tile)
+			if(!soundplaycooldown) //so we don't play the same sound 20 times very fast.
+				playsound(impact_tile, 'sound/effects/gauimpact.ogg',40,1,20)
+				soundplaycooldown = 3
+			soundplaycooldown--
+			if(!debriscooldown)
+				impact_tile.ceiling_debris_check(1)
+				debriscooldown = 6
+			debriscooldown--
 	sleep(11) //speed of sound simulation
 	playsound(impact, 'sound/effects/gau.ogg',100,1,60)
 
@@ -215,7 +214,7 @@
 	point_cost = 325
 	fire_mission_delay = 2
 	shrapnel_type = /datum/ammo/bullet/shrapnel/gau/at
-	directhit_damage = 80 //how much damage is to be inflicted to a mob, this is here so that we can hit resting mobs.
+	directhit_damage = 60 //how much damage is to be inflicted to a mob, this is here so that we can hit resting mobs.
 	penetration = 40 //AP value pretty much
 
 //laser battery


### PR DESCRIPTION
# About the pull request

Another GAU rework trying to learn from the last two and make the GAU stand out more. The GAU either struggles with being absolute dogshit or uber OP when you use 4 of them, this PR attempts to make it better when used with other weaponry rather then just 4 gau. The main issue with 2 bullet per tick was the stunlock, as GAU causes explosions and in such huge amount xenos had no chance to awoid them, the current 1 bulelt per tick suffers from the rng and lack of its is scores on any target in the area as you can stand still and the chance of being harmed is quite low. This PR removes the explosions, pmps up the firerate to 3 bullets per tick with increased area again, and reduces bullet damage. This makes it a lot less (if at all) effective at wall removal, removes the stunlock problem as it causes no stun and thus justifies its high DPS by the lack of stun to keep targets in the area long enough for it to matter, kinda turning it somewhat in brute damage laser in a way. The resoult of this should be that you either use minirockets/missiles to stun enemies to stay in the AOE, use lasers/other fire weaponry alongside so that enemies take damage even after they leave the area or spread out the FM/ force enemies into positions when they can not leave it.

The current values are that each bursts hits 81 tiles with 40 3 round bursts, during 4 seconds, normal ammo 75 damage ap 50 damage per hit. This makes it 111 dmg to every tile per burst making it 28 dps over 4 seconds, per burst, 74 dmg to tile per ap burst. if you long FM firing the GAU you can have 3 gau bursts hitting the central tiles, aka 333 damage, over span of about 8 seconds with no stun of its own. (looking at the numbers it starts to feel subpar, but lot less rng then current GAU and no stunlock as the previous one) numbers up for testing and change

# Explain why it's good for the game

Readds some weaponry options to cas as GAU is noobtrap right now while trying to not turn it into just full load pick to win. The explosion removal resoulting with near zero effect to walls should also make it less frustrating then if it deleted four screens of walls

It should allow for some viable loudouts like two GAU firing in the middle with minirockets on sides for stun, or lasers on side to make running out also risky, gau in center with 3 lasers hitting at the gau and both sides of it too, similar with minirockets instead of lasers, you can technicly still run 4 gau, but you have to fire good FMs to force the enemy to stay in the impact zone for it to kill them. (missiels are not used in FMs that much due to their extreamy bad price performance ratio) 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: GAU rework, 3 bullets per tick, reduces direct damage, removes explosions, increases spread
/:cl:
