### PR TITLE
"""fixes""" xenos not being stunned by impact ammo while resting

### DIFF
--- a/code/datums/ammo/ammo.dm
+++ b/code/datums/ammo/ammo.dm
@@ -153,7 +153,7 @@
 			return
 	if(!living_mob || living_mob == fired_projectile.firer)
 		return
-	if(fired_projectile.distance_travelled > max_range || living_mob.GetKnockDownDuration() != 0)
+	if(fired_projectile.distance_travelled > max_range || living_mob.IsKnockDown())
 		return //Two tiles away or more, basically.
 
 	if(living_mob.mob_size >= MOB_SIZE_BIG)

--- a/code/datums/ammo/ammo.dm
+++ b/code/datums/ammo/ammo.dm
@@ -153,7 +153,7 @@
 			return
 	if(!living_mob || living_mob == fired_projectile.firer)
 		return
-	if(fired_projectile.distance_travelled > max_range)
+	if(fired_projectile.distance_travelled > max_range || living_mob.GetKnockDownDuration() != 0)
 		return //Two tiles away or more, basically.
 
 	if(living_mob.mob_size >= MOB_SIZE_BIG)

--- a/code/datums/ammo/ammo.dm
+++ b/code/datums/ammo/ammo.dm
@@ -153,7 +153,7 @@
 			return
 	if(!living_mob || living_mob == fired_projectile.firer)
 		return
-	if(fired_projectile.distance_travelled > max_range || living_mob.body_position == LYING_DOWN)
+	if(fired_projectile.distance_travelled > max_range)
 		return //Two tiles away or more, basically.
 
 	if(living_mob.mob_size >= MOB_SIZE_BIG)

--- a/code/datums/ammo/ammo.dm
+++ b/code/datums/ammo/ammo.dm
@@ -153,7 +153,7 @@
 			return
 	if(!living_mob || living_mob == fired_projectile.firer)
 		return
-	if(fired_projectile.distance_travelled > max_range || living_mob.IsKnockDown())
+	if(fired_projectile.distance_travelled > max_range || HAS_TRAIT(living_mob, TRAIT_IMMOBILIZED))
 		return //Two tiles away or more, basically.
 
 	if(living_mob.mob_size >= MOB_SIZE_BIG)

--- a/code/datums/ammo/bullet/revolver.dm
+++ b/code/datums/ammo/bullet/revolver.dm
@@ -157,8 +157,8 @@
 	penetration = ARMOR_PENETRATION_TIER_10
 	damage = 50
 
-/datum/ammo/bullet/revolver/mateba/highimpact/on_hit_mob(mob/M, obj/projectile/P)
-	knockback(M, P, 4)
+/datum/ammo/bullet/revolver/mateba/highimpact/on_hit_mob(mob/hit_mob, obj/projectile/bullet)
+	knockback(hit_mob, bullet, 4)
 
 /datum/ammo/bullet/revolver/mateba/highimpact/explosive //if you ever put this in normal gameplay, i am going to scream
 	name = ".454 heavy explosive revolver bullet"

--- a/code/datums/ammo/bullet/rifle.dm
+++ b/code/datums/ammo/bullet/rifle.dm
@@ -202,8 +202,8 @@
 	penetration = ARMOR_PENETRATION_TIER_10
 	shell_speed = AMMO_SPEED_TIER_6
 
-/datum/ammo/bullet/rifle/m4ra/impact/on_hit_mob(mob/M, obj/projectile/P)
-	knockback(M, P, 32) // Can knockback basically at max range max range is 24 tiles...
+/datum/ammo/bullet/rifle/m4ra/impact/on_hit_mob(mob/hit_mob, obj/projectile/bullet)
+	knockback(hit_mob, bullet, 32) // Can knockback basically at max range max range is 24 tiles...
 
 /datum/ammo/bullet/rifle/m4ra/impact/knockback_effects(mob/living/living_mob, obj/projectile/fired_projectile)
 	if(iscarbonsizexeno(living_mob))


### PR DESCRIPTION

# About the pull request
not a bug since it was very intentionally being checked that whoever was hit was resting, but the report is open 4 years later so here we are

fixes: #1570 (as much as you can fix a non-bug)

# Explain why it's good for the game

"bugs" bad


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: resting xenos are now stunned by impact bullets
code: change some one letter vars since i was originally going to do something there but changed my mind
/:cl:
