### PR TITLE
forecon crew monitor

### DIFF
--- a/code/__DEFINES/job.dm
+++ b/code/__DEFINES/job.dm
@@ -138,7 +138,6 @@ GLOBAL_LIST_INIT(job_command_roles, JOB_COMMAND_ROLES_LIST)
 #define JOB_CMC "Commandant of the Marine Corps"
 #define JOB_PLT_MED "Platoon Corpsman"
 #define JOB_PLT_SL "Platoon Squad Leader"
-#define JOB_SQUAD_TECH "Reconnaissance Support Technician"
 
 // Used to add a timelock to a job. Will be passed onto derivatives
 #define AddTimelock(Path, timelockList) \

--- a/code/datums/factions/uscm.dm
+++ b/code/datums/factions/uscm.dm
@@ -49,7 +49,7 @@
 				marine_rk = "soctl"
 			if(JOB_MARINE_RAIDER_CMD)
 				marine_rk = "soccmd"
-			if(JOB_SQUAD_TECH)
+			if(JOB_FORECON_SUPPORT)
 				marine_rk = "tech"
 		if(squad.squad_leader == current_human)
 			switch(squad.squad_type)
@@ -117,7 +117,7 @@
 				marine_rk = "med"
 			if(JOB_PLT_SL)
 				marine_rk = "leader"
-			if(JOB_SQUAD_TECH)
+			if(JOB_FORECON_SUPPORT)
 				marine_rk = "tech"
 			if(JOB_INTEL)
 				marine_rk = "io"

--- a/code/game/jobs/job/special/uscm.dm
+++ b/code/game/jobs/job/special/uscm.dm
@@ -16,4 +16,4 @@
 	title = JOB_RIOT_CHIEF
 
 /datum/job/special/uscm/tech
-	title = JOB_SQUAD_TECH
+	title = JOB_FORECON_SUPPORT

--- a/code/modules/cm_marines/marines_consoles.dm
+++ b/code/modules/cm_marines/marines_consoles.dm
@@ -1015,17 +1015,17 @@ GLOBAL_LIST_EMPTY_TYPED(crew_monitor, /datum/crewmonitor)
 				JOB_CHIEF_REQUISITION = 60,
 				JOB_CARGO_TECH = 61,
 				JOB_MESS_SERGEANT = 62,
-				// 70-139: SQUADS (look below)
+				// 70-149: SQUADS (look below)
 				JOB_SYNTH_K9 = 71,
-				// 140+: Civilian/other
-				JOB_CORPORATE_LIAISON = 140,
-				JOB_CIA = 141,
-				JOB_PASSENGER = 142,
+				// 150+: Civilian/other
+				JOB_CORPORATE_LIAISON = 150,
+				JOB_CIA = 151,
+				JOB_PASSENGER = 152,
 				// Non Almayer jobs lower then registered
-				JOB_SYNTH_SURVIVOR = 150,
-				JOB_SURVIVOR = 151,
-				JOB_COLONIST = 152,
-				JOB_WORKING_JOE = 153,
+				JOB_SYNTH_SURVIVOR = 160,
+				JOB_SURVIVOR = 161,
+				JOB_COLONIST = 162,
+				JOB_WORKING_JOE = 163,
 
 				// WO jobs
 				// 10-19: Command
@@ -1048,10 +1048,10 @@ GLOBAL_LIST_EMPTY_TYPED(crew_monitor, /datum/crewmonitor)
 				// 60-69: Cargo
 				JOB_WO_CHIEF_REQUISITION = 60,
 				JOB_WO_REQUISITION = 61,
-				// 70-139: SQUADS (look below)
-				// 140+: Civilian/other
-				JOB_WO_CORPORATE_LIAISON = 140,
-				JOB_WO_SYNTH = 150,
+				// 70-149: SQUADS (look below)
+				// 150+: Civilian/other
+				JOB_WO_CORPORATE_LIAISON = 150,
+				JOB_WO_SYNTH = 160,
 
 				// ANYTHING ELSE = UNKNOWN_JOB_ID, Unknowns/custom jobs will appear after civilians, and before stowaways
 				JOB_STOWAWAY = 999,
@@ -1080,6 +1080,15 @@ GLOBAL_LIST_EMPTY_TYPED(crew_monitor, /datum/crewmonitor)
 				RAIDER_SL_SQUAD = 130,
 				JOB_MARINE_RAIDER = 131,
 				RAIDER_SQUAD = 131,
+
+				JOB_FORECON_CO = 140,
+				JOB_FORECON_SL = 140,
+				JOB_FORECON_SNIPER = 141,
+				JOB_FORECON_MARKSMAN = 142,
+				JOB_FORECON_SMARTGUNNER = 143,
+				JOB_FORECON_SUPPORT = 144,
+				JOB_FORECON_RIFLEMAN = 145,
+				JOB_FORECON_SYN = 146,
 			)
 			var/squad_number = 70
 			for(var/squad_name in GLOB.ROLES_SQUAD_ALL + "")

--- a/code/modules/gear_presets/uscm_forecon.dm
+++ b/code/modules/gear_presets/uscm_forecon.dm
@@ -119,7 +119,7 @@
 /datum/equipment_preset/uscm/forecon/tech
 	name = "USCM Reconnaissance Support Technician"
 	assignment = JOB_FORECON_SUPPORT
-	job_title = JOB_SQUAD_TECH
+	job_title = JOB_FORECON_SUPPORT
 	role_comm_title = "SuppTech"
 	minimap_icon = "engi"
 	skills = /datum/skills/military/survivor/forecon_techician

--- a/tgui/packages/tgui/constants.ts
+++ b/tgui/packages/tgui/constants.ts
@@ -46,6 +46,7 @@ export const COLORS = {
     echo: '#027d02',
     foxtrot: '#4a4740',
     raiders: '#6e1919',
+    forecon: '#32CD32',
   },
   // Damage type colors
   damageType: {

--- a/tgui/packages/tgui/interfaces/CrewConsole.tsx
+++ b/tgui/packages/tgui/interfaces/CrewConsole.tsx
@@ -68,6 +68,9 @@ const jobToColor = (jobId) => {
   if (jobId >= 130 && jobId < 140) {
     return COLORS.shipDeps.raiders;
   }
+  if (jobId >= 140 && jobId < 150) {
+    return COLORS.shipDeps.forecon;
+  }
   if (jobId >= 200 && jobId < 230) {
     return COLORS.department.centcom;
   }


### PR DESCRIPTION

# About the pull request

Puts forecon on the crew monitor.

# Explain why it's good for the game

They're on the monitor by default due to faction settings, but they all appear in a jumble at the bottom.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Added designated Forecon listing on the crew monitor.
/:cl:
