### PR TITLE
fix IMS / Laser Scalpel  not skipping steps properly

### DIFF
--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -61,7 +61,7 @@
 			SPAN_NOTICE("[user] has constructed a prepared incision in your [surgery.affected_limb.display_name]."),
 			SPAN_NOTICE("[user] has constructed a prepared incision in [target]'s [surgery.affected_limb.display_name]."))
 
-		surgery.status += 2 //IMS completes all steps.
+		surgery.status += 6 //IMS completes all steps.
 
 		switch(target_zone) //forces application of overlays
 			if("chest")
@@ -75,7 +75,7 @@
 			SPAN_NOTICE("[user] finishes making a bloodless incision on your [surgery.affected_limb.display_name] with \the [tool]."),
 			SPAN_NOTICE("[user] finishes making a bloodless incision on [target]'s [surgery.affected_limb.display_name] with \the [tool]."))
 
-		surgery.status++ //A laser scalpel may cauterise as it cuts.
+		surgery.status += 3 //A laser scalpel may cauterise as it cuts.
 	else
 		user.affected_message(target,
 			SPAN_NOTICE("You finish the incision on [target]'s [surgery.affected_limb.display_name]."),
@@ -87,7 +87,7 @@
 			incision_bleed.duration = 10 MINUTES //A weak bleed, but it doesn't stop on its own.
 			surgery.affected_limb.bleeding_effects_list += incision_bleed
 		else
-			surgery.status++ // synth skin doesn't cause bleeders
+			surgery.status += 3 // synth skin doesn't cause bleeders
 
 	target.incision_depths[target_zone] = SURGERY_DEPTH_SHALLOW //Descriptionwise this is done by the retractor, but putting it here means people can examine to see if an unfinished surgery has been done.
 	user.add_blood(target.get_blood_color(), BLOOD_HANDS)


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Oversight introduced in #11078 - the additional abort steps added mean that IMS and Laser Scalpel also need to skip more steps

Fixes #12671

# Testing Photographs and Procedure
Local tested by making sure you can use IMS on Chest then Circular Saw, which was not possible before. If there are side effects, I'm clueless.

# Changelog
:cl:
fix: The IMS and Laser Scalpel will now once again skip their associated steps.
/:cl:
