### PR TITLE
Removes vault damage from railings on harm intent

### DIFF
--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -74,14 +74,6 @@
 			return ..()
 
 		climber.client?.move_delay += 3 DECISECONDS
-		if(do_climb(climber))
-			if(prob(25))
-				if(ishuman(climber))
-					var/mob/living/carbon/human/human = climber
-					human.apply_damage(5, BRUTE, no_limb_loss = TRUE)
-				else
-					climber.apply_damage(5, BRUTE)
-				climber.visible_message(SPAN_WARNING("[climber] injures themselves vaulting over [src]."), SPAN_WARNING("You hit yourself as you vault over [src]."))
 	..()
 
 /obj/structure/barricade/handrail/get_examine_text(mob/user)


### PR DESCRIPTION

# About the pull request
Title
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Makes the game more obnoxious for the sake of being more obnoxious, it serves no real purpose and sometimes can create moments where youre questioning why you have a broken leg or where half your health is gone because theres 2 railings stacked on eachother

https://streamable.com/ih5yhd is an example of me manually hopping a railing, would have been perfectly fine before this change, instead my leg gets broken because theres also 0 checks for if you actually use autoclimb.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
balance: Railings will no longer threaten your life if you autoclimb them on harm intent
/:cl:

