### PR TITLE
[CODEBOUNTY] poplock on co and synth survs

### DIFF
--- a/code/game/jobs/job/civilians/other/survivors.dm
+++ b/code/game/jobs/job/civilians/other/survivors.dm
@@ -185,6 +185,7 @@ AddTimelock(/datum/job/civilian/survivor, list(
 
 /datum/job/civilian/survivor/synth/set_spawn_positions(count)
 	if(count < min_playercount)
+		total_positions = 0
 		spawn_positions = 0
 	return spawn_positions
 

--- a/code/game/jobs/job/civilians/other/survivors.dm
+++ b/code/game/jobs/job/civilians/other/survivors.dm
@@ -181,8 +181,11 @@ AddTimelock(/datum/job/civilian/survivor, list(
 	total_positions = 1
 	spawn_positions = 1
 	job_options = null
+	var/min_playercount = 70
 
 /datum/job/civilian/survivor/synth/set_spawn_positions(count)
+	if(count < min_playercount)
+		spawn_positions = 0
 	return spawn_positions
 
 /datum/job/civilian/survivor/synth/handle_equip_gear(mob/living/carbon/human/equipping_human, obj/effect/landmark/survivor_spawner/picked_spawner)
@@ -208,11 +211,12 @@ AddTimelock(/datum/job/civilian/survivor, list(
 	total_positions = 0
 	spawn_positions = 0
 	job_options = null
+	var/min_playercount = 70
 
-/datum/job/civilian/survivor/commanding_officer/set_spawn_positions()
+/datum/job/civilian/survivor/commanding_officer/set_spawn_positions(count)
 	var/list/CO_survivor_types = SSmapping.configs[GROUND_MAP].CO_survivor_types
 	var/list/CO_insert_survivor_types = SSmapping.configs[GROUND_MAP].CO_insert_survivor_types
-	if(length(CO_survivor_types) || length(CO_insert_survivor_types))
+	if(count > min_playercount && (length(CO_survivor_types) || length(CO_insert_survivor_types)))
 		total_positions = 1
 		spawn_positions = 1
 	return spawn_positions


### PR DESCRIPTION
# About the pull request

introduces player count requirement to surv CO and surv Synth. Smog will be handeling it with the councils, leave that to them to decide

# Explain why it's good for the game

lowpop having too many survivors is an issue and at the same time lowpop shipside needs synth and CO help so much


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: puts poplock on synthetic and commanding officer survivor role
/:cl:
