### PR TITLE
fix plant bag visual bug

### DIFF
--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -383,6 +383,7 @@ GLOBAL_LIST_EMPTY_TYPED(item_storage_box_cache, /datum/item_storage_box)
 			for (var/datum/numbered_display/ND in numbered_contents)
 				if (ND.sample_object.type == I.type)
 					ND.number++
+					I.screen_loc = ND.sample_object.screen_loc
 					found = 1
 					break
 			if (!found)


### PR DESCRIPTION

# About the pull request

fixes: #1122
the second item added to a stack in a plant bag is not added to numbered_contents so its screen loc is never updated and it stays in your hand. adding it to numbered_contents does not work because then it takes up another slot. this pr moves the screen loc of any items past the first in numbered_contents to be over numbered_content's sample object. why does numbered content control screen loc? i dont know!!!!!!!!!!!

# Explain why it's good for the game
bug bad. pr may be worse than bug.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: plant bug visual bug gone
/:cl:
