### PR TITLE
Fix hivenumber not being passed to handle_xeno_hive_hud by weed food component

### DIFF
--- a/code/datums/mob_hud.dm
+++ b/code/datums/mob_hud.dm
@@ -280,7 +280,7 @@ GLOBAL_LIST_INIT_TYPED(huds, /datum/mob_hud, flatten_numeric_alist(alist(
 /mob/proc/add_to_all_mob_huds()
 	return
 
-/mob/hologram/queen/add_to_all_mob_huds(hivenumber)
+/mob/hologram/queen/add_to_all_mob_huds()
 	handle_xeno_hive_hud(hivenumber)
 	var/datum/mob_hud/hud = GLOB.huds[MOB_HUD_XENO_STATUS]
 	hud.add_to_hud(src)
@@ -297,7 +297,7 @@ GLOBAL_LIST_INIT_TYPED(huds, /datum/mob_hud, flatten_numeric_alist(alist(
 		hud.add_to_hud(src)
 	hud_set_new_player()
 
-/mob/living/carbon/xenomorph/add_to_all_mob_huds(hivenumber)
+/mob/living/carbon/xenomorph/add_to_all_mob_huds()
 	handle_xeno_hive_hud(hivenumber)
 	var/datum/mob_hud/hud = GLOB.huds[MOB_HUD_XENO_STATUS]
 	hud.add_to_hud(src)

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -842,7 +842,7 @@
 
 
 	//and display them
-	add_to_all_mob_huds(hivenumber)
+	add_to_all_mob_huds()
 	var/datum/mob_hud/MH = GLOB.huds[MOB_HUD_XENO_INFECTION]
 	MH.add_hud_to(src, src)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -112,7 +112,7 @@
 
 	hivenumber = Q.hivenumber
 	med_hud_set_status()
-	add_to_all_mob_huds(hivenumber)
+	add_to_all_mob_huds()
 
 	Q.sight |= SEE_TURFS|SEE_OBJS
 


### PR DESCRIPTION
# About the pull request
`hivenumber` was passed as a bespoke argument for only xenomorph mobs (xenomorphs and the queen eye). There was no reason for this, since it always used `src.hivenumber` anyway, so now we just use that.

# Explain why it's good for the game
Should address https://runtimes.cm-ss13.com/cm13/issues/187.

# Testing Photographs and Procedure
I really should test this but I'm not sure how.

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MoondancerPony
fix: fixed an error when weeds covering a xenomorph corpse die
/:cl:
