### PR TITLE
Lunge mine CLF buff

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -299,7 +299,7 @@
 	var/unwielded_hitsound = "swing_hit"
 
 	/// This controls how strong the explosion will be on the lunge mine. Higher is better.
-	var/detonation_force = 150
+	var/detonation_force = 200
 
 /obj/item/weapon/twohanded/lungemine/wield(mob/user)
 	. = ..()
@@ -347,7 +347,7 @@
 
 /obj/item/weapon/twohanded/lungemine/proc/lungemine_detonate(atom/target, mob/user)
 	var/turf/epicenter = get_turf(target)
-	cell_explosion(epicenter, detonation_force, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, create_cause_data(initial(name), user))
+	cell_explosion(epicenter, detonation_force, 100, EXPLOSION_FALLOFF_SHAPE_EXPONENTIAL, null, create_cause_data(initial(name), user))
 	if(gib_user)
 		user.gib()
 	qdel(src)
@@ -355,7 +355,7 @@
 /obj/item/weapon/twohanded/lungemine/damaged
 	name = "damaged lunge mine"
 	desc = "A crude but intimidatingly bulky shaped explosive charge, fixed to the end of a pole. To use it, one must grasp it firmly in both hands, and thrust the prongs of the shaped charge into the target. That the resulting explosion occurs directly in front of the user's face was not an apparent concern of the designer. A true hero's weapon. This one seems pretty badly damaged, you probably shouldn't even pick it up from the ground."
-	detonation_force = 50
+	detonation_force = 100
 	gib_user = FALSE
 
 /obj/item/weapon/twohanded/breacher

--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -36605,11 +36605,12 @@
 /area/bigredv2/outside/n)
 "vCd" = (
 /obj/structure/surface/rack,
-/obj/item/weapon/twohanded/lungemine{
+/obj/item/weapon/twohanded/lungemine/damaged{
 	pixel_y = 8
 	},
-/obj/item/weapon/twohanded/lungemine{
-	pixel_y = -7
+/obj/item/weapon/twohanded/lungemine/damaged{
+	pixel_y = 3;
+	pixel_x = 7
 	},
 /turf/open/floor/plating/platingdmg3/west,
 /area/bigredv2/caves/mining)

--- a/maps/map_files/BigRed/standalone/clfmining.dmm
+++ b/maps/map_files/BigRed/standalone/clfmining.dmm
@@ -2008,12 +2008,7 @@
 /area/bigredv2/caves/mining)
 "Fl" = (
 /obj/structure/surface/rack,
-/obj/item/weapon/twohanded/lungemine{
-	pixel_y = 8
-	},
-/obj/item/weapon/twohanded/lungemine{
-	pixel_y = -7
-	},
+/obj/item/weapon/twohanded/lungemine,
 /turf/open/floor/plating/platingdmg3/west,
 /area/bigredv2/caves/mining)
 "Fo" = (

--- a/maps/map_files/DesertDam/nspa/10.clf_attack.dmm
+++ b/maps/map_files/DesertDam/nspa/10.clf_attack.dmm
@@ -167,7 +167,7 @@
 /area/desert_dam/building/security/lobby)
 "pa" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/weapon/twohanded/lungemine,
+/obj/item/weapon/twohanded/lungemine/damaged,
 /turf/open/asphalt/cement_sunbleached,
 /area/desert_dam/exterior/valley/valley_security)
 "pf" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR buffs the regular lunge mine. It's detonation force has been buffed from 150 to 200, this is a large enough increase where you are able to gib the human target you are trying to hit if they are unarmored. a life for a life. To account for that increase, the falloff has been increased from 50 to 100 and the explosion falloff shape has been changed to exponential, making the explosion more concentrated to be designed as a single target explosive device.

armored human targets do not get gibbed but now they die. (they didnt die before if they were full health)

Now when it comes to xenomorphs (assuming they all have full health):
Runner - Gibbed
Drone - Gibbed
Sentinel - Near death crit, will need to land on weeds to survive.
Defender - Survives with 200 health. If Fortified, barely takes damage.
Burrower - Survives with 60 health.
Carrier - Survives with 100 health.
Hivelord - Near death crit, will need to land on weeds to survive.
Lurker - Survives with 70 health.
Warrior - Survives with 60 health.
Spitter - Survives with 5 health.
Boiler - Survives with 105 health.
Ravager - Survives with 380 health.
Despoiler - Survives with 71 health.
Preatorian - Survives with 210.
Queen, Crusher, Predalien and King - insignificant damage.

These values may change depending on the strain of the xenomorph, all tested with base versions.

Now the main part, availability.
Since the lunge mines have been buffed, the following mapping changes were made:

Solaris Ridge - the two lunge mines have been replaced with the damaged variant.

Solaris Ridge Nightmare Insert CLF - It now has only 1 regular lunge mine

Hybrisa Prospera - The three lunge mines have been replaced with the damaged variant.

Trijent Dam NSPA Nightmare insert - the singular lunge mine has been replaced with the damaged variant.

About the damaged variants:
These are nerfed lunge mines that deal less damage and don't gib the user.
Previously they did not exist in regular gameplay but now they do. Their damage was nerfed from 150 to 50 originally, but I've buffed them slightly to 100. They are still worse than the lunge mines you encountered before.

**So in regular (not influenced by admins) gameplay outside of the Solaris Ridge CLF insert: You will NOT encounter the new buffed lunge mines. They remain a rarity that will be fun to see happen once in a while.**

also for preds they still wont kill you (if you are full health). But be mindful of the stun regardless, you can be shot to death just like before. They deal 140 dmg to you now.



# Explain why it's good for the game

The lunge mine as we know despite being a gimmick weapon has fallen off in terms of how lethal has it been in the past due to what we all assumed was intentional, was actually due to bugs. This PR should bring them back as the funny assassination stick we all loved while keeping them very rare and still "balanced" against armored humans and most xenos.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Unknownity
balance: The lunge mine has been buffed to be able to gib unarmored humans and kill armored humans while its area effect has been decreased.
balance: The damaged variant of the lunge mine has been slightly buffed but its still worse than the regular lunge mine before the buff.
maptweak: The lunge mines in Solaris Ridge, Hybrisa Prospera and Trijent Dam have been replaced with the damaged nerfed versions. The Solaris Ridge CLF Insert has only one regular lunge mine now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
