### PR TITLE
Adds time remaining to hivemind collapse warning.

### DIFF
--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -447,7 +447,7 @@
 					var/seconds_left = round(time_remaining / 10)
 					xeno_message("The Hive is ready for a new Queen to evolve. The Hive will collapse in [seconds_left] seconds without a Queen.", 3, hive.hivenumber)
 				else
-					xeno_message("The Hive is ready for a new Queen to evolve. The Hive can only survive for a limited time without a queen!", 3, hive.hivenumber)
+					xeno_message("The Hive is ready for a new Queen to evolve. The Hive can only survive for a limited time without a Queen!", 3, hive.hivenumber)
 
 
 

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -441,9 +441,15 @@
 			hive = GLOB.hive_datum[hivenumber]
 			if(!hive.xeno_queen_timer)
 				continue
-
 			if(!hive.living_xeno_queen && hive.xeno_queen_timer < world.time)
-				xeno_message("The Hive is ready for a new Queen to evolve. The hive can only survive for a limited time without a queen!", 3, hive.hivenumber)
+				var/time_remaining = (QUEEN_DEATH_COUNTDOWN + hive.xeno_queen_timer) - world.time
+				if(time_remaining <= 59 SECONDS)
+					var/seconds_left = round(time_remaining / 10)
+					xeno_message("The Hive is ready for a new Queen to evolve. Only [seconds_left] seconds remain before the Hive collapses!", 3, hive.hivenumber)
+				else
+					xeno_message("The Hive is ready for a new Queen to evolve. The hive can only survive for a limited time without a queen!", 3, hive.hivenumber)
+
+
 
 		if(!active_lz && world.time > lz_selection_timer)
 			select_lz(locate(/obj/structure/machinery/computer/shuttle/dropship/flight/lz1))

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -445,9 +445,9 @@
 				var/time_remaining = (QUEEN_DEATH_COUNTDOWN + hive.xeno_queen_timer) - world.time
 				if(time_remaining <= 59 SECONDS)
 					var/seconds_left = round(time_remaining / 10)
-					xeno_message("The Hive is ready for a new Queen to evolve. Only [seconds_left] seconds remain before the Hive collapses!", 3, hive.hivenumber)
+					xeno_message("The Hive is ready for a new Queen to evolve. The Hive will collapse in [seconds_left] seconds without a Queen.", 3, hive.hivenumber)
 				else
-					xeno_message("The Hive is ready for a new Queen to evolve. The hive can only survive for a limited time without a queen!", 3, hive.hivenumber)
+					xeno_message("The Hive is ready for a new Queen to evolve. The Hive can only survive for a limited time without a queen!", 3, hive.hivenumber)
 
 
 


### PR DESCRIPTION

# About the pull request

Adds the time remaining to the hivemind collapse warning when there's less than a minute until round is about to end.

# Explain why it's good for the game

Makes my PR https://github.com/cmss13-devs/cmss13/pull/9567 strictly better I think.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: hivemind collapse warning now includes the time remaining when there's less than a minute left
/:cl:
