### PR TITLE
half the knockdown time of backblast for xenos

### DIFF
--- a/code/modules/projectiles/guns/specialist/launcher/rocket_launcher.dm
+++ b/code/modules/projectiles/guns/specialist/launcher/rocket_launcher.dm
@@ -208,7 +208,7 @@
 		var/knockdown_amount = 6
 		if(isxeno(mob))
 			var/mob/living/carbon/xenomorph/xeno = mob
-			knockdown_amount = knockdown_amount * (1 - xeno.caste?.xeno_explosion_resistance / 100)
+			knockdown_amount = knockdown_amount * ((1 - xeno.caste?.xeno_explosion_resistance / 100) / 2)
 		mob.KnockDown(knockdown_amount)
 		mob.apply_effect(6, STUTTER)
 		mob.emote("pain")


### PR DESCRIPTION

# About the pull request
the knockdown of the backblast stun is halved, so for a despoiler (20 explosion armor) it goes from 4.8 seconds to 2.4

# Explain why it's good for the game
rockets shot from the launcher should be doing the stunning, not the big gas


# Testing Photographs and Procedure
i used my calculator

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: backblast knockdown time on xenos is halved
/:cl:
