### PR TITLE
Fixes brute upper resin walls

### DIFF
--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -1043,7 +1043,7 @@
 		wall_below = null
 	if(door_below)
 		door_below.upper_wall = null
-		door_below.Dismantle(1)
+		door_below.Dismantle(TRUE)
 		door_below = null
 	var/turf/above = SSmapping.get_turf_above(src)
 	if(above && istransparentturf(above))

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -954,6 +954,7 @@
 	while(above && istransparentturf(above))
 		above.update_vis_contents()
 		above = SSmapping.get_turf_above(above)
+
 /turf/closed/wall/resin/process()
 	. = ..()
 
@@ -1037,10 +1038,12 @@
 /turf/closed/wall/resin/above/Destroy(force)
 	. = ..()
 	if(wall_below)
-		wall_below.upper_wall = null //we should not get here naturaly
+		wall_below.upper_wall = null
+		wall_below.dismantle_wall()
 		wall_below = null
 	if(door_below)
 		door_below.upper_wall = null
+		door_below.Dismantle(1)
 		door_below = null
 	var/turf/above = SSmapping.get_turf_above(src)
 	if(above && istransparentturf(above))


### PR DESCRIPTION

# About the pull request

big explosions of upper resin walls now correctly destroy the lower wall too. big explosions bypassed dealing damage for the sake of spalling or whatever

# Explain why it's good for the game

ther shuld not be walls without upper part


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: explosions on upper xeno walls destroy the lower portion too
/:cl:
