### PR TITLE
Improvements for Healer Drone "Sacrifice" Ability 

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/drone/healer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/drone/healer.dm
@@ -262,11 +262,15 @@
 
 	xeno.say(";MY LIFE FOR THE QUEEN!!!")
 
+	target.ExtinguishMob() //first, extinguish them from fire so they can be healed.
+
 	if(target.health < 0)
-		target.gain_health(abs(target.health)) // gets them out of crit first
+		target.gain_health(abs(target.health)) //second, get them out of crit.
 
 	target.gain_health(xeno.health * transfer_mod)
 	target.updatehealth()
+
+	target.clear_debuffs() //third, remove debuffs so they can stand up.
 
 	target.xeno_jitter(1 SECONDS)
 	target.flick_heal_overlay(3 SECONDS, "#44253d")


### PR DESCRIPTION
# About the pull request

Makes Healer "Sacrifice" Extinguish and remove debuffs.

# Explain why it's good for the game

I never had reason as healer to use sacrifice even after filling it up and giving me free revive, most of times its pointless to use it, boiler is on OB fire and no one is around? you could use sacrifice but they will burn to death anyway, queen getting hit by sadar rocket? you run and sacrifice yourself, only for queen to still be stunned from rocket under heavy fire of enemy weapons, sacrificing yourself to get removed from round (if you did not fill bar to full) only to have nearly to zero impact, sacrifice require too specific conditions to be actually game changing and this PR aim to improve that.


# Testing Photographs and Procedure
<details>
<summary>>Click HERE for Video<</summary>

Example video of boiler getting set on fire and resisting it, drone sacrificed to remove fire, heal and remove stun from resist:

https://github.com/user-attachments/assets/b4b45ac4-e8bc-46b7-9057-0fa9b532556b

</details>


# Changelog

:cl: Venuska1117
balance: Healer Drone "Sacrifice" ability now extinguish and remove debuffs.
/:cl:
