### PR TITLE
Changes SADAR loader pamphlet

### DIFF
--- a/code/modules/character_traits/skills.dm
+++ b/code/modules/character_traits/skills.dm
@@ -100,9 +100,9 @@
 
 /datum/character_trait/skills/loader
 	trait_name = "Loader Training"
-	trait_desc = "Boosts the endurance skill by 1."
-	skill = SKILL_ENDURANCE
-	skill_cap = SKILL_ENDURANCE_TRAINED
+	trait_desc = "Boosts the engineering skill by 1."
+	skill = SKILL_ENGINEER
+	skill_cap = SKILL_ENGINEER_NOVICE
 	skill_increment = 1
 
 /datum/character_trait/skills/mortar


### PR DESCRIPTION
# About the pull request
Changes the loader instructional pamphlet from giving endurance level 2 to engineering level 1.
closes #9440

# Explain why it's good for the game
Marines constantly ask for this pamphlet because of the strong stat boost with no intention of playing the role, engineering level 1 lets the loader use the c4 that comes with their kit. 


# Testing Photographs and Procedure
3 line change
# Changelog

:cl:
balance: loader pamphlet now gives engineering level 1
/:cl:

