### PR TITLE
Updates helmet camera visuals

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -73,6 +73,8 @@
 
 	var/list/equip_slots = list()
 
+	var/atom/movable/screen/screentip/overwatch/overwatch_text
+
 
 /datum/hud/New(mob/owner)
 	mymob = owner
@@ -94,6 +96,9 @@
 	for(var/mytype in subtypesof(/atom/movable/plane_master_controller))
 		var/atom/movable/plane_master_controller/controller_instance = new mytype(null,src)
 		plane_master_controllers[controller_instance.name] = controller_instance
+
+	overwatch_text = new(null, src)
+	static_inventory += overwatch_text
 
 /datum/hud/Destroy()
 	if(mymob.hud_used == src)
@@ -164,6 +169,8 @@
 
 	QDEL_LIST_ASSOC_VAL(plane_masters)
 	QDEL_LIST_ASSOC_VAL(plane_master_controllers)
+
+	QDEL_NULL(overwatch_text)
 
 	return ..()
 

--- a/code/_onclick/hud/screentip.dm
+++ b/code/_onclick/hud/screentip.dm
@@ -1,0 +1,12 @@
+/atom/movable/screen/screentip
+	icon = null
+	icon_state = null
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	screen_loc = "TOP,LEFT"
+	maptext_height = 480
+	maptext_width = 480
+	maptext = ""
+
+/atom/movable/screen/screentip/overwatch
+	maptext_x = 8
+	maptext_y = -45

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -248,6 +248,7 @@
 #include "code\_onclick\hud\radial_persistent.dm"
 #include "code\_onclick\hud\screen_object_holder.dm"
 #include "code\_onclick\hud\screen_objects.dm"
+#include "code\_onclick\hud\screentip.dm"
 #include "code\_onclick\hud\yautja.dm"
 #include "code\_onclick\hud\rendering\plane_master.dm"
 #include "code\_onclick\hud\rendering\plane_master_controller.dm"


### PR DESCRIPTION

# About the pull request

Adds a blue-ish filter to helmet cameras (Same effect as on the minimap)
Adds a slight hue filter too, making colors less vibrant.
See screenshot for visuals

Also adds on-screen text to show marine name, location, job and status.

# Explain why it's good for the game

More immersive is good!
Easier to tell when you're watching someone on a camera.
See screenshots for visuals

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="1036" height="1022" alt="image" src="https://github.com/user-attachments/assets/df5741b6-8057-4a21-b38a-914e75b48216" />
Unconscious marine

<img width="1150" height="841" alt="image" src="https://github.com/user-attachments/assets/424933f7-b9ad-45c0-aaee-7e6a8eaec832" />


<img width="934" height="862" alt="image" src="https://github.com/user-attachments/assets/7b299588-7da1-48f1-b4de-c084c3442280" />
Some fire, for fun

<img width="1200" height="700" alt="image" src="https://github.com/user-attachments/assets/bf4d1c69-80b3-430b-9643-4cd2cac0e26f" />
Poor dead guy

</details>


# Changelog
:cl:
add: Adds onscreen text for helmet cameras.
add: Adds some screen-like filters to helmet cameras, for extra immersion.
/:cl:
