### PR TITLE
Fix broken CI badge on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <p align="center">
 	<a href="https://github.com/cmss13-devs/cmss13/actions?query=workflow%3A%22CI+Suite%22"><img src="https://github.com/cmss13-devs/cmss13/workflows/CI%20Suite/badge.svg"></a>
- 	<a href="https://github.com/cmss13-devs/cmss13/actions/workflows/generate_documentation.yml"><img src="https://github.com/cmss13-devs/cmss13/actions/workflows/generate_documentation.yml/badge.svg"></a>
+ 	<a href="https://github.com/cmss13-devs/cmss13/actions/workflows/generate_documentation.yml"><img src="https://github.com/cmss13-devs/cmss13/actions/workflows/generate_web_assets.yml/badge.svg"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Simply fixes a broken CI badge on the readme broken by https://github.com/cmss13-devs/cmss13/pull/8646 renaming a workflow.

# Changelog
No player facing changes.
