### PR TITLE
Add Morpher, Cluster, Recovery pylon and Plasma Tree to The Xeno Locator.

### DIFF
--- a/code/__DEFINES/mob_hud.dm
+++ b/code/__DEFINES/mob_hud.dm
@@ -80,6 +80,10 @@
 #define TRACKER_HIVE "Hive Core"
 #define TRACKER_LEADER "Leader"
 #define TRACKER_TUNNEL "Tunnel"
+#define TRACKER_MORPHER "Morpher"
+#define TRACKER_CLUSTER "Cluster"
+#define TRACKER_RECOVERY_PYLON "Recovery Pylon"
+#define TRACKER_PLASMA_PYLON "Plasma Pylon"
 
 //These are used to manage the same HUD having multiple sources
 #define HUD_SOURCE_ADMIN "admin"

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -547,9 +547,29 @@
 		for(var/mob/living/carbon/xenomorph/leader in user.hive.xeno_leader_list)
 			options["Xeno Leader [leader]"] = list(leader, TRACKER_LEADER)
 
+		var/list/sorted_morphers = sort_list_dist(user.hive.hive_morphers, get_turf(user))
+		for(var/obj/effect/alien/resin/special/eggmorph/placed_morpher as anything in sorted_morphers)
+			options["Egg Morpher [placed_morpher.morpher_desc]"] = list(placed_morpher, TRACKER_MORPHER)
+
+		var/list/sorted_clusters = sort_list_dist(user.hive.hive_clusters, get_turf(user))
+		for(var/obj/effect/alien/resin/special/cluster/placed_cluster as anything in sorted_clusters)
+			options["Cluster [placed_cluster.cluster_desc]"] = list(placed_cluster, TRACKER_CLUSTER)
+
+		var/list/sorted_recovery_pylons = sort_list_dist(user.hive.hive_recovery_pylons, get_turf(user))
+		for(var/obj/effect/alien/resin/special/recovery/placed_recovery_pylon as anything in sorted_recovery_pylons)
+			options["Recovery Pylon [placed_recovery_pylon.recovery_pylons_desc]"] = list(placed_recovery_pylon, TRACKER_RECOVERY_PYLON)
+
+		var/list/sorted_plasma_pylons = sort_list_dist(user.hive.hive_plasma_pylons, get_turf(user))
+		for(var/obj/effect/alien/resin/special/plasma_tree/placed_plasma_pylon as anything in sorted_plasma_pylons)
+			options["Plasma Tree [placed_plasma_pylon.plasma_pylons_desc]"] = list(placed_plasma_pylon, TRACKER_PLASMA_PYLON)
+
 		var/list/sorted_tunnels = sort_list_dist(user.hive.tunnels, get_turf(user))
 		for(var/obj/structure/tunnel/tunnel as anything in sorted_tunnels)
 			options["Tunnel [tunnel.tunnel_desc]"] = list(tunnel, TRACKER_TUNNEL)
+
+		if(length(options) == 0)
+			to_chat(user, SPAN_WARNING("We don't sense any valid tracking targets!"))
+			return
 
 		var/list/selected = tgui_input_list(user, "Select what you want the locator to track.", "Locator Options", options)
 		if(selected)

--- a/code/modules/cm_aliens/structures/special/egg_morpher.dm
+++ b/code/modules/cm_aliens/structures/special/egg_morpher.dm
@@ -25,9 +25,20 @@
 	var/spawn_cooldown_length_ovi = 60 SECONDS
 	COOLDOWN_DECLARE(spawn_cooldown)
 
+	///Contains description for area name and coords.
+	var/morpher_desc = ""
+	var/datum/hive_status/hive
 
 /obj/effect/alien/resin/special/eggmorph/Initialize(mapload, hive_ref)
 	. = ..()
+
+	var/turf/find = get_turf(src)
+	morpher_desc = find.loc.name + " ([loc.x], [loc.y]) [pick(GLOB.greek_letters)]"
+
+	if(!hive)
+		hive = GLOB.hive_datum[linked_hive.hivenumber]
+		hive.hive_morphers += src
+
 	COOLDOWN_START(src, spawn_cooldown, get_egg_cooldown())
 	range_bounds = SQUARE(x, y, EGGMORPG_RANGE)
 	update_minimap_icon()
@@ -37,15 +48,17 @@
 	SSminimaps.add_marker(src, get_minimap_flag_for_faction(linked_hive?.hivenumber), image('icons/UI_icons/map_blips.dmi', null, "morpher"))
 
 /obj/effect/alien/resin/special/eggmorph/Destroy()
+	if(hive)
+		hive.hive_morphers -= src
 	if(stored_huggers && linked_hive)
 		//Hugger explosion, like a carrier
-		var/obj/item/clothing/mask/facehugger/F
+		var/obj/item/clothing/mask/facehugger/face_hugger
 		var/chance = 60
 		visible_message(SPAN_XENOWARNING("The chittering mass of tiny aliens is trying to escape [src]!"))
 		for(var/i in 1 to stored_huggers)
 			if(prob(chance))
-				F = new(loc, linked_hive.hivenumber)
-				step_away(F,src,1)
+				face_hugger = new(loc, linked_hive.hivenumber)
+				step_away(face_hugger,src,1)
 
 	range_bounds = null
 	SSminimaps.remove_marker(src)

--- a/code/modules/cm_aliens/structures/special/hive_cluster.dm
+++ b/code/modules/cm_aliens/structures/special/hive_cluster.dm
@@ -13,6 +13,10 @@
 	health = 1200
 	block_range = 0
 
+	///Contains description for area name and coords.
+	var/cluster_desc = ""
+	var/datum/hive_status/hive
+
 	var/node_type = /obj/effect/alien/weeds/node/pylon/cluster
 	var/obj/effect/alien/weeds/node/node
 
@@ -26,13 +30,23 @@
 	node = place_node()
 	update_minimap_icon()
 
+	var/turf/find = get_turf(src)
+	cluster_desc = find.loc.name + " ([loc.x], [loc.y]) [pick(GLOB.greek_letters)]"
+
+	if(!hive)
+		hive = GLOB.hive_datum[linked_hive.hivenumber]
+		hive.hive_clusters += src
+
 	RegisterSignal(SSdcs, COMSIG_GLOB_BOOST_XENOMORPH_WALLS, PROC_REF(start_boost))
 	RegisterSignal(SSdcs, COMSIG_GLOB_STOP_BOOST_XENOMORPH_WALLS, PROC_REF(stop_boost))
+
 /obj/effect/alien/resin/special/cluster/proc/update_minimap_icon()
 	SSminimaps.remove_marker(src)
 	SSminimaps.add_marker(src, MINIMAP_FLAG_XENO, image('icons/ui_icons/map_blips.dmi', null, "cluster"))
 
 /obj/effect/alien/resin/special/cluster/Destroy()
+	if(hive)
+		hive.hive_clusters -= src
 	QDEL_NULL(node)
 	SSminimaps.remove_marker(src)
 	return ..()

--- a/code/modules/cm_aliens/structures/special/recovery_node.dm
+++ b/code/modules/cm_aliens/structures/special/recovery_node.dm
@@ -6,11 +6,27 @@
 	var/replenish_amount = 75
 	COOLDOWN_DECLARE(last_replenish)
 
+	///Contains description for area name and coords.
+	var/plasma_pylons_desc = ""
+	var/datum/hive_status/hive
+
 /obj/effect/alien/resin/special/plasma_tree/Initialize(mapload, hive_ref)
 	. = ..()
+	var/turf/find = get_turf(src)
+	plasma_pylons_desc = find.loc.name + " ([loc.x], [loc.y]) [pick(GLOB.greek_letters)]"
+
+	if(!hive)
+		hive = GLOB.hive_datum[linked_hive.hivenumber]
+		hive.hive_plasma_pylons += src
+
 	update_minimap_icon()
 	RegisterSignal(SSdcs, COMSIG_GLOB_BOOST_XENOMORPH_WALLS, PROC_REF(enable_boost))
 	RegisterSignal(SSdcs, COMSIG_GLOB_STOP_BOOST_XENOMORPH_WALLS, PROC_REF(disable_boost))
+
+/obj/effect/alien/resin/special/plasma_tree/Destroy()
+	. = ..()
+	if(hive)
+		hive.hive_plasma_pylons -= src
 
 /obj/effect/alien/resin/special/plasma_tree/proc/update_minimap_icon()
 	SSminimaps.remove_marker(src)
@@ -67,8 +83,19 @@
 	var/heal_amount = 20
 	COOLDOWN_DECLARE(last_heal)
 
+	///Contains description for area name and coords.
+	var/recovery_pylons_desc = ""
+	var/datum/hive_status/hive
+
 /obj/effect/alien/resin/special/recovery/Initialize(mapload, hive_ref)
 	. = ..()
+	var/turf/find = get_turf(src)
+	recovery_pylons_desc = find.loc.name + " ([loc.x], [loc.y]) [pick(GLOB.greek_letters)]"
+
+	if(!hive)
+		hive = GLOB.hive_datum[linked_hive.hivenumber]
+		hive.hive_recovery_pylons += src
+
 	update_minimap_icon()
 	RegisterSignal(SSdcs, COMSIG_GLOB_BOOST_XENOMORPH_WALLS, PROC_REF(enable_boost))
 	RegisterSignal(SSdcs, COMSIG_GLOB_STOP_BOOST_XENOMORPH_WALLS, PROC_REF(disable_boost))
@@ -79,6 +106,8 @@
 
 /obj/effect/alien/resin/special/recovery/Destroy()
 	. = ..()
+	if(hive)
+		hive.hive_recovery_pylons -= src
 	SSminimaps.remove_marker(src)
 
 /obj/effect/alien/resin/special/recovery/get_examine_text(mob/user)

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -104,6 +104,14 @@
 
 	var/list/tunnels = list()
 
+	var/list/hive_clusters = list()
+
+	var/list/hive_morphers = list()
+
+	var/list/hive_recovery_pylons = list()
+
+	var/list/hive_plasma_pylons = list()
+
 	var/list/allies = list()
 	/// The list of factions this hive is forbidden to ally with.
 	var/list/banned_allies

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -406,6 +406,14 @@ Make sure their actual health updates immediately.*/
 			// If the leader exists, and is actually in the leader list.
 			if(leader && (leader in hive.xeno_leader_list))
 				tracking_atom = leader
+		if(TRACKER_MORPHER)
+			tracking_atom = locator.tracking_ref?.resolve()
+		if(TRACKER_CLUSTER)
+			tracking_atom = locator.tracking_ref?.resolve()
+		if(TRACKER_RECOVERY_PYLON)
+			tracking_atom = locator.tracking_ref?.resolve()
+		if(TRACKER_PLASMA_PYLON)
+			tracking_atom = locator.tracking_ref?.resolve()
 		if(TRACKER_TUNNEL)
 			tracking_atom = locator.tracking_ref?.resolve()
 


### PR DESCRIPTION
# About the pull request

Allows xenomorphs to locate any nearby Morphers, Clusters, Recovery pylon and Plasma Tree (sorted by distance)

This is mostly QoL, even if you use locate funtion to see direction where cluster is, its not as handy as tacmap, it show direction but it dont show you how you need to walk to get to it (courages to explore around to find it)

Also this PR fix runtime caused by tgui, when you are for example corrupted without queen or core and want to access locator, it will crash saying they cannot open empty list (and do it anyway after runtime).

Also don't say its broken, currently Morpher, Cluster, Recovery pylon and Plasma Tree send big fat font on chat when they are destroyed, if you worried this will give out that "some structures dissapeared" tunnels do dissapear too when they collapse.

# Explain why it's good for the game

By allowing xenos to track structures that are usually hard to find without any clues, only queen have access to see tacmap when off ovi, and requests to break clusters, but there is for example player who have 20 hours and dont know where to search (maps for them are maze/new) they dont know where to search for specific structure, with this change it would take less time to localize,


# Check photo below

<details>
<summary>Locator in action</summary>
Arrow points towards morpher on the right (showing it works)

<img width="984" height="521" alt="image" src="https://github.com/user-attachments/assets/cb2ecc0f-c456-4973-b652-4b59193d6dd0" />


</details>


# Changelog

:cl: Venuska1117
balance: Adds Morpher, Cluster, Recovery pylon and Plasma Tree to Xeno Locator.
/:cl:
