### PR TITLE
Property_Corrosive is now easier to apply on Xenomorph

### DIFF
--- a/code/modules/reagents/chemistry_properties/prop_negative.dm
+++ b/code/modules/reagents/chemistry_properties/prop_negative.dm
@@ -134,7 +134,7 @@
 			M.take_limb_damage(min(6, volume))
 	if(isxeno(M))
 		var/mob/living/carbon/xenomorph/xeno = M
-		if(potency > POTENCY_MAX_TIER_1) //Needs level 7+ to have any effect
+		if(potency > 2) //Needs level 5+ to have any effect, remember that potency = level * 0.5
 			xeno.AddComponent(/datum/component/status_effect/toxic_buildup, potency * volume * 0.25)
 
 /datum/chem_property/negative/corrosive/reaction_obj(obj/O, volume, potency)


### PR DESCRIPTION

# About the pull request
This PR changes the reagent potency check (ie the level * 0.5) in PROPERTY_CORROSIVE from 3 (ie level > 6) to 2 (ie level > 4).


<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #12345" to link the PR to the corresponding Issue number #12345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #12345, Fixes #12346, Fixes #12347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Primarily, this allows Copper Sulfate and Iron Sulfate (both of which have a PROPERTY_CORROSIVE of 5) to be used in chemical smoke tanks made by the Ordnance Technician *and actually work* on Xenomorph. Gives more fun stuff to do. Balanced by the fact that PROPERTY_CORROSIVE inherently melts everything, including headgear and weapons, and that toxin_buildup at that level is rather slow.

# Testing Photographs and Procedure
N/A
# Changelog
:cl: MarpleJones
balance: lowers PROPERTY_CORROSIVE potency check on xenomorph from 3 to 2; now it works on property_level > 4.
/:cl:
