### PR TITLE
small change to changelog labeler

### DIFF
--- a/.github/add_labels.py
+++ b/.github/add_labels.py
@@ -54,7 +54,7 @@ def get_labels(pr):
             continue
         labels[fileToPrefix[prefix]] = True
 
-    changelog_match = re.search(r"(?:🆑|:cl:)(.*)\/(?:🆑|:cl:)", pr.body, re.S | re.M)
+    changelog_match = re.search(r"(?:🆑|:cl:)(.*)/(?:🆑|:cl:)", pr.body, re.S | re.M)
     if changelog_match is None:
         print("::warning ::No changelog detected.")
         labels[missingLogLabel] = True


### PR DESCRIPTION

# About the pull request
previously the changelog could be wrapped like this

```
:cl:

fix

:cl:


Or like this

🆑 
Fix
🆑

But not this 
:cl:

🆑  
```

not anymore

Old regex: 
<details>
<summary>Screenshots & Videos</summary>
<img width="934" height="112" alt="image" src="https://github.com/user-attachments/assets/ea3e1e11-96d8-40be-bd1f-2cbf9b148b28" />



</details>


New Regex: 
<details>
<summary>Screenshots & Videos</summary>
<img width="938" height="121" alt="image" src="https://github.com/user-attachments/assets/63bc5e3f-0751-41f0-a472-838f84c3a0f0" />


</details>

Changelog for test taken from : #8846 


# Explain why it's good for the game
should  lower the amount of people asking why did they get a missing changelog by 85%
# Testing Photographs and Procedure


# Changelog


no game changes