### PR TITLE
Fixes #11466: Pharmaceutical Physician is now medical green on the crew monitor.

### DIFF
--- a/code/modules/cm_marines/marines_consoles.dm
+++ b/code/modules/cm_marines/marines_consoles.dm
@@ -1010,6 +1010,7 @@ GLOBAL_LIST_EMPTY_TYPED(crew_monitor, /datum/crewmonitor)
 				JOB_RESEARCHER = 41,
 				JOB_DOCTOR = 42,
 				JOB_SURGEON = 42,
+				JOB_PHARMACIST = 42,
 				JOB_FIELD_DOCTOR = 43,
 				JOB_SYNTH_MED = 44,
 				JOB_NURSE = 45,


### PR DESCRIPTION
Resolves #11466

# About the pull request
The crew monitor spaced me when I made PharmPhys, and now my ignorance was everyone's problem. Now I know what else to do while making new job roles....

It's fixed.

# Explain why it's good for the game
Pharmaceutical Physicians are not civilians.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Puckaboo2
fix: Pharmaceutical Physician is now medical green on the crew monitor.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
