### PR TITLE
More Punishing Ground Crash

### DIFF
--- a/code/controllers/subsystem/hijack.dm
+++ b/code/controllers/subsystem/hijack.dm
@@ -128,6 +128,9 @@ SUBSYSTEM_DEF(hijack)
 	/// A list of all APCs on the main ship
 	var/list/obj/structure/machinery/power/apc/almayer/apcs = list()
 
+	/// A list of all powernets on the main ship
+	var/list/datum/powernet/powernets = list()
+
 /datum/controller/subsystem/hijack/Initialize(timeofday)
 	RegisterSignal(SSdcs, COMSIG_GLOB_GENERATOR_SET_OVERLOADING, PROC_REF(on_generator_overload))
 
@@ -192,6 +195,16 @@ SUBSYSTEM_DEF(hijack)
 
 			if((sd_time_remaining <= 0) && !sd_detonated)
 				detonate_sd()
+
+		// Handle power shortage by ship being cracked in half
+		if(crashed && hijack_status == HIJACK_OBJECTIVES_GROUND_CRASH)
+			for(var/obj/structure/machinery/power/apc/almayer/apc as anything in apcs)
+				if(prob(5))
+					apc.shorted = TRUE
+					playsound(apc.loc, 'sound/effects/sparks2.ogg', 25, 1)
+					var/datum/effect_system/spark_spread/spark = new /datum/effect_system/spark_spread
+					spark.set_up(2, 1, apc)
+					spark.start()
 		return
 
 	if(!SSticker.mode.count_marines(SSmapping.levels_by_trait(ZTRAIT_MARINE_MAIN_SHIP)))

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -591,7 +591,7 @@
 		return
 
 	var/list/shortly_exploding_pipes = list()
-	var/explode_count = SShijack?.hijack_status == HIJACK_OBJECTIVES_GROUND_CRASH ? HIJACK_EXPLOSION_COUNT : HIJACK_CRASHED_EXPLOSION_COUNT
+	var/explode_count = SShijack?.hijack_status == HIJACK_OBJECTIVES_GROUND_CRASH ? HIJACK_CRASHED_EXPLOSION_COUNT : HIJACK_EXPLOSION_COUNT
 	for(var/i = 1 to explode_count)
 		shortly_exploding_pipes += pick(GLOB.mainship_pipes)
 

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -4,6 +4,8 @@
 #define PODLOCKS_OPEN_WAIT (45 MINUTES) // CORSAT pod doors drop at 12:45
 /// How many pipes explode at a time during hijack?
 #define HIJACK_EXPLOSION_COUNT 5
+/// How many pipes explode at a time after a ship ground crash?
+#define HIJACK_CRASHED_EXPLOSION_COUNT 10
 /// What percent do we consider a 'majority?' to win
 #define MAJORITY 0.5
 /// How long to delay the round completion (command is immediately notified)
@@ -589,7 +591,8 @@
 		return
 
 	var/list/shortly_exploding_pipes = list()
-	for(var/i = 1 to HIJACK_EXPLOSION_COUNT)
+	var/explode_count = SShijack?.hijack_status == HIJACK_OBJECTIVES_GROUND_CRASH ? HIJACK_EXPLOSION_COUNT : HIJACK_CRASHED_EXPLOSION_COUNT
+	for(var/i = 1 to explode_count)
 		shortly_exploding_pipes += pick(GLOB.mainship_pipes)
 
 	for(var/obj/structure/pipes/exploding_pipe as anything in shortly_exploding_pipes)

--- a/code/game/objects/structures/pipes/pipes.dm
+++ b/code/game/objects/structures/pipes/pipes.dm
@@ -16,6 +16,8 @@
 
 	/// Whether or not the pipe will explode (when on the Almayer) during hijack
 	var/explodey = TRUE
+	/// Whether the pipe is currently exploding
+	var/exploding = FALSE
 	/// The grenade subtypes that pipes will use when they explode
 	var/static/list/exploding_types = list(/obj/item/explosive/grenade/high_explosive/bursting_pipe, /obj/item/explosive/grenade/incendiary/bursting_pipe)
 
@@ -199,6 +201,9 @@
  * time_till: required, the time until the explosion occurs. The sound file lasts 5 seconds.
  */
 /obj/structure/pipes/proc/warning_explode(time_till)
+	if(exploding)
+		return // Already going to happen
+
 	if(!time_till)
 		CRASH("No time given to /warning_explode.")
 	var/turf/position = get_turf(src)
@@ -209,6 +214,7 @@
 	playsound(src, 'sound/effects/pipe_hissing.ogg', vol = 40)
 	addtimer(CALLBACK(src, PROC_REF(kablooie)), time_till)
 	visible_message(SPAN_HIGHDANGER("[src] begins hissing violently!"))
+	exploding = TRUE
 
 /**
  * Makes the pipe go boom.

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1396,6 +1396,11 @@ GLOBAL_LIST_INIT(apc_wire_descriptions, flatten_numeric_alist(alist(
 	if(is_mainship_level(z))
 		SShijack.apcs += src
 
+/obj/structure/machinery/power/apc/almayer/connect_to_network()
+	. = ..()
+	if(is_mainship_level(z) && powernet)
+		SShijack.powernets |= powernet
+
 /obj/structure/machinery/power/apc/almayer/Destroy()
 	SShijack.apcs -= src
 	return ..()

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -110,6 +110,7 @@
 
 // rebuild all power networks from scratch
 /proc/makepowernets()
+	SShijack?.powernets.Cut()
 	for(var/datum/powernet/PN in GLOB.powernets)
 		del(PN) //not qdel on purpose, powernet is still using del.
 	GLOB.powernets.Cut()

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -16,12 +16,13 @@
 /datum/powernet/process()
 	load = newload
 	newload = 0
-	avail = newavail
+	if(!SShijack || !SShijack.crashed || SShijack.hijack_status != HIJACK_OBJECTIVES_GROUND_CRASH || !(src in SShijack.powernets))
+		avail = newavail
+	else // Powernets for a ground crashed ship no longer are powered
+		avail = 0
 	newavail = 0
 
-
 	viewload = 0.8*viewload + 0.2*load
-
 	viewload = floor(viewload)
 
 	var/numapc = 0


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #11368 making ground crash more punishing:
- Pipe explosions are doubled in quantity
- Ship powernet loses all available power
- All ship apcs will randomly short out over time (repairable but you still ultimately only have its battery)

# Explain why it's good for the game

In general it doesn't make sense why a ship cracked in half would still be electrically working, but in addition feedback has been that groundcrash has not felt meaningful enough for xenos to achieve or marines to avoid.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Hijack:
<img width="2156" height="1173" alt="image" src="https://github.com/user-attachments/assets/0efba193-411e-44fc-b3c0-da24621bd260" />

After ground crash has hit the ground:
<img width="2147" height="980" alt="image" src="https://github.com/user-attachments/assets/3b6a0f6f-aabd-4c39-b1dc-f3629d3a2a70" />

After random fault for this APC:
<img width="1065" height="930" alt="image" src="https://github.com/user-attachments/assets/a430eaf3-e662-4ae3-932c-e6e19081bd67" />

</details>


# Changelog
:cl: Drathek
balance: Almayer ground crash now breaks the powernet and APCs will randomly short out over time
/:cl:
