### PR TITLE
Slight expansion to synthetic clothing options

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/synthetic.dm
+++ b/code/game/machinery/vending/vendor_types/crew/synthetic.dm
@@ -754,6 +754,9 @@ GLOBAL_LIST_INIT(cm_vending_clothing_synth, list(
 /datum/gear/synthetic/suit/marine_service
 	path = /obj/item/clothing/suit/storage/jacket/marine/service
 
+/datum/gear/synthetic/suit/marine_service
+	path = /obj/item/clothing/suit/storage/jacket/marine/service/mp
+
 /datum/gear/synthetic/suit/windbreaker_brown
 	path = /obj/item/clothing/suit/storage/windbreaker/windbreaker_brown
 


### PR DESCRIPTION

# About the pull request

Marine combat boots and gloves are now available to synthetics in different variants in the synthetic clothing vendor and the loadout menu. Added MP service jacket to the loadout menu as well. Approved by the senator.

# Explain why it's good for the game

More clothing options to choose from for the special snowflake whitelist (and I wouldn't have it any other way).


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

I was able to spawn with all the boots and gloves I added, and they showed up in the vendor just fine.

</details>


# Changelog
:cl:
add: Added marine combat boots and gloves of different variants to the synthetic clothing vendor and loadout menu
/:cl:
