### PR TITLE
Make spawn_humans only take 5 seconds instead of 60

### DIFF
--- a/code/modules/unit_tests/spawn_humans.dm
+++ b/code/modules/unit_tests/spawn_humans.dm
@@ -4,4 +4,4 @@
 	for(var/I in 1 to 5)
 		new /mob/living/carbon/human(pick(locs))
 
-	sleep(60 SECONDS)
+	sleep(5 SECONDS)


### PR DESCRIPTION
# About the pull request
Makes the spawn_humans unit test only wait for 5 seconds instead of 60.

# Explain why it's good for the game
Waiting for 60 seconds (30 mob Life ticks) is a bit much. 5 seconds is enough for most issues to reasonably shake out in unit tests.

# Testing Photographs and Procedure
N/A, unit testing change.


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: MoondancerPony
code: made the spawn_humans unit test wait 5 seconds instead of 60
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
