### PR TITLE
Shuffles King Vote List

### DIFF
--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -1141,7 +1141,7 @@
 
 	for(var/mob/living/carbon/xenomorph/candidate in hive.totalXenos)
 		if(is_candidate_valid(hive, candidate, playtime_restricted = FALSE, skip_playtime = FALSE))
-			INVOKE_ASYNC(src, PROC_REF(cast_vote), candidate, voting_candidates)
+			INVOKE_ASYNC(src, PROC_REF(cast_vote), candidate, shuffle(voting_candidates))
 
 	candidates = voting_candidates
 


### PR DESCRIPTION

# About the pull request

Vote lists for king are now shuffled for different xenos. Specifically, the first xeno on the list will no longer be the same for all xenos and players spamming enter to remove the vote popup during combat will not all select the same person. Outside of small hives who all actually take the time to vote properly, the xeno at the top of the list is provided a disproportionately higher chance on becoming king.

# Explain why it's good for the game

The xeno who has lived the longest in the hive is no longer always at the top of the king vote list and thus no longer far more likely to become king than all other xenos. It is still a 50/50 between the two highest voted xenos, just now the highest voted is more random than what is currently guaranteed to the oldest non-queen valid xeno.

Democracy shouldn't be weighted.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Debug log of list values for each xeno that can vote. The PR does not actually cause this to be printed.

<img width="1941" height="256" alt="RandomKing" src="https://github.com/user-attachments/assets/e1e4b4b3-f4ce-4412-9c05-c096959a1ae1" />

</details>


# Changelog
:cl: KornFlaks
add: King vote list is now randomized between different voters.
/:cl:
