### PR TITLE
Fix pass flag runtimes

### DIFF
--- a/code/modules/movement/movement.dm
+++ b/code/modules/movement/movement.dm
@@ -17,19 +17,22 @@
 	if(!mover || !mover.pass_flags)
 		return NO_BLOCKED_MOVEMENT
 
-	var/reverse_dir = REVERSE_DIR(dir)
+	if(!density)
+		return NO_BLOCKED_MOVEMENT
+
 	var/flags_can_pass = pass_flags?.flags_can_pass_all|flags_can_pass_all_temp|pass_flags?.flags_can_pass_front|flags_can_pass_front_temp
 	var/mover_flags_pass = mover.pass_flags.flags_pass|mover.flags_pass_temp
 
-	if (!density || (flags_can_pass & mover_flags_pass))
+	if(flags_can_pass & mover_flags_pass)
 		return NO_BLOCKED_MOVEMENT
 
-	if (flags_atom & ON_BORDER)
-		if (!(target_dir & reverse_dir))
+	if(flags_atom & ON_BORDER)
+		var/reverse_dir = REVERSE_DIR(dir)
+		if(!(target_dir & reverse_dir))
 			return NO_BLOCKED_MOVEMENT
 
 		// This is to properly handle diagonal movement (a cade to your NE facing west when you are trying to move NE should block for north instead of east)
-		if (target_dir & (NORTH|SOUTH) && target_dir & (EAST|WEST))
+		if(target_dir & (NORTH|SOUTH) && target_dir & (EAST|WEST))
 			return target_dir - (target_dir & reverse_dir)
 		return target_dir & reverse_dir
 	else


### PR DESCRIPTION

# About the pull request

This PR simply fixes a runtime that occurs ever an atom's pass flags is null (e.g. when pouncing down a z).

# Explain why it's good for the game

Less runtimes.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Fixes this: 

https://github.com/user-attachments/assets/f4d989a3-e28f-4dad-b3d1-ee3625b7e7b1

</details>


# Changelog
:cl: Drathek
fix: Fixed runtimes related to BlockedExitDirs and BlockedPassDirs trying access null pass_flags
/:cl:
