### PR TITLE
Fix #12183 - No spam clicking sentry post upgrades

### DIFF
--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -839,6 +839,9 @@
 /obj/structure/machinery/defenses/sentry/launchable/attackby(obj/item/stack/sheets, mob/user)
 	. = ..()
 
+	if(user.action_busy)
+		return
+
 	if(!istype(sheets, /obj/item/stack/sheet/metal))
 		to_chat(user, SPAN_WARNING("Use [upgrade_cost] metal sheets to give the sentry some plating."))
 		return

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -855,14 +855,15 @@
 		return
 
 	if(sheets.amount >= upgrade_cost)
+		upgraded = TRUE
 		if(!do_after(user, 4 SECONDS * user.get_skill_duration_multiplier(SKILL_CONSTRUCTION) , INTERRUPT_ALL, BUSY_ICON_FRIENDLY))
+			upgraded = FALSE
 			to_chat(user, SPAN_WARNING("You were interrupted! Try to stay still while you bolster the sentry with metal sheets..."))
 			return
 
 		if(sheets.use(upgrade_cost))
 			health_max = health_upgrade
 			health = health_max
-			upgraded = TRUE
 			to_chat(user, SPAN_WARNING("You added some metal plating to the [name], increasing its durability!"))
 		else
 			to_chat(user, SPAN_WARNING("You need at least [upgrade_cost] sheets of metal to upgrade this."))

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -811,8 +811,8 @@
 	static = TRUE
 	/// Cost to give sentry extra health
 	var/upgrade_cost = 5
-	/// Amount of bonus health they get from upgrade
-	var/health_upgrade = 50
+	/// Amount of health set after upgrade
+	var/health_upgrade = 250
 	var/obj/structure/machinery/camera/cas/linked_cam
 	var/static/sentry_count = 1
 	var/sentry_number
@@ -847,7 +847,11 @@
 		return
 
 	if(upgraded)
-		to_chat(user, SPAN_WARNING("\The [src] has already been upgraded."))
+		to_chat(user, SPAN_WARNING("\The [name] has already been upgraded."))
+		return
+
+	if(health != health_max)
+		to_chat(user, SPAN_WARNING("\The [name] must have no damage to be upgraded."))
 		return
 
 	if(sheets.amount >= upgrade_cost)
@@ -856,10 +860,10 @@
 			return
 
 		if(sheets.use(upgrade_cost))
-			src.health_max += health_upgrade
-			src.update_health(-health_upgrade)
+			health_max = health_upgrade
+			health = health_max
 			upgraded = TRUE
-			to_chat(user, SPAN_WARNING("You added some metal plating to the sentry, increasing its durability!"))
+			to_chat(user, SPAN_WARNING("You added some metal plating to the [name], increasing its durability!"))
 		else
 			to_chat(user, SPAN_WARNING("You need at least [upgrade_cost] sheets of metal to upgrade this."))
 	else
@@ -873,7 +877,7 @@
 			return
 
 		var/rounds_used = ammo.inherent_reload(user)
-		to_chat(user, SPAN_WARNING("[src]'s internal magazine was reloaded with [rounds_used] rounds, [ammo.max_inherent_rounds] rounds left in storage."))
+		to_chat(user, SPAN_WARNING("[name]'s internal magazine was reloaded with [rounds_used] rounds, [ammo.max_inherent_rounds] rounds left in storage."))
 		playsound(loc, 'sound/weapons/handling/m40sd_reload.ogg', 25, 1)
 		update_icon()
 		return FALSE


### PR DESCRIPTION

# About the pull request

Fixes [#12183](https://github.com/cmss13-devs/cmss13/issues/12183)

Giga sentry no more.

# Explain why it's good for the game

Bug bad. Fix good.

# Testing Photographs and Procedure
Can't really show spam clicking LMB with screencap but PR works.


# Changelog

:cl:labeo0
fix: fixed stacking health upgrades for sentry posts
/:cl:
