### PR TITLE
Optimize /datum/datacore/proc/manifest

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -9,22 +9,20 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 	var/leveled_riflemen = 0
 	var/leveled_riflemen_max = 7
 
-/datum/datacore/proc/manifest(nosleep = 0)
-	spawn()
-		if(!nosleep)
-			sleep(40)
+/datum/datacore/proc/manifest()
+	var/alist/lookup = alist()
+	for(var/job_title in GLOB.ROLES_USCM + GLOB.ROLES_WO)
+		lookup[job_title] = TRUE
+	for(var/mob/living/carbon/human/current_human as anything in GLOB.human_mob_list)
+		if(should_block_game_interaction(current_human))
+			continue
 
-		var/list/jobs_to_check = GLOB.ROLES_USCM + GLOB.ROLES_WO
+		if(is_in_manifest(current_human))
+			continue
 
-		for(var/mob/living/carbon/human/current_human as anything in GLOB.human_mob_list)
-			if(should_block_game_interaction(current_human))
-				continue
-
-			if(is_in_manifest(current_human))
-				continue
-
-			if(current_human.job in jobs_to_check)
-				manifest_inject(current_human)
+		if(lookup[current_human.job])
+			manifest_inject(current_human)
+		CHECK_TICK
 
 /datum/datacore/proc/is_in_manifest(mob/living/carbon/human/current_human)
 	var/weakref = WEAKREF(current_human)


### PR DESCRIPTION

# About the pull request
/datum/datacore/proc/manifest now uses an assoc lookup for valid job titles to make the looping step much faster.

Removes the sleep from manifest injection. It's entirely unnecessary, see here: https://github.com/tgstation/tgstation/pull/20038

# Explain why it's good for the game
No longer will there be an arbitrary 4 second pause before the manifest loads.

# Testing Photographs and Procedure
Will take screenshots once I'm done PRing all the commits I've split out of #11826. I believe it was testmerged and no one reported issues with the manifest, though.

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
code: removed an unnecessary pause before crew manifest generation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
