### PR TITLE
45 min timeout for run_unit_tests

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   run_unit_tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v5
       - name: Restore BYOND from Cache


### PR DESCRIPTION

# About the pull request

Azure mirrors are randomly slow now when handling:

https://github.com/cmss13-devs/cmss13/blob/f8a5feb0dad60e4547494bb575211f1351cac862/.github/workflows/run_unit_tests.yml#L29-L34

E.g. 
<img width="656" height="324" alt="image" src="https://github.com/user-attachments/assets/4885cc11-c50a-443b-8f61-e26c0f98552e" />

# Changelog

No player facing changes.
