### PR TITLE
removes queen screech and neuro off ovi

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -344,7 +344,6 @@
 		/datum/action/xeno_action/onclick/send_thoughts,
 		/datum/action/xeno_action/activable/info_marker/queen,
 		/datum/action/xeno_action/activable/xeno_spit/queen_macro, //third macro
-		/datum/action/xeno_action/onclick/shift_spits,
 		//second macro
 	)
 


### PR DESCRIPTION

# About the pull request

removes queen screech neuro from queen that is off ovi. having so much power in one hand of one player harms the entire game. The benefits to the game are extensive

# Explain why it's good for the game

Aperently captures are supposed to be hard for xenos to pull off, this goes in that direction. Also aims in making the general xeno and marine experience more enjoyable (mind you, I think this will benefit general xeno experience more then marine)

how is it good:
1) lets the power be more evenly distributed among the hive rather then in hands of one players that can alone decide if the entire side wins or looses

2) keeps queen on ovi more, resoulting in other players having more option to evolve and enjoy the game, being stuck as t1 forever as queen screech carries the game so you know she will not ovi till the point that game is over just makes joining as xeno suck, unless you want to be just t1. One player power should not make the rest of their teamamtes feal weak and useless. (the no evo never outbalanced screech, you can win with queen and all t1s, when given enough good t1s and competent queen)

3) raises stakes for playing normal xeno, you can not longer suicide thinking that queen will just carry and get everyone respawned with few screech captures, you have to try and fight hard for the win as common xeno

4) shifts queen into command role rather then combat "support" role . if you do not enjoy being ovi queen that is too bad, XO also does not get thermobaric rocket launcher on deploy and people play XO with way last powers then queen on ovi

5) makes capturing hard, if we are to make capturing hard keeping around ability that can in single use resoults in 1 - 3 captures just goes agains the spirit 

6) possibly allows marines to perform more advanced manuvers then ungaball as there will no longer be the super certain threat that the entirity of small separate force gets stunned and destroyed with no chance to react

7) hopefuly turns queens into leaders, queen already has more tools to command then marine CIC with markers, live tacmap for all xenos, easily designated targets, nonstop comms and queen announcements, easy to use overwatch and free to move cammera around with full nightvision on all of that

8) makes game more lore accurate, queen leaving oviposition is supposed to be desparate last resort and never happens in lore unless the rest of the hive is basicly wiped out (who cares the above makes game more fun for both sides and that is priority)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: removes queen screech and neurotoxin from queen
/:cl:
