### PR TITLE
Adds IFF to P9 SHARP

### DIFF
--- a/code/modules/projectiles/guns/specialist/sharp.dm
+++ b/code/modules/projectiles/guns/specialist/sharp.dm
@@ -31,6 +31,11 @@
 	. = ..()
 	. += SPAN_INFO("Switching firemodes will toggle the explosion delay timer between 1 second and 5 seconds")
 
+/obj/item/weapon/gun/rifle/sharp/set_bullet_traits()
+	LAZYADD(traits_to_give, list(
+		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_iff)
+	))
+
 /obj/item/weapon/gun/rifle/sharp/set_gun_attachment_offsets()
 	attachable_offset = list("muzzle_x" = 32, "muzzle_y" = 17,"rail_x" = 12, "rail_y" = 22, "under_x" = 23, "under_y" = 13, "stock_x" = 24, "stock_y" = 13)
 


### PR DESCRIPTION
# About the pull request

Adds IFF to the P9 SHARP

# Explain why it's good for the game

SHARP is currently considered a very underpowered spec, and the lack of IFF prevents it from engaging in the first place; you are forced to constantly cycle back and forth while you try to get targets for your (rather slow) gun while marines try their best to run in front of you so they can get an embedded metal rod in them to break their bones. Adding IFF to the SHARP brings it at least in that regard on par with the other fire support specs (like the GL or sniper) and lets it fire through the crowd of PFCs like exotic pieces of equipment such as the UGL that's attached to every MK2 by default.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: 
balance: added IFF to P9 SHARP
/:cl:

