### PR TITLE
corporate bodyguard gets tacmap

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -1144,6 +1144,7 @@
 	)
 	additional_hud_types = list(MOB_HUD_FACTION_MARINE)
 	initial_keys = list(/obj/item/device/encryptionkey/wy_bodyguard)
+	minimap_type = /datum/action/minimap/marine
 
 /obj/item/device/radio/headset/distress/hyperdyne
 	name = "HC corporate headset"


### PR DESCRIPTION

# About the pull request

gives corporate bodyguard access to the tacmap

# Explain why it's good for the game

CL gets access to it, as do most other shipside roles both marine and civilian, so I consider the fact the CB can't open it an oversight

<details>
<summary>Screenshots & Videos</summary>

<img width="1384" height="1378" alt="Screenshot_Y2026_M04_D20_H09_m59" src="https://github.com/user-attachments/assets/eb23dbc9-9835-46ee-997e-5a0001ab6ec4" />

</details>


# Changelog

:cl:
fix: Corporate Bodyguard now can view the tacmap.
/:cl:
