### PR TITLE
Custom Ability Cursor 

### DIFF
--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -587,7 +587,7 @@ CLIENT_VERB(toggle_custom_cursors)
 	do_toggle_custom_cursors()
 
 /client/proc/do_toggle_custom_cursors(mob/user)
-	var/result = tgui_alert(user, "Do you want custom cursors enabled?", "Custom Cursors", list("Yes", "No", "Enable Main Cursor", "Disable Main Cursor"))
+	var/result = tgui_alert(user, "Do you want custom cursors enabled?", "Custom Cursors", list("Yes", "No", "Enable Main Cursor", "Disable Main Cursor", "Enable Ability Cursor", "Disable Ability Cursor"))
 	if(!result)
 		return
 	switch(result)
@@ -614,6 +614,15 @@ CLIENT_VERB(toggle_custom_cursors)
 		if("No")
 			prefs.custom_cursors = FALSE
 			to_chat(src, SPAN_NOTICE("You're no longer using custom cursors."))
+			mouse_pointer_icon = initial(mouse_pointer_icon)
+			prefs.save_preferences()
+		if("Enable Ability Cursor")
+			prefs.custom_cursors = TRUE
+			to_chat(src, SPAN_NOTICE("Your ability cursor will now be visible."))
+			prefs.save_preferences()
+		if("Disable Ability Cursor")
+			prefs.custom_cursors = FALSE
+			to_chat(src, SPAN_NOTICE("Your ability cursor will no longer be visible."))
 			mouse_pointer_icon = initial(mouse_pointer_icon)
 			prefs.save_preferences()
 		if("Enable Main Cursor")

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -328,6 +328,9 @@
 
 	bubble_icon = "alien"
 
+	/// Custom action mouse cursor
+	var/active_action_cursor
+
 	/////////////////////////////////////////////////////////////////////
 	//
 	// Phero related vars
@@ -591,6 +594,30 @@
 		. |= COMPONENT_NO_IGNITE
 	if(fire_immunity & FIRE_IMMUNITY_XENO_FRENZY)
 		. |= COMPONENT_XENO_FRENZY
+
+/mob/living/carbon/xenomorph/proc/set_action_cursor(mouse_pointer)
+	if(!client)
+		return
+	if(active_action_cursor)
+		UnregisterSignal(client, COMSIG_CLIENT_RESET_VIEW)
+	if(!client.prefs.custom_cursors)
+		return
+	active_action_cursor = mouse_pointer
+	client.mouse_pointer_icon = mouse_pointer
+	RegisterSignal(client, COMSIG_CLIENT_RESET_VIEW, PROC_REF(handle_view))
+
+/mob/living/carbon/xenomorph/proc/clear_action_cursor()
+	if(!client)
+		return
+	active_action_cursor = null
+	client.mouse_pointer_icon = null
+	UnregisterSignal(client, COMSIG_CLIENT_RESET_VIEW)
+
+/mob/living/carbon/xenomorph/proc/handle_view(client/user)
+	SIGNAL_HANDLER
+	if(active_action_cursor)
+		if(user?.prefs?.custom_cursors)
+			user.mouse_pointer_icon = active_action_cursor
 
 //Off-load this proc so it can be called freely
 //Since Xenos change names like they change shoes, we need somewhere to hammer in all those legos

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
@@ -8,6 +8,8 @@
 */
 
 /mob/living/carbon/xenomorph/proc/set_selected_ability(datum/action/xeno_action/activable/ability)
+	if(active_action_cursor && active_action_cursor != ability)
+		clear_action_cursor()
 	if(selected_ability)
 		selected_ability.on_deselect(src)
 	if(!ability)


### PR DESCRIPTION
# About the pull request

This change was made for: #11168

This was made for other PR as QoL improvement, but i thought it would be better if i made separate PR for this change considering its not exclusive to PR but can be used for anything else. (added a little modularity)

# Explain why it's good for the game

Allows to attach custom cursor sprite to abilities, this change is not exclusive to #11168, this change was made to include *any* ability and allows people *(in future)* to add their own custom cursors for abilities, placing anything inside **set_action_cursor()** for example **set_action_cursor('icons/effects/mouse_pointer/custom_cursor.dmi')** will automatically apply defined cursor, switching ability automatically clear cursors, but if for some reason you need to clear cursor inside ability, use **clear_action_cursor()**


<details>
<summary>>How custom sprites work.<</summary>
This part is dedicated to people interested in how new added ability sprites works, in general i created it for designer but if someone in future will check this PR for more info, here is how to use the 3 new added lines that can be used anywhere you want with specific setup. (players can disable it with preference -> allow custom cursors)

in xenomorph.dm there are 3 new proc's:

**set_action_cursor()**
**clear_action_cursor()**
**handle_view()**

your interest is in 2 first proc's, 3rd one exist for purpose of "looping", mouse will dissapear after delay because of (maybe) engine fault, so looping using signals make it persist on screen for any amount of time you want it. (view override with signals)

**(!)** made sure that anywhere you want to add this, you have xenomorph path defined inside it example: 
"var/mob/living/carbon/xenomorph/xeno = owner", if you adding it in behavior_delegate, its already defined as "bound_xeno".


**set_action_cursor()** is responsible for changing your mouse icon to any icon you put inside of it, for example you want ability to change cursor? then put it anywhere in code where code activates and place **xeno.set_action_cursor('*[custom cursor image path]*')** by putting image path inside proc call will automatically create and place image in your cursor place. 
*(if you still don't get it, check designer.dm code and see how it works)*

**clear_action_cursor()** is responsible for cleaning (removing) cursor, best use is if you don't want cursor carrying out to other abities that are stored in same action button.

**Extra info for cursor issues:**
If you read this far and wonder how to make "custom cursor registers clicks where i want it", you need to do it inside Dream Maker program (the one that view and allow sprites edit), there is button called "Hot Spot" that you can call by pressing H (default) and wherever you press on that sprite, it will become your cursor "click" point.


Here is description from Dream Maker helping tool to explain how hotspot works.
> Hot Spot: If this icon will be used as a mouse cursor, you can change the hot spot (where the cursor click actually registers) by choosing this tool and clicking a pixel in the icon. That pixel will become the new hot spot.
</details>

# Testing Photographs and Procedure

<details>
<summary>Example of Custom Cursor used on Designer</summary>
Please ignore low video quality, it makes cursor look ugly.

https://github.com/user-attachments/assets/8c74a819-b871-4cee-a670-812d5918605b

</details>


# Changelog
:cl: Venuska1117
add: Abilities now can have custom .dmi sprites as their cursors, custom cursors can be enabled in preferences > allow custom cursors > Enable/Disable Ability Cursor.
/:cl: