### PR TITLE
Allows Unique-Action to be used with all items

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -29,6 +29,7 @@
 #define COMSIG_KB_CARBON_GIVEITEM_DOWN "keybinding_carbon_giveitem_down"
 #define COMSIG_KB_CARBON_WARCRY "keybinding_carbon_warcry"
 #define COMSIG_KB_CARBON_MEDIC "keybinding_carbon_medic"
+#define COMSIG_KB_CARBON_UNIQUEACTION "keybinding_carbon_uniqueaction"
 
 //Client
 #define COMSIG_KB_CLIENT_GETHELP_DOWN "keybinding_client_gethelp_down"
@@ -80,7 +81,6 @@
 #define COMSIG_KB_HUMAN_WEAPON_STOCKATTACHMENT "keybinding_human_weapon_stockattachment"
 #define COMSIG_KB_HUMAN_WEAPON_AUTOEJECT "keybinding_human_weapon_autoeject"
 #define COMSIG_KB_HUMAN_WEAPON_UNDERBARREL "keybinding_human_weapon_underbarrel"
-#define COMSIG_KB_HUMAN_WEAPON_UNIQUEACTION "keybinding_human_weapon_uniqueaction"
 #define COMSIG_KB_HUMAN_WEAPON_SAFETY "keybinding_human_weapon_safety"
 #define COMSIG_KB_HUMAN_WEAPON_UNLOAD "keybinding_human_weapon_unload"
 #define COMSIG_KB_HUMAN_WEAPON_ATTACHMENT "keybinding_human_weapon_attachment"

--- a/code/datums/keybinding/carbon.dm
+++ b/code/datums/keybinding/carbon.dm
@@ -5,6 +5,13 @@
 /datum/keybinding/carbon/can_use(client/user)
 	return iscarbon(user.mob)
 
+/datum/keybinding/carbon/item/can_use(client/user)
+	. = ..()
+	if(!.)
+		return
+	var/mob/user_mob = user.mob
+	return isitem(user_mob.get_held_item())
+
 /datum/keybinding/carbon/toggle_throw_mode
 	hotkey_keys = list("R", "Southwest") // END
 	classic_keys =list("R", "Southwest")
@@ -130,4 +137,20 @@
 		return
 	var/mob/living/carbon/C = user.mob
 	C.give()
+	return TRUE
+
+/datum/keybinding/carbon/item/unique_action
+	hotkey_keys = list("Space")
+	classic_keys = list("Unbound")
+	name = "unique_action"
+	full_name = "Unique Action"
+	keybind_signal = COMSIG_KB_CARBON_UNIQUEACTION
+
+/datum/keybinding/carbon/item/unique_action/down(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/living/carbon/human/human = user.mob
+	var/obj/item/held_item = human.get_held_item()
+	held_item.use_unique_action()
 	return TRUE

--- a/code/datums/keybinding/human_combat.dm
+++ b/code/datums/keybinding/human_combat.dm
@@ -89,22 +89,6 @@
 	held_item.toggle_underbarrel_attachment_verb()
 	return TRUE
 
-/datum/keybinding/human/combat/unique_action
-	hotkey_keys = list("Space")
-	classic_keys = list("Unbound")
-	name = "unique_action"
-	full_name = "Unique Action"
-	keybind_signal = COMSIG_KB_HUMAN_WEAPON_UNIQUEACTION
-
-/datum/keybinding/human/combat/unique_action/down(client/user)
-	. = ..()
-	if(.)
-		return
-	var/mob/living/carbon/human/human = user.mob
-	var/obj/item/weapon/gun/held_item = human.get_held_item()
-	held_item.use_unique_action()
-	return TRUE
-
 /datum/keybinding/human/combat/unload_gun
 	hotkey_keys = list("Shift+Z")
 	classic_keys = list("Unbound")

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1160,6 +1160,32 @@
 /obj/item/proc/hands_swapped(mob/living/carbon/swapper_of_hands)
 	return
 
-// Formerly in gun_helpers.dm, moved here for more universal use
+// formerly in gun_helpers.dm, moved here for universal usage
 /obj/item/proc/unique_action(mob/user)
 	return
+
+/obj/item/verb/use_unique_action()
+	set category = "Object"
+	set name = "Unique Action"
+	set desc = "Use anything unique your item is capable of."
+	set src = usr.contents
+
+	if(usr.is_mob_incapacitated() || !isturf(usr.loc))
+		return
+	if(!ishuman(usr) && !HAS_TRAIT(usr, TRAIT_OPPOSABLE_THUMBS))
+		to_chat(usr, SPAN_WARNING("Not right now."))
+		return
+
+	var/obj/item/held_item = usr.get_active_hand()
+	if(!held_item)
+		to_chat(usr, SPAN_WARNING("You need to be holding something to do that!"))
+		return
+
+	src = held_item
+
+	// For guns, check if we should use the active attachable instead
+	var/obj/item/weapon/gun/gun = src
+	if(isgun(gun) && gun.active_attachable)
+		src = gun.active_attachable
+
+	unique_action(usr)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1159,3 +1159,7 @@
 ///Called by /mob/living/carbon/swap_hand() when hands are swapped
 /obj/item/proc/hands_swapped(mob/living/carbon/swapper_of_hands)
 	return
+
+// Formerly in gun_helpers.dm, moved here for more universal use
+/obj/item/proc/unique_action(mob/user)
+	return

--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -1208,7 +1208,7 @@
 	verbs -= /obj/item/weapon/gun/verb/field_strip
 	verbs -= /obj/item/weapon/gun/verb/use_toggle_burst
 	verbs -= /obj/item/weapon/gun/verb/empty_mag
-	verbs -= /obj/item/weapon/gun/verb/use_unique_action
+	verbs -= /obj/item/verb/use_unique_action
 
 /obj/item/weapon/gun/launcher/spike/set_gun_config_values()
 	..()
@@ -1303,7 +1303,7 @@
 	verbs -= /obj/item/weapon/gun/verb/field_strip
 	verbs -= /obj/item/weapon/gun/verb/use_toggle_burst
 	verbs -= /obj/item/weapon/gun/verb/empty_mag
-	verbs -= /obj/item/weapon/gun/verb/use_unique_action
+	verbs -= /obj/item/verb/use_unique_action
 
 /obj/item/weapon/gun/energy/yautja/plasmarifle/process()
 	if(charge_time < 100)

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -229,9 +229,6 @@ Defined in conflicts.dm of the #defines folder.
 /obj/item/attachable/proc/reload_attachment(obj/item/I, mob/user)
 	return
 
-/obj/item/attachable/proc/unique_action(mob/user)
-	return
-
 ///Returns TRUE if its functionality is successfully used, FALSE if gun's own unloading should proceed instead.
 /obj/item/attachable/proc/unload_attachment(mob/user, reload_override = 0, drop_override = 0, loc_override = 0)
 	return FALSE

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -336,7 +336,6 @@ DEFINES in setup.dm, referenced here.
 				//  \\
 //----------------------------------------------------------
 
-
 /obj/item/weapon/gun/proc/check_inactive_hand(mob/user)
 	if(user)
 		var/obj/item/weapon/gun/in_hand = user.get_inactive_hand()
@@ -804,22 +803,6 @@ DEFINES in setup.dm, referenced here.
 			user.swap_hand()
 
 	unload(user, FALSE, drop_to_ground) //We want to drop the mag on the ground.
-
-/obj/item/weapon/gun/verb/use_unique_action()
-	set category = "Weapons"
-	set name = "Unique Action"
-	set desc = "Use anything unique your firearm is capable of. Includes pumping a shotgun or spinning a revolver. If you have an active attachment, this will activate on the attachment instead."
-	set src = usr.contents
-
-	var/obj/item/weapon/gun/active_firearm = get_active_firearm(usr)
-	if(!active_firearm)
-		return
-	if(active_firearm.active_attachable)
-		src = active_firearm.active_attachable
-	else
-		src = active_firearm
-
-	unique_action(usr)
 
 /obj/item/weapon/gun/verb/toggle_gun_safety()
 	set category = "Weapons"

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -336,8 +336,6 @@ DEFINES in setup.dm, referenced here.
 				//  \\
 //----------------------------------------------------------
 
-/obj/item/weapon/proc/unique_action(mob/user) //moved this up a path to make macroing for other weapons easier -spookydonut
-	return
 
 /obj/item/weapon/gun/proc/check_inactive_hand(mob/user)
 	if(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Title, backend functionality for future upcoming PRs

# Explain why it's good for the game

A button that isn't an ability icon on the top of your hud makes for expanded functionality, which my future PRs makes extensive use of

No player facing changes


# Testing Photographs and Procedure

<img width="573" height="76" alt="image" src="https://github.com/user-attachments/assets/545f295e-4a29-46e0-8233-fd8581b2af28" />


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
code: Adds backend functionality of unique-action for all items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
