### PR TITLE
Fixes curtain code to actually support transparent curtains

### DIFF
--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -5,6 +5,8 @@
 	layer = ABOVE_MOB_LAYER
 	opacity = TRUE
 	density = FALSE
+	var/open = FALSE
+	var/transparent = FALSE
 
 /obj/structure/curtain/open/New()
 	..()
@@ -29,13 +31,15 @@
 	return XENO_ATTACK_ACTION
 
 /obj/structure/curtain/proc/toggle()
-	opacity = !opacity
-	if(opacity)
-		icon_state = "[initial(icon_state)]"
-		layer = ABOVE_MOB_LAYER
-	else
+	open = !open
+	if(!transparent)
+		opacity = !opacity
+	if(open)
 		icon_state = "[initial(icon_state)]-o"
 		layer = OBJ_LAYER
+	else
+		icon_state = "[initial(icon_state)]"
+		layer = ABOVE_MOB_LAYER
 
 /obj/structure/curtain/shower
 	name = "shower curtain"
@@ -96,6 +100,7 @@
 	name = "blinds"
 	icon_state = "colorable_transparent"
 	alpha = 200
+	transparent = TRUE
 
 // Open
 
@@ -107,6 +112,7 @@
 	name = "blinds"
 	icon_state = "colorable_transparent"
 	alpha = 200
+	transparent = TRUE
 
 /obj/structure/curtain/open/red
 	name = "red curtain"
@@ -131,5 +137,5 @@
 
 /obj/structure/curtain/Initialize()
 	. = ..()
-	if(alpha)
-		set_opacity(1)
+	if(transparent)
+		set_opacity(0)


### PR DESCRIPTION
# About the pull request

Fixes #10498 

Curtain code works based on opacity. A closed curtain spawns with an opacity of 0, and a closed sprite. An open curtain spawns the exact same way, but applies a toggle() immediately. 

In adding transparent curtains, the original author attempted to define an alpha value for them, and then make the curtains transparent if this value is present. Unfortunately. all curtains inherit an alpha value, which meant all curtains were being made transparent. This is fixed by clicking the curtain, which cycles the opacity, and thus sets the correct sprite for the opacity. However, this also cycles the opacity for transparent curtains, which makes them opaque. 

This PR changes curtain code to enable curtains to open/close without relying on opacity to store that value.

# Explain why it's good for the game

Open curtains shouldn't start off closed, and closed curtains shouldn't start off open. And transparent curtains should probably be transparent, too.


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Before:
<img width="322" height="487" alt="image" src="https://github.com/user-attachments/assets/d2a08340-7e9c-44b1-91b7-27df3449d606" />
<img width="530" height="583" alt="image" src="https://github.com/user-attachments/assets/1c03e330-0683-43a7-b0f7-bf09fef00bd9" />

After:
<img width="411" height="585" alt="image" src="https://github.com/user-attachments/assets/42979eee-1a48-47d6-b5c4-32f5f086c81b" />
<img width="539" height="482" alt="image" src="https://github.com/user-attachments/assets/1e5ffb48-9d60-4551-80de-4acd26458c9c" />
colorable_transparent:
<img width="444" height="544" alt="image" src="https://github.com/user-attachments/assets/95ef859f-a99a-4586-9dff-57eab1c591d3" />


</details>


# Changelog
:cl:
fix: Curtains block view without prior encouragement.
fix: Transparent curtains remain transparent, even when opened and closed.
/:cl:
