### PR TITLE
Add regex to labels and hand labeller

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -30,9 +30,9 @@
 		text = replacetext(text, char, repl_chars[char])
 	return text
 
-///Helper for only alphanumeric characters plus common punctuation, spaces, underscore and hyphen _ -.
+///Helper for only alphanumeric characters plus common punctuation, spaces, underscore, hyphen, plus, vertical bar _ -+|.
 /proc/replace_non_alphanumeric_plus(text)
-	var/regex/alphanumeric = regex(@{"[^a-z0-9 ,.?!\-_&]"}, "gi")
+	var/regex/alphanumeric = regex(@{"[^a-z0-9 ,.?!|\-+_&]"}, "gi")
 	return alphanumeric.Replace(text, "")
 
 /proc/readd_quotes(text)

--- a/code/datums/components/label.dm
+++ b/code/datums/components/label.dm
@@ -87,6 +87,9 @@
 /// Applies a label to the name of the parent in the format of: "parent_name (label)"
 /datum/component/label/proc/apply_label()
 	var/atom/owner = parent
+	label_name = replace_non_alphanumeric_plus(label_name)
+	if(!label_name)
+		QDEL_NULL(src)
 	owner.name += " ([label_name])"
 
 /// Clears the label from the parent's name (but doesn't delete it)

--- a/code/game/objects/items/tools/misc_tools.dm
+++ b/code/game/objects/items/tools/misc_tools.dm
@@ -93,6 +93,7 @@
 		to_chat(user, SPAN_NOTICE("You turn on [src]."))
 		//Now let them choose the text.
 		var/str = copytext(reject_bad_text(tgui_input_text(user, "Label text?", "Set label", "", MAX_NAME_LEN, ui_state=GLOB.not_incapacitated_state)), 1, MAX_NAME_LEN)
+		str = replace_non_alphanumeric_plus(str)
 		if(!str || !length(str))
 			to_chat(user, SPAN_NOTICE("Label text cleared. You can now remove labels."))
 			label = null


### PR DESCRIPTION

# About the pull request
Mostly to address people putting emojis into labels.
Also slightly expand the characters allowed from `replace_non_alphanumeric_plus`
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #12345" to link the PR to the corresponding Issue number #12345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #12345, Fixes #12346, Fixes #12347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Considered against rule 3, so lowers admin actions.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Labels are more strict on what they allow. Only alphanumeric characters plus common punctuation, spaces, underscore, hyphen, plus, and vertical bar.
/:cl:
