### PR TITLE
Fix null access runtime in jacket toggle verb

### DIFF
--- a/code/modules/clothing/suits/marine_coat.dm
+++ b/code/modules/clothing/suits/marine_coat.dm
@@ -54,16 +54,17 @@
 	set src in usr
 
 	if(usr.is_mob_incapacitated())
-		return 0
+		return FALSE
+	return toggle_buttoned(usr)
 
-	if(src.buttoned == TRUE)
-		src.icon_state = "[initial_icon_state]_o"
-		src.buttoned = FALSE
-		to_chat(usr, SPAN_INFO("You unbutton \the [src]."))
+/obj/item/clothing/suit/storage/jacket/marine/proc/toggle_buttoned(mob/user)
+	buttoned = !buttoned
+	if(!buttoned)
+		icon_state = "[initial_icon_state]_o"
+		to_chat(user, SPAN_INFO("You unbutton \the [src]."))
 	else
-		src.icon_state = "[initial_icon_state]"
-		src.buttoned = TRUE
-		to_chat(usr, SPAN_INFO("You button \the [src]."))
+		icon_state = initial_icon_state
+		to_chat(user, SPAN_INFO("You button \the [src]."))
 	update_clothing_icon()
 
 /obj/item/clothing/suit/storage/jacket/marine/Initialize()

--- a/code/modules/gear_presets/survivors/tyrargo_rift/us_army_survivors.dm
+++ b/code/modules/gear_presets/survivors/tyrargo_rift/us_army_survivors.dm
@@ -343,7 +343,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/patch/army/infantry, WEAR_ACCESSORY)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/ranks/army/o4, WEAR_ACCESSORY)
 	new_human.equip_to_slot_or_del(jacket, WEAR_JACKET)
-	jacket.toggle(new_human)
+	jacket.toggle_buttoned(new_human)
 	jacket.attach_accessory(new_human,patch_army)
 	jacket.attach_accessory(new_human,patch_infantry)
 	jacket.attach_accessory(new_human,boards)


### PR DESCRIPTION
# About the pull request
Fixes a runtime when Tyrargo survivors get their jackets.

# Explain why it's good for the game
Runtimes bad

# Testing Photographs and Procedure
No

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MoondancerPony
fix: fixed Tyrargo army CO survivors not starting with an unbuttoned jacket due to an error
/:cl: