### PR TITLE
wy synth drip

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/synthetic.dm
+++ b/code/game/machinery/vending/vendor_types/crew/synthetic.dm
@@ -918,9 +918,6 @@ GLOBAL_LIST_INIT(cm_vending_clothing_synth, list(
 /datum/gear/synthetic/wy_patch_square
 	path = /obj/item/clothing/accessory/patch/wysquare
 
-/datum/gear/synthetic/hd_patch
-	path = /obj/item/clothing/accessory/patch/hyperdyne_patch
-
 //------------EXPERIMENTAL TOOLS---------------
 /obj/structure/machinery/cm_vending/own_points/experimental_tools
 	name = "\improper W-Y Experimental Tools Vendor"


### PR DESCRIPTION

# About the pull request

adds some WY customization items into the synth loadout options

# Explain why it's good for the game

many of the synths are WY made, it's weird we have so little in the form of WY customization options.

# Testing Photographs and Procedure


<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog



:cl: Nomoresolvalou
add: Added Weyland Yutani hat and patches to the synth loadout picker.

/:cl:

