### PR TITLE
Modifies FTL + SL Essentials + Webbing Addition

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
@@ -177,6 +177,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_leader, list(
 		list("Webbing", 0, /obj/item/clothing/accessory/storage/webbing, MARINE_CAN_BUY_ACCESSORY, VENDOR_ITEM_REGULAR),
 		list("Black Webbing", 0, /obj/item/clothing/accessory/storage/webbing/black, MARINE_CAN_BUY_ACCESSORY, VENDOR_ITEM_REGULAR),
 		list("Drop Pouch", 0, /obj/item/clothing/accessory/storage/droppouch, MARINE_CAN_BUY_ACCESSORY, VENDOR_ITEM_REGULAR),
+		list("Small Tool Webbing (Full)", 0, /obj/item/clothing/accessory/storage/tool_webbing/small/equipped, MARINE_CAN_BUY_ACCESSORY, VENDOR_ITEM_REGULAR),
 
 		list("MASK (CHOOSE 1)", 0, null, null, null),
 		list("Gas Mask", 0, /obj/item/clothing/mask/gas, MARINE_CAN_BUY_MASK, VENDOR_ITEM_REGULAR),
@@ -221,4 +222,5 @@ GLOBAL_LIST_INIT(cm_vending_clothing_leader, list(
 		/obj/item/storage/box/m94/signal,
 		/obj/item/tool/extinguisher/mini,
 		/obj/item/storage/box/zipcuffs,
+		/obj/item/storage/backpack/marine/satchel/rto,
 	)

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_tl.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_tl.dm
@@ -138,6 +138,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_tl, list(
 		list("Webbing", 0, /obj/item/clothing/accessory/storage/webbing, MARINE_CAN_BUY_ACCESSORY, VENDOR_ITEM_REGULAR),
 		list("Black Webbing", 0, /obj/item/clothing/accessory/storage/webbing/black, MARINE_CAN_BUY_ACCESSORY, VENDOR_ITEM_REGULAR),
 		list("Drop Pouch", 0, /obj/item/clothing/accessory/storage/droppouch, MARINE_CAN_BUY_ACCESSORY, VENDOR_ITEM_REGULAR),
+		list("Small Tool Webbing (Full)", 0, /obj/item/clothing/accessory/storage/tool_webbing/small/equipped, MARINE_CAN_BUY_ACCESSORY, VENDOR_ITEM_REGULAR),
 
 		list("MASK (CHOOSE 1)", 0, null, null, null),
 		list("Gas Mask", 0, /obj/item/clothing/mask/gas, MARINE_CAN_BUY_MASK, VENDOR_ITEM_REGULAR),
@@ -180,4 +181,5 @@ GLOBAL_LIST_INIT(cm_vending_clothing_tl, list(
 		/obj/item/device/binoculars/range/designator,
 		/obj/item/storage/box/m94/signal,
 		/obj/item/storage/box/m94/signal,
+		/obj/item/storage/backpack/marine/satchel/rto,
 	)


### PR DESCRIPTION
# About the pull request

Adds radio backpack to FTL and SL essential loadout option.

Adds small tool webbing to webbing section of both jobs.

This gives back an essential tool (for free) to both roles that actually need it to function (as their role is communication). You should not have to go to req, limited squad prep, or use vendor points to get an essential item; this is like forcing an SL to use vendor points or go to req to get a squad leader headset and vice versa for FTL's.

The addition of the small tool webbing is due to the fact that both FTL's and SL's have CT level training and are called upon to do their job occasionally, ESPECIALLY if you are Bravo. This should make it easier on these roles.

# Explain why it's good for the game

QoL for both roles and the rest of my rationale is above.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

N/A

</details>

# Changelog

:cl: Swagile
add: Adds radio backpack to FTL and SL essentials.
add: Adds small tool webbing to the FTL and SL webbing section.
/:cl:
