### PR TITLE
Tip grammar pass + a minor tweak to one

### DIFF
--- a/strings/marinetips.txt
+++ b/strings/marinetips.txt
@@ -9,7 +9,7 @@ The Orbital Bombardment is always closer than it looks.
 Never inject a marine you haven't scanned! You might overdose them; ESPECIALLY so with an emergency autoinjector.
 Check perma-dead marines (skull icon on medhud) for useful gear, such as webbings, AP ammo, or binoculars.
 Always check for traps beneath loose objects - it could save your life!
-Bring a fire extinguisher, it might just save someone's life. They can remove flames that block a push, remove acid from other marines, as well as put out people on fire.
+Bring a fire extinguisher, it might just save someone's life. They can remove flames that block a push, remove acid from other marines and barricades, as well as put out people on fire.
 Trading your life for a Xenomorph's is almost always worth it.
 If another marine is stunned, you can click on them with help intent with an open hand to shake them up faster.
 No round has ever been won behind a barricade. Apart from the ones that have.
@@ -18,7 +18,7 @@ Try not to block off pushes when using a flamethrower.
 Recover bodies whenever possible. Even if the marine is unrevivable, useful gear and ammunition can still be salvaged.
 A lack of supplies at the FOB can cost you the round. Make sure to unpack supply crates, weapons, and ammo for your fellow marines.
 More dakka is not good when it is directed towards your teammates.
-Never place barricades facing each other - Not only does this block bullets, both barricades are damaged at once if one is slashed!
+Never place barricades facing each other. Not only does this block bullets, both barricades are damaged at once if one is slashed!
 An FOB is as strong as its weakest part. Secure all flanks, remember that walls can be pried open.
 Flamethrowers: Green fire is weak but has a lot of utility, such as melting through armor and being instantly extinguishable. Queens and Ravagers are flameproof. Most flamethrower damage comes from the initial burst, not the flame on the ground. Don't forget you have an underbarrel extinguisher.
 CPR extends the defib timer on dead marines. It can be done by clicking the dead marine on help intent with an open hand. Make sure to get the rhythm correct!
@@ -44,10 +44,10 @@ If a grenade comes your way, hit the deck! Lying down will reduce damage and let
 You can grab items from second-level storage, such as a splint in a first aid kit stored inside a satchel.
 By right clicking your medical belt and selecting "toggle belt mode", you can take pills out of bottles by simply clicking them once.
 You can put screwdrivers, cigarettes, and some other things in your second ear slot!
-Pilots : there is one of each engine upgrade in the hangar at the start of the round, saving you the point cost of having to print out a pair of each.
+Pilots: There is one of each engine upgrade in the hangar at the start of the round, saving you the point cost of having to print out a pair of each.
 You can use a hand labeler (as found in squad prep rooms) to name your equipment and make it less likely to be stolen.
 You can use a health analyzer in hand (Z key) to check the last scan readout from it.
-Holocards are a useful triage tool for doctors and medics. Ensure you assign them (examine the marine with shift-click and select an appropriate holocard) to marines who have taken damage that cannot be healed without surgery. (Hint : major organ damage or larval infection = red card!)
+Holocards are a useful triage tool for doctors and medics. Ensure you assign them (examine the marine with shift-click and select an appropriate holocard) to marines who have taken damage that cannot be healed without surgery. (Hint: Major organ damage or larval infection = red card!)
 Escape pods are designed for only three occupants - more than that, or if a larger xenomorph is in the pod, and it will malfunction and blow up on launch.
 A misloaded OB can deviate severely from the intended target area - ensure you load them correctly!
 The XO and CO are trained in Power Loader use and engineering, and can load the OB.
@@ -56,24 +56,24 @@ Boilers emit light - not every glow from around the corner is friendly!
 The amount of items in Requisitions and Squad Preparations depend on how many players readied up at the start of the round.
 You can carry a variety of items inside your helmet - from gauze and cigarettes to flares and screwdrivers.
 CIC staff can track every USCM-aligned person via the suit sensors console and overwatch console - useful for finding escaped prisoners or dead marines.
-When the M7 RPG is fired, it creates a substantial shockwave behind it that can stun and harm marines standing too close. Watch your backblast!
+When the M5 RPG is fired, it creates a substantial shockwave behind it that can stun and harm marines standing too close. Watch your backblast!
 Remember that you need to put a defibrillator's paddles away in order to store it.
 W-Y PMCs do not have marine IFF. Don't fire Smartguns at them!
 To talk on multiple radio channels at once, put a COMMA [,] before your message and add up to four prefixes. E.g, ,abcd talks on the main four squad channels at once.
 Put .w or :w before your message to whisper. Another way to whisper is to use the verb "whisper" in the IC tab or command bar.
-For Vehicle Crewmen : it is often safer to repair the parts of your APC or tank inside the vehicle than outside it.
+For Vehicle Crewmen: It is often safer to repair the parts of your APC or tank inside the vehicle than outside it.
 It is almost always faster to do surgery manually than in the autodoc.
 To check your skills, go to the IC tab and click "view skills".
 Minirockets pack the most punch per cost as far as CAS weaponry is concerned.
 The U7 underbarrel shotgun can instantly break down both resin doors and mechanical airlocks, and it's not bad at breaking walls down either.
 You can find breaching charges in Requisitions or the Squad Engineer vendor. They function like C4, but can be deployed and explode much quicker, and release powerful shrapnel on the opposite side. They require minor engineering knowledge, which can be obtained from pamphlets.
 Armor piercing ammunition does less damage to unarmored targets.
-Requisitions may not grant you service if you are a 'pajamarine' : a marine in cryosleep attire. Be sure to dress up!
+Requisitions may not grant you service if you are a 'pajamarine': a marine in cryosleep attire. Be sure to dress up!
 You can insert empty pill bottles into ChemMasters before creating pills to have them automatically inserted.
 Nurses can practice a full range of surgeries on Professor DUMMY. Ask the gods to give you one if you see (or are) a nurse practicing.
 Drinks from the hot drinks machine warm you up.
 Be careful! Barricades block grenades, and indeed all thrown items, from the front if they're barbed up.
-CAS Fire Missions doubles the accuracy of fired weapons, which can be substantial.
+CAS Fire Missions double the accuracy of fired weapons, which can be substantial.
 Painkillers do not stack. Only the strongest has any effect.
 Don't underestimate the mortar: with ammo and proper communication it can hit surprisingly hard.
 You can shoot through tents, but they won't protect you much in return.
@@ -89,12 +89,12 @@ A night vision HUD optic can be recharged by removing it with a screwdriver, the
 You can put a pistol belt on your suit slot. (Just grab a rifle instead.)
 Alt-clicking the Squad Leader tracker lets you track your fireteam leader instead.
 Armor consistently protects you from damage to your chest, arms, and legs, but does not protect hands and feet. Take the wiki damage values as a best-case scenario.
-You can click on your Security Access Tuner (multitool) in your hand to locate the area's APC if there is one.
+You can use your Security Access Tuner (multitool) in your hand to locate the area's APC if there is one.
 Need help learning the game and these tips aren't enough? Use MentorHelp or try to get ahold of your ship's Senior Enlisted Advisor.
 Clicking on your sprite with help intent will let you check your body, seeing where your fractures and other wounds are.
 Armor has insulative properties - taking it off will help you cool off and take less damage faster if you've been set on fire.
-Both foldable cades & plasteel cades if loosened and folded down can be transported in crates! In this way, you can use the crate as a portable breach-repair kit, or dragged (or carried via Power Loader) to an unsecure area for quick defensive set up.
-The fuel tank pouch doesn't just carry fuel for an incinerator- they can also carry full-size extinguishers. Toolbelts & tool pouches also may hold miniature extinguishers.
+Both foldable cades & plasteel cades if loosened and folded down can be transported in crates! In this way, you can use the crate as a portable breach-repair kit, or drag (or carry via Power Loader) it to an unsecure area for quick defensive set up.
+The fuel tank pouch doesn't just carry fuel for an incinerator - they can also carry full-size extinguishers. Toolbelts & tool pouches also may hold miniature extinguishers.
 The M2C heavy machine gunner belt rig can also carry C4, breaching charges, and most tools.
 You can always multitask as Medic, such as by using pills or healing kits at the same time as defibrillator.
 The nuclear ordnance requires BOTH communication towers to be actively held to decrypt the nuclear codes.

--- a/strings/memetips.txt
+++ b/strings/memetips.txt
@@ -46,14 +46,14 @@ If it's stupid but it works, it isn't stupid.
 If it's stupid but it works, it's still stupid and you got lucky.
 Corroders aren't real. They can't hurt you.
 ARES is not sentient. It has no feelings and its only thoughts are pre-programmed subroutines.
-Remember that as Yautja HPCs are your primary weapons.
+Remember that as Yautja, HPCs are your primary weapons.
 You can always bully staff into giving you more awesome tips.
 Embrace the suck.
 Jump out of the Alamo during transit to deploy quicker than other players.
-Synthetics aren't actually player controlled. Instead, their dialogue and movements are recieved real time from ChatGPT.
+Synthetics aren't actually player controlled. Instead, their dialogue and movements are received in real time from ChatGPT.
 Thank God the Xenos can’t fly, right?
 Remember, an OB is better than no OB. Don't know what those coords are? fire it anyways!
-Remember to pay your drone tax!
+Remember to pay your Drone tax!
 There will always be 20 medics whenever you roll medic, and 0 medics whenever you don’t.
 As a squad leader, your job is to stand around and pretend you’re useful by yelling at people, before being immediately capped for cinematic value.
 If you think your situation is bad, remember that things can always get worse.

--- a/strings/xenotips.txt
+++ b/strings/xenotips.txt
@@ -1,7 +1,7 @@
 Acid pillars can be sneakily placed next to a door in order to surprise marines.
 Acid pillars are amazing at extinguishing fellow sisters- Place them near the frontline for maximum effect.
 Alien structures like clusters, walls, or pillars are vital to your victory, be it as cover or to delay and funnel marines.
-Always thank your drones and Hivelords for supporting the hive!
+Always thank your Drones and Hivelords for supporting the hive!
 Don't underestimate survivors. They have no armor but that makes them very fast, they're inherently hardier than marines and have various tricks up their sleeves.
 While the Queen is de-ovied, the hive does not gain evolution points.
 Try out new castes or strains that you might have passed up initially. You might find them to be surprisingly fun.
@@ -28,7 +28,7 @@ You can dodge pounces that aren't aimed directly at you by laying down.
 You may rest immediately during a pounce to pounce straight through mobs. It's not very practical or useful though.
 Pouncing someone who is buckled to a chair will still stun them, but you won't jump into their tile and they will not be knocked to the ground.
 Star shell dust from said grenades is just as meltable as normal flares.
-You can join the hive as a living Facehugger by clicking on the hive's Eggmorpher. This works on other hives too..
+You can join the hive as a living Facehugger by clicking on the hive's Eggmorpher. This works on other hives too.
 Playable Facehuggers can leap onto targets with a one-second windup, but this will only infect them if they are adjacent to it. Otherwise, it will simply knock them down for a small duration.
 As a Facehugger, you cannot talk in hivemind, but you can still open Hive Status and overwatch your sisters. This can be useful if you're locating other Facehuggers, flanker castes, or trying to learn from experienced Facehugger players.
 Shift-clicking the Queen indicator will tell you what area you are in, on the map.
@@ -44,8 +44,8 @@ Applying acid to flares makes them burn faster.
 Melting weapons, ammo or other valuables owned by marines is a good way to debilitate them.
 The secrete acid shortcut is (by default) Shift + C.
 Placing acid traps under map debris such as metal sheets, wooden planks or other semi-large to large items is good for catching marines by surprise.
-Burrower can place tunnels underneath tables or lockers.
-Lesser drones and facehuggers cannot speak or use the Hivemind for three minutes after spawning.
+Burrowers can place tunnels underneath tables or lockers.
+Lesser Drones and Facehuggers cannot speak or use the Hivemind for three minutes after spawning.
 Alt-clicking on the Queen tracker allows you to set it to also track the Hive Core, any living leaders or any existing tunnels. Tunnels are ordered by closest to furthest; top to bottom.
 Be mindful of not blocking the escape of injured sisters.
 As a Xenomorph, you are able to melt advanced body scanners, sleepers, MarineMeds and limb printers.


### PR DESCRIPTION

# About the pull request

I saw a colon with bad spacing on it ingame and went through all the tip files while my character was dead.

# Explain why it's good for the game

I like well written tips

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

It's just string edits, there is nothing to test.  

</details>


# Changelog

:cl: Orchidfox
spellcheck: Improved grammar in a bunch of tips
/:cl: