### PR TITLE
Add link out to PR feedback form on github issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: PR Feedback
+    url: https://forum.cm-ss13.com/w/pr-feedback
+    about: General pull request feedback can be submitted privately on the forums here.
   - name: Game Breaking Exploits
     url: https://discord.gg/cmss13
-    about: Securely disclose high priority issues to a member of the Maintainer Team here.
+    about: Securely disclose high priority issues in a DM to a member of the Maintainer Team here.


### PR DESCRIPTION

# About the pull request

This PR simply adds another link out option to the forums PR feedback form on github issues. Also indicates DMing for the security issues link since that has been confusing for people.

# Changelog

No player facing changes to the game.