### PR TITLE
fixes micro tesla fire delay

### DIFF
--- a/code/modules/defenses/tesla_coil.dm
+++ b/code/modules/defenses/tesla_coil.dm
@@ -192,12 +192,13 @@
 	M.set_effect(TESLA_COIL_DAZE_EFFECT * 1.5, DAZE) // 1.5x as effective as normal tesla
 
 #undef TESLA_COIL_STUN_FIRE_DELAY
-#define TESLA_COIL_MICRO_FIRE_DELAY 10
+#define TESLA_COIL_MICRO_FIRE_DELAY 1 SECONDS
 /obj/structure/machinery/defenses/tesla_coil/micro
 	name = "\improper 25S micro tesla coil"
 	desc = "A perfected way of producing high-voltage, low-current and high-frequency electricity. Minor modifications allow it to only hit hostile targets with a devastating shock. This one is smaller and more lightweight."
 	handheld_type = /obj/item/defenses/handheld/tesla_coil/micro
 	disassemble_time = 0.5 SECONDS
+	fire_delay = TESLA_COIL_MICRO_FIRE_DELAY
 	density = FALSE
 	defense_type = "Micro"
 


### PR DESCRIPTION
# About the pull request

micro tesla has 1 second fire delay variable defined, but not applied, obvious oversight as with other teslas the variables are used

# Explain why it's good for the game
Makes micro tesla work as inteanded, without it it was just worse normal tesla (that did not block movement)


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: applies 1 second fire delay instead of 2 seconds (same as normal tesla) on micro tesla as intended
/:cl:
