### PR TITLE
Fixed sharp flechette and any other pb projectile interaction

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -642,7 +642,7 @@
 	else
 		effective_accuracy -= (distance_travelled - ammo.accurate_range) * ((ammo_flags & AMMO_SNIPER) ? 1.5 : 10) // Snipers have a smaller falloff constant due to longer max range
 
-	if(distance_travelled <= ammo.accurate_range_min_strict)
+	if(ammo.accurate_range_min_strict > 0 && distance_travelled <= ammo.accurate_range_min_strict)
 		return 0
 
 	effective_accuracy = max(5, effective_accuracy) //default hit chance is at least 5%.


### PR DESCRIPTION

# About the pull request

Fixed some unintended impacts from the Despoiler's min accurate range change, which caused all projectiles that didn't travel X distance to automatically miss. Since standard ammo's min was 0, and SHARP Flechette Dart's flechette projectiles technically traveled 0 tiles, this led to them automatically missing.

Now it also checks if it isn't set to the default value of 0 (Despoiler's spit is set to 3, bullets are set to 0), so that projectiles that spawn on the target do not automatically miss.

Despoiler still can't hit people with their spit within 3 tiles, I tested to be sure.

Closes #12284, #12233
# Explain why it's good for the game

Less bugs = good


# Testing Photographs and Procedure

https://github.com/user-attachments/assets/4892e085-7503-4d38-ab2f-4b0d59effca8



<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixed SHARP Flechette Dart direct hits not registering the additional flechette properly, along with other projectile direct hits interactions.
/:cl:
