### PR TITLE
Fix: Ship Intercomms & Shortwaves not working

### DIFF
--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -99,7 +99,7 @@
 			if(!radio_device)
 				continue
 			var/atom/loc = radio_device.loc
-			if(!loc || !loc.z)
+			if(!loc)
 				continue
 			if(radio_device.receive_range(display_freq, level) > -1 && OBJECTS_CAN_REACH(loc, radio_loc))
 				radios += radio_device
@@ -113,7 +113,7 @@
 			if(istype(radio_device, /obj/item/device/radio/headset))
 				continue
 			var/atom/loc = radio_device.loc
-			if(!loc || !loc.z)
+			if(!loc)
 				continue
 			if(radio_device.receive_range(display_freq, level) > -1 && OBJECTS_CAN_REACH(loc, radio_loc))
 				radios += radio_device
@@ -136,7 +136,7 @@
 			if(!radio_device)
 				continue
 			var/atom/loc = radio_device.loc
-			if(!loc || !loc.z)
+			if(!loc)
 				continue
 			if(radio_device.receive_range(display_freq, level) > -1 && OBJECTS_CAN_REACH(loc, radio_loc))
 				radios += radio_device

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -95,24 +95,28 @@
 	// --- Broadcast only to intercom devices ---
 	if(data == RADIO_FILTER_TYPE_INTERCOM)
 		for (var/datum/weakref/device_ref as anything in connection.devices["[RADIO_CHAT]"])
-			var/obj/item/device/radio/intercom/R = device_ref.resolve()
-			if(!R)
+			var/obj/item/device/radio/intercom/radio_device = device_ref.resolve()
+			if(!radio_device)
 				continue
-			var/atom/loc = R.loc
-			if(R.receive_range(display_freq, level) > -1 && OBJECTS_CAN_REACH(loc, radio_loc))
-				radios += R
+			var/atom/loc = radio_device.loc
+			if(!loc || !loc.z)
+				continue
+			if(radio_device.receive_range(display_freq, level) > -1 && OBJECTS_CAN_REACH(loc, radio_loc))
+				radios += radio_device
 
 	// --- Broadcast only to intercoms and shortwave radios ---
 	else if(data == RADIO_FILTER_TYPE_INTERCOM_AND_BOUNCER)
 		for (var/datum/weakref/device_ref as anything in connection.devices["[RADIO_CHAT]"])
-			var/obj/item/device/radio/R = device_ref.resolve()
-			if(!R)
+			var/obj/item/device/radio/radio_device = device_ref.resolve()
+			if(!radio_device)
 				continue
-			if(istype(R, /obj/item/device/radio/headset))
+			if(istype(radio_device, /obj/item/device/radio/headset))
 				continue
-			var/atom/loc = R.loc
-			if(R.receive_range(display_freq, level) > -1 && OBJECTS_CAN_REACH(loc, radio_loc))
-				radios += R
+			var/atom/loc = radio_device.loc
+			if(!loc || !loc.z)
+				continue
+			if(radio_device.receive_range(display_freq, level) > -1 && OBJECTS_CAN_REACH(loc, radio_loc))
+				radios += radio_device
 
 	/* Currently unused, but leaving incase someone revives agents or another use for it.
 	// --- Broadcast to antag radios! ---
@@ -128,14 +132,14 @@
 	// --- Broadcast to ALL radio devices ---
 	else
 		for (var/datum/weakref/device_ref as anything in connection.devices["[RADIO_CHAT]"])
-			var/obj/item/device/radio/R = device_ref.resolve()
-			if(!R)
+			var/obj/item/device/radio/radio_device = device_ref.resolve()
+			if(!radio_device)
 				continue
-			var/atom/loc = R.loc
-			if (!loc)
+			var/atom/loc = radio_device.loc
+			if(!loc || !loc.z)
 				continue
-			if(R.receive_range(display_freq, level) > -1 && OBJECTS_CAN_REACH(loc, radio_loc))
-				radios += R
+			if(radio_device.receive_range(display_freq, level) > -1 && OBJECTS_CAN_REACH(loc, radio_loc))
+				radios += radio_device
 
 	// Get a list of mobs who can hear from the radios we collected.
 	var/list/receive = get_mobs_in_radio_ranges(radios)


### PR DESCRIPTION

# About the pull request
Caused by one radio being in essential kit and there fore in nullspace for whatever reason.
Add handling for null loc. Yay.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Bug bad
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Ship Intercomms & Shortwaves work again
/:cl:
