### PR TITLE
fixes area tile on LV engi tcomms

### DIFF
--- a/maps/map_files/LV624/LV624.dmm
+++ b/maps/map_files/LV624/LV624.dmm
@@ -9446,7 +9446,7 @@
 	},
 /obj/item/prop/alien/hugger,
 /turf/open/floor/brown/northwest,
-/area/lv624/ground/caves/north_central_caves/lake_house_tower)
+/area/lv624/lazarus/comms)
 "aWF" = (
 /obj/effect/spawner/random/toolbox,
 /obj/structure/surface/table/reinforced/prison,


### PR DESCRIPTION

# About the pull request

fixes #12121

# Explain why it's good for the game

correct areas; what if someone managed to put an APC or something on the SINGULAR incorrect area tile here? wouldn't that be a shame...

# Testing Photographs and Procedure
single line change; code compiles

# Changelog
:cl:
fix: Fixes area tiling in LV624 engineering dome/tcomms
/:cl: