### PR TITLE
disable deprecated agents item tracker

### DIFF
--- a/code/_globalvars/global_lists.dm
+++ b/code/_globalvars/global_lists.dm
@@ -192,8 +192,6 @@ GLOBAL_LIST_EMPTY(all_areas)
 
 GLOBAL_LIST_EMPTY(turfs)
 
-GLOBAL_LIST(objects_of_interest) // This is used to track the stealing objective for Agents.
-
 // Areas exempt from explosive antigrief (not Z-levels)
 GLOBAL_LIST_INIT(explosive_antigrief_exempt_areas, list(
 	//non currently

--- a/code/datums/agents/tools/tracker.dm
+++ b/code/datums/agents/tools/tracker.dm
@@ -1,75 +1,11 @@
+/// Former tracker for agents targets
 /obj/item/device/tracker
 	name = "OoI tracker"
 	desc = "A tracker that tracks Objects of Interest, it is not widely available."
 	icon_state = "tracker"
 	item_state = "tracker"
-	var/active = FALSE
-	var/ping_speed = 20
-	var/ping_duration = 20
-	var/obj/item/tracked_object
 
+/*
 /obj/item/device/tracker/update_icon()
-	overlays.Cut()
-
-	if(active && tracked_object)
-		overlays += icon(icon, "+tracker_arrow", Get_Compass_Dir(src, tracked_object))
-
-/obj/item/device/tracker/attack_self(mob/user)
-	if(!skillcheckexplicit(user, SKILL_ANTAG, SKILL_ANTAG_AGENT))
-		return ..()
-
-	if(isnull(tracked_object))
-		select_object(user)
-		return
-
-	to_chat(user, SPAN_NOTICE("You start tracking the [tracked_object.name]."))
-	if(!do_after(user, ping_speed, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
-		return
-
-	active = TRUE
-	update_icon()
-
-	addtimer(CALLBACK(src, PROC_REF(deactivated)), ping_duration)
-
-/obj/item/device/tracker/proc/deactivated()
-	active = FALSE
-	update_icon()
-
-/obj/item/device/tracker/clicked(mob/user, list/mods)
-	if(!ishuman(user) || !skillcheckexplicit(user, SKILL_ANTAG, SKILL_ANTAG_AGENT))
-		return ..()
-
-	if(mods[ALT_CLICK])
-		if(!CAN_PICKUP(user, src))
-			return ..()
-		select_object(user)
-		return TRUE
-
-	return ..()
-
-/obj/item/device/tracker/proc/select_object(mob/user)
-	if(!LAZYLEN(GLOB.objects_of_interest))
-		to_chat(user, SPAN_WARNING("There are nothing of interest to track."))
-		return
-
-	var/list/object_choices = list()
-	for(var/obj/O in GLOB.objects_of_interest)
-		var/z_level_to_compare_from = O.z
-		if(istype(O.loc, /obj/structure/surface))
-			z_level_to_compare_from = O.loc.z
-
-		if(z_level_to_compare_from == user.z)
-			object_choices += O
-
-	if(!length(object_choices))
-		to_chat(user, SPAN_WARNING("There are nothing of interest to track."))
-		return
-
-	tracked_object = tgui_input_list(usr, "What Object of Interest do you want to track?", "Object type", object_choices)
-
-	to_chat(user, SPAN_WARNING("New interest to track selected as [tracked_object.name]."))
-
-/obj/item/device/tracker/Destroy()
-	if(tracked_object)
-		tracked_object = null
-	. = ..()
+	overlays += icon(icon, "+tracker_arrow", Get_Compass_Dir(src, tracked_object))
+*/

--- a/code/game/objects/items/books/manuals.dm
+++ b/code/game/objects/items/books/manuals.dm
@@ -956,13 +956,3 @@
 			</html>
 			"}
 
-
-/obj/item/book/manual/orbital_cannon_manual/New()
-	. = ..()
-
-	LAZYADD(GLOB.objects_of_interest, src)
-
-/obj/item/book/manual/orbital_cannon_manual/Destroy()
-	. = ..()
-
-	LAZYREMOVE(GLOB.objects_of_interest, src)

--- a/code/game/objects/items/devices/autopsy_scanner.dm
+++ b/code/game/objects/items/devices/autopsy_scanner.dm
@@ -14,16 +14,6 @@
 	var/target_name = null
 	var/timeofdeath = null
 
-/obj/item/device/autopsy_scanner/Initialize()
-	. = ..()
-
-	LAZYADD(GLOB.objects_of_interest, src)
-
-/obj/item/device/autopsy_scanner/Destroy()
-	. = ..()
-
-	LAZYREMOVE(GLOB.objects_of_interest, src)
-
 /datum/autopsy_data_scanner
 	var/weapon = null // this is the DEFINITE weapon type that was used
 	var/list/organs_scanned = list() // this maps a number of scanned organs to the wounds to those organs with this data's weapon type

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -295,16 +295,6 @@
 	clothing_traits = list(TRAIT_EAR_PROTECTION)
 	black_market_value = 20
 
-/obj/item/clothing/ears/earmuffs/New()
-	. = ..()
-
-	LAZYADD(GLOB.objects_of_interest, src)
-
-/obj/item/clothing/ears/earmuffs/Destroy()
-	. = ..()
-
-	LAZYREMOVE(GLOB.objects_of_interest, src)
-
 
 ///////////////////////////////////////////////////////////////////////
 //Suit


### PR DESCRIPTION

# About the pull request

No agents, no need. It only tracked a couple specific items anyway that are not relevant nowadays.

I left the update_icon commented as hint that an overlay exists for future ref.


# Changelog
:cl:
del: The Agents item tracker is now disabled, since agents are gone.
/:cl:
