### PR TITLE
fixes a bug with larva instantly igniting after bursting

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Embryo.dm
@@ -337,9 +337,9 @@
 
 	for(var/mob/living/carbon/xenomorph/larva/larva_embryo in victim)
 		var/datum/hive_status/hive = GLOB.hive_datum[larva_embryo.hivenumber]
+		larva_embryo.grant_spawn_protection(1 SECONDS)
 		larva_embryo.forceMove(get_turf(victim)) //moved to the turf directly so we don't get stuck inside a cryopod or another mob container.
 		SEND_SIGNAL(larva_embryo, COMSIG_MOVABLE_Z_CHANGED, 0, (get_turf(victim)).z)
-		larva_embryo.grant_spawn_protection(1 SECONDS)
 		playsound(larva_embryo, pick('sound/voice/alien_chestburst.ogg','sound/voice/alien_chestburst2.ogg'), 25)
 
 		if(larva_embryo.client)


### PR DESCRIPTION
# About the pull request

Larva that spawn on a tile that already has fire on it will now not ignite for about one second as intended in https://github.com/cmss13-devs/cmss13/pull/7728 .

# Explain why it's good for the game

fixes bug. (also it's just not very fun for the larva player to instantly die because people meta the burstscream sound to know exactly when they will burst)


# Testing Photographs and Procedure
i didn't take a video but i tested it on local before and after, it worked


# Changelog
:cl:
fix: Larva that chestburst onto a tile that already has fire on it will no longer ignite
/:cl:
