### PR TITLE
THE BREADENING PART TWO, ELECTRIC BOOGALOO

### DIFF
--- a/code/datums/recipe.dm
+++ b/code/datums/recipe.dm
@@ -1107,7 +1107,7 @@
 	result = /obj/item/reagent_container/food/snacks/taco
 
 /datum/recipe/bun
-	reagents = list("sodiumchloride" = 1)
+	reagents = list("blackpepper" = 1)
 	items = list(
 		/obj/item/reagent_container/food/snacks/doughslice,
 	)


### PR DESCRIPTION


# About the pull request

Actually changes the recipe for buns to use less dough per bun. Frees the ancient burger chefs from their toil. Induces carbohydrate. 

# Explain why it's good for the game

Burgers should not cost an entire dough, when that same dough can make sliceable breads, pizzas, and cakes. 


# Testing Photographs and Procedure
N/A
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog


:cl:
balance: Dough costs adjusted, burger buns buffed significantly
/:cl:

