### PR TITLE
RMC ERT bay walkways now align with the RMC ERT shuttle's doors

### DIFF
--- a/maps/templates/lazy_templates/twe_ert_station.dmm
+++ b/maps/templates/lazy_templates/twe_ert_station.dmm
@@ -3180,7 +3180,6 @@ yK
 cf
 KG
 kt
-kt
 PH
 Ur
 Qt
@@ -3188,6 +3187,7 @@ kt
 PH
 Ur
 Qt
+kt
 kt
 kt
 KG
@@ -3556,7 +3556,6 @@ yK
 AI
 ZX
 sh
-sh
 Xs
 Ur
 sf
@@ -3564,6 +3563,7 @@ sh
 Xs
 Ur
 sf
+sh
 sh
 sh
 ZX


### PR DESCRIPTION
# About the pull request
Resolves Issue #10607
# Explain why it's good for the game
Stuff not aligning properly is bad.
# Changelog
:cl:
maptweak: Walkways in the RMC ERT map now line up with the RMC ERT shuttle's doors.
/:cl: