### PR TITLE
Prevent Fruits balloon alert spam for every not related Destroy() proc call.

### DIFF
--- a/code/datums/effects/_effects.dm
+++ b/code/datums/effects/_effects.dm
@@ -36,7 +36,7 @@
 	var/obj_icon_state_path = null //The icon_state path for objs
 	var/mob_icon_state_path = null //The icon_state path for mobs
 	var/datum/cause_data/cause_data = null //Cause data for statistics
-	var/from_fruit = FALSE //Used for effects caused by Gardener Fruits
+	var/show_baloon_alert = FALSE //Used to limit balloon alerts
 
 /datum/effects/New(atom/thing, mob/from = null, last_dmg_source = null, zone = "chest")
 	if(!validate_atom(thing) || QDELETED(thing))

--- a/code/datums/effects/_effects.dm
+++ b/code/datums/effects/_effects.dm
@@ -36,6 +36,7 @@
 	var/obj_icon_state_path = null //The icon_state path for objs
 	var/mob_icon_state_path = null //The icon_state path for mobs
 	var/datum/cause_data/cause_data = null //Cause data for statistics
+	var/from_fruit = FALSE //Used for effects caused by Gardener Fruits
 
 /datum/effects/New(atom/thing, mob/from = null, last_dmg_source = null, zone = "chest")
 	if(!validate_atom(thing) || QDELETED(thing))

--- a/code/datums/effects/heal_over_time.dm
+++ b/code/datums/effects/heal_over_time.dm
@@ -6,14 +6,14 @@
 	var/ticks_between_heals = 1
 	var/heal_each_process = 0
 
-/datum/effects/heal_over_time/New(atom/A, heal_amount = 0, healing_time = 5, time_between_heals = 1, limb_name = null, from_fruit = FALSE)
+/datum/effects/heal_over_time/New(atom/A, heal_amount = 0, healing_time = 5, time_between_heals = 1, limb_name = null, show_baloon_alert = FALSE)
 	..(A, null, null, limb_name)
 
 	duration = healing_time
 	total_heal_amount = heal_amount
 	ticks_between_heals = time_between_heals
 	heal_each_process = (heal_amount / healing_time) * time_between_heals
-	src.from_fruit = from_fruit
+	src.show_baloon_alert = show_baloon_alert
 
 /datum/effects/heal_over_time/validate_atom(atom/A)
 	if(isobj(A))
@@ -37,7 +37,7 @@
 /datum/effects/heal_over_time/Destroy()
 	if(affected_atom)
 		var/mob/living/carbon/xenomorph/xeno = affected_atom
-		if(istype(xeno) && from_fruit)
+		if(istype(xeno) && show_baloon_alert)
 			xeno.balloon_alert(xeno, "our regeneration speed returns to normal.", text_color = "#17991b80")
 			playsound(xeno, 'sound/effects/squish_and_exhaust.ogg', 25, 1)
 	return ..()

--- a/code/datums/effects/heal_over_time.dm
+++ b/code/datums/effects/heal_over_time.dm
@@ -5,7 +5,6 @@
 	var/total_heal_amount = 0
 	var/ticks_between_heals = 1
 	var/heal_each_process = 0
-	var/from_fruit = FALSE
 
 /datum/effects/heal_over_time/New(atom/A, heal_amount = 0, healing_time = 5, time_between_heals = 1, limb_name = null, from_fruit = FALSE)
 	..(A, null, null, limb_name)
@@ -38,7 +37,7 @@
 /datum/effects/heal_over_time/Destroy()
 	if(affected_atom)
 		var/mob/living/carbon/xenomorph/xeno = affected_atom
-		if(from_fruit)
+		if(istype(xeno) && from_fruit)
 			xeno.balloon_alert(xeno, "our regeneration speed returns to normal.", text_color = "#17991b80")
 			playsound(xeno, 'sound/effects/squish_and_exhaust.ogg', 25, 1)
 	return ..()

--- a/code/datums/effects/heal_over_time.dm
+++ b/code/datums/effects/heal_over_time.dm
@@ -5,14 +5,16 @@
 	var/total_heal_amount = 0
 	var/ticks_between_heals = 1
 	var/heal_each_process = 0
+	var/from_fruit = FALSE
 
-/datum/effects/heal_over_time/New(atom/A, heal_amount = 0, healing_time = 5, time_between_heals = 1, limb_name = null)
+/datum/effects/heal_over_time/New(atom/A, heal_amount = 0, healing_time = 5, time_between_heals = 1, limb_name = null, from_fruit = FALSE)
 	..(A, null, null, limb_name)
 
 	duration = healing_time
 	total_heal_amount = heal_amount
 	ticks_between_heals = time_between_heals
 	heal_each_process = (heal_amount / healing_time) * time_between_heals
+	src.from_fruit = from_fruit
 
 /datum/effects/heal_over_time/validate_atom(atom/A)
 	if(isobj(A))
@@ -36,7 +38,7 @@
 /datum/effects/heal_over_time/Destroy()
 	if(affected_atom)
 		var/mob/living/carbon/xenomorph/xeno = affected_atom
-		if(istype(xeno))
+		if(from_fruit)
 			xeno.balloon_alert(xeno, "our regeneration speed returns to normal.", text_color = "#17991b80")
 			playsound(xeno, 'sound/effects/squish_and_exhaust.ogg', 25, 1)
 	return ..()

--- a/code/datums/effects/plasma_over_time.dm
+++ b/code/datums/effects/plasma_over_time.dm
@@ -6,14 +6,14 @@
 	var/ticks_between_plasmas = 1
 	var/plasma_each_process = 0
 
-/datum/effects/plasma_over_time/New(atom/A, plasma_amount = 0, plasma_time = 5, time_between_plasmas = 1, from_fruit = FALSE)
+/datum/effects/plasma_over_time/New(atom/A, plasma_amount = 0, plasma_time = 5, time_between_plasmas = 1, show_baloon_alert = FALSE)
 	..(A, null, null)
 
 	duration = plasma_time
 	total_plasma_amount = plasma_amount
 	ticks_between_plasmas = time_between_plasmas
 	plasma_each_process = (plasma_amount / plasma_time) * time_between_plasmas
-	src.from_fruit = from_fruit
+	src.show_baloon_alert = show_baloon_alert
 
 /datum/effects/plasma_over_time/validate_atom(atom/A)
 	if(!isxeno(A))
@@ -36,7 +36,7 @@
 /datum/effects/plasma_over_time/Destroy()
 	if(affected_atom)
 		var/mob/living/carbon/xenomorph/xeno = affected_atom
-		if(istype(xeno) && from_fruit)
+		if(istype(xeno) && show_baloon_alert)
 			xeno.balloon_alert(xeno, "our plasma rush subsides.", text_color = "#1e6072")
 			playsound(xeno, 'sound/effects/squish_and_exhaust.ogg', 25, 1)
 	return ..()

--- a/code/datums/effects/plasma_over_time.dm
+++ b/code/datums/effects/plasma_over_time.dm
@@ -6,13 +6,14 @@
 	var/ticks_between_plasmas = 1
 	var/plasma_each_process = 0
 
-/datum/effects/plasma_over_time/New(atom/A, plasma_amount = 0, plasma_time = 5, time_between_plasmas = 1)
+/datum/effects/plasma_over_time/New(atom/A, plasma_amount = 0, plasma_time = 5, time_between_plasmas = 1, from_fruit = FALSE)
 	..(A, null, null)
 
 	duration = plasma_time
 	total_plasma_amount = plasma_amount
 	ticks_between_plasmas = time_between_plasmas
 	plasma_each_process = (plasma_amount / plasma_time) * time_between_plasmas
+	src.from_fruit = from_fruit
 
 /datum/effects/plasma_over_time/validate_atom(atom/A)
 	if(!isxeno(A))
@@ -35,7 +36,7 @@
 /datum/effects/plasma_over_time/Destroy()
 	if(affected_atom)
 		var/mob/living/carbon/xenomorph/xeno = affected_atom
-		if(istype(xeno))
+		if(istype(xeno) && from_fruit)
 			xeno.balloon_alert(xeno, "our plasma rush subsides.", text_color = "#1e6072")
 			playsound(xeno, 'sound/effects/squish_and_exhaust.ogg', 25, 1)
 	return ..()

--- a/code/datums/effects/xeno_strains/gain_xeno_cooldown_reduction_on_slash.dm
+++ b/code/datums/effects/xeno_strains/gain_xeno_cooldown_reduction_on_slash.dm
@@ -7,7 +7,7 @@
 	var/reduction_amount_per_slash = 0
 	var/current_reduction = 0
 
-/datum/effects/gain_xeno_cooldown_reduction_on_slash/New(atom/A, mob/from = null, max_reduction_amount = 0, reduction_per_slash = 0, duration = 0, effect_source = null, from_fruit = FALSE)
+/datum/effects/gain_xeno_cooldown_reduction_on_slash/New(atom/A, mob/from = null, max_reduction_amount = 0, reduction_per_slash = 0, duration = 0, effect_source = null, show_baloon_alert = FALSE)
 	. = ..(A, from, null, null)
 
 	src.effect_source = effect_source
@@ -18,7 +18,7 @@
 	COMSIG_HUMAN_ALIEN_ATTACK
 	), PROC_REF(increase_cooldown_reduction))
 	QDEL_IN(src, duration)
-	src.from_fruit = from_fruit
+	src.show_baloon_alert = show_baloon_alert
 
 /datum/effects/gain_xeno_cooldown_reduction_on_slash/validate_atom(atom/A)
 	if(isxeno(A))
@@ -29,7 +29,7 @@
 	if(affected_atom)
 		var/mob/living/carbon/xenomorph/xeno  = affected_atom
 		xeno.cooldown_reduction_percentage -= current_reduction
-		if(istype(xeno) && from_fruit)
+		if(istype(xeno) && show_baloon_alert)
 			to_chat(xeno, SPAN_XENOWARNING("We feel our frenzy wane! Our cooldowns are back to normal."))
 			xeno.balloon_alert(xeno, "we feel our frenzy wane!", text_color = "#99461780")
 			playsound(xeno, 'sound/effects/squish_and_exhaust.ogg', 25, 1)

--- a/code/datums/effects/xeno_strains/gain_xeno_cooldown_reduction_on_slash.dm
+++ b/code/datums/effects/xeno_strains/gain_xeno_cooldown_reduction_on_slash.dm
@@ -7,7 +7,7 @@
 	var/reduction_amount_per_slash = 0
 	var/current_reduction = 0
 
-/datum/effects/gain_xeno_cooldown_reduction_on_slash/New(atom/A, mob/from = null, max_reduction_amount = 0, reduction_per_slash = 0, duration = 0, effect_source = null)
+/datum/effects/gain_xeno_cooldown_reduction_on_slash/New(atom/A, mob/from = null, max_reduction_amount = 0, reduction_per_slash = 0, duration = 0, effect_source = null, from_fruit = FALSE)
 	. = ..(A, from, null, null)
 
 	src.effect_source = effect_source
@@ -18,6 +18,7 @@
 	COMSIG_HUMAN_ALIEN_ATTACK
 	), PROC_REF(increase_cooldown_reduction))
 	QDEL_IN(src, duration)
+	src.from_fruit = from_fruit
 
 /datum/effects/gain_xeno_cooldown_reduction_on_slash/validate_atom(atom/A)
 	if(isxeno(A))
@@ -28,9 +29,10 @@
 	if(affected_atom)
 		var/mob/living/carbon/xenomorph/xeno  = affected_atom
 		xeno.cooldown_reduction_percentage -= current_reduction
-		to_chat(xeno, SPAN_XENOWARNING("We feel our frenzy wane! Our cooldowns are back to normal."))
-		xeno.balloon_alert(xeno, "we feel our frenzy wane!", text_color = "#99461780")
-		playsound(xeno, 'sound/effects/squish_and_exhaust.ogg', 25, 1)
+		if(istype(xeno) && from_fruit)
+			to_chat(xeno, SPAN_XENOWARNING("We feel our frenzy wane! Our cooldowns are back to normal."))
+			xeno.balloon_alert(xeno, "we feel our frenzy wane!", text_color = "#99461780")
+			playsound(xeno, 'sound/effects/squish_and_exhaust.ogg', 25, 1)
 		if(xeno.cooldown_reduction_percentage < 0)
 			xeno.cooldown_reduction_percentage = 0
 

--- a/code/datums/effects/xeno_strains/xeno_speed.dm
+++ b/code/datums/effects/xeno_strains/xeno_speed.dm
@@ -6,7 +6,7 @@
 	var/effect_modifier_source = null
 	var/effect_end_message = null
 
-/datum/effects/xeno_speed/New(atom/A, mob/from = null, last_dmg_source = null, zone = "chest", ttl = 3.5 SECONDS, set_speed_modifier = 0, set_modifier_source = null, set_end_message = SPAN_XENONOTICE("You feel lethargic..."), from_fruit = FALSE)
+/datum/effects/xeno_speed/New(atom/A, mob/from = null, last_dmg_source = null, zone = "chest", ttl = 3.5 SECONDS, set_speed_modifier = 0, set_modifier_source = null, set_end_message = SPAN_XENONOTICE("You feel lethargic..."), show_baloon_alert = FALSE)
 	. = ..(A, from, last_dmg_source, zone)
 	if(QDELETED(src))
 		return
@@ -20,7 +20,7 @@
 	effect_modifier_source = set_modifier_source
 	effect_end_message = set_end_message
 	added_effect = TRUE
-	src.from_fruit = from_fruit
+	src.show_baloon_alert = show_baloon_alert
 
 /datum/effects/xeno_speed/validate_atom(atom/A)
 	if(!isxeno(A))
@@ -45,7 +45,7 @@
 			LAZYREMOVE(xeno.modifier_sources, effect_modifier_source)
 		if(effect_end_message)
 			to_chat(xeno, effect_end_message)
-		if(istype(xeno) && from_fruit)
+		if(istype(xeno) && show_baloon_alert)
 			xeno.balloon_alert(xeno, "our speed fall back to normal.", text_color = "#5B248C")
 			playsound(xeno, 'sound/effects/squish_and_exhaust.ogg', 25, 1)
 	return ..()

--- a/code/datums/effects/xeno_strains/xeno_speed.dm
+++ b/code/datums/effects/xeno_strains/xeno_speed.dm
@@ -6,7 +6,7 @@
 	var/effect_modifier_source = null
 	var/effect_end_message = null
 
-/datum/effects/xeno_speed/New(atom/A, mob/from = null, last_dmg_source = null, zone = "chest", ttl = 3.5 SECONDS, set_speed_modifier = 0, set_modifier_source = null, set_end_message = SPAN_XENONOTICE("You feel lethargic..."))
+/datum/effects/xeno_speed/New(atom/A, mob/from = null, last_dmg_source = null, zone = "chest", ttl = 3.5 SECONDS, set_speed_modifier = 0, set_modifier_source = null, set_end_message = SPAN_XENONOTICE("You feel lethargic..."), from_fruit = FALSE)
 	. = ..(A, from, last_dmg_source, zone)
 	if(QDELETED(src))
 		return
@@ -20,6 +20,7 @@
 	effect_modifier_source = set_modifier_source
 	effect_end_message = set_end_message
 	added_effect = TRUE
+	src.from_fruit = from_fruit
 
 /datum/effects/xeno_speed/validate_atom(atom/A)
 	if(!isxeno(A))
@@ -44,6 +45,7 @@
 			LAZYREMOVE(xeno.modifier_sources, effect_modifier_source)
 		if(effect_end_message)
 			to_chat(xeno, effect_end_message)
-		xeno.balloon_alert(xeno, "our speed fall back to normal.", text_color = "#5B248C")
-		playsound(xeno, 'sound/effects/squish_and_exhaust.ogg', 25, 1)
+		if(istype(xeno) && from_fruit)
+			xeno.balloon_alert(xeno, "our speed fall back to normal.", text_color = "#5B248C")
+			playsound(xeno, 'sound/effects/squish_and_exhaust.ogg', 25, 1)
 	return ..()

--- a/code/modules/cm_aliens/structures/fruit.dm
+++ b/code/modules/cm_aliens/structures/fruit.dm
@@ -219,7 +219,7 @@
 	if(recipient && !QDELETED(recipient))
 		recipient.gain_health(heal_amount)
 		//Every second, heal them for 20.
-		new /datum/effects/heal_over_time(recipient, regeneration_amount_total, regeneration_ticks, 1, from_fruit = TRUE)
+		new /datum/effects/heal_over_time(recipient, regeneration_amount_total, regeneration_ticks, 1, show_baloon_alert = TRUE)
 		to_chat(recipient, SPAN_XENOBOLDNOTICE("We recover a bit from our injuries, and begin to regenerate rapidly."))
 		recipient.balloon_alert(recipient, "our flesh mends, and the regeneration quickens!", text_color = "#17991B")
 	if(do_consume)
@@ -255,7 +255,7 @@
 	if(mature && recipient && !QDELETED(recipient))
 		recipient.add_xeno_shield(clamp(overshield_amount, 0, recipient.maxHealth * 0.3), XENO_SHIELD_SOURCE_GARDENER, duration = shield_duration, decay_amount_per_second = shield_decay)
 		//Every second, heal them for 5.
-		new /datum/effects/heal_over_time(recipient, regeneration_amount_total, regeneration_ticks, 1, from_fruit = TRUE)
+		new /datum/effects/heal_over_time(recipient, regeneration_amount_total, regeneration_ticks, 1, show_baloon_alert = TRUE)
 		to_chat(recipient, SPAN_XENOBOLDNOTICE("We feel our defense being bolstered, and begin to slowly regenerate."))
 		recipient.balloon_alert(recipient, "our regeneration quickens and carapace thickens!", text_color = "#179973")
 	if(do_consume)
@@ -291,7 +291,7 @@
 		for(var/datum/effects/gain_xeno_cooldown_reduction_on_slash/E in recipient.effects_list)
 			if(E.effect_source == "spore")
 				qdel(E)
-		new /datum/effects/gain_xeno_cooldown_reduction_on_slash(recipient, bound_xeno, max_cooldown_reduction, cooldown_per_slash, 90 SECONDS, "spore", from_fruit = TRUE)
+		new /datum/effects/gain_xeno_cooldown_reduction_on_slash(recipient, bound_xeno, max_cooldown_reduction, cooldown_per_slash, 90 SECONDS, "spore", show_baloon_alert = TRUE)
 		to_chat(recipient, SPAN_XENOBOLDNOTICE("We feel a frenzy coming onto us! Our abilities will cool off faster as we slash!"))
 		recipient.balloon_alert(recipient, "we feel a frenzy coming onto us!", text_color = "#994617", delay = 1 SECONDS)
 	if(do_consume)
@@ -342,7 +342,7 @@
 
 /obj/effect/alien/resin/fruit/speed/consume_effect(mob/living/carbon/xenomorph/recipient, do_consume = TRUE)
 	if(mature && recipient && !QDELETED(recipient))
-		new /datum/effects/xeno_speed(recipient, ttl = speed_duration, set_speed_modifier = speed_buff_amount, set_modifier_source = XENO_FRUIT_SPEED, set_end_message = SPAN_XENOWARNING("We feel the effects of the [name] wane..."), from_fruit = TRUE)
+		new /datum/effects/xeno_speed(recipient, ttl = speed_duration, set_speed_modifier = speed_buff_amount, set_modifier_source = XENO_FRUIT_SPEED, set_end_message = SPAN_XENOWARNING("We feel the effects of the [name] wane..."), show_baloon_alert = TRUE)
 		to_chat(recipient, SPAN_XENOBOLDNOTICE("The [name] invigorates us to move faster!"))
 		recipient.balloon_alert(recipient, "we feel invigorated to run faster!", text_color = "#5B248C", delay = 1 SECONDS)
 	if(do_consume)
@@ -373,7 +373,7 @@
 /obj/effect/alien/resin/fruit/plasma/consume_effect(mob/living/carbon/xenomorph/recipient, do_consume = TRUE)
 	if(mature && recipient && recipient.plasma_max > 0 && !QDELETED(recipient))
 		//With the current values (240, 15, 3), this will give the recipient 48 plasma every 3 seconds, for a total of 240 in 15 seconds.
-		new /datum/effects/plasma_over_time(recipient, plasma_amount, plasma_time, time_between_plasmas, from_fruit = TRUE)
+		new /datum/effects/plasma_over_time(recipient, plasma_amount, plasma_time, time_between_plasmas, show_baloon_alert = TRUE)
 		to_chat(recipient, SPAN_XENOBOLDNOTICE("The [name] boosts our plasma regeneration!"))
 		recipient.balloon_alert(recipient, "we feel our plasma rapidly regenerate!", text_color = "#287A90")
 	if(do_consume)

--- a/code/modules/cm_aliens/structures/fruit.dm
+++ b/code/modules/cm_aliens/structures/fruit.dm
@@ -219,7 +219,7 @@
 	if(recipient && !QDELETED(recipient))
 		recipient.gain_health(heal_amount)
 		//Every second, heal them for 20.
-		new /datum/effects/heal_over_time(recipient, regeneration_amount_total, regeneration_ticks, 1)
+		new /datum/effects/heal_over_time(recipient, regeneration_amount_total, regeneration_ticks, 1, from_fruit = TRUE)
 		to_chat(recipient, SPAN_XENOBOLDNOTICE("We recover a bit from our injuries, and begin to regenerate rapidly."))
 		recipient.balloon_alert(recipient, "our flesh mends, and the regeneration quickens!", text_color = "#17991B")
 	if(do_consume)
@@ -255,7 +255,7 @@
 	if(mature && recipient && !QDELETED(recipient))
 		recipient.add_xeno_shield(clamp(overshield_amount, 0, recipient.maxHealth * 0.3), XENO_SHIELD_SOURCE_GARDENER, duration = shield_duration, decay_amount_per_second = shield_decay)
 		//Every second, heal them for 5.
-		new /datum/effects/heal_over_time(recipient, regeneration_amount_total, regeneration_ticks, 1)
+		new /datum/effects/heal_over_time(recipient, regeneration_amount_total, regeneration_ticks, 1, from_fruit = TRUE)
 		to_chat(recipient, SPAN_XENOBOLDNOTICE("We feel our defense being bolstered, and begin to slowly regenerate."))
 		recipient.balloon_alert(recipient, "our regeneration quickens and carapace thickens!", text_color = "#179973")
 	if(do_consume)

--- a/code/modules/cm_aliens/structures/fruit.dm
+++ b/code/modules/cm_aliens/structures/fruit.dm
@@ -291,7 +291,7 @@
 		for(var/datum/effects/gain_xeno_cooldown_reduction_on_slash/E in recipient.effects_list)
 			if(E.effect_source == "spore")
 				qdel(E)
-		new /datum/effects/gain_xeno_cooldown_reduction_on_slash(recipient, bound_xeno, max_cooldown_reduction, cooldown_per_slash, 90 SECONDS, "spore")
+		new /datum/effects/gain_xeno_cooldown_reduction_on_slash(recipient, bound_xeno, max_cooldown_reduction, cooldown_per_slash, 90 SECONDS, "spore", from_fruit = TRUE)
 		to_chat(recipient, SPAN_XENOBOLDNOTICE("We feel a frenzy coming onto us! Our abilities will cool off faster as we slash!"))
 		recipient.balloon_alert(recipient, "we feel a frenzy coming onto us!", text_color = "#994617", delay = 1 SECONDS)
 	if(do_consume)
@@ -342,7 +342,7 @@
 
 /obj/effect/alien/resin/fruit/speed/consume_effect(mob/living/carbon/xenomorph/recipient, do_consume = TRUE)
 	if(mature && recipient && !QDELETED(recipient))
-		new /datum/effects/xeno_speed(recipient, ttl = speed_duration, set_speed_modifier = speed_buff_amount, set_modifier_source = XENO_FRUIT_SPEED, set_end_message = SPAN_XENOWARNING("We feel the effects of the [name] wane..."))
+		new /datum/effects/xeno_speed(recipient, ttl = speed_duration, set_speed_modifier = speed_buff_amount, set_modifier_source = XENO_FRUIT_SPEED, set_end_message = SPAN_XENOWARNING("We feel the effects of the [name] wane..."), from_fruit = TRUE)
 		to_chat(recipient, SPAN_XENOBOLDNOTICE("The [name] invigorates us to move faster!"))
 		recipient.balloon_alert(recipient, "we feel invigorated to run faster!", text_color = "#5B248C", delay = 1 SECONDS)
 	if(do_consume)
@@ -373,7 +373,7 @@
 /obj/effect/alien/resin/fruit/plasma/consume_effect(mob/living/carbon/xenomorph/recipient, do_consume = TRUE)
 	if(mature && recipient && recipient.plasma_max > 0 && !QDELETED(recipient))
 		//With the current values (240, 15, 3), this will give the recipient 48 plasma every 3 seconds, for a total of 240 in 15 seconds.
-		new /datum/effects/plasma_over_time(recipient, plasma_amount, plasma_time, time_between_plasmas)
+		new /datum/effects/plasma_over_time(recipient, plasma_amount, plasma_time, time_between_plasmas, from_fruit = TRUE)
 		to_chat(recipient, SPAN_XENOBOLDNOTICE("The [name] boosts our plasma regeneration!"))
 		recipient.balloon_alert(recipient, "we feel our plasma rapidly regenerate!", text_color = "#287A90")
 	if(do_consume)


### PR DESCRIPTION
# About the pull request

This is a fix for issue caused by #9572, i did make tests for shield fruit, becouse there many xenos using shield abilities, but i forgot about xenos that do healing abilities (i forgor)

also i forgot to credit fixing issue on #9572:

Fixes: #8660

# Explain why it's good for the game

Less balloon alert spam caused by healing, like healing drones, queen heal, warrior slash healing, some bullets effects triggering balloons, it should be triggered only by fruits.

# Changelog
:cl: Venuska1117
fix: Fruit balloon alert now only trigger after consuming fruit, instead for every not related Destroy() proc call.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
