### PR TITLE
removes light in wall on CC, eastern reactor

### DIFF
--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -13396,12 +13396,6 @@
 	},
 /turf/open/floor/corsat/plate,
 /area/lv522/atmos/filt)
-"hao" = (
-/obj/structure/machinery/light{
-	dir = 4
-	},
-/turf/closed/wall/strata_outpost/reinforced,
-/area/lv522/atmos/filt)
 "haq" = (
 /turf/open/floor/strata/white_cyan3,
 /area/lv522/indoors/a_block/medical/glass)
@@ -76400,7 +76394,7 @@ sYl
 sYl
 sYl
 gUv
-hao
+shD
 shD
 cpy
 cpy


### PR DESCRIPTION

# About the pull request

fixes #12216


# Explain why it's good for the game
little mapping clean up.

# Testing Photographs and Procedure
one line removal; compiles

i will have to figure out the other CC things elsewhere; they'll likely take a little more brainpower to work out + tables would affect both LV and CC

# Changelog
:cl:
fix: Removes light in wall of LV522 eastern reactor
/:cl: