### PR TITLE
Actually gives some ERTs a working skilless first-aid kit

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -21,6 +21,7 @@
 	can_hold_skill = list(
 		/obj/item/storage/firstaid = list(SKILL_MEDICAL, SKILL_MEDICAL_MEDIC),
 		/obj/item/storage/toolkit = list(SKILL_ENGINEER, SKILL_ENGINEER_TRAINED),
+		/obj/item/storage/firstaid/regular/response = list(SKILL_MEDICAL, SKILL_MEDICAL_DEFAULT),
 		)
 	drop_sound = "armorequip"
 	var/worn_accessible = FALSE //whether you can access its content while worn on the back


### PR DESCRIPTION

# About the pull request

3 years ago I did this PR: #4670 to give ERTs a first aid kit that was not skill-blocked(due to the at the time recent change that made putting a first aid kit in your backpack as a non-medic impossible), little did I know but apparently this did not work at all and I just realized that today.

This fixes that by allowing it to be actually stored if you don't have the required skills.


The specific ERTs who were meant to have this(and actively still have it in the code) are:
VAIPO/VAISO, CLF, DD, freelancers, Provosts, and HGs

# Explain why it's good for the game

This was intended and balance approved but never actually worked, so this fixes a bug which is good for the game.
Also see the why its good for the original PR


# Testing Photographs and Procedure

I actually tested it this time and it WORKED


# Changelog
:cl: Riot
fix: Certain ERTs should now correctly spawn with basic first aid kits, as they were meant to do for the past 3 years.
/:cl:
