### PR TITLE
Flash eye fixes

### DIFF
--- a/code/game/objects/items/explosives/grenades/flashbang.dm
+++ b/code/game/objects/items/explosives/grenades/flashbang.dm
@@ -136,7 +136,7 @@
 		to_chat(M, SPAN_HELPFUL("Your gear protects you from the worst of the 'bang'."))
 
 	M.Stun(weaken_amount)
-	M.KnockDown(weaken_amount)	
+	M.KnockDown(weaken_amount)
 	M.KnockOut(paralyze_amount)
 	if(deafen_amount)
 		M.SetEarDeafness(max(M.ear_deaf, deafen_amount))
@@ -331,7 +331,7 @@
 	M.apply_effect(paralyze_amount, PARALYZE)
 
 	if(flash_amount)
-		M.flash_eyes(EYE_PROTECTION_FLASH, TRUE, /atom/movable/screen/fullscreen/flash, flash_amount)
+		M.flash_eyes(EYE_PROTECTION_FLASH, TRUE, flash_amount, /atom/movable/screen/fullscreen/flash)
 	if(deafen_amount)
 		M.SetEarDeafness(max(M.ear_deaf, deafen_amount))
 

--- a/code/game/objects/items/implants/implantneurostim.dm
+++ b/code/game/objects/items/implants/implantneurostim.dm
@@ -62,7 +62,7 @@
 
 		var/mob_pain_msg = "Excruciating pain shoots through [part ? "your [part.display_name]" : "you"]!"
 		M.visible_message(SPAN_DANGER("[M] convulses in pain!"), SPAN_DANGER(mob_pain_msg))
-		M.flash_eyes(1, TRUE)
+		M.flash_eyes(EYE_PROTECTION_FLAVOR, TRUE)
 		M.apply_effect(10, STUN)
 		M.apply_effect(10, WEAKEN)
 		M.apply_damage(100, HALLOSS, part)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -877,6 +877,8 @@
 			return EYE_PROTECTION_WELDING
 		if(eyes_organ.robotic == ORGAN_ROBOT)
 			return EYE_PROTECTION_WELDING
+	else
+		return EYE_PROTECTION_WELDING
 
 	if(istype(head, /obj/item/clothing))
 		var/obj/item/clothing/cloth_item = head

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -861,10 +861,10 @@
 /mob/living/carbon/human/ui_state(mob/user)
 	return GLOB.not_incapacitated_state
 
-///get_eye_protection()
-///Returns a number between -1 to 2
+/// Gets a value between EYE_PROTECTION_NEGATIVE (-1) and EYE_PROTECTION_WELDING (3) based on whether there are eyes
+/// to blind or how much clothing protects them
 /mob/living/carbon/human/get_eye_protection()
-	var/number = 0
+	var/number = EYE_PROTECTION_NONE
 
 	if(species && !species.has_organ["eyes"])
 		return EYE_PROTECTION_WELDING //No eyes, can't hurt them.
@@ -877,19 +877,17 @@
 			return EYE_PROTECTION_WELDING
 		if(eyes_organ.robotic == ORGAN_ROBOT)
 			return EYE_PROTECTION_WELDING
-	else
-		return EYE_PROTECTION_WELDING
 
 	if(istype(head, /obj/item/clothing))
 		var/obj/item/clothing/cloth_item = head
 		number += cloth_item.eye_protection
 	if(istype(wear_mask, /obj/item/clothing))
-		var/obj/item/clothing/cloth_item = head
+		var/obj/item/clothing/cloth_item = wear_mask
 		number += cloth_item.eye_protection
 	if(glasses)
 		number += glasses.eye_protection
 
-	return number
+	return clamp(number, EYE_PROTECTION_NEGATIVE, EYE_PROTECTION_WELDING)
 
 
 /mob/living/carbon/human/abiotic(full_body = 0)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -465,12 +465,12 @@
 /mob/proc/flash_eyes()
 	return
 
-/mob/living/flash_eyes(intensity = EYE_PROTECTION_FLASH, bypass_checks, flash_timer = 40, type = /atom/movable/screen/fullscreen/flash, dark_type = /atom/movable/screen/fullscreen/flash/dark)
+/mob/living/flash_eyes(intensity = EYE_PROTECTION_FLASH, bypass_checks, flash_timer = 40, light_type = /atom/movable/screen/fullscreen/flash, dark_type = /atom/movable/screen/fullscreen/flash/dark)
 	if(bypass_checks || (get_eye_protection() < intensity && !(sdisabilities & DISABILITY_BLIND)))
 		if(client?.prefs?.flash_overlay_pref == FLASH_OVERLAY_DARK)
 			overlay_fullscreen("flash", dark_type)
 		else
-			overlay_fullscreen("flash", type)
+			overlay_fullscreen("flash", light_type)
 		spawn(flash_timer)
 			clear_fullscreen("flash", 20)
 		return TRUE

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -43,7 +43,7 @@
 		if(2)
 			src.take_limb_damage(10)
 			apply_effect(rand(1,5), STUN)
-	flash_eyes(1, TRUE, type = /atom/movable/screen/fullscreen/flash/noise)
+	flash_eyes(EYE_PROTECTION_FLAVOR, TRUE, light_type = /atom/movable/screen/fullscreen/flash/noise)
 
 	to_chat(src, SPAN_DANGER("<B>*BZZZT*</B>"))
 	to_chat(src, SPAN_DANGER("Warning: Electromagnetic pulse detected."))


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #9917 correcting an error where `head` was used instead of `wear_mask` as well as several other issues:
- Get protection was not clamped as described
- The argument `type` overlaps with the existing `type` (not linted by OpenDream it seems)
- flashbang.dm would sometimes pass `50` as the flash type instead of a path

# Explain why it's good for the game

Fixes 
<img width="635" height="464" alt="image" src="https://github.com/user-attachments/assets/074fa41c-bfa9-49a6-bbb6-7d68750884bc" />

Fixes #9988 
Fixes #9990
Fixes #10020

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![flash](https://github.com/user-attachments/assets/3fb55ea7-7570-46ef-93c9-0374af741e14)

</details>


# Changelog
:cl: Drathek
fix: Fixed various eye protection runtimes
/:cl:
