### PR TITLE
Removes some duplicated admin logging

### DIFF
--- a/code/__HELPERS/logging.dm
+++ b/code/__HELPERS/logging.dm
@@ -306,6 +306,8 @@ GLOBAL_PROTECT(config_error_log)
 	WRITE_LOG(GLOB.mapping_log, text)
 	SEND_TEXT(world.log, text)
 
+/// Logs to Admin Log without sending to in-game admins.
+/// Upstream compatibility proc, don't double up with our message_admins that also logs
 /proc/log_admin_private(text)
 	log_admin(text)
 

--- a/code/controllers/mc/admin.dm
+++ b/code/controllers/mc/admin.dm
@@ -98,8 +98,6 @@ INITIALIZE_IMMEDIATE(/obj/effect/statclick)
 	//SSblackbox.record_feedback("tally", "admin_verb", 1, "Restart Failsafe Controller")
 	message_admins("Admin [key_name_admin(usr)] is debugging the [controller] controller.")
 
-	message_admins("Admin [key_name_admin(usr)] has restarted the [controller] controller.")
-
 /client/proc/debug_role_authority()
 	set category = "Debug.Controllers"
 	set name = "Debug Role Authority"

--- a/code/controllers/subsystem/init/landmarks.dm
+++ b/code/controllers/subsystem/init/landmarks.dm
@@ -38,17 +38,14 @@ SUBSYSTEM_DEF(landmark_init)
 		var/datum/item_pool_holder/pool = pools[pool_key]
 
 		if (!istype(pool))
-			log_debug("Item pool incorrectly initialized by pool spawner landmarks. Code: ITEM_POOL_2")
 			message_admins("Item pool incorrectly initialized by pool spawner landmarks. Tell the devs. Code: ITEM_POOL_2")
 			continue
 
 		if (!pool.quota || !pool.type_to_spawn)
-			log_debug("Item pool [pool.pool_name] has no master landmark, aborting item spawns. Code: ITEM_POOL_3")
 			message_admins("Item pool [pool.pool_name] has no master landmark, aborting item spawns. Tell the devs. Code: ITEM_POOL_3")
 			continue
 
 		if (pool.quota > length(pool.turfs))
-			log_debug("Item pool [pool.pool_name] wants to spawn more items than it has landmarks for. Spawning [length(pool.turfs)] instances of [pool.type_to_spawn] instead. Code: ITEM_POOL_4")
 			message_admins("Item pool [pool.pool_name] wants to spawn more items than it has landmarks for. Spawning [length(pool.turfs)] instances of [pool.type_to_spawn] instead. Tell the devs. Code: ITEM_POOL_4")
 			pool.quota = length(pool.turfs)
 

--- a/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
+++ b/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
@@ -238,7 +238,6 @@
 			J.total_positions = J.current_positions
 		J.current_positions = J.get_total_positions(TRUE)
 	to_world("<B>New players may no longer join the game.</B>")
-	message_admins("Wave one has begun. Disabled new player game joining.")
 	message_admins("Wave one has begun. Disabled new player game joining except for replacement of cryoed marines.")
 	world.update_status()
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -102,7 +102,6 @@
 					set_security_level(tmp_alertlevel)
 					if(GLOB.security_level != old_level)
 						//Only notify the admins if an actual change happened
-						log_game("[key_name(usr)] has changed the security level to [get_security_level()].")
 						message_admins("[key_name_admin(usr)] has changed the security level to [get_security_level()].")
 				else
 					to_chat(usr, SPAN_WARNING("You are not authorized to do this."))
@@ -159,7 +158,6 @@
 					to_chat(usr, SPAN_WARNING("You are unable to initiate an evacuation procedure right now!"))
 					return FALSE
 
-				log_game("[key_name(usr)] has called for an emergency evacuation.")
 				message_admins("[key_name_admin(usr)] has called for an emergency evacuation.")
 				log_ares_security("Initiate Evacuation", "Called for an emergency evacuation.", usr)
 				return TRUE
@@ -185,7 +183,6 @@
 					to_chat(usr, SPAN_WARNING("You are unable to cancel the evacuation right now!"))
 					return FALSE
 
-				log_game("[key_name(usr)] has canceled the emergency evacuation.")
 				message_admins("[key_name_admin(usr)] has canceled the emergency evacuation.")
 				log_ares_security("Cancel Evacuation", "Cancelled the emergency evacuation.", usr)
 				return TRUE

--- a/code/modules/admin/tabs/admin_tab.dm
+++ b/code/modules/admin/tabs/admin_tab.dm
@@ -316,7 +316,6 @@ SET_PROTECTED_PROC(/client/proc/cmd_admin_say)
 
 	for(var/mob/living/mob in view(usr.client))
 		show_blurb(mob, 15, message, null, "center", "center", color, null, null, 1)
-	log_admin("[key_name(src)] sent an In View admin alert with custom message [message].")
 	message_admins("[key_name(src)] sent an In View admin alert with custom message [message].")
 
 /datum/admins/proc/directnarrateall()
@@ -333,7 +332,6 @@ SET_PROTECTED_PROC(/client/proc/cmd_admin_say)
 
 	for(var/mob/living/mob in view(usr.client))
 		to_chat(mob, SPAN_ANNOUNCEMENT_HEADER_BLUE(message))
-	log_admin("[key_name(usr)] sent a Direct Narrate in View with custom message \"[message]\".")
 	message_admins("[key_name(usr)] sent a Direct Narrate in View with custom message \"[message]\".")
 
 #define SUBTLE_MESSAGE_IN_HEAD "Voice in Head"
@@ -670,7 +668,6 @@ SET_PROTECTED_PROC(/client/proc/cmd_mentor_say)
 	friend.aghosted_original_mob = user.mind?.original
 	user.mind.transfer_to(friend)
 
-	log_admin("[key_name(friend)] started being imaginary friend of [key_name(befriended_mob)].")
 	message_admins("[key_name_admin(friend)] started being imaginary friend of [key_name_admin(befriended_mob)].")
 
 /client/proc/in_view_panel()

--- a/code/modules/admin/tabs/round_tab.dm
+++ b/code/modules/admin/tabs/round_tab.dm
@@ -202,7 +202,6 @@
 	SSticker.force_ending = TRUE
 	SSticker.mode.round_finished = winstate
 
-	log_admin("[key_name(usr)] has made the round end early - [winstate].")
 	message_admins("[key_name(usr)] has made the round end early - [winstate].")
 	for(var/client/C in GLOB.admins)
 		to_chat(C, {"
@@ -272,14 +271,12 @@
 			admin_disabled_cdn_transport = null
 			SSassets.OnConfigLoad()
 			message_admins("[key_name_admin(usr)] re-enabled the CDN asset transport")
-			log_admin("[key_name(usr)] re-enabled the CDN asset transport")
 			return
 
 		to_chat(usr, SPAN_ADMINNOTICE("The CDN is not enabled!"))
 		if(alert(usr, "CDN asset transport is not enabled! If you're having issues with assets, you can also try disabling filename mutations.", "CDN asset transport is not enabled!", "Try disabling filename mutations", "Nevermind") == "Try disabling filename mutations")
 			SSassets.transport.dont_mutate_filenames = !SSassets.transport.dont_mutate_filenames
 			message_admins("[key_name_admin(usr)] [(SSassets.transport.dont_mutate_filenames ? "disabled" : "re-enabled")] asset filename transforms.")
-			log_admin("[key_name(usr)] [(SSassets.transport.dont_mutate_filenames ? "disabled" : "re-enabled")] asset filename transforms.")
 		return
 
 	admin_disabled_cdn_transport = current_transport
@@ -287,4 +284,3 @@
 	SSassets.OnConfigLoad()
 	SSassets.transport.dont_mutate_filenames = TRUE
 	message_admins("[key_name_admin(usr)] disabled CDN asset transport")
-	log_admin("[key_name(usr)] disabled CDN asset transport")

--- a/code/modules/admin/topic/topic.dm
+++ b/code/modules/admin/topic/topic.dm
@@ -2085,7 +2085,6 @@
 		return
 	GLOB.distress_cancel = TRUE
 	SSticker.mode.activate_distress()
-	log_game("[key_name_admin(approver)] has sent a randomized distress beacon, requested by [key_name_admin(ref_person)]")
 	message_admins("[key_name_admin(approver)] has sent a randomized distress beacon, requested by [key_name_admin(ref_person)]")
 
 ///Handles calling the ERT sent by handheld distress beacons
@@ -2094,7 +2093,6 @@
 		return
 	GLOB.distress_cancel = TRUE
 	SSticker.mode.get_specific_call("[ert_called]", TRUE, FALSE)
-	log_game("[key_name_admin(approver)] has sent [ert_called], requested by [key_name_admin(ref_person)]")
 	message_admins("[key_name_admin(approver)] has sent [ert_called], requested by [key_name_admin(ref_person)]")
 
 /datum/admins/proc/generate_job_ban_list(mob/M, datum/entity/player/P, list/roles, department, color = "ccccff")

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -510,7 +510,6 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 	plain_message = "Reopened by [usr.username()]", message_type = "system")
 	var/msg = SPAN_ADMINHELP("Ticket [TicketHref("#[id]")] reopened by [key_name_admin(usr)].")
 	message_admins(msg)
-	log_admin_private(msg)
 	log_ahelp(id, "Reopened", "Reopened by [usr.username()]", usr.ckey)
 
 //private
@@ -542,7 +541,6 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 		var/msg = "Ticket [TicketHref("#[id]")] closed by [key_name]."
 		message_admins(msg)
 		log_ahelp(id, "Closed", "Closed by [usr.username()]", null, usr.ckey)
-		log_admin_private(msg)
 
 //Mark open ticket as resolved/legitimate, returns ahelp verb
 /datum/admin_help/proc/Resolve(key_name = key_name_admin(usr), silent = FALSE)
@@ -567,7 +565,6 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 		var/msg = "Ticket [TicketHref("#[id]")] resolved by [key_name]"
 		message_admins(msg)
 		log_ahelp(id, "Resolved", "Resolved by [usr.username()]", null, usr.ckey)
-		log_admin_private(msg)
 
 /datum/admin_help/proc/defer_to_mentors()
 	if(state != AHELP_ACTIVE || !initial_message)
@@ -634,7 +631,6 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 	to_chat(initiator, SPAN_ADMINHELP("An admin is preparing to respond to your ticket."))
 	var/msg = "Ticket [TicketHref("#[id]")] marked by [key_name]."
 	message_admins(msg)
-	log_admin_private(msg)
 	log_ahelp(id, "Marked", "Marked by [user.username()]", sender = user.ckey)
 	marked_admin = user.ckey
 
@@ -644,7 +640,6 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 		plain_message = "Unmarked by [usr.username()] (previously [marked_admin])", message_type = "system")
 	var/msg = "Ticket [TicketHref("#[id]")] unmarked by [key_name]."
 	message_admins(msg)
-	log_admin_private(msg)
 	log_ahelp(id, "Unmarked", "Unmarked by [usr.username()] (previously [marked_admin])", sender = usr.ckey)
 	marked_admin = null
 
@@ -668,7 +663,6 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 
 	var/msg = "Ticket [TicketHref("#[id]")] rejected by [key_name]"
 	message_admins(msg)
-	log_admin_private(msg)
 	AddInteraction("Rejected by [key_name].",
 		plain_message = "Rejected by [usr.username()]", message_type = "system")
 	log_ahelp(id, "Rejected", "Rejected by [usr.username()]", null, usr.ckey)
@@ -702,7 +696,6 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 
 	msg = "Ticket [TicketHref("#[id]")] marked as [response.title] by [key_name]"
 	message_admins(msg)
-	log_admin_private(msg)
 	AddInteraction("Marked as [response.title] by [key_name]",
 		plain_message = "Marked as [response.title] by [usr.username()]", message_type = "system")
 	log_ahelp(id, "Autoreply", "Marked as [response.title] by [usr.username()]", null,  usr.ckey)
@@ -775,7 +768,6 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 		//not saying the original name cause it could be a long ass message
 		var/msg = "Ticket [TicketHref("#[id]")] titled [name] by [key_name_admin(usr)]"
 		message_admins(msg)
-		log_admin_private(msg)
 	TicketPanel() //we have to be here to do this
 
 //Forwarded action from admin/Topic

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -151,7 +151,6 @@
 		else
 			client?.tgui_panel?.stop_music()
 
-	log_admin("[key_name(src)] played admin sound: [web_sound_input] -[log_title ? " [title] -" : ""] [style]")
 	message_admins("[key_name_admin(src)] played admin sound: [web_sound_input] -[log_title ? " [title] -" : ""] [style]")
 
 /client/proc/stop_admin_sound()

--- a/code/modules/tgui_panel/telemetry.dm
+++ b/code/modules/tgui_panel/telemetry.dm
@@ -107,5 +107,4 @@
 	if(found)
 		var/msg = "[key_name(client)] has a banned account in connection history! (Matched: [found["ckey"]], [found["address"]], [found["computer_id"]])"
 		message_admins(msg)
-		log_admin_private(msg)
 		//log_suspicious_login(msg, access_log_mirror = FALSE)


### PR DESCRIPTION

# About the pull request

Our `message_admins` already logs, so all `log_admin` and `log_admin_private` that comes with it causes duplicated logs.

This comes from 3 sources:
 * Legacy code
 * Obvious merge artifacts after conflict resolution (found 2)
 * Upstream /tg/ code that presumably doesnt do that

Mostly left `log_game` alone unless it was obvious admin actions.

# Changelog

:cl:
admin: Removed some doubled up logging.
/:cl:
