### PR TITLE
Adds a 10 minute cooldown to the last stand xenomorph healing

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -3,6 +3,8 @@
 /// Doesn't count tier 0
 GLOBAL_VAR_INIT(total_dead_xenos, 0)
 
+#define LAST_XENO_HEAL_COOLDOWN "last_xeno_heal_cooldown"
+
 /mob/living/carbon/xenomorph/death(cause, gibbed)
 	var/msg = "lets out a waning guttural screech, green blood bubbling from its maw."
 	. = ..(cause, gibbed, msg)
@@ -142,7 +144,9 @@ GLOBAL_VAR_INIT(total_dead_xenos, 0)
 				// Tell the xeno she is the last one, heal her and make her fight to the death
 				if(xeno.client)
 					to_chat(xeno, SPAN_XENOANNOUNCE("Your carapace rattles with RAGE. You are all that remains of the hive! Go out fighting, kill them all!"))
-					xeno.rejuvenate()
+					if(!TIMER_COOLDOWN_CHECK(xeno, LAST_XENO_HEAL_COOLDOWN))
+						xeno.rejuvenate()
+						TIMER_COOLDOWN_START(xeno, LAST_XENO_HEAL_COOLDOWN, 10 MINUTES)
 					if(!isqueen(xeno))
 						xeno.can_heal = FALSE
 				notify_ghosts(header = "Last Xenomorph", message = "There is only one Xenomorph left: [xeno.name].", source = xeno, action = NOTIFY_ORBIT)
@@ -183,3 +187,5 @@ GLOBAL_VAR_INIT(total_dead_xenos, 0)
 /mob/living/carbon/xenomorph/revive()
 	SEND_SIGNAL(src, COMSIG_XENO_REVIVED)
 	..()
+
+#undef LAST_XENO_HEAL_COOLDOWN


### PR DESCRIPTION

# About the pull request

Prevents xenos from getting healed often by this.
Especially bad if the Queen is the last living xeno, and a lesser/hugger/anything that counts as a xenomorph spawns and dies, which can provide pretty "unfair" healing.

# Explain why it's good for the game
Bad to give no-cooldown full-heals that can somewhat be gamed.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Adds a 10 minute cooldown per-xeno for becoming the "last-stand" xenomorph and getting a full-heal
/:cl:
