### PR TITLE
Tracker can be clicked with objects in hand, unless we're on Harm intent

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -481,7 +481,7 @@
 	else if(mods[ALT_CLICK])
 		earpiece.switch_tracker_target()
 		return
-	if(user.get_active_hand())
+	if(user.a_intent == INTENT_HARM && user.get_active_hand()) //Stop it popping up in combat(hopefully), but work any other time.
 		return
 	if(user.assigned_squad)
 		user.assigned_squad.tgui_interact(user)


### PR DESCRIPTION
# About the pull request
Title
Resolves: #6967
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Uhhhhh QOL I guess?
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MistChristmas
qol: Tracker no longer needs empty active hand to be accessed with a normal left click, but needs intent other than harm if something is in hands
/:cl:
