### PR TITLE
Ladders with a radial wheel will show it to you when you use a ladder.

### DIFF
--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -3,17 +3,22 @@
 	desc = "A sturdy metal ladder."
 	icon = 'icons/obj/structures/ladders.dmi'
 	icon_state = "ladder11"
-	var/id = null
-	var/height = 0 //The 'height' of the ladder. higher numbers are considered physically higher
-	var/obj/structure/ladder/down = null //The ladder below this one
-	var/obj/structure/ladder/up = null //The ladder above this one
 	anchored = TRUE
 	unslashable = TRUE
 	unacidable = TRUE
 	layer = LADDER_LAYER
+	/// Used to link up ladders that are above and below
+	var/id = null
+	/// The 'height' of the ladder. higher numbers are considered physically higher
+	var/height = 0
+	/// The ladder below this one
+	var/obj/structure/ladder/down = null
+	/// The ladder above this one
+	var/obj/structure/ladder/up = null
 	var/is_watching = 0
 	var/obj/structure/machinery/camera/cam
-	var/busy = FALSE //Ladders are wonderful creatures, only one person can use it at a time
+	/// Ladders are wonderful creatures, only one person can use it at a time
+	var/busy = FALSE
 	var/static/list/direction_selection = list("up" = image(icon = 'icons/mob/radial.dmi', icon_state = "radial_ladder_up"), "down" = image(icon = 'icons/mob/radial.dmi', icon_state = "radial_ladder_down"))
 
 
@@ -52,17 +57,15 @@
 	update_icon()
 
 /obj/structure/ladder/Destroy()
-	if(down)
-		if(istype(down))
-			down.up = null
-		down = null
-	if(up)
-		if(istype(up))
-			up.down = null
-		up = null
+	if(istype(down))
+		down.up = null
+	if(istype(up))
+		up.down = null
+	down = null
+	up = null
 	QDEL_NULL(cam)
 	GLOB.ladder_list -= src
-	. = ..()
+	return ..()
 
 /obj/structure/ladder/update_icon()
 	if(up && down)
@@ -142,6 +145,8 @@
 			user.trainteleport(ladder_dest.loc)
 	busy = FALSE
 	add_fingerprint(user)
+	if(ladder_dest.up && ladder_dest.down) // Make sure it has a up and down before opening the radial wheel, otherwise it sends you
+		ladder_dest.attack_hand(user)
 	return TRUE
 
 //Alt click to go down

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -12,9 +12,9 @@
 	/// The 'height' of the ladder. higher numbers are considered physically higher
 	var/height = 0
 	/// The ladder below this one
-	var/obj/structure/ladder/down = null
+	var/obj/structure/ladder/down
 	/// The ladder above this one
-	var/obj/structure/ladder/up = null
+	var/obj/structure/ladder/up
 	var/is_watching = 0
 	var/obj/structure/machinery/camera/cam
 	/// Ladders are wonderful creatures, only one person can use it at a time


### PR DESCRIPTION

# About the pull request
Ladders with a radial wheel will show it to you when you use a ladder.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
It's some qol, if a ladder goes up 2 floors, brings up the radial wheel to make it easier to go up/down both.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Ladders will automatically show the radial wheel after being used
/:cl:
