### PR TITLE
prevents larvas from getting more evo points then other castes roundstart

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -59,7 +59,7 @@
 	if(SSxevolution)
 		progress_amount = SSxevolution.get_evolution_boost_power(hive.hivenumber)
 	var/ovipositor_check = hive.allow_no_queen_evo || hive.evolution_without_ovipositor || (hive.living_xeno_queen && hive.living_xeno_queen.ovipositor)
-	if(caste.evolution_allowed && (ovipositor_check || caste.evolve_without_queen))
+	if(caste.evolution_allowed && (ovipositor_check || (caste.evolve_without_queen && evolution_stored < evolution_threshold)))
 		if(evolution_stored >= evolution_threshold)
 			if(!got_evolution_message)
 				evolve_message()

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -59,7 +59,7 @@
 	if(SSxevolution)
 		progress_amount = SSxevolution.get_evolution_boost_power(hive.hivenumber)
 	var/ovipositor_check = hive.allow_no_queen_evo || hive.evolution_without_ovipositor || (hive.living_xeno_queen && hive.living_xeno_queen.ovipositor)
-	if(caste.evolution_allowed && (ovipositor_check || (caste.evolve_without_queen && evolution_stored < evolution_threshold)))
+	if(caste.evolution_allowed && (ovipositor_check || (caste.evolve_without_queen && evolution_stored <= evolution_threshold)))
 		if(evolution_stored >= evolution_threshold)
 			if(!got_evolution_message)
 				evolve_message()

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -59,7 +59,7 @@
 	if(SSxevolution)
 		progress_amount = SSxevolution.get_evolution_boost_power(hive.hivenumber)
 	var/ovipositor_check = hive.allow_no_queen_evo || hive.evolution_without_ovipositor || (hive.living_xeno_queen && hive.living_xeno_queen.ovipositor)
-	if(caste.evolution_allowed && (ovipositor_check || (caste.evolve_without_queen && evolution_stored <= evolution_threshold)))
+	if(caste.evolution_allowed && (ovipositor_check || (caste.evolve_without_queen && evolution_stored < evolution_threshold)))
 		if(evolution_stored >= evolution_threshold)
 			if(!got_evolution_message)
 				evolve_message()
@@ -75,6 +75,9 @@
 
 		else
 			evolution_stored += progress_amount
+			if(evolution_stored >= evolution_threshold)
+				evolve_message()
+				got_evolution_message = TRUE
 
 /mob/living/carbon/xenomorph/proc/evolve_message()
 	to_chat(src, SPAN_XENODANGER("Our carapace crackles and our tendons strengthen. We are ready to <a href='byond://?src=\ref[src];evolve=1;'>evolve</a>!")) //Makes this bold so the Xeno doesn't miss it


### PR DESCRIPTION

# About the pull request

there is a bug that some players abuse where they stay as larva when the queen is about to ovi late as they keep getting evo points even when queen does not enter ovi for over 3 minutes, while for otehrs it stopes at 3 minutes of oviless queen

# Explain why it's good for the game

does not reward players for bugabusing and staying larva roundstart by getting t3 slots first when queen is late to ovi


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: larvas stop getting extra evo points over their threshold as every other caste if queen does not enter ovi for over 3 minutes roundstart
/:cl:
