### PR TITLE
Sharp operator pick rate stats

### DIFF
--- a/code/modules/cm_marines/equipment/kit_boxes.dm
+++ b/code/modules/cm_marines/equipment/kit_boxes.dm
@@ -203,6 +203,7 @@
 	name = "\improper SHARP Operator equipment case"
 	desc = "A large case containing a P9 SHARP rifle, M3-G4 Grenadier armor and helmet, and various pieces of additional equipment.\nDrag this sprite onto yourself to open it up!"
 	kit_overlay = "grenadier"
+	kit_name = "sharp_operator"
 
 /obj/item/storage/box/spec/sharp_operator/fill_preset_inventory()
 	new /obj/item/weapon/gun/rifle/sharp(src)


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #8569 which failed to specify the `kit_name` used by stats for the spec.

Misc. Data (Marine) dashboard already has commented query code once this is merged.

# Explain why it's good for the game

Simply makes stat tracking work for them.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="1593" height="1064" alt="image" src="https://github.com/user-attachments/assets/3291d83e-350d-4c2b-afb7-93b4eb38da10" />

</details>


# Changelog
:cl: Drathek
fix: SHARP operator pick is now stat tracked
/:cl:
