### PR TITLE
Mutated Pixel Offsets

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -319,6 +319,8 @@
 
 	var/icon_xeno
 	var/icon_xenonid
+	var/xenonid_pixel_x
+	var/xenonid_pixel_y
 	/// Stores the overlay icon for spitting/drooling when acid-based abilities are selected
 	var/acid_overlay
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Burrower.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Burrower.dm
@@ -47,6 +47,7 @@
 	plasma_types = list(PLASMA_PURPLE)
 	pixel_x = -12
 	old_x = -12
+	xenonid_pixel_x = -16
 	base_pixel_x = 0
 	base_pixel_y = -20
 	tier = 2

--- a/code/modules/mob/living/carbon/xenomorph/castes/Drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Drone.dm
@@ -57,6 +57,7 @@
 	organ_value = 800
 	pixel_x = -12
 	old_x = -12
+	xenonid_pixel_x = -8
 	base_actions = list(
 		/datum/action/xeno_action/onclick/xeno_resting,
 		/datum/action/xeno_action/onclick/release_haul,

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -29,6 +29,8 @@
 	pixel_y = -6
 	old_x = -8
 	old_y = -6
+	xenonid_pixel_x = -1
+	xenonid_pixel_y = 0
 	layer = MOB_LAYER
 	mob_flags = NOBIOSCAN
 	see_in_dark = 8

--- a/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Lurker.dm
@@ -37,6 +37,7 @@
 	plasma_types = list(PLASMA_CATECHOLAMINE)
 	pixel_x = -12
 	old_x = -12
+	xenonid_pixel_x = -9
 	tier = 2
 	organ_value = 2000
 	base_actions = list(

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -279,6 +279,7 @@
 	wall_smash = 0
 	pixel_x = -29 //new offsets for the much bigger sprite.
 	old_x = -29
+	xenonid_pixel_x = -16
 	mob_size = MOB_SIZE_IMMOBILE
 	drag_delay = 6 //pulling a big dead xeno is hard
 	tier = 0 //Queen doesn't count towards population limit.

--- a/code/modules/mob/living/carbon/xenomorph/castes/Sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Sentinel.dm
@@ -38,6 +38,7 @@
 	plasma_types = list(PLASMA_NEUROTOXIN)
 	pixel_x = -12
 	old_x = -12
+	xenonid_pixel_x = -9
 	tier = 1
 	organ_value = 800
 	base_actions = list(

--- a/code/modules/mob/living/carbon/xenomorph/castes/Spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Spitter.dm
@@ -38,6 +38,7 @@
 	plasma_types = list(PLASMA_NEUROTOXIN)
 	pixel_x = -12
 	old_x = -12
+	xenonid_pixel_x = -9
 	organ_value = 2000
 	tier = 2
 	base_actions = list(

--- a/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
@@ -44,6 +44,7 @@
 	icon = 'icons/mob/xenos/castes/tier_1/drone.dmi'
 	icon_size = 48
 	icon_state = "Lesser Drone Walking"
+	xenonid_pixel_x = -9
 	plasma_types = list(PLASMA_PURPLE)
 	tier = 0
 	mob_flags = NOBIOSCAN

--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -29,17 +29,32 @@
 
 /mob/living/carbon/xenomorph/proc/update_icon_source()
 	if(HAS_TRAIT(src, TRAIT_XENONID))
-		icon = icon_xenonid
+		if(!icon_xenonid)
+			color = hive.color
+		else
+			icon = icon_xenonid
 		if(isqueen(src))
 			var/mob/living/carbon/xenomorph/queen/Q = src
 			Q.queen_standing_icon = icon_xenonid
 			Q.queen_ovipositor_icon = 'icons/mob/xenonids/castes/tier_4/ovipositor.dmi'
+		if(!isnull(xenonid_pixel_x))
+			old_x = xenonid_pixel_x
+			pixel_x = xenonid_pixel_x
+		if(!isnull(xenonid_pixel_y))
+			old_y = xenonid_pixel_y
+			pixel_y = xenonid_pixel_y
 	else
 		icon = icon_xeno
 		if(isqueen(src))
 			var/mob/living/carbon/xenomorph/queen/Q = src
 			Q.queen_standing_icon = icon_xeno
 			Q.queen_ovipositor_icon = 'icons/mob/xenos/castes/tier_4/ovipositor.dmi'
+		if(!isnull(xenonid_pixel_x))
+			old_x = src::old_x
+			pixel_x = src::pixel_x
+		if(!isnull(xenonid_pixel_y))
+			old_y = src::old_y
+			pixel_y = src::pixel_y
 
 	var/mutation_caste_state = "[get_strain_icon()] [caste.caste_type]"
 	if(!walking_state_cache[mutation_caste_state])


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Re-centers Mutated xeno icons and fixes invisible Mutated King.

Adds a new variable for xenos for mutated pixel offsets.
Also adds a failsafe if the icon is missing - mutated king is now visible.

# Explain why it's good for the game
Centered icons is good for perceiving... the center of the mob.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

## BEFORE

<img width="760" height="296" alt="Screenshot_40" src="https://github.com/user-attachments/assets/230b7483-ecfc-4d63-b6db-42a6d0774fae" />

<img width="767" height="345" alt="Screenshot_41" src="https://github.com/user-attachments/assets/7072566e-abc5-4314-a0b4-8dfa3202d2b3" />

## AFTER

<img width="838" height="205" alt="Screenshot_38" src="https://github.com/user-attachments/assets/90fe66e3-a1f9-4112-8fc5-0eddbc9756de" />

<img width="889" height="294" alt="Screenshot_39" src="https://github.com/user-attachments/assets/04a778b6-2e45-4025-b6f5-4c798e1f276c" />

</details>


# Changelog
:cl:
fix: Mutated King is now visible.
fix: Mutated Lesser Drone, Drone, Facehugger, Burrower, Sentinel, Spitter, Lurker and Queen had their icons re-centered.
/:cl:
