### PR TITLE
Fixing a bug where when you take off your welding glasses, your vision remains obstructed.

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -128,13 +128,16 @@
 	..()
 
 /obj/item/clothing/glasses/dropped(mob/living/carbon/human/user)
-	if(istype(user) && src == user.glasses)
+	var/was_active = active
+	if(src == user.glasses)
 		if(hud_type && active)
 			var/datum/mob_hud/H = GLOB.huds[hud_type]
 			H.remove_hud_from(user, src)
 		user.glasses = null
 		user.update_inv_glasses()
 	user.update_sight()
+	if(was_active)
+		user.update_tint()
 	return ..()
 
 /obj/item/clothing/glasses/attack_self(mob/user)


### PR DESCRIPTION
Added logic to update tint when glasses are dropped if they were active.
# About the pull request
Fixing a bug where when you take off your welding glasses, your vision remains obstructed.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixing a bug where when you take off your welding glasses, your vision remains obstructed.
/:cl:
