### PR TITLE
Fix 360° HPR

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -4180,7 +4180,7 @@ Defined in conflicts.dm of the #defines folder.
 	desc = "A set of rugged telescopic poles to keep a weapon stabilized during firing."
 	icon_state = "bipod_m41ae2"
 	attach_icon = "bipod_m41ae2_a"
-	heavy_bipod = TRUE
+	heavy_bipod = FALSE
 	camo_bipod = TRUE // this bipod has a camo skin
 
 /obj/item/attachable/bipod/m41ae2/Initialize(mapload, ...)


### PR DESCRIPTION
# About the pull request
Fixes being able to fire the HPR 360° with bipod without it undeploying, Caused by #10425 which gave the HPR unique bipod the `heavy_bipod` var set true, since it's not a documented change in the CL it is considered an oversight

<img width="898" height="49" alt="image" src="https://github.com/user-attachments/assets/9c34aa41-8108-4f8c-8e95-7f420197fdb3" />

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Fixes a bug
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixes HPR being able to fire 360 degrees while bipoded without undeploying
/:cl:
