### PR TITLE
Fix: VAIPO Synth spawning naked.

### DIFF
--- a/code/datums/emergency_calls/contractor.dm
+++ b/code/datums/emergency_calls/contractor.dm
@@ -32,7 +32,7 @@
 	else if(synths < max_synths && HAS_FLAG(mob.client.prefs.toggles_ert, PLAY_SYNTH) && mob.client.check_whitelist_status(WHITELIST_SYNTHETIC))
 		synths++
 		to_chat(mob, SPAN_ROLE_HEADER("You are a Contractor Support Synthetic of Vanguard's Arrow Incorporated!"))
-		arm_equipment(mob, /datum/equipment_preset/contractor/duty/synth, TRUE, TRUE)
+		arm_equipment(mob, /datum/equipment_preset/synth/contractor/duty, TRUE, TRUE)
 	else if(medics < max_medics && HAS_FLAG(mob.client.prefs.toggles_ert, PLAY_MEDIC) && check_timelock(mob.client, JOB_SQUAD_MEDIC, time_required_for_job))
 		medics++
 		to_chat(mob, SPAN_ROLE_HEADER("You are a Contractor Medical Specialist of Vanguard's Arrow Incorporated!"))

--- a/code/modules/gear_presets/contractor.dm
+++ b/code/modules/gear_presets/contractor.dm
@@ -384,7 +384,7 @@
 	. = ..()
 	access = get_access(ACCESS_LIST_EMERGENCY_RESPONSE)
 
-/datum/equipment_preset/contractor/duty/synth/load_name(mob/living/carbon/human/new_human, randomise)
+/datum/equipment_preset/synth/contractor/duty/load_name(mob/living/carbon/human/new_human, randomise)
 	new_human.gender = pick(MALE, FEMALE)
 
 	var/datum/preferences/A = new()
@@ -416,7 +416,7 @@
 	new_human.g_eyes = colors[eye_color][2]
 	new_human.b_eyes = colors[eye_color][3]
 
-/datum/equipment_preset/contractor/duty/synth/load_gear(mob/living/carbon/human/new_human)
+/datum/equipment_preset/synth/contractor/duty/load_gear(mob/living/carbon/human/new_human)
 	//back
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/marine/smartpack/a1/black, WEAR_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/device/defibrillator, WEAR_IN_BACK) //1


### PR DESCRIPTION

# About the pull request
Hey at least they spawned as a synth this time
I forgot to switch their path stuff... somehow
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
ERT Synths should remember to gear up when they wake up to rescue the marines
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: VAIPO Military Contractor synth now spawns with gear.
/:cl:
