### PR TITLE
Fixes double evo screech for Synthetics appearing

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -269,7 +269,7 @@
 
 		playsound_client(current_mob.client, get_sfx("evo_screech"), current_mob.loc, 70, "minor")
 
-		if(ishuman(current_mob))
+		if(ishuman_strict(current_mob))
 			to_chat(current_mob, SPAN_HIGHDANGER("You hear a distant screech and feel your insides freeze up... something new is with you in this colony."))
 
 		if(issynth(current_mob))


### PR DESCRIPTION
# About the pull request

Disclaimer: I play Synthetic so keep this in mind while reviewing this Synth-related PR :D

At the moment, when the Evo Screech goes off for Synths, they get the text for both humans and Synthetics. This PR changes the type check to "strict" so Synths are excluded from the colonist screech.

This probably closes some issue but I haven't been able to find any by searching.

# Explain why it's good for the game

Less text.


# Testing Photographs and Procedure

## Not broken for humans after changed typecheck

<img width="903" height="645" alt="image" src="https://github.com/user-attachments/assets/81df1c7c-4178-4ba6-bf37-497c93b6c569" />

## Working for Synthetics as intended

<img width="937" height="572" alt="image" src="https://github.com/user-attachments/assets/91e6d7cd-4c6f-4a92-bd80-9177e9db65a9" />


# Changelog

:cl: DangerRevolution
fix: Fixed Synthetics getting double warnings when the Hive is able to evolve to a new caste.
/:cl:
