### PR TITLE
Adds Yautja Autodoc (and upgrades their sleeper)

### DIFF
--- a/code/game/machinery/medical_pod/autodoc.dm
+++ b/code/game/machinery/medical_pod/autodoc.dm
@@ -870,6 +870,7 @@
 /obj/structure/machinery/autodoc_console/yautja
 	name = "medical pod console"
 	icon = 'icons/obj/structures/machinery/yautja_machines.dmi'
+	upgrades = list(1=1, 2=2, 3=3, 4=4)
 
 /obj/structure/machinery/medical_pod/autodoc/unskilled
 	name = "advanced autodoc emergency medical system"
@@ -877,6 +878,6 @@
 	skilllock = null
 
 /obj/structure/machinery/medical_pod/autodoc/yautja
-	name = "alien automated medical pod"
+	name = "automated medical pod"
 	desc = "An emergency surgical alien device designed to perform life-saving treatments and basic surgeries on patients automatically, without the need of a surgeon."
 	icon = 'icons/obj/structures/machinery/yautja_machines.dmi'

--- a/code/game/machinery/medical_pod/sleeper.dm
+++ b/code/game/machinery/medical_pod/sleeper.dm
@@ -430,4 +430,5 @@
 	icon = 'icons/obj/structures/machinery/yautja_machines.dmi'
 	available_chemicals = list("thwei", "inaprovaline", "oxycodone", "anti_toxin", "dexalinp", "tricordrazine", "alkysine", "imidazoline")
 	emergency_chems = list("thwei", "inaprovaline", "oxycodone", "anti_toxin", "dexalinp", "tricordrazine", "bicaridine", "kelotane", "meralyne", "dermaline", "alkysine", "imidazoline")
+	reagent_removed_per_second = AMOUNT_PER_TIME(8, 1 SECONDS)
 	upgraded = TRUE

--- a/code/game/machinery/medical_pod/sleeper.dm
+++ b/code/game/machinery/medical_pod/sleeper.dm
@@ -428,3 +428,6 @@
 
 /obj/structure/machinery/medical_pod/sleeper/yautja
 	icon = 'icons/obj/structures/machinery/yautja_machines.dmi'
+	available_chemicals = list("thwei", "inaprovaline", "oxycodone", "anti_toxin", "dexalinp", "tricordrazine", "alkysine", "imidazoline")
+	emergency_chems = list("thwei", "inaprovaline", "oxycodone", "anti_toxin", "dexalinp", "tricordrazine", "bicaridine", "kelotane", "meralyne", "dermaline", "alkysine", "imidazoline")
+	upgraded = TRUE

--- a/maps/predship/huntership.dmm
+++ b/maps/predship/huntership.dmm
@@ -6,6 +6,12 @@
 /obj/structure/machinery/prop/yautja/bubbler,
 /turf/open/shuttle/dropship/predship/hunter_grille,
 /area/yautja)
+"ac" = (
+/obj/structure/machinery/medical_pod/autodoc/yautja{
+	pixel_y = 8
+	},
+/turf/open/shuttle/dropship/predship/hunter_grille,
+/area/yautja)
 "ad" = (
 /obj/structure/window/framed/colony/reinforced/hull/yautja,
 /obj/structure/machinery/door/poddoor/hybrisa/open_shutters{
@@ -49,6 +55,12 @@
 	},
 /obj/effect/hunter/catwalk/hunter_grate,
 /turf/open/shuttle/dropship/predship/red_glow/on,
+/area/yautja)
+"ag" = (
+/obj/structure/machinery/autodoc_console/yautja{
+	pixel_y = 8
+	},
+/turf/open/shuttle/dropship/predship/hunter_grille,
 /area/yautja)
 "ah" = (
 /obj/structure/prop/hunter/fake_platform/hunter/west,
@@ -16647,7 +16659,7 @@ aV
 jy
 ir
 VD
-ir
+ac
 VD
 rd
 VD
@@ -16749,7 +16761,7 @@ aV
 VD
 xC
 VD
-xC
+ag
 VD
 by
 VD


### PR DESCRIPTION

# About the pull request

Adds the Yautja variant of the Autodoc to the Huntership.
It already existed in code, sprites and everything. So I simply added it to the ship.
The surgical research upgrades are already built in, these being: IB surgery, bone fracture surgery, organ damage surgery and embryo removal surgery. So it actually makes it worth using as an alternative to manual surgery in case predator players don't know surgical steps themselves or have a hard time knowing about their surgical tools as they're renamed variants. Doesn't need having a noskill check as Yautja have the required skill already.

And the sleeper has also been upgraded with the same research stuff while additionally having thwei as one of the available chemicals you can inject.

Approved by Yautja Senator. (specifically embryo removal being included)

# Explain why it's good for the game

Makes use of already existing code and sprites that were laying around so they dont "rot". Provides an alternative to surgery for predator players who might have issues to doing manual surgery since knowing surgery is not a requirement for the whitelist.


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Unknownity
add: Adds an upgraded autodoc to the Yautja ship and upgrades their sleepers.
/:cl:

