### PR TITLE
CBRN ERT changes

### DIFF
--- a/code/datums/skills/uscm.dm
+++ b/code/datums/skills/uscm.dm
@@ -539,7 +539,7 @@ CIA
 CBRN
 ---------------------
 */
-/datum/skills/cbrnrifleman
+/datum/skills/cbrn_rifleman
 	name = "CBRN Rifleman"
 	skills = list(
 		SKILL_ENGINEER = SKILL_ENGINEER_TRAINED,
@@ -551,7 +551,7 @@ CBRN
 		SKILL_ENDURANCE = SKILL_ENDURANCE_TRAINED,
 	)
 
-/datum/skills/cbrntech
+/datum/skills/cbrn_tech
 	name = "CBRN Combat Technician"
 	skills = list(
 		SKILL_POLICE = SKILL_POLICE_SKILLED,
@@ -566,7 +566,7 @@ CBRN
 		SKILL_VEHICLE = SKILL_VEHICLE_SMALL,
 	)
 
-/datum/skills/cbrnmedic
+/datum/skills/cbrn_medic
 	name = "CBRN Medical Technician"
 	skills = list(
 		SKILL_CQC = SKILL_CQC_TRAINED,
@@ -579,7 +579,7 @@ CBRN
 		SKILL_JTAC = SKILL_JTAC_BEGINNER,
 	)
 
-/datum/skills/cbrnlead
+/datum/skills/cbrn_lead
 	name = "CBRN Fireteam Leader"
 	skills = list(
 		SKILL_POLICE = SKILL_POLICE_SKILLED,

--- a/code/modules/gear_presets/cbrn.dm
+++ b/code/modules/gear_presets/cbrn.dm
@@ -7,7 +7,7 @@
 	flags = EQUIPMENT_PRESET_EXTRA
 	auto_squad_name = SQUAD_CBRN
 	ert_squad = TRUE
-	skills = /datum/skills/cbrnrifleman //More trained than the average rifleman
+	skills = /datum/skills/cbrn_rifleman //More trained than the average rifleman
 
 /datum/equipment_preset/uscm/cbrn/New()
 	. = ..()
@@ -63,7 +63,7 @@
 	job_title = JOB_SQUAD_ENGI
 	role_comm_title = "ComTech"
 	minimap_icon = "engi"
-	skills = /datum/skills/cbrntech
+	skills = /datum/skills/cbrn_tech
 
 /datum/equipment_preset/uscm/cbrn/engineer/load_gear(mob/living/carbon/human/new_human)
 	. = ..()
@@ -104,7 +104,7 @@
 	job_title = JOB_SQUAD_MEDIC
 	role_comm_title = "HM"
 	minimap_icon = "medic"
-	skills = /datum/skills/cbrnmedic
+	skills = /datum/skills/cbrn_medic
 
 /datum/equipment_preset/uscm/cbrn/medic/load_gear(mob/living/carbon/human/new_human)
 	. = ..()
@@ -143,7 +143,7 @@
 	job_title = JOB_SQUAD_TEAM_LEADER
 	role_comm_title = "TL"
 	minimap_icon = "tl"
-	skills = /datum/skills/cbrnlead
+	skills = /datum/skills/cbrn_lead
 
 /datum/equipment_preset/uscm/cbrn/leader/load_gear(mob/living/carbon/human/new_human)
 	. = ..()


### PR DESCRIPTION
# About the pull request
completely changes the loadout of all CBRN ERT members

# Explain why it's good for the game
the CBRN ERT is incredibly cool and very rare, but also unlike most 'rare' things is very weak - you spawn with either only a flamer or only a mk2, and the medic spawns with only a pistol. this attempts to reflavor them into all having flamethrowers while not making them overpowered, and gives them their own skills instead of using PMC skills (also nerfing their skills in the process)

they have no attachments, no AP, etc when they arrive - they will have to make use of their ability to firewalk if they want to truly be effective. this also removes some other things from them such as master endurance (end 3), master engineering, et cetera. this also fixes the standard CBRN rifleman not even being able to use most of his equipment due to spawning with a medkit pouch and no medical skill by swapping it out
# Testing Photographs and Procedure

# Changelog

:cl:
balance: CBRN ERT has had a passover and lost some of its more questionable skills in exchange for better armaments
/:cl:
