### PR TITLE
Fix ghostize_apperance verb

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -95,16 +95,6 @@
 		spawn_turf = get_turf(body) //Where is the body located?
 		attack_log = body.attack_log //preserve our attack logs by copying them to our ghost
 		life_kills_total = body.life_kills_total //kills also copy over
-
-		invisibility = INVISIBILITY_OBSERVER
-		plane = GHOST_PLANE
-		layer = ABOVE_FLY_LAYER
-		mouse_opacity = MOUSE_OPACITY_ICON // In case we were weed_food
-
-		sight |= SEE_TURFS|SEE_MOBS|SEE_OBJS|SEE_SELF
-		see_invisible = INVISIBILITY_OBSERVER
-		see_in_dark = 100
-
 		mind = body.mind //we don't transfer the mind but we keep a reference to it.
 
 	if(!own_orbit_size)
@@ -150,6 +140,13 @@
 	own_orbit_size = body.get_orbit_size()
 	desc = initial(desc)
 	alpha = 127
+	invisibility = INVISIBILITY_OBSERVER
+	plane = GHOST_PLANE
+	layer = ABOVE_FLY_LAYER
+	mouse_opacity = MOUSE_OPACITY_ICON // In case we were weed_food
+	sight |= SEE_TURFS|SEE_MOBS|SEE_OBJS|SEE_SELF
+	see_invisible = INVISIBILITY_OBSERVER
+	see_in_dark = 100
 
 /mob/dead/observer/proc/set_lighting_alpha_from_pref(client/ghost_client)
 	var/vision_level = ghost_client?.prefs?.ghost_vision_pref
@@ -761,6 +758,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/real_name = client.prefs.real_name
 	name = real_name
 	real_name = real_name
+
+	to_chat(client, SPAN_NOTICE("Appearance reset."))
 
 /mob/dead/observer/verb/follow_local(mob/target in GLOB.mob_list)
 	set category = "Ghost.Follow"


### PR DESCRIPTION
# About the pull request

This PR is a follow up to https://github.com/cmss13-devs/cmss13/pull/11091 fixing ghosts being able to be visible by living players after using the verb because plane wasn't set again when resetting to the preview mob.

# Explain why it's good for the game

Ghost of Christmas past isn't real.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/6qNcc1DXk40

</details>


# Changelog
:cl: Drathek
fix: Fix Restore Ghost Character verb causing ghosts to be visible to living players
/:cl:
