### PR TITLE
Fix a source of nulls in GLOB.new_player_list and GLOB.player_list

### DIFF
--- a/code/controllers/subsystem/inactivity.dm
+++ b/code/controllers/subsystem/inactivity.dm
@@ -14,6 +14,8 @@ SUBSYSTEM_DEF(inactivity)
 		debug_log("Removed nulls from GLOB.clients!")
 	if(list_clear_nulls(GLOB.player_list))
 		debug_log("Removed nulls from GLOB.player_list!")
+	if(list_clear_nulls(GLOB.new_player_list))
+		debug_log("Removed nulls from GLOB.new_player_list!")
 
 	if(!CONFIG_GET(flag/kick_inactive))
 		return

--- a/code/modules/mob/living/carbon/human/login.dm
+++ b/code/modules/mob/living/carbon/human/login.dm
@@ -3,8 +3,7 @@
 	if(species)
 		species.handle_login_special(src)
 	if(selected_ability)
-		set_selected_ability(null)
-
+		set_selected_ability(null) // This has winsets that can sleep, so all variables must be set prior in the event Logout occurs during sleep
 
 /mob/living/carbon/human/proc/add_fax_responder()
 	if(SSticker.mode)

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -9,13 +9,13 @@
 		forceMove(get_turf(pick(GLOB.newplayer_start)))
 	else
 		forceMove(locate(1,1,1))
-	lastarea = get_area(src.loc)
-
-	initialize_lobby_screen()
+	lastarea = get_area(loc)
 
 	GLOB.new_player_list += src
 
-	. = ..()
+	..()
+
+	initialize_lobby_screen() // This has winsets that can sleep, so all variables must be set prior in the event Logout occurs during sleep
 
 	addtimer(CALLBACK(src, PROC_REF(lobby)), 4 SECONDS)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR is sort of a follow up to https://github.com/cmss13-devs/cmss13/pull/4700 and https://github.com/cmss13-devs/cmss13/pull/7766 fixing a source of null in GLOB.player_list and GLOB.new_player_list. `winset` and `send_asset` (via `send_message`) can apparently sleep sometimes so it makes it possible that a Logout() can occur before the Login() finished resulting in then the late Login() call adding src (null) to the glob.

I also expanded the cleanup to check the new player list. Likely not necessary but helps identify future problems and shouldn't be expensive.

# Explain why it's good for the game

Likely less edgecases where a null is present in global player lists when no nulls should be present.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

The lobby loads fine still? 
![image](https://github.com/user-attachments/assets/eb2dbbc7-b3a9-4d90-9942-fca0a70adfa0)

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Fixed a source of nulls being added to GLOB.new_player_list and GLOB.player_list
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
