### PR TITLE
changed synthetic death messages to be more loreful

### DIFF
--- a/code/modules/mob/living/carbon/human/species/synthetic.dm
+++ b/code/modules/mob/living/carbon/human/species/synthetic.dm
@@ -2,6 +2,7 @@
 	group = SPECIES_SYNTHETIC
 	name = SYNTH_GEN_THREE
 	name_plural = "Synthetics"
+	death_message = "violently gargles fluid and seizes up, their eyes unnervingly still..."
 	special_body_types = TRUE
 
 	unarmed_type = /datum/unarmed_attack/punch/synthetic
@@ -79,6 +80,7 @@
 
 /datum/species/synthetic/gen_two/gen_one
 	name = SYNTH_GEN_ONE
+	death_message = "violently gargles fluid and seizes up, the glow in their eyes dimming..."
 	flags = parent_type::flags & ~HAS_SKIN_COLOR
 	special_body_types = FALSE
 	mob_inherent_traits = list(TRAIT_SUPER_STRONG, TRAIT_INTENT_EYES, TRAIT_IRON_TEETH, TRAIT_POUNCE_RESISTANT)
@@ -92,6 +94,7 @@
 /datum/species/synthetic/infiltrator
 	name = SYNTH_INFILTRATOR
 	name_plural = "Infiltrator Synthetics"
+	death_message = "seizes up and falls limp, their eyes dead and lifeless..." // regular death message here for infiltration purposes
 	mob_inherent_traits = list(TRAIT_SUPER_STRONG, TRAIT_INFILTRATOR_SYNTH, TRAIT_IRON_TEETH)
 
 	bloodsplatter_type = /obj/effect/bloodsplatter/human

--- a/code/modules/mob/living/carbon/human/species/working_joe/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/working_joe/_species.dm
@@ -1,7 +1,6 @@
 /datum/species/synthetic/gen_two/gen_one/working_joe
 	name = SYNTH_WORKING_JOE
 	name_plural = "Working Joes"
-	death_message = "violently gargles fluid and seizes up, the glow in their eyes dimming..."
 	burn_mod = 0.65 // made for hazardous environments, withstanding temperatures up to 1210 degrees
 	mob_inherent_traits = list(TRAIT_SUPER_STRONG, TRAIT_INTENT_EYES, TRAIT_EMOTE_CD_EXEMPT, TRAIT_CANNOT_EAT, TRAIT_UNSTRIPPABLE, TRAIT_IRON_TEETH, TRAIT_POUNCE_RESISTANT)
 


### PR DESCRIPTION

# About the pull request

This gives synthetics (G1, G2 and G3) death messages that better fit what they are.

<!-- Remove this text and explain what the purpose of your PR is. -->

# Explain why it's good for the game

its soulful.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: gnorse
add: Loreful synthetic death messages 
/:cl:
