### PR TITLE
fix: Cryopod intercoms don't go to Narnia when you eject anymore

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -447,40 +447,42 @@ GLOBAL_LIST_INIT(frozen_items, list(SQUAD_MARINE_1 = list(), SQUAD_MARINE_2 = li
 			return TRUE
 
 /obj/structure/machinery/cryopod/relaymove(mob/user)
-	if(user.is_mob_incapacitated(TRUE))
-		return
-	eject()
+	eject(user, override_confirmation = TRUE)
 
-/obj/structure/machinery/cryopod/verb/eject()
+/obj/structure/machinery/cryopod/verb/eject_verb()
 	set name = "Eject Pod"
 	set category = "Object"
 	set src in oview(1)
-	if(usr.stat != 0)
+
+	eject(usr)
+
+/obj/structure/machinery/cryopod/proc/eject(mob/initiator, override_confirmation = FALSE)
+	if(initiator.is_mob_incapacitated(TRUE))
 		return
 
-	if(occupant != usr)
-		to_chat(usr, SPAN_WARNING("You can't drag people out of hypersleep!"))
+	if(occupant != initiator)
+		to_chat(initiator, SPAN_WARNING("You can't drag people out of hypersleep!"))
 		return
 
-	if(!silent_exit && alert(usr, "Would you like eject out of the hypersleep chamber?", "Confirm", "Yes", "No") != "Yes")
+	var/mob/user = occupant // This alert below sleeps, so we have to doublecheck
+	if(!override_confirmation && !silent_exit && tgui_alert(occupant, "Would you like eject out of the hypersleep chamber?", "Eject from Hypersleep", list("Yes", "No")) != "Yes")
+		return
+	if(user != occupant) // Someone tried to game the system - Bail out
 		return
 
 	go_out() //Not adding a delay for this because for some reason it refuses to work. Not a big deal imo
-	add_fingerprint(usr)
+	add_fingerprint(user) // Now we use user not occupant as the occupant has been ejected
 
-	to_chat(usr, SPAN_NOTICE("You get out of \the [src]."))
+	to_chat(occupant, SPAN_NOTICE("You get out of \the [src]."))
 	if(!silent_exit)
 		visible_message(SPAN_WARNING("\The [src]'s casket starts moving!"))
-		var/mob/living/M = usr
-		var/area/location = get_area(src) //Logs the exit
-		message_admins("[key_name_admin(M)], [M.job], has left [src] at [location].")
+		var/area/location = get_area(user) //Logs the exit
+		message_admins("[key_name_admin(user)], [user.job], has left [src] at [location].")
 
-	var/list/items = src.contents //-Removes items from the chamber
-	if(occupant)
-		items -= occupant
+	// Removes items from the chamber, in case someone drops something
+	var/list/items = contents.Copy()
 	if(announce)
-		items -= announce
-
+		items -= announce // Keep the intercom inside the cryopod
 	for(var/obj/item/W in items)
 		W.forceMove(get_turf(src))
 

--- a/code/modules/mob/living/living_verbs.dm
+++ b/code/modules/mob/living/living_verbs.dm
@@ -78,7 +78,7 @@
 	//getting out of hypersleep
 	if(loc && (istype(loc, /obj/structure/machinery/cryopod)))
 		var/obj/structure/machinery/cryopod/BB = loc
-		BB.eject()
+		BB.eject(src)
 
 	//getting out of bodyscanner
 	if(loc && (istype(loc, /obj/structure/machinery/medical_pod/bodyscanner)))

--- a/code/modules/shuttle/computers/escape_pod_computer.dm
+++ b/code/modules/shuttle/computers/escape_pod_computer.dm
@@ -148,7 +148,7 @@
 			move_mob_inside(grabbed_mob)
 			injector_name = user.real_name
 
-/obj/structure/machinery/cryopod/evacuation/eject()
+/obj/structure/machinery/cryopod/evacuation/eject_verb()
 	set name = "Eject Pod"
 	set category = "Object"
 	set src in oview(1)


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Follow-up to #12659 
Without #12659 the radios break when some of them are nullspaced. Mist identified one of the causes (essential kit), but there is another one, which is the cryopod intercoms. 

TL;DR: By copying `contents` by reference, when the intercom is removed from the list, it's also sent to nullspace.

Also modernized the code while i was there. Had to split verb/proc and fix usr because it turns out relaymove doesn't work here without the `usr` hack i put in SSinput and that we shouldn't have.

# Explain why it's good for the game
Bugs


# Testing Photographs and Procedure
Tried going in / ejecting repeatedly with several methods (relaymove, resist, verb)


# Changelog
:cl:
fix: Fixed Cryopod internal intercoms being sent to the void upon ejecting.
fix: Fixed some exploitable race conditions with Cryopods.
/:cl:
