### PR TITLE
Add click notification when phone call is hung up

### DIFF
--- a/code/modules/cm_phone/phone.dm
+++ b/code/modules/cm_phone/phone.dm
@@ -266,7 +266,7 @@ GLOBAL_LIST_EMPTY_TYPED(transmitters, /obj/structure/transmitter)
 	if(T)
 		if(T.attached_to && ismob(T.attached_to.loc))
 			var/mob/M = T.attached_to.loc
-			to_chat(M, SPAN_PURPLE("[icon2html(src, M)] [phone_id] has hung up on you."))
+			to_chat(M, SPAN_PURPLE("[icon2html(src, M)] You hear a click as the phone goes dead. [phone_id] has hung up on you."))
 			T.hangup_loop.start()
 
 		if(attached_to && ismob(attached_to.loc))


### PR DESCRIPTION
# About the pull request

Adds a notification message 'You hear a click as the phone goes dead' when the other player hangs up during a phone call, providing clearer feedback that the call has ended.

# Explain why it's good for the game

Currently when someone hangs up on you, the message only states who hung up. Adding the 'click' sound description makes the experience more immersive and provides clearer audio/visual feedback that the connection has been severed.

# Testing Photographs and Procedure

Tested by making a phone call between two players and having one hang up - the receiving player now sees the new message.

# Changelog

:cl:
qol: Added 'You hear a click as the phone goes dead' notification when someone hangs up the phone on you 
/:cl:
