### PR TITLE
Fixes another flamer bug

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -220,8 +220,6 @@
 			continue
 		A = obstacle
 		blocking_dir |= A.BlockedPassDirs(mover, fdir)
-		if((fd1 && blocking_dir == fd1) || (fd2 && blocking_dir == fd2))
-			return A
 		if((!fd1 || blocking_dir & fd1) && (!fd2 || blocking_dir & fd2))
 			return A
 


### PR DESCRIPTION
# About the pull request

Title.

# Explain why it's good for the game

Fix, the line deletion allows flamers to fire past corners with non-dense objects again.
I don't know if this breaks anything else, or if it reverts the fix in #2143, but through my testing, I haven't found anything crazy

# Testing Photographs and Procedure
It works, doesn't seem like you can vault through the briefing thindows either

# Changelog
:cl:
fix: Flamers can now fire past some corners again
/:cl:
