### PR TITLE
Cryocells' autoeject should check for Toxin damage as well

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -256,8 +256,8 @@
 			beaker.reagents.reaction(occupant, permeable_in_mobs = FALSE)
 
 	if(autoeject)
-		//release the patient automatically when brute and burn are handled on non-robotic limbs
-		if(!occupant.getBruteLoss(TRUE) && !occupant.getFireLoss(TRUE) && !occupant.getCloneLoss())
+		//release the patient automatically when brute and burn are handled on non-robotic limbs and tox damage handled
+		if(!occupant.getBruteLoss(TRUE) && !occupant.getFireLoss(TRUE) && !occupant.getToxLoss() && !occupant.getCloneLoss())
 			display_message("Patient's external wounds are healed.")
 			go_out(TRUE)
 			return


### PR DESCRIPTION
# About the pull request

Currently the medbay Cryo Cells with auto-eject enabled will eject patients with toxin damage left, if no other brute/burn/clone damage.

# Explain why it's good for the game

Toxin requires manual intervention with cryo cells, might as well make it like brute/burn/clone. 
Very handy for the corpse of whoever ate resin fruits.

# Testing Photographs and Procedure

Tested locally 

<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/2ce59f2d-bb0a-4867-907c-b29eebbacda2)
Behold, unejected

</details>


# Changelog

:cl:
qol: Cryo Cell's auto-eject now waits for Toxin damage to heal
/:cl:
