### PR TITLE
OB warnings now have balloon alerts

### DIFF
--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -404,6 +404,7 @@ GLOBAL_LIST_EMPTY(orbital_cannon_cancellation)
 			SPAN_HIGHDANGER("The sky erupts into flames [SPAN_UNDERLINE(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!"), SHOW_MESSAGE_VISIBLE, \
 			SPAN_HIGHDANGER("You hear a very loud sound coming from above to the [SPAN_UNDERLINE(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!"), SHOW_MESSAGE_AUDIBLE \
 		)
+		M.balloon_alert(M, "The sky erupts into flames [(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!", text_color = "#ff0000")
 	sleep(OB_TRAVEL_TIMING/3)
 
 	for(var/mob/M in long_range(25, target))
@@ -415,6 +416,7 @@ GLOBAL_LIST_EMPTY(orbital_cannon_cancellation)
 			SPAN_HIGHDANGER("The sky roars louder [SPAN_UNDERLINE(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!"), SHOW_MESSAGE_VISIBLE, \
 			SPAN_HIGHDANGER("The sound becomes louder [SPAN_UNDERLINE(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!"), SHOW_MESSAGE_AUDIBLE \
 		)
+		M.balloon_alert(M, "The sky roars louder [(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!", text_color = "#ff0000")
 	sleep(OB_TRAVEL_TIMING/3)
 
 	for(var/mob/M in long_range(15, target))
@@ -422,6 +424,7 @@ GLOBAL_LIST_EMPTY(orbital_cannon_cancellation)
 			SPAN_HIGHDANGER("OH GOD THE SKY WILL EXPLODE!!!"), SHOW_MESSAGE_VISIBLE, \
 			SPAN_HIGHDANGER("YOU SHOULDN'T BE HERE!"), SHOW_MESSAGE_AUDIBLE \
 		)
+		M.balloon_alert(M, "OH GOD THE SKY WILL EXPLODE!!!", text_color = "#ff0000")
 	sleep(OB_TRAVEL_TIMING/3)
 
 	if(GLOB.orbital_cannon_cancellation["[cancellation_token]"]) // the cancelling notification is in the topic

--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -404,7 +404,7 @@ GLOBAL_LIST_EMPTY(orbital_cannon_cancellation)
 			SPAN_HIGHDANGER("The sky erupts into flames [SPAN_UNDERLINE(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!"), SHOW_MESSAGE_VISIBLE, \
 			SPAN_HIGHDANGER("You hear a very loud sound coming from above to the [SPAN_UNDERLINE(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!"), SHOW_MESSAGE_AUDIBLE \
 		)
-		M.balloon_alert(M, "The sky erupts into flames [(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!", text_color = "#ff0000")
+		M.balloon_alert(M, "the sky erupts into flames [(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!", text_color = "#ff0000")
 	sleep(OB_TRAVEL_TIMING/3)
 
 	for(var/mob/M in long_range(25, target))
@@ -416,7 +416,7 @@ GLOBAL_LIST_EMPTY(orbital_cannon_cancellation)
 			SPAN_HIGHDANGER("The sky roars louder [SPAN_UNDERLINE(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!"), SHOW_MESSAGE_VISIBLE, \
 			SPAN_HIGHDANGER("The sound becomes louder [SPAN_UNDERLINE(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!"), SHOW_MESSAGE_AUDIBLE \
 		)
-		M.balloon_alert(M, "The sky roars louder [(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!", text_color = "#ff0000")
+		M.balloon_alert(M, "the sky roars louder [(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!", text_color = "#ff0000")
 	sleep(OB_TRAVEL_TIMING/3)
 
 	for(var/mob/M in long_range(15, target))
@@ -424,7 +424,7 @@ GLOBAL_LIST_EMPTY(orbital_cannon_cancellation)
 			SPAN_HIGHDANGER("OH GOD THE SKY WILL EXPLODE!!!"), SHOW_MESSAGE_VISIBLE, \
 			SPAN_HIGHDANGER("YOU SHOULDN'T BE HERE!"), SHOW_MESSAGE_AUDIBLE \
 		)
-		M.balloon_alert(M, "OH GOD THE SKY WILL EXPLODE!!!", text_color = "#ff0000")
+		M.balloon_alert(M, "oh god the sky will explode!!!", text_color = "#ff0000")
 	sleep(OB_TRAVEL_TIMING/3)
 
 	if(GLOB.orbital_cannon_cancellation["[cancellation_token]"]) // the cancelling notification is in the topic


### PR DESCRIPTION
# About the pull request

If you're about to get hit by an OB, you'll get a balloon alert. 

# Explain why it's good for the game

If you're fighting, and particularly if you're a xeno getting shot 5000 times a minute, chat can scroll by super duper fast. Balloon alerts would prevent OBs from getting buried faster than you can catch them.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>


https://github.com/user-attachments/assets/96fab1fc-5d4e-4d2e-afe5-2f4c0d15b6f8


As seen above, other balloon alerts should still work at the same time with no problem

</details>


# Changelog

:cl:
add: Adds balloon alert OB warnings
/:cl:
