### PR TITLE
Add overlay removal to autodoc incision-closing

### DIFF
--- a/code/game/machinery/medical_pod/autodoc.dm
+++ b/code/game/machinery/medical_pod/autodoc.dm
@@ -536,7 +536,13 @@
 							visible_message("[icon2html(src, viewers(src))] \The <b>[src]</b>croaks: Closing surgical incision.");
 						close_encased(patient,current_surgery.limb_ref)
 						close_incision(patient,current_surgery.limb_ref)
-
+						switch(current_surgery.limb_ref.name)
+							if("head")
+								patient.overlays -= image('icons/mob/humans/dam_human.dmi', "skull_surgery_closed")
+								patient.overlays -= image('icons/mob/humans/dam_human.dmi', "skull_surgery_open")
+							if("chest")
+								patient.overlays -= image('icons/mob/humans/dam_human.dmi', "chest_surgery_closed")
+								patient.overlays -= image('icons/mob/humans/dam_human.dmi', "chest_surgery_open")
 
 		if(prob(30))
 			visible_message("[icon2html(src, viewers(src))] \The <b>[src]</b> speaks: Procedure complete.");


### PR DESCRIPTION
# About the pull request

Fixes #10515 
Autodoc will now remove open chest and open skull overlays when Close Open Incisions surgery is run.

# Explain why it's good for the game

Fixes a bug/oversight.

# Testing Photographs and Procedure

Ran locally in debug mode, making sure all four overlay cases get removed and no errors from non-overlay incisions.

# Changelog

:cl:
fix: Autodoc's close incisions surgery now removes the open chest/skull overlays.
/:cl:
