### PR TITLE
Mass screenshot fix for disabling multiple open_space blur planes

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -109,14 +109,19 @@
 	mob.animate_movement = NO_STEPS
 
 	var/atom/movable/screen/plane_master/openspace_backdrop/open_space_shadow = locate() in screen
-	var/atom/movable/screen/plane_master/open_space/open_space_blur = locate() in screen
+	var/list/open_space_blurs = list()
+	for(var/atom/movable/screen/plane_master/open_space/open_space_blur in screen)
+		open_space_blurs += open_space_blur
+
 	switch(multi_z_effects)
 		if("All")
 			open_space_shadow.Hide()
-			open_space_blur.Hide()
+			for(var/atom/movable/screen/plane_master/open_space/open_space_blur as anything in open_space_blurs)
+				open_space_blur.Hide()
 		if("Dropshadow + Blur")
 			open_space_shadow.Hide()
-			open_space_blur.remove_filters()
+			for(var/atom/movable/screen/plane_master/open_space/open_space_blur as anything in open_space_blurs)
+				open_space_blur.remove_filters()
 		if("Dropshadow")
 			open_space_shadow.Hide()
 
@@ -164,10 +169,12 @@
 	switch(multi_z_effects)
 		if("All")
 			open_space_shadow.Show()
-			open_space_blur.Show()
+			for(var/atom/movable/screen/plane_master/open_space/open_space_blur as anything in open_space_blurs)
+				open_space_blur.Show()
 		if("Dropshadow + Blur")
 			open_space_shadow.Show()
-			open_space_blur.add_filters()
+			for(var/atom/movable/screen/plane_master/open_space/open_space_blur as anything in open_space_blurs)
+				open_space_blur.add_filters()
 		if("Dropshadow")
 			open_space_shadow.Show()
 


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #11735 where I was only changing the first `/atom/movable/screen/plane_master/open_space` rather than all of them so you can mass screenshot more than just the second lowest Z with effects disabled. See screenshots section.

# Explain why it's good for the game

Working tools in more scenarios.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Rather than 
<img width="1824" height="1824" alt="- LV624 2026-02-27 032334" src="https://github.com/user-attachments/assets/53ed5e2a-6936-4fea-bdd2-daa3659054f0" />

You properly get:

<img width="1824" height="1824" alt=" - LV624 2026-02-27 033135" src="https://github.com/user-attachments/assets/7e086335-9521-4323-a42f-5f190df29e76" />

</details>

# Changelog
:cl: Drathek
fix: Mass screenshot verb will now optionally disable all open_space blur planes instead of just the first
/:cl:
