### PR TITLE
About the pull request

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Evolution.dm
@@ -263,7 +263,7 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 		to_chat(src, SPAN_WARNING("We must be at full health to evolve."))
 		return FALSE
 
-	if(agility || fortify || crest_defense)
+	if(agility || fortify || crest_defense || stealth)
 		to_chat(src, SPAN_WARNING("We cannot evolve while in this stance."))
 		return FALSE
 


### PR DESCRIPTION
To prevent lurkers from being able to evolve while invisible/stealthed.
I believe that this was probably not intended originally.

# Explain why it's good for the game

A lurker being able to go invisible, jump into a crowd of marines and lie down, then evolve into a Ravager, popping out of thin air to cause sudden havoc in the middle of marines is probably a little unfair feeling. Additionally, the fact that lurkers cannot take on a strain while invisible suggests that the original intention was for the lurker to be unable to make major modifications while stealthed, which should probably include evolving.

# Changelog

:cl:
balance: Lurkers can no longer evolve whilst invisible
/:cl: