### PR TITLE
Welding Fuel now has a recipe

### DIFF
--- a/code/modules/reagents/chemistry_reactions/other.dm
+++ b/code/modules/reagents/chemistry_reactions/other.dm
@@ -118,6 +118,13 @@
 	required_reagents = list("hydrogen" = 2, "oxygen" = 1)
 	result_amount = 1
 
+/datum/chemical_reaction/fuel
+	name = "Acetylene (Welding Fuel)"
+	id = "fuel"
+	result = "fuel"
+	required_reagents = list("carbon" = 2, "hydrogen" = 2)
+	result_amount = 1
+
 
 /datum/chemical_reaction/thermite
 	name = "Thermite"


### PR DESCRIPTION

# About the pull request
Welding Fuel has a recipe. It's called Acetylene and it's 2 Carbon, 2 Hydrogen.
# Explain why it's good for the game
Why welding fuel have no recipe?

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Puckaboo2
add: Welding Fuel has a chem recipe, now. It's 2 carbon, 2 hydrogen.

/:cl:
