### PR TITLE
Adds a runtime to check for bad trait quantity on map jsons

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -165,7 +165,9 @@ SUBSYSTEM_DEF(mapping)
 		for (var/i in 1 to total_z)
 			traits += list(default_traits)
 	else if (total_z != length(traits))  // mismatch
-		INIT_ANNOUNCE("WARNING: [length(traits)] trait sets specified for [total_z] z-levels in [path]!")
+		var/warning = "WARNING: [length(traits)] trait sets specified for [total_z] z-levels in [path]!"
+		INIT_ANNOUNCE(warning)
+		stack_trace(warning)
 		if (total_z < length(traits))  // ignore extra traits
 			traits.Cut(total_z + 1)
 		while (total_z > length(traits))  // fall back to defaults on extra levels


### PR DESCRIPTION

# About the pull request

This PR simply makes a byond dd log warning also a runtime so it can be caught by linters.

# Explain why it's good for the game

Warnings like
> WARNING: 3 trait sets specified for 1 z-levels in map_files/LV624!

will now be caught by linters.

# Changelog

No player facing changes.
