### PR TITLE
Defender un-crests on death

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Defender.dm
@@ -113,27 +113,44 @@
 	if(!action_cooldown_check())
 		return
 
-	xeno.crest_defense = !xeno.crest_defense
+	if(!xeno.crest_defense)
+		RegisterSignal(owner, COMSIG_XENO_ENTER_CRIT, PROC_REF(unconscious_check))
+		RegisterSignal(owner, COMSIG_MOB_DEATH, PROC_REF(unconscious_check))
+		headcrest_switch(xeno, TRUE)
+		if(xeno.selected_ability != src)
+			button.icon_state = "template_active"
+	else
+		UnregisterSignal(owner, COMSIG_XENO_ENTER_CRIT)
+		UnregisterSignal(owner, COMSIG_MOB_DEATH)
+		headcrest_switch(xeno, FALSE)
+		if(xeno.selected_ability != src)
+			button.icon_state = "template_xeno"
 
-	if(xeno.crest_defense)
+	apply_cooldown()
+	return ..()
+
+/datum/action/xeno_action/onclick/toggle_crest/proc/headcrest_switch(mob/living/carbon/xenomorph/xeno, crest_state)
+	if(xeno.crest_defense == crest_state)
+		return
+
+	if(crest_state)
 		to_chat(xeno, SPAN_XENOWARNING("We lower our crest."))
 
 		xeno.ability_speed_modifier += speed_debuff
 		xeno.armor_deflection_buff += armor_buff
+		xeno.crest_defense = TRUE
 		xeno.mob_size = MOB_SIZE_BIG //knockback immune
 		button.icon_state = "template_active"
-		xeno.update_icons()
 	else
 		to_chat(xeno, SPAN_XENOWARNING("We raise our crest."))
 
 		xeno.ability_speed_modifier -= speed_debuff
 		xeno.armor_deflection_buff -= armor_buff
+		xeno.crest_defense = FALSE
 		xeno.mob_size = MOB_SIZE_XENO //no longer knockback immune
 		button.icon_state = "template_xeno"
-		xeno.update_icons()
 
-	apply_cooldown()
-	return ..()
+	xeno.update_icons()
 
 // Defender Headbutt
 /datum/action/xeno_action/activable/headbutt/use_ability(atom/target_atom)
@@ -346,3 +363,12 @@
 	UnregisterSignal(owner, COMSIG_MOB_DEATH)
 	fortify_switch(owner, FALSE)
 
+/datum/action/xeno_action/onclick/toggle_crest/proc/unconscious_check()
+	SIGNAL_HANDLER
+
+	if(QDELETED(owner))
+		return
+
+	UnregisterSignal(owner, COMSIG_XENO_ENTER_CRIT)
+	UnregisterSignal(owner, COMSIG_MOB_DEATH)
+	headcrest_switch(owner, FALSE)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Defender.dm
@@ -114,14 +114,12 @@
 		return
 
 	if(!xeno.crest_defense)
-		RegisterSignal(owner, COMSIG_XENO_ENTER_CRIT, PROC_REF(unconscious_check))
-		RegisterSignal(owner, COMSIG_MOB_DEATH, PROC_REF(unconscious_check))
+		RegisterSignal(owner, COMSIG_MOB_STATCHANGE, PROC_REF(unconscious_check))
 		headcrest_switch(xeno, TRUE)
 		if(xeno.selected_ability != src)
 			button.icon_state = "template_active"
 	else
-		UnregisterSignal(owner, COMSIG_XENO_ENTER_CRIT)
-		UnregisterSignal(owner, COMSIG_MOB_DEATH)
+		UnregisterSignal(owner, COMSIG_MOB_STATCHANGE)
 		headcrest_switch(xeno, FALSE)
 		if(xeno.selected_ability != src)
 			button.icon_state = "template_xeno"
@@ -284,14 +282,12 @@
 	playsound(get_turf(xeno), 'sound/effects/stonedoor_openclose.ogg', 30, 1)
 
 	if(!xeno.fortify)
-		RegisterSignal(owner, COMSIG_XENO_ENTER_CRIT, PROC_REF(unconscious_check))
-		RegisterSignal(owner, COMSIG_MOB_DEATH, PROC_REF(unconscious_check))
+		RegisterSignal(owner, COMSIG_MOB_STATCHANGE, PROC_REF(unconscious_check))
 		fortify_switch(xeno, TRUE)
 		if(xeno.selected_ability != src)
 			button.icon_state = "template_active"
 	else
-		UnregisterSignal(owner, COMSIG_XENO_ENTER_CRIT)
-		UnregisterSignal(owner, COMSIG_MOB_DEATH)
+		UnregisterSignal(owner, COMSIG_MOB_STATCHANGE)
 		fortify_switch(xeno, FALSE)
 		if(xeno.selected_ability != src)
 			button.icon_state = "template_xeno"
@@ -359,8 +355,7 @@
 	if(QDELETED(owner))
 		return
 
-	UnregisterSignal(owner, COMSIG_XENO_ENTER_CRIT)
-	UnregisterSignal(owner, COMSIG_MOB_DEATH)
+	UnregisterSignal(owner, COMSIG_MOB_STATCHANGE)
 	fortify_switch(owner, FALSE)
 
 /datum/action/xeno_action/onclick/toggle_crest/proc/unconscious_check()
@@ -369,6 +364,5 @@
 	if(QDELETED(owner))
 		return
 
-	UnregisterSignal(owner, COMSIG_XENO_ENTER_CRIT)
-	UnregisterSignal(owner, COMSIG_MOB_DEATH)
+	UnregisterSignal(owner, COMSIG_MOB_STATCHANGE)
 	headcrest_switch(owner, FALSE)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Defender.dm
@@ -328,3 +328,21 @@
 		xeno.armor_deflection_buff -= 30
 		xeno.armor_explosive_buff -= 60
 		xeno.small_explosives_stun = TRUE
+
+/datum/action/xeno_action/activable/fortify/proc/check_directional_armor(mob/living/carbon/xenomorph/defendy, list/damagedata)
+	SIGNAL_HANDLER
+	var/projectile_direction = damagedata["direction"]
+	// If the defender is facing the projectile.
+	if(defendy.dir & REVERSE_DIR(projectile_direction))
+		damagedata["armor"] += frontal_armor
+
+/datum/action/xeno_action/activable/fortify/proc/unconscious_check()
+	SIGNAL_HANDLER
+
+	if(QDELETED(owner))
+		return
+
+	UnregisterSignal(owner, COMSIG_XENO_ENTER_CRIT)
+	UnregisterSignal(owner, COMSIG_MOB_DEATH)
+	fortify_switch(owner, FALSE)
+

--- a/code/modules/mob/living/carbon/xenomorph/castes/Defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Defender.dm
@@ -352,17 +352,11 @@
 /datum/action/xeno_action/activable/fortify/proc/unconscious_check()
 	SIGNAL_HANDLER
 
-	if(QDELETED(owner))
-		return
-
 	UnregisterSignal(owner, COMSIG_MOB_STATCHANGE)
 	fortify_switch(owner, FALSE)
 
 /datum/action/xeno_action/onclick/toggle_crest/proc/unconscious_check()
 	SIGNAL_HANDLER
-
-	if(QDELETED(owner))
-		return
 
 	UnregisterSignal(owner, COMSIG_MOB_STATCHANGE)
 	headcrest_switch(owner, FALSE)

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/defender/steel_crest.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/defender/steel_crest.dm
@@ -36,22 +36,6 @@
 		xeno.ability_speed_modifier -= 3
 		xeno.damage_modifier += XENO_DAMAGE_MOD_SMALL
 
-/datum/action/xeno_action/activable/fortify/proc/check_directional_armor(mob/living/carbon/xenomorph/defendy, list/damagedata)
-	SIGNAL_HANDLER
-	var/projectile_direction = damagedata["direction"]
-	// If the defender is facing the projectile.
-	if(defendy.dir & REVERSE_DIR(projectile_direction))
-		damagedata["armor"] += frontal_armor
-
-/datum/action/xeno_action/activable/fortify/proc/unconscious_check()
-	SIGNAL_HANDLER
-
-	if(QDELETED(owner))
-		return
-
-	UnregisterSignal(owner, COMSIG_XENO_ENTER_CRIT)
-	UnregisterSignal(owner, COMSIG_MOB_DEATH)
-	fortify_switch(owner, FALSE)
 
 /datum/action/xeno_action/onclick/soak/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/steelcrest = owner


### PR DESCRIPTION

# About the pull request

Defender dying with crest down or fortified would keep the crest down properties, namely being large, which makes it unbuckleable to a normal rolled bed, which is annoying.

If someone has any idea how to unduplicate the two signal handlers without moving it up to parent _datum/action/xeno_action_  that would be nice to hear.

# Explain why it's good for the game

Bug bad

# Testing Photographs and Procedure
Test procedure:
Spawn in defender, kill it, buckle it to bed, unbuckle
Aheal, fortify, kill it, buckle to bed, unbuckle
Aheal, fortify again, kill, buckle, unbuckle
Aheal, crest down, kill, buckle, unbuckle
Aheal, go steelcrest strain, fortify, kill, buckle, unbuckle
Aheal, crest down, kill, buckle

Behaved as expected


# Changelog
:cl:
fix: Defenders dying while having their crest down or fortified no longer stops them from being buckled to a rollerbed.
/:cl:
