### PR TITLE
new escape pod doors

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -425,7 +425,7 @@
 	name = "\improper Evacuation Airlock SU-3";
 	dir = 1
 	},
-/turf/open/floor/hybrisa/metal/red_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/almayer/powered)
 "abb" = (
 /turf/open/floor/almayer/plating_stripedcorner/west,
@@ -3160,7 +3160,7 @@
 /obj/structure/machinery/door/airlock/almayer/secure/pod/reinforced{
 	name = "\improper Evacuation Airlock SU-2"
 	},
-/turf/open/floor/hybrisa/metal/red_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/almayer/powered)
 "ahj" = (
 /obj/structure/machinery/light{
@@ -9615,7 +9615,7 @@
 /obj/structure/machinery/door/airlock/almayer/secure/pod/reinforced{
 	name = "\improper Evacuation Airlock PU-2"
 	},
-/turf/open/floor/hybrisa/metal/red_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/almayer/powered)
 "ayp" = (
 /obj/structure/machinery/cm_vending/sorted/cargo_guns/intelligence_officer{
@@ -36573,7 +36573,7 @@
 /obj/structure/machinery/door/airlock/almayer/secure/pod/reinforced{
 	name = "\improper Evacuation Airlock PL-3"
 	},
-/turf/open/floor/hybrisa/metal/red_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/almayer/powered)
 "bTx" = (
 /turf/open/floor/almayer/plating_stripedcorner/east,
@@ -36932,7 +36932,7 @@
 	name = "\improper Evacuation Airlock SU-4";
 	dir = 1
 	},
-/turf/open/floor/hybrisa/metal/red_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/almayer/powered)
 "bWn" = (
 /obj/structure/machinery/light/red{
@@ -37611,7 +37611,7 @@
 	name = "\improper Evacuation Airlock PU-3";
 	dir = 1
 	},
-/turf/open/floor/hybrisa/metal/red_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/almayer/powered)
 "ceE" = (
 /turf/closed/wall/almayer,
@@ -37980,7 +37980,7 @@
 	name = "\improper Evacuation Airlock PU-4";
 	dir = 1
 	},
-/turf/open/floor/hybrisa/metal/red_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/almayer/powered)
 "ciB" = (
 /obj/structure/disposalpipe/segment{
@@ -38430,7 +38430,7 @@
 	name = "\improper Evacuation Airlock SL-1";
 	dir = 1
 	},
-/turf/open/floor/hybrisa/metal/red_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/almayer/powered)
 "cmK" = (
 /obj/structure/pipes/vents/pump{
@@ -38472,7 +38472,7 @@
 	name = "\improper Evacuation Airlock PL-1";
 	dir = 1
 	},
-/turf/open/floor/hybrisa/metal/red_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/almayer/powered)
 "cnm" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -44743,7 +44743,7 @@
 	name = "\improper Evacuation Airlock PU-6";
 	dir = 1
 	},
-/turf/open/floor/hybrisa/metal/red_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/almayer/powered)
 "eON" = (
 /obj/effect/decal/warning_stripes{
@@ -57075,7 +57075,7 @@
 	name = "\improper Evacuation Airlock SL-2";
 	dir = 1
 	},
-/turf/open/floor/hybrisa/metal/red_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/almayer/powered)
 "jUF" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
@@ -64721,7 +64721,7 @@
 	name = "\improper Evacuation Airlock PU-CL";
 	dir = 8
 	},
-/turf/open/floor/hybrisa/metal/red_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/almayer/powered)
 "nef" = (
 /obj/effect/decal/warning_stripes{
@@ -66491,7 +66491,7 @@
 /obj/structure/machinery/door/airlock/almayer/secure/pod/reinforced{
 	name = "\improper Evacuation Airlock PU-1"
 	},
-/turf/open/floor/hybrisa/metal/red_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/almayer/powered)
 "nNY" = (
 /turf/open/floor/almayer/plating_stripedcorner/south,
@@ -73859,7 +73859,7 @@
 	name = "\improper Evacuation Airlock SU-6";
 	dir = 1
 	},
-/turf/open/floor/hybrisa/metal/red_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/almayer/powered)
 "qHD" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -83207,7 +83207,7 @@
 /obj/structure/machinery/door/airlock/almayer/secure/pod/reinforced{
 	name = "\improper Evacuation Airlock SU-1"
 	},
-/turf/open/floor/hybrisa/metal/red_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/almayer/powered)
 "uuD" = (
 /obj/structure/machinery/door/airlock/almayer/engineering{
@@ -84997,7 +84997,7 @@
 	name = "\improper Evacuation Airlock PL-2";
 	dir = 1
 	},
-/turf/open/floor/hybrisa/metal/red_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/almayer/powered)
 "vfx" = (
 /obj/structure/pipes/standard/simple/hidden/supply{

--- a/maps/shuttles/escape_shuttle_e.dmm
+++ b/maps/shuttles/escape_shuttle_e.dmm
@@ -16,7 +16,7 @@
 /obj/structure/machinery/door/airlock/evacuation{
 	name = "\improper Evacuation Airlock SU-1"
 	},
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/escape_pod)
 "k" = (
 /turf/closed/shuttle/escapepod{

--- a/maps/shuttles/escape_shuttle_e_cl.dmm
+++ b/maps/shuttles/escape_shuttle_e_cl.dmm
@@ -40,7 +40,7 @@
 	name = "\improper Evacuation Airlock CL-1";
 	id_tag = "cl_evac"
 	},
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/escape_pod)
 "E" = (
 /turf/closed/shuttle/escapepod{

--- a/maps/shuttles/escape_shuttle_n.dmm
+++ b/maps/shuttles/escape_shuttle_n.dmm
@@ -12,7 +12,7 @@
 	dir = 2;
 	name = "\improper Evacuation Airlock PU-3"
 	},
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/escape_pod)
 "l" = (
 /turf/closed/shuttle/escapepod{

--- a/maps/shuttles/escape_shuttle_s.dmm
+++ b/maps/shuttles/escape_shuttle_s.dmm
@@ -79,7 +79,7 @@
 	dir = 2;
 	name = "\improper Evacuation Airlock PU-6"
 	},
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/escape_pod)
 
 (1,1,1) = {"

--- a/maps/shuttles/escape_shuttle_w.dmm
+++ b/maps/shuttles/escape_shuttle_w.dmm
@@ -70,7 +70,7 @@
 /obj/structure/machinery/door/airlock/evacuation{
 	name = "\improper Evacuation Airlock PL-3"
 	},
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/escape_pod)
 "T" = (
 /obj/structure/machinery/cryopod/evacuation,

--- a/maps/shuttles/lifeboat-port-archive.dmm
+++ b/maps/shuttles/lifeboat-port-archive.dmm
@@ -234,7 +234,7 @@
 	id = "Boat1-D1";
 	throw_dir = 1
 	},
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/lifeboat)
 "CI" = (
 /turf/template_noop,
@@ -316,10 +316,10 @@
 	id = "Boat1-D2";
 	throw_dir = 1
 	},
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/lifeboat)
 "Nm" = (
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/lifeboat)
 "Ob" = (
 /turf/closed/shuttle/lifeboat{

--- a/maps/shuttles/lifeboat-port.dmm
+++ b/maps/shuttles/lifeboat-port.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/lifeboat)
 "aF" = (
 /obj/structure/prop/invuln/dropship_parts/lifeboat{
@@ -198,7 +198,7 @@
 	id = "Boat1-D4";
 	throw_dir = 2
 	},
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/lifeboat)
 "yf" = (
 /obj/structure/machinery/cm_vending/sorted/supplies/lifeboat{
@@ -247,7 +247,7 @@
 	id = "Boat1-D1";
 	throw_dir = 1
 	},
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/lifeboat)
 "CI" = (
 /turf/template_noop,
@@ -268,7 +268,7 @@
 	id = "Boat1-D3";
 	throw_dir = 2
 	},
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/lifeboat)
 "FR" = (
 /obj/structure/surface/table/reinforced/almayer_B,
@@ -336,7 +336,7 @@
 	id = "Boat1-D2";
 	throw_dir = 1
 	},
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/lifeboat)
 "Ob" = (
 /turf/closed/shuttle/lifeboat{

--- a/maps/shuttles/lifeboat-rostock.dmm
+++ b/maps/shuttles/lifeboat-rostock.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/lifeboat)
 "ao" = (
 /turf/closed/shuttle/lifeboat{
@@ -58,7 +58,7 @@
 	id = "Boat1-D4";
 	throw_dir = 2
 	},
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/lifeboat)
 "lW" = (
 /turf/closed/shuttle/lifeboat{
@@ -125,7 +125,7 @@
 	id = "Boat1-D3";
 	throw_dir = 2
 	},
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/lifeboat)
 "qb" = (
 /obj/structure/prop/invuln/dropship_parts/lifeboat{
@@ -171,14 +171,14 @@
 	id = "Boat1-D2";
 	throw_dir = 1
 	},
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/lifeboat)
 "ya" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/dropshiprear/lifeboat{
 	id = "Boat1-D1";
 	throw_dir = 1
 	},
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/lifeboat)
 "zc" = (
 /turf/open/shuttle/lifeboat,

--- a/maps/shuttles/lifeboat-starboard-archive.dmm
+++ b/maps/shuttles/lifeboat-starboard-archive.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/lifeboat)
 "ce" = (
 /turf/closed/shuttle/lifeboat{
@@ -108,7 +108,7 @@
 	id = "Boat2-D2";
 	throw_dir = 2
 	},
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/lifeboat)
 "mt" = (
 /turf/closed/shuttle/lifeboat/transparent{
@@ -240,7 +240,7 @@
 	id = "Boat2-D1";
 	throw_dir = 2
 	},
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/lifeboat)
 "EI" = (
 /obj/structure/surface/table/reinforced/almayer_B,

--- a/maps/shuttles/lifeboat-starboard.dmm
+++ b/maps/shuttles/lifeboat-starboard.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/lifeboat)
 "ce" = (
 /turf/closed/shuttle/lifeboat{
@@ -108,7 +108,7 @@
 	id = "Boat2-D4";
 	throw_dir = 2
 	},
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/lifeboat)
 "mt" = (
 /turf/closed/shuttle/lifeboat/transparent{
@@ -167,7 +167,7 @@
 	id = "Boat2-D2";
 	throw_dir = 1
 	},
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/lifeboat)
 "vG" = (
 /obj/docking_port/mobile/crashable/lifeboat/starboard,
@@ -189,7 +189,7 @@
 	id = "Boat2-D1";
 	throw_dir = 1
 	},
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/lifeboat)
 "zv" = (
 /turf/closed/shuttle/lifeboat{
@@ -254,7 +254,7 @@
 	id = "Boat2-D3";
 	throw_dir = 2
 	},
-/turf/open/floor/hybrisa/metal/yellow_warning_floor,
+/turf/open/floor/almayer/test_floor4,
 /area/shuttle/lifeboat)
 "EI" = (
 /obj/structure/surface/table/reinforced/almayer_B,


### PR DESCRIPTION
# About the pull request

Replaces the standard airlock doors with some more fitting airlocks, fits the style of the pods rather then the generic airlocks used everywhere else.

Sprites by dimdimich1996.

# Explain why it's good for the game

New sprites good, and you can now look into the pods and wave your goodbyes while you're left behind and mauled to death.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="1757" height="815" alt="image" src="https://github.com/user-attachments/assets/0e392234-d372-4d04-8802-ce8544a4aa04" />


https://github.com/user-attachments/assets/9c721c6b-0dec-444f-9953-afcec0d2df94




</details>


# Changelog

:cl: Zenith, dimdimich1996

imageadd: added three new pod door style sprites.
maptweak: tweaked the various maps with the escape pod doors - added new escape pod doors to them and minor floor tile changes.

/:cl:
