### PR TITLE
Facehuggers no longer eat your glasses or cigarettes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -576,7 +576,8 @@
 		else
 			visible_message(SPAN_DANGER("[hugger] smashes against [src]'s [W.name] and rips it off!"))
 			drop_inv_item_on_ground(W)
-
+	if(wear_mask)
+		drop_inv_item_on_ground(wear_mask) // drop any item from the face that wasn't handled above (e.g cigs, glasses)
 	return can_infect
 
 /datum/species/proc/handle_hugger_attachment(mob/living/carbon/human/target, obj/item/clothing/mask/facehugger/hugger, mob/living/carbon/xenomorph/facehugger/mob_hugger)


### PR DESCRIPTION

# About the pull request

Title.
This is for pugie.

# Explain why it's good for the game

Facehuggers lacked a check for the mask slot to drop any other item that isn't a mask to the ground, deleting it or putting it in null space instead

This fixes that, now facehuggers no longer has a diet of ray bans and cigarettes.

# Testing Photographs and Procedure
it works, you really don't need a video for this

# Changelog
:cl:
fix: Facehuggers no longer has a diet of ray bans and cigarettes, they will no longer eat your glasses or cigarettes on your face slot
/:cl:
