### PR TITLE
Prevents Non-Admin CO + Synthetic Medals and Ribbons

### DIFF
--- a/code/datums/medal_awards.dm
+++ b/code/datums/medal_awards.dm
@@ -694,6 +694,12 @@ GLOBAL_DATUM_INIT(ic_medals_panel, /datum/ic_medal_panel, new)
 			if(recommendation.recipient_name == user.real_name)
 				to_chat(user, SPAN_WARNING("You cannot give medals to yourself!"))
 				return
+			if(recommendation.recipient_rank == JOB_CO)
+				to_chat(user, SPAN_WARNING("You cannot give a medal to your Commanding Officer!"))
+				return
+			if(recommendation.recipient_rank == JOB_SYNTH)
+				to_chat(user, SPAN_WARNING("What is a Synthetic going to do with a medal?"))
+				return
 
 			var/choice = tgui_alert(user, "Would you like to change the medal text?", "Medal Citation", list("Yes", "No"))
 			var/medal_citation = recommendation.reason

--- a/code/datums/medal_awards.dm
+++ b/code/datums/medal_awards.dm
@@ -695,10 +695,10 @@ GLOBAL_DATUM_INIT(ic_medals_panel, /datum/ic_medal_panel, new)
 				to_chat(user, SPAN_WARNING("You cannot give medals to yourself!"))
 				return
 			if(recommendation.recipient_rank == JOB_CO)
-				to_chat(user, SPAN_WARNING("You cannot give a medal to your Commanding Officer!"))
+				to_chat(user, SPAN_WARNING("You cannot give a ribbon or medal to the Commanding Officer!"))
 				return
 			if(recommendation.recipient_rank == JOB_SYNTH)
-				to_chat(user, SPAN_WARNING("What is a Synthetic going to do with a medal?"))
+				to_chat(user, SPAN_WARNING("What is a Synthetic going to do with a ribbon or medal?"))
 				return
 
 			var/choice = tgui_alert(user, "Would you like to change the medal text?", "Medal Citation", list("Yes", "No"))


### PR DESCRIPTION

# About the pull request

Prevents XOs (or silly COs) from giving medals to COs or Synthetics.

# Explain why it's good for the game

The Senators for both of the WLs above said to do it.

This does not affect medals or ribbons given via the Admin Medal Panel.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
code: added checks to prevent COs or Synthetics from being given medals or ribbons by non-admins.
/:cl:
