### PR TITLE
Lowers Pylon Timer to 00:30

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -200,7 +200,7 @@
 #define XENO_BURIED_LARVA_TIME_LIMIT (30 MINUTES)
 
 /// The time when xenos can start taking over comm towers
-#define XENO_COMM_ACQUISITION_TIME (30 MINUTES)
+#define XENO_COMM_ACQUISITION_TIME (25 MINUTES)
 
 /// The time it takes for a pylon to give one royal resin while activated
 #define XENO_PYLON_ACTIVATION_COOLDOWN (5 MINUTES)


### PR DESCRIPTION
# About the pull request

If I've understood the pylon code + what a define is correctly, this PR *should* lower the Comms Pylon Timer to 00:30 (00:25 + 5 minute lobby).

From memory... no weedkiller placements would clear out any Comms Pylons aside from Fiorina which has Engi Ring (in a circle around Comms, but not the relay areas themselves) + LZ2 Weedkillered but... ***I'm not sure if I should be changing that in this PR or at all***

# Explain why it's good for the game

Following from: https://forum.cm-ss13.com/t/let-xenos-pylon-from-00-30/18623/12 which was somewhat discussed...

This might give Xenos an objective to hold outside of caves as an alternative to a sensor hold inside caves, by allowing them to power up earlier if they manage to hold vs Marines at Comms..

This might hypothetically also give backliners (both Marines and Xenos) a tangible objective to fight over and focus on, most CM13 rounds (in my experience) are under FOB Siege around 01:00 which means this is primarily a slowly ticking timer to get King rather than an objective that's in play round-to-round like Sensors. Similarly, while you can already break the Comms towers as a side objective, it's quickly repaired and getting resin jelly from towers is a much more tangible win and objective for Xenos than temporarily disabling Comms.

The timer is set to 00:30 (including 5 minute lobby) with the idea that it doesn't punish slower drops but also makes it soonish after drop to let Xenos realistically contest relay(s).


# Testing Photographs and Procedure

<img width="1920" height="1025" alt="image" src="https://github.com/user-attachments/assets/83f40a9e-b4ba-4d0e-8057-f3ea83013d3e" />


# Changelog

:cl: DangerRevolution
balance: Lowered Clusters becoming Pylons from 01:00 to 00:30
/:cl:
