### PR TITLE
Helps new players understand hivemind collapse.

### DIFF
--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -446,7 +446,7 @@
 				continue
 
 			if(!hive.living_xeno_queen && hive.xeno_queen_timer < world.time)
-				xeno_message("The Hive is ready for a new Queen to evolve.", 3, hive.hivenumber)
+				xeno_message("The Hive is ready for a new Queen to evolve. The hive can only survive for a limited time without a queen!", 3, hive.hivenumber)
 
 		if(!active_lz && world.time > lz_selection_timer)
 			select_lz(locate(/obj/structure/machinery/computer/shuttle/dropship/flight/lz1))


### PR DESCRIPTION

# About the pull request

Adds text telling players that a queen needs to evolve or the hive cannot survive much longer.

# Explain why it's good for the game

The game ending due to hivemind collapse (no queen for a certain amount of time) is a very strange concept for many players, especially newbies. We might as well warn players that a queen needs to evolve soon or the hive won't survive.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: give hint regarding impending game end due to hivemind collapse
/:cl:
