### PR TITLE
Reduces A19 high velocity impact bullet damage from 40 to 30.

### DIFF
--- a/code/datums/ammo/bullet/rifle.dm
+++ b/code/datums/ammo/bullet/rifle.dm
@@ -167,7 +167,7 @@
 	name = "A19 high velocity impact bullet"
 	flags_ammo_behavior = AMMO_BALLISTIC
 
-	damage = 40
+	damage = 30
 	accuracy = -HIT_ACCURACY_TIER_2
 	scatter = -SCATTER_AMOUNT_TIER_8
 	penetration = ARMOR_PENETRATION_TIER_10


### PR DESCRIPTION
# About the pull request

Reduces A19 high velocity impact bullet damage from 40 to 30. This addresses the current stunlock meta where these bullets deal excessive damage while maintaining high armor penetration, creating unfun instant-death scenarios.

# Explain why it's good for the game

The A19 HV bullet is currently overtuned, it combines devastating damage (40) with tier 10 armor penetration, essentially creating a "delete button" weapon that removes tactical gameplay. Players getting stunlocked and melted in seconds isn't engaging combat.
This nerf maintains the bullet's role as an armor-piercing round while preventing the bullshit instant-kill scenarios that make firefights feel like coin flips rather than skill-based encounters. 30 damage is still lethal but gives players actual time to react, take cover, and engage in meaningful tactical play instead of just getting deleted from full health.
The high penetration stays intact so it's still effective against armored targets, we're just removing the oppressive damage that makes these rounds feel broken.


# Testing Photographs and Procedure
Tested damage values in firing range against various armor types. Bullet still effectively penetrates heavy armor but no longer creates instant-death scenarios against unarmored targets.


# Changelog
:cl:
balance: reduced A19 high velocity impact bullet damage from 40 to 30 to address stunlock gameplay and promote tactical combat
/:cl: