### PR TITLE
hijack now depowers all ship levels

### DIFF
--- a/code/modules/shuttle/dropship_hijack.dm
+++ b/code/modules/shuttle/dropship_hijack.dm
@@ -9,13 +9,14 @@
 	var/final_announcement = FALSE
 
 /datum/dropship_hijack/almayer/proc/crash_landing()
+	var/list/z_levels = SSmapping.levels_by_trait(ZTRAIT_MARINE_MAIN_SHIP)
 	//break APCs
-	for(var/obj/structure/machinery/power/apc/A in GLOB.machines)
-		if(A.z != crash_site.z)
+	for(var/obj/structure/machinery/power/apc/apc in GLOB.machines)
+		if(!(apc.z in z_levels))
 			continue
-		if(prob(A.crash_break_probability))
-			A.overload_lighting()
-			A.set_broken()
+		if(prob(apc.crash_break_probability))
+			apc.overload_lighting()
+			apc.set_broken()
 
 	var/centre_x = crash_site.x + (crash_site.width / 2)
 	//determine outside of ship location


### PR DESCRIPTION

# About the pull request

When multi-z almayer was being reviewed I pointed out that hijack accidentally didnt affect any of the other levels here: https://github.com/cmss13-devs/cmss13/issues/9995 and the fix at some point didn't make it into the final PR, so I wrote a fix for it now cuz I rememberd

# Explain why it's good for the game
much as it pains me to not be able to use my beloved door combat on the other two levels it wasnt intended that 2/3 of the ship would be unaffected by the hijack crash power loss when the multiz almayer was added, and it means that chasing marines around on the middle deck is near impossible and gives a distinct advantage to marines to hold a fully powered and lit area on whichever deck isnt hit 

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

https://streamable.com/2ratd1

</details>


# Changelog

:cl:
fix: the hijack crash affects all levels of the almayer as intended
/:cl:
