### PR TITLE
Nuclear bomb no longer explodes after a last-second disarm.

### DIFF
--- a/code/game/machinery/nuclearbomb.dm
+++ b/code/game/machinery/nuclearbomb.dm
@@ -390,7 +390,7 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 	timeleft = initial(timeleft)
 	explosion_time = null
 	for(var/mob/player in world)
-    	player << sound(null, channel=5) // stops the explosion sound in case bomb is disabled while it's playing
+		player << sound(null, channel=5) // stops the explosion sound in case bomb is disabled while it's playing
 	announce_to_players()
 
 /obj/structure/machinery/nuclearbomb/proc/explode()

--- a/code/game/machinery/nuclearbomb.dm
+++ b/code/game/machinery/nuclearbomb.dm
@@ -411,6 +411,11 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 			shake_camera(current_mob, 110, 4)
 
 	sleep(10 SECONDS)
+	if(GLOB.bomb_set == FALSE)
+		update_minimap_icon()
+		stop_processing()
+		update_icon()
+		return FALSE
 
 	var/list/mob/alive_mobs = list() //Everyone who will be destroyed on the zlevel(s).
 	var/list/mob/dead_mobs = list() //Everyone that needs embryos cleared

--- a/code/game/machinery/nuclearbomb.dm
+++ b/code/game/machinery/nuclearbomb.dm
@@ -391,6 +391,10 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 	explosion_time = null
 	for(var/mob/player in world)
 		player << sound(null, channel=5) // stops the explosion sound in case bomb is disabled while it's playing
+	for(var/mob/current_mob as anything in GLOB.mob_list)
+		var/turf/current_turf = get_turf(current_mob)
+		if(current_turf?.z == z && current_mob.stat != DEAD && current_mob.shakecamera > world.time)
+			stop_camera_shake(current_mob) // stops explosion camera shake in case bomb is disabled while it's shaking
 	announce_to_players()
 
 /obj/structure/machinery/nuclearbomb/proc/explode()

--- a/code/game/machinery/nuclearbomb.dm
+++ b/code/game/machinery/nuclearbomb.dm
@@ -389,6 +389,8 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 	GLOB.bomb_set = FALSE
 	timeleft = initial(timeleft)
 	explosion_time = null
+	for(var/mob/player in world)
+    	player << sound(null, channel=5) // stops the explosion sound in case bomb is disabled while it's playing
 	announce_to_players()
 
 /obj/structure/machinery/nuclearbomb/proc/explode()
@@ -403,7 +405,9 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 	safety = TRUE
 
 	playsound(src, 'sound/machines/Alarm.ogg', 75, 0, 30)
-	world << pick('sound/theme/nuclear_detonation1.ogg','sound/theme/nuclear_detonation2.ogg')
+	var/sound/explosionsound = sound(pick('sound/theme/nuclear_detonation1.ogg', 'sound/theme/nuclear_detonation2.ogg'))
+	explosionsound.channel = 5
+	world << explosionsound
 
 	for(var/mob/current_mob as anything in GLOB.mob_list)
 		var/turf/current_turf = get_turf(current_mob)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -346,7 +346,7 @@ GLOBAL_LIST_INIT(limb_types_by_name, list(
     if(!targetmob?.client) return
 
     targetmob.shakecamera = 0 
-    animate(M.client, pixel_x = 0, pixel_y = 0, time = 1, flags = ANIMATION_END)
+    animate(M.client, pixel_x = 0, pixel_y = 0, time = 1)
 
 /proc/findname(msg)
 	for(var/mob/M in GLOB.mob_list)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -343,10 +343,11 @@ GLOBAL_LIST_INIT(limb_types_by_name, list(
 #undef PIXELS_PER_STRENGTH_VAL
 
 /proc/stop_camera_shake(mob/targetmob)
-    if(!targetmob?.client) return
+	if(!targetmob?.client)
+		return
 
-    targetmob.shakecamera = 0 
-    animate(M.client, pixel_x = 0, pixel_y = 0, time = 1)
+	targetmob.shakecamera = 0 
+	animate(targetmob.client, pixel_x = 0, pixel_y = 0, time = 1, flags = ANIMATION_END)
 
 /proc/findname(msg)
 	for(var/mob/M in GLOB.mob_list)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -347,7 +347,7 @@ GLOBAL_LIST_INIT(limb_types_by_name, list(
 		return
 
 	targetmob.shakecamera = 0 
-	animate(targetmob.client, pixel_x = 0, pixel_y = 0, time = 1, flags = ANIMATION_END)
+	animate(targetmob.client, pixel_x = 0, pixel_y = 0, time = 1)
 
 /proc/findname(msg)
 	for(var/mob/M in GLOB.mob_list)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -342,6 +342,12 @@ GLOBAL_LIST_INIT(limb_types_by_name, list(
 
 #undef PIXELS_PER_STRENGTH_VAL
 
+/proc/stop_camera_shake(mob/targetmob)
+    if(!targetmob?.client) return
+
+    targetmob.shakecamera = 0 
+    animate(M.client, pixel_x = 0, pixel_y = 0, time = 1, flags = ANIMATION_END)
+
 /proc/findname(msg)
 	for(var/mob/M in GLOB.mob_list)
 		if (M.real_name == text("[msg]"))


### PR DESCRIPTION
# About the pull request

Currently, it's possible to disarm the bomb at the last second (after the music starts but before the bomb explodes) - the game throws the usual announcements about the bomb being disarmed, but the bomb still explodes as there isn't a last-minute check in the code. Happened in round 29620 for example. This will stop it exploding.

# Explain why it's good for the game

If someone disarms the bomb at the last second, they shouldn't explode. Or don't allow them to disarm it at the last second at all. I'm going with the first option.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: nuclear bomb no longer explodes if disarmed at the last second
/:cl:
