### PR TITLE
Cryo Break Msg Fix

### DIFF
--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -203,7 +203,7 @@
 	health = max(0, health - damage)
 
 	if(health == 0)
-		visible_message(loc, SPAN_DANGER("[src] shatters!"))
+		visible_message(SPAN_DANGER("[src] shatters!"))
 		deconstruct(FALSE)
 		return TRUE
 


### PR DESCRIPTION

# About the pull request

Fixes the breaking message for decorative cryo tank.

# Explain why it's good for the game

bugfixes are nice

# Changelog

:cl:
fix: cryotanks breaking no longer say "The floor"
/:cl:
