### PR TITLE
Hallucination Nerfs

### DIFF
--- a/code/controllers/subsystem/hijack.dm
+++ b/code/controllers/subsystem/hijack.dm
@@ -220,9 +220,9 @@ SUBSYSTEM_DEF(hijack)
 			current_run_mobs = GLOB.alive_human_list.Copy()
 
 	if(in_ftl)
-		// Scalar between 30s and 5min for ~0-25% chance of a hallucination when in FTL outside a pod
+		// Scalar between 30s and 15min for ~0-12.5% chance of a hallucination when in FTL outside a pod
 		var/duration_clamped = clamp(world.time - in_ftl_time, 30 SECONDS, 5 MINUTES)
-		var/chance_haullucinate = SCALE(duration_clamped, 30 SECONDS, 20 MINUTES) * 100 // max actually seems to be like ~23% because byond floats
+		var/chance_haullucinate = SCALE(duration_clamped, 30 SECONDS, 40 MINUTES) * 100 // max actually seems to be a little less because byond floats
 		for(var/mob/living/carbon/human/current_mob as anything in current_run_mobs)
 			current_run_mobs -= current_mob
 

--- a/code/datums/effects/neurotoxin.dm
+++ b/code/datums/effects/neurotoxin.dm
@@ -141,21 +141,17 @@
 
 	switch(rand(0, 100))
 		if(0 to 5)
-			playsound_client(client, pick('sound/voice/alien_pounce.ogg','sound/voice/alien_pounce.ogg'))
-			KnockDown(3)
-			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound_client), client,"alien_claw_flesh"), 1 SECONDS)
-			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound_client), client,"bonebreak"), 1 SECONDS)
-			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound_client), client,"alien_claw_flesh"), 1.5 SECONDS)
-			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound_client), client,"alien_claw_flesh"), 2 SECONDS)
-			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound_client), client,"bonebreak"), 2.5 SECONDS)
-			apply_effect(AGONY,10)
-			emote("pain")
+			to_chat(src, SPAN_WARNING(pick("Something feels off.", "Something isn't right.", "You feel nauseous.", "You feel like you're going to throw up!")))
+			addtimer(CALLBACK(src, PROC_REF(process_hallucination_lurker)), 3 SECONDS)
+
 		if(6 to 10)
 			playsound_client(client, 'sound/effects/ob_alert.ogg')
 			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound_client), client,'sound/weapons/gun_orbital_travel.ogg'), 2 SECONDS)
+
 		if(11 to 16)
-			playsound_client(client, 'sound/voice/alien_queen_screech.ogg')
-			KnockDown(1)
+			to_chat(src, SPAN_WARNING(pick("Something feels off.", "Something isn't right.", "You feel nauseous.", "You feel like you're going to throw up!")))
+			addtimer(CALLBACK(src, PROC_REF(process_hallucination_queen)), 3 SECONDS)
+
 		if(17 to 24)
 			//Fake CAS sequence
 			playsound_client(client,'sound/weapons/dropship_sonic_boom.ogg', vol = 5)
@@ -190,12 +186,30 @@
 			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound_client), client,"explosion", null, 5), 11 SECONDS)
 			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound_client), client,'sound/effects/gauimpact.ogg', null, 5), 11 SECONDS)
 			emote("pain")
+
 		if(25 to 42)
 			to_chat(src,SPAN_HIGHDANGER("A SHELL IS ABOUT TO IMPACT [pick(SPAN_UNDERLINE("TOWARDS THE [pick("WEST","EAST","SOUTH","NORTH")]"),SPAN_UNDERLINE("RIGHT ONTOP OF YOU!"))]!"))
 			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound_client), client,'sound/weapons/gun_mortar_travel.ogg'), 1 SECONDS)
+
 		if(43 to 69)
 			emote(pick("twitch","drool","moan","giggle"))
 			hallucination = 3
 			druggy = 3
+
 		if(70 to 100) // sound based hallucination
 			playsound_client(client=client, soundin=pick('sound/voice/alien_distantroar_3.ogg','sound/voice/xenos_roaring.ogg','sound/voice/alien_queen_breath1.ogg', 'sound/voice/4_xeno_roars.ogg','sound/misc/notice2.ogg',"bone_break","gun_pulse","metalbang","pry","shatter"),vol = 65)
+
+/mob/living/carbon/human/proc/process_hallucination_lurker()
+	playsound_client(client, pick('sound/voice/alien_pounce.ogg','sound/voice/alien_pounce.ogg'))
+	KnockDown(3)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound_client), client,"alien_claw_flesh"), 1 SECONDS)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound_client), client,"bonebreak"), 1 SECONDS)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound_client), client,"alien_claw_flesh"), 1.5 SECONDS)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound_client), client,"alien_claw_flesh"), 2 SECONDS)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound_client), client,"bonebreak"), 2.5 SECONDS)
+	apply_effect(AGONY,10)
+	emote("pain")
+
+/mob/living/carbon/human/proc/process_hallucination_queen()
+	playsound_client(client, 'sound/voice/alien_queen_screech.ogg')
+	KnockDown(1)

--- a/code/datums/effects/neurotoxin.dm
+++ b/code/datums/effects/neurotoxin.dm
@@ -14,8 +14,6 @@
 	var/stumble_prob = 0
 	/// Chance of blood_cough per proc (damaging)
 	var/bloodcough_prob = 0
-	/// Whether or not we hallucinate. (small rng stun chance)
-	var/hallucinate = TRUE
 	// Tick-based chat cooldown so it doesn't get too spammy
 	var/chat_cd = 0
 	/// Stamina damage per tick. Major balance number.
@@ -84,11 +82,9 @@
 	if(duration > 14) // 3 ticks in smoke
 		affected_mob.apply_effect(5,AGONY)  // Fake crit, a good way to induce panic
 		affected_mob.make_jittery(15)
-		if(hallucinate && affected_mob.client && ishuman_strict(affected_mob))
+		if(prob(50) && affected_mob.client && ishuman_strict(affected_mob))
 			var/mob/living/carbon/human/affected_human = affected_mob
 			affected_human.process_hallucination()
-			hallucinate = FALSE
-			addtimer(VARSET_CALLBACK(src,hallucinate,TRUE),rand(4 SECONDS,10 SECONDS))
 
 	if(duration > 19) // 4 ticks in smoke, neuro is affecting cereberal activity
 		affected_mob.eye_blind = max(affected_mob.eye_blind, floor(strength/4))


### PR DESCRIPTION

# About the pull request

This PR does a few things:
- Halves the upper limit on probability for hallucinations to occur during hijack
- Gives a 3s early msg to some of the hallucinations
- Removes some mostly unnecessary rng handling for boiler triggering of hallucinations (replaced with 50% prob in addition to the standard 15s cooldown)

# Explain why it's good for the game

I'm tired of people nitpicking every aspect of hijack.

# Testing Photographs and Procedure

Force hijack verb & wait

# Changelog
:cl: Drathek
balance: Hijack hallucinations upper limit on probability is halved (was 5 mins in FTL would have 25% chance per tick, now 12.5%)
balance: Some hallucinations have an earlier message to them
code: Replaced an unnecessary old way of RNGing old boiler hallucinations with just a 50% probability (in addition to the standard 15s cooldown FTL imposed to hallucinations)
/:cl:
