### PR TITLE
multiz smoke

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -14,6 +14,7 @@
 	anchored = TRUE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	layer = ABOVE_MOB_LAYER + 0.1 //above mobs and barricades
+	flags_atom = NO_ZFALL
 	var/amount = 2
 	var/spread_speed = 1 //time in decisecond for a smoke to spread one tile.
 	var/time_to_live = 8
@@ -87,6 +88,7 @@
 		return
 
 	var/turf/start_turf = get_turf(src)
+	var/list/turfs_to_spread = list()
 	if(!start_turf)
 		return
 	for(var/i in GLOB.cardinals)
@@ -101,7 +103,20 @@
 				qdel(foundsmoke)
 			else
 				continue
-		var/obj/effect/particle_effect/smoke/smoke = new type(cur_turf, amount, cause_data)
+		turfs_to_spread += cur_turf
+
+
+
+	var/turf/below = SSmapping.get_turf_below(loc)
+	var/turf/above = SSmapping.get_turf_above(loc)
+	if(below && istype(loc,/turf/open_space))
+		turfs_to_spread += below
+
+	if(above && istype(above,/turf/open_space))
+		turfs_to_spread += above
+
+	for(var/turf/spread in turfs_to_spread)
+		var/obj/effect/particle_effect/smoke/smoke = new type(spread, amount, cause_data)
 		smoke.setDir(pick(GLOB.cardinals))
 		smoke.time_to_live = time_to_live
 		if(smoke.amount > 0)

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -115,6 +115,9 @@
 			if(foundsmoke.smokeranking <= src.smokeranking)
 				qdel(foundsmoke)
 				turfs_to_spread += below
+		else
+			turfs_to_spread += below
+
 
 	if(above && istype(above,/turf/open_space))
 		var/obj/effect/particle_effect/smoke/foundsmoke = locate() in above
@@ -122,6 +125,8 @@
 			if(foundsmoke.smokeranking <= src.smokeranking)
 				qdel(foundsmoke)
 				turfs_to_spread += above
+		else
+			turfs_to_spread += below
 
 	for(var/turf/spread in turfs_to_spread)
 		var/obj/effect/particle_effect/smoke/smoke = new type(spread, amount, cause_data)

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -126,7 +126,7 @@
 				qdel(foundsmoke)
 				turfs_to_spread += above
 		else
-			turfs_to_spread += below
+			turfs_to_spread += above
 
 	for(var/turf/spread in turfs_to_spread)
 		var/obj/effect/particle_effect/smoke/smoke = new type(spread, amount, cause_data)

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -110,10 +110,18 @@
 	var/turf/below = SSmapping.get_turf_below(loc)
 	var/turf/above = SSmapping.get_turf_above(loc)
 	if(below && istype(loc,/turf/open_space))
-		turfs_to_spread += below
+		var/obj/effect/particle_effect/smoke/foundsmoke = locate() in below
+		if(foundsmoke)
+			if(foundsmoke.smokeranking <= src.smokeranking)
+				qdel(foundsmoke)
+				turfs_to_spread += below
 
 	if(above && istype(above,/turf/open_space))
-		turfs_to_spread += above
+		var/obj/effect/particle_effect/smoke/foundsmoke = locate() in above
+		if(foundsmoke)
+			if(foundsmoke.smokeranking <= src.smokeranking)
+				qdel(foundsmoke)
+				turfs_to_spread += above
 
 	for(var/turf/spread in turfs_to_spread)
 		var/obj/effect/particle_effect/smoke/smoke = new type(spread, amount, cause_data)


### PR DESCRIPTION
# About the pull request

smokes spreads up and down a z level, moving up/down counts as a step of spreading

# Explain why it's good for the game

better and cooler multiz smoke behavior


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
<img width="370" height="504" alt="image" src="https://github.com/user-attachments/assets/0f032a20-023b-4730-b570-8b4c01be8025" />
<img width="587" height="567" alt="image" src="https://github.com/user-attachments/assets/0f3d9a7b-36e1-4361-b391-05b5a79763a1" />
<img width="392" height="347" alt="image" src="https://github.com/user-attachments/assets/7486240f-3ea5-4008-b786-36eb2eebf46a" />
<img width="515" height="593" alt="image" src="https://github.com/user-attachments/assets/67e0d364-5983-403d-a4ba-40d4998367a4" />


Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Smokes spread up and down a z level
/:cl:
