### PR TITLE
fix chem dispeners init order

### DIFF
--- a/code/modules/reagents/chemistry_machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_dispenser.dm
@@ -59,18 +59,18 @@
 /obj/structure/machinery/chem_dispenser/research
 	network = "Research"
 
-/obj/structure/machinery/chem_dispenser/process()
-	if(!chem_storage)
-		chem_storage = GLOB.chemical_data.connect_chem_storage(network)
 
 /obj/structure/machinery/chem_dispenser/Initialize()
-	. = ..()
+	..()
 	dispensable_reagents = sortList(dispensable_reagents)
-	start_processing()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/structure/machinery/chem_dispenser/LateInitialize()
+	chem_storage = GLOB.chemical_data.connect_chem_storage(network)
 
 /obj/structure/machinery/chem_dispenser/Destroy()
-	if(!chem_storage)
-		chem_storage = GLOB.chemical_data.disconnect_chem_storage(network)
+	GLOB.chemical_data.disconnect_chem_storage(network)
+	chem_storage = null
 	return ..()
 
 /obj/structure/machinery/chem_dispenser/ex_act(severity)


### PR DESCRIPTION

# About the pull request
Chem dispensers had a few issues.

1. They were added to processing just to add their chem storage. That's a useless machine in a constantly called subsystem.... Trying to connect to the storage in Initialize might cause an issue if the storage spawned after. So The storage connection is now done in LateInitialize. By that the storage exists.
2. The destroy logic made no sense. Only if we didn't have a storage, we removed it? This meant, that all the time, every new dispenser only increased the storage scaling but it was never decreased.
3. references should best be explicitly nulled, the chem_storage is a link to an object
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Chem dispensers can be spawned mid-round and work right away without needing to have process pass.
Process has less machines that it constantly iterates over.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: init order for chem dispensers, round spawned dispensers now should directly get their storage
/:cl:
