### PR TITLE
More AI slop disabling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -71,7 +71,6 @@
 		".github/prompts": false
 	},
 	"chat.sendElementsToChat.attachCSS": false,
-	"chat.sendElementsToChat.attachImages": false,
 	"chat.sendElementsToChat.enabled": false,
 	"chat.setupFromDialog": false,
 	"chat.showAgentSessionsViewDescription": false,
@@ -122,5 +121,6 @@
 	"chat.mcp.gallery.enabled": false,
 	"mermaid-chat.enabled": false,
 	"githubPullRequests.experimental.useQuickChat": false,
-	"chat.useAgentSkills": false
+	"chat.useAgentSkills": false,
+	"workbench.browser.sendElementsToChat.attachImages": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -122,5 +122,25 @@
 	"mermaid-chat.enabled": false,
 	"githubPullRequests.experimental.useQuickChat": false,
 	"chat.useAgentSkills": false,
-	"workbench.browser.sendElementsToChat.attachImages": false
+	"workbench.browser.sendElementsToChat.attachImages": false,
+	"workbench.commandPalette.showAskInChat": false,
+	"workbench.browser.enableChatTools": false,
+	"chat.agent.sandbox.allowAutoApprove": false,
+	"chat.agent.sandbox.allowUnsandboxedCommands": false,
+	"chat.agent.sandbox.retryWithAllowNetworkRequests": false,
+	"chat.agent.thinking.terminalTools": false,
+	"chat.tools.riskAssessment.enabled": false,
+	"chat.tools.terminal.autoApproveWorkspaceNpmScripts": false,
+	"chat.mcp.apps.enabled": false,
+	"chat.mcp.autostart": "never",
+	"chat.includeApplyingInstructions": false,
+	"chat.useClaudeMdFile": false,
+	"inlineChat.fixDiagnostics": false,
+	"chat.plugins.enabled": false,
+	"chat.checkpoints.enabled": false,
+	"git.addAICoAuthor": "all",
+	"dotnetAcquisitionExtension.enableLanguageModelTools": false,
+	"chat.tools.edits.autoApprove": {
+		"**/*": false
+	}
 }


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #11458 where seemingly they depreciated `chat.sendElementsToChat.attachImages` for `workbench.browser.sendElementsToChat.attachImages `causing automatic changes. Does not appear to be mentioned in https://code.visualstudio.com/updates/v1_128 and the old variable is still mentioned in https://code.visualstudio.com/docs/chat/copilot-chat-context#_add-browser-context so *shrugs*

The rest of the settings are just me manually searching the settings again for AI, Agent, Chat, and LLM.

# Explain why it's good for the game

[AI slop bad.](https://github.com/cmss13-devs/cmss13/blob/master/.github/CONTRIBUTING.md#generative-ai)

# Changelog

No player facing changes.
