### PR TITLE
Automatic changes to VSC settings because of vsc update

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -117,10 +117,10 @@
 	"chat.extensionUnification.enabled": false,
 	"githubPullRequests.codingAgent.autoCommitAndPush": false,
 	"githubPullRequests.codingAgent.uiIntegration": false,
-	"chat.useClaudeSkills": false,
 	"chat.useNestedAgentsMdFiles": false,
 	"chat.tools.global.autoApprove": false,
 	"chat.mcp.gallery.enabled": false,
 	"mermaid-chat.enabled": false,
-	"githubPullRequests.experimental.useQuickChat": false
+	"githubPullRequests.experimental.useQuickChat": false,
+	"chat.useAgentSkills": false
 }


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #11458 because VSC version 1.108 depreciated a setting for another and it automatically is making a change to the settings file.

As always feel free to point out any other terrible settings to disable.

# Changelog

No player facing changes.
