### PR TITLE
UI: Clean up the Copy button for Range Finders.

### DIFF
--- a/tgui/packages/tgui/interfaces/Binoculars.tsx
+++ b/tgui/packages/tgui/interfaces/Binoculars.tsx
@@ -4,19 +4,6 @@ import { Window } from 'tgui/layouts';
 
 type Data = { xcoord: number; ycoord: number; zcoord: number };
 
-const copyToClipboard = (text) => {
-  const textArea = document.createElement('textarea');
-  textArea.value = text;
-  document.body.appendChild(textArea);
-  textArea.select();
-  try {
-    document.execCommand('copy');
-  } catch (err) {
-    console.error('Failed to copy text', err);
-  }
-  document.body.removeChild(textArea);
-};
-
 export const Binoculars = () => {
   const { data } = useBackend<Data>();
 
@@ -28,9 +15,9 @@ export const Binoculars = () => {
 
   return (
     <Window width={450} height={300}>
-      {' '}
       <Window.Content scrollable>
         <Section
+          fill
           title="SIMPLIFIED COORDINATES OF TARGET"
           textAlign="center"
           fontSize="15px"
@@ -38,15 +25,16 @@ export const Binoculars = () => {
           <Box fontSize="30px" mb={2}>
             LONGITUDE : {x_coord}, LATITUDE : {y_coord}, HEIGHT : {z_coord}
           </Box>
-          <Box textAlign="center">
-            <Button
-              icon="clipboard"
-              content="Copy Coordinates"
-              tooltip="Copies 'X,Y,Z' to clipboard"
-              fontSize="18px"
-              onClick={() => copyToClipboard(coordinatesString)}
-            />
-          </Box>
+          <Button
+            align="center"
+            minWidth="70%"
+            icon="clipboard"
+            tooltip="Copies recorded coordinates to clipboard"
+            fontSize="20px"
+            onClick={() => navigator.clipboard.writeText(coordinatesString)}
+          >
+            Copy Coordinates
+          </Button>
         </Section>
       </Window.Content>
     </Window>


### PR DESCRIPTION

# About the pull request
Use non-deprecated means to do the same thing. 
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Fixes me being dumb
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MistChristmas
code: Clean up deprecated usage. Simplify copying to clipboard.
ui: Makes the copy button text slightly bigger. And scales to width.
/:cl:
