### PR TITLE
fixes not being able to bind to tab

### DIFF
--- a/tgui/packages/tgui/interfaces/KeyBinds.tsx
+++ b/tgui/packages/tgui/interfaces/KeyBinds.tsx
@@ -32,6 +32,7 @@ const KEY_CODE_TO_BYOND = {
   PAGEDOWN: 'Southeast',
   PAGEUP: 'Northeast',
   RIGHT: 'East',
+  TAB: 'Tab',
   ' ': 'Space',
   UP: 'North',
 };


### PR DESCRIPTION
follow up to the oidc pr, you previously couldnt bind to tab, now you could. yayyy

:cl:
fix: binding keys to tab now works
/:cl: