### PR TITLE
Kills Most Kills Fun Fact

### DIFF
--- a/code/datums/statistics/random_facts/kills_fact.dm
+++ b/code/datums/statistics/random_facts/kills_fact.dm
@@ -1,9 +1,0 @@
-/datum/random_fact/kills
-	statistic_name = "kills"
-	statistic_verb = "earned"
-
-/datum/random_fact/kills/life_grab_stat(mob/fact_mob)
-	return fact_mob.life_kills_total
-
-/datum/random_fact/kills/death_grab_stat(datum/entity/statistic/death/fact_death)
-	return fact_death.total_kills

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -705,7 +705,6 @@
 #include "code\datums\statistics\random_facts\christmas_fact.dm"
 #include "code\datums\statistics\random_facts\damage_fact.dm"
 #include "code\datums\statistics\random_facts\ib_fact.dm"
-#include "code\datums\statistics\random_facts\kills_fact.dm"
 #include "code\datums\statistics\random_facts\random_fact.dm"
 #include "code\datums\statistics\random_facts\revives_fact.dm"
 #include "code\datums\status_effects\_status_effect.dm"


### PR DESCRIPTION

# About the pull request

Removes the 'most kills' fun fact from the scoreboard. 

# Explain why it's good for the game

Encouraging people to top-frag to get their name on the scoreboard is something I, and others, finds counterintuitive to a game aimed at encouraging role play with a focus on meaningful combat engagements that are not just people going to as many kills as possible. 

The concept of a scoreboard for kills is a strong passive encouragement to focus on kills at all costs. This will permeate amongst the entire player base even if it is subconsciously. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
del: Most kills fun fact has been removed. 
/:cl:
