### PR TITLE
fixes normal survivors spawning as synth paramedics

### DIFF
--- a/maps/bigredv2.json
+++ b/maps/bigredv2.json
@@ -7,7 +7,6 @@
     "survivor_types": [
         "/datum/equipment_preset/survivor/scientist/solaris",
         "/datum/equipment_preset/survivor/doctor/solaris",
-        "/datum/equipment_preset/synth/survivor/hybrisa/paramedic",
         "/datum/equipment_preset/survivor/chaplain/solaris",
         "/datum/equipment_preset/survivor/engineer/solaris",
         "/datum/equipment_preset/survivor/trucker/solaris",

--- a/maps/desert_dam.json
+++ b/maps/desert_dam.json
@@ -5,7 +5,6 @@
     "webmap_url": "Trijent",
     "survivor_types": [
         "/datum/equipment_preset/survivor/doctor/trijent",
-        "/datum/equipment_preset/synth/survivor/hybrisa/paramedic",
         "/datum/equipment_preset/survivor/scientist/trijent",
         "/datum/equipment_preset/survivor/roughneck",
         "/datum/equipment_preset/survivor/chaplain/trijent",

--- a/maps/lv624.json
+++ b/maps/lv624.json
@@ -7,7 +7,6 @@
     "survivor_types": [
         "/datum/equipment_preset/survivor/scientist/lv",
         "/datum/equipment_preset/survivor/doctor/lv",
-        "/datum/equipment_preset/synth/survivor/hybrisa/paramedic",
         "/datum/equipment_preset/survivor/chaplain/lv",
         "/datum/equipment_preset/survivor/engineer/lv",
         "/datum/equipment_preset/survivor/corporate/lv",


### PR DESCRIPTION

# About the pull request
oversight from #9332


# Changelog
:cl:
fix: survivors no longer randomly spawn as synth paramedics
/:cl:
