### PR TITLE
Adds additional checks to pouncing up a z level

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -496,7 +496,7 @@
 			while(istype(turf_in_path, /turf/open_space))
 				turf_in_path = SSmapping.get_turf_below(turf_in_path)
 
-			if(turf_in_path.turf_flags & TURF_HULL)
+			if(turf_in_path.density && turf_in_path.turf_flags & TURF_HULL)
 				to_chat(xeno, SPAN_WARNING("You can't jump over an object in your path."))
 				return
 


### PR DESCRIPTION
# About the pull request
Adds additional checks to pouncing up a z level to prevent you from going places you shouldn't.<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Prevents jumping over fog or getting stuck between indestructible walls etc..
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: You can no longer pounce up a zlevel into places which would get you stuck
fix: You can no longer pounce over indestructible obstacles (e.g fog)
/:cl:
