### PR TITLE
[EXPERIMENTAL] big red dust, multiz open space indicator

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -91,6 +91,12 @@
 
 	if(above)
 		above.multiz_new(dir=DOWN)
+		if(SSmapping.level_has_any_trait(z,list(ZTRAIT_GROUND)))
+			var/obj/effect/weather_vfx_holder/i_need_to_move_this = new /obj/effect/weather_vfx_holder
+			i_need_to_move_this.icon_state = "bigred_dust"
+			overlays += i_need_to_move_this
+
+
 
 	if(below)
 		below.multiz_new(dir=UP)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

adds dust effect to tiles with open space above them, aims to help with identifing open spaces, will need refining in future but is here for the test

# Explain why it's good for the game

easier to identify where open space is above you and behave acordingly


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Planetside tiles with open space above them have dust effect
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
