### PR TITLE
Fix: Intel Objectives TGUI Bluescreen when known objective is deleted #2 Again.

### DIFF
--- a/code/modules/objectives/documents.dm
+++ b/code/modules/objectives/documents.dm
@@ -22,7 +22,6 @@
 	document?.objective = null
 	document = null
 	initial_area = null
-	state = OBJECTIVE_DELETED
 	return ..()
 
 /datum/cm_objective/document/get_related_label()

--- a/code/modules/objectives/objective.dm
+++ b/code/modules/objectives/objective.dm
@@ -23,6 +23,7 @@
 		LAZYREMOVE(E.required_objectives, src)
 	required_objectives = null
 	enables_objectives = null
+	state = OBJECTIVE_DELETED
 	return ..()
 
 // initial setup after the map has loaded


### PR DESCRIPTION

# About the pull request
Tacking on to the end of #11457 Cause apparently I was oblivious that I put the state change on destroy in a specific type of intel rather than the parent it should be in for... some reason???
Resolves: #12103
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #12345" to link the PR to the corresponding Issue number #12345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #12345, Fixes #12346, Fixes #12347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Runtimes bad mkay
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: View Intel Objectives bluescreening. Again
/:cl:
