### PR TITLE
Issue Fix #9219 - Changes Text and Closes Remaining Problem

### DIFF
--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -435,13 +435,13 @@ GLOBAL_LIST_EMPTY(roles_with_gear)
 	display_name = "USCM cap"
 	path = /obj/item/clothing/head/cmcap
 
+/datum/gear/headwear/uscm/headband_green
+	display_name = "USCM headband, area of operations specific"
+	path = /obj/item/clothing/head/headband
+
 /datum/gear/headwear/uscm/headband_brown
 	display_name = "USCM headband, brown"
 	path = /obj/item/clothing/head/headband/brown
-
-/datum/gear/headwear/uscm/headband_green
-	display_name = "USCM headband, green"
-	path = /obj/item/clothing/head/headband
 
 /datum/gear/headwear/uscm/headband_grey
 	display_name = "USCM headband, grey"


### PR DESCRIPTION

# About the pull request

The red headband has been made static by a PR before mine, and give that the "green headband" is just the map-specific version of the item, I just changed the text from "USCM headband, green" to "USCM headband, area of operations specific", this way the issue is solved.

Fixes #9219.

# Explain why it's good for the game

Good to take out the issue pile isn't it.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
spellcheck: Changes 'USCM headband, green' to 'USCM headband, area of operations speciifc' on the preference loadout menu.
/:cl:
