### PR TITLE
Expedition satchel added to synthetic vendor

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/synthetic.dm
+++ b/code/game/machinery/vending/vendor_types/crew/synthetic.dm
@@ -881,6 +881,7 @@ GLOBAL_LIST_INIT(cm_vending_synth_tools, list(
 	list("Tool Drop Pouch", 15, /obj/item/clothing/accessory/storage/tool_webbing/yellow_drop/equipped, null, VENDOR_ITEM_REGULAR),
 	list("Logistics IMP Backpack", 15, /obj/item/storage/backpack/marine/satchel/big, null, VENDOR_ITEM_REGULAR),
 	list("Expedition Chestrig", 15, /obj/item/storage/backpack/marine/satchel/intel/chestrig, null, VENDOR_ITEM_REGULAR),
+	list("Expedition Satchel", 15, /obj/item/storage/backpack/marine/satchel/intel/expeditionsatchel, null, VENDOR_ITEM_REGULAR),
 ))
 
 //------------EXPERIMENTAL TOOL KITS---------------


### PR DESCRIPTION

# About the pull request

The synthetic points vendor has two out of three intel backpack variants: the logistics IMP backpack and the expedition chestrig. This PR adds the expedition satchel to the vendor.

# Explain why it's good for the game

More variety and extra options to choose from as a synthetic. All three variants of the intel backpack are functionally the same, the difference is purely cosmetic. I know for a fact quite a few synthetic players don't find the two variants currently available to be particularly aesthetic.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Added the expedition satchel to the synthetic points vendor
/:cl:
