### PR TITLE
Restore autowiki workflow back to node

### DIFF
--- a/.github/workflows/autowiki.yml
+++ b/.github/workflows/autowiki.yml
@@ -45,4 +45,4 @@ jobs:
         cd tools/autowiki
         npm install
         cd ../..
-        bun tools/autowiki/autowiki.js data/autowiki_edits.txt data/autowiki_files/
+        node tools/autowiki/autowiki.js data/autowiki_edits.txt data/autowiki_files/


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #10356 simply restoring a `bun` call back to `node`. Possible the `npm install` could be changed to maybe `bun install` but haven't heard back yet from Kash if this matters its node or not (TG still has it using node)

# Testing Photographs and Procedure
You'll need to merge it and run autowiki to see.

# Changelog

No player facing changes.