### PR TITLE
Admin Select Equipment Categories

### DIFF
--- a/code/_globalvars/global_lists.dm
+++ b/code/_globalvars/global_lists.dm
@@ -174,8 +174,15 @@ GLOBAL_LIST_INIT(surgical_tools, setup_surgical_tools())
 GLOBAL_LIST_INIT(surgical_init_tools, GLOB.surgical_tools - typecacheof(SURGERY_TOOLS_NO_INIT_MSG))
 GLOBAL_LIST_INIT(surgical_patient_types, setup_surgical_patient_types())
 
-GLOBAL_LIST_INIT_TYPED(gear_path_presets_list, /datum/equipment_preset, setup_gear_path_presets())
-GLOBAL_LIST_INIT_TYPED(gear_name_presets_list, /datum/equipment_preset, setup_gear_name_presets())
+/datum/equip_preset_folder
+	var/list/categories
+	var/list/datum/equipment_preset/gear_path_presets_list
+	var/list/datum/equipment_preset/gear_name_presets_list
+
+/datum/equip_preset_folder/New()
+	setup_gear_categories()
+
+GLOBAL_DATUM_INIT(equipment_presets, /datum/equip_preset_folder, new)
 
 GLOBAL_LIST_EMPTY(active_areas)
 GLOBAL_LIST_EMPTY(all_areas)
@@ -402,28 +409,35 @@ GLOBAL_LIST_INIT(wy_droid_emotes, setup_wy_droid_emotes())
 		resin_meanings_list[T] = XMD
 	return sortAssoc(resin_meanings_list)
 
-/proc/setup_gear_path_presets()
-	var/list/gear_path_presets_list = list()
-	for(var/T in typesof(/datum/equipment_preset))
-		var/datum/equipment_preset/EP = T
-		if (!initial(EP.flags))
-			continue
-		EP = new T
-		gear_path_presets_list[EP.type] = EP
-	return sortAssoc(gear_path_presets_list)
+// Ideally I need to TGUI this.
+/datum/equip_preset_folder/proc/setup_gear_categories()
+	var/list/all_categories = list()
+	var/list/path_presets_list = list()
 
-/proc/setup_gear_name_presets()
-	var/list/gear_path_presets_list = list()
-	for(var/T in typesof(/datum/equipment_preset))
-		var/datum/equipment_preset/EP = T
-		if (!initial(EP.flags))
+	for(var/type in typesof(/datum/equipment_preset))
+		var/datum/equipment_preset/preset = type
+		if (!initial(preset.flags))
 			continue
-		EP = new T
-		var/datum/equipment_preset/existing = gear_path_presets_list[EP.name]
-		if(existing)
-			stack_trace("[EP.name] from [T] overlaps with [existing.type]! It must have a unique name for lookup!")
-		gear_path_presets_list[EP.name] = EP
-	return sortAssoc(gear_path_presets_list)
+		preset = new type
+		path_presets_list[preset.type] = preset
+
+		var/list/categories_to_check = list("All", preset.faction)
+		categories_to_check += preset.selection_categories
+		for(var/category in categories_to_check)
+			if(!(category in all_categories))
+				all_categories[category] = list()
+
+			if(!(preset.name in all_categories[category]))
+				all_categories[category][preset.name] = preset
+			else
+				var/datum/equipment_preset/existing = all_categories[category][preset.name]
+				stack_trace("[preset.name] from [type] overlaps with [existing.type]! It must have a unique name for lookup!")
+
+	for(var/category_list in all_categories)
+		all_categories[category_list] = sortAssoc(all_categories[category_list])
+
+	gear_path_presets_list = sortAssoc(path_presets_list)
+	categories = all_categories
 
 /proc/setup_language_keys()
 	var/list/language_keys = list()

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -152,29 +152,29 @@
 /datum/job/proc/get_access()
 	if(!gear_preset)
 		return null
-	if(GLOB.gear_path_presets_list[gear_preset])
-		return GLOB.gear_path_presets_list[gear_preset].access
+	if(GLOB.equipment_presets.gear_path_presets_list[gear_preset])
+		return GLOB.equipment_presets.gear_path_presets_list[gear_preset].access
 	return null
 
 /datum/job/proc/get_skills()
 	if(!gear_preset)
 		return null
-	if(GLOB.gear_path_presets_list[gear_preset])
-		return GLOB.gear_path_presets_list[gear_preset].skills
+	if(GLOB.equipment_presets.gear_path_presets_list[gear_preset])
+		return GLOB.equipment_presets.gear_path_presets_list[gear_preset].skills
 	return null
 
 /datum/job/proc/get_paygrade()
 	if(!gear_preset)
 		return ""
-	if(GLOB.gear_path_presets_list[gear_preset])
-		return GLOB.gear_path_presets_list[gear_preset].paygrades[1]
+	if(GLOB.equipment_presets.gear_path_presets_list[gear_preset])
+		return GLOB.equipment_presets.gear_path_presets_list[gear_preset].paygrades[1]
 	return ""
 
 /datum/job/proc/get_comm_title()
 	if(!gear_preset)
 		return ""
-	if(GLOB.gear_path_presets_list[gear_preset])
-		return GLOB.gear_path_presets_list[gear_preset].role_comm_title
+	if(GLOB.equipment_presets.gear_path_presets_list[gear_preset])
+		return GLOB.equipment_presets.gear_path_presets_list[gear_preset].role_comm_title
 	return ""
 
 /datum/job/proc/set_spawn_positions(count)

--- a/code/game/machinery/vending/vendor_types/antag/antag_clothing.dm
+++ b/code/game/machinery/vending/vendor_types/antag/antag_clothing.dm
@@ -36,7 +36,7 @@
 		products_sets = listed_products[H.assigned_equipment_preset.type]
 	else
 		if(!(/datum/equipment_preset/clf in listed_products))
-			listed_products[/datum/equipment_preset/clf] = GLOB.gear_path_presets_list[/datum/equipment_preset/clf].get_antag_clothing_equipment()
+			listed_products[/datum/equipment_preset/clf] = GLOB.equipment_presets.gear_path_presets_list[/datum/equipment_preset/clf].get_antag_clothing_equipment()
 		products_sets = listed_products[/datum/equipment_preset/clf]
 	return products_sets
 

--- a/code/modules/admin/player_panel/actions/antag.dm
+++ b/code/modules/admin/player_panel/actions/antag.dm
@@ -9,9 +9,9 @@
 		return
 
 	var/mob/living/carbon/human/H = target
-	var/datum/equipment_preset/preset = GLOB.gear_path_presets_list[/datum/equipment_preset/other/mutiny/mutineer]
+	var/datum/equipment_preset/preset = GLOB.equipment_presets.gear_path_presets_list[/datum/equipment_preset/other/mutiny/mutineer]
 	if(params["leader"])
-		preset = GLOB.gear_path_presets_list[/datum/equipment_preset/other/mutiny/mutineer/leader]
+		preset = GLOB.equipment_presets.gear_path_presets_list[/datum/equipment_preset/other/mutiny/mutineer/leader]
 
 
 	preset.load_status(H)
@@ -51,10 +51,10 @@
 		return
 
 	var/mob/living/carbon/human/H = target
-	var/datum/equipment_preset/preset = GLOB.gear_path_presets_list[/datum/equipment_preset/other/xeno_cultist]
+	var/datum/equipment_preset/preset = GLOB.equipment_presets.gear_path_presets_list[/datum/equipment_preset/other/xeno_cultist]
 
 	if(params["leader"])
-		preset = GLOB.gear_path_presets_list[/datum/equipment_preset/other/xeno_cultist/leader]
+		preset = GLOB.equipment_presets.gear_path_presets_list[/datum/equipment_preset/other/xeno_cultist/leader]
 
 	preset.load_race(H)
 	preset.load_status(H, params["hivenumber"])

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -869,11 +869,11 @@
 
 /datum/admins/var/create_humans_html = null
 /datum/admins/proc/create_humans(mob/user)
-	if(!GLOB.gear_name_presets_list)
+	if(!GLOB.equipment_presets.categories["All"])
 		return
 
 	if(!create_humans_html)
-		var/equipment_presets = jointext(GLOB.gear_name_presets_list, ";")
+		var/equipment_presets = jointext(GLOB.equipment_presets.categories["All"], ";")
 		create_humans_html = file2text('html/create_humans.html')
 		create_humans_html = replacetext(create_humans_html, "null /* object types */", "\"[equipment_presets]\"")
 		create_humans_html = replacetext(create_humans_html, "/* href token */", RawHrefToken(forceGlobal = TRUE))

--- a/code/modules/admin/topic/topic.dm
+++ b/code/modules/admin/topic/topic.dm
@@ -819,13 +819,13 @@
 		var/datum/hive_status/hive = hives[hive_name]
 
 		if(href_list["makecultist"])
-			var/datum/equipment_preset/preset = GLOB.gear_path_presets_list[/datum/equipment_preset/other/xeno_cultist]
+			var/datum/equipment_preset/preset = GLOB.equipment_presets.gear_path_presets_list[/datum/equipment_preset/other/xeno_cultist]
 			preset.load_race(H)
 			preset.load_status(H, hive.hivenumber)
 			message_admins("[key_name_admin(usr)] has made [key_name_admin(H)] into a cultist for [hive.name].")
 
 		else if(href_list["makecultistleader"])
-			var/datum/equipment_preset/preset = GLOB.gear_path_presets_list[/datum/equipment_preset/other/xeno_cultist/leader]
+			var/datum/equipment_preset/preset = GLOB.equipment_presets.gear_path_presets_list[/datum/equipment_preset/other/xeno_cultist/leader]
 			preset.load_race(H)
 			preset.load_status(H, hive.hivenumber)
 			message_admins("[key_name_admin(usr)] has made [key_name_admin(H)] into a cultist leader for [hive.name].")

--- a/code/modules/admin/verbs/select_equipment.dm
+++ b/code/modules/admin/verbs/select_equipment.dm
@@ -106,7 +106,10 @@
 
 /client/proc/cmd_admin_dress_human(mob/living/carbon/human/M in GLOB.human_mob_list, datum/equipment_preset/dresscode, no_logs = 0, count_participant = FALSE)
 	if (!no_logs)
-		dresscode = tgui_input_list(usr, "Select dress for [M]", "Robust quick dress shop", GLOB.gear_name_presets_list)
+		var/category = tgui_input_list(usr, "Which Equipment Category do you wish to use?", "Select Category", GLOB.equipment_presets.categories)
+		if(!category)
+			return
+		dresscode = tgui_input_list(usr, "Select dress for [M]", "Robust quick dress shop", GLOB.equipment_presets.categories[category])
 
 	if(isnull(dresscode))
 		return
@@ -138,7 +141,7 @@
 	set name = "Select Equipment - All Humans"
 	set desc = "Applies an equipment preset to all humans in the world."
 
-	var/datum/equipment_preset/dresscode = tgui_input_list(usr, "Select dress for ALL HUMANS", "Robust quick dress shop", GLOB.gear_name_presets_list)
+	var/datum/equipment_preset/dresscode = tgui_input_list(usr, "Select dress for ALL HUMANS", "Robust quick dress shop", GLOB.equipment_presets.categories["All"])
 	if (isnull(dresscode))
 		return
 
@@ -154,18 +157,18 @@
 //a rank that matches a job title unless you want the human to bypass the skill system.
 /proc/arm_equipment(mob/living/carbon/human/M, dresscode, randomise = FALSE, count_participant = FALSE, client/mob_client, show_job_gear = TRUE)
 	if(ispath(dresscode))
-		if(!GLOB.gear_path_presets_list)
+		if(!GLOB.equipment_presets.gear_path_presets_list)
 			CRASH("arm_equipment !gear_path_presets_list")
-		if(!GLOB.gear_path_presets_list[dresscode])
+		if(!GLOB.equipment_presets.gear_path_presets_list[dresscode])
 			CRASH("arm_equipment !gear_path_presets_list[dresscode]")
-		GLOB.gear_path_presets_list[dresscode].load_preset(M, randomise, count_participant, mob_client, show_job_gear)
+		GLOB.equipment_presets.gear_path_presets_list[dresscode].load_preset(M, randomise, count_participant, mob_client, show_job_gear)
 	else
-		if(!GLOB.gear_name_presets_list)
+		if(!GLOB.equipment_presets.categories["All"])
 			CRASH("arm_equipment !gear_path_presets_list")
-		if(!GLOB.gear_name_presets_list[dresscode])
+		if(!GLOB.equipment_presets.categories["All"][dresscode])
 			CRASH("arm_equipment !gear_path_presets_list[dresscode]")
-		GLOB.gear_name_presets_list[dresscode].load_preset(M, randomise, count_participant, mob_client, show_job_gear)
-
+		var/datum/equipment_preset/selected_dresscode = GLOB.equipment_presets.categories["All"][dresscode]
+		selected_dresscode.load_preset(M, randomise, count_participant, mob_client, show_job_gear)
 	if(M.faction)
 		M.check_event_info(M.faction)
 	return

--- a/code/modules/buildmode/submodes/outfit.dm
+++ b/code/modules/buildmode/submodes/outfit.dm
@@ -14,7 +14,7 @@
 	dresscode = null
 
 /datum/buildmode_mode/outfit/change_settings(client/c)
-	dresscode = tgui_input_list(c?.mob, "Pick a Preset", "Equipment", GLOB.gear_name_presets_list)
+	dresscode = tgui_input_list(c?.mob, "Pick a Preset", "Equipment", GLOB.equipment_presets.categories["All"])
 
 /datum/buildmode_mode/outfit/when_clicked(client/c, params, object)
 	var/list/modifiers = params2list(params)

--- a/code/modules/gear_presets/_select_equipment.dm
+++ b/code/modules/gear_presets/_select_equipment.dm
@@ -51,7 +51,8 @@
 
 	var/list/uniform_sets = null
 
-
+	/// All presets are in "All" and "Faction" (drawn from the faction variable)
+	var/selection_categories = list()
 
 /datum/equipment_preset/New()
 	if(!manifest_title)

--- a/code/modules/gear_presets/cia.dm
+++ b/code/modules/gear_presets/cia.dm
@@ -139,6 +139,7 @@
 /datum/equipment_preset/clf/engineer/cia
 	name = "CIA Spy (CLF Engineer)"
 	skills = /datum/skills/cia
+	selection_categories = list("CIA")
 
 /datum/equipment_preset/clf/engineer/cia/New()
 	. = ..()
@@ -178,6 +179,7 @@
 /datum/equipment_preset/upp/soldier/dressed/cia
 	name = "CIA Spy (UPP Soldier)"
 	skills = /datum/skills/cia
+	selection_categories = list("CIA")
 
 /datum/equipment_preset/upp/soldier/dressed/cia/New()
 	. = ..()
@@ -191,6 +193,7 @@
 /datum/equipment_preset/upp/officer/senior/dressed/cia
 	name = "CIA Spy (UPP Senior Officer)"
 	skills = /datum/skills/cia_senior
+	selection_categories = list("CIA")
 
 /datum/equipment_preset/upp/officer/senior/dressed/cia/New()
 	. = ..()

--- a/code/modules/gear_presets/corpses.dm
+++ b/code/modules/gear_presets/corpses.dm
@@ -11,6 +11,7 @@
 	skills = /datum/skills/civilian
 	idtype = /obj/item/card/id/lanyard
 	var/xenovictim = FALSE //Set to true to make the corpse spawn as a victim of a xeno burst
+	selection_categories = list("Corpse")
 
 /datum/equipment_preset/corpse/load_languages(mob/living/carbon/human/new_human)
 	return

--- a/code/modules/mob/living/carbon/human/human_abilities.dm
+++ b/code/modules/mob/living/carbon/human/human_abilities.dm
@@ -382,7 +382,7 @@ CULT
 		to_chat(H, SPAN_XENOMINORWARNING("You decide not to convert [chosen]."))
 		return
 
-	var/datum/equipment_preset/preset = GLOB.gear_path_presets_list[/datum/equipment_preset/other/xeno_cultist]
+	var/datum/equipment_preset/preset = GLOB.equipment_presets.gear_path_presets_list[/datum/equipment_preset/other/xeno_cultist]
 	preset.load_race(chosen)
 	preset.load_status(chosen, H.hivenumber)
 


### PR DESCRIPTION

# About the pull request

Cleans up the backend code for use of select equipment, and allows staff to look through by category so they're not forced to open a list of 700+ entries each time.

# Explain why it's good for the game

We were duplicating entries of equipment_presets, now we're not. Also it's nice to have categories.


# Testing Photographs and Procedure
I have tested that all features work.


# Changelog
:cl:
add: Added categories to Select Equipment.
code: Cleaned up backend duplication.
/:cl:
