### PR TITLE
comms signal clarity meter on OW consoles

### DIFF
--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -46,7 +46,6 @@ GLOBAL_LIST_EMPTY_TYPED(active_overwatch_consoles, /obj/structure/machinery/comp
 	var/command_channel_key = ":v"
 
 	var/freq = CRYO_FREQ
-	var/squad_radio_vlairty = 100 //radio garble clarity bar
 
 	/// List of saved coordinates, format of ["x", "y", "z", "comment"]
 	var/list/saved_coordinates = list()

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -46,6 +46,7 @@ GLOBAL_LIST_EMPTY_TYPED(active_overwatch_consoles, /obj/structure/machinery/comp
 	var/command_channel_key = ":v"
 
 	var/freq = CRYO_FREQ
+	var/squad_radio_vlairty = 100 //radio garble clarity bar
 
 	/// List of saved coordinates, format of ["x", "y", "z", "comment"]
 	var/list/saved_coordinates = list()
@@ -479,6 +480,7 @@ GLOBAL_LIST_EMPTY_TYPED(active_overwatch_consoles, /obj/structure/machinery/comp
 /obj/structure/machinery/computer/overwatch/ui_data(mob/user)
 	var/list/data = list()
 
+	data = pack_radio_data()
 	data["theme"] = ui_theme
 
 	if(!current_squad)
@@ -526,6 +528,8 @@ GLOBAL_LIST_EMPTY_TYPED(active_overwatch_consoles, /obj/structure/machinery/comp
 	var/list/data = list()
 
 	data["theme"] = ui_theme
+
+	data = pack_radio_data()
 
 	if(!current_squad)
 		data["squad_list"] = list()
@@ -1675,6 +1679,32 @@ GLOBAL_LIST_EMPTY_TYPED(active_overwatch_consoles, /obj/structure/machinery/comp
 /obj/structure/supply_drop/upp4
 	icon_state = "deltadrop"
 	squad = SQUAD_UPP_4
+
+/obj/structure/machinery/computer/overwatch/proc/get_radio_clarity()
+	var/ground_z = length(SSmapping.levels_by_trait(ZTRAIT_GROUND)) ? SSmapping.levels_by_trait(ZTRAIT_GROUND)[1] : null
+	var/current_clarity
+	if(ground_z && (ground_z in SSradio.get_available_tcomm_zs(COMM_FREQ)))
+		return 100
+	if(SSradio.faction_coms_clarity && SSradio.faction_coms_clarity[faction])
+		current_clarity = SSradio.faction_coms_clarity[faction]
+		if(SSradio.faction_coms_codes && length(SSradio.faction_coms_codes[faction]))
+			return current_clarity
+	return 15
+
+/obj/structure/machinery/computer/overwatch/proc/pack_radio_data()
+	var/list/clarity_data = list ()
+	var/clarity = get_radio_clarity()
+	clarity_data["radio_clarity"] = clarity
+	if(clarity >= 80)
+		clarity_data["clarity_color"] = "good"
+		clarity_data["clarity_status"] = "STABLE"
+	else if(clarity >= 45)
+		clarity_data["clarity_color"] = "average"
+		clarity_data["clarity_status"] = "DEGRADED"
+	else
+		clarity_data["clarity_color"] = "bad"
+		clarity_data["clarity_status"] = "CRITICAL BLACKOUT"
+	return clarity_data
 
 #undef HIDE_ALMAYER
 #undef HIDE_GROUND

--- a/tgui/packages/tgui/interfaces/OverwatchConsole.tsx
+++ b/tgui/packages/tgui/interfaces/OverwatchConsole.tsx
@@ -233,42 +233,43 @@ const MainDashboard = (props) => {
             </Table.Cell>
           </Table.Row>
         </Table>
-      <Table style={{ border: 'none', background: 'none' }}>
-        <Table.Row style={{ border: 'none', background: 'none' }}>
-          <Table.Cell width="50%" style={{ border: 'none' }} textAlign="right">
-            <Stack vertical={false} justify="flex-end">
-            <Button
-              inline
-              mt={0.5}
-              width="49%"
-              icon="envelope"
-              style={{ textAlign: 'Center'}}
-              onClick={() => act('set_primary')}>
-            SET PRIMARY
-            </Button>
-            {primary_objective && (
-            <Button
-              width="49%"
-              inline
-              mt={0.5}
-              icon="person"
-              style={{ textAlign: 'Center'}}
-              onClick={() => act('remind_primary')}
-              >
-              REMIND PRIMARY
-            </Button>
-            )}
-            </Stack>
-            </Table.Cell>
-            <Table.Cell style={{ border: 'none' }} textAlign="left">
-              <Stack vertical={false} justify="flex-start">
+        <Table style= {{ border: 'none', background: 'none' }}>
+          <Table.Row style= {{ border: 'none', background: 'none' }}>
+            <Table.Cell width="50%" style= {{ border: 'none' }} textAlign="right">
+              <Stack vertical= {false} justify="flex-end">
               <Button
                 inline
-                mt={0.5}
+                mt= {0.5}
                 width="49%"
                 icon="envelope"
-                style={{ textAlign: 'Center'}}
-                onClick={() => act('set_secondary')}
+                style= {{ textAlign: 'Center'}}
+                onClick= {() => act('set_primary')}
+                >
+                SET PRIMARY
+              </Button>
+              {primary_objective && (
+              <Button
+                width="49%"
+                inline
+                mt= {0.5}
+                icon="person"
+                style= {{ textAlign: 'Center'}}
+                onClick= {() => act('remind_primary')}
+                >
+                REMIND PRIMARY
+              </Button>
+              )}
+            </Stack>
+          </Table.Cell>
+          <Table.Cell style= {{ border: 'none' }} textAlign="left">
+            <Stack vertical= {false} justify="flex-start">
+              <Button
+                inline
+                mt= {0.5}
+                width="49%"
+                icon="envelope"
+                style= {{ textAlign: 'Center'}}
+                onClick= {() => act('set_secondary')}
               >
               SET SECONDARY
               </Button>
@@ -277,66 +278,66 @@ const MainDashboard = (props) => {
                 inline
                 mt={0.5}
                 width="49%"
-                style={{ textAlign: 'Center'}}
+                style= {{ textAlign: 'Center'}}
                 icon="person"
-                onClick={() => act('remind_secondary')}
+                onClick= {() => act('remind_secondary')}
               >
               REMIND SECONDARY
               </Button>
               )}
-              </Stack>
-            </Table.Cell>
-          </Table.Row>
-          <Table.Row style={{ border: 'none', background: 'none' }}>
-          <Table.Cell width="50%" style={{ border: 'none' }}textAlign="right">
+            </Stack>
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row style= {{ border: 'none', background: 'none' }}>
+          <Table.Cell width="50%" style= {{ border: 'none' }} textAlign="right">
             <Button
-              inline
-              mt={0.5}
-              width="65%"
-              icon="envelope"
-              style={{ textAlign: 'Center'}}
-              onClick={() => act('message')}
+                inline
+                mt= {0.5}
+                width="65%"
+                icon="envelope"
+                style= {{ textAlign: 'Center'}}
+                onClick= {() => act('message')}
               >
               MESSAGE SQUAD
               </Button>
-          </Table.Cell>
-          <Table.Cell width="50%" style={{ border: 'none' }} textAlign="left">
-            <Button
-              inline
-              mt={0.5}
-              width="65%"
-              icon="envelope"
-              style={{ textAlign: 'Center'}}
-              onClick={() => act('sl_message')}
-              >
-              MESSAGE SQUAD LEADER
+            </Table.Cell>
+            <Table.Cell width="50%" style= {{ border: 'none' }} textAlign="left">
+              <Button
+                inline
+                mt= {0.5}
+                width="65%"
+                icon="envelope"
+                style= {{ textAlign: 'Center'}}
+                onClick= {() => act('sl_message')}
+                >
+                MESSAGE SQUAD LEADER
               </Button>
-          </Table.Cell>
+            </Table.Cell>
           </Table.Row>
         </Table>
       </Stack.Item>
       <Stack.Item width="120px">
         <Box>
-          <Box textAlign="center" bold color="label" mb={0.5}>
-            SIGNAL CLARITY
+          <Box textAlign="center" bold color="label" mb= {0.5}>
+          SIGNAL CLARITY
           </Box>
-          <Box textAlign="center" mb={1} fontSize="12px">
-            {data.clarity_status}
+          <Box textAlign="center" mb= {1} fontSize="12px">
+          {data.clarity_status}
           </Box>
-          <ProgressBar
-            value={Number(data.radio_clarity)/100}
-            color={data.clarity_color || 'red'}
-            height='18px'
+            <ProgressBar
+              value= {Number(data.radio_clarity)/100}
+              color= {data.clarity_color || 'red'}
+              height='18px'
             >
             {''}
-          </ProgressBar>
-          <Box textAlign="center" mt={0.5} bold color="white">
+            </ProgressBar>
+            <Box textAlign="center" mt= {0.5} bold color="white">
             {data.radio_clarity}%
+            </Box>
           </Box>
-        </Box>
-      </Stack.Item>
-    </Stack>
-  </Section>
+        </Stack.Item>
+      </Stack>
+    </Section>
   );
 };
 

--- a/tgui/packages/tgui/interfaces/OverwatchConsole.tsx
+++ b/tgui/packages/tgui/interfaces/OverwatchConsole.tsx
@@ -80,7 +80,7 @@ export const OverwatchConsole = (props) => {
 
   return (
     <Window
-      width={800}
+      width={860}
       height={600}
       theme={data.theme ? data.theme : 'crtblue'}
     >
@@ -221,11 +221,11 @@ const MainDashboard = (props) => {
       <Stack.Item grow={1} mr={1}>
         <Table mb="5px">
           <Table.Row bold>
-            <Table.Cell textAlign="center">PRIMARY ORDERS</Table.Cell>
+            <Table.Cell width="50%" textAlign="center">PRIMARY ORDERS</Table.Cell>
             <Table.Cell textAlign="center">SECONDARY ORDERS</Table.Cell>
           </Table.Row>
           <Table.Row>
-           <Table.Cell textAlign="center">
+            <Table.Cell textAlign="center">
               {primary_objective ? primary_objective : 'NONE'}
             </Table.Cell>
             <Table.Cell textAlign="center">
@@ -233,65 +233,89 @@ const MainDashboard = (props) => {
             </Table.Cell>
           </Table.Row>
         </Table>
-      <Box textAlign="center">
-        <Button
-          inline
-          width="48%"
-          icon="envelope"
-          onClick={() => act('set_primary')}
-        >
-          SET PRIMARY
-        </Button>
-        {primary_objective && (
-          <Button
-            inline
-            width="48%"
-            icon="person"
-            onClick={() => act('remind_primary')}
-          >
-            REMIND PRIMARY
-          </Button>
-        )}
-        <Button
-          inline
-          width="48%"
-          icon="envelope"
-          onClick={() => act('set_secondary')}
-        >
-          SET SECONDARY
-        </Button>
-        {secondary_objective && (
-          <Button
-            inline
-            width="48%"
-            icon="person"
-            onClick={() => act('remind_secondary')}
-          >
-            REMIND SECONDARY
-          </Button>
-        )}
-      </Box>
-
-      <Box textAlign="center">
-        <Button
-          inline
-          width="45%"
-          icon="envelope"
-          onClick={() => act('message')}
-        >
-          MESSAGE SQUAD
-        </Button>
-        <Button
-          inline
-          width="45%"
-          icon="person"
-          onClick={() => act('sl_message')}
-        >
-          MESSAGE SQUAD LEADER
-        </Button>
-      </Box>
+      <Table style={{ border: 'none', background: 'none' }}>
+        <Table.Row style={{ border: 'none', background: 'none' }}>
+          <Table.Cell width="50%" style={{ border: 'none' }} textAlign="right">
+            <Stack vertical={false} justify="flex-end">
+            <Button
+              inline
+              mt={0.5}
+              width="49%"
+              icon="envelope"
+              style={{ textAlign: 'Center'}}
+              onClick={() => act('set_primary')}>
+            SET PRIMARY
+            </Button>
+            {primary_objective && (
+            <Button
+              width="49%"
+              inline
+              mt={0.5}
+              icon="person"
+              style={{ textAlign: 'Center'}}
+              onClick={() => act('remind_primary')}
+              >
+              REMIND PRIMARY
+            </Button>
+            )}
+            </Stack>
+            </Table.Cell>
+            <Table.Cell style={{ border: 'none' }} textAlign="left">
+              <Stack vertical={false} justify="flex-start">
+              <Button
+                inline
+                mt={0.5}
+                width="49%"
+                icon="envelope"
+                style={{ textAlign: 'Center'}}
+                onClick={() => act('set_secondary')}
+              >
+              SET SECONDARY
+              </Button>
+              {secondary_objective && (
+              <Button
+                inline
+                mt={0.5}
+                width="49%"
+                style={{ textAlign: 'Center'}}
+                icon="person"
+                onClick={() => act('remind_secondary')}
+              >
+              REMIND SECONDARY
+              </Button>
+              )}
+              </Stack>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row style={{ border: 'none', background: 'none' }}>
+          <Table.Cell width="50%" style={{ border: 'none' }}textAlign="right">
+            <Button
+              inline
+              mt={0.5}
+              width="65%"
+              icon="envelope"
+              style={{ textAlign: 'Center'}}
+              onClick={() => act('message')}
+              >
+              MESSAGE SQUAD
+              </Button>
+          </Table.Cell>
+          <Table.Cell width="50%" style={{ border: 'none' }} textAlign="left">
+            <Button
+              inline
+              mt={0.5}
+              width="65%"
+              icon="envelope"
+              style={{ textAlign: 'Center'}}
+              onClick={() => act('sl_message')}
+              >
+              MESSAGE SQUAD LEADER
+              </Button>
+          </Table.Cell>
+          </Table.Row>
+        </Table>
       </Stack.Item>
-      <Stack.Item width="150px">
+      <Stack.Item width="120px">
         <Box>
           <Box textAlign="center" bold color="label" mb={0.5}>
             SIGNAL CLARITY
@@ -299,26 +323,13 @@ const MainDashboard = (props) => {
           <Box textAlign="center" mb={1} fontSize="12px">
             {data.clarity_status}
           </Box>
-          <Box
-            style={{
-            width: '100%',
-            height: '18px',
-            backgroundColor: 'black',
-            border: '1px solid rgba(255,255,255,0.2)',
-            marginBottom: '4px'
-            }}
-          >
-          <Box
-            style={{
-            width: Number(data.radio_clarity) + '%',
-            height: "100%",
-            minHeight: '18px',
-            backgroundColor: data.clarity_color || 'red'
-            }}
-          >
-            &nbsp;
-          </Box>
-          </Box>
+          <ProgressBar
+            value={Number(data.radio_clarity)/100}
+            color={data.clarity_color || 'red'}
+            height='18px'
+            >
+            {''}
+          </ProgressBar>
           <Box textAlign="center" mt={0.5} bold color="white">
             {data.radio_clarity}%
           </Box>

--- a/tgui/packages/tgui/interfaces/OverwatchConsole.tsx
+++ b/tgui/packages/tgui/interfaces/OverwatchConsole.tsx
@@ -236,7 +236,7 @@ const MainDashboard = (props) => {
       <Box textAlign="center">
         <Button
           inline
-          width="23%"
+          width="48%"
           icon="envelope"
           onClick={() => act('set_primary')}
         >
@@ -245,7 +245,7 @@ const MainDashboard = (props) => {
         {primary_objective && (
           <Button
             inline
-            width="23%"
+            width="48%"
             icon="person"
             onClick={() => act('remind_primary')}
           >
@@ -254,7 +254,7 @@ const MainDashboard = (props) => {
         )}
         <Button
           inline
-          width="23%"
+          width="48%"
           icon="envelope"
           onClick={() => act('set_secondary')}
         >
@@ -263,7 +263,7 @@ const MainDashboard = (props) => {
         {secondary_objective && (
           <Button
             inline
-            width="23%"
+            width="48%"
             icon="person"
             onClick={() => act('remind_secondary')}
           >
@@ -299,10 +299,26 @@ const MainDashboard = (props) => {
           <Box textAlign="center" mb={1} fontSize="12px">
             {data.clarity_status}
           </Box>
-          <ProgressBar
-            value={data.radio_clarity / 100}
-            color={data.clarity_color || 'red'}
-            height="18px"/>
+          <Box
+            style={{
+            width: '100%',
+            height: '18px',
+            backgroundColor: 'black',
+            border: '1px solid rgba(255,255,255,0.2)',
+            marginBottom: '4px'
+            }}
+          >
+          <Box
+            style={{
+            width: Number(data.radio_clarity) + '%',
+            height: "100%",
+            minHeight: '18px',
+            backgroundColor: data.clarity_color || 'red'
+            }}
+          >
+            &nbsp;
+          </Box>
+          </Box>
           <Box textAlign="center" mt={0.5} bold color="white">
             {data.radio_clarity}%
           </Box>

--- a/tgui/packages/tgui/interfaces/OverwatchConsole.tsx
+++ b/tgui/packages/tgui/interfaces/OverwatchConsole.tsx
@@ -242,25 +242,25 @@ const MainDashboard = (props) => {
                   mt={0.5}
                   width="49%"
                   icon="envelope"
-                  style={{ textAlign: 'Center'}}
+                  style={{ textAlign: 'Center' }}
                   onClick={() => act('set_primary')}
                   >
                   SET PRIMARY
                 </Button>
                 {primary_objective && (
-                <Button
-                  width="49%"
-                  inline
-                  mt={0.5}
-                  icon="person"
-                  style={{ textAlign: 'Center'}}
-                  onClick={() => act('remind_primary')}
-                  >
-                  REMIND PRIMARY
-                </Button>
-              )}
-            </Stack>
-          </Table.Cell>
+                  <Button
+                    width="49%"
+                    inline
+                    mt={0.5}
+                    icon="person"
+                    style={{ textAlign: 'Center' }}
+                    onClick={() => act('remind_primary')}
+                    >
+                    REMIND PRIMARY
+                  </Button>
+                )}
+              </Stack>
+            </Table.Cell>
           <Table.Cell style={{ border: 'none' }} textAlign="left">
             <Stack vertical={false} justify="flex-start">
               <Button
@@ -268,26 +268,26 @@ const MainDashboard = (props) => {
                 mt={0.5}
                 width="49%"
                 icon="envelope"
-                style={{ textAlign: 'Center'}}
+                style={{ textAlign: 'Center' }}
                 onClick={() => act('set_secondary')}
                 >
                 SET SECONDARY
-                </Button>
+              </Button>
                 {secondary_objective && (
-                <Button
-                  inline
-                  mt={0.5}
-                  width="49%"
-                  style={{ textAlign: 'Center'}}
-                  icon="person"
-                  onClick={() => act('remind_secondary')}
-                >
-                REMIND SECONDARY
-                </Button>
-              )}
-            </Stack>
-          </Table.Cell>
-        </Table.Row>
+                  <Button
+                    inline
+                    mt={0.5}
+                    width="49%"
+                    style={{ textAlign: 'Center' }}
+                    icon="person"
+                    onClick={() => act('remind_secondary')}
+                  >
+                  REMIND SECONDARY
+                  </Button>
+                )}
+              </Stack>
+            </Table.Cell>
+          </Table.Row>
         <Table.Row style={{ border: 'none', background: 'none' }}>
           <Table.Cell width="50%" style={{ border: 'none' }} textAlign="right">
             <Button
@@ -295,19 +295,19 @@ const MainDashboard = (props) => {
                 mt={0.5}
                 width="65%"
                 icon="envelope"
-                style={{ textAlign: 'Center'}}
+                style={{ textAlign: 'Center' }}
                 onClick={() => act('message')}
               >
               MESSAGE SQUAD
-              </Button>
-            </Table.Cell>
-            <Table.Cell width="50%" style={{ border: 'none' }} textAlign="left">
+            </Button>
+          </Table.Cell>
+          <Table.Cell width="50%" style={{ border: 'none' }} textAlign="left">
               <Button
                 inline
                 mt={0.5}
                 width="65%"
                 icon="envelope"
-                style={{ textAlign: 'Center'}}
+                style={{ textAlign: 'Center' }}
                 onClick={() => act('sl_message')}
                 >
                 MESSAGE SQUAD LEADER

--- a/tgui/packages/tgui/interfaces/OverwatchConsole.tsx
+++ b/tgui/packages/tgui/interfaces/OverwatchConsole.tsx
@@ -217,126 +217,140 @@ const MainDashboard = (props) => {
         </>
       }
     >
-    <Stack vertical={false} justify="space-between" align="stretch">
-      <Stack.Item grow={1} mr={1}>
-        <Table mb="5px">
-          <Table.Row bold>
-            <Table.Cell width="50%" textAlign="center">PRIMARY ORDERS</Table.Cell>
-            <Table.Cell textAlign="center">SECONDARY ORDERS</Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell textAlign="center">
-            {primary_objective ? primary_objective : 'NONE'}
-            </Table.Cell>
-            <Table.Cell textAlign="center">
-            {secondary_objective ? secondary_objective : 'NONE'}
-            </Table.Cell>
-          </Table.Row>
-        </Table>
-        <Table style={{ border: 'none', background: 'none' }}>
-          <Table.Row style={{ border: 'none', background: 'none' }}>
-            <Table.Cell width="50%" style={{ border: 'none' }} textAlign="right">
-              <Stack vertical={false} justify="flex-end">
+      <Stack vertical={false} justify="space-between" align="stretch">
+        <Stack.Item grow={1} mr={1}>
+          <Table mb="5px">
+            <Table.Row bold>
+              <Table.Cell width="50%" textAlign="center">
+                PRIMARY ORDERS
+              </Table.Cell>
+              <Table.Cell textAlign="center">SECONDARY ORDERS</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell textAlign="center">
+                {primary_objective ? primary_objective : 'NONE'}
+              </Table.Cell>
+              <Table.Cell textAlign="center">
+                {secondary_objective ? secondary_objective : 'NONE'}
+              </Table.Cell>
+            </Table.Row>
+          </Table>
+          <Table style={{ border: 'none', background: 'none' }}>
+            <Table.Row style={{ border: 'none', background: 'none' }}>
+              <Table.Cell
+                width="50%"
+                style={{ border: 'none' }}
+                textAlign="right"
+              >
+                <Stack vertical={false} justify="flex-end">
+                  <Button
+                    inline
+                    mt={0.5}
+                    width="49%"
+                    icon="envelope"
+                    style={{ textAlign: 'Center' }}
+                    onClick={() => act('set_primary')}
+                  >
+                    SET PRIMARY
+                  </Button>
+                  {primary_objective && (
+                    <Button
+                      width="49%"
+                      inline
+                      mt={0.5}
+                      icon="person"
+                      style={{ textAlign: 'Center' }}
+                      onClick={() => act('remind_primary')}
+                    >
+                      REMIND PRIMARY
+                    </Button>
+                  )}
+                </Stack>
+              </Table.Cell>
+              <Table.Cell style={{ border: 'none' }} textAlign="left">
+                <Stack vertical={false} justify="flex-start">
+                  <Button
+                    inline
+                    mt={0.5}
+                    width="49%"
+                    icon="envelope"
+                    style={{ textAlign: 'Center' }}
+                    onClick={() => act('set_secondary')}
+                  >
+                    SET SECONDARY
+                  </Button>
+                  {secondary_objective && (
+                    <Button
+                      inline
+                      mt={0.5}
+                      width="49%"
+                      style={{ textAlign: 'Center' }}
+                      icon="person"
+                      onClick={() => act('remind_secondary')}
+                    >
+                      REMIND SECONDARY
+                    </Button>
+                  )}
+                </Stack>
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row style={{ border: 'none', background: 'none' }}>
+              <Table.Cell
+                width="50%"
+                style={{ border: 'none' }}
+                textAlign="right"
+              >
                 <Button
                   inline
                   mt={0.5}
-                  width="49%"
+                  width="65%"
                   icon="envelope"
                   style={{ textAlign: 'Center' }}
-                  onClick={() => act('set_primary')}
-                  >
-                  SET PRIMARY
-                </Button>
-                {primary_objective && (
-                  <Button
-                    width="49%"
-                    inline
-                    mt={0.5}
-                    icon="person"
-                    style={{ textAlign: 'Center' }}
-                    onClick={() => act('remind_primary')}
-                    >
-                    REMIND PRIMARY
-                  </Button>
-                )}
-              </Stack>
-            </Table.Cell>
-          <Table.Cell style={{ border: 'none' }} textAlign="left">
-            <Stack vertical={false} justify="flex-start">
-              <Button
-                inline
-                mt={0.5}
-                width="49%"
-                icon="envelope"
-                style={{ textAlign: 'Center' }}
-                onClick={() => act('set_secondary')}
+                  onClick={() => act('message')}
                 >
-                SET SECONDARY
-              </Button>
-                {secondary_objective && (
-                  <Button
-                    inline
-                    mt={0.5}
-                    width="49%"
-                    style={{ textAlign: 'Center' }}
-                    icon="person"
-                    onClick={() => act('remind_secondary')}
-                  >
-                  REMIND SECONDARY
-                  </Button>
-                )}
-            </Stack>
-          </Table.Cell>
-          </Table.Row>
-          <Table.Row style={{ border: 'none', background: 'none' }}>
-          <Table.Cell width="50%" style={{ border: 'none' }} textAlign="right">
-            <Button
-                inline
-                mt={0.5}
-                width="65%"
-                icon="envelope"
-                style={{ textAlign: 'Center' }}
-                onClick={() => act('message')}
+                  MESSAGE SQUAD
+                </Button>
+              </Table.Cell>
+              <Table.Cell
+                width="50%"
+                style={{ border: 'none' }}
+                textAlign="left"
               >
-              MESSAGE SQUAD
-            </Button>
-          </Table.Cell>
-          <Table.Cell width="50%" style={{ border: 'none' }} textAlign="left">
-            <Button
-              inline
-              mt={0.5}
-              width="65%"
-              icon="envelope"
-              style={{ textAlign: 'Center' }}
-              onClick={() => act('sl_message')}
-              >
-              MESSAGE SQUAD LEADER
-            </Button>
-          </Table.Cell>
-          </Table.Row>
-        </Table>
-      </Stack.Item>
-      <Stack.Item width="120px">
-        <Box>
-          <Box textAlign="center" bold color="label" mb={0.5}>
-          SIGNAL CLARITY
-          </Box>
-          <Box textAlign="center" mb={1} fontSize="12px">
-          {data.clarity_status}
-          </Box>
+                <Button
+                  inline
+                  mt={0.5}
+                  width="65%"
+                  icon="envelope"
+                  style={{ textAlign: 'Center' }}
+                  onClick={() => act('sl_message')}
+                >
+                  MESSAGE SQUAD LEADER
+                </Button>
+              </Table.Cell>
+            </Table.Row>
+          </Table>
+        </Stack.Item>
+        <Stack.Item width="120px">
+          <Box>
+            <Box textAlign="center" bold color="label" mb={0.5}>
+              SIGNAL CLARITY
+            </Box>
+            <Box textAlign="center" mb={1} fontSize="12px">
+              {data.clarity_status}
+            </Box>
             <ProgressBar
-              value={Number(data.radio_clarity)/100}
+              value={Number(data.radio_clarity) / 100}
               color={data.clarity_color || 'red'}
-              height='18px'
+              height="18px"
             >
-            {''}
+              {''}
             </ProgressBar>
             <Box textAlign="center" mt={0.5} bold color="white">
-            {data.radio_clarity}%
+              {data.radio_clarity}%
             </Box>
-        </Box>
-      </Stack.Item>
-    </Stack>
+          </Box>
+        </Stack.Item>
+      </Stack>
     </Section>
   );
 };

--- a/tgui/packages/tgui/interfaces/OverwatchConsole.tsx
+++ b/tgui/packages/tgui/interfaces/OverwatchConsole.tsx
@@ -236,28 +236,28 @@ const MainDashboard = (props) => {
         <Table style={{ border: 'none', background: 'none' }}>
           <Table.Row style={{ border: 'none', background: 'none' }}>
             <Table.Cell width="50%" style={{ border: 'none' }} textAlign="right">
-              <Stack vertical= {false} justify="flex-end">
-              <Button
-                inline
-                mt= {0.5}
-                width="49%"
-                icon="envelope"
-                style={{ textAlign: 'Center'}}
-                onClick={() => act('set_primary')}
-                >
-                SET PRIMARY
-              </Button>
-              {primary_objective && (
-              <Button
-                width="49%"
-                inline
-                mt={0.5}
-                icon="person"
-                style={{ textAlign: 'Center'}}
-                onClick={() => act('remind_primary')}
-                >
-                REMIND PRIMARY
-              </Button>
+              <Stack vertical={false} justify="flex-end">
+                <Button
+                  inline
+                  mt={0.5}
+                  width="49%"
+                  icon="envelope"
+                  style={{ textAlign: 'Center'}}
+                  onClick={() => act('set_primary')}
+                  >
+                  SET PRIMARY
+                </Button>
+                {primary_objective && (
+                <Button
+                  width="49%"
+                  inline
+                  mt={0.5}
+                  icon="person"
+                  style={{ textAlign: 'Center'}}
+                  onClick={() => act('remind_primary')}
+                  >
+                  REMIND PRIMARY
+                </Button>
               )}
             </Stack>
           </Table.Cell>
@@ -271,19 +271,19 @@ const MainDashboard = (props) => {
                 style={{ textAlign: 'Center'}}
                 onClick={() => act('set_secondary')}
                 >
-              SET SECONDARY
-              </Button>
-              {secondary_objective && (
-              <Button
-                inline
-                mt={0.5}
-                width="49%"
-                style={{ textAlign: 'Center'}}
-                icon="person"
-                onClick={() => act('remind_secondary')}
-              >
-              REMIND SECONDARY
-              </Button>
+                SET SECONDARY
+                </Button>
+                {secondary_objective && (
+                <Button
+                  inline
+                  mt={0.5}
+                  width="49%"
+                  style={{ textAlign: 'Center'}}
+                  icon="person"
+                  onClick={() => act('remind_secondary')}
+                >
+                REMIND SECONDARY
+                </Button>
               )}
             </Stack>
           </Table.Cell>
@@ -292,12 +292,12 @@ const MainDashboard = (props) => {
           <Table.Cell width="50%" style={{ border: 'none' }} textAlign="right">
             <Button
                 inline
-                mt= {0.5}
+                mt={0.5}
                 width="65%"
                 icon="envelope"
                 style={{ textAlign: 'Center'}}
                 onClick={() => act('message')}
-                >
+              >
               MESSAGE SQUAD
               </Button>
             </Table.Cell>
@@ -308,7 +308,7 @@ const MainDashboard = (props) => {
                 width="65%"
                 icon="envelope"
                 style={{ textAlign: 'Center'}}
-                onClick= {() => act('sl_message')}
+                onClick={() => act('sl_message')}
                 >
                 MESSAGE SQUAD LEADER
               </Button>

--- a/tgui/packages/tgui/interfaces/OverwatchConsole.tsx
+++ b/tgui/packages/tgui/interfaces/OverwatchConsole.tsx
@@ -8,6 +8,7 @@ import {
   Input,
   LabeledControls,
   NumberInput,
+  ProgressBar,
   Section,
   Stack,
   Table,
@@ -69,6 +70,9 @@ type Data = {
   ob_safety: Boolean;
   supply_cooldown: number;
   operator: string;
+  radio_clarity: number;
+  clarity_color: string;
+  clarity_status: string;
 };
 
 export const OverwatchConsole = (props) => {
@@ -213,20 +217,22 @@ const MainDashboard = (props) => {
         </>
       }
     >
-      <Table mb="5px">
-        <Table.Row bold>
-          <Table.Cell textAlign="center">PRIMARY ORDERS</Table.Cell>
-          <Table.Cell textAlign="center">SECONDARY ORDERS</Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <Table.Cell textAlign="center">
-            {primary_objective ? primary_objective : 'NONE'}
-          </Table.Cell>
-          <Table.Cell textAlign="center">
-            {secondary_objective ? secondary_objective : 'NONE'}
-          </Table.Cell>
-        </Table.Row>
-      </Table>
+    <Stack vertical={false} justify="space-between" align="stretch">
+      <Stack.Item grow={1} mr={1}>
+        <Table mb="5px">
+          <Table.Row bold>
+            <Table.Cell textAlign="center">PRIMARY ORDERS</Table.Cell>
+            <Table.Cell textAlign="center">SECONDARY ORDERS</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+           <Table.Cell textAlign="center">
+              {primary_objective ? primary_objective : 'NONE'}
+            </Table.Cell>
+            <Table.Cell textAlign="center">
+             {secondary_objective ? secondary_objective : 'NONE'}
+            </Table.Cell>
+          </Table.Row>
+        </Table>
       <Box textAlign="center">
         <Button
           inline
@@ -284,7 +290,26 @@ const MainDashboard = (props) => {
           MESSAGE SQUAD LEADER
         </Button>
       </Box>
-    </Section>
+      </Stack.Item>
+      <Stack.Item width="150px">
+        <Box>
+          <Box textAlign="center" bold color="label" mb={0.5}>
+            SIGNAL CLARITY
+          </Box>
+          <Box textAlign="center" mb={1} fontSize="12px">
+            {data.clarity_status}
+          </Box>
+          <ProgressBar
+            value={data.radio_clarity / 100}
+            color={data.clarity_color || 'red'}
+            height="18px"/>
+          <Box textAlign="center" mt={0.5} bold color="white">
+            {data.radio_clarity}%
+          </Box>
+        </Box>
+      </Stack.Item>
+    </Stack>
+  </Section>
   );
 };
 

--- a/tgui/packages/tgui/interfaces/OverwatchConsole.tsx
+++ b/tgui/packages/tgui/interfaces/OverwatchConsole.tsx
@@ -226,24 +226,24 @@ const MainDashboard = (props) => {
           </Table.Row>
           <Table.Row>
             <Table.Cell textAlign="center">
-              {primary_objective ? primary_objective : 'NONE'}
+            {primary_objective ? primary_objective : 'NONE'}
             </Table.Cell>
             <Table.Cell textAlign="center">
-             {secondary_objective ? secondary_objective : 'NONE'}
+            {secondary_objective ? secondary_objective : 'NONE'}
             </Table.Cell>
           </Table.Row>
         </Table>
-        <Table style= {{ border: 'none', background: 'none' }}>
-          <Table.Row style= {{ border: 'none', background: 'none' }}>
-            <Table.Cell width="50%" style= {{ border: 'none' }} textAlign="right">
+        <Table style={{ border: 'none', background: 'none' }}>
+          <Table.Row style={{ border: 'none', background: 'none' }}>
+            <Table.Cell width="50%" style={{ border: 'none' }} textAlign="right">
               <Stack vertical= {false} justify="flex-end">
               <Button
                 inline
                 mt= {0.5}
                 width="49%"
                 icon="envelope"
-                style= {{ textAlign: 'Center'}}
-                onClick= {() => act('set_primary')}
+                style={{ textAlign: 'Center'}}
+                onClick={() => act('set_primary')}
                 >
                 SET PRIMARY
               </Button>
@@ -251,26 +251,26 @@ const MainDashboard = (props) => {
               <Button
                 width="49%"
                 inline
-                mt= {0.5}
+                mt={0.5}
                 icon="person"
-                style= {{ textAlign: 'Center'}}
-                onClick= {() => act('remind_primary')}
+                style={{ textAlign: 'Center'}}
+                onClick={() => act('remind_primary')}
                 >
                 REMIND PRIMARY
               </Button>
               )}
             </Stack>
           </Table.Cell>
-          <Table.Cell style= {{ border: 'none' }} textAlign="left">
-            <Stack vertical= {false} justify="flex-start">
+          <Table.Cell style={{ border: 'none' }} textAlign="left">
+            <Stack vertical={false} justify="flex-start">
               <Button
                 inline
-                mt= {0.5}
+                mt={0.5}
                 width="49%"
                 icon="envelope"
-                style= {{ textAlign: 'Center'}}
-                onClick= {() => act('set_secondary')}
-              >
+                style={{ textAlign: 'Center'}}
+                onClick={() => act('set_secondary')}
+                >
               SET SECONDARY
               </Button>
               {secondary_objective && (
@@ -278,9 +278,9 @@ const MainDashboard = (props) => {
                 inline
                 mt={0.5}
                 width="49%"
-                style= {{ textAlign: 'Center'}}
+                style={{ textAlign: 'Center'}}
                 icon="person"
-                onClick= {() => act('remind_secondary')}
+                onClick={() => act('remind_secondary')}
               >
               REMIND SECONDARY
               </Button>
@@ -288,26 +288,26 @@ const MainDashboard = (props) => {
             </Stack>
           </Table.Cell>
         </Table.Row>
-        <Table.Row style= {{ border: 'none', background: 'none' }}>
-          <Table.Cell width="50%" style= {{ border: 'none' }} textAlign="right">
+        <Table.Row style={{ border: 'none', background: 'none' }}>
+          <Table.Cell width="50%" style={{ border: 'none' }} textAlign="right">
             <Button
                 inline
                 mt= {0.5}
                 width="65%"
                 icon="envelope"
-                style= {{ textAlign: 'Center'}}
-                onClick= {() => act('message')}
-              >
+                style={{ textAlign: 'Center'}}
+                onClick={() => act('message')}
+                >
               MESSAGE SQUAD
               </Button>
             </Table.Cell>
-            <Table.Cell width="50%" style= {{ border: 'none' }} textAlign="left">
+            <Table.Cell width="50%" style={{ border: 'none' }} textAlign="left">
               <Button
                 inline
-                mt= {0.5}
+                mt={0.5}
                 width="65%"
                 icon="envelope"
-                style= {{ textAlign: 'Center'}}
+                style={{ textAlign: 'Center'}}
                 onClick= {() => act('sl_message')}
                 >
                 MESSAGE SQUAD LEADER
@@ -318,20 +318,20 @@ const MainDashboard = (props) => {
       </Stack.Item>
       <Stack.Item width="120px">
         <Box>
-          <Box textAlign="center" bold color="label" mb= {0.5}>
+          <Box textAlign="center" bold color="label" mb={0.5}>
           SIGNAL CLARITY
           </Box>
-          <Box textAlign="center" mb= {1} fontSize="12px">
+          <Box textAlign="center" mb={1} fontSize="12px">
           {data.clarity_status}
           </Box>
             <ProgressBar
-              value= {Number(data.radio_clarity)/100}
-              color= {data.clarity_color || 'red'}
+              value={Number(data.radio_clarity)/100}
+              color={data.clarity_color || 'red'}
               height='18px'
             >
             {''}
             </ProgressBar>
-            <Box textAlign="center" mt= {0.5} bold color="white">
+            <Box textAlign="center" mt={0.5} bold color="white">
             {data.radio_clarity}%
             </Box>
           </Box>

--- a/tgui/packages/tgui/interfaces/OverwatchConsole.tsx
+++ b/tgui/packages/tgui/interfaces/OverwatchConsole.tsx
@@ -285,10 +285,10 @@ const MainDashboard = (props) => {
                   REMIND SECONDARY
                   </Button>
                 )}
-              </Stack>
-            </Table.Cell>
+            </Stack>
+          </Table.Cell>
           </Table.Row>
-        <Table.Row style={{ border: 'none', background: 'none' }}>
+          <Table.Row style={{ border: 'none', background: 'none' }}>
           <Table.Cell width="50%" style={{ border: 'none' }} textAlign="right">
             <Button
                 inline
@@ -302,17 +302,17 @@ const MainDashboard = (props) => {
             </Button>
           </Table.Cell>
           <Table.Cell width="50%" style={{ border: 'none' }} textAlign="left">
-              <Button
-                inline
-                mt={0.5}
-                width="65%"
-                icon="envelope"
-                style={{ textAlign: 'Center' }}
-                onClick={() => act('sl_message')}
-                >
-                MESSAGE SQUAD LEADER
-              </Button>
-            </Table.Cell>
+            <Button
+              inline
+              mt={0.5}
+              width="65%"
+              icon="envelope"
+              style={{ textAlign: 'Center' }}
+              onClick={() => act('sl_message')}
+              >
+              MESSAGE SQUAD LEADER
+            </Button>
+          </Table.Cell>
           </Table.Row>
         </Table>
       </Stack.Item>
@@ -334,9 +334,9 @@ const MainDashboard = (props) => {
             <Box textAlign="center" mt={0.5} bold color="white">
             {data.radio_clarity}%
             </Box>
-          </Box>
-        </Stack.Item>
-      </Stack>
+        </Box>
+      </Stack.Item>
+    </Stack>
     </Section>
   );
 };


### PR DESCRIPTION
# About the pull request
this was a good idea: https://forum.cm-ss13.com/t/overwatch-console-radio-clarity-meter/20423. so i DID it

adds a meter to the overwatch console UI to show the announcement signal strength based on the groundside comms garble. accounts for decoder sequences, drops dynamically in real time, and unobtrusively doesn't extend the OW console interface to make it any longer.

44% clarity or less = CRITICAL BLACKOUT / red
45% to 79% clarity = DEGRADED / orange
80% clarity or greater = STABLE / green

# Explain why it's good for the game
more feedback for butterbars that no one can hear them
 groundside overwatch console still needs this added but that UI is a jenga block stack i fear

uhhhhhh feel free to lmk if there's something different for how i should handle ftl crashes; i left as-is because i feel like survivors running out to the comms towers to set them up is very sovlful

# Testing Photographs and Procedure
<img width="1104" height="753" alt="Screenshot 2026-05-26 143147" src="https://github.com/user-attachments/assets/4819ad8f-0425-4ef4-939a-510b94b73a5a" />
<img width="1113" height="749" alt="Screenshot 2026-05-26 143201" src="https://github.com/user-attachments/assets/aca4004d-e9c4-45cb-9286-4a71fc5b299b" />
<img width="1097" height="756" alt="Screenshot 2026-05-26 143307" src="https://github.com/user-attachments/assets/c448ca60-562d-44a8-94d4-b97d2560f42d" />
<img width="1149" height="757" alt="Screenshot 2026-05-26 143720" src="https://github.com/user-attachments/assets/200bfbd2-8dfb-40df-879c-47d704a267db" />

not broken, updates dynamically, matches tgui, doesn't extend past the console window

only edge case is based on the radio garble itself. you can TECHNICALLY have your radio tower set up but if you don't have fac frequency added, but do have decrypt updated, it'll max at 95% and slowly degrade over time to follow with the announcement clarity degradation. once you add fac freq, it goes back to 100%.

# Changelog

:cl:
add: added an announcement clarity meter to Overwatch consoles so you no longer scream into the void, Lieutenant
ui: added an announcement clarity meter to Overwatch consoles
/:cl: