### PR TITLE
Lets low threat UPP commandos be chosen as a hostile ERT.

### DIFF
--- a/code/datums/emergency_calls/upp_commando.dm
+++ b/code/datums/emergency_calls/upp_commando.dm
@@ -54,6 +54,7 @@
 /datum/emergency_call/upp_commando/low_threat
 	name = "UPP Commandos"
 	probability = 5
+	arrival_message = "[MAIN_SHIP_NAME] t*is i* UP* d^sp^*ch`. STr*&e teaM, #*u are cLe*% for a*pr*%^h. Pr*mE a*l wE*p^ns and pR*epr# t% r@nd$r a(tD."
 
 /datum/emergency_call/upp_commando/low_threat/create_member(datum/mind/mind, turf/override_spawn_loc)
 	var/turf/spawn_loc = override_spawn_loc ? override_spawn_loc : get_spawn_point()

--- a/code/datums/emergency_calls/upp_commando.dm
+++ b/code/datums/emergency_calls/upp_commando.dm
@@ -53,6 +53,7 @@
 
 /datum/emergency_call/upp_commando/low_threat
 	name = "UPP Commandos"
+	probability = 5
 
 /datum/emergency_call/upp_commando/low_threat/create_member(datum/mind/mind, turf/override_spawn_loc)
 	var/turf/spawn_loc = override_spawn_loc ? override_spawn_loc : get_spawn_point()

--- a/code/datums/emergency_calls/upp_commando.dm
+++ b/code/datums/emergency_calls/upp_commando.dm
@@ -54,6 +54,9 @@
 /datum/emergency_call/upp_commando/low_threat
 	name = "UPP Commandos"
 	probability = 5
+
+/datum/emergency_call/upp_commando/New()
+	..()
 	arrival_message = "[MAIN_SHIP_NAME] t*is i* UP* d^sp^*ch`. STr*&e teaM, #*u are cLe*% for a*pr*%^h. Pr*mE a*l wE*p^ns and pR*epr# t% r@nd$r a(tD."
 
 /datum/emergency_call/upp_commando/low_threat/create_member(datum/mind/mind, turf/override_spawn_loc)


### PR DESCRIPTION

# About the pull request
Enables low threat UPP commandos as a hostile ERT. (Same chance to arrive as WY commandos.)
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #12345" to link the PR to the corresponding Issue number #12345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #12345, Fixes #12346, Fixes #12347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
We get low threat WY commandos as an ERT, why not UPP commandos?
They're easily much weaker than WY commandos, they have no smartgunner or sniper, and can't go invisible like the high threat variant.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Low threat UPP commandos can be chosen as hostile ERT.
/:cl:
