### PR TITLE
Relay beacon can now be used by marines to gamble.

### DIFF
--- a/code/_globalvars/lists/mapping_globals.dm
+++ b/code/_globalvars/lists/mapping_globals.dm
@@ -13,6 +13,7 @@ GLOBAL_LIST_EMPTY(survivor_spawns_by_priority)
 GLOBAL_LIST_EMPTY(corpse_spawns)
 
 GLOBAL_LIST_EMPTY(mainship_yautja_teleports)
+GLOBAL_LIST_EMPTY(yautja_ship_spawn)
 GLOBAL_LIST_EMPTY(mainship_yautja_desc)
 GLOBAL_LIST_EMPTY(yautja_teleports)
 GLOBAL_LIST_EMPTY(yautja_teleport_descs)

--- a/code/controllers/subsystem/predships.dm
+++ b/code/controllers/subsystem/predships.dm
@@ -15,7 +15,7 @@ SUBSYSTEM_DEF(predships)
 	load_new(CLAN_SHIP_PUBLIC)
 	return SS_INIT_SUCCESS
 
-/datum/controller/subsystem/predships/proc/init_spawnpoint(obj/effect/landmark/clan_spawn/SP)
+/datum/controller/subsystem/predships/proc/init_spawnpoint(obj/effect/landmark/yautja_spawn/SP)
 	LAZYADD(spawnpoints, get_turf(SP))
 
 /datum/controller/subsystem/predships/proc/get_clan_spawnpoints(clan_id)
@@ -34,12 +34,6 @@ SUBSYSTEM_DEF(predships)
 
 /datum/controller/subsystem/predships/proc/load_new(initiating_clan_id)
 	RETURN_TYPE(/list)
-	if(isnum(initiating_clan_id))
-		initiating_clan_id = "[initiating_clan_id]"
-	if(!ship_template || !initiating_clan_id)
-		return NONE
-	if(initiating_clan_id in managed_z)
-		return managed_z[initiating_clan_id]
 	var/datum/space_level/level = ship_template.load_new_z()
 	if(level)
 		var/new_z = level.z_value
@@ -47,5 +41,3 @@ SUBSYSTEM_DEF(predships)
 		for(var/turf/spawnpoint in spawnpoints)
 			if(spawnpoint?.z == new_z)
 				new_spawns += spawnpoint
-		managed_z[initiating_clan_id] = list(level, new_spawns)
-	return managed_z[initiating_clan_id]

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -243,7 +243,8 @@ Additional game mode variables.
 	var/datum/entity/clan_player/clan_info = pred_candidate?.client?.clan_info
 	clan_info?.sync()
 	SSpredships.load_new(clan_id)
-	var/turf/spawn_point = SAFEPICK(SSpredships.get_clan_spawnpoints(clan_id))
+	var/obj/effect/landmark/yautja_spawn/picked_spawn = pick(GLOB.yautja_ship_spawn)
+	var/turf/spawn_point = get_turf(picked_spawn)
 	if(!isturf(spawn_point))
 		log_debug("Failed to find spawn point for pred ship in transform_predator - clan_id=[clan_id]")
 		to_chat(pred_candidate, SPAN_WARNING("Unable to setup spawn location - you might want to tell someone about this."))

--- a/code/game/objects/effects/landmarks/landmarks.dm
+++ b/code/game/objects/effects/landmarks/landmarks.dm
@@ -268,6 +268,19 @@
 	GLOB.xeno_hive_spawns -= src
 	return ..()
 
+/obj/effect/landmark/yautja_spawn
+	name = "yautja_spawn"
+	icon_state = "clan_spawn"
+
+/obj/effect/landmark/yautja_spawn/Initialize(mapload, ...)
+	. = ..()
+	GLOB.yautja_ship_spawn += src
+
+/obj/effect/landmark/yautja_spawn/Destroy()
+	GLOB.yautja_ship_spawn -= src
+	return ..()
+
+
 /obj/effect/landmark/yautja_teleport
 	name = "yautja_teleport"
 	icon_state = "hunter_teleport"

--- a/code/modules/cm_preds/yaut_items.dm
+++ b/code/modules/cm_preds/yaut_items.dm
@@ -490,10 +490,6 @@ GLOBAL_VAR_INIT(youngblood_timer_yautja, 0)
 		#undef TELEPORT_HUMAN_SHIP
 		#undef TELEPORT_YAUTJA_SHIP
 
-
-
-
-
 /obj/item/device/yautja_teleporter/verb/add_tele_loc()
 	set name = "Add Teleporter Destination"
 	set desc = "Adds this location to the teleporter."

--- a/code/modules/cm_preds/yaut_items.dm
+++ b/code/modules/cm_preds/yaut_items.dm
@@ -455,37 +455,40 @@ GLOBAL_VAR_INIT(youngblood_timer_yautja, 0)
 		#define TELEPORT_YAUTJA_SHIP "Yautja Ship"
 
 		to_chat(user, SPAN_WARNING("You start messing around with the alien device...going against the scream in your gut."))
-		if(do_after(user, 10 SECONDS, INTERRUPT_ALL, BUSY_ICON_GENERIC))
-			var/teleport_location = pick(TELEPORT_HUMAN_SHIP, TELEPORT_YAUTJA_SHIP)
-			var/turf/target_turf
-			var/tele_time = animation_teleport_quick_out(user)
-			var/list/targets = list()
+		if(!do_after(user, 10 SECONDS, INTERRUPT_ALL, BUSY_ICON_GENERIC))
+			to_chat(user, SPAN_WARNING("You were interrupted!"))
+			return
+
+		var/teleport_location = pick(TELEPORT_HUMAN_SHIP, TELEPORT_YAUTJA_SHIP)
+		var/turf/target_turf
+		var/tele_time = animation_teleport_quick_out(user)
+		var/list/targets = list()
 
 
-			switch(teleport_location)
-				if(TELEPORT_YAUTJA_SHIP)
-					var/obj/effect/landmark/yautja_spawn/destination = pick(GLOB.yautja_ship_spawn)
-					target_turf = get_turf(destination)
+		switch(teleport_location)
+			if(TELEPORT_YAUTJA_SHIP)
+				var/obj/effect/landmark/yautja_spawn/destination = pick(GLOB.yautja_ship_spawn)
+				target_turf = get_turf(destination)
 
-				if(TELEPORT_HUMAN_SHIP)
-					var/obj/effect/landmark/yautja_teleport/destination = pick(GLOB.mainship_yautja_teleports)
-					target_turf = get_turf(destination)
+			if(TELEPORT_HUMAN_SHIP)
+				var/obj/effect/landmark/yautja_teleport/destination = pick(GLOB.mainship_yautja_teleports)
+				target_turf = get_turf(destination)
 
-			for(var/mob/living/mobs_in_range in range(3, get_turf(H))) // Make a list because for some reason it wouldnt work any other way.
-				if(mobs_in_range.stat != DEAD)
-					targets.Add(mobs_in_range)
+		for(var/mob/living/mobs_in_range in range(3, get_turf(H))) // Make a list because for some reason it wouldnt work any other way.
+			if(mobs_in_range.stat != DEAD)
+				targets.Add(mobs_in_range)
 
-			for(var/mob/targetz in targets) // I think this will resut in some shenangians, we'll see what happens. I couldnt get tis to work any other way other then making a list.
+		for(var/mob/targetz in targets) // I think this will resut in some shenangians, we'll see what happens. I couldnt get tis to work any other way other then making a list.
 
-				animation_teleport_quick_out(targetz)
-				sleep(tele_time) // Animation delay
-				targetz.forceMove(target_turf)
-				animation_teleport_quick_in(targetz)
+			animation_teleport_quick_out(targetz)
+			sleep(tele_time) // Animation delay
+			targetz.forceMove(target_turf)
+			animation_teleport_quick_in(targetz)
 
-				user.visible_message(SPAN_DANGER("[targetz] dissapear in a puff of smoke!"))
+			user.visible_message(SPAN_DANGER("[targetz] dissapear in a puff of smoke!"))
 
-			qdel(src)
-			user.visible_message(SPAN_DANGER("The alien device decays into dust and ash as it breaks from the usage!"))
+		qdel(src)
+		user.visible_message(SPAN_DANGER("The alien device decays into dust and ash as it breaks from the usage!"))
 
 		#undef TELEPORT_HUMAN_SHIP
 		#undef TELEPORT_YAUTJA_SHIP

--- a/maps/predship/huntership.dmm
+++ b/maps/predship/huntership.dmm
@@ -3571,7 +3571,7 @@
 	dir = 4;
 	layer = 3
 	},
-/obj/effect/landmark/clan_spawn,
+/obj/effect/landmark/yautja_spawn,
 /obj/structure/prop/ice_colony/tiger_rug{
 	icon_state = "Plain";
 	color = "#52443b";
@@ -4268,7 +4268,7 @@
 /area/yautja)
 "ov" = (
 /obj/effect/hunter/bridge_border/brown,
-/obj/effect/landmark/clan_spawn,
+/obj/effect/landmark/yautja_spawn,
 /turf/open/shuttle/dropship/predship/tile/hunter_tile_6/north,
 /area/yautja)
 "oy" = (
@@ -7372,7 +7372,7 @@
 /obj/effect/hunter/bridge_border/brown{
 	dir = 8
 	},
-/obj/effect/landmark/clan_spawn,
+/obj/effect/landmark/yautja_spawn,
 /turf/open/shuttle/dropship/predship/hunter_catwalk_alt,
 /area/yautja)
 "zt" = (
@@ -9537,7 +9537,7 @@
 	pixel_y = 27;
 	anchored = 1
 	},
-/obj/effect/landmark/clan_spawn,
+/obj/effect/landmark/yautja_spawn,
 /obj/item/device/flashlight/lantern/yautja{
 	pixel_x = 3;
 	pixel_y = 15
@@ -10213,7 +10213,7 @@
 /obj/effect/hunter/bridge_border/brown/corner{
 	dir = 8
 	},
-/obj/effect/landmark/clan_spawn,
+/obj/effect/landmark/yautja_spawn,
 /turf/open/shuttle/dropship/predship/tile/hunter_tile_6/north,
 /area/yautja)
 "IT" = (
@@ -10982,7 +10982,7 @@
 	pixel_y = 36;
 	anchored = 1
 	},
-/obj/effect/landmark/clan_spawn,
+/obj/effect/landmark/yautja_spawn,
 /turf/open/shuttle/dropship/predship/tile/hunter_tile_6/north,
 /area/yautja)
 "LJ" = (
@@ -13173,7 +13173,7 @@
 /obj/effect/hunter/bridge_border/brown/corner{
 	dir = 4
 	},
-/obj/effect/landmark/clan_spawn,
+/obj/effect/landmark/yautja_spawn,
 /obj/item/device/flashlight/lantern/yautja{
 	pixel_x = -3;
 	pixel_y = -2
@@ -13564,7 +13564,7 @@
 /obj/effect/hunter/bridge_border/brown{
 	dir = 1
 	},
-/obj/effect/landmark/clan_spawn,
+/obj/effect/landmark/yautja_spawn,
 /turf/open/shuttle/dropship/predship/hunter_catwalk_alt,
 /area/yautja)
 "Uv" = (


### PR DESCRIPTION
# About the pull request

Relay beacon can now be used by people without YAUTJA_TECH on a 50/50 chance to teleport you to the pred ship or the almayer.

some of the code stuff relating to clan id ive removed might be unneeded, let me know

Theres a 10 second use time 

# Explain why it's good for the game

I think this will introduce a pathway for people wanting to kill preds other then just the fun of the fight, and lead to invading the predship.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
code: removes yautja spawn locations being tied to clan ID
code:  new landmark called yautja spawner.
add: Relay beacons can now be fiddled with as a marine or any human mob.
/:cl:
