### PR TITLE
Ground crash now causes xenomorph major

### DIFF
--- a/code/controllers/subsystem/hijack.dm
+++ b/code/controllers/subsystem/hijack.dm
@@ -802,7 +802,7 @@ SUBSYSTEM_DEF(hijack)
 	log_debug("crack_open_ship took [(world.timeofday - time) / 10]s")
 	explode_apcs(50)
 
-	if(!admin_sd_blocked)
+	if(!admin_sd_blocked && MODE_HAS_MODIFIER(/datum/gamemode_modifier/continue_on_ground_crash))
 		addtimer(CALLBACK(src, PROC_REF(unlock_self_destruct), FALSE), 15 SECONDS)
 
 /// Called to explode the apcs with probability (so more shipwide damage)

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -669,6 +669,10 @@
 	if(SShijack?.sd_detonated)
 		round_finished = MODE_INFESTATION_DRAW_DEATH // Self destruction.
 		return
+	if(SShijack?.hijack_status == HIJACK_OBJECTIVES_GROUND_CRASH && !MODE_HAS_MODIFIER(/datum/gamemode_modifier/continue_on_ground_crash))
+		if(SShijack.crashed)
+			round_finished = MODE_INFESTATION_X_MAJOR // Ship crashed into ground and modifier doesn't disable this
+		return
 
 	var/list/living_player_list = count_humans_and_xenos(get_affected_zlevels())
 	var/num_humans = living_player_list[1]

--- a/code/game/gamemodes/round_modifiers.dm
+++ b/code/game/gamemodes/round_modifiers.dm
@@ -120,6 +120,16 @@
 			continue
 		cur_area.is_resin_allowed = enabled ? TRUE : initial(cur_area.is_resin_allowed)
 
+/datum/gamemode_modifier/continue_on_ground_crash
+	modifier_name = "Continue on Hijack Ground Crash"
+	modifier_desc = "Enable this modifier to not trigger Xeno Major on ground crash"
+
+/datum/gamemode_modifier/continue_on_ground_crash/set_active(enabled)
+	if(SShijack?.hijack_status == HIJACK_OBJECTIVES_GROUND_CRASH)
+		to_chat(usr, SPAN_WARNING("Its too late to toggle this!"))
+		return ..(active)
+	return ..()
+
 /datum/gamemode_modifier/mortar_laser_warning
 	modifier_name = "Mortar Telegraphing"
 	modifier_desc = "Shows a visual warning of where a mortar will hit."

--- a/code/game/gamemodes/round_modifiers.dm
+++ b/code/game/gamemodes/round_modifiers.dm
@@ -122,7 +122,7 @@
 
 /datum/gamemode_modifier/continue_on_ground_crash
 	modifier_name = "Continue on Hijack Ground Crash"
-	modifier_desc = "Enable this modifier to not trigger Xeno Major on ground crash"
+	modifier_desc = "Enable this modifier to not trigger Xeno Major on ground crash."
 
 /datum/gamemode_modifier/continue_on_ground_crash/set_active(enabled)
 	if(SShijack?.hijack_status == HIJACK_OBJECTIVES_GROUND_CRASH)

--- a/code/modules/admin/gamemode_modifiers_panel.dm
+++ b/code/modules/admin/gamemode_modifiers_panel.dm
@@ -65,6 +65,8 @@
 	if(action != "set_modifier_state")
 		return FALSE
 
-	message_admins("[key_name_admin(user)] has [params["state"] ? "enabled" : "disabled" ] [params["name"]] modifier.")
+	var/old_value = MODE_HAS_MODIFIER(text2path(params["path"]))
 	MODE_SET_MODIFIER(text2path(params["path"]), params["state"])
+	if(old_value != MODE_HAS_MODIFIER(text2path(params["path"])))
+		message_admins("[key_name_admin(user)] has [params["state"] ? "enabled" : "disabled" ] [params["name"]] modifier.")
 	update_static_data(user, ui)


### PR DESCRIPTION
# About the pull request

This PR does a couple things:
- Ground crash now triggers xenomorph major once the crashing sequence is complete
- A game mode modifier can be enabled by admins to not trigger round end on ground crash
- Modifier panel no longer generates an admin message if no setting is changed (from the modifier refusing the change)

# Explain why it's good for the game

Ultimately this came about because https://github.com/cmss13-devs/cmss13/pull/12571 and I'm not really getting a decision from Forest where it would be undoing some of the APC shorting from https://github.com/cmss13-devs/cmss13/pull/12522 but generally feedback has been that ground crash harms xeno's advantage more than it helps even though they completed their hijack objectives early. So now it will just by default end the round as a xeno major for smashing the ship into the ground.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

New modifier: 
<img width="900" height="600" alt="image" src="https://github.com/user-attachments/assets/ebb8382f-d8b9-4098-98f0-2f2c04a41660" />

Modifier panel testing: 
<img width="1161" height="514" alt="image" src="https://github.com/user-attachments/assets/0f0ef0c7-44fa-4506-91e3-19b96c75c2d3" />

Test as default modifier setting (round ends once ground crash completed): 
<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/989d6979-c198-4bcf-91e5-5b283269db89" />

</details>


# Changelog
:cl: Drathek
balance: Hijack ground crash now causes xenomorph major once the ground crash sequence is complete
/:cl:
