### PR TITLE
Fix: Coffee Machine not checking if hands are occupied.

### DIFF
--- a/code/game/objects/structures/hybrisa_props.dm
+++ b/code/game/objects/structures/hybrisa_props.dm
@@ -1846,7 +1846,11 @@
 	if(..())
 		return TRUE
 
-	if(!brewing && cup && user.Adjacent(src) && user.put_in_hands(cup))
+	if(brewing)
+		to_chat(user, SPAN_WARNING("[src] is still brewing [vends]."))
+		return FALSE
+
+	if(cup && user.Adjacent(src) && user.put_in_hands(cup, FALSE))
 		to_chat(user, SPAN_NOTICE("You take [cup] in your hand."))
 		cup = null
 		update_icon()
@@ -1885,7 +1889,7 @@
 /obj/structure/machinery/hybrisa/coffee_machine/proc/vend_coffee(mob/user, amount)
 	brewing = FALSE
 	cup?.reagents?.add_reagent(vends, amount)
-	if(user?.Adjacent(src) && user.put_in_hands(cup))
+	if(user?.Adjacent(src) && user.put_in_hands(cup, FALSE))
 		to_chat(user, SPAN_NOTICE("You take [cup] in your hand."))
 		cup = null
 	else


### PR DESCRIPTION

# About the pull request
Resolves: #11417
No cup duplication please. Don't drop things to the floor just because we can't put them in hands when we don't handle them.
Adds verbosity about the coffee still brewing when you try to grab it early.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Coffee Addicted Medical staff don't duplicate their coffee cups.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MistChristmas
fix: Coffee Machine no longer generates a magical cup when you brew coffee with your hands full.
/:cl:
