### PR TITLE
No double backdrop for openspace

### DIFF
--- a/code/game/turfs/open_space.dm
+++ b/code/game/turfs/open_space.dm
@@ -53,8 +53,9 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 	var/turf/below = get_turf_below()
 	var/depth = 0
 	while(below)
-		new /obj/vis_contents_holder(src, below, depth, !istype(below, /turf/open_space))
-		if(!istransparentturf(below))
+		var/below_transparent = istransparentturf(below)
+		new /obj/vis_contents_holder(src, below, depth, !below_transparent || !istype(below, /turf/open_space))
+		if(!below_transparent)
 			break
 		below = SSmapping.get_turf_below(below)
 		depth++

--- a/code/game/turfs/open_space.dm
+++ b/code/game/turfs/open_space.dm
@@ -53,7 +53,7 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 	var/turf/below = get_turf_below()
 	var/depth = 0
 	while(below)
-		new /obj/vis_contents_holder(src, below, depth)
+		new /obj/vis_contents_holder(src, below, depth, !istype(below, /turf/open_space))
 		if(!istransparentturf(below))
 			break
 		below = SSmapping.get_turf_below(below)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -132,10 +132,11 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	anchored = TRUE
 
-/obj/vis_contents_holder/Initialize(mapload, vis, offset)
+/obj/vis_contents_holder/Initialize(mapload, vis, offset, backdrop=TRUE)
 	. = ..()
 	plane -= offset
-	vis_contents += GLOB.openspace_backdrop_one_for_all
+	if(backdrop)
+		vis_contents += GLOB.openspace_backdrop_one_for_all
 	vis_contents += vis
 	name = null // Makes it invisible on right click
 


### PR DESCRIPTION

# About the pull request

This PR simply makes it where an openspace looking at an openspace does not add the openspace backdrop (causing it to be doubled+ up). I sort of want to also try just making it where openspaces don't even put other openspaces into vis contents, but then things moving around in that intermediate space are either going to have to update vis contents (which is expensive) or they're just be not rendered at all.

Visually I don't think there's a difference (but there likely would be for airborne things), so even better (see screenshots).

# Explain why it's good for the game

Less unnecessary things being rendered, also may be the cause of some visual artifacts when at larger zoom levels.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Before:
<img width="2560" height="1392" alt="before" src="https://github.com/user-attachments/assets/9bc2aefe-8289-4511-99a8-39dce698868a" />
<img width="2560" height="1392" alt="before2" src="https://github.com/user-attachments/assets/701f8417-7452-47b1-8768-33292a3cff4f" />

<img width="952" height="675" alt="image" src="https://github.com/user-attachments/assets/786faaa4-e26b-4c85-aaea-0d0e4d6b3698" />


After:
<img width="2560" height="1392" alt="after" src="https://github.com/user-attachments/assets/1fc12541-8de2-4cc5-9b55-aceab3d102a7" />
<img width="2560" height="1392" alt="after2" src="https://github.com/user-attachments/assets/89d426fa-9b38-47e0-9108-70a80a2c4f4c" />

<img width="949" height="683" alt="image" src="https://github.com/user-attachments/assets/64cee91b-912a-4988-b005-7464560c26d8" />


</details>


# Changelog
:cl: Drathek
fix: Openspace no longer doubles up the openspace backdrop when viewing an intermediate openspace
/:cl:
