### PR TITLE
Implements Balloonnotices for CAS warnings

### DIFF
--- a/code/game/cas_manager/datums/cas_fire_envelope.dm
+++ b/code/game/cas_manager/datums/cas_fire_envelope.dm
@@ -265,21 +265,21 @@
 					SPAN_HIGHDANGER("YOU HEAR SOMETHING FLYING CLOSER TO YOU!") , SHOW_MESSAGE_AUDIBLE \
 				)
 				//onscreen alert outside of chat
-				mob.balloon_alert(mob, "YOU HEAR THE [ds_identifier] ROAR AS IT PREPARES TO [fm_identifier] NEAR YOU!", text_color = "#ff1e00ad")
+				mob.balloon_alert(mob, " YOU HEAR THE [ds_identifier] ROAR AS IT PREPARES TO [fm_identifier] NEAR YOU!", text_color = "#ff1e00ad")
 			if(2)
 				mob.show_message( \
 					SPAN_HIGHDANGER("A [ds_identifier] FLIES [SPAN_UNDERLINE(relative_dir ? uppertext(("TO YOUR " + dir2text(relative_dir))) : uppertext("right above you"))]!"), SHOW_MESSAGE_VISIBLE, \
 					SPAN_HIGHDANGER("YOU HEAR SOMETHING GO [SPAN_UNDERLINE(relative_dir ? uppertext(("TO YOUR " + dir2text(relative_dir))) : uppertext("right above you"))]!"), SHOW_MESSAGE_AUDIBLE \
 				)
 
-				mob.balloon_alert(mob, "A [ds_identifier] FLIES [SPAN_UNDERLINE(relative_dir ? uppertext(("TO YOUR " + dir2text(relative_dir))) : uppertext("right above you"))]!", text_color = "#ff1e00ad")
+				mob.balloon_alert(mob, " A [ds_identifier] FLIES [SPAN_UNDERLINE(relative_dir ? uppertext(("TO YOUR " + dir2text(relative_dir))) : uppertext("right above you"))]!", text_color = "#ff1e00ad")
 			if(3)
 				mob.show_message( \
 					SPAN_HIGHDANGER("A [ds_identifier] FLIES [SPAN_UNDERLINE(relative_dir ? uppertext(("TO YOUR " + dir2text(relative_dir))) : uppertext("right above you"))]!"), SHOW_MESSAGE_VISIBLE, \
 					SPAN_HIGHDANGER("YOU HEAR SOMETHING GO [SPAN_UNDERLINE(relative_dir ? uppertext(("TO YOUR " + dir2text(relative_dir))) : uppertext("right above you"))]!"), SHOW_MESSAGE_AUDIBLE \
 				)
 
-				mob.balloon_alert(mob, "A [ds_identifier] FLIES [SPAN_UNDERLINE(relative_dir ? uppertext(("TO YOUR " + dir2text(relative_dir))) : uppertext("right above you"))]!", text_color = "#ff1e00ad")
+				mob.balloon_alert(mob, " A [ds_identifier] FLIES [(relative_dir ? uppertext(("TO YOUR " + dir2text(relative_dir))) : uppertext("right above you"))]!", text_color = "#ff1e00ad")
 
 
 /// Step 5: Actually executes the fire mission updating stat to FIRE_MISSION_STATE_FIRING and then FIRE_MISSION_STATE_OFF_TARGET

--- a/code/modules/cm_marines/equipment/mortar/mortars.dm
+++ b/code/modules/cm_marines/equipment/mortar/mortars.dm
@@ -522,7 +522,7 @@
 			SPAN_DANGER("YOU HEAR SOMETHING COMING DOWN [SPAN_UNDERLINE(relative_dir ? uppertext(("TO YOUR " + dir2text(relative_dir))) : uppertext("right above you"))]!"), SHOW_MESSAGE_AUDIBLE \
 		)
 		//onscreen alert outside of chat
-		mob.balloon_alert(mob, "A SHELL IS ABOUT TO IMPACT [SPAN_UNDERLINE(relative_dir ? uppertext(("TO YOUR " + dir2text(relative_dir))) : uppertext("right above you"))]!", text_color = "#ff1100ad")
+		mob.balloon_alert(mob, " A SHELL IS ABOUT TO IMPACT [(relative_dir ? uppertext(("TO YOUR " + dir2text(relative_dir))) : uppertext("right above you"))]!", text_color = "#ff1100ad")
 
 	sleep(2.5 SECONDS) // Sleep a bit to give a message
 	for(var/mob/mob in range(10, target))
@@ -535,7 +535,7 @@
 			SPAN_HIGHDANGER("YOU HEAR SOMETHING VERY CLOSE COMING DOWN [SPAN_UNDERLINE(relative_dir ? uppertext(("TO YOUR " + dir2text(relative_dir))) : uppertext("right above you"))]!"), SHOW_MESSAGE_AUDIBLE \
 		)
 		//onscreen alert outside of chat
-		mob.balloon_alert(mob, "A SHELL IS ABOUT TO IMPACT [SPAN_UNDERLINE(relative_dir ? uppertext(("TO YOUR " + dir2text(relative_dir))) : uppertext("right above you"))]!", text_color = "#ff1100ad")
+		mob.balloon_alert(mob, " A SHELL IS ABOUT TO IMPACT [(relative_dir ? uppertext(("TO YOUR " + dir2text(relative_dir))) : uppertext("right above you"))]!", text_color = "#ff1100ad")
 
 	if(MODE_HAS_MODIFIER(/datum/gamemode_modifier/mortar_laser_warning))
 		new /obj/effect/overlay/temp/blinking_laser(target)

--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -405,7 +405,7 @@ GLOBAL_LIST_EMPTY(orbital_cannon_cancellation)
 			SPAN_HIGHDANGER("You hear a very loud sound coming from above to the [SPAN_UNDERLINE(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!"), SHOW_MESSAGE_AUDIBLE \
 		)
 		//onscreen alert outside of chat
-		M.balloon_alert(M, "The sky erupts into flames [SPAN_UNDERLINE(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!", text_color = "#ff1100ad")
+		M.balloon_alert(M, " The sky erupts into flames [(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!", text_color = "#ff1100ad")
 	sleep(OB_TRAVEL_TIMING/3)
 
 	for(var/mob/M in long_range(25, target))
@@ -418,7 +418,7 @@ GLOBAL_LIST_EMPTY(orbital_cannon_cancellation)
 			SPAN_HIGHDANGER("The sound becomes louder [SPAN_UNDERLINE(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!"), SHOW_MESSAGE_AUDIBLE \
 		)
 
-		M.balloon_alert(M, "The sky roars louder [SPAN_UNDERLINE(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!", text_color = "#ff1100ad")
+		M.balloon_alert(M, " The sky roars louder [(relative_dir ? ("to the " + dir2text(relative_dir)) : "right above you")]!", text_color = "#ff1100ad")
 	sleep(OB_TRAVEL_TIMING/3)
 
 	for(var/mob/M in long_range(15, target))
@@ -429,14 +429,14 @@ GLOBAL_LIST_EMPTY(orbital_cannon_cancellation)
 				SPAN_HIGHDANGER("OUR SKY IS BOOMING!!!"), SHOW_MESSAGE_VISIBLE, \
 				SPAN_HIGHDANGER("YOU SHOULDN'T BE HERE!"), SHOW_MESSAGE_AUDIBLE \
 			)
-			M.balloon_alert(M, "OUR SKY IS BOOMING!!!", text_color = "#ff1100ad")
+			M.balloon_alert(M, " OUR SKY IS BOOMING!!!", text_color = "#ff1100ad")
 
 		else
 			M.show_message( \
 				SPAN_HIGHDANGER("OH GOD THE SKY WILL EXPLODE!!!"), SHOW_MESSAGE_VISIBLE, \
 				SPAN_HIGHDANGER("YOU SHOULDN'T BE HERE!"), SHOW_MESSAGE_AUDIBLE \
 			)
-			M.balloon_alert(M, "OH GOD THE SKY WILL EXPLODE!!!", text_color = "#ff1100ad")
+			M.balloon_alert(M, " OH GOD THE SKY WILL EXPLODE!!!", text_color = "#ff1100ad")
 
 
 	sleep(OB_TRAVEL_TIMING/3)


### PR DESCRIPTION

# About the pull request

Adds **balloonnotices** to CAS warnings, making them visible in the middle of the viewport during gameplay, and not just inside the chat/eventlog.

# Explain why it's good for the game

Makes CAS more visible for both sides and makes it far less likely you're caught off guard by something loud and obvious. Massive QOL for new players, and makes CAS more reactable in chaotic situations. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/user-attachments/assets/d264a3c9-9674-42b8-9401-59687e06f55e

</details>




# Changelog
:cl:
qol: added onscreen visual warnings to CAS/OB/Mortar events. 
/:cl:
