### PR TITLE
Gas trap buff & neuro smoke tweaks

### DIFF
--- a/code/datums/effects/neurotoxin.dm
+++ b/code/datums/effects/neurotoxin.dm
@@ -95,12 +95,13 @@
 
 	if(duration >= 27) // 5+ ticks in smoke, you are ODing now
 		affected_mob.apply_effect(1, DAZE) // Unable to talk and weldervision
-		affected_mob.apply_damage(2,TOX)
+		affected_mob.apply_damage(1,TOX)
 		affected_mob.SetEarDeafness(max(affected_mob.ear_deaf, floor(strength*1.5))) //Paralysis of hearing system, aka deafness
 
 	if(duration >= 50) // 10+ ticks, apply organ damage
-		affected_mob.apply_internal_damage(3,"liver")
-		affected_mob.apply_damage(3, BRAIN)
+		affected_mob.apply_internal_damage(1,"liver")
+		affected_mob.apply_damage(1, BRAIN)
+		affected_mob.KnockOut(2) // sleepy time
 	// Applying additonal effects and messages
 	if(prob(stumble_prob) && stumble)
 		if(affected_mob.is_mob_incapacitated())

--- a/code/datums/effects/neurotoxin.dm
+++ b/code/datums/effects/neurotoxin.dm
@@ -98,9 +98,9 @@
 		affected_mob.apply_damage(2,TOX)
 		affected_mob.SetEarDeafness(max(affected_mob.ear_deaf, floor(strength*1.5))) //Paralysis of hearing system, aka deafness
 
-	if(duration >= 50) // 10+ ticks, apply some semi-perm damage and end their suffering if they are somehow still alive by now
-		affected_mob.apply_internal_damage(10,"liver")
-		affected_mob.apply_damage(150,OXY)
+	if(duration >= 50) // 10+ ticks, apply organ damage
+		affected_mob.apply_internal_damage(3,"liver")
+		affected_mob.apply_damage(3, BRAIN)
 	// Applying additonal effects and messages
 	if(prob(stumble_prob) && stumble)
 		if(affected_mob.is_mob_incapacitated())

--- a/code/datums/effects/neurotoxin.dm
+++ b/code/datums/effects/neurotoxin.dm
@@ -94,13 +94,14 @@
 		affected_mob.eye_blind = max(affected_mob.eye_blind, floor(strength/4))
 
 	if(duration >= 27) // 5+ ticks in smoke, you are ODing now
-		affected_mob.apply_effect(1, DAZE) // Unable to talk and weldervision
-		affected_mob.apply_damage(1,TOX)
+		affected_mob.apply_effect(1,DAZE) // Unable to talk and weldervision
+		affected_mob.apply_damage(2,TOX)
 		affected_mob.SetEarDeafness(max(affected_mob.ear_deaf, floor(strength*1.5))) //Paralysis of hearing system, aka deafness
 
-	if(duration >= 50) // 10+ ticks, apply organ damage
-		affected_mob.apply_internal_damage(1,"liver")
-		affected_mob.apply_damage(1, BRAIN)
+	if(duration >= 50) // 10+ ticks, apply organ damage , death after 2 ticks
+		affected_mob.apply_internal_damage(5,"liver")
+		affected_mob.apply_damage(20,TOX)
+		affected_mob.apply_damage(20,OXY)
 		affected_mob.KnockOut(2) // sleepy time
 	// Applying additonal effects and messages
 	if(prob(stumble_prob) && stumble)

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -625,7 +625,7 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	if(moob.stat == DEAD || moob.stat == UNCONSCIOUS)
+	if(moob.stat == DEAD)
 		return FALSE
 	if(isxeno(moob))
 		return FALSE

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -625,7 +625,7 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	if(moob.stat == DEAD)
+	if(moob.stat == DEAD || moob.stat == UNCONSCIOUS)
 		return FALSE
 	if(isxeno(moob))
 		return FALSE

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -643,7 +643,8 @@
 	var/effect_amt = floor(6 + amount*6)
 	moob.eye_blurry = max(moob.eye_blurry, effect_amt)
 	moob.EyeBlur(max(moob.eye_blurry, effect_amt))
-	moob.apply_damage(5, OXY) //  Base "I can't breath oxyloss" Slightly more longer lasting then stamina damage
+	if(moob.getOxyLoss() <= 60)
+		moob.apply_damage(5, OXY) //  Base "I can't breath oxyloss" Slightly more longer lasting then stamina damage
 	// reworked code below
 	if(!issynth(moob))
 		var/datum/effects/neurotoxin/neuro_effect = locate() in moob.effects_list

--- a/code/modules/cm_aliens/structures/trap.dm
+++ b/code/modules/cm_aliens/structures/trap.dm
@@ -178,7 +178,7 @@
 				for(var/mob/living/carbon/humanus in range(1,loc))
 					humanus.Stun(1)
 					humanus.Superslow(2)
-					to_chat(humanus, SPAN_DANGER("You freeze in confusion as the trap hisses beneath your foot, releasing a cloud of gas."))
+					to_chat(humanus, SPAN_DANGER("You freeze in shock as the trap hisses beneath your foot, releasing a cloud of gas."))
 				trap_type_name = "gas"
 				smoke_system.set_up(smoke_radius, 0, src.loc)
 				smoke_system.start()

--- a/code/modules/cm_aliens/structures/trap.dm
+++ b/code/modules/cm_aliens/structures/trap.dm
@@ -16,6 +16,7 @@
 	var/trap_type = RESIN_TRAP_EMPTY
 	var/armed = 0
 	var/created_by // ckey
+	var/smoke_radius = 2
 	var/list/notify_list = list() // list of xeno mobs to notify on trigger
 	var/datum/effect_system/smoke_spread/smoke_system
 	var/datum/cause_data/cause_data
@@ -171,9 +172,17 @@
 			if(FH.stat == CONSCIOUS && FH.loc) //Make sure we're conscious and not idle or dead.
 				FH.leap_at_nearest_target()
 		if(RESIN_TRAP_GAS)
-			trap_type_name = "gas"
-			smoke_system.set_up(2, 0, src.loc)
-			smoke_system.start()
+			if(smoke_system)
+				if(smoke_system == /datum/effect_system/smoke_spread/xeno_weaken)
+					smoke_radius = 3
+				for(var/mob/living/carbon/humanus in range(1,loc))
+					humanus.Stun(1)
+					humanus.Superslow(2)
+					to_chat(humanus, SPAN_DANGER("You freeze in confusion as the trap hisses beneath your foot, releasing a cloud of gas."))
+				trap_type_name = "gas"
+				smoke_system.set_up(smoke_radius, 0, src.loc)
+				smoke_system.start()
+
 			set_state()
 			clear_tripwires()
 		if(RESIN_TRAP_ACID1, RESIN_TRAP_ACID2, RESIN_TRAP_ACID3)


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->
Neuro smoke will no longer kill humans , the smoke will stop doing damage when the mob falls unconscious.
Boiler gas traps now have a brief stun and slow to allow the smoke to do its effects.
Neuro smoke traps now have 1 more radius than acid traps ( non lethal = bigger , same as globs work)

# Explain why it's good for the game
Neuro smoke killing humans that fall inside of it goes against the purpose of the gas type. this PR fixes that by adding a check so it stops before killing the host.

Smoke traps are on a very rought spot , since the smoke requires a couple ticks to apply the lack of stun makes them entirely useless. this PR aims to give them a little boost for boilers to experiment.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Makes neurotoxin traps bigger.
balance: Adds a brief stun to xenomorph gas traps.
balance: Neurotoxin smoke now does toxin damage at the final stage instead of only oxygen
/:cl:
