### PR TITLE
Fix garbage collecting of effect_system

### DIFF
--- a/code/datums/ammo/ammo.dm
+++ b/code/datums/ammo/ammo.dm
@@ -99,6 +99,24 @@
 /datum/ammo/New()
 	set_bullet_traits()
 
+/**
+ * Does smoke with the awful outdated effect system
+ * Inherits the location and cause from the source projectile,
+ * but exact location and direction can be overriden
+ */
+/datum/ammo/proc/do_smoke(obj/projectile/source, atom/loca, direct = -1, datum/cause_data/cause_data)
+	if(!loca)
+		loca = source?.loc
+	if(!loca)
+		return
+	if(source && direct == -1)
+		direct = reverse_direction(source.dir)
+	if(!cause_data)
+		cause_data = source?.weapon_cause_data
+	var/datum/effect_system/smoke_spread/smoke = new()
+	smoke.set_up(1, loca = get_turf(loca), direct = direct, new_cause_data = cause_data)
+	smoke.start()
+
 /datum/ammo/proc/setup_faction_clash_values()
 	accuracy = (accuracy - 85)/2
 	penetration = min(penetration, 30) //more ap overpenatrates anyway but makes next calculation cleaner

--- a/code/datums/ammo/misc.dm
+++ b/code/datums/ammo/misc.dm
@@ -93,7 +93,7 @@
 	if(!istype(T))
 		return
 	smoke.set_up(1, 0, T, new_cause_data = cause_data)
-	smoke.start()
+	smoke.start(do_NOT_delete = TRUE)
 
 /datum/ammo/flamethrower/sentry_flamer/glob/Destroy()
 	qdel(smoke)
@@ -276,29 +276,33 @@
 	. = ..()
 	smoke = new()
 
+/datum/ammo/arrow/expl/Destroy(force)
+	. = ..()
+	QDEL_NULL(smoke)
+
 /datum/ammo/arrow/expl/on_hit_mob(mob/mob,obj/projectile/projectile)
 	cell_explosion(get_turf(mob), 150, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
 	smoke.set_up(1, get_turf(mob))
-	smoke.start()
+	smoke.start(do_NOT_delete = TRUE)
 
 /datum/ammo/arrow/expl/on_hit_obj(obj/object,obj/projectile/projectile)
 	cell_explosion(get_turf(projectile), 150, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
 	smoke.set_up(1, get_turf(projectile))
-	smoke.start()
+	smoke.start(do_NOT_delete = TRUE)
 /datum/ammo/arrow/expl/on_hit_turf(turf/turf, obj/projectile/projectile)
 	if(turf.density && isturf(projectile.loc))
 		cell_explosion(get_turf(projectile), 150, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
 		smoke.set_up(1, get_turf(projectile))
-		smoke.start()
+		smoke.start(do_NOT_delete = TRUE)
 	else
 		cell_explosion(turf, 150, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
 		smoke.set_up(1, turf)
-		smoke.start()
+		smoke.start(do_NOT_delete = TRUE)
 
 /datum/ammo/arrow/expl/do_at_max_range(obj/projectile/projectile, mob/firer)
 	cell_explosion(get_turf(projectile), 150, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
 	smoke.set_up(1, get_turf(projectile))
-	smoke.start()
+	smoke.start(do_NOT_delete = TRUE)
 
 /datum/ammo/arrow/emp
 	name = "activated EMP arrow"

--- a/code/datums/ammo/misc.dm
+++ b/code/datums/ammo/misc.dm
@@ -83,21 +83,11 @@
 /datum/ammo/flamethrower/sentry_flamer/glob
 	max_range = 14
 	accurate_range = 10
-	var/datum/effect_system/smoke_spread/phosphorus/smoke
-
-/datum/ammo/flamethrower/sentry_flamer/glob/New()
-	. = ..()
-	smoke = new()
 
 /datum/ammo/flamethrower/sentry_flamer/glob/drop_flame(turf/T, datum/cause_data/cause_data)
 	if(!istype(T))
 		return
-	smoke.set_up(1, 0, T, new_cause_data = cause_data)
-	smoke.start(do_NOT_delete = TRUE)
-
-/datum/ammo/flamethrower/sentry_flamer/glob/Destroy()
-	qdel(smoke)
-	return ..()
+	do_smoke(loca = T, cause_data = cause_data)
 
 /datum/ammo/flamethrower/sentry_flamer/mini
 	name = "normal fire"
@@ -266,43 +256,29 @@
 	shrapnel_chance = 0
 	loaded_icon = "expl"
 	arrow_icon = "arrow_expl_active"
-	var/datum/effect_system/smoke_spread/smoke
 
 /datum/ammo/arrow/expl/dynamic
 	name = "explosive dynamic arrow"
 	handful_type = /obj/item/arrow/dynamic_warhead
 
-/datum/ammo/arrow/expl/New()
-	. = ..()
-	smoke = new()
-
-/datum/ammo/arrow/expl/Destroy(force)
-	. = ..()
-	QDEL_NULL(smoke)
-
 /datum/ammo/arrow/expl/on_hit_mob(mob/mob,obj/projectile/projectile)
 	cell_explosion(get_turf(mob), 150, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
-	smoke.set_up(1, get_turf(mob))
-	smoke.start(do_NOT_delete = TRUE)
+	do_smoke(loca = mob)
 
 /datum/ammo/arrow/expl/on_hit_obj(obj/object,obj/projectile/projectile)
 	cell_explosion(get_turf(projectile), 150, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
-	smoke.set_up(1, get_turf(projectile))
-	smoke.start(do_NOT_delete = TRUE)
+	do_smoke(projectile)
 /datum/ammo/arrow/expl/on_hit_turf(turf/turf, obj/projectile/projectile)
 	if(turf.density && isturf(projectile.loc))
 		cell_explosion(get_turf(projectile), 150, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
-		smoke.set_up(1, get_turf(projectile))
-		smoke.start(do_NOT_delete = TRUE)
+		do_smoke(projectile)
 	else
 		cell_explosion(turf, 150, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
-		smoke.set_up(1, turf)
-		smoke.start(do_NOT_delete = TRUE)
+		do_smoke(loca = turf)
 
 /datum/ammo/arrow/expl/do_at_max_range(obj/projectile/projectile, mob/firer)
 	cell_explosion(get_turf(projectile), 150, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
-	smoke.set_up(1, get_turf(projectile))
-	smoke.start(do_NOT_delete = TRUE)
+	do_smoke(projectile)
 
 /datum/ammo/arrow/emp
 	name = "activated EMP arrow"

--- a/code/datums/ammo/rocket.dm
+++ b/code/datums/ammo/rocket.dm
@@ -18,22 +18,6 @@
 	damage = 15
 	shell_speed = AMMO_SPEED_TIER_2
 
-/**
- * Does smoke with the awful outdated effect system
- * Inherits the location and cause from the source projectile,
- * but exact location and direction can be overriden
- */
-/datum/ammo/rocket/proc/do_smoke(obj/projectile/source, atom/loca, direct = -1)
-	if(!loca)
-		loca = source?.loc
-	if(!loca)
-		return
-	if(source && direct == -1)
-		direct = reverse_direction(source.dir)
-	var/datum/effect_system/smoke_spread/smoke = new()
-	smoke.set_up(1, loca = get_turf(loca), direct = direct, new_cause_data = source?.weapon_cause_data)
-	smoke.start()
-
 /datum/ammo/rocket/on_hit_mob(mob/mob, obj/projectile/projectile)
 	cell_explosion(get_turf(mob), 150, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
 	if(ishuman_strict(mob)) // No yautya or synths. Makes humans gib on direct hit.

--- a/code/datums/ammo/rocket.dm
+++ b/code/datums/ammo/rocket.dm
@@ -24,8 +24,7 @@
 	smoke = new()
 
 /datum/ammo/rocket/Destroy()
-	qdel(smoke)
-	smoke = null
+	QDEL_NULL(smoke)
 	. = ..()
 
 /datum/ammo/rocket/on_hit_mob(mob/mob, obj/projectile/projectile)
@@ -33,22 +32,22 @@
 	smoke.set_up(1, get_turf(mob))
 	if(ishuman_strict(mob)) // No yautya or synths. Makes humans gib on direct hit.
 		mob.ex_act(350, null, projectile.weapon_cause_data, 100)
-	smoke.start()
+	smoke.start(do_NOT_delete = TRUE)
 
 /datum/ammo/rocket/on_hit_obj(obj/object, obj/projectile/projectile)
 	cell_explosion(get_turf(object), 150, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
 	smoke.set_up(1, get_turf(object))
-	smoke.start()
+	smoke.start(do_NOT_delete = TRUE)
 
 /datum/ammo/rocket/on_hit_turf(turf/turf, obj/projectile/projectile)
 	cell_explosion(turf, 150, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
 	smoke.set_up(1, turf)
-	smoke.start()
+	smoke.start(do_NOT_delete = TRUE)
 
 /datum/ammo/rocket/do_at_max_range(obj/projectile/projectile)
 	cell_explosion(get_turf(projectile), 150, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
 	smoke.set_up(1, get_turf(projectile))
-	smoke.start()
+	smoke.start(do_NOT_delete = TRUE)
 
 /datum/ammo/rocket/ap
 	name = "anti-armor rocket"
@@ -72,14 +71,14 @@
 		mob.ex_act(300, null, projectile.weapon_cause_data, 100)
 	cell_explosion(turf, 100, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
 	smoke.set_up(1, turf)
-	smoke.start()
+	smoke.start(do_NOT_delete = TRUE)
 
 /datum/ammo/rocket/ap/on_hit_obj(obj/object, obj/projectile/projectile)
 	var/turf/turf = get_turf(object)
 	object.ex_act(150, projectile.dir, projectile.weapon_cause_data, 100)
 	cell_explosion(turf, 100, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
 	smoke.set_up(1, turf)
-	smoke.start()
+	smoke.start(do_NOT_delete = TRUE)
 
 /datum/ammo/rocket/ap/on_hit_turf(turf/turf, obj/projectile/projectile)
 	var/hit_something = 0
@@ -100,7 +99,7 @@
 
 	cell_explosion(turf, 100, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
 	smoke.set_up(1, turf)
-	smoke.start()
+	smoke.start(do_NOT_delete = TRUE)
 
 /datum/ammo/rocket/ap/do_at_max_range(obj/projectile/projectile)
 	var/turf/turf = get_turf(projectile)
@@ -121,7 +120,7 @@
 		turf.ex_act(150, projectile.dir, projectile.weapon_cause_data)
 	cell_explosion(turf, 100, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
 	smoke.set_up(1, turf)
-	smoke.start()
+	smoke.start(do_NOT_delete = TRUE)
 
 /datum/ammo/rocket/ap/anti_tank
 	name = "anti-tank rocket"
@@ -140,7 +139,7 @@
 		var/turf/turf = get_turf(mob.loc)
 		mob.ex_act(150, projectile.dir, projectile.weapon_cause_data, 100)
 		smoke.set_up(1, turf)
-		smoke.start()
+		smoke.start(do_NOT_delete = TRUE)
 		return
 	return ..()
 
@@ -195,14 +194,13 @@
 	if(!istype(turf))
 		return
 	smoke.set_up(1, turf)
-	smoke.start()
+	smoke.start(do_NOT_delete = TRUE)
 	var/datum/reagent/napalm/blue/reagent = new()
 	new /obj/flamer_fire(turf, cause_data, reagent, 3)
 
 	var/datum/effect_system/smoke_spread/phosphorus/landingSmoke = new /datum/effect_system/smoke_spread/phosphorus
 	landingSmoke.set_up(3, 0, turf, null, 6, cause_data)
 	landingSmoke.start()
-	landingSmoke = null
 
 /datum/ammo/rocket/wp/on_hit_mob(mob/mob, obj/projectile/projectile)
 	drop_flame(get_turf(mob), projectile.weapon_cause_data)
@@ -237,7 +235,7 @@
 	if(!istype(turf))
 		return
 	smoke.set_up(1, turf)
-	smoke.start()
+	smoke.start(do_NOT_delete = TRUE)
 	var/datum/reagent/napalm/upp/reagent = new()
 	new /obj/flamer_fire(turf, cause_data, reagent, 3)
 
@@ -294,7 +292,7 @@
 		rocket.warhead.prime()
 		qdel(rocket)
 	smoke.set_up(1, get_turf(atom))
-	smoke.start()
+	smoke.start(do_NOT_delete = TRUE)
 
 /datum/ammo/rocket/custom/on_hit_mob(mob/mob, obj/projectile/projectile)
 	prime(mob, projectile)

--- a/code/datums/ammo/rocket.dm
+++ b/code/datums/ammo/rocket.dm
@@ -11,7 +11,6 @@
 	sound_bounce = "rocket_bounce"
 	damage_falloff = 0
 	flags_ammo_behavior = AMMO_EXPLOSIVE|AMMO_ROCKET|AMMO_STRIKES_SURFACE
-	var/datum/effect_system/smoke_spread/smoke
 
 	accuracy = HIT_ACCURACY_TIER_2
 	accurate_range = 7
@@ -19,35 +18,39 @@
 	damage = 15
 	shell_speed = AMMO_SPEED_TIER_2
 
-/datum/ammo/rocket/New()
-	..()
-	smoke = new()
-
-/datum/ammo/rocket/Destroy()
-	QDEL_NULL(smoke)
-	. = ..()
+/**
+ * Does smoke with the awful outdated effect system
+ * Inherits the location and cause from the source projectile,
+ * but exact location and direction can be overriden
+ */
+/datum/ammo/rocket/proc/do_smoke(obj/projectile/source, atom/loca, direct = -1)
+	if(!loca)
+		loca = source?.loc
+	if(!loca)
+		return
+	if(source && direct == -1)
+		direct = reverse_direction(source.dir)
+	var/datum/effect_system/smoke_spread/smoke = new()
+	smoke.set_up(1, loca = get_turf(loca), direct = direct, new_cause_data = source?.weapon_cause_data)
+	smoke.start()
 
 /datum/ammo/rocket/on_hit_mob(mob/mob, obj/projectile/projectile)
 	cell_explosion(get_turf(mob), 150, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
-	smoke.set_up(1, get_turf(mob))
 	if(ishuman_strict(mob)) // No yautya or synths. Makes humans gib on direct hit.
 		mob.ex_act(350, null, projectile.weapon_cause_data, 100)
-	smoke.start(do_NOT_delete = TRUE)
+	do_smoke(projectile, mob)
 
 /datum/ammo/rocket/on_hit_obj(obj/object, obj/projectile/projectile)
 	cell_explosion(get_turf(object), 150, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
-	smoke.set_up(1, get_turf(object))
-	smoke.start(do_NOT_delete = TRUE)
+	do_smoke(projectile, object)
 
 /datum/ammo/rocket/on_hit_turf(turf/turf, obj/projectile/projectile)
 	cell_explosion(turf, 150, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
-	smoke.set_up(1, turf)
-	smoke.start(do_NOT_delete = TRUE)
+	do_smoke(projectile, turf)
 
 /datum/ammo/rocket/do_at_max_range(obj/projectile/projectile)
 	cell_explosion(get_turf(projectile), 150, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
-	smoke.set_up(1, get_turf(projectile))
-	smoke.start(do_NOT_delete = TRUE)
+	do_smoke(projectile)
 
 /datum/ammo/rocket/ap
 	name = "anti-armor rocket"
@@ -70,15 +73,13 @@
 	if(ishuman_strict(mob)) // No yautya or synths. Makes humans gib on direct hit.
 		mob.ex_act(300, null, projectile.weapon_cause_data, 100)
 	cell_explosion(turf, 100, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
-	smoke.set_up(1, turf)
-	smoke.start(do_NOT_delete = TRUE)
+	do_smoke(projectile, mob)
 
 /datum/ammo/rocket/ap/on_hit_obj(obj/object, obj/projectile/projectile)
 	var/turf/turf = get_turf(object)
 	object.ex_act(150, projectile.dir, projectile.weapon_cause_data, 100)
 	cell_explosion(turf, 100, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
-	smoke.set_up(1, turf)
-	smoke.start(do_NOT_delete = TRUE)
+	do_smoke(projectile, object)
 
 /datum/ammo/rocket/ap/on_hit_turf(turf/turf, obj/projectile/projectile)
 	var/hit_something = 0
@@ -98,8 +99,7 @@
 		turf.ex_act(150, projectile.dir, projectile.weapon_cause_data, 200)
 
 	cell_explosion(turf, 100, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
-	smoke.set_up(1, turf)
-	smoke.start(do_NOT_delete = TRUE)
+	do_smoke(projectile, turf)
 
 /datum/ammo/rocket/ap/do_at_max_range(obj/projectile/projectile)
 	var/turf/turf = get_turf(projectile)
@@ -119,8 +119,7 @@
 	if(!hit_something)
 		turf.ex_act(150, projectile.dir, projectile.weapon_cause_data)
 	cell_explosion(turf, 100, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
-	smoke.set_up(1, turf)
-	smoke.start(do_NOT_delete = TRUE)
+	do_smoke(projectile, turf)
 
 /datum/ammo/rocket/ap/anti_tank
 	name = "anti-tank rocket"
@@ -138,8 +137,7 @@
 		mob.interior_crash_effect()
 		var/turf/turf = get_turf(mob.loc)
 		mob.ex_act(150, projectile.dir, projectile.weapon_cause_data, 100)
-		smoke.set_up(1, turf)
-		smoke.start(do_NOT_delete = TRUE)
+		do_smoke(projectile, turf)
 		return
 	return ..()
 
@@ -193,8 +191,7 @@
 	playsound(turf, 'sound/weapons/gun_flamethrower3.ogg', 75, 1, 7)
 	if(!istype(turf))
 		return
-	smoke.set_up(1, turf)
-	smoke.start(do_NOT_delete = TRUE)
+	do_smoke(loca = turf)
 	var/datum/reagent/napalm/blue/reagent = new()
 	new /obj/flamer_fire(turf, cause_data, reagent, 3)
 
@@ -234,8 +231,7 @@
 	playsound(turf, 'sound/weapons/gun_flamethrower3.ogg', 75, 1, 7)
 	if(!istype(turf))
 		return
-	smoke.set_up(1, turf)
-	smoke.start(do_NOT_delete = TRUE)
+	do_smoke(loca = turf)
 	var/datum/reagent/napalm/upp/reagent = new()
 	new /obj/flamer_fire(turf, cause_data, reagent, 3)
 
@@ -282,6 +278,7 @@
 	max_range = 7
 
 /datum/ammo/rocket/custom/proc/prime(atom/atom, obj/projectile/projectile)
+	do_smoke(projectile)
 	var/obj/item/weapon/gun/launcher/rocket/launcher = projectile.shot_from
 	var/obj/item/ammo_magazine/rocket/custom/rocket = launcher.current_mag
 	if(rocket.locked && rocket.warhead && rocket.warhead.detonator)
@@ -291,8 +288,6 @@
 		rocket.warhead.hit_angle = Get_Angle(launcher, atom)
 		rocket.warhead.prime()
 		qdel(rocket)
-	smoke.set_up(1, get_turf(atom))
-	smoke.start(do_NOT_delete = TRUE)
 
 /datum/ammo/rocket/custom/on_hit_mob(mob/mob, obj/projectile/projectile)
 	prime(mob, projectile)

--- a/code/datums/ammo/xeno.dm
+++ b/code/datums/ammo/xeno.dm
@@ -303,8 +303,7 @@
 	set_xeno_smoke()
 
 /datum/ammo/xeno/boiler_gas/Destroy()
-	qdel(smoke_system)
-	smoke_system = null
+	QDEL_NULL(smoke_system)
 	. = ..()
 
 /datum/ammo/xeno/boiler_gas/on_hit_mob(mob/moob, obj/projectile/proj)
@@ -341,7 +340,7 @@
 		cause_data = proj.weapon_cause_data
 	smoke_system.set_up(smokerange, 0, turf, new_cause_data = cause_data)
 	smoke_system.lifetime = 12 * lifetime_mult
-	smoke_system.start()
+	smoke_system.start(do_NOT_delete = TRUE)
 	turf.visible_message(SPAN_DANGER("A glob of acid lands with a splat and explodes into noxious fumes!"))
 
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -685,7 +685,7 @@ Parameters are passed from New.
 		var/datum/effect_system/spark_spread/spark_system = new
 		spark_system.set_up(5, 0, src)
 		spark_system.attach(src)
-		spark_system.start(src)
+		spark_system.start()
 	return CHECKS_PASSED
 
 ///Turn on the light, should be called by a timer

--- a/code/game/objects/effects/effect_system/chemsmoke.dm
+++ b/code/game/objects/effects/effect_system/chemsmoke.dm
@@ -24,8 +24,8 @@
 	smoke_type = /obj/effect/particle_effect/smoke/chem
 	var/obj/chemholder
 	var/range
-	var/list/targetTurfs
-	var/list/wallList
+	var/list/turf/targetTurfs
+	var/list/turf/wallList
 	var/density
 	var/static/last_reaction_signature
 
@@ -33,6 +33,12 @@
 	..()
 	chemholder = new/obj()
 	chemholder.create_reagents(500)
+
+/datum/effect_system/smoke_spread/chem/Destroy(force)
+	. = ..()
+	QDEL_NULL(chemholder)
+	targetTurfs = null
+	wallList = null
 
 //------------------------------------------
 //Sets up the chem smoke effect
@@ -98,17 +104,23 @@
 
 
 //------------------------------------------
-//Runs the chem smoke effect
-//
-// Spawns damage over time loop for each reagent held in the cloud.
-// Applies reagents to walls that affect walls (only thermite and plant-b-gone at the moment).
-// Also calculates target locations to spawn the visual smoke effect on, so the whole area
-// is covered fairly evenly.
-//------------------------------------------
-/datum/effect_system/smoke_spread/chem/start()
+/** Runs the chem smoke effect
+ *
+ * Spawns damage over time loop for each reagent held in the cloud.
+ * Applies reagents to walls that affect walls (only thermite and plant-b-gone at the moment).
+ * Also calculates target locations to spawn the visual smoke effect on, so the whole area
+ * is covered fairly evenly.
+ */
+/datum/effect_system/smoke_spread/chem/start(do_NOT_delete = FALSE)
 
 	if(!location) //kill grenade if it somehow ends up in nullspace
+		if(!do_NOT_delete)
+			qdel(src)
 		return
+
+	// Hardcoded 5 "runs" below times "3 SECONDS" sleep plus extra wiggle room
+	if(!do_NOT_delete)
+		QDEL_IN(src, (5 + 1) * (3 SECONDS))
 
 	//reagent application - only run if there are extra reagents in the smoke
 	if(length(chemholder.reagents.reagent_list))

--- a/code/game/objects/effects/effect_system/effect_system.dm
+++ b/code/game/objects/effects/effect_system/effect_system.dm
@@ -29,7 +29,25 @@ would spawn and follow the beaker, even if it is carried or thrown.
 /datum/effect_system/proc/attach(atom/atom)
 	holder = atom
 
-/datum/effect_system/proc/start()
+/**
+ * Starts the effect system, which will invariably lead to objects being
+ * created in the most irresponsible way possible.
+ * Since this is decade old legacy code and nobody cares about using this properly,
+ * it provides the following arg:
+ *
+ * [do_NOT_delete] : if TRUE, then effect_system will NOT seld delete after a single
+ *                   start, and YOU have to do it by YOURSELF (defaults to FALSE)
+ *
+ * When you override this proc, you sign a blood contract to uphold this behavior.
+ * Failure to do so leads to a penalty of rewriting the entire effect_system.
+ * I dare you.
+ *
+ * Note: This is purposedly used as named argument because it will cause linter to
+ * complain about someone skipping it in implementations. And hopefully to read this.
+ */
+/datum/effect_system/proc/start(do_NOT_delete = FALSE)
+	if(!do_NOT_delete)
+		qdel(src)
 
 
 /////////////////////////////////////////////
@@ -62,7 +80,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	cardinals = c
 	location = loc
 
-/datum/effect_system/steam_spread/start()
+/datum/effect_system/steam_spread/start(do_NOT_delete = FALSE)
 	var/i = 0
 	for(i=0, i<number, i++)
 		spawn(0)
@@ -78,6 +96,8 @@ would spawn and follow the beaker, even if it is carried or thrown.
 				sleep(5)
 				step(steam,direction)
 			QDEL_IN(steam, 20)
+	if(!do_NOT_delete)
+		QDEL_IN(src, 2 SECONDS)
 
 
 /////////////////////////////////////////////
@@ -117,7 +137,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	else
 		location = get_turf(loca)
 
-/datum/effect_system/spark_spread/start()
+/datum/effect_system/spark_spread/start(do_NOT_delete = FALSE)
 	var/i = 0
 	for(i=0, i<number, i++)
 		if(total_sparks > 20)
@@ -139,7 +159,8 @@ would spawn and follow the beaker, even if it is carried or thrown.
 				if(sparks)
 					qdel(sparks)
 				total_sparks--
-
+	if(!do_NOT_delete)
+		QDEL_IN(src, 2 SECONDS)
 
 
 /////////////////////////////////////////////
@@ -159,11 +180,19 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	var/processing = TRUE
 	var/on = TRUE
 
+/datum/effect_system/ion_trail_follow/Destroy()
+	. = ..()
+	oldposition = null
+
 /datum/effect_system/ion_trail_follow/set_up(atom/atom)
 	attach(atom)
 	oldposition = get_turf(atom)
 
-/datum/effect_system/ion_trail_follow/start()
+/datum/effect_system/ion_trail_follow/start(do_NOT_delete = FALSE)
+	if(!do_NOT_delete)
+		qdel(src) // The recursive spawn loop below is so screwed we only support explicit deletion as in the single instance of code using it
+		return
+
 	if(!on)
 		on = TRUE
 		processing = TRUE
@@ -185,63 +214,13 @@ would spawn and follow the beaker, even if it is carried or thrown.
 				spawn(2)
 					if(on)
 						processing = TRUE
-						start()
+						start(do_NOT_delete)
 			else
 				spawn(2)
 					if(on)
 						processing = TRUE
-						start()
+						start(do_NOT_delete)
 
 /datum/effect_system/ion_trail_follow/proc/stop()
 	processing = FALSE
 	on = FALSE
-
-
-
-
-/////////////////////////////////////////////
-//////// Attach a steam trail to an object (eg. a reacting beaker) that will follow it
-// even if it's carried of thrown.
-/////////////////////////////////////////////
-
-/datum/effect_system/steam_trail_follow
-	var/turf/oldposition
-	var/processing = TRUE
-	var/on = TRUE
-
-/datum/effect_system/steam_trail_follow/set_up(atom/atom)
-	attach(atom)
-	oldposition = get_turf(atom)
-
-/datum/effect_system/steam_trail_follow/start()
-	if(!on)
-		on = TRUE
-		processing = TRUE
-	if(processing)
-		processing = FALSE
-		spawn(0)
-			if(number < 3)
-				var/obj/effect/particle_effect/steam/trails = new /obj/effect/particle_effect/steam(oldposition)
-				number++
-				oldposition = get_turf(holder)
-				if(isnull(oldposition))
-					qdel(src)
-					return
-				trails.setDir(holder.dir)
-				spawn(10)
-					qdel(trails)
-					number--
-				spawn(2)
-					if(on)
-						processing = TRUE
-						start()
-			else
-				spawn(2)
-					if(on)
-						processing = TRUE
-						start()
-
-/datum/effect_system/steam_trail_follow/proc/stop()
-	processing = FALSE
-	on = FALSE
-

--- a/code/game/objects/effects/effect_system/explosions.dm
+++ b/code/game/objects/effects/effect_system/explosions.dm
@@ -19,7 +19,7 @@
 
 	return
 
-/datum/effect_system/reagents_explosion/start()
+/datum/effect_system/reagents_explosion/start(do_NOT_delete = FALSE)
 	if (amount <= 2)
 		var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
 		s.set_up(2, 1, location)
@@ -31,7 +31,6 @@
 			if (prob (50 * amount))
 				to_chat(M, SPAN_WARNING("The explosion knocks you down."))
 				M.apply_effect(rand(1,5), WEAKEN)
-		return
 	else
 		var/light = -1
 		var/flash = -1
@@ -44,7 +43,10 @@
 
 		explosion(location, -1, -1, light, flash)
 		if(light > 0)
-			return TRUE
+			. = TRUE
+
+	if(!do_NOT_delete)
+		qdel(src)
 
 /datum/effect_system/reagents_explosion/proc/holder_damage(atom/holder)
 	if(holder)
@@ -91,7 +93,7 @@
 	else
 		location = get_turf(loca)
 
-/datum/effect_system/expl_particles/start()
+/datum/effect_system/expl_particles/start(do_NOT_delete = FALSE)
 	var/i = 0
 	for(i=0, i<src.number, i++)
 		spawn(0)
@@ -100,7 +102,8 @@
 			for(i=0, i<pick(1;25,2;50,3,4;200), i++)
 				sleep(1)
 				step(expl,direct)
-
+			if(!do_NOT_delete)
+				qdel(src)
 
 
 //EXPLOSION EFFECT
@@ -115,8 +118,10 @@
 	pixel_x = -32
 	pixel_y = -32
 
-/obj/effect/particle_effect/explosion/New()
-	..()
+/obj/effect/particle_effect/explosion/Initialize(mapload, ...)
+	. = ..()
+	if(mapload)
+		return INITIALIZE_HINT_QDEL
 	QDEL_IN(src, 10)
 
 
@@ -132,7 +137,7 @@
 	else
 		location = get_turf(loca)
 
-/datum/effect_system/explosion/start()
+/datum/effect_system/explosion/start(do_NOT_delete = FALSE)
 	new/obj/effect/particle_effect/explosion( location )
 	var/datum/effect_system/expl_particles/P = new/datum/effect_system/expl_particles()
 	P.set_up(10, 0, location)
@@ -141,3 +146,5 @@
 		var/datum/effect_system/smoke_spread/S = new/datum/effect_system/smoke_spread()
 		S.set_up(3,0,location,null, 2)
 		S.start()
+		if(!do_NOT_delete)
+			qdel(src)

--- a/code/game/objects/effects/effect_system/foam.dm
+++ b/code/game/objects/effects/effect_system/foam.dm
@@ -131,7 +131,7 @@
 		for(var/datum/reagent/R in carry.reagent_list)
 			carried_reagents += R.id
 
-/datum/effect_system/foam_spread/start()
+/datum/effect_system/foam_spread/start(do_NOT_delete = FALSE)
 	set waitfor = 0
 	var/obj/effect/particle_effect/foam/F = locate() in location
 	if(F)
@@ -149,6 +149,9 @@
 				F.reagents.add_reagent(id, 1, null, 1) //makes a safety call because all reagents should have already reacted anyway
 		else
 			F.reagents.add_reagent("water", 1, safety = 1)
+
+	if(!do_NOT_delete)
+		qdel(src)
 
 
 

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -802,12 +802,13 @@
 	amount = radius
 	cause_data = istype(new_cause_data) ? new_cause_data : create_cause_data(new_cause_data)
 
-/datum/effect_system/smoke_spread/start()
+/datum/effect_system/smoke_spread/start(do_NOT_delete = FALSE)
 	if(holder)
 		location = get_turf(holder)
 	var/obj/effect/particle_effect/smoke/smoke = new smoke_type(location, amount+1, cause_data, lifetime)
 	if(smoke.amount > 0)
 		smoke.spread_smoke(direction)
+	return ..()
 
 /datum/effect_system/smoke_spread/bad
 	smoke_type = /obj/effect/particle_effect/smoke/bad
@@ -820,13 +821,21 @@
 
 /datum/effect_system/smoke_spread/phosphorus
 	smoke_type = /obj/effect/particle_effect/smoke/phosphorus
+	var/intensity
+	var/max_intensity
 
-/datum/effect_system/smoke_spread/phosphorus/start(intensity, max_intensity)
+/datum/effect_system/smoke_spread/phosphorus/proc/set_intensity(intensity, max_intensity)
+	src.intensity = intensity
+	src.max_intensity = max_intensity
+
+/datum/effect_system/smoke_spread/phosphorus/start(do_NOT_delete = FALSE)
 	if(holder)
 		location = get_turf(holder)
 	var/obj/effect/particle_effect/smoke/phosphorus/smoke = new smoke_type(location, amount+1, cause_data, lifetime, intensity, max_intensity)
 	if(smoke.amount > 0)
 		smoke.spread_smoke(direction)
+	if(!do_NOT_delete)
+		qdel(src)
 
 /datum/effect_system/smoke_spread/phosphorus/weak
 	smoke_type = /obj/effect/particle_effect/smoke/phosphorus/weak
@@ -895,7 +904,7 @@
 /datum/effect_system/smoke_spread/xeno_extinguish_fire
 	smoke_type = /obj/effect/particle_effect/smoke/xeno_weak_fire
 
-/datum/effect_system/smoke_spread/xeno_extinguish_fire/start()
+/datum/effect_system/smoke_spread/xeno_extinguish_fire/start(do_NOT_delete = FALSE)
 	if(holder)
 		location = get_turf(holder)
 	var/obj/effect/particle_effect/smoke/smoke = new smoke_type(location, amount+1, cause_data, lifetime)
@@ -909,3 +918,5 @@
 
 	if(smoke.amount > 0)
 		smoke.spread_smoke(direction)
+	if(!do_NOT_delete)
+		qdel(src)

--- a/code/game/objects/items/devices/cloaking.dm
+++ b/code/game/objects/items/devices/cloaking.dm
@@ -50,17 +50,17 @@
 	if(chameleon_on)
 		user.alpha = 25
 		to_chat(user, SPAN_NOTICE("You activate [src]."))
-		spark_system.start()
+		spark_system.start(do_NOT_delete = TRUE)
 		src.icon_state = "shield1"
 	else
 		user.alpha = initial(user.alpha)
 		to_chat(user, SPAN_NOTICE("You deactivate [src]."))
 		src.icon_state = "shield0"
-		spark_system.start()
+		spark_system.start(do_NOT_delete = TRUE)
 
 /obj/item/device/chameleon/proc/disrupt(mob/user)
 	if(chameleon_on)
-		spark_system.start()
+		spark_system.start(do_NOT_delete = TRUE)
 		user.alpha = initial(user.alpha)
 		chameleon_cooldown = world.time + 50
 		chameleon_on = FALSE

--- a/code/game/objects/items/devices/defibrillator.dm
+++ b/code/game/objects/items/devices/defibrillator.dm
@@ -23,10 +23,9 @@
 	var/max_heart_damage_dealt = 5
 	var/ready = 0
 	var/damage_heal_threshold = 12 //This is the maximum non-oxy damage the defibrillator will heal to get a patient above -100, in all categories
-	var/datum/effect_system/spark_spread/spark_system = new /datum/effect_system/spark_spread
 	var/charge_cost = 66 //How much energy is used.
 	var/obj/item/cell/dcell = null
-	var/datum/effect_system/spark_spread/sparks = new
+	var/datum/effect_system/spark_spread/sparks
 	var/defib_cooldown = 0 //Cooldown for toggling the defib
 	var/shock_cooldown = 0 //cooldown for shocking someone - separate to toggling
 	var/base_icon_state = "defib" //used for overlays of charge
@@ -66,6 +65,7 @@
 	. = ..()
 
 	if(should_spark)
+		sparks = new
 		sparks.set_up(5, 0, src)
 		sparks.attach(src)
 	dcell = new/obj/item/cell(src)
@@ -73,8 +73,7 @@
 
 /obj/item/device/defibrillator/Destroy()
 	QDEL_NULL(dcell)
-	if(should_spark)
-		QDEL_NULL(sparks)
+	QDEL_NULL(sparks)
 	return ..()
 
 /obj/item/device/defibrillator/update_icon()
@@ -238,7 +237,7 @@
 		return FALSE
 
 	//Do this now, order doesn't matter
-	sparks.start()
+	sparks.start(do_NOT_delete = TRUE)
 	dcell.use(charge_cost)
 	update_icon()
 	playsound(get_turf(src), sound_release, 25, 1)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -56,7 +56,7 @@
 		projectilesound = 'sound/weapons/pulse2.ogg'
 	ion_trail = new
 	ion_trail.set_up(src)
-	ion_trail.start()
+	ion_trail.start(do_NOT_delete = TRUE)
 
 /mob/living/simple_animal/hostile/retaliate/malf_drone/Process_Spacemove(check_drift = 0)
 	return 1

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -816,7 +816,8 @@
 	if(smokerad)
 		var/datum/effect_system/smoke_spread/phosphorus/smoke = new /datum/effect_system/smoke_spread/phosphorus
 		smoke.set_up(max(smokerad, 1), 0, sourceturf, null, 6)
-		smoke.start(intensity, max_fire_int)
+		smoke.set_intensity(intensity, max_fire_int)
+		smoke.start()
 		smoke = null
 
 	if(flush_beaker)


### PR DESCRIPTION

# About the pull request

This fixes `/datum/effect_system` not clearing references and fixes various objects' usage of it, by making it so it is now explicitly deleted via SSgarbage. 

Previously, it would rely on soft garbage collection. While this actually DOES work for the `effect_system` itself, other things such as the `chemholder` for chem smoke runs on a circular reference with reagents, and is never deleted.

It comes with the caveat that the time-to-deletion for chemsmoke is guesstimated, for lack of a better way to synchronize the proc doing it. This shouldn't matter unless the server is under ridiculously high TiDi, in which case some smoke puffs might be omitted.

Also fixes explosive arrows and RPG rockets runtiming when attempting to create smoke on impact.

As a bonus, smoke direction is now dynamically set opposite of impact for rockets and arrows.

# Explain why it's good for the game

Long term performance maintenance

# Testing Photographs and Procedure

Due to having setup issues i could only do summary testing.


# Changelog
:cl:
fix: Fixed a number of bad cleanup involved in visual effects, notably smoke.
fix: Rockets and Explosive Arrows will now properly cause on-hit smoke as intended.
/:cl:
