### PR TITLE
Tweaks to Fun Facts

### DIFF
--- a/code/datums/statistics/random_facts/damage_fact.dm
+++ b/code/datums/statistics/random_facts/damage_fact.dm
@@ -1,7 +1,7 @@
 /datum/random_fact/damage
 	statistic_name = "damage"
 	statistic_verb = "took"
-	min_required = 600
+	min_required = 400
 
 /datum/random_fact/damage/life_grab_stat(mob/fact_mob)
 	return fact_mob.life_damage_taken_total


### PR DESCRIPTION
# About the pull request

Changes the calories burnt fun fact to be more 'realistic' (on the upper end of calories burnt for your average fully-encumbered marine in streneous combat conditions as in CM), while increasing the min requirement to compensate, plus changed 'damage taken' to be a bit higher since your average marine gets absolutely shattered every round. 


# Explain why it's good for the game

makes people stop complaining on the forums, also yeah the calories burnt thing was pretty pitifully low and didn't account for combat activities + heavy loads and the fact everyone is sprinting everywhere


# Testing Photographs and Procedure

# Changelog

:cl:
code: upped the average number of calories burnt
code: upped the minimum hurdle for calories burnt fun fact
/:cl: