### PR TITLE
Fixes spec manifest updating

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_specialist.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_specialist.dm
@@ -110,6 +110,8 @@ GLOBAL_LIST_INIT(cm_vending_gear_spec_heavy, list(
 	if(!handle_vend(itemspec, human_user))
 		return
 	vendor_successful_vend(itemspec, user)
+	var/obj/item/card/id/idcard = human_user.get_idcard()
+	GLOB.data_core.manifest_modify(human_user.real_name, WEAKREF(human_user), idcard.assignment)
 
 //------------CLOTHING VENDOR---------------
 


### PR DESCRIPTION
# About the pull request

Fixes specialist that spawned in via preference not updating the manifest, now they update it once they claim the gear from the vendor

# Explain why it's good for the game

bugfix

fixes: #10554
fixes: #10407

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Specialists now properly get updated on the manifest
/:cl:
