### PR TITLE
Quality of Life, Spotters get to cloak and spot separately now

### DIFF
--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -427,7 +427,7 @@
 		overlays += cas_laser_overlay
 
 /datum/action/item_action/specialist/spotter_target
-	ability_primacy = SPEC_PRIMARY_ACTION_1
+	ability_primacy = SPEC_PRIMARY_ACTION_2
 	var/minimum_laze_distance = 2
 
 /datum/action/item_action/specialist/spotter_target/New(mob/living/user, obj/item/holder)


### PR DESCRIPTION


# About the pull request

Changes the ability to activate spotting with the Spotter's Laser Designator to Specialist Ability 2, removing the bloat of having the ghillie suit cloak and the laser designator's ability bound to the same button.

# Explain why it's good for the game

Quality of life addition for spotters to be able to cloak and spot separately without having both abilities tied to the same button. 

# Testing Photographs and Procedure
N/A

# Changelog



:cl:
qol: Spotter's spotting changed to Spec Ability 2 for smoother use of both spotting and cloaking as a spotter.
/:cl:


