### PR TITLE
Make Sorokyne South LZ weedkiller bigger

### DIFF
--- a/code/game/area/strata.dm
+++ b/code/game/area/strata.dm
@@ -134,6 +134,7 @@
 /area/strata/interior/vanyard
 	name = "Flight Control Vehicle Yard"
 	icon_state = "garage"
+	linked_lz = DROPSHIP_LZ2
 
 /area/strata/exterior/tcomms_mining_caves
 	name = "Mining Pathway Relay"
@@ -142,6 +143,7 @@
 /area/strata/exterior/tcomms_vehicle_yard
 	name = "Vehicle Yard Relay"
 	icon_state = "tcomms1"
+	linked_lz = DROPSHIP_LZ2
 
 //-Outpost
 
@@ -314,6 +316,7 @@
 /area/strata/interior/checkpoints/south
 	name = "Landing Zone South Security Checkpoint"
 	is_landing_zone = TRUE
+	linked_lz = DROPSHIP_LZ2
 
 /area/strata/interior/checkpoints/outpost
 	name = "Outpost - Deck Security Checkpoint"
@@ -324,6 +327,7 @@
 /area/strata/interior/parts_storage
 	name = "Engineering - Parts Storage"
 	icon_state = "outpost_engi_1"
+	linked_lz = DROPSHIP_LZ2
 
 /area/strata/interior/generator_substation
 	name = "Engineering - Generator Substation"
@@ -335,6 +339,7 @@
 	ceiling = CEILING_UNDERGROUND_ALLOW_CAS
 	soundscape_playlist = SCAPE_PL_LV759_CAVES
 	ceiling_muffle = FALSE
+	linked_lz = DROPSHIP_LZ2
 
 /area/strata/exterior/parts_storage_cave
 	name = "Engineering - Parts Storage Exterior"


### PR DESCRIPTION

# About the pull request

Sorokyne south LZ weedkiller is really bad. It barely covers anywhere so I wanted to fix it.

# Explain why it's good for the game

making it so that weedkiller actually affects the room next to LZ that marines kinda have to go through is good

# Testing Photographs and Procedure
<img width="968" height="913" alt="Screenshot 2025-08-23 at 17 03 04" src="https://github.com/user-attachments/assets/31b5faa6-a65c-470e-b22d-2e91bfb59231" />
current sorokyne south LZ weedkiller


<img width="797" height="477" alt="Screenshot 2025-08-24 at 00 50 34" src="https://github.com/user-attachments/assets/842dbe84-af87-44ab-972b-6e22b6879730" />
what this PR changes it to
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: Sorokyne LZ2 weedkiller is bigger now
/:cl:
