### PR TITLE
Xeno tacmap is accessable off ovi during hijack ending + other xeno tacmap changes

### DIFF
--- a/code/__DEFINES/dcs/signals/atom/mob/living/signals_xeno.dm
+++ b/code/__DEFINES/dcs/signals/atom/mob/living/signals_xeno.dm
@@ -95,3 +95,6 @@
 
 /// From /mob/living/carbon/xenomorph/proc/do_evolve()
 #define COMSIG_XENO_EVOLVE_TO_NEW_CASTE "xeno_evolve_to_new_caste"
+
+/// From /mob/living/carbon/human/death(cause, gibbed)
+#define COMSIG_XENO_REVEAL_TACMAP "xeno_reveal_tacmap"

--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -769,9 +769,10 @@ SUBSYSTEM_DEF(minimaps)
 	if(faction == FACTION_NEUTRAL && isobserver(user))
 		faction = allowed_flags == MINIMAP_FLAG_XENO ? XENO_HIVE_NORMAL : FACTION_MARINE
 
-	if(is_xeno && xeno.hive.see_humans_on_tacmap && targeted_ztrait != ZTRAIT_MARINE_MAIN_SHIP)
+	if(is_xeno && xeno.hive.see_humans_on_tacmap)
+		if(targeted_ztrait != ZTRAIT_MARINE_MAIN_SHIP && !xeno.hive.need_round_end_check)
+			targeted_ztrait = ZTRAIT_MARINE_MAIN_SHIP
 		allowed_flags |= MINIMAP_FLAG_USCM|MINIMAP_FLAG_WY|MINIMAP_FLAG_UPP|MINIMAP_FLAG_CLF
-		targeted_ztrait = ZTRAIT_MARINE_MAIN_SHIP
 		map_holder = null
 
 	new_current_map = get_unannounced_tacmap_data_png(faction)
@@ -1048,7 +1049,7 @@ SUBSYSTEM_DEF(minimaps)
 		return UI_CLOSE
 
 	var/mob/living/carbon/xenomorph/xeno = user
-	if(!xeno.hive?.living_xeno_queen?.ovipositor)
+	if(!xeno.hive?.living_xeno_queen?.ovipositor && xeno.hive?.tacmap_requires_queen_ovi)
 		return UI_CLOSE
 
 	return UI_INTERACTIVE

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -1,6 +1,13 @@
 /mob/living/carbon/human/gib(datum/cause_data/cause = create_cause_data("gibbing", src))
 	var/is_a_synth = issynth(src)
 	ghostize()
+	var/datum/hive_status/main_hive = GLOB.hive_datum[XENO_HIVE_NORMAL]
+	var/see_humans_on_tacmap = main_hive.see_humans_on_tacmap
+	if(!see_humans_on_tacmap)
+		xeno_announcement("There is only a handful of tallhosts left, they are now visible on our hive mind map.", XENO_HIVE_NORMAL, SPAN_ANNOUNCEMENT_HEADER_BLUE("[QUEEN_MOTHER_ANNOUNCE]"))
+		main_hive.see_humans_on_tacmap = TRUE
+		main_hive.tacmap_requires_queen_ovi = FALSE
+		SEND_SIGNAL(main_hive, COMSIG_XENO_REVEAL_TACMAP)
 	for(var/obj/limb/E in limbs)
 		if(istype(E, /obj/limb/chest))
 			continue
@@ -98,6 +105,8 @@
 		if(!see_humans_on_tacmap && shipside_humans_count < (main_hive.get_real_total_xeno_count() * HIJACK_RATIO_FOR_TACMAP))
 			xeno_announcement("There is only a handful of tallhosts left, they are now visible on our hive mind map.", XENO_HIVE_NORMAL, SPAN_ANNOUNCEMENT_HEADER_BLUE("[QUEEN_MOTHER_ANNOUNCE]"))
 			main_hive.see_humans_on_tacmap = TRUE
+			main_hive.tacmap_requires_queen_ovi = FALSE
+			SEND_SIGNAL(main_hive, COMSIG_XENO_REVEAL_TACMAP)
 		if(last_living_human && shipside_humans_count == 1)
 			if((GLOB.last_qm_callout + 2 MINUTES) < world.time)
 				GLOB.last_qm_callout = world.time

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -1,13 +1,6 @@
 /mob/living/carbon/human/gib(datum/cause_data/cause = create_cause_data("gibbing", src))
 	var/is_a_synth = issynth(src)
 	ghostize()
-	var/datum/hive_status/main_hive = GLOB.hive_datum[XENO_HIVE_NORMAL]
-	var/see_humans_on_tacmap = main_hive.see_humans_on_tacmap
-	if(!see_humans_on_tacmap)
-		xeno_announcement("There is only a handful of tallhosts left, they are now visible on our hive mind map.", XENO_HIVE_NORMAL, SPAN_ANNOUNCEMENT_HEADER_BLUE("[QUEEN_MOTHER_ANNOUNCE]"))
-		main_hive.see_humans_on_tacmap = TRUE
-		main_hive.tacmap_requires_queen_ovi = FALSE
-		SEND_SIGNAL(main_hive, COMSIG_XENO_REVEAL_TACMAP)
 	for(var/obj/limb/E in limbs)
 		if(istype(E, /obj/limb/chest))
 			continue

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
@@ -535,12 +535,13 @@
 
 	hivenumber = xeno.hive.hivenumber
 	RegisterSignal(xeno.hive, COMSIG_HIVE_NEW_QUEEN, PROC_REF(handle_new_queen))
+	RegisterSignal(xeno.hive, COMSIG_XENO_REVEAL_TACMAP, PROC_REF(handle_unhide_tacmap))
 
-	if(!xeno.hive.living_xeno_queen)
+	if(!xeno.hive.living_xeno_queen && !xeno.hive.allow_no_queen_actions)
 		hide_from(xeno)
 		return
 
-	if(!xeno.hive.living_xeno_queen.ovipositor)
+	if(!xeno.hive.living_xeno_queen.ovipositor && !xeno.hive.tacmap_requires_queen_ovi)
 		hide_from(xeno)
 
 	handle_new_queen(new_queen = xeno.hive.living_xeno_queen)
@@ -574,7 +575,14 @@
 /datum/action/xeno_action/onclick/tacmap/proc/handle_dismount_ovipositor()
 	SIGNAL_HANDLER
 
-	hide_from(owner)
+	var/mob/living/carbon/xenomorph/xeno = owner
+	if(xeno.hive?.tacmap_requires_queen_ovi)
+		hide_from(owner)
+
+/datum/action/xeno_action/onclick/tacmap/proc/handle_unhide_tacmap()
+	SIGNAL_HANDLER
+
+	unhide_from(owner)
 
 /datum/action/xeno_action/onclick/tacmap/can_use_action()
 	if(!owner)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
@@ -541,7 +541,7 @@
 		hide_from(xeno)
 		return
 
-	if(!xeno.hive.living_xeno_queen.ovipositor && !xeno.hive.tacmap_requires_queen_ovi)
+	if(!xeno.hive.living_xeno_queen?.ovipositor && !xeno.hive.tacmap_requires_queen_ovi)
 		hide_from(xeno)
 
 	handle_new_queen(new_queen = xeno.hive.living_xeno_queen)

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -131,7 +131,7 @@
 
 	// Can this hive see humans on the tacmap
 	var/see_humans_on_tacmap = FALSE
-	// Does The queen need to be on ovi for xenos to see
+	// Does the queen need to be on ovi for xenos to see
 	var/tacmap_requires_queen_ovi = TRUE
 
 	var/list/available_nicknumbers = list()

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -69,8 +69,6 @@
 	/// If hit limit of larva from pylons
 	var/hit_larva_pylon_limit = FALSE
 
-	var/see_humans_on_tacmap = FALSE
-
 	var/list/hive_inherant_traits
 
 	// Cultist Info
@@ -130,6 +128,11 @@
 
 	var/datum/tacmap/drawing/xeno/tacmap
 	var/minimap_type = MINIMAP_FLAG_XENO
+
+	// Can this hive see humans on the tacmap
+	var/see_humans_on_tacmap = FALSE
+	// Does The queen need to be on ovi for xenos to see
+	var/tacmap_requires_queen_ovi = TRUE
 
 	var/list/available_nicknumbers = list()
 
@@ -1189,6 +1192,7 @@
 	allow_no_queen_evo = TRUE
 	allow_queen_evolve = FALSE
 	latejoin_burrowed = FALSE
+	tacmap_requires_queen_ovi = FALSE
 
 /datum/hive_status/forsaken
 	name = "Forsaken Hive"
@@ -1203,6 +1207,8 @@
 	allow_no_queen_evo = TRUE
 	allow_queen_evolve = FALSE
 	latejoin_burrowed = FALSE
+	see_humans_on_tacmap = TRUE
+	tacmap_requires_queen_ovi = FALSE
 
 	need_round_end_check = TRUE
 
@@ -1244,6 +1250,7 @@
 	allow_no_queen_evo = TRUE
 	allow_queen_evolve = FALSE
 	latejoin_burrowed = FALSE
+	tacmap_requires_queen_ovi = FALSE
 
 	need_round_end_check = TRUE
 
@@ -1273,6 +1280,7 @@
 	allow_no_queen_evo = TRUE
 	allow_queen_evolve = FALSE
 	latejoin_burrowed = FALSE
+	tacmap_requires_queen_ovi = FALSE
 
 	var/mob/living/carbon/human/leader
 	var/list/allied_factions

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -129,9 +129,9 @@
 	var/datum/tacmap/drawing/xeno/tacmap
 	var/minimap_type = MINIMAP_FLAG_XENO
 
-	// Can this hive see humans on the tacmap
+	/// Can this hive see humans on the tacmap
 	var/see_humans_on_tacmap = FALSE
-	// Does the queen need to be on ovi for xenos to see
+	/// Does the queen need to be on ovi for xenos to see
 	var/tacmap_requires_queen_ovi = TRUE
 
 	var/list/available_nicknumbers = list()


### PR DESCRIPTION
# About the pull request
this PR does a few things:

When the xeno:human threshold  for viewing humans on tacmap is reached (see #5278) during hijack (xenos outnumbering marines by 20%), xenos become able to view tacmap regardless of whether queen is on ovi or not 

Xeno hives that have "allow_no_queen_actions"  (feral and hellhound/yautuja) can now view tacmap. they will not be able to see humans.

Forsaken hive can now use tacmap, alongside this, they can now SEE humans on tacmap.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

By the time xenos have reached the threshold for tacmap to view humans, the majority of players are just waiting for the round to end. This will hopefully speed up the process of xenos finding the last couple marines rather than waiting for the queen to walk all the way around the ship before oviing.

For the allow_no_queen_actions hives to be able to use tacmap, I feel like this is how it always should have been? They should be able to use everything as if they had a queen.

For the forsaken buff, wandering around the map as Forsaken and wondering if there are ANY marines even groundside for 10m is the worst part. This will let you know where marines are without needing to do the whole "well, the game pinged me that the escape pod is crash landing at filtration 10 seconds before I rolled forsaken and now it's somewhat obscure whether im gonna get bwonked for ghost info by going to filtration to fight the marines I picked forsaken to fight or not". I don't think I ever got in trouble for this but it has weighed on my mind whenever I rolled forsaken.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: During hijack, xenos can now view tacmap when the queen is off ovipositor when xenos outnumber marines by 20%.
balance: Hives with "allow_no_queen_actions" (notably Feral, Yautuja, and Forsaken) hives can now always view tacmap.
balance: Forsaken hive is capable of seeing humans on tacmap.
/:cl:
