### PR TITLE
correct image for multiz stairs indicator

### DIFF
--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -624,7 +624,7 @@ GLOBAL_DATUM_INIT(above_blackness_backdrop, /atom/movable/above_blackness_backdr
 
 /obj/effect/stairs/Initialize(mapload, ...)
 	. = ..()
-	SSminimaps.add_marker(src, z, MINIMAP_FLAG_ALL, "stairs_[direction]")
+	SSminimaps.add_marker(src, MINIMAP_FLAG_ALL, image('icons/UI_icons/map_blips.dmi', null,"stairs_[direction]", HIGH_FLOAT_LAYER))
 
 /obj/effect/stairs/up
 	direction = "up"


### PR DESCRIPTION

# About the pull request

fixes currently unused indicator that I made badly

# Explain why it's good for the game

will work once mapped in


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: tacmap multiz stair icons (unused) get displayed correctly
/:cl:
