### PR TITLE
move synths to ares core, replace synth closet with a janitor closet

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -318,7 +318,7 @@
 	var/x1 = coords[3] + scan_range
 	var/y1 = coords[4] + scan_range
 
-	for(var/xscan = x0; xscan < x1; xscan++)a
+	for(var/xscan = x0; xscan < x1; xscan++)
 		for(var/yscan = y0; yscan < y1; yscan++)
 			var/turf/searchspot = locate(xscan, yscan, src.z)
 			for(var/obj/structure/machinery/landinglight/light in searchspot)


### PR DESCRIPTION

# About the pull request

title
<img width="295" height="90" alt="image" src="https://github.com/user-attachments/assets/bdf6ba96-cb6a-4f1b-9028-8e2d7a14e6a8" />



# Explain why it's good for the game
change wanted by the synth senator, the little strange closet they spawn in is strange. let them be with their best friend joes


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: synths now spawn in the ares core. their old spawn is replaced with a janitor closet
/:cl:
