### PR TITLE
Minor Fix: Using inventory hotkeys whilst nested or lying down

### DIFF
--- a/code/datums/keybinding/human_inventory.dm
+++ b/code/datums/keybinding/human_inventory.dm
@@ -152,7 +152,7 @@
 	TIMER_COOLDOWN_START(src, COOLDOWN_SLOT_INTERACT_KEYBIND, INTERACT_KEYBIND_COOLDOWN_TIME)
 	var/mob/living/carbon/human/human_user = user.mob
 
-	if(human_user.is_mob_incapacitated(TRUE) || human_user.is_mob_restrained() || human_user.IsKnockDown() || HAS_TRAIT_FROM(human_user, TRAIT_UNDENSE, LYING_DOWN_TRAIT) && !HAS_TRAIT(human_user, TRAIT_HAULED))
+	if((human_user.is_mob_incapacitated(TRUE) || human_user.is_mob_restrained() || human_user.IsKnockDown() || HAS_TRAIT_FROM(human_user, TRAIT_UNDENSE, LYING_DOWN_TRAIT)) && !HAS_TRAIT(human_user, TRAIT_HAULED))
 		to_chat(user, SPAN_WARNING("You can't do that in your current state."))
 		return
 


### PR DESCRIPTION

# About the pull request
Resolves: #8999, Resolves: #7522

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Consistnacy for the first one, QoL for the other so they can spam their buttons and not pull out their holstered weapon until they're upright.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MistChristmas
fix: Inventory hotkeys don't let you use them if your lying down, restrained or nested.
/:cl:
