### PR TITLE
Fix Maps DB Stats

### DIFF
--- a/code/datums/statistics/entities/round_stats.dm
+++ b/code/datums/statistics/entities/round_stats.dm
@@ -22,8 +22,10 @@
 	var/total_friendly_fire_instances = 0
 	var/total_slashes = 0
 
-	// untracked data
+	// Sub entities
 	var/datum/entity/statistic/map/current_map // reference to current map
+
+	// untracked data
 	var/list/datum/entity/statistic/death/death_stats_list = list()
 
 	var/list/abilities_used = list() // types of /datum/entity/statistic, "tail sweep" = 10, "screech" = 2
@@ -62,6 +64,10 @@
 	QDEL_LIST_ASSOC_VAL(caste_stats_list)
 	QDEL_LIST_ASSOC_VAL(weapon_stats_list)
 	QDEL_LIST_ASSOC_VAL(job_stats_list)
+
+/datum/entity/statistic/round/save()
+	. = ..()
+	current_map?.save()
 
 /datum/entity_meta/statistic_round
 	entity_type = /datum/entity/statistic/round
@@ -112,6 +118,8 @@
 
 		// Map stats
 		var/datum/entity/statistic/map/new_map = DB_EKEY(/datum/entity/statistic/map, SSmapping.configs[GROUND_MAP].map_name)
+		new_map.save()
+		new_map.sync()
 		new_map.total_rounds++
 		new_map.save()
 


### PR DESCRIPTION

# About the pull request

This PR fixes a couple issues with maps db stats:
- `total_rounds` now actually waits for to read the existing count before adding to it
- calling `save` to round_statistics now also saves its current_map entity so that end round stats are written

I will likely mysql `delete from maps;` to start stats fresh once this is merged.

# Explain why it's good for the game

Fixes wonky data like this: 
<img width="1904" height="577" alt="image" src="https://github.com/user-attachments/assets/4d7c4d9f-c41f-4919-b31d-8c68cc612ee4" />
Total hijack count presumably correct just because DB finally has loaded by the time it would be adding a number.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="987" height="266" alt="image" src="https://github.com/user-attachments/assets/1ba726ea-2db3-4790-88c0-284e7e5d272a" />

</details>


# Changelog
:cl: Drathek
server: Map DB stats now save correctly
/:cl:
