### PR TITLE
Implement rollover for duration2text and timezone tweak

### DIFF
--- a/code/__HELPERS/_time.dm
+++ b/code/__HELPERS/_time.dm
@@ -13,6 +13,8 @@
 #define MINUTES_TO_DECISECOND *600
 #define MINUTES_TO_HOURS /60
 
+#define DECISECONDS_TO_SECONDS /10
+#define DECISECONDS_TO_MINUTES /600
 #define DECISECONDS_TO_HOURS /36000
 
 GLOBAL_VAR_INIT(midnight_rollovers, 0)
@@ -41,11 +43,27 @@ GLOBAL_VAR_INIT(rollovercheck_last_timeofday, 0)
 /proc/time_stamp() // Shows current GMT time
 	return time2text(world.timeofday, "hh:mm:ss")
 
-/proc/duration2text(time = world.time) // Shows current time starting at 0:00
-	return gameTimestamp("hh:mm", time)
+/// Duration in hh:mm with rollover into hours
+/proc/duration2text(time = world.time)
+	if(time < 24 HOURS)
+		return gameTimestamp("hh:mm", time)
 
-/proc/duration2text_sec(time = world.time) // shows minutes:seconds
-	return gameTimestamp("mm:ss", time)
+	var/hours = floor(time DECISECONDS_TO_HOURS)
+	var/minutes = floor((time - hours HOURS) DECISECONDS_TO_MINUTES)
+	if(minutes < 10)
+		minutes = "0[minutes]"
+	return "[hours]:[minutes]"
+
+/// Duration in mm:ss with rollover into minutes
+/proc/duration2text_sec(time = world.time)
+	if(time < 60 MINUTES)
+		return gameTimestamp("mm:ss", time)
+
+	var/minutes = floor(time DECISECONDS_TO_MINUTES)
+	var/seconds = floor((time - minutes MINUTES) DECISECONDS_TO_SECONDS)
+	if(seconds < 10)
+		seconds = "0[seconds]"
+	return "[minutes]:[seconds]"
 
 /proc/time_left_until(target_time, current_time, time_unit)
 	return ceil(target_time - current_time) / time_unit

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -70,9 +70,8 @@ GLOBAL_LIST_INIT(reboot_sfx, file2list("config/reboot_sfx.txt"))
 
 	change_tick_lag(CONFIG_GET(number/ticklag))
 
-	// As of byond 515.1637 time2text now treats 0 like it does negative numbers so the hour is wrong
-	// We could instead use world.timezone but IMO better to not assume lummox will keep time2text in parity with it
-	GLOB.timezoneOffset = text2num(time2text(10,"hh")) * 36000
+	// I hate that this logic keeps having to change
+	GLOB.timezoneOffset = world.timezone * 36000
 
 	Master.Initialize(10, FALSE, TRUE)
 


### PR DESCRIPTION

# About the pull request

This PR does a few things:
- Implements rollover for `duration2text` where durations larger than a day just get added to the hours
- Implements rollover for `duration2text_sec` where durations larger than an hour just get added to the minutes
- Experimentally changes logic for `GLOB.timezoneoffset` to use `world.timezone` instead of a `time2text` result. I'm doing this because it seems like the behavior might have changed in recent versions of byond or just the other method just didn't support negative offsets. TG currently uses world.timezone. However, I'm not sure if there'll be other effects of this for the live server (e.g. if the timezone is wrong on linux)
<img width="677" height="900" alt="image" src="https://github.com/user-attachments/assets/4fa626c3-40fe-41cd-8e28-a895b444fabd" />

Ultimately the duration rollover is because #10375 uses a timelock that's >24 hours so rather than reporting 30 hours needed for the job, it would report <= 6 Hours while there's at least a day left: 
<img width="393" height="71" alt="image" src="https://github.com/user-attachments/assets/51c7e488-7f62-4c9e-a779-f1b92aade467" />

# Explain why it's good for the game

Timelocks should report accurate information.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="832" height="273" alt="image" src="https://github.com/user-attachments/assets/9114016d-3007-4bf3-b1e7-3b4aa130b4bb" />
<img width="1244" height="1195" alt="image" src="https://github.com/user-attachments/assets/9598c489-744f-4f46-953d-d82682a1f479" />

</details>


# Changelog
:cl: Drathek
fix: duration2text and duration2text_sec now support times greater than a day or hour respectively
code: GLOB.timezoneoffset now experimentally uses world.timezone instead of a time2text result
/:cl:
