### PR TITLE
UBF reload with welding fuel

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -3352,8 +3352,8 @@ Defined in conflicts.dm of the #defines folder.
 
 		var/datum/reagent/to_remove = fuel_holder.reagents.reagent_list[1]
 
-		var/flamer_chem = "utnapthal"
-		if(!istype(to_remove) || flamer_chem != to_remove.id || length(fuel_holder.reagents.reagent_list) > 1)
+		var/list/flamer_chem = list("utnapthal","fuel")
+		if(!istype(to_remove) ||  !(to_remove.id in flamer_chem) || length(fuel_holder.reagents.reagent_list) > 1)
 			to_chat(user, SPAN_WARNING("You can't mix fuel mixtures!"))
 			return
 


### PR DESCRIPTION
# About the pull request

Underbarrel flamethrower can be reloaded with UT-Napthal m240 incinerator tanks or with various welder backpacks which contain welding fuel. But you cannot reload UBF with m240 tanks containing welding fuel.

This PR allows UBF to be reloaded with m240 tanks containing welding fuel.

# Explain why it's good for the game

Consistent behaviour is good. 

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

https://github.com/user-attachments/assets/4ad2d38c-90fe-4556-853c-2f093049e126

</details>


# Changelog

:cl: Labeo0
code: Can now reload UBF with welding fuel from m240 tank
/:cl: