### PR TITLE
Fix minor issue with general quarters

### DIFF
--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -1032,7 +1032,8 @@ GLOBAL_LIST_EMPTY_TYPED(active_overwatch_consoles, /obj/structure/machinery/comp
 				log_ares_security("Manual Security Update", "Changed the security level to red.", user)
 				if(!COOLDOWN_FINISHED(datacore, ares_quarters_cooldown))
 					set_security_level(SEC_LEVEL_RED, no_sound = FALSE, announce = TRUE)
-				else set_security_level(SEC_LEVEL_RED, no_sound = TRUE, announce = FALSE)
+				else
+					set_security_level(SEC_LEVEL_RED, no_sound = TRUE, announce = FALSE)
 			if(!COOLDOWN_FINISHED(datacore, ares_quarters_cooldown))
 				to_chat(user, SPAN_WARNING("It has not been long enough since the last General Quarters call!"))
 				playsound(src, 'sound/machines/buzz-two.ogg', 15, 1)


### PR DESCRIPTION

# About the pull request

If general quarters is on cooldown and someone attempts to call general quarters, red alert will be announced if it's not already red alert. (minor issue with my PR https://github.com/cmss13-devs/cmss13/pull/10645 )

# Explain why it's good for the game

fixes edge case


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: If general quarters is on cooldown and someone attempts to call general quarters, red alert will be announced if it's not already red alert
/:cl:
