### PR TITLE
Another labeler fix

### DIFF
--- a/code/datums/components/label.dm
+++ b/code/datums/components/label.dm
@@ -60,11 +60,12 @@
 	if(!istype(labeler) || labeler.mode)
 		return
 
-	log_admin("[key_name(usr)] has removed label from [parent].")
-	user.visible_message(SPAN_NOTICE("[user] removes label from [parent]."),
-						SPAN_NOTICE("You remove the label from [parent]."))
-	clear_label()
-	playsound(parent, 'sound/items/poster_ripped.ogg', 20, TRUE)
+	if(has_label())
+		log_admin("[key_name(usr)] has removed label from [parent].")
+		user.visible_message(SPAN_NOTICE("[user] removes label from [parent]."),
+							SPAN_NOTICE("You remove the label from [parent]."))
+		clear_label()
+		playsound(parent, 'sound/items/poster_ripped.ogg', 20, TRUE)
 	qdel(src) // Remove the component from the object.
 
 /**

--- a/code/game/objects/items/tools/misc_tools.dm
+++ b/code/game/objects/items/tools/misc_tools.dm
@@ -68,9 +68,9 @@
 		return
 
 	var/datum/component/label/labelcomponent = A.GetComponent(/datum/component/label)
-	if(labelcomponent)
+	if(labelcomponent && labelcomponent.has_label())
 		if(labelcomponent.label_name == label)
-			to_chat(user, SPAN_WARNING("It already has the same label."))
+			to_chat(user, SPAN_WARNING("The label already says \"[label]\"."))
 			return
 
 	user.visible_message(SPAN_NOTICE("[user] labels [A] as \"[label]\"."),


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #9428 to add a couple more needed usages of has_label. Basically since we rarely ever qdel the label component, when a label is cleared the component still knows what the old label was and this was preventing a cleared label to block a new label with the same name.

# Explain why it's good for the game
Fixes #9556 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/sSWyEMwfyoI

</details>


# Changelog
:cl: Drathek
fix: Fixed a cleared label preventing new a label if it was the same as the last label
/:cl:
