### PR TITLE
Fixes a typo in synth maint station

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -257,10 +257,10 @@
 		//Whoever had it so that a borg with a dead cell can't enter this thing should be shot. --NEO
 		return
 	if (!issynth(usr))
-		to_chat(usr, SPAN_NOTICE(" <B>Only non-organics may enter the recharge and repair station!</B>"))
+		to_chat(usr, SPAN_NOTICE(" <B>Only non-organics may enter the [name]!</B>"))
 		return
 	if (src.occupant)
-		to_chat(usr, SPAN_NOTICE(" <B>The cell is already occupied!</B>"))
+		to_chat(usr, SPAN_NOTICE(" <B>The [name] is already occupied!</B>"))
 		return
 	move_mob_inside(usr)
 	return
@@ -279,11 +279,11 @@
 			to_chat(user, SPAN_NOTICE("The [name] is already occupied!"))
 			return
 
-		visible_message(SPAN_NOTICE("[user] starts putting [G.grabbed_thing] into the sleeper."), null, null, 3)
+		visible_message(SPAN_NOTICE("[user] starts putting [G.grabbed_thing] into the [name]."), null, null, 3)
 
 		if(do_after(user, 20, INTERRUPT_ALL, BUSY_ICON_GENERIC))
 			if(occupant)
-				to_chat(user, SPAN_NOTICE("The sleeper is already occupied!"))
+				to_chat(user, SPAN_NOTICE("The [name] is already occupied!"))
 				return
 			if(!G || !G.grabbed_thing)
 				return


### PR DESCRIPTION
# About the pull request

Fixes a message that lists the recharge station as a sleeper; rewrote part of a message to keep it in line in the event of future changes.

# Testing Photographs and Procedure

# Changelog

:cl:
spellcheck: Fixes the synth recharge station being referred to as a sleeper in some cases.
/:cl:
