### PR TITLE
ERT squads

### DIFF
--- a/code/datums/emergency_calls/pmc.dm
+++ b/code/datums/emergency_calls/pmc.dm
@@ -1,7 +1,7 @@
 
 //Weyland-Yutani PMCs. Friendly to USCM, hostile to xenos.
 /datum/emergency_call/pmc
-	name = "Weyland-Yutani PMC (Squad)"
+	name = "Weyland-Yutani PMC (Squad) (Auto-Grouped)"
 	mob_max = 6
 	probability = 20
 	shuttle_id = MOBILE_SHUTTLE_ID_ERT2
@@ -79,6 +79,10 @@
 	to_chat(M, SPAN_BOLD("Deny Weyland-Yutani's involvement and do not trust the UA/USCM forces."))
 
 
+/datum/emergency_call/pmc/no_squad
+	name = "Weyland-Yutani PMC (Squad)"
+	probability = 0
+
 /datum/emergency_call/pmc/platoon
 	name = "Weyland-Yutani PMC (Platoon)"
 	mob_min = 8
@@ -124,18 +128,18 @@
 	if(!leader && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_LEADER) && check_timelock(H.client, JOB_SQUAD_LEADER, time_required_for_job))    //First one spawned is always the leader.
 		leader = H
 		to_chat(H, SPAN_ROLE_HEADER("You are a Weyland-Yutani PMC Lead Investigator!"))
-		arm_equipment(H, /datum/equipment_preset/pmc/pmc_lead_investigator, TRUE, TRUE)
+		arm_equipment(H, /datum/equipment_preset/pmc/pmc_lead_investigator/chem_recovery, TRUE, TRUE)
 	else if(medics < max_medics && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(H.client, JOB_SQUAD_MEDIC, time_required_for_job))
 		medics++
 		to_chat(H, SPAN_ROLE_HEADER("You are a Weyland-Yutani PMC Medical Investigator!"))
-		arm_equipment(H, /datum/equipment_preset/pmc/pmc_med_investigator, TRUE, TRUE)
+		arm_equipment(H, /datum/equipment_preset/pmc/pmc_med_investigator/chem_recovery, TRUE, TRUE)
 	else if(heavies < max_heavies && HAS_FLAG(H.client.prefs.toggles_ert, PLAY_SMARTGUNNER) && check_timelock(H.client, JOB_SQUAD_SMARTGUN, time_required_for_job))
 		heavies++
 		to_chat(H, SPAN_ROLE_HEADER("You are a Weyland-Yutani PMC Crowd Control Specialist!"))
-		arm_equipment(H, /datum/equipment_preset/pmc/pmc_riot_control, TRUE, TRUE)
+		arm_equipment(H, /datum/equipment_preset/pmc/pmc_riot_control/chem_recovery, TRUE, TRUE)
 	else
 		to_chat(H, SPAN_ROLE_HEADER("You are a Weyland-Yutani PMC Detainer!"))
-		arm_equipment(H, /datum/equipment_preset/pmc/pmc_detainer, TRUE, TRUE)
+		arm_equipment(H, /datum/equipment_preset/pmc/pmc_detainer/chem_recovery, TRUE, TRUE)
 
 	print_backstory(H)
 

--- a/code/game/jobs/job/marine/squads.dm
+++ b/code/game/jobs/job/marine/squads.dm
@@ -516,13 +516,13 @@
 
 	var/mob_role = GET_DEFAULT_ROLE(target_mob.job)
 	switch(mob_role)
-		if(JOB_SQUAD_ENGI)
+		if(JOB_SQUAD_ENGI, JOB_UPP_ENGI, JOB_PMC_ENGINEER)
 			assignment = JOB_SQUAD_ENGI
 			id_card.claimedgear = FALSE
-		if(JOB_SQUAD_MEDIC)
+		if(JOB_SQUAD_MEDIC, JOB_UPP_MEDIC, JOB_PMC_MEDIC)
 			assignment = JOB_SQUAD_MEDIC
 			id_card.claimedgear = FALSE
-		if(JOB_SQUAD_SPECIALIST)
+		if(JOB_SQUAD_SPECIALIST, JOB_UPP_SPECIALIST, JOB_PMC_SNIPER)
 			assignment = JOB_SQUAD_SPECIALIST
 		if(JOB_SQUAD_TEAM_LEADER)
 			assignment = JOB_SQUAD_TEAM_LEADER
@@ -539,19 +539,23 @@
 			SStracking.set_leader(tracking_id, target_mob)
 			SStracking.start_tracking("marine_sl", target_mob)
 
-		if(JOB_UPP_ENGI)
-			assignment = JOB_SQUAD_ENGI
-			id_card.claimedgear = FALSE
-		if(JOB_UPP_MEDIC)
-			assignment = JOB_SQUAD_MEDIC
-			id_card.claimedgear = FALSE
-		if(JOB_UPP_SPECIALIST)
-			assignment = JOB_SQUAD_SPECIALIST
 		if(JOB_UPP_LEADER)
 			if(squad_leader && GET_DEFAULT_ROLE(squad_leader.job) != JOB_UPP_LEADER) //field promoted SL
 				var/old_lead = squad_leader
 				demote_squad_leader() //replaced by the real one
 				SStracking.start_tracking(tracking_id, old_lead)
+			assignment = squad_type + " Leader"
+			squad_leader = target_mob
+			SStracking.set_leader(tracking_id, target_mob)
+			SStracking.start_tracking("marine_sl", target_mob)
+
+		if(JOB_PMC_LEADER, JOB_PMC_LEAD_INVEST, JOB_DS_SL)
+			if(squad_leader)
+				var/def_role = GET_DEFAULT_ROLE(squad_leader.job)
+				if((def_role != JOB_PMC_LEADER) && (def_role != JOB_PMC_LEAD_INVEST) && (def_role != JOB_DS_SL)) //field promoted SL
+					var/old_lead = squad_leader
+					demote_squad_leader() //replaced by the real one
+					SStracking.start_tracking(tracking_id, old_lead)
 			assignment = squad_type + " Leader"
 			squad_leader = target_mob
 			SStracking.set_leader(tracking_id, target_mob)

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -1120,6 +1120,10 @@
 	has_hud = TRUE
 	hud_type = MOB_HUD_FACTION_WO
 	additional_hud_types = list(MOB_HUD_FACTION_WY, MOB_HUD_FACTION_PMC)
+	inbuilt_tracking_options = list(
+		"Squad Leader" = TRACKER_SL,
+		"Fireteam Leader" = TRACKER_FTL
+	)
 
 /obj/item/device/radio/headset/distress/pmc
 	name = "PMC headset"
@@ -1133,7 +1137,9 @@
 	misc_tracking = TRUE
 	locate_setting = TRACKER_CL
 	inbuilt_tracking_options = list(
-		"Corporate Liaison" = TRACKER_CL
+		"Corporate Liaison" = TRACKER_CL,
+		"Squad Leader" = TRACKER_SL,
+		"Fireteam Leader" = TRACKER_FTL
 	)
 	additional_hud_types = list(MOB_HUD_FACTION_WY)
 

--- a/code/modules/gear_presets/pmc.dm
+++ b/code/modules/gear_presets/pmc.dm
@@ -11,6 +11,9 @@
 	var/human_versus_human = FALSE
 	var/headset_type = /obj/item/device/radio/headset/distress/pmc
 
+	var/auto_squad_name
+	var/always_squad = FALSE
+
 /datum/equipment_preset/pmc/New()
 	. = ..()
 	access = get_access(ACCESS_LIST_WY_PMC)
@@ -55,6 +58,23 @@
 			uniform.has_sensor = UNIFORM_HAS_SENSORS
 	return ..()
 
+/datum/equipment_preset/pmc/load_preset(mob/living/carbon/human/new_human, randomise, count_participant)
+	. = ..()
+	if(!auto_squad_name || (should_block_game_interaction(new_human) && !always_squad))
+		return
+
+	var/obj/item/card/id/ID = new_human.get_idcard()
+	var/datum/money_account/acct = create_account(new_human, rand(30, 50), GLOB.paygrades[ID.paygrade])
+	ID.associated_account_number = acct.account_number
+
+	var/datum/squad/auto_squad = get_squad_by_name(auto_squad_name)
+	if(auto_squad)
+		transfer_marine_to_squad(new_human, auto_squad, new_human.assigned_squad, ID)
+	if(!always_squad && !auto_squad.active)
+		auto_squad.engage_squad(FALSE)
+
+	new_human.marine_buyable_categories[MARINE_CAN_BUY_EAR] = 0
+	new_human.hud_set_squad()
 
 //*****************************************************************************************************/
 /datum/equipment_preset/pmc/pmc_standard
@@ -66,6 +86,11 @@
 	minimap_icon = "pmc_gun"
 	paygrades = list(PAY_SHORT_PMC_OP = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/pmc
+
+/datum/equipment_preset/pmc/pmc_standard/auto_distress
+	name = "Weyland-Yutani PMC (Standard) (AS)"
+	auto_squad_name = "Team Upsilon"
+	always_squad = TRUE
 
 /datum/equipment_preset/pmc/pmc_standard/load_gear(mob/living/carbon/human/new_human)
 
@@ -249,6 +274,11 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	paygrades = list(PAY_SHORT_PMC_EN = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/pmc
 
+/datum/equipment_preset/pmc/pmc_detainer/chem_recovery
+	name = "Weyland-Yutani PMC (Detainer) (AS)"
+	auto_squad_name = "Team Gamma"
+	always_squad = TRUE
+
 /datum/equipment_preset/pmc/pmc_detainer/load_gear(mob/living/carbon/human/new_human)
 
 	new_human.equip_to_slot_or_del(new headset_type, WEAR_L_EAR)
@@ -383,6 +413,11 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	paygrades = list(PAY_SHORT_PMC_EN = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/pmc
 
+/datum/equipment_preset/pmc/pmc_riot_control/chem_recovery
+	name = "Weyland-Yutani PMC (Crowd Control Specialist) (AS)"
+	auto_squad_name = "Team Gamma"
+	always_squad = TRUE
+
 /datum/equipment_preset/pmc/pmc_riot_control/load_gear(mob/living/carbon/human/new_human)
 
 	new_human.equip_to_slot_or_del(new headset_type, WEAR_L_EAR)
@@ -442,6 +477,11 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	role_comm_title = "CM"
 	skills = /datum/skills/pmc/medic
 	headset_type = /obj/item/device/radio/headset/distress/pmc/medic
+
+/datum/equipment_preset/pmc/pmc_medic/auto_distress
+	name = "Weyland-Yutani PMC (Corporate Medic) (AS)"
+	auto_squad_name = "Team Upsilon"
+	always_squad = TRUE
 
 /datum/equipment_preset/pmc/pmc_medic/load_gear(mob/living/carbon/human/new_human)
 
@@ -630,6 +670,11 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	paygrades = list(PAY_SHORT_PMC_MS = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/pmc/medic/chem
 	headset_type = /obj/item/device/radio/headset/distress/pmc/medic
+
+/datum/equipment_preset/pmc/pmc_med_investigator/chem_recovery
+	name = "Weyland-Yutani PMC (Medical Investigator) (AS)"
+	auto_squad_name = "Team Gamma"
+	always_squad = TRUE
 
 /datum/equipment_preset/pmc/pmc_med_investigator/load_gear(mob/living/carbon/human/new_human)
 
@@ -825,6 +870,11 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	skills = /datum/skills/pmc/SL
 	headset_type = /obj/item/device/radio/headset/distress/pmc/command
 
+/datum/equipment_preset/pmc/pmc_leader/auto_distress
+	name = "Weyland-Yutani PMC (Leader) (AS)"
+	auto_squad_name = "Team Upsilon"
+	always_squad = TRUE
+
 /datum/equipment_preset/pmc/pmc_leader/New()
 	. = ..()
 	access = get_access(ACCESS_LIST_WY_PMC) + list(ACCESS_WY_LEADERSHIP, ACCESS_WY_PMC_TL)
@@ -983,6 +1033,11 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	skills = /datum/skills/pmc/SL/chem
 	headset_type = /obj/item/device/radio/headset/distress/pmc/command
 
+/datum/equipment_preset/pmc/pmc_lead_investigator/chem_recovery
+	name = "Weyland-Yutani PMC (Lead Investigator) (AS)"
+	auto_squad_name = "Team Gamma"
+	always_squad = TRUE
+
 /datum/equipment_preset/pmc/pmc_lead_investigator/New()
 	. = ..()
 	access = get_access(ACCESS_LIST_WY_PMC) + list(ACCESS_WY_LEADERSHIP, ACCESS_WY_PMC_TL)
@@ -1131,6 +1186,11 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 
 	skills = /datum/skills/pmc/smartgunner
 
+/datum/equipment_preset/pmc/pmc_gunner/auto_distress
+	name = "Weyland-Yutani PMC (Gunner) (AS)"
+	auto_squad_name = "Team Upsilon"
+	always_squad = TRUE
+
 /datum/equipment_preset/pmc/pmc_gunner/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new headset_type, WEAR_L_EAR)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/veteran/pmc, WEAR_BODY)
@@ -1240,6 +1300,11 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	minimap_icon = "pmc_spec"
 	skills = /datum/skills/pmc/specialist
 	headset_type = /obj/item/device/radio/headset/distress/pmc/cct
+
+/datum/equipment_preset/pmc/pmc_sniper/auto_distress
+	name = "Weyland-Yutani PMC (Sniper) (AS)"
+	auto_squad_name = "Team Upsilon"
+	always_squad = TRUE
 
 /datum/equipment_preset/pmc/pmc_sniper/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new headset_type, WEAR_L_EAR)
@@ -1682,6 +1747,11 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	skills = /datum/skills/pmc/engineer
 	headset_type = /obj/item/device/radio/headset/distress/pmc/cct
 
+/datum/equipment_preset/pmc/technician/auto_distress
+	name = "Weyland-Yutani PMC (Corporate Technician) (AS)"
+	auto_squad_name = "Team Upsilon"
+	always_squad = TRUE
+
 /datum/equipment_preset/pmc/technician/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/pmc/enclosed/engineer, WEAR_HEAD)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/pmc, WEAR_FACE)
@@ -1884,6 +1954,11 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	paygrades = list(PAY_SHORT_SYN = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "WY Syn"
 	headset_type = /obj/item/device/radio/headset/distress/pmc/command
+
+/datum/equipment_preset/pmc/synth/auto_distress
+	name = "Weyland-Yutani PMC (Support Synthetic) (AS)"
+	auto_squad_name = "Team Upsilon"
+	always_squad = TRUE
 
 
 /datum/equipment_preset/pmc/synth/load_name(mob/living/carbon/human/new_human, randomise)

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -1273,7 +1273,6 @@
 	faction = FACTION_HUNTED
 	flags = EQUIPMENT_PRESET_EXTRA|EQUIPMENT_PRESET_MARINE
 	faction_group = FACTION_LIST_HUNTED
-	ert_squad = TRUE
 
 /datum/equipment_preset/uscm/hunted/rifleman
 	name = "USCM Solar Devils Rifleman (Hunted)"

--- a/code/modules/gear_presets/whiteout.dm
+++ b/code/modules/gear_presets/whiteout.dm
@@ -13,6 +13,9 @@
 	paygrades = list(PAY_SHORT_CDNM = JOB_PLAYTIME_TIER_0)
 	var/new_bubble_icon = "machine"
 
+	auto_squad_name = "Taskforce White"
+	always_squad = TRUE
+
 /datum/equipment_preset/pmc/w_y_whiteout/New()
 	. = ..()
 	access = get_access(ACCESS_LIST_GLOBAL)
@@ -253,6 +256,9 @@
 	minimap_background = "background_pmc"
 	assignment = JOB_DS_CU
 	job_title = JOB_DS_CU
+
+	auto_squad_name = null
+	always_squad = FALSE
 
 /datum/equipment_preset/pmc/w_y_whiteout/low_threat/load_race(mob/living/carbon/human/new_human)
 	new_human.set_species("W-Y Combat Android (Weaker)")


### PR DESCRIPTION

# About the pull request

Puts the PMC ERTs into their squads for organisation purposes. This only applies to the automatic ERT calls, and admins can summon non-squadded ERTs.

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Added Auto-Squad presets for PMCs and Deathsquad (marked as '(AS)')
/:cl:
