### PR TITLE
Disables hugger cross z level hug & misc pounce/look up fixes

### DIFF
--- a/code/modules/cm_tech/hologram.dm
+++ b/code/modules/cm_tech/hologram.dm
@@ -152,8 +152,6 @@ GLOBAL_LIST_EMPTY_TYPED(hologram_list, /mob/hologram)
 			qdel(src)
 			return
 
-
-
 	var/turf/new_turf = get_step(loc, direct)
 	forceMove(new_turf)
 

--- a/code/modules/cm_tech/hologram.dm
+++ b/code/modules/cm_tech/hologram.dm
@@ -108,7 +108,7 @@ GLOBAL_LIST_EMPTY_TYPED(hologram_list, /mob/hologram)
 
 /datum/action/leave_hologram/Destroy()
 	if(!QDESTROYING(linked_hologram))
-		qdel(linked_hologram)
+		QDEL_NULL(linked_hologram)
 	return ..()
 
 /mob/hologram/techtree/Initialize(mapload, mob/M)

--- a/code/modules/cm_tech/hologram.dm
+++ b/code/modules/cm_tech/hologram.dm
@@ -135,7 +135,7 @@ GLOBAL_LIST_EMPTY_TYPED(hologram_list, /mob/hologram)
 	if(linked_mob)
 		UnregisterSignal(linked_mob, COMSIG_MOVABLE_MOVED)
 		if(istype(linked_mob, /mob/living))
-			var/mob/living/linked_living
+			var/mob/living/linked_living = linked_mob
 			linked_living.observed_atom = null
 
 	. = ..()

--- a/code/modules/cm_tech/hologram.dm
+++ b/code/modules/cm_tech/hologram.dm
@@ -130,6 +130,7 @@ GLOBAL_LIST_EMPTY_TYPED(hologram_list, /mob/hologram)
 	if(viewer)
 		UnregisterSignal(viewer, COMSIG_CLIENT_MOB_MOVE)
 		RegisterSignal(viewer, COMSIG_MOVABLE_MOVED, PROC_REF(handle_move))
+		RegisterSignal(viewer, COMSIG_MOB_GHOSTIZE, PROC_REF(on_death))
 
 /mob/hologram/look_up/Destroy()
 	if(linked_mob)
@@ -163,7 +164,7 @@ GLOBAL_LIST_EMPTY_TYPED(hologram_list, /mob/hologram)
 		view_registered = FALSE
 		linked_mob.reset_view()
 	else if (!view_registered)
-		RegisterSignal(linked_mob, COMSIG_MOB_RESET_VIEW, PROC_REF(handle_view))
+		RegisterSignal(linked_mob, COMSIG_MOB_RESET_VIEW, PROC_REF(on_death))
 		view_registered = TRUE
 		linked_mob.reset_view()
 
@@ -182,3 +183,6 @@ GLOBAL_LIST_EMPTY_TYPED(hologram_list, /mob/hologram)
 
 /mob/hologram/look_up/take_damage(mob/M, damage, damagetype)
 	return //no cancelation of looking up by taking damage
+
+/mob/hologram/look_up/proc/on_death()
+	qdel(src)

--- a/code/modules/cm_tech/hologram.dm
+++ b/code/modules/cm_tech/hologram.dm
@@ -130,7 +130,7 @@ GLOBAL_LIST_EMPTY_TYPED(hologram_list, /mob/hologram)
 	if(viewer)
 		UnregisterSignal(viewer, COMSIG_CLIENT_MOB_MOVE)
 		RegisterSignal(viewer, COMSIG_MOVABLE_MOVED, PROC_REF(handle_move))
-		RegisterSignal(viewer, COMSIG_MOB_GHOSTIZE, PROC_REF(on_ghost))
+		RegisterSignal(viewer, COMSIG_MOB_GHOSTIZE, PROC_REF(end_lookup))
 
 /mob/hologram/look_up/Destroy()
 	if(linked_mob)
@@ -164,7 +164,7 @@ GLOBAL_LIST_EMPTY_TYPED(hologram_list, /mob/hologram)
 		view_registered = FALSE
 		linked_mob.reset_view()
 	else if (!view_registered)
-		RegisterSignal(linked_mob, COMSIG_MOB_RESET_VIEW, PROC_REF(on_death))
+		RegisterSignal(linked_mob, COMSIG_MOB_RESET_VIEW, PROC_REF(end_lookup))
 		view_registered = TRUE
 		linked_mob.reset_view()
 
@@ -184,5 +184,6 @@ GLOBAL_LIST_EMPTY_TYPED(hologram_list, /mob/hologram)
 /mob/hologram/look_up/take_damage(mob/M, damage, damagetype)
 	return //no cancelation of looking up by taking damage
 
-/mob/hologram/look_up/proc/on_ghost()
+/mob/hologram/look_up/proc/end_lookup()
+	SIGNAL_HANDLER
 	qdel(src)

--- a/code/modules/cm_tech/hologram.dm
+++ b/code/modules/cm_tech/hologram.dm
@@ -130,7 +130,7 @@ GLOBAL_LIST_EMPTY_TYPED(hologram_list, /mob/hologram)
 	if(viewer)
 		UnregisterSignal(viewer, COMSIG_CLIENT_MOB_MOVE)
 		RegisterSignal(viewer, COMSIG_MOVABLE_MOVED, PROC_REF(handle_move))
-		RegisterSignal(viewer, COMSIG_MOB_GHOSTIZE, PROC_REF(on_death))
+		RegisterSignal(viewer, COMSIG_MOB_GHOSTIZE, PROC_REF(on_ghost))
 
 /mob/hologram/look_up/Destroy()
 	if(linked_mob)
@@ -184,5 +184,5 @@ GLOBAL_LIST_EMPTY_TYPED(hologram_list, /mob/hologram)
 /mob/hologram/look_up/take_damage(mob/M, damage, damagetype)
 	return //no cancelation of looking up by taking damage
 
-/mob/hologram/look_up/proc/on_death()
+/mob/hologram/look_up/proc/on_ghost()
 	qdel(src)

--- a/code/modules/cm_tech/hologram.dm
+++ b/code/modules/cm_tech/hologram.dm
@@ -146,9 +146,13 @@ GLOBAL_LIST_EMPTY_TYPED(hologram_list, /mob/hologram)
 	if(isturf(M.loc) && isturf(oldLoc))
 		var/turf/mob_turf = M.loc
 		var/turf/old_mob_turf = oldLoc
+		if(!direct)
+			direct = get_dir(old_mob_turf, mob_turf)
 		if(mob_turf.z != old_mob_turf.z)
 			qdel(src)
 			return
+
+
 
 	var/turf/new_turf = get_step(loc, direct)
 	forceMove(new_turf)

--- a/code/modules/cm_tech/hologram.dm
+++ b/code/modules/cm_tech/hologram.dm
@@ -108,7 +108,7 @@ GLOBAL_LIST_EMPTY_TYPED(hologram_list, /mob/hologram)
 
 /datum/action/leave_hologram/Destroy()
 	if(!QDESTROYING(linked_hologram))
-		QDEL_NULL(linked_hologram)
+		qdel(linked_hologram)
 	return ..()
 
 /mob/hologram/techtree/Initialize(mapload, mob/M)
@@ -134,13 +134,16 @@ GLOBAL_LIST_EMPTY_TYPED(hologram_list, /mob/hologram)
 /mob/hologram/look_up/Destroy()
 	if(linked_mob)
 		UnregisterSignal(linked_mob, COMSIG_MOVABLE_MOVED)
+		if(istype(linked_mob, /mob/living))
+			var/mob/living/linked_living
+			linked_living.observed_atom = null
 
 	. = ..()
 
 /mob/hologram/look_up/handle_move(mob/M, oldLoc, direct)
 
 	if(!isturf(M.loc) || HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
-		qdel(src)
+		QDEL_NULL(src)
 		return
 
 	if(isturf(M.loc) && isturf(oldLoc))

--- a/code/modules/cm_tech/hologram.dm
+++ b/code/modules/cm_tech/hologram.dm
@@ -143,7 +143,7 @@ GLOBAL_LIST_EMPTY_TYPED(hologram_list, /mob/hologram)
 /mob/hologram/look_up/handle_move(mob/M, oldLoc, direct)
 
 	if(!isturf(M.loc) || HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
-		QDEL_NULL(src)
+		qdel(src)
 		return
 
 	if(isturf(M.loc) && isturf(oldLoc))

--- a/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_abilities.dm
@@ -8,12 +8,7 @@
 	xeno_cooldown = 3 SECONDS
 	plasma_cost = 0
 
-/datum/action/xeno_action/activable/pounce/facehugger/use_ability(atom/atom)
-	var/mob/living/carbon/xenomorph/xeno = owner
-	if(atom.z != xeno.z)
-		to_chat(xeno, SPAN_XENOWARNING("We can't [action_text] that far!"))
-		return FALSE
-	. = ..()
+
 
 
 	// Config options

--- a/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_abilities.dm
@@ -12,6 +12,7 @@
 	var/mob/living/carbon/xenomorph/xeno = owner
 	if(atom.z != xeno.z)
 		to_chat(xeno, SPAN_XENOWARNING("We can't [action_text] that far!"))
+		return FALSE
 	. = ..()
 
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_abilities.dm
@@ -8,9 +8,6 @@
 	xeno_cooldown = 3 SECONDS
 	plasma_cost = 0
 
-
-
-
 	// Config options
 	knockdown = TRUE
 	knockdown_duration = 0.5

--- a/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_abilities.dm
@@ -8,6 +8,13 @@
 	xeno_cooldown = 3 SECONDS
 	plasma_cost = 0
 
+/datum/action/xeno_action/activable/pounce/facehugger/use_ability(atom/atom)
+	var/mob/living/carbon/xenomorph/xeno = owner
+	if(atom.z != xeno.z)
+		to_chat(xeno, SPAN_XENOWARNING("We can't [action_text] that far!"))
+	. = ..()
+
+
 	// Config options
 	knockdown = TRUE
 	knockdown_duration = 0.5

--- a/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_powers.dm
@@ -30,7 +30,7 @@
 		to_chat(owner, SPAN_WARNING("We cannot do that while immobilized!"))
 		return FALSE
 
-	. = ..()
+	return ..()
 
 /datum/action/xeno_action/onclick/toggle_long_range/facehugger/on_zoom_out()
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_powers.dm
@@ -20,7 +20,7 @@
 		did_hug = facehugger.handle_hug(L)
 	log_attack("[key_name] [did_hug ? "successfully hugged" : "tried to hug"] [key_name(L)] (Pounce Distance: [facehugger.pounce_distance]) at [get_location_in_text(L)]")
 
-/datum/action/xeno_action/activable/pounce/facehugger/use_ability(atom/atom)
+/datum/action/xeno_action/activable/pounce/facehugger/use_ability(atom/target)
 	for(var/obj/structure/machinery/door/airlock/current_airlock in get_turf(owner))
 		if(current_airlock.density) //if its CLOSED YOU'RE SCUTTLING AND CANNOT POUNCE!!!
 			to_chat(owner, SPAN_WARNING("We cannot do that while squeezing and scuttling!"))

--- a/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_powers.dm
@@ -29,11 +29,8 @@
 	if(HAS_TRAIT(owner, TRAIT_IMMOBILIZED))
 		to_chat(owner, SPAN_WARNING("We cannot do that while immobilized!"))
 		return FALSE
-	if(atom.z != owner.z)
-		to_chat(xeno, SPAN_XENOWARNING("We can't [action_text] that far!"))
-		return FALSE
 
-	return ..()
+	. = ..()
 
 /datum/action/xeno_action/onclick/toggle_long_range/facehugger/on_zoom_out()
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/facehugger/facehugger_powers.dm
@@ -20,7 +20,7 @@
 		did_hug = facehugger.handle_hug(L)
 	log_attack("[key_name] [did_hug ? "successfully hugged" : "tried to hug"] [key_name(L)] (Pounce Distance: [facehugger.pounce_distance]) at [get_location_in_text(L)]")
 
-/datum/action/xeno_action/activable/pounce/facehugger/use_ability()
+/datum/action/xeno_action/activable/pounce/facehugger/use_ability(atom/atom)
 	for(var/obj/structure/machinery/door/airlock/current_airlock in get_turf(owner))
 		if(current_airlock.density) //if its CLOSED YOU'RE SCUTTLING AND CANNOT POUNCE!!!
 			to_chat(owner, SPAN_WARNING("We cannot do that while squeezing and scuttling!"))
@@ -29,7 +29,10 @@
 	if(HAS_TRAIT(owner, TRAIT_IMMOBILIZED))
 		to_chat(owner, SPAN_WARNING("We cannot do that while immobilized!"))
 		return FALSE
-	
+	if(atom.z != owner.z)
+		to_chat(xeno, SPAN_XENOWARNING("We can't [action_text] that far!"))
+		return FALSE
+
 	return ..()
 
 /datum/action/xeno_action/onclick/toggle_long_range/facehugger/on_zoom_out()

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -525,7 +525,7 @@
 
 	X.pounce_distance = get_dist(X, A)
 	if(X.z != A.z)
-		X.pounce_distance ++
+		X.pounce_distance++
 	X.throw_atom(A, distance, throw_speed, X, launch_type = LOW_LAUNCH, pass_flags = pounce_pass_flags, collision_callbacks = pounce_callbacks, tracking=TRUE)
 	X.update_icons()
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -531,6 +531,7 @@
 
 	additional_effects_always()
 
+	SEND_SIGNAL(X, COMSIG_CLIENT_MOB_MOVE)
 	if(X.observed_atom)
 		QDEL_NULL(X.observed_atom)
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -525,11 +525,15 @@
 
 	X.pounce_distance = get_dist(X, A)
 	if(X.z != A.z)
-		X.pounce_distance++
+		X.pounce_distance += 2
 	X.throw_atom(A, distance, throw_speed, X, launch_type = LOW_LAUNCH, pass_flags = pounce_pass_flags, collision_callbacks = pounce_callbacks, tracking=TRUE)
 	X.update_icons()
 
 	additional_effects_always()
+
+	if(X.observed_atom)
+		QDEL_NULL(X.observed_atom)
+
 	..()
 
 	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -530,7 +530,6 @@
 	X.update_icons()
 
 	additional_effects_always()
-
 	..()
 
 	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -531,10 +531,6 @@
 
 	additional_effects_always()
 
-	SEND_SIGNAL(X, COMSIG_CLIENT_MOB_MOVE)
-	if(X.observed_atom)
-		QDEL_NULL(X.observed_atom)
-
 	..()
 
 	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -524,6 +524,8 @@
 	pre_pounce_effects()
 
 	X.pounce_distance = get_dist(X, A)
+	if(X.z != A.z)
+		X.pounce_distance ++
 	X.throw_atom(A, distance, throw_speed, X, launch_type = LOW_LAUNCH, pass_flags = pounce_pass_flags, collision_callbacks = pounce_callbacks, tracking=TRUE)
 	X.update_icons()
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -26,7 +26,7 @@
 	GLOB.living_mob_list -= src
 	cleanup_status_effects()
 	pipes_shown = null
-	observed_atom = null
+	QDEL_NULL(observed_atom)
 
 	. = ..()
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -415,13 +415,6 @@
 
 	..()
 
-/mob/living/throw_atom(atom/target, range, speed = 0, atom/thrower, spin, launch_type = NORMAL_LAUNCH, pass_flags = NO_FLAGS, list/end_throw_callbacks, list/collision_callbacks, tracking = FALSE)
-	var/turf/above = SSmapping.get_turf_above(thrower)
-	if(above && above.z == target.z)
-		to_chat(thrower, SPAN_WARNING("You can't throw someone that high!"))
-		return
-	..()
-
 /mob/living/launch_towards(datum/launch_metadata/LM, tracking = FALSE)
 	if(src)
 		SEND_SIGNAL(src, COMSIG_MOB_MOVE_OR_LOOK, TRUE, dir, dir)

--- a/code/modules/movement/launching/launching.dm
+++ b/code/modules/movement/launching/launching.dm
@@ -189,8 +189,12 @@
 	throwing = TRUE
 
 	add_temp_pass_flags(pass_flags)
-
-	var/turf/start_turf = get_step_towards(src, LM.target)
+	var/turf/start_turf
+	var/turf/above = SSmapping.get_turf_above(loc)
+	if(LM.target.z > z && istype(above, /turf/open_space))
+		start_turf = above
+	else
+		start_turf = get_step_towards(src, LM.target)
 	var/list/turf/path = get_line(start_turf, LM.target)
 	var/last_loc = loc
 

--- a/code/modules/movement/launching/launching.dm
+++ b/code/modules/movement/launching/launching.dm
@@ -210,11 +210,9 @@
 			break
 		if (!Move(T)) // If this returns FALSE, then a collision happened
 			break
-		SEND_SIGNAL(src, COMSIG_CLIENT_MOB_MOVE, T, get_dir(last_loc, T))
 		last_loc = loc
 		if (++LM.dist >= LM.range)
 			break
-
 		sleep(delay)
 
 	//done throwing, either because it hit something or it finished moving

--- a/code/modules/movement/launching/launching.dm
+++ b/code/modules/movement/launching/launching.dm
@@ -210,9 +210,11 @@
 			break
 		if (!Move(T)) // If this returns FALSE, then a collision happened
 			break
+		SEND_SIGNAL(src, COMSIG_CLIENT_MOB_MOVE, T, get_dir(last_loc, T))
 		last_loc = loc
 		if (++LM.dist >= LM.range)
 			break
+
 		sleep(delay)
 
 	//done throwing, either because it hit something or it finished moving


### PR DESCRIPTION
# About the pull request

Prevents huggers from hugging across z levels
fixes #8692 fixes #9801 fixes #9760 , fixes #9900 and fixes #9721 (that has already been fixed before and dupe report)

# Explain why it's good for the game

Being hugged by hugger from upper level is not intended


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: prevents huggers from hugging across z levels
balance: pounces are one tile shorter when going up a z level
fix: fixes being unable to pounce/throw stuff up a z level when next to an edge
fix: fixes majority of issues with looking up not being updated on movement, report any remaining issues 
fix: crossing z level ends looking up correctly
/:cl:
