### PR TITLE
Medical scans automatically apply triage holocards

### DIFF
--- a/code/__DEFINES/client_prefs.dm
+++ b/code/__DEFINES/client_prefs.dm
@@ -93,6 +93,16 @@
 #define DUAL_WIELD_NONE 2
 //=================================================
 
+//auto_holotag from /datum/preferences
+//=================================================
+// Do not tag patients automatically
+#define NEVER_TAG_PATIENTS 0
+// Only tag patients after scanning them in a bodyscanner (not a handheld scanner)
+#define BODYSCAN_TAG_PATIENTS 1
+// Auto tag patients with triage tags upon scanning
+#define ALWAYS_TAG_PATIENTS 2
+
+
 //=================================================
 ///Do not show any item pickup animations
 #define SHOW_ITEM_ANIMATIONS_NONE 0

--- a/code/__DEFINES/client_prefs.dm
+++ b/code/__DEFINES/client_prefs.dm
@@ -95,11 +95,11 @@
 
 //auto_holotag from /datum/preferences
 //=================================================
-// Do not tag patients automatically
+/// Do not tag patients automatically
 #define NEVER_TAG_PATIENTS 0
-// Only tag patients after scanning them in a bodyscanner (not a handheld scanner)
+/// Only tag patients after scanning them in a bodyscanner (not a handheld scanner)
 #define BODYSCAN_TAG_PATIENTS 1
-// Auto tag patients with triage tags upon scanning
+/// Auto tag patients with triage tags upon scanning
 #define ALWAYS_TAG_PATIENTS 2
 
 

--- a/code/__DEFINES/human.dm
+++ b/code/__DEFINES/human.dm
@@ -112,7 +112,7 @@
 // Holocard defines
 #define HOLOCARD_ACCURACY_HANDHELD 0
 #define HOLOCARD_ACCURACY_MANUAL 1
-#define HOLOCARD_ACCURACY_BODYSCANNER 2 // Bodyscanners will always be able to set the correct holotag
+#define HOLOCARD_ACCURACY_BODYSCANNER 2 //! Bodyscanners will always be able to set the correct holotag
 
 // ORDERS
 #define COMMAND_ORDER_RANGE 7

--- a/code/__DEFINES/human.dm
+++ b/code/__DEFINES/human.dm
@@ -109,6 +109,11 @@
 #define LIMB_PRINTING_TIME 550
 #define LIMB_METAL_AMOUNT 125
 
+// Holocard defines
+#define HOLOCARD_ACCURACY_HANDHELD 0
+#define HOLOCARD_ACCURACY_MANUAL 1
+#define HOLOCARD_ACCURACY_BODYSCANNER 2 // Bodyscanners will always be able to set the correct holotag
+
 // ORDERS
 #define COMMAND_ORDER_RANGE 7
 #define COMMAND_ORDER_COOLDOWN 800 // 1 minute 20 seconds

--- a/code/game/machinery/medical_pod/bodyscanner.dm
+++ b/code/game/machinery/medical_pod/bodyscanner.dm
@@ -182,7 +182,7 @@
 		last_health_display.target_mob = H
 
 	// Handle automatic holotags
-	if (user.client.prefs.auto_holotag >= BODYSCAN_TAG_PATIENTS)
+	if (user.client?.prefs.auto_holotag >= BODYSCAN_TAG_PATIENTS)
 		H.auto_assign_holotag(user, HOLOCARD_ACCURACY_BODYSCANNER)
 
 	N.fields["last_tgui_scan_result"] = last_health_display.ui_data(user, DETAIL_LEVEL_BODYSCAN)

--- a/code/game/machinery/medical_pod/bodyscanner.dm
+++ b/code/game/machinery/medical_pod/bodyscanner.dm
@@ -181,6 +181,10 @@
 	else
 		last_health_display.target_mob = H
 
+	// Handle automatic holotags
+	if (user.client.prefs.auto_holotag >= BODYSCAN_TAG_PATIENTS)
+		H.auto_assign_holotag(user, HOLOCARD_ACCURACY_BODYSCANNER)
+
 	N.fields["last_tgui_scan_result"] = last_health_display.ui_data(user, DETAIL_LEVEL_BODYSCAN)
 	N.fields["autodoc_data"] = generate_autodoc_surgery_list(H)
 	visible_message(SPAN_NOTICE("\The [src] pings as it stores the scan report of [H.real_name]"))

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -107,6 +107,12 @@ K9 SCANNER
 			last_health_display = new(target_mob)
 		else
 			last_health_display.target_mob = target_mob
+
+		// Handle automatic holotags
+		if (user.client.prefs.auto_holotag >= BODYSCAN_TAG_PATIENTS && istype(target_mob, /mob/living/carbon/human))
+			var/mob/living/carbon/human/human = target_mob
+			human.auto_assign_holotag(user, HOLOCARD_ACCURACY_HANDHELD)
+
 		SStgui.close_user_uis(user, src)
 		last_scan = last_health_display.ui_data(user, DETAIL_LEVEL_HEALTHANALYSER)
 		last_health_display.look_at(user, DETAIL_LEVEL_HEALTHANALYSER, bypass_checks = FALSE, ignore_delay = FALSE, alien = alien)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -109,7 +109,7 @@ K9 SCANNER
 			last_health_display.target_mob = target_mob
 
 		// Handle automatic holotags
-		if (user.client.prefs.auto_holotag >= BODYSCAN_TAG_PATIENTS && istype(target_mob, /mob/living/carbon/human))
+		if (user.client.prefs.auto_holotag >= ALWAYS_TAG_PATIENTS && istype(target_mob, /mob/living/carbon/human))
 			var/mob/living/carbon/human/human = target_mob
 			human.auto_assign_holotag(user, HOLOCARD_ACCURACY_HANDHELD)
 

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -109,7 +109,7 @@ K9 SCANNER
 			last_health_display.target_mob = target_mob
 
 		// Handle automatic holotags
-		if (user.client.prefs.auto_holotag >= ALWAYS_TAG_PATIENTS && istype(target_mob, /mob/living/carbon/human))
+		if (user?.client.prefs.auto_holotag >= ALWAYS_TAG_PATIENTS && istype(target_mob, /mob/living/carbon/human))
 			var/mob/living/carbon/human/human = target_mob
 			human.auto_assign_holotag(user, HOLOCARD_ACCURACY_HANDHELD)
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -48,6 +48,7 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 	/client/proc/toggle_ability_deactivation,
 	/client/proc/toggle_clickdrag_override,
 	/client/proc/toggle_dualwield,
+	/client/proc/toggle_auto_holotag,
 	/client/proc/toggle_middle_mouse_swap_hands,
 	/client/proc/toggle_vend_item_to_hand,
 	/client/proc/switch_item_animations,

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -102,6 +102,7 @@ GLOBAL_LIST_INIT(be_special_flags, list(
 	var/ghost_vision_pref = GHOST_VISION_LEVEL_MID_NVG
 	var/ghost_orbit = GHOST_ORBIT_CIRCLE
 	var/dual_wield_pref = DUAL_WIELD_FIRE
+	var/auto_holotag = ALWAYS_TAG_PATIENTS
 	var/playtime_perks = TRUE
 	var/skip_playtime_ranks = FALSE
 	var/show_minimap_ceiling_protection = FALSE
@@ -684,6 +685,7 @@ GLOBAL_LIST_INIT(be_special_flags, list(
 					</b> <a href='byond://?_src_=prefs;preference=toggle_prefs;flag=[TOGGLE_AMMO_DISPLAY_TYPE]'><b>[toggle_prefs & TOGGLE_AMMO_DISPLAY_TYPE ? "On" : "Off"]</b></a><br>"
 			dat += "<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/switch_item_animations'>Toggle Item Animations Detail Level</a><br>"
 			dat += "<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/toggle_dualwield'>Toggle Dual Wield Functionality</a><br>"
+			dat += "<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/toggle_auto_holotag'>Toggle Auto Holotags</a><br>"
 			dat += "<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/toggle_auto_shove'>Toggle Auto Shove</a><br>"
 		if(MENU_SPECIAL) //wart
 			dat += "<div id='column1'>"

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -277,6 +277,7 @@ CLIENT_VERB(toggle_prefs) // Toggle whether anything will happen when you click 
 		"<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/toggle_clickdrag_override'>Toggle Combat Click-Drag Override</a><br>",
 		"<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/toggle_dualwield'>Toggle Alternate-Fire Dual Wielding</a><br>",
 		"<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/toggle_auto_shove'>Toggle Auto Shove</a><br>",
+		"<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/toggle_auto_holotag'>Toggle Auto Holotags</a><br>",
 		"<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/toggle_middle_mouse_swap_hands'>Toggle Middle Mouse Swapping Hands</a><br>",
 		"<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/toggle_vend_item_to_hand'>Toggle Vendors Vending to Hands</a><br>",
 		"<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/switch_item_animations'>Toggle Item Animations</a><br>",
@@ -427,6 +428,24 @@ CLIENT_VERB(toggle_prefs) // Toggle whether anything will happen when you click 
 			to_chat(src, SPAN_BOLDNOTICE("Dual-wielding now has no effect on how you fire."))
 
 	prefs.save_preferences()
+
+// Toggles whether or not using a body scanner/handheld scanner applies a triage tag to patients automatically
+
+/client/proc/toggle_auto_holotag()
+	switch (prefs.auto_holotag) {
+		if (NEVER_TAG_PATIENTS)
+			prefs.auto_holotag = ALWAYS_TAG_PATIENTS
+			to_chat(src, SPAN_BOLDNOTICE("Body scanners and handheld scanners will now automatically apply holocards."))
+		if (ALWAYS_TAG_PATIENTS)
+			prefs.auto_holotag = BODYSCAN_TAG_PATIENTS
+			to_chat(src, SPAN_BOLDNOTICE("Only body scanners will automatically apply triage holocards."))
+		if (BODYSCAN_TAG_PATIENTS)
+			prefs.auto_holotag = NEVER_TAG_PATIENTS
+			to_chat(src, SPAN_BOLDNOTICE("Triage holocards will never be automatically applied by health scanning devices."))
+		else
+			// Redundancy case, if defines ever get changed
+			prefs.auto_holotag = ALWAYS_TAG_PATIENTS
+	}
 
 /client/proc/toggle_middle_mouse_swap_hands() //Toggle whether middle click swaps your hands
 	prefs.toggle_prefs ^= TOGGLE_MIDDLE_MOUSE_SWAP_HANDS

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -872,6 +872,11 @@
 		else if (blood_volume < BLOOD_VOLUME_SAFE)
 			tag_severity = 1 // Severity could only ever be 0 at this point, safe to directly assign
 
+		// Overdoses are life-threatening
+		for (var/datum/reagent/reagent in src.reagents.reagent_list)
+			if (reagent.volume > reagent.overdose)
+				tag_severity = 2
+
 		// The highest holotag you can get from limbs is red, so we can safely break out of the limb loop if we find a red-worthy injury
 		for (var/obj/limb/limb in src)
 			// Uncleaned amputations, while technically not life threatening because amputations
@@ -918,10 +923,14 @@
 		// Check if this new scan would have had the accuracy to view organs
 		if (new_accuracy >= HOLOCARD_ACCURACY_BODYSCANNER)
 			// Heartbroken marines should be operated on IMMEDIATELY
-			if (is_heart_broken()) tag_severity = 2
+			var/datum/internal_organ/kidneys/heart = internal_organs_by_name["heart"]
+			if (heart.organ_status >= ORGAN_BROKEN) tag_severity = 2
+			else if (heart.organ_status >= ORGAN_BRUISED) tag_severity = tag_severity > 1 ? tag_severity : 1
 
 			// Ditto for ruptured lungs
+			var/datum/internal_organ/kidneys/lungs = internal_organs_by_name["lungs"]
 			if (is_lung_ruptured()) tag_severity = 2
+			else if (lungs.organ_status >= ORGAN_BRUISED) tag_severity = tag_severity > 1 ? tag_severity : 1
 
 			// Bruised livers and kidneys will accumulate toxin damage
 			// It's debatable whether or not this should be orange or red, but better safe than sorry
@@ -941,8 +950,7 @@
 
 		if (status_flags & PERMANENTLY_DEAD) tag_severity = 3
 
-		if (status_flags & XENO_HOST) tag_severity = 4
-
+		if (status_flags & XENO_HOST && new_accuracy >= HOLOCARD_ACCURACY_BODYSCANNER) tag_severity = 4
 
 		var/old_severity
 		// Yes, switching between strings and numbers like this is terrible and I should be using a custom define, but I don't want to touch the code already in place
@@ -953,6 +961,7 @@
 			if("red") old_severity = 2
 			if("black") old_severity = 3
 			if("purple") old_severity = 4 // Even if they're unrevivable, we need to get the larva out
+			else old_severity = 0
 
 		// If the scan's accuracy is equal to or greater than the previous scan, or if the severity is higher than the old severity, update the card
 		if (tag_severity > old_severity || new_accuracy >= holo_card_accuracy)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -899,26 +899,13 @@
 				break
 			if (internal_bleeding) break
 
-			// Shrapnel should be removed immediately
-			var/shrapnel = FALSE
-			for(var/implant in limb.implants)
-				if(is_sharp(implant) || istype(implant, /obj/item/shard/shrapnel))
-					tag_severity = 2
-					shrapnel = TRUE
-					break
-			if (shrapnel) break
-
 			// Splinted fractures do not require immediate surgical intervention
 			// Unsplinted fractures should be handled immediately before more damage is done
 			if (limb.status & LIMB_BROKEN)
-				if (!(limb.status & LIMB_SPLINTED))
-					tag_severity = 2
-					break
-
 				tag_severity = max(tag_severity, 1)
 
 			// Severe burns and eschars are not immediately life-threatening
-			if (limb.status & (LIMB_THIRD_DEGREE_BURNS | LIMB_ESCHAR))
+			if (limb.status & LIMB_ESCHAR)
 				tag_severity = max(tag_severity, 1)
 
 		// Check if this new scan would have had the accuracy to view organs

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -874,12 +874,12 @@
 			tag_severity = 1 // Severity could only ever be 0 at this point, safe to directly assign
 
 		// Overdoses are life-threatening
-		for (var/datum/reagent/reagent in src.reagents.reagent_list)
+		for (var/datum/reagent/reagent as anything in reagents.reagent_list)
 			if (reagent.volume > reagent.overdose)
 				tag_severity = 2
 
 		// The highest holotag you can get from limbs is red, so we can safely break out of the limb loop if we find a red-worthy injury
-		for (var/obj/limb/limb in src)
+		for (var/obj/limb/limb as anything in limbs)
 			// Uncleaned amputations, while technically not life threatening because amputations
 			// don't bleed, cause an incredible amount of pain, usually enough to paincrit the injured human.
 			if (limb.status & LIMB_DESTROYED)
@@ -889,7 +889,7 @@
 			// An argument could be made for cleaned and dressed amputations to be red tag, but at that point
 			// it no longer causes any pain and only applies the slowdown/missing hand, so nonlethal
 			if (limb.status & LIMB_AMPUTATED)
-				tag_severity = tag_severity > 1 ? tag_severity : 1
+				tag_severity = max(tag_severity, 1)
 
 			// Internal bleeding requires immediate surgery
 			var/internal_bleeding = FALSE
@@ -915,23 +915,23 @@
 					tag_severity = 2
 					break
 
-				tag_severity = tag_severity > 1 ? tag_severity : 1
+				tag_severity = max(tag_severity, 1)
 
 			// Severe burns and eschars are not immediately life-threatening
 			if (limb.status & (LIMB_THIRD_DEGREE_BURNS | LIMB_ESCHAR))
-				tag_severity = tag_severity > 1 ? tag_severity : 1
+				tag_severity = max(tag_severity, 1)
 
 		// Check if this new scan would have had the accuracy to view organs
 		if (new_accuracy >= HOLOCARD_ACCURACY_BODYSCANNER)
 			// Heartbroken marines should be operated on IMMEDIATELY
 			var/datum/internal_organ/kidneys/heart = internal_organs_by_name["heart"]
 			if (heart.organ_status >= ORGAN_BROKEN) tag_severity = 2
-			else if (heart.organ_status >= ORGAN_BRUISED) tag_severity = tag_severity > 1 ? tag_severity : 1
+			else if (heart.organ_status >= ORGAN_BRUISED) tag_severity = max(tag_severity, 1)
 
 			// Ditto for ruptured lungs
 			var/datum/internal_organ/kidneys/lungs = internal_organs_by_name["lungs"]
 			if (is_lung_ruptured()) tag_severity = 2
-			else if (lungs.organ_status >= ORGAN_BRUISED) tag_severity = tag_severity > 1 ? tag_severity : 1
+			else if (lungs.organ_status >= ORGAN_BRUISED) tag_severity = max(tag_severity, 1)
 
 			// Bruised livers and kidneys will accumulate toxin damage
 			// It's debatable whether or not this should be orange or red, but better safe than sorry
@@ -947,7 +947,7 @@
 
 			// Eye damage is not nearly as bad as the previous three organs, and isn't NECESSARY to be fixed, technically
 			var/datum/internal_organ/eyes/eyes = internal_organs_by_name["eyes"]
-			if (eyes.organ_status >= ORGAN_BRUISED) tag_severity = tag_severity > 1 ? tag_severity : 1
+			if (eyes.organ_status >= ORGAN_BRUISED) tag_severity = max(tag_severity, 1)
 
 		if (status_flags & PERMANENTLY_DEAD) tag_severity = 3
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -837,6 +837,7 @@
 		to_chat(user, SPAN_WARNING("[src] is too far away."))
 		return
 	if(newcolor == "none")
+		holo_card_accuracy = 0
 		if(!holo_card_color)
 			return
 		holo_card_color = null
@@ -847,7 +848,118 @@
 			return
 		holo_card_color = newcolor
 		to_chat(user, SPAN_NOTICE("You add a [newcolor] holo card on [src]."))
+
 	hud_set_holocard()
+
+// Scans the health of a human, then assigns an appropriate holotag based on their injuries
+// Will use new_accuracy to determine both:
+//  - What injuries should be included (for example, organ damage would not show up on a handheld scan)
+//  - Whether to update a holotag to a more accurate reading, or to keep the old one
+// Manual assignments will not change the color of the holotag, but will change the recorded accuracy
+//
+// If a manual assignment or body scanner determines there are no injuries worthy of a holotag, it will reset the accuracy rating (clean slate)
+/mob/living/carbon/human/proc/auto_assign_holotag(mob/user, new_accuracy)
+	if (new_accuracy == HOLOCARD_ACCURACY_MANUAL)
+		holo_card_accuracy = HOLOCARD_ACCURACY_MANUAL
+		return
+
+	// Only handle automatic holotags if the user has the skill to
+	if (skillcheck(user, SKILL_MEDICAL, SKILL_MEDICAL_MEDIC))
+		var/tag_severity = 0
+
+		if (blood_volume < BLOOD_VOLUME_OKAY)
+			tag_severity = 2
+		else if (blood_volume < BLOOD_VOLUME_SAFE)
+			tag_severity = 1 // Severity could only ever be 0 at this point, safe to directly assign
+
+		// The highest holotag you can get from limbs is red, so we can safely break out of the limb loop if we find a red-worthy injury
+		for (var/obj/limb/limb in src)
+			// Internal bleeding requires immediate surgery
+			var/internal_bleeding = FALSE
+			for(var/datum/effects/bleeding/internal/ib in limb.bleeding_effects_list)
+				tag_severity = 2
+				internal_bleeding = TRUE
+				break
+			if (internal_bleeding) break
+
+			// Shrapnel should be removed immediately
+			var/shrapnel = FALSE
+			for(var/implant in limb.implants)
+				if(is_sharp(implant) || istype(implant, /obj/item/shard/shrapnel))
+					tag_severity = 2
+					shrapnel = TRUE
+					break
+			if (shrapnel) break
+
+			// Splinted fractures do not require immediate surgical intervention
+			// Unsplinted fractures should be handled immediately before more damage is done
+			if (limb.status & LIMB_BROKEN)
+				if (!(limb.status & LIMB_SPLINTED))
+					tag_severity = 2
+					break
+
+				tag_severity = tag_severity > 1 ? tag_severity : 1
+
+			// Severe burns and eschars are not immediately life-threatening
+			if (limb.status & (LIMB_THIRD_DEGREE_BURNS | LIMB_ESCHAR))
+				tag_severity = tag_severity > 1 ? tag_severity : 1
+
+		// Check if this new scan would have had the accuracy to view organs
+		if (new_accuracy >= HOLOCARD_ACCURACY_BODYSCANNER)
+			// Heartbroken marines should be operated on IMMEDIATELY
+			if (is_heart_broken()) tag_severity = 2
+
+			// Ditto for ruptured lungs
+			if (is_lung_ruptured()) tag_severity = 2
+
+			// Bruised livers and kidneys will accumulate toxin damage
+			// It's debatable whether or not this should be orange or red, but better safe than sorry
+			var/datum/internal_organ/kidneys/kidneys = internal_organs_by_name["kidneys"]
+			if (kidneys.organ_status >= ORGAN_BRUISED) tag_severity = 2
+
+			var/datum/internal_organ/liver/liver = internal_organs_by_name["liver"]
+			if (liver.organ_status >= ORGAN_BRUISED) tag_severity = 2
+
+			// Brainrot is bad
+			var/datum/internal_organ/brain/brain = internal_organs_by_name["brain"]
+			if (brain.organ_status >= ORGAN_BRUISED) tag_severity = 2
+
+			// Eye damage is not nearly as bad as the previous three organs, and isn't NECESSARY to be fixed, technically
+			var/datum/internal_organ/eyes/eyes = internal_organs_by_name["eyes"]
+			if (eyes.organ_status >= ORGAN_BRUISED) tag_severity = tag_severity > 1 ? tag_severity : 1
+
+		if (status_flags & PERMANENTLY_DEAD) tag_severity = 3
+
+		if (status_flags & XENO_HOST) tag_severity = 4
+
+
+		var/old_severity
+		// Yes, switching between strings and numbers like this is terrible and I should be using a custom define, but I don't want to touch the code already in place
+		// Technical debt schmectical debt
+		switch (holo_card_color)
+			if("", null) old_severity = 0
+			if("orange") old_severity = 1
+			if("red") old_severity = 2
+			if("black") old_severity = 3
+			if("purple") old_severity = 4 // Even if they're unrevivable, we need to get the larva out
+
+		// If the scan's accuracy is equal to or greater than the previous scan, or if the severity is higher than the old severity, update the card
+		if (tag_severity > old_severity || new_accuracy >= holo_card_accuracy)
+			holo_card_accuracy = new_accuracy
+			// See previous comment
+			switch (tag_severity)
+				if (0)
+					holo_card_color = ""
+					holo_card_accuracy = HOLOCARD_ACCURACY_HANDHELD // Reset accuracy for new wounds
+				if (1)
+					holo_card_color = "orange"
+				if (2)
+					holo_card_color = "red"
+				if (3)
+					holo_card_color = "black"
+				if (4)
+					holo_card_color = "purple"
+			hud_set_holocard()
 
 /mob/living/carbon/human/tgui_interact(mob/user, datum/tgui/ui) // I'M SORRY, SO FUCKING SORRY
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -849,6 +849,7 @@
 		holo_card_color = newcolor
 		to_chat(user, SPAN_NOTICE("You add a [newcolor] holo card on [src]."))
 
+	holo_card_accuracy = HOLOCARD_ACCURACY_MANUAL
 	hud_set_holocard()
 
 // Scans the health of a human, then assigns an appropriate holotag based on their injuries
@@ -949,6 +950,14 @@
 			if (eyes.organ_status >= ORGAN_BRUISED) tag_severity = tag_severity > 1 ? tag_severity : 1
 
 		if (status_flags & PERMANENTLY_DEAD) tag_severity = 3
+
+		// For some reason, decapitated humans don't have the permanently dead tag
+		var/obj/limb/head/head
+		for (var/obj/limb/limb in src.limbs)
+			if (istype(limb, /obj/limb/head))
+				head = limb
+		if (head == null || head.status & (LIMB_DESTROYED | LIMB_AMPUTATED))
+			tag_severity = 3
 
 		if (status_flags & XENO_HOST && new_accuracy >= HOLOCARD_ACCURACY_BODYSCANNER) tag_severity = 4
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -874,6 +874,17 @@
 
 		// The highest holotag you can get from limbs is red, so we can safely break out of the limb loop if we find a red-worthy injury
 		for (var/obj/limb/limb in src)
+			// Uncleaned amputations, while technically not life threatening because amputations
+			// don't bleed, cause an incredible amount of pain, usually enough to paincrit the injured human.
+			if (limb.status & LIMB_DESTROYED)
+				tag_severity = 2
+				break
+
+			// An argument could be made for cleaned and dressed amputations to be red tag, but at that point
+			// it no longer causes any pain and only applies the slowdown/missing hand, so nonlethal
+			if (limb.status & LIMB_AMPUTATED)
+				tag_severity = tag_severity > 1 ? tag_severity : 1
+
 			// Internal bleeding requires immediate surgery
 			var/internal_bleeding = FALSE
 			for(var/datum/effects/bleeding/internal/ib in limb.bleeding_effects_list)

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -89,6 +89,7 @@
 	var/undefibbable = FALSE //whether the human is dead and past the defibbrillation period.
 
 	var/holo_card_color = "" //which color type of holocard is printed on us
+	var/holo_card_accuracy = HOLOCARD_ACCURACY_HANDHELD // What placed this holocard on the human
 
 	var/list/obj/limb/limbs = list()
 	var/list/internal_organs_by_name = list() // so internal organs have less ickiness too

--- a/code/modules/reagents/Chemistry-Colours.dm
+++ b/code/modules/reagents/Chemistry-Colours.dm
@@ -29,9 +29,9 @@
 		bluecolor[i]=hex2num(copytext(hue,6,8))
 
 	//mix all the colors
-	var/red = mixOneColor(weight,redcolor)
-	var/green = mixOneColor(weight,greencolor)
-	var/blue = mixOneColor(weight,bluecolor)
+	var/red = floor(mixOneColor(weight,redcolor))
+	var/green = floor(mixOneColor(weight,greencolor))
+	var/blue = floor(mixOneColor(weight,bluecolor))
 
 	//assemble all the pieces
 	var/finalcolor = rgb(red, green, blue)
@@ -55,7 +55,6 @@
 	var/mixedcolor = 0
 	for(i=1; i<=contents; i++)
 		mixedcolor += weight[i]*color[i]
-	mixedcolor = floor(mixedcolor)
 
 	//until someone writes a formal proof for this algorithm, let's keep this in
 // if(mixedcolor<0x00 || mixedcolor>0xFF)
@@ -68,26 +67,84 @@
 /proc/mix_burn_colors(list/reagent_list)
 	var/contents = length(reagent_list)
 	var/list/weight = new /list(contents)
-	var/list/redcolor = new /list(contents)
-	var/list/greencolor = new /list(contents)
-	var/list/bluecolor = new /list(contents)
+	var/list/hue = new /list(contents)
+	var/list/saturation = new /list(contents)
 
 	for(var/i in 1 to contents)
 		//fill the list of weights
-		var/datum/reagent/re = reagent_list[i]
-		weight[i] = max(re.volume,1) * re.burncolormod
-		//fill the lists of colors
-		var/hue = re.burncolor
-		if(length(hue) != 7)
-			return 0
-		redcolor[i]=hex2num(copytext(hue,2,4))
-		greencolor[i]=hex2num(copytext(hue,4,6))
-		bluecolor[i]=hex2num(copytext(hue,6,8))
+		var/datum/reagent/reagent = reagent_list[i]
+		weight[i] = max(reagent.volume, 1) * reagent.burncolormod
 
-	//mix all the colors
-	var/red = mixOneColor(weight,redcolor)
-	var/green = mixOneColor(weight,greencolor)
-	var/blue = mixOneColor(weight,bluecolor)
+		var/hex_color = reagent.burncolor
+		if (length(hex_color) != 7)
+			return 0
+
+		// Convert the rgb factors into hs
+		// This prevents low-value flames (eg:darkflame and invisible flames)
+		var/redfactor = hex2num(copytext(hex_color,2,4)) / 255.0
+		var/greenfactor = hex2num(copytext(hex_color,4,6)) / 255.0
+		var/bluefactor = hex2num(copytext(hex_color,6,8)) / 255.0
+
+		var/cmax = max(redfactor, greenfactor, bluefactor)
+		var/cmin = min(redfactor, greenfactor, bluefactor)
+		var/delta = cmax - cmin
+
+		if (delta == 0)
+			hue[i] = 0
+		else if (redfactor == cmax)
+			hue[i] = (greenfactor - bluefactor)/delta
+		else if (greenfactor == cmax)
+			hue[i] = 2 + (bluefactor - redfactor)/delta
+		else if (bluefactor == cmax)
+			hue[i] = 4 + (redfactor - greenfactor)/delta
+		else
+			// Should be unreachable, but it doesn't hurt to catch this just in case
+			hue[i] = 0
+		hue[i] *= 60 // Converting to degrees
+
+		if (cmax == 0)
+			saturation[i] = 0
+		else
+			saturation[i] = delta / cmax
+
+	// Saturation can be mixed normally
+	var/final_saturation = mixOneColor(weight,saturation)
+
+	// Mixing hues is a little more complicated, take the circular mean of the hues
+	var/sinsum = 0
+	var/cossum = 0
+	for(var/i in 1 to contents)
+		// Because it's on a circle, we don't need to worry about normalizing weights
+		sinsum += sin(hue[i]) * saturation[i] * weight[i]
+		cossum += cos(hue[i]) * saturation[i] * weight[i]
+	var/final_hue = arctan(cossum, sinsum)
+	if (final_hue < 0)
+		final_hue += 360
+
+	// Converting this hue average back into rgb format
+	var/secondary = final_saturation * (1 - (abs(final_hue % 120 - 60) / 60))
+	var/red_prime = 0
+	var/green_prime = 0
+	var/blue_prime = 0
+	if (final_hue < 60)
+		red_prime = final_saturation
+		green_prime = secondary
+	else if (final_hue < 120)
+		red_prime = secondary
+		green_prime = final_saturation
+	else if (final_hue < 180)
+		green_prime = final_saturation
+		blue_prime = secondary
+	else if (final_hue < 240)
+		green_prime = secondary
+		blue_prime = final_saturation
+	else if (final_hue < 300)
+		red_prime = final_saturation
+		blue_prime = secondary
+
+	var/red = (red_prime + 1 - final_saturation) * 255
+	var/green = (green_prime + 1 - final_saturation) * 255
+	var/blue = (blue_prime + 1 - final_saturation) * 255
 
 	//assemble all the pieces
 	var/finalcolor = rgb(red, green, blue)

--- a/code/modules/reagents/Chemistry-Colours.dm
+++ b/code/modules/reagents/Chemistry-Colours.dm
@@ -29,9 +29,9 @@
 		bluecolor[i]=hex2num(copytext(hue,6,8))
 
 	//mix all the colors
-	var/red = floor(mixOneColor(weight,redcolor))
-	var/green = floor(mixOneColor(weight,greencolor))
-	var/blue = floor(mixOneColor(weight,bluecolor))
+	var/red = mixOneColor(weight,redcolor)
+	var/green = mixOneColor(weight,greencolor)
+	var/blue = mixOneColor(weight,bluecolor)
 
 	//assemble all the pieces
 	var/finalcolor = rgb(red, green, blue)
@@ -55,6 +55,7 @@
 	var/mixedcolor = 0
 	for(i=1; i<=contents; i++)
 		mixedcolor += weight[i]*color[i]
+	mixedcolor = floor(mixedcolor)
 
 	//until someone writes a formal proof for this algorithm, let's keep this in
 // if(mixedcolor<0x00 || mixedcolor>0xFF)
@@ -67,84 +68,26 @@
 /proc/mix_burn_colors(list/reagent_list)
 	var/contents = length(reagent_list)
 	var/list/weight = new /list(contents)
-	var/list/hue = new /list(contents)
-	var/list/saturation = new /list(contents)
+	var/list/redcolor = new /list(contents)
+	var/list/greencolor = new /list(contents)
+	var/list/bluecolor = new /list(contents)
 
 	for(var/i in 1 to contents)
 		//fill the list of weights
-		var/datum/reagent/reagent = reagent_list[i]
-		weight[i] = max(reagent.volume, 1) * reagent.burncolormod
-
-		var/hex_color = reagent.burncolor
-		if (length(hex_color) != 7)
+		var/datum/reagent/re = reagent_list[i]
+		weight[i] = max(re.volume,1) * re.burncolormod
+		//fill the lists of colors
+		var/hue = re.burncolor
+		if(length(hue) != 7)
 			return 0
+		redcolor[i]=hex2num(copytext(hue,2,4))
+		greencolor[i]=hex2num(copytext(hue,4,6))
+		bluecolor[i]=hex2num(copytext(hue,6,8))
 
-		// Convert the rgb factors into hs
-		// This prevents low-value flames (eg:darkflame and invisible flames)
-		var/redfactor = hex2num(copytext(hex_color,2,4)) / 255.0
-		var/greenfactor = hex2num(copytext(hex_color,4,6)) / 255.0
-		var/bluefactor = hex2num(copytext(hex_color,6,8)) / 255.0
-
-		var/cmax = max(redfactor, greenfactor, bluefactor)
-		var/cmin = min(redfactor, greenfactor, bluefactor)
-		var/delta = cmax - cmin
-
-		if (delta == 0)
-			hue[i] = 0
-		else if (redfactor == cmax)
-			hue[i] = (greenfactor - bluefactor)/delta
-		else if (greenfactor == cmax)
-			hue[i] = 2 + (bluefactor - redfactor)/delta
-		else if (bluefactor == cmax)
-			hue[i] = 4 + (redfactor - greenfactor)/delta
-		else
-			// Should be unreachable, but it doesn't hurt to catch this just in case
-			hue[i] = 0
-		hue[i] *= 60 // Converting to degrees
-
-		if (cmax == 0)
-			saturation[i] = 0
-		else
-			saturation[i] = delta / cmax
-
-	// Saturation can be mixed normally
-	var/final_saturation = mixOneColor(weight,saturation)
-
-	// Mixing hues is a little more complicated, take the circular mean of the hues
-	var/sinsum = 0
-	var/cossum = 0
-	for(var/i in 1 to contents)
-		// Because it's on a circle, we don't need to worry about normalizing weights
-		sinsum += sin(hue[i]) * saturation[i] * weight[i]
-		cossum += cos(hue[i]) * saturation[i] * weight[i]
-	var/final_hue = arctan(cossum, sinsum)
-	if (final_hue < 0)
-		final_hue += 360
-
-	// Converting this hue average back into rgb format
-	var/secondary = final_saturation * (1 - (abs(final_hue % 120 - 60) / 60))
-	var/red_prime = 0
-	var/green_prime = 0
-	var/blue_prime = 0
-	if (final_hue < 60)
-		red_prime = final_saturation
-		green_prime = secondary
-	else if (final_hue < 120)
-		red_prime = secondary
-		green_prime = final_saturation
-	else if (final_hue < 180)
-		green_prime = final_saturation
-		blue_prime = secondary
-	else if (final_hue < 240)
-		green_prime = secondary
-		blue_prime = final_saturation
-	else if (final_hue < 300)
-		red_prime = final_saturation
-		blue_prime = secondary
-
-	var/red = (red_prime + 1 - final_saturation) * 255
-	var/green = (green_prime + 1 - final_saturation) * 255
-	var/blue = (blue_prime + 1 - final_saturation) * 255
+	//mix all the colors
+	var/red = mixOneColor(weight,redcolor)
+	var/green = mixOneColor(weight,greencolor)
+	var/blue = mixOneColor(weight,bluecolor)
 
 	//assemble all the pieces
 	var/finalcolor = rgb(red, green, blue)


### PR DESCRIPTION

# About the pull request

**Triage cards will now automatically be applied, can be disabled on a per-client basis through the character preferences menu.**
###### *Holotags, holocards, triage cards, and triage tags all reference the same thing and will be used interchangeably. They refer to the small colored square that can be placed next to a marine to indicate their health status.*
> [!NOTE]
> Holotags will be overridden based on the "accuracy" of the scan, and the severity of the scanned symptoms. Handheld scans will be overridden by manual tags, and both will be overridden by full-body scans, such as the scanning machine. Scans that detect higher-severity symptoms will always override lower severity scans, no matter the accuracy. 
> 
> For example, a handheld scan that detects internal bleeding will override a previous holotag that was applied by a body-scanner. This way, scans will never erase information from sources that it otherwise would not have access to, while also updating the tags for new injuries.

## What wounds qualify for what holotag?
Based on the real-life standard triage sections:
 - **Orange:** <ins>Delayed</ins> - Requires surgical or special medical intervention, but will not cause harm if untreated.
 - **Red:** <ins>Immediate</ins> - Requires surgical or special medical intervention, and will continue to cause harm if left untreated.
 - **Black:** <ins>Deceased</ins> - Medically dead or expected. In this case, reserved for perma'd marines.
 - **Purple:** <ins>Infected</ins> - A special tag that signifies an XX-121 infection.

<details>
<summary>Specific Holotag Triggers</summary>
<h4>Orange</h4>
<ul>
<li>Blood volume below 501 cl
<li>Dressed and closed amputations
<li>Fractures
<li>Eschars
<li>Third-degree burns
<li>Bruised (but not broken) hearts or lungs
<li>Eye damage
</ul>
<h4>Red</h4>
<ul>
<li>Blood volume below 336 cl
<li>Chemical overdoses
<li>Unclosed stumps
<li>Internal bleeding
<li>Broken heart
<li>Ruptured lungs
<li>Bruised kidneys, liver, or brain
</ul>
<h4>Black</h4>
<ul>
<li>Defib timer expiring
<li>Decapitation
<li>Other means of being permanently dead
</ul>
<h4>Purple</h4>
<ul>
<li>Infected with an XX-121 larva
</ul>
<b>Tags will be applied with priority to those later in the list.</b>
</details>

# Explain why it's good for the game

Holotags are a very soulful part of medical, and are fairly useful when used correctly. However, many corpsmen simply do not have the time to navigate through the menus to mark every one of their patients with the appropriate tag, especially at the front line.

This also offers a standardization for holocards

# Testing Photographs and Procedure
[26-June-11 22-38.webm](https://github.com/user-attachments/assets/88b1773d-4782-48ef-a11a-e2e304b77109)
<h6>Had to crunch it a bit, sorry.</h6>

# Changelog
:cl: Antlers
qol: Health scanners will now automatically apply the appropriate triage holocard.
/:cl:
Hi