### PR TITLE
Added shipside and groundside filter options for the orbit menu

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -114,6 +114,10 @@
 
 		if(isliving(poi_mob))
 			var/mob/living/player = poi_mob
+
+			serialized["in_ground"] = is_ground_level(player.z)
+			serialized["in_ship"] = is_mainship_level(player.z)
+
 			serialized["health"] = floor(player.health / player.maxHealth * 100)
 
 			if(isxeno(player))

--- a/tgui/packages/tgui/interfaces/Orbit/index.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/index.tsx
@@ -31,23 +31,46 @@ import {
 
 type search = {
   value: string;
+  show_ground: boolean;
+  show_ship: boolean;
   setValue: (value: string) => void;
+  setGroundVisibility: (value: boolean) => void;
+  setShipVisibility: (value: boolean) => void;
 };
 
-const SearchContext = createContext<search>({ value: '', setValue: () => {} });
+const SearchContext = createContext<search>({
+  value: '',
+  show_ground: true,
+  show_ship: true,
+  setValue: () => {},
+  setGroundVisibility: () => {},
+  setShipVisibility: () => {},
+});
 
 export const Orbit = () => {
   const [searchQuery, setSearchQuery] = useState<string>('');
+  const [showGround, setShowGround] = useState<boolean>(true);
+  const [showShip, setShowShip] = useState<boolean>(true);
 
   return (
     <Window title="Orbit" width={500} height={700}>
       <Window.Content scrollable>
         <SearchContext.Provider
-          value={{ value: searchQuery, setValue: setSearchQuery }}
+          value={{
+            show_ground: showGround,
+            show_ship: showShip,
+            value: searchQuery,
+            setGroundVisibility: setShowGround,
+            setShipVisibility: setShowShip,
+            setValue: setSearchQuery,
+          }}
         >
           <Stack fill vertical>
             <Stack.Item>
               <ObservableSearch />
+            </Stack.Item>
+            <Stack.Item mt={0.2}>
+              <ObservableFilter />
             </Stack.Item>
             <Stack.Item mt={0.2} grow>
               <Section fill>
@@ -58,6 +81,47 @@ export const Orbit = () => {
         </SearchContext.Provider>
       </Window.Content>
     </Window>
+  );
+};
+
+const ObservableFilter = () => {
+  const { show_ground, show_ship, setGroundVisibility, setShipVisibility } =
+    useContext(SearchContext);
+  return (
+    <Section>
+      <Stack>
+        <Stack.Item grow>
+          <Icon name="filter" />
+        </Stack.Item>
+        <Stack.Divider />
+        <Stack.Item>
+          <Button.Checkbox
+            checked={!!show_ground}
+            onClick={() => setGroundVisibility(!show_ground)}
+          >
+            Ground
+          </Button.Checkbox>
+        </Stack.Item>
+        <Stack.Item>
+          <Button.Checkbox
+            checked={!!show_ship}
+            onClick={() => setShipVisibility(!show_ship)}
+          >
+            Ship
+          </Button.Checkbox>
+        </Stack.Item>
+        <Stack.Item>
+          <Button
+            onClick={() => {
+              setGroundVisibility(true);
+              setShipVisibility(true);
+            }}
+          >
+            Reset
+          </Button>
+        </Stack.Item>
+      </Stack>
+    </Section>
   );
 };
 
@@ -261,7 +325,11 @@ const GroupedObservable = (props: {
 }) => {
   const { color, section = [], title } = props;
 
-  const { value: searchQuery } = useContext(SearchContext);
+  const {
+    value: searchQuery,
+    show_ground,
+    show_ship,
+  } = useContext(SearchContext);
 
   if (!section.length) {
     return null;
@@ -269,6 +337,8 @@ const GroupedObservable = (props: {
 
   const filteredSection = section
     .filter((observable) => isJobOrNameMatch(observable, searchQuery))
+    .filter((observable) => (observable.in_ground === 1 ? show_ground : true))
+    .filter((observable) => (observable.in_ship === 1 ? show_ship : true))
     .sort((a, b) =>
       a.full_name
         .toLocaleLowerCase()
@@ -535,7 +605,11 @@ const ObservableSection = (props: {
 }) => {
   const { color, section = [], title } = props;
 
-  const { value: searchQuery } = useContext(SearchContext);
+  const {
+    value: searchQuery,
+    show_ground,
+    show_ship,
+  } = useContext(SearchContext);
 
   if (!section.length) {
     return null;
@@ -543,6 +617,8 @@ const ObservableSection = (props: {
 
   const filteredSection = section
     .filter((observable) => isJobOrNameMatch(observable, searchQuery))
+    .filter((observable) => (observable.in_ground === 1 ? show_ground : true))
+    .filter((observable) => (observable.in_ship === 1 ? show_ship : true))
     .sort((a, b) =>
       a.full_name
         .toLocaleLowerCase()

--- a/tgui/packages/tgui/interfaces/Orbit/types.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/types.ts
@@ -46,6 +46,8 @@ export type Observable = {
   ref: string;
   hivenumber: string;
   area_name: string;
+  in_ground?: number;
+  in_ship?: number;
 };
 
 export type SquadObservable = {


### PR DESCRIPTION
# About the pull request

I think the orbit menu should allow you to filter to just those groundside or shipside. I often want to know 'who is groundside'.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Easy filters / QOL
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

![image](https://github.com/user-attachments/assets/910e0ab7-8a33-47b9-9347-39448ab533ba)

</details>


# Changelog
:cl:
ui: added z-level filter buttons to orbit menu
/:cl:
