### PR TITLE
Organ repair surgery now requires the usage of a stack of the surgery tool.

### DIFF
--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -36,6 +36,17 @@ and organ transplant code which may come in handy in future but haven't been edi
 	)
 	time = 3 SECONDS
 	repeat_step = TRUE
+	///How many stacks to use for each organ.
+	var/use_stack = 1
+
+// Use materials to repair organs
+/datum/surgery_step/repair_organs/extra_checks(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, repeating, skipped)
+	. = ..()
+	if(istype(tool, /obj/item/stack/medical))
+		var/obj/item/stack/medical/packs = tool
+		if(!packs.use(use_stack))
+			to_chat(user, SPAN_BOLDWARNING("You don't have enough of \the [packs]!"))
+			return FALSE
 
 /datum/surgery_step/repair_organs/repeat_step_criteria(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, tool_type, datum/surgery/surgery)
 	for(var/datum/internal_organ/IO as anything in surgery.affected_limb.internal_organs)
@@ -92,6 +103,11 @@ and organ transplant code which may come in handy in future but haven't been edi
 		SPAN_WARNING("Your hand slips, bruising [target]'s organs and contaminating \his [surgery.affected_limb.cavity]!"),
 		SPAN_WARNING("[user]'s hand slips, bruising your organs and contaminating your [surgery.affected_limb.cavity]!"),
 		SPAN_WARNING("[user]'s hand slips, bruising [target]'s organs and contaminating \his [surgery.affected_limb.cavity]!"))
+
+	//Refund the stack
+	if(istype(tool, /obj/item/stack/medical))
+		var/obj/item/stack/medical/packs = tool
+		packs.add(use_stack)
 
 	var/dam_amt = 2
 	switch(tool_type)


### PR DESCRIPTION

# About the pull request

This PR adds the requirement for organ repair surgery to use up one of the stacks used for the surgery.

# Explain why it's good for the game

Trauma packs and other tools used for organ repair have set quantities, but these are only used for external wounds. Bone repair surgery currently requires the usage of some bone gel, which is a bit inconsistent. Now both bone repair and organ repair surgeries will use up their respective tools.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

N/A

</details>


# Changelog
:cl:
balance: Organ repair surgery now requires the usage of a stack of the tool used.
/:cl:
