### PR TITLE
Fullbody facepaint point reduction

### DIFF
--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -1151,7 +1151,7 @@ GLOBAL_LIST_EMPTY(roles_with_gear)
 /datum/gear/misc/facepaint_body
 	display_name = "Fullbody paint"
 	path = /obj/item/facepaint/sniper
-	fluff_cost = 4 //To match with the skull paint amount of point, gave this amount of point for the same reason of the skull facepaint (too cool for everyone to be able to constantly use)
+	fluff_cost = 3
 
 /datum/gear/misc/jungle_boots
 	display_name = "Jungle pattern combat boots"


### PR DESCRIPTION
# About the pull request

Reduces the loadout point value of the fullbody facepaint (I.E: The sniper spec paint) to 3, the same as the skull facepaint.

# Explain why it's good for the game

Any PURELY cosmetic item that will mostly be covered by your helmet, mask, or even wounds that appear on your face costing 4 out of 7 loadout points is a bit over the top, especially considering camo facepaint is much more "grounded" and in keeping with CM's theme than the skull facepaint which as of now is CHEAPER in point cost.

Now you can have this facepaint along with two normal costing accessories of your choice, as opposed to just one.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

N/A

</details>

# Changelog
:cl:
balance: Reduces the loadout cost of fullbody paint to 3, in line with the skull paint.
/:cl: