### PR TITLE
Fix forsaken handling

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
@@ -173,10 +173,6 @@
 		return
 
 	var/mob/living/carbon/xenomorph/larva/larva = new /mob/living/carbon/xenomorph/larva(atom)
-	var/turf/turf = get_turf(larva)
-
-	if(SShijack.hijack_status != HIJACK_OBJECTIVES_NOT_STARTED && is_ground_level(turf?.z))
-		hivenumber = XENO_HIVE_FORSAKEN //Set to forsaken hive if hijack is active and on ground level
 
 	larva.set_hive_and_update(hivenumber)
 

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -804,9 +804,12 @@
 		if(xeno.tier >= 1)
 			xenos_count++
 	for(var/mob/living/potential_host as anything in GLOB.alive_mob_list)
-		if(!(potential_host.status_flags & XENO_HOST))
-			continue
 		if(!is_ground_level(potential_host.z) || get_area(potential_host) == hijacked_dropship)
+			continue
+		var/obj/item/clothing/mask/facehugger/hugger = locate() in potential_host
+		if(hugger && hugger.hivenumber == hivenumber)
+			hugger.hivenumber = XENO_HIVE_FORSAKEN
+		if(!(potential_host.status_flags & XENO_HOST))
 			continue
 		for(var/obj/item/alien_embryo/embryo in potential_host)
 			if(embryo.hivenumber != hivenumber)

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -792,7 +792,7 @@
 				qdel(xeno)
 				continue
 			if(xeno.hunter_data.hunted && !isqueen(xeno))
-				to_chat(xeno, SPAN_XENOANNOUNCE("The Queen has left without you, seperating you from her hive! You must defend yourself from the headhunter before you can enter hibernation..."))
+				to_chat(xeno, SPAN_XENOANNOUNCE("The Queen has left without you, separating you from her hive! You must defend yourself from the headhunter before you can enter hibernation..."))
 				xeno.set_hive_and_update(XENO_HIVE_FORSAKEN)
 			else
 				to_chat(xeno, SPAN_XENOANNOUNCE("The Queen has left without you, you quickly find a hiding place to enter hibernation as you lose touch with the hive mind."))
@@ -803,16 +803,14 @@
 			continue
 		if(xeno.tier >= 1)
 			xenos_count++
-	for(var/i in GLOB.alive_mob_list)
-		var/mob/living/potential_host = i
+	for(var/mob/living/potential_host as anything in GLOB.alive_mob_list)
 		if(!(potential_host.status_flags & XENO_HOST))
 			continue
 		if(!is_ground_level(potential_host.z) || get_area(potential_host) == hijacked_dropship)
 			continue
-		var/obj/item/alien_embryo/A = locate() in potential_host
-		if(A && A.hivenumber != hivenumber)
-			continue
 		for(var/obj/item/alien_embryo/embryo in potential_host)
+			if(embryo.hivenumber != hivenumber)
+				continue
 			embryo.hivenumber = XENO_HIVE_FORSAKEN
 		potential_host.update_med_icon()
 	for(var/mob/living/carbon/human/current_human as anything in GLOB.alive_human_list)

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -263,12 +263,6 @@
 
 	X.set_faction(internal_faction)
 
-	var/turf/turf = get_turf(X)
-
-	if (X.hive.hivenumber == XENO_HIVE_NORMAL && SShijack.hijack_status != HIJACK_OBJECTIVES_NOT_STARTED && is_ground_level(turf?.z)) {
-		X.set_hive_and_update(XENO_HIVE_FORSAKEN)
-	}
-
 	if(X.hud_list)
 		X.hud_update()
 

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -377,7 +377,7 @@
 	xeno_message(SPAN_XENOANNOUNCE("The Queen has commanded the metal bird to depart for the metal hive in the sky! Rejoice!"), 3, hivenumber)
 	xeno_message(SPAN_XENOANNOUNCE("The hive swells with power! You will now steadily gain pooled larva over time."), 2, hivenumber)
 	var/datum/hive_status/hive = GLOB.hive_datum[hivenumber]
-	hive.abandon_on_hijack()
+	addtimer(CALLBACK(hive, TYPE_PROC_REF(/datum/hive_status, abandon_on_hijack)), DROPSHIP_WARMUP_TIME, TIMER_UNIQUE)
 	var/original_evilution = hive.evolution_bonus
 	hive.override_evilution(XENO_HIJACK_EVILUTION_BUFF, TRUE)
 	if(hive.living_xeno_queen)


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #9211 which way too aggressively tried to fix a very niche issue. Regardless, the changes in this pr should mitigate two potential issues:
- Xenos leaving dropship while its still leaving (now dropship launch warmup has to finish first)
- Facehugger (masks) are now searched for in groundside mobs to convert those too to handle the situation of a hug in progress during launch.

# Explain why it's good for the game

Should fix all of these issues:
- Fixes #10686 Xenos were getting `0` set as their hive number though I'm not completely clear why which caused lots of runtimes
- Fixes #10685 Add xeno aggressively converted xenos during hijack sequence since hijack starts groundside
- Fixes #10687 Duplicate issue really

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

In process hugger testing:
<img width="1278" height="644" alt="image" src="https://github.com/user-attachments/assets/099416ea-4f71-4274-8571-836fdd5d8bfc" />
<img width="1929" height="1141" alt="image" src="https://github.com/user-attachments/assets/45eb7f9b-a0be-4f7c-b2b0-2111537555cf" />

Hijack launch example: https://youtu.be/uYvHHSHCsZs

</details>

# Changelog
:cl: Drathek
fix: Fixed aggressive forsaken handling reverting some changes in a recent pr: Now abandon on hijack occurs when the shuttle actually launches, and facehugger masks on a person (e.g. hugging someone) will be converted
spellcheck: Fixed a typo in forsaken handling
code: Cleaned up some old forsaken handling code
/:cl:
