### PR TITLE
Preserve previous primary potentate prospect

### DIFF
--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -1167,6 +1167,8 @@
 
 	for(var/mob/living/carbon/xenomorph/candidate in votes)
 		if(votes[candidate] > primary_votes)
+			secondary_votes = primary_votes
+			secondary_candidate = primary_candidate
 			primary_votes = votes[candidate]
 			primary_candidate = candidate
 		else if(votes[candidate] > secondary_votes)


### PR DESCRIPTION
# About the pull request

While looking at king voting code, it seems that the second candidate is heavily based on how the list is ordered. Based on the original PR, it's supposed to be the candidates with two most votes.

# Explain why it's good for the game

Minor impact, but it would reduce the number of times King seems assigned randomly.


# Testing Photographs and Procedure
Made sure it ran properly on local but it was with only one client connected.


# Changelog

:cl:
fix: King election now actually between top two highest votes.
/:cl:
