### PR TITLE
Size labeler action

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,9 @@ on:
     types: [opened, reopened, synchronize, edited]
 jobs:
   label:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: "Check for ACTION_ENABLER secret and pass true to output if it exists to be checked by later steps"
@@ -45,3 +48,10 @@ jobs:
           REPO: ${{ github.repository }}
           TOKEN: ${{ steps.app-token-generation.outputs.token }}
           PR_NUMBER: ${{ github.event.number }}
+
+      - name: size-label
+        if: steps.value_holder.outputs.ACTIONS_ENABLED
+        uses: "pascalgn/size-label-action@v0.5.5"
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token-generation.outputs.token }}
+          IGNORED: ".*\n!.gitignore\nyarn.lock/**"


### PR DESCRIPTION
# About the pull request
Adds https://github.com/pascalgn/size-label-action to the labeler action so that PRs can be labeled with a size based on PR size.

# Explain why it's good for the game
Its just more automatic PR triaging.

# Changelog
No player facing changes.