### PR TITLE
Fix: Strain reseting no longer removes banish lock on evolution

### DIFF
--- a/code/datums/emergency_calls/forsaken_xenos.dm
+++ b/code/datums/emergency_calls/forsaken_xenos.dm
@@ -27,6 +27,5 @@
 	new_member.transfer_to(new_xeno, TRUE)
 
 	new_xeno.set_hive_and_update(XENO_HIVE_FORSAKEN)
-	new_xeno.lock_evolve = TRUE
 
 	QDEL_NULL(current_mob)

--- a/code/modules/mob/living/carbon/xenomorph/Evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Evolution.dm
@@ -262,7 +262,7 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 		to_chat(src, SPAN_WARNING("Our link to the hive is being suppressed...we should wait a bit."))
 		return FALSE
 
-	if(lock_evolve)
+	if(lock_evolve || (hive.evolution_locked && !islarva(src)))
 		if(banished)
 			to_chat(src, SPAN_WARNING("We are banished and cannot reach the hivemind."))
 		else
@@ -381,7 +381,7 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 	if(length(caste.deevolves_to) < 1)
 		to_chat(src, SPAN_XENOWARNING("We can't deevolve any further."))
 		return
-	if(lock_evolve)
+	if(lock_evolve || hive.evolution_locked)
 		if(banished)
 			to_chat(src, SPAN_WARNING("We are banished and cannot reach the hivemind."))
 		else
@@ -477,6 +477,7 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 	new_xeno.generate_name()
 	if(new_xeno.client)
 		new_xeno.set_lighting_alpha(level_to_switch_to)
+	new_xeno.lock_evolve = lock_evolve
 
 	// If the player has lost the Deevolve verb before, don't allow them to do it again
 	if(!(/mob/living/carbon/xenomorph/verb/Deevolve in verbs))

--- a/code/modules/mob/living/carbon/xenomorph/Evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Evolution.dm
@@ -459,6 +459,7 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 
 	new_xeno.built_structures = built_structures.Copy()
 	built_structures = null
+	new_xeno.lock_evolve = lock_evolve
 
 	if(mind)
 		mind.transfer_to(new_xeno)
@@ -477,7 +478,6 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 	new_xeno.generate_name()
 	if(new_xeno.client)
 		new_xeno.set_lighting_alpha(level_to_switch_to)
-	new_xeno.lock_evolve = lock_evolve
 
 	// If the player has lost the Deevolve verb before, don't allow them to do it again
 	if(!(/mob/living/carbon/xenomorph/verb/Deevolve in verbs))

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -60,6 +60,7 @@
 	var/dynamic_evolution = TRUE
 	var/evolution_rate = 3 // Only has use if dynamic_evolution is false
 	var/evolution_bonus = 0
+	var/evolution_locked = FALSE
 
 	var/allow_no_queen_actions = FALSE
 	var/allow_no_queen_evo = FALSE
@@ -1311,6 +1312,7 @@
 	latejoin_burrowed = FALSE
 	see_humans_on_tacmap = TRUE
 	tacmap_requires_queen_ovi = FALSE
+	evolution_locked = TRUE
 
 	need_round_end_check = TRUE
 


### PR DESCRIPTION

# About the pull request
Also add just a hive lock on evolution. Currently just for Forsaken. And remove setting the lock_evolve cause we now don't need it for them
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Bug bad.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="958" height="1127" alt="image" src="https://github.com/user-attachments/assets/a1648000-059b-4c4a-8761-20208f7de38f" />

</details>


# Changelog
:cl:
fix: Strain Resets no longer bypass evolution locks like banishment
/:cl:
