### PR TITLE
Sticky keys pt 2: Release on blur

### DIFF
--- a/tgui/packages/tgui/events.ts
+++ b/tgui/packages/tgui/events.ts
@@ -59,12 +59,14 @@ const stealFocus = (node: HTMLElement) => {
   releaseStolenFocus();
   focusStolenBy = node;
   focusStolenBy.addEventListener('blur', releaseStolenFocus);
+  globalEvents.emit('input-focus');
 };
 
 const releaseStolenFocus = () => {
   if (focusStolenBy) {
     focusStolenBy.removeEventListener('blur', releaseStolenFocus);
     focusStolenBy = null;
+    globalEvents.emit('input-blur'); // Currently unused
   }
 };
 
@@ -116,26 +118,47 @@ window.addEventListener('mousemove', (e) => {
 // Focus event hooks
 // --------------------------------------------------------
 
-window.addEventListener('focusin', (e) => {
-  lastVisitedNode = null;
-  focusedNode = e.target as HTMLElement;
+// Handle stealing focus for textbox elements
+document.addEventListener(
+  'focus',
+  (e: FocusEvent) => {
+    // Window
+    if (!(e.target instanceof Element)) {
+      lastVisitedNode = null;
+      focusedNode = null;
+      return;
+    }
+    lastVisitedNode = null;
+    focusedNode = e.target as HTMLElement;
+    if (canStealFocus(e.target as HTMLElement)) {
+      stealFocus(e.target as HTMLElement);
+    }
+  },
+  true,
+);
+
+// When we click on any element on the page, untrack the last
+// visited node.
+document.addEventListener(
+  'blur',
+  (e) => {
+    lastVisitedNode = null;
+  },
+  true,
+);
+
+// Handle setting the window focus
+window.addEventListener('focus', (e) => {
   setWindowFocus(true);
-  if (canStealFocus(e.target as HTMLElement)) {
-    stealFocus(e.target as HTMLElement);
-  }
 });
 
-window.addEventListener('focusout', (e) => {
-  lastVisitedNode = null;
-  setWindowFocus(false, true);
-});
-
+// If we blur any element, the window may have unfocused if we didn't
+// click on the background
 window.addEventListener('blur', (e) => {
-  lastVisitedNode = null;
   setWindowFocus(false, true);
 });
 
-window.addEventListener('beforeunload', (e) => {
+window.addEventListener('close', (e) => {
   setWindowFocus(false);
 });
 

--- a/tgui/packages/tgui/hotkeys.ts
+++ b/tgui/packages/tgui/hotkeys.ts
@@ -192,6 +192,9 @@ export const setupHotKeys = () => {
   globalEvents.on('window-blur', () => {
     releaseHeldKeys();
   });
+  globalEvents.on('input-focus', () => {
+    releaseHeldKeys();
+  });
   startKeyPassthrough();
 };
 


### PR DESCRIPTION

# About the pull request

This PR ports https://github.com/BeeStation/BeeStation-Hornet/pull/12834 making it so a window losing focus will always release held keys even if they are actually held.

# Explain why it's good for the game

Fixes #9005 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/AEkmcxFP6KI
Incredibly difficult to reproduce this issue so I am not confident its now impossible.

</details>


# Changelog
:cl: Drathek
fix: More attempts to address sticky keys: Unfocusing a window now releases all held keys (even if actually held)
/:cl:
