### PR TITLE
make emissions bright again

### DIFF
--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -43,7 +43,7 @@
 #define EMISSIVE_BLOCK_NONE 2
 
 #define _EMISSIVE_COLOR(val) list(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, val,0,0,0)
-#define _EMISSIVE_COLOR_NO_BLOOM(val) list(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,val,0,0)
+#define _EMISSIVE_COLOR_NO_BLOOM(val) list(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 1,val,1,0)
 /// The color matrix applied to all emissive overlays. Should be solely dependent on alpha and not have RGB overlap with [EM_BLOCK_COLOR].
 #define EMISSIVE_COLOR _EMISSIVE_COLOR(1)
 #define EMISSIVE_COLOR_NO_BLOOM _EMISSIVE_COLOR_NO_BLOOM(1)


### PR DESCRIPTION

# About the pull request

see title

# Explain why it's good for the game

its less muted, which looks better

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

after
<img width="402" height="231" alt="image" src="https://github.com/user-attachments/assets/d7c01441-40a7-4cfc-9e39-d5106f9dde09" />
before
<img width="246" height="219" alt="image" src="https://github.com/user-attachments/assets/7d0dfeff-c3c2-4313-aca8-e0cfbf553212" />


</details>


# Changelog
:cl:
fix: emissions are bright again
/:cl:
