### PR TITLE
Dogtags on crosses will always appear at end of round, even if cross is later destroyed

### DIFF
--- a/code/game/objects/structures/props.dm
+++ b/code/game/objects/structures/props.dm
@@ -988,7 +988,6 @@
 		new_info_tag.fallen_names = list(dogtag_name)
 		new_info_tag.fallen_assgns = list(dogtag_assign)
 		new_info_tag.fallen_blood_types = list(dogtag_blood)
-		GLOB.fallen_list_cross -= dogtag_name
 	return ..()
 
 /obj/structure/prop/wooden_cross/attackby(obj/item/W, mob/living/user)
@@ -1000,7 +999,8 @@
 			dogtag_name = popleft(dog.fallen_names)
 			dogtag_assign = popleft(dog.fallen_assgns)
 			dogtag_blood = popleft(dog.fallen_blood_types)
-			GLOB.fallen_list_cross += dogtag_name
+			if(!(dogtag_name in GLOB.fallen_list_cross))
+				GLOB.fallen_list_cross += dogtag_name
 			update_icon()
 			if(!length(dog.fallen_names))
 				qdel(dog)


### PR DESCRIPTION
# About the pull request

Adding a dogtag to a wooden cross will now always result in the name being shown in the end of round memoriam name list, even if a particularly evil xeno decides to completely destroy the cross.

# Explain why it's good for the game

Going through the effort of extracting dogtags from perma marines and displaying them in a little graveyard is good. Xenos coming along to trample over the crosses and aciding everything, that's mean but xenos can do that.

All this PR does is make it so that the effort spent collecting dogtags will show up at the end of the round in the form of the fallen name list for everyone to see.


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: KornFlaks
add: Dogtags added to crosses will now always display the fallen marine's name at end of round memoriam, even if the cross is later destroyed.
/:cl:
