### PR TITLE
rail flashlights and uscm headset counts as a helmet accessory 

### DIFF
--- a/code/modules/clothing/head/head.dm
+++ b/code/modules/clothing/head/head.dm
@@ -383,6 +383,7 @@
 		WEAR_HEAD = 'icons/mob/humans/onmob/clothing/head/hats_by_faction/UA.dmi',
 		WEAR_AS_GARB = 'icons/mob/humans/onmob/clothing/helmet_garb/misc.dmi',
 	)
+	flags_obj = OBJ_IS_HELMET_GARB
 
 GLOBAL_LIST_INIT(allowed_hat_items, list(
 	/obj/item/storage/fancy/cigarettes/emeraldgreen = PREFIX_HAT_GARB_OVERRIDE,

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -702,6 +702,7 @@ Defined in conflicts.dm of the #defines folder.
 	light_mod = 5
 	slot = "rail"
 	matter = list("metal" = 50,"glass" = 20)
+	flags_obj = OBJ_IS_HELMET_GARB
 	flags_attach_features = ATTACH_REMOVABLE|ATTACH_ACTIVATION
 	attachment_action_type = /datum/action/item_action/toggle
 	activation_sound = 'sound/handling/light_on_1.ogg'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
rail flashlights and uscm headset counts as a helmet accessory now


# Explain why it's good for the game

fluff, rail flashlight has 1 tile of light, uscm headset does nothing afaik



# Testing Photographs and Procedure
STILL HAVE TO TEST IT DNM


# Changelog

:cl: stalkerino
add: makes it so uscm headset (cosmetic) and the rail flashlight counts as a helmet accessory
/:cl:

