### PR TITLE
Random req creates slight rebalance

### DIFF
--- a/code/datums/ASRS.dm
+++ b/code/datums/ASRS.dm
@@ -30,7 +30,7 @@
 // Magazines
 /datum/supply_packs_asrs/gun/ammo_hpr
 	reference_package = /datum/supply_packs/ammo_hpr
-	cost = ASRS_LOWEST_WEIGHT
+	cost = ASRS_VERY_LOW_WEIGHT
 
 /datum/supply_packs_asrs/ammo_m4a3_mag_box
 	reference_package = /datum/supply_packs/ammo_m4a3_mag_box
@@ -72,14 +72,7 @@
 
 /datum/supply_packs_asrs/ammo_smartgun
 	reference_package = /datum/supply_packs/ammo_smartgun
-
-/datum/supply_packs_asrs/ammo_napalm
-	reference_package = /datum/supply_packs/ammo_napalm
-	cost = ASRS_VERY_LOW_WEIGHT
-
-/datum/supply_packs_asrs/ammo_napalm_gel
-	reference_package = /datum/supply_packs/ammo_napalm_gel
-	cost = ASRS_VERY_LOW_WEIGHT
+	cost = ASRS_LOW_WEIGHT
 
 /datum/supply_packs_asrs/ammo_flamer_mixed
 	reference_package = /datum/supply_packs/ammo_flamer_mixed
@@ -105,7 +98,7 @@
 
 /datum/supply_packs_asrs/sandbags
 	reference_package = /datum/supply_packs/sandbags
-	cost = ASRS_LOWEST_WEIGHT
+	cost = ASRS_LOW_WEIGHT
 
 // ============================
 // FOOD POOL - for Mess Tech gradual supplies throughout the round


### PR DESCRIPTION

# About the pull request

random create code is... strange to say at least. I for example intended for sandbags to spawn randomly in req in a PR that increased metal and palsteel cost but aperently they do not spawn at all (or so rarly none knows) this increases sandabg spawn chance and reduces sg and flamer fuel spawn chances. based on reports they have never seen the free sandbags or HPR creates and have piles of flamer fuel around

sandbags should be in 6% of the random creates now, meaning 25 creates in every 15 creates on avrage making for less then two bags per random create

# Explain why it's good for the game
Adds some ammo strain on SG ammo, req does not have ten times more req fuel then anyone can ever use and sandbags show up as inteanded


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: increases random sandbag crate spawn chance
balance: increases random HPR crate spawn chance
balance: reduces random flamer fuel crate spawn chance
balance: reduces random smartgun ammo crate spawn chance
/:cl:
