### PR TITLE
Remove Law comment from Oxycodone Bottle

### DIFF
--- a/code/game/objects/items/reagent_containers/glass/bottle.dm
+++ b/code/game/objects/items/reagent_containers/glass/bottle.dm
@@ -384,7 +384,7 @@
 
 /obj/item/reagent_container/glass/bottle/oxycodone
 	name = "\improper Oxycodone bottle"
-	desc = "A small bottle. Contains Oxycodone - Used as an Extreme Painkiller. ILLEGAL TO DISTRIBUTE."
+	desc = "A small bottle. Contains Oxycodone - Used as an Extreme Painkiller. Use with Caution."
 	volume = 60
 	amount_per_transfer_from_this = 60
 


### PR DESCRIPTION

# About the pull request
You're not going to arrest a Doctor for giving one to a Corpsman. This line doesn't need to exist and shouldn't be treated as a directive.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
spellcheck: Removed Illegal to distribute line from Oxycodone bottle
/:cl:
