### PR TITLE
If it looks like a fridge, acts like a fridge, and hums like a fridge...

### DIFF
--- a/code/game/machinery/nuclearbomb.dm
+++ b/code/game/machinery/nuclearbomb.dm
@@ -434,12 +434,12 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 					qdel(embryo)
 
 	for(var/mob/current_mob in alive_mobs)
-		if(istype(current_mob.loc, /obj/structure/closet/secure_closet/freezer/fridge))
+		if(istype(current_mob.loc, /obj/structure/closet/secure_closet/freezer))
 			continue
 		current_mob.death(create_cause_data("nuclear explosion"))
 
 	for(var/mob/living/current_mob in (alive_mobs + dead_mobs))
-		if(istype(current_mob.loc, /obj/structure/closet/secure_closet/freezer/fridge))
+		if(istype(current_mob.loc, /obj/structure/closet/secure_closet/freezer))
 			continue
 		for(var/obj/item/alien_embryo/embryo in current_mob)
 			qdel(embryo)


### PR DESCRIPTION

# About the pull request

Then it's a fridge.


# Explain why it's good for the game

It's very confusing to work out what is and isn't a 'fridge' according to the nuke. They all look the same and only one counts.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: The various types of freezer/fridges all now count for the nuke protection.
/:cl:
