### PR TITLE
Experimental: Try without apt update installs from CI

### DIFF
--- a/.github/workflows/autowiki.yml
+++ b/.github/workflows/autowiki.yml
@@ -27,9 +27,6 @@ jobs:
     - name: Install rust-g
       if: steps.secrets_set.outputs.SECRETS_ENABLED
       run: |
-        sudo dpkg --add-architecture i386
-        sudo apt update || true
-        sudo apt install -o APT::Immediate-Configure=false zlib1g-dev:i386 libssl-dev:i386 curl:i386
         bash tools/ci/install_rust_g.sh
     - name: Compile and generate Autowiki files
       if: steps.secrets_set.outputs.SECRETS_ENABLED

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -92,11 +92,6 @@ jobs:
         uses: ./.github/actions/setup_bun
       - name: Restore BYOND from Cache
         uses: ./.github/actions/restore_or_install_byond
-      - name: Install curl
-        run: |
-          sudo dpkg --add-architecture i386
-          sudo apt update || true
-          sudo apt install -o APT::Immediate-Configure=false curl:i386
       - name: Compile All Maps
         run: |
           source $HOME/BYOND/byond/bin/byondsetup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,6 @@ jobs:
       - name: Restore BYOND from Cache
         uses: ./.github/actions/restore_or_install_byond
 
-      - name: Install curl
-        run: |
-          sudo dpkg --add-architecture i386
-          sudo apt update || true
-          sudo apt install -o APT::Immediate-Configure=false curl:i386
-
       - name: Build
         run: |
           source $HOME/BYOND/byond/bin/byondsetup

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -28,9 +28,6 @@ jobs:
         uses: ./.github/actions/setup_bun
       - name: Install rust-g
         run: |
-          sudo dpkg --add-architecture i386
-          sudo apt update || true
-          sudo apt install -o APT::Immediate-Configure=false zlib1g-dev:i386 libssl-dev:i386 curl:i386
           bash tools/ci/install_rust_g.sh
       - name: Compile Tests
         run: |


### PR DESCRIPTION

# About the pull request

This very likely won't work, but https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md notes all these (though maybe not specifically an i386 variant of them) except for zlib1g-dev should be present. And if we can cut back on the long durations for apt update steps in CI things should move faster. I do not currently see TG's CI do this any more.

# Changelog

No player facing changes.