### PR TITLE
Fix: Egg Morphers are whackable + Get some extra health

### DIFF
--- a/code/modules/cm_aliens/structures/special/egg_morpher.dm
+++ b/code/modules/cm_aliens/structures/special/egg_morpher.dm
@@ -5,7 +5,7 @@
 	name = XENO_STRUCTURE_EGGMORPH
 	desc = "A disgusting biomass generator that reeks of rotting flesh. Capable of producing facehuggers on its own."
 	icon_state = "eggmorph"
-	health = 300
+	health = 400
 	appearance_flags = KEEP_TOGETHER
 	layer = FACEHUGGER_LAYER
 
@@ -67,7 +67,7 @@
 
 /obj/effect/alien/resin/special/eggmorph/attackby(obj/item/item, mob/user)
 	if(!isxeno(user))
-		return
+		return ..(item, user)
 
 	if(istype(item, /obj/item/clothing/mask/facehugger))
 		var/obj/item/clothing/mask/facehugger/hugger = item


### PR DESCRIPTION

# About the pull request
Split off of https://github.com/cmss13-devs/cmss13/pull/10414
Because I'm bloating it more 
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
It's already been in the game for a while cause my PR is usually sat on TM. But whacking these things should be allowed. Even if it's a bad idea to get into whacking range.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Makes Egg morphers melee-able
balance: Give them 100 extra health so they don't get whacked in one hit by some weapons.
/:cl:
