### PR TITLE
30 min timeouts for jobs involving setup node

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -9,6 +9,7 @@ jobs:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Run Linters
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     concurrency:
       group: run_linters-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
@@ -86,6 +87,7 @@ jobs:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Compile Maps
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node
@@ -171,6 +173,7 @@ jobs:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Windows Build
     runs-on: windows-latest
+    timeout-minutes: 30
     concurrency:
       group: test_windows-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   run_unit_tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - name: Restore BYOND from Cache


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Windows Build for whatever reason can hang during tgui compilation. I suspect its from setup_node ported in https://github.com/cmss13-devs/cmss13/pull/9343 but I am not sure. E.g. https://github.com/cmss13-devs/cmss13/actions/runs/15387579854/job/43289449610?pr=9421

Average run time of windows build this month is 15m 46s but its likely inflated from this issue.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

See checks.


# Changelog

No player facing changes.
