### PR TITLE
Cargo tech is timelocked behind 10 hours of human

### DIFF
--- a/code/game/jobs/job/logistics/cargo/cargo_tech.dm
+++ b/code/game/jobs/job/logistics/cargo/cargo_tech.dm
@@ -10,6 +10,10 @@
 	gear_preset = /datum/equipment_preset/uscm_ship/cargo
 	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>Your job</a> is to dispense supplies to the marines, including weapon attachments. Stay in your department when possible to ensure the marines have full access to the supplies they may require. Listen to the radio in case someone requests a supply drop via the overwatch system."
 
+AddTimelock(/datum/job/logistics/cargo, list(
+	JOB_HUMAN_ROLES = 10 HOURS,
+))
+
 /datum/job/logistics/cargo/set_spawn_positions(count)
 	spawn_positions = ct_slot_formula(count)
 


### PR DESCRIPTION
# About the pull request

Locks cargo tech behind 10 hours of any human job.

# Explain why it's good for the game

If you're completely new to SS13, or even just CM, it's gonna be hard to get a handle on intents and grabbing things and byond's weird controls even without 50 marines screaming at you for their mag harns. 

# Testing Photographs and Procedure

I'll be completely honest, I have no idea how to test timelocks. I mean... everything booted up fine, that's as much as I know.

# Changelog

:cl:
qol: locks the cargo tech job behind 10 hours of any human roles.
/:cl: