### PR TITLE
Fixes being able to WI-FI tac reload

### DIFF
--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -302,6 +302,8 @@ DEFINES in setup.dm, referenced here.
 		if(src != user.r_hand && src != user.l_hand)
 			to_chat(user, SPAN_WARNING("[src] must be in your hand to do that."))
 			return
+		if(magazine.loc != user && !istype(magazine.loc, /obj/item/storage))
+			return
 		if(flags_gun_features & GUN_INTERNAL_MAG)
 			to_chat(user, SPAN_WARNING("Can't do tactical reloads with [src]."))
 			return


### PR DESCRIPTION

# About the pull request

You can now only tac-reload magazines that are in your inventory, and not on the ground
# Explain why it's good for the game

title

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Tac reload now only works if the magazine is in your hand or inventory.
/:cl:
