### PR TITLE
Fixes an infinite metal glitch involving walls

### DIFF
--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -563,6 +563,8 @@
 				playsound(src, 'sound/items/Crowbar.ogg', 25, 1)
 				if(!do_after(user, 60 * user.get_skill_duration_multiplier(SKILL_CONSTRUCTION), INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 					return
+				if(!istype(src, /turf/closed/wall))
+					return
 				user.visible_message(SPAN_NOTICE("[user] pries apart the connecting rods."), SPAN_NOTICE("You pry apart the connecting rods."))
 				new /obj/item/stack/rods(src)
 				dismantle_wall()


### PR DESCRIPTION

# About the pull request

Fixes #9261

Turns into /turf/open/plating then runtimes for every click past the first one, but not before generating 1 metal rod.

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Can no longer extract infinite metal from walls
/:cl:
