### PR TITLE
Minor GAU fixes

### DIFF
--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -187,7 +187,7 @@
 			if(iscarbon(explosion_effect))
 				var/mob/living/carbon/bullet_effect = explosion_effect
 				explosion_effect.ex_act(EXPLOSION_THRESHOLD_VLOW, null, cause_data)
-				bullet_effect.apply_armoured_damage(directhit_damage,ARMOR_BULLET,BRUTE,pick(ALL_LIMBS),penetration)
+				bullet_effect.apply_armoured_damage(directhit_damage,ARMOR_BULLET,BRUTE,null,penetration)
 			else
 				explosion_effect.ex_act(EXPLOSION_THRESHOLD_VLOW)
 		new /obj/effect/particle_effect/expl_particles(impact_tile)


### PR DESCRIPTION
# About the pull request

this is a fix as it sets values to how I inteanded and how I said I am changing them in the GAU rework. it makes spread of both ammo types 3 instead of 4 on AP ~~and ammo hits random bodypart to prevent broken organs on every shot~~ (should already be the case)

# Explain why it's good for the game

makes GAU ammo work as inteanded ~~and spreads out its damage to otehr bodyparts~~


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: reduces AP GAU ammo spread to 3 tile from 4 as intended
/:cl:
