### PR TITLE
add back the check for whitelisted preds when spawning youngbloods

### DIFF
--- a/code/datums/emergency_calls/pred_hunt/hunting_calls.dm
+++ b/code/datums/emergency_calls/pred_hunt/hunting_calls.dm
@@ -317,6 +317,9 @@
 /datum/emergency_call/young_bloods/remove_nonqualifiers(list/datum/mind/candidates_list)
 	var/list/datum/mind/youngblood_candidates_clean = list()
 	for(var/datum/mind/youngblood_candidate in candidates_list)
+		if(youngblood_candidate.current?.client?.check_whitelist_status(WHITELIST_YAUTJA) || jobban_isbanned(youngblood_candidate.current, ERT_JOB_YOUNGBLOOD))
+			to_chat(youngblood_candidate.current, SPAN_WARNING("You didn't qualify for the ERT beacon because you are already whitelisted for predator or you are job banned from youngblood."))
+			continue
 		if(check_timelock(youngblood_candidate.current?.client, JOB_YOUNGBLOOD_ROLES_LIST, youngblood_time))
 			to_chat(youngblood_candidate.current, SPAN_WARNING("You did not qualify for the ERT beacon because you have already reached the maximum time allowed for Youngblood, please consider applying for Predator on the forums."))
 			continue


### PR DESCRIPTION

# About the pull request

im not sure why i removed it am i stupid

# Changelog
:cl:
fix: whitelisted predators can no longer spawn as a youngblood
/:cl:
