### PR TITLE
Disables Macros

### DIFF
--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -47,8 +47,7 @@
 		//SECURITY//
 		////////////
 	var/next_allowed_topic_time = 10
-	// comment out the line below when debugging locally to enable the options & messages menu
-	//control_freak = 1
+	control_freak = CONTROL_FREAK_MACROS
 
 	var/received_irc_pm = -99999
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -22,21 +22,6 @@
 	set category = "IC"
 	return
 
-/mob
-	var/picksay_cooldown = 0
-
-/mob/verb/picksay_verb(message as text)
-	set name = "Pick-Say"
-	set category = "IC"
-
-	if(picksay_cooldown > world.time)
-		return
-
-	var/list/possible_phrases = splittext(message, ";")
-	if(length(possible_phrases))
-		say_verb(pick(possible_phrases))
-		picksay_cooldown = world.time + 1.5 SECONDS
-
 /mob/verb/say_verb(message as text)
 	set name = "Say"
 	set category = "IC"


### PR DESCRIPTION
# About the pull request
Disabled byond macros, and picksay_verb cause its only used by macros

# Explain why it's good for the game
We have nothing that needs byond macros anymore

# Testing Photographs and Procedure
I didnt test it

# Changelog
:cl:
del: Disables Byond macros
/:cl: