### PR TITLE
Stops xenos from eating the server CPU (no need to update icons every life tick)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
@@ -63,9 +63,11 @@
 	if(larva_state == LARVA_STATE_BLOODY && evolution_stored >= evolution_threshold / 2)
 		larva_state = LARVA_STATE_NORMAL
 		generate_name()
+		update_icons()
 	else if(larva_state == LARVA_STATE_NORMAL && evolution_stored >= evolution_threshold)
 		larva_state = LARVA_STATE_MATURE
 		generate_name()
+		update_icons()
 	return ..()
 
 /mob/living/carbon/xenomorph/larva/warn_away_timer()

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -25,9 +25,7 @@
 		handle_pheromones()
 		handle_regular_status_updates()
 		handle_overwatch() // For new Xeno hivewide overwatch - Fourk, 6/24/19
-		update_icons()
 		handle_luminosity()
-		handle_blood()
 
 		behavior_delegate?.on_life()
 		handle_environment()


### PR DESCRIPTION

# About the pull request

fixes #12266

Xenos do not need to call update_icons on each and every one of them every life tick. They are update when something changes, and if not that is the issue with the thing that changes them this is eating the server CPU like crazy.

nothing happens in the update_blood no point for it to be there

# Explain why it's good for the game

stops xenos munching on cpu


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: we no longer update_icons of every xenomorph every life tick
/:cl:
