### PR TITLE
Prevents IBs/Organ Damage on the Hunting Preserve

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -189,6 +189,9 @@
 	if(!owner)
 		return
 
+	if(owner.faction in FACTION_LIST_HUNTED) //Hunting Grounds
+		return
+
 	var/armor = owner.getarmor_organ(src, ARMOR_INTERNALDAMAGE)
 	if(owner.mind && owner.skills)
 		armor += owner.skills.get_skill_level(SKILL_ENDURANCE)*5
@@ -457,7 +460,7 @@ This function completely restores a damaged organ to perfect condition.
 	if(!owner)
 		return
 
-	if(owner.faction in FACTION_LIST_HUNTED)
+	if(owner.faction in FACTION_LIST_HUNTED)//Hunting Grounds
 		return
 
 	var/armor = owner.getarmor_organ(src, ARMOR_INTERNALDAMAGE)


### PR DESCRIPTION
# About the pull request

You can no longer get IB or Organ Damage on the Hunting Grounds.

# Explain why it's good for the game

Getting your HG cut short because you were tapped once at the start is not fun, especially if you win the fight.

Speaking from both an HG fighter perspective and Predator perspective its really really annoying to either **have** the IB/giga brain damage/kidney damage/etc or kidnap the person to take them to the ship to fix the said injuries so I can actually fight someone who's able to actually stand up. 

This does not affect bone breaks at all.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: you can no longer get IB or Organ Damage while on the Hunting Preserve as a FACTION_LIST_HUNTED
/:cl:
