### PR TITLE
Makes a faction-wide text/sound message not be called for every xenomorph in existence(stops our ears bleeding)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -874,6 +874,7 @@
 		buff._on_cease()
 
 /datum/hive_status/proc/bless_on_hijack()
+	xeno_maptext("My Children, the time has come to assault the Metal Hive. Evolve now into castes best suited for the task!", "Queen Mother") // NOTE: sends a maptext to all xenos globally, hence not in below loop
 	for(var/mob/living/carbon/xenomorph/xeno as anything in totalXenos)
 		if(xeno.caste.tier > 3)
 			return
@@ -881,7 +882,6 @@
 		if(get_action(xeno, /datum/action/xeno_action/onclick/transmute))
 			return
 
-		xeno_maptext("My Children, the time has come to assault the Metal Hive. Evolve now into castes best suited for the task!", "Queen Mother")
 
 		if(xeno.caste.tier > 0)
 			add_verb(xeno, /mob/living/carbon/xenomorph/proc/transmute_verb)


### PR DESCRIPTION

# About the pull request

See diff

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Hijack doesn't make ears bleed via the boon notification
/:cl:
