### PR TITLE
Fix: Despoiler's acid effect stacking multiple times

### DIFF
--- a/code/datums/ammo/xeno.dm
+++ b/code/datums/ammo/xeno.dm
@@ -265,7 +265,7 @@
 	. = ..()
 	if(istype(target_object, /obj/structure/barricade))
 		var/obj/structure/barricade/barricade = target_object
-		var/datum/effects/acid/acid_effect = locate() in barricade
+		var/datum/effects/acid/acid_effect = locate() in barricade.effects_list
 		if(!acid_effect)
 			barricade.acid_spray_act()
 


### PR DESCRIPTION

# About the pull request
We check the the effects_list for the effect.
Fixes: #12595
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Bug bad.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="415" height="413" alt="Screenshot 2026-07-06 193529" src="https://github.com/user-attachments/assets/9addcb6c-0496-4e20-9157-8569dccf24df" />

<img width="469" height="405" alt="Screenshot 2026-07-06 195105" src="https://github.com/user-attachments/assets/86fd313d-23d1-42cc-acf6-5f65fadb8a40" />

</details>


# Changelog
:cl:
fix: Despoiler can not longer stack acid on cades multiple times.
/:cl:
