### PR TITLE
Rename Larva Queue as Larva Pool + Tweaks

### DIFF
--- a/code/__DEFINES/client_prefs.dm
+++ b/code/__DEFINES/client_prefs.dm
@@ -1,6 +1,6 @@
 //=================================================
-#define BE_ALIEN_AFTER_DEATH (1<<0)
-#define BE_AGENT (1<<1)
+#define BE_ALIEN (1<<0)
+// 1<<1 was BE_AGENT
 #define BE_KING (1<<2)
 //=================================================
 

--- a/code/__DEFINES/job.dm
+++ b/code/__DEFINES/job.dm
@@ -511,8 +511,8 @@ GLOBAL_LIST_INIT(job_command_roles, JOB_COMMAND_ROLES_LIST)
 
 //---------- ANTAG ----------//
 #define JOB_PREDATOR "Predator"
-#define JOB_XENOMORPH    "Xenomorph"
-#define JOB_XENOMORPH_QUEEN  "Queen"
+#define JOB_XENOMORPH "Xenomorph"
+#define JOB_XENOMORPH_QUEEN "Queen"
 
 // For coloring the ranks in the statistics menu
 #define JOB_PLAYTIME_TIER_0  (0 HOURS)
@@ -527,7 +527,7 @@ GLOBAL_LIST_INIT(job_command_roles, JOB_COMMAND_ROLES_LIST)
 #define JOB_PLAYTIME_TIER_9  (2100 HOURS)
 #define JOB_PLAYTIME_TIER_10 (2800 HOURS)
 
-#define XENO_NO_AGE  -1
+#define XENO_NO_AGE -1
 #define XENO_YOUNG 0
 #define XENO_NORMAL 1
 #define XENO_MATURE 2

--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -64,7 +64,7 @@ GLOBAL_LIST_INIT(cmp_field, "name")
 /proc/cmp_mob_deathtime_asc(mob/A, mob/B)
 	return A.timeofdeath - B.timeofdeath
 
-/// Compares observers based on their larva_queue_time value in ascending order
+/// Compares observers based on their larva_pool_time value in ascending order
 /// Assumes the client on the observer is not null
-/proc/cmp_obs_larvaqueuetime_asc(mob/dead/observer/A, mob/dead/observer/B)
-	return A.client.player_details.larva_queue_time - B.client.player_details.larva_queue_time
+/proc/cmp_obs_larvapooltime_asc(mob/dead/observer/A, mob/dead/observer/B)
+	return A.client.player_details.larva_pool_time - B.client.player_details.larva_pool_time

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -122,8 +122,8 @@ GLOBAL_VAR_INIT(time_offset, setup_offset())
 /proc/setup_offset()
 	return rand(10 MINUTES, 24 HOURS)
 
-/// The last count of possible candidates in the xeno larva queue (updated via get_alien_candidates)
-GLOBAL_VAR(xeno_queue_candidate_count)
+/// The last count of possible candidates in the xeno larva pool (updated via get_alien_candidates)
+GLOBAL_VAR(larva_pool_candidate_count)
 
 //Coordinate obsfucator
 //Used by the rangefinders and linked systems to prevent coords collection/prefiring

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -493,7 +493,7 @@ Additional game mode variables.
 			continue
 		// Only offer buried larva if there is no queue because we are instead relying on the hive cores/larva pops to handle their larva:
 		// Technically this should be after a get_alien_candidates() call to be accurate, but we are intentionally trying to not call that proc as much as possible
-		if(hive.hive_location && GLOB.xeno_queue_candidate_count > 0)
+		if(hive.hive_location && GLOB.larva_pool_candidate_count > 0)
 			continue
 		if(!hive.hive_location && (world.time > XENO_BURIED_LARVA_TIME_LIMIT + SSticker.round_start_time))
 			continue
@@ -508,7 +508,7 @@ Additional game mode variables.
 
 	if(!length(available_xenos) || (instant_join && !length(available_xenos_non_ssd)))
 		var/is_new_player = isnewplayer(xeno_candidate)
-		if(!xeno_candidate.client?.prefs || (!(xeno_candidate.client.prefs.be_special & BE_ALIEN_AFTER_DEATH) && !is_new_player))
+		if(!xeno_candidate.client?.prefs || (!(xeno_candidate.client.prefs.be_special & BE_ALIEN) && !is_new_player))
 			to_chat(xeno_candidate, SPAN_WARNING("There aren't any available xenomorphs or burrowed larvae. \
 				You can try getting spawned as a chestburster larva by toggling your Xenomorph candidacy in \
 				Preferences -> Toggle SpecialRole Candidacy."))
@@ -517,77 +517,18 @@ Additional game mode variables.
 
 		// If a lobby player is trying to join as xeno, estimate their possible position
 		if(is_new_player)
-			if(!SSticker.HasRoundStarted() || world.time < SSticker.round_start_time + 15 SECONDS)
-				// Larva queue numbers are too volatile at the start of the game for the estimation to be what they end up with
-				to_chat(xeno_candidate, SPAN_XENONOTICE("Larva queue position estimation is not available until shortly after the game has started. \
-					The ordering is based on your time of death or the time you joined. When you have been dead long enough and are not inactive, \
-					you will periodically receive messages where you are in the queue relative to other currently valid xeno candidates. \
-					Your current position will shift as others change their preferences or go inactive, but your relative position compared to all observers is the same. \
-					Note: Playing as a facehugger/lesser or in the thunderdome will not alter your time of death. \
-					This means you won't lose your relative place in queue if you step away, disconnect, play as a facehugger/lesser, or play in the thunderdome."))
-				return FALSE
-			var/mob/new_player/candidate_new_player = xeno_candidate
-			if(candidate_new_player.larva_queue_message_stale_time <= world.time)
-				// No cached/current lobby message, determine the position
-				var/list/valid_candidates = get_alien_candidates()
-				var/candidate_time = candidate_new_player.client.player_details.larva_queue_time
-				var/position = 1
-				for(var/mob/dead/observer/current in valid_candidates)
-					if(current.client.player_details.larva_queue_time >= candidate_time)
-						break
-					position++
-				candidate_new_player.larva_queue_message_stale_time = world.time + 3 MINUTES // spam prevention
-				candidate_new_player.larva_queue_cached_message = "Your position would be [position]\th in the larva queue if you observed and were eligible to be a xeno. \
-					The ordering is based on your time of death or the time you joined. When you have been dead long enough and are not inactive, \
-					you will periodically receive messages where you are in the queue relative to other currently valid xeno candidates. \
-					Your current position will shift as others change their preferences or go inactive, but your relative position compared to all observers is the same. \
-					Note: Playing as a facehugger/lesser or in the thunderdome will not alter your time of death. \
-					This means you won't lose your relative place in queue if you step away, disconnect, play as a facehugger/lesser, or play in the thunderdome."
-			to_chat(candidate_new_player, SPAN_XENONOTICE(candidate_new_player.larva_queue_cached_message))
+			message_alien_candidate_new_player(xeno_candidate)
 			return FALSE
 
 		if(!candidate_observer)
 			return FALSE
 
-		// If an observing mod wants to join as a xeno, disable their larva protection so that they can enter the queue.
+		// If an observing mod wants to join as a xeno, disable their larva protection so that they can enter the larva pool.
 		if(check_client_rights(candidate_observer.client, R_MOD, FALSE))
 			candidate_observer.admin_larva_protection = FALSE
 
-		// Give the player a cached message of their queue status if they are an observer
-		if(candidate_observer.larva_queue_cached_message)
-			to_chat(candidate_observer, SPAN_XENONOTICE(candidate_observer.larva_queue_cached_message))
-			return FALSE
-
-		// No cache, lets check now then
-		var/list/valid_candidates = get_alien_candidates()
-		message_alien_candidates(valid_candidates, dequeued = 0, cache_only = TRUE)
-
-		// If we aren't in the queue yet, let's teach them about the queue
-		if(!candidate_observer.larva_queue_cached_message)
-			var/candidate_time = candidate_observer.client.player_details.larva_queue_time
-			var/position = 1
-			for(var/mob/dead/observer/current in valid_candidates)
-				if(current.client.player_details.larva_queue_time >= candidate_time)
-					break
-				position++
-			candidate_observer.larva_queue_cached_message = "You are currently ineligible to be a larva but would be [position]\th in queue. \
-				The ordering is based on your time of death or the time you joined. When you have been dead long enough and are not inactive, \
-				you will periodically receive messages where you are in the queue relative to other currently valid xeno candidates. \
-				Your current position will shift as others change their preferences or go inactive, but your relative position compared to all observers is the same. \
-				Note: Playing as a facehugger/lesser or in the thunderdome will not alter your time of death. \
-				This means you won't lose your relative place in queue if you step away, disconnect, play as a facehugger/lesser, or play in the thunderdome."
-			to_chat(candidate_observer, SPAN_XENONOTICE(candidate_observer.larva_queue_cached_message))
-			return FALSE
-
-		var/datum/hive_status/cur_hive
-		for(var/hive_num in GLOB.hive_datum)
-			cur_hive = GLOB.hive_datum[hive_num]
-			for(var/mob_name in cur_hive.banished_ckeys)
-				if(cur_hive.banished_ckeys[mob_name] == candidate_observer.ckey)
-					candidate_observer.larva_queue_cached_message += "\nNOTE: You are banished from the [cur_hive] and you may not rejoin unless \
-						the Queen re-admits you or dies. Your queue number won't update until there is a hive you aren't banished from."
-					break
-		to_chat(candidate_observer, SPAN_XENONOTICE(candidate_observer.larva_queue_cached_message))
+		// Give the observing player a cached message of their pool status (or update their cache)
+		message_alien_candidate_observer(candidate_observer)
 		return FALSE
 
 	var/mob/living/carbon/xenomorph/new_xeno

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -528,7 +528,7 @@ GLOBAL_LIST_INIT(frozen_items, list(SQUAD_MARINE_1 = list(), SQUAD_MARINE_2 = li
 			to_chat(mob, SPAN_NOTICE("You feel cool air surround you. You go numb as your senses turn inward."))
 			to_chat(mob, SPAN_BOLDNOTICE("If you log out or close your client now, your character will permanently removed from the round in 10 minutes. If you ghost, timer will be decreased to 2 minutes."))
 			if(!should_block_game_interaction(src)) // Set their queue time now because the client has to actually leave to despawn and at that point the client is lost
-				mob.client.player_details.larva_queue_time = max(mob.client.player_details.larva_queue_time, world.time)
+				mob.client.player_details.larva_pool_time = max(mob.client.player_details.larva_pool_time, world.time)
 		var/area/location = get_area(src)
 		if(mob.job != GET_MAPPED_ROLE(JOB_SQUAD_MARINE))
 			message_admins("[key_name_admin(mob)], [mob.job], has entered \a [src] at [location] after playing for [duration2text(world.time - mob.life_time_start)].")

--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -156,10 +156,7 @@ WARNING!*/
 	else
 		jobs += "<td width='20%'><a href='byond://?src=\ref[src];[HrefToken(forceGlobal = TRUE)];jobban3=Survivor;jobban4=\ref[M]'>Survivor</a></td>"
 
-	if(jobban_isbanned(M, "Agent", P) || isbanned_dept)
-		jobs += "<td width='20%'><a href='byond://?src=\ref[src];[HrefToken(forceGlobal = TRUE)];jobban3=Agent;jobban4=\ref[M]'><font color=red>Agent</font></a></td>"
-	else
-		jobs += "<td width='20%'><a href='byond://?src=\ref[src];[HrefToken(forceGlobal = TRUE)];jobban3=Agent;jobban4=\ref[M]'>Agent</a></td>"
+	// Agent was a previous jobban
 
 	if(jobban_isbanned(M, "Urgent Adminhelp", P))
 		jobs += "<td width='20%'><a href='byond://?src=\ref[src];[HrefToken(forceGlobal = TRUE)];jobban3=Urgent Adminhelp;jobban4=\ref[M]'><font color=red>Urgent Adminhelp</font></a></td>"

--- a/code/modules/client/player_details.dm
+++ b/code/modules/client/player_details.dm
@@ -7,11 +7,11 @@ GLOBAL_LIST_EMPTY(player_details) // ckey -> /datum/player_details
 	var/list/post_logout_callbacks = list()
 	var/list/played_names = list() //List of names this key played under this round
 	var/byond_version = "Unknown"
-	/// The descriminator for larva queue ordering: Generally set to timeofdeath except for facehuggers/admin z-level play
-	var/larva_queue_time
+	/// The descriminator for larva pool ordering: Generally set to timeofdeath except for facehuggers/admin z-level play
+	var/larva_pool_time
 
 /datum/player_details/New()
-	larva_queue_time = world.time
+	larva_pool_time = world.time
 	return ..()
 
 /proc/log_played_names(ckey, ...)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -22,8 +22,7 @@ GLOBAL_LIST_INIT(bgstate_options, list(
 ))
 
 GLOBAL_LIST_INIT(be_special_flags, list(
-	"Xenomorph after unrevivable death" = BE_ALIEN_AFTER_DEATH,
-	"Agent" = BE_AGENT,
+	"Xenomorph" = BE_ALIEN,
 	"King" = BE_KING,
 ))
 
@@ -61,7 +60,7 @@ GLOBAL_LIST_INIT(be_special_flags, list(
 	//game-preferences
 	var/lastchangelog = "" // Saved changlog filesize to detect if there was a change
 	var/ooccolor
-	var/be_special = BE_ALIEN_AFTER_DEATH|BE_KING // Special role selection
+	var/be_special = BE_ALIEN|BE_KING // Special role selection
 	var/toggle_prefs = TOGGLE_DIRECTIONAL_ATTACK|TOGGLE_COMBAT_CLICKDRAG_OVERRIDE|TOGGLE_MEMBER_PUBLIC|TOGGLE_AMBIENT_OCCLUSION|TOGGLE_VEND_ITEM_TO_HAND|TOGGLE_LEADERSHIP_SPOKEN_ORDERS // flags in #define/mode.dm
 	var/xeno_ability_click_mode = XENO_ABILITY_CLICK_MIDDLE
 	var/auto_fit_viewport = FALSE
@@ -668,14 +667,7 @@ GLOBAL_LIST_INIT(be_special_flags, list(
 
 			for(var/role_name in GLOB.be_special_flags)
 				var/flag = GLOB.be_special_flags[role_name]
-
-				var/ban_check_name
-				switch(role_name)
-					if("Xenomorph after unrevivable death")
-						ban_check_name = JOB_XENOMORPH
-
-					if("Agent")
-						ban_check_name = "Agent"
+				var/ban_check_name = JOB_XENOMORPH // Ever a be_special_flags uses a different ban check, check and switch here
 
 				if(ban_check_name && jobban_isbanned(user, ban_check_name))
 					dat += "<b>Be [role_name]:</b> <font color=red><b>\[BANNED]</b></font><br>"

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -207,7 +207,7 @@ CLIENT_VERB(toggle_adminpm_flash)
 CLIENT_VERB(toggle_be_special)
 	set name = "Toggle SpecialRole Candidacy"
 	set category = "Preferences"
-	set desc = "Toggles which special roles you would like to be a candidate for, during events."
+	set desc = "Toggles which special roles you would like to be a candidate for."
 
 	var/role = tgui_input_list(usr, "Toggle which candidacy?", "Select role", GLOB.be_special_flags)
 	if(!role)

--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -230,7 +230,7 @@
 	var/last_healed = 0
 	var/last_attempt = 0 // logs time of last attempt to prevent spam. if you want to destroy it, you must commit.
 	var/last_larva_time = 0
-	var/last_larva_queue_time = 0
+	var/last_larva_pool_time = 0
 	var/last_surge_time = 0
 	var/spawn_cooldown = 30 SECONDS
 	var/surge_cooldown = 90 SECONDS
@@ -275,8 +275,8 @@
 		var/spawning_larva = can_spawn_larva() && (last_larva_time + spawn_cooldown) < world.time
 		if(spawning_larva)
 			last_larva_time = world.time
-		if(spawning_larva || (last_larva_queue_time + spawn_cooldown * 4) < world.time)
-			last_larva_queue_time = world.time
+		if(spawning_larva || (last_larva_pool_time + spawn_cooldown * 4) < world.time)
+			last_larva_pool_time = world.time
 			var/list/players_with_xeno_pref = get_alien_candidates(linked_hive)
 			if(spawning_larva)
 				var/i = 0
@@ -291,7 +291,7 @@
 			last_surge_time = world.time
 			linked_hive.stored_larva++
 			linked_hive.hijack_burrowed_left--
-			if(GLOB.xeno_queue_candidate_count < 1 + count_spawned)
+			if(GLOB.larva_pool_candidate_count < 1 + count_spawned)
 				notify_ghosts(header = "Claim Xeno", message = "The Hive has gained another burrowed larva! Click to take it.", source = src, action = NOTIFY_JOIN_XENO, enter_link = "join_xeno=1")
 			if(surge_cooldown > 30 SECONDS) //mostly for sanity purposes
 				surge_cooldown = surge_cooldown - surge_incremental_reduction //ramps up over time

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -61,8 +61,8 @@
 	var/own_orbit_size = 0
 	var/observer_actions = list(/datum/action/observer_action/join_xeno, /datum/action/observer_action/join_lesser_drone)
 	var/datum/action/minimap/observer/minimap
-	///The last message for this player with their larva queue information
-	var/larva_queue_cached_message
+	///The last message for this player with their larva pool information
+	var/larva_pool_cached_message
 	///Used to bypass time of death checks such as when being selected for larva
 	var/bypass_time_of_death_checks = FALSE
 	///Used to bypass time of death checks for a successful hug
@@ -490,7 +490,7 @@ Works together with spawning an observer, noted above.
 
 	mind = null
 
-	// Larva queue: We use the larger of their existing queue time or the new timeofdeath except for facehuggers or lesser drone
+	// Larva pool: We use the larger of their existing time or the new timeofdeath except for facehuggers or lesser drone
 	var/exempt_tod = isfacehugger(src) || islesserdrone(src) || should_block_game_interaction(src, include_hunting_grounds=TRUE)
 	var/new_tod = exempt_tod ? 1 : ghost.timeofdeath
 
@@ -512,11 +512,11 @@ Works together with spawning an observer, noted above.
 			ghost.client.player_data.load_timestat_data()
 
 	if(ghost.client?.player_details)
-		ghost.client.player_details.larva_queue_time = max(ghost.client.player_details.larva_queue_time, new_tod)
+		ghost.client.player_details.larva_pool_time = max(ghost.client.player_details.larva_pool_time, new_tod)
 	else if(persistent_ckey)
 		var/datum/player_details/details = GLOB.player_details[persistent_ckey]
 		if(details)
-			details.larva_queue_time = max(details.larva_queue_time, new_tod)
+			details.larva_pool_time = max(details.larva_pool_time, new_tod)
 
 	ghost.set_huds_from_prefs()
 
@@ -563,18 +563,18 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if(ghost && !should_block_game_interaction(src, include_hunting_grounds=TRUE))
 			ghost.timeofdeath = world.time
 
-			// Larva queue: We use the larger of their existing queue time or the new timeofdeath except for facehuggers or lesser drone
+			// Larva pool: We use the larger of their existing time or the new timeofdeath except for facehuggers or lesser drone
 			var/new_tod = (isfacehugger(src) || islesserdrone(src)) ? 1 : ghost.timeofdeath
 
 			// if they died as facehugger or lesser drone, bypass typical TOD checks
 			ghost.bypass_time_of_death_checks = (isfacehugger(src) || islesserdrone(src))
 
 			if(ghost.client)
-				ghost.client.player_details.larva_queue_time = max(ghost.client.player_details.larva_queue_time, new_tod)
+				ghost.client.player_details.larva_pool_time = max(ghost.client.player_details.larva_pool_time, new_tod)
 			else if(persistent_ckey)
 				var/datum/player_details/details = GLOB.player_details[persistent_ckey]
 				if(details)
-					details.larva_queue_time = max(details.larva_queue_time, new_tod)
+					details.larva_pool_time = max(details.larva_pool_time, new_tod)
 
 		if(is_nested && nest && !QDELETED(nest))
 			ghost.can_reenter_corpse = FALSE
@@ -1393,9 +1393,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if(SShijack.sd_unlocked)
 			. += "Self Destruct Goal: [SShijack.get_sd_eta()]"
 
-	if(client.prefs?.be_special & BE_ALIEN_AFTER_DEATH)
-		if(larva_queue_cached_message)
-			. += larva_queue_cached_message
+	if(client.prefs?.be_special & BE_ALIEN)
+		if(!larva_pool_cached_message)
+			// Try to refresh now
+			message_alien_candidate_observer(src, cache_only=TRUE)
+		if(larva_pool_cached_message)
+			. += larva_pool_cached_message
 			. += ""
 
 	if(timeofdeath)

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -88,15 +88,15 @@
 	GLOB.alive_mob_list -= src
 	GLOB.dead_mob_list += src
 
-	// Larva queue: We use the larger of their existing queue time or the new timeofdeath except for facehuggers or lesser drone
+	// Larva pool: We use the larger of their existing time or the new timeofdeath except for facehuggers or lesser drone
 	var/exempt_tod = isfacehugger(src) || islesserdrone(src) || should_block_game_interaction(src, include_hunting_grounds=TRUE)
 	var/new_tod = exempt_tod ? 1 : timeofdeath
 	if(client)
-		client.player_details.larva_queue_time = max(client.player_details.larva_queue_time, new_tod)
+		client.player_details.larva_pool_time = max(client.player_details.larva_pool_time, new_tod)
 	else if(persistent_ckey)
 		var/datum/player_details/details = GLOB.player_details[persistent_ckey]
 		if(details)
-			details.larva_queue_time = max(details.larva_queue_time, new_tod)
+			details.larva_pool_time = max(details.larva_pool_time, new_tod)
 
 	if(client && client.player_data)
 		record_playtime(client.player_data, job, type)

--- a/code/modules/mob/living/carbon/xenomorph/Embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Embryo.dm
@@ -180,9 +180,9 @@
 
 	// If the bursted person themselves has Xeno enabled, they get the honor of first dibs on the new larva.
 	if((!isyautja(affected_mob) || (isyautja(affected_mob) && prob(20))) && is_nested)
-		if(affected_mob.first_xeno || (affected_mob.client?.prefs?.be_special & BE_ALIEN_AFTER_DEATH && !jobban_isbanned(affected_mob, JOB_XENOMORPH)))
+		if(affected_mob.first_xeno || (affected_mob.client?.prefs?.be_special & BE_ALIEN && !jobban_isbanned(affected_mob, JOB_XENOMORPH)))
 			picked = affected_mob
-		else if(affected_mob.mind?.ghost_mob && affected_mob.client?.prefs?.be_special & BE_ALIEN_AFTER_DEATH && !jobban_isbanned(affected_mob, JOB_XENOMORPH))
+		else if(affected_mob.mind?.ghost_mob && affected_mob.client?.prefs?.be_special & BE_ALIEN && !jobban_isbanned(affected_mob, JOB_XENOMORPH))
 			picked = affected_mob.mind.ghost_mob // This currently doesn't look possible
 		else if(affected_mob.persistent_ckey)
 			for(var/mob/dead/observer/cur_obs as anything in GLOB.observer_list)
@@ -190,7 +190,7 @@
 					continue
 				if(cur_obs.ckey != affected_mob.persistent_ckey)
 					continue
-				if(cur_obs.client?.prefs?.be_special & BE_ALIEN_AFTER_DEATH && !jobban_isbanned(cur_obs, JOB_XENOMORPH))
+				if(cur_obs.client?.prefs?.be_special & BE_ALIEN && !jobban_isbanned(cur_obs, JOB_XENOMORPH))
 					picked = cur_obs
 				break
 

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -953,8 +953,8 @@
 			to_chat(user, SPAN_WARNING("You cannot become a facehugger until you are no longer alive in a nest."))
 			return FALSE
 
-		if(world.time - user.client?.player_details.larva_queue_time < XENO_JOIN_DEAD_TIME)
-			var/time_left = floor((user.client.player_details.larva_queue_time + XENO_JOIN_DEAD_TIME - world.time) / 10)
+		if(world.time - user.client?.player_details.larva_pool_time < XENO_JOIN_DEAD_TIME)
+			var/time_left = floor((user.client.player_details.larva_pool_time + XENO_JOIN_DEAD_TIME - world.time) / 10)
 			to_chat(user, SPAN_WARNING("You ghosted too recently. You cannot become a facehugger until [XENO_JOIN_DEAD_TIME / 600] minutes have passed ([time_left] seconds remaining)."))
 			return FALSE
 
@@ -1033,8 +1033,8 @@
 		to_chat(user, SPAN_WARNING("You cannot become a lesser drone until you are no longer alive in a nest."))
 		return FALSE
 
-	if(world.time - user.client?.player_details.larva_queue_time < XENO_JOIN_DEAD_TIME)
-		var/time_left = floor((user.client.player_details.larva_queue_time + XENO_JOIN_DEAD_TIME - world.time) / 10)
+	if(world.time - user.client?.player_details.larva_pool_time < XENO_JOIN_DEAD_TIME)
+		var/time_left = floor((user.client.player_details.larva_pool_time + XENO_JOIN_DEAD_TIME - world.time) / 10)
 		to_chat(user, SPAN_WARNING("You ghosted too recently. You cannot become a lesser drone until [XENO_JOIN_DEAD_TIME / 600] minutes have passed ([time_left] seconds remaining)."))
 		return FALSE
 

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -247,12 +247,23 @@
 		if("keyboard")
 			playsound_client(client, get_sfx("keyboard"), vol = 20)
 
-/// Join as a 'xeno' - set us up in the larva queue
+/// Join as a 'xeno' - set us up in the larva pool
 /mob/new_player/proc/observe_for_xeno()
-	if(client.prefs && !(client.prefs.be_special & BE_ALIEN_AFTER_DEATH))
-		client.prefs.be_special |= BE_ALIEN_AFTER_DEATH
-		to_chat(src, SPAN_BOLDNOTICE("You will now be considered for Xenomorph after unrevivable death events (where possible)."))
+	if(!client)
+		return
+
+	if(client.prefs && !(client.prefs.be_special & BE_ALIEN))
+		client.prefs.be_special |= BE_ALIEN
+		to_chat(src, SPAN_BOLDNOTICE("SpecialRole Candidacy was forced so you can be considered for Xenomorph."))
+
+	var/client/current_client = client
+
 	attempt_observe()
+
+	// If a mod wants to join as a xeno, disable their larva protection so that they can enter the larva pool.
+	if(check_client_rights(current_client, R_MOD, FALSE) && current_client.mob)
+		var/mob/dead/observer/mod_observer = current_client.mob
+		mod_observer.admin_larva_protection = FALSE
 
 /mob/new_player/proc/lobby()
 	if(!client)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -8,10 +8,10 @@
 
 	var/ready = FALSE
 	var/spawning = FALSE//Referenced when you want to delete the new_player later on in the code.
-	///The last message for this player with their larva queue information
-	var/larva_queue_cached_message
-	///The time when the larva_queue_cached_message should be considered stale
-	var/larva_queue_message_stale_time
+	///The last message for this player with their larva pool information
+	var/larva_pool_cached_message
+	///The time when the larva_pool_cached_message should be considered stale
+	var/larva_pool_message_stale_time
 
 	/// The window that we display the main menu in
 	var/datum/tgui_window/lobby_window

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -720,7 +720,7 @@
 			var/mob/dead/observer/obs = mob.ghostize(FALSE)
 			if(obs)
 				obs.timeofdeath = world.time
-				obs.client?.player_details.larva_queue_time = max(obs.client.player_details.larva_queue_time, world.time)
+				obs.client?.player_details.larva_pool_time = max(obs.client.player_details.larva_pool_time, world.time)
 			mob.moveToNullspace()
 
 	// Now that mobs are stowed, delete the shuttle


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #3636 and the many of the subsequent PRs tweaking it:
- Larva queue is now known as the larva pool. This was done because there's way too many preconceptions of entering/leaving a queue when the larva pool here only cares about A) How long you've been dead and B) Whether you are currently eligible (e.g. not afk, special role set for xenomorph, not xeno job banned, not banished, been dead a minimum amount of time, etc).
- Observer status panel now attempts a refresh immediately if a xeno candidate but no cached message is set yet. This was done because players were thinking the join as the xeno button would enter them into queue/pool and incorrectly thinking afk xenos being offered would prevent them from being entered into the queue/pool.
- Staff joining hive via lobby now sets mod admin larva protection off automatically. I don't know if this confused anyone, but we're already doing it for the in game button so may as well do it for the lobby button too.
- Tweaked special role wordings. Namely I removed the "after unrevivable death" part because people might think observing isn't death so think it doesn't apply to that situation.
- Removed agent as a special role. I have no idea what it was for or why it was left around.

# Explain why it's good for the game

Yet another attempt to nip at player confusion and misinterpretations of the larva queue/pool.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
qol: Larva queue is now known as larva pool and its position message is cached immediately for status panel if xeno candidacy is set
ui: Tweaked some messaging/labels for xeno special role candidacy
code: Renamed larva queue variables and comments to pool and rearranged some larva pool functionality
del: Removed the special role known as agent
admin: Late joining as xeno from menu as a mod now immediately sets larva protection false
/:cl:
