### PR TITLE
Makes unhauling trigger eggmorphers + egg_triggers () + egg morphers only try to hug non-xenos

### DIFF
--- a/code/modules/cm_aliens/structures/special/egg_morpher.dm
+++ b/code/modules/cm_aliens/structures/special/egg_morpher.dm
@@ -128,6 +128,12 @@
 	if(isnull(targets) || !length(targets))
 		return
 
+	for(var/mob/living/carbon/xenomorph/xeno in targets)
+		targets -= xeno //Don't add xenomorphs to the list of possible players we hug.
+
+
+	if(!length(targets))
+		return
 	var/target = pick(targets)
 	if(isnull(target))
 		return

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -546,8 +546,10 @@
 	remove_filter("hauled_shadow")
 	forceMove(location)
 	for(var/obj/object in location)
-		if(istype(object, /obj/effect/alien/resin/trap) || istype(object, /obj/effect/alien/egg))
+		if(istype(object, /obj/effect/alien/resin/trap) || istype(object, /obj/effect/alien/egg) || istype(object, /obj/effect/alien/resin/special/eggmorph))
 			object.HasProximity(src)
+		if(istype(object, /obj/effect/egg_trigger))
+			object.Crossed(src)
 	next_haul_resist = 0
 
 


### PR DESCRIPTION

# About the pull request

Unhauling now triggers egg effects (which is what makes eggs 3x3), so you can drop a capture next to the egg to trigger it, like pre-hauling. (Current hauling only works if you drop directly on the egg)
Unhauling now triggers the egg morpher. (Both for humans and monkeys, even though the egg morpher doesn't normally trigger on monkeys). ((This means you can drop someone on the egg morpher and they will be hugged, so you don't have to wait for the process() trigger of the eggmorpher))

Eggmorpher currently only tries to hug 1 target every process. This is done from a list of players in range of the egg-morpher. This list also included xenomorphs, which meant if a xenomorph and human were on the egg-morpher there's only a 50/50 chance that it actually tries to hug the human or waits a process() (usually 2 seconds)

# Explain why it's good for the game

Makes hauling more like how devouring was.
Removes an easy trap for newer xenos (unhauling on morphers + next to eggs)

Fixes #9927


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Eggs and morphers are now more robust at handling unhauling.
/:cl:
