### PR TITLE
fixes missing atmos pipe in CO room

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -2520,6 +2520,9 @@
 	name = "\improper Hangar Lockdown Blast Door"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/lower_medical_lobby)
 "afX" = (
@@ -28056,6 +28059,9 @@
 	req_one_access = null
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/lower_medical_lobby)
 "bqI" = (
@@ -77317,9 +77323,6 @@
 	id = "medicalemergency";
 	name = "\improper Medical Bay Lockdown"
 	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/lower_medical_lobby)
 "qOk" = (
@@ -79441,9 +79444,6 @@
 	req_one_access = null
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/lower_medical_lobby)
 "rID" = (

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -64214,6 +64214,9 @@
 	req_access = null;
 	req_access_txt = "31"
 	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/living/commandbunks)
 "luE" = (


### PR DESCRIPTION
# About the pull request
this adds a missing pipe to the atmos of the CO's quarters; fixes #12198 

# Explain why it's good for the game
i was spawned in as one of the 100 free larva in the event preceding the bug report and tried to escape the massacre via this VERY pipe system only to discover my fate was sealed, and i was trapped. 

fixes a missing piece of the pipenet, guess that's good

# Testing Photographs and Procedure
one-line change
 hope this is okay even with almayer freeze; i wanted to get some of the other almayer bugs but can't find the aforementioned incorrect lifeboat tile description right now at work

# Changelog
:cl:
fix: Adds missing atmos pipe in CO's quarters on the Almayer
/:cl: