### PR TITLE
Tyrargo Rift - Adds 100-player pop limit. 

### DIFF
--- a/map_config/maps.txt
+++ b/map_config/maps.txt
@@ -64,6 +64,7 @@ map new_varadero
 endmap
 
 map tyrargo_rift
+	minplayers 100
 endmap
 
 map whiskey_outpost_v2


### PR DESCRIPTION

# About the pull request

See title. Adds a 100 player pop limit for Tyrargo.

# Explain why it's good for the game

The map is too big for lowpop from my experience and the experience of players. At least 100 players seems like a good starting spot. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Tyrargo Rift may only be voted for if the server has at least 100 players. 
/:cl:
