### PR TITLE
Fixes IMS not applying open chest/head overlay sprites

### DIFF
--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -58,6 +58,13 @@
 			SPAN_NOTICE("[user] has constructed a prepared incision in [target]'s [surgery.affected_limb.display_name]."))
 
 		surgery.status += 2 //IMS completes all steps.
+
+		switch(target_zone) //forces application of overlays
+			if("chest")
+				target.overlays += image('icons/mob/humans/dam_human.dmi', "chest_surgery_closed")
+			if("head")
+				target.overlays += image('icons/mob/humans/dam_human.dmi', "skull_surgery_closed")
+
 	else if(tool_type == /obj/item/tool/surgery/scalpel/laser && prob(las_scalpel.bloodlessprob))
 		user.affected_message(target,
 			SPAN_NOTICE("You finish making a bloodless incision on [target]'s [surgery.affected_limb.display_name] with \the [tool]."),


### PR DESCRIPTION
# About the pull request

Fixes #11206 
IMS wasn't applying the overlay a retractor applies when widening the incision on the chest/head, so I fixed it.

# Explain why it's good for the game

How are we supposed to know the chest and head are open if the overlay doesn't show up? Missing overlays need fixing.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![dreamseeker_2025-12-04_19-16-13](https://github.com/user-attachments/assets/fc9b5b31-9991-4dfb-9e8d-dc061cb492a3)


</details>


# Changelog

:cl: Puckaboo2
fix: Using the IMS on the head or chest now applies their open incision overlays.
/:cl:
