### PR TITLE
Tent Insulation Tweak

### DIFF
--- a/code/modules/tents/deployed_tents.dm
+++ b/code/modules/tents/deployed_tents.dm
@@ -15,7 +15,8 @@
 	var/y_dim = 4
 
 	/// How much cold protection to add to entering humans - Full body clothing means complete (1) protection
-	var/cold_protection_factor = 0.4
+	/// Insulated enough to protect armorless patients in the medical tent
+	var/cold_protection_factor = 0.7
 
 	/// Roof display icon_state or null to disable
 	var/roof_state


### PR DESCRIPTION
# About the pull request

Increases insulation of tents from 0.4 to 0.7. Tested. Armorless patients in the tent will still become cold, but won't take damage from it. 

# Explain why it's good for the game

Tent insulation is next to useless right now. The insulation level isn't high enough to stop someone from taking cold damage if they're sans helmet/armor. That means that if you do surgery on a patient in a tent on a snow planet, they'll take burn damage while you do it. 

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>


Proof of Improved Insulation
https://github.com/user-attachments/assets/49303403-e80a-4b1a-afa2-d4b9fa0ffd49

Proof that people inside the tent will get colder over time, but never to the level of taking damage
<img width="1917" height="1006" alt="image" src="https://github.com/user-attachments/assets/579bf553-f2cb-4894-800c-7334754dae14" />

</details>


# Changelog

:cl:
balance: increased insulation of tents from 0.4 to 0.7 (enough to stop armorless people from taking cold damage while inside)
/:cl:
