### PR TITLE
Medical rework: nerfs bicaridine and kelotane, non-critical tramadol OD now heals you to compensate

### DIFF
--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -275,10 +275,10 @@
 /datum/chem_property/positive/painkilling/process_overdose(mob/living/M, potency = 1, delta_time)
 	if(!..())
 		return
-	var/effective_potency = (CHECK_BITFIELD(M.disabilities, OPIATE_RECEPTOR_DEFICIENCY) ? potency * 0.25 : potency)
-	M.pain.apply_pain_reduction(PAIN_REDUCTION_MULTIPLIER * effective_potency)
-	M.hallucination = max(M.hallucination, POTENCY_MULTIPLIER_MEDIUM * effective_potency) //Hallucinations and tox damage
-	M.apply_damage(effective_potency * delta_time, TOX)
+	M.heal_limb_damage(potency, potency)
+	if(potency > CREATE_MAX_TIER_1)
+		M.heal_limb_damage(potency * POTENCY_MULTIPLIER_LOW, potency * POTENCY_MULTIPLIER_LOW)
+
 
 /datum/chem_property/positive/painkilling/process_critical(mob/living/M, potency = 1)
 	var/effective_potency = (CHECK_BITFIELD(M.disabilities, OPIATE_RECEPTOR_DEFICIENCY) ? potency * 0.25 : potency)

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -90,7 +90,7 @@
 	overdose = REAGENTS_OVERDOSE
 	overdose_critical = REAGENTS_OVERDOSE_CRITICAL
 	chemclass = CHEM_CLASS_COMMON
-	properties = list(PROPERTY_ANTICORROSIVE = 2)
+	properties = list(PROPERTY_ANTICORROSIVE = 1)
 
 /datum/reagent/medical/dermaline
 	name = "Dermaline"
@@ -101,7 +101,7 @@
 	overdose = LOWH_REAGENTS_OVERDOSE
 	overdose_critical = LOWH_REAGENTS_OVERDOSE_CRITICAL
 	chemclass = CHEM_CLASS_UNCOMMON
-	properties = list(PROPERTY_ANTICORROSIVE = 3)
+	properties = list(PROPERTY_ANTICORROSIVE = 2)
 
 /datum/reagent/medical/dexalin
 	name = "Dexalin"
@@ -282,7 +282,7 @@
 	overdose = REAGENTS_OVERDOSE
 	overdose_critical = REAGENTS_OVERDOSE_CRITICAL
 	chemclass = CHEM_CLASS_COMMON
-	properties = list(PROPERTY_NEOGENETIC = 2)
+	properties = list(PROPERTY_NEOGENETIC = 1)
 
 /datum/reagent/medical/meralyne
 	name = "Meralyne"
@@ -293,7 +293,7 @@
 	overdose = LOWH_REAGENTS_OVERDOSE
 	overdose_critical = LOWH_REAGENTS_OVERDOSE_CRITICAL
 	chemclass = CHEM_CLASS_UNCOMMON
-	properties = list(PROPERTY_NEOGENETIC = 3)
+	properties = list(PROPERTY_NEOGENETIC = 2)
 
 /datum/reagent/medical/adrenaline
 	name = "Epinephrine"


### PR DESCRIPTION

# About the pull request
Bicaridine, kelotane, myraline, dermaline are now less effective, but non-critical tramadol OD heals you (stronger than bica and kelo) instead of messing you up.

# Explain why it's good for the game
Did you know it's bicar**i**dine not bicardine???


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: reworked medical
/:cl:
