### PR TITLE
Huggers and being nested while infected purges stims

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Embryo.dm
@@ -17,6 +17,8 @@
 	/// The total time the person is hugged divided by stages until burst
 	var/per_stage_hugged_time = 90 //Set in Initialize due to config
 
+	var/stim_drain = 5
+
 /obj/item/alien_embryo/Initialize(mapload, ...)
 	. = ..()
 	per_stage_hugged_time = CONFIG_GET(number/embryo_burst_timer) / 5
@@ -84,8 +86,11 @@
 	var/datum/hive_status/hive = GLOB.hive_datum[hivenumber]
 
 	var/is_nested = HAS_TRAIT(affected_mob, TRAIT_NESTED)
-	if(is_nested && !(affected_mob.stat & DEAD) && stage <= 3 && affected_mob.reagents && affected_mob.reagents.get_reagent_amount("host_stabilizer") < 1)
-		affected_mob.reagents.add_reagent("host_stabilizer", 1)
+	if(is_nested && !(affected_mob.stat & DEAD) && stage <= 3 && affected_mob.reagents)
+		if(affected_mob.reagents.get_reagent_amount("host_stabilizer") < 1)
+			affected_mob.reagents.add_reagent("host_stabilizer", 1)
+		for(var/datum/reagent/generated/stim in affected_mob.reagents.reagent_list)
+			affected_mob.reagents.remove_reagent(stim.id, stim_drain, TRUE)
 
 	//Low temperature seriously hampers larva growth (as in, way below livable), so does stasis
 	if(!hive.hardcore) // Cannot progress if the hive has entered hardcore mode.

--- a/code/modules/mob/living/carbon/xenomorph/Embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Embryo.dm
@@ -16,8 +16,8 @@
 	var/hugger_ckey
 	/// The total time the person is hugged divided by stages until burst
 	var/per_stage_hugged_time = 90 //Set in Initialize due to config
-
-	var/stim_drain = 5
+	/// How How many units of stims are drained per tick
+	var/stim_drain = 2
 
 /obj/item/alien_embryo/Initialize(mapload, ...)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -38,6 +38,7 @@
 	var/hivenumber = XENO_HIVE_NORMAL
 	var/flags_embryo = NO_FLAGS
 	var/impregnated = FALSE
+	var/stim_drain = 30 // Value refers to units of chem
 
 	/// The timer for the hugger to jump
 	/// at the nearest human
@@ -314,6 +315,8 @@
 	if(!sterile)
 		if(!human.species || !(human.species.flags & IS_SYNTHETIC)) //synthetics aren't paralyzed
 			human.apply_effect(MIN_IMPREGNATION_TIME * 0.5 * knockout_mod, PARALYZE) //THIS MIGHT NEED TWEAKS
+			for(var/datum/reagent/generated/stim in human.reagents.reagent_list) // Cause fuck 'em stims, boah
+				human.reagents.remove_reagent(stim.id, stim_drain, TRUE)
 
 	var/area/hug_area = get_area(src)
 	var/name = hugger ? "[hugger]" : "\a [src]"

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -38,7 +38,8 @@
 	var/hivenumber = XENO_HIVE_NORMAL
 	var/flags_embryo = NO_FLAGS
 	var/impregnated = FALSE
-	var/stim_drain = 30 // Value refers to units of chem
+	/// How many units of stims are drained upon hugging
+	var/stim_drain = 30
 
 	/// The timer for the hugger to jump
 	/// at the nearest human


### PR DESCRIPTION
# About the pull request

Huggers will purge stims upon hugging someone, and being nested while infected will purge stims until level 4+.

# Explain why it's good for the game

Xenos don't like dealing with stimmed up marines and have quite limited means to. This adds additional means that are nicely integrated into the main loops of Hugging and Capturing.

# Testing Photographs and Procedure

Yoinked my own code known to work and shoved it in/next to similarly known-to-work code, used breakpoints to doublecheck further if it works and it does.

# Changelog

:cl: Killfish
balance: Huggers purge 30u of stims upon hugging someone.
balance: Being nested while infected and below stage 4 purges 2u of stims per tick.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
