### PR TITLE
Hotfix for Effects GC PR (#12457) - Fixes the Synth Defib

### DIFF
--- a/code/game/objects/items/devices/defibrillator.dm
+++ b/code/game/objects/items/devices/defibrillator.dm
@@ -237,7 +237,7 @@
 		return FALSE
 
 	//Do this now, order doesn't matter
-	sparks.start(do_NOT_delete = TRUE)
+	sparks?.start(do_NOT_delete = TRUE)
 	dcell.use(charge_cost)
 	update_icon()
 	playsound(get_turf(src), sound_release, 25, 1)


### PR DESCRIPTION

# About the pull request

Follow up to #12457 

Little oopsie, I forgot sparks on defibs are technically optional. Not that the feature even worked before, apparently......

# Changelog
:cl:
fix: Hotfixed an issue causing the Synthetic Reset Keys to be unusable
fix: The Synth Reset Keys now makes no sparks, as intended
/:cl:
