### PR TITLE
Removes point-buy M6H rockets.

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_engineer.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_engineer.dm
@@ -27,7 +27,6 @@ GLOBAL_LIST_INIT(cm_vending_gear_engi, list(
 		list("ES-11 Mobile Fuel Canister", 4, /obj/item/tool/weldpack/minitank, null, VENDOR_ITEM_REGULAR),
 
 		list("EXPLOSIVES", 0, null, null, null),
-		list("M5510 Laser-Guided Rocket", 8, /obj/item/ammo_magazine/rocket/brute, null, VENDOR_ITEM_RECOMMENDED),
 		list("M40 HEDP High Explosive Packet (x3 grenades)", 18, /obj/item/storage/box/packet/high_explosive, null, VENDOR_ITEM_REGULAR),
 		list("M40 HIDP Incendiary Packet (x3 grenades)", 18, /obj/item/storage/box/packet/incendiary, null, VENDOR_ITEM_REGULAR),
 		list("M40 WPDP White Phosphorus Packet (x3 grenades)", 18, /obj/item/storage/box/packet/phosphorus, null, VENDOR_ITEM_REGULAR),


### PR DESCRIPTION

# About the pull request

No longer able to buy additional rockets for M6H BRUTE, to emphasize attrition.

# Explain why it's good for the game

I don't even know what the current max is but I think more than 4 is bad, too much utility in the time it takes to deplete. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Thwomper
balance: Removed additional BRUTE rockets from ComTech vendor.
/:cl:
