### PR TITLE
FIX: Lets maintenance jacks open unpowered doors without Synth/Yautja Superstrong.

### DIFF
--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -591,7 +591,12 @@
 		if(attacked_door.locked) //Bolted
 			to_chat(user, SPAN_DANGER("You can't pry open [attacked_door] while it is bolted shut."))
 			return
-
+		if(!attacked_door.density && !attacked_door.arePowerSystemsOn()) //If its open and unpowered
+			attacked_door.close(TRUE)
+			return
+		if(attacked_door.density && !attacked_door.arePowerSystemsOn()) // if its closed and unpowered
+			attacked_door.open(TRUE)
+			return
 		if(requires_superstrength_pry)
 			if(!HAS_TRAIT(user, TRAIT_SUPER_STRONG)) //basically IS_PRY_CAPABLE_CROWBAR
 				return
@@ -600,15 +605,8 @@
 			return
 		if(user.action_busy)
 			return
-		if(!attacked_door.density && !attacked_door.arePowerSystemsOn()) //If its open and unpowered
-			attacked_door.close(TRUE)
-			return
-		if(attacked_door.density && !attacked_door.arePowerSystemsOn()) // if its closed and unpowered
-			attacked_door.open(TRUE)
-			return
 		if(!attacked_door.density) //If its open
 			return
-
 		user.visible_message(SPAN_DANGER("[user] jams [src] into [attacked_door] and starts to pry it open."),
 		SPAN_DANGER("You jam [src] into [attacked_door] and start to pry it open."))
 		playsound(src, "pry", 15, TRUE)


### PR DESCRIPTION

# About the pull request

Title. Swaps the order of checks so that the check for super-strength doesn't come first, letting regular-unpowered door conditions be checked first. 

# Explain why it's good for the game

Bug fix!

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: fixed unpowered doors being unable to be opened by maintenance jacks (for humans)
/:cl:
