### PR TITLE
Fixes incorrect fence connection

### DIFF
--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -15,6 +15,7 @@
 	var/junction = 0 //Because everything is terrible, I'm making this a fence-level var
 	var/basestate = "fence"
 	var/forms_junctions = TRUE
+	var/form_junctions_to = TRUE
 
 	var/door = FALSE
 	var/open = FALSE
@@ -262,6 +263,8 @@
 		if(!src)
 			return
 		for(var/obj/structure/fence/fence in orange(src, 1))
+			if(!fence.form_junctions_to)
+				continue
 			if(abs(x - fence.x) - abs(y - fence.y)) //Doesn't count grilles, placed diagonally to src
 				junction |= get_dir(src, fence)
 		if(cut)
@@ -308,6 +311,7 @@ GLOBAL_LIST_INIT(all_electric_fences, list())
 	health = 150
 	health_max = 200
 	forms_junctions = FALSE
+	form_junctions_to = FALSE
 	var/electrified = FALSE
 	var/obj/structure/machinery/colony_floodlight_switch/electrified_fence_switch/breaker_switch = null
 


### PR DESCRIPTION
# About the pull request

Fences should not connected to electric fences

# Explain why it's good for the game

bugfix


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
<img width="337" height="162" alt="image" src="https://github.com/user-attachments/assets/47678ddd-e372-4f82-b78d-80b67aea11a3" />


Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: fences no longer connect to electric fences
/:cl:
