### PR TITLE
Allow marine jackets to hold detectors

### DIFF
--- a/code/modules/clothing/suits/marine_coat.dm
+++ b/code/modules/clothing/suits/marine_coat.dm
@@ -41,6 +41,7 @@
 		/obj/item/tool/crowbar,
 		/obj/item/tool/pen,
 		/obj/item/storage/large_holster/machete,
+		/obj/item/device/motiondetector,
 	)
 
 	//Buttons


### PR DESCRIPTION

# About the pull request

Allows marine jackets to hold detectors (motion and data) on their suit storage slots.

List of affected jackets: 

- All marine service/dress/formal jackets
- All RMC and IASF jackets (except IASF combat jacket which already could)
- M70 flak jacket
- M70B1 light flak jacket
- Quartermaster jacket
- Military police service jackets
- Tanker jacket
- Mess technician jacket
- Combat correspondent jacket
- All of CL's vests/jackets

If maintainers want we could exclude the more non-combatant ones.

# Explain why it's good for the game

Majority of outerwear already allows holding detectors, its strange that ones that numerous marine roles wear dont.
Less IOs running around in labcoats (or any other civilian clothing looted off of colonist bodies)
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Allows marine jackets to hold motion and data detectors.
/:cl:
