### PR TITLE
Fixes facehuggers ignoring hug proof equipment.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -554,11 +554,14 @@
 					m_helmet.add_hugger_damage()
 				update_inv_head()
 
-	if(!wear_mask)
+	/// Don't need to continue if no mask or already can't infect.
+	if(!wear_mask || !can_infect)
 		return can_infect
 
 	var/obj/item/clothing/mask/W = wear_mask
-	if(istype(W))
+	if(!istype(W))
+		drop_inv_item_on_ground(wear_mask) // drop any item from the face that isn't being checked for anti-hug.
+	else
 		if(W.flags_item & NODROP)
 			return FALSE
 
@@ -573,12 +576,10 @@
 			if(prob(15)) //15% chance the hugger will go idle after ripping off a mask. Otherwise it will keep going.
 				hugger.go_idle()
 				return FALSE
-			return FALSE
+			can_infect = FALSE
 		else
 			visible_message(SPAN_DANGER("[hugger] smashes against [src]'s [W.name] and rips it off!"))
 			drop_inv_item_on_ground(W)
-	if(wear_mask)
-		drop_inv_item_on_ground(wear_mask) // drop any item from the face that wasn't handled above (e.g cigs, glasses)
 	return can_infect
 
 /datum/species/proc/handle_hugger_attachment(mob/living/carbon/human/target, obj/item/clothing/mask/facehugger/hugger, mob/living/carbon/xenomorph/facehugger/mob_hugger)


### PR DESCRIPTION

# About the pull request

Recent PR #11047 broke pred masks and any other mask that stops facehuggers.

# Explain why it's good for the game

This is bad.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixes facehuggers bypassing hug resistant masks.
/:cl:
