### PR TITLE
Roller Bed safety checks.

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -312,7 +312,7 @@
 	user.temp_drop_inv_item(src)
 	forceMove(roller)
 	SEND_SIGNAL(user, COMSIG_MOB_ITEM_ROLLER_DEPLOYED, roller)
-	if(target_mob)
+	if(target_mob && ((target_mob.faction == user.faction) || target_mob.stat))
 		roller.buckle_mob(target_mob, user)
 
 /obj/item/roller/afterattack(obj/target, mob/user, proximity)


### PR DESCRIPTION

# About the pull request

As title

# Explain why it's good for the game

Roller bed combat buckling is not something I anticipated having to deal with.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Roller bed mob-click buckling no longer works on enemies unless they're dead or unconscious.
/:cl:
