### PR TITLE
Fix: Shutters not using emp_proof

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -153,7 +153,7 @@
 
 /obj/structure/machinery/door/emp_act(severity)
 	. = ..()
-	if(. == FALSE)
+	if(!.)
 		return .
 	if(prob(20/severity) && use_power)
 		open()

--- a/code/game/machinery/doors/poddoor/poddoor.dm
+++ b/code/game/machinery/doors/poddoor/poddoor.dm
@@ -232,10 +232,6 @@
 	unslashable = TRUE
 	emp_proof = TRUE
 
-/obj/structure/machinery/door/poddoor/hybrisa/secure_red_door/emp_act(power, severity)
-	..()
-	return TRUE
-
 /obj/structure/machinery/door/poddoor/hybrisa/ultra_reinforced_door
 	desc = "A heavily reinforced metal-alloy door, designed to be virtually indestructible—nothing can penetrate its defenses."
 	icon_state = "udoor1"
@@ -247,8 +243,3 @@
 /obj/structure/machinery/door/poddoor/hybrisa/ultra_reinforced_door/open
 	density = FALSE
 
-/obj/structure/machinery/door/poddoor/hybrisa/ultra_reinforced_door/emp_act(power, severity)
-	if(emp_proof)
-		return FALSE
-	..()
-	return TRUE

--- a/code/game/machinery/doors/poddoor/shutters/shutters.dm
+++ b/code/game/machinery/doors/poddoor/shutters/shutters.dm
@@ -199,13 +199,8 @@
 	id = "bot_uniforms"
 	unacidable = TRUE
 	unslashable = TRUE
-
-/obj/structure/machinery/door/poddoor/shutters/almayer/uniform_vendors/ex_act(severity)
-	return
-
-/obj/structure/machinery/door/poddoor/shutters/almayer/uniform_vendors/emp_act(severity)
-	. = ..()
-	return
+	emp_proof = TRUE
+	explo_proof = TRUE
 
 /obj/structure/machinery/door/poddoor/shutters/almayer/uniform_vendors/attackby(obj/item/attacking_item, mob/user)
 	if(HAS_TRAIT(attacking_item, TRAIT_TOOL_CROWBAR) || attacking_item.pry_capable)

--- a/code/game/machinery/doors/poddoor/shutters/shutters.dm
+++ b/code/game/machinery/doors/poddoor/shutters/shutters.dm
@@ -123,12 +123,6 @@
 	breakable = FALSE
 	explo_proof = TRUE
 
-/obj/structure/machinery/door/poddoor/yautja/emp_act(power, severity)
-	if(emp_proof)
-		return FALSE
-	..()
-	return TRUE
-
 /obj/structure/machinery/door/poddoor/yautja/hunting_grounds
 	name = "Preserve Shutter"
 	id = "Yautja Preserve"


### PR DESCRIPTION

# About the pull request
Title. Clean up some other things that had emp_act despite not actually needing it.
Also clean up the ex_act for the uniform shutters.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Stops people G2 spamming the shutters open
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Uniform shutters are now actually EMP Proof.
/:cl:
