### PR TITLE
Fixes airlocks not respecting EMP proof + EMP proofs umbillical poddors

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -153,6 +153,8 @@
 
 /obj/structure/machinery/door/emp_act(severity)
 	. = ..()
+	if(. == FALSE)
+		return .
 	if(prob(20/severity) && use_power)
 		open()
 	if(prob(40/severity))

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -13655,23 +13655,6 @@
 /obj/structure/surface/table/almayer,
 /turf/open/floor/plating/plating_catwalk/no_build,
 /area/almayer/middeck/maintenance/sp)
-"aJn" = (
-/obj/structure/machinery/door/poddoor/almayer{
-	id = "s_umbilical";
-	name = "\improper Umbillical Airlock";
-	unacidable = 1;
-	explo_proof = 1;
-	emp_proof = 1
-	},
-/obj/structure/machinery/door/poddoor/almayer{
-	id = "s_umbilical";
-	name = "\improper Umbillical Airlock";
-	unacidable = 1;
-	explo_proof = 1;
-	emp_proof = 1
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/hallways/lower/port_umbilical)
 "aJo" = (
 /obj/structure/platform/metal/almayer_smooth/north,
 /turf/open_space,
@@ -132484,7 +132467,7 @@ mLg
 wAK
 efk
 bTz
-aJn
+efk
 aaa
 aaa
 aaa

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -8498,7 +8498,8 @@
 	id = "s_umbilical";
 	name = "\improper Umbillical Airlock";
 	unacidable = 1;
-	explo_proof = 1
+	explo_proof = 1;
+	emp_proof = 1
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/lower/port_umbilical)
@@ -13654,6 +13655,23 @@
 /obj/structure/surface/table/almayer,
 /turf/open/floor/plating/plating_catwalk/no_build,
 /area/almayer/middeck/maintenance/sp)
+"aJn" = (
+/obj/structure/machinery/door/poddoor/almayer{
+	id = "s_umbilical";
+	name = "\improper Umbillical Airlock";
+	unacidable = 1;
+	explo_proof = 1;
+	emp_proof = 1
+	},
+/obj/structure/machinery/door/poddoor/almayer{
+	id = "s_umbilical";
+	name = "\improper Umbillical Airlock";
+	unacidable = 1;
+	explo_proof = 1;
+	emp_proof = 1
+	},
+/turf/open/floor/almayer/plate,
+/area/almayer/hallways/lower/port_umbilical)
 "aJo" = (
 /obj/structure/platform/metal/almayer_smooth/north,
 /turf/open_space,
@@ -34093,7 +34111,8 @@
 "bDF" = (
 /obj/structure/machinery/door/poddoor/almayer{
 	dir = 4;
-	unacidable = 1
+	unacidable = 1;
+	emp_proof = 1
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/shipboard/weapon_room/notunnel)
@@ -43064,7 +43083,8 @@
 	id = "s_umbilical";
 	name = "\improper Umbillical Airlock";
 	unacidable = 1;
-	explo_proof = 1
+	explo_proof = 1;
+	emp_proof = 1
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/lower/port_umbilical)
@@ -56352,7 +56372,8 @@
 "jzD" = (
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	icon_state = "almayer_pdoor";
-	id = "s_engi"
+	id = "s_engi";
+	emp_proof = 1
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/engineering/upper_engineering/notunnel)
@@ -64614,7 +64635,8 @@
 "mZF" = (
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	icon_state = "almayer_pdoor";
-	id = "s_engi_ext"
+	id = "s_engi_ext";
+	emp_proof = 1
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/engineering/upper_engineering/notunnel)
@@ -67820,7 +67842,8 @@
 	id = "n_umbilical";
 	name = "\improper Umbillical Airlock";
 	unacidable = 1;
-	explo_proof = 1
+	explo_proof = 1;
+	emp_proof = 1
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/lower/starboard_umbilical)
@@ -77528,7 +77551,8 @@
 "sbq" = (
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	icon_state = "almayer_pdoor";
-	id = "n_engi"
+	id = "n_engi";
+	emp_proof = 1
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/engineering/upper_engineering/notunnel)
@@ -93468,7 +93492,8 @@
 "yjq" = (
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	icon_state = "almayer_pdoor";
-	id = "n_engi_ext"
+	id = "n_engi_ext";
+	emp_proof = 1
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/engineering/upper_engineering/notunnel)
@@ -132459,7 +132484,7 @@ mLg
 wAK
 efk
 bTz
-efk
+aJn
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes #10344

# Explain why it's good for the game

Bugs bad

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: G2 grenades can no longer open the umbillical podlocks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
