### PR TITLE
Fix: Stop orbiting ghosts from dragging items out of inventories

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -308,6 +308,9 @@
 /atom/movable/screen/inventory/proc/handle_dropped_on(atom/dropped_on, atom/dropping, client/user)
 	SIGNAL_HANDLER
 
+	if(!isliving(user.mob))
+		return
+
 	if(slot_id != WEAR_L_HAND && slot_id != WEAR_R_HAND)
 		return
 


### PR DESCRIPTION
# About the pull request
Title.
Orbiting ghosts could move items from open inventories into the hand to force drop them as it tried to put the object in the ghost's hands, so they will contain at least one item if they do this, two if the player swaps hands.

Resolves: #11419
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
No haunting allowed
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MistChristmas
fix: Ghosts no longer able to move items out of open inventories when orbiting
/:cl:
