### PR TITLE
Medbay ceiling lights color change

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -15558,8 +15558,7 @@
 /turf/open/floor/almayer/no_build/test_floor4,
 /area/almayer/middeck/medical)
 "aOE" = (
-/obj/structure/machinery/light/red{
-	light_color = "#BB3F3F";
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes{
@@ -15709,8 +15708,7 @@
 /turf/open_space,
 /area/almayer/middeck/medical)
 "aOZ" = (
-/obj/structure/machinery/light/red{
-	light_color = "#BB3F3F";
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -15724,16 +15722,12 @@
 /turf/open/floor/almayer,
 /area/almayer/command/lifeboat)
 "aPb" = (
-/obj/structure/machinery/light/red{
-	light_color = "#BB3F3F"
-	},
+/obj/structure/machinery/light,
 /turf/open_space,
 /area/almayer/middeck/medical)
 "aPc" = (
 /obj/structure/platform/metal/almayer_smooth/east,
-/obj/structure/machinery/light/red{
-	light_color = "#BB3F3F"
-	},
+/obj/structure/machinery/light,
 /turf/open_space,
 /area/almayer/middeck/medical)
 "aPd" = (
@@ -15801,8 +15795,7 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/alpha)
 "aPm" = (
-/obj/structure/machinery/light/red{
-	light_color = "#BB3F3F";
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /obj/effect/decal/heavy_cable/cable_horizontal,
@@ -16094,16 +16087,14 @@
 /turf/open/floor/plating/plating_catwalk/no_build,
 /area/almayer/middeck/maintenance/saft)
 "aPX" = (
-/obj/structure/machinery/light/red{
-	light_color = "#BB3F3F";
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/open_space,
 /area/almayer/middeck/medical)
 "aPY" = (
 /obj/structure/platform/metal/almayer_smooth/east,
-/obj/structure/machinery/light/red{
-	light_color = "#BB3F3F";
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/open_space,
@@ -21448,8 +21439,7 @@
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/middeck/medical)
 "bci" = (
-/obj/structure/machinery/light/red{
-	light_color = "#BB3F3F";
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -29530,8 +29520,7 @@
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/middeck/medical)
 "btF" = (
-/obj/structure/machinery/light/red{
-	light_color = "#BB3F3F";
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /obj/effect/decal/heavy_cable/cable_horizontal,
@@ -29802,8 +29791,7 @@
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/middeck/medical)
 "bui" = (
-/obj/structure/machinery/light/red{
-	light_color = "#BB3F3F";
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes{


### PR DESCRIPTION
# About the pull request

Changes the mid-deck lights shining on medbay lobby from red to default.

# Explain why it's good for the game

The effect of red misshapen blobs on the stark white and green of medbay is quite fugly.
![medbay-lights-red-glow-blah](https://github.com/user-attachments/assets/916da74c-0960-4deb-b2d5-4c107f22dfbc)


# Testing Photographs and Procedure

"After" shots in the dropdown.
<details>
<summary>Screenshots & Videos</summary>

![medbay-lights-even](https://github.com/user-attachments/assets/2d587809-b0e9-4365-b6c0-3ddfa370ce9b)
Resulting lighting in the medbay lobby

![medbay-lights-even-middeck](https://github.com/user-attachments/assets/14067db3-4bb6-43f1-a246-e39f7f4d2dc4)
Resulting lighting in the medbay middeck

</details>


# Changelog

:cl:
maptweak: Changed lights above medbay lobby.
/:cl:
