### PR TITLE
almayer multiz ledges no longer break

### DIFF
--- a/code/game/objects/structures/platforms.dm
+++ b/code/game/objects/structures/platforms.dm
@@ -234,9 +234,11 @@
 
 /obj/structure/platform/metal/stair_cut/almayer_smooth_left
 	icon_state = "platform_sm_stair"
+	explo_proof = TRUE
 
 /obj/structure/platform/metal/stair_cut/almayer_smooth_right
 	icon_state = "platform_sm_stair_alt"
+	explo_proof = TRUE
 
 //------------------------------//
 //    Stone Stairs Platforms    //
@@ -299,6 +301,7 @@
 
 /obj/structure/platform/metal/almayer_smooth
 	icon_state = "platform_sm"
+	explo_proof = TRUE
 
 /obj/structure/platform/metal/almayer_smooth/north
 	dir = NORTH
@@ -484,6 +487,7 @@
 
 /obj/structure/platform_decoration/metal/almayer_smooth
 	icon_state = "platform_sm_deco"
+	explo_proof = TRUE
 
 /obj/structure/platform_decoration/metal/almayer_smooth/north
 	dir = NORTH

--- a/code/game/objects/structures/platforms.dm
+++ b/code/game/objects/structures/platforms.dm
@@ -115,7 +115,7 @@
 		to_chat(user, SPAN_WARNING("Its already destroyed!"))
 		return XENO_NO_DELAY_ACTION
 
-	if(stat & explo_proof)
+	if(explo_proof)
 		to_chat(user, SPAN_WARNING("Its too strong for us!"))
 		return XENO_NO_DELAY_ACTION
 


### PR DESCRIPTION

# About the pull request

decorative ledges that were not supposed to break on the ship no longer break

# Explain why it's good for the game

<img width="837" height="1039" alt="image" src="https://github.com/user-attachments/assets/46eeeab9-f4ab-4c0d-baad-fe873c69cf61" />

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: decorative z level ledges on the almayer no longer break
/:cl:
