### PR TITLE
Working Joe modifier changes.

### DIFF
--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -1284,7 +1284,7 @@ Additional game mode variables.
 			to_chat(joe_candidate, SPAN_WARNING("Something went wrong!"))
 		return
 
-	if(!joe_job.check_whitelist_status(joe_candidate))
+	if(!joe_job.check_whitelist_status(joe_candidate) && !MODE_HAS_MODIFIER(/datum/gamemode_modifier/ignore_wj_restrictions))
 		if(show_warning)
 			to_chat(joe_candidate, SPAN_WARNING("You are not whitelisted! You may apply on the forums to be whitelisted as a synth."))
 		return
@@ -1309,11 +1309,6 @@ Additional game mode variables.
 			if(show_warning)
 				to_chat(joe_candidate, SPAN_WARNING("Only [joe_max] Working Joes may spawn per round."))
 			return
-
-	if(!GLOB.enter_allowed && !MODE_HAS_MODIFIER(/datum/gamemode_modifier/ignore_wj_restrictions))
-		if(show_warning)
-			to_chat(joe_candidate, SPAN_WARNING("There is an administrative lock from entering the game."))
-		return
 
 	if(show_warning && tgui_alert(joe_candidate, "Confirm joining as a Working Joe.", "Confirmation", list("Yes", "No"), 10 SECONDS) != "Yes")
 		return


### PR DESCRIPTION

# About the pull request

Allows Working Joes to join after hijack/round end. It's the main time they're played so I have no issues with them turning up at that point.
Also changes the disable WJ restrictions modifier to disable the WL requirement as it's somewhat implicative in the name already.

# Explain why it's good for the game

Hopefully means more people will play WJ as it's a nice RP thing to do after death.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Working Joe can now be joined after round end/hijack.
add: Staff disabling WJ restrictions will now open it to non-whitelisted players.
/:cl:
