### PR TITLE
Fix SDQL lookups for closets, cables, and vehicles

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -732,7 +732,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/sdql2_vv_all, new(null
 		if((location == world) && (options & SDQL2_OPTION_OPTIMIZED_SOURCE))
 			search_location = GLOB.all_multi_vehicles
 
-		for(var/obj/item/ammo_magazine/d in search_location)
+		for(var/obj/vehicle/multitile/d in search_location)
 			if(typecache[d.type] && (d.can_vv_get() || superuser))
 				out += d
 			SDQL2_TICK_CHECK
@@ -743,7 +743,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/sdql2_vv_all, new(null
 		if((location == world) && (options & SDQL2_OPTION_OPTIMIZED_SOURCE))
 			search_location = GLOB.closet_list
 
-		for(var/obj/item/ammo_magazine/d in search_location)
+		for(var/obj/structure/closet/d in search_location)
 			if(typecache[d.type] && (d.can_vv_get() || superuser))
 				out += d
 			SDQL2_TICK_CHECK
@@ -754,7 +754,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/sdql2_vv_all, new(null
 		if((location == world) && (options & SDQL2_OPTION_OPTIMIZED_SOURCE))
 			search_location = GLOB.cable_list
 
-		for(var/obj/item/ammo_magazine/d in search_location)
+		for(var/obj/structure/cable/d in search_location)
 			if(typecache[d.type] && (d.can_vv_get() || superuser))
 				out += d
 			SDQL2_TICK_CHECK


### PR DESCRIPTION

# About the pull request

This PR simply fixes a copypaste error making lookups for closets, cables, and vehicles not work.

# Explain why it's good for the game

SDQL should work.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="1575" height="382" alt="image" src="https://github.com/user-attachments/assets/b3594837-fb4a-4acf-8815-f680b7da9efa" />


</details>


# Changelog
:cl: Drathek
fix: SDQL can search for closets, cables, and vehicles
/:cl:
