### PR TITLE
make the other 2 research machines not meltable

### DIFF
--- a/code/modules/reagents/chemistry_machinery/autodispenser.dm
+++ b/code/modules/reagents/chemistry_machinery/autodispenser.dm
@@ -20,7 +20,7 @@
 	health = STRUCTURE_HEALTH_REINFORCED
 	layer = BELOW_OBJ_LAYER
 	density = TRUE
-	unacidable = 1
+	unacidable = TRUE
 	///Contains vials for our program
 	var/obj/item/storage/fancy/vials/input_container
 	///Our output beaker

--- a/code/modules/reagents/chemistry_machinery/autodispenser.dm
+++ b/code/modules/reagents/chemistry_machinery/autodispenser.dm
@@ -20,6 +20,7 @@
 	health = STRUCTURE_HEALTH_REINFORCED
 	layer = BELOW_OBJ_LAYER
 	density = TRUE
+	unacidable = 1
 	///Contains vials for our program
 	var/obj/item/storage/fancy/vials/input_container
 	///Our output beaker

--- a/code/modules/reagents/chemistry_machinery/xenomorph_analyzer.dm
+++ b/code/modules/reagents/chemistry_machinery/xenomorph_analyzer.dm
@@ -19,6 +19,7 @@
 	var/busy = FALSE
 	var/queue_proccessing = FALSE
 	var/caste_of_organ = null
+	unacidable = 1
 
 /obj/structure/machinery/xenoanalyzer/Initialize(mapload, ...)
 	. = ..()

--- a/code/modules/reagents/chemistry_machinery/xenomorph_analyzer.dm
+++ b/code/modules/reagents/chemistry_machinery/xenomorph_analyzer.dm
@@ -19,7 +19,7 @@
 	var/busy = FALSE
 	var/queue_proccessing = FALSE
 	var/caste_of_organ = null
-	unacidable = 1
+	unacidable = TRUE
 
 /obj/structure/machinery/xenoanalyzer/Initialize(mapload, ...)
 	. = ..()

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -67644,10 +67644,7 @@
 /obj/structure/machinery/light{
 	dir = 8
 	},
-/obj/structure/machinery/autodispenser{
-	dir = 4;
-	unacidable = 1
-	},
+/obj/structure/machinery/autodispenser,
 /turf/open/floor/almayer/mono,
 /area/almayer/medical/medical_science)
 "ncG" = (
@@ -93331,9 +93328,7 @@
 	pixel_y = 28;
 	pixel_x = -1
 	},
-/obj/structure/machinery/xenoanalyzer{
-	unacidable = 1
-	},
+/obj/structure/machinery/xenoanalyzer,
 /turf/open/floor/almayer/mono,
 /area/almayer/medical/medical_science)
 "xqy" = (

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -67645,7 +67645,8 @@
 	dir = 8
 	},
 /obj/structure/machinery/autodispenser{
-	dir = 4
+	dir = 4;
+	unacidable = 1
 	},
 /turf/open/floor/almayer/mono,
 /area/almayer/medical/medical_science)
@@ -93330,7 +93331,9 @@
 	pixel_y = 28;
 	pixel_x = -1
 	},
-/obj/structure/machinery/xenoanalyzer,
+/obj/structure/machinery/xenoanalyzer{
+	unacidable = 1
+	},
 /turf/open/floor/almayer/mono,
 /area/almayer/medical/medical_science)
 "xqy" = (

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -67644,7 +67644,9 @@
 /obj/structure/machinery/light{
 	dir = 8
 	},
-/obj/structure/machinery/autodispenser,
+/obj/structure/machinery/autodispenser{
+	dir = 4
+	},
 /turf/open/floor/almayer/mono,
 /area/almayer/medical/medical_science)
 "ncG" = (


### PR DESCRIPTION

# About the pull request

title

# Explain why it's good for the game
not replaceable and it basically locks you out from most of research, simulator already isnt acidable

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: turing dispenser and xeno analyzer thingy are no longer meltable
/:cl:
