### PR TITLE
Fix SSV Rostock on Linux

### DIFF
--- a/maps/ssv_rostock.json
+++ b/maps/ssv_rostock.json
@@ -1,6 +1,6 @@
 {
     "map_name": "SSV Rostock",
     "map_path": "templates/",
-    "map_file": "SSV_Rostock.dmm",
+    "map_file": "ssv_rostock.dmm",
 	"traits": [{ "Station": true, "Admin": true, "Marine Main Ship": true}]
 }


### PR DESCRIPTION
# About the pull request
Linux paths are case-sensitive, Windows paths are not. This means Linux would fail to find the map file and not actually load the Rostock. That doesn't seem like it's a big problem until you remember that our Github Actions CI runs on Ubuntu. Whoops.

# Explain why it's good for the game
The map should actually be tested...

# Testing Photographs and Procedure
The warning should now be gone from the unit tests for the SSV Rostock.

# Changelog
:cl: MoondancerPony
server: Linux servers now load the SSV Rostock properly
/:cl:
