### PR TITLE
LZ is now Named if called by the queen

### DIFF
--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -263,7 +263,7 @@
 				to_chat(xeno, SPAN_WARNING("The metal bird can not land here. It might be currently occupied!"))
 				return
 			to_chat(xeno, SPAN_NOTICE("You command the metal bird to come down. Clever girl."))
-			xeno_announcement(SPAN_XENOANNOUNCE("Our Queen has commanded the metal bird to the hive at [linked_lz]."), xeno.hivenumber, XENO_GENERAL_ANNOUNCE)
+			xeno_announcement(SPAN_XENOANNOUNCE("Our Queen has commanded the metal bird to the hive at [landing_zone.name]."),xeno.hivenumber,XENO_GENERAL_ANNOUNCE)
 			log_ares_flight("Unknown", "Remote launch signal for [shuttle.name] received. Authentication garbled.")
 			log_ares_security("Security Alert", "Remote launch signal for [shuttle.name] received. Authentication garbled.")
 			return


### PR DESCRIPTION

# About the pull request
LZ being named when commanded by queen

# Explain why it's good for the game
Xenos now know where is LZ

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

<img width="711" height="138" alt="image" src="https://github.com/user-attachments/assets/3f02da3f-4006-416e-a8b9-6676a3b3fb26" />

<img width="708" height="140" alt="image" src="https://github.com/user-attachments/assets/3cdb7915-7703-4d13-add9-583d68eb1c96" />


</details>


# Changelog
:cl:
qol: Queen summoning the Dropship fully names the LZ
/:cl:
