### PR TITLE
Vendor Auto-equip fixes

### DIFF
--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -1460,11 +1460,11 @@ GLOBAL_LIST_INIT(cm_vending_gear_corresponding_types_list, list(
 	if(vend_flags & VEND_UNIFORM_AUTOEQUIP)
 		// autoequip
 		if(istype(new_item, /obj/item) && new_item.flags_equip_slot != NO_FLAGS) //auto-equipping feature here
-			if(new_item.flags_equip_slot == SLOT_ACCESSORY)
-				if(user.w_uniform)
-					var/obj/item/clothing/clothing = user.w_uniform
-					if(clothing.can_attach_accessory(new_item))
-						clothing.attach_accessory(user, new_item)
+			if(new_item.flags_equip_slot & SLOT_ACCESSORY)
+				for(var/obj/item/clothing/attaching in list(user.w_uniform, user.head)) // probably better to use a global here, but accessories are currently only concerned about these two for now
+					if(attaching.can_attach_accessory(new_item))
+						attaching.attach_accessory(user, new_item)
+						break
 			else
 				user.equip_to_appropriate_slot(new_item)
 				new_item.update_icon()

--- a/code/game/objects/items/devices/whistle.dm
+++ b/code/game/objects/items/devices/whistle.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/items/tools.dmi'
 	w_class = SIZE_TINY
 	flags_atom = FPRINT|CONDUCT
-	flags_equip_slot = SLOT_FACE
+	flags_equip_slot = SLOT_FACE | SLOT_ACCESSORY
 	actions_types = list(/datum/action/item_action/toggle/use/whistle)
 	item_icons = list(
 		WEAR_FACE = 'icons/mob/humans/onmob/clothing/masks/objects.dmi'


### PR DESCRIPTION

# About the pull request

Title

# Explain why it's good for the game

Bug fix, and slightly updates auto-equip vendor code to respect helmet accessories as well (rain covers, etc)

Also fixes being able to eat whistles, I forgot to add the accessory flag to it

Codewise, vend_uniform_autoequip no longer uses a strictly equal operator, and just checks if the accessory flag exists

Ordinarily, I would also make it so that helmet garb would be automatically inserted, but that will be in #12281

Closes: #11997 

# Testing Photographs and Procedure
it works
# Changelog
:cl:
code: Helmet accessories now supports vendor auto equipping 
fix: You can no longer eat whistles through vendors
/:cl:
