### PR TITLE
Fix tacmap runtime for hunting grounds and misc tacmap fixes

### DIFF
--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -63,6 +63,8 @@ SUBSYSTEM_DEF(minimaps)
 	for(var/datum/space_level/z_level as anything in SSmapping.z_list)
 		load_new_z(null, z_level)
 
+	RegisterSignal(SSdcs, COMSIG_GLOB_NEW_Z, PROC_REF(load_new_z))
+
 	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/minimaps/stat_entry(msg)
@@ -118,6 +120,7 @@ SUBSYSTEM_DEF(minimaps)
 	SIGNAL_HANDLER
 
 	var/level = z_level.z_value
+	ASSERT(!minimaps_by_z["[level]"], "Duplicate load_new_z call for [level]!")
 	minimaps_by_z["[level]"] = new /datum/hud_displays
 	if(!is_mainship_level(level) && !is_ground_level(level) && !(SSmapping.level_trait(level, ZTRAIT_AWAY))) //todo: maybe move this around
 		return

--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -89,7 +89,13 @@ SUBSYSTEM_DEF(minimaps)
 			continue
 
 		var/atom/movable/screen/minimap/target = updater.minimap
-		if(istype(target) && !target.live)
+		var/is_live = FALSE
+		var/is_observer = FALSE
+		if(istype(target))
+			is_live = target.live
+			is_observer = target.is_observer_minimap
+
+		if(!is_live)
 			update_targets_unsorted -= updater
 			continue
 
@@ -97,7 +103,7 @@ SUBSYSTEM_DEF(minimaps)
 		var/list/combined_overlays = list()
 
 		// Filter raw_blips for observer maps to exclude labels
-		if(istype(target) && target.is_observer_minimap)
+		if(is_observer)
 			// For observer maps, filter out any labels
 			for(var/image/blip as anything in updater.raw_blips)
 				if(!blip.maptext)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -986,7 +986,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 		AM.loc = destination
 		AM.loc.Entered(AM,oldLoc)
 		if(oldLoc.z != destination.z)
-			SEND_SIGNAL(AM, COMSIG_MOVABLE_Z_CHANGED)
+			AM.onTransitZ(oldLoc.z, destination.z)
 		var/area/old_area
 		if(oldLoc)
 			old_area = get_area(oldLoc)


### PR DESCRIPTION

# About the pull request

This PR does a few things:
- Fixes https://runtimes.cm-ss13.com/cm13/issues/276 because now Z 14 will exist (its a late loaded Z from hunting grounds when reservation space is already occupied with something else like fax responders - looks like `load_new_z` was always intended to be a signal handler anyways for a global signal)
- Micro-optimizes out a redundant istype check in `/datum/controller/subsystem/minimaps/fire`
- Fixes an incorrect `COMSIG_MOVABLE_Z_CHANGED` signal: It lacked oldz and newz arguments, and generally signal senders should be from one source - in this case from `onTransitZ`.

# Explain why it's good for the game

Less runtimes!

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="2548" height="1339" alt="image" src="https://github.com/user-attachments/assets/f37a478e-eafe-4d26-b263-cb30c727f553" />

</details>


# Changelog
:cl: Drathek
fix: Fixed some tacmap runtimes with hunting grounds
fix: Fixed a bad COMSIG_MOVABLE_Z_CHANGED call
/:cl:
