### PR TITLE
allows damaging and repairing several generators at the same time

### DIFF
--- a/code/game/machinery/fusion_engine.dm
+++ b/code/game/machinery/fusion_engine.dm
@@ -237,10 +237,6 @@
 		to_chat(xeno, SPAN_WARNING("You see no reason to attack [src]."))
 		return
 
-	if(xeno.action_busy)
-		to_chat(xeno, SPAN_WARNING("You cannot damage [src] while doing something else."))
-		return
-
 	if(overloaded)
 		xeno.animation_attack_on(src)
 		playsound(src, 'sound/effects/metalhit.ogg', 25, 1)
@@ -274,8 +270,6 @@
 
 /obj/structure/machinery/power/power_generator/reactor/attackby(obj/item/attacking_item, mob/user)
 	//Fuel Cells
-	if(user.action_busy)
-		return
 
 	if(istype(attacking_item, /obj/item/fuel_cell))
 		var/obj/item/fuel_cell/cell = attacking_item

--- a/code/game/machinery/fusion_engine.dm
+++ b/code/game/machinery/fusion_engine.dm
@@ -244,6 +244,7 @@
 
 	if(buildstate >= BUILDSTATE_DAMAGE_WELD)
 		to_chat(xeno, SPAN_WARNING("You see no reason to attack [src]."))
+		being_damaged = FALSE
 		return
 
 	if(overloaded)

--- a/code/game/machinery/fusion_engine.dm
+++ b/code/game/machinery/fusion_engine.dm
@@ -47,6 +47,9 @@
 	///The reactors fuel cell, fail rate increases if empty
 	var/obj/item/fuel_cell/fusion_cell
 
+	///Is xenomorph already attacking this generator
+	var/being_damaged = FALSE
+
 /obj/structure/machinery/power/power_generator/reactor/Initialize(mapload, ...)
 	. = ..()
 	if(is_mainship_level(z)) //Only ship reactors can overload
@@ -233,6 +236,12 @@
 
 /obj/structure/machinery/power/power_generator/reactor/attack_alien(mob/living/carbon/xenomorph/xeno)
 	. = XENO_NONCOMBAT_ACTION
+	if(being_damaged)
+		to_chat(xeno,SPAN_WARNING("[src] is already being torn apart."))
+		return
+
+	being_damaged = TRUE
+
 	if(buildstate >= BUILDSTATE_DAMAGE_WELD)
 		to_chat(xeno, SPAN_WARNING("You see no reason to attack [src]."))
 		return
@@ -243,6 +252,7 @@
 		xeno.visible_message(SPAN_DANGER("[xeno] [xeno.slashes_verb] [src], stopping its overload process!"),
 		SPAN_DANGER("You [xeno.slash_verb] [src], stopping its overload process!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 		set_overloading(FALSE)
+		being_damaged = FALSE
 		return
 
 	var/looping = FALSE
@@ -264,6 +274,7 @@
 		buildstate = clamp(buildstate + 1, BUILDSTATE_FUNCTIONAL, BUILDSTATE_DAMAGE_WELD)
 		update_icon()
 		looping = TRUE
+	being_damaged = FALSE
 
 /obj/structure/machinery/power/power_generator/reactor/handle_tail_stab(mob/living/carbon/xenomorph/xeno, blunt_stab)
 	return TAILSTAB_COOLDOWN_NONE


### PR DESCRIPTION

# About the pull request

Removes the busy check from fixing and dmaging generators, PR made based on this development forum ideaguy post https://forum.cm-ss13.com/t/readd-multi-repair-on-gens/20095 (if this is no wanted in the game I am not fighting over it)

I did check that you can not be damaging several states of the same generator at the same time can be attacking more or repairing more

# Explain why it's good for the game

https://forum.cm-ss13.com/t/readd-multi-repair-on-gens/20095


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: xeno can be damaging multiple generators at once
balance: human can repair multiple generators at once
/:cl:
