### PR TITLE
Fixes Desert Moon Hunting Grounds walls being destructible

### DIFF
--- a/maps/templates/lazy_templates/pred/desert_moon.dmm
+++ b/maps/templates/lazy_templates/pred/desert_moon.dmm
@@ -34,17 +34,17 @@
 "af" = (
 /obj/structure/prop/hunter/trophy_display,
 /obj/structure/blocker/invisible_wall,
-/turf/closed/wall/cult/dark_temple,
+/turf/closed/wall/cult/dark_temple/hunting_grounds,
 /area/yautja_grounds/prep_room/desert/interior)
 "ag" = (
 /obj/structure/prop/hunter/trophy_display/top_center,
 /obj/structure/blocker/invisible_wall,
-/turf/closed/wall/cult/dark_temple,
+/turf/closed/wall/cult/dark_temple/hunting_grounds,
 /area/yautja_grounds/prep_room/desert/interior)
 "ah" = (
 /obj/structure/prop/hunter/trophy_display/top_right,
 /obj/structure/blocker/invisible_wall,
-/turf/closed/wall/cult/dark_temple,
+/turf/closed/wall/cult/dark_temple/hunting_grounds,
 /area/yautja_grounds/prep_room/desert/interior)
 "ai" = (
 /obj/item/weapon/shield/riot/yautja{
@@ -52,7 +52,7 @@
 	layer = 2.9;
 	pixel_x = 1
 	},
-/turf/closed/wall/cult/dark_temple,
+/turf/closed/wall/cult/dark_temple/hunting_grounds,
 /area/yautja_grounds/prep_room/desert)
 "aj" = (
 /obj/structure/machinery/door_control/yautja{
@@ -302,7 +302,7 @@
 /turf/open/auto_turf/sand/layer1,
 /area/yautja_grounds/desert/south)
 "bu" = (
-/turf/closed/wall/cult/dark_temple,
+/turf/closed/wall/cult/dark_temple/hunting_grounds,
 /area/yautja_grounds/temple/entrance/desert)
 "bv" = (
 /obj/structure/prop/dam/wide_boulder/boulder1,
@@ -983,7 +983,7 @@
 /turf/open/mars_cave/mars_cave_2,
 /area/yautja_grounds/caves)
 "dX" = (
-/turf/closed/wall/cult/dark_temple,
+/turf/closed/wall/cult/dark_temple/hunting_grounds,
 /area/yautja_grounds/prep_room/desert)
 "dY" = (
 /obj/item/weapon/broken_bottle,
@@ -1557,7 +1557,7 @@
 /area/yautja_grounds/caves/north_west)
 "gI" = (
 /obj/structure/prop/brazier/frame/full/torch,
-/turf/closed/wall/cult/dark_temple,
+/turf/closed/wall/cult/dark_temple/hunting_grounds,
 /area/yautja_grounds/temple/entrance/desert)
 "gJ" = (
 /turf/open/mars_cave/mars_dirt_5,
@@ -2370,7 +2370,7 @@
 	anchored = 1;
 	layer = 2.9
 	},
-/turf/closed/wall/cult/dark_temple,
+/turf/closed/wall/cult/dark_temple/hunting_grounds,
 /area/yautja_grounds/temple)
 "jW" = (
 /obj/structure/platform_decoration/metal/hunter/north{
@@ -2405,7 +2405,7 @@
 	pixel_y = -7;
 	pixel_x = -4
 	},
-/turf/closed/wall/cult/dark_temple,
+/turf/closed/wall/cult/dark_temple/hunting_grounds,
 /area/yautja_grounds/temple)
 "ka" = (
 /obj/structure/barricade/handrail/sandstone/b/dark{
@@ -3356,7 +3356,7 @@
 /area/yautja_grounds/caves)
 "Cj" = (
 /obj/structure/prop/brazier/torch,
-/turf/closed/wall/cult/dark_temple,
+/turf/closed/wall/cult/dark_temple/hunting_grounds,
 /area/yautja_grounds/temple)
 "Co" = (
 /obj/structure/closet/coffin/predator,
@@ -3484,7 +3484,7 @@
 /turf/open/gm/river/desert/shallow_edge/northwest,
 /area/yautja_grounds/caves)
 "MT" = (
-/turf/closed/wall/cult/dark_temple,
+/turf/closed/wall/cult/dark_temple/hunting_grounds,
 /area/yautja_grounds/temple)
 "MX" = (
 /obj/structure/platform/stone/kutjevo/west,
@@ -3570,7 +3570,7 @@
 /area/yautja_grounds/temple)
 "Um" = (
 /obj/structure/prop/brazier/torch,
-/turf/closed/wall/cult/dark_temple,
+/turf/closed/wall/cult/dark_temple/hunting_grounds,
 /area/yautja_grounds/prep_room/desert)
 "Up" = (
 /turf/open/floor/engine/cult,


### PR DESCRIPTION

# About the pull request

The visual import PR replaced the cult walls that this map had and they forgot this made them destructible now. This fixes that by replacing all of the walls with the HG subtype version of them

# Explain why it's good for the game

fix good


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Unknownity
fix: Desert Moon temple walls are indestructible again.
/:cl:

