### PR TITLE
Fix: SEAs spawning as Army ranks

### DIFF
--- a/code/datums/paygrades/factions/uscm/army.dm
+++ b/code/datums/paygrades/factions/uscm/army.dm
@@ -88,7 +88,7 @@
 
 /datum/paygrade/army/e9
 	paygrade = PAY_SHORT_AE9
-	name = "Master Sergeant"
+	name = "Sergeant Major"
 	prefix = "SGM"
 	rank_pin = /obj/item/clothing/accessory/ranks/army/e9
 	ranking = 9

--- a/code/datums/paygrades/factions/uscm/marine.dm
+++ b/code/datums/paygrades/factions/uscm/marine.dm
@@ -61,6 +61,7 @@
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e7
 	ranking = 6
 	pay_multiplier = 2.75
+	sea_grade = TRUE
 
 /datum/paygrade/marine/e8
 	paygrade = PAY_SHORT_ME8
@@ -69,6 +70,7 @@
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e8
 	ranking = 7
 	pay_multiplier = 2.75
+	sea_grade = TRUE
 
 /datum/paygrade/marine/e8e
 	paygrade = PAY_SHORT_ME8E
@@ -77,6 +79,7 @@
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e8e
 	ranking = 8
 	pay_multiplier = 2.75
+	sea_grade = TRUE
 
 /datum/paygrade/marine/e9
 	paygrade = PAY_SHORT_ME9
@@ -85,6 +88,7 @@
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e9
 	ranking = 9
 	pay_multiplier = 3
+	sea_grade = TRUE
 
 /datum/paygrade/marine/e9e
 	paygrade = PAY_SHORT_ME9E
@@ -93,6 +97,7 @@
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e9e
 	ranking = 10
 	pay_multiplier = 3
+	sea_grade = TRUE
 
 /datum/paygrade/marine/e9c
 	paygrade = PAY_SHORT_ME9C
@@ -101,6 +106,7 @@
 	rank_pin = /obj/item/clothing/accessory/ranks/marine/e9c
 	ranking = 11
 	pay_multiplier = 3
+	sea_grade = TRUE
 
 /datum/paygrade/marine/wo
 	paygrade = PAY_SHORT_MWO

--- a/code/datums/paygrades/helper.dm
+++ b/code/datums/paygrades/helper.dm
@@ -25,10 +25,12 @@
 			return "[paygrade]"
 		return P.name
 
-/proc/get_paygrade_id_by_name(paygrade_name)
+/proc/get_paygrade_id_by_name(paygrade_name, paygrades_list_to_search = GLOB.paygrades)
 	var/datum/paygrade/paygrade
-	for(var/paygrade_id in GLOB.paygrades)
-		paygrade = GLOB.paygrades[paygrade_id]
+	if(!length(paygrades_list_to_search))
+		paygrades_list_to_search = GLOB.paygrades
+	for(var/paygrade_id in paygrades_list_to_search)
+		paygrade = paygrades_list_to_search[paygrade_id]
 		if(paygrade.name == paygrade_name)
 			return paygrade_id
 

--- a/code/datums/paygrades/paygrade.dm
+++ b/code/datums/paygrades/paygrade.dm
@@ -1,5 +1,6 @@
 GLOBAL_LIST_EMPTY(uscm_highcom_paygrades)
 GLOBAL_LIST_EMPTY(uscm_officer_paygrades)
+GLOBAL_LIST_EMPTY(uscm_sea_paygrades)
 GLOBAL_LIST_EMPTY(wy_highcom_paygrades)
 GLOBAL_LIST_INIT_TYPED(paygrades, /datum/paygrade, setup_paygrades())
 
@@ -20,6 +21,8 @@ GLOBAL_LIST_INIT_TYPED(paygrades, /datum/paygrade, setup_paygrades())
 	var/default_faction
 	/// If the grade refers to an officer equivalent or not.
 	var/officer_grade = GRADE_ENLISTED
+	/// If the grade refers to an senior enlisted advisor grade or not.
+	var/sea_grade
 
 GLOBAL_LIST_INIT(co_paygrades, list(
 	PAY_SHORT_NO6,
@@ -38,6 +41,8 @@ GLOBAL_LIST_INIT(co_paygrades, list(
 	. = ..()
 	switch(default_faction)
 		if(FACTION_MARINE)
+			if(sea_grade)
+				GLOB.uscm_sea_paygrades += paygrade
 			if(officer_grade)
 				GLOB.uscm_officer_paygrades += paygrade
 			if(officer_grade >= GRADE_FLAG)
@@ -55,3 +60,4 @@ GLOBAL_LIST_INIT(co_paygrades, list(
 				log_debug("Duplicate paygrade: '[pg_id]'.")
 			else
 				.[pg_id] = new PG
+	GLOB.uscm_sea_paygrades = . & GLOB.uscm_sea_paygrades

--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -540,7 +540,7 @@
 /datum/equipment_preset/uscm_ship/sea/load_rank(mob/living/carbon/human/rankee, client/mob_client)
 	mob_client?.toggle_newplayer_ic_hud(TRUE)
 	if(rankee?.client?.prefs?.pref_special_job_options[job_title])
-		var/paygrade_choice = get_paygrade_id_by_name(rankee.client.prefs.pref_special_job_options[job_title])
+		var/paygrade_choice = get_paygrade_id_by_name(rankee.client.prefs.pref_special_job_options[job_title], GLOB.uscm_sea_paygrades)
 		return paygrade_choice
 	..()
 


### PR DESCRIPTION

# About the pull request
Resolves: #12073
Only existed for SEAs because they're the only one that uses this awful proc. but just in case someone wants/needs it later, it has an option to take a list but defaults to just everything.

But because AE8 and ME8 for example share the same name, and Army ranks come before Marine ranks, it just used the Army ones. Fix that by just having a short list for USCM SEA ranks. and populating it properly when all of the paygrades get populated.

Also fix Army E9 being Master Sergeant and not Sergeant Major
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #12345" to link the PR to the corresponding Issue number #12345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #12345, Fixes #12346, Fixes #12347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Army but marine bad.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: SEAs can no longer spawn with Army ranks. Fix Army E9 being Master Sergeant and not Sergeant Major
/:cl:
