### PR TITLE
Prevents throwing people upwards

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -415,6 +415,13 @@
 
 	..()
 
+/mob/living/throw_atom(atom/target, range, speed = 0, atom/thrower, spin, launch_type = NORMAL_LAUNCH, pass_flags = NO_FLAGS, list/end_throw_callbacks, list/collision_callbacks, tracking = FALSE)
+	var/turf/above = SSmapping.get_turf_above(thrower)
+	if(above && above.z == target.z)
+		to_chat(thrower, SPAN_WARNING("You can't throw someone that high!"))
+		return
+	..()
+
 /mob/living/launch_towards(datum/launch_metadata/LM, tracking = FALSE)
 	if(src)
 		SEND_SIGNAL(src, COMSIG_MOB_MOVE_OR_LOOK, TRUE, dir, dir)

--- a/code/modules/movement/launching/launching.dm
+++ b/code/modules/movement/launching/launching.dm
@@ -153,12 +153,6 @@
 	if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_LAUNCH, LM) & COMPONENT_LAUNCH_CANCEL)
 		return
 
-	//Stop people hurling eachother up to the next floor. And back down.
-	if(istype(src, /mob/living/carbon/human))
-		var/turf/above = SSmapping.get_turf_above(thrower)
-		if(above && above.z == target.z)
-			to_chat(thrower, SPAN_WARNING("You can't throw someone that high!"))
-			return
 
 	flags_atom |= NO_ZFALL
 

--- a/code/modules/movement/launching/launching.dm
+++ b/code/modules/movement/launching/launching.dm
@@ -153,7 +153,6 @@
 	if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_LAUNCH, LM) & COMPONENT_LAUNCH_CANCEL)
 		return
 
-
 	flags_atom |= NO_ZFALL
 
 	launch_towards(LM, tracking)

--- a/code/modules/movement/launching/launching.dm
+++ b/code/modules/movement/launching/launching.dm
@@ -155,7 +155,7 @@
 
 	//Stop people hurling eachother up to the next floor. And back down.
 	if(istype(src, /mob/living/carbon/human))
-		var/turf/above = SSmapping.get_turf_above(src)
+		var/turf/above = SSmapping.get_turf_above(thrower)
 		if(above && above.z == target.z)
 			to_chat(thrower, SPAN_WARNING("You can't throw someone that high!"))
 			return

--- a/code/modules/movement/launching/launching.dm
+++ b/code/modules/movement/launching/launching.dm
@@ -154,10 +154,10 @@
 		return
 
 	//Stop people hurling eachother up to the next floor. And back down.
-	if(istype(target, /mob/living/carbon/human))
+	if(istype(src, /mob/living/carbon/human))
 		var/turf/above = SSmapping.get_turf_above(src)
-		if(above && above.z != thrower.z)
-			to_chat(thrower, SPAN_DANGER("You can't throw someone that high!"))
+		if(above && above.z == target.z)
+			to_chat(thrower, SPAN_WARNING("You can't throw someone that high!"))
 			return
 
 	flags_atom |= NO_ZFALL

--- a/code/modules/movement/launching/launching.dm
+++ b/code/modules/movement/launching/launching.dm
@@ -153,6 +153,10 @@
 	if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_LAUNCH, LM) & COMPONENT_LAUNCH_CANCEL)
 		return
 
+	if(target.z != thrower.z) //Stop people hurling eachother up to the next floor. And back down.
+		to_chat(thrower, SPAN_DANGER("You can't throw someone that high!"))
+		return
+
 	flags_atom |= NO_ZFALL
 
 	launch_towards(LM, tracking)

--- a/code/modules/movement/launching/launching.dm
+++ b/code/modules/movement/launching/launching.dm
@@ -153,9 +153,12 @@
 	if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_LAUNCH, LM) & COMPONENT_LAUNCH_CANCEL)
 		return
 
-	if(target.z != thrower.z) //Stop people hurling eachother up to the next floor. And back down.
-		to_chat(thrower, SPAN_DANGER("You can't throw someone that high!"))
-		return
+	//Stop people hurling eachother up to the next floor. And back down.
+	if(istype(target, /mob/living/carbon/human))
+		var/turf/above = SSmapping.get_turf_above(src)
+		if(above && above.z != thrower.z)
+			to_chat(thrower, SPAN_DANGER("You can't throw someone that high!"))
+			return
 
 	flags_atom |= NO_ZFALL
 


### PR DESCRIPTION

# About the pull request

Fixes #10248 

Adds a check to throwing code, to see if the object being thrown is a living person, and if so, whether that person is being thrown upwards.

# Explain why it's good for the game

While throwing someone up in a parabolic arc is pretty funny, it also allows you to bypass the climbing delay by instantly throwing someone onto the roof.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/uwCRirtL02c

</details>


# Changelog

:cl:
del: You can no longer throw people upstairs.
/:cl:
