### PR TITLE
Adds a prefix to hunting ground xenos

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -1350,6 +1350,7 @@
 	name = FACTION_XENOMORPH_HUNTED
 	reporting_id = "hunted"
 	hivenumber = XENO_HIVE_HUNTED
+	prefix = "hunted "
 
 	ui_color = "#135029"
 	dynamic_evolution = FALSE

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -1350,7 +1350,7 @@
 	name = FACTION_XENOMORPH_HUNTED
 	reporting_id = "hunted"
 	hivenumber = XENO_HIVE_HUNTED
-	prefix = "hunted "
+	prefix = "Hunted "
 
 	ui_color = "#135029"
 	dynamic_evolution = FALSE


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #12345" to link the PR to the corresponding Issue number #12345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #12345, Fixes #12346, Fixes #12347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Annoying to have the "Join as xeno" button gaslight you into thinking you can play the real game

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Xenos in the hunting grounds now get a prefix to distinguish them
/:cl:
