### PR TITLE
Makes xeno resin doors unacidable

### DIFF
--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -361,6 +361,7 @@
 	mineralType = "resin"
 	hardness = 1.5
 	health = HEALTH_DOOR_XENO
+	unacidable = TRUE
 	var/close_delay = 100
 	var/hivenumber = XENO_HIVE_NORMAL
 


### PR DESCRIPTION

# About the pull request

Prevents xenos from aciding xeno doors. Fixes #9339 

# Explain why it's good for the game

Xenos cannot acid resin walls. This has been a fact for 7 years now since the original commit from CM Devs: https://github.com/cmss13-devs/cmss13/blob/4f694c8ca3d5f1a57039de016586458cc775acc4/code/game/turfs/walls/wall_types.dm#L1367-L1368

The fact that xeno doors can be melted is an oversight that this PR now fixes.

In XvX cases, xenos will need to slash down blocking doors. Same as they do with hostile resin walls.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Nothing.

</details>


# Changelog

:cl: KornFlaks
fix: Xenos can no longer acid resin doors.
/:cl:
