### PR TITLE
Optimize flamer fire spread

### DIFF
--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -261,12 +261,12 @@
 
 /obj/structure/ship_ammo/laser_battery/detonate_on(turf/impact, obj/structure/dropship_equipment/weapon/fired_from)
 	set waitfor = 0
-	var/list/turf_list = RANGE_TURFS(3, impact) //This is its area of effect
+	var/list/turf_list = shuffle(RANGE_TURFS(3, impact)) //This is its area of effect
 	playsound(impact, 'sound/effects/pred_vision.ogg', 20, 1)
-	for(var/i=1 to 16) //This is how many tiles within that area of effect will be randomly ignited
-		var/turf/U = pick(turf_list)
-		turf_list -= U
-		fire_spread_recur(U, create_cause_data(fired_from.name, source_mob), 1, null, 5, 75, "#EE6515")//Very, very intense, but goes out very quick
+	var/datum/reagent/fire_reagent = create_fire_reagent(5, 75, "#EE6515")
+	for(var/i in 1 to 16) //This is how many tiles within that area of effect will be randomly ignited
+		var/turf/target_turf = turf_list[i]
+		fire_spread(target_turf, create_cause_data(fired_from.name, source_mob), 1, fire_reagent)//Very, very intense, but goes out very quick
 
 	if(!ammo_count && !QDELETED(src))
 		qdel(src) //deleted after last laser beam is fired and impact the ground.
@@ -316,8 +316,9 @@
 
 /obj/structure/ship_ammo/rocket/banshee/detonate_on(turf/impact, obj/structure/dropship_equipment/weapon/fired_from)
 	impact.ceiling_debris_check(3)
+	var/datum/reagent/fire_reagent = create_fire_reagent(15, 50, "#00b8ff")
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(cell_explosion), impact, 175, 20, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, create_cause_data(initial(name), source_mob)), 0.5 SECONDS) //Small explosive power with a small fall off for a big explosion range
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(fire_spread), impact, create_cause_data(initial(name), source_mob), 4, 15, 50, "#00b8ff"), 0.5 SECONDS) //Very intense but the fire doesn't last very long
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(fire_spread), impact, create_cause_data(initial(name), source_mob), 4, fire_reagent), 0.5 SECONDS) //Very intense but the fire doesn't last very long
 	QDEL_IN(src, 0.5 SECONDS)
 
 /obj/structure/ship_ammo/rocket/keeper
@@ -357,8 +358,9 @@
 
 /obj/structure/ship_ammo/rocket/napalm/detonate_on(turf/impact, obj/structure/dropship_equipment/weapon/fired_from)
 	impact.ceiling_debris_check(3)
+	var/datum/reagent/fire_reagent = create_fire_reagent(60, 30, "#EE6515")
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(cell_explosion), impact, 200, 25, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, create_cause_data(initial(name), source_mob)), 0.5 SECONDS)
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(fire_spread), impact, create_cause_data(initial(name), source_mob), 6, 60, 30, "#EE6515"), 0.5 SECONDS) //Color changed into napalm's color to better convey how intense the fire actually is.
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(fire_spread), impact, create_cause_data(initial(name), source_mob), 6, fire_reagent), 0.5 SECONDS) //Color changed into napalm's color to better convey how intense the fire actually is.
 	QDEL_IN(src, 0.5 SECONDS)
 
 /obj/structure/ship_ammo/rocket/thermobaric
@@ -371,7 +373,8 @@
 
 /obj/structure/ship_ammo/rocket/thermobaric/detonate_on(turf/impact, obj/structure/dropship_equipment/weapon/fired_from)
 	impact.ceiling_debris_check(3)
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(fire_spread), impact, create_cause_data(initial(name), source_mob), 4, 25, 50, "#c96500"), 0.5 SECONDS) //Very intense but the fire doesn't last very long
+	var/datum/reagent/fire_reagent = create_fire_reagent(25, 50, "#c96500")
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(fire_spread), impact, create_cause_data(initial(name), source_mob), 4, fire_reagent), 0.5 SECONDS) //Very intense but the fire doesn't last very long
 	for(var/mob/living/carbon/victim in orange(5, impact))
 		victim.throw_atom(impact, 3, 15, src, TRUE) // Implosion throws affected towards center of vacuum
 	QDEL_IN(src, 0.5 SECONDS)
@@ -425,7 +428,8 @@
 /obj/structure/ship_ammo/minirocket/incendiary/detonate_on(turf/impact, obj/structure/dropship_equipment/weapon/fired_from)
 	..()
 	spawn(5)
-		fire_spread(impact, create_cause_data(initial(name), source_mob), 3, 25, 20, "#EE6515")
+		var/datum/reagent/fire_reagent = create_fire_reagent(25, 20, "#EE6515")
+		fire_spread(impact, create_cause_data(initial(name), source_mob), 3, fire_reagent)
 
 /obj/structure/ship_ammo/sentry
 	name = "\improper A/C-49-P Air Deployable Sentry"

--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -532,7 +532,8 @@ GLOBAL_LIST_EMPTY(orbital_cannon_cancellation)
 	handle_ob_shake(target)
 
 	sleep(clear_delay)
-	fire_spread(target, cause_data, distance, fire_level, burn_level, fire_color, fire_type, TURF_PROTECTION_OB)
+	var/datum/reagent/fire_reagent = create_fire_reagent(fire_level, burn_level, fire_color, fire_type)
+	fire_spread(target, cause_data, distance, fire_reagent, TURF_PROTECTION_OB)
 	qdel(src)
 
 /obj/structure/ob_ammo/warhead/cluster

--- a/code/modules/projectiles/guns/flamer/flamer.dm
+++ b/code/modules/projectiles/guns/flamer/flamer.dm
@@ -899,38 +899,30 @@ GLOBAL_LIST_EMPTY(flamer_particles)
 	else
 		weather_smothering_strength = 0
 
-/proc/fire_spread_recur(turf/target, datum/cause_data/cause_data, remaining_distance, direction, fire_lvl, burn_lvl, f_color, burn_sprite = "dynamic", aerial_flame_level)
-	var/direction_angle = dir2angle(direction)
+/proc/create_fire_reagent(fire_lvl, burn_lvl, f_color, burn_sprite = "dynamic")
+	var/datum/reagent/fire_reag = new()
+	fire_reag.intensityfire = burn_lvl
+	fire_reag.durationfire = fire_lvl
+	fire_reag.burn_sprite = burn_sprite
+	fire_reag.burncolor = f_color
+	return fire_reag
+
+/proc/fire_spread_recur(turf/target, datum/cause_data/cause_data, remaining_distance, direction, datum/reagent/fire_reagent, aerial_flame_level)
+	set waitfor = FALSE
 	var/obj/flamer_fire/foundflame = locate() in target
 	if(!foundflame)
-		var/datum/reagent/fire_reag = new()
-		fire_reag.intensityfire = burn_lvl
-		fire_reag.durationfire = fire_lvl
-		fire_reag.burn_sprite = burn_sprite
-		fire_reag.burncolor = f_color
-		new/obj/flamer_fire(target, cause_data, fire_reag)
+		new/obj/flamer_fire(target, cause_data, fire_reagent)
 	if(target.density)
 		return
 
-	for(var/spread_direction in GLOB.alldirs)
-
+	for(var/spread_angle in list(-45, 0, 45))
+		var/spread_direction = turn(direction, spread_angle)
 		var/spread_power = remaining_distance
-
-		var/spread_direction_angle = dir2angle(spread_direction)
-
-		var/angle = 180 - abs( abs( direction_angle - spread_direction_angle ) - 180 ) // the angle difference between the spread direction and initial direction
-
-		switch(angle) //this reduces power when the explosion is going around corners
-			if (45)
-				spread_power *= 0.75
-			if (90 to 180) //turns out angles greater than 90 degrees almost never happen. This bit also prevents trying to spread backwards
-				continue
-
-		switch(spread_direction)
-			if(NORTH,SOUTH,EAST,WEST)
-				spread_power--
-			else
-				spread_power -= 1.414 //diagonal spreading
+		if(abs(spread_angle) == 45) // diagonal
+			spread_power -= sqrt(2)
+			spread_power *= 0.75 //this reduces power when the explosion is going around corners
+		else // cardinal
+			spread_power -= 1
 
 		if (spread_power < 1)
 			continue
@@ -942,37 +934,33 @@ GLOBAL_LIST_EMPTY(flamer_particles)
 
 		if(aerial_flame_level)
 			if(picked_turf.get_pylon_protection_level() >= aerial_flame_level)
-				break
-			var/area/picked_area = get_area(picked_turf)
+				continue
+			var/area/picked_area = picked_turf.loc // get_area() is slower here when we know we have a turf
 			if(CEILING_IS_PROTECTED(picked_area?.ceiling, get_ceiling_protection_level(aerial_flame_level)))
-				break
+				continue
 
-		spawn(0)
-			fire_spread_recur(picked_turf, cause_data, spread_power, spread_direction, fire_lvl, burn_lvl, f_color, burn_sprite, aerial_flame_level)
+		CHECK_TICK // before the recursive call
+		fire_spread_recur(picked_turf, cause_data, spread_power, spread_direction, fire_reagent, aerial_flame_level)
 
-/proc/fire_spread(turf/target, datum/cause_data/cause_data, range, fire_lvl, burn_lvl, f_color, burn_sprite = "dynamic", aerial_flame_level = TURF_PROTECTION_NONE)
-	var/datum/reagent/fire_reag = new()
-	fire_reag.intensityfire = burn_lvl
-	fire_reag.durationfire = fire_lvl
-	fire_reag.burn_sprite = burn_sprite
-	fire_reag.burncolor = f_color
-
-	new/obj/flamer_fire(target, cause_data, fire_reag)
-	for(var/direction in GLOB.alldirs)
+/proc/fire_spread(turf/target, datum/cause_data/cause_data, range, fire_reagent, aerial_flame_level = TURF_PROTECTION_NONE)
+	set waitfor = FALSE
+	new/obj/flamer_fire(target, cause_data, fire_reagent)
+	for(var/turf/picked_turf in orange(1, target))
+		var/direction = get_dir(target, picked_turf)
 		var/spread_power = range
 		switch(direction)
 			if(NORTH,SOUTH,EAST,WEST)
 				spread_power--
 			else
 				spread_power -= 1.414 //diagonal spreading
-		var/turf/picked_turf = get_step(target, direction)
 		if(aerial_flame_level)
 			if(picked_turf.get_pylon_protection_level() >= aerial_flame_level)
 				continue
 			var/area/picked_area = get_area(picked_turf)
 			if(CEILING_IS_PROTECTED(picked_area?.ceiling, get_ceiling_protection_level(aerial_flame_level)))
 				continue
-		fire_spread_recur(picked_turf, cause_data, spread_power, direction, fire_lvl, burn_lvl, f_color, burn_sprite, aerial_flame_level)
+		fire_spread_recur(picked_turf, cause_data, spread_power, direction, fire_reagent, aerial_flame_level)
+		CHECK_TICK // don't overrun spreading in just one direction
 
 // So it doens't do the spinny animation
 /obj/flamer_fire/onZImpact(turf/impact_turf, height)


### PR DESCRIPTION
# About the pull request
The fire spread proc now requires a reagent to be passed in, which avoids creating a new reagent for every recursive call.
`fire_spread_recur()` now uses `CHECK_TICK` instead of `spawn(0)`, so instead of delaying each wave by a single tick, it'll proceed as fast as possible without overloading the server.
`fire_spread_recur()` now only checks the directions it'll try to spread to, rather than all directions.
`fire_spread_recur()` and `fire_spread()` now use `set waitfor = FALSE` to avoid blocking callers. This is preferable to an explicit `spawn(0)` because it will only spawn if the server is overloaded, which avoids giving the scheduler a bunch of spawned procs to handle.

Split out of #11946.

# Explain why it's good for the game
Improves performance a good bit, there's no pause/delay when an incendiary OB hits.

# Testing Photographs and Procedure
I do have screenshots and videos, I just am too lazy to upload them right now.

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

# Changelog

:cl: MoondancerPony
refactor: made fire spread (from OB, flamers, etc) much faster
/:cl:
