### PR TITLE
Xenomorph on dropship alert now only occurs after landing

### DIFF
--- a/code/modules/shuttles/marine_ferry.dm
+++ b/code/modules/shuttles/marine_ferry.dm
@@ -221,16 +221,6 @@
 
 	sleep(warmup_time) //Warming up
 
-	if(!queen_locked)
-		for(var/turf/T in turfs_src)
-			var/mob/living/carbon/xenomorph/xeno = locate(/mob/living/carbon/xenomorph) in T
-			if((xeno && xeno.stat != DEAD) && !(FACTION_MARINE in xeno.iff_tag?.faction_groups))
-				var/name = "Unidentified Lifesigns"
-				var/input = "Unidentified lifesigns detected onboard. Recommendation: lockdown of exterior access ports, including ducting and ventilation."
-				shipwide_ai_announcement(input, name, 'sound/AI/unidentified_lifesigns.ogg', ares_logging = ARES_LOG_SECURITY)
-				set_security_level(SEC_LEVEL_RED)
-				break
-
 	moving_status = SHUTTLE_INTRANSIT
 
 	for(var/X in equipments)
@@ -293,6 +283,16 @@
 	turfs_trg = get_shuttle_turfs(T_trg, info_datums)
 
 	open_doors(turfs_trg) //And now open the doors
+
+	if(!queen_locked)
+		for(var/turf/T in turfs_src)
+			var/mob/living/carbon/xenomorph/xeno = locate(/mob/living/carbon/xenomorph) in T
+			if((xeno && xeno.stat != DEAD) && !(FACTION_MARINE in xeno.iff_tag?.faction_groups))
+				var/name = "Unidentified Lifesigns"
+				var/input = "Unidentified lifesigns detected onboard. Recommendation: lockdown of exterior access ports, including ducting and ventilation."
+				shipwide_ai_announcement(input, name, 'sound/AI/unidentified_lifesigns.ogg', ares_logging = ARES_LOG_SECURITY)
+				set_security_level(SEC_LEVEL_RED)
+				break
 
 	//END: Heavy lifting backend
 


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Xenomorph on dropship alert now only occurs after landing.

Stanalbatross closed this 2 years ago, Frozentsbgg asked for this to be reopened yesterday.

# Explain why it's good for the game

Frankly speaking, there is no reason for this alarm to occur inmediately on ship launch. There are already plenty of ways to communicate this beforehand.

1. The pilot on the dropship.
2. The marines on the dropship.
3. The marines near the dropship that witnessed it or heard slashing inside.

Hell, these don't even rely on groundside comms because of RTOs and the fact that on the dropship you can speak directly to the shipside crew. There is no excuse, if there's a xenomorph on the dropship, there's no way the people inside it don't have a chance to call out the infiltrator.

Doing so automatically is, dare I say it, QOL, handholding, and even anti-fun. Why? Because it trivializes defending against infiltrators. Marines can just build 300 barricades that completely block off the xenos inside and screw them over, even if they managed to stealthily assassinate everyone inside in time.

With the alarm moved to post-landing, marines will panic and need to inmediately react to it, but they still do have a warning. The panic is movielike and soulful - of course you'd freak out and scramble if a Xeno got on. The dropship didn't tell Bishop that the Queen had snuck onboard, the disaster only started happening when the ship landed.

This will also stop those annoying times that ARES freaks out over two runners on the dropship in evac, causing the XO to order everyone to hangar for what ends up being nothing at all.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Be sure to properly mark your PRs to prevent unnecessary GBP loss. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: Xenomorph on dropship alert now only occurs after landing.
/:cl:
