### PR TITLE
Gives whitelist senators ooc badge

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -92,7 +92,7 @@ CLIENT_VERB(ooc, msg as text)
 		var/static/sub_icon = icon('icons/effects/effects.dmi', "sub")
 		prefix += "[icon2html(sub_icon, GLOB.clients)]"
 	if(isCouncil(src))
-		prefix += "[icon2html(GLOB.ooc_rank_dmi, GLOB.clients, "WhitelistCouncil")]"
+		prefix += "[icon2html(GLOB.ooc_rank_dmi, GLOB.clients, isSenator(src) ? "WhitelistSenator" : "WhitelistCouncil")]"
 	var/comm_award = find_community_award_icons()
 	if(comm_award)
 		prefix += comm_award


### PR DESCRIPTION

# About the pull request
Gives whitelist senators their ooc badge, not the council one
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #12345" to link the PR to the corresponding Issue number #12345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #12345, Fixes #12346, Fixes #12347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
idk, looks cool
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
<img width="224" height="57" alt="{5381DC5C-8C2B-4D72-B62C-24D124C0ECE8}" src="https://github.com/user-attachments/assets/31f2b27a-0bee-4f90-b552-3e17cea91010" />

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Senators now have their badge, not the council one
/:cl:
