### PR TITLE
M10 ammo box crafting

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -238,6 +238,10 @@ GLOBAL_LIST_INIT_TYPED(cardboard_recipes, /datum/stack_recipe, list ( \
 		new/datum/stack_recipe("empty speed loader box (M44 Heavy)", /obj/item/ammo_box/magazine/m44/heavy/empty), \
 		new/datum/stack_recipe("empty speed loader box (M44 Marksman)", /obj/item/ammo_box/magazine/m44/marksman/empty), \
 		null, \
+		new/datum/stack_recipe("empty magazine box (M10)", /obj/item/ammo_box/magazine/m10/empty), \
+		new/datum/stack_recipe("empty magazine box (M10 Ext)", /obj/item/ammo_box/magazine/m10/extended/empty), \
+		new/datum/stack_recipe("empty magazine box (M10 Drum)", /obj/item/ammo_box/magazine/m10/drum/empty), \
+		null, \
 		new/datum/stack_recipe("empty magazine box (M39)", /obj/item/ammo_box/magazine/m39/empty), \
 		new/datum/stack_recipe("empty magazine box (M39 AP)", /obj/item/ammo_box/magazine/m39/ap/empty), \
 		new/datum/stack_recipe("empty magazine box (M39 Ext)", /obj/item/ammo_box/magazine/m39/ext/empty), \

--- a/code/modules/projectiles/ammo_boxes/magazine_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/magazine_boxes.dm
@@ -270,7 +270,7 @@
 //-----------------------M10 Pistol Mag Boxes-----------------------
 
 /obj/item/ammo_box/magazine/m10
-	name = "magazine box (M10 x 12)"
+	name = "magazine box (M10 x 22)"
 	icon_state = "base_m10"
 	flags_equip_slot = SLOT_BACK
 	overlay_ammo_type = "_reg"
@@ -283,7 +283,7 @@
 	empty = TRUE
 
 /obj/item/ammo_box/magazine/m10/extended
-	name = "magazine box (Ext m10 x 10)"
+	name = "magazine box (Ext m10 x 14)"
 	overlay_ammo_type = "_ext"
 	overlay_content = "_hv"
 	num_of_magazines = 14
@@ -293,7 +293,7 @@
 	empty = TRUE
 
 /obj/item/ammo_box/magazine/m10/drum
-	name = "magazine box (Drum m10 x 10)"
+	name = "magazine box (Drum m10 x 12)"
 	overlay_ammo_type = "_drum"
 	overlay_content = "_hv"
 	num_of_magazines = 12


### PR DESCRIPTION
# About the pull request

Adds M10 ammo boxes to cardboard crafting list. Also corrects the box names to match actual sizes of the boxes.
Fixes #9576 

# Explain why it's good for the game

Was requested by a player. Also fixes inaccurate box descriptions from req vendor.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
</details>

Tested locally, able to craft.

# Changelog

:cl:
fix: M10 ammo boxes now craftable
fix: Changed ammo box names to match actual size
/:cl:
