### PR TITLE
Fix: Tyrago Rift OOB areas missing the AREA_NOBURROW flag

### DIFF
--- a/code/game/area/tyrargo_rift.dm
+++ b/code/game/area/tyrargo_rift.dm
@@ -34,7 +34,7 @@
 	icon_state = "unknown"
 	ceiling = CEILING_MAX
 	is_resin_allowed = FALSE
-	flags_area = AREA_NOTUNNEL
+	flags_area = AREA_NOTUNNEL|AREA_NOBURROW
 	minimap_color = MINIMAP_AREA_OOB
 	requires_power = FALSE
 	ambience_exterior = AMBIENCE_TYRARGO_CITY
@@ -569,7 +569,7 @@
 	icon_state = "Holodeck"
 	ceiling = CEILING_MAX
 	is_resin_allowed = FALSE
-	flags_area = AREA_NOTUNNEL
+	flags_area = AREA_NOTUNNEL|AREA_NOBURROW
 	requires_power = FALSE
 
 /area/tyrargo/underground/engineering
@@ -649,7 +649,7 @@
 	name = "32nd Armor Division: Staging Area - Southern Outskirts"
 	icon_state = "Holodeck"
 	is_resin_allowed = FALSE
-	flags_area = AREA_NOTUNNEL
+	flags_area = AREA_NOTUNNEL|AREA_NOBURROW
 	minimap_color = MINIMAP_AREA_SEC_CAVE
 	ceiling = CEILING_MAX
 	ceiling_muffle = FALSE


### PR DESCRIPTION

# About the pull request
Title. 
Resolves: #11784
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #12345" to link the PR to the corresponding Issue number #12345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #12345, Fixes #12346, Fixes #12347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Stop sneaky burrowers sneaking off into non-accessible areas.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: 
fix: Tyrago Rift Out of bounds areas disallow burrowing.
/:cl:
