### PR TITLE
Fixes acid barrage acid_spray_act stacking

### DIFF
--- a/code/datums/ammo/xeno.dm
+++ b/code/datums/ammo/xeno.dm
@@ -265,7 +265,7 @@
 	. = ..()
 	if(istype(target_object, /obj/structure/barricade))
 		var/obj/structure/barricade/barricade = target_object
-		var/datum/effects/acid/acid_effect = locate() in barricade
+		var/datum/effects/acid/acid_effect = locate() in barricade.effects_list
 		if(!acid_effect)
 			barricade.acid_spray_act()
 


### PR DESCRIPTION

# About the pull request
Meant to fix this here  in this commit c0f8d2884f526d99bd32106cdb6381742a0c498f but I didn't add `.effects_list` so it didn't actually do anything
Fixes: https://github.com/cmss13-devs/cmss13/issues/12595
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Fixes a bug, put the behavior on cades inline with on mobs
# Testing Photographs and Procedure
Only one acid effect after using acid barrage (previously multiple):
<img width="470" height="366" alt="image" src="https://github.com/user-attachments/assets/0b49266f-9c39-47fb-b9ff-2305c33d07d4" />





# Changelog
:cl:
fix: Fixes acid barrage stacking acid spray dots on barricades
/:cl:
