### PR TITLE
Fixes the .38 revolver not tactically reloading

### DIFF
--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -587,7 +587,7 @@
 	fire_sound = 'sound/weapons/gun_44mag2.ogg'
 	current_mag = /obj/item/ammo_magazine/internal/revolver/small
 	force = 6
-	flags_gun_features = GUN_ANTIQUE|GUN_ONE_HAND_WIELDED|GUN_CAN_POINTBLANK
+	flags_gun_features = GUN_ANTIQUE|GUN_ONE_HAND_WIELDED|GUN_CAN_POINTBLANK|GUN_INTERNAL_MAG
 	trickster_gun = TRUE
 
 /obj/item/weapon/gun/revolver/small/set_gun_attachment_offsets()


### PR DESCRIPTION

# About the pull request

Title.

# Explain why it's good for the game

It apparently lacked the internal mag flag, which was required for those types of reloads, annoying

# Testing Photographs and Procedure
line change


# Changelog
:cl:
fix: The .38 revolver can now tactically reload properly.
/:cl:
