### PR TITLE
fixes dark tiles above doors

### DIFF
--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -502,6 +502,10 @@
 	if(upper_wall)
 		upper_wall.dismantle_wall()
 		upper_wall = null
+	var/turf/above = SSmapping.get_turf_above(src)
+	while(above && istransparentturf(above))
+		above.update_vis_contents()
+		above = SSmapping.get_turf_above(above)
 	relativewall_neighbours()
 	var/area/area = get_area(src)
 	area?.current_resin_count--


### PR DESCRIPTION

# About the pull request

I am stupid and when I fixed this issue with walls I did not ralize that doors are a different animal

# Explain why it's good for the game
black tiles lingering on currently unused level after doors are destroyed in wide open place are not an urgent issue but look bad


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: fixes lingering dark tiles above destroyed doors
/:cl:
