### PR TITLE
reverse bursting out of a xeno now gibs it again

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -152,7 +152,8 @@
 				var/hit_sound = pick('sound/weapons/genhit1.ogg', 'sound/weapons/genhit2.ogg', 'sound/weapons/genhit3.ogg')
 				playsound(loc, hit_sound, 25, 1)
 			if(prob(max(4*(100*xeno.getBruteLoss()/xeno.maxHealth - 75),0))) //4% at 24% health, 80% at 5% health
-				xeno.release_haul(stuns=FALSE)
+				xeno.last_damage_data = create_cause_data("scuffling", src)
+				xeno.gib(last_damage_data)
 		else
 			for(var/mob/mobs_can_hear in hearers(4, xeno))
 				if(mobs_can_hear.client)


### PR DESCRIPTION
# About the pull request

reverse bursting out of a xeno gibs it like it used to before double larva

# Explain why it's good for the game

Xenos can easily circumvent this by dropping the hauled marine and tackling them down to make them drop their knife, i believe that such a level of handholding is very unnecessary when it can be avoided by taking 5 seconds to tackle the marine down again. Usually even after reverse bursting out of a xeno you get tackled down really fast, making it not punish the xeno at all. 

# Testing Photographs and Procedure



# Changelog

:cl:
balance: Xenos now gib when reverse bursted out of.
/:cl:


