### PR TITLE
No larva queue estimation for the first 15 seconds from lobby

### DIFF
--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -517,6 +517,15 @@ Additional game mode variables.
 
 		// If a lobby player is trying to join as xeno, estimate their possible position
 		if(is_new_player)
+			if(!SSticker.HasRoundStarted() || world.time < SSticker.round_start_time + 15 SECONDS)
+				// Larva queue numbers are too volatile at the start of the game for the estimation to be what they end up with
+				to_chat(xeno_candidate, SPAN_XENONOTICE("Larva queue position estimation is not available until shortly after the game has started. \
+					The ordering is based on your time of death or the time you joined. When you have been dead long enough and are not inactive, \
+					you will periodically receive messages where you are in the queue relative to other currently valid xeno candidates. \
+					Your current position will shift as others change their preferences or go inactive, but your relative position compared to all observers is the same. \
+					Note: Playing as a facehugger/lesser or in the thunderdome will not alter your time of death. \
+					This means you won't lose your relative place in queue if you step away, disconnect, play as a facehugger/lesser, or play in the thunderdome."))
+				return FALSE
 			var/mob/new_player/candidate_new_player = xeno_candidate
 			if(candidate_new_player.larva_queue_message_stale_time <= world.time)
 				// No cached/current lobby message, determine the position


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #7261 simply preventing the estimation of a position number when you're on the lobby for the first 15 seconds of the game.

# Explain why it's good for the game

Larva queue information endlessly confuses players.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/d79cecef-0505-4d0e-bfcd-625fa99ca2e4)

</details>


# Changelog
:cl: Drathek
qol: First 15 seconds of the game no longer offers a larva queue position estimation on the lobby since other players are still observing and the estimation relies on currently valid candidates.
/:cl:
