### PR TITLE
Xenomorphs can evolve while injured predrop. 

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Evolution.dm
@@ -271,7 +271,7 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 		to_chat(src, SPAN_WARNING("We are already the apex of form and function. Go forth and spread the hive!"))
 		return FALSE
 
-	if(health < maxHealth)
+	if(health < maxHealth && SSobjectives.first_drop_complete) //lets xenomorphs evolve while injured predrop
 		to_chat(src, SPAN_WARNING("We must be at full health to evolve."))
 		return FALSE
 


### PR DESCRIPTION

# About the pull request

Lets xenomorphs evolve while below 100% health before marines have landed on the planet. This restores *only* the health difference between both max health capacities (if applicable), and confers no other advantages. 

# Explain why it's good for the game

No longer punishes players for hunting survivors before marines land. Alleviates awkward bumps in flow between evolution periods predrop, and encourages engaging with survivors.


# Testing Photographs and Procedure


<details>
<summary>Screenshots & Videos</summary>


https://github.com/user-attachments/assets/c0dce8e1-d55e-497f-b8ed-240597966e3a



</details>


# Changelog

:cl:
balance: Xenomorphs can now evolve below 100% health before marines make their first drop. 
/:cl:
