### PR TITLE
Snow Turf Effects Removal

### DIFF
--- a/code/game/turfs/auto_turf.dm
+++ b/code/game/turfs/auto_turf.dm
@@ -165,11 +165,9 @@
 
 /turf/open/auto_turf/snow/Initialize(mapload, ...)
 	. = ..()
-	is_weedable = bleed_layer ? NOT_WEEDABLE : FULLY_WEEDABLE
 
 /turf/open/auto_turf/snow/changing_layer(new_layer)
 	. = ..()
-	is_weedable = bleed_layer ? NOT_WEEDABLE : FULLY_WEEDABLE
 
 /turf/open/auto_turf/snow/insert_self_into_baseturfs()
 	baseturfs += /turf/open/auto_turf/snow/layer0
@@ -226,25 +224,6 @@
 		changing_layer(new_layer)
 
 	return XENO_NO_DELAY_ACTION
-
-/turf/open/auto_turf/snow/Entered(atom/movable/AM)
-	if(bleed_layer > 0)
-		if(iscarbon(AM))
-			var/mob/living/carbon/C = AM
-			var/slow_amount = 0.35
-			var/can_stuck = 1
-			if(istype(C, /mob/living/carbon/xenomorph)||isyautja(C))
-				slow_amount = 0.15
-				can_stuck = 0
-			var/new_slowdown = C.next_move_slowdown + (slow_amount * bleed_layer)
-			if(!HAS_TRAIT(C, TRAIT_HAULED))
-				if(prob(2))
-					to_chat(C, SPAN_WARNING("Moving through [src] slows you down.")) //Warning only
-				else if(can_stuck && bleed_layer == 4 && prob(2))
-					to_chat(C, SPAN_WARNING("You get stuck in [src] for a moment!"))
-					new_slowdown += 10
-				C.next_move_slowdown = new_slowdown
-	..()
 
 /turf/open/auto_turf/snow/layer0 //still have to manually define the layers for the editor
 	icon_state = "snow_0"

--- a/code/game/turfs/snow.dm
+++ b/code/game/turfs/snow.dm
@@ -40,27 +40,6 @@
 /turf/open/snow/Initialize(mapload, ...)
 	. = ..()
 	update_icon(1,1)
-	is_weedable = bleed_layer ? NOT_WEEDABLE : FULLY_WEEDABLE
-
-/turf/open/snow/Entered(atom/movable/AM)
-	if(bleed_layer > 0)
-		if(iscarbon(AM))
-			var/mob/living/carbon/C = AM
-			var/slow_amount = 0.75
-			var/can_stuck = 1
-			if(istype(C, /mob/living/carbon/xenomorph)||isyautja(C))
-				slow_amount = 0.25
-				can_stuck = 0
-			var/new_slowdown = C.next_move_slowdown + (slow_amount * bleed_layer)
-			if(!HAS_TRAIT(C, TRAIT_HAULED))
-				if(prob(2))
-					to_chat(C, SPAN_WARNING("Moving through [src] slows you down.")) //Warning only
-				else if(can_stuck && bleed_layer == 3 && prob(2))
-					to_chat(C, SPAN_WARNING("You get stuck in [src] for a moment!"))
-					new_slowdown += 10
-				C.next_move_slowdown = new_slowdown
-	..()
-
 
 //Update icon
 /turf/open/snow/update_icon(update_full, skip_sides)
@@ -117,10 +96,6 @@
 
 					I.layer = layer + 0.001 + bleed_layer * 0.0001
 					overlays += I
-
-
-		//a bit odd to have it here but weedability should be linked to visual show of snow
-		is_weedable = bleed_layer ? NOT_WEEDABLE : FULLY_WEEDABLE
 
 //Explosion act
 /turf/open/snow/ex_act(severity)


### PR DESCRIPTION
# About the pull request

I borked the old one trying to fix its merge conflicts; this is the same as the old PR for it.

Removes the slowdown from walking in the deeper snow layers and makes all snow tiles weedable. Tested, see videos.

Note: feel free to throw the maptweak tag on here, it affects maps but it's not *mapping* ya'know so I left it off to be safe.

# Explain why it's good for the game

Aims to remove some of the tediousness from Shiva's and other snow maps. Shiva's is pretty lame for xenos; they spend 20 minutes clicking tiles in an exercise to kill brain cells.

The slowdown removal change is more experimental. The thought was that this PR would remove everything bad (slowdown and unweedable) about snow and keep the snow itself for soul and snowball fights. Hopefully will make shiva's a little more fun without it having to undergo the Soro treatment.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

https://github.com/user-attachments/assets/fbe3b6ab-39ed-4b6e-9537-498dc3ac0e1d

</details>


# Changelog

:cl:
balance: removed the slowdown effect of snow and made it weedable
/:cl:

