### PR TITLE
Removes tripping over lightpost stumps on Hybrisia

### DIFF
--- a/code/game/objects/structures/hybrisa_props.dm
+++ b/code/game/objects/structures/hybrisa_props.dm
@@ -2780,14 +2780,6 @@
 	explo_proof = TRUE
 	health = null
 
-/obj/structure/prop/hybrisa/misc/pole_stump/Crossed(atom/movable/crosser)
-	. = ..()
-	if(ishuman(crosser) && prob(10))
-		var/mob/living/carbon/human/crossing_human = crosser
-		crossing_human.visible_message(SPAN_DANGER("[crossing_human] trips on [src] and falls prone."))
-		playsound(loc, 'sound/weapons/alien_knockdown.ogg', 25, 1)
-		crossing_human.KnockDown(0.5)
-
 /obj/structure/prop/hybrisa/misc/pole_stump/traffic
 	name = "colony streetlight stump"
 	icon = 'icons/obj/structures/props/streetlights.dmi'


### PR DESCRIPTION
# About the pull request

title

# Explain why it's good for the game

we've had this for over a year now. i love hybrisia, i know that's an unpopular take, but oh my god these fuckass stumps. the stun is too short to practically matter very much in 99% of situations so all it does is massively annoy the player. in situations where it does do something, that also doesn't feel very good. 

it also for some reason only applies to marines, which if its going to exist why not apply to everyone? (but again, just why to begin with?)

i was talking to Maple the other day and they mentioned that this was the ONE thing about hybrisia they disliked, and i have the exact same opinion. i would wager others with this opinion also exist, and more still who have this on their list of dislikes. 

what purpose does it serve other than to be annoying? as punishment for marines destroying the light? (nevermind xenos can destroy them too). surely the lack of light is enough - no other map has this so it's just an unfun feature that makes people dislike a map for virtually no gain.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
del: Hybrisia lightpost stumps no longer trip humans walking over them.
/:cl: