### PR TITLE
Fix: Terminals on the right plane

### DIFF
--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/structures/machinery/power.dmi'
 	icon_state = "term"
 	desc = "It's an underfloor wiring terminal for power equipment."
+	plane = FLOOR_PLANE
 	level = 1
 	var/obj/structure/machinery/power/master = null
 	anchored = TRUE


### PR DESCRIPTION

# About the pull request
Terminals get their plane changed from the inherited -5 to -7 so they layer under the floor properly now.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Fix good
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="288" height="236" alt="image" src="https://github.com/user-attachments/assets/31096ade-8b46-4f53-bad2-56a2767dc804" />

</details>


# Changelog
:cl:
fix: APC terminals no longer overlay over catwalks and the like
/:cl:
