### PR TITLE
Typo/grammar fixes, minor code improvements and blood spatters for Xeno Dissection

### DIFF
--- a/code/modules/surgery/xeno.dm
+++ b/code/modules/surgery/xeno.dm
@@ -156,7 +156,7 @@
 			SPAN_NOTICE("You sever the connective tissue that holds the [target.caste_type]'s alien organ in place using [tool]."))
 	else
 		user.visible_message(
-			SPAN_NOTICE("[user] gleefully rips the [target.caste_type]'s connective tissue apart using [tool]"),
+			SPAN_NOTICE("[user] gleefully rips the [target.caste_type]'s connective tissue apart using [tool]".),
 			SPAN_NOTICE("You gleefully rip the [target.caste_type]'s connective tissue apart using [tool]."))
 
 /datum/surgery_step/xenomorph/severe_connections/failure(mob/living/carbon/human/user, mob/living/carbon/xenomorph/target, target_zone, obj/item/tool, tool_type, datum/surgery/surgery)

--- a/code/modules/surgery/xeno.dm
+++ b/code/modules/surgery/xeno.dm
@@ -18,7 +18,7 @@
 
 /datum/surgery/xenomorph/can_start(mob/user, mob/living/carbon/xenomorph/patient, obj/limb/L, obj/item/tool)
 	if(islarva(patient) || isfacehugger(patient))
-		to_chat(user, SPAN_DANGER("This race is probably too small to have a mature organ worthy to extract..."))
+		to_chat(user, SPAN_DANGER("This organism is probably too small to have a mature organ worthy of extraction..."))
 		return FALSE
 	if((patient.tier > 2 || isqueen(patient)) && !istype(tool, /obj/item/tool/surgery/scalpel/laser/advanced))
 		to_chat(user, SPAN_DANGER("Chitin of this kind is too thick for an ordinary tool, you would need something special."))
@@ -45,44 +45,38 @@
 	success_sound = 'sound/handling/bandage.ogg'
 	failure_sound = 'sound/surgery/organ2.ogg'
 
+//No need for to-patient messages on this one, they're heckin' dead
 /datum/surgery_step/xenomorph/cut_exoskeleton/preop(mob/living/carbon/human/user, mob/living/carbon/xenomorph/target, target_zone, obj/item/tool, tool_type, datum/surgery/surgery)
 	if(tool_type == /obj/item/tool/surgery/circular_saw || tool_type == /obj/item/tool/surgery/scalpel/laser/advanced)
-		user.affected_message(target,
-			SPAN_NOTICE("You start to cut [target.caste_type] carapace apart using [tool], carefully, trying to prevent acid leaks."),
-			SPAN_NOTICE("[user] starts to cut your carapace apart using [tool], carefully, trying to prevent acid leaks."),
-			SPAN_NOTICE("[user] starts to cut [target.caste_type] carapace. [tool], carefully, trying to prevent acid leaks."))
+		user.visible_message(
+			SPAN_NOTICE("[user] carefully starts to cut the [target.caste_type]'s carapace apart with [tool], trying to prevent acidic blood from leaking."),
+			SPAN_NOTICE("You carefully start to cut the [target.caste_type]'s carapace apart using [tool], trying to prevent acidic blood from leaking."))
 	else
-		user.affected_message(target,
-			SPAN_NOTICE("You start to [pick("smash", "crack", "break")] [target.caste_type] carapace apart using [tool], Recklessly, with acid splashing on you!"),
-			SPAN_NOTICE("[user] starts to [pick("smash", "crack", "break")] your carapace apart using [tool], recklessly splashing acid everywhere!"),
-			SPAN_NOTICE("[user] starts to [pick("smash", "crack", "break")] [target.caste_type] carapace with [tool], recklessly splashing acid everywhere!"))
-		//we dont really need log interact since we're working with dead body... I hope
+		user.visible_message(
+			SPAN_NOTICE("[user] recklessly starts to [pick("smash", "crack", "break")] the [target.caste_type]'s carapace apart with [tool] as acidic blood begins to burst through the corpse's seams!"),
+			SPAN_NOTICE("You recklessly start to [pick("smash", "crack", "break")] the [target.caste_type]'s carapace apart using [tool] as acidic blood begins to burst through the corpse's seams!"))
+			//we dont really need a log interact since we're working with dead bodies... I hope
 
 /datum/surgery_step/xenomorph/cut_exoskeleton/success(mob/living/carbon/human/user, mob/living/carbon/xenomorph/target, target_zone, obj/item/tool, tool_type, datum/surgery/surgery)
 	if(tool_type == /obj/item/tool/surgery/circular_saw)
-		user.affected_message(target,
-			SPAN_NOTICE("You succesfully cut through [target.caste_type] carapace apart using [tool]."),
-			SPAN_NOTICE("[user] successfully cuts through your carapace using [tool]."),
-			SPAN_NOTICE("[user] successfully cuts [target.caste_type] carapace using [tool]."))
+		user.visible_message(
+			SPAN_NOTICE("[user] successfully cuts through the [target.caste_type]'s carapace using [tool]."),
+			SPAN_NOTICE("You successfully cut through the [target.caste_type]'s carapace using [tool]."))
 	else
-		user.affected_message(target,
-			SPAN_NOTICE("You successfully destroy [target.caste_type] carapace into bits and pieces using [tool]."),
-			SPAN_NOTICE("[user] successfully destroys your carapace into bits and pieces using [tool]."),,
-			SPAN_NOTICE("[user] successfully destroys [target.caste_type] carapace into bits and pieces using [tool]."))
+		user.visible_message(
+			SPAN_NOTICE("[user] successfully destroys the [target.caste_type]'s carapace into bits and pieces using [tool]."),
+			SPAN_NOTICE("You successfully destroy the [target.caste_type]'s carapace into bits and pieces using [tool]."))
 	for(var/mob/living/carbon/human/victim in orange(1, target))
 		if(istype(victim.wear_suit, /obj/item/clothing/suit/bio_suit) && istype(victim.head, /obj/item/clothing/head/bio_hood))
 			continue
-		to_chat(victim, SPAN_HIGHDANGER("You are covered in acid as you feel agonizing pain!"))
+		victim.visible_message(
+			SPAN_WARNING("[victim] is [pick("covered", "drenched", "soaked")] in the acidic blood that [pick("spurts", "sprays", "bursts")] out from the [target.caste_type]!"),
+			SPAN_HIGHDANGER("You feel agonizing pain as you're drenched in acid!"))
 		victim.apply_damage(rand(75, 125), BURN) // you WILL wear biosuit.
 		playsound(victim, "acid_sizzle", 25, TRUE)
 		animation_flash_color(victim, "#FF0000")
-
-/datum/surgery_step/xenomorph/cut_exoskeleton/failure(mob/living/carbon/human/user, mob/living/carbon/xenomorph/target, target_zone, obj/item/tool, tool_type, datum/surgery/surgery)
-	user.affected_message(target,
-		SPAN_WARNING("Your hand slips, failing to cut [target.caste_type] carapace apart using [tool]!"),
-		SPAN_WARNING("[user]'s hand slips, failing to cut your carapace apart using [tool]!"),
-		SPAN_WARNING("[user] hand slips, failing to cut [target.caste_type] carapace using [tool]!"))
-	return FALSE
+		//Having acid spray everywhere *but* the floor makes no sense, but this can be removed if research gets too messy.
+		target.add_splatter_floor(get_turf(target.loc)) 
 
 /datum/surgery_step/xenomorph/open_exoskeleton
 	name = "Pry exoskeleton open"
@@ -94,35 +88,39 @@
 	failure_sound = 'sound/surgery/organ1.ogg'
 
 /datum/surgery_step/xenomorph/open_exoskeleton/preop(mob/living/carbon/human/user, mob/living/carbon/xenomorph/target, target_zone, obj/item/tool, tool_type, datum/surgery/surgery)
-			user.affected_message(target,
-				SPAN_NOTICE("You start to pry [target.caste_type] carapace open using [tool]"),
-				SPAN_NOTICE("[user] starts to pry your carapace open with [tool] very carefully"),
-				SPAN_NOTICE("[user] starts to pry [target.caste_type] carapace open with [tool] very carefully"))
+	if(tool_type == /obj/item/tool/surgery/retractor)
+		user.visible_message(
+			SPAN_NOTICE("[user] carefully starts to pry the [target.caste_type]'s carapace open with [tool]."),
+			SPAN_NOTICE("You carefully start to pry the [target.caste_type]'s carapace open using [tool]."))
+	else
+		user.visible_message(
+			SPAN_NOTICE("[user] starts to pry the [target.caste_type]'s carapace open using [tool] like a crazed medieval doctor!"),
+			SPAN_NOTICE("You start to pry the [target.caste_type]'s carapace open using [tool] like a crazed medieval doctor!"))
 
 /datum/surgery_step/xenomorph/open_exoskeleton/success(mob/living/carbon/human/user, mob/living/carbon/xenomorph/target, target_zone, obj/item/tool, tool_type, datum/surgery/surgery)
 	if(tool_type == /obj/item/tool/surgery/retractor)
-		user.affected_message(target,
-			SPAN_NOTICE("You hold [target.caste_type] carapace and exoskeleton open using [tool], exposing [target.caste_type] vital organs"),
-			SPAN_NOTICE("[user] holds your carapace and exoskeleton open with [tool], exposing [target.caste_type] vital organs "),
-			SPAN_NOTICE("[user] holds [target.caste_type] carapace and exoskeleton open with [tool], exposing [target.caste_type] vital organs "))
+		user.visible_message(
+			SPAN_NOTICE("[user] holds the [target.caste_type]'s carapace and exoskeleton open with [tool], exposing the [target.caste_type]'s vital organs."),
+			SPAN_NOTICE("You hold the [target.caste_type]'s carapace and exoskeleton open using [tool], exposing the [target.caste_type]'s vital organs."))
 	else
-		user.affected_message(target,
-			SPAN_NOTICE("You hold [target.caste_type] carapace open using [tool] like a medieval doctor, exposing [target.caste_type] vital organs"),
-			SPAN_NOTICE("[user] starts to open your carapace with [tool] very carefully"),
-			SPAN_NOTICE("[user] starts to open [target.caste_type] carapace with [tool] very carefully"))
+		user.visible_message(
+			SPAN_NOTICE("[user] holds the [target.caste_type]'s carapace open with [tool] like a wacky kid at a science fair."),
+			SPAN_NOTICE("You hold the [target.caste_type]'s carapace open using [tool] like a wacky kid at a science fair."))
 
 /datum/surgery_step/xenomorph/open_exoskeleton/failure(mob/living/carbon/human/user, mob/living/carbon/xenomorph/target, target_zone, obj/item/tool, tool_type, datum/surgery/surgery)
-	user.affected_message(target,
-		SPAN_WARNING("Your hand slips, letting go of [target.caste_type] carapace and exoskeleton, slaming it back into place and splashing acid everywhere!"),
-		SPAN_WARNING("[user] hand slips, letting go of [target.caste_type] carapace and exoskeleton, slaming it back into place and splashing acid everywhere!"),
-		SPAN_WARNING("[user] hand slips, letting go of [target.caste_type] carapace and exoskeleton, slaming it back into place and splashing acid everywhere!"))
+	user.visible_message(
+		SPAN_WARNING("[user] messes up and [user.p_their()] hand slips, letting go of the [target.caste_type]'s carapace and exoskeleton. It snaps back into place, sending acid flying!"),
+		SPAN_WARNING("Your hand slips, letting go of the [target.caste_type]'s carapace and exoskeleton. It snaps back into place, sending acid flying!"))
 	for(var/mob/living/carbon/human/victim in orange(1, target))
 		if(istype(victim.wear_suit, /obj/item/clothing/suit/bio_suit) && istype(victim.head, /obj/item/clothing/head/bio_hood))
 			continue
-		to_chat(victim, SPAN_DANGER("You are covered in blood gushing out from [target.caste_type]"))
+		victim.visible_message(
+			SPAN_WARNING("[victim] is [pick("covered", "drenched", "soaked")] in the acidic blood that [pick("spurts", "sprays", "bursts")] out from the [target.caste_type]!"),
+			SPAN_DANGER("You're [pick("covered", "drenched", "soaked")] in the acidic blood that [pick("spurts", "sprays", "bursts")] out from the [target.caste_type]!"))
 		victim.apply_damage(rand(50, 75), BURN) // still dangerous
 		playsound(victim, "acid_sizzle", 25, TRUE)
 		animation_flash_color(victim, "#FF0000")
+		target.add_splatter_floor(get_turf(target.loc))
 	return FALSE
 
 /datum/surgery_step/xenomorph/severe_connections
@@ -142,35 +140,39 @@
 	failure_sound = 'sound/surgery/organ2.ogg'
 
 /datum/surgery_step/xenomorph/severe_connections/preop(mob/living/carbon/human/user, mob/living/carbon/xenomorph/target, target_zone, obj/item/tool, tool_type, datum/surgery/surgery)
-	user.affected_message(target,
-		SPAN_NOTICE("You start to sever [target.caste_type] organ links using [tool], with confidence"),
-		SPAN_NOTICE("[user] start to sever your organ links using [tool], with confidence"),
-		SPAN_NOTICE("[user] starts to sever [target.caste_type] organ links using [tool], with confidence"))
+	if(tool_type == /obj/item/tool/surgery/scalpel || tool_type == /obj/item/tool/surgery/scalpel/pict_system)
+		user.visible_message(
+			SPAN_NOTICE("[user] confidently starts to sever the [target.caste_type]'s alien organ from its surrounding connective tissue using [tool]."),
+			SPAN_NOTICE("You confidently start to sever the [target.caste_type]'s alien organ from its surrounding connective tissue using [tool]."))
+	else
+		user.visible_message(
+			SPAN_NOTICE("[user] confidently starts to rip the [target.caste_type]'s connective tissue apart using [tool]"),
+			SPAN_NOTICE("You confidently start to rip the [target.caste_type]'s connective tissue apart using [tool]."))
 
 /datum/surgery_step/xenomorph/severe_connections/success(mob/living/carbon/human/user, mob/living/carbon/xenomorph/target, target_zone, obj/item/tool, tool_type, datum/surgery/surgery)
 	if(tool_type == /obj/item/tool/surgery/scalpel || tool_type == /obj/item/tool/surgery/scalpel/pict_system)
-		user.affected_message(target,
-			SPAN_NOTICE("You severed [target.caste_type] connections and links to vital organs using [tool]"),
-			SPAN_NOTICE("[user] severed your connections and links to vital organs using [tool]"),
-			SPAN_NOTICE("[user] severed [target.caste_type] connections and links to vital organs using [tool]"))
+		user.visible_message(
+			SPAN_NOTICE("[user] severs the connective tissue that holds the [target.caste_type]'s alien organ in place using [tool]."),
+			SPAN_NOTICE("You sever the connective tissue that holds the [target.caste_type]'s alien organ in place using [tool]."))
 	else
-		user.affected_message(target,
-			SPAN_NOTICE("You rip [target.caste_type] connections and links to vital organs apart using [tool]"),
-			SPAN_NOTICE("[user] rips your connections and links to vital organs apart using [tool]"),
-			SPAN_NOTICE("[user] rips [target.caste_type] connections and links to vital organs apart using [tool]"))
+		user.visible_message(
+			SPAN_NOTICE("[user] gleefully rips the [target.caste_type]'s connective tissue apart using [tool]"),
+			SPAN_NOTICE("You gleefully rip the [target.caste_type]'s connective tissue apart using [tool]."))
 
 /datum/surgery_step/xenomorph/severe_connections/failure(mob/living/carbon/human/user, mob/living/carbon/xenomorph/target, target_zone, obj/item/tool, tool_type, datum/surgery/surgery)
-	user.affected_message(target,
-		SPAN_WARNING("Your hand slips, damaging one of [target.caste_type] [pick("arteries", "viens")], gushing acid blood everywhere!"),
-		SPAN_WARNING("[user] hand slips, damaging one of your [pick("arteries", "viens")], gushing acid blood everywhere!"),
-		SPAN_WARNING("[user] hand slips, damaging one of [target.caste_type] [pick("arteries", "viens")], gushing acid blood everywhere!"))
+	user.visible_message(
+		SPAN_WARNING("[user] messes up and [user.p_their()] hand slips, damaging one of the [target.caste_type]'s [pick("arteries", "veins")]. Acidic blood sprays everywhere!"),
+		SPAN_WARNING("Your hand slips, damaging one of the [target.caste_type]'s [pick("arteries", "veins")]. Acidic blood sprays everywhere!"))
 	for(var/mob/living/carbon/human/victim in orange(1, target))
 		if(istype(victim.wear_suit, /obj/item/clothing/suit/bio_suit) && istype(victim.head, /obj/item/clothing/head/bio_hood))
 			continue
-		to_chat(victim, SPAN_DANGER("You are covered in blood gushing out from [target.caste_type]"))
-		victim.apply_damage(rand(50, 75), BURN) // not SO dangerous but still is
+		victim.visible_message(
+			SPAN_WARNING("[victim] is [pick("covered", "drenched", "soaked")] in the acidic blood that [pick("spurts", "sprays", "bursts")] out from the [target.caste_type]!"),
+			SPAN_DANGER("You're [pick("covered", "drenched", "soaked")] in the acidic blood that [pick("spurts", "sprays", "bursts")] out from the [target.caste_type]!"))
+		victim.apply_damage(rand(50, 75), BURN) // not AS dangerous but still is
 		playsound(victim, "acid_sizzle", 25, TRUE)
 		animation_flash_color(victim, "#FF0000")
+		target.add_splatter_floor(get_turf(target.loc))
 
 /datum/surgery_step/xenomorph/remove_organ
 	name = "Remove Xenomorph Organ"
@@ -188,33 +190,28 @@
 
 /datum/surgery_step/xenomorph/remove_organ/preop(mob/living/carbon/human/user, mob/living/carbon/xenomorph/target, target_zone, obj/item/tool, tool_type, datum/surgery/surgery)
 	if(tool)
-		user.affected_message(target,
-		SPAN_NOTICE("You start to get a firm grip on the [target.caste_type] organ using [tool] "),
-		SPAN_NOTICE("[user] start to get a firm grip on your insides using [tool]"),
-		SPAN_NOTICE("[user] starts to get a firm grip on the [target.caste_type] organ using [tool] "))
+		user.visible_message(
+			SPAN_NOTICE("[user] starts to get a firm grip on the [target.caste_type]'s alien organ using [tool]."),
+			SPAN_NOTICE("You start to get a firm grip on the [target.caste_type]'s alien organ using [tool]."))
 	else
-		user.affected_message(target,
-			SPAN_NOTICE("You start to get a firm grip on the [target.caste_type] organ"),
-			SPAN_NOTICE("[user] starts to get a firm grip on your insides"),
-			SPAN_NOTICE("[user] starts to get a firm grip on the [target.caste_type] organ"))
+		user.visible_message(
+			SPAN_NOTICE("Like a mad scientist, [user] starts to get a firm grip on the [target.caste_type]'s alien organ!"),
+			SPAN_NOTICE("Like a mad scientist, you start to get a firm grip on the [target.caste_type]'s alien organ!"))
 
 /datum/surgery_step/xenomorph/remove_organ/success(mob/living/carbon/human/user, mob/living/carbon/xenomorph/target, target_zone, obj/item/tool, tool_type, datum/surgery/surgery)
 	if(tool)
-		user.affected_message(target,
-			SPAN_NOTICE("You pulled the [target.caste_type] organ out using [tool]"),
-			SPAN_NOTICE("[user] pulled your organ out using [tool]"),
-			SPAN_NOTICE("[user] pulled the [target.caste_type] organ out using [tool]"))
+		user.visible_message(
+			SPAN_NOTICE("[user] pulls the [target.caste_type]'s alien organ out using [tool]."),
+			SPAN_NOTICE("You pull the [target.caste_type]'s alien organ out using [tool]."))
 	else
 		if(istype(user.wear_suit, /obj/item/clothing/suit/bio_suit))
-			user.affected_message(target,
-				SPAN_NOTICE("You pulled the [target.caste_type] organ out!"),
-				SPAN_NOTICE("[user] pulles your insides out!"),
-				SPAN_NOTICE("[user] pulled the [target.caste_type] organ out."))
+			user.visible_message(
+				SPAN_NOTICE("[user] pulls the [target.caste_type]'s alien organ out."),
+				SPAN_NOTICE("You pull the [target.caste_type]'s alien organ out."))
 		else
-			user.affected_message(target,
-				SPAN_NOTICE("You burn your hands as you pulled the [target.caste_type] organ out!"),
-				SPAN_NOTICE("[user] burns their hands as they pulled your insides out!"),
-				SPAN_NOTICE("[user] burns [user.p_their()] hands as [user.p_they()] pulled the [target.caste_type] organ out."))
+			user.visible_message(
+				SPAN_WARNING("[user] burns [user.p_their()] hands as [user.p_they()] pull the [target.caste_type]'s alien organ out!"),
+				SPAN_WARNING("You burn your hands as you pull the [target.caste_type]'s alien organ out!"))
 			user.emote("pain")
 			if(user.hand)
 				user.apply_damage(rand(30,50), BURN, "l_hand")
@@ -222,6 +219,7 @@
 				user.apply_damage(rand(30,50), BURN, "r_hand")
 			playsound(user, "acid_sizzle", 25, TRUE)
 			animation_flash_color(user, "#FF0000")
+			//no blood splatter here, we're just sticking our hands in, not cutting anything open
 	var/obj/item/organ/xeno/organ = locate() in target
 	if(!isnull(organ))
 		organ.forceMove(target.loc)
@@ -230,9 +228,8 @@
 
 /datum/surgery_step/xenomorph/remove_organ/failure(mob/living/carbon/human/user, mob/living/carbon/xenomorph/target, target_zone, obj/item/tool, tool_type, datum/surgery/surgery)
 	if(tool)
-		user.affected_message(target,
-			SPAN_NOTICE("You fail to pull the [target.caste_type] organ out using [tool]"),
-			SPAN_NOTICE("[user] fails to pull your organ out using [tool]"),
-			SPAN_NOTICE("[user] fails to pull the [target.caste_type] organ out using [tool]"))
+		user.visible_message(
+			SPAN_NOTICE("[user] fails to pull the [target.caste_type]'s alien organ out using [tool]."),
+			SPAN_NOTICE("You fail to pull the [target.caste_type]'s alien organ out using [tool]."))
 	return FALSE
 

--- a/code/modules/surgery/xeno.dm
+++ b/code/modules/surgery/xeno.dm
@@ -76,7 +76,7 @@
 		playsound(victim, "acid_sizzle", 25, TRUE)
 		animation_flash_color(victim, "#FF0000")
 		//Having acid spray everywhere *but* the floor makes no sense, but this can be removed if research gets too messy.
-		target.add_splatter_floor(get_turf(target.loc)) 
+		target.add_splatter_floor(get_turf(target.loc))
 
 /datum/surgery_step/xenomorph/open_exoskeleton
 	name = "Pry exoskeleton open"
@@ -156,7 +156,7 @@
 			SPAN_NOTICE("You sever the connective tissue that holds the [target.caste_type]'s alien organ in place using [tool]."))
 	else
 		user.visible_message(
-			SPAN_NOTICE("[user] gleefully rips the [target.caste_type]'s connective tissue apart using [tool]".),
+			SPAN_NOTICE("[user] gleefully rips the [target.caste_type]'s connective tissue apart using [tool]."),
 			SPAN_NOTICE("You gleefully rip the [target.caste_type]'s connective tissue apart using [tool]."))
 
 /datum/surgery_step/xenomorph/severe_connections/failure(mob/living/carbon/human/user, mob/living/carbon/xenomorph/target, target_zone, obj/item/tool, tool_type, datum/surgery/surgery)


### PR DESCRIPTION
# About the pull request

- Fixes a whole slew of grammar and spelling errors
- Removes unused to_patient messages, since our patient is a corpse
- Removes unused first step failure code, because a first step can't fail, only exit the surgery
- Adds a couple more improvised tool messages
- Adds a message for those in line of sight when someone forgets to put their biosuit on and takes an acid bath
- Adds the creation of blood on the floor whenever a xeno corpse sprays blood everywhere. Can be removed if research ends up super messy each round- well, more than it already does

# Explain why it's good for the game

- spealling ahnd grahmmur gud
- More improvised tool messages, so that when you're going after a corpse with a toolbox you have a little flavor to entertain you
- let others know why the researcher is in crit (although they probably could've guessed)
- Xenos are pressurized canisters of blood, cutting them open and not having it get on the floor doesn't make a whole ton of sense

# Testing Photographs and Procedure


# Changelog

:cl:
add: Added blood splatters when you do xeno dissection, added a few more improvised tool messages
spellcheck: fixed a bunch of spelling and grammatical errors in xeno dissection
code: Removed unused to_patient and first step failure code in xeno dissection.
/:cl:
