### PR TITLE
masks working joe records on consoles

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -250,3 +250,13 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 	qdel(clothes_s)
 
 	return preview_icon
+
+//remove joes from medical and sec records; leaving open as a list
+//in case someone comes up with others who should be excluded
+/proc/is_record_visible(datum/data/record/console_record)
+	if(!console_record)
+		return FALSE
+	var/static/list/hidden_ranks = list(
+		SYNTH_WORKING_JOE
+	)
+	return !(console_record.fields["rank"] in hidden_ranks)

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -220,7 +220,6 @@
 
 /obj/structure/machinery/computer/med_data/ui_data(mob/user)
 	. = ..()
-
 	// Map medical records via id
 	var/list/records = list()
 	var/list/medical_record = list()
@@ -228,6 +227,8 @@
 		medical_record[medical.fields["id"]] = medical
 
 	for (var/datum/data/record/general in GLOB.data_core.general)
+		if(!is_record_visible(general))
+			continue
 		var/id_number = general.fields["id"]
 		var/datum/data/record/medical = medical_record[id_number]
 

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -55,6 +55,8 @@
 		security_map[security.fields["id"]] = security
 
 	for (var/datum/data/record/general in GLOB.data_core.general)
+		if (general.fields["rank"] == SYNTH_WORKING_JOE)
+			continue
 		var/id = general.fields["id"]
 		var/datum/data/record/security = security_map[id]
 

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -49,17 +49,15 @@
 	.["scanner"] = scanner_status
 
 	// Map security records via id
-	var/list/records = list()
 	var/list/security_map = list()
 	for (var/datum/data/record/security in GLOB.data_core.security)
 		security_map[security.fields["id"]] = security
-
+	var/list/records = list()
 	for (var/datum/data/record/general in GLOB.data_core.general)
-		if (general.fields["rank"] == SYNTH_WORKING_JOE)
+		if(!is_record_visible(general))
 			continue
 		var/id = general.fields["id"]
 		var/datum/data/record/security = security_map[id]
-
 		var/list/record = list(
 			"id" = id,
 			"general_name" = general.fields["name"],


### PR DESCRIPTION
# About the pull request
fixes #12022
joes have become ungovernable

# Explain why it's good for the game
joe records are masked from display in the records console UIs. this is done with a reusable proc defined on the datacore.dm because i imagine maybe one day this could be useful for masking other roles from lists (CBRN from manifest, survivor factions or VOs from lifesigns computers [actually that might be a really bad idea, VOs are common assassination targets])

completely UI-display-focused. datacore itself remains unchanged, so player records are safe!

TO BE CLEAR: joe is still on the vitals tracker; we must ensure the safety of our joes

# Testing Photographs and Procedure
i did be testing this.
i tested first with masking just on sec records and that was fine, then figured med records were done the same-ish way; i decided to make a helper proc for it since there's other masking on UIs that could be useful.
spawned in at each phase as a Joe, aghosted, respawned as MW or CMP, checked records PCs to see my record, but not Joe's. Joe was still on the manifest, though. confirmed against main branch that Joe records were successfully hidden. i'd include a screenshot of the UI here but it tells you like nothing since there's no joe record!

also tried to load VV for global vars but that ended up being a whole mistake so i did the lazy man's debug code-test to confirm the datacore list remained unchanged.

refactor tag to let people know about this FABULOUS NEW PROC!!! ABSOLUTELY FREE TO USE !!! especially to fix other bugs please someone

# Changelog
:cl:
fix: fixed working joes having security records
refactor: created helper proc to mask certain roles from UI displays on computers
/:cl: