### PR TITLE
Dropping crew monitor now closes the UI

### DIFF
--- a/code/game/objects/items/tools/experimental_tools.dm
+++ b/code/game/objects/items/tools/experimental_tools.dm
@@ -22,7 +22,7 @@
 
 /obj/item/tool/crew_monitor/dropped(mob/user)
 	. = ..()
-	SStgui.close_uis(src)
+	SStgui.close_uis(radar)
 
 /obj/item/clothing/suit/auto_cpr
 	name = "autocompressor" //autocompressor


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Tracking down reference strings back to original objects ain't fun.

Fixes: #9296 

# Explain why it's good for the game

No more remote crew monitoring UI.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

None.

</details>


# Changelog

:cl: KornFlaks
fix: Dropping handheld crew monitor now properly closes the UI.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
