### PR TITLE
External webbing, windbreakers, and two bomber jacket variants now accept general utility belts

### DIFF
--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -391,7 +391,7 @@
 		/obj/item/storage/belt/gun/m44,
 		/obj/item/storage/belt/gun/mateba,
 		/obj/item/storage/belt/gun/smartpistol,
-    /obj/item/storage/backpack/general_belt,
+		/obj/item/storage/backpack/general_belt,
 		/obj/item/weapon/gun,
 
 		/obj/item/device/flashlight,

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -268,7 +268,7 @@
 		/obj/item/storage/belt/gun/mateba,
 		/obj/item/storage/belt/gun/smartpistol,
 		/obj/item/storage/belt/gun/type47,
-    /obj/item/storage/backpack/general_belt,
+		/obj/item/storage/backpack/general_belt,
 		/obj/item/weapon/gun,
 
 		/obj/item/device/flashlight,
@@ -446,7 +446,7 @@
 		/obj/item/storage/belt/gun/m44,
 		/obj/item/storage/belt/gun/mateba,
 		/obj/item/storage/belt/gun/smartpistol,
-    /obj/item/storage/backpack/general_belt,
+		/obj/item/storage/backpack/general_belt,
 		/obj/item/weapon/gun,
 
 		/obj/item/device/flashlight,


### PR DESCRIPTION
# About the pull request

Currently, the general utility pouch/belt can be equipped if you're wearing one of three suit jackets, the marine service jacket, or three out of five bomber jacket variants, but you can't equip one if you're wearing an external webbing, any of the windbreakers, or the black and brown bomber jacket variants. This pull request will allow you to equip this belt on any of these functionally identical pieces of clothing

Fixes issue #10571 

# Explain why it's good for the game

This PR gives people a wider variety of clothing options when they're considering what to pick for their loadouts. People are no longer constrained to specific bomber jacket colors if they intend to wear something that can hold the utility belt. Functionally, they're all the same in terms of armor and storage capacity, it was just weird for some to allow general utility belts and not others.


# Testing Photographs and Procedure

I booted up my game, spawned all of those jackets, wore them, and equipped the GA-8.

</details>


# Changelog

:cl:
balance: General utility belts can now be worn on windbreakers and external webbings
fix: Fixed general utility belts not being wearable when certain bomber jacket variants are equipped
/:cl:
