### PR TITLE
Revert "Allows Queen Eye to look into tents (#10494)"

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -116,8 +116,6 @@
 	med_hud_set_status()
 	add_to_all_mob_huds()
 
-	hud_used = Q.hud_used
-
 	Q.sight |= SEE_TURFS|SEE_OBJS
 
 /mob/hologram/queen/proc/exit_hologram()


### PR DESCRIPTION
This reverts commit e34d1f639def077e7bad9030cd74ff47cba0f6f5.

# Changelog
:cl:
fix: Fixes weird lighting/vision errors caused by 10494
/:cl:
