### PR TITLE
Fix/Add: Req now logs to ARES, total cost actually uses correct number

### DIFF
--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -655,6 +655,8 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 
 	/// The user submitted reason as to why they want this order
 	var/reason
+	///Pack cost is updated after purchase, so needs to be recorded beforehand to reflect actual cost
+	var/total_cost
 
 /datum/supply_order/proc/get_list_representation()
 	var/type_to_quantity = list()
@@ -678,9 +680,10 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 		"ordered_by" = orderedby,
 		"approved_by" = approvedby,
 		"reason" = reason,
+		"total_cost" = total_cost
 	)
 
-/datum/supply_order/proc/buy(obj/structure/machinery/computer/supply/asrs/buyer)
+/datum/supply_order/proc/buy(obj/structure/machinery/computer/supply/asrs/buyer, mob/user)
 	var/ordered = list()
 
 	for(var/datum/supply_packs/pack as anything in objects)
@@ -694,6 +697,7 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 			continue
 
 		buyer.linked_supply_controller.points -= pack.cost
+		total_cost += pack.cost
 		buyer.linked_supply_controller.black_market_points -= pack.dollar_cost
 
 		if(buyer.linked_supply_controller.black_market_heat != -1) // -1 Heat means heat is disabled
@@ -701,9 +705,6 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 			buyer.linked_supply_controller.black_market_heat = clamp(buyer.linked_supply_controller.black_market_heat + pack.crate_heat + (pack.crate_heat * rand(rand(-0.25,0),0.25)), 0, 100)
 
 		ordered += pack
-
-	for(var/datum/supply_packs/pack as anything in ordered)
-		pack.cost = floor(pack.cost * SUPPLY_COST_MULTIPLIER)
 
 	if(buyer.linked_supply_controller.black_market_heat == 100)
 		buyer.linked_supply_controller.black_market_investigation()
@@ -715,6 +716,12 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 		objects = ordered
 		buyer.linked_supply_controller.requestlist -= src
 		buyer.linked_supply_controller.shoppinglist += src
+		var/counter = 0
+		for(var/datum/supply_packs/pack as anything in ordered)
+			counter++
+			log_ares_requisition("Requisitioned", "[pack.name] purchased for $[pack.cost * 100] requested by: [orderedby] and approved by [approvedby]. Reason: [reason ? reason : "N/A"]. No. [counter] of [length(ordered)]", user.real_name)
+		for(var/datum/supply_packs/pack as anything in ordered)
+			pack.cost = floor(pack.cost * SUPPLY_COST_MULTIPLIER)
 		return TRUE
 
 /datum/controller/supply
@@ -1019,6 +1026,7 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 				slip.ordernum = order.ordernum
 				slip.orderedby = order.orderedby
 				slip.approvedby = order.approvedby
+				slip.total_cost = order.total_cost
 				slip.packages = content_names
 				slip.generate_contents()
 				slip.update_icon()
@@ -1030,6 +1038,7 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 	var/ordernum
 	var/orderedby
 	var/approvedby
+	var/total_cost
 	var/list/packages
 
 /obj/item/paper/manifest/read_paper(mob/user, scramble = FALSE)
@@ -1072,6 +1081,8 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 		<td>[orderedby]</td></tr>  \
 		<tr><td>Approved by:</td>  \
 		<td>[approvedby]</td></tr> \
+		<tr><td>Total Cost:</td>  \
+		<td>[total_cost]</td></tr> \
 		<tr><td># packages:</td>   \
 		<td class='field'>[length(packages)]</td></tr> \
 		</table><hr><p class='header important'>Contents</p>   \
@@ -1176,7 +1187,7 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 
 			current_order = list()
 
-			if(supply_order.buy(src))
+			if(supply_order.buy(src, ui.user))
 				return TRUE
 
 			linked_supply_controller.requestlist += supply_order
@@ -1203,7 +1214,7 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 			switch(params["order_status"])
 				if("approve")
 					order.approvedby = id_name
-					if(order.buy(src))
+					if(order.buy(src, ui.user))
 						return TRUE
 
 					system_message = "Unable to approve order, order remains in Requests."

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -352,6 +352,7 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 	reqform.info += "REQUESTED BY: [order.orderedby]<br>"
 	reqform.info += "RANK: [order.orderedby_rank]<br>"
 	reqform.info += "REASON: [order.reason]<br>"
+	reqform.info += "TOTAL COST: [order.total_cost]<br>"
 	reqform.info += "ACCESS RESTRICTION: [english_list(accesses, nothing_text = "None")]<br>"
 	reqform.info += "CONTENTS:<br>"
 	for(var/datum/supply_packs/supply_pack as anything in order.objects)
@@ -697,7 +698,7 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 			continue
 
 		buyer.linked_supply_controller.points -= pack.cost
-		total_cost += pack.cost
+		total_cost += pack.cost * 100
 		buyer.linked_supply_controller.black_market_points -= pack.dollar_cost
 
 		if(buyer.linked_supply_controller.black_market_heat != -1) // -1 Heat means heat is disabled
@@ -1081,8 +1082,6 @@ GLOBAL_DATUM_INIT(supply_controller, /datum/controller/supply, new())
 		<td>[orderedby]</td></tr>  \
 		<tr><td>Approved by:</td>  \
 		<td>[approvedby]</td></tr> \
-		<tr><td>Total Cost:</td>  \
-		<td>[total_cost]</td></tr> \
 		<tr><td># packages:</td>   \
 		<td class='field'>[length(packages)]</td></tr> \
 		</table><hr><p class='header important'>Contents</p>   \

--- a/tgui/packages/tgui/interfaces/SupplyComputer.tsx
+++ b/tgui/packages/tgui/interfaces/SupplyComputer.tsx
@@ -539,7 +539,9 @@ const RenderOrder = (props: {
               <Stack.Item pt={1}>
                 <Stack>
                   <Stack.Item bold>Total Cost:</Stack.Item>
-                  <Stack.Item>${order.total_cost}</Stack.Item>
+                  <Stack.Item>
+                    {order.total_cost ? '$' + order.total_cost : 'N/A'}
+                  </Stack.Item>
                 </Stack>
               </Stack.Item>
             </Stack.Item>

--- a/tgui/packages/tgui/interfaces/SupplyComputer.tsx
+++ b/tgui/packages/tgui/interfaces/SupplyComputer.tsx
@@ -74,6 +74,7 @@ type Order = {
   ordered_by: string;
   approved_by: string;
   reason?: string;
+  total_cost: number;
 };
 
 type Item = {
@@ -538,13 +539,7 @@ const RenderOrder = (props: {
               <Stack.Item pt={1}>
                 <Stack>
                   <Stack.Item bold>Total Cost:</Stack.Item>
-                  <Stack.Item>
-                    $
-                    {order.contents.reduce(
-                      (curr, next) => curr + next.cost * next.quantity,
-                      0,
-                    ) * 100}
-                  </Stack.Item>
+                  <Stack.Item>${order.total_cost}</Stack.Item>
                 </Stack>
               </Stack.Item>
             </Stack.Item>


### PR DESCRIPTION

# About the pull request
Title. As the price doesn't get adjusted until after purchase.
Also Tack it onto the Form.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #12345" to link the PR to the corresponding Issue number #12345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #12345, Fixes #12346, Fixes #12347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Funny logs for CMB.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Req purchases get logged to ARES
fix: Total cost is now the actual amount of points spent
/:cl:
