### PR TITLE
Fix: Radial Menus getting stuck, and unable to be opened

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -97,6 +97,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	var/hudfix_method = TRUE //TRUE to change anchor to user, FALSE to shift by py_shift
 	var/py_shift = 0
 	var/entry_animation = TRUE
+	COOLDOWN_DECLARE(radial_menu)
 
 /datum/radial_menu/Destroy()
 	Reset()
@@ -282,18 +283,29 @@ GLOBAL_LIST_EMPTY(radial_menus)
 		current_page = WRAP(current_page + 1,1,pages+1)
 		update_screen_objects()
 
-/datum/radial_menu/proc/show_to(mob/M)
+/datum/radial_menu/proc/show_to(mob/user)
 	if(current_user)
 		hide()
-	if(!M.client || !anchor)
+	if(!user.client || !anchor)
 		return
-	current_user = M.client
+	current_user = user.client
 	//Blank
 	menu_holder = image(icon = 'icons/effects/effects.dmi', loc = anchor, icon_state = "nothing", layer = ABOVE_HUD_LAYER)
 	menu_holder.plane = ABOVE_HUD_PLANE
 	menu_holder.appearance_flags |= KEEP_APART
 	menu_holder.vis_contents += elements + close_button
 	current_user.images += menu_holder
+
+/datum/radial_menu/proc/refresh(mob/user)
+	if(!(COOLDOWN_FINISHED(src, radial_menu)))
+		return
+	if(current_user)
+		hide()
+	if(!user.client || !anchor)
+		return
+	current_user = user.client
+	current_user.images += menu_holder
+	COOLDOWN_START(src, radial_menu, 2 SECONDS)
 
 /datum/radial_menu/proc/hide()
 	if(current_user)
@@ -321,10 +333,15 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	if(!uniqueid)
 		uniqueid = "defmenu_[REF(user)]_[REF(anchor)]"
 
-	if(GLOB.radial_menus[uniqueid])
-		return
+	var/datum/radial_menu/menu
 
-	var/datum/radial_menu/menu = new
+	if(GLOB.radial_menus[uniqueid])
+		menu = GLOB.radial_menus[uniqueid]
+		menu.refresh(user)
+		return
+	else
+		menu = new
+
 	GLOB.radial_menus[uniqueid] = menu
 	if(radius)
 		menu.radius = radius
@@ -338,6 +355,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 		use_labels = FALSE
 	menu.set_choices(choices, tooltips, use_labels)
 	menu.show_to(user)
+	COOLDOWN_START(menu, radial_menu, 2 SECONDS)
 	menu.wait(user, anchor, require_near)
 	var/answer = menu.selected_choice
 	qdel(menu)


### PR DESCRIPTION

# About the pull request
Radials could get stuck if you ghosted with them open. Or reconnected, Or took over a mob that had them open.
Resolves: #7547, Resolves: #11647

To fix this I just attempt a refresh shoving the menu_holder back on their screen. Add a cooldown to it just because this is spamable.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #12345" to link the PR to the corresponding Issue number #12345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #12345, Fixes #12346, Fixes #12347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Bug bad.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/user-attachments/assets/125be6ab-19df-460f-ba9c-a1df94aca10e

</details>


# Changelog
:cl:
fix: Radial Menus no longer get stuck unable to appear for new, reconnecting, or aghosting users.
/:cl:
