### PR TITLE
All mobs should call parent Life()

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -30,11 +30,8 @@
 		handle_luminosity()
 		handle_blood()
 
-		if(behavior_delegate)
-			behavior_delegate.on_life()
-
-		if(loc)
-			handle_environment()
+		behavior_delegate?.on_life()
+		handle_environment()
 		if(client)
 			handle_regular_hud_updates()
 

--- a/code/modules/mob/living/silicon/decoy/decoy.dm
+++ b/code/modules/mob/living/silicon/decoy/decoy.dm
@@ -32,6 +32,7 @@
 	return ..()
 
 /mob/living/silicon/decoy/Life(delta_time)
+	..()
 	if(stat == DEAD)
 		return FALSE
 	if(health <= HEALTH_THRESHOLD_DEAD && stat != DEAD)

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -59,18 +59,17 @@
 	if(stat == DEAD)
 		return ..()
 
-	if((src.loc) && isturf(src.loc))
-		if(stat != DEAD)
-			if(++miaow_counter >= rand(20, 30)) //Increase the meow variable each tick. Play it at random intervals.
-				playsound(loc, "cat_meow", 15, 1, 4)
-				miaow_counter = 0 //Reset the counter
-		if(!stat && !resting && !buckled)
+	if(isturf(loc))
+		if(++miaow_counter >= rand(20, 30)) //Increase the meow variable each tick. Play it at random intervals.
+			playsound(loc, "cat_meow", 15, 1, 4)
+			miaow_counter = 0 //Reset the counter
+		if(stat == CONSCIOUS && !resting && !buckled)
 			for(var/mob/prey in view(1,src))
 				if(is_type_in_list(prey, hunting_targets) && play_counter < 5 && prey.stat != DEAD)
 					var/mob/living/livingprey = prey
 
 					if(livingprey.stat == DEAD) //quick deadcheck
-						return
+						return ..()
 
 					play_counter++
 					visible_message(pick("[src] bites [livingprey]!","[src] toys with [livingprey].","[src] chomps on [livingprey]!"))
@@ -96,7 +95,7 @@
 			visible_message(pick("[src] hisses at [snack]!", "[src] mrowls fiercely!", "[src] eyes [snack] hungrily."))
 		break
 
-	if(!stat && !resting && !buckled)
+	if(stat == CONSCIOUS && !resting && !buckled)
 		handle_movement_target()
 
 /mob/living/simple_animal/cat/death()

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -201,13 +201,13 @@
 		PF.flags_pass = PASS_UNDER
 
 /mob/living/simple_animal/chick/Life(delta_time)
-	. =..()
+	. = ..()
 	if(!.)
 		return
-	if(!stat)
+	if(stat == CONSCIOUS)
 		amount_grown += rand(1,2)
 		if(amount_grown >= 100)
-			new /mob/living/simple_animal/chicken(src.loc)
+			new /mob/living/simple_animal/chicken(loc)
 			qdel(src)
 
 GLOBAL_VAR_INIT(MAX_CHICKENS, 50)
@@ -274,10 +274,10 @@ GLOBAL_VAR_INIT(chicken_count, 0)
 		..()
 
 /mob/living/simple_animal/chicken/Life(delta_time)
-	. =..()
+	. = ..()
 	if(!.)
 		return
-	if(!stat && prob(3) && eggsleft > 0)
+	if(stat == CONSCIOUS && prob(3) && eggsleft > 0)
 		visible_message("[src] [pick("lays an egg.","squats down and croons.","begins making a huge racket.","begins clucking raucously.")]")
 		eggsleft--
 		var/obj/item/reagent_container/food/snacks/egg/E = new(get_turf(src))

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -34,7 +34,7 @@
 
 /mob/living/simple_animal/mouse/Life(delta_time)
 	..()
-	if(!stat && prob(speak_chance))
+	if(stat == CONSCIOUS && prob(speak_chance))
 		FOR_DVIEW(var/mob/mob, world.view, src, HIDE_INVISIBLE_OBSERVER)
 			mob << 'sound/effects/mousesqueek.ogg'
 		FOR_DVIEW_END

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -79,7 +79,7 @@
 
 /mob/living/simple_animal/hostile/giant_spider/Life(delta_time)
 	. = ..()
-	if(!stat)
+	if(stat == CONSCIOUS)
 		if(stance == HOSTILE_STANCE_IDLE)
 			//1% chance to skitter madly away
 			if(!busy && prob(1))
@@ -102,7 +102,7 @@
 
 /mob/living/simple_animal/hostile/giant_spider/nurse/Life(delta_time)
 	. = ..()
-	if(!stat)
+	if(stat == CONSCIOUS)
 		if(stance == HOSTILE_STANCE_IDLE)
 			var/list/can_see = view(src, 10)
 			//30% chance to stop wandering and do something

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -269,7 +269,7 @@
 	if(client || stat)
 		return //Lets not force players or dead/incap parrots to move
 
-	if(!isturf(src.loc) || !(mobility_flags & MOBILITY_MOVE) || buckled)
+	if(!isturf(loc) || !(mobility_flags & MOBILITY_MOVE) || buckled)
 		return //If it can't move, dont let it move. (The buckled check probably isn't necessary thanks to canmove)
 
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -157,6 +157,7 @@
 		fire_overlay = fire_overlay_image
 
 /mob/living/simple_animal/Life(delta_time)
+	..()
 	if(affected_by_fire)
 		handle_fire()
 	//Health

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -237,6 +237,7 @@
 
 
 /mob/proc/Life(delta_time)
+	SHOULD_CALL_PARENT(TRUE)
 	SHOULD_NOT_SLEEP(TRUE)
 	if(client == null)
 		away_timer++


### PR DESCRIPTION

# About the pull request

This PR simply ensures all mobs (was only simple mobs and decoys that didn't already) call parent so the away_timer is always updated. I also did some minor refactoring for clarity.

# Explain why it's good for the game

`away_timer` should always be updated.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/68297572-0ca1-4c60-a358-9593be503cd3)

</details>


# Changelog
:cl: Drathek
fix: Simple mobs and decoys now update away_timer
refactor: Calling parent for Life() is now required as well as other minor Life() refactoring
/:cl:
