### PR TITLE
Observer message tweak

### DIFF
--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -254,6 +254,8 @@
 	. = ..()
 
 	if(turf_flags & TURF_HULL)
+		if(isobserver(user))
+			return
 		.+= SPAN_WARNING("You don't think you have any tools able to even scratch this.")
 		return //If it's indestructable, we don't want to give the wrong impression by saying "you can decon it with a welder"
 

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -254,9 +254,7 @@
 	. = ..()
 
 	if(turf_flags & TURF_HULL)
-		if(isobserver(user))
-			return
-		.+= SPAN_WARNING("You don't think you have any tools able to even scratch this.")
+		.+= SPAN_WARNING("This cannot even be scratched by any tools.")
 		return //If it's indestructable, we don't want to give the wrong impression by saying "you can decon it with a welder"
 
 	if(!damage)

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -254,7 +254,7 @@
 	. = ..()
 
 	if(turf_flags & TURF_HULL)
-		.+= SPAN_WARNING("This cannot even be scratched by any tools.")
+		.+= SPAN_WARNING("This cannot be damaged by anything available.")
 		return //If it's indestructable, we don't want to give the wrong impression by saying "you can decon it with a welder"
 
 	if(!damage)


### PR DESCRIPTION

# About the pull request

Redoes a line where we're warning observers that they don't have tools to scratch a wall.

# Explain why it's good for the game

New message can logically apply to everyone, even observers.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
spellcheck: reworked wall description to apply logically to observers
/:cl:
