### PR TITLE
Atomizing #11115 Part 3: MS-11 Smart Refill Tank & Pressurized Reagent Canister Update

### DIFF
--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -305,7 +305,7 @@
 		/obj/item/reagent_container/hypospray/autoinjector/ultrazine,
 
 		/obj/item/reagent_container/hypospray/autoinjector/ez, //remember, all ez autoinjectors are skillless
-		/obj/item/reagent_container/hypospray/autoinjector/marine, //remember, this includes marine/tramadol
+		/obj/item/reagent_container/hypospray/autoinjector/skillless, //remember, this includes marine/tramadol
 
 	)
 /obj/item/reagent_container/glass/minitank/on_reagent_change()


### PR DESCRIPTION
# WARNING: CHECKS WILL FAIL UNLESS #11346 IS MERGED FIRST!

# About the pull request

Checkmarks mean tested and successful in repeat attempts (several days worth of testing, trust)

- [x] 1. Fixes #10916
- [x] 2. Smart Refill tanks are even smarter, now! It has 6 error dialogues for why it cannot fill an autoinjector.
- [x] 3. Smart Refill tanks can now refill autoinjectors that are partially filled.
- [x] 4. Smart Refill tanks recognize pathogen cure autoinjectors and ultrazine autoinjectors.
- [x] 5. You can now flush a Pressurized Reagent Canister without the need for it to be in the pouch, first.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

1. Smart Refill tanks were not very smart at all! They could not identify single-use autoinjectors; refilling pain-stop, first-aid, and ez autoinjectors were out of the question. In addition, it only recognized empty autoinjectors that needed refilling. Now, it intelligently differentiates between single-use and three-use autoinjectors AND can partially refill said autoinjectors with the precise amount of chemicals left in the tank.

2. 	It's a very smart tank! Now, it has several reasons for refusal:

	1. It recognizes the autoinjector in question must be refilled with a pressurized reagent canister pouch.
	2. It recognizes the autoinjector cannot be refilled by any means and must be disposed of. (You have an emergency autoinjector or a sleep toxin autoinjector.)
	3. It recognizes that the autoinjector's valves are incompatible with the tank. ((It does not accept autoinjectors that contain massive amounts of chemicals or potentially toxic chemicals, like sleep toxin+chloral hydrate.))
	4. The tank knows when it is empty. No chemicals until you fill it with something.
	5. It knows the autoinjector is full, so it refuses to add any more chemicals.
	6. Tank recognizes the autoinjector, but it cannot find enough reagents inside itself to fill it.


3. It's a smart little tank.
4. It's a VERY smart little tank.
5. You can flush the canister while it's in the pouch... But not flush the canister by itself? That did not make any sense to me, so I decided to add this feature.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Puckaboo2
add: Smart Refill tanks have 6 complete reasons for refusing to fill an autoinjector.
add: Smart Refill tanks can now recognize autoinjectors that are not fully emptied and try to refill them without wasting chemicals.
add: Smart Refill tanks can now fill pain-stop/first-aid autoinjectors and one-use EZ autoinjectors. As a bonus, it can also fill Ultrazine and pathogen cure autoinjectors.
add: You can now flush a Pressurized Reagent Canister without the need for it to be in a pouch, first.
fix:  Smart Refill tanks can now differentiate between ez/pain-stop/first-aid autoinjectors and standard Wey-Med varieties and fill both kinds without wasting chemicals.
/:cl:
