### PR TITLE
Extinguishers can now be refilled from more water sources

### DIFF
--- a/code/game/objects/items/tools/extinguisher.dm
+++ b/code/game/objects/items/tools/extinguisher.dm
@@ -118,7 +118,7 @@
 	if(is_type_in_typecache(target, refill_sources))
 		if(is_type_in_typecache(target, refill_excluded) || target == src)
 			return
-		if(!proximity_flag)
+		if(!target.Adjacent(user))
 			return
 		if(istype(target, /obj/structure/sink))
 			var/obj/structure/sink/target_sink = target

--- a/code/game/objects/structures/sink.dm
+++ b/code/game/objects/structures/sink.dm
@@ -55,7 +55,7 @@
 
 
 /obj/structure/sink/attackby(obj/item/attacking_item, mob/living/user, list/mods)
-	if(istype(attacking_item, /obj/item/tool/extinguisher))
+	if(istype(attacking_item, /obj/item/tool/extinguisher) || istype(attacking_item, /obj/item/attachable/attached_gun/extinguisher))
 		return
 
 	if(busy)

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -3666,7 +3666,7 @@ Defined in conflicts.dm of the #defines folder.
 	w_class = SIZE_MEDIUM
 	attachment_action_type = /datum/action/item_action/toggle/ext
 	slot = "under"
-	flags_attach_features = ATTACH_REMOVABLE|ATTACH_ACTIVATION|ATTACH_WEAPON|ATTACH_MELEE
+	flags_attach_features = ATTACH_REMOVABLE|ATTACH_ACTIVATION|ATTACH_RELOADABLE|ATTACH_WEAPON|ATTACH_MELEE
 	var/obj/item/tool/extinguisher/internal_extinguisher
 	current_rounds = 1 //This has to be done to pass the fire_attachment check.
 
@@ -3696,10 +3696,16 @@ Defined in conflicts.dm of the #defines folder.
 	internal_extinguisher.create_reagents(internal_extinguisher.max_water)
 	internal_extinguisher.reagents.add_reagent("water", internal_extinguisher.max_water)
 
+/obj/item/attachable/attached_gun/extinguisher/reload_attachment(obj/item/used_item, mob/user)
+	internal_extinguisher.attackby(used_item, user)
+
+/obj/item/attachable/attached_gun/extinguisher/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+	return internal_extinguisher.afterattack(target, user, proximity_flag, click_parameters)
+
 /obj/item/attachable/attached_gun/extinguisher/pyro
 	name = "HME-88B underbarrel extinguisher"
 	desc = "An experimental Taiho-Technologies HME-88B underbarrel extinguisher integrated with a select few gun models. It is capable of putting out the strongest of flames. Point at flame before applying pressure."
-	flags_attach_features = ATTACH_ACTIVATION|ATTACH_WEAPON|ATTACH_MELEE //not removable
+	flags_attach_features = ATTACH_ACTIVATION|ATTACH_RELOADABLE|ATTACH_WEAPON|ATTACH_MELEE //not removable
 
 /obj/item/attachable/attached_gun/extinguisher/pyro/initialize_internal_extinguisher()
 	internal_extinguisher = new /obj/item/tool/extinguisher/pyro()


### PR DESCRIPTION
# About the pull request

Allows extinguishers and underslung extinguishers to be refilled from water bottles, flasks, sinks, water tanks, and water coolers. 
Mixed reagents are rejected. 
Fixes an existing bug where the spray effect was invisible when firing at own or adjacent tile.

# Explain why it's good for the game

QoL update. 

Marines are grabbing 4+ portable fire extinguishers with an underslung extinguisher. Gives players a practical option to maintain their extinguishers in the field. Made at Boonie's request.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Video of refill in action: 
https://streamable.com/dezyxn

Video showing that you cannot fill it with mixed reagent or non-pure water only mixes: 
https://streamable.com/oowlat
</details>

# Changelog

:cl:
add: Fire extinguishers (portable extinguishers and underslung extinguishers) can now be refilled from water bottles, flasks, sinks, water tanks, and water coolers. 
fix: Fixed existing bug where adjacent extinguisher spray was not appearing visually
/:cl: