### PR TITLE
Rename `var/mob/usr` to `var/mob/user`

### DIFF
--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -149,11 +149,11 @@ Nah
 */
 
 //Allow you to drag-drop disposal pipes into it
-/obj/structure/machinery/pipedispenser/disposal/MouseDrop_T(obj/structure/disposalconstruct/pipe as obj, mob/usr as mob)
-	if(usr.is_mob_incapacitated())
+/obj/structure/machinery/pipedispenser/disposal/MouseDrop_T(obj/structure/disposalconstruct/pipe as obj, mob/user as mob)
+	if(user.is_mob_incapacitated())
 		return
 
-	if (!istype(pipe) || get_dist(usr, src) > 1 || get_dist(src,pipe) > 1 )
+	if (!istype(pipe) || get_dist(user, src) > 1 || get_dist(src,pipe) > 1 )
 		return
 
 	if (pipe.anchored)

--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -1,4 +1,4 @@
-/proc/notes_add(key, note, mob/usr)
+/proc/notes_add(key, note, mob/user)
 	if (!key || !note)
 		return
 
@@ -25,12 +25,12 @@
 	var/day_loc = findtext(full_date, time2text(world.timeofday, "DD"))
 
 	var/datum/player_info/P = new
-	if (usr)
-		P.author = usr.key
-		if(usr.client && usr.client.admin_holder && (usr.client.admin_holder.rights & R_MOD))
-			P.rank = usr.client.admin_holder.rank
+	if (user)
+		P.author = user.key
+		if(user.client && user.client.admin_holder && (user.client.admin_holder.rights & R_MOD))
+			P.rank = user.client.admin_holder.rank
 		else
-			to_chat(usr, "NA01: Something went wrong, tell a coder.")
+			to_chat(user, "NA01: Something went wrong, tell a coder.")
 			return
 	else
 		P.author = "Adminbot"
@@ -41,7 +41,7 @@
 	infos += P
 	info << infos
 
-	message_admins("[key_name_admin(usr)] has edited [key]'s notes: [sanitize(note)]")
+	message_admins("[key_name_admin(user)] has edited [key]'s notes: [sanitize(note)]")
 	qdel(info)
 
 	//Updating list of keys with notes on them


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

OpenDream is adding `usr` to the `SoftReservedKeyword` pragma: https://github.com/OpenDreamProject/OpenDream/pull/2307

This PR renames `var/mob/usr` to `var/mob/user`.

# Explain why it's good for the game
This pragma is currently set as an error in CM, because using internal var names for declared var names is cringe.


# Changelog
it's a var rename