### PR TITLE
Plasteel cades no longer upgradeable

### DIFF
--- a/code/game/objects/structures/barricade/non_folding.dm
+++ b/code/game/objects/structures/barricade/non_folding.dm
@@ -19,6 +19,7 @@
 	var/build_state = BARRICADE_BSTATE_SECURED //Look at __game.dm for barricade defines
 	var/upgrade = null
 	var/refund_type = /obj/item/stack/sheet/metal
+	var/upgradable = TRUE
 
 	welder_lower_damage_limit = BARRICADE_DMG_HEAVY
 
@@ -91,6 +92,9 @@
 					return
 				if(upgraded)
 					to_chat(user, SPAN_NOTICE("This barricade is already upgraded."))
+					return
+				if(!upgradable)
+					to_chat(user, SPAN_WARNING("This type of fortification cannot be upgraded any further!"))
 					return
 				var/obj/item/stack/sheet/metal/metal = item
 				if(user.client?.prefs?.no_radials_preference)
@@ -301,5 +305,6 @@
 	stack_amount = 6
 	destroyed_stack_amount = 3
 	barricade_type = "new_plasteel"
+	upgradable = FALSE
 	repair_materials = list("plasteel" = 0.45)
 


### PR DESCRIPTION

# About the pull request

Title

# Explain why it's good for the game

Plasteel cades are are already incredibly strong, they do not need the health upgrade from the upgrade.

Before anyone leaves feedback or comment ssaying "but erm, plasteel is more expensive and rare!" yes its why people use it for folding cades, its intended use, barricades are an emergency option.

Folding cades should also be removed- since they have basically made plasteel nothing but a barricade only material, but that will maybe come at a later date depending on how this goes.

Please remember that the amount of health they get is also multiplied when an upgrade hits, not only that but combined witth nailguns (sure rare) but also the fact that you can repair them even with a blowtorch from a tile away- it makes some scenarios absurd as a xeno.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Plasteel barricades are no longer upgradeable.
/:cl:
