### PR TITLE
Detonating on hitting open space fix

### DIFF
--- a/code/datums/ammo/bullet/shotgun.dm
+++ b/code/datums/ammo/bullet/shotgun.dm
@@ -24,8 +24,8 @@
 	damage_armor_punch = 2
 	handful_state = "slug_shell"
 
-/datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/M,obj/projectile/P)
-	knockback(M, P, 6)
+/datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/M,obj/projectile/projectile)
+	knockback(M, projectile, 6)
 
 /datum/ammo/bullet/shotgun/slug/knockback_effects(mob/living/living_mob, obj/projectile/fired_projectile)
 	if(iscarbonsizexeno(living_mob))
@@ -70,8 +70,8 @@
 	shell_speed = AMMO_SPEED_TIER_3
 	handful_state = "beanbag_slug"
 
-/datum/ammo/bullet/shotgun/beanbag/on_hit_mob(mob/M, obj/projectile/P)
-	if(!M || M == P.firer)
+/datum/ammo/bullet/shotgun/beanbag/on_hit_mob(mob/M, obj/projectile/projectile)
+	if(!M || M == projectile.firer)
 		return
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
@@ -96,7 +96,7 @@
 	shell_speed = AMMO_SPEED_TIER_4
 	handful_state = "shock_slug"
 
-/datum/ammo/bullet/shotgun/beanbag/es7/on_hit_mob(mob/mobs, obj/projectile/P)
+/datum/ammo/bullet/shotgun/beanbag/es7/on_hit_mob(mob/mobs, obj/projectile/projectile)
 	if(!isyautja(mobs) && !isxeno(mobs))
 		mobs.emote("pain")
 		mobs.sway_jitter(2,1)
@@ -124,15 +124,18 @@
 		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_incendiary)
 	))
 
-/datum/ammo/bullet/shotgun/incendiary/on_hit_mob(mob/M,obj/projectile/P)
-	burst(get_turf(M),P,damage_type)
-	knockback(M,P)
+/datum/ammo/bullet/shotgun/incendiary/on_hit_mob(mob/M,obj/projectile/projectile)
+	burst(get_turf(M),projectile,damage_type)
+	knockback(M,projectile)
 
-/datum/ammo/bullet/shotgun/incendiary/on_hit_obj(obj/O,obj/projectile/P)
-	burst(get_turf(P),P,damage_type)
+/datum/ammo/bullet/shotgun/incendiary/on_hit_obj(obj/O,obj/projectile/projectile)
+	burst(get_turf(projectile),projectile,damage_type)
 
-/datum/ammo/bullet/shotgun/incendiary/on_hit_turf(turf/T,obj/projectile/P)
-	burst(get_turf(T),P,damage_type)
+/datum/ammo/bullet/shotgun/incendiary/on_hit_turf(turf/turf,obj/projectile/projectile)
+	if(istype(turf,/turf/open_space))
+		.=..()
+		return
+	burst(get_turf(turf),projectile,damage_type)
 
 
 /datum/ammo/bullet/shotgun/flechette
@@ -206,8 +209,8 @@
 		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_incendiary)
 	))
 
-/datum/ammo/bullet/shotgun/buckshot/on_hit_mob(mob/M,obj/projectile/P)
-	knockback(M,P)
+/datum/ammo/bullet/shotgun/buckshot/on_hit_mob(mob/M,obj/projectile/projectile)
+	knockback(M,projectile)
 
 //buckshot variant only used by the masterkey shotgun attachment.
 /datum/ammo/bullet/shotgun/buckshot/masterkey
@@ -215,8 +218,8 @@
 
 	damage = 55
 
-/datum/ammo/bullet/shotgun/buckshot/masterkey/on_hit_mob(mob/M,obj/projectile/P)
-	knockback(M,P,1)
+/datum/ammo/bullet/shotgun/buckshot/masterkey/on_hit_mob(mob/M,obj/projectile/projectile)
+	knockback(M,projectile,1)
 
 /datum/ammo/bullet/shotgun/spread
 	name = "additional buckshot"
@@ -257,8 +260,8 @@
 	damage_armor_punch = 0
 	pen_armor_punch = 0
 
-/datum/ammo/bullet/shotgun/heavy/buckshot/on_hit_mob(mob/M,obj/projectile/P)
-	knockback(M,P)
+/datum/ammo/bullet/shotgun/heavy/buckshot/on_hit_mob(mob/M,obj/projectile/projectile)
+	knockback(M,projectile)
 
 /datum/ammo/bullet/shotgun/heavy/buckshot/spread
 	name = "additional heavy buckshot"
@@ -301,8 +304,8 @@
 	penetration = ARMOR_PENETRATION_TIER_6
 	damage_armor_punch = 2
 
-/datum/ammo/bullet/shotgun/heavy/slug/on_hit_mob(mob/M,obj/projectile/P)
-	knockback(M, P, 7)
+/datum/ammo/bullet/shotgun/heavy/slug/on_hit_mob(mob/M,obj/projectile/projectile)
+	knockback(M, projectile, 7)
 
 /datum/ammo/bullet/shotgun/heavy/slug/knockback_effects(mob/living/living_mob, obj/projectile/fired_projectile)
 	if(iscarbonsizexeno(living_mob))
@@ -334,8 +337,8 @@
 	accuracy = HIT_ACCURACY_TIER_2
 	shell_speed = AMMO_SPEED_TIER_2
 
-/datum/ammo/bullet/shotgun/heavy/beanbag/on_hit_mob(mob/M, obj/projectile/P)
-	if(!M || M == P.firer)
+/datum/ammo/bullet/shotgun/heavy/beanbag/on_hit_mob(mob/M, obj/projectile/projectile)
+	if(!M || M == projectile.firer)
 		return
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
@@ -441,18 +444,18 @@
 	effective_range_max = EFFECTIVE_RANGE_MAX_TIER_2 //Full damage up to this distance, then falloff for each tile beyond.
 	var/hit_messages = list()
 
-/datum/ammo/bullet/shotgun/twobore/on_hit_mob(mob/living/M, obj/projectile/P)
-	var/mob/shooter = P.firer
+/datum/ammo/bullet/shotgun/twobore/on_hit_mob(mob/living/M, obj/projectile/projectile)
+	var/mob/shooter = projectile.firer
 	if(shooter && ismob(shooter) && HAS_TRAIT(shooter, TRAIT_TWOBORE_TRAINING) && M.stat != DEAD && prob(40)) //Death is handled by periodic life() checks so this should have a chance to fire on a killshot.
 		if(!length(hit_messages)) //Pick and remove lines, refill on exhaustion.
 			hit_messages = list("Got you!", "Aha!", "Bullseye!", "It's curtains for you, Sonny Jim!", "Your head will look fantastic on my wall!", "I have you now!", "You miserable coward! Come and fight me like a man!", "Tally ho!")
 		var/message = pick_n_take(hit_messages)
 		shooter.say(message)
 
-	if(P.distance_travelled > 8)
-		knockback(M, P, 12)
+	if(projectile.distance_travelled > 8)
+		knockback(M, projectile, 12)
 
-	else if(!M || M == P.firer || M.body_position == LYING_DOWN) //These checks are included in knockback and would be redundant above.
+	else if(!M || M == projectile.firer || M.body_position == LYING_DOWN) //These checks are included in knockback and would be redundant above.
 		return
 
 	shake_camera(M, 3, 4)
@@ -464,7 +467,7 @@
 	else //This will hammer a Yautja as hard as a human.
 		to_chat(M, SPAN_HIGHDANGER("The impact knocks you off your feet!"))
 
-	step(M, get_dir(P.firer, M))
+	step(M, get_dir(projectile.firer, M))
 
 /datum/ammo/bullet/shotgun/twobore/knockback_effects(mob/living/living_mob, obj/projectile/fired_projectile)
 	if(iscarbonsizexeno(living_mob))

--- a/code/datums/ammo/bullet/tank.dm
+++ b/code/datums/ammo/bullet/tank.dm
@@ -23,22 +23,25 @@
 	max_range = 32
 	shell_speed = AMMO_SPEED_TIER_6
 
-/datum/ammo/bullet/tank/flak/on_hit_mob(mob/M,obj/projectile/P)
-	burst(get_turf(M),P,damage_type, 2 , 3)
-	burst(get_turf(M),P,damage_type, 1 , 3 , 0)
+/datum/ammo/bullet/tank/flak/on_hit_mob(mob/M,obj/projectile/projectile)
+	burst(get_turf(M),projectile,damage_type, 2 , 3)
+	burst(get_turf(M),projectile,damage_type, 1 , 3 , 0)
 
-/datum/ammo/bullet/tank/flak/on_near_target(turf/T, obj/projectile/P)
-	burst(get_turf(T),P,damage_type, 2 , 3)
-	burst(get_turf(T),P,damage_type, 1 , 3, 0)
+/datum/ammo/bullet/tank/flak/on_near_target(turf/turf, obj/projectile/projectile)
+	burst(get_turf(turf),projectile,damage_type, 2 , 3)
+	burst(get_turf(turf),projectile,damage_type, 1 , 3, 0)
 	return 1
 
-/datum/ammo/bullet/tank/flak/on_hit_obj(obj/O,obj/projectile/P)
-	burst(get_turf(P),P,damage_type, 2 , 3)
-	burst(get_turf(P),P,damage_type, 1 , 3 , 0)
+/datum/ammo/bullet/tank/flak/on_hit_obj(obj/O,obj/projectile/projectile)
+	burst(get_turf(projectile),projectile,damage_type, 2 , 3)
+	burst(get_turf(projectile),projectile,damage_type, 1 , 3 , 0)
 
-/datum/ammo/bullet/tank/flak/on_hit_turf(turf/T,obj/projectile/P)
-	burst(get_turf(T),P,damage_type, 2 , 3)
-	burst(get_turf(T),P,damage_type, 1 , 3 , 0)
+/datum/ammo/bullet/tank/flak/on_hit_turf(turf/turf,obj/projectile/projectile)
+	if(istype(turf,/turf/open_space))
+		.=..()
+		return
+	burst(get_turf(turf),projectile,damage_type, 2 , 3)
+	burst(get_turf(turf),projectile,damage_type, 1 , 3 , 0)
 
 /datum/ammo/bullet/tank/dualcannon
 	name = "dualcannon bullet"
@@ -55,24 +58,27 @@
 	max_range = 12
 	shell_speed = AMMO_SPEED_TIER_5
 
-/datum/ammo/bullet/tank/dualcannon/on_hit_mob(mob/M,obj/projectile/P)
+/datum/ammo/bullet/tank/dualcannon/on_hit_mob(mob/M,obj/projectile/projectile)
 	for(var/mob/living/carbon/L in get_turf(M))
 		if(L.stat == CONSCIOUS && L.mob_size <= MOB_SIZE_XENO)
 			shake_camera(L, 1, 1)
 
-/datum/ammo/bullet/tank/dualcannon/on_near_target(turf/T, obj/projectile/P)
-	for(var/mob/living/carbon/L in T)
+/datum/ammo/bullet/tank/dualcannon/on_near_target(turf/turf, obj/projectile/projectile)
+	for(var/mob/living/carbon/L in turf)
 		if(L.stat == CONSCIOUS && L.mob_size <= MOB_SIZE_XENO)
 			shake_camera(L, 1, 1)
 	return 1
 
-/datum/ammo/bullet/tank/dualcannon/on_hit_obj(obj/O,obj/projectile/P)
+/datum/ammo/bullet/tank/dualcannon/on_hit_obj(obj/O,obj/projectile/projectile)
 	for(var/mob/living/carbon/L in get_turf(O))
 		if(L.stat == CONSCIOUS && L.mob_size <= MOB_SIZE_XENO)
 			shake_camera(L, 1, 1)
 
-/datum/ammo/bullet/tank/dualcannon/on_hit_turf(turf/T,obj/projectile/P)
-	for(var/mob/living/carbon/L in T)
+/datum/ammo/bullet/tank/dualcannon/on_hit_turf(turf/turf,obj/projectile/projectile)
+	if(istype(turf,/turf/open_space))
+		.=..()
+		return
+	for(var/mob/living/carbon/L in turf)
 		if(L.stat == CONSCIOUS && L.mob_size <= MOB_SIZE_XENO)
 			shake_camera(L, 1, 1)
 

--- a/code/datums/ammo/energy.dm
+++ b/code/datums/ammo/energy.dm
@@ -147,6 +147,9 @@
 	do_area_stun(stun_projectile)
 
 /datum/ammo/energy/yautja/caster/sphere/aoe_stun/on_hit_turf(turf/any_turf, obj/projectile/stun_projectile)
+	if(istype(any_turf,/turf/open_space))
+		.=..()
+		return
 	do_area_stun(stun_projectile)
 
 /datum/ammo/energy/yautja/caster/sphere/aoe_stun/on_hit_obj(obj/any_object, obj/projectile/stun_projectile)
@@ -201,7 +204,10 @@
 /datum/ammo/energy/yautja/caster/aoe_lethal/on_hit_mob(mob/all_targets, obj/projectile/lethal_projectile)
 	cell_explosion(lethal_projectile, 170, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, lethal_projectile.weapon_cause_data)
 
-/datum/ammo/energy/yautja/caster/aoe_lethal/on_hit_turf(mob/all_targets, obj/projectile/lethal_projectile)
+/datum/ammo/energy/yautja/caster/aoe_lethal/on_hit_turf(turf/any_turf, mob/all_targets, obj/projectile/lethal_projectile)
+	if(istype(any_turf,/turf/open_space))
+		.=..()
+		return
 	cell_explosion(lethal_projectile, 170, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, lethal_projectile.weapon_cause_data)
 
 /datum/ammo/energy/yautja/caster/aoe_lethal/on_hit_obj(obj/any_object, obj/projectile/lethal_projectile)

--- a/code/datums/ammo/misc.dm
+++ b/code/datums/ammo/misc.dm
@@ -42,8 +42,11 @@
 /datum/ammo/flamethrower/on_hit_obj(obj/O, obj/projectile/P)
 	drop_flame(get_turf(O), P.weapon_cause_data)
 
-/datum/ammo/flamethrower/on_hit_turf(turf/T, obj/projectile/P)
-	drop_flame(T, P.weapon_cause_data)
+/datum/ammo/flamethrower/on_hit_turf(turf/any_turf, obj/projectile/P)
+	if(istype(any_turf,/turf/open_space))
+		.=..()
+		return
+	drop_flame(any_turf, P.weapon_cause_data)
 
 /datum/ammo/flamethrower/do_at_max_range(obj/projectile/P)
 	drop_flame(get_turf(P), P.weapon_cause_data)
@@ -89,10 +92,10 @@
 	. = ..()
 	smoke = new()
 
-/datum/ammo/flamethrower/sentry_flamer/glob/drop_flame(turf/T, datum/cause_data/cause_data)
-	if(!istype(T))
+/datum/ammo/flamethrower/sentry_flamer/glob/drop_flame(turf/any_turf, datum/cause_data/cause_data)
+	if(!istype(any_turf))
 		return
-	smoke.set_up(1, 0, T, new_cause_data = cause_data)
+	smoke.set_up(1, 0, any_turf, new_cause_data = cause_data)
 	smoke.start()
 
 /datum/ammo/flamethrower/sentry_flamer/glob/Destroy()
@@ -102,12 +105,12 @@
 /datum/ammo/flamethrower/sentry_flamer/mini
 	name = "normal fire"
 
-/datum/ammo/flamethrower/sentry_flamer/mini/drop_flame(turf/T, datum/cause_data/cause_data)
-	if(!istype(T))
+/datum/ammo/flamethrower/sentry_flamer/mini/drop_flame(turf/any_turf, datum/cause_data/cause_data)
+	if(!istype(any_turf))
 		return
 	var/datum/reagent/napalm/ut/R = new()
 	R.durationfire = BURN_TIME_INSTANT
-	new /obj/flamer_fire(T, cause_data, R, 0)
+	new /obj/flamer_fire(any_turf, cause_data, R, 0)
 
 /datum/ammo/flamethrower/sentry_flamer/wy
 	name = "sticky fire"
@@ -145,17 +148,20 @@
 /datum/ammo/flare/on_hit_obj(obj/O,obj/projectile/P)
 	drop_flare(get_turf(P), P, P.firer)
 
-/datum/ammo/flare/on_hit_turf(turf/T, obj/projectile/P)
-	if(T.density && isturf(P.loc))
+/datum/ammo/flare/on_hit_turf(turf/any_turf, obj/projectile/P)
+	if(istype(any_turf,/turf/open_space))
+		.=..()
+		return
+	if(any_turf.density && isturf(P.loc))
 		drop_flare(P.loc, P, P.firer)
 	else
-		drop_flare(T, P, P.firer)
+		drop_flare(any_turf, P, P.firer)
 
 /datum/ammo/flare/do_at_max_range(obj/projectile/P, mob/firer)
 	drop_flare(get_turf(P), P, P.firer)
 
-/datum/ammo/flare/proc/drop_flare(turf/T, obj/projectile/fired_projectile, mob/firer)
-	var/obj/item/device/flashlight/flare/G = new flare_type(T)
+/datum/ammo/flare/proc/drop_flare(turf/any_turf, obj/projectile/fired_projectile, mob/firer)
+	var/obj/item/device/flashlight/flare/G = new flare_type(any_turf)
 	var/matrix/rotation = matrix()
 	rotation.Turn(fired_projectile.angle - 90)
 	G.apply_transform(rotation)
@@ -168,7 +174,7 @@
 	flare_type = /obj/item/device/flashlight/flare/signal/gun
 	handful_type = /obj/item/device/flashlight/flare/signal
 
-/datum/ammo/flare/signal/drop_flare(turf/T, obj/projectile/fired_projectile, mob/firer)
+/datum/ammo/flare/signal/drop_flare(turf/any_turf, obj/projectile/fired_projectile, mob/firer)
 	var/obj/item/device/flashlight/flare/signal/gun/signal_flare = ..()
 	signal_flare.activate_signal(firer)
 	if(istype(fired_projectile.shot_from, /obj/item/weapon/gun/flare))
@@ -198,8 +204,8 @@
 		return
 	target_organ.embed(new shrapnel_type)
 
-/datum/ammo/arrow/proc/drop_arrow(turf/T, obj/projectile/fired_projectile)
-	var/obj/item/arrow/arrow = new handful_type(T)
+/datum/ammo/arrow/proc/drop_arrow(turf/any_turf, obj/projectile/fired_projectile)
+	var/obj/item/arrow/arrow = new handful_type(any_turf)
 	var/matrix/rotation = matrix()
 	rotation.Turn(fired_projectile.angle - 90)
 	arrow.apply_transform(rotation)
@@ -215,6 +221,9 @@
 	drop_arrow(get_turf(projectile), projectile)
 
 /datum/ammo/arrow/on_hit_turf(turf/turf, obj/projectile/projectile)
+	if(istype(turf,/turf/open_space))
+		.=..()
+		return
 	if(turf.density && isturf(projectile.loc))
 		drop_arrow(projectile.loc, projectile)
 	else
@@ -244,7 +253,11 @@
 	cell_explosion(get_turf(projectile), 150, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
 	smoke.set_up(1, get_turf(projectile))
 	smoke.start()
+
 /datum/ammo/arrow/expl/on_hit_turf(turf/turf, obj/projectile/projectile)
+	if(istype(turf,/turf/open_space))
+		.=..()
+		return
 	if(turf.density && isturf(projectile.loc))
 		cell_explosion(get_turf(projectile), 150, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
 		smoke.set_up(1, get_turf(projectile))
@@ -317,7 +330,10 @@
 /datum/ammo/souto/on_hit_obj(obj/O,obj/projectile/P)
 	drop_can(P.loc, P) //We make a can at the location.
 
-/datum/ammo/souto/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/souto/on_hit_turf(turf/any_turf, obj/projectile/P)
+	if(istype(any_turf,/turf/open_space))
+		.=..()
+		return
 	drop_can(P.loc, P) //We make a can at the location.
 
 /datum/ammo/souto/do_at_max_range(obj/projectile/P)
@@ -353,16 +369,19 @@
 /datum/ammo/grenade_container/on_hit_obj(obj/O,obj/projectile/P)
 	drop_nade(P)
 
-/datum/ammo/grenade_container/on_hit_turf(turf/T,obj/projectile/P)
+/datum/ammo/grenade_container/on_hit_turf(turf/any_turf,obj/projectile/P)
+	if(istype(any_turf,/turf/open_space))
+		.=..()
+		return
 	drop_nade(P)
 
 /datum/ammo/grenade_container/do_at_max_range(obj/projectile/P)
 	drop_nade(P)
 
 /datum/ammo/grenade_container/proc/drop_nade(obj/projectile/P)
-	var/turf/T = get_turf(P)
-	var/obj/item/explosive/grenade/G = new nade_type(T)
-	G.visible_message(SPAN_WARNING("\A [G] lands on [T]!"))
+	var/turf/any_turf = get_turf(P)
+	var/obj/item/explosive/grenade/G = new nade_type(any_turf)
+	G.visible_message(SPAN_WARNING("\A [G] lands on [any_turf]!"))
 	G.det_time = 10
 	G.cause_data = P.weapon_cause_data
 	G.activate()
@@ -395,14 +414,17 @@
 /datum/ammo/hugger_container/on_hit_obj(obj/O,obj/projectile/P)
 	spawn_hugger(get_turf(P))
 
-/datum/ammo/hugger_container/on_hit_turf(turf/T,obj/projectile/P)
+/datum/ammo/hugger_container/on_hit_turf(turf/any_turf,obj/projectile/P)
+	if(istype(any_turf,/turf/open_space))
+		.=..()
+		return
 	spawn_hugger(get_turf(P))
 
 /datum/ammo/hugger_container/do_at_max_range(obj/projectile/P)
 	spawn_hugger(get_turf(P))
 
-/datum/ammo/hugger_container/proc/spawn_hugger(turf/T)
-	var/obj/item/clothing/mask/facehugger/child = new(T)
+/datum/ammo/hugger_container/proc/spawn_hugger(turf/any_turf)
+	var/obj/item/clothing/mask/facehugger/child = new(any_turf)
 	child.hivenumber = hugger_hive
 	INVOKE_ASYNC(child, TYPE_PROC_REF(/obj/item/clothing/mask/facehugger, leap_at_nearest_target))
 

--- a/code/datums/ammo/rocket.dm
+++ b/code/datums/ammo/rocket.dm
@@ -41,6 +41,9 @@
 	smoke.start()
 
 /datum/ammo/rocket/on_hit_turf(turf/turf, obj/projectile/projectile)
+	if(istype(turf,/turf/open_space))
+		.=..()
+		return
 	cell_explosion(turf, 150, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
 	smoke.set_up(1, turf)
 	smoke.start()
@@ -82,6 +85,9 @@
 	smoke.start()
 
 /datum/ammo/rocket/ap/on_hit_turf(turf/turf, obj/projectile/projectile)
+	if(istype(turf,/turf/open_space))
+		.=..()
+		return
 	var/hit_something = 0
 	for(var/mob/mob in turf)
 		mob.ex_act(150, projectile.dir, projectile.weapon_cause_data, 100)
@@ -167,6 +173,9 @@
 	cell_explosion(get_turf(object), 200, 100, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
 
 /datum/ammo/rocket/ltb/on_hit_turf(turf/turf, obj/projectile/projectile)
+	if(istype(turf,/turf/open_space))
+		.=..()
+		return
 	cell_explosion(get_turf(turf), 220, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
 	cell_explosion(get_turf(turf), 200, 100, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
 
@@ -211,6 +220,9 @@
 	drop_flame(get_turf(object), projectile.weapon_cause_data)
 
 /datum/ammo/rocket/wp/on_hit_turf(turf/turf, obj/projectile/projectile)
+	if(istype(turf,/turf/open_space))
+		.=..()
+		return
 	drop_flame(turf, projectile.weapon_cause_data)
 
 /datum/ammo/rocket/wp/do_at_max_range(obj/projectile/projectile)
@@ -248,6 +260,9 @@
 	drop_flame(get_turf(object), projectile.weapon_cause_data)
 
 /datum/ammo/rocket/wp/upp/on_hit_turf(turf/turf, obj/projectile/projectile)
+	if(istype(turf,/turf/open_space))
+		.=..()
+		return
 	drop_flame(turf, projectile.weapon_cause_data)
 
 /datum/ammo/rocket/wp/upp/do_at_max_range(obj/projectile/projectile)
@@ -270,6 +285,9 @@
 	explosion(projectile.loc,  -1, 2, 4, 5, , , ,projectile.weapon_cause_data)
 
 /datum/ammo/rocket/wp/quad/on_hit_turf(turf/turf, obj/projectile/projectile)
+	if(istype(turf,/turf/open_space))
+		.=..()
+		return
 	drop_flame(turf, projectile.weapon_cause_data)
 	explosion(projectile.loc,  -1, 2, 4, 5, , , ,projectile.weapon_cause_data)
 
@@ -303,6 +321,9 @@
 	prime(object, projectile)
 
 /datum/ammo/rocket/custom/on_hit_turf(turf/turf, obj/projectile/projectile)
+	if(istype(turf,/turf/open_space))
+		.=..()
+		return
 	prime(turf, projectile)
 
 /datum/ammo/rocket/custom/do_at_max_range(obj/projectile/projectile)
@@ -336,6 +357,9 @@
 	INVOKE_ASYNC(src,PROC_REF(prime), object, projectile)
 
 /datum/ammo/rocket/brute/on_hit_turf(turf/turf, obj/projectile/projectile)
+	if(istype(turf,/turf/open_space))
+		.=..()
+		return
 	INVOKE_ASYNC(src,PROC_REF(prime), turf, projectile)
 
 /datum/ammo/rocket/brute/do_at_max_range(obj/projectile/projectile)

--- a/code/datums/ammo/xeno.dm
+++ b/code/datums/ammo/xeno.dm
@@ -264,11 +264,14 @@
 /datum/ammo/xeno/boiler_gas/on_hit_obj(obj/outbacksteakhouse, obj/projectile/proj)
 	drop_nade(get_turf(proj), proj)
 
-/datum/ammo/xeno/boiler_gas/on_hit_turf(turf/Turf, obj/projectile/proj)
-	if(Turf.density && isturf(proj.loc))
+/datum/ammo/xeno/boiler_gas/on_hit_turf(turf/turf, obj/projectile/proj)
+	if(istype(turf,/turf/open_space))
+		.=..()
+		return
+	if(turf.density && isturf(proj.loc))
 		drop_nade(proj.loc, proj) //we don't want the gas globs to land on dense turfs, they block smoke expansion.
 	else
-		drop_nade(Turf, proj)
+		drop_nade(turf, proj)
 
 /datum/ammo/xeno/boiler_gas/do_at_max_range(obj/projectile/proj)
 	drop_nade(get_turf(proj), proj)

--- a/code/modules/projectiles/guns/specialist/sharp.dm
+++ b/code/modules/projectiles/guns/specialist/sharp.dm
@@ -112,8 +112,11 @@
 /datum/ammo/rifle/sharp/on_hit_obj(obj/O, obj/projectile/P)
 	drop_dart(P.loc, P)
 
-/datum/ammo/rifle/sharp/on_hit_turf(turf/T, obj/projectile/P)
-	drop_dart(T, P)
+/datum/ammo/rifle/sharp/on_hit_turf(turf/turf, obj/projectile/P)
+	if(istype(turf,/turf/open_space))
+		.=..()
+		return
+	drop_dart(turf, P)
 
 /datum/ammo/rifle/sharp/do_at_max_range(obj/projectile/P)
 	drop_dart(P.loc, P)
@@ -225,8 +228,11 @@
 /datum/ammo/rifle/sharp/flechette/on_hit_obj(obj/O, obj/projectile/P)
 	create_flechette(O.loc, P)
 
-/datum/ammo/rifle/sharp/flechette/on_hit_turf(turf/T, obj/projectile/P)
-	create_flechette(T, P)
+/datum/ammo/rifle/sharp/flechette/on_hit_turf(turf/turf, obj/projectile/P)
+	if(istype(turf,/turf/open_space))
+		.=..()
+		return
+	create_flechette(turf, P)
 
 /datum/ammo/rifle/sharp/flechette/do_at_max_range(obj/projectile/P)
 	create_flechette(P.loc, P)


### PR DESCRIPTION
# About the pull request

impacts of ammo should not happen on hiting open_space, fixes a LOT of projectile behavior, fixes #10001
also renamed bunch of single letter vars when I was there, you are just looking for additions of (or simmilar with other var)

	if(istype(turf,/turf/open_space))
		.=..()
		return

# Explain why it's good for the game

impacts do not trigger by hitting air, that is how it should be.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: impact projectiles do not trigger on impacting open_space, boiler gas, plasma caster, SHARP, SADAR and many more
/:cl:
