### PR TITLE
Fix MD and QuadTrees

### DIFF
--- a/code/__DEFINES/__game.dm
+++ b/code/__DEFINES/__game.dm
@@ -500,8 +500,8 @@
 /// Minimum Y height up to which we keep dividing the tree (meaning cells can be half that)
 #define QUADTREE_BOUNDARY_MINIMUM_HEIGHT 12
 
-
-#define QTREE_EXCLUDE_OBSERVER 1
+/// Whether to filter to only living mobs
+#define QTREE_FILTER_LIVING 1
 
 /// Return mob list instead of client list.
 #define QTREE_SCAN_MOBS 2

--- a/code/controllers/subsystem/quadtrees.dm
+++ b/code/controllers/subsystem/quadtrees.dm
@@ -42,7 +42,7 @@ SUBSYSTEM_DEF(quadtree)
 		p_coords.x_pos = mob_turf.x
 		p_coords.y_pos = mob_turf.y
 		p_coords.z_pos = mob_turf.z
-		p_coords.is_observer = !isliving(cur_client.mob)
+		p_coords.non_living_mob = !isliving(cur_client.mob)
 		p_coords.weak_mob = WEAKREF(cur_client.mob)
 		var/datum/quadtree/quad = new_quadtrees[mob_turf.z]
 		quad.insert_player(p_coords)

--- a/code/datums/quadtree.dm
+++ b/code/datums/quadtree.dm
@@ -40,8 +40,8 @@
 /datum/coords/qtplayer
 	/// Relevant client the coords are associated to
 	var/client/player
-	/// Truthy if player is an observer
-	var/is_observer = FALSE
+	/// Truthy if player.mob is not a living mob
+	var/non_living_mob = FALSE
 	/// Weakref to the player.mob to determine if this is stale
 	var/datum/weakref/weak_mob
 
@@ -217,7 +217,7 @@
 	for(var/datum/coords/qtplayer/quad_player as anything in player_coords)
 		if(!quad_player.player) // Basically client is gone
 			continue
-		if((flags & QTREE_EXCLUDE_OBSERVER) && quad_player.is_observer)
+		if((flags & QTREE_FILTER_LIVING) && quad_player.non_living_mob)
 			continue
 		if(range.contains_coords(quad_player))
 			if(flags & QTREE_SCAN_MOBS)

--- a/code/game/objects/items/devices/motion_detector.dm
+++ b/code/game/objects/items/devices/motion_detector.dm
@@ -266,13 +266,13 @@
 
 	range_bounds.set_shape(cur_turf.x, cur_turf.y, detector_range * 2)
 
-	var/list/ping_candidates = SSquadtree.players_in_range(range_bounds, cur_turf.z, QTREE_EXCLUDE_OBSERVER | QTREE_SCAN_MOBS)
+	var/list/ping_candidates = SSquadtree.players_in_range(range_bounds, cur_turf.z, QTREE_FILTER_LIVING | QTREE_SCAN_MOBS)
 	var/turf/above = SSmapping.get_turf_above(cur_turf)
 	var/turf/below = SSmapping.get_turf_below(cur_turf)
 	if(above)
-		ping_candidates += SSquadtree.players_in_range(range_bounds, above.z, QTREE_EXCLUDE_OBSERVER | QTREE_SCAN_MOBS)
+		ping_candidates += SSquadtree.players_in_range(range_bounds, above.z, QTREE_FILTER_LIVING | QTREE_SCAN_MOBS)
 	if(below)
-		ping_candidates += SSquadtree.players_in_range(range_bounds, below.z, QTREE_EXCLUDE_OBSERVER | QTREE_SCAN_MOBS)
+		ping_candidates += SSquadtree.players_in_range(range_bounds, below.z, QTREE_FILTER_LIVING | QTREE_SCAN_MOBS)
 
 	for(var/mob/living/current_mob as anything in ping_candidates)
 		if(current_mob == loc)

--- a/code/modules/cm_aliens/structures/special/egg_morpher.dm
+++ b/code/modules/cm_aliens/structures/special/egg_morpher.dm
@@ -128,7 +128,7 @@
 	if(!range_bounds)
 		range_bounds = SQUARE(x, y, EGGMORPG_RANGE)
 
-	var/list/targets = SSquadtree.players_in_range(range_bounds, z, QTREE_SCAN_MOBS | QTREE_EXCLUDE_OBSERVER)
+	var/list/targets = SSquadtree.players_in_range(range_bounds, z, QTREE_SCAN_MOBS | QTREE_FILTER_LIVING)
 	if(isnull(targets) || !length(targets))
 		return
 

--- a/code/modules/defenses/bell_tower.dm
+++ b/code/modules/defenses/bell_tower.dm
@@ -265,7 +265,7 @@
 		STOP_PROCESSING(SSobj, src)
 		return
 
-	var/list/targets = SSquadtree.players_in_range(SQUARE(M.x, M.y, area_range), M.z, QTREE_SCAN_MOBS | QTREE_EXCLUDE_OBSERVER)
+	var/list/targets = SSquadtree.players_in_range(SQUARE(M.x, M.y, area_range), M.z, QTREE_SCAN_MOBS | QTREE_FILTER_LIVING)
 	if(!targets)
 		return
 

--- a/code/modules/defenses/planted_flag.dm
+++ b/code/modules/defenses/planted_flag.dm
@@ -94,7 +94,7 @@
 	if(!range_bounds)
 		range_bounds = SQUARE(x, y, area_range)
 
-	var/list/targets = SSquadtree.players_in_range(SQUARE(x, y, area_range), z, QTREE_SCAN_MOBS | QTREE_EXCLUDE_OBSERVER)
+	var/list/targets = SSquadtree.players_in_range(SQUARE(x, y, area_range), z, QTREE_SCAN_MOBS | QTREE_FILTER_LIVING)
 	if(!targets)
 		return
 
@@ -222,7 +222,7 @@
 	if(!M.x && !M.y && !M.z)
 		return
 
-	var/list/targets = SSquadtree.players_in_range(SQUARE(M.x, M.y, area_range), M.z, QTREE_SCAN_MOBS | QTREE_EXCLUDE_OBSERVER)
+	var/list/targets = SSquadtree.players_in_range(SQUARE(M.x, M.y, area_range), M.z, QTREE_SCAN_MOBS | QTREE_FILTER_LIVING)
 	targets |= M
 
 	for(var/mob/living/carbon/human/H in targets)

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -86,7 +86,7 @@
 
 	if(!range_bounds)
 		set_range()
-	targets = SSquadtree.players_in_range(range_bounds, z, QTREE_SCAN_MOBS | QTREE_EXCLUDE_OBSERVER)
+	targets = SSquadtree.players_in_range(range_bounds, z, QTREE_SCAN_MOBS | QTREE_FILTER_LIVING)
 	if(!targets)
 		return FALSE
 


### PR DESCRIPTION
# About the pull request

This PR is to fix MD that have had runtimes for about a month. I have done the following:
- Multiz checking now actually will use the Z offset value rather than assuming its 1
- Quadtree now can filter non-living mobs instead of merely observers (should include a case where a client.mob is null)
- Misc code cleanup as usual

What I'm confused about though is that `undefined proc or verb /mob/dead/observer/get target lock()` could occur before on the line `if(M.get_target_lock(iff_signal))` but quadtree explicitly checked for observers... This change makes sense for `undefined proc or verb /mob/camera/imaginary_friend/get target lock()` and `undefined proc or verb /mob/new_player/get target lock()` and `undefined proc or verb /mob/ghost/get target lock()` though. So I can only hope that handling a null C.mob addresses the observer aspect... That or moving the current_mob.l_move_time back around.

Update on above: I think its possible that you could get `undefined proc or verb /mob/dead/observer/get target lock()` to occur if say the quadtree fires for a mob, but between fires that client then ghosts so the is_observer value is incorrect until next fire. Now the quadtree holds a weakref so that a `QTREE_SCAN_MOBS` check only returns results where is_observer is accurate.

# Explain why it's good for the game

Fixes #11071

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/eH55u8l_O_o

Will be testing on live.

</details>

# Changelog
:cl: Drathek
fix: Fix MDs breaking when handling non-living mobs and potentially differently offset Zs
code: Quadtrees now hold a weakref to the client mob to ignore a QTREE_SCAN_MOBS potentially returning a mob that has changed since the last subsystem fire
code: Quadtrees now optionally filter out non-living mobs instead of only observers
/:cl:
