### PR TITLE
Changes combistick block chance from 66% to 10%

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -97,7 +97,7 @@ Contains most of the procs that are called when a mob is attacked by something
 	var/block_effect = /obj/effect/block
 	var/owner_turf = get_turf(src)
 	if(l_hand && istype(l_hand, /obj/item/weapon))//Current base is the prob(50-d/3)
-		if(combistick && istype(l_hand,/obj/item/weapon/yautja/chained/combistick) && prob(15))
+		if(combistick && istype(l_hand,/obj/item/weapon/yautja/chained/combistick) && prob(10))
 			var/obj/item/weapon/yautja/chained/combistick/C = l_hand
 			if(C.on)
 				return TRUE
@@ -126,7 +126,7 @@ Contains most of the procs that are called when a mob is attacked by something
 			return TRUE
 
 	if(r_hand && istype(r_hand, /obj/item/weapon))
-		if(combistick && istype(r_hand,/obj/item/weapon/yautja/chained/combistick) && prob(15))
+		if(combistick && istype(r_hand,/obj/item/weapon/yautja/chained/combistick) && prob(10))
 			var/obj/item/weapon/yautja/chained/combistick/C = r_hand
 			if(C.on)
 				return TRUE


### PR DESCRIPTION
# About the pull request
Title
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Outdated balancing, back from when you get hit once with a glaive and you're dead, encourages people to bring the combi more as they aren't deterred from it being classed as a "slimer weapon", asked other people around and they agree the block chance is the most egregious part of it right now and the reason they don't consider it as a weapon choice, will ask that Joelampost or forest look over this before its considered

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
balance: Combistick block chance 66% to 10%
/:cl:

