### PR TITLE
Sneaky Hijack Edgecase + Transmute Fixes

### DIFF
--- a/code/__DEFINES/__game.dm
+++ b/code/__DEFINES/__game.dm
@@ -45,10 +45,16 @@
 #define MAP_CHINOOK "Chinook 91 GSO" //admin level
 #define MAP_ROSTOCK "SSV Rostock" //UPP Warship
 #define MAP_HUNTERSHIP "Hunter Ship"
+
 #define GAMEMODE_DISTRESS_SIGNAL "Distress Signal"
 #define GAMEMODE_WHISKEY_OUTPOST "Whiskey Outpost"
 #define GAMEMODE_HIVE_WARS "Hive Wars"
+#define GAMEMODE_FACTION_CLASH "Faction Clash"
 #define GAMEMODE_FACTION_CLASH_UPP_CM "Faction Clash UPP CM"
+#define GAMEMODE_HUNTER_GAMES "Hunter Games"
+#define GAMEMODE_INFECTION "Infection"
+#define GAMEMODE_EXTENDED "Extended"
+#define GAMEMODE_EXTENDED_NO_SPAWN "Extended - No Spawn"
 
 /// Number of players before we switch to lowpop maps only (LV, BR, Prison).
 #define PLAYERCOUNT_LOWPOP_MAP_LIMIT 130

--- a/code/__DEFINES/__game.dm
+++ b/code/__DEFINES/__game.dm
@@ -45,6 +45,7 @@
 #define MAP_CHINOOK "Chinook 91 GSO" //admin level
 #define MAP_ROSTOCK "SSV Rostock" //UPP Warship
 #define MAP_HUNTERSHIP "Hunter Ship"
+#define GAMEMODE_DISTRESS_SIGNAL "Distress Signal"
 #define GAMEMODE_WHISKEY_OUTPOST "Whiskey Outpost"
 #define GAMEMODE_HIVE_WARS "Hive Wars"
 #define GAMEMODE_FACTION_CLASH_UPP_CM "Faction Clash UPP CM"

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -83,7 +83,7 @@ GLOBAL_VAR_INIT(perf_flags, NO_FLAGS)
 
 GLOBAL_LIST_INIT(bitflags, list((1<<0), (1<<1), (1<<2), (1<<3), (1<<4), (1<<5), (1<<6), (1<<7), (1<<8), (1<<9), (1<<10), (1<<11), (1<<12), (1<<13), (1<<14), (1<<15), (1<<16), (1<<17), (1<<18), (1<<19), (1<<20), (1<<21), (1<<22), (1<<23)))
 
-GLOBAL_VAR_INIT(master_mode, "Distress Signal")
+GLOBAL_VAR_INIT(master_mode, GAMEMODE_DISTRESS_SIGNAL)
 
 GLOBAL_VAR_INIT(timezoneOffset, 0)
 

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -279,7 +279,7 @@ Voting
 
 // Gamemode to auto-switch to at the start of the round
 /datum/config_entry/string/gamemode_default
-	config_entry_value = "Extended"
+	config_entry_value = GAMEMODE_EXTENDED
 
 /datum/config_entry/number/rounds_until_hard_restart
 	config_entry_value = -1 // -1 is disabled by default, 0 is every round, x is after so many rounds

--- a/code/controllers/subsystem/hijack.dm
+++ b/code/controllers/subsystem/hijack.dm
@@ -285,9 +285,25 @@ SUBSYSTEM_DEF(hijack)
 		current_run_progress_multiplicative = 1
 
 ///Called when the dropship has been called by the xenos
-/datum/controller/subsystem/hijack/proc/call_shuttle()
+/datum/controller/subsystem/hijack/proc/on_call_shuttle()
 	hijack_status = HIJACK_OBJECTIVES_SHIP_INBOUND
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_HIJACK_INBOUND)
+
+	if(istype(SSticker.mode, /datum/game_mode/colonialmarines))
+		var/datum/game_mode/colonialmarines/colonial_marines = SSticker.mode
+		colonial_marines.add_current_round_status_to_end_results("Hijack")
+	GLOB.round_statistics?.track_hijack()
+
+/// Called usually after some delay after the dropship has been called by the xenos (or immediately on queen sneak)
+/datum/controller/subsystem/hijack/proc/hijack_general_quarters()
+	var/datum/ares_datacore/datacore = GLOB.ares_datacore
+	if(GLOB.security_level < SEC_LEVEL_RED)
+		set_security_level(SEC_LEVEL_RED, no_sound = TRUE, announce = FALSE)
+	if(!COOLDOWN_FINISHED(datacore, ares_quarters_cooldown))
+		return FALSE
+	COOLDOWN_START(datacore, ares_quarters_cooldown, 10 MINUTES)
+	shipwide_ai_announcement("ATTENTION! GENERAL QUARTERS. ALL HANDS, MAN YOUR BATTLESTATIONS.", MAIN_AI_SYSTEM, 'sound/effects/GQfullcall.ogg')
+	return TRUE
 
 ///Called when the xeno dropship crashes into the Almayer and announces the current status of various objectives to marines
 /datum/controller/subsystem/hijack/proc/announce_status_on_crash()

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -362,7 +362,7 @@ SUBSYSTEM_DEF(ticker)
 	if(mode)
 		GLOB.master_mode = SSmapping.configs[GROUND_MAP].force_mode ? SSmapping.configs[GROUND_MAP].force_mode : mode
 	else
-		GLOB.master_mode = "Extended"
+		GLOB.master_mode = GAMEMODE_EXTENDED
 	log_game("Saved mode is '[GLOB.master_mode]'")
 
 

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -445,10 +445,10 @@
 			if(!(g in gamemode_names))
 				log_world("map_config has an invalid gamemode name!")
 				return
-			if(g == "Extended") // always allow extended
+			if(g == GAMEMODE_EXTENDED) // always allow extended
 				continue
 			gamemodes += g
-		gamemodes += "Extended"
+		gamemodes += GAMEMODE_EXTENDED
 	else if(!isnull(json["gamemodes"]))
 		log_world("map_config gamemodes is not a list!")
 		return

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -12,8 +12,8 @@
 #define GROUNDSIDE_XENO_MULTIPLIER 1.0
 
 /datum/game_mode/colonialmarines
-	name = "Distress Signal"
-	config_tag = "Distress Signal"
+	name = GAMEMODE_DISTRESS_SIGNAL
+	config_tag = GAMEMODE_DISTRESS_SIGNAL
 	required_players = 1 //Need at least one player, but really we need 2.
 	xeno_required_num = 1 //Need at least one xeno.
 	monkey_amount = 5

--- a/code/game/gamemodes/colonialmarines/huntergames.dm
+++ b/code/game/gamemodes/colonialmarines/huntergames.dm
@@ -86,8 +86,8 @@
 //Digging through this is a pain. I'm leaving it mostly alone until a full rework takes place.
 
 /datum/game_mode/huntergames
-	name = "Hunter Games"
-	config_tag = "Hunter Games"
+	name = GAMEMODE_HUNTER_GAMES
+	config_tag = GAMEMODE_HUNTER_GAMES
 	required_players = 1
 	flags_round_type = MODE_NO_LATEJOIN
 	latejoin_larva_drop = 0 //You never know

--- a/code/game/gamemodes/extended/cm_vs_upp.dm
+++ b/code/game/gamemodes/extended/cm_vs_upp.dm
@@ -2,8 +2,8 @@
 #define ROUND_END_DELAY (2 MINUTES)
 
 /datum/game_mode/extended/faction_clash/cm_vs_upp
-	name = "Faction Clash UPP CM"
-	config_tag = "Faction Clash UPP CM"
+	name = GAMEMODE_FACTION_CLASH_UPP_CM
+	config_tag = GAMEMODE_FACTION_CLASH_UPP_CM
 	flags_round_type = MODE_THUNDERSTORM|MODE_FACTION_CLASH
 	starting_round_modifiers = list(
 		/datum/gamemode_modifier/blood_optimization,

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -1,6 +1,6 @@
 /datum/game_mode/extended
-	name = "Extended"
-	config_tag = "Extended"
+	name = GAMEMODE_EXTENDED
+	config_tag = GAMEMODE_EXTENDED
 	required_players = 0
 	latejoin_larva_drop = 0
 	static_comms_amount = 2

--- a/code/game/gamemodes/extended/extended_clash.dm
+++ b/code/game/gamemodes/extended/extended_clash.dm
@@ -1,6 +1,6 @@
 /datum/game_mode/extended/faction_clash
-	name = "Faction Clash"
-	config_tag = "Faction Clash"
+	name = GAMEMODE_FACTION_CLASH
+	config_tag = GAMEMODE_FACTION_CLASH
 	flags_round_type = MODE_THUNDERSTORM|MODE_FACTION_CLASH
 	starting_round_modifiers = list(/datum/gamemode_modifier/blood_optimization, /datum/gamemode_modifier/defib_past_armor, /datum/gamemode_modifier/disable_combat_cas, /datum/gamemode_modifier/disable_ib, /datum/gamemode_modifier/disable_attacking_corpses, /datum/gamemode_modifier/disable_long_range_sentry, /datum/gamemode_modifier/disable_stripdrag_enemy, /datum/gamemode_modifier/indestructible_splints, /datum/gamemode_modifier/mortar_laser_warning, /datum/gamemode_modifier/no_body_c4)
 

--- a/code/game/gamemodes/extended/extended_nospawn.dm
+++ b/code/game/gamemodes/extended/extended_nospawn.dm
@@ -1,6 +1,6 @@
 /datum/game_mode/extended/nospawn
-	name = "Extended - No Spawn"
-	config_tag = "Extended - No Spawn"
+	name = GAMEMODE_EXTENDED_NO_SPAWN
+	config_tag = GAMEMODE_EXTENDED_NO_SPAWN
 	flags_round_type = MODE_NO_LATEJOIN|MODE_NO_SPAWN
 	votable = FALSE
 

--- a/code/game/gamemodes/extended/infection.dm
+++ b/code/game/gamemodes/extended/infection.dm
@@ -1,7 +1,7 @@
 //THIS IS A BLANK LABEL ONLY SO PEOPLE CAN SEE WHEN WE RUNNIN DIS BITCH.   Should probably write a real one one day.  Maybe.
 /datum/game_mode/infection
-	name = "Infection"
-	config_tag = "Infection"
+	name = GAMEMODE_INFECTION
+	config_tag = GAMEMODE_INFECTION
 	required_players = 0 //otherwise... no zambies
 	latejoin_larva_drop = 0
 	flags_round_type = MODE_INFECTION //Apparently without this, the game mode checker ignores this as a potential legit game mode.

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -906,17 +906,19 @@
 	return ..()
 
 /obj/structure/machinery/door/airlock/dropship_hatch/attack_alien(mob/living/carbon/xenomorph/xeno)
-
 	if(xeno.hive_pos != XENO_QUEEN)
 		return ..()
 
 	if(!locked)
 		return ..()
 
-	to_chat(xeno, SPAN_NOTICE("You try and force the doors open."))
-	if(do_after(xeno, 3 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
+	if(xeno.action_busy)
+		return
+
+	to_chat(xeno, SPAN_NOTICE("You try and force the doors open!"))
+	if(do_after(xeno, 5 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
 		unlock(TRUE)
-		open(1)
+		open(TRUE)
 		lock(TRUE)
 
 /obj/structure/machinery/door/airlock/dropship_hatch/two

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -259,7 +259,7 @@
 
 /obj/structure/machinery/door/airlock/multi_tile/almayer/maint/reinforced/colony/autoname
 	autoname = TRUE
- 
+
 //------Containment 3-tile Doors -----//
 
 /obj/structure/machinery/door/airlock/multi_tile/almayer/containment
@@ -374,7 +374,7 @@
 		return
 
 	to_chat(xeno, SPAN_WARNING("You try and force the doors open!"))
-	if(do_after(xeno, 3 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
+	if(do_after(xeno, 5 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
 		if(control)
 			control.status = SHUTTLE_DOOR_BROKEN
 		unlock(TRUE)

--- a/code/modules/cm_aliens/hivebuffs/hivebuff.dm
+++ b/code/modules/cm_aliens/hivebuffs/hivebuff.dm
@@ -488,7 +488,7 @@
 	radial_icon = "shield_m"
 
 /datum/hivebuff/adaptability/apply_buff_effects(mob/living/carbon/xenomorph/xeno)
-	if(xeno.caste.tier > 3)
+	if(xeno.caste.tier < 1 || xeno.caste.tier > 3)
 		return
 
 	if(get_action(xeno, /datum/action/xeno_action/onclick/transmute))

--- a/code/modules/cm_aliens/hivebuffs/hivebuff.dm
+++ b/code/modules/cm_aliens/hivebuffs/hivebuff.dm
@@ -494,7 +494,6 @@
 	if(get_action(xeno, /datum/action/xeno_action/onclick/transmute))
 		return
 
-	add_verb(xeno, /mob/living/carbon/xenomorph/proc/transmute_verb)
 	var/datum/action/xeno_action/onclick/transmute/transmute_action = new()
 	transmute_action.give_to(xeno)
 

--- a/code/modules/cm_tech/droppod/gear_access_point.dm
+++ b/code/modules/cm_tech/droppod/gear_access_point.dm
@@ -45,7 +45,7 @@
 /obj/structure/techpod_vendor/proc/get_access_permission(mob/living/carbon/human/user)
 	if(SSticker.mode == GAMEMODE_WHISKEY_OUTPOST || GLOB.master_mode == GAMEMODE_WHISKEY_OUTPOST) //all WO has lifted access restrictions
 		return TRUE
-	else if(SSticker.mode == "Distress Signal" || GLOB.master_mode == "Distress Signal")
+	else if(SSticker.mode == GAMEMODE_DISTRESS_SIGNAL || GLOB.master_mode == GAMEMODE_DISTRESS_SIGNAL)
 		if(access_settings_override) //everyone allowed to grab stuff
 			return TRUE
 		else if(user.get_target_lock(faction_requirement)) //only it's faction group allowed

--- a/code/modules/mob/living/carbon/xenomorph/Evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Evolution.dm
@@ -296,10 +296,12 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 
 	return TRUE
 
-/mob/living/carbon/xenomorph/verb/verb_transmute()
+// Intentionally a proc variant of a verb so its not just automatically given to xenos
+/mob/living/carbon/xenomorph/proc/verb_transmute()
 	set name = "Transmute"
 	set desc = "Transmute into a different caste of the same tier."
 	set category = "Alien"
+	set hidden = TRUE
 
 	if(!check_state())
 		return

--- a/code/modules/mob/living/carbon/xenomorph/Evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Evolution.dm
@@ -296,7 +296,7 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 
 	return TRUE
 
-/mob/living/carbon/xenomorph/proc/transmute_verb()
+/mob/living/carbon/xenomorph/verb/verb_transmute()
 	set name = "Transmute"
 	set desc = "Transmute into a different caste of the same tier."
 	set category = "Alien"

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
@@ -516,7 +516,7 @@
 	name = "Transmute"
 	action_icon_state = "transmute"
 	action_type = XENO_ACTION_CLICK
-	macro_path = /mob/living/carbon/xenomorph/verb/verb_transmute
+	macro_path = /mob/living/carbon/xenomorph/proc/verb_transmute
 
 /datum/action/xeno_action/onclick/transmute/action_activate()
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
@@ -516,11 +516,12 @@
 	name = "Transmute"
 	action_icon_state = "transmute"
 	action_type = XENO_ACTION_CLICK
+	macro_path = /mob/living/carbon/xenomorph/verb/verb_transmute
 
 /datum/action/xeno_action/onclick/transmute/action_activate()
 	. = ..()
 	var/mob/living/carbon/xenomorph/xeno = owner
-	xeno.transmute_verb()
+	xeno.verb_transmute()
 
 /datum/action/xeno_action/onclick/transmute/can_use_action()
 	if(!owner)

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -875,18 +875,17 @@
 
 /datum/hive_status/proc/bless_on_hijack()
 	xeno_maptext("My Children, the time has come to assault the Metal Hive. Evolve now into castes best suited for the task!", "Queen Mother") // NOTE: sends a maptext to all xenos globally, hence not in below loop
+
+	// Grant transmute
 	for(var/mob/living/carbon/xenomorph/xeno as anything in totalXenos)
-		if(xeno.caste.tier > 3)
-			return
+		if(xeno.caste.tier < 1 || xeno.caste.tier > 3)
+			continue
 
 		if(get_action(xeno, /datum/action/xeno_action/onclick/transmute))
-			return
+			continue
 
-
-		if(xeno.caste.tier > 0)
-			add_verb(xeno, /mob/living/carbon/xenomorph/proc/transmute_verb)
-			var/datum/action/xeno_action/onclick/transmute/transmute_action = new()
-			transmute_action.give_to(xeno)
+		var/datum/action/xeno_action/onclick/transmute/transmute_action = new()
+		transmute_action.give_to(xeno)
 
 	// Reset ovi & make combat effective queen
 	if(living_xeno_queen)

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -888,6 +888,17 @@
 			var/datum/action/xeno_action/onclick/transmute/transmute_action = new()
 			transmute_action.give_to(xeno)
 
+	// Reset ovi & make combat effective queen
+	if(living_xeno_queen)
+		var/datum/action/xeno_action/onclick/grow_ovipositor/ovi_ability = get_action(living_xeno_queen, /datum/action/xeno_action/onclick/grow_ovipositor)
+		ovi_ability?.reduce_cooldown(ovi_ability.xeno_cooldown)
+		if(!living_xeno_queen.queen_aged)
+			living_xeno_queen.make_combat_effective()
+
+	// Buff evilution temporarily
+	var/original_evilution = evolution_bonus
+	override_evilution(XENO_HIJACK_EVILUTION_BUFF, TRUE)
+	addtimer(CALLBACK(src, PROC_REF(override_evilution), original_evilution, FALSE), XENO_HIJACK_EVILUTION_TIME)
 
 /datum/hive_status/proc/free_respawn(client/C)
 	stored_larva++

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -367,7 +367,7 @@
 	// select crash location
 	var/turf/source_turf = get_turf(src)
 	var/obj/docking_port/mobile/marine_dropship/dropship = SSshuttle.getShuttle(shuttleId)
-	var/result = tgui_input_list(user, "Where to 'land'?", "Dropship Hijack", GLOB.almayer_ship_sections , timeout = 10 SECONDS)
+	var/result = tgui_input_list(user, "Where to 'land'?", "Dropship Hijack", GLOB.almayer_ship_sections, timeout = 10 SECONDS)
 	if(!result)
 		return
 	if(!user.Adjacent(source_turf) && !force)
@@ -376,20 +376,25 @@
 		return
 
 	var/datum/dropship_hijack/almayer/hijack = new()
-	SShijack.call_shuttle()
 	dropship.hijack = hijack
 	hijack.shuttle = dropship
+	SShijack.on_call_shuttle()
 	hijack.target_crash_site(result)
 
 	dropship.crashing = TRUE
 	dropship.is_hijacked = TRUE
 
 	hijack.fire()
-	GLOB.alt_ctrl_disabled = TRUE
 
-	marine_announcement("Unscheduled dropship departure detected from operational area. Hijack likely. Shutting down autopilot.", "Dropship Alert", 'sound/AI/hijack.ogg', logging = ARES_LOG_SECURITY)
-	log_ares_flight("Unknown", "Unscheduled dropship departure detected from operational area. Hijack likely. Shutting down autopilot.")
-	addtimer(CALLBACK(src, PROC_REF(hijack_general_quarters)), 10 SECONDS)
+	var/ares_message = "Unscheduled dropship departure detected from operational area. Hijack likely. Shutting down autopilot."
+	marine_announcement(ares_message, "Dropship Alert", 'sound/AI/hijack.ogg', logging = ARES_LOG_SECURITY)
+	log_ares_flight("Unknown", ares_message)
+	playsound(src, 'sound/misc/queen_alarm.ogg')
+	addtimer(CALLBACK(SShijack, TYPE_PROC_REF(/datum/controller/subsystem/hijack, hijack_general_quarters)), 10 SECONDS)
+
+	var/obj/structure/machinery/computer/shuttle/dropship/flight/console = dropship.getControlConsole()
+	console?.balloon_alert_to_viewers("autopilot disabled!")
+
 	var/mob/living/carbon/xenomorph/xeno = user
 	var/hivenumber = XENO_HIVE_NORMAL
 	if(istype(xeno))
@@ -397,34 +402,11 @@
 	xeno_message(SPAN_XENOANNOUNCE("The Queen has commanded the metal bird to depart for the metal hive in the sky! Rejoice!"), 3, hivenumber)
 	xeno_message(SPAN_XENOANNOUNCE("The hive swells with power! You will now steadily gain pooled larva over time."), 2, hivenumber)
 	var/datum/hive_status/hive = GLOB.hive_datum[hivenumber]
-	addtimer(CALLBACK(hive, TYPE_PROC_REF(/datum/hive_status, abandon_on_hijack)), DROPSHIP_WARMUP_TIME, TIMER_UNIQUE)
 	hive.bless_on_hijack()
-	var/original_evilution = hive.evolution_bonus
-	hive.override_evilution(XENO_HIJACK_EVILUTION_BUFF, TRUE)
-	if(hive.living_xeno_queen)
-		var/datum/action/xeno_action/onclick/grow_ovipositor/ovi_ability = get_action(hive.living_xeno_queen, /datum/action/xeno_action/onclick/grow_ovipositor)
-		ovi_ability.reduce_cooldown(ovi_ability.xeno_cooldown)
-		if(!hive.living_xeno_queen.queen_aged)
-			hive.living_xeno_queen.make_combat_effective()
-	addtimer(CALLBACK(hive, TYPE_PROC_REF(/datum/hive_status, override_evilution), original_evilution, FALSE), XENO_HIJACK_EVILUTION_TIME)
+	addtimer(CALLBACK(hive, TYPE_PROC_REF(/datum/hive_status, abandon_on_hijack)), DROPSHIP_WARMUP_TIME, TIMER_UNIQUE)
 
 	// Notify the yautja too so they stop the hunt
 	elder_overseer_message("The serpent Queen has commanded the landing shuttle to depart.")
-	playsound(src, 'sound/misc/queen_alarm.ogg')
-
-	if(istype(SSticker.mode, /datum/game_mode/colonialmarines))
-		var/datum/game_mode/colonialmarines/colonial_marines = SSticker.mode
-		colonial_marines.add_current_round_status_to_end_results("Hijack")
-
-/obj/structure/machinery/computer/shuttle/dropship/flight/proc/hijack_general_quarters()
-	var/datum/ares_datacore/datacore = GLOB.ares_datacore
-	if(GLOB.security_level < SEC_LEVEL_RED)
-		set_security_level(SEC_LEVEL_RED, no_sound = TRUE, announce = FALSE)
-	if(!COOLDOWN_FINISHED(datacore, ares_quarters_cooldown))
-		return FALSE
-	COOLDOWN_START(datacore, ares_quarters_cooldown, 10 MINUTES)
-	shipwide_ai_announcement("ATTENTION! GENERAL QUARTERS. ALL HANDS, MAN YOUR BATTLESTATIONS.", MAIN_AI_SYSTEM, 'sound/effects/GQfullcall.ogg')
-	return TRUE
 
 /obj/structure/machinery/computer/shuttle/dropship/flight/proc/remove_door_lock()
 	if(door_control_cooldown)

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -392,9 +392,6 @@
 	playsound(src, 'sound/misc/queen_alarm.ogg')
 	addtimer(CALLBACK(SShijack, TYPE_PROC_REF(/datum/controller/subsystem/hijack, hijack_general_quarters)), 10 SECONDS)
 
-	var/obj/structure/machinery/computer/shuttle/dropship/flight/console = dropship.getControlConsole()
-	console?.balloon_alert_to_viewers("autopilot disabled!")
-
 	var/mob/living/carbon/xenomorph/xeno = user
 	var/hivenumber = XENO_HIVE_NORMAL
 	if(istype(xeno))

--- a/code/modules/shuttle/dropship_hijack.dm
+++ b/code/modules/shuttle/dropship_hijack.dm
@@ -72,9 +72,8 @@
 	if(!shuttle || !crash_site)
 		return FALSE
 	shuttle.callTime = DROPSHIP_CRASH_TRANSIT_DURATION * GLOB.ship_alt
+	GLOB.alt_ctrl_disabled = TRUE
 	SSshuttle.moveShuttle(shuttle.id, crash_site.id, TRUE)
-	if(GLOB.round_statistics)
-		GLOB.round_statistics.track_hijack()
 	return TRUE
 
 /datum/dropship_hijack/almayer/proc/target_crash_site(ship_section)
@@ -135,7 +134,7 @@
 	if(shuttle.mode != SHUTTLE_CALL)
 		return
 
-	if(shuttle.timeLeft(1) > 10 SECONDS)
+	if(shuttle.timeLeft(1) > 10 SECONDS) // This time must be less than /obj/docking_port/mobile/marine_dropship/proc/stealth_hijack_check()
 		return
 
 	if(final_announcement)

--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -214,9 +214,6 @@
 	log_ares_flight("Unknown", ares_message)
 	playsound(src, 'sound/misc/queen_alarm.ogg')
 
-	var/obj/structure/machinery/computer/shuttle/dropship/flight/console = getControlConsole()
-	console?.balloon_alert_to_viewers("autopilot disabled!")
-
 	xeno_message(SPAN_XENOANNOUNCE("The metal bird is arriving at the metal hive in the sky!"), 3, queen.hivenumber)
 	xeno_message(SPAN_XENOANNOUNCE("The hive swells with power! You will now steadily gain pooled larva over time."), 2, queen.hivenumber)
 	var/datum/hive_status/hive = queen.hive
@@ -225,6 +222,16 @@
 
 	// Notify the yautja too so they stop the hunt
 	elder_overseer_message("The serpent Queen has snuck on a landing shuttle.")
+
+	// Also some /obj/structure/machinery/computer/shuttle/dropship/flight/attack_alien() stuff
+	if(!MODE_HAS_MODIFIER(/datum/gamemode_modifier/lz_weeding))
+		MODE_SET_MODIFIER(/datum/gamemode_modifier/lz_weeding, TRUE)
+
+	var/obj/structure/machinery/computer/shuttle/dropship/flight/console = getControlConsole()
+	if(console)
+		console.balloon_alert_to_viewers("autopilot disabled!")
+		console.dropship_control_lost = TRUE
+		console.update_icon()
 
 	return TRUE
 

--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -158,7 +158,75 @@
 
 	automated_check()
 
-	hijack?.check()
+	if(hijack)
+		hijack.check()
+	else
+		sneak_hijack_check()
+
+/// Searches the shuttle_areas for a non-dead, non-iff tagged queen and returns her (or null)
+/obj/docking_port/mobile/marine_dropship/proc/find_hijack_queen()
+	for(var/area/checked_area in shuttle_areas)
+		for(var/mob/living/carbon/xenomorph/queen/checked_queen in checked_area)
+			if(checked_queen.stat == DEAD || (FACTION_MARINE in checked_queen.iff_tag?.faction_groups))
+				continue
+			return checked_queen
+	return null
+
+/// Triggers a sneak hijack if not already hijacked, less than 20s left on call, and a hostile queen is aboard
+/obj/docking_port/mobile/marine_dropship/proc/sneak_hijack_check()
+	if(is_hijacked)
+		return FALSE
+
+	if(SSticker.mode?.is_in_endgame)
+		return FALSE
+
+	if(GLOB.master_mode != GAMEMODE_DISTRESS_SIGNAL)
+		return FALSE
+
+	if(mode != SHUTTLE_CALL)
+		return FALSE
+
+	if(timeLeft(1) > 20 SECONDS) // This time must be more than /datum/dropship_hijack/almayer/proc/check_final_approach() time
+		return FALSE
+
+	// Not already hijacked, look for a queen
+	var/mob/living/carbon/xenomorph/queen/queen = find_hijack_queen()
+	if(!queen)
+		return FALSE
+
+	// Theres a queen that snuck on!
+	// Replicate most of /obj/structure/machinery/computer/shuttle/dropship/flight/proc/hijack...
+	hijack = new()
+	hijack.shuttle = src
+	SShijack.on_call_shuttle()
+	hijack.target_crash_site(pick(GLOB.almayer_ship_sections - GLOB.almayer_aa_cannon?.protecting_section))
+
+	crashing = TRUE
+	is_hijacked = TRUE
+
+	// /datum/dropship_hijack/almayer/proc/fire() stuff
+	destination = hijack.crash_site
+	GLOB.alt_ctrl_disabled = TRUE
+
+	SShijack.hijack_general_quarters()
+	var/ares_message = "Unidentified lifesigns detected onboard. Hijack likely. Shutting down autopilot."
+	marine_announcement(ares_message, "Dropship Alert", logging=ARES_LOG_SECURITY)
+	log_ares_flight("Unknown", ares_message)
+	playsound(src, 'sound/misc/queen_alarm.ogg')
+
+	var/obj/structure/machinery/computer/shuttle/dropship/flight/console = getControlConsole()
+	console?.balloon_alert_to_viewers("autopilot disabled!")
+
+	xeno_message(SPAN_XENOANNOUNCE("The metal bird is arriving at the metal hive in the sky!"), 3, queen.hivenumber)
+	xeno_message(SPAN_XENOANNOUNCE("The hive swells with power! You will now steadily gain pooled larva over time."), 2, queen.hivenumber)
+	var/datum/hive_status/hive = queen.hive
+	hive.bless_on_hijack()
+	hive.abandon_on_hijack()
+
+	// Notify the yautja too so they stop the hunt
+	elder_overseer_message("The serpent Queen has snuck on a landing shuttle.")
+
+	return TRUE
 
 /obj/docking_port/mobile/marine_dropship/proc/automated_check()
 	var/obj/structure/machinery/computer/shuttle/dropship/flight/root_console = getControlConsole()

--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -214,6 +214,9 @@
 	if(timeLeft(1) > 20 SECONDS) // This time must be more than /datum/dropship_hijack/almayer/proc/check_final_approach() time
 		return FALSE
 
+	if(!is_mainship_level(destination?.z))
+		return FALSE
+
 	// Not already hijacked, look for a queen
 	var/mob/living/carbon/xenomorph/queen/queen = find_hijack_queen()
 	if(!queen)

--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -176,8 +176,10 @@
 		for(var/mob/living/carbon/xenomorph/queen/checked_queen in checked_area)
 			if(checked_queen.stat == DEAD)
 				continue
+			if(checked_queen.hive?.need_round_end_check && !checked_queen.hive.can_delay_round_end())
+				continue // Not a hive that can hijack
 			if(checked_queen.hive?.faction_is_ally(FACTION_MARINE, TRUE))
-				continue
+				continue // Technically included in above for corrupted but really don't want an ally to hijack
 			if(FACTION_MARINE in checked_queen.iff_tag?.faction_groups)
 				continue
 			if(checked_queen == existing_allied_queen)

--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -163,11 +163,15 @@
 	else
 		sneak_hijack_check()
 
-/// Searches the shuttle_areas for a non-dead, non-iff tagged queen and returns her (or null)
+/// Searches the shuttle_areas for a non-dead, non-USCM-allied, non-USCM-iff tagged queen and returns her (or null)
 /obj/docking_port/mobile/marine_dropship/proc/find_hijack_queen()
 	for(var/area/checked_area in shuttle_areas)
 		for(var/mob/living/carbon/xenomorph/queen/checked_queen in checked_area)
-			if(checked_queen.stat == DEAD || (FACTION_MARINE in checked_queen.iff_tag?.faction_groups))
+			if(checked_queen.stat == DEAD)
+				continue
+			if(checked_queen.hive?.faction_is_ally(FACTION_MARINE, TRUE))
+				continue
+			if(FACTION_MARINE in checked_queen.iff_tag?.faction_groups)
 				continue
 			return checked_queen
 	return null

--- a/code/modules/shuttle/shuttles/dropship.dm
+++ b/code/modules/shuttle/shuttles/dropship.dm
@@ -21,6 +21,8 @@
 	// Is hijacked by opfor
 	var/is_hijacked = FALSE
 	var/datum/dropship_hijack/almayer/hijack
+	/// Any allied queen present on launch otherwise null
+	var/datum/weakref/boarded_allied_queen = null
 	// CAS gear
 	var/list/obj/structure/dropship_equipment/equipments = list()
 
@@ -89,6 +91,10 @@
 	. = ..()
 	if(SSticker?.mode && !(SSticker.mode.flags_round_type & MODE_DS_LANDED) && !in_flyby && is_ground_level(destination?.z)) //Launching on first drop.
 		SSticker.mode.ds_first_drop(src)
+	boarded_allied_queen = null
+	var/mob/boarded_queen = find_allied_queen()
+	if(boarded_queen)
+		boarded_allied_queen = WEAKREF(boarded_queen)
 
 /obj/docking_port/mobile/marine_dropship/beforeShuttleMove(turf/newT, rotation, move_mode, obj/docking_port/mobile/moving_dock)
 	. = ..()
@@ -165,6 +171,7 @@
 
 /// Searches the shuttle_areas for a non-dead, non-USCM-allied, non-USCM-iff tagged queen and returns her (or null)
 /obj/docking_port/mobile/marine_dropship/proc/find_hijack_queen()
+	var/mob/existing_allied_queen = boarded_allied_queen?.resolve()
 	for(var/area/checked_area in shuttle_areas)
 		for(var/mob/living/carbon/xenomorph/queen/checked_queen in checked_area)
 			if(checked_queen.stat == DEAD)
@@ -173,7 +180,21 @@
 				continue
 			if(FACTION_MARINE in checked_queen.iff_tag?.faction_groups)
 				continue
+			if(checked_queen == existing_allied_queen)
+				continue // She was allied when boarding
 			return checked_queen
+	return null
+
+/// Searches the shuttle_areas for a non-dead, USCM-allied or USCM-iff tagged queen and returns her (or null)
+/obj/docking_port/mobile/marine_dropship/proc/find_allied_queen()
+	for(var/area/checked_area in shuttle_areas)
+		for(var/mob/living/carbon/xenomorph/queen/checked_queen in checked_area)
+			if(checked_queen.stat == DEAD)
+				continue
+			if(checked_queen.hive?.faction_is_ally(FACTION_MARINE, TRUE))
+				return checked_queen
+			if(FACTION_MARINE in checked_queen.iff_tag?.faction_groups)
+				return checked_queen
 	return null
 
 /// Triggers a sneak hijack if not already hijacked, less than 20s left on call, and a hostile queen is aboard

--- a/code/modules/vehicles/apc/apc_command.dm
+++ b/code/modules/vehicles/apc/apc_command.dm
@@ -182,7 +182,7 @@
 /obj/vehicle/multitile/apc/command/proc/get_access_permission(mob/living/carbon/human/user)
 	if(SSticker.mode == GAMEMODE_WHISKEY_OUTPOST || GLOB.master_mode == GAMEMODE_WHISKEY_OUTPOST)
 		return TRUE
-	else if(SSticker.mode == "Distress Signal" || GLOB.master_mode == "Distress Signal")
+	else if(SSticker.mode == GAMEMODE_DISTRESS_SIGNAL || GLOB.master_mode == GAMEMODE_DISTRESS_SIGNAL)
 		if(techpod_access_settings_override)
 			return TRUE
 		else if(user.get_target_lock(techpod_faction_requirement))


### PR DESCRIPTION
# About the pull request

This PR does several things:
- Makes it where a hostile queen (an allied queen at the start of transit is ignored) that is on a shuttle that's arriving normally to the almayer will trigger a hijack crash (with little warning)
- Fixes some logic errors in #10238 where the loop would end on the first xeno that is a king or already has the ability (rather than continuing on to the next xeno)
- Transmute is no longer given to queen on purchase
- Moves some hijack effects around (namely evilution changes, ovi reset, queen maturity into `/datum/hive_status/proc/bless_on_hijack()`; and hijack round status+ stat tracking into `/datum/controller/subsystem/hijack/proc/on_call_shuttle()`)
- Standardizes the defines for game modes (some did it this way, many not)
- Transmute needs to be a proc verb (or if a verb verb it needs additional ability checks to see if the ability is granted). Ultimately I messed with transmute because of the weird issue with the loop early returning incorrectly where I wanted to move logic to
- **NEW** Queen pry for dropship airlocks is increased from 3s to 5s
- Mapped in dropships using `/obj/structure/machinery/door/airlock/dropship_hatch` now check if the queen is busy - generally to keep consistency with `/obj/structure/machinery/door/airlock/multi_tile/almayer/dropshiprear` and `/obj/structure/machinery/door/airlock/multi_tile/almayer/dropshiprear/dropshipside`

Technically a xeno evolving as queen on the Almayer could still be in this scenario, but I think it even less likely to occur and unlikely for them to succeed enough that warrants needing to put the game into a hijack state.

# Explain why it's good for the game

Presently admins have been sort of having to intervene whenever a queen sneaks onto the dropship, but since hijack effects are kinda all over the place its difficult for them to do all changes nor in a way that really thematically can work. Now its as if the dropship has its autopilot disabled shortly before docking procedures and ends up crashing into the ship (because the queen is a bad driver).

Queen pry increase is from feedback that thinks DP needs more time to react to a queen trying to enter.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Normal hijack + transmute testing: https://youtu.be/CuSb9vs2NiQ

Stealth hijack as marine: https://youtu.be/mL4UUED1mqA

Stealth hijack as xeno: https://youtu.be/u05M-Y6q32E

</details>


# Changelog
:cl: Drathek
balance: A hostile queen that sneaks on a shuttle will now trigger a hijack automatically just before arrival
balance: Queen pry on dropship airlocks is increased from 3s to 5s
fix: Fixed grant transmute on hijack buff loop stopping early if it encounters a king or xeno with the ability already
fix: Hive buff purchase for transmute no longer is applied to queen
/:cl:
