### PR TITLE
Removes dead larva core refunding

### DIFF
--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -263,10 +263,9 @@
 	// Handle spawning larva if core is connected to a hive
 	if(linked_hive)
 		for(var/mob/living/carbon/xenomorph/larva/worm in range(2, src))
-			if((!worm.ckey || worm.stat == DEAD) && worm.burrowable && (worm.hivenumber == linked_hive.hivenumber) && !QDELETED(worm))
+			if((!worm.ckey && worm.stat != DEAD) && worm.burrowable && (worm.hivenumber == linked_hive.hivenumber) && !QDELETED(worm))
 				visible_message(SPAN_XENODANGER("[worm] quickly burrows into \the [src]."))
-				if(!worm.banished)
-					// Goob job bringing her back home, but no doubling please
+				if(!worm.banished) // banished xenos dying refunds a larva anyway, better to have them brutally murdered than be allowed to retreat into the core
 					linked_hive.stored_larva++
 					linked_hive.hive_ui.update_burrowed_larva()
 				qdel(worm)

--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -263,11 +263,10 @@
 	// Handle spawning larva if core is connected to a hive
 	if(linked_hive)
 		for(var/mob/living/carbon/xenomorph/larva/worm in range(2, src))
-			if((!worm.ckey && worm.stat != DEAD) && worm.burrowable && (worm.hivenumber == linked_hive.hivenumber) && !QDELETED(worm))
+			if((!worm.ckey && worm.stat != DEAD) && worm.burrowable && !worm.banished && (worm.hivenumber == linked_hive.hivenumber) && !QDELETED(worm)) //only admit non-banished, living, ghosted larva of the same hive. Banished larva refund on death, which is cooler
 				visible_message(SPAN_XENODANGER("[worm] quickly burrows into \the [src]."))
-				if(!worm.banished) // banished xenos dying refunds a larva anyway, better to have them brutally murdered than be allowed to retreat into the core
-					linked_hive.stored_larva++
-					linked_hive.hive_ui.update_burrowed_larva()
+				linked_hive.stored_larva++
+				linked_hive.hive_ui.update_burrowed_larva()
 				qdel(worm)
 
 		var/count_spawned = 0

--- a/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
@@ -207,9 +207,6 @@
 	playsound(loc, "alien_roar_larva", 15)
 	return TRUE
 
-/mob/living/carbon/xenomorph/larva/is_xeno_grabbable()
-	return TRUE
-
 /*
 Larva name generation, set nicknumber = (number between 1 & 999) which isn't taken by any other xenos in GLOB.xeno_mob_list if doesn't already exist.
 Also handles the "Mature / Bloody naming convention. Call this to update the name."


### PR DESCRIPTION

# About the pull request

Removes the ability to drag dead larva and revive them at the hive core

# Explain why it's good for the game

A couple of things to note: this was never an intended feature and was only borne out of an oversight. Originally, larva without clients were automatically burrowed and added to the reserve pool to remove AFK larva from the round, but this had the added consequence of allowing DEAD larva (who also usually dont have a client) to be refunded as well. It was semi-formalized as a feature some time later for some god-forsaken reason instead of being actually fixed.

Things larva refunding does not do:
It does not prevent larva suicide, as larva have a base chance of 25 percent to gib and will often be unrecoverable anyway.
It does not prevent survs killing AFK larva roundstart, for the same reason as above.
both of these are ADMIN issues that are NOT solved by larva refunding, and need to be ahelped anyway.

Things larva refunding does do:
Provide a get out of jail free card for xenos that fail to protect the hive. The whole reason why xenos are supposed to build and protect the hive is to prevent captures and burst larva from dying. Failing to do this should have real consequences, including the loss of the young you fail to protect. It may feel bad to die as a larva, but it's not like refunding even let you return to your body anyway, it just gave it to the next guy in queue because it's not a real feature anyway.
Look incredibly stupid. The message is the same regardless of whether or not the larva is dead from being riddled with bullets because it was never an intended mechanic
`visible_message(SPAN_XENODANGER("[worm] quickly burrows into \the [src]."))`
I'd like to see how this guy burrowed into anything after being cut in half by a machine gun.
<details>
<img width="109" height="87" alt="image" src="https://github.com/user-attachments/assets/4aa9539c-a521-4820-addf-2ee2798c0abc" />
</details>

Also, because this is just an oversight and not a real feature, there is NO time limit on this, so if a larva dies after bursting shipside, gets sent to research, sits there for an hour, and gets dragged to the core post-hijack, it crawls into the core and gets added to the burrowed counter because ????

# Testing Photographs and Procedure

I fired up local, if I ghost I still burrow, if I die I don't, and I can't drag dead larva anymore but I can drag living ones.


# Changelog
:cl:
fix: Dead larva no longer get refunded at the hive core as if they are AFK/ghosted
/:cl:
