### PR TITLE
Huggers time-to-jump is now always 4 seconds

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -788,7 +788,7 @@
 #define MIN_IMPREGNATION_TIME 10 SECONDS //Time it takes to impregnate someone
 #define MAX_IMPREGNATION_TIME 15 SECONDS
 
-#define HUGGER_ACTIVE_TIME 3.5 SECONDS //Time between being dropped and being able to jump
+#define HUGGER_ACTIVE_TIME 3 SECONDS //Time between being dropped and being able to jump
 
 #define FACEHUGGER_JUMP_RANGE 1 // dont really want them to hug you immediately as you break down a corner or a door when a carrier stacks them on a tile
 #define EGG_JUMP_RANGE 2 // This is for egg huggers, they are supposed to be scary and leap at people yes.

--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -788,7 +788,7 @@
 #define MIN_IMPREGNATION_TIME 10 SECONDS //Time it takes to impregnate someone
 #define MAX_IMPREGNATION_TIME 15 SECONDS
 
-#define HUGGER_ACTIVE_TIME 3 SECONDS //Time between being dropped and being able to jump
+#define HUGGER_ACTIVE_TIME 3.5 SECONDS //Time between being dropped and being able to jump
 
 #define FACEHUGGER_JUMP_RANGE 1 // dont really want them to hug you immediately as you break down a corner or a door when a carrier stacks them on a tile
 #define EGG_JUMP_RANGE 2 // This is for egg huggers, they are supposed to be scary and leap at people yes.

--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -788,8 +788,7 @@
 #define MIN_IMPREGNATION_TIME 10 SECONDS //Time it takes to impregnate someone
 #define MAX_IMPREGNATION_TIME 15 SECONDS
 
-#define HUGGER_MIN_ACTIVE_TIME 3.5 SECONDS //Time between being dropped and going idle
-#define HUGGER_MAX_ACTIVE_TIME 7 SECONDS
+#define HUGGER_ACTIVE_TIME 3.5 SECONDS //Time between being dropped and being able to jump
 
 #define FACEHUGGER_JUMP_RANGE 1 // dont really want them to hug you immediately as you break down a corner or a door when a carrier stacks them on a tile
 #define EGG_JUMP_RANGE 2 // This is for egg huggers, they are supposed to be scary and leap at people yes.

--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -788,7 +788,7 @@
 #define MIN_IMPREGNATION_TIME 10 SECONDS //Time it takes to impregnate someone
 #define MAX_IMPREGNATION_TIME 15 SECONDS
 
-#define HUGGER_ACTIVE_TIME 3.5 SECONDS //Time between being dropped and being able to jump
+#define HUGGER_ACTIVE_TIME 4 SECONDS //Time between being dropped and being able to jump
 
 #define FACEHUGGER_JUMP_RANGE 1 // dont really want them to hug you immediately as you break down a corner or a door when a carrier stacks them on a tile
 #define EGG_JUMP_RANGE 2 // This is for egg huggers, they are supposed to be scary and leap at people yes.

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -392,7 +392,7 @@
 	jump_timer = null
 	// Reset the jumps left to their original count
 	jumps_left = initial(jumps_left)
-	addtimer(CALLBACK(src, PROC_REF(go_active)), rand(HUGGER_MIN_ACTIVE_TIME, HUGGER_MAX_ACTIVE_TIME))
+	addtimer(CALLBACK(src, PROC_REF(go_active)), HUGGER_ACTIVE_TIME)
 
 /obj/item/clothing/mask/facehugger/proc/try_jump()
 	jump_timer = addtimer(CALLBACK(src, PROC_REF(try_jump)), time_between_jumps, TIMER_OVERRIDE|TIMER_STOPPABLE|TIMER_UNIQUE)


### PR DESCRIPTION

# About the pull request

Huggers dropped on the ground no longer have RNG whether they are inactive between 3.5 to 7 seconds, it's now just ~~3.5~~4 seconds always.

# Explain why it's good for the game

Having watched a lot of xeno gameplay since this was touched at https://github.com/cmss13-devs/cmss13/pull/11551 I can say that huggers dropped on the ground pretty much never live if any marine in view is able to shoot at all. There is no interesting moment where someone hopes the hugger activates sooner or later. Either the marines in the area are already incapacitated and it's just faster to use the hugger from hand rather than wait up to 7 seconds for it to be able to jump, or the hugger is spotted and killed instantly. Or it's not spotted and just killed by a stray bullet. At a flat ~~3.5~~ 4 seconds, I still think it's pretty much never going to be the 'right move' to drop a hugger on the ground and wait a full ~~3.5~~4 seconds for it to hopefully live and jump at it's new range of 1 tile, rather than use it from hand. But at least it will have a slightly higher chance of doing something.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: huggers dropped on the ground become able to jump in 4 seconds.
/:cl:
