### PR TITLE
Hijack ERT probabilities rebalance.

### DIFF
--- a/code/datums/emergency_calls/cbrn.dm
+++ b/code/datums/emergency_calls/cbrn.dm
@@ -42,7 +42,7 @@
 /datum/emergency_call/cbrn/ert
 	name = "CBRN (Distress)"
 	arrival_message = "Attention, this is the USS Kurtz, we have dispatched a CBRN squad to your ship per your distress call. Stand by for arrival."
-	probability = 10
+	probability = 15
 
 /datum/emergency_call/cbrn/ert/New()
 	..()

--- a/code/datums/emergency_calls/clf.dm
+++ b/code/datums/emergency_calls/clf.dm
@@ -5,7 +5,7 @@
 	name = "Colonial Liberation Front (Squad)"
 	mob_max = 10
 	arrival_message = "'Attention, you are trespassing on our sovereign territory. Expect no forgiveness.'"
-	probability = 20
+	probability = 30 //Broadcasting a distress in contested space should result in likely pirate boarding.
 	hostility = TRUE
 	home_base = /datum/lazy_template/ert/clf_station
 	var/max_synths = 1

--- a/code/datums/emergency_calls/cmb.dm
+++ b/code/datums/emergency_calls/cmb.dm
@@ -2,7 +2,7 @@
 /datum/emergency_call/cmb
 	name = "CMB - Colonial Marshals Patrol Team (Friendly)"
 	mob_max = 5
-	probability = 10
+	probability = 20 //The most common ERT alongside UPP. Represents the largest responding force in Neroid alongside Wey-Yu expeditionaries.
 	home_base = /datum/lazy_template/ert/weyland_station
 
 	var/max_synths = 1

--- a/code/datums/emergency_calls/feral_xenos.dm
+++ b/code/datums/emergency_calls/feral_xenos.dm
@@ -6,14 +6,14 @@
 	mob_max = 8
 	max_medics = 2 //Support T2 castes
 	max_engineers = 3 //Combat T2 castes
-	probability = 5
+	probability = 15 //More common than regular xeno ERT, but less common than actual reinforcements or UPP.
 	auto_shuttle_launch = TRUE //because xenos can't use the shuttle console.
 	hostility = TRUE
 
 /datum/emergency_call/feral_xenos/New()
 	..()
-	arrival_message = "[MAIN_SHIP_NAME], this is USS Vriess respond-- #&...*#&^#.. signal... oh god, they're in the vent---... Priority Warning: Signal lost."
-	objectives = "Destroy everything!"
+	arrival_message = "[MAIN_SHIP_NAME], this is USS Vriess respond-- #&...*#&^#.. signal... &#*)- What *&# fuck-- &#**#^#^)-- *h GOD- they're in the vent---... Priority Warning: Signal lost."
+	objectives = "...Other hive- they're here... fighting hosts? Kill... KILL THEM ALL!"
 
 /datum/emergency_call/feral_xenos/spawn_items()
 	var/turf/drop_spawn = get_spawn_point(TRUE)

--- a/code/datums/emergency_calls/feral_xenos.dm
+++ b/code/datums/emergency_calls/feral_xenos.dm
@@ -12,7 +12,7 @@
 
 /datum/emergency_call/feral_xenos/New()
 	..()
-	arrival_message = "[MAIN_SHIP_NAME], this is USS Vriess respond-- #&...*#&^#.. signal... &#*)- What *&# fuck-- &#**#^#^)-- *h GOD- they're in the vent---... Priority Warning: Signal lost."
+	arrival_message = "[MAIN_SHIP_NAME], this is USCSS Vriess respond-- #&...*#&^#.. signal... &#*)- What *&# fuck-- &#**#^#^)-- *h GOD- they're in the vent---... Priority Warning: Signal lost."
 	objectives = "...Other hive- they're here... fighting hosts? Kill... KILL THEM ALL!"
 
 /datum/emergency_call/feral_xenos/spawn_items()

--- a/code/datums/emergency_calls/goons.dm
+++ b/code/datums/emergency_calls/goons.dm
@@ -1,14 +1,14 @@
 /datum/emergency_call/goon
 	name = "Weyland-Yutani Corporate Security (Squad)"
 	mob_max = 6
-	probability = 0
+	probability = 25 //The most common ERT alongside UPP. Represents the largest responding force in Neroid alongside CMB.
 	shuttle_id = MOBILE_SHUTTLE_ID_ERT2
 	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_pmc
 	home_base = /datum/lazy_template/ert/weyland_station
 
 /datum/emergency_call/goon/New()
 	..()
-	arrival_message = "[MAIN_SHIP_NAME], this is a Weyland-Yutani Corporate Security shuttle inbound to your distress beacon. We are coming to help."
+	arrival_message = "[MAIN_SHIP_NAME], this is a Weyland-Yutani Corporate Security shuttle inbound to your distress signal. We are coming to help."
 	objectives = "Secure the Corporate Liaison and the [MAIN_SHIP_NAME]'s Commanding Officer, and eliminate any hostile threats. Do not damage Wey-Yu property."
 
 /datum/emergency_call/goon/create_member(datum/mind/M, turf/override_spawn_loc)

--- a/code/datums/emergency_calls/pizza.dm
+++ b/code/datums/emergency_calls/pizza.dm
@@ -5,7 +5,6 @@
 	mob_max = 1
 	mob_min = 1
 	arrival_message = "'That'll be... sixteen orders of cheesy fries, eight large double topping pizzas, nine bottles of Four Loko... hello? Is anyone on this ship? Your pizzas're getting cold.'"
-	objectives = "Well, shit. That's not a commercial liner. Still, someone in that ship's gotta be hungry. Let's find out who ordered these pizzas, and get outta here..."
 	shuttle_id = MOBILE_SHUTTLE_ID_ERT_SMALL
 	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_pizza
 	home_base = /datum/lazy_template/ert/pizza_station
@@ -13,7 +12,7 @@
 
 /datum/emergency_call/pizza/New()
 	. = ..()
-	objectives = "Make sure you get a tip!"
+	objectives = "That's... not a commercial liner... Make sure you get a tip!"
 
 /datum/emergency_call/pizza/create_member(datum/mind/M, turf/override_spawn_loc)
 	var/turf/spawn_loc = override_spawn_loc ? override_spawn_loc : get_spawn_point()

--- a/code/datums/emergency_calls/pizza.dm
+++ b/code/datums/emergency_calls/pizza.dm
@@ -4,11 +4,12 @@
 	name = "Pizza Delivery"
 	mob_max = 1
 	mob_min = 1
-	arrival_message = "'That'll be... sixteen orders of cheesy fries, eight large double topping pizzas, nine bottles of Four Loko... hello? Is anyone on this ship? Your pizzas are getting cold.'"
+	arrival_message = "'That'll be... sixteen orders of cheesy fries, eight large double topping pizzas, nine bottles of Four Loko... hello? Is anyone on this ship? Your pizzas're getting cold.'"
+	objectives = "Well, shit. That's not a commercial liner. Still, someone in that ship's gotta be hungry. Let's find out who ordered these pizzas, and get outta here..."
 	shuttle_id = MOBILE_SHUTTLE_ID_ERT_SMALL
 	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_pizza
 	home_base = /datum/lazy_template/ert/pizza_station
-	probability = 2
+	probability = 5 //Very low probability, and mostly just for jokes. Still- that's what happens when you broadcast your location, someone might just prank you with Pizza.
 
 /datum/emergency_call/pizza/New()
 	. = ..()

--- a/code/datums/emergency_calls/pmc.dm
+++ b/code/datums/emergency_calls/pmc.dm
@@ -3,7 +3,7 @@
 /datum/emergency_call/pmc
 	name = "Weyland-Yutani PMC (Squad)"
 	mob_max = 6
-	probability = 20
+	probability = 10 //Likely the strongest non-admin ERT in the game. Rare as such.
 	shuttle_id = MOBILE_SHUTTLE_ID_ERT2
 	home_base = /datum/lazy_template/ert/weyland_station
 	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_pmc

--- a/code/datums/emergency_calls/upp.dm
+++ b/code/datums/emergency_calls/upp.dm
@@ -4,7 +4,7 @@
 /datum/emergency_call/upp
 	name = "UPP Naval Infantry (Squad) (RANDOM)"
 	mob_max = 9
-	probability = 20
+	probability = 25 //Significant chance. With a significant chance of being hostile. The wildcards and unlikely allies of the UA.
 	shuttle_id = MOBILE_SHUTTLE_ID_ERT3
 	home_base = /datum/lazy_template/ert/upp_station
 	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_upp
@@ -22,7 +22,7 @@
 /datum/emergency_call/upp/New()
 	. = ..()
 	if(isnull(hostility))
-		hostility = pick(50;FALSE,50;TRUE)
+		hostility = pick(33;FALSE,66;TRUE) // 2/3 chance of being hostile.
 	arrival_message = "[MAIN_SHIP_NAME] t*is i* UP* d^sp^*ch`. STr*&e teaM, #*u are cLe*% for a*pr*%^h. Pr*mE a*l wE*p^ns and pR*epr# t% r@nd$r a(tD."
 	if(hostility)
 		objectives = "Eliminate the UA Forces to ensure the UPP prescence in this sector is continued. Listen to your superior officers and take over the [MAIN_SHIP_NAME] at all costs."

--- a/code/datums/emergency_calls/xenos.dm
+++ b/code/datums/emergency_calls/xenos.dm
@@ -1,5 +1,5 @@
 
-//Xenomorphs, hostile to everyone.
+//Xenomorphs, hostile to everyone except the Prime hive.
 /datum/emergency_call/xenos
 	name = "Xenomorphs (Squad)"
 	mob_max = 7
@@ -9,7 +9,7 @@
 
 /datum/emergency_call/xenos/New()
 	..()
-	arrival_message = "[MAIN_SHIP_NAME], this is USS Vriess respond-- #&...*#&^#.. signal... &#*)- What *&# fuck-- &#**#^#^)-- *h GOD- they're in the vent---... Priority Warning: Signal lost."
+	arrival_message = "[MAIN_SHIP_NAME], this is USCSS Vriess respond-- #&...*#&^#.. signal... &#*)- What *&# fuck-- &#**#^#^)-- *h GOD- they're in the vent---... Priority Warning: Signal lost."
 	objectives = "Across the stars... For the Empress!"
 
 
@@ -37,6 +37,15 @@
 	M.transfer_to(new_xeno, TRUE)
 
 	QDEL_NULL(current_mob)
+
+/datum/emergency_call/xenos/corpsespawner(turf/override_spawn_loc)
+	var/turf/spawn_loc = override_spawn_loc ? override_spawn_loc : get_spawn_point()
+	var/list/obj/effect/landmark/corpse
+	if(!istype(spawn_loc))
+		return //No usable spawn.
+
+	for()
+
 
 
 /datum/emergency_call/xenos/platoon

--- a/code/datums/emergency_calls/xenos.dm
+++ b/code/datums/emergency_calls/xenos.dm
@@ -38,14 +38,6 @@
 
 	QDEL_NULL(current_mob)
 
-/datum/emergency_call/xenos/corpsespawner(turf/override_spawn_loc)
-	var/turf/spawn_loc = override_spawn_loc ? override_spawn_loc : get_spawn_point()
-	var/list/obj/effect/landmark/corpse
-	if(!istype(spawn_loc))
-		return //No usable spawn.
-
-	for()
-
 
 
 /datum/emergency_call/xenos/platoon

--- a/code/datums/emergency_calls/xenos.dm
+++ b/code/datums/emergency_calls/xenos.dm
@@ -3,14 +3,14 @@
 /datum/emergency_call/xenos
 	name = "Xenomorphs (Squad)"
 	mob_max = 7
-	probability = 5
+	probability = 10 //Xeno reinforcements shouldn't be too common, but just common enough to throw the hive a bone.
 	auto_shuttle_launch = TRUE //because xenos can't use the shuttle console.
 	hostility = TRUE
 
 /datum/emergency_call/xenos/New()
 	..()
-	arrival_message = "[MAIN_SHIP_NAME], this is USS Vriess respond-- #&...*#&^#.. signal... oh god, they're in the vent---... Priority Warning: Signal lost."
-	objectives = "For the Empress!"
+	arrival_message = "[MAIN_SHIP_NAME], this is USS Vriess respond-- #&...*#&^#.. signal... &#*)- What *&# fuck-- &#**#^#^)-- *h GOD- they're in the vent---... Priority Warning: Signal lost."
+	objectives = "Across the stars... For the Empress!"
 
 
 /datum/emergency_call/xenos/spawn_items()


### PR DESCRIPTION

# About the pull request

Rebalances the default probabilities for ERTs to feature more likely hostile responses, increase the likelihood of CMB and Wey-Yu security and UPP, and reduces the chance for PMCs. Also enables the Weyland Yutani non-chem-retrieval ERT for use. 

Non-hostiles:
PMC: 20 > 10
CMB: 10 > 20
W-Y (Security): 0 > 25
CBRN: 10 > 15
Pizza Galaxy: 2 > 5 (mostly for fun)

Hostiles:
UPP: 20 > 25 (Hostility true-false: 50/50 > 66/33)
Xenomorphs (Prime): 5 >10
Xenomorphs (Feral): 5 > 15
CLF: 20 > 30

# Explain why it's good for the game

With the addition of FTL Hijack, marines have a set of objectives that give them access to infinite response teams, effectively giving them the much-needed numbers they need to defeat the hive on their ship. However, with this objective and new set of mechanics, the current distress signal hasn't been adjusted to accommodate that massive balance shift. Even outside of that context, the current distress signal heavily skewed to massively beneficial responses, contrary to what the desperation of sending out an SOS as a military vessel in contested space should imply in terms of responses, and the balance gamestate of the Xenomorph faction having won the initial battle. This PR rectifies this inconsistency by increasing the chance for hostile responses, and also increasing the chance for more mundane positive reinforcements.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Rebalances distress signal response probabilities outside of admin intervention, increasing the chance for hostile ERTs and non-PMC ERTs. 
/:cl:
