### PR TITLE
Chances Claim - Dropship Loot Alteration + Minor Resin Change

### DIFF
--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -750,6 +750,89 @@
 /obj/effect/landmark/spycam_start,
 /turf/open/floor/prison/floor_marked/southwest,
 /area/lv522/landing_zone_1)
+"acV" = (
+/obj/structure/barricade/deployable{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/lv522/outdoors/colony_streets/north_east_street)
+"acW" = (
+/obj/structure/cargo_container/horizontal/blue/bottom,
+/turf/open/floor/prison/floor_plate,
+/area/lv522/outdoors/colony_streets/north_east_street)
+"acX" = (
+/obj/structure/cargo_container/horizontal/blue/middle{
+	layer = 3.1
+	},
+/turf/open/floor/plating,
+/area/lv522/outdoors/colony_streets/north_east_street)
+"acY" = (
+/obj/item/ammo_magazine/rifle/m4ra/extended{
+	current_rounds = 0
+	},
+/obj/item/ammo_magazine/rifle/m4ra/extended{
+	current_rounds = 0
+	},
+/obj/item/ammo_magazine/rifle/m4ra/extended{
+	current_rounds = 0
+	},
+/obj/item/ammo_magazine/rifle/m4ra/extended{
+	current_rounds = 0
+	},
+/obj/structure/closet/crate/ammo,
+/turf/open/shuttle/dropship/can_surgery/light_grey_single_wide_up_to_down,
+/area/lv522/landing_zone_forecon/UD6_Tornado)
+"acZ" = (
+/obj/item/stack/sheet/metal/med_small_stack,
+/obj/structure/closet/crate/construction,
+/turf/open/shuttle/dropship/medium_grey_single_wide_up_to_down,
+/area/lv522/landing_zone_forecon/UD6_Tornado)
+"ada" = (
+/obj/structure/cargo_container/horizontal/blue/middle,
+/obj/structure/largecrate/supply/floodlights{
+	layer = 3.1;
+	pixel_y = 3
+	},
+/turf/open/floor/prison/floor_plate,
+/area/lv522/outdoors/colony_streets/north_east_street)
+"adb" = (
+/obj/structure/cargo_container/horizontal/blue/top,
+/turf/open/floor/plating,
+/area/lv522/outdoors/colony_streets/north_east_street)
+"adc" = (
+/obj/structure/cargo_container/kelland/right,
+/obj/structure/cargo_container/horizontal/blue/top{
+	layer = 4.3
+	},
+/turf/open/floor/prison/floor_plate,
+/area/lv522/outdoors/colony_streets/north_east_street)
+"add" = (
+/obj/effect/alien/resin/sticky,
+/turf/open/floor/corsat/brown,
+/area/lv522/atmos/filt)
+"ade" = (
+/obj/effect/alien/resin/sticky,
+/turf/open/floor/corsat/plate,
+/area/lv522/atmos/filt)
+"adf" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/turf/open/floor/prison/floor_plate,
+/area/lv522/outdoors/nw_rockies)
+"adg" = (
+/obj/effect/alien/resin/sticky,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/lv522/atmos/filt)
+"adh" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/turf/open/floor/prison,
+/area/lv522/outdoors/nw_rockies)
+"adi" = (
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
+/turf/open/floor/corsat/plate,
+/area/lv522/atmos/cargo_intake)
 "adk" = (
 /obj/structure/surface/table/almayer,
 /obj/item/trash/plate,
@@ -1776,11 +1859,6 @@
 /area/lv522/indoors/a_block/medical)
 "aOf" = (
 /obj/structure/platform_decoration/metal/almayer/east,
-/obj/structure/closet/crate/ammo,
-/obj/item/ammo_magazine/rifle/lmg/holo_target,
-/obj/item/weapon/gun/rifle/lmg{
-	current_mag = null
-	},
 /turf/open/shuttle/dropship/medium_grey_single_wide_up_to_down,
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "aOi" = (
@@ -3776,6 +3854,10 @@
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/cargo)
 "bYC" = (
+/obj/item/defenses/handheld/sentry/mini{
+	pixel_y = -4;
+	pixel_x = -5
+	},
 /turf/open/shuttle/dropship/can_surgery/light_grey_top_right,
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "bYM" = (
@@ -4440,10 +4522,6 @@
 /obj/effect/spawner/gibspawner/xeno,
 /obj/structure/platform/metal/almayer/west,
 /turf/open/asphalt/cement/cement1,
-/area/lv522/outdoors/colony_streets/north_east_street)
-"cuk" = (
-/obj/structure/cargo_container/horizontal/blue/top,
-/turf/open/floor/prison/floor_marked,
 /area/lv522/outdoors/colony_streets/north_east_street)
 "cuF" = (
 /obj/structure/machinery/light{
@@ -6787,13 +6865,7 @@
 /turf/open/floor/prison/darkbrownfull2,
 /area/lv522/indoors/c_block/casino)
 "dBd" = (
-/obj/item/clothing/mask/facehugger{
-	desc = "It has some sort of a tube at the end of its tail. What the hell is this thing?";
-	icon_state = "facehugger_impregnated";
-	layer = 3;
-	name = "????";
-	stat = 2
-	},
+/obj/structure/cargo_container/kelland/left,
 /turf/open/floor/plating,
 /area/lv522/outdoors/colony_streets/north_east_street)
 "dBe" = (
@@ -9241,9 +9313,7 @@
 /turf/open/floor/corsat/brown/southeast,
 /area/lv522/atmos/east_reactor/south)
 "eRI" = (
-/obj/structure/barricade/deployable{
-	dir = 8
-	},
+/obj/structure/cargo_container/horizontal/blue/bottom,
 /turf/open/floor/plating,
 /area/lv522/outdoors/colony_streets/north_east_street)
 "eRQ" = (
@@ -18555,6 +18625,7 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
+/obj/effect/landmark/structure_spawner/setup/distress/xeno_weed_node,
 /turf/open/floor/corsat/plate,
 /area/lv522/atmos/east_reactor/south)
 "kbg" = (
@@ -25496,15 +25567,6 @@
 	pixel_x = 30
 	},
 /obj/effect/decal/cleanable/blood/splatter,
-/obj/item/ammo_box/rounds/smg{
-	layer = 3;
-	pixel_x = 1;
-	pixel_y = 4
-	},
-/obj/item/defenses/handheld/sentry/mini{
-	pixel_y = -4;
-	pixel_x = -5
-	},
 /turf/open/shuttle/dropship/medium_grey_single_wide_up_to_down,
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "nBo" = (
@@ -26693,6 +26755,11 @@
 /turf/open/floor/corsat,
 /area/lv522/atmos/east_reactor/south)
 "oeV" = (
+/obj/structure/closet/crate/ammo,
+/obj/item/ammo_magazine/rifle/lmg/holo_target,
+/obj/item/weapon/gun/rifle/lmg{
+	current_mag = null
+	},
 /turf/open/shuttle/dropship/can_surgery/light_grey_bottom_left,
 /area/lv522/landing_zone_forecon/UD6_Tornado)
 "oeX" = (
@@ -30527,11 +30594,6 @@
 	pixel_x = 7;
 	pixel_y = 19
 	},
-/obj/structure/machinery/door_control{
-	id = "UD6 East";
-	name = "Cargo Shutter Control";
-	pixel_y = -4
-	},
 /obj/item/clothing/head/headset{
 	pixel_x = 4
 	},
@@ -31449,10 +31511,6 @@
 	dir = 8;
 	pixel_y = -5
 	},
-/obj/item/ammo_magazine/rifle/m4ra{
-	pixel_x = 5;
-	pixel_y = 6
-	},
 /turf/open/floor/strata/white_cyan2,
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "qHD" = (
@@ -32043,24 +32101,16 @@
 /turf/open/auto_turf/sand_white/layer0,
 /area/lv522/outdoors/colony_streets/south_east_street)
 "qUf" = (
-/obj/item/ammo_magazine/rifle/m4ra/extended{
-	current_rounds = 0
-	},
-/obj/item/ammo_magazine/rifle/m4ra/extended{
-	current_rounds = 0
-	},
-/obj/item/ammo_magazine/rifle/m4ra/extended{
-	current_rounds = 0
-	},
-/obj/item/ammo_magazine/rifle/m4ra/extended{
-	current_rounds = 0
-	},
-/obj/structure/closet/crate/ammo,
 /obj/structure/barricade/handrail{
 	dir = 8
 	},
 /obj/structure/barricade/handrail{
 	dir = 4
+	},
+/obj/item/ammo_box/rounds/smg{
+	layer = 3;
+	pixel_x = 1;
+	pixel_y = 4
 	},
 /turf/open/shuttle/dropship/medium_grey_single_wide_up_to_down,
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
@@ -37919,10 +37969,6 @@
 	},
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/security)
-"tLJ" = (
-/obj/structure/cargo_container/horizontal/blue/bottom,
-/turf/open/floor/prison/floor_marked,
-/area/lv522/outdoors/colony_streets/north_east_street)
 "tLL" = (
 /obj/structure/curtain/medical,
 /obj/effect/decal/cleanable/dirt,
@@ -38186,7 +38232,8 @@
 	dir = 4;
 	pixel_y = -5
 	},
-/obj/structure/largecrate/supply/supplies/metal,
+/obj/item/stack/sheet/metal/med_small_stack,
+/obj/structure/closet/crate/construction,
 /turf/open/shuttle/dropship/medium_grey_single_wide_up_to_down,
 /area/lv522/landing_zone_forecon/UD6_Typhoon)
 "tTb" = (
@@ -43792,14 +43839,6 @@
 "wAB" = (
 /turf/open/floor/corsat/brown/west,
 /area/lv522/atmos/cargo_intake)
-"wAM" = (
-/obj/structure/cargo_container/horizontal/blue/middle,
-/obj/structure/largecrate/supply/floodlights{
-	layer = 3.1;
-	pixel_y = 9
-	},
-/turf/open/floor/prison/floor_marked,
-/area/lv522/outdoors/colony_streets/north_east_street)
 "wBp" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -46311,11 +46350,6 @@
 "xRM" = (
 /obj/structure/machinery/door/airlock/dropship_hatch/two{
 	dir = 8
-	},
-/obj/structure/machinery/door/poddoor/shutters/almayer{
-	dir = 4;
-	id = "UD6 East";
-	explo_proof = 1
 	},
 /turf/open/shuttle/dropship/can_surgery/light_grey_single_wide_up_to_down,
 /area/lv522/landing_zone_forecon/UD6_Tornado)
@@ -56728,12 +56762,12 @@ saC
 tTl
 wAB
 ezp
-wBR
+adi
 iTX
 eZq
 fmv
 auG
-gat
+adf
 gsZ
 uWO
 uWO
@@ -57556,7 +57590,7 @@ abB
 epb
 abu
 fol
-auG
+adh
 gbQ
 gsZ
 uWO
@@ -75271,11 +75305,11 @@ cpy
 xZE
 eWn
 gUv
+ade
 sYl
+ade
 sYl
-sYl
-sYl
-gUv
+add
 han
 shD
 cpy
@@ -75478,9 +75512,9 @@ xZE
 eWy
 gUv
 sYl
+adg
 fSe
-fSe
-sYl
+ade
 gUv
 sYl
 shD
@@ -75682,10 +75716,10 @@ cpy
 cpy
 xZE
 sYl
-gUv
+add
 sYl
 fSe
-fSe
+adg
 gJD
 gUv
 sYl
@@ -78776,7 +78810,7 @@ pvZ
 pvZ
 pvZ
 pvZ
-pvZ
+hXo
 pvZ
 pvZ
 lBM
@@ -79596,7 +79630,7 @@ rdC
 pvZ
 pvZ
 pvZ
-pvZ
+hXo
 pvZ
 pvZ
 pvZ
@@ -79604,7 +79638,7 @@ pvZ
 pvZ
 lBM
 lBM
-lBM
+cDO
 lBM
 lBM
 lBM
@@ -82512,8 +82546,8 @@ qUL
 qUL
 nSF
 qUL
-qUL
-eRI
+adb
+acX
 eRI
 sct
 fzC
@@ -83337,7 +83371,7 @@ sKi
 hLR
 dNx
 dNx
-dNx
+acY
 dNx
 nHF
 dNx
@@ -83955,7 +83989,7 @@ sIA
 goC
 jAX
 tna
-xyu
+acZ
 xyu
 goC
 ucs
@@ -84367,8 +84401,8 @@ qUL
 ucD
 vpU
 wXe
-qUL
-qUL
+acV
+acV
 sct
 dWY
 qzw
@@ -84563,7 +84597,7 @@ qSH
 qSH
 hKN
 ljq
-iNs
+ljA
 qUL
 qUL
 qUL
@@ -84769,7 +84803,7 @@ vGp
 qSH
 esu
 lhr
-kbn
+ljA
 ljA
 lAn
 lAn
@@ -84778,9 +84812,9 @@ lAn
 lAn
 nVX
 nVX
-lAn
-lAn
-lAn
+adc
+ada
+acW
 lAn
 naw
 nzU
@@ -85193,9 +85227,9 @@ mqc
 mqc
 hKS
 eNW
-cuk
-wAM
-tLJ
+mqc
+mqc
+mqc
 xIv
 mqc
 ljA


### PR DESCRIPTION

# About the pull request

Redistributes the loot within the west Dropship and evens it out with the East dropship. 

Removes the requirement to access the west dropship to open the east dropship. You will need to C4 in to both dropships now. 

Adds a few extra resin nodes near the reactor core entrance, and places extra sticky resin by the east reactor entrance to slow down early game intruders. 

# Explain why it's good for the game

The loot redistribution is to shake up the loot meta and to de-emphasize the concept that the westdropship is a prime loot location. 

The extra weed and sticky resin is to provide early game xenos a small defensive boon from survivor intruders, mainly the scout. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: The loot inside the west dropship on Chances Claim has been partially distributed to the east dropship. Furthermore, the east dropship is now accessible via C4 instead of needing to be opened from the west dropship.
maptweak: Additional resin nodes and sticky resin tiles have been placed near the reactor core entrance. To slightly deter early game intruders. 
/:cl:
