### PR TITLE
Fixes message when autodoc powers down

### DIFF
--- a/code/game/machinery/medical_pod/autodoc.dm
+++ b/code/game/machinery/medical_pod/autodoc.dm
@@ -106,7 +106,7 @@
 
 /obj/structure/machinery/medical_pod/autodoc/power_change(area/master_area = null)
 	..()
-	if(stat & NOPOWER)
+	if(stat && NOPOWER && occupant)
 		visible_message("\The [src] engages the safety override, ejecting the occupant.")
 		surgery = 0
 		go_out()

--- a/code/game/machinery/medical_pod/autodoc.dm
+++ b/code/game/machinery/medical_pod/autodoc.dm
@@ -106,7 +106,7 @@
 
 /obj/structure/machinery/medical_pod/autodoc/power_change(area/master_area = null)
 	..()
-	if(stat && NOPOWER && occupant)
+	if((stat & NOPOWER) && occupant)
 		visible_message("\The [src] engages the safety override, ejecting the occupant.")
 		surgery = 0
 		go_out()

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -31,10 +31,6 @@
 				help_shake_act(attacking_mob)
 				return 1
 
-			if(src.species.flags & IS_SYNTHETIC)
-				to_chat(attacking_mob, SPAN_DANGER("Your hands compress the metal chest uselessly... "))
-				return 0
-
 			if(cpr_attempt_timer >= world.time)
 				to_chat(attacking_mob, SPAN_NOTICE("<B>CPR is already being performed on [src]!</B>"))
 				return 0

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -31,6 +31,10 @@
 				help_shake_act(attacking_mob)
 				return 1
 
+			if(src.species.flags & IS_SYNTHETIC)
+				to_chat(attacking_mob, SPAN_DANGER("Your hands compress the metal chest uselessly... "))
+				return 0
+
 			if(cpr_attempt_timer >= world.time)
 				to_chat(attacking_mob, SPAN_NOTICE("<B>CPR is already being performed on [src]!</B>"))
 				return 0


### PR DESCRIPTION
# About the pull request

Prevents the message "The autodoc engages the safety override, ejecting the occupant." from displaying if there's no occupant. Tested.

# Explain why it's good for the game

# Testing Photographs and Procedure

# Changelog

:cl:
fix: Prevents an error message  about ejecting an occupant from an auotdoc if there is no occupant.
/:cl:
