### PR TITLE
Stasis bags now accept infected corpses and tell you when they won't accept uninfected ones

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -307,7 +307,10 @@
 	. = ..()
 	var/list/mobs_can_store = list()
 	for(var/mob/living/carbon/human/human in loc)
-		if(human.buckled || (human.stat == DEAD))
+		if(human.buckled)
+			continue
+		if(human.stat == DEAD && !(locate(/obj/item/alien_embryo) in human))
+			visible_message(SPAN_WARNING("\The [src] cannot store an uninfected corpse."))
 			continue
 		mobs_can_store += human
 	if(length(mobs_can_store))
@@ -334,6 +337,8 @@
 		open()
 		return
 	if(stasis_mob.stat == DEAD)// || !stasis_mob.key || !stasis_mob.client) // stop using cryobags for corpses and SSD/Ghosted
+		if(locate(/obj/item/alien_embryo) in stasis_mob) // infected, hold in stasis
+			return
 		STOP_PROCESSING(SSobj, src)
 		open()
 		visible_message(SPAN_NOTICE("\The [src] rejects the corpse."))

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -336,7 +336,7 @@
 		STOP_PROCESSING(SSobj, src)
 		open()
 		return
-	if(stasis_mob.stat == DEAD)// || !stasis_mob.key || !stasis_mob.client) // stop using cryobags for corpses and SSD/Ghosted
+	if(stasis_mob.stat == DEAD)
 		if(locate(/obj/item/alien_embryo) in stasis_mob) // infected, hold in stasis
 			return
 		STOP_PROCESSING(SSobj, src)


### PR DESCRIPTION

# About the pull request

Stasis bags will no longer yeet infected corpses out onto the floor. Previously, if a marine was infected and died, the stasis bag would detect them as dead and immediately eject them. This PR makes the bag check whether the corpse is carrying an alien embryo before deciding to reject it, if they're infected, they stay in. Uninfected corpses still get rejected, and now actually tell you why instead of silently doing nothing.

# Explain why it's good for the game

I have personally witnessed, on multiple occasions, brand new players spend upwards of three minutes repeatedly trying to bag a dead infected marine, getting increasingly confused because the bag keeps spitting the body out with zero explanation. Three minutes. Of just. Trying to put a body in a bag. These people are not stupid, the bag is just doing something completely counterintuitive with no feedback whatsoever.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Stasis bags no longer reject infected corpses, allowing them to be preserved for embryo removal surgery
qol: Stasis bags now display a message when refusing to store an uninfected corpse instead of silently doing nothing
/:cl:
