### PR TITLE
Adds Yautja Reagent Grinder

### DIFF
--- a/code/game/machinery/kitchen/juicer.dm
+++ b/code/game/machinery/kitchen/juicer.dm
@@ -162,7 +162,7 @@
 			break
 
 /obj/structure/machinery/juicer/yautja
-	name = "Blood Juicer"
+	name = "Gibs Juicer"
 	icon = 'icons/obj/structures/machinery/yautja_machines.dmi'
 
 /obj/structure/closet/crate/juice

--- a/code/game/machinery/kitchen/juicer.dm
+++ b/code/game/machinery/kitchen/juicer.dm
@@ -162,7 +162,7 @@
 			break
 
 /obj/structure/machinery/juicer/yautja
-	name = "bone grinder"
+	name = "Blood Juicer"
 	icon = 'icons/obj/structures/machinery/yautja_machines.dmi'
 
 /obj/structure/closet/crate/juice

--- a/code/modules/reagents/chemistry_machinery/reagent_grinder.dm
+++ b/code/modules/reagents/chemistry_machinery/reagent_grinder.dm
@@ -477,3 +477,7 @@
 /obj/structure/machinery/reagentgrinder/industrial/update_icon()
 	icon_state = "industry"+num2text(!isnull(beaker))
 	return
+
+/obj/structure/machinery/reagentgrinder/yautja
+	name = "Bone Grinder"
+	icon = 'icons/obj/structures/machinery/yautja_machines.dmi'

--- a/maps/map_files/Hunter_Ship/Hunter_Ship.dmm
+++ b/maps/map_files/Hunter_Ship/Hunter_Ship.dmm
@@ -11350,13 +11350,13 @@
 	pixel_x = 7;
 	density = 0
 	},
-/obj/structure/machinery/juicer/yautja{
-	pixel_x = -9;
-	pixel_y = 16
-	},
 /obj/structure/window/reinforced/toughened{
 	dir = 4;
 	color = "#912727"
+	},
+/obj/structure/machinery/reagentgrinder/yautja{
+	pixel_x = -9;
+	pixel_y = 16
 	},
 /turf/open/predship/tile/red4/glow,
 /area/yautja_ship/middle_deck/research)


### PR DESCRIPTION

# About the pull request

Adds a Yautja variant of the all in one reagent grinder and replaces the juicer with it in the hunter ship inside the research room. The Yautja juicer was renamed to Gibs Juicer (you can suggest a better name) for the reagent grinder to get its previous name instead as the Bone Grinder. No spriting changes (juicers and reagent grinders always shared sprites, even human versions)

# Explain why it's good for the game

If you want to do anything related with hydroponics research, you need a reagent grinder to be able to obtain the chems from the produce which the Hunter Ship currently lacks. Also you need the reagent grinder to be able to obtain some chemicals like the psilocybin to be able to make certain foods/drinks for cooking.


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl: Unknownity
add: The Hunter Ship has gained a reagent grinder.
/:cl:

