### PR TITLE
Temporary maturity for early game queens

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -437,9 +437,8 @@
 		// Also update the choose_resin icon since it resets
 		if(istype(action, /datum/action/xeno_action/onclick/choose_resin))
 			var/datum/action/xeno_action/onclick/choose_resin/choose_resin_ability = action
-			if(choose_resin_ability)
-				choose_resin_ability.update_button_icon(selected_resin)
-				break // Don't need to keep looking
+			choose_resin_ability.update_button_icon(selected_resin)
+			break // Don't need to keep looking
 
 	if(hive.dynamic_evolution && !queen_aged)
 		queen_age_timer_id = addtimer(CALLBACK(src, PROC_REF(make_combat_effective)), XENO_QUEEN_AGE_TIME, TIMER_UNIQUE|TIMER_STOPPABLE)
@@ -563,8 +562,7 @@
 		// Also update the choose_resin icon since it resets
 		if(istype(action, /datum/action/xeno_action/onclick/choose_resin))
 			var/datum/action/xeno_action/onclick/choose_resin/choose_resin_ability = action
-			if(choose_resin_ability)
-				choose_resin_ability.update_button_icon(selected_resin)
+			choose_resin_ability.update_button_icon(selected_resin)
 
 	var/list/abilities_to_give = mobile_abilities.Copy()
 
@@ -904,8 +902,7 @@
 		// Also update the choose_resin icon since it resets
 		if(istype(action, /datum/action/xeno_action/onclick/choose_resin))
 			var/datum/action/xeno_action/onclick/choose_resin/choose_resin_ability = action
-			if(choose_resin_ability)
-				choose_resin_ability.update_button_icon(selected_resin)
+			choose_resin_ability.update_button_icon(selected_resin)
 
 	var/list/immobile_abilities = list(
 		// These already have their placement locked in:

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -1,4 +1,6 @@
 #define XENO_QUEEN_AGE_TIME (10 MINUTES)
+#define XENO_QUEEN_TEMP_AGE_DURATION (1 MINUTES)
+#define XENO_QUEEN_TEMP_AGE_EXTENSION (15 SECONDS)
 #define XENO_QUEEN_DEATH_DELAY (5 MINUTES)
 #define YOUNG_QUEEN_HEALTH_MULTIPLIER 0.5
 
@@ -358,8 +360,12 @@
 	skull = /obj/item/skull/queen
 	pelt = /obj/item/pelt/queen
 
+	/// Whether queen has completed normal maturity
 	var/queen_aged = FALSE
+	/// Normal maturity timer
 	var/queen_age_timer_id = TIMER_ID_NULL
+	/// Temporary maturity timer
+	var/queen_age_temp_timer_id = TIMER_ID_NULL
 
 	bubble_icon = "alienroyal"
 
@@ -502,18 +508,53 @@
 		return FALSE
 	update_living_queens()
 
-/mob/living/carbon/xenomorph/queen/proc/make_combat_effective()
-	queen_aged = TRUE
-	if(queen_age_timer_id != TIMER_ID_NULL)
-		deltimer(queen_age_timer_id)
-		queen_age_timer_id = TIMER_ID_NULL
+/// Signal handler for COMSIG_XENO_TAKE_DAMAGE intended to extend temporary maturity by XENO_QUEEN_TEMP_AGE_EXTENSION up to XENO_QUEEN_TEMP_AGE_DURATION
+/mob/living/carbon/xenomorph/queen/proc/on_take_damage(owner, damage_data, damage_type)
+	SIGNAL_HANDLER
+	if(queen_age_temp_timer_id == TIMER_ID_NULL)
+		CRASH("[src] called on_take_damage when not temporarily mature!")
+	var/new_duration = min(timeleft(queen_age_temp_timer_id) + XENO_QUEEN_TEMP_AGE_EXTENSION, XENO_QUEEN_TEMP_AGE_DURATION)
+	queen_age_temp_timer_id = addtimer(CALLBACK(src, PROC_REF(refresh_combat_effective)), new_duration, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_STOPPABLE|TIMER_NO_HASH_WAIT)
 
-	give_combat_abilities()
+/// Performs all updates to abilities, name, and health depending on maturity
+/mob/living/carbon/xenomorph/queen/proc/refresh_combat_effective()
+	if(queen_age_temp_timer_id != TIMER_ID_NULL && isnull(timeleft(queen_age_temp_timer_id)))
+		queen_age_temp_timer_id = TIMER_ID_NULL
+		UnregisterSignal(src, COMSIG_XENO_TAKE_DAMAGE)
+
+	refresh_combat_abilities()
 	recalculate_actions()
 	recalculate_health()
 	generate_name()
 
-/mob/living/carbon/xenomorph/queen/proc/give_combat_abilities()
+/// Matures the queen either permnantly or temporarily
+/mob/living/carbon/xenomorph/queen/proc/make_combat_effective(temporary=FALSE)
+	if(temporary)
+		if(timeleft(queen_age_timer_id) <= XENO_QUEEN_TEMP_AGE_DURATION)
+			// Just give them full maturity
+			temporary = FALSE
+		else
+			var/already_temp_mature = queen_age_temp_timer_id != TIMER_ID_NULL
+			if(!already_temp_mature)
+				RegisterSignal(src, COMSIG_XENO_TAKE_DAMAGE, PROC_REF(on_take_damage))
+			queen_age_temp_timer_id = addtimer(CALLBACK(src, PROC_REF(refresh_combat_effective)), XENO_QUEEN_TEMP_AGE_DURATION, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_STOPPABLE|TIMER_NO_HASH_WAIT)
+			if(already_temp_mature)
+				return
+
+	if(!temporary)
+		queen_aged = TRUE
+		if(queen_age_timer_id != TIMER_ID_NULL)
+			deltimer(queen_age_timer_id)
+			queen_age_timer_id = TIMER_ID_NULL
+		if(queen_age_temp_timer_id != TIMER_ID_NULL)
+			deltimer(queen_age_temp_timer_id)
+			queen_age_temp_timer_id = TIMER_ID_NULL
+			UnregisterSignal(src, COMSIG_XENO_TAKE_DAMAGE)
+
+	refresh_combat_effective()
+
+/// When not on ovipositor, refreshes all mobile_abilities including mobile_aged_abilities if applicable
+/mob/living/carbon/xenomorph/queen/proc/refresh_combat_abilities()
 	if(ovipositor)
 		return
 
@@ -527,7 +568,7 @@
 
 	var/list/abilities_to_give = mobile_abilities.Copy()
 
-	if(!queen_aged)
+	if(!queen_aged && queen_age_temp_timer_id == TIMER_ID_NULL)
 		abilities_to_give -= mobile_aged_abilities
 
 	for(var/path in abilities_to_give)
@@ -536,7 +577,7 @@
 
 /mob/living/carbon/xenomorph/queen/recalculate_health()
 	. = ..()
-	if(!queen_aged)
+	if(!queen_aged && queen_age_temp_timer_id == TIMER_ID_NULL)
 		maxHealth *= YOUNG_QUEEN_HEALTH_MULTIPLIER
 
 	if(health > maxHealth)
@@ -577,6 +618,16 @@
 						egg_amount--
 						new /obj/item/xeno_egg(loc, hivenumber)
 
+		// Grant temporary maturity if near the hive_location for early game
+		if(!queen_aged)
+			var/near_hive = hive?.hive_location && (get_area(hive.hive_location) == get_area(src) || get_dist(hive.hive_location, src) <= 10)
+			if(near_hive && ROUND_TIME < XENO_QUEEN_AGE_TIME * 2 && !is_mob_incapacitated(TRUE))
+				make_combat_effective(temporary=TRUE)
+			else if(queen_age_temp_timer_id != TIMER_ID_NULL)
+				var/alert_time = timeleft(queen_age_temp_timer_id) - XENO_QUEEN_TEMP_AGE_EXTENSION * 0.5
+				if(alert_time >= 0 && alert_time < delta_time SECONDS) // Only display once at a threshold within delta_time
+					balloon_alert(src, "our maturity wanes soon!", text_color = "#7d32bb")
+
 /mob/living/carbon/xenomorph/queen/get_status_tab_items()
 	. = ..()
 	var/stored_larvae = GLOB.hive_datum[hivenumber].stored_larva
@@ -585,8 +636,11 @@
 	. += "Pooled Larvae: [stored_larvae]"
 	. += "Leaders: [xeno_leader_num] / [hive?.queen_leader_limit]"
 	. += "Royal Resin: [hive?.buff_points]"
-	if(!queen_aged && queen_age_timer_id != TIMER_ID_NULL)
-		. += "Maturity: [time2text(timeleft(queen_age_timer_id), "mm:ss")] remaining"
+	if(!queen_aged)
+		if(queen_age_timer_id != TIMER_ID_NULL)
+			. += "Maturity: [time2text(timeleft(queen_age_timer_id), "mm:ss")] remaining"
+		if(queen_age_temp_timer_id != TIMER_ID_NULL)
+			. += "Temporary Maturity: [time2text(timeleft(queen_age_temp_timer_id), "mm:ss")] remaining"
 
 /mob/living/carbon/xenomorph/queen/proc/set_orders()
 	set category = "Alien"
@@ -927,7 +981,7 @@
 	zoom_out()
 
 	set_resin_build_order(GLOB.resin_build_order_drone) // This needs to occur before we update the abilities so we can update the choose resin icon
-	give_combat_abilities()
+	refresh_combat_abilities()
 
 	remove_verb(src, /mob/living/carbon/xenomorph/proc/xeno_tacmap)
 
@@ -994,3 +1048,9 @@
 	point.color = "#a800a8"
 
 	visible_message("<b>[src]</b> points to [target_atom]", null, null, 5)
+
+#undef XENO_QUEEN_AGE_TIME
+#undef XENO_QUEEN_TEMP_AGE_DURATION
+#undef XENO_QUEEN_TEMP_AGE_EXTENSION
+#undef XENO_QUEEN_DEATH_DELAY
+#undef YOUNG_QUEEN_HEALTH_MULTIPLIER

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -526,7 +526,7 @@
 	recalculate_health()
 	generate_name()
 
-/// Matures the queen either permnantly or temporarily
+/// Matures the queen either permanently or temporarily
 /mob/living/carbon/xenomorph/queen/proc/make_combat_effective(temporary=FALSE)
 	if(temporary)
 		if(timeleft(queen_age_timer_id) <= XENO_QUEEN_TEMP_AGE_DURATION)

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/hivelord/resin_whisperer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/hivelord/resin_whisperer.dm
@@ -31,9 +31,8 @@
 		// Also update the choose_resin icon since it resets
 		if(istype(action, /datum/action/xeno_action/onclick/choose_resin))
 			var/datum/action/xeno_action/onclick/choose_resin/choose_resin_ability = action
-			if(choose_resin_ability)
-				choose_resin_ability.update_button_icon(hivelord.selected_resin)
-				break // Don't need to keep looking
+			choose_resin_ability.update_button_icon(hivelord.selected_resin)
+			break // Don't need to keep looking
 
 /*
  * Coerce Resin ability


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR adds temporary maturity for early game queens (first 20 minutes of play). Basically when in the area that is the hive_location (hive_core) or within 10 tiles of it, the queen will have a 1 minute timer that refreshes every Life tick when either taking damage (bumps the timer by 15s currently) or when remaining near the hive_location. The maturity timer appears in status panel and also has a balloon alert at about 7s remaining.

For clarity, being shot won't ever mature a queen - it can only *extend* an *existing* timer. Even has an assertion that will call CRASH ending the proc if it somehow could try to do that. 

# Explain why it's good for the game

This is to mitigate the issue where an immature queen at the start of the game cannot deal with an early game rush from survivors.

I don't want it where people aren't free to try to do things e.g. seek out xenos. The risk of rushes in itself should combat xenos thinking predrop is boring and they shouldn't be on alert. There should be a threat. HOWEVER the aspect that doesn't sit well with me is that an immature queen would literally be better de-evolved as a drone than to be fighting anything. I didn’t want to just give early queen free maturity though so we don’t have the opposite problem of queen rushing survivors.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Main testing (though I forgot to turn off second view to see status panel)
https://youtu.be/FpDwqYGDeEY

Also balloon alerts:
![alert](https://github.com/user-attachments/assets/cffb85a6-878d-4e15-954c-ddb5de30eeb0)

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Drathek
balance: Early game queen is now temporarily mature when near the hive core (1 minute timer that refreshes while close or when getting shot)
code: Added missing undefs for queen and removed a few redundant checks for refreshing the choose resin ability 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
