### PR TITLE
Removes all Timelocks from all Roles

### DIFF
--- a/code/game/jobs/job/antag/xeno/queen.dm
+++ b/code/game/jobs/job/antag/xeno/queen.dm
@@ -17,9 +17,3 @@
 	to_chat(new_queen, "<B>Your job is to spread the hive.</B>")
 	to_chat(new_queen, "<B>You should start by building a hive core.</B>")
 	to_chat(new_queen, "Talk in Hivemind using <strong>;</strong> (e.g. ';Hello my children!')")
-
-AddTimelock(/datum/job/antag/xenos/queen, list(
-	JOB_XENO_ROLES = 10 HOURS,
-	JOB_DRONE_ROLES = 5 HOURS,
-	JOB_T3_ROLES = 3 HOURS,
-))

--- a/code/game/jobs/job/civilians/other/liaison.dm
+++ b/code/game/jobs/job/civilians/other/liaison.dm
@@ -23,6 +23,3 @@
 	icon_state = "cl_spawn"
 	job = /datum/job/civilian/liaison
 
-AddTimelock(/datum/job/civilian/liaison, list(
-	JOB_HUMAN_ROLES = 10 HOURS,
-))

--- a/code/game/jobs/job/civilians/other/reporter.dm
+++ b/code/game/jobs/job/civilians/other/reporter.dm
@@ -35,6 +35,3 @@ This could be the story of the sector! 'Brave Marines responding to dangerous di
 	icon_state = "cc_spawn"
 	job = /datum/job/civilian/reporter
 
-AddTimelock(/datum/job/civilian/reporter, list(
-	JOB_HUMAN_ROLES = 10 HOURS,
-))

--- a/code/game/jobs/job/civilians/other/survivors.dm
+++ b/code/game/jobs/job/civilians/other/survivors.dm
@@ -167,11 +167,6 @@ GLOBAL_LIST_EMPTY(spawned_survivors)
 
 		SSticker.mode.survivors_by_type_amounts[preferred_variant] += 1
 
-AddTimelock(/datum/job/civilian/survivor, list(
-	JOB_SQUAD_ROLES = 5 HOURS,
-	JOB_ENGINEER_ROLES = 5 HOURS,
-	JOB_MEDIC_ROLES = 5 HOURS
-))
 
 /datum/job/civilian/survivor/synth
 	title = JOB_SYNTH_SURVIVOR

--- a/code/game/jobs/job/civilians/support/cmo.dm
+++ b/code/game/jobs/job/civilians/support/cmo.dm
@@ -22,12 +22,6 @@
 /datum/job/civilian/professor/get_active_player_on_job()
 	return active_cmo
 
-AddTimelock(/datum/job/civilian/professor, list(
-	JOB_DOCTOR_ROLES = 10 HOURS,
-	JOB_MEDIC_ROLES = 10 HOURS,
-	JOB_RESEARCH_ROLES = 5 HOURS,
-))
-
 /obj/effect/landmark/start/professor
 	name = JOB_CMO
 	icon_state = "cmo_spawn"

--- a/code/game/jobs/job/civilians/support/doctor.dm
+++ b/code/game/jobs/job/civilians/support/doctor.dm
@@ -51,10 +51,6 @@
 		total_positions_so_far = positions
 	return positions
 
-AddTimelock(/datum/job/civilian/doctor, list(
-	JOB_MEDIC_ROLES = 1 HOURS
-))
-
 /obj/effect/landmark/start/doctor
 	name = JOB_DOCTOR
 	icon_state = "doc_spawn"

--- a/code/game/jobs/job/civilians/support/field_doctor.dm
+++ b/code/game/jobs/job/civilians/support/field_doctor.dm
@@ -11,10 +11,6 @@
 	gear_preset = /datum/equipment_preset/uscm_ship/uscm_medical/field_doctor
 	entry_message_body = "You are a <a href='"+WIKI_PLACEHOLDER+"'>Field Doctor</a> tasked with keeping the marines healthy and strong in the field, usually in the form of surgery. You must stay onboard the Almayer medical bay if there are no other doctors present and until the FOB is secured. Your superiors may also delay your deployment to the field."
 
-AddTimelock(/datum/job/civilian/field_doctor, list(
-	JOB_DOCTOR_ROLES = 5 HOURS
-))
-
 /obj/effect/landmark/start/field_doctor
 	name = JOB_FIELD_DOCTOR
 	icon_state = "field_doc_spawn"

--- a/code/game/jobs/job/civilians/support/nurse.dm
+++ b/code/game/jobs/job/civilians/support/nurse.dm
@@ -13,6 +13,3 @@
 	icon_state = "nur_spawn"
 	job = /datum/job/civilian/nurse
 
-AddTimelock(/datum/job/civilian/nurse, list(
-	JOB_HUMAN_ROLES = 1 HOURS
-))

--- a/code/game/jobs/job/civilians/support/researcher.dm
+++ b/code/game/jobs/job/civilians/support/researcher.dm
@@ -27,10 +27,6 @@
 		total_positions_so_far = positions
 	return positions
 
-AddTimelock(/datum/job/civilian/researcher, list(
-	JOB_MEDIC_ROLES = 5 HOURS
-))
-
 /obj/effect/landmark/start/researcher
 	name = JOB_RESEARCHER
 	icon_state = "res_spawn"

--- a/code/game/jobs/job/command/auxiliary/auxiliary_support_officer.dm
+++ b/code/game/jobs/job/command/auxiliary/auxiliary_support_officer.dm
@@ -20,13 +20,6 @@
 /datum/job/command/auxiliary_officer/get_active_player_on_job()
 	return active_auxiliary_officer
 
-AddTimelock(/datum/job/command/auxiliary_officer, list(
-	JOB_SQUAD_ROLES = 5 HOURS,
-	JOB_REQUISITION_ROLES = 5 HOURS,
-	JOB_ENGINEER_ROLES = 5 HOURS,
-	JOB_AUXILIARY_ROLES = 5 HOURS,
-))
-
 /obj/effect/landmark/start/auxiliary_officer
 	name = JOB_AUXILIARY_OFFICER
 	icon_state = "aso_spawn"

--- a/code/game/jobs/job/command/auxiliary/cas_pilot.dm
+++ b/code/game/jobs/job/command/auxiliary/cas_pilot.dm
@@ -26,11 +26,6 @@
 	total_positions = 2
 	spawn_positions = 2
 
-// Dropship Roles is both DP, GP and DCC combined to not force people to backtrack
-AddTimelock(/datum/job/command/pilot/cas_pilot, list(
-	JOB_DROPSHIP_ROLES = 2 HOURS
-))
-
 /obj/effect/landmark/start/pilot/cas_pilot
 	name = JOB_CAS_PILOT
 	icon_state = "cas_spawn"

--- a/code/game/jobs/job/command/auxiliary/crew_chief.dm
+++ b/code/game/jobs/job/command/auxiliary/crew_chief.dm
@@ -9,11 +9,6 @@
 	gear_preset = /datum/equipment_preset/uscm_ship/dcc
 	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>Your job is to assist</a> the pilot officer maintain the ship's dropship. You have authority only on the dropship, but you are expected to maintain order, as not to disrupt the pilot."
 
-AddTimelock(/datum/job/command/crew_chief, list(
-	JOB_SQUAD_ROLES = 5 HOURS,
-	JOB_MEDIC_ROLES = 1 HOURS
-))
-
 /obj/effect/landmark/start/crew_chief
 	name = JOB_DROPSHIP_CREW_CHIEF
 	icon_state = "dcc_spawn"

--- a/code/game/jobs/job/command/auxiliary/dropship_pilot.dm
+++ b/code/game/jobs/job/command/auxiliary/dropship_pilot.dm
@@ -22,11 +22,6 @@
 /datum/job/command/pilot/dropship_pilot/get_active_player_on_job()
 	return active_dropship_pilot
 
-// Dropship Roles is both DP, GP and DCC combined to not force people to backtrack
-AddTimelock(/datum/job/command/pilot/dropship_pilot, list(
-	JOB_DROPSHIP_ROLES = 2 HOURS
-))
-
 /obj/effect/landmark/start/pilot/dropship_pilot
 	name = JOB_DROPSHIP_PILOT
 	icon_state = "dp_spawn"

--- a/code/game/jobs/job/command/auxiliary/intel.dm
+++ b/code/game/jobs/job/command/auxiliary/intel.dm
@@ -23,10 +23,6 @@
 			total_positions_so_far = positions
 	return positions
 
-AddTimelock(/datum/job/command/intel, list(
-	JOB_SQUAD_ROLES = 5 HOURS
-))
-
 /obj/effect/landmark/start/intel
 	name = JOB_INTEL
 	icon_state = "io_spawn"

--- a/code/game/jobs/job/command/auxiliary/senior.dm
+++ b/code/game/jobs/job/command/auxiliary/senior.dm
@@ -27,16 +27,6 @@
 
 	return filtered_job_options
 
-AddTimelock(/datum/job/command/senior, list(
-	JOB_SQUAD_ROLES = 15 HOURS,
-
-	JOB_ENGINEER_ROLES = 10 HOURS,
-	JOB_POLICE_ROLES = 10 HOURS,
-	JOB_MEDIC_ROLES = 10 HOURS,
-
-	JOB_COMMAND_ROLES = 5 HOURS,
-))
-
 /obj/effect/landmark/start/senior
 	name = JOB_SEA
 	icon_state = "sea_spawn"

--- a/code/game/jobs/job/command/cic/executive.dm
+++ b/code/game/jobs/job/command/cic/executive.dm
@@ -17,10 +17,6 @@
 	SIGNAL_HANDLER
 	GLOB.marine_leaders -= JOB_XO
 
-AddTimelock(/datum/job/command/executive, list(
-	JOB_COMMAND_ROLES = 20 HOURS,
-	JOB_SQUAD_LEADER = 10 HOURS,
-))
 
 /datum/job/command/executive/announce_entry_message(mob/living/carbon/human/H)
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(all_hands_on_deck), "Attention all hands, [H.get_paygrade(0)] [H.real_name] on deck!"), 1.5 SECONDS)

--- a/code/game/jobs/job/command/cic/staffofficer.dm
+++ b/code/game/jobs/job/command/cic/staffofficer.dm
@@ -35,11 +35,6 @@
 	SIGNAL_HANDLER
 	GLOB.marine_leaders[JOB_SO] -= M
 
-AddTimelock(/datum/job/command/bridge, list(
-	JOB_SQUAD_LEADER = 1 HOURS,
-	JOB_HUMAN_ROLES = 15 HOURS
-))
-
 /obj/effect/landmark/start/bridge
 	name = JOB_SO
 	icon_state = "so_spawn"

--- a/code/game/jobs/job/command/police/chief_police.dm
+++ b/code/game/jobs/job/command/police/chief_police.dm
@@ -19,11 +19,6 @@
 /datum/job/command/warrant/get_active_player_on_job()
 	return active_cmp
 
-AddTimelock(/datum/job/command/warrant, list(
-	JOB_POLICE_ROLES = 15 HOURS,
-	JOB_COMMAND_ROLES = 5 HOURS
-))
-
 /obj/effect/landmark/start/warrant
 	name = JOB_CHIEF_POLICE
 	icon_state = "cmp_spawn"

--- a/code/game/jobs/job/command/police/police.dm
+++ b/code/game/jobs/job/command/police/police.dm
@@ -25,10 +25,6 @@
 		total_positions_so_far = positions
 	return positions
 
-AddTimelock(/datum/job/command/police, list(
-	JOB_SQUAD_ROLES = 10 HOURS
-))
-
 /obj/effect/landmark/start/police
 	name = JOB_POLICE
 	icon_state = "mp_spawn"

--- a/code/game/jobs/job/command/police/warden.dm
+++ b/code/game/jobs/job/command/police/warden.dm
@@ -17,10 +17,6 @@
 	SIGNAL_HANDLER
 	active_warden = null
 
-AddTimelock(/datum/job/command/warden, list(
-	JOB_POLICE_ROLES = 10 HOURS
-))
-
 /obj/effect/landmark/start/warden
 	name = JOB_WARDEN
 	icon_state = "mw_spawn"

--- a/code/game/jobs/job/logistics/cargo/chief_req.dm
+++ b/code/game/jobs/job/logistics/cargo/chief_req.dm
@@ -5,10 +5,6 @@
 	gear_preset = /datum/equipment_preset/uscm_ship/qm
 	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>Your job</a> is to dispense supplies to the marines, including weapon attachments. Your cargo techs can help you out, but you have final say in your department. Make sure they're not goofing off. While you may request paperwork for supplies, do not go out of your way to screw with marines, unless you want to get deposed. A happy ship is a well-functioning ship."
 
-AddTimelock(/datum/job/logistics/requisition, list(
-	JOB_REQUISITION_ROLES = 10 HOURS,
-))
-
 /obj/effect/landmark/start/requisition
 	name = JOB_CHIEF_REQUISITION
 	icon_state = "ro_spawn"

--- a/code/game/jobs/job/logistics/engi/chief_engineer.dm
+++ b/code/game/jobs/job/logistics/engi/chief_engineer.dm
@@ -18,10 +18,6 @@
 /datum/job/logistics/engineering/get_active_player_on_job()
 	return active_chief_engineer
 
-AddTimelock(/datum/job/logistics/engineering, list(
-	JOB_ENGINEER_ROLES = 10 HOURS,
-))
-
 /obj/effect/landmark/start/engineering
 	name = JOB_CHIEF_ENGINEER
 	icon_state = "ce_spawn"

--- a/code/game/jobs/job/logistics/engi/ordnance_tech.dm
+++ b/code/game/jobs/job/logistics/engi/ordnance_tech.dm
@@ -26,10 +26,6 @@
 		total_positions_so_far = positions
 	return positions
 
-AddTimelock(/datum/job/logistics/otech, list(
-	JOB_ENGINEER_ROLES = 1 HOURS
-))
-
 /obj/effect/landmark/start/otech
 	name = JOB_ORDNANCE_TECH
 	icon_state = "ot_spawn"

--- a/code/game/jobs/job/marine/squad/engineer.dm
+++ b/code/game/jobs/job/marine/squad/engineer.dm
@@ -32,10 +32,6 @@
 	flags_startup_parameters = ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/wo/marine/engineer
 
-AddTimelock(/datum/job/marine/engineer, list(
-	JOB_SQUAD_ROLES = 1 HOURS
-))
-
 /obj/effect/landmark/start/marine/engineer
 	name = JOB_SQUAD_ENGI
 	icon_state = "engi_spawn"

--- a/code/game/jobs/job/marine/squad/leader.dm
+++ b/code/game/jobs/job/marine/squad/leader.dm
@@ -12,10 +12,6 @@
 	flags_startup_parameters = ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/wo/marine/sl
 
-AddTimelock(/datum/job/marine/leader, list(
-	JOB_SQUAD_ROLES = 10 HOURS
-))
-
 /obj/effect/landmark/start/marine/leader
 	name = JOB_SQUAD_LEADER
 	icon_state = "leader_spawn"

--- a/code/game/jobs/job/marine/squad/medic.dm
+++ b/code/game/jobs/job/marine/squad/medic.dm
@@ -32,11 +32,6 @@
 	flags_startup_parameters = ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/wo/marine/medic
 
-AddTimelock(/datum/job/marine/medic, list(
-	JOB_MEDIC_ROLES = 1 HOURS,
-	JOB_SQUAD_ROLES = 1 HOURS
-))
-
 /obj/effect/landmark/start/marine/medic
 	name = JOB_SQUAD_MEDIC
 	icon_state = "medic_spawn"

--- a/code/game/jobs/job/marine/squad/smartgunner.dm
+++ b/code/game/jobs/job/marine/squad/smartgunner.dm
@@ -28,10 +28,6 @@
 	flags_startup_parameters = ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/wo/marine/sg
 
-AddTimelock(/datum/job/marine/smartgunner, list(
-	JOB_SQUAD_ROLES = 5 HOURS
-))
-
 /obj/effect/landmark/start/marine/smartgunner
 	name = JOB_SQUAD_SMARTGUN
 	icon_state = "smartgunner_spawn"

--- a/code/game/jobs/job/marine/squad/specialist.dm
+++ b/code/game/jobs/job/marine/squad/specialist.dm
@@ -34,10 +34,6 @@
 	flags_startup_parameters = ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/wo/marine/spec
 
-AddTimelock(/datum/job/marine/specialist, list(
-	JOB_SQUAD_ROLES = 5 HOURS
-))
-
 /obj/effect/landmark/start/marine/spec
 	name = JOB_SQUAD_SPECIALIST
 	icon_state = "spec_spawn"

--- a/code/game/jobs/job/marine/squad/tl.dm
+++ b/code/game/jobs/job/marine/squad/tl.dm
@@ -11,10 +11,6 @@
 	. = ..()
 	spawning_human.important_radio_channels += JTAC_FREQ
 
-AddTimelock(/datum/job/marine/tl, list(
-	JOB_SQUAD_ROLES = 8 HOURS
-))
-
 /obj/effect/landmark/start/marine/tl
 	name = JOB_SQUAD_TEAM_LEADER
 	icon_state = "tl_spawn"

--- a/code/game/jobs/job/special/responders.dm
+++ b/code/game/jobs/job/special/responders.dm
@@ -19,65 +19,30 @@
 	title = JOB_FAX_RESPONDER_USCM_HC
 	gear_preset = /datum/equipment_preset/fax_responder/uscm
 
-AddTimelock(/datum/job/fax_responder/uscm_hc, list(
-	JOB_POLICE_ROLES = 25 HOURS,
-	JOB_COMMAND_ROLES = 75 HOURS,
-))
-
 /datum/job/fax_responder/uscm_pvst
 	title = JOB_FAX_RESPONDER_USCM_PVST
 	gear_preset = /datum/equipment_preset/fax_responder/uscm/provost
-
-AddTimelock(/datum/job/fax_responder/uscm_pvst, list(
-	JOB_POLICE_ROLES = 75 HOURS,
-	JOB_COMMAND_ROLES = 75 HOURS,
-))
 
 /datum/job/fax_responder/wy
 	title = JOB_FAX_RESPONDER_WY
 	gear_preset = /datum/equipment_preset/fax_responder/wey_yu
 
-AddTimelock(/datum/job/fax_responder/wy, list(
-	JOB_CORPORATE_ROLES = 75 HOURS,
-))
-
 /datum/job/fax_responder/upp
 	title = JOB_FAX_RESPONDER_UPP
 	gear_preset = /datum/equipment_preset/fax_responder/upp
-
-AddTimelock(/datum/job/fax_responder/upp, list(
-	JOB_COMMAND_ROLES = 75 HOURS,
-))
 
 /datum/job/fax_responder/twe
 	title = JOB_FAX_RESPONDER_TWE
 	gear_preset = /datum/equipment_preset/fax_responder/twe
 
-AddTimelock(/datum/job/fax_responder/twe, list(
-	JOB_COMMAND_ROLES = 75 HOURS,
-))
-
 /datum/job/fax_responder/clf
 	title = JOB_FAX_RESPONDER_CLF
 	gear_preset = /datum/equipment_preset/fax_responder/clf
-
-AddTimelock(/datum/job/fax_responder/clf, list(
-	JOB_COMMAND_ROLES = 75 HOURS,
-))
 
 /datum/job/fax_responder/cmb
 	title = JOB_FAX_RESPONDER_CMB
 	gear_preset = /datum/equipment_preset/fax_responder/cmb
 
-AddTimelock(/datum/job/fax_responder/cmb, list(
-	JOB_POLICE_ROLES = 75 HOURS,
-	JOB_COMMAND_ROLES = 25 HOURS,
-))
-
 /datum/job/fax_responder/press
 	title = JOB_FAX_RESPONDER_PRESS
 	gear_preset = /datum/equipment_preset/fax_responder/press
-
-AddTimelock(/datum/job/fax_responder/press, list(
-	JOB_CIVIL_ROLES = 25 HOURS,
-))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Removes all Timelocks from all Roles, setting them to 0

# Explain why it's good for the game
This PR removes all existing playtime (timelock) requirements from roles across the board.

This change follows feedback provided in a previous discussion by harryob:

>_"Timelocks are not a guarantee of competency in a role, and were not intended to be used as such._
>_They were primarily implemented to dissuade low effort griefers taking high importance roles."_

Given this clarification of intent, continuing to rely on timelocks as a gatekeeping mechanism seems misaligned with their original purpose. While they may provide a minor deterrent to griefers, they do not effectively ensure player preparedness or role competency.

Concerns about griefers accessing critical roles are valid, and there are ongoing plans to explore more targeted, behavior-based safeguards that don't rely on passive time accumulation.

This PR aims to streamline access while aligning mechanics with their stated intent and paving the way for more robust solutions moving forward.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Removed timelocks from all roles, now more easily accessible for players to train in.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
