### PR TITLE
Increases base reagent grinder item limit to 16

### DIFF
--- a/code/modules/reagents/chemistry_machinery/reagent_grinder.dm
+++ b/code/modules/reagents/chemistry_machinery/reagent_grinder.dm
@@ -11,7 +11,7 @@
 	var/inuse = 0
 	var/grind_duration = 6 SECONDS // 6 seconds
 	var/obj/item/reagent_container/beaker = null
-	var/limit = 10
+	var/limit = 16
 	var/tether_range = 8
 	var/obj/structure/machinery/smartfridge/chemistry/linked_storage //Where we send bottle chemicals
 	var/list/blend_items = list (
@@ -93,7 +93,7 @@
 		to_chat(user, SPAN_WARNING("The machine cannot hold anymore items."))
 		return TRUE
 	if (istype(O, /obj/item/research_upgrades/grinderspeed))
-		if(limit == 10)
+		if(limit == 16)
 			grind_duration = 3 SECONDS
 			limit = 25
 			to_chat(user, SPAN_NOTICE("You insert [O] into [src]"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Self-explanatory. I'm increasing the amount of items you can shove in a basic reagent grinder that has not been updated to 16.

Changes have been tested.

# Explain why it's good for the game

I was excited to learn that I could pour the contents of pill bottles into the reagent grinder, so, I tried it out... Only to realize I couldn't put more than ten tiny ass pills into the grinder. With this update, now I can. 

An increase from 10 to 16 has also been necessary for chemists due to the increase in beaker capacity

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->


<details>
#<summary>Screenshots & Videos</summary>
[dreamseeker_2025-12-08_12-12-49](https://github.com/user-attachments/assets/744b44b6-8692-45d8-9be2-1a60887362a2)

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Puckaboo2
balance: Reagent grinders can now hold 16 items, up from 10.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
