### PR TITLE
Prevents CPR'ing synths

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -31,6 +31,10 @@
 				help_shake_act(attacking_mob)
 				return 1
 
+			if(src.species.flags & IS_SYNTHETIC)
+				to_chat(attacking_mob, SPAN_DANGER("Your hands compress the metal chest uselessly... "))
+				return 0
+
 			if(cpr_attempt_timer >= world.time)
 				to_chat(attacking_mob, SPAN_NOTICE("<B>CPR is already being performed on [src]!</B>"))
 				return 0


### PR DESCRIPTION
# About the pull request

Removes the ability to do CPR on a synth.

# Explain why it's good for the game

CPR'ing a synth is useless.

# Testing Photographs and Procedure

# Changelog

:cl:
del: Removed CPR'ing synths
/:cl:
