### PR TITLE
UI: Radio gets some extra formatting, Sentry Computer gets a better looking '%', Fix TSL constant being misnamed

### DIFF
--- a/tgui/packages/tgui-say/constants.ts
+++ b/tgui/packages/tgui-say/constants.ts
@@ -381,7 +381,7 @@ export const LANGUAGE_PREFIXES = {
   },
   '!l ': {
     id: 'tactical sign language',
-    label: 'Tacitical Sign',
+    label: 'Tactical Sign',
   },
   '!s ': {
     id: 'sainja',

--- a/tgui/packages/tgui-say/constants.ts
+++ b/tgui/packages/tgui-say/constants.ts
@@ -380,7 +380,7 @@ export const LANGUAGE_PREFIXES = {
     label: 'Xenomporph',
   },
   '!l ': {
-    id: 'tatical',
+    id: 'tactical sign language',
     label: 'Tacitical Sign',
   },
   '!s ': {

--- a/tgui/packages/tgui/interfaces/Radio.tsx
+++ b/tgui/packages/tgui/interfaces/Radio.tsx
@@ -143,7 +143,10 @@ export const Radio = (props) => {
                         })
                       }
                     >
-                      {channel.name + ' ' + channel.hotkey}
+                      {channel.name + ' '}
+                      {channel.hotkey
+                        ? '[' + channel.hotkey.toUpperCase() + ']'
+                        : '[N/A]'}
                     </Button>
                   </Box>
                 ))}

--- a/tgui/packages/tgui/interfaces/SentryGunUI.tsx
+++ b/tgui/packages/tgui/interfaces/SentryGunUI.tsx
@@ -515,7 +515,7 @@ const PowerLevel = () => {
       value={data.electrical.charge}
     >
       {((data.electrical.charge / data.electrical.max_charge) * 100).toFixed(2)}{' '}
-      %
+      <span>%</span>
     </ProgressBar>
   );
 };

--- a/tgui/packages/tgui/styles/interfaces/SentryUi.scss
+++ b/tgui/packages/tgui/styles/interfaces/SentryUi.scss
@@ -87,6 +87,11 @@ $large-text: 1.5rem;
     font-family: monospace;
     font-weight: bold;
     font-size: 1.4rem;
+    span {
+      font-family: Verdana, monospace;
+      font-weight: bold;
+      font-size: 1.4rem;
+    }
   }
 
   .SentryCard {


### PR DESCRIPTION

# About the pull request
Some other stuff I missed cause I have the dumb.

- Sentry UI gets a span for the percentage sign that makes it look a little better.
- "tatical" *sigh to "tactical sign language" so it actually registers.
- Radio menu gets some extra formatting and a conditional in case there isn't a radio prefix for whatever reason.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Fixes me being dumb.
Makes things slightly prettier?
# Testing Photographs and Procedure
<details>
<summary>Screenshot</summary>

After:
![image](https://github.com/user-attachments/assets/b1b4e776-84d7-4431-a67e-a13eddff4870)

Before:
![image](https://github.com/user-attachments/assets/e424a081-ea38-4aef-8dd4-b2a5144588f6)

</details>


# Changelog
:cl: MistChristmas
fix: Tactical Sign Language not registering for TGUI
ui: Sentry computer % sign for power level uses a different font that looks better. Radio menu gets a little more formatting 
/:cl:
