### PR TITLE
Fix stylesheet errors for 1681

### DIFF
--- a/.github/alternate_byond_versions.txt
+++ b/.github/alternate_byond_versions.txt
@@ -5,4 +5,4 @@
 # Format is version: map
 # Example:
 # 500.1337: runtime
-516.1673: runtime
+516.1681: runtime

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -53,7 +53,7 @@ em {font-style: normal; font-weight: bold;}
 .jtacradio {color: #702963;}
 .intelradio {color: #027D02;}
 .wyradio {color: #FE9B24;}
-.hdcradio {color: #FEE6C24;}
+.hdcradio {color: #FE6C24;}
 .pmcradio {color: #A13852;}
 
 .clfradio {color: #6f679c}
@@ -155,7 +155,7 @@ h1.alert, h2.alert {color: #000000;}
 .german {color: #858F1E; font-family: 'Times New Roman', Times, serif}
 .spanish {color: #CF982B;}
 .japanese {color: #0047A0}
-.commando {color: #FE9B24; font-style: bold;}
+.commando {color: #FE9B24; font-weight: bold;}
 .say_quote {font-family: Georgia, Verdana, sans-serif;}
 
 .retro_translator {font-weight: bold;}

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -1480,7 +1480,7 @@ em {
 
 .commando {
   color: hsl(33, 99%, 57%);
-  font-style: bold;
+  font-weight: bold;
 }
 
 .say_quote {

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -1501,7 +1501,7 @@ h2.alert {
 
 .commando {
   color: hsl(33, 99%, 57%);
-  font-style: bold;
+  font-weight: bold;
 }
 
 .rough {


### PR DESCRIPTION

# About the pull request

This PR fixes a couple errors in stylesheet preventing compilation in 516.1681. It also bumps alternate test unit testing version to 516.1681.

# Explain why it's good for the game

Compiling successfully is good.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="1196" height="933" alt="image" src="https://github.com/user-attachments/assets/de39c348-944a-4c29-b0db-6083f6204f02" />

<img width="610" height="110" alt="image" src="https://github.com/user-attachments/assets/ca9e9d3c-384b-47b3-8323-e4ba6b6ea965" />

<img width="602" height="62" alt="image" src="https://github.com/user-attachments/assets/0188b43a-43f0-4549-b2d1-92cf142b7038" />

<img width="550" height="102" alt="image" src="https://github.com/user-attachments/assets/fe05924b-fe29-4354-bcd1-0dae00c3e411" />


</details>


# Changelog
:cl: Drathek
fix: Fixes a couple stylesheet errors affecting tactical sign language (both chats) and hyperdyne radios (non-fancy chat)
/:cl:
