### PR TITLE
Jungle Vines are now untrappable

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -595,6 +595,10 @@
 			to_chat(xeno, SPAN_XENOWARNING("We cannot make a hole on a light!"))
 			return FALSE
 
+		if(locate(/obj/structure/flora/jungle/vines) in src)
+			to_chat(xeno, SPAN_XENOWARNING("We cannot make a hole under the vines!"))
+			return FALSE
+
 	if(!xeno.check_alien_construction(src, check_doors = TRUE))
 		return FALSE
 


### PR DESCRIPTION
# About the pull request

In current LV, all vines (i believe) are placed on unweedable tiles. Hence, this PR should change nothing in current LV and will only affect the LV rework. The upcoming LV rework intends to make these tiles unweedable, but keep them untrappable as that is one of the original major balance intentions of the unweedable jungle in current LV. Requested by Kyo, this PR can be kept open until that PR is ready.

# Explain why it's good for the game

It's hard/impossible to see traps under vines, and there is a LOT of them in the jungle in very tight corridors, hence allowing them to be trappable would be a very significant, and undesired outcome (Kyo please confirm as lead mapper...)


# Testing Photographs and Procedure

# Changelog
:cl:
maptweak: Jungle Vines on LV are now untrappable.
/:cl:
<!-- Both :cl:'s are required for the changelog to work! -->
