### PR TITLE
Fixes "label label" for FTC, moves examine text to examine box.

### DIFF
--- a/code/modules/cm_marines/equipment/gear.dm
+++ b/code/modules/cm_marines/equipment/gear.dm
@@ -544,11 +544,11 @@
 	QDEL_NULL(camera)
 	return ..()
 
-/obj/structure/overwatch_camera_tripod/examine(mob/user)
+obj/structure/overwatch_camera_tripod/get_examine_text(mob/user)
 	. = ..()
-	to_chat(user, SPAN_INFO("The label label reads: [label]")) // ToDO: This maybe should be in the description box I just don't know how to add it atm
+	. += "The label reads: [label]"
 	if(squad)
-		to_chat(user, SPAN_INFO("It is currently assigned to squad: [squad.name]")) // ToDO: This maybe should be in the description box I just don't know how to add it atm
+		. += "It is currently assigned to squad: [squad.name]"
 
 /obj/structure/overwatch_camera_tripod/attack_hand(mob/user)
 	if(user.a_intent != INTENT_HELP) // I've left this in just in case maints want me to change the tgui menu to intent handling or smth.

--- a/code/modules/cm_marines/equipment/gear.dm
+++ b/code/modules/cm_marines/equipment/gear.dm
@@ -544,7 +544,7 @@
 	QDEL_NULL(camera)
 	return ..()
 
-obj/structure/overwatch_camera_tripod/get_examine_text(mob/user)
+/obj/structure/overwatch_camera_tripod/get_examine_text(mob/user)
 	. = ..()
 	. += "The label reads: [label]"
 	if(squad)


### PR DESCRIPTION
# About the pull request

1. Fixes "this label label reads"
2. Moves the box from a regular to_chat to examine box

# Explain why it's good for the game

Bad English bad
Looks nicer in the examine box.

# Testing Photographs and Procedure

<img width="876" height="229" alt="image" src="https://github.com/user-attachments/assets/53b25b92-d1cd-44b9-8953-91056c119ef2" />

# Changelog
:cl: DangerRevolution
fix: Fixes the Field Cameras' label reading "this label label reads"...
fix: Moves the Field Cameras' labels to the examine box rather than outputting it to the chatbox.
/:cl: