### PR TITLE
Changes Almayer Astronav and Reactor Room APCs to Hardened

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -15130,7 +15130,7 @@
 /area/almayer/middeck/maintenance/sp)
 "aNu" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/machinery/power/apc/almayer/east,
+/obj/structure/machinery/power/apc/almayer/hardened/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plating,
 /area/almayer/shipboard/navigation)
@@ -69102,7 +69102,7 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/shipboard/brig/starboard_hallway)
 "nAd" = (
-/obj/structure/machinery/power/apc/almayer/east,
+/obj/structure/machinery/power/apc/almayer/hardened/east,
 /turf/open/floor/almayer,
 /area/almayer/engineering/lower/engine_core)
 "nAm" = (


### PR DESCRIPTION
# About the pull request

Currently only the pump APCs are hardened, since #12351 this has become far more prevalent due to it consistently destroying non hardened APCs across the entire Almayer. 

# Explain why it's good for the game

While the aforementioned PR was both a bug fix and also somewhat a remedy to a hijack that many view as very Marine sided, it's made FTL functionally impossible to "win" as Marines unless an engineer can repair engineering before all pumps are taken down. Speaking from experience the way this usually goes is that the FTL is lost as I am repairing my first APC, regardless of if I'm going to Reactor or I'm trying to sneak in to repair a pump or whatever. 

To me, the intended purpose of the hijack objectives is to hold them. Starting them as broken (85% of the time) means that 

1. If they're not quickly repaired the hijack ends very quickly, as holding the pump APCs is very unlikely and once the Almayer falls below the fuel pumping threshold it's instantly lost no matter what repairs happen past that point. 
2. As people adapt to this it will change the hijack meta in a way that I don't think is appealing, where the moment the alert happens you have engineers standing next to astronav / reactor. To me this just seems like a noob trap where either we functionally have all objective APCs online at the start of the hijack anyways or the people playing engi happen to not understand this obscure game mechanic and it's over instantly. 
3. Or people just ignore these two objectives outright even moreso than they do already, and they might as well not be there. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Orchidfox
maptweak: The Almayer's Reactor Room and Astronav APCs are now Hardened APCs and will not break upon hijack.
/:cl: