### PR TITLE
Yet another quadtree runtime fix

### DIFF
--- a/code/datums/quadtree.dm
+++ b/code/datums/quadtree.dm
@@ -221,7 +221,7 @@
 			continue
 		if(range.contains_coords(quad_player))
 			if(flags & QTREE_SCAN_MOBS)
-				if(quad_player.player.mob != quad_player.weak_mob.resolve())
+				if(!quad_player.player.mob || quad_player.player.mob != quad_player.weak_mob?.resolve())
 					continue
 				found_players.Add(quad_player.player.mob)
 			else


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #11099 where I see another runtime where a weakref is missing in the quadtree. What this should mean is that the mob was qdeleted when the quadtrees fired thus preventing a weakref from being returned when calling `WEAKREF`; but since right now our quadtrees monitors clients, its not like its necessarily incorrect that a client could have a deleted mob...

# Explain why it's good for the game

Should fix 
<img width="1004" height="269" alt="image" src="https://github.com/user-attachments/assets/650da58d-d01f-4ef0-ab79-ea3f40a88ee9" />

# Testing Photographs and Procedure
Will just monitor runtimes in the future after merge.

# Changelog
:cl: Drathek
fix: Fixed an edgecase where quadtree results would fail because a qdeleted mob was in the tree
/:cl:
