### PR TITLE
Deathsquad ignore FTL/Crash

### DIFF
--- a/code/datums/emergency_calls/deathsquad.dm
+++ b/code/datums/emergency_calls/deathsquad.dm
@@ -15,6 +15,7 @@
 	max_medics = 1
 	max_heavies = 2
 	hostility = TRUE
+	ignore_ftl_or_crash = TRUE
 
 /datum/emergency_call/death/New()
 	. = ..()
@@ -103,6 +104,7 @@
 	var/leader_preset = /datum/equipment_preset/uscm/marsoc/sl
 	var/member_preset = /datum/equipment_preset/uscm/marsoc
 	var/sg_preset = /datum/equipment_preset/uscm/marsoc/sg
+	ignore_ftl_or_crash = TRUE
 
 /datum/emergency_call/marsoc/create_member(datum/mind/player, turf/override_spawn_loc)
 	var/turf/spawn_loc = override_spawn_loc ? override_spawn_loc : get_spawn_point()
@@ -151,6 +153,7 @@
 	shuttle_id = MOBILE_SHUTTLE_ID_ERT5
 	home_base = /datum/lazy_template/ert/yautja_station
 	hostility = TRUE
+	ignore_ftl_or_crash = TRUE
 	var/team_lead_preset = /datum/equipment_preset/yautja/soldier/enforcer
 	var/team_member_preset = /datum/equipment_preset/yautja/soldier
 

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -256,6 +256,7 @@
 	if(!ignore_ftl_or_crash && (SShijack.in_ftl || SShijack.crashed || SShijack.hijack_status == HIJACK_OBJECTIVES_GROUND_CRASH))
 		members = list()
 		candidates = list()
+		message_admins("Aborting distress beacon, not setup to bypass FTL or [MAIN_SHIP_NAME] Crash.")
 		return
 
 	//We've got enough!

--- a/code/datums/emergency_calls/upp_commando.dm
+++ b/code/datums/emergency_calls/upp_commando.dm
@@ -9,6 +9,7 @@
 	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_upp
 	item_spawn = /obj/effect/landmark/ert_spawns/distress_upp/item
 	hostility = TRUE
+	ignore_ftl_or_crash = TRUE
 
 /datum/emergency_call/upp_commando/print_backstory(mob/living/carbon/human/M)
 	to_chat(M, SPAN_BOLD("You grew up in relatively simple family in [pick(75;"Eurasia", 25;"a famished UPP colony")] with few belongings or luxuries."))

--- a/code/datums/emergency_calls/wy_commando.dm
+++ b/code/datums/emergency_calls/wy_commando.dm
@@ -72,6 +72,7 @@
 	item_spawn = /obj/effect/landmark/ert_spawns/distress_pmc/item
 
 	max_smartgunners = 2
+	ignore_ftl_or_crash = TRUE
 
 /datum/emergency_call/wy_commando/deathsquad/New()
 	..()


### PR DESCRIPTION

# About the pull request

As title

# Explain why it's good for the game

Staff can still send deathsquad regardless of ship's state.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
admin: Deathsquad ERTs can now be sent during FTL/Ship Crash.
admin: Added a log to ERTs failing due to FTL/Crash status.
/:cl:
