### PR TITLE
Adds dexplus and oxycodone to the pressurized chem dispenser

### DIFF
--- a/code/modules/reagents/chemistry_machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_dispenser.dm
@@ -285,10 +285,12 @@
 		"kelotane",
 		"anti_toxin",
 		"dexalin",
+		"dexalinp",
 		"inaprovaline",
 		"adrenaline",
 		"peridaxon",
 		"tramadol",
+		"oxycodone",
 		"tricordrazine",
 	)
 


### PR DESCRIPTION
# About the pull request

Adds oxycodone and dexalin plus to the special pressurized reagent pouch chem dispensers

# Explain why it's good for the game

Requested by a couple medics. Shouldn't affect balance too much, but tagging it just in case

# Testing Photographs and Procedure

# Changelog

:cl:
balance: adds dexalin plus and oxycodone to the pressurized reagent canister chem dispensers.
/:cl:
