### PR TITLE
Fixes #8828: Lighters, matches, and cigs now have different attack descriptions depending on if they're lit or not.

### DIFF
--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -110,14 +110,14 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		)
 	icon_state = "match"
 	item_state = "match"
+	attack_verb = list("poked", "jabbed", "pricked", "prodded")
+	damtype = "brute"
 	var/burnt = 0
 	var/smoketime = 10 SECONDS
 	var/burnt_name = "burnt match"
 	w_class = SIZE_TINY
 	light_range = 2
 	light_power = 1
-
-	attack_verb = list("burnt", "singed")
 
 /obj/item/tool/match/afterattack(atom/target, mob/living/carbon/human/user, proximity_flag, click_parameters)
 	if(istype(user) && istype(target, /obj/item/clothing/shoes/marine) && user.shoes == target && light_match(user))
@@ -153,6 +153,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	set_light_on(toggle_on)
 
 /obj/item/tool/match/proc/light_match(mob/user)
+	attack_verb = list("burnt", "singed", "scorched", "seared")
 	if(heat_source || burnt)
 		return
 	heat_source = 1000
@@ -169,6 +170,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	return TRUE
 
 /obj/item/tool/match/proc/burn_out()
+	attack_verb = list("poked", "jabbed", "pricked", "prodded")
 	heat_source = 0
 	burnt = 1
 	damtype = "brute"
@@ -211,7 +213,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	flags_equip_slot = SLOT_EAR | SLOT_FACE
 	flags_obj = parent_type::flags_obj|OBJ_IS_HELMET_GARB
 	flags_atom = CAN_BE_SYRINGED
-	attack_verb = list("burnt", "singed")
+	attack_verb = list("poked", "jabbed", "pricked", "prodded")
+	damtype = "brute"
 	blood_overlay_type = ""
 	light_color = LIGHT_COLOR_ORANGE
 	/// Note - these are in masks.dmi not in cigarette.dmi
@@ -225,7 +228,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/clothing/mask/cigarette/Initialize()
 	. = ..()
 	flags_atom |= NOREACT // so it doesn't react until you light it
-	create_reagents(chem_volume) // making the cigarrete a chemical holder with a maximum volume of 15
+	create_reagents(chem_volume) // making the cigarette a chemical holder with a maximum volume of 15
 	reagents.add_reagent("nicotine",10)
 	if(w_class == SIZE_TINY)
 		AddElement(/datum/element/mouth_drop_item)
@@ -332,10 +335,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/clothing/mask/cigarette/proc/light(flavor_text)
 	SIGNAL_HANDLER
-
 	if(!heat_source)
 		heat_source = 1000
 		damtype = "fire"
+		attack_verb = list("burnt", "singed", "scorched", "seared")
 		if(reagents.handle_volatiles())
 			qdel(src)
 			return
@@ -407,7 +410,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		var/obj/item/butt = new type_butt(T)
 		transfer_fingerprints_to(butt)
 		//if(M)
-			//M.temp_drop_inv_item(src) //un-equip it so the overlays can updat
+			//M.temp_drop_inv_item(src) //un-equip it so the overlays can update
 		qdel(src)
 		. = butt
 	else
@@ -415,6 +418,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		heat_source = 0
 		icon_state = icon_off
 		item_state = icon_off
+		attack_verb = list("poked", "jabbed", "pricked", "prodded")
+		damtype = "brute"
 	if(M)
 		M.update_inv_wear_mask()
 
@@ -744,7 +749,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	flags_atom = FPRINT|CONDUCT
 	flags_equip_slot = SLOT_WAIST
 	flags_obj = parent_type::flags_obj|OBJ_IS_HELMET_GARB
-	attack_verb = list("burnt", "singed")
+	attack_verb = list("poked", "jabbed", "pricked", "prodded")
+	damtype = "brute"
 
 /obj/item/tool/lighter/zippo
 	name = "\improper Zippo lighter"
@@ -832,6 +838,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			heat_source = 1500
 			icon_state = icon_on
 			item_state = icon_on
+
 			if(istype(src, /obj/item/tool/lighter/zippo) )
 				user.visible_message(SPAN_ROSE("Without even breaking stride, [user] flips open and lights [src] in one smooth movement."))
 				playsound(src.loc,"zippo_open",10, 1, 3)
@@ -847,7 +854,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 					else
 						user.apply_damage(2,BURN,"r_hand")
 					user.visible_message(SPAN_NOTICE("After a few attempts, [user] manages to light [src], they however burn their finger in the process."))
-
+			attack_verb = list("burnt", "branded", "scorched", "seared")
+			damtype = "fire"
 			set_light_range(2)
 			set_light_on(TRUE)
 			START_PROCESSING(SSobj, src)
@@ -862,6 +870,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		heat_source = 0
 		icon_state = icon_off
 		item_state = icon_off
+		attack_verb = list("smacked", "hit", "strike")
+		damtype = "brute"
 		if(!silent)
 			if(istype(src, /obj/item/tool/lighter/zippo) )
 				bearer.visible_message(SPAN_ROSE("You hear a quiet click, as [bearer] shuts off [src] without even looking at what they're doing."))

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -153,7 +153,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	set_light_on(toggle_on)
 
 /obj/item/tool/match/proc/light_match(mob/user)
-	attack_verb = list("burnt", "singed", "scorched", "seared")
+	attack_verb = list("burned", "singed", "scorched", "seared")
 	if(heat_source || burnt)
 		return
 	heat_source = 1000
@@ -854,7 +854,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 					else
 						user.apply_damage(2,BURN,"r_hand")
 					user.visible_message(SPAN_NOTICE("After a few attempts, [user] manages to light [src], they however burn their finger in the process."))
-			attack_verb = list("burnt", "branded", "scorched", "seared")
+			attack_verb = list("burned", "branded", "scorched", "seared")
 			damtype = "fire"
 			set_light_range(2)
 			set_light_on(TRUE)
@@ -870,7 +870,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		heat_source = 0
 		icon_state = icon_off
 		item_state = icon_off
-		attack_verb = list("smacked", "hit", "strike")
+		attack_verb = list("smacked", "hit", "struck")
 		damtype = "brute"
 		if(!silent)
 			if(istype(src, /obj/item/tool/lighter/zippo) )


### PR DESCRIPTION
Resolves [#8828](https://github.com/cmss13-devs/cmss13/issues/8828)

# About the pull request
Depending on whether a match is lit/unused/doused or a lighter is on/off, they have different attack descriptions and damage types. (still no damage tho)
Changes have been tested and they work.

# Explain why it's good for the game
Consistency. Before, an unlit match or a closed lighter 'burned' its target.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Puckaboo2
fix: Unlit matches, cigs, and closed lighters no longer say they burn your target.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
