### PR TITLE
Fix a runtime for new players opening loadouts

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -298,7 +298,7 @@ GLOBAL_LIST_INIT(be_special_flags, list(
 	VAR_PRIVATE/list/loadout = list()
 
 	/// Mapping of jobs to slot numbers to names, to allow users to customise slots
-	var/list/loadout_slot_names
+	var/list/loadout_slot_names = list()
 
 	/// Which slot is currently in use
 	var/selected_loadout_slot = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR is a follow up to #8105 fixing a runtime where a list is not initialized if the player is a new player (as in has never loaded prefs yet for sanitization to occur)

# Explain why it's good for the game

Fixes 
<img width="919" height="156" alt="image" src="https://github.com/user-attachments/assets/be6ef451-8197-4c36-94eb-86fed7cfafce" />


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Simply open loadout button from character preferences as a new player (e.g. delete data folder)
<img width="601" height="520" alt="image" src="https://github.com/user-attachments/assets/4bb8d824-4efe-4db5-ba65-3f97ebd2d528" />


</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Drathek
fix: Fix a runtime related to new players opening the loadout menu in character preferences
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
