### PR TITLE
Fix for set pose grammar

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -89,10 +89,12 @@
 				t_He = "He"
 				t_his = "his"
 				t_him = "him"
+				t_is = "is"
 			if(FEMALE)
 				t_He = "She"
 				t_his = "her"
 				t_him = "her"
+				t_is = "is"
 
 	if(id_paygrade)
 		msg += "<EM>[rank_display] </EM>"
@@ -542,7 +544,7 @@
 	if (pose)
 		if( findtext(pose,".",length(pose)) == 0 && findtext(pose,"!",length(pose)) == 0 && findtext(pose,"?",length(pose)) == 0 )
 			pose = addtext(pose,".") //Makes sure all emotes end with a period.
-		msg += "\n[t_He] is [pose]"
+		msg += "\n[t_He] [t_is] [pose]"
 
 	. += msg
 


### PR DESCRIPTION
# About the pull request

Fix for [#11026](https://github.com/cmss13-devs/cmss13/issues/11026)

Also fixes the grammar when using clothing that obscures gender. (example the biosuit and biohood together)

Tested on private server and didn't see any issues (Set pose is supposed to prefix before the pose. "They is" is not proper grammar however)

# Explain why it's good for the game

Wearing full covering clothing or being nonbinary shouldn't cause your set pose to have horrendous grammar

# Changelog
:cl: armsdealer9876
spellcheck: Set pose now says They are instead of They is
code: Added 2 new var's for human/examin.dm
/:cl:
