### PR TITLE
Strips \improper formatting from fulton object names

### DIFF
--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -1267,7 +1267,7 @@
 			continue
 		var/recovery_object
 		if(fulton.attached_atom)
-			recovery_object = fulton.attached_atom.name
+			recovery_object = strip_improper(fulton.attached_atom.name)
 		else
 			recovery_object = "Empty"
 		.["[recovery_object]"] = fulton


### PR DESCRIPTION

# About the pull request

Applies strip_improper() to objects being added to the fulton targets list

Fixes #6531

# Explain why it's good for the game

Runtimes are bad.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

<img width="580" height="521" alt="image" src="https://github.com/user-attachments/assets/d28185ea-9164-4585-a0da-91399c81a7d9" />

<img width="431" height="329" alt="image" src="https://github.com/user-attachments/assets/269e6df7-5964-4d34-ada8-5c438bd2d2d7" />

</details>


# Changelog

:cl:
fix: fixed a runtime caused by fulton name formatting
/:cl:
