### PR TITLE
Adds Minimap Icons and Plasma Column to Hive Status

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -477,17 +477,23 @@
 		list(XENO_CASTE_HIVELORD = "", XENO_CASTE_BURROWER = "", XENO_CASTE_CARRIER = "", XENO_CASTE_LURKER = "", XENO_CASTE_SPITTER = "", XENO_CASTE_WARRIOR = ""),
 		list(XENO_CASTE_BOILER = "", XENO_CASTE_CRUSHER = "", XENO_CASTE_PRAETORIAN = "", XENO_CASTE_RAVAGER = "")
 	)
-	
+
 	for(var/caste in GLOB.xeno_datum_list)
 		var/datum/caste_datum/caste_datum = GLOB.xeno_datum_list[caste]
 
 		// Special castes like king will not show up.
 		if(caste_datum.tier < 0 || caste_datum.tier >= length(xeno_icons) || !(caste_datum.caste_type in xeno_icons[caste_datum.tier+1]))
 			continue
-		
+
 		xeno_icons[caste_datum.tier+1][caste_datum.caste_type] = GLOB.minimap_icons[caste_datum.minimap_icon]
-	
+
 	return xeno_icons
+
+/// Returns the default minimap icon background, as specified on drone caste.
+/datum/hive_status/proc/get_xeno_background()
+	var/datum/caste_datum/drone = GLOB.xeno_datum_list[XENO_CASTE_DRONE]
+
+	return GLOB.minimap_icons[drone.minimap_background]
 
 /**
  * Returns a sorted list of some basic info (stuff that's needed for sorting) about all the xenos in the hive

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -608,6 +608,7 @@
 
 		xenos["[xeno.nicknumber]"] = list(
 			"health" = round((xeno.health / xeno.maxHealth) * 100, 1),
+			"plasma" = round((xeno.plasma_stored / xeno.plasma_max) * 100, 1),
 			"area" = area_name,
 			"is_ssd" = (!xeno.client)
 		)

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -478,7 +478,7 @@
 		list(XENO_CASTE_BOILER = "", XENO_CASTE_CRUSHER = "", XENO_CASTE_PRAETORIAN = "", XENO_CASTE_RAVAGER = "")
 	)
 
-	for(var/caste as anything in GLOB.xeno_datum_list)
+	for(var/caste in GLOB.xeno_datum_list)
 		var/datum/caste_datum/caste_datum = GLOB.xeno_datum_list[caste]
 
 		// Special castes like king will not show up.

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -450,7 +450,7 @@
 	// Every caste is manually defined here so you get
 	var/list/xeno_counts = list(
 		// Yes, Queen is technically considered to be tier 0
-		list(XENO_CASTE_LARVA = 0, "Queen" = 0),
+		list(XENO_CASTE_LARVA = 0, XENO_CASTE_QUEEN = 0),
 		list(XENO_CASTE_DRONE = 0, XENO_CASTE_RUNNER = 0, XENO_CASTE_SENTINEL = 0, XENO_CASTE_DEFENDER = 0),
 		list(XENO_CASTE_HIVELORD = 0, XENO_CASTE_BURROWER = 0, XENO_CASTE_CARRIER = 0, XENO_CASTE_LURKER = 0, XENO_CASTE_SPITTER = 0, XENO_CASTE_WARRIOR = 0),
 		list(XENO_CASTE_BOILER = 0, XENO_CASTE_CRUSHER = 0, XENO_CASTE_PRAETORIAN = 0, XENO_CASTE_RAVAGER = 0)
@@ -467,6 +467,27 @@
 			xeno_counts[xeno.caste.tier+1][xeno.caste.caste_type]++
 
 	return xeno_counts
+
+/// Returns the full minimap icon as base64 string.
+/datum/hive_status/proc/get_xeno_icons()
+	// Must match hardcoded xeno counts order.
+	var/list/xeno_icons = list(
+		list(XENO_CASTE_LARVA = "", XENO_CASTE_QUEEN = ""),
+		list(XENO_CASTE_DRONE = "", XENO_CASTE_RUNNER = "", XENO_CASTE_SENTINEL = "", XENO_CASTE_DEFENDER = ""),
+		list(XENO_CASTE_HIVELORD = "", XENO_CASTE_BURROWER = "", XENO_CASTE_CARRIER = "", XENO_CASTE_LURKER = "", XENO_CASTE_SPITTER = "", XENO_CASTE_WARRIOR = ""),
+		list(XENO_CASTE_BOILER = "", XENO_CASTE_CRUSHER = "", XENO_CASTE_PRAETORIAN = "", XENO_CASTE_RAVAGER = "")
+	)
+	
+	for(var/caste in GLOB.xeno_datum_list)
+		var/datum/caste_datum/caste_datum = GLOB.xeno_datum_list[caste]
+
+		// Special castes like king will not show up.
+		if(caste_datum.tier < 0 || caste_datum.tier >= length(xeno_icons) || !(caste_datum.caste_type in xeno_icons[caste_datum.tier+1]))
+			continue
+		
+		xeno_icons[caste_datum.tier+1][caste_datum.caste_type] = GLOB.minimap_icons[caste_datum.minimap_icon]
+	
+	return xeno_icons
 
 /**
  * Returns a sorted list of some basic info (stuff that's needed for sorting) about all the xenos in the hive

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -478,7 +478,7 @@
 		list(XENO_CASTE_BOILER = "", XENO_CASTE_CRUSHER = "", XENO_CASTE_PRAETORIAN = "", XENO_CASTE_RAVAGER = "")
 	)
 
-	for(var/caste in GLOB.xeno_datum_list)
+	for(var/caste as anything in GLOB.xeno_datum_list)
 		var/datum/caste_datum/caste_datum = GLOB.xeno_datum_list[caste]
 
 		// Special castes like king will not show up.

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -627,9 +627,13 @@
 		if(cur_area)
 			area_name = cur_area.name
 
+		var/plasma_percent = -1
+		if(xeno.plasma_max != 0)
+			plasma_percent = round((xeno.plasma_stored / xeno.plasma_max) * 100, 1)
+
 		xenos["[xeno.nicknumber]"] = list(
 			"health" = round((xeno.health / xeno.maxHealth) * 100, 1),
-			"plasma" = round((xeno.plasma_stored / xeno.plasma_max) * 100, 1),
+			"plasma" = plasma_percent,
 			"area" = area_name,
 			"is_ssd" = (!xeno.client)
 		)

--- a/code/modules/mob/living/carbon/xenomorph/hive_status_ui.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status_ui.dm
@@ -115,6 +115,7 @@
 	update_xeno_keys(FALSE)
 	update_xeno_info(FALSE)
 	update_pylon_status(FALSE)
+	update_xeno_icons(FALSE)
 
 	if(send_update)
 		SStgui.update_uis(src)
@@ -125,7 +126,6 @@
 	update_all_xeno_data(FALSE)
 	update_burrowed_larva(FALSE)
 	update_pylon_status(FALSE)
-	update_xeno_icons(FALSE)
 	SStgui.update_uis(src)
 
 /datum/hive_status_ui/proc/update_pylon_status(send_update = TRUE)

--- a/code/modules/mob/living/carbon/xenomorph/hive_status_ui.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status_ui.dm
@@ -13,6 +13,7 @@
 	var/burrowed_larva
 	var/evilution_level
 	var/pylon_status
+	var/xeno_background
 
 	var/data_initialized = FALSE
 
@@ -102,6 +103,7 @@
 
 /datum/hive_status_ui/proc/update_xeno_icons(send_update = TRUE)
 	xeno_icons = assoc_hive.get_xeno_icons()
+	xeno_background = assoc_hive.get_xeno_background()
 
 	if(send_update)
 		SStgui.update_uis(src)
@@ -164,6 +166,7 @@
 	.["burrowed_larva"] = burrowed_larva
 	.["evilution_level"] = evilution_level
 	.["pylon_status"] = pylon_status
+	.["xeno_background"] = xeno_background
 
 	var/mob/living/carbon/xenomorph/queen/Q = user
 	.["is_in_ovi"] = istype(Q) && Q.ovipositor

--- a/code/modules/mob/living/carbon/xenomorph/hive_status_ui.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status_ui.dm
@@ -3,6 +3,7 @@
 
 	// Data to pass when rendering the UI (not static)
 	var/total_xenos
+	var/list/xeno_icons
 	var/list/xeno_counts
 	var/list/tier_slots
 	var/list/xeno_vitals
@@ -99,6 +100,12 @@
 	if(send_update)
 		SStgui.update_uis(src)
 
+/datum/hive_status_ui/proc/update_xeno_icons(send_update = TRUE)
+	xeno_icons = assoc_hive.get_xeno_icons()
+
+	if(send_update)
+		SStgui.update_uis(src)
+
 // Updates all data except burrowed larva
 /datum/hive_status_ui/proc/update_all_xeno_data(send_update = TRUE)
 	update_xeno_counts(FALSE)
@@ -116,6 +123,7 @@
 	update_all_xeno_data(FALSE)
 	update_burrowed_larva(FALSE)
 	update_pylon_status(FALSE)
+	update_xeno_icons(FALSE)
 	SStgui.update_uis(src)
 
 /datum/hive_status_ui/proc/update_pylon_status(send_update = TRUE)
@@ -143,6 +151,7 @@
 /datum/hive_status_ui/ui_data(mob/user)
 	. = list()
 	.["total_xenos"] = total_xenos
+	.["xeno_icons"] = xeno_icons
 	.["xeno_counts"] = xeno_counts
 	.["tier_slots"] = tier_slots
 	.["xeno_keys"] = xeno_keys

--- a/tgui/packages/tgui/interfaces/HiveStatus.tsx
+++ b/tgui/packages/tgui/interfaces/HiveStatus.tsx
@@ -9,6 +9,7 @@ import {
   Flex,
   Icon,
   Input,
+  Image,
   NumberInput,
   Table,
 } from 'tgui/components';
@@ -48,6 +49,7 @@ const filterXenos = (data: {
       strain: xeno_info[nicknumber].strain,
       location: xeno_vitals[nicknumber].area,
       health: xeno_vitals[nicknumber].health,
+      plasma: xeno_vitals[nicknumber].plasma,
       ref: xeno_info[nicknumber].ref,
       is_ssd: xeno_vitals[nicknumber].is_ssd,
       is_leader: key.is_leader,
@@ -99,6 +101,7 @@ type XenoEntry = {
   strain: string;
   location: string | null;
   health: number;
+  plasma: number;
   ref: string;
   is_ssd: BooleanLike;
   is_leader: BooleanLike;
@@ -119,6 +122,7 @@ type XenoVitals = { health: number; plasma: number; area: string; is_ssd: Boolea
 
 type Data = {
   total_xenos: number;
+  xeno_icons: Record<string, string>[];
   xeno_counts: Record<string, number>[];
   tier_slots: { 3: TierSlot; 2: TierSlot };
   xeno_keys: XenoKey[];
@@ -212,7 +216,7 @@ const GeneralInformation = (props) => {
 
 const XenoCounts = (props) => {
   const { data } = useBackend<Data>();
-  const { xeno_counts, tier_slots, hive_color } = data;
+  const { xeno_icons, xeno_counts, tier_slots, hive_color } = data;
 
   return (
     <Flex direction="column-reverse">
@@ -277,7 +281,13 @@ const XenoCounts = (props) => {
                   <Table className="xenoCountTable" collapsing>
                     <Table.Row header>
                       {Object.keys(counts).map((caste, i) => (
-                        <Table.Cell key={i} className="underlineCell" width={7}>
+                        <Table.Cell key={i} className="underlineCell" width={7} nowrap={true}>
+                          <Image
+                            src={`data:image/jpeg;base64,${xeno_icons[tier][caste]}`}
+                            style={{
+                              transform: 'scale(3) translateX(-3px)',
+                            }}
+                          />
                           {caste === 'Bloody Larva' ? 'Larva' : caste}
                         </Table.Cell>
                       ))}
@@ -405,7 +415,8 @@ const XenoList = (props) => {
           <Table.Cell>Name</Table.Cell>
           <Table.Cell width="15%">Strain</Table.Cell>
           <Table.Cell>Location</Table.Cell>
-          <Table.Cell width="75px">Health</Table.Cell>
+          <Table.Cell width="60px">Health</Table.Cell>
+          <Table.Cell width="60px">Plasma</Table.Cell>
           <Table.Cell width="100px" />
         </Table.Row>
 
@@ -431,6 +442,13 @@ const XenoList = (props) => {
                 <b style={redFont}>{entry.health}%</b>
               ) : (
                 <>{entry.health}%</>
+              )}
+            </Table.Cell>
+            <Table.Cell>
+              {entry.plasma < 30 ? (
+                <b style={redFont}>{entry.plasma}%</b>
+              ) : (
+                <>{entry.plasma}%</>
               )}
             </Table.Cell>
             <Table.Cell className="noPadCell" textAlign="center">

--- a/tgui/packages/tgui/interfaces/HiveStatus.tsx
+++ b/tgui/packages/tgui/interfaces/HiveStatus.tsx
@@ -8,8 +8,8 @@ import {
   Divider,
   Flex,
   Icon,
-  Input,
   Image,
+  Input,
   NumberInput,
   Table,
 } from 'tgui/components';
@@ -122,7 +122,12 @@ type XenoKey = {
 
 type TierSlot = { open_slots: string; guaranteed_slots: string };
 type XenoInfo = { name: string; straing: string; ref: string };
-type XenoVitals = { health: number; plasma: number; area: string; is_ssd: BooleanLike };
+type XenoVitals = {
+  health: number;
+  plasma: number;
+  area: string;
+  is_ssd: BooleanLike;
+};
 
 type Data = {
   total_xenos: number;
@@ -285,7 +290,12 @@ const XenoCounts = (props) => {
                   <Table className="xenoCountTable" collapsing>
                     <Table.Row header>
                       {Object.keys(counts).map((caste, i) => (
-                        <Table.Cell key={i} className="underlineCell" width={7} nowrap>
+                        <Table.Cell
+                          key={i}
+                          className="underlineCell"
+                          width={7}
+                          nowrap
+                        >
                           <Image
                             src={`data:image/jpeg;base64,${xeno_icons[tier][caste]}`}
                             style={{

--- a/tgui/packages/tgui/interfaces/HiveStatus.tsx
+++ b/tgui/packages/tgui/interfaces/HiveStatus.tsx
@@ -142,6 +142,7 @@ type Data = {
   burrowed_larva: number;
   evilution_level: number;
   pylon_status: string;
+  xeno_background: string;
   is_in_ovi: BooleanLike;
   user_ref: string;
   hive_color: string;
@@ -225,7 +226,8 @@ const GeneralInformation = (props) => {
 
 const XenoCounts = (props) => {
   const { data } = useBackend<Data>();
-  const { xeno_icons, xeno_counts, tier_slots, hive_color } = data;
+  const { xeno_background, xeno_icons, xeno_counts, tier_slots, hive_color } =
+    data;
 
   return (
     <Flex direction="column-reverse">
@@ -288,18 +290,28 @@ const XenoCounts = (props) => {
               <Flex.Item>
                 <center>
                   <Table className="xenoCountTable" collapsing>
-                    <Table.Row header>
+                    <Table.Row header style={{ transform: 'translateX(10px)' }}>
                       {Object.keys(counts).map((caste, i) => (
                         <Table.Cell
                           key={i}
                           className="underlineCell"
-                          width={7}
+                          width={caste.length}
                           nowrap
                         >
                           <Image
-                            src={`data:image/jpeg;base64,${xeno_icons[tier][caste]}`}
+                            src={`data:image/jpeg;base64,${xeno_background}`}
+                            position="absolute"
                             style={{
-                              transform: 'scale(3) translateX(-3px)',
+                              transform:
+                                'scale(3) translateX(-6px) translateY(1px)',
+                            }}
+                          />
+                          <Image
+                            src={`data:image/jpeg;base64,${xeno_icons[tier][caste]}`}
+                            position="absolute"
+                            style={{
+                              transform:
+                                'scale(3) translateX(-6px) translateY(1px)',
                             }}
                           />
                           {caste === 'Bloody Larva' ? 'Larva' : caste}

--- a/tgui/packages/tgui/interfaces/HiveStatus.tsx
+++ b/tgui/packages/tgui/interfaces/HiveStatus.tsx
@@ -115,7 +115,7 @@ type XenoKey = {
 
 type TierSlot = { open_slots: string; guaranteed_slots: string };
 type XenoInfo = { name: string; straing: string; ref: string };
-type XenoVitals = { health: number; area: string; is_ssd: BooleanLike };
+type XenoVitals = { health: number; plasma: number; area: string; is_ssd: BooleanLike };
 
 type Data = {
   total_xenos: number;

--- a/tgui/packages/tgui/interfaces/HiveStatus.tsx
+++ b/tgui/packages/tgui/interfaces/HiveStatus.tsx
@@ -19,6 +19,10 @@ const redFont = {
   color: 'red',
 };
 
+const grayFont = {
+  color: 'gray',
+};
+
 /**
  * Filters the list of xenos and returns a set of rows that will be used in the
  * xeno list table
@@ -445,7 +449,9 @@ const XenoList = (props) => {
               )}
             </Table.Cell>
             <Table.Cell>
-              {entry.plasma < 30 ? (
+              {entry.plasma < 0 ? (
+                <div style={grayFont}>------</div>
+              ) : entry.plasma < 30 ? (
                 <b style={redFont}>{entry.plasma}%</b>
               ) : (
                 <>{entry.plasma}%</>

--- a/tgui/packages/tgui/interfaces/HiveStatus.tsx
+++ b/tgui/packages/tgui/interfaces/HiveStatus.tsx
@@ -285,7 +285,7 @@ const XenoCounts = (props) => {
                   <Table className="xenoCountTable" collapsing>
                     <Table.Row header>
                       {Object.keys(counts).map((caste, i) => (
-                        <Table.Cell key={i} className="underlineCell" width={7} nowrap={true}>
+                        <Table.Cell key={i} className="underlineCell" width={7} nowrap>
                           <Image
                             src={`data:image/jpeg;base64,${xeno_icons[tier][caste]}`}
                             style={{


### PR DESCRIPTION
# About the pull request

Some QOL enhancements to the hive status page. Check screenshot tab for the additions.

# Explain why it's good for the game

Unless the player knows how to inspect sprites or has memorized all the caste minimap icons, it's quite confusing to check the minimap and know what each icon represents. Now, the hive status page will include the icon next to the name in the caste count pyramid for easy reference.

For Queen QOL, plasma percentage is also included in the xeno list for quick reference and rapid plasma transfer without having to check every single xeno to see if they need plasma.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/fdf85088-3e57-4bcc-949a-8f7fe74bb645)
![image](https://github.com/user-attachments/assets/f3480099-d8a2-46ef-bdeb-513f38211a10)
![image](https://github.com/user-attachments/assets/a5c91a0b-578b-4a25-b1bb-4006ec3f455e)


</details>


# Changelog

:cl: KornFlaks
qol: Xeno minimap icons are now shown alongside caste name in hive status
qol: Xeno plasma percentage column is added to the hive status
/:cl:
