### PR TITLE
UPP Ship Hull Window Fix + UPP Brig Buffs + UPP APCs

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -1076,13 +1076,20 @@
 /obj/structure/window/framed/upp_ship/reinforced
 	name = "reinforced window"
 	desc = "A glass window. Light refracts incorrectly when looking through. It looks rather strong. Might take a few good hits to shatter it."
+	//	icon_state = "upp_rwindow0"
 	health = 100
 	reinf = 1
 	window_frame = /obj/structure/window_frame/upp_ship/reinforced
 
 /obj/structure/window/framed/upp_ship/hull
+	name = "hull window"
 	desc = "A glass window. Something tells you this one is somehow indestructible."
-//	icon_state = "upp_rwindow0"
+	not_damageable = TRUE
+	not_deconstructable = TRUE
+	unslashable = TRUE
+	unacidable = TRUE
+	health = 1000000
+	window_frame = /obj/structure/window_frame/upp_ship/hull
 
 //UPP almayer retexture windows
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -1119,6 +1119,7 @@
 	unslashable = TRUE
 	unacidable = TRUE
 	health = 1000000
+	window_frame = /obj/structure/window_frame/upp/hull
 //	icon_state = "upp_rwindow0"
 
 // Hybrisa Windows

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -1112,7 +1112,13 @@
 	window_frame = /obj/structure/window_frame/upp/reinforced
 
 /obj/structure/window/framed/upp/hull
+	name = "hull window"
 	desc = "A glass window. Something tells you this one is somehow indestructible."
+	not_damageable = TRUE
+	not_deconstructable = TRUE
+	unslashable = TRUE
+	unacidable = TRUE
+	health = 1000000
 //	icon_state = "upp_rwindow0"
 
 // Hybrisa Windows

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -1083,7 +1083,7 @@
 
 /obj/structure/window/framed/upp_ship/hull
 	name = "hull window"
-	desc = "A glass window. Something tells you this one is somehow indestructible."
+	desc = "A glass window with a special rod matrix inside a wall frame. This one was made out of exotic materials to prevent hull breaches. No way to get through here."
 	not_damageable = TRUE
 	not_deconstructable = TRUE
 	unslashable = TRUE

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -71,8 +71,10 @@ GLOBAL_LIST_INIT(apc_wire_descriptions, list(
 	var/areastring = null
 
 	var/obj/item/cell/cell
-	var/start_charge = 90 //Initial cell charge %
-	var/cell_type = /obj/item/cell/apc/empty //0 = no cell, 1 = regular, 2 = high-cap (x5) <- old, now it's just 0 = no cell, otherwise dictate cellcapacity by changing this value. 1 used to be 1000, 2 was 2500
+	/// Initial cell charge %
+	var/start_charge = 90
+	/// 0 = no cell, 1 = regular, 2 = high-cap (x5) <- old, now it's just 0 = no cell, otherwise dictate cellcapacity by changing this value. 1 used to be 1000, 2 was 2500
+	var/cell_type = /obj/item/cell/apc/empty
 
 	var/opened = APC_COVER_CLOSED
 	var/shorted = 0
@@ -99,16 +101,21 @@ GLOBAL_LIST_INIT(apc_wire_descriptions, list(
 
 	powernet = 0 //Set so that APCs aren't found as powernet nodes //Hackish, Horrible, was like this before I changed it :(
 	var/debug = 0
-	var/autoflag = 0 // 0 = off, 1 = eqp and lights off, 2 = eqp off, 3 = all on.
-	var/has_electronics = 0 // 0 - none, 1 - plugged in, 2 - secured by screwdriver
-	var/overload = 1 //Used for the Blackout malf module
-	var/beenhit = 0 //Used for counting how many times it has been hit, used for Aliens at the moment
+	/// 0 = off, 1 = eqp and lights off, 2 = eqp off, 3 = all on.
+	var/autoflag = 0
+	/// 0 - none, 1 - plugged in, 2 - secured by screwdriver
+	var/has_electronics = 0
+	/// Used for the Blackout malf module
+	var/overload = 1
+	/// Used for counting how many times it has been hit, used for Aliens at the moment
+	var/beenhit = 0
 	var/longtermpower = 10
 	var/update_state = -1
 	var/update_overlay = -1
 	var/global/status_overlays = 0
 	var/updating_icon = 0
-	var/crash_break_probability = 85 //Probability of APC being broken by a shuttle crash on the same z-level
+	/// Probability of APC being broken by a shuttle crash on the same z-level, set to 0 to have the APC not be destroyed
+	var/crash_break_probability = 85
 
 	var/global/list/status_overlays_lock
 	var/global/list/status_overlays_charging
@@ -1381,6 +1388,29 @@ GLOBAL_LIST_INIT(apc_wire_descriptions, list(
 	dir = 4
 
 /obj/structure/machinery/power/apc/almayer/hardened/west
+	pixel_x = -30
+	dir = 8
+
+//------UPP APCs ------//
+
+/// Same as other APCs, but with restricted access
+/obj/structure/machinery/power/apc/upp
+	cell_type = /obj/item/cell/high
+	req_one_access = list(ACCESS_UPP_ENGINEERING)
+
+/obj/structure/machinery/power/apc/upp/north
+	pixel_y = 32
+	dir = 1
+
+/obj/structure/machinery/power/apc/upp/south
+	pixel_y = -26
+	dir = 2
+
+/obj/structure/machinery/power/apc/upp/east
+	pixel_x = 30
+	dir = 4
+
+/obj/structure/machinery/power/apc/upp/west
 	pixel_x = -30
 	dir = 8
 

--- a/maps/templates/ssv_rostock.dmm
+++ b/maps/templates/ssv_rostock.dmm
@@ -868,7 +868,7 @@
 /turf/open/floor/corsat/spiralplate,
 /area/rostock/upperdeck_maint/s_f)
 "acK" = (
-/obj/structure/machinery/power/apc/power/west,
+/obj/structure/machinery/power/apc/upp/west,
 /turf/open/floor/strata,
 /area/rostock/security/execution_room)
 "acL" = (
@@ -913,7 +913,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/rostock/security/execution_storage)
 "acR" = (
-/obj/structure/machinery/power/apc/power/east,
+/obj/structure/machinery/power/apc/upp/east,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/rostock/security/execution_storage)
 "acS" = (
@@ -1195,7 +1195,7 @@
 	layer = 2.5;
 	pixel_y = 2
 	},
-/obj/structure/machinery/power/apc/power/east,
+/obj/structure/machinery/power/apc/upp/east,
 /turf/open/floor/almayer/plating/northeast,
 /area/rostock/ert_dock/port)
 "afs" = (
@@ -1507,17 +1507,6 @@
 	},
 /turf/open/floor/strata/fake_wood,
 /area/rostock/command/dining)
-"arp" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/machinery/camera/autoname/almayer{
-	name = "rostock camera";
-	network = list("Rostock");
-	dir = 1
-	},
-/turf/open/floor/strata/fake_wood,
-/area/rostock/security/brig_holding_area)
 "art" = (
 /obj/structure/machinery/door/poddoor/almayer{
 	name = "\improper Umbillical Airlock";
@@ -2106,7 +2095,7 @@
 /turf/open/floor/corsat/plate,
 /area/rostock/railgun/starboard)
 "aNY" = (
-/obj/structure/machinery/power/apc/power/west,
+/obj/structure/machinery/power/apc/upp/west,
 /turf/open/floor/strata,
 /area/rostock/security/brig_office)
 "aOB" = (
@@ -2315,7 +2304,7 @@
 /obj/structure/closet/secure_closet/personal/cabinet{
 	req_access = null
 	},
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /obj/item/clothing/suit/storage/webbing,
 /obj/item/clothing/suit/storage/webbing,
 /obj/item/clothing/under/marine/veteran/UPP/officer,
@@ -2557,7 +2546,7 @@
 /turf/closed/wall/upp_ship,
 /area/rostock/upperdeck_maint/s_f)
 "biL" = (
-/obj/structure/machinery/power/apc/power/south,
+/obj/structure/machinery/power/apc/upp/south,
 /turf/open/floor/corsat/plate,
 /area/rostock/railgun/starboard)
 "biQ" = (
@@ -2850,7 +2839,7 @@
 /turf/open/floor/strata/orange_edge/north,
 /area/rostock/req)
 "bud" = (
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /turf/open/floor/corsat/plate,
 /area/rostock/security/headquarters_interrogation)
 "buT" = (
@@ -3311,7 +3300,7 @@
 /turf/open/floor/corsat/red/west,
 /area/rostock/command/cic)
 "bMB" = (
-/obj/structure/machinery/power/apc/power/south,
+/obj/structure/machinery/power/apc/upp/south,
 /turf/open/floor/strata/orange_edge,
 /area/rostock/vehiclehangar)
 "bMP" = (
@@ -3586,7 +3575,7 @@
 /turf/open/floor/strata,
 /area/rostock/upper_deck/hallway)
 "bVO" = (
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /obj/effect/decal/heavy_cable/cable_vertical,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/rostock/engineering/reactor)
@@ -4411,7 +4400,7 @@
 /turf/open/floor/strata/green4/west,
 /area/rostock/lower_deck/prep)
 "cIm" = (
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /turf/open/floor/strata/floor3/east,
 /area/rostock/security/headquarters_storage)
 "cIN" = (
@@ -4836,7 +4825,7 @@
 /turf/open/floor/almayer/plating/northeast,
 /area/rostock/ert_dock/port)
 "ddi" = (
-/obj/structure/machinery/power/apc/power/west,
+/obj/structure/machinery/power/apc/upp/west,
 /turf/open/floor/corsat/spiralplate,
 /area/rostock/hangar/pilotbunk)
 "ddO" = (
@@ -6185,7 +6174,7 @@
 /turf/open/floor/plating,
 /area/rostock/security/brig_holding_area)
 "ees" = (
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /turf/open/floor/strata/multi_tiles,
 /area/rostock/command/hallway)
 "eeC" = (
@@ -7352,7 +7341,7 @@
 	icon_state = "NW-out";
 	pixel_y = 1
 	},
-/obj/structure/machinery/power/apc/power/south,
+/obj/structure/machinery/power/apc/upp/south,
 /turf/open/floor/corsat/plate,
 /area/rostock/lower_deck/p_hallway)
 "eZO" = (
@@ -7457,7 +7446,7 @@
 /obj/item/clothing/glasses/welding{
 	pixel_y = 6
 	},
-/obj/structure/machinery/power/apc/power/south,
+/obj/structure/machinery/power/apc/upp/south,
 /turf/open/floor/strata/blue3/north,
 /area/rostock/command/cic)
 "fdp" = (
@@ -7725,7 +7714,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/machinery/power/apc/power/east,
+/obj/structure/machinery/power/apc/upp/east,
 /turf/open/floor/prison/cell_stripe/west,
 /area/rostock/engineering/main_area)
 "fkV" = (
@@ -7850,7 +7839,7 @@
 	pixel_x = 8;
 	pixel_y = 6
 	},
-/obj/structure/machinery/power/apc/power/east,
+/obj/structure/machinery/power/apc/upp/east,
 /turf/open/floor/corsat,
 /area/rostock/lower_deck/starboard_umbilical)
 "fop" = (
@@ -7931,7 +7920,7 @@
 /turf/open/floor/prison/floor_plate,
 /area/rostock/engineering/main_area)
 "fqz" = (
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /turf/open/floor/almayer/silverfull,
 /area/rostock/medical/surgery)
 "fqP" = (
@@ -9771,7 +9760,7 @@
 	name = "\improper Entrance Shutters"
 	},
 /turf/open/floor/plating,
-/area/rostock/security/brig_holding_area)
+/area/rostock/security/brig_entryway)
 "gZL" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -10177,7 +10166,7 @@
 /area/space)
 "hmW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/machinery/power/apc/power/south,
+/obj/structure/machinery/power/apc/upp/south,
 /turf/open/floor/corsat/spiralplate,
 /area/rostock/upperdeck_maint/p_a)
 "hnn" = (
@@ -11077,7 +11066,7 @@
 /turf/closed/wall/upp_ship/reinforced,
 /area/rostock/command/polcom)
 "hTG" = (
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /turf/open/floor/corsat/plate,
 /area/rostock/railgun)
 "hTL" = (
@@ -12054,7 +12043,7 @@
 /turf/open/floor/upp_hull_rostock,
 /area/space)
 "iFK" = (
-/obj/structure/machinery/power/apc/power/east,
+/obj/structure/machinery/power/apc/upp/east,
 /turf/open/floor/strata/red4/west,
 /area/rostock/security/headquarters_bunk)
 "iFY" = (
@@ -12803,9 +12792,13 @@
 	name = "Entrance Shutter";
 	req_one_access = list(230, 240)
 	},
-/obj/structure/machinery/power/apc/power/south,
+/obj/structure/machinery/camera/autoname/almayer{
+	name = "rostock camera";
+	network = list("Rostock");
+	dir = 1
+	},
 /turf/open/floor/strata/red2,
-/area/rostock/security/brig_holding_area)
+/area/rostock/security/brig_entryway)
 "jiF" = (
 /obj/structure/barricade/handrail{
 	pixel_x = 2
@@ -13313,7 +13306,7 @@
 	icon_state = "triagedecaldir";
 	pixel_y = 18
 	},
-/obj/structure/machinery/power/apc/power/east,
+/obj/structure/machinery/power/apc/upp/east,
 /turf/open/floor/almayer/silverfull,
 /area/rostock/medical/prep)
 "jCq" = (
@@ -13487,7 +13480,7 @@
 /obj/effect/decal/strata_decals/grime/grime3{
 	dir = 8
 	},
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /turf/open/floor/corsat/spiralplate,
 /area/rostock/upperdeck_maint/s_a)
 "jJL" = (
@@ -14085,7 +14078,7 @@
 	pixel_y = 9;
 	pixel_x = 2
 	},
-/obj/structure/machinery/power/apc/power/south,
+/obj/structure/machinery/power/apc/upp/south,
 /turf/open/floor/strata/floor3/east,
 /area/rostock/engineering/starboard_aft_accessway)
 "kfg" = (
@@ -14120,7 +14113,7 @@
 /turf/open/floor/wood/ship,
 /area/rostock/command/so)
 "khq" = (
-/obj/structure/machinery/power/apc/power/west,
+/obj/structure/machinery/power/apc/upp/west,
 /turf/open/floor/strata/red3/west,
 /area/rostock/security/headquarters_lobby)
 "khK" = (
@@ -14239,7 +14232,7 @@
 /area/rostock/lower_deck/engineering_lower_access)
 "kkt" = (
 /obj/structure/surface/table/almayer,
-/obj/structure/machinery/power/apc/power/west,
+/obj/structure/machinery/power/apc/upp/west,
 /obj/item/storage/belt,
 /turf/open/floor/prison/darkyellowfull2/east,
 /area/rostock/hangar/repairbay)
@@ -14912,7 +14905,7 @@
 	dir = 4;
 	light_color = "#ccecff"
 	},
-/obj/structure/machinery/power/apc/power/east,
+/obj/structure/machinery/power/apc/upp/east,
 /turf/open/floor/almayer/sterile_green,
 /area/rostock/medical/chemistry)
 "kIs" = (
@@ -15108,7 +15101,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/rostock/lower_deck/bathroom)
 "kQV" = (
-/obj/structure/machinery/power/apc/power/south,
+/obj/structure/machinery/power/apc/upp/south,
 /turf/open/floor/almayer/aicore/no_build,
 /area/rostock/airoom)
 "kRk" = (
@@ -15774,7 +15767,7 @@
 /turf/open/floor/prison,
 /area/rostock/engineering/main_area)
 "lxo" = (
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /turf/open/floor/strata/multi_tiles/southeast,
 /area/rostock/lower_deck/m_hallway)
 "lxH" = (
@@ -15874,7 +15867,7 @@
 /turf/open/floor/corsat/spiralplate,
 /area/rostock/lower_deck/ammunition_storage)
 "lEP" = (
-/obj/structure/machinery/power/apc/power/south,
+/obj/structure/machinery/power/apc/upp/south,
 /turf/open/floor/prison/floor_plate,
 /area/rostock/engineering/lower_aft_corridor)
 "lFi" = (
@@ -17083,7 +17076,7 @@
 /turf/open/floor/corsat/spiralplate,
 /area/rostock/upperdeck_maint/s_a)
 "mFt" = (
-/obj/structure/machinery/power/apc/power/west,
+/obj/structure/machinery/power/apc/upp/west,
 /turf/open/floor/corsat/spiralplate,
 /area/rostock/lower_deck/ammunition_storage)
 "mGL" = (
@@ -17464,7 +17457,7 @@
 "mXe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /turf/open/floor/corsat/spiralplate,
 /area/rostock/lowerdeck_maint/p_f)
 "mXj" = (
@@ -17598,7 +17591,7 @@
 /turf/open/floor/almayer/sterile_green,
 /area/rostock/medical/lobby)
 "nep" = (
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /turf/open/floor/plating/prison,
 /area/rostock/upperdeck_maint/p_m)
 "neM" = (
@@ -18045,7 +18038,7 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /turf/open/floor/strata/floor3/east,
 /area/rostock/upper_deck/hallway)
 "nCE" = (
@@ -18263,7 +18256,7 @@
 /area/rostock/railgun/starboard)
 "nLu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/machinery/power/apc/power/east,
+/obj/structure/machinery/power/apc/upp/east,
 /turf/open/floor/corsat/spiralplate,
 /area/rostock/upperdeck_maint/p_f)
 "nMh" = (
@@ -18907,7 +18900,7 @@
 /turf/open/floor/corsat/marked,
 /area/rostock/security/headquarters_interrogation)
 "omS" = (
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /turf/open/floor/corsat/plate,
 /area/rostock/command/astronavigation)
 "omU" = (
@@ -19725,7 +19718,7 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /turf/open/floor/prison/darkyellowfull2/east,
 /area/rostock/lower_deck/engineering_lower_access)
 "oSB" = (
@@ -19860,7 +19853,7 @@
 /area/rostock/engineering/reactor)
 "oZA" = (
 /obj/structure/largecrate/random/case/double,
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /turf/open/floor/strata/floor3/east,
 /area/rostock/engineering/port_aft_accessway)
 "pap" = (
@@ -20095,7 +20088,7 @@
 "pjA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /turf/open/floor/corsat/spiralplate,
 /area/rostock/upperdeck_maint/s_f)
 "pjC" = (
@@ -20212,11 +20205,6 @@
 	req_access = list(230);
 	req_one_access = null
 	},
-/obj/structure/machinery/camera/autoname/almayer{
-	name = "rostock camera";
-	network = list("Rostock");
-	dir = 4
-	},
 /turf/open/floor/almayer/cargo,
 /area/rostock/security/brig_entryway)
 "pmQ" = (
@@ -20262,7 +20250,7 @@
 /turf/open/floor/strata/green3/north,
 /area/rostock/lower_deck/p_a_hallway)
 "poD" = (
-/obj/structure/machinery/power/apc/power/east,
+/obj/structure/machinery/power/apc/upp/east,
 /turf/open/floor/corsat/lightplate,
 /area/rostock/lower_deck/bathroom)
 "poQ" = (
@@ -20778,7 +20766,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/rostock/upperdeck_maint/p_a)
 "pIQ" = (
-/obj/structure/machinery/power/apc/power/east,
+/obj/structure/machinery/power/apc/upp/east,
 /turf/open/floor/strata/floor3/east,
 /area/rostock/lower_deck/briefing)
 "pJl" = (
@@ -20978,7 +20966,7 @@
 /turf/open/floor/strata/red3/north,
 /area/rostock/upper_deck/hallway)
 "pQZ" = (
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /turf/open/floor/strata/orange_edge/north,
 /area/rostock/req)
 "pRh" = (
@@ -21351,7 +21339,7 @@
 /turf/open/floor/almayer/silverfull,
 /area/rostock/medical/lobby)
 "qgH" = (
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/rostock/lowerdeck_maint/p_m)
 "qgI" = (
@@ -21425,7 +21413,7 @@
 	req_access_txt = "240";
 	pixel_x = -28
 	},
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /turf/open/floor/corsat/spiralplate,
 /area/rostock/lowerdeck_maint/s_f)
 "qhX" = (
@@ -21615,7 +21603,7 @@
 /turf/open/floor/corsat/spiralplate,
 /area/rostock/lowerdeck_maint/p_a)
 "qqC" = (
-/obj/structure/machinery/power/apc/power/west,
+/obj/structure/machinery/power/apc/upp/west,
 /turf/open/floor/strata/multi_tiles/southeast,
 /area/rostock/lower_deck/s_a_hallway)
 "qqG" = (
@@ -21762,7 +21750,7 @@
 /turf/open/floor/plating/plating_catwalk/strata,
 /area/rostock/lower_deck/p_a_hallway)
 "qxy" = (
-/obj/structure/machinery/power/apc/power/south,
+/obj/structure/machinery/power/apc/upp/south,
 /turf/open/floor/corsat/plate,
 /area/rostock/security/headquarters_armory)
 "qxO" = (
@@ -22170,7 +22158,7 @@
 	pixel_x = 12;
 	pixel_y = 12
 	},
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /turf/open/floor/corsat/spiralplate,
 /area/rostock/lowerdeck_maint/p_a)
 "qPi" = (
@@ -22427,7 +22415,7 @@
 	icon_state = "pottedplant_22";
 	pixel_y = 6
 	},
-/obj/structure/machinery/power/apc/power/west,
+/obj/structure/machinery/power/apc/upp/west,
 /turf/open/floor/strata/red4/west,
 /area/rostock/security/brig_accessway)
 "qYy" = (
@@ -22760,7 +22748,7 @@
 /area/rostock/hangar/hangarbay)
 "rkL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/machinery/power/apc/power/west,
+/obj/structure/machinery/power/apc/upp/west,
 /turf/open/floor/corsat/spiralplate,
 /area/rostock/upperdeck_maint/s_m)
 "rkR" = (
@@ -22809,7 +22797,7 @@
 /turf/open/floor/corsat/spiralplate,
 /area/rostock/upperdeck_maint/s_f)
 "rmX" = (
-/obj/structure/machinery/power/apc/power/south,
+/obj/structure/machinery/power/apc/upp/south,
 /turf/open/floor/carpet,
 /area/rostock/command/polcom)
 "rnj" = (
@@ -23197,7 +23185,7 @@
 	pixel_y = 6;
 	pixel_x = -12
 	},
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /turf/open/floor/strata/red4/north,
 /area/rostock/security/brig_entryway)
 "rDE" = (
@@ -24920,7 +24908,7 @@
 /obj/structure/pipes/vents/pump{
 	dir = 1
 	},
-/obj/structure/machinery/power/apc/power/south,
+/obj/structure/machinery/power/apc/upp/south,
 /turf/open/floor/wood,
 /area/rostock/command/xo)
 "tiN" = (
@@ -25253,7 +25241,7 @@
 /obj/item/reagent_container/food/drinks/bottle/vodka{
 	pixel_x = 6
 	},
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /turf/open/floor/strata/fake_wood,
 /area/rostock/command/dining)
 "tup" = (
@@ -25953,7 +25941,7 @@
 /obj/effect/decal/strata_decals/grime/grime4{
 	dir = 1
 	},
-/obj/structure/machinery/power/apc/power/west,
+/obj/structure/machinery/power/apc/upp/west,
 /obj/structure/closet/coffin{
 	name = "\improper UPP coffin";
 	desc = "A burial receptacle for for the fallen, adorned in red and finished with the emblem of the union. Unity through Strength, Freedom through Unity"
@@ -26580,7 +26568,7 @@
 	icon_state = "triagedecalbottomleft";
 	pixel_y = 18
 	},
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /turf/open/floor/almayer/silverfull,
 /area/rostock/medical/lobby)
 "uvW" = (
@@ -26723,7 +26711,7 @@
 /area/rostock/lower_deck/prep)
 "uEN" = (
 /obj/structure/largecrate/supply/medicine/medivend,
-/obj/structure/machinery/power/apc/power/west,
+/obj/structure/machinery/power/apc/upp/west,
 /turf/open/floor/almayer/sterile_green,
 /area/rostock/medical/storage)
 "uEV" = (
@@ -26743,6 +26731,7 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/machinery/power/apc/upp/south,
 /turf/open/floor/strata/floor3,
 /area/rostock/security/brig_holding_area)
 "uHu" = (
@@ -26957,7 +26946,7 @@
 /obj/item/stack/sheet/metal/large_stack,
 /obj/item/stack/sheet/plasteel/large_stack,
 /obj/item/stack/sheet/plasteel/large_stack,
-/obj/structure/machinery/power/apc/power/south,
+/obj/structure/machinery/power/apc/upp/south,
 /turf/open/floor/strata/red1,
 /area/rostock/command/armory)
 "uQa" = (
@@ -27013,6 +27002,17 @@
 "uRe" = (
 /turf/closed/wall/upp_ship/reinforced,
 /area/rostock/command/so)
+"uRK" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/camera/autoname/almayer{
+	name = "rostock camera";
+	network = list("Rostock");
+	dir = 1
+	},
+/turf/open/floor/strata/fake_wood,
+/area/rostock/security/brig_holding_area)
 "uRW" = (
 /turf/open/floor/strata/orange_icorner,
 /area/rostock/lifeboat)
@@ -27149,7 +27149,7 @@
 	dir = 1;
 	light_color = "#ffd4d4"
 	},
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /turf/open/floor/corsat/plate,
 /area/rostock/lowerdeck_maint/s_a)
 "uZe" = (
@@ -28024,7 +28024,7 @@
 /turf/open/floor/prison/floor_plate,
 /area/rostock/engineering/main_area)
 "vFs" = (
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/rostock/lowerdeck_maint/s_m)
 "vFy" = (
@@ -28568,7 +28568,7 @@
 	pixel_x = 9;
 	pixel_y = -11
 	},
-/obj/structure/machinery/power/apc/power/east,
+/obj/structure/machinery/power/apc/upp/east,
 /turf/open/floor/strata/floor2,
 /area/rostock/lower_deck/bunk)
 "vXE" = (
@@ -28731,7 +28731,7 @@
 	dir = 8;
 	pixel_y = 3
 	},
-/obj/structure/machinery/power/apc/power/east,
+/obj/structure/machinery/power/apc/upp/east,
 /turf/open/floor/strata/floor3/east,
 /area/rostock/lower_deck/kitchen)
 "wcu" = (
@@ -28788,7 +28788,7 @@
 /turf/open/floor/almayer/tcomms,
 /area/rostock/upperdeck_maint/p_a)
 "wea" = (
-/obj/structure/machinery/power/apc/power/south,
+/obj/structure/machinery/power/apc/upp/south,
 /turf/open/floor/carpet,
 /area/rostock/command/co)
 "weh" = (
@@ -29002,7 +29002,7 @@
 	icon_state = "W";
 	pixel_x = -1
 	},
-/obj/structure/machinery/power/apc/power/east,
+/obj/structure/machinery/power/apc/upp/east,
 /turf/open/floor/strata/multi_tiles/west,
 /area/rostock/hangar/hangarbay)
 "wlm" = (
@@ -29427,7 +29427,7 @@
 /turf/open/floor/almayer/silverfull,
 /area/rostock/medical/chemistry)
 "wDv" = (
-/obj/structure/machinery/power/apc/power/south,
+/obj/structure/machinery/power/apc/upp/south,
 /turf/open/floor/almayer/silverfull,
 /area/rostock/medical/accessway)
 "wDZ" = (
@@ -29950,7 +29950,7 @@
 	pixel_x = 2;
 	pixel_y = -1
 	},
-/obj/structure/machinery/power/apc/power/west,
+/obj/structure/machinery/power/apc/upp/west,
 /turf/open/floor/almayer/plating/northeast,
 /area/rostock/ert_dock/starboard)
 "xct" = (
@@ -30393,7 +30393,7 @@
 /turf/open/floor/strata/multi_tiles/southeast,
 /area/rostock/lower_deck/s_a_hallway)
 "xtL" = (
-/obj/structure/machinery/power/apc/power/west,
+/obj/structure/machinery/power/apc/upp/west,
 /turf/open/floor/almayer/cargo_arrow,
 /area/rostock/lower_deck/prep)
 "xun" = (
@@ -30438,7 +30438,7 @@
 /turf/open/floor/corsat/plate,
 /area/rostock/lower_deck/p_hallway)
 "xvT" = (
-/obj/structure/machinery/power/apc/power/north,
+/obj/structure/machinery/power/apc/upp/north,
 /obj/structure/pipes/vents/pump,
 /turf/open/floor/strata/floor2,
 /area/rostock/lifeboat)
@@ -31149,7 +31149,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/rostock/medical/surgery)
 "yaZ" = (
-/obj/structure/machinery/power/apc/power/west,
+/obj/structure/machinery/power/apc/upp/west,
 /turf/open/floor/strata/floor2,
 /area/rostock/lower_deck/p_a_hallway)
 "ybI" = (
@@ -31394,7 +31394,7 @@
 	light_color = "#66ccff";
 	invisibility = 101
 	},
-/obj/structure/machinery/power/apc/power/east,
+/obj/structure/machinery/power/apc/upp/east,
 /obj/effect/landmark/start/upp{
 	name = "UPP soldier join";
 	job_list = list("UPP Ryadovoy","UPP MSzht Engineer","UPP MSzht Medic","UPP Serzhant","UPP Starshiy Serzhant")
@@ -45895,7 +45895,7 @@ kSD
 pjY
 oRz
 jiy
-guf
+acl
 acL
 acD
 acv
@@ -46077,7 +46077,7 @@ lPy
 lPy
 eKA
 gYI
-guf
+acl
 acM
 acD
 acw
@@ -46622,7 +46622,7 @@ ogL
 trk
 ogL
 ogL
-arp
+uRK
 guf
 acP
 acs

--- a/maps/templates/ssv_rostock.dmm
+++ b/maps/templates/ssv_rostock.dmm
@@ -1507,6 +1507,17 @@
 	},
 /turf/open/floor/strata/fake_wood,
 /area/rostock/command/dining)
+"arp" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/camera/autoname/almayer{
+	name = "rostock camera";
+	network = list("Rostock");
+	dir = 1
+	},
+/turf/open/floor/strata/fake_wood,
+/area/rostock/security/brig_holding_area)
 "art" = (
 /obj/structure/machinery/door/poddoor/almayer{
 	name = "\improper Umbillical Airlock";
@@ -9746,7 +9757,9 @@
 /turf/open/floor/corsat/spiralplate,
 /area/rostock/medical/morgue)
 "gYI" = (
-/obj/structure/window/framed/upp_ship/reinforced,
+/obj/structure/window/framed/upp_ship/reinforced{
+	desc = "A glass window. Light refracts incorrectly when looking through. It seems weaker than the other windows in the area, but still rather strong."
+	},
 /obj/structure/machinery/door/poddoor/almayer/open{
 	dir = 4;
 	id = "uppbrig1";
@@ -9758,7 +9771,7 @@
 	name = "\improper Entrance Shutters"
 	},
 /turf/open/floor/plating,
-/area/rostock/security/brig_entryway)
+/area/rostock/security/brig_holding_area)
 "gZL" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -12790,13 +12803,9 @@
 	name = "Entrance Shutter";
 	req_one_access = list(230, 240)
 	},
-/obj/structure/machinery/camera/autoname/almayer{
-	name = "rostock camera";
-	network = list("Rostock");
-	dir = 1
-	},
+/obj/structure/machinery/power/apc/power/south,
 /turf/open/floor/strata/red2,
-/area/rostock/security/brig_entryway)
+/area/rostock/security/brig_holding_area)
 "jiF" = (
 /obj/structure/barricade/handrail{
 	pixel_x = 2
@@ -20203,6 +20212,11 @@
 	req_access = list(230);
 	req_one_access = null
 	},
+/obj/structure/machinery/camera/autoname/almayer{
+	name = "rostock camera";
+	network = list("Rostock");
+	dir = 4
+	},
 /turf/open/floor/almayer/cargo,
 /area/rostock/security/brig_entryway)
 "pmQ" = (
@@ -23993,6 +24007,11 @@
 /area/rostock/upperdeck_maint/p_a)
 "snr" = (
 /obj/structure/machinery/seed_extractor,
+/obj/structure/machinery/camera/autoname/almayer{
+	name = "rostock camera";
+	network = list("Rostock");
+	dir = 8
+	},
 /turf/open/floor/strata/purp3/west,
 /area/rostock/security/brig_holding_area)
 "snF" = (
@@ -26721,7 +26740,6 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
 	},
-/obj/structure/machinery/power/apc/power/south,
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
@@ -45877,7 +45895,7 @@ kSD
 pjY
 oRz
 jiy
-acl
+guf
 acL
 acD
 acv
@@ -46059,7 +46077,7 @@ lPy
 lPy
 eKA
 gYI
-acl
+guf
 acM
 acD
 acw
@@ -46604,7 +46622,7 @@ ogL
 trk
 ogL
 ogL
-ddO
+arp
 guf
 acP
 acs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

- UPP hull windows did not have their undamagable flags (among other things), now added, which makes exterior and _most_ prisoner_ holding windows indestructable
- UPP ship APCs given new subtype with access only for UPP engineering
- Additional cameras in UPP Prisoner holding

# Explain why it's good for the game

- The windows were meant to be indestructable in the first place, just adding the missing variables
- APCs in the UPP ship should not be accessible by only USMC and civilians
- Additional cameras in prisoner holding to remove deadzones (until someone destroys them ofc)

# Testing Photographs and Procedure

Loaded up SSV Rostock and verified the following

1. UPP prisoner Holding windows (except one by entrance) indestructible, alongside exterior windows
2. 

<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/276b3dbe-7e4a-4180-adc2-dceb805ed569)

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: APCs in SSV Rostock now use a UPP subtype that only allows UPP engineers access
fix: UPP hull windows now act like USMC hull windows and cannot be destroyed
maptweak: Additional cameras added to SSV Rostock Prisoner Holding
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
