### PR TITLE
[Re] Add Larva & Facehugger Roar emote cooldown.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -312,6 +312,9 @@
 
 	bubble_icon = "alien"
 
+	/// Hugger and Larva emote cooldown.
+	var/last_roar_time = 0
+
 	/////////////////////////////////////////////////////////////////////
 	//
 	// Phero related vars
@@ -1138,3 +1141,12 @@
 	if(new_player.mind)
 		new_player.mind_initialize()
 		new_player.mind.transfer_to(target, TRUE)
+
+/mob/living/carbon/xenomorph/proc/roar_and_delay()
+	var/current_time = world.time
+	if(current_time - last_roar_time < 1 SECONDS)
+		to_chat(src, SPAN_WARNING("You must wait before roaring again."))
+		return FALSE
+
+	last_roar_time = current_time
+	playsound(loc, "alien_roar_larva", 15)

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -1141,12 +1141,3 @@
 	if(new_player.mind)
 		new_player.mind_initialize()
 		new_player.mind.transfer_to(target, TRUE)
-
-/mob/living/carbon/xenomorph/proc/roar_and_delay()
-	var/current_time = world.time
-	if(current_time - last_roar_time < 1 SECONDS)
-		to_chat(src, SPAN_WARNING("You must wait before roaring again."))
-		return FALSE
-
-	last_roar_time = current_time
-	playsound(loc, "alien_roar_larva", 15)

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -312,9 +312,6 @@
 
 	bubble_icon = "alien"
 
-	/// Hugger and Larva emote cooldown.
-	var/last_roar_time = 0
-
 	/////////////////////////////////////////////////////////////////////
 	//
 	// Phero related vars

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -71,6 +71,7 @@
 	var/next_facehug_goal = FACEHUG_TIER_1
 	/// Whether a hug was performed successfully
 	var/hug_successful = FALSE
+	var/last_roar_time = 0
 
 /mob/living/carbon/xenomorph/facehugger/Login()
 	var/last_ckey_inhabited = persistent_ckey

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -256,7 +256,14 @@
 		if(!client.attempt_talking())
 			return FALSE
 
-	roar_and_delay()
+	// Otherwise, ""roar""!
+	var/current_time = world.time
+	if(current_time - last_roar_time < 1 SECONDS)
+		to_chat(src, SPAN_WARNING("You must wait before roaring again."))
+		return FALSE
+
+	last_roar_time = current_time
+	playsound(loc, "alien_roar_larva", 15)
 	return TRUE
 
 /mob/living/carbon/xenomorph/facehugger/get_status_tab_items()

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -256,8 +256,7 @@
 		if(!client.attempt_talking())
 			return FALSE
 
-	// Otherwise, ""roar""!
-	playsound(loc, "alien_roar_larva", 15)
+	roar_and_delay()
 	return TRUE
 
 /mob/living/carbon/xenomorph/facehugger/get_status_tab_items()

--- a/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
@@ -196,8 +196,7 @@
 		if(!client.attempt_talking())
 			return FALSE
 
-	// Otherwise, ""roar""!
-	playsound(loc, "alien_roar_larva", 15)
+	roar_and_delay()
 	return TRUE
 
 /mob/living/carbon/xenomorph/larva/is_xeno_grabbable()

--- a/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
@@ -54,6 +54,7 @@
 	var/state_override
 	/// Whether we're bloody, normal, or mature
 	var/larva_state = LARVA_STATE_BLOODY
+	var/last_roar_time = 0
 
 	icon_xeno = 'icons/mob/xenos/castes/tier_0/larva.dmi'
 	icon_xenonid = 'icons/mob/xenonids/castes/tier_0/larva.dmi'

--- a/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
@@ -196,7 +196,14 @@
 		if(!client.attempt_talking())
 			return FALSE
 
-	roar_and_delay()
+	// Otherwise, ""roar""!
+	var/current_time = world.time
+	if(current_time - last_roar_time < 1 SECONDS)
+		to_chat(src, SPAN_WARNING("You must wait before roaring again."))
+		return FALSE
+
+	last_roar_time = current_time
+	playsound(loc, "alien_roar_larva", 15)
 	return TRUE
 
 /mob/living/carbon/xenomorph/larva/is_xeno_grabbable()


### PR DESCRIPTION
# About the pull request

Add 1 second cooldown on *roar emote for Huggers/Larvas

Re-open PR: #9362
_(closed by stale bot)_

# Explain why it's good for the game

Hate me all you want for this PR, but having your ears bombarded by Larva/Facehuggers binding and spamming *roar emote to your ear 90% time without reason is so bad, with this change you still can spam your *roar emote, but it will play sound once per second instead of how quickly you pressed button.

If you ask "why you just don't lower your volume down?" i still need to hear game like CAS incomming, OB's falling etc, i will not lower game volume for someone spamming *roar emote.

Also, when you do emote as xeno of any caste, you can do one emote every x seconds, this is mainly QoL improvement.

# Testing Photographs and Procedure

<details>
<summary>>Click Here<</summary>

How roar works after this change:

https://github.com/user-attachments/assets/5bb83e57-7c66-483c-a5f9-11d24d905306

</details>


# Changelog

:cl: Venuska1117
qol: Facehugger and Larva now get 1 sec cooldown on *roar emote.
/:cl:

