### PR TITLE
Qdel instanced new_comp if COMPONENT_DUPE_UNIQUE_PASSARGS

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -437,6 +437,7 @@
 						old_comp.InheritComponent(arglist(arguments))
 					else
 						old_comp.InheritComponent(new_comp, TRUE)
+						QDEL_NULL(new_comp)
 				if(COMPONENT_DUPE_SELECTIVE)
 					var/list/arguments = raw_args.Copy()
 					arguments[1] = new_comp


### PR DESCRIPTION

# About the pull request

This PR simply adds a QDEL_NULL for a duplicate component when in COMPONENT_DUPE_UNIQUE_PASSARGS mode if you passed it an instance. Currently there's no situation where the code would ever do this, but TG added this change a couple months ago in https://github.com/tgstation/tgstation/pull/91368 and it looks correct to me.

# Explain why it's good for the game

Better future proofing I guess.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Drathek
code: Adding a duplicate instanced component in COMPONENT_DUPE_UNIQUE_PASSARGS mode will now qdel the new component
/:cl:
