### PR TITLE
Fix despoiler acid stacking on direct hits

### DIFF
--- a/code/datums/ammo/xeno.dm
+++ b/code/datums/ammo/xeno.dm
@@ -256,7 +256,8 @@
 	if(. == FALSE)
 		return
 	var/datum/effects/acid/acid_effect = locate() in mob.effects_list
-	acid_effect = new /datum/effects/acid(mob, projectile.firer)
+	if(!acid_effect)
+		acid_effect = new /datum/effects/acid(mob, projectile.firer)
 	acid_effect.enhance_acid()
 	acid_effect.increment_duration(acid_progression)
 	splatter(mob, 1, projectile)


### PR DESCRIPTION

# About the pull request

Fixes despoiler acid direct hits creating a new acid effect every time instead of reusing the existing acid effect on the target

# Explain why it's good for the game
Prevents despoiler acid from dealing unintended extra damage by stacking multiple acid effects on the same target

# Testing Photographs and Procedure
Hit a mob multiple times with acid, verified only one acid effect was active at a time instead of multiple
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fixed Despoiler acid barrage direct hits applying a new acid effect on every hit instead of refreshing the existing one
/:cl:
