### PR TITLE
Fixes Thwei overlay not changing... Again again. Everything works now, prommy.

### DIFF
--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -393,6 +393,7 @@
 	qdel(src)
 
 /obj/item/reagent_container/hypospray/autoinjector/yautja/update_icon()
+	overlays.Cut()
 	if(uses_left && autoinjector_type) //does not apply a colored fill overlay like the rest of the autoinjectors
 		var/image/filling = image('icons/obj/items/hunter/pred_gear.dmi', src, "[autoinjector_type]_[uses_left]")
 		overlays += filling


### PR DESCRIPTION
# About the pull request
Fixes Thwei not returning to its original sprite.

# Explain why it's good for the game
Thwei still broken. I swear, I fixed it, I tested it, and it worked, but the code gaslit me. 

# Testing Photographs and Procedure<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<details>
<summary>Screenshots & Videos</summary>

Yes, the Thwei on the ground at the beginning of the gif crumbled some time after the gif ended.
![dreamseeker_2025-11-05_12-20-56](https://github.com/user-attachments/assets/04f8271b-3965-4fa1-a029-7c9c5ede2c32)

</details>


# Changelog

:cl: Puckaboo2

fix: Thwei goes back to its normal sprite after use.

/:cl:
