### PR TITLE
removes hugger skipping of larva queue

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Embryo.dm
@@ -198,28 +198,6 @@
 		// Get a candidate from observers
 		var/list/candidates = get_alien_candidates(hive, abomination = (isyautja(affected_mob) || (flags_embryo & FLAG_EMBRYO_PREDATOR)))
 		if(candidates && length(candidates))
-			// If they were facehugged by a player thats still in queue, they get second dibs on the new larva.
-			if(hugger_ckey)
-				for(var/mob/dead/observer/cur_obs as anything in candidates)
-					if(cur_obs.ckey == hugger_ckey)
-						hugger = cur_obs
-						if(!is_nested)
-							cur_obs.ManualFollow(affected_mob)
-							if(cur_obs.client.prefs?.toggles_flashing & FLASH_POOLSPAWN)
-								window_flash(cur_obs.client)
-						if(is_nested || tgui_alert(cur_obs, "An unnested host you hugged is about to burst! Do you want to control the new larva?", "Larva maturation", list("Yes", "No"), 10 SECONDS) == "Yes")
-							picked = cur_obs
-							candidates -= cur_obs
-							message_alien_candidates(candidates, dequeued = 0)
-							for(var/obj/item/alien_embryo/embryo as anything in GLOB.player_embryo_list)
-								if(!embryo)
-									continue
-								if(embryo.hugger_ckey == cur_obs.ckey && embryo != src)
-									// Skipping src just in case an admin wants to quickly check before this thing fully deletes
-									// If this nulls out any embryo, wow
-									embryo.hugger_ckey = null
-						break
-
 			// Get a candidate from the front of the queue
 			if(!picked)
 				if(is_nested)


### PR DESCRIPTION

# About the pull request

removes second larva dibs from sentient hugger that hugged

# Explain why it's good for the game

If long larva queue is an issue then we should not have mechanic that allows people to skip it over those waiting longer by just hugging already basicly captured human. Makes larva queue more fair there is no good reason for people who camp at hive for incoming captures to skip people who have been waiting for long. 

The only thing you will skip is time


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
del: removes sentient hugger second dibs on larva
/:cl:
