### PR TITLE
config for maintainer ooc color

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -156,6 +156,9 @@ Administrative related.
 /datum/config_entry/string/ooc_color_admin
 	config_entry_value = "#ff8000"
 
+/datum/config_entry/string/ooc_color_maint
+	config_entry_value = "#00ffff"
+
 /datum/config_entry/string/ooc_color_default
 	config_entry_value = "#b82e00"
 

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -55,6 +55,8 @@
 			display_colour = CONFIG_GET(string/ooc_color_mods)
 		if(admin_holder.rights & R_ADMIN)
 			display_colour = CONFIG_GET(string/ooc_color_admin)
+		if(admin_holder.rights & R_PROFILER)
+			display_colour  = CONFIG_GET(string/ooc_color_maint)
 		if(admin_holder.rights & R_COLOR)
 			display_colour = prefs.ooccolor
 	else if(donator)


### PR DESCRIPTION

# About the pull request

as title, stops potential confusion about responsibility/authority by adding a config for maintainer ooc color.

defaults to #00ffff like on our discord

# Explain why it's good for the game

our wokeness quota requires us add more rainbow to the ooc chat

# Changelog
:cl:
config: config added for maintainer color, maintainers being anyone with R_PROFILER. this layers above R_ADMIN color and below R_COLOR custom colors.
/:cl:

