### PR TITLE
Fix: M56D double-mounting

### DIFF
--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -400,6 +400,12 @@
 
 	if(istype(O,/obj/item/device/m56d_gun)) //lets mount the MG onto the mount.
 		var/obj/item/device/m56d_gun/MG = O
+		if(gun_mounted == 1)
+			to_chat(user, SPAN_WARNING("There is already a gun mounted to this tripod!"))
+			return
+		if(MG.has_mount)
+			to_chat(user, SPAN_WARNING("The gun you're trying to attach already has a mount!"))
+			return
 		for(var/obj/structure/machinery/machine in long_orange(MG.defense_check_range, loc))
 			if(istype(machine, /obj/structure/machinery/m56d_hmg) || istype(machine, /obj/structure/machinery/m56d_post))
 				to_chat(user, SPAN_WARNING("This is too close to [machine]!"))

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -400,7 +400,7 @@
 
 	if(istype(O,/obj/item/device/m56d_gun)) //lets mount the MG onto the mount.
 		var/obj/item/device/m56d_gun/MG = O
-		if(gun_mounted == 1)
+		if(gun_mounted)
 			to_chat(user, SPAN_WARNING("There is already a gun mounted to this tripod!"))
 			return
 		if(MG.has_mount)


### PR DESCRIPTION

# About the pull request

Fixes #12340

Also fixes a related issue where a gun could be attached to a M56 mount, where the *anchored mount* already had a gun.

# Explain why it's good for the game

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

# Changelog

:cl: Antlers
fix: Fixed an issue where a M56D could be attached to a mount that already had a gun
fix: Fixed an issue where a disassembled M56D that already had a mount could be attached to another mount.
/:cl:

