### PR TITLE
Prevent ground weed sounds from reaching ship decks

### DIFF
--- a/code/game/area/almayer.dm
+++ b/code/game/area/almayer.dm
@@ -1,4 +1,4 @@
-//ALMAYER AREAS--------------------------------------//
+﻿//ALMAYER AREAS--------------------------------------//
 // Fore = West  | Aft = East //
 // Port = South | Starboard = North //
 // Bow = Western|Stern = Eastern //(those are the front and back small sections)
@@ -15,6 +15,7 @@
 	ambience_exterior = AMBIENCE_ALMAYER
 	ceiling_muffle = FALSE
 	flags_area = AREA_NOSECURECADES
+	sound_isolated = TRUE
 	weather_enabled = FALSE
 
 	///Whether this area is used for hijack evacuation progress

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -44,6 +44,7 @@
 	var/allow_construction = TRUE // whether or not you can build things like barricades in this area
 	var/is_landing_zone = FALSE // primarily used to prevent mortars from hitting this location
 	var/resin_construction_allowed = TRUE // Allow construction of resin walls, and other special
+	var/sound_isolated = FALSE
 
 	// Weather
 	var/weather_enabled = TRUE // Manual override for weather if set to false
@@ -470,3 +471,4 @@
 	name = "Sky"
 	icon_state = "lv-626"
 	flags_area = AREA_UNWEEDABLE
+

--- a/code/game/area/rostock.dm
+++ b/code/game/area/rostock.dm
@@ -19,6 +19,7 @@
 	// soundscape_playlist = list('sound/effects/xylophone1.ogg', 'sound/effects/xylophone2.ogg', 'sound/effects/xylophone3.ogg')
 	ambience_exterior = AMBIENCE_ALMAYER
 	ceiling_muffle = FALSE
+	sound_isolated = TRUE
 
 // Upper Deck Misc
 /area/rostock/upper_deck
@@ -423,4 +424,5 @@
 	name = "SSV Rostock - Lifeboat Docking Port"
 	icon_state = "selfdestruct"
 	fake_zlevel = 2 // lowerdeck
+
 

--- a/html/changelogs/PGrayCS-bugfix-almayer-weed-audio.yml
+++ b/html/changelogs/PGrayCS-bugfix-almayer-weed-audio.yml
@@ -1,0 +1,7 @@
+﻿author: PGrayCS
+
+delete-after: True
+
+changes:
+  - bugfix: "Stopped multiz weed planting sounds from reaching ship decks by honoring a new sound isolation flag."
+

--- a/html/changelogs/peter-fax-double-click-fix.yml
+++ b/html/changelogs/peter-fax-double-click-fix.yml
@@ -1,0 +1,9 @@
+# Fix for fax machine double-click vulnerability
+# GitHub Issue: https://github.com/cmss13-devs/cmss13/issues/9953
+
+author: peter
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed ability to bypass fax machine cooldown by rapidly clicking the SEND button, preventing duplicate transmissions."

--- a/tgui/packages/tgui/interfaces/FaxMachine.tsx
+++ b/tgui/packages/tgui/interfaces/FaxMachine.tsx
@@ -30,6 +30,7 @@ type Data = {
   can_send_priority: BooleanLike;
   is_priority_fax: BooleanLike;
   is_single_sending: BooleanLike;
+  sending_fax: BooleanLike;
 };
 
 export const FaxMachine = () => {
@@ -192,6 +193,7 @@ const ConfirmSend = (props) => {
     nextfaxtime,
     can_send_priority,
     is_priority_fax,
+    sending_fax,
   } = data;
 
   const timeLeft = nextfaxtime - worldtime;
@@ -211,16 +213,20 @@ const ConfirmSend = (props) => {
           </Button>
         </Stack.Item>
         <Stack.Item grow>
-          {(timeLeft < 0 && (
+          {(timeLeft < 0 && !sending_fax && (
             <Button
               icon="paper-plane"
               fluid
               onClick={() => act('send')}
-              disabled={timeLeft > 0 || !paper || !authenticated}
+              disabled={timeLeft > 0 || !paper || !authenticated || sending_fax}
             >
               {paper ? 'Send' : 'No paper loaded!'}
             </Button>
-          )) || (
+          )) || sending_fax ? (
+            <Button icon="hourglass-half" fluid disabled={1}>
+              Transmission in progress...
+            </Button>
+          ) : (
             <Button icon="window-close" fluid disabled={1}>
               {'Transmitters realigning, ' + timeLeft / 10 + ' seconds left.'}
             </Button>
@@ -233,7 +239,7 @@ const ConfirmSend = (props) => {
               fluid
               onClick={() => act('toggle_priority')}
               color={is_priority_fax ? 'green' : 'red'}
-              disabled={!paper || !can_send_priority || !authenticated}
+              disabled={!paper || !can_send_priority || !authenticated || sending_fax}
               tooltip="Toggle priority alert."
             />
           </Stack.Item>


### PR DESCRIPTION
## Summary
- add an opt-in sound_isolated flag for areas so we can mark acoustically sealed locations such as ship decks
- teach playsound()'s vertical propagation (reas_can_share_sound()) to stop when two stacked areas disagree about isolation, preventing ground SFX from bleeding onto ships
- enable the flag across Almayer- and Rostock-class areas so Marines no longer hear xeno weed planting on Solaris Ridge before the drop

## Why?
Players on round 30087 reported hearing weed planting while standing in Bravo prep on the Almayer (Solaris Ridge multiz). Our sound quadtree scan climbs through z-trait-linked turfs without considering the acoustics of the areas it crosses, so a ground-level node placement sound rode the vertical chain straight into the ship. Marking ships as isolated and checking that flag keeps pre-drop hive activity planetside while still letting sounds travel within the ship itself.


Fixes cmss13-devs/cmss13#10724