### PR TITLE
Enables the storage of flags and tesla into the construction belt.

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -155,7 +155,7 @@
 		/obj/item/stack/sandbags_empty,
 		/obj/item/stack/sandbags,
 		/obj/item/stack/barbed_wire,
-		/obj/item/defenses/handheld/sentry,
+		/obj/item/defenses/handheld,
 		/obj/item/stack/rods,
 		/obj/item/stack/tile,
 		/obj/item/device/defibrillator/synthetic,
@@ -169,7 +169,7 @@
 		/obj/item/stack/sheet,
 		/obj/item/stack/sandbags_empty,
 		/obj/item/stack/sandbags,
-		/obj/item/defenses/handheld/sentry,
+		/obj/item/defenses/handheld,
 	)
 
 /obj/item/storage/belt/medical


### PR DESCRIPTION

# About the pull request

Enables the storage of flags and teslas into the construction rig belt.

I do believe it might be an oversight, considering all sentries, flame sentries and their "upgraded" counterparts are able to be put inside them.

# Explain why it's good for the game

Puts the tesla and flag in line with the other two sentries when it comes to storage and prevents attempts at putting the flags/teslas into the construction rig thinking it could be done the same as the flamer/normal sentries, possibly wasting their belt choice.


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

![Capture d'écran 2025-06-02 140712](https://github.com/user-attachments/assets/4d7384cc-05e6-4431-a51b-19787f8bee73)

</details>


# Changelog
:cl:
balance: Enabled the storage of flag/teslas into the construction rig.
/:cl:

