### PR TITLE
Add delay when moving guns directly to/from some inventory slots

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -21,6 +21,8 @@
 
 #define BAYONET_DRAW_DELAY (1 SECONDS)
 
+#define GUN_TRANSFER_DELAY (0.7 SECONDS)
+
 //Predator decloak multpliers based on the standard.
 #define DECLOAK_STANDARD (10 SECONDS)
 /// Forced for any unspecified reason.

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -21,6 +21,7 @@
 
 #define BAYONET_DRAW_DELAY (1 SECONDS)
 
+#define GUN_SLOW_SWAP_SLOTS list(WEAR_J_STORE, WEAR_WAIST, WEAR_BACK)
 #define GUN_TRANSFER_DELAY (0.7 SECONDS)
 
 //Predator decloak multpliers based on the standard.

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -340,7 +340,8 @@
 	throwing = 0
 
 	if(loc == user)
-		if(isgun(src) && user.get_slot_by_item(src) == WEAR_J_STORE)
+		var/slot = user.get_slot_by_item(src)
+		if(isgun(src) && (slot in GUN_SLOW_SWAP_SLOTS))
 			to_chat(user, "You start grabbing the [src].")
 			if (!do_after(user, GUN_TRANSFER_DELAY, INTERRUPT_ALL, BUSY_ICON_GENERIC))
 				return

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -340,6 +340,11 @@
 	throwing = 0
 
 	if(loc == user)
+		if(isgun(src) && user.get_slot_by_item(src) == WEAR_J_STORE)
+			to_chat(user, "You start grabbing the [src].")
+			if (!do_after(user, 0.7 SECONDS, INTERRUPT_ALL, BUSY_ICON_GENERIC))
+				return
+
 		if(!user.drop_inv_item_on_ground(src))
 			return
 	else

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -342,7 +342,7 @@
 	if(loc == user)
 		if(isgun(src) && user.get_slot_by_item(src) == WEAR_J_STORE)
 			to_chat(user, "You start grabbing the [src].")
-			if (!do_after(user, 0.7 SECONDS, INTERRUPT_ALL, BUSY_ICON_GENERIC))
+			if (!do_after(user, GUN_TRANSFER_DELAY, INTERRUPT_ALL, BUSY_ICON_GENERIC))
 				return
 
 		if(!user.drop_inv_item_on_ground(src))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -286,12 +286,14 @@
 
 	var/start_loc = W.loc
 
+	// Uniform storage delay.
 	if(W.time_to_equip && !ignore_delay)
 		INVOKE_ASYNC(src, PROC_REF(equip_to_slot_timed), W, slot, W.time_to_equip, redraw_mob, permanent, start_loc, del_on_fail, disable_warning)
 		return TRUE
 
-	if(isgun(W) && slot == WEAR_J_STORE)
-		to_chat(src, "You start storing the [W].")
+	// Direct-slot weapon storage delay.
+	if(!ignore_delay && isgun(W) && (slot in GUN_SLOW_SWAP_SLOTS))
+		to_chat(src, "You start storing the [W]].")
 		INVOKE_ASYNC(src, PROC_REF(equip_to_slot_timed), W, slot, GUN_TRANSFER_DELAY, redraw_mob, permanent, start_loc, del_on_fail, disable_warning)
 		return TRUE
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -287,7 +287,12 @@
 	var/start_loc = W.loc
 
 	if(W.time_to_equip && !ignore_delay)
-		INVOKE_ASYNC(src, PROC_REF(equip_to_slot_timed), W, slot, redraw_mob, permanent, start_loc, del_on_fail, disable_warning)
+		INVOKE_ASYNC(src, PROC_REF(equip_to_slot_timed), W, slot, W.time_to_equip, redraw_mob, permanent, start_loc, del_on_fail, disable_warning)
+		return TRUE
+
+	if(isgun(W) && slot == WEAR_J_STORE)
+		to_chat(src, "You start storing the [W].")
+		INVOKE_ASYNC(src, PROC_REF(equip_to_slot_timed), W, slot, 0.7 SECONDS, redraw_mob, permanent, start_loc, del_on_fail, disable_warning)
 		return TRUE
 
 	equip_to_slot(W, slot, disable_warning) //This proc should not ever fail.
@@ -303,8 +308,8 @@
 	return TRUE
 
 //This is an UNSAFE proc. It handles situations of timed equips.
-/mob/proc/equip_to_slot_timed(obj/item/W, slot, redraw_mob = 1, permanent = 0, start_loc, del_on_fail = 0, disable_warning = 0)
-	if(!do_after(src, W.time_to_equip, INTERRUPT_ALL, BUSY_ICON_GENERIC))
+/mob/proc/equip_to_slot_timed(obj/item/W, slot, time_to_equip, redraw_mob = 1, permanent = 0, start_loc, del_on_fail = 0, disable_warning = 0)
+	if(!do_after(src, time_to_equip, INTERRUPT_ALL, BUSY_ICON_GENERIC))
 		to_chat(src, SPAN_WARNING("You stop putting on \the [W]!"))
 		return
 	if(!W.mob_can_equip(src, slot, disable_warning)) // we have to do these checks again as circumstances may have changed during the do_after

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -292,7 +292,7 @@
 
 	if(isgun(W) && slot == WEAR_J_STORE)
 		to_chat(src, "You start storing the [W].")
-		INVOKE_ASYNC(src, PROC_REF(equip_to_slot_timed), W, slot, 0.7 SECONDS, redraw_mob, permanent, start_loc, del_on_fail, disable_warning)
+		INVOKE_ASYNC(src, PROC_REF(equip_to_slot_timed), W, slot, GUN_TRANSFER_DELAY, redraw_mob, permanent, start_loc, del_on_fail, disable_warning)
 		return TRUE
 
 	equip_to_slot(W, slot, disable_warning) //This proc should not ever fail.


### PR DESCRIPTION
# About the pull request

This PR adds an action lasting `0.7 SECONDS` when stowing or removing a gun from the suit accessory slot. The delay is implemented the same was as opening a backpack or putting on armor.

The check looks for `is_gun` and the `j_store`, `belt`, or `back` slots, which means using inventories (like m39/pistol holsters) are still instant.
This also makes it easy to control which weapons can be insta-grabbed. If it has a holster (or equivalent) it can be insta-grabbed. If not, it can't.

To quickly test: spawn in a human, equip `USCM Squad Rifleman (Equipped)`, press `[E]`.

## DRAFT

A few notes and requests for feedback:
- The action delay probably needs tweaking. Definitely need a lot of feedback on this.
- I made the delay apply to all three slots for consistency, would like feedback on which slots should be affected.
- This applies to things like the smartgun. Perhaps it shouldn't, but that would mean creating a list of allowed/denied items.
- In testing, deleting the gun while the action is happening causes a strange ghost. I may be missing a QDEL somewhere?
- The messages probably need work.

# Explain why it's good for the game

TLDR: Unpredictable insta-kill without opportunity cost is bad.

Instant weapon grabbing, particularly shotgun into a PB, is so much more dangerous than anything else a marine can do to a backliner that it warps your entire playstyle around avoiding it. Because this is an instant round-removal as runner, and extremely deadly as lurker, it forces you to change how you approach *every encounter*. You end up slashing twice instead of three times, because it is never worth the risk of a PB. *Even if you dodge 95% of the time*, rolling an "is my round over" d20 every time you pounce someone as runner is not fun. 

Shotguns being badass death-cannons is not the issue, because you can understand the risk and adapt to it. You cannot effectively play around *shotgun swapping*. You are given no indication that someone has one one instantly available, and they can insta-grab it after being pounced. I have missed a pounce on a group of ~3 marines not holding shotguns and gotten PBd twice before I could move 1 tile away. I have seen marines dragging around non-injured teammates just to bait pounces for a PB. 
¹ I know there is a tiny sprite change, but it is easy to conceal and you can't reliably notice it in *the heat of battle*™.

This problem affects other castes and guns to a lesser extent, but those cases are much less of an issue.

The delay is short enough that it should never be a real issue outside of extremely high-intensity fights. You can still pull a gun off your suit if you get pounced, but it is more difficult to do that *and* run away at the same time. This makes the "fight or flight" decision more interesting than "I will always instantly start shooting and strafing". You can still PB after pounce, you just need to have the shotgun out beforehand and. Running a dedicated holster, **such as the shotgun scabbard**, completely removes the delay, but that is a tradeoff instead of having no downside. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Compare a video of a rifleman using the keybind (holster?) to grab a shotgun from their suit and PB a runner. **Video starts the last frame of the shotgun on the back, and ends when the runner is hit (note the chat window, visuals happen a frame or two later).**

This video is so short that you will probably need to open it in a new window and scroll through it.
I think this clip is <200ms. You can get faster.

https://github.com/user-attachments/assets/f7c7311f-0024-436b-91cf-ab8cec217487

With the added delay, it takes roughly 1 second. This is still very fast, but enough to risk a 3rd slash, and enough for a xeno to react. 

https://github.com/user-attachments/assets/e91e3e40-fb84-4d93-b7b6-6464f86da17a

</details>


# Changelog 

:cl:
balance: Added a delay when transferring a gun directly to/from the suit accessory, back, and belt slots.
/:cl:
