### PR TITLE
Flameshape refactor

### DIFF
--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -254,10 +254,18 @@
 	set waitfor = 0
 	var/list/turf_list = RANGE_TURFS(3, impact) //This is its area of effect
 	playsound(impact, 'sound/effects/pred_vision.ogg', 20, 1)
+
+	var/datum/reagent/fire_reag = new()
+	fire_reag.intensityfire = 75
+	fire_reag.durationfire = 5
+	fire_reag.burn_sprite = "dynamic"
+	fire_reag.burncolor = "#EE6515"
+
 	for(var/i=1 to 16) //This is how many tiles within that area of effect will be randomly ignited
-		var/turf/U = pick(turf_list)
-		turf_list -= U
-		fire_spread_recur(U, create_cause_data(fired_from.name, source_mob), 1, null, 5, 75, "#EE6515")//Very, very intense, but goes out very quick
+		var/turf/U = pick_n_take(turf_list)
+		var/obj/flamer_fire/foundflame = locate() in U
+		if(!foundflame)
+			new/obj/flamer_fire(U, create_cause_data(fired_from.name, source_mob), fire_reag)//Very, very intense, but goes out very quick
 
 	if(!ammo_count && !QDELETED(src))
 		qdel(src) //deleted after last laser beam is fired and impact the ground.

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -255,7 +255,7 @@
 	var/list/turf_list = RANGE_TURFS(3, impact) //This is its area of effect
 	playsound(impact, 'sound/effects/pred_vision.ogg', 20, 1)
 
-	var/datum/reagent/fire_reag = new()
+	var/datum/reagent/fire_reag = new() //Very, very intense, but goes out very quick
 	fire_reag.intensityfire = 75
 	fire_reag.durationfire = 5
 	fire_reag.burn_sprite = "dynamic"
@@ -265,7 +265,7 @@
 		var/turf/U = pick_n_take(turf_list)
 		var/obj/flamer_fire/foundflame = locate() in U
 		if(!foundflame)
-			new/obj/flamer_fire(U, create_cause_data(fired_from.name, source_mob), fire_reag)//Very, very intense, but goes out very quick
+			new/obj/flamer_fire(U, create_cause_data(fired_from.name, source_mob), fire_reag)
 
 	if(!ammo_count && !QDELETED(src))
 		qdel(src) //deleted after last laser beam is fired and impact the ground.

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -2856,9 +2856,7 @@ Defined in conflicts.dm of the #defines folder.
 		current_turf.flamer_fire_act(0, cause_data)
 		stop_at_turf = TRUE
 	else if(prev_turf)
-		var/atom/movable/temp = new/obj/flamer_fire()
-		var/atom/movable/blocked = LinkBlocked(temp, prev_turf, current_turf)
-		qdel(temp)
+		var/atom/movable/blocked = FireLinkBlocked(prev_turf, current_turf)
 
 		if(blocked)
 			blocked.flamer_fire_act(0, cause_data)

--- a/code/modules/projectiles/guns/flamer/flamer.dm
+++ b/code/modules/projectiles/guns/flamer/flamer.dm
@@ -259,9 +259,7 @@
 	if(current_turf.density)
 		stop_at_turf = TRUE
 	else
-		var/atom/movable/temp = new /obj/flamer_fire()
-		var/atom/movable/blocked = LinkBlocked(temp, prev_turf, current_turf)
-		qdel(temp)
+		var/atom/movable/blocked = FireLinkBlocked(prev_turf, current_turf)
 
 		if(blocked)
 			if(blocked.flags_atom & ON_BORDER)

--- a/code/modules/projectiles/guns/flamer/flamer.dm
+++ b/code/modules/projectiles/guns/flamer/flamer.dm
@@ -855,7 +855,7 @@
 	else
 		weather_smothering_strength = 0
 
-/proc/fire_spread_recur(turf/target, datum/cause_data/cause_data, remaining_distance, direction, /datum/reagent/fire_reag, aerial_flame_level)
+/proc/fire_spread_recur(turf/target, datum/cause_data/cause_data, remaining_distance, direction, datum/reagent/fire_reag, aerial_flame_level)
 	var/obj/flamer_fire/foundflame = locate() in target
 	if(!foundflame)
 		new/obj/flamer_fire(target, cause_data, fire_reag)

--- a/code/modules/projectiles/guns/flamer/flamer.dm
+++ b/code/modules/projectiles/guns/flamer/flamer.dm
@@ -249,7 +249,7 @@
 	process_flame_tiles(temp, target, user, chem, max_range, flameshape, fire_type)
 
 /obj/item/weapon/gun/flamer/proc/process_flame_tiles(list/turfs, atom/target, mob/living/user, datum/reagent/chem, max_range, flameshape, fire_type)
-	if(length(turfs) < 2) // prevents unleasing flame underneath user
+	if(length(turfs) < 2) // prevents unleashing flame underneath user
 		return
 
 	var/turf/prev_turf = turfs[1] // from get_line proc will be turf under user

--- a/code/modules/projectiles/guns/flamer/flamer.dm
+++ b/code/modules/projectiles/guns/flamer/flamer.dm
@@ -855,32 +855,19 @@
 	else
 		weather_smothering_strength = 0
 
-/proc/fire_spread_recur(turf/target, datum/cause_data/cause_data, remaining_distance, direction, fire_lvl, burn_lvl, f_color, burn_sprite = "dynamic", aerial_flame_level)
-	var/direction_angle = dir2angle(direction)
+/proc/fire_spread_recur(turf/target, datum/cause_data/cause_data, remaining_distance, direction, /datum/reagent/fire_reag, aerial_flame_level)
 	var/obj/flamer_fire/foundflame = locate() in target
 	if(!foundflame)
-		var/datum/reagent/fire_reag = new()
-		fire_reag.intensityfire = burn_lvl
-		fire_reag.durationfire = fire_lvl
-		fire_reag.burn_sprite = burn_sprite
-		fire_reag.burncolor = f_color
 		new/obj/flamer_fire(target, cause_data, fire_reag)
 	if(target.density)
 		return
 
-	for(var/spread_direction in GLOB.alldirs)
-
+	for(var/angle in list(-45, 0, 45))
 		var/spread_power = remaining_distance
+		var/spread_direction = turn(direction, angle)
 
-		var/spread_direction_angle = dir2angle(spread_direction)
-
-		var/angle = 180 - abs( abs( direction_angle - spread_direction_angle ) - 180 ) // the angle difference between the spread direction and initial direction
-
-		switch(angle) //this reduces power when the explosion is going around corners
-			if (45)
-				spread_power *= 0.75
-			if (90 to 180) //turns out angles greater than 90 degrees almost never happen. This bit also prevents trying to spread backwards
-				continue
+		if(angle != 0)
+			spread_power *= 0.75
 
 		switch(spread_direction)
 			if(NORTH,SOUTH,EAST,WEST)
@@ -904,7 +891,7 @@
 				break
 
 		spawn(0)
-			fire_spread_recur(picked_turf, cause_data, spread_power, spread_direction, fire_lvl, burn_lvl, f_color, burn_sprite, aerial_flame_level)
+			fire_spread_recur(picked_turf, cause_data, spread_power, spread_direction, fire_reag, aerial_flame_level)
 
 /proc/fire_spread(turf/target, datum/cause_data/cause_data, range, fire_lvl, burn_lvl, f_color, burn_sprite = "dynamic", aerial_flame_level = TURF_PROTECTION_NONE)
 	var/datum/reagent/fire_reag = new()
@@ -928,7 +915,7 @@
 			var/area/picked_area = get_area(picked_turf)
 			if(CEILING_IS_PROTECTED(picked_area?.ceiling, get_ceiling_protection_level(aerial_flame_level)))
 				continue
-		fire_spread_recur(picked_turf, cause_data, spread_power, direction, fire_lvl, burn_lvl, f_color, burn_sprite, aerial_flame_level)
+		fire_spread_recur(picked_turf, cause_data, spread_power, direction, fire_reag, aerial_flame_level)
 
 // So it doens't do the spinny animation
 /obj/flamer_fire/onZImpact(turf/impact_turf, height)

--- a/code/modules/projectiles/guns/flamer/flamer.dm
+++ b/code/modules/projectiles/guns/flamer/flamer.dm
@@ -244,29 +244,21 @@
 	var/max_range = chem.rangefire
 	if(chem.rangefire == -1)
 		max_range = current_mag.reagents.max_fire_rad
-	var/distance = 0
 
 	var/turf/temp[] = get_line(get_turf(user), get_turf(target))
-	process_flame_tiles(temp, target, user, chem, max_range, flameshape, fire_type, distance, null, FALSE)
+	process_flame_tiles(temp, target, user, chem, max_range, flameshape, fire_type)
 
-/obj/item/weapon/gun/flamer/proc/process_flame_tiles(list/turfs, atom/target, mob/living/user, datum/reagent/chem, max_range, flameshape, fire_type, distance, turf/prev_turf, stop_at_turf)
-	if(!length(turfs))
+/obj/item/weapon/gun/flamer/proc/process_flame_tiles(list/turfs, atom/target, mob/living/user, datum/reagent/chem, max_range, flameshape, fire_type)
+	if(length(turfs) < 2) // prevents unleasing flame underneath user
 		return
 
-	var/turf/current_turf = turfs[1]
-	turfs.Cut(1, 2)
+	var/turf/prev_turf = turfs[1] // from get_line proc will be turf under user
+	var/turf/current_turf = turfs[2] // first turf to unleash flame onto
 
-	if(current_turf == user.loc)
-		prev_turf = current_turf
-		addtimer(CALLBACK(src, PROC_REF(process_flame_tiles), turfs, target, user, chem, max_range, flameshape, fire_type, distance, prev_turf, stop_at_turf), 1, TIMER_UNIQUE)
-		return
-
-	if(distance >= max_range)
-		return
-
+	var/stop_at_turf = FALSE
 	if(current_turf.density)
 		stop_at_turf = TRUE
-	else if(prev_turf)
+	else
 		var/atom/movable/temp = new /obj/flamer_fire()
 		var/atom/movable/blocked = LinkBlocked(temp, prev_turf, current_turf)
 		qdel(temp)
@@ -281,9 +273,6 @@
 		playsound(current_turf, src.get_fire_sound(), 50, TRUE)
 		show_percentage(user)
 		return
-
-	distance++
-	prev_turf = current_turf
 
 	playsound(current_turf, src.get_fire_sound(), 50, TRUE)
 

--- a/code/modules/projectiles/guns/flamer/flameshape.dm
+++ b/code/modules/projectiles/guns/flamer/flameshape.dm
@@ -3,6 +3,8 @@
 #define FIRE_CANPASS_STOP_BORDER 3 // found dense atom on border
 #define FIRE_CANPASS_STOP 4 // found space
 
+#define SET_AFLAME_LIST_SOFT_CAP 30 // prevent creating too big to be set aflame lists
+
 
 /proc/_fire_spread_check(obj/flamer_fire/F, obj/flamer_fire/mover, turf/prev_T, turf/T, burn_dam)
 	if(istype(T, /turf/open/space))
@@ -80,6 +82,10 @@
 						checked_tiles[T] = TRUE
 					if(FIRE_CANPASS_STOP)
 						checked_tiles[T] = TRUE
+
+		if(tiles_to_set_aflame.len >= SET_AFLAME_LIST_SOFT_CAP)
+			addtimer(CALLBACK(src, PROC_REF(generate_fire_list), tiles_to_set_aflame, F, FALSE, fuel_pressure), 0)
+			tiles_to_set_aflame = list()
 
 		if(next_tiles_to_spread.len == 0)
 			break
@@ -247,3 +253,5 @@ GLOBAL_LIST_INIT(flameshapes, list(
 #undef FIRE_CANPASS_SET_AFLAME
 #undef FIRE_CANPASS_STOP_BORDER
 #undef FIRE_CANPASS_STOP
+
+#undef SET_AFLAME_LIST_SOFT_CAP

--- a/code/modules/projectiles/guns/flamer/flameshape.dm
+++ b/code/modules/projectiles/guns/flamer/flameshape.dm
@@ -147,10 +147,7 @@
 	var/turf/prev_T = source_turf
 	var/list/turfs = get_line(source_turf, F.target_clicked)
 
-	if(source_turf.density) // prevents spreading through 1 tile wall
-		source_turf.flamer_fire_act(burn_dam, F.weapon_cause_data)
-		fire_spread_amount = 1
-	else if(fire_spread_amount > turfs.len)
+	if(fire_spread_amount > turfs.len)
 		fire_spread_amount = turfs.len
 
 	var/distance = 1
@@ -187,10 +184,7 @@
 	var/list/turf/turfs = get_line(source_turf, F.target_clicked)
 	var/turf/prev_T = source_turf
 
-	if(source_turf.density) // prevents spreading through 1 tile wall
-		source_turf.flamer_fire_act(burn_dam, F.weapon_cause_data)
-		fire_spread_amount = 1
-	else if(fire_spread_amount > turfs.len)
+	if(fire_spread_amount > turfs.len)
 		fire_spread_amount = turfs.len
 
 	for(var/distance in 1 to fire_spread_amount)

--- a/code/modules/projectiles/guns/flamer/flameshape.dm
+++ b/code/modules/projectiles/guns/flamer/flameshape.dm
@@ -221,9 +221,9 @@
 					tiles_to_set_aflame.Add(side_T)
 				if(FIRE_CANPASS_SET_AFLAME)
 					tiles_to_set_aflame.Add(side_T)
-					break
+					continue
 				if(FIRE_CANPASS_STOP, FIRE_CANPASS_STOP_BORDER)
-					break
+					continue
 
 		addtimer(CALLBACK(src, PROC_REF(generate_fire_list), tiles_to_set_aflame, F, FALSE, fuel_pressure), 0)
 

--- a/code/modules/projectiles/guns/flamer/flameshape.dm
+++ b/code/modules/projectiles/guns/flamer/flameshape.dm
@@ -22,14 +22,7 @@
 
 	return FIRE_CANPASS_SPREAD
 
-/datum/flameshape
-	var/name = ""
-	var/id = FLAMESHAPE_NONE
-
-/datum/flameshape/proc/handle_fire_spread(obj/flamer_fire/F, fire_spread_amount, burn_dam, fuel_pressure = 1)
-	return
-
-/datum/flameshape/proc/generate_fire(turf/T, obj/flamer_fire/F2, fs, should_call, skip_flame = FALSE, fuel_pressure = 1)
+/proc/_generate_fire(turf/T, obj/flamer_fire/F2, fs, should_call, skip_flame = FALSE, fuel_pressure = 1)
 	var/obj/flamer_fire/foundflame = locate() in T
 	if(foundflame && foundflame.tied_reagents == F2.tied_reagents && !skip_flame) // From the same flames
 		return
@@ -45,9 +38,19 @@
 	new /obj/flamer_fire(T, F2.weapon_cause_data, F2.tied_reagent, 0, F2.tied_reagents, fs, F2.target_clicked, to_call, fuel_pressure, F2.fire_variant)
 	return TRUE
 
+/datum/flameshape
+	var/name = ""
+	var/id = FLAMESHAPE_NONE
+
+/datum/flameshape/proc/handle_fire_spread(obj/flamer_fire/F, fire_spread_amount, burn_dam, fuel_pressure = 1)
+	return
+
+/datum/flameshape/proc/generate_fire(turf/T, obj/flamer_fire/F2, fs, should_call, skip_flame = FALSE, fuel_pressure = 1)
+	return _generate_fire(T, F2, fs, should_call, skip_flame, fuel_pressure)
+
 /datum/flameshape/proc/generate_fire_list(list/turf/turfs, obj/flamer_fire/F2, fs, should_call, skip_flame = FALSE, fuel_pressure = 1)
 	for(var/turf/T in turfs)
-		generate_fire(T, F2, fs, should_call, skip_flame, fuel_pressure)
+		_generate_fire(T, F2, fs, should_call, skip_flame, fuel_pressure)
 
 /datum/flameshape/default
 	name = "Default"

--- a/code/modules/projectiles/guns/flamer/flameshape.dm
+++ b/code/modules/projectiles/guns/flamer/flameshape.dm
@@ -6,6 +6,16 @@
 #define SET_AFLAME_LIST_SOFT_CAP 30 // prevent creating too big to be set aflame lists
 
 
+// Same as LinkBlocked, but for fire as mover
+/proc/FireLinkBlocked(turf/prev_T, turf/T)
+	var/static/obj/flamer_fire/eternal
+	if(QDELETED(eternal)) // initialization or in case someone was able to extinguish it in nullspace
+		eternal = new()
+		STOP_PROCESSING(SSobj, eternal) // prevent self deliting because of nullspace
+
+	return LinkBlocked(eternal, prev_T, T)
+
+
 /proc/_fire_spread_check(obj/flamer_fire/F, turf/prev_T, turf/T, burn_dam)
 	if(istype(T, /turf/open/space))
 		return FIRE_CANPASS_STOP
@@ -14,12 +24,7 @@
 		T.flamer_fire_act(burn_dam, F.weapon_cause_data)
 		return FIRE_CANPASS_SET_AFLAME
 
-	var/static/obj/flamer_fire/eternal
-	if(QDELETED(eternal)) // initialization or in case someone was able to extinguish it in nullspace
-		eternal = new()
-		STOP_PROCESSING(SSobj, eternal) // prevent self deliting because of nullspace
-
-	var/atom/A = LinkBlocked(eternal, prev_T, T)
+	var/atom/A = FireLinkBlocked(prev_T, T)
 
 	if(A)
 		A.flamer_fire_act(burn_dam, F.weapon_cause_data)

--- a/code/modules/projectiles/guns/flamer/flameshape.dm
+++ b/code/modules/projectiles/guns/flamer/flameshape.dm
@@ -52,11 +52,11 @@
 	id = FLAMESHAPE_DEFAULT
 
 /datum/flameshape/default/handle_fire_spread(obj/flamer_fire/F, fire_spread_amount, burn_dam, fuel_pressure = 1)
-	var/turf/start_turf = get_turf(F.loc)
+	var/turf/source_turf = get_turf(F.loc)
 
-	var/list/tiles_to_spread = list(start_turf)
+	var/list/tiles_to_spread = list(source_turf)
 	var/list/tiles_to_set_aflame = list()
-	var/list/checked_tiles = list(start_turf)
+	var/list/checked_tiles = list(source_turf)
 	var/obj/flamer_fire/temp = new()
 
 	for(var/spread_amount in 1 to fire_spread_amount)

--- a/code/modules/projectiles/guns/flamer/flameshape.dm
+++ b/code/modules/projectiles/guns/flamer/flameshape.dm
@@ -22,7 +22,7 @@
 
 	return FIRE_CANPASS_SPREAD
 
-/proc/_generate_fire(turf/T, obj/flamer_fire/F2, fs, should_call, skip_flame = FALSE, fuel_pressure = 1)
+/proc/_generate_fire(turf/T, obj/flamer_fire/F2, fs, should_call = FALSE, skip_flame = FALSE, fuel_pressure = 1)
 	var/obj/flamer_fire/foundflame = locate() in T
 	if(foundflame && foundflame.tied_reagents == F2.tied_reagents && !skip_flame) // From the same flames
 		return
@@ -45,10 +45,10 @@
 /datum/flameshape/proc/handle_fire_spread(obj/flamer_fire/F, fire_spread_amount, burn_dam, fuel_pressure = 1)
 	return
 
-/datum/flameshape/proc/generate_fire(turf/T, obj/flamer_fire/F2, fs, should_call, skip_flame = FALSE, fuel_pressure = 1)
+/datum/flameshape/proc/generate_fire(turf/T, obj/flamer_fire/F2, fs, should_call = FALSE, skip_flame = FALSE, fuel_pressure = 1)
 	return _generate_fire(T, F2, fs, should_call, skip_flame, fuel_pressure)
 
-/datum/flameshape/proc/generate_fire_list(list/turf/turfs, obj/flamer_fire/F2, fs, should_call, skip_flame = FALSE, fuel_pressure = 1)
+/datum/flameshape/proc/generate_fire_list(list/turf/turfs, obj/flamer_fire/F2, fs, should_call = FALSE, skip_flame = FALSE, fuel_pressure = 1)
 	for(var/turf/T in turfs)
 		_generate_fire(T, F2, fs, should_call, skip_flame, fuel_pressure)
 
@@ -94,7 +94,7 @@
 
 		tiles_to_spread = next_tiles_to_spread
 		
-	addtimer(CALLBACK(src, PROC_REF(generate_fire_list), tiles_to_set_aflame, F, F.flameshape, null, FALSE, fuel_pressure), 0)
+	addtimer(CALLBACK(src, PROC_REF(generate_fire_list), tiles_to_set_aflame, F, id, FALSE, FALSE, fuel_pressure), 0)
 
 
 /datum/flameshape/default/irregular
@@ -129,7 +129,7 @@
 			tiles_to_set_aflame.Add(T)
 			prev_T = T
 
-	addtimer(CALLBACK(src, PROC_REF(generate_fire_list), tiles_to_set_aflame, F, id, null, FALSE, fuel_pressure), 0)
+	addtimer(CALLBACK(src, PROC_REF(generate_fire_list), tiles_to_set_aflame, F, id, FALSE, FALSE, fuel_pressure), 0)
 
 /datum/flameshape/star/minor
 	name = "Minor Star"
@@ -162,9 +162,9 @@
 		var/result = _fire_spread_check(F, temp, prev_T, T, burn_dam)
 		switch(result)
 			if(FIRE_CANPASS_SPREAD)
-				addtimer(CALLBACK(src, PROC_REF(generate_fire), T, F, F.flameshape, null, TRUE, fuel_pressure), 1)
+				addtimer(CALLBACK(src, PROC_REF(generate_fire), T, F, id, FALSE, TRUE, fuel_pressure), 1)
 			if(FIRE_CANPASS_SET_AFLAME)
-				addtimer(CALLBACK(src, PROC_REF(generate_fire), T, F, F.flameshape, null, TRUE, fuel_pressure), 1)
+				addtimer(CALLBACK(src, PROC_REF(generate_fire), T, F, id, FALSE, TRUE, fuel_pressure), 1)
 				break
 			if(FIRE_CANPASS_STOP, FIRE_CANPASS_STOP_BORDER)
 				break
@@ -223,7 +223,7 @@
 					if(FIRE_CANPASS_STOP, FIRE_CANPASS_STOP_BORDER)
 						break
 
-		addtimer(CALLBACK(src, PROC_REF(generate_fire_list), tiles_to_set_aflame, F, id, null, FALSE, fuel_pressure), 0)
+		addtimer(CALLBACK(src, PROC_REF(generate_fire_list), tiles_to_set_aflame, F, id, FALSE, FALSE, fuel_pressure), 0)
 
 		if(result == FIRE_CANPASS_SET_AFLAME)
 			break

--- a/code/modules/projectiles/guns/flamer/flameshape.dm
+++ b/code/modules/projectiles/guns/flamer/flameshape.dm
@@ -200,7 +200,6 @@
 
 	for(var/distance in 1 to fire_spread_amount)
 		var/turf/T = turfs[distance]
-		var/list/tiles_to_set_aflame = list()
 
 		var/result = FIRE_CANPASS_SPREAD
 		if(prev_T != T) // first tile already set on fire

--- a/code/modules/projectiles/guns/flamer/flameshape.dm
+++ b/code/modules/projectiles/guns/flamer/flameshape.dm
@@ -22,7 +22,7 @@
 
 	return FIRE_CANPASS_SPREAD
 
-/proc/_generate_fire(turf/T, obj/flamer_fire/F2, fs, should_call = FALSE, skip_flame = FALSE, fuel_pressure = 1)
+/proc/_generate_fire(turf/T, obj/flamer_fire/F2, skip_flame = FALSE, fuel_pressure = 1)
 	var/obj/flamer_fire/foundflame = locate() in T
 	if(foundflame && foundflame.tied_reagents == F2.tied_reagents && !skip_flame) // From the same flames
 		return
@@ -30,12 +30,7 @@
 	if(foundflame)
 		qdel(foundflame)
 
-	var/to_call = F2.to_call
-
-	if(!should_call)
-		to_call = null
-
-	new /obj/flamer_fire(T, F2.weapon_cause_data, F2.tied_reagent, 0, F2.tied_reagents, fs, F2.target_clicked, to_call, fuel_pressure, F2.fire_variant)
+	new /obj/flamer_fire(T, F2.weapon_cause_data, F2.tied_reagent, 0, F2.tied_reagents, FLAMESHAPE_DEFAULT, F2.target_clicked, null, fuel_pressure, F2.fire_variant)
 	return TRUE
 
 /datum/flameshape
@@ -45,12 +40,12 @@
 /datum/flameshape/proc/handle_fire_spread(obj/flamer_fire/F, fire_spread_amount, burn_dam, fuel_pressure = 1)
 	return
 
-/datum/flameshape/proc/generate_fire(turf/T, obj/flamer_fire/F2, fs, should_call = FALSE, skip_flame = FALSE, fuel_pressure = 1)
-	return _generate_fire(T, F2, fs, should_call, skip_flame, fuel_pressure)
+/datum/flameshape/proc/generate_fire(turf/T, obj/flamer_fire/F2, skip_flame = FALSE, fuel_pressure = 1)
+	return _generate_fire(T, F2, skip_flame, fuel_pressure)
 
-/datum/flameshape/proc/generate_fire_list(list/turf/turfs, obj/flamer_fire/F2, fs, should_call = FALSE, skip_flame = FALSE, fuel_pressure = 1)
+/datum/flameshape/proc/generate_fire_list(list/turf/turfs, obj/flamer_fire/F2, skip_flame = FALSE, fuel_pressure = 1)
 	for(var/turf/T in turfs)
-		_generate_fire(T, F2, fs, should_call, skip_flame, fuel_pressure)
+		_generate_fire(T, F2, skip_flame, fuel_pressure)
 
 /datum/flameshape/default
 	name = "Default"
@@ -94,7 +89,7 @@
 
 		tiles_to_spread = next_tiles_to_spread
 		
-	addtimer(CALLBACK(src, PROC_REF(generate_fire_list), tiles_to_set_aflame, F, id, FALSE, FALSE, fuel_pressure), 0)
+	addtimer(CALLBACK(src, PROC_REF(generate_fire_list), tiles_to_set_aflame, F, FALSE, fuel_pressure), 0)
 
 
 /datum/flameshape/default/irregular
@@ -129,7 +124,7 @@
 			tiles_to_set_aflame.Add(T)
 			prev_T = T
 
-	addtimer(CALLBACK(src, PROC_REF(generate_fire_list), tiles_to_set_aflame, F, id, FALSE, FALSE, fuel_pressure), 0)
+	addtimer(CALLBACK(src, PROC_REF(generate_fire_list), tiles_to_set_aflame, F, FALSE, fuel_pressure), 0)
 
 /datum/flameshape/star/minor
 	name = "Minor Star"
@@ -162,9 +157,9 @@
 		var/result = _fire_spread_check(F, temp, prev_T, T, burn_dam)
 		switch(result)
 			if(FIRE_CANPASS_SPREAD)
-				addtimer(CALLBACK(src, PROC_REF(generate_fire), T, F, id, FALSE, TRUE, fuel_pressure), 1)
+				addtimer(CALLBACK(src, PROC_REF(generate_fire), T, F, TRUE, fuel_pressure), 1)
 			if(FIRE_CANPASS_SET_AFLAME)
-				addtimer(CALLBACK(src, PROC_REF(generate_fire), T, F, id, FALSE, TRUE, fuel_pressure), 1)
+				addtimer(CALLBACK(src, PROC_REF(generate_fire), T, F, TRUE, fuel_pressure), 1)
 				break
 			if(FIRE_CANPASS_STOP, FIRE_CANPASS_STOP_BORDER)
 				break
@@ -223,7 +218,7 @@
 					if(FIRE_CANPASS_STOP, FIRE_CANPASS_STOP_BORDER)
 						break
 
-		addtimer(CALLBACK(src, PROC_REF(generate_fire_list), tiles_to_set_aflame, F, id, FALSE, FALSE, fuel_pressure), 0)
+		addtimer(CALLBACK(src, PROC_REF(generate_fire_list), tiles_to_set_aflame, F, FALSE, fuel_pressure), 0)
 
 		if(result == FIRE_CANPASS_SET_AFLAME)
 			break

--- a/code/modules/projectiles/guns/flamer/flameshape.dm
+++ b/code/modules/projectiles/guns/flamer/flameshape.dm
@@ -52,9 +52,11 @@
 	id = FLAMESHAPE_DEFAULT
 
 /datum/flameshape/default/handle_fire_spread(obj/flamer_fire/F, fire_spread_amount, burn_dam, fuel_pressure = 1)
-	var/list/tiles_to_spread = list(get_turf(F.loc))
+	var/turf/start_turf = get_turf(F.loc)
+
+	var/list/tiles_to_spread = list(start_turf)
 	var/list/tiles_to_set_aflame = list()
-	var/list/checked_tiles = list()
+	var/list/checked_tiles = list(start_turf)
 	var/obj/flamer_fire/temp = new()
 
 	for(var/spread_amount in 1 to fire_spread_amount)
@@ -68,11 +70,6 @@
 				var/turf/T = get_step(prev_T, dirn)
 
 				if(checked_tiles[T])
-					continue
-
-				var/obj/flamer_fire/foundflame = locate() in T
-				if(foundflame && foundflame.tied_reagent == F.tied_reagent)
-					checked_tiles[T] = TRUE
 					continue
 
 				var/result = _fire_spread_check(F, temp, prev_T, T, burn_dam)

--- a/code/modules/projectiles/guns/flamer/flameshape.dm
+++ b/code/modules/projectiles/guns/flamer/flameshape.dm
@@ -146,13 +146,13 @@
 	var/turf/source_turf = get_turf(F.loc)
 
 	var/turf/prev_T = source_turf
-	var/obj/flamer_fire/temp = new()
 	var/list/turfs = get_line(source_turf, F.target_clicked, FALSE)
 
 	if(fire_spread_amount > turfs.len)
 		fire_spread_amount = turfs.len
 
 	for(var/distance in 1 to fire_spread_amount)
+		var/obj/flamer_fire/temp = new()
 		var/turf/T = turfs[distance]
 		var/result = _fire_spread_check(F, temp, prev_T, T, burn_dam)
 		switch(result)
@@ -177,7 +177,6 @@
 /datum/flameshape/triangle/handle_fire_spread(obj/flamer_fire/F, fire_spread_amount, burn_dam, fuel_pressure = 1)
 	set waitfor = 0
 
-	var/obj/flamer_fire/temp = new()
 	var/unleash_dir = get_cardinal_dir(F, F.target_clicked)
 	var/list/turf/turfs = get_line(F, F.target_clicked, FALSE)
 	var/distance = 1
@@ -188,6 +187,7 @@
 		fire_spread_amount = turfs.len
 
 	for(var/distance in 1 to fire_spread_amount)
+		var/obj/flamer_fire/temp = new()
 		var/turf/T = turfs[distance]
 		var/list/tiles_to_set_aflame = list()
 

--- a/code/modules/projectiles/guns/flamer/flameshape.dm
+++ b/code/modules/projectiles/guns/flamer/flameshape.dm
@@ -62,7 +62,7 @@
 	var/list/checked_tiles = list()
 	var/obj/flamer_fire/temp = new()
 
-	for(var/spread_amount = 1 to fire_spread_amount)
+	for(var/spread_amount in 1 to fire_spread_amount)
 		var/list/next_tiles_to_spread = list()
 
 		if(tiles_to_spread.len == 0)

--- a/code/modules/projectiles/guns/flamer/flameshape.dm
+++ b/code/modules/projectiles/guns/flamer/flameshape.dm
@@ -134,11 +134,12 @@
 	id = FLAMESHAPE_LINE
 
 /datum/flameshape/line/handle_fire_spread(obj/flamer_fire/F, fire_spread_amount, burn_dam, fuel_pressure = 1)
+	set waitfor = 0
+
 	var/turf/source_turf = get_turf(F.loc)
 
 	var/turf/prev_T = source_turf
 	var/obj/flamer_fire/temp = new()
-	var/list/tiles_to_set_aflame = list()
 	var/list/turfs = get_line(source_turf, F.target_clicked, FALSE)
 
 	if(fire_spread_amount > turfs.len)
@@ -149,15 +150,15 @@
 		var/result = _fire_spread_check(F, temp, prev_T, T, burn_dam)
 		switch(result)
 			if(FIRE_CANPASS_SPREAD)
-				tiles_to_set_aflame.Add(T)
+				addtimer(CALLBACK(src, PROC_REF(generate_fire), T, F, F.flameshape, null, TRUE, fuel_pressure), 1)
 			if(FIRE_CANPASS_SET_AFLAME)
-				tiles_to_set_aflame.Add(T)
+				addtimer(CALLBACK(src, PROC_REF(generate_fire), T, F, F.flameshape, null, TRUE, fuel_pressure), 1)
 				break
 			if(FIRE_CANPASS_STOP, FIRE_CANPASS_STOP_BORDER)
 				break
 
 		prev_T = T
-		addtimer(CALLBACK(src, PROC_REF(generate_fire), T, F, F.flameshape, null, TRUE, fuel_pressure), distance)
+		sleep(1) // sleep to properly check next tile spread
 
 	if(F.to_call)
 		addtimer(F.to_call, fire_spread_amount)

--- a/code/modules/projectiles/guns/flamer/flameshape.dm
+++ b/code/modules/projectiles/guns/flamer/flameshape.dm
@@ -62,9 +62,6 @@
 	for(var/spread_amount in 1 to fire_spread_amount)
 		var/list/next_tiles_to_spread = list()
 
-		if(tiles_to_spread.len == 0)
-			break
-
 		for(var/turf/prev_T in tiles_to_spread)
 			for(var/dirn in GLOB.cardinals)
 				var/turf/T = get_step(prev_T, dirn)
@@ -83,6 +80,9 @@
 						checked_tiles[T] = TRUE
 					if(FIRE_CANPASS_STOP)
 						checked_tiles[T] = TRUE
+
+		if(next_tiles_to_spread.len == 0)
+			break
 
 		tiles_to_spread = next_tiles_to_spread
 
@@ -150,7 +150,8 @@
 	if(fire_spread_amount > turfs.len)
 		fire_spread_amount = turfs.len
 
-	for(var/distance in 1 to fire_spread_amount)
+	var/distance = 1
+	for(distance in 1 to fire_spread_amount)
 		var/obj/flamer_fire/temp = new()
 		var/turf/T = turfs[distance]
 		var/result = _fire_spread_check(F, temp, prev_T, T, burn_dam)
@@ -168,7 +169,7 @@
 		sleep(1) // sleep to properly check next tile spread
 
 	if(F.to_call)
-		addtimer(F.to_call, fire_spread_amount)
+		addtimer(F.to_call, distance)
 
 /datum/flameshape/triangle
 	name = "Triangle"
@@ -179,8 +180,6 @@
 
 	var/unleash_dir = get_cardinal_dir(F, F.target_clicked)
 	var/list/turf/turfs = get_line(F, F.target_clicked, FALSE)
-	var/distance = 1
-	var/hit_dense_atom_mid = FALSE
 	var/turf/prev_T = get_turf(F.loc)
 
 	if(fire_spread_amount > turfs.len)

--- a/code/modules/projectiles/guns/flamer/flameshape.dm
+++ b/code/modules/projectiles/guns/flamer/flameshape.dm
@@ -88,7 +88,8 @@
 						checked_tiles[T] = TRUE
 
 		tiles_to_spread = next_tiles_to_spread
-		
+
+	qdel(temp)
 	addtimer(CALLBACK(src, PROC_REF(generate_fire_list), tiles_to_set_aflame, F, FALSE, fuel_pressure), 0)
 
 
@@ -124,6 +125,7 @@
 			tiles_to_set_aflame.Add(T)
 			prev_T = T
 
+	qdel(temp)
 	addtimer(CALLBACK(src, PROC_REF(generate_fire_list), tiles_to_set_aflame, F, FALSE, fuel_pressure), 0)
 
 /datum/flameshape/star/minor
@@ -165,6 +167,7 @@
 				break
 
 		prev_T = T
+		QDEL_NULL(temp)
 		sleep(1) // sleep to properly check next tile spread
 
 	if(F.to_call)
@@ -223,6 +226,7 @@
 		if(result == FIRE_CANPASS_SET_AFLAME)
 			break
 
+		QDEL_NULL(temp)
 		sleep(3) // 1 from step forward, 1 for each step in each side
 
 	if(F.to_call)

--- a/code/modules/projectiles/guns/flamer/flameshape.dm
+++ b/code/modules/projectiles/guns/flamer/flameshape.dm
@@ -56,6 +56,7 @@
 /datum/flameshape/default/handle_fire_spread(obj/flamer_fire/F, fire_spread_amount, burn_dam, fuel_pressure = 1)
 	var/list/tiles_to_spread = list(get_turf(F.loc))
 	var/list/tiles_to_set_aflame = list()
+	var/list/checked_tiles = list()
 	var/obj/flamer_fire/temp = new()
 
 	for(var/spread_amount = 1 to fire_spread_amount)
@@ -68,8 +69,12 @@
 			for(var/dirn in GLOB.cardinals)
 				var/turf/T = get_step(prev_T, dirn)
 
+				if(checked_tiles[T])
+					continue
+
 				var/obj/flamer_fire/foundflame = locate() in T
 				if(foundflame && foundflame.tied_reagent == F.tied_reagent)
+					checked_tiles[T] = TRUE
 					continue
 
 				var/result = _fire_spread_check(F, temp, prev_T, T, burn_dam)
@@ -77,8 +82,12 @@
 					if(FIRE_CANPASS_SPREAD)
 						next_tiles_to_spread.Add(T)
 						tiles_to_set_aflame.Add(T)
+						checked_tiles[T] = TRUE
 					if(FIRE_CANPASS_SET_AFLAME)
 						tiles_to_set_aflame.Add(T)
+						checked_tiles[T] = TRUE
+					if(FIRE_CANPASS_STOP)
+						checked_tiles[T] = TRUE
 
 		tiles_to_spread = next_tiles_to_spread
 		

--- a/code/modules/projectiles/guns/flamer/flameshape.dm
+++ b/code/modules/projectiles/guns/flamer/flameshape.dm
@@ -4,14 +4,14 @@
 #define FIRE_CANPASS_STOP 4
 
 
-/proc/_fire_spread_check(obj/flamer_fire/F, obj/flamer_fire/mover, turf/T, turf/prev_T, burn_dam)
+/proc/_fire_spread_check(obj/flamer_fire/F, obj/flamer_fire/mover, turf/prev_T, turf/T, burn_dam)
 	if(istype(T, /turf/open/space))
 		return FIRE_CANPASS_STOP
 
 	if(T.density)
 		T.flamer_fire_act(burn_dam, F.weapon_cause_data)
 		return FIRE_CANPASS_SET_AFLAME
-		
+
 	var/atom/A = LinkBlocked(mover, prev_T, T)
 
 	if(A)


### PR DESCRIPTION
# About the pull request

Refactor of flameshape.dm to make it readable, removed recursion from FLAMESHAPE_DEFAULT and a bit easier to understand OB recursion. Also removed strange usage of OB recursion in /obj/structure/ship_ammo/laser_battery to place  1 tile of fire...
The only thing changed is that line flame will check for new obstacles when spreading, and green fire is able to replace itself.

# Explain why it's good for the game

Cleaner and faster code.

# Testing Photographs and Procedure

Checked OB, pyro flamer and datum proc called laser_battery and mortar_shell/incendiary.

# Changelog

:cl:
refactor: refactored some related to fire spreading code
/:cl:
