### PR TITLE
you can no longer look up ladders from half a screen away

### DIFF
--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -147,7 +147,10 @@
 	user.reset_view(null)
 
 //Peeking up/down
-/obj/structure/ladder/MouseDrop(over_object, src_location, over_location, mob/user)
+/obj/structure/ladder/MouseDrop(over_object, src_location, over_location, mob/living/user)
+	//Are we capable of looking?
+	if(user.is_mob_incapacitated() || get_dist(user, src) > 1 || user.blinded || user.body_position == LYING_DOWN || !user.client)
+		return
 
 	var/obj/structure/ladder/looking_at
 	if(up && down)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

closes #9980

# Explain why it's good for the game

getting stunned by accidentally mousedragging a ladder half a screen away is not funny

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: you can no longer look up ladders from half a screen away
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
