### PR TITLE
adds a bunch of new launch options via vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,8 +11,114 @@
         {
             "type": "byond",
             "request": "launch",
+            "name": "Launch DreamSeeker (runtime map)",
+            "preLaunchTask": "Build All (runtime map)",
+            "dmb": "${workspaceFolder}/${command:CurrentDMB}"
+        },
+        {
+            "type": "byond",
+            "request": "launch",
+            "name": "Launch DreamSeeker (quickstart)",
+            "preLaunchTask": "Build All (quickstart)",
+            "dmb": "${workspaceFolder}/${command:CurrentDMB}"
+        },
+        {
+            "type": "byond",
+            "request": "launch",
+            "name": "Launch DreamSeeker (testing)",
+            "preLaunchTask": "Build All (testing)",
+            "dmb": "${workspaceFolder}/${command:CurrentDMB}"
+        },
+        {
+            "type": "byond",
+            "request": "launch",
+            "name": "Launch DreamSeeker (runtime map + quickstart)",
+            "preLaunchTask": "Build All (runtime map + quickstart)",
+            "dmb": "${workspaceFolder}/${command:CurrentDMB}"
+        },
+        {
+            "type": "byond",
+            "request": "launch",
+            "name": "Launch DreamSeeker (runtime map + testing)",
+            "preLaunchTask": "Build All (runtime map + testing)",
+            "dmb": "${workspaceFolder}/${command:CurrentDMB}"
+        },
+        {
+            "type": "byond",
+            "request": "launch",
+            "name": "Launch DreamSeeker (quickstart + testing)",
+            "preLaunchTask": "Build All (quickstart + testing)",
+            "dmb": "${workspaceFolder}/${command:CurrentDMB}"
+        },
+        {
+            "type": "byond",
+            "request": "launch",
+            "name": "Launch DreamSeeker (runtime map + quickstart + testing)",
+            "preLaunchTask": "Build All (runtime map + quickstart + testing)",
+            "dmb": "${workspaceFolder}/${command:CurrentDMB}"
+        },
+        {
+            "type": "byond",
+            "request": "launch",
             "name": "Launch DreamDaemon",
             "preLaunchTask": "Build All",
+            "dmb": "${workspaceFolder}/${command:CurrentDMB}",
+            "dreamDaemon": true
+        },
+        {
+            "type": "byond",
+            "request": "launch",
+            "name": "Launch DreamDaemon (runtime map)",
+            "preLaunchTask": "Build All (runtime map)",
+            "dmb": "${workspaceFolder}/${command:CurrentDMB}",
+            "dreamDaemon": true
+        },
+        {
+            "type": "byond",
+            "request": "launch",
+            "name": "Launch DreamDaemon (quickstart)",
+            "preLaunchTask": "Build All (quickstart)",
+            "dmb": "${workspaceFolder}/${command:CurrentDMB}",
+            "dreamDaemon": true
+
+        },
+        {
+            "type": "byond",
+            "request": "launch",
+            "name": "Launch DreamDaemon (testing)",
+            "preLaunchTask": "Build All (testing)",
+            "dmb": "${workspaceFolder}/${command:CurrentDMB}",
+            "dreamDaemon": true
+        },
+        {
+            "type": "byond",
+            "request": "launch",
+            "name": "Launch DreamDaemon (runtime map + quickstart)",
+            "preLaunchTask": "Build All (runtime map + quickstart)",
+            "dmb": "${workspaceFolder}/${command:CurrentDMB}",
+            "dreamDaemon": true
+        },
+        {
+            "type": "byond",
+            "request": "launch",
+            "name": "Launch DreamDaemon (runtime map + testing)",
+            "preLaunchTask": "Build All (runtime map + testing)",
+            "dmb": "${workspaceFolder}/${command:CurrentDMB}",
+            "dreamDaemon": true
+        },
+        {
+            "type": "byond",
+            "request": "launch",
+            "name": "Launch DreamDaemon (quickstart + testing)",
+            "preLaunchTask": "Build All (quickstart + testing)",
+            "dmb": "${workspaceFolder}/${command:CurrentDMB}",
+            "dreamDaemon": true
+        },
+        {
+            "type": "byond",
+            "request": "launch",
+            "name": "Launch DreamDaemon (runtime map + quickstart + testing)",
+            "preLaunchTask": "Build All (runtime map + quickstart + testing)",
             "dmb": "${workspaceFolder}/${command:CurrentDMB}",
             "dreamDaemon": true
         }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -25,6 +25,174 @@
             "label": "Build All"
         },
         {
+            "type": "process",
+            "command": "tools/build/build.sh",
+            "windows": {
+                "command": ".\\tools\\build\\build.bat",
+                "args": ["-DRUNTIME_MAP"]
+            },
+            "options": {
+                "env": {
+                    "DM_EXE": "${config:dreammaker.byondPath}"
+                }
+            },
+            "problemMatcher": [
+                "$dreammaker",
+                "$tsc",
+                "$eslint-stylish"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "dependsOn": "dm: reparse",
+            "label": "Build All (runtime map)"
+        },
+        {
+            "type": "process",
+            "command": "tools/build/build.sh",
+            "windows": {
+                "command": ".\\tools\\build\\build.bat",
+                "args": ["-DQUICK_START"]
+            },
+            "options": {
+                "env": {
+                    "DM_EXE": "${config:dreammaker.byondPath}"
+                }
+            },
+            "problemMatcher": [
+                "$dreammaker",
+                "$tsc",
+                "$eslint-stylish"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "dependsOn": "dm: reparse",
+            "label": "Build All (quickstart)"
+        },
+        {
+            "type": "process",
+            "command": "tools/build/build.sh",
+            "windows": {
+                "command": ".\\tools\\build\\build.bat",
+                "args": ["-DTESTING"]
+            },
+            "options": {
+                "env": {
+                    "DM_EXE": "${config:dreammaker.byondPath}"
+                }
+            },
+            "problemMatcher": [
+                "$dreammaker",
+                "$tsc",
+                "$eslint-stylish"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "dependsOn": "dm: reparse",
+            "label": "Build All (testing)"
+        },
+        {
+            "type": "process",
+            "command": "tools/build/build.sh",
+            "windows": {
+                "command": ".\\tools\\build\\build.bat",
+                "args": ["-DRUNTIME_MAP", "-DQUICK_START"]
+            },
+            "options": {
+                "env": {
+                    "DM_EXE": "${config:dreammaker.byondPath}"
+                }
+            },
+            "problemMatcher": [
+                "$dreammaker",
+                "$tsc",
+                "$eslint-stylish"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "dependsOn": "dm: reparse",
+            "label": "Build All (runtime map + quickstart)"
+        },
+        {
+            "type": "process",
+            "command": "tools/build/build.sh",
+            "windows": {
+                "command": ".\\tools\\build\\build.bat",
+                "args": ["-DTESTING", "-DQUICK_START"]
+            },
+            "options": {
+                "env": {
+                    "DM_EXE": "${config:dreammaker.byondPath}"
+                }
+            },
+            "problemMatcher": [
+                "$dreammaker",
+                "$tsc",
+                "$eslint-stylish"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "dependsOn": "dm: reparse",
+            "label": "Build All (quickstart + quickstart)"
+        },
+        {
+            "type": "process",
+            "command": "tools/build/build.sh",
+            "windows": {
+                "command": ".\\tools\\build\\build.bat",
+                "args": ["-DRUNTIME_MAP", "-DTESTING"]
+            },
+            "options": {
+                "env": {
+                    "DM_EXE": "${config:dreammaker.byondPath}"
+                }
+            },
+            "problemMatcher": [
+                "$dreammaker",
+                "$tsc",
+                "$eslint-stylish"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "dependsOn": "dm: reparse",
+            "label": "Build All (runtime map + testing)"
+        },
+        {
+            "type": "process",
+            "command": "tools/build/build.sh",
+            "windows": {
+                "command": ".\\tools\\build\\build.bat",
+                "args": ["-DRUNTIME_MAP", "-DTESTING", "-DQUICK_START"]
+            },
+            "options": {
+                "env": {
+                    "DM_EXE": "${config:dreammaker.byondPath}"
+                }
+            },
+            "problemMatcher": [
+                "$dreammaker",
+                "$tsc",
+                "$eslint-stylish"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "dependsOn": "dm: reparse",
+            "label": "Build All (runtime map + quickstart + testing)"
+        },
+        {
             "type": "dreammaker",
             "dme": "colonialmarines.dme",
             "problemMatcher": [

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -36,6 +36,10 @@
 #warn Consider switching to VSCode editor instead, where you can press Ctrl+Shift+B to build.
 #endif
 
+#ifdef RUNTIME_MAP
+#define FORCE_GROUND_MAP "maps/runtime.json"
+#endif
+
 //#define UNIT_TESTS //If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
 
 // #define TESTING

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -72,6 +72,11 @@ SUBSYSTEM_DEF(ticker)
 			to_chat_spaced(world, type = MESSAGE_TYPE_SYSTEM, margin_top = 0, html = SPAN_ROUNDBODY("Please, setup your character and select ready. Game will start in [floor(time_left / 10) || CONFIG_GET(number/lobby_countdown)] seconds."))
 			SEND_GLOBAL_SIGNAL(COMSIG_GLOB_MODE_PREGAME_LOBBY)
 			current_state = GAME_STATE_PREGAME
+
+			#ifdef QUICK_START
+			request_start()
+			#endif
+
 			fire()
 
 		if(GAME_STATE_PREGAME)

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -149,6 +149,16 @@
 
 #define CHECK_EXISTS(X) if(!istext(json[X])) { log_world("[##X] missing from json!"); return; }
 /datum/map_config/proc/LoadConfig(filename, error_if_missing, maptype)
+	#ifdef FORCE_GROUND_MAP
+	if(maptype == GROUND_MAP)
+		filename = FORCE_GROUND_MAP
+	#endif
+
+	#ifdef FORCE_SHIP_MAP
+	if(maptype == SHIP_MAP)
+		filename = FORCE_SHIP_MAP
+	#endif
+
 	if(!fexists(filename))
 		if(error_if_missing)
 			log_world("map_config not found: [filename]")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -333,6 +333,9 @@ GLOBAL_LIST_INIT(be_special_flags, list(
 	real_name = random_name(gender)
 	gear = list()
 
+	#ifdef QUICK_START
+	job_preference_list[JOB_CO] = HIGH_PRIORITY
+	#endif
 
 /datum/preferences/proc/client_reconnected(client/C)
 	owner = C

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -23,6 +23,10 @@
 	var/datum/callback/execute_on_confirm
 
 /mob/new_player/Initialize()
+	#ifdef QUICK_START
+	ready = TRUE
+	#endif
+
 	. = ..()
 	GLOB.dead_mob_list -= src
 	ADD_TRAIT(src, TRAIT_IMMOBILIZED, TRAIT_SOURCE_INHERENT)


### PR DESCRIPTION
you can now boot into runtime without having to mess around with your data dir

<img width="371" height="371" alt="image" src="https://github.com/user-attachments/assets/24599af3-8781-4cb7-8304-4d3496a26c9f" />

quickstart will immediately join you as a CO as soon as the game is ready

testing just applies the TESTING define, which exposes some additional debug lines