### PR TITLE
Remove the mention of firemodes (burst) on the M56D's description.

### DIFF
--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -463,7 +463,7 @@
 // The actual Machinegun itself, going to borrow some stuff from current sentry code to make sure it functions. Also because they're similiar.
 /obj/structure/machinery/m56d_hmg
 	name = "\improper M56D heavy machine gun"
-	desc = "A deployable, heavy machine gun. While it is capable of taking the same rounds as the M56, it fires specialized tungsten rounds for increased armor penetration.<br>Drag its sprite onto yourself to man it. Ctrl-click it to cycle through firemodes."
+	desc = "A deployable, heavy machine gun. While it is capable of taking the same rounds as the M56, it fires specialized tungsten rounds for increased armor penetration.<br>Drag its sprite onto yourself to man it."
 	icon = 'icons/obj/items/weapons/guns/guns_by_faction/USCM/hmg.dmi'
 	icon_state = "M56D"
 	anchored = TRUE


### PR DESCRIPTION

# About the pull request

Removes the mention of different firemodes on the M56D's description, since burst fire was removed a year ago.

# Explain why it's good for the game
Making sure that the few people who DO read items description don't get false info.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="774" height="63" alt="image" src="https://github.com/user-attachments/assets/41f6271e-1785-4ce2-a8ea-297309e3ecc4" />

</details>


# Changelog
:cl:

del: Removed the M56D's description mention of other firemodes.

/:cl:
