### PR TITLE
Fix: Daniels not getting their verbs

### DIFF
--- a/code/modules/gear_presets/synths.dm
+++ b/code/modules/gear_presets/synths.dm
@@ -706,6 +706,7 @@
 	languages = list(LANGUAGE_ENGLISH, LANGUAGE_APOLLO, LANGUAGE_JAPANESE, LANGUAGE_SPANISH)
 	/// Used to set species when loading race
 	var/joe_type = SYNTH_WORKING_JOE
+	var/corp_label = /datum/element/corp_label/seegson
 
 /datum/equipment_preset/synth/working_joe/New()
 	. = ..()
@@ -714,6 +715,8 @@
 /datum/equipment_preset/synth/working_joe/load_race(mob/living/carbon/human/new_human)
 	. = ..()
 	new_human.set_species(joe_type)
+	if(corp_label)
+		new_human.AddElement(corp_label)
 	new_human.bubble_icon = "robot"
 	new_human.gender = MALE
 	new_human.flavor_text = ""
@@ -877,6 +880,7 @@
 	faction_group = list(FACTION_UPP)
 	faction = FACTION_UPP
 	languages = list(LANGUAGE_RUSSIAN, LANGUAGE_GERMAN, LANGUAGE_SPANISH, LANGUAGE_CHINESE, LANGUAGE_ENGLISH)
+	corp_label = /datum/element/corp_label/norcomm
 
 /datum/equipment_preset/synth/working_joe/upp/New()
 	. = ..()
@@ -959,6 +963,7 @@
 	languages = list(LANGUAGE_ENGLISH, LANGUAGE_ARTEMIS)
 	minimap_icon = "daniel"
 	joe_type = SYNTH_DANIEL
+	corp_label = /datum/element/corp_label/wy
 
 /datum/equipment_preset/synth/working_joe/daniel/New()
 	. = ..()

--- a/code/modules/gear_presets/synths.dm
+++ b/code/modules/gear_presets/synths.dm
@@ -713,7 +713,6 @@
 	access = get_access(ACCESS_LIST_MARINE_ALL)
 
 /datum/equipment_preset/synth/working_joe/load_race(mob/living/carbon/human/new_human)
-	. = ..()
 	new_human.set_species(joe_type)
 	if(corp_label)
 		new_human.AddElement(corp_label)

--- a/code/modules/mob/living/carbon/human/species/working_joe/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/working_joe/_species.dm
@@ -38,14 +38,9 @@
 /datum/species/synthetic/gen_two/gen_one/working_joe/daniel/handle_death(mob/living/carbon/human/dying_joe, gibbed)
 	playsound(get_turf(dying_joe), "daniel_death", 25, FALSE)
 
-/datum/species/synthetic/gen_two/gen_one/working_joe/daniel/handle_post_spawn(mob/living/carbon/human/joe)
-	give_action(joe, /datum/action/joe_emote_panel)
-	joe.AddElement(/datum/element/corp_label/wy)
-
 /datum/species/synthetic/gen_two/gen_one/working_joe/handle_post_spawn(mob/living/carbon/human/joe)
 	. = ..()
 	give_action(joe, /datum/action/joe_emote_panel)
-	joe.AddElement(/datum/element/corp_label/seegson)
 
 // Special death noise for Working Joe
 /datum/species/synthetic/gen_two/gen_one/working_joe/handle_death(mob/living/carbon/human/dying_joe, gibbed)


### PR DESCRIPTION

# About the pull request
Proc needs to call parent for verb adding, so just move the corp label stuff to to load_race in the equipment_preset stuff
Give UPP Joes their correct corp label
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Fix good.
Apparently Dzhos got a seegson label, but they're built by norcomm?
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="1234" height="1313" alt="image" src="https://github.com/user-attachments/assets/165bd9a1-a8d5-4bd9-87eb-91dff65b6c7d" />

</details>


# Changelog
:cl:
add: Dzho's get a label that they're made by norcomm
fix: Daniel's get their synthetic verbs once again
/:cl:
