### PR TITLE
Sensor tower fixes

### DIFF
--- a/code/modules/desert_dam/motion_sensor/sensortower.dm
+++ b/code/modules/desert_dam/motion_sensor/sensortower.dm
@@ -19,7 +19,7 @@
 	is_on = FALSE  //Is this damn thing on or what?
 	var/buildstate = SENSORTOWER_BUILDSTATE_BLOWTORCH //What state of building it are we on, 0-3, 1 is "broken", the default
 	var/fail_rate = 15 //% chance of failure each fail_tick check
-	var/fail_check_ticks = 50 //Check for failure every this many ticks
+	var/fail_check_ticks = 3 //Check for failure every this many ticks
 	//The sensor tower fails more often since it is experimental.
 	var/cur_tick = 0 //Tick updater
 
@@ -57,6 +57,10 @@
 		return FALSE
 	checkfailure()
 	add_xenos_to_minimap()
+
+/obj/structure/machinery/sensortower/stop_processing()
+	. = ..()
+	remove_xenos_from_minimap()
 
 /obj/structure/machinery/sensortower/proc/remove_xenos_from_minimap()
 	for(var/mob/living/carbon/xenomorph/current_xeno as anything in GLOB.living_xeno_list)

--- a/code/modules/desert_dam/motion_sensor/sensortower.dm
+++ b/code/modules/desert_dam/motion_sensor/sensortower.dm
@@ -135,6 +135,7 @@
 	is_on = TRUE
 	cur_tick = 0
 	update_icon()
+	add_xenos_to_minimap()
 	START_PROCESSING(SSslowobj, src)
 	return TRUE
 

--- a/code/modules/vehicles/arc/arc.dm
+++ b/code/modules/vehicles/arc/arc.dm
@@ -115,7 +115,7 @@
 		minimap_added.Remove(xeno)
 
 /obj/vehicle/multitile/arc/process()
-var/turf/arc_turf = get_turf(src)
+	var/turf/arc_turf = get_turf(src)
 	if((health <= 0) || !visible_in_tacmap || !is_ground_level(arc_turf.z))
 		return
 

--- a/code/modules/vehicles/arc/arc.dm
+++ b/code/modules/vehicles/arc/arc.dm
@@ -109,6 +109,10 @@
 	else
 		STOP_PROCESSING(SSslowobj, src)
 
+/obj/vehicle/multitile/arc/proc/clear_tacmap()
+	for(var/datum/weakref/xeno as anything in minimap_added)
+		SSminimaps.remove_marker(xeno.resolve())
+		minimap_added.Remove(xeno)
 /obj/vehicle/multitile/arc/process()
 	var/turf/arc_turf = get_turf(src)
 	if((health <= 0) || !visible_in_tacmap || !is_ground_level(arc_turf.z))
@@ -116,9 +120,7 @@
 
 	var/obj/item/hardpoint/support/arc_antenna/antenna = locate() in hardpoints
 	if(!antenna || (antenna.health <= 0))
-		for(var/datum/weakref/xeno as anything in minimap_added)
-			SSminimaps.remove_marker(xeno.resolve())
-			minimap_added.Remove(xeno)
+		clear_tacmap()
 		return
 
 	for(var/mob/living/carbon/xenomorph/current_xeno as anything in GLOB.living_xeno_list)

--- a/code/modules/vehicles/arc/arc.dm
+++ b/code/modules/vehicles/arc/arc.dm
@@ -113,8 +113,9 @@
 	for(var/datum/weakref/xeno as anything in minimap_added)
 		SSminimaps.remove_marker(xeno.resolve())
 		minimap_added.Remove(xeno)
+
 /obj/vehicle/multitile/arc/process()
-	var/turf/arc_turf = get_turf(src)
+var/turf/arc_turf = get_turf(src)
 	if((health <= 0) || !visible_in_tacmap || !is_ground_level(arc_turf.z))
 		return
 

--- a/code/modules/vehicles/hardpoints/support/antenna.dm
+++ b/code/modules/vehicles/hardpoints/support/antenna.dm
@@ -91,4 +91,5 @@
 
 	if(arc_owner.antenna_deployed)
 		retract_antenna()
+		arc_owner.clear_tacmap()
 		addtimer(CALLBACK(arc_owner, TYPE_PROC_REF(/obj/vehicle/multitile/arc, finish_antenna_retract)), deploy_animation_time)


### PR DESCRIPTION

# About the pull request

fixes: #12168
Taking down sensor tower should clear xenos from tacmap instantly rather then after up to 30 seconds. reduces avrage sensor autobreake time to 8 minutes from 3.3 hours

# Explain why it's good for the game

fix aaand welp none ever heard about the second so also fix


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: reduces average autobreake time from 3.3 hours to 8 minutes
fix: xenos clear from sensor tower instantly when it gets broken
fix: sensos add xenos instantly to the tacmap when turned on
/:cl:
