### PR TITLE
Head surgery after some steps have no [Open Surgical Incision] on the analyzer 

### DIFF
--- a/code/modules/mob/living/living_healthscan.dm
+++ b/code/modules/mob/living/living_healthscan.dm
@@ -255,7 +255,7 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 
 			//checking for open incisions, but since eyes and mouths incisions are "head incisions" but not "head surgeries" gotta do some snowflake
 			if(limb.name == "head")
-				if(human_target_mob.active_surgeries["head"])
+				if(human_target_mob.active_surgeries["head"] || limb.get_incision_depth())
 					current_list["open_incision"] = TRUE
 
 				var/zone


### PR DESCRIPTION
# About the pull request

This PR fixes bug that head surgery after some steps have no [Open Surgical Incision] text on the analyzer.

Probably fixes #5715 

# Explain why it's good for the game

Bug fix

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Bug showcase

https://github.com/user-attachments/assets/3a43e9ac-2e42-4b52-9206-ce26bebd6b72

</details>

# Changelog

:cl: Sergeys
fix: The analyzer no longer forgets about surgery in the head.
/:cl:
