### PR TITLE
"Fixes" sleepy pens

### DIFF
--- a/code/game/objects/items/tools/misc_tools.dm
+++ b/code/game/objects/items/tools/misc_tools.dm
@@ -365,7 +365,7 @@
 /obj/item/tool/pen/sleepypen/Initialize()
 	. = ..()
 	create_reagents(30)
-	reagents.add_reagent("chloralhydrate", 22)
+	reagents.add_reagent("chloralhydrate", 15)
 
 /obj/item/tool/pen/sleepypen/attack(mob/M as mob, mob/user as mob)
 	if(!(istype(M,/mob)))


### PR DESCRIPTION

# About the pull request

they had 30, chloral hydrate od is 15+ so i just lowered it to 15 so people dont die
closes ##9808
Open

# Explain why it's good for the game

allegedly

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: CIA sleepy pens now have 15 chloral hydrate instead of 30, preventing overdoses. Happy kidnapping!
/:cl:
