### PR TITLE
Fixes Central overwatch not showing correct rank for Lt.Col+

### DIFF
--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -274,7 +274,7 @@ GLOBAL_LIST_EMPTY_TYPED(active_overwatch_consoles, /obj/structure/machinery/comp
 				role = marine_human.job
 			else if(card?.rank) //decapitated marine is mindless,
 				role = card.rank
-				rank = card.paygrade
+			rank = card?.paygrade
 
 			if(current_squad.squad_leader)
 				if(marine_human == current_squad.squad_leader)
@@ -445,7 +445,7 @@ GLOBAL_LIST_EMPTY_TYPED(active_overwatch_consoles, /obj/structure/machinery/comp
 			role = marine_human.job
 		else if(card?.rank) //decapitated marine is mindless,
 			role = card.rank
-			rank = card.paygrade
+		rank = card?.paygrade
 
 
 

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -478,7 +478,7 @@ GLOBAL_LIST_EMPTY_TYPED(active_overwatch_consoles, /obj/structure/machinery/comp
 				if(mob_state != "Dead")
 					so_alive++
 
-		var/marine_data = list(list("name" = mob_name, "state" = mob_state, "has_helmet" = has_helmet, "role" = role, "area_name" = area_name, "ref" = REF(marine)))
+		var/marine_data = list(list("name" = mob_name, "state" = mob_state, "has_helmet" = has_helmet, "role" = role, "area_name" = area_name, "ref" = REF(marine), "rank" = rank))
 		data["marines"] += marine_data
 
 	data["total_deployed"] = co_count + xo_count + so_count

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -240,6 +240,7 @@ GLOBAL_LIST_EMPTY_TYPED(active_overwatch_consoles, /obj/structure/machinery/comp
 		var/mob_state = ""
 		var/has_helmet = TRUE
 		var/role = "unknown"
+		var/rank = "unknown"
 		var/acting_sl = ""
 		var/fteam = ""
 		var/distance = "???"
@@ -273,6 +274,7 @@ GLOBAL_LIST_EMPTY_TYPED(active_overwatch_consoles, /obj/structure/machinery/comp
 				role = marine_human.job
 			else if(card?.rank) //decapitated marine is mindless,
 				role = card.rank
+				rank = card.paygrade
 
 			if(current_squad.squad_leader)
 				if(marine_human == current_squad.squad_leader)
@@ -360,7 +362,7 @@ GLOBAL_LIST_EMPTY_TYPED(active_overwatch_consoles, /obj/structure/machinery/comp
 				if(mob_state != "Dead")
 					marines_alive++
 
-		var/marine_data = list(list("name" = mob_name, "state" = mob_state, "has_helmet" = has_helmet, "role" = role, "acting_sl" = acting_sl, "fteam" = fteam, "distance" = distance, "area_name" = area_name,"ref" = REF(marine)))
+		var/marine_data = list(list("name" = mob_name, "state" = mob_state, "has_helmet" = has_helmet, "role" = role, "acting_sl" = acting_sl, "fteam" = fteam, "distance" = distance, "area_name" = area_name,"ref" = REF(marine), "rank" = rank))
 		data["marines"] += marine_data
 		if(is_squad_leader)
 			if(!data["squad_leader"])
@@ -413,6 +415,8 @@ GLOBAL_LIST_EMPTY_TYPED(active_overwatch_consoles, /obj/structure/machinery/comp
 		var/mob_state = ""
 		var/has_helmet = TRUE
 		var/role = "unknown"
+		var/rank = "unknown"
+
 		var/area_name = "???"
 		var/mob/living/carbon/human/marine_human
 
@@ -441,6 +445,9 @@ GLOBAL_LIST_EMPTY_TYPED(active_overwatch_consoles, /obj/structure/machinery/comp
 			role = marine_human.job
 		else if(card?.rank) //decapitated marine is mindless,
 			role = card.rank
+			rank = card.paygrade
+
+
 
 		switch(marine_human.stat)
 			if(CONSCIOUS)

--- a/tgui/packages/tgui/interfaces/CentralOverwatchConsole.tsx
+++ b/tgui/packages/tgui/interfaces/CentralOverwatchConsole.tsx
@@ -1124,9 +1124,12 @@ const CommandMonitor = (props) => {
   let { marines } = data;
 
   const rankFinder = {
-    'Commanding Officer': 'MAJ. ',
-    'Executive Officer': 'CAPT. ',
-    'Staff Officer': 'LT. ',
+    MO6: 'COL. ',
+    MO5: 'LT COL. ',
+    MO4: 'MAJ. ',
+    MO3: 'CAPT. ',
+    MO2: 'LT. ',
+    MO1: 'LT. ',
   };
 
   let determine_status_color = (status) => {
@@ -1199,7 +1202,7 @@ const CommandMonitor = (props) => {
                       pb="15px"
                       align="center"
                     >
-                      {rankFinder[marine.role] + marine.name.toUpperCase()}
+                      {rankFinder[marine.rank] + marine.name.toUpperCase()}
                     </Box>
                   </Flex.Item>
                   <Flex.Item textAlign="end" align="center">

--- a/tgui/packages/tgui/interfaces/CentralOverwatchConsole.tsx
+++ b/tgui/packages/tgui/interfaces/CentralOverwatchConsole.tsx
@@ -23,6 +23,7 @@ type MarineData = {
   state: string;
   has_helmet: BooleanLike;
   role: string;
+  rank: string;
   acting_sl: string;
   fteam: string;
   distance: string;


### PR DESCRIPTION

# About the pull request

Poor CO council and senator....

# Explain why it's good for the game
<img width="617" height="117" alt="image" src="https://github.com/user-attachments/assets/d9e9bd2c-daf4-41d7-9ef5-7fa3281c69b5" />

<img width="629" height="72" alt="image" src="https://github.com/user-attachments/assets/baf37d4f-ed05-4b35-9d50-fff1df891a49" />

<img width="623" height="79" alt="image" src="https://github.com/user-attachments/assets/7f585bca-8593-4688-bc5c-8ce401de384a" />


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: The Overwatch console now properly adresses the ranks of Lt.Col+
/:cl:
