### PR TITLE
BRUTE can no longer target bodybags / stasis bags

### DIFF
--- a/code/modules/projectiles/guns/specialist/launcher/rocket_launcher.dm
+++ b/code/modules/projectiles/guns/specialist/launcher/rocket_launcher.dm
@@ -453,7 +453,7 @@
 	if(aiming)
 		return
 
-	if(!(istype(target, /obj/structure) || istype(target,/turf/closed/wall)) )
+	if(!(istype(target, /obj/structure) && !istype(target, /obj/structure/closet/bodybag)) || istype(target,/turf/closed/wall)) )
 		to_chat(user, SPAN_WARNING("Invalid target!"))
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes #10317

# Explain why it's good for the game

While technically structures, there's no real reason to be able to shoot these.

If you do shoot them, it will delete the bag, eject the occupant, then gib them from the explosion

Less griefing potential, can't place down custom "structures" to shoot

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Can't shoot at bodybags with the BRUTE launcher
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
