### PR TITLE
Gender and Name and Orbit Fixes

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -53,14 +53,14 @@
 
 		return f_style
 
-/proc/random_name(gender, species = "Human")
+/proc/random_name(gender)
 	switch(gender)
 		if(FEMALE)
-			return capitalize(pick(GLOB.first_names_female)) + " " + capitalize(pick(GLOB.last_names))
-		if(MALE)
-			return capitalize(pick(GLOB.first_names_male)) + " " + capitalize(pick(GLOB.last_names))
-		if(PLURAL)
-			return capitalize(pick(pick(GLOB.first_names_male), pick(GLOB.first_names_female))) + " " + capitalize(pick(GLOB.last_names))
+			return "[capitalize(pick(GLOB.first_names_female))] [capitalize(pick(GLOB.last_names))]"
+		if(PLURAL, NEUTER)
+			return "[capitalize(pick(MALE, FEMALE) == MALE ? pick(GLOB.first_names_male) : pick(GLOB.first_names_female))] [capitalize(pick(GLOB.last_names))]"
+		else // MALE
+			return "[capitalize(pick(GLOB.first_names_male))] [capitalize(pick(GLOB.last_names))]"
 
 /proc/has_species(mob/M, species)
 	if(!M || !istype(M,/mob/living/carbon/human))

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1698,11 +1698,15 @@ GLOBAL_LIST_INIT(duplicate_forbidden_vars,list(
 
 		if(current.real_name && current.real_name != current.name)
 			name += " \[[current.real_name]\]"
-		if(current.stat == DEAD && specify_dead_role)
-			if(isobserver(current))
-				name += " \[ghost\]"
-			else
-				name += " \[dead\]"
+		if(current.stat == DEAD)
+			var/isobserver = isobserver(current)
+			if(isobserver && current.mind?.original?.aghosted)
+				continue
+			if(specify_dead_role)
+				if(isobserver)
+					name += " \[ghost\]"
+				else
+					name += " \[dead\]"
 		pois[name] = current
 
 	if(!mobs_only)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1688,24 +1688,25 @@ GLOBAL_LIST_INIT(duplicate_forbidden_vars,list(
 	var/list/mobs = sortmobs()
 	var/list/namecounts = list()
 	var/list/pois = list()
-	for(var/mob/M as anything in mobs)
-		if(skip_mindless && (!M.mind && !M.ckey))
+	for(var/mob/current as anything in mobs)
+		if(skip_mindless && (!current.mind && !current.ckey))
 			continue
-		if(M.client?.admin_holder)
-			if(M.client.admin_holder.fakekey || M.client.admin_holder.invisimined) //stealthmins
+		if(current.client?.admin_holder)
+			if(current.client.admin_holder.fakekey || current.client.admin_holder.invisimined) //stealthmins
 				continue
-		var/name = avoid_assoc_duplicate_keys(M.name, namecounts)
+		var/name = avoid_assoc_duplicate_keys(current.name ? current.name : "Unknown", namecounts)
 
-		if(M.real_name && M.real_name != M.name)
-			name += " \[[M.real_name]\]"
-		if(M.stat == DEAD && specify_dead_role)
-			if(isobserver(M))
+		if(current.real_name && current.real_name != current.name)
+			name += " \[[current.real_name]\]"
+		if(current.stat == DEAD && specify_dead_role)
+			if(isobserver(current))
 				name += " \[ghost\]"
 			else
 				name += " \[dead\]"
-		pois[name] = M
+		pois[name] = current
 
-	pois.Add(get_multi_vehicles())
+	if(!mobs_only)
+		pois.Add(get_multi_vehicles())
 
 	return pois
 

--- a/code/datums/origin/origin.dm
+++ b/code/datums/origin/origin.dm
@@ -3,13 +3,7 @@
 	var/desc = "You were born somewhere, someplace. The area is known for doing things, you think."
 
 /datum/origin/proc/generate_human_name(gender = MALE)
-	switch(gender)
-		if(FEMALE)
-			return capitalize(pick(GLOB.first_names_female)) + " " + capitalize(pick(GLOB.last_names))
-		if(MALE)
-			return capitalize(pick(GLOB.first_names_male)) + " " + capitalize(pick(GLOB.last_names))
-		if(PLURAL)
-			return capitalize(pick(pick(GLOB.first_names_male), pick(GLOB.first_names_female))) + " " + capitalize(pick(GLOB.last_names))
+	return random_name(gender)
 
 /// Return null if the name is correct, otherwise return a string containing the error message
 /datum/origin/proc/validate_name(name_to_check)

--- a/code/datums/origin/upp.dm
+++ b/code/datums/origin/upp.dm
@@ -11,10 +11,10 @@
 		switch(gender)
 			if(FEMALE)
 				first_name = capitalize(pick(GLOB.first_names_female_upp))
-			if(MALE)
-				first_name = capitalize(pick(GLOB.first_names_male_upp))
-			if(PLURAL)
+			if(PLURAL, NEUTER)
 				first_name = capitalize(pick(pick(GLOB.first_names_male_upp), pick(GLOB.first_names_female_upp)))
+			else // MALE
+				first_name = capitalize(pick(GLOB.first_names_male_upp))
 	if(prob(35))
 		last_name = "[capitalize(randomly_generate_chinese_word(pick(20;1, 80;2)))]"
 	else

--- a/code/datums/origin/uscm.dm
+++ b/code/datums/origin/uscm.dm
@@ -30,11 +30,11 @@
 /datum/origin/uscm/aw/generate_human_name(gender = MALE)
 	switch(gender)
 		if(FEMALE)
-			return capitalize(pick(GLOB.first_names_female)) + " A.W. " + capitalize(pick(GLOB.weapon_surnames))
-		if(MALE)
-			return capitalize(pick(GLOB.first_names_male)) + " A.W. " + capitalize(pick(GLOB.weapon_surnames))
-		if(PLURAL)
-			return capitalize(pick(pick(GLOB.first_names_male), pick(GLOB.first_names_female))) + " A.W. " + capitalize(pick(GLOB.weapon_surnames))
+			return "[capitalize(pick(GLOB.first_names_female))] A.W. [capitalize(pick(GLOB.weapon_surnames))]"
+		if(PLURAL, NEUTER)
+			return "[capitalize(pick(MALE, FEMALE) == MALE ? pick(GLOB.first_names_male) : pick(GLOB.first_names_female))] A.W. [capitalize(pick(GLOB.weapon_surnames))]"
+		else // MALE
+			return "[capitalize(pick(GLOB.first_names_male))] A.W. [capitalize(pick(GLOB.weapon_surnames))]"
 
 /datum/origin/uscm/aw/validate_name(name_to_check)
 	if(!findtext(name_to_check, "A.W. "))

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -1002,7 +1002,7 @@ Additional game mode variables.
 			current_survivors -= survivor
 			continue //Not a mind? How did this happen?
 
-		random_name = pick(random_name(FEMALE),random_name(MALE))
+		random_name = random_name(pick(FEMALE, MALE))
 
 		if(istype(survivor.current, /mob/living) && survivor.current.first_xeno)
 			current_survivors -= survivor

--- a/code/game/jobs/job/civilians/other/survivors.dm
+++ b/code/game/jobs/job/civilians/other/survivors.dm
@@ -145,7 +145,7 @@ GLOBAL_LIST_EMPTY(spawned_survivors)
 										)
 										*/
 
-	var/random_name = pick(random_name(FEMALE), random_name(MALE))
+	var/random_name = random_name(pick(FEMALE, MALE))
 	var/temp_story = "<b>Your story thus far</b>: " + replacetext(pick(survivor_story), "{name}", "[random_name]")
 	to_chat(H, temp_story)
 	H.mind.memory += temp_story

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -521,12 +521,12 @@ GLOBAL_LIST_INIT(mentor_verbs, list(
 
 	var/new_gender = alert(usr, "Please select gender.", "Character Generation", "Male", "Female", "Non-Binary")
 	if(new_gender)
-		if(new_gender == "Male")
-			M.gender = MALE
-		else if(new_gender == "Female")
+		if(new_gender == "Female")
 			M.gender = FEMALE
 		else if(new_gender == "Non-Binary")
 			M.gender = PLURAL
+		else
+			M.gender = MALE
 	M.update_hair()
 	M.update_body()
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1758,7 +1758,7 @@ GLOBAL_LIST_INIT(be_special_flags, list(
 						gender = FEMALE
 					else if(gender == FEMALE)
 						gender = PLURAL
-					else if(gender == PLURAL)
+					else
 						gender = MALE
 					underwear = sanitize_inlist(underwear, gender == MALE ? GLOB.underwear_m : GLOB.underwear_f, initial(underwear))
 					undershirt = sanitize_inlist(undershirt, gender == MALE ? GLOB.undershirt_m : GLOB.undershirt_f, initial(undershirt))

--- a/code/modules/gear_presets/agents.dm
+++ b/code/modules/gear_presets/agents.dm
@@ -111,12 +111,12 @@
 
 /datum/equipment_preset/twe/representative/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = MALE
+
 	var/datum/preferences/A = new()
 	A.randomize_appearance(new_human)
-	var/random_name
-	if(new_human.gender == MALE)
-		random_name = "[pick(GLOB.first_names_male_dutch)] [pick(GLOB.last_names_clf)]"
-		new_human.f_style = "Shaved"
+
+	var/random_name = "[capitalize(pick(GLOB.first_names_male_dutch))] [capitalize(pick(GLOB.last_names_clf))]"
+	new_human.f_style = "Shaved"
 
 	new_human.change_real_name(new_human, random_name)
 	new_human.age = rand(17,35)

--- a/code/modules/gear_presets/clf.dm
+++ b/code/modules/gear_presets/clf.dm
@@ -15,29 +15,26 @@
 
 /datum/equipment_preset/clf/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(MALE, FEMALE)
-	var/random_name
+
 	var/first_name
 	var/last_name
-	//gender checks
 	if(prob(40))
 		first_name = "[capitalize(randomly_generate_japanese_word(rand(1, 3)))]"
 	else
 		switch(new_human.gender)
-			if(MALE)
-				first_name = "[pick(GLOB.first_names_male_clf)]"
-				new_human.f_style = pick("3 O'clock Shadow", "3 O'clock Moustache", "5 O'clock Shadow", "5 O'clock Moustache")
 			if(FEMALE)
-				first_name = "[pick(GLOB.first_names_female_clf)]"
-			if(PLURAL)
-				first_name = "[pick(pick(GLOB.first_names_male_clf), pick(GLOB.first_names_female_clf))]"
-	//surname
+				first_name = capitalize(pick(GLOB.first_names_female_clf))
+			if(PLURAL, NEUTER) // Currently not possible here
+				first_name = capitalize(pick(MALE, FEMALE) == MALE ? pick(GLOB.first_names_male_clf) : pick(GLOB.first_names_female_clf))
+			else // MALE
+				first_name = capitalize(pick(GLOB.first_names_male_clf))
+				new_human.f_style = pick("3 O'clock Shadow", "3 O'clock Moustache", "5 O'clock Shadow", "5 O'clock Moustache")
 	if(prob(35))
 		last_name = "[capitalize(randomly_generate_japanese_word(rand(1, 4)))]"
 	else
 		last_name = "[pick(GLOB.last_names_clf)]"
-	//put them together
-	random_name = "[first_name] [last_name]"
-	new_human.change_real_name(new_human, random_name)
+
+	new_human.change_real_name(new_human, "[first_name] [last_name]")
 	new_human.age = rand(17,45)
 	new_human.r_hair = 25
 	new_human.g_hair = 25
@@ -781,20 +778,22 @@
 
 /datum/equipment_preset/clf/synth/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(MALE, FEMALE)
+
 	var/datum/preferences/A = new()
 	A.randomize_appearance(new_human)
+
 	var/random_name
 	if(prob(10))
 		random_name = "[capitalize(randomly_generate_japanese_word(rand(2, 3)))]"
 	else
 		switch(new_human.gender)
-			if(MALE)
-				random_name = "[pick(GLOB.first_names_male_clf)]"
-				new_human.f_style = "5 O'clock Shadow"
 			if(FEMALE)
-				random_name = "[pick(GLOB.first_names_female_clf)]"
-			if(PLURAL)
-				random_name = "[pick(pick(GLOB.first_names_male_clf), pick(GLOB.first_names_female_clf))]"
+				random_name = capitalize(pick(GLOB.first_names_female_clf))
+			if(PLURAL, NEUTER) // Currently not possible here
+				random_name = capitalize(pick(MALE, FEMALE) == MALE ? pick(GLOB.first_names_male_clf) : pick(GLOB.first_names_female_clf))
+			else // MALE
+				random_name = capitalize(pick(GLOB.first_names_male_clf))
+				new_human.f_style = "5 O'clock Shadow"
 
 	new_human.change_real_name(new_human, random_name)
 	new_human.r_hair = 15

--- a/code/modules/gear_presets/cmb.dm
+++ b/code/modules/gear_presets/cmb.dm
@@ -21,7 +21,7 @@
 	var/random_name = random_name(new_human.gender)
 	new_human.change_real_name(new_human, random_name)
 	new_human.name = new_human.real_name
-	new_human.age = rand(22,45)
+	new_human.age = rand(20,45)
 
 	var/static/list/colors = list("BLACK" = list(15, 15, 25), "BROWN" = list(102, 51, 0), "AUBURN" = list(139, 62, 19))
 	var/static/list/hair_colors = colors.Copy() + list("BLONDE" = list(197, 164, 30), "CARROT" = list(174, 69, 42))
@@ -41,11 +41,6 @@
 		new_human.f_style = pick("5 O'clock Shadow", "Shaved", "Full Beard", "3 O'clock Moustache", "5 O'clock Shadow", "5 O'clock Moustache", "7 O'clock Shadow", "7 O'clock Moustache",)
 	else
 		new_human.h_style = pick("Ponytail 1", "Ponytail 2", "Ponytail 3", "Ponytail 4", "Pvt. Redding", "Pvt. Clarison", "Cpl. Dietrich", "Pvt. Vasquez", "Marine Bun", "Marine Bun 2", "Marine Flat Top",)
-	new_human.change_real_name(new_human, random_name)
-	new_human.age = rand(20,45)
-	new_human.r_hair = rand(15,35)
-	new_human.g_hair = rand(15,35)
-	new_human.b_hair = rand(25,45)
 
 /datum/equipment_preset/cmb/load_id(mob/living/carbon/human/new_human, client/mob_client)
 	if(human_versus_human)
@@ -542,20 +537,19 @@
 
 /datum/equipment_preset/cmb/synth/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(MALE, FEMALE)
+
 	var/datum/preferences/A = new()
 	A.randomize_appearance(new_human)
+
 	var/random_name
 	switch(new_human.gender)
-		if(MALE)
-			random_name = "[pick(GLOB.first_names_male)]"
 		if(FEMALE)
-			random_name = "[pick(GLOB.first_names_female)]"
-		if(PLURAL)
-			random_name = "[pick(pick(GLOB.first_names_male), pick(GLOB.first_names_female))]"
-
-	if(new_human.gender == MALE)
-		new_human.f_style = pick("3 O'clock Shadow", "3 O'clock Moustache", "5 O'clock Shadow", "5 O'clock Moustache")
-
+			random_name = capitalize(pick(GLOB.first_names_female))
+		if(PLURAL, NEUTER) // Currently not possible
+			random_name = capitalize(pick(MALE, FEMALE) == MALE ? pick(GLOB.first_names_male) : pick(GLOB.first_names_female))
+		else // MALE
+			random_name = capitalize(pick(GLOB.first_names_male))
+			new_human.f_style = pick("3 O'clock Shadow", "3 O'clock Moustache", "5 O'clock Shadow", "5 O'clock Moustache")
 
 	new_human.change_real_name(new_human, random_name)
 	new_human.h_style = pick("Crewcut", "Shaved Head", "Buzzcut", "Undercut", "Side Undercut")

--- a/code/modules/gear_presets/contractor.dm
+++ b/code/modules/gear_presets/contractor.dm
@@ -21,7 +21,7 @@
 	var/random_name = random_name(new_human.gender)
 	new_human.change_real_name(new_human, random_name)
 	new_human.name = new_human.real_name
-	new_human.age = rand(22,45)
+	new_human.age = rand(20,45)
 
 	var/static/list/colors = list("BLACK" = list(15, 15, 25), "BROWN" = list(102, 51, 0), "AUBURN" = list(139, 62, 19))
 	var/static/list/hair_colors = colors.Copy() + list("BLONDE" = list(197, 164, 30), "CARROT" = list(174, 69, 42))
@@ -42,11 +42,6 @@
 		new_human.f_style = pick("5 O'clock Shadow", "Shaved", "Full Beard", "3 O'clock Moustache", "5 O'clock Shadow", "5 O'clock Moustache", "7 O'clock Shadow", "7 O'clock Moustache",)
 	else
 		new_human.h_style = pick("Ponytail 1", "Ponytail 2", "Ponytail 3", "Ponytail 4", "Pvt. Redding", "Pvt. Clarison", "Cpl. Dietrich", "Pvt. Vasquez", "Marine Bun", "Marine Bun 2", "Marine Flat Top",)
-	new_human.change_real_name(new_human, random_name)
-	new_human.age = rand(20,45)
-	new_human.r_hair = rand(15,35)
-	new_human.g_hair = rand(15,35)
-	new_human.b_hair = rand(25,45)
 
 /datum/equipment_preset/contractor/load_id(mob/living/carbon/human/new_human, client/mob_client)
 	if(human_versus_human)
@@ -387,20 +382,19 @@
 
 /datum/equipment_preset/contractor/duty/synth/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(MALE, FEMALE)
+
 	var/datum/preferences/A = new()
 	A.randomize_appearance(new_human)
+
 	var/random_name
 	switch(new_human.gender)
-		if(MALE)
-			random_name = "[pick(GLOB.first_names_male)]"
 		if(FEMALE)
-			random_name = "[pick(GLOB.first_names_female)]"
-		if(PLURAL)
-			random_name = "[pick(pick(GLOB.first_names_male), pick(GLOB.first_names_female))]"
-
-	if(new_human.gender == MALE)
-		new_human.f_style = pick("3 O'clock Shadow", "3 O'clock Moustache", "5 O'clock Shadow", "5 O'clock Moustache")
-
+			random_name = capitalize(pick(GLOB.first_names_female))
+		if(PLURAL, NEUTER) // Not currently possible
+			random_name = capitalize(pick(MALE, FEMALE) == MALE ? pick(GLOB.first_names_male) : pick(GLOB.first_names_female))
+		else // MALE
+			random_name = capitalize(pick(GLOB.first_names_male))
+			new_human.f_style = pick("3 O'clock Shadow", "3 O'clock Moustache", "5 O'clock Shadow", "5 O'clock Moustache")
 
 	new_human.change_real_name(new_human, random_name)
 	new_human.h_style = pick("Crewcut", "Shaved Head", "Buzzcut", "Undercut", "Side Undercut")
@@ -787,20 +781,19 @@
 
 /datum/equipment_preset/contractor/covert/synth/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(MALE, FEMALE)
+
 	var/datum/preferences/A = new()
 	A.randomize_appearance(new_human)
+
 	var/random_name
 	switch(new_human.gender)
-		if(MALE)
-			random_name = "[pick(GLOB.first_names_male)]"
 		if(FEMALE)
-			random_name = "[pick(GLOB.first_names_female)]"
-		if(PLURAL)
-			random_name = "[pick(pick(GLOB.first_names_male), pick(GLOB.first_names_female))]"
-
-	if(new_human.gender == MALE)
-		new_human.f_style = pick("3 O'clock Shadow", "3 O'clock Moustache", "5 O'clock Shadow", "5 O'clock Moustache")
-
+			random_name = capitalize(pick(GLOB.first_names_female))
+		if(PLURAL, NEUTER) // Not currently possible
+			random_name = capitalize(pick(MALE, FEMALE) == MALE ? pick(GLOB.first_names_male) : pick(GLOB.first_names_female))
+		else // MALE
+			random_name = capitalize(pick(GLOB.first_names_male))
+			new_human.f_style = pick("3 O'clock Shadow", "3 O'clock Moustache", "5 O'clock Shadow", "5 O'clock Moustache")
 
 	new_human.change_real_name(new_human, random_name)
 	new_human.h_style = pick("Crewcut", "Shaved Head", "Buzzcut", "Undercut", "Side Undercut")

--- a/code/modules/gear_presets/dutch.dm
+++ b/code/modules/gear_presets/dutch.dm
@@ -15,18 +15,22 @@
 
 /datum/equipment_preset/dutch/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(MALE, FEMALE)
+
 	var/datum/preferences/human = new()
 	human.randomize_appearance(new_human)
-	var/random_name
+
+	var/first_name
+	var/last_name = capitalize(pick(GLOB.last_names))
 	switch(new_human.gender)
-		if(MALE)
-			random_name = "[pick(GLOB.first_names_male_dutch)] [pick(GLOB.last_names)]"
-			new_human.f_style = "5 O'clock Shadow"
 		if(FEMALE)
-			random_name = "[pick(GLOB.first_names_female_dutch)] [pick(GLOB.last_names)]"
-		if(PLURAL)
-			random_name = "[pick(pick(GLOB.first_names_male_dutch), pick(GLOB.first_names_female_dutch))] [pick(GLOB.last_names)]"
-	new_human.change_real_name(new_human, random_name)
+			first_name = capitalize(pick(GLOB.first_names_female_dutch))
+		if(PLURAL, NEUTER) // Not currently possible
+			first_name = capitalize(pick(MALE, FEMALE) == MALE ? pick(GLOB.first_names_male_dutch) : pick(GLOB.first_names_female_dutch))
+		else // MALE
+			first_name = capitalize(pick(GLOB.first_names_male_dutch))
+			new_human.f_style = "5 O'clock Shadow"
+
+	new_human.change_real_name(new_human, "[first_name] [last_name]")
 	new_human.age = rand(25,35)
 	new_human.r_hair = rand(10,30)
 	new_human.g_hair = rand(10,30)
@@ -37,8 +41,6 @@
 	idtype = /obj/item/card/id/dogtag
 
 /datum/equipment_preset/dutch/load_gear(mob/living/carbon/human/new_human)
-
-
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/dutch(new_human), WEAR_HEAD)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/fancy/cigarettes/lucky_strikes(new_human), WEAR_IN_HELMET)
 	new_human.equip_to_slot_or_del(new /obj/item/tool/lighter/zippo(new_human), WEAR_IN_HELMET)

--- a/code/modules/gear_presets/fax_responders.dm
+++ b/code/modules/gear_presets/fax_responders.dm
@@ -40,7 +40,7 @@
 	if(new_human.client && new_human.client.prefs)
 		var/new_name = get_fax_responder_name(new_human.client)
 		if(new_name)
-			final_name = new_name
+			final_name = capitalize_first_letters(new_name)
 
 	new_human.change_real_name(new_human, final_name)
 

--- a/code/modules/gear_presets/fun.dm
+++ b/code/modules/gear_presets/fun.dm
@@ -436,7 +436,7 @@
 	new_human.age = rand(1, 40)
 
 /datum/equipment_preset/fun/monkey/proc/get_random_name(mob/living/carbon/human/new_human)
-	return pick(GLOB.monkey_names)
+	return capitalize(pick(GLOB.monkey_names))
 
 /datum/equipment_preset/fun/monkey/marine
 	name = "Fun - Monkey Marine"

--- a/code/modules/gear_presets/other.dm
+++ b/code/modules/gear_presets/other.dm
@@ -19,18 +19,22 @@
 
 /datum/equipment_preset/other/freelancer/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(MALE, FEMALE)
+
 	var/datum/preferences/A = new()
 	A.randomize_appearance(new_human)
-	var/random_name
+
+	var/first_name
+	var/last_name = capitalize(pick(GLOB.last_names_colonist))
 	switch(new_human.gender)
-		if(MALE)
-			random_name = "[pick(GLOB.first_names_male_colonist)] [pick(GLOB.last_names_colonist)]"
-			new_human.f_style = "5 O'clock Shadow"
 		if(FEMALE)
-			random_name = "[pick(GLOB.first_names_female_colonist)] [pick(GLOB.last_names_colonist)]"
-		if(PLURAL)
-			random_name = "[pick(pick(GLOB.first_names_male_colonist), pick(GLOB.first_names_female_colonist))] [pick(GLOB.last_names_colonist)]"
-	new_human.change_real_name(new_human, random_name)
+			first_name = capitalize(pick(GLOB.first_names_female_colonist))
+		if(PLURAL, NEUTER) // Not currently possible
+			first_name = capitalize(pick(MALE, FEMALE) == MALE ? pick(GLOB.first_names_male_colonist) : pick(GLOB.first_names_female_colonist))
+		else // MALE
+			first_name = capitalize(pick(GLOB.first_names_male_colonist))
+			new_human.f_style = "5 O'clock Shadow"
+
+	new_human.change_real_name(new_human, "[first_name] [last_name]")
 	new_human.age = rand(20,45)
 	new_human.r_hair = 25
 	new_human.g_hair = 25
@@ -285,18 +289,22 @@
 
 /datum/equipment_preset/other/elite_merc/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(MALE, FEMALE)
+
 	var/datum/preferences/A = new()
 	A.randomize_appearance(new_human)
-	var/random_name
+
+	var/first_name
+	var/last_name = capitalize(pick(GLOB.last_names_colonist))
 	switch(new_human.gender)
-		if(MALE)
-			random_name = "[pick(GLOB.first_names_male_colonist)] [pick(GLOB.last_names_colonist)]"
-			new_human.f_style = "5 O'clock Shadow"
 		if(FEMALE)
-			random_name = "[pick(GLOB.first_names_female_colonist)] [pick(GLOB.last_names_colonist)]"
-		if(PLURAL)
-			random_name = "[pick(pick(GLOB.first_names_male_colonist), pick(GLOB.first_names_female_colonist))] [pick(GLOB.last_names_colonist)]"
-	new_human.change_real_name(new_human, random_name)
+			first_name = capitalize(pick(GLOB.first_names_female_colonist))
+		if(PLURAL, NEUTER) // Not currently possible
+			first_name = capitalize(pick(MALE, FEMALE) == MALE ? pick(GLOB.first_names_male_colonist) : pick(GLOB.first_names_female_colonist))
+		else // MALE
+			first_name = capitalize(pick(GLOB.first_names_male_colonist))
+			new_human.f_style = "5 O'clock Shadow"
+
+	new_human.change_real_name(new_human, "[first_name] [last_name]")
 	new_human.age = rand(20,45)
 	new_human.r_hair = rand(15,35)
 	new_human.g_hair = rand(15,35)
@@ -539,11 +547,7 @@
 	new_human.gender = pick(MALE, FEMALE)
 	var/datum/preferences/A = new()
 	A.randomize_appearance(new_human)
-	var/random_name
-	if(new_human.gender == MALE)
-		random_name = "[pick(GLOB.first_names_male)] [pick(GLOB.last_names)]"
-	else
-		random_name = "[pick(GLOB.first_names_female)] [pick(GLOB.last_names)]"
+	var/random_name = random_name(new_human.gender)
 	new_human.change_real_name(new_human, random_name)
 	new_human.age = rand(17,45)
 
@@ -670,9 +674,19 @@
 
 /datum/equipment_preset/other/gladiator/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(MALE, FEMALE)
+
 	var/datum/preferences/A = new
 	A.randomize_appearance(new_human)
-	var/random_name = capitalize(pick(new_human.gender == MALE ? GLOB.first_names_male_gladiator : FEMALE ? GLOB.first_names_female_gladiator : pick(pick(GLOB.first_names_male_gladiator), pick(GLOB.first_names_female_gladiator))))
+
+	var/random_name
+	switch(new_human.gender)
+		if(FEMALE)
+			random_name = capitalize(pick(GLOB.first_names_female_gladiator))
+		if(PLURAL, NEUTER) // Not currently possible
+			random_name = capitalize(pick(MALE, FEMALE) == MALE ? pick(GLOB.first_names_male_gladiator) : pick(GLOB.first_names_female_gladiator))
+		else // MALE
+			random_name = capitalize(pick(GLOB.first_names_male_gladiator))
+
 	new_human.change_real_name(new_human, random_name)
 	new_human.age = rand(21,45)
 
@@ -852,8 +866,7 @@
 
 /datum/equipment_preset/other/professor_dummy/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(MALE, FEMALE)
-	new_human.real_name = "Alex the Medical Mannequin"
-	new_human.name = new_human.real_name
+	new_human.change_real_name(new_human, "Alex the Medical Mannequin")
 	new_human.age = rand(1,5)
 	var/datum/preferences/A = new
 	A.randomize_appearance(new_human)
@@ -983,7 +996,7 @@
 
 /datum/equipment_preset/uscm/tutorial_rifleman/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(MALE, FEMALE)
-	var/mob_name = "[random_name(new_human.gender)]"
+	var/mob_name = random_name(new_human.gender)
 	new_human.change_real_name(new_human, mob_name)
 	var/datum/preferences/preferences = new
 	preferences.randomize_appearance(new_human)
@@ -1009,7 +1022,7 @@
 
 /datum/equipment_preset/uscm_ship/uscm_medical/cmo/npc/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(MALE, FEMALE)
-	var/mob_name = "[random_name(new_human.gender)]"
+	var/mob_name = random_name(new_human.gender)
 	new_human.change_real_name(new_human, mob_name)
 	var/datum/preferences/preferences = new
 	preferences.randomize_appearance(new_human)

--- a/code/modules/gear_presets/pmc.dm
+++ b/code/modules/gear_presets/pmc.dm
@@ -21,28 +21,29 @@
 
 /datum/equipment_preset/pmc/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(MALE, FEMALE)
-	var/random_name
-	var/first_name
-	var/last_name
+
 	var/datum/preferences/A = new()
 	A.randomize_appearance(new_human)
+
+	var/first_name
+	var/last_name
 	if(prob(10))
-		first_name = "[capitalize(randomly_generate_japanese_word(rand(2, 3)))]"
+		first_name = capitalize(randomly_generate_japanese_word(rand(2, 3)))
 	else
 		switch(new_human.gender)
-			if(MALE)
-				first_name = "[pick(GLOB.first_names_male_pmc)]"
-				new_human.f_style = "5 O'clock Shadow"
 			if(FEMALE)
-				first_name = "[pick(GLOB.first_names_female_pmc)]"
-			if(PLURAL)
-				first_name = "[pick(pick(GLOB.first_names_male_pmc), pick(GLOB.first_names_female_pmc))]"
+				first_name = capitalize(pick(GLOB.first_names_female_pmc))
+			if(PLURAL, NEUTER) // Not currently possible
+				first_name = capitalize(pick(MALE, FEMALE) == MALE ? pick(GLOB.first_names_male_pmc) : pick(GLOB.first_names_female_pmc))
+			else // MALE
+				first_name = capitalize(pick(GLOB.first_names_male_pmc))
+				new_human.f_style = "5 O'clock Shadow"
 	if(prob(25))
-		last_name = "[capitalize(randomly_generate_japanese_word(rand(2, 4)))]"
+		last_name = capitalize(randomly_generate_japanese_word(rand(2, 4)))
 	else
-		last_name = "[pick(GLOB.last_names_pmc)]"
-	random_name = "[first_name] [last_name]"
-	new_human.change_real_name(new_human, random_name)
+		last_name = pick(GLOB.last_names_pmc)
+	new_human.change_real_name(new_human, "[first_name] [last_name]")
+
 	new_human.age = rand(25,35)
 	new_human.h_style = "Shaved Head"
 	new_human.r_hair = 25
@@ -1889,19 +1890,21 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 
 /datum/equipment_preset/pmc/synth/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(MALE, FEMALE)
+
 	var/datum/preferences/A = new()
 	A.randomize_appearance(new_human)
+
 	var/random_name
 	if(prob(10))
 		random_name = "[capitalize(randomly_generate_japanese_word(rand(2, 3)))]"
 	switch(new_human.gender)
-		if(MALE)
-			random_name = "[pick(GLOB.first_names_male_pmc)]"
-			new_human.f_style = "5 O'clock Shadow"
 		if(FEMALE)
-			random_name = "[pick(GLOB.first_names_female_pmc)]"
-		if(PLURAL)
-			random_name = "[pick(pick(GLOB.first_names_male_pmc), pick(GLOB.first_names_female_pmc))]"
+			random_name = capitalize(pick(GLOB.first_names_female_pmc))
+		if(PLURAL, NEUTER) // Not currently possible
+			random_name = capitalize(pick(MALE, FEMALE) == MALE ? pick(GLOB.first_names_male_pmc) : pick(GLOB.first_names_female_pmc))
+		else // MALE
+			random_name = capitalize(pick(GLOB.first_names_male_pmc))
+			new_human.f_style = "5 O'clock Shadow"
 
 	new_human.change_real_name(new_human, random_name)
 	new_human.r_hair = 15

--- a/code/modules/gear_presets/royal_marines.dm
+++ b/code/modules/gear_presets/royal_marines.dm
@@ -10,7 +10,10 @@
 	new_human.gender = pick(MALE, FEMALE)
 	var/datum/preferences/placeholder_pref = new()
 	placeholder_pref.randomize_appearance(new_human)
-	var/random_name
+	var/random_name = random_name(new_human.gender)
+	new_human.change_real_name(new_human, random_name)
+	new_human.age = rand(20,45)
+
 	var/static/list/colors = list("BLACK" = list(15, 15, 25), "BROWN" = list(102, 51, 0), "AUBURN" = list(139, 62, 19))
 	var/static/list/hair_colors = colors.Copy() + list("BLONDE" = list(197, 164, 30), "CARROT" = list(174, 69, 42))
 	var/hair_color = pick(hair_colors)
@@ -26,17 +29,10 @@
 	new_human.b_eyes = colors[eye_color][3]
 	idtype = /obj/item/card/id/dogtag
 	if(new_human.gender == MALE)
-		random_name = "[pick(GLOB.first_names_male)] [pick(GLOB.last_names)]"
 		new_human.h_style = pick("Crewcut", "Shaved Head", "Buzzcut", "Undercut", "Side Undercut", "Pvt. Joker", "Marine Fade", "Low Fade", "Medium Fade", "High Fade", "No Fade", "Coffee House Cut", "Flat Top",)
 		new_human.f_style = pick("5 O'clock Shadow", "Shaved", "Full Beard", "3 O'clock Moustache", "5 O'clock Shadow", "5 O'clock Moustache", "7 O'clock Shadow", "7 O'clock Moustache",)
 	else
-		random_name = "[pick(GLOB.first_names_female)] [pick(GLOB.last_names)]"
 		new_human.h_style = pick("Ponytail 1", "Ponytail 2", "Ponytail 3", "Ponytail 4", "Pvt. Redding", "Pvt. Clarison", "Cpl. Dietrich", "Pvt. Vasquez", "Marine Bun", "Marine Bun 2", "Marine Flat Top",)
-	new_human.change_real_name(new_human, random_name)
-	new_human.age = rand(20,45)
-	new_human.r_hair = rand(15,35)
-	new_human.g_hair = rand(15,35)
-	new_human.b_hair = rand(25,45)
 
 /datum/equipment_preset/twe/royal_marine/load_id(mob/living/carbon/human/new_human, client/mob_client)
 	if(human_versus_human)

--- a/code/modules/gear_presets/synths.dm
+++ b/code/modules/gear_presets/synths.dm
@@ -880,7 +880,7 @@
 	new_human.bubble_icon = "syndibot"
 
 /datum/equipment_preset/synth/working_joe/load_name(mob/living/carbon/human/new_human, randomise)
-	if(src.faction == FACTION_UPP)
+	if(faction == FACTION_UPP)
 		new_human.change_real_name(new_human, "Dzho Automaton №[rand(9)][rand(9)][ascii2text(rand(65, 90))][ascii2text(rand(65, 90))]")
 	else
 		new_human.change_real_name(new_human, "Working Joe #[rand(100)][rand(100)]")
@@ -970,22 +970,23 @@
 
 /datum/equipment_preset/synth/infiltrator/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(MALE, FEMALE)
-	var/random_name
-	var/first_name
-	var/last_name
+
 	var/datum/preferences/A = new()
 	A.randomize_appearance(new_human)
-	switch(new_human.gender)
-		if(MALE)
-			random_name = "[pick(GLOB.first_names_male_colonist)] [pick(GLOB.last_names_colonist)]"
-		if(FEMALE)
-			random_name = "[pick(GLOB.first_names_female_colonist)] [pick(GLOB.last_names_colonist)]"
-		if(PLURAL)
-			random_name = "[pick(pick(GLOB.first_names_male_colonist), pick(GLOB.first_names_female_colonist))] [pick(GLOB.last_names_colonist)]"
 
-	last_name ="[pick(GLOB.last_names_colonist)]"
-	random_name = "[first_name] [last_name]"
-	new_human.change_real_name(new_human, random_name)
+	var/first_name
+	var/last_name
+	switch(new_human.gender)
+		if(FEMALE)
+			first_name = capitalize(pick(GLOB.first_names_female_colonist))
+		if(PLURAL, NEUTER) // Not currently possible
+			first_name = capitalize(pick(MALE, FEMALE) == MALE ? pick(GLOB.first_names_male_colonist) : pick(GLOB.first_names_female_colonist))
+		else // MALE
+			first_name = capitalize(pick(GLOB.first_names_male_colonist))
+
+	last_name = capitalize(pick(GLOB.last_names_colonist))
+	new_human.change_real_name(new_human, "[first_name] [last_name]")
+
 	var/static/list/colors = list("BLACK" = list(15, 15, 25), "BROWN" = list(102, 51, 0), "AUBURN" = list(139, 62, 19))
 	var/static/list/hair_colors = colors.Copy() + list("BLONDE" = list(197, 164, 30), "CARROT" = list(174, 69, 42))
 	var/hair_color = pick(hair_colors)

--- a/code/modules/gear_presets/upp.dm
+++ b/code/modules/gear_presets/upp.dm
@@ -39,30 +39,28 @@
 
 /datum/equipment_preset/upp/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(MALE, FEMALE)
+
 	var/datum/preferences/A = new()
 	A.randomize_appearance(new_human)
-	var/random_name
+
 	var/first_name
 	var/last_name
-	//gender checks
 	if(prob(40))
-		first_name = "[capitalize(randomly_generate_chinese_word(1))]"
+		first_name = capitalize(randomly_generate_chinese_word(1))
 	else
 		switch(new_human.gender)
 			if(FEMALE)
 				first_name = capitalize(pick(GLOB.first_names_female_upp))
-			if(MALE)
+			if(PLURAL, NEUTER) // Not currently possible
+				first_name = capitalize(pick(MALE, FEMALE) == MALE ? pick(GLOB.first_names_male_upp) : pick(GLOB.first_names_female_upp))
+			else // MALE
 				first_name = capitalize(pick(GLOB.first_names_male_upp))
-			if(PLURAL)
-				first_name = capitalize(pick(pick(GLOB.first_names_male_upp), pick(GLOB.first_names_female_upp)))
 	if(prob(35))
-		last_name = "[capitalize(randomly_generate_chinese_word(pick(20;1, 80;2)))]"
+		last_name = capitalize(randomly_generate_chinese_word(pick(20;1, 80;2)))
 	else
-		last_name = "[pick(GLOB.last_names_upp)]"
-	//put them together
-	random_name = "[first_name] [last_name]"
+		last_name = capitalize(pick(GLOB.last_names_upp))
 
-	new_human.change_real_name(new_human, random_name)
+	new_human.change_real_name(new_human, "[first_name] [last_name]")
 	new_human.age = rand(17,35)
 	new_human.h_style = pick("Crewcut", "Shaved Head", "Buzzcut", "Undercut", "Side Undercut", "Bun, Topknot")
 	var/static/list/colors = list("BLACK" = list(15, 15, 25), "BROWN" = list(102, 51, 0), "AUBURN" = list(139, 62, 19))
@@ -2865,20 +2863,22 @@
 
 /datum/equipment_preset/upp/synth/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(MALE, FEMALE)
+
 	var/datum/preferences/A = new()
 	A.randomize_appearance(new_human)
+
 	var/random_name
 	if(prob(10))
 		random_name = "[capitalize(randomly_generate_chinese_word(2))]"
 	else
 		switch(new_human.gender)
-			if(MALE)
-				random_name = capitalize(pick(GLOB.first_names_male_upp))
-				new_human.f_style = pick("3 O'clock Shadow", "3 O'clock Moustache", "5 O'clock Shadow", "5 O'clock Moustache")
 			if(FEMALE)
 				random_name = capitalize(pick(GLOB.first_names_female_upp))
-			if(PLURAL)
-				random_name = capitalize(pick(pick(GLOB.first_names_male_upp), pick(GLOB.first_names_female_upp)))
+			if(PLURAL, NEUTER) // Not currently possible
+				random_name = capitalize(pick(MALE, FEMALE) == MALE ? pick(GLOB.first_names_male_upp) : pick(GLOB.first_names_female_upp))
+			else // MALE
+				random_name = capitalize(pick(GLOB.first_names_male_upp))
+				new_human.f_style = pick("3 O'clock Shadow", "3 O'clock Moustache", "5 O'clock Shadow", "5 O'clock Moustache")
 
 	new_human.change_real_name(new_human, random_name)
 	new_human.h_style = pick("Crewcut", "Shaved Head", "Buzzcut", "Undercut", "Side Undercut")

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -948,7 +948,7 @@
 
 /datum/equipment_preset/uscm/marsoc/covert/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = MALE
-	new_human.change_real_name(new_human, "[pick(GLOB.nato_phonetic_alphabet)]")
+	new_human.change_real_name(new_human, capitalize(pick(GLOB.nato_phonetic_alphabet)))
 	new_human.age = rand(20,30)
 
 /datum/equipment_preset/uscm/marsoc/covert/load_rank(mob/living/carbon/human/new_human)
@@ -960,7 +960,7 @@
 
 /datum/equipment_preset/uscm/marsoc/sg/covert/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = MALE
-	new_human.change_real_name(new_human, "[pick(GLOB.nato_phonetic_alphabet)]")
+	new_human.change_real_name(new_human, capitalize(pick(GLOB.nato_phonetic_alphabet)))
 	new_human.age = rand(20,30)
 
 /datum/equipment_preset/uscm/marsoc/sg/covert/load_rank(mob/living/carbon/human/new_human)
@@ -988,7 +988,7 @@
 
 /datum/equipment_preset/uscm/marsoc/sl/covert/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = MALE
-	new_human.change_real_name(new_human, "[pick(GLOB.nato_phonetic_alphabet)]")
+	new_human.change_real_name(new_human, capitalize(pick(GLOB.nato_phonetic_alphabet)))
 	new_human.age = rand(20,30)
 
 /datum/equipment_preset/uscm/marsoc/sl/covert/load_rank(mob/living/carbon/human/new_human)

--- a/code/modules/gear_presets/whiteout.dm
+++ b/code/modules/gear_presets/whiteout.dm
@@ -30,9 +30,9 @@
 	new_human.gender = pick(MALE)
 	var/random_name
 	if(new_human.gender == MALE)
-		random_name = "[pick(GLOB.greek_letters)]"
+		random_name = capitalize(pick(GLOB.greek_letters))
 	else
-		random_name = "[pick(GLOB.greek_letters)]"
+		random_name = capitalize(pick(GLOB.greek_letters))
 	new_human.change_real_name(new_human, random_name)
 	new_human.bubble_icon = new_bubble_icon
 	new_human.age = rand(3, 5)

--- a/code/modules/gear_presets/wy_commandos.dm
+++ b/code/modules/gear_presets/wy_commandos.dm
@@ -214,15 +214,16 @@
 
 /datum/equipment_preset/pmc/commando/leader/load_name(mob/living/carbon/human/new_human, randomise) //reference to Theo Stern from A:DD
 	new_human.gender = MALE
+
 	var/datum/preferences/human = new()
 	human.randomize_appearance(new_human)
-	var/random_name
 
+	var/random_name
 	new_human.h_style = "Cpl. Dietrich"
 	new_human.f_style = "Soulful Selleck"
-	random_name = "[pick(GLOB.first_names_male)] [pick(GLOB.last_names)]"
-
+	random_name = random_name(new_human.gender)
 	new_human.change_real_name(new_human, random_name)
+
 	new_human.age = rand(30,40)
 	new_human.r_facial = 0
 	new_human.g_facial = 0

--- a/code/modules/gear_presets/wy_goons.dm
+++ b/code/modules/gear_presets/wy_goons.dm
@@ -23,21 +23,18 @@
 	var/datum/preferences/A = new()
 	A.randomize_appearance(new_human)
 
-	var/random_name
 	var/first_name
 	var/last_name
-	//gender checks
 	switch(new_human.gender)
-		if(MALE)
-			first_name = "[pick(GLOB.first_names_male_pmc)]"
-			new_human.f_style = pick("3 O'clock Shadow", "3 O'clock Moustache", "5 O'clock Shadow", "5 O'clock Moustache")
 		if(FEMALE)
-			first_name = "[pick(GLOB.first_names_female_pmc)]"
-		if(PLURAL)
-			first_name = "[pick(pick(GLOB.first_names_male_pmc), pick(GLOB.first_names_female_pmc))]"
-	last_name = "[pick(GLOB.last_names_pmc)]"
-	random_name = "[first_name] [last_name]"
-	new_human.change_real_name(new_human, random_name)
+			first_name = capitalize(pick(GLOB.first_names_female_pmc))
+		if(PLURAL, NEUTER) // Not currently possible
+			first_name = capitalize(pick(MALE, FEMALE) == MALE ? pick(GLOB.first_names_male_pmc) : pick(GLOB.first_names_female_pmc))
+		else // MALE
+			first_name = capitalize(pick(GLOB.first_names_male_pmc))
+			new_human.f_style = pick("3 O'clock Shadow", "3 O'clock Moustache", "5 O'clock Shadow", "5 O'clock Moustache")
+	last_name = capitalize(pick(GLOB.last_names_pmc))
+	new_human.change_real_name(new_human, "[first_name] [last_name]")
 
 	new_human.age = rand(17,35)
 

--- a/code/modules/gear_presets/yautja.dm
+++ b/code/modules/gear_presets/yautja.dm
@@ -69,7 +69,7 @@
 		new_human.flavor_text = new_human.client.prefs.predator_flavor_text
 		new_human.flavor_texts["general"] = new_human.flavor_text
 		if(!final_name || final_name == "Undefined") //In case they don't have a name set or no prefs, there's a name.
-			final_name = capitalize(pick(GLOB.pred_names)) + " " + capitalize(pick(GLOB.pred_last_names))
+			final_name = "[capitalize(pick(GLOB.pred_names))] [capitalize(pick(GLOB.pred_last_names))]"
 	new_human.change_real_name(new_human, final_name)
 
 /datum/equipment_preset/yautja/youngblood //normal WL youngblood rank

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -198,12 +198,14 @@
 
 	//Target is not us
 	var/t_him = "it"
-	if (gender == MALE)
-		t_him = "him"
-	else if (gender == FEMALE)
-		t_him = "her"
-	else if (gender == PLURAL)
-		t_him = "them"
+	switch(gender)
+		if(MALE)
+			t_him = "him"
+		if(FEMALE)
+			t_him = "her"
+		if(PLURAL)
+			t_him = "them"
+
 	if (w_uniform)
 		w_uniform.add_fingerprint(M)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR is a follow up to #10491 to address the following issues:
- Mobs incorrectly having no name (hopefully - assumption is a mob with a neuter gender would then fail to randomize a name because old code used to use else as the male gender when randomizing a name.
- Because of above, this would break the orbit menu. Now the orbit menu shouldn't ever be encountering null named mobs (they will instead show up as Unknown)
- New players now sanitize their preferences even if they don't have a save file (this corrects things like fax responder names not randomizing because previously only if preferences were loaded would they get sanitized)
- Fixed where a dummy mob wouldn't use the standard `change_real_name` proc which does a lot more than just assign the real_name.
- Fixed some duplicate calls in `/datum/equipment_preset/cmb/load_name`, `/datum/equipment_preset/contractor/load_name`, and `/datum/equipment_preset/twe/royal_marine/load_name` notably making it so their hair actually will change color now.
- `getpois` proc argument `mobs_only` now actually works
- Aghosts are now ignored in orbit menu

# Explain why it's good for the game

Should fix #10717, more standardized code, as well as the improvements described above.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

We're going to subject players to this on live!


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Drathek
fix: Orbit menu should no longer be finding null named mobs to crash on (also has fallback behavior to name them as Unknown)
fix: New players (or atleast one that has never saved preferences before) now have their preferences sanitized immediately: For example this makes it so fax responder names are randomized to begin with
fix: A few equipment presents (cmb, contractor, and royal marine) now will have different hair colors
code: Various code standardization related to names and gender
admin: Aghost observers are now hidden in Orbit menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
