### PR TITLE
remove command comms from IASF survs

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -1335,7 +1335,7 @@
 	desc = "A sleek headset used by the IASF. Low profile enough to fit under any headgear."
 	frequency = RMC_FREQ
 	icon_state = "vai_headset"
-	initial_keys = list(/obj/item/device/encryptionkey/public)
+	initial_keys = list(/obj/item/device/encryptionkey/colony)
 	has_hud = TRUE
 	hud_type = MOB_HUD_FACTION_IASF
 	additional_hud_types = list(MOB_HUD_FACTION_TWE, MOB_HUD_FACTION_IASF, MOB_HUD_FACTION_MARINE)


### PR DESCRIPTION

# About the pull request

IASF survivors spawn with an RMC radio key that gives them access to multiple almayer channels. This PR does not remove their access to the RMC frequency but it does remove their access to those channels.

# Explain why it's good for the game

survs generally should not be able to contact the almayer with a few notable exceptions.

<details>
<summary>Screenshots & Videos</summary>


</details>


# Changelog

:cl:
fix: IASF survs no longer have almayer command radio.
/:cl:
