### PR TITLE
Potato Patches are not real in the neroid sector

### DIFF
--- a/code/modules/gear_presets/corpses.dm
+++ b/code/modules/gear_presets/corpses.dm
@@ -1145,7 +1145,7 @@
 	var/obj/item/clothing/under/marine/reconnaissance/uniform = new()
 	var/obj/item/clothing/accessory/storage/droppouch/pouch = new()
 	var/obj/item/clothing/accessory/ranks/marine/e5/pin = new()
-	var/obj/item/clothing/accessory/patch/patch_uscm = new()
+	var/obj/item/clothing/accessory/patch/uscmpatch/patch_uscm = new()
 	var/obj/item/clothing/accessory/patch/forecon/patch_forecon = new()
 	uniform.attach_accessory(new_human,pouch)
 	uniform.attach_accessory(new_human,patch_uscm)


### PR DESCRIPTION

# About the pull request


yeah potatoes arent real
theres always that one line of code you thought you fixed but havent

# Explain why it's good for the game

bugfix
closes: #12325 

# Testing Photographs and Procedure
line change

:cl:
fix: Fixes the forecon spotter corpse spawning the parent item for patches
/:cl:
