### PR TITLE
Small loadout preference changes

### DIFF
--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -1231,37 +1231,6 @@ GLOBAL_LIST_EMPTY(roles_with_gear)
 	fluff_cost = 1 //The cadmium poisoning pays for the discounted cost longterm
 	allowed_origins = USCM_ORIGINS
 
-// civilian shoes, technically contraband for marines so more expensive, civilians can get them discounted in the civilian only section.
-
-/datum/gear/misc/shoes
-	display_name = "black shoes"
-	path = /obj/item/clothing/shoes/black
-	fluff_cost = 3
-
-/datum/gear/misc/shoes/brown
-	display_name = "brown shoes"
-	path = /obj/item/clothing/shoes/brown
-
-/datum/gear/misc/shoes/blue
-	display_name = "blue shoes"
-	path = /obj/item/clothing/shoes/blue
-
-/datum/gear/misc/shoes/green
-	display_name = "green shoes"
-	path = /obj/item/clothing/shoes/green
-
-/datum/gear/misc/shoes/yellow
-	display_name = "yellow shoes"
-	path = /obj/item/clothing/shoes/yellow
-
-/datum/gear/misc/shoes/purple
-	display_name = "purple shoes"
-	path = /obj/item/clothing/shoes/purple
-
-/datum/gear/misc/shoes/red
-	display_name = "red shoes"
-	path = /obj/item/clothing/shoes/red
-
 /datum/gear/misc/dogtags
 	display_name = "Attachable Dogtags"
 	path = /obj/item/clothing/accessory/dogtags


### PR DESCRIPTION
# About the pull request

The knock-off BiMax sunglasses from the civilian only section have been moved to normal eyewear, and can thusly be bought by marines, I know some people preferred the old sprite, and when these got moved to civ-only they got a bunch of new variants I have hardly ever seen, so this just moves them into normal glasses.

# Explain why it's good for the game

As said above, a lot of people like the old sunglasses sprite more than the new one, and these colored versions of the regular sunglasses have seen little to not use since they were added, considering they've been locked to civs only. Also I'm going to construe [this](https://discord.com/channels/150315577943130112/604397850675380234/1347180288333320232) to be permission to add the knock-offs to regular marines.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="639" height="256" alt="image" src="https://github.com/user-attachments/assets/dd93c648-7f14-400b-a842-70f0cab967da" />

</details>


# Changelog
:cl: riot
add: Knockoff Bimax sunglasses can now be bought in the loadout as non-civilians.
/:cl:
