### PR TITLE
Sentries now correctly process mobs inside inventories

### DIFF
--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -357,6 +357,7 @@
 	var/list/unconscious_targets = list()
 
 	for(var/atom/movable/A in targets) // orange allows sentry to fire through gas and darkness
+		var/turf/target_turf = get_turf(A)
 		if(isliving(A))
 			var/mob/living/M = A
 			if(M.stat & DEAD)
@@ -382,17 +383,17 @@
 			var/adj
 			switch(dir)
 				if(NORTH)
-					opp = x-A.x
-					adj = A.y-y
+					opp = x-target_turf.x
+					adj = target_turf.y-y
 				if(SOUTH)
-					opp = x-A.x
-					adj = y-A.y
+					opp = x-target_turf.x
+					adj = y-target_turf.y
 				if(EAST)
-					opp = y-A.y
-					adj = A.x-x
+					opp = y-target_turf.y
+					adj = target_turf.x-x
 				if(WEST)
-					opp = y-A.y
-					adj = x-A.x
+					opp = y-target_turf.y
+					adj = x-target_turf.x
 
 			var/r = 9999
 			if(adj != 0)
@@ -404,8 +405,8 @@
 				targets.Remove(A)
 				continue
 
-		var/list/turf/path = get_line(src, A, include_start_atom = FALSE)
-		if(!length(path) || get_dist(src, A) > sentry_range)
+		var/list/turf/path = get_line(src, target_turf, include_start_atom = FALSE)
+		if(!length(path) || get_dist(src, target_turf) > sentry_range)
 			if(A == target)
 				target = null
 			targets.Remove(A)


### PR DESCRIPTION
Update sentry.dm
# About the pull request

If you put a CLF member inside a closet and put them infront of the sentry, the sentry will shoot the closet as intended.

But if you then move the closet behind the (non-omnidirectional) sentry, it will keep firing.
The math assumes that the possible target has x and y coordinates.
Replaces all references to .x and .y with the .x and .y of the turf returned from calling get_turf() with the target.

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Sentries will correctly handle mobs in inventories.
/:cl:
