### PR TITLE
USS Runtime mode no longer loads predator ship

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -242,9 +242,11 @@ SUBSYSTEM_DEF(mapping)
 	if(trim(file2text("data/mode.txt")) == GAMEMODE_FACTION_CLASH_UPP_CM)
 		Loadship(FailedZs, "ssv_rostock", "templates/", list("ssv_rostock.dmm") , list(),ZTRAITS_MAIN_SHIP , override_map_path = "maps/")
 
+	#ifndef RUNTIME_MAP
 	var/datum/map_config/hunter_map = new
 	hunter_map.LoadConfig("maps/huntership.json", TRUE)
 	Loadship(FailedZs, hunter_map.map_name, hunter_map.map_path, hunter_map.map_file, hunter_map.traits, ZTRAITS_ADMIN, override_map_path = "maps/")
+	#endif
 
 	if(LAZYLEN(FailedZs)) //but seriously, unless the server's filesystem is messed up this will never happen
 		var/msg = "RED ALERT! The following map files failed to load: [FailedZs[1]]"


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #11414 disabling the predator ship if RUNTIME_MAP is defined. Runtime map mode is intended to load quickly; not be slowed down with extra stuff.

# Explain why it's good for the game

Fixes #11979 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="611" height="131" alt="image" src="https://github.com/user-attachments/assets/b9012701-7896-4a42-88fb-ec04529d0bf3" />

</details>


# Changelog

No player facing changes.
