### PR TITLE
interference fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Evolution.dm
@@ -236,6 +236,10 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 		to_chat(src, SPAN_WARNING("We can't evolve here."))
 		return FALSE
 
+	if(HAS_TRAIT((src, TRAIT_HIVEMIND_INTERFERENCE)))
+		to_chat(src, SPAN_WARNING("Our link to the hive is being suppressed...we should wait a bit."))
+		return FALSE
+
 	if(hardcore)
 		to_chat(src, SPAN_WARNING("Nuh-uh."))
 		return FALSE
@@ -289,6 +293,9 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 	if(!isturf(loc))
 		to_chat(src, SPAN_XENOWARNING("We can't transmute here."))
 		return
+	if(HAS_TRAIT((src, TRAIT_HIVEMIND_INTERFERENCE)))
+		to_chat(src, SPAN_WARNING("Our link to the hive is being suppressed...we should wait a bit."))
+		return FALSE
 	if(health < maxHealth)
 		to_chat(src, SPAN_XENOWARNING("We are too weak to transmute, we must regain our health first."))
 		return
@@ -346,6 +353,9 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 	if(health < maxHealth)
 		to_chat(src, SPAN_XENOWARNING("We are too weak to deevolve, we must regain our health first."))
 		return
+	if(HAS_TRAIT((src, TRAIT_HIVEMIND_INTERFERENCE)))
+		to_chat(src, SPAN_WARNING("Our link to the hive is being suppressed...we should wait a bit."))
+		return FALSE
 	if(length(caste.deevolves_to) < 1)
 		to_chat(src, SPAN_XENOWARNING("We can't deevolve any further."))
 		return

--- a/code/modules/mob/living/carbon/xenomorph/Evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Evolution.dm
@@ -236,7 +236,7 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 		to_chat(src, SPAN_WARNING("We can't evolve here."))
 		return FALSE
 
-	if(HAS_TRAIT((src, TRAIT_HIVEMIND_INTERFERENCE)))
+	if(HAS_TRAIT(src, TRAIT_HIVEMIND_INTERFERENCE))
 		to_chat(src, SPAN_WARNING("Our link to the hive is being suppressed...we should wait a bit."))
 		return FALSE
 
@@ -293,7 +293,7 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 	if(!isturf(loc))
 		to_chat(src, SPAN_XENOWARNING("We can't transmute here."))
 		return
-	if(HAS_TRAIT((src, TRAIT_HIVEMIND_INTERFERENCE)))
+	if(HAS_TRAIT(src, TRAIT_HIVEMIND_INTERFERENCE))
 		to_chat(src, SPAN_WARNING("Our link to the hive is being suppressed...we should wait a bit."))
 		return FALSE
 	if(health < maxHealth)
@@ -353,7 +353,7 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 	if(health < maxHealth)
 		to_chat(src, SPAN_XENOWARNING("We are too weak to deevolve, we must regain our health first."))
 		return
-	if(HAS_TRAIT((src, TRAIT_HIVEMIND_INTERFERENCE)))
+	if(HAS_TRAIT(src, TRAIT_HIVEMIND_INTERFERENCE))
 		to_chat(src, SPAN_WARNING("Our link to the hive is being suppressed...we should wait a bit."))
 		return FALSE
 	if(length(caste.deevolves_to) < 1)


### PR DESCRIPTION

# About the pull request

if you step on a trap, devolve you will forever have TRAIT_INTERFERENCE which means you cant talk in the hivemind

# Explain why it's good for the game

its probablynot

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Predator taps aka TRAIT_INTERFERENCE now stops xenos from devolving and transmuting, so they dont bug themselves out forever.
/:cl:
