### PR TITLE
Fix: Flaky create_and_destroy: /obj/item/cell/apc/empty

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1315,15 +1315,15 @@ GLOBAL_LIST_INIT(apc_wire_descriptions, flatten_numeric_alist(alist(
 			if(prob(25))
 				set_broken()
 				if(cell && prob(25))
-					cell.ex_act(severity)
+					QDEL_NULL(cell)
 		if(EXPLOSION_THRESHOLD_LOW to EXPLOSION_THRESHOLD_MEDIUM)
 			if(prob(50))
 				set_broken()
 				if(cell && prob(50))
-					cell.ex_act(severity)
+					QDEL_NULL(cell)
 		if(EXPLOSION_THRESHOLD_MEDIUM to INFINITY)
 			if(cell)
-				cell.ex_act(severity) //More lags woohoo
+				QDEL_NULL(cell)
 			deconstruct(FALSE)
 			return
 


### PR DESCRIPTION

# About the pull request
Presumably caused by this 
<img width="470" height="410" alt="image" src="https://github.com/user-attachments/assets/06e236b0-5809-477a-bec9-6bcb8ca03a6a" />
Exploding the APC and then the cell just having it's own ex_act called on it for no good reason. Where sometimes it does delete itself but not it's references. Duh. Use QDEL_NULL instead.

Resolves: #12359, Resolves: #12379, Resolves: #12399

Probably. 
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: APCs not properly handling explosions on the cells within them
/:cl:
