### PR TITLE
Remove viewers usage for Manufacturer Logos

### DIFF
--- a/code/datums/elements/manufacturer_logos.dm
+++ b/code/datums/elements/manufacturer_logos.dm
@@ -86,5 +86,5 @@
 
 /datum/element/corp_label/proc/on_examine(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
-	var/logo = "[icon2html('icons/ui_icons/logos.dmi', viewers(get_turf(source)), manufacturer, extra_classes = "corplogo", non_standard_size = TRUE)]"
+	var/logo = "[icon2html('icons/ui_icons/logos.dmi', user, manufacturer, extra_classes = "corplogo", non_standard_size = TRUE)]"
 	examine_list += SPAN_INFO("On [source] you can see [full_name] logo, it reads: [logo]")


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #10840 just simply reducing the clients getting sent the image.

# Explain why it's good for the game

Less work for the server.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="1955" height="432" alt="image" src="https://github.com/user-attachments/assets/d760266f-8170-42c2-8f4b-bdb8c6d38d2a" />

</details>


# Changelog
:cl: Drathek
code: Manufacturer logos are now only sent to the examiner mob instead of all viewers
/:cl:
