### PR TITLE
Re-enables WO pred rounds

### DIFF
--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -1,4 +1,4 @@
-/*
+F/*
 How this works:
 jobs.dm contains the job defines that work on that level only. Things like equipping a character, creating IDs, and so forth, are handled there.
 Role Authority handles the creation and assignment of roles. Roles can be things like regular marines, PMC response teams, aliens, and so forth.
@@ -213,7 +213,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 	else
 		chance = 20
 
-	if((prob(chance) || SSnightmare.get_scenario_value("predator_round"))
+	if((prob(chance) || SSnightmare.get_scenario_value("predator_round")))
 		SSticker.mode.flags_round_type |= MODE_PREDATOR
 		// Set predators starting amount based on marines assigned
 		var/datum/job/PJ = temp_roles_for_mode[JOB_PREDATOR]


### PR DESCRIPTION
# About the pull request
title

<img width="518" height="90" alt="image" src="https://github.com/user-attachments/assets/8a241e8a-c1bc-4e7e-b4f2-4a9c79818558" />

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Pred content vastly expanded during the time between it being disabled on WO and now, gives time and reason to RP.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
add: Whiskey Outpost will now roll pred rounds once more
/:cl:

