### PR TITLE
Fixes #9856, changes depreciated Spitter Frenzy verb/macro to Charge Spit and makes it visible

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Spitter.dm
@@ -86,7 +86,7 @@
 	to_chat(zenomorf, SPAN_XENOHIGHDANGER("We accumulate acid in your glands. Our next spit will be stronger but shorter-ranged."))
 	to_chat(zenomorf, SPAN_XENOWARNING("Additionally, we are slightly faster and more armored for a small amount of time."))
 	zenomorf.create_custom_empower(icolor = "#93ec78", ialpha = 200, small_xeno = TRUE)
-	zenomorf.balloon_alert(zenomorf, "Our next spit will be stronger.", text_color = "#93ec78")
+	zenomorf.balloon_alert(zenomorf, "our next spit will be stronger", text_color = "#93ec78")
 	buffs_active = TRUE
 	zenomorf.ammo = GLOB.ammo_list[/datum/ammo/xeno/acid/spatter] // shitcode is my city
 	zenomorf.speed_modifier -= speed_buff_amount
@@ -107,7 +107,7 @@
 	var/mob/living/carbon/xenomorph/zenomorf = owner
 	if(zenomorf.ammo == GLOB.ammo_list[/datum/ammo/xeno/acid/spatter])
 		to_chat(zenomorf, SPAN_XENOWARNING("Our acid glands empty out and return back to normal. We will once more fire long-ranged weak spits."))
-		zenomorf.balloon_alert(zenomorf, "Our spits return to normal strength.", text_color = "#93ec78")
+		zenomorf.balloon_alert(zenomorf, "our spits are back to normal", text_color = "#93ec78")
 		zenomorf.ammo = GLOB.ammo_list[/datum/ammo/xeno/acid] // el codigo de mierda es mi ciudad
 	UnregisterSignal(zenomorf, COMSIG_XENO_POST_SPIT)
 


### PR DESCRIPTION
# About the pull request
Fixes #9856, where Spitter Frenzy should have been renamed to Charge Spit.

# Explain why it's good for the game
Spitter Frenzy is depreciated. The new macro and verb in the sidebar is now Charge Spit, as it should have been. 

# Testing Photographs and Procedure
<img width="1605" height="511" alt="image" src="https://github.com/user-attachments/assets/7e1f0310-2f10-41e1-892c-c06ecd4c2c34" />

<summary>Screenshots & Videos</summary>
<img width="1605" height="511" alt="image" src="https://github.com/user-attachments/assets/33a9d400-3877-4add-9794-579d057af3e6" />
![dreamseeker_2025-12-31_19-41-38](https://github.com/user-attachments/assets/d1e5a97f-1dd5-49d4-a8d8-a3bb53f53cf5)
Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Puckaboo2
del: Removed Spitter Frenzy's macro. Replaced it with Charge Spit.
fix: Spitter Frenzy should not show up in Spitter's Alien sidebar.
fix: Charge Spit should appear in Spitter's Alien sidebar.
/:cl:
