### PR TITLE
carrier plasma buff

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Carrier.dm
@@ -7,8 +7,8 @@
 	melee_damage_upper = XENO_DAMAGE_TIER_4
 	melee_vehicle_damage = XENO_DAMAGE_TIER_3
 	max_health = XENO_HEALTH_TIER_9
-	plasma_gain = XENO_PLASMA_GAIN_TIER_6
-	plasma_max = XENO_PLASMA_TIER_5
+	plasma_gain = XENO_PLASMA_GAIN_TIER_7
+	plasma_max = XENO_PLASMA_TIER_8
 	xeno_explosion_resistance = XENO_EXPLOSIVE_ARMOR_TIER_2
 	armor_deflection = XENO_NO_ARMOR
 	evasion = XENO_EVASION_NONE


### PR DESCRIPTION

# About the pull request

Buffs both the carrier's plasma regen and max plasma. carrier now has 800 plasma, and level 7 plasma regen. level 7 is more than burrower but less than drone 

# Explain why it's good for the game

As it stands carrier feels actually horrific to play because of its plasma abilities. with a measly 500 plasma, you barely have enough plasma to make any special buildings. And besides that, the time it takes to regen that plasma makes building anything such a slog unless you have a queen on ovi spamming plasma on you or a drone following you constantly giving you plasma. I don't think it's reasonable that a support caste should have such a shit time doing normal support things, like building clusters and morphers, and weeding. as a carrier you are basically required at all times to be on recovery pheromones to try and make up for your shit regen, which helps but only slightly. so this also means that when you are off weeds, say, to weed, like your job or something, you are constantly losing plasma, meaning that you will probably lose about 1 node worth of plasma just running forward and weeding. This buff to carrier plasma will make the experience of playing carrier so much nicer. I won't have this looming sense of dread at the thought of attempting to build a cluster somewhere.

# Testing Photographs and Procedure


<details>
<summary>Screenshots & Videos</summary>


</details>


# Changelog


Nomoresolvalou
:cl:

balance: buffed carrier plasma to 800, and plasma regen to level 7 (better than burrower, worse than drone)

/:cl:
