### PR TITLE
Adds Research Reagent HUD to Research Medilathe 

### DIFF
--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -500,4 +500,4 @@
 
 /datum/autolathe/recipe/medilathe/research_glasses
 	name = "Reagent scanner HUD goggles"
-	pathe = /obj/item/clothing/glasses/science
+	path = /obj/item/clothing/glasses/science

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -497,3 +497,7 @@
 	name = "Pressurized Canister"
 	path = /obj/item/reagent_container/glass/pressurized_canister
 	category = AUTOLATHE_CATEGORY_MEDICAL_CONTAINERS
+
+/datum/autolathe/recipe/medilathe/research_glasses
+	name = "Reagent scanner HUD goggles"
+	pathe = /obj/item/clothing/glasses/science

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -173,6 +173,7 @@
 	req_skill = SKILL_RESEARCH
 	req_skill_level = SKILL_RESEARCH_TRAINED
 	clothing_traits = list(TRAIT_REAGENT_SCANNER)
+	matter = list("glass" = 500,"plastic" = 500)
 
 /obj/item/clothing/glasses/science/prescription
 	name = "prescription reagent scanner HUD goggles"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Adds the research goggles to the research medilathe.

# Explain why it's good for the game

Currently the only source of research goggles are the 2 pre spawns and researchers own vendors. If other roles like IO's ask for them or if their existing ones are lost its very easy for research to run out of this item which is required to do their role. 


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

<img width="4096" height="3239" alt="image" src="https://github.com/user-attachments/assets/533d2e1b-4705-4b21-8675-96d5cc2875e1" />


</details>


# Changelog


:cl:
add: Adds reagent scanner HUD goggles to the medilathe 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
