### PR TITLE
Airlocks fire sparks when electrocuted 

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -312,6 +312,10 @@ GLOBAL_LIST_INIT(airlock_wire_descriptions, list(
 
 /obj/structure/machinery/door/airlock/proc/isElectrified()
 	if(secondsElectrified != 0)
+		addtimer(CALLBACK( src, PROC_REF(isElectrified)), 6 SECONDS)
+		var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
+		sparks.set_up(5, 1, src)
+		sparks.start()
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
# About the pull request

Title, when electrocuted airlocks will pulse sparks every six seconds.
6 seconds still leaves some decent downtime between sparks existing, meaning impatient xenos may still fall for the trap. They'll still serve as a lengthy deterrent no matter what.
# Explain why it's good for the game
Communicates gameplay features to new players instead of them inexplicably dying to cheese they had no opportunity to know about. 

# Testing Photographs and Procedure
4 line addition
# Changelog

:cl:
balance: airlocks fire sparks every 6 seconds when electrocuted
/:cl: