### PR TITLE
Fixes akimbo firing

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1133,6 +1133,9 @@ and you're good to go.
 /obj/item/weapon/gun/proc/Fire(atom/target, mob/living/user, params, reflex = FALSE, dual_wield)
 	set waitfor = FALSE
 
+	if(!gun_user)
+		gun_user = user
+
 	if(!able_to_fire(user) || !target || !get_turf(user) || !get_turf(target))
 		return NONE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Sets gun_user for a gun upon being fired, assuming it isn't already set.

Fixes #10399

# Explain why it's good for the game

Firing akimbo is pretty cool, and runtimes are not.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

m4a3
<img width="517" height="368" alt="image" src="https://github.com/user-attachments/assets/51438d34-6cd5-4cb8-bbad-6de37bb656ed" />

HPR
<img width="440" height="142" alt="image" src="https://github.com/user-attachments/assets/ea985156-ecf0-4f62-bb5b-c10094ce64ea" />


</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Firing your guns akimbo is once again possible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
