### PR TITLE
fix pmc CO surv not having proper skills

### DIFF
--- a/code/datums/skills/civilian.dm
+++ b/code/datums/skills/civilian.dm
@@ -184,7 +184,7 @@ CIVILIAN
 
 /datum/skills/civilian/survivor/pmc/co_survivor // PMC Nightmare Variant of CMB CO Survivor for Solaris Ridge
 	name = "Survivor PMC Field Operations Leader"
-	skills = list(
+	additional_skills = list(
 		SKILL_CQC = SKILL_CQC_EXPERT,
 		SKILL_POLICE = SKILL_POLICE_SKILLED,
 		SKILL_MELEE_WEAPONS = SKILL_MELEE_TRAINED,


### PR DESCRIPTION
# About the pull request

changes skills to additional_skills, giving the pmc co surv the skills he is meant to have

# Explain why it's good for the game

bug bad fix good

# Testing Photographs and Procedure


# Changelog


:cl:
fix: The solaris PMC CO surv now has his proper skills.
/:cl:

