### PR TITLE
Small qol additions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -122,5 +122,6 @@
 	"chat.mcp.gallery.enabled": false,
 	"mermaid-chat.enabled": false,
 	"githubPullRequests.experimental.useQuickChat": false,
-	"chat.useAgentSkills": false
+	"chat.useAgentSkills": false,
+	"chat.editor.copilotCli.hideExtensionHost": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -122,6 +122,5 @@
 	"chat.mcp.gallery.enabled": false,
 	"mermaid-chat.enabled": false,
 	"githubPullRequests.experimental.useQuickChat": false,
-	"chat.useAgentSkills": false,
-	"chat.editor.copilotCli.hideExtensionHost": false
+	"chat.useAgentSkills": false
 }

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -896,7 +896,7 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	xeno_types = null
 
 /obj/item/storage/backpack/marine/grenadepack/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/storage/box/nade_box) || istype(W, /obj/item/storage/backpack/marine/grenadepack) || istype(W, /obj/item/storage/belt/grenade))
+	if(istype(W, /obj/item/storage/box/nade_box) || istype(W, /obj/item/storage/backpack/marine/grenadepack) || istype(W, /obj/item/storage/box/packet) || istype(W, /obj/item/storage/belt/grenade))
 		dump_into(W,user)
 	else
 		return ..()

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -1258,7 +1258,6 @@
 	max_storage_space = 24
 	can_hold = list(/obj/item/explosive/grenade)
 
-
 /obj/item/storage/belt/grenade/full/fill_preset_inventory()
 	new /obj/item/explosive/grenade/incendiary(src)
 	new /obj/item/explosive/grenade/incendiary(src)
@@ -1270,7 +1269,7 @@
 	new /obj/item/explosive/grenade/high_explosive/airburst(src)
 
 /obj/item/storage/belt/grenade/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/storage/box/nade_box) || istype(W, /obj/item/storage/backpack/marine/grenadepack))
+	if(istype(W, /obj/item/storage/box/nade_box) || istype(W, /obj/item/storage/backpack/marine/grenadepack) || istype(W, /obj/item/storage/box/packet) || istype(W, /obj/item/storage/belt/grenade))
 		dump_into(W,user)
 	else
 		return ..()
@@ -1334,12 +1333,6 @@
 	new /obj/item/explosive/grenade/high_explosive/upp(src)
 	new /obj/item/explosive/grenade/high_explosive/upp(src)
 	new /obj/item/explosive/grenade/high_explosive/upp(src)
-
-/obj/item/storage/belt/grenade/upp/attackby(obj/item/attacked_item, mob/user)
-	if(istype(attacked_item, /obj/item/storage/box/nade_box) || istype(attacked_item, /obj/item/storage/backpack/marine/grenadepack))
-		dump_into(attacked_item, user)
-	else
-		return ..()
 
 ////////////////////////////// GUN BELTS /////////////////////////////////////
 

--- a/code/modules/cm_marines/m2c.dm
+++ b/code/modules/cm_marines/m2c.dm
@@ -21,6 +21,7 @@
 	icon_state = "m2c"
 	item_state = "m2c"
 	max_rounds = 125
+	flags_magazine = AMMUNITION_REFILLABLE|AMMUNITION_SLAP_TRANSFER
 	default_ammo = /datum/ammo/bullet/machinegun/auto
 	gun_type = null
 

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -8,8 +8,8 @@
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/USCM/machineguns.dmi'
 	w_class = SIZE_MEDIUM
 	icon_state = "m56d_drum"
-	flags_magazine = NO_FLAGS //can't be refilled or emptied by hand
 	caliber = "10x28mm"
+	flags_magazine = AMMUNITION_REFILLABLE|AMMUNITION_SLAP_TRANSFER
 	max_rounds = 700
 	default_ammo = /datum/ammo/bullet/machinegun
 	gun_type = null

--- a/code/modules/projectiles/ammo_boxes/grenade_packets.dm
+++ b/code/modules/projectiles/ammo_boxes/grenade_packets.dm
@@ -8,7 +8,7 @@
 	w_class = SIZE_MEDIUM//fits into bags
 	storage_slots = 3
 	can_hold = list(/obj/item/explosive/grenade)
-	foldable = null
+	foldable = TRUE
 	var/content_type
 
 /obj/item/storage/box/packet/update_icon()

--- a/code/modules/projectiles/magazines/lever_action.dm
+++ b/code/modules/projectiles/magazines/lever_action.dm
@@ -18,6 +18,12 @@ Similar to shotguns.dm but not exactly.
 	handful_state = "lever_action_bullet"
 	transfer_handful_amount = 9
 
+/obj/item/ammo_magazine/lever_action/attack_self(mob/user)
+	if(current_rounds == 0)
+		new /obj/item/stack/sheet/cardboard(user.loc)
+		qdel(src)
+	else
+		return ..()
 
 /obj/item/ammo_magazine/lever_action/training
 	name = "box of 45-70 blanks"


### PR DESCRIPTION

# About the pull request

* Grenade Packs and SOCOM packs can now be folded to reduce clutter
* Grenade belts n pack can now be refiled with each other, or by using small grenade packs
* M56D ammo can now be taken out of its mags, like every other mag can.
* M56D and M2C can now use Slap Tranfer 

# Explain why it's good for the game

SOCOM and grenade packs not being able to be broken apart is weird. It leaves behind clutter players cant remove.
Not a bad thing to allow players to reduce the number of items.

Besides that just some small qol stuff, letting M56D and M2C use slap transfer. Wich now means essentially all MG/LGM mags can it. All ones that are used in regular gameplay at least.
M56D able to have ammo taken out of because why not, its weird you couldnt. Nice immersion.

Lastly that you cant use grenade packs to fill belts and the satchel is a bit strange. It just makes using packs a lot better.
No reason not to if you can already do so with the big box.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:NHC
qol: SOCOM and grenade packs can now be collapsed
qol: Grenade belt and satchel can now be filed by being slapped by themself, each other, and via grenade packs n boxes
qol: M56D and M2C mags can be used to refil other mags of their own kind
qol: M56D mags can be manually loaded/unloaded
/:cl:
