### PR TITLE
Stasis bag changes

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -289,7 +289,6 @@
 	if(!opened && stasis_mob && open_cooldown <= world.time)
 		user.visible_message(SPAN_WARNING("[user] opens [src]."), SPAN_NOTICE("You open [src]."))
 		user.attack_log += text("\[[time_stamp()]\] opened stasis bag containing <b>[key_name(stasis_mob)]</b> at [get_area(src)] ([loc.x],[loc.y],[loc.z])")
-		attack_log += text("\[[time_stamp()]\] <font color='orange'>was [M.slash_verb]ed by [key_name(M)] at [get_area(src)] ([loc.x],[loc.y],[loc.z])</font>")
 		stasis_mob.attack_log += text("\[[time_stamp()]\] had their stasis bag opened by <b>[key_name(user)]</b> at [get_area(src)] ([loc.x],[loc.y],[loc.z])")
 	. = ..()
 


### PR DESCRIPTION
# About the pull request

Cooldown check for opening a stasis bag now checks when you try to open it, rather than closing it. Message about opening a bag is now only triggered when opening a stasis bag with a mob inside, as intended when I added it in the other PR. Opening a stasis bag with someone inside is now logged in the attack logs (for when people open stasis bags to grief the hugged people inside)

# Explain why it's good for the game

Makes logs more useful when encountering this kind of grief. Also opening the bag is a bigger deal than closing it so the cooldown and message should just trigger on opening.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
admin: added logging in attack log for when people open stasis bags to grief the hugged people inside
qol: stasis bags now check for the open/close cooldown when opening the bag instead of closing it.
fix: message about opening a bag only appears when opening a stasis bag with a mob inside
/:cl:
