### PR TITLE
Adds button to toggle displaying Plasma on the updated Hive Status

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_status_ui.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status_ui.dm
@@ -170,6 +170,7 @@
 
 	var/mob/living/carbon/xenomorph/queen/Q = user
 	.["is_in_ovi"] = istype(Q) && Q.ovipositor
+	.["is_queen"] = istype(Q)
 
 /datum/hive_status_ui/ui_static_data(mob/user)
 	. = list()

--- a/tgui/packages/tgui/interfaces/HiveStatus.tsx
+++ b/tgui/packages/tgui/interfaces/HiveStatus.tsx
@@ -147,6 +147,7 @@ type Data = {
   user_ref: string;
   hive_color: string;
   hive_name: string;
+  is_queen: BooleanLike;
 };
 
 export const HiveStatus = (props) => {
@@ -351,8 +352,10 @@ const XenoList = (props) => {
     location: true,
   });
   const [maxHealth, setMaxHealth] = useState(100);
-  const { xeno_keys, xeno_vitals, xeno_info, user_ref, is_in_ovi, hive_color } =
+  const { xeno_keys, xeno_vitals, xeno_info, user_ref, is_in_ovi, hive_color, is_queen } =
     data;
+  const [showPlasma, setShowPlasma] = useState(is_queen ? true : false);
+  
   const xeno_entries = filterXenos({
     searchKey: searchKey,
     searchFilters: searchFilters,
@@ -412,6 +415,22 @@ const XenoList = (props) => {
       </Flex.Item>
       <Flex.Item mb={1}>
         <Flex align="baseline">
+          <Flex.Item>
+            <Button.Checkbox
+              inline
+              checked={showPlasma}
+              backgroundColor={showPlasma && hive_color}
+              onClick={() =>
+                setShowPlasma(!showPlasma)
+              }
+            >
+              Show Plasma
+            </Button.Checkbox>
+          </Flex.Item>
+        </Flex>
+      </Flex.Item>
+      <Flex.Item mb={1}>
+        <Flex align="baseline">
           <Flex.Item width="100px">Max Health:</Flex.Item>
           <Flex.Item>
             <NumberInput
@@ -442,7 +461,9 @@ const XenoList = (props) => {
           <Table.Cell width="15%">Strain</Table.Cell>
           <Table.Cell>Location</Table.Cell>
           <Table.Cell width="60px">Health</Table.Cell>
-          <Table.Cell width="60px">Plasma</Table.Cell>
+          {(showPlasma && (
+            <Table.Cell width="60px">Plasma</Table.Cell>
+          ))}
           <Table.Cell width="100px" />
         </Table.Row>
 
@@ -470,15 +491,17 @@ const XenoList = (props) => {
                 <>{entry.health}%</>
               )}
             </Table.Cell>
-            <Table.Cell>
-              {entry.plasma < 0 ? (
-                <div style={grayFont}>------</div>
-              ) : entry.plasma < 30 ? (
-                <b style={redFont}>{entry.plasma}%</b>
-              ) : (
-                <>{entry.plasma}%</>
-              )}
-            </Table.Cell>
+            {(showPlasma && (
+                <Table.Cell>
+                  {entry.plasma < 0 ? (
+                    <div style={grayFont}>------</div>
+                  ) : entry.plasma < 30 ? (
+                    <b style={redFont}>{entry.plasma}%</b>
+                  ) : (
+                    <>{entry.plasma}%</>
+                  )}
+                </Table.Cell>
+            ))}
             <Table.Cell className="noPadCell" textAlign="center">
               {entry.ref !== user_ref && (
                 <Flex


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Plasma level is somewhat relevant for Queens, and not at all relevant for most other castes.

Adds a button in the UI to toggle the column. Default option is ON for the Queen, and OFF for anyone else.


# Explain why it's good for the game

Less clutter, yay!

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>
![image](https://github.com/user-attachments/assets/2a9b92e2-f290-46a5-a98b-c74f7661e96d)

![image](https://github.com/user-attachments/assets/0109118e-a87f-44a2-a658-5ca3db286207)

</details>


# Changelog

:cl:
ui: There's now a 'Show Plasma' toggle in the Hive Status UI to toggle the Plasma column.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
