### PR TITLE
Spellchecks 'resistible', multiple', 'multiplied', and 'inheritable'

### DIFF
--- a/code/datums/effects/tether.dm
+++ b/code/datums/effects/tether.dm
@@ -71,11 +71,11 @@
 	effect_name = "tethered"
 	flags = INF_DURATION
 	var/datum/effects/tethering/tether
-	var/resistable = FALSE
+	var/resistible = FALSE
 	var/resist_time = 15 SECONDS
 
-/datum/effects/tethered/New(atom/A, resistable)
-	src.resistable = resistable
+/datum/effects/tethered/New(atom/A, resistible)
+	src.resistible = resistible
 	..()
 
 /datum/effects/tethered/validate_atom(atom/A)
@@ -86,7 +86,7 @@
 
 /datum/effects/tethered/on_apply_effect()
 	RegisterSignal(affected_atom, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(check_move))
-	if (resistable)
+	if (resistible)
 		RegisterSignal(affected_atom, COMSIG_MOB_RESISTED, PROC_REF(resist_callback))
 
 // affected is always going to be the same as affected_atom
@@ -110,7 +110,7 @@
 		tether = null
 	if (affected_atom)
 		UnregisterSignal(affected_atom, COMSIG_MOVABLE_PRE_MOVE)
-		if (resistable)
+		if (resistible)
 			UnregisterSignal(affected_atom, COMSIG_MOB_RESISTED)
 	. = ..()
 
@@ -131,11 +131,11 @@
 
 // Tethers the tethered atom to the tetherer
 // If you want both atoms to be tethered to each other, pass in TRUE to the two_way arg
-/proc/apply_tether(atom/tetherer, atom/tethered, two_way = FALSE, range = 1, resistable = FALSE, icon = "chain", always_face = TRUE)
+/proc/apply_tether(atom/tetherer, atom/tethered, two_way = FALSE, range = 1, resistible = FALSE, icon = "chain", always_face = TRUE)
 	var/list/ret_list = list()
 
 	var/datum/effects/tethering/TR = new /datum/effects/tethering(tetherer, range, icon, always_face)
-	var/datum/effects/tethered/TD = new /datum/effects/tethered(tethered, resistable)
+	var/datum/effects/tethered/TD = new /datum/effects/tethered(tethered, resistible)
 	TR.set_tethered(TD)
 
 	ret_list["tetherer_tether"] = TR
@@ -143,7 +143,7 @@
 
 	if (two_way)
 		TR = new /datum/effects/tethering(tethered, icon)
-		TD = new /datum/effects/tethered(tetherer, resistable)
+		TD = new /datum/effects/tethered(tetherer, resistible)
 		TR.set_tethered(TD)
 		ret_list["tetherer_tethered"] = TD
 		ret_list["tethered_tether"] = TR

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -1,4 +1,4 @@
-//Largely negative status effects go here, even if they have small benificial effects
+//Largely negative status effects go here, even if they have small beneficial effects
 //STUN EFFECTS
 /datum/status_effect/incapacitating
 	tick_interval = -1
@@ -21,7 +21,7 @@
 		owner.update_stat()
 	return ..()
 
-#define MAX_RESISTABLE_STUN (20 SECONDS)
+#define MAX_RESISTIBLE_STUN (20 SECONDS)
 
 //STUN
 /datum/status_effect/incapacitating/stun
@@ -30,17 +30,17 @@
 	var/last_amount = 0
 //	alert_type = /atom/movable/screen/alert/status_effect/stun
 
-/datum/status_effect/incapacitating/stun/on_creation(mob/living/new_owner, set_duration, resistable=FALSE)
-	if(!resistable)
+/datum/status_effect/incapacitating/stun/on_creation(mob/living/new_owner, set_duration, resistible = FALSE)
+	if(!resistible)
 		if(new_owner)
 			last_amount = set_duration / new_owner.GetStunDuration(1)
 		return ..()
 
-	resist_duration = world.time + MAX_RESISTABLE_STUN
-	var/capped_amount = min(set_duration, MAX_RESISTABLE_STUN)
+	resist_duration = world.time + MAX_RESISTIBLE_STUN
+	var/capped_amount = min(set_duration, MAX_RESISTIBLE_STUN)
 	if(new_owner)
 		last_amount = capped_amount / new_owner.GetStunDuration(1)
-	return ..(new_owner, capped_amount, resistable)
+	return ..(new_owner, capped_amount, resistible)
 
 /datum/status_effect/incapacitating/stun/on_apply()
 	. = ..()
@@ -53,28 +53,28 @@
 	owner?.remove_traits(list(TRAIT_INCAPACITATED, TRAIT_IMMOBILIZED /*, TRAIT_HANDS_BLOCKED*/), TRAIT_STATUS_EFFECT(id))
 	return ..()
 
-/datum/status_effect/incapacitating/stun/update_duration(amount, increment, resistable=FALSE)
-	if(!resistable)
+/datum/status_effect/incapacitating/stun/update_duration(amount, increment, resistible = FALSE)
+	if(!resistible)
 		if(owner)
 			last_amount = amount / owner.GetStunDuration(1)
 		return ..()
 
 	if(resist_duration < 0)
-		resist_duration = world.time + MAX_RESISTABLE_STUN
+		resist_duration = world.time + MAX_RESISTIBLE_STUN
 
 	var/capped_amount = min(amount, resist_duration - world.time)
 	if(owner)
 		last_amount = capped_amount / owner.GetStunDuration(1)
 	return ..(capped_amount, increment)
 
-/datum/status_effect/incapacitating/stun/adjust_duration(amount, resistable=FALSE)
-	if(!resistable)
+/datum/status_effect/incapacitating/stun/adjust_duration(amount, resistible = FALSE)
+	if(!resistible)
 		if(owner)
 			last_amount = amount / owner.GetStunDuration(1)
 		return ..()
 
 	if(resist_duration < 0)
-		resist_duration = world.time + MAX_RESISTABLE_STUN
+		resist_duration = world.time + MAX_RESISTIBLE_STUN
 
 	var/capped_amount = min(amount, resist_duration - world.time)
 	if(owner)
@@ -86,7 +86,7 @@
 	desc = "You are incapacitated. You may not move or act."
 	icon_state = ALERT_INCAPACITATED
 
-#undef MAX_RESISTABLE_STUN
+#undef MAX_RESISTIBLE_STUN
 
 //KNOCKDOWN
 /datum/status_effect/incapacitating/knockdown

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -482,11 +482,11 @@
 	var/range = 5
 	/// Maximum possible damage before falloff.
 	var/damage = 110
-	/// Factor to mutiply the effect range has on damage.
+	/// Factor to multiply the effect range has on damage.
 	var/falloff_dam_reduction_mult = 20
 	/// Post falloff calc damage is divided by this to get xeno slowdown
 	var/xeno_slowdown_numerator = 11
-	/// Post falloff calc damage is multipled by this to get human stamina damage
+	/// Post falloff calc damage is multiplied by this to get human stamina damage
 	var/human_stam_dam_factor = 0.5
 
 /obj/item/explosive/grenade/sebb/Initialize()
@@ -576,14 +576,14 @@
 		sentry_stun.sentry_range = 0 // Temporarily "disable" the sentry by killing its range then setting it back.
 		new /obj/effect/overlay/temp/elec_arc(get_turf(sentry_stun))  // sprites are meh but we need visual indication that the sentry was messed up
 		addtimer(VARSET_CALLBACK(sentry_stun, sentry_range, initial(sentry_stun.sentry_range)), 5 SECONDS) // assure to set it back
-		sentry_stun.visible_message(SPAN_DANGER("[src]'s screen flickes violently as it's shocked!"))
-		sentry_stun.visible_message(SPAN_DANGER("[src] says \"ERROR: Fire control system resetting due to critical voltage flucuation!\""))
+		sentry_stun.visible_message(SPAN_DANGER("[src]'s screen flicks violently as it's shocked!"))
+		sentry_stun.visible_message(SPAN_DANGER("[src] says \"ERROR: Fire control system resetting due to critical voltage fluctuation!\""))
 		sparka.set_up(1, 1, sentry_stun)
 		sparka.start()
 
 	for(var/turf/turf in full_range)
 		if(prob(8))
-			var/datum/effect_system/spark_spread/sparkTurf = new //using a different spike system because the spark system doesn't like when you reuse it for differant things
+			var/datum/effect_system/spark_spread/sparkTurf = new //using a different spike system because the spark system doesn't like when you reuse it for different things
 			sparkTurf.set_up(1, 1, turf)
 			sparkTurf.start()
 		if(prob(10))
@@ -611,7 +611,7 @@
 				damage_applied *= 1.5
 				new /obj/effect/overlay/temp/elec_arc(get_turf(shocked_human))
 				to_chat(mob, SPAN_HIGHDANGER("All of your systems jam up as your main bus is overvolted by [damage_applied*2] volts."))
-				mob.visible_message(SPAN_WARNING("[mob] seizes up from the elctric shock."))
+				mob.visible_message(SPAN_WARNING("[mob] seizes up from the electric shock."))
 			shocked_human.take_overall_armored_damage(damage_applied, ARMOR_ENERGY, BURN, 90) // 90% chance to be on additional limbs
 			shocked_human.make_dizzy(damage_applied)
 			mob.apply_stamina_damage(damage_applied*human_stam_dam_factor) // Stamina damage

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -44,8 +44,8 @@
 			move_delay++
 		if(!working_hands)
 			return // No hands to drive your chair? Tough luck!
-		if(driver.pulling && driver.pulling.drag_delay && driver.get_pull_miltiplier()) //Dragging stuff can slow you down a bit.
-			var/pull_delay = driver.pulling.get_pull_drag_delay() * driver.get_pull_miltiplier()
+		if(driver.pulling && driver.pulling.drag_delay && driver.get_pull_multiplier()) //Dragging stuff can slow you down a bit.
+			var/pull_delay = driver.pulling.get_pull_drag_delay() * driver.get_pull_multiplier()
 			move_delay += max(driver.pull_speed + pull_delay + 3*driver.grab_level, 0) //harder grab makes you slower
 
 		if(isgun(driver.get_active_hand())) //Wheelchair user has a gun out, so obviously can't move

--- a/code/modules/admin/topic/topic_events.dm
+++ b/code/modules/admin/topic/topic_events.dm
@@ -142,9 +142,9 @@
 			for(var/datum/hive_status/permit_hive as anything in permit_hives)
 				//Give or remove the trait from newly-born xenos in this hive.
 				if(grant == "Grant")
-					LAZYADD(permit_hive.hive_inherant_traits, TRAIT_OPPOSABLE_THUMBS)
+					LAZYADD(permit_hive.hive_inherited_traits, TRAIT_OPPOSABLE_THUMBS)
 				else
-					LAZYREMOVE(permit_hive.hive_inherant_traits, TRAIT_OPPOSABLE_THUMBS)
+					LAZYREMOVE(permit_hive.hive_inherited_traits, TRAIT_OPPOSABLE_THUMBS)
 
 			if(!length(handled_xenos) && !length(permit_hives))
 				return
@@ -198,9 +198,9 @@
 			for(var/datum/hive_status/permit_hive as anything in permit_hives)
 				//Give or remove the trait from newly-born xenos in this hive.
 				if(grant == "Grant")
-					LAZYADD(permit_hive.hive_inherant_traits, TRAIT_CARDPLAYING_THUMBS)
+					LAZYADD(permit_hive.hive_inherited_traits, TRAIT_CARDPLAYING_THUMBS)
 				else
-					LAZYREMOVE(permit_hive.hive_inherant_traits, TRAIT_CARDPLAYING_THUMBS)
+					LAZYREMOVE(permit_hive.hive_inherited_traits, TRAIT_CARDPLAYING_THUMBS)
 
 			if(!length(handled_xenos) && !length(permit_hives))
 				return

--- a/code/modules/cm_preds/yaut_bracers.dm
+++ b/code/modules/cm_preds/yaut_bracers.dm
@@ -823,7 +823,7 @@
 
 	decloak(wearer, TRUE, DECLOAK_EXTINGUISHER)
 
-/obj/item/clothing/gloves/yautja/hunter/decloak(mob/user, forced, force_multipler = DECLOAK_FORCED)
+/obj/item/clothing/gloves/yautja/hunter/decloak(mob/user, forced, force_multiplier = DECLOAK_FORCED)
 	if(!user)
 		return
 
@@ -833,7 +833,7 @@
 	UnregisterSignal(user, COMSIG_HUMAN_PRE_BULLET_ACT)
 	UnregisterSignal(user, COMSIG_MOB_EFFECT_CLOAK_CANCEL)
 
-	var/decloak_timer = (DECLOAK_STANDARD * force_multipler)
+	var/decloak_timer = (DECLOAK_STANDARD * force_multiplier)
 	if(forced)
 		cloak_malfunction = world.time + decloak_timer
 

--- a/code/modules/cm_preds/yaut_items.dm
+++ b/code/modules/cm_preds/yaut_items.dm
@@ -934,7 +934,7 @@ GLOBAL_VAR_INIT(youngblood_timer_yautja, 0)
 	armed = FALSE
 	anchored = TRUE
 
-	var/list/tether_effects = apply_tether(src, C, range = tether_range, resistable = TRUE)
+	var/list/tether_effects = apply_tether(src, C, range = tether_range, resistible = TRUE)
 	tether_effect = tether_effects["tetherer_tether"]
 	RegisterSignal(tether_effect, COMSIG_PARENT_QDELETING, PROC_REF(disarm))
 
@@ -1129,7 +1129,7 @@ GLOBAL_VAR_INIT(youngblood_timer_yautja, 0)
 		return
 	handle_dissolve(target, user)
 
-///Checks for permission and items dissallowed to be dissolved.
+///Checks for permission and items unallowed to be dissolved.
 /obj/item/tool/yautja_cleaner/proc/can_dissolve(obj/item/target, mob/user)
 	if(!HAS_TRAIT(user, TRAIT_YAUTJA_TECH))
 		to_chat(user, SPAN_WARNING("You have no idea what this even does."))

--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -551,7 +551,7 @@
 	add_verb(user, /mob/living/carbon/human/proc/call_combi)
 	linked_to = user
 
-	var/list/tether_effects = apply_tether(user, src, range = 6, resistable = FALSE)
+	var/list/tether_effects = apply_tether(user, src, range = 6, resistible = FALSE)
 	chain = tether_effects["tetherer_tether"]
 	RegisterSignal(chain, COMSIG_PARENT_QDELETING, PROC_REF(cleanup_chain))
 	RegisterSignal(src, COMSIG_ITEM_PICKUP, PROC_REF(on_pickup))

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -63,7 +63,7 @@
 	if (hive)
 		hivenumber = hive
 		var/datum/hive_status/hive_s = GLOB.hive_datum[hivenumber]
-		for(var/trait in hive_s.hive_inherant_traits)
+		for(var/trait in hive_s.hive_inherited_traits)
 			ADD_TRAIT(src, trait, TRAIT_SOURCE_HIVE)
 
 	set_hive_data(src, hivenumber)

--- a/code/modules/mob/living/carbon/xenomorph/XenoAttacks.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoAttacks.dm
@@ -172,7 +172,7 @@
 			if(xeno.behavior_delegate)
 				damage = xeno.behavior_delegate.melee_attack_modify_damage(damage, src)
 
-			//Frenzy auras stack in a way, then the raw value is multipled by two to get the additive modifier
+			//Frenzy auras stack in a way, then the raw value is multiplied by two to get the additive modifier
 			if(xeno.frenzy_aura > 0)
 				damage += (xeno.frenzy_aura * FRENZY_DAMAGE_MULTIPLIER)
 

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -421,7 +421,7 @@
 			old_xeno.iff_tag = null
 
 	if(hive)
-		for(var/trait in hive.hive_inherant_traits)
+		for(var/trait in hive.hive_inherited_traits)
 			ADD_TRAIT(src, trait, TRAIT_SOURCE_HIVE)
 
 	//Set caste stuff
@@ -870,7 +870,7 @@
 /mob/living/carbon/xenomorph/get_eye_protection()
 	return EYE_PROTECTION_WELDING
 
-/mob/living/carbon/xenomorph/get_pull_miltiplier()
+/mob/living/carbon/xenomorph/get_pull_multiplier()
 	return pull_multiplier
 
 /mob/living/carbon/xenomorph/proc/set_faction(new_faction = FACTION_XENOMORPH)
@@ -887,7 +887,7 @@
 
 	new_hive.add_xeno(src)
 
-	for(var/trait in new_hive.hive_inherant_traits)
+	for(var/trait in new_hive.hive_inherited_traits)
 		ADD_TRAIT(src, trait, TRAIT_SOURCE_HIVE)
 
 	generate_name()

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -98,7 +98,7 @@
 			var/damage = rand(attacking_xeno.melee_damage_lower, attacking_xeno.melee_damage_upper) + dam_bonus
 			var/acid_damage = 0
 
-			//Frenzy auras stack in a way, then the raw value is multipled by two to get the additive modifier
+			//Frenzy auras stack in a way, then the raw value is multiplied by two to get the additive modifier
 			if(attacking_xeno.frenzy_aura > 0)
 				damage += (attacking_xeno.frenzy_aura * FRENZY_DAMAGE_MULTIPLIER)
 				if(acid_damage)
@@ -231,7 +231,7 @@
 			var/knocked_down
 			if(attacking_xeno.attempt_tackle(src, tackle_mult, tackle_min_offset, tackle_max_offset))
 				var/strength = rand(attacking_xeno.tacklestrength_min, attacking_xeno.tacklestrength_max)
-				var/datum/status_effect/incapacitating/stun/stun = Stun(strength, resistable=TRUE)
+				var/datum/status_effect/incapacitating/stun/stun = Stun(strength, resistible=TRUE)
 				var/stun_resisted = strength != stun.last_amount
 				playsound(loc, 'sound/weapons/alien_knockdown.ogg', 25, stun_resisted ? 1.5 : 0)
 				KnockDown(stun.last_amount) // Purely for knockdown visuals. All the heavy lifting is done by Stun
@@ -281,7 +281,7 @@
 			M.track_slashes(M.caste_type) //Adds to slash stat.
 			var/damage = rand(M.melee_damage_lower, M.melee_damage_upper)
 
-			//Frenzy auras stack in a way, then the raw value is multipled by two to get the additive modifier
+			//Frenzy auras stack in a way, then the raw value is multiplied by two to get the additive modifier
 			if(M.frenzy_aura > 0)
 				damage += (M.frenzy_aura * FRENZY_DAMAGE_MULTIPLIER)
 

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -72,7 +72,7 @@
 	/// If hit limit of larva from pylons
 	var/hit_larva_pylon_limit = FALSE
 
-	var/list/hive_inherant_traits
+	var/list/hive_inherited_traits
 
 	// Cultist Info
 	var/mob/living/carbon/leading_cult_sl
@@ -1319,7 +1319,7 @@
 	color = "#6abd99"
 	ui_color = "#6abd99"
 
-	hive_inherant_traits = list(TRAIT_XENONID, TRAIT_NO_COLOR)
+	hive_inherited_traits = list(TRAIT_XENONID, TRAIT_NO_COLOR)
 	latejoin_burrowed = FALSE
 
 /datum/hive_status/corrupted/tamed

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -312,7 +312,7 @@
 	clear_fullscreen("dazed")
 
 /*Heal 1/70th of your max health in brute per tick. 1 as a bonus, to help smaller pools.
-Additionally, recovery pheromones mutiply this base healing, up to 2.5 times faster at level 5
+Additionally, recovery pheromones multiply this base healing, up to 2.5 times faster at level 5
 Modified via m, to multiply the number of wounds healed.
 Heal from fire half as fast
 Xenos don't actually take oxyloss, oh well

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -150,7 +150,7 @@
 		if(client)
 			to_chat(usr, "[src]'s Metainfo:<br>[client.prefs.metadata]")
 		else
-			to_chat(usr, "[src] does not have any stored infomation!")
+			to_chat(usr, "[src] does not have any stored information!")
 	else
 		to_chat(usr, "OOC Metadata is not supported by this server!")
 
@@ -265,8 +265,8 @@
 	if (drowsiness > 0)
 		. += 6
 
-	if(pulling && pulling.drag_delay && get_pull_miltiplier()) //Dragging stuff can slow you down a bit.
-		var/pull_delay = pulling.get_pull_drag_delay() * get_pull_miltiplier()
+	if(pulling && pulling.drag_delay && get_pull_multiplier()) //Dragging stuff can slow you down a bit.
+		var/pull_delay = pulling.get_pull_drag_delay() * get_pull_multiplier()
 
 		var/grab_level_delay = 0
 		switch(grab_level)
@@ -300,7 +300,7 @@
 		. = drag_delay
 
 //whether we are slowed when dragging things
-/mob/living/proc/get_pull_miltiplier()
+/mob/living/proc/get_pull_multiplier()
 	if(!HAS_TRAIT(src, TRAIT_DEXTROUS))
 		if(grab_level == GRAB_CARRY)
 			return 0.1

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -104,7 +104,7 @@
 	if(S)
 		return S.get_duration_left() / GLOBAL_STATUS_MULTIPLIER
 	return 0
-/mob/living/proc/Stun(amount, resistable = FALSE)
+/mob/living/proc/Stun(amount, resistible = FALSE)
 	if(!(status_flags & CANSTUN))
 		return
 	amount = GetStunDuration(amount)
@@ -113,9 +113,9 @@
 		if(nst_stim.get_property(PROPERTY_NERVESTIMULATING))
 			nst_stim.volume += max(min((-1*amount)/10, 0), -10)
 	if(S)
-		S.update_duration(amount, increment=TRUE, resistable=resistable)
+		S.update_duration(amount, increment=TRUE, resistible=resistible)
 	else if(amount > 0)
-		S = apply_status_effect(/datum/status_effect/incapacitating/stun, amount, resistable)
+		S = apply_status_effect(/datum/status_effect/incapacitating/stun, amount, resistible)
 	return S
 /mob/living/proc/SetStun(amount, ignore_canstun = FALSE) //Sets remaining duration
 	if(!(status_flags & CANSTUN))

--- a/code/modules/vehicles/multitile/multitile_interaction.dm
+++ b/code/modules/vehicles/multitile/multitile_interaction.dm
@@ -262,7 +262,7 @@
 	if(X.caste == XENO_CASTE_RAVAGER || X.caste == XENO_CASTE_QUEEN)
 		damage_mult = 2
 
-	//Frenzy auras stack in a way, then the raw value is multipled by two to get the additive modifier
+	//Frenzy auras stack in a way, then the raw value is multiplied by two to get the additive modifier
 	if(X.frenzy_aura > 0)
 		damage += (X.frenzy_aura * FRENZY_DAMAGE_MULTIPLIER)
 
@@ -506,7 +506,7 @@
 		currently_dragged = G.grabbed_thing
 
 	if(currently_dragged != dragged_atom)
-		to_chat(user, SPAN_WARNING("You stop fiting [dragged_atom] inside \the [src]!"))
+		to_chat(user, SPAN_WARNING("You stop fitting [dragged_atom] inside \the [src]!"))
 		return
 
 	var/success = interior.enter(dragged_atom, entrance_used)


### PR DESCRIPTION
# About the pull request
'Resistible', multiple', 'multiplied', and 'inheritable' are no longer misspelled anywhere.

# Explain why it's good for the game
Spellchecks is good.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Puckaboo2
spellcheck: 'Resistible', multiple', 'multiplied', and 'inheritable' are no longer misspelled anywhere, among other words.
/:cl:
