### PR TITLE
Re-enables hornet shrapnels and readjust requirement for special shrapnel for OT

### DIFF
--- a/code/__DEFINES/chemistry.dm
+++ b/code/__DEFINES/chemistry.dm
@@ -357,7 +357,7 @@
 /// The minimum amount of chems required to turn shrapnel into a special type
 #define EXPLOSION_PHORON_THRESHOLD 10
 #define EXPLOSION_ACID_THRESHOLD 10
-#define EXPLOSION_NEURO_THRESHOLD 30
+#define EXPLOSION_NEURO_THRESHOLD 10
 
 #define EXPLOSION_MIN_FALLOFF 25
 #define EXPLOSION_BASE_SHARDS 4

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -751,7 +751,7 @@
 				shards += floor(reagent.volume)
 			else if(reagent.id == "phoron" && reagent.volume >= EXPLOSION_PHORON_THRESHOLD)
 				shard_type = /datum/ammo/bullet/shrapnel/incendiary
-			else if(reagent.id == "sulphuric acid" && reagent.volume >= EXPLOSION_ACID_THRESHOLD)
+			else if(reagent.id == "pacid" && reagent.volume >= EXPLOSION_ACID_THRESHOLD)
 				shard_type = /datum/ammo/bullet/shrapnel/hornet_rounds
 			else if(reagent.id == "neurotoxinplasma" && reagent.volume >= EXPLOSION_NEURO_THRESHOLD)
 				shard_type = /datum/ammo/bullet/shrapnel/neuro


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

- Fixes turning shrapnel from OT explosives from regular shrapnel into hornet shrapnel by replacing the required recipe from Sulphuric Acid into Polytrinic Acid
- Couldn't change the shrapnel type due to conflict with Sulphuric Acid and Iron mixing into Iron Sulfate.
- Lowers required neurotoxin plasma to alter shrapnel to neurotoxin shrapnel

# Explain why it's good for the game

- More options for OT
- Lowered Requirement for neurotoxin as the slow isnt that long anyway and doesnt stack, plus the demand is quite too high as it is considering the low accuracy of shrapnel and the amount of shrapnel is already halved.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: lowers required neurotoxin plasma to turn shrapnel type of custom explosives from 30 to 10
fix: replaces the chemical required to turn shrapnel into hornet shrapnel from sulphuric acid into polytrinic acid due to recipe conflicts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
