### PR TITLE
Adds Purple Option for OW Console UI #SAVECHARLIE

### DIFF
--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -38,8 +38,8 @@ GLOBAL_LIST_EMPTY_TYPED(active_overwatch_consoles, /obj/structure/machinery/comp
 	var/datum/tacmap/tacmap
 	var/minimap_type = MINIMAP_FLAG_USCM
 
-	var/list/possible_options = list("Blue" = "crtblue", "Green" = "crtgreen", "Yellow" = "crtyellow", "Red" = "crtred")
-	var/list/chosen_theme = list("Blue", "Green", "Yellow", "Red")
+	var/list/possible_options = list("Blue" = "crtblue", "Green" = "crtgreen", "Yellow" = "crtyellow", "Red" = "crtred", "Purple" = "crtpurple")
+	var/list/chosen_theme = list("Blue", "Green", "Yellow", "Red", "Purple")
 	var/command_channel_key = ":v"
 
 	var/freq = CRYO_FREQ

--- a/tgui/packages/tgui/index.tsx
+++ b/tgui/packages/tgui/index.tsx
@@ -14,6 +14,7 @@ import './styles/themes/crt/crt-green.scss';
 import './styles/themes/crt/crt-lobby.scss';
 import './styles/themes/crt/crt-lobby-red.scss';
 import './styles/themes/crt/crt-red.scss';
+import './styles/themes/crt/crt-purple.scss';
 import './styles/themes/crt/crt-white.scss';
 import './styles/themes/crt/crt-upp.scss';
 import './styles/themes/crt/crt-yellow.scss';

--- a/tgui/packages/tgui/styles/themes/crt/crt-purple.scss
+++ b/tgui/packages/tgui/styles/themes/crt/crt-purple.scss
@@ -1,0 +1,37 @@
+@use 'sass:meta';
+
+$light: hsl(288, 67%, 51%);
+$dark: hsl(10, 67%, 3%);
+
+@use '../../base.scss' with (
+  $color-bg: $dark,
+  $color-fg: $light
+);
+
+@use '../crt.scss';
+
+.theme-crtpurple {
+  @extend %theme-crt;
+
+  @keyframes purpleConfirmFlicker {
+    0% {
+      background-color: $light;
+      color: $dark;
+    }
+    50% {
+      background-color: $dark;
+      color: $light;
+    }
+    100% {
+      background-color: $light;
+      color: $dark;
+    }
+  }
+
+  .Button.ConfirmButton {
+    animation: purpleConfirmFlicker 5s infinite;
+    &:hover {
+      animation: none;
+    }
+  }
+}


### PR DESCRIPTION
# About the pull request

This PR adds purple as an option for OW console coloring.

# Explain why it's good for the game

It is extremely helpful to color OW consoles to their squad, especially when you are working two consoles at once. Currently every other squad has a coloring option (alpha red, bravo yellow, delta blue) but Charlie does not.


# Testing Photographs and Procedure

<img width="1160" height="608" alt="YzHRCrm" src="https://github.com/user-attachments/assets/0b7b4801-fa66-4e4e-aa33-814afea8fc07" />

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changel

:cl:
qol: Added purple-crt style sheet and imported it with other crt color style sheets
qol: Added purple as OW console color option
/:cl:
