### PR TITLE
Mutated Larva correct icon on chestburst

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Embryo.dm
@@ -257,7 +257,7 @@
 		new_xeno = new(affected_mob)
 
 	if(hive)
-		hive.add_xeno(new_xeno)
+		new_xeno.set_hive_and_update(hive.hivenumber)
 		if(!affected_mob.first_xeno && hive.hive_location && !ismonkey(affected_mob))
 			hive.increase_larva_after_burst(is_nested)
 			hive.hive_ui.update_burrowed_larva()


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Chestbursted Mutated Larva will now correctly have Mutated icons.

Now uses set_hive_and_update on spawning the larva to add traits.

# Explain why it's good for the game
Cool Mutated Larva > Sad Green Normal Larva

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="205" height="336" alt="image" src="https://github.com/user-attachments/assets/ef7349a6-95c2-40ae-b332-6b37557fd3cf" />

</details>


# Changelog
:cl:
fix: Chestbursting mutated larva will now have mutated icon.
/:cl:
