### PR TITLE
Fix playtime mob type sometimes being the game mode type

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -184,9 +184,9 @@ GLOBAL_VAR_INIT(cas_tracking_id_increment, 0) //this var used to assign unique t
 
 		if(M.client && M.client.player_data)
 			if(M.stat == DEAD)
-				record_playtime(M.client.player_data, JOB_OBSERVER, type)
+				record_playtime(M.client.player_data, JOB_OBSERVER, M.type)
 			else
-				record_playtime(M.client.player_data, M.job, type)
+				record_playtime(M.client.player_data, M.job, M.type)
 
 /datum/game_mode/proc/show_end_statistics(icon_state)
 	GLOB.round_statistics.update_panel_data()


### PR DESCRIPTION

# About the pull request

This PR fixes an error where sometimes the playtime db stores the gamemode type instead of the mob type.

# Explain why it's good for the game

Consistent data.

# Changelog
:cl: Drathek
fix: Fix db backend for playtime sometimes recording the gamemode type instead of mob type
/:cl:
