### PR TITLE
Bump all actions for node24

### DIFF
--- a/.github/actions/restore_or_install_byond/action.yml
+++ b/.github/actions/restore_or_install_byond/action.yml
@@ -35,7 +35,7 @@ runs:
     # is cancelled, we already have a cache to restore from.
     - name: Restore BYOND cache
       id: restore_byond_cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ~/BYOND
         key: ${{ runner.os }}-byond-${{ env.BYOND_MAJOR }}-${{ env.BYOND_MINOR }}
@@ -45,7 +45,7 @@ runs:
       run: bash tools/ci/install_byond.sh
     - name: Save BYOND cache
       if: ${{ !steps.restore_byond_cache.outputs.cache-hit }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: ~/BYOND
         key: ${{ steps.restore_byond_cache.outputs.cache-primary-key }}

--- a/.github/actions/setup_node/action.yml
+++ b/.github/actions/setup_node/action.yml
@@ -19,7 +19,7 @@ runs:
         source dependencies.sh
         echo "NODE_VERSION_REQUIRED=$NODE_VERSION_LTS" >> $GITHUB_ENV
     - name: Install Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ env.NODE_VERSION_REQUIRED }}
         cache: ${{ fromJSON(inputs.restore-yarn-cache) && 'yarn' || '' }}

--- a/.github/workflows/auto_changelog.yml
+++ b/.github/workflows/auto_changelog.yml
@@ -15,18 +15,18 @@ jobs:
     steps:
     - name: Generate App Token
       id: app-token-generation
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@v3.1.1
       with:
-        app-id: ${{ secrets.APP_ID }}
+        client-id: ${{ secrets.APP_ID }}
         private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         token: ${{ steps.app-token-generation.outputs.token }}
 
     - name: Run auto changelog
-      uses: actions/github-script@v6
+      uses: actions/github-script@v9
       with:
         script: |
           const { processAutoChangelog } = await import('${{ github.workspace }}/tools/pull_request_hooks/autoChangelog.js')

--- a/.github/workflows/autowiki.yml
+++ b/.github/workflows/autowiki.yml
@@ -20,7 +20,7 @@ jobs:
         echo "SECRETS_ENABLED=$SECRET_EXISTS" >> $GITHUB_OUTPUT
     - name: Checkout
       if: steps.secrets_set.outputs.SECRETS_ENABLED
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: Install BYOND
       if: steps.secrets_set.outputs.SECRETS_ENABLED
       uses: ./.github/actions/restore_or_install_byond

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -14,11 +14,11 @@ jobs:
       group: run_linters-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Restore SpacemanDMM cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/SpacemanDMM
           key: ${{ runner.os }}-spacemandmm-${{ hashFiles('dependencies.sh') }}
@@ -27,14 +27,14 @@ jobs:
       - name: Setup Bun
         uses: ./.github/actions/setup_bun
       - name: Restore Bootstrap cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: tools/bootstrap/.cache
           key: ${{ runner.os }}-bootstrap-${{ hashFiles('tools/requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-bootstrap-
       - name: Restore Rust cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo
           key: ${{ runner.os }}-rust-${{ hashFiles('dependencies.sh')}}
@@ -69,11 +69,11 @@ jobs:
     name: Lint with OpenDream
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 9
-      - uses: actions/checkout@v4
-      - uses: robinraju/release-downloader@v1.9
+      - uses: actions/checkout@v6
+      - uses: robinraju/release-downloader@616444d935c04e4269e694a274bd94383479ecde
         with:
           repository: "OpenDreamProject/OpenDream"
           tag: "latest"
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup Bun
         uses: ./.github/actions/setup_bun
       - name: Restore BYOND from Cache
@@ -113,7 +113,7 @@ jobs:
       group: find_all_maps-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Find Maps
         id: map_finder
         run: |
@@ -181,7 +181,7 @@ jobs:
       group: test_windows-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup Bun
         uses: ./.github/actions/setup_bun
       - name: Configure BYOND version from inputs
@@ -198,7 +198,7 @@ jobs:
           echo "BYOND_MAJOR=$BYOND_MAJOR" >> $GITHUB_ENV
           echo "BYOND_MINOR=$BYOND_MINOR" >> $GITHUB_ENV
       - name: Restore BYOND cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: C:\\byond
           key: ${{ runner.os }}-byond-${{ env.BYOND_MAJOR }}-${{ env.BYOND_MINOR }}

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           dotnet-version: 9
       - uses: actions/checkout@v6
-      - uses: robinraju/release-downloader@616444d935c04e4269e694a274bd94383479ecde
+      - uses: robinraju/release-downloader@v1.13
         with:
           repository: "OpenDreamProject/OpenDream"
           tag: "latest"

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -14,6 +14,11 @@ jobs:
       group: run_linters-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
+      - name: DreamAnnotate
+        uses: alexkar598/DreamAnnotate@v3
+        with:
+          dreamchecker: true
+          dreammaker: true
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -57,13 +62,6 @@ jobs:
           tools/build/build.sh --ci lint tgui-test
           tools/bootstrap/python -m dmi.test
           tools/bootstrap/python -m mapmerge2.dmm_test
-          ~/dreamchecker > ${GITHUB_WORKSPACE}/output-annotations.txt 2>&1
-      - name: Annotate Lints
-        uses: yogstation13/DreamAnnotate@v2
-        if: success() || failure()
-        with:
-          outputFile: output-annotations.txt
-
 
   odlint:
     name: Lint with OpenDream

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -62,6 +62,7 @@ jobs:
           tools/build/build.sh --ci lint tgui-test
           tools/bootstrap/python -m dmi.test
           tools/bootstrap/python -m mapmerge2.dmm_test
+          ~/dreamchecker
 
   odlint:
     name: Lint with OpenDream

--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -21,9 +21,9 @@ jobs:
 
       - name: Generate App Token
         id: app-token-generation
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3.1.1
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Work around setup-python cache issue
@@ -45,7 +45,7 @@ jobs:
           sudo apt-get install dos2unix
       - name: "Checkout"
         if: steps.value_holder.outputs.ACTIONS_ENABLED
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 25
           persist-credentials: false
@@ -64,6 +64,6 @@ jobs:
           git commit -m "Automatic changelog compile [ci skip]" -a || true
       - name: "Push"
         if: steps.value_holder.outputs.ACTIONS_ENABLED
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@v1.1.0
         with:
           github_token: ${{ steps.app-token-generation.outputs.token }}

--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -9,7 +9,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: eps1lon/actions-label-merge-conflict@v3.0.3
+      - uses: eps1lon/actions-label-merge-conflict@v3.1.0
         with:
           dirtyLabel: 'Merge Conflict'
           commentOnDirty: "This pull request has conflicts, please resolve those before we can evaluate the pull request."

--- a/.github/workflows/generate_web_assets.yml
+++ b/.github/workflows/generate_web_assets.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: gen-assets
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/SpacemanDMM
           key: ${{ runner.os }}-spacemandmm-${{ hashFiles('dependencies.sh') }}
@@ -26,10 +26,9 @@ jobs:
           echo docs.cm-ss13.com > dmdoc/CNAME
           mv tgui/public/ dmdoc/assets
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
-          BRANCH: gh-pages
-          CLEAN: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SINGLE_COMMIT: true
-          FOLDER: dmdoc
+          branch: gh-pages
+          clean: true
+          single-commit: true
+          folder: dmdoc

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -20,9 +20,9 @@ jobs:
 
       - name: Generate App Token
         id: app-token-generation
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3.1.1
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Get The Script
@@ -58,7 +58,7 @@ jobs:
 
       - name: size-label
         if: steps.value_holder.outputs.ACTIONS_ENABLED
-        uses: "pascalgn/size-label-action@v0.5.5"
+        uses: "pascalgn/size-label-action@v0.5.7"
         env:
           GITHUB_TOKEN: ${{ steps.app-token-generation.outputs.token }}
           IGNORED: "**/bun.lock"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: ./.github/actions/setup_bun
@@ -42,7 +42,7 @@ jobs:
           tar --exclude='./icons' --exclude='./sound' --exclude='./.git' --exclude='node_modules' --exclude='./code' --exclude='./tools' -cvf - . | zstd -19 -T0 -o colonialmarines-build.tar.zst
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: build-${{ github.sha }}
           name: Build ${{ github.sha }}

--- a/.github/workflows/remove_guide_comments.yml
+++ b/.github/workflows/remove_guide_comments.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: Remove guide comments
-      uses: actions/github-script@v6
+      uses: actions/github-script@v9
       with:
         script: |
           const { removeGuideComments } = await import('${{ github.workspace }}/tools/pull_request_hooks/removeGuideComments.js')

--- a/.github/workflows/rerun_flaky_tests.yml
+++ b/.github/workflows/rerun_flaky_tests.yml
@@ -10,9 +10,9 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt == 1 }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: Rerun flaky tests
-      uses: actions/github-script@v6
+      uses: actions/github-script@v9
       with:
         script: |
           const { rerunFlakyTests } = await import('${{ github.workspace }}/tools/pull_request_hooks/rerunFlakyTests.js')
@@ -22,9 +22,9 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.run_attempt == 2 }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: Report flaky tests
-      uses: actions/github-script@v6
+      uses: actions/github-script@v9
       with:
         script: |
           const { reportFlakyTests } = await import('${{ github.workspace }}/tools/pull_request_hooks/rerunFlakyTests.js')

--- a/.github/workflows/run_approval.yml
+++ b/.github/workflows/run_approval.yml
@@ -9,9 +9,9 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token-generation
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3.1.1
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Automatic Approve

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Restore BYOND from Cache
         uses: ./.github/actions/restore_or_install_byond
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,12 +14,12 @@ jobs:
 
     - name: Generate App Token
       id: app-token-generation
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@v3.1.1
       with:
-        app-id: ${{ secrets.APP_ID }}
+        client-id: ${{ secrets.APP_ID }}
         private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-    - uses: actions/stale@v4
+    - uses: actions/stale@v10.2.0
       with:
         repo-token: ${{ steps.app-token-generation.outputs.token }}
         stale-pr-message: "This PR has been inactive for long enough to be automatically marked as stale. This means it is at risk of being auto closed in ~ 7 days, please address any outstanding review items and ensure your PR is finished, if these are all true and you are auto-staled anyway, you need to actively ask maintainers if your PR will be merged. Once you have done any of the previous actions then you should request a maintainer remove the stale label on your PR, to reset the stale timer. If you feel no maintainer will respond in that time, you may wish to close this PR youself, while you seek maintainer comment, as you will then be able to reopen the PR yourself"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,7 @@ jobs:
         client-id: ${{ secrets.APP_ID }}
         private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-    - uses: actions/stale@v10.2.0
+    - uses: actions/stale@v10
       with:
         repo-token: ${{ steps.app-token-generation.outputs.token }}
         stale-pr-message: "This PR has been inactive for long enough to be automatically marked as stale. This means it is at risk of being auto closed in ~ 7 days, please address any outstanding review items and ensure your PR is finished, if these are all true and you are auto-staled anyway, you need to actively ask maintainers if your PR will be merged. Once you have done any of the previous actions then you should request a maintainer remove the stale label on your PR, to reset the stale timer. If you feel no maintainer will respond in that time, you may wish to close this PR youself, while you seek maintainer comment, as you will then be able to reopen the PR yourself"

--- a/.github/workflows/update_tgs_dmapi.yml
+++ b/.github/workflows/update_tgs_dmapi.yml
@@ -13,13 +13,13 @@ jobs:
 
     - name: Generate App Token
       id: app-token-generation
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@v3.1.1
       with:
-        app-id: ${{ secrets.APP_ID }}
+        client-id: ${{ secrets.APP_ID }}
         private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
     - name: Clone Repo
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         token: ${{ steps.app-token-generation.outputs.token }}
 


### PR DESCRIPTION
# About the pull request

This PR bumps all actions because of https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

We will need to double check releases, pages, change log, and stale still work correctly (as well as just a PR after this is merged).

~~release-downloader is a specific commit because of https://github.com/tgstation/tgstation/pull/95627#pullrequestreview-4093859127~~ They since changed their mind on this with https://github.com/tgstation/tgstation/commit/d70eb776f869bdeb93a5190158d5112aac200819

Actions that have not been updated for node24 (resolved now):
- [X] ~~eps1lon/actions-label-merge-conflict~~
- [X] ~~yogstation13/DreamAnnotate aka alexkar598/DreamAnnotate~~

# Changelog
:cl: Drathek
code: Bumped all github action versions because of node update requirement
/:cl:
