### PR TITLE
Dragging an invisible lurker doesn't stun humans.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -810,7 +810,6 @@
 		playsound(puller.loc, 'sound/weapons/pierce.ogg', 25, 1)
 		puller.visible_message(SPAN_WARNING("[puller] tried to pull [src] but instead gets a tail swipe to the head!"))
 		if(stealth)
-			puller.apply_effect(caste.tacklestrength_min, WEAKEN)
 			return FALSE
 		puller.apply_effect(rand(caste.tacklestrength_min,caste.tacklestrength_max), WEAKEN)
 		return FALSE


### PR DESCRIPTION

# About the pull request

Removes a cheese strat lurkers could do where they sit on top of invisible marines.

# Explain why it's good for the game

This is almost exclusively used for cheese where lurkers sit, invisible, on top of dead marines. When a medic walks up and tries to pull the body, surprise stun and cap.

I don't think there's any real skill here besides cheese. The only 'counterplay' is to right click all corpses before starting to drag them, which is uninteresting.

The only thing 'lost' by removing this is a cute tech lurkers can do but I don't think that's sufficient to justify round removal for the victims. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

# Changelog

:cl:
balance: Dragging an invisible xenomorph doesn't stun humans.
/:cl:
