### PR TITLE
Grabbing Invisible Xeno Doesn't Stun

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -41,7 +41,6 @@
 	old_x = -12
 
 	var/atom/movable/vis_obj/wound_icon_holder
-	/// for check on lurker invisibility
 
 /mob/living/simple_animal/hostile/alien/Initialize()
 	maxHealth = health


### PR DESCRIPTION

# About the pull request

When you grab a stealthed lurker you don't get stunned.

# Explain why it's good for the game

Cheese bad, rewarding gama crank bad.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
add: Added a check for stealth on the xeno grab stun
/:cl:
