### PR TITLE
feat: Add ignitable and igniter traits

### DIFF
--- a/code/__DEFINES/dcs/signals/atom/signals_atom.dm
+++ b/code/__DEFINES/dcs/signals/atom/signals_atom.dm
@@ -55,3 +55,6 @@
 
 //from base of atom/Exited(): (atom/movable/exiting, direction)
 #define COMSIG_ATOM_EXITED "atom_exited"
+
+/// Called when an ignitable atom is ignited
+#define COMSIG_ATOM_IGNITE "atom_ignite"

--- a/code/__DEFINES/dcs/signals/atom/signals_item.dm
+++ b/code/__DEFINES/dcs/signals/atom/signals_item.dm
@@ -66,3 +66,6 @@
 //from /datum/component/overwatch_console_control
 #define COMSIG_OW_CONSOLE_OBSERVE_START "ow_console_observe_start"
 #define COMSIG_OW_CONSOLE_OBSERVE_END "ow_console_observe_end"
+
+/// When igniting an object, igniter can be overridden (e.g. by underbarrel flamer attachment)
+#define COMSIG_IGNITER_OVERRIDE "igniter_override"

--- a/code/__DEFINES/dcs/signals/signals_datum.dm
+++ b/code/__DEFINES/dcs/signals/signals_datum.dm
@@ -11,10 +11,12 @@
 #define COMSIG_TOPIC "handle_topic"
 /// from datum ui_act (usr, action)
 #define COMSIG_UI_ACT "COMSIG_UI_ACT"
-///from base of atom/attackby(): (/obj/item, /mob/living, params)
+/// Called whenever an atom is being attacked with an item, from base of atom/attackby(): (/obj/item, /mob/living, params)
 #define COMSIG_PARENT_ATTACKBY "atom_attackby"
-///Return this in response if you don't want afterattack to be called
+	///Return this in response if you don't want afterattack to be called
 	#define COMPONENT_NO_AFTERATTACK (1<<0)
+/// Called in base of obj/item/afterattack():(atom/target, obj/item/attackedby, mob/living/user, params)
+#define COMSIG_PARENT_AFTERATTACK "atom_afterattack"
 ///from base of atom/examine(): (/mob, list/examine_text)
 #define COMSIG_PARENT_EXAMINE "atom_examine"
 /// handler for vv_do_topic (usr, href_list)

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -142,6 +142,10 @@
 /// Example trait
 // #define TRAIT_X "t_x"
 
+//-- atom traits --
+/// This item can be ignited by items that can ignite (have the trait TRAIT_IGNITES)
+#define TRAIT_IGNITABLE "ignitable"
+
 //-- mob traits --
 /// Apply this to make a mob not dense, and remove it when you want it to no longer make them undense, other sources of undensity will still apply. Always define a unique source when adding a new instance of this!
 #define TRAIT_UNDENSE "undense"
@@ -333,6 +337,9 @@
 
 //This item is being dissolved. Used by yautja_cleaner.
 #define TRAIT_ITEM_DISSOLVING "item_dissolving"
+
+/// This item can ignite other atoms
+#define TRAIT_IGNITER "t_item_igniter"
 
 //-- structure traits --
 // TABLE TRAITS

--- a/code/__DEFINES/typecheck/generic_types.dm
+++ b/code/__DEFINES/typecheck/generic_types.dm
@@ -1,3 +1,6 @@
+/// For lists of typepaths where you want to be able to match any other type
+#define ANY_TYPE_MATCHER "NOT A PATH"
+
 #define isdatum(X)   (istype(X, /datum))
 #define istypestrict(D, typepath)   D.type == typepath
 #define ismind(X)    (istype(X, /datum/mind))
@@ -16,6 +19,8 @@
 #define isgenerator(A) (istype(A, /generator))
 #define istransparentturf(A) (HAS_TRAIT(A, TURF_Z_TRANSPARENT_TRAIT))
 
+/// istype() but properly validates if [ANY_TYPE_MATCHER] is passed to `path`
+#define istype_or_any(to_check, path) (path == ANY_TYPE_MATCHER || istype(to_check, path))
 
 //Byond type ids
 #define TYPEID_NULL "0"

--- a/code/__DEFINES/typecheck/generic_types.dm
+++ b/code/__DEFINES/typecheck/generic_types.dm
@@ -1,6 +1,3 @@
-/// For lists of typepaths where you want to be able to match any other type
-#define ANY_TYPE_MATCHER "NOT A PATH"
-
 #define isdatum(X)   (istype(X, /datum))
 #define istypestrict(D, typepath)   D.type == typepath
 #define ismind(X)    (istype(X, /datum/mind))
@@ -18,9 +15,6 @@
 #define isweakref(D) (istype(D, /datum/weakref))
 #define isgenerator(A) (istype(A, /generator))
 #define istransparentturf(A) (HAS_TRAIT(A, TURF_Z_TRANSPARENT_TRAIT))
-
-/// istype() but properly validates if [ANY_TYPE_MATCHER] is passed to `path`
-#define istype_or_any(to_check, path) (path == ANY_TYPE_MATCHER || istype(to_check, path))
 
 //Byond type ids
 #define TYPEID_NULL "0"

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -390,6 +390,47 @@
 
 	return message
 
+/**
+ * Proc for inserting strings into locations that are only known at runtime
+ *
+ * Every nth argument passed after `text_template` replaces any `{n}` in `message`
+ *
+ * Example:
+ * > If first argument is `chicken`, the second argument is `pie`, and the string template is "I love {1} and {2}",
+ * then the resulting text is "I love `chicken` and `pie`"
+ */
+/proc/text_dynamic_insertion(text_template, ...)
+	var/base_arg_count = 1
+	if (length(args) <= base_arg_count)
+		CRASH("No args passed for string template")
+	var/result = text_template
+	// Start after text_template
+	for (var/i in base_arg_count + 1 to length(args))
+		result = replacetext(result, "{[i-base_arg_count]}", "[args[i]]")
+	return result
+
+/**
+ * Proc for inserting strings into locations that are only known at runtime
+ *
+ * The length `index_keys` MUST match the number of args to be inserted into the string template.
+ * Every nth argument passed after `index_keys` replaces any `{index_keys[n]}` in `message`.
+ *
+ * Example:
+ * > If index_keys=list("name", "age"), the first argument is `Lother`, the last argument is `5`, and the string template is "You are {age} years old now, {name}",
+ * then the resulting text is "You are `5` years old now, `Lother`"
+ */
+/proc/text_dynamic_insertion_custom(text_template, index_keys, ...)
+	var/base_arg_count = 2
+	if (!length(index_keys))
+		CRASH("No index keys passed")
+	if (length(index_keys) != (length(args) - base_arg_count))
+		CRASH("The size of index_keys MUST match the number of characters to insert")
+	var/result = text_template
+	// Start after index_keys
+	for (var/i in base_arg_count + 1 to length(args))
+		result = replacetext(result, "{[index_keys[i-base_arg_count]]}", "[args[i]]")
+	return result
+
 #define SMALL_FONTS(FONTSIZE, MSG) "<span style=\"font-family: 'Small Fonts'; -dm-text-outline: 1 black; font-size: [FONTSIZE]px;\">[MSG]</span>"
 #define SMALL_FONTS_CENTRED(FONTSIZE, MSG) "<center><span style=\"font-family: 'Small Fonts'; -dm-text-outline: 1 black; font-size: [FONTSIZE]px;\">[MSG]</span></center>"
 #define SMALL_FONTS_COLOR(FONTSIZE, MSG, COLOR) "<span style=\"font-family: 'Small Fonts'; -dm-text-outline: 1 black; font-size: [FONTSIZE]px; color: [COLOR];\">[MSG]</span>"

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1826,3 +1826,27 @@ GLOBAL_LIST_INIT(duplicate_forbidden_vars,list(
 	var/x = (text2num(x_dirty[1])-1)*32 + text2num(x_dirty[2])
 	var/y = (text2num(y_dirty[1])-1)*32 + text2num(y_dirty[2])
 	return list(x, y)
+
+/datum/matching_paths
+	var/datum/highest_matching
+	var/list/datum/matching
+
+/datum/matching_paths/New()
+	. = ..()
+	highest_matching = null
+	matching = list()
+
+/proc/get_matching_paths(datum/to_check, list/typepaths)
+	RETURN_TYPE(/datum/matching_paths)
+	var/datum/matching_paths/matching_paths = new /datum/matching_paths
+	ASSERT(matching_paths.highest_matching == null, "matching_paths.highest_matching should be null on creation")
+	ASSERT(!isnull(matching_paths.matching), "matching_paths.matching should be a list on creation")
+	ASSERT(length(matching_paths.matching) == 0, "matching_paths.matching should be empty on creation")
+	for (var/path in typepaths)
+		if (ispath(path) && istype(to_check, path))
+			// to_check is going to be of type `path` and `highest_matching`, so check whether
+			// `highest_matching` is a parent of `path` (lower in the type tree)
+			if (isnull(matching_paths.highest_matching) || !ispath(matching_paths.highest_matching, path))
+				matching_paths.highest_matching = path
+			matching_paths.matching += path
+	return matching_paths

--- a/code/_globalvars/global_lists.dm
+++ b/code/_globalvars/global_lists.dm
@@ -282,6 +282,9 @@ GLOBAL_LIST_EMPTY(paramslist_cache)
 //Turf Edge info uberlist -- a list whos states contain GLOB.edgeinfo_X keyed as different icon_states
 GLOBAL_LIST_EMPTY(turf_edgeinfo_cache)
 
+// Cache for text insertion data
+GLOBAL_LIST_EMPTY(text_insertion_data_cache)
+
 #define FULL_EDGE 1
 #define HALF_EDGE_RIGHT 2
 #define HALF_EDGE_LEFT 3

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -46,6 +46,7 @@
 // Proximity_flag is 1 if this afterattack was called on something adjacent, in your square, or on your person.
 // Click parameters is the params string from byond Click() code, see that documentation.
 /obj/item/proc/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+	SEND_SIGNAL(src, COMSIG_PARENT_AFTERATTACK, target, user, click_parameters)
 	return FALSE
 
 

--- a/code/datums/elements/traitbound/igniting/ignitable.dm
+++ b/code/datums/elements/traitbound/igniting/ignitable.dm
@@ -1,0 +1,65 @@
+/// Element for atoms that can ignite
+/datum/element/traitbound/ignitable
+	compatible_types = list(/atom)
+	associated_trait = TRAIT_IGNITABLE
+	/**
+	 * List of string templates containing text when parent ignites an object
+	 * String templates should have `{ignitable}`, `{igniter}`, and `{user}` in the string
+	 * templates to get expected results
+	 * - `{ignitable}` = thing being ignited
+	 * - `{igniter}` = thing triggering the ignition
+	 * - `{user}` = evil person responsible
+	 */
+	VAR_PRIVATE/list/flavor_text_by_type
+
+/datum/element/traitbound/ignitable/Attach(atom/target)
+	. = ..()
+	if (. & ELEMENT_INCOMPATIBLE)
+		return
+	flavor_text_by_type = target.get_ignitable_flavor_text()
+	RegisterSignal(target, COMSIG_ATOM_IGNITE, PROC_REF(ignite))
+
+/datum/element/traitbound/ignitable/Detach(datum/source, force)
+	UnregisterSignal(source, COMSIG_ATOM_IGNITE)
+	return ..()
+
+/datum/element/traitbound/ignitable/proc/ignite(atom/ignitable, obj/item/igniter, mob/user, custom_flavor_text)
+	SIGNAL_HANDLER
+
+	var/flavor_text
+	var/ignition_source = igniter
+	if (custom_flavor_text)
+		flavor_text = custom_flavor_text
+	var/datum/igniter_override_metadata/metadata = new /datum/igniter_override_metadata()
+	SEND_SIGNAL(igniter, COMSIG_IGNITER_OVERRIDE, metadata)
+	if (metadata.igniter_override)
+		ignition_source = metadata.igniter_override
+	else if (flavor_text_by_type)
+		for (var/path in flavor_text_by_type)
+			if (!istype_or_any(ignition_source, path))
+				continue
+			flavor_text = text_dynamic_insertion_custom(
+				flavor_text_by_type[path],
+				list("ignitable", "igniter", "user"),
+				"[ignitable.name]", "\the [ignition_source]", user
+			)
+			break
+	if (!flavor_text)
+		flavor_text = "[user] ignites [ignitable] with [ignition_source]."
+	ignitable.ignite(ignition_source, user, flavor_text)
+
+/// Data class for setting igniter_override
+/datum/igniter_override_metadata
+	var/atom/igniter_override
+
+/// Proc to overwrite for any ignitables with custom flavor text
+/atom/proc/get_ignitable_flavor_text() as /list
+	return
+
+/**
+ * Proc to overwrite for when an ignitable ignites
+ *
+ * Should not be called directly, instead send the signal `COMSIG_ATOM_IGNITE`
+ */
+/atom/proc/ignite(obj/item/igniter, mob/user, flavor_text)
+	return

--- a/code/datums/elements/traitbound/igniting/ignitable.dm
+++ b/code/datums/elements/traitbound/igniting/ignitable.dm
@@ -2,21 +2,11 @@
 /datum/element/traitbound/ignitable
 	compatible_types = list(/atom)
 	associated_trait = TRAIT_IGNITABLE
-	/**
-	 * List of string templates containing text when parent ignites an object
-	 * String templates should have `{ignitable}`, `{igniter}`, and `{user}` in the string
-	 * templates to get expected results
-	 * - `{ignitable}` = thing being ignited
-	 * - `{igniter}` = thing triggering the ignition
-	 * - `{user}` = evil person responsible
-	 */
-	VAR_PRIVATE/list/flavor_text_by_type
 
 /datum/element/traitbound/ignitable/Attach(atom/target)
 	. = ..()
 	if (. & ELEMENT_INCOMPATIBLE)
 		return
-	flavor_text_by_type = target.get_ignitable_flavor_text()
 	RegisterSignal(target, COMSIG_ATOM_IGNITE, PROC_REF(ignite))
 
 /datum/element/traitbound/ignitable/Detach(datum/source, force)
@@ -26,6 +16,7 @@
 /datum/element/traitbound/ignitable/proc/ignite(atom/ignitable, obj/item/igniter, mob/user, custom_flavor_text)
 	SIGNAL_HANDLER
 
+	var/flavor_text_by_type = ignitable.get_ignitable_flavor_text()
 	var/flavor_text
 	var/ignition_source = igniter
 	if (custom_flavor_text)
@@ -34,7 +25,7 @@
 	SEND_SIGNAL(igniter, COMSIG_IGNITER_OVERRIDE, metadata)
 	if (metadata.igniter_override)
 		ignition_source = metadata.igniter_override
-	else if (flavor_text_by_type)
+	if (flavor_text_by_type)
 		for (var/path in flavor_text_by_type)
 			if (!istype_or_any(ignition_source, path))
 				continue
@@ -52,8 +43,18 @@
 /datum/igniter_override_metadata
 	var/atom/igniter_override
 
-/// Proc to overwrite for any ignitables with custom flavor text
-/atom/proc/get_ignitable_flavor_text() as /list
+/**
+ * Proc to overwrite for any ignitables with custom flavor text
+ *
+ * List of string templates containing text when parent ignites an object
+ * String templates should have `{ignitable}`, `{igniter}`, and `{user}` in the string
+ * templates to get expected results
+ * - `{ignitable}` = thing being ignited
+ * - `{igniter}` = thing triggering the ignition
+ * - `{user}` = evil person responsible
+ */
+/atom/proc/get_ignitable_flavor_text()
+	RETURN_TYPE(/alist)
 	return
 
 /**

--- a/code/datums/elements/traitbound/igniting/ignitable.dm
+++ b/code/datums/elements/traitbound/igniting/ignitable.dm
@@ -1,3 +1,9 @@
+/datum/ignitable_constants
+	// Update /proc/replace_ignitable_flavor_text(...) to handle any more constants here
+	VAR_FINAL/const/APPLY_THE = 1
+
+GLOBAL_REAL(ignitable_constants, /datum/ignitable_constants)
+
 /// Element for atoms that can ignite
 /datum/element/traitbound/ignitable
 	compatible_types = list(/atom)
@@ -26,22 +32,54 @@
 	if (metadata.igniter_override)
 		ignition_source = metadata.igniter_override
 	if (flavor_text_by_type)
-		for (var/path in flavor_text_by_type)
-			if (!istype_or_any(ignition_source, path))
-				continue
+		var/highest_matching_path = get_matching_paths(igniter, flavor_text_by_type).highest_matching
+		if (highest_matching_path)
+			var/datum/ignitable_flavor_text_data/flavor_text_data = flavor_text_by_type[highest_matching_path]
+			var/replacement_text = flavor_text_data.replacement_text
+			var/index_params = flavor_text_data.index_params
 			flavor_text = text_dynamic_insertion_custom(
-				flavor_text_by_type[path],
+				replacement_text,
 				list("ignitable", "igniter", "user"),
-				"[ignitable.name]", "\the [ignition_source]", user
+				replace_ignitable_flavor_text(
+					ignitable,
+					LAZYACCESS(index_params, "ignitable"),
+				),
+				replace_ignitable_flavor_text(
+					igniter,
+					LAZYACCESS(index_params, "igniter"),
+				),
+				replace_ignitable_flavor_text(
+					user,
+					LAZYACCESS(index_params, "user"),
+				),
 			)
-			break
 	if (!flavor_text)
-		flavor_text = "[user] ignites [ignitable] with [ignition_source]."
+		flavor_text = "[user] ignites \the [ignitable] with \the [ignition_source]."
 	ignitable.ignite(ignition_source, user, flavor_text)
 
 /// Data class for setting igniter_override
 /datum/igniter_override_metadata
+	/// Atom to track as source of ignition
 	var/atom/igniter_override
+
+// TODO: generalize this to be usable in other contexts
+/datum/ignitable_flavor_text_data
+	/// Text template for replacement text
+	var/replacement_text
+	/// Optional mapping of index keys to a text modifiers
+	var/alist/index_params
+
+/datum/ignitable_flavor_text_data/New(replacement_text, alist/index_params)
+	src.replacement_text = replacement_text
+	src.index_params = index_params
+
+/proc/replace_ignitable_flavor_text(atom/atom_to_reference, text_param)
+	if (!text_param)
+		return "[atom_to_reference.name]"
+	else if (text_param == ignitable_constants::APPLY_THE)
+		return "\the [atom_to_reference]"
+	else
+		CRASH("Invalid text_param passed: '[text_param]'")
 
 /**
  * Proc to overwrite for any ignitables with custom flavor text

--- a/code/datums/elements/traitbound/igniting/igniter.dm
+++ b/code/datums/elements/traitbound/igniting/igniter.dm
@@ -1,0 +1,40 @@
+/datum/element/traitbound/igniter
+	compatible_types = list(/obj/item)
+	associated_trait = TRAIT_IGNITER
+
+	/// Proc to check whether ignition can happen
+	VAR_PRIVATE/check_ignition_proc
+	/// Message to send to user if ignition fails
+	VAR_PRIVATE/failure_message
+
+/datum/element/traitbound/igniter/Attach(obj/item/target)
+	. = ..()
+	if (. & ELEMENT_INCOMPATIBLE)
+		return
+
+	check_ignition_proc = TYPE_PROC_REF(/obj/item, _check_can_ignite)
+	failure_message = target.get_igniter_failure_message()
+	RegisterSignal(target, COMSIG_PARENT_AFTERATTACK, PROC_REF(try_ignite))
+
+/datum/element/traitbound/igniter/proc/try_ignite(obj/item/igniter, atom/ignitable, mob/user)
+	SIGNAL_HANDLER
+
+	if (!call(igniter, check_ignition_proc)())
+		if (failure_message)
+			to_chat(user, failure_message)
+		return
+	SEND_SIGNAL(ignitable, COMSIG_ATOM_IGNITE, igniter, user)
+
+/datum/element/traitbound/igniter/Detach(datum/source, force)
+	UnregisterSignal(source, COMSIG_PARENT_AFTERATTACK)
+	return ..()
+
+/obj/item/proc/_check_can_ignite(self)
+	return check_can_ignite()
+
+/// Proc to overwrite when specifying how an atom checks whether it can ignition. Default is to always ignite.
+/obj/item/proc/check_can_ignite()
+	return TRUE
+
+/obj/item/proc/get_igniter_failure_message()
+	return

--- a/code/datums/elements/traitbound/igniting/igniter.dm
+++ b/code/datums/elements/traitbound/igniting/igniter.dm
@@ -2,24 +2,18 @@
 	compatible_types = list(/obj/item)
 	associated_trait = TRAIT_IGNITER
 
-	/// Proc to check whether ignition can happen
-	VAR_PRIVATE/check_ignition_proc
-	/// Message to send to user if ignition fails
-	VAR_PRIVATE/failure_message
-
 /datum/element/traitbound/igniter/Attach(obj/item/target)
 	. = ..()
 	if (. & ELEMENT_INCOMPATIBLE)
 		return
 
-	check_ignition_proc = TYPE_PROC_REF(/obj/item, _check_can_ignite)
-	failure_message = target.get_igniter_failure_message()
 	RegisterSignal(target, COMSIG_PARENT_AFTERATTACK, PROC_REF(try_ignite))
 
 /datum/element/traitbound/igniter/proc/try_ignite(obj/item/igniter, atom/ignitable, mob/user)
 	SIGNAL_HANDLER
 
-	if (!call(igniter, check_ignition_proc)())
+	if (!igniter.check_can_ignite())
+		var/failure_message = igniter.get_igniter_failure_message()
 		if (failure_message)
 			to_chat(user, failure_message)
 		return
@@ -28,9 +22,6 @@
 /datum/element/traitbound/igniter/Detach(datum/source, force)
 	UnregisterSignal(source, COMSIG_PARENT_AFTERATTACK)
 	return ..()
-
-/obj/item/proc/_check_can_ignite(self)
-	return check_can_ignite()
 
 /// Proc to overwrite when specifying how an atom checks whether it can ignition. Default is to always ignite.
 /obj/item/proc/check_can_ignite()

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -80,11 +80,11 @@
 
 /obj/structure/machinery/sparker/attack_remote()
 	if (src.anchored)
-		return src.ignite()
+		return src.turn_on()
 	else
 		return
 
-/obj/structure/machinery/sparker/proc/ignite()
+/obj/structure/machinery/sparker/proc/turn_on()
 	if (!(powered()))
 		return
 
@@ -107,7 +107,7 @@
 	. = ..()
 	if(inoperable())
 		return
-	ignite()
+	turn_on()
 
 /obj/structure/machinery/ignition_switch/attack_remote(mob/user as mob)
 	return attack_hand(user)
@@ -125,7 +125,7 @@
 
 	for(var/obj/structure/machinery/sparker/M in GLOB.machines)
 		if (M.id == src.id)
-			INVOKE_ASYNC(M, TYPE_PROC_REF(/obj/structure/machinery/sparker, ignite))
+			INVOKE_ASYNC(M, TYPE_PROC_REF(/obj/structure/machinery/sparker, turn_on))
 
 	for(var/obj/structure/machinery/igniter/M in GLOB.machines)
 		if(M.id == src.id)

--- a/code/game/objects/effects/decals/cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/cleanable/fuel.dm
@@ -34,11 +34,11 @@
 /obj/effect/decal/cleanable/liquid_fuel/LateInitialize()
 	// Ignition because fire already exists
 	if(locate(/obj/flamer_fire) in cleanable_turf)
-		INVOKE_NEXT_TICK(src, PROC_REF(ignite))
+		INVOKE_NEXT_TICK(src, PROC_REF(ignite_fuel))
 		return
 	for(var/obj/item/thing in cleanable_turf)
 		if(thing.heat_source)
-			INVOKE_NEXT_TICK(src, PROC_REF(ignite))
+			INVOKE_NEXT_TICK(src, PROC_REF(ignite_fuel))
 			return
 	RegisterSignal(cleanable_turf, COMSIG_TURF_ENTERED, PROC_REF(on_turf_entered))
 
@@ -62,7 +62,7 @@
 
 	var/obj/item/entered_thing = enterer
 	if(entered_thing.heat_source)
-		INVOKE_NEXT_TICK(src, PROC_REF(ignite))
+		INVOKE_NEXT_TICK(src, PROC_REF(ignite_fuel))
 		UnregisterSignal(source, COMSIG_MOVABLE_MOVED)
 
 /obj/effect/decal/cleanable/liquid_fuel/proc/spread()
@@ -86,7 +86,12 @@
 			new /obj/effect/decal/cleanable/liquid_fuel(target, amount * 0.25)
 			amount *= 0.75
 
-/obj/effect/decal/cleanable/liquid_fuel/proc/ignite()
+/obj/effect/decal/cleanable/liquid_fuel/ignite(obj/item/igniter, mob/user, flavor_text)
+	var/turf/fuel_turf = get_turf(src)
+	fuel_turf.visible_message(flavor_text)
+	ignite_fuel()
+
+/obj/effect/decal/cleanable/liquid_fuel/proc/ignite_fuel()
 	if(QDELETED(src))
 		return
 

--- a/code/game/objects/effects/decals/cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/cleanable/fuel.dm
@@ -86,11 +86,6 @@
 			new /obj/effect/decal/cleanable/liquid_fuel(target, amount * 0.25)
 			amount *= 0.75
 
-/obj/effect/decal/cleanable/liquid_fuel/ignite(obj/item/igniter, mob/user, flavor_text)
-	var/turf/fuel_turf = get_turf(src)
-	fuel_turf.visible_message(flavor_text)
-	ignite_fuel()
-
 /obj/effect/decal/cleanable/liquid_fuel/proc/ignite_fuel()
 	if(QDELETED(src))
 		return

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -348,6 +348,7 @@
 /obj/item/device/flashlight/flare/Initialize()
 	. = ..()
 	set_light_color(flame_tint)
+	ADD_TRAIT(src, TRAIT_IGNITER, TRAIT_SOURCE_INHERENT)
 
 /obj/item/device/flashlight/flare/update_icon()
 	overlays?.Cut()

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -43,7 +43,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	ADD_TRAIT(src, TRAIT_IGNITABLE, TRAIT_SOURCE_INHERENT)
 
 /obj/item/tool/candle/get_ignitable_flavor_text()
-	return list(
+	. = alist(
 		/obj/item/tool/weldingtool = SPAN_NOTICE("{user} casually lights {ignitable} with {igniter}."),
 		ANY_TYPE_MATCHER = SPAN_NOTICE("{user} lights {ignitable} with {igniter}."),
 	)
@@ -129,7 +129,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	. = ..()
 	ADD_TRAIT(src, TRAIT_IGNITER, TRAIT_SOURCE_INHERENT)
 
-/obj/item/tool/lighter/check_can_ignite()
+/obj/item/tool/match/check_can_ignite()
 	return heat_source
 
 /obj/item/tool/match/afterattack(atom/target, mob/living/carbon/human/user, proximity_flag, click_parameters)
@@ -250,7 +250,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	ADD_TRAIT(src, TRAIT_IGNITER, TRAIT_SOURCE_INHERENT)
 
 /obj/item/clothing/mask/cigarette/get_ignitable_flavor_text()
-	return list(
+	return alist(
 		/obj/item/tool/weldingtool = SPAN_NOTICE("{user} casually lights the {ignitable} with {igniter}."),
 		/obj/item/tool/lighter/zippo = SPAN_ROSE("With a flick of their wrist, {user} lights their {ignitable} with {igniter}."),
 		/obj/item/device/flashlight/flare = SPAN_NOTICE("{user} lights their {ignitable} with {igniter}."),
@@ -262,17 +262,12 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		/obj/item/weapon/gun/flamer = SPAN_NOTICE("{user} lights their {ignitable} with the pilot light of {igniter}."),
 		/obj/item/weapon/gun = SPAN_NOTICE("{user} lights their {ignitable} with {igniter}."),
 		/obj/item/tool/surgery/cautery = SPAN_NOTICE("{user} lights their {ignitable} with {igniter}."),
-		/obj/item/clothing/mask/cigarette = SPAN_NOTICE("{user} lights their {ignitable} with {igniter} after a few attempts."),SPAN_NOTICE("{user} lights their {ignitable} with {igniter} after a few attempts."),
+		/obj/item/clothing/mask/cigarette = SPAN_NOTICE("{user} lights their {ignitable} with {igniter} after a few attempts."),
 		/obj/item/tool/candle = SPAN_NOTICE("{user} lights their {ignitable} with {igniter} after a few attempts."),
 	)
 
 /obj/item/clothing/mask/cigarette/check_can_ignite()
 	return item_state == icon_on
-
-// TODO: Refactor this to use signals holy shit
-/obj/item/clothing/mask/cigarette/proc/try_light(obj/item/W, mob/user)
-	return
-
 
 /obj/item/clothing/mask/cigarette/afterattack(atom/target, mob/living/user, proximity)
 	..()
@@ -515,16 +510,16 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	chem_volume = 30
 
 /obj/item/clothing/mask/cigarette/cigar/havana/get_ignitable_flavor_text()
-	. = ..()
-	. += list(
-		/obj/item/tool/weldingtool = SPAN_NOTICE("{user} insults {ignitable} by lighting it with {igniter}."),
-		/obj/item/tool/lighter = SPAN_NOTICE("{user} manages to offend their {ignitable} by lighting it with {igniter}."),
-		/obj/item/device/assembly/igniter = SPAN_NOTICE("{user} fiddles with {igniter}, and manages to light their {ignitable} with the power of science."),
-		/obj/item/attachable/attached_gun/flamer = SPAN_NOTICE("{user} lights their {ignitable} with {igniter}, bet that would have looked cooler if it was attached to something first!"),
-		/obj/item/weapon/gun/flamer = SPAN_NOTICE("{user} lights their {ignitable} with the pilot light of {igniter}, the glint of pyromania in their eye."),
-		/obj/item/weapon/gun = SPAN_NOTICE("{user} lights their {ignitable} with {igniter} like a complete badass."),
-		/obj/item/tool/surgery/cautery = SPAN_NOTICE("{user} lights their {ignitable} with {igniter}, that can't be sterile!"),
+	. = alist(
+		/obj/item/tool/weldingtool = SPAN_NOTICE("{user} insults \the {ignitable} by lighting it with \the {igniter}."),
+		/obj/item/tool/lighter = SPAN_NOTICE("{user} manages to offend their {ignitable} by lighting it with \the {igniter}."),
+		/obj/item/device/assembly/igniter = SPAN_NOTICE("{user} fiddles with \the {igniter}, and manages to light their {ignitable} with the power of science."),
+		/obj/item/attachable/attached_gun/flamer = SPAN_NOTICE("{user} lights their {ignitable} with \the {igniter}, bet that would have looked cooler if it was attached to something first!"),
+		/obj/item/weapon/gun/flamer = SPAN_NOTICE("{user} lights their {ignitable} with the pilot light of \the {igniter}, the glint of pyromania in their eye."),
+		/obj/item/weapon/gun = SPAN_NOTICE("{user} lights their {ignitable} with \the {igniter} like a complete badass."),
+		/obj/item/tool/surgery/cautery = SPAN_NOTICE("{user} lights their {ignitable} with \the {igniter}, that can't be sterile!"),
 	)
+	. += ..()
 
 /////////////////
 //SMOKING PIPES//
@@ -567,8 +562,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	..()
 
 /obj/item/clothing/mask/cigarette/pipe/get_ignitable_flavor_text()
-	. = ..()
-	. += list(
+	. = list(
 		/obj/item/tool/weldingtool = SPAN_NOTICE("{user} recklessly lights {ignitable} with {igniter}."),
 		/obj/item/tool/lighter/zippo = SPAN_ROSE("With much care, {user} lights their {ignitable} with their {igniter}."),
 		/obj/item/device/flashlight/flare = SPAN_NOTICE("{user} lights their {ignitable} with {igniter}."),
@@ -576,6 +570,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		/obj/item/tool/match = SPAN_NOTICE("{user} lights their {ignitable} with their {igniter}."),
 		/obj/item/device/assembly/igniter = SPAN_NOTICE("{user} fiddles with the {igniter}, and manages to light their {ignitable} with the power of science."),
 	)
+	. += ..()
 
 /obj/item/clothing/mask/cigarette/pipe/light()
 	if(smoketime > 0)
@@ -662,7 +657,11 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	attack_verb = list("poked", "jabbed", "pricked", "prodded")
 	damtype = "brute"
 
-/obj/item/tool/lighter/proc/check_ignite()
+/obj/item/tool/lighter/Initialize(mapload, ...)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_IGNITER, TRAIT_SOURCE_INHERENT)
+
+/obj/item/tool/lighter/check_can_ignite()
 	return heat_source
 
 /obj/item/tool/lighter/zippo
@@ -746,7 +745,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	LAZYSET(item_state_slots, WEAR_AS_GARB, "lighter_[clr]")
 
 /obj/item/tool/lighter/attack_self(mob/living/user)
-	if(user.r_hand != src && user.l_hand == src)
+	if(user.r_hand != src && user.l_hand != src)
 		return ..()
 	if(heat_source)
 		turn_off(user, 0)

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -44,8 +44,14 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/tool/candle/get_ignitable_flavor_text()
 	. = alist(
-		/obj/item/tool/weldingtool = SPAN_NOTICE("{user} casually lights {ignitable} with {igniter}."),
-		ANY_TYPE_MATCHER = SPAN_NOTICE("{user} lights {ignitable} with {igniter}."),
+		/obj/item/tool/weldingtool = new /datum/ignitable_flavor_text_data(
+			replacement_text = SPAN_NOTICE("{user} casually lights {ignitable} with {igniter}."),
+			text_params = alist("ignitable" = ignitable_constants::APPLY_THE, "igniter" = ignitable_constants::APPLY_THE)
+		),
+		/datum = new /datum/ignitable_flavor_text_data(
+			replacement_text = SPAN_NOTICE("{user} lights {ignitable} with {igniter}."),
+			text_params = alist("ignitable" = ignitable_constants::APPLY_THE, "igniter" = ignitable_constants::APPLY_THE)
+		),
 	)
 
 /obj/item/tool/candle/check_can_ignite()
@@ -249,21 +255,34 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	ADD_TRAIT(src, TRAIT_IGNITABLE, TRAIT_SOURCE_INHERENT)
 	ADD_TRAIT(src, TRAIT_IGNITER, TRAIT_SOURCE_INHERENT)
 
+// TODO: setup typecache for this
 /obj/item/clothing/mask/cigarette/get_ignitable_flavor_text()
 	return alist(
-		/obj/item/tool/weldingtool = SPAN_NOTICE("{user} casually lights the {ignitable} with {igniter}."),
-		/obj/item/tool/lighter/zippo = SPAN_ROSE("With a flick of their wrist, {user} lights their {ignitable} with {igniter}."),
-		/obj/item/device/flashlight/flare = SPAN_NOTICE("{user} lights their {ignitable} with {igniter}."),
-		/obj/item/tool/lighter = SPAN_NOTICE("{user} manages to light their {ignitable} with {igniter}."),
-		/obj/item/tool/match = SPAN_NOTICE("{user} lights their {ignitable} with their {igniter}."),
-		/obj/item/weapon/energy/sword = SPAN_WARNING("{user} swings their {igniter}, barely missing their nose. They light their {ignitable} in the process."),
-		/obj/item/device/assembly/igniter = SPAN_NOTICE("{user} fiddles with {igniter}, and manages to light their {ignitable}."),
-		/obj/item/attachable/attached_gun/flamer = SPAN_NOTICE("{user} lights their {ignitable} with {igniter}."),
-		/obj/item/weapon/gun/flamer = SPAN_NOTICE("{user} lights their {ignitable} with the pilot light of {igniter}."),
-		/obj/item/weapon/gun = SPAN_NOTICE("{user} lights their {ignitable} with {igniter}."),
-		/obj/item/tool/surgery/cautery = SPAN_NOTICE("{user} lights their {ignitable} with {igniter}."),
-		/obj/item/clothing/mask/cigarette = SPAN_NOTICE("{user} lights their {ignitable} with {igniter} after a few attempts."),
-		/obj/item/tool/candle = SPAN_NOTICE("{user} lights their {ignitable} with {igniter} after a few attempts."),
+		/obj/item/tool/weldingtool = new /datum/ignitable_flavor_text_data(
+			replacement_text = SPAN_NOTICE("{user} casually lights {ignitable} with {igniter}."),
+			text_params = alist("ignitable" = ignitable_constants::APPLY_THE, "igniter" = ignitable_constants::APPLY_THE)
+		),
+		/obj/item/tool/lighter/zippo = new /datum/ignitable_flavor_text_data(
+			replacement_text = SPAN_ROSE("With a flick of their wrist, {user} lights their {ignitable} with {igniter}."),
+			text_params = alist("igniter" = ignitable_constants::APPLY_THE)
+		),
+		/obj/item/device/flashlight/flare = new /datum/ignitable_flavor_text_data(
+			replacement_text = SPAN_NOTICE("{user} lights their {ignitable} with {igniter}."),
+			text_params = alist("igniter" = ignitable_constants::APPLY_THE)
+		),
+		/obj/item/tool/lighter = new /datum/ignitable_flavor_text_data(
+			replacement_text = SPAN_NOTICE("{user} manages to light their {ignitable} with {igniter}.")
+			text_params = alist("igniter" = ignitable_constants::APPLY_THE)
+		),
+		/obj/item/tool/match = new /datum/ignitable_flavor_text_data(SPAN_NOTICE("{user} lights their {ignitable} with their {igniter}.")),
+		/obj/item/weapon/energy/sword = new /datum/ignitable_flavor_text_data(SPAN_WARNING("{user} swings their {igniter}, barely missing their nose. They light their {ignitable} in the process.")),
+		/obj/item/device/assembly/igniter = new /datum/ignitable_flavor_text_data(SPAN_NOTICE("{user} fiddles with {igniter}, and manages to light their {ignitable}.")),
+		/obj/item/attachable/attached_gun/flamer = new /datum/ignitable_flavor_text_data(SPAN_NOTICE("{user} lights their {ignitable} with {igniter}.")),
+		/obj/item/weapon/gun/flamer = new /datum/ignitable_flavor_text_data(SPAN_NOTICE("{user} lights their {ignitable} with the pilot light of {igniter}.")),
+		/obj/item/weapon/gun = new /datum/ignitable_flavor_text_data(SPAN_NOTICE("{user} lights their {ignitable} with {igniter}.")),
+		/obj/item/tool/surgery/cautery = new /datum/ignitable_flavor_text_data(SPAN_NOTICE("{user} lights their {ignitable} with {igniter}.")),
+		/obj/item/clothing/mask/cigarette = new /datum/ignitable_flavor_text_data(SPAN_NOTICE("{user} lights their {ignitable} with {igniter} after a few attempts.")),
+		/obj/item/tool/candle = new /datum/ignitable_flavor_text_data(SPAN_NOTICE("{user} lights their {ignitable} with {igniter} after a few attempts.")),
 	)
 
 /obj/item/clothing/mask/cigarette/check_can_ignite()
@@ -511,13 +530,34 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/clothing/mask/cigarette/cigar/havana/get_ignitable_flavor_text()
 	. = alist(
-		/obj/item/tool/weldingtool = SPAN_NOTICE("{user} insults \the {ignitable} by lighting it with \the {igniter}."),
-		/obj/item/tool/lighter = SPAN_NOTICE("{user} manages to offend their {ignitable} by lighting it with \the {igniter}."),
-		/obj/item/device/assembly/igniter = SPAN_NOTICE("{user} fiddles with \the {igniter}, and manages to light their {ignitable} with the power of science."),
-		/obj/item/attachable/attached_gun/flamer = SPAN_NOTICE("{user} lights their {ignitable} with \the {igniter}, bet that would have looked cooler if it was attached to something first!"),
-		/obj/item/weapon/gun/flamer = SPAN_NOTICE("{user} lights their {ignitable} with the pilot light of \the {igniter}, the glint of pyromania in their eye."),
-		/obj/item/weapon/gun = SPAN_NOTICE("{user} lights their {ignitable} with \the {igniter} like a complete badass."),
-		/obj/item/tool/surgery/cautery = SPAN_NOTICE("{user} lights their {ignitable} with \the {igniter}, that can't be sterile!"),
+		/obj/item/tool/weldingtool = new /datum/ignitable_flavor_text_data(
+			replacement_text = SPAN_NOTICE("{user} insults {ignitable} by lighting it with {igniter}."),
+			index_params = alist("ignitable" = ignitable_constants::APPLY_THE, "igniter" = ignitable_constants::APPLY_THE)
+		),
+		/obj/item/tool/lighter = new /datum/ignitable_flavor_text_data(
+			replacement_text = SPAN_NOTICE("{user} manages to offend their {ignitable} by lighting it with {igniter}."),
+			index_params = alist("igniter" = ignitable_constants::APPLY_THE)
+		),
+		/obj/item/device/assembly/igniter = new /datum/ignitable_flavor_text_data(
+			replacement_text = SPAN_NOTICE("{user} fiddles with {igniter}, and manages to light their {ignitable} with the power of science."),
+			index_params = alist("igniter" = ignitable_constants::APPLY_THE),
+		),
+		/obj/item/attachable/attached_gun/flamer = new /datum/ignitable_flavor_text_data(
+			replacement_text = SPAN_NOTICE("{user} lights their {ignitable} with {igniter}, bet that would have looked cooler if it was attached to something first!"),
+			index_params = alist("igniter" = ignitable_constants::APPLY_THE),
+		),
+		/obj/item/weapon/gun/flamer = new /datum/ignitable_flavor_text_data(
+			replacement_text = SPAN_NOTICE("{user} lights their {ignitable} with the pilot light of {igniter}, the glint of pyromania in their eye."),
+			index_params = alist("igniter" = ignitable_constants::APPLY_THE),
+		),
+		/obj/item/weapon/gun = new /datum/ignitable_flavor_text_data(
+			replacement_text = SPAN_NOTICE("{user} lights their {ignitable} with {igniter} like a complete badass."),
+			index_params = alist("igniter" = ignitable_constants::APPLY_THE),
+		),
+		/obj/item/tool/surgery/cautery = new /datum/ignitable_flavor_text_data(
+			replacement_text = SPAN_NOTICE("{user} lights their {ignitable} with {igniter}, that can't be sterile!"),
+			index_params = alist("igniter" = ignitable_constants::APPLY_THE),
+		)
 	)
 	. += ..()
 
@@ -563,12 +603,12 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/clothing/mask/cigarette/pipe/get_ignitable_flavor_text()
 	. = list(
-		/obj/item/tool/weldingtool = SPAN_NOTICE("{user} recklessly lights {ignitable} with {igniter}."),
-		/obj/item/tool/lighter/zippo = SPAN_ROSE("With much care, {user} lights their {ignitable} with their {igniter}."),
-		/obj/item/device/flashlight/flare = SPAN_NOTICE("{user} lights their {ignitable} with {igniter}."),
-		/obj/item/tool/lighter = SPAN_NOTICE("{user} manages to light their {ignitable} with {igniter}."),
-		/obj/item/tool/match = SPAN_NOTICE("{user} lights their {ignitable} with their {igniter}."),
-		/obj/item/device/assembly/igniter = SPAN_NOTICE("{user} fiddles with the {igniter}, and manages to light their {ignitable} with the power of science."),
+		/obj/item/tool/weldingtool = new /datum/ignitable_flavor_text_data(SPAN_NOTICE("{user} recklessly lights {ignitable} with {igniter}.")),
+		/obj/item/tool/lighter/zippo = new /datum/ignitable_flavor_text_data(SPAN_ROSE("With much care, {user} lights their {ignitable} with their {igniter}.")),
+		/obj/item/device/flashlight/flare = new /datum/ignitable_flavor_text_data(SPAN_NOTICE("{user} lights their {ignitable} with {igniter}.")),
+		/obj/item/tool/lighter = new /datum/ignitable_flavor_text_data(SPAN_NOTICE("{user} manages to light their {ignitable} with {igniter}.")),
+		/obj/item/tool/match = new /datum/ignitable_flavor_text_data(SPAN_NOTICE("{user} lights their {ignitable} with their {igniter}.")),
+		/obj/item/device/assembly/igniter = new /datum/ignitable_flavor_text_data(SPAN_NOTICE("{user} fiddles with the {igniter}, and manages to light their {ignitable} with the power of science.")),
 	)
 	. += ..()
 

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -37,6 +37,20 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 	var/wax = 800
 
+/obj/item/tool/candle/Initialize(mapload, ...)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_IGNITER, TRAIT_SOURCE_INHERENT)
+	ADD_TRAIT(src, TRAIT_IGNITABLE, TRAIT_SOURCE_INHERENT)
+
+/obj/item/tool/candle/get_ignitable_flavor_text()
+	return list(
+		/obj/item/tool/weldingtool = SPAN_NOTICE("{user} casually lights {ignitable} with {igniter}."),
+		ANY_TYPE_MATCHER = SPAN_NOTICE("{user} lights {ignitable} with {igniter}."),
+	)
+
+/obj/item/tool/candle/check_can_ignite()
+	return heat_source
+
 /obj/item/tool/candle/update_icon(mob/user)
 	var/i
 	if(wax>150)
@@ -56,26 +70,16 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 	. = ..()
 
-/obj/item/tool/candle/attackby(obj/item/W as obj, mob/user as mob)
-	if(iswelder(W))
-		var/obj/item/tool/weldingtool/WT = W
-		if(WT.isOn()) //Badasses don't get blinded by lighting their candle with a blowtorch
-			light(SPAN_NOTICE("[user] casually lights [src] with [W]."))
-	else if(W.heat_source > 400)
-		light()
-	else
-		return ..()
+/obj/item/tool/candle/ignite(obj/item/igniter, mob/user, flavor_text)
+	if(heat_source)
+		return
 
-/obj/item/tool/candle/proc/light(flavor_text)
-	if(!heat_source)
-		heat_source = 1000
-		if(!flavor_text)
-			flavor_text = SPAN_NOTICE("[usr] lights [src].")
-		for(var/mob/O in viewers(usr, null))
-			O.show_message(flavor_text, SHOW_MESSAGE_VISIBLE)
-		set_light(CANDLE_LUM)
-		update_icon()
-		START_PROCESSING(SSobj, src)
+	heat_source = 1000
+	for(var/mob/O in viewers(user, null))
+		O.show_message(flavor_text, SHOW_MESSAGE_VISIBLE)
+	set_light(CANDLE_LUM)
+	update_icon()
+	START_PROCESSING(SSobj, src)
 
 /obj/item/tool/candle/process()
 	if(!heat_source)
@@ -118,6 +122,15 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	w_class = SIZE_TINY
 	light_range = 2
 	light_power = 1
+
+	attack_verb = list("burnt", "singed")
+
+/obj/item/tool/match/Initialize(mapload, ...)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_IGNITER, TRAIT_SOURCE_INHERENT)
+
+/obj/item/tool/lighter/check_can_ignite()
+	return heat_source
 
 /obj/item/tool/match/afterattack(atom/target, mob/living/carbon/human/user, proximity_flag, click_parameters)
 	if(istype(user) && istype(target, /obj/item/clothing/shoes/marine) && user.shoes == target && light_match(user))
@@ -199,6 +212,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	name = "cigarette"
 	desc = "A roll of tobacco and fillers, wrapped in paper with a filter at the end. Apparently, inhaling the smoke makes you feel happier."
 	icon_state = "cigoff"
+	throw_speed = SPEED_AVERAGE
 	item_state = "cigoff"
 	icon = 'icons/obj/items/smoking/cigarettes.dmi'
 	item_icons = list(
@@ -232,71 +246,31 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	reagents.add_reagent("nicotine",10)
 	if(w_class == SIZE_TINY)
 		AddElement(/datum/element/mouth_drop_item)
+	ADD_TRAIT(src, TRAIT_IGNITABLE, TRAIT_SOURCE_INHERENT)
+	ADD_TRAIT(src, TRAIT_IGNITER, TRAIT_SOURCE_INHERENT)
 
-/obj/item/clothing/mask/cigarette/attackby(obj/item/W, mob/user)
-	..()
-	if(iswelder(W))
-		var/obj/item/tool/weldingtool/WT = W
-		if(WT.isOn())//Badasses don't get blinded while lighting their cig with a blowtorch
-			light(SPAN_NOTICE("[user] casually lights the [name] with [W]."))
+/obj/item/clothing/mask/cigarette/get_ignitable_flavor_text()
+	return list(
+		/obj/item/tool/weldingtool = SPAN_NOTICE("{user} casually lights the {ignitable} with {igniter}."),
+		/obj/item/tool/lighter/zippo = SPAN_ROSE("With a flick of their wrist, {user} lights their {ignitable} with {igniter}."),
+		/obj/item/device/flashlight/flare = SPAN_NOTICE("{user} lights their {ignitable} with {igniter}."),
+		/obj/item/tool/lighter = SPAN_NOTICE("{user} manages to light their {ignitable} with {igniter}."),
+		/obj/item/tool/match = SPAN_NOTICE("{user} lights their {ignitable} with their {igniter}."),
+		/obj/item/weapon/energy/sword = SPAN_WARNING("{user} swings their {igniter}, barely missing their nose. They light their {ignitable} in the process."),
+		/obj/item/device/assembly/igniter = SPAN_NOTICE("{user} fiddles with {igniter}, and manages to light their {ignitable}."),
+		/obj/item/attachable/attached_gun/flamer = SPAN_NOTICE("{user} lights their {ignitable} with {igniter}."),
+		/obj/item/weapon/gun/flamer = SPAN_NOTICE("{user} lights their {ignitable} with the pilot light of {igniter}."),
+		/obj/item/weapon/gun = SPAN_NOTICE("{user} lights their {ignitable} with {igniter}."),
+		/obj/item/tool/surgery/cautery = SPAN_NOTICE("{user} lights their {ignitable} with {igniter}."),
+		/obj/item/clothing/mask/cigarette = SPAN_NOTICE("{user} lights their {ignitable} with {igniter} after a few attempts."),SPAN_NOTICE("{user} lights their {ignitable} with {igniter} after a few attempts."),
+		/obj/item/tool/candle = SPAN_NOTICE("{user} lights their {ignitable} with {igniter} after a few attempts."),
+	)
 
-	else if(istype(W, /obj/item/tool/lighter/zippo))
-		var/obj/item/tool/lighter/zippo/Z = W
-		if(Z.heat_source)
-			light(SPAN_ROSE("With a flick of their wrist, [user] lights their [name] with [W]."))
+/obj/item/clothing/mask/cigarette/check_can_ignite()
+	return item_state == icon_on
 
-	else if(istype(W, /obj/item/device/flashlight/flare))
-		var/obj/item/device/flashlight/flare/FL = W
-		if(FL.heat_source)
-			light(SPAN_NOTICE("[user] lights their [name] with [W]."))
-
-	else if(istype(W, /obj/item/tool/lighter))
-		var/obj/item/tool/lighter/L = W
-		if(L.heat_source)
-			light(SPAN_NOTICE("[user] manages to light their [name] with [W]."))
-
-	else if(istype(W, /obj/item/tool/match))
-		var/obj/item/tool/match/M = W
-		if(M.heat_source)
-			light(SPAN_NOTICE("[user] lights their [name] with their [W]."))
-
-	else if(istype(W, /obj/item/weapon/energy/sword))
-		var/obj/item/weapon/energy/sword/S = W
-		if(S.active)
-			light(SPAN_WARNING("[user] swings their [W], barely missing their nose. They light their [name] in the process."))
-
-	else if(istype(W, /obj/item/device/assembly/igniter))
-		light(SPAN_NOTICE("[user] fiddles with [W], and manages to light their [name]."))
-
-	else if(istype(W, /obj/item/attachable/attached_gun/flamer))
-		light(SPAN_NOTICE("[user] lights their [name] with [W]."))
-
-	else if(istype(W, /obj/item/weapon/gun/flamer))
-		var/obj/item/weapon/gun/flamer/F = W
-		if(!(F.flags_gun_features & GUN_TRIGGER_SAFETY))
-			light(SPAN_NOTICE("[user] lights their [name] with the pilot light of [F]."))
-		else
-			to_chat(user, SPAN_WARNING("Turn on the pilot light first!"))
-
-	else if(isgun(W))
-		var/obj/item/weapon/gun/G = W
-		for(var/slot in G.attachments)
-			if(istype(G.attachments[slot], /obj/item/attachable/attached_gun/flamer))
-				light(SPAN_NOTICE("[user] lights their [name] with [G.attachments[slot]]."))
-				break
-
-	else if(istype(W, /obj/item/tool/surgery/cautery))
-		light(SPAN_NOTICE("[user] lights their [name] with [W]."))
-
-	else if(istype(W, /obj/item/clothing/mask/cigarette))
-		var/obj/item/clothing/mask/cigarette/C = W
-		if(C.item_state == icon_on)
-			light(SPAN_NOTICE("[user] lights their [name] with [C] after a few attempts."))
-
-	else if(istype(W, /obj/item/tool/candle))
-		if(W.heat_source > 200)
-			light(SPAN_NOTICE("[user] lights their [name] with [W] after a few attempts."))
-
+// TODO: Refactor this to use signals holy shit
+/obj/item/clothing/mask/cigarette/proc/try_light(obj/item/W, mob/user)
 	return
 
 
@@ -333,36 +307,41 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		if(fixture.is_broken())
 			light(SPAN_NOTICE("[user] lights their [src] from the broken light."))
 
+/obj/item/clothing/mask/cigarette/ignite(obj/item/igniter, mob/user, flavor_text)
+	light(flavor_text)
+
 /obj/item/clothing/mask/cigarette/proc/light(flavor_text)
 	SIGNAL_HANDLER
-	if(!heat_source)
-		heat_source = 1000
-		damtype = "fire"
-		attack_verb = list("burnt", "singed", "scorched", "seared")
-		if(reagents.handle_volatiles())
-			qdel(src)
-			return
-		flags_atom &= ~NOREACT // allowing reagents to react after being lit
-		reagents.handle_reactions()
-		icon_state = icon_on
-		item_state = icon_on
-		set_light_range(1)
-		set_light_power(0.5)
-		set_light_on(TRUE)
-		if(iscarbon(loc))
-			var/mob/living/carbon/C = loc
-			if(C.r_hand == src)
-				C.update_inv_r_hand()
-			else if(C.l_hand == src)
-				C.update_inv_l_hand()
-			else if(ishuman(loc))
-				var/mob/living/carbon/human/H = loc
-				if(H.wear_mask == src)
-					H.update_inv_wear_mask()
-		if(flavor_text)
-			var/turf/T = get_turf(src)
-			T.visible_message(flavor_text)
-		START_PROCESSING(SSobj, src)
+
+	if(heat_source)
+		return
+
+	heat_source = 1000
+	damtype = "fire"
+	if(reagents.handle_volatiles())
+		qdel(src)
+		return
+	flags_atom &= ~NOREACT // allowing reagents to react after being lit
+	reagents.handle_reactions()
+	icon_state = icon_on
+	item_state = icon_on
+	set_light_range(1)
+	set_light_power(0.5)
+	set_light_on(TRUE)
+	if(iscarbon(loc))
+		var/mob/living/carbon/C = loc
+		if(C.r_hand == src)
+			C.update_inv_r_hand()
+		else if(C.l_hand == src)
+			C.update_inv_l_hand()
+		else if(ishuman(loc))
+			var/mob/living/carbon/human/H = loc
+			if(H.wear_mask == src)
+				H.update_inv_wear_mask()
+	if(flavor_text)
+		var/turf/T = get_turf(src)
+		T.visible_message(flavor_text)
+	START_PROCESSING(SSobj, src)
 
 /obj/item/clothing/mask/cigarette/process(delta_time)
 	var/mob/living/M = loc
@@ -535,68 +514,17 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	smoketime = 7200
 	chem_volume = 30
 
-/obj/item/clothing/mask/cigarette/cigar/attackby(obj/item/W as obj, mob/user as mob)
-	if(iswelder(W))
-		var/obj/item/tool/weldingtool/WT = W
-		if(WT.isOn())
-			light(SPAN_NOTICE("[user] insults [name] by lighting it with [W]."))
-
-	else if(istype(W, /obj/item/tool/lighter/zippo))
-		var/obj/item/tool/lighter/zippo/Z = W
-		if(Z.heat_source)
-			light(SPAN_ROSE("With a flick of their wrist, [user] lights their [name] with their [W]."))
-
-	else if(istype(W, /obj/item/device/flashlight/flare))
-		var/obj/item/device/flashlight/flare/FL = W
-		if(FL.heat_source)
-			light(SPAN_NOTICE("[user] lights their [name] with [W]."))
-
-	else if(istype(W, /obj/item/tool/lighter))
-		var/obj/item/tool/lighter/L = W
-		if(L.heat_source)
-			light(SPAN_NOTICE("[user] manages to offend their [name] by lighting it with [W]."))
-
-	else if(istype(W, /obj/item/tool/match))
-		var/obj/item/tool/match/M = W
-		if(M.heat_source)
-			light(SPAN_NOTICE("[user] lights their [name] with their [W]."))
-
-	else if(istype(W, /obj/item/weapon/energy/sword))
-		var/obj/item/weapon/energy/sword/S = W
-		if(S.active)
-			light(SPAN_WARNING("[user] swings their [W], barely missing their nose. They light their [name] in the process."))
-
-	else if(istype(W, /obj/item/device/assembly/igniter))
-		light(SPAN_NOTICE("[user] fiddles with [W], and manages to light their [name] with the power of science."))
-
-	else if(istype(W, /obj/item/attachable/attached_gun/flamer))
-		light(SPAN_NOTICE("[user] lights their [name] with [W], bet that would have looked cooler if it was attached to something first!"))
-
-	else if(istype(W, /obj/item/weapon/gun/flamer))
-		var/obj/item/weapon/gun/flamer/F = W
-		if(!(F.flags_gun_features & GUN_TRIGGER_SAFETY))
-			light(SPAN_NOTICE("[user] lights their [name] with the pilot light of [F], the glint of pyromania in their eye."))
-		else
-			to_chat(user, SPAN_WARNING("Turn on the pilot light first!"))
-
-	else if(isgun(W))
-		var/obj/item/weapon/gun/G = W
-		for(var/slot in G.attachments)
-			if(istype(G.attachments[slot], /obj/item/attachable/attached_gun/flamer))
-				light(SPAN_NOTICE("[user] lights their [src] with [G.attachments[slot]] like a complete badass."))
-				break
-
-	else if(istype(W, /obj/item/tool/surgery/cautery))
-		light(SPAN_NOTICE("[user] lights their [name] with [W], that can't be sterile!"))
-
-	else if(istype(W, /obj/item/clothing/mask/cigarette))
-		var/obj/item/clothing/mask/cigarette/C = W
-		if(C.item_state == icon_on)
-			light(SPAN_NOTICE("[user] lights their [name] with [C] after a few attempts."))
-
-	else if(istype(W, /obj/item/tool/candle))
-		if(W.heat_source > 200)
-			light(SPAN_NOTICE("[user] lights their [name] with [W] after a few attempts."))
+/obj/item/clothing/mask/cigarette/cigar/havana/get_ignitable_flavor_text()
+	. = ..()
+	. += list(
+		/obj/item/tool/weldingtool = SPAN_NOTICE("{user} insults {ignitable} by lighting it with {igniter}."),
+		/obj/item/tool/lighter = SPAN_NOTICE("{user} manages to offend their {ignitable} by lighting it with {igniter}."),
+		/obj/item/device/assembly/igniter = SPAN_NOTICE("{user} fiddles with {igniter}, and manages to light their {ignitable} with the power of science."),
+		/obj/item/attachable/attached_gun/flamer = SPAN_NOTICE("{user} lights their {ignitable} with {igniter}, bet that would have looked cooler if it was attached to something first!"),
+		/obj/item/weapon/gun/flamer = SPAN_NOTICE("{user} lights their {ignitable} with the pilot light of {igniter}, the glint of pyromania in their eye."),
+		/obj/item/weapon/gun = SPAN_NOTICE("{user} lights their {ignitable} with {igniter} like a complete badass."),
+		/obj/item/tool/surgery/cautery = SPAN_NOTICE("{user} lights their {ignitable} with {igniter}, that can't be sterile!"),
+	)
 
 /////////////////
 //SMOKING PIPES//
@@ -638,34 +566,16 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		smoketime = initial(smoketime)
 	..()
 
-/obj/item/clothing/mask/cigarette/pipe/attackby(obj/item/W as obj, mob/user as mob)
-	if(iswelder(W))
-		var/obj/item/tool/weldingtool/WT = W
-		if(WT.isOn())//
-			light(SPAN_NOTICE("[user] recklessly lights [name] with [W]."))
-
-	else if(istype(W, /obj/item/tool/lighter/zippo))
-		var/obj/item/tool/lighter/zippo/Z = W
-		if(Z.heat_source)
-			light(SPAN_ROSE("With much care, [user] lights their [name] with their [W]."))
-
-	else if(istype(W, /obj/item/device/flashlight/flare))
-		var/obj/item/device/flashlight/flare/FL = W
-		if(FL.heat_source)
-			light(SPAN_NOTICE("[user] lights their [name] with [W]."))
-
-	else if(istype(W, /obj/item/tool/lighter))
-		var/obj/item/tool/lighter/L = W
-		if(L.heat_source)
-			light(SPAN_NOTICE("[user] manages to light their [name] with [W]."))
-
-	else if(istype(W, /obj/item/tool/match))
-		var/obj/item/tool/match/M = W
-		if(M.heat_source)
-			light(SPAN_NOTICE("[user] lights their [name] with their [W]."))
-
-	else if(istype(W, /obj/item/device/assembly/igniter))
-		light(SPAN_NOTICE("[user] fiddles with \the [W], and manages to light their [name] with the power of science."))
+/obj/item/clothing/mask/cigarette/pipe/get_ignitable_flavor_text()
+	. = ..()
+	. += list(
+		/obj/item/tool/weldingtool = SPAN_NOTICE("{user} recklessly lights {ignitable} with {igniter}."),
+		/obj/item/tool/lighter/zippo = SPAN_ROSE("With much care, {user} lights their {ignitable} with their {igniter}."),
+		/obj/item/device/flashlight/flare = SPAN_NOTICE("{user} lights their {ignitable} with {igniter}."),
+		/obj/item/tool/lighter = SPAN_NOTICE("{user} manages to light their {ignitable} with {igniter}."),
+		/obj/item/tool/match = SPAN_NOTICE("{user} lights their {ignitable} with their {igniter}."),
+		/obj/item/device/assembly/igniter = SPAN_NOTICE("{user} fiddles with the {igniter}, and manages to light their {ignitable} with the power of science."),
+	)
 
 /obj/item/clothing/mask/cigarette/pipe/light()
 	if(smoketime > 0)
@@ -752,6 +662,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	attack_verb = list("poked", "jabbed", "pricked", "prodded")
 	damtype = "brute"
 
+/obj/item/tool/lighter/proc/check_ignite()
+	return heat_source
+
 /obj/item/tool/lighter/zippo
 	name = "\improper Zippo lighter"
 	desc = "A fancy steel Zippo lighter. Ignite in style."
@@ -824,46 +737,42 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/tool/lighter/random
 
 /obj/item/tool/lighter/random/Initialize()
-		. = ..()
-		clr = pick("r","c","y","g")
-		icon_on = "lighter_[clr]_on"
-		icon_off = "lighter_[clr]"
-		icon_state = icon_off
-		item_state = icon_off
-		LAZYSET(item_state_slots, WEAR_AS_GARB, "lighter_[clr]")
+	. = ..()
+	clr = pick("r","c","y","g")
+	icon_on = "lighter_[clr]_on"
+	icon_off = "lighter_[clr]"
+	icon_state = icon_off
+	item_state = icon_off
+	LAZYSET(item_state_slots, WEAR_AS_GARB, "lighter_[clr]")
 
 /obj/item/tool/lighter/attack_self(mob/living/user)
-	if(user.r_hand == src || user.l_hand == src)
-		if(!heat_source)
-			heat_source = 1500
-			icon_state = icon_on
-			item_state = icon_on
-
-			if(istype(src, /obj/item/tool/lighter/zippo) )
-				user.visible_message(SPAN_ROSE("Without even breaking stride, [user] flips open and lights [src] in one smooth movement."))
-				playsound(src.loc,"zippo_open",10, 1, 3)
-			else
-				playsound(src.loc,"lighter",10, 1, 3)
-				if(prob(95))
-					user.visible_message(SPAN_NOTICE("After a few attempts, [user] manages to light [src]."))
-
-				else
-					to_chat(user, SPAN_WARNING("You burn yourself while lighting the lighter."))
-					if (user.l_hand == src)
-						user.apply_damage(2,BURN,"l_hand")
-					else
-						user.apply_damage(2,BURN,"r_hand")
-					user.visible_message(SPAN_NOTICE("After a few attempts, [user] manages to light [src], they however burn their finger in the process."))
-			attack_verb = list("burned", "branded", "scorched", "seared")
-			damtype = "fire"
-			set_light_range(2)
-			set_light_on(TRUE)
-			START_PROCESSING(SSobj, src)
-		else
-			turn_off(user, 0)
-	else
+	if(user.r_hand != src && user.l_hand == src)
 		return ..()
-	return
+	if(heat_source)
+		turn_off(user, 0)
+		return
+	heat_source = 1500
+	icon_state = icon_on
+	item_state = icon_on
+	if(istype(src, /obj/item/tool/lighter/zippo) )
+		user.visible_message(SPAN_ROSE("Without even breaking stride, [user] flips open and lights [src] in one smooth movement."))
+		playsound(src.loc,"zippo_open",10, 1, 3)
+	else
+		playsound(src.loc,"lighter",10, 1, 3)
+		if(prob(95))
+			user.visible_message(SPAN_NOTICE("After a few attempts, [user] manages to light [src]."))
+
+		else
+			to_chat(user, SPAN_WARNING("You burn yourself while lighting the lighter."))
+			if (user.l_hand == src)
+				user.apply_damage(2,BURN,"l_hand")
+			else
+				user.apply_damage(2,BURN,"r_hand")
+			user.visible_message(SPAN_NOTICE("After a few attempts, [user] manages to light [src], they however burn their finger in the process."))
+
+	set_light_range(2)
+	set_light_on(TRUE)
+	START_PROCESSING(SSobj, src)
 
 /obj/item/tool/lighter/proc/turn_off(mob/living/bearer, silent = 1)
 	if(heat_source)
@@ -884,21 +793,20 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		return 1
 	return 0
 
-/obj/item/tool/lighter/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/tool/lighter/attack(mob/living/carbon/M, mob/living/carbon/user)
 	if(!isliving(M))
 		return
 	M.IgniteMob()
 	if(!istype(M, /mob))
 		return
 
-	if(istype(M.wear_mask, /obj/item/clothing/mask/cigarette) && user.zone_selected == "mouth" && heat_source)
-		var/obj/item/clothing/mask/cigarette/cig = M.wear_mask
-		if(M == user)
-			cig.attackby(src, user)
-		else
-			if(istype(src, /obj/item/tool/lighter/zippo))
-				cig.light(SPAN_ROSE("[user] whips the [name] out and holds it for [M]."))
-			else
-				cig.light(SPAN_NOTICE("[user] holds the [name] out for [M], and lights the [cig.name]."))
+	if(!istype(M.wear_mask, /obj/item/clothing/mask/cigarette) || user.zone_selected != "mouth" || !heat_source)
+		return ..()
+	var/obj/item/clothing/mask/cigarette/cig = M.wear_mask
+	if(M == user)
+		SEND_SIGNAL(cig, COMSIG_ATOM_IGNITE, src, user)
+	else if(istype(src, /obj/item/tool/lighter/zippo))
+		SEND_SIGNAL(cig, COMSIG_ATOM_IGNITE, src, user, SPAN_ROSE("[user] whips the [name] out and holds it for [M]."))
 	else
-		..()
+		SEND_SIGNAL(cig, COMSIG_ATOM_IGNITE, src, user, SPAN_NOTICE("[user] holds the [name] out for [M], and lights the [cig.name]."))
+

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -297,10 +297,10 @@
 			var/obj/structure/reagent_dispensers/tank/fuel/tank = target
 			tank.explode()
 		return
-	if (welding)
-		if(isliving(target))
-			var/mob/living/L = target
-			L.IgniteMob()
+	if (welding && isliving(target))
+		var/mob/living/living_target = target
+		living_target.IgniteMob()
+		return
 	..()
 
 

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -217,12 +217,15 @@
 		reagents.add_reagent("fuel", max_fuel)
 
 	base_icon_state = initial(icon_state)
-	return
+	ADD_TRAIT(src, TRAIT_IGNITER, TRAIT_SOURCE_INHERENT)
 
 /obj/item/tool/weldingtool/Destroy()
 	if(welding)
 		STOP_PROCESSING(SSobj, src)
 	. = ..()
+
+/obj/item/tool/weldingtool/check_can_ignite()
+	return isOn()
 
 /obj/item/tool/weldingtool/get_examine_text(mob/user)
 	. = ..()
@@ -298,6 +301,7 @@
 		if(isliving(target))
 			var/mob/living/L = target
 			L.IgniteMob()
+	..()
 
 
 /obj/item/tool/weldingtool/attack_self(mob/user)
@@ -746,7 +750,6 @@ Welding backpack
 	if(istype(W, /obj/item/ammo_magazine/flamer_tank))
 		return
 	to_chat(user, SPAN_NOTICE("You cannot figure out how to use \the [W] with [src]."))
-	return
 
 /obj/item/tool/weldpack/afterattack(obj/target as obj, mob/user as mob, proximity)
 	if(!proximity) // this replaces and improves the get_dist(src,target) <= 1 checks used previously

--- a/code/game/objects/items/tools/surgery_tools.dm
+++ b/code/game/objects/items/tools/surgery_tools.dm
@@ -65,6 +65,10 @@
 	flags_item = ANIMATED_SURGICAL_TOOL
 	attack_verb = list("burned", "seared", "scorched", "singed")
 
+/obj/item/tool/surgery/cautery/Initialize(mapload, ...)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_IGNITER, TRAIT_SOURCE_INHERENT)
+
 /obj/item/tool/surgery/cautery/predatorcautery
 	name = "cauterizer"
 	icon_state = "predator_cautery"

--- a/code/game/objects/items/weapons/energy.dm
+++ b/code/game/objects/items/weapons/energy.dm
@@ -61,9 +61,14 @@
 	var/base_sword_icon = "sword"
 	var/sword_color
 
-/obj/item/weapon/energy/sword/New()
+/obj/item/weapon/energy/sword/Initialize(mapload, ...)
+	. = ..()
 	if(!sword_color)
 		sword_color = pick("red","blue","green","purple")
+	ADD_TRAIT(src, TRAIT_IGNITER, TRAIT_SOURCE_INHERENT)
+
+/obj/item/weapon/energy/sword/check_can_ignite()
+	return active
 
 /obj/item/weapon/energy/sword/attack_self(mob/living/user)
 	..()

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -8,6 +8,10 @@
 	heat_source = 1000 //Can ignite Thermite.
 	flags_item = IGNITING_ITEM
 
+/obj/item/device/assembly/igniter/Initialize(mapload, ...)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_IGNITER, TRAIT_SOURCE_INHERENT)
+
 /obj/item/device/assembly/igniter/activate()
 	if(!..())
 		return FALSE//Cooldown check

--- a/code/modules/movement/launching/launching.dm
+++ b/code/modules/movement/launching/launching.dm
@@ -28,19 +28,12 @@
 
 
 /datum/launch_metadata/proc/get_collision_callbacks(atom/A)
-	var/highest_matching = null
-	var/list/matching = list()
-
 	if (isnull(collision_callbacks))
 		return null
 
-	for (var/path in collision_callbacks)
-		if (ispath(path) && istype(A, path))
-			// A is going to be of type `path` and `highest_matching`, so check whether
-			// `highest_matching` is a parent of `path` (lower in the type tree)
-			if (isnull(highest_matching) || !ispath(highest_matching, path))
-				highest_matching = path
-			matching += path
+	var/datum/matching_paths/matching_paths = get_matching_paths(A, collision_callbacks)
+	var/datum/highest_matching = matching_paths.highest_matching
+	var/list/datum/matching = matching_paths.matching
 
 	if (!call_all)
 		if (isnull(highest_matching))

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1405,12 +1405,14 @@ and you're good to go.
 
 /obj/item/weapon/gun/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	if(!proximity_flag)
-		return FALSE
+		return
 
 	if(active_attachable && (active_attachable.flags_attach_features & ATTACH_MELEE))
 		active_attachable.last_fired = world.time
 		active_attachable.fire_attachment(target, src, user)
-		return TRUE
+		return
+
+	..()
 
 
 /obj/item/weapon/gun/attack(mob/living/attacked_mob, mob/living/user, dual_wield)
@@ -2414,3 +2416,6 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 			if(!explo_proof) // heavy explosions don't care if the weapon has it's protection left; else you'd get weird situations where OBs/yautja SD/etc leave damaged but working guns everywhere.
 				visible_message(SPAN_DANGER(SPAN_UNDERLINE("[src] [msg]")))
 				deconstruct(FALSE)
+
+/obj/item/weapon/gun/check_can_ignite()
+	return active_attachable && HAS_TRAIT(active_attachable, TRAIT_IGNITER) && active_attachable.check_can_ignite()

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -3350,9 +3350,9 @@ Defined in conflicts.dm of the #defines folder.
 	ADD_TRAIT(to_attach_to, TRAIT_IGNITER, TRAIT_SOURCE_ATTACHMENT(slot))
 	RegisterSignal(to_attach_to, COMSIG_IGNITER_OVERRIDE, PROC_REF(igniter_override))
 
-/obj/item/attachable/attached_gun/flamer/Detach(mob/user, obj/item/weapon/gun/detaching_gub)
-	REMOVE_TRAIT(detaching_gub, TRAIT_IGNITER, TRAIT_SOURCE_ATTACHMENT(slot))
-	UnregisterSignal(detaching_gub, COMSIG_IGNITER_OVERRIDE)
+/obj/item/attachable/attached_gun/flamer/Detach(mob/user, obj/item/weapon/gun/detaching_gun)
+	REMOVE_TRAIT(detaching_gun, TRAIT_IGNITER, TRAIT_SOURCE_ATTACHMENT(slot))
+	UnregisterSignal(detaching_gun, COMSIG_IGNITER_OVERRIDE)
 	..()
 
 /obj/item/attachable/attached_gun/flamer/proc/igniter_override(obj/item/weapon/gun/attached_to, datum/igniter_override_metadata/metadata)

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -3340,9 +3340,24 @@ Defined in conflicts.dm of the #defines folder.
 	var/round_usage_per_tile = 1
 	var/intense_mode = FALSE
 
-/obj/item/attachable/attached_gun/flamer/New()
-	..()
+/obj/item/attachable/attached_gun/flamer/Initialize(mapload, ...)
+	. = ..()
 	attachment_firing_delay = FIRE_DELAY_TIER_4 * 5
+	ADD_TRAIT(src, TRAIT_IGNITER, TRAIT_SOURCE_INHERENT)
+
+/obj/item/attachable/attached_gun/flamer/Attach(obj/item/weapon/gun/to_attach_to)
+	..()
+	ADD_TRAIT(to_attach_to, TRAIT_IGNITER, TRAIT_SOURCE_ATTACHMENT(slot))
+	RegisterSignal(to_attach_to, COMSIG_IGNITER_OVERRIDE, PROC_REF(igniter_override))
+
+/obj/item/attachable/attached_gun/flamer/Detach(mob/user, obj/item/weapon/gun/detaching_gub)
+	REMOVE_TRAIT(detaching_gub, TRAIT_IGNITER, TRAIT_SOURCE_ATTACHMENT(slot))
+	UnregisterSignal(detaching_gub, COMSIG_IGNITER_OVERRIDE)
+	..()
+
+/obj/item/attachable/attached_gun/flamer/proc/igniter_override(obj/item/weapon/gun/attached_to, datum/igniter_override_metadata/metadata)
+	SIGNAL_HANDLER
+	metadata.igniter_override = src
 
 /obj/item/attachable/attached_gun/flamer/get_examine_text(mob/user)
 	. = ..()

--- a/code/modules/projectiles/guns/flamer/flamer.dm
+++ b/code/modules/projectiles/guns/flamer/flamer.dm
@@ -47,6 +47,12 @@
 /obj/item/weapon/gun/flamer/Initialize(mapload, spawn_empty)
 	. = ..()
 	update_icon()
+	ADD_TRAIT(src, TRAIT_IGNITER, TRAIT_SOURCE_INHERENT)
+
+/obj/item/weapon/gun/flamer/check_can_ignite()
+	if(!(flags_gun_features & GUN_TRIGGER_SAFETY))
+		return TRUE
+	return ..()
 
 /obj/item/weapon/gun/flamer/set_gun_attachment_offsets()
 	attachable_offset = list("muzzle_x" = 0, "muzzle_y" = 0, "rail_x" = 11, "rail_y" = 20, "under_x" = 21, "under_y" = 14, "stock_x" = 0, "stock_y" = 0)
@@ -683,7 +689,7 @@ GLOBAL_LIST_EMPTY(flamer_particles)
 			scorch_turf_target.scorch(burnlevel)
 		var/obj/effect/decal/cleanable/liquid_fuel/liquid = LAZYACCESS(scorch_turf_target.cleanables, CLEANABLE_IGNITABLE)
 		if(liquid && istype(liquid))
-			INVOKE_NEXT_TICK(liquid, TYPE_PROC_REF(/obj/effect/decal/cleanable/liquid_fuel, ignite))
+			INVOKE_NEXT_TICK(liquid, TYPE_PROC_REF(/obj/effect/decal/cleanable/liquid_fuel, ignite_fuel))
 
 	if (istype(loc, /turf/open/auto_turf/snow))
 		var/turf/open/auto_turf/snow/S = loc

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -562,6 +562,8 @@
 #include "code\datums\elements\traitbound\crawler.dm"
 #include "code\datums\elements\traitbound\gun_silenced.dm"
 #include "code\datums\elements\traitbound\leadership.dm"
+#include "code\datums\elements\traitbound\igniting\ignitable.dm"
+#include "code\datums\elements\traitbound\igniting\igniter.dm"
 #include "code\datums\emergency_calls\big_game_hunter.dm"
 #include "code\datums\emergency_calls\bodyguard.dm"
 #include "code\datums\emergency_calls\cbrn.dm"


### PR DESCRIPTION

# About the pull request

Replaces if-chaining logic for lighting some items with two elements: IGNITER for objects that can ignite things and IGNITABLE for things that can be ignited.

This isn't super comprehensive, just a baseline from original attackby refactor: https://github.com/cmss13-devs/cmss13/pull/7130

# Explain why it's good for the game

Precursor to requiring attackby to call parent for signals. Using elements to dictate behavior is preferable over difficult-to-maintain if-statement chains and can be more easily extended for other situations (e.g. lighting fuel on the floor or lighting mobs on fire).


# Testing Photographs and Procedure
<details>
<summary>Lighting a bunch of havana cigars which have unique flavor text per item</summary>


https://github.com/user-attachments/assets/fdddd9f9-2a8b-435b-abdb-8503ca6200d2



</details>

I tested with other ignitables too, namely candles, cigarettes, and pipes


# Changelog
:cl: TheDonkified
refactor: Created an IGNITER element for items that can light other objects on fire
refactor: Created an IGNITABLE element for atoms that can be lit on fire
refactor: Updated a few items like lighters, flares, flamethrowers, and cauteries to use the IGNITER element
refactor: Updated a few items like cigarettes and candles to use the IGNITABLE element
/:cl:
