### PR TITLE
Extinguishers can now be refilled

### DIFF
--- a/code/game/objects/items/tools/extinguisher.dm
+++ b/code/game/objects/items/tools/extinguisher.dm
@@ -247,6 +247,7 @@
 		if(T == target)
 			break
 		sleep(2)
+	sleep(2)
 	qdel(W)
 
 #undef BASE_EXTINGUISHER_PWR


### PR DESCRIPTION

# About the pull request

Allows fire extinguishers and portable fire extinguishers to be refilled from water sources by clicking on them. 
Valid water sources are: water tanks, sinks, showers, water bottles, and reagent containers holding pure water only.
Mixed reagents are rejected entirely. 
Also fixes a preexisting bug where the spray particle effect was invisible when firing at an adjacent tile.

Tested in-game: 
Refill from sinks, showers, water tanks, and water bottles. 
Verified mixed reagent containers are rejected. 
Verified spray visually works at 1 tile distance.

# Explain why it's good for the game

QoL update. 

Marines are grabbing 4+ portable fire extinguishers with an underslung extinguisher. This gives players a practical option to maintain their extinguishers in the field.

Made at Boonie's request. 

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Video of refill in action: 
https://streamable.com/dezyxn

Video showing that you cannot fill it with mixed reagent or non-pure water only mixes: 
https://streamable.com/oowlat
</details>

# Changelog

:cl:
add: Fire extinguishers (portable extinguishers too) can now be refilled from water tanks, sinks, water bottles, showers, and water-only reagent containers
fix: Fixed existing bug where adjacent extinguisher spray was not appearing visually
/:cl: