### PR TITLE
Provides optional sounds for ghost ERT alerts

### DIFF
--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -71,6 +71,9 @@
 	/// the [/datum/lazy_template] we should attempt to spawn in for the return journey
 	var/home_base = /datum/lazy_template/ert/freelancer_station
 
+	/// What sound plays to ghosts when this rolls? Silent if null
+	var/alert_sound
+
 /datum/game_mode/proc/initialize_emergency_calls()
 	if(length(all_calls)) //It's already been set up.
 		return
@@ -138,6 +141,9 @@
 			to_chat(M, SPAN_WARNING(FONT_SIZE_LARGE("You cannot join if you have Ghosted recently. Click the link in chat, or use the verb in the ghost tab to join.</span>\n")))
 
 			give_action(M, /datum/action/join_ert, src)
+
+			if(!isnull(alert_sound))
+				playsound_client(M.client, alert_sound, vol = 50)
 
 /datum/game_mode/proc/activate_distress()
 	ert_dispatched = TRUE

--- a/code/datums/emergency_calls/pred_hunt/hunting_calls.dm
+++ b/code/datums/emergency_calls/pred_hunt/hunting_calls.dm
@@ -8,6 +8,7 @@
 	shuttle_id = ""
 	ert_message = "Prey is being set loose in the Yautja Hunting Grounds"
 	ignore_ftl_or_crash = TRUE
+	alert_sound = 'sound/items/pred_bracer.ogg'
 	/// Multiplier on the base RESERVE_HUNT_COOLDOWN when a given ERT is selected; 1 is no change.
 	var/timer_mult = 1
 	var/hunt_name
@@ -311,7 +312,6 @@
 	name_of_spawn = /obj/effect/landmark/ert_spawns/distress/hunt_spawner/pred
 	shuttle_id = ""
 	ignore_ftl_or_crash = TRUE
-	alert_sound = 'sound/items/pred_bracer.ogg'
 
 /datum/emergency_call/young_bloods/New()
 	. = ..()

--- a/code/datums/emergency_calls/pred_hunt/hunting_calls.dm
+++ b/code/datums/emergency_calls/pred_hunt/hunting_calls.dm
@@ -311,6 +311,7 @@
 	name_of_spawn = /obj/effect/landmark/ert_spawns/distress/hunt_spawner/pred
 	shuttle_id = ""
 	ignore_ftl_or_crash = TRUE
+	alert_sound = 'sound/items/pred_bracer.ogg'
 
 /datum/emergency_call/young_bloods/New()
 	. = ..()


### PR DESCRIPTION

# About the pull request

Adds the alert_sound variable to emergency calls. Adding a sound here will allow response team alerts to ghosts to have a special sound, if desired. This allows for certain response teams to have unique pings to ghosts (if so desired) or allows an ert alert sound on otherwise silent pings.

This PR keeps the vast majority of response teams unchanged (since many are already accompanied by sounds ghosts can already hear). The only datum changed by this is the predator alerts, which now has the bracer alert sound. Forsaken are also silent, but due to their frequency during hijack they were left silent.

# Explain why it's good for the game

Extra options for response teams allow for certain pings to feel unique, and allows coverage to normally silent pings. Not knowing alerts are happening because there is no accompanying sound can be frustrating if you're looking for it. Many players are alt tabbed when dead and only tab back in if certain sounds alert the. This should assist that issue a bit.

# Testing Photographs and Procedure

Changed the youngblood ERT temporarily to clownshoes
Spawned in as a  yautja, called youngbloods with no observers. Heard no sound.
Had a second client join as a ghost and called youngbloods. Heard clownshoes.
Called many ERT, heart no additional sounds.

# Changelog

:cl:
add: Added optional customizable sound alerts for response teams
add: Predator response team calls now produce a bracer noise alert for ghosts.
/:cl:
