### PR TITLE
Fix more missing html headers needed for webview in browse

### DIFF
--- a/code/__DEFINES/html_assistant.dm
+++ b/code/__DEFINES/html_assistant.dm
@@ -1,0 +1,5 @@
+#define HTML_SKELETON_INTERNAL(head, body) \
+"<!DOCTYPE html><html><head><meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><meta http-equiv='X-UA-Compatible' content='IE=edge'>[head]</head><body>[body]</body></html>"
+
+#define HTML_SKELETON_TITLE(title, body) HTML_SKELETON_INTERNAL("<title>[title]</title>", body)
+#define HTML_SKELETON(body) HTML_SKELETON_INTERNAL("", body)

--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -96,7 +96,7 @@
 				dat += "<a href='byond://?src=\ref[src];choice=access;access=[A]'>[area]</a><br>"
 		dat += "<br><a href='byond://?src=\ref[src];action=issue'>Issue pass</a><br>"
 
-	user << browse(dat, "window=guestpass;size=400x520")
+	user << browse(HTML_SKELETON(dat), "window=guestpass;size=400x520")
 	onclose(user, "guestpass")
 
 

--- a/code/game/machinery/robot_fabricator.dm
+++ b/code/game/machinery/robot_fabricator.dm
@@ -56,7 +56,7 @@ Please wait until completion...</TT><BR>
 <A href='byond://?src=\ref[src];make=7'>Robot Frame (75,000 cc metal).<BR>
 "}
 
-	user << browse("<HEAD><TITLE>Robotic Fabricator Control Panel</TITLE></HEAD><TT>[dat]</TT>", "window=robot_fabricator")
+	user << browse(HTML_SKELETON_TITLE("Robotic Fabricator Control Panel", "<TT>[dat]</TT>"), "window=robot_fabricator")
 	onclose(user, "robot_fabricator")
 	return
 

--- a/code/game/objects/items/implants/implantpad.dm
+++ b/code/game/objects/items/implants/implantpad.dm
@@ -70,7 +70,7 @@
 			dat += "The implant casing is empty."
 	else
 		dat += "Please insert an implant casing!"
-	user << browse(dat, "window=implantpad")
+	user << browse(HTML_SKELETON(dat), "window=implantpad")
 	onclose(user, "implantpad")
 	return
 

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -84,7 +84,7 @@
 	if (!locked)
 		message = "*****"
 	dat += text("<HR>\n>[]<BR>\n<A href='byond://?src=\ref[];type=1'>1</A>-<A href='byond://?src=\ref[];type=2'>2</A>-<A href='byond://?src=\ref[];type=3'>3</A><BR>\n<A href='byond://?src=\ref[];type=4'>4</A>-<A href='byond://?src=\ref[];type=5'>5</A>-<A href='byond://?src=\ref[];type=6'>6</A><BR>\n<A href='byond://?src=\ref[];type=7'>7</A>-<A href='byond://?src=\ref[];type=8'>8</A>-<A href='byond://?src=\ref[];type=9'>9</A><BR>\n<A href='byond://?src=\ref[];type=R'>R</A>-<A href='byond://?src=\ref[];type=0'>0</A>-<A href='byond://?src=\ref[];type=E'>E</A><BR>\n</TT>", message, src, src, src, src, src, src, src, src, src, src, src, src)
-	user << browse(dat, "window=caselock;size=300x280")
+	user << browse(HTML_SKELETON(dat), "window=caselock;size=300x280")
 
 /obj/item/storage/secure/Topic(href, href_list)
 	..()

--- a/code/modules/admin/tag.dm
+++ b/code/modules/admin/tag.dm
@@ -100,7 +100,7 @@
 		dat += "No datums tagged :("
 
 	dat = dat.Join("<br>")
-	usr << browse(dat, "window=tag;size=800x480")
+	usr << browse(HTML_SKELETON(dat), "window=tag;size=800x480")
 
 #undef TAG_DEL
 #undef TAG_MARK

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -564,7 +564,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/sdql2_vv_all, new(null
 			if(length(select_text))
 				var/text = islist(select_text)? select_text.Join() : select_text
 				var/static/result_offset = 0
-				showmob << browse(text, "window=SDQL-result-[result_offset++]")
+				showmob << browse(HTML_SKELETON(text), "window=SDQL-result-[result_offset++]")
 	show_next_to_key = null
 	if(qdel_on_finish)
 		qdel(src)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -339,7 +339,7 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 			msg += "Your version: [byond_version].[byond_build]<br>"
 			msg += "Required version to remove this message: [warn_version].[warn_build] or later<br>"
 			msg += "Visit <a href=\"https://www.byond.com/download\">BYOND's website</a> to get the latest version of BYOND.<br>"
-			src << browse(msg, "window=warning_popup")
+			src << browse(HTML_SKELETON(msg), "window=warning_popup")
 		else
 			to_chat(src, SPAN_DANGER("<b>Your version of BYOND may be getting out of date:</b>"))
 			to_chat(src, CONFIG_GET(string/client_warn_message))

--- a/code/modules/mapping/verify.dm
+++ b/code/modules/mapping/verify.dm
@@ -39,7 +39,7 @@
 				html += "<ul><li>[messages.Join("</li><li>")]</li></ul>"
 			html += "</li>"
 		html += "</ul></p>"
-	C << browse(html.Join(), "window=[tag];size=600x400")
+	C << browse(HTML_SKELETON(html.Join()), "window=[tag];size=600x400")
 
 /datum/map_report/Topic(href, href_list)
 	. = ..()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -119,7 +119,7 @@
 	for(var/datum/language/L in languages)
 		dat += "<b>[L.name] (:[L.key])</b><br/>Speech Synthesizer: <i>[(L in speech_synthesizer_langs)? "YES":"NOT SUPPORTED"]</i><br/>[L.desc]<br/><br/>"
 
-	src << browse(dat, "window=checklanguage")
+	src << browse(HTML_SKELETON(dat), "window=checklanguage")
 	return
 
 

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -315,7 +315,7 @@ display floor(lastgen) and phorontank amount
 	dat += text("Power current: [(powernet == null ? "Unconnected" : "[avail()]")]<br>")
 	dat += text("Heat: [heat]<br>")
 	dat += "<br><A href='byond://?src=\ref[src];action=close'>Close</A>"
-	user << browse("[dat]", "window=port_gen")
+	user << browse(HTML_SKELETON(dat), "window=port_gen")
 	onclose(user, "port_gen")
 
 /obj/structure/machinery/power/port_gen/pacman/Topic(href, href_list)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -351,7 +351,7 @@
 
 	dat += "</tr></table><br>Current Selection: [currTag ? currTag : "None"]</tt>"
 
-	user << browse(dat, "window=destTagScreen;size=450x350")
+	user << browse(HTML_SKELETON(dat), "window=destTagScreen;size=450x350")
 	onclose(user, "destTagScreen")
 
 /obj/item/device/destTagger/attack_self(mob/user)

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -67,6 +67,7 @@
 #include "code\__DEFINES\guns.dm"
 #include "code\__DEFINES\hijack.dm"
 #include "code\__DEFINES\html.dm"
+#include "code\__DEFINES\html_assistant.dm"
 #include "code\__DEFINES\hud.dm"
 #include "code\__DEFINES\human.dm"
 #include "code\__DEFINES\job.dm"


### PR DESCRIPTION

# About the pull request

This PR partially ports https://github.com/tgstation/tgstation/pull/89766 updating some `browse` calls that would create a browser without proper headers. Webview sometimes will force this to render as text rather than assume html, so some helper defines put in some basic headers to force the browse to display as html.

# Explain why it's good for the game

Fixes SDQL MAP queries like `SDQL2-query "SELECT /obj/item/stack/sheet/metal WHERE (global._get_step(src,0)).z == 2 MAP [src,amount]` displaying this:
<img width="402" height="432" alt="image" src="https://github.com/user-attachments/assets/3cf79809-7686-4d4d-af5b-35c2a179ad1d" />


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="2019" height="1096" alt="image" src="https://github.com/user-attachments/assets/44d6d420-5b61-49ba-86b4-57f159e15b1d" />

</details>


# Changelog
:cl: Drathek
fix: Fix some busted browse calls displaying as text instead of html
/:cl:
