### PR TITLE
Organ healing no longer gives pain message

### DIFF
--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -79,7 +79,7 @@
 		src.damage += amount
 
 	var/obj/limb/parent = owner.get_limb(parent_limb)
-	if(!silent)
+	if(!silent && amount > 0)
 		owner.custom_pain("Something inside your [parent.display_name] hurts a lot.", 1)
 	set_organ_status()
 


### PR DESCRIPTION

# About the pull request

Organ healing no longer gives pain message.

# Explain why it's good for the game

Misleading messages bad. I have a sneaky feeling that this is the primary source of false "bad stim" cries from marines.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Organ healing chemicals no longer produce messages falsely indicating organ damage being taken.
/:cl:
