### PR TITLE
Fix: Round-spawn nested bodies no longer block projectiles

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -258,18 +258,18 @@ GLOBAL_VAR_INIT(cas_tracking_id_increment, 0) //this var used to assign unique t
 		var/obj/effect/landmark/corpsespawner/spawner = pick(gamemode_spawn_corpse)
 		var/turf/spawnpoint = get_turf(spawner)
 		if(spawnpoint)
-			var/mob/living/carbon/human/M = new /mob/living/carbon/human(spawnpoint)
-			M.create_hud() //Need to generate hud before we can equip anything apparently...
-			arm_equipment(M, spawner.equip_path, TRUE, FALSE)
+			var/mob/living/carbon/human/human_mob = new /mob/living/carbon/human(spawnpoint)
+			human_mob.create_hud() //Need to generate hud before we can equip anything apparently...
+			arm_equipment(human_mob, spawner.equip_path, TRUE, FALSE)
 			for(var/obj/structure/bed/nest/found_nest in spawnpoint)
 				for(var/turf/the_turf in list(get_step(found_nest, NORTH),get_step(found_nest, EAST),get_step(found_nest, WEST)))
 					if(the_turf.density)
 						found_nest.dir = get_dir(found_nest, the_turf)
 						found_nest.pixel_x = found_nest.buckling_x["[found_nest.dir]"]
 						found_nest.pixel_y = found_nest.buckling_y["[found_nest.dir]"]
-						M.dir = get_dir(the_turf,found_nest)
+						human_mob.dir = get_dir(the_turf,found_nest)
 				if(!found_nest.buckled_mob)
-					found_nest.do_buckle(M,M)
+					found_nest.forced_buckle_mob(human_mob,human_mob)
 		gamemode_spawn_corpse.Remove(spawner)
 
 /datum/game_mode/proc/spawn_static_comms()

--- a/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
@@ -218,7 +218,7 @@
 	if(mob == user)
 		return
 
-	var/mob/living/carbon/human/human = null
+	var/mob/living/carbon/human/human
 	if(ishuman(mob))
 		human = mob
 		if(human.body_position != LYING_DOWN) //Don't ask me why is has to be
@@ -265,6 +265,12 @@
 		human.do_ghost()
 
 	return TRUE
+
+/obj/structure/bed/nest/proc/forced_buckle_mob(mob/mob, mob/user)
+	do_buckle(mob, user)
+	ADD_TRAIT(mob, TRAIT_NESTED, TRAIT_SOURCE_BUCKLE)
+	ADD_TRAIT(mob, TRAIT_NO_STRAY, TRAIT_SOURCE_BUCKLE)
+	SEND_SIGNAL(mob, COMSIG_MOB_NESTED, user)
 
 /obj/structure/bed/nest/send_buckling_message(mob/M, mob/user)
 	M.visible_message(SPAN_XENONOTICE("[user] secretes a thick, vile resin, securing [M] into [src]!"),

--- a/code/modules/objectives/mob_objectives.dm
+++ b/code/modules/objectives/mob_objectives.dm
@@ -32,18 +32,18 @@
 		var/obj/effect/landmark/corpsespawner/spawner = pick(objective_spawn_corpse)
 		var/turf/spawnpoint = get_turf(spawner)
 		if(spawnpoint)
-			var/mob/living/carbon/human/M = new /mob/living/carbon/human(spawnpoint)
-			M.create_hud() //Need to generate hud before we can equip anything apparently...
-			arm_equipment(M, spawner.equip_path, TRUE, FALSE)
+			var/mob/living/carbon/human/human_mob = new /mob/living/carbon/human(spawnpoint)
+			human_mob.create_hud() //Need to generate hud before we can equip anything apparently...
+			arm_equipment(human_mob, spawner.equip_path, TRUE, FALSE)
 			for(var/obj/structure/bed/nest/found_nest in spawnpoint)
 				for(var/turf/the_turf in list(get_step(found_nest, NORTH),get_step(found_nest, EAST),get_step(found_nest, WEST)))
 					if(the_turf.density)
 						found_nest.dir = get_dir(found_nest, the_turf)
 						found_nest.pixel_x = found_nest.buckling_x["[found_nest.dir]"]
 						found_nest.pixel_y = found_nest.buckling_y["[found_nest.dir]"]
-						M.dir = get_dir(the_turf,found_nest)
+						human_mob.dir = get_dir(the_turf,found_nest)
 				if(!found_nest.buckled_mob)
-					found_nest.do_buckle(M,M)
+					found_nest.forced_buckle_mob(human_mob,human_mob)
 		objective_spawn_corpse.Remove(spawner)
 
 /datum/cm_objective/recover_corpses/post_round_start()


### PR DESCRIPTION

# About the pull request
Title
Eh Resolves: #11480 that I made like less than an hour ago cause I figured it out.

Makes a new proc that just takes the bits we need out of buckle_mob and slaps it on them
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Shooting weed food nested or nested bodies is bad.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MistChristmas
fix: Round-Start nested corpses no longer block projectiles like bullets.
/:cl:
