### PR TITLE
Makes iron grey

### DIFF
--- a/code/modules/reagents/chemistry_reagents/other.dm
+++ b/code/modules/reagents/chemistry_reagents/other.dm
@@ -463,7 +463,7 @@
 	id = "iron"
 	description = "Chemical element of atomic number 26. Has a broad range of uses in multiple industries particularly in engineering and construction. Iron is an important component of hemoglobin, the substance in red blood cells that carries oxygen. Overdosing on iron is extremely toxic."
 	reagent_state = SOLID
-	color = "#C8A5DC" // rgb: 200, 165, 220
+	color = "#a19d94" // rgb: 161, 157, 148
 	overdose = REAGENTS_OVERDOSE
 	overdose_critical = REAGENTS_OVERDOSE_CRITICAL
 	chemclass = CHEM_CLASS_BASIC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Iron was supposed to be grey, but it's still pink.

# Explain why it's good for the game
Pink iron is dumb.

# Changelog
:cl: Puckaboo2
fix: Iron is no longer pink.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
