### PR TITLE
Recovery Node healing crit xeno

### DIFF
--- a/code/modules/cm_aliens/structures/special/recovery_node.dm
+++ b/code/modules/cm_aliens/structures/special/recovery_node.dm
@@ -103,7 +103,7 @@
 	var/list/heal_candidates = list()
 
 	for(var/mob/living/carbon/xenomorph/xeno_in_range in orange(src, 1))
-		if(xeno_in_range.health >= xeno_in_range.maxHealth || !xeno_in_range.resting || xeno_in_range.hivenumber != linked_hive.hivenumber)
+		if(xeno_in_range.health >= xeno_in_range.maxHealth || (!xeno_in_range.resting && xeno_in_range.health > 0) || xeno_in_range.hivenumber != linked_hive.hivenumber)
 			continue
 		if(xeno_in_range.stat == DEAD)
 			continue


### PR DESCRIPTION

# About the pull request
Recovery Node will now heal crit xenos without them trying to Rest.

Xeno still need to Rest after exiting crit though.


# Explain why it's good for the game
Xenos in crit are already laying down and not moving. No reason for them to not benefit from Recovery Node.

Less hidden knowledge for new players. Less hassle for those who already knew.



# Testing Photographs and Procedure


<details>
<summary>Screenshots & Videos</summary>


https://github.com/user-attachments/assets/95f742ea-de71-4b89-8339-a8d412ab1ca1



</details>


# Changelog
:cl: labeo0
qol: Crit xenos do not need to Rest to get healing from Recovery Node.
/:cl:
