### PR TITLE
More CO surv stopgaps

### DIFF
--- a/code/game/objects/effects/landmarks/survivor_spawner.dm
+++ b/code/game/objects/effects/landmarks/survivor_spawner.dm
@@ -326,6 +326,7 @@
 /obj/effect/landmark/survivor_spawner/lv624_corporate_dome_cl
 	icon_state = "surv_wy"
 	equipment = /datum/equipment_preset/survivor/corporate/executive
+	CO_equipment = /datum/equipment_preset/survivor/corporate/executive
 	synth_equipment = /datum/equipment_preset/synth/survivor/wy/security_synth
 	intro_text = list("<h2>You are the last alive Executive of Lazarus Landing!</h2>",\
 	"<span class='notice'>You are aware of the xenomorph threat.</span>",\
@@ -337,6 +338,7 @@
 /obj/effect/landmark/survivor_spawner/lv624_corporate_dome_goon
 	icon_state = "surv_wy"
 	equipment = /datum/equipment_preset/survivor/goon
+	CO_equipment = /datum/equipment_preset/survivor/goon/lead
 	synth_equipment = /datum/equipment_preset/synth/survivor/wy/security_synth
 	intro_text = list("<h2>You are a Corporate Security Officer!</h2>",\
 	"<span class='notice'>You are aware of the xenomorph threat.</span>",\
@@ -348,6 +350,7 @@
 /obj/effect/landmark/survivor_spawner/lv624_corporate_dome_goon_medic
 	icon_state = "surv_wy"
 	equipment = /datum/equipment_preset/survivor/goon/medic
+	CO_equipment = /datum/equipment_preset/survivor/goon/medic
 	synth_equipment = /datum/equipment_preset/synth/survivor/wy/security_synth
 	intro_text = list("<h2>You are a Corporate Security Medic!</h2>",\
 	"<span class='notice'>You are aware of the xenomorph threat.</span>",\
@@ -359,6 +362,7 @@
 /obj/effect/landmark/survivor_spawner/lv624_corporate_dome_goon_engi
 	icon_state = "surv_wy"
 	equipment = /datum/equipment_preset/survivor/goon/engineer
+	CO_equipment = /datum/equipment_preset/survivor/goon/engineer
 	synth_equipment = /datum/equipment_preset/synth/survivor/wy/security_synth
 	intro_text = list("<h2>You are a Corporate Security Technician!</h2>",\
 	"<span class='notice'>You are aware of the xenomorph threat.</span>",\
@@ -370,6 +374,7 @@
 /obj/effect/landmark/survivor_spawner/lv624_corporate_dome_goon_lead
 	icon_state = "surv_wy"
 	equipment = /datum/equipment_preset/survivor/goon/lead
+	CO_equipment = /datum/equipment_preset/survivor/goon/lead
 	synth_equipment = /datum/equipment_preset/synth/survivor/wy/security_synth
 	intro_text = list("<h2>You are a Corporate Security Lead!</h2>",\
 	"<span class='notice'>You are aware of the xenomorph threat.</span>",\

--- a/code/game/objects/effects/landmarks/survivor_spawner.dm
+++ b/code/game/objects/effects/landmarks/survivor_spawner.dm
@@ -458,6 +458,7 @@
 /obj/effect/landmark/survivor_spawner/shivas_panic_room_commando
 	icon_state = "surv_wy"
 	equipment = /datum/equipment_preset/survivor/pmc/commando_shivas
+	CO_equipment = /datum/equipment_preset/survivor/pmc/commando_shivas
 	intro_text = list("<h2>You are the last living security element on the Colony!</h2>",\
 	"<span class='notice'>You are aware of the xenomorph threat.</span>",\
 	"<span class='danger'>Your primary objective is to survive the outbreak.</span>")
@@ -468,6 +469,7 @@
 /obj/effect/landmark/survivor_spawner/shivas_panic_room_cl
 	icon_state = "surv_wy"
 	equipment = /datum/equipment_preset/survivor/corporate/asstmanager
+	CO_equipment = /datum/equipment_preset/survivor/corporate/asstmanager
 	synth_equipment = /datum/equipment_preset/synth/survivor/wy/corporate_synth
 	intro_text = list("<h2>You are the last alive Senior Administrator on the Colony!</h2>",\
 	"<span class='notice'>You are aware of the xenomorph threat.</span>",\
@@ -479,6 +481,7 @@
 /obj/effect/landmark/survivor_spawner/shivas_panic_room_doc
 	icon_state = "surv_wy"
 	equipment = /datum/equipment_preset/survivor/doctor/shiva
+	CO_equipment = /datum/equipment_preset/survivor/doctor/shiva
 	synth_equipment = /datum/equipment_preset/synth/survivor/emt_synth_teal
 	intro_text = list("<h2>You are a Medical Doctor on the Colony!</h2>",\
 	"<span class='notice'>You are aware of the xenomorph threat.</span>",\
@@ -493,6 +496,7 @@
 /obj/effect/landmark/survivor_spawner/shivas_panic_room_eng
 	icon_state = "surv_wy"
 	equipment = /datum/equipment_preset/survivor/engineer/shiva
+	CO_equipment = /datum/equipment_preset/survivor/engineer/shiva
 	synth_equipment = /datum/equipment_preset/synth/survivor/engineer_synth
 	intro_text = list("<h2>You are an Engineer on the Colony!</h2>",\
 	"<span class='notice'>You are aware of the xenomorph threat.</span>",\
@@ -507,6 +511,7 @@
 /obj/effect/landmark/survivor_spawner/shivas_panic_room_sci
 	icon_state = "surv_wy"
 	equipment = /datum/equipment_preset/survivor/scientist/shiva
+	CO_equipment = /datum/equipment_preset/survivor/scientist/shiva
 	synth_equipment = /datum/equipment_preset/synth/survivor/scientist_synth
 	intro_text = list("<h2>You are a Weyland-Yutani Scientist on the Colony!</h2>",\
 	"<span class='notice'>You are aware of the xenomorph threat.</span>",\
@@ -520,6 +525,7 @@
 
 /obj/effect/landmark/survivor_spawner/shivas_panic_room_civ
 	equipment = /datum/equipment_preset/survivor/civilian
+	CO_equipment = /datum/equipment_preset/survivor/civilian
 	synth_equipment = /datum/equipment_preset/synth/survivor/chef_synth
 	intro_text = list("<h2>You are a worker on the Colony!</h2>",\
 	"<span class='notice'>You are aware of the xenomorph threat.</span>",\
@@ -532,6 +538,7 @@
 
 /obj/effect/landmark/survivor_spawner/fiorina_armory_cmb
 	equipment = /datum/equipment_preset/survivor/cmb/riot
+	CO_equipment = /datum/equipment_preset/survivor/cmb/riot
 	synth_equipment = /datum/equipment_preset/synth/survivor/cmb/riotsynth
 	intro_text = list("<h2>You are a CMB Riot Control Officer!</h2>",\
 	"<span class='notice'>You are aware of the 'alien' threat.</span>",\
@@ -542,6 +549,7 @@
 
 /obj/effect/landmark/survivor_spawner/fiorina_armory_riot_control
 	equipment = /datum/equipment_preset/survivor/cmb/ua
+	CO_equipment = /datum/equipment_preset/survivor/cmb/ua
 	synth_equipment = /datum/equipment_preset/synth/survivor/cmb/ua_synth
 	intro_text = list("<h2>You are a United Americas Riot Control Officer!</h2>",\
 	"<span class='notice'>You are aware of the 'alien' threat.</span>",\
@@ -580,6 +588,7 @@
 /obj/effect/landmark/survivor_spawner/upp/soldier
 	icon_state = "surv_upp"
 	equipment = /datum/equipment_preset/survivor/upp/soldier
+	CO_equipment = /datum/equipment_preset/survivor/upp/soldier
 	synth_equipment = /datum/equipment_preset/synth/survivor/upp
 	intro_text = list("<h2>You are a member of a UPP recon force!</h2>",\
 	"<span class='notice'>You ARE aware of the xenomorph threat.</span>",\
@@ -590,6 +599,7 @@
 /obj/effect/landmark/survivor_spawner/upp_sapper
 	icon_state = "surv_upp"
 	equipment = /datum/equipment_preset/survivor/upp/sapper
+	CO_equipment = /datum/equipment_preset/survivor/upp/sapper
 	synth_equipment = /datum/equipment_preset/synth/survivor/upp
 	intro_text = list("<h2>You are a member of a UPP recon force!</h2>",\
 	"<span class='notice'>You ARE aware of the xenomorph threat.</span>",\
@@ -600,6 +610,7 @@
 /obj/effect/landmark/survivor_spawner/upp_medic
 	icon_state = "surv_upp"
 	equipment = /datum/equipment_preset/survivor/upp/medic
+	CO_equipment = /datum/equipment_preset/survivor/upp/medic
 	synth_equipment = /datum/equipment_preset/synth/survivor/upp
 	intro_text = list("<h2>You are a member of a UPP recon force!</h2>",\
 	"<span class='notice'>You ARE aware of the xenomorph threat.</span>",\
@@ -610,6 +621,7 @@
 /obj/effect/landmark/survivor_spawner/upp_specialist
 	icon_state = "surv_upp"
 	equipment = /datum/equipment_preset/survivor/upp/specialist
+	CO_equipment = /datum/equipment_preset/survivor/upp/specialist
 	synth_equipment = /datum/equipment_preset/synth/survivor/upp
 	intro_text = list("<h2>You are a member of a UPP recon force!</h2>",\
 	"<span class='notice'>You ARE aware of the xenomorph threat.</span>",\
@@ -620,6 +632,7 @@
 /obj/effect/landmark/survivor_spawner/squad_leader
 	icon_state = "surv_upp"
 	equipment = /datum/equipment_preset/survivor/upp/squad_leader
+	CO_equipment = /datum/equipment_preset/survivor/upp/squad_leader
 	synth_equipment = /datum/equipment_preset/synth/survivor/upp
 	intro_text = list("<h2>You are a member of a UPP recon force!</h2>",\
 	"<span class='notice'>You ARE aware of the xenomorph threat.</span>",\
@@ -687,6 +700,7 @@
 
 /obj/effect/landmark/survivor_spawner/SOF_survivor/soldier
 	equipment = /datum/equipment_preset/survivor/upp/SOF_survivor/soldier
+	CO_equipment = /datum/equipment_preset/survivor/upp/SOF_survivor/soldier
 	synth_equipment = /datum/equipment_preset/synth/survivor/upp/SOF_synth
 	intro_text = list("You are a member of a UPP SOF QRF team!",\
 	"<span class='notice'>You ARE aware of the xenomorph threat.</span>",\
@@ -698,6 +712,7 @@
 
 /obj/effect/landmark/survivor_spawner/SOF_survivor/sapper
 	equipment = /datum/equipment_preset/survivor/upp/SOF_survivor/sapper
+	CO_equipment = /datum/equipment_preset/survivor/upp/SOF_survivor/sapper
 	synth_equipment = /datum/equipment_preset/synth/survivor/upp/SOF_synth
 	intro_text = list("You are a member of a UPP SOF QRF team!",\
 	"<span class='notice'>You ARE aware of the xenomorph threat.</span>",\
@@ -709,6 +724,7 @@
 
 /obj/effect/landmark/survivor_spawner/SOF_survivor/medic
 	equipment = /datum/equipment_preset/survivor/upp/SOF_survivor/medic
+	CO_equipment = /datum/equipment_preset/survivor/upp/SOF_survivor/medic
 	synth_equipment = /datum/equipment_preset/synth/survivor/upp/SOF_synth
 	intro_text = list("You are a member of a UPP SOF QRF team!",\
 	"<span class='notice'>You ARE aware of the xenomorph threat.</span>",\
@@ -720,6 +736,7 @@
 
 /obj/effect/landmark/survivor_spawner/SOF_survivor/specialist
 	equipment = /datum/equipment_preset/survivor/upp/SOF_survivor/specialist
+	CO_equipment = /datum/equipment_preset/survivor/upp/SOF_survivor/specialist
 	synth_equipment = /datum/equipment_preset/synth/survivor/upp/SOF_synth
 	intro_text = list("You are a member of a UPP SOF QRF team!",\
 	"<span class='notice'>You ARE aware of the xenomorph threat.</span>",\
@@ -731,6 +748,7 @@
 
 /obj/effect/landmark/survivor_spawner/SOF_survivor/squad_leader
 	equipment = /datum/equipment_preset/survivor/upp/SOF_survivor/squad_leader
+	CO_equipment = /datum/equipment_preset/survivor/upp/SOF_survivor/squad_leader
 	synth_equipment = /datum/equipment_preset/synth/survivor/upp/SOF_synth
 	intro_text = list("You are a member of a UPP SOF QRF team!",\
 	"<span class='notice'>You ARE aware of the xenomorph threat.</span>",\


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

adds co equip overrides to literally every single insert

# Explain why it's good for the game

when doing #10270 I didn't consider that many maps have both CLF and other team inserts, which would permit a CO to roll for survivor for the CLF, causing them to spawn as a normal survivor in a team insert like the UPP. This is behavior is undesirable IMO.  Prompted by a CO surv rolling on trijent when the UPP insert spawned and an admin having to fix it.

As an aside I'm also trying to change the backend of how insert roles are assigned in a different future to be more like ERTs with prefs to make setting stuff like this up more intuitive and prevent COs/synths from taking RP slots like the CLs in lv, solaris, and shivas, and make it so that people can opt out of roles they don't want in these team inserts. Until that's done, though, COs shouldn't spawn as truckers in the upp ship, probably. My bad!


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: civilian survivor COs should no longer show up in team inerts like the UPP on Trijent
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
