### PR TITLE
Rigged crate fixes and balancing

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -271,7 +271,7 @@
 			if(!C.stasis_mob)
 				return
 			M = C.stasis_mob
-			C.open()
+			C.open(user)
 			user.stop_pulling()
 			user.start_pulling(M)
 		else

--- a/code/game/machinery/medical_pod/medical_pod.dm
+++ b/code/game/machinery/medical_pod/medical_pod.dm
@@ -181,7 +181,7 @@
 				to_chat(user, SPAN_WARNING("\The [C] is empty!"))
 				return
 			to_put_in = C.stasis_mob
-			C.open()
+			C.open(user)
 			user.start_pulling(to_put_in)
 		else if(ismob(G.grabbed_thing))
 			to_put_in = G.grabbed_thing

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -172,14 +172,14 @@
 	. = ..()
 
 
-/obj/structure/closet/bodybag/close()
+/obj/structure/closet/bodybag/close(mob/user)
 	if(..())
 		density = FALSE
 		update_name()
 		return 1
 	return 0
 
-/obj/structure/closet/bodybag/open()
+/obj/structure/closet/bodybag/open(mob/user, force)
 	. = ..()
 	update_name()
 
@@ -286,7 +286,7 @@
 
 		overlays |= holo_card_icon
 
-/obj/structure/closet/bodybag/cryobag/open()
+/obj/structure/closet/bodybag/cryobag/open(mob/user, force)
 	. = ..()
 	if(stasis_mob)
 		stasis_mob.in_stasis = FALSE

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -135,7 +135,7 @@
 		return
 
 	else if(istype(W, /obj/item/weapon/zombie_claws))
-		open()
+		open(user)
 
 /obj/structure/closet/bodybag/store_mobs(stored_units) // overriding this
 	var/list/dead_mobs = list()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -90,11 +90,12 @@
 				M.visible_message(SPAN_WARNING("[M] suddenly gets out of [src]!"),
 				SPAN_WARNING("You get out of [src] and get your bearings!"))
 
-/obj/structure/closet/proc/open(mob/user)
+/// Attempts to open this closet by user, skipping checks that prevent opening if forced
+/obj/structure/closet/proc/open(mob/user, force)
 	if(opened)
 		return FALSE
 
-	if(!can_open())
+	if(!force && !can_open())
 		return FALSE
 
 	dump_contents()
@@ -386,7 +387,7 @@
 /obj/structure/closet/proc/break_open(mob/user)
 	if(!opened)
 		welded = FALSE
-		open(user)
+		open(user, force=TRUE)
 
 /obj/structure/closet/yautja
 	name = "alien closet"

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -90,21 +90,21 @@
 				M.visible_message(SPAN_WARNING("[M] suddenly gets out of [src]!"),
 				SPAN_WARNING("You get out of [src] and get your bearings!"))
 
-/obj/structure/closet/proc/open()
+/obj/structure/closet/proc/open(mob/user)
 	if(opened)
-		return 0
+		return FALSE
 
 	if(!can_open())
-		return 0
+		return FALSE
 
 	dump_contents()
 
 	UnregisterSignal(src, COMSIG_CLOSET_FLASHBANGED)
-	opened = 1
+	opened = TRUE
 	update_icon()
-	playsound(src.loc, open_sound, 15, 1)
+	playsound(loc, open_sound, 15, 1)
 	density = FALSE
-	return 1
+	return TRUE
 
 /obj/structure/closet/proc/close(mob/user)
 	if(!src.opened)
@@ -159,7 +159,7 @@
 
 /obj/structure/closet/proc/toggle(mob/living/user)
 	user.next_move = world.time + 5
-	if(!(src.opened ? src.close(user) : src.open()))
+	if(!(opened ? close(user) : open(user)))
 		to_chat(user, SPAN_NOTICE("It won't budge!"))
 	return
 
@@ -333,7 +333,7 @@
 		qdel(src)
 		return
 
-	if(!src.open())
+	if(!open(user))
 		to_chat(user, SPAN_NOTICE("It won't budge!"))
 		if(!lastbang)
 			lastbang = 1
@@ -383,10 +383,10 @@
 			proxy_object_heard(src, M, TM, text, verb, language, italics)
 #endif // ifdef OBJECTS_PROXY_SPEECH
 
-/obj/structure/closet/proc/break_open()
+/obj/structure/closet/proc/break_open(mob/user)
 	if(!opened)
-		welded = 0
-		open()
+		welded = FALSE
+		open(user)
 
 /obj/structure/closet/yautja
 	name = "alien closet"

--- a/code/game/objects/structures/crates_lockers/closets/crittercrate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/crittercrate.dm
@@ -4,3 +4,6 @@
 	icon_state = "critter"
 	icon_opened = "critteropen"
 	icon_closed = "critter"
+
+/obj/structure/closet/crate/critter/attempt_rigging(obj/item/object, mob/user)
+	return FALSE // No rigging

--- a/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
@@ -187,8 +187,8 @@
 		hasaxe = 1
 	icon_state = text("fireaxe[][][][]",hasaxe,src.localopened,src.hitstaken,src.smashed)
 
-/obj/structure/closet/fireaxecabinet/open()
+/obj/structure/closet/fireaxecabinet/open(mob/user, force)
 	return
 
-/obj/structure/closet/fireaxecabinet/close()
+/obj/structure/closet/fireaxecabinet/close(mob/user)
 	return

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -11,7 +11,7 @@
 	anchored = FALSE
 	throwpass = 1 //prevents moving crates by hurling things at them
 	store_mobs = FALSE
-	var/rigged = 0
+	var/rigged = FALSE
 	/// Types this crate can be made into
 	var/list/crate_customizing_types = list(
 		"Plain" = /obj/structure/closet/crate,
@@ -32,6 +32,7 @@
 		"Charlie" = /obj/structure/closet/crate/charlie,
 		"Delta" = /obj/structure/closet/crate/delta,
 	)
+	COOLDOWN_DECLARE(rigged_activation_cooldown)
 
 /obj/structure/closet/crate/initialize_pass_flags(datum/pass_flags_container/PF)
 	..()
@@ -55,30 +56,31 @@
 
 	return ..()
 
-/obj/structure/closet/crate/open()
+/obj/structure/closet/crate/open(mob/user)
 	if(opened)
-		return 0
+		return FALSE
 	if(!can_open())
-		return 0
+		return FALSE
 
 	if(rigged && locate(/obj/item/device/radio/electropack) in src)
-		if(isliving(usr))
-			var/mob/living/L = usr
-			if(L.electrocute_act(17, src))
-				var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
-				s.set_up(5, 1, src)
-				s.start()
+		if(isliving(user) && COOLDOWN_FINISHED(src, rigged_activation_cooldown))
+			var/mob/living/living_user = user
+			if(living_user.electrocute_act(17, src))
+				COOLDOWN_START(src, rigged_activation_cooldown, 3 SECONDS)
+				var/datum/effect_system/spark_spread/sparker = new /datum/effect_system/spark_spread
+				sparker.set_up(5, 1, src)
+				sparker.start()
 				return 2
 
 	playsound(src.loc, 'sound/machines/click.ogg', 15, 1)
-	for(var/obj/O in src)
-		O.forceMove(get_turf(src))
-	opened = 1
+	for(var/obj/thing in src)
+		thing.forceMove(get_turf(src))
+	opened = TRUE
 	update_icon()
 	if(climbable)
 		structure_shaken()
-		climbable = 0 //Open crate is not a surface that works when climbing around
-	return 1
+		climbable = FALSE //Open crate is not a surface that works when climbing around
+	return TRUE
 
 /obj/structure/closet/crate/close()
 	if(!opened)
@@ -107,37 +109,77 @@
 	update_icon()
 	return 1
 
-/obj/structure/closet/crate/attackby(obj/item/W as obj, mob/user as mob)
-	if(W.flags_item & ITEM_ABSTRACT)
+/obj/structure/closet/crate/attackby(obj/item/object, mob/user)
+	if(object.flags_item & ITEM_ABSTRACT)
 		return
 	if(opened)
-		user.drop_inv_item_to_loc(W, loc)
-	else if(istype(W, /obj/item/packageWrap) || istype(W, /obj/item/stack/fulton) || istype(W, /obj/item/tool/hand_labeler)) //If it does something to the crate, don't open it.
+		user.drop_inv_item_to_loc(object, loc)
 		return
-	else if(istype(W, /obj/item/stack/cable_coil))
-		var/obj/item/stack/cable_coil/C = W
+	if(istype(object, /obj/item/packageWrap) || istype(object, /obj/item/stack/fulton) || istype(object, /obj/item/tool/hand_labeler)) //If it does something to the crate, don't open it.
+		return
+	if(attempt_rigging(object, user))
+		return
+	return attack_hand(user)
+
+/// Returns TRUE if any rigging handling was performed (even if nothing changed)
+/obj/structure/closet/crate/proc/attempt_rigging(obj/item/object, mob/user)
+	if(istype(object, /obj/item/stack/cable_coil))
+		var/obj/item/stack/cable_coil/cable = object
 		if(rigged)
-			to_chat(user, SPAN_NOTICE("[src] is already rigged!"))
-			return
-		if (C.use(1))
-			to_chat(user, SPAN_NOTICE("You rig [src]."))
-			rigged = 1
-			return
-	else if(istype(W, /obj/item/device/radio/electropack))
-		if(rigged)
-			overlays += "securecrate_tampered"
-			to_chat(user, SPAN_NOTICE("You attach [W] to [src]."))
+			to_chat(user, SPAN_NOTICE("[src] is already wired for rigging!"))
+			return TRUE
+		if(cable.use(1))
+			var/pack = locate(/obj/item/device/radio/electropack) in src
+			if(pack)
+				to_chat(user, SPAN_NOTICE("You wire [src] and rig it with [pack]."))
+			else
+				to_chat(user, SPAN_NOTICE("You wire [src] for rigging."))
+			rigged = TRUE
+			update_icon()
+		return TRUE
+	if(istype(object, /obj/item/device/radio/electropack))
+		if(rigged && !(locate(/obj/item/device/radio/electropack) in src))
+			to_chat(user, SPAN_NOTICE("You attach [object] to [src] and rig it."))
 			user.drop_held_item()
-			W.forceMove(src)
-			return
-	else if(HAS_TRAIT(W, TRAIT_TOOL_WIRECUTTERS))
+			object.forceMove(src)
+		return TRUE
+	if(HAS_TRAIT(object, TRAIT_TOOL_WIRECUTTERS))
 		if(rigged)
 			to_chat(user, SPAN_NOTICE("You cut away the wiring."))
 			playsound(loc, 'sound/items/Wirecutter.ogg', 25, 1)
-			rigged = 0
-			return
-	else
-		return attack_hand(user)
+			rigged = FALSE
+			update_icon()
+		return TRUE
+	return FALSE
+
+/obj/structure/closet/crate/foodcart/attempt_rigging(obj/item/object, mob/user)
+	return FALSE // No rigging
+
+/obj/structure/closet/crate/miningcar/attempt_rigging(obj/item/object, mob/user)
+	return FALSE // No rigging
+
+/obj/structure/closet/crate/trashcart/attempt_rigging(obj/item/object, mob/user)
+	return FALSE // No rigging
+
+/obj/structure/closet/crate/freezer/cooler/attempt_rigging(obj/item/object, mob/user)
+	return FALSE // No rigging
+
+/obj/structure/closet/crate/supply/attempt_rigging(obj/item/object, mob/user)
+	return FALSE // No rigging because its wooden I guess
+
+/obj/structure/closet/crate/explosives/attempt_rigging(obj/item/object, mob/user)
+	return FALSE // No rigging because its wooden I guess
+
+/obj/structure/closet/crate/empexplosives/attempt_rigging(obj/item/object, mob/user)
+	return FALSE // No rigging because its wooden I guess
+
+/obj/structure/closet/crate/secure/explosives/attempt_rigging(obj/item/object, mob/user)
+	return FALSE // No rigging because its wooden I guess
+
+/obj/structure/closet/crate/update_icon()
+	. = ..()
+	if(rigged)
+		overlays += "securecrate_tampered"
 
 /obj/structure/closet/crate/ex_act(severity)
 	switch(severity)
@@ -156,7 +198,7 @@
 
 /obj/structure/closet/crate/alpha
 	name = "alpha squad crate"
-	desc = "A crate with alpha squad's symbol on it. "
+	desc = "A crate with alpha squad'sparker symbol on it. "
 	icon_state = "closed_alpha"
 	icon_opened = "open_alpha"
 	icon_closed = "closed_alpha"
@@ -191,14 +233,14 @@
 
 /obj/structure/closet/crate/bravo
 	name = "bravo squad crate"
-	desc = "A crate with bravo squad's symbol on it. "
+	desc = "A crate with bravo squad'sparker symbol on it. "
 	icon_state = "closed_bravo"
 	icon_opened = "open_bravo"
 	icon_closed = "closed_bravo"
 
 /obj/structure/closet/crate/charlie
 	name = "charlie squad crate"
-	desc = "A crate with charlie squad's symbol on it. "
+	desc = "A crate with charlie squad'sparker symbol on it. "
 	icon_state = "closed_charlie"
 	icon_opened = "open_charlie"
 	icon_closed = "closed_charlie"
@@ -212,7 +254,7 @@
 
 /obj/structure/closet/crate/delta
 	name = "delta squad crate"
-	desc = "A crate with delta squad's symbol on it. "
+	desc = "A crate with delta squad'sparker symbol on it. "
 	icon_state = "closed_delta"
 	icon_opened = "open_delta"
 	icon_closed = "closed_delta"

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -167,15 +167,6 @@
 /obj/structure/closet/crate/supply/attempt_rigging(obj/item/object, mob/user)
 	return FALSE // No rigging because its wooden I guess
 
-/obj/structure/closet/crate/explosives/attempt_rigging(obj/item/object, mob/user)
-	return FALSE // No rigging because its wooden I guess
-
-/obj/structure/closet/crate/empexplosives/attempt_rigging(obj/item/object, mob/user)
-	return FALSE // No rigging because its wooden I guess
-
-/obj/structure/closet/crate/secure/explosives/attempt_rigging(obj/item/object, mob/user)
-	return FALSE // No rigging because its wooden I guess
-
 /obj/structure/closet/crate/update_icon()
 	. = ..()
 	if(rigged)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -198,7 +198,7 @@
 
 /obj/structure/closet/crate/alpha
 	name = "alpha squad crate"
-	desc = "A crate with alpha squad'sparker symbol on it. "
+	desc = "A crate with alpha squad's symbol on it. "
 	icon_state = "closed_alpha"
 	icon_opened = "open_alpha"
 	icon_closed = "closed_alpha"
@@ -233,14 +233,14 @@
 
 /obj/structure/closet/crate/bravo
 	name = "bravo squad crate"
-	desc = "A crate with bravo squad'sparker symbol on it. "
+	desc = "A crate with bravo squad's symbol on it. "
 	icon_state = "closed_bravo"
 	icon_opened = "open_bravo"
 	icon_closed = "closed_bravo"
 
 /obj/structure/closet/crate/charlie
 	name = "charlie squad crate"
-	desc = "A crate with charlie squad'sparker symbol on it. "
+	desc = "A crate with charlie squad's symbol on it. "
 	icon_state = "closed_charlie"
 	icon_opened = "open_charlie"
 	icon_closed = "closed_charlie"
@@ -254,7 +254,7 @@
 
 /obj/structure/closet/crate/delta
 	name = "delta squad crate"
-	desc = "A crate with delta squad'sparker symbol on it. "
+	desc = "A crate with delta squad's symbol on it. "
 	icon_state = "closed_delta"
 	icon_opened = "open_delta"
 	icon_closed = "closed_delta"

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -56,10 +56,10 @@
 
 	return ..()
 
-/obj/structure/closet/crate/open(mob/user)
+/obj/structure/closet/crate/open(mob/user, force)
 	if(opened)
 		return FALSE
-	if(!can_open())
+	if(!force && !can_open())
 		return FALSE
 
 	if(rigged && locate(/obj/item/device/radio/electropack) in src)
@@ -70,7 +70,8 @@
 				var/datum/effect_system/spark_spread/sparker = new /datum/effect_system/spark_spread
 				sparker.set_up(5, 1, src)
 				sparker.start()
-				return 2
+				if(!force)
+					return 2
 
 	playsound(src.loc, 'sound/machines/click.ogg', 15, 1)
 	for(var/obj/thing in src)
@@ -82,7 +83,7 @@
 		climbable = FALSE //Open crate is not a surface that works when climbing around
 	return TRUE
 
-/obj/structure/closet/crate/close()
+/obj/structure/closet/crate/close(mob/user)
 	if(!opened)
 		return 0
 	if(!can_close())

--- a/code/modules/cm_marines/equipment/gear.dm
+++ b/code/modules/cm_marines/equipment/gear.dm
@@ -138,7 +138,7 @@
 			is_animating = FALSE //animation finished
 			return
 
-/obj/structure/closet/bodybag/tarp/open()
+/obj/structure/closet/bodybag/tarp/open(mob/user)
 	COOLDOWN_START(src, toggle_delay, 3 SECONDS) //3 seconds must pass before tarp can be closed
 	. = ..()
 	handle_cloaking()

--- a/code/modules/cm_marines/equipment/gear.dm
+++ b/code/modules/cm_marines/equipment/gear.dm
@@ -138,7 +138,7 @@
 			is_animating = FALSE //animation finished
 			return
 
-/obj/structure/closet/bodybag/tarp/open(mob/user)
+/obj/structure/closet/bodybag/tarp/open(mob/user, force)
 	COOLDOWN_START(src, toggle_delay, 3 SECONDS) //3 seconds must pass before tarp can be closed
 	. = ..()
 	handle_cloaking()

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -951,7 +951,7 @@
 			if(welded)
 				difficulty = 30 // if its welded shut it should be harder to smash open
 			if(prob(difficulty))
-				break_open()
+				break_open(M)
 				M.visible_message(SPAN_DANGER("[M] smashes \the [src] open!"),
 				SPAN_DANGER("We smash \the [src] open!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 		else

--- a/code/modules/mob/living/living_verbs.dm
+++ b/code/modules/mob/living/living_verbs.dm
@@ -71,7 +71,7 @@
 			return
 		visible_message("[BB] begins to wiggle violently!")
 		if(do_after(src, 5 SECONDS, INTERRUPT_UNCONSCIOUS, BUSY_ICON_HOSTILE, BB))//5 second unzip from inside
-			BB.open()
+			BB.open(src)
 
 		///The medical machines below are listed separately to allow easier changes to each process
 
@@ -159,7 +159,7 @@
 			if(istype(SC.loc, /obj/structure/bigDelivery)) //Do this to prevent contents from being opened into nullspace (read: bluespace)
 				var/obj/structure/bigDelivery/BD = SC.loc
 				BD.attack_hand(src)
-			SC.open()
+			SC.open(src)
 			return
 		else
 			C.welded = 0
@@ -170,7 +170,7 @@
 			if(istype(C.loc, /obj/structure/bigDelivery)) //nullspace ect... read the comment above
 				var/obj/structure/bigDelivery/BD = C.loc
 				BD.attack_hand(src)
-			C.open()
+			C.open(src)
 			return
 
 	//breaking out of handcuffs & putting out fires

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -37,8 +37,6 @@
 	var/ico[0] //Icons and
 	var/offset_x[0] //offsets stored for later
 	var/offset_y[0] //usage by the photocopier
-	var/rigged = 0
-	var/spam_flag = 0
 
 	// any photos that might be attached to the paper
 	var/list/photo_list


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #10499 which stuck in the rigged crate sprite but it still had issues namely in that the overlay was only applied when the electropack is inserted, no cooldown, and opening/closing would reset overlay despite still potentially being rigged, as well as the overlay being applied to more crates than desired, etc.

# Explain why it's good for the game

- Prevents excessive electrocution spam
- Allows you to fake crates being rigged by only wiring them (no electropack)
- Adds a cooldown to its electrocution (so could be disarmed without wirecutters)
- Overlays properly work rather than there being a way to hide them
- Several kinds of crates are now not riggable (mostly for visual reasons but)
- Fixes edgecases where opening behavior would always trigger electrocution to `usr` even if they wouldn't be touching it themselves
- Misc code cleanup

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/C7wY-m-nMEE

Test merged with #10536 :

https://github.com/user-attachments/assets/e1f64353-d66b-477b-a0a5-7683afa7fa97

</details>


# Changelog
:cl: Drathek
balance: Some crates are no longer riggable
balance: Xenos can break open crates even if normally unopenable (e.g. secure crates)
balance: Rigged crate electrocution now has a 3s cooldown
fix: Rigging crate overlays now applies when wired (not necessarily with an electropack) and is properly retained when opened
fix: Fixed edge cases where a rigged crate opening would electrocute usr even if they weren't physically touching it
code: Various code cleanup including user arguments for open and breakopen
/:cl:
