### PR TITLE
Allows the Queen to lock the dropship mid-flight and mid-ignite

### DIFF
--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -312,6 +312,12 @@
 			MODE_SET_MODIFIER(/datum/gamemode_modifier/lz_weeding, TRUE)
 		stop_playing_launch_announcement_alarm()
 
+		if(dropship.mode == SHUTTLE_IGNITING) //cancel the launch
+			var/obj/docking_port/stationary/marine_dropship/landing_port = dropship.get_docked()
+			if(istype(landing_port))
+				landing_port.turn_off_landing_lights()
+			dropship.mode = SHUTTLE_IDLE
+
 		to_chat(xeno, SPAN_XENONOTICE("You override the doors."))
 		xeno_message(SPAN_XENOANNOUNCE("The doors of the metal bird have been overridden! Rejoice!"), 3, xeno.hivenumber)
 		message_admins("[key_name(xeno)] has locked the dropship '[dropship]'", xeno.x, xeno.y, xeno.z)


### PR DESCRIPTION

# About the pull request
Allows the Queen to lock the dropship mid-flight and mid-ignite. This will change the dropship destination back to the LZ (or any other ground LZ if the original LZ is somehow occupied).

# Explain why it's good for the game
Making Queen's lock a timed action has led to some (potential) issues, like someone in CiC, in the cockpit, or a quick enough synth might just launch the ship while the Queen is waiting for do_after. This will make Queen's abduction not as devastating for xenos, while also opening some new interesting scenarios.

# Testing Photographs and Procedure
<details>
I did test this, trust.
</details>


# Changelog
:cl: ihatethisengine
balance: Queen is now allowed to lock the dropship mid-transit and mid-ignite, changing the dropship destination back to the planet.
/:cl:
