### PR TITLE
Adjust the PR Template to use correct syntax for Automatic Issue linking

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
 If this addresses a reported issue, you can include "Fixes #12345" to link the PR to the corresponding Issue number #12345.
-For multiple issues you must include the "fixes" keyword for each, e.g. "Fixes #12345, fixes #12346, fixes #12347". You cannot use multiple issue numbers with only one keyword.
+For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #12345, Fixes #12346, Fixes #12347". You cannot use multiple issue numbers with only one keyword.
 
 Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->
 


### PR DESCRIPTION

# About the pull request
Title
Syntax can be found [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue)
TL;DR
`KEYWORD #ISSUE-NUMBER`
And for multiple
`KEYWORD #ISSUE-NUMBER, KEYWORD #ISSUE-NUMBER`

Keywords:
- close
- closes
- closed
- fix
- fixes
- fixed
- resolve
- resolves
- resolved

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Gives the correct syntax to do the auto issue linking
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
