### PR TITLE
Easier Research Botany Option: Directed Mutation

### DIFF
--- a/code/__DEFINES/dcs/signals/atom/signals_obj.dm
+++ b/code/__DEFINES/dcs/signals/atom/signals_obj.dm
@@ -75,3 +75,6 @@
 // from /obj/item/device/binoculars/range/designator/acquire_target()
 #define COMSIG_DESIGNATOR_LASE "comsig_designator_lase"
 #define COMSIG_DESIGNATOR_LASE_OFF "comsig_designator_lase_off"
+
+// Directed Mutation Trigger Signal
+#define COMSIG_DIRECTED_MUTATION "comsig_directed_mutation"

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -72,7 +72,9 @@
 		"New Chems" = 0,
 		"New Chems2" = 0,
 		"New Chems3" = 0,
+		//Non Rolled Mutations If adding more need to adjust mutation code in seed_datums
 		"Mutate Species" = 0,
+		"Mutate Hydro Chem" = 0,
 		)
 
 

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -275,8 +275,7 @@
 		metabolism_adjust = 0
 		for(var/i in 1 to length(mutation_controller))
 			var/mut_name = mutation_controller[i]
-			if(mutation_controller[mut_name] > -3)
-				mutation_controller[mut_name] = 0
+			mutation_controller[mut_name] = 0
 
 	check_level_sanity()
 	update_icon()
@@ -301,8 +300,7 @@
 	metabolism_adjust = 0
 	for(var/i in 1 to length(mutation_controller))
 		var/mut_name = mutation_controller[i]
-		if(mutation_controller[mut_name] > -3)
-			mutation_controller[mut_name] = 0
+		mutation_controller[mut_name] = 0
 
 
 	to_chat(user, SPAN_NOTICE("You remove the dead plant from [src]."))
@@ -721,3 +719,19 @@
 
 /obj/structure/machinery/portable_atmospherics/hydroponics/yautja
 	icon_state = "yautja_tray"
+
+//If conditions satisfied add 1 or 2u of a hydro chem to the plant, then increases directed mutation value
+/obj/structure/machinery/portable_atmospherics/hydroponics/proc/handle_directed_mutation_sig(obj/structure/machinery/portable_atmospherics/hydroponics/processing_tray)
+	SIGNAL_HANDLER
+	if(!processing_tray.seed)
+		return
+	var/turf/source_turf = get_turf(processing_tray)
+	if ((processing_tray.seed.directed_mutation["Current Value"] < processing_tray.seed.directed_mutation["Max Value"]) && !processing_tray.seed.chems_special)
+		var/list/new_chem = list(pick( GLOB.chemical_gen_classes_list["H1"]) = list(rand(1,2)))
+		processing_tray.seed.directed_mutation["Current Value"] = processing_tray.seed.directed_mutation["Current Value"] + 1
+		if (processing_tray.seed.directed_mutation["Current Value"] == processing_tray.seed.directed_mutation["Max Value"])
+			source_turf.visible_message(SPAN_NOTICE("\The [processing_tray.seed.display_name] makes a crackling noise and looks brittle!"))
+		else
+			source_turf.visible_message(SPAN_NOTICE("\The [processing_tray.seed.display_name] makes a soft crackling noise."))
+		processing_tray.seed.chems += new_chem
+	UnregisterSignal(processing_tray, COMSIG_DIRECTED_MUTATION)

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -410,20 +410,11 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 											prob(25);pick(GLOB.chemical_gen_classes_list["C3"]),
 											prob(30);pick(GLOB.chemical_gen_classes_list["C4"]),
 											) = list(1,rand(1,2)))
-
-				//If conditions satisfied add 1 or 2u of a hydro chem to the plant, then increases directed mutation value
-				if (mutation_controller["Mutate Hydro Chem"] == -5 && (directed_mutation["Current Value"] < directed_mutation["Max Value"]) && !chems_special)
-					var/list/new_chem = list(pick( GLOB.chemical_gen_classes_list["H1"]) = list(rand(1,2)))
-					directed_mutation["Current Value"] = directed_mutation["Current Value"] + 1
-					if (directed_mutation["Current Value"] == directed_mutation["Max Value"])
-						source_turf.visible_message(SPAN_NOTICE("\The [display_name] makes a crackling noise and looks brittle!"))
-					else
-						source_turf.visible_message(SPAN_NOTICE("\The [display_name] makes a soft crackling noise."))
-					chem_to_add = new_chem
+				//Trigger Copper Sulfate adding hydrochems to non special plants
+				SEND_SIGNAL(processing_tray, COMSIG_DIRECTED_MUTATION, processing_tray)
 
 				if(prob(40) && chems_special)
 					chem_to_add = list(pick(chems_special) = list(7,rand(5,8)))
-				mutation_controller["Mutation Hydro Chem"] = 0
 				chems += chem_to_add
 
 	//reset mutation_controller for next cycle

--- a/code/modules/reagents/chemistry_reagents/toxin.dm
+++ b/code/modules/reagents/chemistry_reagents/toxin.dm
@@ -326,6 +326,14 @@
 	chemclass = CHEM_CLASS_RARE
 	properties = list(PROPERTY_CORROSIVE = 5)
 
+//Gives 1st point of directed mutation capacity
+/datum/reagent/toxin/copper_sulfate/reaction_hydro_tray_reagent(obj/structure/machinery/portable_atmospherics/hydroponics/processing_tray, volume)
+	. = ..()
+	if(!processing_tray.seed)
+		return
+	if (processing_tray.seed.directed_mutation["Max Value"] < 1)
+		processing_tray.seed.directed_mutation["Max Value"] = 1
+
 /datum/reagent/toxin/acid/polyacid
 	name = "Polytrinic acid"
 	id = "pacid"

--- a/code/modules/reagents/chemistry_reagents/toxin.dm
+++ b/code/modules/reagents/chemistry_reagents/toxin.dm
@@ -326,13 +326,14 @@
 	chemclass = CHEM_CLASS_RARE
 	properties = list(PROPERTY_CORROSIVE = 5)
 
-//Gives 1st point of directed mutation capacity
+//Gives 1st point of directed mutation capacity but also allows hydrochem mutation on chem mutation
 /datum/reagent/toxin/copper_sulfate/reaction_hydro_tray_reagent(obj/structure/machinery/portable_atmospherics/hydroponics/processing_tray, volume)
 	. = ..()
 	if(!processing_tray.seed)
 		return
-	if (processing_tray.seed.directed_mutation["Max Value"] < 1)
+	if (processing_tray.seed.directed_mutation["Max Value"] < 1 && processing_tray.seed.directed_mutation["Current Value"] < 1)
 		processing_tray.seed.directed_mutation["Max Value"] = 1
+		RegisterSignal(processing_tray, COMSIG_DIRECTED_MUTATION, TYPE_PROC_REF(/obj/structure/machinery/portable_atmospherics/hydroponics, handle_directed_mutation_sig))
 
 /datum/reagent/toxin/acid/polyacid
 	name = "Polytrinic acid"


### PR DESCRIPTION
# About the pull request

Adds Directed_mutation, allowing some controlled chem adding to plants. Copper Sulfate adds 1 to the max capacity of directed mutations for the seed, provided the prior max was 0. And gives a persistent mutation controller flag to the plant in tray

When a plant with the flag, no "chems_special", and is not at max directed mutation points has a chem add mutation it will add 1 or 2 u of a hydro chem to it and increase the directed mutation value by 1. This value is unaffected by plant potency. With non-exotic chems such as copper sulfate the max cap of directed mutation can't exceed 1.

Quietly adds backend for the discovery of randomized plant species that make hydro chems by adding a testing method. Hydro chem plant species can;t do the special add and will never generate the messages like "The display_name makes a crackling noise and looks brittle!". So it is a litmus test for hydro chem plants

# Explain why it's good for the game

Easier option for botany that is ultimately less efficient than the current route but fully viable and practical.

Not all players were ss13 botanists before playing cm13. This creates is rift in current botany because it requires familiarity with the ss13 botany system. This PR intends to give two routes for the researcher botanist, the existing method of farming specific plants, and an easier route that fully resembles old research botany.

Just like olde times you can plant a monocrop of corn or wheat, so long as it isnt a hydro chem plant, treat them all with copper sulfate, and mutate. If you see the chat message "The display_name makes a crackling noise and looks brittle!" 1 or 2u of a hydro chem will be found in the fruits. Make the plant repeat harvest and add 60u+ of fertilizer you should get atleast 30u rapidly by grinding the many fruits.

If 2u possibility is to generous we can tone it down to only 1u add.

# Testing Photographs and Procedure

Visible chat message occurs when the chem add occurs making testing easy.
Only affects non hydro chem plants. Once a plant is directed mutated it is not directed mutated again. Only 1u or 2u of a single hydro chem was found in any tested plant. Potency did not affect it. Plants still mutated new chemicals after treatment. Directed mutation and mutation controller flag properly added and cleared

# Changelog

:cl:
add: Directed Mutation system
add: Copper Sulfate gives plants 1 max capacity to directed mutation, and mutation controller flag. Next chem add mutation will add 1 or 2u of a hydro chem and increase counter by 1.
/:cl:
CKEY: paperbirch
