### PR TITLE
Add TGUI dev and build launch targets

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -121,6 +121,20 @@
             "preLaunchTask": "Build All (runtime map + quickstart + testing)",
             "dmb": "${workspaceFolder}/${command:CurrentDMB}",
             "dreamDaemon": true
+        },
+        {
+            "name": "TGUI Dev Server",
+            "type": "node-terminal",
+            "request": "launch",
+            "command": ".\\bin\\tgui-dev.cmd",
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "name": "TGUI Build",
+            "type": "node-terminal",
+            "request": "launch",
+            "command": ".\\bin\\tgui-build.cmd",
+            "cwd": "${workspaceFolder}"
         }
     ]
 }


### PR DESCRIPTION
# About the pull request

Added new launch targets for running TGUI build / dev (hot reload)

# Explain why it's good for the game

- **Improved Developer Experience**: TGUI tasks are now directly accessible from VS Code's Run and Debug interface instead of requiring manual terminal commands
- **Consistency**: Aligns with existing BYOND launch configurations, providing a unified workflow
- **Convenience**: One-click access to common TGUI development tasks without memorizing command paths
- **Better Integration**: Leverages VS Code's built-in task management system for better IDE integration
- **Reduced Context Switching**: Developers can stay within the VS Code interface instead of switching to external terminals

This streamlines the TGUI development workflow and makes the codebase more accessible to new contributors who may not be familiar with the command-line build tools.

<img width="366" height="507" alt="image" src="https://github.com/user-attachments/assets/dd8817e9-1a89-4bae-bda0-e48522627f4e" />


:cl: rattybag
code: adding TGUI build and dev launch targets
/:cl:

