### PR TITLE
Fix doubled up fax responders

### DIFF
--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -316,13 +316,18 @@ Additional game mode variables.
 
 /datum/game_mode/proc/attempt_to_join_as_fax_responder(mob/responder_candidate, from_lobby = FALSE)
 	var/list/options = get_fax_responder_slots(responder_candidate)
-	if(!options || !options.len)
+	if(!options || !length(options))
 		to_chat(responder_candidate, SPAN_WARNING("No Available Slot!"))
 		return FALSE
 
 	var/choice = tgui_input_list(responder_candidate, "What Fax Responder do you want to join as?", "Which Responder?", options, 30 SECONDS)
 	if(!(choice in FAX_RESPONDER_JOB_LIST))
 		to_chat(responder_candidate, SPAN_WARNING("Error: No valid responder selected."))
+		return FALSE
+
+	options = get_fax_responder_slots(responder_candidate)
+	if(!(choice in options))
+		to_chat(responder_candidate, SPAN_WARNING("Error: Option is no longer available."))
 		return FALSE
 
 	if(!transform_fax_responder(responder_candidate, choice))


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #7164

Since there is a TGUI list prompt to select a role, its possible for two people to make the same choice which is unintended. Rather than spawning two people in the same pod, now they get an error message. See testing.

# Explain why it's good for the game

Unintended for fax responder slots to be used by multiple people.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Have two people open prompt, both try to be the same, only first one gets the spot:
<img width="2266" height="890" alt="image" src="https://github.com/user-attachments/assets/847fbd37-bc26-400c-a4c7-95b2d57aa6e4" />

</details>


# Changelog
:cl: Drathek
fix: Fixed the possibility of multiple people picking the same fax responder
/:cl:
