### PR TITLE
Removes aimed shot from PMC sniper spec

### DIFF
--- a/code/datums/emergency_calls/pmc.dm
+++ b/code/datums/emergency_calls/pmc.dm
@@ -11,7 +11,7 @@
 
 	max_smartgunners = 1
 	max_medics = 2
-	max_heavies = 0
+	max_heavies = 1
 	var/max_synths = 1
 	var/synths = 0
 

--- a/code/modules/projectiles/guns/specialist/sniper.dm
+++ b/code/modules/projectiles/guns/specialist/sniper.dm
@@ -494,6 +494,7 @@
 	sniper_beam_type = /obj/effect/ebeam/laser/intense
 	sniper_beam_icon = "laser_beam_intense"
 	sniper_lockon_icon = "sniper_lockon_intense"
+	has_aimed_shot = FALSE
 
 /obj/item/weapon/gun/rifle/sniper/elite/Initialize()
 	. = ..()


### PR DESCRIPTION
# About the pull request

Removes aimed shot from PMC sniper spec

# Explain why it's good for the game

A sniper spec with with wallhack that can two tap every xeno from complete safety is not really good for the game, even if it's hijack. For what it worth, PMC ERT will still be the strongest ERT even after this change. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: ihatethisengine
balance: removed aimed shot from PMC sniper spec
/:cl:
