### PR TITLE
Fix: NVGs being fullwhite

### DIFF
--- a/code/__HELPERS/matrices.dm
+++ b/code/__HELPERS/matrices.dm
@@ -108,9 +108,9 @@ list(0.393,0.349,0.272,0, 0.769,0.686,0.534,0, 0.189,0.168,0.131,0, 0,0,0,1, 0,0
 	if((length != 7 && length != 9) || length != length_char(string))
 		return COLOR_MATRIX_IDENTITY
 	var/list/color_list = rgb2num(string)
-	var/r = color_list[1]
-	var/g = color_list[2]
-	var/b = color_list[3]
+	var/r = color_list[1] /255
+	var/g = color_list[2] /255
+	var/b = color_list[3] /255
 	var/a = length(color_list) == 4 ? color_list[4] : 1
 	if(!isnum(r) || !isnum(g) || !isnum(b) || !isnum(a))
 		return COLOR_MATRIX_IDENTITY
@@ -122,9 +122,9 @@ list(0.393,0.349,0.272,0, 0.769,0.686,0.534,0, 0.189,0.168,0.131,0, 0,0,0,1, 0,0
 		return COLOR_MATRIX_IDENTITY
 
 	var/list/color_list = rgb2num(string)
-	var/string_r = color_list[1]
-	var/string_g = color_list[2]
-	var/string_b = color_list[3]
+	var/string_r = color_list[1] /255
+	var/string_g = color_list[2] /255
+	var/string_b = color_list[3] /255
 
 	return list(string_r,0,0,0, 0,string_g,0,0, 0,0,string_b,0, 0,0,0,1, 0,0,0,0)
 


### PR DESCRIPTION

# About the pull request
We need the conversion from rgb to matrix here so the values should keep there / 255

Otherwise it does this:
<img width="429" height="324" alt="image" src="https://github.com/user-attachments/assets/381758cc-510b-461d-a9d0-99f79e8075d1" />


<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Maybe don't flashbang people and make NVGs extremely bad.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: NVGs/Malfunctioning AR/King Doom no longer are fullwhite.
/:cl:
