### PR TITLE
Hybrisa health values fixes & map fixes.

### DIFF
--- a/code/game/machinery/doors/poddoor/poddoor.dm
+++ b/code/game/machinery/doors/poddoor/poddoor.dm
@@ -152,14 +152,14 @@
 
 /obj/structure/machinery/door/poddoor/hybrisa/open_shutters
 	name = "\improper shutters"
-	desc = null
+	desc = "Thin metal shutters, more for show than security. They redirect light and add a bit of structure to the space."
 	icon_state = "almayer_pdoor1"
 	base_icon_state = "almayer_pdoor"
 	opacity = FALSE
 	vehicle_resistant = FALSE
 	unslashable = FALSE
 	gender = PLURAL
-	health = 100
+	health = 10
 
 /obj/structure/machinery/door/poddoor/hybrisa/open_shutters/bullet_act(obj/projectile/P)
 	health -= P.damage

--- a/code/game/objects/structures/crates_lockers/closets/phonebox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/phonebox.dm
@@ -10,7 +10,7 @@
 	anchored = TRUE
 	layer = BETWEEN_OBJECT_ITEM_LAYER
 	exit_stun = 1
-	health = 750
+	health = 250
 
 	open_sound = 'sound/effects/metal_door_open.ogg'
 	close_sound = 'sound/effects/metal_door_close.ogg'

--- a/code/game/objects/structures/hybrisa_props.dm
+++ b/code/game/objects/structures/hybrisa_props.dm
@@ -11,9 +11,9 @@
 /obj/structure/prop/hybrisa/vehicles
 	icon = 'icons/obj/structures/props/vehicles/meridian_red.dmi'
 	icon_state = "meridian_red"
-	health = 3000
+	health = 1500
 	var/damage_state = 0
-	var/brute_multiplier = 3
+	var/brute_multiplier = 4
 
 /obj/structure/prop/hybrisa/vehicles/attack_alien(mob/living/carbon/xenomorph/user)
 	user.animation_attack_on(src)
@@ -30,35 +30,35 @@
 
 /obj/structure/prop/hybrisa/vehicles/update_icon()
 	switch(health)
-		if(2500 to 3000)
+		if(1250 to 1500)
 			icon_state = initial(icon_state)
 			return
-		if(2000 to 2500)
+		if(1000 to 1250)
 			damage_state = 1
-		if(1500 to 2000)
+		if(750 to 1000)
 			damage_state = 2
-		if(1000 to 1500)
+		if(500 to 750)
 			damage_state = 3
-		if(500 to 1000)
+		if(250 to 500)
 			damage_state = 4
-		if(0 to 500)
+		if(0 to 250)
 			damage_state = 5
 	icon_state = "[initial(icon_state)]_damage_[damage_state]"
 
 /obj/structure/prop/hybrisa/vehicles/get_examine_text(mob/user)
 	. = ..()
 	switch(health)
-		if(2500 to 3000)
+		if(1250 to 1500)
 			. += SPAN_WARNING("It looks to be in good condition.")
-		if(2000 to 2500)
+		if(1000 to 1250)
 			. += SPAN_WARNING("It looks slightly damaged.")
-		if(1500 to 2000)
+		if(750 to 1000)
 			. += SPAN_WARNING("It looks moderately damaged.")
-		if(1000 to 1500)
+		if(500 to 750)
 			. += SPAN_DANGER("It looks heavily damaged.")
-		if(500 to 1000)
+		if(250 to 500)
 			. += SPAN_DANGER("It looks very heavily damaged.")
-		if(0 to 500)
+		if(0 to 250)
 			. += SPAN_DANGER("It looks like it's about break down into scrap.")
 
 /obj/structure/prop/hybrisa/vehicles/proc/explode(dam, mob/M)
@@ -286,57 +286,267 @@
 	icon = 'icons/obj/structures/props/vehicles/meridian_red.dmi'
 	icon_state = "meridian_red"
 
+/obj/structure/prop/hybrisa/vehicles/Meridian/Red/damage_1
+	health = 1125
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Red/damage_2
+	health = 875
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Red/damage_3
+	health = 625
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Red/damage_4
+	health = 375
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Red/damage_5
+	health = 125
+
 /obj/structure/prop/hybrisa/vehicles/Meridian/Black
 	icon = 'icons/obj/structures/props/vehicles/meridian_black.dmi'
 	icon_state = "meridian_black"
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Black/damage_1
+	health = 1125
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Black/damage_2
+	health = 875
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Black/damage_3
+	health = 625
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Black/damage_4
+	health = 375
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Black/damage_5
+	health = 125
 
 /obj/structure/prop/hybrisa/vehicles/Meridian/Blue
 	icon = 'icons/obj/structures/props/vehicles/meridian_blue.dmi'
 	icon_state = "meridian_blue"
 
+/obj/structure/prop/hybrisa/vehicles/Meridian/Blue/damage_1
+	health = 1125
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Blue/damage_2
+	health = 875
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Blue/damage_3
+	health = 625
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Blue/damage_4
+	health = 375
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Blue/damage_5
+	health = 125
+
 /obj/structure/prop/hybrisa/vehicles/Meridian/Brown
 	icon = 'icons/obj/structures/props/vehicles/meridian_brown.dmi'
 	icon_state = "meridian_brown"
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Brown/damage_1
+	health = 1125
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Brown/damage_2
+	health = 875
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Brown/damage_3
+	health = 625
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Brown/damage_4
+	health = 375
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Brown/damage_5
+	health = 125
 
 /obj/structure/prop/hybrisa/vehicles/Meridian/Cop
 	icon = 'icons/obj/structures/props/vehicles/meridian_cop.dmi'
 	icon_state = "meridian_cop"
 
+/obj/structure/prop/hybrisa/vehicles/Meridian/Cop/damage_1
+	health = 1125
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Cop/damage_2
+	health = 875
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Cop/damage_3
+	health = 625
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Cop/damage_4
+	health = 375
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Cop/damage_5
+	health = 125
+
 /obj/structure/prop/hybrisa/vehicles/Meridian/Desat_Blue
 	icon = 'icons/obj/structures/props/vehicles/meridian_desatblue.dmi'
 	icon_state = "meridian_desatblue"
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Desat_Blue/damage_1
+	health = 1125
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Desat_Blue/damage_2
+	health = 875
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Desat_Blue/damage_3
+	health = 625
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Desat_Blue/damage_4
+	health = 375
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Desat_Blue/damage_5
+	health = 125
 
 /obj/structure/prop/hybrisa/vehicles/Meridian/Green
 	icon = 'icons/obj/structures/props/vehicles/meridian_green.dmi'
 	icon_state = "meridian_green"
 
+/obj/structure/prop/hybrisa/vehicles/Meridian/Green/damage_1
+	health = 1125
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Green/damage_2
+	health = 875
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Green/damage_3
+	health = 625
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Green/damage_4
+	health = 375
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Green/damage_5
+	health = 125
+
 /obj/structure/prop/hybrisa/vehicles/Meridian/Light_Blue
 	icon = 'icons/obj/structures/props/vehicles/meridian_lightblue.dmi'
 	icon_state = "meridian_lightblue"
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Light_Blue/damage_1
+	health = 1125
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Light_Blue/damage_2
+	health = 875
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Light_Blue/damage_3
+	health = 625
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Light_Blue/damage_4
+	health = 375
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Light_Blue/damage_5
+	health = 125
 
 /obj/structure/prop/hybrisa/vehicles/Meridian/Pink
 	icon = 'icons/obj/structures/props/vehicles/meridian_pink.dmi'
 	icon_state = "meridian_pink"
 
+/obj/structure/prop/hybrisa/vehicles/Meridian/Pink/damage_1
+	health = 1125
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Pink/damage_2
+	health = 875
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Pink/damage_3
+	health = 625
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Pink/damage_4
+	health = 375
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Pink/damage_5
+	health = 125
+
 /obj/structure/prop/hybrisa/vehicles/Meridian/Purple
 	icon = 'icons/obj/structures/props/vehicles/meridian_purple.dmi'
 	icon_state = "meridian_purple"
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Purple/damage_1
+	health = 1125
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Purple/damage_2
+	health = 875
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Purple/damage_3
+	health = 625
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Purple/damage_4
+	health = 375
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Purple/damage_5
+	health = 125
 
 /obj/structure/prop/hybrisa/vehicles/Meridian/Turquoise
 	icon = 'icons/obj/structures/props/vehicles/meridian_turquoise.dmi'
 	icon_state = "meridian_turquoise"
 
+/obj/structure/prop/hybrisa/vehicles/Meridian/Turquoise/damage_1
+	health = 1125
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Turquoise/damage_2
+	health = 875
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Turquoise/damage_3
+	health = 625
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Turquoise/damage_4
+	health = 375
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Turquoise/damage_5
+	health = 125
+
 /obj/structure/prop/hybrisa/vehicles/Meridian/Orange
 	icon = 'icons/obj/structures/props/vehicles/meridian_orange.dmi'
 	icon_state = "meridian_orange"
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Orange/damage_1
+	health = 1125
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Orange/damage_2
+	health = 875
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Orange/damage_3
+	health = 625
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Orange/damage_4
+	health = 375
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Orange/damage_5
+	health = 125
 
 /obj/structure/prop/hybrisa/vehicles/Meridian/WeylandYutani
 	icon = 'icons/obj/structures/props/vehicles/meridian_wy.dmi'
 	icon_state = "meridian_wy"
 
+/obj/structure/prop/hybrisa/vehicles/Meridian/WeylandYutani/damage_1
+	health = 1125
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/WeylandYutani/damage_2
+	health = 875
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/WeylandYutani/damage_3
+	health = 625
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/WeylandYutani/damage_4
+	health = 375
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/WeylandYutani/damage_5
+	health = 125
+
 /obj/structure/prop/hybrisa/vehicles/Meridian/Taxi
 	icon = 'icons/obj/structures/props/vehicles/meridian_taxi.dmi'
 	icon_state = "meridian_taxi"
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Taxi/damage_1
+	health = 1125
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Taxi/damage_2
+	health = 875
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Taxi/damage_3
+	health = 625
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Taxi/damage_4
+	health = 375
+
+/obj/structure/prop/hybrisa/vehicles/Meridian/Taxi/damage_5
+	health = 125
 
 /obj/structure/prop/hybrisa/vehicles/Meridian/Shell
 	desc = "A Mono-Spectra chassis in the early stages of assembly."
@@ -490,7 +700,7 @@
 	density = TRUE
 	projectile_coverage = 20
 	throwpass = TRUE
-	health = 200
+	health = 15
 
 /obj/structure/prop/hybrisa/supermart/bullet_act(obj/projectile/P)
 	health -= P.damage
@@ -574,51 +784,58 @@
 	desc = "A commercial grade freezer."
 	icon_state = "freezerupper"
 	density = TRUE
+	health = 30
 
-/obj/structure/prop/hybrisa/supermart/freezer/supermartfreezer1
+/obj/structure/prop/hybrisa/supermart/freezer/freezer1
 	icon_state = "freezerupper"
 
-/obj/structure/prop/hybrisa/supermart/freezer/supermartfreezer2
+/obj/structure/prop/hybrisa/supermart/freezer/freezer2
 	icon_state = "freezerlower"
 
-/obj/structure/prop/hybrisa/supermart/freezer/supermartfreezer3
+/obj/structure/prop/hybrisa/supermart/freezer/freezer3
 	icon_state = "freezermid"
 
-/obj/structure/prop/hybrisa/supermart/freezer/supermartfreezer4
+/obj/structure/prop/hybrisa/supermart/freezer/freezer4
 	icon_state = "freezerupper1"
 
-/obj/structure/prop/hybrisa/supermart/freezer/supermartfreezer5
+/obj/structure/prop/hybrisa/supermart/freezer/freezer5
 	icon_state = "freezerlower1"
 
-/obj/structure/prop/hybrisa/supermart/freezer/supermartfreezer6
+/obj/structure/prop/hybrisa/supermart/freezer/freezer6
 	icon_state = "freezermid1"
 
-/obj/structure/prop/hybrisa/supermart/supermartfruitbasketempty
+/obj/structure/prop/hybrisa/supermart/supermartfruitbasket
+	name = "basket"
+	desc = "A basket."
+	icon_state = "supermarketbasketempty"
+	health = 5
+
+/obj/structure/prop/hybrisa/supermart/supermartfruitbasket/empty
 	name = "basket"
 	desc = "A basket."
 	icon_state = "supermarketbasketempty"
 
-/obj/structure/prop/hybrisa/supermart/supermartfruitbasketoranges
+/obj/structure/prop/hybrisa/supermart/supermartfruitbasket/oranges
 	name = "basket"
 	desc = "A basket full of oranges."
 	icon_state = "supermarketbasket1"
 
-/obj/structure/prop/hybrisa/supermart/supermartfruitbasketpears
+/obj/structure/prop/hybrisa/supermart/supermartfruitbasket/pears
 	name = "basket"
 	desc = "A basket full of pears."
 	icon_state = "supermarketbasket2"
 
-/obj/structure/prop/hybrisa/supermart/supermartfruitbasketcarrots
+/obj/structure/prop/hybrisa/supermart/supermartfruitbasket/carrots
 	name = "basket"
 	desc = "A basket full of carrots."
 	icon_state = "supermarketbasket3"
 
-/obj/structure/prop/hybrisa/supermart/supermartfruitbasketmelons
+/obj/structure/prop/hybrisa/supermart/supermartfruitbasket/melons
 	name = "basket"
 	desc = "A basket full of melons."
 	icon_state = "supermarketbasket4"
 
-/obj/structure/prop/hybrisa/supermart/supermartfruitbasketapples
+/obj/structure/prop/hybrisa/supermart/supermartfruitbasket/apples
 	name = "basket"
 	desc = "A basket full of apples."
 	icon_state = "supermarketbasket5"
@@ -629,6 +846,7 @@
 	desc = "A mannequin of the famous 'Souto-Man', Party like it's 1999!"
 	icon_state = "souto_man_prop"
 	density = TRUE
+	health = 100
 
 /obj/structure/prop/hybrisa/supermart/souto_rack
 	name = "Souto cans rack"
@@ -636,6 +854,7 @@
 	desc = "A rack filled with Souto cans of various flavors."
 	icon_state = "souto_rack"
 	density = TRUE
+	health = 15
 
 /obj/structure/prop/hybrisa/supermart/souto_can_stack
 	name = "stacked souto cans"
@@ -643,19 +862,21 @@
 	desc = "A large stack of 'Souto-Classic' cans."
 	icon_state = "souto_can_stack"
 	density = TRUE
+	health = 15
 
 // Furniture
+
 /obj/structure/prop/hybrisa/furniture
 	icon = 'icons/obj/structures/tables_64x64.dmi'
 	icon_state = "blackmetaltable"
-	health = 200
+	health = 100
 	projectile_coverage = 20
 	throwpass = TRUE
 
 /obj/structure/prop/hybrisa/furniture/tables
 	icon = 'icons/obj/structures/tables_64x64.dmi'
 	icon_state = "table_pool"
-	health = 200
+	health = 100
 
 /obj/structure/prop/hybrisa/furniture/tables/bullet_act(obj/projectile/P)
 	health -= P.damage
@@ -699,6 +920,7 @@
 	bound_height = 32
 	bound_width = 64
 	debris = list(/obj/item/stack/sheet/metal)
+	health = 150
 
 /obj/structure/prop/hybrisa/furniture/tables/tableblack/blacktablecomputer
 	icon = 'icons/obj/structures/tables_64x64.dmi'
@@ -714,6 +936,7 @@
 	bound_height = 32
 	bound_width = 64
 	debris = list(/obj/item/stack/sheet/wood)
+	health = 100
 
 /obj/structure/prop/hybrisa/furniture/tables/tablewood/woodtablecomputer
 	icon = 'icons/obj/structures/tables_64x64.dmi'
@@ -769,7 +992,7 @@
 	icon_state = "bed_dingy"
 
 /obj/structure/bed/hybrisa
-	icon_state = ""
+	icon_state = "bunk bed"
 	buckling_y = 8
 
 /obj/structure/bed/hybrisa/prisonbed
@@ -1436,7 +1659,7 @@
 	anchored = TRUE
 	density = TRUE
 	layer = WINDOW_LAYER
-	health = 450
+	health = 150
 
 /obj/structure/prop/hybrisa/misc/slotmachine/broken
 	name = "slot machine"
@@ -1610,7 +1833,7 @@
 	bound_height = 32
 	anchored = TRUE
 	density = TRUE
-	health = 250
+	health = 150
 	opacity = FALSE
 
 /obj/structure/machinery/big_computers/bullet_act(obj/projectile/P)
@@ -1724,7 +1947,7 @@
 	bound_height = 32
 	anchored = TRUE
 	density = TRUE
-	health = 250
+	health = 150
 	opacity = FALSE
 
 /obj/structure/machinery/big_computers/science_big/synthesis_simulator
@@ -1756,7 +1979,7 @@
 
 /obj/structure/prop/hybrisa/misc/machinery/screens
 	name = "monitor"
-	health = 150
+	health = 50
 
 /obj/structure/prop/hybrisa/misc/machinery/screens/bullet_act(obj/projectile/P)
 	health -= P.damage
@@ -2149,6 +2372,7 @@
 	icon_state = "hybrisaplatform_deco"
 
 // Greeblies
+
 /obj/structure/prop/hybrisa/misc/buildinggreeblies
 	name = "\improper machinery"
 	icon = 'icons/obj/structures/props/hybrisa/64x64_props.dmi'
@@ -2156,7 +2380,7 @@
 	bound_width = 64
 	bound_height = 32
 	density = TRUE
-	health = 500
+	health = 200
 	anchored = TRUE
 	layer = ABOVE_XENO_LAYER
 	gender = PLURAL
@@ -2238,7 +2462,7 @@
 	icon = 'icons/obj/structures/props/hybrisa/piping_wiring.dmi'
 	icon_state = "smallwallvent1"
 	density = FALSE
-	health = 250
+	health = 150
 
 /obj/structure/prop/hybrisa/misc/buildinggreebliessmall/bullet_act(obj/projectile/P)
 	health -= P.damage
@@ -2307,7 +2531,7 @@
 	bound_width = 32
 	bound_height = 64
 	density = TRUE
-	health = 2000
+	health = 1500
 	anchored = TRUE
 	layer = ABOVE_MOB_LAYER
 	projectile_coverage = 20
@@ -2361,7 +2585,7 @@
 	icon_state = "firehydrant"
 	density = TRUE
 	anchored = TRUE
-	health = 250
+	health = 15
 	projectile_coverage = 20
 	throwpass = TRUE
 
@@ -2556,7 +2780,7 @@
 	bound_height = 64
 	bound_width = 64
 	layer = BILLBOARD_LAYER
-	health = 250
+	health = 100
 
 /obj/structure/roof/hybrisa/signs/bullet_act(obj/projectile/P)
 	health -= P.damage
@@ -2711,7 +2935,7 @@
 	desc = "An advertisement billboard."
 	icon = 'icons/obj/structures/props/wall_decorations/32x64_hybrisabillboards.dmi'
 	icon_state = "billboard_bigger"
-	health = 500
+	health = 150
 	bound_width = 64
 	bound_height = 32
 	density = FALSE
@@ -2800,6 +3024,7 @@
 	bound_width = 64
 	bound_height = 32
 	anchored = TRUE
+	health = 100
 
 /obj/structure/prop/hybrisa/Factory/Robotic_arm/Flipped
 	icon_state = "factory_roboticarm2"
@@ -2809,6 +3034,7 @@
 	desc = "A large conveyor belt used in industrial factories."
 	icon_state = "factory_conveyer"
 	density = FALSE
+	health = 25
 
 // Hybrisa Lattice
 /obj/structure/roof/hybrisa/lattice_prop

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -1126,13 +1126,14 @@
 
 
 // Colony
+
 /obj/structure/window/framed/hybrisa/colony
 	name = "window"
 	icon = 'icons/turf/walls/hybrisa_colony_window.dmi'
 	icon_state = "strata_window0"
 	basestate = "strata_window"
 	desc = "A glass window inside a wall frame."
-	health = 40
+	health = 15
 	window_frame = /obj/structure/window_frame/hybrisa/colony
 
 /obj/structure/window/framed/hybrisa/colony/reinforced
@@ -1155,13 +1156,14 @@
 	health = 1000000
 
 // Research
+
 /obj/structure/window/framed/hybrisa/research
 	name = "window"
 	icon = 'icons/turf/walls/hybrisaresearchbrown_windows.dmi'
 	icon_state = "strata_window0"
 	basestate = "strata_window"
 	desc = "A glass window inside a wall frame."
-	health = 40
+	health = 15
 	window_frame = /obj/structure/window_frame/hybrisa/research
 
 /obj/structure/window/framed/hybrisa/research/reinforced
@@ -1190,7 +1192,9 @@
 	icon = 'icons/turf/walls/hybrisa_marshalls_windows.dmi'
 	icon_state = "prison_window0"
 	basestate = "prison_window"
+	health = 15
 	window_frame = /obj/structure/window_frame/hybrisa/marshalls
+
 /obj/structure/window/framed/hybrisa/marshalls/reinforced
 	name = "reinforced window"
 	desc = "A glass window with a special rod matrix inside a wall frame. It looks rather strong. Might take a few good hits to shatter it."
@@ -1199,11 +1203,13 @@
 	icon_state = "prison_rwindow0"
 	basestate = "prison_rwindow"
 	window_frame = /obj/structure/window_frame/hybrisa/marshalls/reinforced
+
 /obj/structure/window/framed/hybrisa/marshalls/cell
 	name = "cell window"
 	icon_state = "prison_cellwindow0"
 	basestate = "prison_cellwindow"
 	desc = "A glass window with a special rod matrix inside a wall frame."
+	health = 100
 
 // Hospital
 
@@ -1213,7 +1219,7 @@
 	icon_state = "strata_window0"
 	basestate = "strata_window"
 	desc = "A glass window inside a wall frame."
-	health = 40
+	health = 15
 	window_frame = /obj/structure/window_frame/hybrisa/colony/hospital
 
 /obj/structure/window/framed/hybrisa/colony/hospital/reinforced
@@ -1243,7 +1249,7 @@
 	icon_state = "strata_window0"
 	basestate = "strata_window"
 	desc = "A glass window inside a wall frame."
-	health = 40
+	health = 15
 	window_frame = /obj/structure/window_frame/hybrisa/colony/office
 
 /obj/structure/window/framed/hybrisa/colony/office/reinforced
@@ -1273,7 +1279,7 @@
 	icon_state = "strata_window0"
 	basestate = "strata_window"
 	desc = "A glass window inside a wall frame."
-	health = 40
+	health = 15
 	window_frame = /obj/structure/window_frame/hybrisa/colony/engineering
 
 /obj/structure/window/framed/hybrisa/colony/engineering/reinforced
@@ -1303,6 +1309,8 @@
 	icon_state = "prison_window0"
 	basestate = "prison_window"
 	window_frame = /obj/structure/window_frame/hybrisa/spaceport
+	health = 15
+
 /obj/structure/window/framed/hybrisa/spaceport/reinforced
 	name = "reinforced window"
 	desc = "A glass window with a special rod matrix inside a wall frame. It looks rather strong. Might take a few good hits to shatter it."
@@ -1311,8 +1319,10 @@
 	icon_state = "prison_rwindow0"
 	basestate = "prison_rwindow"
 	window_frame = /obj/structure/window_frame/hybrisa/spaceport/reinforced
+
 /obj/structure/window/framed/hybrisa/spaceport/cell
 	name = "window"
 	icon_state = "prison_cellwindow0"
 	basestate = "prison_cellwindow"
 	desc = "A glass window with a special rod matrix inside a wall frame."
+	health = 100

--- a/maps/map_files/LV759_Hybrisa_Prospera/standalone/clfspaceport.dmm
+++ b/maps/map_files/LV759_Hybrisa_Prospera/standalone/clfspaceport.dmm
@@ -1821,7 +1821,7 @@
 	},
 /area/lv759/indoors/spaceport/clf_dropship)
 "yH" = (
-/obj/structure/prop/hybrisa/supermart/freezer/supermartfreezer4,
+/obj/structure/prop/hybrisa/supermart/freezer/freezer4,
 /turf/closed/wall/hybrisa/spaceport/reinforced,
 /area/lv759/indoors/spaceport/kitchen)
 "yN" = (

--- a/maps/map_files/LV759_Hybrisa_Prospera/standalone/landingzone_hybrisa_upp_lz1.dmm
+++ b/maps/map_files/LV759_Hybrisa_Prospera/standalone/landingzone_hybrisa_upp_lz1.dmm
@@ -366,7 +366,7 @@
 /obj/item/reagent_container/food/snacks/packaged_burger{
 	pixel_y = 11
 	},
-/obj/structure/prop/hybrisa/supermart/freezer/supermartfreezer5,
+/obj/structure/prop/hybrisa/supermart/freezer/freezer5,
 /turf/open/floor/corsat/officetiles,
 /area/lv759/indoors/spaceport/kitchen)
 "aW" = (
@@ -3131,8 +3131,8 @@
 /turf/open/floor/hybrisa/tile/cuppajoesfloor,
 /area/lv759/indoors/spaceport/cuppajoes)
 "qL" = (
-/obj/structure/window/framed/hybrisa/spaceport/reinforced,
 /obj/structure/machinery/door/poddoor/hybrisa/open_shutters,
+/obj/structure/window/framed/hybrisa/spaceport,
 /turf/open/floor/plating,
 /area/lv759/indoors/spaceport/docking_bay_1)
 "qM" = (
@@ -3839,7 +3839,7 @@
 /turf/open/floor/strata/floor3,
 /area/lv759/indoors/spaceport/docking_bay_2)
 "uY" = (
-/obj/structure/prop/hybrisa/supermart/freezer/supermartfreezer4,
+/obj/structure/prop/hybrisa/supermart/freezer/freezer4,
 /turf/closed/wall/hybrisa/spaceport/reinforced,
 /area/lv759/indoors/spaceport/kitchen)
 "va" = (
@@ -3992,10 +3992,10 @@
 /turf/open/floor/strata/multi_tiles,
 /area/lv759/indoors/spaceport/docking_bay_1)
 "vM" = (
-/obj/structure/window/framed/hybrisa/spaceport/reinforced,
 /obj/structure/machinery/door/poddoor/hybrisa/shutters{
 	dir = 8
 	},
+/obj/structure/window/framed/hybrisa/spaceport,
 /turf/open/floor/plating,
 /area/lv759/indoors/spaceport/kitchen)
 "vN" = (
@@ -8062,7 +8062,7 @@
 /obj/structure/closet/crate/freezer/cooler{
 	layer = 5
 	},
-/obj/structure/prop/hybrisa/supermart/freezer/supermartfreezer6,
+/obj/structure/prop/hybrisa/supermart/freezer/freezer6,
 /turf/open/floor/corsat/officetiles,
 /area/lv759/indoors/spaceport/kitchen)
 "TG" = (
@@ -8456,10 +8456,10 @@
 /turf/open/shuttle/escapepod/floor1,
 /area/lv759/indoors/spaceport/engineering)
 "Wq" = (
-/obj/structure/window/framed/hybrisa/spaceport/reinforced,
 /obj/structure/machinery/door/poddoor/hybrisa/shutters{
 	dir = 8
 	},
+/obj/structure/window/framed/hybrisa/spaceport,
 /turf/open/floor/plating,
 /area/lv759/indoors/spaceport/hallway_east)
 "Ww" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Basically changes a bunch of "health" values for the destructible stuff on Hybrisa - Windows, Cars, various other props and more.

Makes it much easier to destroy window's, they take one hit to smash the glass, one hit to destroy the annoying shutters now as well.

Also cars health values have been halved and the Xeno brute_multiplier has gone up by one, so it's easier for Xenos even more so as well. Also I've added them properly, so there should be a few less lines on the map file, since it's now in code.

# Explain why it's good for the game

The health values for things was way too high, it makes clearing cars, props and such annoying for both Xenos and marines, now it's much, much easier and shouldn't be so much of an issue. Especially with things like windows, cars ect.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Zenith

balance: rebalanced health values for many Hybrisa map props, Cars, Windows, Shutters ect. Should be much easier to break as both the Marines and Xenos.
fix: replaced a lot of windows with their correct versions, was reinforced in some cases, as well as reduced the regular window health values.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
