### PR TITLE
Fix/UI: Ahelps Over-sharing + Ticket Panel tweaks

### DIFF
--- a/code/modules/admin/ticket_panel/ticket_panel.dm
+++ b/code/modules/admin/ticket_panel/ticket_panel.dm
@@ -63,7 +63,7 @@
 		"status" = status,
 		"timestamp" = AH.time_activity["opened_at"],
 		"closed_at" = AH.time_activity["closed_at"],
-		"claimed_by" = AH.marked_admin,
+		"claimed_by" = AH.marked_admin_key_name,
 		"all_responses" = formatted_responses,
 		"viewer_is_claiming" = (AH.marked_admin == (viewer ? viewer.ckey : usr?.ckey) ? TRUE : FALSE),
 		"is_archived" = (AH.state != AHELP_ACTIVE),

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -371,13 +371,16 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 	return ..()
 
 /datum/admin_help/proc/AddInteraction(formatted_message, plain_message = null, message_type = "admin", link_data = null)
+	var/ckey_to_use = null
 	var/key_name_to_use = null
 
 	// Safely get the user's ckey
-	if(usr && !isnull(usr.client))
-		key_name_to_use = key_name(usr.client, FALSE, FALSE)
-		if(key_name_to_use != initiator_ckey)
-			admins_involved |= key_name_to_use
+	if(usr && !isnull(usr.ckey))
+		ckey_to_use = usr.ckey
+		if(!isnull(usr.client))
+			key_name_to_use = key_name(usr.client, FALSE, FALSE)
+		if(ckey_to_use != initiator_ckey)
+			admins_involved |= ckey_to_use
 			if(heard_by_no_admins)
 				heard_by_no_admins = FALSE
 

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -723,9 +723,9 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 	dat += "[FOURSPACES][TicketHref("Refresh", ref_src)][FOURSPACES][TicketHref("Re-Title", ref_src, "retitle")]"
 	if(state != AHELP_ACTIVE)
 		dat += "[FOURSPACES][TicketHref("Reopen", ref_src, "reopen")]"
-	dat += "<br><br>Opened at: [time2text(time = opened_at)] (Approx [DisplayTimeText(REALTIMEOFDAY - opened_at)] ago)"
+	dat += "<br><br>Opened at: [time2text(opened_at, "hh:mm:ss")] (Approx [DisplayTimeText(REALTIMEOFDAY - opened_at)] ago)"
 	if(closed_at)
-		dat += "<br>Closed at: [time2text(time = closed_at)] (Approx [DisplayTimeText(REALTIMEOFDAY - closed_at)] ago)"
+		dat += "<br>Closed at: [time2text(closed_at, "hh:mm:ss")] (Approx [DisplayTimeText(REALTIMEOFDAY - closed_at)] ago)"
 	dat += "<br>"
 	if(initiator)
 		dat += "[FullMonty(ref_src)]<br>" //All the action buttons for tickets/ahelps
@@ -830,9 +830,9 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 		else
 			dat += "UNKNOWN</b>"
 	dat += "\n[FOURSPACES]<A href='byond://?_src_=admin_holder;[HrefToken(forceGlobal = TRUE)];player_ticket_panel=1'>Refresh</A>"
-	dat += "<br><br>Opened at: [time2text("hh:mm:ss", opened_at)] (Approx [DisplayTimeText(REALTIMEOFDAY - opened_at)] ago)"
+	dat += "<br><br>Opened at: [time2text(opened_at, "hh:mm:ss")] (Approx [DisplayTimeText(REALTIMEOFDAY - opened_at)] ago)"
 	if(closed_at)
-		dat += "<br>Closed at: [time2text("hh:mm:ss", closed_at)] (Approx [DisplayTimeText(REALTIMEOFDAY - closed_at)] ago)"
+		dat += "<br>Closed at: [time2text(closed_at, "hh:mm:ss")] (Approx [DisplayTimeText(REALTIMEOFDAY - closed_at)] ago)"
 	dat += "<br><br>"
 	dat += "<br><b>Log:</b><br><br>"
 	for (var/interaction in player_interactions)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -371,13 +371,13 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 	return ..()
 
 /datum/admin_help/proc/AddInteraction(formatted_message, plain_message = null, message_type = "admin", link_data = null)
-	var/ckey_to_use = null
+	var/key_name_to_use = null
 
 	// Safely get the user's ckey
-	if(usr && !isnull(usr.ckey))
-		ckey_to_use = usr.ckey
-		if(ckey_to_use != initiator_ckey)
-			admins_involved |= ckey_to_use
+	if(usr && !isnull(usr.client))
+		key_name_to_use = key_name(usr.client, FALSE, FALSE)
+		if(key_name_to_use != initiator_ckey)
+			admins_involved |= key_name_to_use
 			if(heard_by_no_admins)
 				heard_by_no_admins = FALSE
 
@@ -391,7 +391,7 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 	var/plain_text = plain_message || strip_html(formatted_message)
 	var/html_message = "[worldtime2text(timestamp)]: [formatted_message]"
 
-	var/author = ckey_to_use || "System"
+	var/author = key_name_to_use || "System"
 
 	if(message_type == "system")
 		author = "System"

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -210,7 +210,7 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 	var/list/admins_involved = list()
 	/// The ckey of the admin that marked this ahelp?
 	var/marked_admin
-	/// The key name of the admin
+	/// The key name of that admin
 	var/marked_admin_key_name
 	/// Has the player replied to this ticket yet?
 	var/player_replied = FALSE
@@ -638,7 +638,7 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 	message_admins(msg)
 	log_ahelp(id, "Marked", "Marked by [user.username()]", sender = user.ckey)
 	marked_admin = user.ckey
-	marked_admin_key_name = key_name
+	marked_admin_key_name = user.username()
 
 /datum/admin_help/proc/unmark_ticket()
 	var/key_name = key_name_admin(usr, FALSE)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -372,13 +372,13 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 
 /datum/admin_help/proc/AddInteraction(formatted_message, plain_message = null, message_type = "admin", link_data = null)
 	var/ckey_to_use = null
-	var/key_name_to_use = null
+	var/username_to_use = null
 
 	// Safely get the user's ckey
 	if(usr && !isnull(usr.ckey))
 		ckey_to_use = usr.ckey
 		if(!isnull(usr.client))
-			key_name_to_use = key_name(usr.client, FALSE, FALSE)
+			username_to_use = usr.client.username()
 		if(ckey_to_use != initiator_ckey)
 			admins_involved |= ckey_to_use
 			if(heard_by_no_admins)
@@ -394,7 +394,7 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 	var/plain_text = plain_message || strip_html(formatted_message)
 	var/html_message = "[worldtime2text(timestamp)]: [formatted_message]"
 
-	var/author = key_name_to_use || "System"
+	var/author = username_to_use || "System"
 
 	if(message_type == "system")
 		author = "System"

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -236,8 +236,8 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 		return
 
 	id = ++ticket_counter
-	opened_at = world.time
-	time_activity["opened_at"] = "[worldtime2text(opened_at)]"
+	opened_at = REALTIMEOFDAY
+	time_activity["opened_at"] = "[time2text(opened_at, "YYYY-MM-DD hh:mm:ss")]"
 
 	name = copytext_char(msg, 1, 100)
 	initial_message = msg
@@ -390,9 +390,9 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 	if(!plain_message && link_data && length(link_data))
 		plain_message = link_data[1]
 
-	var/timestamp = world.time
+	var/time_stamp = time_stamp()
 	var/plain_text = plain_message || strip_html(formatted_message)
-	var/html_message = "[worldtime2text(timestamp)]: [formatted_message]"
+	var/html_message = "[time_stamp]: [formatted_message]"
 
 	var/author = username_to_use || "System"
 
@@ -400,7 +400,7 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 		author = "System"
 
 	var/list/structured_data = list(
-		"timestamp" = worldtime2text(timestamp),
+		"timestamp" = time_stamp,
 		"author" = author,
 		"message" = html_encode(plain_text),
 		"html_message" = formatted_message,
@@ -522,8 +522,8 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 /datum/admin_help/proc/RemoveActive()
 	if(state != AHELP_ACTIVE)
 		return
-	closed_at = world.time
-	time_activity["closed_at"] = "[worldtime2text(closed_at)]"
+	closed_at = REALTIMEOFDAY
+	time_activity["closed_at"] = "[time2text(closed_at, "YYYY-MM-DD hh:mm:ss")]"
 	QDEL_NULL(statclick)
 	GLOB.ahelp_tickets.active_tickets -= src
 	if(initiator && initiator.current_ticket == src)
@@ -723,9 +723,9 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 	dat += "[FOURSPACES][TicketHref("Refresh", ref_src)][FOURSPACES][TicketHref("Re-Title", ref_src, "retitle")]"
 	if(state != AHELP_ACTIVE)
 		dat += "[FOURSPACES][TicketHref("Reopen", ref_src, "reopen")]"
-	dat += "<br><br>Opened at: [worldtime2text(time = opened_at)] (Approx [DisplayTimeText(world.time - opened_at)] ago)"
+	dat += "<br><br>Opened at: [time2text(time = opened_at)] (Approx [DisplayTimeText(REALTIMEOFDAY - opened_at)] ago)"
 	if(closed_at)
-		dat += "<br>Closed at: [worldtime2text(time = closed_at)] (Approx [DisplayTimeText(world.time - closed_at)] ago)"
+		dat += "<br>Closed at: [time2text(time = closed_at)] (Approx [DisplayTimeText(REALTIMEOFDAY - closed_at)] ago)"
 	dat += "<br>"
 	if(initiator)
 		dat += "[FullMonty(ref_src)]<br>" //All the action buttons for tickets/ahelps
@@ -830,9 +830,9 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 		else
 			dat += "UNKNOWN</b>"
 	dat += "\n[FOURSPACES]<A href='byond://?_src_=admin_holder;[HrefToken(forceGlobal = TRUE)];player_ticket_panel=1'>Refresh</A>"
-	dat += "<br><br>Opened at: [worldtime2text("hh:mm:ss", opened_at)] (Approx [DisplayTimeText(world.time - opened_at)] ago)"
+	dat += "<br><br>Opened at: [time2text("hh:mm:ss", opened_at)] (Approx [DisplayTimeText(REALTIMEOFDAY - opened_at)] ago)"
 	if(closed_at)
-		dat += "<br>Closed at: [worldtime2text("hh:mm:ss", closed_at)] (Approx [DisplayTimeText(world.time - closed_at)] ago)"
+		dat += "<br>Closed at: [time2text("hh:mm:ss", closed_at)] (Approx [DisplayTimeText(REALTIMEOFDAY - closed_at)] ago)"
 	dat += "<br><br>"
 	dat += "<br><b>Log:</b><br><br>"
 	for (var/interaction in player_interactions)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -208,8 +208,10 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 	var/list/player_interactions
 	/// List of admin ckeys that are involved, like through responding
 	var/list/admins_involved = list()
-	/// Which admin has marked this ahelp?
+	/// The ckey of the admin that marked this ahelp?
 	var/marked_admin
+	/// The key name of the admin
+	var/marked_admin_key_name
 	/// Has the player replied to this ticket yet?
 	var/player_replied = FALSE
 	/// What was the first message sent by the player?
@@ -257,8 +259,9 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 	player_interactions = list()
 
 	if(is_bwoink)
-		AddInteraction(SPAN_BLUE("[key_name_admin(usr)] PM'd [LinkedReplyName()]"),
-		plain_message = "[initiator.ckey] PM'd [initiator_key_name]")
+		var/admin_initiating = key_name_admin(usr, FALSE)
+		AddInteraction(SPAN_BLUE("[admin_initiating] PM'd [LinkedReplyName()]"),
+		plain_message = "[admin_initiating] PM'd [initiator_key_name]")
 		message_admins(SPAN_BLUE("Ticket [TicketHref("#[id]")] created"))
 	else
 		MessageNoRecipient(msg_raw, urgent)
@@ -506,7 +509,7 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 	if(initiator)
 		initiator.current_ticket = src
 
-	AddInteraction(SPAN_PURPLE("Reopened by [key_name_admin(usr)]"),
+	AddInteraction(SPAN_PURPLE("Reopened by [key_name_admin(usr, FALSE)]"),
 	plain_message = "Reopened by [usr.username()]", message_type = "system")
 	var/msg = SPAN_ADMINHELP("Ticket [TicketHref("#[id]")] reopened by [key_name_admin(usr)].")
 	message_admins(msg)
@@ -524,15 +527,16 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 		initiator.current_ticket = null
 
 //Mark open ticket as closed/meme
-/datum/admin_help/proc/Close(key_name = key_name_admin(usr), silent = FALSE)
+/datum/admin_help/proc/Close(key_name = key_name_admin(usr, FALSE), silent = FALSE)
 	if(state != AHELP_ACTIVE)
 		return
 
 	if(marked_admin && marked_admin != usr.ckey)
-		to_chat(usr, SPAN_WARNING("This ticket is currently marked by [marked_admin]. Please override their mark to interact with this ticket!"))
+		to_chat(usr, SPAN_WARNING("This ticket is currently marked by [marked_admin_key_name]. Please override their mark to interact with this ticket!"))
 		return
 
 	marked_admin = null
+	marked_admin_key_name = null
 	RemoveActive()
 	state = AHELP_CLOSED
 	GLOB.ahelp_tickets.ListInsert(src)
@@ -543,15 +547,16 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 		log_ahelp(id, "Closed", "Closed by [usr.username()]", null, usr.ckey)
 
 //Mark open ticket as resolved/legitimate, returns ahelp verb
-/datum/admin_help/proc/Resolve(key_name = key_name_admin(usr), silent = FALSE)
+/datum/admin_help/proc/Resolve(key_name = key_name_admin(usr, FALSE), silent = FALSE)
 	if(state != AHELP_ACTIVE)
 		return
 
 	if(marked_admin && marked_admin != usr.ckey)
-		to_chat(usr, SPAN_WARNING("This ticket is currently marked by [marked_admin]. Please override their mark to interact with this ticket!"))
+		to_chat(usr, SPAN_WARNING("This ticket is currently marked by [marked_admin_key_name]. Please override their mark to interact with this ticket!"))
 		return
 
 	marked_admin = null
+	marked_admin_key_name = null
 	RemoveActive()
 	state = AHELP_RESOLVED
 	GLOB.ahelp_tickets.ListInsert(src)
@@ -571,7 +576,7 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 		return
 
 	if(marked_admin && marked_admin != usr.ckey)
-		to_chat(usr, SPAN_WARNING("This ticket is currently marked by [marked_admin]. Please override their mark to interact with this ticket!"))
+		to_chat(usr, SPAN_WARNING("This ticket is currently marked by [marked_admin_key_name]. Please override their mark to interact with this ticket!"))
 		return
 
 	if(GLOB.mentorhelp_manager.get_active_ticket_by_ckey(initiator_ckey))
@@ -599,7 +604,7 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 	MH.subject = subject
 	MH.broadcast_unhandled(message, initiator)
 
-	AddInteraction("Deferred to Mentors by [key_name_admin(usr)].", plain_message = "Deferred to Mentors by [usr.username()]", message_type = "system")
+	AddInteraction("Deferred to Mentors by [key_name_admin(usr, FALSE)].", plain_message = "Deferred to Mentors by [usr.username()]", message_type = "system")
 	to_chat(initiator, SPAN_ADMINHELP("[usr.username()] has deferred your ticket to Mentors."))
 	log_admin_private("Ticket [TicketHref("#[id]")] deferred to mentors by [usr.username()].")
 	for(var/client/admin in GLOB.admins)
@@ -617,15 +622,15 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 		if(marked_admin == user.ckey)
 			unmark_ticket()
 			return
-		to_chat(user, SPAN_WARNING("This ticket has already been marked by [marked_admin]."))
-		var/unmark_option = tgui_alert(user, "This message has been marked by [marked_admin]. Do you want to override?", "Marked Ticket", list("Overwrite Mark", "Unmark", "Cancel"))
+		to_chat(user, SPAN_WARNING("This ticket has already been marked by [marked_admin_key_name]."))
+		var/unmark_option = tgui_alert(user, "This message has been marked by [marked_admin_key_name]. Do you want to override?", "Marked Ticket", list("Overwrite Mark", "Unmark", "Cancel"))
 		if(unmark_option == "Unmark")
 			unmark_ticket()
 			return
 		if(unmark_option != "Overwrite Mark")
 			return
 
-	var/key_name = key_name_admin(user)
+	var/key_name = key_name_admin(user, FALSE)
 	AddInteraction("Marked by [key_name].",
 		plain_message = "Marked by [user.username()]", message_type = "system")
 	to_chat(initiator, SPAN_ADMINHELP("An admin is preparing to respond to your ticket."))
@@ -633,23 +638,25 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 	message_admins(msg)
 	log_ahelp(id, "Marked", "Marked by [user.username()]", sender = user.ckey)
 	marked_admin = user.ckey
+	marked_admin_key_name = key_name
 
 /datum/admin_help/proc/unmark_ticket()
-	var/key_name = key_name_admin(usr)
-	AddInteraction("Unmarked by [key_name] (previously [marked_admin]).",
-		plain_message = "Unmarked by [usr.username()] (previously [marked_admin])", message_type = "system")
+	var/key_name = key_name_admin(usr, FALSE)
+	AddInteraction("Unmarked by [key_name] (previously [marked_admin_key_name]).",
+		plain_message = "Unmarked by [usr.username()] (previously [marked_admin_key_name])", message_type = "system")
 	var/msg = "Ticket [TicketHref("#[id]")] unmarked by [key_name]."
 	message_admins(msg)
-	log_ahelp(id, "Unmarked", "Unmarked by [usr.username()] (previously [marked_admin])", sender = usr.ckey)
+	log_ahelp(id, "Unmarked", "Unmarked by [usr.username()] (previously [marked_admin_key_name])", sender = usr.ckey)
 	marked_admin = null
+	marked_admin_key_name = null
 
 //Close and return ahelp verb, use if ticket is incoherent
-/datum/admin_help/proc/Reject(key_name = key_name_admin(usr))
+/datum/admin_help/proc/Reject(key_name = key_name_admin(usr, FALSE))
 	if(state != AHELP_ACTIVE)
 		return
 
 	if(marked_admin && ckey(marked_admin) != usr.ckey)
-		to_chat(usr, SPAN_WARNING("This ticket is currently marked by [marked_admin]. Please override their mark to interact with this ticket!"))
+		to_chat(usr, SPAN_WARNING("This ticket is currently marked by [marked_admin_key_name]. Please override their mark to interact with this ticket!"))
 		return
 
 	if(initiator)
@@ -670,14 +677,14 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 
 /// Resolve ticket with a premade message
 /datum/admin_help/proc/AutoReply()
-	var/key_name = key_name_admin(usr)
+	var/key_name = key_name_admin(usr, FALSE)
 	if(state != AHELP_ACTIVE)
 		to_chat(usr, SPAN_WARNING("This ticket is already closed!"))
 		return
 
 	if(marked_admin != usr.ckey)
 		if(marked_admin)
-			to_chat(usr, SPAN_WARNING("This ticket is currently marked by [marked_admin]. Please override their mark to interact with this ticket!"))
+			to_chat(usr, SPAN_WARNING("This ticket is currently marked by [marked_admin_key_name]. Please override their mark to interact with this ticket!"))
 			return
 		else
 			mark_ticket(usr)

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -249,7 +249,7 @@ SET_PROTECTED_PROC(/client/proc/cmd_admin_pm)
 			var/already_logged = FALSE
 			if(!recipient.current_ticket)
 				var/datum/admin_help/new_ticket = new(msg, recipient, TRUE)
-				new_ticket.marked_admin = ckey
+				new_ticket.marked_admin = key_name_admin(src, FALSE)
 				already_logged = TRUE
 				if(recipient.current_ticket)
 					log_ahelp(recipient.current_ticket.id, "Ticket Opened", msg, recipient.ckey, src.ckey)
@@ -272,7 +272,7 @@ SET_PROTECTED_PROC(/client/proc/cmd_admin_pm)
 				html = SPAN_NOTICE("Admin PM to-<b>[key_name(recipient, src, 1, show_username = TRUE)]</b>: <span class='linkify'>[msg]</span>"),
 				confidential = TRUE)
 
-			admin_ticket_log(recipient, SPAN_GREEN("PM From [key_name_with_username(src)]: [msg]"), log_in_blackbox = FALSE,
+			admin_ticket_log(recipient, SPAN_GREEN("PM From [key_name_admin(src, FALSE)]: [msg]"), log_in_blackbox = FALSE,
 				player_message = SPAN_GREEN("PM From [key_name_with_username(src, include_name = FALSE)]: [msg]"),
 				raw_message = "PM from-[src.username()] to-[recipient.username()]: [msg]",
 				raw_player_message = "[msg]")

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -249,7 +249,8 @@ SET_PROTECTED_PROC(/client/proc/cmd_admin_pm)
 			var/already_logged = FALSE
 			if(!recipient.current_ticket)
 				var/datum/admin_help/new_ticket = new(msg, recipient, TRUE)
-				new_ticket.marked_admin = key_name_admin(src, FALSE)
+				new_ticket.marked_admin = ckey
+				new_ticket.marked_admin_key_name = username()
 				already_logged = TRUE
 				if(recipient.current_ticket)
 					log_ahelp(recipient.current_ticket.id, "Ticket Opened", msg, recipient.ckey, src.ckey)

--- a/code/modules/mentor/mentorhelp.dm
+++ b/code/modules/mentor/mentorhelp.dm
@@ -69,8 +69,8 @@ GLOBAL_DATUM_INIT(mentorhelp_manager, /datum/mentorhelp_manager, new)
 		qdel(src)
 		return
 
-	opened_at = world.time
-	time_activity["opened_at"] = "[worldtime2text(opened_at)]"
+	opened_at = REALTIMEOFDAY
+	time_activity["opened_at"] = "[time2text(opened_at, "YYYY-MM-DD hh:mm:ss")]"
 
 	author = thread_author
 	author_key = thread_author.key
@@ -223,9 +223,10 @@ GLOBAL_DATUM_INIT(mentorhelp_manager, /datum/mentorhelp_manager, new)
 	log_mhelp(log_msg)
 
 	if(include_in_ticket)
-		var/html_message = "[time_stamp()]: [html_msg]"
+		var/time_stamp = time_stamp()
+		var/html_message = "[time_stamp]: [html_msg]"
 		var/list/structured_data = list(
-			"timestamp" = worldtime2text(world.time),
+			"timestamp" = time_stamp,
 			"author" = from_key || "System",
 			"message" = plain_text,
 			"html_message" = html_msg,
@@ -545,8 +546,8 @@ GLOBAL_DATUM_INIT(mentorhelp_manager, /datum/mentorhelp_manager, new)
 		if(GLOB.mentorhelp_manager.active_tickets["[id]"] == src)
 			GLOB.mentorhelp_manager.active_tickets -= "[id]"
 			GLOB.mentorhelp_manager.archived_tickets["[id]"] = src
-		closed_at = world.time
-		time_activity["closed_at"] = "[worldtime2text(closed_at)]"
+		closed_at = REALTIMEOFDAY
+		time_activity["closed_at"] = "[time2text(closed_at, "YYYY-MM-DD hh:mm:ss")]"
 		return
 
 	// Make sure it's being closed by staff or the mentor handling the thread
@@ -579,8 +580,8 @@ GLOBAL_DATUM_INIT(mentorhelp_manager, /datum/mentorhelp_manager, new)
 	to_chat(author, SPAN_NOTICE("Your mentorhelp thread has been closed."))
 	notify("[SPAN_RED(author_key)]'s mentorhelp thread has been closed.",
 			unformatted_text = "[author_key]'s mentorhelp thread has been closed.")
-	closed_at = world.time
-	time_activity["closed_at"] = "[worldtime2text(closed_at)]"
+	closed_at = REALTIMEOFDAY
+	time_activity["closed_at"] = "[time2text(closed_at, "YYYY-MM-DD hh:mm:ss")]"
 
 	// Clear the client reference if they're still connected
 	if(author && author.current_mhelp == src)

--- a/code/modules/mentor/mentorhelp.dm
+++ b/code/modules/mentor/mentorhelp.dm
@@ -263,10 +263,10 @@ GLOBAL_DATUM_INIT(mentorhelp_manager, /datum/mentorhelp_manager, new)
 		if(author_key)
 			latest_msg_unformatted = replacetext(latest_msg_unformatted, author_key, get_author_ic_name())
 		latest_message = latest_msg_unformatted
-
-	var/html_message = "[time_stamp()]: [text]"
+	var/time_stamp = time_stamp()
+	var/html_message = "[time_stamp]: [text]"
 	var/list/structured_data = list(
-		"timestamp" = worldtime2text(world.time),
+		"timestamp" = time_stamp,
 		"author" = "System",
 		"message" = unformatted,
 		"type" = "system"

--- a/tgui/packages/tgui/components/Collapsible.tsx
+++ b/tgui/packages/tgui/components/Collapsible.tsx
@@ -23,7 +23,7 @@ export function Collapsible(props: Props) {
 
   return (
     <Box mb={1}>
-      <div className="Table">
+      <div className="Table__Collapsible">
         <div className="Table__cell">
           <Button
             fluid

--- a/tgui/packages/tgui/interfaces/TicketPanel.tsx
+++ b/tgui/packages/tgui/interfaces/TicketPanel.tsx
@@ -189,294 +189,262 @@ export const TicketPanel = (props) => {
               </Stack>
             </Section>
           </Stack.Item>
-          <Stack.Item
-            grow
-            basis={0}
-            style={{ display: 'flex', flexDirection: 'column' }}
-          >
+          <Stack.Item grow>
             <Stack fill>
-              <Stack.Item
-                width="300px"
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  height: '100%',
-                }}
-              >
-                <Tabs vertical>
-                  {data.is_admin ? (
-                    <Tabs.Tab
-                      selected={data.selected_tab === 'admin'}
-                      onClick={() => act('select_tab', { tab: 'admin' })}
-                      icon="user-shield"
+              <Stack.Item minWidth={30}>
+                <Stack vertical fill>
+                  <Stack.Item shrink>
+                    <Tabs vertical>
+                      {data.is_admin ? (
+                        <Tabs.Tab
+                          selected={data.selected_tab === 'admin'}
+                          onClick={() => act('select_tab', { tab: 'admin' })}
+                          icon="user-shield"
+                        >
+                          Admin Tickets ({data.admin_open_tickets.length})
+                        </Tabs.Tab>
+                      ) : (
+                        ''
+                      )}
+                      <Tabs.Tab
+                        selected={data.selected_tab === 'mentor'}
+                        onClick={() => act('select_tab', { tab: 'mentor' })}
+                        icon="user-graduate"
+                      >
+                        Mentor Tickets ({data.mentor_open_tickets.length})
+                      </Tabs.Tab>
+                    </Tabs>
+                  </Stack.Item>
+                  <Stack.Item grow={2}>
+                    <Section
+                      fill
+                      title={`Open Tickets (${openTickets.length})`}
+                      scrollable
                     >
-                      Admin Tickets ({data.admin_open_tickets.length})
-                    </Tabs.Tab>
-                  ) : (
-                    ''
-                  )}
-                  <Tabs.Tab
-                    selected={data.selected_tab === 'mentor'}
-                    onClick={() => act('select_tab', { tab: 'mentor' })}
-                    icon="user-graduate"
-                  >
-                    Mentor Tickets ({data.mentor_open_tickets.length})
-                  </Tabs.Tab>
-                </Tabs>
-
-                <Box
-                  style={{
-                    flexGrow: '1',
-                    minHeight: '0',
-                    overflowY: 'auto',
-                  }}
-                >
-                  <Stack vertical>
-                    <Section title={`Open Tickets (${openTickets.length})`}>
                       {openTickets.length === 0 ? (
                         <Box>No open tickets.</Box>
                       ) : (
-                        <Box
-                          style={{
-                            maxHeight: '320px',
-                            overflowY: 'auto',
-                            paddingRight: '4px',
-                          }}
-                        >
-                          <Stack vertical>
-                            {openTickets.map((ticket) => (
-                              <Box
-                                key={ticket.id}
-                                className={[
-                                  'TicketItem',
-                                  data.selected_ticket === ticket.id &&
-                                    'TicketItem--selected',
-                                ]
-                                  .filter(Boolean)
-                                  .join(' ')}
-                                onClick={() =>
-                                  act('select_ticket', { ticket_id: ticket.id })
-                                }
-                                p={1}
-                                mb={1}
-                                style={{
-                                  cursor: 'pointer',
-                                  borderRadius: '6px',
-                                  backgroundColor:
-                                    data.selected_ticket === ticket.id
-                                      ? 'rgba(0,0,0,0.15)'
-                                      : 'transparent',
-                                }}
-                              >
-                                <Stack align="center">
-                                  <Stack.Item>
-                                    <Button
-                                      icon="times"
-                                      color={
-                                        ticket.claimed_by &&
-                                        !ticket.viewer_is_claiming
-                                          ? 'default'
-                                          : 'bad'
-                                      }
-                                      tooltip="Close Ticket"
-                                      disabled={
-                                        !!ticket.claimed_by &&
-                                        !ticket.viewer_is_claiming
-                                      }
-                                      onClick={(e) => {
-                                        e.stopPropagation();
-                                        act('close_ticket', {
-                                          ticket_id: ticket.id,
-                                        });
-                                      }}
-                                    />
-                                  </Stack.Item>
-                                  <Stack.Item>
-                                    <Icon
-                                      name={
-                                        ticket.claimed_by
-                                          ? 'user-check'
-                                          : 'user'
-                                      }
-                                      color={
-                                        ticket.claimed_by ? 'good' : 'average'
-                                      }
-                                      mr={1}
-                                    />
-                                  </Stack.Item>
-                                  <Stack.Item grow={1} overflow="hidden">
+                        <Stack vertical fill>
+                          {openTickets.map((ticket) => (
+                            <Box
+                              key={ticket.id}
+                              className={[
+                                'TicketItem',
+                                data.selected_ticket === ticket.id &&
+                                  'TicketItem--selected',
+                              ]
+                                .filter(Boolean)
+                                .join(' ')}
+                              onClick={() =>
+                                act('select_ticket', { ticket_id: ticket.id })
+                              }
+                              p={1}
+                              mb={1}
+                              style={{
+                                cursor: 'pointer',
+                                borderRadius: '6px',
+                                backgroundColor:
+                                  data.selected_ticket === ticket.id
+                                    ? 'rgba(0,0,0,0.15)'
+                                    : 'transparent',
+                              }}
+                            >
+                              <Stack align="center">
+                                <Stack.Item>
+                                  <Button
+                                    icon="times"
+                                    color={
+                                      ticket.claimed_by &&
+                                      !ticket.viewer_is_claiming
+                                        ? 'default'
+                                        : 'bad'
+                                    }
+                                    tooltip="Close Ticket"
+                                    disabled={
+                                      !!ticket.claimed_by &&
+                                      !ticket.viewer_is_claiming
+                                    }
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      act('close_ticket', {
+                                        ticket_id: ticket.id,
+                                      });
+                                    }}
+                                  />
+                                </Stack.Item>
+                                <Stack.Item>
+                                  <Icon
+                                    name={
+                                      ticket.claimed_by ? 'user-check' : 'user'
+                                    }
+                                    color={
+                                      ticket.claimed_by ? 'good' : 'average'
+                                    }
+                                    mr={1}
+                                  />
+                                </Stack.Item>
+                                <Stack.Item grow={1} overflow="hidden">
+                                  <Box
+                                    bold
+                                    color={
+                                      ticket.claimed_by ? 'good' : 'default'
+                                    }
+                                  >
+                                    {ticket.author}
+                                    {ticket.role ? ` (${ticket.role})` : ''}
+                                  </Box>
+                                  {decodeHtmlEntities(ticket.subject) ? (
                                     <Box
-                                      bold
-                                      color={
-                                        ticket.claimed_by ? 'good' : 'default'
-                                      }
-                                    >
-                                      {ticket.author}
-                                      {ticket.role ? ` (${ticket.role})` : ''}
-                                    </Box>
-                                    {decodeHtmlEntities(ticket.subject) ? (
-                                      <Box
-                                        color={'average'}
-                                        style={{
-                                          whiteSpace: 'nowrap',
-                                          overflow: 'hidden',
-                                          textOverflow: 'ellipsis',
-                                        }}
-                                      >
-                                        <b>
-                                          {'[' +
-                                            decodeHtmlEntities(ticket.subject) +
-                                            ']'}
-                                        </b>
-                                      </Box>
-                                    ) : (
-                                      ''
-                                    )}
-                                    <Box
-                                      color="label"
+                                      color={'average'}
                                       style={{
                                         whiteSpace: 'nowrap',
                                         overflow: 'hidden',
                                         textOverflow: 'ellipsis',
                                       }}
                                     >
-                                      {decodeHtmlEntities(
-                                        ticket.latest_message,
-                                      )}
+                                      <b>
+                                        {'[' +
+                                          decodeHtmlEntities(ticket.subject) +
+                                          ']'}
+                                      </b>
                                     </Box>
-                                    <Box color="gray" fontSize="0.9em">
-                                      {ticket.timestamp}
-                                    </Box>
-                                  </Stack.Item>
-                                </Stack>
-                              </Box>
-                            ))}
-                          </Stack>
-                        </Box>
+                                  ) : (
+                                    ''
+                                  )}
+                                  <Box
+                                    color="label"
+                                    style={{
+                                      whiteSpace: 'nowrap',
+                                      overflow: 'hidden',
+                                      textOverflow: 'ellipsis',
+                                    }}
+                                  >
+                                    {decodeHtmlEntities(ticket.latest_message)}
+                                  </Box>
+                                  <Box color="gray" fontSize="0.9em">
+                                    {ticket.timestamp}
+                                  </Box>
+                                </Stack.Item>
+                              </Stack>
+                            </Box>
+                          ))}
+                        </Stack>
                       )}
                     </Section>
-
-                    <Section title={`Archived (${archivedTickets.length})`}>
+                  </Stack.Item>
+                  <Stack.Item grow>
+                    <Section
+                      fill
+                      title={`Archived (${archivedTickets.length})`}
+                      scrollable
+                    >
                       {archivedTickets.length === 0 ? (
                         <Box>No archived tickets.</Box>
                       ) : (
-                        <Box
-                          style={{
-                            maxHeight: '320px',
-                            overflowY: 'auto',
-                            paddingRight: '4px',
-                          }}
-                        >
-                          <Stack vertical>
-                            {archivedTickets.map((ticket) => (
-                              <Box
-                                key={ticket.id}
-                                className={[
-                                  'TicketItem',
-                                  data.selected_ticket === ticket.id &&
-                                    'TicketItem--selected',
-                                ]
-                                  .filter(Boolean)
-                                  .join(' ')}
-                                onClick={() =>
-                                  act('select_ticket', { ticket_id: ticket.id })
-                                }
-                                p={1}
-                                mb={1}
-                                style={{
-                                  cursor: 'pointer',
-                                  borderRadius: '6px',
-                                  backgroundColor:
-                                    data.selected_ticket === ticket.id
-                                      ? 'rgba(0,0,0,0.15)'
-                                      : 'rgba(0,0,0,0.05)',
-                                  opacity: '0.7',
-                                }}
-                              >
-                                <Stack align="center">
-                                  <Stack.Item>
-                                    <Icon name="lock" color="average" mr={1} />
-                                  </Stack.Item>
-                                  <Stack.Item>
-                                    <Icon
-                                      name={
-                                        ticket.claimed_by
-                                          ? 'user-check'
-                                          : 'user'
-                                      }
-                                      color={
-                                        ticket.claimed_by ? 'good' : 'average'
-                                      }
-                                      mr={1}
-                                    />
-                                  </Stack.Item>
-                                  <Stack.Item grow={1} overflow="hidden">
+                        <Stack vertical>
+                          {archivedTickets.map((ticket) => (
+                            <Box
+                              key={ticket.id}
+                              className={[
+                                'TicketItem',
+                                data.selected_ticket === ticket.id &&
+                                  'TicketItem--selected',
+                              ]
+                                .filter(Boolean)
+                                .join(' ')}
+                              onClick={() =>
+                                act('select_ticket', {
+                                  ticket_id: ticket.id,
+                                })
+                              }
+                              p={1}
+                              mb={1}
+                              style={{
+                                cursor: 'pointer',
+                                borderRadius: '6px',
+                                backgroundColor:
+                                  data.selected_ticket === ticket.id
+                                    ? 'rgba(0,0,0,0.15)'
+                                    : 'rgba(0,0,0,0.05)',
+                                opacity: '0.7',
+                              }}
+                            >
+                              <Stack align="center" fill>
+                                <Stack.Item>
+                                  <Icon name="lock" color="average" mr={1} />
+                                </Stack.Item>
+                                <Stack.Item>
+                                  <Icon
+                                    name={
+                                      ticket.claimed_by ? 'user-check' : 'user'
+                                    }
+                                    color={
+                                      ticket.claimed_by ? 'good' : 'average'
+                                    }
+                                    mr={1}
+                                  />
+                                </Stack.Item>
+                                <Stack.Item grow={1} overflow="hidden">
+                                  <Box
+                                    bold
+                                    color={
+                                      ticket.claimed_by ? 'good' : 'default'
+                                    }
+                                  >
+                                    {ticket.author}
+                                    {ticket.role ? ` (${ticket.role})` : ''}
+                                  </Box>
+                                  {decodeHtmlEntities(ticket.subject) ? (
                                     <Box
-                                      bold
-                                      color={
-                                        ticket.claimed_by ? 'good' : 'default'
-                                      }
-                                    >
-                                      {ticket.author}
-                                      {ticket.role ? ` (${ticket.role})` : ''}
-                                    </Box>
-                                    {decodeHtmlEntities(ticket.subject) ? (
-                                      <Box
-                                        color={'average'}
-                                        style={{
-                                          whiteSpace: 'nowrap',
-                                          overflow: 'hidden',
-                                          textOverflow: 'ellipsis',
-                                        }}
-                                      >
-                                        <b>
-                                          {'[' +
-                                            decodeHtmlEntities(ticket.subject) +
-                                            ']'}
-                                        </b>
-                                      </Box>
-                                    ) : (
-                                      ''
-                                    )}
-                                    <Box
-                                      color="label"
+                                      color={'average'}
                                       style={{
                                         whiteSpace: 'nowrap',
                                         overflow: 'hidden',
                                         textOverflow: 'ellipsis',
                                       }}
                                     >
-                                      {decodeHtmlEntities(
-                                        ticket.latest_message,
-                                      )}
+                                      <b>
+                                        {'[' +
+                                          decodeHtmlEntities(ticket.subject) +
+                                          ']'}
+                                      </b>
                                     </Box>
-                                    <Box color="gray" fontSize="0.9em">
-                                      {ticket.timestamp}
-                                    </Box>
-                                  </Stack.Item>
-                                </Stack>
-                              </Box>
-                            ))}
-                          </Stack>
-                        </Box>
+                                  ) : (
+                                    ''
+                                  )}
+                                  <Box
+                                    color="label"
+                                    style={{
+                                      whiteSpace: 'nowrap',
+                                      overflow: 'hidden',
+                                      textOverflow: 'ellipsis',
+                                    }}
+                                  >
+                                    {decodeHtmlEntities(ticket.latest_message)}
+                                  </Box>
+                                  <Box color="gray" fontSize="0.9em">
+                                    {ticket.timestamp}
+                                  </Box>
+                                </Stack.Item>
+                              </Stack>
+                            </Box>
+                          ))}
+                        </Stack>
                       )}
                     </Section>
-                  </Stack>
-                </Box>
+                  </Stack.Item>
+                </Stack>
               </Stack.Item>
 
               <Stack.Divider />
 
-              <Stack.Item
-                grow
-                basis={0}
-                style={{ display: 'flex', flexDirection: 'column' }}
-              >
+              <Stack.Item grow>
                 {selectedTicketData ? (
                   <Stack fill vertical>
                     <Stack.Item grow basis={0} position="relative">
                       <Section
                         fill
+                        m={0}
                         title={`${selectedTicketData.is_archived ? '[ARCHIVED] ' : ''}Ticket #${selectedTicketData.id} ${selectedTicketData.subject ? ': ' + decodeHtmlEntities(selectedTicketData.subject) : ''}`}
                         buttons={
                           !selectedTicketData.is_archived ? (
@@ -692,11 +660,7 @@ export const TicketPanel = (props) => {
                               </LabeledList.Item>
                             </LabeledList>
                           </Stack.Item>
-                          <Stack.Item
-                            grow
-                            basis={0}
-                            style={{ display: 'flex', flexDirection: 'column' }}
-                          >
+                          <Stack.Item grow>
                             {(selectedTicketData.all_responses?.length ?? 0) >
                               0 && (
                               <Section
@@ -704,14 +668,9 @@ export const TicketPanel = (props) => {
                                 scrollable
                                 title="Conversation Log"
                                 key={`ticket-${selectedTicketData.id}-${ticketUpdateTime}`}
+                                m={0}
                               >
-                                <Box
-                                  mt={2}
-                                  style={{
-                                    overflowX: 'hidden',
-                                    padding: '0.5em',
-                                  }}
-                                >
+                                <Box m={2}>
                                   {selectedTicketData.all_responses?.map(
                                     (response, index) => {
                                       const link = response.islink;
@@ -756,12 +715,13 @@ export const TicketPanel = (props) => {
                                                 <Box as="span">
                                                   {link ? (
                                                     <Button
-                                                      content={link[0]}
                                                       onClick={() => {
                                                         window.location.href =
                                                           link[1];
                                                       }}
-                                                    />
+                                                    >
+                                                      {link[0]}
+                                                    </Button>
                                                   ) : (
                                                     decodeHtmlEntities(
                                                       response.message,
@@ -783,7 +743,7 @@ export const TicketPanel = (props) => {
                       </Section>
                     </Stack.Item>
                     <Stack.Item>
-                      <Box mt={1}>
+                      <Box mt={1} pb={1}>
                         {!selectedTicketData.is_archived ? (
                           <Stack vertical>
                             <Stack.Item>

--- a/tgui/packages/tgui/interfaces/TicketPanel.tsx
+++ b/tgui/packages/tgui/interfaces/TicketPanel.tsx
@@ -540,7 +540,7 @@ export const TicketPanel = (props) => {
                         }
                       >
                         <Stack fill vertical>
-                          <Stack.Item>
+                          <Stack.Item pb="3px">
                             <LabeledList>
                               {selectedTicketData.subject ? (
                                 <LabeledList.Item label="Subject">
@@ -603,6 +603,7 @@ export const TicketPanel = (props) => {
                               </LabeledList.Item>
                               <LabeledList.Item label="Initial Message">
                                 <Box
+                                  mb="2px"
                                   style={{
                                     whiteSpace: 'pre-wrap',
                                     wordBreak: 'break-all',
@@ -678,8 +679,9 @@ export const TicketPanel = (props) => {
                                         <Box key={index} mb={2}>
                                           <Stack align="flex-start">
                                             <Stack.Item
+                                              mr="3%"
                                               style={{
-                                                width: '120px',
+                                                width: '10%',
                                                 fontSize: '1em',
                                                 color: 'gray',
                                               }}

--- a/tgui/packages/tgui/interfaces/TicketPanel.tsx
+++ b/tgui/packages/tgui/interfaces/TicketPanel.tsx
@@ -677,11 +677,10 @@ export const TicketPanel = (props) => {
                                       const link = response.islink;
                                       return (
                                         <Box key={index} mb={2}>
-                                          <Stack align="flex-start">
+                                          <Stack align="start">
                                             <Stack.Item
-                                              mr="3%"
+                                              mr="25px"
                                               style={{
-                                                width: '10%',
                                                 fontSize: '1em',
                                                 color: 'gray',
                                               }}

--- a/tgui/packages/tgui/styles/components/Table.scss
+++ b/tgui/packages/tgui/styles/components/Table.scss
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
+.Table__Collapsible,
 .Table {
   display: table;
   width: 100%;


### PR DESCRIPTION

# About the pull request

## Fix
- Title. Non staff recipients don't need to see the IC name of the admins replying to them.
- Move things that were displaying admin_marked to use a new variable that has the admin's username instead.
- Time stamps use real time instead of IC/world time

## UI - Shoving this in here so I can subject my changes on to everyone. Plus it's kinda relevant anyway.
- Kill the weird border around the collapsibles button. - I was going to use this to hide the Archive but it didn't want to play nice nested, and I gave up bashing it to work.
- Make the ticket panel scale better Achived section is made smaller, both scale to window size
- Center the conversation Log
- Remove depreciated use of content 
- Add some small spacing to the buttons at the bottom of the ticket

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Uhmmm yes.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

## Fix

<img width="622" height="512" alt="Screenshot 2026-07-16 020243" src="https://github.com/user-attachments/assets/97694b68-d1cb-40cf-8e18-a8c7f1805387" />

<img width="693" height="715" alt="Screenshot 2026-07-16 020314" src="https://github.com/user-attachments/assets/aded4ec9-5a7b-4a9f-8f8d-6738ebb978bd" />

<img width="622" height="512" alt="Screenshot 2026-07-16 023036" src="https://github.com/user-attachments/assets/d42d6f2a-39ba-45a2-914e-41380a68debc" />

<img width="792" height="702" alt="Screenshot 2026-07-16 023053" src="https://github.com/user-attachments/assets/8736f6cb-2c36-40fa-89a5-6764d7e4bac3" />

## UI

<img width="1120" height="900" alt="Screenshot 2026-07-07 194424" src="https://github.com/user-attachments/assets/65fd475a-785b-4ace-aa5b-8d8fe8ad598c" />

<img width="1403" height="914" alt="Screenshot 2026-07-07 195032" src="https://github.com/user-attachments/assets/d7e973b3-de7a-447c-9706-6c24496818ed" />

<img width="860" height="600" alt="Screenshot 2026-07-07 195233" src="https://github.com/user-attachments/assets/622cc419-14c0-4fcc-bae5-8a999d14f05f" />

</details>


# Changelog
:cl:
fix: Users no longer see admin's IC Characters from ahelp interactions
ui: Ticket Panel scales better. Collapsibles like in the Overwatch Console are no longer bordered.
/:cl:
