### PR TITLE
Weapons in scabbards can now be used for reverse bursting

### DIFF
--- a/code/__DEFINES/equipment.dm
+++ b/code/__DEFINES/equipment.dm
@@ -574,6 +574,8 @@ GLOBAL_LIST_INIT(uniform_categories, list(
 #define STORAGE_ALLOW_QUICKDRAW (1<<11)
 /// Whether using this item will try not to empty it if possible
 #define STORAGE_DISABLE_USE_EMPTY (1<<12)
+/// Whether the user can withdraw the items in storage while being hauled by a xeno
+#define STORAGE_ALLOW_WHILE_HAULED (1<<13)
 
 #define STORAGE_FLAGS_DEFAULT (STORAGE_SHOW_FULLNESS|STORAGE_GATHER_SIMULTAENOUSLY|STORAGE_ALLOW_EMPTY)
 #define STORAGE_FLAGS_BOX (STORAGE_FLAGS_DEFAULT)

--- a/code/game/objects/items/storage/large_holster.dm
+++ b/code/game/objects/items/storage/large_holster.dm
@@ -10,7 +10,7 @@
 	max_w_class = SIZE_LARGE
 	storage_slots = 1
 	max_storage_space = 4
-	storage_flags = STORAGE_FLAGS_DEFAULT|STORAGE_USING_DRAWING_METHOD|STORAGE_ALLOW_QUICKDRAW
+	storage_flags = STORAGE_FLAGS_DEFAULT|STORAGE_USING_DRAWING_METHOD|STORAGE_ALLOW_QUICKDRAW|STORAGE_ALLOW_WHILE_HAULED
 	///Icon/item states change based on contents; this stores base icon state.
 	var/base_icon
 	var/drawSound = 'sound/weapons/gun_rifle_draw.ogg'

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -1631,7 +1631,7 @@
 		WEAR_R_HAND = 'icons/mob/humans/onmob/inhands/clothing/belts_righthand.dmi'
 	)
 	max_w_class = SIZE_LARGE
-	storage_flags = STORAGE_FLAGS_POUCH|STORAGE_USING_DRAWING_METHOD|STORAGE_ALLOW_QUICKDRAW
+	storage_flags = STORAGE_FLAGS_POUCH|STORAGE_USING_DRAWING_METHOD|STORAGE_ALLOW_QUICKDRAW|STORAGE_ALLOW_WHILE_HAULED
 	can_hold = list(/obj/item/weapon/sword/machete)
 
 	var/sheathe_sound = 'sound/weapons/gun_rifle_draw.ogg'

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -641,7 +641,7 @@ W is always an item. stop_warning prevents messaging. user may be null.**/
 	return handle_item_insertion(W, prevent_warning, user)
 
 /obj/item/storage/attack_hand(mob/user, mods)
-	if(HAS_TRAIT(user, TRAIT_HAULED))
+	if(HAS_TRAIT(user, TRAIT_HAULED) && !HAS_FLAG(storage_flags, STORAGE_ALLOW_WHILE_HAULED))
 		return
 	if (loc == user)
 		if((mods && mods[ALT_CLICK] || storage_flags & STORAGE_USING_DRAWING_METHOD) && ishuman(user) && length(contents)) //Alt mod can reach attack_hand through the clicked() override.


### PR DESCRIPTION
# About the pull request

Large weapon scabbards like shotgun scabbards and m39 holsters can now be opened while being hauled by xenos. This is so that you can use the weapons within to reverse burst from a xeno. Also included is the machete pouch which similar to the machete scabbard can be withdrawn while hauled for bursting.

Fixes: #9299

# Explain why it's good for the game

Guns on armor and belt holsters can already be used to kill xenos from within. Now weapons in scabbards on armor and back slots can be accessed for stabbing your way out of a xeno kidnapping you.

This allows machete pouch, shogun scabbard, machete / sword scabbard, smartgunner machete scabbard, M39 holster, and pyro spec backpack fuel tank to be withdrawn while hauled for reverse bursting.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

None.

</details>


# Changelog

:cl: KornFlaks
add: Weapons in scabbards can now be accessed while hauled for reverse bursting. This also includes the machete pouch.
/:cl:
