### PR TITLE
Tyrargo Rift Out of Bounds Areas fix

### DIFF
--- a/code/game/area/tyrargo_rift.dm
+++ b/code/game/area/tyrargo_rift.dm
@@ -34,7 +34,7 @@
 	icon_state = "unknown"
 	ceiling = CEILING_MAX
 	is_resin_allowed = FALSE
-	flags_area = AREA_NOTUNNEL
+	flags_area = AREA_NOTUNNEL|AREA_NOBURROW
 	minimap_color = MINIMAP_AREA_OOB
 	requires_power = FALSE
 	ambience_exterior = AMBIENCE_TYRARGO_CITY
@@ -569,7 +569,7 @@
 	icon_state = "Holodeck"
 	ceiling = CEILING_MAX
 	is_resin_allowed = FALSE
-	flags_area = AREA_NOTUNNEL
+	flags_area = AREA_NOTUNNEL|AREA_NOBURROW
 	requires_power = FALSE
 
 /area/tyrargo/underground/engineering
@@ -649,7 +649,7 @@
 	name = "32nd Armor Division: Staging Area - Southern Outskirts"
 	icon_state = "Holodeck"
 	is_resin_allowed = FALSE
-	flags_area = AREA_NOTUNNEL
+	flags_area = AREA_NOTUNNEL|AREA_NOBURROW
 	minimap_color = MINIMAP_AREA_SEC_CAVE
 	ceiling = CEILING_MAX
 	ceiling_muffle = FALSE


### PR DESCRIPTION

# About the pull request

Fixes the OOB areas of Tyrargo Rift by adding the proper flag that prevents burrowing. Prevents Burrowers from being able to burrow out of bounds.

Fixes #11784 

# Explain why it's good for the game

fixes good
stops evil burrower mains (like myself)


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Unknownity
fix: Burrowers are no longer able to burrow out of bounds in Tyrargo Rift.
/:cl:

