### PR TITLE
Removes brute rockets from the requisitions vendor.

### DIFF
--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -61,7 +61,6 @@
 		list("M40 MFHS Metal Foam Grenade", floor(scale * 6), /obj/item/explosive/grenade/metal_foam, VENDOR_ITEM_REGULAR),
 		list("Plastic Explosives", floor(scale * 3), /obj/item/explosive/plastic, VENDOR_ITEM_REGULAR),
 		list("Breaching Charge", floor(scale * 2), /obj/item/explosive/plastic/breaching_charge, VENDOR_ITEM_REGULAR),
-		list("M6H-BRUTE Breaching Rocket", floor(scale * 3), /obj/item/ammo_magazine/rocket/brute, VENDOR_ITEM_REGULAR),
 
 		list("WEBBINGS", -1, null, null),
 		list("Black Webbing Vest", floor(scale * 2), /obj/item/clothing/accessory/storage/black_vest, VENDOR_ITEM_REGULAR),


### PR DESCRIPTION

# About the pull request

Removes BRUTE rockets from the requisitions vendors. This means the only source of BRUTE rockets is from comtech-loadout vendors.

# Explain why it's good for the game

Puts BRUTE on the same level as the other special tools comtech has available to it (emplacements) in terms of ammo economy, and reduces the sheer omnipresence of BRUTE weaponry on the battlefield.  


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.
<img width="1503" height="819" alt="image" src="https://github.com/user-attachments/assets/d1ca7a46-539a-4ad3-99b0-87baf1dff11b" />

</details>


# Changelog
:cl:
balance: removes guaranteed BRUTE ammunition from the requisitions vendors.
/:cl:
