### PR TITLE
Mutated Queen no color

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -626,8 +626,6 @@
 		name_client_postfix = client.xeno_postfix ? ("-"+client.xeno_postfix) : ""
 		age_xeno()
 	full_designation = "[name_client_prefix][nicknumber][name_client_postfix]"
-	if(!HAS_TRAIT(src, TRAIT_NO_COLOR))
-		color = in_hive.color
 
 	var/age_display = show_age_prefix ? age_prefix : ""
 	var/name_display = ""

--- a/code/modules/mob/living/carbon/xenomorph/castes/Boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Boiler.dm
@@ -86,8 +86,6 @@
 	smoke.cause_data = create_cause_data(initial(caste_type), src)
 	see_in_dark = 20
 
-	update_icon_source()
-
 /mob/living/carbon/xenomorph/boiler/Destroy()
 	if(smoke)
 		qdel(smoke)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -507,7 +507,6 @@
 
 
 	full_designation = "[name_client_prefix][nicknumber][name_client_postfix]"
-	color = hive.color
 
 	//Update linked data so they show up properly
 	change_real_name(src, name)

--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -51,6 +51,7 @@
 		walking_state_cache[mutation_caste_state] = cache_walking_state
 	has_walking_icon_state = walking_state_cache[mutation_caste_state]
 	update_icons()
+	color = HAS_TRAIT(src, TRAIT_NO_COLOR) ? null : hive.color
 
 /mob/living/carbon/xenomorph/update_icons()
 	if(!caste)


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Removes recoloring for the Mutated Queen, since the mutated hive should not have their xenomorphs recolored.

Also fixes recoloring logic if the pre-mutated xeno was recolored - if the xeno was recolored (say, Alpha-red), then morphed to Mutated, it would retain its red color.

Moved the recoloring logic to `proc/update_icon_source()` from `proc/generate_name()`. Could be moved to `proc/recalculate_everything()` instead if desired.

# Explain why it's good for the game
Fixes good, green queen is not good.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="485" height="246" alt="Screenshot_42" src="https://github.com/user-attachments/assets/3e6f713c-2748-4122-b24c-fe3f83f61aab" />

</details>


# Changelog
:cl:
fix: Mutated Queen is now not recoloring.
fix: Recolored Xenomorph morphed to Mutated Xenomorph will now reset their color to none.
/:cl:
