### PR TITLE
Remove low_amount medical items

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -214,11 +214,6 @@
 	. = ..()
 	heal_brute = initial(heal_brute) * 3 // 3x stronger
 
-/obj/item/stack/medical/advanced/bruise_pack/upgraded/low_amount/Initialize(mapload, ...)
-	. = ..()
-	amount = rand(1,4)
-	update_icon()
-
 /obj/item/stack/medical/advanced/bruise_pack/predator
 	name = "mending herbs"
 	singular_name = "mending herb"
@@ -294,11 +289,6 @@
 /obj/item/stack/medical/advanced/ointment/upgraded/Initialize(mapload, ...)
 	. = ..()
 	heal_burn = initial(heal_burn) * 3 // 3x stronger
-
-/obj/item/stack/medical/advanced/ointment/upgraded/low_amount/Initialize(mapload, ...)
-	. = ..()
-	amount = rand(1,4)
-	update_icon()
 
 /obj/item/stack/medical/advanced/ointment/predator
 	name = "soothing herbs"
@@ -390,11 +380,6 @@
 	max_amount = 5
 
 	stack_id = "nano splint"
-
-/obj/item/stack/medical/splint/nano/low_amount/Initialize(mapload, ...)
-	. = ..()
-	amount = rand(1,2)
-	update_icon()
 
 /obj/item/stack/medical/splint/nano/research
 	desc = "Advanced technology allows these splints to hold bones in place while being flexible and damage-resistant. Those are made from durable carbon fiber and dont look cheap, better use them sparingly."

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -322,7 +322,7 @@
 /obj/item/storage/firstaid/whiteout/medical/commando/looted/fill_preset_inventory() //for commando insert
 	new /obj/item/storage/box/czsp/medic_upgraded_kits/looted(src)
 	new /obj/item/storage/box/czsp/medic_upgraded_kits/looted(src)
-	new /obj/item/stack/medical/splint/nano/low_amount(src)
+	new /obj/item/stack/medical/splint/nano(src, rand(1,2))
 	new /obj/item/storage/syringe_case/commando/looted(src)
 	new /obj/item/storage/surgical_case/elite/commando/looted(src)
 	new /obj/item/roller(src)
@@ -497,9 +497,9 @@
 /obj/item/storage/box/czsp/medic_upgraded_kits/looted/Initialize()
 	. = ..()
 	if(prob(35))
-		new /obj/item/stack/medical/advanced/bruise_pack/upgraded/low_amount(src)
+		new /obj/item/stack/medical/advanced/bruise_pack/upgraded(src, rand(1,4))
 	if(prob(35))
-		new /obj/item/stack/medical/advanced/ointment/upgraded/low_amount(src)
+		new /obj/item/stack/medical/advanced/ointment/upgraded(src, rand(1,4))
 
 
 //---------SURGICAL CASE---------


### PR DESCRIPTION
# About the pull request

Removes the low_amount subtypes for nano splints, upgraded bruise packs, and upgraded ointment. 
Modified the kits and presets that used them to have random-sized stacks instead.

# Explain why it's good for the game

Fixes #10711 

# Testing Photographs and Procedure

Spawned a few surv commandos and a bunch of "looted" revive kits in a debug build; verified they got random amounts of nanosplints and upgrade bruise/ointment packs. No errors thrown.

<details>
<summary>Screenshots & Videos</summary>

![un-low-amount](https://github.com/user-attachments/assets/79bd27de-eac2-44ca-992c-8d5438c6debc)

</details>


# Changelog

:cl:
fix: Fixes an instance of medical item duping
/:cl:
