### PR TITLE
Add ChemMaster toggle to auto-select inserted pill bottles

### DIFF
--- a/code/modules/reagents/chemistry_machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_master.dm
@@ -20,7 +20,7 @@
 	var/condi = 0
 	var/useramount = 30 // Last used amount
 	var/pillamount = 16
-	var/bottle_select = FALSE
+	var/bottle_autoselect = FALSE //Toggle for whether extra new bottles are added to to_fill list
 	var/bottlesprite = "1" //yes, strings
 	var/pillsprite = "1"
 	var/client/has_sprites = list()
@@ -139,7 +139,7 @@
 
 	loaded_pill_bottles += bottle
 
-	if (length(loaded_pill_bottles) == 1 || length(loaded_pill_bottles_to_fill) == 0 || bottle_select)
+	if (length(loaded_pill_bottles) == 1 || length(loaded_pill_bottles_to_fill) == 0 || bottle_autoselect)
 		loaded_pill_bottles_to_fill += bottle
 
 
@@ -167,7 +167,7 @@
 	.["mode"] = mode
 	.["pillsprite"] = pillsprite
 	.["bottlesprite"] = bottlesprite
-	.["bottle_select"] = bottle_select
+	.["bottle_autoselect"] = bottle_autoselect
 
 	.["pill_bottles"] = list()
 	if(length(loaded_pill_bottles) > 0)
@@ -708,8 +708,8 @@
 				loaded_pill_bottles_to_fill = list()
 			return TRUE
 
-		if("bottle_select_toggle")
-			bottle_select = !bottle_select
+		if("bottle_autoselect_toggle")
+			bottle_autoselect = !bottle_autoselect
 			return TRUE
 
 /obj/structure/machinery/chem_master/attack_hand(mob/living/user)

--- a/tgui/packages/tgui/interfaces/ChemMaster.tsx
+++ b/tgui/packages/tgui/interfaces/ChemMaster.tsx
@@ -43,7 +43,7 @@ type ChemMasterData = {
   };
   buffer?: Reagent[];
   mode: BooleanLike;
-  bottle_select: BooleanLike;
+  bottle_autoselect: BooleanLike;
   pill_or_bottle_icon: string;
   pill_icon_choices: number;
   bottle_icon_choices: number;
@@ -293,12 +293,12 @@ export const ChemMaster = () => {
                             : 'Select All'}
                         </Button>
                         <Button.Checkbox
-                          checked={data.bottle_select}
+                          checked={data.bottle_autoselect}
                           tooltip={
                             'If checked, new pill bottles will be autoselected'
                           }
                           onClick={() => {
-                            act('bottle_select_toggle');
+                            act('bottle_autoselect_toggle');
                           }}
                         >
                           Auto-select


### PR DESCRIPTION
# About the pull request

When multiple pill bottles are inserted, adds a checkbox toggle to enable the auto-selection of new pill bottles.

# Explain why it's good for the game

Saves clicks for chemline workers that load pill bottles as needed without affecting the ones that pre-load.

# Testing Photographs and Procedure

Tested bottle insert/eject functionality, made some pills. 
Made sure it didn't affect OT and worked in research as well.
<details>
<summary>Screenshots & Videos</summary>

![chemmaster_auto](https://github.com/user-attachments/assets/7c230f56-b520-469c-a18b-0ddaad11f7d7)

</details>

# Changelog

:cl:
qol: ChemMaster toggle to allow pill bottle auto-selection
/:cl:

