### PR TITLE
changes "pooled larva" announcement to "burrowed"

### DIFF
--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -294,7 +294,7 @@
 				surge_cooldown = surge_cooldown - surge_incremental_reduction //ramps up over time
 			if(linked_hive.hijack_burrowed_left < 1)
 				linked_hive.hijack_burrowed_surge = FALSE
-				xeno_message(SPAN_XENOANNOUNCE("The hive's power wanes. We will no longer gain pooled larva over time."), 3, linked_hive.hivenumber)
+				xeno_message(SPAN_XENOANNOUNCE("The hive's power wanes. We will no longer gain burrowed larva over time."), 3, linked_hive.hivenumber)
 
 	// Hive core can repair itself over time
 	if(health < maxhealth && last_healed <= world.time)


### PR DESCRIPTION
# About the pull request

Changes the "We will no longer gain pooled larva over time" hijack msg to "We will no longer gain burrowed larva over time"

# Explain why it's good for the game

Xenos haven't been able to afford pool fees in years

# Testing Photographs and Procedure

# Changelog

:cl:
spellcheck: fixed burrowed larva being referred to as pooled in a hijack msg 
/:cl: