### PR TITLE
C4 and subtypes require adjacency to plant

### DIFF
--- a/code/game/objects/items/explosives/plastic.dm
+++ b/code/game/objects/items/explosives/plastic.dm
@@ -226,7 +226,7 @@
 	if(customizable && assembly_stage < ASSEMBLY_LOCKED)
 		return FALSE
 
-	return TRUE
+	return user.Adjacent(target)
 
 /obj/item/explosive/plastic/proc/calculate_pixel_offset(mob/user, atom/target)
 	switch(get_dir(user, target))


### PR DESCRIPTION

# About the pull request

Normally this is caught by afterattack only being called when clicking adjacently, but seemingly if you have a proc that sleeps in attack_hand (like climbing) the afterattack is delayed some amount of time, in which you could've moved.

This means you can take a stick of C4, start climbing, then walk away from the wall. This stops the climbing, but then starts trying to place the C4 on the wall, that you are no longer next to.
 
# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Further enforced adjacency requirements when planting C4 and subtypes
/:cl:
