### PR TITLE
Project Big-mike P1.5: Invisible Ink Removal

### DIFF
--- a/code/game/jobs/job/command/cic/captain.dm
+++ b/code/game/jobs/job/command/cic/captain.dm
@@ -112,6 +112,7 @@
 
 	var/datum/asset/asset = get_asset_datum(/datum/asset/simple/paper)
 	co_briefing.info = replacetext(co_briefing.info, "%%USCMLOGO%%", asset.get_url_mappings()["logo_uscm.png"])
+	co_briefing.info = replacetext(co_briefing.info, "%%DARKBACKGROUND%%", asset.get_url_mappings()["background_dark2.jpg"])
 
 	var/obj/structure/machinery/faxmachine/receiver
 	for(var/target_machine_code as anything in GLOB.fax_network.all_faxcodes)

--- a/maps/map_briefings/commanding_officer/big_red/SOLARISRIDGEcpo.html
+++ b/maps/map_briefings/commanding_officer/big_red/SOLARISRIDGEcpo.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/big_red/SOLARISRIDGEhmm.html
+++ b/maps/map_briefings/commanding_officer/big_red/SOLARISRIDGEhmm.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/big_red/SOLARISRIDGEmodi.html
+++ b/maps/map_briefings/commanding_officer/big_red/SOLARISRIDGEmodi.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/big_red/SOLARISRIDGEunaligned.html
+++ b/maps/map_briefings/commanding_officer/big_red/SOLARISRIDGEunaligned.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/chances/CHANCEScpo.html
+++ b/maps/map_briefings/commanding_officer/chances/CHANCEScpo.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/chances/CHANCEShmm.html
+++ b/maps/map_briefings/commanding_officer/chances/CHANCEShmm.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/chances/CHANCESmodi.html
+++ b/maps/map_briefings/commanding_officer/chances/CHANCESmodi.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/chances/CHANCESunaligned.html
+++ b/maps/map_briefings/commanding_officer/chances/CHANCESunaligned.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/fiorina/FIORINAcpo.html
+++ b/maps/map_briefings/commanding_officer/fiorina/FIORINAcpo.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/fiorina/FIORINAhmm.html
+++ b/maps/map_briefings/commanding_officer/fiorina/FIORINAhmm.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/fiorina/FIORINAmodi.html
+++ b/maps/map_briefings/commanding_officer/fiorina/FIORINAmodi.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/fiorina/FIORINAunaligned.html
+++ b/maps/map_briefings/commanding_officer/fiorina/FIORINAunaligned.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/hybrisa/HYBRISAcpo.html
+++ b/maps/map_briefings/commanding_officer/hybrisa/HYBRISAcpo.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/hybrisa/HYBRISAhmm.html
+++ b/maps/map_briefings/commanding_officer/hybrisa/HYBRISAhmm.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/hybrisa/HYBRISAmodi.html
+++ b/maps/map_briefings/commanding_officer/hybrisa/HYBRISAmodi.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/hybrisa/HYBRISAunaligned.html
+++ b/maps/map_briefings/commanding_officer/hybrisa/HYBRISAunaligned.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/kutjevo/KUTJEVOcpo.html
+++ b/maps/map_briefings/commanding_officer/kutjevo/KUTJEVOcpo.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/kutjevo/KUTJEVOhmm.html
+++ b/maps/map_briefings/commanding_officer/kutjevo/KUTJEVOhmm.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/kutjevo/KUTJEVOmodi.html
+++ b/maps/map_briefings/commanding_officer/kutjevo/KUTJEVOmodi.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/kutjevo/KUTJEVOunaligned.html
+++ b/maps/map_briefings/commanding_officer/kutjevo/KUTJEVOunaligned.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/lv624/LV624cpo.html
+++ b/maps/map_briefings/commanding_officer/lv624/LV624cpo.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/lv624/LV624hmm.html
+++ b/maps/map_briefings/commanding_officer/lv624/LV624hmm.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/lv624/LV624modi.html
+++ b/maps/map_briefings/commanding_officer/lv624/LV624modi.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/lv624/LV624unaligned.html
+++ b/maps/map_briefings/commanding_officer/lv624/LV624unaligned.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/new_varadero/NEWVARADEROcpo.html
+++ b/maps/map_briefings/commanding_officer/new_varadero/NEWVARADEROcpo.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/new_varadero/NEWVARADEROhmm.html
+++ b/maps/map_briefings/commanding_officer/new_varadero/NEWVARADEROhmm.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/new_varadero/NEWVARADEROmodi.html
+++ b/maps/map_briefings/commanding_officer/new_varadero/NEWVARADEROmodi.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/new_varadero/NEWVARADEROunaligned.html
+++ b/maps/map_briefings/commanding_officer/new_varadero/NEWVARADEROunaligned.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/shivas/SHIVAScpo.html
+++ b/maps/map_briefings/commanding_officer/shivas/SHIVAScpo.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/shivas/SHIVAShmm.html
+++ b/maps/map_briefings/commanding_officer/shivas/SHIVAShmm.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/shivas/SHIVASmodi.html
+++ b/maps/map_briefings/commanding_officer/shivas/SHIVASmodi.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/shivas/SHIVASunaligned.html
+++ b/maps/map_briefings/commanding_officer/shivas/SHIVASunaligned.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/sorokyne/SOROKYNEcpo.html
+++ b/maps/map_briefings/commanding_officer/sorokyne/SOROKYNEcpo.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/sorokyne/SOROKYNEhmm.html
+++ b/maps/map_briefings/commanding_officer/sorokyne/SOROKYNEhmm.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/sorokyne/SOROKYNEmodi.html
+++ b/maps/map_briefings/commanding_officer/sorokyne/SOROKYNEmodi.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/sorokyne/SOROKYNEunaligned.html
+++ b/maps/map_briefings/commanding_officer/sorokyne/SOROKYNEunaligned.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/trijent_dam/TRIJENTDAMcpo.html
+++ b/maps/map_briefings/commanding_officer/trijent_dam/TRIJENTDAMcpo.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/trijent_dam/TRIJENTDAMhmm.html
+++ b/maps/map_briefings/commanding_officer/trijent_dam/TRIJENTDAMhmm.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/trijent_dam/TRIJENTDAMmodi.html
+++ b/maps/map_briefings/commanding_officer/trijent_dam/TRIJENTDAMmodi.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">

--- a/maps/map_briefings/commanding_officer/trijent_dam/TRIJENTDAMunaligned.html
+++ b/maps/map_briefings/commanding_officer/trijent_dam/TRIJENTDAMunaligned.html
@@ -1,6 +1,6 @@
 <style>
 	body {
-	background-image: url('background_dark2.jpg');
+	background-image: url("%%DARKBACKGROUND%%");
 	}
 </style>
 <font color="#ffffff">


### PR DESCRIPTION

# About the pull request

Fixes a fun little typo in my code for #10641 that incorrectly references the dark background jpg, and makes the background white, with white ink.

All hyper-classified documents no longer use invisible ink, COs no longer require UV pen lights to read their mission reports, and the lore faxes have dark background for real this time

# Explain why it's good for the game

Apparently the 3rd regiment cant afford enough UV penlights for each battalion

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: CO lore faxes no longer use invisible ink
/:cl:
