### PR TITLE
Fixes zombie claws having no delay against barricades

### DIFF
--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -174,6 +174,7 @@
 	sharp = 1
 	attack_verb = list("slashed", "torn", "scraped", "gashed", "ripped")
 	pry_capable = IS_PRY_CAPABLE_FORCE
+	attack_speed = 1 SECONDS
 
 /obj/item/weapon/zombie_claws/attack(mob/living/target, mob/living/carbon/human/user)
 	if(iszombie(target))

--- a/code/game/objects/structures/barricade/barricade.dm
+++ b/code/game/objects/structures/barricade/barricade.dm
@@ -233,6 +233,7 @@
 	if(istype(item, /obj/item/weapon/zombie_claws))
 		user.visible_message(SPAN_DANGER("The zombie smashed at the [src.barricade_type] barricade!"),
 		SPAN_DANGER("You smack the [src.barricade_type] barricade!"))
+		. = ..()
 		if(barricade_hitsound)
 			playsound(src, barricade_hitsound, 35, 1)
 		hit_barricade(item)


### PR DESCRIPTION

# About the pull request

Fixes an oversight during the "no non-combat click delay PR" which forgot to also add a delay to zombie claws in attacking cades. They no longer have no click delay while attacking cades, using their intended attack speed delay now.

Also changed their attack speed to using SECONDS instead of whatever the default for weapon is.

# Explain why it's good for the game

I heard bugs are bad so: bug fix = good

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Unknownity
fix: Zombie claws have attack delay against cades again.
/:cl:

