### PR TITLE
fix duplicate wyc6 paygrade definition

### DIFF
--- a/code/datums/paygrades/factions/wy/wy.dm
+++ b/code/datums/paygrades/factions/wy/wy.dm
@@ -61,7 +61,7 @@
 	pay_multiplier = 6
 	officer_grade = GRADE_OFFICER
 
-/datum/paygrade/wy_ranks/wyc6
+/datum/paygrade/wy_ranks/wyc6l
 	paygrade = PAY_SHORT_WYC6L
 	name = "Legal Supervisor"
 	prefix = "L. Spvsr."


### PR DESCRIPTION

# About the pull request

title; saw this while looking at why von bandolier shows up as WYC6 as their title

<img width="900" height="672" alt="image" src="https://github.com/user-attachments/assets/1ae456a5-8467-4568-b01e-1b85d4acfded" />

far as I could tell this path isnt directly referenced anywhere else that would need to be changed.


# Changelog

:cl:
fix: WYC6 Executive supervisor paygrade fixed
/:cl:
