### PR TITLE
Seethrough for queen

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -234,6 +234,10 @@
 #define GAME_PLANE -6
 /// Above Game Plane. For things which are above game objects, but below screen effects.
 #define ABOVE_GAME_PLANE -5
+
+///Slightly above the game plane but does not catch mouse clicks. Useful for certain visuals that should be clicked through, like seethrough trees
+#define SEETHROUGH_PLANE -2
+
 /// Roof plane, disappearing when entering buildings
 #define ROOF_PLANE -4
 

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -220,3 +220,9 @@
 	filters += filter(type = "drop_shadow", color = "#04080FAA", size = -10)
 	filters += filter(type = "drop_shadow", color = "#04080FAA", size = -15)
 	filters += filter(type = "drop_shadow", color = "#04080FAA", size = -20)
+
+/atom/movable/screen/plane_master/seethrough
+	name = "Seethrough"
+	plane = SEETHROUGH_PLANE
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	plane = SEETHROUGH_PLANE

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
@@ -617,3 +617,16 @@
 		return
 	for(var/action_path in base_actions)
 		give_action(src, action_path)
+
+
+/datum/action/xeno_action/onclick/toggle_seethrough
+	name = "Toggle Seethrough"
+	action_icon_state = "xenohide"
+
+
+/datum/action/xeno_action/onclick/toggle_seethrough/use_ability(atom/target)
+
+	var/datum/component/seethrough_mob/seethroughComp = owner.GetComponent(/datum/component/seethrough_mob)
+	. = ..()
+
+	seethroughComp.toggle_active()

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -313,6 +313,7 @@
 		/datum/action/xeno_action/activable/info_marker/queen,
 		/datum/action/xeno_action/onclick/manage_hive,
 		/datum/action/xeno_action/onclick/send_thoughts,
+		/datum/action/xeno_action/onclick/toggle_seethrough,
 	)
 
 	inherent_verbs = list(
@@ -346,6 +347,7 @@
 		/datum/action/xeno_action/onclick/screech, //custom macro, Screech
 		/datum/action/xeno_action/activable/xeno_spit/queen_macro, //third macro
 		/datum/action/xeno_action/onclick/shift_spits,
+		/datum/action/xeno_action/onclick/toggle_seethrough,
 		//second macro
 	)
 
@@ -354,6 +356,7 @@
 		/datum/action/xeno_action/onclick/screech, //custom macro, Screech
 		/datum/action/xeno_action/activable/xeno_spit/queen_macro, //third macro
 		/datum/action/xeno_action/onclick/shift_spits, //second macro
+		/datum/action/xeno_action/onclick/toggle_seethrough,
 	)
 	claw_type = CLAW_TYPE_VERY_SHARP
 
@@ -446,6 +449,7 @@
 		make_combat_effective()
 
 	AddComponent(/datum/component/footstep, 2 , 35, 11, 4, "alien_footstep_large")
+	AddComponent(/datum/component/seethrough_mob)
 	RegisterSignal(src, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(check_block))
 
 /mob/living/carbon/xenomorph/queen/proc/check_block(mob/queen, turf/new_loc)

--- a/code/modules/mob/living/carbon/xenomorph/seethrough.dm
+++ b/code/modules/mob/living/carbon/xenomorph/seethrough.dm
@@ -1,0 +1,105 @@
+///A component that lets you turn your character transparent in order to see and click through yourself.
+/datum/component/seethrough_mob
+	///The atom that enables our dark magic
+	var/atom/movable/render_source_atom
+	///The fake version of ourselves
+	var/image/trickery_image
+	///Which alpha do we animate towards?
+	var/target_alpha
+	///How long our faze in/out takes
+	var/animation_time
+	///Does this object let clicks from players its transparent to pass through it
+	var/clickthrough
+	///Is the seethrough effect currently active
+	var/is_active
+	///The mob's original render_target value
+	var/initial_render_target_value
+	///This component's personal uid
+	var/personal_uid
+
+/datum/component/seethrough_mob/Initialize(target_alpha = 100, animation_time = 0.5 SECONDS, clickthrough = TRUE)
+	. = ..()
+
+	if(!ismob(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	src.target_alpha = target_alpha
+	src.animation_time = animation_time
+	src.clickthrough = clickthrough
+	src.is_active = FALSE
+	src.render_source_atom = new()
+
+	var/static/uid = 0
+	uid++
+	src.personal_uid = uid
+
+	render_source_atom.appearance_flags |= ( RESET_COLOR | RESET_TRANSFORM)
+
+	render_source_atom.vis_flags |= (VIS_INHERIT_ID | VIS_INHERIT_PLANE | VIS_INHERIT_LAYER)
+
+	render_source_atom.render_source = "*transparent_bigmob[personal_uid]"
+
+/datum/component/seethrough_mob/Destroy(force, silent)
+	QDEL_NULL(render_source_atom)
+	return ..()
+
+///Set up everything we need to trick the client and keep it looking normal for everyone else
+/datum/component/seethrough_mob/proc/trick_mob()
+	SIGNAL_HANDLER
+
+	var/mob/fool = parent
+
+	render_source_atom.pixel_x = 0
+	render_source_atom.pixel_y = 0
+
+	initial_render_target_value = fool.render_target
+	fool.render_target = "*transparent_bigmob[personal_uid]"
+	fool.vis_contents.Add(render_source_atom)
+
+	trickery_image = new(render_source_atom)
+	trickery_image.loc = render_source_atom
+	trickery_image.override = TRUE
+
+	trickery_image.pixel_x = 0
+	trickery_image.pixel_y = 0
+
+	if(clickthrough)
+		//Special plane so we can click through the overlay
+		trickery_image.plane = SEETHROUGH_PLANE
+
+	fool.client.images += trickery_image
+
+	animate(trickery_image, alpha = target_alpha, time = animation_time)
+
+	RegisterSignal(fool, COMSIG_MOB_LOGOUT, PROC_REF(on_client_disconnect))
+
+///Remove the screen object and make us appear solid to ourselves again
+/datum/component/seethrough_mob/proc/untrick_mob()
+	var/mob/fool = parent
+	animate(trickery_image, alpha = 255, time = animation_time)
+	UnregisterSignal(fool, COMSIG_MOB_LOGOUT)
+
+	//after playing the fade-in animation, remove the image and the trick atom
+	addtimer(CALLBACK(src, PROC_REF(clear_image), trickery_image, fool.client), animation_time)
+
+///Remove the image and the trick atom
+/datum/component/seethrough_mob/proc/clear_image(image/removee, client/remove_from)
+	var/atom/movable/atom_parent = parent
+	atom_parent.vis_contents -= render_source_atom
+	atom_parent.render_target = initial_render_target_value
+	remove_from?.images -= removee
+
+///Effect is disabled when they log out because client gets deleted
+/datum/component/seethrough_mob/proc/on_client_disconnect()
+	SIGNAL_HANDLER
+
+	var/mob/fool = parent
+	UnregisterSignal(fool, COMSIG_MOB_LOGOUT)
+	clear_image(trickery_image, fool.client)
+
+/datum/component/seethrough_mob/proc/toggle_active()
+	is_active = !is_active
+	if(is_active)
+		trick_mob()
+	else
+		untrick_mob()

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -2141,6 +2141,7 @@
 #include "code\modules\mob\living\carbon\xenomorph\Powers.dm"
 #include "code\modules\mob\living\carbon\xenomorph\resin_constructions.dm"
 #include "code\modules\mob\living\carbon\xenomorph\say.dm"
+#include "code\modules\mob\living\carbon\xenomorph\seethrough.dm"
 #include "code\modules\mob\living\carbon\xenomorph\update_icons.dm"
 #include "code\modules\mob\living\carbon\xenomorph\xeno_helpers.dm"
 #include "code\modules\mob\living\carbon\xenomorph\xeno_tackle_counter.dm"


### PR DESCRIPTION
# About the pull request

Makes it so you can press an ability to make yourself see through as the queen, since the recent sprite is much bigger facing some areas.

port of  https://github.com/tgstation/tgstation/pull/77361

This is currently only on queen, but you can assign the ability and component to anyone and it will work with any xeno

# Explain why it's good for the game

Sprites shouldnt be stopping people from playing the game

https://github.com/user-attachments/assets/71a5729d-07dc-42fd-9a91-28df1da2cd25



# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
code: Added a transparent sprite ability for the queen
/:cl:
