### PR TITLE
Allows deaf marines to see above head emotes

### DIFF
--- a/code/datums/langchat/langchat.dm
+++ b/code/datums/langchat/langchat.dm
@@ -95,6 +95,7 @@
 	var/image/r_icon
 	var/use_mob_style = TRUE
 	var/text_to_display = message
+	var/is_emote = additional_styles && additional_styles.Find("emote")
 	if(length(text_to_display) > LANGCHAT_LONGEST_TEXT)
 		text_to_display = copytext_char(text_to_display, 1, LANGCHAT_LONGEST_TEXT + 1) + "..."
 	var/timer = (length(text_to_display) / LANGCHAT_LONGEST_TEXT) * 4 SECONDS + 2 SECONDS
@@ -115,7 +116,7 @@
 
 	langchat_listeners = listeners
 	for(var/mob/M in langchat_listeners)
-		if(langchat_client_enabled(M) && !M.ear_deaf && (skip_language_check || M.say_understands(src, language)))
+		if(langchat_client_enabled(M) && (is_emote || !M.ear_deaf) && (skip_language_check || M.say_understands(src, language)))
 			M.client.images += langchat_image
 
 	if(isturf(loc))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Title.

# Explain why it's good for the game

Allows deaf humans to see langchat emotes when they are deaf.

Its a bit annoying that I have to look at the chatbar to see if someone is emoting my way, which typically happens when i get revived from an explosion, or if i have to revive someone who blew up from an explosion

This should be relatively harmless for balance, since you could already see emotes from the chat bar
This won't display the alternative messages though; I've no idea how to get it to display clientside without it displaying for others

# Testing Photographs and Procedure

https://www.youtube.com/watch?v=nuijjAZD59k

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Abovehead emotes can now appear for deaf people.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
