### PR TITLE
putting the 'swag' back into 'scimitar' - reduces clickdelay of wrist scimitars from 1 SECOND to 0.5 SECONDS, implements a temporary bugfix

### DIFF
--- a/code/modules/cm_preds/yaut_bracers.dm
+++ b/code/modules/cm_preds/yaut_bracers.dm
@@ -502,7 +502,7 @@
 
 /obj/item/bracer_attachments/scimitars
 	name = "scimitar bracer attachment"
-	desc = "A pair of huge, serrated blades."
+	desc = "A pair of massive, serrated blades."
 	icon_state = "scim"
 	item_state = "scim"
 	attached_weapon_type = /obj/item/weapon/bracer_attachment/scimitar
@@ -511,7 +511,7 @@
 
 /obj/item/bracer_attachments/scimitars_alt
 	name = "scimitar bracer attachment"
-	desc = "A pair of huge, serrated blades."
+	desc = "A pair of massive, serrated blades."
 	icon_state = "scim_alt"
 	item_state = "scim_alt"
 	attached_weapon_type = /obj/item/weapon/bracer_attachment/scimitar/alt

--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -337,23 +337,57 @@
 /obj/item/weapon/bracer_attachment/scimitar
 	name = "wrist scimitar"
 	plural_name = "wrist scimitars"
-	desc = "A huge, serrated blade extending from metal gauntlets."
+	desc = "A massive, serrated blade extending from metal gauntlets."
 	icon_state = "scim"
 	item_state = "scim"
-	attack_speed = 1 SECONDS
+	attack_speed = 0.5 SECONDS
 	attack_verb = list("sliced", "slashed", "jabbed", "torn", "gored")
 	force = MELEE_FORCE_TIER_5
-	speed_bonus_amount = -0.4 SECONDS
+	speed_bonus_amount = 0 SECONDS //Original value is -0.4 SECONDS, but is currently glitched(?) at the moment. Someone should restore this, once the function's properly working again.
 
 /obj/item/weapon/bracer_attachment/scimitar/alt
 	name = "wrist scimitar"
 	plural_name = "wrist scimitars"
-	desc = "A huge, serrated blade extending from metal gauntlets."
+	desc = "A massive, serrated blade extending from metal gauntlets."
 	icon_state = "scim_alt"
 	item_state = "scim_alt"
-	attack_speed = 1 SECONDS
+	attack_speed = 0.5 SECONDS
 	force = MELEE_FORCE_TIER_5
-	speed_bonus_amount =  -0.4 SECONDS
+	speed_bonus_amount = 0 SECONDS //Ditto.
+
+/obj/item/weapon/bracer_attachment/scimitar/unique_action(mob/user)
+	. = ..()
+	var/mob/living/carbon/human/yautja_user = user
+	if(!scimitar_deployed)
+		scimitar_deployed = TRUE
+		yautja_user.start_stomping()
+		RegisterSignal(user, COMSIG_HUMAN_POST_MOVE_DELAY, PROC_REF(handle_movedelay))
+		addtimer(CALLBACK(src, PROC_REF(undeploy_scimitars), user), 10 SECONDS)
+		yautja_user.visible_message(SPAN_WARNING("[yautja_user] raises the wrist scimitars in front of its face and starts sprinting!"))
+		addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), yautja_user, SPAN_WARNING("You stop covering your face and stop sprinting.")), 10 SECONDS)
+
+	if(gauntlet_deployed)
+		to_chat(user, SPAN_WARNING("You're already charging."))
+		return
+
+/obj/item/weapon/bracer_attachment/scimitar/proc/undeploy_scimitars(mob/user)
+	scimitar_deployed = FALSE
+	UnregisterSignal(user, COMSIG_HUMAN_POST_MOVE_DELAY)
+
+/mob/living/carbon/human/proc/stop_stomping(mob/user, obj/item/weapon/bracer_attachment/scimitar)
+	GetExactComponent(/datum/component/footstep).RemoveComponent()
+
+/obj/item/weapon/bracer_attachment/scimitar/proc/handle_movedelay(mob/living/moving_mob, list/movedata)
+	SIGNAL_HANDLER
+	movedata["move_delay"] -= move_delay_addition
+
+/obj/item/weapon/bracer_attachment/scimitar/verb/scimitar_guard()
+	set category = "Weapons"
+	set name = "Guard Yourself (Scimitars)"
+	set desc = "Get into a protective stance with your scimitars."
+	set src = usr.contents
+
+	unique_action(usr)
 
 /*#########################################
 ########### One Handed Weapons ############

--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -355,40 +355,6 @@
 	force = MELEE_FORCE_TIER_5
 	speed_bonus_amount = 0 SECONDS //Ditto.
 
-/obj/item/weapon/bracer_attachment/scimitar/unique_action(mob/user)
-	. = ..()
-	var/mob/living/carbon/human/yautja_user = user
-	if(!scimitar_deployed)
-		scimitar_deployed = TRUE
-		yautja_user.start_stomping()
-		RegisterSignal(user, COMSIG_HUMAN_POST_MOVE_DELAY, PROC_REF(handle_movedelay))
-		addtimer(CALLBACK(src, PROC_REF(undeploy_scimitars), user), 10 SECONDS)
-		yautja_user.visible_message(SPAN_WARNING("[yautja_user] raises the wrist scimitars in front of its face and starts sprinting!"))
-		addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), yautja_user, SPAN_WARNING("You stop covering your face and stop sprinting.")), 10 SECONDS)
-
-	if(gauntlet_deployed)
-		to_chat(user, SPAN_WARNING("You're already charging."))
-		return
-
-/obj/item/weapon/bracer_attachment/scimitar/proc/undeploy_scimitars(mob/user)
-	scimitar_deployed = FALSE
-	UnregisterSignal(user, COMSIG_HUMAN_POST_MOVE_DELAY)
-
-/mob/living/carbon/human/proc/stop_stomping(mob/user, obj/item/weapon/bracer_attachment/scimitar)
-	GetExactComponent(/datum/component/footstep).RemoveComponent()
-
-/obj/item/weapon/bracer_attachment/scimitar/proc/handle_movedelay(mob/living/moving_mob, list/movedata)
-	SIGNAL_HANDLER
-	movedata["move_delay"] -= move_delay_addition
-
-/obj/item/weapon/bracer_attachment/scimitar/verb/scimitar_guard()
-	set category = "Weapons"
-	set name = "Guard Yourself (Scimitars)"
-	set desc = "Get into a protective stance with your scimitars."
-	set src = usr.contents
-
-	unique_action(usr)
-
 /*#########################################
 ########### One Handed Weapons ############
 #########################################*/


### PR DESCRIPTION
# About the pull request

Hello! Just a very brief contribution, nothing too fancy.
A quick thing, first:
* If the balance changes shown here feel a bit too radical, I'm _also_ completely fine with toning them down. No shame there.

With that out of the way, here's what I've changed:
* The Wrist Scimitars now have a click delay of 0.5 SECONDS instead of 1 SECOND - the very same as the Wristblades.
* Sets the Wrist Scimitar's attack speed bonus to 0 SECONDS instead of -0.4 SECONDS, as a temporary band-aided bugfix.
* Adjusts the verbage in the Wrist Scimitar's description from 'huge' _(shared by the Wristblades)_ to 'massive'.

# Explain why it's good for the game

* Wrist Scimitars take up a dedicated weapon slot _(like the Combistick and War Glaive),_ but are fairly weaker than the freely available Wristblades due to their heftsome click delay. This particular issue has been so prevalent that almost _every_ recorded mention of it in within the past year - both in-game and on-the-'cord - has been near-exclusively negative. This fixes that.
_(To note, this is almost complete inverse to what people thought about the Wrist Scimitar's performance, during my first tenure on the Hunter whitelist from a couple years back. You know something has to be wrong, when even a Xenomorph'll use LOOC to politely remark on the wristweapon's ineffectiveness.)_

* Implements a temporary(?) bugfix for a glitch that, to my knowledge, is still ongoing. I've left a note in the code so that the intended function can be easily restored, if-or-when a more permanent solution is found. Now, the Wrist Scimitars shouldn't inexplicably have a differing click delay depending on which gauntlet you've attached them to.

# Testing Photographs and Procedure

Relatively simple change, composed of a one-liner.


# Changelog

:cl:
balance: The Wrist Scimitars now have a click delay of 0.5 SECONDS instead of 1 SECOND, making them a slight - but direct - upgrade over the Wristblades.
code: Temporarily disables the ATTACK_SPEED_BONUS mechanic for the Wrist Scimitars, due to an ongoing bug. This shouldn't affect the mechanical balance too much, besides a -0.1 SECOND bonus to its click delay.
spellcheck: Adds a new verb to the Wrist Scimitar's description to better differentiate it from the Wristblades.
/:cl:
