### PR TITLE
Makes it so you can't tackle people dragging caps unless queen

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/XenoAttacks.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoAttacks.dm
@@ -212,7 +212,7 @@
 
 			if(!can_resist_shove && pulling && ishuman(pulling))
 				var/mob/living/carbon/human/pulled_human = pulling
-				if(!is_shover_queen && pulled_human.stat == ALIVE)
+				if(!is_shover_queen && pulled_human.stat != DEAD)
 					can_resist_shove = TRUE
 					to_chat(xeno, SPAN_WARNING("We cannot tackle sisters pulling living hosts!"))
 


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Number 1 cause of lost captures.

It's frustrating when we have multiple xenomorphs tackling a person and they misclick the person trying to devour the capture, leading to lost captures. This is especially bad depending the caste as some have sprites overlapping onto other tiles, not to mentional directional slash assist sometimes messes things up.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: You cannot shove people dragging captures unless you're the Queen.
/:cl:
