### PR TITLE
Fix ctrl click on xeno take over messaging

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -30,8 +30,9 @@
 		if(ismob(target) || isVehicle(target))
 			if(isxeno(target) && SSticker.mode.check_xeno_late_join(src)) //if it's a xeno and all checks are alright, we are gonna try to take their body
 				var/mob/living/carbon/xenomorph/xeno = target
-				if(xeno.stat == DEAD || should_block_game_interaction(xeno) || xeno.aghosted)
-					if(!xeno.aghosted)
+				var/dead_or_ignored = xeno.stat == DEAD || should_block_game_interaction(xeno)
+				if(dead_or_ignored || xeno.aghosted)
+					if(dead_or_ignored)
 						to_chat(src, SPAN_WARNING("You cannot join as [xeno]."))
 					do_observe(xeno)
 					return FALSE

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -31,7 +31,8 @@
 			if(isxeno(target) && SSticker.mode.check_xeno_late_join(src)) //if it's a xeno and all checks are alright, we are gonna try to take their body
 				var/mob/living/carbon/xenomorph/xeno = target
 				if(xeno.stat == DEAD || should_block_game_interaction(xeno) || xeno.aghosted)
-					to_chat(src, SPAN_WARNING("You cannot join as [xeno]."))
+					if(!xeno.aghosted)
+						to_chat(src, SPAN_WARNING("You cannot join as [xeno]."))
 					do_observe(xeno)
 					return FALSE
 
@@ -48,7 +49,7 @@
 
 				if(xeno.away_timer < required_leave_time)
 					var/to_wait = required_leave_time - xeno.away_timer
-					if(to_wait > 60 SECONDS) // don't spam for clearly non-AFK xenos
+					if(to_wait < 30) // don't spam for clearly non-AFK xenos
 						to_chat(src, SPAN_WARNING("That player hasn't been away long enough. Please wait [to_wait] second\s longer."))
 					do_observe(target)
 					return FALSE


### PR DESCRIPTION

# About the pull request

This PR simply tweaks a couple things about ctrl clicking a xeno
- No longer will is give the message "You cannot join as [xeno]." because they're aghosted
- It will now mention if the xeno can be taken over if its within the next 30s

# Explain why it's good for the game

Better messaging for ctrl+click takeover so its clearer it can be used to take over a AFK xeno, but also not pointlessly reveal when they're aghosted.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/OK6QXO3rF_c

</details>


# Changelog
:cl: Drathek
fix: Ctrl clicking a xeno now can give a timer how long until the afk xeno can be taken over if its within the next 30s
admin: Ctrl clicking a xeno no longer gives a message just because they're aghosted
/:cl:
