### PR TITLE
Tiny fix for RMC ERT helmet slot.

### DIFF
--- a/code/modules/gear_presets/royal_marines.dm
+++ b/code/modules/gear_presets/royal_marines.dm
@@ -130,7 +130,7 @@
 
 /datum/equipment_preset/twe/royal_marine/spec/marksman/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new headset_type, WEAR_L_EAR)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/iasf_beret, WEAR_HEAD)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/royal_marine, WEAR_HEAD)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/rebreather/scarf/tacticalmask/tan, WEAR_FACE)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/veteran/royal_marine, WEAR_BODY)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/veteran/royal_marine, WEAR_HANDS)


### PR DESCRIPTION
Fixes a mistake from a previous PR that had overwritten a RMC helmet for the spec.
# About the pull request

Tiny mistake from a previous PR that accidently replaced the RMC specs helmet with an IASF beret, it should be /obj/item/clothing/head/helmet/marine/veteran/royal_marine rather then the IASF beret.

# Explain why it's good for the game

Unintended mistake, should be reverted.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Zenith

fix: Fixes a mistake from a previous PR that had overwritten a RMC helmet for the spec.

/:cl:
