### PR TITLE
Adds a supply crate with only surgical beds

### DIFF
--- a/code/datums/supply_packs/medical.dm
+++ b/code/datums/supply_packs/medical.dm
@@ -130,12 +130,12 @@
 /datum/supply_packs/surgery/beds
 	name = "surgery crate (surgical beds)"
 	contains = list(
-	/obj/item/roller/surgical,
-	/obj/item/roller/surgical,
-	/obj/item/roller/surgical,
-	/obj/item/roller/surgical,
-	/obj/item/roller/surgical,
-	/obj/item/roller/surgical,
+		/obj/item/roller/surgical,
+		/obj/item/roller/surgical,
+		/obj/item/roller/surgical,
+		/obj/item/roller/surgical,
+		/obj/item/roller/surgical,
+		/obj/item/roller/surgical,
 	)
 	cost = 25
 	containertype = /obj/structure/closet/crate/secure/surgery


### PR DESCRIPTION

# About the pull request

Makes a supply crate with only surgical beds

# Explain why it's good for the game

Some chucklefuck took off with all the surgical beds in storage and a few in the OR, leaving for the rest of us to fight for more beds. 

That's not happening again.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Puckaboo2
add: Adds a supply crate with only surgical beds
/:cl:
