### PR TITLE
Fix fax machine double-click exploit

### DIFF
--- a/code/game/machinery/fax_machine.dm
+++ b/code/game/machinery/fax_machine.dm
@@ -85,6 +85,8 @@ GLOBAL_DATUM_INIT(fax_network, /datum/fax_network, new)
 	///storer var for cooldown on sending faxes
 	var/fax_cooldown = 300
 	COOLDOWN_DECLARE(send_cooldown)
+	/// Whether or not the machine is currently sending a fax (prevents double-clicking)
+	var/sending_fax = FALSE
 	/// Whether or not the next fax to be sent is a priority one.
 	var/is_priority_fax = FALSE
 	/// If this machine can send priority faxes.
@@ -317,6 +319,7 @@ GLOBAL_DATUM_INIT(fax_network, /datum/fax_network, new)
 	data["can_send_priority"] = can_send_priority
 	data["is_priority_fax"] = is_priority_fax
 	data["is_single_sending"] = single_sending
+	data["sending_fax"] = sending_fax
 
 
 	return data
@@ -351,6 +354,10 @@ GLOBAL_DATUM_INIT(fax_network, /datum/fax_network, new)
 				to_chat(user, SPAN_NOTICE("No paper loaded."))
 				return
 
+			if(sending_fax)
+				to_chat(user, SPAN_WARNING("Fax transmission already in progress."))
+				return
+
 			if(single_sending && (target_machine == "Undefined") && !(target_department == FAX_DEPARTMENT_SPECIFIC_CODE))
 				to_chat(user, SPAN_WARNING("No target machine selected!"))
 				return
@@ -367,13 +374,19 @@ GLOBAL_DATUM_INIT(fax_network, /datum/fax_network, new)
 					to_chat(user, SPAN_NOTICE("\The [src] is jammed!"))
 					return
 
+			sending_fax = TRUE
 			copy_fax_paper()
 
-			outgoing_fax_message(user, is_priority_fax)
-			is_priority_fax = FALSE
-
-			COOLDOWN_START(src, send_cooldown, fax_cooldown)
-			to_chat(user, "Message transmitted successfully.")
+			try
+				outgoing_fax_message(user, is_priority_fax)
+				is_priority_fax = FALSE
+				COOLDOWN_START(src, send_cooldown, fax_cooldown)
+				to_chat(user, "Message transmitted successfully.")
+			catch(var/exception/e)
+				to_chat(user, SPAN_WARNING("Transmission failed: [e.name]"))
+				log_runtime(e)
+			finally
+				sending_fax = FALSE
 			. = TRUE
 
 		if("ejectpaper")

--- a/html/changelogs/peter-fax-double-click-fix.yml
+++ b/html/changelogs/peter-fax-double-click-fix.yml
@@ -1,0 +1,9 @@
+# Fix for fax machine double-click vulnerability
+# GitHub Issue: https://github.com/cmss13-devs/cmss13/issues/9953
+
+author: peter
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed ability to bypass fax machine cooldown by rapidly clicking the SEND button, preventing duplicate transmissions."

--- a/tgui/packages/tgui/interfaces/FaxMachine.tsx
+++ b/tgui/packages/tgui/interfaces/FaxMachine.tsx
@@ -30,6 +30,7 @@ type Data = {
   can_send_priority: BooleanLike;
   is_priority_fax: BooleanLike;
   is_single_sending: BooleanLike;
+  sending_fax: BooleanLike;
 };
 
 export const FaxMachine = () => {
@@ -192,6 +193,7 @@ const ConfirmSend = (props) => {
     nextfaxtime,
     can_send_priority,
     is_priority_fax,
+    sending_fax,
   } = data;
 
   const timeLeft = nextfaxtime - worldtime;
@@ -211,16 +213,20 @@ const ConfirmSend = (props) => {
           </Button>
         </Stack.Item>
         <Stack.Item grow>
-          {(timeLeft < 0 && (
+          {(timeLeft < 0 && !sending_fax && (
             <Button
               icon="paper-plane"
               fluid
               onClick={() => act('send')}
-              disabled={timeLeft > 0 || !paper || !authenticated}
+              disabled={timeLeft > 0 || !paper || !authenticated || sending_fax}
             >
               {paper ? 'Send' : 'No paper loaded!'}
             </Button>
-          )) || (
+          )) || sending_fax ? (
+            <Button icon="hourglass-half" fluid disabled={1}>
+              Transmission in progress...
+            </Button>
+          ) : (
             <Button icon="window-close" fluid disabled={1}>
               {'Transmitters realigning, ' + timeLeft / 10 + ' seconds left.'}
             </Button>
@@ -233,7 +239,7 @@ const ConfirmSend = (props) => {
               fluid
               onClick={() => act('toggle_priority')}
               color={is_priority_fax ? 'green' : 'red'}
-              disabled={!paper || !can_send_priority || !authenticated}
+              disabled={!paper || !can_send_priority || !authenticated || sending_fax}
               tooltip="Toggle priority alert."
             />
           </Stack.Item>


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Resolves issue #9953 where users could bypass the fax cooldown by rapidly clicking the SEND button, causing multiple duplicate transmissions.

Changes:
- Added `sending_fax` boolean flag to prevent concurrent transmissions
- Updated UI to show "Transmission in progress..." during send operations
- Added error handling with try/catch/finally to ensure flag is always reset
- Disabled send and priority toggle buttons during transmission
- Added changelog entry documenting the bugfix

The fix ensures only one fax can be sent at a time while providing clear user feedback about the transmission state.

# Explain why it's good for the game

esolves issue #9953 where users could bypass the fax cooldown by rapidly clicking the SEND button, causing multiple duplicate transmissions.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: fixed a few things
/:cl:
