### PR TITLE
fixes light fixture deconstruction getting stuck on removing the light fitting

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -400,10 +400,10 @@
 			to_chat(user, "There is a [fitting] already inserted.")
 			return
 		else
-			playsound(loc, 'sound/items/Screwdriver.ogg', 25, 1)
 			src.add_fingerprint(user)
 			var/obj/item/light_bulb/L = W
 			if(istype(L, light_type))
+				playsound(loc, 'sound/items/Screwdriver.ogg', 25, 1)
 				status = L.status
 				to_chat(user, "You insert the [L.name].")
 				switchcount = L.switchcount
@@ -425,11 +425,7 @@
 		return
 
 	// attempt to remove light via screwdriver
-	if(HAS_TRAIT(W, TRAIT_TOOL_SCREWDRIVER))
-		if(status == LIGHT_EMPTY)
-			to_chat(user, "There is no [fitting] in this light.")
-			return
-
+	if(HAS_TRAIT(W, TRAIT_TOOL_SCREWDRIVER) && status != LIGHT_EMPTY)
 		to_chat(user, "You remove the light [fitting].")
 		playsound(loc, 'sound/items/Screwdriver.ogg', 25, 1)
 		// create a light tube/bulb item and put it in the user's hand


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

fixes getting stuck on removing the light fitting with a screwdriver and not being able to open the fixture.


# Explain why it's good for the game

bug fix


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: fixed light fixture deconstruction getting stuck on removing the light fitting. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
