### PR TITLE
Remove CLF headband from char prefs

### DIFF
--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -1392,13 +1392,6 @@ GLOBAL_LIST_EMPTY(roles_with_gear)
 	display_name = "Suntex-Sightware rounded shades, bloodred"
 	path = /obj/item/clothing/glasses/sunglasses/hippie/bloodred
 
-// Headband
-
-/datum/gear/civilian/headwear/headband_rebel
-	display_name = "CLF headband"
-	path = /obj/item/clothing/head/headband/rebel
-	fluff_cost = 2
-
 // Civilian shoes
 
 /datum/gear/civilian/shoes


### PR DESCRIPTION

# About the pull request

Title

# Explain why it's good for the game

Same reason why i removed CLF patch from char prefs entirely, CLF already spawn in such, creating opportunity for shipside civs or total majority of survivors to have that is just gonna cause headache and shouldn't be a thing.

:cl:
del: Removed CLF headband from char prefs
/:cl:
