### PR TITLE
ports lighting optimizations and makes lights fall off in intensity across zs as well

### DIFF
--- a/code/datums/mutable_appearance.dm
+++ b/code/datums/mutable_appearance.dm
@@ -4,10 +4,12 @@
 
 // Mutable appearances are children of images, just so you know.
 
-/mutable_appearance/New()
+// Mutable appearances erase template vars on new, because they accept an appearance to copy as an arg
+// If we have nothin to copy, we set the float plane
+/mutable_appearance/New(mutable_appearance/to_copy)
 	..()
-	plane = FLOAT_PLANE // No clue why this is 0 by default yet images are on FLOAT_PLANE
-						// And yes this does have to be in the constructor, BYOND ignores it if you set it as a normal var
+	if(!to_copy)
+		plane = FLOAT_PLANE
 
 /// Helper similar to image()
 /proc/mutable_appearance(icon, icon_state = "", layer = FLOAT_LAYER, plane = FLOAT_PLANE, alpha = 255, appearance_flags = NONE)

--- a/code/modules/lighting/lighting_static/static_lighting_corner.dm
+++ b/code/modules/lighting/lighting_static/static_lighting_corner.dm
@@ -7,6 +7,7 @@
 
 	var/x = 0
 	var/y = 0
+	var/z = 0
 
 	var/turf/master_NE
 	var/turf/master_SE
@@ -28,35 +29,48 @@
 	///whether we are to be added to SSlighting's corners_queue list for an update
 	var/needs_update = FALSE
 
-/datum/static_lighting_corner/New(turf/new_turf, diagonal)
+// Takes as an argument the coords to use as the bottom left (south west) of our corner
+/datum/static_lighting_corner/New(x, y, z)
 	. = ..()
-	save_master(new_turf, turn(diagonal, 180))
+	src.x = x + 0.5
+	src.y = y + 0.5
+	src.z = z
 
-	var/vertical = diagonal & ~(diagonal - 1) // The horizontal directions (4 and 8) are bigger than the vertical ones (1 and 2), so we can reliably say the lsb is the horizontal direction.
-	var/horizontal = diagonal & ~vertical       // Now that we know the horizontal one we can get the vertical one.
+	// Alright. We're gonna take a set of coords, and from them do a loop clockwise
+	// To build out the turfs adjacent to us. This is pretty fast
+	var/turf/process_next = locate(x, y, z)
+	if(process_next)
+		master_SW = process_next
+		process_next.lighting_corner_NE = src
+		// Now, we go north!
+		process_next = get_step(process_next, NORTH)
+	else
+		// Yes this is slightly slower then having a guarenteeed turf, but there aren't many null turfs
+		// So this is pretty damn fast
+		process_next = locate(x, y + 1, z)
 
-	x = new_turf.x + (horizontal == EAST ? 0.5 : -0.5)
-	y = new_turf.y + (vertical   == NORTH ? 0.5 : -0.5)
+	// Ok, if we have a north turf, go there. otherwise, onto the next
+	if(process_next)
+		master_NW = process_next
+		process_next.lighting_corner_SE = src
+		// Now, TO THE EAST
+		process_next = get_step(process_next, EAST)
+	else
+		process_next = locate(x + 1, y + 1, z)
 
-	// My initial plan was to make this loop through a list of all the dirs (horizontal, vertical, diagonal).
-	// Issue being that the only way I could think of doing it was very messy, slow and honestly overengineered.
-	// So we'll have this hardcode instead.
-	var/turf/new_master_turf
+	// Etc etc
+	if(process_next)
+		master_NE = process_next
+		process_next.lighting_corner_SW = src
+		// Now, TO THE SOUTH AGAIN (SE)
+		process_next = get_step(process_next, SOUTH)
+	else
+		process_next = locate(x + 1, y, z)
 
-	// Diagonal one is easy.
-	new_master_turf = get_step(new_turf, diagonal)
-	if(new_master_turf) // In case we're on the map's border.
-		save_master(new_master_turf, diagonal)
-
-	// Now the horizontal one.
-	new_master_turf = get_step(new_turf, horizontal)
-	if(new_master_turf) // Ditto.
-		save_master(new_master_turf, ((new_master_turf.x > x) ? EAST : WEST) | ((new_master_turf.y > y) ? NORTH : SOUTH)) // Get the dir based on coordinates.
-
-	// And finally the vertical one.
-	new_master_turf = get_step(new_turf, vertical)
-	if (new_master_turf)
-		save_master(new_master_turf, ((new_master_turf.x > x) ? EAST : WEST) | ((new_master_turf.y > y) ? NORTH : SOUTH)) // Get the dir based on coordinates.
+	// anddd the last tile
+	if(process_next)
+		master_SE = process_next
+		process_next.lighting_corner_NW = src
 
 /datum/static_lighting_corner/proc/save_master(turf/master, dir)
 	switch (dir)

--- a/code/modules/lighting/lighting_static/static_lighting_object.dm
+++ b/code/modules/lighting/lighting_static/static_lighting_object.dm
@@ -8,6 +8,9 @@
 	///the turf that our light is applied to
 	var/turf/affected_turf
 
+// Global list of lighting underlays, indexed by z level
+GLOBAL_LIST_EMPTY(default_lighting_underlays_by_z)
+
 /datum/static_lighting_object/New(turf/source)
 	if(!isturf(source))
 		qdel(src, force=TRUE)
@@ -15,7 +18,7 @@
 		return
 	..()
 
-	current_underlay = mutable_appearance(LIGHTING_ICON, "transparent", FLOAT_LAYER, LIGHTING_PLANE, 255, RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM)
+	current_underlay = new(GLOB.default_lighting_underlays_by_z[source.z])
 
 	affected_turf = source
 	if (affected_turf.static_lighting_object)
@@ -51,28 +54,13 @@
 
 	var/static/datum/static_lighting_corner/dummy/dummy_lighting_corner = new
 
+	var/turf/affected_turf = src.affected_turf
 	var/datum/static_lighting_corner/red_corner = affected_turf.lighting_corner_SW || dummy_lighting_corner
 	var/datum/static_lighting_corner/green_corner = affected_turf.lighting_corner_SE || dummy_lighting_corner
 	var/datum/static_lighting_corner/blue_corner = affected_turf.lighting_corner_NW || dummy_lighting_corner
 	var/datum/static_lighting_corner/alpha_corner = affected_turf.lighting_corner_NE || dummy_lighting_corner
 
 	var/max = max(red_corner.largest_color_luminosity, green_corner.largest_color_luminosity, blue_corner.largest_color_luminosity, alpha_corner.largest_color_luminosity)
-
-	var/rr = red_corner.cache_r
-	var/rg = red_corner.cache_g
-	var/rb = red_corner.cache_b
-
-	var/gr = green_corner.cache_r
-	var/gg = green_corner.cache_g
-	var/gb = green_corner.cache_b
-
-	var/br = blue_corner.cache_r
-	var/bg = blue_corner.cache_g
-	var/bb = blue_corner.cache_b
-
-	var/ar = alpha_corner.cache_r
-	var/ag = alpha_corner.cache_g
-	var/ab = alpha_corner.cache_b
 
 	#if LIGHTING_SOFT_THRESHOLD != 0
 	var/set_luminosity = max > LIGHTING_SOFT_THRESHOLD
@@ -81,35 +69,34 @@
 	// This number is mostly arbitrary.
 	var/set_luminosity = max > 1e-6
 	#endif
-
-	if((rr & gr & br & ar) && (rg + gg + bg + ag + rb + gb + bb + ab == 8))
+	var/mutable_appearance/current_underlay = src.current_underlay
+	affected_turf.underlays -= current_underlay
+	if(red_corner.cache_r & green_corner.cache_r & blue_corner.cache_r & alpha_corner.cache_r && \
+		(red_corner.cache_g + green_corner.cache_g + blue_corner.cache_g + alpha_corner.cache_g + \
+		red_corner.cache_b + green_corner.cache_b + blue_corner.cache_b + alpha_corner.cache_b == 8))
 		//anything that passes the first case is very likely to pass the second, and addition is a little faster in this case
-		affected_turf.underlays -= current_underlay
 		current_underlay.icon_state = "transparent"
 		current_underlay.color = null
-		affected_turf.underlays += current_underlay
 	else if(!set_luminosity)
-		affected_turf.underlays -= current_underlay
 		current_underlay.icon_state = "dark"
 		current_underlay.color = null
-		affected_turf.underlays += current_underlay
 	else
-		affected_turf.underlays -= current_underlay
 		current_underlay.icon_state = null
 		current_underlay.color = list(
-			rr, rg, rb, 00,
-			gr, gg, gb, 00,
-			br, bg, bb, 00,
-			ar, ag, ab, 00,
+			red_corner.cache_r, red_corner.cache_g, red_corner.cache_b, 00,
+			green_corner.cache_r, green_corner.cache_g, green_corner.cache_b, 00,
+			blue_corner.cache_r, blue_corner.cache_g, blue_corner.cache_b, 00,
+			alpha_corner.cache_r, alpha_corner.cache_g, alpha_corner.cache_b, 00,
 			00, 00, 00, 01
 		)
 
-		affected_turf.underlays += current_underlay
-
-	var/area/A = affected_turf.loc
-	//We are luminous
+	// Of note. Most of the cost in this proc is here, I think because color matrix'd underlays DO NOT cache well, which is what adding to underlays does
+	// We use underlays because objects on each tile would fuck with maptick. if that ever changes, use an object for this instead
+	affected_turf.underlays += current_underlay
 	if(set_luminosity)
 		affected_turf.luminosity = set_luminosity
+		return
+	var/area/turf_area = affected_turf.loc
 	//We are not lit by static light OR dynamic light.
-	else if(!LAZYLEN(affected_turf.hybrid_lights_affecting) && !A.base_lighting_alpha)
+	if(!LAZYLEN(affected_turf.hybrid_lights_affecting) && !turf_area.base_lighting_alpha)
 		affected_turf.luminosity = 0

--- a/code/modules/lighting/lighting_static/static_lighting_setup.dm
+++ b/code/modules/lighting/lighting_static/static_lighting_setup.dm
@@ -3,7 +3,7 @@
 
 		if(!A.static_lighting)
 			continue
-
+		// I hate this so much dude. why do areas not track their turfs lummyyyyyyy
 		for(var/turf/T in A)
 			new/datum/static_lighting_object(T)
 			CHECK_TICK

--- a/code/modules/lighting/lighting_static/static_lighting_turf.dm
+++ b/code/modules/lighting/lighting_static/static_lighting_turf.dm
@@ -44,21 +44,3 @@
 		overlays -= old_area.lighting_effect
 	if(new_area.lighting_effect)
 		overlays += new_area.lighting_effect
-
-
-
-/turf/proc/static_generate_missing_corners()
-	if (!lighting_corner_NE)
-		lighting_corner_NE = new/datum/static_lighting_corner(src, NORTH|EAST)
-
-	if (!lighting_corner_SE)
-		lighting_corner_SE = new/datum/static_lighting_corner(src, SOUTH|EAST)
-
-	if (!lighting_corner_SW)
-		lighting_corner_SW = new/datum/static_lighting_corner(src, SOUTH|WEST)
-
-	if (!lighting_corner_NW)
-		lighting_corner_NW = new/datum/static_lighting_corner(src, NORTH|WEST)
-
-	lighting_corners_initialised = TRUE
-

--- a/code/modules/mapping/space_management/space_level.dm
+++ b/code/modules/mapping/space_management/space_level.dm
@@ -12,6 +12,10 @@
 	name = new_name
 	traits = new_traits
 
+	if(length(GLOB.default_lighting_underlays_by_z) < z_value)
+		GLOB.default_lighting_underlays_by_z.len = z_value
+	GLOB.default_lighting_underlays_by_z[z_value] = mutable_appearance(LIGHTING_ICON, "transparent", new_z, LIGHTING_PLANE, 255, RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM)
+
 	if (islist(new_traits))
 		for (var/trait in new_traits)
 			SSmapping.z_trait_levels[trait] += list(new_z)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

ports tgstation/tgstation#69838
adds falloff in z direction for lights so lights no longer bleed as much across zs, even less across multiple zs

# Explain why it's good for the game

true and real

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: lights now get dimmer across zlevels
refactor: optimized lights
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
