### PR TITLE
maybe fix pharm phys showing as misc dept

### DIFF
--- a/code/modules/gear_presets/uscm_medical.dm
+++ b/code/modules/gear_presets/uscm_medical.dm
@@ -108,6 +108,7 @@
 /datum/equipment_preset/uscm_ship/uscm_medical/doctor/pharmacist
 	name = "USCM Pharmaceutical Physician"
 	assignment = JOB_PHARMACIST
+	job_title = JOB_DOCTOR
 
 /datum/equipment_preset/uscm_ship/uscm_medical/doctor/pharmacist/load_gear(mob/living/carbon/human/new_human)
 	var/back_item = /obj/item/storage/backpack/marine/satchel


### PR DESCRIPTION
# About the pull request

Probably fixes #12405 by forcing the job presets to explicitly pass job_doctor to the datacore first before the equip presents will call manfest_modify and force update it to the correct job title

**this is exactly how the surgeon vanity title also does it**.  some thoughts on that below

# Explain why it's good for the game
Well, well, well.

So actually what i found out in the course of this is that the way surgeon passes the vanity title into the manifest specifically sets up great circumstances for a race condition. Did I duplicate that logic? Yes. Here's why:
1. I don't want to override completely the way the roles populate into the manifest so every doctor appears as "doctor" because having pharmacists be stripped of their vanity titles on manifest and surgeons not seems...weird. happy to force both to appear as doctor though if we want to move away from vanity titles. Maybe its more intelligible for people to see there's 4 doctors versus 2 doctors and a surgeon and a pharm
2. I also didnt want to overwrite the actual assignment in the datacore; on the backend, I thought it's probably best for doctors, surgeons, and pharms to still all appear as just doctors.
In short, there were better ways to do this; this is the only one I came up with preserving current behavior across both roles.
# Testing Photographs and Procedure
I did this on my phone smh. Pls provide feedback if we'd rather just cut the potential for race conditions here, it feels hack-y.


# Changelog

:cl:
fix: fixed pharmacists not showing in the medical department
/:cl: