### PR TITLE
Simplemobs no longer "see" cloaked entities

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -16,6 +16,8 @@
 	var/move_to_delay = 4
 	/// List of weakrefs of our friend mobs
 	var/list/friends = list()
+	/// Above what alpha can the mob "see" a target
+	var/vision_alpha = 30
 	var/break_stuff_probability = 10
 	var/destroy_surroundings = TRUE
 
@@ -59,6 +61,8 @@
 	if((target.faction == faction || (target.faction in faction_group)) && !attack_same)
 		return FALSE
 	if(WEAKREF(target) in friends)
+		return FALSE
+	if (target.alpha <= vision_alpha)
 		return FALSE
 	return target
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -16,8 +16,6 @@
 	var/move_to_delay = 4
 	/// List of weakrefs of our friend mobs
 	var/list/friends = list()
-	/// Above what alpha can the mob "see" a target
-	var/vision_alpha = 30
 	var/break_stuff_probability = 10
 	var/destroy_surroundings = TRUE
 
@@ -62,7 +60,7 @@
 		return FALSE
 	if(WEAKREF(target) in friends)
 		return FALSE
-	if (target.alpha <= vision_alpha)
+	if (HAS_TRAIT(target, TRAIT_CLOAKED))
 		return FALSE
 	return target
 


### PR DESCRIPTION

# About the pull request

Fixes #12335 by adding a new "vision_alpha" variable to simplemobs, below which entities will no longer be marked as a valid target.

This means burrowed burrows, cloaked lurkers, and cloaked scouts will no longer be attacked by lizards or snowball's spiders.

# Explain why it's good for the game

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

# Changelog

:cl: Antlers
fix: Spiders and lizards will no longer attack burrowed burrowers.
balance: Spiders and lizards will no longer attack cloaked lurkers or cloaked scouts.
/:cl:

