### PR TITLE
Small FTL wording change

### DIFF
--- a/code/controllers/subsystem/hijack.dm
+++ b/code/controllers/subsystem/hijack.dm
@@ -471,7 +471,7 @@ SUBSYSTEM_DEF(hijack)
 /datum/controller/subsystem/hijack/proc/unlock_self_destruct(from_ftl = FALSE)
 	sd_time_remaining = sd_max_time
 	sd_unlocked = TRUE
-	shipwide_ai_announcement("[from_ftl ? "Hyperdrive tachyon shunt no longer operable. " : ""]Remaining fuel transferred to on board fusion generators to permit scuttling.", HIJACK_ANNOUNCE, sound('sound/misc/notice2.ogg'))
+	shipwide_ai_announcement("[from_ftl ? "Hyperdrive tachyon shunt no longer operable. Lifeboats and pods re-enabled. " : ""]Remaining fuel transferred to on board fusion generators to permit scuttling.", HIJACK_ANNOUNCE, sound('sound/misc/notice2.ogg'))
 
 /// Signal handler for COMSIG_GLOB_GENERATOR_SET_OVERLOADING
 /datum/controller/subsystem/hijack/proc/on_generator_overload(obj/structure/machinery/power/power_generator/reactor/source, new_overloading)


### PR DESCRIPTION

# About the pull request

Changes FTL wording to make game mechanics more transparent.

# Explain why it's good for the game

I don't know about the rest of you, but with the current wording, "initiating quantum jump" - when the fueling hasn't reached 100% yet... I thought it was just saying that the process is spooling up and we'll jump at 100% fuel. It's not obvious to me that the jump has actually been initiated at that point and that the fuel actually just needs to be maintained in order to keep traveling in hyperspace. It's more clear if you look out the window, but I never seem to be at a window. So, this is just a small wording change. Also, it should be made clear to people that they can't evacuate until the ship drops out of hyperspace.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: FTL jump wording changed to make game mechanics more transparent
/:cl:
