### PR TITLE
xenos can no longer re-plant on a hostile hive's weeds.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -37,7 +37,7 @@
 			return
 
 		if(node.hivenumber != xeno.hivenumber)
-			to_chat(xeno, SPAN_WARNING("The other hive's node resists your attempt to uproot it.")
+			to_chat(xeno, SPAN_WARNING("The other hive's node resists your attempt to uproot it."))
 			return
 
 		if(!do_after(xeno, 1 SECONDS, INTERRUPT_ALL, BUSY_ICON_GENERIC, node, INTERRUPT_ALL))


### PR DESCRIPTION

# About the pull request

https://github.com/cmss13-devs/cmss13/pull/11126 added the ability to replant resin nodes to make them regrow-- mostly intended for situations where fire for example had cleared out some of it's child weeds to allow you to have it regrow them without having to just place a new node next to it. 

This came with an (I believe) unintended side effect that hostile hives can instantly destroy each others' weeds by planting new nodes on them-- since the addition in that PR did not add a check for whether the xeno attempting to replant shared the hive of the node.


# Explain why it's good for the game

fixes an oversight

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: hostile hives can no longer replant each others' weed nodes.
/:cl:
