### PR TITLE
Fix area base lighting not working

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -111,11 +111,6 @@
 	if(light_power && light_range)
 		update_light()
 
-	//Get area light
-	var/area/current_area = loc
-	if(current_area?.lighting_effect)
-		overlays += current_area.lighting_effect
-
 	if(opacity)
 		directional_opacity = ALL_CARDINALS
 

--- a/code/game/turfs/walls/wall_icon.dm
+++ b/code/game/turfs/walls/wall_icon.dm
@@ -43,10 +43,6 @@
 				bullet_overlay = image('icons/effects/bulletholes.dmi', src, "bhole_[bullethole_state]_2")
 			overlays += bullet_overlay
 
-	var/area/my_area = loc
-	if(my_area.lighting_effect)
-		overlays += my_area.lighting_effect
-
 #undef BULLETHOLE_STATES
 #undef cur_increment
 

--- a/code/modules/lighting/lighting_area.dm
+++ b/code/modules/lighting/lighting_area.dm
@@ -41,8 +41,8 @@
 		add_base_lighting()
 
 /area/proc/remove_base_lighting()
-	for(var/turf/T in src)
-		T.overlays -= lighting_effect
+	overlays -= lighting_effect
+	luminosity = initial(luminosity)
 	QDEL_NULL(lighting_effect)
 	area_has_base_lighting = FALSE
 
@@ -53,7 +53,6 @@
 	lighting_effect.blend_mode = BLEND_ADD
 	lighting_effect.alpha = base_lighting_alpha
 	lighting_effect.color = base_lighting_color
-	for(var/turf/T in src)
-		T.overlays += lighting_effect
-		T.luminosity = 1
+	overlays += lighting_effect
+	luminosity = 1
 	area_has_base_lighting = TRUE

--- a/code/modules/lighting/lighting_static/static_lighting_turf.dm
+++ b/code/modules/lighting/lighting_static/static_lighting_turf.dm
@@ -39,8 +39,3 @@
 				static_lighting_build_overlay(new_area)
 			else
 				static_lighting_clear_overlay()
-	//Inherit overlay of new area
-	if(old_area.lighting_effect)
-		overlays -= old_area.lighting_effect
-	if(new_area.lighting_effect)
-		overlays += new_area.lighting_effect


### PR DESCRIPTION
# About the pull request
#11863 accidentally included an incomplete change that broke area base lighting, because I was optimizing it but reverted the changes (or so I thought) to put in a separate PR. That broke space, runtime map, tutorial, and vehicle area lighting...

Basically, now we use area overlays instead of turf overlays, which is much faster. If we port planecube we'll have to go back to using turf overlays I think, though.

# Explain why it's good for the game
Fixes #11929. Also technically an optimization.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

<img width="1057" height="1057" alt="image" src="https://github.com/user-attachments/assets/ed662ad9-c5cc-4139-ac18-0f23ceed3ce3" />

<img width="1057" height="1057" alt="image" src="https://github.com/user-attachments/assets/f5f6d7d6-6f9c-4593-bd05-51cf5513e6db" />

<img width="1057" height="1057" alt="image" src="https://github.com/user-attachments/assets/3cff8fc7-4afa-43bd-9dd9-9f1347e107a5" />


</details>


# Changelog

:cl: MoondancerPony
del: broke area-based lighting
fix: fixed area-based lighting
/:cl: