### PR TITLE
Gun holster var for gun holstered icon

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -1385,6 +1385,9 @@
 		/obj/item/weapon/gun/pistol/skorpion, // HONKed currently
 	)
 
+	///Where update_gun_icon should look for their holstered gun icon
+	var/gun_slot_icon = 'icons/obj/items/clothing/belts/holstered_guns.dmi'
+
 /obj/item/storage/belt/gun/select_gamemode_skin(expected_type, list/override_icon_state, list/override_protection)
 	. = ..()
 	switch(SSmapping.configs[GROUND_MAP].camouflage_type)
@@ -1469,17 +1472,18 @@
 		sure that we don't have to do any extra calculations.
 		*/
 		playsound(src, drawSound, 7, TRUE)
-		var/image/gun_underlay = image('icons/obj/items/clothing/belts/holstered_guns.dmi', current_gun.base_gun_icon)
+		var/prefix = ""
 		if(gun_has_gamemode_skin && current_gun.map_specific_decoration)
 			switch(SSmapping.configs[GROUND_MAP].camouflage_type)
 				if("snow")
-					gun_underlay = image('icons/obj/items/clothing/belts/holstered_guns.dmi', "s_" + current_gun.base_gun_icon)
+					prefix = "s_"
 				if("desert")
-					gun_underlay = image('icons/obj/items/clothing/belts/holstered_guns.dmi', "d_" + current_gun.base_gun_icon)
+					prefix = "d_"
 				if("classic")
-					gun_underlay = image('icons/obj/items/clothing/belts/holstered_guns.dmi', "c_" + current_gun.base_gun_icon)
+					prefix = "c_"
 				if("urban")
-					gun_underlay = image('icons/obj/items/clothing/belts/holstered_guns.dmi', "u_" + current_gun.base_gun_icon)
+					prefix = "u_"
+		var/image/gun_underlay = image(gun_slot_icon, prefix + current_gun.base_gun_icon)
 		gun_underlay.pixel_x = holster_slots[slot]["icon_x"]
 		gun_underlay.pixel_y = holster_slots[slot]["icon_y"]
 		gun_underlay.color = current_gun.color

--- a/code/modules/unit_tests/missing_icons.dm
+++ b/code/modules/unit_tests/missing_icons.dm
@@ -159,10 +159,10 @@
 					for(var/obj/item/weapon/gun/guntype as anything in guntypes)
 						if(isnull(initial(guntype.icon_state)))
 							continue
-						if(!guntype.map_specific_decoration)
-							check(obj_path, 'icons/obj/items/clothing/belts/holstered_guns.dmi', initial(guntype.icon_state), guntype, "gun_underlay")
+						if(guntype.map_specific_decoration)
+							check(obj_path, belt_gun.gun_slot_icon, prefix + initial(guntype.icon_state), guntype, "gun_underlay")
 						else
-							check(obj_path, 'icons/obj/items/clothing/belts/holstered_guns.dmi', prefix + initial(guntype.icon_state), guntype, "gun_underlay")
+							check(obj_path, belt_gun.gun_slot_icon, initial(guntype.icon_state), guntype, "gun_underlay")
 		qdel(spawned)
 
 


### PR DESCRIPTION
# About the pull request
Simply reduce ammount of hardcode in cmss13
By making hardcoded ref 'icons/obj/items/clothing/belts/holstered_guns.dmi' into the var gun_slot_icon. This way, we can make life easier for countless devs.

# Explain why it's good for the game

QOL for the devs always GOOD


# Changelog

No player facing changes, devs QOL