### PR TITLE
fixes army freq prefix

### DIFF
--- a/tgui/packages/tgui-say/constants.ts
+++ b/tgui/packages/tgui-say/constants.ts
@@ -249,8 +249,8 @@ export const RADIO_PREFIXES = {
     label: 'Yautja',
   },
   ':s ': {
-    id: 'cia',
-    label: 'CIA',
+    id: 'army',
+    label: 'Army',
   },
   '.s ': {
     id: 'army',
@@ -331,6 +331,18 @@ export const RADIO_PREFIXES = {
   '#1 ': {
     id: 'wypub',
     label: 'W-Y Pub',
+  },
+  ':2 ': {
+    id: 'cia',
+    label: 'CIA',
+  },
+  '.2 ': {
+    id: 'cia',
+    label: 'CIA',
+  },
+  '#2 ': {
+    id: 'cia',
+    label: 'CIA',
   },
   ':z ': {
     id: 'highcom',


### PR DESCRIPTION

# About the pull request

fully moves CIA prefixes to :2, fully moves army prefixes to :S

# Explain why it's good for the game

I was asked to


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Riot
fix: Fixes the army tgui prefixes
/:cl:
