### PR TITLE
Removes SensorMate hud goggles from SG vendor

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_smartgunner.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_smartgunner.dm
@@ -47,7 +47,6 @@ GLOBAL_LIST_INIT(cm_vending_gear_smartgun, list(
 		list("Roller Bed", 5, /obj/item/roller, null, VENDOR_ITEM_REGULAR),
 		list("Fulton Device Stack", 5, /obj/item/stack/fulton, null, VENDOR_ITEM_REGULAR),
 		list("DV9 Smartgun Battery", 15, /obj/item/smartgun_battery, null, VENDOR_ITEM_REGULAR),
-		list("SensorMate Medical HUD", 15, /obj/item/clothing/glasses/hud/sensor, null, VENDOR_ITEM_REGULAR),
 
 		list("BINOCULARS", 0, null, null, null),
 		list("Binoculars", 5, /obj/item/device/binoculars, null, VENDOR_ITEM_REGULAR),


### PR DESCRIPTION

# About the pull request

* Removes the SensorMate hud as a 15 point buy option from the SG vendor.

# Explain why it's good for the game

The SG is the ONLY role that consitently does not have the eye equipment slot open for builds.
So giving them the option to spend 15 points on goggles is more bait for new players then anything.
Especially when you can buy a helmet med hud for 5 poins as SG.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
code: Removes SensorMate hud from SG vendor
/:cl:
