### PR TITLE
Shooting targets expansion

### DIFF
--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -114,7 +114,7 @@
 
 /obj/structure/target/attack_hand(mob/user)
 	. = ..()
-	var/list/sorted_options = list("Very Light Target" = PRACTICE_LEVEL_LOW, "Light target" = PRACTICE_LEVEL_MEDIUM_LOW, "Standard target" = PRACTICE_LEVEL_MEDIUM, "Heavy target" = PRACTICE_LEVEL_HIGH, "Super-heavy target" = PRACTICE_LEVEL_VERY_HIGH, "Impossible" = PRACTICE_LEVEL_EXTREMELY_HIGH)
+	var/list/sorted_options = list("Very light target" = PRACTICE_LEVEL_LOW, "Light target" = PRACTICE_LEVEL_MEDIUM_LOW, "Standard target" = PRACTICE_LEVEL_MEDIUM, "Heavy target" = PRACTICE_LEVEL_HIGH, "Super-heavy target" = PRACTICE_LEVEL_VERY_HIGH, "Impossible" = PRACTICE_LEVEL_EXTREMELY_HIGH)
 	var/picked_option = tgui_input_list(user, "Select target difficulty.", "Target difficulty", sorted_options,  20 SECONDS)
 	if(picked_option)
 		practice_mode = sorted_options[picked_option]


### PR DESCRIPTION

# About the pull request

expands the target dummy functionality to immitate a bunch of xenos.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

runner
drone
warrior
crusher
queen
king

difficulty curve ^^
# Explain why it's good for the game
allowing players to test their new loadouts  or see how tough is each xeno 

also shows the importantce of AP ammo if anyone decided to shoot AP at it idk why but its there.

# Testing Photographs and Procedure
https://github.com/user-attachments/assets/cb47c87b-7110-485c-a986-a8247ab5e956

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Shooting target on target range should be more useful now.
/:cl:
