### PR TITLE
[EXPERIMENTAL] Increases Guaranteed Hivelord Slot from 1 to 2.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -31,7 +31,7 @@
 	/// Assoc list of free slots available to specific castes
 	var/list/free_slots = list(
 		/datum/caste_datum/burrower = 1,
-		/datum/caste_datum/hivelord = 1,
+		/datum/caste_datum/hivelord = 2,
 		/datum/caste_datum/carrier = 1
 	)
 	/// Assoc list of slots currently used by specific castes (for calculating free_slot usage)


### PR DESCRIPTION
# Spotted issues or want to give feedback?
click this link: https://discord.com/channels/150315577943130112/1464087612796174501

# About the pull request

Title

# Explain why it's good for the game

I noticed specific drift in community around hivelord, people are arguing to make hivelord mandatory, having more than 1 hivelord is waste of T2 slot, there are hivelord strains but you will rarely see them in action considering there will be 1 hivelord so it doesn't take up T2 slot, it kinda makes strains inferior to base one, hivelords have the biggest impact on game but no one want to take on hivelord duty *alone* maybe they would like to work together with designer or whisperer?

Hivelord is essential for xenos but people will be discouraged to do it alone or to occupy extra T2 slot, this simple change is mainly experimental to see if hivelords pickrate would increase and if there would be more hivelords variety.

# Testing Photographs and Procedure

<details>
<summary>Just Image HERE</summary>

<img width="330" height="60" alt="image" src="https://github.com/user-attachments/assets/2bd706c8-2704-4435-8c97-78a5f5534b7c" />

</details>


# Changelog
:cl: Venuska1117
balance: Hivelords Guaranteed slots are increased from 1 to 2.
/:cl:
