### PR TITLE
Loadout Pistol Changes

### DIFF
--- a/code/datums/supply_packs/black_market.dm
+++ b/code/datums/supply_packs/black_market.dm
@@ -1131,7 +1131,7 @@ This is where the RO can reclaim their lost honor and purchase the M44 custom, t
 
 /datum/supply_packs/contraband/deep_storage/clf_holdout
 	name = "D18 Holdout Pistol"
-	contains = list(/obj/item/storage/box/clf)
+	contains = list(/obj/item/storage/box/fluff_gun/clf)
 	dollar_cost = 10
 	crate_heat = 2
 	containertype = /obj/structure/largecrate/black_market

--- a/code/game/objects/items/storage/misc.dm
+++ b/code/game/objects/items/storage/misc.dm
@@ -128,64 +128,99 @@
 	else
 		icon_state = "6_pack_[length(contents)]"
 
-/obj/item/storage/box/clf
-	name = "D18-storing box"
-	desc = "A fairly decorated and ceremonial box containing a CLF D18 and a single additional magazine for it. I guess those CLF folk really care about their craftsmanship and prose rather than practicality, eh?"
+/obj/item/storage/box/fluff_gun
+	name = "Sidearm Storage Box"
+	desc = "Base item for prefrence weapons."
+	w_class = SIZE_LARGE
+	max_w_class = SIZE_MEDIUM
+	storage_slots = 7
 	icon = 'icons/obj/items/storage/kits.dmi'
 	icon_state = "m43case"
-	w_class = SIZE_SMALL
+
+/obj/item/storage/box/fluff_gun/clf
+	name = "D18-storing box"
+	desc = "A fairly decorated and ceremonial box containing a CLF D18 and a few additional magazines for it. I guess those CLF folk really care about their craftsmanship and prose rather than practicality, eh?"
+	w_class = SIZE_SMALL //pocket pistols have smaller boxes because noone is going to put these in a belt
 	max_w_class = SIZE_TINY
-	storage_slots = 2
+	storage_slots = 4
 	can_hold = list(/obj/item/weapon/gun/pistol/clfpistol, /obj/item/ammo_magazine/pistol/clfpistol)
 
-/obj/item/storage/box/clf/fill_preset_inventory()
+/obj/item/storage/box/fluff_gun/clf/fill_preset_inventory()
 	new /obj/item/weapon/gun/pistol/clfpistol(src)
 	new /obj/item/ammo_magazine/pistol/clfpistol(src)
+	new /obj/item/ammo_magazine/pistol/clfpistol(src)
+	new /obj/item/ammo_magazine/pistol/clfpistol(src)
 
-/obj/item/storage/box/upp //war trophy luger
+/obj/item/storage/box/fluff_gun/upp //war trophy luger
 	name = "Type 73 storing case"
-	desc = "A small case containing the once-standard sidearm of the UPP, the Type 73, and two additional magazines. The contained sidearm is probably looted off a dead officer or from a captured stockpile, either way this thing is worth a pretty penny."
-	icon = 'icons/obj/items/storage/kits.dmi'
-	icon_state = "matebacase"
-	w_class = SIZE_MEDIUM
-	max_w_class = SIZE_MEDIUM
-	storage_slots = 3
+	desc = "A small case containing the once-standard sidearm of the UPP, the Type 73, and some additional magazines. The contained sidearm is probably looted off a dead officer or from a captured stockpile, either way this thing is worth a pretty penny."
 	can_hold = list(/obj/item/weapon/gun/pistol/t73, /obj/item/ammo_magazine/pistol/t73)
 
-/obj/item/storage/box/upp/fill_preset_inventory()
+/obj/item/storage/box/fluff_gun/upp/fill_preset_inventory()
 	new /obj/item/weapon/gun/pistol/t73(src)
 	new /obj/item/ammo_magazine/pistol/t73(src)
 	new /obj/item/ammo_magazine/pistol/t73(src)
+	new /obj/item/ammo_magazine/pistol/t73(src)
+	new /obj/item/ammo_magazine/pistol/t73(src)
+	new /obj/item/ammo_magazine/pistol/t73(src)
+	new /obj/item/ammo_magazine/pistol/t73(src)
 
-/obj/item/storage/box/action
+/obj/item/storage/box/fluff_gun/action
 	name = "AC71 'Action' storing case"
 	desc = "A small case containing an AC71 Action, a holdout pistol by Spearhead Armory. It was most likely brought by a marine from home, or taken from a colony without permission."
-	icon = 'icons/obj/items/storage/kits.dmi'
-	icon_state = "m43case"
-	w_class = SIZE_SMALL
+	w_class = SIZE_SMALL //pocket pistols have smaller boxes because noone is going to put these in a belt
 	max_w_class = SIZE_TINY
-	storage_slots = 3
+	storage_slots = 4
 	can_hold = list(/obj/item/weapon/gun/pistol/action, /obj/item/ammo_magazine/pistol/action)
 
-/obj/item/storage/box/action/fill_preset_inventory()
+/obj/item/storage/box/fluff_gun/action/fill_preset_inventory()
 	new /obj/item/weapon/gun/pistol/action(src)
 	new /obj/item/ammo_magazine/pistol/action(src)
 	new /obj/item/ammo_magazine/pistol/action(src)
+	new /obj/item/ammo_magazine/pistol/action(src)
 
-/obj/item/storage/box/plinker
+/obj/item/storage/box/fluff_gun/plinker
 	name = "W62 'Whisper' storing case"
 	desc = "A small case containing a W62 Whisper, a .22 ratkiller made by Spearhead Armory. It was most likely brought by a marine from home, or taken from a colony without permission."
-	icon = 'icons/obj/items/storage/kits.dmi'
-	icon_state = "m43case"
-	w_class = SIZE_MEDIUM
-	max_w_class = SIZE_SMALL
-	storage_slots = 3
 	can_hold = list(/obj/item/weapon/gun/pistol/holdout, /obj/item/ammo_magazine/pistol/holdout)
 
-/obj/item/storage/box/plinker/fill_preset_inventory()
+/obj/item/storage/box/fluff_gun/plinker/fill_preset_inventory()
 	new /obj/item/weapon/gun/pistol/holdout(src)
 	new /obj/item/ammo_magazine/pistol/holdout(src)
 	new /obj/item/ammo_magazine/pistol/holdout(src)
+	new /obj/item/ammo_magazine/pistol/holdout(src)
+	new /obj/item/ammo_magazine/pistol/holdout(src)
+	new /obj/item/ammo_magazine/pistol/holdout(src)
+	new /obj/item/ammo_magazine/pistol/holdout(src)
+
+/obj/item/storage/box/fluff_gun/m1911
+	name = "M48A4 storing case"
+	desc = "A small case containing a M48A4, a modernized version of the classic M1911. It was most likely privately bought by a marine, or specially ordered by an officer."
+	can_hold = list(/obj/item/weapon/gun/pistol/m1911/fluff, /obj/item/ammo_magazine/pistol/m1911)
+
+/obj/item/storage/box/fluff_gun/m1911/fill_preset_inventory()
+	new /obj/item/weapon/gun/pistol/m1911/fluff(src)
+	new /obj/item/ammo_magazine/pistol/m1911(src)
+	new /obj/item/ammo_magazine/pistol/m1911(src)
+	new /obj/item/ammo_magazine/pistol/m1911(src)
+	new /obj/item/ammo_magazine/pistol/m1911(src)
+	new /obj/item/ammo_magazine/pistol/m1911(src)
+	new /obj/item/ammo_magazine/pistol/m1911(src)
+
+/obj/item/storage/box/fluff_gun/l54
+	name = "L54 storing case"
+	desc = "A small case containing an L54 Service Pistol, the standard sidearm of the NSPA. It was most likely brought by a marine from home, or taken from a colony without permission."
+	can_hold = list(/obj/item/weapon/gun/pistol/l54, /obj/item/ammo_magazine/pistol/l54)
+
+/obj/item/storage/box/fluff_gun/l54/fill_preset_inventory()
+	new /obj/item/weapon/gun/pistol/l54(src)
+	new /obj/item/ammo_magazine/pistol/l54(src)
+	new /obj/item/ammo_magazine/pistol/l54(src)
+	new /obj/item/ammo_magazine/pistol/l54(src)
+	new /obj/item/ammo_magazine/pistol/l54(src)
+	new /obj/item/ammo_magazine/pistol/l54(src)
+	new /obj/item/ammo_magazine/pistol/l54(src)
+
 
 /obj/item/storage/box/co2_knife
 	name = "M8 cartridge bayonet packaging"

--- a/code/game/objects/items/storage/misc.dm
+++ b/code/game/objects/items/storage/misc.dm
@@ -165,6 +165,20 @@
 	new /obj/item/ammo_magazine/pistol/t73(src)
 	new /obj/item/ammo_magazine/pistol/t73(src)
 
+/obj/item/storage/box/fluff_gun/np92
+	name = "NP92 storing case"
+	desc = "A small case containing the standard sidearm of the UPP, the NP92, and some additional magazines. The contained sidearm is probably looted from a captured stockpile."
+	can_hold = list(/obj/item/weapon/gun/pistol/np92, /obj/item/ammo_magazine/pistol/np92)
+
+/obj/item/storage/box/fluff_gun/np92/fill_preset_inventory()
+	new /obj/item/weapon/gun/pistol/np92(src)
+	new /obj/item/ammo_magazine/pistol/np92(src)
+	new /obj/item/ammo_magazine/pistol/np92(src)
+	new /obj/item/ammo_magazine/pistol/np92(src)
+	new /obj/item/ammo_magazine/pistol/np92(src)
+	new /obj/item/ammo_magazine/pistol/np92(src)
+	new /obj/item/ammo_magazine/pistol/np92(src)
+
 /obj/item/storage/box/fluff_gun/action
 	name = "AC71 'Action' storing case"
 	desc = "A small case containing an AC71 Action, a holdout pistol by Spearhead Armory. It was most likely brought by a marine from home, or taken from a colony without permission."

--- a/code/game/objects/items/storage/misc.dm
+++ b/code/game/objects/items/storage/misc.dm
@@ -130,7 +130,7 @@
 
 /obj/item/storage/box/fluff_gun
 	name = "Sidearm Storage Box"
-	desc = "Base item for prefrence weapons."
+	desc = "Base item for preference weapons."
 	w_class = SIZE_LARGE
 	max_w_class = SIZE_MEDIUM
 	storage_slots = 7

--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -812,28 +812,36 @@ GLOBAL_LIST_EMPTY(roles_with_gear)
 	display_name = "M8 Cartridge Bayonet"
 	path = /obj/item/storage/box/co2_knife
 
+
 /datum/gear/weapon/clfpistol
 	display_name = "D18 Holdout Pistol"
-	path = /obj/item/storage/box/clf
+	path = /obj/item/storage/box/fluff_gun/clf
+	slot = WEAR_R_HAND
 
 /datum/gear/weapon/upppistol //ww2 war trophy luger
 	display_name = "Type 73 Pistol"
-	path = /obj/item/storage/box/upp
-	slot = WEAR_IN_BACK
-	fluff_cost = 4
+	path = /obj/item/storage/box/fluff_gun/upp
+	slot = WEAR_R_HAND
 
 /datum/gear/weapon/l54_pistol
 	display_name = "L54 Pistol" // TWE service pistol - same stats as the m4a3
-	path = /obj/item/weapon/gun/pistol/l54
-	allowed_origins = USCM_ORIGINS
+	path = /obj/item/storage/box/fluff_gun/l54
+	slot = WEAR_R_HAND
 
 /datum/gear/weapon/holdout
 	display_name = "W62 'Whisper'" //22LR ratkiller and/or plinker
-	path = /obj/item/storage/box/plinker
+	path = /obj/item/storage/box/fluff_gun/plinker
+	slot = WEAR_R_HAND
 
 /datum/gear/weapon/action
 	display_name = "AC71 'Action'" //380ACP holdout pistol
-	path = /obj/item/storage/box/action
+	path = /obj/item/storage/box/fluff_gun/action
+	slot = WEAR_R_HAND
+
+/datum/gear/weapon/m1911
+	display_name = "M48A4 Service pistol" //modernized m1911
+	path = /obj/item/storage/box/fluff_gun/m1911
+	slot = WEAR_R_HAND
 
 /datum/gear/weapon/m4a3_custom
 	display_name = "M4A3 Custom Pistol"

--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -823,6 +823,11 @@ GLOBAL_LIST_EMPTY(roles_with_gear)
 	path = /obj/item/storage/box/fluff_gun/upp
 	slot = WEAR_R_HAND
 
+/datum/gear/weapon/np92_pistol
+	display_name = "NP92 Pistol"
+	path = /obj/item/storage/box/fluff_gun/np92
+	slot = WEAR_R_HAND
+
 /datum/gear/weapon/l54_pistol
 	display_name = "L54 Pistol" // TWE service pistol - same stats as the m4a3
 	path = /obj/item/storage/box/fluff_gun/l54

--- a/code/modules/gear_presets/cmb.dm
+++ b/code/modules/gear_presets/cmb.dm
@@ -293,7 +293,7 @@
 			new_human.equip_to_slot_or_del(new /obj/item/restraint/handcuffs/zip, WEAR_IN_BACK)
 			new_human.equip_to_slot_or_del(new /obj/item/storage/box/packet/smoke, WEAR_IN_BACK)
 			new_human.equip_to_slot_or_del(new /obj/item/storage/belt/shotgun/black, WEAR_WAIST)
-			new_human.equip_to_slot_or_del(new /obj/item/weapon/shield/riot/metal, WEAR_R_HAND)
+			new_human.equip_to_slot_or_del(new /obj/item/weapon/shield/riot/metal, WEAR_L_HAND)
 			new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/shotgun, WEAR_IN_JACKET)
 			new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/shotgun, WEAR_IN_JACKET)
 			new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/shotgun/buckshot, WEAR_IN_BELT)

--- a/code/modules/gear_presets/dust_raider.dm
+++ b/code/modules/gear_presets/dust_raider.dm
@@ -179,7 +179,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m39(new_human), WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/pistol(new_human), WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/attachable/magnetic_harness(new_human), WEAR_IN_BACK)
-	new_human.equip_to_slot_or_del(new /obj/item/spec_kit, WEAR_R_HAND)
+	new_human.equip_to_slot_or_del(new /obj/item/spec_kit, WEAR_L_HAND)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine(new_human), WEAR_HEAD)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/magazine/large/wy/pmc_m39(new_human), WEAR_L_STORE)
 	add_common_wo_equipment(new_human)

--- a/code/modules/gear_presets/upp.dm
+++ b/code/modules/gear_presets/upp.dm
@@ -4039,7 +4039,7 @@
 		new_human.equip_to_slot_or_del(new maybegloves, WEAR_HANDS)
 
 	//gun
-	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/rifle/type71/carbine, WEAR_R_HAND)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/rifle/type71/carbine, WEAR_L_HAND)
 
 	//webbing or belt?
 	if(prob(30))

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -286,7 +286,7 @@
 /datum/equipment_preset/uscm/spec/cryo/load_gear(mob/living/carbon/human/new_human)
 	..()
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/marine/cryo(new_human), WEAR_L_EAR)
-	new_human.equip_to_slot_or_del(new /obj/item/spec_kit/cryo, WEAR_R_HAND)
+	new_human.equip_to_slot_or_del(new /obj/item/spec_kit/cryo, WEAR_L_HAND)
 
 //*****************************************************************************************************/
 
@@ -596,7 +596,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/construction/full(new_human), WEAR_R_STORE)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/full(new_human), WEAR_L_STORE)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/insulated(new_human), WEAR_HANDS)
-	new_human.equip_to_slot_or_del(new /obj/item/device/motiondetector, WEAR_R_HAND)
+	new_human.equip_to_slot_or_del(new /obj/item/device/motiondetector, WEAR_L_HAND)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/box/attachments(new_human), WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(new_human), WEAR_FEET)
 	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/rifle/m41a(new_human), WEAR_J_STORE)
@@ -697,7 +697,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m39(new_human), WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/pistol(new_human), WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/attachable/magnetic_harness(new_human), WEAR_IN_BACK)
-	new_human.equip_to_slot_or_del(new /obj/item/spec_kit, WEAR_R_HAND)
+	new_human.equip_to_slot_or_del(new /obj/item/spec_kit, WEAR_L_HAND)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine(new_human), WEAR_HEAD)
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/marine/cryo(new_human), WEAR_L_EAR)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/magazine/large/wy/pmc_m39(new_human), WEAR_L_STORE)

--- a/code/modules/gear_presets/uscm_forecon.dm
+++ b/code/modules/gear_presets/uscm_forecon.dm
@@ -269,7 +269,7 @@
 
 	new_human.equip_to_slot_or_del(uniform, WEAR_BODY)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/full/alternate(new_human), WEAR_L_STORE)
-	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/rifle/m41aMK1/tactical(new_human), WEAR_R_HAND)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/rifle/m41aMK1/tactical(new_human), WEAR_L_HAND)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/marine/satchel(new_human), WEAR_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/m41aMK1(new_human), WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/m41aMK1(new_human), WEAR_IN_BACK)

--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -535,7 +535,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/general/large(new_human), WEAR_R_STORE)
 	new_human.equip_to_slot_or_del(new /obj/item/device/flash(new_human), WEAR_L_STORE)
 	new_human.equip_to_slot_or_del(new /obj/item/device/binoculars(new_human), WEAR_L_HAND)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/device/whistle(new_human), WEAR_R_HAND)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/device/whistle(new_human), WEAR_IN_BACK)
 
 /datum/equipment_preset/uscm_ship/sea/load_rank(mob/living/carbon/human/rankee, client/mob_client)
 	mob_client?.toggle_newplayer_ic_hud(TRUE)

--- a/code/modules/gear_presets/wo.dm
+++ b/code/modules/gear_presets/wo.dm
@@ -267,7 +267,7 @@
 	//limbs
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/officer(new_human), WEAR_HANDS)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/knife(new_human), WEAR_FEET)
-	new_human.equip_to_slot_or_del(new /obj/item/spec_kit(new_human), WEAR_R_HAND)
+	new_human.equip_to_slot_or_del(new /obj/item/spec_kit(new_human), WEAR_L_HAND)
 	//pockets
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/general/medium(new_human), WEAR_R_STORE)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/magazine/large/wy/pmc_m39(new_human), WEAR_L_STORE)
@@ -704,7 +704,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/smg/m39(new_human), WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/pistol(new_human), WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/attachable/magnetic_harness(new_human), WEAR_IN_BACK)
-	new_human.equip_to_slot_or_del(new /obj/item/spec_kit, WEAR_R_HAND)
+	new_human.equip_to_slot_or_del(new /obj/item/spec_kit, WEAR_L_HAND)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine(new_human), WEAR_HEAD)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/magazine/large/wy/pmc_m39(new_human), WEAR_L_STORE)
 

--- a/code/modules/gear_presets/wy.dm
+++ b/code/modules/gear_presets/wy.dm
@@ -108,7 +108,7 @@
 
 /datum/equipment_preset/wy/exec_supervisor/lawyer/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/WY(new_human), WEAR_L_EAR)
-	new_human.equip_to_slot_or_del(new /obj/item/storage/secure/briefcase(new_human), WEAR_R_HAND)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/secure/briefcase(new_human), WEAR_L_HAND)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/liaison_suit/black(new_human), WEAR_BODY)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/tie/black(new_human), WEAR_ACCESSORY)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/jacket/marine/corporate/black(new_human), WEAR_JACKET)

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -175,7 +175,24 @@
 	damage_mult = BASE_BULLET_DAMAGE_MULT + BULLET_DAMAGE_MULT_TIER_5
 
 /obj/item/weapon/gun/pistol/m1911/socom/equipped
-	starting_attachment_types = list(/obj/item/attachable/suppressor, /obj/item/attachable/lasersight, /obj/item/attachable/reflex)
+	starting_attachment_types = list(/obj/item/attachable/suppressor/sleek, /obj/item/attachable/lasersight, /obj/item/attachable/reflex)
+
+/obj/item/weapon/gun/pistol/m1911/fluff
+	name = "\improper M48A4 service pistol"
+	desc = "A timeless classic since the first World War, the M1911A1 has limited use with the USCM, and is also often privately bought and used as a sidearm if a standard pistol is not issued out. This is a modernized version with an ammo counter and a polymer grip, designated M48A4. Chambered in .45 ACP. This one looks a bit worn and old."
+	icon_state = "m4a345_s"
+	item_state = "m4a3"
+	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK|GUN_ONE_HAND_WIELDED|GUN_AMMO_COUNTER
+
+/obj/item/weapon/gun/pistol/m1911/fluff/set_gun_config_values() //does not have the damage boost that normal m1911 has
+	..()
+	set_fire_delay(FIRE_DELAY_TIER_11)
+	accuracy_mult = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_4
+	accuracy_mult_unwielded = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_2
+	scatter = SCATTER_AMOUNT_TIER_8
+	burst_scatter_mult = SCATTER_AMOUNT_TIER_6
+	scatter_unwielded = SCATTER_AMOUNT_TIER_6
+	damage_mult = BASE_BULLET_DAMAGE_MULT
 
 /obj/item/weapon/gun/pistol/m1911/custom
 	name = "\improper M1911C service pistol"

--- a/maps/map_files/LV759_Hybrisa_Prospera/standalone/clfspaceport.dmm
+++ b/maps/map_files/LV759_Hybrisa_Prospera/standalone/clfspaceport.dmm
@@ -764,7 +764,7 @@
 	pixel_x = -1;
 	pixel_y = 5
 	},
-/obj/item/storage/box/clf{
+/obj/item/storage/box/fluff_gun/clf{
 	pixel_x = 8;
 	pixel_y = 1
 	},

--- a/tools/UpdatePaths/Scripts/11911-loadout-guns-path.txt
+++ b/tools/UpdatePaths/Scripts/11911-loadout-guns-path.txt
@@ -1,0 +1,4 @@
+/obj/item/storage/box/clf : /obj/item/storage/box/fluff_gun/clf{@OLD}
+/obj/item/storage/box/upp : /obj/item/storage/box/fluff_gun/upp{@OLD}
+/obj/item/storage/box/action : /obj/item/storage/box/fluff_gun/action{@OLD}
+/obj/item/storage/box/plinker : /obj/item/storage/box/fluff_gun/plinker{@OLD}


### PR DESCRIPTION

# About the pull request

Main thing this does is have the various pistol boxes now hold six magazines(the amount in a pistol belt) in addition to the pistol, instead of the 2 extra it was previous, in exchange these now cannot fit in backpacks, spawning in your hand instead.

This adds a pistol box for the L54, since despite essentially being an M4A3 reskin, it cannot fit M4a3 mags, leaving you with just the one

This adds an M1911 variant(without the damage mod) to the loadout menu, without the extra damage its basically a sidegrade/downgrade to the M4A3 stat-wise, so I don't think this is really a balance change.

Adds the NP92 as an additional option, fits alongside the Type 73 as UPP captured weapons taken as trophies

The VAIPO M1911 has the sleek silencer instead of the normal big one because I like the sprite.

To more easily do the first part's backpack change, loadout pistols are now their own subtype of boxes, with the details applied there(and changed on a case-per-case basis), additionally, some gearsets have changed their right hand to be open, allowing someone to spawn with a loadout pistol.

Also this gives 1 extra mag to both of the loadout holdout pistols, you can just drop the extra mag if you don't want to store it.
These can still fit in backpacks since they only have the pistol and 2 mags



This doesn't actually change maps I just changed a subtype to the new version with VSC.
# Explain why it's good for the game
In order:

Allows the cool special pistols you spent 4 loadout points on to be used with a pistol belt, ammo is still limited because you can't get more besides black market, but you get to play around with your cool guns more, I did the storage size changes so they aren't used as backpack pistol belts, you can just drop or store the extra mags somewhere if you don't have room

L54 is pretty cool, but only has a singular magazine that comes loaded in the gun, this gives you the extra mags that it didn't have before allowing you to use it for more than 12 shots

M1911 is peak soul, this adds the modernized version(M48A4) as it fits a tiny bit more as a modern production, its nothing out of the ordinary too considering the other loadout guns that have been added

I was asked to do this in the comments of this PR and I see no reason why not, it still fits with the other captured weapon, and is balance-wise not a concern.

This was easier to do, and makes it simpler for people to add more weapons in the future.

Just gives a bit more staying power for the pistols, so they aren't something you toss out after 2 uses, kept them with just an extra mag instead of the 6 like the others so they can still be stored in backpacks/shoulder holsters entirely, noone is putting these in a pistol belt anyway



I don't think anything in here is an actual balance concern but I tagged the magazine count changes anyway just in case.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>



:cl: Riot
add: Adds an M1911 variant and the NP92 as loadout point weapons.
add: The L54 now spawns with its own box with spare ammo
add: The M48A4 Tactical(VAIPO M1911) now spawns with the sleek silencer instead of the normal one
balance: Most pistol boxes from loadout menu now hold the pistol plus six magazines, but cannot fit in backpacks
/:cl:
