### PR TITLE
Partial Revert "Fixes crew manifest and cryopod item storage regarding HG MP"

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -236,7 +236,7 @@ GLOBAL_LIST_INIT(frozen_items, list(SQUAD_MARINE_1 = list(), SQUAD_MARINE_2 = li
 	if(ishuman(occupant))
 		var/mob/living/carbon/human/cryo_human = occupant
 		switch(cryo_human.job)
-			if(JOB_POLICE, JOB_WARDEN, JOB_CHIEF_POLICE)
+			if(JOB_POLICE, JOB_POLICE_HG, JOB_WARDEN, JOB_CHIEF_POLICE)
 				dept_console = GLOB.frozen_items["MP"]
 			if(JOB_NURSE, JOB_DOCTOR, JOB_FIELD_DOCTOR, JOB_RESEARCHER, JOB_CMO)
 				dept_console = GLOB.frozen_items["Med"]


### PR DESCRIPTION
Partial Revert of cmss13-devs/cmss13#11224

made HGMPs spawnable which I didnt think to look at the spawn menu; removes the addition to the list that makes it spawnable. alternative; https://github.com/cmss13-devs/cmss13/pull/11255

:cl: 
fix: MP honor guards no longer spawnable.
/:cl: