### PR TITLE
Upgrades all sleepers and autodocs in ERT stations

### DIFF
--- a/maps/templates/lazy_templates/freelancer_ert_station.dmm
+++ b/maps/templates/lazy_templates/freelancer_ert_station.dmm
@@ -131,7 +131,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/adminlevel/ert_station)
 "fX" = (
-/obj/structure/machinery/medical_pod/sleeper,
+/obj/structure/machinery/medical_pod/sleeper/upgraded,
 /turf/open/floor/almayer/dark_sterile,
 /area/adminlevel/ert_station)
 "fY" = (
@@ -759,7 +759,7 @@
 /turf/open/floor/prison/kitchen,
 /area/adminlevel/ert_station)
 "KN" = (
-/obj/structure/machinery/autodoc_console,
+/obj/structure/machinery/autodoc_console/upgraded,
 /turf/open/floor/almayer/dark_sterile,
 /area/adminlevel/ert_station)
 "Lh" = (

--- a/maps/templates/lazy_templates/twe_ert_station.dmm
+++ b/maps/templates/lazy_templates/twe_ert_station.dmm
@@ -1696,7 +1696,7 @@
 /turf/closed/wall/r_wall/elevator,
 /area/adminlevel/ert_station/royal_marines_station)
 "Oi" = (
-/obj/structure/machinery/medical_pod/sleeper,
+/obj/structure/machinery/medical_pod/sleeper/upgraded,
 /turf/open/floor/almayer/sterile_green,
 /area/adminlevel/ert_station/royal_marines_station)
 "Os" = (
@@ -1808,7 +1808,7 @@
 /turf/open/floor/almayer/sterile_green,
 /area/adminlevel/ert_station/royal_marines_station)
 "PU" = (
-/obj/structure/machinery/medical_pod/autodoc,
+/obj/structure/machinery/medical_pod/autodoc/unskilled,
 /turf/open/floor/almayer/sterile_green,
 /area/adminlevel/ert_station/royal_marines_station)
 "PY" = (
@@ -2276,7 +2276,7 @@
 /turf/open/void,
 /area/adminlevel/ert_station/royal_marines_station)
 "Yk" = (
-/obj/structure/machinery/autodoc_console,
+/obj/structure/machinery/autodoc_console/upgraded,
 /turf/open/floor/almayer/sterile_green,
 /area/adminlevel/ert_station/royal_marines_station)
 "YI" = (

--- a/maps/templates/lazy_templates/upp_ert_station.dmm
+++ b/maps/templates/lazy_templates/upp_ert_station.dmm
@@ -2013,7 +2013,7 @@
 /turf/open/floor/strata/floor2,
 /area/adminlevel/ert_station/upp_station)
 "QR" = (
-/obj/structure/machinery/medical_pod/sleeper,
+/obj/structure/machinery/medical_pod/sleeper/upgraded,
 /turf/open/floor/strata/white_cyan3,
 /area/adminlevel/ert_station/upp_station)
 "Rd" = (

--- a/maps/templates/lazy_templates/uscm_ert_station.dmm
+++ b/maps/templates/lazy_templates/uscm_ert_station.dmm
@@ -1302,7 +1302,7 @@
 	icon_state = "S";
 	layer = 3.3
 	},
-/obj/structure/machinery/autodoc_console,
+/obj/structure/machinery/autodoc_console/upgraded,
 /turf/open/floor/almayer/dark_sterile,
 /area/adminlevel/ert_station/uscm_station)
 "oD" = (

--- a/maps/templates/lazy_templates/weyland_ert_station.dmm
+++ b/maps/templates/lazy_templates/weyland_ert_station.dmm
@@ -362,7 +362,7 @@
 /area/adminlevel/ert_station/weyland_station)
 "gf" = (
 /obj/structure/machinery/body_scanconsole,
-/obj/structure/machinery/autodoc_console{
+/obj/structure/machinery/autodoc_console/upgraded{
 	dir = 1
 	},
 /turf/open/floor/corsat/green/north,
@@ -761,7 +761,7 @@
 /turf/open/floor/corsat/yellow/southeast,
 /area/adminlevel/ert_station/weyland_station)
 "mm" = (
-/obj/structure/machinery/medical_pod/sleeper,
+/obj/structure/machinery/medical_pod/sleeper/upgraded,
 /turf/open/floor/corsat/green/east,
 /area/adminlevel/ert_station/weyland_station)
 "mn" = (


### PR DESCRIPTION

# About the pull request

Self explanatory, I have upgraded all the sleepers and autodocs in the ERT stations that have them, so now all ERT stations have machines that have been upgraded with research upgrades (meaning autodocs can do more surgeries and sleepers perform better). I have also replaced the autodocs with unskilled ones where they weren't yet.

CLF ERT station gets nothing lol! UPP ERT station doesn't get an autodoc (they never had one) and the USCM ERT station doesn't get a sleeper (they also never had one)

# Explain why it's good for the game

Provides a better experience to the people who escape to the respective ERT station, being able to perform surgeries on others despite having nobody with surgical skills who escaped with you and making the unskilled autodocs actually worthwile as they get back the original functions before they got split into research upgrades (ERTs have no way to upgrade them)


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
maptweak: All ERT stations who had sleepers and autodocs have recieved upgrades to said machines.
/:cl:

