### PR TITLE
Tweak: Add 2 ASRS console boards to the circuit board vendor.

### DIFF
--- a/code/game/machinery/vending/vendor_types/engineering.dm
+++ b/code/game/machinery/vending/vendor_types/engineering.dm
@@ -89,6 +89,7 @@
 		list("ID Computer", 2, /obj/item/circuitboard/computer/card, VENDOR_ITEM_REGULAR),
 		list("Security Records", 2, /obj/item/circuitboard/computer/secure_data, VENDOR_ITEM_REGULAR),
 		list("Supply Ordering Console", 2, /obj/item/circuitboard/computer/ordercomp, VENDOR_ITEM_REGULAR),
+		list("ASRS Console", 2, /obj/item/circuitboard/computer/supplycomp, VENDOR_ITEM_REGULAR),
 		list("Research Data Terminal", 2, /obj/item/circuitboard/computer/research_terminal, VENDOR_ITEM_REGULAR),
 		list("P.A.C.M.A.N Generator", 1, /obj/item/circuitboard/machine/pacman, VENDOR_ITEM_REGULAR),
 		list("Auxiliary Power Storage Unit", 2, /obj/item/circuitboard/machine/ghettosmes, VENDOR_ITEM_REGULAR),


### PR DESCRIPTION

# About the pull request
One line to add ASRS circuit to the circuit board vendor
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Ehhhhh if all of the ASRS consoles get melted they have no boards to make new ones. Now they have two.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="570" height="693" alt="Screenshot 2026-06-26 094735" src="https://github.com/user-attachments/assets/5452209f-87ee-4159-8d1b-a76f3e0a0217" />

</details>


# Changelog
:cl:
add: 2 ASRS console circuit boards to the circuit board vendor.
/:cl:
