### PR TITLE
Fixes delimb immunity by having burn damage

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -377,7 +377,7 @@
 	var/no_perma_damage = owner.status_flags & NO_PERMANENT_DAMAGE
 	var/no_bone_break = owner.chem_effect_flags & CHEM_EFFECT_RESIST_FRACTURE
 	if(previous_brute > 0 && !is_ff && body_part != BODY_FLAG_CHEST && body_part != BODY_FLAG_GROIN && !no_limb_loss && !no_perma_damage && !no_bone_break)
-		if(CONFIG_GET(flag/limbs_can_break) && brute_dam >= max_damage * CONFIG_GET(number/organ_health_multiplier) && (previous_bonebreak || (status & (LIMB_ROBOT|LIMB_SYNTHSKIN)))) //delimbable only if broken before this hit or we're a robot limb (synths do not fracture)
+		if(CONFIG_GET(flag/limbs_can_break) && (brute_dam + burn_dam) >= max_damage * CONFIG_GET(number/organ_health_multiplier) && (previous_bonebreak || (status & (LIMB_ROBOT|LIMB_SYNTHSKIN)))) //delimbable only if broken before this hit or we're a robot limb (synths do not fracture)
 			var/cut_prob = brute/max_damage * 5
 			if(prob(cut_prob))
 				limb_delimb(damage_source)


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

It is possible to make your limb immune to delimbing if it has any burn damage.

Now instead of checking if all the damage on the limb is brute, we check total damage on the limb and if it's capped out (max damage achieved on limb)

~~It's the third time I'm fixing this bug with my travels across the realms of SS13.~~

# Explain why it's good for the game
Probably not expected behaviour; making yourself immune to delimbing by taking 1 burn damage is not expected behaviour?

# Testing Photographs and Procedure
* Make delimb chance 100% via code
* Apply burn damage to head with Welding Tool
* Be xeno, target head
* Attack head till fracture, fracture head
* Attack head after fracture, head is delimbed (wasn't delimbing before this fix)

# Changelog
:cl:
fix: Delimbing now requires to have total limb damage to be maxed out instead of all limb damage to be brute. It still requires brute attack for a chance to delimb.
/:cl:
