### PR TITLE
crayons use a cosmetic helmet slot

### DIFF
--- a/code/game/objects/items/toys/toys.dm
+++ b/code/game/objects/items/toys/toys.dm
@@ -143,6 +143,8 @@
 	var/instant = 0
 	var/colorName = "red" //for updateIcon purposes
 
+	flags_obj = OBJ_IS_HELMET_GARB
+
 /*
  * Snap pops
  */


### PR DESCRIPTION

# About the pull request

changes crayons to have the flag to use a cosmetic rather than limited helmet slot

# Explain why it's good for the game

I have given up both my helmet slots for my crayons for like a year now and it is slowly eroding my soul



# Changelog



:cl:
add: crayons count as cosmetic for the purposes of helmet inventory slots
/:cl:

