### PR TITLE
Disable AI slop in VSC workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,69 +43,69 @@
 	"dreammaker.reparseOnSave": true,
 	"dreammaker.autoUpdate": true,
 	"accessibility.verbosity.inlineChat": false,
-    "accessibility.verbosity.panelChat": false,
-    "ansible.lightspeed.suggestions.waitWindow": 360000,
-    "chat.agent.enabled": false,
-    "chat.agent.maxRequests": 0,
-    "chat.commandCenter.enabled": false,
-    "chat.detectParticipant.enabled": false,
-    "chat.disableAIFeatures": true,
-    "chat.extensionTools.enabled": false,
-    "chat.focusWindowOnConfirmation": false,
-    "chat.implicitContext.enabled": {
-        "panel": "never"
-    },
-    "chat.implicitContext.suggestedContext": false,
-    "chat.instructionsFilesLocations": {
-        ".github/instructions": false
-    },
-    "chat.mcp.access": "none",
-    "chat.mcp.discovery.enabled": {
-        "claude-desktop": false,
-        "windsurf": false,
-        "cursor-global": false,
-        "cursor-workspace": false
-    },
-    "chat.promptFiles": false,
-    "chat.promptFilesLocations": {
-        ".github/prompts": false
-    },
-    "chat.sendElementsToChat.attachCSS": false,
-    "chat.sendElementsToChat.attachImages": false,
-    "chat.sendElementsToChat.enabled": false,
-    "chat.setupFromDialog": false,
-    "chat.showAgentSessionsViewDescription": false,
-    "chat.tools.todos.showWidget": false,
-    "chat.useAgentsMdFile": false,
-    "chat.useFileStorage": false,
-    "dataWrangler.experiments.copilot.enabled": false,
-    "github.copilot.editor.enableAutoCompletions": false,
-    "github.copilot.editor.enableCodeActions": false,
-    "github.copilot.enable": false,
-    "github.copilot.nextEditSuggestions.enabled": false,
-    "github.copilot.renameSuggestions.triggerAutomatically": false,
-    "githubPullRequests.codingAgent.enabled": false,
-    "githubPullRequests.experimental.chat": false,
-    "gitlab.duoChat.enabled": false,
-    "mcp": {
-        "inputs": [],
-        "servers": {}
-    },
-    "notebook.experimental.generate": false,
-    "python.analysis.aiCodeActions": {
-        "convertFormatString": false,
-        "convertLambdaToNamedFunction": false,
-        "generateDocstring": false,
-        "generateSymbol": false,
-        "implementAbstractClasses": false
-    },
-    "python.experiments.enabled": false,
-    "redhat.telemetry.enabled": false,
-    "remote.SSH.experimental.chat": false,
-    "telemetry.feedback.enabled": false,
-    "terminal.integrated.initialHint": false,
-    "workbench.editor.empty.hint": "hidden",
-    "workbench.settings.showAISearchToggle": false,
+	"accessibility.verbosity.panelChat": false,
+	"ansible.lightspeed.suggestions.waitWindow": 360000,
+	"chat.agent.enabled": false,
+	"chat.agent.maxRequests": 0,
+	"chat.commandCenter.enabled": false,
+	"chat.detectParticipant.enabled": false,
+	"chat.disableAIFeatures": true,
+	"chat.extensionTools.enabled": false,
+	"chat.focusWindowOnConfirmation": false,
+	"chat.implicitContext.enabled": {
+		"panel": "never"
+	},
+	"chat.implicitContext.suggestedContext": false,
+	"chat.instructionsFilesLocations": {
+		".github/instructions": false
+	},
+	"chat.mcp.access": "none",
+	"chat.mcp.discovery.enabled": {
+		"claude-desktop": false,
+		"windsurf": false,
+		"cursor-global": false,
+		"cursor-workspace": false
+	},
+	"chat.promptFiles": false,
+	"chat.promptFilesLocations": {
+		".github/prompts": false
+	},
+	"chat.sendElementsToChat.attachCSS": false,
+	"chat.sendElementsToChat.attachImages": false,
+	"chat.sendElementsToChat.enabled": false,
+	"chat.setupFromDialog": false,
+	"chat.showAgentSessionsViewDescription": false,
+	"chat.tools.todos.showWidget": false,
+	"chat.useAgentsMdFile": false,
+	"chat.useFileStorage": false,
+	"dataWrangler.experiments.copilot.enabled": false,
+	"github.copilot.editor.enableAutoCompletions": false,
+	"github.copilot.editor.enableCodeActions": false,
+	"github.copilot.enable": false,
+	"github.copilot.nextEditSuggestions.enabled": false,
+	"github.copilot.renameSuggestions.triggerAutomatically": false,
+	"githubPullRequests.codingAgent.enabled": false,
+	"githubPullRequests.experimental.chat": false,
+	"gitlab.duoChat.enabled": false,
+	"mcp": {
+		"inputs": [],
+		"servers": {}
+	},
+	"notebook.experimental.generate": false,
+	"python.analysis.aiCodeActions": {
+		"convertFormatString": false,
+		"convertLambdaToNamedFunction": false,
+		"generateDocstring": false,
+		"generateSymbol": false,
+		"implementAbstractClasses": false
+	},
+	"python.experiments.enabled": false,
+	"redhat.telemetry.enabled": false,
+	"remote.SSH.experimental.chat": false,
+	"telemetry.feedback.enabled": false,
+	"terminal.integrated.initialHint": false,
+	"workbench.editor.empty.hint": "hidden",
+	"workbench.settings.showAISearchToggle": false,
 	"C_Cpp.copilotHover": "disabled",
 	"chat.tools.terminal.enableAutoApprove": false,
 	"chat.undoRequests.restoreInput": false,
@@ -121,6 +121,6 @@
 	"chat.useNestedAgentsMdFiles": false,
 	"chat.tools.global.autoApprove": false,
 	"chat.mcp.gallery.enabled": false,
-    "mermaid-chat.enabled": false,
-    "githubPullRequests.experimental.useQuickChat": false
+	"mermaid-chat.enabled": false,
+	"githubPullRequests.experimental.useQuickChat": false
 }


### PR DESCRIPTION
# About the pull request

This PR should disable most AI slop in VSC (but unfortunately they will continue to introduce a million new settings next month too that have to be opted out) since this repository does not allow it: https://github.com/cmss13-devs/cmss13/blob/master/.github/CONTRIBUTING.md#generative-ai

If you are a fork that does allow slop, then its on you to modify your workplace settings yourself should you pull this.

Largely based on settings from https://gist.github.com/rpavlik/95d6c40d8407805e2c20bdf6d9efa44e but also some settings I also found too.

Let me know if I missed anything, or something is incorrect.

# Changelog

No player facing changes.
