### PR TITLE
hotfix for #12501 blood decal issue

### DIFF
--- a/code/game/objects/effects/decals/cleanable/blood/tracks.dm
+++ b/code/game/objects/effects/decals/cleanable/blood/tracks.dm
@@ -1,7 +1,7 @@
 // Footprints, tire trails...
 /obj/effect/decal/cleanable/blood/tracks
 	icon = 'icons/effects/fluidtracks.dmi'
-	icon_state = "human2"
+	icon_state = ""
 	amount = 0
 	random_icon_states = null
 	var/coming_state="blood1"


### PR DESCRIPTION

# About the pull request
fixes uncleanable blood trail decals
fixes: #12501

# Explain why it's good for the game

this particular decal has special spawn logic that means it shouldnt start with an icon or it cant be cleaned

# Changelog


:cl:
fix:uncleanable blood decals
/:cl:

