### PR TITLE
Fix #12030 - Fix burning icons of misc boxes

### DIFF
--- a/code/modules/projectiles/ammo_boxes/misc_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/misc_boxes.dm
@@ -45,7 +45,7 @@
 	var/offset_x = 1
 	var/offset_y = -6
 
-	var/image/fire_overlay = image(icon, icon_state = will_explode ? "on_fire_explode_overlay" : "on_fire_overlay", pixel_x = offset_x, pixel_y = offset_y)
+	var/image/fire_overlay = image(flames_icon, icon_state = will_explode ? "on_fire_explode_overlay" : "on_fire_overlay", pixel_x = offset_x, pixel_y = offset_y)
 	overlays.Add(fire_overlay)
 
 /obj/item/ammo_box/magazine/misc/explode(severity, datum/cause_data/flame_cause_data)


### PR DESCRIPTION

# About the pull request

Fixes [#12030](https://github.com/cmss13-devs/cmss13/issues/12030) "

Power cell and other misc boxes get proper icon with fire overlay

# Explain why it's good for the game

Bug bad. Fix good.


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Tested. idk what's with videos not uploading. If you wanna see it message me

https://github.com/user-attachments/assets/8464967f-6968-4e14-a4b7-db6c7c858efa



</details>


# Changelog

:cl:labeo0
fix: fixed burning icons of some boxes
/:cl:
