### PR TITLE
Adds a HealthMate HUD to Medic Gear Vendor

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_medic.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_medic.dm
@@ -46,7 +46,6 @@ GLOBAL_LIST_INIT(cm_vending_gear_medic, list(
 		list("Roller Bed", 4, /obj/item/roller, null, VENDOR_ITEM_REGULAR),
 		list("Health Analyzer", 4, /obj/item/device/healthanalyzer, null, VENDOR_ITEM_REGULAR),
 		list("Stasis Bag", 6, /obj/item/bodybag/cryobag, null, VENDOR_ITEM_REGULAR),
-		list("HealthMate HUD", 1, /obj/item/clothing/glasses/hud/health, null, VENDOR_ITEM_REGULAR),
 
 		list("EXPLOSIVES", 0, null, null, null),
 		list("M40 HEDP High Explosive Packet (x3 grenades)", 18, /obj/item/storage/box/packet/high_explosive, null, VENDOR_ITEM_REGULAR),
@@ -132,6 +131,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_medic, list(
 		list("Combat Sterile Gloves", 0, /obj/item/clothing/gloves/marine/medical, MARINE_CAN_BUY_GLOVES, VENDOR_ITEM_REGULAR),
 		list("MRE", 0, /obj/item/storage/box/mre, MARINE_CAN_BUY_MRE, VENDOR_ITEM_MANDATORY),
 		list("Map", 0, /obj/item/map/current_map, MARINE_CAN_BUY_MAP, VENDOR_ITEM_MANDATORY),
+		list("HealthMate HUD", 0, /obj/item/clothing/glasses/hud/health, MARINE_CAN_BUY_GLASSES, VENDOR_ITEM_REGULAR),
 
 		list("ARMOR (CHOOSE 1)", 0, null, null, null),
 		list("Light Armor", 0, /obj/item/clothing/suit/storage/marine/light, MARINE_CAN_BUY_ARMOR, VENDOR_ITEM_REGULAR),


### PR DESCRIPTION
# About the pull request

Adds a HealthMate HUD to the medic gear vendor under Standard Equipment.

# Explain why it's good for the game

Absolutely no reason why it shouldn't have them. Medics can already get them for free aplenty from WeyMeds.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
</details>


# Changelog
:cl:
add: HealthMate HUD added to the medic gear vendor.
/:cl:
