### PR TITLE
Swaps Designer Keybinds macros of Place Design and Change Design.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/hivelord/designer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/hivelord/designer.dm
@@ -12,8 +12,8 @@
 		/datum/action/xeno_action/active_toggle/toggle_meson_vision,
 	)
 	actions_to_add = list(
-		/datum/action/xeno_action/activable/place_design, //macro 2, macro 1 is for weeds
-		/datum/action/xeno_action/onclick/change_design, //macro 3
+		/datum/action/xeno_action/onclick/change_design, //macro 2, macro 1 is for weeds
+		/datum/action/xeno_action/activable/place_design, //macro 3
 		/datum/action/xeno_action/onclick/toggle_design_icons, //macro 4
 		/datum/action/xeno_action/activable/greater_resin_surge, //macro 5
 		/datum/action/xeno_action/onclick/toggle_long_range/designer,
@@ -1113,12 +1113,19 @@
 ///   Change Design    ///
 //////////////////////////
 
+/datum/action/xeno_action/verb/verb_change_design()
+	set category = "Alien"
+	set name = "Change Design Mark"
+	set hidden = TRUE
+	var/action_name = "Change Design Mark"
+	handle_xeno_macro(src, action_name)
+
 /datum/action/xeno_action/onclick/change_design
 	name = "Choose Action"
 	action_icon_state = "static_speednode"
 	plasma_cost = 0
 	xeno_cooldown = 0
-	macro_path = /datum/action/xeno_action/verb/verb_resin_surge
+	macro_path = /datum/action/xeno_action/verb/verb_change_design
 	action_type = XENO_ACTION_CLICK
 	ability_primacy = XENO_PRIMARY_ACTION_2
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Swap macro number of Place Design and Change Design ability.
Also gives "change design" missing micro_path.

Fixes keybinds for: #7703 

# Explain why it's good for the game

It follows builders order of abilities, where macro 2 is for selecting and macro 3 is for building, i forgot to swap them in original Designer PR 


</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Venuska1117
fix: Swap Designer macros of Place Design and Change Design ability.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
