### PR TITLE
Fix riot in progress nightmare variable

### DIFF
--- a/maps/Nightmare/maps/FOP_v3_Sciannex/nightmare.json
+++ b/maps/Nightmare/maps/FOP_v3_Sciannex/nightmare.json
@@ -5,7 +5,7 @@
     "landmark": "riot_control",
     "chance": 0.5,
     "path": "standalone/riot_in_progress.dmm",
-    "when": { "riot_in_progress": "true" }
+    "when": { "riot_in_progress": "riot" }
 },
 {
     "type": "map_insert",


### PR DESCRIPTION

# About the pull request

This PR is a follow up #7768 which looks to incorrectly have change the variable check from `riot` to `true` despite https://github.com/cmss13-devs/cmss13/blob/5db6cec30633e3cc564fe90cf9d4d43cfbbcec0f/maps/Nightmare/maps/FOP_v3_Sciannex/scenario.json#L3-L8

# Explain why it's good for the game

Nightmare insert is now possible again.

# Testing Photographs and Procedure
Not tested.

# Changelog
:cl: Drathek
fix: Fixed the SciAnnex insert riot in progress not triggering
/:cl:
