### PR TITLE
ammo rack can carry filled sandbags

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -480,7 +480,7 @@
 	item_icons = list(
 		WEAR_BACK = 'icons/mob/humans/onmob/clothing/back/backpacks_by_faction/UA.dmi'
 	)
-	can_hold = list(/obj/item/ammo_box, /obj/item/stack/folding_barricade)
+	can_hold = list(/obj/item/ammo_box, /obj/item/stack/folding_barricade, /obj/item/stack/sandbags, /obj/item/stack/sandbags_empty)
 	max_w_class = SIZE_MASSIVE
 	throw_range = 0
 	xeno_types = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

allows both empty and filled sandbags to fit into IMP ammo rack

# Explain why it's good for the game
Riflemen can purchase sandbags but currently lack a viable storage solution for filled ones. The IMP ammo rack is a limited logistical item that already supports carrying deployable barricades. Adding support for sandbags enhances its utility without undermining its primary role.

This change doesn't make the IMP rack solely a sandbag carrier; it still excels at transporting large quantities of ammunition or deployable barricades. Instead, it adds flexibility and gives players more tactical options.

At the same time, it preserves the unique role of the construction rig, which remains the superior choice for carrying large quantities of filled sandbags due to its ability to hold twice as many and utilize the belt slot.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: Allows IMP ammo rack to carry filled sandbags
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
