### PR TITLE
Fixes a runtime namely with lessers who can die during Life

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -304,6 +304,9 @@ Make sure their actual health updates immediately.*/
 
 /mob/living/carbon/xenomorph/proc/handle_environment()
 	var/turf/T = loc
+	if(!T || !istype(T))
+		return
+
 	var/recoveryActual = (!caste || (caste.fire_immunity & FIRE_IMMUNITY_NO_IGNITE) || !on_fire) ? recovery_aura : 0
 	var/env_temperature = loc.return_temperature()
 	if(caste && !(caste.fire_immunity & FIRE_IMMUNITY_NO_DAMAGE))
@@ -312,9 +315,6 @@ Make sure their actual health updates immediately.*/
 			updatehealth() //Make sure their actual health updates immediately
 			if(prob(20))
 				to_chat(src, SPAN_WARNING("You feel a searing heat!"))
-
-	if(!T || !istype(T))
-		return
 
 	if(caste)
 		if(caste.innate_healing || check_weeds_for_healing())

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -303,8 +303,8 @@ Make sure their actual health updates immediately.*/
 
 
 /mob/living/carbon/xenomorph/proc/handle_environment()
-	var/turf/T = loc
-	if(!T || !istype(T))
+	var/turf/current_turf = loc
+	if(!current_turf || !istype(current_turf))
 		return
 
 	var/recoveryActual = (!caste || (caste.fire_immunity & FIRE_IMMUNITY_NO_IGNITE) || !on_fire) ? recovery_aura : 0


### PR DESCRIPTION

# About the pull request

This PR simply fixes a runtime where because a lesser may die when on_life() is called here:
https://github.com/cmss13-devs/cmss13/blob/ab882041cc096d231803990f2d57629f09758695/code/modules/mob/living/carbon/xenomorph/life.dm#L20-L34

they may get a null loc, and the existing code used that loc (but later was checking the loc). So that checking is just moved up in the proc.

# Explain why it's good for the game

Fixes 
![image](https://github.com/user-attachments/assets/cad24595-07a7-4802-ab44-d79ee57c2eaf)

# Changelog
:cl: Drathek
fix: Fixed a runtime with lessers on death
/:cl:
