### PR TITLE
Fix: Mis-assigned red holotags

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -921,12 +921,13 @@
 			else if (lungs.organ_status >= ORGAN_BRUISED) tag_severity = max(tag_severity, 1)
 
 			// Bruised livers and kidneys will accumulate toxin damage
-			// It's debatable whether or not this should be orange or red, but better safe than sorry
 			var/datum/internal_organ/kidneys/kidneys = internal_organs_by_name["kidneys"]
-			if (kidneys.organ_status >= ORGAN_BRUISED) tag_severity = 2
+			if (kidneys.organ_status >= ORGAN_BROKEN) tag_severity = 2
+			else if (kidneys.organ_status >= ORGAN_BRUISED) tag_severity = max(tag_severity, 1)
 
 			var/datum/internal_organ/liver/liver = internal_organs_by_name["liver"]
-			if (liver.organ_status >= ORGAN_BRUISED) tag_severity = 2
+			if (liver.organ_status >= ORGAN_BROKEN) tag_severity = 2
+			else if (liver.organ_status >= ORGAN_BRUISED) tag_severity = max(tag_severity, 1)
 
 			// Brainrot is bad
 			var/datum/internal_organ/brain/brain = internal_organs_by_name["brain"]

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -875,7 +875,7 @@
 
 		// Overdoses are life-threatening
 		for (var/datum/reagent/reagent as anything in reagents.reagent_list)
-			if (reagent.volume > reagent.overdose)
+			if (reagent.volume > reagent.overdose && reagent.overdose != 0)
 				tag_severity = 2
 
 		// The highest holotag you can get from limbs is red, so we can safely break out of the limb loop if we find a red-worthy injury

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -897,7 +897,8 @@
 				tag_severity = 2
 				internal_bleeding = TRUE
 				break
-			if (internal_bleeding) break
+			if (internal_bleeding)
+				break
 
 			// Splinted fractures do not require immediate surgical intervention
 			// Unsplinted fractures should be handled immediately before more damage is done
@@ -912,30 +913,40 @@
 		if (new_accuracy >= HOLOCARD_ACCURACY_BODYSCANNER)
 			// Heartbroken marines should be operated on IMMEDIATELY
 			var/datum/internal_organ/kidneys/heart = internal_organs_by_name["heart"]
-			if (heart.organ_status >= ORGAN_BROKEN) tag_severity = 2
-			else if (heart.organ_status >= ORGAN_BRUISED) tag_severity = max(tag_severity, 1)
+			if (heart.organ_status >= ORGAN_BROKEN)
+				tag_severity = 2
+			else if (heart.organ_status >= ORGAN_BRUISED)
+				tag_severity = max(tag_severity, 1)
 
 			// Ditto for ruptured lungs
 			var/datum/internal_organ/kidneys/lungs = internal_organs_by_name["lungs"]
-			if (is_lung_ruptured()) tag_severity = 2
-			else if (lungs.organ_status >= ORGAN_BRUISED) tag_severity = max(tag_severity, 1)
+			if (is_lung_ruptured())
+				tag_severity = 2
+			else if (lungs.organ_status >= ORGAN_BRUISED)
+				tag_severity = max(tag_severity, 1)
 
 			// Bruised livers and kidneys will accumulate toxin damage
 			var/datum/internal_organ/kidneys/kidneys = internal_organs_by_name["kidneys"]
-			if (kidneys.organ_status >= ORGAN_BROKEN) tag_severity = 2
-			else if (kidneys.organ_status >= ORGAN_BRUISED) tag_severity = max(tag_severity, 1)
+			if (kidneys.organ_status >= ORGAN_BROKEN)
+				tag_severity = 2
+			else if (kidneys.organ_status >= ORGAN_BRUISED)
+				tag_severity = max(tag_severity, 1)
 
 			var/datum/internal_organ/liver/liver = internal_organs_by_name["liver"]
-			if (liver.organ_status >= ORGAN_BROKEN) tag_severity = 2
-			else if (liver.organ_status >= ORGAN_BRUISED) tag_severity = max(tag_severity, 1)
+			if (liver.organ_status >= ORGAN_BROKEN)
+				tag_severity = 2
+			else if (liver.organ_status >= ORGAN_BRUISED)
+				tag_severity = max(tag_severity, 1)
 
 			// Brainrot is bad
 			var/datum/internal_organ/brain/brain = internal_organs_by_name["brain"]
-			if (brain.organ_status >= ORGAN_BRUISED) tag_severity = 2
+			if (brain.organ_status >= ORGAN_BRUISED)
+				tag_severity = 2
 
 			// Eye damage is not nearly as bad as the previous three organs, and isn't NECESSARY to be fixed, technically
 			var/datum/internal_organ/eyes/eyes = internal_organs_by_name["eyes"]
-			if (eyes.organ_status >= ORGAN_BRUISED) tag_severity = max(tag_severity, 1)
+			if (eyes.organ_status >= ORGAN_BRUISED)
+				tag_severity = max(tag_severity, 1)
 
 		if (status_flags & PERMANENTLY_DEAD) tag_severity = 3
 
@@ -947,7 +958,8 @@
 		if (head == null || head.status & (LIMB_DESTROYED | LIMB_AMPUTATED))
 			tag_severity = 3
 
-		if (status_flags & XENO_HOST && new_accuracy >= HOLOCARD_ACCURACY_BODYSCANNER) tag_severity = 4
+		if (status_flags & XENO_HOST && new_accuracy >= HOLOCARD_ACCURACY_BODYSCANNER)
+			tag_severity = 4
 
 		var/old_severity
 		// Yes, switching between strings and numbers like this is terrible and I should be using a custom define, but I don't want to touch the code already in place


### PR DESCRIPTION

# About the pull request

Fixes issues relating to red triage tags being applied where they shouldn't.

# Explain why it's good for the game

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
fix: Reagents without overdose thresholds will no longer trigger red holocards
fix: Brusied livers/kidneys no longer immediately trigger red holocards
/:cl:

