### PR TITLE
Fix health scan unnecessary updates + Ghost autoupdate

### DIFF
--- a/code/modules/mob/living/living_healthscan.dm
+++ b/code/modules/mob/living/living_healthscan.dm
@@ -56,7 +56,7 @@ GLOBAL_LIST_INIT(known_implants, subtypesof(/obj/item/implant))
 	if(!ui)
 		ui = new(user, src, "HealthScan", "Health Scan")
 		ui.open()
-		ui.set_autoupdate(FALSE)
+		ui.set_autoupdate(isobserver(user))
 
 /**
  * Returns TRUE if the target is either dead or appears to be dead.


### PR DESCRIPTION
# About the pull request

This PR makes it where the health scan UI only updates relevant data when performing its `ui_act`. Should be more performant (at least for non-ghosts), turns on autoupdate for ghosts, and fixes the below exploit(s).

# Explain why it's good for the game

Fixes #10813
Fixes #9207
Fixes #8112

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/eVLKHVAykEU

</details>


# Changelog
:cl: Drathek
fix: Fixed health scans performing new scans just by changing holocard or minimal hud mode
qol: Healthscan now autoupdates for ghosts
/:cl:
