### PR TITLE
Fix larva spawn protection post fire refactor

### DIFF
--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -499,9 +499,22 @@
 	RegisterSignal(src, list(COMSIG_LIVING_FLAMER_CROSSED, COMSIG_LIVING_FLAMER_FLAMED), PROC_REF(handle_fire_protection))
 	addtimer(CALLBACK(src, PROC_REF(end_spawn_protection)), duration)
 
+/mob/living/carbon/xenomorph/grant_spawn_protection(duration)
+	status_flags |= RECENTSPAWN|GODMODE
+	fire_immunity |= FIRE_IMMUNITY_NO_DAMAGE|FIRE_IMMUNITY_NO_IGNITE
+	addtimer(CALLBACK(src, PROC_REF(end_spawn_protection)), duration)
+
 /mob/living/proc/end_spawn_protection()
 	status_flags &= ~(RECENTSPAWN|GODMODE)
 	UnregisterSignal(src, list(COMSIG_LIVING_FLAMER_CROSSED, COMSIG_LIVING_FLAMER_FLAMED))
+
+/mob/living/carbon/xenomorph/end_spawn_protection()
+	status_flags &= ~(RECENTSPAWN|GODMODE)
+	fire_immunity = initial(fire_immunity)
+	if(hive?.active_hivebuffs)
+		var/datum/hivebuff/fire/fire_buff = locate() in hive.active_hivebuffs
+		if(fire_buff)
+			fire_buff.apply_buff_effects(src)
 
 /mob/living/proc/handle_fire_protection(mob/living/living, datum/reagent/chem)
 	SIGNAL_HANDLER


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #11615 where I forgot to update larva protections because larva protections would replace the xeno's fire signals. I don't think this normally matters because larva aren't a combat caste and they'd soon evolve to something else that couldn't be trampled, but still fixes a runtime at least.

# Explain why it's good for the game

Fixes this runtime:
<img width="1127" height="551" alt="image" src="https://github.com/user-attachments/assets/8cc5efeb-8469-40e8-bed1-fb9428d4ce08" />

# Testing Photographs and Procedure
Just spawn as a roundstart larva, check you got protection briefly, and it reset correctly w/o trampling existing xeno fire signals.

# Changelog
:cl: Drathek
fix: Fix larva fire protection trampling existing xeno fire signals
/:cl:
