### PR TITLE
Fixes new Unica revolvers having standard ammo in them

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -2102,7 +2102,7 @@
 			"icon_y" = -3))
 
 /obj/item/storage/belt/gun/mateba/full/fill_preset_inventory()
-	handle_item_insertion(new /obj/item/weapon/gun/revolver/mateba())
+	handle_item_insertion(new /obj/item/weapon/gun/revolver/mateba/impact())
 	new /obj/item/ammo_magazine/revolver/mateba/highimpact(src)
 	new /obj/item/ammo_magazine/revolver/mateba/highimpact(src)
 	new /obj/item/ammo_magazine/revolver/mateba/highimpact(src)

--- a/code/modules/gear_presets/survivors/lv_522/forcon_survivors.dm
+++ b/code/modules/gear_presets/survivors/lv_522/forcon_survivors.dm
@@ -276,7 +276,7 @@
 				sidearmbelt = /obj/item/storage/belt/gun/mateba/cmateba
 				sidearmammo = /obj/item/ammo_magazine/revolver/mateba
 			if(CO_GUN_MATEBA_CLASSIC)
-				sidearm = /obj/item/weapon/gun/revolver/mateba
+				sidearm = /obj/item/weapon/gun/revolver/mateba/impact
 				sidearmbelt = /obj/item/storage/belt/gun/mateba
 				sidearmammo = /obj/item/ammo_magazine/revolver/mateba
 			if(CO_GUN_2006M)

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -714,6 +714,9 @@
 /obj/item/weapon/gun/revolver/mateba/pmc
 	current_mag = /obj/item/ammo_magazine/internal/revolver/mateba/ap
 
+/obj/item/weapon/gun/revolver/mateba/impact
+	current_mag = /obj/item/ammo_magazine/internal/revolver/mateba/impact
+
 /obj/item/weapon/gun/revolver/mateba/general
 	name = "\improper golden Spearhead Unica-6 autorevolver custom"
 	desc = "Boasting a gold-plated frame and grips made of a critically-endangered rosewood tree, this heavily-customized Unica 6 autorevolver's pretentious design rivals only the power of its wielder. Fit for a king. Or a general."
@@ -842,7 +845,7 @@
 	usually comes with authentic wooden grips, engravings, or gold plating finish."
 	icon_state = "mateba_2006m"
 	item_state = "mateba_2006m"
-
+	current_mag = /obj/item/ammo_magazine/internal/revolver/mateba/impact
 	fire_sound = 'sound/weapons/gun_mateba_2006m.ogg'
 	chamber_close_sound = 'sound/weapons/gun_mateba_2006m_close_chamber.ogg'
 	unload_sound = 'sound/weapons/gun_mateba_2006m_open_chamber.ogg'


### PR DESCRIPTION

# About the pull request

Title

# Explain why it's good for the game

Oversight bad

# Changelog
:cl:
fix: fixed Unica 2006 and Unica 6 classic having normal ammo in them instead of impact like other CO guns
/:cl:
