### PR TITLE
Xeno Hauling Stuns - Option 1

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -152,7 +152,7 @@
 				var/hit_sound = pick('sound/weapons/genhit1.ogg', 'sound/weapons/genhit2.ogg', 'sound/weapons/genhit3.ogg')
 				playsound(loc, hit_sound, 25, 1)
 			if(prob(max(4*(100*xeno.getBruteLoss()/xeno.maxHealth - 75),0))) //4% at 24% health, 80% at 5% health
-				xeno.release_haul(stuns=FALSE)
+				xeno.release_haul(stuns_human = FALSE)
 		else
 			for(var/mob/mobs_can_hear in hearers(4, xeno))
 				if(mobs_can_hear.client)

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -443,20 +443,20 @@
 	hauled_mob = null
 
 // Releasing a hauled mob
-/mob/living/carbon/xenomorph/proc/release_haul(stuns = FALSE)
+/mob/living/carbon/xenomorph/proc/release_haul(stuns_human = FALSE)
 	deltimer(haul_timer)
-	var/mob/living/carbon/human/user = hauled_mob?.resolve()
-	if(!user)
+	var/mob/living/carbon/human/luggage = hauled_mob?.resolve()
+	if(!luggage)
 		to_chat(src, SPAN_WARNING("We are not hauling anyone."))
 		return
-	user.handle_unhaul()
-	visible_message(SPAN_XENOWARNING("[src] releases [user] from their grip!"),
-	SPAN_XENOWARNING("We release [user] from our grip!"), null, 5)
+	luggage.handle_unhaul()
+	visible_message(SPAN_XENOWARNING("[src] releases [luggage] from their grip!"),
+	SPAN_XENOWARNING("We release [luggage] from our grip!"), null, 5)
 	playsound(src, 'sound/voice/alien_growl1.ogg', 15)
-	log_interact(src, user, "[key_name(src)] released [key_name(user)] at [get_area_name(loc)]")
-	if(stuns)
-		user.adjust_effect(2, STUN)
-	UnregisterSignal(user, COMSIG_MOB_DEATH)
+	log_interact(src, luggage, "[key_name(src)] released [key_name(luggage)] at [get_area_name(loc)]")
+	if(stuns_human)
+		luggage.adjust_effect(2, STUN)
+	UnregisterSignal(luggage, COMSIG_MOB_DEATH)
 	UnregisterSignal(src, COMSIG_ATOM_DIR_CHANGE)
 	hauled_mob = null
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -132,7 +132,7 @@
 		to_chat(X, SPAN_WARNING("We cannot put them down here."))
 		return
 
-	X.release_haul(TRUE)
+	X.release_haul(FALSE)
 
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Option 1 of changing xeno haul stuns.
This will stun humans on release of haul only if they're not done manually. No more xenos dropping people then tackle spamming them during the stun when they can't do anything, for that lovely stunlock gameplay.

Option 2 is #9780 

# Explain why it's good for the game

Constant stunlock is dreadful. It is very dissatisfying for people playing human, and for people watching. I don't much like watching people exploiting haul stun.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: Xenos dropping humans no longer stuns the human.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
