### PR TITLE
L23 (RMC Main gun recoil buff)

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -2299,7 +2299,7 @@
 	scatter_unwielded = SCATTER_AMOUNT_TIER_2
 	damage_mult = BASE_BULLET_DAMAGE_MULT
 	recoil = RECOIL_AMOUNT_TIER_4
-	recoil_unwielded = RECOIL_AMOUNT_TIER_1 + RECOIL_AMOUNT_TIER_1/10
+	recoil_unwielded = RECOIL_AMOUNT_TIER_2+ RECOIL_AMOUNT_TIER_1/10
 	damage_falloff_mult = 0
 	fa_max_scatter = SCATTER_AMOUNT_TIER_5
 

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -2298,8 +2298,8 @@
 	burst_scatter_mult = SCATTER_AMOUNT_TIER_10
 	scatter_unwielded = SCATTER_AMOUNT_TIER_2
 	damage_mult = BASE_BULLET_DAMAGE_MULT
-	recoil = RECOIL_AMOUNT_TIER_2_5
-	recoil_unwielded = RECOIL_AMOUNT_TIER_1
+	recoil = RECOIL_AMOUNT_TIER_4
+	recoil_unwielded = RECOIL_AMOUNT_TIER_1 + RECOIL_AMOUNT_TIER_1/10
 	damage_falloff_mult = 0
 	fa_max_scatter = SCATTER_AMOUNT_TIER_5
 


### PR DESCRIPTION

# About the pull request

Changes recoil tiers for the L23 to be slightly worse than the recoil of the NSG.

It has recoil 3.4 for Wielded and /5/ unwielded at the moment.
Changes it to 2 recoil for wielded and 4.5 unwielded.
For comparison NSG gets 1.1 recoil for wielded and 4 for unwielded.

# Explain why it's good for the game

Buffs L23 to be slightly worse than the NSG, the gun it's based off on and probably the 'cheaper' model the TWE buys from WY.

The description says it has better handling and performance, yet it has WORSE recoil than almost all of the guns. The breacher variant already gets recoil TIER 4. It doesn't make sense that the RMCommando units, essentially one of the elite branches of the TWE (Who get their weapons from WY or atleast WY Subsidaries) get extremely poor firearms.

"A rare sight, this rifle is seen most commonly in the hands of Three World Empire RMCs. Compared to the M41A MK2, it has noticeably improved handling and vastly improved performance. This one is painted in RMC's purple-blue camouflage"

But... It's not. It has more recoil than the pulse rifle, meaning the performance is shit at actually doing it's job.

# Changelog

:cl: Teragen/Gorap
balance: Rebalanced L23, the RMC Standard rifle, to be closer to the NSG23 in terms of recoil

/:cl:
