### PR TITLE
No driving on lz turrets

### DIFF
--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -658,8 +658,8 @@
 		if(TURRET_BATTERY_STATE_DEAD)
 			. += SPAN_INFO("It appears to be offline.")
 
-/obj/structure/machinery/defenses/sentry/premade/deployable/colony/landing_zone/handle_vehicle_bump(obj/vehicle/multitile/V)
-	var/mob/driver = V.seats[VEHICLE_DRIVER]
+/obj/structure/machinery/defenses/sentry/premade/deployable/colony/landing_zone/handle_vehicle_bump(obj/vehicle/multitile/bumping_vehicle)
+	var/mob/driver = bumping_vehicle.seats[VEHICLE_DRIVER]
 	to_chat(driver, SPAN_WARNING("[src] is in the way!"))
 	return FALSE // Prevent movement over
 


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #6363 making it so the turrets cannot be destroyed by driving over them (nor driven past). You need to undeploy them to get past them.

# Explain why it's good for the game

Prevents silly CLF survivor exploits.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/YHFWmM5spZU

</details>


# Changelog
:cl: Drathek
balance: LZ turrets (spaceborne) can no longer be driven past or destroyed by vehicles
/:cl:
