### PR TITLE
Crusher Melee Attacks now Slow for 2 seconds (was 3.5)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Crusher.dm
@@ -235,7 +235,7 @@
 	if (!isxeno_human(target))
 		return
 
-	new /datum/effects/xeno_slow(target, bound_xeno, 2 SECONDS)
+	new /datum/effects/xeno_slow(target, bound_xeno, ttl = 2 SECONDS)
 
 	var/damage = bound_xeno.melee_damage_upper * aoe_slash_damage_reduction
 
@@ -301,7 +301,7 @@
 		if(xeno.can_not_harm(target))
 			continue
 
-		new /datum/effects/xeno_slow(target, xeno, null, null, 3.5 SECONDS)
+		new /datum/effects/xeno_slow(target, xeno, ttl = 3.5 SECONDS)
 		to_chat(target, SPAN_XENODANGER("You are slowed as the impact of [xeno] shakes the ground!"))
 
 /datum/action/xeno_action/activable/pounce/crusher_charge/additional_effects(mob/living/target)


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #12345" to link the PR to the corresponding Issue number #12345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #12345, Fixes #12346, Fixes #12347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Actually it is a fix, since during a refactor 15 months ago `2 second slow` was not correctly set in the proc argument, so it was using the proc's default value of `3.5 second slow`

# Explain why it's good for the game
Fixes good?

# Changelog
:cl:
balance: Crusher Melee Attacks now Slow for 2 Seconds (was 3.5 Seconds)
/:cl:
