### PR TITLE
Fix: Holding Right click stops left clicks from going through or vice versa.

### DIFF
--- a/code/_onclick/click_hold.dm
+++ b/code/_onclick/click_hold.dm
@@ -37,12 +37,7 @@
 			mods -= LEFT_CLICK
 		else
 			mods -= RIGHT_CLICK
-	else if(mods[LEFT_CLICK] && mods[MIDDLE_CLICK])
-		if(mods[BUTTON] == MIDDLE_CLICK)
-			mods -= LEFT_CLICK
-		else
-			mods -= MIDDLE_CLICK
-	params = list2params(mods)
+		params = list2params(mods)
 
 	if(SEND_SIGNAL(mob, COMSIG_MOB_MOUSEDOWN, A, T, skin_ctl, params) & COMSIG_MOB_CLICK_CANCELED)
 		return


### PR DESCRIPTION
# About the pull request
Resolves: #11566

Sorta? It's not really that much of a bug. The main issue is PBs when clicking adjacent tiles only do something on clicking a mob.

But this stops you from spamming whilst following the sprite until it gets into that range.

But more than that this also helps xenos who are accidently holding down their ability button when they want to slash so It's an improvement... barely. For the few Xeno players that use Right click abilities

~Do the same for middle click I suppose.~
Oh look a can of worms.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Stops people from extending the range of the "PB only works when you sprite click on a mob" to the whole screen.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MistChristmas
fix: Holding Right click no longer stops the left clicking from going through and vice versa.
/:cl:
