### PR TITLE
Makes Weedkiller Legit

### DIFF
--- a/code/game/objects/effects/effect_system/chemsmoke.dm
+++ b/code/game/objects/effects/effect_system/chemsmoke.dm
@@ -113,11 +113,11 @@
 	//reagent application - only run if there are extra reagents in the smoke
 	if(length(chemholder.reagents.reagent_list))
 		for(var/datum/reagent/R in chemholder.reagents.reagent_list)
-			var/proba = 100
+			var/proba = 20
 			var/runs = 5
 
 			//dilute the reagents according to cloud density
-			R.volume /= density
+			R.volume *= POTENCY_MULTIPLIER_VVLOW / (density * runs * range)
 			chemholder.reagents.update_total()
 
 			//apply wall affecting reagents to walls
@@ -136,18 +136,17 @@
 			spawn(0)
 				for(var/i = 0, i < runs, i++)
 					for(var/turf/T in targetTurfs)
-						if(prob(proba))
-							R.reaction_turf(T, R.volume)
+						if (!prob(proba))
+							continue
+						var/volume = R.volume / max(1, cheap_pythag(T.x - location.x, T.y - location.y))
+						R.reaction_turf(T, volume)
 						for(var/atom/A in T.contents)
 							if(istype(A, /obj/effect/particle_effect/smoke/chem)) //skip the item if it is chem smoke
 								continue
 							else if(istype(A, /mob))
-								var/dist = cheap_pythag(T.x - location.x, T.y - location.y)
-								if(!dist)
-									dist = 1
-								R.reaction_mob(A, volume = R.volume * POTENCY_MULTIPLIER_VLOW / dist, permeable = FALSE)
+								R.reaction_mob(A, TOUCH, volume, FALSE)
 							else if(istype(A, /obj))
-								R.reaction_obj(A, R.volume)
+								R.reaction_obj(A, volume)
 					sleep(3 SECONDS)
 
 

--- a/code/game/objects/items/backpack_sprayers.dm
+++ b/code/game/objects/items/backpack_sprayers.dm
@@ -18,6 +18,9 @@
 
 	var/obj/item/noz
 
+	var/last_fired = 0
+	var/fire_delay = FIRE_DELAY_TIER_5 * 3 // 40% faster than flamer to fire.
+
 /obj/item/reagent_container/glass/watertank/Initialize()
 	. = ..()
 	if(!spawn_empty)
@@ -177,7 +180,10 @@
 		to_chat(user, SPAN_WARNING("The safety is on!"))
 		return
 
+	if (world.time - W.last_fired < W.fire_delay)
+		return
 
+	W.last_fired = world.time
 	Spray_at(A, user)
 
 	playsound(src.loc, 'sound/effects/spray2.ogg', 25, 1, 3)

--- a/code/modules/reagents/chemistry_properties/prop_negative.dm
+++ b/code/modules/reagents/chemistry_properties/prop_negative.dm
@@ -86,7 +86,8 @@
 	if(!iscarbon(M))
 		return
 	var/mob/living/carbon/C = M
-	if(C.wear_mask) // Wearing a mask
+	// Higher concentration, less effective gas mask.
+	if(method == TOUCH && C.wear_mask && !prob(100 * min(volume * 5, 1))) // Wearing a mask
 		return
 	C.apply_damage(potency, TOX)  // applies potency toxin damage
 

--- a/code/modules/reagents/chemistry_properties/prop_negative.dm
+++ b/code/modules/reagents/chemistry_properties/prop_negative.dm
@@ -86,8 +86,8 @@
 	if(!iscarbon(M))
 		return
 	var/mob/living/carbon/C = M
-	// Higher concentration, less effective gas mask.
-	if(method == TOUCH && C.wear_mask && !prob(100 * min(volume * 5, 1))) // Wearing a mask
+	// Gas masks only block airborne chems.
+	if(method == TOUCH && (C.wear_mask && (C.wear_mask.flags_inventory & BLOCKGASEFFECT)))
 		return
 	C.apply_damage(potency, TOX)  // applies potency toxin damage
 

--- a/code/modules/reagents/chemistry_properties/prop_negative.dm
+++ b/code/modules/reagents/chemistry_properties/prop_negative.dm
@@ -49,20 +49,27 @@
 /datum/chem_property/negative/toxic/process_critical(mob/living/M, potency = 1)
 	M.apply_damage(potency * POTENCY_MULTIPLIER_VHIGH, TOX)
 
-/datum/chem_property/negative/toxic/reaction_obj(obj/O, volume, potency = 1)
-	if(istype(O,/obj/effect/alien/weeds/))
-		var/obj/effect/alien/weeds/alien_weeds = O
-		alien_weeds.take_damage(25 * potency) // Kills alien weeds on touch
+/datum/chem_property/negative/toxic/reaction_obj(obj/object, volume, potency = 1)
+	if(istype(object,/obj/effect/alien/weeds/))
+		var/obj/effect/alien/weeds/alien_weeds = object
+		var/damage_multi = 15
+
+		// Reduces damage from chemicals acting as weedkiller (e.g., welder fuel).
+		if (alien_weeds.weed_strength >= WEED_LEVEL_HARDY)
+			damage_multi /= WEED_LEVEL_HARDY
+
+		// Kills alien weeds on touch.
+		alien_weeds.take_damage(damage_multi * potency)
 		return
-	if(istype(O,/obj/effect/glowshroom))
-		qdel(O)
+	if(istype(object,/obj/effect/glowshroom))
+		qdel(object)
 		return
-	if(istype(O,/obj/effect/plantsegment))
+	if(istype(object,/obj/effect/plantsegment))
 		if(prob(50))
-			qdel(O)
+			qdel(object)
 		return
-	if(istype(O,/obj/structure/machinery/portable_atmospherics/hydroponics))
-		var/obj/structure/machinery/portable_atmospherics/hydroponics/tray = O
+	if(istype(object,/obj/structure/machinery/portable_atmospherics/hydroponics))
+		var/obj/structure/machinery/portable_atmospherics/hydroponics/tray = object
 
 		if(!tray.seed)
 			return


### PR DESCRIPTION
# About the pull request

An alternative to #9184 that actually does what the title says it'll do.

Despite not being intended, weedkiller with welding fuel has become more popular and numerous bugs / exploits have been reported from its use. This PR is not removing weedkiller, rather it's adding firing delay to the water-tank version, making smoke not spread massive amounts of chemicals, and fortifying stronger weed types to weedkillers.

Regular weeds take 1 shot from water-tank sprayer and smoke version, hardy weeds take 2 shots from sprayer and smoke, hive weeds take 2 shots from sprayer and 3 from smoke. All numbers use max range sprays so spraying closer to you will mean you can one-shot hive weed with sprayer if you fire only 2 tiles instead of 5.

**Does not impact other gas mechanics like boiler gas, WPDP, or CCDP.**

# Explain why it's good for the game

Weedkiller spec no longer deletes hive. However, it will still be viable (the chem is just welding fuel, basically free) to annoy hives and make you a target for gibbing. An actual game mechanic from unintentional chemical properties of welder fuel.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Welding fuel gas vs regular weeds.

https://github.com/user-attachments/assets/884b797d-c5b6-409e-8558-fc75db11545d

Welding fuel gas vs hive weeds and repeated application to marines with and without gas masks.

https://github.com/user-attachments/assets/f72d882e-1977-4e7c-8812-796a5295e2df


</details>


# Changelog

:cl: KornFlaks
balance: Add firing delay to water tank sprayer.
balance: Reduced the damage that toxic chemicals have on xeno weeds.
balance: Gas masks now only reduce the effects of toxic chemical gas instead of making the marine immune.
balance: Reduced deposition of chemicals spread by smoke from chemicals and smoke flamers.
/:cl:
