### PR TITLE
Equipment Preset and Manifest interaction backend changes

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -85,8 +85,8 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 	record_general.fields["id"] = id
 	record_general.fields["name"] = target.real_name
 	record_general.name = target.real_name
-	record_general.fields["real_rank"] = manifest_title
-	record_general.fields["rank"] = assignment
+	record_general.fields["real_rank"] = assignment
+	record_general.fields["rank"] = manifest_title
 	record_general.fields["squad"] = target.assigned_squad ? target.assigned_squad.name : null
 	record_general.fields["age"] = target.age
 	record_general.fields["p_stat"] = "Active"

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -69,6 +69,12 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 	else
 		assignment = "Unassigned"
 
+	var/manifest_title
+	if(target?.assigned_equipment_preset.manifest_title)
+		manifest_title = target.assigned_equipment_preset.manifest_title
+	else
+		manifest_title = target.job
+
 	var/id = add_zero(num2hex(target.gid), 6) //this was the best they could come up with? A large random number? *sigh*
 	var/icon/front = new(get_id_photo(target), dir = SOUTH)
 	var/icon/side = new(get_id_photo(target), dir = WEST)
@@ -79,7 +85,7 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 	record_general.fields["id"] = id
 	record_general.fields["name"] = target.real_name
 	record_general.name = target.real_name
-	record_general.fields["real_rank"] = target.job
+	record_general.fields["real_rank"] = manifest_title
 	record_general.fields["rank"] = assignment
 	record_general.fields["squad"] = target.assigned_squad ? target.assigned_squad.name : null
 	record_general.fields["age"] = target.age

--- a/code/modules/gear_presets/_select_equipment.dm
+++ b/code/modules/gear_presets/_select_equipment.dm
@@ -14,7 +14,8 @@
 	var/idtype = /obj/item/card/id
 	var/list/access = list()
 	var/assignment
-	var/rank
+	var/job_title
+	var/manifest_title
 	var/list/paygrades = list("???")
 	var/role_comm_title
 	var/minimum_age
@@ -53,6 +54,9 @@
 
 
 /datum/equipment_preset/New()
+	if(!manifest_title)
+		manifest_title = job_title
+
 	uniform_sets = list(
 		UNIFORM_VEND_UTILITY_UNIFORM = utility_under,
 		UNIFORM_VEND_UTILITY_JACKET = utility_over,
@@ -102,7 +106,7 @@
 	if(!mob_client || new_human.client != mob_client)
 		playtime = JOB_PLAYTIME_TIER_1
 	else
-		playtime = get_job_playtime(mob_client, rank)
+		playtime = get_job_playtime(mob_client, job_title)
 		if((playtime >= JOB_PLAYTIME_TIER_1) && !mob_client.prefs.playtime_perks)
 			playtime = JOB_PLAYTIME_TIER_1
 	var/final_paygrade
@@ -111,7 +115,7 @@
 		if(required_time - playtime > 0)
 			break
 		final_paygrade = current_paygrade
-	if(rank == JOB_SQUAD_MARINE && final_paygrade == PAY_SHORT_ME3)
+	if(job_title == JOB_SQUAD_MARINE && final_paygrade == PAY_SHORT_ME3)
 		if(GLOB.data_core.leveled_riflemen > GLOB.data_core.leveled_riflemen_max)
 			return PAY_SHORT_ME2
 		else
@@ -145,7 +149,7 @@
 	ID.faction = faction
 	ID.faction_group = faction_group.Copy()
 	ID.assignment = assignment
-	ID.rank = rank
+	ID.rank = manifest_title
 	ID.registered_name = new_human.real_name
 	ID.registered_ref = WEAKREF(new_human)
 	ID.registered_gid = new_human.gid
@@ -158,7 +162,7 @@
 	if(new_human.mind)
 		new_human.mind.name = new_human.real_name
 		// Bank account details handled in generate_money_account()
-	new_human.job = rank
+	new_human.job = job_title
 	new_human.comm_title = role_comm_title
 
 /datum/equipment_preset/proc/load_languages(mob/living/carbon/human/new_human, client/mob_client)
@@ -222,7 +226,7 @@
 				qdel(R)
 
 	if(flags & EQUIPMENT_PRESET_MARINE)
-		var/playtime = get_job_playtime(new_human.client, rank)
+		var/playtime = get_job_playtime(new_human.client, job_title)
 		var/medal_type
 
 		switch(playtime)

--- a/code/modules/gear_presets/agents.dm
+++ b/code/modules/gear_presets/agents.dm
@@ -16,7 +16,7 @@
 		ACCESS_MARINE_MAINT,
 	)
 	assignment = JOB_STOWAWAY
-	rank = JOB_STOWAWAY
+	job_title = JOB_STOWAWAY
 	paygrades = list("???" = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "???"
 	skills = /datum/skills/civilian/survivor
@@ -68,7 +68,7 @@
 		ACCESS_UPP_LEADERSHIP,
 	)
 	assignment = JOB_UPP_REPRESENTATIVE
-	rank = JOB_UPP_REPRESENTATIVE
+	job_title = JOB_UPP_REPRESENTATIVE
 	paygrades = list(PAY_SHORT_CREP = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "UPP Rep."
 	skills = /datum/skills/civilian/survivor
@@ -104,7 +104,7 @@
 		ACCESS_TWE_LEADERSHIP,
 	)
 	assignment = JOB_TWE_REPRESENTATIVE
-	rank = JOB_TWE_REPRESENTATIVE
+	job_title = JOB_TWE_REPRESENTATIVE
 	paygrades = list(PAY_SHORT_CREP = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "TWE Rep."
 	skills = /datum/skills/civilian/survivor

--- a/code/modules/gear_presets/cbrn.dm
+++ b/code/modules/gear_presets/cbrn.dm
@@ -1,7 +1,7 @@
 /datum/equipment_preset/uscm/cbrn
 	name = "Generic CBRN" //Parent type for easier gear
 	assignment = JOB_SQUAD_MARINE
-	rank = JOB_SQUAD_MARINE
+	job_title = JOB_SQUAD_MARINE
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "CBRN"
 	flags = EQUIPMENT_PRESET_EXTRA
@@ -69,7 +69,7 @@
 	name = "CBRN Combat Technician"
 	paygrades = list(PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_0)
 	assignment = JOB_SQUAD_ENGI
-	rank = JOB_SQUAD_ENGI
+	job_title = JOB_SQUAD_ENGI
 	role_comm_title = "ComTech"
 	minimap_icon = "engi"
 	skills = /datum/skills/pmc/engineer
@@ -113,7 +113,7 @@
 	name = "CBRN Hospital Corpsman"
 	paygrades = list(PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_0)
 	assignment = JOB_SQUAD_MEDIC
-	rank = JOB_SQUAD_MEDIC
+	job_title = JOB_SQUAD_MEDIC
 	role_comm_title = "HM"
 	minimap_icon = "medic"
 	skills = /datum/skills/pmc/medic
@@ -156,7 +156,7 @@
 	name = "CBRN Fireteam Leader"
 	paygrades = list(PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_0)
 	assignment = JOB_SQUAD_TEAM_LEADER
-	rank = JOB_SQUAD_TEAM_LEADER
+	job_title = JOB_SQUAD_TEAM_LEADER
 	role_comm_title = "TL"
 	minimap_icon = "tl"
 	skills = /datum/skills/pmc/SL
@@ -191,7 +191,7 @@
 	name = "CBRN Specialist"
 	paygrades = list(PAY_SHORT_OPR = JOB_PLAYTIME_TIER_0)
 	assignment = JOB_SQUAD_SPECIALIST
-	rank = JOB_SQUAD_SPECIALIST
+	job_title = JOB_SQUAD_SPECIALIST
 	role_comm_title = "Spc"
 	minimap_icon = "spec"
 	languages = list(LANGUAGE_ENGLISH, LANGUAGE_TSL)
@@ -241,6 +241,6 @@
 /datum/equipment_preset/uscm/cbrn/specialist/lead //Same gear, better title
 	name = "CBRN Specialist SL"
 	assignment = JOB_SQUAD_LEADER
-	rank = JOB_SQUAD_LEADER
+	job_title = JOB_SQUAD_LEADER
 	role_comm_title = "Spc SL"
 	skills = /datum/skills/commando/deathsquad/leader

--- a/code/modules/gear_presets/cia.dm
+++ b/code/modules/gear_presets/cia.dm
@@ -13,7 +13,7 @@
 
 /datum/equipment_preset/cia/analyst
 	name = "CIA Agent (Civilian Clothing)"
-	rank = "Intelligence Analyst"
+	job_title = "Intelligence Analyst"
 	paygrades = list(PAY_SHORT_CIV = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "CIV"
 	minimap_background = "background_civillian"
@@ -62,7 +62,7 @@
 
 /datum/equipment_preset/cia/officer
 	name = "CIA Agent (USCM Liaison - 1st Lieutenant)"
-	rank = "Intelligence Liaison Officer"
+	job_title = "Intelligence Liaison Officer"
 	assignment = JOB_CIA_LIAISON
 	paygrades = list(PAY_SHORT_MO2 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "ILO"

--- a/code/modules/gear_presets/cia.dm
+++ b/code/modules/gear_presets/cia.dm
@@ -13,7 +13,7 @@
 
 /datum/equipment_preset/cia/analyst
 	name = "CIA Agent (Civilian Clothing)"
-	job_title = "Intelligence Analyst"
+	job_title = JOB_CIA
 	paygrades = list(PAY_SHORT_CIV = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "CIV"
 	minimap_background = "background_civillian"
@@ -62,7 +62,7 @@
 
 /datum/equipment_preset/cia/officer
 	name = "CIA Agent (USCM Liaison - 1st Lieutenant)"
-	job_title = "Intelligence Liaison Officer"
+	job_title = JOB_CIA_LIAISON
 	assignment = JOB_CIA_LIAISON
 	paygrades = list(PAY_SHORT_MO2 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "ILO"

--- a/code/modules/gear_presets/clf.dm
+++ b/code/modules/gear_presets/clf.dm
@@ -2,7 +2,7 @@
 	name = FACTION_CLF
 	languages = list(LANGUAGE_JAPANESE, LANGUAGE_ENGLISH)
 	assignment = JOB_CLF
-	rank = FACTION_CLF
+	job_title = FACTION_CLF
 	paygrades = list(PAY_SHORT_REB = JOB_PLAYTIME_TIER_0)
 	faction = FACTION_CLF
 	origin_override = ORIGIN_CIVILIAN
@@ -52,7 +52,7 @@
 	name = "CLF Soldier"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_CLF
-	rank = JOB_CLF
+	job_title = JOB_CLF
 	role_comm_title = "GRL"
 
 	minimap_icon = "clf_mil"
@@ -162,7 +162,7 @@
 	name = "CLF Engineer"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_CLF_ENGI
-	rank = JOB_CLF_ENGI
+	job_title = JOB_CLF_ENGI
 	role_comm_title = "TECH"
 
 	minimap_icon = "clf_engi"
@@ -291,7 +291,7 @@
 	name = "CLF Medic"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_CLF_MEDIC
-	rank = JOB_CLF_MEDIC
+	job_title = JOB_CLF_MEDIC
 	role_comm_title = "MED"
 	minimap_icon = "clf_med"
 	paygrades = list(PAY_SHORT_CDOC = JOB_PLAYTIME_TIER_0)
@@ -452,7 +452,7 @@
 	name = "CLF Specialist"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_CLF_SPECIALIST
-	rank = JOB_CLF_SPECIALIST
+	job_title = JOB_CLF_SPECIALIST
 	role_comm_title = "SPC"
 
 	minimap_icon = "clf_spec"
@@ -581,7 +581,7 @@
 	name = "CLF Leader"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_CLF_LEADER
-	rank = JOB_CLF_LEADER
+	job_title = JOB_CLF_LEADER
 	role_comm_title = "LDR"
 
 	minimap_icon = "clf_sl"
@@ -737,7 +737,7 @@
 
 	skills = /datum/skills/colonial_synthetic
 	assignment = JOB_CLF_SYNTH
-	rank = JOB_CLF_SYNTH
+	job_title = JOB_CLF_SYNTH
 	paygrades = list(PAY_SHORT_SYN = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "Syn"
 
@@ -988,7 +988,7 @@
 	name = "CLF Cell Commander"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_CLF_COMMANDER
-	rank = JOB_CLF_COMMANDER
+	job_title = JOB_CLF_COMMANDER
 	paygrades = list(PAY_SHORT_REBC = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "CMDR"
 

--- a/code/modules/gear_presets/cmb.dm
+++ b/code/modules/gear_presets/cmb.dm
@@ -2,7 +2,7 @@
 	name = "Colonial Marshal"
 	faction = FACTION_MARSHAL
 	faction_group = list(FACTION_MARSHAL, FACTION_MARINE)
-	rank = JOB_CMB
+	job_title = JOB_CMB
 	idtype = /obj/item/card/id/deputy
 	languages = list(LANGUAGE_ENGLISH, LANGUAGE_JAPANESE)
 	minimap_background = "background_cmb"
@@ -62,7 +62,7 @@
 	role_comm_title = "CMB DEP"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = "CMB Deputy"
-	rank = JOB_CMB
+	job_title = JOB_CMB
 
 	minimap_icon = "deputy"
 
@@ -152,7 +152,7 @@
 	minimap_icon = "xo"
 
 	assignment = "CMB Marshal"
-	rank = JOB_CMB_TL
+	job_title = JOB_CMB_TL
 	skills = /datum/skills/cmb/leader
 	minimum_age = 30
 	languages = ALL_HUMAN_LANGUAGES
@@ -260,7 +260,7 @@
 	minimap_icon = "mp"
 
 	assignment = "CMB Riot Control Officer"
-	rank = JOB_CMB_RIOT
+	job_title = JOB_CMB_RIOT
 
 	skills = /datum/skills/cmb
 
@@ -377,7 +377,7 @@
 	minimap_icon = "medic"
 
 	assignment = "CMB Medical Technician"
-	rank = JOB_CMB_MED
+	job_title = JOB_CMB_MED
 	skills = /datum/skills/cmb/medic
 
 /datum/equipment_preset/cmb/med/load_gear(mob/living/carbon/human/new_human)
@@ -428,7 +428,7 @@
 	minimap_icon = "engi"
 
 	assignment = "CMB Breaching Technician"
-	rank = JOB_CMB_ENG
+	job_title = JOB_CMB_ENG
 	skills = /datum/skills/cmb/engi
 
 /datum/equipment_preset/cmb/eng/load_gear(mob/living/carbon/human/new_human)
@@ -482,7 +482,7 @@
 	minimap_icon = "cmb_spc"
 
 	assignment = "CMB SWAT Specialist"
-	rank = JOB_CMB_SWAT
+	job_title = JOB_CMB_SWAT
 	skills = /datum/skills/cmb/spec
 
 /datum/equipment_preset/cmb/spec/load_gear(mob/living/carbon/human/new_human)
@@ -533,7 +533,7 @@
 	minimap_icon = "cmb_syn"
 
 	assignment = "CMB Investigative Synthetic"
-	rank = JOB_CMB_SYN
+	job_title = JOB_CMB_SYN
 	languages = ALL_SYNTH_LANGUAGES
 
 /datum/equipment_preset/cmb/synth/load_skills(mob/living/carbon/human/new_human)
@@ -631,7 +631,7 @@
 	minimap_icon = "pmc_syn"
 
 	assignment = "CMB Riot Control Synthetic"
-	rank = JOB_CMB_RSYN
+	job_title = JOB_CMB_RSYN
 	skills = /datum/skills/synthetic
 
 /datum/equipment_preset/cmb/synth/riot/load_gear(mob/living/carbon/human/new_human)
@@ -693,7 +693,7 @@
 	minimap_icon = "icc"
 
 	assignment = "Interstellar Commerce Commission Corporate Liaison"
-	rank = JOB_CMB_ICC
+	job_title = JOB_CMB_ICC
 	skills = /datum/skills/civilian/survivor
 	languages = list(LANGUAGE_ENGLISH, LANGUAGE_SPANISH, LANGUAGE_JAPANESE)
 
@@ -754,7 +754,7 @@
 	minimap_icon = "obs"
 
 	assignment = "Interstellar Human Rights Observer"
-	rank = JOB_CMB_OBS
+	job_title = JOB_CMB_OBS
 	skills = /datum/skills/civilian/survivor/doctor
 	languages = list(LANGUAGE_ENGLISH, LANGUAGE_SPANISH, LANGUAGE_RUSSIAN)
 
@@ -802,7 +802,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA|EQUIPMENT_PRESET_MARINE
 
 	assignment = "Anchorpoint Station Marine Rifleman"
-	rank = JOB_SQUAD_MARINE
+	job_title = JOB_SQUAD_MARINE
 	paygrades = list(PAY_SHORT_ME2 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "A-RFN"
 	skills = /datum/skills/pfc/crafty
@@ -855,7 +855,7 @@
 	name = "USCM Anchorpoint Station Team Leader"
 	flags = EQUIPMENT_PRESET_EXTRA|EQUIPMENT_PRESET_MARINE
 	assignment = "Anchorpoint Station Marine Team Leader"
-	rank = JOB_SQUAD_LEADER
+	job_title = JOB_SQUAD_LEADER
 	paygrades = list(PAY_SHORT_ME6 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "A-TL"
 	minimum_age = 25
@@ -898,7 +898,7 @@
 	name = "USCM Anchorpoint Station Technical Specialist"
 	flags = EQUIPMENT_PRESET_EXTRA|EQUIPMENT_PRESET_MARINE
 	assignment = "Anchorpoint Station Marine Technical Specialist"
-	rank = JOB_SQUAD_TEAM_LEADER
+	job_title = JOB_SQUAD_TEAM_LEADER
 	paygrades = list(PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "A-TS"
 	skills = /datum/skills/tl
@@ -941,7 +941,7 @@
 	name = "USCM Anchorpoint Station Corpsman"
 	flags = EQUIPMENT_PRESET_EXTRA|EQUIPMENT_PRESET_MARINE
 	assignment = "Anchorpoint Station Hospital Corpsman"
-	rank = JOB_SQUAD_MEDIC
+	job_title = JOB_SQUAD_MEDIC
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "A-HM"
 	skills = /datum/skills/combat_medic
@@ -1000,7 +1000,7 @@
 	name = "USCM Anchorpoint Station Smartgunner"
 	flags = EQUIPMENT_PRESET_EXTRA|EQUIPMENT_PRESET_MARINE
 	assignment = "Anchorpoint Station Marine Smartgunner"
-	rank = JOB_SQUAD_SMARTGUN
+	job_title = JOB_SQUAD_SMARTGUN
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "A-SG"
 	skills = /datum/skills/smartgunner

--- a/code/modules/gear_presets/colonist.dm
+++ b/code/modules/gear_presets/colonist.dm
@@ -3,7 +3,7 @@
 	name = JOB_COLONIST
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_COLONIST
-	rank = JOB_COLONIST
+	job_title = JOB_COLONIST
 	faction = FACTION_COLONIST
 
 	access = list(ACCESS_CIVILIAN_PUBLIC)

--- a/code/modules/gear_presets/contractor.dm
+++ b/code/modules/gear_presets/contractor.dm
@@ -1,7 +1,7 @@
 /datum/equipment_preset/contractor
 	name = "Military Contractor"
 	faction = FACTION_CONTRACTOR
-	rank = JOB_CONTRACTOR
+	job_title = JOB_CONTRACTOR
 	idtype = /obj/item/card/id/data
 	faction = FACTION_CONTRACTOR
 	faction_group = list(FACTION_CONTRACTOR)
@@ -64,7 +64,7 @@
 	role_comm_title = "Merc"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = "VAIPO Mercenary"
-	rank = JOB_CONTRACTOR_ST
+	job_title = JOB_CONTRACTOR_ST
 	skills = /datum/skills/contractor
 	faction = FACTION_CONTRACTOR
 
@@ -173,7 +173,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = "VAIPO Automatic Rifleman"
-	rank = JOB_CONTRACTOR_MG
+	job_title = JOB_CONTRACTOR_MG
 	skills = /datum/skills/contractor/heavy
 	faction = FACTION_CONTRACTOR
 
@@ -235,7 +235,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = "VAIPO Engineering Specialist"
-	rank = JOB_CONTRACTOR_ENGI
+	job_title = JOB_CONTRACTOR_ENGI
 	skills = /datum/skills/contractor/engi
 	faction = FACTION_CONTRACTOR
 
@@ -281,7 +281,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = "VAIMS Medical Specialist"
-	rank = JOB_CONTRACTOR_MEDIC
+	job_title = JOB_CONTRACTOR_MEDIC
 	skills = /datum/skills/contractor/medic
 	faction = FACTION_CONTRACTOR
 
@@ -327,7 +327,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = "VAIPO Team Leader"
-	rank = JOB_CONTRACTOR_TL
+	job_title = JOB_CONTRACTOR_TL
 	skills = /datum/skills/contractor/leader
 	faction = FACTION_CONTRACTOR
 
@@ -378,7 +378,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = "VAIPO Support Synthetic"
-	rank = JOB_CONTRACTOR_SYN
+	job_title = JOB_CONTRACTOR_SYN
 	faction = FACTION_CONTRACTOR
 	languages = ALL_SYNTH_LANGUAGES
 
@@ -469,7 +469,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = "VAISO Mercenary"
-	rank = JOB_CONTRACTOR_COVST
+	job_title = JOB_CONTRACTOR_COVST
 	skills = /datum/skills/contractor
 	faction = FACTION_CONTRACTOR
 
@@ -578,7 +578,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = "VAISO Automatic Rifleman"
-	rank = JOB_CONTRACTOR_COVMG
+	job_title = JOB_CONTRACTOR_COVMG
 	skills = /datum/skills/contractor/heavy
 	faction = FACTION_CONTRACTOR
 
@@ -629,7 +629,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = "VAISO Engineering Specialist"
-	rank = JOB_CONTRACTOR_COVENG
+	job_title = JOB_CONTRACTOR_COVENG
 	skills = /datum/skills/contractor/engi
 	faction = FACTION_CONTRACTOR
 
@@ -676,7 +676,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = "VAIMS Medical Specialist"
-	rank = JOB_CONTRACTOR_COVMED
+	job_title = JOB_CONTRACTOR_COVMED
 	skills = /datum/skills/contractor/medic
 	faction = FACTION_CONTRACTOR
 
@@ -723,7 +723,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = "VAISO Team Leader"
-	rank = JOB_CONTRACTOR_COVTL
+	job_title = JOB_CONTRACTOR_COVTL
 	skills = /datum/skills/contractor/leader
 	faction = FACTION_CONTRACTOR
 
@@ -774,7 +774,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = "VAISO Support Synthetic"
-	rank = JOB_CONTRACTOR_COVSYN
+	job_title = JOB_CONTRACTOR_COVSYN
 	skills = /datum/skills/synthetic
 	faction = FACTION_CONTRACTOR
 	languages = ALL_SYNTH_LANGUAGES

--- a/code/modules/gear_presets/corpses.dm
+++ b/code/modules/gear_presets/corpses.dm
@@ -3,7 +3,7 @@
 	name = "Corpse"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_COLONIST
-	rank = JOB_COLONIST
+	job_title = JOB_COLONIST
 	faction = FACTION_COLONIST
 	languages = list()
 	access = list(ACCESS_CIVILIAN_PUBLIC)
@@ -208,7 +208,7 @@
 
 /datum/equipment_preset/corpse/security/cmb
 	name = "Corpse - Colonial Marshal Deputy"
-	rank = JOB_CMB
+	job_title = JOB_CMB
 	paygrades = list(PAY_SHORT_CMBD = JOB_PLAYTIME_TIER_0)
 	idtype = /obj/item/card/id/deputy
 	xenovictim = TRUE
@@ -239,7 +239,7 @@
 
 /datum/equipment_preset/corpse/security/cmb/riot
 	name = "Corpse - CMB Riot Control Officer"
-	rank = JOB_CMB_RIOT
+	job_title = JOB_CMB_RIOT
 	paygrades = list(PAY_SHORT_CMBR = JOB_PLAYTIME_TIER_0)
 	idtype = /obj/item/card/id/deputy/riot
 	xenovictim = FALSE
@@ -272,7 +272,7 @@
 /datum/equipment_preset/corpse/liaison
 	name = "Corpse - Corporate Liaison"
 	assignment = JOB_EXECUTIVE
-	rank = JOB_EXECUTIVE
+	job_title = JOB_EXECUTIVE
 	faction_group = FACTION_LIST_WY
 	paygrades = list(PAY_SHORT_WYC3 = JOB_PLAYTIME_TIER_0)
 	idtype = /obj/item/card/id/silver/clearance_badge/cl
@@ -349,7 +349,7 @@
 /datum/equipment_preset/corpse/manager
 	name = "Corpse - Colony Division Manager"
 	assignment = "Colonial Division Manager"
-	rank = JOB_DIVISION_MANAGER
+	job_title = JOB_DIVISION_MANAGER
 	faction_group = FACTION_LIST_WY
 	paygrades = list(PAY_SHORT_WYC8 = JOB_PLAYTIME_TIER_0)
 	access = list(
@@ -385,7 +385,7 @@
 /datum/equipment_preset/corpse/administrator
 	name = "Corpse - Colony Administrator"
 	assignment = "Colonial Administrator"
-	rank = JOB_DEPUTY_DIRECTOR
+	job_title = JOB_DEPUTY_DIRECTOR
 	faction_group = FACTION_LIST_WY
 	paygrades = list(PAY_SHORT_WYC10 = JOB_PLAYTIME_TIER_0)
 	idtype = /obj/item/card/id/silver/cl
@@ -574,7 +574,7 @@
 	assignment = "Colony Supervisor"
 	flags = EQUIPMENT_PRESET_EXTRA
 	paygrades = list(PAY_SHORT_WYC6 = JOB_PLAYTIME_TIER_0)
-	rank = FACTION_WY
+	job_title = FACTION_WY
 	idtype = /obj/item/card/id/silver/clearance_badge/manager
 	faction_group = FACTION_LIST_WY
 	access = list(
@@ -616,7 +616,7 @@
 	name = "Corpse - Colonial Liberation Front Soldier"
 	assignment = JOB_CLF
 	idtype = /obj/item/card/id/data
-	rank = JOB_CLF
+	job_title = JOB_CLF
 	faction = FACTION_CLF
 	paygrades = list(PAY_SHORT_REB = JOB_PLAYTIME_TIER_0)
 
@@ -656,7 +656,7 @@
 	assignment = JOB_UPP
 	idtype = /obj/item/card/id/dogtag/upp
 	paygrades = list(PAY_SHORT_UE2 = JOB_PLAYTIME_TIER_0)
-	rank = JOB_UPP
+	job_title = JOB_UPP
 	faction = FACTION_UPP
 
 /datum/equipment_preset/corpse/upp/New()
@@ -691,7 +691,7 @@
 	assignment = JOB_PMC_STANDARD
 	faction = FACTION_PMC
 	faction_group = FACTION_LIST_WY
-	rank = JOB_PMC_STANDARD
+	job_title = JOB_PMC_STANDARD
 	paygrades = list(PAY_SHORT_PMC_OP = JOB_PLAYTIME_TIER_0)
 	idtype = /obj/item/card/id/pmc
 	access = list(
@@ -742,7 +742,7 @@
 	name = "Corpse - Weyland-Yutani Corporate (Goon)"
 	languages = list(LANGUAGE_ENGLISH)
 	assignment = JOB_WY_GOON
-	rank = JOB_WY_GOON
+	job_title = JOB_WY_GOON
 	paygrades = list(PAY_SHORT_CPO = JOB_PLAYTIME_TIER_0)
 
 /datum/equipment_preset/corpse/pmc/goon/load_gear(mob/living/carbon/human/new_human)
@@ -767,7 +767,7 @@
 	name = "Corpse - Weyland-Yutani Corporate Security Lead (Goon Lead)"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_WY_GOON_LEAD
-	rank = JOB_WY_GOON_LEAD
+	job_title = JOB_WY_GOON_LEAD
 	paygrades = list(PAY_SHORT_CSPO = JOB_PLAYTIME_TIER_0)
 
 /datum/equipment_preset/corpse/pmc/goon/lead/load_gear(mob/living/carbon/human/new_human)
@@ -796,7 +796,7 @@
 	name = "Corpse - Weyland-Yutani Corporate Security (Kutjevo Goon)"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_WY_GOON
-	rank = JOB_WY_GOON
+	job_title = JOB_WY_GOON
 	paygrades = list(PAY_SHORT_CPO = JOB_PLAYTIME_TIER_0)
 
 /datum/equipment_preset/corpse/pmc/goon/kutjevo/load_gear(mob/living/carbon/human/new_human)
@@ -822,7 +822,7 @@
 /datum/equipment_preset/corpse/freelancer
 	name = "Corpse - Freelancer"
 	paygrades = list(PAY_SHORT_FL_S = JOB_PLAYTIME_TIER_0)
-	rank = FACTION_FREELANCER
+	job_title = FACTION_FREELANCER
 	idtype = /obj/item/card/id/data
 	faction = FACTION_FREELANCER
 
@@ -1082,7 +1082,7 @@
 	name = "Corpse - Weyland-Yutani - Corporate Security"
 	languages = list(LANGUAGE_ENGLISH)
 	assignment = JOB_WY_GOON
-	rank = JOB_WY_GOON
+	job_title = JOB_WY_GOON
 	paygrades = list(PAY_SHORT_CPO = JOB_PLAYTIME_TIER_0)
 
 /datum/equipment_preset/corpse/pmc/hybrisa_goon/load_gear(mob/living/carbon/human/new_human)
@@ -1113,7 +1113,7 @@
 	name = "Corpse - Weyland-Yutani - Corporate Security Lead"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_WY_GOON_LEAD
-	rank = JOB_WY_GOON_LEAD
+	job_title = JOB_WY_GOON_LEAD
 	paygrades = list(PAY_SHORT_CSPO = JOB_PLAYTIME_TIER_0)
 
 /datum/equipment_preset/corpse/pmc/hybrisa_goon/lead/load_gear(mob/living/carbon/human/new_human)

--- a/code/modules/gear_presets/dust_raider.dm
+++ b/code/modules/gear_presets/dust_raider.dm
@@ -23,7 +23,7 @@
 
 	access = list(ACCESS_MARINE_PREP)
 	assignment = JOB_SQUAD_MARINE
-	rank = JOB_SQUAD_MARINE
+	job_title = JOB_SQUAD_MARINE
 	paygrades = list(PAY_SHORT_ME2 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "RFN"
 	skills = /datum/skills/pfc/crafty
@@ -45,7 +45,7 @@
 
 	access = list(ACCESS_MARINE_PREP)
 	assignment = JOB_SQUAD_LEADER
-	rank = JOB_SQUAD_LEADER
+	job_title = JOB_SQUAD_LEADER
 	paygrades = list(PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "SL"
 	skills = /datum/skills/SL
@@ -74,7 +74,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_SMARTPREP)
 	assignment = JOB_SQUAD_SMARTGUN
-	rank = JOB_SQUAD_SMARTGUN
+	job_title = JOB_SQUAD_SMARTGUN
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "SG"
 	skills = /datum/skills/smartgunner
@@ -99,7 +99,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_ENGPREP, ACCESS_CIVILIAN_ENGINEERING)
 	assignment = JOB_SQUAD_ENGI
-	rank = JOB_SQUAD_ENGI
+	job_title = JOB_SQUAD_ENGI
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "Eng"
 	skills = /datum/skills/combat_engineer
@@ -128,7 +128,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_MEDPREP, ACCESS_MARINE_MEDBAY)
 	assignment = JOB_SQUAD_MEDIC
-	rank = JOB_SQUAD_MEDIC
+	job_title = JOB_SQUAD_MEDIC
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "HM"
 	skills = /datum/skills/combat_medic
@@ -163,7 +163,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_SPECPREP)
 	assignment = JOB_SQUAD_SPECIALIST
-	rank = JOB_SQUAD_SPECIALIST
+	job_title = JOB_SQUAD_SPECIALIST
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "Spc"
 	skills = /datum/skills/specialist

--- a/code/modules/gear_presets/dutch.dm
+++ b/code/modules/gear_presets/dutch.dm
@@ -11,7 +11,7 @@
 
 /datum/equipment_preset/dutch/New()
 	..()
-	rank = assignment
+	job_title = assignment
 
 /datum/equipment_preset/dutch/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(60;MALE,40;FEMALE)

--- a/code/modules/gear_presets/fax_responders.dm
+++ b/code/modules/gear_presets/fax_responders.dm
@@ -1,7 +1,7 @@
 /datum/equipment_preset/fax_responder
 	name = "Fax Responder"
 	assignment = "Fax Responder"
-	rank = "Fax Responder"
+	job_title = "Fax Responder"
 
 	role_comm_title = "Resp."
 
@@ -72,7 +72,7 @@
 /datum/equipment_preset/fax_responder/uscm
 	name = "Fax Responder - USCM HC"
 	assignment = JOB_FAX_RESPONDER_USCM_HC
-	rank = JOB_FAX_RESPONDER_USCM_HC
+	job_title = JOB_FAX_RESPONDER_USCM_HC
 	faction_group = list(FACTION_FAX, FACTION_MARINE)
 
 	paygrades = list(PAY_SHORT_MO2 = JOB_PLAYTIME_TIER_0, PAY_SHORT_MO3 = JOB_PLAYTIME_TIER_1, PAY_SHORT_MO4 = JOB_PLAYTIME_TIER_3)
@@ -96,7 +96,7 @@
 /datum/equipment_preset/fax_responder/uscm/provost
 	name = "Fax Responder - USCM Provost"
 	assignment = JOB_FAX_RESPONDER_USCM_PVST
-	rank = JOB_FAX_RESPONDER_USCM_PVST
+	job_title = JOB_FAX_RESPONDER_USCM_PVST
 	faction_group = list(FACTION_FAX, FACTION_MARINE)
 	idtype = /obj/item/card/id/provost
 
@@ -120,7 +120,7 @@
 /datum/equipment_preset/fax_responder/wey_yu
 	name = "Fax Responder - WY"
 	assignment = JOB_FAX_RESPONDER_WY
-	rank = JOB_FAX_RESPONDER_WY
+	job_title = JOB_FAX_RESPONDER_WY
 	faction_group = list(FACTION_FAX, FACTION_MARINE, FACTION_WY, FACTION_WY_DEATHSQUAD, FACTION_PMC)
 	paygrades = list(PAY_SHORT_WYC5 = JOB_PLAYTIME_TIER_0, PAY_SHORT_WYC6 = JOB_PLAYTIME_TIER_1, PAY_SHORT_WYC7 = JOB_PLAYTIME_TIER_3)
 	access = list(ACCESS_MARINE_COMMAND, ACCESS_WY_COLONIAL, ACCESS_WY_EXEC, ACCESS_WY_GENERAL, ACCESS_WY_LEADERSHIP)
@@ -142,7 +142,7 @@
 /datum/equipment_preset/fax_responder/upp
 	name = "Fax Responder - UPP"
 	assignment = JOB_FAX_RESPONDER_UPP
-	rank = JOB_FAX_RESPONDER_UPP
+	job_title = JOB_FAX_RESPONDER_UPP
 	faction_group = list(FACTION_FAX, FACTION_UPP)
 	paygrades = list(PAY_SHORT_UO2 = JOB_PLAYTIME_TIER_0, PAY_SHORT_UO3 = JOB_PLAYTIME_TIER_1, PAY_SHORT_UO4 = JOB_PLAYTIME_TIER_3)
 	headset_type = /obj/item/device/radio/headset/distress/UPP/kdo/command
@@ -174,7 +174,7 @@
 /datum/equipment_preset/fax_responder/twe
 	name = "Fax Responder - TWE"
 	assignment = JOB_FAX_RESPONDER_TWE
-	rank = JOB_FAX_RESPONDER_TWE
+	job_title = JOB_FAX_RESPONDER_TWE
 	faction_group = list(FACTION_FAX, FACTION_MARINE, FACTION_TWE)
 	headset_type = /obj/item/device/radio/headset/distress/royal_marine
 	idtype = /obj/item/card/id/gold
@@ -197,7 +197,7 @@
 /datum/equipment_preset/fax_responder/clf
 	name = "Fax Responder - CLF"
 	assignment = JOB_FAX_RESPONDER_CLF
-	rank = JOB_FAX_RESPONDER_CLF
+	job_title = JOB_FAX_RESPONDER_CLF
 	faction_group = list(FACTION_FAX, FACTION_CLF)
 	headset_type = /obj/item/device/radio/headset/distress/CLF/command
 	paygrades = list(PAY_SHORT_REBC = JOB_PLAYTIME_TIER_0)
@@ -223,7 +223,7 @@
 /datum/equipment_preset/fax_responder/cmb
 	name = "Fax Responder - CMB"
 	assignment = JOB_FAX_RESPONDER_CMB
-	rank = JOB_FAX_RESPONDER_CMB
+	job_title = JOB_FAX_RESPONDER_CMB
 	faction_group = list(FACTION_FAX, FACTION_MARINE, FACTION_MARSHAL)
 	headset_type = /obj/item/device/radio/headset/distress/CMB
 	idtype = /obj/item/card/id/marshal
@@ -253,7 +253,7 @@
 /datum/equipment_preset/fax_responder/press
 	name = "Fax Responder - Press"
 	assignment = JOB_FAX_RESPONDER_PRESS
-	rank = JOB_FAX_RESPONDER_PRESS
+	job_title = JOB_FAX_RESPONDER_PRESS
 	faction_group = list(FACTION_FAX, FACTION_MARINE, FACTION_COLONIST)
 	headset_type = /obj/item/device/radio/headset/almayer/reporter
 	idtype = /obj/item/card/id/silver/cl

--- a/code/modules/gear_presets/fun.dm
+++ b/code/modules/gear_presets/fun.dm
@@ -81,7 +81,7 @@
 	// Cooperate!
 	idtype = /obj/item/card/id/gold
 	assignment = "Shrapnelsworn"
-	rank = "Brother of the Order"
+	job_title = "Brother of the Order"
 	paygrades = list("Ser" = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "OHEFA"
 
@@ -294,7 +294,7 @@
 	paygrades = list(PAY_SHORT_UE6 = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/everything
 	assignment = "UPP Armsmaster"
-	rank = "UPP Armsmaster"
+	job_title = "UPP Armsmaster"
 	role_comm_title = null
 
 /datum/equipment_preset/upp/ivan/load_name(mob/living/carbon/human/new_human, randomise)
@@ -346,7 +346,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 	skills = /datum/skills/everything
 	assignment = "Huntsman"
-	rank = "Huntsman"
+	job_title = "Huntsman"
 	idtype = /obj/item/card/id/gold
 
 /datum/equipment_preset/fun/van_bandolier/New()
@@ -423,7 +423,7 @@
 	skills = /datum/skills/pfc/crafty // about equivalent to a marine
 
 	assignment = "Monkey"
-	rank = "Monkey"
+	job_title = "Monkey"
 	idtype = /obj/item/card/id/dogtag
 
 /datum/equipment_preset/fun/monkey/load_race(mob/living/carbon/human/new_human, client/mob_client)
@@ -442,7 +442,7 @@
 	name = "Fun - Monkey Marine"
 
 	assignment = "Monkey Marine"
-	rank = "Monkey Marine"
+	job_title = "Monkey Marine"
 	paygrades = list(PAY_SHORT_ME2 = JOB_PLAYTIME_TIER_0)
 
 /datum/equipment_preset/fun/monkey/marine/load_gear(mob/living/carbon/human/new_human)
@@ -459,7 +459,7 @@
 	name = "Fun - Monkey Soldier"
 
 	assignment = "Monkey Soldier"
-	rank = "Monkey Soldier"
+	job_title = "Monkey Soldier"
 	paygrades = list(PAY_SHORT_UE1 = JOB_PLAYTIME_TIER_0)
 
 /datum/equipment_preset/fun/monkey/soldier/get_random_name(mob/living/carbon/human/new_human)

--- a/code/modules/gear_presets/other.dm
+++ b/code/modules/gear_presets/other.dm
@@ -9,7 +9,7 @@
 	name = "Freelancer"
 
 	assignment = "Freelancer"
-	rank = FACTION_FREELANCER
+	job_title = FACTION_FREELANCER
 	idtype = /obj/item/card/id/data
 	faction = FACTION_FREELANCER
 
@@ -272,7 +272,7 @@
 	name = "Elite Mercenary"
 
 	assignment = "Elite Mercenary"
-	rank = "Mercenary"
+	job_title = "Mercenary"
 	idtype = /obj/item/card/id/centcom
 	faction = FACTION_MERCENARY
 
@@ -305,7 +305,7 @@
 
 	idtype = /obj/item/card/id/centcom
 	assignment = "Mercenary Miner"
-	rank = "Mercenary"
+	job_title = "Mercenary"
 	skills = /datum/skills/mercenary/elite
 	faction = FACTION_MERCENARY
 
@@ -342,7 +342,7 @@
 
 	idtype = /obj/item/card/id/centcom
 	assignment = "Mercenary Heavy"
-	rank = "Mercenary"
+	job_title = "Mercenary"
 	skills = /datum/skills/mercenary/elite/heavy
 	faction = FACTION_MERCENARY
 
@@ -382,7 +382,7 @@
 
 	idtype = /obj/item/card/id/data
 	assignment = "Mercenary Engineer"
-	rank = "Mercenary"
+	job_title = "Mercenary"
 	skills = /datum/skills/mercenary/elite/engineer
 	faction = FACTION_MERCENARY
 
@@ -436,7 +436,7 @@
 
 	idtype = /obj/item/card/id/centcom
 	assignment = "Mercenary Medic"
-	rank = "Mercenary"
+	job_title = "Mercenary"
 	skills = /datum/skills/mercenary/elite/medic
 	faction = FACTION_MERCENARY
 
@@ -482,7 +482,7 @@
 
 	idtype = /obj/item/card/id/centcom
 	assignment = "Mercenary Warlord"
-	rank = "Mercenary"
+	job_title = "Mercenary"
 	skills = /datum/skills/mercenary/elite/leader
 	faction = FACTION_MERCENARY
 
@@ -520,7 +520,7 @@
 	languages = list(LANGUAGE_ENGLISH, LANGUAGE_RUSSIAN, LANGUAGE_JAPANESE, LANGUAGE_CHINESE) //Just in case they are delivering to UPP or CLF...
 	idtype = /obj/item/card/id/pizza
 	assignment = "Pizza Deliverer"
-	rank = FACTION_PIZZA
+	job_title = FACTION_PIZZA
 	skills = /datum/skills/civilian
 	paygrades = list(PAY_SHORT_CIV = JOB_PLAYTIME_TIER_0)
 	faction = FACTION_PIZZA
@@ -568,7 +568,7 @@
 	languages = list(LANGUAGE_ENGLISH, LANGUAGE_RUSSIAN, LANGUAGE_JAPANESE, LANGUAGE_CHINESE) //Just in case they are delivering to UPP or CLF...
 	idtype = /obj/item/card/id/souto
 	assignment = FACTION_SOUTO
-	rank = "Souto Man"
+	job_title = "Souto Man"
 	skills = /datum/skills/souto
 	faction = FACTION_SOUTO
 
@@ -604,7 +604,7 @@
 /datum/equipment_preset/other/zombie
 	name = "Zombie"
 	flags = EQUIPMENT_PRESET_EXTRA
-	rank = FACTION_ZOMBIE
+	job_title = FACTION_ZOMBIE
 	languages = list("Zombie")
 	skills = null //no restrictions
 	faction = FACTION_ZOMBIE
@@ -659,7 +659,7 @@
 	skills = /datum/skills/gladiator
 
 	assignment = "Bestiarius"
-	rank = FACTION_GLADIATOR
+	job_title = FACTION_GLADIATOR
 	faction = FACTION_GLADIATOR
 
 /datum/equipment_preset/other/gladiator/load_name(mob/living/carbon/human/new_human, randomise)
@@ -694,7 +694,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 	skills = /datum/skills/gladiator/champion
 	assignment = "Samnite"
-	rank = "Samnite"
+	job_title = "Samnite"
 
 /datum/equipment_preset/other/gladiator/champion/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/UPP, WEAR_L_EAR)
@@ -720,7 +720,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 	skills = /datum/skills/gladiator/champion/leader
 	assignment = "Spartacus"
-	rank = "Spartacus"
+	job_title = "Spartacus"
 
 /datum/equipment_preset/other/gladiator/leader/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/UPP, WEAR_L_EAR)
@@ -751,7 +751,7 @@
 	languages = list(LANGUAGE_XENOMORPH, LANGUAGE_ENGLISH)
 
 	assignment = "Cultist"
-	rank = "Cultist"
+	job_title = "Cultist"
 
 	minimap_icon = "cultist"
 	minimap_background = "background_cultist"
@@ -815,7 +815,7 @@
 	skills = /datum/skills/cultist_leader
 
 	assignment = "Cultist Leader"
-	rank = "Cultist Leader"
+	job_title = "Cultist Leader"
 
 	minimap_icon = "cult_leader"
 
@@ -839,7 +839,7 @@
 	name = "DUMMY"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = "DUMMY"
-	rank = "DUMMY"
+	job_title = "DUMMY"
 	paygrades = list(PAY_SHORT_CCMO)
 	idtype = /obj/item/card/id/dogtag
 	uses_special_name = TRUE
@@ -873,7 +873,7 @@
 
 	idtype = /obj/item/card/id/dogtag
 	assignment = JOB_TANK_CREW
-	rank = JOB_TANK_CREW
+	job_title = JOB_TANK_CREW
 	paygrades = list(PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "CRMN"
 	minimum_age = 30
@@ -913,7 +913,7 @@
 
 	idtype = /obj/item/card/id/dogtag
 	assignment = "Crewman Trainee"
-	rank = "Crewman Trainee"
+	job_title = "Crewman Trainee"
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "CRTR"
 	minimum_age = 25
@@ -967,7 +967,7 @@
 	name = "Tutorial Rifleman"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_SQUAD_MARINE
-	rank = JOB_SQUAD_MARINE
+	job_title = JOB_SQUAD_MARINE
 	paygrades = list(PAY_SHORT_ME1 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "RFN"
 	skills = /datum/skills/pfc/crafty

--- a/code/modules/gear_presets/pmc.dm
+++ b/code/modules/gear_presets/pmc.dm
@@ -2,7 +2,7 @@
 /datum/equipment_preset/pmc
 	name = "PMC"
 	faction = FACTION_PMC
-	rank = FACTION_PMC
+	job_title = FACTION_PMC
 	idtype = /obj/item/card/id/pmc
 	faction = FACTION_PMC
 	faction_group = FACTION_LIST_WY
@@ -62,7 +62,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_PMC_STANDARD
-	rank = JOB_PMC_STANDARD
+	job_title = JOB_PMC_STANDARD
 	minimap_icon = "pmc_gun"
 	paygrades = list(PAY_SHORT_PMC_OP = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/pmc
@@ -244,7 +244,7 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_PMC_DETAINER
-	rank = JOB_PMC_DETAINER
+	job_title = JOB_PMC_DETAINER
 	minimap_icon = "pmc_mp"
 	paygrades = list(PAY_SHORT_PMC_EN = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/pmc
@@ -378,7 +378,7 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_PMC_CROWD_CONTROL
-	rank = JOB_PMC_CROWD_CONTROL
+	job_title = JOB_PMC_CROWD_CONTROL
 	minimap_icon = "pmc_riot"
 	paygrades = list(PAY_SHORT_PMC_EN = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/pmc
@@ -436,7 +436,7 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_PMC_MEDIC
-	rank = JOB_PMC_MEDIC
+	job_title = JOB_PMC_MEDIC
 	minimap_icon = "pmc_md"
 	paygrades = list(PAY_SHORT_PMC_MS = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "CM"
@@ -625,7 +625,7 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_PMC_INVESTIGATOR
-	rank = JOB_PMC_INVESTIGATOR
+	job_title = JOB_PMC_INVESTIGATOR
 	minimap_icon = "pmc_mi"
 	paygrades = list(PAY_SHORT_PMC_MS = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/pmc/medic/chem
@@ -816,7 +816,7 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_PMC_LEADER
-	rank = JOB_PMC_LEADER
+	job_title = JOB_PMC_LEADER
 	paygrades = list(PAY_SHORT_PMC_TL = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "SL"
 
@@ -976,7 +976,7 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_PMC_LEAD_INVEST
-	rank = JOB_PMC_LEAD_INVEST
+	job_title = JOB_PMC_LEAD_INVEST
 	paygrades = list(PAY_SHORT_PMC_TL = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "SL"
 	minimap_icon = "cia_lo"
@@ -1123,7 +1123,7 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_PMC_GUNNER
-	rank = JOB_PMC_GUNNER
+	job_title = JOB_PMC_GUNNER
 	paygrades = list(PAY_SHORT_PMC_SS = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "SG"
 
@@ -1234,7 +1234,7 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_PMC_SNIPER
-	rank = JOB_PMC_SNIPER
+	job_title = JOB_PMC_SNIPER
 	paygrades = list(PAY_SHORT_PMC_WS = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "Spc"
 	minimap_icon = "pmc_spec"
@@ -1358,7 +1358,7 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_PMC_CREWMAN
-	rank = JOB_PMC_CREWMAN
+	job_title = JOB_PMC_CREWMAN
 	minimap_icon = "pmc_vc"
 	paygrades = list(PAY_SHORT_PMC_VS = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/pmc/tank_crew
@@ -1493,7 +1493,7 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_PMC_DOCTOR
-	rank = JOB_PMC_DOCTOR
+	job_title = JOB_PMC_DOCTOR
 	paygrades = list(PAY_SHORT_PMC_DOC = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "SGN"
 
@@ -1673,7 +1673,7 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_PMC_ENGINEER
-	rank = JOB_PMC_ENGINEER
+	job_title = JOB_PMC_ENGINEER
 	paygrades = list(PAY_SHORT_PMC_TEC = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "TEC"
 
@@ -1836,7 +1836,7 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	languages = ALL_HUMAN_LANGUAGES
 
 	assignment = JOB_PMC_DIRECTOR
-	rank = JOB_PMC_DIRECTOR
+	job_title = JOB_PMC_DIRECTOR
 	paygrades = list(PAY_SHORT_PMC_DIR = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "DIR"
 	skills = /datum/skills/pmc/director
@@ -1879,7 +1879,7 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	skills = /datum/skills/synthetic
 	idtype = /obj/item/card/id/pmc
 	assignment = JOB_PMC_SYNTH
-	rank = JOB_PMC_SYNTH
+	job_title = JOB_PMC_SYNTH
 	minimap_icon = "pmc_syn"
 	paygrades = list(PAY_SHORT_SYN = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "WY Syn"

--- a/code/modules/gear_presets/royal_marines.dm
+++ b/code/modules/gear_presets/royal_marines.dm
@@ -49,7 +49,7 @@
 /datum/equipment_preset/twe/royal_marine
 	name = "Royal Marines Commando"
 	assignment = "Royal Marine"
-	rank = JOB_TWE_RMC_RIFLEMAN
+	job_title = JOB_TWE_RMC_RIFLEMAN
 	var/human_versus_human = FALSE
 	///Gives the Royal Marines their radios
 	var/headset_type = /obj/item/device/radio/headset/distress/royal_marine
@@ -63,7 +63,7 @@
 	role_comm_title = "RMC"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = "Royal Marines Rifleman"
-	rank = JOB_TWE_RMC_RIFLEMAN
+	job_title = JOB_TWE_RMC_RIFLEMAN
 
 	minimap_icon = "rmc_rifleman"
 
@@ -124,7 +124,7 @@
 /datum/equipment_preset/twe/royal_marine/spec/marksman
 	name = "TWE Royal Marine Commando (Marksman)"
 	assignment = "Royal Marines Marksman"
-	rank = JOB_TWE_RMC_MARKSMAN
+	job_title = JOB_TWE_RMC_MARKSMAN
 	minimap_icon = "rmc_marksman"
 
 /datum/equipment_preset/twe/royal_marine/spec/marksman/load_gear(mob/living/carbon/human/new_human)
@@ -169,7 +169,7 @@
 	name = "TWE Royal Marine Commando (Breacher)"
 	role_comm_title = "RMC BRC"
 	assignment = "Royal Marines Breacher"
-	rank = JOB_TWE_RMC_BREACHER
+	job_title = JOB_TWE_RMC_BREACHER
 	minimap_icon = "rmc_breacher"
 
 	skills = /datum/skills/rmc/breacher
@@ -219,7 +219,7 @@
 	name = "TWE Royal Marine Commando (Smartgunner)"
 	role_comm_title = "RMC SG"
 	assignment = "Royal Marines Smartgunner"
-	rank = JOB_TWE_RMC_SMARTGUNNER
+	job_title = JOB_TWE_RMC_SMARTGUNNER
 
 	minimap_icon = "rmc_sg"
 
@@ -270,7 +270,7 @@
 	role_comm_title = "RMC MED"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = "Royal Marines Medical Technician"
-	rank = JOB_TWE_RMC_MEDIC
+	job_title = JOB_TWE_RMC_MEDIC
 
 	minimap_icon = "rmc_medic"
 
@@ -319,7 +319,7 @@
 	role_comm_title = "RMC TL"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = "Royal Marines Team Leader"
-	rank = JOB_TWE_RMC_TEAMLEADER
+	job_title = JOB_TWE_RMC_TEAMLEADER
 
 	minimap_icon = "rmc_teamleader"
 
@@ -372,7 +372,7 @@
 	role_comm_title = "RMC LT"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = "Royal Marines Team Commander"
-	rank = JOB_TWE_RMC_LIEUTENANT
+	job_title = JOB_TWE_RMC_LIEUTENANT
 
 	minimap_icon = "rmc_lieutenant"
 
@@ -441,7 +441,7 @@
 	role_comm_title = "RMC CPT"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = "Royal Marines Captain"
-	rank = JOB_TWE_RMC_CAPTAIN
+	job_title = JOB_TWE_RMC_CAPTAIN
 
 	minimap_icon = "rmc_commander"
 
@@ -510,7 +510,7 @@
 	role_comm_title = "RMC MJR"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = "Royal Marines Major"
-	rank = JOB_TWE_RMC_MAJOR
+	job_title = JOB_TWE_RMC_MAJOR
 
 	minimap_icon = "rmc_major"
 

--- a/code/modules/gear_presets/survivors/corsat/preset_corsat.dm
+++ b/code/modules/gear_presets/survivors/corsat/preset_corsat.dm
@@ -1,7 +1,7 @@
 /datum/equipment_preset/survivor/security/corsat
 	name = "Survivor - CORSAT Security Guard"
 	assignment = JOB_WY_SEC
-	rank = JOB_WY_SEC
+	job_title = JOB_WY_SEC
 	minimap_background = "background_goon"
 	minimap_icon = "cmp"
 	idtype = /obj/item/card/id/silver/cl

--- a/code/modules/gear_presets/survivors/fiorina_sciannex/preset_fiorina_sciannex.dm
+++ b/code/modules/gear_presets/survivors/fiorina_sciannex/preset_fiorina_sciannex.dm
@@ -29,7 +29,7 @@
 /datum/equipment_preset/survivor/security/fiorina
 	name = "Survivor - Fiorina Prison Guard"
 	assignment = JOB_WY_SEC
-	rank = JOB_WY_SEC
+	job_title = JOB_WY_SEC
 	minimap_background = "background_goon"
 	minimap_icon = "cmp"
 	idtype = /obj/item/card/id/silver/cl
@@ -53,7 +53,7 @@
 	assignment = "United Americas Riot Officer"
 	paygrades = list(PAY_SHORT_CPO = JOB_PLAYTIME_TIER_0)
 	idtype = /obj/item/card/id/silver
-	rank = JOB_SURVIVOR
+	job_title = JOB_SURVIVOR
 	role_comm_title = "UA RO"
 	faction = FACTION_SURVIVOR
 	minimap_icon = "mp"

--- a/code/modules/gear_presets/survivors/fiorina_sciannex/riot_in_progress_insert_fiorina_nightmare.dm
+++ b/code/modules/gear_presets/survivors/fiorina_sciannex/riot_in_progress_insert_fiorina_nightmare.dm
@@ -22,7 +22,7 @@
 	faction_group = list(FACTION_MARSHAL, FACTION_MARINE, FACTION_SURVIVOR)
 	assignment = "CMB Riot Control Officer"
 	idtype = /obj/item/card/id/deputy/riot
-	rank = JOB_CMB_RIOT
+	job_title = JOB_CMB_RIOT
 	skills = /datum/skills/cmb
 	minimap_icon = "deputy"
 
@@ -95,7 +95,7 @@
 	faction_group = list(FACTION_MARSHAL, FACTION_MARINE, FACTION_SURVIVOR)
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = "CMB Riot Control Synthetic"
-	rank = JOB_CMB_RSYN
+	job_title = JOB_CMB_RSYN
 	languages = ALL_SYNTH_LANGUAGES
 	idtype = /obj/item/card/id/deputy/riot
 	skills = /datum/skills/synthetic/cmb

--- a/code/modules/gear_presets/survivors/kutjevo/preset_kutjevo.dm
+++ b/code/modules/gear_presets/survivors/kutjevo/preset_kutjevo.dm
@@ -158,7 +158,7 @@
 	idtype = /obj/item/card/id/silver/cl
 	role_comm_title = "WY Syn"
 	assignment = JOB_WY_GOON_SYNTH
-	rank = JOB_WY_GOON_SYNTH
+	job_title = JOB_WY_GOON_SYNTH
 	faction = FACTION_WY
 	faction_group = list(FACTION_WY, FACTION_SURVIVOR)
 	minimap_icon = "goon_synth"
@@ -185,7 +185,7 @@
 	idtype = /obj/item/card/id/deputy
 	role_comm_title = "CMB Syn"
 	assignment = JOB_CMB_SYN
-	rank = JOB_CMB_SYN
+	job_title = JOB_CMB_SYN
 	minimap_background = "background_cmb"
 	minimap_icon = "cmb_syn"
 

--- a/code/modules/gear_presets/survivors/lv_522/forcon_survivors.dm
+++ b/code/modules/gear_presets/survivors/lv_522/forcon_survivors.dm
@@ -5,7 +5,7 @@
 	idtype = /obj/item/card/id/dogtag
 	role_comm_title = "FORECON"
 	minimap_background = "background_forecon"
-	rank = JOB_SURVIVOR
+	job_title = JOB_SURVIVOR
 	faction_group = list(FACTION_MARINE, FACTION_SURVIVOR)
 	flags = EQUIPMENT_PRESET_START_OF_ROUND
 	access = list(

--- a/code/modules/gear_presets/survivors/lv_624/clfship_insert_lv624.dm
+++ b/code/modules/gear_presets/survivors/lv_624/clfship_insert_lv624.dm
@@ -8,7 +8,7 @@
 	skills = /datum/skills/civilian/survivor/clf
 	languages = list(LANGUAGE_ENGLISH, LANGUAGE_JAPANESE)
 	assignment = JOB_CLF
-	rank = JOB_CLF
+	job_title = JOB_CLF
 	role_comm_title = "GRL"
 	faction = FACTION_CLF
 	faction_group = list(FACTION_CLF, FACTION_SURVIVOR)
@@ -41,7 +41,7 @@
 	name = "CLF Survivor Leader"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_CLF_LEADER
-	rank = JOB_CLF_LEADER
+	job_title = JOB_CLF_LEADER
 	role_comm_title = "LDR"
 	skills = /datum/skills/civilian/survivor/clf/leader
 	minimap_icon = "clf_sl"
@@ -84,7 +84,7 @@
 	name = "CLF Survivor Medic"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_CLF_MEDIC
-	rank = JOB_CLF_MEDIC
+	job_title = JOB_CLF_MEDIC
 	role_comm_title = "MED"
 	minimap_icon = "clf_med"
 	paygrades = list(PAY_SHORT_CDOC = JOB_PLAYTIME_TIER_0)
@@ -132,7 +132,7 @@
 	name = "CLF Survivor Engineer"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_CLF_ENGI
-	rank = JOB_CLF_ENGI
+	job_title = JOB_CLF_ENGI
 	role_comm_title = "TECH"
 
 	minimap_icon = "clf_engi"
@@ -184,7 +184,7 @@
 	skills = /datum/skills/colonial_synthetic
 	preset_generation_support = FALSE
 	assignment = JOB_CLF_SYNTH
-	rank = JOB_CLF_SYNTH
+	job_title = JOB_CLF_SYNTH
 	paygrades = list(PAY_SHORT_SYN = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "Syn"
 	minimap_background = "background_clf"

--- a/code/modules/gear_presets/survivors/lv_624/corporate_dome_insert_lv624.dm
+++ b/code/modules/gear_presets/survivors/lv_624/corporate_dome_insert_lv624.dm
@@ -55,7 +55,7 @@
 	name = "Survivor - Corporate Security Goon Medic"
 	flags = EQUIPMENT_PRESET_START_OF_ROUND
 	assignment = JOB_WY_GOON_MEDIC
-	rank = JOB_WY_GOON_MEDIC
+	job_title = JOB_WY_GOON_MEDIC
 	skills = /datum/skills/civilian/survivor/goon/medic
 	access = list(ACCESS_CIVILIAN_PUBLIC, ACCESS_CIVILIAN_COMMAND, ACCESS_CIVILIAN_MEDBAY, ACCESS_CIVILIAN_BRIG, ACCESS_WY_COLONIAL, ACCESS_WY_MEDICAL)
 	minimap_icon = "goon_med"
@@ -92,7 +92,7 @@
 	name = "Survivor - Corporate Security Goon Technician"
 	flags = EQUIPMENT_PRESET_START_OF_ROUND
 	assignment = JOB_WY_GOON_TECH
-	rank = JOB_WY_GOON_TECH
+	job_title = JOB_WY_GOON_TECH
 	skills = /datum/skills/civilian/survivor/goon/tech
 	access = list(ACCESS_CIVILIAN_PUBLIC, ACCESS_CIVILIAN_COMMAND, ACCESS_CIVILIAN_ENGINEERING, ACCESS_CIVILIAN_BRIG, ACCESS_WY_COLONIAL, ACCESS_WY_ENGINEERING)
 	minimap_icon = "goon_engi"
@@ -125,7 +125,7 @@
 	name = "Survivor - Corporate Security Goon Lead"
 	flags = EQUIPMENT_PRESET_START_OF_ROUND
 	assignment = JOB_WY_GOON_LEAD
-	rank = JOB_WY_GOON_LEAD
+	job_title = JOB_WY_GOON_LEAD
 	paygrades = list(PAY_SHORT_CSPO = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/civilian/survivor/goon/lead
 	access = list(ACCESS_CIVILIAN_PUBLIC, ACCESS_CIVILIAN_COMMAND, ACCESS_CIVILIAN_MEDBAY, ACCESS_CIVILIAN_ENGINEERING, ACCESS_CIVILIAN_BRIG, ACCESS_WY_COLONIAL, ACCESS_WY_MEDICAL, ACCESS_WY_ENGINEERING)
@@ -159,7 +159,7 @@
 	name = "Survivor - Synthetic - Corporate Security Goon Synthetic"
 	idtype = /obj/item/card/id/silver/cl
 	assignment = JOB_WY_GOON_SYNTH
-	rank = JOB_WY_GOON_SYNTH
+	job_title = JOB_WY_GOON_SYNTH
 	minimap_icon = "goon_synth"
 	role_comm_title = "WY Syn"
 	equipment_to_spawn = list(

--- a/code/modules/gear_presets/survivors/lv_624/preset_lv.dm
+++ b/code/modules/gear_presets/survivors/lv_624/preset_lv.dm
@@ -78,7 +78,7 @@
 /datum/equipment_preset/survivor/security/lv
 	name = "Survivor - LV-624 Security Guard"
 	assignment = JOB_WY_SEC
-	rank = JOB_WY_SEC
+	job_title = JOB_WY_SEC
 	minimap_background = "background_goon"
 	minimap_icon = "cmp"
 	idtype = /obj/item/card/id/silver/cl

--- a/code/modules/gear_presets/survivors/lv_759/preset_hybrisa.dm
+++ b/code/modules/gear_presets/survivors/lv_759/preset_hybrisa.dm
@@ -848,7 +848,7 @@
 	name = "Survivor - Hybrisa - Weyland-Yutani - Corporate Security Guard"
 	assignment = "Weyland-Yutani - Corporate Security Guard"
 	assignment = JOB_WY_GOON
-	rank = JOB_WY_GOON
+	job_title = JOB_WY_GOON
 	minimap_icon = "goon_standard"
 	minimap_background = "background_goon"
 	flags = EQUIPMENT_PRESET_START_OF_ROUND

--- a/code/modules/gear_presets/survivors/misc.dm
+++ b/code/modules/gear_presets/survivors/misc.dm
@@ -180,7 +180,7 @@ Everything below isn't used or out of place.
 	name = "Survivor - Corporate Security Goon"
 	flags = EQUIPMENT_PRESET_START_OF_ROUND
 	assignment = JOB_WY_GOON
-	rank = JOB_WY_GOON
+	job_title = JOB_WY_GOON
 	paygrades = list(PAY_SHORT_CPO = JOB_PLAYTIME_TIER_0)
 	idtype = /obj/item/card/id/silver/cl
 	skills = /datum/skills/civilian/survivor/goon

--- a/code/modules/gear_presets/survivors/shivas_snowball/panic_room_insert_shivas.dm
+++ b/code/modules/gear_presets/survivors/shivas_snowball/panic_room_insert_shivas.dm
@@ -9,7 +9,7 @@
 	assignment = "Assistant Operations Manager"
 	minimap_background = "background_wy_management"
 	minimap_icon = "ass_man"
-	rank = JOB_ASSISTANT_MANAGER
+	job_title = JOB_ASSISTANT_MANAGER
 	idtype = /obj/item/card/id/silver/clearance_badge/manager
 	faction_group = list(FACTION_WY, FACTION_SURVIVOR)
 	access = list(
@@ -49,7 +49,7 @@
 	name = "Survivor - Weyland-Yutani Commando (Shivas)"
 	flags = EQUIPMENT_PRESET_START_OF_ROUND
 	assignment = JOB_WY_COMMANDO_STANDARD
-	rank = JOB_WY_COMMANDO_STANDARD
+	job_title = JOB_WY_COMMANDO_STANDARD
 	faction = FACTION_PMC
 	faction_group = list(FACTION_WY, FACTION_SURVIVOR, FACTION_PMC)
 	paygrades = list(PAY_SHORT_WY_COM = JOB_PLAYTIME_TIER_0)

--- a/code/modules/gear_presets/survivors/solaris/crashlanding-offices_insert_bigred.dm
+++ b/code/modules/gear_presets/survivors/solaris/crashlanding-offices_insert_bigred.dm
@@ -5,7 +5,7 @@
 	name = "Survivor - PMC"
 	flags = EQUIPMENT_PRESET_START_OF_ROUND
 	assignment = JOB_PMC_STANDARD
-	rank = JOB_PMC_STANDARD
+	job_title = JOB_PMC_STANDARD
 	faction = FACTION_PMC
 	faction_group = list(FACTION_WY, FACTION_SURVIVOR, FACTION_PMC)
 	paygrades = list(PAY_SHORT_PMC_OP = JOB_PLAYTIME_TIER_0)
@@ -82,7 +82,7 @@
 /datum/equipment_preset/survivor/pmc/medic
 	name = "Survivor - PMC Medic"
 	assignment = JOB_PMC_MEDIC
-	rank = JOB_PMC_MEDIC
+	job_title = JOB_PMC_MEDIC
 	paygrades = list(PAY_SHORT_PMC_MS = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "CM"
 	skills = /datum/skills/civilian/survivor/pmc/medic
@@ -128,7 +128,7 @@
 /datum/equipment_preset/survivor/pmc/engineer
 	name = "Survivor - PMC Engineer"
 	assignment = JOB_PMC_ENGINEER
-	rank = JOB_PMC_ENGINEER
+	job_title = JOB_PMC_ENGINEER
 	paygrades = list(PAY_SHORT_PMC_TEC = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "TEC"
 	skills = /datum/skills/civilian/survivor/pmc/engineer
@@ -168,7 +168,7 @@
 /datum/equipment_preset/survivor/pmc/pmc_leader
 	name = "Survivor - PMC Leader"
 	assignment = JOB_PMC_LEADER
-	rank = JOB_PMC_LEADER
+	job_title = JOB_PMC_LEADER
 	paygrades = list(PAY_SHORT_PMC_TL = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "SL"
 	skills = /datum/skills/civilian/survivor/pmc/lead
@@ -211,7 +211,7 @@
 	paygrades = list(PAY_SHORT_WYC6 = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/civilian/survivor/manager
 	assignment = "Colony Supervisor"
-	rank = JOB_EXECUTIVE_SUPERVISOR
+	job_title = JOB_EXECUTIVE_SUPERVISOR
 	minimap_icon = "exec_super"
 	role_comm_title = "Supervisor"
 	idtype = /obj/item/card/id/silver/clearance_badge/manager
@@ -279,7 +279,7 @@
 	skills = /datum/skills/synthetic
 	idtype = /obj/item/card/id/pmc
 	assignment = JOB_PMC_SYNTH
-	rank = JOB_PMC_SYNTH
+	job_title = JOB_PMC_SYNTH
 	paygrades = list(PAY_SHORT_SYN = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "WY Syn"
 	skills = /datum/skills/synthetic

--- a/code/modules/gear_presets/survivors/survivors.dm
+++ b/code/modules/gear_presets/survivors/survivors.dm
@@ -1,7 +1,7 @@
 /datum/equipment_preset/survivor
 	name = JOB_SURVIVOR
 	assignment = JOB_SURVIVOR
-	rank = JOB_SURVIVOR
+	job_title = JOB_SURVIVOR
 
 	skills = /datum/skills/civilian/survivor
 	languages = list(LANGUAGE_ENGLISH)
@@ -194,7 +194,7 @@ Standart Survivors :	/datum/equipment_preset/survivor/scientist,
 	minimap_background = "background_cmb"
 	flags = EQUIPMENT_PRESET_START_OF_ROUND
 	idtype = /obj/item/card/id/deputy
-	rank = JOB_CMB
+	job_title = JOB_CMB
 	faction = FACTION_MARSHAL
 	faction_group = list(FACTION_MARSHAL, FACTION_MARINE, FACTION_SURVIVOR)
 	role_comm_title = "CMB DEP"
@@ -299,7 +299,7 @@ Everything bellow is a parent used as a base for one or multiple maps.
 	flags = EQUIPMENT_PRESET_START_OF_ROUND
 	paygrades = list(PAY_SHORT_WYC2 = JOB_PLAYTIME_TIER_0, PAY_SHORT_WYC3 = JOB_PLAYTIME_TIER_2, PAY_SHORT_WYC4 = JOB_PLAYTIME_TIER_3, PAY_SHORT_WYC5 = JOB_PLAYTIME_TIER_4)
 	faction_group = FACTION_LIST_SURVIVOR_WY
-	rank = JOB_EXECUTIVE
+	job_title = JOB_EXECUTIVE
 	faction = FACTION_WY
 	faction_group = list(FACTION_WY, FACTION_SURVIVOR)
 	idtype = /obj/item/card/id/silver/clearance_badge/cl

--- a/code/modules/gear_presets/survivors/trijent/crashlanding_upp_bar_insert_trijent.dm
+++ b/code/modules/gear_presets/survivors/trijent/crashlanding_upp_bar_insert_trijent.dm
@@ -4,7 +4,7 @@
 	name = "Survivor - UPP"
 	paygrades = list(PAY_SHORT_UE1 = JOB_PLAYTIME_TIER_0)
 	origin_override = ORIGIN_UPP
-	rank = JOB_SURVIVOR
+	job_title = JOB_SURVIVOR
 	skills = /datum/skills/military/survivor/upp_private
 	languages = list(LANGUAGE_RUSSIAN, LANGUAGE_GERMAN, LANGUAGE_CHINESE)
 	faction = FACTION_UPP
@@ -44,7 +44,7 @@
 	name = "Survivor - UPP Soldier"
 	paygrades = list(PAY_SHORT_UE1 = JOB_PLAYTIME_TIER_0, PAY_SHORT_UE2 = JOB_PLAYTIME_TIER_1)
 	assignment = JOB_UPP
-	rank = JOB_UPP
+	job_title = JOB_UPP
 	skills = /datum/skills/military/survivor/upp_private
 
 /datum/equipment_preset/survivor/upp/soldier/load_gear(mob/living/carbon/human/new_human)
@@ -70,7 +70,7 @@
 	name = "Survivor - UPP Sapper"
 	paygrades = list(PAY_SHORT_UE3 = JOB_PLAYTIME_TIER_0)
 	assignment = JOB_UPP_ENGI
-	rank = JOB_UPP_ENGI
+	job_title = JOB_UPP_ENGI
 
 	minimap_icon = "upp_sapper"
 
@@ -101,7 +101,7 @@
 	name = "Survivor - UPP Medic"
 	paygrades = list(PAY_SHORT_UE3 = JOB_PLAYTIME_TIER_0)
 	assignment = JOB_UPP_MEDIC
-	rank = JOB_UPP_MEDIC
+	job_title = JOB_UPP_MEDIC
 
 	minimap_icon = "upp_med"
 
@@ -133,7 +133,7 @@
 /datum/equipment_preset/survivor/upp/specialist
 	name = "Survivor - UPP Specialist"
 	assignment = JOB_UPP_SPECIALIST
-	rank = JOB_UPP_SPECIALIST
+	job_title = JOB_UPP_SPECIALIST
 	minimap_icon = "upp_spec"
 	paygrades = list(PAY_SHORT_UE4 = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/military/survivor/upp_spec
@@ -156,7 +156,7 @@
 	name = "Survivor - UPP Squad Leader"
 	paygrades = list(PAY_SHORT_UE5 = JOB_PLAYTIME_TIER_0)
 	assignment = JOB_UPP_LEADER
-	rank = JOB_UPP_LEADER
+	job_title = JOB_UPP_LEADER
 	languages = list(LANGUAGE_RUSSIAN, LANGUAGE_ENGLISH,  LANGUAGE_GERMAN,  LANGUAGE_CHINESE)
 	role_comm_title = "173/RECON SL"
 
@@ -181,7 +181,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 	languages = ALL_SYNTH_LANGUAGES_UPP
 	assignment = JOB_UPP_SUPPORT_SYNTH
-	rank = JOB_UPP_SUPPORT_SYNTH
+	job_title = JOB_UPP_SUPPORT_SYNTH
 	faction = FACTION_UPP
 	faction_group = list(FACTION_UPP, FACTION_SURVIVOR)
 	skills = /datum/skills/colonial_synthetic

--- a/code/modules/gear_presets/survivors/trijent/preset_trijent.dm
+++ b/code/modules/gear_presets/survivors/trijent/preset_trijent.dm
@@ -11,7 +11,7 @@
 /datum/equipment_preset/survivor/security/trijent
 	name = "Survivor - Trijent Security Guard"
 	assignment = JOB_WY_SEC
-	rank = JOB_WY_SEC
+	job_title = JOB_WY_SEC
 	minimap_background = "background_goon"
 	minimap_icon = "cmp"
 	faction = FACTION_WY

--- a/code/modules/gear_presets/synth_k9.dm
+++ b/code/modules/gear_presets/synth_k9.dm
@@ -8,7 +8,7 @@
 	faction = FACTION_MARINE
 	idtype = /obj/item/card/id/gold
 	assignment = JOB_SYNTH_K9
-	job_title = "Synthetic K9"
+	job_title = JOB_SYNTH_K9
 	paygrades = list(PAY_SHORT_SYN_K9 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "K9"
 

--- a/code/modules/gear_presets/synth_k9.dm
+++ b/code/modules/gear_presets/synth_k9.dm
@@ -8,7 +8,7 @@
 	faction = FACTION_MARINE
 	idtype = /obj/item/card/id/gold
 	assignment = JOB_SYNTH_K9
-	rank = "Synthetic K9"
+	job_title = "Synthetic K9"
 	paygrades = list(PAY_SHORT_SYN_K9 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "K9"
 

--- a/code/modules/gear_presets/synths.dm
+++ b/code/modules/gear_presets/synths.dm
@@ -53,7 +53,7 @@
 	faction = FACTION_MARINE
 	idtype = /obj/item/card/id/gold
 	assignment = JOB_SYNTH
-	rank = "Synthetic"
+	job_title = "Synthetic"
 	role_comm_title = "Syn"
 	preset_generation_support = TRUE
 
@@ -80,7 +80,7 @@
 	faction = FACTION_MARINE
 	idtype = /obj/item/card/id/gold
 	assignment = JOB_SYNTH
-	rank = "Synthetic"
+	job_title = "Synthetic"
 	role_comm_title = "Syn"
 	paygrades = list(PAY_SHORT_ME9 = JOB_PLAYTIME_TIER_0)
 

--- a/code/modules/gear_presets/synths.dm
+++ b/code/modules/gear_presets/synths.dm
@@ -126,7 +126,7 @@
 	faction_group = list(FACTION_SURVIVOR)
 	idtype = /obj/item/card/id/lanyard
 	assignment = JOB_SYNTH
-	rank = JOB_SYNTH_SURVIVOR
+	job_title = JOB_SYNTH_SURVIVOR
 	skills = /datum/skills/colonial_synthetic
 	preset_generation_support = TRUE
 
@@ -617,7 +617,7 @@
 	idtype = /obj/item/card/id/deputy
 	role_comm_title = "CMB Syn"
 	assignment = JOB_CMB_SYN
-	rank = JOB_CMB_SYN
+	job_title = JOB_CMB_SYN
 	paygrades = list(PAY_SHORT_CMBS = JOB_PLAYTIME_TIER_0)
 	faction = FACTION_MARSHAL
 	faction_group = list(FACTION_MARSHAL, FACTION_MARINE, FACTION_SURVIVOR)
@@ -646,7 +646,7 @@
 /datum/equipment_preset/synth/survivor/wy/security_synth
 	name = "Survivor - Synthetic - W-Y Security Guard Synthetic"
 	assignment = JOB_WY_SEC_SYNTH
-	rank = JOB_WY_SEC_SYNTH
+	job_title = JOB_WY_SEC_SYNTH
 	idtype = /obj/item/card/id/silver/cl
 	role_comm_title = "WY Syn"
 	equipment_to_spawn = list(
@@ -746,7 +746,7 @@
 	faction = FACTION_MARINE
 	faction_group = list(FACTION_MARINE)
 	assignment = JOB_WORKING_JOE
-	rank = JOB_WORKING_JOE
+	job_title = JOB_WORKING_JOE
 
 	minimap_icon = "joe"
 
@@ -837,7 +837,7 @@
 /datum/equipment_preset/synth/working_joe/upp
 	name = "Synthetic - Dzho Automaton"
 	assignment = JOB_UPP_JOE
-	rank = JOB_UPP_JOE
+	job_title = JOB_UPP_JOE
 	joe_type = SYNTH_UPP_JOE
 	idtype = /obj/item/card/id/dogtag
 	minimap_background = "background_upp"
@@ -950,7 +950,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 	faction = FACTION_NEUTRAL
 	assignment = JOB_COLONIST
-	rank = JOB_COLONIST
+	job_title = JOB_COLONIST
 	skills = /datum/skills/infiltrator_synthetic
 	idtype = /obj/item/card/id/lanyard
 	paygrades = list(PAY_SHORT_CIV = JOB_PLAYTIME_TIER_0)

--- a/code/modules/gear_presets/upp.dm
+++ b/code/modules/gear_presets/upp.dm
@@ -98,7 +98,7 @@
 
 	skills = /datum/skills/pfc
 	assignment = JOB_UPP
-	rank = JOB_UPP
+	job_title = JOB_UPP
 	role_comm_title = "Sol"
 	minimap_icon = "upp_pvt"
 	paygrades = list(PAY_SHORT_UE1 = JOB_PLAYTIME_TIER_0, PAY_SHORT_UE2 = JOB_PLAYTIME_TIER_1)
@@ -332,7 +332,7 @@
 
 	skills = /datum/skills/combat_medic
 	assignment = JOB_UPP_MEDIC
-	rank = JOB_UPP_MEDIC
+	job_title = JOB_UPP_MEDIC
 	role_comm_title = "Med"
 	minimap_icon = "upp_med"
 	paygrades = list(PAY_SHORT_UE3 = JOB_PLAYTIME_TIER_0)
@@ -542,7 +542,7 @@
 
 	skills = /datum/skills/combat_engineer
 	assignment = JOB_UPP_ENGI
-	rank = JOB_UPP_ENGI
+	job_title = JOB_UPP_ENGI
 	role_comm_title = "Sap"
 	minimap_icon = "upp_sapper"
 	paygrades = list(PAY_SHORT_UE3 = JOB_PLAYTIME_TIER_0)
@@ -715,7 +715,7 @@
 
 	skills = /datum/skills/upp/specialist
 	assignment = JOB_UPP_SPECIALIST
-	rank = JOB_UPP_SPECIALIST
+	job_title = JOB_UPP_SPECIALIST
 	role_comm_title = "Spc"
 	minimap_icon = "upp_spec"
 	paygrades = list(PAY_SHORT_UE5 = JOB_PLAYTIME_TIER_0)
@@ -860,7 +860,7 @@
 
 	skills = /datum/skills/upp/specialist
 	assignment = JOB_UPP_SPECIALIST
-	rank = JOB_UPP_SPECIALIST
+	job_title = JOB_UPP_SPECIALIST
 	role_comm_title = "Spc"
 	minimap_icon = "upp_spec"
 	paygrades = list(PAY_SHORT_UE5 = JOB_PLAYTIME_TIER_0)
@@ -1016,7 +1016,7 @@
 
 	skills = /datum/skills/SL
 	assignment = JOB_UPP_LEADER
-	rank = JOB_UPP_LEADER
+	job_title = JOB_UPP_LEADER
 	role_comm_title = "SL"
 	minimap_icon = "upp_sl"
 	paygrades = list(PAY_SHORT_UE6 = JOB_PLAYTIME_TIER_0)
@@ -1226,7 +1226,7 @@
 
 	skills = /datum/skills/upp/military_police
 	assignment = JOB_UPP_POLICE
-	rank = JOB_UPP_POLICE
+	job_title = JOB_UPP_POLICE
 	role_comm_title = "MP"
 	minimap_icon = "upp_mp"
 	paygrades = list(PAY_SHORT_UE6 = JOB_PLAYTIME_TIER_0)
@@ -1422,7 +1422,7 @@
 
 	skills = /datum/skills/upp/combat_medic
 	assignment = JOB_UPP_LT_DOKTOR
-	rank = JOB_UPP_LT_DOKTOR
+	job_title = JOB_UPP_LT_DOKTOR
 	role_comm_title = "Lt. Med."
 	paygrades = list(PAY_SHORT_UO1 = JOB_PLAYTIME_TIER_0)
 	access = list(
@@ -1600,7 +1600,7 @@
 
 	skills = /datum/skills/upp/logistics_technician
 	assignment = JOB_UPP_SUPPLY
-	rank = JOB_UPP_SUPPLY
+	job_title = JOB_UPP_SUPPLY
 	role_comm_title = "Log."
 	minimap_icon = "upp_cargo"
 	paygrades = list(PAY_SHORT_UE3 = JOB_PLAYTIME_TIER_0)
@@ -1712,7 +1712,7 @@
 
 	skills = /datum/skills/upp/officer
 	assignment = JOB_UPP_LT_OFFICER
-	rank = JOB_UPP_LT_OFFICER
+	job_title = JOB_UPP_LT_OFFICER
 	role_comm_title = "Lt."
 	minimap_icon = "upp_lt"
 	paygrades = list(PAY_SHORT_UO1 = JOB_PLAYTIME_TIER_0)
@@ -1917,7 +1917,7 @@
 /datum/equipment_preset/upp/officer/senior
 	name = "UPP Starshiy Leytenant (Cryo)"
 	assignment = JOB_UPP_SRLT_OFFICER
-	rank = JOB_UPP_SRLT_OFFICER
+	job_title = JOB_UPP_SRLT_OFFICER
 	role_comm_title = "Sr-Lt."
 	minimap_icon = "upp_slt"
 	paygrades = list(PAY_SHORT_UO2 = JOB_PLAYTIME_TIER_0)
@@ -2093,7 +2093,7 @@
 /datum/equipment_preset/upp/officer/kapitan
 	name = "UPP Kapitan (Cryo)"
 	assignment = JOB_UPP_KPT_OFFICER
-	rank = JOB_UPP_KPT_OFFICER
+	job_title = JOB_UPP_KPT_OFFICER
 	role_comm_title = "May."
 	minimap_icon = "upp_xo"
 	paygrades = list(PAY_SHORT_UO3 = JOB_PLAYTIME_TIER_0)
@@ -2288,7 +2288,7 @@
 /datum/equipment_preset/upp/officer/major
 	name = "UPP Mayjor (Cryo)"
 	assignment = JOB_UPP_MAY_OFFICER
-	rank = JOB_UPP_MAY_OFFICER
+	job_title = JOB_UPP_MAY_OFFICER
 	role_comm_title = "May."
 	minimap_icon = "upp_co"
 	paygrades = list(PAY_SHORT_UO4 = JOB_PLAYTIME_TIER_0)
@@ -2297,7 +2297,7 @@
 /datum/equipment_preset/upp/officer/major/co
 	name = "UPP Mayjor (CO)(Cryo)"
 	assignment = JOB_UPP_CO_OFFICER
-	rank = JOB_UPP_CO_OFFICER
+	job_title = JOB_UPP_CO_OFFICER
 
 /datum/equipment_preset/upp/officer/major/dressed
 	name = "UPP Major"
@@ -2476,7 +2476,7 @@
 /datum/equipment_preset/upp/officer/flag/podpolkovnik
 	name = "UPP Podpolkovnik (Cryo)"
 	assignment = JOB_UPP_LTKOL_OFFICER
-	rank = JOB_UPP_LTKOL_OFFICER
+	job_title = JOB_UPP_LTKOL_OFFICER
 	role_comm_title = "Lt. Kol."
 	minimap_icon = "upp_co"
 	paygrades = list(PAY_SHORT_UO5 = JOB_PLAYTIME_TIER_0)
@@ -2485,12 +2485,12 @@
 /datum/equipment_preset/upp/officer/flag/podpolkovnik/co
 	name = "UPP Podpolkovnik (CO)(Cryo)"
 	assignment = JOB_UPP_CO_OFFICER
-	rank = JOB_UPP_CO_OFFICER
+	job_title = JOB_UPP_CO_OFFICER
 
 /datum/equipment_preset/upp/officer/flag/dressed/podpolkovnik
 	name = "UPP Podpolkovnik"
 	assignment = JOB_UPP_LTKOL_OFFICER
-	rank = JOB_UPP_LTKOL_OFFICER
+	job_title = JOB_UPP_LTKOL_OFFICER
 	role_comm_title = "Lt. Kol."
 	minimap_icon = "upp_co"
 	paygrades = list(PAY_SHORT_UO5 = JOB_PLAYTIME_TIER_0)
@@ -2674,19 +2674,19 @@
 /datum/equipment_preset/upp/officer/flag/polkovnik
 	name = "UPP Polkovnik (Cryo)"
 	assignment = JOB_UPP_KOL_OFFICER
-	rank = JOB_UPP_KOL_OFFICER
+	job_title = JOB_UPP_KOL_OFFICER
 	role_comm_title = "Kol."
 	paygrades = list(PAY_SHORT_UO6 = JOB_PLAYTIME_TIER_0)
 
 /datum/equipment_preset/upp/officer/flag/polkovnik/co
 	name = "UPP Polkovnik (CO)(Cryo)"
 	assignment = JOB_UPP_CO_OFFICER
-	rank = JOB_UPP_CO_OFFICER
+	job_title = JOB_UPP_CO_OFFICER
 
 /datum/equipment_preset/upp/officer/flag/dressed/polkovnik
 	name = "UPP Polkovnik"
 	assignment = JOB_UPP_KOL_OFFICER
-	rank = JOB_UPP_KOL_OFFICER
+	job_title = JOB_UPP_KOL_OFFICER
 	role_comm_title = "Kol."
 	paygrades = list(PAY_SHORT_UO6 = JOB_PLAYTIME_TIER_0)
 //*****************************************************************************************************/
@@ -2697,14 +2697,14 @@
 /datum/equipment_preset/upp/officer/flag/brig_gen
 	name = "UPP General Mayjor (Cryo)"
 	assignment = JOB_UPP_BRIG_GENERAL
-	rank = JOB_UPP_BRIG_GENERAL
+	job_title = JOB_UPP_BRIG_GENERAL
 	role_comm_title = "May. Gen."
 	paygrades = list(PAY_SHORT_UO7 = JOB_PLAYTIME_TIER_0)
 
 /datum/equipment_preset/upp/officer/flag/dressed/brig_gen
 	name = "UPP General Mayjor"
 	assignment = JOB_UPP_BRIG_GENERAL
-	rank = JOB_UPP_BRIG_GENERAL
+	job_title = JOB_UPP_BRIG_GENERAL
 	role_comm_title = "May. Gen."
 	paygrades = list(PAY_SHORT_UO7 = JOB_PLAYTIME_TIER_0)
 
@@ -2713,7 +2713,7 @@
 /datum/equipment_preset/upp/officer/flag/may_gen
 	name = "UPP General Leytenant (Cryo)"
 	assignment = JOB_UPP_MAY_GENERAL
-	rank = JOB_UPP_MAY_GENERAL
+	job_title = JOB_UPP_MAY_GENERAL
 	role_comm_title = "Ley. Gen."
 	minimap_icon = "upp_co"
 	paygrades = list(PAY_SHORT_UO8 = JOB_PLAYTIME_TIER_0)
@@ -2722,7 +2722,7 @@
 /datum/equipment_preset/upp/officer/flag/may_gen/dressed
 	name = "UPP General Leytenant"
 	assignment = JOB_UPP_MAY_GENERAL
-	rank = JOB_UPP_MAY_GENERAL
+	job_title = JOB_UPP_MAY_GENERAL
 	role_comm_title = "Ley. Gen."
 	minimap_icon = "upp_co"
 	paygrades = list(PAY_SHORT_UO8 = JOB_PLAYTIME_TIER_0)
@@ -2740,7 +2740,7 @@
 /datum/equipment_preset/upp/officer/flag/ley_gen
 	name = "UPP General Polkovnik (Cryo)"
 	assignment = JOB_UPP_LT_GENERAL
-	rank = JOB_UPP_LT_GENERAL
+	job_title = JOB_UPP_LT_GENERAL
 	role_comm_title = "Lt. Gen."
 	minimap_icon = "upp_co"
 	paygrades = list(PAY_SHORT_UO9 = JOB_PLAYTIME_TIER_0)
@@ -2749,7 +2749,7 @@
 /datum/equipment_preset/upp/officer/flag/ley_gen/dressed
 	name = "UPP General Polkovnik"
 	assignment = JOB_UPP_LT_GENERAL
-	rank = JOB_UPP_LT_GENERAL
+	job_title = JOB_UPP_LT_GENERAL
 	role_comm_title = "Lt. Gen."
 	minimap_icon = "upp_co"
 
@@ -2765,7 +2765,7 @@
 /datum/equipment_preset/upp/officer/flag/gen
 	name = "UPP General Armii (Cryo)"
 	assignment = JOB_UPP_GENERAL
-	rank = JOB_UPP_GENERAL
+	job_title = JOB_UPP_GENERAL
 	role_comm_title = "Gen."
 	minimap_icon = "upp_co"
 	paygrades = list(PAY_SHORT_UO10 = JOB_PLAYTIME_TIER_0)
@@ -2774,7 +2774,7 @@
 /datum/equipment_preset/upp/officer/flag/gen/dressed
 	name = "UPP General Armii"
 	assignment = JOB_UPP_GENERAL
-	rank = JOB_UPP_GENERAL
+	job_title = JOB_UPP_GENERAL
 	role_comm_title = "Gen."
 	minimap_icon = "upp_co"
 
@@ -2844,7 +2844,7 @@
 
 	skills = /datum/skills/synthetic
 	assignment = JOB_UPP_SUPPORT_SYNTH
-	rank = JOB_UPP_SUPPORT_SYNTH
+	job_title = JOB_UPP_SUPPORT_SYNTH
 	minimap_icon = "upp_synth"
 	paygrades = list(PAY_SHORT_SYN = JOB_PLAYTIME_TIER_0)
 	idtype = /obj/item/card/id/dogtag/upp
@@ -3088,7 +3088,7 @@
 	name = "UPP Combat Synthetic (Cryo)"
 
 	assignment = JOB_UPP_COMBAT_SYNTH
-	rank = JOB_UPP_COMBAT_SYNTH
+	job_title = JOB_UPP_COMBAT_SYNTH
 
 /datum/equipment_preset/upp/synth/combat/dressed
 	name = "UPP Combat Synthetic"
@@ -3154,7 +3154,7 @@
 
 	skills = /datum/skills/commando
 	assignment = JOB_UPP_COMMANDO
-	rank = JOB_UPP_COMMANDO
+	job_title = JOB_UPP_COMMANDO
 	role_comm_title = "JKdo"
 	paygrades = list(PAY_SHORT_UC1 = JOB_PLAYTIME_TIER_0)
 	idtype = /obj/item/card/id/data
@@ -3291,7 +3291,7 @@
 
 	skills = /datum/skills/commando/medic
 	assignment = JOB_UPP_COMMANDO_MEDIC
-	rank = JOB_UPP_COMMANDO_MEDIC
+	job_title = JOB_UPP_COMMANDO_MEDIC
 	role_comm_title = "2ndKdo"
 	minimap_icon = "upp_commed"
 	paygrades = list(PAY_SHORT_UC2 = JOB_PLAYTIME_TIER_0)
@@ -3462,7 +3462,7 @@
 
 	skills = /datum/skills/commando/leader
 	assignment = JOB_UPP_COMMANDO_LEADER
-	rank = JOB_UPP_COMMANDO_LEADER
+	job_title = JOB_UPP_COMMANDO_LEADER
 	role_comm_title = "1stKdo"
 	minimap_icon = "upp_comsl"
 	paygrades = list(PAY_SHORT_UC3 = JOB_PLAYTIME_TIER_0)
@@ -3731,7 +3731,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_UPP_CREWMAN
-	rank = JOB_UPP_CREWMAN
+	job_title = JOB_UPP_CREWMAN
 	paygrades = list(PAY_SHORT_UE5 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "TANK"
 
@@ -3849,7 +3849,7 @@
 	name = "UPP Pilot (Cryo)"
 	assignment = JOB_UPP_PILOT
 	role_comm_title = "Pilot"
-	rank = JOB_UPP_PILOT
+	job_title = JOB_UPP_PILOT
 	paygrades = list(PAY_SHORT_UO1 = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/pilot
 	access = list(ACCESS_UPP_GENERAL, ACCESS_UPP_ENGINEERING, ACCESS_UPP_FLIGHT)
@@ -3951,7 +3951,7 @@
 	name = "UPP Political Commissar (Cryo)"
 
 	assignment = JOB_UPP_COMMISSAR
-	rank = JOB_UPP_COMMISSAR
+	job_title = JOB_UPP_COMMISSAR
 	paygrades = list(PAY_SHORT_UO4P = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "Commissar"
 	minimap_icon = "upp_plt"
@@ -4073,7 +4073,7 @@
 
 	skills = /datum/skills/upp
 	assignment = JOB_UPP_CONSCRIPT
-	rank = JOB_UPP_CONSCRIPT
+	job_title = JOB_UPP_CONSCRIPT
 	role_comm_title = "Cons"
 	minimap_icon = "upp_pvt"
 	paygrades = list(PAY_SHORT_UE1 = JOB_PLAYTIME_TIER_0)

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -32,7 +32,7 @@
 	. = ..()
 	if(!auto_squad_name || (should_block_game_interaction(new_human) && !ert_squad))
 		return
-	if(!GLOB.data_core.manifest_modify(new_human.real_name, WEAKREF(new_human), assignment, rank))
+	if(!GLOB.data_core.manifest_modify(new_human.real_name, WEAKREF(new_human), assignment, manifest_title))
 		GLOB.data_core.manifest_inject(new_human)
 
 	var/obj/item/card/id/ID = new_human.get_idcard()
@@ -66,7 +66,7 @@
 
 	access = list(ACCESS_MARINE_PREP)
 	assignment = JOB_SQUAD_MARINE
-	rank = JOB_SQUAD_MARINE
+	job_title = JOB_SQUAD_MARINE
 	paygrades = list(PAY_SHORT_ME1 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME2 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "RFN"
 	skills = /datum/skills/pfc
@@ -98,7 +98,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_SMARTPREP)
 	assignment = JOB_SQUAD_SMARTGUN
-	rank = JOB_SQUAD_SMARTGUN
+	job_title = JOB_SQUAD_SMARTGUN
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "SG"
 	skills = /datum/skills/smartgunner
@@ -157,7 +157,7 @@
 		ACCESS_MARINE_DELTA,
 	)
 	assignment = JOB_TANK_CREW
-	rank = JOB_TANK_CREW
+	job_title = JOB_TANK_CREW
 	paygrades = list(PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "CRMN"
 	minimum_age = 30
@@ -217,7 +217,7 @@
 		ACCESS_CIVILIAN_ENGINEERING,
 	)
 	assignment = JOB_INTEL
-	rank = JOB_INTEL
+	job_title = JOB_INTEL
 	paygrades = list(PAY_SHORT_MO1 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "IO"
 	skills = /datum/skills/intel
@@ -276,7 +276,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_SPECPREP)
 	assignment = JOB_SQUAD_SPECIALIST
-	rank = JOB_SQUAD_SPECIALIST
+	job_title = JOB_SQUAD_SPECIALIST
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "Spc"
 	skills = /datum/skills/specialist
@@ -335,7 +335,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_MEDPREP, ACCESS_MARINE_MEDBAY)
 	assignment = JOB_SQUAD_MEDIC
-	rank = JOB_SQUAD_MEDIC
+	job_title = JOB_SQUAD_MEDIC
 	paygrades = list(PAY_SHORT_ME2 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "HM"
 	skills = /datum/skills/combat_medic
@@ -369,7 +369,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_TL_PREP)
 	assignment = JOB_SQUAD_TEAM_LEADER
-	rank = JOB_SQUAD_TEAM_LEADER
+	job_title = JOB_SQUAD_TEAM_LEADER
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "FTL"
 	skills = /datum/skills/tl
@@ -399,7 +399,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_ENGPREP, ACCESS_CIVILIAN_ENGINEERING)
 	assignment = JOB_SQUAD_ENGI
-	rank = JOB_SQUAD_ENGI
+	job_title = JOB_SQUAD_ENGI
 	paygrades = list(PAY_SHORT_ME2 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "ComTech"
 	skills = /datum/skills/combat_engineer
@@ -433,7 +433,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP)
 	assignment = JOB_SQUAD_LEADER
-	rank = JOB_SQUAD_LEADER
+	job_title = JOB_SQUAD_LEADER
 	paygrades = list(PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME6 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME7 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "SL"
 	minimum_age = 25
@@ -466,7 +466,7 @@
 
 	access = list(ACCESS_MARINE_PREP)
 	assignment = JOB_SQUAD_MARINE
-	rank = JOB_SQUAD_MARINE
+	job_title = JOB_SQUAD_MARINE
 	paygrades = list(PAY_SHORT_ME1 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME2 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "RFN"
 	skills = /datum/skills/pfc/crafty
@@ -510,7 +510,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP)
 	assignment = JOB_SQUAD_LEADER
-	rank = JOB_SQUAD_LEADER
+	job_title = JOB_SQUAD_LEADER
 	paygrades = list(PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME6 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME7 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "SL"
 	minimum_age = 25
@@ -552,7 +552,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_SMARTPREP)
 	assignment = JOB_SQUAD_SMARTGUN
-	rank = JOB_SQUAD_SMARTGUN
+	job_title = JOB_SQUAD_SMARTGUN
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "SG"
 	skills = /datum/skills/smartgunner
@@ -591,7 +591,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_ENGPREP, ACCESS_CIVILIAN_ENGINEERING)
 	assignment = JOB_SQUAD_ENGI
-	rank = JOB_SQUAD_ENGI
+	job_title = JOB_SQUAD_ENGI
 	paygrades = list(PAY_SHORT_ME2 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "ComTech"
 	skills = /datum/skills/combat_engineer
@@ -639,7 +639,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_MEDPREP, ACCESS_MARINE_MEDBAY)
 	assignment = JOB_SQUAD_MEDIC
-	rank = JOB_SQUAD_MEDIC
+	job_title = JOB_SQUAD_MEDIC
 	paygrades = list(PAY_SHORT_ME2 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "HM"
 	skills = /datum/skills/combat_medic
@@ -695,7 +695,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_SPECPREP)
 	assignment = JOB_SQUAD_SPECIALIST
-	rank = JOB_SQUAD_SPECIALIST
+	job_title = JOB_SQUAD_SPECIALIST
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "Spc"
 	skills = /datum/skills/specialist
@@ -767,7 +767,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_TL_PREP)
 	assignment = JOB_SQUAD_TEAM_LEADER
-	rank = JOB_SQUAD_TEAM_LEADER
+	job_title = JOB_SQUAD_TEAM_LEADER
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "TL"
 	skills = /datum/skills/tl
@@ -803,7 +803,7 @@
 	name = "Marine Raider (!DEATHSQUAD!)"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = "Marine Raider"
-	rank = JOB_MARINE_RAIDER
+	job_title = JOB_MARINE_RAIDER
 	role_comm_title = "Op."
 	languages = list(LANGUAGE_TSL, LANGUAGE_ENGLISH)
 	skills = /datum/skills/commando/deathsquad
@@ -876,7 +876,7 @@
 /datum/equipment_preset/uscm/marsoc/sl
 	name = "Marine Raider Team Leader (!DEATHSQUAD!)"
 	assignment = JOB_MARINE_RAIDER_SL
-	rank = JOB_MARINE_RAIDER_SL
+	job_title = JOB_MARINE_RAIDER_SL
 	role_comm_title = "TL."
 	paygrades = list(PAY_SHORT_MO1 = JOB_PLAYTIME_TIER_0, PAY_SHORT_MO2 = JOB_PLAYTIME_TIER_3)
 	skills = /datum/skills/commando/deathsquad/leader
@@ -904,7 +904,7 @@
 /datum/equipment_preset/uscm/marsoc/cmd
 	name = "Marine Raider Officer (!DEATHSQUAD!)"
 	assignment = JOB_MARINE_RAIDER_CMD
-	rank = JOB_MARINE_RAIDER_CMD
+	job_title = JOB_MARINE_RAIDER_CMD
 	role_comm_title = "CMD."
 	minimap_icon = "sof_officer"
 	paygrades = list(PAY_SHORT_MO3 = JOB_PLAYTIME_TIER_0, PAY_SHORT_MO4 = JOB_PLAYTIME_TIER_3)
@@ -958,7 +958,7 @@
 /datum/equipment_preset/uscm/marsoc/low_threat/sl
 	name = "Marine Raider Team Leader"
 	assignment = JOB_MARINE_RAIDER_SL
-	rank = JOB_MARINE_RAIDER_SL
+	job_title = JOB_MARINE_RAIDER_SL
 	role_comm_title = "TL."
 	paygrades = list(PAY_SHORT_MO1 = JOB_PLAYTIME_TIER_0, PAY_SHORT_MO2 = JOB_PLAYTIME_TIER_3)
 	skills = /datum/skills/commando/deathsquad/leader
@@ -987,7 +987,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA|EQUIPMENT_PRESET_MARINE
 	access = list(ACCESS_MARINE_PREP)
 	assignment = JOB_SQUAD_MARINE
-	rank = JOB_SQUAD_MARINE
+	job_title = JOB_SQUAD_MARINE
 	paygrades = list(PAY_SHORT_ME1 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME2 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "RFN"
 	skills = /datum/skills/rifleman_pve
@@ -1048,7 +1048,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_MEDPREP, ACCESS_MARINE_MEDBAY)
 	assignment = JOB_PLT_MED
-	rank = JOB_SQUAD_MEDIC
+	job_title = JOB_SQUAD_MEDIC
 	paygrades = list(PAY_SHORT_ME2 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "HM"
 	skills = /datum/skills/combat_medic_pve
@@ -1111,7 +1111,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_SMARTPREP)
 	assignment = JOB_SQUAD_SMARTGUN
-	rank = JOB_SQUAD_SMARTGUN
+	job_title = JOB_SQUAD_SMARTGUN
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "SG"
 	skills = /datum/skills/smartgunner_pve
@@ -1157,7 +1157,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_TL_PREP, ACCESS_MARINE_DROPSHIP)
 	assignment = JOB_SQUAD_TEAM_LEADER
-	rank = JOB_SQUAD_TEAM_LEADER
+	job_title = JOB_SQUAD_TEAM_LEADER
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "FTL"
 	skills = /datum/skills/tl_pve
@@ -1213,7 +1213,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP)
 	assignment = JOB_PLT_SL
-	rank = JOB_SQUAD_LEADER
+	job_title = JOB_SQUAD_LEADER
 	paygrades = list(PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME6 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME7 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "SL"
 	skills = /datum/skills/sl_pve
@@ -1279,7 +1279,7 @@
 	name = "USCM Solar Devils Rifleman (Hunted)"
 	access = list(ACCESS_MARINE_PREP)
 	assignment = JOB_SQUAD_MARINE
-	rank = JOB_SQUAD_MARINE
+	job_title = JOB_SQUAD_MARINE
 	paygrades = list(PAY_SHORT_ME1 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME2 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "RFN"
 	skills = /datum/skills/rifleman_pve
@@ -1326,7 +1326,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_TL_PREP, ACCESS_MARINE_DROPSHIP)
 	assignment = JOB_SQUAD_TEAM_LEADER
-	rank = JOB_SQUAD_TEAM_LEADER
+	job_title = JOB_SQUAD_TEAM_LEADER
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "FTL"
 	skills = /datum/skills/tl_pve
@@ -1369,7 +1369,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_SMARTPREP)
 	assignment = JOB_SQUAD_SMARTGUN
-	rank = JOB_SQUAD_SMARTGUN
+	job_title = JOB_SQUAD_SMARTGUN
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "SG"
 	skills = /datum/skills/smartgunner_pve

--- a/code/modules/gear_presets/uscm_co.dm
+++ b/code/modules/gear_presets/uscm_co.dm
@@ -6,7 +6,7 @@
 
 	idtype = /obj/item/card/id/gold
 	assignment = JOB_CO
-	rank = JOB_CO
+	job_title = JOB_CO
 	paygrades = list(PAY_SHORT_MO4 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "CO"
 	minimum_age = 30
@@ -313,7 +313,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_USCM_OBSV
-	rank = JOB_USCM_OBSV
+	job_title = JOB_USCM_OBSV
 	role_comm_title = "VO"
 	minimap_background = "background_medical_WO"
 
@@ -322,7 +322,7 @@
 	flags = EQUIPMENT_PRESET_START_OF_ROUND|EQUIPMENT_PRESET_MARINE
 
 	idtype = /obj/item/card/id/gold/council
-	rank = JOB_CO
+	job_title = JOB_CO
 	paygrades = list(PAY_SHORT_MO5 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "CO"
 	minimum_age = 35

--- a/code/modules/gear_presets/uscm_dress.dm
+++ b/code/modules/gear_presets/uscm_dress.dm
@@ -2,7 +2,7 @@
 	name = "Dress Blues - (E-2) Private First Class"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_MARINE
-	rank = JOB_MARINE
+	job_title = JOB_MARINE
 	access = list(ACCESS_MARINE_PREP)
 	minimum_age = 18
 	paygrades = list(PAY_SHORT_ME2 = JOB_PLAYTIME_TIER_0)

--- a/code/modules/gear_presets/uscm_event.dm
+++ b/code/modules/gear_presets/uscm_event.dm
@@ -393,7 +393,7 @@
 	skills = /datum/skills/general
 
 	assignment = JOB_PROVOST_MARSHAL
-	job_title = "Provost Marshal"
+	job_title = JOB_PROVOST_MARSHAL
 	paygrades = list(PAY_SHORT_PVM = JOB_PLAYTIME_TIER_0)
 	role_comm_title = PAY_SHORT_PVM
 	flags = EQUIPMENT_PRESET_EXTRA
@@ -427,7 +427,7 @@
 	minimum_age = 50
 
 	assignment = JOB_PROVOST_SMARSHAL
-	job_title = "Provost Sector Marshal"
+	job_title = JOB_PROVOST_SMARSHAL
 	paygrades = list(PAY_SHORT_PVSM = JOB_PLAYTIME_TIER_0)
 	role_comm_title = PAY_SHORT_PVSM
 

--- a/code/modules/gear_presets/uscm_event.dm
+++ b/code/modules/gear_presets/uscm_event.dm
@@ -15,7 +15,7 @@
 	idtype = /obj/item/card/id/general
 	access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_MORGUE)
 	assignment = JOB_COLONEL
-	rank = JOB_COLONEL
+	job_title = JOB_COLONEL
 	paygrades = list(PAY_SHORT_MO6 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "COL"
 	minimum_age = 40
@@ -60,7 +60,7 @@
 	idtype = /obj/item/card/id/general
 	access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_MORGUE)
 	assignment = JOB_GENERAL
-	rank = JOB_GENERAL
+	job_title = JOB_GENERAL
 	paygrades = list(PAY_SHORT_MO7 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "GEN"
 	minimum_age = 50
@@ -127,14 +127,14 @@
 	name = "USCM O-10C - Assistant Commandant of the Marine Corps (High Command)"
 	paygrades = list(PAY_SHORT_MO10C = JOB_PLAYTIME_TIER_0)
 	assignment = JOB_ACMC
-	rank = JOB_ACMC
+	job_title = JOB_ACMC
 	role_comm_title = "ACMC"
 
 /datum/equipment_preset/uscm_event/general/o10s
 	name = "USCM O-10S - Commandant of the Marine Corps (High Command)"
 	paygrades = list(PAY_SHORT_MO10S = JOB_PLAYTIME_TIER_0)
 	assignment = JOB_CMC
-	rank = JOB_CMC
+	job_title = JOB_CMC
 	role_comm_title = "CMC"
 
 /*****************************************************************************************************/
@@ -151,7 +151,7 @@
 		ACCESS_MARINE_OT,
 	)
 	assignment = JOB_ORDNANCE_TECH
-	rank = "UPP"
+	job_title = "UPP"
 	paygrades = list(PAY_SHORT_ME1 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME2 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "OT"
 	skills = /datum/skills/spy
@@ -206,7 +206,7 @@
 /datum/equipment_preset/uscm_event/provost/enforcer
 	name = "Provost Enforcer"
 	assignment = JOB_PROVOST_ENFORCER
-	rank = JOB_PROVOST_ENFORCER
+	job_title = JOB_PROVOST_ENFORCER
 	paygrades = list(PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME6 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME7 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "PvE"
 	flags = EQUIPMENT_PRESET_EXTRA
@@ -250,7 +250,7 @@
 	name = "Provost Team Leader"
 	skills = /datum/skills/CMP
 	assignment = JOB_PROVOST_TML
-	rank = JOB_PROVOST_TML
+	job_title = JOB_PROVOST_TML
 	paygrades = list(PAY_SHORT_ME8 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME9 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "PvTML"
 	flags = EQUIPMENT_PRESET_EXTRA
@@ -294,7 +294,7 @@
 /datum/equipment_preset/uscm_event/provost/inspector
 	name = "Provost Inspector"
 	assignment = JOB_PROVOST_INSPECTOR
-	rank = JOB_PROVOST_INSPECTOR
+	job_title = JOB_PROVOST_INSPECTOR
 	paygrades = list(PAY_SHORT_PVI = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "PvI"
 	flags = EQUIPMENT_PRESET_EXTRA
@@ -332,7 +332,7 @@
 /datum/equipment_preset/uscm_event/provost/inspector/chief
 	name = "Provost Chief Inspector"
 	assignment = JOB_PROVOST_CINSPECTOR
-	rank = JOB_PROVOST_CINSPECTOR
+	job_title = JOB_PROVOST_CINSPECTOR
 	paygrades = list(PAY_SHORT_PVCI = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "PvCI"
 	flags = EQUIPMENT_PRESET_EXTRA
@@ -369,7 +369,7 @@
 /datum/equipment_preset/uscm_event/provost/inspector/advisor
 	name = "Provost Advisor"
 	assignment = JOB_PROVOST_ADVISOR
-	rank = JOB_PROVOST_ADVISOR
+	job_title = JOB_PROVOST_ADVISOR
 	paygrades = list(PAY_SHORT_ME8E = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME9E = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "PvA"
 	flags = EQUIPMENT_PRESET_EXTRA
@@ -381,7 +381,7 @@
 	skills = /datum/skills/general
 
 	assignment = JOB_PROVOST_DMARSHAL
-	rank = JOB_PROVOST_DMARSHAL
+	job_title = JOB_PROVOST_DMARSHAL
 	paygrades = list(PAY_SHORT_PVDM = JOB_PLAYTIME_TIER_0)
 	role_comm_title = PAY_SHORT_PVDM
 	flags = EQUIPMENT_PRESET_EXTRA
@@ -393,7 +393,7 @@
 	skills = /datum/skills/general
 
 	assignment = JOB_PROVOST_MARSHAL
-	rank = "Provost Marshal"
+	job_title = "Provost Marshal"
 	paygrades = list(PAY_SHORT_PVM = JOB_PLAYTIME_TIER_0)
 	role_comm_title = PAY_SHORT_PVM
 	flags = EQUIPMENT_PRESET_EXTRA
@@ -427,7 +427,7 @@
 	minimum_age = 50
 
 	assignment = JOB_PROVOST_SMARSHAL
-	rank = "Provost Sector Marshal"
+	job_title = "Provost Sector Marshal"
 	paygrades = list(PAY_SHORT_PVSM = JOB_PLAYTIME_TIER_0)
 	role_comm_title = PAY_SHORT_PVSM
 
@@ -436,7 +436,7 @@
 	minimum_age = 60
 
 	assignment = JOB_PROVOST_CMARSHAL
-	rank = "Provost Chief Marshal"
+	job_title = "Provost Chief Marshal"
 	paygrades = list(PAY_SHORT_PVCM = JOB_PLAYTIME_TIER_0)
 	role_comm_title = PAY_SHORT_PVCM
 

--- a/code/modules/gear_presets/uscm_event.dm
+++ b/code/modules/gear_presets/uscm_event.dm
@@ -436,7 +436,7 @@
 	minimum_age = 60
 
 	assignment = JOB_PROVOST_CMARSHAL
-	job_title = "Provost Chief Marshal"
+	job_title = JOB_PROVOST_CMARSHAL
 	paygrades = list(PAY_SHORT_PVCM = JOB_PLAYTIME_TIER_0)
 	role_comm_title = PAY_SHORT_PVCM
 

--- a/code/modules/gear_presets/uscm_forecon.dm
+++ b/code/modules/gear_presets/uscm_forecon.dm
@@ -1,10 +1,10 @@
 /datum/equipment_preset/uscm/forecon
 	assignment = JOB_SQUAD_MARINE
-	rank = JOB_SQUAD_MARINE
+	job_title = JOB_SQUAD_MARINE
 	paygrades = list(PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_0)
 	idtype = /obj/item/card/id/dogtag
 	role_comm_title = "FORECON"
-	rank = JOB_MARINE
+	job_title = JOB_MARINE
 	faction_group = list(FACTION_MARINE)
 	flags = EQUIPMENT_PRESET_START_OF_ROUND
 	auto_squad_name = SQUAD_FORECON
@@ -83,7 +83,7 @@
 /datum/equipment_preset/uscm/forecon/standard
 	name = "USCM Reconnaissance Marine"
 	assignment = JOB_FORECON_RIFLEMAN
-	rank = JOB_SQUAD_MARINE
+	job_title = JOB_SQUAD_MARINE
 	role_comm_title = "RFN"
 	minimap_icon = ""
 	skills = /datum/skills/military/survivor/forecon_standard
@@ -120,7 +120,7 @@
 /datum/equipment_preset/uscm/forecon/tech
 	name = "USCM Reconnaissance Support Technician"
 	assignment = JOB_FORECON_SUPPORT
-	rank = JOB_SQUAD_TECH
+	job_title = JOB_SQUAD_TECH
 	role_comm_title = "SuppTech"
 	minimap_icon = "engi"
 	skills = /datum/skills/military/survivor/forecon_techician
@@ -162,7 +162,7 @@
 /datum/equipment_preset/uscm/forecon/marksman
 	name = "USCM Reconnaissance Designated Marksman"
 	assignment = JOB_FORECON_MARKSMAN
-	rank = JOB_SQUAD_SPECIALIST
+	job_title = JOB_SQUAD_SPECIALIST
 	role_comm_title = "DMR"
 	minimap_icon = "spec"
 	skills = /datum/skills/military/survivor/forecon_marksman
@@ -206,7 +206,7 @@
 /datum/equipment_preset/uscm/forecon/smartgunner
 	name = "USCM Reconnaissance Smartgunner"
 	assignment = JOB_FORECON_SMARTGUNNER
-	rank = JOB_SQUAD_SMARTGUN
+	job_title = JOB_SQUAD_SMARTGUN
 	role_comm_title = "SG"
 	minimap_icon = "smartgunner"
 	skills = /datum/skills/military/survivor/forecon_smartgunner
@@ -248,7 +248,7 @@
 /datum/equipment_preset/uscm/forecon/squad_leader
 	name = "USCM Reconnaissance Squad Leader"
 	assignment = JOB_FORECON_SL
-	rank = JOB_SQUAD_LEADER
+	job_title = JOB_SQUAD_LEADER
 	role_comm_title = "SL"
 	skills = /datum/skills/military/survivor/forecon_squad_leader
 	paygrades = list(PAY_SHORT_MO1 = JOB_PLAYTIME_TIER_0)

--- a/code/modules/gear_presets/uscm_forecon.dm
+++ b/code/modules/gear_presets/uscm_forecon.dm
@@ -4,7 +4,6 @@
 	paygrades = list(PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_0)
 	idtype = /obj/item/card/id/dogtag
 	role_comm_title = "FORECON"
-	job_title = JOB_MARINE
 	faction_group = list(FACTION_MARINE)
 	flags = EQUIPMENT_PRESET_START_OF_ROUND
 	auto_squad_name = SQUAD_FORECON

--- a/code/modules/gear_presets/uscm_medical.dm
+++ b/code/modules/gear_presets/uscm_medical.dm
@@ -36,7 +36,7 @@
 		ACCESS_MARINE_FIELD_DOC,
 	)
 	assignment = JOB_CMO
-	rank = JOB_CMO
+	job_title = JOB_CMO
 	paygrades = list(PAY_SHORT_MO1 = JOB_PLAYTIME_TIER_0, PAY_SHORT_MO2 = JOB_PLAYTIME_TIER_1)
 	role_comm_title = "CMO"
 	skills = /datum/skills/CMO
@@ -66,7 +66,7 @@
 	name = "USCM Doctor"
 
 	assignment = JOB_DOCTOR
-	rank = JOB_DOCTOR
+	job_title = JOB_DOCTOR
 	paygrades = list(PAY_SHORT_MO1 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "Doc"
 	skills = /datum/skills/doctor
@@ -105,7 +105,7 @@
 	name = "USCM Field Doctor"
 
 	assignment = JOB_FIELD_DOCTOR
-	rank = JOB_FIELD_DOCTOR
+	job_title = JOB_FIELD_DOCTOR
 	paygrades = list(PAY_SHORT_MO1 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "Fld Doc"
 	skills = /datum/skills/doctor
@@ -130,7 +130,7 @@
 	name = "USCM Nurse"
 
 	assignment = JOB_NURSE
-	rank = JOB_NURSE
+	job_title = JOB_NURSE
 	paygrades = list(PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_1)
 	role_comm_title = "Nurse"
 	skills = /datum/skills/nurse
@@ -160,7 +160,7 @@
 
 	access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_RESEARCH, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_MORGUE)
 	assignment = JOB_RESEARCHER
-	rank = JOB_RESEARCHER
+	job_title = JOB_RESEARCHER
 	paygrades = list(PAY_SHORT_MO1 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "Rsr"
 	skills = /datum/skills/researcher

--- a/code/modules/gear_presets/uscm_police.dm
+++ b/code/modules/gear_presets/uscm_police.dm
@@ -27,7 +27,7 @@
 		ACCESS_MARINE_OT,
 	)
 	assignment = JOB_POLICE
-	rank = JOB_POLICE
+	job_title = JOB_POLICE
 	paygrades = list(PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME6 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "MP"
 	skills = /datum/skills/MP
@@ -85,7 +85,7 @@
 		ACCESS_MARINE_OT,
 	)
 	assignment = JOB_WARDEN
-	rank = JOB_WARDEN
+	job_title = JOB_WARDEN
 	paygrades = list(PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME6 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME7 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "MW"
 	minimum_age = 25
@@ -147,7 +147,7 @@
 		ACCESS_MARINE_SYNTH,
 	)
 	assignment = JOB_CHIEF_POLICE
-	rank = JOB_CHIEF_POLICE
+	job_title = JOB_CHIEF_POLICE
 	paygrades = list(PAY_SHORT_MO1 = JOB_PLAYTIME_TIER_0, PAY_SHORT_MO2 = JOB_PLAYTIME_TIER_1)
 	minimum_age = 23
 	role_comm_title = "CMP"
@@ -191,7 +191,7 @@
 	idtype = /obj/item/card/id/silver
 	access = list()
 	assignment = JOB_RIOT
-	rank = JOB_RIOT
+	job_title = JOB_RIOT
 	paygrades = list(PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "RMP"
 	skills = /datum/skills/CMP
@@ -243,7 +243,7 @@
 	minimap_icon = list("crmp")
 
 	assignment = JOB_RIOT_CHIEF
-	rank = JOB_RIOT_CHIEF
+	job_title = JOB_RIOT_CHIEF
 	paygrades = list(PAY_SHORT_MO1 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "CRMP"
 	skills = /datum/skills/CMP

--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -47,7 +47,7 @@
 		ACCESS_CIVILIAN_COMMAND,
 	)
 	assignment = JOB_CORPORATE_LIAISON
-	rank = JOB_CORPORATE_LIAISON
+	job_title = JOB_CORPORATE_LIAISON
 	paygrades = list(PAY_SHORT_WYC2 = JOB_PLAYTIME_TIER_0, PAY_SHORT_WYC3 = JOB_PLAYTIME_TIER_2, PAY_SHORT_WYC4 = JOB_PLAYTIME_TIER_3, PAY_SHORT_WYC5 = JOB_PLAYTIME_TIER_4)
 	role_comm_title = "CL"
 	skills = /datum/skills/civilian
@@ -91,7 +91,7 @@
 		ACCESS_PRESS,
 	)
 	assignment = JOB_COMBAT_REPORTER
-	rank = JOB_COMBAT_REPORTER
+	job_title = JOB_COMBAT_REPORTER
 	paygrades = list(PAY_SHORT_CIV = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "PRESS"
 	skills = /datum/skills/civilian
@@ -126,7 +126,7 @@
 		ACCESS_MARINE_PREP,
 	)
 	assignment = JOB_COMBAT_REPORTER
-	rank = JOB_COMBAT_REPORTER
+	job_title = JOB_COMBAT_REPORTER
 	paygrades = list(PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "CC"
 	skills = /datum/skills/pfc
@@ -178,7 +178,7 @@
 		ACCESS_MARINE_DROPSHIP,
 	)
 	assignment = JOB_CHIEF_ENGINEER
-	rank = JOB_CHIEF_ENGINEER
+	job_title = JOB_CHIEF_ENGINEER
 	paygrades = list(PAY_SHORT_MO1 = JOB_PLAYTIME_TIER_0, PAY_SHORT_MO2 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "CE"
 	minimum_age = 25
@@ -214,7 +214,7 @@
 		ACCESS_MARINE_MAINT,
 	)
 	assignment = JOB_MAINT_TECH
-	rank = JOB_MAINT_TECH
+	job_title = JOB_MAINT_TECH
 	paygrades = list(PAY_SHORT_ME1 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME2 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "MT"
 	skills = /datum/skills/MT
@@ -250,7 +250,7 @@
 
 	)
 	assignment = JOB_ORDNANCE_TECH
-	rank = JOB_ORDNANCE_TECH
+	job_title = JOB_ORDNANCE_TECH
 	paygrades = list(PAY_SHORT_ME1 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME2 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "OT"
 	skills = /datum/skills/OT
@@ -295,7 +295,7 @@
 		ACCESS_MARINE_PREP,
 	)
 	assignment = JOB_CHIEF_REQUISITION
-	rank = JOB_CHIEF_REQUISITION
+	job_title = JOB_CHIEF_REQUISITION
 	paygrades = list(PAY_SHORT_ME6 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME7 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME8 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "QM"
 	minimum_age = 25
@@ -330,7 +330,7 @@
 
 	access = list(ACCESS_MARINE_CARGO)
 	assignment = JOB_CARGO_TECH
-	rank = JOB_CARGO_TECH
+	job_title = JOB_CARGO_TECH
 	paygrades = list(PAY_SHORT_ME1 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME2 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "CT"
 	skills = /datum/skills/CT
@@ -368,7 +368,7 @@
 
 	idtype = /obj/item/card/id/silver
 	assignment = JOB_XO
-	rank = JOB_XO
+	job_title = JOB_XO
 	paygrades = list(PAY_SHORT_MO3 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "XO"
 	minimum_age = 27
@@ -407,7 +407,7 @@
 	idtype = /obj/item/card/id/silver
 	access = list(ACCESS_MARINE_COMMAND, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_DATABASE, ACCESS_MARINE_MEDBAY)
 	assignment = JOB_SO
-	rank = JOB_SO
+	job_title = JOB_SO
 	paygrades = list(PAY_SHORT_MO1 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "SO"
 	minimum_age = 23
@@ -438,7 +438,7 @@
 
 	idtype = /obj/item/card/id/silver
 	assignment = JOB_SEA
-	rank = JOB_SEA
+	job_title = JOB_SEA
 	paygrades = list(PAY_SHORT_ME7 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "SEA"
 	minimum_age = 40
@@ -473,8 +473,8 @@
 
 /datum/equipment_preset/uscm_ship/sea/load_rank(mob/living/carbon/human/rankee, client/mob_client)
 	mob_client?.toggle_newplayer_ic_hud(TRUE)
-	if(rankee?.client?.prefs?.pref_special_job_options[rank])
-		var/paygrade_choice = get_paygrade_id_by_name(rankee.client.prefs.pref_special_job_options[rank])
+	if(rankee?.client?.prefs?.pref_special_job_options[job_title])
+		var/paygrade_choice = get_paygrade_id_by_name(rankee.client.prefs.pref_special_job_options[job_title])
 		return paygrade_choice
 	..()
 
@@ -486,7 +486,7 @@
 
 	idtype = /obj/item/card/id/silver
 	assignment = JOB_AUXILIARY_OFFICER
-	rank = JOB_AUXILIARY_OFFICER
+	job_title = JOB_AUXILIARY_OFFICER
 	paygrades = list(PAY_SHORT_MO2 = JOB_PLAYTIME_TIER_0, PAY_SHORT_MO3 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "ASO"
 	minimum_age = 25
@@ -545,7 +545,7 @@
 	idtype = /obj/item/card/id/silver
 	access = list(ACCESS_MARINE_COMMAND, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_PILOT)
 	assignment = JOB_CAS_PILOT
-	rank = JOB_CAS_PILOT
+	job_title = JOB_CAS_PILOT
 	paygrades = list(PAY_SHORT_MO1 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "GP"
 	minimum_age = 23
@@ -597,7 +597,7 @@
 	idtype = /obj/item/card/id/silver
 	access = list(ACCESS_MARINE_COMMAND, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_PILOT, ACCESS_MARINE_MEDBAY)
 	assignment = JOB_DROPSHIP_PILOT
-	rank = JOB_DROPSHIP_PILOT
+	job_title = JOB_DROPSHIP_PILOT
 	paygrades = list(PAY_SHORT_MO1 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "DP"
 	minimum_age = 23
@@ -649,7 +649,7 @@
 	idtype = /obj/item/card/id/silver
 	access = list(ACCESS_MARINE_COMMAND, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_PILOT, ACCESS_MARINE_MEDBAY)
 	assignment = JOB_DROPSHIP_CREW_CHIEF
-	rank = JOB_DROPSHIP_CREW_CHIEF
+	job_title = JOB_DROPSHIP_CREW_CHIEF
 	paygrades = list(PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME6 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "DCC"
 	skills = /datum/skills/crew_chief
@@ -703,7 +703,7 @@
 	idtype = /obj/item/card/id/general
 	access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_MORGUE)
 	assignment = "USCM Officer"
-	rank = "USCM Officer"
+	job_title = "USCM Officer"
 	paygrades = list(PAY_SHORT_MO3 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "Cpt"
 	minimum_age = 25
@@ -741,7 +741,7 @@
 
 	access = list(ACCESS_MARINE_KITCHEN)
 	assignment = JOB_MESS_SERGEANT
-	rank = JOB_MESS_SERGEANT
+	job_title = JOB_MESS_SERGEANT
 	paygrades = list(PAY_SHORT_ME1 = JOB_PLAYTIME_TIER_0, PAY_SHORT_ME2 = JOB_PLAYTIME_TIER_1, PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_3)
 	role_comm_title = "MST"
 	skills = /datum/skills/mess_technician

--- a/code/modules/gear_presets/whiteout.dm
+++ b/code/modules/gear_presets/whiteout.dm
@@ -5,7 +5,7 @@
 	faction = FACTION_WY_DEATHSQUAD
 	assignment = JOB_DS_CU
 	role_comm_title = "WO"
-	rank = JOB_DS_CU
+	job_title = JOB_DS_CU
 	languages = list(LANGUAGE_ENGLISH, LANGUAGE_JAPANESE, LANGUAGE_CHINESE, LANGUAGE_RUSSIAN, LANGUAGE_GERMAN, LANGUAGE_FRENCH, LANGUAGE_SCANDINAVIAN, LANGUAGE_SPANISH, LANGUAGE_YAUTJA, LANGUAGE_XENOMORPH, LANGUAGE_TSL) //Synths after all.
 	skills = /datum/skills/everything //They are Synths, programmed for Everything.
 	minimap_icon = "whiteout"
@@ -90,7 +90,7 @@
 	role_comm_title = "WO-SUP"
 	minimap_background = "background_ua"
 	assignment = JOB_DS_SUP
-	rank = JOB_DS_SUP
+	job_title = JOB_DS_SUP
 
 /datum/equipment_preset/pmc/w_y_whiteout/medic/load_gear(mob/living/carbon/human/new_human)
 	// back
@@ -141,7 +141,7 @@
 	role_comm_title = "WO-CK"
 	minimap_background = "background_mp"
 	assignment = JOB_DS_CK
-	rank = JOB_DS_CK
+	job_title = JOB_DS_CK
 	new_bubble_icon = "syndibot"
 
 /datum/equipment_preset/pmc/w_y_whiteout/cloaker/load_race(mob/living/carbon/human/new_human)
@@ -201,7 +201,7 @@
 	role_comm_title = "WO-LU"
 	minimap_background = "background_command"
 	assignment = JOB_DS_SL
-	rank = JOB_DS_SL
+	job_title = JOB_DS_SL
 
 /datum/equipment_preset/pmc/w_y_whiteout/leader/load_gear(mob/living/carbon/human/new_human)
 	// back
@@ -252,7 +252,7 @@
 	name = "Whiteout Team Combat Unit"
 	minimap_background = "background_pmc"
 	assignment = JOB_DS_CU
-	rank = JOB_DS_CU
+	job_title = JOB_DS_CU
 
 /datum/equipment_preset/pmc/w_y_whiteout/low_threat/load_race(mob/living/carbon/human/new_human)
 	new_human.set_species("W-Y Combat Android (Weaker)")
@@ -315,7 +315,7 @@
 	minimap_background = "background_ua"
 	role_comm_title = "WO-SUP"
 	assignment = JOB_DS_SUP
-	rank = JOB_DS_SUP
+	job_title = JOB_DS_SUP
 
 /datum/equipment_preset/pmc/w_y_whiteout/low_threat/medic/load_gear(mob/living/carbon/human/new_human)
 	// back
@@ -364,7 +364,7 @@
 	role_comm_title = "WO-CK"
 	minimap_background = "background_mp"
 	assignment = JOB_DS_CK
-	rank = JOB_DS_CK
+	job_title = JOB_DS_CK
 	new_bubble_icon = "syndibot"
 
 /datum/equipment_preset/pmc/w_y_whiteout/low_threat/cloaker/load_race(mob/living/carbon/human/new_human)
@@ -424,7 +424,7 @@
 	minimap_background = "background_command"
 	role_comm_title = "WO-LU"
 	assignment = JOB_DS_SL
-	rank = JOB_DS_SL
+	job_title = JOB_DS_SL
 
 /datum/equipment_preset/pmc/w_y_whiteout/low_threat/leader/load_gear(mob/living/carbon/human/new_human)
 	// back

--- a/code/modules/gear_presets/wo.dm
+++ b/code/modules/gear_presets/wo.dm
@@ -16,7 +16,7 @@
 	flags = EQUIPMENT_PRESET_START_OF_ROUND_WO
 
 	assignment = JOB_WO_CO
-	rank = JOB_WO_CO
+	job_title = JOB_WO_CO
 	paygrades = list(PAY_SHORT_MO2 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "CDR"
 	skills = /datum/skills/commander
@@ -96,7 +96,7 @@
 	flags = EQUIPMENT_PRESET_START_OF_ROUND_WO
 
 	assignment = JOB_WO_XO
-	rank = JOB_WO_XO
+	job_title = JOB_WO_XO
 	paygrades = list(PAY_SHORT_MO1 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "LCDR"
 	skills = /datum/skills/XO
@@ -141,7 +141,7 @@
 
 	access = list(ACCESS_MARINE_BRIG, ACCESS_MARINE_COMMAND, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_DATABASE, ACCESS_MARINE_PREP, ACCESS_MARINE_CMP, ACCESS_MARINE_MEDBAY)
 	assignment = JOB_WO_CHIEF_POLICE
-	rank = JOB_WO_CHIEF_POLICE
+	job_title = JOB_WO_CHIEF_POLICE
 	paygrades = list(PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "HGSL"
 	skills = /datum/skills/honor_guard/lead
@@ -178,7 +178,7 @@
 
 	access = list(ACCESS_MARINE_COMMAND, ACCESS_MARINE_BRIG, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_DATABASE)
 	assignment = JOB_WO_SO
-	rank = JOB_WO_SO
+	job_title = JOB_WO_SO
 	paygrades = list(PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "VHG"
 	skills = /datum/skills/honor_guard/vet
@@ -221,7 +221,7 @@
 
 	access = list(ACCESS_MARINE_COMMAND, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_DATABASE)
 	assignment = JOB_WO_CREWMAN
-	rank = JOB_WO_CREWMAN
+	job_title = JOB_WO_CREWMAN
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "HGS"
 	skills = /datum/skills/honor_guard/spec
@@ -262,7 +262,7 @@
 
 	access = list(ACCESS_MARINE_BRIG, ACCESS_MARINE_COMMAND, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_DATABASE, ACCESS_MARINE_PREP, ACCESS_MARINE_MEDBAY)
 	assignment = JOB_WO_POLICE
-	rank = JOB_WO_POLICE
+	job_title = JOB_WO_POLICE
 	paygrades = list(PAY_SHORT_ME2 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "HG"
 	skills = /datum/skills/honor_guard
@@ -297,7 +297,7 @@
 
 	access = list(ACCESS_MARINE_COMMAND, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_PILOT)
 	assignment = JOB_WO_PILOT
-	rank = JOB_WO_PILOT
+	job_title = JOB_WO_PILOT
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "MC"
 	skills = /datum/skills/mortar_crew
@@ -333,7 +333,7 @@
 
 	access = list(ACCESS_MARINE_CARGO, ACCESS_MARINE_RO, ACCESS_MARINE_COMMAND)
 	assignment = JOB_WO_CHIEF_REQUISITION
-	rank = JOB_WO_CHIEF_REQUISITION
+	job_title = JOB_WO_CHIEF_REQUISITION
 	paygrades = list(PAY_SHORT_ME8 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "QM"
 	skills = /datum/skills/RO
@@ -364,7 +364,7 @@
 
 	access = list(ACCESS_MARINE_ENGINEERING, ACCESS_CIVILIAN_ENGINEERING, ACCESS_MARINE_CARGO)
 	assignment = JOB_WO_REQUISITION
-	rank = JOB_WO_REQUISITION
+	job_title = JOB_WO_REQUISITION
 	paygrades = list(PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "BCL"
 	skills = /datum/skills/CE
@@ -399,7 +399,7 @@
 
 	access = list(ACCESS_MARINE_CMO, ACCESS_MARINE_MEDBAY, ACCESS_MARINE_RESEARCH, ACCESS_MARINE_COMMAND, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_MORGUE)
 	assignment = JOB_WO_CMO
-	rank = JOB_WO_CMO
+	job_title = JOB_WO_CMO
 	paygrades = list(PAY_SHORT_CCMO = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "HS"
 	skills = /datum/skills/CMO
@@ -443,7 +443,7 @@
 
 	access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_MORGUE)
 	assignment = JOB_WO_DOCTOR
-	rank = JOB_WO_DOCTOR
+	job_title = JOB_WO_DOCTOR
 	paygrades = list(PAY_SHORT_CDOC = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "Doc"
 	skills = /datum/skills/doctor
@@ -484,7 +484,7 @@
 
 	access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_RESEARCH, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_MORGUE)
 	assignment = JOB_WO_RESEARCHER
-	rank = JOB_WO_RESEARCHER
+	job_title = JOB_WO_RESEARCHER
 	paygrades = list(PAY_SHORT_CDOC = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "Chem"
 	skills = /datum/skills/researcher
@@ -525,7 +525,7 @@
 
 	access = list(ACCESS_MARINE_CE, ACCESS_MARINE_ENGINEERING, ACCESS_MARINE_COMMAND, ACCESS_CIVILIAN_ENGINEERING, ACCESS_MARINE_DATABASE)
 	assignment = JOB_WO_CHIEF_ENGINEER
-	rank = JOB_WO_CHIEF_ENGINEER
+	job_title = JOB_WO_CHIEF_ENGINEER
 	paygrades = list(PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "BCM"
 	skills = /datum/skills/CE
@@ -560,7 +560,7 @@
 
 	access = list(ACCESS_MARINE_CE, ACCESS_MARINE_ENGINEERING, ACCESS_MARINE_COMMAND, ACCESS_CIVILIAN_ENGINEERING)
 	assignment = JOB_WO_ORDNANCE_TECH
-	rank = JOB_WO_ORDNANCE_TECH
+	job_title = JOB_WO_ORDNANCE_TECH
 	paygrades = list(PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "BC"
 	skills = /datum/skills/OT
@@ -594,7 +594,7 @@
 	flags = EQUIPMENT_PRESET_START_OF_ROUND_WO
 
 	assignment = JOB_WO_CORPORATE_LIAISON
-	rank = JOB_WO_CORPORATE_LIAISON
+	job_title = JOB_WO_CORPORATE_LIAISON
 	paygrades = list(PAY_SHORT_WYC2 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "PRESS"
 	skills = /datum/skills/civilian
@@ -639,7 +639,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP)
 	assignment = JOB_SQUAD_LEADER
-	rank = JOB_SQUAD_LEADER
+	job_title = JOB_SQUAD_LEADER
 	paygrades = list(PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "SL"
 	skills = /datum/skills/SL
@@ -675,7 +675,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_SPECPREP)
 	assignment = JOB_SQUAD_SPECIALIST
-	rank = JOB_SQUAD_SPECIALIST
+	job_title = JOB_SQUAD_SPECIALIST
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "Spc"
 	skills = /datum/skills/specialist
@@ -711,7 +711,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_SMARTPREP)
 	assignment = JOB_SQUAD_SMARTGUN
-	rank = JOB_SQUAD_SMARTGUN
+	job_title = JOB_SQUAD_SMARTGUN
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "SG"
 	skills = /datum/skills/smartgunner
@@ -736,7 +736,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_ENGPREP, ACCESS_CIVILIAN_ENGINEERING)
 	assignment = JOB_SQUAD_ENGI
-	rank = JOB_SQUAD_ENGI
+	job_title = JOB_SQUAD_ENGI
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "ComTech"
 	skills = /datum/skills/combat_engineer
@@ -771,7 +771,7 @@
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_MEDPREP, ACCESS_MARINE_MEDBAY)
 	assignment = JOB_SQUAD_MEDIC
-	rank = JOB_SQUAD_MEDIC
+	job_title = JOB_SQUAD_MEDIC
 	paygrades = list(PAY_SHORT_ME3 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "HM"
 	skills = /datum/skills/combat_medic
@@ -810,7 +810,7 @@
 
 	access = list(ACCESS_MARINE_PREP)
 	assignment = JOB_SQUAD_MARINE
-	rank = JOB_SQUAD_MARINE
+	job_title = JOB_SQUAD_MARINE
 	paygrades = list(PAY_SHORT_ME2 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "RFN"
 	skills = /datum/skills/pfc

--- a/code/modules/gear_presets/wy.dm
+++ b/code/modules/gear_presets/wy.dm
@@ -3,7 +3,7 @@
 	paygrades = list(PAY_SHORT_WYC1 = JOB_PLAYTIME_TIER_0)
 
 	faction = FACTION_WY
-	rank = FACTION_WY
+	job_title = FACTION_WY
 	idtype = /obj/item/card/id/silver
 	faction_group = FACTION_LIST_WY
 	skills = /datum/skills/civilian
@@ -34,7 +34,7 @@
 	name = "Corporate - A - Trainee"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_TRAINEE
-	rank = JOB_TRAINEE
+	job_title = JOB_TRAINEE
 	minimap_icon = "trainee"
 	paygrades = list(PAY_SHORT_WYC1 = JOB_PLAYTIME_TIER_0)
 
@@ -46,7 +46,7 @@
 	name = "Corporate - B - Junior Executive"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_JUNIOR_EXECUTIVE
-	rank = JOB_JUNIOR_EXECUTIVE
+	job_title = JOB_JUNIOR_EXECUTIVE
 	minimap_icon = "junior_exec"
 	paygrades = list(PAY_SHORT_WYC2 = JOB_PLAYTIME_TIER_0)
 
@@ -54,14 +54,14 @@
 	name = "Corporate - C - Executive"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_EXECUTIVE
-	rank = JOB_EXECUTIVE
+	job_title = JOB_EXECUTIVE
 	paygrades = list(PAY_SHORT_WYC3 = JOB_PLAYTIME_TIER_0)
 
 /datum/equipment_preset/wy/senior_exec
 	name = "Corporate - D - Senior Executive"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_SENIOR_EXECUTIVE
-	rank = JOB_SENIOR_EXECUTIVE
+	job_title = JOB_SENIOR_EXECUTIVE
 	minimap_icon = "senior_exec"
 	paygrades = list(PAY_SHORT_WYC4 = JOB_PLAYTIME_TIER_0)
 
@@ -69,14 +69,14 @@
 	name = "Corporate - E - Executive Specialist"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_EXECUTIVE_SPECIALIST
-	rank = JOB_EXECUTIVE_SPECIALIST
+	job_title = JOB_EXECUTIVE_SPECIALIST
 	minimap_icon = "exec_spec"
 	paygrades = list(PAY_SHORT_WYC5 = JOB_PLAYTIME_TIER_0)
 
 /datum/equipment_preset/wy/exec_spec/lawyer
 	name = "Corporate - E - Lawyer"
 	assignment = JOB_LEGAL_SPECIALIST
-	rank = JOB_LEGAL_SPECIALIST
+	job_title = JOB_LEGAL_SPECIALIST
 
 /datum/equipment_preset/wy/exec_spec/lawyer/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/WY(new_human), WEAR_L_EAR)
@@ -94,14 +94,14 @@
 	name = "Corporate - F - Executive Supervisor"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_EXECUTIVE_SUPERVISOR
-	rank = JOB_EXECUTIVE_SUPERVISOR
+	job_title = JOB_EXECUTIVE_SUPERVISOR
 	minimap_icon = "exec_super"
 	paygrades = list(PAY_SHORT_WYC6 = JOB_PLAYTIME_TIER_0)
 
 /datum/equipment_preset/wy/exec_supervisor/lawyer
 	name = "Corporate - F - Lawyer"
 	assignment = JOB_LEGAL_SUPERVISOR
-	rank = JOB_LEGAL_SUPERVISOR
+	job_title = JOB_LEGAL_SUPERVISOR
 
 /datum/equipment_preset/wy/exec_supervisor/lawyer/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/WY(new_human), WEAR_L_EAR)
@@ -137,7 +137,7 @@
 	name = "Corporate - G - Assistant Manager"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_ASSISTANT_MANAGER
-	rank = JOB_ASSISTANT_MANAGER
+	job_title = JOB_ASSISTANT_MANAGER
 	minimap_icon = "ass_man"
 	paygrades = list(PAY_SHORT_WYC7 = JOB_PLAYTIME_TIER_0)
 
@@ -145,7 +145,7 @@
 	name = "Corporate - H - Division Manager"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_DIVISION_MANAGER
-	rank = JOB_DIVISION_MANAGER
+	job_title = JOB_DIVISION_MANAGER
 	minimap_icon = "div_man"
 	paygrades = list(PAY_SHORT_WYC8 = JOB_PLAYTIME_TIER_0)
 
@@ -153,7 +153,7 @@
 	name = "Corporate - I - Chief Executive"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_CHIEF_EXECUTIVE
-	rank = JOB_CHIEF_EXECUTIVE
+	job_title = JOB_CHIEF_EXECUTIVE
 	minimap_icon = "chief_man"
 	paygrades = list(PAY_SHORT_WYC9 = JOB_PLAYTIME_TIER_0)
 
@@ -165,7 +165,7 @@
 	name = "Corporate - J - Deputy Director"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_DEPUTY_DIRECTOR
-	rank = JOB_DEPUTY_DIRECTOR
+	job_title = JOB_DEPUTY_DIRECTOR
 	minimap_icon = "dep_director"
 	paygrades = list(PAY_SHORT_WYC10 = JOB_PLAYTIME_TIER_0)
 	gun_type = /obj/item/storage/belt/gun/m4a3/heavy/co_golden
@@ -174,7 +174,7 @@
 	name = "Corporate - K - Director"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_DIRECTOR
-	rank = JOB_DIRECTOR
+	job_title = JOB_DIRECTOR
 	minimap_icon = "director"
 	paygrades = list(PAY_SHORT_WYC11 = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/civilian/manager/director
@@ -198,7 +198,7 @@
 	name = "Weyland-Yutani Security Guard"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = JOB_WY_SEC
-	rank = JOB_WY_SEC
+	job_title = JOB_WY_SEC
 	paygrades = list(PAY_SHORT_CPO = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/wy_goon
 	minimap_background = "background_goon"

--- a/code/modules/gear_presets/wy_commandos.dm
+++ b/code/modules/gear_presets/wy_commandos.dm
@@ -2,7 +2,7 @@
 /datum/equipment_preset/pmc/commando
 	name = "WY-Commandos"
 	faction = FACTION_PMC
-	rank = FACTION_PMC
+	job_title = FACTION_PMC
 	idtype = /obj/item/card/id/pmc/commando
 	headset_type = /obj/item/device/radio/headset/distress/pmc/commando
 	faction = FACTION_PMC
@@ -15,7 +15,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_WY_COMMANDO_STANDARD
-	rank = JOB_WY_COMMANDO_STANDARD
+	job_title = JOB_WY_COMMANDO_STANDARD
 	minimap_icon = "pmc_gun"
 	paygrades = list(PAY_SHORT_WY_COM = JOB_PLAYTIME_TIER_0)
 
@@ -67,7 +67,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_WY_COMMANDO_GUNNER
-	rank = JOB_WY_COMMANDO_GUNNER
+	job_title = JOB_WY_COMMANDO_GUNNER
 	minimap_icon = "pmc_sg"
 	skills = /datum/skills/pmc/commando/gunner
 	paygrades = list(PAY_SHORT_WY_GUN = JOB_PLAYTIME_TIER_0)
@@ -117,7 +117,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_WY_COMMANDO_LEADER
-	rank = JOB_WY_COMMANDO_LEADER
+	job_title = JOB_WY_COMMANDO_LEADER
 	minimap_icon = "pmc_ld"
 	skills = /datum/skills/pmc/commando/leader
 	paygrades = list(PAY_SHORT_WY_COMLD = JOB_PLAYTIME_TIER_0)
@@ -189,7 +189,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_WY_COMMANDO_DOGCATHER
-	rank = JOB_WY_COMMANDO_DOGCATHER
+	job_title = JOB_WY_COMMANDO_DOGCATHER
 	paygrades = list(PAY_SHORT_WY_DOG = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "DOG"
 	minimap_icon = "dogcather"

--- a/code/modules/gear_presets/wy_goons.dm
+++ b/code/modules/gear_presets/wy_goons.dm
@@ -1,7 +1,7 @@
 /datum/equipment_preset/goon
 	name = "WY Goons"
 	faction = FACTION_WY
-	rank = FACTION_WY
+	job_title = FACTION_WY
 	idtype = /obj/item/card/id/silver/cl
 	faction_group = list(FACTION_WY)
 	languages = list(LANGUAGE_ENGLISH, LANGUAGE_JAPANESE)
@@ -64,7 +64,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_WY_GOON
-	rank = JOB_WY_GOON
+	job_title = JOB_WY_GOON
 	paygrades = list(PAY_SHORT_CPO = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/wy_goon
 	minimap_icon = "goon_standard"
@@ -146,7 +146,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_WY_GOON_TECH
-	rank = JOB_WY_GOON_TECH
+	job_title = JOB_WY_GOON_TECH
 	paygrades = list(PAY_SHORT_CPO = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/wy_goon_tech
 	minimap_icon = "goon_engi"
@@ -193,7 +193,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_WY_GOON_MEDIC
-	rank = JOB_WY_GOON_MEDIC
+	job_title = JOB_WY_GOON_MEDIC
 	paygrades = list(PAY_SHORT_CPO = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/wy_goon_medic
 	minimap_icon = "goon_med"
@@ -251,7 +251,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_WY_GOON_LEAD
-	rank = JOB_WY_GOON_LEAD
+	job_title = JOB_WY_GOON_LEAD
 	paygrades = list(PAY_SHORT_CSPO = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/wy_goon_lead
 	minimap_icon = "goon_leader"
@@ -334,7 +334,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_WY_RESEARCHER
-	rank = JOB_WY_RESEARCHER
+	job_title = JOB_WY_RESEARCHER
 	paygrades = list(PAY_SHORT_CDOC = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/researcher
 	minimap_icon = "goon_sci"
@@ -380,7 +380,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	assignment = JOB_WY_RESEARCH_LEAD
-	rank = JOB_WY_RESEARCH_LEAD
+	job_title = JOB_WY_RESEARCH_LEAD
 	paygrades = list(PAY_SHORT_CCMO = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/researcher
 	minimap_icon = "goon_sci_lead"

--- a/code/modules/gear_presets/yautja.dm
+++ b/code/modules/gear_presets/yautja.dm
@@ -2,7 +2,7 @@
 	name = "Yautja"
 	idtype = null //No IDs for Yautja!
 	languages = list(LANGUAGE_YAUTJA)
-	rank = "Predator"
+	job_title = "Predator"
 	faction = FACTION_YAUTJA
 	faction_group = FACTION_LIST_YAUTJA
 	uses_special_name = TRUE
@@ -24,7 +24,7 @@
 		new_human.skin_color = mob_client.prefs.predator_skin_color
 
 /datum/equipment_preset/yautja/load_id(mob/living/carbon/human/new_human)
-	new_human.job = rank
+	new_human.job = job_title
 	new_human.faction = faction
 	new_human.faction_group = faction_group
 
@@ -144,7 +144,7 @@
 /datum/equipment_preset/yautja/non_wl //For hunting grounds ONLY
 	name = "Yautja Young (non-WL)"
 	minimap_icon = "predator_young"
-	rank = "Young Blood"
+	job_title = "Young Blood"
 	faction = FACTION_YAUTJA_YOUNG
 	flags = EQUIPMENT_PRESET_START_OF_ROUND
 
@@ -156,7 +156,7 @@
 /datum/equipment_preset/yautja/non_wl_leader //The "leader" of the group if a WL player is not on
 	name = "Yautja Youngblood pack leader (non-WL)"
 	minimap_icon = "predator_young"
-	rank = "Young Blood"
+	job_title = "Young Blood"
 	faction = FACTION_YAUTJA_YOUNG
 	flags = EQUIPMENT_PRESET_START_OF_ROUND
 


### PR DESCRIPTION

# About the pull request

Changes the back-end for manifest interaction from job equipment presets.

# Explain why it's good for the game

Makes things easier to customise presentation.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
code: Changed the backend of crew manifest labelling from equipment presets.
/:cl:
