### PR TITLE
Adds Lesser Drone swarm during hijack

### DIFF
--- a/code/modules/cm_aliens/structures/special/pylon_core.dm
+++ b/code/modules/cm_aliens/structures/special/pylon_core.dm
@@ -56,9 +56,19 @@
 	. = ..()
 
 /obj/effect/alien/resin/special/pylon/process(delta_time)
-	if(lesser_drone_spawns < lesser_drone_spawn_limit)
-		// One every 10 seconds while on ovi, one every 120-ish seconds while off ovi
-		lesser_drone_spawns = min(lesser_drone_spawns + ((linked_hive.living_xeno_queen?.ovipositor ? 0.1 : 0.008) * delta_time), lesser_drone_spawn_limit)
+	var/charge_limit = lesser_drone_spawn_limit
+	if(istype(src, /obj/effect/alien/resin/special/pylon/core))
+		var/obj/effect/alien/resin/special/pylon/core/core = src
+		if(core.hijack_lesser_drone_regen)
+			charge_limit = 20
+
+	if(lesser_drone_spawns < charge_limit)
+		var/regen_rate = linked_hive.living_xeno_queen?.ovipositor ? 0.1 : 0.008
+		if(istype(src, /obj/effect/alien/resin/special/pylon/core))
+			var/obj/effect/alien/resin/special/pylon/core/core = src
+			if(core.hijack_lesser_drone_regen)
+				regen_rate = 0.2
+		lesser_drone_spawns = min(lesser_drone_spawns + (regen_rate * delta_time), charge_limit)
 
 /obj/effect/alien/resin/special/pylon/attack_alien(mob/living/carbon/xenomorph/M)
 	if(isxeno_builder(M) && M.a_intent == INTENT_HELP && M.hivenumber == linked_hive.hivenumber)
@@ -77,7 +87,13 @@
 	for(var/mob/living/carbon/xenomorph/lesser_drone/lesser in linked_hive.totalXenos)
 		lesser_count++
 
-	. += "Currently holding [SPAN_NOTICE("[floor(lesser_drone_spawns)]")]/[SPAN_NOTICE("[lesser_drone_spawn_limit]")] lesser drones."
+	var/max_lesser_drone_spawns = lesser_drone_spawn_limit
+	if(istype(src, /obj/effect/alien/resin/special/pylon/core))
+		var/obj/effect/alien/resin/special/pylon/core/core = src
+		if(core.hijack_lesser_drone_regen)
+			max_lesser_drone_spawns = 20
+
+	. += "Currently holding [SPAN_NOTICE("[floor(lesser_drone_spawns)]")]/[SPAN_NOTICE("[max_lesser_drone_spawns]")] lesser drones."
 	. += "There are currently [SPAN_NOTICE("[lesser_count]")] lesser drones in the hive. The hive can support a total of [SPAN_NOTICE("[linked_hive.lesser_drone_limit]")] lesser drones at present."
 
 /obj/effect/alien/resin/special/pylon/attack_ghost(mob/dead/observer/user)
@@ -235,6 +251,7 @@
 	var/spawn_cooldown = 30 SECONDS
 	var/surge_cooldown = 90 SECONDS
 	var/surge_incremental_reduction = 3 SECONDS
+	var/hijack_lesser_drone_regen = FALSE
 
 	plane = FLOOR_PLANE
 
@@ -245,12 +262,21 @@
 /obj/effect/alien/resin/special/pylon/core/Initialize(mapload, datum/hive_status/hive_ref)
 	. = ..()
 
+	RegisterSignal(SSdcs, COMSIG_GLOB_HIJACK_INBOUND, PROC_REF(on_hijack_inbound))
+	if(SShijack.hijack_status >= HIJACK_OBJECTIVES_SHIP_INBOUND)
+		hijack_lesser_drone_regen = TRUE
+
 	// Pick the closest xeno resource activator
 
 	update_minimap_icon()
 
 	if(hive_ref)
 		hive_ref.set_hive_location(src, linked_hive.hivenumber)
+
+/obj/effect/alien/resin/special/pylon/core/proc/on_hijack_inbound()
+	SIGNAL_HANDLER
+
+	hijack_lesser_drone_regen = TRUE
 
 /obj/effect/alien/resin/special/pylon/core/proc/update_minimap_icon()
 	SSminimaps.remove_marker(src)
@@ -410,6 +436,8 @@
 		. = ..()
 
 /obj/effect/alien/resin/special/pylon/core/Destroy()
+	UnregisterSignal(SSdcs, COMSIG_GLOB_HIJACK_INBOUND)
+
 	if(linked_hive)
 		visible_message(SPAN_XENOHIGHDANGER("The resin roof withers away as \the [src] dies!"), max_distance = WEED_RANGE_CORE)
 		linked_hive.hive_location = null

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -1067,6 +1067,10 @@
 	msg_admin_niche("[key_name(hugger)] has joined as a facehugger at ([A.x],[A.y],[A.z]).")
 
 /datum/hive_status/proc/update_lesser_drone_limit()
+	if(SShijack.hijack_status >= HIJACK_OBJECTIVES_SHIP_INBOUND)
+		lesser_drone_limit = INFINITY
+		return
+
 	var/countable_xeno_iterator = 0
 	for(var/mob/living/carbon/xenomorph/cycled_xeno as anything in totalXenos)
 		if(cycled_xeno.counts_for_slots)
@@ -1097,9 +1101,10 @@
 		to_chat(user, SPAN_WARNING("You ghosted too recently. You cannot become a lesser drone until [XENO_JOIN_DEAD_TIME / 600] minutes have passed ([time_left] seconds remaining)."))
 		return FALSE
 
-	if(world.time - user.timeofdeath < JOIN_AS_LESSER_DRONE_DELAY)
-		var/time_left = floor((user.timeofdeath + JOIN_AS_LESSER_DRONE_DELAY - world.time) / 10)
-		to_chat(user, SPAN_WARNING("You ghosted too recently. You cannot become a lesser drone until [JOIN_AS_LESSER_DRONE_DELAY / 10] seconds have passed ([time_left] seconds remaining)."))
+	var/lesser_drone_join_delay = SShijack.hijack_status >= HIJACK_OBJECTIVES_SHIP_INBOUND ? 25 SECONDS : JOIN_AS_LESSER_DRONE_DELAY
+	if(world.time - user.timeofdeath < lesser_drone_join_delay)
+		var/time_left = floor((user.timeofdeath + lesser_drone_join_delay - world.time) / 10)
+		to_chat(user, SPAN_WARNING("You ghosted too recently. You cannot become a lesser drone until [lesser_drone_join_delay / 10] seconds have passed ([time_left] seconds remaining)."))
 		return FALSE
 
 	if(length(totalXenos) <= 0)
@@ -1760,4 +1765,3 @@
 	name = "Attack"
 	desc = "Attack the enemy here!"
 	icon_state = "attack"
-

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -396,6 +396,7 @@
 		hivenumber = xeno.hivenumber
 	xeno_message(SPAN_XENOANNOUNCE("The Queen has commanded the metal bird to depart for the metal hive in the sky! Rejoice!"), 3, hivenumber)
 	xeno_message(SPAN_XENOANNOUNCE("The hive swells with power! You will now steadily gain pooled larva over time."), 2, hivenumber)
+	xeno_message(SPAN_XENOANNOUNCE("The hive is ready to take its new home! You now have infinite Lesser Drones."), 2, hivenumber)
 	var/datum/hive_status/hive = GLOB.hive_datum[hivenumber]
 	addtimer(CALLBACK(hive, TYPE_PROC_REF(/datum/hive_status, abandon_on_hijack)), DROPSHIP_WARMUP_TIME, TIMER_UNIQUE)
 	hive.bless_on_hijack()

--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -300,6 +300,7 @@ GLOBAL_LIST_EMPTY(shuttle_controls)
 					to_chat(Q, SPAN_DANGER("A loud alarm erupts from [src]! The fleshy hosts must know that you can access it!"))
 					xeno_message(SPAN_XENOANNOUNCE("The Queen has commanded the metal bird to depart for the metal hive in the sky! Rejoice!"),3,Q.hivenumber)
 					xeno_message(SPAN_XENOANNOUNCE("The hive swells with power! You will now steadily gain burrowed larva over time."),2,Q.hivenumber)
+					xeno_message(SPAN_XENOANNOUNCE("The hive is ready to take its new home! You now have infinite Lesser Drones."),2,Q.hivenumber)
 
 					// Notify the yautja too so they stop the hunt
 					message_all_yautja("The serpent Queen has commanded the landing shuttle to depart.")


### PR DESCRIPTION

# About the pull request

After hijack begins, the max Lesser Drone spawns the core can give at once is set to 20, gaining one charge every 5 seconds, maxing out in 100 seconds. The number of alive Lesser Drones the hive can support becomes infinite. The respawn timer for Lesser Drones is reduced to 25 seconds.

# Explain why it's good for the game

I can rant on & on here but I don't want to waste anyone's time - happy to discuss further in Discord. Firstly, this was highly requested. 

While this might accelerate hijack, it is more intended to provide some much-needed soul. Hijack should feel like a last stand for marines (as a marine main), but in recent rounds it has felt more like a scramble for xenos to desperately try to disable fuel pumps--it feels like xenos are on the backfoot. I don't enjoy it either as marine or as xeno. 

I feel this will help change the "vibe" of hijack. It is at least worth a test. Please? 


# Testing Photographs and Procedure
The code has been pretty thoroughly tested in a debug server; I individually tested each part before adding the next, and everything ran fine together. I also tested scenarios to make sure I didn't accidentally break pre-hijack Lesser code. 


# Changelog

:cl: Deepwaterguard
balance: Hijack now allows for a massive horde of Lesser Drones. 
/:cl:

