### PR TITLE
Fix #11912 - Simple animals get healed with any med item stack

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -381,7 +381,7 @@
 			var/obj/item/stack/medical/MED = O
 			if(health < maxHealth)
 				if(MED.get_amount() >= 1)
-					apply_damage(-MED.heal_brute, BRUTE)
+					apply_damage(-12, BRUTE)
 					MED.use(1)
 					for(var/mob/M as anything in viewers(src, null))
 						if ((M.client && !( M.blinded )))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes [#11921](https://github.com/cmss13-devs/cmss13/issues/11912)

Only trauma kits did any healing to simple mobs. Now any med stack (gauze, ointment, splints, burn kits) apply flat 12 point healing (same amount as trauma kit).

# Explain why it's good for the game

Simple mobs get simple healing
Bug bad. Fix good

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Video does not upload. It works, trust

https://github.com/user-attachments/assets/05a5e99d-2cb0-4791-942e-9d7c699b32e8


</details>


# Changelog
:cl:labeo0
fix: gauze, ointment, kits and splints now heal simple animal mobs
/:cl: