### PR TITLE
CO surv bugfixes

### DIFF
--- a/code/game/objects/effects/landmarks/survivor_spawner.dm
+++ b/code/game/objects/effects/landmarks/survivor_spawner.dm
@@ -382,6 +382,7 @@
 	icon_state = "surv_wy"
 	equipment = /datum/equipment_preset/survivor/pmc/standard
 	synth_equipment = /datum/equipment_preset/synth/survivor/pmc
+	CO_equipment = /datum/equipment_preset/survivor/pmc/standard
 	intro_text = list("<h2>You are a survivor of a crash landing!</h2>",\
 	"<span class='notice'>You are NOT aware of the xenomorph threat.</span>",\
 	"<span class='danger'>Your primary objective is to survive. You believe a second dropship crashed somewhere to the north, which was carrying additional supplies.</span>")
@@ -396,6 +397,7 @@
 	icon_state = "surv_wy"
 	equipment = /datum/equipment_preset/survivor/pmc/medic
 	synth_equipment = /datum/equipment_preset/synth/survivor/pmc
+	CO_equipment = /datum/equipment_preset/survivor/pmc/medic
 	intro_text = list("<h2>You are a survivor of a crash landing!</h2>",\
 	"You are NOT aware of the xenomorph threat.",\
 	"Your primary objective is to survive. You believe a second dropship crashed somewhere to the north, which was carrying additional supplies.")
@@ -410,6 +412,7 @@
 	icon_state = "surv_wy"
 	equipment = /datum/equipment_preset/survivor/pmc/engineer
 	synth_equipment = /datum/equipment_preset/synth/survivor/pmc
+	CO_equipment = /datum/equipment_preset/survivor/pmc/engineer
 	intro_text = list("<h2>You are a survivor of a crash landing!</h2>",\
 	"You are NOT aware of the xenomorph threat.",\
 	"Your primary objective is to survive. You believe a second dropship crashed somewhere to the north, which was carrying additional supplies.")
@@ -424,6 +427,7 @@
 	icon_state = "surv_wy"
 	equipment = /datum/equipment_preset/survivor/pmc/pmc_leader
 	synth_equipment = /datum/equipment_preset/synth/survivor/pmc
+	CO_equipment = /datum/equipment_preset/survivor/pmc/pmc_leader
 	intro_text = list("<h2>You are a survivor of a crash landing!</h2>",\
 	"You are NOT aware of the xenomorph threat.",\
 	"Your primary objective is to survive. You believe a second dropship crashed somewhere to the north, which was carrying additional supplies.")

--- a/maps/bigredv2.json
+++ b/maps/bigredv2.json
@@ -24,6 +24,9 @@
     "CO_survivor_types": [
         "/datum/equipment_preset/survivor/solaris_ridge/co_survivor"
     ],
+    "CO_insert_survivor_types": [
+        "/datum/equipment_preset/survivor/clf/coordinator"
+    ],
     "defcon_triggers": [
         4750,
         3500,

--- a/maps/desert_dam.json
+++ b/maps/desert_dam.json
@@ -20,6 +20,9 @@
         "/datum/equipment_preset/survivor/civilian_unique",
         "/datum/equipment_preset/survivor/hybrisa/fire_fighter"
     ],
+    "CO_insert_survivor_types": [
+        "/datum/equipment_preset/survivor/clf/coordinator"
+    ],
     "defcon_triggers": [
         3300,
         2100,

--- a/maps/fiorina_sciannex.json
+++ b/maps/fiorina_sciannex.json
@@ -16,6 +16,9 @@
         "/datum/equipment_preset/survivor/corporate/fiorina",
         "/datum/equipment_preset/survivor/civilian"
     ],
+    "CO_insert_survivor_types": [
+        "/datum/equipment_preset/survivor/clf/coordinator"
+    ],
     "defcon_triggers": [
         3750,
         2600,

--- a/maps/kutjevo.json
+++ b/maps/kutjevo.json
@@ -23,6 +23,9 @@
         "/datum/equipment_preset/synth/survivor/kutjevo/scientist",
         "/datum/equipment_preset/synth/survivor/kutjevo/corporate"
     ],
+    "CO_insert_survivor_types": [
+        "/datum/equipment_preset/survivor/clf/coordinator"
+    ],
     "defcon_triggers": [
         4250,
         2950,

--- a/maps/lv624.json
+++ b/maps/lv624.json
@@ -18,6 +18,9 @@
         "/datum/equipment_preset/survivor/civilian",
         "/datum/equipment_preset/survivor/civilian_unique"
     ],
+    "CO_insert_survivor_types": [
+        "/datum/equipment_preset/survivor/clf/coordinator"
+    ],
     "map_item_type": "/obj/item/map/lazarus_landing_map",
     "announce_text": "An automated distress signal has been received from the archaeological site of Lazarus Landing, on the border world of LV-624. A response team from the ###SHIPNAME### will be dispatched shortly to investigate.",
     "monkey_types": [

--- a/maps/lv759_hybrisa_prospera.json
+++ b/maps/lv759_hybrisa_prospera.json
@@ -36,7 +36,8 @@
         "/datum/equipment_preset/synth/survivor/hybrisa/exec_bodyguard"
     ],
     "CO_insert_survivor_types": [
-        "/datum/equipment_preset/survivor/hybrisa/iasf_commander"
+        "/datum/equipment_preset/survivor/hybrisa/iasf_commander",
+        "/datum/equipment_preset/survivor/clf/coordinator"
     ],
     "defcon_triggers": [
         3750,

--- a/maps/new_varadero.json
+++ b/maps/new_varadero.json
@@ -22,7 +22,9 @@
 	"CO_survivor_types": [
         "/datum/equipment_preset/survivor/new_varadero/commander"
     ],
-
+    "CO_insert_survivor_types": [
+        "/datum/equipment_preset/survivor/clf/coordinator"
+    ],
     "defcon_triggers": [
         3300,
         2100,

--- a/maps/shivas_snowball.json
+++ b/maps/shivas_snowball.json
@@ -15,6 +15,9 @@
         "/datum/equipment_preset/survivor/security/shiva",
         "/datum/equipment_preset/survivor/civilian"
     ],
+    "CO_insert_survivor_types": [
+        "/datum/equipment_preset/survivor/clf/coordinator"
+    ],
     "defcon_triggers": [
         3300,
         2100,

--- a/maps/sorokyne_strata.json
+++ b/maps/sorokyne_strata.json
@@ -16,6 +16,9 @@
         "/datum/equipment_preset/survivor/upp_miner",
         "/datum/equipment_preset/survivor/upp_fire_fighter"
     ],
+    "CO_insert_survivor_types": [
+        "/datum/equipment_preset/survivor/clf/coordinator"
+    ],
     "defcon_triggers": [
         3750,
         2600,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Two things:
sets CO equipment for pmc insert spawners to their own default equipment to prevent CO survs from spawning in the PMC inserts as CMB. If and when a PMC surv CO is implemented, this can be set to an actual PMC CO surv, in the meantime, the CMB marshal shouldn't be materializing in the PMC insert with flavortext about being a CL or whatever.

also, allows CLF co survs to actually spawn, as the default slots for CO surv is 0 unless you have an equipment preset for them in the map json, which most maps do not.

# Explain why it's good for the game


bugs bad

# Testing Photographs and Procedure

too hard

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: CLF CO survs now actually spawn, CO survs in PMC insert will no longer be CMB
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
