### PR TITLE
Food wraps are trash

### DIFF
--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -3340,7 +3340,7 @@
 		to_chat(user, SPAN_NOTICE("You pull off the wrapping from the squishy burrito!"))
 		RemoveElement(/datum/element/corp_label/wy)
 		package = 0
-		new /obj/item/trash/buritto (user.loc)
+		user.put_in_hands(new /obj/item/trash/buritto)
 		icon_state = "open-burrito"
 		item_state = "burrito"
 
@@ -3368,7 +3368,7 @@
 		to_chat(user, SPAN_NOTICE("You pull off the wrapping from the squishy hamburger!"))
 		RemoveElement(/datum/element/corp_label/wy)
 		package = 0
-		new /obj/item/trash/burger (user.loc)
+		user.put_in_hands(new /obj/item/trash/burger)
 		icon_state = "hburger"
 		item_state = "burger"
 
@@ -3396,7 +3396,7 @@
 		to_chat(user, SPAN_NOTICE("You pull off the wrapping from the squishy hotdog!"))
 		RemoveElement(/datum/element/corp_label/wy)
 		package = 0
-		new /obj/item/trash/hotdog (user.loc)
+		user.put_in_hands(new /obj/item/trash/hotdog)
 		icon_state = "open-hotdog"
 		item_state = "hotdog"
 
@@ -3459,7 +3459,7 @@
 		playsound(loc,'sound/effects/pageturn2.ogg', 15, 1)
 
 		if(wrapper)
-			new wrapper(user.loc)
+			user.put_in_hands(new wrapper)
 		icon_state = "[initial(icon_state)]-o"
 		item_state = "[initial(item_state)]-o"
 		package = 0

--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -3333,8 +3333,6 @@
 	AddElement(/datum/element/corp_label/wy)
 
 /obj/item/reagent_container/food/snacks/packaged_burrito/attack_self(mob/user)
-	..()
-
 	if(package)
 		playsound(src.loc,'sound/effects/pageturn2.ogg', 15, 1)
 		to_chat(user, SPAN_NOTICE("You pull off the wrapping from the squishy burrito!"))
@@ -3343,6 +3341,8 @@
 		user.put_in_hands(new /obj/item/trash/buritto)
 		icon_state = "open-burrito"
 		item_state = "burrito"
+		return
+	..()
 
 /obj/item/reagent_container/food/snacks/packaged_burger
 	name = "Packaged Cheeseburger"
@@ -3361,8 +3361,6 @@
 	AddElement(/datum/element/corp_label/wy)
 
 /obj/item/reagent_container/food/snacks/packaged_burger/attack_self(mob/user)
-	..()
-
 	if(package)
 		playsound(src.loc,'sound/effects/pageturn2.ogg', 15, 1)
 		to_chat(user, SPAN_NOTICE("You pull off the wrapping from the squishy hamburger!"))
@@ -3371,6 +3369,8 @@
 		user.put_in_hands(new /obj/item/trash/burger)
 		icon_state = "hburger"
 		item_state = "burger"
+		return
+	..()
 
 /obj/item/reagent_container/food/snacks/packaged_hdogs
 	name = "Packaged Hotdog"
@@ -3389,8 +3389,6 @@
 	AddElement(/datum/element/corp_label/wy)
 
 /obj/item/reagent_container/food/snacks/packaged_hdogs/attack_self(mob/user)
-	..()
-
 	if(package)
 		playsound(src.loc,'sound/effects/pageturn2.ogg', 15, 1)
 		to_chat(user, SPAN_NOTICE("You pull off the wrapping from the squishy hotdog!"))
@@ -3399,6 +3397,8 @@
 		user.put_in_hands(new /obj/item/trash/hotdog)
 		icon_state = "open-hotdog"
 		item_state = "hotdog"
+		return
+	..()
 
 /obj/item/reagent_container/food/snacks/eat_bar
 	name = "MEAT Bar"
@@ -3452,8 +3452,6 @@
 	var/obj/item/trash/wrapper = null //Why this and not trash? Because it pulls the wrapper off when you unwrap it as a trash item.
 
 /obj/item/reagent_container/food/snacks/wrapped/attack_self(mob/user)
-	..()
-
 	if(package)
 		to_chat(user, SPAN_NOTICE("You pull open the package of [src]!"))
 		playsound(loc,'sound/effects/pageturn2.ogg', 15, 1)
@@ -3463,6 +3461,8 @@
 		icon_state = "[initial(icon_state)]-o"
 		item_state = "[initial(item_state)]-o"
 		package = 0
+		return
+	..()
 
 //CM SNACKS
 /obj/item/reagent_container/food/snacks/wrapped/booniebars


### PR DESCRIPTION

# About the pull request

Makes marines take off the wrappers off their food first, instead of unnecessarily giving the message that its still on yet eating it anyways.
Pulled off wrappers try going into a free hand first instead of always onto the ground.

# Explain why it's good for the game

Make wrappers act like they are supposed to: Very good
Also less filthy marines leaving trash everywhere. No need to pick the trash off the floor after automatically dropping it to put it in a bin.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Marines now need to take the wrappers off their food instead of just eating through it.
qol: Food wrappers will now go into a hand if possible, instead of onto the ground.
/:cl:
