### PR TITLE
Adds a missing busy check for autoclimb

### DIFF
--- a/code/game/objects/structures/barricade/handrail.dm
+++ b/code/game/objects/structures/barricade/handrail.dm
@@ -74,6 +74,9 @@
 		if(climber.a_intent != INTENT_HARM)
 			return ..()
 
+		if(climber.action_busy)
+			return ..()
+
 		climber.client?.move_delay += 3 DECISECONDS
 		if(do_climb(climber))
 			if(prob(25))


### PR DESCRIPTION

# About the pull request
This PR attempts to address the reason why https://github.com/cmss13-devs/cmss13/pull/10851 was opened doing the following:
- Adds a busy check before performing autoclimb

This should mean that if you're manually vaulting, or somehow collide multiple times with the railing, it will not perform an autoclimb (because you're likely already autoclimbing or manually climbing).

# Explain why it's good for the game

Should only vault once not multiple times simultaneously.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/user-attachments/assets/bf8f87b6-379f-4c86-8d18-9ddf5dc840be

</details>


# Changelog
:cl: Drathek
fix: Fix autoclimb potentially being performed when already autoclimbing or manually climbing a railing
/:cl:
