### PR TITLE
More byond download fallbacks for CI

### DIFF
--- a/tools/ci/download_byond.sh
+++ b/tools/ci/download_byond.sh
@@ -8,7 +8,12 @@ if [ $? -ne 0 ] || !(unzip -qt C:/byond.zip); then
 	rm C:/byond.zip
 	curl "https://cmss13-devs.github.io/byond-build-mirror/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond.zip" -o C:/byond.zip -A "CMSS13/1.0 Continuous Integration"
 	if [ $? -ne 0 ] || !(unzip -qt C:/byond.zip); then
-		echo "Failure!"
-		exit 1
+		echo "Attempting another fallback mirror..."
+		rm C:/byond.zip
+		curl "https://byond-builds.dm-lang.org/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond.zip" -o C:/byond.zip -A "CMSS13/1.0 Continuous Integration"
+		if [ $? -ne 0 ] || !(unzip -qt C:/byond.zip); then
+			echo "Failure!"
+			exit 1
+		fi
 	fi
 fi

--- a/tools/ci/install_byond.sh
+++ b/tools/ci/install_byond.sh
@@ -3,31 +3,35 @@ set -euo pipefail
 
 # BYOND_MAJOR and BYOND_MINOR can be explicitly set, such as in alt_byond_versions.txt
 if [ -z "${BYOND_MAJOR+x}" ]; then
-  source dependencies.sh
+	source dependencies.sh
 fi
 
-if [ -d "$HOME/BYOND/byond/bin" ] && grep -Fxq "${BYOND_MAJOR}.${BYOND_MINOR}" $HOME/BYOND/version.txt;
-then
-  echo "Using cached directory."
+if [ -d "$HOME/BYOND/byond/bin" ] && grep -Fxq "${BYOND_MAJOR}.${BYOND_MINOR}" $HOME/BYOND/version.txt; then
+	echo "Using cached directory."
 else
-  echo "Setting up BYOND version ${BYOND_MAJOR}.${BYOND_MINOR} (linux)..."
-  rm -rf "$HOME/BYOND"
-  mkdir -p "$HOME/BYOND"
-  cd "$HOME/BYOND"
-  curl "http://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -o byond.zip -A "CMSS13/1.0 Continuous Integration"
-  if [ $? -ne 0 ] || !(unzip -qt byond.zip); then
-    echo "Attempting fallback mirror..."
-    rm byond.zip
-    curl "https://cmss13-devs.github.io/byond-build-mirror/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -o byond.zip -A "CMSS13/1.0 Continuous Integration"
-    if [ $? -ne 0 ] || !(unzip -qt byond.zip); then
-      echo "Failure!"
-      exit 1
-    fi
-  fi
-  unzip byond.zip
-  rm byond.zip
-  cd byond
-  make here
-  echo "$BYOND_MAJOR.$BYOND_MINOR" > "$HOME/BYOND/version.txt"
-  cd ~/
+	echo "Setting up BYOND version ${BYOND_MAJOR}.${BYOND_MINOR} (linux)..."
+	rm -rf "$HOME/BYOND"
+	mkdir -p "$HOME/BYOND"
+	cd "$HOME/BYOND"
+	curl "http://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -o byond.zip -A "CMSS13/1.0 Continuous Integration"
+	if [ $? -ne 0 ] || !(unzip -qt byond.zip); then
+		echo "Attempting fallback mirror..."
+		rm byond.zip
+		curl "https://cmss13-devs.github.io/byond-build-mirror/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -o byond.zip -A "CMSS13/1.0 Continuous Integration"
+		if [ $? -ne 0 ] || !(unzip -qt byond.zip); then
+			echo "Attempting another fallback mirror..."
+			rm byond.zip
+			curl "https://byond-builds.dm-lang.org/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -o byond.zip -A "CMSS13/1.0 Continuous Integration"
+			if [ $? -ne 0 ] || !(unzip -qt byond.zip); then
+				echo "Failure!"
+				exit 1
+			fi
+		fi
+	fi
+	unzip byond.zip
+	rm byond.zip
+	cd byond
+	make here
+	echo "$BYOND_MAJOR.$BYOND_MINOR" > "$HOME/BYOND/version.txt"
+	cd ~/
 fi


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #9343 simply adding another fallback source for byond downloads. Also converted whitespace to tabs on one of them.

# Explain why it's good for the game

More reliable CI in case byond download sources go down.

# Testing Photographs and Procedure
Simply ran each script with test modifications to invalidate the url for different mirrors in WSL (for install byond - linux) and powershell (for download byond - windows) respectively.

Otherwise see checks.

# Changelog

No player facing changes.
