### PR TITLE
Move Tyrargo army survivors to bottom of Marine crew monitor

### DIFF
--- a/code/modules/cm_marines/marines_consoles.dm
+++ b/code/modules/cm_marines/marines_consoles.dm
@@ -1025,10 +1025,6 @@ GLOBAL_LIST_EMPTY_TYPED(crew_monitor, /datum/crewmonitor)
 				JOB_MESS_SERGEANT = 62,
 				// 70-149: SQUADS (look below)
 				JOB_SYNTH_K9 = 71,
-				JOB_ARMY_TROOPER = 72,
-				JOB_ARMY_ENGI = 73,
-				JOB_ARMY_MEDIC = 74,
-				JOB_ARMY_SYN = 75,
 				// 150+: Civilian/other
 				JOB_CORPORATE_LIAISON = 150,
 				JOB_CORPORATE_BODYGUARD = 151,
@@ -1103,6 +1099,15 @@ GLOBAL_LIST_EMPTY_TYPED(crew_monitor, /datum/crewmonitor)
 				JOB_FORECON_SUPPORT = 144,
 				JOB_FORECON_RIFLEMAN = 145,
 				JOB_FORECON_SYN = 146,
+
+				JOB_ARMY_CO = 160,
+				JOB_ARMY_SNCO = 160,
+				JOB_ARMY_MARKSMAN = 161,
+				JOB_ARMY_SMARTGUNNER = 162,
+				JOB_ARMY_MEDIC = 163,
+				JOB_ARMY_ENGI = 164,
+				JOB_ARMY_TROOPER = 165,
+				JOB_ARMY_SYN = 166,
 			)
 			var/squad_number = 70
 			for(var/squad_name in GLOB.ROLES_SQUAD_ALL + "")


### PR DESCRIPTION
# About the pull request
Moves the Tyrargo army survivors to the bottom of the crew monitor, similar to how FORECON and other survivors are handled.

# Explain why it's good for the game

Fixes #11852.

# Testing Photographs and Procedure
N/A, simple number tweaks.

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: MoondancerPony
fix: Tyrargo Rift army survivors no longer show up as part of Alpha Squad on the crew monitor.
/:cl:
