### PR TITLE
xenos cant be buckled to chairs anymore

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -430,6 +430,10 @@
 			if(buckle_target.loc != loc)
 				return
 			. = buckle_mob(buckle_target)
+	if(buckle_target.mob_size > MOB_SIZE_HUMAN)
+		if(buckle_target.stat != DEAD)
+			to_chat(user, SPAN_WARNING("[buckle_target] resists your attempt to buckle!"))
+			return
 	if(SEND_SIGNAL(src, COMSIG_MOVABLE_PREBUCKLE, buckle_target, user, ride_check_flags, force, check_loc, lying_buckle, hands_needed, target_hands_needed, silent) & COMPONENT_BLOCK_BUCKLE)
 		return
 	do_buckle(buckle_target, user)


### PR DESCRIPTION

# About the pull request
i removed a line of code that should have stayed

# Explain why it's good for the game
fixes: #11572

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: you cant buckle xenos
/:cl:
