### PR TITLE
Makes the shotgun stock attachable to the shotgun again

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -1344,6 +1344,7 @@ can cause issues with ammo types getting mixed up during the burst.
 		/obj/item/attachable/shotgun_choke,
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/attached_gun/extinguisher,
+		/obj/item/attachable/stock/shotgun,
 	)
 
 /obj/item/weapon/gun/shotgun/pump/dual_tube


### PR DESCRIPTION
# About the pull request

see title
# Explain why it's good for the game

resolves #10007 (thwomper can fix the color of the sprite and the 'lore' behind a wooden stock if he wants later)

# Testing Photographs and Procedure
i tested it and it works i promise


# Changelog
:cl:
fix: the shotgun stock can now be attached to the m37a1 again
/:cl:
