### PR TITLE
Revolvers have a hint in description about revolver tricks and a warning shot

### DIFF
--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -35,6 +35,7 @@
 	var/recent_trick //So they're not spamming tricks.
 	var/russian_roulette = 0 //God help you if you do this.
 	var/trickster_gun = FALSE //If true, allows gun spinning.
+	var/threat_gun = FALSE //If true, will give a hint about warning shot ability
 
 /obj/item/weapon/gun/revolver/Initialize(mapload, spawn_empty)
 	. = ..()
@@ -61,6 +62,10 @@
 
 	if(trickster_gun)
 		. += SPAN_NOTICE("You feel like tricks with it can be done easily.")
+		. += SPAN_INFO ("To perform tricks, swap on <span class='corp_label_blue'>disarm</span> intent.")
+
+	if(threat_gun)
+		. += SPAN_INFO ("To perform a warning shot, swap on <span class='corp_label_yellow'>grab</span> intent.")
 
 /obj/item/weapon/gun/revolver/display_ammo(mob/user) // revolvers don't *really* have a chamber, at least in a way that matters for ammo displaying
 	if(flags_gun_features & GUN_AMMO_COUNTER && !(flags_gun_features & GUN_BURST_FIRING) && current_mag)
@@ -667,6 +672,7 @@
 	unacidable = TRUE
 	explo_proof = TRUE
 	black_market_value = 100
+	threat_gun = TRUE
 	var/is_locked = TRUE
 	var/can_change_barrel = TRUE
 


### PR DESCRIPTION

# About the pull request

Title

<img width="293" height="58" alt="dreamseeker_aWzSvex3j3" src="https://github.com/user-attachments/assets/ef08107a-65d2-4963-9083-74f62ccb05e3" />

Clears up the confusion about what your gun can and cannot do

# Changelog
:cl:
qol: revolvers now have a hint in description about what intent should you use to make warning shot or revolver tricks
/:cl:
