### PR TITLE
alt iff cares about zlevels now

### DIFF
--- a/code/datums/components/iff_fire_prevention.dm
+++ b/code/datums/components/iff_fire_prevention.dm
@@ -29,7 +29,11 @@
 
 	var/range_to_check = user.get_maximum_view_range()
 
-	var/extended_target_turf = get_angle_target_turf(user, angle, range_to_check)
+	var/extended_target_turf
+	if(target.z > user.z)
+		extended_target_turf = get_angle_target_turf(locate(user.x, user.y, target.z), angle, range_to_check)
+	else
+		extended_target_turf = get_angle_target_turf(user, angle, range_to_check)
 
 	var/turf/starting_turf = get_turf(user)
 


### PR DESCRIPTION

# About the pull request

fixes the following situation for alt iff fire (SG frontline, B8 scoped weapons)
Before fix:
<img width="654" height="375" alt="Screenshot 2025-07-30 202242-before" src="https://github.com/user-attachments/assets/5cc4397a-1f95-4dd6-84d7-1f0699767aff" />
After fix:
<img width="654" height="375" alt="Screenshot 2025-07-30 202242-after" src="https://github.com/user-attachments/assets/4868dc6a-f5d4-418e-a2ea-a9c65cae0b3b" />

# Explain why it's good for the game

you can't hit the people on the same z as you while you're looking up and targetting an upstairs turf, why should the check care about those people

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: alt iff now does not care about people on the same z as you if you're shooting at a turf above
/:cl:
