### PR TITLE
Fixes flamer tank refueling removed from the Reagent Tank PR

### DIFF
--- a/code/modules/projectiles/magazines/flamer.dm
+++ b/code/modules/projectiles/magazines/flamer.dm
@@ -82,7 +82,7 @@
 /obj/item/ammo_magazine/flamer_tank/afterattack(obj/target, mob/user , flag) //refuel at fueltanks when we run out of ammo.
 	if(get_dist(user,target) > 1)
 		return ..()
-	if(!istype(target, /obj/structure/reagent_dispensers/tank/fuel) && !istype(target, /obj/item/tool/weldpack) && !istype(target, /obj/item/storage/backpack/marine/engineerpack))
+	if(!istype(target, /obj/structure/reagent_dispensers/tank/fuel) && !istype(target, /obj/item/tool/weldpack) && !istype(target, /obj/item/storage/backpack/marine/engineerpack) && !istype(target, /obj/item/ammo_magazine/flamer_tank))
 		return ..()
 
 	if(!target.reagents || length(target.reagents.reagent_list) < 1)


### PR DESCRIPTION

# About the pull request

#10950 reverted the change after all the type path renames


# Explain why it's good for the game

We really shouldn't be silently reverting approved PRs immediately after its merging


# Testing Photographs and Procedure
It works



# Changelog
:cl:
fix: Flamer tanks can refill from other flamer tanks again
/:cl:
