### PR TITLE
Fix: 12392 Sprite-fix for m56d in-hand reload

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -49,7 +49,7 @@
 	"chat.agent.maxRequests": 0,
 	"chat.commandCenter.enabled": false,
 	"chat.detectParticipant.enabled": false,
-	"chat.disableAIFeatures": true,
+	"chat.disableAIFeatures": false,
 	"chat.extensionTools.enabled": false,
 	"chat.focusWindowOnConfirmation": false,
 	"chat.implicitContext.enabled": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -49,7 +49,7 @@
 	"chat.agent.maxRequests": 0,
 	"chat.commandCenter.enabled": false,
 	"chat.detectParticipant.enabled": false,
-	"chat.disableAIFeatures": false,
+	"chat.disableAIFeatures": true,
 	"chat.extensionTools.enabled": false,
 	"chat.focusWindowOnConfirmation": false,
 	"chat.implicitContext.enabled": {

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -102,6 +102,7 @@
 		. += "It seems to be lacking an ammo drum."
 
 /obj/item/device/m56d_gun/update_icon() //Lets generate the icon based on how much ammo it has.
+	icon_state = initial(icon_state)
 	if(has_mount)
 		icon_state += "_tri"
 	if(rounds)


### PR DESCRIPTION
New Coder here,
This happens because the icon checks to update when loading the ammunition. It also updates the icon when a tripod is attached to it. It updates the state of the icon by adding "_tri" to it. So when you add ammunition after the tripod is already attached, it does both. Making the item become "m56d_tri_tri", of which there is no sprite of.

This is what I can think of as a quick fix, but I'm not really experienced so maybe there's a way to adjust the whole "icon_state += _tri" thing. But by just reseting the icon_state to its initial seems to fix it.


# About the pull request

Fixes: #12392

# Explain why it's good for the game
Let's players continue to load their m56d without the sprite breaking each time they reload it in-hand.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.
<img width="1248" height="216" alt="image" src="https://github.com/user-attachments/assets/98a129dd-d675-4deb-b232-6ad2511af58c" />

</details>


# Changelog
🆑

fix: Loading m56d (with tripod) in-hand.
/:cl:

