### PR TITLE
Fixing my messed up shuttle PR

### DIFF
--- a/code/datums/emergency_calls/bodyguard.dm
+++ b/code/datums/emergency_calls/bodyguard.dm
@@ -4,6 +4,7 @@
 	mob_min = 1
 	shuttle_id = MOBILE_SHUTTLE_ID_ERT2
 	home_base = /datum/lazy_template/ert/weyland_station
+	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_pmc
 	ert_message = "A corporate security beacon has been activated!"
 	var/equipment_preset = /datum/equipment_preset/wy/security
 	var/equipment_preset_leader = /datum/equipment_preset/wy/security

--- a/code/datums/emergency_calls/goons.dm
+++ b/code/datums/emergency_calls/goons.dm
@@ -3,6 +3,7 @@
 	mob_max = 6
 	probability = 0
 	shuttle_id = MOBILE_SHUTTLE_ID_ERT2
+	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_pmc
 	home_base = /datum/lazy_template/ert/weyland_station
 
 /datum/emergency_call/goon/New()


### PR DESCRIPTION
# About the pull request
@Blundir 
Fixes #11151 

So I seem to have messed up in the testing phase and was on the wrong branch. The chem-goons and bodyguards spawned on the old ERT base instead of on a shuttle in the air on it's way to the Almayer. This PR is a quick hotfix to this issue.

# Changelog
:cl:
fix: The Chem-Goons and Bodyguards now spawn properly.
/:cl: