### PR TITLE
B8 Smart Scope now tries to continue fire after IFF prevention

### DIFF
--- a/code/datums/components/iff_fire_prevention.dm
+++ b/code/datums/components/iff_fire_prevention.dm
@@ -49,7 +49,7 @@
 	if(target == user)
 		playsound_client(user.client, 'sound/weapons/smartgun_fail.ogg', src, 25)
 		to_chat(user, SPAN_WARNING("[firing_weapon] halts firing as an IFF marked target crosses your field of fire!"))
-		COOLDOWN_START(src, iff_halt_cooldown, IFF_HALT_COOLDOWN)
+		COOLDOWN_START(src, iff_halt_cooldown, IFF_HALT_COOLDOWN + iff_additional_fire_delay)
 		if(iff_additional_fire_delay)
 			var/obj/item/weapon/gun/gun = firing_weapon
 			if(istype(gun))
@@ -92,7 +92,7 @@
 					continue
 				playsound_client(user.client, 'sound/weapons/smartgun_fail.ogg', src, 25)
 				to_chat(user, SPAN_WARNING("[firing_weapon] halts firing as an IFF marked target crosses your field of fire!"))
-				COOLDOWN_START(src, iff_halt_cooldown, IFF_HALT_COOLDOWN)
+				COOLDOWN_START(src, iff_halt_cooldown, IFF_HALT_COOLDOWN + iff_additional_fire_delay)
 				if(iff_additional_fire_delay)
 					var/obj/item/weapon/gun/gun = firing_weapon
 					if(istype(gun))

--- a/code/datums/components/iff_fire_prevention.dm
+++ b/code/datums/components/iff_fire_prevention.dm
@@ -47,14 +47,7 @@
 
 	//Don't shoot yourself, thanks
 	if(target == user)
-		playsound_client(user.client, 'sound/weapons/smartgun_fail.ogg', src, 25)
-		to_chat(user, SPAN_WARNING("[firing_weapon] halts firing as an IFF marked target crosses your field of fire!"))
-		COOLDOWN_START(src, iff_halt_cooldown, IFF_HALT_COOLDOWN + iff_additional_fire_delay)
-		if(iff_additional_fire_delay)
-			var/obj/item/weapon/gun/gun = firing_weapon
-			if(istype(gun))
-				gun.last_fired = world.time + iff_additional_fire_delay
-				SEND_SIGNAL(gun, COMSIG_GUN_NEXT_FIRE_MODIFIED, gun.last_fired) //for autofire
+		apply_fire_delay(firing_weapon, user)
 		return COMPONENT_CANCEL_GUN_BEFORE_FIRE
 
 	//At some angles (scatter or otherwise) the original target is not in checked_turfs so we put it in there in order based on distance from user
@@ -90,14 +83,7 @@
 			if(checked_living.get_target_lock(user.faction_group))
 				if(HAS_TRAIT(checked_living, TRAIT_CLOAKED))
 					continue
-				playsound_client(user.client, 'sound/weapons/smartgun_fail.ogg', src, 25)
-				to_chat(user, SPAN_WARNING("[firing_weapon] halts firing as an IFF marked target crosses your field of fire!"))
-				COOLDOWN_START(src, iff_halt_cooldown, IFF_HALT_COOLDOWN + iff_additional_fire_delay)
-				if(iff_additional_fire_delay)
-					var/obj/item/weapon/gun/gun = firing_weapon
-					if(istype(gun))
-						gun.last_fired = world.time + iff_additional_fire_delay
-						SEND_SIGNAL(gun, COMSIG_GUN_NEXT_FIRE_MODIFIED, gun.last_fired) //for autofire
+				apply_fire_delay(firing_weapon, user)
 				return COMPONENT_CANCEL_GUN_BEFORE_FIRE
 
 			return //if we have a target we *can* hit and find it before any IFF targets we want to fire
@@ -109,5 +95,16 @@
 		RegisterSignal(parent, COMSIG_GUN_BEFORE_FIRE, PROC_REF(check_firing_lane))
 	else
 		UnregisterSignal(parent, COMSIG_GUN_BEFORE_FIRE)
+
+/// Applies IFF prevention firing delay
+/datum/component/iff_fire_prevention/proc/apply_fire_delay(obj/firing_weapon, mob/living/user)
+	playsound_client(user.client, 'sound/weapons/smartgun_fail.ogg', src, 25)
+	to_chat(user, SPAN_WARNING("[firing_weapon] halts firing as an IFF marked target crosses your field of fire!"))
+	COOLDOWN_START(src, iff_halt_cooldown, IFF_HALT_COOLDOWN + iff_additional_fire_delay)
+	if(iff_additional_fire_delay)
+		var/obj/item/weapon/gun/gun = firing_weapon
+		if(istype(gun))
+			gun.last_fired = world.time + iff_additional_fire_delay
+			SEND_SIGNAL(gun, COMSIG_GUN_NEXT_FIRE_MODIFIED, gun.last_fired) //for autofire
 
 #undef IFF_HALT_COOLDOWN

--- a/code/datums/components/iff_fire_prevention.dm
+++ b/code/datums/components/iff_fire_prevention.dm
@@ -25,6 +25,9 @@
 /datum/component/iff_fire_prevention/proc/check_firing_lane(obj/firing_weapon, obj/projectile/projectile_to_fire, atom/target, mob/living/user)
 	SIGNAL_HANDLER
 
+	if(!COOLDOWN_FINISHED(src, iff_halt_cooldown) && user.client)
+		return COMPONENT_CANCEL_GUN_BEFORE_FIRE
+
 	var/angle = Get_Angle(user, target)
 
 	var/range_to_check = user.get_maximum_view_range()
@@ -44,15 +47,13 @@
 
 	//Don't shoot yourself, thanks
 	if(target == user)
-		if(COOLDOWN_FINISHED(src, iff_halt_cooldown) && user.client)
-			playsound_client(user.client, 'sound/weapons/smartgun_fail.ogg', src, 25)
-			to_chat(user, SPAN_WARNING("[firing_weapon] halts firing as an IFF marked target crosses your field of fire!"))
-			COOLDOWN_START(src, iff_halt_cooldown, IFF_HALT_COOLDOWN)
+		playsound_client(user.client, 'sound/weapons/smartgun_fail.ogg', src, 25)
+		to_chat(user, SPAN_WARNING("[firing_weapon] halts firing as an IFF marked target crosses your field of fire!"))
+		COOLDOWN_START(src, iff_halt_cooldown, IFF_HALT_COOLDOWN)
 		if(iff_additional_fire_delay)
 			var/obj/item/weapon/gun/gun = firing_weapon
 			if(istype(gun))
 				gun.last_fired = world.time + iff_additional_fire_delay
-				SEND_SIGNAL(gun, COMSIG_GUN_STOP_FIRE) //for autofire
 				SEND_SIGNAL(gun, COMSIG_GUN_NEXT_FIRE_MODIFIED, gun.last_fired) //for autofire
 		return COMPONENT_CANCEL_GUN_BEFORE_FIRE
 
@@ -89,15 +90,13 @@
 			if(checked_living.get_target_lock(user.faction_group))
 				if(HAS_TRAIT(checked_living, TRAIT_CLOAKED))
 					continue
-				if(COOLDOWN_FINISHED(src, iff_halt_cooldown) && user.client)
-					playsound_client(user.client, 'sound/weapons/smartgun_fail.ogg', src, 25)
-					to_chat(user, SPAN_WARNING("[firing_weapon] halts firing as an IFF marked target crosses your field of fire!"))
-					COOLDOWN_START(src, iff_halt_cooldown, IFF_HALT_COOLDOWN)
+				playsound_client(user.client, 'sound/weapons/smartgun_fail.ogg', src, 25)
+				to_chat(user, SPAN_WARNING("[firing_weapon] halts firing as an IFF marked target crosses your field of fire!"))
+				COOLDOWN_START(src, iff_halt_cooldown, IFF_HALT_COOLDOWN)
 				if(iff_additional_fire_delay)
 					var/obj/item/weapon/gun/gun = firing_weapon
 					if(istype(gun))
 						gun.last_fired = world.time + iff_additional_fire_delay
-						SEND_SIGNAL(gun, COMSIG_GUN_STOP_FIRE) //for autofire
 						SEND_SIGNAL(gun, COMSIG_GUN_NEXT_FIRE_MODIFIED, gun.last_fired) //for autofire
 				return COMPONENT_CANCEL_GUN_BEFORE_FIRE
 


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #12345" to link the PR to the corresponding Issue number #12345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #12345, Fixes #12346, Fixes #12347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Currently, AutoFire is canceled if B8 IFF prevention triggers, which makes you need to release and hold fire button again if you want to shoot something.

B8 Smart Scope now works as Frontline Smartgun - it will try to fire again after a delay if you are holding AutoFire.

I think it's a fix?

# Explain why it's good for the game
B8 Smart Scope is advertised to work exactly as Frontline Smartgun, now it does.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

B8 Scope (now it tries to fire again if you AutoFire)

https://github.com/user-attachments/assets/aea78828-9703-4b46-a627-5d5688ae5ea9

Same but Burst Fire

https://github.com/user-attachments/assets/c3443e72-ec89-493c-83a0-cc319bd8048c

Smartgun (no changes)

https://github.com/user-attachments/assets/16323fdf-a922-4387-b355-13fbfe03bc78

Additional delay difference example

https://github.com/user-attachments/assets/fdb41711-ce99-48b7-b604-07e2fb3cd915

</details>

# Changelog
:cl:
fix: B8 Smart Scope now tries to fire after a delay when it prevents IFF. Holding M1 with MK2 is now exactly as Holding M1 with Smartgun Frontline.
/:cl:
