### PR TITLE
Fix a few ignored spacemandmm directives

### DIFF
--- a/code/datums/elements/_element.dm
+++ b/code/datums/elements/_element.dm
@@ -28,9 +28,9 @@
 /// Deactivates the functionality defines by the element on the given datum
 /datum/element/proc/Detach(datum/source, force)
 	SIGNAL_HANDLER
+	SHOULD_CALL_PARENT(TRUE)
 
 	SEND_SIGNAL(source, COMSIG_ELEMENT_DETACH, src)
-	SHOULD_CALL_PARENT(TRUE)
 	UnregisterSignal(source, COMSIG_PARENT_QDELETING)
 
 /datum/element/Destroy(force)

--- a/code/modules/projectiles/guns/lever_action.dm
+++ b/code/modules/projectiles/guns/lever_action.dm
@@ -135,7 +135,6 @@ their unique feature is that a direct hit will buff your damage and firerate
 /obj/item/weapon/gun/lever_action/proc/reset_hit_buff(mob/user, one_hand_lever)
 	if(!(flags_gun_lever_action & USES_STREAKS))
 		return
-	SIGNAL_HANDLER
 	streak = 0
 	lever_sound = initial(lever_sound)
 	lever_message = initial(lever_message)
@@ -504,7 +503,6 @@ their unique feature is that a direct hit will buff your damage and firerate
 /obj/item/weapon/gun/lever_action/xm88/reset_hit_buff(mob/user, one_hand_lever)
 	if(!(flags_gun_lever_action & USES_STREAKS))
 		return
-	SIGNAL_HANDLER
 	if(streak > 0)
 		to_chat(user, SPAN_WARNING("[src] beeps as it loses its targeting data, and returns to normal firing procedures."))
 	streak = 0


### PR DESCRIPTION

# About the pull request

This PR (in addition to #9762) fixes a few places where Spacemandmm directives like `SHOULD_CALL_PARENT` were doing nothing but also not emitting any warning. With https://github.com/SpaceManiac/SpacemanDMM/pull/435 they will now be errors.

# Explain why it's good for the game

Code should not merely be no-ops.

# Changelog

No player facing changes.
