### PR TITLE
Fixes disposals components linking to nowhere

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -67,6 +67,9 @@
 /obj/structure/machinery/disposal/Destroy()
 	if(length(contents))
 		eject()
+	var/obj/structure/disposalpipe/trunk/T = trunk
+	if(T)
+		T.linked = null
 	trunk = null
 	return ..()
 
@@ -1265,6 +1268,9 @@
 	getlinked()
 
 /obj/structure/disposalpipe/trunk/Destroy()
+	var/obj/structure/machinery/disposal/D = linked
+	if(istype(D, /obj/structure/machinery/disposal))
+		D.trunk = null
 	linked = null
 	return ..()
 
@@ -1372,6 +1378,12 @@
 	var/obj/structure/disposalpipe/trunk/trunk = locate() in loc
 	if(trunk)
 		trunk.linked = src //Link the pipe trunk to self
+
+/obj/structure/disposaloutlet/Destroy()
+	var/obj/structure/disposalpipe/trunk/trunk = locate() in loc //Outlets don't record the trunk they're linked to, so we need to find it again.
+	if(trunk)
+		trunk.linked = null
+	return ..()
 
 //Expel the contents of the holder object, then delete it. Called when the holder exits the outlet
 /obj/structure/disposaloutlet/proc/expel(obj/structure/disposalholder/H)


### PR DESCRIPTION

# About the pull request

Fixes #10406

This PR adds logic to the destroy() procs of some disposals components that clear the linkage to and from a trunk, at both ends.

# Explain why it's good for the game

Trunks/disposal bins/outlets should unlink themselves from connected parts of the network upon destruction.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

After deleting outlet:
<img width="722" height="596" alt="image" src="https://github.com/user-attachments/assets/f6534a39-d8cd-48a6-8b81-f78bddaa21e4" />
After deleting trunk:
<img width="694" height="425" alt="image" src="https://github.com/user-attachments/assets/f359bb18-fb95-453f-829a-be3f7443cc43" />
After deleting bin:
<img width="648" height="338" alt="image" src="https://github.com/user-attachments/assets/c931547c-8ac5-46c2-b844-6f0336a62319" />



</details>


# Changelog

:cl:
fix: destroying parts of the disposal network will no longer send your items to nullspace
/:cl:
