### PR TITLE
Adds hangar-podlocks for the lockdown to remapped areas

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -789,6 +789,11 @@
 	dir = 4
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/machinery/door/poddoor/almayer/open{
+	dir = 4;
+	id = "Hangar Lockdown";
+	name = "\improper Hangar Lockdown Blast Door"
+	},
 /turf/open/floor/plating,
 /area/almayer/medical/lockerroom)
 "aca" = (
@@ -1228,6 +1233,11 @@
 	id = "MedicalDistriShu";
 	name = "\improper Medical Equipment Distribution Shutters";
 	dir = 4
+	},
+/obj/structure/machinery/door/poddoor/almayer/open{
+	dir = 4;
+	id = "Hangar Lockdown";
+	name = "\improper Hangar Lockdown Blast Door"
 	},
 /turf/open/floor/plating,
 /area/almayer/medical/lockerroom)
@@ -3203,6 +3213,11 @@
 	dir = 4
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/machinery/door/poddoor/almayer/open{
+	dir = 4;
+	id = "Hangar Lockdown";
+	name = "\improper Hangar Lockdown Blast Door"
+	},
 /turf/open/floor/plating,
 /area/almayer/medical/chemistry)
 "ahm" = (
@@ -5728,6 +5743,10 @@
 	req_one_access_txt = "3;22;2;19"
 	},
 /obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/machinery/door/poddoor/almayer/open{
+	id = "Hangar Lockdown";
+	name = "\improper Hangar Lockdown Blast Door"
+	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/living/offices/flight)
 "anV" = (
@@ -29466,6 +29485,11 @@
 	req_access = null;
 	req_one_access_txt = "3;19"
 	},
+/obj/structure/machinery/door/poddoor/almayer/open{
+	dir = 4;
+	id = "Hangar Lockdown";
+	name = "\improper Hangar Lockdown Blast Door"
+	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/hallways/hangar)
 "btO" = (
@@ -42369,6 +42393,10 @@
 	name = "\improper Dropship Control Bubble";
 	req_access = null;
 	req_one_access_txt = "3;22;2;19"
+	},
+/obj/structure/machinery/door/poddoor/almayer/open{
+	id = "Hangar Lockdown";
+	name = "\improper Hangar Lockdown Blast Door"
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/living/offices/flight)
@@ -65146,6 +65174,11 @@
 	name = "\improper Astronavigational Deck";
 	req_access = null;
 	req_one_access_txt = "3;19"
+	},
+/obj/structure/machinery/door/poddoor/almayer/open{
+	dir = 4;
+	id = "Hangar Lockdown";
+	name = "\improper Hangar Lockdown Blast Door"
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/hallways/hangar)


### PR DESCRIPTION
# About the pull request
This adds shutters linked to the hangar-lockdown button at the Navigation ladders, the new medbay windows and the ATC tower. This was all non-vent entrances are actually closed off.
Fixes Issue #10582 

Is a fixed version of #10672 
# Explain why it's good for the game
Now locking down the hangar actually seals it of for hostile combatants, not leaving the ladders that lead right to CIC or windows that lead into medbay extremely vulnerable.
I added the shutters at the base of the ATC tower since I considered just adding shutters to all middle/maintenance deck entrances instead, but I thought that there SHOULD be a way for people/alien to enter and leave the hangar, just with more difficulty + I'd imagine the person in the tower, hitting the lockdown, should be protected..
If xenos were to land in the hangar now, they could climb up the walls, venturing into the maintenance tunnels and spreading through the ship that way, or if people were to hide in the hangar, they could come storming from above onto them.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="1071" height="838" alt="Hangar1" src="https://github.com/user-attachments/assets/492d4b98-bc12-4537-bdea-1e16f4d5eaf0" />
<img width="779" height="572" alt="Hangar2" src="https://github.com/user-attachments/assets/e417ad1e-602c-4b4e-a1e2-7dda6e72a560" />
<img width="743" height="504" alt="Hangar3" src="https://github.com/user-attachments/assets/c4dfa6b8-c096-4485-90e7-ae6df63ba8e5" />
<img width="945" height="532" alt="Hangar4" src="https://github.com/user-attachments/assets/d3c8e17f-88a1-4d8b-b468-9a2288bad42a" />


</details>


# Changelog
:cl:
maptweak: Added lockdown doors to remapped areas of the Hangar that lacked them.
/:cl: