### PR TITLE
Adds Emergency Close Incision surgeries, fixes some surgery issues

### DIFF
--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -11,6 +11,7 @@
 	required_surgery_skill = SKILL_SURGERY_TRAINED
 	pain_reduction_required = PAIN_REDUCTION_HEAVY
 	steps = list(
+		/datum/surgery_step/clamp_bleeders_step, //oop i forgor, also cuz you can't clamp bleeders here, normally, for some reason
 		/datum/surgery_step/mend_bones,
 		/datum/surgery_step/set_bones,
 	)

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -12,6 +12,8 @@
 	required_surgery_skill = SKILL_SURGERY_NOVICE
 	steps = list(
 		/datum/surgery_step/incision,
+		/datum/surgery_step/cauterize/abort,
+		/datum/surgery_step/suture_incision/abort,
 		/datum/surgery_step/clamp_bleeders_step,
 		/datum/surgery_step/retract_skin,
 	)
@@ -387,6 +389,33 @@
 	target.apply_damage(3, BURN, target_zone)
 	log_interact(user, target, "[key_name(user)] failed to cauterize an incision in [key_name(target)]'s [surgery.affected_limb.display_name], aborting [surgery].")
 	return FALSE
+
+/datum/surgery_step/cauterize/abort
+	name = "Abort Surgery"
+	desc = "close the incision early"
+
+/datum/surgery_step/cauterize/abort/skip_step_criteria(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	return TRUE //If you opened the wrong limb or you need to close an autopsy incision; this has you covered. Different from amputation abortion.
+
+/datum/surgery_step/cauterize/abort/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, tool_type, datum/surgery/surgery)
+	user.affected_message(target,
+		SPAN_NOTICE("You cauterize the incision on [target]'s [surgery.affected_limb.display_name]."),
+		SPAN_NOTICE("[user] cauterizes the incision on your [surgery.affected_limb.display_name]."),
+		SPAN_NOTICE("[user] cauterizes the incision on [target]'s [surgery.affected_limb.display_name]."))
+	switch(target_zone)
+		if("head")
+			target.overlays -= image('icons/mob/humans/dam_human.dmi', "skull_surgery_closed")
+			target.overlays -= image('icons/mob/humans/dam_human.dmi', "skull_surgery_open")
+		if("chest")
+			target.overlays -= image('icons/mob/humans/dam_human.dmi', "chest_surgery_closed")
+			target.overlays -= image('icons/mob/humans/dam_human.dmi', "chest_surgery_open")
+
+	to_chat(target, SPAN_NOTICE("You feel better."))
+	target.incision_depths[target_zone] = SURGERY_DEPTH_SURFACE
+	surgery.affected_limb.remove_all_bleeding(TRUE, FALSE)
+	target.pain.recalculate_pain()
+	complete(target, surgery)
+	log_interact(user, target, "[key_name(user)] cauterized an incision in [key_name(target)]'s [surgery.affected_limb.display_name], ending [surgery].")
 
 //////////////////////////////////////////////////////////////////
 // BONE-OPENING SURGERIES //

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -15,6 +15,8 @@
 		/datum/surgery_step/cauterize/abort,
 		/datum/surgery_step/suture_incision/abort,
 		/datum/surgery_step/clamp_bleeders_step,
+		/datum/surgery_step/cauterize/abort,
+		/datum/surgery_step/suture_incision/abort,
 		/datum/surgery_step/retract_skin,
 	)
 	lying_required = FALSE

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -430,6 +430,7 @@
 	required_surgery_skill = SKILL_SURGERY_TRAINED
 	steps = list(
 		/datum/surgery_step/saw_encased,
+		/datum/surgery_step/clamp_bleeders_step, //oop i forgor, also cuz you can't clamp bleeders here, normally, for some reason
 		/datum/surgery_step/open_encased_step,
 		/datum/surgery_step/mend_encased,
 	)
@@ -576,6 +577,7 @@
 	steps = list(
 		/datum/surgery_step/close_encased_step,
 		/datum/surgery_step/open_encased_step,
+		/datum/surgery_step/clamp_bleeders_step, //oop i forgor, also cuz you can't clamp bleeders here, normally, for some reason
 		/datum/surgery_step/mend_encased,
 	)
 	pain_reduction_required = PAIN_REDUCTION_HEAVY

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -412,7 +412,6 @@
 			target.overlays -= image('icons/mob/humans/dam_human.dmi', "chest_surgery_closed")
 			target.overlays -= image('icons/mob/humans/dam_human.dmi', "chest_surgery_open")
 
-	to_chat(target, SPAN_NOTICE("You feel better."))
 	target.incision_depths[target_zone] = SURGERY_DEPTH_SURFACE
 	surgery.affected_limb.remove_all_bleeding(TRUE, FALSE)
 	target.pain.recalculate_pain()

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -372,11 +372,8 @@
 	switch(target_zone)
 		if("head")
 			target.overlays -= image('icons/mob/humans/dam_human.dmi', "skull_surgery_closed")
-			target.overlays -= image('icons/mob/humans/dam_human.dmi', "skull_surgery_open")
 		if("chest")
 			target.overlays -= image('icons/mob/humans/dam_human.dmi', "chest_surgery_closed")
-			target.overlays -= image('icons/mob/humans/dam_human.dmi', "chest_surgery_open")
-
 	target.incision_depths[target_zone] = SURGERY_DEPTH_SURFACE
 	surgery.affected_limb.remove_all_bleeding(TRUE, FALSE)
 	target.pain.recalculate_pain()
@@ -407,11 +404,8 @@
 	switch(target_zone)
 		if("head")
 			target.overlays -= image('icons/mob/humans/dam_human.dmi', "skull_surgery_closed")
-			target.overlays -= image('icons/mob/humans/dam_human.dmi', "skull_surgery_open")
 		if("chest")
 			target.overlays -= image('icons/mob/humans/dam_human.dmi', "chest_surgery_closed")
-			target.overlays -= image('icons/mob/humans/dam_human.dmi', "chest_surgery_open")
-
 	target.incision_depths[target_zone] = SURGERY_DEPTH_SURFACE
 	surgery.affected_limb.remove_all_bleeding(TRUE, FALSE)
 	target.pain.recalculate_pain()

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -376,6 +376,7 @@
 		if("chest")
 			target.overlays -= image('icons/mob/humans/dam_human.dmi', "chest_surgery_closed")
 			target.overlays -= image('icons/mob/humans/dam_human.dmi', "chest_surgery_open")
+
 	target.incision_depths[target_zone] = SURGERY_DEPTH_SURFACE
 	surgery.affected_limb.remove_all_bleeding(TRUE, FALSE)
 	target.pain.recalculate_pain()

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -404,8 +404,10 @@
 	switch(target_zone)
 		if("head")
 			target.overlays -= image('icons/mob/humans/dam_human.dmi', "skull_surgery_closed")
+			target.overlays -= image('icons/mob/humans/dam_human.dmi', "skull_surgery_open")
 		if("chest")
 			target.overlays -= image('icons/mob/humans/dam_human.dmi', "chest_surgery_closed")
+			target.overlays -= image('icons/mob/humans/dam_human.dmi', "chest_surgery_open")
 	target.incision_depths[target_zone] = SURGERY_DEPTH_SURFACE
 	surgery.affected_limb.remove_all_bleeding(TRUE, FALSE)
 	target.pain.recalculate_pain()

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -372,8 +372,10 @@
 	switch(target_zone)
 		if("head")
 			target.overlays -= image('icons/mob/humans/dam_human.dmi', "skull_surgery_closed")
+			target.overlays -= image('icons/mob/humans/dam_human.dmi', "skull_surgery_open")
 		if("chest")
 			target.overlays -= image('icons/mob/humans/dam_human.dmi', "chest_surgery_closed")
+			target.overlays -= image('icons/mob/humans/dam_human.dmi', "chest_surgery_open")
 	target.incision_depths[target_zone] = SURGERY_DEPTH_SURFACE
 	surgery.affected_limb.remove_all_bleeding(TRUE, FALSE)
 	target.pain.recalculate_pain()

--- a/code/modules/surgery/surgery_initiator.dm
+++ b/code/modules/surgery/surgery_initiator.dm
@@ -115,7 +115,7 @@
 					else
 						hint_msg += ", [current_step.desc]"
 				else
-					hint_msg = "You can't [current_step.desc] with \the [tool]"
+					hint_msg = "You can't [current_step.desc] with [tool]"
 			if(!isnull(hint_msg))
 				to_chat(user, SPAN_WARNING("[hint_msg]."))
 		return FALSE

--- a/code/modules/surgery/surgery_procedure.dm
+++ b/code/modules/surgery/surgery_procedure.dm
@@ -109,19 +109,19 @@
 				[user.zone_selected == "r_hand"||user.zone_selected == "l_hand" ? "hand":"arm"] you're using!"))
 			return FALSE
 	var/datum/surgery_step/current_step = GLOB.surgery_step_list[steps[status]]
-	if(current_step)
-		if(current_step.attempt_step(user, target, user.zone_selected, tool, src, repeating)) //First, try this step.
+	var/next = status
+	while(current_step)
+		// attempt the step
+		if(current_step.attempt_step(user, target, user.zone_selected, tool, src, repeating))
 			return TRUE
-		var/datum/surgery_step/next_step
-		if(current_step.skip_step_criteria(user, target, user.zone_selected, tool, src) && status < length(steps)) //If that doesn't work but the step is optional and not the last in the list, try the next step.
-			next_step = GLOB.surgery_step_list[steps[status + 1]]
-			if(next_step.attempt_step(user, target, user.zone_selected, tool, src, skipped = TRUE))
-				return TRUE
-		if(tool && is_surgery_tool(tool)) //Just because you used the wrong tool doesn't mean you meant to whack the patient with it...
-			if(next_step)
-				to_chat(user, SPAN_WARNING("You can't [current_step.desc] with \the [tool], or [next_step.desc]."))
-			else
-				to_chat(user, SPAN_WARNING("You can't [current_step.desc] with \the [tool]."))
-			return FALSE //...but you might be wanting to use it on them anyway. If on help intent, the help-intent safety will apply for this attack.
-	return FALSE
+		// check if its an optional step
+		if(!current_step.skip_step_criteria(user, target, user.zone_selected, tool, src))
+			if(tool && is_surgery_tool(tool)) //Just because you used the wrong tool doesn't mean you meant to whack the patient with it...
+				to_chat(user, SPAN_WARNING("You can't [current_step.desc] with [tool]."))
+		return FALSE
+		// step was optional, try the next if it exists
+		if(++next > length(steps))
+			break
+		current_step = GLOB.surgery_step_list[steps[next]]
 
+	return FALSE

--- a/code/modules/surgery/surgery_procedure.dm
+++ b/code/modules/surgery/surgery_procedure.dm
@@ -118,7 +118,7 @@
 		if(!current_step.skip_step_criteria(user, target, user.zone_selected, tool, src))
 			if(tool && is_surgery_tool(tool)) //Just because you used the wrong tool doesn't mean you meant to whack the patient with it...
 				to_chat(user, SPAN_WARNING("You can't [current_step.desc] with [tool]."))
-		return FALSE
+			return FALSE
 		// step was optional, try the next if it exists
 		if(++next > length(steps))
 			break

--- a/code/modules/surgery/surgery_steps.dm
+++ b/code/modules/surgery/surgery_steps.dm
@@ -237,10 +237,7 @@ affected_limb, or location vars. Also, in that case there may be a wait between 
 		tool.update_icon() // in order to not reset shit too far.
 
 	if(advance)
-		if(skipped) //Skipped previous step.
-			surgery.status += 2
-		else
-			surgery.status++
+		surgery.status += max(skipped + 1, 1)
 		if(surgery.status > length(surgery.steps))
 			complete(target, surgery)
 


### PR DESCRIPTION
# About the pull request

Adds the following features:
1. Multiple surgery steps can be skipped instead of only one step being skipped. 
2. Adds two new surgeries that allow you to close an incision without fully preparing it first: one with a cautery, and one with a surgical line. They have the same function as cauterizing and sewing a patient up.
3. Fixes being able to execute certain surgery steps out of order.
4. Prevents the ability to cauterize/sew a patient early during an incomplete surface or deep surgery.
5. Allows you to pinch bleeders during steps you couldn't pinch, before

# Explain why it's good for the game
Streamlining surgeries and being able to close autopsies faster is good. 
1. Code only recognized that only one surgery step can be skipped. Now, you can skip multiple steps, if they're ever implemented.
2. Fixes the occasional, "aw, fuck, wrong limb, sorry", or "I don't wanna do two extra steps before closing an autopsy patient, so I'll just stuff them in while they're all open."
3. Why are you closing the patient after you just drilled their skull/ribcage in half? You monster. Stop it.
4. So... You removed the corneas, and then you cauterized the eyeballs. Great. Now your patient is completely blind. Finish major surgeries before you close your patient up!
5. "Aw fuck. Forgot to pinch after sawing the chest--wait, I can't pinch? Maybe if I open up the bone--NOW I can pinch." Nah, you can pinch here, now. 

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Drathek and I both tested. It works, prommy. Trust.

But if you don't, here's the proof.
![dreamseeker_2025-12-04_20-31-16](https://github.com/user-attachments/assets/6766feb8-a1fd-49e0-b08f-29c37438b9cf)
</details>


# Changelog

:cl: Drathek, Puckaboo2
add: You can close unprepared incisions without having to skip to using the retractor, now.
add: Multiple skippable surgery steps are now possible.
add: Adds two Abort Surgery surgeries, one with surgical line and one with the cautery. 
qol: If you can't complete a surgical step with a tool, the game will tell you so and it will also tell you what surgeries are available at the current step to give you a clue on what tools you CAN use.
fix: Fixes being able to execute certain surgery steps out of order.
fix: Prevents the ability to cauterize/sew a patient early during an incomplete surface or deep surgery.
/:cl:
