### PR TITLE
Fixes a bug where dog tags couldn't be retrieved in some cases

### DIFF
--- a/code/modules/mob/living/carbon/human/human_stripping.dm
+++ b/code/modules/mob/living/carbon/human/human_stripping.dm
@@ -207,9 +207,9 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 	if(!ishuman(source))
 		return
 	var/mob/living/carbon/human/sourcemob = source
-	if (!istype(tag))
+	if(!istype(tag))
 		return
-	if (sourcemob.is_revivable() && (!skillcheck(user, SKILL_POLICE, SKILL_POLICE_SKILLED) || sourcemob.stat != DEAD))
+	if(!sourcemob.undefibbable && sourcemob.is_revivable() && (!skillcheck(user, SKILL_POLICE, SKILL_POLICE_SKILLED) || sourcemob.stat != DEAD))
 		return
 	return tag.dogtag_taken ? null : "retrieve_tag"
 
@@ -224,7 +224,7 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 		return
 	if(!istype(sourcemob.wear_id, /obj/item/card/id/dogtag))
 		return
-	if (sourcemob.is_revivable() && !skillcheck(user, SKILL_POLICE, SKILL_POLICE_SKILLED))
+	if(!sourcemob.undefibbable && sourcemob.is_revivable() && !skillcheck(user, SKILL_POLICE, SKILL_POLICE_SKILLED))
 		return
 	var/obj/item/card/id/dogtag/tag = sourcemob.wear_id
 	if(tag.dogtag_taken)

--- a/code/modules/mob/living/carbon/human/human_stripping.dm
+++ b/code/modules/mob/living/carbon/human/human_stripping.dm
@@ -209,7 +209,7 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 	var/mob/living/carbon/human/sourcemob = source
 	if (!istype(tag))
 		return
-	if (!sourcemob.undefibbable && (!skillcheck(user, SKILL_POLICE, SKILL_POLICE_SKILLED) || sourcemob.stat != DEAD))
+	if (sourcemob.is_revivable() && (!skillcheck(user, SKILL_POLICE, SKILL_POLICE_SKILLED) || sourcemob.stat != DEAD))
 		return
 	return tag.dogtag_taken ? null : "retrieve_tag"
 
@@ -224,7 +224,7 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 		return
 	if(!istype(sourcemob.wear_id, /obj/item/card/id/dogtag))
 		return
-	if (!sourcemob.undefibbable && !skillcheck(user, SKILL_POLICE, SKILL_POLICE_SKILLED))
+	if (sourcemob.is_revivable() && !skillcheck(user, SKILL_POLICE, SKILL_POLICE_SKILLED))
 		return
 	var/obj/item/card/id/dogtag/tag = sourcemob.wear_id
 	if(tag.dogtag_taken)


### PR DESCRIPTION

# About the pull request

Fixes a bug where you couldn't retrieve a dog tag from bursted or headless corpses until after 5 minutes had passed. Tested.

# Explain why it's good for the game

bug bad

# Testing Photographs and Procedure

# Changelog

:cl:
fix: fixed a bug where dog tags couldn't be retrieved from bursted/headless bodies until 5 minutes had passed.
/:cl: