### PR TITLE
Allows Queen Eye to look into tents

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -116,6 +116,8 @@
 	med_hud_set_status()
 	add_to_all_mob_huds()
 
+	hud_used = Q.hud_used
+
 	Q.sight |= SEE_TURFS|SEE_OBJS
 
 /mob/hologram/queen/proc/exit_hologram()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes #3678 

Passes Queen hud to the hud_used variable in Queen Eye, thereby preventing a runtime.

# Explain why it's good for the game

Runtimes are bad

# Testing Photographs and Procedure

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

<img width="309" height="283" alt="image" src="https://github.com/user-attachments/assets/24773df3-9047-4111-9af0-62284cc6ae8d" />
<img width="938" height="414" alt="image" src="https://github.com/user-attachments/assets/6e0931f6-a9a1-41aa-9b91-05ff993cf4ca" />


</details>


# Changelog

:cl:
fix: Queen eye can now peep into tents
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
