### PR TITLE
Pounces now need a windup to go between z levels.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -388,7 +388,7 @@
 
 	if(A.z != X.z)
 
-		if (!do_after(X, 3 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE))
+		if (!do_after(X, 2 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE))
 			return
 
 		X.throw_atom(A, distance, throw_speed, X, launch_type = LOW_LAUNCH, pass_flags = pounce_pass_flags, collision_callbacks = pounce_callbacks, tracking=TRUE)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -386,6 +386,14 @@
 	if(A.layer >= FLY_LAYER)//anything above that shouldn't be pounceable (hud stuff)
 		return
 
+	if(A.z != X.z)
+
+		if (!do_after(X, 3 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE))
+			return
+
+		X.throw_atom(A, distance, throw_speed, X, launch_type = LOW_LAUNCH, pass_flags = pounce_pass_flags, collision_callbacks = pounce_callbacks, tracking=TRUE)
+
+
 	if(!isturf(X.loc))
 		to_chat(X, SPAN_XENOWARNING("We can't [action_text] from here!"))
 		return


### PR DESCRIPTION
# About the pull request

Pounces now need about 2 seconds to go up or down a z level

# Explain why it's good for the game


I think just being unable to chase anything around because they can just click the parkour ability is going to be very frustrating for marines, and really strong for xenos.

This should make it so you can take a risk for safety.
im willing to budge on maybe runners being able to do this without a windup, will need to talk

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Pounces now take two seconds if you're aiming for another z level.
/:cl:
