### PR TITLE
Tweak acid fill

### DIFF
--- a/code/modules/cm_aliens/structures/trap.dm
+++ b/code/modules/cm_aliens/structures/trap.dm
@@ -224,7 +224,7 @@
 		to_chat(xeno, SPAN_XENONOTICE("Better not risk setting this off."))
 		return XENO_NO_DELAY_ACTION
 
-	if(!xeno.try_fill_trap(src))
+	if(xeno.try_fill_trap(src))
 		return XENO_NO_DELAY_ACTION
 
 /obj/effect/alien/resin/trap/proc/setup_tripwires()

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -331,7 +331,7 @@
 		return FALSE
 
 	if(!acid_level)
-		to_chat(src, SPAN_XENONOTICE("You can't secrete any acid into [target]"))
+		to_chat(src, SPAN_XENONOTICE("You can't secrete any acid into [target]."))
 		return FALSE
 
 	var/trap_acid_level = 0

--- a/code/modules/mob/living/carbon/xenomorph/castes/Boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Boiler.dm
@@ -287,7 +287,7 @@
 		return FALSE
 
 	if(!acid_level)
-		to_chat(src, SPAN_XENONOTICE("You can't secrete any acid into [target]"))
+		to_chat(src, SPAN_XENONOTICE("You can't secrete any acid into [target]."))
 		return FALSE
 
 	var/trap_acid_level = 0


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #10250 making it so filling a trap doesn't swipe (only failing will swipe) and adds a couple missing punctuation.

# Explain why it's good for the game

Maintains old behavior.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/user-attachments/assets/dfec4098-c9eb-4328-a7d4-4c1d21d5d7d6

</details>


# Changelog
:cl: Drathek
fix: Filling an acid trap successfully no longer swipes at it
/:cl:
