### PR TITLE
Medics' Vendor Rebalance

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_medic.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_medic.dm
@@ -16,15 +16,15 @@ GLOBAL_LIST_INIT(cm_vending_gear_medic, list(
 		list("Burn Kit", 1, /obj/item/stack/medical/advanced/ointment, null, VENDOR_ITEM_REGULAR),
 		list("Trauma Kit", 1, /obj/item/stack/medical/advanced/bruise_pack, null, VENDOR_ITEM_REGULAR),
 		list("Medical Splints", 1, /obj/item/stack/medical/splint, null, VENDOR_ITEM_REGULAR),
-		list("Blood Bag (O-)", 2, /obj/item/reagent_container/blood/OMinus, null, VENDOR_ITEM_REGULAR),
+		list("Blood Bag (O-)", 4, /obj/item/reagent_container/blood/OMinus, null, VENDOR_ITEM_REGULAR),
 
 		list("FIRSTAID KITS", 0, null, null, null),
-		list("Advanced Firstaid Kit", 10, /obj/item/storage/firstaid/adv, null, VENDOR_ITEM_RECOMMENDED),
-		list("Firstaid Kit", 3, /obj/item/storage/firstaid/regular, null, VENDOR_ITEM_REGULAR),
-		list("Fire Firstaid Kit", 3, /obj/item/storage/firstaid/fire, null, VENDOR_ITEM_REGULAR),
-		list("Toxin Firstaid Kit", 3, /obj/item/storage/firstaid/toxin, null, VENDOR_ITEM_REGULAR),
-		list("Oxygen Firstaid Kit", 3, /obj/item/storage/firstaid/o2, null, VENDOR_ITEM_REGULAR),
-		list("Radiation Firstaid Kit", 3, /obj/item/storage/firstaid/rad, null, VENDOR_ITEM_REGULAR),
+		list("Advanced Firstaid Kit", 8, /obj/item/storage/firstaid/adv, null, VENDOR_ITEM_RECOMMENDED),
+		list("Firstaid Kit", 5, /obj/item/storage/firstaid/regular, null, VENDOR_ITEM_REGULAR),
+		list("Fire Firstaid Kit", 6, /obj/item/storage/firstaid/fire, null, VENDOR_ITEM_REGULAR),
+		list("Toxin Firstaid Kit", 6, /obj/item/storage/firstaid/toxin, null, VENDOR_ITEM_REGULAR),
+		list("Oxygen Firstaid Kit", 6, /obj/item/storage/firstaid/o2, null, VENDOR_ITEM_REGULAR),
+		list("Radiation Firstaid Kit", 6, /obj/item/storage/firstaid/rad, null, VENDOR_ITEM_REGULAR),
 		list("Advanced Firstaid Kit (Empty)", 1, /obj/item/storage/firstaid/adv/empty, null, VENDOR_ITEM_REGULAR),
 
 		list("PILL BOTTLES", 0, null, null, null),
@@ -102,7 +102,6 @@ GLOBAL_LIST_INIT(cm_vending_gear_medic, list(
 		list("Laser Designator", 15, /obj/item/device/binoculars/range/designator, null, VENDOR_ITEM_REGULAR),
 
 		list("HELMET OPTICS", 0, null, null, null),
-		list("Medical Helmet Optic", 10, /obj/item/device/helmet_visor/medical, null, VENDOR_ITEM_REGULAR),
 		list("Welding Visor", 5, /obj/item/device/helmet_visor/welding_visor, null, VENDOR_ITEM_REGULAR),
 
 		list("PAMPHLETS", 0, null, null, null),


### PR DESCRIPTION
## SUMMARY
- Rebalances the medics' vendor point costs to a sensible level.
- Adds HealthMate HUDs, medical helmet optics, and empty firstaid kits to the vendor.

## REASONING
I firmly believe that loadout costs should create real tradeoffs and minimize unnecessary time waste for the same outcome. Each point spent should feel like something weighed against alternatives without unnecessarily and arbitrarily limiting player choice through imposed artificial scarcity, without creating purchase pitfalls, and without wasting their time for no good reason. 

If the basis behind the vendor point system is to create a tough but interesting budgeting choice for players, then keeping meaningless pitfalls that will leave vendor items 100% of the time unused is simply bad game mechanics and should be fixed.

For example, WeyMeds and medbay provide free and plentiful full pill bottles, burn kits, trauma kits, roller beds, etc., yet the medic prep vendor charges 5 points for a **single** pill bottle, 2 points for a **single** kit, and even 4 points for a roller bed. 
Players will never purchase these items at the prep vendor when they can just get them from WeyMeds and medbay for free aplenty. The point cost here isn't a trade-off, it's a cost that eliminates options. Entire vendor line items become deadweight and absolute net loss waste with no upside whatsoever. 

_"But it's a learned experience!"_
Realizing that you shouldn't spend limited points on pill bottles and other freebie items because they're free in the next room is not savvy play and choice optimization between valid options, it's the blunt realization that spending those 5+ points is a waste and that doing so costs you variety and utility elsewhere. 

Yes, mostly new players to each role would fall prey to this, but why even keep it this way? What is the benefit in this? It's purely going to result in frustration and players questioning if they're being suckered into point waste for every item purchase decision. 

**More importantly,** these pitfalls nudge players early on into rational choice decision-making for every potential purchase which inevitably leads them down the path of cost-minimizing hyperefficiency powergaming, where these players, now attuned to this frustrating experience, will seek to maximize point allocation and finding free alternatives all over Almayer. This is a problem in and of itself and, as I argue, the pre-deployment time cost here is not a commodity that should ever be on the table as a trade-off for a multitude of reasons.

If you want to make interesting and appealing choices with a limited budget, then give players reasonable, proper, and **accessible** choices and alternatives to try out different options and builds. Give players a limited pool of points and many tempting niche options with limited access to them, but do not add unreasonable high point costs for staples that they can get from medbay for free because they will **never** buy them at that price.

Similarly, locking webbings for Riflemen behind 15 points when they're free in the next room is a net loss with zero upside. It's a noob trap that later becomes a wasted line item. It breeds player frustration for what reason? None whatsoever.

_"High point cost is the cost of convenience! Time spent collecting stuff is the trade-off!"_ 
This is both invalid and even damaging because pre-deployment time on the Almayer isn't an opportunity cost. It's a subtraction from something that shouldn't be on the table at all. The RP and player interaction that happens before drop builds relationships, squad dynamics, and stories that carry into the mission itself. That's not a resource to be traded against gear acquisition. Spending ten minutes racing to chase equipment before the first drop doesn't produce a return, it just removes something that has compounding value and replaces it with nothing. 

The value of pre-deployment RP is invisible until it happens. 
You can't miss a conversation that never started and nobody at the prep screen is weighing kit cost against something they don't know they're losing. 
Players don't recognize this tradeoff during prep which is what makes it damaging, it just doesn't show up in any visible calculus. The value of a new squad relationship or a conversation that shapes the mission isn't quantifiable in the prep screen and it's unknown so it never enters the decision at all.

This PR should fit in with the current gameplay without causing unnecessary changes or disruption to the existing gameplay. Players are going to powergame anyway and find the least costly route every single time, these point problems give them more reason to do so. But even then why fight it? Instead, accept that players will always seek to rationally powergame and lean into it by adapting game mechanics around that. If players are running around medbay, req, prep to get basic staples as a medic, just give them easier access to the staples. They're doing it anyway, you just save them time for other matters and RP. Maybe they can even have time to attend brief.

I would oppose changes to fundamental gameplay, but this is just reasonable

## CHANGES
### **New items added:**
- ~HealthMate HUD (1 pts) added to MEDICAL UTILITIES~
- Advanced Firstaid Kit (Empty) (1 pt) added to FIRSTAID KITS
- ~Medical Helmet Optic (10 pts) added to HELMET OPTICS~

### **Point cost reductions:**

**- Roller Bed: 4 -> 1**
_(can get these for free at medbay, no reason to charge more)_

**- Health Analyzer: 4 -> 1**
_(can get these for free at medbay, no reason to charge more)_

**- Burn Kit: 2 -> 1**
_(can get these for free at medbay, no reason to charge more)_

**- Trauma Kit: 2 -> 1** 
_(can get these for free at medbay, no reason to charge more)_

**- Stasis Bag: 6 -> 3**
_(6 is too much to justify buying any, medics would often go without any if they cant get from medbay than buy one for 6 points)_

**- Mini Smart Refill Tank: 6 -> 5**
_(slightly cheaper, why 5? Why 6? When uncertain, round down)_

**- FixOVein: 7 -> 5**
_(a slight upgrade for IBs, already costs an additional inventory space over just surgical wire, reduce the points cost, the cost is already inherent in the space it takes for very niche and limited use)_

**- Advanced Firstaid Kit: 12 -> ~10~ 8**
_(12 and even 10 is too much, but slightly decreased cost, less controversial)_

**- Filled Pill Bottles: 5 -> 1**
_(plenty for free in 6+ WeyMeds, one of each already in your lifesaver belt bag, half rendered useless by better Chemist meds, no reason they should even cost 5, even 1 is too much)_

**- Autoinjectors (basically epi, rest were 1): 2 -> 1**
_(plenty for free everywhere, why cost 2? Why even cost 1?)_

**- USCM Radio Telephone Pack: 15 -> 10**
_(reaching Normandy for medevac is crucial, you can already get 3 for free in prep, reduce the cost and leave a proper decision dilemma between getting a radio pack or more inventory space with a backpack/rocketeer's pack)_ 

**- Fire Extinguisher (Portable): 3 -> 1**
_(available for free publicly in several machines, get it in prep to save prep time)_

~**- Firstaid Kit: 5 -> 3**
_(also too much considering there's a ton in medbay that go without use, contents are useless for a medic anyway, only value is in the container)_~

~**- Fire/Toxin/Oxygen/Radiation Firstaid Kits: 6 -> 3**
_(same as above)_~

~**- Blood Bag (O-): 4 -> 2**~
~_(limited availability in medbay, shouldnt be 4 given medics get two each, 2 points is reasonable)_~

### **Point cost increase:**
**- Welding Goggles: 3 -> 5**

### **Recommendation changes:**
**- Burn Kit: Recommended -> Regular**
**- Trauma Kit: Recommended -> Regular**
**- FixOVein: Regular -> Recommended**

### **Section reordered:**
**- Medical Utilities moved to directly after Medical Set (was previously after Autoinjectors)**

# Explain why it's good for the game

The medic's predeployment prep is a timeconsuming mess. 

A part of that is the medic's vendor has point costs which are completely disconnected from the actual value of the items. Nobody is spending 5 points on a pill bottle, 4 points on a health analyzer, or 2 points per kit when they can just grab the same stuff from medbay before deployment. 
It just sends medics on unnecessary loops throughout medbay when the vendor should be handling it.

This PR brings the costs down to something sensible so the vendor is actually worth using.

I would actually be very happy if we can add a couple of WeyMeds vendors to the medic's prep room, but this will have to suffice for now. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: HealthMate HUD added to emdic vendor
add: Empty advanced firstaid kit added to medic vendor
add: Medical helmet optic added to medic vendor
qol: Rebalanced point cost for multiple medic vendor items
/:cl:
