### PR TITLE
Fix mass screenshot not expecting offset map coordinates

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -195,7 +195,7 @@ SUBSYSTEM_DEF(mapping)
 		// CM Snowflake for Mass Screenshot dimensions auto detection
 		for(var/z in bounds[MAP_MINZ] to bounds[MAP_MAXZ])
 			var/datum/space_level/zlevel = z_list[start_z + z - 1]
-			zlevel.bounds = list(bounds[MAP_MINX], bounds[MAP_MINY], z, bounds[MAP_MAXX], bounds[MAP_MAXY], z)
+			zlevel.bounds = list(bounds[MAP_MINX] + x_offset - 1, bounds[MAP_MINY] + y_offset - 1, z, bounds[MAP_MAXX] + x_offset - 1, bounds[MAP_MAXY] + y_offset - 1, z)
 
 	// =============== END CM Change =================
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -113,20 +113,24 @@
 	var/cur_z = mob.z
 	var/width
 	var/height
+	var/offset_x = 0
+	var/offset_y = 0
 	if(istype(SSmapping.z_list[cur_z], /datum/space_level))
 		var/datum/space_level/cur_level = SSmapping.z_list[cur_z]
-		cur_x += cur_level.bounds[MAP_MINX] - 1
-		cur_y += cur_level.bounds[MAP_MINY] - 1
+		offset_x = cur_level.bounds[MAP_MINX] - 1
+		cur_x += offset_x
+		offset_y = cur_level.bounds[MAP_MINY] - 1
+		cur_y += offset_y
 		width = cur_level.bounds[MAP_MAXX] - cur_level.bounds[MAP_MINX] - half_chunk_size + 3
 		height = cur_level.bounds[MAP_MAXY] - cur_level.bounds[MAP_MINY] - half_chunk_size + 3
 	else
 		width = world.maxx - half_chunk_size + 2
 		height = world.maxy - half_chunk_size + 2
-	var/width_inside = width - 1
-	var/height_inside = height - 1
+	var/width_inside = width - 1 + offset_x
+	var/height_inside = height - 1 + offset_y
 
-	while(cur_y < height)
-		while(cur_x < width)
+	while(cur_y < height + offset_y)
+		while(cur_x < width + offset_x)
 			mob.on_mob_jump()
 			mob.forceMove(locate(cur_x, cur_y, cur_z))
 			sleep(sleep_duration)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

With #9590 this is now a space level that is centered so its coordinates in the map are different than they are in game (e.g. it looks like 16,3,4 in strongdmm is 16,67,4 in game)

# Explain why it's good for the game

I like my mass screenshot verb working correctly.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

LV (shrunk 50% to fit github size)
![lv](https://github.com/user-attachments/assets/d7022fb6-8b35-4456-891c-8dc1325f6d01)

Z level 4 almayer
<img width="9600" height="3232" alt="new" src="https://github.com/user-attachments/assets/e9cfcf38-92e2-4edc-9590-5de8716c950a" />

</details>

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Drathek
fix: Mass screenshot verb now can handle offset maps (like multiz Almayer)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
