### PR TITLE
One retry on relay browser

### DIFF
--- a/tgui/packages/common/ping.js
+++ b/tgui/packages/common/ping.js
@@ -96,7 +96,7 @@ export class Ping {
       }
     };
 
-    self.img.src = source + self.favicon + '?' + +new Date(); // Trigger image load with cache buster
+    self.img.src = source + self.favicon + '?' + new Date(); // Trigger image load with cache buster
   }
 
   /**

--- a/tgui/packages/tgui/interfaces/PingRelaysPanel.tsx
+++ b/tgui/packages/tgui/interfaces/PingRelaysPanel.tsx
@@ -53,17 +53,32 @@ class PingApp extends Component<PingAppProps> {
     this.realCurrentIndex = 0;
   }
 
-  startTest(desc: string, pingURL: string, connectURL: string) {
+  startTest(
+    desc: string,
+    pingURL: string,
+    connectURL: string,
+    retryIndex: number = -1,
+  ) {
     this.pinger.ping(
       'http://' + pingURL,
       (error: string | null, pong: number) => {
         // reading state is too unreliable now somereason so we have to use realCurrentIndex
-        this.results[this.realCurrentIndex++]?.update(
+        let index = retryIndex === -1 ? this.realCurrentIndex++ : retryIndex;
+
+        if (error !== null && retryIndex === -1) {
+          // Attempt a retry since it errored and we haven't tried yet
+          console.warn('Retrying ' + desc);
+          this.startTest(desc, pingURL, connectURL, index);
+          return;
+        }
+
+        this.results[index]?.update(
           desc,
           'byond://' + connectURL,
           round(pong * 0.75, 0), // The ping is inflated so lets compensate a bit
           error,
         );
+
         // We still have to set a state to cause a redraw
         this.setState((prevState: State) => ({
           currentIndex: prevState.currentIndex + 1,


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #5777 adding one retry on error.

It won't necessarily be in ping order, but the order is based on the original response time for the first attempt.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

I faked this failure because it doesn't seem the relays are currently overloaded but should look like this: 
![retry](https://github.com/user-attachments/assets/65612517-7509-4f10-b42c-40964b3b52aa)

</details>


# Changelog
:cl: Drathek
ui: Ping relay browser will attempt to retry once if a relay errors
/:cl:
