### PR TITLE
Fixes closets protecting their contents from shuttles

### DIFF
--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -24,36 +24,45 @@ All ShuttleMove procs go here
 	for(var/i in contents)
 		var/atom/movable/thing = i
 		SEND_SIGNAL(thing, COMSIG_MOVABLE_SHUTTLE_CRUSH, shuttle)
-		if(ismob(thing))
-			if(isliving(thing))
-				var/mob/living/M = thing
-// if(M.status_flags & INCORPOREAL)
-// continue // Ghost things don't splat
-				if(M.buckled)
-					M.buckled.unbuckle()//M, TRUE)
-				if(M.pulledby)
-					M.pulledby.stop_pulling()
-				M.stop_pulling()
-				M.visible_message(SPAN_WARNING("[shuttle] slams into [M]!"))
-				M.gib()
-
-		else //non-living mobs shouldn't be affected by shuttles, which is why this is an else
-			if(thing.anchored)
-				// Ordered by most likely:
-				if(istype(thing, /obj/structure/machinery/landinglight))
-					continue
-				if(istype(thing, /obj/docking_port))
-					continue
-				if(istype(thing, /obj/structure/machinery/camera))
-					continue
-				if(istype(thing, /obj/structure/machinery/floodlight/landing/floor))
-					continue
-
-				// SSshuttle also removes these in remove_ripples, but its timing is weird
-				if(!istype(thing, /obj/effect))
-					log_debug("[shuttle] deleted an anchored [thing]")
-
+		if(istype(thing, /obj/structure/closet))
+			for(var/j in thing.contents)
+				shuttleCrushThing(j, shuttle)
 			qdel(thing)
+			continue
+		shuttleCrushThing(thing, shuttle)
+
+/turf/proc/shuttleCrushThing(atom/movable/thing, obj/docking_port/mobile/shuttle)
+	var/should_be_crushed = TRUE
+	if(ismob(thing))
+		if(isliving(thing))
+			var/mob/living/M = thing
+			if(M.buckled)
+				M.buckled.unbuckle()//M, TRUE)
+			if(M.pulledby)
+				M.pulledby.stop_pulling()
+			M.stop_pulling()
+			M.visible_message(SPAN_WARNING("[shuttle] slams into [M]!"))
+			M.gib()
+
+	else //non-living mobs shouldn't be affected by shuttles, which is why this is an else
+		if(thing.anchored)
+			// Ordered by most likely:
+			if(istype(thing, /obj/structure/machinery/landinglight))
+				should_be_crushed = FALSE
+			if(istype(thing, /obj/docking_port))
+				should_be_crushed = FALSE
+			if(istype(thing, /obj/structure/machinery/camera))
+				should_be_crushed = FALSE
+			if(istype(thing, /obj/structure/machinery/floodlight/landing/floor))
+				should_be_crushed = FALSE
+
+			// SSshuttle also removes these in remove_ripples, but its timing is weird
+			if(!istype(thing, /obj/effect))
+				log_debug("[shuttle] deleted an anchored [thing]")
+
+		if(should_be_crushed)
+			qdel(thing)
+
 
 // Called on the old turf to move the turf data
 /turf/proc/onShuttleMove(turf/newT, list/movement_force, move_dir)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes #6965

Migrates shuttle crush code into dedicated function, and applies that function to anything inside a stasis bag.

# Explain why it's good for the game

Stasis bags and crates probably shouldn't allow their occupants to phase through the dropship floor

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/q_0LUr6VihI

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: stasis bags and crates now properly destroy their contents when being crushed by shuttles
refactor: shuttle crush code is now a dedicated function
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
