### PR TITLE
filing cabinet fixes

### DIFF
--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -84,7 +84,9 @@
 	if(href_list["retrieve"])
 		var/obj/item/P = locate(href_list["retrieve"])
 		if (!P || P.loc != src || !usr.can_use_hands() || !usr.Adjacent(src))
-			if(usr.Adjacent(src)) attack_hand(usr) //refresh so removed files disappear
+			if(usr.Adjacent(src))
+				attack_hand(usr)
+				to_chat(usr, SPAN_WARNING("The document you're looking for isn't in \the [src] anymore."))//refresh so removed files disappear
 			return
 		close_browser(usr, "filingcabinet") // Close the menu
 		usr.put_in_hands(P)

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -135,12 +135,13 @@
 			"completed" = document_report.completed,
 			"overdose" = document_report.data?.overdose,
 			"overall_value" = chemical_value,
-			"document_type" = (document_spliced[1] == "Contract" ? 1 : (document_spliced[1] == "Synthesis" ? 2 : 3)),
+			"document_type" = (doc_type_string == "Contract" ? 1 : (doc_type_string == "Synthesis" ? 2 : 3)),
 			"properties_list" = properties_codes_level,
 		))
 	if(!length(data["paper_data"]))
 		data["paper_data"] = null
 	return data
+
 /obj/structure/filingcabinet/research/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	if(..())
 		return
@@ -162,33 +163,58 @@
 		var/obj/item/paper/research_notes/note = attacked_item
 		if(note.note_type != "synthesis")
 			return
-		var/obj/item/new_report = note.convert_to_chem_report()
+		var/obj/item/paper/research_report/new_report = note.convert_to_chem_report()
 		if(!new_report)
+			to_chat(user, SPAN_WARNING("The notes could not be converted into a valid report."))
 			return
-		attacked_item = new_report
-		if(is_type_in_list(attacked_item, allowed_types))
-			var/obj/item/paper/research_report/document_report = attacked_item
-			if(document_report.valid_report && !isnull(document_report.data))
-				var/duplicate = FALSE
-				for(var/obj/item/paper/research_report/document_inside in paper_contents)
-					if(document_inside.data?.id == document_report.data?.id)
-						duplicate = TRUE
-						to_chat(user, SPAN_WARNING("You try to slot a document into a sorting tray, but there is identical document already in the array."))
-						break
-				if(duplicate)
-					return
-				to_chat(user, SPAN_NOTICE("You slot a document into a sorting tray, and [src] whirs to life."))
-				if(attacked_item.loc == user)
-					user.drop_inv_item_to_loc(attacked_item, src)
-				else
-					attacked_item.forceMove(src)
-				LAZYADD(paper_contents, attacked_item)
-				icon_state = "[initial(icon_state)]-open"
-				addtimer(CALLBACK(src, "reset_icon"), 0.5 SECONDS)
-				update_static_data_for_all_viewers()
-			else
-				to_chat(user, SPAN_WARNING("You try to slot a document into a sorting tray, but is refused."))
+		if(!new_report.valid_report || isnull(new_report.data))
+			to_chat(user, SPAN_WARNING("You try to slot the converted notes into a sorting tray, but they are refused."))
+			qdel(new_report) //clean up failed instance
+			return
+		var/duplicate = FALSE
+		for(var/obj/item/paper/research_report/document_inside in paper_contents)
+			if(document_inside.data?.id == new_report.data?.id)
+				duplicate = TRUE
+				break
+		if(duplicate)
+			to_chat(user, SPAN_WARNING("You try to slot the document into a sorting tray, but there is an identical document already in the array."))
+			qdel(new_report)
+			return
+
+		to_chat(user, SPAN_NOTICE("You slot a document into a sorting tray, and [src] whirs to life."))
+		qdel(note)
+		new_report.forceMove(src)
+		LAZYADD(paper_contents, new_report)
+		icon_state = "[initial(icon_state)]-open"
+		addtimer(CALLBACK(src, "reset_icon"), 0.5 SECONDS)
+		update_static_data_for_all_viewers()
+		return
+
+	if(is_type_in_list(attacked_item, allowed_types))
+		var/obj/item/paper/research_report/document_report = attacked_item
+		if(document_report.valid_report && !isnull (document_report.data))
+			var/duplicate = FALSE
+			for(var/obj/item/paper/research_report/document_inside in paper_contents)
+				if(document_inside.data?.id == document_report.data?.id)
+					duplicate = TRUE
+					to_chat(user, SPAN_WARNING("You try to slot a document into a sorting tray, but there is an identical document already in the array."))
+					break
+			if(duplicate)
 				return
+			to_chat(user, SPAN_NOTICE("You slot a document into a sorting tray, and [src] whirs to life."))
+			if(attacked_item.loc == user)
+				user.drop_inv_item_to_loc(attacked_item, src)
+			else
+				attacked_item.forceMove(src)
+			LAZYADD(paper_contents, attacked_item)
+			icon_state = "[initial(icon_state)]-open"
+			addtimer(CALLBACK(src, "reset_icon"),0.5 SECONDS)
+			update_static_data_for_all_viewers()
+			return
+		else
+			to_chat(user, SPAN_WARNING("You try to slot a document into a sorting tray, but it is refused."))
+			return
+
 /*
  * Security Record Cabinets
  */

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -220,32 +220,32 @@
  * Security Record Cabinets
  */
 /obj/structure/filingcabinet/security
-	var/virgin = TRUE
+	var/is_unopened = TRUE
 
 
 /obj/structure/filingcabinet/security/proc/populate()
-	if(!virgin)
+	if(!is_unopened)
 		return
-	virgin = FALSE
+	is_unopened = FALSE
 	if(!GLOB.data_core?.general)
 		return
-	for(var/datum/data/record/G in GLOB.data_core.general)
-		var/datum/data/record/S
-		for(var/datum/data/record/R in GLOB.data_core.security)
-			if((R.fields["name"] == G.fields["name"] || R.fields["id"] == G.fields["id"]))
-				S = R
+	for(var/datum/data/record/general_record in GLOB.data_core.general)
+		var/datum/data/record/security_record
+		for(var/datum/data/record/security_cabinet_record in GLOB.data_core.security)
+			if((security_cabinet_record.fields["name"] == general_record.fields["name"] || security_cabinet_record.fields["id"] == general_record.fields["id"]))
+				security_record = security_cabinet_record
 				break
-		if(S)
-			var/obj/item/paper/P = new /obj/item/paper(src)
-			P.info = "<CENTER><B>Security Record</B></CENTER><BR>"
-			P.info += "Name: [G.fields["name"]] ID: [G.fields["id"]]<BR>\nSex: [G.fields["sex"]]<BR>\nAge: [G.fields["age"]]<BR>\nPhysical Status: [G.fields["p_stat"]]<BR>\nMental Status: [G.fields["m_stat"]]<BR>"
-			P.info += "<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\nCriminal Status: [S.fields["criminal"]]<BR>\n<BR>\nIncidents: [S.fields["incident"]]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>"
+		if(security_record)
+			var/obj/item/paper/security_record_paper = new /obj/item/paper(src)
+			security_record_paper.info = "<CENTER><B>Security Record</B></CENTER><BR>"
+			security_record_paper.info += "Name: [general_record.fields["name"]] ID: [general_record.fields["id"]]<BR>\nSex: [general_record.fields["sex"]]<BR>\nAge: [general_record.fields["age"]]<BR>\nPhysical Status: [general_record.fields["p_stat"]]<BR>\nMental Status: [general_record.fields["m_stat"]]<BR>"
+			security_record_paper.info += "<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\nCriminal Status: [security_record.fields["criminal"]]<BR>\n<BR>\nIncidents: [security_record.fields["incident"]]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>"
 			var/counter = 1
-			while(!isnull(S.fields["com_[counter]"])) //prevent infin looping
-				P.info += "[S.fields["com_[counter]"]]<BR>"
+			while(!isnull(security_record.fields["com_[counter]"])) //prevent infin looping
+				security_record_paper.info += "[security_record.fields["com_[counter]"]]<BR>"
 				counter++
-			P.info += "</TT>"
-			P.name = "Security Record ([G.fields["name"]])"
+			security_record_paper.info += "</TT>"
+			security_record_paper.name = "Security Record ([general_record.fields["name"]])"
 
 /obj/structure/filingcabinet/security/attack_hand(mob/user)
 	populate()
@@ -255,31 +255,31 @@
  * Medical Record Cabinets
  */
 /obj/structure/filingcabinet/medical
-	var/virgin = TRUE
+	var/is_unopened = TRUE
 
 /obj/structure/filingcabinet/medical/proc/populate()
-	if(!virgin)
+	if(!is_unopened)
 		return
-	virgin = FALSE
+	is_unopened = FALSE
 	if(!GLOB.data_core?.general)
 		return
-	for(var/datum/data/record/G in GLOB.data_core.general)
-		var/datum/data/record/M
-		for(var/datum/data/record/R as anything in GLOB.data_core.medical)
-			if((R.fields["name"] == G.fields["name"] || R.fields["id"] == G.fields["id"]))
-				M = R
+	for(var/datum/data/record/general_record in GLOB.data_core.general)
+		var/datum/data/record/medical_record
+		for(var/datum/data/record/medical_cabinet_record as anything in GLOB.data_core.medical)
+			if((medical_cabinet_record.fields["name"] == general_record.fields["name"] || medical_cabinet_record.fields["id"] == general_record.fields["id"]))
+				medical_record = medical_cabinet_record
 				break
-		if(M)
-			var/obj/item/paper/P = new /obj/item/paper(src)
-			P.info = "<CENTER><B>Medical Record</B></CENTER><BR>"
-			P.info += "Name: [G.fields["name"]] ID: [G.fields["id"]]<BR>\nSex: [G.fields["sex"]]<BR>\nAge: [G.fields["age"]]<BR>\nPhysical Status: [G.fields["p_stat"]]<BR>\nMental Status: [G.fields["m_stat"]]<BR>"
-			P.info += "<BR>\n<CENTER><B>Medical Data</B></CENTER><BR>\nBlood Type: [M.fields["blood_type"]]<BR>\n<BR>\nMinor Disabilities: [M.fields["minor_disability"]]<BR>\nDetails: [M.fields["minor_disability_details"]]<BR>\n<BR>\nMajor Disabilities: [M.fields["major_disability"]]<BR>\nDetails: [M.fields["major_disability_details"]]<BR>\n<BR>\nAllergies: [M.fields["allergies"]]<BR>\nDetails: [M.fields["allergies_details"]]<BR>\n<BR>\nCurrent Diseases: [M.fields["diseases"]] (per disease info placed in log/comment section)<BR>\nDetails: [M.fields["diseases_details"]]<BR>\n<BR>\nImportant Notes:<BR>\n\t[M.fields["notes"]]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>"
+		if(medical_record)
+			var/obj/item/paper/medical_record_paper = new /obj/item/paper(src)
+			medical_record_paper.info = "<CENTER><B>Medical Record</B></CENTER><BR>"
+			medical_record_paper.info += "Name: [general_record.fields["name"]] ID: [general_record.fields["id"]]<BR>\nSex: [general_record.fields["sex"]]<BR>\nAge: [general_record.fields["age"]]<BR>\nPhysical Status: [general_record.fields["p_stat"]]<BR>\nMental Status: [general_record.fields["m_stat"]]<BR>"
+			medical_record_paper.info += "<BR>\n<CENTER><B>Medical Data</B></CENTER><BR>\nBlood Type: [medical_record.fields["blood_type"]]<BR>\n<BR>\nMinor Disabilities: [medical_record.fields["minor_disability"]]<BR>\nDetails: [medical_record.fields["minor_disability_details"]]<BR>\n<BR>\nMajor Disabilities: [medical_record.fields["major_disability"]]<BR>\nDetails: [medical_record.fields["major_disability_details"]]<BR>\n<BR>\nAllergies: [medical_record.fields["allergies"]]<BR>\nDetails: [medical_record.fields["allergies_details"]]<BR>\n<BR>\nCurrent Diseases: [medical_record.fields["diseases"]] (per disease info placed in log/comment section)<BR>\nDetails: [medical_record.fields["diseases_details"]]<BR>\n<BR>\nImportant Notes:<BR>\n\t[medical_record.fields["notes"]]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>"
 			var/counter = 1
-			while (!isnull(M.fields["com_[counter]"])) //prevent infin looping
-				P.info += "[M.fields["com_[counter]"]]<BR>"
+			while (!isnull(medical_record.fields["com_[counter]"])) //prevent infin looping
+				medical_record_paper.info += "[medical_record.fields["com_[counter]"]]<BR>"
 				counter++
-			P.info += "</TT>"
-			P.name = "Medical Record ([G.fields["name"]])"
+			medical_record_paper.info += "</TT>"
+			medical_record_paper.name = "Medical Record ([general_record.fields["name"]])"
 
 /obj/structure/filingcabinet/medical/attack_hand(mob/user)
 	populate()

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -64,7 +64,7 @@
 		to_chat(user, SPAN_NOTICE("\The [src] is empty."))
 		return
 
-	user.set_interaction(src) //hello??? dummy comment because my commit got lost in the cloud???
+	user.set_interaction(src)
 	var/dat = "<center><table>"
 	for(var/obj/item/stored_document in src)
 		dat += "<tr><td><a href='byond://?src=\ref[src];retrieve=\ref[stored_document]'>[stored_document.name]</a></td></tr>"

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -53,8 +53,7 @@
 		to_chat(user, SPAN_NOTICE("You put [attacking_item] in [src]."))
 		if(user.drop_inv_item_to_loc(attacking_item, src))
 			icon_state = "[initial(icon_state)]-open"
-			sleep(5)
-			icon_state = initial(icon_state)
+			addtimer(CALLBACK(src, "reset_icon"),0.5 SECONDS)
 			updateUsrDialog()
 		return
 	to_chat(user, SPAN_NOTICE("You can't put [attacking_item] in [src]!"))

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -160,37 +160,36 @@
 	if(HAS_TRAIT(attacked_item, TRAIT_TOOL_WRENCH))
 		return ..()
 	if(istype(attacked_item, /obj/item/paper/research_notes))
-		var/obj/item/paper/research_notes/note = attacked_item
-		if(note.note_type != "synthesis")
-			to_chat(user, SPAN_WARNING("You try to slot the notes into a sorting tray, but they are refused."))
-			return
-		var/obj/item/paper/research_report/new_report = note.convert_to_chem_report()
-		if(!new_report)
-			to_chat(user, SPAN_WARNING("The notes could not be converted into a valid report."))
-			return
-		if(!new_report.valid_report || isnull(new_report.data))
-			to_chat(user, SPAN_WARNING("You try to slot the converted notes into a sorting tray, but they are refused."))
-			qdel(new_report) //clean up failed instance
-			return
-		var/duplicate = FALSE
-		for(var/obj/item/paper/research_report/document_inside in paper_contents)
-			if(document_inside.data?.id == new_report.data?.id)
-				duplicate = TRUE
-				break
-		if(duplicate)
-			to_chat(user, SPAN_WARNING("You try to slot the document into a sorting tray, but there is an identical document already in the array."))
-			qdel(new_report)
-			return
+		if(istype(attacked_item, /obj/item/paper/research_notes/unique))
+			var/obj/item/paper/research_notes/unique/unique_note = attacked_item
+			var/obj/item/paper/research_report/new_report = unique_note.convert_to_chem_report()
+			if(!new_report)
+				to_chat(user, SPAN_WARNING("The notes could not be converted into a valid report."))
+				return
+			if(!new_report.valid_report || isnull(new_report.data))
+				to_chat(user, SPAN_WARNING("You try to slot the converted notes into a sorting tray, but they are refused."))
+				qdel(new_report) //clean up failed instance
+				return
+			var/duplicate = FALSE
+			for(var/obj/item/paper/research_report/document_inside in paper_contents)
+				if(document_inside.data?.id == new_report.data?.id)
+					duplicate = TRUE
+					break
+			if(duplicate)
+				to_chat(user, SPAN_WARNING("You try to slot the document into a sorting tray, but there is an identical document already in the array."))
+				qdel(new_report)
+				return
 
-		to_chat(user, SPAN_NOTICE("You slot a document into a sorting tray, and [src] whirs to life."))
-		qdel(note)
-		new_report.forceMove(src)
-		LAZYADD(paper_contents, new_report)
-		icon_state = "[initial(icon_state)]-open"
-		addtimer(CALLBACK(src, "reset_icon"), 0.5 SECONDS)
-		update_static_data_for_all_viewers()
+			to_chat(user, SPAN_NOTICE("You slot a document into a sorting tray, and [src] whirs to life."))
+			qdel(unique_note)
+			new_report.forceMove(src)
+			LAZYADD(paper_contents, new_report)
+			icon_state = "[initial(icon_state)]-open"
+			addtimer(CALLBACK(src, "reset_icon"), 0.5 SECONDS)
+			update_static_data_for_all_viewers()
+			return
+		to_chat(user, SPAN_WARNING("You try to slot the note into a sorting tray, but it is refused."))
 		return
-
 	if(is_type_in_list(attacked_item, allowed_types))
 		var/obj/item/paper/research_report/document_report = attacked_item
 		if(!document_report.valid_report || isnull(document_report.data))

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -64,7 +64,7 @@
 		to_chat(user, SPAN_NOTICE("\The [src] is empty."))
 		return
 
-	user.set_interaction(src)
+	user.set_interaction(src) //hello??? dummy comment because my commit got lost in the cloud???
 	var/dat = "<center><table>"
 	for(var/obj/item/stored_document in src)
 		dat += "<tr><td><a href='byond://?src=\ref[src];retrieve=\ref[stored_document]'>[stored_document.name]</a></td></tr>"

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -139,7 +139,7 @@
 			"properties_list" = properties_codes_level,
 		))
 	if(!length(data["paper_data"]))
-		data["paper_data"] = null
+		data["paper_data"] = list()
 	return data
 
 /obj/structure/filingcabinet/research/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -76,21 +76,23 @@
 	return
 
 /obj/structure/filingcabinet/Topic(href, href_list)
-	. = ..()
-	if(.)
+	if(..())
+		return
+	if(!usr.Adjacent(src))
+		close_browser(usr, "filingcabinet")
 		return
 	if(href_list["retrieve"])
+		var/obj/item/P = locate(href_list["retrieve"])
+		if (!P || P.loc != src || !usr.can_use_hands() || !usr.Adjacent(src))
+			if(usr.Adjacent(src)) attack_hand(usr) //refresh so removed files disappear
+			return
 		close_browser(usr, "filingcabinet") // Close the menu
-
-		//var/retrieveindex = text2num(href_list["retrieve"])
-		var/obj/item/P = locate(href_list["retrieve"])//contents[retrieveindex]
-		if(istype(P) && (P.loc == src) && src.Adjacent(usr))
-			usr.put_in_hands(P)
-			updateUsrDialog()
-			icon_state = "[initial(icon_state)]-open"
-			spawn(0)
-				sleep(5)
-				icon_state = initial(icon_state)
+		usr.put_in_hands(P)
+		updateUsrDialog()
+		icon_state = "[initial(icon_state)]-open"
+		addtimer(CALLBACK(src, .proc/reset_icon),5)
+/obj/structure/filingcabinet/proc/reset_icon()
+	icon_state = initial(icon_state)
 
 /obj/structure/filingcabinet/research
 	name = "automated sorting cabinet"

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -49,19 +49,17 @@
 
 /obj/structure/filingcabinet/attackby(obj/item/P as obj, mob/user as mob)
 	if(HAS_TRAIT(P, TRAIT_TOOL_WRENCH))
-		. = ..()
-	else
-		for(var/allowed_type in allowed_types)
-			if(istype(P, allowed_type))
-				to_chat(user, SPAN_NOTICE("You put [P] in [src]."))
-				if(user.drop_inv_item_to_loc(P, src))
-					icon_state = "[initial(icon_state)]-open"
-					sleep(5)
-					icon_state = initial(icon_state)
-					updateUsrDialog()
-					break
-			else
-				to_chat(user, SPAN_NOTICE("You can't put [P] in [src]!"))
+		return ..()
+	for(var/allowed_type in allowed_types)
+		if(istype(P, allowed_type))
+			to_chat(user, SPAN_NOTICE("You put [P] in [src]."))
+			if(user.drop_inv_item_to_loc(P, src))
+				icon_state = "[initial(icon_state)]-open"
+				sleep(5)
+				icon_state = initial(icon_state)
+				updateUsrDialog()
+			return
+	to_chat(user, SPAN_NOTICE("You can't put [P] in [src]!"))
 
 /obj/structure/filingcabinet/attack_hand(mob/user as mob)
 	if(length(contents) <= 0)

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -41,33 +41,33 @@
 
 /obj/structure/filingcabinet/Initialize()
 	. = ..()
-	for(var/obj/item/I in loc)
-		if(is_type_in_list(I, allowed_types))
-			I.forceMove(src)
+	for(var/obj/current_obj in loc)
+		if(is_type_in_list(current_obj, allowed_types))
+			current_obj.forceMove(src)
 
 
-/obj/structure/filingcabinet/attackby(obj/item/P as obj, mob/user as mob)
-	if(HAS_TRAIT(P, TRAIT_TOOL_WRENCH))
+/obj/structure/filingcabinet/attackby(obj/item/attacking_item, mob/user)
+	if(HAS_TRAIT(attacking_item, TRAIT_TOOL_WRENCH))
 		return ..()
-	if(is_type_in_list(P, allowed_types))
-		to_chat(user, SPAN_NOTICE("You put [P] in [src]."))
-		if(user.drop_inv_item_to_loc(P, src))
+	if(is_type_in_list(attacking_item, allowed_types))
+		to_chat(user, SPAN_NOTICE("You put [attacking_item] in [src]."))
+		if(user.drop_inv_item_to_loc(attacking_item, src))
 			icon_state = "[initial(icon_state)]-open"
 			sleep(5)
 			icon_state = initial(icon_state)
 			updateUsrDialog()
 		return
-	to_chat(user, SPAN_NOTICE("You can't put [P] in [src]!"))
+	to_chat(user, SPAN_NOTICE("You can't put [attacking_item] in [src]!"))
 
-/obj/structure/filingcabinet/attack_hand(mob/user as mob)
+/obj/structure/filingcabinet/attack_hand(mob/user)
 	if(length(contents) <= 0)
 		to_chat(user, SPAN_NOTICE("\The [src] is empty."))
 		return
 
 	user.set_interaction(src)
 	var/dat = "<center><table>"
-	for(var/obj/item/P in src)
-		dat += "<tr><td><a href='byond://?src=\ref[src];retrieve=\ref[P]'>[P.name]</a></td></tr>"
+	for(var/obj/item/stored_document in src)
+		dat += "<tr><td><a href='byond://?src=\ref[src];retrieve=\ref[stored_document]'>[stored_document.name]</a></td></tr>"
 	dat += "</table></center>"
 	show_browser(user, dat, name, "filingcabinet", width = 350, height = 300)
 
@@ -78,14 +78,14 @@
 		close_browser(usr, "filingcabinet")
 		return
 	if(href_list["retrieve"])
-		var/obj/item/P = locate(href_list["retrieve"])
-		if (!P || P.loc != src || !usr.can_use_hands() || !usr.Adjacent(src))
+		var/obj/item/filed_document = locate(href_list["retrieve"])
+		if (!filed_document || filed_document.loc != src || !usr.can_use_hands() || !usr.Adjacent(src))
 			if(usr.Adjacent(src))
 				attack_hand(usr)
 				to_chat(usr, SPAN_WARNING("The document you're looking for isn't in \the [src] anymore."))//refresh so removed files disappear
 			return
 		close_browser(usr, "filingcabinet") // Close the menu
-		usr.put_in_hands(P)
+		usr.put_in_hands(filed_document)
 		updateUsrDialog()
 		icon_state = "[initial(icon_state)]-open"
 		addtimer(CALLBACK(src, "reset_icon"),0.5 SECONDS)

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -42,23 +42,21 @@
 /obj/structure/filingcabinet/Initialize()
 	. = ..()
 	for(var/obj/item/I in loc)
-		for(var/allowed_type in allowed_types)
-			if(istype(I, allowed_type))
-				I.forceMove(src)
+		if(is_type_in_list(I, allowed_types))
+			I.forceMove(src)
 
 
 /obj/structure/filingcabinet/attackby(obj/item/P as obj, mob/user as mob)
 	if(HAS_TRAIT(P, TRAIT_TOOL_WRENCH))
 		return ..()
-	for(var/allowed_type in allowed_types)
-		if(istype(P, allowed_type))
-			to_chat(user, SPAN_NOTICE("You put [P] in [src]."))
-			if(user.drop_inv_item_to_loc(P, src))
-				icon_state = "[initial(icon_state)]-open"
-				sleep(5)
-				icon_state = initial(icon_state)
-				updateUsrDialog()
-			return
+	if(is_type_in_list(P, allowed_types))
+		to_chat(user, SPAN_NOTICE("You put [P] in [src]."))
+		if(user.drop_inv_item_to_loc(P, src))
+			icon_state = "[initial(icon_state)]-open"
+			sleep(5)
+			icon_state = initial(icon_state)
+			updateUsrDialog()
+		return
 	to_chat(user, SPAN_NOTICE("You can't put [P] in [src]!"))
 
 /obj/structure/filingcabinet/attack_hand(mob/user as mob)
@@ -72,8 +70,6 @@
 		dat += "<tr><td><a href='byond://?src=\ref[src];retrieve=\ref[P]'>[P.name]</a></td></tr>"
 	dat += "</table></center>"
 	show_browser(user, dat, name, "filingcabinet", width = 350, height = 300)
-
-	return
 
 /obj/structure/filingcabinet/Topic(href, href_list)
 	if(..())
@@ -92,9 +88,11 @@
 		usr.put_in_hands(P)
 		updateUsrDialog()
 		icon_state = "[initial(icon_state)]-open"
-		addtimer(CALLBACK(src, .proc/reset_icon),5)
+		addtimer(CALLBACK(src, "reset_icon"),0.5 SECONDS)
 /obj/structure/filingcabinet/proc/reset_icon()
 	icon_state = initial(icon_state)
+
+/* Automated Research Sorting Cabinet*/
 
 /obj/structure/filingcabinet/research
 	name = "automated sorting cabinet"
@@ -115,6 +113,7 @@
 
 /obj/structure/filingcabinet/research/ui_static_data(mob/user)
 	var/list/data = list()
+	data["paper_data"] = list()
 	for(var/document_obj in paper_contents)
 		var/obj/item/paper/research_report/document_report = document_obj
 		var/chemical_value = 0
@@ -125,15 +124,16 @@
 				//this should give us the absolutely rough estimate of how good paper is, value var on properties are a mess, so nada.
 				chemical_value += properties_document.level * attitude
 				properties_codes_level += list(list(
-				"code" = properties_document.code,
-				"level" = properties_document.level))
-		chemical_value += document_report.data.overdose / 5
+					"code" = properties_document.code,
+					"level" = properties_document.level))
+		chemical_value += ((document_report.data?.overdose || 0) / 5)
 		var/list/document_spliced = splittext(document_report.name," ")
+		var/doc_type_string = length(document_spliced) ? document_spliced[1] : ""
 		data["paper_data"] += list(list(
-			"name" = document_report.data.name,
+			"name" = document_report.data?.name,
 			"document_id" = document_report.data?.id,
 			"completed" = document_report.completed,
-			"overdose" = document_report.data.overdose,
+			"overdose" = document_report.data?.overdose,
 			"overall_value" = chemical_value,
 			"document_type" = (document_spliced[1] == "Contract" ? 1 : (document_spliced[1] == "Synthesis" ? 2 : 3)),
 			"properties_list" = properties_codes_level,
@@ -142,7 +142,8 @@
 		data["paper_data"] = null
 	return data
 /obj/structure/filingcabinet/research/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
-	. = ..()
+	if(..())
+		return
 	switch(action)
 		if("take_out_document")
 			for(var/obj/item/paper/research_report/document_report as anything in paper_contents)
@@ -152,7 +153,7 @@
 				LAZYREMOVE(paper_contents, document_report)
 				update_static_data_for_all_viewers()
 				return TRUE
-
+	return FALSE
 
 /obj/structure/filingcabinet/research/attackby(obj/item/attacked_item, mob/user)
 	if(HAS_TRAIT(attacked_item, TRAIT_TOOL_WRENCH))
@@ -161,94 +162,101 @@
 		var/obj/item/paper/research_notes/note = attacked_item
 		if(note.note_type != "synthesis")
 			return
-		attacked_item = note.convert_to_chem_report()
-	for(var/allowed_type in allowed_types)
-		if(istype(attacked_item, allowed_type))
+		var/obj/item/new_report = note.convert_to_chem_report()
+		if(!new_report)
+			return
+		attacked_item = new_report
+		if(is_type_in_list(attacked_item, allowed_types))
 			var/obj/item/paper/research_report/document_report = attacked_item
 			if(document_report.valid_report && !isnull(document_report.data))
 				var/duplicate = FALSE
 				for(var/obj/item/paper/research_report/document_inside in paper_contents)
-					if(document_inside.data.id == document_report.data.id)
+					if(document_inside.data?.id == document_report.data?.id)
 						duplicate = TRUE
 						to_chat(user, SPAN_WARNING("You try to slot a document into a sorting tray, but there is identical document already in the array."))
 						break
 				if(duplicate)
 					return
 				to_chat(user, SPAN_NOTICE("You slot a document into a sorting tray, and [src] whirs to life."))
-				user.drop_inv_item_to_loc(attacked_item, src)
+				if(attacked_item.loc == user)
+					user.drop_inv_item_to_loc(attacked_item, src)
+				else
+					attacked_item.forceMove(src)
 				LAZYADD(paper_contents, attacked_item)
-				icon_state = initial(icon_state)+"-open"
-				addtimer(VARSET_CALLBACK(src, icon_state, initial(icon_state)), 0.5 SECONDS)
+				icon_state = "[initial(icon_state)]-open"
+				addtimer(CALLBACK(src, "reset_icon"), 0.5 SECONDS)
 				update_static_data_for_all_viewers()
 			else
 				to_chat(user, SPAN_WARNING("You try to slot a document into a sorting tray, but is refused."))
 				return
-
 /*
  * Security Record Cabinets
  */
 /obj/structure/filingcabinet/security
-	var/virgin = 1
+	var/virgin = TRUE
 
 
 /obj/structure/filingcabinet/security/proc/populate()
-	if(virgin)
-		for(var/datum/data/record/G in GLOB.data_core.general)
-			var/datum/data/record/S
-			for(var/datum/data/record/R in GLOB.data_core.security)
-				if((R.fields["name"] == G.fields["name"] || R.fields["id"] == G.fields["id"]))
-					S = R
-					break
-			if(S)
-				var/obj/item/paper/P = new /obj/item/paper(src)
-				P.info = "<CENTER><B>Security Record</B></CENTER><BR>"
-				P.info += "Name: [G.fields["name"]] ID: [G.fields["id"]]<BR>\nSex: [G.fields["sex"]]<BR>\nAge: [G.fields["age"]]<BR>\nPhysical Status: [G.fields["p_stat"]]<BR>\nMental Status: [G.fields["m_stat"]]<BR>"
-				P.info += "<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\nCriminal Status: [S.fields["criminal"]]<BR>\n<BR>\nIncidents: [S.fields["incident"]]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>"
-				var/counter = 1
-				while(S.fields["com_[counter]"])
-					P.info += "[S.fields["com_[counter]"]]<BR>"
-					counter++
-				P.info += "</TT>"
-				P.name = "Security Record ([G.fields["name"]])"
-			virgin = 0 //tabbing here is correct- it's possible for people to try and use it
-						//before the records have been generated, so we do this inside the loop.
+	if(!virgin)
+		return
+	virgin = FALSE
+	if(!GLOB.data_core?.general)
+		return
+	for(var/datum/data/record/G in GLOB.data_core.general)
+		var/datum/data/record/S
+		for(var/datum/data/record/R in GLOB.data_core.security)
+			if((R.fields["name"] == G.fields["name"] || R.fields["id"] == G.fields["id"]))
+				S = R
+				break
+		if(S)
+			var/obj/item/paper/P = new /obj/item/paper(src)
+			P.info = "<CENTER><B>Security Record</B></CENTER><BR>"
+			P.info += "Name: [G.fields["name"]] ID: [G.fields["id"]]<BR>\nSex: [G.fields["sex"]]<BR>\nAge: [G.fields["age"]]<BR>\nPhysical Status: [G.fields["p_stat"]]<BR>\nMental Status: [G.fields["m_stat"]]<BR>"
+			P.info += "<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\nCriminal Status: [S.fields["criminal"]]<BR>\n<BR>\nIncidents: [S.fields["incident"]]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>"
+			var/counter = 1
+			while(!isnull(S.fields["com_[counter]"])) //prevent infin looping
+				P.info += "[S.fields["com_[counter]"]]<BR>"
+				counter++
+			P.info += "</TT>"
+			P.name = "Security Record ([G.fields["name"]])"
 
-/obj/structure/filingcabinet/security/attack_hand()
+/obj/structure/filingcabinet/security/attack_hand(mob/user)
 	populate()
-	..()
+	return ..()
 
 /*
  * Medical Record Cabinets
  */
 /obj/structure/filingcabinet/medical
-	var/virgin = 1
+	var/virgin = TRUE
 
 /obj/structure/filingcabinet/medical/proc/populate()
-	if(virgin)
-		for(var/datum/data/record/G in GLOB.data_core.general)
-			var/datum/data/record/M
-			for(var/datum/data/record/R as anything in GLOB.data_core.medical)
-				if((R.fields["name"] == G.fields["name"] || R.fields["id"] == G.fields["id"]))
-					M = R
-					break
-			if(M)
-				var/obj/item/paper/P = new /obj/item/paper(src)
-				P.info = "<CENTER><B>Medical Record</B></CENTER><BR>"
-				P.info += "Name: [G.fields["name"]] ID: [G.fields["id"]]<BR>\nSex: [G.fields["sex"]]<BR>\nAge: [G.fields["age"]]<BR>\nPhysical Status: [G.fields["p_stat"]]<BR>\nMental Status: [G.fields["m_stat"]]<BR>"
+	if(!virgin)
+		return
+	virgin = FALSE
+	if(!GLOB.data_core?.general)
+		return
+	for(var/datum/data/record/G in GLOB.data_core.general)
+		var/datum/data/record/M
+		for(var/datum/data/record/R as anything in GLOB.data_core.medical)
+			if((R.fields["name"] == G.fields["name"] || R.fields["id"] == G.fields["id"]))
+				M = R
+				break
+		if(M)
+			var/obj/item/paper/P = new /obj/item/paper(src)
+			P.info = "<CENTER><B>Medical Record</B></CENTER><BR>"
+			P.info += "Name: [G.fields["name"]] ID: [G.fields["id"]]<BR>\nSex: [G.fields["sex"]]<BR>\nAge: [G.fields["age"]]<BR>\nPhysical Status: [G.fields["p_stat"]]<BR>\nMental Status: [G.fields["m_stat"]]<BR>"
+			P.info += "<BR>\n<CENTER><B>Medical Data</B></CENTER><BR>\nBlood Type: [M.fields["blood_type"]]<BR>\n<BR>\nMinor Disabilities: [M.fields["minor_disability"]]<BR>\nDetails: [M.fields["minor_disability_details"]]<BR>\n<BR>\nMajor Disabilities: [M.fields["major_disability"]]<BR>\nDetails: [M.fields["major_disability_details"]]<BR>\n<BR>\nAllergies: [M.fields["allergies"]]<BR>\nDetails: [M.fields["allergies_details"]]<BR>\n<BR>\nCurrent Diseases: [M.fields["diseases"]] (per disease info placed in log/comment section)<BR>\nDetails: [M.fields["diseases_details"]]<BR>\n<BR>\nImportant Notes:<BR>\n\t[M.fields["notes"]]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>"
+			var/counter = 1
+			while (!isnull(M.fields["com_[counter]"])) //prevent infin looping
+				P.info += "[M.fields["com_[counter]"]]<BR>"
+				counter++
+			P.info += "</TT>"
+			P.name = "Medical Record ([G.fields["name"]])"
 
-				P.info += "<BR>\n<CENTER><B>Medical Data</B></CENTER><BR>\nBlood Type: [M.fields["blood_type"]]<BR>\n<BR>\nMinor Disabilities: [M.fields["minor_disability"]]<BR>\nDetails: [M.fields["minor_disability_details"]]<BR>\n<BR>\nMajor Disabilities: [M.fields["major_disability"]]<BR>\nDetails: [M.fields["major_disability_details"]]<BR>\n<BR>\nAllergies: [M.fields["allergies"]]<BR>\nDetails: [M.fields["allergies_details"]]<BR>\n<BR>\nCurrent Diseases: [M.fields["diseases"]] (per disease info placed in log/comment section)<BR>\nDetails: [M.fields["diseases_details"]]<BR>\n<BR>\nImportant Notes:<BR>\n\t[M.fields["notes"]]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>"
-				var/counter = 1
-				while(M.fields["com_[counter]"])
-					P.info += "[M.fields["com_[counter]"]]<BR>"
-					counter++
-				P.info += "</TT>"
-				P.name = "Medical Record ([G.fields["name"]])"
-			virgin = 0 //tabbing here is correct- it's possible for people to try and use it
-						//before the records have been generated, so we do this inside the loop.
-
-/obj/structure/filingcabinet/medical/attack_hand()
+/obj/structure/filingcabinet/medical/attack_hand(mob/user)
 	populate()
-	..()
+	return ..()
 
 /*
  * Hydroponics Cabinets

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -162,6 +162,7 @@
 	if(istype(attacked_item, /obj/item/paper/research_notes))
 		var/obj/item/paper/research_notes/note = attacked_item
 		if(note.note_type != "synthesis")
+			to_chat(user, SPAN_WARNING("You try to slot the notes into a sorting tray, but they are refused."))
 			return
 		var/obj/item/paper/research_report/new_report = note.convert_to_chem_report()
 		if(!new_report)
@@ -192,28 +193,29 @@
 
 	if(is_type_in_list(attacked_item, allowed_types))
 		var/obj/item/paper/research_report/document_report = attacked_item
-		if(document_report.valid_report && !isnull (document_report.data))
-			var/duplicate = FALSE
-			for(var/obj/item/paper/research_report/document_inside in paper_contents)
-				if(document_inside.data?.id == document_report.data?.id)
-					duplicate = TRUE
-					to_chat(user, SPAN_WARNING("You try to slot a document into a sorting tray, but there is an identical document already in the array."))
-					break
-			if(duplicate)
-				return
-			to_chat(user, SPAN_NOTICE("You slot a document into a sorting tray, and [src] whirs to life."))
-			if(attacked_item.loc == user)
-				user.drop_inv_item_to_loc(attacked_item, src)
-			else
-				attacked_item.forceMove(src)
-			LAZYADD(paper_contents, attacked_item)
-			icon_state = "[initial(icon_state)]-open"
-			addtimer(CALLBACK(src, "reset_icon"),0.5 SECONDS)
-			update_static_data_for_all_viewers()
+		if(!document_report.valid_report || isnull(document_report.data))
+			to_chat (user, SPAN_WARNING("You try to slot a document into a sorting tray, but it is refused."))
 			return
+		var/duplicate = FALSE
+		for(var/obj/item/paper/research_report/document_inside in paper_contents)
+			if(document_inside.data?.id == document_report.data?.id)
+				duplicate = TRUE
+				break
+		if(duplicate)
+			to_chat(user, SPAN_WARNING("You try to slot a document into a sorting tray, but there is an identical document already in the array."))
+			return
+		to_chat(user, SPAN_NOTICE("You slot a document into a sorting tray, and [src] whirs to life."))
+		if(attacked_item.loc == user)
+			user.drop_inv_item_to_loc(attacked_item, src)
 		else
-			to_chat(user, SPAN_WARNING("You try to slot a document into a sorting tray, but it is refused."))
-			return
+			attacked_item.forceMove(src)
+		LAZYADD(paper_contents, attacked_item)
+		icon_state = "[initial(icon_state)]-open"
+		addtimer(CALLBACK(src, "reset_icon"),0.5 SECONDS)
+		update_static_data_for_all_viewers()
+		return
+	to_chat(user, SPAN_WARNING("You try to slot [attacked_item] into a sorting tray, but it is refused."))
+	return
 
 /*
  * Security Record Cabinets

--- a/code/modules/paperwork/prefab_papers.dm
+++ b/code/modules/paperwork/prefab_papers.dm
@@ -57,6 +57,8 @@ GLOBAL_REFERENCE_LIST_INDEXED(prefab_papers, /obj/item/paper/prefab, document_ti
 		to_chat(user, SPAN_WARNING("[src] has no remaining official forms!"))
 		return FALSE
 	var/chosen = tgui_input_list(usr, "What document do you need?", "Choose Document", available_documents)
+	if(!chosen)
+		return FALSE
 	var/selected = GLOB.prefab_papers[chosen].type
 	if(!user.Adjacent(src))
 		return
@@ -75,6 +77,7 @@ GLOBAL_REFERENCE_LIST_INDEXED(prefab_papers, /obj/item/paper/prefab, document_ti
 	available_categories = list(PAPER_CATEGORY_USCM)
 
 /obj/structure/filingcabinet/documentation/uscm_mp
+	icon_state = "chestdrawer"
 	available_categories = list(PAPER_CATEGORY_USCM, PAPER_CATEGORY_MP)
 
 /obj/structure/filingcabinet/documentation/liaison


### PR DESCRIPTION
# About the pull request
fixes #11955 ; one message per failed object placement
fixes #11808 ; runtime gone! wow!!!
fixes #8886 ; fixes state inheritance for lil doc cabinets

backend refactor of filing cabinet code to fix some minor bugs + improve runtime performance. see next section for more on that.

# Explain why it's good for the game
less chat spam
fix blank doc generation runtime!!! wow!!!
fixing icon consistency issues;
fixes some edge cases, namely:

- in the event a research note isn't safely converted when putting into sorting cabinet, it no longer gets "eaten" from user's hands
- patched some potential loops in medical and security record population
- garbage collecting of duplicate reports put into the automatic cabinet so less memory leakage happens
- fixed some potential spots for runtimes in the event research note data was uninitialized

# Testing Photographs and Procedure
hitting with wrench wrenches/unwrenches as expected and generates no in-chat text
hitting with a fileable item files the item and generates in-text notification you filed the item. item also correctly goes to contents
hitting with a jones politely instructs you just once in-text that you can't put a jones/rangefinder/revolver in the filing cabinet.
placing a doc in the mini cabinet in CIC doesn't cause it to become a full-sized cabinet
clicking to get a doc in the doc cabinet, then hitting "cancel" doesn't generate a blank paper and clears the window correctly.
research papers still sort and work the same
med and sec records still work the same

the UI also doesn't update in this case to reflect that but it didn't in the first place; you just can't pull anything out. server state refuses to give nonexistent paper to user when user is not adjacent. when adjacent, user gets the message the cabinet is empty. 

reflecting that in the UI/updating the UI probably will have to be done when the HTML window for filing cabinets is re-done.
# Changelog
:cl:
fix: Filing cabinets no longer give 6 messages when you try to put an unfilable item in them
fix: Half-sized document cabinets no longer shrink when you put a paper into them
/:cl: