### PR TITLE
Add lint for range/hearers optimization

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -209,8 +209,8 @@
 	var/hear_dist = 7
 	if(max_distance)
 		hear_dist = max_distance
-	for(var/mob/M as anything in hearers(hear_dist, src.loc))
-		M.show_message(message, SHOW_MESSAGE_AUDIBLE, deaf_message, SHOW_MESSAGE_VISIBLE, message_flags = message_flags)
+	for(var/mob/current in hearers(hear_dist, loc))
+		current.show_message(message, SHOW_MESSAGE_AUDIBLE, deaf_message, SHOW_MESSAGE_VISIBLE, message_flags = message_flags)
 
 /atom/proc/ranged_message(message, blind_message, max_distance, message_flags = CHAT_TYPE_OTHER)
 	var/view_dist = 7

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -218,6 +218,13 @@ if $grep 'to_chat\(("|SPAN)' $code_files; then
 	st=1
 fi;
 
+part "deoptimization of range/hearers with as anything"
+if $grep 'as anything in o?(range|hearers)\(' $code_files; then
+	echo
+	echo -e "${RED}ERROR: range(), orange(), hearers(), and ohearers() perform significantly worse with as anything.${NC}"
+	st=1
+fi;
+
 section "515 Proc Syntax"
 part "proc ref syntax"
 if $grep '\.proc/' $code_x_515 ; then


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #6692 finding another optimization: range, orange, hearers, ohearers should be used with type checking else they will have a much larger scope of things to work through skipping any engine optimizations to type checking primitives.

# Explain why it's good for the game

For example:
```js
#define SIZE 10
#define VAL var/turf/C
#define S_VAL var/turf/special/C
#define RECT_TURFS(H_RADIUS,V_RADIUS,CENTER) \
  block( \
    (CENTER).x-(H_RADIUS),(CENTER).y-(V_RADIUS),(CENTER).z,\
    (CENTER).x+(H_RADIUS),(CENTER).y+(V_RADIUS),(CENTER).z \
  )
#define RANGE_TURFS(Dist,Center) RECT_TURFS(Dist,Dist,Center)
var/temp
/turf/special
/proc/range_test(any,special)
  var/turf/start = locate(SIZE,SIZE,1)
  if(any)
    if(special)
      for(S_VAL as anything in range(SIZE,start))
        temp = C.x
    else
      for(VAL as anything in range(SIZE,start))
        temp = C.x
  else
    if(special)
      for(S_VAL in range(SIZE,start))
        temp = C.x
    else
      for(VAL in range(SIZE,start))
        temp = C.x
/proc/range_turf_test(any,special)
  var/turf/start = locate(SIZE,SIZE,1)
  if(any)
    if(special)
      for(S_VAL as anything in RANGE_TURFS(SIZE,start))
        temp = C.x
    else
      for(VAL as anything in RANGE_TURFS(SIZE,start))
        temp = C.x
  else
    if(special)
      for(S_VAL in RANGE_TURFS(SIZE,start))
        temp = C.x
    else
      for(VAL in RANGE_TURFS(SIZE,start))
        temp = C.x
WORLD(SIZE*2,SIZE*2,1)
MAIN
  for(var/turf/C in world)
    for(var/x in 1 to 5)
      new /obj(C)
  BEGIN_BENCH(8)
    BENCH_PHASE("range",range_test(0,0))
    BENCH_PHASE("anything range",range_test(1,0))
    BENCH_PHASE("RANGE_TURFS",range_turf_test(0,0))
    BENCH_PHASE("anything RANGE_TURFS",range_turf_test(1,0))
    BENCH_PHASE("special range",range_test(0,1))
    BENCH_PHASE("special anything range",range_test(1,1))
    BENCH_PHASE("special RANGE_TURFS",range_turf_test(0,1))
    BENCH_PHASE("special anything RANGE_TURFS",range_turf_test(1,1))
  END_BENCH
```
Produces the following benchmark:
<img width="610" height="614" alt="image" src="https://github.com/user-attachments/assets/a3a18275-eb32-43cc-acc1-25e669e29817" />

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="742" height="873" alt="image" src="https://github.com/user-attachments/assets/ed219bd8-2a42-4725-8282-b7f464fdde6a" />

</details>


# Changelog
:cl: Drathek
code: Added a lint for optimization of range, orange, hearers, and ohearers
/:cl:
