### PR TITLE
Large mobs (ex.: big T2 or T3 xeno) can ignore pushes from normal mobs using the help intent

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -387,7 +387,8 @@
 		else if((living_mob.is_mob_restrained() || living_mob.a_intent == INTENT_HELP) && (is_mob_restrained() || a_intent == INTENT_HELP))
 			mob_swap = 1
 		// Big mobs (ex.: T3 xeno) can ignore pushes from smaller creatures using the help intent
-		else if(a_intent == INTENT_HELP && mob_size >= MOB_SIZE_BIG && living_mob.mob_size < MOB_SIZE_BIG)
+		else if(!ishuman(living_mob) && !isyautja(living_mob) && ( // But not with humans and jautja
+				a_intent == INTENT_HELP && mob_size >= MOB_SIZE_BIG && living_mob.mob_size < MOB_SIZE_BIG))
 			mob_swap = 1
 		if(mob_swap)
 			//switch our position with L


### PR DESCRIPTION

# About the pull request

Let the large xenomorphs leave from the human body block.

Example, this video (CM13 discord) and maaaany stupid and non-logical situations:
https://discord.com/channels/150315577943130112/862155128441012234/1434673539826585630

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

This PR eliminates the ridiculous situation where a 10-ton xenomorph gets blocked by a 100-kilogram marine.

Now, a large xenomorph in a help intent can pass through a small human.
At the same time, we retain the ability to push large xenomorphs if they are in a harm intent.
# Testing Photographs and Procedure


https://github.com/user-attachments/assets/4ac39a24-d77a-48a2-9cb5-b3c149bfae50




# Changelog
:cl:
balance: Large mobs (ex.: big T2 or T3 xeno) now can ignore pushes from normal mobs using the help intent
/:cl:
