### PR TITLE
Fix essentials_set spawning

### DIFF
--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -1183,18 +1183,22 @@ GLOBAL_LIST_EMPTY(vending_products)
 /obj/effect/essentials_set
 	var/list/spawned_gear_list
 
-/obj/effect/essentials_set/New(loc)
-	..()
+/obj/effect/essentials_set/Initialize(mapload, ...)
+	. = ..()
+	if(loc) // Don't spawn stuff in nullspace please
+		spawn_stuff()
+	return INITIALIZE_HINT_QDEL
+
+/obj/effect/essentials_set/proc/spawn_stuff()
 	for(var/typepath in spawned_gear_list)
 		if(spawned_gear_list[typepath])
 			new typepath(loc, spawned_gear_list[typepath])
 		else
 			new typepath(loc)
-	qdel(src)
 
 //same thing, but spawns only 1 item from the list
-/obj/effect/essentials_set/random/New(loc)
-	if(!spawned_gear_list)
+/obj/effect/essentials_set/random/spawn_stuff()
+	if(!length(spawned_gear_list))
 		return
 
 	var/typepath = pick(spawned_gear_list)
@@ -1202,7 +1206,6 @@ GLOBAL_LIST_EMPTY(vending_products)
 		new typepath(loc, TRUE)
 	else
 		new typepath(loc)
-	qdel(src)
 
 
 //---helper glob data


### PR DESCRIPTION

# About the pull request

Bit of a shot in the dark but also a follow up to #12659 

During game init the asset_transport generates the vendors spritesheets to be sent in bulk to clients.
This involves spawning and deleting every object. The problem is that essentials_set-s were never meant to be used like this.
They'll spawn items where they are (in nullspace) that will just stay there, forever (or, for the more mundane items, until refcount drops to 0 and they are cleaned up by the in-engine garbage collector)
Allegedly, this means more complex items with refs like radios will still linger for no real reason and cause side effects
No more?

# Testing Photographs and Procedure
Did basic testing using them.


# Changelog
No player facing changes
