### PR TITLE
Facehuggers can be worn in the helmet garb slot

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -8,6 +8,7 @@
 	name = "facehugger"
 	desc = "It has some sort of a tube at the end of its tail."
 	icon = 'icons/mob/xenos/effects.dmi'
+	flags_obj = OBJ_IS_HELMET_GARB
 	item_icons = list(
 		WEAR_FACE = 'icons/mob/humans/onmob/clothing/masks/objects.dmi',
 		WEAR_AS_GARB = 'icons/mob/humans/onmob/clothing/helmet_garb/misc.dmi',


### PR DESCRIPTION
# About the pull request

Allows dead facehuggers to be worn in the helmet garb slot, as opposed to only fitting in the storage slots. As far as I can tell from testing, this doesn't break any of the weird jank hugger code (famous last words)

# Explain why it's good for the game

Purely cosmetic items shouldn't be taking up slots that could otherwise be used to store ammo/flasks of healing mix.

# Testing Photographs and Procedure

<details>
<img width="508" height="668" alt="image" src="https://github.com/user-attachments/assets/ddd02ea3-3fcb-48dc-8e37-349a4735fb80" />

</details>


# Changelog

:cl:
qol: facehuggers are now able to be worn in the helmet garb slot
/:cl: