### PR TITLE
Fixes medical laptop returning a null entry when weakref doesn't resolve

### DIFF
--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -154,7 +154,6 @@
 		ui.open()
 
 /obj/structure/machinery/computer/med_data/proc/gather_record_data(mob/user, datum/data/record/general)
-
 	if(!general)
 		return
 
@@ -168,12 +167,14 @@
 
 	if(target_ref)
 		target = target_ref.resolve()
-		if(!target)	// if the target has been gibbed, or no longer physically exists
-			return
-		id = target.get_idcard()
-		// checks if record target is in the chain of command, and needs their record protected
-		if(target.job in CHAIN_OF_COMMAND_ROLES)
-			record_classified = TRUE
+		if(target)	// null if the target has been gibbed, or no longer physically exists
+			id = target.get_idcard()
+			// checks if record target is in the chain of command, and needs their record protected
+			if(target.job in CHAIN_OF_COMMAND_ROLES)
+				record_classified = TRUE
+
+	if(!record_classified && (general.fields["rank"] in CHAIN_OF_COMMAND_ROLES))
+		record_classified = TRUE
 
 	var/paygrade = id ? id.paygrade : "None"
 


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #9210 fixing an incorrect early return in `gather_record_data` ever the weakref to the mob doesn't resolve.

# Explain why it's good for the game

Fixes #10621 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Gibbed people don't crash the ui:
<img width="964" height="770" alt="image" src="https://github.com/user-attachments/assets/a1303524-7ec0-4510-abce-580a0db40dc6" />

Even confidentiality permission persists if it was a command gibbed and the viewer doesn't have sufficient access.
<img width="1176" height="803" alt="image" src="https://github.com/user-attachments/assets/6244097d-8964-4325-b617-41cd1c247d3c" />

</details>


# Changelog
:cl: Drathek
fix: Fixed medical laptop UI crashing when someone has been gibbed
/:cl:
