### PR TITLE
Stops almayer crash breaking unbreakable APCs.

### DIFF
--- a/code/controllers/subsystem/hijack.dm
+++ b/code/controllers/subsystem/hijack.dm
@@ -797,7 +797,7 @@ SUBSYSTEM_DEF(hijack)
 	var/cause_data = create_cause_data("ship explosion")
 	for(var/obj/structure/machinery/power/apc/apc as anything in apcs)
 		var/turf/apc_turf = get_turf(apc)
-		if(apc_turf && prob(chance))
+		if(apc_turf && apc.crash_break_probability && prob(chance))
 			cell_explosion(apc_turf, 30, 5, explosion_cause_data=cause_data, enviro=TRUE)
 			CHECK_TICK
 


### PR DESCRIPTION

# About the pull request

If it can't be broken without direct intervention it should not break. Main purpose for this is the AI Core APC which cannot be repaired.

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Almayer crash no longer breaks hardened APCs.
/:cl:
