### PR TITLE
Fix: Drenching an object in acid properly displays the object name

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
@@ -25,7 +25,7 @@
 
 	for(var/obj/effect/xenomorph/acid/A in turf)
 		if(acid_type == A.type && A.acid_t == O)
-			to_chat(src, SPAN_WARNING("[A] is already drenched in acid."))
+			to_chat(src, SPAN_WARNING("[O] is already drenched in acid."))
 			return
 
 	var/obj/I
@@ -103,7 +103,7 @@
 	// AGAIN BECAUSE SOMETHING COULD'VE ACIDED THE PLACE
 	for(var/obj/effect/xenomorph/acid/A in turf)
 		if(acid_type == A.type && A.acid_t == O)
-			to_chat(src, SPAN_WARNING("[A] is already drenched in acid."))
+			to_chat(src, SPAN_WARNING("[O] is already drenched in acid."))
 			return
 
 	if(HAS_TRAIT(src, TRAIT_ABILITY_BURROWED)) //Checked again to account for people trying to place acid while channeling the burrow ability

--- a/code/modules/mob/living/carbon/xenomorph/abilities/runner/runner_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/runner/runner_powers.dm
@@ -91,7 +91,7 @@
 	// AGAIN BECAUSE SOMETHING COULD'VE ACIDED THE PLACE
 	for(var/obj/effect/xenomorph/acid/acid in turf)
 		if(acid_type == acid.type && acid.acid_t == affected_atom)
-			to_chat(src, SPAN_WARNING("[acid] is already drenched in acid."))
+			to_chat(src, SPAN_WARNING("[affected_atom] is already drenched in acid."))
 			return
 
 	if(!check_state())


### PR DESCRIPTION
# About the pull request

Drenching an acid-ed object in acid in current state will tell you that the "Acid (Obj)" is already drenched in acid. It should instead say that the object alone is drenched.

Trying to drench the acid itself still will say that you are trying to acid the acid. 

I hope this make sense. Try to do it in-game and you'll see what I mean.

# Explain why it's good for the game

Yay yippee fix!!! Yay!!!

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

https://files.catbox.moe/mpl4op.png

</details>


# Changelog

:cl:
fix: Trying to drench an acid-ed object in acid now properly states the object's name
/:cl:
