### PR TITLE
Trijent Dam Elevator Fix but cleaner

### DIFF
--- a/code/game/area/DesertDam.dm
+++ b/code/game/area/DesertDam.dm
@@ -1077,6 +1077,15 @@
 	icon_state = "valley"
 	unoviable_timer = FALSE
 
+/area/desert_dam/exterior/valley/valley_medical_elevator_landing
+	name = "Medical Valley Elevator Landing"
+	icon_state = "valley"
+	unoviable_timer = FALSE
+	always_unpowered = FALSE
+	power_light = TRUE
+	power_equip = TRUE
+	power_environ = TRUE
+
 /area/desert_dam/exterior/valley/valley_hydro
 	name = "Hydro Valley"
 	icon_state = "valley"
@@ -1101,6 +1110,14 @@
 /area/desert_dam/exterior/valley/valley_wilderness
 	name = "Wilderness Valley"
 	icon_state = "central"
+
+/area/desert_dam/exterior/valley/valley_wilderness_elevator_landing
+	name = "Wilderness Valley Elevator Landing"
+	icon_state = "central"
+	always_unpowered = FALSE
+	power_light = TRUE
+	power_equip = TRUE
+	power_environ = TRUE
 
 //Rivers
 /area/desert_dam/exterior/river

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -1428,6 +1428,16 @@
 	},
 /turf/open/asphalt/cement/cement3,
 /area/desert_dam/interior/dam_interior/central_tunnel)
+"aer" = (
+/obj/docking_port/stationary/trijent_elevator/empty{
+	airlock_area = /area/shuttle/trijent_shuttle/omega;
+	airlock_exit = "east";
+	elevator_network = "B";
+	id = "trijent_omega";
+	name = "Omega Elevator"
+	},
+/turf/open/gm/empty,
+/area/shuttle/trijent_shuttle/omega)
 "aes" = (
 /obj/effect/decal/sand_overlay/sand2/corner2{
 	dir = 1
@@ -2708,6 +2718,9 @@
 	},
 /turf/open/floor/prison/whitegreenfull/southwest,
 /area/desert_dam/building/medical/stairwell/upper_north)
+"aip" = (
+/turf/open/asphalt/tile,
+/area/desert_dam/exterior/valley/valley_medical_elevator_landing)
 "aiq" = (
 /turf/open/floor/prison/darkred2/southwest,
 /area/desert_dam/building/security/southern_hallway)
@@ -3259,6 +3272,10 @@
 	},
 /turf/open/floor/prison/darkred2/west,
 /area/desert_dam/building/security/southern_hallway)
+"ajU" = (
+/obj/effect/decal/sand_overlay/sand1/corner1,
+/turf/open/asphalt/tile,
+/area/desert_dam/exterior/valley/valley_medical_elevator_landing)
 "ajV" = (
 /obj/item/trash/cigbutt{
 	pixel_x = 9;
@@ -3742,6 +3759,10 @@
 	},
 /turf/open/floor/prison/darkred2/north,
 /area/desert_dam/building/security/southern_hallway)
+"alv" = (
+/obj/effect/decal/sand_overlay/sand1,
+/turf/open/asphalt/tile,
+/area/desert_dam/exterior/valley/valley_medical_elevator_landing)
 "alw" = (
 /obj/structure/bed/stool{
 	buckling_y = 14;
@@ -4217,6 +4238,9 @@
 	},
 /turf/open/asphalt/cement/cement13,
 /area/desert_dam/exterior/valley/valley_security)
+"amQ" = (
+/turf/open/asphalt/cement_sunbleached/cement_sunbleached14,
+/area/desert_dam/exterior/valley/valley_medical_elevator_landing)
 "amR" = (
 /obj/effect/decal/sand_overlay/sand1,
 /turf/open/asphalt/cement/cement12,
@@ -4233,6 +4257,9 @@
 	},
 /turf/open/asphalt/cement/cement4,
 /area/desert_dam/exterior/valley/valley_security)
+"amU" = (
+/turf/open/asphalt/cement_sunbleached/cement_sunbleached12,
+/area/desert_dam/exterior/valley/valley_medical_elevator_landing)
 "amV" = (
 /obj/structure/prop/hybrisa/vehicles/Meridian/Orange,
 /turf/open/asphalt,
@@ -4243,6 +4270,9 @@
 	},
 /turf/open/asphalt/cement/cement1,
 /area/desert_dam/exterior/valley/valley_security)
+"amX" = (
+/turf/open/asphalt/cement_sunbleached/cement_sunbleached15,
+/area/desert_dam/exterior/valley/valley_medical_elevator_landing)
 "amY" = (
 /obj/effect/decal/sand_overlay/sand1/corner1{
 	dir = 8
@@ -6765,6 +6795,9 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/desert_dam/exterior/roof)
+"avI" = (
+/turf/open/asphalt/cement_sunbleached/cement_sunbleached2,
+/area/desert_dam/exterior/valley/valley_medical_elevator_landing)
 "avJ" = (
 /obj/item/ammo_magazine/pistol/l54/rubber{
 	pixel_x = 10;
@@ -7121,6 +7154,9 @@
 	},
 /turf/open/floor/prison/darkyellow2/north,
 /area/desert_dam/interior/dam_interior/primary_tool_storage/upper)
+"awU" = (
+/turf/open/asphalt/cement_sunbleached/cement_sunbleached4,
+/area/desert_dam/exterior/valley/valley_medical_elevator_landing)
 "awV" = (
 /obj/structure/largecrate/random/barrel/yellow{
 	pixel_x = 5;
@@ -8744,6 +8780,9 @@
 	},
 /turf/open/floor/prison/blue/east,
 /area/desert_dam/interior/dam_interior/hanger/control)
+"aBF" = (
+/turf/open/asphalt/cement_sunbleached/cement_sunbleached9,
+/area/desert_dam/exterior/valley/valley_medical_elevator_landing)
 "aBG" = (
 /turf/open/floor/almayer_hull,
 /area/desert_dam/interior/dam_interior/hanger/roof)
@@ -9233,6 +9272,12 @@
 	},
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/hanger/roof)
+"aCT" = (
+/obj/effect/decal/sand_overlay/sand1{
+	dir = 1
+	},
+/turf/open/asphalt/tile,
+/area/desert_dam/exterior/valley/valley_medical_elevator_landing)
 "aCU" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -10331,6 +10376,12 @@
 /obj/structure/largecrate/empty/case/double,
 /turf/open/floor/prison/blue/west,
 /area/desert_dam/building/administration/gate)
+"aGA" = (
+/obj/effect/decal/sand_overlay/sand1/corner1{
+	dir = 1
+	},
+/turf/open/asphalt/tile,
+/area/desert_dam/exterior/valley/valley_medical_elevator_landing)
 "aGB" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/structure/disposalpipe/segment,
@@ -10347,6 +10398,11 @@
 /obj/structure/closet/crate/foodcart,
 /turf/open/floor/prison/blue/west,
 /area/desert_dam/building/administration/gate)
+"aGE" = (
+/turf/closed/wall/hangar{
+	name = "Elevator Shaft"
+	},
+/area/shuttle/trijent_shuttle/omega)
 "aGF" = (
 /obj/item/card/id/visa{
 	desc = "A United Americas entry visa. A rare commodity out here on the rim.";
@@ -10401,6 +10457,11 @@
 	},
 /turf/open/floor/prison/blue/west,
 /area/desert_dam/building/administration/gate)
+"aGO" = (
+/obj/structure/machinery/colony_floodlight,
+/obj/effect/decal/sand_overlay/sand2,
+/turf/open/asphalt/tile,
+/area/desert_dam/exterior/valley/valley_wilderness_elevator_landing)
 "aGP" = (
 /turf/open/floor/neutral,
 /area/desert_dam/interior/dam_interior/engine_room)
@@ -12111,9 +12172,6 @@
 /turf/open/floor/prison/bright_clean2,
 /area/desert_dam/building/administration/upper_hallway)
 "aLZ" = (
-/obj/effect/decal/sand_overlay/sand1/corner1{
-	dir = 4
-	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
 	},
@@ -12122,7 +12180,7 @@
 	shuttleId = "trijentshuttle22"
 	},
 /turf/open/floor/prison/sterile_white/west,
-/area/desert_dam/exterior/valley/valley_medical)
+/area/desert_dam/exterior/valley/valley_medical_elevator_landing)
 "aMa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/green{
@@ -17824,6 +17882,13 @@
 /obj/structure/fence/slim/dark,
 /turf/open/desert/rock/deep/rock3,
 /area/desert_dam/interior/caves/east_caves)
+"bel" = (
+/obj/effect/decal/sand_overlay/sand2/corner2{
+	dir = 8;
+	layer = 2.02
+	},
+/turf/open/asphalt/cement/cement1,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "bem" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -18513,6 +18578,9 @@
 /obj/effect/blocker/water/toxic,
 /turf/open/desert/desert_shore/shore_corner2,
 /area/desert_dam/exterior/river_mouth/southern)
+"bgj" = (
+/turf/open/asphalt/tile,
+/area/desert_dam/exterior/valley/valley_wilderness_elevator_landing)
 "bgk" = (
 /obj/structure/prop/dam/large_boulder/boulder1{
 	pixel_x = -11;
@@ -19766,6 +19834,9 @@
 	},
 /turf/open/desert/rock,
 /area/desert_dam/interior/caves/pred_ship)
+"bjR" = (
+/turf/open/asphalt/cement/cement12,
+/area/desert_dam/exterior/valley/valley_wilderness_elevator_landing)
 "bjS" = (
 /obj/effect/decal/sand_overlay/sand2/corner2{
 	dir = 1;
@@ -20637,6 +20708,9 @@
 	},
 /turf/open/predship/hull,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"bmv" = (
+/turf/open/asphalt/cement/cement2,
+/area/desert_dam/exterior/valley/valley_wilderness_elevator_landing)
 "bmw" = (
 /obj/structure/prop/ice_colony/ground_wire{
 	dir = 8
@@ -20659,6 +20733,9 @@
 	},
 /turf/open/predship/hull,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"bmz" = (
+/turf/open/asphalt/cement/cement4,
+/area/desert_dam/exterior/valley/valley_wilderness_elevator_landing)
 "bmA" = (
 /obj/structure/prop/ice_colony/ground_wire{
 	dir = 8
@@ -20737,11 +20814,23 @@
 	},
 /turf/open/predship/hull,
 /area/desert_dam/exterior/valley/valley_crashsite)
+"bmM" = (
+/obj/effect/decal/sand_overlay/sand2{
+	dir = 1
+	},
+/turf/open/asphalt/tile,
+/area/desert_dam/exterior/valley/valley_wilderness_elevator_landing)
 "bmN" = (
 /obj/structure/platform/metal/kutjevo_smooth_immune/north,
 /obj/structure/platform/metal/kutjevo_smooth_immune/west,
 /turf/open_space,
 /area/desert_dam/building/water_treatment_two/overlook)
+"bmO" = (
+/obj/effect/decal/sand_overlay/sand2/corner2{
+	dir = 1
+	},
+/turf/open/asphalt/cement/cement1,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "bmQ" = (
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 10
@@ -27075,8 +27164,11 @@
 /obj/structure/machinery/computer/shuttle/elevator_controller/elevator_call/trijent/engi{
 	pixel_x = -32
 	},
-/turf/open/desert/rock/deep/transition/southwest,
-/area/desert_dam/exterior/valley/valley_wilderness)
+/obj/effect/decal/sand_overlay/sand2{
+	dir = 1
+	},
+/turf/open/asphalt/tile,
+/area/desert_dam/exterior/valley/valley_wilderness_elevator_landing)
 "drB" = (
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 5
@@ -34217,9 +34309,6 @@
 /turf/open/floor/plating,
 /area/desert_dam/building/medical/maint/south)
 "ger" = (
-/obj/effect/decal/sand_overlay/sand2/corner2{
-	dir = 8
-	},
 /turf/open/asphalt/cement/cement13,
 /area/desert_dam/exterior/valley/valley_wilderness)
 "gew" = (
@@ -37250,12 +37339,6 @@
 	},
 /turf/open/asphalt/cement_sunbleached/cement_sunbleached1,
 /area/desert_dam/exterior/valley/valley_security)
-"hlL" = (
-/obj/effect/decal/sand_overlay/sand2/corner2{
-	dir = 1
-	},
-/turf/open/asphalt/cement/cement13,
-/area/desert_dam/exterior/valley/valley_wilderness)
 "hlN" = (
 /turf/open/floor/prison/whitegreen,
 /area/desert_dam/building/medical/outgoing)
@@ -37826,12 +37909,6 @@
 "hxL" = (
 /turf/open/floor/prison/floor_plate/southwest,
 /area/desert_dam/interior/dam_interior/north_tunnel_entrance)
-"hxO" = (
-/obj/effect/decal/sand_overlay/sand2{
-	dir = 1
-	},
-/turf/open/asphalt/tile,
-/area/desert_dam/exterior/valley/valley_wilderness)
 "hxT" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
 	name = "\improper Freezer"
@@ -46365,11 +46442,11 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
 	},
-/obj/effect/decal/sand_overlay/sand1{
-	dir = 1
+/obj/effect/decal/sand_overlay/sand1/corner1{
+	dir = 4
 	},
 /turf/open/floor/prison/sterile_white/west,
-/area/desert_dam/exterior/valley/valley_medical)
+/area/desert_dam/exterior/valley/valley_medical_elevator_landing)
 "kQa" = (
 /turf/closed/shuttle/ert/transparent{
 	icon_state = "leftengine_3_clean"
@@ -62742,7 +62819,7 @@
 /area/desert_dam/building/water_treatment_one/breakroom)
 "reX" = (
 /turf/open/asphalt/cement/cement14,
-/area/desert_dam/exterior/valley/valley_wilderness)
+/area/desert_dam/exterior/valley/valley_wilderness_elevator_landing)
 "rfg" = (
 /obj/structure/flora/grass/tallgrass/desert/corner{
 	dir = 1
@@ -62881,9 +62958,17 @@
 /turf/open/gm/river/desert/deep/covered,
 /area/desert_dam/exterior/river/filtration_a)
 "rhr" = (
-/obj/structure/flora/grass/desert/lightgrass_8,
-/turf/open/desert/rock/deep/rock3,
-/area/desert_dam/exterior/valley/valley_wilderness)
+/obj/structure/machinery/power/apc/no_power/west,
+/obj/effect/decal/warning_stripes{
+	icon_state = "N"
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/obj/effect/decal/sand_overlay/sand2,
+/turf/open/floor/prison/sterile_white/west,
+/area/desert_dam/exterior/valley/valley_wilderness_elevator_landing)
 "rhB" = (
 /obj/structure/machinery/computer/med_data,
 /obj/structure/window/reinforced{
@@ -77203,10 +77288,6 @@
 "wSk" = (
 /turf/open/floor/prison/darkbrowncorners2/east,
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
-"wSl" = (
-/obj/effect/decal/sand_overlay/sand2,
-/turf/open/asphalt/tile,
-/area/desert_dam/exterior/valley/valley_wilderness)
 "wSA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/sand_overlay/sand1{
@@ -166023,7 +166104,7 @@ dEQ
 dEQ
 dEQ
 dEQ
-dEQ
+aer
 yjZ
 qaR
 uxD
@@ -167892,9 +167973,9 @@ qaR
 qaR
 yjZ
 aLZ
-fDa
-dbK
-dHl
+avI
+amQ
+aip
 qaR
 qaR
 qaR
@@ -168124,11 +168205,11 @@ mJF
 qaR
 qaR
 qaR
-qaR
+aGE
 kPR
-cRc
-ckJ
-dHl
+awU
+amU
+aip
 qaR
 qaR
 qaR
@@ -168359,10 +168440,10 @@ aYn
 qaR
 qaR
 otd
-btz
-cRc
-ckJ
-dHl
+aCT
+awU
+amU
+aip
 qaR
 qaR
 qaR
@@ -168593,10 +168674,10 @@ iWi
 vbi
 iUk
 wqW
-btz
-cRc
-ckJ
-dHl
+aCT
+awU
+amU
+aip
 qaR
 qaR
 qaR
@@ -168827,10 +168908,10 @@ iWi
 jMA
 iWi
 iWi
-btz
-cRc
-ckJ
-kfE
+aCT
+awU
+amU
+ajU
 qaR
 aYj
 vOZ
@@ -169061,10 +169142,10 @@ iWi
 iWi
 qNx
 uSe
-uPs
-oYM
-rxa
-mJF
+aGA
+aBF
+amX
+alv
 vbi
 eHo
 vbi
@@ -172988,12 +173069,12 @@ mUT
 iCL
 ihw
 dqS
-aeD
-hxO
-oJY
+bgj
+bgj
+bmv
 reX
-wSl
-aeD
+bgj
+bgj
 rhr
 aeD
 aeD
@@ -173221,14 +173302,14 @@ xmG
 mUT
 iCL
 oId
-xAI
-fdY
-hxO
-aec
-xDb
-wSl
-fdY
-tuC
+bmM
+bgj
+bgj
+bmz
+bjR
+bgj
+bgj
+aGO
 fdY
 are
 oId
@@ -173455,14 +173536,14 @@ jtK
 mUT
 jmR
 cLO
-cLO
-cLO
-hlL
+bmO
+mpk
+ger
 mpk
 mpk
 ger
-cLO
-cLO
+mpk
+bel
 cLO
 cLO
 cLO

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -10458,10 +10458,21 @@
 /turf/open/floor/prison/blue/west,
 /area/desert_dam/building/administration/gate)
 "aGO" = (
-/obj/structure/machinery/colony_floodlight,
-/obj/effect/decal/sand_overlay/sand2,
-/turf/open/asphalt/tile,
-/area/desert_dam/exterior/valley/valley_wilderness_elevator_landing)
+/obj/structure/surface/table,
+/obj/item/reagent_container/food/drinks/coffeecup/wy{
+	pixel_x = 10;
+	pixel_y = 11
+	},
+/obj/item/tool/screwdriver{
+	pixel_y = 2;
+	pixel_x = 11
+	},
+/obj/item/device/multitool{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/turf/open/desert/dirt/desert_transition_edge1/southwest,
+/area/desert_dam/exterior/valley/valley_medical)
 "aGP" = (
 /turf/open/floor/neutral,
 /area/desert_dam/interior/dam_interior/engine_room)
@@ -17883,11 +17894,20 @@
 /turf/open/desert/rock/deep/rock3,
 /area/desert_dam/interior/caves/east_caves)
 "bel" = (
-/obj/effect/decal/sand_overlay/sand2/corner2{
-	dir = 8;
-	layer = 2.02
+/obj/structure/surface/table,
+/obj/item/reagent_container/food/drinks/coffeecup{
+	pixel_x = 11;
+	pixel_y = 11
 	},
-/turf/open/asphalt/cement/cement1,
+/obj/structure/prop/server_equipment/laptop{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/clipboard{
+	pixel_x = 12;
+	pixel_y = -5
+	},
+/turf/open/desert/rock/deep/rock3,
 /area/desert_dam/exterior/valley/valley_wilderness)
 "bem" = (
 /obj/structure/machinery/light{
@@ -18579,6 +18599,8 @@
 /turf/open/desert/desert_shore/shore_corner2,
 /area/desert_dam/exterior/river_mouth/southern)
 "bgj" = (
+/obj/structure/machinery/colony_floodlight,
+/obj/effect/decal/sand_overlay/sand2,
 /turf/open/asphalt/tile,
 /area/desert_dam/exterior/valley/valley_wilderness_elevator_landing)
 "bgk" = (
@@ -19835,8 +19857,12 @@
 /turf/open/desert/rock,
 /area/desert_dam/interior/caves/pred_ship)
 "bjR" = (
-/turf/open/asphalt/cement/cement12,
-/area/desert_dam/exterior/valley/valley_wilderness_elevator_landing)
+/obj/effect/decal/sand_overlay/sand2/corner2{
+	dir = 8;
+	layer = 2.02
+	},
+/turf/open/asphalt/cement/cement1,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "bjS" = (
 /obj/effect/decal/sand_overlay/sand2/corner2{
 	dir = 1;
@@ -20709,7 +20735,7 @@
 /turf/open/predship/hull,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "bmv" = (
-/turf/open/asphalt/cement/cement2,
+/turf/open/asphalt/tile,
 /area/desert_dam/exterior/valley/valley_wilderness_elevator_landing)
 "bmw" = (
 /obj/structure/prop/ice_colony/ground_wire{
@@ -20734,7 +20760,7 @@
 /turf/open/predship/hull,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "bmz" = (
-/turf/open/asphalt/cement/cement4,
+/turf/open/asphalt/cement/cement12,
 /area/desert_dam/exterior/valley/valley_wilderness_elevator_landing)
 "bmA" = (
 /obj/structure/prop/ice_colony/ground_wire{
@@ -20815,10 +20841,7 @@
 /turf/open/predship/hull,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "bmM" = (
-/obj/effect/decal/sand_overlay/sand2{
-	dir = 1
-	},
-/turf/open/asphalt/tile,
+/turf/open/asphalt/cement/cement2,
 /area/desert_dam/exterior/valley/valley_wilderness_elevator_landing)
 "bmN" = (
 /obj/structure/platform/metal/kutjevo_smooth_immune/north,
@@ -20826,27 +20849,14 @@
 /turf/open_space,
 /area/desert_dam/building/water_treatment_two/overlook)
 "bmO" = (
-/obj/effect/decal/sand_overlay/sand2/corner2{
+/turf/open/asphalt/cement/cement4,
+/area/desert_dam/exterior/valley/valley_wilderness_elevator_landing)
+"bmP" = (
+/obj/effect/decal/sand_overlay/sand2{
 	dir = 1
 	},
-/turf/open/asphalt/cement/cement1,
-/area/desert_dam/exterior/valley/valley_wilderness)
-"bmP" = (
-/obj/structure/surface/table,
-/obj/item/reagent_container/food/drinks/coffeecup/wy{
-	pixel_x = 10;
-	pixel_y = 11
-	},
-/obj/item/tool/screwdriver{
-	pixel_y = 2;
-	pixel_x = 11
-	},
-/obj/item/device/multitool{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/turf/open/desert/dirt/desert_transition_edge1/southwest,
-/area/desert_dam/exterior/valley/valley_medical)
+/turf/open/asphalt/tile,
+/area/desert_dam/exterior/valley/valley_wilderness_elevator_landing)
 "bmQ" = (
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 10
@@ -21655,20 +21665,10 @@
 /turf/open_space,
 /area/desert_dam/interior/caves/temple)
 "bpb" = (
-/obj/structure/surface/table,
-/obj/item/reagent_container/food/drinks/coffeecup{
-	pixel_x = 11;
-	pixel_y = 11
+/obj/effect/decal/sand_overlay/sand2/corner2{
+	dir = 1
 	},
-/obj/structure/prop/server_equipment/laptop{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/item/clipboard{
-	pixel_x = 12;
-	pixel_y = -5
-	},
-/turf/open/desert/rock/deep/rock3,
+/turf/open/asphalt/cement/cement1,
 /area/desert_dam/exterior/valley/valley_wilderness)
 "bpc" = (
 /obj/effect/decal/strata_decals/grime/grime3{
@@ -168471,7 +168471,7 @@ mJF
 aYn
 qaR
 qaR
-bmP
+aGO
 aCT
 awU
 amU
@@ -172874,7 +172874,7 @@ ybV
 ybV
 ida
 kPy
-bpb
+bel
 qaR
 aeD
 aeD
@@ -173101,12 +173101,12 @@ mUT
 iCL
 ihw
 dqS
-bgj
-bgj
 bmv
+bmv
+bmM
 reX
-bgj
-bgj
+bmv
+bmv
 rhr
 aeD
 aeD
@@ -173334,14 +173334,14 @@ xmG
 mUT
 iCL
 oId
-bmM
-bgj
-bgj
+bmP
+bmv
+bmv
+bmO
 bmz
-bjR
+bmv
+bmv
 bgj
-bgj
-aGO
 fdY
 are
 oId
@@ -173568,14 +173568,14 @@ jtK
 mUT
 jmR
 cLO
-bmO
+bpb
 mpk
 ger
 mpk
 mpk
 ger
 mpk
-bel
+bjR
 cLO
 cLO
 cLO

--- a/maps/map_files/DesertDam/Desert_Dam.dmm
+++ b/maps/map_files/DesertDam/Desert_Dam.dmm
@@ -20831,6 +20831,22 @@
 	},
 /turf/open/asphalt/cement/cement1,
 /area/desert_dam/exterior/valley/valley_wilderness)
+"bmP" = (
+/obj/structure/surface/table,
+/obj/item/reagent_container/food/drinks/coffeecup/wy{
+	pixel_x = 10;
+	pixel_y = 11
+	},
+/obj/item/tool/screwdriver{
+	pixel_y = 2;
+	pixel_x = 11
+	},
+/obj/item/device/multitool{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/turf/open/desert/dirt/desert_transition_edge1/southwest,
+/area/desert_dam/exterior/valley/valley_medical)
 "bmQ" = (
 /obj/effect/decal/sand_overlay/sand1{
 	dir = 10
@@ -21638,6 +21654,22 @@
 	},
 /turf/open_space,
 /area/desert_dam/interior/caves/temple)
+"bpb" = (
+/obj/structure/surface/table,
+/obj/item/reagent_container/food/drinks/coffeecup{
+	pixel_x = 11;
+	pixel_y = 11
+	},
+/obj/structure/prop/server_equipment/laptop{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/clipboard{
+	pixel_x = 12;
+	pixel_y = -5
+	},
+/turf/open/desert/rock/deep/rock3,
+/area/desert_dam/exterior/valley/valley_wilderness)
 "bpc" = (
 /obj/effect/decal/strata_decals/grime/grime3{
 	icon_state = "grime4"
@@ -168439,7 +168471,7 @@ mJF
 aYn
 qaR
 qaR
-otd
+bmP
 aCT
 awU
 amU
@@ -172842,7 +172874,7 @@ ybV
 ybV
 ida
 kPy
-aeD
+bpb
 qaR
 aeD
 aeD

--- a/tgui/packages/tgui/interfaces/ElevatorControl.tsx
+++ b/tgui/packages/tgui/interfaces/ElevatorControl.tsx
@@ -63,7 +63,7 @@ const ElevatorPanel = (props) => {
 
       {data.mode === 'recharging' && (
         <Stack.Item>
-          <InfoBox title="Curtesy Time" text={data.eta} />
+          <InfoBox title="Courtesy Time" text={data.eta} />
         </Stack.Item>
       )}
       {data.mode === 'igniting' && (


### PR DESCRIPTION
# About the pull request

Pretty much another #11700 but cleaner - Fixes #10552 by adding two new areas to Trijent Dam, "Medical Valley Elevator Landing" and "Wilderness Valley Elevator Landing." These areas are limited to their respective elevator landings and only differ by being powered (while still keeping the rest of the valley unpowered). This PR also adds an APC to the wilderness valley's elevator landing, and adds a docking port for the medical valley's elevator shaft. Finally, this PR adds metal walls and floors to the two APCs and the tiles in front of them, allowing them to be repaired when they are inevitably destroyed.

# Explain why it's good for the game

The elevators are unique to Trijent Dam, allowing quick transport from one side of the colony to the other, yet have seen virtually no use due to the fact that both ends of both elevators are non-functional (50% functional in the case of the medical valley's elevator landing, to be precise).


# Testing Photographs and Procedure
I tested this locally by calling the two elevators from the four points across the map, riding the elevators between each point, then deleting the APCs powering the landings and rebuilding them.

</details>


# Changelog
:cl:
fix: The elevator landing at Trijent Dam's wilderness valley now has an APC powering it
fix: The APCs powering the elevator landings at Trijent Dam's wilderness and medical valleys now have metal walls and floors to allow for field repairs without requiring admin intervention
fix: The elevator shaft at the medical valley now has a docking port
maptweak: Added two new areas to Trijent Dam that can be powered with an APC: "Medical Valley Elevator Landing" and "Wilderness Valley Elevator Landing"
spellcheck: Changed "curtesy" to "courtesy" in the elevator control panel
/:cl:
