### PR TITLE
Removes burst from the custom m4ra

### DIFF
--- a/code/modules/projectiles/guns/specialist/scout.dm
+++ b/code/modules/projectiles/guns/specialist/scout.dm
@@ -86,11 +86,9 @@
 /obj/item/weapon/gun/rifle/m4ra_custom/set_gun_config_values()
 	..()
 	set_fire_delay(FIRE_DELAY_TIER_6)
-	set_burst_amount(BURST_AMOUNT_TIER_2)
-	set_burst_delay(FIRE_DELAY_TIER_12)
+	set_burst_amount(0)
 	accuracy_mult = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_2
 	scatter = SCATTER_AMOUNT_TIER_8
-	burst_scatter_mult = SCATTER_AMOUNT_TIER_8
 	damage_mult = BASE_BULLET_DAMAGE_MULT + BULLET_DAMAGE_MULT_TIER_2
 	recoil = RECOIL_AMOUNT_TIER_5
 	damage_falloff_mult = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Title

# Explain why it's good for the game

Scout is too strong, i dont think theres any other way to nerf scout in a way that doesnt completetly gut its usefulness, i believe that scould should win in one v ones yes, but with burst i believe its made too easy and basically impossible to counter unless the scout sucks.

I believe this change will not affect lower skill players, i think they are still going to just hive dive and get captured.

For the higher to mid level skill players (which, lets be honest, you dont need to be good as a scout player to get kills anyway) this just means they'll have to pick battles more carefully.

Now, before any obviously marine one sider player with below 75 hours comments on the pr

1.) Scouts strongest power is the ability to pick its fights, you have nvgs, binoculars and a cloak. This means you can engage and disengage in most circumstances, this just means you're going to have to pick your fights better instead of just decloaking offs screen and then immidietly nuke any tier 2 / 1 thats resting.

2.) This affects more then just the incin / high impact combo, the HV rounds for scout are pretty strong in themselves, having all the ap and damage that they have, albeit less then high impact they are still pretty good at nuking any tier 3 or even the Queen,  and yes just because only a few people know about this, does make it nerf worthy, something being rare does not justify it being overpowered.

3.) "But scout is a specialist, shouldnt he have an easy time killing tier 2's and ones." Yes, he should however again, burst fire makes this that basically literally the moment you catch something overextending, it means it dies. This pr will make it so it takes a bit longer to kill things, but if youre competent (able to fire at an enemy standing infront of you) nothing will really change, other then at most giving the lurker ONE chance to pounce away, if they can even react, also no other specialist can as easily and as reliably one v one or even one v three xenos as scout.

4.) "But you already nerfed ammo, hecking xenomorph dev why do you keep nerfing my fricking underdog marine faction" I think if this change is properly test merged, ammo per req buy and spawn can be increased again to compensate for the fact that you'll be spending more ammo per each encounter.

5.) "So if youre just going to give it more ammo what is the point in making it fire less" Because xenomorphs believe it or not are supposed to have hand holding, killing one tier two might not have an immidediate effect, but when people who are DECENT can perform very well and get up to 10-15 kills per each time they pick it, its going to have a big effect on the game in longer terms. This just basically means they have a fraction of a second to fight you off or atleast, try to get away. Yes its a team game, but remember its one xenomorph to 3 marines, not one spec vs 3 xenomorphs, refer to my previous point about scouts power.
One man being able to clear the entire backline basically means in most maps that IO's can pretty easily get all the intel they want to get. This will even maybe let scout players hang with IO's hurray teamwork

6.) I think there are some buffs scout could use that makes it less of a "kill everyone in the backline" and more of a "scout", i will consider them post this pr if it does get in.

7.) dont make comments in the pr use the forums for feedback i dont care

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/4b6dfabc-33d8-4c82-8b55-2488e37995ff)
job application cv

</details>


# Changelog


:cl:
balance: Scout rifle no longer has burst fire.
/:cl: