### PR TITLE
stops dropship solid turfs being weedable

### DIFF
--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -286,10 +286,6 @@
 	icon = 'icons/turf/shuttle.dmi'
 	layer = ABOVE_TURF_LAYER
 
-/turf/closed/shuttle/Initialize(mapload)
-	. = ..()
-	is_weedable = FULLY_WEEDABLE
-
 /turf/closed/shuttle/dropship
 	icon = 'icons/turf/walls/walls.dmi'
 	icon_state = "rasputin1"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

As title.

# Explain why it's good for the game

It is quite common for xeno weeds to spread under solid turfs on the dropship which aren't accessible, and this can often lead to the queen eye hiding in places marines can't remove, along with other niche things.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
del: Dropship walls and other solid turfs cannot be weeded. This does not affect dropship internals.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
