### PR TITLE
Fix: A computer ontop of a decryption computer + Duplicate Field Doc locker + Missing button in ORs.

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -696,7 +696,7 @@
 /obj/structure/machinery/light,
 /obj/structure/machinery/door_control{
 	id = "or3privacyshutter";
-	name = "\improper Window's Privacy Shutters";
+	name = "\improper Privacy Shutters Control";
 	pixel_y = -24;
 	throw_range = 15;
 	req_one_access_txt = "19;20"
@@ -740,7 +740,7 @@
 /obj/structure/machinery/light,
 /obj/structure/machinery/door_control{
 	id = "or4privacyshutter";
-	name = "\improper Window's Privacy Shutters";
+	name = "\improper Privacy Shutters Control";
 	pixel_y = -24;
 	throw_range = 15;
 	req_one_access_txt = "19;20"
@@ -1412,7 +1412,7 @@
 	id_tag = "or03"
 	},
 /obj/structure/machinery/door/poddoor/shutters/almayer{
-	id = "or3shutter";
+	id = "or3privacyshutter";
 	name = "\improper Privacy Shutters"
 	},
 /turf/open/floor/almayer/test_floor4,
@@ -1432,7 +1432,7 @@
 	id_tag = "or04"
 	},
 /obj/structure/machinery/door/poddoor/shutters/almayer{
-	id = "or4shutter";
+	id = "or4privacyshutter";
 	name = "\improper Privacy Shutters"
 	},
 /turf/open/floor/almayer/test_floor4,
@@ -3042,7 +3042,7 @@
 	id_tag = "or01"
 	},
 /obj/structure/machinery/door/poddoor/shutters/almayer{
-	id = "or1shutter";
+	id = "or1privacyshutter";
 	name = "\improper Privacy Shutters"
 	},
 /turf/open/floor/almayer/test_floor4,
@@ -3059,7 +3059,7 @@
 	id_tag = "or02"
 	},
 /obj/structure/machinery/door/poddoor/shutters/almayer{
-	id = "or2shutter";
+	id = "or2privacyshutter";
 	name = "\improper Privacy Shutters"
 	},
 /turf/open/floor/almayer/test_floor4,
@@ -3569,7 +3569,7 @@
 	},
 /obj/structure/machinery/door_control{
 	id = "or1privacyshutter";
-	name = "\improper Window's Privacy Shutters";
+	name = "\improper Privacy Shutters Control";
 	pixel_y = 23;
 	throw_range = 15;
 	req_one_access_txt = "19;20"
@@ -3639,7 +3639,7 @@
 	},
 /obj/structure/machinery/door_control{
 	id = "or2privacyshutter";
-	name = "\improper Window's Privacy Shutters";
+	name = "\improper Privacy Shutters Control";
 	pixel_y = 23;
 	throw_range = 15;
 	req_one_access_txt = "19;20"
@@ -24139,8 +24139,8 @@
 	pixel_y = 3
 	},
 /obj/structure/machinery/door_control{
-	id = "or2shutter";
-	name = "\improper Door's Privacy Shutters";
+	id = "or2privacyshutter";
+	name = "\improper Privacy Shutters Control";
 	pixel_y = -22;
 	throw_range = 15;
 	pixel_x = 5;
@@ -35943,8 +35943,8 @@
 	dir = 1
 	},
 /obj/structure/machinery/door_control{
-	id = "or1shutter";
-	name = "\improper Door's Privacy Shutters";
+	id = "or1privacyshutter";
+	name = "\improper Privacy Shutters Control";
 	pixel_y = 23;
 	throw_range = 15;
 	req_one_access_txt = "19;20"
@@ -37971,8 +37971,8 @@
 	dir = 1
 	},
 /obj/structure/machinery/door_control{
-	id = "or2shutter";
-	name = "\improper Door's Privacy Shutters";
+	id = "or2privacyshutter";
+	name = "\improper Privacy Shutters Control";
 	pixel_y = 23;
 	throw_range = 15;
 	req_one_access_txt = "19;20"
@@ -41654,8 +41654,8 @@
 	pixel_y = -22
 	},
 /obj/structure/machinery/door_control{
-	id = "or1shutter";
-	name = "\improper Door's Privacy Shutters";
+	id = "or1privacyshutter";
+	name = "\improper Privacy Shutters Control";
 	pixel_y = -22;
 	throw_range = 15;
 	pixel_x = -5;
@@ -53650,8 +53650,8 @@
 	},
 /obj/structure/machinery/light,
 /obj/structure/machinery/door_control{
-	id = "or3shutter";
-	name = "\improper Door's Privacy Shutters";
+	id = "or3privacyshutter";
+	name = "\improper Privacy Shutters Control";
 	pixel_y = -24;
 	throw_range = 15;
 	req_one_access_txt = "19;20"
@@ -57280,8 +57280,8 @@
 	pixel_y = 26
 	},
 /obj/structure/machinery/door_control{
-	id = "or4shutter";
-	name = "\improper Door's Privacy Shutters";
+	id = "or4privacyshutter";
+	name = "\improper Privacy Shutters Control";
 	pixel_y = 26;
 	throw_range = 15;
 	pixel_x = 5;
@@ -78696,8 +78696,8 @@
 "siW" = (
 /obj/structure/machinery/light,
 /obj/structure/machinery/door_control{
-	id = "or4shutter";
-	name = "\improper Door's Privacy Shutters";
+	id = "or4privacyshutter";
+	name = "\improper Privacy Shutters Control";
 	pixel_y = -24;
 	throw_range = 15;
 	req_one_access_txt = "19;20"
@@ -89867,8 +89867,8 @@
 	pixel_y = 26
 	},
 /obj/structure/machinery/door_control{
-	id = "or3shutter";
-	name = "\improper Door's Privacy Shutters";
+	id = "or3privacyshutter";
+	name = "\improper Privacy Shutters Control";
 	pixel_y = 26;
 	throw_range = 15;
 	pixel_x = -5;


### PR DESCRIPTION
# About the pull request
Title
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
CIC needs that.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MistChristmas
maptweak: Removed a computer place ontop of the decryption computers. Removed a duplicate Field Doctor Locker. Restored the Privacy button in the ORs.
/:cl:
