### PR TITLE
Adds create_cause_data for acid runner "FOR THE HIVE" ability to fix runtime.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/runner/acider.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/runner/acider.dm
@@ -190,7 +190,7 @@
 			addtimer(CALLBACK(bound_xeno.hive, TYPE_PROC_REF(/datum/hive_status, respawn_on_turf), bound_xeno.client, spawning_turf), 0.5 SECONDS)
 		else
 			addtimer(CALLBACK(bound_xeno.hive, TYPE_PROC_REF(/datum/hive_status, free_respawn), bound_xeno.client), 5 SECONDS)
-	bound_xeno.gib()
+	bound_xeno.gib(create_cause_data("internal acid rupture", src))
 
 /mob/living/carbon/xenomorph/runner/ventcrawl_carry()
 	var/datum/behavior_delegate/runner_acider/behavior_delegates = behavior_delegate

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -2294,7 +2294,7 @@
 #include "code\modules\mob\living\carbon\xenomorph\strains\castes\praetorian\vanguard.dm"
 #include "code\modules\mob\living\carbon\xenomorph\strains\castes\ravager\berserker.dm"
 #include "code\modules\mob\living\carbon\xenomorph\strains\castes\ravager\hedgehog.dm"
-#include "code\modules\mob\living\carbon\xenomorph\strains\castes\runner\acid.dm"
+#include "code\modules\mob\living\carbon\xenomorph\strains\castes\runner\acider.dm"
 #include "code\modules\mob\living\silicon\death.dm"
 #include "code\modules\mob\living\silicon\login.dm"
 #include "code\modules\mob\living\silicon\say.dm"


### PR DESCRIPTION
# About the pull request

Fixes runtime caused by acid runner FOR THE HIVE explosion .
Renames file from acid.dm -> acider.dm for less confusion in future.

# Explain why it's good for the game

Discovered this by accident when creating #9367, during testing my private instance keep crashing, because acider FOR THE HIVE lacked cause_data, i hoped someone else do this easy fix but, looks like it will be best to do it anyway.

# Testing Photographs and Procedure

<img width="1375" height="229" alt="image" src="https://github.com/user-attachments/assets/d4b890b9-df18-411f-92c3-b2f23d29ead5" />

# Changelog
:cl: Venuska1117
fix: "FOR THE HIVE" ability now create correctly chat message explaining cause of death.
/:cl: