### PR TITLE
Tweaks the mortars ranges

### DIFF
--- a/code/modules/cm_marines/equipment/mortar/mortars.dm
+++ b/code/modules/cm_marines/equipment/mortar/mortars.dm
@@ -35,9 +35,9 @@
 	/// if true, blows up the shell immediately
 	var/ship_side = FALSE
 	/// The max range the mortar can fire at
-	var/max_range = 75
+	var/max_range = 56
 	/// The min range the mortar can fire at
-	var/min_range = 14
+	var/min_range = 15
 	/// True if in lase mode, else in coordinate mode
 	var/lase_mode = FALSE
 	/// Used for lase mode aiming, busy but not used by someone else.

--- a/code/modules/cm_marines/equipment/mortar/mortars.dm
+++ b/code/modules/cm_marines/equipment/mortar/mortars.dm
@@ -35,7 +35,7 @@
 	/// if true, blows up the shell immediately
 	var/ship_side = FALSE
 	/// The max range the mortar can fire at
-	var/max_range = 56
+	var/max_range = 64
 	/// The min range the mortar can fire at
 	var/min_range = 15
 	/// True if in lase mode, else in coordinate mode

--- a/code/modules/cm_marines/equipment/mortar/mortars.dm
+++ b/code/modules/cm_marines/equipment/mortar/mortars.dm
@@ -37,7 +37,7 @@
 	/// The max range the mortar can fire at
 	var/max_range = 75
 	/// The min range the mortar can fire at
-	var/min_range = 25
+	var/min_range = 14
 	/// True if in lase mode, else in coordinate mode
 	var/lase_mode = FALSE
 	/// Used for lase mode aiming, busy but not used by someone else.


### PR DESCRIPTION
# About the pull request

Title.

# Explain why it's good for the game

Currently, the mortar is a bit intrusive to use, even especially on the front due to its minimum range requirements since it requires three and roughly a quarter screens to use properly meaning if you are the sole user, you are forced to be at constant pace back and forth relazing and recalculating on the go.

I personally think that lowering it to at least 2 screens worth still allows for more legroom, while also not a pain to utilize during FOB sieges, with the constant repositioning that it currently requires for it.

Max range is also lowered to compensate

# Testing Photographs and Procedure
Line change.

# Changelog

:cl:
balance: Mortar minimum range is lowered from 25 to 15, maximum range from 75 to 64
/:cl:
