### PR TITLE
Re-enables Prison Station v2 and CORSAT

### DIFF
--- a/map_config/maps.txt
+++ b/map_config/maps.txt
@@ -20,7 +20,6 @@ map bigredv2
 endmap
 
 map prison_station_fop
-	disabled
 endmap
 
 map fiorina_sciannex
@@ -29,8 +28,6 @@ endmap
 
 map corsat
 	minplayers 130
-	voteweight 0
-	disabled
 endmap
 
 map desert_dam


### PR DESCRIPTION

# About the pull request

Re-enables the Prison Station v2 and CORSAT main maps to be able to be chosen by the players, **this is democracy manifest.**

Prison v2 will be on the map vote at any playercount, CORSAT will show up on the list when the playercount is 130+

# Explain why it's good for the game

Did you know Prison Station was originally made as a Prison Architect map and was ported to CM completely unchanged? V2 was remapped to make it atleast more bearable to play as a CM map.

Did you know CORSAT is the only map that has both a transit shuttle that goes from one LZ to another AND a static teleporting room that can even teleport vehicles? It also has several different biome themes in it at once! Oh its too large? well sucks for you


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

this is an april fools PR btw

</details>


# Changelog

:cl:
config: Prison v2 and CORSAT can now be voted by the players.
/:cl:

