### PR TITLE
Fix: SEAs with no prefs spawning as Civs

### DIFF
--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -542,7 +542,7 @@
 	if(rankee?.client?.prefs?.pref_special_job_options[job_title])
 		var/paygrade_choice = get_paygrade_id_by_name(rankee.client.prefs.pref_special_job_options[job_title], GLOB.uscm_sea_paygrades)
 		return paygrade_choice
-	..()
+	. = ..()
 
 //*****************************************************************************************************/
 


### PR DESCRIPTION

# About the pull request
Title. Resolves: #12576
Helps if we return the parent call as our return. Rather than just calling it to do nothing with it...
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
SEAs no longer beg for rank changes when they spawn as civilians
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: SEAs with no preference on their rank spawn as Gunnery Sergeants rather than Civs.
/:cl:
