### PR TITLE
cut temp lists

### DIFF
--- a/code/modules/tgui/tgui_alert.dm
+++ b/code/modules/tgui/tgui_alert.dm
@@ -101,7 +101,7 @@
 /datum/tgui_modal/Destroy(force, ...)
 	SStgui.close_uis(src)
 	state = null
-	buttons = null // TG QDEL_NULLs this
+	buttons?.Cut()
 	return ..()
 
 /**

--- a/code/modules/tgui/tgui_input_list.dm
+++ b/code/modules/tgui/tgui_input_list.dm
@@ -155,7 +155,8 @@
 /datum/tgui_list_input/Destroy(force, ...)
 	SStgui.close_uis(src)
 	state = null
-	buttons = null // TG QDEL_NULLs this
+	buttons?.Cut()
+	buttons_map?.Cut()
 	return ..()
 
 /**

--- a/code/modules/tgui_input/checkboxes.dm
+++ b/code/modules/tgui_input/checkboxes.dm
@@ -134,7 +134,7 @@
 /datum/tgui_checkbox_input/Destroy(force)
 	SStgui.close_uis(src)
 	state = null
-	items = null // TG QDEL_NULLs this
+	items?.Cut()
 	return ..()
 
 /**

--- a/code/modules/tgui_input/checkboxes.dm
+++ b/code/modules/tgui_input/checkboxes.dm
@@ -189,7 +189,11 @@
 		if("submit")
 			var/list/selections = params["entry"]
 			if(length(selections) >= min_checked && length(selections) <= max_checked)
-				set_choices(selections)
+				var/list/valid_selections = list()
+				for(var/raw_entry in selections)
+					if(raw_entry in items)
+						valid_selections += raw_entry
+				set_choices(valid_selections)
 			closed = TRUE
 			SStgui.close_uis(src)
 			return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR does a couple minor tweaks:
- Checkboxes input is now validated (mostly to be stronger against user manip)
- Checkboxes, input list, and alert now Cut their lists rather than null to better handle potential object references lingering. So partially ports https://github.com/tgstation/tgstation/pull/90227

# Explain why it's good for the game

Should be slightly more robust tgui input code.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Just very basic testing
![example](https://github.com/user-attachments/assets/a750c3e6-0aa1-4027-8a4b-91af2d82c3a1)

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Drathek
code: TGUI input lists now Cut their entries rather than wait for byond garbage collection
ui: TGUI checkboxes input now validates the selected entries passed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
