### PR TITLE
runners being ridden can no longer ventcrawl

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/can_ventcrawl()
-	return (mob_size < MOB_SIZE_BIG && caste.can_vent_crawl)
+	return (mob_size < MOB_SIZE_BIG && caste.can_vent_crawl && !LAZYLEN(buckled_mobs))
 
 /mob/living/carbon/xenomorph/ventcrawl_carry()
 	var/mob/living/carbon/human/user = hauled_mob?.resolve()


### PR DESCRIPTION

# About the pull request
title, fixes: nothing because this wasnt reported

# Explain why it's good for the game

vents are not clown cars, people dont fit in there. could also leave someone in there if they unbuckle while you're ventcrawling

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: ridden runners cannot ventcrawl
/:cl:
