### PR TITLE
Random fun facts

### DIFF
--- a/code/datums/statistics/random_facts/christmas_fact.dm
+++ b/code/datums/statistics/random_facts/christmas_fact.dm
@@ -1,17 +1,35 @@
-/datum/random_fact/christmas/announce()
+// Leaderboard stat for festivizer_hits_total_max
+// Normally includes dead always but can disable by setting prob_check_dead to 0
+
+/datum/random_fact/christmas/life_grab_stat(mob/fact_mob)
+	return fact_mob.festivizer_hits_total
+
+/datum/random_fact/christmas/generate_announcement_message()
+	if(!check_xeno && !check_human)
+		return null
+
 	var/festivizer_hits_total_max = 0
 	var/mob/mob_to_report = null
 
 	var/list/list_to_check = list()
-	list_to_check += GLOB.living_mob_list
-	list_to_check += GLOB.dead_mob_list
+	if(check_human)
+		if(prob_check_dead > 0)
+			list_to_check += GLOB.human_mob_list
+		else
+			list_to_check += GLOB.alive_human_list
+	if(check_xeno)
+		if(prob_check_dead > 0)
+			list_to_check += GLOB.xeno_mob_list
+		else
+			list_to_check += GLOB.living_xeno_list
+
 	for(var/mob/checked_mob as anything in list_to_check)
-		if(festivizer_hits_total_max < checked_mob.festivizer_hits_total)
+		if(festivizer_hits_total_max < checked_mob.festivizer_hits_total && (checked_mob.persistent_ckey in GLOB.directory))
 			mob_to_report = checked_mob
-			festivizer_hits_total_max = checked_mob.festivizer_hits_total
+			festivizer_hits_total_max = life_grab_stat(checked_mob)
 
 	if(!mob_to_report || !festivizer_hits_total_max)
-		return
+		return null
 
 	var/name = mob_to_report.real_name
 	var/additional_message
@@ -27,6 +45,4 @@
 		else
 			additional_message = "<b>[name] is the VERY SPIRIT of CHRISTMAS!!!</b>"
 
-	message = "<b>[name]</b> festivized a grand total of <b>[festivizer_hits_total_max] objects!</b> [additional_message]"
-
-	return ..()
+	return "<b>[name]</b> festivized a grand total of <b>[festivizer_hits_total_max] objects!</b> [additional_message]"

--- a/code/datums/statistics/random_facts/christmas_fact.dm
+++ b/code/datums/statistics/random_facts/christmas_fact.dm
@@ -28,7 +28,7 @@
 			mob_to_report = checked_mob
 			festivizer_hits_total_max = life_grab_stat(checked_mob)
 
-	if(!mob_to_report || !festivizer_hits_total_max)
+	if(!mob_to_report || festivizer_hits_total_max < min_required)
 		return null
 
 	var/name = mob_to_report.real_name

--- a/code/datums/statistics/random_facts/random_fact.dm
+++ b/code/datums/statistics/random_facts/random_fact.dm
@@ -1,86 +1,117 @@
+/// How many facts per faction (marine/xeno) to announce
+#define MAX_FACTION_FACTS_TO_ANNOUNCE 5
+
 /datum/random_fact
-	var/message = null
+	/// The noun for this statistic in the announcement
 	var/statistic_name = null
+	/// The verb for this statistic in the announcement
 	var/statistic_verb = null
-
+	/// Whether this statistic can apply to humans
 	var/check_human = TRUE
+	/// Whether this statistic can apply to xenos
 	var/check_xeno = TRUE
+	/// The prob dead are checked for this statistic
+	var/prob_check_dead = 50
+	/// The min stat required to be noted
+	var/min_required = 1
 
-/datum/random_fact/New(set_check_human = TRUE, set_check_xeno = TRUE)
+/datum/random_fact/New(check_human=TRUE, check_xeno=TRUE)
 	. = ..()
-	check_human = set_check_human
-	check_xeno = set_check_xeno
+	src.check_human = initial(src.check_human) && check_human
+	src.check_xeno = initial(src.check_human) && check_xeno
 
+/// Announces this random_fact to world if possible (returns TRUE if sent)
 /datum/random_fact/proc/announce()
-	calculate_announcement_message()
+	var/message = generate_announcement_message()
 	if(message)
 		to_world(SPAN_CENTERBOLD(message))
 		return TRUE
 	return FALSE
 
-/datum/random_fact/proc/calculate_announcement_message()
-	var/death_stat_gotten = 0
-	var/living_stat_gotten = 0
-	var/datum/entity/statistic/death/death_to_report = null
-	var/mob/mob_to_report = null
+/// Returns the /datum/entity/statistic/death for a random still connected player that has min_required for this stat
+/datum/random_fact/proc/find_death_to_report()
+	RETURN_TYPE(/datum/entity/statistic/death)
 
-	if(GLOB.round_statistics && length(GLOB.round_statistics.death_stats_list))
-		for(var/datum/entity/statistic/death/death in GLOB.round_statistics.death_stats_list)
-			if(!check_human && !death.is_xeno)
+	if(!GLOB.round_statistics)
+		return null
+	if(!length(GLOB.round_statistics.death_stats_list))
+		return null
+
+	var/list/list_to_check = shuffle(GLOB.round_statistics.death_stats_list)
+	for(var/datum/entity/statistic/death/death as anything in GLOB.round_statistics.death_stats_list)
+		if(death.is_xeno)
+			if(!check_xeno)
 				continue
-			if(!check_xeno && death.is_xeno)
+		else
+			if(!check_human)
 				continue
-			if(death_stat_gotten < death_grab_stat(death))
-				death_to_report = death
-				death_stat_gotten = death_grab_stat(death)
+		var/datum/entity/player/player_record = DB_ENTITY(/datum/entity/player, death.player_id)
+		if(!player_record)
+			debug_log("player_entity lookup failed for '[death.player_id]' during [type]'s find_death_to_report")
+			continue
+		if(!(player_record.ckey in GLOB.directory))
+			continue // Not connected anymore
+		if(death_grab_stat(death) >= min_required)
+			return death // Success
+
+/// Returns the /mob/living/carbon for a random still connected player that has min_required for this stat
+/datum/random_fact/proc/find_living_to_report()
+	RETURN_TYPE(/mob/living/carbon)
 
 	var/list/list_to_check = list()
 	if(check_human)
 		list_to_check += GLOB.alive_human_list
 	if(check_xeno)
 		list_to_check += GLOB.living_xeno_list
+	list_to_check = shuffle(list_to_check)
 
-	for(var/mob/checked_mob as anything in list_to_check)
-		if(!checked_mob?.persistent_ckey)
-			continue // We don't care about NPCs
-		if(living_stat_gotten < life_grab_stat(checked_mob))
-			mob_to_report = checked_mob
-			living_stat_gotten = life_grab_stat(checked_mob)
+	for(var/mob/living/carbon/checked_mob as anything in list_to_check)
+		if(!(checked_mob.persistent_ckey in GLOB.directory))
+			continue // We don't care about NPCs or people disconnected
+		if(life_grab_stat(checked_mob) >= min_required)
+			return checked_mob // Success
+
+/// Attempts to get a statistic to report on and returns the string of the message otherwise null if no one met requirements
+/datum/random_fact/proc/generate_announcement_message()
+	if(!check_xeno && !check_human)
+		return null
+
+	var/datum/entity/statistic/death/death_to_report = null
+	var/mob/mob_to_report = null
+
+	var/dead_attempted = FALSE
+	if(prob(prob_check_dead))
+		dead_attempted = TRUE
+		death_to_report = find_death_to_report()
+	if(!death_to_report && prob_check_dead < 100)
+		mob_to_report = find_living_to_report()
+	if(!mob_to_report && prob_check_dead > 0 && !dead_attempted)
+		death_to_report = find_death_to_report()
 
 	if(!death_to_report && !mob_to_report)
-		return
+		return null
 
 	var/name = ""
 	var/stat_gotten = 0
 	var/additional_message = ""
-	if(death_to_report && mob_to_report)
-		if(living_stat_gotten > death_stat_gotten)
-			name = mob_to_report.real_name
-			stat_gotten = living_stat_gotten
-			additional_message = "and survived! Great work!"
-		else
-			name = death_to_report.mob_name
-			stat_gotten = death_stat_gotten
-			additional_message = "before dying"
-			if(death_to_report.cause_name)
-				additional_message += " to <b>[death_to_report.cause_name]</b>"
-			additional_message += ". Good work!"
-	else if(death_to_report)
+	if(death_to_report)
 		name = death_to_report.mob_name
-		stat_gotten = death_stat_gotten
+		stat_gotten = death_grab_stat(death_to_report)
 		additional_message = "before dying"
 		if(death_to_report.cause_name)
 			additional_message += " to <b>[death_to_report.cause_name]</b>"
 		additional_message += ". Good work!"
 	else
 		name = mob_to_report.real_name
-		stat_gotten = living_stat_gotten
+		stat_gotten = life_grab_stat(mob_to_report)
 		additional_message = "and survived! Great work!"
 
-	message = "<b>[name]</b> [statistic_verb] <b>[stat_gotten] [statistic_name]</b> [additional_message]"
+	return "<b>[name]</b> [statistic_verb] <b>[stat_gotten] [statistic_name]</b> [additional_message]"
 
+/// Override this to specify what value on a mob to get for this statistic
 /datum/random_fact/proc/life_grab_stat(mob/fact_mob)
 	return 0
 
+/// Override this to specify what value on a death to get for this statistic
 /datum/random_fact/proc/death_grab_stat(datum/entity/statistic/death/fact_death)
 	return 0

--- a/code/datums/statistics/random_facts/random_fact.dm
+++ b/code/datums/statistics/random_facts/random_fact.dm
@@ -47,7 +47,7 @@
 				continue
 		var/datum/entity/player/player_record = DB_ENTITY(/datum/entity/player, death.player_id)
 		if(!player_record)
-			debug_log("player_entity lookup failed for '[death.player_id]' during [type]'s find_death_to_report")
+			debug_log("/datum/entity/player lookup failed for '[death.player_id]' during [type]'s find_death_to_report")
 			continue
 		if(!(player_record.ckey in GLOB.directory))
 			continue // Not connected anymore

--- a/code/datums/statistics/random_facts/random_fact.dm
+++ b/code/datums/statistics/random_facts/random_fact.dm
@@ -38,7 +38,7 @@
 		return null
 
 	var/list/list_to_check = shuffle(GLOB.round_statistics.death_stats_list)
-	for(var/datum/entity/statistic/death/death as anything in GLOB.round_statistics.death_stats_list)
+	for(var/datum/entity/statistic/death/death as anything in list_to_check)
 		if(death.is_xeno)
 			if(!check_xeno)
 				continue

--- a/code/game/gamemodes/cm_process.dm
+++ b/code/game/gamemodes/cm_process.dm
@@ -89,13 +89,21 @@ of predators), but can be added to include variant game modes (like humans vs. h
 	sleep(2 SECONDS)
 	to_chat_spaced(world, margin_bottom = 0, html = SPAN_ROLE_BODY("|______________________|"))
 	to_world(SPAN_ROLE_HEADER("FUN FACTS"))
-	var/list/fact_types = subtypesof(/datum/random_fact)
+	var/list/fact_types = shuffle(subtypesof(/datum/random_fact))
+	var/facts_so_far = 0
 	for(var/fact_type as anything in fact_types)
-		var/datum/random_fact/fact_human = new fact_type(set_check_human = TRUE, set_check_xeno = FALSE)
-		fact_human.announce()
+		var/datum/random_fact/fact_human = new fact_type(check_human=TRUE, check_xeno=FALSE)
+		if(fact_human.announce())
+			facts_so_far++
+		if(facts_so_far >= MAX_FACTION_FACTS_TO_ANNOUNCE)
+			break
+	facts_so_far = 0
 	for(var/fact_type as anything in fact_types)
-		var/datum/random_fact/fact_xeno = new fact_type(set_check_human = FALSE, set_check_xeno = TRUE)
-		fact_xeno.announce()
+		var/datum/random_fact/fact_xeno = new fact_type(check_human=FALSE, check_xeno=TRUE)
+		if(fact_xeno.announce())
+			facts_so_far++
+		if(facts_so_far >= MAX_FACTION_FACTS_TO_ANNOUNCE)
+			break
 	to_chat_spaced(world, margin_top = 0, html = SPAN_ROLE_BODY("|______________________|"))
 
 //===================================================\\

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -562,13 +562,6 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 	// P.setup_save(ckey)
 	return P
 
-/proc/save_player_entities()
-	for(var/key_ref in GLOB.player_entities)
-		// var/datum/entity/player_entity/P = player_entities["[key_ref]"]
-		// P.save_statistics()
-	log_debug("STATISTICS: Statistics saving complete.")
-	message_admins("STATISTICS: Statistics saving complete.")
-
 /client/proc/clear_chat_spam_mute(warn_level = 1, message = FALSE, increase_warn = FALSE)
 	if(talked > warn_level)
 		return


### PR DESCRIPTION
# About the pull request

This PR does the following:
- Only 5 facts per faction are displayed (only 5 exist currently but future proofs other facts being added)
- Facts are only displayed for players who are still in the GLOB.directory (connected)
- Facts can specify a probability to try dead first
- Other than festivizer fact, facts are just the first person in the shuffled list to meet `min_required`
- Removes some dead code (save_player_entities)
- Adds autodoc comments for /datum/random_fact

I encourage people to add more random stats. Its as simple as (lots of random things already tracked - but obviously something new would just follow suit as the others):
https://github.com/cmss13-devs/cmss13/blob/9e3d3a250d5f63f7264a7b017975b7fdd5f86a85/code/datums/statistics/random_facts/ib_fact.dm#L1-L9

# Explain why it's good for the game

Less encouragement to chase stats and now will only mention players still connected.

> One would hope people don't chase stats but they do and it's at the cost of other player's enjoyment. E.g. focusing only on defib rather than fully treating people; actually raging at someone for them getting the last shot on a kill, etc

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/3201da8f-4387-4538-92e9-a9b210ab0186)
![image](https://github.com/user-attachments/assets/dff22d96-af40-4779-a587-cb304754f4f3)

</details>


# Changelog
:cl: Drathek
add: Fun facts are now randomized (meaning just mentions first player meeting a minimum is mentioned - not a top stat) and are only displayed for currently connected players
/:cl:
