### PR TITLE
Trapper window smashing fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/boiler/trapper.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/boiler/trapper.dm
@@ -188,7 +188,7 @@
 	if(!affected_atom || affected_atom.layer >= FLY_LAYER || !isturf(xeno.loc))
 		return
 
-	if(!check_clear_path_to_target(xeno, affected_atom, TRUE, TRAPPER_VIEWRANGE))
+	if(!check_clear_path_to_target(xeno, affected_atom, TRUE, TRAPPER_VIEWRANGE, FALSE))
 		to_chat(xeno, SPAN_XENOWARNING("Something is in the way!"))
 		return
 


### PR DESCRIPTION
# About the pull request

This is utterly horrible. Please help.

What I am trying to fix here is issue #11510
Basically right now if a trapper tries to fire an acid mine through any N number of windows it will cause all the windows to be silently destroyed, without the ability hitting or getting a cooldown.

With this fix as is right now, what will instead happen is that the acid mine will go through a singular window, if it doesnt encounter any more obstructions it will hit its target and destroy the window, if it does encounter then the ability will be completely cancelled without cooldown and the window will remain unharmed.

However the only way I could make it work in the code is horrible.

I will fix single letter vars after we get better code.

# Explain why it's good for the game

Silent bugs bad.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Trapper boilers can no longer mass delete windows.
/:cl:
