### PR TITLE
Allows the honorable yautja to wear accessories

### DIFF
--- a/code/modules/cm_preds/yaut_items.dm
+++ b/code/modules/cm_preds/yaut_items.dm
@@ -59,7 +59,7 @@ GLOBAL_VAR_INIT(hunt_timer_yautja, 0)
 	)
 	unacidable = TRUE
 	item_state_slots = list(WEAR_JACKET = "halfarmor1")
-	valid_accessory_slots = list(ACCESSORY_SLOT_ARMOR_A, ACCESSORY_SLOT_ARMOR_L, ACCESSORY_SLOT_ARMOR_S, ACCESSORY_SLOT_ARMOR_M, ACCESSORY_SLOT_TROPHY)
+	valid_accessory_slots = list(ACCESSORY_SLOT_MEDAL, ACCESSORY_SLOT_RANK, ACCESSORY_SLOT_DECOR, ACCESSORY_SLOT_PONCHO, ACCESSORY_SLOT_MASK, ACCESSORY_SLOT_ARMBAND, ACCESSORY_SLOT_ARMOR_A, ACCESSORY_SLOT_ARMOR_L, ACCESSORY_SLOT_ARMOR_S, ACCESSORY_SLOT_ARMOR_M, ACCESSORY_SLOT_UTILITY, ACCESSORY_SLOT_PATCH, ACCESSORY_SLOT_TROPHY)
 	var/thrall = FALSE//Used to affect icon generation.
 	fire_intensity_resistance = 10
 	black_market_value = 100
@@ -155,6 +155,8 @@ GLOBAL_VAR_INIT(hunt_timer_yautja, 0)
 	flags_item = ITEM_PREDATOR
 	unacidable = TRUE
 	var/councillor_override = FALSE
+	worn_accessory_slot = ACCESSORY_SLOT_PONCHO
+	can_become_accessory = TRUE
 
 /obj/item/clothing/yautja_cape/Initialize(mapload, new_color = "#654321")
 	. = ..()
@@ -278,6 +280,7 @@ GLOBAL_VAR_INIT(hunt_timer_yautja, 0)
 	has_sensor = UNIFORM_HAS_SENSORS
 	siemens_coefficient = 0.9
 	min_cold_protection_temperature = ICE_PLANET_MIN_COLD_PROT
+	valid_accessory_slots = list(ACCESSORY_SLOT_DEFAULT, ACCESSORY_SLOT_TIE, ACCESSORY_SLOT_PATCH, ACCESSORY_SLOT_STORAGE, ACCESSORY_SLOT_UTILITY, ACCESSORY_SLOT_ARMBAND, ACCESSORY_SLOT_RANK, ACCESSORY_SLOT_DECOR, ACCESSORY_SLOT_MEDAL, ACCESSORY_SLOT_ARMOR_C, ACCESSORY_SLOT_WRIST_L, ACCESSORY_SLOT_WRIST_R, ACCESSORY_SLOT_MASK, ACCESSORY_SLOT_TROPHY)
 
 	armor_melee = CLOTHING_ARMOR_LOW
 	armor_bullet = CLOTHING_ARMOR_MEDIUMLOW
@@ -291,7 +294,6 @@ GLOBAL_VAR_INIT(hunt_timer_yautja, 0)
 /obj/item/clothing/under/chainshirt/hunter
 	name = "body mesh"
 	desc = "A set of very fine chainlink in a meshwork for comfort and utility."
-	valid_accessory_slots = list(ACCESSORY_SLOT_TROPHY)
 
 	armor_melee = CLOTHING_ARMOR_LOW
 	armor_bullet = CLOTHING_ARMOR_MEDIUM


### PR DESCRIPTION
# About the pull request

Title, also allows their capes to be converted into an accessory
No longer will you have to be forced to be dripless while being a predator

# Explain why it's good for the game

Assumed request for this to happen, not like theres anything wrong with giving them more accessory slots under the pretext that theyre salvaged trophies, or whatever

# Testing Photographs and Procedure
Yes, due to how its coded, the icons look weird in the inventory since it inherits from its predecessor, fix will be eventually, just not on this PR
![image](https://github.com/user-attachments/assets/af1e2fd6-d4cf-4384-bc63-f9b2566f798d)



# Changelog
:cl:
add: Yautja capes can now be converted into accessories
fix: Yautja clothings can hold more accessories
/:cl:
