### PR TITLE
Fix: Adds missing faction HUDs to Anchorpoint marines, miscellaneous CMB fixes

### DIFF
--- a/code/datums/factions/cmb.dm
+++ b/code/datums/factions/cmb.dm
@@ -51,9 +51,6 @@
 		if(JOB_SQUAD_SMARTGUN)
 			hud_icon_state = "gun"
 			anchorpoint_marine = TRUE
-		if(JOB_SQUAD_LEADER)
-			hud_icon_state = "leader"
-			anchorpoint_marine = TRUE
 
 	if(anchorpoint_marine)
 		var/image/IMG = image('icons/mob/hud/factions/marine.dmi', H, "hudsquad")

--- a/code/datums/factions/cmb.dm
+++ b/code/datums/factions/cmb.dm
@@ -8,6 +8,7 @@
 	var/hud_icon_state
 	var/obj/item/card/id/ID = H.get_idcard()
 	var/_role
+	var/anchorpoint_marine
 	if(H.mind)
 		_role = H.job
 	else if(ID)
@@ -33,5 +34,33 @@
 			hud_icon_state = "mar"
 		if(JOB_CMB_SWAT)
 			hud_icon_state = "spec"
+
+	//Anchorpoint Marines
+		if(JOB_SQUAD_MARINE)
+			hud_icon_state = "grunt"
+			anchorpoint_marine = TRUE
+		if(JOB_SQUAD_ENGI)
+			hud_icon_state = "engi"
+			anchorpoint_marine = TRUE
+		if(JOB_SQUAD_TEAM_LEADER)
+			hud_icon_state = "tl"
+			anchorpoint_marine = TRUE
+		if(JOB_SQUAD_MEDIC)
+			hud_icon_state = "med"
+			anchorpoint_marine = TRUE
+		if(JOB_SQUAD_SMARTGUN)
+			hud_icon_state = "gun"
+			anchorpoint_marine = TRUE
+		if(JOB_SQUAD_LEADER)
+			hud_icon_state = "leader"
+			anchorpoint_marine = TRUE
+
+	if(anchorpoint_marine)
+		var/image/IMG = image('icons/mob/hud/factions/marine.dmi', H, "hudsquad")
+		IMG.color = "#194877"
+		holder.overlays += IMG
+		holder.overlays += image('icons/mob/hud/factions/marine.dmi', H, "hudsquad_[hud_icon_state]")
+		return
+
 	if(hud_icon_state)
 		holder.overlays += image(override_icon_file ? override_icon_file : base_icon_file, H, "cmb_[hud_icon_state]")

--- a/code/modules/gear_presets/cmb.dm
+++ b/code/modules/gear_presets/cmb.dm
@@ -194,6 +194,8 @@
 
 /datum/equipment_preset/cmb/leader/riot
 	name = "CMB - The Colonial Marshal Riot Control"
+	role_comm_title = "CMB MAR RC"
+	assignment = "CMB Riot Control Marshal"
 
 /datum/equipment_preset/cmb/leader/riot/load_gear(mob/living/carbon/human/new_human)
 	//clothes
@@ -522,7 +524,7 @@
 	name = "CMB - Colonial Marshal Investigative Synthetic"
 	paygrades = list(PAY_SHORT_CMBS = JOB_PLAYTIME_TIER_0)
 	idtype = /obj/item/card/id/deputy
-	role_comm_title = "CMB Syn"
+	role_comm_title = "CMB Inv. Syn"
 	flags = EQUIPMENT_PRESET_EXTRA
 
 	minimap_icon = "cmb_syn"
@@ -624,8 +626,8 @@
 /datum/equipment_preset/cmb/synth/riot
 	name = "CMB - Colonial Marshal Riot Control Synthetic"
 	paygrades = list(PAY_SHORT_CMBRS = JOB_PLAYTIME_TIER_0)
-
-	minimap_icon = "pmc_syn"
+	role_comm_title = "CMB RC Syn"
+	minimap_icon = "pmc_syn" //actually not PMC, it just has the same color palette as CMB
 
 	assignment = "CMB Riot Control Synthetic"
 	job_title = JOB_CMB_RSYN

--- a/code/modules/gear_presets/survivors/fiorina_sciannex/riot_in_progress_insert_fiorina_nightmare.dm
+++ b/code/modules/gear_presets/survivors/fiorina_sciannex/riot_in_progress_insert_fiorina_nightmare.dm
@@ -24,7 +24,8 @@
 	idtype = /obj/item/card/id/deputy/riot
 	job_title = JOB_CMB_RIOT
 	skills = /datum/skills/cmb
-	minimap_icon = "deputy"
+	minimap_icon = "mp"
+	minimap_background = "background_cmb"
 
 /datum/equipment_preset/survivor/cmb/riot/load_gear(mob/living/carbon/human/new_human)
 
@@ -90,7 +91,7 @@
 /datum/equipment_preset/synth/survivor/cmb/riotsynth
 	name = "Survivor - Synthetic - CMB Riot Control Synthetic"
 	paygrades = list(PAY_SHORT_CMBRS = JOB_PLAYTIME_TIER_0)
-	role_comm_title = "CMB Syn"
+	role_comm_title = "CMB RC Syn"
 	faction = FACTION_MARSHAL
 	faction_group = list(FACTION_MARSHAL, FACTION_MARINE, FACTION_SURVIVOR)
 	flags = EQUIPMENT_PRESET_EXTRA
@@ -99,7 +100,7 @@
 	languages = ALL_SYNTH_LANGUAGES
 	idtype = /obj/item/card/id/deputy/riot
 	skills = /datum/skills/synthetic/cmb
-	minimap_icon = "cmb_syn"
+	minimap_icon = "pmc_syn"
 	minimap_background = "background_cmb"
 
 /datum/equipment_preset/synth/survivor/cmb/riotsynth/load_race(mob/living/carbon/human/new_human)

--- a/code/modules/gear_presets/survivors/kutjevo/preset_kutjevo.dm
+++ b/code/modules/gear_presets/survivors/kutjevo/preset_kutjevo.dm
@@ -187,7 +187,7 @@
 	assignment = JOB_CMB_SYN
 	job_title = JOB_CMB_SYN
 	minimap_background = "background_cmb"
-	minimap_icon = "cmb_syn"
+	minimap_icon = "pmc_syn"
 
 	paygrades = list(PAY_SHORT_CMBS = JOB_PLAYTIME_TIER_0)
 	faction = FACTION_MARSHAL

--- a/code/modules/gear_presets/synths.dm
+++ b/code/modules/gear_presets/synths.dm
@@ -546,7 +546,7 @@
 /datum/equipment_preset/synth/survivor/cmb_synth
 	name = "Survivor - Synthetic - CMB Investigative Synthetic"
 	idtype = /obj/item/card/id/deputy
-	role_comm_title = "CMB Syn"
+	role_comm_title = "CMB Inv. Syn"
 	assignment = JOB_CMB_SYN
 	job_title = JOB_CMB_SYN
 	paygrades = list(PAY_SHORT_CMBS = JOB_PLAYTIME_TIER_0)


### PR DESCRIPTION
Part 1 of atomizing #11382

# About the pull request
1. Adds faction HUDs to Anchorpoint Station marines. 
2. Differentiates CMB Marshals vs CMB Riot Marshals; and Investigative Synths vs Riot Control Synths in role comms, including survivor variants. 
3. Adds minimap_backgrounds and applies the correct minimap icons for the Survivor CMB synths.

# Explain why it's good for the game

1. The Anchorpoint Station faction file had code to establish HUD icon state names, but not code to make the icons actually _appear._ Fixed.
2. Lore, I guess. They have different preset names, so I presume they could have differing assignments and role comm titles?
3. Investigative Synths are supposed to have a magnifying glass as their icons (cmb_syn) while riot control synths should have the regular synth (pmc_synth) icon. They have been properly applied, if they have been swapped. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/cc38d59d-35b9-4d3a-9da6-9e21c5939a02" />

</details>


# Changelog
:cl: Puckaboo2
fix: Anchorpoint Station marines have their minimap faction icons. 
fix: Missing minimap icons, minimap backgrounds, and role comm titles have been applied to all CMB personnel. 
fix: CMB Riot Control synths should have the correct minimap icons vs the CMB Investigation synths. 
/:cl:
