### PR TITLE
remove urban intel helmet from synth loadout

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/synthetic.dm
+++ b/code/game/machinery/vending/vendor_types/crew/synthetic.dm
@@ -606,9 +606,6 @@ GLOBAL_LIST_INIT(cm_vending_clothing_synth, list(
 /datum/gear/synthetic/helmet/marine_intel_desert
 	path = /obj/item/clothing/head/helmet/marine/rto/intel/desert
 
-/datum/gear/synthetic/helmet/marine_intel_urban
-	path = /obj/item/clothing/head/helmet/marine/rto/intel/urban
-
 /datum/gear/synthetic/helmet/marine_mp
 	path = /obj/item/clothing/head/helmet/marine/MP
 


### PR DESCRIPTION

# About the pull request

removed for the same reason the blue faceshield etc was; approved by senator.

<img width="89" height="78" alt="image" src="https://github.com/user-attachments/assets/0739acdb-eae7-4ab1-a034-d4fc8f32ea2e" />


(this one specifically.)

# Changelog
:cl:
del: removed an aesthetically clashing helmet from the synth loadout screen.
/:cl:
