### PR TITLE
Change Xenos attacking reactor do_after check timing

### DIFF
--- a/code/game/machinery/fusion_engine.dm
+++ b/code/game/machinery/fusion_engine.dm
@@ -252,7 +252,7 @@
 	var/looping = FALSE
 	while(buildstate < BUILDSTATE_DAMAGE_WELD)
 		to_chat(xeno, SPAN_NOTICE("You [looping ? "continue damaging" : "start to damage"] [src]."))
-		if(!do_after(xeno, 10 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE, src))
+		if(!do_after(xeno, 10 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE, src, numticks = 20))
 			to_chat(xeno, SPAN_DANGER("You stop damaging [src]."))
 			break
 		xeno.animation_attack_on(src)


### PR DESCRIPTION

# About the pull request
With the currently logic of delay/numticks it checks it 5 times over 10 seconds. Which is every 2 seconds.
Which kinda sucks when you try to cancel it and you're stuck there for a while.

changing the numticks to 20 means it does check 20 times, so every 0.5 seconds.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #12345" to link the PR to the corresponding Issue number #12345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #12345, Fixes #12346, Fixes #12347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
More responsive, less annoying.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
code: Xenos destroying reactors now have their do_after checks occur faster.
/:cl:
