### PR TITLE
Refactor hostile survivor check logic

### DIFF
--- a/code/__DEFINES/nightmare.dm
+++ b/code/__DEFINES/nightmare.dm
@@ -6,8 +6,8 @@
 #define NIGHTMARE_CTX_GROUND "ground"
 /// Ship Map Context: Performs actions relevant to the ship map
 #define NIGHTMARE_CTX_SHIP "ship"
-/// Hostile Survivor Scenarios
-#define NIGHTMARE_SCENARIO_HOSTILE_SURVIVOR list("lvevent" = list("fallen_ship", "clfpods", "clfraid", "clfcrash", "clfsmugglers", "clf", "clfship"), "riot_in_progress" = list("rocinante"), "panic_room" = list("clfraid"))
+/// Ground Map Context: Whether hostile survivors should be used instead
+#define NIGHTMARE_SCENARIO_HOSTILE_SURVIVOR "hostile_survivors"
 
 // File names for use in context configs
 #define NIGHTMARE_FILE_SCENARIO "scenario.json"

--- a/code/controllers/subsystem/nightmare.dm
+++ b/code/controllers/subsystem/nightmare.dm
@@ -12,8 +12,6 @@ SUBSYSTEM_DEF(nightmare)
 	var/list/contexts = list()
 	/// List of parsed file nodes
 	var/list/roots = list()
-	/// Associated list of scenarios that indicate hostile survivor spawning
-	var/list/hostile_survivor_scenarios = NIGHTMARE_SCENARIO_HOSTILE_SURVIVOR
 
 /datum/controller/subsystem/nightmare/Initialize(start_timeofday)
 	var/global_nightmare_path = CONFIG_GET(string/nightmare_path)
@@ -150,9 +148,5 @@ SUBSYSTEM_DEF(nightmare)
 /datum/controller/subsystem/nightmare/proc/get_scenario_is_hostile_survivor()
 	// Assumption: Only ground context is relevant
 	var/datum/nmcontext/ground_context = contexts[NIGHTMARE_CTX_GROUND]
-	for(var/key in hostile_survivor_scenarios)
-		var/scenario = ground_context.get_scenario_value(key)
-		for(var/value in hostile_survivor_scenarios[key])
-			if(scenario == value)
-				return TRUE
-	return FALSE
+	var/scenario = ground_context.get_scenario_value(NIGHTMARE_SCENARIO_HOSTILE_SURVIVOR)
+	return !!scenario

--- a/maps/Nightmare/maps/BigRed/scenario.json
+++ b/maps/Nightmare/maps/BigRed/scenario.json
@@ -2,8 +2,8 @@
     {
         "type": "pick", "name": "Big Red Global Event",
         "choices": [
-            { "weight": 7, "type": "def", "values": { "lvevent": "none"       } },
-            { "weight": 1, "type": "def", "values": { "lvevent": "clf" } },
+            { "weight": 7, "type": "def", "values": { "lvevent": "none" } },
+            { "weight": 1, "type": "def", "values": { "lvevent": "clf", "hostile_survivors": true } },
             { "weight": 2, "type": "def", "values": { "lvevent": "pmccrash" } }
         ]
     }

--- a/maps/Nightmare/maps/DesertDam/scenario.json
+++ b/maps/Nightmare/maps/DesertDam/scenario.json
@@ -4,7 +4,7 @@
     "choices": [
         { "weight": 5, "type": "def", "values": { "lvevent": "none" } },
         { "weight": 4, "type": "def", "values": { "lvevent": "uppcrash" } },
-        { "weight": 1, "type": "def", "values": { "lvevent": "clfpods" } }
+        { "weight": 1, "type": "def", "values": { "lvevent": "clfpods", "hostile_survivors": true } }
     ]
     }
 ]

--- a/maps/Nightmare/maps/FOP_v3_Sciannex/scenario.json
+++ b/maps/Nightmare/maps/FOP_v3_Sciannex/scenario.json
@@ -4,7 +4,7 @@
         "choices": [
             { "weight": 6, "type": "def", "values": { "riot_in_progress": "none" } },
             { "weight": 3, "type": "def", "values": { "riot_in_progress": "riot" } },
-            { "weight": 1, "type": "def", "values": { "riot_in_progress": "rocinante" } }
+            { "weight": 1, "type": "def", "values": { "riot_in_progress": "rocinante", "hostile_survivors": true } }
         ]
     }
 ]

--- a/maps/Nightmare/maps/Ice_Colony_v3/scenario.json
+++ b/maps/Nightmare/maps/Ice_Colony_v3/scenario.json
@@ -12,9 +12,9 @@
 {
     "type": "pick", "name": "Panic Room",
     "choices": [
-        { "weight": 6, "type": "def", "values": { "panic_room": "none"} },
-        { "weight": 3, "type": "def", "values": { "panic_room": "full"} },
-        { "weight": 1, "type": "def", "values": { "panic_room": "clfraid"} }
+        { "weight": 6, "type": "def", "values": { "panic_room": "none" } },
+        { "weight": 3, "type": "def", "values": { "panic_room": "full" } },
+        { "weight": 1, "type": "def", "values": { "panic_room": "clfraid", "hostile_survivors": true } }
     ]
 }
 

--- a/maps/Nightmare/maps/Kutjevo/scenario.json
+++ b/maps/Nightmare/maps/Kutjevo/scenario.json
@@ -3,7 +3,7 @@
         "type": "pick", "name": "event",
         "choices": [
             { "weight": 9, "type": "def", "values": { "lvevent": "none" } },
-            { "weight": 1, "type": "def", "values": { "lvevent": "clfsmugglers" } }
+            { "weight": 1, "type": "def", "values": { "lvevent": "clfsmugglers", "hostile_survivors": true } }
         ]
     }
 ]

--- a/maps/Nightmare/maps/LV624/nightmare.json
+++ b/maps/Nightmare/maps/LV624/nightmare.json
@@ -2,7 +2,7 @@
 	{
 		"type": "map_insert",
 		"landmark": "clfship",
-		"chance": 0.3,
+		"chance": 1.0,
 		"path": "standalone/clfship.dmm",
 		"when": { "lvevent": "fallen_ship" }
 	},

--- a/maps/Nightmare/maps/LV624/scenario.json
+++ b/maps/Nightmare/maps/LV624/scenario.json
@@ -10,10 +10,10 @@
 {
 	"type": "pick", "name": "LV624 Global Event",
 	"choices": [
-		{ "weight": 2, "type": "def", "values": { "lvevent": "none"       } },
+		{ "weight": 2, "type": "def", "values": { "lvevent": "none" } },
 		{ "weight": 4, "type": "def", "values": { "lvevent": "last_stand" } },
-		{ "weight": 2, "type": "def", "values": { "lvevent": "fallen_ship", "mainpath": "bridge"  } },
-		{ "weight": 2, "type": "def", "values": { "lvevent": "fallen_ship", "mainpath": "right" } },
+		{ "weight": 2, "type": "def", "values": { "lvevent": "fallen_ship", "mainpath": "bridge", "hostile_survivors": true } },
+		{ "weight": 2, "type": "def", "values": { "lvevent": "fallen_ship", "mainpath": "right", "hostile_survivors": true } },
 		{ "weight": 2, "type": "def", "values": { "lvevent": "asset_protection", "mainpath": "left" } }
 	]
 }

--- a/maps/Nightmare/maps/LV624/scenario.json
+++ b/maps/Nightmare/maps/LV624/scenario.json
@@ -12,8 +12,8 @@
 	"choices": [
 		{ "weight": 2, "type": "def", "values": { "lvevent": "none" } },
 		{ "weight": 4, "type": "def", "values": { "lvevent": "last_stand" } },
-		{ "weight": 2, "type": "def", "values": { "lvevent": "fallen_ship", "mainpath": "bridge", "hostile_survivors": true } },
-		{ "weight": 2, "type": "def", "values": { "lvevent": "fallen_ship", "mainpath": "right", "hostile_survivors": true } },
+		{ "weight": 1, "type": "def", "values": { "lvevent": "fallen_ship", "mainpath": "bridge", "hostile_survivors": true } },
+		{ "weight": 1, "type": "def", "values": { "lvevent": "fallen_ship", "mainpath": "right", "hostile_survivors": true } },
 		{ "weight": 2, "type": "def", "values": { "lvevent": "asset_protection", "mainpath": "left" } }
 	]
 }

--- a/maps/Nightmare/maps/LV759_Hybrisa_Prospera/scenario.json
+++ b/maps/Nightmare/maps/LV759_Hybrisa_Prospera/scenario.json
@@ -3,7 +3,7 @@
         "type": "pick", "name": "event",
         "choices": [
             { "weight": 6, "type": "def", "values": { "lvevent": "none" } },
-            { "weight": 1, "type": "def", "values": { "lvevent": "clfraid" } },
+            { "weight": 1, "type": "def", "values": { "lvevent": "clfraid", "hostile_survivors": true } },
             { "weight": 3, "type": "def", "values": { "lvevent": "twe_iasf" } }
         ]
     }

--- a/maps/Nightmare/maps/New_Varadero/scenario.json
+++ b/maps/Nightmare/maps/New_Varadero/scenario.json
@@ -3,7 +3,7 @@
         "type": "pick", "name": "event",
         "choices": [
             { "weight": 9, "type": "def", "values": { "lvevent": "none" } },
-            { "weight": 1, "type": "def", "values": { "lvevent": "clfraid" } }
+            { "weight": 1, "type": "def", "values": { "lvevent": "clfraid", "hostile_survivors": true } }
         ]
     }
 ]

--- a/maps/Nightmare/maps/Sorokyne_Strata/scenario.json
+++ b/maps/Nightmare/maps/Sorokyne_Strata/scenario.json
@@ -2,8 +2,8 @@
     {
         "type": "pick", "name": "Soro Global Event",
         "choices": [
-            { "weight": 5, "type": "def", "values": { "lvevent": "none"       } },
-            { "weight": 1, "type": "def", "values": { "lvevent": "clfcrash" } },
+            { "weight": 5, "type": "def", "values": { "lvevent": "none" } },
+            { "weight": 1, "type": "def", "values": { "lvevent": "clfcrash", "hostile_survivors": true } },
             { "weight": 4, "type": "def", "values": { "lvevent": "sof_insert" } }
         ]
     }


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #7816 refactoring how hostile survivors are checked.

Of note (I don't know if this was their original intention or not) in the scenario of say:
https://github.com/cmss13-devs/cmss13/blob/67ccee5d868012d7d26d9d66fd84a45e788dc2bd/maps/Nightmare/maps/LV624/nightmare.json#L2-L8
Since the map had a non 1.0 chance that means that it was being considered a hostile survivor scenario despite not spawning the map intended which is likely why `"Failed to spawn_in_player [key_name_admin(H)] as a survivor! This likely means NIGHTMARE_SCENARIO_HOSTILE_SURVIVOR is incorrect for this map!")` has been occurring on LV for lack of hostile survivor landmarks.

# Explain why it's good for the game

More consolidated I guess.
Fixes #12301

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="1206" height="784" alt="image" src="https://github.com/user-attachments/assets/aca51ad1-dc78-463d-b0cc-181d39fd5501" />
<img width="477" height="682" alt="image" src="https://github.com/user-attachments/assets/f0b48c31-a961-4e9f-98ae-6ab8a7f60840" />

</details>


# Changelog
:cl: Drathek
refactor: Refactored how get_scenario_is_hostile_survivor is determined
fix: Fixed at least one cause of hostile survivors failing to spawn sometimes on LV - This will result in different probabilities of the clf crashsite on LV now
/:cl:
