### PR TITLE
Fixes typos & rewrites most of magazines .dms

### DIFF
--- a/code/modules/projectiles/magazines/flamer.dm
+++ b/code/modules/projectiles/magazines/flamer.dm
@@ -4,7 +4,7 @@
 
 /obj/item/ammo_magazine/flamer_tank
 	name = "M240 incinerator tank"
-	desc = "A fuel tank used to store fuel for use in the M240 incinerator unit. Handle with care."
+	desc = "A fuel tank for use in the M240 incinerator unit. Handle with care."
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/USCM/flamers.dmi'
 	icon_state = "flametank_custom"
 	item_state = "flametank"
@@ -151,7 +151,8 @@
 // This is gellie fuel. Green Flames.
 /obj/item/ammo_magazine/flamer_tank/gellied
 	name = "M240 incinerator tank (B-Gel)"
-	desc = "A fuel tank full of specialized Ultra Thick Napthal Fuel type B-Gel. Unlike its liquid contemporaries, this gelled variant of napalm is easily extinguished, but shoots far and lingers on the ground in a viscous mess, while reacting with inorganic materials to break them down. Handle with exceptional care."
+	desc = "A fuel tank full of specialized Ultra Thick Napthal Fuel type B-Gel, a gelled variant of napalm that is easily extinguished, but shoots further and lingers for longer. Handle with exceptional care."
+	desc_lore = "Unlike its liquid contemporaries, this gelled variant of napalm is easily extinguished, but shoots far and lingers on the ground in a viscous mess. The gel reacts violently with inorganic materials to break them down, forming an extremely sticky crytallized goo."
 	caliber = "Napalm Gel"
 	flamer_chem = "napalmgel"
 	max_rounds = 200
@@ -161,7 +162,7 @@
 
 /obj/item/ammo_magazine/flamer_tank/custom
 	name = "M240 custom incinerator tank"
-	desc = "A fuel tank used to store fuel for use in the M240 incinerator unit. This one has been modified with a pressure regulator and an internal propellant tank."
+	desc = "A fuel tank for use in the M240 incinerator unit. This one has been modified with a pressure regulator and an internal propellant tank."
 	matter = list("metal" = 3750)
 	flamer_chem = null
 	max_rounds = 100
@@ -192,7 +193,7 @@
 // Pyro regular flamer tank just bigger than the base flamer tank.
 /obj/item/ammo_magazine/flamer_tank/large
 	name = "M240 large incinerator tank"
-	desc = "A large fuel tank used to store fuel for use in the M240-T incinerator unit. Handle with care."
+	desc = "A large fuel tank for use in the M240-T incinerator unit. Handle with extreme caution."
 	icon_state = "flametank_large_custom"
 	item_state = "flametank_large"
 	max_rounds = 250
@@ -210,7 +211,8 @@
 // This is the green flamer fuel for the pyro.
 /obj/item/ammo_magazine/flamer_tank/large/B
 	name = "M240 large incinerator tank (B)"
-	desc = "A large fuel tank of Ultra Thick Napthal Fuel type B, a special variant of napalm that is easily extinguished, but disperses over a wide area while burning slowly. The composition reacts with inorganic materials to break them down, causing severe damage. For use in the M240-T incinerator unit. Handle with care."
+	desc = "A large fuel tank of Ultra Thick Napthal Fuel type B, a special variant of napalm that is easily extinguished, but disperses over a wide area while burning slowly."
+	desc_lore = "desc_lore = "Unlike its thinner contemporaries, this special ultra-thick variant of napalm is easily extinguished, but disperses over a wide area and lingers on the ground in a viscous mess. The composition reacts violently with inorganic materials to break them down, causing severe structural damage. Handle with extreme caution."
 	caliber = "Napalm B"
 	flamer_chem = "napalmb"
 
@@ -219,7 +221,7 @@
 // This is the blue flamer fuel for the pyro.
 /obj/item/ammo_magazine/flamer_tank/large/X
 	name = "M240 large incinerator tank (X)"
-	desc = "A large fuel tank of Ultra Thick Napthal Fuel type X, a sticky combustible liquid chemical that burns extremely hot, for use in the M240-T incinerator unit. Handle with care."
+	desc = "A large fuel tank of Ultra Thick Napthal Fuel type X, a sticky combustible liquid chemical that burns extremely hot, for use in the M240-T incinerator unit. Handle with extreme caution."
 	caliber = "Napalm X"
 	flamer_chem = "napalmx"
 
@@ -227,7 +229,7 @@
 
 /obj/item/ammo_magazine/flamer_tank/large/EX
 	name = "M240 large incinerator tank (EX)"
-	desc = "A large fuel tank of Ultra Thick Napthal Fuel type EX, a sticky combustible liquid chemical that burns so hot it melts straight through flame-resistant material, for use in the M240-T incinerator unit. Handle with care."
+	desc = "A large fuel tank of Ultra Thick Napthal Fuel type EX, a sticky combustible liquid chemical that burns so hot it melts straight through most flame-resistant materials, for use in the M240-T incinerator unit. Handle with extreme caution."
 	caliber = "Napalm EX"
 	flamer_chem = "napalmex"
 
@@ -254,7 +256,7 @@
 //tanks printable by the research biomass machine
 /obj/item/ammo_magazine/flamer_tank/custom/upgraded
 	name = "M240 upgraded custom incinerator tank"
-	desc = "A fuel tank used to store fuel for use in the M240 incinerator unit. This one has been modified with a larger and more sophisticated internal propellant tank, allowing for bigger capacity and stronger fuels."
+	desc = "A fuel tank for use in the M240 incinerator unit. This one has been modified with a larger and more sophisticated internal propellant tank, allowing for larger capacity and stronger fuels."
 	matter = list("metal" = 50) // no free metal
 	flamer_chem = null
 	max_rounds = 200
@@ -266,7 +268,7 @@
 
 /obj/item/ammo_magazine/flamer_tank/smoke/upgraded
 	name = "M240 large custom incinerator smoke tank"
-	desc = "A tank holding powdered smoke that expands when exposed to an open flame and carries any chemicals along with it. This one has been outfitted with an upgraded internal compressor, allowing for bigger capacity."
+	desc = "A tank holding powdered smoke that expands when exposed to an open flame and carries any chemicals along with it. This one has been outfitted with an upgraded internal compressor, allowing for larger capacity."
 	matter = list("metal" = 50) //no free metal
 	flamer_chem = null
 	custom = TRUE
@@ -274,7 +276,7 @@
 
 /obj/item/ammo_magazine/flamer_tank/survivor
 	name = "improvised flamer tank"
-	desc = "A repurposed tank from heavy welding equipment, holds a mix similar to napalm."
+	desc = "A repurposed tank from heavy welding equipment, holding a flammable mix similar to napalm."
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/colony/flamers.dmi'
 	icon_state = "flamer_fuel"
 	gun_type = /obj/item/weapon/gun/flamer/survivor
@@ -285,7 +287,7 @@
 
 /obj/item/ammo_magazine/flamer_tank/flammenwerfer
 	name = "FW3 heavy incinerator tank"
-	desc = "A heavy, high capacity tank utilized by Flammenwerfer 3 Heavy Incineration Unit. This has a blue Weyland-Yutani logo on it."
+	desc = "A heavy, high capacity tank utilized by the Flammenwerfer 3 Heavy Incineration Unit. This one has a blue, heat-resistant Weyland-Yutani logo on it."
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/WY/flamers.dmi'
 	icon_state = "fl3"
 	item_state = "fl3"
@@ -297,7 +299,7 @@
 
 /obj/item/ammo_magazine/flamer_tank/flammenwerfer/whiteout
 	name = "FW3 heavy incinerator tank (EX)"
-	desc = "A heavy fuel tank of Ultra Thick Napthal Fuel type EX, a sticky combustible liquid chemical that burns so hot it melts straight through flame-resistant material, utilized by Flammenwerfer 3 Heavy Incineration Unit. This has a blue Weyland-Yutani logo on it. Handle with care."
+	desc = "A heavy fuel tank of Ultra Thick Napthal Fuel type EX, a sticky combustible liquid chemical that burns so hot it melts straight through most flame-resistant materials, utilized by the Flammenwerfer 3 Heavy Incineration Unit. This has a blue, heat-resistant Weyland-Yutani logo on it. Handle with care."
 	caliber = "Napalm EX"
 	flamer_chem = "napalmex"
 	stripe_icon = TRUE

--- a/code/modules/projectiles/magazines/flamer.dm
+++ b/code/modules/projectiles/magazines/flamer.dm
@@ -212,7 +212,7 @@
 /obj/item/ammo_magazine/flamer_tank/large/B
 	name = "M240 large incinerator tank (B)"
 	desc = "A large fuel tank of Ultra Thick Napthal Fuel type B, a special variant of napalm that is easily extinguished, but disperses over a wide area while burning slowly."
-	desc_lore = "desc_lore = "Unlike its thinner contemporaries, this special ultra-thick variant of napalm is easily extinguished, but disperses over a wide area and lingers on the ground in a viscous mess. The composition reacts violently with inorganic materials to break them down, causing severe structural damage. Handle with extreme caution."
+	desc_lore = "Unlike its thinner contemporaries, this special ultra-thick variant of napalm is easily extinguished, but disperses over a wide area and lingers on the ground in a viscous mess. The composition reacts violently with inorganic materials to break them down, causing severe structural damage. Handle with extreme caution."
 	caliber = "Napalm B"
 	flamer_chem = "napalmb"
 

--- a/code/modules/projectiles/magazines/lever_action.dm
+++ b/code/modules/projectiles/magazines/lever_action.dm
@@ -5,7 +5,7 @@ Similar to shotguns.dm but not exactly.
 
 /obj/item/ammo_magazine/lever_action
 	name = "box of 45-70 rounds"
-	desc = "A box filled with handfuls of 45-70 Govt. rounds, for the old-timed."
+	desc = "A box filled with handfuls of 45-70 Govt. rounds, for the old-timers."
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/colony/marksman_rifles.dmi'
 	icon_state = "45-70-box"
 	item_state = "45-70-box"
@@ -21,7 +21,7 @@ Similar to shotguns.dm but not exactly.
 
 /obj/item/ammo_magazine/lever_action/training
 	name = "box of 45-70 blanks"
-	desc = "A box filled with training lever action 45-70 rounds that aren't very damaging... unless you fire them point-blank or something."
+	desc = "A box filled with handfuls of 45-70 Govt. blank rounds. These won't do much damage unless you fire them point blank, or something."
 	icon_state = "45-70-training-box"
 	item_state = "45-70-training-box"
 	default_ammo = /datum/ammo/bullet/lever_action/training
@@ -30,7 +30,7 @@ Similar to shotguns.dm but not exactly.
 //unused
 /obj/item/ammo_magazine/lever_action/marksman
 	name = "box of marksman 45-70 rounds"
-	desc = "A box filled with marksman lever action 45-70 rounds, which have a lower-density, more precise bullet package."
+	desc = "A box filled with handfuls of marksman 45-70 Govt. rounds, which have a lower-density, more precise bullet package."
 	icon_state = "45-70-marksman-box"
 	item_state = "45-70-marksman-box"
 	default_ammo = /datum/ammo/bullet/lever_action/marksman
@@ -39,7 +39,7 @@ Similar to shotguns.dm but not exactly.
 //unused
 /obj/item/ammo_magazine/lever_action/tracker
 	name = "box of tracker 45-70 rounds"
-	desc = "A box filled with tracker lever action 45-70 rounds, which replace some of the bullet package with an electronic tracking chip."
+	desc = "A box filled with handfuls of tracker 45-70 Govt. rounds, which replace some of the bullet package with an electronic tracking chip."
 	icon_state = "45-70-tracker-box"
 	item_state = "45-70-tracker-box"
 	default_ammo = /datum/ammo/bullet/lever_action/tracker
@@ -95,7 +95,7 @@ Handfuls of lever_action rounds. For spawning directly on mobs in roundstart, ER
 
 /obj/item/ammo_magazine/handful/lever_action/training
 	name = "handful of blanks (45-70)"
-	desc = "A handful of blank 45-70 Govt. rounds. These rounds are blanks, which are mostly harmless.... just don't shoot them at point-blank range."
+	desc = "A handful of blank 45-70 Govt. rounds. These rounds are blanks, which are mostly harmless... Just don't shoot them at point-blank range."
 	icon_state = "training_lever_action_bullet_9"
 	default_ammo = /datum/ammo/bullet/lever_action/training
 	handful_state = "training_lever_action_bullet"
@@ -103,7 +103,7 @@ Handfuls of lever_action rounds. For spawning directly on mobs in roundstart, ER
 //unused
 /obj/item/ammo_magazine/handful/lever_action/tracker
 	name = "handful of tracker 45-70 rounds (45-70)"
-	desc = "A handful of tracker 45-70 Govt. rounds. Some of their bullet package's been replaced with a chip that when fired can be picked up by Motion Detectors."
+	desc = "A handful of tracker 45-70 Govt. rounds. Some of their bullet package has been replaced with a chip that, when fired, can be picked up by Motion Detectors."
 	icon_state = "tracking_lever_action_bullet_9"
 	default_ammo = /datum/ammo/bullet/lever_action/tracker
 	handful_state = "tracking_lever_action_bullet"
@@ -111,14 +111,14 @@ Handfuls of lever_action rounds. For spawning directly on mobs in roundstart, ER
 //unused
 /obj/item/ammo_magazine/handful/lever_action/marksman
 	name = "handful of marksman 45-70 rounds (45-70)"
-	desc = "A handful of marksman 45-70 Govt. rounds. Their small bullet package reduces damage, but increases penetration and bullet velocity."
+	desc = "A handful of marksman 45-70 Govt. rounds. Their smaller bullet package reduces damage, but increases penetration and bullet velocity."
 	icon_state = "marksman_lever_action_bullet_9"
 	default_ammo = /datum/ammo/bullet/lever_action/marksman
 	handful_state = "marksman_lever_action_bullet"
 
 /obj/item/ammo_magazine/handful/lever_action/xm88
 	name = "handful of .458 SOCOM rounds (.458)"
-	desc = "A handful of .458 SOCOM rounds, chambered for the XM88 heavy rifle."
+	desc = "A handful of .458 SOCOM rounds, designed for the XM88 heavy rifle."
 	caliber = ".458"
 	icon_state = "marksman_lever_action_bullet_9"
 	default_ammo = /datum/ammo/bullet/lever_action/xm88

--- a/code/modules/projectiles/magazines/misc.dm
+++ b/code/modules/projectiles/magazines/misc.dm
@@ -4,7 +4,7 @@
 
 /obj/item/ammo_magazine/minigun
 	name = "rotating ammo drum (7.62x51mm)"
-	desc = "A huge ammo drum for a huge gun."
+	desc = "A huge 7.62x51mm ammo drum for a huge rotary machine gun."
 	caliber = "7.62x51mm"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/event.dmi'
 	icon_state = "painless" //PLACEHOLDER
@@ -20,7 +20,7 @@
 
 /obj/item/ammo_magazine/m60
 	name = "M60 ammo box (7.62x51mm)"
-	desc = "A blast from the past chambered in 7.62X51mm NATO."
+	desc = "A blast from the past, chambered in 7.62x51mm NATO."
 	caliber = "7.62x51mm"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/colony/machineguns.dmi'
 	icon_state = "m60" //PLACEHOLDER
@@ -33,7 +33,7 @@
 
 /obj/item/ammo_magazine/pkp
 	name = "QYJ-72 ammo box (7.62x54mmR)"
-	desc = "A 250 round box for the UPP's standard GPMG, the QYJ-72. Chambered in 7.62x54mmR."
+	desc = "A 7.62x54mmR 250-round box magazine for the UPP's standard GPMG, the QYJ-72."
 	caliber = "7.62x54mmR"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/UPP/machineguns.dmi'
 	icon_state = "qjy72"

--- a/code/modules/projectiles/magazines/pistols.dm
+++ b/code/modules/projectiles/magazines/pistols.dm
@@ -4,7 +4,7 @@
 
 /obj/item/ammo_magazine/pistol
 	name = "\improper M4A3 magazine (9mm)"
-	desc = "A pistol magazine."
+	desc = "A 9mm pistol magazine for the M4A3."
 	caliber = "9mm"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/USCM/pistols.dmi'
 	icon_state = "m4a3"
@@ -17,38 +17,42 @@
 
 /obj/item/ammo_magazine/pistol/hp
 	name = "\improper M4A3 hollowpoint magazine (9mm)"
-	desc = "A pistol magazine. This one contains hollowpoint bullets, which have noticeably higher stopping power on unarmored targets, and noticeably less on armored targets."
+	desc = "A hollow-point 9mm pistol magazine for the M4A3. These hollow-point bullets have noticeably higher stopping power on unarmored targets, and noticeably less on armored targets."
 	default_ammo = /datum/ammo/bullet/pistol/hollow
 	ammo_band_color = AMMO_BAND_COLOR_HOLLOWPOINT
 	mag_jam_modifier = MAG_JAM_MOD_PISTOL_MEDIUM
 
 /obj/item/ammo_magazine/pistol/ap
 	name = "\improper M4A3 AP magazine (9mm)"
-	desc = "A pistol magazine. This one contains armor-piercing bullets, which have noticeably higher stopping power on well-armored targets, and noticeably less on unarmored or lightly-armored targets."
+	desc = "An armor-piercing 9mm pistol magazine for the M4A3. These armor-piercing rounds have noticeably higher stopping power on armored targets, and noticeably less on unarmored targets."
 	default_ammo = /datum/ammo/bullet/pistol/ap
 	ammo_band_color = AMMO_BAND_COLOR_AP
 	mag_jam_modifier = MAG_JAM_MOD_PISTOL_MEDIUM
 
 /obj/item/ammo_magazine/pistol/rubber
 	name = "\improper M4A3 Rubber magazine (9mm)"
+	desc = "A 9mm pistol magazine for the M4A3. This one contains rubber bullets."
 	default_ammo = /datum/ammo/bullet/pistol/rubber
 	ammo_band_color = AMMO_BAND_COLOR_RUBBER
 	mag_jam_modifier = MAG_JAM_MOD_PISTOL_RUBBER //youre firing rubber, of course its gonna jam your shit a lot more... but its smaller so we give it a little pass
 
 /obj/item/ammo_magazine/pistol/incendiary
 	name = "\improper M4A3 incendiary magazine (9mm)"
+	desc = "An incendiary 9mm pistol magazine for the M4A3."
 	default_ammo = /datum/ammo/bullet/pistol/incendiary
 	ammo_band_color = AMMO_BAND_COLOR_INCENDIARY
 	mag_jam_modifier = MAG_JAM_MOD_PISTOL_LOW
 
 /obj/item/ammo_magazine/pistol/penetrating
 	name = "\improper M4A3 wall-penetrating magazine (9mm)"
+	desc = "A wall-penetrating 9mm pistol magazine for the M4A3."
 	default_ammo = /datum/ammo/bullet/pistol/ap/penetrating
 	ammo_band_color = AMMO_BAND_COLOR_PENETRATING
 	mag_jam_modifier = MAG_JAM_MOD_PISTOL_FAIR
 
 /obj/item/ammo_magazine/pistol/toxin
 	name = "\improper M4A3 toxin magazine (9mm)"
+	desc = "A toxin 9mm pistol magazine for the M4A3."
 	default_ammo = /datum/ammo/bullet/pistol/ap/toxin
 	ammo_band_color = AMMO_BAND_COLOR_TOXIN
 	mag_jam_modifier = MAG_JAM_MOD_PISTOL_LOW
@@ -58,6 +62,7 @@
 
 /obj/item/ammo_magazine/pistol/m1911
 	name = "\improper M1911 magazine (.45)"
+	desc = "A .45 ACP pistol magazine."
 	default_ammo = /datum/ammo/bullet/pistol/heavy
 	caliber = ".45"
 	icon_state = "m4a345"//rename later
@@ -70,6 +75,7 @@
 
 /obj/item/ammo_magazine/pistol/mod88
 	name = "\improper 88M4 AP magazine (9mm)"
+	desc = "A 9mm pistol magazine for the Mod88."
 	default_ammo = /datum/ammo/bullet/pistol/ap
 	caliber = "9mm"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/WY/pistols.dmi'
@@ -94,24 +100,28 @@
 
 /obj/item/ammo_magazine/pistol/mod88/toxin
 	name = "\improper 88M4 toxic magazine (9mm)"
+	desc = "A toxin 9mm pistol magazine for the Mod88."
 	default_ammo = /datum/ammo/bullet/pistol/ap/toxin
 	ammo_band_color = AMMO_BAND_COLOR_TOXIN
 	mag_jam_modifier = MAG_JAM_MOD_PISTOL_LOW
 
 /obj/item/ammo_magazine/pistol/mod88/penetrating
 	name = "\improper 88M4 wall-penetrating magazine (9mm)"
+	desc = "A wall-penetrating 9mm pistol magazine for the Mod88."
 	default_ammo = /datum/ammo/bullet/pistol/ap/penetrating
 	ammo_band_color = AMMO_BAND_COLOR_PENETRATING
 	mag_jam_modifier = MAG_JAM_MOD_PISTOL_FAIR
 
 /obj/item/ammo_magazine/pistol/mod88/incendiary
 	name = "\improper 88M4 incendiary magazine (9mm)"
+	desc = "An incendiary 9mm pistol magazine for the Mod88."
 	default_ammo = /datum/ammo/bullet/pistol/incendiary
 	ammo_band_color = AMMO_BAND_COLOR_INCENDIARY
 	mag_jam_modifier = MAG_JAM_MOD_PISTOL_LOW
 
 /obj/item/ammo_magazine/pistol/mod88/rubber
 	name = "\improper 88M4 rubber magazine (9mm)"
+	desc = "A 9mm pistol magazine for the Mod88. This one contains rubber bullets."
 	default_ammo = /datum/ammo/bullet/pistol/rubber
 	ammo_band_color = AMMO_BAND_COLOR_RUBBER
 	mag_jam_modifier = MAG_JAM_MOD_PISTOL_RUBBER //youre firing rubber, of course its gonna jam your shit a lot more... but its smaller so we give it a little pass
@@ -134,6 +144,7 @@
 
 /obj/item/ammo_magazine/pistol/vp78
 	name = "\improper VP78 magazine (9mm)"
+	desc = "A 9mm pistol magazine for the VP78."
 	default_ammo = /datum/ammo/bullet/pistol/squash
 	caliber = "9mm"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/WY/pistols.dmi'
@@ -145,24 +156,28 @@
 
 /obj/item/ammo_magazine/pistol/vp78/toxin
 	name = "\improper VP78 toxic magazine (9mm)"
+	desc = "A toxin 9mm pistol magazine for the VP78."
 	default_ammo = /datum/ammo/bullet/pistol/squash/toxin
 	ammo_band_color = AMMO_BAND_COLOR_TOXIN
 	mag_jam_modifier = MAG_JAM_MOD_PISTOL_LOW
 
 /obj/item/ammo_magazine/pistol/vp78/penetrating
 	name = "\improper VP78 wall-penetrating magazine (9mm)"
+	desc = "A wall-penetrating 9mm pistol magazine for the VP78."
 	default_ammo = /datum/ammo/bullet/pistol/squash/penetrating
 	ammo_band_color = AMMO_BAND_COLOR_PENETRATING
 	mag_jam_modifier = MAG_JAM_MOD_PISTOL_FAIR
 
 /obj/item/ammo_magazine/pistol/vp78/incendiary
 	name = "\improper VP78 incendiary magazine (9mm)"
+	desc = "An incendiary 9mm pistol magazine for the VP78."
 	default_ammo = /datum/ammo/bullet/pistol/squash/incendiary
 	ammo_band_color = AMMO_BAND_COLOR_INCENDIARY
 	mag_jam_modifier = MAG_JAM_MOD_PISTOL_LOW
 
 /obj/item/ammo_magazine/pistol/vp78/rubber
 	name = "\improper VP78 rubber magazine (9mm)"
+	desc = "A 9mm pistol magazine for the VP78. This one is loaded with rubber bullets."
 	default_ammo = /datum/ammo/bullet/pistol/squash/rubber
 	ammo_band_color = AMMO_BAND_COLOR_RUBBER
 
@@ -171,6 +186,7 @@
 
 /obj/item/ammo_magazine/pistol/b92fs
 	name = "\improper Beretta 92FS magazine (9mm)"
+	desc = "A 9mm pistol magazine for the Beretta 92FS."
 	caliber = "9mm"
 	icon_state = "m4a3" //PLACEHOLDER
 	max_rounds = 15
@@ -183,6 +199,7 @@
 
 /obj/item/ammo_magazine/pistol/heavy
 	name = "\improper Desert Eagle magazine (.50)"
+	desc = "Seven rounds of powerful 50-caliber destruction."
 	default_ammo = /datum/ammo/bullet/pistol/deagle
 	caliber = ".50"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/colony/pistols.dmi'
@@ -209,7 +226,7 @@
 
 /obj/item/ammo_magazine/pistol/heavy/super/highimpact/ap
 	name = "\improper High Impact Armor-Piercing Desert Eagle magazine (.50)"
-	desc = "Seven rounds of devastatingly powerful 50-caliber destruction. Packs a devastating punch. The bullets are tipped with an osmium-tungsten carbide alloy to not only stagger but shred through any target's armor. Issued in few numbers due to the massive production cost and worries about hull breaches. Point away from anything you value."
+	desc = "Seven rounds of devastatingly powerful 50-caliber destruction. Packs a devastating punch. The bullets are tipped with an osmium-tungsten carbide alloy to not only stagger but also shred through any target's armor. Issued in few numbers due to the massive production cost and worries about hull breaches. Point away from anything you value."
 	default_ammo = /datum/ammo/bullet/pistol/heavy/super/highimpact/ap
 	ammo_band_color = AMMO_BAND_COLOR_AP
 	mag_jam_modifier = MAG_JAM_MOD_PISTOL_CRITICAL
@@ -219,6 +236,7 @@
 
 /obj/item/ammo_magazine/pistol/np92
 	name = "\improper NP92 magazine (9x18mm Makarov)"
+	desc = "A 9x18mm Makarov pistol magazine, for use in the NP92."
 	default_ammo = /datum/ammo/bullet/pistol
 	caliber = "9x18mm Makarov"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/UPP/pistols.dmi'
@@ -228,6 +246,7 @@
 
 /obj/item/ammo_magazine/pistol/np92/suppressed
 	name = "\improper NPZ92 magazine (9x18mm Makarov)"
+	desc = "A 9x18mm Makarov pistol magazine, for use in the NPZ92."
 	default_ammo = /datum/ammo/bullet/pistol
 	caliber = "9x18mm Makarov"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/UPP/pistols.dmi'
@@ -236,6 +255,7 @@
 
 /obj/item/ammo_magazine/pistol/np92/tranq
 	name = "\improper NPZ92 tranq magazine (9x18mm Makarov)"
+	desc = "A tranquilizer 9x18mm Makaraov pistol magazine."
 	default_ammo = /datum/ammo/bullet/pistol/tranq
 	caliber = "9x18mm Makarov"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/UPP/pistols.dmi'
@@ -248,6 +268,7 @@
 
 /obj/item/ammo_magazine/pistol/t73
 	name = "\improper Type 73 magazine (7.62x25mm Tokarev)"
+	desc = "A 7.62x25mm pistol magazine."
 	default_ammo = /datum/ammo/bullet/pistol/heavy
 	caliber = "7.62x25mm Tokarev"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/UPP/pistols.dmi'
@@ -257,6 +278,7 @@
 
 /obj/item/ammo_magazine/pistol/t73_impact
 	name = "\improper High Impact Type 74 magazine (7.62x25mm Tokarev)"
+	desc = "A high-impact 7.62x25mm Tokarev pistol magazine. The bullets are tipped with a tungsten-lead alloy to stagger absolutely anything they hit. Point towards dissidents."
 	default_ammo = /datum/ammo/bullet/pistol/heavy/super/highimpact/upp
 	caliber = "7.62x25mm Tokarev"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/UPP/pistols.dmi'
@@ -270,6 +292,7 @@
 
 /obj/item/ammo_magazine/pistol/kt42
 	name = "\improper KT-42 magazine (.44)"
+	desc = "A .44 pistol magazine."
 	default_ammo = /datum/ammo/bullet/pistol/heavy
 	caliber = ".44"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/colony/pistols.dmi'
@@ -312,6 +335,7 @@
 
 /obj/item/ammo_magazine/pistol/highpower
 	name = "\improper MK-45 Automagnum magazine (.45)"
+	desc = "A .45 pistol magazine."
 	default_ammo = /datum/ammo/bullet/pistol/highpower
 	caliber = ".45"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/colony/pistols.dmi'
@@ -332,6 +356,7 @@ It is a modified Beretta 93R, and can fire three-round burst or single fire. Whe
 
 /obj/item/ammo_magazine/pistol/auto9
 	name = "\improper Auto-9 magazine (9mm)"
+	desc = "A 9mm pistol magazine for the Auto-9 pistol. Squash-head to squash criminal's heads.
 	default_ammo = /datum/ammo/bullet/pistol/squash
 	caliber = "9mm"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/WY/pistols.dmi'
@@ -345,6 +370,7 @@ It is a modified Beretta 93R, and can fire three-round burst or single fire. Whe
 //The first rule of monkey pistol is we don't talk about monkey pistol.
 /obj/item/ammo_magazine/pistol/chimp
 	name = "\improper CHIMP70 magazine (.70M)"
+	desc = "A .70M banana-mag."
 	default_ammo = /datum/ammo/bullet/pistol/mankey
 	caliber = ".70M"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/event.dmi'
@@ -359,6 +385,7 @@ It is a modified Beretta 93R, and can fire three-round burst or single fire. Whe
 
 /obj/item/ammo_magazine/pistol/smart
 	name = "\improper SU-6 Smartpistol magazine (.45)"
+	desc = "An IFF-compatible .45 pistol magazine, for use in the SU-6."
 	default_ammo = /datum/ammo/bullet/pistol/smart
 	caliber = ".45"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/USCM/pistols.dmi'
@@ -371,7 +398,7 @@ It is a modified Beretta 93R, and can fire three-round burst or single fire. Whe
 
 /obj/item/ammo_magazine/pistol/skorpion
 	name = "\improper CZ-81 20-round magazine (.32ACP)"
-	desc = "A .32ACP caliber magazine for the CZ-81."
+	desc = "A .32ACP magazine for the CZ-81."
 	caliber = ".32ACP"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/colony/smgs.dmi'
 	icon_state = "skorpion" //PLACEHOLDER
@@ -399,7 +426,7 @@ Unlike other pistols, it can be equipped with limited mods (small muzzle, magazi
 
 /obj/item/ammo_magazine/pistol/m10/extended
 	name = "\improper M10 HV extended magazine (10x20mm)"
-	desc = "A 78-round high-velocity magazine, offering additional firepower for sustained engagements without significantly increasing reload time."
+	desc = "An extended 10x20mm 78-round high-velocity magazine, offering additional firepower for sustained engagements without significantly increasing reload time."
 	default_ammo = /datum/ammo/bullet/smg/m39
 	caliber = "10x20mm"
 	icon_state = "m10_ext"
@@ -410,7 +437,7 @@ Unlike other pistols, it can be equipped with limited mods (small muzzle, magazi
 
 /obj/item/ammo_magazine/pistol/m10/drum
 	name = "\improper M10 HV drum magazine (10x20mm)"
-	desc = "High-capacity 92-round drum magazine designed for prolonged firefights, delivering maximum ammunition capacity at the cost of a longer reload."
+	desc = "A super-extended 10x20mm 92-round drum magazine designed for prolonged firefights, delivering maximum ammunition capacity at the cost of a longer reload."
 	default_ammo = /datum/ammo/bullet/smg/m39
 	caliber = "10x20mm"
 	icon_state = "m10_drum"

--- a/code/modules/projectiles/magazines/pistols.dm
+++ b/code/modules/projectiles/magazines/pistols.dm
@@ -356,7 +356,7 @@ It is a modified Beretta 93R, and can fire three-round burst or single fire. Whe
 
 /obj/item/ammo_magazine/pistol/auto9
 	name = "\improper Auto-9 magazine (9mm)"
-	desc = "A 9mm pistol magazine for the Auto-9 pistol. Squash-head to squash criminal's heads.
+	desc = "A 9mm pistol magazine for the Auto-9 pistol. Squash-head to squash criminal's heads."
 	default_ammo = /datum/ammo/bullet/pistol/squash
 	caliber = "9mm"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/WY/pistols.dmi'

--- a/code/modules/projectiles/magazines/revolvers.dm
+++ b/code/modules/projectiles/magazines/revolvers.dm
@@ -3,7 +3,7 @@
 
 /obj/item/ammo_magazine/revolver
 	name = "\improper M44 speed loader (.44)"
-	desc = "A revolver speed loader."
+	desc = "A 7-round .44 revolver speed loader."
 	default_ammo = /datum/ammo/bullet/revolver
 	flags_equip_slot = NO_FLAGS
 	caliber = ".44"
@@ -22,29 +22,33 @@
 
 /obj/item/ammo_magazine/revolver/marksman
 	name = "\improper M44 marksman speed loader (.44)"
+	desc = "A 7-round .44 revolver speed loader containing long-range armor-piercing marksman bullets."
 	default_ammo = /datum/ammo/bullet/revolver/marksman
 	caliber = ".44"
 	ammo_band_color = REVOLVER_TIP_COLOR_MARKSMAN
 
 /obj/item/ammo_magazine/revolver/heavy
 	name = "\improper M44 heavy speed loader (.44)"
-	desc = "A revolver speed loader containing heavy bullets. While less damaging overall than the traditional rounds, they are more accurate."
+	desc = "A 7-round .44 revolver speed loader containing heavy bullets. While less damaging than traditional .44 rounds, they deliver a higher stopping power."
 	default_ammo = /datum/ammo/bullet/revolver/heavy
 	caliber = ".44"
 	ammo_band_color = REVOLVER_TIP_COLOR_HEAVY
 
 /obj/item/ammo_magazine/revolver/incendiary
 	name = "\improper M44 incendiary speed loader (.44)"
+	desc = "a 7-round .44 revolver speed loader containing incendiary bullets."
 	default_ammo = /datum/ammo/bullet/revolver/incendiary
 	ammo_band_color = REVOLVER_TIP_COLOR_INCENDIARY
 
 /obj/item/ammo_magazine/revolver/marksman/toxin
 	name = "\improper M44 toxic speed loader (.44)"
+	desc = "a 7-round .44 revolver speed loader containing toxin bullets."
 	default_ammo = /datum/ammo/bullet/revolver/marksman/toxin
 	ammo_band_color = REVOLVER_TIP_COLOR_TOXIN
 
 /obj/item/ammo_magazine/revolver/penetrating
 	name = "\improper M44 wall-penetrating speed loader (.44)"
+	desc = "A 7-round .44 revolver speed loader containing wall-penetrating bullets."
 	default_ammo = /datum/ammo/bullet/revolver/penetrating
 	ammo_band_color = REVOLVER_TIP_COLOR_PENETRATING
 
@@ -61,6 +65,7 @@
 
 /obj/item/ammo_magazine/revolver/upp
 	name = "\improper ZHNK-72 speed loader (7.62x38mmR)"
+	desc = "A 7-round 7.62x38mmR revolver speed loader."
 	default_ammo = /datum/ammo/bullet/revolver/upp
 	caliber = "7.62x38mmR"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/UPP/revolvers.dmi'
@@ -75,6 +80,7 @@
 
 /obj/item/ammo_magazine/revolver/small
 	name = "\improper S&W speed loader (.38)"
+	desc = "a 6-round .38 revolver speed loader."
 	default_ammo = /datum/ammo/bullet/revolver/small
 	caliber = ".38"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/colony/revolvers.dmi'
@@ -84,7 +90,7 @@
 
 /obj/item/ammo_magazine/revolver/cmb
 	name = "\improper Spearhead hollowpoint speed loader (.357)"
-	desc = "This speedloader was created for the Colonial Marshals' most commonly issued sidearm, loaded with hollowpoint rounds either for colonies with wildlife problems or orbital stations, which favor the lesser penetration over other ammunition to lessen the risk of hull breaches. In exchange, they're near useless against armored targets, but what's the chance of that being a problem on a space station?"
+	desc = "This 6-round speed loader was created for the Colonial Marshals' most commonly issued sidearm, loaded with hollow-point rounds either for colonies with wildlife problems or orbital stations, which favor the lesser penetration over other ammunition to reduce the risk of hull breaches. In exchange, they're near useless against armored targets, but what's the chance of that being a problem on a space station?"
 	default_ammo = /datum/ammo/bullet/revolver/small/hollowpoint
 	caliber = ".357"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/colony/revolvers.dmi'
@@ -94,7 +100,7 @@
 
 /obj/item/ammo_magazine/revolver/cmb/normalpoint //put these in the marshal ert - ok sure :)
 	name = "\improper Spearhead speed loader (.357)"
-	desc = "This speedloader is fitted with standard .357 revolver bullets. A surprising rarity, as most CMB revolvers are issued to Marshals on colonies with wildlife, or weakly-hulled space stations."
+	desc = "This 6-round speed loader is fitted with standard .357 revolver bullets. A surprising rarity, as most CMB revolvers are issued with hollow-point rounds to Marshals on colonies with inimical wildlife, or thin-hulled space stations."
 	default_ammo = /datum/ammo/bullet/revolver/small/cmb
 	icon_state = "cmb"
 
@@ -104,7 +110,7 @@
 
 /obj/item/ammo_magazine/revolver/mateba
 	name = "\improper Mateba speed loader (.454)"
-	desc = "A formidable .454 speedloader, made exclusively for the Mateba autorevolver. Packs a devastating punch. This standard-variant is optimized for anti-armor."
+	desc = "A formidable 6-round .454 speedloader, made exclusively for the Mateba autorevolver. Packs a devastating punch. This standard-variant is optimized for anti-armor."
 	default_ammo = /datum/ammo/bullet/revolver/mateba
 	caliber = ".454"
 	icon_state = "mateba"
@@ -113,19 +119,19 @@
 
 /obj/item/ammo_magazine/revolver/mateba/highimpact
 	name = "\improper High Impact Mateba speed loader (.454)"
-	desc = "A formidable .454 speedloader, made exclusively for the Mateba autorevolver. Packs a devastating punch. This high impact variant is optimized for anti-personnel. Don't point at anything you don't want to destroy."
+	desc = "A formidable 6-round .454 speedloader, made exclusively for the Mateba autorevolver. Packs a devastating punch. This high impact variant is optimized for anti-personnel. Don't point at anything you don't want to destroy."
 	default_ammo = /datum/ammo/bullet/revolver/mateba/highimpact
 	ammo_band_color = REVOLVER_TIP_COLOR_HIGH_IMPACT
 
 /obj/item/ammo_magazine/revolver/mateba/highimpact/ap
 	name = "\improper High Impact Armor-Piercing Mateba speed loader (.454)"
-	desc = "A formidable .454 speedloader, made exclusively for the Mateba autorevolver. Packs a devastating punch. This armor-piercing variant is optimized against armored targets at the cost of lower overall damage. Don't point at anything you don't want to destroy."
+	desc = "A formidable 6-round .454 speedloader, made exclusively for the Mateba autorevolver. Packs a devastating punch. This armor-piercing variant is optimized against armored targets at the cost of lower overall damage. Don't point at anything you don't want to destroy."
 	default_ammo = /datum/ammo/bullet/revolver/mateba/highimpact/ap
 	ammo_band_color = REVOLVER_TIP_COLOR_AP
 
 /obj/item/ammo_magazine/revolver/mateba/highimpact/explosive
 	name = "\improper Mateba explosive speed loader (.454)"
-	desc = "A formidable .454 speedloader, made exclusively for the Mateba autorevolver. There's an impact charge built into the bullet tip. Firing this at anything will result in a powerful explosion. Use with EXTREME caution."
+	desc = "A formidable 6-round .454 speedloader, made exclusively for the Mateba autorevolver. There's an impact charge built into the bullet tip. Firing this at anything will result in a powerful explosion. Use with EXTREME caution."
 	default_ammo = /datum/ammo/bullet/revolver/mateba/highimpact/explosive
 	ammo_band_color = REVOLVER_TIP_COLOR_EXPLOSIVE
 

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -310,7 +310,7 @@
 
 /obj/item/ammo_magazine/rifle/lmg/holo_target
 	name = "\improper M41AE2 ammo box (10x24mm holo-target)"
-	desc = "A semi-rectangular box of holo-target rounds for the M41AE2 Heavy Pulse Rifle."
+	desc = "A semi-rectangular holo-targeting box magazine for the M41AE2 Heavy Pulse Rifle."
 	default_ammo = /datum/ammo/bullet/rifle/holo_target
 	max_rounds = 200
 	ammo_band_color = AMMO_BAND_COLOR_HOLOTARGETING
@@ -318,7 +318,7 @@
 
 /obj/item/ammo_magazine/rifle/lmg/ap
 	name = "\improper M41AE2 ammo box (10x24mm armor-piercing)"
-	desc = "A semi-rectangular box of armor-piercing rounds for the M41AE2 Heavy Pulse Rifle."
+	desc = "A semi-rectangular armor piercing box magazine for the M41AE2 Heavy Pulse Rifle."
 	default_ammo = /datum/ammo/bullet/rifle/ap
 	max_rounds = 300
 	ammo_band_color = AMMO_BAND_COLOR_AP
@@ -326,7 +326,7 @@
 
 /obj/item/ammo_magazine/rifle/lmg/heap
 	name = "\improper M41AE2 ammo box (10x24mm high-explosive armor-piercing)"
-	desc = "A semi-rectangular box of rounds for the M41AE2 Heavy Pulse Rifle. This one contains the standard Armor-Piercing explosive tipped round of the USCM."
+	desc = "A semi-rectangular box magazine for the M41AE2 Heavy Pulse Rifle. This one contains the standard armor-piercing explosive tipped round of the USCM."
 	default_ammo = /datum/ammo/bullet/rifle/heap
 	max_rounds = 300
 	gun_type = /obj/item/weapon/gun/rifle/lmg
@@ -350,13 +350,13 @@
 
 /obj/item/ammo_magazine/rifle/type71/ap
 	name = "\improper Type 71 AP magazine (5.45x39mm)"
-	desc = "A 5.45x39mm high-capacity casket magazine containing armor piercing rounds for the Type 71 rifle."
+	desc = "An armor piercing 5.45x39mm high-capacity casket magazine for the Type 71 rifle."
 	default_ammo = /datum/ammo/bullet/rifle/type71/ap
 	ammo_band_color = AMMO_BAND_COLOR_AP
 
 /obj/item/ammo_magazine/rifle/type71/heap
 	name = "\improper Type 71 HEAP magazine (5.45x39mm)"
-	desc = "A 5.45x39mm high-capacity casket magazine containing the standard high explosive armor piercing rounds for the Type 71 rifle."
+	desc = "A standard high explosive armor piercing 5.45x39mm high-capacity casket magazine for the Type 71 rifle."
 	default_ammo = /datum/ammo/bullet/rifle/type71/heap
 	ammo_band_color = AMMO_BAND_COLOR_HEAP
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_HIGH
@@ -366,7 +366,7 @@
 
 /obj/item/ammo_magazine/rifle/l42a
 	name = "\improper L42A magazine (10x24mm)"
-	desc = "A 10mm battle rifle magazine."
+	desc = "A 10x24mm battle rifle magazine."
 	caliber = "10x24mm"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/USCM/marksman_rifles.dmi'
 	icon_state = "l42mk1"
@@ -381,46 +381,48 @@
 
 /obj/item/ammo_magazine/rifle/l42a/ap
 	name = "\improper L42A AP magazine (10x24mm)"
-	desc = "A 10mm battle rifle armor piercing magazine."
+	desc = "An armor piercing 10x24mm battle rifle magazine."
 	default_ammo = /datum/ammo/bullet/rifle/ap
 	ammo_band_color = AMMO_BAND_COLOR_AP
 
 /obj/item/ammo_magazine/rifle/l42a/le
 	name = "\improper L42A LE magazine (10x24mm)"
-	desc = "A 10mm battle rifle armor shredding magazine."
+	desc = "An armor-shredding 10x24mm battle rifle magazine."
 	default_ammo = /datum/ammo/bullet/rifle/le
 	ammo_band_color = AMMO_BAND_COLOR_LIGHT_EXPLOSIVE
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_MEDIUM
 
 /obj/item/ammo_magazine/rifle/l42a/rubber
 	name = "L42A rubber magazine (10x24mm)"
+	desc = "A 10x24mm battle rifle magazine filled with rubber bullets."
 	default_ammo = /datum/ammo/bullet/rifle/rubber
 	ammo_band_color = AMMO_BAND_COLOR_RUBBER
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_RUBBER //youre firing rubber, of course its gonna jam your shit a lot more
 
 /obj/item/ammo_magazine/rifle/l42a/heap
 	name = "\improper L42A HEAP (10x24mm)"
-	desc = "A 10mm battle rifle high explosive armor piercing magazine."
+	desc = "A high-explosive armor-piercing 10x24mm battle rifle magazine."
 	default_ammo = /datum/ammo/bullet/rifle/heap
 	ammo_band_color = AMMO_BAND_COLOR_HEAP
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_HIGH
 
 /obj/item/ammo_magazine/rifle/l42a/penetrating
 	name = "\improper L42A wall-penetrating magazine (10x24mm)"
+	desc = "A wall-penetrating 10x24mm battle rifle magazine."
 	default_ammo = /datum/ammo/bullet/rifle/ap/penetrating
 	ammo_band_color = AMMO_BAND_COLOR_PENETRATING
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_FAIR
 
 /obj/item/ammo_magazine/rifle/l42a/toxin
 	name = "\improper L42A toxin magazine (10x24mm)"
-	desc = "A 10mm battle rifle toxin magazine."
+	desc = "A toxin 10x244mm battle rifle magazine."
 	default_ammo = /datum/ammo/bullet/rifle/ap/toxin
 	ammo_band_color = AMMO_BAND_COLOR_TOXIN
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_LOW
 
 /obj/item/ammo_magazine/rifle/l42a/extended
 	name = "\improper L42A extended magazine (10x24mm)"
-	desc = "A 10mm battle rifle extended magazine."
+	desc = "An extended 10x24mm battle rifle magazine."
 	caliber = "10x24mm"
 	icon_state = "l42mk1_extended"
 	bonus_overlay = "l42_ex_overlay"
@@ -432,7 +434,7 @@
 
 /obj/item/ammo_magazine/rifle/l42a/incendiary
 	name = "\improper L42A incendiary magazine (10x24mm)"
-	desc = "A 10mm battle rifle incendiary magazine."
+	desc = "An incendiary 10mm battle rifle magazine."
 	caliber = "10x24mm"
 	default_ammo = /datum/ammo/bullet/rifle/incendiary
 	max_rounds = 20
@@ -486,20 +488,20 @@
 
 /obj/item/ammo_magazine/rifle/nsg23/ap
 	name = "\improper NSG 23 armor-piercing magazine (10x24mm)"
-	desc = "An NSG 23 assault rifle magazine. This one is armor piercing."
+	desc = "An armor-piercing NSG 23 assault rifle magazine."
 	default_ammo = /datum/ammo/bullet/rifle/ap
 	ammo_band_color = AMMO_BAND_COLOR_AP
 
 /obj/item/ammo_magazine/rifle/nsg23/heap
 	name = "\improper NSG 23 HEAP magazine (10x24mm)"
-	desc = "An NSG 23 assault rifle magazine. This one is loaded with armor-piercing explosive tipped rounds."
+	desc = "A high-explosive armor-piercing NSG 23 assault rifle magazine."
 	default_ammo = /datum/ammo/bullet/rifle/heap
 	ammo_band_color = AMMO_BAND_COLOR_HEAP
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_HIGH
 
 /obj/item/ammo_magazine/rifle/nsg23/incendiary
 	name = "\improper NSG 23 incindiary magazine (10x24mm)"
-	desc = "An NSG 23 assault rifle magazine. This one is loaded with incendiary white phosphorus tipped rounds."
+	desc = "A white phosphorus-tipped incendiary NSG 23 assault rifle magazine."
 	default_ammo = /datum/ammo/bullet/rifle/incendiary
 	ammo_band_color = AMMO_BAND_COLOR_INCENDIARY
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_LOW
@@ -526,7 +528,7 @@
 
 /obj/item/ammo_magazine/rifle/boltaction/vulture
 	name = "\improper M707 \"Vulture\" magazine (20x102mm)"
-	desc = "A magazine for the M707 \"Vulture\" anti-matieriel rifle. Contains up to 4 massively oversized rounds."
+	desc = "A magazine for the M707 \"Vulture\" anti-materiel rifle. Contains up to 4 massively oversized rounds."
 	caliber = "20x102mm"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/USCM/marksman_rifles.dmi'
 	icon_state = "vulture"
@@ -540,7 +542,7 @@
 
 /obj/item/ammo_magazine/rifle/boltaction/vulture/holo_target
 	name = "\improper M707 \"Vulture\" holo-target magazine (20x102mm)"
-	desc = "A magazine for the M707 \"Vulture\" anti-matieriel rifle. Contains up to 4 massively oversized <b>IFF-CAPABLE</b> holo-targeting rounds, which excel at marking heavy targets to be attacked by allied ground forces. The logistical requirements for such capabilities heavily hinder the performance and stopping power of this round."
+	desc = "A magazine for the M707 \"Vulture\" anti-materiel rifle. Contains up to 4 massively oversized <b>IFF-CAPABLE</b> holo-targeting rounds, which excel at marking heavy targets to be attacked by allied ground forces. The logistical requirements for such capabilities heavily hinder the performance and stopping power of this round."
 	default_ammo =  /datum/ammo/bullet/sniper/anti_materiel/vulture/holo_target
 	ammo_band_color = AMMO_BAND_COLOR_HOLOTARGETING
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_FAIR
@@ -549,7 +551,7 @@
 
 /obj/item/ammo_magazine/rifle/rmc_f90
 	name = "\improper F903 magazine (10x24mm)"
-	desc = "A 10mm assault rifle magazine used by the royal marines."
+	desc = "A 10x24mm F903 assault rifle magazine."
 	caliber = "10x24mm"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/TWE/assault_rifles.dmi'
 	icon_state = "aug"
@@ -563,7 +565,7 @@
 
 /obj/item/ammo_magazine/rifle/rmc_f90/marksman
 	name = "\improper F903A1 Marksman magazine (10x24mm)"
-	desc = "A 10mm armor-piercing assault rifle magazine used by the royal marines."
+	desc = "An armor-piercing 10x24mm armor-piercing F903 assault rifle magazine."
 	icon_state = "aug_dmr"
 	item_state = "aug_dmr"
 	default_ammo = /datum/ammo/bullet/rifle/ap
@@ -575,14 +577,14 @@
 
 /obj/item/ammo_magazine/rifle/rmc_f90/heap
 	name = "\improper F903 HEAP magazine (10x24mm)"
-	desc = "A 10mm armor piercing high explosive assault rifle magazine used by the royal marines."
+	desc = "A high-explosive armor-piercing 10x24mm armor piercing high explosive assault rifle magazine."
 	default_ammo = /datum/ammo/bullet/rifle/heap
 	ammo_band_color = AMMO_BAND_COLOR_HEAP
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_HIGH
 
 /obj/item/ammo_magazine/rifle/rmc_f90/marksman/heap
 	name = "\improper F903A1 Marksman magazine (10x24mm)"
-	desc = "A 10mm armor piercing high explosive assault rifle magazine used by the royal marines."
+	desc = "A high-explosive armor-piercing 10x24mm F903 assault rifle magazine."
 	icon_state = "aug_dmr"
 	item_state = "aug_dmr"
 	default_ammo = /datum/ammo/bullet/rifle/heap
@@ -591,7 +593,7 @@
 
 /obj/item/ammo_magazine/rifle/l23
 	name = "\improper L23 magazine (8.88x51mm)"
-	desc = "An L23 assault rifle magazine."
+	desc = "An 8.88x51mm L23 assault rifle magazine."
 	caliber = "8.88x51mm"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/TWE/assault_rifles.dmi'
 	icon_state = "l23"
@@ -604,7 +606,7 @@
 
 /obj/item/ammo_magazine/rifle/l23/extended
 	name = "\improper L23 high-capacity drum magazine (8.88x51mm)"
-	desc = "An L23 assault rifle magazine. This one contains 45 bullets."
+	desc = "An 8.88x51mm L23 assault rifle magazine. This one contains 45 bullets."
 	icon_state = "l23_ext"
 	item_state = "l23_ext"
 	bonus_overlay = "l23_ext_overlay"
@@ -613,20 +615,20 @@
 
 /obj/item/ammo_magazine/rifle/l23/ap
 	name = "\improper L23 armor-piercing magazine (8.88x51mm)"
-	desc = "An L23 assault rifle magazine. This one is armor piercing."
+	desc = "An armor-piercing 8.88x51mm L23 assault rifle magazine."
 	default_ammo = /datum/ammo/bullet/rifle/l23/ap
 	ammo_band_color = AMMO_BAND_COLOR_AP
 
 /obj/item/ammo_magazine/rifle/l23/heap
 	name = "\improper L23 HEAP magazine (8.88x51mm)"
-	desc = "An L23 assault rifle magazine. This one is loaded with armor-piercing explosive tipped rounds."
+	desc = "A high-explosive armor-piercing 8.88x51mm L23 assault rifle magazine."
 	default_ammo = /datum/ammo/bullet/rifle/l23/heap
 	ammo_band_color = AMMO_BAND_COLOR_HEAP
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_HIGH
 
 /obj/item/ammo_magazine/rifle/l23/incendiary
 	name = "\improper L23 incindiary magazine (8.88x51mm)"
-	desc = "An L23 assault rifle magazine. This one is loaded with incendiary white phosphorus tipped rounds."
+	desc = "A white phosphorus-tipped incendiary 8.88x51mm L23 assault rifle magazine."
 	default_ammo = /datum/ammo/bullet/rifle/l23/incendiary
 	ammo_band_color = AMMO_BAND_COLOR_INCENDIARY
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_LOW
@@ -640,7 +642,7 @@
 
 /obj/item/ammo_magazine/rifle/l23/toxin
 	name = "\improper L23 toxin magazine (8.88x51mm)"
-	desc = "A 8.88mm toxin magazine."
+	desc = "A toxin 8.88x51mm L23 assault rifle magazine."
 	default_ammo = /datum/ammo/bullet/rifle/l23/ap/toxin
 	ammo_band_color = AMMO_BAND_COLOR_TOXIN
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_LOW
@@ -650,7 +652,7 @@
 
 /obj/item/ammo_magazine/rifle/xm51
 	name = "\improper XM51 magazine (16g)"
-	desc = "A 16 gauge pump-action shotgun magazine."
+	desc = "A 16 gauge shotgun magazine."
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/USCM/shotguns.dmi'
 	icon_state = "xm51"
 	caliber = "16g"
@@ -667,7 +669,7 @@
 
 /obj/item/ammo_magazine/rifle/xm51/cmb/rubber
 	name = "\improper Model 1771 magazine (16g rubber buckshot)"
-	desc = "A 16 gauge pump-action rubber shotgun magazine."
+	desc = "A 16 gauge rubber buckshot shotgun magazine."
 	icon_state = "m51b_rubber"
 	gun_type = /obj/item/weapon/gun/rifle/xm51/cmb
 	default_ammo = /datum/ammo/bullet/shotgun/light/rubber
@@ -691,7 +693,7 @@
 
 /obj/item/ammo_magazine/rifle/sharp/explosive
 	name = "\improper 9X-E sticky explosive dart magazine"
-	desc = "A specialized sticky explosive dart magazine for the SHARP rifle."
+	desc = "A specialized explosive sticky dart magazine for the SHARP rifle."
 
 /obj/item/ammo_magazine/rifle/sharp/incendiary
 	name = "\improper 9X-T sticky incendiary dart magazine"

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -55,6 +55,7 @@
 /obj/item/ammo_magazine/rifle/ap
 	name = "\improper M41A AP magazine (10x24mm)"
 	desc = "An armor piercing 10x24mm assault rifle magazine."
+	desc_lore = "Unlike standard HEAP magazines, these reserve bullets do not have depleted uranium tips. Instead, these rounds trade off some of their bullet package for a lighter weight, reducing damage but increasing penetration capabilities and muzzle velocity.
 	default_ammo = /datum/ammo/bullet/rifle/ap
 	ammo_band_color = AMMO_BAND_COLOR_AP
 

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -6,7 +6,7 @@
 
 /obj/item/ammo_magazine/rifle
 	name = "\improper M41A magazine (10x24mm)"
-	desc = "A 10mm assault rifle magazine."
+	desc = "A 10x24mm assault rifle magazine."
 	caliber = "10x24mm"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/USCM/assault_rifles.dmi'
 	icon_state = "m41a"
@@ -24,7 +24,7 @@
 
 /obj/item/ammo_magazine/rifle/extended
 	name = "\improper M41A extended magazine (10x24mm)"
-	desc = "A 10mm assault extended rifle magazine."
+	desc = "An extended 10x24mm assault rifle magazine."
 	icon_state = "m41a_extended"
 	max_rounds = 60
 	bonus_overlay_icon = 'icons/obj/items/weapons/guns/guns_by_faction/USCM/assault_rifles.dmi'
@@ -33,55 +33,55 @@
 
 /obj/item/ammo_magazine/rifle/incendiary
 	name = "\improper M41A incendiary magazine (10x24mm)"
-	desc = "A 10mm assault rifle magazine."
+	desc = "An incendiary 10x24mm assault rifle magazine."
 	default_ammo = /datum/ammo/bullet/rifle/incendiary
 	ammo_band_color = AMMO_BAND_COLOR_INCENDIARY
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_LOW
 
 /obj/item/ammo_magazine/rifle/explosive
 	name = "\improper M41A explosive magazine (10x24mm)"
-	desc = "A 10mm assault rifle magazine. Oh god... just don't hit friendlies with it."
+	desc = "An explosive 10x24mm assault rifle magazine. Oh god... just don't hit friendlies with it."
 	default_ammo = /datum/ammo/bullet/rifle/explosive
 	ammo_band_color = AMMO_BAND_COLOR_EXPLOSIVE
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_CRITICAL
 
 /obj/item/ammo_magazine/rifle/heap
 	name = "\improper M41A HEAP magazine (10x24mm)"
-	desc = "A 10mm armor piercing high explosive magazine."
+	desc = "A high explosive armor piercing 10x24mm assault rifle magazine."
 	default_ammo = /datum/ammo/bullet/rifle/heap
 	ammo_band_color = AMMO_BAND_COLOR_HEAP
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_HIGH
 
 /obj/item/ammo_magazine/rifle/ap
 	name = "\improper M41A AP magazine (10x24mm)"
-	desc = "A 10mm armor piercing magazine."
+	desc = "An armor piercing 10x24mm assault rifle magazine."
 	default_ammo = /datum/ammo/bullet/rifle/ap
 	ammo_band_color = AMMO_BAND_COLOR_AP
 
 /obj/item/ammo_magazine/rifle/le
 	name = "\improper M41A LE magazine (10x24mm)"
-	desc = "A 10mm armor shredding magazine."
+	desc = "An armor-shredding 10x24mm assault rifle magazine."
 	default_ammo = /datum/ammo/bullet/rifle/le
 	ammo_band_color = AMMO_BAND_COLOR_LIGHT_EXPLOSIVE
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_MEDIUM
 
 /obj/item/ammo_magazine/rifle/penetrating
 	name = "\improper M41A wall-penetrating magazine (10x24mm)"
-	desc = "A 10mm wall-penetrating magazine."
+	desc = "A wall-penetrating 10x24mm assault rifle magazine."
 	default_ammo = /datum/ammo/bullet/rifle/ap/penetrating
 	ammo_band_color = AMMO_BAND_COLOR_PENETRATING
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_FAIR
 
 /obj/item/ammo_magazine/rifle/toxin
 	name = "\improper M41A toxin magazine (10x24mm)"
-	desc = "A 10mm toxin magazine."
+	desc = "A toxin 10x24mm assault rifle magazine."
 	default_ammo = /datum/ammo/bullet/rifle/ap/toxin
 	ammo_band_color = AMMO_BAND_COLOR_TOXIN
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_LOW
 
 /obj/item/ammo_magazine/rifle/rubber
 	name = "M41A Rubber Magazine (10x24mm)"
-	desc = "A 10mm magazine filled with rubber bullets."
+	desc = "A 10x24mm assault rifle magazine filled with rubber bullets."
 	default_ammo = /datum/ammo/bullet/rifle/rubber
 	ammo_band_color = AMMO_BAND_COLOR_RUBBER
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_RUBBER //youre firing rubber, of course its gonna jam your shit a lot more
@@ -140,7 +140,7 @@
 
 /obj/item/ammo_magazine/rifle/m4ra
 	name = "\improper M4RA magazine (10x24mm)"
-	desc = "A magazine of standard 10x24mm rounds for use in the M4RA battle rifle."
+	desc = "A magazine of 10x24mm rounds for use in the M4RA battle rifle."
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/USCM/marksman_rifles.dmi'
 	icon_state = "m4ra"
 	default_ammo = /datum/ammo/bullet/rifle
@@ -159,7 +159,7 @@
 
 /obj/item/ammo_magazine/rifle/m4ra/extended
 	name = "\improper M4RA extended magazine (10x24mm)"
-	desc = "A magazine of 10x24mm rounds for use in the M4RA battle rifle. Holds an additional 10 rounds, up to 35."
+	desc = "An extended magazine of 10x24mm rounds for use in the M4RA battle rifle. Holds an additional 10 rounds, up to 35."
 	icon_state = "m4ra_extended"
 	bonus_overlay = "m4ra_ex"
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_LOW
@@ -197,7 +197,7 @@
 //XM40 AKA SOF RIFLE FROM HELL (It's an EM-2, a prototype of the real world L85A1 way back from the 1940s. We've given it a blue plastic shell and an integral suppressor)
 /obj/item/ammo_magazine/rifle/xm40
 	name = "\improper XM40 magazine (10x24mm)"
-	desc = "A stubby and wide, high-capacity double stack magazine used in the XM40 pulse rifle. Fires 10x24mm Armor Piercing rounds, holding up to 60 + 1 in the chamber."
+	desc = "A stubby and wide high-capacity double stack magazine used in the XM40 pulse rifle. Fires 10x24mm armor piercing rounds, holding up to 60 + 1 in the chamber."
 	icon_state = "m40_sd"
 	max_rounds = 60
 	gun_type = /obj/item/weapon/gun/rifle/m41a/elite/xm40
@@ -205,7 +205,7 @@
 
 /obj/item/ammo_magazine/rifle/xm40/heap
 	name = "\improper XM40 HEAP magazine (10x24mm)"
-	desc = "A stubby and wide, high-capacity double stack magazine used in the XM40 pulse rifle. Fires 10x24mm High Explosive Armor Piercing rounds, holding up to 60 + 1 in the chamber."
+	desc = "A stubby and wide high-capacity double stack magazine used in the XM40 pulse rifle. Fires 10x24mm high explosive armor piercing rounds, holding up to 60 + 1 in the chamber."
 	icon_state = "m40_sd_heap"
 	max_rounds = 60
 	gun_type = /obj/item/weapon/gun/rifle/m41a/elite/xm40
@@ -262,7 +262,7 @@
 
 /obj/item/ammo_magazine/rifle/m16/ap
 	name = "\improper M16 AP magazine (5.56x45mm)"
-	desc = "An AP 5.56x45mm magazine for the M16 assault rifle."
+	desc = "An armor piercing 5.56x45mm magazine for the M16 assault rifle."
 	caliber = "5.56x45mm"
 	default_ammo = /datum/ammo/bullet/rifle/ap
 	max_rounds = 20
@@ -272,7 +272,7 @@
 
 /obj/item/ammo_magazine/rifle/m16/ext
 	name = "\improper M16 extended magazine (5.56x45mm)"
-	desc = "An AP 5.56x45mm magazine for the M16 assault rifle. This one contains 30 bullets."
+	desc = "An extended 5.56x45mm magazine for the M16 assault rifle. This one contains 30 bullets."
 	icon_state = "m16_ext"
 	item_state = "m16_ext"
 	bonus_overlay = "m16_ext_overlay"
@@ -298,7 +298,7 @@
 
 /obj/item/ammo_magazine/rifle/lmg
 	name = "\improper M41AE2 ammo box (10x24mm)"
-	desc = "A semi-rectangular box of rounds for the M41AE2 Heavy Pulse Rifle."
+	desc = "A semi-rectangular 10x24mm box magazine for the M41AE2 Heavy Pulse Rifle."
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/USCM/machineguns.dmi'
 	icon_state = "m41ae2"
 	max_rounds = 300

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -47,14 +47,14 @@
 
 /obj/item/ammo_magazine/rifle/heap
 	name = "\improper M41A HEAP magazine (10x24mm)"
-	desc = "A high explosive armor piercing 10x24mm assault rifle magazine."
+	desc = "A high-explosive armor-piercing 10x24mm assault rifle magazine."
 	default_ammo = /datum/ammo/bullet/rifle/heap
 	ammo_band_color = AMMO_BAND_COLOR_HEAP
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_HIGH
 
 /obj/item/ammo_magazine/rifle/ap
 	name = "\improper M41A AP magazine (10x24mm)"
-	desc = "An armor piercing 10x24mm assault rifle magazine."
+	desc = "An armor-piercing 10x24mm assault rifle magazine."
 	desc_lore = "Unlike standard HEAP magazines, these reserve bullets do not have depleted uranium tips. Instead, these rounds trade off some of their bullet package for a lighter weight, reducing damage but increasing penetration capabilities and muzzle velocity.
 	default_ammo = /datum/ammo/bullet/rifle/ap
 	ammo_band_color = AMMO_BAND_COLOR_AP
@@ -175,7 +175,7 @@
 
 /obj/item/ammo_magazine/rifle/m4ra/heap
 	name = "\improper M4RA high-explosive armor-piercing magazine (10x24mm)"
-	desc = "A magazine of high explosive armor piercing 10x24mm rounds for use in the M4RA battle rifle."
+	desc = "A magazine of high-explosive armor-piercing 10x24mm rounds for use in the M4RA battle rifle."
 	default_ammo = /datum/ammo/bullet/rifle/heap
 	ammo_band_color = AMMO_BAND_COLOR_HEAP
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_HIGH
@@ -263,7 +263,7 @@
 
 /obj/item/ammo_magazine/rifle/m16/ap
 	name = "\improper M16 AP magazine (5.56x45mm)"
-	desc = "An armor piercing 5.56x45mm magazine for the M16 assault rifle."
+	desc = "An armor-piercing 5.56x45mm magazine for the M16 assault rifle."
 	caliber = "5.56x45mm"
 	default_ammo = /datum/ammo/bullet/rifle/ap
 	max_rounds = 20
@@ -319,7 +319,7 @@
 
 /obj/item/ammo_magazine/rifle/lmg/ap
 	name = "\improper M41AE2 ammo box (10x24mm armor-piercing)"
-	desc = "A semi-rectangular armor piercing box magazine for the M41AE2 Heavy Pulse Rifle."
+	desc = "A semi-rectangular armor-piercing box magazine for the M41AE2 Heavy Pulse Rifle."
 	default_ammo = /datum/ammo/bullet/rifle/ap
 	max_rounds = 300
 	ammo_band_color = AMMO_BAND_COLOR_AP
@@ -351,13 +351,13 @@
 
 /obj/item/ammo_magazine/rifle/type71/ap
 	name = "\improper Type 71 AP magazine (5.45x39mm)"
-	desc = "An armor piercing 5.45x39mm high-capacity casket magazine for the Type 71 rifle."
+	desc = "An armor-piercing 5.45x39mm high-capacity casket magazine for the Type 71 rifle."
 	default_ammo = /datum/ammo/bullet/rifle/type71/ap
 	ammo_band_color = AMMO_BAND_COLOR_AP
 
 /obj/item/ammo_magazine/rifle/type71/heap
 	name = "\improper Type 71 HEAP magazine (5.45x39mm)"
-	desc = "A standard high explosive armor piercing 5.45x39mm high-capacity casket magazine for the Type 71 rifle."
+	desc = "A standard high-explosive armor-piercing 5.45x39mm high-capacity casket magazine for the Type 71 rifle."
 	default_ammo = /datum/ammo/bullet/rifle/type71/heap
 	ammo_band_color = AMMO_BAND_COLOR_HEAP
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_HIGH
@@ -382,7 +382,7 @@
 
 /obj/item/ammo_magazine/rifle/l42a/ap
 	name = "\improper L42A AP magazine (10x24mm)"
-	desc = "An armor piercing 10x24mm battle rifle magazine."
+	desc = "An armor-piercing 10x24mm battle rifle magazine."
 	default_ammo = /datum/ammo/bullet/rifle/ap
 	ammo_band_color = AMMO_BAND_COLOR_AP
 

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -55,7 +55,7 @@
 /obj/item/ammo_magazine/rifle/ap
 	name = "\improper M41A AP magazine (10x24mm)"
 	desc = "An armor-piercing 10x24mm assault rifle magazine."
-	desc_lore = "Unlike standard HEAP magazines, these reserve bullets do not have depleted uranium tips. Instead, these rounds trade off some of their bullet package for a lighter weight, reducing damage but increasing penetration capabilities and muzzle velocity.
+	desc_lore = "Unlike standard HEAP magazines, these reserve bullets do not have depleted uranium tips. Instead, these rounds trade off some of their bullet package for a lighter weight, reducing damage but increasing penetration capabilities and muzzle velocity."
 	default_ammo = /datum/ammo/bullet/rifle/ap
 	ammo_band_color = AMMO_BAND_COLOR_AP
 

--- a/code/modules/projectiles/magazines/smgs.dm
+++ b/code/modules/projectiles/magazines/smgs.dm
@@ -174,7 +174,7 @@
 
 /obj/item/ammo_magazine/smg/pps43/extended
 	name = "\improper Type-19 drum magazine (7.62x25mm)"
-	desc = "A drum magazine for the Type-19 submachinegun."
+	desc = "A 7.62x25mm drum magazine for the Type-19 submachinegun."
 	icon_state = "insasu_drum"
 	bonus_overlay = "insasu_drum_overlay"
 	max_rounds = 71
@@ -188,7 +188,7 @@
 
 /obj/item/ammo_magazine/smg/bizon
 	name = "\improper Type 64 Helical Magazine (7.62x19mm)"
-	desc = "A 64 round magazine for the Type 64 submachinegun, the standard SMG of the UPP armed forces."
+	desc = "A 7.62x19mm 64-round helical magazine for the Type 64 submachinegun, the standard SMG of the UPP armed forces."
 	caliber = "7.62x19mm"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/UPP/smgs.dmi'
 	icon_state = "type64mag"
@@ -200,7 +200,7 @@
 
 /obj/item/ammo_magazine/smg/mac15 //Based on the Uzi.
 	name = "\improper MAC-15 magazine (9mm)"
-	desc = "A magazine for the MAC-15."
+	desc = "A 9mm magazine for the MAC-15."
 	caliber = "9mm"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/colony/smgs.dmi'
 	icon_state = "mac15"
@@ -209,6 +209,7 @@
 
 /obj/item/ammo_magazine/smg/mac15/extended
 	name = "\improper MAC-15 extended magazine (9mm)"
+	desc = "An extended 9mm magazine for the MAC-15."
 	icon_state = "mac15_extended"
 	bonus_overlay = "mac15_ext"
 	max_rounds = 50
@@ -219,7 +220,7 @@
 
 /obj/item/ammo_magazine/smg/uzi
 	name = "\improper UZI magazine (9x21mm)"
-	desc = "A magazine for the UZI. Seems pretty small, huh? Anything larger could cause feeding errors."
+	desc = "A 9x21mm magazine for the UZI. Seems pretty small, huh? Anything larger could cause feeding errors."
 	caliber = "9x12mm"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/colony/smgs.dmi'
 	icon_state = "uzi"
@@ -228,7 +229,7 @@
 
 /obj/item/ammo_magazine/smg/uzi/extended
 	name = "\improper UZI extended magazine (9x21mm)"
-	desc = "A slightly extended magazine for the UZI. Due to its size, it may or may not cause feeding errors."
+	desc = "A slightly extended 9x21mm magazine for the UZI. Due to its size, it may or may not cause feeding errors."
 	icon_state = "uzi_extended"
 	bonus_overlay = "uzi_ext"
 	max_rounds = 32
@@ -240,7 +241,7 @@
 
 /obj/item/ammo_magazine/smg/fp9000
 	name = "FN FP9000 magazine (5.7x28mm)"
-	desc = "A magazine for the FN FP9000 SMG."
+	desc = "A 5.7x28mm magazine for the FN FP9000 SMG."
 	default_ammo = /datum/ammo/bullet/smg/ap
 	caliber = "5.7x28mm"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/colony/smgs.dmi'
@@ -253,7 +254,7 @@
 //Nailgun!
 /obj/item/ammo_magazine/smg/nailgun
 	name = "nailgun magazine (7x45mm)"
-	desc = "A large magazine of oversized plasteel nails. Unfortunately, the production cost of those nail makes them ill-affordable for most military projects, and only some specific construction projects requires them."
+	desc = "A large magazine of oversized plasteel nails. Unfortunately, the production cost of those nail makes them ill-affordable for most military projects, and only some specific construction projects require them."
 	default_ammo = /datum/ammo/bullet/smg/nail
 	flags_magazine = NO_FLAGS // Let's not start messing with nails...
 	caliber = "7x45mm"
@@ -281,7 +282,7 @@
 
 /obj/item/ammo_magazine/smg/p90/twe
 	name = "\improper FN-TWE P90 AP magazine (5.7×28mm)"
-	desc = "A 5.7×28mm (AP) magazine for the FN-TWE P90."
+	desc = "An armor-piercing 5.7×28mm magazine for the FN-TWE P90."
 	default_ammo = /datum/ammo/bullet/smg/p90/twe_ap
 	caliber = "5.7×28mm"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/TWE/smgs.dmi'

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -4,7 +4,7 @@
 
 /obj/item/ammo_magazine/sniper
 	name = "\improper M42A marksman magazine (10x28mm Caseless)"
-	desc = "A magazine of sniper rifle ammo. An aimed shot with it will deal significant damage."
+	desc = "A magazine of 10x28mm caseless sniper rifle ammo. An aimed shot with it will deal significant damage."
 	caliber = "10x28mm"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/USCM/marksman_rifles.dmi'
 	icon_state = "m42c" //PLACEHOLDER
@@ -17,14 +17,14 @@
 
 /obj/item/ammo_magazine/sniper/incendiary
 	name = "\improper M42A incendiary magazine (10x28mm)"
-	desc = "A magazine of sniper rifle ammo. An aimed shot with it will temporarily blind the targe and kindle the blaze further."
+	desc = "An incendiary magazine of 10x28mm sniper rifle ammo. An aimed shot with it will temporarily blind the target and light them heavily on fire."
 	default_ammo = /datum/ammo/bullet/sniper/incendiary
 	ammo_band_color = AMMO_BAND_COLOR_INCENDIARY
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_INSUBSTANTIAL
 
 /obj/item/ammo_magazine/sniper/flak
 	name = "\improper M42A flak magazine (10x28mm)"
-	desc = "A magazine of sniper rifle ammo. An aimed shot with it will temporarily slow the target and minimize the backlash."
+	desc = "A flak magazine of 10x28mm sniper rifle ammo. An aimed shot with it will temporarily slow the target, as well as inflicting backlash to anyone nearby."
 	default_ammo = /datum/ammo/bullet/sniper/flak
 	ammo_band_color = AMMO_BAND_COLOR_IMPACT
 	mag_jam_modifier = MAG_JAM_MOD_RIFLE_INSUBSTANTIAL
@@ -54,7 +54,7 @@
 
 /obj/item/ammo_magazine/sniper/svd
 	name = "\improper Type-88 Magazine (7.62x54mmR)"
-	desc = "A large caliber magazine for the Type-88 designated marksman rifle."
+	desc = "A large-caliber 7.62x54mmR magazine for the Type-88 designated marksman rifle."
 	caliber = "7.62x54mmR"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/UPP/marksman_rifles.dmi'
 	icon_state = "type88mag"
@@ -66,7 +66,7 @@
 
 /obj/item/ammo_magazine/rifle/m4ra/custom
 	name = "\improper A19 HV magazine (10x24mm)"
-	desc = "A magazine of A19 high velocity rounds for use in the M4RA custom battle rifle. The M4RA custom battle rifle is the only gun that can chamber these rounds."
+	desc = "A high-velocity 10x24mm magazine of A19 rounds for use in the M4RA custom battle rifle. The M4RA custom battle rifle is the only gun that can chamber these rounds."
 	icon_state = "a19"
 	default_ammo = /datum/ammo/bullet/rifle/m4ra
 	max_rounds = 18
@@ -76,7 +76,7 @@
 
 /obj/item/ammo_magazine/rifle/m4ra/custom/incendiary
 	name = "\improper A19 HV incendiary magazine (10x24mm)"
-	desc = "A magazine of A19 HV incendiary rounds for use in the M4RA battle rifle. The M4RA battle rifle is the only gun that can chamber these rounds."
+	desc = "An incendiary magazine of A19 HV rounds for use in the M4RA battle rifle. The M4RA custom battle rifle is the only gun that can chamber these rounds."
 	default_ammo = /datum/ammo/bullet/rifle/m4ra/incendiary
 	max_rounds = 18
 	gun_type = /obj/item/weapon/gun/rifle/m4ra_custom
@@ -85,7 +85,7 @@
 
 /obj/item/ammo_magazine/rifle/m4ra/custom/impact
 	name = "\improper A19 HV high impact magazine (10x24mm)"
-	desc = "A magazine of A19 HV high impact rounds for use in the M4RA battle rifle. The M4RA battle rifle is the only gun that can chamber these rounds."
+	desc = "A high-impact magazine of A19 rounds for use in the M4RA battle rifle. The M4RA custom battle rifle is the only gun that can chamber these rounds."
 	default_ammo = /datum/ammo/bullet/rifle/m4ra/impact
 	max_rounds = 18
 	gun_type = /obj/item/weapon/gun/rifle/m4ra_custom
@@ -96,6 +96,7 @@
 //SMARTGUN
 /obj/item/ammo_magazine/smartgun
 	name = "smartgun drum"
+	desc = "A 10x28mm 500-round drum magazine for use in the M56 Smartgun."
 	caliber = "10x28mm"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/USCM/machineguns.dmi'
 	icon_state = "m56_drum"
@@ -107,7 +108,7 @@
 
 /obj/item/ammo_magazine/smartgun/dirty
 	name = "irradiated smartgun drum"
-	desc = "What at first glance appears to be a standard 500 round M56 Smartgun drum, is actually a drum loaded with irradiated rounds, providing an extra 'oomph' to to its bullets. The magazine itself is slightly modified to only fit in M56D or M56T smartguns, and is marked with a red X."
+	desc = "What at first glance appears to be a standard 500-round M56 Smartgun drum, is actually a drum loaded with irradiated rounds, providing an extra 'oomph' to to its bullets. The magazine itself is slightly modified to only fit in M56D or M56T smartguns, and is marked with a red X."
 	icon_state = "m56_drum_dirty"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/WY/machineguns.dmi'
 	default_ammo = /datum/ammo/bullet/smartgun/dirty
@@ -117,7 +118,7 @@
 
 /obj/item/ammo_magazine/smartgun/holo_targetting
 	name = "holotargetting smartgun drum"
-	desc = "Holotargetting rounds for use in the royal marines commando L56A2 smartgun."
+	desc = "A 10x28mm holotargetting drum magazine for use in the Royal Marines Commando L56A2 Smartgun."
 	icon_state = "m56_drum" //PLACEHOLDER
 	default_ammo = /datum/ammo/bullet/smartgun/holo_target
 	gun_type = /obj/item/weapon/gun/smartgun/rmc
@@ -137,7 +138,7 @@
 
 /obj/item/ammo_magazine/rocket
 	name = "\improper 84mm high explosive rocket"
-	desc = "A rocket tube loaded with a HE warhead. Deals high damage to soft targets on direct hit and stuns most targets in a 5-meter-wide area for a short time. Has decreased effect on heavily armored targets."
+	desc = "A rocket tube loaded with a high-explosive warhead. Deals high damage to soft targets on direct hit and stuns most targets in a 5-meter-wide area for a short time. Has decreased effect on heavily armored targets."
 	caliber = "rocket"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/USCM/rocket_launchers.dmi'
 	icon_state = "rocket"
@@ -218,7 +219,7 @@
 	if(current_rounds <= 0)
 		name = "\improper 84mm spent rocket tube"
 		icon_state = "rocket_e"
-		desc = "Spent rocket tube for M5 RPG rocket launcher. Activate in hand to disassemble for metal."
+		desc = "A spent rocket tube for M5 RPG rocket launcher. Activate in hand to disassemble for metal."
 		add_to_garbage(src)
 	else
 		icon_state = initial(icon_state)
@@ -241,17 +242,17 @@
 	name = "\improper 84mm anti-armor rocket"
 	icon_state = "ap_rocket"
 	default_ammo = /datum/ammo/rocket/ap
-	desc = "A rocket tube loaded with an AP warhead. Capable of piercing heavily armored targets. Deals very little to no splash damage. Inflicts guaranteed stun to most targets. Has high accuracy within 7 meters."
+	desc = "A rocket tube loaded with an armor-piercing warhead. Capable of piercing heavily armored targets. Deals very little to no splash damage. Inflicts guaranteed stun to most targets. Has high accuracy within 7 meters."
 
 /obj/item/ammo_magazine/rocket/wp
 	name = "\improper 84mm white-phosphorus rocket"
 	icon_state = "wp_rocket"
 	default_ammo = /datum/ammo/rocket/wp
-	desc = "Rocket tube loaded with WP warhead. Has two damaging factors. On hit disperses X-Variant Napthal (blue flames) in a 4-meter radius circle, ignoring cover, while simultaneously bursting into highly heated shrapnel that ignites targets within slightly bigger area."
+	desc = "A rocket tube loaded with a white phosphorus incendiary warhead. Has two damaging factors. On hit disperses X-Variant Napthal (blue flames) in a 4-meter radius circle, ignoring cover, while simultaneously bursting into highly heated shrapnel that ignites targets within slightly bigger area."
 
 /obj/item/ammo_magazine/rocket/custom
 	name = "\improper 84mm custom rocket"
-	desc = "An 84mm custom rocket."
+	desc = "A rocket tube loaded with a custom warhead."
 	icon_state = "custom_rocket"
 	default_ammo = /datum/ammo/rocket/custom
 	matter = list("metal" = 7500) //2 sheets
@@ -349,7 +350,7 @@
 
 /obj/item/ammo_magazine/rocket/anti_tank
 	name = "\improper 84mm Anti-Tank Rocket"
-	desc = "An anti-armor rocket specifically modified for penetration of armored vehicle hulls."
+	desc = "An anti-armor rocket specifically designed for penetration of armored vehicle hulls."
 	caliber = "rocket"
 	icon_state = "at_rocket"
 
@@ -364,7 +365,7 @@
 
 /obj/item/ammo_magazine/rocket/upp
 	name = "\improper HJRA-12 High-Explosive Rocket"
-	desc = "A rocket for the UPP standard-issue HJRA-12 Handheld Anti-Tank Grenade Launcher. This one is a standard High-Explosive rocket for anti-personal or light-vehicle use."
+	desc = "A rocket for the UPP standard-issue HJRA-12 Handheld Anti-Tank Grenade Launcher. This one is a standard high-explosive rocket for use against light vehicles or as an anti-personnel grenade."
 	caliber = "88mm"
 	icon_state = "hjra_explosive"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/UPP/rocket_launchers.dmi'
@@ -382,7 +383,7 @@
 
 /obj/item/ammo_magazine/rocket/upp/at
 	name = "\improper HJRA-12 Anti-Tank Rocket"
-	desc = "A rocket for the UPP standard-issue HJRA-12 Handheld Anti-Tank Grenade Launcher. This one is a standard Anti-Tank rocket designed to disable or destroy hostile vehicles."
+	desc = "A rocket for the UPP standard-issue HJRA-12 Handheld Anti-Tank Grenade Launcher. This one is a standard anti-tank rocket designed to disable or destroy hostile armored vehicles."
 	caliber = "88mm"
 	icon_state = "hjra_tank"
 
@@ -393,7 +394,8 @@
 
 /obj/item/ammo_magazine/rocket/upp/incen
 	name = "\improper HJRA-12 Extreme-Intensity Incendiary Rocket"
-	desc = "A rocket for the UPP standard-issue HJRA-12 Handheld Anti-Tank Grenade Launcher. This one is an extreme-intensity incendiary rocket, using an experimental chemical designated R-189 by the UPP, it is designed to melt through fortified positions and bunkers but is most commonly used in an anti-personnal role due to over-issuing and the tempatures after use in its intended role leaving the tempature of the air incompatible with human life."
+	desc = "A rocket for the UPP standard-issue HJRA-12 Handheld Anti-Tank Grenade Launcher. This one is an extreme-intensity incendiary rocket."
+	desc_lore = "This incendiary rocket uses an experimental chemical designated 'R-189' by the UPP. It is designed to melt through fortifications and bunkers but is most commonly used in an anti-personnel role due to over-issuing and the tempeartures after use in its intended role leaving behind a cloud of super-heated air, preventing troops' advance."
 	caliber = "88mm"
 	icon_state = "hjra_incen"
 


### PR DESCRIPTION
# About the pull request

See title, fixes a LOT of typos and adds a lot of missing descriptions to those magazines which are missing it. Adds some stuff, too. (most notably an extended lore description to AP mags, which are actually also reserve ammo!)

I started this because the M41's extended magazine was described as a '10mm assault extended rifle magazine'

# Explain why it's good for the game

Typos bad. Bad English/writing bad. 

# Testing Photographs and Procedure
None required, please spellcheck if you can


# Changelog
:cl:
add: extra descriptions and lore to many gun magazines
spellcheck: fixed many typos in the descriptions of gun magazines
/:cl:
