### PR TITLE
Fixes runtime when object transits openspace

### DIFF
--- a/code/game/turfs/open_space.dm
+++ b/code/game/turfs/open_space.dm
@@ -16,6 +16,7 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 	is_weedable = NOT_WEEDABLE
 
 /turf/open_space/Initialize()
+	..()
 	ADD_TRAIT(src, TURF_Z_TRANSPARENT_TRAIT, TRAIT_SOURCE_INHERENT)
 	return INITIALIZE_HINT_LATELOAD
 

--- a/code/game/turfs/open_space.dm
+++ b/code/game/turfs/open_space.dm
@@ -16,7 +16,15 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 	is_weedable = NOT_WEEDABLE
 
 /turf/open_space/Initialize()
-	..()
+	pass_flags = GLOB.pass_flags_cache[type]
+
+	if (isnull(pass_flags))
+		pass_flags = new()
+		initialize_pass_flags(pass_flags)
+		GLOB.pass_flags_cache[type] = pass_flags
+	else
+		initialize_pass_flags()
+
 	ADD_TRAIT(src, TURF_Z_TRANSPARENT_TRAIT, TRAIT_SOURCE_INHERENT)
 	return INITIALIZE_HINT_LATELOAD
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes #10504 

It turns out that openspace, being a turf with its own Initialize() proc, had no pass_flags. Which was causing this runtime.

# Explain why it's good for the game

Runtimes are bad.


# Testing Photographs and Procedure

I don't know how I would screenshot an object not runtiming. The behaviour is entirely unchanged.

<details>
<summary>Screenshots & Videos</summary>
Before:
<img width="199" height="260" alt="image" src="https://github.com/user-attachments/assets/d864ab93-c93d-4754-8655-55bb0d1d4dbe" />
<img width="1419" height="431" alt="image" src="https://github.com/user-attachments/assets/4b1fbd4f-e1a3-4b6e-b07c-8fe941209b99" />


After:
<img width="198" height="264" alt="image" src="https://github.com/user-attachments/assets/251effbb-9ad7-4c98-b49a-c43229d407a2" />
<img width="506" height="362" alt="image" src="https://github.com/user-attachments/assets/b72d3e59-0087-43e5-894e-96f4d806fd39" />


</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: openspace now properly initializes pass_flags
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
