### PR TITLE
Changes some logging from key -> ckey

### DIFF
--- a/code/datums/components/temporary_mute.dm
+++ b/code/datums/components/temporary_mute.dm
@@ -56,7 +56,7 @@
 	SIGNAL_HANDLER
 
 	if(!nolog)
-		msg_admin_niche("[user.name != "Unknown" ? user.name : "([user.real_name])"] attempted to say the following before their spawn mute ended: [message] (CKEY: [user.key]) (JOB: [user.job]) (AREA: [get_area_name(user)])")
+		msg_admin_niche("[user.name != "Unknown" ? user.name : "([user.real_name])"] attempted to say the following before their spawn mute ended: [message] (CKEY: [user.ckey]) (JOB: [user.job]) (AREA: [get_area_name(user)])")
 	if(on_speak_message)
 		to_chat(parent, SPAN_BOLDNOTICE(on_speak_message))
 	return COMPONENT_OVERRIDE_SPEAK
@@ -64,7 +64,7 @@
 /datum/component/temporary_mute/proc/on_hivemind(mob/user, message)
 	SIGNAL_HANDLER
 
-	msg_admin_niche("[user.name != "Unknown" ? user.name : "([user.real_name])"] attempted to hivemind the following before their spawn mute ended: [message] (CKEY: [user.key]) (JOB: [user.job]) (AREA: [get_area_name(user)])")
+	msg_admin_niche("[user.name != "Unknown" ? user.name : "([user.real_name])"] attempted to hivemind the following before their spawn mute ended: [message] (CKEY: [user.ckey]) (JOB: [user.job]) (AREA: [get_area_name(user)])")
 	if(on_speak_message)
 		to_chat(parent, SPAN_BOLDNOTICE(on_speak_message))
 	return COMPONENT_OVERRIDE_HIVEMIND_TALK
@@ -78,7 +78,7 @@
 	if(!param && !istype(current_emote, /datum/emote/custom))
 		return
 
-	msg_admin_niche("[user.name != "Unknown" ? user.name : "([user.real_name])"] attempted to emote the following before their spawn mute ended: [param] (CKEY: [user.key]) (JOB: [user.job]) (AREA: [get_area_name(user)])")
+	msg_admin_niche("[user.name != "Unknown" ? user.name : "([user.real_name])"] attempted to emote the following before their spawn mute ended: [param] (CKEY: [user.ckey]) (JOB: [user.job]) (AREA: [get_area_name(user)])")
 	if(on_emote_message)
 		to_chat(parent, SPAN_BOLDNOTICE(on_emote_message))
 	return COMPONENT_OVERRIDE_EMOTE
@@ -86,7 +86,7 @@
 /datum/component/temporary_mute/proc/on_point(mob/user, atom/target)
 	SIGNAL_HANDLER
 
-	msg_admin_niche("[user.name != "Unknown" ? user.name : "([user.real_name])"] attempted to point at the following before their spawn mute ended: [target] (CKEY: [user.key]) (JOB: [user.job]) (AREA: [get_area_name(user)])")
+	msg_admin_niche("[user.name != "Unknown" ? user.name : "([user.real_name])"] attempted to point at the following before their spawn mute ended: [target] (CKEY: [user.ckey]) (JOB: [user.job]) (AREA: [get_area_name(user)])")
 	if(on_emote_message)
 		to_chat(parent, SPAN_BOLDNOTICE(on_emote_message))
 	return COMPONENT_OVERRIDE_POINT

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -109,7 +109,7 @@
 			S_TIMER_COOLDOWN_START(user, COOLDOWN_MOB_AUDIO, 20 SECONDS) // We won't ever want to stop this except during qdel
 		playsound(user, tmp_sound, volume, vary)
 
-	log_emote("[user.name]/[user.key] : [msg ? msg : key]")
+	log_emote("[user.name]/[user.ckey] : [msg ? msg : key]")
 
 	if(!msg)
 		return
@@ -329,7 +329,7 @@
 	if(!text)
 		CRASH("Someone passed nothing to manual_emote(), fix it")
 
-	log_emote(text)
+	log_emote("[name]/[ckey] : [text]")
 
 	var/paygrade = get_paygrade()
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -300,25 +300,25 @@ directive is properly returned.
 	return
 
 /atom/proc/add_hiddenprint(mob/living/M)
-	if(!M || QDELETED(M) || !M.key || !(flags_atom  & FPRINT) || fingerprintslast == M.key)
+	if(!M || QDELETED(M) || !M.logging_ckey || !(flags_atom  & FPRINT) || fingerprintslast == M.logging_ckey)
 		return
 	if (ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if (H.gloves)
-			fingerprintshidden += "\[[time_stamp()]\] (Wearing gloves). Real name: [H.real_name], Key: [H.key]"
+			fingerprintshidden += "\[[time_stamp()]\] (Wearing gloves). Real name: [H.real_name], CKEY: [H.logging_ckey]"
 		else
-			fingerprintshidden += "\[[time_stamp()]\] Real name: [H.real_name], Key: [H.key]"
+			fingerprintshidden += "\[[time_stamp()]\] Real name: [H.real_name], CKEY: [H.logging_ckey]"
 	else
-		fingerprintshidden += "\[[time_stamp()]\] Real name: [M.real_name], Key: [M.key]"
-	fingerprintslast = M.key
+		fingerprintshidden += "\[[time_stamp()]\] Real name: [M.real_name], CKEY: [M.logging_ckey]"
+	fingerprintslast = M.logging_ckey
 
 
 /atom/proc/add_fingerprint(mob/living/M)
-	if(!M || QDELETED(M) || !M.key || !(flags_atom & FPRINT) || fingerprintslast == M.key)
+	if(!M || QDELETED(M) || !M.logging_ckey || !(flags_atom & FPRINT) || fingerprintslast == M.logging_ckey)
 		return
 	if(!fingerprintshidden)
 		fingerprintshidden = list()
-	fingerprintslast = M.key
+	fingerprintslast = M.logging_ckey
 
 	if (ishuman(M))
 		var/mob/living/carbon/human/H = M
@@ -326,15 +326,15 @@ directive is properly returned.
 		//Fibers~
 		blood_touch(H)
 
-		fingerprintslast = M.key
+		fingerprintslast = M.logging_ckey
 
 		//Now, deal with gloves.
 		if (H.gloves && H.gloves != src)
-			fingerprintshidden += "\[[time_stamp()]\](Wearing gloves). Real name: [H.real_name], Key: [H.key]"
+			fingerprintshidden += "\[[time_stamp()]\](Wearing gloves). Real name: [H.real_name], CKEY: [H.logging_ckey]"
 		else
-			fingerprintshidden += "\[[time_stamp()]\]Real name: [H.real_name], Key: [H.key]"
+			fingerprintshidden += "\[[time_stamp()]\]Real name: [H.real_name], CKEY: [H.logging_ckey]"
 	else
-		fingerprintshidden +=  "\[[time_stamp()]\]Real name: [M.real_name], Key: [M.key]"
+		fingerprintshidden +=  "\[[time_stamp()]\]Real name: [M.real_name], CKEY: [M.logging_ckey]"
 
 
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -300,25 +300,25 @@ directive is properly returned.
 	return
 
 /atom/proc/add_hiddenprint(mob/living/M)
-	if(!M || QDELETED(M) || !M.logging_ckey || !(flags_atom  & FPRINT) || fingerprintslast == M.logging_ckey)
+	if(!M || QDELETED(M) || !M.ckey || !(flags_atom  & FPRINT) || fingerprintslast == M.ckey)
 		return
 	if (ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if (H.gloves)
-			fingerprintshidden += "\[[time_stamp()]\] (Wearing gloves). Real name: [H.real_name], CKEY: [H.logging_ckey]"
+			fingerprintshidden += "\[[time_stamp()]\] (Wearing gloves). Real name: [H.real_name], CKEY: [H.ckey]"
 		else
-			fingerprintshidden += "\[[time_stamp()]\] Real name: [H.real_name], CKEY: [H.logging_ckey]"
+			fingerprintshidden += "\[[time_stamp()]\] Real name: [H.real_name], CKEY: [H.ckey]"
 	else
-		fingerprintshidden += "\[[time_stamp()]\] Real name: [M.real_name], CKEY: [M.logging_ckey]"
-	fingerprintslast = M.logging_ckey
+		fingerprintshidden += "\[[time_stamp()]\] Real name: [M.real_name], CKEY: [M.ckey]"
+	fingerprintslast = M.ckey
 
 
 /atom/proc/add_fingerprint(mob/living/M)
-	if(!M || QDELETED(M) || !M.logging_ckey || !(flags_atom & FPRINT) || fingerprintslast == M.logging_ckey)
+	if(!M || QDELETED(M) || !M.ckey || !(flags_atom & FPRINT) || fingerprintslast == M.ckey)
 		return
 	if(!fingerprintshidden)
 		fingerprintshidden = list()
-	fingerprintslast = M.logging_ckey
+	fingerprintslast = M.ckey
 
 	if (ishuman(M))
 		var/mob/living/carbon/human/H = M
@@ -326,15 +326,15 @@ directive is properly returned.
 		//Fibers~
 		blood_touch(H)
 
-		fingerprintslast = M.logging_ckey
+		fingerprintslast = M.ckey
 
 		//Now, deal with gloves.
 		if (H.gloves && H.gloves != src)
-			fingerprintshidden += "\[[time_stamp()]\](Wearing gloves). Real name: [H.real_name], CKEY: [H.logging_ckey]"
+			fingerprintshidden += "\[[time_stamp()]\](Wearing gloves). Real name: [H.real_name], CKEY: [H.ckey]"
 		else
-			fingerprintshidden += "\[[time_stamp()]\]Real name: [H.real_name], CKEY: [H.logging_ckey]"
+			fingerprintshidden += "\[[time_stamp()]\]Real name: [H.real_name], CKEY: [H.ckey]"
 	else
-		fingerprintshidden +=  "\[[time_stamp()]\]Real name: [M.real_name], CKEY: [M.logging_ckey]"
+		fingerprintshidden +=  "\[[time_stamp()]\]Real name: [M.real_name], CKEY: [M.ckey]"
 
 
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -320,14 +320,14 @@ GLOBAL_VAR_INIT(cas_tracking_id_increment, 0) //this var used to assign unique t
 		for(var/mob/dead/observer/D in GLOB.observer_list)
 			if(D.mind && (D.mind.original == L || D.mind.current == L))
 				if(L.stat == DEAD)
-					msg += "<b>[L.name]</b> ([ckey(D.mind.key)]), the [L.job] (Dead)\n"
+					msg += "<b>[L.name]</b> ([D.mind.ckey]), the [L.job] (Dead)\n"
 					continue //Dead mob, ghost abandoned
 				else
 					if(D.can_reenter_corpse)
-						msg += "<b>[L.name]</b> ([ckey(D.mind.key)]), the [L.job] (<font color='red'><b>This shouldn't appear.</b></font>)\n"
+						msg += "<b>[L.name]</b> ([D.mind.ckey]), the [L.job] (<font color='red'><b>This shouldn't appear.</b></font>)\n"
 						continue //Lolwhat
 					else
-						msg += "<b>[L.name]</b> ([ckey(D.mind.key)]), the [L.job] (<font color='red'><b>Ghosted</b></font>)\n"
+						msg += "<b>[L.name]</b> ([D.mind.ckey]), the [L.job] (<font color='red'><b>Ghosted</b></font>)\n"
 						continue //Ghosted while alive
 
 	for(var/mob/M in GLOB.player_list)

--- a/code/game/objects/effects/effect_system/chemsmoke.dm
+++ b/code/game/objects/effects/effect_system/chemsmoke.dm
@@ -96,11 +96,11 @@
 	var/whereLink = "[ADMIN_JUMP_COORDS(location.x, location.y, location.z)] at [where]"
 
 	if(carry.my_atom.fingerprintslast)
-		msg_admin_niche("A chemical smoke reaction has taken place in ([whereLink])[contained]. Last associated key is [carry.my_atom.fingerprintslast].")
-		log_game("A chemical smoke reaction has taken place in ([where])[contained]. Last associated key is [carry.my_atom.fingerprintslast].")
+		msg_admin_niche("A chemical smoke reaction has taken place in ([whereLink])[contained]. Last associated ckey is [carry.my_atom.fingerprintslast].")
+		log_game("A chemical smoke reaction has taken place in ([where])[contained]. Last associated ckey is [carry.my_atom.fingerprintslast].")
 	else
-		msg_admin_niche("A chemical smoke reaction has taken place in ([whereLink])[contained]. No associated key.")
-		log_game("A chemical smoke reaction has taken place in ([where])[contained]. No associated key.")
+		msg_admin_niche("A chemical smoke reaction has taken place in ([whereLink])[contained]. No associated ckey.")
+		log_game("A chemical smoke reaction has taken place in ([where])[contained]. No associated ckey.")
 
 
 //------------------------------------------

--- a/code/game/objects/items/reagent_containers/dropper.dm
+++ b/code/game/objects/items/reagent_containers/dropper.dm
@@ -111,7 +111,7 @@
 			var/contained = english_list(injected)
 			M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been squirted with [src.name] by [user.name] ([user.ckey]). Reagents: [contained]</font>")
 			user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] to squirt [M.name] ([M.key]). Reagents: [contained]</font>")
-			msg_admin_attack("[user.name] ([user.ckey]) squirted [M.name] ([M.key]) with [src.name] (REAGENTS: [contained]) (INTENT: [uppertext(intent_text(user.a_intent))]) in [get_area(src)] ([src.loc.x],[src.loc.y],[src.loc.z]).", src.loc.x, src.loc.y, src.loc.z)
+			msg_admin_attack("[user.name] ([user.ckey]) squirted [M.name] ([M.ckey]) with [src.name] (REAGENTS: [contained]) (INTENT: [uppertext(intent_text(user.a_intent))]) in [get_area(src)] ([src.loc.x],[src.loc.y],[src.loc.z]).", src.loc.x, src.loc.y, src.loc.z)
 
 		trans = src.reagents.trans_to(target, amount_per_transfer_from_this)
 		to_chat(user, SPAN_NOTICE("You transfer [trans] units of the solution."))

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -98,7 +98,7 @@
 		M.last_damage_data = create_cause_data(initial(name), user)
 		M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been splashed with [src.name] by [user.name] ([user.ckey]). Reagents: [contained]</font>")
 		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] to splash [M.name] ([M.key]). Reagents: [contained]</font>")
-		msg_admin_attack("[user.name] ([user.ckey]) splashed [M.name] ([M.key]) with [src.name] (REAGENTS: [contained]) (INTENT: [uppertext(intent_text(user.a_intent))]) in [get_area(user)] ([user.loc.x],[user.loc.y],[user.loc.z]).", user.loc.x, user.loc.y, user.loc.z)
+		msg_admin_attack("[user.name] ([user.ckey]) splashed [M.name] ([M.ckey]) with [src.name] (REAGENTS: [contained]) (INTENT: [uppertext(intent_text(user.a_intent))]) in [get_area(user)] ([user.loc.x],[user.loc.y],[user.loc.z]).", user.loc.x, user.loc.y, user.loc.z)
 
 		visible_message(SPAN_WARNING("[target] has been splashed with something by [user]!"))
 		reagents.reaction(target, TOUCH)

--- a/code/game/objects/items/reagent_containers/robodropper.dm
+++ b/code/game/objects/items/reagent_containers/robodropper.dm
@@ -94,7 +94,7 @@
 			var/contained = english_list(injected)
 			M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been squirted with [src.name] by [user.name] ([user.ckey]). Reagents: [contained]</font>")
 			user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] to squirt [M.name] ([M.key]). Reagents: [contained]</font>")
-			msg_admin_attack("[user.name] ([user.ckey]) squirted [M.name] ([M.key]) with [src.name] (REAGENTS: [contained]) (INTENT: [uppertext(intent_text(user.a_intent))]) in [get_area(user)] ([user.loc.x],[user.loc.y],[user.loc.z]).", user.loc.x, user.loc.y, user.loc.z)
+			msg_admin_attack("[user.name] ([user.ckey]) squirted [M.name] ([M.ckey]) with [src.name] (REAGENTS: [contained]) (INTENT: [uppertext(intent_text(user.a_intent))]) in [get_area(user)] ([user.loc.x],[user.loc.y],[user.loc.z]).", user.loc.x, user.loc.y, user.loc.z)
 
 
 		trans = src.reagents.trans_to(target, amount_per_transfer_from_this)

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -39,8 +39,8 @@ CLIENT_VERB(ooc, msg as text)
 	if(!attempt_talking(msg))
 		return
 
-	log_ooc("[mob.name]/[key] : [msg]")
-	GLOB.STUI.ooc.Add("\[[time_stamp()]] <font color='#display_colour'>OOC: [mob.name]/[key]: [msg]</font><br>")
+	log_ooc("[mob.name]/[ckey] : [msg]")
+	GLOB.STUI.ooc.Add("\[[time_stamp()]] <font color='#display_colour'>OOC: [mob.name]/[ckey]: [msg]</font><br>")
 	GLOB.STUI.processing |= STUI_LOG_OOC_CHAT
 
 	var/display_colour = GLOB.ooc_color_override
@@ -153,8 +153,8 @@ CLIENT_VERB(looc, msg as text)
 	if(!attempt_talking(msg))
 		return
 
-	log_ooc("(LOCAL) [mob.name]/[key] : [msg]")
-	GLOB.STUI.ooc.Add("\[[time_stamp()]] <font color='#6699CC'>LOOC: [mob.name]/[key]: [msg]</font><br>")
+	log_ooc("(LOCAL) [mob.name]/[ckey] : [msg]")
+	GLOB.STUI.ooc.Add("\[[time_stamp()]] <font color='#6699CC'>LOOC: [mob.name]/[ckey]: [msg]</font><br>")
 	GLOB.STUI.processing |= STUI_LOG_OOC_CHAT
 	var/list/heard = get_mobs_in_view(7, src.mob)
 	var/mob/S = src.mob

--- a/code/modules/cm_preds/yaut_bracers.dm
+++ b/code/modules/cm_preds/yaut_bracers.dm
@@ -1460,7 +1460,7 @@
 	if(is_local)
 		user.show_speech_bubble(heard, "pred_translator1")
 
-	log_say("[user.name != "Unknown" ? user.name : "([user.real_name])"] \[Yautja Translator\]: [message] (CKEY: [user.key]) (JOB: [user.job]) (AREA: [get_area_name(user)])")
+	log_say("[user.name != "Unknown" ? user.name : "([user.real_name])"] \[Yautja Translator\]: [message] (CKEY: [user.ckey]) (JOB: [user.job]) (AREA: [get_area_name(user)])")
 
 	var/overhead_color = "#ff0505"
 	var/span_class = "yautja_translator"

--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -102,7 +102,6 @@
 	var/speech_bubble_test = say_test(message)
 	show_speech_bubble(listening, "[bubble_icon][speech_bubble_test]")
 
-	var/not_dead_speaker = (stat != DEAD)
 	for(var/mob/possible_listening_mob in listening)
 		possible_listening_mob.hear_say(message, verb, speaking, alt_name, italics, src)
 		langchat_speech(message, listening, speaking, langchat_color, FALSE, LANGCHAT_DEFAULT_POP, list("langchat_italic"))
@@ -113,9 +112,7 @@
 			possible_listening_mob.hear_say(new_message, verb, speaking, alt_name, italics, src)
 			langchat_speech(message, listening, speaking, langchat_color, FALSE, LANGCHAT_DEFAULT_POP, list("langchat_italic"))
 
-	spawn(30)
-		if(not_dead_speaker)
-			log_say("[name != "Unknown" ? name : "([real_name])"] \[Whisper\]: [message] (CKEY: [key]) (JOB: [job]) (AREA: [get_area_name(loc)])")
+	log_say("[name != "Unknown" ? name : "([real_name])"] \[Whisper\]: [message] (CKEY: [ckey]) (JOB: [job]) (AREA: [get_area_name(loc)])")
 
 	if (length(watching))
 		var/rendered = "<span class='game say'><span class='name'>[src.name]</span> whispers something.</span>"

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -188,11 +188,11 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		if(message_mode) // we are talking into a radio
 			if(message_mode == "headset") // default value, means general
 				message_mode = "General"
-			log_say("[name != "Unknown" ? name : "([real_name])"] \[[message_mode]\]: [message] (CKEY: [key]) (JOB: [job]) (AREA: [get_area_name(loc)])")
+			log_say("[name != "Unknown" ? name : "([real_name])"] \[[message_mode]\]: [message] (CKEY: [ckey]) (JOB: [job]) (AREA: [get_area_name(loc)])")
 		else // we talk normally
-			log_say("[name != "Unknown" ? name : "([real_name])"]: [message] (CKEY: [key]) (JOB: [job]) (AREA: [get_area_name(loc)])")
+			log_say("[name != "Unknown" ? name : "([real_name])"]: [message] (CKEY: [ckey]) (JOB: [job]) (AREA: [get_area_name(loc)])")
 	else
-		log_say("[name != "Unknown" ? name : "([real_name])"]: [message] (CKEY: [key]) (AREA: [get_area_name(loc)])")
+		log_say("[name != "Unknown" ? name : "([real_name])"]: [message] (CKEY: [ckey]) (AREA: [get_area_name(loc)])")
 
 	return 1
 

--- a/code/modules/mob/unauthenticated/unauthenticated.dm
+++ b/code/modules/mob/unauthenticated/unauthenticated.dm
@@ -136,7 +136,7 @@ GENERAL_PROTECT_DATUM(/mob/unauthenticated)
 		QDEL_IN(client, 10 SECONDS)
 		return FALSE
 
-	message_admins("Non-BYOND user [new_ckey] (previously [key]) has been authenticated via [request.authentication_method].")
+	message_admins("Non-BYOND user [new_ckey] (previously [ckey]) has been authenticated via [request.authentication_method].")
 
 	STOP_PROCESSING(SSauthentication, src)
 

--- a/code/modules/projectiles/guns/specialist/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/specialist/launcher/grenade_launcher.dm
@@ -200,7 +200,7 @@
 			if(ishuman(user))
 				var/mob/living/carbon/human/human_user = user
 				human_user.remember_dropped_object(fired)
-				fired.fingerprintslast = key_name(user)
+				fired.fingerprintslast = user.logging_ckey
 			pass_flags |= PASS_MOB_THRU_HUMAN|PASS_MOB_IS_OTHER|PASS_OVER
 		else
 			pass_flags |= PASS_MOB_THRU|PASS_HIGH_OVER

--- a/code/modules/projectiles/guns/specialist/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/specialist/launcher/grenade_launcher.dm
@@ -200,7 +200,7 @@
 			if(ishuman(user))
 				var/mob/living/carbon/human/human_user = user
 				human_user.remember_dropped_object(fired)
-				fired.fingerprintslast = user.logging_ckey
+				fired.fingerprintslast = user.ckey
 			pass_flags |= PASS_MOB_THRU_HUMAN|PASS_MOB_IS_OTHER|PASS_OVER
 		else
 			pass_flags |= PASS_MOB_THRU|PASS_HIGH_OVER

--- a/code/modules/reagents/chemistry_reactions/other.dm
+++ b/code/modules/reagents/chemistry_reactions/other.dm
@@ -200,11 +200,11 @@
 	var/data = " [created_volume] volume -> fuel: [light.fuel] range: [light.light_range] power: [light.light_power]"
 
 	if(holder.my_atom.fingerprintslast)
-		msg_admin_niche("[src] reaction has taken place in ([whereLink])[data]. Last associated key is [holder.my_atom.fingerprintslast].")
-		log_game("[src] reaction has taken place in ([where])[data]. Last associated key is [holder.my_atom.fingerprintslast].")
+		msg_admin_niche("[src] reaction has taken place in ([whereLink])[data]. Last associated ckey is [holder.my_atom.fingerprintslast].")
+		log_game("[src] reaction has taken place in ([where])[data]. Last associated ckey is [holder.my_atom.fingerprintslast].")
 	else
-		msg_admin_niche("[src] reaction has taken place in ([whereLink])[data]. No associated key.")
-		log_game("[src] reaction has taken place in ([where])[data]. No associated key.")
+		msg_admin_niche("[src] reaction has taken place in ([whereLink])[data]. No associated ckey.")
+		log_game("[src] reaction has taken place in ([where])[data]. No associated ckey.")
 
 /datum/chemical_reaction/chemfire
 	name = "Napalm"


### PR DESCRIPTION

# About the pull request

Switches around key for ckey in fingerprints and some logging interactions.

We need ckey in logs for two reasons:
 - It's what's used in 90% of places, and you can't properly filter if there are several forms of it
 - It's easier and more consistent for parsing logs

Right now it turns out SAY logs use key not ckey so you can't search them by ckey for example

Doesn't touch adminhelp logs because they're not actual logs (just sent to redis/discord)

Also fixes an invalid emote log and one runtimey fingerprint usage
Removes a weird logging clause in whisper. There's no need for spawn, and the person can't be dead when using it anyway. So now it always logs.

Untested, no way i can manage to check every single one

# Changelog
:cl:
admin: Most logging (and fingerprints) should now properly use ckey, instead of key
/:cl:


