### PR TITLE
update 2 comments to be autodoc comments

### DIFF
--- a/code/__DEFINES/paygrade_defs/civilian.dm
+++ b/code/__DEFINES/paygrade_defs/civilian.dm
@@ -13,10 +13,10 @@
 /// CDOC, Doctor
 #define PAY_SHORT_CDOC "CDOC"
 
-// CCMOA, Assistant Professor
+/// CCMOA, Assistant Professor
 #define PAY_SHORT_CCMOA "CCMOA"
 
-// CCMOB, Associate Professor
+/// CCMOB, Associate Professor
 #define PAY_SHORT_CCMOB "CCMOB"
 
 /// CCMOC, Professor


### PR DESCRIPTION
noticed when reading some code that these two comments were normal comments and not autodoc like the other paygrades, and so did not show up in the langserver parse. 

<img width="211" height="157" alt="image" src="https://github.com/user-attachments/assets/2a2d8b2a-f940-4a71-b765-9ee894b1362b" />

<img width="256" height="135" alt="image" src="https://github.com/user-attachments/assets/0b6f4168-14f2-4c23-b954-e3a5e622a48d" />

difference seen above.

this is a webedit

# Changelog

:cl:
code: tweaks a comment to be documented better.
/:cl:
