### PR TITLE
Fix: Multi-Z stairs not working after an explosion damages their tile

### DIFF
--- a/code/__DEFINES/dcs/signals/atom/signals_atom.dm
+++ b/code/__DEFINES/dcs/signals/atom/signals_atom.dm
@@ -24,8 +24,8 @@
 ///from /atom/hitby(): (atom/movable/AM)
 #define COMSIG_ATOM_HITBY "atom_hitby"
 
-///from /turf/ChangeTurf
-#define COMSIG_ATOM_TURF_CHANGE "movable_turf_change"
+///from /turf/ChangeTurf: (atom/movable/source, turf/turf)
+#define COMSIG_ATOM_TURF_CHANGE "atom_turf_change"
 
 //from atom/set_light(): (l_range, l_power, l_color)
 #define COMSIG_ATOM_SET_LIGHT "atom_set_light"

--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -394,7 +394,6 @@
 /obj/structure/stairs/multiz/proc/on_turf_changed()
 	SIGNAL_HANDLER
 	RegisterSignal(loc, COMSIG_TURF_ENTERED, PROC_REF(on_turf_entered))
-	RegisterSignal(src, COMSIG_ATOM_TURF_CHANGE, PROC_REF(on_turf_changed))
 
 /obj/structure/stairs/multiz/proc/on_turf_entered(turf/source, atom/movable/enterer)
 	SIGNAL_HANDLER
@@ -537,14 +536,24 @@
 					continue
 
 				LAZYADD(from_turf_to_images["\ref[turf]"], destination_turf_images["\ref[to_turf]"])
-				RegisterSignal(turf, COMSIG_ATOM_TURF_CHANGE, PROC_REF(on_turf_changed), TRUE)
 				RegisterSignal(turf, COMSIG_TURF_ENTERED, PROC_REF(handle_entered), TRUE)
+				RegisterSignal(turf, COMSIG_PARENT_QDELETING, PROC_REF(on_turf_changing), TRUE)
 
-/datum/staircase/proc/on_turf_changed(turf/originator)
+/datum/staircase/proc/on_turf_changing(turf/source)
 	SIGNAL_HANDLER
-	RegisterSignal(originator, COMSIG_TURF_ENTERED, PROC_REF(handle_entered), TRUE)
-	RegisterSignal(originator, COMSIG_ATOM_TURF_CHANGE, PROC_REF(on_turf_changed), TRUE)
+	from_turfs -= source
+	INVOKE_NEXT_TICK(src, PROC_REF(finish_on_turf_changed), source.x, source.y, source.z, "\ref[source]")
 
+/datum/staircase/proc/finish_on_turf_changed(x, y, z, old_ref)
+	var/turf/new_turf = locate(x, y, z)
+	if(!new_turf) // This should never happen but maybe if there's map shrinking??
+		from_turf_to_images -= old_ref
+		return
+	from_turfs += new_turf
+	RegisterSignal(new_turf, COMSIG_TURF_ENTERED, PROC_REF(handle_entered))
+	RegisterSignal(new_turf, COMSIG_PARENT_QDELETING, PROC_REF(on_turf_changing))
+	// Technically from_turf_to_images should change too but the ref should always be reused how we want
+	ASSERT(locate(old_ref) == new_turf, "Ref needs updating for /datum/staircase/proc/finish_on_turf_changed!")
 
 /datum/staircase/proc/handle_entered(turf/originator, atom/what_did_it)
 	SIGNAL_HANDLER

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -489,20 +489,13 @@
 	//hybrid lighting
 	var/list/old_hybrid_lights_affecting = hybrid_lights_affecting?.Copy()
 	var/old_directional_opacity = directional_opacity
-	var/list/old_comp_lookup = LAZYCOPY(comp_lookup)
 
 	changing_turf = TRUE
 	qdel(src) //Just get the side effects and call Destroy
 	var/turf/W = new path(src)
 
-	for(var/signal in old_comp_lookup)
-		if(signal == COMSIG_ATOM_TURF_CHANGE)
-			var/datum/target = old_comp_lookup[signal]
-			SEND_SIGNAL(target, COMSIG_ATOM_TURF_CHANGE, src)
-
-	for(var/i in W.contents)
-		var/datum/A = i
-		SEND_SIGNAL(A, COMSIG_ATOM_TURF_CHANGE, src)
+	for(var/atom/movable/thing as anything in W.contents)
+		SEND_SIGNAL(thing, COMSIG_ATOM_TURF_CHANGE, src)
 
 	if(new_baseturfs)
 		W.baseturfs = new_baseturfs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Fixes: #11243
Not limited to explosions being the cause, but they'd probably be the most common case.
Renames "movable_turf_change" -> "atom_turf_change"
Adds handling for Multi-Z Staircase related turfs to update with their new replacements if they are destroyed/replaced/new tiling/suddenly a wall etc.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Stair worky good. + Continuing to see what's up the stairs is good, instead of seeing walls.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Drathek
fix: Multi-Z stairs remain usable after an explosion
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
