### PR TITLE
Acid spray can now pass around hybrisa poles/hydrants

### DIFF
--- a/code/game/machinery/hybrisa_lights.dm
+++ b/code/game/machinery/hybrisa_lights.dm
@@ -57,6 +57,10 @@
 	. = ..()
 	AddComponent(/datum/component/shimmy_around, east_offset = -15, west_offset = -15)
 
+/obj/structure/machinery/colony_floodlight/street/initialize_pass_flags(datum/pass_flags_container/PF)
+	if(PF)
+		PF.flags_can_pass_all = PASS_HIGH_OVER_ONLY|PASS_AROUND|PASS_OVER_THROW_ITEM|PASS_OVER_ACID_SPRAY
+
 /obj/structure/machinery/colony_floodlight/street/update_icon()
 	if(damaged)
 		icon_state = "street_dmg"

--- a/code/game/objects/structures/hybrisa_props.dm
+++ b/code/game/objects/structures/hybrisa_props.dm
@@ -2595,6 +2595,10 @@
 	. = ..()
 	AddComponent(/datum/component/shimmy_around)
 
+/obj/structure/prop/hybrisa/misc/firehydrant/initialize_pass_flags(datum/pass_flags_container/PF)
+	if(PF)
+		PF.flags_can_pass_all = PASS_AROUND|PASS_OVER_THROW_ITEM|PASS_OVER_ACID_SPRAY
+
 /obj/structure/prop/hybrisa/misc/firehydrant/bullet_act(obj/projectile/P)
 	health -= P.damage
 	playsound(src, 'sound/effects/metalping.ogg', 35, 1)
@@ -2684,6 +2688,10 @@
 /obj/structure/prop/hybrisa/misc/pole/Initialize(mapload, ...)
 	. = ..()
 	AddComponent(/datum/component/shimmy_around)
+
+/obj/structure/prop/hybrisa/misc/pole/initialize_pass_flags(datum/pass_flags_container/PF)
+	if(PF)
+		PF.flags_can_pass_all = PASS_HIGH_OVER_ONLY|PASS_AROUND|PASS_OVER_THROW_ITEM|PASS_OVER_ACID_SPRAY
 
 /obj/structure/bed/sofa/hybrisa/misc/bench
 	name = "bench"


### PR DESCRIPTION
# About the pull request

This PR does a few things:
- Sets pass flags for hybrisa hydrants (this means you can throw over them, flame around them, and acid around them)
- Adds the pass flag `PASS_OVER_ACID_SPRAY` to hybrisa poles to allow acid around them

# Explain why it's good for the game

I don't know if I remembered wrong, or if fire now has been passing around poles, but since I deem acid spray the xeno equivalent to fire it can now go around those poles. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/Y3fD1uS5SHM

</details>


# Changelog
:cl: Drathek
balance: Hybrisa hydrants can now be flamed and acid sprayed around and hybrisa poles can now be acid sprayed around (already was allowing fire around)
/:cl:
