### PR TITLE
THE GREAT BALANCING OF REAPING YAUTJA

### DIFF
--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -479,7 +479,6 @@
 	icon_state = "predscythe_alt"
 	item_state = "scythe_dual"
 
-	shield_chance = SHIELD_CHANCE_MED
 
 /obj/item/weapon/yautja/sword/staff
 	name = "cruel staff"


### PR DESCRIPTION


# About the pull request

Yautja Scythes now have equal block chances, which is 15 percent. They used to be different.

# Explain why it's good for the game

One weapon having a superior block chance over another is BAD and NOT GOOD and also I'm harvesting goodwill to buff shields later.

# Testing Photographs and Procedure
N/A

# Changelog



:cl:
balance: Scythes Restored
/:cl:

