### PR TITLE
Replace hex2num and other bespoke hex helpers with builtin equivalents

### DIFF
--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -65,23 +65,14 @@ GLOBAL_LIST_INIT(em_block_color, EM_BLOCK_COLOR)
 /// A globally cached version of [EM_MASK_MATRIX] for quick access.
 GLOBAL_LIST_INIT(em_mask_matrix, EM_MASK_MATRIX)
 
-/// Returns the red part of a #RRGGBB hex sequence as number
-#define GETREDPART(hexa) hex2num(copytext(hexa, 2, 4))
-
-/// Returns the green part of a #RRGGBB hex sequence as number
-#define GETGREENPART(hexa) hex2num(copytext(hexa, 4, 6))
-
-/// Returns the blue part of a #RRGGBB hex sequence as number
-#define GETBLUEPART(hexa) hex2num(copytext(hexa, 6, 8))
-
 /// Parse the hexadecimal color into lumcounts of each perspective.
 #define PARSE_LIGHT_COLOR(source) \
 do { \
 	if (source.light_color != COLOR_WHITE) { \
-		var/__light_color = source.light_color; \
-		source.lum_r = GETREDPART(__light_color) / 255; \
-		source.lum_g = GETGREENPART(__light_color) / 255; \
-		source.lum_b = GETBLUEPART(__light_color) / 255; \
+		var/list/color_parts = rgb2num(source.light_color); \
+		source.lum_r = color_parts[1] / 255; \
+		source.lum_g = color_parts[2] / 255; \
+		source.lum_b = color_parts[3] / 255; \
 	} else { \
 		source.lum_r = 1; \
 		source.lum_g = 1; \

--- a/code/__HELPERS/matrices.dm
+++ b/code/__HELPERS/matrices.dm
@@ -107,12 +107,11 @@ list(0.393,0.349,0.272,0, 0.769,0.686,0.534,0, 0.189,0.168,0.131,0, 0,0,0,1, 0,0
 	var/length = length(string)
 	if((length != 7 && length != 9) || length != length_char(string))
 		return COLOR_MATRIX_IDENTITY
-	var/r = hex2num(copytext(string, 2, 4))/255
-	var/g = hex2num(copytext(string, 4, 6))/255
-	var/b = hex2num(copytext(string, 6, 8))/255
-	var/a = 1
-	if(length == 9)
-		a = hex2num(copytext(string, 8, 10))/255
+	var/list/color_list = rgb2num(string)
+	var/r = color_list[1]
+	var/g = color_list[2]
+	var/b = color_list[3]
+	var/a = length(color_list) == 4 ? color_list[4] : 1
 	if(!isnum(r) || !isnum(g) || !isnum(b) || !isnum(a))
 		return COLOR_MATRIX_IDENTITY
 	return list(r,0,0,0, 0,g,0,0, 0,0,b,0, 0,0,0,a, 0,0,0,0)
@@ -122,9 +121,10 @@ list(0.393,0.349,0.272,0, 0.769,0.686,0.534,0, 0.189,0.168,0.131,0, 0,0,0,1, 0,0
 	if(!string || !istext(string))
 		return COLOR_MATRIX_IDENTITY
 
-	var/string_r = hex2num(copytext(string, 2, 4)) / 255
-	var/string_g = hex2num(copytext(string, 4, 6)) / 255
-	var/string_b = hex2num(copytext(string, 6, 8)) / 255
+	var/list/color_list = rgb2num(string)
+	var/string_r = color_list[1]
+	var/string_g = color_list[2]
+	var/string_b = color_list[3]
 
 	return list(string_r,0,0,0, 0,string_g,0,0, 0,0,string_b,0, 0,0,0,1, 0,0,0,0)
 

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -10,77 +10,11 @@
 
 //Returns an integer given a hex input
 /proc/hex2num(hex)
-	if (!( istext(hex) ))
-		return
-
-	var/num = 0
-	var/power = 0
-	var/i = null
-	i = length(hex)
-	while(i > 0)
-		var/char = copytext(hex, i, i + 1)
-		switch(char)
-			if("0")
-				pass()
-			if("9", "8", "7", "6", "5", "4", "3", "2", "1")
-				num += text2num(char) * 16 ** power
-			if("a", "A")
-				num += 16 ** power * 10
-			if("b", "B")
-				num += 16 ** power * 11
-			if("c", "C")
-				num += 16 ** power * 12
-			if("d", "D")
-				num += 16 ** power * 13
-			if("e", "E")
-				num += 16 ** power * 14
-			if("f", "F")
-				num += 16 ** power * 15
-			else
-				return
-		power++
-		i--
-	return num
+	return text2num(hex, 16)
 
 //Returns the hex value of a number given a value assumed to be a base-ten value
 /proc/num2hex(num, placeholder)
-
-	if (placeholder == null)
-		placeholder = 2
-	if (!( isnum(num) ))
-		return
-	if (num == 0)
-		var/final = ""
-		for(var/i=1 to placeholder) final = "[final]0"
-		return final
-	var/hex = ""
-	var/i = 0
-	while(16 ** i < num)
-		i++
-	var/power = null
-	power = i - 1
-	while(power >= 0)
-		var/val = floor(num / 16 ** power)
-		num -= val * 16 ** power
-		switch(val)
-			if(9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0)
-				hex += text("[]", val)
-			if(10.0)
-				hex += "A"
-			if(11.0)
-				hex += "B"
-			if(12.0)
-				hex += "C"
-			if(13.0)
-				hex += "D"
-			if(14.0)
-				hex += "E"
-			if(15.0)
-				hex += "F"
-		power--
-	while(length(hex) < placeholder)
-		hex = text("0[]", hex)
-	return hex
+	return num2text(num, placeholder, 16)
 
 //Splits the text of a file at seperator and returns them in a list.
 /proc/file2list(filename, seperator="\n", trim = TRUE)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -499,21 +499,24 @@ GLOBAL_LIST_INIT(mentor_verbs, list(
 			return
 	var/new_facial = input("Please select facial hair color.", "Character Generation") as color
 	if(new_facial)
-		M.r_facial = hex2num(copytext(new_facial, 2, 4))
-		M.g_facial = hex2num(copytext(new_facial, 4, 6))
-		M.b_facial = hex2num(copytext(new_facial, 6, 8))
+		var/list/color_list = rgb2num(new_facial)
+		M.r_facial = color_list[1]
+		M.g_facial = color_list[2]
+		M.b_facial = color_list[3]
 
 	var/new_hair = input("Please select hair color.", "Character Generation") as color
-	if(new_facial)
-		M.r_hair = hex2num(copytext(new_hair, 2, 4))
-		M.g_hair = hex2num(copytext(new_hair, 4, 6))
-		M.b_hair = hex2num(copytext(new_hair, 6, 8))
+	if(new_hair)
+		var/list/color_list = rgb2num(new_hair)
+		M.r_hair = color_list[1]
+		M.g_hair = color_list[2]
+		M.b_hair = color_list[3]
 
 	var/new_eyes = input("Please select eye color.", "Character Generation") as color
 	if(new_eyes)
-		M.r_eyes = hex2num(copytext(new_eyes, 2, 4))
-		M.g_eyes = hex2num(copytext(new_eyes, 4, 6))
-		M.b_eyes = hex2num(copytext(new_eyes, 6, 8))
+		var/list/color_list = rgb2num(new_eyes)
+		M.r_eyes = color_list[1]
+		M.g_eyes = color_list[2]
+		M.b_eyes = color_list[3]
 
 
 	// hair

--- a/code/modules/client/hair_picker.dm
+++ b/code/modules/client/hair_picker.dm
@@ -80,9 +80,10 @@
 			if(!param_color)
 				return
 
-			var/r = hex2num(copytext(param_color, 2, 4))
-			var/g = hex2num(copytext(param_color, 4, 6))
-			var/b = hex2num(copytext(param_color, 6, 8))
+			var/list/color_list = rgb2num(param_color)
+			var/r = color_list[1]
+			var/g = color_list[2]
+			var/b = color_list[3]
 
 			if(!isnum(r) || !isnum(g) || !isnum(b))
 				return
@@ -112,9 +113,10 @@
 			if(!param_color)
 				return
 
-			var/r = hex2num(copytext(param_color, 2, 4))
-			var/g = hex2num(copytext(param_color, 4, 6))
-			var/b = hex2num(copytext(param_color, 6, 8))
+			var/list/color_list = rgb2num(param_color)
+			var/r = color_list[1]
+			var/g = color_list[2]
+			var/b = color_list[3]
 
 			if(!isnum(r) || !isnum(g) || !isnum(b))
 				return
@@ -141,9 +143,10 @@
 			if(!param_color)
 				return
 
-			var/r = hex2num(copytext(param_color, 2, 4))
-			var/g = hex2num(copytext(param_color, 4, 6))
-			var/b = hex2num(copytext(param_color, 6, 8))
+			var/list/color_list = rgb2num(param_color)
+			var/r = color_list[1]
+			var/g = color_list[2]
+			var/b = color_list[3]
 
 			if(!isnum(r) || !isnum(g) || !isnum(b))
 				return

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1635,9 +1635,10 @@ GLOBAL_LIST_INIT(be_special_flags, list(
 					var/new_eyes = tgui_color_picker(user, "Choose your character's eye color:", "Character Preference", rgb(r_eyes, g_eyes, b_eyes))
 
 					if(new_eyes)
-						r_eyes = hex2num(copytext(new_eyes, 2, 4))
-						g_eyes = hex2num(copytext(new_eyes, 4, 6))
-						b_eyes = hex2num(copytext(new_eyes, 6, 8))
+						var/list/color_list = rgb2num(new_eyes)
+						r_eyes = color_list[1]
+						g_eyes = color_list[2]
+						b_eyes = color_list[3]
 
 
 				if("ooccolor")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1186,18 +1186,20 @@
 
 	if(species.base_color && default_color)
 		//Apply color.
-		r_skin = hex2num(copytext(species.base_color,2,4))
-		g_skin = hex2num(copytext(species.base_color,4,6))
-		b_skin = hex2num(copytext(species.base_color,6,8))
+		var/list/color_list = rgb2num(species.base_color)
+		r_skin = color_list[1]
+		g_skin = color_list[2]
+		b_skin = color_list[3]
 	else
 		r_skin = 0
 		g_skin = 0
 		b_skin = 0
 
 	if(species.hair_color)
-		r_hair = hex2num(copytext(species.hair_color, 2, 4))
-		g_hair = hex2num(copytext(species.hair_color, 4, 6))
-		b_hair = hex2num(copytext(species.hair_color, 6, 8))
+		var/list/color_list = rgb2num(species.hair_color)
+		r_hair = color_list[1]
+		g_hair = color_list[2]
+		b_hair = color_list[3]
 
 	if(species.no_grad_style)
 		grad_style = "None"

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -3,7 +3,6 @@
 #define XENO_ARMOR_REGEN_DELAY 30 SECONDS
 /mob/living/carbon/xenomorph/Life(delta_time)
 	set invisibility = 0
-	set background = 1
 
 	if(!loc)
 		return

--- a/code/modules/reagents/Chemistry-Colours.dm
+++ b/code/modules/reagents/Chemistry-Colours.dm
@@ -24,9 +24,10 @@
 		var/hue = re.color
 		if(length(hue) != 7)
 			return 0
-		redcolor[i]=hex2num(copytext(hue,2,4))
-		greencolor[i]=hex2num(copytext(hue,4,6))
-		bluecolor[i]=hex2num(copytext(hue,6,8))
+		var/list/color_list = rgb2num(hue)
+		redcolor[i]=color_list[1]
+		greencolor[i]=color_list[2]
+		bluecolor[i]=color_list[3]
 
 	//mix all the colors
 	var/red = mixOneColor(weight,redcolor)
@@ -80,9 +81,10 @@
 		var/hue = re.burncolor
 		if(length(hue) != 7)
 			return 0
-		redcolor[i]=hex2num(copytext(hue,2,4))
-		greencolor[i]=hex2num(copytext(hue,4,6))
-		bluecolor[i]=hex2num(copytext(hue,6,8))
+		var/list/color_list = rgb2num(hue)
+		redcolor[i]=color_list[1]
+		greencolor[i]=color_list[2]
+		bluecolor[i]=color_list[3]
 
 	//mix all the colors
 	var/red = mixOneColor(weight,redcolor)


### PR DESCRIPTION
# About the pull request

Replaces `hex2num()` and `GETREDPART()`/`GETGREENPART()`/`GETBLUEPART()` with built-in equivalents like `rgb2num()` and `num2text(x, placeholder, 16)`.

# Explain why it's good for the game

Operations manipulating hex strings can be really slow due to the way strings are stored in BYOND. Using built-in helpers for converting RGB hex strings into numbers avoids most of these operations and is much, much faster.

# Testing Photographs and Procedure

There should be no user-facing changes here.

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MoondancerPony
code: made color manipulation in lighting and elsewhere much faster
/:cl:
