### PR TITLE
Adds paygrade prefixes to the crew manifest, shortens a couple researcher paygrade prefixes

### DIFF
--- a/code/datums/crew_manifest.dm
+++ b/code/datums/crew_manifest.dm
@@ -47,10 +47,10 @@ GLOBAL_DATUM_INIT(crew_manifest, /datum/crew_manifest, new)
 		if(record_entry.fields["mob_faction"] != FACTION_MARINE && !(rank in USCM_SHARED_JOBS))
 			continue
 
-		var/display_name = "[paygrade_prefix] [name]"
 		var/entry_dept = null
 		var/list/entry = list(
-			"name" = display_name,
+			"paygrade_prefix" = paygrade_prefix,
+			"name" = name,
 			"rank" = rank,
 			"squad" = squad,
 			"is_active" = record_entry.fields["p_stat"]

--- a/code/datums/crew_manifest.dm
+++ b/code/datums/crew_manifest.dm
@@ -39,6 +39,7 @@ GLOBAL_DATUM_INIT(crew_manifest, /datum/crew_manifest, new)
 	for(var/datum/data/record/record_entry in GLOB.data_core.general)
 		var/name = record_entry.fields["name"]
 		var/rank = record_entry.fields["rank"]
+		var/paygrade_prefix = record_entry.fields["paygrade_prefix"]
 		var/squad = record_entry.fields["squad"]
 		if(isnull(name) || isnull(rank))
 			continue
@@ -46,9 +47,10 @@ GLOBAL_DATUM_INIT(crew_manifest, /datum/crew_manifest, new)
 		if(record_entry.fields["mob_faction"] != FACTION_MARINE && !(rank in USCM_SHARED_JOBS))
 			continue
 
+		var/display_name = "[paygrade_prefix] [name]"
 		var/entry_dept = null
 		var/list/entry = list(
-			"name" = name,
+			"name" = display_name,
 			"rank" = rank,
 			"squad" = squad,
 			"is_active" = record_entry.fields["p_stat"]

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -87,7 +87,7 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 	record_general.name = target.real_name
 	record_general.fields["real_rank"] = assignment
 	record_general.fields["rank"] = manifest_title
-	record_general.fields["paygrade_prefix"] = target.get_paygrade(1) || ""
+	record_general.fields["paygrade_prefix"] = target.get_paygrade(1)
 	record_general.fields["squad"] = target.assigned_squad ? target.assigned_squad.name : null
 	record_general.fields["age"] = target.age
 	record_general.fields["p_stat"] = "Active"

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -87,6 +87,7 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 	record_general.name = target.real_name
 	record_general.fields["real_rank"] = assignment
 	record_general.fields["rank"] = manifest_title
+	record_general.fields["paygrade_prefix"] = target.get_paygrade(1) || ""
 	record_general.fields["squad"] = target.assigned_squad ? target.assigned_squad.name : null
 	record_general.fields["age"] = target.age
 	record_general.fields["p_stat"] = "Active"

--- a/code/datums/paygrades/factions/other/civilian.dm
+++ b/code/datums/paygrades/factions/other/civilian.dm
@@ -33,7 +33,7 @@
 /datum/paygrade/civilian/associateprofessor
 	paygrade = PAY_SHORT_CCMOB
 	name = "Associate Professor"
-	prefix = "Assoc. Prof."
+	prefix = "Asc. Prof."
 	pay_multiplier = 3.5
 
 /datum/paygrade/civilian/professor
@@ -46,7 +46,7 @@
 /datum/paygrade/civilian/regentsprofessor
 	paygrade = PAY_SHORT_CCMOD
 	name = "Regents Professor"
-	prefix = "Regents Prof."
+	prefix = "Rgts. Prof."
 	pay_multiplier = 4
 	officer_grade = GRADE_OFFICER
 

--- a/tgui/packages/tgui/interfaces/CrewManifest.tsx
+++ b/tgui/packages/tgui/interfaces/CrewManifest.tsx
@@ -116,17 +116,27 @@ export const CrewManifest = (props, context) => {
                     className={index % 2 === 0 ? 'row-even' : 'row-odd'}
                   >
                     <TableCell
-                      width="50%"
+                      width="15%"
+                      textAlign="right"
+                      pr="5px"
+                      pt="5px"
+                      pb="5px"
+                      nowrap
+                    >
+                      {crew.paygrade_prefix}
+                    </TableCell>
+                    <TableCell
+                      width="40%"
                       textAlign="left"
                       pt="5px"
                       pb="5px"
-                      pl="10px"
+                      pl="5px"
                       nowrap
                     >
                       {crew.name}
                     </TableCell>
                     <TableCell
-                      width="45%"
+                      width="40%"
                       textAlign="right"
                       pr="2%"
                       pt="5px"

--- a/tgui/packages/tgui/interfaces/CrewManifest.tsx
+++ b/tgui/packages/tgui/interfaces/CrewManifest.tsx
@@ -13,6 +13,7 @@ type ManifestData = {
 };
 
 type Crew = {
+  paygrade_prefix: string;
   name: string;
   rank: string;
   squad?: string | null;


### PR DESCRIPTION

# About the pull request

Paygrades are now visible in the crew manifest

# Explain why it's good for the game

Ever called the colonel a major? Didn't know what to call the SEA? Didn't know whether or not the combat correspondent fell under marine law by being an enlisted marine or was actually a civilian reporter? Ever wanted to know which squad had an innocent PVT? Boy do I have a PR for you!

23-05-2026: I have placed paygrade prefixes in a separate column to the left and made the names in line with each other. Unfortunately for nearly all entries in the crew manifest you'll find a sizeable gap to the left of the paygrades, that's because I have to accomodate for the special snowflake paygrade prefixes that the researchers and corporate liaisons have. Nevertheless I've shortened 'Regents Prof.' and 'Assoc. Prof' to 'Rgts. Prof.' and 'Asc. Prof.' respectively.
<details><summary>Screenshots & Videos</summary>

<img width="834" height="2140" alt="Crew manifest with paygrades" src="https://github.com/user-attachments/assets/a2ea09f9-11dc-464b-9bbf-e1c868979cdc" />

</details>


# Changelog
:cl:
add: Added paygrades prefixes to the crew manifest
ui: Paygrade prefixes in the crew manifest are in a separate column. Names are in line with each other
spellcheck: Slightly shortened two researcher paygrade prefixes
/:cl:
