### PR TITLE
Allow extinguishing in coastline as well as river

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1623,7 +1623,7 @@
 		visible_message(SPAN_DANGER("[src] rolls on the floor, trying to put themselves out!"),
 			SPAN_NOTICE("You stop, drop, and roll!"), null, 5)
 
-	if(istype(get_turf(src), /turf/open/gm/river) || (/obj/effect/blocker/water in loc || istype(get_turf(src), /turf/open/beach/coastline) || istype(get_turf(src), /turf/open/gm/coast))
+	if(istype(get_turf(src), /turf/open/gm/river) || (/obj/effect/blocker/water in loc) || istype(get_turf(src), /turf/open/beach/coastline) || istype(get_turf(src), /turf/open/gm/coast))
 		ExtinguishMob()
 
 	if(fire_stacks > 0)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1623,7 +1623,7 @@
 		visible_message(SPAN_DANGER("[src] rolls on the floor, trying to put themselves out!"),
 			SPAN_NOTICE("You stop, drop, and roll!"), null, 5)
 
-	if(istype(get_turf(src), /turf/open/gm/river) || (/obj/effect/blocker/water in loc))
+	if(istype(get_turf(src), /turf/open/gm/river) || (/obj/effect/blocker/water in loc || istype(get_turf(src), /turf/open/beach/coastline) || istype(get_turf(src), /turf/open/gm/coast))
 		ExtinguishMob()
 
 	if(fire_stacks > 0)

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -1086,7 +1086,7 @@
 	visible_message(SPAN_DANGER("[src] rolls on the floor, trying to put themselves out!"),
 		SPAN_NOTICE("You stop, drop, and roll!"), null, 5)
 
-	if(istype(get_turf(src), /turf/open/gm/river) || istype(get_turf(src), /turf/open/beach/coastline))
+	if(istype(get_turf(src), /turf/open/gm/river) || istype(get_turf(src), /turf/open/beach/coastline) || istype(get_turf(src), /turf/open/gm/coast))
 		ExtinguishMob()
 
 	if(fire_stacks > 0)

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -1086,7 +1086,7 @@
 	visible_message(SPAN_DANGER("[src] rolls on the floor, trying to put themselves out!"),
 		SPAN_NOTICE("You stop, drop, and roll!"), null, 5)
 
-	if(istype(get_turf(src), /turf/open/gm/river) || istype(get_turf(src), /turf/open/gm/coastline))
+	if(istype(get_turf(src), /turf/open/gm/river) || istype(get_turf(src), /turf/open/beach/coastline))
 		ExtinguishMob()
 
 	if(fire_stacks > 0)

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -1086,7 +1086,7 @@
 	visible_message(SPAN_DANGER("[src] rolls on the floor, trying to put themselves out!"),
 		SPAN_NOTICE("You stop, drop, and roll!"), null, 5)
 
-	if(istype(get_turf(src), /turf/open/gm/river) OR istype(get_turf(src), /turf/open/gm/coastline))
+	if(istype(get_turf(src), /turf/open/gm/river) || istype(get_turf(src), /turf/open/gm/coastline))
 		ExtinguishMob()
 
 	if(fire_stacks > 0)

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -1086,7 +1086,7 @@
 	visible_message(SPAN_DANGER("[src] rolls on the floor, trying to put themselves out!"),
 		SPAN_NOTICE("You stop, drop, and roll!"), null, 5)
 
-	if(istype(get_turf(src), /turf/open/gm/river))
+	if(istype(get_turf(src), /turf/open/gm/river) OR istype(get_turf(src), /turf/open/gm/coastline))
 		ExtinguishMob()
 
 	if(fire_stacks > 0)


### PR DESCRIPTION
# About the pull request

Resisting in a coastline tile will now provide the same insta-extinguish property as rivers.

# Explain why it's good for the game
Tyrargo rift in particular has a vast amount of pseudo-rivers which clearly and misleadingly contain enough water to extinguish oneself. Being able to use water to extinguish in one context but not another because of frustrating corner-water tiles stacked around eachother is counter-intuitive and extremely annoying when it leads to your death as a xeno.

This also applies for marines and fire to a lesser extent, but also for acid, which is why I don't think this is excessively xeno-sided.

I invite any mappers to state their qualms regarding balance as this may lead to a lot of extra extinguish spots. Having said that, I believe that water should function as water in appropriate contexts, of which I believe all coastline tiles to be.


# Testing Photographs and Procedure
i tested it and it worked


# Changelog

:cl:
balance: resisting in coastline tiles now extinguishes fires and acid like river tiles.
/:cl:
