### PR TITLE
Toolbelt Quality of Life Fix

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -2785,6 +2785,7 @@
 		/obj/item/ammo_magazine/pistol,
 		/obj/item/ammo_magazine/revolver,
 		/obj/item/ammo_magazine/handful,
+		/obj/item/ammo_magazine/smg/nailgun,
 	)
 	bypass_w_limit = list(
 		/obj/item/tool/shovel/etool,


### PR DESCRIPTION


# About the pull request

Allows Combat Toolbelts to hold magazines for nailguns.

# Explain why it's good for the game

Combat Toolbelts can hold revolvers, flare guns, and a variety of other big items, but not spare magazines for additional nails. This is silly, and is to be amended.

# Testing Photographs and Procedure
N/A 




# Changelog

:cl:
balance: Combat Toolbelts may now hold nails.
/:cl:

