### PR TITLE
Prevents climbing with C4 and subtypes in-hand

### DIFF
--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -25,7 +25,7 @@
 
 	var/obj/item/held_item = user.get_held_item()
 	if(istype(held_item, /obj/item/explosive/plastic))
-		to_chat(user, SPAN_WARNING("You cannot climb while holding [held_item]!"))
+		to_chat(user, SPAN_DANGER("You cannot climb while holding [held_item]!"))
 		return
 
 	if(user.action_busy)

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -23,6 +23,11 @@
 		if(possible_blocker.density)
 			return
 
+	var/obj/item/held_item = user.get_held_item()
+	if(istype(held_item, /obj/item/explosive/plastic))
+		to_chat(user, SPAN_WARNING("You cannot climb while holding [held_item]!"))
+		return
+
 	if(user.action_busy)
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This means you don't try to climb + plant C4 at the same time. 

You could accomplish this before by being on harm-intent, but if you're holding C4 you're likely trying to plant it, and not climb.

# Explain why it's good for the game

Maybe it isn't, let me know and we can close this or find a different solution. (The easiest of course being 'just be on harm-intent', but :/)
The code for this isn't very elegant either. Climbing happens before C4's afterattack, and I don't see a good way to cancel an in-progress climb via the C4 afterattack. (Not sure we'd even want that to be fair)

# Testing Photographs and Procedure
Tested by trying to climb a wall with C4 in my hands.
Didn't climb, could plant C4


# Changelog

:cl:
qol: You can no longer climb with C4 in your hands, as you're more likely to want to plant it on the wall.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
