### PR TITLE
Fixes Marine Sorting in Orbit

### DIFF
--- a/tgui/packages/tgui/interfaces/Orbit/index.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/index.tsx
@@ -402,7 +402,8 @@ const GroupedObservable = (props: {
             <ObservableSection
               color={x.color}
               title={x.title}
-              section={props.sorter ? x.members.sort(props.sorter) : x.members}
+              section={x.members}
+              sorter={props.sorter}
               key={x.title}
             />
           ))}
@@ -675,8 +676,9 @@ const ObservableSection = (props: {
   readonly color?: string;
   readonly section: Array<Observable>;
   readonly title: string;
+  readonly sorter?: groupSorter;
 }) => {
-  const { color, section = [], title } = props;
+  const { color, section = [], title, sorter } = props;
 
   const {
     value: searchQuery,
@@ -692,11 +694,14 @@ const ObservableSection = (props: {
     .filter((observable) => isJobOrNameMatch(observable, searchQuery))
     .filter((observable) => (observable.in_ground === 1 ? show_ground : true))
     .filter((observable) => (observable.in_ship === 1 ? show_ship : true))
-    .sort((a, b) =>
-      a.full_name
+    .sort((a, b) => {
+      if (sorter) {
+        return sorter(a, b);
+      }
+      return a.full_name
         .toLocaleLowerCase()
-        .localeCompare(b.full_name.toLocaleLowerCase()),
-    );
+        .localeCompare(b.full_name.toLocaleLowerCase());
+    });
 
   if (!filteredSection.length) {
     return null;


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Fixes marine sorting logic in Ghost Orbit. `ObservableSection` was overriding sorting by usual "sort by name" instead of checking if it was already sorted/need special sorting logic. So, it was sorting correctly, then overriding to default sorting.

Check images for comparison.

# Explain why it's good for the game
Fixing bugs is good, easier to find roles in descending priority order.

# Testing Photographs and Procedure
<details>
<summary>
Images
</summary>

Before (sorted ONLY by name)
<img width="513" height="220" alt="Screenshot_30" src="https://github.com/user-attachments/assets/549b0ddf-982d-4b6a-903b-1221687c154e" />

After (sorted by Ranking and then by name)
<img width="499" height="137" alt="Screenshot_29" src="https://github.com/user-attachments/assets/2766ccb5-e87a-46ab-84fc-c4bb6007e024" />

</details>

# Changelog
:cl:
fix: Fixed Marine Sorting in Orbit. Now it first sorts by rank, then by name.
/:cl:
