### PR TITLE
allows medkit pouch to hold scalpel hemostat and retractor

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -977,6 +977,9 @@
 		/obj/item/bodybag = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
 		/obj/item/reagent_container/blood = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
 		/obj/item/tool/surgery/FixOVein = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
+		/obj/item/tool/surgery/scalpel = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
+		/obj/item/tool/surgery/hemostat = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
+		/obj/item/tool/surgery/retractor = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
 	)
 	can_hold_skill_only = TRUE
 	instant_pill_grabbable = TRUE // If TRUE, pills can be taken directly from bottles while in hand/equipped.


### PR DESCRIPTION

# About the pull request

allows medkit pouch to hold the rest of the medic surgery tools

# Explain why it's good for the game

more options for medic loudout, the medkit pouch can already hold fixovein and the lines with only 7 slots so this should be fine


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: allows medkit pouch to hold scalpel, hemostat, and retractor
/:cl:
