### PR TITLE
Fix custom smoke spawning runtime

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -47,7 +47,7 @@
 		src.time_to_live += rand(-1,1)
 
 	var/area/my_area = get_area(src)
-	if(my_area.flags_area & AREA_HEAVILY_VENTILATED)
+	if(my_area?.flags_area & AREA_HEAVILY_VENTILATED)
 		var/new_amount = rand(1,3)
 		src.time_to_live = min(new_amount, src.time_to_live)
 

--- a/code/modules/projectiles/guns/flamer/flamer.dm
+++ b/code/modules/projectiles/guns/flamer/flamer.dm
@@ -328,6 +328,7 @@
 		else
 			var/obj/effect/particle_effect/smoke/chem/checker = new()
 			var/atom/blocked = LinkBlocked(checker, source_turf, turf)
+			qdel(checker)
 			if(blocked)
 				break
 


### PR DESCRIPTION

# About the pull request

This PR does just a couple things (follow up to #11963 ):
- Deletes a test smoke immediately
- Makes the area check for new smoke to be null safe (because above spawns it with no loc)

# Explain why it's good for the game

Fixes 
<img width="1375" height="547" alt="image" src="https://github.com/user-attachments/assets/9091bf9c-fc21-44da-b05a-ff525cc999c4" />


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="2239" height="1202" alt="image" src="https://github.com/user-attachments/assets/2b0da34c-afdb-4612-bf3c-4eb68b2665f1" />

</details>


# Changelog
:cl: Drathek
fix: Fixed a runtime with custom smoke spawning
/:cl:
