### PR TITLE
Using a bandage in your hand will now slowly automatically find and bandage any open wounds on you

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -67,7 +67,7 @@
 
 /obj/item/stack/medical/bruise_pack/get_examine_text(mob/user)
 	. = ..()
-	. += SPAN_NOTICE("Using [src] in your hand will bandage any open, bleeding wounds on you. This will take a bit longer if you're not aiming at the hurt limbs.")
+	. += SPAN_NOTICE("Using [src] in your hand will bandage any open, bleeding wounds on you. This will take a longer if you're not targeting the hurt limbs.")
 
 /obj/item/stack/medical/bruise_pack/handle_attack_self(mob/living/carbon/human/user)
 	if(!ishuman(user))
@@ -93,9 +93,9 @@
 			chosen_limb = user.get_limb(user.zone_selected)
 			bandage_wound(user, user, chosen_limb)
 			return
-		// If your aimed limb isn't the picked, wounded one, the delay is forced and slightly slower
+		// If your aimed limb isn't the picked, wounded one, the delay is forced and slower
 		// Prevents corpsmen+ from spamming the brute kit in their hands without dancing around the numpad
-		bandage_wound(user, user, chosen_limb, force_delay = TRUE, delay_mult = 1.5)
+		bandage_wound(user, user, chosen_limb, force_delay = TRUE, delay_mult = 2)
 
 /obj/item/stack/medical/bruise_pack/attack(mob/living/carbon/human/human_target, mob/user)
 	if(..())


### PR DESCRIPTION

# About the pull request

Using a bandage in your hand will now automatically find and bandage any open wounds on you.

If you're not aiming at a wounded limb, it will take 2 seconds to bandage the limb, **even** if you're a corpsman or above.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

I'm tired of being nicked by a bullet and needing to examine and bandage myself every time, it's tedious.

I made sure this wasn't encroaching powercreep by making it objectively slower and not allowing corpsmen to turn into lesser gods by spamming action on their bruise kits.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Using a bandage in your hand will now slowly automatically find and bandage any open wounds on you
/:cl:
