### PR TITLE
Fix multi-z lightning to run ~1.5 faster 

### DIFF
--- a/code/modules/lighting/lighting_static/static_lighting_source.dm
+++ b/code/modules/lighting/lighting_static/static_lighting_source.dm
@@ -222,37 +222,37 @@
 	var/list/datum/static_lighting_corner/corners = list()
 	if (source_turf)
 		var/list/turf/impacted_turfs = list()
-		var/list/turf/below_turfs = list()
+		var/list/turf/check_below_turfs = list()
 		var/oldlum = source_turf.luminosity
 		source_turf.luminosity = ceil(light_range)
 		for(var/turf/T in view(ceil(light_range), source_turf))
 			if(!IS_OPAQUE_TURF(T))
 				impacted_turfs += T
 			if(istransparentturf(T))
-				below_turfs += T // we need to go below only for transparent turfs
+				check_below_turfs += T // we need to go below only for transparent turfs
 
-		var/list/turf/above_turfs = impacted_turfs
+		var/list/turf/check_above_turfs = impacted_turfs
 		while(TRUE) // we know that it starts with len > 0
-			var/list/turf/temp = SSmapping.get_same_z_turfs_above(above_turfs)
-			if(temp.len == 0) // levels are not connected
+			var/list/turf/above_turfs = SSmapping.get_same_z_turfs_above(check_above_turfs)
+			if(above_turfs.len == 0) // levels are not connected
 				break
-			above_turfs = list()
-			for(var/turf/T as anything in temp)
+			check_above_turfs = list()
+			for(var/turf/T as anything in above_turfs)
 				if(istransparentturf(T))
-					above_turfs += T // turf from which we can see light below
-			if(above_turfs.len == 0)
+					check_above_turfs += T // turf from which we can see light below
+			if(check_above_turfs.len == 0)
 				break
-			impacted_turfs += above_turfs // add them to the impacted
+			impacted_turfs += check_above_turfs // add them to the impacted
 
-		while(below_turfs.len > 0)
-			var/list/turf/temp = SSmapping.get_same_z_turfs_below(below_turfs)
-			if(temp.len == 0) // levels are not connected
+		while(check_below_turfs.len > 0)
+			var/list/turf/below_turfs = SSmapping.get_same_z_turfs_below(check_below_turfs)
+			if(below_turfs.len == 0) // levels are not connected
 				break
-			impacted_turfs += temp // add turfs that we found below transparent
-			below_turfs = list()
-			for(var/turf/T as anything in temp)
+			impacted_turfs += below_turfs // add turfs that we found below transparent
+			check_below_turfs = list()
+			for(var/turf/T as anything in below_turfs)
 				if(istransparentturf(T))
-					below_turfs += T // next time check only below transparent
+					check_below_turfs += T // next time check only below transparent
 
 		for(var/turf/T as anything in impacted_turfs)
 			if (!T.lighting_corners_initialised)

--- a/code/modules/lighting/lighting_static/static_lighting_source.dm
+++ b/code/modules/lighting/lighting_static/static_lighting_source.dm
@@ -234,19 +234,19 @@
 		var/list/turf/above_turfs = impacted_turfs
 		while(TRUE) // we know that it starts with len > 0
 			var/list/turf/temp = SSmapping.get_same_z_turfs_above(above_turfs)
-			if(temp.len == 0) // levels is not connected
+			if(temp.len == 0) // levels are not connected
 				break
 			above_turfs = list()
 			for(var/turf/T as anything in temp)
 				if(istransparentturf(T))
-					above_turfs += T // next time check only above transparent turfs
+					above_turfs += T // turf from which we can see light below
 			if(above_turfs.len == 0)
 				break
-			impacted_turfs += above_turfs // and add them to the impacted
+			impacted_turfs += above_turfs // add them to the impacted
 
 		while(below_turfs.len > 0)
 			var/list/turf/temp = SSmapping.get_same_z_turfs_below(below_turfs)
-			if(temp.len == 0) // levels is not connected
+			if(temp.len == 0) // levels are not connected
 				break
 			impacted_turfs += temp // add turfs that we found below transparent
 			below_turfs = list()

--- a/code/modules/lighting/lighting_static/static_lighting_source.dm
+++ b/code/modules/lighting/lighting_static/static_lighting_source.dm
@@ -252,8 +252,7 @@
 			below_turfs = list()
 			for(var/turf/T as anything in temp)
 				if(istransparentturf(T))
-					above_turfs += T // next time check only below transparent
-			impacted_turfs += below_turfs
+					below_turfs += T // next time check only below transparent
 
 		for(var/turf/T as anything in impacted_turfs)
 			if (!T.lighting_corners_initialised)

--- a/code/modules/mapping/space_management/traits.dm
+++ b/code/modules/mapping/space_management/traits.dm
@@ -67,6 +67,34 @@
 		return
 	return locate(T.x, T.y, T.z + offset)
 
+// Same as get_turf_below, but for multiple turfs from the same z level
+/datum/controller/subsystem/mapping/proc/get_same_z_turfs_below(list/turf/turfs)
+	if (turfs.len < 1)
+		return list()
+	var/turf/first_turf = turfs[1]
+	var/offset = level_trait(first_turf.z, ZTRAIT_DOWN)
+	if(!offset)
+		return list()
+	var/new_z = first_turf.z + offset
+	var/list/turf/new_turfs = list()
+	for(var/turf/T as anything in turfs)
+		new_turfs += locate(T.x, T.y, new_z)
+	return new_turfs
+
+// Same as get_turf_above, but for multiple turfs from the same z level
+/datum/controller/subsystem/mapping/proc/get_same_z_turfs_above(list/turf/turfs)
+	if (turfs.len < 1)
+		return list()
+	var/turf/first_turf = turfs[1]
+	var/offset = level_trait(first_turf.z, ZTRAIT_UP)
+	if(!offset)
+		return list()
+	var/new_z = first_turf.z + offset
+	var/list/turf/new_turfs = list()
+	for(var/turf/T as anything in turfs)
+		new_turfs += locate(T.x, T.y, new_z)
+	return new_turfs
+
 // Prefer not to use this one too often
 /datum/controller/subsystem/mapping/proc/get_station_center()
 	var/station_z = levels_by_trait(ZTRAIT_STATION)[1]


### PR DESCRIPTION
# About the pull request

Reduces amount of calls to mapping subsystem in lightning handling. 

# Explain why it's good for the game

A bit less lags. The main source why we need better lightning handling is fire. Every fire tile tries to affect lightning in 9x9 turfs, with going down to 7x7 turfs after first burst. With multi-z its times connected z levels.

# Testing Photographs and Procedure

Checked with profiling, speeded up inscenary shell update_corners about 1.5 times. I didnt checked whether it works as supposed to work in multi-z, but code is pretty straightforward, shouldnt be an issue.

# Changelog

:cl:
refactor: a bit faster multi-z lightning.
/:cl:
