### PR TITLE
More xenomorph z level fixes(?)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -192,7 +192,7 @@
 
 		if(length(possible_xenos) > 1)
 			var/mob/living/carbon/xenomorph/selected_xeno = tgui_input_list(xeno, "Target", "Watch which leader?", possible_xenos, theme="hive_status")
-			if(!selected_xeno || selected_xeno.hive_pos == NORMAL_XENO || selected_xeno == xeno.observed_xeno || selected_xeno.stat == DEAD || selected_xeno.z != xeno.z || !xeno.check_state())
+			if(!selected_xeno || selected_xeno.hive_pos == NORMAL_XENO || selected_xeno == xeno.observed_xeno || selected_xeno.stat == DEAD || !xeno.check_state())
 				return
 			xeno.overwatch(selected_xeno)
 		else if(length(possible_xenos))
@@ -710,7 +710,7 @@
 
 	var/turf/turf_to_get = get_turf(atom)
 
-	if(!turf_to_get || turf_to_get.is_weedable < FULLY_WEEDABLE || turf_to_get.density || (turf_to_get.z != xeno.z))
+	if(!turf_to_get || turf_to_get.is_weedable < FULLY_WEEDABLE || turf_to_get.density || !SSmapping.same_z_map(turf_to_get.z, xeno.z))
 		to_chat(xeno, SPAN_XENOWARNING("You can't do that here."))
 		return
 


### PR DESCRIPTION

# About the pull request

Makes it so the leader menu can be used to watch leaders without having a z level check, you can already do this by just watching them through the hive status, so i dont see why this is needed.


You can now expand weeds on the same map level 

# Explain why it's good for the game

better compability with z level stuff


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Queens can now watch leaders through "watch leaders" properly.
fix: Queens can now weed through the queen eye, the same map level they are on regardless of z level.
/:cl:
