### PR TITLE
Fixes get_access in Airlock electronics

### DIFF
--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -94,7 +94,7 @@
 /datum/world_topic/playerlist/Run(list/input)
 	. = ..()
 	data = list()
-	for(var/client/C as() in GLOB.clients)
+	for(var/client/C in GLOB.clients)
 		data += C.ckey
 	statuscode = 200
 	response = "Player list fetched"

--- a/code/game/objects/items/circuitboards/airlock.dm
+++ b/code/game/objects/items/circuitboards/airlock.dm
@@ -44,7 +44,7 @@
 
 		t1 += "<br>"
 
-		var/list/accesses = get_access(ACCESS_LIST_MARINE_ALL)
+		var/list/accesses = get_access(ACCESS_LIST_MARINE_ALL) + get_access(ACCESS_CIVILIAN_ENGINEERING)
 		for (var/acc in accesses)
 			var/aname = get_access_desc(acc)
 

--- a/code/game/objects/items/circuitboards/airlock.dm
+++ b/code/game/objects/items/circuitboards/airlock.dm
@@ -44,7 +44,7 @@
 
 		t1 += "<br>"
 
-		var/list/accesses = get_access(ACCESS_LIST_MARINE_ALL) + get_access(ACCESS_CIVILIAN_ENGINEERING)
+		var/list/accesses = get_access(ACCESS_LIST_MARINE_ALL)
 		for (var/acc in accesses)
 			var/aname = get_access_desc(acc)
 


### PR DESCRIPTION

# About the pull request
 and makes it anyone that has engineering access should be able to modify airlock electronics with using get_access(ACCESS_CIVILIAN_ENGINEERING)

Oh yeah and deleted some old code that was no longer used in config
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Old code and bugs are not great for peak gameplay
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Added get_access(ACCESS_CIVILIAN_ENGINEERING) in the airlock electronics so anyone who has engineering access can now edit airlock access
del: Removed as() in the world start up
/:cl:
