### PR TITLE
Unpowered disposals can be emptied

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -271,13 +271,13 @@
 ///Human interact with machine
 /obj/structure/machinery/disposal/attack_hand(mob/user as mob)
 	if(user)
-		if(stat & NOPOWER && ishuman(user) && (contents && contents.len != 0))
-			to_chat(usr, SPAN_NOTICE("You begin to empty the [name]."))
-			if(do_after(user, 20, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
+		if((stat & NOPOWER) && ishuman(user) && length(contents)))
+			to_chat(user, SPAN_NOTICE("You begin to empty the [name]."))
+			if(do_after(user, 2 SECONDS, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 				eject()
 			return
 		if(user.loc == src)
-			to_chat(usr, SPAN_DANGER("You cannot reach the controls from inside."))
+			to_chat(user, SPAN_DANGER("You cannot reach the controls from inside."))
 			return
 
 	tgui_interact(user)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -271,7 +271,7 @@
 ///Human interact with machine
 /obj/structure/machinery/disposal/attack_hand(mob/user as mob)
 	if(user)
-		if(stat & NOPOWER && ishuman(user))
+		if(stat & NOPOWER && ishuman(user) && (contents && contents.len != 0))
 			to_chat(usr, SPAN_NOTICE("You begin to empty the [name]."))
 			if(do_after(user, 20, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 				eject()

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -271,7 +271,7 @@
 ///Human interact with machine
 /obj/structure/machinery/disposal/attack_hand(mob/user as mob)
 	if(user)
-		if((stat & NOPOWER) && ishuman(user) && length(contents)))
+		if((stat & NOPOWER) && ishuman(user) && length(contents))
 			to_chat(user, SPAN_NOTICE("You begin to empty the [name]."))
 			if(do_after(user, 2 SECONDS, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 				eject()

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -270,9 +270,15 @@
 
 ///Human interact with machine
 /obj/structure/machinery/disposal/attack_hand(mob/user as mob)
-	if(user && user.loc == src)
-		to_chat(usr, SPAN_DANGER("You cannot reach the controls from inside."))
-		return
+	if(user)
+		if(stat & NOPOWER && ishuman(user))
+			to_chat(usr, SPAN_NOTICE("You begin to empty the [name]."))
+			if(do_after(user, 20, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
+				eject()
+			return
+		if(user.loc == src)
+			to_chat(usr, SPAN_DANGER("You cannot reach the controls from inside."))
+			return
 
 	tgui_interact(user)
 


### PR DESCRIPTION

# About the pull request

Makes one able to empty an unpowered disposals bin, mainly meant to make intel items easier to retrieve.

# Explain why it's good for the game

If an intel items end up being thrown in by an explosion or similar thing the IOs wont have to go fix the APC which may be far behind enemy lines just to retrieve said sad piece of intel (often happens on C_Claim A-Block dorms).
But also is generally useful if say a marine accidentally puts their gun in an unpowered bin.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: Unpowered disposal bins can now be manually emptied by hand.
/:cl:
