### PR TITLE
Chem Dispenser Plumbing | Makes dispensing water free

### DIFF
--- a/code/modules/reagents/chemistry_machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_dispenser.dm
@@ -195,10 +195,8 @@
 				if(reagent_name == "water")
 					current_reagent.add_reagent(reagent_name, min(amount, space))
 				else
-					var/dispense_amount = min(amount, chem_storage.energy * 10, space)
-					if (dispense_amount > 0)
-						current_reagent.add_reagent(reagent_name, dispense_amount)
-						chem_storage.energy = max(chem_storage.energy - dispense_amount / 10, 0)
+					current_reagent.add_reagent(reagent_name, min(amount, chem_storage.energy * 10, space))
+					chem_storage.energy = max(chem_storage.energy - min(amount, chem_storage.energy * 10, space) / 10, 0)
 
 			. = TRUE
 


### PR DESCRIPTION
# About the pull request

This PR makes dispensing water in the chemical dispensers free and possible while at 0 power. 

# Explain why it's good for the game

It has long been common to run to a sink to get water during chemline to save power, mainly to make meralyne for MB/unga, or to make sure CLF3 does not explode when making some for an OT. This is unintuitive to new players and is likely not the intended method of making such chemicals.
By removing energy requirements when dispensing water, there is no longer any need for running to the sink to save some power during chemline, making it more comfortable to do chems, especially during highpop chemline, without affecting the actual balance of chem energy in any way, as water was already free.

# Testing Photographs and Procedure

Dispensing water with energy left
https://github.com/user-attachments/assets/d3963333-d214-47d8-8631-3c7f7ca07604

Dispensing water without any energy left
https://github.com/user-attachments/assets/3cf40228-7646-4f2c-891c-102c72a3a6e6



</details>


# Changelog
:cl: BertStein
qol: Removed the energy requirements for water in the chemical dispenser.
/:cl:
