### PR TITLE
Makes /area/interior NO_TUNNEL

### DIFF
--- a/code/modules/vehicles/interior/areas.dm
+++ b/code/modules/vehicles/interior/areas.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/turf/areas_interiors.dmi'
 	icon_state = "interior"
 	base_lighting_alpha = 255
+	flags_area = AREA_NOTUNNEL
 
 	ambience_exterior = 'sound/ambience/vehicle_interior1.ogg'
 	sound_environment = SOUND_ENVIRONMENT_ROOM


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes #10442 

# Explain why it's good for the game

Shouldn't be able to burrow inside interiors, especially since they're loaded in a shared z-level, permitting "teleportation"


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: You can no longer tunnel in vehicle interiors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
