### PR TITLE
removes trapper boiler as pickable strain

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Boiler.dm
@@ -13,7 +13,6 @@
 	evasion = XENO_EVASION_NONE
 	speed = XENO_SPEED_TIER_3
 
-	available_strains = list(/datum/xeno_strain/trapper)
 	behavior_delegate_type = /datum/behavior_delegate/boiler_base
 
 	evolution_allowed = FALSE


### PR DESCRIPTION
# About the pull request

It just removes the strain as pickable option, and do not call me lazy, the stuff used by trapper are still used in unremoved stuff from old base boiler.
(I have asked thwomper if ther are rework planed for it and was told that it is rather time for removal so here we go)

# Explain why it's good for the game

It was up for removal for a long time, the strain requires no cooperation, risk or skill and does not fit the desired gameplay at all with its main abilities keeping it several screens away from any enemy who can try to conteast it. There is no space for rework as its current role does not match the name of the caste at all. It is super unfun to play again, with and as the caste and only gets picked when xenos want to end the round and it comes to siege, now they have king and fob rework for that and king has to take at least some risk and requires skill and cooperation to utilize fully.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
del: Removes trapper boiler strain
/:cl:
