### PR TITLE
prevents mar-50 from attaching a bipod

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -896,7 +896,6 @@
 		/obj/item/attachable/reddot,
 		/obj/item/attachable/reflex,
 		/obj/item/attachable/flashlight,
-		/obj/item/attachable/bipod,
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/scope/slavic,
 	)
@@ -907,6 +906,8 @@
 		/obj/item/attachable/scope/slavic,
 		/obj/item/attachable/magnetic_harness,
 	)
+	random_spawn_under = list() //prevents equiping invalid attachments from base
+	random_spawn_muzzle = list()
 
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_WIELDED_FIRING_ONLY
 	hud_offset = -4
@@ -934,7 +935,7 @@
 
 /obj/item/weapon/gun/rifle/mar40/lmg/tactical
 	desc = "A cheap, reliable LMG chambered in 7.62x39mm. Commonly found in the hands of slightly better funded criminals. This one has been equipped with an after-market ammo-counter."
-	starting_attachment_types = list(/obj/item/attachable/bipod, /obj/item/attachable/magnetic_harness)
+	starting_attachment_types = list(/obj/item/attachable/magnetic_harness)
 	flags_gun_features = GUN_AMMO_COUNTER|GUN_CAN_POINTBLANK|GUN_WIELDED_FIRING_ONLY
 //-------------------------------------------------------
 //M16 RIFLE


### PR DESCRIPTION

# About the pull request

removes the bipod from the list of valid attachments for the mar-50 LMG
fixes minor bug where the mar-50 could spawn with invalid attachments

# Explain why it's good for the game

same reasoning as #8768

The mar-50 with a bipod is too powerful right now, and can obliterate heavily armored t3s in about a second from full screen range, which is too much. My sincerest apologies to the survcord.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: the mar-50 LMG can no longer be used with a bipod
fix: the mar-50 no longer spawns with other invalid attachments like barrel attachments
/:cl:
