### PR TITLE
you can see mobs within 6 tiles

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -868,7 +868,7 @@
 
 	if(isliving(bullet.firer))
 		var/mob/living/shooter_living = bullet.firer
-		if(!can_see(shooter_living,src))
+		if(!can_see(shooter_living,src,6))
 			. -= 15 //Can't see the target (Opaque thing between shooter and target)
 
 /mob/living/carbon/human/get_projectile_hit_chance(obj/projectile/bullet)


### PR DESCRIPTION

# About the pull request

right now the -15 acc debuff is applied even when the mob is on your screen edge tile aka you can fully see it

# Explain why it's good for the game

ehh projectile code is jank, this does not give you hidden acc debuff on stuff you can still see


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: now -15 accuracy debuff from being unable to see your target is applied when target is off screen, rather then from the last tile on screen 
/:cl:
