### PR TITLE
allows servers to configure an alternative cdn

### DIFF
--- a/code/controllers/configuration/entries/resources.dm
+++ b/code/controllers/configuration/entries/resources.dm
@@ -29,6 +29,16 @@
 		str_var += "/"
 	return ..(str_var)
 
+/datum/config_entry/string/asset_secondary_cdn_url
+	protection = CONFIG_ENTRY_LOCKED
+
+/datum/config_entry/string/asset_secondary_cdn_url/ValidateAndSet(str_var)
+	if (!str_var || trim(str_var) == "")
+		return FALSE
+	if (str_var && str_var[length(str_var)] != "/")
+		str_var += "/"
+	return ..(str_var)
+
 /datum/config_entry/string/storage_cdn_iframe
 	config_entry_value = "https://cmss13-devs.github.io/cmss13/assets/iframe.html"
 	protection = CONFIG_ENTRY_LOCKED

--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -42,13 +42,21 @@ SUBSYSTEM_DEF(tgui)
 	basehtml = replacetext(basehtml, "tgui:stylesheet", MAP_STYLESHEET)
 
 /datum/controller/subsystem/tgui/OnConfigLoad()
+	var/is_webroot = CONFIG_GET(string/asset_transport) == "webroot"
+	if(is_webroot)
+		basehtml = replacetext(basehtml, "tgui:primarycdn", CONFIG_GET(string/asset_cdn_url))
+
+		var/secondary_url = CONFIG_GET(string/asset_secondary_cdn_url)
+		if(secondary_url)
+			basehtml = replacetext(basehtml, "tgui:secondarycdn", secondary_url)
+
 	var/storage_iframe = CONFIG_GET(string/storage_cdn_iframe)
 
 	if(storage_iframe && storage_iframe != /datum/config_entry/string/storage_cdn_iframe::config_entry_value)
 		basehtml = replacetext(basehtml, "tgui:storagecdn", storage_iframe)
 		return
 
-	if(CONFIG_GET(string/asset_transport) == "webroot")
+	if(is_webroot)
 		var/datum/asset_transport/webroot/webroot = SSassets.transport
 
 		var/datum/asset_cache_item/item = webroot.register_asset("iframe.html", file("tgui/public/iframe.html"))

--- a/tgui/packages/tgui-setup/helpers.js
+++ b/tgui/packages/tgui-setup/helpers.js
@@ -34,6 +34,9 @@
 
   Byond.storageCdn = 'tgui:storagecdn';
 
+  Byond.primaryCdn = 'tgui:primarycdn';
+  Byond.secondaryCdn = 'tgui:secondarycdn';
+
   // Backwards compatibility
   window.__windowId__ = Byond.windowId;
 
@@ -262,6 +265,8 @@
   let RETRY_WAIT_INITIAL = 500;
   let RETRY_WAIT_INCREMENT = 500;
 
+  let RETRY_SECONDARY_ATTEMPTS = 2;
+
   let loadedAssetByUrl = {};
 
   let isStyleSheetLoaded = function (node, url) {
@@ -318,6 +323,16 @@
         RETRY_WAIT_INITIAL + attempt * RETRY_WAIT_INCREMENT
       );
     };
+
+    if (attempt >= RETRY_SECONDARY_ATTEMPTS) {
+      if (
+        !Byond.primaryUrl.contains('tgui') &&
+        !Byond.secondaryUrl.contains('tgui')
+      ) {
+        url = url.replace(Byond.primaryUrl, Byond.secondaryUrl);
+      }
+    }
+
     // JS specific code
     if (type === 'js') {
       let node = document.createElement('script');


### PR DESCRIPTION
say if spain decided to block all of cloudflare during footie matches. as if that makes sense

:cl:
server: the server can now be configured with an alternative cdn to failover to if the primary one cannot be reached by a user
/:cl: