### PR TITLE
Emergency fix for #12514: Restores research headsets to Research loadouts and removes extra webbing

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/medical.dm
+++ b/code/game/machinery/vending/vendor_types/crew/medical.dm
@@ -279,7 +279,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_researcher, list(
 		list("Sling Pouch", 0, /obj/item/storage/pouch/sling, MARINE_CAN_BUY_POUCH, VENDOR_ITEM_REGULAR),
 
 		list("ACCESSORIES (CHOOSE 1)", 0, null, null, null),
-		list("Black Webbing Vest", 0, /obj/item/clothing/accessory/storage/black_vest, MARINE_CAN_BUY_ACCESSORY, VENDOR_ITEM_REGULAR),
+		list("Black Webbing Vest", 0, /obj/item/clothing/accessory/storage/black_vest, MARINE_CAN_BUY_ACCESSORY, VENDOR_ITEM_RECOMMENDED),
 		list("Brown Webbing Vest", 0, /obj/item/clothing/accessory/storage/black_vest/brown_vest, MARINE_CAN_BUY_ACCESSORY, VENDOR_ITEM_REGULAR),
 		list("Leg Pouch", 0, /obj/item/clothing/accessory/storage/black_vest/leg_pouch, MARINE_CAN_BUY_ACCESSORY, VENDOR_ITEM_REGULAR),
 		list("Leg Pouch (Black)", 0, /obj/item/clothing/accessory/storage/black_vest/black_leg_pouch, MARINE_CAN_BUY_ACCESSORY, VENDOR_ITEM_REGULAR),
@@ -431,10 +431,11 @@ GLOBAL_LIST_INIT(cm_vending_clothing_field_doctor, list(
 /obj/effect/essentials_set/medical/researcher
 	spawned_gear_list = list(
 		/obj/item/device/healthanalyzer,
+		/obj/item/storage/firstaid/adv,
 		/obj/item/device/reagent_scanner,
 		/obj/item/clothing/accessory/stethoscope,
 		/obj/item/device/flashlight/pen,
-		/obj/item/clothing/accessory/storage/black_vest,
+		/obj/item/clothing/mask/surgical,
 	)
 
 

--- a/code/game/machinery/vending/vendor_types/crew/medical.dm
+++ b/code/game/machinery/vending/vendor_types/crew/medical.dm
@@ -198,6 +198,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_researcher, list(
 
 		list("IMPORTANT EQUIPMENT", 0, null, null, null),
 		list("Latex Gloves", 0, /obj/item/clothing/gloves/latex, MARINE_CAN_BUY_GLOVES, VENDOR_ITEM_MANDATORY),
+		list("Research Headset", 0, /obj/item/device/radio/headset/almayer/research, MARINE_CAN_BUY_EAR, VENDOR_ITEM_MANDATORY),
 
 		list("SHOULDER PATCHES (CHOOSE 1)", 0, null, null, null),
 		list("Weyland-Yutani Round Patch, Black", 0, /obj/item/clothing/accessory/patch/wy, MARINE_CAN_BUY_MASK, VENDOR_ITEM_REGULAR),

--- a/code/modules/gear_presets/uscm_medical.dm
+++ b/code/modules/gear_presets/uscm_medical.dm
@@ -213,5 +213,6 @@
 	if (new_human.client && new_human.client.prefs && (new_human.client.prefs.backbag == 1))
 		back_item = /obj/item/storage/backpack/marine
 
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/research(new_human), WEAR_L_EAR)
 	new_human.equip_to_slot_or_del(new back_item(new_human), WEAR_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/paper/research_notes/unique/tier_one(new_human), WEAR_IN_BACK)

--- a/code/modules/gear_presets/uscm_medical.dm
+++ b/code/modules/gear_presets/uscm_medical.dm
@@ -213,6 +213,5 @@
 	if (new_human.client && new_human.client.prefs && (new_human.client.prefs.backbag == 1))
 		back_item = /obj/item/storage/backpack/marine
 
-	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/research(new_human), WEAR_L_EAR)
 	new_human.equip_to_slot_or_del(new back_item(new_human), WEAR_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/paper/research_notes/unique/tier_one(new_human), WEAR_IN_BACK)


### PR DESCRIPTION

# About the pull request

1. Restores deleted Research headsets from Research loadouts.
2. Removes extra webbing from Research essentials in ColMarTechs. 
3. Adds Advanced First Aid Kit and Surgical Mask to Research essentials.

# Explain why it's good for the game
1. Research cannot receive headsets unless they beg for only one from the CMO's extra loadout sets. I had not realized the recent Civilianization PR removed headsets from Research loadouts before removing them from the ColMarTech. 
2. I guess people don't want a webbing if they choose a tie instead?
3. Eh. Why not?

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Managed to get everything in one shot. Essentials were vended, research headset is available for purchase.
<img width="1084" height="832" alt="image" src="https://github.com/user-attachments/assets/745c6f98-212b-4b29-b181-df8a2f21f72a" />

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Adds Advanced First Aid Kit and Surgical Mask to Research essentials.
del: Removes extra webbing from Research essentials in ColMarTechs. 
fix: Restores deleted Research headsets from Research Wardrobes.
/:cl:
