### PR TITLE
Update PhoneMenu.tsx

### DIFF
--- a/tgui/packages/tgui/interfaces/PhoneMenu.tsx
+++ b/tgui/packages/tgui/interfaces/PhoneMenu.tsx
@@ -67,7 +67,7 @@ const GeneralPanel = (props) => {
     <Section fill>
       <Stack vertical fill>
         <Stack.Item>
-          <Tabs>
+          <Tabs style={{ flexWrap: 'wrap' }}>
             {categories.map((val) => (
               <Tabs.Tab
                 selected={val === currentCategory}


### PR DESCRIPTION
# About the pull request

Added `flexWrap: ‘wrap’` for tabs in the phone interface

Screens are in the testing section

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

It looks prettier. And now all of the tabs fit

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Previously, the interface looks like this:
<img width="500" height="400" alt="изображение" src="https://github.com/user-attachments/assets/d35be311-3dce-45a1-9017-19dc8a51b1b3" />

Now the phone interface looks like this:
<img width="500" height="400" alt="изображение" src="https://github.com/user-attachments/assets/bcc0817b-df2f-4e9f-9f1c-31e84a9aafd6" />


</details>


# Changelog
:cl: Comka
ui: Added `flexWrap: ‘wrap’` for tabs in the phone interface. Now they should fit in the window
/:cl:
