### PR TITLE
Minor Fix: You can pick up nettles with gloves

### DIFF
--- a/code/game/objects/items/reagent_containers/food/snacks/grown.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks/grown.dm
@@ -105,7 +105,6 @@
 		to_chat(user, SPAN_DANGER("The nettle burns your bare hand!"))
 		var/obj/limb/affecting = user.get_limb(user.hand ? "l_hand":"r_hand")
 		affecting.take_damage(0, force)
-	return TRUE
 
 /obj/item/reagent_container/food/snacks/grown/nettle/death
 	plantname = "deathnettle"
@@ -120,12 +119,11 @@
 	user.apply_internal_damage(potency/potency_divisior, user.internal_organs_by_name["liver"])
 
 /obj/item/reagent_container/food/snacks/grown/nettle/death/pickup(mob/living/carbon/human/user)
-
-	if(..() && !user.gloves && prob(50))
+	. = ..()
+	if(!user.gloves && prob(50))
 		user.apply_effect(5, PARALYZE)
 		to_chat(user, SPAN_DANGER("You are stunned by the deathnettle as you try to pick it up!"))
 		return FALSE
-	return TRUE
 
 /obj/item/reagent_container/food/snacks/grown/harebell
 	name = "harebell"


### PR DESCRIPTION

# About the pull request
Title
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
You should be able to pick things up. Even if you are wearing gloves.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MistChristmas
fix: Nettles and Death nettles can be picked up when you have gloves on
/:cl:
