### PR TITLE
Bump sdmm suite for linting to 1.11

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -14,7 +14,7 @@ export RUST_G_VERSION=3.3.0
 export NODE_VERSION_LTS=22.14.0
 
 # SpacemanDMM git tag
-export SPACEMAN_DMM_VERSION=suite-1.10
+export SPACEMAN_DMM_VERSION=suite-1.11
 
 # Python version for mapmerge and other tools
 export PYTHON_VERSION=3.11.9


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Bumps spacemandmm suite to 1.11 for https://github.com/SpaceManiac/SpacemanDMM/releases/tag/suite-1.11

# Explain why it's good for the game

Bringing linters back on parity with local dev tools in VSC.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Drathek
code: SDMM suite for linting is bumped to a new version for more 516 support
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
