### PR TITLE
Valkyrie buff package

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/valkyrie.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/valkyrie.dm
@@ -36,7 +36,7 @@
 	var/fury_max = 200
 	var/fury_per_attack = 15
 	var/fury_per_life = 5
-	var/heal_range =  3
+	var/heal_range =  5
 	var/raging = FALSE
 
 	// State
@@ -467,9 +467,6 @@
 	if(!check_plasma_owner())
 		return
 
-	if(!behavior.use_internal_fury_ability(retrieve_cost))
-		return
-
 	if(!check_and_use_plasma_owner())
 		return
 
@@ -561,3 +558,21 @@
 	targetXeno.throw_atom(throw_target_turf, throw_dist, SPEED_VERY_FAST, pass_flags = PASS_MOB_THRU)
 	apply_cooldown()
 	return ..()
+
+/datum/status_effect/grace_period
+	status_type = STATUS_EFFECT_REFRESH
+	alert_type = null
+	remove_on_fullheal = TRUE
+	duration = 3 SECONDS
+	var/list/bit_to_remove = list(CANSTUN,CANDAZE,CANSLOW)
+
+/datum/status_effect/grace_period/on_creation(mob/living/new_owner, ...)
+	. = ..()
+	for(var/bit in bit_to_remove)
+		new_owner.status_flags &= bit
+
+/datum/status_effect/grace_period/on_remove()
+	. = ..()
+	for(var/bit in bit_to_remove)
+		owner.status_flags |= bit
+

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/valkyrie.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/valkyrie.dm
@@ -36,7 +36,7 @@
 	var/fury_max = 200
 	var/fury_per_attack = 15
 	var/fury_per_life = 5
-	var/heal_range =  5
+	var/heal_range =  3
 	var/raging = FALSE
 
 	// State

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/valkyrie.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/valkyrie.dm
@@ -563,7 +563,7 @@
 	status_type = STATUS_EFFECT_REFRESH
 	alert_type = null
 	remove_on_fullheal = TRUE
-	duration = 3 SECONDS
+	duration = 30 SECONDS
 	var/list/bit_to_remove = list(CANSTUN,CANDAZE,CANSLOW)
 
 /datum/status_effect/grace_period/on_creation(mob/living/new_owner, ...)

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/valkyrie.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/valkyrie.dm
@@ -564,14 +564,16 @@
 	status_type = STATUS_EFFECT_REFRESH
 	alert_type = null
 	remove_on_fullheal = TRUE
-	duration = 30 SECONDS
+	duration = 3 SECONDS
 
 
 /datum/status_effect/grace_period/on_creation(mob/living/new_owner, ...)
 	. = ..()
 	new_owner.status_flags &= ~(CANSTUN|CANDAZE|CANSLOW|CANKNOCKDOWN|CANKNOCKOUT)
+	new_owner.add_filter("grace", 1, list("type" = "outline", "color" = "#21a310", "size" = 1))
 
 /datum/status_effect/grace_period/on_remove()
 	. = ..()
 	owner.status_flags |= (CANSTUN|CANDAZE|CANSLOW|CANKNOCKDOWN|CANKNOCKOUT)
+	owner.remove_filter("grace")
 

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/valkyrie.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/valkyrie.dm
@@ -376,6 +376,7 @@
 		allied_xenomorphs.xeno_jitter(1 SECONDS,)
 		allied_xenomorphs.flick_heal_overlay(3 SECONDS, "#F5007A")
 		allied_xenomorphs.clear_debuffs()
+		allied_xenomorphs.apply_status_effect(/datum/status_effect/grace_period)
 	apply_cooldown()
 	return ..()
 
@@ -564,15 +565,13 @@
 	alert_type = null
 	remove_on_fullheal = TRUE
 	duration = 30 SECONDS
-	var/list/bit_to_remove = list(CANSTUN,CANDAZE,CANSLOW)
+
 
 /datum/status_effect/grace_period/on_creation(mob/living/new_owner, ...)
 	. = ..()
-	for(var/bit in bit_to_remove)
-		new_owner.status_flags &= bit
+	new_owner.status_flags &= ~(CANSTUN|CANDAZE|CANSLOW|CANKNOCKDOWN|CANKNOCKOUT)
 
 /datum/status_effect/grace_period/on_remove()
 	. = ..()
-	for(var/bit in bit_to_remove)
-		owner.status_flags |= bit
+	owner.status_flags |= (CANSTUN|CANDAZE|CANSLOW|CANKNOCKDOWN|CANKNOCKOUT)
 


### PR DESCRIPTION

# About the pull request

Does the following:
1 - Increase the healing range from 3->5 (nvm keeping it as 3)
2 - Remove the fury requirements from retrieve
3 - Add a 3 seconds grace period to xeno affected by roar ability which prevents further stuns and slow, the grace period is indicated by the green outline xeno will have


# Explain why it's good for the game
1 - 3 tiles healing range is too short to effectively heal allies in front line unless its very close quarter which people avoids clumping up due to body block and thus less people to heal. The increase in range should allow for more significant aid especially those healing or ally xeno pushing together but doesnt stay too far.
2 - The retrieve ability is normally used in split second decision and having to manage your rage for it sucks and would lead to xeno dying bc you are unable to pull them back, additionally the ability is really janky with its pathfinding and doesnt work if the target is moving so you end up just wasting your fury most of the time. The only situation where ive gotten it to reliably work is if both target and i are in the open and they enter crit. Without the fury it should be less crippling to your fury stash when this ability fails
3 - The  roar ability cancels stun only once and is not effective for chain stuning ie grenade spam, scout impact round, slugs. The ability also cannot be used when you yourself are stun thus it promotes this stay in the back and use roar when your ally is stun playstyle which i dont think is the playstyle the original author had in mind for valk. I think there are 2 solution to promote a more frontlining approach to this which is to 1 - allow roar usage while stunned 2 - add a grace period after it clears stun. I think 1 is a little inconsistent with how all xeno abilities are done while 2 allows for a little more skillful play, with good players being able to predict ahead of time and use roar. Note that this does not decrease the range so if you wanna sit back and save xeno you still can, it just rewards people who wanna push out together and support.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
add: Added grace period to valkyrie praetorian fight or flight ability, 3 seconds of stun immunity 
balance:  valkyrie retrieve ability no long consumes fury to activate
/:cl:

