### PR TITLE
remove upp sadar and GL spec belt from soro

### DIFF
--- a/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
+++ b/maps/map_files/Sorokyne_Strata/Sorokyne_Strata.dmm
@@ -576,7 +576,6 @@
 	pixel_x = 7;
 	pixel_y = 10;
 	emp_proof = 1;
-	explo_proof = 1;
 	name = "Checkpoint - Secure Lockdown Release Control Button - Main Door";
 	id = "checkpoint_main"
 	},
@@ -584,7 +583,6 @@
 	pixel_x = 7;
 	pixel_y = -1;
 	emp_proof = 1;
-	explo_proof = 1;
 	name = "Checkpoint - Secure Lockdown Release Control Button - Side Door";
 	id = "checkpoint_main_2"
 	},
@@ -4932,7 +4930,6 @@
 /obj/structure/machinery/door_control/brbutton/alt{
 	pixel_y = -18;
 	emp_proof = 1;
-	explo_proof = 1;
 	name = "Landing Zone - Secure Lockdown Button";
 	id = "LZ1";
 	needs_power = 0
@@ -6259,7 +6256,6 @@
 	pixel_x = -7;
 	pixel_y = 10;
 	emp_proof = 1;
-	explo_proof = 1;
 	name = "Landing Zone - Secure Lockdown Button";
 	id = "LZ1"
 	},
@@ -24117,16 +24113,14 @@
 	name = "Checkpoint - Secure Lockdown Release Control Button";
 	pixel_x = 7;
 	pixel_y = 10;
-	emp_proof = 1;
-	explo_proof = 1
+	emp_proof = 1
 	},
 /obj/structure/machinery/door_control{
 	id = "checkpoint_small_2";
 	name = "Checkpoint - Secure Lockdown Release Control Button";
 	pixel_x = 7;
 	pixel_y = 3;
-	emp_proof = 1;
-	explo_proof = 1
+	emp_proof = 1
 	},
 /obj/item/reagent_container/food/drinks/bottle/vodka{
 	pixel_x = -4;
@@ -36462,7 +36456,7 @@
 /area/strata/interior/administration)
 "cfX" = (
 /obj/structure/largecrate/random,
-/obj/item/storage/belt/grenade/large/full,
+/obj/item/storage/belt/grenade/full,
 /turf/open/asphalt/cement,
 /area/strata/interior/outpost/engi)
 "cfY" = (
@@ -42429,7 +42423,6 @@
 	pixel_x = -6;
 	pixel_y = 8;
 	emp_proof = 1;
-	explo_proof = 1;
 	name = "Checkpoint - Secure Lockdown Release Control Button - Main Doors";
 	id = "checkpoint_main"
 	},

--- a/maps/map_files/Sorokyne_Strata/standalone/sof_insert_supplyship.dmm
+++ b/maps/map_files/Sorokyne_Strata/standalone/sof_insert_supplyship.dmm
@@ -206,7 +206,6 @@
 	icon_state = "test_square_red"
 	},
 /obj/structure/closet/crate/explosives,
-/obj/item/weapon/gun/launcher/rocket/upp,
 /obj/item/explosive/grenade/high_explosive/upp,
 /obj/item/explosive/grenade/high_explosive/upp,
 /obj/item/explosive/grenade/high_explosive/upp,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

removed a UPP rocket launcher from the SOF insert

removed a GL specialist grenade belt and replaced it with the normal belt

# Explain why it's good for the game

survivors shouldnt have rocket launchers it totally ruins them thematically
survivors also shouldnt have USCM spec gear

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
maptweak: removes UPP RPG and GL spec belt from sorokyne
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
