### PR TITLE
Reloading M240 flamethrower tanks from each other

### DIFF
--- a/code/__DEFINES/chemistry.dm
+++ b/code/__DEFINES/chemistry.dm
@@ -133,6 +133,8 @@
 /// Reagent doesn't randomly generate in chemicals
 #define REAGENT_NO_GENERATION (1<<5)
 
+#define REAGENT_TYPE_SPECIALIST (1<<6)
+
 /*
 	properties defines
 */

--- a/code/modules/projectiles/magazines/flamer.dm
+++ b/code/modules/projectiles/magazines/flamer.dm
@@ -18,6 +18,7 @@
 	gun_type = /obj/item/weapon/gun/flamer/m240
 	caliber = "UT-Napthal Fuel" //Ultra Thick Napthal Fuel, from the lore book.
 	var/custom = FALSE //accepts custom fuels if true
+	var/specialist = FALSE //for specialist fuels
 
 	var/flamer_chem = "utnapthal"
 	flags_magazine = AMMUNITION_HIDE_AMMO
@@ -81,7 +82,7 @@
 /obj/item/ammo_magazine/flamer_tank/afterattack(obj/target, mob/user , flag) //refuel at fueltanks when we run out of ammo.
 	if(get_dist(user,target) > 1)
 		return ..()
-	if(!istype(target, /obj/structure/reagent_dispensers/fueltank) && !istype(target, /obj/item/tool/weldpack) && !istype(target, /obj/item/storage/backpack/marine/engineerpack))
+	if(!istype(target, /obj/structure/reagent_dispensers/fueltank) && !istype(target, /obj/item/tool/weldpack) && !istype(target, /obj/item/storage/backpack/marine/engineerpack) && !istype(target, /obj/item/ammo_magazine/flamer_tank))
 		return ..()
 
 	if(!target.reagents || length(target.reagents.reagent_list) < 1)
@@ -99,6 +100,10 @@
 
 	if(istype(to_add, /datum/reagent/generated) && !custom)
 		to_chat(user, SPAN_WARNING("[src] cannot accept custom fuels!"))
+		return
+
+	if(to_add.flags & REAGENT_TYPE_SPECIALIST && !specialist)
+		to_chat(user, SPAN_WARNING("[src] cannot accept specialist fuels!"))
 		return
 
 	if(!to_add.intensityfire && to_add.id != "stablefoam" && !istype(src, /obj/item/ammo_magazine/flamer_tank/smoke))
@@ -198,6 +203,7 @@
 	item_state = "flametank_large"
 	max_rounds = 250
 	gun_type = /obj/item/weapon/gun/flamer/m240/spec
+	specialist = TRUE
 
 	max_intensity = 80
 	max_range = 5

--- a/code/modules/reagents/chemistry_reagents/other.dm
+++ b/code/modules/reagents/chemistry_reagents/other.dm
@@ -844,6 +844,7 @@
 	color = "#00b8ff"
 	burncolor = "#00b8ff"
 	burn_sprite = "blue"
+	flags = REAGENT_TYPE_SPECIALIST
 	properties = list(
 		PROPERTY_INTENSITY = BURN_LEVEL_TIER_7,
 		PROPERTY_DURATION = BURN_TIME_TIER_4,
@@ -859,6 +860,7 @@
 	color = COLOR_GREEN
 	burncolor = COLOR_GREEN
 	burn_sprite = "green"
+	flags = REAGENT_TYPE_SPECIALIST
 	properties = list(
 		PROPERTY_INTENSITY = BURN_LEVEL_TIER_2,
 		PROPERTY_DURATION = BURN_TIME_TIER_5,


### PR DESCRIPTION

# About the pull request
Adds the ability to refill half-empty flamethrower tanks from one another, for example, a tank with napalm from a tank with napalm or a tank with B-gel from a tank with B-gel.
Fuel cannot be mixed.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
QoL feature.
No more fuel tanks with 11 units of fuel scattered around the FOB.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

https://github.com/user-attachments/assets/9ec438dc-6328-4844-8e82-ea18228ce39b


</details>


# Changelog
:cl:
qol: reloading M240 flamethrower tanks one by one

/:cl:
