### PR TITLE
Removes natural resin membranes from LV.

### DIFF
--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -973,11 +973,6 @@
 "adO" = (
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/north_central_caves/lake_house_tower)
-"adP" = (
-/obj/effect/landmark/structure_spawner/xvx_hive/xeno_membrane,
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_membrane,
-/turf/open/gm/dirt,
-/area/lv624/ground/caves/south_east_caves)
 "adQ" = (
 /obj/structure/surface/table/woodentable/poor,
 /obj/item/weapon/gun/rifle/mar40,
@@ -1437,21 +1432,6 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_west_caves)
-"afA" = (
-/obj/effect/landmark/structure_spawner/xvx_hive/xeno_membrane,
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_membrane,
-/turf/open/gm/dirt,
-/area/lv624/ground/caves/west_caves)
-"afB" = (
-/obj/effect/landmark/structure_spawner/xvx_hive/xeno_membrane,
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_membrane,
-/turf/open/gm/dirt,
-/area/lv624/ground/caves/east_caves)
-"afC" = (
-/obj/effect/landmark/structure_spawner/xvx_hive/xeno_membrane,
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_membrane,
-/turf/open/gm/dirt,
-/area/lv624/ground/caves/central_caves)
 "afE" = (
 /obj/effect/decal/remains/xeno,
 /obj/structure/stairs/perspective{
@@ -11309,6 +11289,11 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/north_west_caves)
+"diW" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_membrane,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_membrane,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_east_caves)
 "diZ" = (
 /obj/structure/surface/rack,
 /obj/item/tool/crowbar,
@@ -13396,6 +13381,11 @@
 	},
 /turf/open/floor/white,
 /area/lv624/lazarus/corporate_dome)
+"hBL" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_membrane,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_membrane,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/central_caves)
 "hDe" = (
 /obj/structure/bed/stool,
 /obj/item/prop/alien/hugger,
@@ -18810,6 +18800,11 @@
 	},
 /turf/open/floor/sandstone/runed,
 /area/lv624/ground/caves/sand_temple)
+"sMx" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_membrane,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_membrane,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/west_caves)
 "sMK" = (
 /obj/structure/flora/grass/tallgrass/jungle/corner{
 	dir = 1
@@ -19609,6 +19604,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/lv624/lazarus/secure_storage)
+"umb" = (
+/obj/effect/landmark/structure_spawner/xvx_hive/xeno_membrane,
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_membrane,
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/east_caves)
 "unp" = (
 /turf/closed/wall/strata_ice/jungle,
 /area/lv624/ground/caves/south_east_caves)
@@ -24722,11 +24722,11 @@ mdQ
 xZE
 wlh
 oAV
-afA
+sMx
 tOS
 gwP
 gwP
-afA
+sMx
 oAV
 wlh
 xZE
@@ -25176,15 +25176,15 @@ mdQ
 mdQ
 mdQ
 xZE
-afA
-afA
-afA
+sMx
+sMx
+sMx
 gwP
 gwP
 tOS
-afA
-afA
-afA
+sMx
+sMx
+sMx
 xZE
 mdQ
 mdQ
@@ -25634,11 +25634,11 @@ mdQ
 xZE
 wlh
 oAV
-afA
+sMx
 tOS
 gwP
 gwP
-afA
+sMx
 oAV
 wlh
 xZE
@@ -38393,8 +38393,8 @@ acf
 acf
 acf
 izh
-afC
-afC
+hBL
+hBL
 izh
 abl
 abl
@@ -39077,8 +39077,8 @@ acf
 acf
 acf
 izh
-afC
-afC
+hBL
+hBL
 izh
 abl
 abl
@@ -58715,8 +58715,8 @@ whU
 whU
 whU
 jMS
-adP
-adP
+diW
+diW
 jMS
 jMS
 wEO
@@ -59374,9 +59374,9 @@ egU
 nzw
 nHq
 jAo
-afB
+umb
 acg
-afB
+umb
 iyr
 eZC
 uBR
@@ -59400,8 +59400,8 @@ whU
 whU
 whU
 jMS
-adP
-adP
+diW
+diW
 fIt
 fTM
 fIt
@@ -59629,7 +59629,7 @@ whU
 whU
 whU
 jMS
-adP
+diW
 aed
 fIt
 jMS
@@ -59828,13 +59828,13 @@ pUm
 bvj
 bvj
 gVR
-afB
-afB
-afB
+umb
+umb
+umb
 aaN
-afB
-afB
-afB
+umb
+umb
+umb
 uBR
 vVC
 vVC
@@ -60286,9 +60286,9 @@ pUm
 uBR
 jhj
 upQ
-afB
+umb
 acg
-afB
+umb
 fAD
 rPK
 uBR


### PR DESCRIPTION
# About the pull request

Exchanges all membranes on LV for regular resin walls and adds in a grand total of 9 2x2s.

# Explain why it's good for the game

Membranes are just kind of useless and will get destroyed by any competent builder during the round anyway, so they're kind of just wasting space and not contributing anything and only serve to waste a builders time - I have however left the membranes around the old nests because it's soulful.

As for the 2x2s, SW Caves and Far NE Caves were just really empty looking so I added 5 2x2s to SW Caves and 4 2x2s to NE caves to break up the massive open space a bit, shouldn't really affect much as they're very widely spaced out.

# Testing Photographs and Procedure

Booted it up locally, ran fine and the walls appeared where they should have been.

# Changelog

:cl:
maptweak: Exchanges every membrane on LV for normal resin walls.
maptweak: Adds in a few 2x2s to break up massive open spaces.
/:cl:
