### PR TITLE
Standardize admin log getters

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -81,9 +81,12 @@ GLOBAL_LIST_INIT(admin_verbs_default, list(
 GLOBAL_LIST_INIT(admin_verbs_admin, list(
 	/datum/admins/proc/togglejoin, /*toggles whether people can join the current game*/
 	/datum/admins/proc/announce, /*priority announce something to all clients.*/
+	/datum/admins/proc/getserverlog, /*allows us to fetch any server logs (diary) for other days*/
 	/datum/admins/proc/view_game_log, /*shows the server game log (diary) for this round*/
 	/datum/admins/proc/view_attack_log, /*shows the server attack log for this round*/
-	/client/proc/giveruntimelog, /*allows us to give access to all runtime logs to somebody*/
+	/datum/admins/proc/view_runtime_log, /*shows the server runtime log for this round*/
+	/datum/admins/proc/view_href_log, /*shows the server HREF log for this round*/
+	/datum/admins/proc/view_tgui_log, /*shows the server TGUI log for this round*/
 	/client/proc/cmd_admin_delete, /*delete an instance/object/mob/etc*/
 	/client/proc/toggleprayers, /*toggles prayers on/off*/
 	/client/proc/toggle_hear_radio, /*toggles whether we hear the radio*/
@@ -211,9 +214,9 @@ GLOBAL_LIST_INIT(admin_verbs_debug, list(
 	/client/proc/enter_tree,
 	/client/proc/set_tree_points,
 	/client/proc/purge_data_tab,
-	/client/proc/getserverlog, /*allows us to fetch any server logs (diary) for other days*/
-	/client/proc/getruntimelog,  /*allows us to access any runtime logs (can be granted by giveruntimelog)*/
+	/datum/admins/proc/getserverlog, /*allows us to fetch any server logs (diary) for other days*/
 	/datum/admins/proc/view_game_log, /*shows the server game log (diary) for this round*/
+	/datum/admins/proc/view_attack_log, /*shows the server attack log for this round*/
 	/datum/admins/proc/view_runtime_log, /*shows the server runtime log for this round*/
 	/datum/admins/proc/view_href_log, /*shows the server HREF log for this round*/
 	/datum/admins/proc/view_tgui_log, /*shows the server TGUI log for this round*/

--- a/code/modules/admin/verbs/getlogs.dm
+++ b/code/modules/admin/verbs/getlogs.dm
@@ -1,5 +1,5 @@
 /*
-	HOW DO I LOG RUNTIMES?
+	HOW DO I LOG DREAM DAEMON RUNTIMES?
 	Firstly, start dreamdeamon if it isn't already running. Then select "world>Log Session" (or press the F3 key)
 	navigate the popup window to the data/logs/runtime/ folder from where your tgstation .dmb is located.
 	(you may have to make this folder yourself)
@@ -8,79 +8,32 @@
 				start a world. Just remember to repeat these steps with a new name when you update to a new revision!
 
 	Save it with the name of the revision your server uses (e.g. r3459.txt).
-	Game Masters will now be able to grant access any runtime logs you have archived this way!
-	This will allow us to gather information on bugs across multiple servers and make maintaining the TG
-	codebase for the entire /TG/station commuity a TONNE easier :3 Thanks for your help!
 */
 
-//This proc allows Game Masters to grant a client access to the .getruntimelog verb
-//Permissions expire at the end of each round.
-//Runtimes can be used to meta or spot game-crashing exploits so it's advised to only grant coders that
-//you trust access. Also, it may be wise to ensure that they are not going to play in the current round.
-/client/proc/giveruntimelog()
-	set name = ".giveruntimelog"
-	set desc = "Give somebody access to any session logfiles saved to the /log/runtime/ folder."
-	set category = null
-
-	if(!src.admin_holder || !(admin_holder.rights & R_MOD) || !(admin_holder.rights & R_DEBUG))
-		to_chat(src, "<font color='red'>Access denied.</font>")
-		return
-
-	var/client/target = tgui_input_list(src,"Choose somebody to grant access to the server's runtime logs (permissions expire at the end of each round):","Grant Permissions", GLOB.clients)
-	if(!istype(target, /client))
-		to_chat(src, "<font color='red'>Error: giveruntimelog(): Client not found.</font>")
-		return
-
-	message_admins("[key_name_admin(src)] granted [key_name_admin(target)] access to runtime logs this round.")
-	target.verbs |= /client/proc/getruntimelog
-	to_chat(target, "<font color='red'>You have been granted access to runtime logs. Please use them responsibly or risk being banned.</font>")
-
-//This proc allows download of runtime logs saved within the data/logs/ folder by dreamdeamon.
-//It works similarly to show-server-log.
-/client/proc/getruntimelog()
-	set name = ".getruntimelog"
-	set desc = "Pick a logfile from data/logs/runtime to view."
-	set category = null
-
-	var/path = browse_files("data/logs/runtime/")
-	if(!path)
-		return
-
-	if(file_spam_check())
-		return
-
-	message_admins("[key_name_admin(src)] accessed file: [path]")
-	to_chat(src, "Attempting to send file, this may take a fair few minutes if the file is very large.")
-	src << ftp(file(path))
-
-//This proc allows download of past server logs saved within the data/logs/ folder.
-//It works similarly to show-server-log.
-/client/proc/getserverlog()
+/// This proc allows download of past server logs saved within the data/logs/ folder.
+/datum/admins/proc/getserverlog()
 	set name = ".getserverlog"
 	set desc = "Pick a logfile from data/logs to view."
 	set category = null
 
-	if(!src.admin_holder || !(admin_holder.rights & (R_MOD) || !(admin_holder.rights & R_DEBUG)))
-		to_chat(src, "<font color='red'>Access denied.</font>")
+	if(!check_rights(R_MOD|R_DEBUG))
 		return
 
-	var/path = browse_files("data/logs/")
+	var/path = usr.client.browse_files("data/logs/")
 	if(!path)
 		return
 
-	if(file_spam_check())
+	if(usr.client.file_spam_check())
 		return
 
 	message_admins("[key_name_admin(src)] accessed file: [path]")
 	to_chat(src, "Attempting to send file, this may take a fair few minutes if the file is very large.")
 	src << ftp(file(path))
 
-//Other log stuff put here for the sake of organisation
-
-/**Shows this round's server log*/
+/// Shows this round's game log
 /datum/admins/proc/view_game_log()
 	set name = "Show Server Game Log"
-	set desc = "Shows this round's server game log."
+	set desc = "Shows this round's game log."
 	set category = "Server"
 
 	if(!check_rights(R_MOD|R_DEBUG))
@@ -98,13 +51,13 @@
 	to_chat(src, "Attempting to send file, this may take a fair few minutes if the file is very large.")
 	src << ftp(file(path))
 
-/**Shows this round's attack log*/
+/// Shows this round's attack log
 /datum/admins/proc/view_attack_log()
 	set name = "Show Server Attack Log"
-	set desc = "Shows this round's server attack log."
+	set desc = "Shows this round's attack log."
 	set category = "Server"
 
-	if(!check_rights(R_MOD))
+	if(!check_rights(R_MOD|R_DEBUG))
 		return
 
 	var/path = GLOB.world_attack_log
@@ -119,13 +72,13 @@
 	to_chat(src, "Attempting to send file, this may take a fair few minutes if the file is very large.")
 	src << ftp(file(path))
 
-/**Shows this round's runtime log*/
+/// Shows this round's runtime log
 /datum/admins/proc/view_runtime_log()
 	set name = "Show Server Runtime Log"
-	set desc = "Shows this round's server runtime log."
+	set desc = "Shows this round's runtime log."
 	set category = "Server"
 
-	if(!check_rights(R_DEBUG))
+	if(!check_rights(R_MOD|R_DEBUG))
 		return
 
 	var/path = GLOB.world_runtime_log
@@ -140,13 +93,13 @@
 	to_chat(src, "Attempting to send file, this may take a fair few minutes if the file is very large.")
 	src << ftp(file(path))
 
-/**Shows this round's href log*/
+/// Shows this round's href log
 /datum/admins/proc/view_href_log()
 	set name = "Show Server HREF Log"
-	set desc = "Shows this round's server HREF log."
+	set desc = "Shows this round's HREF log."
 	set category = "Server"
 
-	if(!check_rights(R_DEBUG))
+	if(!check_rights(R_MOD|R_DEBUG))
 		return
 
 	var/path = GLOB.world_href_log
@@ -161,13 +114,13 @@
 	to_chat(src, "Attempting to send file, this may take a fair few minutes if the file is very large.")
 	src << ftp(file(path))
 
-/**Shows this round's tgui log*/
+/// Shows this round's tgui log
 /datum/admins/proc/view_tgui_log()
 	set name = "Show Server TGUI Log"
-	set desc = "Shows this round's server TGUI log."
+	set desc = "Shows this round's TGUI log."
 	set category = "Server"
 
-	if(!check_rights(R_DEBUG))
+	if(!check_rights(R_MOD|R_DEBUG))
 		return
 
 	var/path = GLOB.tgui_log


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #3289 standardizing it some more:
- Admins get access to all log getter verbs
- Logic in all verbs is standardized (namely in that `if(!check_rights(R_MOD|R_DEBUG))` checks MOD *or* DEBUG rather than before where it was kinda random
- This means admins get access to more log getter verbs than they used to, but all staff already can access raw logs (technically it ought to be given to Moderators too but leme know if you want them to have more verbs overwhelming them)
- Removed getruntimelog and giveruntimelog since they are for access to a folder we don't use anymore

# Explain why it's good for the game
Admins can do admin things better.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="325" height="333" alt="image" src="https://github.com/user-attachments/assets/9a453273-8425-4363-8729-18ee7d6ead1f" />

</details>


# Changelog
:cl:
admin: Admins get more access to log getter verbs
del: Removed getruntimelog and giveruntimelog since they aren't really applicable to how TGS logs dream daemon logs
/:cl:
