### PR TITLE
Fix fire sprites to render above tall grass and bushes

### DIFF
--- a/code/modules/projectiles/guns/flamer/flamer.dm
+++ b/code/modules/projectiles/guns/flamer/flamer.dm
@@ -552,7 +552,7 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	icon = 'icons/effects/fire.dmi'
 	icon_state = "dynamic_2"
-	layer = BELOW_OBJ_LAYER
+	layer = FACEHUGGER_LAYER
 
 	light_system = STATIC_LIGHT
 	light_on = TRUE


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

This changes the render layer for fire from `BELOW_OBJ_LAYER` to be higher than tallgrass and bushes. To see which layers are in between we can look at:

https://github.com/cmss13-devs/cmss13/blob/b5fdd521893688496435d65c5f52abdf4233c8e5/code/__DEFINES/layers.dm#L82-L135

The reason we need to go past the xeno layer is because several shrubbery structures render on the `ABOVE_XENO_LAYER`. 

# Explain why it's good for the game
I played CM back in 2018. This bug still has not been fucking fixed. It's not very fun to die from fire that is hiding underneath tallgrass that you cannot see. 

# Testing Photographs and Procedure
N/A

# Changelog
:cl:
fix: Fix fire sprites to render above tall grass and bushes
/:cl:
