### PR TITLE
Fix Runtime with Set Operations Commander admin verb

### DIFF
--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -408,13 +408,13 @@
 	for(var/job_by_chain in CHAIN_OF_COMMAND_ROLES)
 		role_in_charge = job_by_chain
 
-		if(job_by_chain == JOB_SO && GLOB.marine_leaders[JOB_SO])
+		if(job_by_chain == JOB_SO && length(GLOB.marine_leaders[JOB_SO]))
 			person_in_charge = pick(GLOB.marine_leaders[JOB_SO])
 			break
-		if(job_by_chain == JOB_INTEL && GLOB.marine_officers[JOB_INTEL])
+		if(job_by_chain == JOB_INTEL && length(GLOB.marine_officers[JOB_INTEL]))
 			person_in_charge = pick(GLOB.marine_officers[JOB_INTEL])
 			break
-		if(job_by_chain == JOB_DOCTOR && GLOB.marine_officers[JOB_DOCTOR])
+		if(job_by_chain == JOB_DOCTOR && length(GLOB.marine_officers[JOB_DOCTOR]))
 			person_in_charge = pick(GLOB.marine_officers[JOB_DOCTOR])
 			break
 


### PR DESCRIPTION

# About the pull request

Fixes #12650 

https://runtimes.cm-ss13.com/cm13/issues/3205

Don't try to pick() if there's nothing in the list, it doesn't work


# Testing Photographs and Procedure
Untested


# Changelog
:cl:
fix: Fixed 'Set Operations Commander' admin verb breaking under certain circumstances.
/:cl:
