### PR TITLE
Vehicle-spawned telephones get name

### DIFF
--- a/code/modules/vehicles/interior/interior_landmarks.dm
+++ b/code/modules/vehicles/interior/interior_landmarks.dm
@@ -240,7 +240,7 @@
 	Phone.pixel_x = pixel_x
 	Phone.pixel_y = pixel_y
 	Phone.phone_category = "Vehicles"
-	Phone.phone_id = replacetext(I.map_template.name, "\improper", "") // this has to be done because phone IDs need to be the same as their display name (\improper doesn't display, obviously)
+	Phone.phone_id = I.map_template.name
 
 	qdel(src)
 


### PR DESCRIPTION
# About the pull request

From a defect report, telephones on the ARC were just listed as "Telephone" in the call list.
Changed the telephone spawner to name the phone_id after the interior's template name.

# Explain why it's good for the game

Fixes #10604 
Identifies phones in spawned vehicles.

# Testing Photographs and Procedure

Bought and brought up the ARC through tech points; made sure it showed up in the phone list as "ARC".

Afterwards, admin-spawned some APCs and it worked for them as well, see image.

Did these tests in debug mode and hit no runtimes.

<details>
<summary>Screenshots & Videos</summary>

![vehicle_phones](https://github.com/user-attachments/assets/05154fcf-0836-4d19-9d20-c9280d706cf0)

</details>

# Changelog

:cl:
fix: ARC phone now shows up as "ARC" in the Vehicles phone list.
/:cl:
