### PR TITLE
Fixes King corpse not giving intel 

### DIFF
--- a/code/modules/objectives/mob_objectives.dm
+++ b/code/modules/objectives/mob_objectives.dm
@@ -116,6 +116,8 @@
 				value = OBJECTIVE_MEDIUM_VALUE
 			if(3)
 				value = OBJECTIVE_EXTREME_VALUE
+			if(4)
+				value = OBJECTIVE_ABSOLUTE_VALUE
 			else
 				if(isqueen(X)) //Queen is Tier 0 for some reason...
 					value = OBJECTIVE_ABSOLUTE_VALUE


### PR DESCRIPTION

# About the pull request

Only tier 4 xeno it seems.

Gives same intel at Queen now.

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: King corpse gives intel
/:cl:
