### PR TITLE
Allows observers to health scan xenos/simple mobs again

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -721,7 +721,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	usr.forceMove(pick(L))
 	following = null
 
-/mob/dead/observer/proc/scan_health(mob/living/carbon/human/target in GLOB.living_mob_list)
+/mob/dead/observer/proc/scan_health(mob/living/target in GLOB.living_mob_list)
 	set name = "Scan Health"
 
 	if(!istype(target))


### PR DESCRIPTION

# About the pull request

Reverts a tiny change from #8878
This is labelled as a bugfix there, but there's nothing wrong with it from my experience. It's useful/fun for an observer to see how much health a xeno has left, so I'm not quite sure why it was removed. 

# Explain why it's good for the game

Allow ghosts to see health values instead of just the visual UI. Shouldn't matter for gameplay at all, just a neat little thing to be able to do.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Observers can once again healthscan xenos/simple mobs
/:cl:
