### PR TITLE
Adds Messages so Informing Marines APS Trait is Working and Will Not Work in Stasis Bags

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -72,7 +72,6 @@
 		handle_stasis_bag()
 
 
-
 	stabilize_body_temperature() //Body temperature adjusts itself (self-regulation) (even when dead)
 
 	//Handle temperature/pressure differences between body and environment

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -70,7 +70,7 @@
 
 	else if(stat != DEAD)
 		handle_stasis_bag()
-
+		handle_stasis_bag_with_APS()
 
 	stabilize_body_temperature() //Body temperature adjusts itself (self-regulation) (even when dead)
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -70,7 +70,8 @@
 
 	else if(stat != DEAD)
 		handle_stasis_bag()
-		handle_stasis_bag_with_APS()
+
+
 
 	stabilize_body_temperature() //Body temperature adjusts itself (self-regulation) (even when dead)
 

--- a/code/modules/mob/living/carbon/human/life/handle_stasis_bag.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_stasis_bag.dm
@@ -14,8 +14,7 @@
 
 /mob/living/carbon/human/proc/handle_stasis_bag_with_APS()
 	for(var/datum/reagent/antiparasitic_reagent in src.reagents.reagent_list)
-		var/datum/chem_property/property = antiparasitic_reagent.get_property(PROPERTY_ANTIPARASITIC) //Adrenaline helps greatly at restarting the heart
-		if(property)
+		var/datum/chem_property/property = antiparasitic_reagent.get_property(PROPERTY_ANTIPARASITIC) //If I have APS in me. Tell player APS is not working in stasis
 			if(prob(25))
 				to_chat(src, SPAN_NOTICE("A strange sensation of anxiety sweeps over you as something inside you relaxes under the stasis field.")) //Inform the marine the stasis field is killing
 				break

--- a/code/modules/mob/living/carbon/human/life/handle_stasis_bag.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_stasis_bag.dm
@@ -18,7 +18,7 @@
 		if(property) //If we have APS and a 25% chance to run
 			var/obj/item/alien_embryo/embryo = locate() in contents //Check if we have an embryo in us
 			if(embryo)
-				if(prob(25))
+				if(prob(25) && embryo.stage >= 2) //Embryo should only be noticed when you are above stage 2 (This is the standard in embryo.dm)
 					to_chat(src, SPAN_NOTICE("As metabolism slows down as something inside you relaxes")) //Inform the marine the stasis field is killing
 				break// otherwise, stop looping this handling regardless
 

--- a/code/modules/mob/living/carbon/human/life/handle_stasis_bag.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_stasis_bag.dm
@@ -12,9 +12,19 @@
 			if(sleeping < 10)
 				sleeping += 10 //Puts the mob to sleep indefinitely.
 
+
+
 /mob/living/carbon/human/proc/handle_stasis_bag_with_APS()
+	var/has_embryo = FALSE
 	for(var/datum/reagent/antiparasitic_reagent in src.reagents.reagent_list)
 		var/datum/chem_property/property = antiparasitic_reagent.get_property(PROPERTY_ANTIPARASITIC) //If I have APS in me. Tell player APS is not working in stasis
-			if(prob(25))
+		if(prob(25) && property) //If we have APS and a 25% chance to run
+			for(var/obj/item/alien_embryo/embryo in src.contents) //Check if we have an embryo in us
+				if(embryo && istype(embryo))
+					if(embryo.counter > 0)
+						has_embryo = TRUE
+					else
+						has_embryo = FALSE
+			if(has_embryo) // If so, send a mesage
 				to_chat(src, SPAN_NOTICE("A strange sensation of anxiety sweeps over you as something inside you relaxes under the stasis field.")) //Inform the marine the stasis field is killing
-				break
+			break// otherwise, stop looping this handling regardless

--- a/code/modules/mob/living/carbon/human/life/handle_stasis_bag.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_stasis_bag.dm
@@ -12,19 +12,14 @@
 			if(sleeping < 10)
 				sleeping += 10 //Puts the mob to sleep indefinitely.
 
-
-
-/mob/living/carbon/human/proc/handle_stasis_bag_with_APS()
-	var/has_embryo = FALSE
-	for(var/datum/reagent/antiparasitic_reagent in src.reagents.reagent_list)
+	//APS Stuff
+	for(var/datum/reagent/antiparasitic_reagent in reagents.reagent_list)
 		var/datum/chem_property/property = antiparasitic_reagent.get_property(PROPERTY_ANTIPARASITIC) //If I have APS in me. Tell player APS is not working in stasis
-		if(prob(25) && property) //If we have APS and a 25% chance to run
-			for(var/obj/item/alien_embryo/embryo in src.contents) //Check if we have an embryo in us
-				if(embryo && istype(embryo))
-					if(embryo.counter > 0)
-						has_embryo = TRUE
-					else
-						has_embryo = FALSE
-			if(has_embryo) // If so, send a mesage
-				to_chat(src, SPAN_NOTICE("A strange sensation of anxiety sweeps over you as something inside you relaxes under the stasis field.")) //Inform the marine the stasis field is killing
-			break// otherwise, stop looping this handling regardless
+		if(property) //If we have APS and a 25% chance to run
+			var/obj/item/alien_embryo/embryo = locate() in contents //Check if we have an embryo in us
+			if(embryo)
+				if(prob(25))
+					to_chat(src, SPAN_NOTICE("As metabolism slows down as something inside you relaxes")) //Inform the marine the stasis field is killing
+				break// otherwise, stop looping this handling regardless
+
+

--- a/code/modules/mob/living/carbon/human/life/handle_stasis_bag.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_stasis_bag.dm
@@ -19,7 +19,7 @@
 			var/obj/item/alien_embryo/embryo = locate() in contents //Check if we have an embryo in us
 			if(embryo)
 				if(prob(25) && embryo.stage >= 2) //Embryo should only be noticed when you are above stage 2 (This is the standard in embryo.dm)
-					to_chat(src, SPAN_NOTICE("As metabolism slows down as something inside you relaxes")) //Inform the marine the stasis field is killing
-				break// otherwise, stop looping this handling regardless
+					to_chat(src, SPAN_NOTICE("As your metabolism slows down, something inside you relaxes")) //Inform the marine the stasis makes it ineffective
+			break// otherwise, stop looping this handling regardless
 
 

--- a/code/modules/mob/living/carbon/human/life/handle_stasis_bag.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_stasis_bag.dm
@@ -11,3 +11,11 @@
 		if(STASIS_IN_CRYO_CELL)
 			if(sleeping < 10)
 				sleeping += 10 //Puts the mob to sleep indefinitely.
+
+/mob/living/carbon/human/proc/handle_stasis_bag_with_APS()
+	for(var/datum/reagent/antiparasitic_reagent in src.reagents.reagent_list)
+		var/datum/chem_property/property = antiparasitic_reagent.get_property(PROPERTY_ANTIPARASITIC) //Adrenaline helps greatly at restarting the heart
+		if(property)
+			if(prob(25))
+				to_chat(src, SPAN_NOTICE("A strange sensation of anxiety sweeps over you as something inside you relaxes under the stasis field.")) //Inform the marine the stasis field is killing
+				break

--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -595,12 +595,15 @@
 			if(embryo.counter > 0)
 				embryo.counter = embryo.counter - (potency * delta_time)
 				current_human.take_limb_damage(0, POTENCY_MULTIPLIER_MEDIUMLOW*potency)
+				if(prob(potency * 5)) //Higher chance of notice with higher potency makes sense
+					to_chat(current_human, SPAN_NOTICE("You feel something inside you squirming in agitation!")) //Inform the marine their embryo is dying
 			else
 				embryo.stage--
 				if(embryo.stage <= 0)//if we reach this point, the embryo dies and the occupant takes a nasty amount of acid damage
 					qdel(embryo)
 					current_human.take_limb_damage(0,rand(20,40))
 					current_human.vomit()
+					to_chat(current_human, SPAN_NOTICE("You start to throw up several bits of wormlike matter!")) //Embryo is dead
 				else
 					embryo.counter = embryo.per_stage_hugged_time - (potency * delta_time)
 

--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -603,7 +603,7 @@
 					qdel(embryo)
 					current_human.take_limb_damage(0,rand(20,40))
 					current_human.vomit()
-					to_chat(current_human, SPAN_NOTICE("You start to throw up several bits of wormlike matter!")) //Embryo is dead
+					to_chat(current_human, SPAN_NOTICE("You throw up several bits of wormlike matter!")) //Embryo is dead
 				else
 					embryo.counter = embryo.per_stage_hugged_time - (potency * delta_time)
 

--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -600,7 +600,7 @@
 			else
 				embryo.stage--
 				if(embryo.stage <= 0)//if we reach this point, the embryo dies and the occupant takes a nasty amount of acid damage
-					qdel(embryo)
+					embryo.forceMove(current_human.loc) //forces the embryo out of the container that is the human host and onto the ground
 					current_human.take_limb_damage(0,rand(20,40))
 					current_human.vomit()
 					to_chat(current_human, SPAN_NOTICE("You throw up several bits of wormlike matter!")) //Embryo is dead


### PR DESCRIPTION
# About the pull request
See changelog.

# Testing Photographs and Procedure
Tested all changes with admin tools in private server

# Explain why it's good for the game

Removes ambiguity about game mechanics without changing balance or functionality of present game mechanics

# Changelog
:cl:
code: Modified APS trait to give span_notices when processing telling you it is doing something. Also gives a notice when you finally kill the larva
code: Modifies the handling of stasis bags to check for an APS chem and notifies the player of the incompatibility with lore compatible text.
/:cl: