### PR TITLE
Observer/Admin/Predator infected hud icon colors

### DIFF
--- a/code/datums/mob_hud.dm
+++ b/code/datums/mob_hud.dm
@@ -466,6 +466,7 @@ GLOBAL_LIST_INIT_TYPED(huds, /datum/mob_hud, list(
 
 				if(hive && hive.color)
 					holder3.color = hive.color
+					holder2.color = hive.color
 
 				if(stat == DEAD || status_flags & FAKEDEATH)
 					holder2.alpha = 100


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

The xenohud infected icon that is seen by Observers,Admins and people wearing a clan mask (Predators) will now change colors depending on the hive the person is infected with.

# Explain why it's good for the game

I wanted ghosts gain extra information regarding infected people, this is a nice compromise compared to getting the full infection status (their stage progression) like xenos get as I think that may provide a bit too much information (they could meta their exact stage etc. and anyone wearing a clan mask would also be able to know the exact progression stage)

With this, they may only know to which hive the embryo belongs to, also useful for admins to quickly know without needing to become a xeno or VV to check which hive it belongs to.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

<img width="402" height="96" alt="Screenshot_46" src="https://github.com/user-attachments/assets/edeeb562-e74e-45b3-b222-876f844d9985" />

in order of hive: Alpha, Prime (normal), Corrupted, Bravo, Charlie, Delta

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Unknownity
add: The observer xeno infection icon now changes colors depending on the hive of the embryo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
