### PR TITLE
Breaching charge direction fix

### DIFF
--- a/code/game/objects/items/explosives/plastic.dm
+++ b/code/game/objects/items/explosives/plastic.dm
@@ -68,8 +68,6 @@
 	to_chat(user, SPAN_NOTICE("Timer set for [timer] seconds."))
 
 /obj/item/explosive/plastic/afterattack(atom/target, mob/user, flag)
-	setDir(get_dir(user, target))
-
 	if(user.action_busy || !flag)
 		return
 	if(!skillcheck(user, req_skill, req_skill_level))
@@ -94,6 +92,7 @@
 			disarm()
 		return
 
+	setDir(get_dir(user, target))
 	user.drop_held_item()
 	cause_data = create_cause_data(initial(name), user)
 	plant_target = target


### PR DESCRIPTION

# About the pull request

The breaching charge's direction would always get changed towards the direction the player clicked, even if it was already being planted.
Fixed by simply moving the direction setting past all the plantability checks.

# Explain why it's good for the game

No.

# Testing Photographs and Procedure
Tested.

# Changelog
:cl:
fix: Breaching charges no longer explode in unexpected directions.
/:cl:
