### PR TITLE
Updates CIC tablet UI state to in_inventory + not incapacitated

### DIFF
--- a/code/game/objects/items/devices/cictablet.dm
+++ b/code/game/objects/items/devices/cictablet.dm
@@ -76,8 +76,6 @@
 	if(!on)
 		return UI_DISABLED
 
-	return UI_INTERACTIVE
-
 /obj/item/device/cotablet/ui_state(mob/user)
 	return GLOB.not_incapacitated_and_inventory_state
 


### PR DESCRIPTION

# About the pull request

Shouldn't really have the UI available to you when you're dead or unconscious

Fixes #10884 

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: CIC tablet now closes when you die/fall unconscious
/:cl:
