### PR TITLE
Fixes Bulwark "reset strain" issue.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/xeno_strain.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/xeno_strain.dm
@@ -171,7 +171,7 @@
 		to_chat(src, SPAN_WARNING("We must be at full health to take a strain."))
 		return FALSE
 
-	if(agility || fortify || crest_defense || stealth)
+	if(agility || fortify || crest_defense || stealth || HAS_TRAIT(src, TRAIT_ABILITY_ENCLOSED_PLATES) || HAS_TRAIT(src, TRAIT_ABILITY_REFLECTIVE_PLATES))
 		to_chat(src, SPAN_WARNING("We cannot take a strain while in this stance."))
 		return FALSE
 


### PR DESCRIPTION
# About the pull request

Fixes: #12629

# Explain why it's good for the game

issues bad, fixing? good.

# Testing Procedure:

 Run code, no compile errors.
 Spawn Warrior, strain to bulwark, activate encasing plates, cannot reset strain.
 Disengage encasing plates, can reset strain.
 
 Code works as intended.
 
 
# Changelog

:cl: Venuska1117
fix: Made player unable to reset strain as bulwark when they have stances active like encasing plates or reflective plates.
/:cl:

