### PR TITLE
Adds a black headband to marines' loadout

### DIFF
--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -423,6 +423,10 @@ GLOBAL_LIST_EMPTY(roles_with_gear)
 	display_name = "USCM headband, red"
 	path = /obj/item/clothing/head/headband/red
 
+/datum/gear/headwear/uscm/headband_intel
+	display_name = "USCM headband, black"
+	path = /obj/item/clothing/head/headband/intel
+
 /datum/gear/headwear/uscm/headband_tan
 	display_name = "USCM headband, tan"
 	path = /obj/item/clothing/head/headband/tan

--- a/code/modules/clothing/head/head.dm
+++ b/code/modules/clothing/head/head.dm
@@ -278,6 +278,18 @@
 	icon_state = "headbandtan"
 	item_state_slots = list(WEAR_AS_GARB = "headbandtan")
 
+/obj/item/clothing/head/headband/intel
+	icon_state = "headbandintel"
+	icon = 'icons/obj/items/clothing/hats/headbands.dmi'
+	item_icons = list(
+		WEAR_HEAD = 'icons/mob/humans/onmob/clothing/head/headbands.dmi',
+		WEAR_AS_GARB = 'icons/mob/humans/onmob/clothing/helmet_garb/headbands.dmi',
+	)
+	item_state_slots = list(
+		WEAR_AS_GARB = "headbandintel",
+	)
+	flags_atom = NO_GAMEMODE_SKIN
+
 /obj/item/clothing/head/headband/brown
 	icon_state = "headbandbrown"
 	icon = 'icons/obj/items/clothing/hats/headbands.dmi'
@@ -427,6 +439,7 @@ GLOBAL_LIST_INIT(allowed_hat_items, list(
 	/obj/item/clothing/head/headband/red = PREFIX_HAT_GARB_OVERRIDE, // _hat
 	/obj/item/clothing/head/headband/brown = PREFIX_HAT_GARB_OVERRIDE, // _hat
 	/obj/item/clothing/head/headband/gray = PREFIX_HAT_GARB_OVERRIDE, // _hat
+	/obj/item/clothing/head/headband/intel = PREFIX_HAT_GARB_OVERRIDE, // _hat
 	/obj/item/clothing/head/headband/squad = PREFIX_HAT_GARB_OVERRIDE, // _hat
 	/obj/item/prop/helmetgarb/lucky_feather = NO_GARB_OVERRIDE,
 	/obj/item/prop/helmetgarb/lucky_feather/blue = NO_GARB_OVERRIDE,

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -351,6 +351,7 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 	/obj/item/clothing/head/headband/red = NO_GARB_OVERRIDE,
 	/obj/item/clothing/head/headband/brown = PREFIX_HELMET_GARB_OVERRIDE, // helmet_
 	/obj/item/clothing/head/headband/gray = PREFIX_HELMET_GARB_OVERRIDE, // helmet_
+	/obj/item/clothing/head/headband/intel = PREFIX_HELMET_GARB_OVERRIDE, // helmet_
 	/obj/item/clothing/head/headband/squad = PREFIX_HELMET_GARB_OVERRIDE, // helmet_
 	/obj/item/clothing/head/headband/rebel = PREFIX_HELMET_GARB_OVERRIDE, // helmet_
 	/obj/item/tool/candle = NO_GARB_OVERRIDE,


### PR DESCRIPTION
# About the pull request
Uses the existing headbandintel sprite to add a black headband to the marines' loadout. Works with helmets too. See screenshot images below. 

# Explain why it's good for the game
The intel headband sprite already exists in the game files but wasn't available in loadout selection. This makes it accessible to players who want this aesthetic option. The aesthetic being thematically relevant with the whole Aliens/Vietnam vibe. Adds: Variety. War. Grit. 80s. Fashion. RP. What more can I say? 

# Testing Photographs and Procedure

<img width="93" height="142" alt="image" src="https://github.com/user-attachments/assets/dbbb782c-4473-4c91-9339-b80a08fe0d74" />


<img width="233" height="121" alt="image" src="https://github.com/user-attachments/assets/646bde73-ed79-4354-b0e4-9f1693488871" />


<img width="82" height="136" alt="image" src="https://github.com/user-attachments/assets/d9946428-ce61-441c-b047-5da403b70ae0" />


<img width="68" height="148" alt="image" src="https://github.com/user-attachments/assets/4089c6dd-8c15-4f16-af57-ec369a1ed16b" />


# Changelog

:cl:
add: Added black headband to marines' loadout
/:cl: