### PR TITLE
Single monkey burst

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Embryo.dm
@@ -253,7 +253,7 @@
 
 	if(hive)
 		hive.add_xeno(new_xeno)
-		if(!affected_mob.first_xeno && hive.hive_location)
+		if(!affected_mob.first_xeno && hive.hive_location && !ismonkey(affected_mob))
 			hive.increase_larva_after_burst(is_nested)
 			hive.hive_ui.update_burrowed_larva()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR is a follow up to #9412 simply making it so monkeys are unaffected by the additional burst configs.

Related: #9552 

# Explain why it's good for the game

Xenos don't need much help early game with numbers, but also monkeys should almost never have a client in them (only if an admin some reason puts a client into one) so even without a double burst, the larva queue will always move when a monkey bursts (unlike the situation with a survivor/marine where larva queue w/o double burst will only move if the original client or player facehugger didn't take dibs). Monkeys also never would really resist a capture either unlike a marine/survivor.

I'm not terribly interested in making it so survivors don't double burst though. I don't see any reason why they would be different from a marine host. If they actually prove to be a problem giving too many xenos pre-drop I would sooner explore giving survivors better skills or spawn in lower numbers.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Drathek
balance: Monkey hosts now are single spawns.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
