### PR TITLE
Research can make announcements regarding published chemicals.

### DIFF
--- a/code/__DEFINES/dcs/signals/atom/signals_obj.dm
+++ b/code/__DEFINES/dcs/signals/atom/signals_obj.dm
@@ -20,6 +20,9 @@
 #define COMSIG_BLEEDING_PROCESS "bleeding_process"
 	#define COMPONENT_BLEEDING_CANCEL (1<<0)
 
+// From /obj/structure/machinery/computer/research/ui_act()
+#define COMSIG_CHEMICAL_ANNOUNCEMENT "chemical_announcement"
+
 /// From /obj/effect/alien/weeds/Initialize()
 #define COMSIG_WEEDNODE_GROWTH_COMPLETE "weednode_growth_complete"
 /// From /obj/effect/alien/weeds/Initialize()

--- a/code/game/machinery/computer/research.dm
+++ b/code/game/machinery/computer/research.dm
@@ -209,5 +209,22 @@
 				playsound(loc, 'sound/machines/buzz-two.ogg', 5, 1)
 				langchat_speech("There are no contracts to reprint available", get_mobs_in_view(7, src), GLOB.all_languages, skip_language_check = TRUE, additional_styles = list("langchat_small"))
 				visible_message("[icon2html(src, viewers(src))] \The <b>[src]</b> speaks: There are no contracts to reprint available")
+		if("announce")
+			if(!COOLDOWN_FINISHED(GLOB.chemical_data, announcement_cooldown))
+				to_chat(ui.user, SPAN_WARNING("You cant announce about chemicals that quick!"))
+				return
+			var/print_type = params["print_type"]
+			var/print_title = params["print_title"]
+			var/obj/item/paper/research_report/report = GLOB.chemical_data.get_report(print_type, print_title)
+			for(var/i in 1 to length(GLOB.chemical_data.research_publications?["[print_type]"]))
+				if(GLOB.chemical_data.research_publications?["[print_type]"][i]["document"] == report )
+					var/message = sanitize_control_chars(tgui_input_text(ui.user, "Type a message you want to announce to medical staff regarding [report.data.name]. Only the personnel with medical HUD will see it. You'll be put on 4 minute cooldown to announce again.", "Chemical Advisory Announcement.", max_length = 400, multiline = TRUE))
+					log_game("[key_name(ui.user)] sent '[message]' as a chemical advisory announcement.")
+					message_admins("[key_name(ui.user)] made a chemical announcment. Contents: ([message]) [ADMIN_JMP_USER(ui.user)]")
+					SEND_SIGNAL(GLOB.chemical_data, COMSIG_CHEMICAL_ANNOUNCEMENT, message, report.data.name)
+					COOLDOWN_START(GLOB.chemical_data, announcement_cooldown, 4 MINUTES)
+					return
+			to_chat(ui.user, SPAN_NOTICE("The document must be published to announce information to medical staff. Ask Chief Medical Officer to publish it."))
+
 
 	playsound(loc, pick('sound/machines/computer_typing1.ogg','sound/machines/computer_typing2.ogg','sound/machines/computer_typing3.ogg'), 5, 1)

--- a/code/game/machinery/computer/research.dm
+++ b/code/game/machinery/computer/research.dm
@@ -211,14 +211,14 @@
 				visible_message("[icon2html(src, viewers(src))] \The <b>[src]</b> speaks: There are no contracts to reprint available")
 		if("announce")
 			if(!COOLDOWN_FINISHED(GLOB.chemical_data, announcement_cooldown))
-				to_chat(ui.user, SPAN_WARNING("You cant announce about chemicals that quick!"))
+				to_chat(ui.user, SPAN_WARNING("You can't announce about chemicals that quick!"))
 				return
 			var/print_type = params["print_type"]
 			var/print_title = params["print_title"]
 			var/obj/item/paper/research_report/report = GLOB.chemical_data.get_report(print_type, print_title)
 			for(var/i in 1 to length(GLOB.chemical_data.research_publications?["[print_type]"]))
 				if(GLOB.chemical_data.research_publications?["[print_type]"][i]["document"] == report )
-					var/message = sanitize_control_chars(tgui_input_text(ui.user, "Type a message you want to announce to medical staff regarding [report.data.name]. Only the personnel with medical HUD will see it. You'll be put on 4 minute cooldown to announce again.", "Chemical Advisory Announcement.", max_length = 400, multiline = TRUE))
+					var/message = sanitize_control_chars(tgui_input_text(ui.user, "Type a message you want to announce to medical staff regarding [report.data.name]. Only personnel with medical HUD will see it. There is a 4 minute cooldown to announce again.", "Chemical Advisory Announcement.", max_length = 400, multiline = TRUE))
 					log_game("[key_name(ui.user)] sent '[message]' as a chemical advisory announcement.")
 					message_admins("[key_name(ui.user)] made a chemical announcment. Contents: ([message]) [ADMIN_JMP_USER(ui.user)]")
 					SEND_SIGNAL(GLOB.chemical_data, COMSIG_CHEMICAL_ANNOUNCEMENT, message, report.data.name)

--- a/code/game/objects/items/devices/helmet_visors.dm
+++ b/code/game/objects/items/devices/helmet_visors.dm
@@ -88,16 +88,19 @@
 /obj/item/device/helmet_visor/medical/advanced
 	name = "advanced medical optic"
 	helmet_overlay = "med_sight_right"
+	var/datum/weakref/equipped_user
 
 /obj/item/device/helmet_visor/medical/advanced/activate_visor(obj/item/clothing/head/helmet/marine/attached_helmet, mob/living/carbon/human/user)
 	. = ..()
-
+	equipped_user = WEAKREF(user)
+	user.RegisterSignal(GLOB.chemical_data, COMSIG_CHEMICAL_ANNOUNCEMENT, PROC_REF(announce_to_user), override = TRUE)
 	var/datum/action/item_action/view_publications/helmet_visor/publication_action = new(attached_helmet)
 	publication_action.give_to(user)
 
 /obj/item/device/helmet_visor/medical/advanced/deactivate_visor(obj/item/clothing/head/helmet/marine/attached_helmet, mob/living/carbon/human/user)
 	. = ..()
-
+	equipped_user = null
+	UnregisterSignal(GLOB.chemical_data, COMSIG_CHEMICAL_ANNOUNCEMENT)
 	var/datum/action/item_action/view_publications/helmet_visor/publication_action = locate() in attached_helmet.actions
 	qdel(publication_action)
 
@@ -111,6 +114,11 @@
 		return FALSE
 
 	return TRUE
+
+/obj/item/device/helmet_visor/medical/advanced/proc/announce_to_user(datum/source, text, name)
+	var/mob/player = equipped_user.resolve()
+	playsound_client(player.client, 'sound/effects/radiostatic.ogg', player.loc, 25, FALSE)
+	player.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>Chemical Advisory: [name]</u></span><br>[text]", /atom/movable/screen/text/screen_text/chemical_advisory, "#13d182", TRUE)
 
 /obj/item/device/helmet_visor/medical/advanced/ui_state(mob/user)
 	return GLOB.not_incapacitated_and_adjacent_strict_state

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -21,6 +21,24 @@
 	actions_types = list(/datum/action/item_action/toggle/hudgoggles, /datum/action/item_action/view_publications)
 	req_skill = SKILL_MEDICAL
 	req_skill_level = SKILL_MEDICAL_MEDIC
+	var/datum/weakref/equipped_user
+
+/obj/item/clothing/glasses/hud/health/equipped(mob/user, slot)
+	. = ..()
+	if(slot == "glasses")
+		equipped_user = WEAKREF(user)
+		RegisterSignal(GLOB.chemical_data, COMSIG_CHEMICAL_ANNOUNCEMENT, PROC_REF(announce_to_user))
+
+/obj/item/clothing/glasses/hud/health/unequipped(mob/user, slot)
+	. = ..()
+	if(slot == "glasses")
+		equipped_user = null
+		UnregisterSignal(GLOB.chemical_data, COMSIG_CHEMICAL_ANNOUNCEMENT)
+
+/obj/item/clothing/glasses/hud/health/proc/announce_to_user(datum/source, text, name)
+	var/mob/player = equipped_user.resolve()
+	playsound_client(player.client, 'sound/effects/radiostatic.ogg', player.loc, 25, FALSE)
+	player.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>Chemical Advisory: [name]</u></span><br>[text]", /atom/movable/screen/text/screen_text/chemical_advisory, "#13d182")
 
 /obj/item/clothing/glasses/hud/health/prescription
 	name = "\improper Prescription HealthMate HUD"

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -38,7 +38,7 @@
 /obj/item/clothing/glasses/hud/health/proc/announce_to_user(datum/source, text, name)
 	var/mob/player = equipped_user.resolve()
 	playsound_client(player.client, 'sound/effects/radiostatic.ogg', player.loc, 25, FALSE)
-	player.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>Chemical Advisory: [name]</u></span><br>[text]", /atom/movable/screen/text/screen_text/chemical_advisory, "#13d182")
+	player.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>Chemical Advisory: [name]</u></span><br>[text]", /atom/movable/screen/text/screen_text/chemical_advisory, "#13d182", TRUE)
 
 /obj/item/clothing/glasses/hud/health/prescription
 	name = "\improper Prescription HealthMate HUD"

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -25,13 +25,13 @@
 
 /obj/item/clothing/glasses/hud/health/equipped(mob/user, slot)
 	. = ..()
-	if(slot == "glasses")
+	if(slot == WEAR_EYES)
 		equipped_user = WEAKREF(user)
 		RegisterSignal(GLOB.chemical_data, COMSIG_CHEMICAL_ANNOUNCEMENT, PROC_REF(announce_to_user))
 
 /obj/item/clothing/glasses/hud/health/unequipped(mob/user, slot)
 	. = ..()
-	if(slot == "glasses")
+	if(slot == WEAR_EYES)
 		equipped_user = null
 		UnregisterSignal(GLOB.chemical_data, COMSIG_CHEMICAL_ANNOUNCEMENT)
 

--- a/code/modules/maptext_alerts/screen_alerts.dm
+++ b/code/modules/maptext_alerts/screen_alerts.dm
@@ -90,6 +90,19 @@
 	fade_out_delay = 10 SECONDS
 	fade_out_time = 3 SECONDS
 
+
+/atom/movable/screen/text/screen_text/chemical_advisory
+	maptext_height = 64
+	maptext_width = 480
+	maptext_x = 0
+	maptext_y = 0
+	screen_loc = "LEFT,TOP-3"
+
+	letters_per_update = 1
+	fade_out_delay = 6 SECONDS
+	style_open = "<span class='langchat' style=font-size:16pt;text-align:center valign='top'>"
+	style_close = "</span>"
+
 ///proc for actually playing this screen_text on a mob.
 /atom/movable/screen/text/screen_text/proc/play_to_client()
 	player?.add_to_screen(src)

--- a/code/modules/maptext_alerts/screen_alerts.dm
+++ b/code/modules/maptext_alerts/screen_alerts.dm
@@ -10,13 +10,16 @@
  * * alert_type: typepath for screen text type we want to play here
  * * override_color: the color of the text to use
  */
-/mob/proc/play_screen_text(text, alert_type = /atom/movable/screen/text/screen_text, override_color = "#FFFFFF")
+/mob/proc/play_screen_text(text, alert_type = /atom/movable/screen/text/screen_text, override_color = "#FFFFFF", cancel_duplicate = FALSE)
 	var/atom/movable/screen/text/screen_text/text_box = new alert_type()
 	text_box.text_to_play = text
 	text_box.player = client
 	if(override_color)
 		text_box.color = override_color
-
+	if(cancel_duplicate)
+		for(var/atom/i in client.screen_texts)
+			if(i.type == text_box.type)
+				return
 	LAZYADD(client.screen_texts, text_box)
 	if(LAZYLEN(client.screen_texts) == 1) //lets only play one at a time, for thematic effect and prevent overlap
 		INVOKE_ASYNC(text_box, TYPE_PROC_REF(/atom/movable/screen/text/screen_text, play_to_client))

--- a/code/modules/reagents/chemical_research/Chemical-Research.dm
+++ b/code/modules/reagents/chemical_research/Chemical-Research.dm
@@ -23,6 +23,7 @@ GLOBAL_DATUM_INIT(chemical_data, /datum/chemical_data, new)
 	var/list/chemical_objective_list = list() //List of all objective reagents indexed by ID associated with the objective value
 	var/list/chemical_not_completed_objective_list = list() //List of not completed objective reagents indexed by ID associated with the objective value
 	var/list/chemical_identified_list = list() //List of all identified objective reagents indexed by ID associated with the objective value
+	COOLDOWN_DECLARE(announcement_cooldown)
 	var/list/research_computers = list()
 
 /datum/chemical_data/proc/update_credits(change)

--- a/tgui/packages/tgui/interfaces/ResearchTerminal.tsx
+++ b/tgui/packages/tgui/interfaces/ResearchTerminal.tsx
@@ -143,6 +143,11 @@ const CompoundRecord = (props: CompoundRecordProps) => {
               </Button>
             </Flex.Item>
           )}
+          <Flex.Item>
+            <Button icon="exclamation" onClick={() => act('announce', doc_ref)}>
+              Announce
+            </Button>
+          </Flex.Item>
           {isMainTerminal && !compound.isPublished && (
             <Flex.Item>
               <Button


### PR DESCRIPTION

# About the pull request

This adds a button to all chemicals in research terminal that allows researchers send maptext messages to everyone who is wearing a medical hud, on a 4 minute cooldown.

closes #12113 


Only published chemicals are allowed to be announced, making CMO able to be held accountable. 
<!-- Remove this text and explain what the purpose of your PR is.


Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #12345" to link the PR to the corresponding Issue number #12345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #12345, Fixes #12346, Fixes #12347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
This will ease the already extremely difficult logistics part of the research, allowing research to focus on more engaging matters.

# Testing Photographs and Procedure
<img width="1422" height="812" alt="Screenshot 2026-03-16 165031" src="https://github.com/user-attachments/assets/db8ca2e2-96af-4739-9264-0d45c18df1ab" />
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Research can announce information about their chemicals to everyone with a medical hud. This requires CMO to publish their work first, though.
/:cl:
