### PR TITLE
extra projectile multiz fix

### DIFF
--- a/code/datums/ammo/ammo.dm
+++ b/code/datums/ammo/ammo.dm
@@ -259,7 +259,7 @@
 			if(below)
 				new_target = below
 
-		if(cur_target.z > new_target.z)
+		else if(cur_target.z > new_target.z)
 			var/turf/above = SSmapping.get_turf_above(new_target)
 			if(above)
 				new_target = above


### PR DESCRIPTION

# About the pull request

extra (shotgun) projectiles are fired on the same z level as the main projectile

# Explain why it's good for the game
shotguns work correctly and you do not FF the shit out of people when firing flachete up a z level


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: extra (shotgun) projectiles are fired on the same z level as the main shot
/:cl:
