### PR TITLE
Fix flaky fire extinguisher harddel (#11807)

### DIFF
--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -6,7 +6,7 @@
 	anchored = TRUE
 	density = FALSE
 	var/obj/item/tool/extinguisher/has_extinguisher
-	var/opened = 0
+	var/opened = FALSE
 	var/base_icon
 
 /obj/structure/extinguisher_cabinet/Initialize()
@@ -14,6 +14,11 @@
 	base_icon = initial(icon_state)
 	has_extinguisher = new /obj/item/tool/extinguisher()
 	has_extinguisher.forceMove(src)
+
+/obj/structure/extinguisher_cabinet/Destroy()
+	if(has_extinguisher)
+		has_extinguisher = null // it's in contents so it'll be destroyed in the parent call, just null the var
+	return ..()
 
 /obj/structure/extinguisher_cabinet/lifeboat
 	name = "extinguisher cabinet"


### PR DESCRIPTION
# About the pull request
When an atom is qdeleted, its contents are also qdeleted. The fire extinguisher for fire extinguisher cabinets is in its contents, and the reference to it is not cleared on Destroy(); this means it will leave a reference that can cause a harddel, as shown in #11807.

# Explain why it's good for the game
Fixes #11807, fixes #11597, fixes #11520, fixes #10907, fixes #10730, fixes #10681, and fixes #9088.

# Testing Photographs and Procedure
Well, if the unit tests pass...