### PR TITLE
Grammar: More accounting for gender/obscured in examine text

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -248,7 +248,7 @@
 			if(user && src && distance <= 1)
 				get_pulse(GETPULSE_HAND) // to update it
 				if(pulse == PULSE_NONE || status_flags & FAKEDEATH)
-					to_chat(user, SPAN_DEADSAY("[t_He] [t_has] no pulse[client ? "" : " and [t_his] soul [t_has] departed"]..."))
+					to_chat(user, SPAN_DEADSAY("[t_He] [t_has] no pulse[client ? "" : " and [t_his] soul has departed"]..."))
 				else
 					to_chat(user, SPAN_DEADSAY("[t_He] [t_has] a pulse!"))
 


### PR DESCRIPTION

# About the pull request
As Title
replace a bunch of instances of has/does/is replace with the appropriate var
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Game talk good yes
# Testing Photographs and Procedure
<details>
<summary>Le Example:</summary>

<img width="1096" height="1760" alt="They" src="https://github.com/user-attachments/assets/56219724-bb66-479f-a1bf-9ddc54a11df4" />


</details>



# Changelog
:cl: MistChristmas
spellcheck: Fixed some examine instances not accounting for gender/obscured face.
/:cl:
