### PR TITLE
Fixes kill feed removing the first letter of the weapon

### DIFF
--- a/code/datums/statistics/entities/panel_stats.dm
+++ b/code/datums/statistics/entities/panel_stats.dm
@@ -131,11 +131,12 @@
 				damage_list += list(list("name" = "oxy", "value" = S.total_oxy))
 			if(S.total_tox)
 				damage_list += list(list("name" = "tox", "value" = S.total_tox))
+
 			death_list += list(list(
 				"mob_name" = sanitize(S.mob_name),
 				"job_name" = S.role_name,
 				"area_name" = sanitize_area(S.area_name),
-				"cause_name" = sanitize(S.cause_name),
+				"cause_name" = sanitize(S.cause_name, list("\n"=" ","\t"=" ","�"=" ", "\u{16}" =""))),
 				"total_kills" = S.total_kills,
 				"total_damage" = damage_list,
 				"time_of_death" = duration2text(S.time_of_death),

--- a/code/datums/statistics/entities/panel_stats.dm
+++ b/code/datums/statistics/entities/panel_stats.dm
@@ -136,7 +136,7 @@
 				"mob_name" = sanitize(S.mob_name),
 				"job_name" = S.role_name,
 				"area_name" = sanitize_area(S.area_name),
-				"cause_name" = sanitize(S.cause_name, list("\n"=" ","\t"=" ","�"=" ", "\u{16}" =""))),
+				"cause_name" = sanitize(S.cause_name, list("\n"=" ","\t"=" ","�"=" ", "\u{16}" ="")),
 				"total_kills" = S.total_kills,
 				"total_damage" = damage_list,
 				"time_of_death" = duration2text(S.time_of_death),

--- a/code/datums/statistics/entities/panel_stats.dm
+++ b/code/datums/statistics/entities/panel_stats.dm
@@ -136,7 +136,7 @@
 				"mob_name" = sanitize(S.mob_name),
 				"job_name" = S.role_name,
 				"area_name" = sanitize_area(S.area_name),
-				"cause_name" = sanitize(S.cause_name, list("\n"=" ","\t"=" ","�"=" ", "\u{16}" ="")),
+				"cause_name" = sanitize(strip_improper(S.cause_name)),
 				"total_kills" = S.total_kills,
 				"total_damage" = damage_list,
 				"time_of_death" = duration2text(S.time_of_death),


### PR DESCRIPTION

# About the pull request

There's a \u{16} character infront, which likely gets eaten by html_encode for some reason.
Just replaces it with nothing.

Fixes #8842

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Kill feed now preserves the first letter of the killing weapon
/:cl:
