### PR TITLE
Add faction and role filtering to fun facts

### DIFF
--- a/code/datums/statistics/random_facts/christmas_fact.dm
+++ b/code/datums/statistics/random_facts/christmas_fact.dm
@@ -1,6 +1,9 @@
 // Leaderboard stat for festivizer_hits_total_max
 // Normally includes dead always but can disable by setting prob_check_dead to 0
 
+/datum/random_fact/christmas
+	role_filter = null
+
 /datum/random_fact/christmas/life_grab_stat(mob/fact_mob)
 	return fact_mob.festivizer_hits_total
 
@@ -24,6 +27,8 @@
 			list_to_check += GLOB.living_xeno_list
 
 	for(var/mob/checked_mob as anything in list_to_check)
+		if(check_mob_ignored(checked_mob))
+			continue
 		if(festivizer_hits_total_max < checked_mob.festivizer_hits_total && (checked_mob.persistent_ckey in GLOB.directory))
 			mob_to_report = checked_mob
 			festivizer_hits_total_max = life_grab_stat(checked_mob)

--- a/code/datums/statistics/random_facts/kills_fact.dm
+++ b/code/datums/statistics/random_facts/kills_fact.dm
@@ -1,6 +1,8 @@
 /datum/random_fact/kills
 	statistic_name = "kills"
 	statistic_verb = "earned"
+	role_filter = list(XENO_CASTE_FACEHUGGER, XENO_CASTE_LESSER_DRONE, XENO_CASTE_LARVA, XENO_CASTE_PREDALIEN_LARVA)
+	var/list/role_filter_blacklist = TRUE
 
 /datum/random_fact/kills/life_grab_stat(mob/fact_mob)
 	return fact_mob.life_kills_total

--- a/code/datums/statistics/random_facts/kills_fact.dm
+++ b/code/datums/statistics/random_facts/kills_fact.dm
@@ -2,7 +2,7 @@
 	statistic_name = "kills"
 	statistic_verb = "earned"
 	role_filter = list(XENO_CASTE_FACEHUGGER, XENO_CASTE_LESSER_DRONE, XENO_CASTE_LARVA, XENO_CASTE_PREDALIEN_LARVA)
-	var/list/role_filter_blacklist = TRUE
+	role_filter_blacklist = TRUE
 
 /datum/random_fact/kills/life_grab_stat(mob/fact_mob)
 	return fact_mob.life_kills_total


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #9794 adding role and faction checks to random_fact. Namely this prevents lessers & huggers from showing up in fun facts. The tutorial hive faction shouldn't be applicable in normal play because of `statistic_exempt` should be set true for tutorial mobs but mostly provided for demonstration and proof of concept.

# Explain why it's good for the game

Based on feedback that lessers were showing up in fun facts. Ghost roles make it much more likely a single player may get mentioned in fun facts since they are very disposable.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

XO revived a person, and a lesser killed someone so lesser was ignored:
![image](https://github.com/user-attachments/assets/702226a2-9dec-4a29-898d-8775202d6731)
![image](https://github.com/user-attachments/assets/d860d3d6-d1d2-4039-9695-4c7bca26dda0)

</details>


# Changelog
:cl: Drathek
add: Fun facts can now have whitelist/blacklists for role and faction. Namely this now prevents lessers and huggers from generating fun facts, and larva from generating kills fun facts (burst)
/:cl:
