### PR TITLE
Dragging a storage item onto another dumps the contents onto the other item

### DIFF
--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -642,6 +642,13 @@ W is always an item. stop_warning prevents messaging. user may be null.**/
 	..()
 	return attempt_item_insertion(W, FALSE, user)
 
+/// Dragging a storage item to another will move the contents of the dragged item into the target storage if possible.
+/obj/item/storage/MouseDrop_T(atom/movable/C, mob/user)
+	if(!istype(C, /obj/item/storage))
+		return ..()
+	var/obj/item/storage/storage_being_dragged_in = C
+	dump_into(storage_being_dragged_in, user)
+
 /obj/item/storage/equipped(mob/user, slot, silent)
 	if ((storage_flags & STORAGE_ALLOW_EMPTY))
 		if(!isxeno(user))

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -643,10 +643,15 @@ W is always an item. stop_warning prevents messaging. user may be null.**/
 	return attempt_item_insertion(W, FALSE, user)
 
 /// Dragging a storage item to another will move the contents of the dragged item into the target storage if possible.
-/obj/item/storage/MouseDrop_T(atom/movable/C, mob/user)
-	if(!istype(C, /obj/item/storage))
+/obj/item/storage/MouseDrop_T(atom/movable/dragged_thing, mob/user)
+	if(!istype(dragged_thing, /obj/item/storage))
 		return ..()
-	var/obj/item/storage/storage_being_dragged_in = C
+	var/obj/item/storage/storage_being_dragged_in = dragged_thing
+	if(!(storage_flags & STORAGE_ALLOW_EMPTY))
+		to_chat(user, SPAN_WARNING("You can't dump items into [src]."))
+	if(!(storage_being_dragged_in.storage_flags & STORAGE_ALLOW_EMPTY))
+		to_chat(user, SPAN_WARNING("You can't dump items from [storage_being_dragged_in]."))
+		return
 	dump_into(storage_being_dragged_in, user)
 
 /obj/item/storage/equipped(mob/user, slot, silent)

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -865,6 +865,12 @@ W is always an item. stop_warning prevents messaging. user may be null.**/
 	for(var/obj/item/new_item in origin_storage)
 		if(!has_room(new_item))
 			break
+		if(!(new_item.type in can_hold))
+			to_chat(user, SPAN_WARNING("[new_item] can't fit into [src]!"))
+			continue
+		if(new_item.type in cant_hold)
+			to_chat(user, SPAN_WARNING("[new_item] can't fit into [src]!"))
+			continue
 		origin_storage.remove_from_storage(new_item, user)
 		handle_item_insertion(new_item, TRUE, user) //quiet insertion
 


### PR DESCRIPTION

# About the pull request

Dragging a storage item onto another dumps the contents onto the other item

TL;DR: Drag pouch into backpack to move pouch item inside

takes 1.5 seconds.

Doesn't work on non-storage items like armor and webbing on jumpsuit. Shucks.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Reduces possible tedium. 

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
qol: Dragging a storage item onto another dumps the contents onto the other item
/:cl:

