### PR TITLE
Adds flush option to Reagent Pouch Autoinjectors

### DIFF
--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -609,7 +609,7 @@
 	if(!reagents.total_volume)
 		to_chat(usr, SPAN_WARNING("[src] is already empty!"))
 		return
-	playsound(src.loc, 'sound/effects/slosh.ogg', 25, 1, 3)
+	playsound(loc, 'sound/effects/slosh.ogg', 25, 1, 3)
 	to_chat(usr, SPAN_WARNING("You work the flush valve and empty [src]'s contents!"))
 	reagents.clear_reagents()
 	uses_left = 0


### PR DESCRIPTION

# About the pull request
Adds a flush option to the Reagent Pouch Autoinjectors. 

# Explain why it's good for the game
You currently can flush pouch containers, but not the injectors. Meaning, after flushing your container, your injector is STILL filled with reagents that you had wanted cleared out, yet they're stuck in it with no way out other than injecting them into yourself and hope you don't OD. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

</details>


# Changelog
:cl:
qol: Reagent Pouch Autoinjectors can now be flushed.
/:cl:
