### PR TITLE
light/med armor bomb armor changes (Light armor no longer protects you from bombs better than med armor)

### DIFF
--- a/code/modules/clothing/suits/marine_armor/_marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor/_marine_armor.dm
@@ -51,7 +51,7 @@
 	armor_bullet = CLOTHING_ARMOR_MEDIUM
 	armor_laser = CLOTHING_ARMOR_MEDIUMLOW
 	armor_energy = CLOTHING_ARMOR_LOW
-	armor_bomb = CLOTHING_ARMOR_MEDIUMLOW
+	armor_bomb = CLOTHING_ARMOR_MEDIUM
 	armor_bio = CLOTHING_ARMOR_MEDIUM
 	armor_rad = CLOTHING_ARMOR_MEDIUMLOW
 	armor_internaldamage = CLOTHING_ARMOR_MEDIUM
@@ -289,7 +289,6 @@
 	armor_bullet = CLOTHING_ARMOR_MEDIUM
 	armor_laser = CLOTHING_ARMOR_LOW
 	armor_energy = CLOTHING_ARMOR_LOW
-	armor_bomb = CLOTHING_ARMOR_MEDIUM
 	armor_bio = CLOTHING_ARMOR_MEDIUMLOW
 	armor_internaldamage = CLOTHING_ARMOR_MEDIUMLOW
 	storage_slots = 2
@@ -394,7 +393,6 @@
 	icon_state = "7"
 	armor_variation = 0
 	armor_melee = CLOTHING_ARMOR_MEDIUMHIGH
-	armor_bomb = CLOTHING_ARMOR_MEDIUM
 	armor_bio = CLOTHING_ARMOR_MEDIUMHIGH
 	armor_internaldamage = CLOTHING_ARMOR_MEDIUMHIGH
 	armor_energy = CLOTHING_ARMOR_MEDIUM
@@ -463,7 +461,7 @@
 	slowdown = SLOWDOWN_ARMOR_LIGHT
 	armor_melee = CLOTHING_ARMOR_MEDIUMLOW
 	armor_bullet = CLOTHING_ARMOR_MEDIUMLOW
-	armor_bomb = CLOTHING_ARMOR_MEDIUM
+	armor_bomb = CLOTHING_ARMOR_MEDIUMLOW
 	armor_bio = CLOTHING_ARMOR_MEDIUMLOW
 	armor_rad = CLOTHING_ARMOR_MEDIUMHIGH
 	armor_internaldamage = CLOTHING_ARMOR_LOW
@@ -603,7 +601,6 @@
 	armor_bullet = CLOTHING_ARMOR_MEDIUM
 	armor_laser = CLOTHING_ARMOR_MEDIUMLOW
 	armor_energy = CLOTHING_ARMOR_NONE
-	armor_bomb = CLOTHING_ARMOR_MEDIUMLOW
 	armor_bio = CLOTHING_ARMOR_MEDIUM
 	armor_rad = CLOTHING_ARMOR_MEDIUMLOW
 	armor_internaldamage = CLOTHING_ARMOR_MEDIUM
@@ -736,6 +733,7 @@
 	desc = "A custom set of M3 armor designed for USCM Scouts."
 	icon_state = "scout_armor"
 	armor_melee = CLOTHING_ARMOR_MEDIUMHIGH
+	armor_bomb = CLOTHING_ARMOR_MEDIUMLOW
 	slowdown = SLOWDOWN_ARMOR_LIGHT
 	specialty = "M3-S light"
 	flags_item = MOB_LOCK_ON_EQUIP|NO_CRYO_STORE

--- a/code/modules/clothing/suits/marine_armor/_marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor/_marine_armor.dm
@@ -733,7 +733,6 @@
 	desc = "A custom set of M3 armor designed for USCM Scouts."
 	icon_state = "scout_armor"
 	armor_melee = CLOTHING_ARMOR_MEDIUMHIGH
-	armor_bomb = CLOTHING_ARMOR_MEDIUMLOW
 	slowdown = SLOWDOWN_ARMOR_LIGHT
 	specialty = "M3-S light"
 	flags_item = MOB_LOCK_ON_EQUIP|NO_CRYO_STORE

--- a/code/modules/clothing/suits/marine_armor/ert.dm
+++ b/code/modules/clothing/suits/marine_armor/ert.dm
@@ -25,6 +25,7 @@
 //=======================================================================\\
 
 /obj/item/clothing/suit/storage/marine/veteran
+	armor_bomb = CLOTHING_ARMOR_MEDIUMLOW
 	flags_marine_armor = ARMOR_LAMP_OVERLAY
 	flags_atom = NO_GAMEMODE_SKIN|NO_NAME_OVERRIDE //Let's make these keep their name and icon.
 

--- a/code/modules/clothing/suits/marine_armor/smartgunner.dm
+++ b/code/modules/clothing/suits/marine_armor/smartgunner.dm
@@ -4,7 +4,6 @@
 	icon_state = "8"
 	item_state = "armor"
 	armor_laser = CLOTHING_ARMOR_LOW
-	armor_bomb = CLOTHING_ARMOR_MEDIUM
 	armor_rad = CLOTHING_ARMOR_MEDIUM
 	storage_slots = 2
 	slowdown = SLOWDOWN_ARMOR_LIGHT


### PR DESCRIPTION
# About the pull request
When looking at https://forum.cm-ss13.com/t/trend-of-lobbing-nades-into-marine-groups-to-kill-xenos-and-then-bandaging-marines/14807 I decided to take a look at the bomb armor values, and discovered that light armor actually has **higher bomb prot than medium**.

Light armor's bomb armor goes from 20 -> 15
Med armor's bomb armor goes from 15 -> 20

This has an effect on all subtypes, meaning that
* RTO, Tanker, Ghillie, Pyro, Scout armors get +5 Bomb prot

and
* press body armor  loses 5 bomb prot

Because im lazy, I set /marine/veteran (ERT armors) to keep MEDIUMLOW (15) bomb prot, instead of looking through all the ERT armors.

If a maintainer requests, I can change the values around further (removing the buffs to ghillie/pyro armors so that they're the same as light armor).

Code deletions are redundant armor values (as they inherit med bomb armor from parent)
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Light armor probably should always have worse stats than medium in terms of protection, and med armor's 15 bomb armor looks quite worthless, so instead of nerfing light armor to 10 bomb armor I instead decided to swap them. This way there's slightly more reasons :tm: to run med armor
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

compiles, works
![image](https://github.com/user-attachments/assets/042680c0-fe85-45fb-b861-e4b8b25eae3a)


</details>


# Changelog
:cl:
balance: Medium, RTO, Tanker, Ghillie, Scout, and Pyro armor now have 20 bomb prot (from 15).
balance: Light and Press armor now have 15 bomb prot (from 20).
fix: light armor no longer has more bomb armor than medium.
/:cl:
