### PR TITLE
Dropship Lock now takes 5 seconds

### DIFF
--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -300,7 +300,7 @@
 		return
 
 	// door controls being overridden
-	if(!dropship_control_lost)
+	if(!dropship_control_lost && do_after(xeno, 5 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
 		dropship.control_doors("unlock", "all", TRUE)
 		dropship_control_lost = TRUE
 		update_icon()

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -300,7 +300,7 @@
 		return
 
 	// door controls being overridden
-	if(!dropship_control_lost && do_after(xeno, 5 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
+	if(!dropship_control_lost && do_after(xeno, 3 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
 		dropship.control_doors("unlock", "all", TRUE)
 		dropship_control_lost = TRUE
 		update_icon()


### PR DESCRIPTION

# About the pull request

As title

# Explain why it's good for the game

I dislike seeing queens running in on a screech and one-click locking the dropship down then running off again. It is very frustrating to play against and to observe, and doesn't make much sense to me, especially with how long it takes to override it as a pilot.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Locking the dropship as Queen now takes 5 seconds.
/:cl:
