### PR TITLE
Ability "For The Hive!" cooldown is moved from status to button display.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/runner/runner_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/runner/runner_powers.dm
@@ -183,12 +183,13 @@
 	behavior_delegate.caboom_last_proc = 0
 	xeno.set_effect(behavior_delegate.caboom_timer*2, SUPERSLOW)
 
+	START_PROCESSING(SSfasteffects, src)
+
 	xeno.say(";FOR THE HIVE!!!")
 	return ..()
 
 /datum/action/xeno_action/activable/acider_for_the_hive/proc/cancel_ability()
 	var/mob/living/carbon/xenomorph/xeno = owner
-
 	if(!istype(xeno))
 		return
 	var/datum/behavior_delegate/runner_acider/behavior_delegate = xeno.behavior_delegate
@@ -205,3 +206,20 @@
 	xeno.adjust_effect(behavior_delegate.caboom_timer * -2 - (behavior_delegate.caboom_timer - behavior_delegate.caboom_left + 2) * xeno.life_slow_reduction * 0.5, SUPERSLOW)
 
 	to_chat(xeno, SPAN_XENOWARNING("We remove all our explosive acid before it combusted."))
+
+	STOP_PROCESSING(SSfasteffects, src)
+	button.set_maptext()
+
+/datum/action/xeno_action/activable/acider_for_the_hive/process(delta_time)
+	. = ..()
+	return update_caboom_maptext()
+
+/datum/action/xeno_action/activable/acider_for_the_hive/proc/update_caboom_maptext()
+	var/mob/living/carbon/xenomorph/xeno = owner
+	var/datum/behavior_delegate/runner_acider/delegate = xeno.behavior_delegate
+	if(!istype(delegate) || !delegate.caboom_trigger || delegate.caboom_left <= 0)
+		button.set_maptext()
+		return PROCESS_KILL
+
+	button.set_maptext(SMALL_FONTS_COLOR(7, delegate.caboom_left, "#e69d00"), 19, 2)
+	return

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/runner/acid.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/runner/acid.dm
@@ -75,8 +75,6 @@
 	if(acid_amount >= acid_gen_cap)
 		. += "Passive acid generation cap ([acid_gen_cap]) reached"
 	. += "Battle acid generation: [combat_gen_active ? "Active" : "Inactive"]"
-	if(caboom_trigger)
-		. += "FOR THE HIVE!: in [caboom_left] seconds"
 
 /datum/behavior_delegate/runner_acider/melee_attack_additional_effects_target(mob/living/carbon/target_mob)
 	if(ishuman(target_mob)) //Will acid be applied to the mob
@@ -141,6 +139,7 @@
 /datum/behavior_delegate/runner_acider/handle_death(mob/M)
 	var/image/holder = bound_xeno.hud_list[PLASMA_HUD]
 	holder.overlays.Cut()
+	STOP_PROCESSING(SSfasteffects, src)
 
 /datum/behavior_delegate/runner_acider/proc/do_caboom()
 	if(!bound_xeno)


### PR DESCRIPTION
# About the pull request

Add "For The Hive!" countdown directly to button instead of status tab.

Status tab is not reliable source of checking your countdown when you need to focus on screen more than on panel on right side of screen, during testing i noticed that status tab info is not reliable because of time dilation, my button counter showed sometimes 4 sec to explosion, but status told me with it is 6 seconds (delay), i was not able to remove -2s counting caused by world.tick calculations.

This is my first time touching field where i have START_PROCESSING() and STOP_PROCESSING() so code might be junky wonky.

# Explain why it's good for the game

Having ability to see how much time left on your ability on top of game screen is way better than checking status tab that inconsistently updates text, making it better visual for players, also added orange number text on right side of button (so you dont mistake it with cooldown timer with is on left side of screen)


# Testing Photographs and Procedure

<details>
<summary>>Click Here<</summary>

https://github.com/user-attachments/assets/2444710d-0fc5-4d04-808a-87cba534c834

</details>


# Changelog

:cl: Venuska1117
qol: For The Hive! ability countdown now display on action button.
/:cl:
