### PR TITLE
fixes satchel onmobs never working

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -344,7 +344,6 @@
 	worn_accessible = TRUE
 	storage_slots = null
 	max_storage_space = 15
-	item_state_slots = list(WEAR_BACK = "satchel")
 	var/mode = TRUE
 
 /obj/item/storage/backpack/satchel/post_skin_selection()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

These sprites have been in the game ever since the coloured satchels were added, and have NEVER functioned.

# Explain why it's good for the game

I'd rather the blue satchel look blue for once.


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Fixed non-functional on-mob sprites for the blue and black leather satchels.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
