### PR TITLE
Fix Type-19 attachments offsets

### DIFF
--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -520,7 +520,7 @@
 	)
 
 /obj/item/weapon/gun/smg/pps43/set_gun_attachment_offsets()
-	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 20,"rail_x" = 20, "rail_y" = 24, "under_x" = 25, "under_y" = 17, "stock_x" = 26, "stock_y" = 15)
+	attachable_offset = list("muzzle_x" = 32, "muzzle_y" = 20, "rail_x" = 10, "rail_y" = 21, "under_x" = 25, "under_y" = 17, "stock_x" = 26, "stock_y" = 15)
 
 /obj/item/weapon/gun/smg/pps43/set_gun_config_values()
 	..()


### PR DESCRIPTION

# About the pull request

Title

<img width="406" height="285" alt="dreamseeker_ibuQqG57ZH" src="https://github.com/user-attachments/assets/16c6be2a-a735-495c-b1f1-86806ff0e699" />

closes https://github.com/cmss13-devs/cmss13/issues/10304




# Changelog
:cl:
fix: fixed type 19 incorrect attachment offsets
/:cl:
