### PR TITLE
Health scanners can no longer scan xenos

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -96,18 +96,21 @@ K9 SCANNER
 	QDEL_NULL(last_health_display)
 	return ..()
 
-/obj/item/device/healthanalyzer/attack(mob/living/M, mob/living/user)
+/obj/item/device/healthanalyzer/attack(mob/living/target_mob, mob/living/user)
+	if(!istype(target_mob, /mob/living/carbon) || isxeno(target_mob))
+		to_chat(user, SPAN_WARNING("[src] can't make sense of this creature."))
+		return
 	if(!popup_window)
-		last_scan = M.health_scan(user, FALSE, TRUE, popup_window, alien)
+		last_scan = target_mob.health_scan(user, FALSE, TRUE, popup_window, alien)
 	else
 		if (!last_health_display)
-			last_health_display = new(M)
+			last_health_display = new(target_mob)
 		else
-			last_health_display.target_mob = M
+			last_health_display.target_mob = target_mob
 		SStgui.close_user_uis(user, src)
 		last_scan = last_health_display.ui_data(user, DETAIL_LEVEL_HEALTHANALYSER)
 		last_health_display.look_at(user, DETAIL_LEVEL_HEALTHANALYSER, bypass_checks = FALSE, ignore_delay = FALSE, alien = alien)
-	to_chat(user, SPAN_NOTICE("[user] has analyzed [M]'s vitals."))
+	to_chat(user, SPAN_NOTICE("[user] has analyzed [target_mob]'s vitals."))
 	playsound(src.loc, 'sound/items/healthanalyzer.ogg', 50)
 	src.add_fingerprint(user)
 	return

--- a/code/modules/mob/living/living_healthscan.dm
+++ b/code/modules/mob/living/living_healthscan.dm
@@ -32,15 +32,12 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 			to_chat(usr, SPAN_WARNING("You don't have the dexterity to do this!"))
 			return
 		if(!ignore_delay && !skillcheck(user, SKILL_MEDICAL, SKILL_MEDICAL_MEDIC))
-			to_chat(user, SPAN_WARNING("You start fumbling around with [target_mob]..."))
+			to_chat(user, SPAN_WARNING("You start fumbling around with the scanner..."))
 			var/fduration = 60
 			if(skillcheck(user, SKILL_MEDICAL, SKILL_MEDICAL_DEFAULT))
 				fduration = 30
 			if(!do_after(user, fduration, INTERRUPT_NO_NEEDHAND, BUSY_ICON_FRIENDLY) || !user.Adjacent(target_mob))
 				return
-		if(!istype(target_mob, /mob/living/carbon) || isxeno(target_mob))
-			to_chat(user, SPAN_WARNING("The scanner can't make sense of this creature."))
-			return
 
 	detail_level = detail
 	tgui_interact(user, ui)
@@ -526,9 +523,6 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 				fduration = 30
 			if(!do_after(user, fduration, INTERRUPT_NO_NEEDHAND, BUSY_ICON_FRIENDLY) || !user.Adjacent(src))
 				return
-		if(isxeno(src))
-			to_chat(user, SPAN_WARNING("[src] can't make sense of this creature."))
-			return
 		// Doesn't work on non-humans
 		if(!istype(src, /mob/living/carbon))
 			user.show_message("\nHealth Analyzer results for ERROR:\n\t Overall Status: ERROR")


### PR DESCRIPTION
# About the pull request

Fixes: #9258

This PR moves the check for xeno to before the health scan is printed so you cannot bypass the check by looking at last scan.

# Explain why it's good for the game

Xeno bodies are not intended to be analyzed by health scanners. 

# Testing Photographs and Procedure

None.


# Changelog

:cl: KornFlaks
fix: Xenos are no longer health scannable.
/:cl:
