### PR TITLE
Hand labeler crate fixes

### DIFF
--- a/code/game/objects/items/tools/misc_tools.dm
+++ b/code/game/objects/items/tools/misc_tools.dm
@@ -53,7 +53,8 @@
 	if(istype(A, /obj/item/tool/surgery) || istype(A, /obj/item/reagent_container/pill))
 		to_chat(user, SPAN_WARNING("That wouldn't be sanitary."))
 		return
-	if(istype(A, /obj/vehicle/multitile) || (istype(A, /obj/structure) && !istype(A, /obj/structure/closet/crate))) // disallow naming structures and vehicles, but not crates!
+	//disallow naming structures and vehicles, but not crates!
+	if(istype(A, /obj/vehicle/multitile) || (istype(A, /obj/structure) && !istype(A, /obj/structure/closet/crate) && !istype(A, /obj/structure/closet/coffin/woodencrate)))
 		to_chat(user, SPAN_WARNING("The label won't stick to that."))
 		return
 	if(isturf(A))

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -254,6 +254,9 @@
 				return
 		user.drop_inv_item_to_loc(W,loc)
 
+	//If we're trying to label a crate, label it, don't open it. The code that lets a hand labeler label crates but not lockers is in misc_tools.dm
+	else if(istype(W, /obj/item/tool/hand_labeler))
+		return
 	else if(istype(W, /obj/item/packageWrap) || istype(W, /obj/item/explosive/plastic))
 		return
 	else if(iswelder(W))


### PR DESCRIPTION
# About the pull request

- Fixes the hand labeler being unable to label wooden crates
- Tweaks it so that when you use a hand labeler on a crate, it tries to label it instead of labeling it and opening it at the same time.

# Explain why it's good for the game

- Wooden crates are more or less the same as crates, but they're under the coffin subtype so my initial PR missed them. 
- It feels really jank to label a crate and have it open at the same time.

# Testing Photographs and Procedure


# Changelog

:cl:
qol: trying to use a hand labeler on closed crates no longer opens them 
fix: fixed being unable to label wooden crates
/:cl:
