### PR TITLE
Fixes #9960 Hunted freelancers no longer spawn with only beanbags with their Type-23

### DIFF
--- a/code/modules/gear_presets/other.dm
+++ b/code/modules/gear_presets/other.dm
@@ -244,12 +244,6 @@
 
 	load_freelancer_soldier(new_human)
 
-	var/percentage = rand(1, 100)
-	switch(percentage)
-		if(1 to 66)
-			load_freelancer_rifleman(new_human)
-		else
-			load_freelancer_machinegunner(new_human)
 
 /datum/equipment_preset/other/freelancer/leader/hunted
 	name = "Freelancer Leader (Hunted)"


### PR DESCRIPTION
Resolves #9960

# About the pull request
This PR removes the random chance for hunted freelancers to spawn with only beanbags.

# Explain why it's good for the game
Your gun should gun when it needs to gun the most.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Puckaboo2
fix: Removes the random chance that Hunted Freelancers only spawn with beanbags with their Type-23.
/:cl:
