### PR TITLE
Fix runtimes caused by facehuggers gibbing after deleted

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -99,6 +99,9 @@
 	if(stat == DEAD)
 		return
 
+	if(QDELETED(src))
+		return
+
 	if(!aghosted)
 		gib()
 


### PR DESCRIPTION

# About the pull request
This PR is a follow up to #9384 and simply adds another check to facehuggers to prevent gibbing (from logout) after a hug (which already qdels)

# Explain why it's good for the game

Fixes:
<img width="1607" height="995" alt="image" src="https://github.com/user-attachments/assets/e4c16961-274f-4f15-9317-0e9fe7d18f3e" />

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/user-attachments/assets/89fbd59d-42c6-48d5-98a7-53bc1544ad29

</details>


# Changelog
:cl: Drathek
fix: Fixed runtimes caused by playable huggers hugging
/:cl:
