### PR TITLE
Allows Queen eye to look into tents

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -116,12 +116,20 @@
 	med_hud_set_status()
 	add_to_all_mob_huds()
 
-	hud_used = Q.hud_used
-
 	Q.sight |= SEE_TURFS|SEE_OBJS
 
 /mob/hologram/queen/proc/exit_hologram()
 	SIGNAL_HANDLER
+
+	var/obj/structure/tent/tent = locate() in ((get_turf(linked_mob)).contents)
+
+	var/atom/movable/screen/plane_master/roof/roof_plane = linked_mob.hud_used.plane_masters["[ROOF_PLANE]"]
+
+	if(!tent)
+		roof_plane?.invisibility = 0
+	else if (roof_plane?.invisibility == 0)
+		roof_plane?.invisibility = INVISIBILITY_MAXIMUM
+
 	qdel(src)
 
 /mob/hologram/queen/handle_move(mob/living/carbon/xenomorph/X, NewLoc, direct)

--- a/code/modules/tents/deployed_tents.dm
+++ b/code/modules/tents/deployed_tents.dm
@@ -54,9 +54,17 @@
 	SIGNAL_HANDLER
 	if(!ismob(subject))
 		return
+
 	var/mob/subject_mob = subject
+
+
 	RegisterSignal(subject_mob, list(COMSIG_MOVABLE_TURF_ENTERED, COMSIG_GHOST_MOVED), PROC_REF(mob_moved), override = TRUE) // Must override because we can't know if mob was already inside tent without keeping an awful ref list
 	subject_mob.RegisterSignal(src, COMSIG_PARENT_QDELETING, TYPE_PROC_REF(/mob, tent_deletion_clean_up), override = TRUE)
+
+	if(istype(subject_mob, /mob/hologram))
+		var/mob/hologram/hologram_mob = subject_mob
+		subject_mob = hologram_mob.linked_mob
+
 	var/atom/movable/screen/plane_master/roof/roof_plane = subject_mob.hud_used.plane_masters["[ROOF_PLANE]"]
 	roof_plane?.invisibility = INVISIBILITY_MAXIMUM
 	if(ishuman(subject))
@@ -68,12 +76,18 @@
 
 /obj/structure/tent/proc/mob_moved(mob/subject, turf/target_turf)
 	SIGNAL_HANDLER
+
 	if(!(target_turf in locs)) // Exited the tent
 		mob_exited_tent(subject)
 
 /obj/structure/tent/proc/mob_exited_tent(mob/subject)
 	UnregisterSignal(subject, list(COMSIG_MOVABLE_TURF_ENTERED, COMSIG_GHOST_MOVED, COMSIG_HUMAN_COLD_PROTECTION_APPLY_MODIFIERS))
 	subject.UnregisterSignal(src, COMSIG_PARENT_QDELETING)
+
+	if(istype(subject, /mob/hologram))
+		var/mob/hologram/hologram_mob = subject
+		subject = hologram_mob.linked_mob
+
 	var/atom/movable/screen/plane_master/roof/roof_plane = subject.hud_used.plane_masters["[ROOF_PLANE]"]
 	roof_plane?.invisibility = 0
 


### PR DESCRIPTION

# About the pull request
Allows Queen eye to see inside tents (without breaking lighting this time around)

This also (apparently?) fixes the runtimes in #3678 
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Quality of life
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/user-attachments/assets/0dfcbd6c-add8-4bf2-9bd1-98e24d5503da


Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Queen eye can now look into tents
/:cl:
