### PR TITLE
Fix: Not being able to immediately retract open a broken chest/head

### DIFF
--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -436,7 +436,7 @@
 	steps = list(
 		/datum/surgery_step/saw_encased,
 		/datum/surgery_step/open_encased_step,
-		/datum/surgery_step/clamp_bleeders_step, //oop i forgor, also cuz you can't clamp bleeders here, normally, for some reason
+		/datum/surgery_step/clamp_bleeders_step,
 		/datum/surgery_step/mend_encased,
 	)
 	pain_reduction_required = PAIN_REDUCTION_HEAVY

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -435,8 +435,8 @@
 	required_surgery_skill = SKILL_SURGERY_TRAINED
 	steps = list(
 		/datum/surgery_step/saw_encased,
-		/datum/surgery_step/clamp_bleeders_step, //oop i forgor, also cuz you can't clamp bleeders here, normally, for some reason
 		/datum/surgery_step/open_encased_step,
+		/datum/surgery_step/clamp_bleeders_step, //oop i forgor, also cuz you can't clamp bleeders here, normally, for some reason
 		/datum/surgery_step/mend_encased,
 	)
 	pain_reduction_required = PAIN_REDUCTION_HEAVY


### PR DESCRIPTION

# About the pull request
Title. Resolves: https://github.com/cmss13-devs/cmss13/issues/12645
Moves the clamp bleeders step to the third position because the second position is currently reserved for steps immediately after the first skipped step. Not optional steps. Meaning it unintentionally changed previous behaviour.

Also remove the comment as it doesn't really provide anything of note
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Fix good.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="1708" height="759" alt="image" src="https://github.com/user-attachments/assets/7d338a27-4a05-4b2b-b70c-8ed6b194cdac" />

</details>


# Changelog
:cl:
fix: Surgery to the chest/head no longer requires you to clamp bleeders up to twice before you can open it.
/:cl:
