### PR TITLE
Fire axes can open unpowered doors after a wind up

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -634,6 +634,25 @@ GLOBAL_LIST_INIT(airlock_wire_descriptions, list(
 	else if(HAS_TRAIT(attacking_item, TRAIT_TOOL_MULTITOOL))
 		return attack_hand(user)
 
+	else if(istype(attacking_item, /obj/item/weapon/twohanded/fireaxe))
+		var/pry_delay = 3 SECONDS
+		if(arePowerSystemsOn())
+			to_chat(user, SPAN_WARNING("The airlock's motors resist your efforts to force it."))
+		else if(locked)
+			to_chat(user, SPAN_WARNING("The airlock's bolts prevent it from being forced."))
+		else if(welded)
+			to_chat(user, SPAN_WARNING("The airlock is welded shut."))
+		else if(!operating)
+			spawn(0)
+				if(density)
+					to_chat(user, SPAN_NOTICE("You start forcing the airlock open with [attacking_item]."))
+					if(do_after(user, pry_delay, INTERRUPT_ALL, BUSY_ICON_FRIENDLY))
+						open(1)
+				else
+					to_chat(user, SPAN_NOTICE("You start forcing the airlock shut with [attacking_item]."))
+					if(do_after(user, pry_delay, INTERRUPT_ALL, BUSY_ICON_FRIENDLY))
+						close(1)
+
 	else if(isgun(attacking_item))
 		var/obj/item/weapon/gun/gun_item = attacking_item
 		for(var/slot in gun_item.attachments)


### PR DESCRIPTION
# About the pull request

A fire axe can be used on an unpowered door to force it open/shut after a wind up, similar to using a bayonet on a gun to open/shut a door. Has the exact same wind up time

# Explain why it's good for the game

Fire axes right now are kind of useless, despite the fact that we have cool "break in case of emergency" glass cases scattered around the almayer with them in it. This should solve that, restore the fire axe's original purpose as a door opener, and give people another chance at escaping an emergency such as hijack. Now a nurse with no crowbar isn't trapped, they can escape via breaking the glass with a scalpel! 

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>
I tested it but was too lazy to film it

</details>


# Changelog

:cl:
add: Fire axes can now open unpowered doors after a 3 sec wind up, same as a bayonet attached to a gun
/:cl: