### PR TITLE
Changes hivelord minimum evolve time from 3 minutes to 4 minutes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Hivelord.dm
@@ -37,7 +37,7 @@
 
 	aura_strength = 2.5
 
-	minimum_evolve_time = 3 MINUTES
+	minimum_evolve_time = 4 MINUTES
 
 	minimap_icon = "hivelord"
 


### PR DESCRIPTION
# About the pull request

This changes the Hivelord's minimum evolve timer from 3 minutes to 4 minutes.

# Explain why it's good for the game

Two reasons, one, currently it is at 3 minutes when drones still are at around 120/200, so nobody can evolve into it, it is just unnecessary clutter. After the change, on local, my drone was at 178/200 when the announcement came, still not 200/200, but I don't think having an announcement about defenders and then one about hivelords 10 seconds later is a good idea.

Two, now it is at the same time as Defender, so we only get one meaningful announcement instead of one useful one plus one useless one.

# Testing Photographs and Procedure

<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/bef7abbf-03a4-48f5-8396-ac81f675c398" />

# Changelog

:cl:
qol: Hivelords can now evolve from 4 minutes instead of 3 minutes, the same time as Defenders (drones should be around at 180/200 evolution when this announcement comes, this is just to cut down on extra announcements).
/:cl:
