### PR TITLE
Fixes `the the` in digital clock examine.

### DIFF
--- a/code/game/objects/items/misc.dm
+++ b/code/game/objects/items/misc.dm
@@ -302,4 +302,4 @@
 
 /obj/item/clock/get_examine_text(mob/user)
 	. = ..()
-	. += SPAN_NOTICE("The [src] reads: [GLOB.current_date_string] - [worldtime2text()]")
+	. += SPAN_NOTICE("The [name] reads: [GLOB.current_date_string] - [worldtime2text()]")


### PR DESCRIPTION
Fixes `the the` output when examining a digital clock.
# About the pull request
Fixing bug is good.
<!-- Remove this text and explain what the purpose of your PR is.
Fixes an output bug to do with examine text.
Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Fixes a logical bug.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixed clocks outputting "the" twice on examine.
/:cl:
