### PR TITLE
Stops hardened (crash proof) APCs from shorting out.

### DIFF
--- a/code/controllers/subsystem/hijack.dm
+++ b/code/controllers/subsystem/hijack.dm
@@ -199,7 +199,7 @@ SUBSYSTEM_DEF(hijack)
 		// Handle power shortage by ship being cracked in half
 		if(crashed && hijack_status == HIJACK_OBJECTIVES_GROUND_CRASH)
 			for(var/obj/structure/machinery/power/apc/almayer/apc as anything in apcs)
-				if(prob(5))
+				if(prob(5) && apc.crash_break_probability)
 					apc.shorted = TRUE
 					playsound(apc.loc, 'sound/effects/sparks2.ogg', 25, 1)
 					var/datum/effect_system/spark_spread/spark = new /datum/effect_system/spark_spread


### PR DESCRIPTION

# About the pull request

Mainly an issue with ARES, but having every single APC break with 5% chance each tick renders them pointless really as they all will break within a minute.

# Explain why it's good for the game

This will at least mean the critical areas are more resistant, and will stop the unreachable APC in ARES from breaking.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: APCs that do not break on crash will not short circuit either.
/:cl:
