### PR TITLE
fix: Crossed ARES alerts with non-mobs runtime

### DIFF
--- a/code/game/machinery/ARES/ARES_step_triggers.dm
+++ b/code/game/machinery/ARES/ARES_step_triggers.dm
@@ -140,8 +140,9 @@
 				idcard = locate(/obj/item/card/id) in holder.contents
 				if(idcard)
 					break
-	if(!istype(idcard) && ismob(passer))
-		Trigger(passer, failure = TRUE)
+	if(!istype(idcard))
+		if(ismob(passer))
+			Trigger(passer, failure = TRUE)
 		return FALSE
 	if(!(ACCESS_MARINE_AI_TEMP in idcard.access))//No temp access, don't care
 		return FALSE


### PR DESCRIPTION
# About the pull request

Fixes https://runtimes.cm-ss13.com/cm13/issues/3240

Shrapnel can't have an idcard, so you need to return

:cl:
fix: Fixed runtimes regarding ares step alerts for non-mobs
/:cl: