### PR TITLE
fixes bypassing engi skill upgrade limit

### DIFF
--- a/code/game/objects/items/pamphlets/pamphlet_upgrades.dm
+++ b/code/game/objects/items/pamphlets/pamphlet_upgrades.dm
@@ -92,7 +92,7 @@
 	desc = "A pamphlet used to quickly impart vital knowledge on heavier-duty equipments and firearms. You suppose you can utilize some of its teachings for some engineering practices."
 	icon_state = "pamphlet_machinegunner"
 	skill_upgrade = SKILL_ENGINEER
-	skill_cap = 2
+	skill_cap = 1
 
 /obj/item/pamphlet/upgradeable/surgery
 	name = "Surgery instructional pamphlet"


### PR DESCRIPTION

# About the pull request

jobs like medics and certain specs, etc are not meant to have skills equivalent to squad engis, and are not meant to be able to do things like fix APCs. This is in an attempt to not have people powergame and defeat the teamwork aspect of the game.

in the upgradable pamphlet PR, the cap for the machine gun pamphlet was mistakenly set at 2, which allowed users to use an engineering pamphlet and then a HMG pamphlet to obtain the ability to repair APCs etc as jobs which are not intended to have that ability, such as scout specialist and medic.

this pr resolves that by lowering the cap


# Explain why it's good for the game

fixes an oversight


# Changelog

:cl:
fix: pamphlets can no longer be used to bypass intended engi skill caps
/:cl:

