### PR TITLE
Fix: Dummy Tablet no longer delimbs cleanly

### DIFF
--- a/code/game/objects/items/devices/dummy_tablet.dm
+++ b/code/game/objects/items/devices/dummy_tablet.dm
@@ -259,7 +259,7 @@
 				return
 			if(limb.status & LIMB_DESTROYED)
 				return
-			limb.droplimb(TRUE, TRUE, "tablet")
+			limb.droplimb(FALSE, TRUE, "tablet")
 			playsound(loc, 'sound/weapons/slice.ogg', 25)
 		if("reset")
 			linked_dummy.revive()


### PR DESCRIPTION

# About the pull request
It's a training aid, and if they want to delimb cleaning they can practice delimbing.
They should practice it on a limp that was lopped off haphazardly.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #12345" to link the PR to the corresponding Issue number #12345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #12345, Fixes #12346, Fixes #12347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Better training
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Medical Dummy now doesn't cleanly delimb, needing the relevant surgical steps to clean up the wound.
/:cl:
