### PR TITLE
Death stats are no longer deattached & deleted

### DIFF
--- a/code/datums/statistics/entities/death_stats.dm
+++ b/code/datums/statistics/entities/death_stats.dm
@@ -140,7 +140,6 @@
 		GLOB.round_statistics.track_death(new_death)
 
 	new_death.save()
-	new_death.detach()
 	return new_death
 
 /mob/living/carbon/human/track_mob_death(datum/cause_data/cause_data, turf/death_loc)


### PR DESCRIPTION

# About the pull request

This PR makes it so death stats are no longer deattached. The reason for this change is because GLOB.round_statistics holds on to this entity, but by deattaching it, it was qdeleted. So this resulted in GLOB.round_statistics holding on to lots of qdeleted entities.

# Explain why it's good for the game

Less unintentional deletions.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Previously this entity would be qdeleted: 
<img width="477" height="682" alt="image" src="https://github.com/user-attachments/assets/dd216456-cb55-4c05-acc8-9c7595e95e53" />

</details>


# Changelog
:cl: Drathek
code: Death statistics are no longer deleted since GLOB.round_statistics holds on to them
/:cl:
