### PR TITLE
Guarantees a fog gap on LV-624

### DIFF
--- a/maps/Nightmare/maps/LV624/nightmare.json
+++ b/maps/Nightmare/maps/LV624/nightmare.json
@@ -23,7 +23,7 @@
 	{
 		"type": "map_insert",
 		"landmark": "lv-leftsidepass",
-		"chance": 0.7,
+		"chance": 1.0,
 		"path": "standalone/leftsidepass.dmm",
 		"when": { "mainpath": "left" }
 	},
@@ -32,13 +32,13 @@
 		"choices": [
 			{ "type": "map_insert", "landmark": "lv-bridge-nofog", "path": "standalone/lv-bridge-nofog.dmm" },
 			{ "type": "map_insert", "landmark": "lv-bridge-east",  "path": "standalone/lv-bridge-east.dmm"  }
-		], "chance": 0.6,
+		], "chance": 1.0,
 		"when": { "mainpath": "bridge" }
 	},
 	{
 		"type": "map_insert",
 		"landmark": "lv-rightsidepass",
-		"chance": 0.7,
+		"chance": 1.0,
 		"path": "standalone/rightsidepass.dmm",
 		"when": { "mainpath": "right" }
 	},


### PR DESCRIPTION
# About the pull request

Ensures that one fog gap will always be generated on LV.

# Explain why it's good for the game

As it stands, many people think that fog on LV is a relic and should be removed entirely. Furthermore, fog gaps (usually) lead to somewhat interesting close-quarters combat more often than not. This shouldn't lead to the same issues encountered in #4997 as it is still much more difficult to push through this gap than to just let the fog go down, as observed in rounds currently.

Additionally, removing the fog gap will give survivors access to the rest of the map, allowing them to get to the armory and crashed ship which otherwise seem quite pointless on an already weapon-scarce and extremely small map. Hopefully this will discourage and make drone rushing somewhat more difficult and allowing access to some (risky) loot with similar parity to other maps.

This may lead to unintended consequences of a new meta for the CLF crashed ship insert despite the benefits given to their hold anyway, but can be observed over a long time period and potentially always have no gap instead (meta-able? problem for later). The RNG isn't fun as it stands now anyway.

# Testing Photographs and Procedure
I tested it and I think it works, code should be pretty obvious. I don't think that recording a single or even a few rounds would prove that it does anyway.

<details>
<summary>Screenshots & Videos</summary>
nil

</details>


# Changelog
:cl:
maptweak: LV-624 will now always generate a fog gap.
/:cl:
