### PR TITLE
Add alt-click and ctrl-click modifers to ladder for quick climbing

### DIFF
--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -32,6 +32,7 @@
 	. += SPAN_NOTICE("Ctrl-click to go up, Alt-click to go down.")
 	if(ishuman(user))
 		. += SPAN_NOTICE("Click [src] with unprimed grenades/flares to prime and toss it up or down.")
+		. += SPAN_NOTICE("Ctrl-click or Alt-click with grenades/flares to throw in that direction.")
 
 /obj/structure/ladder/LateInitialize()
 	. = ..()
@@ -157,6 +158,13 @@
 
 //Override clicked to handle modifier clicks
 /obj/structure/ladder/clicked(mob/user, list/mods)
+	// If user is holding a throwable item, let attackby handle the modifier clicks
+	if(isliving(user))
+		var/mob/living/living_user = user
+		var/obj/item/held_item = living_user.get_active_hand()
+		if(held_item && (istype(held_item, /obj/item/explosive/grenade) || istype(held_item, /obj/item/device/flashlight)))
+			return FALSE // Let attackby handle this
+
 	if(mods[ALT_CLICK])
 		alt_click_action(user)
 		return TRUE
@@ -257,92 +265,91 @@
 /obj/structure/ladder/ex_act(severity)
 	return
 
-//Throwing Shiet
-/obj/structure/ladder/attackby(obj/item/W, mob/user)
-	//Throwing Grenades
-	if(istype(W,/obj/item/explosive/grenade))
-		var/obj/item/explosive/grenade/G = W
-		var/ladder_dir_name
-		var/obj/structure/ladder/ladder_dest
-		if(up && down)
-			ladder_dest = lowertext(show_radial_menu(user, src, direction_selection, require_near = TRUE))
-			if(ladder_dest == "up")
-				ladder_dest = up
-				ladder_dir_name = ("up")
-			if(ladder_dest == "down")
-				ladder_dest = down
-				ladder_dir_name = ("down")
-		else if(up)
-			ladder_dir_name = "up"
-			ladder_dest = up
-		else if(down)
-			ladder_dir_name = "down"
-			ladder_dest = down
-		else
-			return FALSE //just in case
+//Helper function to handle throwing items up/down ladders
+/obj/structure/ladder/proc/throw_item_ladder(obj/item/item, mob/user, direction)
+	var/ladder_dir_name
+	var/obj/structure/ladder/ladder_dest
 
-		if(!ladder_dest)
-			return
+	if(direction == "up")
+		if(!up)
+			return FALSE
+		ladder_dir_name = "up"
+		ladder_dest = up
+	else if(direction == "down")
+		if(!down)
+			return FALSE
+		ladder_dir_name = "down"
+		ladder_dest = down
+	else
+		return FALSE
 
+	if(!ladder_dest)
+		return FALSE
+
+	// Handle grenade-specific logic
+	if(istype(item, /obj/item/explosive/grenade))
+		var/obj/item/explosive/grenade/G = item
 		if(G.antigrief_protection && user.faction == FACTION_MARINE && explosive_antigrief_check(G, user))
 			to_chat(user, SPAN_WARNING("\The [G.name]'s safe-area accident inhibitor prevents you from priming the grenade!"))
-			// Let staff know, in case someone's actually about to try to grief
 			msg_admin_niche("[key_name(user)] attempted to prime \a [G.name] in [get_area(src)] [ADMIN_JMP(src.loc)]")
-			return
+			return FALSE
 
-		user.visible_message(SPAN_WARNING("[user] takes position to throw [G] [ladder_dir_name] [src]."),
-		SPAN_WARNING("You take position to throw [G] [ladder_dir_name] [src]."))
-		if(do_after(user, 10, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
-			user.visible_message(SPAN_WARNING("[user] throws [G] [ladder_dir_name] [src]!"),
-			SPAN_WARNING("You throw [G] [ladder_dir_name] [src]"))
-			user.drop_held_item()
-			G.forceMove(ladder_dest.loc)
-			G.setDir(pick(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST))
-			step_away(G, src, rand(1, 5))
+	user.visible_message(SPAN_WARNING("[user] takes position to throw [item] [ladder_dir_name] [src]."),
+	SPAN_WARNING("You take position to throw [item] [ladder_dir_name] [src]."))
+
+	if(do_after(user, 10, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
+		user.visible_message(SPAN_WARNING("[user] throws [item] [ladder_dir_name] [src]!"),
+		SPAN_WARNING("You throw [item] [ladder_dir_name] [src]"))
+		user.drop_held_item()
+		item.forceMove(ladder_dest.loc)
+		item.setDir(pick(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST))
+		step_away(item, src, rand(1, 5))
+
+		// Handle grenade activation
+		if(istype(item, /obj/item/explosive/grenade))
+			var/obj/item/explosive/grenade/G = item
 			if(!G.active)
 				G.activate(user)
 
-	//Throwing Flares and flashlights
-	else if(istype(W,/obj/item/device/flashlight))
-		var/obj/item/device/flashlight/F = W
-		var/ladder_dir_name
-		var/obj/structure/ladder/ladder_dest
-		if(up && down)
-			ladder_dest = lowertext(show_radial_menu(user, src, direction_selection, require_near = TRUE))
-			if(ladder_dest == "up")
-				ladder_dest = up
-				ladder_dir_name = ("up")
-			if(ladder_dest == "down")
-				ladder_dest = down
-				ladder_dir_name = ("down")
-		else if(up)
-			ladder_dir_name = "up"
-			ladder_dest = up
-		else if(down)
-			ladder_dir_name = "down"
-			ladder_dest = down
-		else
-			return FALSE //just in case
+		// Handle flare activation
+		if(istype(item, /obj/item/device/flashlight/flare))
+			var/obj/item/device/flashlight/flare/the_flare = item
+			if(!the_flare.on)
+				the_flare.turn_on()
 
+	return TRUE
 
-		if(!ladder_dest)
-			return
-
-		user.visible_message(SPAN_WARNING("[user] takes position to throw [F] [ladder_dir_name] [src]."),
-		SPAN_WARNING("You take position to throw [F] [ladder_dir_name] [src]."))
-		if(do_after(user, 10, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
-			user.visible_message(SPAN_WARNING("[user] throws [F] [ladder_dir_name] [src]!"),
-			SPAN_WARNING("You throw [F] [ladder_dir_name] [src]"))
-			user.drop_held_item()
-			F.forceMove(ladder_dest.loc)
-			F.setDir(pick(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST))
-			step_away(F,src,rand(1, 5))
-			if(istype(W, /obj/item/device/flashlight/flare))
-				var/obj/item/device/flashlight/flare/the_flare = W
-				if(!the_flare.on)
-					the_flare.turn_on()
-	else
+//Throwing Shiet
+/obj/structure/ladder/attackby(obj/item/W, mob/user, list/mods)
+	// Check if this is a throwable item (grenades or flashlights)
+	if(!istype(W, /obj/item/explosive/grenade) && !istype(W, /obj/item/device/flashlight))
 		return attack_hand(user)
+
+	var/direction
+
+	// Check for modifier keys first
+	if(mods && mods[CTRL_CLICK] && up)
+		direction = "up"
+	else if(mods && mods[ALT_CLICK] && down)
+		direction = "down"
+	// If no modifier or invalid direction, use menu/auto-select
+	else if(up && down)
+		var/choice = lowertext(show_radial_menu(user, src, direction_selection, require_near = TRUE))
+		if(choice == "up")
+			direction = "up"
+		else if(choice == "down")
+			direction = "down"
+		else
+			return // User cancelled
+	else if(up)
+		direction = "up"
+	else if(down)
+		direction = "down"
+	else
+		return FALSE // No valid directions
+
+	// Use the helper function to throw the item
+	throw_item_ladder(W, user, direction)
 
 /obj/structure/ladder/fragile_almayer //goes away on hijack
 	name = "rickety ladder"


### PR DESCRIPTION
# About the pull request

Adds modifier key shortcuts for ladder interactions to streamline navigation and item throwing, reducing context switching and clicks by allowing bypass of radial menu.

**Changes:**
- **Ctrl+click** a ladder to climb up (bypasses radial menu)
- **Alt+click** a ladder to climb down (bypasses radial menu)
- **Ctrl+click** with grenades/flares to throw up without menu
- **Alt+click** with grenades/flares to throw down without menu
- Refactored climbing logic into shared `climb_ladder()` helper function
- Refactored throwing logic into shared `throw_item_ladder()` helper function
- Enhanced `attackby()` to accept modifier parameters and route to helper function
- Enhanced `clicked()` to handle modifier keys while deferring to `attackby` for throwable items
- Updated examine text to inform players about all available shortcuts
- Maintains full backward compatibility with existing interactions

**Technical improvements:**
- Eliminated code duplication between climbing and throwing logic
- Centralized item throwing behavior for grenades and flares
- Improved code maintainability with shared helper functions
- Fixed interaction priority so throwing takes precedence over climbing when holding items

# Explain why it's good for the game

**Quality of Life Improvements:**
- Eliminates context switching from radial menu
- Faster tactical gameplay - quick grenade/flare throws without UI interruption
- Reduces click fatigue on multi-level maps with frequent ladder use

**Maintains Accessibility:**
- All existing functionality preserved unchanged

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/GEn0P4qUAhc

Also tested this and confirm it's working for xenos as well

</details>


# Changelog

:cl: rattybag
qol: add modifier keys to ladders for fast throwing and climbing
refactor: consolidated ladder climbing and item throwing logic into shared helper functions
/:cl:

