### PR TITLE
refactor: Require all overrides of Crossed to call parent

### DIFF
--- a/code/__DEFINES/dcs/signals/atom/signals_atom.dm
+++ b/code/__DEFINES/dcs/signals/atom/signals_atom.dm
@@ -55,3 +55,6 @@
 
 //from base of atom/Exited(): (atom/movable/exiting, direction)
 #define COMSIG_ATOM_EXITED "atom_exited"
+
+/// Called when an atom is crossed by a movable atom
+#define COMSIG_ATOM_CROSSED "atom_crossed"

--- a/code/datums/tutorial/marine/reqs_line.dm
+++ b/code/datums/tutorial/marine/reqs_line.dm
@@ -491,6 +491,7 @@
 
 /// Deletes dummies coming onto it, purely and simply
 /obj/effect/landmark/tutorial/reqs_line_cleaner/Crossed(atom/movable/passer)
+	..()
 	if(istype(passer, /mob/living/carbon/human))
 		qdel(passer)
 

--- a/code/datums/weakrefs.dm
+++ b/code/datums/weakrefs.dm
@@ -25,6 +25,7 @@
 	return ..()
 
 /datum/weakref/proc/resolve()
+	RETURN_TYPE(/datum)
 	var/datum/D = locate(reference)
 	return (!QDELETED(D) && D.weak_reference == src) ? D : null
 

--- a/code/game/machinery/ARES/ARES_step_triggers.dm
+++ b/code/game/machinery/ARES/ARES_step_triggers.dm
@@ -16,29 +16,35 @@
 	var/list/pass_jobs = list(JOB_WORKING_JOE, JOB_CHIEF_ENGINEER, JOB_CO)
 	/// The accesses on an ID card to enter
 	var/pass_accesses = list(ACCESS_MARINE_AI, ACCESS_ARES_DEBUG)
+	/// Look at can_trigger for conditions to trigger on Crossed call
+	can_trigger_proc_ref = TYPE_PROC_REF(/obj/effect/step_trigger/ares_alert, can_trigger_wrapper)
 
-/obj/effect/step_trigger/ares_alert/Crossed(mob/living/passer)
+/// Wrapper function to allow overriding can_trigger in child types
+/obj/effect/step_trigger/ares_alert/proc/can_trigger_wrapper(atom/movable/passer)
+	return can_trigger(passer)
+
+/obj/effect/step_trigger/ares_alert/proc/can_trigger(atom/movable/passer)
 	if(!COOLDOWN_FINISHED(src, sensor_cooldown))//Don't want alerts spammed.
 		return FALSE
 	if(!passer)
 		return FALSE
 	if(!(ishuman(passer) || isxeno(passer)))
 		return FALSE
-	if(HAS_TRAIT(passer, TRAIT_CLOAKED))
+	var/mob/living/passer_mob = passer
+	if(HAS_TRAIT(passer_mob, TRAIT_CLOAKED))
 		return FALSE
 	if(pass_jobs)
-		if(passer.job in pass_jobs)
+		if(passer_mob.job in pass_jobs)
 			return FALSE
-		if(isxeno(passer) && (JOB_XENOMORPH in pass_jobs))
+		if(isxeno(passer_mob) && (JOB_XENOMORPH in pass_jobs))
 			return FALSE
-	if(ishuman(passer))
+	if(ishuman(passer_mob))
 		var/mob/living/carbon/human/trespasser = passer
 		var/obj/item/card/id/card = trespasser.get_idcard()
 		if(pass_accesses && card)
 			for(var/tag in pass_accesses)
 				if(tag in card.access)
 					return FALSE
-	Trigger(passer)
 	return TRUE
 
 
@@ -110,48 +116,45 @@
 	alert_id = "ARES Access"
 	cooldown_duration = COOLDOWN_ARES_ACCESS_CONTROL
 
+/obj/effect/step_trigger/ares_alert/access_control/proc/get_id_card(atom/movable/passer)
+	if(ishuman(passer))
+		var/mob/living/carbon/human/human_passer = passer
+		var/obj/item/card/id/idcard = human_passer.get_idcard()
+		return idcard
 
-/obj/effect/step_trigger/ares_alert/access_control/Crossed(atom/passer as mob|obj)
-	if(isobserver(passer) || isxeno(passer) || ishologram(passer))
-		return FALSE
-	if(!passer)
+	if(istype(passer, /obj/item/card/id))
+		return passer
+
+	var/obj/item/card/id/idcard = locate(/obj/item/card/id) in passer
+	if(!idcard)
+		for(var/obj/item/holder in passer.contents)
+			idcard = locate(/obj/item/card/id) in holder.contents
+			if(idcard)
+				break
+	return idcard
+
+/obj/effect/step_trigger/ares_alert/access_control/can_trigger(atom/movable/passer)
+	if(!passer || isobserver(passer) || isxeno(passer) || ishologram(passer))
 		return FALSE
 	if(HAS_TRAIT(passer, TRAIT_CLOAKED))//Can't be seen/detected to trigger alert.
 		return FALSE
 	var/area/pass_area = get_area(get_step(passer, passer.dir))
 	if(istype(pass_area, /area/almayer/command/airoom))//Don't want it to freak out over someone /entering/ the area. Only leaving.
 		return FALSE
-	var/obj/item/card/id/idcard
-	var/check_contents = TRUE
-	if(ishuman(passer))
-		var/mob/living/carbon/human/human_passer = passer
-		idcard = human_passer.get_idcard()
-		if(idcard)
-			check_contents = FALSE
-
-	if(istype(passer, /obj/item/card/id))
-		idcard = passer
-		check_contents = FALSE
-
-	if(check_contents)
-		idcard = locate(/obj/item/card/id) in passer
-		if(!idcard)
-			for(var/obj/item/holder in passer.contents)
-				idcard = locate(/obj/item/card/id) in holder.contents
-				if(idcard)
-					break
+	var/obj/item/card/id/idcard = get_id_card(passer)
 	if(!istype(idcard))
 		if(ismob(passer))
-			Trigger(passer, failure = TRUE)
+			return TRUE
 		return FALSE
 	if(!(ACCESS_MARINE_AI_TEMP in idcard.access))//No temp access, don't care
 		return FALSE
 	if((ACCESS_MARINE_AI in idcard.access) || (ACCESS_ARES_DEBUG in idcard.access))//Permanent access prevents loss of temporary
 		return FALSE
-	Trigger(passer, idcard)
 	return TRUE
 
-/obj/effect/step_trigger/ares_alert/access_control/Trigger(atom/passer, obj/item/card/id/idcard, failure = FALSE)
+/obj/effect/step_trigger/ares_alert/access_control/Trigger(atom/passer)
+	var/obj/item/card/id/idcard = get_id_card(passer)
+	var/failure = (!istype(idcard) && ismob(passer))
 	var/broadcast_message = get_broadcast(passer, idcard, failure)
 
 	var/datum/ares_link/link = GLOB.ares_link

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -139,15 +139,6 @@
 	density = TRUE
 	anchored = TRUE
 
-/*
-//Allow you to push disposal pipes into it (for those with density 1)
-/obj/structure/machinery/pipedispenser/disposal/Crossed(obj/structure/disposalconstruct/pipe as obj)
-	if(istype(pipe) && !pipe.anchored)
-		qdel(pipe)
-
-Nah
-*/
-
 //Allow you to drag-drop disposal pipes into it
 /obj/structure/machinery/pipedispenser/disposal/MouseDrop_T(obj/structure/disposalconstruct/pipe as obj, mob/user as mob)
 	if(user.is_mob_incapacitated())

--- a/code/game/objects/effects/decals/cleanable/blood/blood.dm
+++ b/code/game/objects/effects/decals/cleanable/blood/blood.dm
@@ -17,6 +17,7 @@
 	var/amount = 3
 	var/drying_time = 30 SECONDS
 	var/dry_start_time // If this dries, track the dry start time for footstep drying
+	var/apply_bloody_feet = TRUE
 	garbage = FALSE // Keep for atmosphere
 
 /obj/effect/decal/cleanable/blood/Destroy()
@@ -43,7 +44,11 @@
 		addtimer(CALLBACK(src, PROC_REF(dry)), drying_time * (amount+1))
 
 /obj/effect/decal/cleanable/blood/Crossed(atom/movable/AM)
-	. = ..()
+	..()
+
+	if (!apply_bloody_feet)
+		return
+
 	// Check if the blood is dry and only humans
 	// can make footprints
 	if(!amount || !ishuman(AM) || QDELETED(AM))

--- a/code/game/objects/effects/decals/cleanable/blood/tracks.dm
+++ b/code/game/objects/effects/decals/cleanable/blood/tracks.dm
@@ -8,6 +8,7 @@
 	var/going_state="blood2"
 	cleanable_type = CLEANABLE_TRACKS
 	overlay_on_initialize = TRUE
+	apply_bloody_feet = FALSE
 
 	var/list/steps_in
 	var/list/steps_out
@@ -16,9 +17,6 @@
 
 	/// Amount of pixels to shift either way in an attempt to make the tracks more organic
 	var/transverse_amplitude = 3
-
-/obj/effect/decal/cleanable/blood/tracks/Crossed()
-	return
 
 /obj/effect/decal/cleanable/blood/tracks/can_place_cleanable()
 	return FALSE

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -175,6 +175,7 @@
 	icon_state = "blackgoo"
 
 /obj/effect/decal/cleanable/blackgoo/Crossed(mob/living/carbon/human/H)
+	..()
 	if(!istype(H))
 		return
 	if(H.species.name == "Human")

--- a/code/game/objects/effects/effect_system/foam.dm
+++ b/code/game/objects/effects/effect_system/foam.dm
@@ -93,6 +93,7 @@
 
 
 /obj/effect/particle_effect/foam/Crossed(atom/movable/AM)
+	..()
 	if(metal)
 		return
 	if (iscarbon(AM))

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -19,6 +19,7 @@
 	var/spread_speed = 1 //time in decisecond for a smoke to spread one tile.
 	var/time_to_live = 8
 	var/smokeranking = SMOKE_RANK_HARMLESS //Override priority. A higher ranked smoke cloud will displace lower and equal ones on spreading.
+	var/affect_on_cross = TRUE
 	var/datum/cause_data/cause_data = null
 	//does it obscure aim
 	var/obscuring = TRUE
@@ -87,7 +88,7 @@
 	if(istype(moveable, /obj/projectile/beam) && obscuring)
 		var/obj/projectile/beam/beam = moveable
 		beam.damage /= 2
-	if(iscarbon(moveable))
+	if(iscarbon(moveable) && affect_on_cross)
 		affect(moveable)
 
 /obj/effect/particle_effect/smoke/proc/apply_smoke_effect(turf/cur_turf)
@@ -545,6 +546,7 @@
 	anchored = TRUE
 	spread_speed = 6
 	smokeranking = SMOKE_RANK_BOILER
+	affect_on_cross = FALSE
 
 	var/hivenumber = XENO_HIVE_NORMAL
 	var/gas_damage = 20
@@ -571,10 +573,6 @@
 
 	for(var/obj/structure/machinery/m56d_hmg/auto/gun in cur_turf)
 		gun.update_health(XENO_ACID_HMG_DAMAGE)
-
-//No effect when merely entering the smoke turf, for balance reasons
-/obj/effect/particle_effect/smoke/xeno_burn/Crossed(mob/living/carbon/affected_mob as mob)
-	return
 
 /obj/effect/particle_effect/smoke/xeno_burn/affect(mob/living/carbon/affected_mob)
 	. = ..()
@@ -625,13 +623,12 @@
 	spread_speed = 5
 	amount = 1 //Amount depends on Boiler upgrade!
 	smokeranking = SMOKE_RANK_BOILER
+	affect_on_cross = FALSE
+
 	/// How much neuro is dosed per tick
 	var/neuro_dose = 6
 	var/msg = "Your skin tingles as the gas consumes you!" // Message given per tick. Changes depending on which species is hit.
 
-//No effect when merely entering the smoke turf, for balance reasons
-/obj/effect/particle_effect/smoke/xeno_weak/Crossed(mob/living/carbon/moob as mob)
-	return
 
 /obj/effect/particle_effect/smoke/xeno_weak/affect(mob/living/carbon/moob) // This applies every tick someone is in the smoke
 	. = ..()
@@ -688,12 +685,11 @@
 	smokeranking = SMOKE_RANK_BOILER
 
 //No effect when merely entering the smoke turf, for balance reasons
-/obj/effect/particle_effect/smoke/xeno_weak_fire/Crossed(mob/living/carbon/moob as mob)
-	if(!istype(moob))
-		return
+/obj/effect/particle_effect/smoke/xeno_weak_fire/Crossed(mob/living/carbon/moob)
+	..()
 
-	moob.ExtinguishMob()
-	. = ..()
+	if(istype(moob))
+		moob.ExtinguishMob()
 
 /obj/effect/particle_effect/smoke/xeno_weak_fire/affect(mob/living/carbon/moob)
 	. = ..()

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -14,6 +14,7 @@
 	INVOKE_ASYNC(src, PROC_REF(teleport), AM)
 
 /obj/effect/portal/Crossed(AM as mob|obj)
+	..()
 	INVOKE_ASYNC(src, PROC_REF(teleport), AM)
 
 /obj/effect/portal/attack_hand(mob/user as mob)

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -4,22 +4,26 @@
 	var/affect_ghosts = 0
 	var/stopper = 1 // stops throwers
 	invisibility = 101 // nope can't see this shit
+	/// Proc ref for any method to check a trigger
+	var/can_trigger_proc_ref
 	anchored = TRUE
 	icon = 'icons/landmarks.dmi'
 	icon_state = "trigger"
 	flags_atom = NO_ZFALL
 
 /obj/effect/step_trigger/proc/Trigger(atom/movable/A)
-	return 0
+	return
 
-/obj/effect/step_trigger/Crossed(H as mob|obj)
+/obj/effect/step_trigger/Crossed(atom/movable/crossed_by)
 	..()
-	if(!H)
+	if(!crossed_by)
 		return
-	if(istype(H, /mob/dead/observer) && !affect_ghosts)
+	if(istype(crossed_by, /mob/dead/observer) && !affect_ghosts)
 		return
-	Trigger(H)
-
+	/// If we have a proc to validate trigger, call it to see whether trigger can occur
+	if(can_trigger_proc_ref && !call(src, can_trigger_proc_ref)(crossed_by))
+		return
+	Trigger(crossed_by)
 
 
 /* Tosses things in a certain direction */

--- a/code/game/objects/items/devices/radio/motion_sensor.dm
+++ b/code/game/objects/items/devices/radio/motion_sensor.dm
@@ -69,27 +69,27 @@
 		name = initial(name)
 
 /obj/item/device/motion_sensor/Crossed(mob/living/passer)
+	..()
 	if(!anchored)//Not working if it isn't on the floor.
-		return FALSE
+		return
 	if(!transceiver || !voice)//Can't send if there's no radio or voice
-		return FALSE
+		return
 	if(!COOLDOWN_FINISHED(src, sensor_cooldown))//Don't want alerts spammed.
-		return FALSE
+		return
 	if(!passer)
-		return FALSE
+		return
 	if(!(ishuman(passer) || isxeno(passer)))
-		return FALSE
+		return
 	if(HAS_TRAIT(passer, TRAIT_CLOAKED))
-		return FALSE
+		return
 	if(pass_jobs)
 		if(passer.job in pass_jobs)
-			return FALSE
+			return
 		if(isxeno(passer) && (JOB_XENOMORPH in pass_jobs))
-			return FALSE
+			return
 	if(allowed(passer))
-		return FALSE
+		return
 	send_alert(passer)
-	return TRUE
 
 /obj/item/device/motion_sensor/proc/send_alert(mob/living/passer, message_override)
 	var/broadcast_message = alert_message

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -332,6 +332,7 @@
 	return
 
 /obj/effect/mine_tripwire/Crossed(atom/movable/AM)
+	..()
 	if(!linked_claymore)
 		qdel(src)
 		return

--- a/code/game/objects/items/legcuffs.dm
+++ b/code/game/objects/items/legcuffs.dm
@@ -69,6 +69,7 @@
 		to_chat(user, SPAN_NOTICE("[src] is now [armed ? "armed" : "disarmed"]"))
 
 /obj/item/restraint/legcuffs/beartrap/Crossed(atom/movable/AM)
+	..()
 	if(armed)
 		if(ismob(AM))
 			var/mob/M = AM
@@ -92,8 +93,6 @@
 					armed = 0
 					var/mob/living/simple_animal/SA = AM
 					SA.health -= 20
-	..()
-
 
 /obj/item/restraint/legcuffs/xeno_restraints
 	name = "xeno restraints"

--- a/code/game/objects/items/lightstick.dm
+++ b/code/game/objects/items/lightstick.dm
@@ -20,6 +20,7 @@
 		set_light_range(0)
 
 /obj/item/lightstick/Crossed(mob/living/O)
+	..()
 	if(anchored && prob(trample_chance) && can_trample)
 		if(!istype(O,/mob/living/carbon/xenomorph/larva))
 			visible_message(SPAN_DANGER("[O] tramples [src]!"))

--- a/code/game/objects/items/misc.dm
+++ b/code/game/objects/items/misc.dm
@@ -11,6 +11,7 @@
 	garbage = TRUE
 
 /obj/item/bananapeel/Crossed(AM as mob|obj)
+	..()
 	if (iscarbon(AM))
 		var/mob/living/carbon/C = AM
 		C.slip(name, 4, 2)

--- a/code/game/objects/items/reagent_containers/food/snacks/grown.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks/grown.dm
@@ -484,6 +484,7 @@
 	return
 
 /obj/item/reagent_container/food/snacks/grown/bluetomato/Crossed(AM as mob|obj)
+	..()
 	if (iscarbon(AM))
 		var/mob/living/carbon/C = AM
 		C.slip(name, 8, 5)

--- a/code/game/objects/items/tools/cleaning_tools.dm
+++ b/code/game/objects/items/tools/cleaning_tools.dm
@@ -139,6 +139,7 @@
 	throw_range = 20
 
 /obj/item/tool/soap/Crossed(atom/movable/AM)
+	..()
 	if (iscarbon(AM))
 		var/mob/living/carbon/C =AM
 		C.slip("soap", 3, 2)

--- a/code/game/objects/items/toys/toys.dm
+++ b/code/game/objects/items/toys/toys.dm
@@ -165,6 +165,7 @@
 	qdel(src)
 
 /obj/item/toy/snappop/Crossed(H as mob|obj)
+	..()
 	if((ishuman(H))) //i guess carp and shit shouldn't set them off
 		var/mob/living/carbon/M = H
 		to_chat(M, SPAN_WARNING("You step on the snap pop!"))

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -811,6 +811,7 @@ ICEY GRASS. IT LOOKS LIKE IT'S MADE OF ICE.
 
 
 /obj/structure/flora/jungle/thickbush/Crossed(atom/movable/AM)
+	..()
 	if(!stump)
 		if(isliving(AM))
 			var/mob/living/L = AM

--- a/code/game/objects/structures/roof.dm
+++ b/code/game/objects/structures/roof.dm
@@ -80,6 +80,7 @@
 	var/datum/roof_master_node/linked_master
 
 /obj/effect/roof_node/Crossed(atom/movable/mover, target_dir)
+	..()
 	if(!linked_master)
 		return
 	if(isliving(mover))

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -76,6 +76,7 @@
 
 /obj/structure/surface/table/Crossed(atom/movable/O)
 	..()
+	// TODO: Replace this with signals or trait checks from xeno
 	if(istype(O,/mob/living/carbon/xenomorph/ravager) || istype(O,/mob/living/carbon/xenomorph/crusher))
 		var/mob/living/carbon/xenomorph/M = O
 		if(!M.stat) //No dead xenos jumpin on the bed~
@@ -724,6 +725,7 @@
 
 /obj/structure/surface/rack/Crossed(atom/movable/O)
 	..()
+	// TODO: Replace this with signals or trait check from xeno
 	if(istype(O,/mob/living/carbon/xenomorph/ravager) || istype(O,/mob/living/carbon/xenomorph/crusher))
 		var/mob/living/carbon/xenomorph/M = O
 		if(!M.stat) //No dead xenos jumpin on the bed~

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -111,6 +111,7 @@
 		special_assembly.HasProximity(AM)
 
 /obj/item/device/assembly_holder/Crossed(atom/movable/AM as mob|obj)
+	..()
 	if(a_left)
 		a_left.Crossed(AM)
 	if(a_right)

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -261,6 +261,7 @@
 	return
 
 /obj/effect/beam/i_beam/Crossed(atom/movable/AM as mob|obj)
+	..()
 	if(istype(AM, /obj/effect/beam))
 		return
 	spawn(0)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -88,6 +88,7 @@
 
 
 /obj/item/device/assembly/mousetrap/Crossed(atom/movable/AM)
+	..()
 	if(armed)
 		if(ishuman(AM))
 			var/mob/living/carbon/H = AM
@@ -95,7 +96,6 @@
 			H.visible_message(SPAN_WARNING("[H] accidentally steps on [src]."),SPAN_WARNING("You accidentally step on [src]"))
 		if(ismouse(AM))
 			triggered(AM)
-	..()
 
 
 /obj/item/device/assembly/mousetrap/on_found(mob/finder as mob)

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -168,15 +168,15 @@
 		RegisterSignal(SSdcs, COMSIG_GLOB_GROUNDSIDE_FORSAKEN_HANDLING, PROC_REF(forsaken_handling))
 
 /obj/effect/alien/resin/sticky/Crossed(atom/movable/AM)
-	. = ..()
+	..()
 	var/mob/living/carbon/human/H = AM
 	if(istype(H) && !H.ally_of_hivenumber(hivenumber))
 		H.next_move_slowdown = max(H.next_move_slowdown, slow_amt)
-		return .
+		return
 	var/mob/living/carbon/xenomorph/X = AM
 	if(istype(X) && !X.ally_of_hivenumber(hivenumber))
 		X.next_move_slowdown = max(X.next_move_slowdown, slow_amt)
-		return .
+		return
 
 /obj/effect/alien/resin/sticky/proc/forsaken_handling()
 	SIGNAL_HANDLER
@@ -217,7 +217,7 @@
 		RegisterSignal(SSdcs, COMSIG_GLOB_GROUNDSIDE_FORSAKEN_HANDLING, PROC_REF(forsaken_handling))
 
 /obj/effect/alien/resin/spike/Crossed(atom/movable/AM)
-	. = ..()
+	..()
 	var/mob/living/carbon/H = AM
 	if(!istype(H))
 		return
@@ -261,11 +261,8 @@
 	desc = "A layer of disgusting sleek slime."
 	icon_state = "fast"
 	health = HEALTH_RESIN_XENO_FAST
+	slow_amt = 0
 	var/speed_amt = 0.7
-
-/obj/effect/alien/resin/sticky/fast/Crossed(atom/movable/AM)
-	return
-
 
 //xeno marker :0)
 /obj/effect/alien/resin/marker

--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -311,6 +311,7 @@
 		Burst(TRUE)
 
 /obj/effect/alien/egg/Crossed(atom/movable/AM)
+	..()
 	HasProximity(AM)
 
 /obj/effect/alien/egg/HasProximity(atom/movable/AM)
@@ -372,6 +373,7 @@
 
 
 /obj/effect/egg_trigger/Crossed(atom/movable/AM)
+	..()
 	if(!linked_egg && !linked_eggmorph) //something went very wrong.
 		qdel(src)
 	else if(linked_egg && (get_dist(src, linked_egg) != 1 || !isturf(linked_egg.loc))) //something went wrong

--- a/code/modules/cm_aliens/structures/trap.dm
+++ b/code/modules/cm_aliens/structures/trap.dm
@@ -271,6 +271,7 @@
 	..()
 
 /obj/effect/alien/resin/trap/Crossed(atom/A)
+	..()
 	if(ismob(A) || isVehicleMultitile(A))
 		HasProximity(A)
 
@@ -293,6 +294,7 @@
 	. = ..()
 
 /obj/effect/trap_tripwire/Crossed(atom/A)
+	..()
 	if(!linked_trap)
 		qdel(src)
 		return

--- a/code/modules/cm_aliens/structures/xeno_structures_boilertrap.dm
+++ b/code/modules/cm_aliens/structures/xeno_structures_boilertrap.dm
@@ -63,14 +63,14 @@
 	return XENO_NO_DELAY_ACTION
 
 /obj/effect/alien/resin/boilertrap/Crossed(atom/A)
+	..()
+
 	if (isxeno(A))
 		var/mob/living/carbon/xenomorph/X = A
 		if (X.hivenumber != hivenumber)
 			trigger_trap(A)
 	else if(ishuman(A))
 		trigger_trap(A)
-
-	return ..()
 
 /obj/effect/hole_tripwire_boiler
 	name = "hole tripwire"
@@ -86,6 +86,7 @@
 	return ..()
 
 /obj/effect/hole_tripwire_boiler/Crossed(atom/A)
+	..()
 	if(!linked_trap)
 		qdel(src)
 		return

--- a/code/modules/cm_aliens/weeds.dm
+++ b/code/modules/cm_aliens/weeds.dm
@@ -176,6 +176,7 @@
 
 
 /obj/effect/alien/weeds/Crossed(atom/movable/atom_movable)
+	..()
 	if(!isliving(atom_movable))
 		return
 

--- a/code/modules/cm_preds/yaut_items.dm
+++ b/code/modules/cm_preds/yaut_items.dm
@@ -1181,6 +1181,7 @@ GLOBAL_VAR_INIT(youngblood_timer_yautja, 0)
 	return COMPONENT_CANCEL_XENO_HEAL
 
 /obj/item/hunting_trap/Crossed(atom/movable/AM)
+	..()
 	if(armed && ismob(AM))
 		var/mob/trap_mob = AM
 		if(!trap_mob.buckled)
@@ -1201,7 +1202,6 @@ GLOBAL_VAR_INIT(youngblood_timer_yautja, 0)
 				armed = FALSE
 				var/mob/living/simple_animal/simple_mob = trap_mob
 				simple_mob.health -= 20
-	..()
 
 /obj/item/hunting_trap/proc/cleanup_tether()
 	if (tether_effect)

--- a/code/modules/defenses/bell_tower.dm
+++ b/code/modules/defenses/bell_tower.dm
@@ -98,6 +98,7 @@
 	. = ..()
 
 /obj/effect/bell_tripwire/Crossed(atom/movable/A)
+	..()
 	if(!linked_bell)
 		qdel(src)
 		return

--- a/code/modules/desert_dam/filtration/water_toxic.dm
+++ b/code/modules/desert_dam/filtration/water_toxic.dm
@@ -51,6 +51,7 @@
 		C.update_icon()
 
 /obj/effect/blocker/water/toxic/Crossed(atom/A)
+	..()
 	if(toxic == WATER_TOXIC_NO)
 		return
 

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -229,6 +229,7 @@ Gunshots/explosions/opening doors/less rare audio (done)
 	src.health -= P.force
 
 /obj/effect/fake_attacker/Crossed(mob/M, somenumber)
+	..()
 	if(M.weak_reference != weak_target)
 		return
 	step_away(src,M,2,world.icon_size/move_delay)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -328,6 +328,7 @@
 // called when something steps onto a human
 // this handles mulebots and vehicles
 /mob/living/carbon/human/Crossed(atom/movable/AM)
+	..()
 	if(istype(AM, /obj/structure/machinery/bot/mulebot))
 		var/obj/structure/machinery/bot/mulebot/MB = AM
 		MB.RunOver(src)

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -212,6 +212,8 @@
 	go_idle()
 
 /obj/item/clothing/mask/facehugger/Crossed(atom/target)
+	..()
+	
 	has_proximity(target)
 
 /obj/item/clothing/mask/facehugger/on_found(mob/finder)

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -84,6 +84,7 @@
 	return
 
 /mob/living/simple_animal/small/mouse/Crossed(AM as mob|obj)
+	..()
 	if( ishuman(AM) )
 		if(!ckey && stat == UNCONSCIOUS)
 			set_stat(CONSCIOUS)
@@ -93,7 +94,6 @@
 			var/mob/M = AM
 			to_chat(M, SPAN_NOTICE("[icon2html(src, M)] Squeek!"))
 			M << 'sound/effects/mousesqueek.ogg'
-	..()
 
 /mob/living/simple_animal/small/mouse/death()
 	layer = ABOVE_LYING_MOB_LAYER

--- a/code/modules/movement/movement.dm
+++ b/code/modules/movement/movement.dm
@@ -56,6 +56,7 @@
 
 	return NO_BLOCKED_MOVEMENT
 
+// TODO: Remove any and all overrides of this proc
 /atom/movable/Move(NewLoc, direct)
 	// If Move is not valid, exit
 	if (SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, NewLoc) & COMPONENT_CANCEL_MOVE)
@@ -78,7 +79,14 @@
 		Moved(oldloc, direct)
 
 	handle_rotation()
-	
+
+/// Called when `crossed_by` enters the atom's turf (via native Move() or doMove() if allowed).
+/// Does not return anything, only handles side effects from Crossed.
+/atom/Crossed(atom/movable/crossed_by)
+	SHOULD_CALL_PARENT(TRUE)
+	SEND_SIGNAL(src, COMSIG_ATOM_CROSSED, crossed_by)
+
+	..()
 
 /// Called when a movable atom has hit an atom via movement
 /atom/movable/proc/Collide(atom/A)

--- a/code/modules/projectiles/guns/flamer/flamer.dm
+++ b/code/modules/projectiles/guns/flamer/flamer.dm
@@ -772,6 +772,7 @@ GLOBAL_LIST_EMPTY(flamer_particles)
 		PF.flags_pass = PASS_FLAGS_FLAME
 
 /obj/flamer_fire/Crossed(atom/movable/atom_movable)
+	..()
 	atom_movable.handle_flamer_fire_crossed(src)
 
 /obj/flamer_fire/proc/type_b_debuff_xeno_armor(mob/living/carbon/xenomorph/X)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -132,6 +132,7 @@
 			qdel(src)
 
 /obj/projectile/Crossed(atom/movable/AM)
+	..()
 	/* Fun fact: Crossed is called for any contents involving operations.
 	 * This notably means, inserting a magazing in a gun Crossed() it with the bullets in the gun. */
 	if(!loc?.z)

--- a/code/modules/sorokyne/sorokyne_hot_water.dm
+++ b/code/modules/sorokyne/sorokyne_hot_water.dm
@@ -14,6 +14,7 @@
 	invisibility = 101
 
 /obj/effect/blocker/sorokyne_hot_water/Crossed(mob/living/affected_mob)
+	..()
 	if(!ismob(affected_mob))
 		return
 	if(affected_mob.stat == DEAD)


### PR DESCRIPTION

# About the pull request

First change as part of a series of changes to refactor the launching into a subsystem. Extracted from my original PR here: https://github.com/cmss13-devs/cmss13/pull/7110

# Explain why it's good for the game

- Routing all Crossed calls to parent will allow us to have signals setup on Crossed

- Part of a larger charge to move launching into a subsystem, which should be preferable to sleeps


# Testing Photographs and Procedure

<details>
<summary>Testing ARES step triggers</summary>

Triggers broadcast for AI mob as expected

https://github.com/user-attachments/assets/3caab83f-4271-4c03-81da-d82f5013f615

</details>


<details>
<summary>Testing facehugger Crossed trigger</summary>

https://github.com/user-attachments/assets/c1f4874c-d011-464d-8ea5-a2a47c0dfaab

</details>


<details>
<summary>Testing bloody feet Crossed trigger </summary>

Blood decal causes bloody feet, bloody tracks does NOT cause bloody feet

https://github.com/user-attachments/assets/ddf7a998-4556-4917-a08e-962dc961d5c2


</details>

<details>
<summary>Testing boiler gas Crossed trigger </summary>

Boiler gas does not cause damage on Crossed

https://github.com/user-attachments/assets/355a12cc-7100-41c6-a448-f2abcda0757c


</details>

<details>
<summary>Testing fast resin does not cause slow down</summary>


https://github.com/user-attachments/assets/e06414e3-c1a3-480c-9d14-616465e82018


</details>




# Changelog
:cl: TheDonkified
refactor: Refactors Crossed function so that all calls to Crossed must route to the parent Crossed function
/:cl:
