### PR TITLE
Fix: Acid Harness not accounting for actual reagent amount in OD check

### DIFF
--- a/code/modules/reagents/chemistry_machinery/acid_harness.dm
+++ b/code/modules/reagents/chemistry_machinery/acid_harness.dm
@@ -497,8 +497,6 @@
 	if(!acid_harness.beaker || !acid_harness.beaker.reagents)
 		voice("Warning: Medicinal container missing.")
 		return
-	var/reagents_in_harness = length(acid_harness.beaker.reagents.reagent_list)
-
 	for(var/datum/reagent/R in acid_harness.beaker.reagents.reagent_list)
 		var/amount_in_inject = (acid_harness.beaker.reagents.get_reagent_amount(R.id) / acid_harness.beaker.reagents.total_volume) * inject_amount
 		if(R.overdose && (user.reagents.get_reagent_amount(R.id) + amount_in_inject) > R.overdose) //Don't overdose our boi


### PR DESCRIPTION

# About the pull request
Resolves: #11338
In fairness no one bug reported it before I batched my other fixes so I didn't check the math...
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Fixy Fix for the few people that use this forsaken thing.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MistChristmas
fix: Acid Harness no longer warns of erroneous ODs when you have more than one reagent
/:cl:
