### PR TITLE
Move Admin Sleeping to use status effects

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -120,6 +120,8 @@
 #define NO_PERMANENT_DAMAGE (1<<20)
 #define CORRUPTED_ALLY (1<<21)
 #define FAKESOUL (1<<22) // Lets things without souls pretend like they do
+#define ASLEPT (1<<23)
+// NOTE: Don't add flags past 1<<23, it'll break things due to BYOND limitations. You can usually use a Component instead.
 
 // =============================
 // hive types

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -120,7 +120,6 @@
 #define NO_PERMANENT_DAMAGE (1<<20)
 #define CORRUPTED_ALLY (1<<21)
 #define FAKESOUL (1<<22) // Lets things without souls pretend like they do
-#define ASLEPT (1<<23)
 // NOTE: Don't add flags past 1<<23, it'll break things due to BYOND limitations. You can usually use a Component instead.
 
 // =============================

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -150,7 +150,7 @@
 	icon_state = ALERT_KNOCKEDOUT
 
 /datum/status_effect/incapacitating/unconscious/aslept
-	id = "aslept"
+	id = TRAIT_SOURCE_ADMIN
 	needs_update_stat = TRUE
 	remove_on_fullheal = FALSE
 	duration = -1

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -149,6 +149,18 @@
 	desc = "You've been knocked out."
 	icon_state = ALERT_KNOCKEDOUT
 
+/datum/status_effect/incapacitating/unconscious/aslept
+	id = "aslept"
+	needs_update_stat = TRUE
+	remove_on_fullheal = FALSE
+	duration = -1
+
+/datum/status_effect/incapacitating/unconscious/aslept/update_duration(amount, increment)
+	return
+
+/datum/status_effect/incapacitating/unconscious/aslept/adjust_duration(amount)
+	return
+
 /// DAZED:
 /// This prevents talking as human or using abilities as Xenos, mainly
 /datum/status_effect/incapacitating/dazed

--- a/code/modules/admin/player_panel/actions/general.dm
+++ b/code/modules/admin/player_panel/actions/general.dm
@@ -36,14 +36,14 @@
 /datum/player_action/mob_sleep/act(client/user, mob/target, list/params)
 	if(!istype(target, /mob/living))
 		return TRUE
-	var/mob/living/living = target
+	var/mob/living/living_target = target
 
-	if (!params["sleep"]) //if they're already slept, set their sleep to zero and remove the icon
-		living.sleeping = 0
-		living.RemoveSleepingIcon()
+	if(living_target.IsKnockOut()) //if they're already KnockOut, set their sleep to zero and remove the icon
+		living_target.SetKnockOut(0, TRUE)
+		living_target.RemoveSleepingIcon()
 	else
-		living.sleeping = 9999999 //if they're not, sleep them and add the sleep icon, so other marines nearby know not to mess with them.
-		living.AddSleepingIcon()
+		living_target.SetKnockOut(9999999, TRUE) //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
+		living_target.AddSleepingIcon()
 
 	message_admins("[key_name_admin(user)] toggled sleep on [key_name_admin(target)].")
 

--- a/code/modules/admin/player_panel/actions/general.dm
+++ b/code/modules/admin/player_panel/actions/general.dm
@@ -38,11 +38,11 @@
 		return TRUE
 	var/mob/living/living_target = target
 
-	if(living_target.IsKnockOut()) //if they're already KnockOut, set their sleep to zero and remove the icon
-		living_target.SetKnockOut(0, TRUE, TRUE)
+	if(living_target.is_admin_slept()) //if they're already KnockOut, set their sleep to zero and remove the icon
+		living_target.set_admin_sleep(TRUE)
 		living_target.RemoveSleepingIcon()
 	else
-		living_target.SetKnockOut(9999999, TRUE, TRUE) //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
+		living_target.set_admin_sleep() //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
 		living_target.AddSleepingIcon()
 
 	message_admins("[key_name_admin(user)] toggled sleep on [key_name_admin(target)].")

--- a/code/modules/admin/player_panel/actions/general.dm
+++ b/code/modules/admin/player_panel/actions/general.dm
@@ -39,10 +39,10 @@
 	var/mob/living/living_target = target
 
 	if(living_target.IsKnockOut()) //if they're already KnockOut, set their sleep to zero and remove the icon
-		living_target.SetKnockOut(0, TRUE)
+		living_target.SetKnockOut(0, TRUE, TRUE)
 		living_target.RemoveSleepingIcon()
 	else
-		living_target.SetKnockOut(9999999, TRUE) //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
+		living_target.SetKnockOut(9999999, TRUE, TRUE) //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
 		living_target.AddSleepingIcon()
 
 	message_admins("[key_name_admin(user)] toggled sleep on [key_name_admin(target)].")

--- a/code/modules/admin/player_panel/actions/general.dm
+++ b/code/modules/admin/player_panel/actions/general.dm
@@ -38,11 +38,11 @@
 		return TRUE
 	var/mob/living/living_target = target
 
-	if(living_target.is_admin_slept()) //if they're already KnockOut, set their sleep to zero and remove the icon
+	if(living_target.is_admin_slept()) //if they're already slept, remove the aslept trait and remove the icon
 		living_target.set_admin_sleep(FALSE)
 		living_target.RemoveSleepingIcon()
 	else
-		living_target.set_admin_sleep(TRUE) //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
+		living_target.set_admin_sleep(TRUE) //if they're not, add the aslept trait and add the sleep icon, so other marines nearby know not to mess with them.
 		living_target.AddSleepingIcon()
 
 	message_admins("[key_name_admin(user)] toggled sleep on [key_name_admin(target)].")

--- a/code/modules/admin/player_panel/actions/general.dm
+++ b/code/modules/admin/player_panel/actions/general.dm
@@ -39,10 +39,10 @@
 	var/mob/living/living_target = target
 
 	if(living_target.is_admin_slept()) //if they're already KnockOut, set their sleep to zero and remove the icon
-		living_target.set_admin_sleep(TRUE)
+		living_target.set_admin_sleep(FALSE)
 		living_target.RemoveSleepingIcon()
 	else
-		living_target.set_admin_sleep() //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
+		living_target.set_admin_sleep(TRUE) //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
 		living_target.AddSleepingIcon()
 
 	message_admins("[key_name_admin(user)] toggled sleep on [key_name_admin(target)].")

--- a/code/modules/admin/tabs/admin_tab.dm
+++ b/code/modules/admin/tabs/admin_tab.dm
@@ -229,7 +229,7 @@
 	if(alert("This will sleep ALL mobs within your view range (for Administration purposes). Are you sure?",,"Yes","Cancel") == "Cancel")
 		return
 	for(var/mob/living/living_target in view(usr.client))
-		living_target.set_admin_sleep() //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
+		living_target.set_admin_sleep(TRUE) //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
 		living_target.AddSleepingIcon()
 
 	message_admins("[key_name(usr)] used Toggle Sleep In View.")
@@ -245,7 +245,7 @@
 	if(alert("This wake ALL mobs within your view range (for Administration purposes). Are you sure?",,"Yes","Cancel") == "Cancel")
 		return
 	for(var/mob/living/living_target in view(usr.client))
-		living_target.set_admin_sleep(TRUE) //set their KnockOut to zero and remove their icon
+		living_target.set_admin_sleep(FALSE) //set their KnockOut to zero and remove their icon
 		living_target.RemoveSleepingIcon()
 
 	message_admins("[key_name(usr)] used Toggle Wake In View.")

--- a/code/modules/admin/tabs/admin_tab.dm
+++ b/code/modules/admin/tabs/admin_tab.dm
@@ -229,7 +229,7 @@
 	if(alert("This will sleep ALL mobs within your view range (for Administration purposes). Are you sure?",,"Yes","Cancel") == "Cancel")
 		return
 	for(var/mob/living/living_target in view(usr.client))
-		living_target.SetKnockOut(9999999, TRUE, TRUE) //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
+		living_target.set_admin_sleep() //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
 		living_target.AddSleepingIcon()
 
 	message_admins("[key_name(usr)] used Toggle Sleep In View.")
@@ -245,7 +245,7 @@
 	if(alert("This wake ALL mobs within your view range (for Administration purposes). Are you sure?",,"Yes","Cancel") == "Cancel")
 		return
 	for(var/mob/living/living_target in view(usr.client))
-		living_target.SetKnockOut(0, TRUE, TRUE) //set their KnockOut to zero and remove their icon
+		living_target.set_admin_sleep(TRUE) //set their KnockOut to zero and remove their icon
 		living_target.RemoveSleepingIcon()
 
 	message_admins("[key_name(usr)] used Toggle Wake In View.")

--- a/code/modules/admin/tabs/admin_tab.dm
+++ b/code/modules/admin/tabs/admin_tab.dm
@@ -228,10 +228,10 @@
 
 	if(alert("This will sleep ALL mobs within your view range (for Administration purposes). Are you sure?",,"Yes","Cancel") == "Cancel")
 		return
-	for(var/mob/living/M in view(usr.client))
-		M.apply_effect(3, PARALYZE) // prevents them from exiting the screen range
-		M.sleeping = 9999999 //if they're not, sleep them and add the sleep icon, so other marines nearby know not to mess with them.
-		M.AddSleepingIcon()
+	for(var/mob/living/living_target in view(usr.client))
+		living_target.apply_effect(3, PARALYZE) // prevents them from exiting the screen range
+		living_target.SetKnockOut(9999999, TRUE) //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
+		living_target.AddSleepingIcon()
 
 	message_admins("[key_name(usr)] used Toggle Sleep In View.")
 
@@ -245,9 +245,9 @@
 
 	if(alert("This wake ALL mobs within your view range (for Administration purposes). Are you sure?",,"Yes","Cancel") == "Cancel")
 		return
-	for(var/mob/living/M in view(usr.client))
-		M.sleeping = 0 //set their sleep to zero and remove their icon
-		M.RemoveSleepingIcon()
+	for(var/mob/living/living_target in view(usr.client))
+		living_target.SetKnockOut(0, TRUE) //set their KnockOut to zero and remove their icon
+		living_target.RemoveSleepingIcon()
 
 	message_admins("[key_name(usr)] used Toggle Wake In View.")
 

--- a/code/modules/admin/tabs/admin_tab.dm
+++ b/code/modules/admin/tabs/admin_tab.dm
@@ -229,8 +229,7 @@
 	if(alert("This will sleep ALL mobs within your view range (for Administration purposes). Are you sure?",,"Yes","Cancel") == "Cancel")
 		return
 	for(var/mob/living/living_target in view(usr.client))
-		living_target.apply_effect(3, PARALYZE) // prevents them from exiting the screen range
-		living_target.SetKnockOut(9999999, TRUE) //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
+		living_target.SetKnockOut(9999999, TRUE, TRUE) //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
 		living_target.AddSleepingIcon()
 
 	message_admins("[key_name(usr)] used Toggle Sleep In View.")
@@ -246,7 +245,7 @@
 	if(alert("This wake ALL mobs within your view range (for Administration purposes). Are you sure?",,"Yes","Cancel") == "Cancel")
 		return
 	for(var/mob/living/living_target in view(usr.client))
-		living_target.SetKnockOut(0, TRUE) //set their KnockOut to zero and remove their icon
+		living_target.SetKnockOut(0, TRUE, TRUE) //set their KnockOut to zero and remove their icon
 		living_target.RemoveSleepingIcon()
 
 	message_admins("[key_name(usr)] used Toggle Wake In View.")

--- a/code/modules/admin/tabs/admin_tab.dm
+++ b/code/modules/admin/tabs/admin_tab.dm
@@ -229,7 +229,7 @@
 	if(alert("This will sleep ALL mobs within your view range (for Administration purposes). Are you sure?",,"Yes","Cancel") == "Cancel")
 		return
 	for(var/mob/living/living_target in view(usr.client))
-		living_target.set_admin_sleep(TRUE) //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
+		living_target.set_admin_sleep(TRUE) //if they're not already, add the aslept trait them and add the sleep icon, so other marines nearby know not to mess with them.
 		living_target.AddSleepingIcon()
 
 	message_admins("[key_name(usr)] used Toggle Sleep In View.")
@@ -245,7 +245,7 @@
 	if(alert("This wake ALL mobs within your view range (for Administration purposes). Are you sure?",,"Yes","Cancel") == "Cancel")
 		return
 	for(var/mob/living/living_target in view(usr.client))
-		living_target.set_admin_sleep(FALSE) //set their KnockOut to zero and remove their icon
+		living_target.set_admin_sleep(FALSE) //if they're already slept, remove the aslept trait and remove the icon
 		living_target.RemoveSleepingIcon()
 
 	message_admins("[key_name(usr)] used Toggle Wake In View.")

--- a/code/modules/admin/verbs/mob_verbs.dm
+++ b/code/modules/admin/verbs/mob_verbs.dm
@@ -405,21 +405,21 @@
 
 	message_admins("[key_name(src)] changed name of [old_name] to [newname].")
 
-/datum/admins/proc/togglesleep(mob/living/M as mob in GLOB.mob_list)
+/datum/admins/proc/togglesleep(mob/living/living_target as mob in GLOB.mob_list)
 	set name = "Toggle Sleeping"
 	set category = null
 
 	if(!check_rights(0))
 		return
 
-	if (M.sleeping > 0) //if they're already slept, set their sleep to zero and remove the icon
-		M.sleeping = 0
-		M.RemoveSleepingIcon()
+	if (living_target.IsKnockOut()) //if they're already slept, set their KnockOut to zero and remove the icon
+		living_target.SetKnockOut(0, TRUE)
+		living_target.RemoveSleepingIcon()
 	else
-		M.sleeping = 9999999 //if they're not, sleep them and add the sleep icon, so other marines nearby know not to mess with them.
-		M.AddSleepingIcon()
+		living_target.SetKnockOut(9999999, TRUE) //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
+		living_target.AddSleepingIcon()
 
-	message_admins("[key_name(usr)] used Toggle Sleeping on [key_name(M)].")
+	message_admins("[key_name(usr)] used Toggle Sleeping on [key_name(living_target)].")
 	return
 
 #undef NARRATION_METHOD_SAY

--- a/code/modules/admin/verbs/mob_verbs.dm
+++ b/code/modules/admin/verbs/mob_verbs.dm
@@ -413,10 +413,10 @@
 		return
 
 	if (living_target.IsKnockOut()) //if they're already slept, set their KnockOut to zero and remove the icon
-		living_target.SetKnockOut(0, TRUE)
+		living_target.SetKnockOut(0, TRUE, TRUE)
 		living_target.RemoveSleepingIcon()
 	else
-		living_target.SetKnockOut(9999999, TRUE) //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
+		living_target.SetKnockOut(9999999, TRUE, TRUE) //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
 		living_target.AddSleepingIcon()
 
 	message_admins("[key_name(usr)] used Toggle Sleeping on [key_name(living_target)].")

--- a/code/modules/admin/verbs/mob_verbs.dm
+++ b/code/modules/admin/verbs/mob_verbs.dm
@@ -412,11 +412,11 @@
 	if(!check_rights(0))
 		return
 
-	if (living_target.IsKnockOut()) //if they're already slept, set their KnockOut to zero and remove the icon
-		living_target.SetKnockOut(0, TRUE, TRUE)
+	if (living_target.is_admin_slept()) //if they're already slept, set their KnockOut to zero and remove the icon
+		living_target.set_admin_sleep(TRUE)
 		living_target.RemoveSleepingIcon()
 	else
-		living_target.SetKnockOut(9999999, TRUE, TRUE) //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
+		living_target.set_admin_sleep() //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
 		living_target.AddSleepingIcon()
 
 	message_admins("[key_name(usr)] used Toggle Sleeping on [key_name(living_target)].")

--- a/code/modules/admin/verbs/mob_verbs.dm
+++ b/code/modules/admin/verbs/mob_verbs.dm
@@ -413,10 +413,10 @@
 		return
 
 	if (living_target.is_admin_slept()) //if they're already slept, set their KnockOut to zero and remove the icon
-		living_target.set_admin_sleep(TRUE)
+		living_target.set_admin_sleep(FALSE)
 		living_target.RemoveSleepingIcon()
 	else
-		living_target.set_admin_sleep() //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
+		living_target.set_admin_sleep(TRUE) //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
 		living_target.AddSleepingIcon()
 
 	message_admins("[key_name(usr)] used Toggle Sleeping on [key_name(living_target)].")

--- a/code/modules/admin/verbs/mob_verbs.dm
+++ b/code/modules/admin/verbs/mob_verbs.dm
@@ -412,11 +412,11 @@
 	if(!check_rights(0))
 		return
 
-	if (living_target.is_admin_slept()) //if they're already slept, set their KnockOut to zero and remove the icon
+	if (living_target.is_admin_slept()) //if they're already slept, remove the aslept trait and remove the icon
 		living_target.set_admin_sleep(FALSE)
 		living_target.RemoveSleepingIcon()
 	else
-		living_target.set_admin_sleep(TRUE) //if they're not, KnockOut them and add the sleep icon, so other marines nearby know not to mess with them.
+		living_target.set_admin_sleep(TRUE) //if they're not, add the aslept trait them and add the sleep icon, so other marines nearby know not to mess with them.
 		living_target.AddSleepingIcon()
 
 	message_admins("[key_name(usr)] used Toggle Sleeping on [key_name(living_target)].")

--- a/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
@@ -44,7 +44,7 @@
 		if(!already_in_crit)
 			new /datum/effects/crit/human(src)
 
-	if(IsKnockOut())
+	if(IsKnockOut() || is_admin_slept())
 		blinded = TRUE
 		if(regular_update && halloss > 0)
 			apply_damage(-3, HALLOSS)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -68,7 +68,7 @@
 		if(client.prefs.muted & MUTE_IC)
 			to_chat(src, SPAN_DANGER("You cannot speak in IC (Muted)."))
 			return
-		if(HAS_TRAIT_FROM_ONLY(src, TRAIT_KNOCKEDOUT, TRAIT_SOURCE_ADMIN))
+		if(HAS_TRAIT_FROM(src, TRAIT_KNOCKEDOUT, TRAIT_STATUS_EFFECT(TRAIT_SOURCE_ADMIN)))
 			to_chat(src, SPAN_HIGHDANGER("You cannot speak. You have been slept by admins. You should respond to them."))
 			return
 

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -68,7 +68,7 @@
 		if(client.prefs.muted & MUTE_IC)
 			to_chat(src, SPAN_DANGER("You cannot speak in IC (Muted)."))
 			return
-		if(status_flags & ASLEPT)
+		if(HAS_TRAIT_FROM_ONLY(src, TRAIT_KNOCKEDOUT, TRAIT_SOURCE_ADMIN))
 			to_chat(src, SPAN_HIGHDANGER("You cannot speak. You have been slept by admins. You should respond to them."))
 			return
 

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -68,6 +68,9 @@
 		if(client.prefs.muted & MUTE_IC)
 			to_chat(src, SPAN_DANGER("You cannot speak in IC (Muted)."))
 			return
+		if(status_flags & ASLEPT)
+			to_chat(src, SPAN_HIGHDANGER("You cannot speak. You have been slept by admins. You should respond to them."))
+			return
 
 	message = trim(strip_html(message))
 

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -376,6 +376,8 @@
 			S.update_duration(amount)
 		else
 			S = apply_status_effect(/datum/status_effect/incapacitating/unconscious, amount)
+		if(admin)
+			S.remove_on_fullheal = FALSE
 	return S
 
 /// Adds to remaining Knockout duration
@@ -605,7 +607,8 @@
 		timeofdeath = 0
 
 	// restore us to consciousness
-	set_stat(CONSCIOUS)
+	if(!(status_flags & ASLEPT))
+		set_stat(CONSCIOUS)
 	regenerate_all_icons()
 
 	SEND_SIGNAL(src, COMSIG_LIVING_REJUVENATED)

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -499,7 +499,7 @@
 /mob/living/proc/is_admin_slept()
 	return has_status_effect(/datum/status_effect/incapacitating/unconscious/aslept)
 
-/// Sets Admin sleeping
+/// Sets Admin sleeping, TRUE for applying FALSE for removing, defualts to removing
 /mob/living/proc/set_admin_sleep(apply)
 	if(!apply)
 		var/datum/status_effect/incapacitating/unconscious/aslept/admin_slept = is_admin_slept()

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -370,6 +370,7 @@
 	if(amount <= 0)
 		if(S)
 			qdel(S)
+			satus_flags &= ~ASLEPT
 	else
 		if(S)
 			S.update_duration(amount)

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -347,8 +347,6 @@
 /mob/living/proc/KnockOut(amount)
 	if(!(status_flags & CANKNOCKOUT))
 		return
-	if((status_flags & ASLEPT))
-		return
 	amount = GetKnockOutDuration(amount)
 	var/datum/status_effect/incapacitating/unconscious/S = IsKnockOut()
 	if(S)
@@ -358,33 +356,24 @@
 	return S
 
 /// Sets exact remaining Knockout duration
-/mob/living/proc/SetKnockOut(amount, ignore_canstun = FALSE, admin = FALSE)
+/mob/living/proc/SetKnockOut(amount, ignore_canstun = FALSE)
 	if(!(status_flags & CANKNOCKOUT))
 		return
-	if((status_flags & ASLEPT) && !admin)
-		return
-	if(admin)
-		status_flags |= ASLEPT
 	amount = GetKnockOutDuration(amount)
 	var/datum/status_effect/incapacitating/unconscious/S = IsKnockOut()
 	if(amount <= 0)
 		if(S)
 			qdel(S)
-			status_flags &= ~ASLEPT
 	else
 		if(S)
 			S.update_duration(amount)
 		else
 			S = apply_status_effect(/datum/status_effect/incapacitating/unconscious, amount)
-		if(admin)
-			S.remove_on_fullheal = FALSE
 	return S
 
 /// Adds to remaining Knockout duration
 /mob/living/proc/AdjustKnockOut(amount, ignore_canstun = FALSE)
 	if(!(status_flags & CANKNOCKOUT))
-		return
-	if((status_flags & ASLEPT))
 		return
 	amount = GetKnockOutDuration(amount)
 	var/datum/status_effect/incapacitating/unconscious/S = IsKnockOut()
@@ -485,7 +474,6 @@
 	else if(ear_deaf)
 		on_deafness_gain()
 
-
 /mob/living/proc/SetEarDeafness(amount)
 	var/prev_deaf = ear_deaf
 	ear_deaf = max(amount, 0)
@@ -507,6 +495,19 @@
 	if(!ear_deaf && (client?.soundOutput?.status_flags & EAR_DEAF_MUTE))
 		client.soundOutput.status_flags ^= EAR_DEAF_MUTE
 		client.soundOutput.apply_status()
+
+/mob/living/proc/is_admin_slept()
+	return has_status_effect(/datum/status_effect/incapacitating/unconscious/aslept)
+
+/// Sets Admin sleeping
+/mob/living/proc/set_admin_sleep(remove = FALSE)
+	if(remove)
+		var/datum/status_effect/incapacitating/unconscious/aslept/admin_slept = is_admin_slept()
+		if(admin_slept)
+			qdel(admin_slept)
+	else
+		apply_status_effect(/datum/status_effect/incapacitating/unconscious/aslept)
+	return
 
 /mob/living/proc/grant_spawn_protection(duration)
 	status_flags |= RECENTSPAWN|GODMODE
@@ -607,7 +608,7 @@
 		timeofdeath = 0
 
 	// restore us to consciousness
-	if(!(status_flags & ASLEPT))
+	if(!(HAS_TRAIT_FROM_ONLY(src, TRAIT_KNOCKEDOUT, TRAIT_SOURCE_ADMIN)))
 		set_stat(CONSCIOUS)
 	regenerate_all_icons()
 

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -607,7 +607,7 @@
 		tod = null
 		timeofdeath = 0
 
-	// restore us to consciousness
+	// restore us to consciousness if we're not admin slept
 	if(!(HAS_TRAIT_FROM(src, TRAIT_KNOCKEDOUT, TRAIT_STATUS_EFFECT(TRAIT_SOURCE_ADMIN))))
 		set_stat(CONSCIOUS)
 	regenerate_all_icons()

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -500,8 +500,8 @@
 	return has_status_effect(/datum/status_effect/incapacitating/unconscious/aslept)
 
 /// Sets Admin sleeping
-/mob/living/proc/set_admin_sleep(remove = FALSE)
-	if(remove)
+/mob/living/proc/set_admin_sleep(apply)
+	if(!apply)
 		var/datum/status_effect/incapacitating/unconscious/aslept/admin_slept = is_admin_slept()
 		if(admin_slept)
 			qdel(admin_slept)
@@ -608,7 +608,7 @@
 		timeofdeath = 0
 
 	// restore us to consciousness
-	if(!(HAS_TRAIT_FROM_ONLY(src, TRAIT_KNOCKEDOUT, TRAIT_SOURCE_ADMIN)))
+	if(!(HAS_TRAIT_FROM(src, TRAIT_KNOCKEDOUT, TRAIT_STATUS_EFFECT(TRAIT_SOURCE_ADMIN))))
 		set_stat(CONSCIOUS)
 	regenerate_all_icons()
 

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -370,7 +370,7 @@
 	if(amount <= 0)
 		if(S)
 			qdel(S)
-			satus_flags &= ~ASLEPT
+			status_flags &= ~ASLEPT
 	else
 		if(S)
 			S.update_duration(amount)

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -363,6 +363,8 @@
 		return
 	if((status_flags & ASLEPT) && !admin)
 		return
+	if(admin)
+		status_flags |= ASLEPT
 	amount = GetKnockOutDuration(amount)
 	var/datum/status_effect/incapacitating/unconscious/S = IsKnockOut()
 	if(amount <= 0)

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -347,6 +347,8 @@
 /mob/living/proc/KnockOut(amount)
 	if(!(status_flags & CANKNOCKOUT))
 		return
+	if((status_flags & ASLEPT))
+		return
 	amount = GetKnockOutDuration(amount)
 	var/datum/status_effect/incapacitating/unconscious/S = IsKnockOut()
 	if(S)
@@ -356,8 +358,10 @@
 	return S
 
 /// Sets exact remaining Knockout duration
-/mob/living/proc/SetKnockOut(amount, ignore_canstun = FALSE)
+/mob/living/proc/SetKnockOut(amount, ignore_canstun = FALSE, admin = FALSE)
 	if(!(status_flags & CANKNOCKOUT))
+		return
+	if((status_flags & ASLEPT) && !admin)
 		return
 	amount = GetKnockOutDuration(amount)
 	var/datum/status_effect/incapacitating/unconscious/S = IsKnockOut()
@@ -374,6 +378,8 @@
 /// Adds to remaining Knockout duration
 /mob/living/proc/AdjustKnockOut(amount, ignore_canstun = FALSE)
 	if(!(status_flags & CANKNOCKOUT))
+		return
+	if((status_flags & ASLEPT))
 		return
 	amount = GetKnockOutDuration(amount)
 	var/datum/status_effect/incapacitating/unconscious/S = IsKnockOut()


### PR DESCRIPTION

# About the pull request
Title.
Move it from the sleeping var to just applying status effects with a flag that stops it being removed by other sources and also stops humans whispering in their sleep.
Works a bit faster than sleeping.

Also stop rejuvenate from making them conscious or getting rid of the effect.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #12345" to link the PR to the corresponding Issue number #12345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #12345, Fixes #12346, Fixes #12347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Does the thing faster, and stops people whispering rule breaks
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
admin: Admin Sleeping works faster, Rejuvenate doesn't get rid of Admin Sleeping
/:cl:
