### PR TITLE
Fix: M39 Brace still affecting weapons it was detached from

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1981,8 +1981,8 @@ Defined in conflicts.dm of the #defines folder.
 	if(!collapsible)
 		return .
 
-	if(turn_off && stock_activated)
-		stock_activated = FALSE
+	if(turn_off)
+		stock_activated = initial(stock_activated)
 		apply_on_weapon(gun)
 		return TRUE
 
@@ -2909,11 +2909,6 @@ Defined in conflicts.dm of the #defines folder.
 
 	applying_gun.recalculate_attachment_bonuses()
 	applying_gun.update_overlays(src, "stock")
-
-/obj/item/attachable/stock/smg/collapsible/brace/Detach(mob/user, obj/item/weapon/gun/detaching_gun)
-	. = ..()
-
-	detaching_gun.flags_item &= ~(NODROP|FORCEDROP_CONDITIONAL)
 
 /obj/item/attachable/stock/revolver
 	name = "\improper M44 magnum sharpshooter stock"


### PR DESCRIPTION

# About the pull request
Stops the Activated M39 brace flags from being still applied to the gun whilst it was swapped out for another stock by fixing the logic for turn_off

Rename some single letter vars
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Bug bad
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MistChristmas
fix: M39s no longer get stuck to you after you swap out your activated M39 Brace for something else
/:cl:
