### PR TITLE
Poncho Synth Returns

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/synthetic.dm
+++ b/code/game/machinery/vending/vendor_types/crew/synthetic.dm
@@ -944,6 +944,12 @@ GLOBAL_LIST_INIT(cm_vending_synth_tools, list(
 	list("Logistics IMP Backpack", 15, /obj/item/storage/backpack/marine/satchel/big, null, VENDOR_ITEM_REGULAR),
 	list("Expedition Chestrig", 15, /obj/item/storage/backpack/marine/satchel/intel/chestrig, null, VENDOR_ITEM_REGULAR),
 	list("Expedition Satchel", 15, /obj/item/storage/backpack/marine/satchel/intel/expeditionsatchel, null, VENDOR_ITEM_REGULAR),
+	list("Green Poncho", 30, /obj/item/clothing/accessory/poncho/green, null, VENDOR_ITEM_REGULAR),
+	list("Brown Poncho", 30, /obj/item/clothing/accessory/poncho/brown, null, VENDOR_ITEM_REGULAR),
+	list("Black Poncho", 30, /obj/item/clothing/accessory/poncho/black, null, VENDOR_ITEM_REGULAR),
+	list("Blue Poncho", 30, /obj/item/clothing/accessory/poncho/blue, null, VENDOR_ITEM_REGULAR),
+	list("Purple Poncho", 30, /obj/item/clothing/accessory/poncho/purple, null, VENDOR_ITEM_REGULAR),
+
 ))
 
 //------------EXPERIMENTAL TOOL KITS---------------


### PR DESCRIPTION


# About the pull request

Approved by the all powerful synthator Westrover, the 5 different colored ponchos are available to buy in the experimental vendor for 30 points

# Explain why it's good for the game

Returns ponchos for the synths that need the drip. But drip comes at a price.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>


</details>


# Changelog



:cl: Nomoresolvalou
add: Adds ponchos to the synth experimental vendor for 30 points each

/:cl:

