### PR TITLE
Dead Facehuggers don't block structures placement. (got merged with #9963)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -473,10 +473,6 @@
 				if(!silent)
 					to_chat(src, SPAN_WARNING("[O] is blocking the resin! There's not enough space to build that here."))
 				return
-		if(istype(O, /obj/item/clothing/mask/facehugger))
-			if(!silent)
-				to_chat(src, SPAN_WARNING("There is a little one here already. Best move it."))
-			return
 		if(istype(O, /obj/effect/alien/egg))
 			if(!silent)
 				to_chat(src, SPAN_WARNING("There's already an egg."))

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -473,6 +473,12 @@
 				if(!silent)
 					to_chat(src, SPAN_WARNING("[O] is blocking the resin! There's not enough space to build that here."))
 				return
+		if(istype(O, /obj/item/clothing/mask/facehugger))
+			var/obj/item/clothing/mask/facehugger/hugger = O
+			if(hugger.stat != DEAD)
+				if(!silent)
+					to_chat(src, SPAN_WARNING("There is a little one here already. Best move it."))
+				return
 		if(istype(O, /obj/effect/alien/egg))
 			if(!silent)
 				to_chat(src, SPAN_WARNING("There's already an egg."))


### PR DESCRIPTION

# About the pull request

Facehuggers corpses don't block structures placement anymore

# Explain why it's good for the game

If i have to be honest, i dont even know why this check exist in first place, random hugger corpse can just block your building so you need to pick it up/melt to be able to continue on your way, at first i was thinking its because of traps but carrier and burrower can pick up the corpses of huggers and just place them back on trap placement (they are only ones who make traps and only ones of few who can pick up huggers)

# Testing Photographs and Procedure

<details>
<summary>>Click HERE to see image<</summary>

<img width="287" height="285" alt="image" src="https://github.com/user-attachments/assets/666a2e4c-29bb-447f-8edd-1527b6c73b87" />

</details>


# Changelog

:cl:
qol: Dead Facehuggers don't block xenos structures placement.
/:cl:
