### PR TITLE
removes dirlock slowdown from humans

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -2,6 +2,7 @@
 	light_system = MOVABLE_LIGHT
 	rotate_on_lying = TRUE
 	blocks_emissive = EMISSIVE_BLOCK_UNIQUE
+	dirlock_slowdown = FALSE
 	//Hair color and style
 	var/r_hair = 0
 	var/g_hair = 0

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -47,6 +47,7 @@
 	var/recalculate_move_delay = TRUE // Whether move delay needs to be recalculated, on by default so that new mobs actually get movement delay calculated upon creation
 	var/crawling = FALSE
 	var/can_crawl = TRUE
+	var/dirlock_slowdown = TRUE // are they slowed down by dirlocking
 	var/monkeyizing = null //Carbon
 	var/hand = null
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -185,7 +185,7 @@ CLIENT_VERB(drop_item)
 		if(mob.next_move_slowdown)
 			move_delay += mob.next_move_slowdown
 			mob.next_move_slowdown = 0
-		if(!ishuman(mob)) //humans can dirlock with no slowdown
+		if(mob.dirlock_slowdown) //humans can dirlock with no slowdown
 			if((mob.flags_atom & DIRLOCK) && mob.dir != direct)
 				move_delay += MOVE_REDUCTION_DIRECTION_LOCKED // by Geeves
 


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

As directional lighting was added back to humans, the reason for humans being able to dirlock is back, and thus the slowdown should be removed. Let me explain:

2019-06-25
  RavingManiac:
  - rscadd: Made light from humans directional. In front of you, light. Behind you,
      darkness.
  - rscadd: You can now lock your direction with alt-move. This is unset by pressing
      alt-move in the same direction again, or facing another direction via clicking
      or ctrl-move.

directional lighting is added, and direction locking is added in turn to let marines keep their shoulder lamps locked in one direction.

2019-09-29
  Vampmare:
  - rscdel: Disabled directional lightning temporarily.

dir lighting is removed, but dir locking remains

2022
nanu tells me to remove dir lock because dir lighting is gone and its goofy (also bad for powergaming xenos who can lock their sprite to minimise target area), I come to a compromise of adding a slowdown (#179)

2023
harry adds back dir lighting #4229 but dirlock is untouched

THEREFORE dirlock slowdown should be removed from humans as they now have a need to dirlock again. Xenos and everyone else have no need to dirlock so it will still slow them down

# Explain why it's good for the game
adds back complexity to directional lighting and encourages thinking about your direction when patrolling to marine gameplay instead of dirlock being a giga slow and never used

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: direction locking no longer slows down humans. Xenos etc unaffected.
/:cl:
