### PR TITLE
Xenos now heal at normal speed when not on fire

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -307,7 +307,7 @@ Make sure their actual health updates immediately.*/
 
 /mob/living/carbon/xenomorph/proc/handle_environment()
 	var/turf/T = loc
-	var/recoveryActual = (!caste || (caste.fire_immunity & FIRE_IMMUNITY_NO_IGNITE) || fire_stacks == 0) ? recovery_aura : 0
+	var/recoveryActual = (!caste || (caste.fire_immunity & FIRE_IMMUNITY_NO_IGNITE) || !on_fire) ? recovery_aura : 0
 	var/env_temperature = loc.return_temperature()
 	if(caste && !(caste.fire_immunity & FIRE_IMMUNITY_NO_DAMAGE))
 		if(env_temperature > (T0C + 66))


### PR DESCRIPTION
# About the pull request

Current healing checks if there are any fire stacks currently on the xeno, not if the xeno is actually on fire.
Xenos with fire stacks while not on fire is basically a rag soaked in petrol, very flammable but not harmed.

Fixes: #9363 and xeno ignition immunity boon healing slowly while not on fire.

# Explain why it's good for the game

Xenos not on fire should not have healing penalized for flame stacks that have yet to be lit on fire.

# Testing Photographs and Procedure

None.


# Changelog

:cl: KornFlaks
fix: Xenos now heal at full speed while not on fire.
/:cl:
