### PR TITLE
Reverts boosting nerf revert

### DIFF
--- a/code/modules/reagents/chemistry_properties/prop_special.dm
+++ b/code/modules/reagents/chemistry_properties/prop_special.dm
@@ -6,12 +6,12 @@
 /datum/chem_property/special/boosting
 	name = PROPERTY_BOOSTING
 	code = "BST"
-	description = "Boosts the potency of all other properties in this chemical when inside the body by 1 levels for every level that this property has."
+	description = "Boosts the potency of all other properties in this chemical when inside the body by 0.5 levels for every level that this property has."
 	rarity = PROPERTY_LEGENDARY
 	category = PROPERTY_TYPE_METABOLITE
 
 /datum/chem_property/special/boosting/pre_process(mob/living/M)
-	return list(REAGENT_BOOST = level)
+	return list(REAGENT_BOOST = level * 0.5)
 
 /datum/chem_property/special/optimized
 	name = PROPERTY_OPTIMIZED


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Boosting boosts props by 0.5 per level again.

# Explain why it's good for the game
We love number changes.
<img width="451" height="132" alt="2025-08-31_19-17-59" src="https://github.com/user-attachments/assets/0408cc40-bf31-4039-bf5f-8ef1b1f5171e" />


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: ihatethisengine
balance: boosting boosts props by 0.5 per level again instead of 1 per level.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
