### PR TITLE
Sharp buff

### DIFF
--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -520,7 +520,7 @@
 
 /obj/item/explosive/mine/sharp/incendiary
 	name = "\improper P9 SHARP incendiary dart"
-	desc = "An experimental P9 SHARP proximity triggered explosive dart designed by Armat Systems for use by the United States Colonial Marines. This one has full 360 detection range."
+	desc = "An experimental P9 SHARP proximity triggered incendiary dart designed by Armat Systems for use by the United States Colonial Marines. This one has full 360 detection range."
 	icon_state = "sharp_incendiary_mine"
 
 /obj/item/explosive/mine/sharp/incendiary/prime(mob/user)

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -449,13 +449,13 @@
 		explosion_size = 100
 	else if(mine_level == 2)
 		explosion_size = 100
-		explosion_falloff = 25
+		explosion_falloff = 20
 	else if(mine_level == 3)
 		explosion_size = 125
-		explosion_falloff = 30
+		explosion_falloff = 25
 	else
 		explosion_size = 125
-		explosion_falloff = 25
+		explosion_falloff = 20
 	cell_explosion(loc, explosion_size, explosion_falloff, EXPLOSION_FALLOFF_SHAPE_LINEAR, CARDINAL_ALL_DIRS, cause_data, enviro=map_deployed)
 	playsound(loc, 'sound/weapons/gun_sharp_explode.ogg', 100)
 	qdel(src)
@@ -491,7 +491,7 @@
 	update_icon()
 	deploy_time = world.time
 	mine_state = icon_state
-	timer_id = addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/explosive/mine/sharp, upgrade_mine)), 30 SECONDS, TIMER_DELETE_ME | TIMER_STOPPABLE)
+	timer_id = addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/explosive/mine/sharp, upgrade_mine)), 45 SECONDS, TIMER_DELETE_ME | TIMER_STOPPABLE)
 	for(var/mob/living/carbon/mob in range(1, src))
 		try_to_prime(mob)
 
@@ -541,10 +541,10 @@
 		playsound(loc, 'sound/weapons/gun_flamethrower3.ogg', 45)
 	else if(mine_level == 3)
 		var/datum/reagent/napalm/ut/reagent = new()
-		new /obj/flamer_fire(loc, cause_data, reagent, 2)
+		new /obj/flamer_fire(loc, cause_data, reagent, 3)
 		playsound(loc, 'sound/weapons/gun_flamethrower3.ogg', 45)
 	else
-		var/datum/reagent/napalm/ut/reagent = new()
-		new /obj/flamer_fire(loc, cause_data, reagent, 3)
+		var/datum/reagent/napalm/blue/reagent = new()
+		new /obj/flamer_fire(loc, cause_data, reagent, 2)
 		playsound(loc, 'sound/weapons/gun_flamethrower3.ogg', 45)
 	qdel(src)

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -409,7 +409,7 @@
 	mine_level++
 	icon_state = mine_state + "_[mine_level]"
 	if(mine_level < 4)
-		timer_id = addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/explosive/mine/sharp, upgrade_mine)), 45 SECONDS, TIMER_DELETE_ME | TIMER_STOPPABLE)
+		timer_id = addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/explosive/mine/sharp, upgrade_mine)), 65 SECONDS, TIMER_DELETE_ME | TIMER_STOPPABLE)
 
 /obj/item/explosive/mine/sharp/check_for_obstacles(mob/living/user)
 	return FALSE
@@ -491,7 +491,7 @@
 	update_icon()
 	deploy_time = world.time
 	mine_state = icon_state
-	timer_id = addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/explosive/mine/sharp, upgrade_mine)), 45 SECONDS, TIMER_DELETE_ME | TIMER_STOPPABLE)
+	timer_id = addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/explosive/mine/sharp, upgrade_mine)), 65 SECONDS, TIMER_DELETE_ME | TIMER_STOPPABLE)
 	for(var/mob/living/carbon/mob in range(1, src))
 		try_to_prime(mob)
 

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -409,7 +409,7 @@
 	mine_level++
 	icon_state = mine_state + "_[mine_level]"
 	if(mine_level < 4)
-		timer_id = addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/explosive/mine/sharp, upgrade_mine)), 30 SECONDS, TIMER_DELETE_ME | TIMER_STOPPABLE)
+		timer_id = addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/explosive/mine/sharp, upgrade_mine)), 45 SECONDS, TIMER_DELETE_ME | TIMER_STOPPABLE)
 
 /obj/item/explosive/mine/sharp/check_for_obstacles(mob/living/user)
 	return FALSE

--- a/code/modules/projectiles/guns/specialist/sharp.dm
+++ b/code/modules/projectiles/guns/specialist/sharp.dm
@@ -145,9 +145,9 @@
 			var/obj/item/weapon/gun/rifle/sharp/weapon = shot_dart.shot_from
 			playsound(get_turf(target), 'sound/weapons/gun_sharp_explode.ogg', 100)
 			if(weapon && weapon.explosion_delay_sharp)
-				addtimer(CALLBACK(src, PROC_REF(delayed_explosion), shot_dart, target, shooter), 6 SECONDS)
+				addtimer(CALLBACK(src, PROC_REF(delayed_explosion), shot_dart, target, shooter), 5 SECONDS)
 			else
-				addtimer(CALLBACK(src, PROC_REF(delayed_explosion), shot_dart, target, shooter), 3 SECONDS)
+				addtimer(CALLBACK(src, PROC_REF(delayed_explosion), shot_dart, target, shooter), 2.5 SECONDS)
 
 /datum/ammo/rifle/sharp/explosive/drop_dart(loc, obj/projectile/shot_dart, mob/shooter)
 	var/signal_explosion = FALSE

--- a/code/modules/projectiles/guns/specialist/sharp.dm
+++ b/code/modules/projectiles/guns/specialist/sharp.dm
@@ -33,7 +33,7 @@
 
 /obj/item/weapon/gun/rifle/sharp/get_examine_text(mob/user)
 	. = ..()
-	. += SPAN_INFO("Switching firemodes will toggle the explosion delay timer between 1 second and 5 seconds.")
+	. += SPAN_INFO("Switching firemodes will toggle the explosion delay timer between 2.5 second and 5 seconds.")
 
 /obj/item/weapon/gun/rifle/sharp/set_bullet_traits()
 	LAZYADD(traits_to_give, list(
@@ -145,9 +145,9 @@
 			var/obj/item/weapon/gun/rifle/sharp/weapon = shot_dart.shot_from
 			playsound(get_turf(target), 'sound/weapons/gun_sharp_explode.ogg', 100)
 			if(weapon && weapon.explosion_delay_sharp)
-				addtimer(CALLBACK(src, PROC_REF(delayed_explosion), shot_dart, target, shooter), 5 SECONDS)
+				addtimer(CALLBACK(src, PROC_REF(delayed_explosion), shot_dart, target, shooter), 6 SECONDS)
 			else
-				addtimer(CALLBACK(src, PROC_REF(delayed_explosion), shot_dart, target, shooter), 2.5 SECONDS)
+				addtimer(CALLBACK(src, PROC_REF(delayed_explosion), shot_dart, target, shooter), 3 SECONDS)
 
 /datum/ammo/rifle/sharp/explosive/drop_dart(loc, obj/projectile/shot_dart, mob/shooter)
 	var/signal_explosion = FALSE
@@ -159,8 +159,7 @@
 		INVOKE_ASYNC(dart, TYPE_PROC_REF(/obj/item/explosive/mine/sharp, prime), shooter)
 	else
 		dart.anchored = TRUE
-		addtimer(CALLBACK(dart, TYPE_PROC_REF(/obj/item/explosive/mine/sharp, deploy_mine), shooter), 3 SECONDS, TIMER_DELETE_ME)
-		addtimer(CALLBACK(dart, TYPE_PROC_REF(/obj/item/explosive/mine/sharp, disarm)), 5 MINUTES, TIMER_DELETE_ME)
+		addtimer(CALLBACK(dart, TYPE_PROC_REF(/obj/item/explosive/mine/sharp, deploy_mine), shooter), 6 SECONDS, TIMER_DELETE_ME)
 
 /datum/ammo/rifle/sharp/explosive/proc/delayed_explosion(obj/projectile/shot_dart, mob/target, mob/shooter)
 	if(ismob(target))

--- a/code/modules/projectiles/guns/specialist/sharp.dm
+++ b/code/modules/projectiles/guns/specialist/sharp.dm
@@ -200,8 +200,7 @@
 		INVOKE_ASYNC(dart, TYPE_PROC_REF(/obj/item/explosive/mine/sharp/incendiary, prime), shooter)
 	else
 		dart.anchored = TRUE
-		addtimer(CALLBACK(dart, TYPE_PROC_REF(/obj/item/explosive/mine/sharp, deploy_mine), shooter), 3 SECONDS, TIMER_DELETE_ME)
-		addtimer(CALLBACK(dart, TYPE_PROC_REF(/obj/item/explosive/mine/sharp, disarm)), 5 MINUTES, TIMER_DELETE_ME)
+		addtimer(CALLBACK(dart, TYPE_PROC_REF(/obj/item/explosive/mine/sharp, deploy_mine), shooter), 6 SECONDS, TIMER_DELETE_ME)
 
 /datum/ammo/rifle/sharp/incendiary/proc/delayed_fire(obj/projectile/shot_dart, mob/target, mob/shooter)
 	if(ismob(target))


### PR DESCRIPTION

# About the pull request

From what i have seen SHARP is perceived as a weaker GL that only does FF and nothing else. This PR is targeted to change that to make SHARP operator as a trapper more rewarding and playstyle worth going for. 
# Explain why it's good for the game

All specialists have separate purposes and unique gimmicks why would not SHARP have one too, this one is a trapper for retreat, flanks or backlines

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: SHARP sticky mines will now stay up permanently
balance: Buffed T3 with one more fire range
balance: Buffed HE sticky mines with little less falloff across tiers
balance: Changed T4 incen sticky fire from UT to White Phosphorus
balance: Changed arm time from 3 to 6 seconds
balance: Changed upgrade time from 30 to 65 seconds
spellcheck: fixed a typo in the examine description of the rifle and incendiary stickie description
/:cl:
