### PR TITLE
Spotter sight locked to spotter until death

### DIFF
--- a/code/modules/clothing/glasses/night.dm
+++ b/code/modules/clothing/glasses/night.dm
@@ -61,6 +61,27 @@
 /obj/item/clothing/glasses/night/m42_night_goggles/spotter
 	name = "\improper M42 spotter sight"
 	desc = "A companion headset and night vision goggles system for USCM spotters. Allows highlighted imaging of surroundings. Click it to toggle."
+	flags_item = MOB_LOCK_ON_EQUIP|NO_CRYO_STORE
+	/// Only for first lock is trait required
+	var/require_training = TRUE
+
+/obj/item/clothing/glasses/night/m42_night_goggles/spotter/mob_can_equip(mob/equipping_mob, slot, disable_warning)
+	if(slot != WEAR_EYES)
+		return ..()
+	if(!require_training)
+		return ..()
+	if(!ishuman(equipping_mob))
+		return ..()
+	var/mob/living/carbon/human/equipping_human = equipping_mob
+	if(!(GLOB.character_traits[/datum/character_trait/skills/spotter] in equipping_human.traits))
+		to_chat(equipping_mob, SPAN_NOTICE("You don't know how to use [src]."))
+		return FALSE
+	return ..()
+
+/obj/item/clothing/glasses/night/m42_night_goggles/spotter/equipped(mob/user, slot)
+	if(slot == WEAR_EYES)
+		require_training = FALSE
+	..()
 
 /obj/item/clothing/glasses/night/m42_night_goggles/m42c
 	name = "\improper M42C special operations sight"


### PR DESCRIPTION

# About the pull request

This PR ultimately just adds a trait check for spotter to the spotter sight, but it also stops checking this trait after its first successful equip to the eyes meaning it can be used by anyone after the original owner permas.

# Explain why it's good for the game

Stops spotter squabbling at round start.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/uNxQbnEP3gk

</details>


# Changelog
:cl: Drathek
balance: Spotter sight is now spotter trait locked on first equip, but then is free to equip after ID lock ends (generally permadeath)
/:cl:
