### PR TITLE
Fix: Dropship crew not getting their full options of point buys

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/pilot_officer.dm
+++ b/code/game/machinery/vending/vendor_types/crew/pilot_officer.dm
@@ -275,7 +275,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_dropship_crew_chief, list(
 		list("M41A Solid Stock", 10, /obj/item/attachable/stock/rifle, null, VENDOR_ITEM_REGULAR),
 		list("M37A2 Collapsible Stock", 10, /obj/item/attachable/stock/synth/collapsible, null, VENDOR_ITEM_REGULAR),
 		list("M10 Solid Stock", 10, /obj/item/attachable/stock/m10_solid, null, VENDOR_ITEM_REGULAR),
-		list("M10 Folding Stock", 10, /obj/item/attachable/stock/pistol/collapsible, VENDOR_ITEM_REGULAR),
+		list("M10 Folding Stock", 10, /obj/item/attachable/stock/pistol/collapsible, null, VENDOR_ITEM_REGULAR),
 		list("M39 Stock", 10, /obj/item/attachable/stock/smg, null, VENDOR_ITEM_REGULAR),
 
 		list("AMMUNITION", 0, null, null, null),


### PR DESCRIPTION

# About the pull request
I.E. Fix me missing a null. Oopsies
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #12345" to link the PR to the corresponding Issue number #12345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #12345, Fixes #12346, Fixes #12347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Fix another instance of me being dumb
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Dropship Crew now see their full list of buyables again... Sorry.
/:cl:
