### PR TITLE
Stealth hijack begone

### DIFF
--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -304,10 +304,6 @@
 		playsound(loc, 'sound/machines/terminal_error.ogg', KEYBOARD_SOUND_VOLUME, TRUE)
 		return XENO_NONCOMBAT_ACTION
 
-	if(check_danger())
-		to_chat(xeno, SPAN_XENONOTICE("Lights flash with warnings. There is still too much danger on this planet for us to leave!"))
-		playsound(loc, 'sound/machines/terminal_error.ogg', KEYBOARD_SOUND_VOLUME, TRUE)
-		return XENO_NONCOMBAT_ACTION
 
 	if(is_remote)
 		groundside_alien_action(xeno)
@@ -334,6 +330,11 @@
 		message_admins("[key_name(xeno)] has locked the dropship '[dropship]'", xeno.x, xeno.y, xeno.z)
 		notify_ghosts(header = "Dropship Locked", message = "[xeno] has locked [dropship]!", source = xeno, action = NOTIFY_ORBIT)
 		return
+
+	if(check_danger())
+		to_chat(xeno, SPAN_XENONOTICE("Lights flash with warnings. There is still too much danger on this planet for us to leave!"))
+		playsound(loc, 'sound/machines/terminal_error.ogg', KEYBOARD_SOUND_VOLUME, TRUE)
+		return XENO_NONCOMBAT_ACTION
 
 	if(dropship_control_lost)
 		//keyboard


### PR DESCRIPTION

# About the pull request

Adds the same danger check to allowing hijack as there is to preventing boon purchase, aka 12 + humans on the planet.

# Explain why it's good for the game

Stealth hijack is bad for gameplay and anticlimactic, accept your defeat or die fighting.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Disables hijack option if there are more then 12 humans still on the planet
/:cl:
