### PR TITLE
Adds a new grinder and phoron in PMC ERT station

### DIFF
--- a/maps/templates/lazy_templates/weyland_ert_station.dmm
+++ b/maps/templates/lazy_templates/weyland_ert_station.dmm
@@ -662,6 +662,8 @@
 /obj/item/storage/firstaid/adv,
 /obj/item/storage/belt/medical/lifesaver/full,
 /obj/structure/surface/table/reinforced/almayer_B,
+/obj/item/roller,
+/obj/item/roller,
 /turf/open/floor/corsat/green,
 /area/adminlevel/ert_station/weyland_station)
 "lo" = (
@@ -829,9 +831,14 @@
 /turf/open/floor/plating/plating_catwalk/strata,
 /area/adminlevel/ert_station/weyland_station)
 "nJ" = (
-/obj/item/roller,
-/obj/item/roller,
 /obj/structure/surface/table/reinforced/almayer_B,
+/obj/structure/machinery/reagentgrinder{
+	pixel_y = 6
+	},
+/obj/item/stack/sheet/mineral/phoron{
+	amount = 25;
+	pixel_y = 1
+	},
 /turf/open/floor/corsat/green/southwest,
 /area/adminlevel/ert_station/weyland_station)
 "nQ" = (


### PR DESCRIPTION

# About the pull request
Fixes #11753 by adding a grinder and a stick of phoron on PMC ERT station

# Explain why it's good for the game
The ability to make clonexadone on your own without having admin intervention


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: Adds a grinder and phoron in PMC ERT station for the ability to make clonexadone  again
/:cl:
