### PR TITLE
big xenos can no longer be buckled into office chairs

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -245,10 +245,7 @@
 /obj/structure/bed/roller/proc/check_buckle(obj/bed, mob/buckle_target, mob/user)
 	SIGNAL_HANDLER
 
-	if(buckle_target.mob_size <= MOB_SIZE_XENO)
-		return
-
-	if(buckle_target.mob_size > MOB_SIZE_HUMAN)
+	if(buckle_target.mob_size > MOB_SIZE_XENO)
 		if(!can_carry_big)
 			to_chat(user, SPAN_WARNING("[buckle_target] is too big to buckle in."))
 			return COMPONENT_BLOCK_BUCKLE

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -354,10 +354,7 @@
 /obj/structure/bed/chair/office/proc/check_buckle(obj/bed, mob/buckle_target, mob/user)
 	SIGNAL_HANDLER
 
-	if(buckle_target.mob_size <= MOB_SIZE_XENO)
-		return
-
-	if(buckle_target.mob_size > MOB_SIZE_HUMAN)
+	if(buckle_target.mob_size > MOB_SIZE_XENO)
 		if(!can_carry_big)
 			to_chat(user, SPAN_WARNING("[buckle_target] is too big to buckle in."))
 			return COMPONENT_BLOCK_BUCKLE


### PR DESCRIPTION
# About the pull request

title

# Explain why it's good for the game

you shouldn't be able to bypass the restriction on rollerbeds by using an office chair


# Testing Photographs and Procedure

works


# Changelog

:cl:
fix: large xenos can no longer be buckled to office chairs
code: remove redundant line for the rollerbed
/:cl:

