### PR TITLE
Fixes FORECON M1911C being duplicated

### DIFF
--- a/code/modules/gear_presets/survivors/lv_522/forcon_survivors.dm
+++ b/code/modules/gear_presets/survivors/lv_522/forcon_survivors.dm
@@ -285,8 +285,8 @@
 				sidearmammo = /obj/item/ammo_magazine/pistol/heavy/super
 			if(CO_GUN_M1911C)
 				sidearm = /obj/item/weapon/gun/pistol/m1911/custom
-				sidearmbelt = /obj/item/storage/belt/gun/m4a3/m1911/commander
-				sidearmammo = /obj/item/ammo_magazine/pistol/m1911/highimpact
+				sidearmbelt = /obj/item/storage/belt/gun/m4a3
+				sidearmammo = /obj/item/ammo_magazine/pistol/m1911
 
 	var/obj/item/clothing/under/marine/reconnaissance/uniform = new()
 	var/obj/item/clothing/accessory/storage/droppouch/pouch = new()

--- a/code/modules/projectiles/magazines/pistols.dm
+++ b/code/modules/projectiles/magazines/pistols.dm
@@ -225,7 +225,7 @@
 /obj/item/ammo_magazine/pistol/heavy/super/highimpact/ap
 	name = "\improper High Impact Armor-Piercing Desert Eagle magazine (.50)"
 	desc = "Seven rounds of devastatingly powerful 50-caliber destruction. Packs a devastating punch. The bullets are tipped with an osmium-tungsten carbide alloy to not only stagger but also shred through any target's armor. Issued in few numbers due to the massive production cost and worries about hull breaches. Point away from anything you value."
-	default_ammo = /datum/ammo/bullet/pistol/heavy/highimpact/ap
+	default_ammo = /datum/ammo/bullet/pistol/deagle/highimpact/ap
 	ammo_band_color = AMMO_BAND_COLOR_AP
 
 //-------------------------------------------------------


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Partially fixes #10428

Caused by giving them a belt with the gun + ammo in, instead of an empty belt. Also gives them the non-high impact ammo, like the others guns get

Have asked Sammy if the M1911C is supposed to cause knockback for xenomorphs, else that's an easy fix.

# Explain why it's good for the game

Bugs bad


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: FORECON CO no longer gets 2 guns when they love the M1911C
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
