### PR TITLE
fix survivor snowsuit not having neuro protection

### DIFF
--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -250,6 +250,7 @@
 	armor_rad = CLOTHING_ARMOR_NONE
 	armor_internaldamage = CLOTHING_ARMOR_LOW
 	flags_armor_protection = BODY_FLAG_CHEST|BODY_FLAG_GROIN|BODY_FLAG_ARMS
+	slowdown = SLOWDOWN_ARMOR_VERY_LIGHT
 	allowed = list(
 		/obj/item/weapon/gun,
 		/obj/item/tank/emergency_oxygen,


### PR DESCRIPTION
# About the pull request

gives the survivor snowsuit (robust snowsuit and parkas) very light slowdown in order to have it protect against sent neuro

# Explain why it's good for the game

<img width="645" height="37" alt="image" src="https://github.com/user-attachments/assets/1d700bdb-9a1c-41cb-b432-8059769120ac" />
this was always supposed to have neuro protection, it's just that it was fucked by some changes related to neuro.
 this is because shivas has very little to no armor and all survs which spawn on it cannot spawn with any armor vests



# Testing Photographs and Procedure
it works


# Changelog

:cl:
balance: The robust snowsuit now has very light slowdown which also gives resist againts sent neuro
/:cl:

