### PR TITLE
Fix queen check not checking affected z_levels + No Hijack Hive Collapse

### DIFF
--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -652,6 +652,9 @@
 	if(!(flags_round_type & MODE_INFESTATION))
 		return
 
+	if(is_in_endgame)
+		return // Don't handle hive collapse for hijack
+
 	var/datum/hive_status/hive = GLOB.hive_datum[hivenumber]
 	if(hive.need_round_end_check && !hive.can_delay_round_end())
 		return


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #7773 simply making it where the queen is still checked to be in whatever is the relevant Z levels per https://github.com/cmss13-devs/cmss13/blob/7b2625ed6b5a33f3cc7588dd78bed71f6d286737/code/game/gamemodes/game_mode.dm#L122-L125 and https://github.com/cmss13-devs/cmss13/blob/7b2625ed6b5a33f3cc7588dd78bed71f6d286737/code/game/gamemodes/colonialmarines/colonialmarines.dm#L602-L631

Additionally, we don't want to check for hive collapse during hijack because normally a hive collapse is either marine minor/major. But this could potentially return as just always a xeno minor if needed.

# Explain why it's good for the game

Fixes issues where say the queen and the rest of her hive hops off a crashed almayer and the round doesn't end.

Should also fix #11516

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Tunnel still doesn't end round: 
<img width="2103" height="1028" alt="image" src="https://github.com/user-attachments/assets/493b23cf-8a0f-454a-afa5-4fe6e2630c7d" />

But going to a Z level that isn't checked anymore does matter:
<img width="4158" height="1080" alt="image" src="https://github.com/user-attachments/assets/952a8e77-0c3a-4370-9fc9-362c5053c8ca" />

</details>


# Changelog
:cl: Drathek
fix: Fixed queen no forfeit check not checking the relevant Z levels (namely regarding hijack/FTL)
fix: Fixed potential for hive collapse during hijack
/:cl:
