### PR TITLE
Lurker can now evolve into Praetorian

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
@@ -20,7 +20,7 @@
 
 	deevolves_to = list(XENO_CASTE_RUNNER)
 	caste_desc = "A fast, powerful backline combatant."
-	evolves_to = list(XENO_CASTE_RAVAGER)
+	evolves_to = list(XENO_CASTE_RAVAGER, XENO_CASTE_PRAETORIAN)
 
 	heal_resting = 1.5
 


### PR DESCRIPTION
# About the pull request

It's a common request by lurker players to have the ability to evolve into the Praetorian generalist caste rather than be forced into Ravager. With this PR, lurkers now have that option.

# Explain why it's good for the game

While base Praetorian may seem like a dedicated spitter caste, the various strains which drastically change the caste's playstyle fit warrior and now lurker styles far more. This evolution path makes sense in that a xeno seeks to evolve into one of the specialized Praetorian strains such as oppressor or vanguard for a final T3 evolution.


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: KornFlaks
balance: Lurker can now evolve into Praetorian.
/:cl:
