### PR TITLE
Rewrite hallucinations for better(ish) code quality

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -11,232 +11,188 @@ Gunshots/explosions/opening doors/less rare audio (done)
 
 */
 
-/mob/living/carbon/var
-	image/halimage
-	image/halbody
-	obj/halitem
-	hal_screwyhud = 0 //1 - critical, 2 - dead, 3 - oxygen indicator, 4 - toxin indicator
-	handling_hal = 0
-	hal_crit = 0
+/mob/living/carbon
+	var/image/halimage
+	var/image/halbody
+	var/obj/halitem
+	var/hal_screwyhud = 0 //1 - critical, 2 - dead, 3 - oxygen indicator, 4 - toxin indicator
+	var/handling_hal = FALSE
+	var/hal_crit = FALSE
 
 /mob/living/carbon/proc/handle_hallucinations()
 	if(handling_hal)
 		return
-	handling_hal = 1
-	while(client && hallucination > 20)
-		sleep(rand(200,500)/(hallucination/25))
-		var/halpick = rand(1,100)
-		if(QDELETED(client) || isnull(client.prefs))
-			continue
-		switch(halpick)
-			if(0 to 15)
-				//Screwy HUD
-				//to_chat(src, "Screwy HUD.")
-				hal_screwyhud = pick(1,2,3,3,4,4)
-				spawn(rand(100,250))
-					hal_screwyhud = 0
-			if(16 to 25)
-				//Strange items
-				//to_chat(src, "Traitor Items.")
-				if(!halitem)
-					halitem = new
-					var/datum/custom_hud/ui_datum = GLOB.custom_huds_list[client.prefs.UI_style]
-					var/list/slots_free = list(ui_datum.ui_lhand, ui_datum.ui_rhand)
-					if(l_hand)
-						slots_free -= ui_datum.ui_lhand
-					if(r_hand)
-						slots_free -= ui_datum.ui_rhand
-					if(ishuman(src))
-						var/mob/living/carbon/human/H = src
-						if(!H.belt)
-							slots_free += ui_datum.ui_belt
-						if(!H.l_store)
-							slots_free += ui_datum.ui_storage1
-						if(!H.r_store)
-							slots_free += ui_datum.ui_storage2
-					if(length(slots_free))
-						halitem.screen_loc = pick(slots_free)
-						halitem.layer = 50
-						switch(rand(1,6))
-							if(1) //revolver
-								halitem.icon = 'icons/obj/items/weapons/guns/guns_by_faction/USCM/revolvers.dmi'
-								halitem.icon_state = "m44r"
-								halitem.name = "Revolver"
-							if(2) //c4
-								halitem.icon = 'icons/obj/items/assemblies.dmi'
-								halitem.icon_state = "plastic-explosive0"
-								halitem.name = "Mysterious Package"
-								if(prob(25))
-									halitem.icon_state = "c4small_1"
-							if(3) //sword
-								halitem.icon = 'icons/obj/items/weapons/melee/swords.dmi'
-								halitem.icon_state = "sword1"
-								halitem.name = "Sword"
-							if(4) //stun baton
-								halitem.icon = 'icons/obj/items/weapons/melee/non_lethal.dmi'
-								halitem.icon_state = "stunbaton"
-								halitem.name = "Stun Baton"
-							if(5) //emag
-								halitem.icon = 'icons/obj/items/card.dmi'
-								halitem.icon_state = "emag"
-								halitem.name = "Cryptographic Sequencer"
-							if(6) //flashbang
-								halitem.icon = 'icons/obj/items/weapons/grenade.dmi'
-								halitem.icon_state = "flashbang1"
-								halitem.name = "Flashbang"
-						if(client)
-							client.add_to_screen(halitem)
-						spawn(rand(100,250))
-							if(client)
-								client.remove_from_screen(halitem)
-							halitem = null
-			if(26 to 40)
-				//Flashes of danger
-				//to_chat(src, "Danger Flash")
-				if(!halimage)
-					var/list/possible_points = list()
-					for(var/turf/open/floor/F in view(src,GLOB.world_view_size))
-						possible_points += F
-					if(length(possible_points))
-						var/turf/open/floor/target = pick(possible_points)
+	handling_hal = TRUE
+	addtimer(CALLBACK(src, PROC_REF(do_hallucination)), rand(20 SECONDS,50 SECONDS)/(hallucination/25))
 
-						switch(rand(1,3))
-							if(1)
-								//to_chat(src, "Space")
-								halimage = image('icons/turf/floors/space.dmi',target,"[rand(1,25)]",TURF_LAYER)
-							if(2)
-								//to_chat(src, "Fire")
-								halimage = image('icons/effects/fire.dmi',target,"1",TURF_LAYER)
-							if(3)
-								//to_chat(src, "C4")
-								halimage = image('icons/obj/items/assemblies.dmi',target,"plastic-explosive2",OBJ_LAYER+0.01)
+/mob/living/carbon/proc/do_hallucination()
+	if(!hallucination)
+		handling_hal = FALSE
+		return
+	var/halpick = rand(1,100)
+	if(!client || !hud_used?.ui_datum)
+		handling_hal = FALSE
+		return
+	switch(halpick)
+		if(0 to 15)
+			//Screwy HUD
+			//to_chat(src, "Screwy HUD.")
+			hal_screwyhud = pick(1,2,3,3,4,4)
+			addtimer(VARSET_CALLBACK(src,hal_screwyhud, 0), rand(10 SECONDS, 25 SECONDS))
+		if(16 to 25)
+			//Strange items
+			//to_chat(src, "Traitor Items.")
+			if(!halitem)
+				halitem = new
+				var/datum/custom_hud/ui_datum = hud_used.ui_datum
+				var/list/slots_free = list(ui_datum.ui_lhand, ui_datum.ui_rhand)
+				if(l_hand)
+					slots_free -= ui_datum.ui_lhand
+				if(r_hand)
+					slots_free -= ui_datum.ui_rhand
+				if(ishuman(src))
+					var/mob/living/carbon/human/H = src
+					if(!H.belt)
+						slots_free += ui_datum.ui_belt
+					if(!H.l_store)
+						slots_free += ui_datum.ui_storage1
+					if(!H.r_store)
+						slots_free += ui_datum.ui_storage2
+				if(length(slots_free))
+					halitem.screen_loc = pick(slots_free)
+					halitem.layer = 50
+					switch(rand(1,6))
+						if(1) //revolver
+							halitem.icon = 'icons/obj/items/weapons/guns/guns_by_faction/USCM/revolvers.dmi'
+							halitem.icon_state = "m44r"
+							halitem.name = "Revolver"
+						if(2) //c4
+							halitem.icon = 'icons/obj/items/assemblies.dmi'
+							halitem.icon_state = "plastic-explosive0"
+							halitem.name = "Mysterious Package"
+							if(prob(25))
+								halitem.icon_state = "c4small_1"
+						if(3) //sword
+							halitem.icon = 'icons/obj/items/weapons/melee/swords.dmi'
+							halitem.icon_state = "sword1"
+							halitem.name = "Sword"
+						if(4) //stun baton
+							halitem.icon = 'icons/obj/items/weapons/melee/non_lethal.dmi'
+							halitem.icon_state = "stunbaton"
+							halitem.name = "Stun Baton"
+						if(5) //emag
+							halitem.icon = 'icons/obj/items/card.dmi'
+							halitem.icon_state = "emag"
+							halitem.name = "Cryptographic Sequencer"
+						if(6) //flashbang
+							halitem.icon = 'icons/obj/items/weapons/grenade.dmi'
+							halitem.icon_state = "flashbang1"
+							halitem.name = "Flashbang"
+					if(client)
+						client.add_to_screen(halitem)
+					var/time_to_wait = rand(1 SECONDS, 5 SECONDS) //Only seen for a brief moment.
+					// We use timers here because then being deleted will cancel them and avoid causing harddels.
+					addtimer(CALLBACK(client, TYPE_PROC_REF(/client, remove_from_screen), halitem), time_to_wait)
+					addtimer(VARSET_CALLBACK(src, halitem, null), time_to_wait)
+					QDEL_IN(halitem, time_to_wait) // it's an object and so needs to be deleted
+		if(26 to 40)
+			//Flashes of danger
+			//to_chat(src, "Danger Flash")
+			if(!halimage)
+				var/list/possible_points = list()
+				for(var/turf/open/floor/F in view(src,GLOB.world_view_size))
+					possible_points += F
+				if(length(possible_points))
+					var/turf/open/floor/target = pick(possible_points)
 
+					switch(rand(1,3))
+						if(1)
+							//to_chat(src, "Space")
+							halimage = image('icons/turf/floors/space.dmi',target,"[rand(1,25)]",TURF_LAYER)
+						if(2)
+							//to_chat(src, "Fire")
+							halimage = image('icons/effects/fire.dmi',target,"1",TURF_LAYER)
+						if(3)
+							//to_chat(src, "C4")
+							halimage = image('icons/obj/items/assemblies.dmi',target,"plastic-explosive2",OBJ_LAYER+0.01)
 
-						if(client)
-							client.images += halimage
-						spawn(rand(10,50)) //Only seen for a brief moment.
-							if(client)
-								client.images -= halimage
-							halimage = null
-
-
-			if(41 to 65)
-				//Strange audio
-				//to_chat(src, "Strange Audio.")
-				switch(rand(1,12))
-					if(1)
-						src << 'sound/machines/airlock.ogg'
-					if(2)
-						if(prob(50))src << 'sound/effects/Explosion1.ogg'
-						else
-							src << 'sound/effects/Explosion2.ogg'
-					if(3)
-						src << 'sound/effects/explosionfar.ogg'
-					if(4)
-						src << 'sound/effects/Glassbr1.ogg'
-					if(5)
-						src << 'sound/effects/Glassbr2.ogg'
-					if(6)
-						src << 'sound/effects/Glassbr3.ogg'
-					if(7)
-						src << 'sound/machines/twobeep.ogg'
-					if(8)
-						src << 'sound/machines/windowdoor.ogg'
-					if(9)
-						//To make it more realistic, I added two gunshots (enough to kill)
+					if(client)
+						client.images += halimage
+					var/time_to_wait = rand(1 SECONDS, 5 SECONDS) //Only seen for a brief moment.
+					// We use timers here because then being deleted will cancel them and avoid causing harddels.
+					addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(remove_image_from_client), halimage, client), time_to_wait)
+					addtimer(VARSET_CALLBACK(src, halimage, null), time_to_wait)
+		if(41 to 65)
+			//Strange audio
+			//to_chat(src, "Strange Audio.")
+			switch(rand(1,12))
+				if(1)
+					src << 'sound/machines/airlock.ogg'
+				if(2)
+					src << pick('sound/effects/Explosion1.ogg', 'sound/effects/Explosion2.ogg')
+				if(3)
+					src << 'sound/effects/explosionfar.ogg'
+				if(4)
+					src << 'sound/effects/Glassbr1.ogg'
+				if(5)
+					src << 'sound/effects/Glassbr2.ogg'
+				if(6)
+					src << 'sound/effects/Glassbr3.ogg'
+				if(7)
+					src << 'sound/machines/twobeep.ogg'
+				if(8)
+					src << 'sound/machines/windowdoor.ogg'
+				if(9)
+					//To make it more realistic, I added two gunshots (enough to kill)
+					src << 'sound/weapons/Gunshot.ogg'
+					spawn(rand(1 SECONDS,3 SECONDS))
 						src << 'sound/weapons/Gunshot.ogg'
-						spawn(rand(10,30))
-							src << 'sound/weapons/Gunshot.ogg'
-					if(10)
-						src << 'sound/weapons/smash.ogg'
-					if(11)
-						//Same as above, but with tasers.
+				if(10)
+					src << 'sound/weapons/smash.ogg'
+				if(11)
+					//Same as above, but with tasers.
+					src << 'sound/weapons/Taser.ogg'
+					spawn(rand(1 SECONDS,3 SECONDS))
 						src << 'sound/weapons/Taser.ogg'
-						spawn(rand(10,30))
-							src << 'sound/weapons/Taser.ogg'
-				//Rare audio
-					if(12)
+			//Rare audio
+				if(12)
 //These sounds are (mostly) taken from Hidden: Source
-						var/list/creepyasssounds = list('sound/effects/ghost.ogg', 'sound/effects/ghost2.ogg', 'sound/effects/Heart Beat.ogg', 'sound/effects/screech.ogg',\
-							'sound/hallucinations/behind_you1.ogg', 'sound/hallucinations/behind_you2.ogg', 'sound/hallucinations/far_noise.ogg', 'sound/hallucinations/growl1.ogg', 'sound/hallucinations/growl2.ogg',\
-							'sound/hallucinations/growl3.ogg', 'sound/hallucinations/im_here1.ogg', 'sound/hallucinations/im_here2.ogg', 'sound/hallucinations/i_see_you1.ogg', 'sound/hallucinations/i_see_you2.ogg',\
-							'sound/hallucinations/look_up1.ogg', 'sound/hallucinations/look_up2.ogg', 'sound/hallucinations/over_here1.ogg', 'sound/hallucinations/over_here2.ogg', 'sound/hallucinations/over_here3.ogg',\
-							'sound/hallucinations/turn_around1.ogg', 'sound/hallucinations/turn_around2.ogg', 'sound/hallucinations/veryfar_noise.ogg', 'sound/hallucinations/wail.ogg')
-						src << pick(creepyasssounds)
-			if(66 to 70)
-				//Flashes of danger
-				//to_chat(src, "Danger Flash")
-				if(!halbody)
-					var/list/possible_points = list()
-					for(var/turf/open/floor/F in view(src,GLOB.world_view_size))
-						possible_points += F
-					if(length(possible_points))
-						var/turf/open/floor/target = pick(possible_points)
-						switch(rand(1,3))
-							if(1)
-								halbody = image('icons/mob/humans/human.dmi',target,"husk_l",TURF_LAYER)
-							if(2,3)
-								halbody = image('icons/mob/humans/human.dmi',target,"husk_s",TURF_LAYER)
-	// if(5)
-	// halbody = image('xcomalien.dmi',target,"chryssalid",TURF_LAYER)
-
-						if(client)
-							client.images += halbody
-						spawn(rand(50,80)) //Only seen for a brief moment.
-							if(client)
-								client.images -= halbody
-							halbody = null
-			if(71 to 72)
-				//Fake death
-// src.sleeping_willingly = 1
-				src.sleeping = 20
-				hal_crit = 1
-				hal_screwyhud = 1
-				spawn(rand(50,100))
-// src.sleeping_willingly = 0
-					src.sleeping = 0
-					hal_crit = 0
-					hal_screwyhud = 0
-	handling_hal = 0
-
-
-
-
-/*obj/structure/machinery/proc/mockpanel(list/buttons,start_txt,end_txt,list/mid_txts)
-
-	if(!mocktxt)
-
-		mocktxt = ""
-
-		var/possible_txt = list("Launch Escape Pods","Self-Destruct Sequence","\[Swipe ID\]","De-Monkify",\
-		"Reticulate Splines","Plasma","Open Valve","Lockdown","Nerf Airflow","Kill Traitor","Nihilism",\
-		"OBJECTION!","Arrest Stephen Bowman","Engage Anti-Trenna Defenses","Increase Captain IQ","Retrieve Arms",\
-		"Play Charades","Oxygen","Inject BeAcOs","Ninja Lizards","Limit Break","Build Sentry")
-
-		if(mid_txts)
-			while(length(mid_txts))
-				var/mid_txt = pick(mid_txts)
-				mocktxt += mid_txt
-				mid_txts -= mid_txt
-
-		while(length(buttons))
-
-			var/button = pick(buttons)
-
-			var/button_txt = pick(possible_txt)
-
-			mocktxt += "<a href='byond://?src=\ref[src];[button]'>[button_txt]</a><br>"
-
-			buttons -= button
-			possible_txt -= button_txt
-
-	return start_txt + mocktxt + end_txt + "</TT></BODY></HTML>"
-
-/proc/check_panel(mob/M)
-	if (istype(M, /mob/living/carbon/human) || isRemoteControlling(M))
-		if(M.hallucination < 15)
-			return 1
-	return 0*/
+					var/list/creepyasssounds = list('sound/effects/ghost.ogg', 'sound/effects/ghost2.ogg', 'sound/effects/Heart Beat.ogg', 'sound/effects/screech.ogg',\
+						'sound/hallucinations/behind_you1.ogg', 'sound/hallucinations/behind_you2.ogg', 'sound/hallucinations/far_noise.ogg', 'sound/hallucinations/growl1.ogg', 'sound/hallucinations/growl2.ogg',\
+						'sound/hallucinations/growl3.ogg', 'sound/hallucinations/im_here1.ogg', 'sound/hallucinations/im_here2.ogg', 'sound/hallucinations/i_see_you1.ogg', 'sound/hallucinations/i_see_you2.ogg',\
+						'sound/hallucinations/look_up1.ogg', 'sound/hallucinations/look_up2.ogg', 'sound/hallucinations/over_here1.ogg', 'sound/hallucinations/over_here2.ogg', 'sound/hallucinations/over_here3.ogg',\
+						'sound/hallucinations/turn_around1.ogg', 'sound/hallucinations/turn_around2.ogg', 'sound/hallucinations/veryfar_noise.ogg', 'sound/hallucinations/wail.ogg')
+					src << pick(creepyasssounds)
+		if(66 to 70)
+			//Flashes of danger
+			//to_chat(src, "Danger Flash")
+			if(!halbody)
+				var/list/possible_points = list()
+				for(var/turf/open/floor/F in view(src,GLOB.world_view_size))
+					possible_points += F
+				if(length(possible_points))
+					var/turf/open/floor/target = pick(possible_points)
+					switch(rand(1,3))
+						if(1)
+							halbody = image('icons/mob/humans/human.dmi',target,"husk_l",TURF_LAYER)
+						if(2,3)
+							halbody = image('icons/mob/humans/human.dmi',target,"husk_s",TURF_LAYER)
+					if(client)
+						client.images += halbody
+					var/time_to_wait = rand(5 SECONDS, 8 SECONDS) //Only seen for a brief moment.
+					// We use timers here because then being deleted will cancel them and avoid causing harddels.
+					addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(remove_image_from_client), halbody, client), time_to_wait)
+					addtimer(VARSET_CALLBACK(src, halbody, null), time_to_wait)
+		if(71 to 72)
+			//Fake death
+			sleeping = 2 SECONDS
+			hal_crit = TRUE
+			hal_screwyhud = TRUE
+			var/time_to_wait = rand(5 SECONDS, 10 SECONDS)
+			addtimer(VARSET_CALLBACK(src,hal_screwyhud, 0), time_to_wait)
+			addtimer(VARSET_CALLBACK(src,hal_crit, 0), time_to_wait)
+			addtimer(VARSET_CALLBACK(src,sleeping, 0), time_to_wait)
+	handling_hal = FALSE
 
 /obj/effect/fake_attacker
 	icon = null
@@ -246,50 +202,62 @@ Gunshots/explosions/opening doors/less rare audio (done)
 	density = FALSE
 	anchored = TRUE
 	opacity = FALSE
-	var/mob/living/carbon/human/my_target = null
+	health = 100
+	var/datum/weakref/weak_target = null
 	var/weapon_name = null
-	var/obj/item/weap = null
+	var/list/copied_attack_verbs
 	var/image/currentimage = null
 	var/image/left
 	var/image/right
 	var/image/up
-	var/collapse
 	var/image/down
-
-	health = 100
+	var/collapse
+	var/skipped_last_turn = FALSE
+	// seconds per tile, to convert to pixels per second do world.icon_size/move_delay
+	var/move_delay = 2
 
 /obj/effect/fake_attacker/attackby(obj/item/P as obj, mob/user as mob)
-	step_away(src,my_target,2)
-	for(var/mob/M in oviewers(GLOB.world_view_size,my_target))
-		to_chat(M, SPAN_WARNING("<B>[my_target] flails around wildly.</B>"))
-	my_target.show_message(SPAN_DANGER("<B>[src] has been attacked by [my_target] </B>"), SHOW_MESSAGE_VISIBLE) //Lazy.
-
+	if(user.weak_reference != weak_target)
+		return
+	step_away(src,user,2,world.icon_size/move_delay)
+	for(var/mob/M in oviewers(GLOB.world_view_size,user))
+		to_chat(M, SPAN_WARNING("<B>[user] flails around wildly.</B>"))
+	user << sound(pick('sound/weapons/genhit1.ogg', 'sound/weapons/genhit2.ogg', 'sound/weapons/genhit3.ogg'))
+	user.show_message(SPAN_DANGER("<B>[src] has been attacked by [user] </B>"), SHOW_MESSAGE_VISIBLE) //Lazy.
 	src.health -= P.force
 
-
-	return
-
 /obj/effect/fake_attacker/Crossed(mob/M, somenumber)
-	if(M == my_target)
-		step_away(src,my_target,2)
-		if(prob(30))
-			for(var/mob/O in oviewers(GLOB.world_view_size , my_target))
-				to_chat(O, SPAN_DANGER("<B>[my_target] stumbles around.</B>"))
+	if(M.weak_reference != weak_target)
+		return
+	step_away(src,M,2,world.icon_size/move_delay)
+	if(prob(30))
+		for(var/mob/O in oviewers(GLOB.world_view_size, M))
+			to_chat(O, SPAN_DANGER("<B>[M] stumbles around.</B>"))
 
-/obj/effect/fake_attacker/New()
-	..()
-	spawn(30 SECONDS)
-		if(my_target)
-			my_target.hallucinations -= src
-		qdel(src)
-	step_away(src,my_target,2)
-	spawn attack_loop()
+/obj/effect/fake_attacker/Initialize(mapload, mob/target_to_use, mob/living/carbon/human/clone, clone_weapon_name, attack_verbs_to_copy)
+	. = ..()
+	if(!target_to_use || !clone)
+		return INITIALIZE_HINT_QDEL
+	QDEL_IN(src, 30 SECONDS)
+	weak_target = WEAKREF(target_to_use)
+	name = clone.name
+	weapon_name = clone_weapon_name
+	copied_attack_verbs = attack_verbs_to_copy
+	move_delay = clone.move_delay
+	// target must be set before we call updateimage
+	left = image(clone, dir = WEST)
+	right = image(clone, dir = EAST)
+	up = image(clone, dir = NORTH)
+	down = image(clone, dir = SOUTH)
+	updateimage()
+	step_away(src, target_to_use, 2,world.icon_size/move_delay)
+	START_PROCESSING(SSfastobj, src)
 
 /obj/effect/fake_attacker/Destroy()
+	var/mob/living/carbon/human/my_target = weak_target.resolve()
 	if(my_target)
+		remove_image_from_client(currentimage, my_target.client)
 		my_target.hallucinations -= src
-		my_target = null
-	weap = null
 	currentimage = null
 	left = null
 	right = null
@@ -298,102 +266,113 @@ Gunshots/explosions/opening doors/less rare audio (done)
 	return ..()
 
 /obj/effect/fake_attacker/proc/updateimage()
-	if(src.dir == NORTH)
-		src.currentimage = new /image(up,src)
-	else if(src.dir == SOUTH)
-		src.currentimage = new /image(down,src)
-	else if(src.dir == EAST)
-		src.currentimage = new /image(right,src)
-	else if(src.dir == WEST)
-		src.currentimage = new /image(left,src)
+	var/mob/living/carbon/human/my_target = weak_target.resolve()
+	if(!my_target)
+		qdel(src)
+		return
+	my_target.client?.images -= currentimage
+	switch(dir)
+		if(NORTH)
+			currentimage = new /image(up,src)
+		if(SOUTH)
+			currentimage = new /image(down,src)
+		if(EAST)
+			currentimage = new /image(right,src)
+		if(WEST)
+			currentimage = new /image(left,src)
+	if(collapse)
+		currentimage.transform = currentimage.transform.Turn(90)
 	my_target << currentimage
 
+/obj/effect/fake_attacker/process()
+	var/mob/living/carbon/human/my_target = weak_target.resolve()
+	if(!my_target) // they vanished on us!
+		qdel(src)
+		return PROCESS_KILL
+	if(health < 0)
+		collapse()
+		animate(src, alpha = 0, time = 1 SECONDS)
+		QDEL_IN_CLIENT_TIME(src, 1 SECONDS)
+		return PROCESS_KILL // dead!
+	if(!skipped_last_turn && prob(50)) // The old one would wait either 0.5 or 1 second, we always wait 0.5, so we skip sometimes.
+		skipped_last_turn = TRUE
+		return
+	skipped_last_turn = FALSE
+	if(get_dist(src,my_target) > 1)
+		var/true_direction = get_dir(src,my_target) // can be diagonal
+		var/cardinal_direction = true_direction & -(true_direction) // gets the first-set bit
+		setDir(cardinal_direction)
+		step_towards(src,my_target,world.icon_size/move_delay)
+		updateimage()
+		return
 
-/obj/effect/fake_attacker/proc/attack_loop()
-	while(1)
-		sleep(rand(5,10))
-		if(src.health < 0)
-			collapse()
-			continue
-		if(get_dist(src,my_target) > 1)
-			setDir(get_dir(src,my_target))
-			step_towards(src,my_target)
-			updateimage()
+	if(prob(15))
+		var/hit_zone = rand_zone()
+		if(weapon_name)
+			my_target << sound(pick('sound/weapons/genhit1.ogg', 'sound/weapons/genhit2.ogg', 'sound/weapons/genhit3.ogg'))
+			var/verb_to_use = "attacked"
+			if(LAZYLEN(copied_attack_verbs))
+				verb_to_use = pick(copied_attack_verbs)
+			my_target.show_message(SPAN_DANGER("<B>[my_target] has been [verb_to_use] with [weapon_name] in the [parse_zone(hit_zone)] by [src.name].</B>"), SHOW_MESSAGE_VISIBLE)
+			my_target.halloss += 8
+			if(prob(20))
+				my_target.AdjustEyeBlur(3)
+			if(prob(33))
+				if(!locate(/obj/effect/overlay) in my_target.loc)
+					fake_blood(my_target)
 		else
-			if(prob(15))
-				if(weapon_name)
-					my_target << sound(pick('sound/weapons/genhit1.ogg', 'sound/weapons/genhit2.ogg', 'sound/weapons/genhit3.ogg'))
-					my_target.show_message(SPAN_DANGER("<B>[my_target] has been attacked with [weapon_name] by [src.name] </B>"), SHOW_MESSAGE_VISIBLE)
-					my_target.halloss += 8
-					if(prob(20))
-						my_target.AdjustEyeBlur(3)
-					if(prob(33))
-						if(!locate(/obj/effect/overlay) in my_target.loc)
-							fake_blood(my_target)
-				else
-					my_target << sound(pick('sound/weapons/punch1.ogg','sound/weapons/punch2.ogg','sound/weapons/punch3.ogg','sound/weapons/punch4.ogg'))
-					my_target.show_message(SPAN_DANGER("<B>[src.name] has punched [my_target]!</B>"), SHOW_MESSAGE_VISIBLE)
-					my_target.halloss += 4
-					if(prob(33))
-						if(!locate(/obj/effect/overlay) in my_target.loc)
-							fake_blood(my_target)
+			my_target << sound(pick('sound/weapons/punch1.ogg','sound/weapons/punch2.ogg','sound/weapons/punch3.ogg','sound/weapons/punch4.ogg'))
+			my_target.show_message(SPAN_DANGER("<B>[src.name] has punched [my_target]!</B>"), SHOW_MESSAGE_VISIBLE)
+			my_target.halloss += 4
+			if(prob(33))
+				if(!locate(/obj/effect/overlay) in my_target.loc)
+					fake_blood(my_target)
 
-		if(prob(15))
-			step_away(src,my_target,2)
+	if(prob(15)) // if we're adjacent we have a chance to move away
+		step_away(src,my_target,2,world.icon_size/move_delay)
 
 /obj/effect/fake_attacker/proc/collapse()
-	collapse = 1
+	collapse = TRUE
 	updateimage()
 
+// not actually visible, has a per-client override
+/obj/effect/overlay/fake_blood
+	name = "blood"
+	// not visible to anyone, it's just overridden by the object
+
 /proc/fake_blood(mob/target)
-	var/obj/effect/overlay/O = new/obj/effect/overlay(target.loc)
-	O.name = "blood"
-	var/image/I = image('icons/effects/blood.dmi',O,"floor[rand(1,7)]",O.dir,1)
+	var/obj/effect/overlay/fake_blood/O = new/obj/effect/overlay/fake_blood(target.loc)
+	var/image/I = image('icons/effects/blood.dmi',O,"mfloor[rand(1,7)]", dir = O.dir, layer = ABOVE_WEED_LAYER)
+	I.color = /obj/effect/decal/cleanable/blood::basecolor // it's greyscale now
+	I.override = TRUE
 	target << I
 	QDEL_IN(O, 30 SECONDS)
-	return
 
 GLOBAL_LIST_INIT(non_fakeattack_weapons, list(/obj/item/device/aicard,\
 	/obj/item/clothing/shoes/magboots, /obj/item/disk/nuclear,\
 	/obj/item/clothing/suit/space/uscm, /obj/item/tank))
 
 /proc/fake_attack(mob/living/target)
-// var/list/possible_clones = new/list()
+	var/list/possible_clones = new/list()
 	var/mob/living/carbon/human/clone = null
 	var/clone_weapon = null
 
-	for(var/mob/living/carbon/human/H in GLOB.alive_mob_list)
+	for(var/mob/living/carbon/human/H in GLOB.alive_human_list)
 		if(H.stat)
 			continue
-// possible_clones += H
-		clone = H
-		break //changed the code a bit. Less randomised, but less work to do. Should be ok, world.contents aren't stored in any particular order.
+		possible_clones += H
 
-// if(!length(possible_clones)) return
-// clone = pick(possible_clones)
+	if(!length(possible_clones))
+		return
+	clone = pick(possible_clones)
 	if(!clone)
 		return
 
-	//var/obj/effect/fake_attacker/F = new/obj/effect/fake_attacker(outside_range(target))
-	var/obj/effect/fake_attacker/F = new/obj/effect/fake_attacker(target.loc)
-	if(clone.l_hand)
-		if(!(locate(clone.l_hand) in GLOB.non_fakeattack_weapons))
-			clone_weapon = clone.l_hand.name
-			F.weap = clone.l_hand
-	else if (clone.r_hand)
-		if(!(locate(clone.r_hand) in GLOB.non_fakeattack_weapons))
-			clone_weapon = clone.r_hand.name
-			F.weap = clone.r_hand
-
-	F.name = clone.name
-	F.my_target = target
-	F.weapon_name = clone_weapon
-	target.hallucinations += F
-
-
-	F.left = image(clone,dir = WEST)
-	F.right = image(clone,dir = EAST)
-	F.up = image(clone,dir = NORTH)
-	F.down = image(clone,dir = SOUTH)
-
-	F.updateimage()
+	var/list/attack_verbs_to_copy
+	if(clone.l_hand && !is_type_in_list(clone.l_hand, GLOB.non_fakeattack_weapons))
+		clone_weapon = clone.l_hand.name
+		attack_verbs_to_copy = clone.l_hand.attack_verb
+	else if(clone.r_hand && !is_type_in_list(clone.r_hand, GLOB.non_fakeattack_weapons))
+		clone_weapon = clone.r_hand.name
+		attack_verbs_to_copy = clone.r_hand.attack_verb
+	new /obj/effect/fake_attacker(target.loc, target, clone, clone_weapon, attack_verbs_to_copy)

--- a/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
@@ -8,128 +8,124 @@
 	if(stat == DEAD) //DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
 		blinded = TRUE
 		silent = 0
-	else //ALIVE. LIGHTS ARE ON
+		return 1
+	//ALIVE. LIGHTS ARE ON
+	if(regular_update)
+		switch(hallucination)
+			if(20 to INFINITY)
+				if(prob(3))
+					fake_attack(src)
+				handle_hallucinations()
+				hallucination -= 2
+			if(2 to 20)
+				hallucination -= 2
+			if(0 to 2)
+				hallucination = 0
+				halloss = 0
+			if(-INFINITY to 0)
+				QDEL_LIST(hallucinations)
+		// for some reason halloss only worked when you had no hallucination left? which i assume is unintended bc then it would never run
+		if(halloss > 100)
+			visible_message(SPAN_WARNING("\The [src] slumps to the ground, too weak to continue fighting."),
+			SPAN_WARNING("You slump to the ground, you're in too much pain to keep going."))
+			apply_effect(10, PARALYZE)
+			setHalLoss(99)
+
+	//UNCONSCIOUS. NO-ONE IS HOME
+	if(regular_update && ((getOxyLoss() > 50)))
+		apply_effect(3, PARALYZE)
+
+	if((species.flags & HAS_HARDCRIT) && health_threshold_crit > health)
+		var/already_in_crit = FALSE
+		for(var/datum/effects/crit/C in effects_list)
+			already_in_crit = TRUE
+			break
+		// Need to only apply if its not already active
+		if(!already_in_crit)
+			new /datum/effects/crit/human(src)
+
+	if(IsKnockOut())
+		blinded = TRUE
+		if(regular_update && halloss > 0)
+			apply_damage(-3, HALLOSS)
+	else if(sleeping)
 		if(regular_update)
-			if(hallucination)
-				if(hallucination >= 20)
-					if(prob(3))
-						fake_attack(src)
-					if(!handling_hal)
-						INVOKE_ASYNC(src, TYPE_PROC_REF(/mob/living/carbon, handle_hallucinations))
+			handle_dreams()
+			apply_damage(-3, HALLOSS)
+			if(mind)
+				if((mind.active && client != null) || immune_to_ssd) //This also checks whether a client is connected, if not, sleep is not reduced.
+					sleeping = max(sleeping - 1, 0)
+			if(prob(2) && health && !hal_crit)
+				addtimer(CALLBACK(src, PROC_REF(emote), "snore"))
+		blinded = TRUE
+		set_stat(UNCONSCIOUS)
+	else
+		set_stat(CONSCIOUS)
 
-				if(hallucination <= 2)
-					hallucination = 0
-					halloss = 0
-				else
-					hallucination -= 2
+	if(in_stasis == STASIS_IN_CRYO_CELL)
+		blinded = TRUE //Always blinded while in stasisTUBES
 
-			else
-				for(var/atom/a in hallucinations)
-					hallucinations -= a
-					qdel(a)
+	if(!regular_update)
+		return
+	//Eyes
+	if(!species.has_organ["eyes"]) //Presumably if a species has no eyes, they see via something else.
+		SetEyeBlind(0)
+		if(stat == CONSCIOUS) //even with 'eye-less' vision, unconsciousness makes you blind
+			blinded = FALSE
+		SetEyeBlur(0)
+	else if(!has_eyes()) //Eyes cut out? Permablind.
+		SetEyeBlind(1)
+		blinded = 1
+		// we don't need to blur vision if they are blind...
+	else if(eye_blind) //Blindness, heals slowly over time
+		ReduceEyeBlind(1)
+		blinded = TRUE
+	else if(eye_blurry) //Blurry eyes heal slowly
+		ReduceEyeBlur(1)
 
-				if(halloss > 100)
-					visible_message(SPAN_WARNING("\The [src] slumps to the ground, too weak to continue fighting."),
-					SPAN_WARNING("You slump to the ground, you're in too much pain to keep going."))
-					apply_effect(10, PARALYZE)
-					setHalLoss(99)
-
-		//UNCONSCIOUS. NO-ONE IS HOME
-		if(regular_update && ((getOxyLoss() > 50)))
-			apply_effect(3, PARALYZE)
-
-		if((species.flags & HAS_HARDCRIT) && health_threshold_crit > health)
-			var/already_in_crit = FALSE
-			for(var/datum/effects/crit/C in effects_list)
-				already_in_crit = TRUE
-				break
-			// Need to only apply if its not already active
-			if(!already_in_crit)
-				new /datum/effects/crit/human(src)
-
-		if(IsKnockOut())
-			blinded = TRUE
-			if(regular_update && halloss > 0)
-				apply_damage(-3, HALLOSS)
-		else if(sleeping)
-			if(regular_update)
-				handle_dreams()
-				apply_damage(-3, HALLOSS)
-				if(mind)
-					if((mind.active && client != null) || immune_to_ssd) //This also checks whether a client is connected, if not, sleep is not reduced.
-						sleeping = max(sleeping - 1, 0)
-				if(prob(2) && health && !hal_crit)
-					addtimer(CALLBACK(src, PROC_REF(emote), "snore"))
-			blinded = TRUE
-			set_stat(UNCONSCIOUS)
-		else
-			set_stat(CONSCIOUS)
-
-		if(in_stasis == STASIS_IN_CRYO_CELL)
-			blinded = TRUE //Always blinded while in stasisTUBES
-
-		if(!regular_update)
-			return
-		//Eyes
-		if(!species.has_organ["eyes"]) //Presumably if a species has no eyes, they see via something else.
-			SetEyeBlind(0)
-			if(stat == CONSCIOUS) //even with 'eye-less' vision, unconsciousness makes you blind
-				blinded = FALSE
-			SetEyeBlur(0)
-		else if(!has_eyes()) //Eyes cut out? Permablind.
-			SetEyeBlind(1)
-			blinded = 1
-			// we don't need to blur vision if they are blind...
-		else if(eye_blind) //Blindness, heals slowly over time
-			ReduceEyeBlind(1)
-			blinded = TRUE
-		else if(eye_blurry) //Blurry eyes heal slowly
-			ReduceEyeBlur(1)
-
-		//Ears
-		if(ear_deaf) //Deafness, heals slowly over time
-			if(client && client.soundOutput && !(client.soundOutput.status_flags & EAR_DEAF_MUTE))
-				client.soundOutput.status_flags |= EAR_DEAF_MUTE
-				client.soundOutput.apply_status()
-
-			AdjustEarDeafness(-1)
-
-		else if(ear_damage)
-			ear_damage = max(ear_damage - 0.05, 0)
-
-		// This should be done only on updates above, or even better in the AdjustEarDeafness handlers
-		if(!ear_deaf && (client?.soundOutput?.status_flags & EAR_DEAF_MUTE))
-			client.soundOutput.status_flags ^= EAR_DEAF_MUTE
+	//Ears
+	if(ear_deaf) //Deafness, heals slowly over time
+		if(client && client.soundOutput && !(client.soundOutput.status_flags & EAR_DEAF_MUTE))
+			client.soundOutput.status_flags |= EAR_DEAF_MUTE
 			client.soundOutput.apply_status()
 
-		//Resting
-		if(resting)
-			dizziness = max(0, dizziness - 15)
-			jitteriness = max(0, jitteriness - 15)
-			apply_damage(-3, HALLOSS)
-		else
-			dizziness = max(0, dizziness - 3)
-			jitteriness = max(0, jitteriness - 3)
-			apply_damage(-1, HALLOSS)
+		AdjustEarDeafness(-1)
 
-		//Other
-		handle_statuses()
+	else if(ear_damage)
+		ear_damage = max(ear_damage - 0.05, 0)
 
-		if(paralyzed)
-			apply_effect(1, WEAKEN)
-			silent = 1
-			blinded = TRUE
-			use_me = 0
-			pain.apply_pain_reduction(PAIN_REDUCTION_FULL)
-			paralyzed--
+	// This should be done only on updates above, or even better in the AdjustEarDeafness handlers
+	if(!ear_deaf && (client?.soundOutput?.status_flags & EAR_DEAF_MUTE))
+		client.soundOutput.status_flags ^= EAR_DEAF_MUTE
+		client.soundOutput.apply_status()
 
-		if(drowsiness)
-			drowsiness = max(0,drowsiness - 2)
-			EyeBlur(2)
-			if(drowsiness > 10 && prob(5))
-				sleeping++
-				apply_effect(5, PARALYZE)
+	//Resting
+	if(resting)
+		dizziness = max(0, dizziness - 15)
+		jitteriness = max(0, jitteriness - 15)
+		apply_damage(-3, HALLOSS)
+	else
+		dizziness = max(0, dizziness - 3)
+		jitteriness = max(0, jitteriness - 3)
+		apply_damage(-1, HALLOSS)
 
-		confused = max(0, confused - 1)
+	//Other
+	handle_statuses()
 
+	if(paralyzed)
+		apply_effect(1, WEAKEN)
+		silent = 1
+		blinded = TRUE
+		use_me = 0
+		pain.apply_pain_reduction(PAIN_REDUCTION_FULL)
+		paralyzed--
+
+	if(drowsiness)
+		drowsiness = max(0,drowsiness - 2)
+		EyeBlur(2)
+		if(drowsiness > 10 && prob(5))
+			sleeping++
+			apply_effect(5, PARALYZE)
+
+	confused = max(0, confused - 1)
 	return 1


### PR DESCRIPTION
# About the pull request
Hallucinations no longer use long (15-50 second) sleeps in a big loop, and instead just use a timer on a delay in Life(). That may have a performance hit so it could be worth replacing the timer with a spawn, but importantly it removes the loop which I think is good.

fake_attacker also now uses Process() rather than an infinite loop, which should be better for the scheduler as well. I also made it use the attack verb from the weapon chosen, and it no longer hangs a reference to items. It uses a weakref too, which isn't super important since it's not very long-lived, but I figured I may as well.

# Explain why it's good for the game
Makes the code more readable and maintainable, in my eyes at least.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

https://github.com/user-attachments/assets/25c07702-4222-4a83-b84a-32f19692fb21

</details>