### PR TITLE
Fixes Abduct going through wall griders.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/oppressor.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/oppressor.dm
@@ -118,6 +118,9 @@
 				continue
 			if(!structure.density && !structure.opacity)
 				continue
+			if(istype(structure, /obj/structure/girder))
+				blocked = TRUE
+				continue
 			if(istype(structure, /obj/structure/window/reinforced))
 				var/obj/structure/window/reinforced/pane_glass = structure
 				var/pane_facing = pane_glass.dir


### PR DESCRIPTION
# About the pull request

Fix issue implemented with #9575

Fixes: #11360


# Explain why it's good for the game

Not intentional behavior.

# Testing Photographs and Procedure

Tryied to cast trough wall grider, and ability got stopped.


# Changelog

:cl: Venuska1117
fix: Abduct can no longer can pass through wall griders.
/:cl:
