### PR TITLE
Forsaken ERT no longer says that an emergency beacon has been activated

### DIFF
--- a/code/datums/emergency_calls/forsaken_xenos.dm
+++ b/code/datums/emergency_calls/forsaken_xenos.dm
@@ -6,6 +6,7 @@
 	shuttle_id = ""
 	name_of_spawn = /obj/effect/landmark/ert_spawns/groundside_xeno
 	objectives = "You have been left behind to safeguard the abandoned colony. Do not allow trespassers."
+	ert_message = "Forsaken xenomorphs are emerging."
 
 /datum/emergency_call/forsaken_xenos/create_member(datum/mind/new_member, turf/override_spawn_loc)
 	var/turf/spawn_loc = override_spawn_loc ? override_spawn_loc : get_spawn_point()


### PR DESCRIPTION

# About the pull request

Replaces this
<img width="1095" height="62" alt="image" src="https://github.com/user-attachments/assets/e9b6e2d6-f2e9-4c4c-b5b3-720610db1744" />

So it says "Forsaken xenomorphs are emerging." instead of "An emergency beacon has been activated."

# Explain why it's good for the game

QOL, forsaken and ERTs are quite different, makes it easier to see so you don't have to click every time.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Forsaken ERT no longer pretends to be a distress beacon
/:cl:
