### PR TITLE
Prevents C4 and breaching charges from sticking to dense fog.

### DIFF
--- a/code/game/objects/items/explosives/plastic.dm
+++ b/code/game/objects/items/explosives/plastic.dm
@@ -209,10 +209,6 @@
 			to_chat(user, SPAN_WARNING("You are unable to stick [src] to [W]!"))
 			return FALSE
 
-	if(istype(target, /obj/structure/blocker/fog))
-		to_chat(user, SPAN_WARNING("You cannot plant [name] on [target]!"))
-		return FALSE
-
 	if(istype(target, /obj/structure/window))
 		var/obj/structure/window/W = target
 		if(W.not_damageable)
@@ -350,10 +346,6 @@
 
 	if(target.explo_proof)
 		to_chat(user, SPAN_WARNING("[name] would do nothing to [target]!"))
-		return FALSE
-
-	if(istype(target, /obj/structure/blocker/fog))
-		to_chat(user, SPAN_WARNING("You are unable to stick to [target]."))
 		return FALSE
 
 	if(SSinterior.in_interior(target))// vehicle checks again JUST IN CASE

--- a/code/game/objects/items/explosives/plastic.dm
+++ b/code/game/objects/items/explosives/plastic.dm
@@ -209,6 +209,10 @@
 			to_chat(user, SPAN_WARNING("You are unable to stick [src] to [W]!"))
 			return FALSE
 
+	if(istype(target, /obj/structure/blocker/fog))
+		to_chat(user, SPAN_WARNING("You cannot plant [name] on [target]!"))
+		return FALSE
+
 	if(istype(target, /obj/structure/window))
 		var/obj/structure/window/W = target
 		if(W.not_damageable)
@@ -346,6 +350,10 @@
 
 	if(target.explo_proof)
 		to_chat(user, SPAN_WARNING("[name] would do nothing to [target]!"))
+		return FALSE
+
+	if(istype(target, /obj/structure/blocker/fog))
+		to_chat(user, SPAN_WARNING("You are unable to stick to [target]."))
 		return FALSE
 
 	if(SSinterior.in_interior(target))// vehicle checks again JUST IN CASE

--- a/code/game/objects/structures/blocker.dm
+++ b/code/game/objects/structures/blocker.dm
@@ -5,6 +5,7 @@
 	anchored = TRUE
 	unacidable = TRUE
 	unslashable = TRUE
+	explo_proof = TRUE
 	icon = 'icons/landmarks.dmi'
 	icon_state = "map_blocker"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes #9382 by adding fog to the things that cannot have a C4/Custom C4 stuck on them. 
Also added that to breaching charges and their non-lethal/plasma variants.

Tested on LV's roundstart fog and LV-522's fog.

# Explain why it's good for the game

Bugs bad, so is denying the laws of physics and sticking something to GASES.


# Testing Photographs and Procedure

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

![Capture d'écran 2025-06-05 201937](https://github.com/user-attachments/assets/e4335634-8d89-4079-a798-ad60faa1bd15)

![Capture d'écran 2025-06-05 202915](https://github.com/user-attachments/assets/7f26faca-8aeb-43e7-b32a-07f22535646a)


</details>


# Changelog

:cl:
fix: Fix being able to put C4 / Custom C4 / Breaching charges / Non-lethal breaching charges / Plasma breaching charges to dense fog.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
