### PR TITLE
Nuke messaging clarity (again)

### DIFF
--- a/code/game/machinery/nuclearbomb.dm
+++ b/code/game/machinery/nuclearbomb.dm
@@ -346,7 +346,7 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 		//xenos part
 		var/warning
 		if(timer_warning & NUKE_SHOW_TIMER_HALF)
-			warning = "A shiver goes down our carapace as we feel the approaching end... the hive killer is halfway through its preparation cycle!"
+			warning = "A shiver goes down our carapace as we feel the approaching end... the hive killer is halfway through the detonation countdown!"
 		else if(timer_warning & NUKE_SHOW_TIMER_MINUTE)
 			warning = "Every sense in our form is screaming... the hive killer is almost ready to trigger!"
 		else


### PR DESCRIPTION

# About the pull request

Currently, halfway through the detonation countdown is referred to as a 'preparation cycle' in xeno messaging. Changes messaging to 'detonation countdown'. Continuation of https://github.com/cmss13-devs/cmss13/pull/7592

# Explain why it's good for the game

"Preparation cycle" is confusing, even for me as a bazillion hour player. Isn't the preparation cycle the decryption phase? Can we call the detonation countdown "the detonation countdown"?


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
qol: nuke detonation countdown is now called detonation countdown, not "preparation cycle"
/:cl:
