### PR TITLE
Fixes the world's strongest brace for impact (Hijack stopper)

### DIFF
--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -343,7 +343,7 @@
 			continue
 		if(affected_mob && HAS_TRAIT_FROM(affected_mob, TRAIT_UNDENSE, WALL_HIDING_TRAIT))
 			to_chat(affected_mob, SPAN_WARNING("You brace yourself against the impact!"))
-			return
+			continue
 		if(affected_mob.buckled)
 			to_chat(affected_mob, SPAN_WARNING("You are jolted against [affected_mob.buckled]!"))
 			// shake_camera(affected_mob, 3, 1)


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #10963 doing a couple things:
- Bracing for impact no longer early returns the entire `on_arrival` proc for the shuttle arriving (crashing)
- All mobs on the ship zs now are affected again (Multi-z issue)

# Explain why it's good for the game

Fixes #11019

You shouldn't be able to brace against the wall so well that you stop hijack from occurring.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Same Z brace: https://youtu.be/frIg0p7yDbY
Other Z brace: https://youtu.be/lpEIGezLRT4

</details>

# Changelog
:cl: Drathek
fix: Fixed bracing for impact preventing hijack
fix: Fixed mobs only on the same Z as the crashing shuttle being affected by the crash
/:cl:
