### PR TITLE
Fixes putting things on conveyor belts when not on harm intent and steals the 10k pr

### DIFF
--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -107,7 +107,9 @@
 			var/mob/GM = G.grabbed_thing
 			step(GM, get_dir(GM, src))
 			return
-	user.drop_inv_item_to_loc(I, loc)
+
+	if(user.a_intent != INTENT_HARM)
+		user.drop_inv_item_to_loc(I, loc)
 
 // attack with hand, move pulled object onto conveyor
 /obj/structure/machinery/conveyor/attack_hand(mob/user as mob)


### PR DESCRIPTION
# About the pull request

powerful message about fixing bugs

# Explain why it's good for the game

Putting things into a conveyor belt mid game is very frustrating


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: You will now only put items on conveyor belts when not on harm intent.
/:cl:
