### PR TITLE
Rebalances lowpop comms garble

### DIFF
--- a/code/controllers/subsystem/gameplay_enjoyability_moderator.dm
+++ b/code/controllers/subsystem/gameplay_enjoyability_moderator.dm
@@ -1,0 +1,27 @@
+SUBSYSTEM_DEF(gameplay_enjoyability_moderator)
+	name = "Gameplay Enjoyability Moderator"
+	wait = 1
+	var/first = 1
+	init_order = first
+
+/datum/controller/subsystem/fun/fire()
+	var/number_of_ground_towers = 0
+	// checks for any active comms towers
+	for(var/T as anything in SSradio.tcomm_machines_ground)
+		if(istype(T, /obj/structure/machinery/telecomms))
+			if(astype(T, /obj/structure/machinery/telecomms).powered())
+				return
+	// checks to see if the game is in low-pop
+	var/player_count = 0
+	for(var/z_level as anything in SSmapping.z_list)
+		for(var/area as anything in SSmapping.areas_in_z[z_level])
+			if(is_type_in_list(area.type, typesof(/area)))
+				for(var/mob/living/carbon/human/player in area.contents)
+					player_count + 1
+	if(80 >= player_count)
+		// now that comms are disabled, CIC is made redundant, and is deleted along with its contents
+		for(var/z_level as anything in SSmapping.z_list)
+			for(var/area as anything in SSmapping.areas_in_z[z_level])
+				if(is_type_in_list(area.type, typesof(/area/almayer/command)))
+					for(var/T as anything in area.contents)
+						Destroy(T)


### PR DESCRIPTION

# About the pull request

Builds upon the work of previous PRs to more heavily streamline the involvement of comms in the CIC gameplay loop, and remove player laziness on the field of battle.

This PR takes that idea one step further by, when groundside comms are lost, physically deleting CIC as well as its occupants (who were made redundant by the lack of comms anyway) and allowing said occupants to find something more meaningful to do with their afternoon.

# Explain why it's good for the game

Encourages command regulars to rethink their life decisions for the 1-2 hours per round they would normally spend being useless without comms.

Removes gameplay bloat

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Groundside comms loss now causes CIC to be physically deleted, alongside the players within
/:cl:
