### PR TITLE
stops traps going under jungle bushes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -723,8 +723,8 @@
 			to_chat(xeno, SPAN_XENOWARNING("We cannot make a hole on a light!"))
 			return FALSE
 
-		if(locate(/obj/structure/flora/jungle/vines) in src)
-			to_chat(xeno, SPAN_XENOWARNING("We cannot make a hole under the vines!"))
+		if(locate(/obj/structure/flora/jungle) in src)
+			to_chat(xeno, SPAN_XENOWARNING("We cannot make a hole under the flora here!"))
 			return FALSE
 
 	if(!xeno.check_alien_construction(src, check_doors = TRUE))


### PR DESCRIPTION

# About the pull request

As title

# Explain why it's good for the game
Same reason you can't do it under vines.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: You can no longer place resin traps under jungle bushes that entirely obscure them.
/:cl:
