### PR TITLE
balance: Minor Base Prae Buffs

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
@@ -228,6 +228,9 @@
 	slash = FALSE
 	freeze_self = FALSE
 
+/datum/action/xeno_action/activable/pounce/base_prae_dash/initialize_pounce_pass_flags()
+	pounce_pass_flags = PASS_MOB_THRU|PASS_OVER_THROW_MOB
+
 /datum/action/xeno_action/activable/prae_acid_ball
 	name = "Acid Ball"
 	action_icon_state = "prae_acid_ball"
@@ -289,8 +292,6 @@
 	spray_type = ACID_SPRAY_LINE
 	spray_distance = 7
 	spray_effect_type = /obj/effect/xenomorph/spray/praetorian
-	activation_delay = TRUE
-	activation_delay_length = 5
 
 ///////////////////////// VALKYRIE PRAE
 


### PR DESCRIPTION
# About the pull request
Just copy of [this PR](https://github.com/cmss13-devs/cmss13/pull/9229), but  removed the acid ball buff. As suggested in the comments. Author of that request wanted to do it himself, but apparently died.

1. Removes the wind up from acid spray, it's now instant like spitter's or boiler's
2. The dash can now pass over mobs instead of getting stuck if there's one in the way
Everything's tested and should be good to go.

# Explain why it's good for the game

Base prae needs a little bit of love. It and dancer are consistently overshadowed and outperformed by vanguard, oppressor, and valkyrie. These changes should make it a little less clunky to play and feel a little smoother. The wind up removal owes itself to the fact that prae's acid spray doesn't stun or do insane amounts of damage. Base prae is supposed to be better than the other strains for survivability, so its dash ability passing over mobs brings it in line with that idea. No more will your retreat path be blocked by a boiler; bodyblock begone!

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/user-attachments/assets/8134d548-7424-45e8-a874-bba39a27cefa


</details>


# Changelog
:cl:
balance: Base prae's acid spray, its dash can now pass over mobs
/:cl:
