### PR TITLE
XO role can only be unlocked through SO hours and not ASO and SO hours

### DIFF
--- a/code/game/jobs/job/command/cic/executive.dm
+++ b/code/game/jobs/job/command/cic/executive.dm
@@ -18,7 +18,7 @@
 	GLOB.marine_leaders -= JOB_XO
 
 AddTimelock(/datum/job/command/executive, list(
-	JOB_COMMAND_ROLES = 20 HOURS,
+	JOB_SO = 20 HOURS,
 	JOB_SQUAD_LEADER = 10 HOURS,
 ))
 


### PR DESCRIPTION
# About the pull request

Changes one of the timelock requirements for XO from requiring 20 hours of CO, XO, SO, or ASO to requiring 20 hours of SO

# Explain why it's good for the game

ASO is an important role in the game, but it's also not usually in CIC unless it's lowpop or an admin's run an event where the WY/UPP/CLF kills all command staff. 

Considering that XO is an incredibly important position to the round, they should have 20 full hours of familiarity with CIC and knowing how all the buttons work.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

I will note that I didn't test this PR like I usually do; the admin powers granted to you to run your own local host override any timelock requirements and I wouldn't want to spend 30 hours afk'ing to test this anyways.

</details>


# Changelog

:cl:
balance: Changes one of the XO's timelock requirements from being 20 hours of ASO or SO to just 20 hours of SO
/:cl:
