### PR TITLE
M1911C Tweaks 2

### DIFF
--- a/code/datums/ammo/bullet/pistol.dm
+++ b/code/datums/ammo/bullet/pistol.dm
@@ -120,7 +120,7 @@
 
 /datum/ammo/bullet/pistol/heavy/highimpact
 	name = "high-impact pistol bullet"
-	debilitate = list(0,0.2,0,0,0,1,0,0)
+	debilitate = list(0,1,0,0,0,1,0,0)
 
 /datum/ammo/bullet/pistol/heavy/highimpact/ap
 	name = "high-impact armor-piercing pistol bullet"

--- a/code/game/machinery/vending/vendor_types/crew/commanding_officer.dm
+++ b/code/game/machinery/vending/vendor_types/crew/commanding_officer.dm
@@ -17,6 +17,8 @@ GLOBAL_LIST_INIT(cm_vending_gear_commanding_officer, list(
 		list("High Impact AP Mateba Speedloader (.454)", 20, /obj/item/ammo_magazine/revolver/mateba/highimpact/ap, null, VENDOR_ITEM_REGULAR),
 		list("High Impact Desert Eagle Magazine (.50)", 15, /obj/item/ammo_magazine/pistol/heavy/super/highimpact, null, VENDOR_ITEM_RECOMMENDED),
 		list("High Impact AP Desert Eagle Magazine (.50)", 20, /obj/item/ammo_magazine/pistol/heavy/super/highimpact/ap, null, VENDOR_ITEM_REGULAR),
+		list("High Impact M1911C Magazine (.45)", 15, /obj/item/ammo_magazine/pistol/m1911/highimpact, null, VENDOR_ITEM_RECOMMENDED),
+		list("High Impact AP M1911C Magazine (.45)", 20, /obj/item/ammo_magazine/pistol/m1911/highimpact/ap, null, VENDOR_ITEM_REGULAR),
 
 		list("SHOTGUN AMMUNITION", 0, null, null, null),
 		list("Buckshot Shells", 20, /obj/item/ammo_magazine/shotgun/buckshot, null, VENDOR_ITEM_REGULAR),

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -190,6 +190,10 @@
 /obj/item/weapon/gun/pistol/m1911/custom/set_gun_attachment_offsets()
 	attachable_offset = list("muzzle_x" = 29, "muzzle_y" = 20, "rail_x" = 10, "rail_y" = 22, "under_x" = 21, "under_y" = 15, "stock_x" = 21, "stock_y" = 17)
 
+/obj/item/weapon/gun/pistol/m1911/custom/unique_action(mob/user)
+	if(fire_into_air(user))
+		return ..()
+
 //-------------------------------------------------------
 //Beretta 92FS, the gun McClane carries around in Die Hard. Very similar to the service pistol, all around.
 


### PR DESCRIPTION

# About the pull request

- Allows you to fire the M1911C into the air like all other CO guns.
- Allows you to purchase M1911C ammo from the CO vendor.
- Gives the M1911C impact rounds a `1.0 second` knockdown instead of a `0.2 second` knockdown.

# Explain why it's good for the game

For a gun that only has one extra bullet and some more fire rate, you cannot reliably BE with it at all. In terms of worries about juggling xenos/humans with it's longer stun, you could do the same thing with the Deagle if you really wanted to. I think its actually **easier** to miss the juggle window with the higher firerate and lower stun time.

Firing into the air and the vendor are likely oversights, which are now fixed.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: added M1911C ammo to the CO vendor.
balance: gave the M1911C a 1 second knockdown, up from 0.2 seconds.
fix: added the "fire in the air" ability to the M1911C to match all other CO guns.
/:cl:
