### PR TITLE
Capitalize name in most tgui interfaces

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -101,7 +101,7 @@
 /obj/structure/machinery/autolathe/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "Autolathe", "[name] control panel")
+		ui = new(user, src, "Autolathe", "[capitalize(name)] control panel")
 		ui.open()
 
 /obj/structure/machinery/autolathe/ui_data(mob/user)

--- a/code/game/machinery/computer/almayer_control.dm
+++ b/code/game/machinery/computer/almayer_control.dm
@@ -42,7 +42,7 @@
 /obj/structure/machinery/computer/almayer_control/tgui_interact(mob/user, datum/tgui/ui, datum/ui_state/state)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "AlmayerControl", "[name]")
+		ui = new(user, src, "AlmayerControl", "[capitalize(name)]")
 		ui.open()
 
 /obj/structure/machinery/computer/almayer_control/ui_status(mob/user, datum/ui_state/state)

--- a/code/game/machinery/computer/demo_sim.dm
+++ b/code/game/machinery/computer/demo_sim.dm
@@ -40,7 +40,7 @@
 /obj/structure/machinery/computer/demo_sim/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "DemoSim", "[src.name]")
+		ui = new(user, src, "DemoSim", "[capitalize(name)]")
 		ui.open()
 
 /obj/structure/machinery/computer/demo_sim/ui_state(mob/user) // we gotta do custom shit here so that it always closes instead of suspending

--- a/code/game/machinery/door_display/door_display.dm
+++ b/code/game/machinery/door_display/door_display.dm
@@ -223,7 +223,7 @@
 /obj/structure/machinery/door_display/research_cell/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "ResearchDoorDisplay", "[src.name]")
+		ui = new(user, src, "ResearchDoorDisplay", "[capitalize(name)]")
 		ui.open()
 
 /obj/structure/machinery/door_display/research_cell/ui_state(mob/user)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -464,7 +464,7 @@ GLOBAL_LIST_INIT(airlock_wire_descriptions, list(
 /obj/structure/machinery/door/airlock/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if (!ui)
-		ui = new(user, src, "Wires", "[name] Wires")
+		ui = new(user, src, "Wires", "[capitalize(name)] Wires")
 		ui.open()
 
 /obj/structure/machinery/door/airlock/ui_data(mob/user)
@@ -478,7 +478,7 @@ GLOBAL_LIST_INIT(airlock_wire_descriptions, list(
 			"attached" = !isnull(getAssembly(wire)),
 		)))
 	.["wires"] = payload
-	.["proper_name"] = name
+	.["proper_name"] = capitalize(name)
 
 /obj/structure/machinery/door/airlock/ui_static_data(mob/user)
 	. = list()

--- a/code/game/machinery/fax_machine.dm
+++ b/code/game/machinery/fax_machine.dm
@@ -266,7 +266,7 @@ GLOBAL_DATUM_INIT(fax_network, /datum/fax_network, new)
 /obj/structure/machinery/faxmachine/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "FaxMachine", "[src.name]")
+		ui = new(user, src, "FaxMachine", "[capitalize(name)]")
 		ui.open()
 
 /obj/structure/machinery/faxmachine/ui_state(mob/user)

--- a/code/game/machinery/nuclearbomb.dm
+++ b/code/game/machinery/nuclearbomb.dm
@@ -129,7 +129,7 @@ GLOBAL_VAR_INIT(bomb_set, FALSE)
 /obj/structure/machinery/nuclearbomb/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "NuclearBomb", "[src.name]")
+		ui = new(user, src, "NuclearBomb", "[capitalize(name)]")
 		ui.open()
 
 /obj/structure/machinery/nuclearbomb/ui_state(mob/user)

--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -221,7 +221,7 @@
 /obj/item/device/binoculars/range/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "Binoculars", "[src.name]")
+		ui = new(user, src, "Binoculars", "[capitalize(name)]")
 		ui.open()
 
 /obj/item/device/binoculars/range/ui_state(mob/user)

--- a/code/modules/admin/player_panel/player_panel.dm
+++ b/code/modules/admin/player_panel/player_panel.dm
@@ -453,14 +453,14 @@
 
 	ui = SStgui.try_update_ui(user, src, ui)
 	if (!ui)
-		ui = new(user, src, "PlayerPanel", "[targetMob.name] Player Panel")
+		ui = new(user, src, "PlayerPanel", "[capitalize(targetMob.name)] Player Panel")
 		ui.open()
 		ui.set_autoupdate(FALSE)
 
 // Player panel
 /datum/player_panel/ui_data(mob/user)
 	. = list()
-	.["mob_name"] = targetMob.name
+	.["mob_name"] = capitalize(targetMob.name)
 
 	if(istype(targetMob, /mob/living))
 		var/mob/living/livingTarget = targetMob

--- a/code/modules/cm_marines/altitude_control_console.dm
+++ b/code/modules/cm_marines/altitude_control_console.dm
@@ -77,7 +77,7 @@ GLOBAL_VAR_INIT(ship_alt, SHIP_ALT_MED)
 /obj/structure/machinery/computer/altitude_control_console/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "AltitudeControlConsole", "[src.name]")
+		ui = new(user, src, "AltitudeControlConsole", "[capitalize(name)]")
 		ui.open()
 
 /obj/structure/machinery/computer/altitude_control_console/ui_state(mob/user)

--- a/code/modules/cm_marines/anti_air.dm
+++ b/code/modules/cm_marines/anti_air.dm
@@ -60,7 +60,7 @@ GLOBAL_DATUM(almayer_aa_cannon, /obj/structure/anti_air_cannon)
 /obj/structure/machinery/computer/aa_console/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "AntiAirConsole", "[src.name]")
+		ui = new(user, src, "AntiAirConsole", "[capitalize(name)]")
 		ui.open()
 
 

--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -610,7 +610,7 @@ GLOBAL_LIST_EMPTY(orbital_cannon_cancellation)
 /obj/structure/machinery/computer/orbital_cannon_console/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "OrbitalCannonConsole", "[src.name]")
+		ui = new(user, src, "OrbitalCannonConsole", "[capitalize(name)]")
 		ui.open()
 
 /obj/structure/machinery/computer/orbital_cannon_console/ui_state(mob/user)

--- a/code/modules/cm_marines/radar.dm
+++ b/code/modules/cm_marines/radar.dm
@@ -30,7 +30,7 @@
 /datum/radar/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if (!ui)
-		ui = new(user, src, "Radar", "[holder.name]")
+		ui = new(user, src, "Radar", "[capitalize(holder.name)]")
 		ui.open()
 
 /datum/radar/ui_assets(mob/user)

--- a/code/modules/cm_tech/tech_memories.dm
+++ b/code/modules/cm_tech/tech_memories.dm
@@ -4,7 +4,7 @@
 /datum/objective_memory_interface/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "TechMemories", "[holder.name] Objectives")
+		ui = new(user, src, "TechMemories", "[capitalize(holder.name)] Objectives")
 		ui.open()
 		ui.set_autoupdate(TRUE)
 

--- a/code/modules/desert_dam/filtration/consoles.dm
+++ b/code/modules/desert_dam/filtration/consoles.dm
@@ -48,7 +48,7 @@ GLOBAL_VAR_INIT(river_activated, FALSE)
 /obj/structure/machinery/filtration/console/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "FiltrationControl", "[src.name]")
+		ui = new(user, src, "FiltrationControl", "[capitalize(name)]")
 		ui.open()
 
 /obj/structure/machinery/filtration/console/ui_state(mob/user)

--- a/code/modules/mob/living/carbon/xenomorph/hive_faction.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_faction.dm
@@ -30,7 +30,7 @@ GLOBAL_LIST_INIT(hive_alliable_factions, generate_alliable_factions())
 
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "HiveFaction", "[assoc_hive.name] Faction Panel")
+		ui = new(user, src, "HiveFaction", "[capitalize(assoc_hive.name)] Faction Panel")
 		ui.open()
 		ui.set_autoupdate(FALSE)
 

--- a/code/modules/mob/living/carbon/xenomorph/hive_status_ui.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status_ui.dm
@@ -199,7 +199,7 @@
 
 	ui = SStgui.try_update_ui(user, src, ui)
 	if (!ui)
-		ui = new(user, src, "HiveStatus", "[assoc_hive.name] Status")
+		ui = new(user, src, "HiveStatus", "[capitalize(assoc_hive.name)] Status")
 		ui.open()
 		ui.set_autoupdate(FALSE)
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -192,10 +192,10 @@ GLOBAL_LIST_INIT(apc_wire_descriptions, list(
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		if(!opened && wiresexposed)
-			ui = new(user, src, "Wires", "[name] Wires")
+			ui = new(user, src, "Wires", "[capitalize(name)] Wires")
 			ui.open()
 		else
-			ui = new(user, src, "Apc", name)
+			ui = new(user, src, "Apc", capitalize(name))
 			ui.open()
 
 /obj/structure/machinery/power/apc/ui_status(mob/user)
@@ -264,7 +264,7 @@ GLOBAL_LIST_INIT(apc_wire_descriptions, list(
 			"cut" = isWireCut(wire),
 		)))
 	data["wires"] = payload
-	data["proper_name"] = name
+	data["proper_name"] = capitalize(name)
 
 	return data
 

--- a/code/modules/reagents/chemistry_machinery/centrifuge.dm
+++ b/code/modules/reagents/chemistry_machinery/centrifuge.dm
@@ -108,7 +108,7 @@
 /obj/structure/machinery/centrifuge/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "Centrifuge", "[src.name]")
+		ui = new(user, src, "Centrifuge", "[capitalize(name)]")
 		ui.open()
 
 /obj/structure/machinery/centrifuge/ui_state(mob/user)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -257,7 +257,7 @@
 /obj/structure/machinery/disposal/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "Disposals", "[src.name]")
+		ui = new(user, src, "Disposals", "[capitalize(name)]")
 		ui.open()
 
 /obj/structure/machinery/disposal/ui_data(mob/user)

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -189,7 +189,7 @@
 
 	ui = SStgui.try_update_ui(user, src, ui)
 	if (!ui)
-		ui = new(user, src, "NavigationShuttle", "[ert.name] Navigation Computer")
+		ui = new(user, src, "NavigationShuttle", "[capitalize(ert.name)] Navigation Computer")
 		ui.open()
 
 

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -104,7 +104,7 @@
 	ui = SStgui.try_update_ui(user, src, ui)
 	if (!ui)
 		var/obj/docking_port/mobile/shuttle = SSshuttle.getShuttle(shuttleId)
-		var/name = shuttle?.name
+		var/name = capitalize(shuttle?.name)
 		if(can_change_shuttle)
 			name = "Remote"
 		ui = new(user, src, "DropshipFlightControl", "[name] Flight Computer")

--- a/code/modules/shuttle/computers/escape_pod_computer.dm
+++ b/code/modules/shuttle/computers/escape_pod_computer.dm
@@ -30,7 +30,7 @@
 /obj/structure/machinery/computer/shuttle/escape_pod_panel/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "EscapePodConsole", "[src.name]")
+		ui = new(user, src, "EscapePodConsole", "[capitalize(name)]")
 		ui.open()
 
 /obj/structure/machinery/computer/shuttle/escape_pod_panel/ui_state(mob/user)

--- a/code/modules/vehicles/multitile/multitile_verbs.dm
+++ b/code/modules/vehicles/multitile/multitile_verbs.dm
@@ -131,7 +131,7 @@
 /obj/vehicle/multitile/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "VehicleStatus", "[name]")
+		ui = new(user, src, "VehicleStatus", "[capitalize(name)]")
 		ui.open()
 
 /obj/vehicle/multitile/ui_data(mob/user)


### PR DESCRIPTION

# About the pull request

This PR simply ensures most TGUI interfaces uses a `name` that is capitalized.

# Explain why it's good for the game

Fixes various possibilities like this: 
<img width="380" height="350" alt="image" src="https://github.com/user-attachments/assets/f59c22c4-1c4a-4810-915b-a03867903552" />

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="380" height="350" alt="image" src="https://github.com/user-attachments/assets/2831ab82-34ee-4736-9155-5fc2e8ee95a9" />

</details>

# Changelog
:cl: Drathek
spellcheck: Most TGUI interfaces will not have a uncapitalized name in the title now
/:cl:
