### PR TITLE
Fix: Add Senior Command Access to Dropship controls

### DIFF
--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -3,7 +3,7 @@
 	desc = "A flight computer that can be used for autopilot or long-range flights."
 	icon = 'icons/obj/structures/machinery/shuttle-parts.dmi'
 	icon_state = "console"
-	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP)
+	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_SENIOR)
 	unacidable = TRUE
 	explo_proof = TRUE
 	needs_power = FALSE


### PR DESCRIPTION

# About the pull request
Let's the aCO if they don't have dropship or leader, neither of which they get from the auto "promotion" use the dropship consoles if they're unlucky enough to be aCO without already having those things.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #12345" to link the PR to the corresponding Issue number #12345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #12345, Fixes #12346, Fixes #12347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Nice of ARES to gift them the gift of being able to put the Dropships on Auto
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Dropship controls now recognise Senior Command Access as valid.
/:cl:
