### PR TITLE
Yautja duel click-drag override

### DIFF
--- a/code/_onclick/click_hold.dm
+++ b/code/_onclick/click_hold.dm
@@ -48,7 +48,7 @@
 
 		//Some combat intent click-drags shouldn't be overridden.
 		var/mob/target_mob = A
-		if(ismob(target_mob) && (target_mob.faction == mob.faction & mob.faction != FACTION_YAUTJA) && !mods[CTRL_CLICK] && !(iscarbonsizexeno(mob) && !mob.get_active_hand())) //Don't attack your allies or yourself, unless you're a xeno with an open hand.
+		if(ismob(target_mob) && (target_mob.faction == mob.faction & mob.faction != FACTION_YAUTJA) && !mods[CTRL_CLICK] && !(iscarbonsizexeno(mob) && !mob.get_active_hand())) //Don't attack your allies (besides yautja) or yourself, unless you're a xeno with an open hand.
 			return
 
 		if(!isturf(T)) //If clickdragging something in your own inventory, it's probably a deliberate attempt to open something, tactical-reload, etc. Don't click it.


### PR DESCRIPTION

# About the pull request

Makes yautja dueling/spar better

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Already long duels between yautjas are even longer because click-drag override doesn't work on friendlies
# Testing Photographs and Procedure
local 
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Yautja click-drag override now works on yautjas
/:cl:
