### PR TITLE
Spore Fruit Description Fix

### DIFF
--- a/code/modules/cm_aliens/structures/fruit.dm
+++ b/code/modules/cm_aliens/structures/fruit.dm
@@ -318,7 +318,7 @@
 	if(ishuman(user))
 		. += "[SPAN_NOTICE("A basketball sized resin growth. Its translucent insides radiate faint orange light. It appears to be loosely attached to the weeds below.")]"
 	if(isxeno(user) || isobserver(user))
-		. += "[SPAN_NOTICE("We sense eating this fruit will reduce ability cooldown by [SPAN_BOLDNOTICE("5%")] per slash, up to [SPAN_BOLDNOTICE("25%")] on next ability cast. The casting cooldown effect of fruit persist for [SPAN_BOLDNOTICE("60")] seconds. While rooted, it passively emits weak recovery pheromones around itself.")]"
+		. += "[SPAN_NOTICE("We sense eating this fruit will reduce ability cooldown by [SPAN_BOLDNOTICE("5%")] per slash, up to [SPAN_BOLDNOTICE("25%")] on next ability cast. The casting cooldown effect of fruit persist for [SPAN_BOLDNOTICE("90")] seconds. While rooted, it passively emits weak recovery pheromones around itself.")]"
 
 /obj/effect/alien/resin/fruit/speed
 	name = XENO_FRUIT_SPEED
@@ -598,7 +598,7 @@
 	if(ishuman(user))
 		. += "[SPAN_NOTICE("It looks unappetizing... maybe the eggheads would want to study it instead.")]"
 	if(isxeno(user) || isobserver(user))
-		. += "[SPAN_NOTICE("We sense eating this fruit will reduce ability cooldown by [SPAN_BOLDNOTICE("5%")] per slash, up to [SPAN_BOLDNOTICE("25%")] on next ability cast. The casting cooldown effect of fruit persist for [SPAN_BOLDNOTICE("60")] seconds. While rooted, it passively emits weak recovery pheromones around itself.")]"
+		. += "[SPAN_NOTICE("We sense eating this fruit will reduce ability cooldown by [SPAN_BOLDNOTICE("5%")] per slash, up to [SPAN_BOLDNOTICE("25%")] on next ability cast. The casting cooldown effect of fruit persist for [SPAN_BOLDNOTICE("90")] seconds. While rooted, it passively emits weak recovery pheromones around itself.")]"
 
 /obj/item/reagent_container/food/snacks/resin_fruit/speed
 	name = XENO_FRUIT_SPEED


### PR DESCRIPTION

# About the pull request

Fixes Examine info that i forgot to change in #9572 for spore fruit description.

# Explain why it's good for the game

Display correct information of 90s instead of 60s, less confusion.

# Changelog
:cl:
fix: Changed description of spore fruit duration time from 60s to correct 90s.
/:cl:
