### PR TITLE
Makes prime thunderdome Kings exempt from alliance breaking

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/King.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/King.dm
@@ -80,7 +80,7 @@
 	. = ..()
 	AddComponent(/datum/component/footstep, 2 , 35, 11, 4, "alien_footstep_large")
 	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(post_move))
-	if(!should_block_game_interaction(src)) // don't let admin-level kings mess up alliances
+	if(!should_block_game_interaction(src, TRUE)) // don't let admin-level kings mess up alliances
 		hive = GLOB.hive_datum[hivenumber]
 		hive.banned_allies = list("All")
 		if(hive.break_all_alliances())


### PR DESCRIPTION

# About the pull request

Fixes an issue encountered on round 31999 where a Hunting Ground King broke alliance on main map

# Explain why it's good for the game

Don't let admins break the game that easy


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Kings spawned in hunting grounds won't affect their primary hive wrt. alliances
/:cl:
