### PR TITLE
Fix hauling pull responses and monkey wandering

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -504,6 +504,7 @@
 
 	hauling_xeno = xeno
 	RegisterSignal(xeno, COMSIG_MOB_DEATH, PROC_REF(release_haul_death))
+	RegisterSignal(src, COMSIG_ATTEMPT_MOB_PULL, PROC_REF(haul_grab_attempt))
 	RegisterSignal(src, COMSIG_LIVING_PREIGNITION, PROC_REF(haul_fire_shield))
 	RegisterSignal(src, list(COMSIG_LIVING_FLAMER_CROSSED, COMSIG_LIVING_FLAMER_FLAMED), PROC_REF(haul_fire_shield_callback))
 	layer = LYING_BETWEEN_MOB_LAYER
@@ -515,21 +516,24 @@
 	SIGNAL_HANDLER
 	handle_unhaul()
 
+/mob/living/carbon/human/proc/haul_grab_attempt()
+	SIGNAL_HANDLER
+	return COMPONENT_CANCEL_MOB_PULL
+
 /mob/living/carbon/human/proc/haul_fire_shield(mob/living/burning_mob) //Stealing it from the pyro spec armor, xenos shield us from fire
 	SIGNAL_HANDLER
 	return COMPONENT_CANCEL_IGNITION
 
-
 /mob/living/carbon/human/proc/haul_fire_shield_callback(mob/living/burning_mob)
 	SIGNAL_HANDLER
-	. = COMPONENT_NO_IGNITE|COMPONENT_NO_BURN
+	return COMPONENT_NO_IGNITE|COMPONENT_NO_BURN
 
 // Removing traits and other stuff after xeno releases us from haul
 /mob/living/carbon/human/proc/handle_unhaul()
 	var/location = get_turf(loc)
 	remove_traits(list(TRAIT_HAULED, TRAIT_NO_STRAY, TRAIT_FLOORED, TRAIT_IMMOBILIZED), TRAIT_SOURCE_XENO_HAUL)
 	pixel_y = 0
-	UnregisterSignal(src, list(COMSIG_LIVING_PREIGNITION, COMSIG_LIVING_FLAMER_CROSSED, COMSIG_LIVING_FLAMER_FLAMED))
+	UnregisterSignal(src, list(COMSIG_ATTEMPT_MOB_PULL, COMSIG_LIVING_PREIGNITION, COMSIG_LIVING_FLAMER_CROSSED, COMSIG_LIVING_FLAMER_FLAMED))
 	UnregisterSignal(hauling_xeno, COMSIG_MOB_DEATH)
 	hauling_xeno = null
 	layer = MOB_LAYER

--- a/code/modules/mob/living/carbon/human/species/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/monkey.dm
@@ -51,8 +51,9 @@
 
 	var/is_on_turf = isturf(monkey.loc)
 	var/monkey_turf = get_turf(monkey)
+	var/hauled = HAS_TRAIT(monkey, TRAIT_HAULED)
 
-	if(prob(33) && is_on_turf && !monkey.pulledby && (monkey.mobility_flags & MOBILITY_MOVE) && !monkey.is_mob_restrained()) //won't move if being pulled
+	if(prob(33) && is_on_turf && !monkey.pulledby && (monkey.mobility_flags & MOBILITY_MOVE) && !monkey.is_mob_restrained() && !hauled) //won't move if being pulled
 		step(monkey, pick(GLOB.cardinals))
 
 	var/obj/held = monkey.get_active_hand()
@@ -71,7 +72,7 @@
 				monkey.throw_item(turf)
 		else
 			monkey.drop_held_item()
-	if(!held && !monkey.buckled && prob(5))
+	if(!held && !monkey.buckled && !hauled && prob(5))
 		var/list/touchables = list()
 		for(var/obj/thing in range(1, monkey_turf))
 			if(thing.Adjacent(monkey))

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -180,7 +180,7 @@
 
 	//Movement
 	if(!client && !stop_automated_movement && wander && !anchored)
-		if(isturf(src.loc) && !resting && !buckled && (mobility_flags & MOBILITY_MOVE)) //This is so it only moves if it's not inside a closet, gentics machine, etc.
+		if(isturf(loc) && !resting && !buckled && (mobility_flags & MOBILITY_MOVE) && !HAS_TRAIT(src, TRAIT_HAULED)) //This is so it only moves if it's not inside a closet, gentics machine, etc.
 			turns_since_move++
 			if(turns_since_move >= turns_per_move)
 				if(!(stop_automated_movement_when_pulled && pulledby)) //Soma animals don't move when pulled

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -479,6 +479,9 @@
 	if(throwing || is_mob_incapacitated())
 		return
 
+	if(HAS_TRAIT(src, TRAIT_HAULED))
+		return
+
 	if(pulling)
 		// Are we pulling the same thing twice? Just stop pulling.
 		if(pulling == AM)


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #8442 and fixes #9433 

Up until now nothing was preventing the hauled person from performing pull attempts (so could spam the pull response on xenos), and nothing prevented someone else from pulling a hauled person. Also prevents monkeys (and simple mobs - though dunno if anything currently applicable) from wandering while hauled.

# Explain why it's good for the game

Less hauling bugs and spam!

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/y68oCz6C9V4

</details>


# Changelog
:cl: Drathek
fix: Fixed hauled persons being able to pull stuff and other people being able to pull hauled people
fix: Fixed monkeys being able to move while hauled
/:cl:
