### PR TITLE
Makes the buttons in the CC Corporate Vault explosion-proof

### DIFF
--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -212,10 +212,12 @@
 
 /obj/structure/machinery/door_control/brbutton
 	icon_state = "big_red_button_wallv"
+	explo_proof = TRUE
 
 
 /obj/structure/machinery/door_control/brbutton/alt
 	icon_state = "big_red_button_tablev"
+	explo_proof = TRUE
 
 /obj/structure/machinery/door_control/airlock
 	icon = 'icons/obj/structures/machinery/computer.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -595,6 +595,10 @@
 			to_chat(xeno, SPAN_XENOWARNING("We cannot make a hole on a light!"))
 			return FALSE
 
+		if(locate(/obj/structure/flora/jungle/vines) in src)
+			to_chat(xeno, SPAN_XENOWARNING("We cannot make a hole under the vines!"))
+			return FALSE
+
 	if(!xeno.check_alien_construction(src, check_doors = TRUE))
 		return FALSE
 


### PR DESCRIPTION
# About the pull request
Solves #9386 

# Explain why it's good for the game
dont want to get trapped

# Testing Photographs and Procedure

https://github.com/user-attachments/assets/65dccfed-4238-474e-882c-d34b5f0a313f

# Changelog
:cl:
fix: vault buttons on CC can no longer be destroyed by explosives
/:cl:
