### PR TITLE
Reduces A50 impact round power

### DIFF
--- a/code/datums/ammo/bullet/rifle.dm
+++ b/code/datums/ammo/bullet/rifle.dm
@@ -174,22 +174,25 @@
 	shell_speed = AMMO_SPEED_TIER_6
 
 /datum/ammo/bullet/rifle/m4ra/impact/on_hit_mob(mob/M, obj/projectile/P)
-	knockback(M, P, 32) // Can knockback basically at max range max range is 24 tiles...
+	knockback(M, P, 24) // Can knockback basically at max range
 
 /datum/ammo/bullet/rifle/m4ra/impact/knockback_effects(mob/living/living_mob, obj/projectile/fired_projectile)
+	var/effectiveness = clamp(1.7-(fired_projectile.distance_travelled*0.1), 0.1, 1)
 	if(iscarbonsizexeno(living_mob))
 		var/mob/living/carbon/xenomorph/target = living_mob
 		to_chat(target, SPAN_XENODANGER("You are shaken and slowed by the sudden impact!"))
-		target.KnockDown(0.5-fired_projectile.distance_travelled/100) // purely for visual effect, noone actually cares
-		target.Stun(0.5-fired_projectile.distance_travelled/100)
-		target.apply_effect(2-fired_projectile.distance_travelled/20, SUPERSLOW)
-		target.apply_effect(5-fired_projectile.distance_travelled/10, SLOW)
+		target.KnockDown(0.5 * effectiveness) // purely for visual effect, noone actually cares
+		target.Stun(0.5 * effectiveness)
+		target.Superslow(1 * effectiveness)
+		target.Slow(2 * effectiveness)
 	else
 		if(!isyautja(living_mob)) //Not predators.
-			living_mob.apply_effect(1, SUPERSLOW)
-			living_mob.apply_effect(2, SLOW)
-			to_chat(living_mob, SPAN_HIGHDANGER("The impact knocks you off-balance!"))
+			living_mob.Superslow(1)
+			living_mob.Slow(2)
+		shake_camera(living_mob, 2, 1)
+		living_mob.sway_jitter(2,1)
 		living_mob.apply_stamina_damage(fired_projectile.ammo.damage, fired_projectile.def_zone, ARMOR_BULLET)
+		to_chat(living_mob, SPAN_HIGHDANGER("The impact knocks you off-balance!"))
 
 /datum/ammo/bullet/rifle/mar40
 	name = "heavy rifle bullet"


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->
-new range calculations for impact rounds. ( 7 tiles of range , after 7 tiles you loose 10% power per tile traveled to a minimun of 10%).
-adds some effects for humanoid hits.
-impacts rounds now give "off balance" message to predators.
-Reduces Superslow to 2 seconds.
-Reduces slowdown to 4 seconds.


# Explain why it's good for the game
Impact rounds are really unfun to be on the receiving end . the massive slowdown guarantees a permanent stunlock , this PR aims to give xenomorphs a chance by reducing the lenght of the slowdown while keeping the stun capabilities.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Adds effects for A19 impact bullet humanoid targets.
balance: Reduces A19 impact bullet superslow to 2 seconds.
balance: Reduces A19 impact bullet slow to 4 seconds.
code: changed range calculations of A19 impact bullet.
/:cl:
