### PR TITLE
z level changes now stop you from looking up

### DIFF
--- a/code/modules/cm_tech/hologram.dm
+++ b/code/modules/cm_tech/hologram.dm
@@ -138,9 +138,21 @@ GLOBAL_LIST_EMPTY_TYPED(hologram_list, /mob/hologram)
 	. = ..()
 
 /mob/hologram/look_up/handle_move(mob/M, oldLoc, direct)
+
+	if(!isturf(M.loc) || HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
+		qdel(src)
+		return
+
+	if(isturf(M.loc) && isturf(oldLoc))
+		var/turf/mob_turf = M.loc
+		var/turf/old_mob_turf = oldLoc
+		if(mob_turf.z != old_mob_turf.z)
+			qdel(src)
+			return
+
 	var/turf/new_turf = get_step(loc, direct)
 	forceMove(new_turf)
-	
+
 	if(!istype(new_turf, /turf/open_space))
 		UnregisterSignal(linked_mob, COMSIG_MOB_RESET_VIEW)
 		view_registered = FALSE
@@ -156,7 +168,7 @@ GLOBAL_LIST_EMPTY_TYPED(hologram_list, /mob/hologram)
 
 	return -2
 
-/mob/hologram/look_up/handle_view(mob/M, atom/target)	
+/mob/hologram/look_up/handle_view(mob/M, atom/target)
 	if(M.client)
 		M.client.perspective = EYE_PERSPECTIVE
 		M.client.eye = src

--- a/code/modules/mob/living/carbon/xenomorph/castes/Burrower.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Burrower.dm
@@ -144,6 +144,7 @@
 		return
 	// TODO Make immune to all damage here.
 	to_chat(src, SPAN_XENOWARNING("We burrow ourselves into the ground."))
+	stop_looking_multiz()
 	invisibility = 101
 	alpha = 100
 	anchored = TRUE

--- a/code/modules/mob/mob_verbs.dm
+++ b/code/modules/mob/mob_verbs.dm
@@ -250,10 +250,14 @@
 	set name = "Look Up"
 	set category = "IC"
 
-	if(observed_atom)
-		var/atom/to_delete = observed_atom
-		observed_atom = null
-		qdel(to_delete)
+	stop_looking_multiz()
+
+	if(HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
+		to_chat(src, SPAN_WARNING("We cannot look up here, we are burrowed!"))
+		return
+
+	if(!isturf(loc))
+		to_chat(src, SPAN_WARNING("You cannot look up here."))
 		return
 
 	var/turf/above = locate(x, y, z+1)
@@ -265,3 +269,10 @@
 	var/mob/hologram/look_up/observed_hologram = new(above, src)
 
 	observed_atom = observed_hologram
+
+/mob/living/proc/stop_looking_multiz()
+	if(!observed_atom)
+		return
+	var/atom/to_delete = observed_atom
+	observed_atom = null
+	qdel(to_delete)

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -213,6 +213,10 @@ All ShuttleMove procs go here
 			shake_force *= 0.25
 		shake_camera(src, shake_force, 1)
 
+/mob/living/onShuttleMove(turf/newT, turf/oldT, list/movement_force, move_dir, obj/docking_port/stationary/old_dock, obj/docking_port/mobile/moving_dock)
+	stop_looking_multiz()
+	. = ..()
+
 /mob/living/lateShuttleMove(turf/oldT, list/movement_force, move_dir)
 	if(buckled)
 		return


### PR DESCRIPTION
# About the pull request

you now stop looking up on
- falling down open space
- climbing down open space
- climbing up walls
- yautja teleport
- climbing ladders
- using stairs
- shuttlemove
- ventcrawling
- burrowing

# Explain why it's good for the game

closes #9903
closes #9993


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: you now stop looking up on zlevel transitions
/:cl:
