### PR TITLE
clf qol changes

### DIFF
--- a/code/modules/gear_presets/clf.dm
+++ b/code/modules/gear_presets/clf.dm
@@ -46,6 +46,12 @@
 	new_human.g_eyes = 62
 	new_human.b_eyes = 19
 
+/datum/equipment_preset/clf/load_traits(mob/living/carbon/human/new_human, client/mob_client)
+	. = ..()
+	if(!HAS_TRAIT(new_human, TRAIT_IRON_TEETH))
+		var/datum/character_trait/character_trait = GLOB.character_traits[/datum/character_trait/biology/iron_teeth]
+		character_trait.apply_trait(new_human, src)
+
 //*****************************************************************************************************/
 
 /datum/equipment_preset/clf/soldier

--- a/code/modules/gear_presets/survivors/lv_624/clfship_insert_lv624.dm
+++ b/code/modules/gear_presets/survivors/lv_624/clfship_insert_lv624.dm
@@ -28,6 +28,7 @@
 
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/storage/webbing, WEAR_ACCESSORY)
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/CLF(new_human), WEAR_L_EAR)
+	new_human.equip_to_slot_or_del(new /obj/item/attachable/bayonet/upp(new_human), WEAR_FACE)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/lightpack/five_slot(new_human), WEAR_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/ert(new_human), WEAR_R_STORE)
 	new_human.equip_to_slot_or_del(new /obj/item/mre_food_packet/clf, WEAR_IN_BACK)
@@ -35,6 +36,12 @@
 	add_survivor_weapon_rebel(new_human)
 
 	..()
+
+/datum/equipment_preset/survivor/clf/load_traits(mob/living/carbon/human/new_human, client/mob_client)
+	. = ..()
+	if(!HAS_TRAIT(new_human, TRAIT_IRON_TEETH))
+		var/datum/character_trait/character_trait = GLOB.character_traits[/datum/character_trait/biology/iron_teeth]
+		character_trait.apply_trait(new_human, src)
 
 //lead
 /datum/equipment_preset/survivor/clf/leader

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -871,20 +871,21 @@
 
 	if(!internal_organs_by_name)
 		return EYE_PROTECTION_WELDING
-	var/datum/internal_organ/eyes/I = internal_organs_by_name["eyes"]
-	if(I)
-		if(I.cut_away)
+	var/datum/internal_organ/eyes/eyes_organ = internal_organs_by_name["eyes"]
+	if(eyes_organ)
+		if(eyes_organ.cut_away)
 			return EYE_PROTECTION_WELDING
-		if(I.robotic == ORGAN_ROBOT)
+		if(eyes_organ.robotic == ORGAN_ROBOT)
 			return EYE_PROTECTION_WELDING
 	else
 		return EYE_PROTECTION_WELDING
 
 	if(istype(head, /obj/item/clothing))
-		var/obj/item/clothing/C = head
-		number += C.eye_protection
+		var/obj/item/clothing/cloth_item = head
+		number += cloth_item.eye_protection
 	if(istype(wear_mask, /obj/item/clothing))
-		number += wear_mask.eye_protection
+		var/obj/item/clothing/cloth_item = head
+		number += cloth_item.eye_protection
 	if(glasses)
 		number += glasses.eye_protection
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -138,7 +138,7 @@
 	var/obj/item/back = null//Human/Monkey
 	var/obj/item/tank/internal = null//Human/Monkey
 	var/obj/item/storage/s_active = null//Carbon
-	var/obj/item/clothing/mask/wear_mask = null//Carbon
+	var/obj/item/wear_mask = null//Carbon
 
 	var/able_to_speak = TRUE
 

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -508,9 +508,16 @@ DEFINES in setup.dm, referenced here.
 /mob/living/carbon/human/proc/can_unholster_from_storage_slot(obj/item/storage/slot)
 	if(isnull(slot))
 		return FALSE
-	if(slot == shoes)//Snowflakey check for shoes and uniform
+
+	//Snowflakey check for shoes, face, and uniform
+	if(slot == shoes)
 		if(shoes.stored_item && isweapon(shoes.stored_item))
 			return shoes
+		return FALSE
+
+	if(slot == wear_mask)
+		if(wear_mask && isweapon(wear_mask))
+			return wear_mask
 		return FALSE
 
 	if(slot == w_uniform)
@@ -602,8 +609,8 @@ DEFINES in setup.dm, referenced here.
 			to_chat(src, SPAN_DANGER("You are unable to equip that."))
 	else //empty hand, start checking slots and holsters
 
-		//default order: suit, belt, back, pockets, uniform, shoes
-		var/list/slot_order = list("s_store", "belt", "back", "l_store", "r_store", "w_uniform", "shoes")
+		//default order: suit, belt, back, pockets, uniform, shoes, wear_mask
+		var/list/slot_order = list("s_store", "belt", "back", "l_store", "r_store", "w_uniform", "shoes", "wear_mask")
 
 		var/obj/item/slot_selected
 


### PR DESCRIPTION
# About the pull request

clf survivors now spawn with the iron teeth trait
bayonet in face slot can now be equipped with a keybind
standard clf surv guerillas now spawn with a bayonet in their mouths
kills some 1 letter vars

# Explain why it's good for the game

shouldn't need to have a trait equipped specifically for a single role
the rest of clf surv roles spawn with bayonets in their mouths idk why standard ones don't

# Testing Photographs and Procedure


# Changelog

:cl:
qol: face slot bayonet can now be equipped with keybinds
balance: clf survs spawn with the iron teeth trait and guerillas spawn with bayonets in their mouths 

/:cl:

