### PR TITLE
Remove unnecessary lobby xeno latejoin call

### DIFF
--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -170,17 +170,13 @@
 				return FALSE
 
 			if(SSticker.mode.check_xeno_late_join(src))
-				var/mob/new_xeno = SSticker.mode.attempt_to_join_as_xeno(src, FALSE)
+				var/new_xeno = SSticker.mode.attempt_to_join_as_xeno(src, FALSE)
 				if(!new_xeno)
 					lobby_confirmation_message = list(
 						"Are you sure you wish to observe to be a xeno candidate?",
 						"When you observe, you will not be able to join as marine.",
 						"It might also take some time to become a xeno or responder!")
 					execute_on_confirm = CALLBACK(src, PROC_REF(observe_for_xeno))
-
-				else if(!istype(new_xeno, /mob/living/carbon/xenomorph/larva))
-					SSticker.mode.transfer_xeno(src, new_xeno)
-
 				return TRUE
 
 		if("late_join_pred")


### PR DESCRIPTION

# About the pull request

This PR removes an unnecessary call for late joining as a xeno from lobby. Some reason Harry thought that `attempt_to_join_as_xeno` returned a mob, and if that returned mob wasn't larva it would need a `transfer_xeno` call.

But there shouldn't be any behavior change from this change because returning FALSE would just trigger the observe message. Returning TRUE would attempt `/datum/game_mode/proc/transfer_xeno(xeno_candidate, mob/living/carbon/xenomorph/new_xeno)` where `new_xeno` is `TRUE` but that then wouldn't pass `if(!xeno_candidate || !isxeno(new_xeno) || QDELETED(new_xeno))` so it would do nothing anyways.

# Explain why it's good for the game

Less dead code.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/gx3yR95evIM

</details>


# Changelog

No player facing changes.
