### PR TITLE
Acider Runner Trap Filling

### DIFF
--- a/code/modules/cm_aliens/structures/trap.dm
+++ b/code/modules/cm_aliens/structures/trap.dm
@@ -202,103 +202,30 @@
 	QDEL_NULL_LIST(tripwires)
 	tripwires = list()
 
-/obj/effect/alien/resin/trap/attack_alien(mob/living/carbon/xenomorph/X)
-	if(X.hivenumber != hivenumber)
+/obj/effect/alien/resin/trap/attack_alien(mob/living/carbon/xenomorph/xeno)
+	if(xeno.hivenumber != hivenumber)
 		return ..()
 
-	var/trap_acid_level = 0
-	if(trap_type >= RESIN_TRAP_ACID1)
-		trap_acid_level = 1 + trap_type - RESIN_TRAP_ACID1
-	if(X.a_intent == INTENT_HARM && trap_type == RESIN_TRAP_EMPTY)
+	if(xeno.a_intent == INTENT_HARM && trap_type == RESIN_TRAP_EMPTY)
 		return ..()
 
 	if(trap_type == RESIN_TRAP_HUGGER)
-		if(X.caste.can_hold_facehuggers)
+		if(xeno.caste.can_hold_facehuggers)
 			set_state()
-			var/obj/item/clothing/mask/facehugger/F = new (loc, hivenumber)
-			X.put_in_active_hand(F)
-			to_chat(X, SPAN_XENONOTICE("You remove the facehugger from [src]."))
+			var/obj/item/clothing/mask/facehugger/hugger = new (loc, hivenumber)
+			xeno.put_in_active_hand(hugger)
+			to_chat(xeno, SPAN_XENONOTICE("You remove the facehugger from [src]."))
 			return XENO_NONCOMBAT_ACTION
 		else
-			to_chat(X, SPAN_XENONOTICE("[src] is occupied by a child."))
+			to_chat(xeno, SPAN_XENONOTICE("[src] is occupied by a child."))
 			return XENO_NO_DELAY_ACTION
 
-	if((!X.acid_level || trap_type == RESIN_TRAP_GAS) && trap_type != RESIN_TRAP_EMPTY)
-		to_chat(X, SPAN_XENONOTICE("Better not risk setting this off."))
+	if((!xeno.acid_level || trap_type == RESIN_TRAP_GAS) && trap_type != RESIN_TRAP_EMPTY)
+		to_chat(xeno, SPAN_XENONOTICE("Better not risk setting this off."))
 		return XENO_NO_DELAY_ACTION
 
-	if(!X.acid_level)
-		to_chat(X, SPAN_XENONOTICE("You can't secrete any acid into \the [src]"))
+	if(!xeno.try_fill_trap(src))
 		return XENO_NO_DELAY_ACTION
-
-	if(trap_acid_level >= X.acid_level)
-		to_chat(X, SPAN_XENONOTICE("It already has good acid in."))
-		return XENO_NO_DELAY_ACTION
-
-	if(isboiler(X))
-		var/mob/living/carbon/xenomorph/boiler/B = X
-
-		if(!B.check_plasma(200))
-			to_chat(B, SPAN_XENOWARNING("You must produce more plasma before doing this."))
-			return XENO_NO_DELAY_ACTION
-
-		to_chat(X, SPAN_XENONOTICE("You begin charging the resin trap with acid gas."))
-		xeno_attack_delay(X)
-		if(!do_after(B, 30, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE, src))
-			return XENO_NO_DELAY_ACTION
-
-		if(trap_type != RESIN_TRAP_EMPTY)
-			return XENO_NO_DELAY_ACTION
-
-		if(!B.check_plasma(200))
-			return XENO_NO_DELAY_ACTION
-
-		if(B.ammo.type == /datum/ammo/xeno/boiler_gas)
-			smoke_system = new /datum/effect_system/smoke_spread/xeno_weaken()
-		else
-			smoke_system = new /datum/effect_system/smoke_spread/xeno_acid()
-
-		setup_tripwires()
-		B.use_plasma(200)
-		playsound(loc, 'sound/effects/refill.ogg', 25, 1)
-		set_state(RESIN_TRAP_GAS)
-		cause_data = create_cause_data("resin gas trap", B)
-		B.visible_message(SPAN_XENOWARNING("\The [B] pressurises the resin trap with acid gas!"),
-		SPAN_XENOWARNING("You pressurise the resin trap with acid gas!"), null, 5)
-	else
-		//Non-boiler acid types
-		var/acid_cost = 70
-		if(X.acid_level == 2)
-			acid_cost = 100
-		else if(X.acid_level == 3)
-			acid_cost = 200
-
-		if (!X.check_plasma(acid_cost))
-			to_chat(X, SPAN_XENOWARNING("You must produce more plasma before doing this."))
-			return XENO_NO_DELAY_ACTION
-
-		to_chat(X, SPAN_XENONOTICE("You begin charging the resin trap with acid."))
-		xeno_attack_delay(X)
-		if(!do_after(X, 3 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE, src))
-			return XENO_NO_DELAY_ACTION
-
-		if (!X.check_plasma(acid_cost))
-			return XENO_NO_DELAY_ACTION
-
-		X.use_plasma(acid_cost)
-		cause_data = create_cause_data("resin acid trap", X)
-		setup_tripwires()
-		playsound(loc, 'sound/effects/refill.ogg', 25, 1)
-
-		if(isburrower(X))
-			set_state(RESIN_TRAP_ACID3)
-		else
-			set_state(RESIN_TRAP_ACID1 + X.acid_level - 1)
-
-		X.visible_message(SPAN_XENOWARNING("\The [X] pressurises the resin trap with acid!"),
-		SPAN_XENOWARNING("You pressurise the resin trap with acid!"), null, 5)
-	return XENO_NO_DELAY_ACTION
-
 
 /obj/effect/alien/resin/trap/proc/setup_tripwires()
 	clear_tripwires()

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -320,6 +320,67 @@
 		xeno.corrosive_acid(explosive,acid_type,acid_plasma_cost)
 	return ..()
 
+#define ACID_COST_LEVEL_1 70
+#define ACID_COST_LEVEL_2 100
+#define ACID_COST_LEVEL_3 200
+
+/// Attempt to fill the target trap (called when xeno attacks with an empty hand)
+/// Returns TRUE if the trap was filled
+/mob/living/carbon/xenomorph/proc/try_fill_trap(obj/effect/alien/resin/trap/target)
+	if(!istype(target))
+		return FALSE
+
+	if(!acid_level)
+		to_chat(src, SPAN_XENONOTICE("You can't secrete any acid into [target]"))
+		return FALSE
+
+	var/trap_acid_level = 0
+	if(target.trap_type >= RESIN_TRAP_ACID1)
+		trap_acid_level = 1 + target.trap_type - RESIN_TRAP_ACID1
+
+	if(trap_acid_level >= acid_level)
+		to_chat(src, SPAN_XENONOTICE("It already has good acid in."))
+		return FALSE
+
+	var/acid_cost = ACID_COST_LEVEL_1
+	if(acid_level == 2)
+		acid_cost = ACID_COST_LEVEL_2
+	else if(acid_level == 3)
+		acid_cost = ACID_COST_LEVEL_3
+
+	if(!check_plasma(acid_cost))
+		to_chat(src, SPAN_XENOWARNING("You must produce more plasma before doing this."))
+		return FALSE
+
+	to_chat(src, SPAN_XENONOTICE("You begin charging the resin trap with acid."))
+	xeno_attack_delay(src)
+	if(!do_after(src, 3 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE, src))
+		return FALSE
+
+	if(target.trap_type >= RESIN_TRAP_ACID1)
+		trap_acid_level = 1 + target.trap_type - RESIN_TRAP_ACID1
+
+	if(trap_acid_level >= acid_level)
+		return FALSE
+
+	if(!check_plasma(acid_cost))
+		return FALSE
+
+	use_plasma(acid_cost)
+
+	target.cause_data = create_cause_data("resin acid trap", src)
+	target.setup_tripwires()
+	target.set_state(RESIN_TRAP_ACID1 + acid_level - 1)
+
+	playsound(target, 'sound/effects/refill.ogg', 25, 1)
+	visible_message(SPAN_XENOWARNING("[src] pressurises the resin trap with acid!"),
+	SPAN_XENOWARNING("You pressurise the resin trap with acid!"), null, 5)
+	return TRUE
+
+#undef ACID_COST_LEVEL_1
+#undef ACID_COST_LEVEL_2
+#undef ACID_COST_LEVEL_3
+
 /datum/action/xeno_action/onclick/emit_pheromones/use_ability(atom/target)
 	var/mob/living/carbon/xenomorph/xeno = owner
 	if(!istype(xeno))

--- a/code/modules/mob/living/carbon/xenomorph/castes/Boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Boiler.dm
@@ -279,3 +279,56 @@
 		else
 			CRASH("Globber has unknown ammo [stabbing_xeno.ammo]! Oh no!")
 		return TRUE
+
+#define ACID_COST_BOILER 200 // ACID_COST_LEVEL_3
+
+/mob/living/carbon/xenomorph/boiler/try_fill_trap(obj/effect/alien/resin/trap/target)
+	if(!istype(target))
+		return FALSE
+
+	if(!acid_level)
+		to_chat(src, SPAN_XENONOTICE("You can't secrete any acid into [target]"))
+		return FALSE
+
+	var/trap_acid_level = 0
+	if(target.trap_type >= RESIN_TRAP_ACID1)
+		trap_acid_level = 1 + target.trap_type - RESIN_TRAP_ACID1
+
+	if(trap_acid_level >= acid_level)
+		to_chat(src, SPAN_XENONOTICE("It already has good acid in."))
+		return FALSE
+
+	if(!check_plasma(ACID_COST_BOILER))
+		to_chat(src, SPAN_XENOWARNING("You must produce more plasma before doing this."))
+		return FALSE
+
+	to_chat(src, SPAN_XENONOTICE("You begin charging the resin trap with acid gas."))
+	xeno_attack_delay(src)
+	if(!do_after(src, 3 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE, src))
+		return FALSE
+
+	if(target.trap_type >= RESIN_TRAP_ACID1)
+		trap_acid_level = 1 + target.trap_type - RESIN_TRAP_ACID1
+
+	if(trap_acid_level >= acid_level)
+		return FALSE
+
+	if(!check_plasma(ACID_COST_BOILER))
+		return FALSE
+
+	use_plasma(ACID_COST_BOILER)
+
+	if(ammo.type == /datum/ammo/xeno/boiler_gas)
+		target.smoke_system = new /datum/effect_system/smoke_spread/xeno_weaken()
+	else
+		target.smoke_system = new /datum/effect_system/smoke_spread/xeno_acid()
+	target.cause_data = create_cause_data("resin gas trap", src)
+	target.setup_tripwires()
+	target.set_state(RESIN_TRAP_GAS)
+
+	playsound(target, 'sound/effects/refill.ogg', 25, 1)
+	visible_message(SPAN_XENOWARNING("[src] pressurises the resin trap with acid gas!"),
+	SPAN_XENOWARNING("You pressurise the resin trap with acid gas!"), null, 5)
+	return TRUE
+
+#undef ACID_COST_BOILER

--- a/code/modules/mob/living/carbon/xenomorph/castes/Burrower.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Burrower.dm
@@ -435,3 +435,8 @@
 	var/mob/living/carbon/xenomorph/xenomorph = owner
 	to_chat(xenomorph, SPAN_NOTICE("We are ready to dig a tunnel again."))
 	xenomorph.tunnel_delay = 0
+
+/mob/living/carbon/xenomorph/burrower/try_fill_trap(obj/effect/alien/resin/trap/target)
+	. = ..()
+	if(.)
+		target.set_state(RESIN_TRAP_ACID3)

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/runner/acid.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/runner/acid.dm
@@ -45,7 +45,10 @@
 	/// Determines whether the combat acid generation is on or off
 	var/combat_gen_active = FALSE
 
+	/// How much acid is required to melt something
 	var/melt_acid_cost = 100
+	/// How much acid is required to fill a trap
+	var/fill_acid_cost = 75
 
 	var/list/caboom_sound = list('sound/effects/runner_charging_1.ogg','sound/effects/runner_charging_2.ogg')
 	var/caboom_loop = 1


### PR DESCRIPTION

# About the pull request

This PR allows acid runners to fill traps with 75 acid at level 3. It also refactors trap filling code to better allow trap filling behavior to be altered rather than via lots of istype checks.

# Explain why it's good for the game

Acid runners produce acid, so it doesn't much much sense why they couldn't spend their resource to fill traps with acid.

Resolves #10032 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/tgFfzy-lPEw

</details>


# Changelog
:cl: Drathek
balance: Acider runner can now fill traps for 75 acid at level 3
fix: Acid level is now checked after the do_after when filling a trap to ensure it wasn't filled by someone else
refactor: Alien open hand trap filling is now handled with a try_fill_trap proc per mob type to avoid istype checking and more easily customize its implementation
/:cl:
