### PR TITLE
Fixes stray wall under a girder in LV Medbay Insert

### DIFF
--- a/maps/map_files/LV624/medbay/10.destroyed.dmm
+++ b/maps/map_files/LV624/medbay/10.destroyed.dmm
@@ -643,7 +643,7 @@ ih
 YV
 YV
 Il
-yU
+Jc
 QR
 QR
 YJ


### PR DESCRIPTION

# About the pull request

In the Destroyed Medbay insert, under one of the girders is a wall. This doesn't make sense... as the girder is the destroyed wall and it looks weird + is weird to decon twice.

# Explain why it's good for the game

It's good when things make sense.


# Testing Photographs and Procedure

Check MDB Bot


# Changelog

:cl: DangerRevolution
maptweak: Removed a stray wall under a girder in the LV Destroyed Medbay variation.
/:cl:
