### PR TITLE
Fix hydrotrays ignoring bullet damage

### DIFF
--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -101,10 +101,17 @@
 
 	bullet_ping(Proj)
 	if(Proj.damage)
-		take_damage(Proj.damage, Proj.firer)
+		take_damage(Proj.damage)
 		return TRUE
 
 	..()
+
+/obj/structure/machinery/portable_atmospherics/hydroponics/proc/take_damage(damage)
+	health -= damage
+	if(health <= 0)
+		visible_message(SPAN_WARNING("[src] crumbles into pieces!"))
+		playsound(src, 'sound/effects/meteorimpact.ogg', 25, 1)
+		qdel(src)
 
 /obj/structure/machinery/portable_atmospherics/hydroponics/process()
 


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Hydrotrays were immune to bullet damage for some strange reason. This fixes that, so you can shoot them out of the way like most other objects. 

# Explain why it's good for the game
Being blocked by hydrotrays is annoying. Most objects you can simply shoot your way to destruction. This shouldn't be special.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
<img width="1920" height="1080" alt="dreamseeker_iihw4Vzkzs" src="https://github.com/user-attachments/assets/b7d6a488-0436-46eb-b56c-83bbb7ac1c67" />
:cl:
fix: Fix hydrotrays ignoring bullet damage
/:cl:
