### PR TITLE
UI: Sentry Computer Section scrolling over Content scrolling, some scalability

### DIFF
--- a/code/modules/defenses/sentry_computer.dm
+++ b/code/modules/defenses/sentry_computer.dm
@@ -150,6 +150,7 @@
  */
 /obj/item/device/sentry_computer/proc/send_message(message)
 	if(!silent && transceiver)
+		message = strip_improper(message)
 		transceiver.talk_into(voice, "[message]", RADIO_CHANNEL_SENTRY)
 		voice.say(message)
 

--- a/tgui/packages/tgui/interfaces/SentryGunUI.tsx
+++ b/tgui/packages/tgui/interfaces/SentryGunUI.tsx
@@ -9,6 +9,7 @@ import {
   Icon,
   Input,
   ProgressBar,
+  Section,
   Stack,
   Tabs,
 } from 'tgui/components';
@@ -397,7 +398,7 @@ const ShowSentryCard = (props: { readonly data: SentrySpec }) => {
 
 const ShowAllSentry = (props: { readonly data: SentrySpec[] }) => {
   return (
-    <Flex align="space-between" wrap>
+    <Flex align="space-around" wrap>
       {props.data.map((x) => (
         <Flex.Item key={x.index}>
           <ShowSentryCard data={x} />
@@ -472,11 +473,22 @@ const SentryTabMenu = (props: {
 }) => {
   const { data, act } = useBackend<SentryData>();
   return (
-    <Tabs fill>
+    <Tabs>
+      <Tabs.Tab
+        selected={props.selected === undefined}
+        onClick={() => {
+          props.setSelected(undefined);
+          act('clear-camera');
+        }}
+      >
+        All
+      </Tabs.Tab>
       {props.sentrySpecs.map((x, index) => (
         <Tabs.Tab
           key={x.index}
           selected={props.selected === index}
+          textAlign="center"
+          minWidth="2%"
           onClick={() => {
             props.setSelected(index);
             if (data.camera_target) {
@@ -489,15 +501,6 @@ const SentryTabMenu = (props: {
           {x.nickname.length === 0 ? x.index : x.nickname}
         </Tabs.Tab>
       ))}
-      <Tabs.Tab
-        selected={props.selected === undefined}
-        onClick={() => {
-          props.setSelected(undefined);
-          act('clear-camera');
-        }}
-      >
-        All
-      </Tabs.Tab>
     </Tabs>
   );
 };
@@ -506,6 +509,7 @@ const PowerLevel = () => {
   const { data } = useBackend<SentryData>();
   return (
     <ProgressBar
+      width="75px"
       minValue={0}
       maxValue={data.electrical.max_charge}
       value={data.electrical.charge}
@@ -537,55 +541,57 @@ export const SentryGunUI = () => {
 
   return (
     <Window theme="crtyellow" height={700} width={700}>
-      <Window.Content className="SentryGun" scrollable>
-        <Stack vertical>
-          {data.sentry.length > 0 && (
+      <Window.Content className="SentryGun">
+        <Section fill scrollable>
+          <Stack vertical>
+            {data.sentry.length > 0 && (
+              <Stack.Item>
+                <Flex justify="space-between" align-items="center">
+                  <Flex.Item width="85%">
+                    <SentryTabMenu
+                      sentrySpecs={sentrySpecs}
+                      selected={selectedSentry}
+                      setSelected={setSelectedSentry}
+                    />
+                  </Flex.Item>
+                  <Flex.Item align="right">
+                    <PowerLevel />
+                  </Flex.Item>
+                </Flex>
+              </Stack.Item>
+            )}
             <Stack.Item>
-              <Flex justify="space-between" align-items="center">
-                <Flex.Item>
-                  <SentryTabMenu
-                    sentrySpecs={sentrySpecs}
-                    selected={selectedSentry}
-                    setSelected={setSelectedSentry}
+              {data.screen_state === 0 && (
+                <div>
+                  <TimedCallback
+                    time={1.5}
+                    callback={() => act('screen-state', { state: 1 })}
                   />
-                </Flex.Item>
-                <Flex.Item align="center">
-                  <PowerLevel />
-                </Flex.Item>
-              </Flex>
+                  <div className="TopPanelSlide" />
+                  <div className="BottomPanelSlide" />
+                </div>
+              )}
+              {data.camera_target === null && (
+                <>
+                  {!validSelection && <EmptyDisplay />}
+                  {validSelection && (
+                    <>
+                      {selectedSentry !== undefined && (
+                        <ShowSingleSentry data={sentrySpecs[selectedSentry]} />
+                      )}
+                      {selectedSentry === undefined && (
+                        <ShowAllSentry data={sentrySpecs} />
+                      )}
+                    </>
+                  )}
+                </>
+              )}
+              {data.camera_target !== null && (
+                <SentryCamera sentry_data={sentrySpecs} />
+              )}
             </Stack.Item>
-          )}
-          <Stack.Item>
-            {data.screen_state === 0 && (
-              <div>
-                <TimedCallback
-                  time={1.5}
-                  callback={() => act('screen-state', { state: 1 })}
-                />
-                <div className="TopPanelSlide" />
-                <div className="BottomPanelSlide" />
-              </div>
-            )}
-            {data.camera_target === null && (
-              <>
-                {!validSelection && <EmptyDisplay />}
-                {validSelection && (
-                  <>
-                    {selectedSentry !== undefined && (
-                      <ShowSingleSentry data={sentrySpecs[selectedSentry]} />
-                    )}
-                    {selectedSentry === undefined && (
-                      <ShowAllSentry data={sentrySpecs} />
-                    )}
-                  </>
-                )}
-              </>
-            )}
-            {data.camera_target !== null && (
-              <SentryCamera sentry_data={sentrySpecs} />
-            )}
-          </Stack.Item>
-        </Stack>
+          </Stack>
+        </Section>
       </Window.Content>
     </Window>
   );

--- a/tgui/packages/tgui/interfaces/SentryGunUI.tsx
+++ b/tgui/packages/tgui/interfaces/SentryGunUI.tsx
@@ -509,7 +509,7 @@ const PowerLevel = () => {
   const { data } = useBackend<SentryData>();
   return (
     <ProgressBar
-      width="75px"
+      width="100px"
       minValue={0}
       maxValue={data.electrical.max_charge}
       value={data.electrical.charge}

--- a/tgui/packages/tgui/styles/interfaces/SentryUi.scss
+++ b/tgui/packages/tgui/styles/interfaces/SentryUi.scss
@@ -82,7 +82,11 @@ $large-text: 1.5rem;
   }
 
   .ProgressBar__content {
-    color: $dark;
+    color: $light;
+    mix-blend-mode: difference;
+    font-family: monospace;
+    font-weight: bold;
+    font-size: 1.4rem;
   }
 
   .SentryCard {


### PR DESCRIPTION
# About the pull request
Some UI Tweaks for the Sentry Computer.
Section scrolling over Window.Content scrolling so the CRT theme doesn't scroll away from you.
'Squishability' to some extent for the tabs so you can still click them and they won't overspill with little space
<!-- Remove this text and explain what the purpose of your PR is.

Re org the tab bar and let it be squishable in case you have lots of sentries or little space.
Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Stops the CRT Theme scrolling away.
Lets you squish the window if you're a maniac or accommodates 14+ Sentries if your a maniac.
# Testing Photographs and Procedure
<details>
<summary>Screenshots</summary>

![Screenshot 2025-06-27 055727](https://github.com/user-attachments/assets/cf4e5279-e8c4-4c55-a814-740612964462)

![Screenshot 2025-06-27 060016](https://github.com/user-attachments/assets/1fd44ee6-d6b8-46a9-9079-1a4e34efc976)

Does eventually get to a point it will look even dumber than above.

![image](https://github.com/user-attachments/assets/82da7810-b86b-4480-b1b2-cc49a6bd712b)

Without the squish it's more or less the same

Before:

![image](https://github.com/user-attachments/assets/0448f538-e5fb-4f4f-b693-6bc971328cfc)

</details>

# Changelog
:cl: MistChristmas
ui: Sentry Computer's CRT theme won't scroll away.
/:cl:
