### PR TITLE
Remove a UpdatePath Script for lathes

### DIFF
--- a/tools/UpdatePaths/Scripts/11608-lathes.txt
+++ b/tools/UpdatePaths/Scripts/11608-lathes.txt
@@ -1,3 +1,0 @@
-/obj/structure/machinery/autolathe/full : /obj/structure/machinery/autolathe/partial{@OLD}
-/obj/structure/machinery/autolathe/armylathe/full : /obj/structure/machinery/autolathe/armylathe/partial{@OLD}
-/obj/structure/machinery/autolathe/medilathe/full : /obj/structure/machinery/autolathe/medilathe/partial{@OLD}


### PR DESCRIPTION

# About the pull request
They got split into 3 versions partial, full, and normal
Most places should use partial or normal(which is mostly just a little less than partial for the normal autolathe, but the other subtypes come empty on normal
Admin/ERT should/can use full without balance concerns.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
del: Removed a UpdatePath script for lathes
/:cl:
