### PR TITLE
fix broken synth/pred character creator preview

### DIFF
--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -198,8 +198,6 @@
 	if(refresh_limb_status)
 		for(var/obj/limb/L in preview_dummy.limbs)
 			L.status = LIMB_ORGANIC
-//	for(var/obj/limb/L in preview_dummy.limbs)
-//		L.blocks_emissive = EMISSIVE_BLOCK_NONE
 	preview_dummy.set_species()
 	copy_appearance_to(preview_dummy)
 	preview_dummy.update_body()


### PR DESCRIPTION

# About the pull request

set_species() was overriding the code that removed emissive blockers from dummy icons-- I don't super love regenerating all the icons again afterwards (arm_equipment() already does this) but it's the cleanest way *I* could think of to resolve this without introducing hacky code elsewhere.

# Explain why it's good for the game

fixes:#11109


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

<img width="1148" height="976" alt="image" src="https://github.com/user-attachments/assets/5cc7f8cf-d15a-4bd7-8c89-5c8e74588170" />

<img width="1286" height="1042" alt="image" src="https://github.com/user-attachments/assets/b777fca6-23c6-4807-abe0-1074ac06dfae" />

<img width="1267" height="1007" alt="image" src="https://github.com/user-attachments/assets/88bb4f7c-674e-4030-bd96-6cc07613c199" />

</details>


# Changelog

:cl:
fix: character previews for non-human jobs work again.
/:cl:

