### PR TITLE
makes the rescue survivors objective actually give intel points

### DIFF
--- a/code/modules/objectives/mob_objectives.dm
+++ b/code/modules/objectives/mob_objectives.dm
@@ -172,6 +172,7 @@
 	var/mob/living/target
 	var/mob_can_die = MOB_CAN_COMPLETE_AFTER_DEATH
 	objective_flags = OBJECTIVE_DO_NOT_TREE
+	controller = TREE_MARINE
 
 
 /datum/cm_objective/move_mob/New(mob/living/survivor)


### PR DESCRIPTION

# About the pull request

makes the rescue survivors intel objective actually reward the points it says it does. it used to update the intel objectives panel but early return on the proc that actually increments the intel points total because the objective itself wasn't assigned to the marine controller and had the default which is undefined.

# Explain why it's good for the game

bugs bad


# Testing Photographs and Procedure
<img width="1145" height="494" alt="image" src="https://github.com/user-attachments/assets/04cf7114-2cac-4ffb-92fc-36de9e4ee5b9" />



# Changelog
:cl:
fix: rescuing survivors now properly awards intel points instead of only pretending to
/:cl:
