### PR TITLE
Removes stun from a Marine when a Xeno chooses to un-haul them.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -454,8 +454,6 @@
 	SPAN_XENOWARNING("We release [user] from our grip!"), null, 5)
 	playsound(src, 'sound/voice/alien_growl1.ogg', 15)
 	log_interact(src, user, "[key_name(src)] released [key_name(user)] at [get_area_name(loc)]")
-	if(stuns)
-		user.adjust_effect(2, STUN)
 	UnregisterSignal(user, COMSIG_MOB_DEATH)
 	UnregisterSignal(src, COMSIG_ATOM_DIR_CHANGE)
 	hauled_mob = null


### PR DESCRIPTION
# About the pull request
Removes the two second stun given to a marine when they are dropped from haul by the player.

# Explain why it's good for the game
Bringing attention to an oversight to https://github.com/cmss13-devs/cmss13/pull/9412, where you can bypass the no tunnel balance by being able to infinitely stun someone by dropping and tackling spam due to the two second stun given.

Seems silly that when a marine breaks out, or if the timer runs out naturally, the marine gets no stun, but if the player chooses to drop the marine they get a free two seconds to get at least 3 tackles in (4 if they're a runner). 

I also believe letting a hugged marine instantly able to fight back once dropped in hive is in line with Drathek's original intention with the PR, with having to take into account if bringing a marine who's hugger stun has worn off to the hive can lead to abandonment or needing teamwork for potentially dangerous hosts. Also, queen screech will nullify any resistance, and gives a heightened importance of queen being inside the hive to deal with hosts.

I can add back the stun to have 0.2 seconds or a small number under 0.5 seconds to allow huggers to have a chance to attach once dropped, but seems unnecessary due to huggers being instant. (not taking player huggers into account, as they should be attaching to capable hosts that aren't already in possession of a hauled xeno, at least imo)

# Testing Photographs and Procedure
<details>

<summary>Screenshots & Videos</summary>

Idk i think it works, i cant test it alone

</details>

# Changelog
:cl: bostonthebear
balance: removes stun from choosing to un-haul
/:cl: