### PR TITLE
tweak: Xeno can be fed with more types of food

### DIFF
--- a/code/game/objects/items/reagent_containers/food/cans.dm
+++ b/code/game/objects/items/reagent_containers/food/cans.dm
@@ -132,7 +132,7 @@
 
 		playsound(M.loc, consume_sound, 15, 1)
 		return 1
-	else if( istype(M, /mob/living/carbon/human) )
+	else if( istype(M, /mob/living/carbon) )
 		if (!open)
 			to_chat(user, SPAN_NOTICE("You need to open the [object_fluff]!"))
 			return

--- a/code/game/objects/items/reagent_containers/food/condiment.dm
+++ b/code/game/objects/items/reagent_containers/food/condiment.dm
@@ -22,7 +22,7 @@
 	if(M == user)
 		to_chat(M, SPAN_NOTICE("You swallow some of contents of [src]."))
 
-	else if(istype(M, /mob/living/carbon/human))
+	else if(istype(M, /mob/living/carbon))
 		user.affected_message(M,
 			SPAN_HELPFUL("You <b>start feeding</b> [user == M ? "yourself" : "[M]"] <b>[src]</b>."),
 			SPAN_HELPFUL("[user] <b>starts feeding</b> you <b>[src]</b>."),

--- a/code/game/objects/items/reagent_containers/food/drinks.dm
+++ b/code/game/objects/items/reagent_containers/food/drinks.dm
@@ -40,7 +40,7 @@
 
 		playsound(M.loc,'sound/items/drink.ogg', 15, 1)
 		return TRUE
-	else if(istype(M, /mob/living/carbon/human))
+	else if(istype(M, /mob/living/carbon))
 
 		user.affected_message(M,
 			SPAN_HELPFUL("You <b>start feeding</b> [user == M ? "yourself" : "[M]"] <b>[src]</b>."),


### PR DESCRIPTION

# About the pull request
Xenomorphs can be fed with any /obj/item/reagent_container/food/snacks, so why not remove the restriction on the ability to consume other types of food/drink for xenomorphs?
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
**Xeno can drink beer! Its cool!**
# Testing Photographs and Procedure
below
<details>
<summary>Screenshots & Videos</summary>

https://github.com/user-attachments/assets/addd1724-c8d9-490e-91d5-1e9d5853e319


</details>


# Changelog
:cl:
add: Xeno can be fed with any type of food
/:cl:
