### PR TITLE
swaps the bodyguard beacon commandos off the deathsquad version

### DIFF
--- a/code/datums/emergency_calls/bodyguard.dm
+++ b/code/datums/emergency_calls/bodyguard.dm
@@ -68,8 +68,8 @@
 	spawn_header_leader = "You are a Weyland-Yutani PMC Lead Investigator!"
 
 /datum/emergency_call/wy_bodyguard/commando
-	equipment_preset = /datum/equipment_preset/pmc/commando/standard
-	equipment_preset_leader = /datum/equipment_preset/pmc/commando/leader
+	equipment_preset = /datum/equipment_preset/pmc/commando/standard/low_threat
+	equipment_preset_leader = /datum/equipment_preset/pmc/commando/leader/low_threat
 	spawn_header = "You are a Weyland-Yutani Commando!"
 	spawn_header_leader = "You are a Weyland-Yutani Commando Leader!"
 


### PR DESCRIPTION

# About the pull request

as title, CL bodyguard beacon commandos are the non deathsquad version now

# Explain why it's good for the game

admins are basically never going to want to send a deathsquad with heap like this


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
admin: CL beacon bodyguard commandos are the low_threat, non deathsquad version now
/:cl:
