### PR TITLE
Fix timer buckets being reset unnecessarily

### DIFF
--- a/code/__DEFINES/_math.dm
+++ b/code/__DEFINES/_math.dm
@@ -17,6 +17,8 @@
 // round() acts like floor(x, 1) by default but can't handle other values
 #define FLOOR(x, y) ( floor((x) / (y)) * (y) )
 
+#define ROUND_UP(x) (-round(-(x)))
+
 // Returns true if val is from min to max, inclusive.
 #define ISINRANGE(val, min, max) ((min) <= (val) && (val) <= (max))
 

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -1,7 +1,7 @@
 /// Controls how many buckets should be kept, each representing a tick. (1 minutes worth)
 #define BUCKET_LEN (world.fps*1*60)
 /// Helper for getting the correct bucket for a given timer
-#define BUCKET_POS(timer) (((floor((timer.timeToRun - timer.timer_subsystem.head_offset) / world.tick_lag)+1) % BUCKET_LEN)||BUCKET_LEN)
+#define BUCKET_POS(timer) (((ROUND_UP((timer.timeToRun - timer.timer_subsystem.head_offset) / world.tick_lag)+1) % BUCKET_LEN) || BUCKET_LEN)
 /// Gets the maximum time at which timers will be invoked from buckets, used for deferring to secondary queue
 #define TIMER_MAX(timer_ss) (timer_ss.head_offset + TICKS2DS(BUCKET_LEN + timer_ss.practical_offset - 1))
 /// Max float with integer precision

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -316,7 +316,8 @@ GLOBAL_LIST_INIT(reboot_sfx, file2list("config/reboot_sfx.txt"))
 	on_tickrate_change()
 
 /world/proc/on_tickrate_change()
-	SStimer.reset_buckets()
+	SStimer?.reset_buckets()
+	SSsound_loops?.reset_buckets()
 
 /**
  * Handles incresing the world's maxx var and initializing the new turfs and assigning them to the global area.


### PR DESCRIPTION

# About the pull request
Timer buckets were getting reset unnecessarily due to rounding issues. Change separated out from #11826.

# Explain why it's good for the game
Resetting buckets is an expensive operations.

# Testing Photographs and Procedure
N/A, backend change. Basic game testing still worked.

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: MoondancerPony
code: made timer buckets do fewer unnecessary resets
code: made the sound_loops timer subsystem reset buckets on tickrate change like timers do
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
