### PR TITLE
moving under transparent does not cancel looking up, multiz init

### DIFF
--- a/code/modules/cm_tech/hologram.dm
+++ b/code/modules/cm_tech/hologram.dm
@@ -183,7 +183,7 @@ GLOBAL_LIST_EMPTY_TYPED(hologram_list, /mob/hologram)
 	var/turf/new_turf = get_step(loc, direct)
 	forceMove(new_turf)
 
-	if(!istype(new_turf, /turf/open_space))
+	if(!istransparentturf(new_turf))
 		UnregisterSignal(linked_mob, COMSIG_MOB_RESET_VIEW)
 		view_registered = FALSE
 		linked_mob.reset_view()


### PR DESCRIPTION

# About the pull request

moving under turf that allows you to look up (istransparent) no longer cancels looking up

# Explain why it's good for the game

having to mash the button as you move under catwalks is incorrect


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: moving under transparent turfs no longer cancels looking up
/:cl:
