### PR TITLE
Fix: Cades stacking on top of each other.

### DIFF
--- a/code/game/objects/structures/barricade/barricade.dm
+++ b/code/game/objects/structures/barricade/barricade.dm
@@ -477,7 +477,7 @@
 		setDir(new_dir)
 		update_icon()
 	else
-		to_chat(usr, SPAN_WARNING("Every other facing direction is occupied, you can't rotate it!"))
+		to_chat(user, SPAN_WARNING("Every other facing direction is occupied, you can't rotate it!"))
 
 /obj/structure/barricade/proc/handle_barricade_stacking(potential_dir = FALSE)
 	var/list/directions = list()


### PR DESCRIPTION

# About the pull request
Resolves: #11333
Stops people from making cades stronger on one line. By stopping matching dirs.
There's probably a case I didn't think of. Lord knows what.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Balans, you shouldn't be able to strengthen your cades on the same tile and direction scaling with the amount of metal you might have on hand.
# Testing Photographs and Procedure
<details>
<summary>Testing Video Below</summary>

https://github.com/user-attachments/assets/a7637efe-59cb-41f9-98dc-5789cb928709

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MistChristmas
fix: Cades can no longer sit on top of each other.
/:cl:
