### PR TITLE
Fix: HTML Encoding leaking through labeller regex

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -32,7 +32,7 @@
 
 ///Helper for only alphanumeric characters plus common punctuation, spaces, underscore, hyphen, plus, vertical bar _ -+|.
 /proc/replace_non_alphanumeric_plus(text)
-	var/regex/alphanumeric = regex(@{"[^a-z0-9 ,.?!|\-+_&]"}, "gi")
+	var/regex/alphanumeric = regex(@{"[^a-z0-9 ,.'?!|\-+_&]"}, "gi")
 	return alphanumeric.Replace(text, "")
 
 /proc/readd_quotes(text)

--- a/code/datums/components/label.dm
+++ b/code/datums/components/label.dm
@@ -87,7 +87,7 @@
 /// Applies a label to the name of the parent in the format of: "parent_name (label)"
 /datum/component/label/proc/apply_label()
 	var/atom/owner = parent
-	label_name = replace_non_alphanumeric_plus(label_name)
+	label_name = replace_non_alphanumeric_plus(html_decode(label_name))
 	if(!label_name)
 		QDEL_NULL(src)
 	owner.name += " ([label_name])"

--- a/code/game/objects/items/tools/misc_tools.dm
+++ b/code/game/objects/items/tools/misc_tools.dm
@@ -92,8 +92,8 @@
 	if(mode)
 		to_chat(user, SPAN_NOTICE("You turn on [src]."))
 		//Now let them choose the text.
-		var/str = copytext(reject_bad_text(tgui_input_text(user, "Label text?", "Set label", "", MAX_NAME_LEN, ui_state=GLOB.not_incapacitated_state)), 1, MAX_NAME_LEN)
-		str = replace_non_alphanumeric_plus(str)
+		var/str = copytext(reject_bad_text(tgui_input_text(user, "Label text?", "Set label", "", MAX_NAME_LEN, ui_state=GLOB.not_incapacitated_state, encode=FALSE)), 1, MAX_NAME_LEN)
+		str = trim_right(replace_non_alphanumeric_plus(str))
 		if(!str || !length(str))
 			to_chat(user, SPAN_NOTICE("Label text cleared. You can now remove labels."))
 			label = null

--- a/code/game/objects/items/tools/misc_tools.dm
+++ b/code/game/objects/items/tools/misc_tools.dm
@@ -92,14 +92,14 @@
 	if(mode)
 		to_chat(user, SPAN_NOTICE("You turn on [src]."))
 		//Now let them choose the text.
-		var/str = copytext(reject_bad_text(tgui_input_text(user, "Label text?", "Set label", "", MAX_NAME_LEN, ui_state=GLOB.not_incapacitated_state, encode=FALSE)), 1, MAX_NAME_LEN)
-		str = trim_right(replace_non_alphanumeric_plus(str))
-		if(!str || !length(str))
+		var/label_text = copytext(reject_bad_text(tgui_input_text(user, "Label text?", "Set label", "", MAX_NAME_LEN, ui_state=GLOB.not_incapacitated_state, encode=FALSE)), 1, MAX_NAME_LEN)
+		label_text = trim_right(replace_non_alphanumeric_plus(label_text))
+		if(!label_text || !length(label_text))
 			to_chat(user, SPAN_NOTICE("Label text cleared. You can now remove labels."))
 			label = null
 			return
-		label = str
-		to_chat(user, SPAN_NOTICE("You set the text to '[str]'."))
+		label = label_text
+		to_chat(user, SPAN_NOTICE("You set the text to '[label_text]'."))
 		return
 
 	to_chat(user, SPAN_NOTICE("You turn off [src]."))


### PR DESCRIPTION

# About the pull request
AKA Fix me being dumb and forgetting this is a thing. Despite watching it happen a bunch with other TGUI things.
Also allow apostrophes.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #12345" to link the PR to the corresponding Issue number #12345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #12345, Fixes #12346, Fixes #12347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Same as the last but this time fix it so It doesn't look weird
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Hand Labeller/Labels No longer get funky HTML encoding leaking through when trying to use things like apostrophes
/:cl:
