### PR TITLE
Adds K92 Maintenance Jacks to Requisitions

### DIFF
--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -143,6 +143,7 @@
 		list("W-Y brand rechargeable mini-battery", floor(scale * 3), /obj/item/cell/crap, VENDOR_ITEM_REGULAR),
 
 		list("MISCELLANEOUS", -1, null, null),
+		list("K92 Maintenance Jack", floor(scale * 1), /obj/item/maintenance_jack, VENDOR_ITEM_REGULAR),
 		list("Entrenching Tool", floor(scale * 4), /obj/item/tool/shovel/etool/folded, VENDOR_ITEM_REGULAR),
 		list("Gas Mask", floor(scale * 10), /obj/item/clothing/mask/gas, VENDOR_ITEM_REGULAR),
 		list("Machete Scabbard (Full)", floor(scale * 6), /obj/item/storage/large_holster/machete/full, VENDOR_ITEM_REGULAR),


### PR DESCRIPTION

# About the pull request

Title. Requested by synthetic senator.

# Explain why it's good for the game

For a tool that's nothing more than a combined two-in-one wrench and crowbar that's so large it can't fit in any storage item, it should be available in a limited quantity to engineers instead of being exclusive to Working Joes and the synthetic.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Added K92 Maintenance Jacks to Requisitions
/:cl:
