### PR TITLE
Makes Eye Surgery a Little More Interesting (BALANCE)

### DIFF
--- a/code/modules/surgery/eye.dm
+++ b/code/modules/surgery/eye.dm
@@ -48,7 +48,7 @@
 		SPAN_NOTICE("[user] starts to separate the corneas of [target]'s eyes with [tool]."))
 
 	target.custom_pain("You feel a searing, piercing pain in your eyeballs as your corneas are being sliced open!",1)
-	log_interact(user, target, "[key_name(user)] started to separate the corneas on [key_name(target)]'s eyes and reshape them with [tool].")
+	log_interact(user, target, "[key_name(user)] started to separate the corneas on [key_name(target)]'s eyes with [tool].")
 
 /datum/surgery_step/separate_corneas/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, tool_type, datum/surgery/surgery)
 	user.affected_message(target,
@@ -68,7 +68,7 @@
 		SPAN_WARNING("[user]'s hand slips, slicing your eyes with [tool]!"),
 		SPAN_WARNING("[user]'s hand slips, slicing [target]'s eyes with [tool]!"))
 
-	log_interact(user, target, "[key_name(user)] failed to separate and reshape the corneas on [key_name(target)]'s eyes with [tool], aborting [surgery].")
+	log_interact(user, target, "[key_name(user)] failed to separate the corneas on [key_name(target)]'s eyes with [tool], aborting [surgery].")
 
 	target.apply_damage(10, BRUTE, target_zone)
 	surgery.target_eyes.take_damage(5, FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
# About The Pull Request

1. Makes the surgery more descriptive
2. Adds extra flavor text for successful surgeries. If you cured blindness or nearsightedness, you get extra messages letting you know what you fixed.
3. You can begin eye surgery if the patient is nearsighted or blind, even if the patient has 0 eye damage.
4. Adds sounds to all steps.
5. Eyes now require the patient to have Oxycodone in their system for a painless surgery.
6. Rearranges some surgery steps and adds one final step.

# Explain why it's good for the game

1. Learn about different parts of the eyeball if you're awake! Isn't surgery fun?
2. Not only did you complete a surgery, but you can see exactly what you've fixed! Cured blindness and nearsightedness at the same time? The game lets you know. 
3. If the scenario somehow pops up, there won't be an issue for it.
4. Wher sounds? Here sounds.
5. Eyes have some of the greatest concentrations of nociceptive nerves in the human body and must be fully numbed for LASIK or to be be completely anesthetized in real life for an operation to commence. Have you ever been poked or hit in the eye before? Or ever got a little bit of dust in your eye? A teeny dust particle can cause an immense amount of pain, let alone a big ass scalpel separating your eye bits.

5a. Okay, so... It's mostly logic-based, here. Tools, first, why would you lift the corneas with a giant ass retractor meant for separating bones? That's better used for opening up the eyeball, itself.  How would a hemostat repair any damage in the eye if it only pinches? No, that's better suited for lifting the corneas and lenses. Scalpel to open>Hemostat to lift the lenses>Retractor to open up the eye. Now what?

5b. Currently, the steps are to separate the corneas, lift them, and repair the damage. What damage? The surface damage? Yes, surface damage explains eye damage and nearsightedness, but to address complete blindness, you need to go inside the eyeball. So, retractor after scalpel and hemostat. To fix the inside of the eyeball, it's Fix-o-Vein, time. Then you just close everything all neatly.

So, the new steps of eye surgery are:
Scalpel to separate the corneas
Hemostat to lift and pull them away from the rest of the eyes
Retractor to open the eyes up
Fix-o-vein to fix all the goodies causing nearsightedness and blindness inside the eyeballs
Cautery to put everything back into place. 

In essence, you're doing internal bleeding surgery on the eyes.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Some words have been swapped around, but here's how the surgery looks on a fully blinded patient with 50 eye damage.
![dreamseeker_2025-12-04_22-58-52](https://github.com/user-attachments/assets/6e9d3cfb-961b-424e-adc0-faa09e91a46b)

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Puckaboo2
fix: All steps in eye surgeries now have sounds.
fix: If the patient is blind or nearsighted and has 0 eye damage, you can still initiate eye surgery. A patient now needs to either have eye damage or be blind/nearsighted to need surgery.
qol: Makes eye surgery steps more descriptive.
qol: If you cured blindness or nearsightedness, you get extra flavor text and a pat on the back (from Puck)
balance: Changes eye surgery steps. It's now Scalpel, Hemostat, Retractor, FixoVein, Cautery. Pretend you're doing internal bleeding on the eyes and you will be fine.
balance: Eye surgery now requires Oxycodone instead of getting away with inaprovaline. Eyes have some of the greatest concentrations of nociceptive nerves in the human body and must be fully numbed for LASIK or to be be completely anesthetized in real life for an operation to commence.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
