### PR TITLE
Optimize create_all_lighting_objects

### DIFF
--- a/code/modules/lighting/lighting_static/static_lighting_setup.dm
+++ b/code/modules/lighting/lighting_static/static_lighting_setup.dm
@@ -1,10 +1,7 @@
 /proc/create_all_lighting_objects()
-	for(var/area/A in world)
-
-		if(!A.static_lighting)
+	for(var/turf/turf in world) // area contents loops are in-world loops, so we may as well do one directly
+		var/area/area = turf.loc
+		if(!area.static_lighting)
 			continue
-		// I hate this so much dude. why do areas not track their turfs lummyyyyyyy
-		for(var/turf/T in A)
-			new/datum/static_lighting_object(T)
-			CHECK_TICK
+		new /datum/static_lighting_object(turf)
 		CHECK_TICK


### PR DESCRIPTION
# About the pull request
Makes create_all_lighting_objects loop over the world once instead of once per area with `static_lighting = TRUE`. This took it from 10 seconds to 6 on my local machine, and didn't seem to cause any issues.

# Explain why it's good for the game
Saves 4 seconds in init time. Won't be necessary once I get #11826 working, but that PR is a doozy.

# Testing Photographs and Procedure
Haven't taken screenshots but it looked fine in conjunction with some other fixes. Need to test it again now that I've separated it into its own branch.

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>