### PR TITLE
Scouts lose 100% IFF on cloak, but have a lower uncloak gun cooldown

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -1045,7 +1045,7 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	H.unset_interaction()
 
 	H.alpha = camo_alpha
-	H.FF_hit_evade = 30
+	H.FF_hit_evade = 40
 	if(!allowed_stealth_shooting)
 		H.allow_gun_usage = allow_gun_usage
 


### PR DESCRIPTION
It would be funnier if the scout's sprite got replaced with a lurker's while cloaked, but i'm too lazy to do that. so just removing the IFF is all I'll do 
# About the pull request
see: https://forum.cm-ss13.com/t/remove-ff-protection-cloaked-scouts-get/19799/7

Scout's friendly bullet evade dropped from 1000 -> 40 (for reference, base Friendly evade is 15). this means that RARELY you'll be able to avoid bullets fired from friendlies that have NON-INSANE accuracy stats (for reference, all mk2 wielded bullets will ALWAYS hit because the mk2 has an accurate wielded range of TWENTY TILES, this will provide partial resistance to... pistols sometimes I guess)

Scout can now fire after 1 second, instead of 1.5s after uncloaking.

Demonstration of how you can, infact, shoot the scout here:

https://github.com/user-attachments/assets/fc116b8a-06ca-4a96-af3e-79107eef8886



<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #12345" to link the PR to the corresponding Issue number #12345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #12345, Fixes #12346, Fixes #12347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
<img width="422" height="95" alt="image" src="https://github.com/user-attachments/assets/98dc0d8e-41cd-4777-b422-deec36ebc813" />


# Changelog
:cl:
balance: Scouts are no longer completely IFF while cloaked
balance: Scouts can fire 0.5s (1.5s->1s) faster from uncloak
/:cl:
