### PR TITLE
fixes a runtime when checking main cursor prefs

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -67,8 +67,7 @@
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_MOB_LOGGED_IN, src)
 	SEND_SIGNAL(client, COMSIG_CLIENT_MOB_LOGGED_IN, src)
 	SEND_SIGNAL(src, COMSIG_MOB_LOGGED_IN)
-
-	if(client?.prefs?.main_cursor)
+	if(client?.prefs.main_cursor)
 		update_cursor()
 
 /mob/proc/set_logged_in_mob()

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -67,7 +67,8 @@
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_MOB_LOGGED_IN, src)
 	SEND_SIGNAL(client, COMSIG_CLIENT_MOB_LOGGED_IN, src)
 	SEND_SIGNAL(src, COMSIG_MOB_LOGGED_IN)
-	if(client?.prefs.main_cursor)
+
+	if(client?.prefs?.main_cursor)
 		update_cursor()
 
 /mob/proc/set_logged_in_mob()

--- a/code/modules/mob/unauthenticated/unauthenticated.dm
+++ b/code/modules/mob/unauthenticated/unauthenticated.dm
@@ -25,8 +25,6 @@ GENERAL_PROTECT_DATUM(/mob/unauthenticated)
 	ADD_TRAIT(src, TRAIT_IMMOBILIZED, TRAIT_SOURCE_INHERENT)
 
 /mob/unauthenticated/Login()
-	client.acquire_dpi()
-
 	var/static/datum/preferences/dummy_preferences
 	if(!dummy_preferences)
 		dummy_preferences = new()
@@ -34,6 +32,8 @@ GENERAL_PROTECT_DATUM(/mob/unauthenticated)
 	client.prefs = dummy_preferences
 
 	. = ..()
+
+	client.acquire_dpi()
 
 	display_unauthenticated_menu()
 

--- a/code/modules/mob/unauthenticated/unauthenticated.dm
+++ b/code/modules/mob/unauthenticated/unauthenticated.dm
@@ -25,8 +25,6 @@ GENERAL_PROTECT_DATUM(/mob/unauthenticated)
 	ADD_TRAIT(src, TRAIT_IMMOBILIZED, TRAIT_SOURCE_INHERENT)
 
 /mob/unauthenticated/Login()
-	. = ..()
-
 	client.acquire_dpi()
 
 	var/static/datum/preferences/dummy_preferences
@@ -34,6 +32,8 @@ GENERAL_PROTECT_DATUM(/mob/unauthenticated)
 		dummy_preferences = new()
 
 	client.prefs = dummy_preferences
+
+	. = ..()
 
 	display_unauthenticated_menu()
 


### PR DESCRIPTION
prefs weren't guaranteed in /mob/Login()

:cl:
fix: fixes a runtime when checking cursor preferences
/:cl:

fixes #10322