### PR TITLE
Minor Fix: UPP ERT Synths get the flag that lets their preset spawn

### DIFF
--- a/code/modules/gear_presets/upp.dm
+++ b/code/modules/gear_presets/upp.dm
@@ -2781,6 +2781,7 @@
 
 /datum/equipment_preset/synth/upp
 	name = "UPP Synthetic (Cryo)"
+	flags = EQUIPMENT_PRESET_EXTRA
 	faction = FACTION_UPP
 	origin_override = ORIGIN_UPP
 	languages = ALL_SYNTH_LANGUAGES_UPP


### PR DESCRIPTION

# About the pull request
I missed the gear preset flags that means these was previously a stub before. In my defense every other synth had them so uhhhhhh sorgy.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Fix me missing things
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MistChristmas
fix: ERT UPP Synths can spawn again. Along with the admin spawn ones.
/:cl:
