### PR TITLE
Paperwork Macros and Default Window Size

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -114,7 +114,7 @@
 	var/paper_info = info
 	if(scramble)
 		paper_info = stars_decode_html(info)
-	show_browser(user, "<BODY class='paper'>[paper_info][stamps]</BODY>", name, name, width = 650, height = 700)
+	show_browser(user, "<BODY class='paper'>[paper_info][stamps]</BODY>", name, name, width = 700, height = 900)
 	onclose(user, name)
 
 /obj/item/paper/verb/rename()
@@ -245,6 +245,8 @@
 	paper_text = replacetext(paper_text, "\[/i\]", "</I>")
 	paper_text = replacetext(paper_text, "\[u\]", "<U>")
 	paper_text = replacetext(paper_text, "\[/u\]", "</U>")
+	paper_text = replacetext(paper_text, "\[s\]", "<S>")
+	paper_text = replacetext(paper_text, "\[/s\]", "</S>")
 	paper_text = replacetext(paper_text, "\[large\]", "<font size=\"4\">")
 	paper_text = replacetext(paper_text, "\[/large\]", "</font>")
 	paper_text = replacetext(paper_text, "\[sign\]", "<font face=\"[signfont]\"><i>[user ? user.real_name : "Anonymous"]</i></font>")
@@ -253,6 +255,12 @@
 	paper_text = replacetext(paper_text, "\[time\]", "<font face=\"[signfont]\"><i>[worldtime2text("hh:mm")]</i></font>")
 	paper_text = replacetext(paper_text, "\[date+time\]", "<font face=\"[signfont]\"><i>[worldtime2text("hh:mm")], [time2text(REALTIMEOFDAY, "Day DD Month [GLOB.game_year]")]</i></font>")
 	paper_text = replacetext(paper_text, "\[field\]", "<span class=\"paper_field\"></span>")
+	paper_text = replacetext(paper_text, "\[name\]", "[user ? user.name : "Anonymous"]")
+	paper_text = replacetext(paper_text, "\[rank\]", "<font face=\"[signfont]\"><i>[user ? user.get_paygrade(0) : "None"]</i></font>")
+	paper_text = replacetext(paper_text, "\[job\]", "<font face=\"[signfont]\"><i>[user ? user.job : "None"]</i></font>")
+	paper_text = replacetext(paper_text, "\[op\]", "<font face=\"[signfont]\"><i>[GLOB.round_statistics.round_name]</i></font>")
+	paper_text = replacetext(paper_text, "\[colony\]", "<font face=\"[signfont]\"><i>[SSmapping.configs[GROUND_MAP].map_name]</i></font>")
+
 
 	paper_text = replacetext(paper_text, "\[h1\]", "<H1>")
 	paper_text = replacetext(paper_text, "\[/h1\]", "</H1>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Adds a few new text macros for paperwork:
- [s][/s] | strikethrough!
- [name] | your name (but not in signfont)
- [job] | your position on the ship
- [rank] | your rank on the ship
- [op] | the operation's name
- [colony] | the map's name

I have also increased the default paper window's size and made it an 8.5x11(ish) ratio.

# Explain why it's good for the game

Making paperwork easier is good.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

<img width="2261" height="1440" alt="image" src="https://github.com/user-attachments/assets/92be95cc-8fcc-4770-afe3-59c42b58b32e" />

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Added [s][/s], [name], [rank], [job], [op], and [colony] macros.
ui: increased the size of the default paper popup window.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
