### PR TITLE
Spellchecks 'transferred', 'transferring', 'suppress', 'modifying', 'chosen', + more spellchecks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -61,11 +61,11 @@
 	},
 	"chat.mcp.access": "none",
 	"chat.mcp.discovery.enabled": {
-        "claude-desktop": false,
-        "windsurf": false,
-        "cursor-global": false,
-        "cursor-workspace": false
-    },
+		"claude-desktop": false,
+		"windsurf": false,
+		"cursor-global": false,
+		"cursor-workspace": false
+	},
 	"chat.promptFiles": false,
 	"chat.promptFilesLocations": {
 		".github/prompts": false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -61,11 +61,11 @@
 	},
 	"chat.mcp.access": "none",
 	"chat.mcp.discovery.enabled": {
-		"claude-desktop": false,
-		"windsurf": false,
-		"cursor-global": false,
-		"cursor-workspace": false
-	},
+        "claude-desktop": false,
+        "windsurf": false,
+        "cursor-global": false,
+        "cursor-workspace": false
+    },
 	"chat.promptFiles": false,
 	"chat.promptFilesLocations": {
 		".github/prompts": false

--- a/code/__DEFINES/MC.dm
+++ b/code/__DEFINES/MC.dm
@@ -32,7 +32,7 @@
 #define STOP_PROCESSING(Processor, Datum) Datum.datum_flags &= ~DF_ISPROCESSING;Processor.processing -= Datum;Processor.currentrun -= Datum
 
 /// Returns true if the MC is initialized and running.
-/// Optional argument init_stage controls what stage the mc must have initializted to count as initialized. Defaults to INITSTAGE_MAX if not specified.
+/// Optional argument init_stage controls what stage the mc must have initialized to count as initialized. Defaults to INITSTAGE_MAX if not specified.
 #define MC_RUNNING(INIT_STAGE...) (Master && Master.processing > 0 && Master.current_runlevel && Master.init_stage_completed == (max(min(INITSTAGE_MAX, ##INIT_STAGE), 1)))
 
 #define MC_LOOP_RTN_NEWSTAGES 1

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -143,7 +143,7 @@
 // #define TRAIT_X "t_x"
 
 //-- mob traits --
-/// Apply this to make a mob not dense, and remove it when you want it to no longer make them undense, other sorces of undesity will still apply. Always define a unique source when adding a new instance of this!
+/// Apply this to make a mob not dense, and remove it when you want it to no longer make them undense, other sources of undensity will still apply. Always define a unique source when adding a new instance of this!
 #define TRAIT_UNDENSE "undense"
 /// Forces the user to stay unconscious.
 #define TRAIT_KNOCKEDOUT "knockedout"
@@ -153,7 +153,7 @@
 #define TRAIT_FLOORED "floored"
 /// Forces user to stay standing
 #define TRAIT_FORCED_STANDING "forcedstanding"
-/// Stuns preventing movement and using objects but without further impairement
+/// Stuns preventing movement and using objects but without further impairment
 #define TRAIT_INCAPACITATED "incapacitated"
 /// Disoriented. Unable to talk properly, and unable to use some skills as Xeno
 #define TRAIT_DAZED "dazed"
@@ -257,7 +257,7 @@
 #define TRAIT_ABILITY_NO_PLASMA_TRANSFER "t_ability_no_plasma_transfer"
 /// Shows that the xeno queen is on ovi
 #define TRAIT_ABILITY_OVIPOSITOR "t_ability_ovipositor"
-/// Used for burrowed mobs, prevent's SG/sentrys/claymores from autofiring
+/// Used for burrowed mobs, prevent's SG/sentries/claymores from autofiring
 #define TRAIT_ABILITY_BURROWED "t_ability_burrowed"
 /// Xenos with this trait can toggle long sight while resting.
 #define TRAIT_ABILITY_SIGHT_IGNORE_REST "t_ability_sight_ignore_rest"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -253,7 +253,7 @@
 #define TRAIT_IRON_TEETH "t_iron_teeth"
 
 // -- ability traits --
-/// Xenos with this trait cannot have plasma transfered to them
+/// Xenos with this trait cannot have plasma transferred to them
 #define TRAIT_ABILITY_NO_PLASMA_TRANSFER "t_ability_no_plasma_transfer"
 /// Shows that the xeno queen is on ovi
 #define TRAIT_ABILITY_OVIPOSITOR "t_ability_ovipositor"

--- a/code/datums/mob_hud.dm
+++ b/code/datums/mob_hud.dm
@@ -551,8 +551,8 @@ GLOBAL_LIST_INIT_TYPED(huds, /datum/mob_hud, flatten_numeric_alist(alist(
 	if(!client)
 		return
 	for(var/obj/effect/alien/resin/design/des in hive.designer_marks)
-		if(des.choosenMark)
-			client.images |= des.choosenMark
+		if(des.chosenMark)
+			client.images |= des.chosenMark
 
 /mob/living/carbon/xenomorph/proc/hud_set_plasma()
 	var/image/holder = hud_list[PLASMA_HUD]

--- a/code/game/objects/items/explosives/explosive.dm
+++ b/code/game/objects/items/explosives/explosive.dm
@@ -226,7 +226,7 @@
 		G.reagents.trans_to(src, G.reagents.total_volume)
 		i--
 		if(reagents && i <= 1)
-			reagents.trigger_volatiles = TRUE //So it doesn't explode before transfering the last container
+			reagents.trigger_volatiles = TRUE //So it doesn't explode before transferring the last container
 	if(reagents)
 		reagents.trigger_volatiles = FALSE
 

--- a/code/game/objects/items/explosives/explosive.dm
+++ b/code/game/objects/items/explosives/explosive.dm
@@ -232,7 +232,7 @@
 
 
 	if(!QDELETED(src)) //the possible reactions didn't qdel src
-		if(reagents.total_volume) //The possible reactions didnt use up all reagents.
+		if(reagents.total_volume) //The possible reactions didn't use up all reagents.
 			var/datum/effect_system/steam_spread/steam = new /datum/effect_system/steam_spread()
 			steam.set_up(10, 0, get_turf(src))
 			steam.attach(src)

--- a/code/game/objects/items/reagent_containers/reagent_container.dm
+++ b/code/game/objects/items/reagent_containers/reagent_container.dm
@@ -7,7 +7,7 @@
 	attack_speed = 3
 	ground_offset_x = 7
 	ground_offset_y = 7
-	/// How many units of reagent get transfered out of the container at a time
+	/// How many units of reagent get transferred out of the container at a time
 	var/amount_per_transfer_from_this = 5
 	/// A list of possible amounts that can be transferred
 	var/possible_transfer_amounts = list(5, 10, 15, 20, 25, 30)

--- a/code/game/objects/items/reagent_containers/robodropper.dm
+++ b/code/game/objects/items/reagent_containers/robodropper.dm
@@ -1,7 +1,7 @@
 
 /obj/item/reagent_container/robodropper
 	name = "industrial dropper"
-	desc = "A robust-looking dropper for measuring and transfering small units of liquid. Transfers up to 10 units."
+	desc = "A robust-looking dropper for measuring and transferring small units of liquid. Transfers up to 10 units."
 	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "robodropper"
 	amount_per_transfer_from_this = 10

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -303,8 +303,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		return
 	if(istype(target, /obj/item/reagent_container/glass)) //you can dip cigarettes into beakers
 		var/obj/item/reagent_container/glass/glass = target
-		var/transfered = glass.reagents.trans_to(src, chem_volume)
-		if(transfered) //if reagents were transfered, show the message
+		var/transferred = glass.reagents.trans_to(src, chem_volume)
+		if(transferred) //if reagents were transferred, show the message
 			to_chat(user, SPAN_NOTICE("You dip \the [src] into \the [glass]."))
 		else //if not, either the beaker was empty, or the cigarette was full
 			if(!glass.reagents.total_volume)

--- a/code/modules/admin/verbs/mob_verbs.dm
+++ b/code/modules/admin/verbs/mob_verbs.dm
@@ -38,7 +38,7 @@
 	if(!istype(O) || (!check_rights(R_ADMIN|R_DEBUG, 0))) //Let's add a few extra sanity checks.
 		return
 	if(alert("Do you want to possess this mob?", "Switch Ckey", "Yes", "No") == "Yes")
-		if(!M || !O) //Extra check in case the mob was deleted while we were transfering.
+		if(!M || !O) //Extra check in case the mob was deleted while we were transferring.
 			return
 		change_ckey(M, O.ckey)
 	else

--- a/code/modules/clothing/under/marine_uniform.dm
+++ b/code/modules/clothing/under/marine_uniform.dm
@@ -950,7 +950,7 @@
 
 /obj/item/clothing/under/marine/veteran/marsoc
 	name = "SOF Uniform"
-	desc = "A black uniform for elite Marine personnel. Designed to be comfortable and help blend into dark enviorments."
+	desc = "A black uniform for elite Marine personnel. Designed to be comfortable and help blend into dark environments."
 	flags_jumpsuit = UNIFORM_SLEEVE_ROLLABLE
 	icon = 'icons/obj/items/clothing/uniforms/uniforms_by_faction/UA.dmi'
 	item_icons = list(
@@ -1211,7 +1211,7 @@
 
 /obj/item/clothing/under/marine/veteran/cmb
 	name = "\improper CMB Riot Control uniform"
-	desc = "A dark set of tactical uniform utilized by the Colonial Marshals, designed to be used by units of riot supression on the distant worlds, under colonial jurisdiction."
+	desc = "A dark set of tactical uniform utilized by the Colonial Marshals, designed to be used by units of riot suppression on the distant worlds, under colonial jurisdiction."
 	icon = 'icons/obj/items/clothing/uniforms/uniforms_by_faction/CMB.dmi'
 	item_icons = list(
 		WEAR_BODY = 'icons/mob/humans/onmob/clothing/uniforms/uniforms_by_faction/CMB.dmi',

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -1296,7 +1296,7 @@ GLOBAL_LIST_EMPTY_TYPED(active_overwatch_consoles, /obj/structure/machinery/comp
 		return
 
 	if(!istype(transfer_marine) || !transfer_marine.mind || transfer_marine.stat == DEAD) //gibbed, decapitated, dead
-		to_chat(usr, "[icon2html(src, usr)] [SPAN_WARNING("[transfer_marine] is unable to be transfered!")]")
+		to_chat(usr, "[icon2html(src, usr)] [SPAN_WARNING("[transfer_marine] is unable to be transferred!")]")
 		return
 
 	var/obj/item/card/id/card = transfer_marine.get_idcard()
@@ -1333,8 +1333,8 @@ GLOBAL_LIST_EMPTY_TYPED(active_overwatch_consoles, /obj/structure/machinery/comp
 
 	. = transfer_marine_to_squad(transfer_marine, new_squad, old_squad, card)
 	if(.)
-		visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("[transfer_marine] has been transfered from squad '[old_squad]' to squad '[new_squad]'. Logging to enlistment file.")]")
-		to_chat(transfer_marine, "[icon2html(src, transfer_marine)] <font size='3' color='blue'><B>\[Overwatch\]:</b> You've been transfered to [new_squad]!</font>")
+		visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("[transfer_marine] has been transferred from squad '[old_squad]' to squad '[new_squad]'. Logging to enlistment file.")]")
+		to_chat(transfer_marine, "[icon2html(src, transfer_marine)] <font size='3' color='blue'><B>\[Overwatch\]:</b> You've been transferred to [new_squad]!</font>")
 	else
 		visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("[transfer_marine] transfer from squad '[old_squad]' to squad '[new_squad]' unsuccessful.")]")
 

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -916,7 +916,7 @@ GLOBAL_LIST_EMPTY_TYPED(active_overwatch_consoles, /obj/structure/machinery/comp
 
 				if(announcement_type == "shipside")
 					shipwide_ai_announcement(input, COMMAND_SHIP_ANNOUNCE, signature = signed)
-					message_admins("[key_name(user)] has made a shipwide annoucement.")
+					message_admins("[key_name(user)] has made a shipwide announcement.")
 					log_announcement("[key_name(user)] has announced the following to the ship: [input]")
 					COOLDOWN_START(src, cooldown_shipside_message, COOLDOWN_COMM_MESSAGE)
 				else

--- a/code/modules/gear_presets/pmc.dm
+++ b/code/modules/gear_presets/pmc.dm
@@ -103,7 +103,7 @@
 			new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m39/ap, WEAR_IN_JACKET)
 			new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m39/ap, WEAR_IN_JACKET)
 			new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m39/ap, WEAR_IN_BACK)
-		if(2) //Light with a nsg23 rifle (UBS+reflex sight+supressor) / fp9000 pmc version
+		if(2) //Light with a nsg23 rifle (UBS+reflex sight+suppressor) / fp9000 pmc version
 			new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/pmc, WEAR_BACK)
 			new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/pmc, WEAR_HEAD)
 			new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/marine/veteran/pmc/light, WEAR_JACKET)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
@@ -334,7 +334,7 @@
 	use_plasma(amount)
 	target.gain_plasma(amount)
 	target.xeno_jitter(1 SECONDS)
-	to_chat(target, SPAN_XENOWARNING("[src] has transfered [amount] plasma to us. We now have [target.plasma_stored]."))
+	to_chat(target, SPAN_XENOWARNING("[src] has transferred [amount] plasma to us. We now have [target.plasma_stored]."))
 	to_chat(src, SPAN_XENOWARNING("We have transferred [amount] plasma to [target]. We now have [plasma_stored]."))
 	playsound(src, "alien_drool", 25)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Hellhound.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Hellhound.dm
@@ -99,7 +99,7 @@
 /mob/living/carbon/xenomorph/hellhound/Login()
 	. = ..()
 	if(SSticker.mode) SSticker.mode.xenomorphs -= mind
-	to_chat(src, SPAN_RED("Attention!! You are playing as a hellhound. This is a roleplay role which means you must maintain a high degree of roleplay or you risk getting job banned. LISTEN TO THE YAUTJA THAT CALLED YOU. Their order takes priority. If you dont, you will be ghosted and replaced and potentially punished if you are breaking the rules. If the yautja who called you dies, try to listen to other yautja or otherwise ask for one to give you a fight that will surely end in your demise. You are loyal to yautja above all else, do not act without their permission and do not disturb the round too much!"))
+	to_chat(src, SPAN_RED("Attention!! You are playing as a hellhound. This is a roleplay role which means you must maintain a high degree of roleplay or you risk getting job banned. LISTEN TO THE YAUTJA THAT CALLED YOU. Their order takes priority. If you don't, you will be ghosted and replaced and potentially punished if you are breaking the rules. If the yautja who called you dies, try to listen to other yautja or otherwise ask for one to give you a fight that will surely end in your demise. You are loyal to yautja above all else, do not act without their permission and do not disturb the round too much!"))
 
 /mob/living/carbon/xenomorph/hellhound/death(cause, gibbed)
 	. = ..(cause, gibbed, "lets out a horrible roar as it collapses and stops moving...")

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -198,7 +198,7 @@
 
 	setup_banned_allies()
 
-///Generate the image()'s requried for the evolution radial menu.
+///Generate the image()'s required for the evolution radial menu.
 /datum/hive_status/proc/generate_evo_menu_images()
 	for(var/datum/caste_datum/caste as anything in subtypesof(/datum/caste_datum))
 		evolution_menu_images[initial(caste.caste_type)] = image('icons/mob/xenos/radial_xenos.dmi', initial(caste.caste_type))
@@ -1533,7 +1533,7 @@
 
 	xeno_message(SPAN_XENOANNOUNCE("We sense that [english_list(defectors)] turned their backs against their sisters and the Queen in favor of their slavemasters!"), 3, hivenumber)
 	if(faction == FACTION_MARINE && ares_can_interface())
-		marine_announcement("The advanced IFF Xenomorph tagging technology has detected hostile intentions and succesfully supressed the psychic link of [length(defectors)] lifeform\s. The collaborative lifeforms are given designation Renegades. Full cooperation is to be expected.", MAIN_AI_SYSTEM)
+		marine_announcement("The advanced IFF Xenomorph tagging technology has detected hostile intentions and successfully suppressed the psychic link of [length(defectors)] lifeform\s. The collaborative lifeforms are given designation Renegades. Full cooperation is to be expected.", MAIN_AI_SYSTEM)
 	defectors.Cut()
 
 /datum/hive_status/corrupted/proc/add_personal_ally(mob/living/ally)

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/hivelord/designer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/hivelord/designer.dm
@@ -97,7 +97,7 @@
 /datum/design_mark
 	var/name = "xeno_declare"
 	var/icon_state = "empty"
-	var/desc = "Xenos make psychic markers with this meaning as positional lasting communication to eachother."
+	var/desc = "Xenos make psychic markers with this meaning as positional lasting communication to each other."
 
 /datum/design_mark/resin_wall
 	name = "Resin Wall"
@@ -137,7 +137,7 @@
 	var/hivenumber = XENO_HIVE_NORMAL
 	var/plasma_cost = 0
 
-	var/image/choosenMark
+	var/image/chosenMark
 
 /obj/effect/alien/resin/design/Initialize(mapload, obj/effect/alien/weeds/weeds, mob/living/carbon/xenomorph/xeno)
 	if(!istype(xeno))
@@ -165,9 +165,9 @@
 		if(mark_meaning)
 			var/icon_state_to_use = get_marker_icon_state()
 			if(icon_state_to_use)
-				choosenMark = image(icon, src, icon_state_to_use, ABOVE_HUD_LAYER, "pixel_y" = 5)
-				choosenMark.plane = ABOVE_HUD_PLANE
-				choosenMark.appearance_flags = RESET_COLOR
+				chosenMark = image(icon, src, icon_state_to_use, ABOVE_HUD_LAYER, "pixel_y" = 5)
+				chosenMark.plane = ABOVE_HUD_PLANE
+				chosenMark.appearance_flags = RESET_COLOR
 
 				for(xeno in hive.totalXenos)
 					if(xeno.client)
@@ -179,8 +179,8 @@
 	if(hive)
 		hive.designer_marks -= src
 		for(var/mob/living/carbon/xenomorph/xeno in hive.totalXenos)
-			if(xeno.client && choosenMark)
-				xeno.client.images -= choosenMark
+			if(xeno.client && chosenMark)
+				xeno.client.images -= chosenMark
 				xeno.hud_set_design_marks()
 
 	if(!QDELETED(bound_xeno))
@@ -188,15 +188,15 @@
 	unregister_weed_expiration_signal_design()
 	bound_xeno = null
 	bound_weed = null
-	choosenMark = null
+	chosenMark = null
 	return ..()
 
 /obj/effect/alien/resin/design/proc/refresh_marker()
-	if(!choosenMark || !mark_meaning)
+	if(!chosenMark || !mark_meaning)
 		return
 
 	if(bound_xeno.selected_design_mark == /datum/design_mark/resin_wall || bound_xeno.selected_design_mark == /datum/design_mark/resin_door)
-		choosenMark.icon_state = mark_meaning.icon_state
+		chosenMark.icon_state = mark_meaning.icon_state
 
 /obj/effect/alien/resin/design/proc/get_marker_icon_state()
 	if(!mark_meaning)
@@ -237,11 +237,11 @@
 	plasma_cost = 50
 
 /obj/effect/alien/resin/design/speed_node/refresh_marker()
-	if(!choosenMark || !mark_meaning)
+	if(!chosenMark || !mark_meaning)
 		return
 
 	if(bound_xeno.selected_design_mark == /datum/design_mark/resin_wall || bound_xeno.selected_design_mark == /datum/design_mark/resin_door)
-		choosenMark.icon_state = mark_meaning.icon_state + "_speed"
+		chosenMark.icon_state = mark_meaning.icon_state + "_speed"
 	else
 		..()
 
@@ -263,11 +263,11 @@
 	plasma_cost = 60
 
 /obj/effect/alien/resin/design/cost_node/refresh_marker()
-	if(!choosenMark || !mark_meaning)
+	if(!chosenMark || !mark_meaning)
 		return
 
 	if(bound_xeno.selected_design_mark == /datum/design_mark/resin_wall || bound_xeno.selected_design_mark == /datum/design_mark/resin_door)
-		choosenMark.icon_state = mark_meaning.icon_state + "_cost"
+		chosenMark.icon_state = mark_meaning.icon_state + "_cost"
 	else
 		..()
 
@@ -648,7 +648,7 @@
 /obj/effect/alien/resin/sticky/weak_nutriplasm/get_examine_text(mob/user)
 	. = ..()
 	if(ishuman(user))
-		. += SPAN_NOTICE("On closer examination, this thin sticky substance remainds you of sticky resin.")
+		. += SPAN_NOTICE("On closer examination, this thin, sticky substance reminds you of sticky resin.")
 	if(isxeno(user) || isobserver(user))
 		. += SPAN_NOTICE("We stare at the remains of weedbound walls - nutriplasm. As edible as it sounds, it's just another kind of sticky resin.")
 
@@ -661,7 +661,7 @@
 /obj/effect/alien/resin/sticky/strong_nutriplasm/get_examine_text(mob/user)
 	. = ..()
 	if(ishuman(user))
-		. += SPAN_NOTICE("On closer examination, this thick sticky substance remainds you of sticky resin.")
+		. += SPAN_NOTICE("On closer examination, this thick, sticky substance reminds you of sticky resin.")
 	if(isxeno(user) || isobserver(user))
 		. += SPAN_NOTICE("We stare at thick nutriplasm, the remains from weedbound resin, it sound delicious but you remember, its just different sticky resin.")
 
@@ -934,7 +934,7 @@
 		playsound(xeno.loc, "alien_resin_move2", 25)
 		return
 
-	if(length(xeno.current_design) >= xeno.max_design_nodes) //Check if there are more nodes than lenght that was defined
+	if(length(xeno.current_design) >= xeno.max_design_nodes) //Check if there are more nodes than length that was defined
 		to_chat(xeno, SPAN_XENOWARNING("We cannot sustain another node, one will wither away to allow this one to live!"))
 		var/obj/effect/alien/resin/design/old_design = xeno.current_design[1] //Check with node is first for deletion on list
 		xeno.current_design.Remove(old_design) //Removes first node stored inside list
@@ -1145,7 +1145,7 @@
 
 	var/choice
 	if(owner.client.prefs.no_radials_preference)
-		choice = tgui_input_list(owner, "Choose Desing Option", "Pick", options, theme="hive_status")
+		choice = tgui_input_list(owner, "Choose Design Option", "Pick", options, theme="hive_status")
 	else
 		choice = show_radial_menu(owner, owner?.client.get_eye(), options, radius = 50)
 

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/valkyrie.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/valkyrie.dm
@@ -1,6 +1,6 @@
 /datum/xeno_strain/valkyrie
 	name = PRAETORIAN_VALKYRIE
-	description = "You trade your ranged abilities and acid to gain the ability to emit strong pheromones and buff other Xenomorphs, giving them extra armor. An ability that knocksdown people in a 2 by 3 infront of you while also throwing back grenades. You get an ability that rejuvenates everyone in a certain range depending on your rage. You also trade your tailstab for an extinguisher, while it doesn't do damage it can put out both enemies and allies. This can be used to extuingish people on fire to help capture them."
+	description = "You trade your ranged abilities and acid to gain the ability to emit strong pheromones and buff other Xenomorphs, giving them extra armor. An ability that knocks down people in a 2 by 3 infront of you while also throwing back grenades. You get an ability that rejuvenates everyone in a certain range depending on your rage. You also trade your tailstab for an extinguisher, while it doesn't do damage it can put out both enemies and allies. This can be used to extinguish people on fire to help capture them."
 	flavor_description = "This one will deny her sisters' deaths until they earn it. Fight or be forgotten."
 	icon_state_prefix = "Warden"
 
@@ -101,7 +101,7 @@
 
 /datum/behavior_delegate/praetorian_valkyrie/proc/use_internal_fury_ability(cost)
 	if (cost > base_fury)
-		to_chat(bound_xeno, SPAN_XENODANGER("We dont feel angry enough to do this!"))
+		to_chat(bound_xeno, SPAN_XENODANGER("We don't feel angry enough to do this!"))
 		return FALSE
 
 	add_base_fury(-cost)

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -60,10 +60,10 @@
 	var/obj/item/reagent_container/glass/G = O
 	if(stat == CONSCIOUS && istype(G) && G.is_open_container())
 		user.visible_message(SPAN_NOTICE("[user] milks [src] using \the [O]."))
-		var/transfered = udder.trans_id_to(G, "milk", rand(5,10))
+		var/transferred = udder.trans_id_to(G, "milk", rand(5,10))
 		if(G.reagents.total_volume >= G.volume)
 			to_chat(user, SPAN_DANGER("[O] is full."))
-		if(!transfered)
+		if(!transferred)
 			to_chat(user, SPAN_DANGER("The udder is dry. Wait a bit longer..."))
 	else
 		..()
@@ -106,10 +106,10 @@
 	var/obj/item/reagent_container/glass/G = O
 	if(stat == CONSCIOUS && istype(G) && G.is_open_container())
 		user.visible_message(SPAN_NOTICE("[user] milks [src] using \the [O]."))
-		var/transfered = udder.trans_id_to(G, "milk", rand(5,10))
+		var/transferred = udder.trans_id_to(G, "milk", rand(5,10))
 		if(G.reagents.total_volume >= G.volume)
 			to_chat(user, SPAN_DANGER("The [O] is full."))
-		if(!transfered)
+		if(!transferred)
 			to_chat(user, SPAN_DANGER("The udder is dry. Wait a bit longer..."))
 	else
 		..()

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -251,7 +251,7 @@
 /**
  * Describes how limbs (body parts) of human mobs get damage applied.
  *
- * Any damage past the limb maximum health is transfered onto the next limb up the line, by
+ * Any damage past the limb maximum health is transferred onto the next limb up the line, by
  * calling this proc recursively. When a hand is too damaged it is passed to the arm,
  * then to the chest and so on.
  *
@@ -263,7 +263,7 @@
  * do 16 damage, assuming the marine is wearing medium armor which has armor value of 30.
  *
  * Thus we have to apply armor damage reduction on each limb to which the damage is
- * transfered. When this proc is called recursively for the first damage transfer to the
+ * transferred. When this proc is called recursively for the first damage transfer to the
  * parent, we set reduced_by variables to be the armor of the original limb hit. Then we
  * compare the parent limb armor with the applicable reduced_by and if it's higher we reduce
  * the damage by the difference between the two. Then we set reduced_by to
@@ -281,7 +281,7 @@
  * initial child limb armor.
  * One practical example where this would happen is when a human is wearing a set of armor
  * that does not protect legs, like the UPP officer. If a xeno keeps slashing his foot,
- * the damage would eventually get transfered to the leg, which has 0 armor. But this damage
+ * the damage would eventually get transferred to the leg, which has 0 armor. But this damage
  * has been already reduced by the boot armor even before this proc got first called.
  * So, assuming 35 damage slash, the leg would only be damaged by 21 even though it has
  * 0 armor. Fixing this would require a new proc that would be able to unapply armor

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -259,7 +259,7 @@
  * directly would allow the attacker to effectively bypass all of that armor. A lurker
  * with 35 slash damage repeatedly slashing a hand protected by marine combat gloves
  * (20 armor) would do 20 damage to the hand, then would start doing the same 20 to
- * the arm, and then the chest. But if the lurker slashes the arm direclty it would only
+ * the arm, and then the chest. But if the lurker slashes the arm directly it would only
  * do 16 damage, assuming the marine is wearing medium armor which has armor value of 30.
  *
  * Thus we have to apply armor damage reduction on each limb to which the damage is
@@ -461,7 +461,7 @@ This function completely restores a damaged organ to perfect condition.
 	damage_state = "=="
 	if(status & LIMB_SYNTHSKIN)
 		status = LIMB_SYNTHSKIN
-	else if(status & LIMB_ROBOT) //Robotic organs stay robotic.  Fix because right click rejuvinate makes IPC's organs organic.
+	else if(status & LIMB_ROBOT) //Robotic organs stay robotic.  Fix because right click rejuvenate makes IPC's organs organic.
 		status = LIMB_ROBOT
 	else
 		status = LIMB_ORGANIC
@@ -572,7 +572,7 @@ This function completely restores a damaged organ to perfect condition.
 
 ///Adds bleeding to the limb. Damage_amount lets you apply an amount worth of bleeding, otherwise it uses the given wound's damage.
 /obj/limb/proc/add_bleeding(datum/wound/W, internal = FALSE, damage_amount)
-	if(!(SSticker.current_state >= GAME_STATE_PLAYING)) //If the game hasnt started, don't add bleed. Hacky fix to avoid having 100 bleed effect from roundstart.
+	if(!(SSticker.current_state >= GAME_STATE_PLAYING)) //If the game hasn't started, don't add bleed. Hacky fix to avoid having 100 bleed effect from roundstart.
 		return
 
 	if(status & (LIMB_ROBOT|LIMB_SYNTHSKIN))

--- a/code/modules/projectiles/ammo_boxes/ammo_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/ammo_boxes.dm
@@ -344,8 +344,8 @@
 					return
 				dumping = TRUE
 
-			var/transfering   = 0   // Amount of bullets we're trying to transfer
-			var/transferable  = 0   // Amount of bullets that can actually be transfered
+			var/transferring   = 0   // Amount of bullets we're trying to transfer
+			var/transferable  = 0   // Amount of bullets that can actually be transferred
 			do
 				// General checking
 				if(dumping)
@@ -355,24 +355,24 @@
 				if(transferable < 1)
 					to_chat(user, SPAN_NOTICE("You cannot transfer any more rounds."))
 
-				// Half-Loop 1: Start transfering
-				else if(!transfering)
-					transfering = min(transferable, 48) // Max per transfer
+				// Half-Loop 1: Start transferring
+				else if(!transferring)
+					transferring = min(transferable, 48) // Max per transfer
 					if(!do_after(user, 1.5 SECONDS, INTERRUPT_ALL, dumping ? BUSY_ICON_HOSTILE : BUSY_ICON_FRIENDLY))
 						to_chat(user, SPAN_NOTICE("You stop transferring rounds."))
 						transferable = 0
 
 				// Half-Loop 2: Process transfer
 				else
-					transfering = min(transfering, transferable)
-					transferable -= transfering
+					transferring = min(transferring, transferable)
+					transferable -= transferring
 					if(dumping)
-						transfering = -transfering
-					AM.current_rounds += transfering
-					bullet_amount  -= transfering
+						transferring = -transferring
+					AM.current_rounds += transferring
+					bullet_amount  -= transferring
 					playsound(src, pick('sound/weapons/handling/mag_refill_1.ogg', 'sound/weapons/handling/mag_refill_2.ogg', 'sound/weapons/handling/mag_refill_3.ogg'), 20, TRUE, 6)
-					to_chat(user, SPAN_NOTICE("You have transferred [abs(transfering)] round\s to [dumping ? src : AM]."))
-					transfering = 0
+					to_chat(user, SPAN_NOTICE("You have transferred [abs(transferring)] round\s to [dumping ? src : AM]."))
+					transferring = 0
 
 			while(transferable >= 1)
 

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -38,13 +38,13 @@
 	return ..()
 
 /datum/reagents/proc/remove_any(amount=1)
-	var/total_transfered = 0
+	var/total_transferred = 0
 	var/current_list_element = 1
 
 	current_list_element = rand(1,length(reagent_list))
 
-	while(total_transfered != amount)
-		if(total_transfered >= amount)
+	while(total_transferred != amount)
+		if(total_transferred >= amount)
 			break
 		if(total_volume <= 0 || !length(reagent_list))
 			break
@@ -56,21 +56,21 @@
 		remove_reagent(current_reagent.id, 1)
 
 		current_list_element++
-		total_transfered++
+		total_transferred++
 		update_total()
 
 	handle_reactions()
-	return total_transfered
+	return total_transferred
 
 ///This proc is one that removes all reagents from the targeted datum other than the designated ignored reagent
 /datum/reagents/proc/remove_any_but(reagent_to_ignore, amount=1)
-	var/total_transfered = 0
+	var/total_transferred = 0
 	var/current_list_element = 1
 
 	current_list_element = rand(1, length(reagent_list))
 
-	while(total_transfered != amount)
-		if(total_transfered >= amount)
+	while(total_transferred != amount)
+		if(total_transferred >= amount)
 			break
 		if(total_volume <= 0 || !length(reagent_list))
 			break
@@ -90,11 +90,11 @@
 		remove_reagent(current_reagent.id, 1)
 
 		current_list_element++
-		total_transfered++
+		total_transferred++
 		update_total()
 
 	handle_reactions()
-	return total_transfered
+	return total_transferred
 
 
 /datum/reagents/proc/get_master_reagent()

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -6,7 +6,7 @@
 	var/trigger_volatiles = FALSE
 	var/allow_star_shape = TRUE
 	var/exploded = FALSE
-	var/endothermic_reaction_occuring = FALSE
+	var/endothermic_reaction_occurring = FALSE
 	var/datum/weakref/source_mob
 
 	var/locked = FALSE
@@ -132,7 +132,7 @@
 		return trans_to_datum(R, amount, multiplier, preserve_data, reaction)
 
 /// Transfers to a reagent datum
-/datum/reagents/proc/trans_to_datum(datum/reagents/target, amount=1, multiplier=1, preserve_data=1, reaction = TRUE)//if preserve_data=0, the reagents data will be lost. Usefull if you use data for some strange stuff and don't want it to be transferred.
+/datum/reagents/proc/trans_to_datum(datum/reagents/target, amount=1, multiplier=1, preserve_data=1, reaction = TRUE)//if preserve_data=0, the reagents data will be lost. Useful if you use data for some strange stuff and don't want it to be transferred.
 	amount = min(min(amount, total_volume), target.maximum_volume-target.total_volume)
 	var/part = amount / total_volume
 	for(var/datum/reagent/current_reagent in reagent_list)
@@ -310,7 +310,7 @@
 						multiplier = max(multiplier, 1) //this shouldn't happen ...
 						set_data(reaction.result, preserved_data)
 					if(CHECK_BITFIELD(reaction.reaction_type, CHEM_REACTION_CALM) && !CHECK_BITFIELD(reaction.reaction_type, CHEM_REACTION_ENDOTHERMIC)) //mix the chemicals
-						if(endothermic_reaction_occuring)
+						if(endothermic_reaction_occurring)
 							continue
 						for(var/required_reagent in reaction.required_reagents)
 							remove_reagent(required_reagent, (multiplier * reaction.required_reagents[required_reagent]), safety = TRUE)
@@ -420,7 +420,7 @@
 		if((catalysts_in_holder.id in reaction.required_catalysts) && catalysts_in_holder.volume >= reaction.required_catalysts[catalysts_in_holder.id])
 			required_catalysts_present++
 	if(!(length(reaction.required_reagents) == required_reagents_present && length(reaction.required_catalysts) == required_catalysts_present))
-		endothermic_reaction_occuring = FALSE //forgive me
+		endothermic_reaction_occurring = FALSE //forgive me
 		handle_reactions()
 		return
 	var/list/seen = viewers(2, get_turf(my_atom))
@@ -437,7 +437,7 @@
 	for(var/mob/seen_mob in this_turf)
 		if(prob(15))
 			to_chat(seen_mob, SPAN_NOTICE("[icon2html(my_atom, seen_mob)] [my_atom] feels extremely cold to touch."))
-	endothermic_reaction_occuring = TRUE
+	endothermic_reaction_occurring = TRUE
 	addtimer(CALLBACK(src, PROC_REF(handle_endothermic_reaction), reaction), 1 SECONDS, TIMER_UNIQUE)
 
 /datum/reagents/proc/isolate_reagent(reagent)
@@ -491,7 +491,7 @@
 
 	update_total()
 	if(total_volume + amount > maximum_volume)
-		amount = maximum_volume - total_volume //Doesnt fit in. Make it disappear. Shouldnt happen. Will happen.
+		amount = maximum_volume - total_volume //Doesn't fit in. Make it disappear. Shouldn't happen. Will happen.
 
 	var/new_data = list("blood_type" = null, "blood_color" = "#A10808", "viruses" = null, "resistances" = null, "last_source_mob" = null)
 	if(data)
@@ -608,7 +608,7 @@
 
 	return res
 
-/datum/reagents/proc/remove_all_type(reagent_type, amount, strict = 0, safety = 1) // Removes all reagent of X type. @strict set to 1 determines whether the childs of the type are included.
+/datum/reagents/proc/remove_all_type(reagent_type, amount, strict = 0, safety = 1) // Removes all reagent of X type. @strict set to 1 determines whether the children of the type are included.
 	if(!isnum(amount))
 		return TRUE
 

--- a/code/modules/reagents/Chemistry-Readme.dm
+++ b/code/modules/reagents/Chemistry-Readme.dm
@@ -32,7 +32,7 @@ About the Holder:
 			This proc equally transfers the contents of the holder to another
 			objects holder. You need to pass it the object (not the holder) you want
 			to transfer to and the amount you want to transfer. Its return value is the
-			actual amount transfered (if one of the objects is full/empty)
+			actual amount transferred (if one of the objects is full/empty)
 
 		trans_id_to(obj/target, reagent, amount)
 			Same as above but only for a specific reagent in the reagent list.

--- a/code/modules/reagents/Chemistry-Readme.dm
+++ b/code/modules/reagents/Chemistry-Readme.dm
@@ -140,7 +140,7 @@ About Reagents:
 			slippery floors for lube or something in here.
 
 		on_mob_life(mob/M)
-			This proc is called everytime the mobs life proc executes.
+			This proc is called every time the mobs life proc executes.
 			This is the place where you put damage for toxins ,
 			drowsiness for sleep toxins etc etc.
 			You'll want to call the parents proc by using ..() .

--- a/code/modules/reagents/chemistry_machinery/centrifuge.dm
+++ b/code/modules/reagents/chemistry_machinery/centrifuge.dm
@@ -247,7 +247,7 @@
 			if(V.reagents.total_volume == V.reagents.maximum_volume) //The vial is full
 				continue
 
-			//Calculate how much we are transfering
+			//Calculate how much we are transferring
 			var/amount_to_transfer = V.reagents.maximum_volume - V.reagents.total_volume
 			if(R.volume < amount_to_transfer)
 				amount_to_transfer = R.volume
@@ -265,7 +265,7 @@
 		if(V.reagents.total_volume == V.reagents.maximum_volume) //The vial is full
 			continue
 
-		//Calculate how much we are transfering
+		//Calculate how much we are transferring
 		var/amount_to_transfer = V.reagents.maximum_volume - V.reagents.total_volume
 		if(source_container.reagents.total_volume < amount_to_transfer)
 			amount_to_transfer = source_container.reagents.total_volume

--- a/code/modules/reagents/chemistry_machinery/chem_simulator.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_simulator.dm
@@ -270,32 +270,32 @@
 			if(SIMULATION_STAGE_3)
 				status_bar = pick("PREDICTING REACTION PATTERNS","CALCULATING OVERDOSE RATIOS","CALCULATING SYNTHESIS","CLOSING THE EVENTUALITY","COMPUTING REAGENT INTERPRETATIONS",)
 			if(SIMULATION_STAGE_WAIT)
-				var/datum/reagent/generated/chemical_modfying = new /datum/reagent/generated
+				var/datum/reagent/generated/chemical_modifying = new /datum/reagent/generated
 				switch(mode)
 					if(MODE_AMPLIFY)
-						amplify(chemical_modfying)
+						amplify(chemical_modifying)
 					if(MODE_SUPPRESS)
-						suppress(chemical_modfying)
+						suppress(chemical_modifying)
 					if(MODE_RELATE)
-						relate(chemical_modfying)
+						relate(chemical_modifying)
 					if(MODE_ADD)
-						add(chemical_modfying)
-				if(!chemical_modfying.original_id)
-					chemical_modfying.original_id = target.data.id
-				encode_reagent(chemical_modfying)
-				if(chemical_modfying.id in simulations)
+						add(chemical_modifying)
+				if(!chemical_modifying.original_id)
+					chemical_modifying.original_id = target.data.id
+				encode_reagent(chemical_modifying)
+				if(chemical_modifying.id in simulations)
 					//We've already simulated this before, so we don't need to continue
-					chemical_modfying = GLOB.chemical_reagents_list[chemical_modfying.id]
-					print(chemical_modfying.id)
+					chemical_modifying = GLOB.chemical_reagents_list[chemical_modifying.id]
+					print(chemical_modifying.id)
 					status_bar = "SIMULATION COMPLETE"
 					simulating = SIMULATION_STAGE_OFF
 				else if(prepare_recipe_options())
-					chem_cache = chemical_modfying
+					chem_cache = chemical_modifying
 					status_bar = "ANALYSIS READY"
 					icon_state = "modifier_ready"
 					playsound(loc, 'sound/machines/twobeep.ogg', 15, 1)
 				else
-					finalize_simulation(chemical_modfying)
+					finalize_simulation(chemical_modifying)
 	else
 		ready = check_ready()
 		stop_processing()
@@ -347,7 +347,7 @@
 /obj/structure/machinery/chem_simulator/proc/calculate_new_od_level()
 	new_od_level = max(target.data.overdose, 1)
 	if(mode == MODE_ADD)
-		return //add mode doesnt harm od level of target
+		return //add mode doesn't harm od level of target
 	if(new_od_level <= 5)
 		new_od_level = max(new_od_level - 1, 1)
 	else
@@ -371,7 +371,7 @@
 			//Make sure we don't have an identical reaction and that the component is identified
 			if(R.check_duplicate() || R.check_reaction_uses_all_default_medical() || new_component.chemclass >= CHEM_CLASS_SPECIAL)
 				R.required_reagents = old_reaction.Copy()
-				if(i >= 8) //doesnt really fix the issue but we went from 5 to 8 attempts to roll.
+				if(i >= 8) //doesn't really fix the issue but we went from 5 to 8 attempts to roll.
 					//Elevate the reaction to a higher order
 					target_elevated["[new_component.id]"] = TRUE
 					break
@@ -614,15 +614,15 @@
 	var/mode_id
 	var/icon_type
 
-/datum/chemical_simulator_modes/supress
-	name = "SUPRESS"
-	desc = "Supress one level in the choosen property. This operation lowers the OD level."
+/datum/chemical_simulator_modes/suppress
+	name = "SUPPRESS"
+	desc = "Suppress one level in the chosen property. This operation lowers the OD level."
 	mode_id = MODE_SUPPRESS
 	icon_type = "square-minus"
 
 /datum/chemical_simulator_modes/amplify
 	name = "AMPLIFY"
-	desc = "Amplify one level in the choosen property. This operation lowers the OD level."
+	desc = "Amplify one level in the chosen property. This operation lowers the OD level."
 	mode_id = MODE_AMPLIFY
 	icon_type = "square-plus"
 
@@ -634,7 +634,7 @@
 
 /datum/chemical_simulator_modes/relate
 	name = "RELATE"
-	desc = "Use the reference chemical to replace one choosen property in the target chemical. The target and reference target property level must be equal, This operation lowers the OD level."
+	desc = "Use the reference chemical to replace one chosen property in the target chemical. The target and reference target property level must be equal, This operation lowers the OD level."
 	mode_id = MODE_RELATE
 	icon_type = "repeat"
 

--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -939,7 +939,7 @@
 /datum/chem_property/positive/explosive
 	name = PROPERTY_EXPLOSIVE
 	code = "EXP"
-	description = "The chemical is highly explosive. Do not ignite. Careful when handling, sensitivity is based off the OD threshold, which can lead to spontanous detonation."
+	description = "The chemical is highly explosive. Do not ignite. Careful when handling, sensitivity is based off the OD threshold, which can lead to spontaneous detonation."
 	rarity = PROPERTY_UNCOMMON
 	category = PROPERTY_TYPE_REACTANT|PROPERTY_TYPE_COMBUSTIBLE
 	volatile = TRUE
@@ -1124,7 +1124,7 @@
 /datum/chem_property/positive/aiding
 	name = PROPERTY_AIDING
 	code = "AID"
-	description = "Fixes genetic defects, disfigurments, disabilities. In plants removes compounds modfying yield and mutation."
+	description = "Fixes genetic defects, disfigurments, disabilities. In plants removes compounds modifying yield and mutation."
 	rarity = PROPERTY_DISABLED
 	category = PROPERTY_TYPE_MEDICINE
 	value = 1


### PR DESCRIPTION
# About the pull request

If the words 'transferred', 'transferring', 'suppress', 'modifying', and 'chosen' were misspelled, now they are not. Plus, more spellchecks.

# Explain why it's good for the game

Spellchecks is good.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Puckaboo2
spellcheck: 'transferred', 'transferring', 'suppress', 'modifying', and 'chosen' are no longer misspelled, among other words.
/:cl:
