### PR TITLE
Add missing label to CMO timelocks

### DIFF
--- a/code/game/jobs/job/civilians/civilian.dm
+++ b/code/game/jobs/job/civilians/civilian.dm
@@ -15,6 +15,9 @@
 	. = ..()
 	src.roles = JOB_DOCTOR_ROLES_LIST
 
+/datum/timelock/research
+	name = "Research Roles"
+
 /datum/timelock/research/New(name, time_required, list/roles)
 	. = ..()
 	src.roles = JOB_RESEARCH_ROLES_LIST


### PR DESCRIPTION
# About the pull request

Fixes issue reported in gameplay-help channel where one of the timelocks for CMO is blank, Researcher.

# Explain why it's good for the game

New players having to figure out which roles count on their own.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

After:
![image](https://github.com/user-attachments/assets/67d886ee-20e9-4456-b51a-cc5228c140f7)


</details>


# Changelog

:cl:
fix: Add "Research Roles" label to timelocks
/:cl:
