### PR TITLE
Fix boon of fire resistance

### DIFF
--- a/code/modules/cm_aliens/hivebuffs/hivebuff.dm
+++ b/code/modules/cm_aliens/hivebuffs/hivebuff.dm
@@ -476,27 +476,29 @@
 
 	var/valid_immunity = xeno.fire_immunity
 	if(xeno.fire_immunity & FIRE_IMMUNITY_XENO_FRENZY)
-		valid_immunity -= FIRE_IMMUNITY_XENO_FRENZY
+		valid_immunity &= ~FIRE_IMMUNITY_XENO_FRENZY
 
 	if((valid_immunity & FIRE_IMMUNITY_COMPLETE)) // Already completely fire immune, return
 		return
 
+	xeno.remove_fire_immunity_signals()
 
 	switch(valid_immunity)
 		if(FIRE_IMMUNITY_NONE) // No immunities whatsoever, make immune to ignition but not fire damage
-			xeno.RegisterSignal(xeno, COMSIG_LIVING_PREIGNITION, TYPE_PROC_REF(/mob/living/carbon/xenomorph, preignition_no_ignition), TRUE)
-			xeno.RegisterSignal(xeno, list(COMSIG_LIVING_FLAMER_CROSSED, COMSIG_LIVING_FLAMER_FLAMED), TYPE_PROC_REF(/mob/living/carbon/xenomorph, flamer_cross_no_ignition), TRUE)
+			RegisterSignal(xeno, COMSIG_LIVING_PREIGNITION, TYPE_PROC_REF(/mob/living/carbon/xenomorph, preignition_no_ignition))
+			RegisterSignal(xeno, list(COMSIG_LIVING_FLAMER_CROSSED, COMSIG_LIVING_FLAMER_FLAMED), TYPE_PROC_REF(/mob/living/carbon/xenomorph, flamer_cross_no_ignition))
 
 		if(FIRE_IMMUNITY_NO_DAMAGE) // Immune to damage but not ignition, make them immune to ignition
-			xeno.RegisterSignal(xeno, COMSIG_LIVING_PREIGNITION, TYPE_PROC_REF(/mob/living/carbon/xenomorph, preignition_complete_immunity), TRUE)
-			xeno.RegisterSignal(xeno, list(COMSIG_LIVING_FLAMER_CROSSED, COMSIG_LIVING_FLAMER_FLAMED), TYPE_PROC_REF(/mob/living/carbon/xenomorph, flamer_cross_complete_immunity), TRUE)
+			RegisterSignal(xeno, COMSIG_LIVING_PREIGNITION, TYPE_PROC_REF(/mob/living/carbon/xenomorph, preignition_complete_immunity))
+			RegisterSignal(xeno, list(COMSIG_LIVING_FLAMER_CROSSED, COMSIG_LIVING_FLAMER_FLAMED), TYPE_PROC_REF(/mob/living/carbon/xenomorph, flamer_cross_complete_immunity))
 
 		if(FIRE_IMMUNITY_NO_IGNITE) // Immune to ignition but not damage, make them immune to damage
-			xeno.RegisterSignal(xeno, list(COMSIG_LIVING_FLAMER_CROSSED, COMSIG_LIVING_FLAMER_FLAMED), TYPE_PROC_REF(/mob/living/carbon/xenomorph, flamer_cross_complete_immunity), TRUE)
+			RegisterSignal(xeno, COMSIG_LIVING_PREIGNITION, TYPE_PROC_REF(/mob/living/carbon/xenomorph, preignition_complete_immunity))
+			RegisterSignal(xeno, list(COMSIG_LIVING_FLAMER_CROSSED, COMSIG_LIVING_FLAMER_FLAMED), TYPE_PROC_REF(/mob/living/carbon/xenomorph, flamer_cross_complete_immunity))
 
 		if(FIRE_IMMUNITY_BURROWER) // Burrower, get same immunities as FIRE_IMMUNITY_NONE
-			xeno.RegisterSignal(xeno, COMSIG_LIVING_PREIGNITION, TYPE_PROC_REF(/mob/living/carbon/xenomorph, preignition_no_ignition), TRUE)
-			xeno.RegisterSignal(xeno, list(COMSIG_LIVING_FLAMER_CROSSED, COMSIG_LIVING_FLAMER_FLAMED), TYPE_PROC_REF(/mob/living/carbon/xenomorph, flamer_cross_no_ignition), TRUE)
+			RegisterSignal(xeno, COMSIG_LIVING_PREIGNITION, TYPE_PROC_REF(/mob/living/carbon/xenomorph, preignition_no_ignition))
+			RegisterSignal(xeno, list(COMSIG_LIVING_FLAMER_CROSSED, COMSIG_LIVING_FLAMER_FLAMED), TYPE_PROC_REF(/mob/living/carbon/xenomorph, flamer_cross_no_ignition))
 
 /datum/hivebuff/fire/remove_buff_effects(mob/living/carbon/xenomorph/xeno)
 	xeno.refresh_fire_immunity() // Returns all affected Xenos back to whatever fire immunity is logged on the mob

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -677,7 +677,7 @@
 /mob/living/carbon/xenomorph/proc/add_fire_immunity_signals()
 	var/valid_immunity = fire_immunity
 	if(fire_immunity & FIRE_IMMUNITY_XENO_FRENZY)
-		valid_immunity -= FIRE_IMMUNITY_XENO_FRENZY
+		valid_immunity &= ~FIRE_IMMUNITY_XENO_FRENZY
 
 	switch(valid_immunity)
 		if(FIRE_IMMUNITY_NO_DAMAGE)


### PR DESCRIPTION
# About the pull request

The fire resistance rework was putting signals on the boon itself instead of the xenos, causing runtimes and the boon to be completely ineffective.
Besides that, the signals don't work additively (rav just went from no damage to no ignite) and so they've been marked as overrides and the xenos that start with no damage (rav, king) and no ignite (none, currently) are instead temporarily immune in the boon.

Unaddressed: Boilers get no benefit from the boon.

# Explain why it's good for the game

Makes fire resistance boon actually work.
Fixes #11485

# Testing Photographs and Procedure

Tested behavior without boon. Then with boon. Then after boon expired. Then with again. Using drone, queen, rav, burrower, boiler.

# Changelog

:cl:
fix: fix boon of fire resistance
/:cl:

