### PR TITLE
Minor UI: R and L in strip menu stay static

### DIFF
--- a/tgui/packages/tgui/styles/interfaces/StripMenu.scss
+++ b/tgui/packages/tgui/styles/interfaces/StripMenu.scss
@@ -4,16 +4,16 @@ $background-color: hsla(0, 0%, 0%, 0.33) !default;
 
 .StripMenu__cornertext_left {
   position: absolute;
-  top: -1%;
-  left: 3%;
+  top: -2px;
+  left: 3px;
   text-align: left;
   text-shadow: 1px 1px 1px hsl(0, 0%, 33%);
 }
 
 .StripMenu__cornertext_right {
   position: absolute;
-  top: -1%;
-  right: 3%;
+  top: -2px;
+  right: 4px;
   text-align: absolute;
   text-shadow: 1px 1px 1px hsl(0, 0%, 33%);
 }


### PR DESCRIPTION

# About the pull request
Title
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Doesn't look silly
# Testing Photographs and Procedure
<details>
<summary>Before & After pictures:</summary>


Before:
<img width="430" height="400" alt="Screenshot 2026-01-11 221400" src="https://github.com/user-attachments/assets/c1fa0254-c815-4ff7-bc1a-91a343550b38" />
After:
<img width="430" height="400" alt="image" src="https://github.com/user-attachments/assets/57f50469-c840-4b20-b5a2-084fb44da135" />

</details>


# Changelog
:cl: MistChristmas
ui: Tweaks to make the L and R in strip menu not move.
/:cl:
