### PR TITLE
Yautja Council preset

### DIFF
--- a/code/game/jobs/job/antag/other/pred.dm
+++ b/code/game/jobs/job/antag/other/pred.dm
@@ -18,6 +18,7 @@
 		"[JOB_PREDATOR][CLAN_RANK_ELITE]" = /datum/equipment_preset/yautja/elite,
 		"[JOB_PREDATOR][CLAN_RANK_ELDER]" = /datum/equipment_preset/yautja/elder,
 		"[JOB_PREDATOR][CLAN_RANK_LEADER]" = /datum/equipment_preset/yautja/leader,
+		"[JOB_PREDATOR]Enforcer" = /datum/equipment_preset/yautja/enforcer,
 		"[JOB_PREDATOR][CLAN_RANK_ADMIN]" = /datum/equipment_preset/yautja/ancient
 	)
 
@@ -42,8 +43,8 @@
 	if(!("[JOB_PREDATOR][rank]" in gear_preset_whitelist))
 		return CLAN_RANK_BLOODED
 
-	if(player.check_whitelist_status(WHITELIST_YAUTJA_LEADER|WHITELIST_YAUTJA_COUNCIL|WHITELIST_YAUTJA_COUNCIL_LEGACY) && get_desired_status(player.prefs.yautja_status, WHITELIST_COUNCIL) == WHITELIST_NORMAL)
-		return CLAN_RANK_BLOODED
+	if(player.check_whitelist_status(WHITELIST_YAUTJA_LEADER|WHITELIST_YAUTJA_COUNCIL) && get_desired_status(player.prefs.yautja_status, WHITELIST_COUNCIL) == WHITELIST_COUNCIL)
+		return "Enforcer"
 
 	return rank
 

--- a/code/modules/gear_presets/yautja.dm
+++ b/code/modules/gear_presets/yautja.dm
@@ -126,6 +126,19 @@
 	var/new_name = "Elder [new_human.real_name]"
 	new_human.change_real_name(new_human, new_name)
 
+// Council (ELDER)
+/datum/equipment_preset/yautja/enforcer
+	name = "Yautja Enforcer (Councillor)"
+	minimap_icon = "predator_elder"
+	flags = EQUIPMENT_PRESET_START_OF_ROUND
+	default_cape_type = PRED_YAUTJA_THIRD_CAPE
+	clan_rank = CLAN_RANK_ELDER_INT
+
+/datum/equipment_preset/yautja/enforcer/load_name(mob/living/carbon/human/new_human, randomise)
+	. = ..()
+	var/new_name = "Elder [new_human.real_name]"
+	new_human.change_real_name(new_human, new_name)
+
 // CLAN LEADER
 /datum/equipment_preset/yautja/leader
 	name = YAUTJA_LEADER


### PR DESCRIPTION

# About the pull request

Lets councillors join as Enforcers, if they want to.

# Explain why it's good for the game

Snazzy


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Yautja councillors can now join with a unique prefix, if they want to.
/:cl:
