### PR TITLE
Oppressor Praetorian: Fixes abduction ability interaction with objects.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/oppressor.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/oppressor.dm
@@ -143,7 +143,7 @@
 				else if(cade_facing == facing)
 					allow_one_more_step = TRUE
 				continue
-			if(structure.pass_flags.flags_can_pass_all && PASS_HIGH_OVER)
+			if(structure.pass_flags.flags_can_pass_all & PASS_HIGH_OVER)
 				continue
 			blocked = TRUE
 		if(blocked)


### PR DESCRIPTION
I am not sure if this should be QoL or Balance change, so i keep it balance because it allows you to do thing that was not possible before because of wonky code.

# About the pull request
Allows Abduction ability to be casted at same tile as barricade, flipped tables and glass window panes (as long as they don't face ability casting direction), and also allows abduction to be cast trought low obstacles that contain pass_flags, such as PASS_HIGH_OVER

#  Explain why it's good for the game
As person who enjoyed playing oppressor i found it frustrating when cade was destroyed at corner, so cade facing towards you was open, but at same tile, there was another cade facing 90 degree in other direction, so when you cast ability it gets blocked, same follows for other small obstacles, its so annoying when you want to cast through tables, trays or crates and your ability get blocked by them, this change allows for abductor main ability to be more usefull.

_With this change now you can cast ability at tiles that have barricade in them as long as they dont face casting direction, same follows for flipped tables and window panes._

# Testing Photographs and Procedure
<details>
<summary>>Click Here<</summary>

Some testing done with abduct:

https://github.com/user-attachments/assets/1b0fc84d-517b-426f-b279-e6adde07abaf


https://github.com/user-attachments/assets/d2080ed4-0a05-4b7a-8d0c-851753dcbea7


https://github.com/user-attachments/assets/26c5acae-eecf-4050-bf83-d8b8d6f2ed54


https://github.com/user-attachments/assets/af0e2779-222d-41dd-a3b0-9a59be3b91f2


</details>

# Details for Reviewers.

**Need to re-type**

<details>
<summary>opressor.dm</summary>

line 117 check if tile contains any structures, if one of checks is **FALSE** it will continue to next check.

line 162 check if structure is barricade then go to 164 and attach cade direction to "cade_facing" var.

line 165 check if **cade_facing** direction faces 180^ in opposite direction of casting, for example if you cast from west to east, if cade on east is facing west (towards you) it will then trigger line 166, where it sets **"blocked = TRUE"**, preventing ability continuation.

line 167 check if **cade_facing** direction faces same direction you are casting at, for example if you cast from west to east and cade east is facing east (the direction you cast to) it will then trigger var **"allow_one_more_step = TRUE"**, afterwards it will continue to line 168, where it will check if "allow_one_more_step" is  **TRUE**, if it is, it will break code before it will reach end of turflist, thanks to that it will make hook appear at same tile as cade, but still get blocked (so you don't cast trough it).

</details>

# Changelog

:cl: Venuska1117
balance: Abduction ability can now be casted at same tile with cade, flipped table and glass window panes, as long as it doesn't face praetorian ability casting direction.
balance: Abduction ability can now be casted through smoke, such as boiler smoke, explosion smoke, and other related smoke effects.
balance: Abduction ability can now be casted through obstacles containing any group pass_flag in PASS_HIGH_OVER
fix: Abduction ability can no longer be casted through multitile vehicles.
fix: Abduction ability can no longer be casted through glass windows panes.
/:cl