### PR TITLE
Filteriffic & Particle editor fixes and VV icon QoL

### DIFF
--- a/code/__DEFINES/generators.dm
+++ b/code/__DEFINES/generators.dm
@@ -13,3 +13,4 @@
 #define P_DATA_ICON_ADD "icon_add"
 #define P_DATA_ICON_REMOVE "icon_remove"
 #define P_DATA_ICON_WEIGHT "icon_edit"
+#define P_DATA_GRADIENT "gradient"

--- a/code/__DEFINES/matrices.dm
+++ b/code/__DEFINES/matrices.dm
@@ -1,0 +1,15 @@
+/// Identity transform matrix (2d) with 6 values
+/// list(ax,by,c, dx,dy,f)
+#define TRANSFORM_MATRIX_IDENTITY list(1,0,0, 0,1,0)
+
+/// Identity transform matrix (xyz + translation) with 12 values
+/// list(xx,xy,xz, yx,yy,yz, zx,zy,zz, cx,cy,cz)
+#define TRANSFORM_COMPLEX_MATRIX_IDENTITY list(1,0,0, 0,1,0, 0,0,1, 0,0,0)
+
+/// Identity transform matrix (xyzw + projection) with 16 values exclusive to particles
+/// list(xx,xy,xz,xw, yx,yy,yz,yw, zx,zy,zz,zw, wx,wy,wz,ww)
+#define TRANSFORM_PROJECTION_MATRIX_IDENTITY list(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1)
+
+/// Identity matrix for colors with 20 values
+/// list(rr,rg,rb,ra, gr,gg,gb,ga, br,bg,bb,ba, ar,ag,ab,aa, cr,cg,cb,ca)
+#define COLOR_MATRIX_IDENTITY list(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1, 0,0,0,0)

--- a/code/__HELPERS/filters.dm
+++ b/code/__HELPERS/filters.dm
@@ -22,20 +22,27 @@ GLOBAL_LIST_INIT(master_filter_info, list(
 			"size" = 1
 		)
 	),
-	/* Not supported because making a proper matrix editor on the frontend would be a huge dick pain.
-		Uncomment if you ever implement it
+	// Not implemented fully
+	// Needs either a proper matrix editor, or just a hook to our existing one
+	// Issue is filterrific assumes variables will have the same value type if they share the same name, which this violates
+	// Gotta refactor this sometime
 	"color" = list(
 		"defaults" = list(
 			"color" = matrix(),
 			"space" = FILTER_COLOR_RGB
+		),
+		"enums" = list(
+			"FILTER_COLOR_RGB" = FILTER_COLOR_RGB,
+			"FILTER_COLOR_HSV" = FILTER_COLOR_HSV,
+			"FILTER_COLOR_HSL" = FILTER_COLOR_HSL,
+			"FILTER_COLOR_HCY" = FILTER_COLOR_HCY
 		)
 	),
-	*/
 	"displace" = list(
 		"defaults" = list(
 			"x" = 0,
 			"y" = 0,
-			"size" = null,
+			"size" = 1,
 			"icon" = ICON_NOT_SET,
 			"render_source" = ""
 		)
@@ -64,6 +71,18 @@ GLOBAL_LIST_INIT(master_filter_info, list(
 			"color" = "",
 			"transform" = null,
 			"blend_mode" = BLEND_DEFAULT
+		),
+		"flags" = list(
+			"FILTER_OVERLAY" = FILTER_OVERLAY,
+			"FILTER_UNDERLAY" = FILTER_UNDERLAY
+		),
+		"enums" = list(
+			"BLEND_DEFAULT" = BLEND_DEFAULT,
+			"BLEND_OVERLAY" = BLEND_OVERLAY,
+			"BLEND_ADD" = BLEND_ADD,
+			"BLEND_SUBTRACT" = BLEND_SUBTRACT,
+			"BLEND_MULTIPLY" = BLEND_MULTIPLY,
+			"BLEND_INSET_OVERLAY" = BLEND_INSET_OVERLAY
 		)
 	),
 	"motion_blur" = list(
@@ -137,7 +156,6 @@ GLOBAL_LIST_INIT(master_filter_info, list(
 ))
 
 #undef ICON_NOT_SET
-
 
 //Helpers to generate lists for filter helpers
 //This is the only practical way of writing these that actually produces sane lists
@@ -313,6 +331,8 @@ GLOBAL_LIST_INIT(master_filter_info, list(
 		animate(offset = random_roll - 1, time = rand() * 20 + 10)
 
 /proc/remove_wibbly_filters(atom/in_atom)
+	if(QDELETED(in_atom))
+		return
 	var/filter
 	for(var/i in 1 to 7)
 		filter = in_atom.get_filter("wibbly-[i]")

--- a/code/__HELPERS/filters.dm
+++ b/code/__HELPERS/filters.dm
@@ -22,7 +22,6 @@ GLOBAL_LIST_INIT(master_filter_info, list(
 			"size" = 1
 		)
 	),
-	// Not implemented fully
 	// Needs either a proper matrix editor, or just a hook to our existing one
 	// Issue is filterrific assumes variables will have the same value type if they share the same name, which this violates
 	// Gotta refactor this sometime
@@ -69,7 +68,7 @@ GLOBAL_LIST_INIT(master_filter_info, list(
 			"render_source" = "",
 			"flags" = FILTER_OVERLAY,
 			"color" = "",
-			"transform" = null,
+			"transform" = TRANSFORM_MATRIX_IDENTITY,
 			"blend_mode" = BLEND_DEFAULT
 		),
 		"flags" = list(

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -680,6 +680,61 @@ world
 
 	return FALSE
 
+/// Asks the user for an icon (either from file or as a path) and offers to customize it if possible (e.g. setting icon_state)
+/proc/pick_and_customize_icon(mob/user, old_value, pick_only=FALSE)
+	var/icon/icon_result = null
+	if(!user)
+		user = usr
+
+	var/icon_from_file = tgui_alert(user, "Do you wish to pick an icon from file?", "File picker icon", list("Yes", "No"))
+	if(isnull(icon_from_file))
+		return null
+	if(icon_from_file == "Yes")
+		icon_result = input(user, "Pick icon:", "Icon") as null|icon
+		if(!icon_result)
+			return null
+	else if(icon_from_file == "No")
+		var/new_icon = tgui_input_text(user, "Pick icon path", "icon path")
+		if(isnull(new_icon))
+			return null
+		var/regex/regex = regex(@"^.+icons/")
+		new_icon = regex.Replace(replacetext(new_icon, @"\", "/"), "icons/")
+		icon_result = fcopy_rsc(new_icon)
+		if(!icon_result)
+			to_chat(user, SPAN_WARNING("'[new_icon]' is an invalid icon path!"))
+			return null
+
+	var/dmi_path = get_icon_dmi_path(icon_result)
+	if(!dmi_path || pick_only)
+		return icon_result
+
+	var/custom = tgui_alert(user, "Do you wish to specify any arguments for the icon?", "Customize Icon", list("Yes", "No"))
+	if(isnull(custom))
+		return null
+	if(custom == "Yes")
+		var/new_icon_state = tgui_input_text(user, "Pick icon_state", "icon_state")
+		if(isnull(new_icon_state))
+			return null
+		var/new_icon_dir = tgui_input_list(user, "Pick icon dir", "dir", list("North", "East", "South", "West"), default="South")
+		if(isnull(new_icon_dir))
+			return null
+		var/new_icon_frame = tgui_input_number(user, "Pick icon frame", "frame", min_value=0, integer_only=TRUE)
+		if(isnull(new_icon_frame))
+			return null
+		var/new_icon_moving = tgui_input_list(user, "Pick icon moving", "moving", list("Both", "Movement only", "Non-Movement Only"), default="Both")
+		switch(new_icon_moving)
+			if("Both")
+				new_icon_moving = null
+			if("Movement only")
+				new_icon_moving = 1
+			if("Non-Movement Only")
+				new_icon_moving = 0
+			else
+				return null
+		icon_result = new(dmi_path, new_icon_state, text2dir(new_icon_dir), new_icon_frame, new_icon_moving)
+
+	return icon_result
+
 /**
  * generate an asset for the given icon or the icon of the given appearance for [thing], and send it to any clients in target.
  * Arguments:

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -681,7 +681,7 @@ world
 	return FALSE
 
 /// Asks the user for an icon (either from file or as a path) and offers to customize it if possible (e.g. setting icon_state)
-/proc/pick_and_customize_icon(mob/user, old_value, pick_only=FALSE)
+/proc/pick_and_customize_icon(mob/user, pick_only=FALSE)
 	var/icon/icon_result = null
 	if(!user)
 		user = usr

--- a/code/__HELPERS/matrices.dm
+++ b/code/__HELPERS/matrices.dm
@@ -102,16 +102,11 @@ list(-1,0,0,0, 0,-1,0,0, 0,0,-1,0, 0,0,0,1, 1,1,1,0)
 list(0.393,0.349,0.272,0, 0.769,0.686,0.534,0, 0.189,0.168,0.131,0, 0,0,0,1, 0,0,0,0)
 */
 
-
-//Does nothing
-/proc/color_matrix_identity()
-	return list(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1, 0,0,0,0)
-
 //word of warning: using a matrix like this as a color value will simplify it back to a string after being set
 /proc/color_hex2color_matrix(string)
 	var/length = length(string)
 	if((length != 7 && length != 9) || length != length_char(string))
-		return color_matrix_identity()
+		return COLOR_MATRIX_IDENTITY
 	var/r = hex2num(copytext(string, 2, 4))/255
 	var/g = hex2num(copytext(string, 4, 6))/255
 	var/b = hex2num(copytext(string, 6, 8))/255
@@ -119,13 +114,13 @@ list(0.393,0.349,0.272,0, 0.769,0.686,0.534,0, 0.189,0.168,0.131,0, 0,0,0,1, 0,0
 	if(length == 9)
 		a = hex2num(copytext(string, 8, 10))/255
 	if(!isnum(r) || !isnum(g) || !isnum(b) || !isnum(a))
-		return color_matrix_identity()
+		return COLOR_MATRIX_IDENTITY
 	return list(r,0,0,0, 0,g,0,0, 0,0,b,0, 0,0,0,a, 0,0,0,0)
 
 ///Converts a hex color string to a color matrix.
 /proc/color_matrix_from_string(string)
 	if(!string || !istext(string))
-		return color_matrix_identity()
+		return COLOR_MATRIX_IDENTITY
 
 	var/string_r = hex2num(copytext(string, 2, 4)) / 255
 	var/string_g = hex2num(copytext(string, 4, 6)) / 255
@@ -192,9 +187,9 @@ round(cos_inv_third+sqrt3_sin, 0.001), round(cos_inv_third-sqrt3_sin, 0.001), ro
 //Returns a matrix addition of A with B
 /proc/color_matrix_add(list/A, list/B)
 	if(!istype(A) || !istype(B))
-		return color_matrix_identity()
+		return COLOR_MATRIX_IDENTITY
 	if(length(A) != 20 || length(B) != 20)
-		return color_matrix_identity()
+		return COLOR_MATRIX_IDENTITY
 	var/list/output = list()
 	output.len = 20
 	for(var/value in 1 to 20)
@@ -205,9 +200,9 @@ round(cos_inv_third+sqrt3_sin, 0.001), round(cos_inv_third-sqrt3_sin, 0.001), ro
 //Returns a matrix multiplication of A with B
 /proc/color_matrix_multiply(list/A, list/B)
 	if(!istype(A) || !istype(B))
-		return color_matrix_identity()
+		return COLOR_MATRIX_IDENTITY
 	if(length(A) != 20 || length(B) != 20)
-		return color_matrix_identity()
+		return COLOR_MATRIX_IDENTITY
 	var/list/output = list()
 	output.len = 20
 	var/x = 1
@@ -225,7 +220,7 @@ round(cos_inv_third+sqrt3_sin, 0.001), round(cos_inv_third-sqrt3_sin, 0.001), ro
 The arg is a list of hex colours, for ex "list("#d4c218", "#b929f7", "#339933"".
 if you want variations of the same color, color_matrix_recolor_red() is simpler.**/
 /proc/color_matrix_recolor_rgb(list/replacement_shades)
-	var/list/final_matrix = color_matrix_identity()
+	var/list/final_matrix = COLOR_MATRIX_IDENTITY
 
 	if(length(replacement_shades) != 3)
 		CRASH("color_matrix_recolor_rgb() called with less than 3 replacement colours.")

--- a/code/datums/global_variables.dm
+++ b/code/datums/global_variables.dm
@@ -399,7 +399,7 @@
 			global.vars[variable] = var_new
 
 		if("icon")
-			var/var_new = input("Pick icon:","Icon",global.vars[variable]) as null|icon
+			var/var_new = pick_and_customize_icon(old_value=global.vars[variable], pick_only=TRUE)
 			if(var_new==null)
 				return
 			global.vars[variable] = var_new

--- a/code/datums/global_variables.dm
+++ b/code/datums/global_variables.dm
@@ -399,7 +399,7 @@
 			global.vars[variable] = var_new
 
 		if("icon")
-			var/var_new = pick_and_customize_icon(old_value=global.vars[variable], pick_only=TRUE)
+			var/var_new = pick_and_customize_icon(pick_only=TRUE)
 			if(var_new==null)
 				return
 			global.vars[variable] = var_new

--- a/code/modules/admin/view_variables/color_matrix_editor.dm
+++ b/code/modules/admin/view_variables/color_matrix_editor.dm
@@ -60,7 +60,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/color_matrix_proxy_view)
 	else if(istext(_target?.color))
 		current_color = color_hex2color_matrix(_target.color)
 	else
-		current_color = color_matrix_identity()
+		current_color = COLOR_MATRIX_IDENTITY
 	proxy_view = new
 	if(_target)
 		target = WEAKREF(_target)

--- a/code/modules/admin/view_variables/filterrific.dm
+++ b/code/modules/admin/view_variables/filterrific.dm
@@ -24,7 +24,7 @@
 	data["target_filter_data"] = target.filter_data
 	return data
 
-/datum/filter_editor/ui_act(action, list/params)
+/datum/filter_editor/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
 	if(.)
 		return
@@ -72,7 +72,7 @@
 				target.transition_filter(params["name"], list("color" = new_color), 4)
 				. = TRUE
 		if("modify_icon_value")
-			var/icon/new_icon = input("Pick icon:", "Icon") as null|icon
+			var/icon/new_icon = pick_and_customize_icon()
 			if(new_icon)
 				target.filter_data[params["name"]]["icon"] = new_icon
 				target.update_filters()

--- a/code/modules/admin/view_variables/get_variables.dm
+++ b/code/modules/admin/view_variables/get_variables.dm
@@ -236,7 +236,7 @@
 				return
 
 		if(VV_ICON)
-			.["value"] = input("Pick icon:", "Icon") as null|icon
+			.["value"] = pick_and_customize_icon(pick_only=TRUE)
 			if(.["value"] == null)
 				.["class"] = null
 				return

--- a/code/modules/admin/view_variables/get_variables.dm
+++ b/code/modules/admin/view_variables/get_variables.dm
@@ -328,7 +328,7 @@
 
 		if(VV_COLOR_MATRIX)
 			.["value"] = open_color_matrix_editor()
-			if(.["value"] == color_matrix_identity()) //identity is equivalent to null
+			if(.["value"] == COLOR_MATRIX_IDENTITY) //identity is equivalent to null
 				.["class"] = null
 
 		if(VV_INFINITY)

--- a/code/modules/admin/view_variables/particle_editor.dm
+++ b/code/modules/admin/view_variables/particle_editor.dm
@@ -141,7 +141,7 @@
 			if(!target.particles.transform || length(target.particles.transform) != new_size)
 				switch(new_size)
 					if(6)
-						target.particles.transform = TRANSFORM_MATRIX_IDENTITY
+						target.particles.transform = list(1,0,0, 1,0,0) // TRANSFORM_MATRIX_IDENTITY seems wrong for only particles?
 					if(12)
 						target.particles.transform = TRANSFORM_COMPLEX_MATRIX_IDENTITY
 					if(16)

--- a/code/modules/admin/view_variables/particle_editor.dm
+++ b/code/modules/admin/view_variables/particle_editor.dm
@@ -29,7 +29,15 @@
 	data["bound1"] = islist(bound1) ? bound1 : list(bound1,bound1,bound1) //float OR list(x, y, z)
 	data["bound2"] = islist(bound2) ? bound2 : list(bound2,bound2,bound2) //float OR list(x, y, z)
 	data["gravity"] = gravity //list(x, y, z)
-	data["gradient"] = gradient //gradient array list(number, string, number, string, "loop", "space"=COLORSPACE_RGB)
+
+	var/list/tgui_grad_list = list()
+	for(var/entry in gradient)
+		if(entry == "space")
+			tgui_grad_list += list(list("[entry]" = gradient[entry])) // package this thing else json encoding breaks
+			continue
+		tgui_grad_list += entry
+	data["gradient"] = tgui_grad_list //gradient array list(number, string, number, string, "loop", "space"=COLORSPACE_RGB)
+
 	data["transform"] = transform //list(a, b, c, d, e, f) OR list(xx,xy,xz, yx,yy,yz, zx,zy,zz) OR list(xx,xy,xz, yx,yy,yz, zx,zy,zz, cx,cy,cz) OR list(xx,xy,xz,xw, yx,yy,yz,yw, zx,zy,zz,zw, wx,wy,wz,ww)
 
 	//applied on spawn
@@ -102,6 +110,7 @@
 	data["target_name"] = target.name
 	if(!target.particles)
 		target.particles = new /particles
+		target.particles.gradient = list(0, "red", 1, "#ffffff", "loop", "space"=COLORSPACE_RGB) // TODO: Remove this
 	data["particle_data"] = target.particles.return_ui_representation(user)
 	return data
 
@@ -131,11 +140,15 @@
 			. = TRUE
 			target.particles.datum_flags |= DF_VAR_EDITED
 			if(!target.particles.transform)
-				target.particles.transform = new /list(new_size)
+				target.particles.transform = list()
+				for(var/i in 1 to new_size)
+					target.particles.transform += 0
 				return
 			var/size = length(target.particles.transform)
 			if(size < new_size)
-				target.particles.transform += new /list(new_size-size)
+				target.particles.transform = list()
+				for(var/i in 1 to new_size-size)
+					target.particles.transform += 0
 				return
 			//transform is not cast as a list
 			var/list/holder =  target.particles.transform
@@ -162,7 +175,7 @@
 						var_value[3] = var_value[1]
 					var_value = generator(arglist(var_value))
 				if(P_DATA_ICON_ADD)
-					var_value = input("Pick icon:", "Icon") as null|icon
+					var_value = pick_and_customize_icon(ui.user, pick_only=TRUE)
 					if(!var_value)
 						return FALSE
 					var/list/new_values = list()
@@ -190,6 +203,13 @@
 					for(var/file in owner.icon)
 						if("[file]" == mod_data[1])
 							owner.icon[file] = mod_data[2]
+					target.particles.datum_flags |= DF_VAR_EDITED
+					return TRUE
+				if(P_DATA_GRADIENT)
+					var/list/new_grad_list = list()
+					for(var/entry in var_value)
+						new_grad_list += entry // Unpackage nested lists
+					owner.gradient = new_grad_list
 					target.particles.datum_flags |= DF_VAR_EDITED
 					return TRUE
 

--- a/code/modules/admin/view_variables/particle_editor.dm
+++ b/code/modules/admin/view_variables/particle_editor.dm
@@ -133,16 +133,20 @@
 			target.particles.datum_flags |= DF_VAR_EDITED
 			. = TRUE
 		if("transform_size")
-			var/list/values = list("Simple Matrix" = 6, "Complex Matrix" = 12, "Projection Matrix" = 16)
-			var/new_size = values[params["new_value"]]
+			var/list/matrix_size = list("Simple Matrix" = 6, "Complex Matrix" = 12, "Projection Matrix" = 16)
+			var/new_size = matrix_size[params["new_value"]]
 			if(!new_size)
 				return FALSE
 			. = TRUE
 			target.particles.datum_flags |= DF_VAR_EDITED
 			if(!target.particles.transform || length(target.particles.transform) != new_size)
-				target.particles.transform = list()
-				for(var/i in 1 to new_size)
-					target.particles.transform += 0
+				switch(new_size)
+					if(6)
+						target.particles.transform = TRANSFORM_MATRIX_IDENTITY
+					if(12)
+						target.particles.transform = TRANSFORM_COMPLEX_MATRIX_IDENTITY
+					if(16)
+						target.particles.transform = TRANSFORM_PROJECTION_MATRIX_IDENTITY
 				return
 		if("edit")
 			var/particles/owner = target.particles

--- a/code/modules/admin/view_variables/particle_editor.dm
+++ b/code/modules/admin/view_variables/particle_editor.dm
@@ -110,7 +110,6 @@
 	data["target_name"] = target.name
 	if(!target.particles)
 		target.particles = new /particles
-		target.particles.gradient = list(0, "red", 1, "#ffffff", "loop", "space"=COLORSPACE_RGB) // TODO: Remove this
 	data["particle_data"] = target.particles.return_ui_representation(user)
 	return data
 

--- a/code/modules/admin/view_variables/particle_editor.dm
+++ b/code/modules/admin/view_variables/particle_editor.dm
@@ -139,20 +139,11 @@
 				return FALSE
 			. = TRUE
 			target.particles.datum_flags |= DF_VAR_EDITED
-			if(!target.particles.transform)
+			if(!target.particles.transform || length(target.particles.transform) != new_size)
 				target.particles.transform = list()
 				for(var/i in 1 to new_size)
 					target.particles.transform += 0
 				return
-			var/size = length(target.particles.transform)
-			if(size < new_size)
-				target.particles.transform = list()
-				for(var/i in 1 to new_size-size)
-					target.particles.transform += 0
-				return
-			//transform is not cast as a list
-			var/list/holder =  target.particles.transform
-			holder.Cut(new_size)
 		if("edit")
 			var/particles/owner = target.particles
 			var/param_var_name = params["var"]

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -77,6 +77,7 @@
 #include "code\__DEFINES\maps.dm"
 #include "code\__DEFINES\marine.dm"
 #include "code\__DEFINES\math_physics.dm"
+#include "code\__DEFINES\matrices.dm"
 #include "code\__DEFINES\MC.dm"
 #include "code\__DEFINES\minimap.dm"
 #include "code\__DEFINES\misc.dm"

--- a/tgui/packages/tgui/interfaces/Filteriffic.tsx
+++ b/tgui/packages/tgui/interfaces/Filteriffic.tsx
@@ -81,7 +81,7 @@ type MasterFilter = {
       render_source: string;
       flags: number;
       color: string;
-      transform: null | number;
+      transform: null | number[];
       blend_mode: number;
     };
     enums: {
@@ -173,6 +173,14 @@ type FilterEntryProps = {
   readonly filterType: string;
 };
 
+type FilterEntryTransformProps = {
+  readonly name: string;
+  readonly value: number[];
+  readonly hasValue: boolean;
+  readonly filterName: string;
+  readonly filterType: string;
+};
+
 export type Data = {
   filter_info: MasterFilter;
   target_name: string;
@@ -239,6 +247,35 @@ const FilterFloatEntry = (props: FilterEntryProps) => {
         onChange={(value) => setStep(value)}
       />
     </>
+  );
+};
+
+const FilterTransformEntry = (props: FilterEntryProps) => {
+  const { name, value, hasValue, filterName, filterType } = props;
+  const { act } = useBackend();
+
+  return (
+    <Box>
+      {value?.map((current_value: number, current_index: number) => (
+        <NumberInput
+          key={current_index}
+          value={current_value}
+          minValue={0}
+          maxValue={1}
+          step={1}
+          onDrag={(new_value) =>
+            act('modify_filter_value', {
+              name: filterName,
+              new_data: {
+                [name]: value!.map((x: number, i: number) =>
+                  i === current_index ? new_value : x,
+                ),
+              },
+            })
+          }
+        />
+      ))}
+    </Box>
   );
 };
 
@@ -371,6 +408,7 @@ const FilterDataEntry = (props: FilterEntryProps) => {
     icon: <FilterIconEntry {...props} />,
     flags: <FilterFlagsEntry {...props} />,
     enum: <FilterEnumEntry {...props} />,
+    transform: <FilterTransformEntry {...props} />,
   };
 
   const filterEntryMap = {
@@ -391,7 +429,7 @@ const FilterDataEntry = (props: FilterEntryProps) => {
     alpha: 'int',
     space: 'enum',
     blend_mode: 'enum',
-    // transform
+    transform: 'transform',
   };
 
   return (
@@ -481,7 +519,7 @@ const FilterEntry = (props: {
   );
 };
 
-export const Filteriffic = (props) => {
+export const Filteriffic = (props: any) => {
   const { act, data } = useBackend<Data>();
   const name = data.target_name || 'Unknown Object';
   const filters = data.target_filter_data || {};

--- a/tgui/packages/tgui/interfaces/Filteriffic.tsx
+++ b/tgui/packages/tgui/interfaces/Filteriffic.tsx
@@ -173,14 +173,6 @@ type FilterEntryProps = {
   readonly filterType: string;
 };
 
-type FilterEntryTransformProps = {
-  readonly name: string;
-  readonly value: number[];
-  readonly hasValue: boolean;
-  readonly filterName: string;
-  readonly filterType: string;
-};
-
 export type Data = {
   filter_info: MasterFilter;
   target_name: string;

--- a/tgui/packages/tgui/interfaces/Filteriffic.tsx
+++ b/tgui/packages/tgui/interfaces/Filteriffic.tsx
@@ -345,7 +345,7 @@ const FilterFlagsEntry = (props: FilterEntryProps) => {
   const { act, data } = useBackend<Data>();
 
   const filterInfo = data.filter_info;
-  const flags: { string: number } = filterInfo[filterType]['flags'];
+  const flags: Record<string, number> = filterInfo[filterType]['flags'];
   return Object.entries(flags).map(([flagName, bitField]) => (
     <Button.Checkbox
       checked={value & bitField}
@@ -369,7 +369,7 @@ const FilterEnumEntry = (props: FilterEntryProps) => {
   const { act, data } = useBackend<Data>();
 
   const filterInfo = data.filter_info;
-  const enums: { string: number } = filterInfo[filterType]['enums'];
+  const enums: Record<string, number> = filterInfo[filterType]['enums'];
   return Object.entries(enums).map(([enumName, enumNumber]) => (
     <Button.Checkbox
       checked={value === enumNumber}

--- a/tgui/packages/tgui/interfaces/Filteriffic.tsx
+++ b/tgui/packages/tgui/interfaces/Filteriffic.tsx
@@ -30,128 +30,157 @@ type MasterFilter = {
       MASK_INVERSE: number;
       MASK_SWAP: number;
     };
-
-    angular_blur: {
-      defaults: {
-        x: number;
-        y: number;
-        size: number;
-      };
+  };
+  angular_blur: {
+    defaults: {
+      x: number;
+      y: number;
+      size: number;
     };
-    displace: {
-      defaults: {
-        x: number;
-        y: number;
-        size: null | number;
-        icon: string;
-        render_source: '';
-      };
+  };
+  color: {
+    defaults: {
+      color: string;
+      space: number;
     };
-    drop_shadow: {
-      defaults: {
-        x: number;
-        y: number;
-        size: number;
-        offset: number;
-        color: string;
-      };
+    enums: {
+      FILTER_COLOR_RGB: number;
+      FILTER_COLOR_HSV: number;
+      FILTER_COLOR_HSL: number;
+      FILTER_COLOR_HCY: number;
     };
-    blur: {
-      defaults: {
-        size: number;
-      };
+  };
+  displace: {
+    defaults: {
+      x: number;
+      y: number;
+      size: number;
+      icon: string;
+      render_source: '';
     };
-    layer: {
-      defaults: {
-        x: number;
-        y: number;
-        icon: string;
-        render_source: string;
-        flags: number;
-        color: string;
-        transform: null | number;
-        blend_mode: number;
-      };
+  };
+  drop_shadow: {
+    defaults: {
+      x: number;
+      y: number;
+      size: number;
+      offset: number;
+      color: string;
     };
-    motion_blur: {
-      defaults: {
-        x: number;
-        y: number;
-      };
+  };
+  blur: {
+    defaults: {
+      size: number;
     };
-    outline: {
-      defaults: {
-        size: number;
-        color: string;
-        flags: number;
-      };
-      flags: {
-        OUTLINE_SHARP: number;
-        OUTLINE_SQUARE: number;
-      };
+  };
+  layer: {
+    defaults: {
+      x: number;
+      y: number;
+      icon: string;
+      render_source: string;
+      flags: number;
+      color: string;
+      transform: null | number;
+      blend_mode: number;
     };
-    radial_blur: {
-      defaults: {
-        x: number;
-        y: number;
-        size: number;
-      };
+    enums: {
+      BLEND_DEFAULT: number;
+      BLEND_OVERLAY: number;
+      BLEND_ADD: number;
+      BLEND_SUBTRACT: number;
+      BLEND_MULTIPLY: number;
+      BLEND_INSET_OVERLAY: number;
     };
-    rays: {
-      defaults: {
-        x: number;
-        y: number;
-        size: number;
-        color: string;
-        offset: number;
-        density: number;
-        threshold: number;
-        factor: number;
-        flags: number;
-      };
-      flags: {
-        FILTER_OVERLAY: number;
-        FILTER_UNDERLAY: number;
-      };
+  };
+  motion_blur: {
+    defaults: {
+      x: number;
+      y: number;
     };
-    ripple: {
-      defaults: {
-        x: number;
-        y: number;
-        size: number;
-        repeat: number;
-        radius: number;
-        falloff: number;
-        flags: number;
-      };
-      flags: {
-        WAVE_BOUNDED: number;
-      };
+  };
+  outline: {
+    defaults: {
+      size: number;
+      color: string;
+      flags: number;
     };
-    wave: {
-      defaults: {
-        x: number;
-        y: number;
-        size: number;
-        offset: number;
-        flags: number;
-      };
-      flags: {
-        WAVE_SIDEWAYS: number;
-        WAVE_BOUNDED: number;
-      };
+    flags: {
+      OUTLINE_SHARP: number;
+      OUTLINE_SQUARE: number;
+    };
+  };
+  radial_blur: {
+    defaults: {
+      x: number;
+      y: number;
+      size: number;
+    };
+  };
+  rays: {
+    defaults: {
+      x: number;
+      y: number;
+      size: number;
+      color: string;
+      offset: number;
+      density: number;
+      threshold: number;
+      factor: number;
+      flags: number;
+    };
+    flags: {
+      FILTER_OVERLAY: number;
+      FILTER_UNDERLAY: number;
+    };
+  };
+  ripple: {
+    defaults: {
+      x: number;
+      y: number;
+      size: number;
+      repeat: number;
+      radius: number;
+      falloff: number;
+      flags: number;
+    };
+    flags: {
+      WAVE_BOUNDED: number;
+    };
+  };
+  wave: {
+    defaults: {
+      x: number;
+      y: number;
+      size: number;
+      offset: number;
+      flags: number;
+    };
+    flags: {
+      WAVE_SIDEWAYS: number;
+      WAVE_BOUNDED: number;
     };
   };
 };
 
-type Data = {
-  filter_info: MasterFilter;
-  target_name: string;
-  target_filter_data: string[];
+type ActiveFilters = { type: string; priority: number } & Partial<MasterFilter>;
+
+type FilterEntryProps = {
+  readonly name: string;
+  readonly value: any;
+  readonly hasValue: boolean;
+  readonly filterName: string;
+  readonly filterType: string;
 };
 
-const FilterIntegerEntry = (props) => {
-  const { value, name, filterName } = props;
+export type Data = {
+  filter_info: MasterFilter;
+  target_name: string;
+  target_filter_data: Record<string, ActiveFilters>;
+};
+
+const FilterIntegerEntry = (props: FilterEntryProps) => {
+  const { name, value, hasValue, filterName, filterType } = props;
   const { act } = useBackend();
   return (
     <NumberInput
@@ -173,8 +202,8 @@ const FilterIntegerEntry = (props) => {
   );
 };
 
-const FilterFloatEntry = (props) => {
-  const { value, name, filterName } = props;
+const FilterFloatEntry = (props: FilterEntryProps) => {
+  const { name, value, hasValue, filterName, filterType } = props;
   const { act } = useBackend();
   const [step, setStep] = useState(0.01);
 
@@ -213,8 +242,8 @@ const FilterFloatEntry = (props) => {
   );
 };
 
-const FilterTextEntry = (props) => {
-  const { value, name, filterName } = props;
+const FilterTextEntry = (props: FilterEntryProps) => {
+  const { name, value, hasValue, filterName, filterType } = props;
   const { act } = useBackend();
 
   return (
@@ -233,8 +262,8 @@ const FilterTextEntry = (props) => {
   );
 };
 
-const FilterColorEntry = (props) => {
-  const { value, filterName, name } = props;
+const FilterColorEntry = (props: FilterEntryProps) => {
+  const { name, value, hasValue, filterName, filterType } = props;
   const { act } = useBackend();
   return (
     <>
@@ -263,8 +292,8 @@ const FilterColorEntry = (props) => {
   );
 };
 
-const FilterIconEntry = (props) => {
-  const { value, filterName } = props;
+const FilterIconEntry = (props: FilterEntryProps) => {
+  const { name, value, hasValue, filterName, filterType } = props;
   const { act } = useBackend();
   return (
     <>
@@ -283,8 +312,8 @@ const FilterIconEntry = (props) => {
   );
 };
 
-const FilterFlagsEntry = (props) => {
-  const { name, value, filterName, filterType } = props;
+const FilterFlagsEntry = (props: FilterEntryProps) => {
+  const { name, value, hasValue, filterName, filterType } = props;
   const { act, data } = useBackend<Data>();
 
   const filterInfo = data.filter_info;
@@ -307,8 +336,32 @@ const FilterFlagsEntry = (props) => {
   ));
 };
 
-const FilterDataEntry = (props) => {
-  const { name, value, hasValue, filterName } = props;
+const FilterEnumEntry = (props: FilterEntryProps) => {
+  const { name, value, hasValue, filterName, filterType } = props;
+  const { act, data } = useBackend<Data>();
+
+  const filterInfo = data.filter_info;
+  const enums = filterInfo[filterType]['enums'];
+  return map(enums, (enumNumber: number, enumName) => (
+    <Button.Checkbox
+      checked={value === enumNumber}
+      onClick={() =>
+        act('modify_filter_value', {
+          name: filterName,
+          new_data: {
+            [name]: enumNumber,
+          },
+        })
+      }
+      key={enumName}
+    >
+      {enumName}
+    </Button.Checkbox>
+  ));
+};
+
+const FilterDataEntry = (props: FilterEntryProps) => {
+  const { name, value, hasValue, filterName, filterType } = props;
 
   const filterEntryTypes = {
     int: <FilterIntegerEntry {...props} />,
@@ -317,6 +370,7 @@ const FilterDataEntry = (props) => {
     color: <FilterColorEntry {...props} />,
     icon: <FilterIconEntry {...props} />,
     flags: <FilterFlagsEntry {...props} />,
+    enum: <FilterEnumEntry {...props} />,
   };
 
   const filterEntryMap = {
@@ -334,6 +388,10 @@ const FilterDataEntry = (props) => {
     threshold: 'float',
     factor: 'float',
     repeat: 'int',
+    alpha: 'int',
+    space: 'enum',
+    blend_mode: 'enum',
+    // transform
   };
 
   return (
@@ -348,7 +406,10 @@ const FilterDataEntry = (props) => {
   );
 };
 
-const FilterEntry = (props) => {
+const FilterEntry = (props: {
+  readonly name: string;
+  readonly filterDataEntry: ActiveFilters;
+}) => {
   const { act, data } = useBackend<Data>();
   const { name, filterDataEntry } = props;
   const { type, priority, ...restOfProps } = filterDataEntry;
@@ -482,8 +543,12 @@ export const Filteriffic = (props) => {
           {!hasFilters ? (
             <Box>No filters</Box>
           ) : (
-            map(filters, (entry, key) => (
-              <FilterEntry filterDataEntry={entry} name={key} key={key} />
+            Object.entries(filters).map(([name, filterData]) => (
+              <FilterEntry
+                filterDataEntry={filterData}
+                name={name}
+                key={name}
+              />
             ))
           )}
         </Section>

--- a/tgui/packages/tgui/interfaces/Filteriffic.tsx
+++ b/tgui/packages/tgui/interfaces/Filteriffic.tsx
@@ -1,4 +1,3 @@
-import { map } from 'common/collections';
 import { toFixed } from 'common/math';
 import { numberOfDecimalDigits } from 'common/math';
 import { useState } from 'react';
@@ -346,8 +345,8 @@ const FilterFlagsEntry = (props: FilterEntryProps) => {
   const { act, data } = useBackend<Data>();
 
   const filterInfo = data.filter_info;
-  const flags = filterInfo[filterType]['flags'];
-  return map(flags, (bitField: number, flagName) => (
+  const flags: { string: number } = filterInfo[filterType]['flags'];
+  return Object.entries(flags).map(([flagName, bitField]) => (
     <Button.Checkbox
       checked={value & bitField}
       onClick={() =>
@@ -370,8 +369,8 @@ const FilterEnumEntry = (props: FilterEntryProps) => {
   const { act, data } = useBackend<Data>();
 
   const filterInfo = data.filter_info;
-  const enums = filterInfo[filterType]['enums'];
-  return map(enums, (enumNumber: number, enumName) => (
+  const enums: { string: number } = filterInfo[filterType]['enums'];
+  return Object.entries(enums).map(([enumName, enumNumber]) => (
     <Button.Checkbox
       checked={value === enumNumber}
       onClick={() =>

--- a/tgui/packages/tgui/interfaces/ParticleEdit/EntriesBasic.tsx
+++ b/tgui/packages/tgui/interfaces/ParticleEdit/EntriesBasic.tsx
@@ -251,25 +251,24 @@ export const EntryTransform = (props: EntryTransformProps) => {
           />
         </Stack.Item>
         <Stack.Item>
-          {transform &&
-            transform.map((value, index) => (
-              <NumberInput
-                animated
-                key={index}
-                value={value}
-                minValue={0}
-                maxValue={1}
-                step={1}
-                onDrag={(value) =>
-                  act('edit', {
-                    var: var_name,
-                    new_value: transform!.map((x, i) =>
-                      i === index ? value : x,
-                    ),
-                  })
-                }
-              />
-            ))}
+          {transform?.map((value, index) => (
+            <NumberInput
+              animated
+              key={index}
+              value={value}
+              minValue={0}
+              maxValue={1}
+              step={1}
+              onDrag={(value) =>
+                act('edit', {
+                  var: var_name,
+                  new_value: transform!.map((x, i) =>
+                    i === index ? value : x,
+                  ),
+                })
+              }
+            />
+          ))}
         </Stack.Item>
       </Stack>
     </LabeledList.Item>

--- a/tgui/packages/tgui/interfaces/ParticleEdit/EntriesBasic.tsx
+++ b/tgui/packages/tgui/interfaces/ParticleEdit/EntriesBasic.tsx
@@ -17,6 +17,7 @@ import {
   type EntryIconStateProps,
   type EntryTransformProps,
   MatrixTypes,
+  P_DATA_GRADIENT,
   P_DATA_ICON_ADD,
   P_DATA_ICON_REMOVE,
   P_DATA_ICON_WEIGHT,
@@ -109,12 +110,22 @@ export const EntryCoord = (props: EntryCoordProps) => {
 export const EntryGradient = (props: EntryGradientProps) => {
   const { act, data } = useBackend<ParticleUIData>();
   const { name, var_name, gradient, setDesc } = props;
+  const cleanGradient = gradient?.map((entry) => {
+    if (typeof entry === 'object') {
+      return Object.keys(entry)[0];
+    } else {
+      return entry;
+    }
+  });
   const isLooping = gradient?.find((x) => x === 'loop');
-  const space_type = gradient?.includes('space')
-    ? Object.keys(SpaceToNum).find(
-        (space) => SpaceToNum[space] === gradient['space'],
-      )
-    : 'COLORSPACE_RGB';
+  const spaceIndex = cleanGradient ? cleanGradient.indexOf('space') : -1;
+  const space_type =
+    spaceIndex >= 0
+      ? Object.keys(SpaceToNum).find(
+          (space) =>
+            SpaceToNum[space] === Object.values(gradient![spaceIndex])[0],
+        )
+      : 'COLORSPACE_RGB';
   return (
     <LabeledList.Item label={name}>
       <Stack>
@@ -133,6 +144,7 @@ export const EntryGradient = (props: EntryGradientProps) => {
             onClick={() =>
               act('edit', {
                 var: var_name,
+                var_mod: P_DATA_GRADIENT,
                 new_value: isLooping
                   ? gradient!.filter((x, i) => i !== gradient!.indexOf('loop'))
                   : [...(gradient || []), 'loop'],
@@ -147,6 +159,7 @@ export const EntryGradient = (props: EntryGradientProps) => {
             onSelected={(e) =>
               act('edit', {
                 var: var_name,
+                var_mod: P_DATA_GRADIENT,
                 new_value: gradient
                   ? setGradientSpace(gradient, SpaceToNum[e])
                   : { space: SpaceToNum[e] },
@@ -156,7 +169,7 @@ export const EntryGradient = (props: EntryGradientProps) => {
           />
         </Stack.Item>
         <Stack.Item>
-          {gradient?.map((entry, index) =>
+          {cleanGradient?.map((entry, index) =>
             entry === 'loop' || entry === 'space' ? null : (
               <>
                 {typeof entry === 'string' ? (
@@ -169,6 +182,7 @@ export const EntryGradient = (props: EntryGradientProps) => {
                   onChange={(e, value) =>
                     act('edit', {
                       var: var_name,
+                      var_mod: P_DATA_GRADIENT,
                       new_value: gradient!.map((x, i) =>
                         i === index ? value : x,
                       ),
@@ -181,7 +195,8 @@ export const EntryGradient = (props: EntryGradientProps) => {
                   onClick={() =>
                     act('edit', {
                       var: var_name,
-                      new_value: gradient.filter((x, i) => i !== index),
+                      var_mod: P_DATA_GRADIENT,
+                      new_value: gradient!.filter((x, i) => i !== index),
                     })
                   }
                 />
@@ -196,6 +211,7 @@ export const EntryGradient = (props: EntryGradientProps) => {
             onClick={() =>
               act('edit', {
                 var: var_name,
+                var_mod: P_DATA_GRADIENT,
                 new_value: [...(gradient || []), '#FFFFFF'],
               })
             }
@@ -235,24 +251,25 @@ export const EntryTransform = (props: EntryTransformProps) => {
           />
         </Stack.Item>
         <Stack.Item>
-          {transform?.map((value, index) => (
-            <NumberInput
-              animated
-              key={index}
-              value={value}
-              minValue={0}
-              maxValue={1}
-              step={1}
-              onDrag={(value) =>
-                act('edit', {
-                  var: var_name,
-                  new_value: transform!.map((x, i) =>
-                    i === index ? value : x,
-                  ),
-                })
-              }
-            />
-          ))}
+          {transform &&
+            transform.map((value, index) => (
+              <NumberInput
+                animated
+                key={index}
+                value={value}
+                minValue={0}
+                maxValue={1}
+                step={1}
+                onDrag={(value) =>
+                  act('edit', {
+                    var: var_name,
+                    new_value: transform!.map((x, i) =>
+                      i === index ? value : x,
+                    ),
+                  })
+                }
+              />
+            ))}
         </Stack.Item>
       </Stack>
     </LabeledList.Item>

--- a/tgui/packages/tgui/interfaces/ParticleEdit/EntriesBasic.tsx
+++ b/tgui/packages/tgui/interfaces/ParticleEdit/EntriesBasic.tsx
@@ -183,9 +183,11 @@ export const EntryGradient = (props: EntryGradientProps) => {
                     act('edit', {
                       var: var_name,
                       var_mod: P_DATA_GRADIENT,
-                      new_value: gradient!.map((x, i) =>
-                        i === index ? value : x,
-                      ),
+                      new_value: gradient!.map((x, i) => {
+                        const floatNum = parseFloat(value);
+                        const result = isNaN(floatNum) ? value : floatNum;
+                        return i === index ? result : x;
+                      }),
                     })
                   }
                 />

--- a/tgui/packages/tgui/interfaces/ParticleEdit/data.ts
+++ b/tgui/packages/tgui/interfaces/ParticleEdit/data.ts
@@ -15,6 +15,7 @@ export const P_DATA_GENERATOR = 'generator';
 export const P_DATA_ICON_ADD = 'icon_add';
 export const P_DATA_ICON_REMOVE = 'icon_remove';
 export const P_DATA_ICON_WEIGHT = 'icon_edit';
+export const P_DATA_GRADIENT = 'gradient';
 
 export const MatrixTypes = [
   'Simple Matrix',
@@ -68,7 +69,7 @@ type ParticleData = {
   bound1: number[];
   bound2: number[];
   gravity?: number[];
-  gradient?: (string | number)[];
+  gradient?: (string | number | { space: number })[];
   transform?: number[];
 
   icon?: string | { [key: string]: number };
@@ -106,7 +107,7 @@ export type EntryCoordProps = {
 export type EntryGradientProps = {
   name: string;
   var_name: string;
-  gradient?: (string | number)[];
+  gradient?: (string | number | { space: number })[];
   setDesc: React.Dispatch<React.SetStateAction<string>>;
 };
 

--- a/tgui/packages/tgui/interfaces/ParticleEdit/helpers.ts
+++ b/tgui/packages/tgui/interfaces/ParticleEdit/helpers.ts
@@ -34,11 +34,22 @@ export const isStringArray = (value: any): value is string[] => {
   return value.every((x) => typeof x === 'string');
 };
 
-/** sets the "space" keys value on  an object, then returns that object*/
+/** sets the "space" keys value on an object, then returns that object*/
 export const setGradientSpace = (
-  gradient: (number | string)[],
+  gradient: (string | number | { space: number })[],
   space: number,
 ) => {
-  gradient['space'] = space;
+  let found = false;
+  gradient?.map((entry) => {
+    if (typeof entry === 'object') {
+      if (Object.keys(entry)[0] === 'space') {
+        entry['space'] = space;
+        found = true;
+      }
+    }
+  });
+  if (!found) {
+    gradient.push({ space: space });
+  }
   return gradient;
 };


### PR DESCRIPTION

# About the pull request

This PR was originally to just fix some wrong typing but spiraled out to a giant series of bug fixes for filterrific and the particle editor. See changelog and testing for more details.

I am not 100% certain looping & color space are correct for particles in gradients because I see no visual change when altering them, but as far as I can tell the resulting values in VV are correct so may just be a bug/limitation in byond particles at the moment.

# Explain why it's good for the game

Filteriffic and particle editor should not crash.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/7480c5f6-8b46-423f-aa13-44b8f7b0bc18)
![example](https://github.com/user-attachments/assets/023f2ee3-d213-41dc-ae0a-3061dcb06cfc)

</details>


# Changelog
:cl: Drathek
add: Added missing implementations for transform and enumerations in Filteriffic
fix: Fixed multiple crash causes in Filteriffic e.g. opening displacement at all
fix: Fixed multiple crash causes in particle editor e.g. touching gradients or transform at all
qol: When picking icons in VV Filteriffic or Particle editor, you can now specify just a dmi path, and in the case of Filteriffic customize the icon paramters
code: Moved matrix identities to a define file and ported a filter qdel check from TG
/:cl:
