### PR TITLE
Fix king jump

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/King.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/King.dm
@@ -418,7 +418,7 @@
 			item.throw_atom(throwtarget, 2, SPEED_REALLY_FAST, owner, TRUE)
 
 	for(var/obj/structure/structure in orange(1, owner))
-		structure.ex_act(1000, get_dir(owner, structure))
+		INVOKE_ASYNC(structure, TYPE_PROC_REF(/atom, ex_act), 1000, get_dir(owner, structure))
 
 	for(var/mob/living in range(7, owner))
 		shake_camera(living, 15, 1)


### PR DESCRIPTION
# About the pull request

Fixed bug, which stunned king for duration of ex_act (for example ~12 sleep for each turret).

# Explain why it's good for the game

Prevents turrets from being used as traps to stun king.

# Testing Photographs and Procedure

# Changelog
:cl:
fix: fixed king stunning himself by jumping on turrets.
/:cl:
