### PR TITLE
Allows Two Chefs to spawn at anytime, and changes most comments in job.dm to be autodoc comments

### DIFF
--- a/code/game/jobs/job/civilians/other/mess_seargent.dm
+++ b/code/game/jobs/job/civilians/other/mess_seargent.dm
@@ -1,30 +1,13 @@
 /datum/job/civilian/chef
 	title = JOB_MESS_SERGEANT
 	total_positions = 2
-	spawn_positions = 1
+	spawn_positions = 2
 	allow_additional = TRUE
-	scaled = TRUE
 	selection_class = "job_ot"
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT
 	supervisors = "the auxiliary support officer"
 	gear_preset = /datum/equipment_preset/uscm_ship/chef
 	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>Your job is to service the marines with excellent food</a>, drinks and entertaining the shipside crew when needed. You have a lot of freedom and it is up to you, to decide what to do with it. Good luck!"
-
-/datum/job/civilian/chef/set_spawn_positions(count)
-	spawn_positions = mess_sergeant_slot_formula(count)
-
-/datum/job/civilian/chef/get_total_positions(latejoin = FALSE)
-	var/positions = spawn_positions
-	if(latejoin)
-		positions = mess_sergeant_slot_formula(get_total_marines())
-		if(positions <= total_positions_so_far)
-			positions = total_positions_so_far
-		else
-			total_positions_so_far = positions
-	else
-		total_positions_so_far = positions
-
-	return positions
 
 /obj/effect/landmark/start/chef
 	name = JOB_MESS_SERGEANT

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -1,30 +1,45 @@
 /datum/job
 	//The name of the job
-	var/title = null //The internal title for the job, used for the job ban system and so forth. Don't change these, change the disp_title instead.
-	var/disp_title //Determined on new(). Usually the same as the title, but doesn't have to be. Set this to override what the player sees in the game as their title.
-	var/role_ban_alternative // If the roleban title needs to be an extra check, like Xenomorphs = Alien.
 
-	var/total_positions = 0 //How many players can be this job
-	var/spawn_positions = 0 //How many players can spawn in as this job
-	var/total_positions_so_far = 0 //How many slots were open in this round. Used to prevent slots locking with decreasing amount of alive players
-	var/allow_additional = 0 //Can admins modify positions to it
+	///The internal title for the job, used for the job ban system and so forth. Don't change these, change the disp_title instead.
+	var/title = null
+	///Determined on new(). Usually the same as the title, but doesn't have to be. Set this to override what the player sees in the game as their title.
+	var/disp_title
+	///If the roleban title needs to be an extra check, like Xenomorphs = Alien.
+	var/role_ban_alternative
+
+	///How many players can be this job
+	var/total_positions = 0
+	///How many players can spawn in as this job
+	var/spawn_positions = 0
+	///How many slots were open in this round. Used to prevent slots locking with decreasing amount of alive players
+	var/total_positions_so_far = 0
+	/// Can admins modify positions to it
+	var/allow_additional = 0
+	///If it can be scaled with playercount
 	var/scaled = 0
-	var/current_positions = 0 //How many players have this job
-	var/supervisors = "" //Supervisors, who this person answers to directly. Should be a string, shown to the player when they enter the game.
-	var/selection_class = "" // Job Selection span class (for background color)
-
+	///How many players have this job
+	var/current_positions = 0
+	///Supervisors, who this person answers to directly. Should be a string, shown to the player when they enter the game.
+	var/supervisors = ""
+	/// Job Selection span class (for background color)
+	var/selection_class = ""
 	var/late_joinable = TRUE
 
-	var/flags_startup_parameters = NO_FLAGS //These flags are used to determine how to load the role, and some other parameters.
-	var/flags_whitelist = NO_FLAGS //Only used by whitelisted roles. Can be a single whitelist flag, or a combination of them.
+	///These flags are used to determine how to load the role, and some other parameters.
+	var/flags_startup_parameters = NO_FLAGS
+	///Only used by whitelisted roles. Can be a single whitelist flag, or a combination of them.
+	var/flags_whitelist = NO_FLAGS
 
-	//If you have use_timelocks config option enabled, this option will add a requirement for players to have the prerequisite roles have at least x minimum playtime before unlocking.
+	///If you have use_timelocks config option enabled, this option will add a requirement for players to have the prerequisite roles have at least x minimum playtime before unlocking.
 	var/list/minimum_playtimes
 
 	var/minimum_playtime_as_job = 3 HOURS
 
-	var/datum/equipment_preset/gear_preset //Gear preset name used for this job
-	var/list/gear_preset_whitelist = list()//Gear preset name used for council snowflakes ;)
+	///Gear preset name used for this job
+	var/datum/equipment_preset/gear_preset
+	///Gear preset name used for council snowflakes ;)
+	var/list/gear_preset_whitelist = list()
 
 	//For generating entry messages
 	var/entry_message_intro

--- a/code/game/jobs/slot_scaling.dm
+++ b/code/game/jobs/slot_scaling.dm
@@ -50,6 +50,3 @@
 
 /proc/working_joe_slot_formula(playercount)
 	return job_slot_formula(playercount,30,1,3,6)
-
-/proc/mess_sergeant_slot_formula(playercount)
-	return job_slot_formula(playercount, 70, 1, 1, 2)


### PR DESCRIPTION

# About the pull request

Title. A friend asked me to do this
This is for the poor starving marines of the USS Almayer

# Explain why it's good for the game

It is pretty rare to get two MSTs despite the fact that one is scaled to open at 70 marines. Sometimes, even at 130+ pop, you wouldn't even see two due to how it is coded to only prefer active marines rather than total playercount.

That said, I also think messtechs work better with pairs and having one experienced and one inexperienced messtech would lead to better outcomes, and if both are inexperienced, then the shenanigans would be welcome as well, probably.

Should be relatively harmless for balance

Also, makes job.dm comments into autodoc comments

# Testing Photographs and Procedure
It works, don't need a video for it

# Changelog
:cl:
balance: Two chefs can now spawn at anytime, regardless of scaling
code: Most Job.dm comments are now autodoc'd for convenience
/:cl:
