### PR TITLE
Reconnaissance Major now spawns with their selected sidearm (standard desert eagle or standard mateba)

### DIFF
--- a/code/modules/gear_presets/survivors/lv_522/forcon_survivors.dm
+++ b/code/modules/gear_presets/survivors/lv_522/forcon_survivors.dm
@@ -264,6 +264,7 @@
 	var/sidearmammo = /obj/item/ammo_magazine/revolver/mateba
 
 	if(new_human.client && new_human.client.prefs)
+		sidearm = new_human.client.prefs.commander_sidearm
 		switch(sidearm)
 			if(CO_GUN_MATEBA)
 				sidearm = /obj/item/weapon/gun/revolver/mateba/cmateba

--- a/code/modules/gear_presets/survivors/lv_522/forcon_survivors.dm
+++ b/code/modules/gear_presets/survivors/lv_522/forcon_survivors.dm
@@ -280,11 +280,11 @@
 			if(CO_GUN_DEAGLE)
 				sidearm = /obj/item/weapon/gun/pistol/heavy/co
 				sidearmbelt = /obj/item/storage/belt/gun/m4a3
-				sidearmammo = /obj/item/ammo_magazine/pistol/heavy
+				sidearmammo = /obj/item/ammo_magazine/pistol/heavy/super
 			if(CO_GUN_DEAGLE_COUNCIL)
 				sidearm = /obj/item/weapon/gun/pistol/heavy/co
 				sidearmbelt = /obj/item/storage/belt/gun/m4a3
-				sidearmammo = /obj/item/ammo_magazine/pistol/heavy
+				sidearmammo = /obj/item/ammo_magazine/pistol/heavy/super
 
 	var/obj/item/clothing/under/marine/reconnaissance/uniform = new()
 	var/obj/item/clothing/accessory/storage/droppouch/pouch = new()

--- a/code/modules/gear_presets/survivors/lv_522/forcon_survivors.dm
+++ b/code/modules/gear_presets/survivors/lv_522/forcon_survivors.dm
@@ -264,7 +264,6 @@
 	var/sidearmammo = /obj/item/ammo_magazine/revolver/mateba
 
 	if(new_human.client && new_human.client.prefs)
-		sidearm = new_human.client.prefs.commander_sidearm
 		switch(sidearm)
 			if(CO_GUN_MATEBA)
 				sidearm = /obj/item/weapon/gun/revolver/mateba/cmateba

--- a/code/modules/gear_presets/survivors/lv_522/forcon_survivors.dm
+++ b/code/modules/gear_presets/survivors/lv_522/forcon_survivors.dm
@@ -259,6 +259,34 @@
 	dress_hat = list(/obj/item/clothing/head/marine/dress_cover/officer)
 
 /datum/equipment_preset/survivor/forecon/major/load_gear(mob/living/carbon/human/new_human)
+	var/sidearm = /obj/item/weapon/gun/revolver/mateba/cmateba
+	var/sidearmbelt = /obj/item/storage/belt/gun/mateba/cmateba
+	var/sidearmammo = /obj/item/ammo_magazine/revolver/mateba
+
+	if(new_human.client && new_human.client.prefs)
+		sidearm = new_human.client.prefs.commander_sidearm
+		switch(sidearm)
+			if(CO_GUN_MATEBA)
+				sidearm = /obj/item/weapon/gun/revolver/mateba/cmateba
+				sidearmbelt = /obj/item/storage/belt/gun/mateba/cmateba
+				sidearmammo = /obj/item/ammo_magazine/revolver/mateba
+			if(CO_GUN_MATEBA_SPECIAL)
+				sidearm = /obj/item/weapon/gun/revolver/mateba/cmateba
+				sidearmbelt = /obj/item/storage/belt/gun/mateba/cmateba
+				sidearmammo = /obj/item/ammo_magazine/revolver/mateba
+			if(CO_GUN_MATEBA_COUNCIL)
+				sidearm = /obj/item/weapon/gun/revolver/mateba/cmateba
+				sidearmbelt = /obj/item/storage/belt/gun/mateba/cmateba
+				sidearmammo = /obj/item/ammo_magazine/revolver/mateba
+			if(CO_GUN_DEAGLE)
+				sidearm = /obj/item/weapon/gun/pistol/heavy/co
+				sidearmbelt = /obj/item/storage/belt/gun/m4a3
+				sidearmammo = /obj/item/ammo_magazine/pistol/heavy
+			if(CO_GUN_DEAGLE_COUNCIL)
+				sidearm = /obj/item/weapon/gun/pistol/heavy/co
+				sidearmbelt = /obj/item/storage/belt/gun/m4a3
+				sidearmammo = /obj/item/ammo_magazine/pistol/heavy
+
 	var/obj/item/clothing/under/marine/reconnaissance/uniform = new()
 	var/obj/item/clothing/accessory/storage/droppouch/pouch = new()
 	var/obj/item/clothing/accessory/ranks/marine/o4/pin = new()
@@ -271,11 +299,11 @@
 	new_human.equip_to_slot_or_del(uniform, WEAR_BODY)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/windbreaker/windbreaker_green(new_human), WEAR_JACKET)
 	..()
-	new_human.equip_to_slot_or_del(new /obj/item/storage/belt/gun/mateba/cmateba(new_human), WEAR_WAIST)
-	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/revolver/mateba/cmateba(new_human), WEAR_R_HAND)
-	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/revolver/mateba(new_human), WEAR_IN_BELT)
-	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/revolver/mateba(new_human), WEAR_IN_BELT)
-	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/revolver/mateba(new_human), WEAR_IN_BELT)
+	new_human.equip_to_slot_or_del(new sidearmbelt(new_human), WEAR_WAIST)
+	new_human.equip_to_slot_or_del(new sidearmammo(new_human), WEAR_IN_BELT)
+	new_human.equip_to_slot_or_del(new sidearmammo(new_human), WEAR_IN_BELT)
+	new_human.equip_to_slot_or_del(new sidearmammo(new_human), WEAR_IN_BELT)
+	new_human.equip_to_slot_or_del(new sidearm(new_human), WEAR_R_HAND)
 	new_human.equip_to_slot_or_del(new /obj/item/device/binoculars/range/designator(new_human), WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/cigarette/cigar(new_human), WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/tool/lighter/zippo/gold(new_human), WEAR_IN_BACK)


### PR DESCRIPTION
# About the pull request

recon major now spawns with the deagle or mateba depending on what one they pick

# Explain why it's good for the game

some people like using a different gun for their CO
more conflict is good as well because it'll make people argue about what one is the superior choice

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
balance: FORECON major now spawns with their chosen sidearm
/:cl:
