### PR TITLE
stop autobanning linux users

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -733,3 +733,6 @@ This maintains a list of ip addresses that are able to bypass topic filtering.
 
 /datum/config_entry/string/sentry_dsn
 	protection = CONFIG_ENTRY_HIDDEN
+
+/datum/config_entry/str_list/ignored_cids
+	protection = CONFIG_ENTRY_LOCKED

--- a/code/controllers/subsystem/stickyban.dm
+++ b/code/controllers/subsystem/stickyban.dm
@@ -125,6 +125,9 @@ SUBSYSTEM_DEF(stickyban)
 
 /// Adds a CID match to the specified stickyban.
 /datum/controller/subsystem/stickyban/proc/add_matched_cid(existing_ban_id, cid)
+	if(cid in CONFIG_GET(str_list/ignored_cids))
+		return
+
 	if(length(DB_VIEW(/datum/view_record/stickyban_matched_cid,
 		DB_AND(
 			DB_COMP("linked_stickyban", DB_EQUALS, existing_ban_id),
@@ -203,6 +206,9 @@ SUBSYSTEM_DEF(stickyban)
  * Connections matching this CID will be blocked - provided the linked stickyban is active.
  */
 /datum/controller/subsystem/stickyban/proc/get_impacted_cid_records(cid)
+	if(cid in CONFIG_GET(str_list/ignored_cids))
+		return list()
+
 	return DB_VIEW(/datum/view_record/stickyban_matched_cid,
 			DB_COMP("cid", DB_EQUALS, cid)
 		)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -265,3 +265,10 @@ CLIENT_ERROR_VERSION 514
 #GITHUB_APP_API
 #REPO_NAME cmss13
 #ORG cmss13-devs
+
+# Which CIDs will not be considered for stickybans. This is the default CID that Wine spits out,
+# and for the purpose of not default banning all Linux players, we'll just ignore it.
+# People can spoof this CID and ignore that element of stickybans forever, but they can equally
+# just keep generating new ones. Kind of doesn't matter.
+IGNORED_CIDS 4055623708
+


### PR DESCRIPTION
title really

:cl:
server: server operators can now configure a list of CIDs that will not be considered for stickybans
/:cl: