### PR TITLE
Linux mapmerge scripts

### DIFF
--- a/tools/bootstrap/python
+++ b/tools/bootstrap/python
@@ -25,6 +25,12 @@ PythonDir="$Cache/python-$PythonVersion"
 PythonExe="$PythonDir/python.exe"
 Log="$Cache/last-command.log"
 
+# function that prints an error message and exits
+error_exit() {
+	echo "If you are seeing this message, please try to fix it by running tools/hooks/install.(bat/sh) again."
+	exit 1
+}
+
 # If a portable Python for Windows is not present, search on $PATH.
 if [ "$(uname)" = "Linux" ] || [ ! -f "$PythonExe" ]; then
 	# Strip the "App Execution Aliases" from $PATH. Even if the user installed
@@ -55,7 +61,7 @@ if [ "$(uname)" = "Linux" ] || [ ! -f "$PythonExe" ]; then
 			echo "Please install Python from https://www.python.org/downloads/ or using your system's package manager."
 		fi
 		echo
-		exit 1
+		error_exit
 	fi
 
 	# Create a venv and activate it
@@ -70,7 +76,7 @@ if [ "$(uname)" = "Linux" ] || [ ! -f "$PythonExe" ]; then
 		PythonExe="$PythonDir/scripts/python3.exe";
 	else
 		echo "bootstrap/python failed to find the python executable inside its virtualenv"
-		exit 1
+		error_exit
 	fi
 fi
 

--- a/tools/mapmerge2/README.md
+++ b/tools/mapmerge2/README.md
@@ -13,7 +13,7 @@ To install the [Git hooks], open the `tools/hooks/` folder and double-click
 `Install.bat`. Linux users run `tools/hooks/install.sh`.
 
 > Linux note: If you get an error like:
-> `./tools/mapmerge2/../bootstrap/python: not found`
+> `./tools/hooks/../bootstrap/python: not found`
 > You must update the line endings of the `tools/bootstrap/python` file to LF.
 
 

--- a/tools/mapmerge2/README.md
+++ b/tools/mapmerge2/README.md
@@ -12,12 +12,17 @@ For detailed troubleshooting instructions and other tips, visit the
 To install the [Git hooks], open the `tools/hooks/` folder and double-click
 `Install.bat`. Linux users run `tools/hooks/install.sh`.
 
+> Linux note: If you get an error like:
+> `./tools/mapmerge2/../bootstrap/python: not found`
+> You must update the line endings of the `tools/bootstrap/python` file to LF.
+
+
 ## Manual Use
 
 If using a Git GUI which is not compatible with the hooks:
 
-* Before committing, double-click `Run Before Committing.bat`
-* When a merge has map conflicts, double-click `Resolve Map Conflicts.bat`
+* Before committing, double-click `Run Before Committing.bat` (Linux: `run_before_committing_no_hooks_linux.sh`)
+* When a merge has map conflicts, double-click `Resolve Map Conflicts.bat` (Linux: `resolve_map_conflicts_no_hooks_linux.sh`)
 
 The console will show whether the operation succeeded.
 

--- a/tools/mapmerge2/i_forgot_to_map_merge_linux.sh
+++ b/tools/mapmerge2/i_forgot_to_map_merge_linux.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+"$(dirname "$0")/../bootstrap/python" -m hooks.install "$@"
+"$(dirname "$0")/../bootstrap/python" -m mapmerge2.fixup "$@"

--- a/tools/mapmerge2/resolve_map_conflicts_no_hooks_linux.sh
+++ b/tools/mapmerge2/resolve_map_conflicts_no_hooks_linux.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec "$(dirname "$0")/../bootstrap/python" -m mapmerge2.merge_driver --posthoc "$@"

--- a/tools/mapmerge2/run_before_committing_no_hooks_linux.sh
+++ b/tools/mapmerge2/run_before_committing_no_hooks_linux.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec "$(dirname "$0")/../bootstrap/python" -m mapmerge2.precommit --use-workdir "$@"


### PR DESCRIPTION

# About the pull request

This PR just adds some helper scripts to run the mapmerge scripts on linux and updates the readme some to accommodate. Also copied over the helper error messages from https://github.com/tgstation/tgstation/pull/94493

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="1983" height="833" alt="image" src="https://github.com/user-attachments/assets/b88d6cf6-294b-4abb-b294-d44894f7a054" />
<img width="733" height="65" alt="image" src="https://github.com/user-attachments/assets/8db3a656-3a8c-4865-817d-709bc0706d37" />

Replicating hooks installed but bootstrap cache missing: 
<img width="879" height="164" alt="image" src="https://github.com/user-attachments/assets/1f3dcad1-b7d1-4a9c-a9b3-afc6ffc532e4" />

</details>


# Changelog

No player facing changes.
