### PR TITLE
Add Cooldowns to give and force showing papers

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -18,6 +18,7 @@ Gunshots/explosions/opening doors/less rare audio (done)
 	var/hal_screwyhud = 0 //1 - critical, 2 - dead, 3 - oxygen indicator, 4 - toxin indicator
 	var/handling_hal = FALSE
 	var/hal_crit = FALSE
+	COOLDOWN_DECLARE(give_item_cooldown)
 
 /mob/living/carbon/proc/handle_hallucinations()
 	if(handling_hal)

--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -34,6 +34,9 @@
 	if(r_hand && l_hand)
 		to_chat(giver, SPAN_WARNING("[src]'s hands are full."))
 		return
+	if(!COOLDOWN_FINISHED(giver, give_item_cooldown))
+		to_chat(giver, SPAN_WARNING("You can not do that again for a while."))
+		return
 	giver.mob_flags |= GIVING
 	if(tgui_alert(src, "[giver] wants to give you \a [I]?", "You are being offered an item", list("Yes", "No"), 10 SECONDS) == "Yes")
 		giver.mob_flags &= ~GIVING
@@ -61,4 +64,5 @@
 				SPAN_NOTICE("You hand [I] to [src]."), null, 4)
 	else
 		giver.mob_flags &= ~GIVING
+		COOLDOWN_START(giver, give_item_cooldown, 4 SECONDS)
 		return

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -59,6 +59,8 @@
 	var/document_title
 	var/datum/prefab_document/doc_datum_type
 
+	COOLDOWN_DECLARE(show_paper_cooldown)
+
 //lipstick wiping is in code/game/obj/items/weapons/cosmetics.dm!
 
 /obj/item/paper/Initialize(mapload, photo_list)
@@ -146,19 +148,28 @@
 	else
 		read_paper(user, scramble=TRUE)
 
-/obj/item/paper/attack(mob/living/carbon/human/M, mob/living/carbon/user)
+/obj/item/paper/attack(mob/living/carbon/human/human_target, mob/living/carbon/user)
 
 	if(user.zone_selected == "eyes")
-		if(!ishumansynth_strict(M))
+		if(!ishumansynth_strict(human_target))
+			return
+		if(!COOLDOWN_FINISHED(src, show_paper_cooldown))
+			to_chat(user, SPAN_WARNING("You can not do that again for a while."))
+			return
+		if(human_target.a_intent != INTENT_HELP)
+			user.visible_message(SPAN_WARNING("[human_target] stops [user] from showing them [src]"),
+			SPAN_WARNING("[human_target] stops you from showing them the [src]."))
+			COOLDOWN_START(src, show_paper_cooldown, 3 SECONDS)
 			return
 
-		user.visible_message(SPAN_NOTICE("You show the paper to [M]."),
-		SPAN_NOTICE("[user] holds up a paper and shows it to [M]."))
-		examine(M)
+		user.visible_message(SPAN_NOTICE("[user] holds up a paper and shows it to [human_target]."),
+		SPAN_NOTICE("You show the paper to [human_target]."))
+		COOLDOWN_START(src, show_paper_cooldown, 3 SECONDS)
+		examine(human_target)
 
 	else if(user.zone_selected == "mouth") // lipstick wiping
-		if(ishuman(M))
-			var/mob/living/carbon/human/H = M
+		if(ishuman(human_target))
+			var/mob/living/carbon/human/H = human_target
 			if(H == user)
 				to_chat(user, SPAN_NOTICE("You wipe off the face paint with [src]."))
 				H.lip_style = null


### PR DESCRIPTION

# About the pull request
Title.
Shove some cooldowns for showing a paper (3 Seconds) And giving items (4 Seconds if it's rejected)

Also the person being shown the paper needs to be on help intent to get shown it.

Also also switch around the message for that so it's in the right order and not showing the wrong message
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #12345" to link the PR to the corresponding Issue number #12345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #12345, Fixes #12346, Fixes #12347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Stops people spamming this stuff and forcing pop-ups upon people.
Give already has a timed UI so It's not that bad, but if you say no they can just keep spamming it immediately, Ideally you just run out the timer to stop them spamming you, but that's not all that intuitive. 
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Cooldowns to give and force showing papers. Force showing papers also need the receiving person to be on help intent as well.
/:cl:
