### PR TITLE
Fixes the eternal hangup loop

### DIFF
--- a/code/modules/cm_phone/phone.dm
+++ b/code/modules/cm_phone/phone.dm
@@ -343,6 +343,7 @@ GLOBAL_LIST_EMPTY_TYPED(transmitters, /obj/structure/transmitter)
 	reset_call()
 	busy_loop.stop()
 	outring_loop.stop()
+	hangup_loop.stop()
 
 	update_icon()
 
@@ -419,8 +420,6 @@ GLOBAL_LIST_EMPTY_TYPED(transmitters, /obj/structure/transmitter)
 		attach_to(loc)
 
 /obj/item/phone/Destroy()
-	if(attached_to)
-		attached_to.hangup_loop.stop()
 	remove_attached()
 	return ..()
 

--- a/code/modules/cm_phone/phone.dm
+++ b/code/modules/cm_phone/phone.dm
@@ -419,6 +419,8 @@ GLOBAL_LIST_EMPTY_TYPED(transmitters, /obj/structure/transmitter)
 		attach_to(loc)
 
 /obj/item/phone/Destroy()
+	if(attached_to)
+		attached_to.hangup_loop.stop()
 	remove_attached()
 	return ..()
 

--- a/code/modules/cm_phone/phone.dm
+++ b/code/modules/cm_phone/phone.dm
@@ -337,7 +337,6 @@ GLOBAL_LIST_EMPTY_TYPED(transmitters, /obj/structure/transmitter)
 		var/mob/M = attached_to.loc
 		M.drop_held_item(attached_to)
 		playsound(get_turf(M), pickup_sound, 100, FALSE, 7)
-		hangup_loop.stop()
 
 	attached_to.forceMove(src)
 	reset_call()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes #8767 

Moves hangup_loop.stop() out of the mob loc check, to enable the loop to stop even if the phone is thrown down the ASRS pit.

I haven't been able to find any instances of this needing to be inside the check.

# Explain why it's good for the game

Throwing the phone into the ASRS pit (or otherwise destroying it without it being on a person) probably shouldn't cause it to ring forever.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/9g-m9EHrRQc

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Throwing the phone down the ASRS pit after being hung up on won't cause it to loop forever.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
