### PR TITLE
Optimize lighting and convert underlay lights to objects

### DIFF
--- a/code/__DEFINES/dcs/signals/atom/signals_obj.dm
+++ b/code/__DEFINES/dcs/signals/atom/signals_obj.dm
@@ -75,3 +75,6 @@
 // from /obj/item/device/binoculars/range/designator/acquire_target()
 #define COMSIG_DESIGNATOR_LASE "comsig_designator_lase"
 #define COMSIG_DESIGNATOR_LASE_OFF "comsig_designator_lase_off"
+
+/// From /datum/reagent/water/reaction_obj()
+#define COMSIG_OBJ_EXTINGUISH "obj_extinguish"

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -30,94 +30,94 @@ SUBSYSTEM_DEF(lighting)
 	. = ..("ShCalcs:[total_shadow_calculations]|SourcQ:[length(static_sources_queue)]|CcornQ:[length(corners_queue)]|ObjQ:[length(objects_queue)]|HybrQ:[length(mask_queue)]")
 
 /datum/controller/subsystem/lighting/fire(resumed, init_tick_checks)
-	MC_SPLIT_TICK_INIT(3)
+	MC_SPLIT_TICK_INIT(4)
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
-	var/updators_num = 0
-	while(updators_num < length(static_sources_queue))
-		updators_num += 1
-
-		var/datum/static_light_source/L = static_sources_queue[updators_num]
-		L.update_corners()
-
-		if(!QDELETED(L))
-			L.needs_update = LIGHTING_NO_UPDATE
+	// anything added while processing gets deferred to the next tick
+	var/current_index = 0
+	while(current_index < length(static_sources_queue))
+		current_index += 1
+		var/datum/static_light_source/source = static_sources_queue[current_index]
+		source.update_corners()
+		// source.update_corners() can qdel(source) in certain conditions,
+		// and we don't include them in the count to cut because they're already removed
+		if(!QDELING(source))
+			source.needs_update = LIGHTING_NO_UPDATE
 		else
-			updators_num -= 1
+			current_index -= 1
 		if(init_tick_checks)
 			if(!TICK_CHECK)
 				continue
-			static_sources_queue.Cut(1, updators_num + 1)
-			updators_num = 0
+			static_sources_queue.Cut(1, current_index + 1)
+			current_index = 0
 			stoplag()
 		else if (MC_TICK_CHECK)
 			break
-	if(updators_num)
-		static_sources_queue.Cut(1, updators_num + 1)
-		updators_num = 0
+	if(current_index)
+		static_sources_queue.Cut(1, current_index + 1)
+		current_index = 0
 
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
 
-	while(updators_num < length(corners_queue))
-		updators_num += 1
-
-		var/datum/static_lighting_corner/C = corners_queue[updators_num]
-		C.needs_update = FALSE //update_objects() can call qdel if the corner is storing no data
-		C.update_objects()
+	while(current_index < length(corners_queue))
+		current_index += 1
+		var/datum/static_lighting_corner/corner = corners_queue[current_index]
+		corner.update_objects()
+		corner.needs_update = FALSE //update_objects() can call qdel if the corner is storing no data
+		if(QDELING(corner))
+			current_index -= 1
 
 		if(init_tick_checks)
 			if(!TICK_CHECK)
 				continue
-			corners_queue.Cut(1, updators_num + 1)
-			updators_num = 0
+			corners_queue.Cut(1, current_index + 1)
+			current_index = 0
 			stoplag()
 		else if (MC_TICK_CHECK)
 			break
-	if(updators_num)
-		corners_queue.Cut(1, updators_num + 1)
-		updators_num = 0
+	if(current_index)
+		corners_queue.Cut(1, current_index + 1)
+		current_index = 0
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
 
-	while(updators_num < length(objects_queue))
-		updators_num += 1
-
-		var/datum/static_lighting_object/O = objects_queue[updators_num]
-		if (QDELETED(O))
-			continue
-		O.update()
-		O.needs_update = FALSE
-
+	while(current_index < length(objects_queue))
+		current_index += 1
+		var/datum/static_lighting_object/lighting_object = objects_queue[current_index]
+		// these can't delete themselves in update() and so nothing in this should be qdeleted
+		ASSERT(!QDELETED(lighting_object))
+		lighting_object.update()
+		lighting_object.needs_update = FALSE
 		if(init_tick_checks)
 			if(!TICK_CHECK)
 				continue
-			objects_queue.Cut(1, updators_num + 1)
-			updators_num = 0
+			objects_queue.Cut(1, current_index + 1)
+			current_index = 0
+			stoplag()
 		else if (MC_TICK_CHECK)
 			break
-	if(updators_num)
-		objects_queue.Cut(1, updators_num + 1)
-		updators_num = 0
+	if(current_index)
+		objects_queue.Cut(1, current_index + 1)
+		current_index = 0
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
 
-	while(updators_num > length(mask_queue))
-		updators_num += 1
-
-		var/atom/movable/lighting_mask/mask_to_update = mask_queue[updators_num]
+	while(current_index < length(mask_queue))
+		current_index += 1
+		var/atom/movable/lighting_mask/mask_to_update = mask_queue[current_index]
+		ASSERT(!QDELETED(mask_to_update)) // nothing in this list should be qdeleted when we loop
 		mask_to_update.calculate_lighting_shadows()
-
 		if(init_tick_checks)
 			if(!TICK_CHECK)
 				continue
-			mask_queue.Cut(1, updators_num + 1)
-			updators_num = 0
+			mask_queue.Cut(1, current_index + 1)
+			current_index = 0
 			stoplag()
 		else if (MC_TICK_CHECK)
 			break
-	if(updators_num)
-		mask_queue.Cut(1, updators_num + 1)
+	if(current_index)
+		mask_queue.Cut(1, current_index + 1)
 
 /datum/controller/subsystem/lighting/Recover()
 	initialized = SSlighting.initialized

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -84,7 +84,7 @@ SUBSYSTEM_DEF(lighting)
 
 	while(current_index < length(objects_queue))
 		current_index += 1
-		var/datum/static_lighting_object/lighting_object = objects_queue[current_index]
+		var/atom/movable/static_lighting_object/lighting_object = objects_queue[current_index]
 		// these can't delete themselves in update() and so nothing in this should be qdeleted
 		ASSERT(!QDELETED(lighting_object))
 		lighting_object.update()

--- a/code/datums/lazy_template.dm
+++ b/code/datums/lazy_template.dm
@@ -96,7 +96,7 @@
 		if(!turf_area.static_lighting)
 			continue
 
-		new /datum/static_lighting_object(initializing_turf)
+		new /atom/movable/static_lighting_object(initializing_turf)
 
 	SSatoms.InitializeAtoms(loaded_areas + loaded_atom_movables + loaded_turfs)
 

--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -1568,6 +1568,7 @@
 /obj/item/reagent_container/food/snacks/monkeycube/Initialize()
 	. = ..()
 	reagents.add_reagent("meatprotein",10)
+	RegisterSignal(src, COMSIG_OBJ_EXTINGUISH, PROC_REF(on_extinguish))
 
 /obj/item/reagent_container/food/snacks/monkeycube/afterattack(obj/O, mob/user, proximity)
 	if(!proximity)
@@ -1621,8 +1622,8 @@
 		new monkey_type(T)
 	qdel(src)
 
-/obj/item/reagent_container/food/snacks/monkeycube/extinguish()
-	. = ..()
+/obj/item/reagent_container/food/snacks/monkeycube/proc/on_extinguish()
+	SIGNAL_HANDLER
 	if(!package)
 		Expand()
 

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -230,6 +230,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	flags_atom |= NOREACT // so it doesn't react until you light it
 	create_reagents(chem_volume) // making the cigarette a chemical holder with a maximum volume of 15
 	reagents.add_reagent("nicotine",10)
+	RegisterSignal(src, COMSIG_OBJ_EXTINGUISH, PROC_REF(handle_extinguish))
 	if(w_class == SIZE_TINY)
 		AddElement(/datum/element/mouth_drop_item)
 
@@ -427,11 +428,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	. = ..()
 	if(!heat_source)
 		light()
-
-/obj/item/clothing/mask/cigarette/extinguish()
-	. = ..()
-	if(heat_source)
-		go_out()
 
 /obj/item/clothing/mask/cigarette/proc/handle_extinguish()
 	SIGNAL_HANDLER

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -328,9 +328,6 @@
 
 	O.name += " ([label])"
 
-/obj/proc/extinguish()
-	return
-
 /obj/handle_flamer_fire(obj/flamer_fire/fire, damage, delta_time)
 	. = ..()
 	flamer_fire_act(damage, fire.weapon_cause_data)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -534,11 +534,7 @@
 	//static Update
 	if(SSlighting.initialized)
 		recalculate_directional_opacity()
-
 		W.static_lighting_object = old_lighting_object
-
-		if(static_lighting_object && !static_lighting_object.needs_update)
-			static_lighting_object.update()
 
 	//Since the old turf was removed from hybrid_lights_affecting, readd the new turf here
 	if(W.hybrid_lights_affecting)
@@ -841,7 +837,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 
 /// Remove all atoms except observers, landmarks, docking ports - clearing up the turf contents
 /turf/proc/empty(turf_type=/turf/open/space, baseturf_type, list/ignore_typecache, flags)
-	var/static/list/ignored_atoms = typecacheof(list(/mob/dead, /obj/effect/landmark, /obj/docking_port))
+	var/static/list/ignored_atoms = typecacheof(list(/mob/dead, /obj/effect/landmark, /obj/docking_port, /atom/movable/static_lighting_object))
 	var/list/removable_contents = typecache_filter_list_reverse(GetAllContentsIgnoring(ignore_typecache), ignored_atoms)
 	removable_contents -= src
 	for(var/i in 1 to length(removable_contents))

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -191,7 +191,7 @@
 	set name = "Delete Instance"
 
 	// to prevent REALLY stupid deletions
-	var/blocked = list(/obj, /obj/item, /obj/effect, /obj/structure/machinery, /mob, /mob/living, /mob/living/carbon, /mob/living/carbon/xenomorph, /mob/living/carbon/human, /mob/dead, /mob/dead/observer, /mob/living/silicon, /mob/living/silicon/ai)
+	var/blocked = list(/obj, /obj/item, /obj/effect, /obj/structure/machinery, /mob, /mob/living, /mob/living/carbon, /mob/living/carbon/xenomorph, /mob/living/carbon/human, /mob/dead, /mob/dead/observer, /mob/living/silicon, /mob/living/silicon/ai, /atom/movable/static_lighting_object)
 	var/chosen_deletion = input(usr, "Type the path of the object you want to delete", "Delete:") as null|text
 	if(chosen_deletion)
 		chosen_deletion = text2path(chosen_deletion)

--- a/code/modules/droppod/droppod_ui.dm
+++ b/code/modules/droppod/droppod_ui.dm
@@ -34,7 +34,7 @@ GLOBAL_LIST_INIT(droppod_target_mode, list(
 	new /datum/admin_podlauncher(usr)//create the datum
 
 /datum/admin_podlauncher
-	var/static/list/ignored_atoms = typecacheof(list(null, /mob/dead, /obj/effect/landmark, /obj/effect/particle_effect/sparks, /obj/effect/warning))
+	var/static/list/ignored_atoms = typecacheof(list(null, /mob/dead, /obj/effect/landmark, /obj/effect/particle_effect/sparks, /obj/effect/warning, /atom/movable/static_lighting_object))
 
 	var/client/holder
 	var/area/admin/droppod/loading/bay

--- a/code/modules/lighting/lighting_mask/lighting_mask.dm
+++ b/code/modules/lighting/lighting_mask/lighting_mask.dm
@@ -50,7 +50,8 @@
 
 /atom/movable/lighting_mask/Destroy()
 	//Make sure we werent destroyed in init
-	SSlighting.mask_queue -= src
+	if(awaiting_update)
+		SSlighting.mask_queue -= src
 	//Remove from affecting turfs
 	if(affecting_turfs)
 		for(var/turf/thing as anything in affecting_turfs)

--- a/code/modules/lighting/lighting_mask/shadow_calculator.dm
+++ b/code/modules/lighting/lighting_mask/shadow_calculator.dm
@@ -43,7 +43,9 @@
 
 ///Enqueues the mask in the queue properly
 /atom/movable/lighting_mask/proc/queue_mask_update()
-	SSlighting.mask_queue |= src
+	if(awaiting_update || QDELING(src)) // don't update us if we're qdeling
+		return
+	SSlighting.mask_queue += src
 	awaiting_update = TRUE
 
 /**

--- a/code/modules/lighting/lighting_static/static_lighting_corner.dm
+++ b/code/modules/lighting/lighting_static/static_lighting_corner.dm
@@ -109,7 +109,7 @@
 	lum_g += delta_g
 	lum_b += delta_b
 
-	if(!needs_update)
+	if(!needs_update && !QDELING(src))
 		needs_update = TRUE
 		SSlighting.corners_queue += src
 
@@ -139,22 +139,22 @@
 	src.largest_color_luminosity = round(largest_color_luminosity, LIGHTING_ROUND_VALUE)
 
 	var/datum/static_lighting_object/lighting_object = master_NE?.static_lighting_object
-	if (lighting_object && !lighting_object.needs_update)
+	if (!QDELETED(lighting_object) && !lighting_object.needs_update)
 		lighting_object.needs_update = TRUE
 		SSlighting.objects_queue += lighting_object
 
 	lighting_object = master_SE?.static_lighting_object
-	if (lighting_object && !lighting_object.needs_update)
+	if (!QDELETED(lighting_object) && !lighting_object.needs_update)
 		lighting_object.needs_update = TRUE
 		SSlighting.objects_queue += lighting_object
 
 	lighting_object = master_SW?.static_lighting_object
-	if (lighting_object && !lighting_object.needs_update)
+	if (!QDELETED(lighting_object) && !lighting_object.needs_update)
 		lighting_object.needs_update = TRUE
 		SSlighting.objects_queue += lighting_object
 
 	lighting_object = master_NW?.static_lighting_object
-	if (lighting_object && !lighting_object.needs_update)
+	if (!QDELETED(lighting_object) && !lighting_object.needs_update)
 		lighting_object.needs_update = TRUE
 		SSlighting.objects_queue += lighting_object
 

--- a/code/modules/lighting/lighting_static/static_lighting_corner.dm
+++ b/code/modules/lighting/lighting_static/static_lighting_corner.dm
@@ -138,7 +138,7 @@
 
 	src.largest_color_luminosity = round(largest_color_luminosity, LIGHTING_ROUND_VALUE)
 
-	var/datum/static_lighting_object/lighting_object = master_NE?.static_lighting_object
+	var/atom/movable/static_lighting_object/lighting_object = master_NE?.static_lighting_object
 	if (!QDELETED(lighting_object) && !lighting_object.needs_update)
 		lighting_object.needs_update = TRUE
 		SSlighting.objects_queue += lighting_object

--- a/code/modules/lighting/lighting_static/static_lighting_object.dm
+++ b/code/modules/lighting/lighting_static/static_lighting_object.dm
@@ -1,46 +1,65 @@
-/datum/static_lighting_object
-	///the underlay we are currently applying to our turf to apply light
-	var/mutable_appearance/current_underlay
-
+/atom/movable/static_lighting_object
+	name          = ""
+	anchored      = TRUE
+	icon          = LIGHTING_ICON
+	icon_state    = "transparent"
+	color         = LIGHTING_BASE_MATRIX
+	plane         = LIGHTING_PLANE
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	invisibility  = INVISIBILITY_LIGHTING
+	vis_flags     = VIS_HIDE
+	unacidable    = TRUE
 	///whether we are already in the SSlighting.objects_queue list
 	var/needs_update = FALSE
-
 	///the turf that our light is applied to
 	var/turf/affected_turf
 
-/datum/static_lighting_object/New(turf/source)
-	if(!isturf(source))
-		qdel(src, force=TRUE)
-		stack_trace("a lighting object was assigned to [source], a non turf!")
-		return
-	..()
+/atom/movable/static_lighting_object/Initialize(mapload)
+	SHOULD_CALL_PARENT(FALSE)
 
-	current_underlay = mutable_appearance(LIGHTING_ICON, "transparent", FLOAT_LAYER, LIGHTING_PLANE, 255, RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM)
+	if(flags_atom & INITIALIZED)
+		CRASH("Warning: [src]([type]) initialized multiple times!")
+	flags_atom |= INITIALIZED
 
-	affected_turf = source
+	// do we even need these...?
+	pass_flags = GLOB.pass_flags_cache[type]
+	if (isnull(pass_flags))
+		pass_flags = new()
+		initialize_pass_flags(pass_flags)
+		GLOB.pass_flags_cache[type] = pass_flags
+	else
+		initialize_pass_flags()
+	verbs.Cut()
+
+	affected_turf = loc
 	if (affected_turf.static_lighting_object)
 		qdel(affected_turf.static_lighting_object, force = TRUE)
 		stack_trace("a lighting object was assigned to a turf that already had a lighting object!")
-
 	affected_turf.static_lighting_object = src
 	affected_turf.luminosity = 0
 
 	needs_update = TRUE
 	SSlighting.objects_queue += src
+	return INITIALIZE_HINT_NORMAL
 
-/datum/static_lighting_object/Destroy(force)
-	if (!force)
-		return QDEL_HINT_LETMELIVE
-	if(needs_update)
+/atom/movable/static_lighting_object/Destroy(force)
+	if (force)
 		SSlighting.objects_queue -= src
-	if (isturf(affected_turf))
-		affected_turf.static_lighting_object = null
-		affected_turf.luminosity = 1
-		affected_turf.underlays -= current_underlay
-	affected_turf = null
-	return ..()
+		if (loc != affected_turf)
+			var/turf/oldturf = get_turf(affected_turf)
+			var/turf/newturf = get_turf(loc)
+			stack_trace("A lighting object was qdeleted with a different loc then it is suppose to have ([COORD(oldturf)] -> [COORD(newturf)])")
+		if (isturf(affected_turf))
+			affected_turf.static_lighting_object = null
+			affected_turf.luminosity = 1
+		affected_turf = null
 
-/datum/static_lighting_object/proc/update()
+		return ..()
+
+	else
+		return QDEL_HINT_LETMELIVE
+
+/atom/movable/static_lighting_object/proc/update()
 
 	// To the future coder who sees this and thinks
 	// "Why didn't he just use a loop?"
@@ -67,20 +86,18 @@
 	// This number is mostly arbitrary.
 	var/set_luminosity = max > 1e-6
 	#endif
-	var/mutable_appearance/current_underlay = src.current_underlay
-	affected_turf.underlays -= current_underlay
 	if(red_corner.cache_r & green_corner.cache_r & blue_corner.cache_r & alpha_corner.cache_r && \
 		(red_corner.cache_g + green_corner.cache_g + blue_corner.cache_g + alpha_corner.cache_g + \
 		red_corner.cache_b + green_corner.cache_b + blue_corner.cache_b + alpha_corner.cache_b == 8))
 		//anything that passes the first case is very likely to pass the second, and addition is a little faster in this case
-		current_underlay.icon_state = "transparent"
-		current_underlay.color = null
+		icon_state = "transparent"
+		color = null
 	else if(!set_luminosity)
-		current_underlay.icon_state = "dark"
-		current_underlay.color = null
+		icon_state = "dark"
+		color = null
 	else
-		current_underlay.icon_state = null
-		current_underlay.color = list(
+		icon_state = null
+		color = list(
 			red_corner.cache_r, red_corner.cache_g, red_corner.cache_b, 00,
 			green_corner.cache_r, green_corner.cache_g, green_corner.cache_b, 00,
 			blue_corner.cache_r, blue_corner.cache_g, blue_corner.cache_b, 00,
@@ -88,9 +105,6 @@
 			00, 00, 00, 01
 		)
 
-	// Of note. Most of the cost in this proc is here, I think because color matrix'd underlays DO NOT cache well, which is what adding to underlays does
-	// We use underlays because objects on each tile would fuck with maptick. if that ever changes, use an object for this instead
-	affected_turf.underlays += current_underlay
 	if(set_luminosity)
 		affected_turf.luminosity = set_luminosity
 		return
@@ -98,3 +112,25 @@
 	//We are not lit by static light OR dynamic light.
 	if(!LAZYLEN(affected_turf.hybrid_lights_affecting) && !turf_area.base_lighting_alpha)
 		affected_turf.luminosity = 0
+
+// Variety of overrides so the overlays don't get affected by weird things.
+
+/atom/movable/static_lighting_object/ex_act(severity)
+	return FALSE
+
+/atom/movable/static_lighting_object/fire_act()
+	return
+
+/atom/movable/static_lighting_object/acid_spray_act()
+	return
+
+/atom/movable/static_lighting_object/flamer_fire_act()
+	return
+
+/atom/movable/static_lighting_object/onTransitZ()
+	return
+
+// Override here to prevent things accidentally moving around overlays.
+/atom/movable/static_lighting_object/forceMove(atom/destination, no_tp=FALSE, harderforce = FALSE)
+	if(harderforce)
+		. = ..()

--- a/code/modules/lighting/lighting_static/static_lighting_object.dm
+++ b/code/modules/lighting/lighting_static/static_lighting_object.dm
@@ -31,7 +31,8 @@
 /datum/static_lighting_object/Destroy(force)
 	if (!force)
 		return QDEL_HINT_LETMELIVE
-	SSlighting.objects_queue -= src
+	if(needs_update)
+		SSlighting.objects_queue -= src
 	if (isturf(affected_turf))
 		affected_turf.static_lighting_object = null
 		affected_turf.luminosity = 1

--- a/code/modules/lighting/lighting_static/static_lighting_setup.dm
+++ b/code/modules/lighting/lighting_static/static_lighting_setup.dm
@@ -3,5 +3,5 @@
 		var/area/area = turf.loc
 		if(!area.static_lighting)
 			continue
-		new /datum/static_lighting_object(turf)
+		new /atom/movable/static_lighting_object(turf)
 		CHECK_TICK

--- a/code/modules/lighting/lighting_static/static_lighting_source.dm
+++ b/code/modules/lighting/lighting_static/static_lighting_source.dm
@@ -68,7 +68,8 @@
 	if (top_atom)
 		LAZYREMOVE(top_atom.static_light_sources, src)
 
-	SSlighting.static_sources_queue -= src
+	if(needs_update)
+		SSlighting.static_sources_queue -= src
 	return ..()
 
 // Yes this doesn't align correctly on anything other than 4 width tabs.
@@ -83,6 +84,8 @@
 
 /// This proc will cause the light source to update the top atom, and add itself to the update queue.
 /datum/static_light_source/proc/update(atom/new_top_atom)
+	if(QDELING(src)) // this should never be called if src is null so QDELING is better than QDELETED
+		return // no-op on deleted sources
 	// This top atom is different.
 	if (new_top_atom && new_top_atom != top_atom)
 		if(top_atom != source_atom && top_atom.static_light_sources) // Remove ourselves from the light sources of that top atom.
@@ -97,10 +100,14 @@
 
 /// Will force an update without checking if it's actually needed.
 /datum/static_light_source/proc/force_update()
+	if(QDELING(src)) // this should never be called if src is null so QDELING is better than QDELETED
+		return // no-op on deleted sources
 	EFFECT_UPDATE(LIGHTING_FORCE_UPDATE)
 
 /// Will cause the light source to recalculate turfs that were removed or added to visibility only.
 /datum/static_light_source/proc/vis_update()
+	if(QDELING(src)) // this should never be called if src is null so QDELING is better than QDELETED
+		return // no-op on deleted sources
 	EFFECT_UPDATE(LIGHTING_VIS_UPDATE)
 
 // Macro that applies light to a new corner.

--- a/code/modules/lighting/lighting_static/static_lighting_turf.dm
+++ b/code/modules/lighting/lighting_static/static_lighting_turf.dm
@@ -1,6 +1,6 @@
 /turf
 	var/tmp/lighting_corners_initialised = FALSE
-	var/tmp/datum/static_lighting_object/static_lighting_object
+	var/tmp/atom/movable/static_lighting_object/static_lighting_object
 
 	///Lighting Corner datums.
 	var/tmp/datum/static_lighting_corner/lighting_corner_NE
@@ -17,7 +17,7 @@
 	if(static_lighting_object)
 		qdel(static_lighting_object, force=TRUE) //Shitty fix for lighting objects persisting after death
 
-	new/datum/static_lighting_object(src)
+	new/atom/movable/static_lighting_object(src)
 
 
 

--- a/code/modules/reagents/chemistry_reagents/other.dm
+++ b/code/modules/reagents/chemistry_reagents/other.dm
@@ -163,7 +163,7 @@
 
 /datum/reagent/water/reaction_obj(obj/O, volume)
 	src = null
-	O.extinguish()
+	SEND_SIGNAL(O, COMSIG_OBJ_EXTINGUISH)
 
 /datum/reagent/water/reaction_mob(mob/living/M, method=TOUCH, volume, permeable)//Splashing people with water can help put them out!
 	if(!istype(M, /mob/living))

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -41,6 +41,8 @@ All ShuttleMove procs go here
 	else //non-living mobs shouldn't be affected by shuttles, which is why this is an else
 		if(thing.anchored)
 			// Ordered by most likely:
+			if(istype(thing, /atom/movable/static_lighting_object))
+				return
 			if(istype(thing, /obj/structure/machinery/landinglight))
 				return
 			if(istype(thing, /obj/docking_port))
@@ -280,7 +282,7 @@ All ShuttleMove procs go here
 
 /* ***********************************Misc move procs************************************/
 
-/atom/movable/lighting_object/onShuttleMove()
+/atom/movable/static_lighting_object/onShuttleMove()
 	return FALSE
 
 /obj/docking_port/mobile/beforeShuttleMove(turf/newT, rotation, move_mode, obj/docking_port/mobile/moving_dock)

--- a/code/modules/unit_tests/create_and_destroy.dm
+++ b/code/modules/unit_tests/create_and_destroy.dm
@@ -19,6 +19,7 @@ GLOBAL_VAR_INIT(create_and_destroy_ignore_paths, generate_ignore_paths())
 		/obj/effect/landmark/lizard_spawn,
 		/obj/effect/fake_attacker,
 		/atom/movable/lighting_mask, //leave it alone
+		/atom/movable/static_lighting_object, // ditto
 		//This is meant to fail extremely loud every single time it occurs in any environment in any context, and it falsely alarms when this unit test iterates it. Let's not spawn it in.
 		/obj/merge_conflict_marker,
 		/obj/effect/projector_anchor, // Needs a link ID set to work as intended


### PR DESCRIPTION
# About the pull request
Split out of #11946, plus a commit to replace underlay lights with objects.

# Explain why it's good for the game

According to comparisons done by Paradise, underlay lights save on maptick (which scales with playercount) but dramatically increases CPU usage (which still scales with playercount, but indirectly due to more lighting updates). It also increases CPU usage more than it saves on maptick, especially now that sendmaps is threaded.

Judging from /status reports in the Discord server, rounds are hitting 79% CPU on 140 players while sitting at a cozy 18% maptick. That means 61% of the CPU usage at highpop comes from non-maptick sources, which will be important when comparing later.

See here for more info: https://github.com/ParadiseSS13/Paradise/pull/17178

# Testing Photographs and Procedure
Same as #11946, I'd have to dig through my screenshots folder to find the screenshots. This will also need to be tested on live (hooray!) to see how it impacts performance and overtime both at low- and highpop.

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: MoondancerPony
refactor: rewrote SSlighting to avoid overtime
refactor: made lighting use objects instead of underlays, which may improve lag at both low- and highpop
/:cl:
