### PR TITLE
Allows humans to brace from impact on shuttle landing by wall leaning

### DIFF
--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -341,6 +341,9 @@
 	for(var/mob/living/carbon/affected_mob in (GLOB.alive_human_list + GLOB.living_xeno_list)) //knock down mobs
 		if(affected_mob.z != z)
 			continue
+		if(affected_mob && HAS_TRAIT_FROM(affected_mob, TRAIT_UNDENSE, WALL_HIDING_TRAIT))
+			to_chat(affected_mob, SPAN_WARNING("You brace yourself against the impact!"))
+			return
 		if(affected_mob.buckled)
 			to_chat(affected_mob, SPAN_WARNING("You are jolted against [affected_mob.buckled]!"))
 			// shake_camera(affected_mob, 3, 1)


### PR DESCRIPTION

# About the pull request

Title.

# Explain why it's good for the game

I've seen a lot of people RP about bracing for impact only to fail nonchalantly and end up landing on their asses if not comically pulling out a roller bed out of nowhere and bracing from impact there.

This PR allows you to brace for impact by wall leaning instead, the caveat being the slow effect you get upon unleaning, of course. 

# Testing Photographs and Procedure

<img width="328" height="36" alt="image" src="https://github.com/user-attachments/assets/228afcae-6a13-47e4-97b4-ec58db9e4e05" />

# Changelog
:cl:
add: Humans can now brace for shuttle impact by leaning on walls.
/:cl:
