### PR TITLE
Fixes Ravager Empower icon background bugging out

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Ravager.dm
@@ -155,7 +155,7 @@
 	var/datum/behavior_delegate/ravager_base/behavior = xeno.behavior_delegate
 
 	activated_once = FALSE
-	button.icon_state = "template_xeno_xeno"
+	button.icon_state = "template_xeno"
 	xeno.visible_message(SPAN_XENOWARNING("[xeno] gets empowered by the surrounding enemies!"), SPAN_XENOWARNING("We feel a rush of power from the surrounding enemies!"))
 	xeno.create_empower()
 


### PR DESCRIPTION
# About the pull request

Fixes: #11757
The background for empower is updated after usage; this fixes it having a messed-up icon

# Explain why it's good for the game

squashin ma bugs

# Testing Photographs and Procedure

<img width="153" height="158" alt="image" src="https://github.com/user-attachments/assets/49bbbf19-deff-4275-a870-ccd7c7e6ae51" />
<img width="151" height="167" alt="image" src="https://github.com/user-attachments/assets/a8328534-4f3e-4b69-bb00-e4f5762f32ed" />


# Changelog

:cl:
fix: Ravager Empower ability background no longer bugs out
/:cl:
