### PR TITLE
fix setup characters being black

### DIFF
--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -194,13 +194,12 @@
 	if(isnull(preview_dummy))
 		preview_dummy = new()
 
-	preview_dummy.blocks_emissive = EMISSIVE_BLOCK_NONE
-	preview_dummy.update_emissive_block()
-
 	clear_equipment()
 	if(refresh_limb_status)
 		for(var/obj/limb/L in preview_dummy.limbs)
 			L.status = LIMB_ORGANIC
+	for(var/obj/limb/L in preview_dummy.limbs)
+		L.blocks_emissive = EMISSIVE_BLOCK_NONE
 	preview_dummy.set_species()
 	copy_appearance_to(preview_dummy)
 	preview_dummy.update_body()

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -784,7 +784,7 @@ This function completely restores a damaged organ to perfect condition.
 /obj/limb/proc/get_limb_icon_key()
 	SHOULD_CALL_PARENT(TRUE)
 
-	return "[species.name]-[body_size]-[body_type]-[limb_gender]-[icon_name]-[skin_color]-[status]"
+	return "[species.name]-[body_size]-[body_type]-[limb_gender]-[icon_name]-[skin_color]-[status]-[blocks_emissive]"
 
 // new damage icon system
 // returns just the brute/burn damage code


### PR DESCRIPTION

# About the pull request

it was ignoring emission blockers

# Explain why it's good for the game

its a fix


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: fixed character setup preview being black
/:cl:
