### PR TITLE
LV624 - Correct LZ1 name (for announcement)

### DIFF
--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -8365,7 +8365,7 @@
 	},
 /obj/structure/machinery/computer/shuttle/dropship/flight/lz1,
 /turf/open/gm/grass/grass1,
-/area/lv624/lazarus/landing_zones/lz1)
+/area/lv624/landing/console)
 "aRu" = (
 /obj/structure/machinery/landinglight/ds2{
 	dir = 8


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Instead of "Alamo Landing Zone was selected for LZ", it will now correctly say "LZ1 Robotics was selected for LZ"

# Explain why it's good for the game
Fixing bugs good (it's an oversight)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="746" height="156" alt="image" src="https://github.com/user-attachments/assets/ff0b58c4-dba7-4554-ae29-32e5a06a1f1f" />


</details>


# Changelog
:cl:
maptweak: LV624 LZ1 is now correctly called "LZ1 Nexus", instead of being "Alamo Landing Zone".
/:cl:
