### PR TITLE
Guarantees a fog gap on LV-624

### DIFF
--- a/code/game/objects/items/ore.dm
+++ b/code/game/objects/items/ore.dm
@@ -7,6 +7,8 @@
 
 /obj/item/ore/uranium
 	name = "pitchblende"
+	desc = "An ore containing Uranium. Just looking at it makes your head feel fuzzy... it's slightly luminescent."
+	desc_lore = "Colonies all over the Neroid Sector mine extensively for pitchblende - uranium ore. It finds use in outdated fusion reactors, nuclear weapons, and more commonly armor-piercing munitions. A W-Y funded reserach team determined that radiation poisoning from using these munitions is 'negligible'."
 	icon_state = "Uranium ore"
 
 	oretag = "uranium"
@@ -69,7 +71,7 @@
 
 /obj/item/ore/slag
 	name = "Slag"
-	desc = "Completely useless"
+	desc = "Completely useless."
 	icon_state = "slag"
 	oretag = "slag"
 	black_market_value = 0

--- a/code/game/objects/items/ore.dm
+++ b/code/game/objects/items/ore.dm
@@ -8,7 +8,7 @@
 /obj/item/ore/uranium
 	name = "pitchblende"
 	desc = "An ore containing Uranium. Just looking at it makes your head feel fuzzy... it's slightly luminescent."
-	desc_lore = "Colonies all over the Neroid Sector mine extensively for pitchblende - uranium ore. It finds use in outdated fusion reactors, nuclear weapons, and more commonly armor-piercing munitions. A W-Y funded reserach team determined that radiation poisoning from using these munitions is 'negligible'."
+	desc_lore = "Colonies all over the Neroid Sector mine extensively for pitchblende - uranium ore. It finds use in outdated fusion reactors, nuclear weapons, and more commonly armor-piercing munitions. A W-Y funded research team determined that radiation poisoning from using these munitions is 'negligible'."
 	icon_state = "Uranium ore"
 
 	oretag = "uranium"

--- a/code/game/objects/items/ore.dm
+++ b/code/game/objects/items/ore.dm
@@ -8,7 +8,7 @@
 /obj/item/ore/uranium
 	name = "pitchblende"
 	desc = "An ore containing Uranium. Just looking at it makes your head feel fuzzy... it's slightly luminescent."
-	desc_lore = "Colonies all over the Neroid Sector mine extensively for pitchblende - uranium ore. It finds use in outdated fusion reactors, nuclear weapons, and more commonly armor-piercing munitions. A W-Y funded research team determined that radiation poisoning from using these munitions is 'negligible'."
+	desc_lore = "Colonies all over the Neroid Sector mine extensively for pitchblende - uranium ore. It finds use in outdated fission reactors, nuclear weapons, and more commonly armor-piercing munitions. A W-Y funded research team determined that radiation poisoning from using these munitions is 'negligible'."
 	icon_state = "Uranium ore"
 
 	oretag = "uranium"

--- a/maps/Nightmare/maps/LV624/nightmare.json
+++ b/maps/Nightmare/maps/LV624/nightmare.json
@@ -23,7 +23,7 @@
 	{
 		"type": "map_insert",
 		"landmark": "lv-leftsidepass",
-		"chance": 0.7,
+		"chance": 1.0,
 		"path": "standalone/leftsidepass.dmm",
 		"when": { "mainpath": "left" }
 	},
@@ -32,13 +32,13 @@
 		"choices": [
 			{ "type": "map_insert", "landmark": "lv-bridge-nofog", "path": "standalone/lv-bridge-nofog.dmm" },
 			{ "type": "map_insert", "landmark": "lv-bridge-east",  "path": "standalone/lv-bridge-east.dmm"  }
-		], "chance": 0.6,
+		], "chance": 1.0,
 		"when": { "mainpath": "bridge" }
 	},
 	{
 		"type": "map_insert",
 		"landmark": "lv-rightsidepass",
-		"chance": 0.7,
+		"chance": 1.0,
 		"path": "standalone/rightsidepass.dmm",
 		"when": { "mainpath": "right" }
 	},

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -19330,6 +19330,7 @@
 	dir = 4
 	},
 /obj/item/ore/uranium{
+	
 	},
 /turf/open/floor/plating/platingdmg3/west,
 /area/bigredv2/caves/mining)
@@ -35027,6 +35028,7 @@
 	pixel_y = 15
 	},
 /obj/item/ore/uranium{
+	
 	},
 /turf/open/mars_cave/mars_cave_14,
 /area/bigredv2/caves/mining)
@@ -38931,6 +38933,7 @@
 	pixel_y = 9
 	},
 /obj/item/ore/uranium{
+	
 	},
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -19330,7 +19330,6 @@
 	dir = 4
 	},
 /obj/item/ore/uranium{
-	desc = "You feel fuzzy just looking at it.... it's slightly lumanesant"
 	},
 /turf/open/floor/plating/platingdmg3/west,
 /area/bigredv2/caves/mining)
@@ -34974,7 +34973,6 @@
 "tQo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ore/uranium{
-	desc = "You feel fuzzy just looking at it.... it's slightly lumanesant";
 	pixel_x = -7;
 	pixel_y = 4
 	},
@@ -35021,17 +35019,14 @@
 /area/bigredv2/outside/c)
 "tRV" = (
 /obj/item/ore/uranium{
-	desc = "You feel fuzzy just looking at it.... it's slightly lumanesant";
 	pixel_x = -8;
 	pixel_y = 9
 	},
 /obj/item/ore/uranium{
-	desc = "You feel fuzzy just looking at it.... it's slightly lumanesant";
 	pixel_x = 4;
 	pixel_y = 15
 	},
 /obj/item/ore/uranium{
-	desc = "You feel fuzzy just looking at it.... it's slightly lumanesant"
 	},
 /turf/open/mars_cave/mars_cave_14,
 /area/bigredv2/caves/mining)
@@ -38928,17 +38923,14 @@
 /area/bigredv2/caves/lambda/research)
 "xWr" = (
 /obj/item/ore/uranium{
-	desc = "You feel fuzzy just looking at it.... it's slightly lumanesant";
 	pixel_x = 4;
 	pixel_y = 15
 	},
 /obj/item/ore/uranium{
-	desc = "You feel fuzzy just looking at it.... it's slightly lumanesant";
 	pixel_x = -8;
 	pixel_y = 9
 	},
 /obj/item/ore/uranium{
-	desc = "You feel fuzzy just looking at it.... it's slightly lumanesant"
 	},
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)

--- a/maps/map_files/BigRed/standalone/clfmining.dmm
+++ b/maps/map_files/BigRed/standalone/clfmining.dmm
@@ -2755,17 +2755,14 @@
 /area/bigredv2/caves/mining)
 "QZ" = (
 /obj/item/ore/uranium{
-	desc = "You feel fuzzy just looking at it.... it's slightly lumanesant";
 	pixel_x = 4;
 	pixel_y = 15
 	},
 /obj/item/ore/uranium{
-	desc = "You feel fuzzy just looking at it.... it's slightly lumanesant";
 	pixel_x = -8;
 	pixel_y = 9
 	},
 /obj/item/ore/uranium{
-	desc = "You feel fuzzy just looking at it.... it's slightly lumanesant"
 	},
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
@@ -2821,7 +2818,6 @@
 	dir = 4
 	},
 /obj/item/ore/uranium{
-	desc = "You feel fuzzy just looking at it.... it's slightly lumanesant"
 	},
 /turf/open/floor/plating/platingdmg3/west,
 /area/bigredv2/caves/mining)

--- a/maps/map_files/BigRed/standalone/clfmining.dmm
+++ b/maps/map_files/BigRed/standalone/clfmining.dmm
@@ -2763,6 +2763,7 @@
 	pixel_y = 9
 	},
 /obj/item/ore/uranium{
+	
 	},
 /turf/open/floor/plating,
 /area/bigredv2/caves/mining)
@@ -2818,6 +2819,7 @@
 	dir = 4
 	},
 /obj/item/ore/uranium{
+	
 	},
 /turf/open/floor/plating/platingdmg3/west,
 /area/bigredv2/caves/mining)


### PR DESCRIPTION
# About the pull request

Ensures that one fog gap will always be generated on LV.

# Explain why it's good for the game

As it stands, many people think that fog on LV is a relic and should be removed entirely. Furthermore, fog gaps (usually) lead to somewhat interesting close-quarters combat more often than not. This shouldn't lead to the same issues encountered in #4997 as it is still much more difficult to push through this gap than to just let the fog go down, as observed in rounds currently.

Additionally, removing the fog gap will give survivors access to the rest of the map, allowing them to get to the armory and crashed ship which otherwise seem quite pointless on an already weapon-scarce and extremely small map. Hopefully this will discourage and make drone rushing somewhat more difficult and allowing access to some (risky) loot with similar parity to other maps.

This may lead to unintended consequences of a new meta for the CLF crashed ship insert despite the benefits given to their hold anyway, but can be observed over a long time period and potentially always have no gap instead (meta-able? problem for later). The RNG isn't fun as it stands now anyway.

# Testing Photographs and Procedure
I tested it and I think it works, code should be pretty obvious. I don't think that recording a single or even a few rounds would prove that it does anyway.

<details>
<summary>Screenshots & Videos</summary>
nil

</details>


# Changelog
:cl:
maptweak: LV-624 will now always generate a fog gap.
/:cl:
