### PR TITLE
Mass Screenshot Fixes Again

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -183,7 +183,7 @@
 		mob.hud_used.show_hud(HUD_STYLE_STANDARD)
 	mob.animate_movement = SLIDE_STEPS // Initial is incorrect
 
-	to_chat(usr, "Provide these values when asked for the MapTileImageTool: [width] [height] [half_chunk_size] [world.icon_size]")
+	to_chat(mob, "Provide these values when asked for the MapTileImageTool: [width] [height] [half_chunk_size] [world.icon_size]")
 
 //TODO: merge the vievars version into this or something maybe mayhaps
 /client/proc/cmd_debug_del_all()

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -162,7 +162,7 @@
 			cur_x = min(cur_x, width_inside)
 		if(cur_y == height_inside)
 			break
-		cur_x = half_chunk_size
+		cur_x = half_chunk_size + offset_x
 		cur_y += chunk_size
 		cur_y = min(cur_y, height_inside)
 


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #10293 fixing two things:
- I forgot when repeating the for x loop to also apply the `offset_x` again (for centered Z levels)
- I didn't notice the to_chat was getting sent to the old mob rather than a possibly force aghosted one

# Explain why it's good for the game

Rather than USS runtime looking like this (formed from 7 images): 
<img width="832" height="544" alt="image" src="https://github.com/user-attachments/assets/3f5d2fd9-8013-4dd3-b402-ce53af09993c" />

It looks like this (formed from 4 images) 
<img width="832" height="544" alt="rawr" src="https://github.com/user-attachments/assets/fe33cafa-d96a-4ec4-b139-db8aa255ed49" />

# Testing Photographs and Procedure
See above.

# Changelog
:cl: Drathek
fix: Fixed a couple errors with the debug mass screenshot verb when handling centered space levels and ever the mob is force aghosted
/:cl:
