### PR TITLE
Mid-deck CMO Office that overlooks Lower Medical (+morguecreep)

### DIFF
--- a/code/game/area/almayer.dm
+++ b/code/game/area/almayer.dm
@@ -709,6 +709,7 @@
 
 /area/almayer/medical/cmo_office
 	name = "\improper Chief Medical Officer's Office"
+	allow_construction = FALSE
 	icon_state = "medical"
 
 /area/almayer/medical/operating_room_one

--- a/code/game/area/almayer.dm
+++ b/code/game/area/almayer.dm
@@ -707,6 +707,10 @@
 	icon_state = "operating"
 	fake_zlevel = 1 // upperdeck
 
+/area/almayer/medical/cmo_office
+	name = "\improper Chief Medical Officer's Office"
+	icon_state = "medical"
+
 /area/almayer/medical/operating_room_one
 	name = "\improper Medical Operating Room 1"
 	icon_state = "operating"

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -5361,6 +5361,21 @@
 	},
 /turf/open/floor/grass,
 /area/almayer/medical/upper_medical)
+"anq" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	layer = 3.3
+	},
+/turf/open/floor/almayer/no_build/plate,
+/area/almayer/middeck/medical)
 "anr" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -178277,8 +178292,8 @@ bjq
 bjl
 boE
 aYN
-bxI
-aYN
+anq
+baC
 bhz
 crm
 crk

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -10522,7 +10522,7 @@
 	pixel_y = -1
 	},
 /turf/open/floor/almayer/sterile_green_side/west,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "aBe" = (
 /obj/structure/prop/invuln/lattice_prop{
 	icon_state = "lattice4";
@@ -14517,7 +14517,7 @@
 /area/almayer/maint/hull/lower/lower_astronav)
 "aLS" = (
 /turf/open/floor/almayer/flooredge/south,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "aLT" = (
 /turf/closed/wall/almayer,
 /area/almayer/squads/alpha)
@@ -18389,7 +18389,7 @@
 /obj/structure/closet/secure_closet/CMO,
 /obj/item/clothing/accessory/stethoscope,
 /turf/open/floor/almayer/flooredge/southwest,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "aVQ" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/sign/poster{
@@ -22016,7 +22016,7 @@
 "bec" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/almayer/outer/internal,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "bed" = (
 /obj/structure/stairs/perspective{
 	dir = 8;
@@ -29186,7 +29186,7 @@
 	pixel_y = -1
 	},
 /turf/open/floor/almayer/sterile_green_corner/north,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "btQ" = (
 /obj/structure/machinery/pipedispenser,
 /turf/open/floor/almayer/no_build/plate,
@@ -34521,7 +34521,7 @@
 	pixel_y = 1
 	},
 /turf/closed/wall/almayer/reinforced,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "bGk" = (
 /obj/structure/prop/invuln/lattice_prop{
 	icon_state = "lattice1";
@@ -34580,7 +34580,7 @@
 	icon_state = "ramptop"
 	},
 /turf/open_space,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "bGs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -34826,7 +34826,7 @@
 	pixel_y = -3
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "bGW" = (
 /obj/structure/machinery/light/small,
 /obj/structure/closet/secure_closet/guncabinet/red/mp_armory_mk2_rifle,
@@ -41500,15 +41500,15 @@
 	},
 /obj/structure/machinery/light/blue,
 /turf/open_space,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "bXK" = (
 /obj/structure/window/framed/almayer,
 /turf/open/floor/almayer/dark_sterile,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "bXL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/sterile_green_corner,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "bXM" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer/open{
 	dir = 4;
@@ -41516,7 +41516,7 @@
 	name = "\improper CMO Office Shutters"
 	},
 /turf/open/floor/almayer/test_floor4,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "bXN" = (
 /obj/structure/sign/safety/intercom{
 	pixel_y = -26;
@@ -41533,7 +41533,7 @@
 	pixel_y = 0
 	},
 /turf/open/floor/almayer/sterile_green_corner/east,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "bXO" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer/containment{
 	id = "W_Containment Cell 3";
@@ -42453,7 +42453,7 @@
 /area/almayer/medical/containment)
 "bZq" = (
 /turf/open/floor/almayer/dark_sterile,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "bZr" = (
 /turf/open/floor/almayer/plating_striped/north,
 /area/almayer/squads/req)
@@ -42465,7 +42465,7 @@
 	name = "\improper CMO Office Shutters"
 	},
 /turf/open_space,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "bZt" = (
 /turf/closed/wall/almayer/research/containment/wall/connect3,
 /area/almayer/medical/containment/cell)
@@ -44743,7 +44743,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer/sterile_green_side/west,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "cdX" = (
 /obj/structure/machinery/cm_vending/gear/engi,
 /turf/open/floor/almayer/plate,
@@ -45126,7 +45126,7 @@
 "ceR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/sterile_green_side/southeast,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "ceS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/flooredge/north,
@@ -51394,7 +51394,7 @@
 	pixel_x = -1
 	},
 /turf/open/floor/almayer/dark_sterile,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "cOK" = (
 /obj/structure/prop/invuln{
 	desc = "An inflated membrane. This one is puncture proof. Wow!";
@@ -52629,7 +52629,7 @@
 /area/almayer/command/lifeboat)
 "dqr" = (
 /turf/open/floor/almayer/sterile_green_side/northwest,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "dqw" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/shipboard/weapon_room/notunnel)
@@ -52775,7 +52775,7 @@
 	dir = 2
 	},
 /turf/open/floor/almayer/test_floor4,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "duo" = (
 /obj/structure/machinery/power/apc/almayer/west,
 /turf/open/floor/prison/kitchen,
@@ -53379,7 +53379,7 @@
 	name = "\improper CMO Office Shutters"
 	},
 /turf/open/floor/almayer/sterile_green_side/southeast,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "dEQ" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/food/condiment/hotsauce/tabasco,
@@ -53965,7 +53965,7 @@
 	pixel_x = 7
 	},
 /turf/open/floor/almayer/dark_sterile,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "dSI" = (
 /turf/open/floor/almayer/bluecorner/west,
 /area/almayer/hallways/upper/midship_hallway)
@@ -55891,7 +55891,7 @@
 	name = "\improper CMO Office Shutters"
 	},
 /turf/open/floor/almayer/test_floor4,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "eIf" = (
 /obj/structure/prop/invuln/pipe_water,
 /obj/structure/prop/invuln/overhead_pipe{
@@ -59042,7 +59042,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/sterile_green_side/north,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "gbQ" = (
 /obj/structure/machinery/light/red{
 	light_color = "#BB3F3F"
@@ -60053,7 +60053,7 @@
 "gzY" = (
 /obj/structure/machinery/light/blue,
 /turf/open/floor/almayer/sterile_green_side,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "gAj" = (
 /obj/structure/bed/chair/comfy/charlie{
 	dir = 1
@@ -60272,7 +60272,7 @@
 /area/almayer/hallways/upper/midship_hallway)
 "gFK" = (
 /turf/open/floor/almayer/flooredge/north,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "gFP" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/shipboard/stern_point_defense)
@@ -60531,7 +60531,7 @@
 	pixel_x = 7
 	},
 /turf/open/floor/almayer/sterile_green_side/north,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "gKB" = (
 /obj/structure/machinery/portable_atmospherics/hydroponics,
 /obj/structure/machinery/firealarm{
@@ -61777,7 +61777,7 @@
 	density = 0
 	},
 /turf/open/floor/almayer/flooredge/northwest,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "hmj" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out";
@@ -61908,7 +61908,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/dark_sterile,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "hpS" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer{
 	id = "crate_room3";
@@ -63797,7 +63797,7 @@
 /area/space)
 "ihH" = (
 /turf/open/floor/almayer/sterile_green_corner/east,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "ihI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -63885,7 +63885,7 @@
 /area/almayer/engineering/lower/workshop)
 "ijq" = (
 /turf/open/floor/almayer/sterile_green_side/southeast,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "ijr" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 4
@@ -67175,7 +67175,7 @@
 	pixel_y = -26
 	},
 /turf/open/floor/almayer/sterile_green_corner/west,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "jDO" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/airlock/almayer{
@@ -68249,7 +68249,7 @@
 	pixel_y = 0
 	},
 /turf/open/floor/almayer/flooredge/southeast,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "kbv" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/upper/starboard)
@@ -68692,7 +68692,7 @@
 "kmd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/sterile_green_corner/east,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "kmp" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -68778,7 +68778,7 @@
 /obj/item/book/manual/surgery,
 /obj/item/book/manual/medical_diagnostics_manual,
 /turf/open/floor/almayer/flooredge/north,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "kon" = (
 /obj/structure/pipes/vents/pump{
 	dir = 1
@@ -69208,7 +69208,7 @@
 	pixel_x = 6
 	},
 /turf/open/floor/almayer/sterile_green_corner,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "kwQ" = (
 /obj/item/tool/warning_cone{
 	pixel_y = 16
@@ -69608,7 +69608,7 @@
 /obj/structure/window/framed/almayer/white,
 /obj/structure/window/framed/almayer,
 /turf/open/floor/almayer/dark_sterile,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "kEs" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/flashlight/lamp{
@@ -69690,7 +69690,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/power/apc/almayer/east,
 /turf/open/floor/almayer/sterile_green_side/east,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "kGi" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
@@ -69960,7 +69960,7 @@
 /area/almayer/shipboard/brig/yard)
 "kMI" = (
 /turf/open/floor/almayer/sterile_green_corner/west,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "kMK" = (
 /obj/structure/prop/invuln{
 	desc = "An inflated membrane. This one is puncture proof. Wow!";
@@ -70812,7 +70812,7 @@
 "lgA" = (
 /obj/structure/stairs/multiz/up,
 /turf/open/space/basic,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "lgC" = (
 /obj/structure/platform/metal/almayer/west,
 /turf/open/floor/almayer/uscm/directional/northwest,
@@ -72474,7 +72474,7 @@
 "lUc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/sterile_green_corner/north,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "lUA" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/manifold/hidden/supply{
@@ -74353,7 +74353,7 @@
 	pixel_x = 9
 	},
 /turf/open_space,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "mMB" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -75979,7 +75979,7 @@
 	},
 /obj/item/device/megaphone,
 /turf/open/floor/almayer/sterile_green_side/west,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "nvM" = (
 /obj/structure/window/framed/almayer/white,
 /obj/structure/machinery/door/poddoor/shutters/almayer{
@@ -76352,7 +76352,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/almayer/sterile_green_side/southwest,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "nDo" = (
 /turf/closed/wall/almayer/white,
 /area/almayer/medical/hydroponics)
@@ -77830,7 +77830,7 @@
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/device/flash,
 /turf/open/floor/almayer/sterile_green_side/west,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "ojF" = (
 /obj/structure/machinery/cm_vending/clothing/tl/charlie{
 	density = 0;
@@ -78420,7 +78420,7 @@
 	pixel_x = 0
 	},
 /turf/open/floor/almayer/sterile_green_side/east,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "osQ" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -79833,7 +79833,7 @@
 	},
 /obj/structure/machinery/light/small,
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "oVo" = (
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/upper/u_a_s)
@@ -84816,7 +84816,7 @@
 	icon_state = "pottedplant_21"
 	},
 /turf/open/floor/almayer/sterile_green_corner/east,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "rdI" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/technology_scanner,
@@ -85123,6 +85123,9 @@
 /obj/structure/pipes/vents/scrubber,
 /turf/open/floor/almayer,
 /area/almayer/living/gym)
+"rkL" = (
+/turf/closed/wall/almayer/reinforced,
+/area/almayer/medical/cmo_office)
 "rkV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -90032,7 +90035,7 @@
 	pixel_y = 13
 	},
 /turf/open/floor/almayer/sterile_green_side/east,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "tpd" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 4
@@ -92037,7 +92040,7 @@
 	pixel_y = 29
 	},
 /turf/open/floor/almayer/flooredge/northeast,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "uiZ" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/comdoor/reinforced{
 	dir = 1;
@@ -92222,7 +92225,7 @@
 /area/almayer/maint/hull/lower/l_a_s)
 "uol" = (
 /turf/closed/wall/almayer/outer/internal,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "uoA" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 5
@@ -93059,7 +93062,7 @@
 	name = "\improper Bathroom"
 	},
 /turf/open/floor/almayer/test_floor4,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "uGQ" = (
 /obj/structure/machinery/suit_storage_unit/compression_suit/uscm,
 /turf/open/floor/almayer/plate,
@@ -94245,7 +94248,7 @@
 "vgx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/dark_sterile,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "vgB" = (
 /obj/structure/window/framed/almayer/white,
 /obj/structure/machinery/door/firedoor/border_only/almayer,
@@ -96584,7 +96587,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/sterile_green_side/east,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "wab" = (
 /obj/vehicle/powerloader{
 	dir = 4
@@ -96715,7 +96718,7 @@
 "wcl" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/sterile_green_side/west,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "wcm" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out";
@@ -99303,7 +99306,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/almayer/dark_sterile,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "xcV" = (
 /obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/almayer/cargo,
@@ -100454,7 +100457,7 @@
 	dir = 8
 	},
 /turf/open/floor/almayer/dark_sterile,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "xzB" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_f_s)
@@ -101111,7 +101114,7 @@
 	layer = 3.3
 	},
 /turf/closed/wall/almayer/reinforced,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "xNv" = (
 /obj/structure/platform/metal/almayer/north,
 /obj/structure/machinery/light{
@@ -101427,7 +101430,7 @@
 "xUE" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer/flooredge/south,
-/area/almayer/middeck/medical)
+/area/almayer/medical/cmo_office)
 "xUV" = (
 /turf/open/floor/almayer/silver,
 /area/almayer/command/combat_correspondent)
@@ -178334,7 +178337,7 @@ aOY
 aOY
 aOY
 aOY
-avN
+rkL
 bXK
 bXK
 uol
@@ -178643,7 +178646,7 @@ aOY
 aOY
 aOY
 aOY
-avN
+rkL
 bGr
 bXJ
 uol
@@ -178739,17 +178742,17 @@ bGl
 bnv
 blH
 cax
-avN
+rkL
 bZs
 bZs
 bZs
 bZs
 bZs
 dEM
-avN
+rkL
 mMg
 bGr
-avN
+rkL
 bwp
 blO
 blH
@@ -178837,22 +178840,22 @@ bGg
 baF
 aOh
 baC
-avN
-avN
+rkL
+rkL
 bGj
 xNu
-avN
-avN
+rkL
+rkL
 btP
 nvK
 cdW
 ojs
 aBd
 jDE
-avN
+rkL
 bXM
 eIc
-avN
+rkL
 bck
 blP
 blH
@@ -178940,12 +178943,12 @@ bGg
 bnY
 bnY
 bnY
-avN
-avN
-avN
+rkL
+rkL
+rkL
 hme
 aVP
-avN
+rkL
 gbP
 bZq
 xzy
@@ -178955,7 +178958,7 @@ nDj
 wcl
 dqr
 gzY
-avN
+rkL
 bWW
 blP
 blH
@@ -179043,9 +179046,9 @@ boD
 bbJ
 aOh
 baC
-avN
+rkL
 bGV
-avN
+rkL
 kol
 aLS
 dtQ
@@ -179058,7 +179061,7 @@ xcG
 vgx
 ceR
 ihH
-avN
+rkL
 avN
 avN
 aIA
@@ -179146,12 +179149,12 @@ boE
 aYN
 bxI
 aYN
-avN
+rkL
 cOC
 uGD
 gFK
 xUE
-avN
+rkL
 gKz
 bZq
 bZq
@@ -179160,8 +179163,8 @@ hpL
 bZq
 ijq
 bXN
-avN
-avN
+rkL
+rkL
 lwT
 bcP
 bcP
@@ -179249,22 +179252,22 @@ boE
 bjf
 bah
 baC
-avN
+rkL
 oVl
-avN
+rkL
 uiW
 kbn
-avN
+rkL
 kwv
 vZY
 tpa
 osM
-avN
+rkL
 kGa
 rdB
-avN
-avN
-avN
+rkL
+rkL
+rkL
 nGU
 nGU
 iqw

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -5354,17 +5354,6 @@
 	},
 /turf/open/floor/grass,
 /area/almayer/medical/upper_medical)
-"anq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/structure/barricade/handrail/no_vault{
-	dir = 1
-	},
-/turf/open/floor/almayer/no_build/plate,
-/area/space)
 "anr" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -8673,13 +8662,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/living/starboard_garden)
-"awj" = (
-/obj/structure/machinery/cm_vending/clothing/senior_officer{
-	pixel_y = 19;
-	density = 0
-	},
-/turf/open/floor/almayer/flooredge/south,
-/area/space)
 "awk" = (
 /turf/open/floor/almayer/silver,
 /area/almayer/command/cic)
@@ -8905,12 +8887,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/living/intel)
-"awQ" = (
-/obj/structure/bed/chair/office/light{
-	dir = 4
-	},
-/turf/open/floor/almayer/sterile_green_side,
-/area/space)
 "awR" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/flora/pottedplant{
@@ -16383,13 +16359,6 @@
 /obj/structure/machinery/door/airlock/almayer/maint,
 /turf/open/floor/almayer/no_build/test_floor4,
 /area/almayer/middeck/maintenance/sp)
-"aQZ" = (
-/obj/structure/flora/bush/ausbushes/var3/fullgrass{
-	desc = "Just like a real plant, but fake!";
-	name = "fake fullgrass"
-	},
-/turf/open/floor/grass,
-/area/space)
 "aRa" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -17946,16 +17915,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/middeck/maintenance/pb)
-"aUO" = (
-/obj/structure/pipes/vents/scrubber{
-	dir = 4
-	},
-/obj/structure/platform_decoration/metal/almayer/west,
-/obj/structure/sign/nosmoking_2{
-	pixel_x = 28
-	},
-/turf/open/floor/almayer/mono,
-/area/space)
 "aUP" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -23664,9 +23623,6 @@
 "bid" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/lower)
-"bie" = (
-/turf/open/floor/almayer/plating_stripedcorner/west,
-/area/space)
 "bif" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
@@ -24985,27 +24941,6 @@
 	},
 /turf/open/floor/almayer/plating_striped/north,
 /area/almayer/hallways/lower/repair_bay)
-"bkT" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 4;
-	id = "CMO Shutters";
-	name = "\improper CMO Office Shutters"
-	},
-/obj/structure/machinery/door/airlock/almayer/medical/glass{
-	access_modified = 1;
-	name = "\improper CMO's Office";
-	req_one_access = null;
-	req_one_access_txt = "1;5"
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/almayer/test_floor4,
-/area/space)
 "bkU" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S";
@@ -34799,13 +34734,6 @@
 	},
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/shipboard/navigation)
-"bGT" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/dark_sterile,
-/area/space)
 "bGU" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
@@ -44499,16 +44427,6 @@
 	},
 /turf/open/floor/almayer/sterile_green_corner,
 /area/almayer/medical/upper_medical)
-"cdw" = (
-/turf/open/floor/almayer/dark_sterile,
-/area/space)
-"cdx" = (
-/obj/structure/closet/secure_closet/guncabinet/red/armory_shotgun,
-/obj/structure/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/almayer/redfull,
-/area/space)
 "cdy" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -44706,10 +44624,6 @@
 	},
 /turf/open/floor/almayer/sterile_green,
 /area/almayer/medical/upper_medical)
-"cdS" = (
-/obj/structure/platform/metal/almayer_smooth,
-/turf/open_space,
-/area/space)
 "cdT" = (
 /obj/structure/machinery/cm_vending/clothing/smartgun/charlie,
 /turf/open/floor/almayer/plate,
@@ -44764,13 +44678,6 @@
 /obj/structure/machinery/fuelpump,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south2)
-"ceb" = (
-/obj/structure/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/almayer/sterile_green_corner/west,
-/area/space)
 "cec" = (
 /obj/structure/machinery/vending/cola/research{
 	pixel_x = -2;
@@ -44876,17 +44783,6 @@
 /obj/structure/platform_decoration/metal/almayer/west,
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
-"cem" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer{
-	id = "Research Armory";
-	name = "\improper Armory Shutters";
-	dir = 4
-	},
-/turf/open/floor/almayer/test_floor4,
-/area/space)
-"cen" = (
-/turf/open/floor/almayer/sterile_green_corner,
-/area/space)
 "ceo" = (
 /obj/structure/surface/rack,
 /obj/item/clothing/suit/storage/marine/light/vest{
@@ -45027,16 +44923,6 @@
 "ceE" = (
 /turf/closed/wall/almayer,
 /area/almayer/command/cichallway)
-"ceF" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 4;
-	id = "CMO Shutters";
-	name = "\improper CMO Office Shutters"
-	},
-/obj/structure/window/framed/almayer/white,
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/turf/open/floor/plating,
-/area/space)
 "ceG" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -45131,26 +45017,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/flooredge/north,
 /area/almayer/medical/morgue)
-"ceT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/heavy_cable/cable_vertical,
-/turf/open/floor/plating/plating_catwalk/no_build,
-/area/space)
-"ceU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "S";
-	layer = 3.3
-	},
-/obj/structure/barricade/handrail/no_vault{
-	dir = 1
-	},
-/turf/open/floor/almayer/no_build/plate,
-/area/space)
 "ceV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45248,10 +45114,6 @@
 	},
 /turf/open/floor/almayer/green/east,
 /area/almayer/hallways/upper/fore_hallway)
-"cfh" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/sterile_green_corner/north,
-/area/space)
 "cfi" = (
 /obj/structure/largecrate/random{
 	pixel_y = 8
@@ -46293,20 +46155,6 @@
 /obj/structure/flora/bush/ausbushes/var3/sunnybush,
 /turf/open/floor/grass,
 /area/almayer/medical/upper_medical)
-"chy" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_29";
-	pixel_y = 3;
-	pixel_x = -4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/almayer/flooredge/southeast,
-/area/space)
 "chz" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -50446,12 +50294,6 @@
 	},
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/underdeck/hangar)
-"csb" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/obj/structure/platform_decoration/metal/almayer/east,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/mono,
-/area/space)
 "csd" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating/plating_catwalk,
@@ -51860,12 +51702,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/command/lifeboat)
-"cYE" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 5
-	},
-/turf/open/floor/almayer/dark_sterile,
-/area/space)
 "cYN" = (
 /obj/structure/stairs/multiz/up{
 	dir = 8
@@ -52167,13 +52003,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/almayer,
 /area/almayer/engineering/lower/workshop/hangar)
-"ddN" = (
-/obj/structure/flora/bush/ausbushes/ausbush{
-	name = "fake ausbush";
-	desc = "Just like a real plant, but fake!"
-	},
-/turf/open/floor/grass,
-/area/space)
 "ddO" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -52515,10 +52344,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/port_emb)
-"dnb" = (
-/obj/effect/decal/heavy_cable/node_s_w,
-/turf/open/floor/plating/plating_catwalk/no_build,
-/area/space)
 "dnh" = (
 /obj/structure/surface/rack,
 /obj/item/book/manual/orbital_cannon_manual,
@@ -52697,12 +52522,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/command/corporateliaison)
-"drT" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/open/floor/almayer/sterile_green_side/northwest,
-/area/space)
 "drU" = (
 /obj/structure/machinery/door_control{
 	id = "ARES JoeCryo";
@@ -52741,18 +52560,6 @@
 	},
 /turf/open/floor/almayer/cargo,
 /area/almayer/maint/upper/u_a_s)
-"dtB" = (
-/obj/structure/reagent_dispensers/water_cooler/stacks{
-	pixel_y = 6;
-	pixel_x = -8;
-	density = 0
-	},
-/obj/structure/machinery/light/double/blue{
-	light_color = "#a7dbc7"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/sterile_green_corner/west,
-/area/space)
 "dtE" = (
 /obj/structure/stairs/perspective{
 	dir = 4;
@@ -52914,17 +52721,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/orange/northeast,
 /area/almayer/engineering/lower/workshop/hangar)
-"dya" = (
-/obj/structure/flora/bush/ausbushes/var3/brflowers{
-	name = "fake brflowers";
-	desc = "Just like a real plant, but fake!"
-	},
-/obj/structure/machinery/light/double/blue{
-	light_color = "#a7dbc7";
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/space)
 "dyb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53100,35 +52896,12 @@
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/floor/almayer/plating_striped/east,
 /area/almayer/stair_clone/lower/port_aft)
-"dBh" = (
-/obj/structure/sign/calendar/ua{
-	pixel_y = 27;
-	layer = 2.9
-	},
-/obj/structure/machinery/faxmachine/uscm/almayer{
-	pixel_x = -3;
-	pixel_y = 5;
-	sub_name = "Chief Medical Officer"
-	},
-/obj/structure/surface/table/reinforced/prison,
-/turf/open/floor/almayer/sterile_green_corner,
-/area/space)
 "dBi" = (
 /obj/structure/platform/metal/almayer/north,
 /obj/structure/platform/metal/almayer/east,
 /obj/structure/platform_decoration/metal/almayer/northwest,
 /turf/open/floor/almayer/red/northeast,
 /area/almayer/lifeboat_pumps/north2)
-"dBj" = (
-/obj/structure/machinery/door_control{
-	dir = 1;
-	id = "Research Armory";
-	name = "Emergency Research Armory Release";
-	pixel_x = -31;
-	pixel_y = 26
-	},
-/turf/open/floor/almayer/plating_stripedcorner/north,
-/area/space)
 "dBs" = (
 /obj/structure/machinery/cm_vending/clothing/dress,
 /turf/open/floor/almayer/cargo,
@@ -53292,13 +53065,6 @@
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/stern)
-"dDY" = (
-/obj/structure/machinery/light/double/blue{
-	light_color = "#a7dbc7";
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/space)
 "dEk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
@@ -53633,22 +53399,6 @@
 	},
 /turf/open/floor/almayer/plating,
 /area/almayer/living/basketball)
-"dJX" = (
-/obj/item/device/flashlight/lamp{
-	pixel_y = 14;
-	layer = 2.96
-	},
-/obj/item/prop/tableflag/uscm{
-	pixel_x = -8;
-	pixel_y = 1
-	},
-/obj/item/prop/tableflag{
-	pixel_x = -8;
-	pixel_y = -10
-	},
-/obj/structure/surface/table/reinforced/prison,
-/turf/open/floor/almayer/dark_sterile,
-/area/space)
 "dKp" = (
 /turf/open/floor/almayer/research/containment/corner_var1/east,
 /area/almayer/medical/containment/cell/cl)
@@ -53810,13 +53560,6 @@
 	},
 /turf/open/floor/almayer/no_build,
 /area/almayer/underdeck/vehicle)
-"dOU" = (
-/obj/structure/flora/bush/ausbushes/var3/ppflowers{
-	name = "fake ppflowers";
-	desc = "Just like a real plant, but fake!"
-	},
-/turf/open/floor/grass,
-/area/space)
 "dPd" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/flashlight/lamp{
@@ -53872,22 +53615,6 @@
 /obj/item/paper_bin/uscm,
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/lower/workshop)
-"dQk" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/filingcabinet/filingcabinet{
-	density = 0;
-	pixel_x = 7;
-	pixel_y = 16
-	},
-/obj/structure/filingcabinet/filingcabinet{
-	density = 0;
-	pixel_x = -8;
-	pixel_y = 16
-	},
-/turf/open/floor/almayer/sterile_green_corner,
-/area/space)
 "dQA" = (
 /obj/structure/pipes/standard/simple/visible{
 	dir = 4
@@ -54510,26 +54237,6 @@
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/upper/midship_hallway)
-"efX" = (
-/obj/structure/surface/rack,
-/obj/item/clothing/suit/storage/marine/light/vest{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/clothing/suit/storage/marine/light/vest{
-	pixel_x = -4;
-	pixel_y = -5
-	},
-/obj/item/clothing/suit/storage/marine/light/vest{
-	pixel_y = 2;
-	pixel_x = 5
-	},
-/obj/item/clothing/suit/storage/marine/light/vest{
-	pixel_y = -5;
-	pixel_x = 5
-	},
-/turf/open/floor/almayer/redfull,
-/area/space)
 "egt" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1
@@ -55861,13 +55568,6 @@
 	},
 /turf/open/floor/almayer/plating_striped/east,
 /area/almayer/maint/hull/lower/l_a_p)
-"eHU" = (
-/obj/structure/platform/metal/almayer/east,
-/obj/structure/bed/chair/comfy{
-	dir = 8
-	},
-/turf/open/floor/almayer/mono,
-/area/space)
 "eHX" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	req_one_access = null;
@@ -57207,17 +56907,6 @@
 	},
 /turf/open/floor/almayer/blue/west,
 /area/almayer/hallways/upper/midship_hallway)
-"fjL" = (
-/obj/structure/platform/metal/almayer/north,
-/obj/structure/platform/metal/almayer/east,
-/obj/structure/platform_decoration/metal/almayer/northwest{
-	layer = 4.1
-	},
-/obj/structure/bed/chair/comfy{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/space)
 "fki" = (
 /obj/structure/cargo_container/horizontal/blue/bottom,
 /turf/open/floor/almayer/no_build,
@@ -57604,30 +57293,6 @@
 /obj/structure/target,
 /turf/open/floor/almayer/plating_striped/west,
 /area/almayer/living/cryo_cells)
-"fuc" = (
-/obj/item/paper_bin/wy{
-	pixel_y = 8;
-	pixel_x = -6
-	},
-/obj/item/tool/pen{
-	pixel_y = 3;
-	pixel_x = -6
-	},
-/obj/item/tool/stamp/cmo{
-	pixel_x = 9;
-	pixel_y = 10;
-	name = "Chief Medical Officer's rubber stamp"
-	},
-/obj/structure/machinery/door_control{
-	id = "CMO Shutters";
-	name = "\improper Office Privacy Shutters";
-	pixel_y = -1;
-	req_one_access_txt = "28";
-	pixel_x = 9
-	},
-/obj/structure/surface/table/reinforced/prison,
-/turf/open/floor/almayer/sterile_green_side/north,
-/area/space)
 "fuz" = (
 /obj/structure/machinery/cm_vending/clothing/pilot_officer,
 /turf/open/floor/almayer/plate,
@@ -57848,10 +57513,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_f_s)
-"fzO" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer/dark_sterile,
-/area/space)
 "fzP" = (
 /obj/structure/surface/table/almayer,
 /obj/item/paper_bin/uscm,
@@ -58571,13 +58232,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/hangar)
-"fPw" = (
-/obj/structure/machinery/light/double/blue{
-	light_color = "#a7dbc7"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/sterile_green_corner/east,
-/area/space)
 "fPB" = (
 /obj/structure/machinery/ares/processor/apollo,
 /turf/open/floor/almayer/no_build/test_floor4,
@@ -58783,18 +58437,6 @@
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/chemistry)
-"fVJ" = (
-/obj/structure/platform/metal/almayer/north,
-/obj/structure/platform/metal/almayer/west,
-/obj/structure/platform_decoration/metal/almayer/northeast{
-	layer = 4.1
-	},
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_22";
-	pixel_y = 6
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/space)
 "fVS" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -62238,10 +61880,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/alpha_bravo_shared)
-"hxg" = (
-/obj/structure/machinery/computer/med_data,
-/turf/open/floor/almayer/sterile_green_corner/north,
-/area/space)
 "hxm" = (
 /obj/item/paper_bin/uscm{
 	pixel_y = 4
@@ -62717,19 +62355,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_f_s)
-"hLl" = (
-/obj/structure/platform/metal/almayer/north,
-/obj/structure/platform/metal/almayer/west,
-/obj/structure/platform/metal/almayer/east,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/platform_decoration/metal/almayer/northeast{
-	layer = 4.1
-	},
-/obj/structure/platform_decoration/metal/almayer/northwest{
-	layer = 4.1
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/space)
 "hLr" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/manifold/hidden/supply{
@@ -63413,9 +63038,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/underdeck/vehicle)
-"hYA" = (
-/turf/open/floor/almayer/sterile_green,
-/area/space)
 "hYE" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/flora/pottedplant{
@@ -63791,10 +63413,6 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/maint/lower/constr)
-"ihu" = (
-/obj/structure/pipes/vents/pump,
-/turf/open/floor/almayer/dark_sterile2,
-/area/space)
 "ihH" = (
 /turf/open/floor/almayer/sterile_green_corner/east,
 /area/almayer/medical/cmo_office)
@@ -63839,12 +63457,6 @@
 /obj/structure/machinery/door/airlock/almayer/marine/bravo/spec,
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/squads/bravo)
-"iit" = (
-/obj/structure/machinery/status_display{
-	pixel_x = -32
-	},
-/turf/open/floor/grass,
-/area/space)
 "iiU" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -63963,10 +63575,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
-"imk" = (
-/obj/structure/window/framed/almayer/hull,
-/turf/closed/wall/almayer/white,
-/area/almayer/middeck/maintenance/sf)
 "imt" = (
 /obj/structure/reagent_dispensers/water_cooler/stacks{
 	density = 0;
@@ -64784,12 +64392,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/lower/starboard_fore_hallway)
-"iGA" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/almayer/dark_sterile,
-/area/space)
 "iHc" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/upper_engineering/notunnel)
@@ -65015,16 +64617,6 @@
 /obj/structure/machinery/cryopod/right,
 /turf/open/floor/almayer/cargo,
 /area/almayer/squads/bravo)
-"iMv" = (
-/obj/structure/machinery/status_display{
-	pixel_x = 32
-	},
-/obj/structure/flora/bush/ausbushes/var3/fullgrass{
-	desc = "Just like a real plant, but fake!";
-	name = "fake fullgrass"
-	},
-/turf/open/floor/grass,
-/area/space)
 "iMD" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -65713,9 +65305,6 @@
 "iYe" = (
 /turf/open/floor/almayer/plating,
 /area/almayer/living/basketball)
-"iYf" = (
-/turf/closed/wall/almayer/white/reinforced,
-/area/space)
 "iYm" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/almayer/plate,
@@ -65973,10 +65562,6 @@
 "jei" = (
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/u_a_p)
-"jeq" = (
-/obj/structure/platform/metal/almayer_smooth/north,
-/turf/open_space,
-/area/space)
 "jer" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -66282,9 +65867,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk/no_build,
 /area/almayer/underdeck/hangar)
-"jjs" = (
-/turf/open/floor/almayer/flooredge/southwest,
-/area/space)
 "jjz" = (
 /obj/structure/cargo_container/uscm/chinook/left,
 /obj/structure/prop/invuln/lattice_prop{
@@ -67218,9 +66800,6 @@
 /obj/structure/platform/metal/almayer_smooth,
 /turf/open/floor/almayer/red/southwest,
 /area/almayer/shipboard/brig)
-"jFo" = (
-/turf/open/floor/almayer/no_build/plate,
-/area/space)
 "jFt" = (
 /obj/structure/platform/metal/almayer_smooth/north,
 /obj/structure/platform/metal/almayer_smooth/west,
@@ -68919,13 +68498,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/living/gym)
-"kqM" = (
-/obj/structure/flora/bush/ausbushes/grassybush{
-	name = "fake grassybush";
-	desc = "Just like a real plant, but fake!"
-	},
-/turf/open/floor/grass,
-/area/space)
 "kqN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -69656,19 +69228,6 @@
 "kFv" = (
 /turf/open/floor/almayer/sterile_green_side/northeast,
 /area/almayer/medical/lower_medical_medbay)
-"kFH" = (
-/obj/structure/platform/metal/almayer/north,
-/obj/structure/platform/metal/almayer/east,
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_22";
-	pixel_y = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/platform_decoration/metal/almayer/northwest{
-	layer = 4.1
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/space)
 "kFO" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer{
 	dir = 4;
@@ -70349,20 +69908,6 @@
 	},
 /turf/open/floor/almayer/mono,
 /area/almayer/lifeboat_pumps/south2)
-"kVj" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "S";
-	layer = 3.3
-	},
-/obj/structure/barricade/handrail/no_vault{
-	dir = 1
-	},
-/turf/open/floor/almayer/no_build/plate,
-/area/space)
 "kVV" = (
 /obj/structure/bed/chair/comfy/black,
 /turf/open/floor/wood/ship,
@@ -71847,25 +71392,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/orangecorner/north,
 /area/almayer/engineering/upper_engineering)
-"lEu" = (
-/obj/structure/sink{
-	pixel_y = 1;
-	dir = 4;
-	pixel_x = 14
-	},
-/obj/structure/mirror{
-	pixel_x = 30
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	layer = 3.33;
-	pixel_y = 2
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
-	},
-/turf/open/floor/almayer/dark_sterile,
-/area/space)
 "lEv" = (
 /obj/structure/bookcase{
 	opacity = 0
@@ -71998,12 +71524,6 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/living/grunt_rnr)
-"lHI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/heavy_cable/cable_vertical,
-/obj/structure/largecrate/random/barrel/medical,
-/turf/open/floor/plating/plating_catwalk/no_build,
-/area/space)
 "lIj" = (
 /turf/closed/wall/almayer,
 /area/almayer/maint/upper/mess)
@@ -72293,10 +71813,6 @@
 /obj/structure/platform_decoration/metal/almayer/north,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/u_a_p)
-"lPh" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/mono,
-/area/space)
 "lPm" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/wood/ship,
@@ -72747,13 +72263,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/living/gym)
-"mcW" = (
-/obj/structure/closet/secure_closet/guncabinet/red/armory_m39_submachinegun,
-/obj/structure/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/almayer/redfull,
-/area/space)
 "mdk" = (
 /obj/structure/machinery/door/poddoor/railing{
 	dir = 4;
@@ -73191,16 +72700,6 @@
 "mlm" = (
 /turf/open/floor/almayer/redfull,
 /area/almayer/living/cryo_cells)
-"mlq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/heavy_cable/cable_vertical,
-/obj/structure/largecrate/random/barrel/medical,
-/obj/structure/machinery/light/red{
-	light_color = "#BB3F3F";
-	dir = 1
-	},
-/turf/open/floor/plating/plating_catwalk/no_build,
-/area/space)
 "mlF" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -74377,16 +73876,6 @@
 	},
 /turf/open/floor/almayer/silver,
 /area/almayer/shipboard/brig/cic_hallway)
-"mNa" = (
-/obj/structure/machinery/status_display{
-	pixel_y = 32
-	},
-/obj/structure/flora/bush/ausbushes/var3/ppflowers{
-	name = "fake ppflowers";
-	desc = "Just like a real plant, but fake!"
-	},
-/turf/open/floor/grass,
-/area/space)
 "mNG" = (
 /obj/structure/sign/safety/stairs{
 	pixel_x = 15;
@@ -74943,15 +74432,6 @@
 	},
 /turf/open/floor/almayer/plating_striped/south,
 /area/almayer/engineering/lower/engine_core)
-"naf" = (
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/structure/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/space)
 "nah" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -75027,12 +74507,6 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/living/gym)
-"nbj" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/open/floor/almayer/sterile_green_side/northeast,
-/area/space)
 "nbu" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
@@ -75902,11 +75376,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north2)
-"nuv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/heavy_cable/node_n_w,
-/turf/open/floor/plating/plating_catwalk/no_build,
-/area/space)
 "nux" = (
 /obj/structure/surface/table/gamblingtable,
 /obj/item/toy/deck,
@@ -78534,16 +78003,6 @@
 "ovi" = (
 /turf/open/floor/almayer/orangecorner/east,
 /area/almayer/engineering/upper_engineering/port)
-"ovm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 9
-	},
-/turf/open/floor/almayer/dark_sterile,
-/area/space)
 "ovp" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/flora/pottedplant{
@@ -78792,18 +78251,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/u_a_p)
-"oAY" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
-/obj/item/device/radio/intercom{
-	freerange = 1;
-	name = "General Listening Channel";
-	pixel_y = -28;
-	pixel_x = 1
-	},
-/turf/open/floor/almayer/sterile_green_side,
-/area/space)
 "oBq" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal7";
@@ -79488,10 +78935,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/command/lifeboat)
-"oOU" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/mono,
-/area/space)
 "oOW" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/junction{
@@ -79659,10 +79102,6 @@
 /obj/item/clipboard,
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/lower/workshop)
-"oSg" = (
-/obj/structure/pipes/standard/manifold/hidden/supply,
-/turf/open/floor/almayer/flooredge/northeast,
-/area/space)
 "oSq" = (
 /obj/item/device/radio/intercom{
 	freerange = 1;
@@ -79733,19 +79172,6 @@
 /obj/structure/platform/metal/almayer/west,
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/underdeck/req)
-"oTc" = (
-/obj/structure/machinery/shower{
-	pixel_y = 16
-	},
-/obj/item/tool/soap{
-	pixel_x = 3;
-	pixel_y = 1
-	},
-/obj/structure/machinery/door/window/westright{
-	dir = 2
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/space)
 "oTe" = (
 /obj/item/prop/almayer/box,
 /obj/item/prop{
@@ -80103,12 +79529,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer/plate,
 /area/almayer/living/captain_mess)
-"pbr" = (
-/obj/structure/pipes/vents/pump{
-	dir = 4
-	},
-/turf/open/floor/almayer/mono,
-/area/space)
 "pbs" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4;
@@ -80486,20 +79906,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/upper/fore_hallway)
-"plL" = (
-/obj/structure/bookcase{
-	icon_state = "book-5";
-	pixel_x = -1;
-	pixel_y = 19;
-	density = 0;
-	opacity = 0
-	},
-/obj/structure/sign/safety/bathunisex{
-	pixel_x = 32;
-	pixel_y = -5
-	},
-/turf/open/floor/almayer/flooredge/south,
-/area/space)
 "pmd" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer/plate,
@@ -81327,18 +80733,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
-"pIX" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/machinery/door/airlock/almayer/white{
-	name = "\improper CMO's Bedroom";
-	req_one_access = list(28,206,207);
-	req_one_access_txt = "1;5"
-	},
-/turf/open/floor/almayer/test_floor4,
-/area/space)
 "pIZ" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -82295,13 +81689,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/upper/midship_hallway)
-"qdM" = (
-/obj/structure/pipes/vents/pump{
-	dir = 4
-	},
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/mono,
-/area/space)
 "qdQ" = (
 /obj/structure/bed/sofa/vert/grey/top,
 /turf/open/floor/almayer,
@@ -82340,18 +81727,6 @@
 /obj/structure/pipes/vents/scrubber/no_boom,
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/upper_engineering/port)
-"qeU" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S";
-	layer = 3.3
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/structure/barricade/handrail/no_vault,
-/turf/open/floor/almayer/no_build/plate,
-/area/space)
 "qeY" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/toy/beach_ball/holoball,
@@ -82621,21 +81996,6 @@
 /obj/effect/landmark/late_join/charlie,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/charlie)
-"qkB" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 1
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/obj/structure/machinery/door/airlock/almayer/medical/glass{
-	dir = 2;
-	name = "\improper Psychiatric Care Unit";
-	req_one_access = null;
-	req_access = null
-	},
-/turf/open/floor/almayer/test_floor4,
-/area/space)
 "qkP" = (
 /obj/item/frame/light_fixture{
 	anchored = 1;
@@ -85059,21 +84419,6 @@
 	},
 /turf/open/floor/almayer/plating_striped/north,
 /area/almayer/shipboard/stern_point_defense)
-"rjj" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "S";
-	layer = 3.3
-	},
-/obj/structure/largecrate/random/barrel/medical,
-/obj/structure/barricade/handrail/no_vault{
-	dir = 1
-	},
-/turf/open/floor/almayer/no_build/plate,
-/area/space)
 "rjn" = (
 /obj/structure/machinery/light,
 /obj/structure/reagent_dispensers/water_cooler/stacks,
@@ -85627,13 +84972,6 @@
 /obj/structure/reagent_dispensers/tank/water,
 /turf/open/floor/almayer/cargo,
 /area/almayer/hallways/hangar)
-"ruC" = (
-/obj/structure/flora/bush/ausbushes/lavendergrass{
-	name = "fake lavendergrass";
-	desc = "Just like a real plant, but fake!"
-	},
-/turf/open/floor/grass,
-/area/space)
 "ruL" = (
 /obj/structure/window/framed/almayer/hull/hijack_bustable,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -86459,10 +85797,6 @@
 /obj/structure/largecrate/random/barrel/true_random,
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/underdeck/hangar)
-"rNZ" = (
-/obj/structure/pipes/vents/scrubber,
-/turf/open/floor/almayer/dark_sterile2,
-/area/space)
 "rOc" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -86783,11 +86117,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cic_hallway)
-"rTo" = (
-/obj/structure/closet/secure_closet/CMO,
-/obj/item/clothing/accessory/stethoscope,
-/turf/open/floor/almayer/flooredge/south,
-/area/space)
 "rTJ" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
 /turf/open/floor/almayer/plate,
@@ -87223,9 +86552,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/vehiclehangar)
-"sdn" = (
-/turf/closed/wall/almayer/white,
-/area/space)
 "sdu" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -87748,13 +87074,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plate,
 /area/almayer/command/cic)
-"sos" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/dark_sterile,
-/area/space)
 "sov" = (
 /turf/open/floor/almayer/orange/north,
 /area/almayer/engineering/lower/engine_core)
@@ -88592,9 +87911,6 @@
 /obj/structure/mirror,
 /turf/closed/wall/almayer,
 /area/almayer/living/gym)
-"sGW" = (
-/turf/open/floor/grass,
-/area/space)
 "sGZ" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer/silverfull,
@@ -89088,13 +88404,6 @@
 	},
 /turf/open/floor/almayer/plating,
 /area/almayer/shipboard/brig/yard)
-"sVj" = (
-/obj/structure/platform/metal/almayer/west,
-/obj/structure/bed/chair/comfy{
-	dir = 4
-	},
-/turf/open/floor/almayer/mono,
-/area/space)
 "sVv" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/red/north,
@@ -91379,10 +90688,6 @@
 	},
 /turf/open/floor/almayer/silver,
 /area/almayer/hallways/lower/repair_bay)
-"tWY" = (
-/obj/effect/decal/heavy_cable/cable_vertical,
-/turf/open/floor/plating/plating_catwalk/no_build,
-/area/space)
 "tXa" = (
 /obj/structure/largecrate/supply/weapons/m39{
 	pixel_x = 2
@@ -92131,14 +91436,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/cargo_arrow,
 /area/almayer/living/offices)
-"umh" = (
-/obj/structure/machinery/photocopier{
-	layer = 2.9;
-	pixel_y = 16;
-	density = 0
-	},
-/turf/open/floor/almayer/sterile_green_side/north,
-/area/space)
 "umk" = (
 /obj/structure/machinery/light/red{
 	light_color = "#BB3F3F";
@@ -94003,29 +93300,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/hangar)
-"vbk" = (
-/obj/structure/sign/safety/terminal{
-	pixel_x = 7;
-	pixel_y = -26
-	},
-/obj/structure/transmitter/rotary{
-	name = "CMO Office Telephone";
-	phone_category = "Offices";
-	phone_id = "CMO Office";
-	pixel_y = 20;
-	pixel_x = 6
-	},
-/obj/item/ashtray/plastic{
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/obj/structure/sign/safety/intercom{
-	pixel_y = -26;
-	pixel_x = 21
-	},
-/obj/structure/surface/table/reinforced/prison,
-/turf/open/floor/almayer/sterile_green_side,
-/area/space)
 "vbB" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/south1)
@@ -94796,20 +94070,6 @@
 /obj/structure/machinery/power/apc/almayer/west,
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/engineering/laundry)
-"vqM" = (
-/obj/structure/surface/table/reinforced/almayer_B,
-/obj/item/device/flashlight/lamp{
-	pixel_y = 11;
-	pixel_x = 5
-	},
-/obj/item/device/megaphone,
-/obj/item/device/flash,
-/obj/item/clothing/glasses/science{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/almayer/flooredge/north,
-/area/space)
 "vqY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
@@ -95395,26 +94655,6 @@
 	},
 /turf/open/floor/almayer/green,
 /area/almayer/squads/req)
-"vCk" = (
-/obj/structure/surface/rack,
-/obj/item/clothing/suit/storage/marine/light/vest{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/clothing/suit/storage/marine/light/vest{
-	pixel_y = 2;
-	pixel_x = 5
-	},
-/obj/item/clothing/suit/storage/marine/light/vest{
-	pixel_y = -5;
-	pixel_x = 5
-	},
-/obj/item/clothing/suit/storage/marine/light/vest{
-	pixel_x = -4;
-	pixel_y = -5
-	},
-/turf/open/floor/almayer/redfull,
-/area/space)
 "vCt" = (
 /obj/structure/sign/safety/storage{
 	pixel_x = 7;
@@ -95462,11 +94702,6 @@
 /obj/effect/landmark/start/bridge,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/bridgebunks)
-"vDa" = (
-/obj/structure/bed,
-/obj/item/bedsheet/green,
-/turf/open/floor/almayer/flooredge/northwest,
-/area/space)
 "vDd" = (
 /obj/structure/window/framed/almayer/hull/hijack_bustable,
 /obj/structure/machinery/door/poddoor/shutters/almayer/open{
@@ -95862,19 +95097,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/lower/repair_bay)
-"vLs" = (
-/obj/structure/machinery/computer/cameras/containment{
-	name = "Research Cameras";
-	pixel_y = 1;
-	pixel_x = 2
-	},
-/obj/structure/machinery/computer/research/main_terminal{
-	pixel_y = 1;
-	pixel_x = -15
-	},
-/obj/structure/surface/table/reinforced/prison,
-/turf/open/floor/almayer/dark_sterile,
-/area/space)
 "vLA" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W";
@@ -96548,16 +95770,6 @@
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/port_missiles)
-"vZE" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "SW-out"
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/machinery/door/airlock/almayer/white{
-	name = "\improper Bathroom"
-	},
-/turf/open/floor/almayer/test_floor4,
-/area/space)
 "vZI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -96872,28 +96084,10 @@
 	},
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/underdeck/hangar)
-"weH" = (
-/obj/structure/coatrack{
-	pixel_x = -8;
-	pixel_y = 15
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/sign/catclock{
-	pixel_y = 28;
-	pixel_x = 7
-	},
-/turf/open/floor/almayer/sterile_green_corner/north,
-/area/space)
 "weR" = (
 /obj/structure/machinery/cryopod,
 /turf/open/floor/almayer/cargo,
 /area/almayer/living/offices/cryo)
-"weW" = (
-/obj/structure/machinery/light,
-/turf/open/floor/almayer/sterile_green_side,
-/area/space)
 "weX" = (
 /obj/structure/surface/rack{
 	layer = 3;
@@ -96949,12 +96143,6 @@
 	},
 /turf/open/floor/almayer/silver/east,
 /area/almayer/command/cichallway)
-"wgy" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "SW-out"
-	},
-/turf/closed/wall/almayer/white,
-/area/space)
 "wgO" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -97727,10 +96915,6 @@
 	},
 /turf/open/floor/almayer/silvercorner/east,
 /area/almayer/shipboard/brig/visitation_waiting)
-"wvO" = (
-/obj/structure/pipes/vents/scrubber,
-/turf/open/floor/almayer/mono,
-/area/space)
 "wvU" = (
 /obj/structure/surface/rack,
 /obj/item/reagent_container/spray/cleaner{
@@ -98553,10 +97737,6 @@
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/living/auxiliary_officer_office)
-"wMx" = (
-/obj/structure/machinery/computer/crew,
-/turf/open/floor/almayer/sterile_green_corner/east,
-/area/space)
 "wMB" = (
 /obj/structure/barricade/handrail{
 	dir = 1;
@@ -99318,12 +98498,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/port_midship_hallway)
-"xdy" = (
-/obj/structure/closet/secure_closet/professor_dummy{
-	pixel_y = 32
-	},
-/turf/open/floor/almayer/sterile_green_side/north,
-/area/space)
 "xdA" = (
 /obj/structure/surface/rack{
 	density = 0;
@@ -99359,9 +98533,6 @@
 	},
 /turf/open/floor/almayer/emeraldfull,
 /area/almayer/living/briefing)
-"xdS" = (
-/turf/open_space,
-/area/space)
 "xee" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4;
@@ -99420,12 +98591,6 @@
 /obj/structure/platform/metal/almayer/east,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/u_a_p)
-"xfd" = (
-/obj/structure/closet/secure_closet/personal/cabinet{
-	req_access_txt = "5"
-	},
-/turf/open/floor/almayer/flooredge/north,
-/area/space)
 "xfm" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -99449,14 +98614,6 @@
 /obj/structure/platform_decoration/metal/almayer/southeast,
 /turf/open/floor/almayer/red/southeast,
 /area/almayer/lifeboat_pumps/south1)
-"xfJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/heavy_cable/cable_vertical,
-/obj/structure/machinery/light/red{
-	light_color = "#BB3F3F"
-	},
-/turf/open/floor/plating/plating_catwalk/no_build,
-/area/space)
 "xfK" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -99983,21 +99140,6 @@
 	},
 /turf/open/floor/almayer/red/east,
 /area/almayer/shipboard/brig/visitation)
-"xrw" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "S";
-	layer = 3.3
-	},
-/obj/structure/barricade/handrail/no_vault{
-	dir = 1
-	},
-/obj/structure/largecrate/random/barrel/medical,
-/turf/open/floor/almayer/no_build/plate,
-/area/space)
 "xry" = (
 /obj/structure/window/reinforced/toughened{
 	dir = 4;
@@ -100096,21 +99238,6 @@
 /obj/structure/machinery/light,
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/port_aft_hallway)
-"xuo" = (
-/obj/item/toy/plush/therapy/random_color{
-	pixel_y = 2;
-	pixel_x = 2
-	},
-/obj/structure/platform/metal/almayer/north,
-/obj/structure/platform/metal/almayer/west,
-/obj/structure/platform_decoration/metal/almayer/northeast{
-	layer = 4.1
-	},
-/obj/structure/bed/chair/comfy{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/space)
 "xuy" = (
 /obj/structure/machinery/status_display{
 	pixel_x = 32
@@ -102068,19 +101195,6 @@
 /obj/item/tool/mop,
 /turf/open/floor/almayer/plate,
 /area/almayer/command/cic)
-"yjb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes{
-	icon_state = "S";
-	layer = 3.3
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/structure/barricade/handrail/no_vault,
-/turf/open/floor/almayer/no_build/plate,
-/area/space)
 "yjq" = (
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	icon_state = "almayer_pdoor";
@@ -174688,16 +173802,16 @@ aaa
 aaa
 aaa
 aaa
-tWY
-yjb
-jeq
-xdS
-xdS
-xdS
-cdS
-xrw
-tWY
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 bdH
@@ -174791,15 +173905,15 @@ aaa
 aaa
 aaa
 aaa
-tWY
-yjb
-jeq
-xdS
-xdS
-xdS
-cdS
-rjj
-ceT
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 aaa
 aaa
@@ -174894,15 +174008,15 @@ aaa
 aaa
 aaa
 aaa
-tWY
-yjb
-jeq
-xdS
-xdS
-xdS
-cdS
-kVj
-ceT
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 aaa
 aaa
@@ -174997,16 +174111,16 @@ aaa
 aaa
 aaa
 aaa
-tWY
-qeU
-jeq
-xdS
-xdS
-xdS
-cdS
-kVj
-ceT
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 bdH
@@ -175100,16 +174214,16 @@ aaa
 aaa
 aaa
 aaa
-tWY
-qeU
-jeq
-xdS
-xdS
-xdS
-cdS
-kVj
-ceT
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 bdH
@@ -175203,16 +174317,16 @@ aaa
 aaa
 aaa
 aaa
-mlq
-qeU
-jeq
-xdS
-xdS
-xdS
-cdS
-ceU
-xfJ
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 bdH
@@ -175306,15 +174420,15 @@ aaa
 aaa
 aaa
 aaa
-lHI
-yjb
-jeq
-xdS
-xdS
-xdS
-cdS
-ceU
-ceT
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 aaa
 bdH
@@ -175409,15 +174523,15 @@ aaa
 aaa
 aaa
 aaa
-lHI
-yjb
-jeq
-xdS
-xdS
-xdS
-cdS
-ceU
-tWY
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 aaa
 bdH
@@ -175512,15 +174626,15 @@ aaa
 aaa
 aaa
 aaa
-ceT
-yjb
-jeq
-xdS
-xdS
-xdS
-cdS
-ceU
-tWY
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 aaa
 bdH
@@ -175615,15 +174729,15 @@ aaa
 aaa
 aaa
 aaa
-ceT
-yjb
-jeq
-xdS
-xdS
-xdS
-cdS
-anq
-jFo
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 bdH
 bdH
@@ -175718,15 +174832,15 @@ aaa
 aaa
 aaa
 aaa
-nuv
-yjb
-jeq
-xdS
-xdS
-xdS
-cdS
-ceU
-dnb
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 bdH
 bdH
@@ -178511,7 +177625,7 @@ bGi
 bGi
 aWj
 bnV
-imk
+aWi
 bzC
 bzi
 aJM
@@ -180024,12 +179138,12 @@ bwH
 bdH
 bdH
 bdH
-sdn
-sdn
-ceF
-bkT
-ceF
-iYf
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 aab
 aaa
@@ -180127,12 +179241,12 @@ bwH
 bdH
 bdH
 bdH
-sdn
-sdn
-weH
-ovm
-ceb
-iYf
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 aab
 aaa
@@ -180230,12 +179344,12 @@ bwH
 bdH
 bdH
 bdH
-sdn
-hxg
-drT
-ihu
-weW
-iYf
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 aab
 aaa
@@ -180333,12 +179447,12 @@ bdH
 bdH
 bdH
 bdH
-sdn
-xdy
-iGA
-cdw
-awQ
-iYf
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 aab
 aaa
@@ -180436,12 +179550,12 @@ bdH
 bdH
 bdH
 bdH
-sdn
-umh
-iGA
-dJX
-vbk
-iYf
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 aab
 aaa
@@ -180539,12 +179653,12 @@ bdH
 bdH
 bdH
 bdH
-sdn
-fuc
-iGA
-vLs
-oAY
-iYf
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 aab
 aaa
@@ -180642,12 +179756,12 @@ bdH
 bdH
 bdH
 bdH
-sdn
-dBh
-nbj
-rNZ
-weW
-iYf
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 aab
 aaa
@@ -180745,12 +179859,12 @@ bdH
 bdH
 bdH
 bdH
-sdn
-sdn
-dQk
-cYE
-wMx
-iYf
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 aab
 aaa
@@ -180848,12 +179962,12 @@ bdH
 bdH
 bdH
 bdH
-sdn
-sdn
-sdn
-pIX
-sdn
-iYf
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 aab
 aaa
@@ -180951,12 +180065,12 @@ bdH
 bdH
 bdH
 bdH
-sdn
-rTo
-chy
-oSg
-xfd
-iYf
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 aab
 aaa
@@ -181054,12 +180168,12 @@ bdH
 bdH
 bdH
 bdH
-sdn
-awj
-wvO
-pbr
-vqM
-iYf
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 aab
 aaa
@@ -181157,12 +180271,12 @@ bwH
 bdH
 bdH
 bdH
-sdn
-plL
-jjs
-vDa
-sdn
-iYf
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 aab
 aaa
@@ -181260,12 +180374,12 @@ bwH
 bwH
 aaa
 aaa
-sdn
-sdn
-vZE
-sdn
-iYf
-iYf
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aab
 aaa
@@ -181363,11 +180477,11 @@ aIi
 bwH
 aaa
 aaa
-sdn
-oTc
-lEu
-naf
-iYf
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 aaa
 aab
@@ -181466,11 +180580,11 @@ aJZ
 bwH
 aaa
 aaa
-sdn
-sdn
-sdn
-iYf
-iYf
+bdH
+bdH
+bdH
+bdH
+bdH
 bdH
 aaa
 aab
@@ -202705,21 +201819,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 bdH
 bdH
 bdH
 bdH
 bdH
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aad
 adG
@@ -202811,18 +201925,18 @@ aaa
 bdH
 bdH
 bdH
-sdn
-sdn
-sdn
-sdn
-sdn
 bdH
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aad
 adG
@@ -202912,20 +202026,20 @@ aaa
 aaa
 aaa
 bdH
-sdn
-sdn
-sdn
-aQZ
-iit
-dOU
-sdn
-sdn
-sdn
 bdH
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aad
 aeE
@@ -203015,20 +202129,20 @@ aaa
 aaa
 aaa
 bdH
-sdn
-sdn
-dDY
-kqM
-xuo
-sVj
-qdM
-sdn
-sdn
 bdH
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aad
 aeE
@@ -203118,20 +202232,20 @@ aaa
 aaa
 aaa
 bdH
-sdn
-ddN
-dOU
-fVJ
-lPh
-cfh
-iGA
-dtB
-sdn
 bdH
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aad
 aeE
@@ -203221,20 +202335,20 @@ aaa
 aaa
 aaa
 bdH
-sdn
-mNa
-hLl
-csb
-hYA
-cdw
-sos
-fzO
-qkB
 bdH
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aad
 adG
@@ -203324,20 +202438,20 @@ aaa
 aaa
 aaa
 bdH
-sdn
-aQZ
-ruC
-kFH
-oOU
-cen
-bGT
-fPw
-sdn
 bdH
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aad
 adG
@@ -203427,20 +202541,20 @@ aaa
 aaa
 aaa
 bdH
-sdn
-sdn
-dya
-sGW
-fjL
-eHU
-aUO
-sdn
-sdn
 bdH
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aad
 adG
@@ -203531,19 +202645,19 @@ aaa
 aaa
 bdH
 bdH
-sdn
-sdn
-ruC
-iMv
-ddN
-sdn
-sdn
 bdH
 bdH
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aad
 adG
@@ -203634,19 +202748,19 @@ aaa
 aaa
 bdH
 bdH
-sdn
-iYf
-iYf
-iYf
-iYf
-wgy
 bdH
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aad
 adG
@@ -203737,19 +202851,19 @@ aaa
 aaa
 bdH
 bdH
-iYf
-iYf
-efX
-vCk
-iYf
-iYf
 bdH
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aad
 aag
@@ -203840,19 +202954,19 @@ aaa
 bdH
 bdH
 bdH
-iYf
-mcW
-dBj
-bie
-cdx
-iYf
 bdH
 bdH
 bdH
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aad
 ciS
@@ -203943,19 +203057,19 @@ aaa
 bdH
 bdH
 bdH
-iYf
-iYf
-cem
-cem
-iYf
-iYf
 bdH
 bdH
 bdH
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aad
 aag
@@ -204058,7 +203172,7 @@ bdH
 bdH
 bdH
 bdH
-aaa
+bdH
 aaa
 aad
 aag
@@ -204161,7 +203275,7 @@ bdH
 bdH
 bdH
 bdH
-aaa
+bdH
 aaa
 aad
 aag

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -5361,21 +5361,6 @@
 	},
 /turf/open/floor/grass,
 /area/almayer/medical/upper_medical)
-"anq" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "NE-out";
-	pixel_y = 1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "NW-out";
-	pixel_y = 1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "S";
-	layer = 3.3
-	},
-/turf/open/floor/almayer/no_build/plate,
-/area/almayer/middeck/medical)
 "anr" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -50640,6 +50625,21 @@
 "cro" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NE-out";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	layer = 3.3
+	},
+/turf/open/floor/almayer/no_build/plate,
+/area/almayer/middeck/medical)
+"crp" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
 	pixel_y = 1;
 	pixel_x = 1
 	},
@@ -50655,33 +50655,33 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/upper_medical)
-"crp" = (
+"crq" = (
 /obj/structure/stairs/multiz/down,
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/upper_medical)
-"crq" = (
+"crr" = (
 /obj/structure/foamed_metal/iron,
 /turf/open/floor/plating,
 /area/almayer/medical/upper_medical)
-"crr" = (
+"crs" = (
 /turf/open_space,
 /area/almayer/medical/upper_medical)
-"crs" = (
+"crt" = (
 /obj/structure/stairs/multiz/down{
 	dir = 4
 	},
 /turf/closed/wall/almayer/white,
 /area/almayer/medical/upper_medical)
-"crt" = (
+"cru" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/flooredge/west,
 /area/almayer/medical/morgue)
-"cru" = (
+"crv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/light/small/blue,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/morgue)
-"crv" = (
+"crw" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "test_square_smooth"
 	},
@@ -50690,7 +50690,7 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/medical/morgue)
-"crw" = (
+"crx" = (
 /obj/structure/morgue{
 	dir = 2
 	},
@@ -50702,7 +50702,7 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/medical/morgue)
-"crx" = (
+"cry" = (
 /obj/structure/morgue{
 	dir = 2
 	},
@@ -50714,14 +50714,14 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/medical/morgue)
-"cry" = (
+"crz" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "test_square_smooth"
 	},
 /obj/structure/morgue,
 /turf/open/floor/almayer/plate,
 /area/almayer/medical/morgue)
-"crz" = (
+"crA" = (
 /obj/structure/flora/bush/ausbushes/var3/fullgrass{
 	desc = "Just like a real plant, but fake!";
 	name = "fake fullgrass"
@@ -50732,7 +50732,7 @@
 	},
 /turf/open/floor/grass,
 /area/almayer/medical/upper_medical)
-"crA" = (
+"crB" = (
 /obj/structure/platform/metal/almayer/north{
 	dir = 2
 	},
@@ -50748,7 +50748,7 @@
 	},
 /turf/open/floor/almayer/mono,
 /area/almayer/medical/upper_medical)
-"crB" = (
+"crC" = (
 /obj/structure/platform/metal/almayer/north{
 	dir = 2
 	},
@@ -50763,14 +50763,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/upper_medical)
-"crC" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/dark_sterile,
-/area/almayer/medical/upper_medical)
 "crD" = (
 /turf/open/floor/almayer/greencorner/north,
 /area/almayer/squads/req)
 "crE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/medical/upper_medical)
+"crF" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/safety/hazard{
@@ -50783,38 +50783,38 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/east,
 /area/almayer/medical/upper_medical)
-"crF" = (
+"crG" = (
 /obj/structure/closet/secure_closet/guncabinet/red/armory_m39_submachinegun,
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/almayer/redfull,
 /area/almayer/medical/upper_medical)
-"crG" = (
+"crH" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/sterile_green_corner/north,
 /area/almayer/medical/upper_medical)
-"crH" = (
+"crI" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	name = "ship-grade camera"
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/upper_medical)
-"crI" = (
+"crJ" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Psychiatric Care Unit";
 	req_access = list()
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/upper_medical)
-"crJ" = (
+"crK" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/upper_medical)
-"crK" = (
+"crL" = (
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/upper_medical)
-"crL" = (
+"crM" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/flooredge/south,
 /area/almayer/hallways/upper/midship_hallway)
@@ -178292,7 +178292,7 @@ bjq
 bjl
 boE
 aYN
-anq
+cro
 baC
 bhz
 crm
@@ -207764,7 +207764,7 @@ ceQ
 ajn
 ajp
 ajn
-crt
+cru
 ajg
 ccX
 akA
@@ -207863,11 +207863,11 @@ chH
 chj
 aEN
 ajt
-crv
+crw
 ajr
-crv
+crw
 arb
-cru
+crv
 aoe
 aoe
 ajl
@@ -208071,13 +208071,13 @@ cgR
 ajt
 cfS
 aoe
-crw
+crx
 arb
 arb
 aEN
 cfy
 aoe
-crq
+crr
 ajl
 onQ
 cct
@@ -208174,13 +208174,13 @@ wUd
 ajy
 cfU
 aoe
-crx
+cry
 aEO
 cfG
 ceA
 cfS
 aoe
-crq
+crr
 ajl
 fOL
 aRS
@@ -208283,7 +208283,7 @@ ceS
 aEO
 cfy
 aoe
-crq
+crr
 ajl
 tEi
 vtx
@@ -208380,7 +208380,7 @@ cgS
 cgD
 cfS
 aoe
-crw
+crx
 arb
 arb
 aoe
@@ -208487,10 +208487,10 @@ skl
 aEO
 ceS
 aCo
-crr
-crr
-crr
-crp
+crs
+crs
+crs
+crq
 ccH
 alD
 ccj
@@ -208584,16 +208584,16 @@ aoe
 aoe
 jTj
 cgG
-cry
+crz
 isN
-cry
+crz
 arb
-cru
+crv
 aoe
-crr
-crr
-crr
-crp
+crs
+crs
+crs
+crq
 rrD
 vQN
 ccl
@@ -208693,11 +208693,11 @@ cfW
 ePX
 jZY
 aoe
-crr
-crr
+crs
+crs
 ajl
 ajl
-cro
+crp
 vQN
 ccm
 gWG
@@ -208796,8 +208796,8 @@ chr
 ceS
 ceA
 aoe
-crr
-crr
+crs
+crs
 ajl
 fEC
 uRt
@@ -209002,8 +209002,8 @@ aoe
 aoe
 aoe
 aoe
-crs
-crs
+crt
+crt
 ajl
 ccW
 uRt
@@ -209197,7 +209197,7 @@ ciE
 ciA
 ciw
 ccn
-crE
+crF
 chV
 cht
 cgW
@@ -209403,7 +209403,7 @@ rSW
 dNv
 rSW
 sqf
-crF
+crG
 aSn
 lYL
 pNP
@@ -209816,7 +209816,7 @@ lGh
 qmW
 ajl
 xyt
-crB
+crC
 tpa
 cek
 vOy
@@ -209917,10 +209917,10 @@ abE
 tkF
 qdJ
 bMW
-crI
+crJ
 akw
 bIM
-crA
+crB
 mzq
 sqf
 vOy
@@ -210019,9 +210019,9 @@ afs
 agA
 lXl
 iCT
-crL
-crJ
-crG
+crM
+crK
+crH
 wiW
 chu
 lFn
@@ -210124,10 +210124,10 @@ lXl
 yiu
 cih
 ajl
-crH
-crC
+crI
+crE
 ydE
-crz
+crA
 sqf
 cgb
 vdO
@@ -210226,7 +210226,7 @@ agA
 lXl
 yiu
 bMW
-crI
+crJ
 aAr
 pGK
 chw
@@ -210329,8 +210329,8 @@ abE
 tkF
 yiu
 bMW
-crK
-crC
+crL
+crE
 gLc
 wub
 mzq

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -53227,6 +53227,22 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/auxiliary_officer_office)
+"dGR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	layer = 3.3
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/structure/machinery/light/red{
+	light_color = "#BB3F3F";
+	dir = 4
+	},
+/turf/open/floor/almayer/no_build/plate,
+/area/almayer/middeck/medical)
 "dGT" = (
 /obj/structure/machinery/door/airlock/almayer/security/glass{
 	name = "\improper Cryogenics Bay"
@@ -177140,7 +177156,7 @@ bWm
 bmU
 cbk
 cbk
-bmU
+dGR
 cbk
 bWm
 bmV
@@ -178469,22 +178485,22 @@ aJM
 aWK
 cbq
 aWK
-aRQ
-aRQ
-aRQ
-aRQ
-aRQ
-aRQ
-aRQ
-aRQ
-aRQ
-aRQ
-aRQ
-aRQ
-aRQ
-aRQ
-aRQ
-aRQ
+rkL
+rkL
+rkL
+rkL
+rkL
+rkL
+rkL
+rkL
+rkL
+rkL
+rkL
+rkL
+rkL
+rkL
+rkL
+rkL
 aRQ
 aRQ
 aRQ

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -5355,12 +5355,16 @@
 /turf/open/floor/grass,
 /area/almayer/medical/upper_medical)
 "anq" = (
-/obj/structure/pipes/vents/pump{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
 	},
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/mono,
-/area/almayer/medical/upper_medical)
+/obj/structure/barricade/handrail/no_vault{
+	dir = 1
+	},
+/turf/open/floor/almayer/no_build/plate,
+/area/space)
 "anr" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -5413,8 +5417,17 @@
 /turf/open/floor/plating/plating_catwalk/no_build,
 /area/almayer/middeck/maintenance/sp)
 "anz" = (
-/obj/structure/machinery/computer/med_data,
-/turf/open/floor/almayer/sterile_green_corner/north,
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/safety/hazard{
+	pixel_x = 32;
+	pixel_y = 7
+	},
+/obj/structure/sign/safety/ammunition{
+	pixel_y = -7;
+	pixel_x = 32
+	},
+/turf/open/floor/almayer/sterile_green_side/east,
 /area/almayer/medical/upper_medical)
 "anA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8661,12 +8674,12 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/living/starboard_garden)
 "awj" = (
-/obj/structure/platform/metal/almayer/east,
-/obj/structure/bed/chair/comfy{
-	dir = 8
+/obj/structure/machinery/cm_vending/clothing/senior_officer{
+	pixel_y = 19;
+	density = 0
 	},
-/turf/open/floor/almayer/mono,
-/area/almayer/medical/upper_medical)
+/turf/open/floor/almayer/flooredge/south,
+/area/space)
 "awk" = (
 /turf/open/floor/almayer/silver,
 /area/almayer/command/cic)
@@ -8893,11 +8906,11 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/living/intel)
 "awQ" = (
-/obj/structure/closet/secure_closet/professor_dummy{
-	pixel_y = 32
+/obj/structure/bed/chair/office/light{
+	dir = 4
 	},
-/turf/open/floor/almayer/sterile_green_side/north,
-/area/almayer/medical/upper_medical)
+/turf/open/floor/almayer/sterile_green_side,
+/area/space)
 "awR" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/flora/pottedplant{
@@ -9090,10 +9103,19 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/medical/morgue)
 "axm" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/platform/metal/almayer/north{
+	dir = 2
+	},
+/obj/structure/platform/metal/almayer/west,
+/obj/structure/platform_decoration/metal/almayer/northwest{
+	layer = 4.1;
+	dir = 10
+	},
+/obj/structure/bed/chair/comfy{
 	dir = 4
 	},
-/turf/open/floor/almayer/dark_sterile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/upper_medical)
 "axn" = (
 /obj/effect/decal/warning_stripes{
@@ -10219,9 +10241,8 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/command/cicconference)
 "aAr" = (
-/obj/structure/closet/secure_closet/CMO,
-/obj/item/clothing/accessory/stethoscope,
-/turf/open/floor/almayer/flooredge/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_corner,
 /area/almayer/medical/upper_medical)
 "aAs" = (
 /turf/closed/wall/almayer/reinforced,
@@ -10480,12 +10501,28 @@
 /turf/open_space,
 /area/almayer/middeck/hanger)
 "aBd" = (
-/obj/structure/closet/emcloset,
-/obj/structure/machinery/alarm/almayer{
-	dir = 1
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/ashtray/plastic{
+	pixel_x = -6;
+	pixel_y = -2
 	},
-/turf/open/floor/almayer/cargo,
-/area/almayer/medical/upper_medical)
+/obj/structure/transmitter/rotary{
+	name = "CMO Office Telephone";
+	phone_category = "Offices";
+	phone_id = "CMO Office";
+	pixel_y = 9;
+	pixel_x = -6
+	},
+/obj/item/clipboard{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/folder/black{
+	pixel_x = 7;
+	pixel_y = -1
+	},
+/turf/open/floor/almayer/sterile_green_side/west,
+/area/almayer/middeck/medical)
 "aBe" = (
 /obj/structure/prop/invuln/lattice_prop{
 	icon_state = "lattice4";
@@ -11017,8 +11054,11 @@
 /turf/open/floor/almayer/orange/southeast,
 /area/almayer/engineering/upper_engineering)
 "aCo" = (
-/turf/open/floor/almayer/sterile_green_corner,
-/area/almayer/medical/upper_medical)
+/obj/effect/decal/warning_stripes{
+	icon_state = "test_square_smooth"
+	},
+/turf/closed/wall/almayer/white,
+/area/almayer/medical/morgue)
 "aCp" = (
 /turf/open/floor/almayer/flooredgesmooth2/west,
 /area/almayer/command/cichallway)
@@ -11957,8 +11997,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/morgue)
 "aEO" = (
-/turf/open/floor/almayer/sterile_green,
-/area/almayer/medical/upper_medical)
+/obj/effect/decal/warning_stripes{
+	icon_state = "test_square_smooth"
+	},
+/obj/structure/morgue,
+/turf/open/floor/almayer/plate,
+/area/almayer/medical/morgue)
 "aEP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/prop/invuln/overhead_pipe{
@@ -12721,7 +12765,16 @@
 /turf/open/floor/wood/ship,
 /area/almayer/living/numbertwobunks)
 "aGW" = (
-/turf/closed/wall/almayer/white/reinforced,
+/obj/structure/morgue{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "test_square_smooth"
+	},
+/obj/structure/machinery/light/small/blue{
+	dir = 1
+	},
+/turf/open/floor/almayer/plate,
 /area/almayer/medical/morgue)
 "aGX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13274,11 +13327,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/medical_science)
 "aID" = (
-/obj/structure/machinery/cm_vending/clothing/senior_officer{
-	pixel_y = 19;
-	density = 0
-	},
-/turf/open/floor/almayer/flooredge/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/upper_medical)
 "aIE" = (
 /obj/effect/decal/warning_stripes{
@@ -14466,11 +14516,8 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/lower_astronav)
 "aLS" = (
-/obj/structure/machinery/status_display{
-	pixel_x = -32
-	},
-/turf/open/floor/grass,
-/area/almayer/medical/upper_medical)
+/turf/open/floor/almayer/flooredge/south,
+/area/almayer/middeck/medical)
 "aLT" = (
 /turf/closed/wall/almayer,
 /area/almayer/squads/alpha)
@@ -14528,22 +14575,19 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/weapon_room)
 "aMd" = (
-/obj/structure/bookcase{
-	icon_state = "book-5";
-	pixel_x = -1;
-	pixel_y = 19;
-	density = 0;
-	opacity = 0
+/obj/structure/platform/metal/almayer/east,
+/obj/structure/bed/chair/comfy{
+	dir = 8
 	},
-/obj/item/book/manual/medical_diagnostics_manual,
-/obj/item/book/manual/surgery,
-/obj/item/book/manual/research_and_development,
-/obj/item/book/manual/ripley_build_and_repair,
-/obj/structure/sign/safety/bathunisex{
-	pixel_x = 32;
-	pixel_y = -5
+/obj/item/toy/plush/therapy/random_color{
+	pixel_y = 2;
+	pixel_x = 2
 	},
-/turf/open/floor/almayer/flooredge/south,
+/obj/structure/machinery/light/double/blue{
+	light_color = "#a7dbc7";
+	dir = 1
+	},
+/turf/open/floor/almayer/mono,
 /area/almayer/medical/upper_medical)
 "aMe" = (
 /obj/structure/machinery/door/airlock/almayer/maint/reinforced{
@@ -16132,6 +16176,10 @@
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/machinery/firealarm{
+	pixel_y = 26;
+	pixel_x = -1
+	},
 /turf/open/floor/almayer/flooredgesmooth2/south,
 /area/almayer/medical/upper_medical)
 "aQA" = (
@@ -16336,18 +16384,12 @@
 /turf/open/floor/almayer/no_build/test_floor4,
 /area/almayer/middeck/maintenance/sp)
 "aQZ" = (
-/obj/structure/machinery/shower{
-	pixel_y = 16
+/obj/structure/flora/bush/ausbushes/var3/fullgrass{
+	desc = "Just like a real plant, but fake!";
+	name = "fake fullgrass"
 	},
-/obj/item/tool/soap{
-	pixel_x = 3;
-	pixel_y = 1
-	},
-/obj/structure/machinery/door/window/westright{
-	dir = 2
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/medical/upper_medical)
+/turf/open/floor/grass,
+/area/space)
 "aRa" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -16846,28 +16888,25 @@
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/middeck/engineer)
 "aSn" = (
-/obj/structure/coatrack{
-	pixel_x = -8;
-	pixel_y = 15
+/obj/structure/machinery/door_control{
+	dir = 1;
+	id = "Research Armory";
+	name = "Emergency Research Armory Release";
+	pixel_x = 30;
+	pixel_y = 26
 	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/sign/catclock{
-	pixel_y = 28;
-	pixel_x = 7
-	},
-/turf/open/floor/almayer/sterile_green_corner/north,
+/turf/open/floor/almayer/plating_stripedcorner/south,
 /area/almayer/medical/upper_medical)
 "aSo" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "SW-out"
+/obj/structure/flora/bush/ausbushes/var3/fullgrass{
+	desc = "Just like a real plant, but fake!";
+	name = "fake fullgrass"
 	},
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/machinery/door/airlock/almayer/white{
-	name = "\improper Bathroom"
+/obj/structure/machinery/status_display{
+	pixel_y = 0;
+	pixel_x = 32
 	},
-/turf/open/floor/almayer/test_floor4,
+/turf/open/floor/grass,
 /area/almayer/medical/upper_medical)
 "aSp" = (
 /obj/structure/surface/table/almayer,
@@ -17908,14 +17947,15 @@
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/middeck/maintenance/pb)
 "aUO" = (
-/obj/structure/largecrate/random/barrel/true_random,
-/obj/structure/machinery/light/red{
-	dir = 8;
-	light_color = "#BB3F3F"
+/obj/structure/pipes/vents/scrubber{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/no_build/plate,
-/area/almayer/middeck/medical)
+/obj/structure/platform_decoration/metal/almayer/west,
+/obj/structure/sign/nosmoking_2{
+	pixel_x = 28
+	},
+/turf/open/floor/almayer/mono,
+/area/space)
 "aUP" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -18346,17 +18386,9 @@
 /turf/open/floor/almayer/plating,
 /area/almayer/middeck/maintenance/pb)
 "aVP" = (
-/obj/structure/machinery/light/red{
-	dir = 4;
-	light_color = "#BB3F3F"
-	},
-/obj/structure/filingcabinet{
-	pixel_x = -8
-	},
-/obj/structure/filingcabinet{
-	pixel_x = 8
-	},
-/turf/open/floor/almayer/no_build/plate,
+/obj/structure/closet/secure_closet/CMO,
+/obj/item/clothing/accessory/stethoscope,
+/turf/open/floor/almayer/flooredge/southwest,
 /area/almayer/middeck/medical)
 "aVQ" = (
 /obj/structure/surface/table/almayer,
@@ -21983,13 +22015,7 @@
 /area/almayer/shipboard/navigation)
 "bec" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/surface/rack,
-/obj/item/clothing/head/hardhat,
-/obj/item/clothing/head/hardhat,
-/obj/item/clothing/head/hardhat,
-/obj/item/clothing/head/hardhat,
-/obj/item/clothing/head/hardhat,
-/turf/open/floor/almayer/no_build/plate,
+/turf/closed/wall/almayer/outer/internal,
 /area/almayer/middeck/medical)
 "bed" = (
 /obj/structure/stairs/perspective{
@@ -23639,12 +23665,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/lower)
 "bie" = (
-/obj/structure/surface/table/almayer,
-/obj/structure/machinery/iv_drip{
-	pixel_y = 11
-	},
-/turf/open/floor/almayer/no_build/plate,
-/area/almayer/middeck/medical)
+/turf/open/floor/almayer/plating_stripedcorner/west,
+/area/space)
 "bif" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
@@ -24964,24 +24986,26 @@
 /turf/open/floor/almayer/plating_striped/north,
 /area/almayer/hallways/lower/repair_bay)
 "bkT" = (
-/obj/structure/sink{
-	pixel_y = 1;
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
 	dir = 4;
-	pixel_x = 14
+	id = "CMO Shutters";
+	name = "\improper CMO Office Shutters"
 	},
-/obj/structure/mirror{
-	pixel_x = 30
+/obj/structure/machinery/door/airlock/almayer/medical/glass{
+	access_modified = 1;
+	name = "\improper CMO's Office";
+	req_one_access = null;
+	req_one_access_txt = "1;5"
 	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	layer = 3.33;
-	pixel_y = 2
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "S"
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/almayer/dark_sterile,
-/area/almayer/medical/upper_medical)
+/turf/open/floor/almayer/test_floor4,
+/area/space)
 "bkU" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S";
@@ -29144,10 +29168,24 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/hangar)
 "btP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/heavy_cable/cable_vertical,
-/obj/structure/largecrate/random/barrel/medical,
-/turf/open/floor/plating/plating_catwalk/no_build,
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/sign/calendar/ua{
+	pixel_y = 27;
+	layer = 2.9
+	},
+/obj/item/prop/tableflag/uscm{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/obj/item/prop/tableflag{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/prop/tableflag/uscm2{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/turf/open/floor/almayer/sterile_green_corner/north,
 /area/almayer/middeck/medical)
 "btQ" = (
 /obj/structure/machinery/pipedispenser,
@@ -34482,8 +34520,7 @@
 	icon_state = "N";
 	pixel_y = 1
 	},
-/obj/structure/largecrate/random/barrel/true_random,
-/turf/open/floor/almayer/no_build/plating,
+/turf/closed/wall/almayer/reinforced,
 /area/almayer/middeck/medical)
 "bGk" = (
 /obj/structure/prop/invuln/lattice_prop{
@@ -34524,12 +34561,12 @@
 /turf/open/floor/plating,
 /area/almayer/squads/req)
 "bGp" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/machinery/light/red{
-	light_color = "#BB3F3F"
+/obj/structure/closet/secure_closet/guncabinet/red/armory_m39_submachinegun,
+/obj/structure/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/almayer/no_build/test_floor4,
-/area/almayer/middeck/medical)
+/turf/open/floor/almayer/redfull,
+/area/almayer/medical/upper_medical)
 "bGq" = (
 /obj/structure/machinery/light,
 /obj/effect/decal/warning_stripes{
@@ -34538,12 +34575,11 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/hangar)
 "bGr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/heavy_cable/cable_vertical,
-/obj/structure/machinery/light/red{
-	light_color = "#BB3F3F"
+/obj/structure/stairs{
+	dir = 4;
+	icon_state = "ramptop"
 	},
-/turf/open/floor/plating/plating_catwalk/no_build,
+/turf/open_space,
 /area/almayer/middeck/medical)
 "bGs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34764,26 +34800,32 @@
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/shipboard/navigation)
 "bGT" = (
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/machinery/light/red{
-	light_color = "#BB3F3F";
-	dir = 1
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
-/turf/open/floor/almayer/no_build/test_floor4,
-/area/almayer/middeck/medical)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/dark_sterile,
+/area/space)
 "bGU" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/req)
 "bGV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/heavy_cable/cable_vertical,
-/obj/structure/largecrate/random/barrel/medical,
-/obj/structure/machinery/light/red{
-	light_color = "#BB3F3F";
-	dir = 1
+/obj/structure/machinery/door/window/westright{
+	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk/no_build,
+/obj/structure/machinery/shower{
+	pixel_y = 16
+	},
+/obj/item/tool/soap{
+	pixel_x = 3;
+	pixel_y = 1
+	},
+/obj/item/toy/bikehorn/rubberducky{
+	pixel_x = -8;
+	pixel_y = -3
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/middeck/medical)
 "bGW" = (
 /obj/structure/machinery/light/small,
@@ -35464,10 +35506,11 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/shipboard/stern_point_defense)
 "bIM" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
+/obj/structure/platform_decoration/metal/almayer/northwest{
+	layer = 4.1;
 	dir = 1
 	},
-/turf/open/floor/almayer/sterile_green_side/northeast,
+/turf/open/floor/almayer/mono,
 /area/almayer/medical/upper_medical)
 "bIN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41013,18 +41056,16 @@
 /turf/open/floor/almayer/flooredge/southwest,
 /area/almayer/medical/containment)
 "bWV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/surface/rack,
-/obj/item/clothing/head/hardhat,
-/obj/item/clothing/head/hardhat,
-/obj/item/clothing/head/hardhat,
-/obj/item/clothing/head/hardhat,
-/obj/item/clothing/head/hardhat,
-/obj/item/clothing/head/hardhat,
-/obj/item/clothing/head/hardhat,
-/obj/item/clothing/head/hardhat,
-/turf/open/floor/almayer/no_build/plate,
-/area/almayer/middeck/medical)
+/obj/structure/flora/bush/ausbushes/var3/brflowers{
+	name = "fake brflowers";
+	desc = "Just like a real plant, but fake!"
+	},
+/obj/structure/machinery/status_display{
+	pixel_y = 0;
+	pixel_x = -32
+	},
+/turf/open/floor/grass,
+/area/almayer/medical/upper_medical)
 "bWW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/surface/rack,
@@ -41453,74 +41494,45 @@
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/middeck/medical)
 "bXJ" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
+/obj/structure/stairs{
+	dir = 4;
+	icon_state = "ramptop"
 	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "S";
-	layer = 3.3
-	},
-/obj/structure/barricade/handrail/no_vault{
-	dir = 1
-	},
-/obj/structure/largecrate/random/barrel/medical,
-/turf/open/floor/almayer/no_build/plate,
+/obj/structure/machinery/light/blue,
+/turf/open_space,
 /area/almayer/middeck/medical)
 "bXK" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "S";
-	layer = 3.3
-	},
-/obj/structure/largecrate/random/barrel/medical,
-/obj/structure/barricade/handrail/no_vault{
-	dir = 1
-	},
-/turf/open/floor/almayer/no_build/plate,
+/obj/structure/window/framed/almayer,
+/turf/open/floor/almayer/dark_sterile,
 /area/almayer/middeck/medical)
 "bXL" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "S";
-	layer = 3.3
-	},
-/obj/structure/barricade/handrail/no_vault{
-	dir = 1
-	},
-/turf/open/floor/almayer/no_build/plate,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_corner,
 /area/almayer/middeck/medical)
 "bXM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 4;
+	id = "CMO Shutters";
+	name = "\improper CMO Office Shutters"
 	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "S";
-	layer = 3.3
-	},
-/obj/structure/barricade/handrail/no_vault{
-	dir = 1
-	},
-/turf/open/floor/almayer/no_build/plate,
+/turf/open/floor/almayer/test_floor4,
 /area/almayer/middeck/medical)
 "bXN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
+/obj/structure/sign/safety/intercom{
+	pixel_y = -26;
+	pixel_x = 16
 	},
-/obj/structure/barricade/handrail/no_vault{
-	dir = 1
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	name = "General Listening Channel";
+	pixel_y = -28;
+	pixel_x = -6
 	},
-/turf/open/floor/almayer/no_build/plate,
+/obj/structure/sign/poster/art{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/almayer/sterile_green_corner/east,
 /area/almayer/middeck/medical)
 "bXO" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer/containment{
@@ -42440,32 +42452,19 @@
 /turf/open/floor/almayer/sterile_green2,
 /area/almayer/medical/containment)
 "bZq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes{
-	icon_state = "S";
-	layer = 3.3
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/structure/barricade/handrail/no_vault,
-/turf/open/floor/almayer/no_build/plate,
+/turf/open/floor/almayer/dark_sterile,
 /area/almayer/middeck/medical)
 "bZr" = (
 /turf/open/floor/almayer/plating_striped/north,
 /area/almayer/squads/req)
 "bZs" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S";
-	layer = 3.3
+/obj/structure/window/framed/almayer,
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 4;
+	id = "CMO Shutters";
+	name = "\improper CMO Office Shutters"
 	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/structure/barricade/handrail/no_vault,
-/turf/open/floor/almayer/no_build/plate,
+/turf/open_space,
 /area/almayer/middeck/medical)
 "bZt" = (
 /turf/closed/wall/almayer/research/containment/wall/connect3,
@@ -43042,8 +43041,8 @@
 	pixel_x = -9
 	},
 /obj/item/clothing/head/headset{
-	pixel_x = 14;
-	pixel_y = 1
+	pixel_x = 8;
+	pixel_y = -1
 	},
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/middeck/medical)
@@ -43558,14 +43557,11 @@
 /turf/open/floor/almayer/no_build/test_floor4,
 /area/almayer/middeck/briefing)
 "cbn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/heavy_cable/cable_vertical,
-/obj/structure/sign/safety/reduction{
-	pixel_x = 8;
-	pixel_y = -26
+/obj/structure/machinery/camera/autoname/almayer{
+	name = "ship-grade camera"
 	},
-/turf/open/floor/plating/plating_catwalk/no_build,
-/area/almayer/middeck/medical)
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/medical/upper_medical)
 "cbo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/heavy_cable/cable_vertical,
@@ -44139,6 +44135,11 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_y = 2;
+	pixel_x = 1
+	},
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/upper_medical)
 "ccG" = (
@@ -44153,11 +44154,11 @@
 /area/almayer/hallways/hangar)
 "ccH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/machinery/firealarm{
-	pixel_y = 26;
-	pixel_x = -1
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 2
 	},
-/turf/open/floor/almayer/sterile_green_side/north,
+/turf/open/floor/almayer/sterile_green_side/northwest,
 /area/almayer/medical/upper_medical)
 "ccI" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
@@ -44249,11 +44250,19 @@
 /turf/open/floor/almayer/sterile_green_side/southwest,
 /area/almayer/medical/upper_medical)
 "ccW" = (
-/obj/structure/sign/safety/reduction{
-	pixel_y = 28;
-	pixel_x = 8
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
 	},
-/turf/open/floor/almayer/sterile_green_corner/north,
+/obj/structure/machinery/light{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/tank/water,
+/obj/structure/sign/safety/reduction{
+	pixel_x = 8;
+	pixel_y = 28
+	},
+/turf/open/floor/almayer/cargo,
 /area/almayer/medical/upper_medical)
 "ccX" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -44491,15 +44500,15 @@
 /turf/open/floor/almayer/sterile_green_corner,
 /area/almayer/medical/upper_medical)
 "cdw" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/dark_sterile,
-/area/almayer/medical/upper_medical)
+/area/space)
 "cdx" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "SW-out"
+/obj/structure/closet/secure_closet/guncabinet/red/armory_shotgun,
+/obj/structure/machinery/light/small{
+	dir = 8
 	},
-/turf/closed/wall/almayer/white,
-/area/almayer/medical/upper_medical)
+/turf/open/floor/almayer/redfull,
+/area/space)
 "cdy" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -44698,12 +44707,9 @@
 /turf/open/floor/almayer/sterile_green,
 /area/almayer/medical/upper_medical)
 "cdS" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/dark_sterile,
-/area/almayer/medical/upper_medical)
+/obj/structure/platform/metal/almayer_smooth,
+/turf/open_space,
+/area/space)
 "cdT" = (
 /obj/structure/machinery/cm_vending/clothing/smartgun/charlie,
 /turf/open/floor/almayer/plate,
@@ -44724,25 +44730,26 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/charlie)
 "cdW" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/machinery/computer/cameras/containment{
+	name = "Research Cameras";
+	pixel_y = 9;
+	pixel_x = 1;
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/dark_sterile,
-/area/almayer/medical/upper_medical)
+/obj/structure/machinery/computer/research/main_terminal{
+	pixel_y = -5;
+	pixel_x = 1;
+	dir = 4
+	},
+/turf/open/floor/almayer/sterile_green_side/west,
+/area/almayer/middeck/medical)
 "cdX" = (
 /obj/structure/machinery/cm_vending/gear/engi,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/charlie)
 "cdY" = (
-/obj/structure/pipes/vents/scrubber{
-	dir = 4
-	},
-/obj/structure/platform_decoration/metal/almayer/west,
-/obj/structure/sign/nosmoking_2{
-	pixel_x = 28
-	},
-/turf/open/floor/almayer/mono,
+/turf/open_space,
 /area/almayer/medical/upper_medical)
 "cdZ" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
@@ -44758,16 +44765,12 @@
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south2)
 "ceb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/machinery/door_control{
-	dir = 1;
-	id = "Research Armory";
-	name = "Research Armory";
-	req_one_access_txt = "4;28";
-	pixel_x = -22
+/obj/structure/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/turf/open/floor/almayer/sterile_green_side/west,
-/area/almayer/medical/upper_medical)
+/turf/open/floor/almayer/sterile_green_corner/west,
+/area/space)
 "cec" = (
 /obj/structure/machinery/vending/cola/research{
 	pixel_x = -2;
@@ -44874,16 +44877,16 @@
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
 "cem" = (
-/obj/structure/platform/metal/almayer/west,
-/obj/structure/bed/chair/comfy{
+/obj/structure/machinery/door/poddoor/shutters/almayer{
+	id = "Research Armory";
+	name = "\improper Armory Shutters";
 	dir = 4
 	},
-/turf/open/floor/almayer/mono,
-/area/almayer/medical/upper_medical)
+/turf/open/floor/almayer/test_floor4,
+/area/space)
 "cen" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/sterile_green_corner/north,
-/area/almayer/medical/upper_medical)
+/turf/open/floor/almayer/sterile_green_corner,
+/area/space)
 "ceo" = (
 /obj/structure/surface/rack,
 /obj/item/clothing/suit/storage/marine/light/vest{
@@ -44976,24 +44979,20 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/morgue)
 "cez" = (
-/obj/item/toy/plush/therapy/random_color{
-	pixel_y = 2;
-	pixel_x = 2
+/obj/structure/morgue{
+	dir = 2
 	},
-/obj/structure/platform/metal/almayer/north,
-/obj/structure/platform/metal/almayer/west,
-/obj/structure/platform_decoration/metal/almayer/northeast{
-	layer = 4.1
+/obj/effect/decal/warning_stripes{
+	icon_state = "test_square_smooth"
 	},
-/obj/structure/bed/chair/comfy{
-	dir = 4
+/obj/structure/machinery/camera/autoname/almayer{
+	name = "ship-grade camera"
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/medical/upper_medical)
+/turf/open/floor/almayer/plate,
+/area/almayer/medical/morgue)
 "ceA" = (
-/obj/structure/platform_decoration/metal/almayer/east,
-/turf/open/floor/almayer/mono,
-/area/almayer/medical/upper_medical)
+/turf/open/floor/almayer/flooredge/north,
+/area/almayer/medical/morgue)
 "ceB" = (
 /obj/structure/surface/rack,
 /obj/item/clothing/suit/storage/marine/light/vest{
@@ -45029,15 +45028,15 @@
 /turf/closed/wall/almayer,
 /area/almayer/command/cichallway)
 "ceF" = (
-/obj/structure/machinery/door_control{
-	dir = 1;
-	id = "Research Armory";
-	name = "Emergency Research Armory Release";
-	pixel_x = -31;
-	pixel_y = 26
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 4;
+	id = "CMO Shutters";
+	name = "\improper CMO Office Shutters"
 	},
-/turf/open/floor/almayer/plating_stripedcorner/north,
-/area/almayer/medical/upper_medical)
+/obj/structure/window/framed/almayer/white,
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/turf/open/floor/plating,
+/area/space)
 "ceG" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -45125,36 +45124,33 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/morgue)
 "ceR" = (
-/obj/structure/flora/bush/ausbushes/grassybush{
-	name = "fake grassybush";
-	desc = "Just like a real plant, but fake!"
-	},
-/turf/open/floor/grass,
-/area/almayer/medical/upper_medical)
-"ceS" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/obj/structure/platform_decoration/metal/almayer/east,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/mono,
-/area/almayer/medical/upper_medical)
+/turf/open/floor/almayer/sterile_green_side/southeast,
+/area/almayer/middeck/medical)
+"ceS" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/flooredge/north,
+/area/almayer/medical/morgue)
 "ceT" = (
-/obj/structure/closet/secure_closet/guncabinet/red/armory_m39_submachinegun,
-/obj/structure/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/almayer/redfull,
-/area/almayer/medical/upper_medical)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/heavy_cable/cable_vertical,
+/turf/open/floor/plating/plating_catwalk/no_build,
+/area/space)
 "ceU" = (
-/obj/structure/sign/safety/ammunition{
-	pixel_y = -7;
-	pixel_x = -17
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
 	},
-/obj/structure/sign/safety/hazard{
-	pixel_x = -17;
-	pixel_y = 7
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	layer = 3.3
 	},
-/turf/open/floor/almayer/sterile_green_side/west,
-/area/almayer/medical/upper_medical)
+/obj/structure/barricade/handrail/no_vault{
+	dir = 1
+	},
+/turf/open/floor/almayer/no_build/plate,
+/area/space)
 "ceV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45253,12 +45249,9 @@
 /turf/open/floor/almayer/green/east,
 /area/almayer/hallways/upper/fore_hallway)
 "cfh" = (
-/obj/structure/machinery/light/double/blue{
-	light_color = "#a7dbc7";
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/almayer/medical/upper_medical)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_corner/north,
+/area/space)
 "cfi" = (
 /obj/structure/largecrate/random{
 	pixel_y = 8
@@ -45635,7 +45628,7 @@
 	pixel_x = -7;
 	pixel_y = 1
 	},
-/turf/open/floor/almayer/plate,
+/turf/closed/wall/almayer/white/reinforced,
 /area/almayer/medical/medical_science)
 "cga" = (
 /obj/structure/medical_supply_link,
@@ -45647,7 +45640,7 @@
 /obj/structure/machinery/status_display{
 	pixel_y = 32
 	},
-/turf/open/floor/plating/plating_catwalk,
+/turf/closed/wall/almayer/white/reinforced,
 /area/almayer/medical/medical_science)
 "cgb" = (
 /turf/closed/wall/almayer/research/containment/wall/north,
@@ -46046,6 +46039,14 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/door_control{
+	dir = 1;
+	id = "Research Armory";
+	name = "Research Armory";
+	req_one_access_txt = "4;28";
+	pixel_x = 23;
+	pixel_y = 0
+	},
 /turf/open/floor/almayer/sterile_green_side/east,
 /area/almayer/medical/upper_medical)
 "cgX" = (
@@ -46257,43 +46258,55 @@
 /turf/closed/wall/almayer/white,
 /area/almayer/medical/morgue)
 "cht" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/turf/open/floor/almayer/dark_sterile,
+/obj/structure/disposalpipe/segment,
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer/sterile_green_side/southeast,
 /area/almayer/medical/upper_medical)
 "chu" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 5
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	pixel_y = 6
 	},
-/turf/open/floor/almayer/dark_sterile,
+/obj/structure/platform/metal/almayer/north{
+	dir = 2
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/upper_medical)
 "chv" = (
 /obj/structure/closet/secure_closet/guncabinet/red/mp_armory_shotgun,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/armory)
 "chw" = (
-/obj/structure/pipes/standard/manifold/hidden/supply,
-/turf/open/floor/almayer/flooredge/northeast,
-/area/almayer/medical/upper_medical)
-"chx" = (
-/obj/structure/bed,
-/obj/item/bedsheet/green,
-/turf/open/floor/almayer/flooredge/northwest,
-/area/almayer/medical/upper_medical)
-"chy" = (
-/obj/structure/toilet{
-	dir = 1
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	pixel_y = 6
 	},
-/obj/structure/machinery/light/small{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/platform/metal/almayer/north{
+	dir = 2
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/upper_medical)
+"chx" = (
+/obj/structure/flora/bush/ausbushes/var3/sunnybush,
+/turf/open/floor/grass,
+/area/almayer/medical/upper_medical)
+"chy" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_29";
+	pixel_y = 3;
+	pixel_x = -4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/almayer/flooredge/southeast,
+/area/space)
 "chz" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -46499,7 +46512,7 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/almayer/sterile_green_side/east,
+/turf/open/floor/almayer/sterile_green_side/northeast,
 /area/almayer/medical/upper_medical)
 "chW" = (
 /obj/structure/pipes/vents/scrubber{
@@ -46514,7 +46527,19 @@
 /turf/open/floor/almayer/emerald/north,
 /area/almayer/squads/charlie)
 "chX" = (
-/turf/open/floor/almayer/flooredge/southwest,
+/obj/structure/platform/metal/almayer/north{
+	dir = 2
+	},
+/obj/structure/platform/metal/almayer/east,
+/obj/structure/platform_decoration/metal/almayer/northwest{
+	layer = 4.1;
+	dir = 6
+	},
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/upper_medical)
 "chY" = (
 /obj/structure/ladder/multiz,
@@ -50421,6 +50446,12 @@
 	},
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/underdeck/hangar)
+"csb" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/obj/structure/platform_decoration/metal/almayer/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/mono,
+/area/space)
 "csd" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating/plating_catwalk,
@@ -50972,6 +51003,15 @@
 "cGR" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/upper/u_m_s)
+"cGU" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "test_square_smooth"
+	},
+/obj/structure/morgue{
+	dir = 8
+	},
+/turf/open/floor/almayer/plate,
+/area/almayer/medical/morgue)
 "cGV" = (
 /turf/open/floor/almayer/cargo_arrow,
 /area/almayer/squads/alpha_bravo_shared)
@@ -51344,6 +51384,17 @@
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_f_p)
+"cOC" = (
+/obj/structure/sink{
+	pixel_y = 22;
+	pixel_x = 0
+	},
+/obj/structure/mirror{
+	pixel_y = 36;
+	pixel_x = -1
+	},
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/middeck/medical)
 "cOK" = (
 /obj/structure/prop/invuln{
 	desc = "An inflated membrane. This one is puncture proof. Wow!";
@@ -51809,6 +51860,12 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/command/lifeboat)
+"cYE" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 5
+	},
+/turf/open/floor/almayer/dark_sterile,
+/area/space)
 "cYN" = (
 /obj/structure/stairs/multiz/up{
 	dir = 8
@@ -52110,6 +52167,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/almayer,
 /area/almayer/engineering/lower/workshop/hangar)
+"ddN" = (
+/obj/structure/flora/bush/ausbushes/ausbush{
+	name = "fake ausbush";
+	desc = "Just like a real plant, but fake!"
+	},
+/turf/open/floor/grass,
+/area/space)
 "ddO" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -52451,6 +52515,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/port_emb)
+"dnb" = (
+/obj/effect/decal/heavy_cable/node_s_w,
+/turf/open/floor/plating/plating_catwalk/no_build,
+/area/space)
 "dnh" = (
 /obj/structure/surface/rack,
 /obj/item/book/manual/orbital_cannon_manual,
@@ -52559,6 +52627,9 @@
 "dqj" = (
 /turf/open/floor/almayer/redcorner/east,
 /area/almayer/command/lifeboat)
+"dqr" = (
+/turf/open/floor/almayer/sterile_green_side/northwest,
+/area/almayer/middeck/medical)
 "dqw" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/shipboard/weapon_room/notunnel)
@@ -52627,26 +52698,11 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/command/corporateliaison)
 "drT" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 4;
-	id = "CMO Shutters";
-	name = "\improper CMO Office Shutters"
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/structure/machinery/door/airlock/almayer/medical/glass{
-	access_modified = 1;
-	name = "\improper CMO's Office";
-	req_one_access = null;
-	req_one_access_txt = "1;5"
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/almayer/test_floor4,
-/area/almayer/medical/upper_medical)
+/turf/open/floor/almayer/sterile_green_side/northwest,
+/area/space)
 "drU" = (
 /obj/structure/machinery/door_control{
 	id = "ARES JoeCryo";
@@ -52685,6 +52741,18 @@
 	},
 /turf/open/floor/almayer/cargo,
 /area/almayer/maint/upper/u_a_s)
+"dtB" = (
+/obj/structure/reagent_dispensers/water_cooler/stacks{
+	pixel_y = 6;
+	pixel_x = -8;
+	density = 0
+	},
+/obj/structure/machinery/light/double/blue{
+	light_color = "#a7dbc7"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_corner/west,
+/area/space)
 "dtE" = (
 /obj/structure/stairs/perspective{
 	dir = 4;
@@ -52699,6 +52767,15 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/hangar)
+"dtQ" = (
+/obj/structure/machinery/door/airlock/almayer/white{
+	name = "\improper CMO's Bedroom";
+	req_one_access = list(28,206,207);
+	req_one_access_txt = "1;5";
+	dir = 2
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/middeck/medical)
 "duo" = (
 /obj/structure/machinery/power/apc/almayer/west,
 /turf/open/floor/prison/kitchen,
@@ -52837,6 +52914,17 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/orange/northeast,
 /area/almayer/engineering/lower/workshop/hangar)
+"dya" = (
+/obj/structure/flora/bush/ausbushes/var3/brflowers{
+	name = "fake brflowers";
+	desc = "Just like a real plant, but fake!"
+	},
+/obj/structure/machinery/light/double/blue{
+	light_color = "#a7dbc7";
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/space)
 "dyb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53012,6 +53100,19 @@
 /obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/floor/almayer/plating_striped/east,
 /area/almayer/stair_clone/lower/port_aft)
+"dBh" = (
+/obj/structure/sign/calendar/ua{
+	pixel_y = 27;
+	layer = 2.9
+	},
+/obj/structure/machinery/faxmachine/uscm/almayer{
+	pixel_x = -3;
+	pixel_y = 5;
+	sub_name = "Chief Medical Officer"
+	},
+/obj/structure/surface/table/reinforced/prison,
+/turf/open/floor/almayer/sterile_green_corner,
+/area/space)
 "dBi" = (
 /obj/structure/platform/metal/almayer/north,
 /obj/structure/platform/metal/almayer/east,
@@ -53019,17 +53120,15 @@
 /turf/open/floor/almayer/red/northeast,
 /area/almayer/lifeboat_pumps/north2)
 "dBj" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
+/obj/structure/machinery/door_control{
+	dir = 1;
+	id = "Research Armory";
+	name = "Emergency Research Armory Release";
+	pixel_x = -31;
+	pixel_y = 26
 	},
-/obj/item/device/radio/intercom{
-	freerange = 1;
-	name = "General Listening Channel";
-	pixel_y = -28;
-	pixel_x = 1
-	},
-/turf/open/floor/almayer/sterile_green_side,
-/area/almayer/medical/upper_medical)
+/turf/open/floor/almayer/plating_stripedcorner/north,
+/area/space)
 "dBs" = (
 /obj/structure/machinery/cm_vending/clothing/dress,
 /turf/open/floor/almayer/cargo,
@@ -53193,6 +53292,13 @@
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/stern)
+"dDY" = (
+/obj/structure/machinery/light/double/blue{
+	light_color = "#a7dbc7";
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/space)
 "dEk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
@@ -53265,6 +53371,15 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/port_aft_hallway)
+"dEM" = (
+/obj/structure/window/framed/almayer,
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 4;
+	id = "CMO Shutters";
+	name = "\improper CMO Office Shutters"
+	},
+/turf/open/floor/almayer/sterile_green_side/southeast,
+/area/almayer/middeck/medical)
 "dEQ" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/food/condiment/hotsauce/tabasco,
@@ -53518,6 +53633,22 @@
 	},
 /turf/open/floor/almayer/plating,
 /area/almayer/living/basketball)
+"dJX" = (
+/obj/item/device/flashlight/lamp{
+	pixel_y = 14;
+	layer = 2.96
+	},
+/obj/item/prop/tableflag/uscm{
+	pixel_x = -8;
+	pixel_y = 1
+	},
+/obj/item/prop/tableflag{
+	pixel_x = -8;
+	pixel_y = -10
+	},
+/obj/structure/surface/table/reinforced/prison,
+/turf/open/floor/almayer/dark_sterile,
+/area/space)
 "dKp" = (
 /turf/open/floor/almayer/research/containment/corner_var1/east,
 /area/almayer/medical/containment/cell/cl)
@@ -53679,6 +53810,13 @@
 	},
 /turf/open/floor/almayer/no_build,
 /area/almayer/underdeck/vehicle)
+"dOU" = (
+/obj/structure/flora/bush/ausbushes/var3/ppflowers{
+	name = "fake ppflowers";
+	desc = "Just like a real plant, but fake!"
+	},
+/turf/open/floor/grass,
+/area/space)
 "dPd" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/flashlight/lamp{
@@ -53734,6 +53872,22 @@
 /obj/item/paper_bin/uscm,
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/lower/workshop)
+"dQk" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/filingcabinet/filingcabinet{
+	density = 0;
+	pixel_x = 7;
+	pixel_y = 16
+	},
+/obj/structure/filingcabinet/filingcabinet{
+	density = 0;
+	pixel_x = -8;
+	pixel_y = 16
+	},
+/turf/open/floor/almayer/sterile_green_corner,
+/area/space)
 "dQA" = (
 /obj/structure/pipes/standard/simple/visible{
 	dir = 4
@@ -53802,6 +53956,16 @@
 	},
 /turf/open/floor/almayer/red/northwest,
 /area/almayer/lifeboat_pumps/south1)
+"dSG" = (
+/obj/structure/machinery/door_control{
+	id = "CMO Shutters";
+	name = "\improper Office Privacy Shutters";
+	pixel_y = -22;
+	req_one_access_txt = "28";
+	pixel_x = 7
+	},
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/middeck/medical)
 "dSI" = (
 /turf/open/floor/almayer/bluecorner/west,
 /area/almayer/hallways/upper/midship_hallway)
@@ -54346,6 +54510,26 @@
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/upper/midship_hallway)
+"efX" = (
+/obj/structure/surface/rack,
+/obj/item/clothing/suit/storage/marine/light/vest{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/clothing/suit/storage/marine/light/vest{
+	pixel_x = -4;
+	pixel_y = -5
+	},
+/obj/item/clothing/suit/storage/marine/light/vest{
+	pixel_y = 2;
+	pixel_x = 5
+	},
+/obj/item/clothing/suit/storage/marine/light/vest{
+	pixel_y = -5;
+	pixel_x = 5
+	},
+/turf/open/floor/almayer/redfull,
+/area/space)
 "egt" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 1
@@ -55677,6 +55861,13 @@
 	},
 /turf/open/floor/almayer/plating_striped/east,
 /area/almayer/maint/hull/lower/l_a_p)
+"eHU" = (
+/obj/structure/platform/metal/almayer/east,
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/turf/open/floor/almayer/mono,
+/area/space)
 "eHX" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	req_one_access = null;
@@ -55687,6 +55878,20 @@
 "eHY" = (
 /turf/open/floor/almayer/plating_striped/east,
 /area/almayer/command/securestorage)
+"eIc" = (
+/obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
+	name = "\improper CMO's Office";
+	dir = 2;
+	access_modified = 1;
+	req_one_access_txt = "1;5"
+	},
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 4;
+	id = "CMO Shutters";
+	name = "\improper CMO Office Shutters"
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/middeck/medical)
 "eIf" = (
 /obj/structure/prop/invuln/pipe_water,
 /obj/structure/prop/invuln/overhead_pipe{
@@ -57002,6 +57207,17 @@
 	},
 /turf/open/floor/almayer/blue/west,
 /area/almayer/hallways/upper/midship_hallway)
+"fjL" = (
+/obj/structure/platform/metal/almayer/north,
+/obj/structure/platform/metal/almayer/east,
+/obj/structure/platform_decoration/metal/almayer/northwest{
+	layer = 4.1
+	},
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/space)
 "fki" = (
 /obj/structure/cargo_container/horizontal/blue/bottom,
 /turf/open/floor/almayer/no_build,
@@ -57388,6 +57604,30 @@
 /obj/structure/target,
 /turf/open/floor/almayer/plating_striped/west,
 /area/almayer/living/cryo_cells)
+"fuc" = (
+/obj/item/paper_bin/wy{
+	pixel_y = 8;
+	pixel_x = -6
+	},
+/obj/item/tool/pen{
+	pixel_y = 3;
+	pixel_x = -6
+	},
+/obj/item/tool/stamp/cmo{
+	pixel_x = 9;
+	pixel_y = 10;
+	name = "Chief Medical Officer's rubber stamp"
+	},
+/obj/structure/machinery/door_control{
+	id = "CMO Shutters";
+	name = "\improper Office Privacy Shutters";
+	pixel_y = -1;
+	req_one_access_txt = "28";
+	pixel_x = 9
+	},
+/obj/structure/surface/table/reinforced/prison,
+/turf/open/floor/almayer/sterile_green_side/north,
+/area/space)
 "fuz" = (
 /obj/structure/machinery/cm_vending/clothing/pilot_officer,
 /turf/open/floor/almayer/plate,
@@ -57608,6 +57848,10 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_f_s)
+"fzO" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer/dark_sterile,
+/area/space)
 "fzP" = (
 /obj/structure/surface/table/almayer,
 /obj/item/paper_bin/uscm,
@@ -57846,8 +58090,22 @@
 /turf/open/floor/almayer/sterile_green,
 /area/almayer/medical/lower_medical_medbay)
 "fFO" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_y = 1;
+	pixel_x = 1
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/sterile_green_side/northwest,
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/obj/structure/sign/safety/reduction{
+	pixel_x = 8;
+	pixel_y = 28
+	},
+/turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/upper_medical)
 "fFQ" = (
 /obj/structure/surface/table/almayer,
@@ -58313,6 +58571,13 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/hangar)
+"fPw" = (
+/obj/structure/machinery/light/double/blue{
+	light_color = "#a7dbc7"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_corner/east,
+/area/space)
 "fPB" = (
 /obj/structure/machinery/ares/processor/apollo,
 /turf/open/floor/almayer/no_build/test_floor4,
@@ -58518,6 +58783,18 @@
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/chemistry)
+"fVJ" = (
+/obj/structure/platform/metal/almayer/north,
+/obj/structure/platform/metal/almayer/west,
+/obj/structure/platform_decoration/metal/almayer/northeast{
+	layer = 4.1
+	},
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	pixel_y = 6
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/space)
 "fVS" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -58742,6 +59019,30 @@
 	},
 /turf/open/floor/almayer/orange/north,
 /area/almayer/engineering/upper_engineering/starboard)
+"gbP" = (
+/obj/structure/filingcabinet/filingcabinet{
+	density = 0;
+	pixel_x = 7;
+	pixel_y = 16
+	},
+/obj/structure/filingcabinet/filingcabinet{
+	density = 0;
+	pixel_x = -8;
+	pixel_y = 16
+	},
+/obj/item/folder/blue{
+	pixel_y = 5
+	},
+/obj/item/folder/black,
+/obj/item/folder/white,
+/obj/structure/machinery/light/blue{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 17
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_side/north,
+/area/almayer/middeck/medical)
 "gbQ" = (
 /obj/structure/machinery/light/red{
 	light_color = "#BB3F3F"
@@ -59749,6 +60050,10 @@
 	},
 /turf/open/floor/almayer/green,
 /area/almayer/living/grunt_rnr)
+"gzY" = (
+/obj/structure/machinery/light/blue,
+/turf/open/floor/almayer/sterile_green_side,
+/area/almayer/middeck/medical)
 "gAj" = (
 /obj/structure/bed/chair/comfy/charlie{
 	dir = 1
@@ -59961,6 +60266,13 @@
 	},
 /turf/open/floor/almayer/mono,
 /area/almayer/lifeboat_pumps/south1)
+"gFD" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer/flooredge/south,
+/area/almayer/hallways/upper/midship_hallway)
+"gFK" = (
+/turf/open/floor/almayer/flooredge/north,
+/area/almayer/middeck/medical)
 "gFP" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/shipboard/stern_point_defense)
@@ -60205,6 +60517,21 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/port_midship_hallway)
+"gKz" = (
+/obj/structure/machinery/computer/med_data{
+	pixel_x = -9;
+	pixel_y = 0
+	},
+/obj/structure/machinery/computer/crew{
+	pixel_x = 15;
+	pixel_y = 0
+	},
+/obj/structure/sign/catclock{
+	pixel_y = 28;
+	pixel_x = 7
+	},
+/turf/open/floor/almayer/sterile_green_side/north,
+/area/almayer/middeck/medical)
 "gKB" = (
 /obj/structure/machinery/portable_atmospherics/hydroponics,
 /obj/structure/machinery/firealarm{
@@ -60220,14 +60547,8 @@
 /turf/open/floor/almayer/redfull,
 /area/almayer/shipboard/port_missiles)
 "gKR" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 4;
-	id = "CMO Shutters";
-	name = "\improper CMO Office Shutters"
-	},
-/obj/structure/window/framed/almayer/white,
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/turf/open/floor/plating,
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/upper_medical)
 "gKW" = (
 /obj/structure/surface/rack,
@@ -60240,7 +60561,10 @@
 /turf/open/floor/almayer/plating_striped,
 /area/almayer/underdeck/req)
 "gLc" = (
-/obj/structure/pipes/vents/scrubber,
+/obj/structure/platform_decoration/metal/almayer/northwest{
+	layer = 4.1;
+	dir = 2
+	},
 /turf/open/floor/almayer/mono,
 /area/almayer/medical/upper_medical)
 "gLl" = (
@@ -60354,6 +60678,10 @@
 	},
 /turf/open/floor/almayer/uscm/directional/east,
 /area/almayer/living/briefing)
+"gNe" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer/flooredge/west,
+/area/almayer/medical/morgue)
 "gNg" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = -17
@@ -60789,16 +61117,8 @@
 /turf/open/floor/plating,
 /area/almayer/medical/upper_medical)
 "gXl" = (
-/obj/structure/flora/bush/ausbushes/var3/brflowers{
-	name = "fake brflowers";
-	desc = "Just like a real plant, but fake!"
-	},
-/obj/structure/machinery/light/double/blue{
-	light_color = "#a7dbc7";
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/almayer/medical/upper_medical)
+/turf/open/floor/almayer/flooredge,
+/area/almayer/medical/morgue)
 "gXs" = (
 /obj/effect/step_trigger/ares_alert/terminals,
 /obj/structure/machinery/door/poddoor/shutters/almayer{
@@ -61452,9 +61772,12 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/command/cichallway)
 "hme" = (
-/obj/structure/pipes/vents/pump,
-/turf/open/floor/almayer/dark_sterile2,
-/area/almayer/medical/upper_medical)
+/obj/structure/machinery/cm_vending/clothing/senior_officer{
+	pixel_y = 19;
+	density = 0
+	},
+/turf/open/floor/almayer/flooredge/northwest,
+/area/almayer/middeck/medical)
 "hmj" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out";
@@ -61529,12 +61852,8 @@
 /turf/open/floor/wood/ship,
 /area/almayer/living/commandbunks)
 "hng" = (
-/obj/structure/machinery/photocopier{
-	layer = 2.9;
-	pixel_y = 16;
-	density = 0
-	},
-/turf/open/floor/almayer/sterile_green_side/north,
+/obj/structure/flora/bush/ausbushes/var3/leafybush,
+/turf/open/floor/grass,
 /area/almayer/medical/upper_medical)
 "hnt" = (
 /obj/item/toy/deck{
@@ -61583,6 +61902,13 @@
 	},
 /turf/open/floor/almayer/red,
 /area/almayer/shipboard/weapon_room)
+"hpL" = (
+/obj/structure/machinery/light/blue{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/middeck/medical)
 "hpS" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer{
 	id = "crate_room3";
@@ -61912,6 +62238,10 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/alpha_bravo_shared)
+"hxg" = (
+/obj/structure/machinery/computer/med_data,
+/turf/open/floor/almayer/sterile_green_corner/north,
+/area/space)
 "hxm" = (
 /obj/item/paper_bin/uscm{
 	pixel_y = 4
@@ -62387,6 +62717,19 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_f_s)
+"hLl" = (
+/obj/structure/platform/metal/almayer/north,
+/obj/structure/platform/metal/almayer/west,
+/obj/structure/platform/metal/almayer/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/platform_decoration/metal/almayer/northeast{
+	layer = 4.1
+	},
+/obj/structure/platform_decoration/metal/almayer/northwest{
+	layer = 4.1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/space)
 "hLr" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/manifold/hidden/supply{
@@ -62586,20 +62929,8 @@
 /turf/open/floor/almayer/no_build/plating,
 /area/almayer/underdeck/req)
 "hPN" = (
-/obj/item/device/flashlight/lamp{
-	pixel_y = 14;
-	layer = 2.96
-	},
-/obj/item/prop/tableflag/uscm{
-	pixel_x = -8;
-	pixel_y = 1
-	},
-/obj/item/prop/tableflag{
-	pixel_x = -8;
-	pixel_y = -10
-	},
-/obj/structure/surface/table/reinforced/prison,
-/turf/open/floor/almayer/dark_sterile,
+/obj/structure/flora/bush/ausbushes/var3/fullgrass,
+/turf/open/floor/grass,
 /area/almayer/medical/upper_medical)
 "hQc" = (
 /obj/structure/window/reinforced{
@@ -63082,6 +63413,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/underdeck/vehicle)
+"hYA" = (
+/turf/open/floor/almayer/sterile_green,
+/area/space)
 "hYE" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/flora/pottedplant{
@@ -63457,6 +63791,13 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/maint/lower/constr)
+"ihu" = (
+/obj/structure/pipes/vents/pump,
+/turf/open/floor/almayer/dark_sterile2,
+/area/space)
+"ihH" = (
+/turf/open/floor/almayer/sterile_green_corner/east,
+/area/almayer/middeck/medical)
 "ihI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -63499,19 +63840,11 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/squads/bravo)
 "iit" = (
-/obj/structure/surface/table/reinforced/almayer_B,
-/obj/item/device/flashlight/lamp{
-	pixel_y = 11;
-	pixel_x = 5
+/obj/structure/machinery/status_display{
+	pixel_x = -32
 	},
-/obj/item/device/megaphone,
-/obj/item/device/flash,
-/obj/item/clothing/glasses/science{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/almayer/flooredge/north,
-/area/almayer/medical/upper_medical)
+/turf/open/floor/grass,
+/area/space)
 "iiU" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -63550,6 +63883,9 @@
 /obj/structure/machinery/cell_charger,
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/lower/workshop)
+"ijq" = (
+/turf/open/floor/almayer/sterile_green_side/southeast,
+/area/almayer/middeck/medical)
 "ijr" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 4
@@ -63627,6 +63963,10 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
+"imk" = (
+/obj/structure/window/framed/almayer/hull,
+/turf/closed/wall/almayer/white,
+/area/almayer/middeck/maintenance/sf)
 "imt" = (
 /obj/structure/reagent_dispensers/water_cooler/stacks{
 	density = 0;
@@ -63842,6 +64182,13 @@
 "iqp" = (
 /turf/open/floor/wood/ship,
 /area/almayer/living/pilotbunks)
+"iqw" = (
+/obj/structure/machinery/light/red{
+	light_color = "#BB3F3F";
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk/no_build,
+/area/almayer/middeck/medical)
 "iqH" = (
 /obj/item/trash/chips{
 	pixel_x = 9;
@@ -64438,12 +64785,11 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/lower/starboard_fore_hallway)
 "iGA" = (
-/obj/structure/machinery/light/double/blue{
-	light_color = "#a7dbc7"
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/sterile_green_corner/east,
-/area/almayer/medical/upper_medical)
+/turf/open/floor/almayer/dark_sterile,
+/area/space)
 "iHc" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/upper_engineering/notunnel)
@@ -64669,6 +65015,16 @@
 /obj/structure/machinery/cryopod/right,
 /turf/open/floor/almayer/cargo,
 /area/almayer/squads/bravo)
+"iMv" = (
+/obj/structure/machinery/status_display{
+	pixel_x = 32
+	},
+/obj/structure/flora/bush/ausbushes/var3/fullgrass{
+	desc = "Just like a real plant, but fake!";
+	name = "fake fullgrass"
+	},
+/turf/open/floor/grass,
+/area/space)
 "iMD" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -65358,18 +65714,8 @@
 /turf/open/floor/almayer/plating,
 /area/almayer/living/basketball)
 "iYf" = (
-/obj/structure/sign/calendar/ua{
-	pixel_y = 27;
-	layer = 2.9
-	},
-/obj/structure/machinery/faxmachine/uscm/almayer{
-	pixel_x = -3;
-	pixel_y = 5;
-	sub_name = "Chief Medical Officer"
-	},
-/obj/structure/surface/table/reinforced/prison,
-/turf/open/floor/almayer/sterile_green_corner,
-/area/almayer/medical/upper_medical)
+/turf/closed/wall/almayer/white/reinforced,
+/area/space)
 "iYm" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/almayer/plate,
@@ -65628,9 +65974,9 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/u_a_p)
 "jeq" = (
-/obj/structure/machinery/computer/crew,
-/turf/open/floor/almayer/sterile_green_corner/east,
-/area/almayer/medical/upper_medical)
+/obj/structure/platform/metal/almayer_smooth/north,
+/turf/open_space,
+/area/space)
 "jer" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -65936,6 +66282,9 @@
 	},
 /turf/open/floor/plating/plating_catwalk/no_build,
 /area/almayer/underdeck/hangar)
+"jjs" = (
+/turf/open/floor/almayer/flooredge/southwest,
+/area/space)
 "jjz" = (
 /obj/structure/cargo_container/uscm/chinook/left,
 /obj/structure/prop/invuln/lattice_prop{
@@ -66806,6 +67155,27 @@
 /obj/structure/barricade/handrail,
 /turf/open/floor/almayer/test_floor5,
 /area/almayer/hallways/lower/port_midship_hallway)
+"jDE" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	pixel_y = 9;
+	pixel_x = -6
+	},
+/obj/item/alienjar{
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/obj/item/reagent_container/food/snacks/toastedsandwich{
+	pixel_x = 12;
+	pixel_y = 4
+	},
+/obj/structure/sign/safety/terminal{
+	pixel_x = 7;
+	pixel_y = -26
+	},
+/turf/open/floor/almayer/sterile_green_corner/west,
+/area/almayer/middeck/medical)
 "jDO" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/airlock/almayer{
@@ -66848,6 +67218,9 @@
 /obj/structure/platform/metal/almayer_smooth,
 /turf/open/floor/almayer/red/southwest,
 /area/almayer/shipboard/brig)
+"jFo" = (
+/turf/open/floor/almayer/no_build/plate,
+/area/space)
 "jFt" = (
 /obj/structure/platform/metal/almayer_smooth/north,
 /obj/structure/platform/metal/almayer_smooth/west,
@@ -66883,6 +67256,17 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/upper/u_m_s)
+"jFQ" = (
+/obj/structure/flora/bush/ausbushes/var3/fullgrass{
+	desc = "Just like a real plant, but fake!";
+	name = "fake fullgrass"
+	},
+/obj/structure/machinery/status_display{
+	pixel_y = -32;
+	pixel_x = 0
+	},
+/turf/open/floor/grass,
+/area/almayer/medical/upper_medical)
 "jFY" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer/cargo,
@@ -67858,9 +68242,14 @@
 /turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
 "kbn" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/floor/almayer/mono,
-/area/almayer/medical/upper_medical)
+/obj/structure/bed,
+/obj/item/bedsheet/green,
+/obj/structure/sign/poster/hunk{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/almayer/flooredge/southeast,
+/area/almayer/middeck/medical)
 "kbv" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/upper/starboard)
@@ -67954,6 +68343,22 @@
 /obj/structure/largecrate/random/barrel/red,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_f_s)
+"kds" = (
+/obj/structure/platform/metal/almayer/north{
+	dir = 2
+	},
+/obj/structure/platform/metal/almayer/west,
+/obj/structure/platform_decoration/metal/almayer/northwest{
+	layer = 4.1;
+	dir = 10
+	},
+/obj/structure/reagent_dispensers/water_cooler/stacks{
+	pixel_y = 7;
+	pixel_x = -3;
+	density = 0
+	},
+/turf/open/floor/almayer/mono,
+/area/almayer/medical/upper_medical)
 "kdv" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -68284,6 +68689,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_f_s)
+"kmd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_corner/east,
+/area/almayer/middeck/medical)
 "kmp" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -68356,6 +68765,20 @@
 "knU" = (
 /turf/open/floor/almayer/red/northwest,
 /area/almayer/hallways/upper/aft_hallway)
+"kol" = (
+/obj/structure/bookcase{
+	icon_state = "book-5";
+	pixel_x = -1;
+	pixel_y = 19;
+	density = 0;
+	opacity = 0
+	},
+/obj/item/book/manual/ripley_build_and_repair,
+/obj/item/book/manual/research_and_development,
+/obj/item/book/manual/surgery,
+/obj/item/book/manual/medical_diagnostics_manual,
+/turf/open/floor/almayer/flooredge/north,
+/area/almayer/middeck/medical)
 "kon" = (
 /obj/structure/pipes/vents/pump{
 	dir = 1
@@ -68496,6 +68919,13 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/living/gym)
+"kqM" = (
+/obj/structure/flora/bush/ausbushes/grassybush{
+	name = "fake grassybush";
+	desc = "Just like a real plant, but fake!"
+	},
+/turf/open/floor/grass,
+/area/space)
 "kqN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -68771,6 +69201,14 @@
 	},
 /turf/open/floor/almayer/sterile_green,
 /area/almayer/medical/lower_medical_lobby)
+"kwv" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_29";
+	pixel_y = 12;
+	pixel_x = 6
+	},
+/turf/open/floor/almayer/sterile_green_corner,
+/area/almayer/middeck/medical)
 "kwQ" = (
 /obj/item/tool/warning_cone{
 	pixel_y = 16
@@ -69167,8 +69605,10 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/living/briefing)
 "kEp" = (
-/turf/open/floor/almayer/plating_stripedcorner/west,
-/area/almayer/medical/upper_medical)
+/obj/structure/window/framed/almayer/white,
+/obj/structure/window/framed/almayer,
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/middeck/medical)
 "kEs" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/flashlight/lamp{
@@ -69216,6 +69656,19 @@
 "kFv" = (
 /turf/open/floor/almayer/sterile_green_side/northeast,
 /area/almayer/medical/lower_medical_medbay)
+"kFH" = (
+/obj/structure/platform/metal/almayer/north,
+/obj/structure/platform/metal/almayer/east,
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/platform_decoration/metal/almayer/northwest{
+	layer = 4.1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/space)
 "kFO" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer{
 	dir = 4;
@@ -69230,6 +69683,14 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_f_s)
+"kGa" = (
+/obj/structure/closet/secure_closet/professor_dummy{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/power/apc/almayer/east,
+/turf/open/floor/almayer/sterile_green_side/east,
+/area/almayer/middeck/medical)
 "kGi" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
@@ -69497,6 +69958,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plating,
 /area/almayer/shipboard/brig/yard)
+"kMI" = (
+/turf/open/floor/almayer/sterile_green_corner/west,
+/area/almayer/middeck/medical)
 "kMK" = (
 /obj/structure/prop/invuln{
 	desc = "An inflated membrane. This one is puncture proof. Wow!";
@@ -69885,6 +70349,20 @@
 	},
 /turf/open/floor/almayer/mono,
 /area/almayer/lifeboat_pumps/south2)
+"kVj" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	layer = 3.3
+	},
+/obj/structure/barricade/handrail/no_vault{
+	dir = 1
+	},
+/turf/open/floor/almayer/no_build/plate,
+/area/space)
 "kVV" = (
 /obj/structure/bed/chair/comfy/black,
 /turf/open/floor/wood/ship,
@@ -70331,6 +70809,10 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/living/cryo_cells)
+"lgA" = (
+/obj/structure/stairs/multiz/up,
+/turf/open/space/basic,
+/area/almayer/middeck/medical)
 "lgC" = (
 /obj/structure/platform/metal/almayer/west,
 /turf/open/floor/almayer/uscm/directional/northwest,
@@ -70621,6 +71103,12 @@
 "llO" = (
 /turf/open/floor/almayer/orange/east,
 /area/almayer/hallways/hangar)
+"lmk" = (
+/obj/structure/stairs/multiz/down{
+	dir = 4
+	},
+/turf/closed/wall/almayer/white,
+/area/almayer/medical/upper_medical)
 "lmz" = (
 /turf/closed/wall/almayer/aicore/hull,
 /area/almayer/middeck/req)
@@ -71082,6 +71570,17 @@
 	},
 /turf/open/floor/almayer/emeraldfull,
 /area/almayer/squads/charlie)
+"lwT" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	layer = 3.3
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E"
+	},
+/obj/structure/largecrate/random/case/double,
+/turf/open/floor/almayer/no_build/plate,
+/area/almayer/middeck/medical)
 "lwY" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/glass{
 	name = "\improper Port Viewing Room"
@@ -71348,6 +71847,25 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/orangecorner/north,
 /area/almayer/engineering/upper_engineering)
+"lEu" = (
+/obj/structure/sink{
+	pixel_y = 1;
+	dir = 4;
+	pixel_x = 14
+	},
+/obj/structure/mirror{
+	pixel_x = 30
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	layer = 3.33;
+	pixel_y = 2
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/turf/open/floor/almayer/dark_sterile,
+/area/space)
 "lEv" = (
 /obj/structure/bookcase{
 	opacity = 0
@@ -71480,6 +71998,12 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/living/grunt_rnr)
+"lHI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/heavy_cable/cable_vertical,
+/obj/structure/largecrate/random/barrel/medical,
+/turf/open/floor/plating/plating_catwalk/no_build,
+/area/space)
 "lIj" = (
 /turf/closed/wall/almayer,
 /area/almayer/maint/upper/mess)
@@ -71769,6 +72293,10 @@
 /obj/structure/platform_decoration/metal/almayer/north,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/upper/u_a_p)
+"lPh" = (
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/mono,
+/area/space)
 "lPm" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/wood/ship,
@@ -71943,6 +72471,10 @@
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/living/chapel)
+"lUc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_corner/north,
+/area/almayer/middeck/medical)
 "lUA" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/manifold/hidden/supply{
@@ -72080,14 +72612,7 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/u_a_p)
 "lYL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 9
-	},
-/turf/open/floor/almayer/dark_sterile,
+/turf/open/floor/almayer/plating_stripedcorner/east,
 /area/almayer/medical/upper_medical)
 "lYN" = (
 /obj/effect/decal/warning_stripes{
@@ -72222,6 +72747,13 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/living/gym)
+"mcW" = (
+/obj/structure/closet/secure_closet/guncabinet/red/armory_m39_submachinegun,
+/obj/structure/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/almayer/redfull,
+/area/space)
 "mdk" = (
 /obj/structure/machinery/door/poddoor/railing{
 	dir = 4;
@@ -72329,18 +72861,9 @@
 	},
 /area/almayer/squads/alpha)
 "mfC" = (
-/obj/structure/platform/metal/almayer/north,
-/obj/structure/platform/metal/almayer/west,
-/obj/structure/platform/metal/almayer/east,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/platform_decoration/metal/almayer/northeast{
-	layer = 4.1
-	},
-/obj/structure/platform_decoration/metal/almayer/northwest{
-	layer = 4.1
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/medical/upper_medical)
+/turf/open/floor/almayer/flooredge/southeast,
+/area/almayer/medical/morgue)
 "mfL" = (
 /obj/item/reagent_container/glass/bucket/janibucket{
 	pixel_x = -1;
@@ -72668,6 +73191,16 @@
 "mlm" = (
 /turf/open/floor/almayer/redfull,
 /area/almayer/living/cryo_cells)
+"mlq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/heavy_cable/cable_vertical,
+/obj/structure/largecrate/random/barrel/medical,
+/obj/structure/machinery/light/red{
+	light_color = "#BB3F3F";
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk/no_build,
+/area/space)
 "mlF" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -73168,8 +73701,9 @@
 /turf/open/floor/almayer/emerald,
 /area/almayer/squads/charlie)
 "mzq" = (
-/obj/structure/machinery/light,
-/turf/open/floor/almayer/sterile_green_side,
+/obj/structure/flora/bush/ausbushes/var3/stalkybush,
+/obj/structure/machinery/light/double/blue,
+/turf/open/floor/grass,
 /area/almayer/medical/upper_medical)
 "mzs" = (
 /obj/effect/decal/warning_stripes{
@@ -73807,18 +74341,19 @@
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/underdeck/vehicle)
 "mMg" = (
-/obj/structure/platform/metal/almayer/north,
-/obj/structure/platform/metal/almayer/east,
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_22";
-	pixel_y = 6
+/obj/structure/stairs{
+	dir = 4;
+	icon_state = "ramptop"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/platform_decoration/metal/almayer/northwest{
-	layer = 4.1
+/obj/structure/machinery/door_control{
+	id = "CMO Shutters";
+	name = "\improper Office Privacy Shutters";
+	pixel_y = 24;
+	req_one_access_txt = "28";
+	pixel_x = 9
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/medical/upper_medical)
+/turf/open_space,
+/area/almayer/middeck/medical)
 "mMB" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -73842,6 +74377,16 @@
 	},
 /turf/open/floor/almayer/silver,
 /area/almayer/shipboard/brig/cic_hallway)
+"mNa" = (
+/obj/structure/machinery/status_display{
+	pixel_y = 32
+	},
+/obj/structure/flora/bush/ausbushes/var3/ppflowers{
+	name = "fake ppflowers";
+	desc = "Just like a real plant, but fake!"
+	},
+/turf/open/floor/grass,
+/area/space)
 "mNG" = (
 /obj/structure/sign/safety/stairs{
 	pixel_x = 15;
@@ -74398,6 +74943,15 @@
 	},
 /turf/open/floor/almayer/plating_striped/south,
 /area/almayer/engineering/lower/engine_core)
+"naf" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/structure/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/space)
 "nah" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -74473,6 +75027,12 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/living/gym)
+"nbj" = (
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/open/floor/almayer/sterile_green_side/northeast,
+/area/space)
 "nbu" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
@@ -75342,6 +75902,11 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/north2)
+"nuv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/heavy_cable/node_n_w,
+/turf/open/floor/plating/plating_catwalk/no_build,
+/area/space)
 "nux" = (
 /obj/structure/surface/table/gamblingtable,
 /obj/item/toy/deck,
@@ -75405,6 +75970,16 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_a_s)
+"nvK" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/device/flashlight/lamp{
+	pixel_y = 9;
+	layer = 2.96;
+	pixel_x = 3
+	},
+/obj/item/device/megaphone,
+/turf/open/floor/almayer/sterile_green_side/west,
+/area/almayer/middeck/medical)
 "nvM" = (
 /obj/structure/window/framed/almayer/white,
 /obj/structure/machinery/door/poddoor/shutters/almayer{
@@ -75766,6 +76341,18 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/starboard_umbilical)
+"nDj" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/device/flashlight/lamp/green{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/device/camera{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/turf/open/floor/almayer/sterile_green_side/southwest,
+/area/almayer/middeck/medical)
 "nDo" = (
 /turf/closed/wall/almayer/white,
 /area/almayer/medical/hydroponics)
@@ -75925,6 +76512,10 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_a_p)
+"nGU" = (
+/obj/structure/largecrate/random/barrel/medical,
+/turf/open/floor/plating/plating_catwalk/no_build,
+/area/almayer/middeck/medical)
 "nGY" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/almayer/cargo,
@@ -76763,7 +77354,7 @@
 /area/almayer/maint/hull/lower/l_a_s)
 "oap" = (
 /obj/structure/pipes/vents/scrubber,
-/turf/open/floor/almayer/dark_sterile2,
+/turf/open/floor/almayer/sterile_green_side/northwest,
 /area/almayer/medical/upper_medical)
 "oaw" = (
 /obj/structure/closet/firecloset,
@@ -77235,6 +77826,11 @@
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/lower)
+"ojs" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/device/flash,
+/turf/open/floor/almayer/sterile_green_side/west,
+/area/almayer/middeck/medical)
 "ojF" = (
 /obj/structure/machinery/cm_vending/clothing/tl/charlie{
 	density = 0;
@@ -77816,6 +78412,15 @@
 "osI" = (
 /turf/open/floor/almayer/orange,
 /area/almayer/engineering/lower/workshop)
+"osM" = (
+/obj/structure/machinery/photocopier{
+	layer = 2.9;
+	pixel_y = 8;
+	density = 0;
+	pixel_x = 0
+	},
+/turf/open/floor/almayer/sterile_green_side/east,
+/area/almayer/middeck/medical)
 "osQ" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -77929,6 +78534,16 @@
 "ovi" = (
 /turf/open/floor/almayer/orangecorner/east,
 /area/almayer/engineering/upper_engineering/port)
+"ovm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 9
+	},
+/turf/open/floor/almayer/dark_sterile,
+/area/space)
 "ovp" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/flora/pottedplant{
@@ -78177,6 +78792,18 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/u_a_p)
+"oAY" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	name = "General Listening Channel";
+	pixel_y = -28;
+	pixel_x = 1
+	},
+/turf/open/floor/almayer/sterile_green_side,
+/area/space)
 "oBq" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal7";
@@ -78861,6 +79488,10 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/command/lifeboat)
+"oOU" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/floor/almayer/mono,
+/area/space)
 "oOW" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/junction{
@@ -79028,6 +79659,10 @@
 /obj/item/clipboard,
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/lower/workshop)
+"oSg" = (
+/obj/structure/pipes/standard/manifold/hidden/supply,
+/turf/open/floor/almayer/flooredge/northeast,
+/area/space)
 "oSq" = (
 /obj/item/device/radio/intercom{
 	freerange = 1;
@@ -79098,6 +79733,19 @@
 /obj/structure/platform/metal/almayer/west,
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/underdeck/req)
+"oTc" = (
+/obj/structure/machinery/shower{
+	pixel_y = 16
+	},
+/obj/item/tool/soap{
+	pixel_x = 3;
+	pixel_y = 1
+	},
+/obj/structure/machinery/door/window/westright{
+	dir = 2
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/space)
 "oTe" = (
 /obj/item/prop/almayer/box,
 /obj/item/prop{
@@ -79177,6 +79825,15 @@
 	},
 /turf/open/floor/almayer/no_build,
 /area/almayer/stair_clone/lower/port_fore)
+"oVl" = (
+/obj/structure/toilet{
+	dir = 8;
+	layer = 2.9;
+	pixel_y = 8
+	},
+/obj/structure/machinery/light/small,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/middeck/medical)
 "oVo" = (
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/upper/u_a_s)
@@ -79446,6 +80103,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer/plate,
 /area/almayer/living/captain_mess)
+"pbr" = (
+/obj/structure/pipes/vents/pump{
+	dir = 4
+	},
+/turf/open/floor/almayer/mono,
+/area/space)
 "pbs" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4;
@@ -79823,6 +80486,20 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/upper/fore_hallway)
+"plL" = (
+/obj/structure/bookcase{
+	icon_state = "book-5";
+	pixel_x = -1;
+	pixel_y = 19;
+	density = 0;
+	opacity = 0
+	},
+/obj/structure/sign/safety/bathunisex{
+	pixel_x = 32;
+	pixel_y = -5
+	},
+/turf/open/floor/almayer/flooredge/south,
+/area/space)
 "pmd" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer/plate,
@@ -80534,18 +81211,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/offices/cryo)
 "pGK" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_29";
-	pixel_y = 3;
-	pixel_x = -4
-	},
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/almayer/flooredge/southeast,
+/turf/open/floor/almayer/sterile_green_corner/east,
 /area/almayer/medical/upper_medical)
 "pGT" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -80661,6 +81327,18 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
+"pIX" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/machinery/door/airlock/almayer/white{
+	name = "\improper CMO's Bedroom";
+	req_one_access = list(28,206,207);
+	req_one_access_txt = "1;5"
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/space)
 "pIZ" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -80669,14 +81347,7 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/lifeboat_pumps/north1)
 "pJl" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	pixel_x = 1
-	},
-/obj/structure/machinery/light{
-	dir = 1
-	},
-/obj/structure/reagent_dispensers/tank/water,
+/obj/structure/closet/emcloset,
 /turf/open/floor/almayer/cargo,
 /area/almayer/medical/upper_medical)
 "pJr" = (
@@ -80865,11 +81536,11 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/command/cichallway)
 "pNP" = (
-/obj/structure/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/structure/closet/secure_closet/guncabinet/red/armory_shotgun,
+/obj/structure/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/almayer/sterile_green_corner/west,
+/turf/open/floor/almayer/redfull,
 /area/almayer/medical/upper_medical)
 "pOi" = (
 /obj/structure/disposalpipe/segment,
@@ -81624,6 +82295,13 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/upper/midship_hallway)
+"qdM" = (
+/obj/structure/pipes/vents/pump{
+	dir = 4
+	},
+/obj/structure/platform_decoration/metal/almayer/east,
+/turf/open/floor/almayer/mono,
+/area/space)
 "qdQ" = (
 /obj/structure/bed/sofa/vert/grey/top,
 /turf/open/floor/almayer,
@@ -81662,6 +82340,18 @@
 /obj/structure/pipes/vents/scrubber/no_boom,
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/upper_engineering/port)
+"qeU" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	layer = 3.3
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/structure/barricade/handrail/no_vault,
+/turf/open/floor/almayer/no_build/plate,
+/area/space)
 "qeY" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/toy/beach_ball/holoball,
@@ -81931,6 +82621,21 @@
 /obj/effect/landmark/late_join/charlie,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/charlie)
+"qkB" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 1
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 2
+	},
+/obj/structure/machinery/door/airlock/almayer/medical/glass{
+	dir = 2;
+	name = "\improper Psychiatric Care Unit";
+	req_one_access = null;
+	req_access = null
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/space)
 "qkP" = (
 /obj/item/frame/light_fixture{
 	anchored = 1;
@@ -84106,6 +84811,12 @@
 "rdA" = (
 /turf/open/floor/almayer/red/south,
 /area/almayer/shipboard/brig/perma)
+"rdB" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_21"
+	},
+/turf/open/floor/almayer/sterile_green_corner/east,
+/area/almayer/middeck/medical)
 "rdI" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/technology_scanner,
@@ -84348,6 +85059,21 @@
 	},
 /turf/open/floor/almayer/plating_striped/north,
 /area/almayer/shipboard/stern_point_defense)
+"rjj" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	layer = 3.3
+	},
+/obj/structure/largecrate/random/barrel/medical,
+/obj/structure/barricade/handrail/no_vault{
+	dir = 1
+	},
+/turf/open/floor/almayer/no_build/plate,
+/area/space)
 "rjn" = (
 /obj/structure/machinery/light,
 /obj/structure/reagent_dispensers/water_cooler/stacks,
@@ -84727,16 +85453,10 @@
 /area/almayer/living/bridgebunks)
 "rrD" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "NE-out";
-	pixel_y = 1;
-	pixel_x = 1
+	icon_state = "N";
+	pixel_y = 2
 	},
-/obj/structure/machinery/status_display{
-	pixel_y = 32;
-	pixel_x = -2
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/sterile_green_side/north,
+/turf/open/floor/almayer/sterile_green_side/northeast,
 /area/almayer/medical/upper_medical)
 "rrK" = (
 /obj/structure/filingcabinet{
@@ -84904,6 +85624,13 @@
 /obj/structure/reagent_dispensers/tank/water,
 /turf/open/floor/almayer/cargo,
 /area/almayer/hallways/hangar)
+"ruC" = (
+/obj/structure/flora/bush/ausbushes/lavendergrass{
+	name = "fake lavendergrass";
+	desc = "Just like a real plant, but fake!"
+	},
+/turf/open/floor/grass,
+/area/space)
 "ruL" = (
 /obj/structure/window/framed/almayer/hull/hijack_bustable,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -85405,15 +86132,17 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/hangar)
 "rHz" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	name = "ship-grade camera"
+/obj/structure/morgue{
+	dir = 2
 	},
-/obj/structure/flora/bush/ausbushes/var3/fullgrass{
-	desc = "Just like a real plant, but fake!";
-	name = "fake fullgrass"
+/obj/structure/machinery/light/small/blue{
+	dir = 1
 	},
-/turf/open/floor/grass,
-/area/almayer/medical/upper_medical)
+/obj/effect/decal/warning_stripes{
+	icon_state = "test_square_smooth"
+	},
+/turf/open/floor/almayer/plate,
+/area/almayer/medical/morgue)
 "rHB" = (
 /obj/item/ammo_box/magazine/misc/mre/empty{
 	pixel_x = 8;
@@ -85727,6 +86456,10 @@
 /obj/structure/largecrate/random/barrel/true_random,
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/underdeck/hangar)
+"rNZ" = (
+/obj/structure/pipes/vents/scrubber,
+/turf/open/floor/almayer/dark_sterile2,
+/area/space)
 "rOc" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -86047,6 +86780,11 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/cic_hallway)
+"rTo" = (
+/obj/structure/closet/secure_closet/CMO,
+/obj/item/clothing/accessory/stethoscope,
+/turf/open/floor/almayer/flooredge/south,
+/area/space)
 "rTJ" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
 /turf/open/floor/almayer/plate,
@@ -86483,15 +87221,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/vehiclehangar)
 "sdn" = (
-/obj/structure/morgue{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "test_square_smooth"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/plate,
-/area/almayer/medical/morgue)
+/turf/closed/wall/almayer/white,
+/area/space)
 "sdu" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -87014,6 +87745,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plate,
 /area/almayer/command/cic)
+"sos" = (
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/dark_sterile,
+/area/space)
 "sov" = (
 /turf/open/floor/almayer/orange/north,
 /area/almayer/engineering/lower/engine_core)
@@ -87851,6 +88589,9 @@
 /obj/structure/mirror,
 /turf/closed/wall/almayer,
 /area/almayer/living/gym)
+"sGW" = (
+/turf/open/floor/grass,
+/area/space)
 "sGZ" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer/silverfull,
@@ -88344,6 +89085,13 @@
 	},
 /turf/open/floor/almayer/plating,
 /area/almayer/shipboard/brig/yard)
+"sVj" = (
+/obj/structure/platform/metal/almayer/west,
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
+/turf/open/floor/almayer/mono,
+/area/space)
 "sVv" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/red/north,
@@ -89264,11 +90012,27 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/hallways/lower/starboard_fore_hallway)
 "tpa" = (
-/obj/structure/closet/secure_closet/personal/cabinet{
-	req_access_txt = "5"
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/paper_bin/wy{
+	pixel_y = 8;
+	pixel_x = -6
 	},
-/turf/open/floor/almayer/flooredge/north,
-/area/almayer/medical/upper_medical)
+/obj/item/tool/stamp/cmo{
+	pixel_x = 8;
+	pixel_y = -3;
+	name = "Chief Medical Officer's rubber stamp"
+	},
+/obj/item/tool/pen{
+	pixel_y = 3;
+	pixel_x = -6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/hand_labeler{
+	pixel_x = 8;
+	pixel_y = 13
+	},
+/turf/open/floor/almayer/sterile_green_side/east,
+/area/almayer/middeck/medical)
 "tpd" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 4
@@ -89443,16 +90207,8 @@
 /turf/open/floor/almayer/bluefull,
 /area/almayer/command/cicconference)
 "tsC" = (
-/obj/structure/reagent_dispensers/water_cooler/stacks{
-	pixel_y = 6;
-	pixel_x = -8;
-	density = 0
-	},
-/obj/structure/machinery/light/double/blue{
-	light_color = "#a7dbc7"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/sterile_green_corner/west,
+/obj/structure/foamed_metal/iron,
+/turf/open/floor/plating,
 /area/almayer/medical/upper_medical)
 "tsE" = (
 /obj/structure/largecrate/random/barrel/blue,
@@ -89903,8 +90659,13 @@
 /turf/open/floor/almayer/plating_stripedcorner/west,
 /area/almayer/engineering/lower/workshop/hangar)
 "tEi" = (
-/obj/structure/pipes/standard/manifold/hidden/supply,
-/turf/open/floor/almayer/dark_sterile,
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/alarm/almayer{
+	dir = 1
+	},
+/turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/upper_medical)
 "tEu" = (
 /obj/structure/machinery/disposal,
@@ -90290,17 +91051,11 @@
 /turf/open/floor/almayer,
 /area/almayer/squads/alpha)
 "tOr" = (
-/obj/structure/machinery/computer/cameras/containment{
-	name = "Research Cameras";
-	pixel_y = 1;
-	pixel_x = 2
+/obj/structure/flora/bush/ausbushes/var3/brflowers{
+	name = "fake brflowers";
+	desc = "Just like a real plant, but fake!"
 	},
-/obj/structure/machinery/computer/research/main_terminal{
-	pixel_y = 1;
-	pixel_x = -15
-	},
-/obj/structure/surface/table/reinforced/prison,
-/turf/open/floor/almayer/dark_sterile,
+/turf/open/floor/grass,
 /area/almayer/medical/upper_medical)
 "tOu" = (
 /obj/structure/surface/table/reinforced/almayer_B,
@@ -90622,12 +91377,9 @@
 /turf/open/floor/almayer/silver,
 /area/almayer/hallways/lower/repair_bay)
 "tWY" = (
-/obj/structure/closet/secure_closet/guncabinet/red/armory_shotgun,
-/obj/structure/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/almayer/redfull,
-/area/almayer/medical/upper_medical)
+/obj/effect/decal/heavy_cable/cable_vertical,
+/turf/open/floor/plating/plating_catwalk/no_build,
+/area/space)
 "tXa" = (
 /obj/structure/largecrate/supply/weapons/m39{
 	pixel_x = 2
@@ -91276,6 +92028,16 @@
 "uiT" = (
 /turf/open/floor/almayer/orange/north,
 /area/almayer/hallways/hangar)
+"uiW" = (
+/obj/structure/closet/secure_closet/personal/cabinet{
+	req_access_txt = "5"
+	},
+/obj/structure/sign/safety/bathunisex{
+	pixel_x = 2;
+	pixel_y = 29
+	},
+/turf/open/floor/almayer/flooredge/northeast,
+/area/almayer/middeck/medical)
 "uiZ" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/comdoor/reinforced{
 	dir = 1;
@@ -91366,6 +92128,14 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/cargo_arrow,
 /area/almayer/living/offices)
+"umh" = (
+/obj/structure/machinery/photocopier{
+	layer = 2.9;
+	pixel_y = 16;
+	density = 0
+	},
+/turf/open/floor/almayer/sterile_green_side/north,
+/area/space)
 "umk" = (
 /obj/structure/machinery/light/red{
 	light_color = "#BB3F3F";
@@ -91451,15 +92221,8 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_a_s)
 "uol" = (
-/obj/structure/machinery/status_display{
-	pixel_x = 32
-	},
-/obj/structure/flora/bush/ausbushes/var3/fullgrass{
-	desc = "Just like a real plant, but fake!";
-	name = "fake fullgrass"
-	},
-/turf/open/floor/grass,
-/area/almayer/medical/upper_medical)
+/turf/closed/wall/almayer/outer/internal,
+/area/almayer/middeck/medical)
 "uoA" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 5
@@ -91480,18 +92243,7 @@
 /turf/open/floor/plating/plating_catwalk/no_build,
 /area/almayer/underdeck/hangar)
 "upM" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 1
-	},
-/obj/structure/machinery/door/firedoor/border_only/almayer{
-	dir = 2
-	},
-/obj/structure/machinery/door/airlock/almayer/medical/glass{
-	dir = 2;
-	name = "\improper Psychiatric Care Unit";
-	req_one_access = null;
-	req_access = null
-	},
+/obj/structure/stairs/multiz/down,
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/upper_medical)
 "upO" = (
@@ -91994,6 +92746,21 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/hangar)
+"uAd" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 16
+	},
+/obj/structure/machinery/light/red{
+	light_color = "#BB3F3F";
+	dir = 1
+	},
+/turf/open/floor/almayer/no_build/plating,
+/area/almayer/middeck/medical)
 "uAj" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -92286,6 +93053,13 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/medical/morgue)
+"uGD" = (
+/obj/structure/machinery/door/airlock/almayer/white{
+	dir = 2;
+	name = "\improper Bathroom"
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/middeck/medical)
 "uGQ" = (
 /obj/structure/machinery/suit_storage_unit/compression_suit/uscm,
 /turf/open/floor/almayer/plate,
@@ -93226,6 +94000,29 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/hangar)
+"vbk" = (
+/obj/structure/sign/safety/terminal{
+	pixel_x = 7;
+	pixel_y = -26
+	},
+/obj/structure/transmitter/rotary{
+	name = "CMO Office Telephone";
+	phone_category = "Offices";
+	phone_id = "CMO Office";
+	pixel_y = 20;
+	pixel_x = 6
+	},
+/obj/item/ashtray/plastic{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/structure/sign/safety/intercom{
+	pixel_y = -26;
+	pixel_x = 21
+	},
+/obj/structure/surface/table/reinforced/prison,
+/turf/open/floor/almayer/sterile_green_side,
+/area/space)
 "vbB" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/lifeboat_pumps/south1)
@@ -93446,11 +94243,9 @@
 /turf/closed/wall/almayer/outer,
 /area/almayer/engineering/lower)
 "vgx" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/open/floor/almayer/sterile_green_side/northwest,
-/area/almayer/medical/upper_medical)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/middeck/medical)
 "vgB" = (
 /obj/structure/window/framed/almayer/white,
 /obj/structure/machinery/door/firedoor/border_only/almayer,
@@ -93998,6 +94793,20 @@
 /obj/structure/machinery/power/apc/almayer/west,
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/engineering/laundry)
+"vqM" = (
+/obj/structure/surface/table/reinforced/almayer_B,
+/obj/item/device/flashlight/lamp{
+	pixel_y = 11;
+	pixel_x = 5
+	},
+/obj/item/device/megaphone,
+/obj/item/device/flash,
+/obj/item/clothing/glasses/science{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/almayer/flooredge/north,
+/area/space)
 "vqY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
@@ -94584,28 +95393,25 @@
 /turf/open/floor/almayer/green,
 /area/almayer/squads/req)
 "vCk" = (
-/obj/structure/sign/safety/terminal{
-	pixel_x = 7;
-	pixel_y = -26
+/obj/structure/surface/rack,
+/obj/item/clothing/suit/storage/marine/light/vest{
+	pixel_x = -4;
+	pixel_y = 2
 	},
-/obj/structure/transmitter/rotary{
-	name = "CMO Office Telephone";
-	phone_category = "Offices";
-	phone_id = "CMO Office";
-	pixel_y = 20;
-	pixel_x = 6
+/obj/item/clothing/suit/storage/marine/light/vest{
+	pixel_y = 2;
+	pixel_x = 5
 	},
-/obj/item/ashtray/plastic{
-	pixel_x = -5;
-	pixel_y = -3
+/obj/item/clothing/suit/storage/marine/light/vest{
+	pixel_y = -5;
+	pixel_x = 5
 	},
-/obj/structure/sign/safety/intercom{
-	pixel_y = -26;
-	pixel_x = 21
+/obj/item/clothing/suit/storage/marine/light/vest{
+	pixel_x = -4;
+	pixel_y = -5
 	},
-/obj/structure/surface/table/reinforced/prison,
-/turf/open/floor/almayer/sterile_green_side,
-/area/almayer/medical/upper_medical)
+/turf/open/floor/almayer/redfull,
+/area/space)
 "vCt" = (
 /obj/structure/sign/safety/storage{
 	pixel_x = 7;
@@ -94654,11 +95460,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/bridgebunks)
 "vDa" = (
-/obj/structure/bed/chair/office/light{
-	dir = 4
-	},
-/turf/open/floor/almayer/sterile_green_side,
-/area/almayer/medical/upper_medical)
+/obj/structure/bed,
+/obj/item/bedsheet/green,
+/turf/open/floor/almayer/flooredge/northwest,
+/area/space)
 "vDd" = (
 /obj/structure/window/framed/almayer/hull/hijack_bustable,
 /obj/structure/machinery/door/poddoor/shutters/almayer/open{
@@ -95054,6 +95859,19 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/lower/repair_bay)
+"vLs" = (
+/obj/structure/machinery/computer/cameras/containment{
+	name = "Research Cameras";
+	pixel_y = 1;
+	pixel_x = 2
+	},
+/obj/structure/machinery/computer/research/main_terminal{
+	pixel_y = 1;
+	pixel_x = -15
+	},
+/obj/structure/surface/table/reinforced/prison,
+/turf/open/floor/almayer/dark_sterile,
+/area/space)
 "vLA" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W";
@@ -95727,6 +96545,16 @@
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/port_missiles)
+"vZE" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out"
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/machinery/door/airlock/almayer/white{
+	name = "\improper Bathroom"
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/space)
 "vZI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -95747,6 +96575,16 @@
 	},
 /turf/open/floor/almayer/green/southeast,
 /area/almayer/hallways/upper/fore_hallway)
+"vZY" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/machinery/faxmachine/uscm/almayer{
+	pixel_x = -3;
+	pixel_y = 5;
+	sub_name = "Chief Medical Officer"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_side/east,
+/area/almayer/middeck/medical)
 "wab" = (
 /obj/vehicle/powerloader{
 	dir = 4
@@ -95874,6 +96712,10 @@
 	},
 /turf/open/floor/almayer/silver/north,
 /area/almayer/command/cic)
+"wcl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_side/west,
+/area/almayer/middeck/medical)
 "wcm" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out";
@@ -96027,10 +96869,28 @@
 	},
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/underdeck/hangar)
+"weH" = (
+/obj/structure/coatrack{
+	pixel_x = -8;
+	pixel_y = 15
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/sign/catclock{
+	pixel_y = 28;
+	pixel_x = 7
+	},
+/turf/open/floor/almayer/sterile_green_corner/north,
+/area/space)
 "weR" = (
 /obj/structure/machinery/cryopod,
 /turf/open/floor/almayer/cargo,
 /area/almayer/living/offices/cryo)
+"weW" = (
+/obj/structure/machinery/light,
+/turf/open/floor/almayer/sterile_green_side,
+/area/space)
 "weX" = (
 /obj/structure/surface/rack{
 	layer = 3;
@@ -96086,6 +96946,12 @@
 	},
 /turf/open/floor/almayer/silver/east,
 /area/almayer/command/cichallway)
+"wgy" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "SW-out"
+	},
+/turf/closed/wall/almayer/white,
+/area/space)
 "wgO" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -96221,27 +97087,8 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/hallways/lower/vehiclehangar)
 "wiW" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/filingcabinet/filingcabinet{
-	density = 0;
-	pixel_x = 7;
-	pixel_y = 16
-	},
-/obj/structure/filingcabinet/filingcabinet{
-	density = 0;
-	pixel_x = -8;
-	pixel_y = 16
-	},
-/obj/item/folder/blue{
-	pixel_y = 5
-	},
-/obj/item/folder/white,
-/obj/item/folder/black,
-/obj/item/folder/black,
-/obj/item/clipboard,
-/turf/open/floor/almayer/sterile_green_corner,
+/obj/structure/pipes/vents/scrubber,
+/turf/open/floor/almayer/sterile_green_corner/west,
 /area/almayer/medical/upper_medical)
 "wjq" = (
 /obj/structure/bed/chair/comfy/beige{
@@ -96747,8 +97594,13 @@
 /turf/open/floor/almayer,
 /area/almayer/shipboard/brig/visitation_waiting)
 "wub" = (
-/obj/structure/pipes/vents/pump{
-	dir = 4
+/obj/structure/platform/metal/almayer/north{
+	dir = 2
+	},
+/obj/structure/platform/metal/almayer/east,
+/obj/structure/platform_decoration/metal/almayer/northwest{
+	layer = 4.1;
+	dir = 6
 	},
 /turf/open/floor/almayer/mono,
 /area/almayer/medical/upper_medical)
@@ -96872,6 +97724,10 @@
 	},
 /turf/open/floor/almayer/silvercorner/east,
 /area/almayer/shipboard/brig/visitation_waiting)
+"wvO" = (
+/obj/structure/pipes/vents/scrubber,
+/turf/open/floor/almayer/mono,
+/area/space)
 "wvU" = (
 /obj/structure/surface/rack,
 /obj/item/reagent_container/spray/cleaner{
@@ -97479,12 +98335,10 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/shipboard/brig/general_equipment)
 "wJo" = (
-/obj/structure/flora/bush/ausbushes/lavendergrass{
-	name = "fake lavendergrass";
-	desc = "Just like a real plant, but fake!"
-	},
-/turf/open/floor/grass,
-/area/almayer/medical/upper_medical)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/light/small/blue,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/medical/morgue)
 "wJC" = (
 /obj/structure/largecrate/random/barrel/yellow,
 /turf/open/floor/plating/plating_catwalk,
@@ -97696,6 +98550,10 @@
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/living/auxiliary_officer_office)
+"wMx" = (
+/obj/structure/machinery/computer/crew,
+/turf/open/floor/almayer/sterile_green_corner/east,
+/area/space)
 "wMB" = (
 /obj/structure/barricade/handrail{
 	dir = 1;
@@ -97839,6 +98697,10 @@
 "wQD" = (
 /turf/open/floor/almayer/orange/southeast,
 /area/almayer/engineering/lower/engine_core)
+"wQH" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer/sterile_green_corner/north,
+/area/almayer/medical/upper_medical)
 "wQI" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/emails{
@@ -98284,6 +99146,9 @@
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor/almayer_hull/outerhull_dir/east,
 /area/almayer/engineering/upper_engineering/port)
+"wZH" = (
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/medical/upper_medical)
 "wZL" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/secure_data{
@@ -98432,6 +99297,13 @@
 	},
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/underdeck/hangar)
+"xcG" = (
+/obj/structure/coatrack{
+	pixel_x = -11;
+	pixel_y = 2
+	},
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/middeck/medical)
 "xcV" = (
 /obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/almayer/cargo,
@@ -98443,6 +99315,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/port_midship_hallway)
+"xdy" = (
+/obj/structure/closet/secure_closet/professor_dummy{
+	pixel_y = 32
+	},
+/turf/open/floor/almayer/sterile_green_side/north,
+/area/space)
 "xdA" = (
 /obj/structure/surface/rack{
 	density = 0;
@@ -98479,16 +99357,8 @@
 /turf/open/floor/almayer/emeraldfull,
 /area/almayer/living/briefing)
 "xdS" = (
-/obj/structure/platform/metal/almayer/north,
-/obj/structure/platform/metal/almayer/east,
-/obj/structure/platform_decoration/metal/almayer/northwest{
-	layer = 4.1
-	},
-/obj/structure/bed/chair/comfy{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/medical/upper_medical)
+/turf/open_space,
+/area/space)
 "xee" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4;
@@ -98547,6 +99417,12 @@
 /obj/structure/platform/metal/almayer/east,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/u_a_p)
+"xfd" = (
+/obj/structure/closet/secure_closet/personal/cabinet{
+	req_access_txt = "5"
+	},
+/turf/open/floor/almayer/flooredge/north,
+/area/space)
 "xfm" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -98570,6 +99446,14 @@
 /obj/structure/platform_decoration/metal/almayer/southeast,
 /turf/open/floor/almayer/red/southeast,
 /area/almayer/lifeboat_pumps/south1)
+"xfJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/heavy_cable/cable_vertical,
+/obj/structure/machinery/light/red{
+	light_color = "#BB3F3F"
+	},
+/turf/open/floor/plating/plating_catwalk/no_build,
+/area/space)
 "xfK" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -98710,6 +99594,13 @@
 /obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_f_s)
+"xiL" = (
+/obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
+	name = "\improper Psychiatric Care Unit";
+	req_access = list()
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/medical/upper_medical)
 "xiP" = (
 /obj/structure/closet/secure_closet/engineering_welding{
 	req_one_access_txt = "7;23;27"
@@ -99089,6 +99980,21 @@
 	},
 /turf/open/floor/almayer/red/east,
 /area/almayer/shipboard/brig/visitation)
+"xrw" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	layer = 3.3
+	},
+/obj/structure/barricade/handrail/no_vault{
+	dir = 1
+	},
+/obj/structure/largecrate/random/barrel/medical,
+/turf/open/floor/almayer/no_build/plate,
+/area/space)
 "xry" = (
 /obj/structure/window/reinforced/toughened{
 	dir = 4;
@@ -99187,6 +100093,21 @@
 /obj/structure/machinery/light,
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/port_aft_hallway)
+"xuo" = (
+/obj/item/toy/plush/therapy/random_color{
+	pixel_y = 2;
+	pixel_x = 2
+	},
+/obj/structure/platform/metal/almayer/north,
+/obj/structure/platform/metal/almayer/west,
+/obj/structure/platform_decoration/metal/almayer/northeast{
+	layer = 4.1
+	},
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/space)
 "xuy" = (
 /obj/structure/machinery/status_display{
 	pixel_x = 32
@@ -99459,28 +100380,16 @@
 /turf/open/floor/almayer/silver/east,
 /area/almayer/hallways/upper/midship_hallway)
 "xyt" = (
-/obj/item/paper_bin/wy{
-	pixel_y = 8;
-	pixel_x = -6
+/obj/structure/platform/metal/almayer/west,
+/obj/structure/bed/chair/comfy{
+	dir = 4
 	},
-/obj/item/tool/pen{
-	pixel_y = 3;
-	pixel_x = -6
+/obj/structure/machinery/light/double/blue{
+	light_color = "#a7dbc7";
+	dir = 1
 	},
-/obj/item/tool/stamp/cmo{
-	pixel_x = 9;
-	pixel_y = 10;
-	name = "Chief Medical Officer's rubber stamp"
-	},
-/obj/structure/machinery/door_control{
-	id = "CMO Shutters";
-	name = "\improper Office Privacy Shutters";
-	pixel_y = -1;
-	req_one_access_txt = "28";
-	pixel_x = 9
-	},
-/obj/structure/surface/table/reinforced/prison,
-/turf/open/floor/almayer/sterile_green_side/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/mono,
 /area/almayer/medical/upper_medical)
 "xyw" = (
 /turf/open/floor/almayer/plate,
@@ -99540,6 +100449,12 @@
 "xzh" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/upper/u_m_p)
+"xzy" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/middeck/medical)
 "xzB" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_f_s)
@@ -100191,15 +101106,12 @@
 /turf/open/floor/almayer/no_build/test_floor4,
 /area/almayer/underdeck/req)
 "xNu" = (
-/obj/structure/machinery/status_display{
-	pixel_y = 32
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	layer = 3.3
 	},
-/obj/structure/flora/bush/ausbushes/var3/ppflowers{
-	name = "fake ppflowers";
-	desc = "Just like a real plant, but fake!"
-	},
-/turf/open/floor/grass,
-/area/almayer/medical/upper_medical)
+/turf/closed/wall/almayer/reinforced,
+/area/almayer/middeck/medical)
 "xNv" = (
 /obj/structure/platform/metal/almayer/north,
 /obj/structure/machinery/light{
@@ -100512,6 +101424,10 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/silver,
 /area/almayer/command/cic)
+"xUE" = (
+/obj/structure/machinery/light,
+/turf/open/floor/almayer/flooredge/south,
+/area/almayer/middeck/medical)
 "xUV" = (
 /turf/open/floor/almayer/silver,
 /area/almayer/command/combat_correspondent)
@@ -100888,16 +101804,11 @@
 /turf/open/floor/almayer/no_build,
 /area/almayer/stair_clone/lower/port_fore)
 "ydE" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/platform/metal/almayer/north{
+	dir = 2
 	},
-/obj/structure/machinery/door/firedoor/border_only/almayer,
-/obj/structure/machinery/door/airlock/almayer/white{
-	name = "\improper CMO's Bedroom";
-	req_one_access = list(28,206,207);
-	req_one_access_txt = "1;5"
-	},
-/turf/open/floor/almayer/test_floor4,
+/turf/open/floor/almayer/mono,
 /area/almayer/medical/upper_medical)
 "ydI" = (
 /obj/effect/decal/warning_stripes{
@@ -101155,17 +102066,18 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/command/cic)
 "yjb" = (
-/obj/structure/platform/metal/almayer/north,
-/obj/structure/platform/metal/almayer/west,
-/obj/structure/platform_decoration/metal/almayer/northeast{
-	layer = 4.1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	layer = 3.3
 	},
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_22";
-	pixel_y = 6
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/medical/upper_medical)
+/obj/structure/barricade/handrail/no_vault,
+/turf/open/floor/almayer/no_build/plate,
+/area/space)
 "yjq" = (
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	icon_state = "almayer_pdoor";
@@ -173773,15 +174685,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tWY
+yjb
+jeq
+xdS
+xdS
+xdS
+cdS
+xrw
+tWY
 aaa
 aaa
 aaa
@@ -173876,15 +174788,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tWY
+yjb
+jeq
+xdS
+xdS
+xdS
+cdS
+rjj
+ceT
 bdH
 aaa
 aaa
@@ -173979,15 +174891,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tWY
+yjb
+jeq
+xdS
+xdS
+xdS
+cdS
+kVj
+ceT
 bdH
 aaa
 aaa
@@ -174082,15 +174994,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tWY
+qeU
+jeq
+xdS
+xdS
+xdS
+cdS
+kVj
+ceT
 aaa
 aaa
 aaa
@@ -174185,15 +175097,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tWY
+qeU
+jeq
+xdS
+xdS
+xdS
+cdS
+kVj
+ceT
 aaa
 aaa
 aaa
@@ -174288,15 +175200,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+mlq
+qeU
+jeq
+xdS
+xdS
+xdS
+cdS
+ceU
+xfJ
 aaa
 aaa
 aaa
@@ -174391,15 +175303,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lHI
+yjb
+jeq
+xdS
+xdS
+xdS
+cdS
+ceU
+ceT
 bdH
 aaa
 bdH
@@ -174494,15 +175406,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lHI
+yjb
+jeq
+xdS
+xdS
+xdS
+cdS
+ceU
+tWY
 bdH
 aaa
 bdH
@@ -174597,15 +175509,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ceT
+yjb
+jeq
+xdS
+xdS
+xdS
+cdS
+ceU
+tWY
 bdH
 aaa
 bdH
@@ -174700,15 +175612,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ceT
+yjb
+jeq
+xdS
+xdS
+xdS
+cdS
+anq
+jFo
 bdH
 bdH
 bdH
@@ -174803,15 +175715,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+nuv
+yjb
+jeq
+xdS
+xdS
+xdS
+cdS
+ceU
+dnb
 bdH
 bdH
 bdH
@@ -177012,8 +177924,8 @@ aPM
 aPd
 aHE
 bmV
-beB
-beB
+bWm
+bWm
 aOD
 bdB
 aHQ
@@ -177107,15 +178019,15 @@ aJA
 bih
 avN
 bWm
-bnn
+bWm
 bmU
-aHE
-aHE
+cbk
+cbk
 bmU
-aHE
-beB
+cbk
+bWm
 bmV
-bdu
+bWm
 bWm
 avN
 aIb
@@ -177210,15 +178122,15 @@ aIA
 avN
 avN
 avN
-bGT
-bhD
 avN
 avN
 avN
 avN
 avN
-bnY
-bGp
+avN
+avN
+avN
+avN
 avN
 avN
 avN
@@ -177313,15 +178225,15 @@ bns
 blH
 avN
 avN
-baF
-bZq
-aOl
 aOY
 aOY
 aOY
-aOx
-bXJ
-baF
+aOY
+aOY
+aOY
+aOY
+aOY
+aOY
 avN
 avN
 blO
@@ -177416,18 +178328,18 @@ caX
 blH
 avN
 avN
-baF
-bZq
-aOl
 aOY
 aOY
 aOY
-aOx
+aOY
+aOY
+aOY
+avN
 bXK
-baC
-avN
-avN
-blO
+bXK
+uol
+uol
+uAd
 bcO
 bWs
 avN
@@ -177519,17 +178431,17 @@ bns
 blH
 caw
 avN
-baF
-bZq
-aOl
 aOY
 aOY
 aOY
-aOx
-bXL
-baC
-avN
-aUO
+aOY
+aOY
+aOY
+kEp
+lUc
+kMI
+lgA
+bec
 blO
 bcO
 bcj
@@ -177596,7 +178508,7 @@ bGi
 bGi
 aWj
 bnV
-aWi
+imk
 bzC
 bzi
 aJM
@@ -177622,17 +178534,17 @@ bnv
 blH
 bcj
 avN
-baF
-bZs
-aOl
 aOY
 aOY
 aOY
-aOx
+aOY
+aOY
+aOY
+kEp
 bXL
-baC
-avN
-bWV
+kmd
+lgA
+bec
 blO
 aSj
 aSc
@@ -177725,16 +178637,16 @@ bnv
 caL
 bcj
 avN
-baF
-bZs
-aOl
 aOY
 aOY
 aOY
-aOx
-bXL
-baC
+aOY
+aOY
+aOY
 avN
+bGr
+bXJ
+uol
 bec
 blP
 aSj
@@ -177828,14 +178740,14 @@ bnv
 blH
 cax
 avN
-bGV
 bZs
-aOl
-aOY
-aOY
-aOY
-aOx
-bXM
+bZs
+bZs
+bZs
+bZs
+dEM
+avN
+mMg
 bGr
 avN
 bwp
@@ -177926,20 +178838,20 @@ baF
 aOh
 baC
 avN
-aSc
+avN
 bGj
-blH
-bie
+xNu
+avN
 avN
 btP
-bZq
-aOl
-aOY
-aOY
-aOY
-aOx
+nvK
+cdW
+ojs
+aBd
+jDE
+avN
 bXM
-baC
+eIc
 avN
 bck
 blP
@@ -178030,19 +178942,19 @@ bnY
 bnY
 avN
 avN
-bGj
-blH
+avN
+hme
 aVP
 avN
-btP
+gbP
 bZq
-aOl
-aOY
-aOY
-aOY
-aOx
-bXM
-baF
+xzy
+vgx
+dSG
+nDj
+wcl
+dqr
+gzY
 avN
 bWW
 blP
@@ -178130,22 +179042,22 @@ bjj
 boD
 bbJ
 aOh
-cbn
-avN
-avN
-aIA
-avN
-avN
-avN
 baC
+avN
+bGV
+avN
+kol
+aLS
+dtQ
 bZq
-aOl
-aOY
-aOY
-aOY
-aOx
-bXM
-baF
+bZq
+vgx
+vgx
+bZq
+xcG
+vgx
+ceR
+ihH
 avN
 avN
 avN
@@ -178234,23 +179146,23 @@ boE
 aYN
 bxI
 aYN
-bWj
-bcP
-bcP
-bcP
-bcP
-bWj
-baC
+avN
+cOC
+uGD
+gFK
+xUE
+avN
+gKz
 bZq
-aOl
-aOY
-aOY
-aOY
-aOx
+bZq
+vgx
+hpL
+bZq
+ijq
 bXN
-aQm
-bWj
-bcP
+avN
+avN
+lwT
 bcP
 bcP
 bcP
@@ -178336,29 +179248,29 @@ bjm
 boE
 bjf
 bah
-baD
+baC
+avN
+oVl
+avN
+uiW
+kbn
+avN
+kwv
+vZY
+tpa
+osM
+avN
+kGa
+rdB
+avN
+avN
+avN
+nGU
+nGU
+iqw
+bWm
 bWj
-beB
-aPm
-beB
-beB
-bWj
-bna
-bZq
-aOl
-aOY
-aOY
-aOY
-aOx
-bXM
-bmS
-bWj
-beB
-beB
-aPm
-beB
-bWj
-bjf
+baC
 bah
 baE
 aZc
@@ -179109,12 +180021,12 @@ bwH
 bdH
 bdH
 bdH
-bdH
-bdH
-bdH
-bdH
-bdH
-bdH
+sdn
+sdn
+ceF
+bkT
+ceF
+iYf
 bdH
 aab
 aaa
@@ -179212,12 +180124,12 @@ bwH
 bdH
 bdH
 bdH
-bdH
-bdH
-bdH
-bdH
-bdH
-bdH
+sdn
+sdn
+weH
+ovm
+ceb
+iYf
 bdH
 aab
 aaa
@@ -179315,12 +180227,12 @@ bwH
 bdH
 bdH
 bdH
-bdH
-bdH
-bdH
-bdH
-bdH
-bdH
+sdn
+hxg
+drT
+ihu
+weW
+iYf
 bdH
 aab
 aaa
@@ -179418,12 +180330,12 @@ bdH
 bdH
 bdH
 bdH
-bdH
-bdH
-bdH
-bdH
-bdH
-bdH
+sdn
+xdy
+iGA
+cdw
+awQ
+iYf
 bdH
 aab
 aaa
@@ -179521,12 +180433,12 @@ bdH
 bdH
 bdH
 bdH
-bdH
-bdH
-bdH
-bdH
-bdH
-bdH
+sdn
+umh
+iGA
+dJX
+vbk
+iYf
 bdH
 aab
 aaa
@@ -179624,12 +180536,12 @@ bdH
 bdH
 bdH
 bdH
-bdH
-bdH
-bdH
-bdH
-bdH
-bdH
+sdn
+fuc
+iGA
+vLs
+oAY
+iYf
 bdH
 aab
 aaa
@@ -179727,12 +180639,12 @@ bdH
 bdH
 bdH
 bdH
-bdH
-bdH
-bdH
-bdH
-bdH
-bdH
+sdn
+dBh
+nbj
+rNZ
+weW
+iYf
 bdH
 aab
 aaa
@@ -179830,12 +180742,12 @@ bdH
 bdH
 bdH
 bdH
-bdH
-bdH
-bdH
-bdH
-bdH
-bdH
+sdn
+sdn
+dQk
+cYE
+wMx
+iYf
 bdH
 aab
 aaa
@@ -179933,12 +180845,12 @@ bdH
 bdH
 bdH
 bdH
-bdH
-bdH
-bdH
-bdH
-bdH
-bdH
+sdn
+sdn
+sdn
+pIX
+sdn
+iYf
 bdH
 aab
 aaa
@@ -180036,12 +180948,12 @@ bdH
 bdH
 bdH
 bdH
-bdH
-bdH
-bdH
-bdH
-bdH
-bdH
+sdn
+rTo
+chy
+oSg
+xfd
+iYf
 bdH
 aab
 aaa
@@ -180139,12 +181051,12 @@ bdH
 bdH
 bdH
 bdH
-bdH
-bdH
-bdH
-bdH
-bdH
-bdH
+sdn
+awj
+wvO
+pbr
+vqM
+iYf
 bdH
 aab
 aaa
@@ -180242,12 +181154,12 @@ bwH
 bdH
 bdH
 bdH
-bdH
-bdH
-bdH
-bdH
-bdH
-bdH
+sdn
+plL
+jjs
+vDa
+sdn
+iYf
 bdH
 aab
 aaa
@@ -180345,12 +181257,12 @@ bwH
 bwH
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sdn
+sdn
+vZE
+sdn
+iYf
+iYf
 aaa
 aab
 aaa
@@ -180448,12 +181360,12 @@ aIi
 bwH
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sdn
+oTc
+lEu
+naf
+iYf
+bdH
 aaa
 aab
 aaa
@@ -180551,12 +181463,12 @@ aJZ
 bwH
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sdn
+sdn
+sdn
+iYf
+iYf
+bdH
 aaa
 aab
 aaa
@@ -201793,11 +202705,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -201893,15 +202805,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+bdH
+sdn
+sdn
+sdn
+sdn
+sdn
+bdH
 aaa
 aaa
 aaa
@@ -201996,17 +202908,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+sdn
+sdn
+sdn
+aQZ
+iit
+dOU
+sdn
+sdn
+sdn
+bdH
 aaa
 aaa
 aaa
@@ -202099,17 +203011,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+sdn
+sdn
+dDY
+kqM
+xuo
+sVj
+qdM
+sdn
+sdn
+bdH
 aaa
 aaa
 aaa
@@ -202202,17 +203114,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+sdn
+ddN
+dOU
+fVJ
+lPh
+cfh
+iGA
+dtB
+sdn
+bdH
 aaa
 aaa
 aaa
@@ -202305,17 +203217,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
 bdH
+sdn
+mNa
+hLl
+csb
+hYA
+cdw
+sos
+fzO
+qkB
 bdH
-bdH
-bdH
-bdH
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -202408,17 +203320,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
 bdH
+sdn
+aQZ
+ruC
+kFH
+oOU
+cen
+bGT
+fPw
+sdn
 bdH
-bdH
-bdH
-bdH
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -202511,17 +203423,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
 bdH
+sdn
+sdn
+dya
+sGW
+fjL
+eHU
+aUO
+sdn
+sdn
 bdH
-bdH
-bdH
-bdH
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -202614,17 +203526,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
 bdH
 bdH
+sdn
+sdn
+ruC
+iMv
+ddN
+sdn
+sdn
 bdH
 bdH
-bdH
-bdH
-bdH
-bdH
-bdH
-aaa
 aaa
 aaa
 aaa
@@ -202717,16 +203629,16 @@ aaa
 aaa
 aaa
 aaa
+bdH
+bdH
+sdn
+iYf
+iYf
+iYf
+iYf
+wgy
+bdH
 aaa
-bdH
-bdH
-bdH
-bdH
-bdH
-bdH
-bdH
-bdH
-bdH
 aaa
 aaa
 aaa
@@ -202820,15 +203732,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bdH
+bdH
+iYf
+iYf
+efX
+vCk
+iYf
+iYf
+bdH
 aaa
 aaa
 aaa
@@ -202922,18 +203834,18 @@ bdH
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 bdH
 bdH
 bdH
+iYf
+mcW
+dBj
+bie
+cdx
+iYf
 bdH
 bdH
-aaa
-aaa
-aaa
+bdH
 aaa
 aaa
 aaa
@@ -203025,18 +203937,18 @@ bdH
 aaa
 aaa
 aaa
-aaa
 bdH
 bdH
 bdH
+iYf
+iYf
+cem
+cem
+iYf
+iYf
 bdH
 bdH
 bdH
-bdH
-bdH
-bdH
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -203128,7 +204040,7 @@ bdH
 aaa
 aaa
 aaa
-aaa
+bdH
 bdH
 bdH
 bdH
@@ -203231,7 +204143,7 @@ bdH
 aaa
 aaa
 aaa
-aaa
+bdH
 bdH
 bdH
 bdH
@@ -203334,7 +204246,7 @@ bdH
 aaa
 aaa
 aaa
-aaa
+bdH
 bdH
 bdH
 bdH
@@ -203437,7 +204349,6 @@ bdH
 aaa
 aaa
 aaa
-aaa
 bdH
 bdH
 bdH
@@ -203449,8 +204360,9 @@ bdH
 bdH
 bdH
 bdH
-aaa
-aaa
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -203540,7 +204452,6 @@ bdH
 aaa
 aaa
 aaa
-aaa
 bdH
 bdH
 bdH
@@ -203552,8 +204463,9 @@ bdH
 bdH
 bdH
 bdH
-aaa
-aaa
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -203643,7 +204555,6 @@ bdH
 aaa
 aaa
 aaa
-aaa
 bdH
 bdH
 bdH
@@ -203655,8 +204566,9 @@ bdH
 bdH
 bdH
 bdH
-aaa
-aaa
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -203746,7 +204658,7 @@ bdH
 aaa
 aaa
 aaa
-aaa
+bdH
 bdH
 bdH
 bdH
@@ -203849,7 +204761,6 @@ bdH
 aaa
 aaa
 aaa
-aaa
 bdH
 bdH
 bdH
@@ -203859,8 +204770,9 @@ bdH
 bdH
 bdH
 bdH
-aaa
-aaa
+bdH
+bdH
+bdH
 aaa
 aaa
 aaa
@@ -203952,7 +204864,6 @@ bdH
 aaa
 aaa
 aaa
-aaa
 bdH
 bdH
 bdH
@@ -203962,8 +204873,9 @@ bdH
 bdH
 bdH
 bdH
-aaa
-aaa
+bdH
+bdH
+bdH
 aaa
 aaa
 bdH
@@ -204170,10 +205082,10 @@ bdH
 bdH
 bdH
 bdH
-aaa
-aaa
 bdH
-aaa
+bdH
+bdH
+bdH
 aaa
 aad
 tvt
@@ -204276,7 +205188,7 @@ bdH
 bdH
 bdH
 bdH
-aaa
+bdH
 aaa
 aad
 cZe
@@ -207601,7 +208513,7 @@ aEN
 ajN
 aEN
 ajN
-aEN
+ajN
 cey
 ans
 aGX
@@ -207704,7 +208616,7 @@ ceQ
 ajn
 ajp
 ajn
-ceQ
+gNe
 ajg
 ccX
 akA
@@ -207803,13 +208715,13 @@ chH
 chj
 aEN
 ajt
-ajq
+cGU
 ajr
-ajq
+cGU
+arb
+wJo
 aoe
 aoe
-aoe
-ajl
 ajl
 cdv
 fvd
@@ -207908,12 +208820,12 @@ ajJ
 ajw
 cfy
 aoe
+skl
+ceS
+gXl
+cfy
 aoe
 aoe
-lFn
-aLS
-cek
-ajl
 ajl
 ajl
 aQz
@@ -208011,13 +208923,13 @@ cgR
 ajt
 cfS
 aoe
+rHz
+arb
+arb
+aEN
+cfy
 aoe
-cfh
-ceR
-cez
-cem
-anq
-ajl
+tsC
 ajl
 onQ
 cct
@@ -208114,12 +209026,12 @@ wUd
 ajy
 cfU
 aoe
-anp
-cek
-yjb
+cez
+gXl
+cfG
 ceA
-cen
-axm
+cfS
+aoe
 tsC
 ajl
 fOL
@@ -208217,14 +209129,14 @@ arb
 cgC
 cfy
 aoe
-xNu
+skl
 mfC
 ceS
-aEO
-akw
-cdS
-cdw
-upM
+gXl
+cfy
+aoe
+tsC
+ajl
 tEi
 vtx
 vIf
@@ -208321,12 +209233,12 @@ cgD
 cfS
 aoe
 rHz
-wJo
-mMg
-kbn
+arb
+arb
+aoe
 aCo
-cdW
-iGA
+aoe
+ajl
 ajl
 ccF
 txW
@@ -208423,14 +209335,14 @@ eDo
 cgF
 cfy
 aoe
-aoe
+skl
 gXl
-hSo
-xdS
-awj
+ceS
+aCo
 cdY
-ajl
-ajl
+cdY
+cdY
+upM
 ccH
 alD
 ccj
@@ -208524,16 +209436,16 @@ aoe
 aoe
 jTj
 cgG
+aEO
 isN
-isN
-aoe
-aoe
+aEO
+arb
 wJo
-uol
-anp
-ajl
-ajl
-ajl
+aoe
+cdY
+cdY
+cdY
+upM
 rrD
 vQN
 ccl
@@ -208629,15 +209541,15 @@ arb
 cgH
 cfV
 ePX
-cfy
+cfW
+ePX
+jZY
 aoe
-sqf
-sqf
-sqf
-sqf
-cdx
-fEC
-uRt
+cdY
+cdY
+ajl
+ajl
+fFO
 vQN
 ccm
 gWG
@@ -208732,14 +209644,14 @@ jZY
 wDH
 cfW
 cfG
-sdn
-aGW
-sqf
-ceB
-ceo
-sqf
-sqf
-aBd
+chr
+ceS
+ceA
+aoe
+cdY
+cdY
+ajl
+fEC
 uRt
 wjz
 ajl
@@ -208837,11 +209749,11 @@ ajq
 cfH
 aoe
 aGW
-ceT
-ceF
-kEp
-tWY
-sqf
+ajq
+aoe
+ajl
+ajl
+ajl
 pJl
 uRt
 ccu
@@ -208939,14 +209851,14 @@ cgI
 aoe
 aoe
 aoe
-aGW
-sqf
-cep
-cep
-sqf
-sqf
+aoe
+aoe
+aoe
+lmk
+lmk
+ajl
 ccW
-aos
+uRt
 vQN
 ajl
 aiN
@@ -209043,12 +209955,12 @@ cfX
 aGX
 cfz
 ans
-ceU
-aos
-ccV
-ceb
+ans
+ans
+aGX
+aGX
 cbT
-fFO
+aGX
 oap
 aSb
 aEe
@@ -209137,7 +210049,7 @@ ciE
 ciA
 ciw
 ccn
-hFC
+anz
 chV
 cht
 cgW
@@ -209239,12 +210151,12 @@ epT
 llo
 bXc
 vZJ
-ajl
-ajl
-gKR
-drT
-gKR
-vOy
+sqf
+sqf
+cep
+cep
+sqf
+sqf
 vOy
 vOy
 ncE
@@ -209342,13 +210254,13 @@ abE
 rSW
 dNv
 rSW
-ajl
-ajl
+sqf
+bGp
 aSn
 lYL
 pNP
 vOy
-cco
+vOy
 nLI
 cfA
 dwr
@@ -209445,11 +210357,11 @@ agA
 mRJ
 fjA
 gqH
-ajl
-anz
-vgx
-hme
-mzq
+sqf
+sqf
+ceB
+ceo
+sqf
 vOy
 cfZ
 cfI
@@ -209547,12 +210459,12 @@ aef
 uZZ
 aiO
 lGh
-bBH
+cii
 ajl
-awQ
-axm
-akw
-vDa
+sqf
+sqf
+sqf
+sqf
 vOy
 cga
 qfy
@@ -209653,9 +210565,9 @@ efV
 bBH
 ajl
 hng
-axm
+bWV
 hPN
-vCk
+ajl
 vOy
 qam
 riE
@@ -209758,9 +210670,9 @@ ajl
 xyt
 axm
 tOr
-dBj
+cek
 vOy
-cco
+vOy
 cfJ
 jsx
 tjn
@@ -209856,14 +210768,14 @@ tRD
 abE
 tkF
 qdJ
-bBH
-ajl
-iYf
+bMW
+xiL
+akw
 bIM
-oap
+kds
 mzq
+sqf
 vOy
-cco
 cco
 cco
 cfj
@@ -209958,14 +210870,14 @@ aef
 afs
 agA
 lXl
-poD
-cii
-ajl
-ajl
+iCT
+gFD
+gKR
+wQH
 wiW
 chu
-jeq
-vOy
+lFn
+sqf
 wWR
 cfK
 vkp
@@ -210062,13 +210974,13 @@ afs
 agA
 lXl
 yiu
-bBH
+cih
 ajl
-ajl
-ajl
+cbn
+aID
 ydE
-ajl
-vOy
+jFQ
+sqf
 cgb
 vdO
 cfB
@@ -210165,13 +211077,13 @@ afs
 agA
 lXl
 yiu
-cih
-ajl
+bMW
+xiL
 aAr
 pGK
 chw
-tpa
-vOy
+tOr
+sqf
 cgb
 dHV
 cfC
@@ -210268,13 +211180,13 @@ pHG
 abE
 tkF
 yiu
-bBH
-ajl
+bMW
+wZH
 aID
 gLc
 wub
-iit
-vOy
+mzq
+sqf
 cgc
 cfL
 jpl
@@ -210371,12 +211283,12 @@ aGS
 agA
 lXl
 poD
-bBH
+qmW
 ajl
 aMd
 chX
 chx
-ajl
+cek
 rQy
 nDo
 nDo
@@ -210476,9 +211388,9 @@ aiO
 poD
 bBH
 ajl
-ajl
+anp
 aSo
-ajl
+hSo
 rQy
 rQy
 cgd
@@ -210579,9 +211491,9 @@ aiO
 yiu
 bBH
 ajl
-aQZ
-bkT
-chy
+ajl
+ajl
+ajl
 rQy
 pRX
 cge

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -199,6 +199,13 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"aaD" = (
+/obj/structure/machinery/light/red{
+	light_color = "#BB3F3F";
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk/no_build,
+/area/almayer/middeck/medical)
 "aaE" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/almayer/plating_striped/south,
@@ -5405,19 +5412,6 @@
 /obj/effect/decal/heavy_cable/cable_vertical,
 /turf/open/floor/plating/plating_catwalk/no_build,
 /area/almayer/middeck/maintenance/sp)
-"anz" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/safety/hazard{
-	pixel_x = 32;
-	pixel_y = 7
-	},
-/obj/structure/sign/safety/ammunition{
-	pixel_y = -7;
-	pixel_x = 32
-	},
-/turf/open/floor/almayer/sterile_green_side/east,
-/area/almayer/medical/upper_medical)
 "anA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/no_build,
@@ -9079,19 +9073,15 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/medical/morgue)
 "axm" = (
-/obj/structure/platform/metal/almayer/north{
-	dir = 2
+/obj/structure/flora/bush/ausbushes/var3/brflowers{
+	name = "fake brflowers";
+	desc = "Just like a real plant, but fake!"
 	},
-/obj/structure/platform/metal/almayer/west,
-/obj/structure/platform_decoration/metal/almayer/northwest{
-	layer = 4.1;
-	dir = 10
+/obj/structure/machinery/status_display{
+	pixel_y = 0;
+	pixel_x = -32
 	},
-/obj/structure/bed/chair/comfy{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/grass,
 /area/almayer/medical/upper_medical)
 "axn" = (
 /obj/effect/decal/warning_stripes{
@@ -10476,29 +10466,6 @@
 /obj/structure/platform/metal/almayer_smooth/east,
 /turf/open_space,
 /area/almayer/middeck/hanger)
-"aBd" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/ashtray/plastic{
-	pixel_x = -6;
-	pixel_y = -2
-	},
-/obj/structure/transmitter/rotary{
-	name = "CMO Office Telephone";
-	phone_category = "Offices";
-	phone_id = "CMO Office";
-	pixel_y = 9;
-	pixel_x = -6
-	},
-/obj/item/clipboard{
-	pixel_x = 6;
-	pixel_y = 2
-	},
-/obj/item/folder/black{
-	pixel_x = 7;
-	pixel_y = -1
-	},
-/turf/open/floor/almayer/sterile_green_side/west,
-/area/almayer/medical/cmo_office)
 "aBe" = (
 /obj/structure/prop/invuln/lattice_prop{
 	icon_state = "lattice4";
@@ -11533,6 +11500,21 @@
 	},
 /turf/open/floor/almayer/silver/east,
 /area/almayer/command/cic)
+"aDL" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice12";
+	pixel_y = 16
+	},
+/obj/structure/machinery/light/red{
+	light_color = "#BB3F3F";
+	dir = 1
+	},
+/turf/open/floor/almayer/no_build/plating,
+/area/almayer/middeck/medical)
 "aDM" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/machinery/faxmachine/uscm/almayer/command{
@@ -11973,11 +11955,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/morgue)
 "aEO" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "test_square_smooth"
-	},
-/obj/structure/morgue,
-/turf/open/floor/almayer/plate,
+/turf/open/floor/almayer/flooredge,
 /area/almayer/medical/morgue)
 "aEP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13302,10 +13280,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/medical_science)
-"aID" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/dark_sterile,
-/area/almayer/medical/upper_medical)
 "aIE" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E"
@@ -14491,9 +14465,6 @@
 /obj/structure/largecrate/random/case,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/lower_astronav)
-"aLS" = (
-/turf/open/floor/almayer/flooredge/south,
-/area/almayer/medical/cmo_office)
 "aLT" = (
 /turf/closed/wall/almayer,
 /area/almayer/squads/alpha)
@@ -17915,6 +17886,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/middeck/maintenance/pb)
+"aUO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/almayer/outer/internal,
+/area/almayer/medical/cmo_office)
 "aUP" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -20711,6 +20686,10 @@
 	},
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/middeck/medical)
+"bbi" = (
+/obj/structure/largecrate/random/barrel/medical,
+/turf/open/floor/plating/plating_catwalk/no_build,
+/area/almayer/middeck/medical)
 "bbj" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out";
@@ -21972,10 +21951,6 @@
 	},
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/shipboard/navigation)
-"bec" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/almayer/outer/internal,
-/area/almayer/medical/cmo_office)
 "bed" = (
 /obj/structure/stairs/perspective{
 	dir = 8;
@@ -23070,6 +23045,9 @@
 /obj/structure/surface/rack,
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/middeck/maintenance/aft)
+"bgG" = (
+/turf/closed/wall/almayer/outer/internal,
+/area/almayer/medical/cmo_office)
 "bgH" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out";
@@ -23225,6 +23203,17 @@
 	},
 /turf/open/floor/almayer/flooredge/east,
 /area/almayer/medical/containment)
+"bha" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "W";
+	layer = 3.3
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "E"
+	},
+/obj/structure/largecrate/random/case/double,
+/turf/open/floor/almayer/no_build/plate,
+/area/almayer/middeck/medical)
 "bhb" = (
 /turf/open/floor/almayer/sterile_green_side,
 /area/almayer/medical/containment)
@@ -23292,6 +23281,10 @@
 	},
 /turf/open/floor/almayer/plating_striped/south,
 /area/almayer/shipboard/port_point_defense)
+"bhk" = (
+/obj/structure/stairs/multiz/up,
+/turf/open/space/basic,
+/area/almayer/medical/cmo_office)
 "bhl" = (
 /obj/structure/largecrate/random/barrel/true_random,
 /obj/effect/decal/heavy_cable/cable_vertical,
@@ -23408,6 +23401,9 @@
 /obj/effect/spawner/random/tool,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_m_p)
+"bhz" = (
+/turf/closed/wall/almayer/reinforced,
+/area/almayer/medical/cmo_office)
 "bhA" = (
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/containment)
@@ -23620,6 +23616,10 @@
 /obj/item/storage/firstaid/regular/empty,
 /turf/open/floor/almayer/no_build/plating,
 /area/almayer/middeck/medical)
+"bic" = (
+/obj/structure/window/framed/almayer,
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/medical/cmo_office)
 "bid" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/lower)
@@ -23956,6 +23956,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/middeck/maintenance/sb)
+"biO" = (
+/turf/open/floor/almayer/sterile_green_corner/west,
+/area/almayer/medical/cmo_office)
 "biP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
@@ -24425,6 +24428,10 @@
 	},
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/middeck/maintenance/sb)
+"bjI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_corner/east,
+/area/almayer/medical/cmo_office)
 "bjJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes{
@@ -32633,6 +32640,14 @@
 /obj/structure/largecrate/random/barrel/true_random,
 /turf/open/floor/plating/plating_catwalk/no_build,
 /area/almayer/underdeck/hangar)
+"bBU" = (
+/obj/structure/stairs{
+	dir = 4;
+	icon_state = "ramptop"
+	},
+/obj/structure/machinery/light/blue,
+/turf/open_space,
+/area/almayer/medical/cmo_office)
 "bBV" = (
 /obj/effect/decal/heavy_cable/cable_horizontal,
 /obj/effect/decal/cleanable/dirt,
@@ -34495,13 +34510,6 @@
 /obj/structure/window/framed/almayer/hull/hijack_bustable,
 /turf/open/floor/plating,
 /area/almayer/squads/req)
-"bGp" = (
-/obj/structure/closet/secure_closet/guncabinet/red/armory_m39_submachinegun,
-/obj/structure/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/almayer/redfull,
-/area/almayer/medical/upper_medical)
 "bGq" = (
 /obj/structure/machinery/light,
 /obj/effect/decal/warning_stripes{
@@ -34738,23 +34746,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/squads/req)
-"bGV" = (
-/obj/structure/machinery/door/window/westright{
-	dir = 4
-	},
-/obj/structure/machinery/shower{
-	pixel_y = 16
-	},
-/obj/item/tool/soap{
-	pixel_x = 3;
-	pixel_y = 1
-	},
-/obj/item/toy/bikehorn/rubberducky{
-	pixel_x = -8;
-	pixel_y = -3
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/medical/cmo_office)
 "bGW" = (
 /obj/structure/machinery/light/small,
 /obj/structure/closet/secure_closet/guncabinet/red/mp_armory_mk2_rifle,
@@ -36106,6 +36097,20 @@
 /obj/effect/decal/heavy_cable/cable_horizontal,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/starboard_point_defense)
+"bKI" = (
+/obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
+	name = "\improper CMO's Office";
+	dir = 2;
+	access_modified = 1;
+	req_one_access_txt = "1;5"
+	},
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 4;
+	id = "CMO Shutters";
+	name = "\improper CMO Office Shutters"
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/medical/cmo_office)
 "bKJ" = (
 /obj/effect/decal/heavy_cable/cable_vertical,
 /turf/open/floor/plating/plating_catwalk,
@@ -36456,6 +36461,10 @@
 	},
 /turf/open/floor/almayer/orange,
 /area/almayer/engineering/lower)
+"bLF" = (
+/obj/structure/machinery/light/blue,
+/turf/open/floor/almayer/sterile_green_side,
+/area/almayer/medical/cmo_office)
 "bLG" = (
 /obj/structure/closet/secure_closet/guncabinet/red/mp_armory_m39_submachinegun,
 /obj/item/vehicle_clamp,
@@ -36899,6 +36908,9 @@
 	},
 /turf/open/floor/almayer/green,
 /area/almayer/hallways/upper/fore_hallway)
+"bMN" = (
+/turf/open/floor/almayer/sterile_green_corner/east,
+/area/almayer/medical/cmo_office)
 "bMO" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/prop/almayer/CICmap,
@@ -37140,6 +37152,10 @@
 	},
 /turf/open/floor/prison/kitchen,
 /area/almayer/living/grunt_rnr)
+"bNx" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_corner,
+/area/almayer/medical/cmo_office)
 "bNy" = (
 /obj/structure/sign/safety/life_support{
 	pixel_y = 25
@@ -40983,17 +40999,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply/no_boom,
 /turf/open/floor/almayer/flooredge/southwest,
 /area/almayer/medical/containment)
-"bWV" = (
-/obj/structure/flora/bush/ausbushes/var3/brflowers{
-	name = "fake brflowers";
-	desc = "Just like a real plant, but fake!"
-	},
-/obj/structure/machinery/status_display{
-	pixel_y = 0;
-	pixel_x = -32
-	},
-/turf/open/floor/grass,
-/area/almayer/medical/upper_medical)
 "bWW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/surface/rack,
@@ -41421,29 +41426,23 @@
 /obj/structure/machinery/power/apc/almayer/north,
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/middeck/medical)
-"bXJ" = (
+"bXL" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_corner/north,
+/area/almayer/medical/cmo_office)
+"bXM" = (
 /obj/structure/stairs{
 	dir = 4;
 	icon_state = "ramptop"
 	},
-/obj/structure/machinery/light/blue,
-/turf/open_space,
-/area/almayer/medical/cmo_office)
-"bXK" = (
-/obj/structure/window/framed/almayer,
-/turf/open/floor/almayer/dark_sterile,
-/area/almayer/medical/cmo_office)
-"bXL" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/sterile_green_corner,
-/area/almayer/medical/cmo_office)
-"bXM" = (
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 4;
+/obj/structure/machinery/door_control{
 	id = "CMO Shutters";
-	name = "\improper CMO Office Shutters"
+	name = "\improper Office Privacy Shutters";
+	pixel_y = 24;
+	req_one_access_txt = "28";
+	pixel_x = 9
 	},
-/turf/open/floor/almayer/test_floor4,
+/turf/open_space,
 /area/almayer/medical/cmo_office)
 "bXN" = (
 /obj/structure/sign/safety/intercom{
@@ -42380,20 +42379,18 @@
 /turf/open/floor/almayer/sterile_green2,
 /area/almayer/medical/containment)
 "bZq" = (
-/turf/open/floor/almayer/dark_sterile,
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/device/flashlight/lamp{
+	pixel_y = 9;
+	layer = 2.96;
+	pixel_x = 3
+	},
+/obj/item/device/megaphone,
+/turf/open/floor/almayer/sterile_green_side/west,
 /area/almayer/medical/cmo_office)
 "bZr" = (
 /turf/open/floor/almayer/plating_striped/north,
 /area/almayer/squads/req)
-"bZs" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 4;
-	id = "CMO Shutters";
-	name = "\improper CMO Office Shutters"
-	},
-/turf/open_space,
-/area/almayer/medical/cmo_office)
 "bZt" = (
 /turf/closed/wall/almayer/research/containment/wall/connect3,
 /area/almayer/medical/containment/cell)
@@ -43484,12 +43481,6 @@
 	},
 /turf/open/floor/almayer/no_build/test_floor4,
 /area/almayer/middeck/briefing)
-"cbn" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	name = "ship-grade camera"
-	},
-/turf/open/floor/almayer/dark_sterile,
-/area/almayer/medical/upper_medical)
 "cbo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/heavy_cable/cable_vertical,
@@ -44643,28 +44634,10 @@
 /obj/structure/machinery/cm_vending/gear/medic,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/charlie)
-"cdW" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/structure/machinery/computer/cameras/containment{
-	name = "Research Cameras";
-	pixel_y = 9;
-	pixel_x = 1;
-	dir = 4
-	},
-/obj/structure/machinery/computer/research/main_terminal{
-	pixel_y = -5;
-	pixel_x = 1;
-	dir = 4
-	},
-/turf/open/floor/almayer/sterile_green_side/west,
-/area/almayer/medical/cmo_office)
 "cdX" = (
 /obj/structure/machinery/cm_vending/gear/engi,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/charlie)
-"cdY" = (
-/turf/open_space,
-/area/almayer/medical/upper_medical)
 "cdZ" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 1
@@ -44874,18 +44847,6 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/morgue)
-"cez" = (
-/obj/structure/morgue{
-	dir = 2
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "test_square_smooth"
-	},
-/obj/structure/machinery/camera/autoname/almayer{
-	name = "ship-grade camera"
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/medical/morgue)
 "ceA" = (
 /turf/open/floor/almayer/flooredge/north,
 /area/almayer/medical/morgue)
@@ -45009,10 +44970,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/morgue)
-"ceR" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/sterile_green_side/southeast,
-/area/almayer/medical/cmo_office)
 "ceS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/flooredge/north,
@@ -49360,6 +49317,14 @@
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/shipboard/brig/warden_office)
+"cov" = (
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 4;
+	id = "CMO Shutters";
+	name = "\improper CMO Office Shutters"
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/medical/cmo_office)
 "cow" = (
 /obj/structure/machinery/door_control{
 	pixel_x = 25;
@@ -50220,6 +50185,35 @@
 /obj/structure/machinery/power/apc/almayer/north,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/s_bow)
+"cqs" = (
+/turf/open/floor/almayer/sterile_green_side/northwest,
+/area/almayer/medical/cmo_office)
+"cqt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_side/southeast,
+/area/almayer/medical/cmo_office)
+"cqu" = (
+/obj/structure/window/framed/almayer/white,
+/obj/structure/window/framed/almayer,
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/medical/cmo_office)
+"cqv" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_side/west,
+/area/almayer/medical/cmo_office)
+"cqw" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/medical/cmo_office)
+"cqx" = (
+/turf/open/floor/almayer/sterile_green_side/southeast,
+/area/almayer/medical/cmo_office)
+"cqy" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_21"
+	},
+/turf/open/floor/almayer/sterile_green_corner/east,
+/area/almayer/medical/cmo_office)
 "cqz" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -50227,24 +50221,163 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plate,
 /area/almayer/squads/alpha)
+"cqA" = (
+/obj/structure/window/framed/almayer,
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 4;
+	id = "CMO Shutters";
+	name = "\improper CMO Office Shutters"
+	},
+/turf/open/floor/almayer/sterile_green_side/southeast,
+/area/almayer/medical/cmo_office)
+"cqB" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	pixel_y = 9;
+	pixel_x = -6
+	},
+/obj/item/alienjar{
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/obj/item/reagent_container/food/snacks/toastedsandwich{
+	pixel_x = 12;
+	pixel_y = 4
+	},
+/obj/structure/sign/safety/terminal{
+	pixel_x = 7;
+	pixel_y = -26
+	},
+/turf/open/floor/almayer/sterile_green_corner/west,
+/area/almayer/medical/cmo_office)
+"cqC" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/device/flashlight/lamp/green{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/device/camera{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/turf/open/floor/almayer/sterile_green_side/southwest,
+/area/almayer/medical/cmo_office)
+"cqD" = (
+/obj/structure/coatrack{
+	pixel_x = -11;
+	pixel_y = 2
+	},
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/medical/cmo_office)
+"cqE" = (
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/medical/cmo_office)
+"cqF" = (
+/obj/structure/closet/secure_closet/professor_dummy{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/power/apc/almayer/east,
+/turf/open/floor/almayer/sterile_green_side/east,
+/area/almayer/medical/cmo_office)
+"cqG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	layer = 3.3
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/structure/machinery/light/red{
+	light_color = "#BB3F3F";
+	dir = 4
+	},
+/turf/open/floor/almayer/no_build/plate,
+/area/almayer/middeck/medical)
 "cqH" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 4
 	},
 /turf/open/floor/almayer,
 /area/almayer/maint/hull/lower/l_m_s)
+"cqI" = (
+/obj/structure/window/framed/almayer,
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	dir = 4;
+	id = "CMO Shutters";
+	name = "\improper CMO Office Shutters"
+	},
+/turf/open_space,
+/area/almayer/medical/cmo_office)
 "cqJ" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/processing)
+"cqK" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/ashtray/plastic{
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/structure/transmitter/rotary{
+	name = "CMO Office Telephone";
+	phone_category = "Offices";
+	phone_id = "CMO Office";
+	pixel_y = 9;
+	pixel_x = -6
+	},
+/obj/item/clipboard{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/folder/black{
+	pixel_x = 7;
+	pixel_y = -1
+	},
+/turf/open/floor/almayer/sterile_green_side/west,
+/area/almayer/medical/cmo_office)
+"cqL" = (
+/obj/structure/machinery/door_control{
+	id = "CMO Shutters";
+	name = "\improper Office Privacy Shutters";
+	pixel_y = -22;
+	req_one_access_txt = "28";
+	pixel_x = 7
+	},
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/medical/cmo_office)
 "cqM" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 8
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/processing)
+"cqN" = (
+/obj/structure/machinery/light/blue{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/medical/cmo_office)
+"cqO" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/device/flash,
+/turf/open/floor/almayer/sterile_green_side/west,
+/area/almayer/medical/cmo_office)
+"cqP" = (
+/obj/structure/machinery/photocopier{
+	layer = 2.9;
+	pixel_y = 8;
+	density = 0;
+	pixel_x = 0
+	},
+/turf/open/floor/almayer/sterile_green_side/east,
+/area/almayer/medical/cmo_office)
 "cqQ" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
@@ -50255,6 +50388,131 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/shipboard/starboard_missiles)
+"cqR" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/machinery/computer/cameras/containment{
+	name = "Research Cameras";
+	pixel_y = 9;
+	pixel_x = 1;
+	dir = 4
+	},
+/obj/structure/machinery/computer/research/main_terminal{
+	pixel_y = -5;
+	pixel_x = 1;
+	dir = 4
+	},
+/turf/open/floor/almayer/sterile_green_side/west,
+/area/almayer/medical/cmo_office)
+"cqS" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/medical/cmo_office)
+"cqT" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/item/paper_bin/wy{
+	pixel_y = 8;
+	pixel_x = -6
+	},
+/obj/item/tool/stamp/cmo{
+	pixel_x = 8;
+	pixel_y = -3;
+	name = "Chief Medical Officer's rubber stamp"
+	},
+/obj/item/tool/pen{
+	pixel_y = 3;
+	pixel_x = -6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tool/hand_labeler{
+	pixel_x = 8;
+	pixel_y = 13
+	},
+/turf/open/floor/almayer/sterile_green_side/east,
+/area/almayer/medical/cmo_office)
+"cqU" = (
+/obj/structure/surface/table/reinforced/prison,
+/obj/structure/machinery/faxmachine/uscm/almayer{
+	pixel_x = -3;
+	pixel_y = 5;
+	sub_name = "Chief Medical Officer"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_side/east,
+/area/almayer/medical/cmo_office)
+"cqV" = (
+/obj/structure/filingcabinet/filingcabinet{
+	density = 0;
+	pixel_x = 7;
+	pixel_y = 16
+	},
+/obj/structure/filingcabinet/filingcabinet{
+	density = 0;
+	pixel_x = -8;
+	pixel_y = 16
+	},
+/obj/item/folder/blue{
+	pixel_y = 5
+	},
+/obj/item/folder/black,
+/obj/item/folder/white,
+/obj/structure/machinery/light/blue{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 17
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/sterile_green_side/north,
+/area/almayer/medical/cmo_office)
+"cqW" = (
+/obj/structure/machinery/computer/med_data{
+	pixel_x = -9;
+	pixel_y = 0
+	},
+/obj/structure/machinery/computer/crew{
+	pixel_x = 15;
+	pixel_y = 0
+	},
+/obj/structure/sign/catclock{
+	pixel_y = 28;
+	pixel_x = 7
+	},
+/turf/open/floor/almayer/sterile_green_side/north,
+/area/almayer/medical/cmo_office)
+"cqX" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_29";
+	pixel_y = 12;
+	pixel_x = 6
+	},
+/turf/open/floor/almayer/sterile_green_corner,
+/area/almayer/medical/cmo_office)
+"cqY" = (
+/obj/structure/machinery/door/airlock/almayer/white{
+	name = "\improper CMO's Bedroom";
+	req_one_access = list(28,206,207);
+	req_one_access_txt = "1;5";
+	dir = 2
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/medical/cmo_office)
+"cqZ" = (
+/turf/open/floor/almayer/flooredge/south,
+/area/almayer/medical/cmo_office)
+"cra" = (
+/obj/structure/machinery/light,
+/turf/open/floor/almayer/flooredge/south,
+/area/almayer/medical/cmo_office)
+"crb" = (
+/obj/structure/bed,
+/obj/item/bedsheet/green,
+/obj/structure/sign/poster/hunk{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/almayer/flooredge/southeast,
+/area/almayer/medical/cmo_office)
 "crc" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -50266,6 +50524,37 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/hallways/lower/port_midship_hallway)
+"crd" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	layer = 3.3
+	},
+/turf/closed/wall/almayer/reinforced,
+/area/almayer/medical/cmo_office)
+"cre" = (
+/obj/structure/machinery/cm_vending/clothing/senior_officer{
+	pixel_y = 19;
+	density = 0
+	},
+/turf/open/floor/almayer/flooredge/northwest,
+/area/almayer/medical/cmo_office)
+"crf" = (
+/obj/structure/bookcase{
+	icon_state = "book-5";
+	pixel_x = -1;
+	pixel_y = 19;
+	density = 0;
+	opacity = 0
+	},
+/obj/item/book/manual/ripley_build_and_repair,
+/obj/item/book/manual/research_and_development,
+/obj/item/book/manual/surgery,
+/obj/item/book/manual/medical_diagnostics_manual,
+/turf/open/floor/almayer/flooredge/north,
+/area/almayer/medical/cmo_office)
+"crg" = (
+/turf/open/floor/almayer/flooredge/north,
+/area/almayer/medical/cmo_office)
 "crh" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -50279,9 +50568,241 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/u_f_s)
+"crj" = (
+/obj/structure/closet/secure_closet/personal/cabinet{
+	req_access_txt = "5"
+	},
+/obj/structure/sign/safety/bathunisex{
+	pixel_x = 2;
+	pixel_y = 29
+	},
+/turf/open/floor/almayer/flooredge/northeast,
+/area/almayer/medical/cmo_office)
+"crk" = (
+/obj/structure/machinery/door/airlock/almayer/white{
+	dir = 2;
+	name = "\improper Bathroom"
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/medical/cmo_office)
+"crl" = (
+/obj/structure/machinery/door/window/westright{
+	dir = 4
+	},
+/obj/structure/machinery/shower{
+	pixel_y = 16
+	},
+/obj/item/tool/soap{
+	pixel_x = 3;
+	pixel_y = 1
+	},
+/obj/item/toy/bikehorn/rubberducky{
+	pixel_x = -8;
+	pixel_y = -3
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/medical/cmo_office)
+"crm" = (
+/obj/structure/sink{
+	pixel_y = 22;
+	pixel_x = 0
+	},
+/obj/structure/mirror{
+	pixel_y = 36;
+	pixel_x = -1
+	},
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/medical/cmo_office)
+"crn" = (
+/obj/structure/toilet{
+	dir = 8;
+	layer = 2.9;
+	pixel_y = 8
+	},
+/obj/structure/machinery/light/small,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/medical/cmo_office)
+"cro" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "NE-out";
+	pixel_y = 1;
+	pixel_x = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "NW-out";
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/obj/structure/sign/safety/reduction{
+	pixel_x = 8;
+	pixel_y = 28
+	},
+/turf/open/floor/almayer/sterile_green_side/north,
+/area/almayer/medical/upper_medical)
+"crp" = (
+/obj/structure/stairs/multiz/down,
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/medical/upper_medical)
+"crq" = (
+/obj/structure/foamed_metal/iron,
+/turf/open/floor/plating,
+/area/almayer/medical/upper_medical)
+"crr" = (
+/turf/open_space,
+/area/almayer/medical/upper_medical)
+"crs" = (
+/obj/structure/stairs/multiz/down{
+	dir = 4
+	},
+/turf/closed/wall/almayer/white,
+/area/almayer/medical/upper_medical)
+"crt" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer/flooredge/west,
+/area/almayer/medical/morgue)
+"cru" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/light/small/blue,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/medical/morgue)
+"crv" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "test_square_smooth"
+	},
+/obj/structure/morgue{
+	dir = 8
+	},
+/turf/open/floor/almayer/plate,
+/area/almayer/medical/morgue)
+"crw" = (
+/obj/structure/morgue{
+	dir = 2
+	},
+/obj/structure/machinery/light/small/blue{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "test_square_smooth"
+	},
+/turf/open/floor/almayer/plate,
+/area/almayer/medical/morgue)
+"crx" = (
+/obj/structure/morgue{
+	dir = 2
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "test_square_smooth"
+	},
+/obj/structure/machinery/camera/autoname/almayer{
+	name = "ship-grade camera"
+	},
+/turf/open/floor/almayer/plate,
+/area/almayer/medical/morgue)
+"cry" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "test_square_smooth"
+	},
+/obj/structure/morgue,
+/turf/open/floor/almayer/plate,
+/area/almayer/medical/morgue)
+"crz" = (
+/obj/structure/flora/bush/ausbushes/var3/fullgrass{
+	desc = "Just like a real plant, but fake!";
+	name = "fake fullgrass"
+	},
+/obj/structure/machinery/status_display{
+	pixel_y = -32;
+	pixel_x = 0
+	},
+/turf/open/floor/grass,
+/area/almayer/medical/upper_medical)
+"crA" = (
+/obj/structure/platform/metal/almayer/north{
+	dir = 2
+	},
+/obj/structure/platform/metal/almayer/west,
+/obj/structure/platform_decoration/metal/almayer/northwest{
+	layer = 4.1;
+	dir = 10
+	},
+/obj/structure/reagent_dispensers/water_cooler/stacks{
+	pixel_y = 7;
+	pixel_x = -3;
+	density = 0
+	},
+/turf/open/floor/almayer/mono,
+/area/almayer/medical/upper_medical)
+"crB" = (
+/obj/structure/platform/metal/almayer/north{
+	dir = 2
+	},
+/obj/structure/platform/metal/almayer/west,
+/obj/structure/platform_decoration/metal/almayer/northwest{
+	layer = 4.1;
+	dir = 10
+	},
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/medical/upper_medical)
+"crC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/medical/upper_medical)
 "crD" = (
 /turf/open/floor/almayer/greencorner/north,
 /area/almayer/squads/req)
+"crE" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/safety/hazard{
+	pixel_x = 32;
+	pixel_y = 7
+	},
+/obj/structure/sign/safety/ammunition{
+	pixel_y = -7;
+	pixel_x = 32
+	},
+/turf/open/floor/almayer/sterile_green_side/east,
+/area/almayer/medical/upper_medical)
+"crF" = (
+/obj/structure/closet/secure_closet/guncabinet/red/armory_m39_submachinegun,
+/obj/structure/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/almayer/redfull,
+/area/almayer/medical/upper_medical)
+"crG" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer/sterile_green_corner/north,
+/area/almayer/medical/upper_medical)
+"crH" = (
+/obj/structure/machinery/camera/autoname/almayer{
+	name = "ship-grade camera"
+	},
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/medical/upper_medical)
+"crI" = (
+/obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
+	name = "\improper Psychiatric Care Unit";
+	req_access = list()
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/medical/upper_medical)
+"crJ" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/medical/upper_medical)
+"crK" = (
+/turf/open/floor/almayer/test_floor4,
+/area/almayer/medical/upper_medical)
+"crL" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer/flooredge/south,
+/area/almayer/hallways/upper/midship_hallway)
 "csa" = (
 /obj/structure/barricade/handrail{
 	dir = 4;
@@ -50845,15 +51366,6 @@
 "cGR" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/upper/u_m_s)
-"cGU" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "test_square_smooth"
-	},
-/obj/structure/morgue{
-	dir = 8
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/medical/morgue)
 "cGV" = (
 /turf/open/floor/almayer/cargo_arrow,
 /area/almayer/squads/alpha_bravo_shared)
@@ -51226,17 +51738,6 @@
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_f_p)
-"cOC" = (
-/obj/structure/sink{
-	pixel_y = 22;
-	pixel_x = 0
-	},
-/obj/structure/mirror{
-	pixel_y = 36;
-	pixel_x = -1
-	},
-/turf/open/floor/almayer/dark_sterile,
-/area/almayer/medical/cmo_office)
 "cOK" = (
 /obj/structure/prop/invuln{
 	desc = "An inflated membrane. This one is puncture proof. Wow!";
@@ -52452,9 +52953,6 @@
 "dqj" = (
 /turf/open/floor/almayer/redcorner/east,
 /area/almayer/command/lifeboat)
-"dqr" = (
-/turf/open/floor/almayer/sterile_green_side/northwest,
-/area/almayer/medical/cmo_office)
 "dqw" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/shipboard/weapon_room/notunnel)
@@ -52574,15 +53072,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/hangar)
-"dtQ" = (
-/obj/structure/machinery/door/airlock/almayer/white{
-	name = "\improper CMO's Bedroom";
-	req_one_access = list(28,206,207);
-	req_one_access_txt = "1;5";
-	dir = 2
-	},
-/turf/open/floor/almayer/test_floor4,
-/area/almayer/medical/cmo_office)
 "duo" = (
 /obj/structure/machinery/power/apc/almayer/west,
 /turf/open/floor/prison/kitchen,
@@ -53137,15 +53626,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/port_aft_hallway)
-"dEM" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 4;
-	id = "CMO Shutters";
-	name = "\improper CMO Office Shutters"
-	},
-/turf/open/floor/almayer/sterile_green_side/southeast,
-/area/almayer/medical/cmo_office)
 "dEQ" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/food/condiment/hotsauce/tabasco,
@@ -53227,22 +53707,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/auxiliary_officer_office)
-"dGR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes{
-	icon_state = "S";
-	layer = 3.3
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/structure/machinery/light/red{
-	light_color = "#BB3F3F";
-	dir = 4
-	},
-/turf/open/floor/almayer/no_build/plate,
-/area/almayer/middeck/medical)
 "dGT" = (
 /obj/structure/machinery/door/airlock/almayer/security/glass{
 	name = "\improper Cryogenics Bay"
@@ -53699,16 +54163,6 @@
 	},
 /turf/open/floor/almayer/red/northwest,
 /area/almayer/lifeboat_pumps/south1)
-"dSG" = (
-/obj/structure/machinery/door_control{
-	id = "CMO Shutters";
-	name = "\improper Office Privacy Shutters";
-	pixel_y = -22;
-	req_one_access_txt = "28";
-	pixel_x = 7
-	},
-/turf/open/floor/almayer/dark_sterile,
-/area/almayer/medical/cmo_office)
 "dSI" = (
 /turf/open/floor/almayer/bluecorner/west,
 /area/almayer/hallways/upper/midship_hallway)
@@ -55594,20 +56048,6 @@
 "eHY" = (
 /turf/open/floor/almayer/plating_striped/east,
 /area/almayer/command/securestorage)
-"eIc" = (
-/obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
-	name = "\improper CMO's Office";
-	dir = 2;
-	access_modified = 1;
-	req_one_access_txt = "1;5"
-	},
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 4;
-	id = "CMO Shutters";
-	name = "\improper CMO Office Shutters"
-	},
-/turf/open/floor/almayer/test_floor4,
-/area/almayer/medical/cmo_office)
 "eIf" = (
 /obj/structure/prop/invuln/pipe_water,
 /obj/structure/prop/invuln/overhead_pipe{
@@ -57766,24 +58206,6 @@
 	},
 /turf/open/floor/almayer/sterile_green,
 /area/almayer/medical/lower_medical_medbay)
-"fFO" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "NE-out";
-	pixel_y = 1;
-	pixel_x = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes{
-	icon_state = "NW-out";
-	pixel_x = 0;
-	pixel_y = 2
-	},
-/obj/structure/sign/safety/reduction{
-	pixel_x = 8;
-	pixel_y = 28
-	},
-/turf/open/floor/almayer/sterile_green_side/north,
-/area/almayer/medical/upper_medical)
 "fFQ" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/spray/cleaner{
@@ -58677,30 +59099,6 @@
 	},
 /turf/open/floor/almayer/orange/north,
 /area/almayer/engineering/upper_engineering/starboard)
-"gbP" = (
-/obj/structure/filingcabinet/filingcabinet{
-	density = 0;
-	pixel_x = 7;
-	pixel_y = 16
-	},
-/obj/structure/filingcabinet/filingcabinet{
-	density = 0;
-	pixel_x = -8;
-	pixel_y = 16
-	},
-/obj/item/folder/blue{
-	pixel_y = 5
-	},
-/obj/item/folder/black,
-/obj/item/folder/white,
-/obj/structure/machinery/light/blue{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 17
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/sterile_green_side/north,
-/area/almayer/medical/cmo_office)
 "gbQ" = (
 /obj/structure/machinery/light/red{
 	light_color = "#BB3F3F"
@@ -59708,10 +60106,6 @@
 	},
 /turf/open/floor/almayer/green,
 /area/almayer/living/grunt_rnr)
-"gzY" = (
-/obj/structure/machinery/light/blue,
-/turf/open/floor/almayer/sterile_green_side,
-/area/almayer/medical/cmo_office)
 "gAj" = (
 /obj/structure/bed/chair/comfy/charlie{
 	dir = 1
@@ -59924,13 +60318,6 @@
 	},
 /turf/open/floor/almayer/mono,
 /area/almayer/lifeboat_pumps/south1)
-"gFD" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer/flooredge/south,
-/area/almayer/hallways/upper/midship_hallway)
-"gFK" = (
-/turf/open/floor/almayer/flooredge/north,
-/area/almayer/medical/cmo_office)
 "gFP" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/shipboard/stern_point_defense)
@@ -60175,21 +60562,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/port_midship_hallway)
-"gKz" = (
-/obj/structure/machinery/computer/med_data{
-	pixel_x = -9;
-	pixel_y = 0
-	},
-/obj/structure/machinery/computer/crew{
-	pixel_x = 15;
-	pixel_y = 0
-	},
-/obj/structure/sign/catclock{
-	pixel_y = 28;
-	pixel_x = 7
-	},
-/turf/open/floor/almayer/sterile_green_side/north,
-/area/almayer/medical/cmo_office)
 "gKB" = (
 /obj/structure/machinery/portable_atmospherics/hydroponics,
 /obj/structure/machinery/firealarm{
@@ -60204,10 +60576,6 @@
 	},
 /turf/open/floor/almayer/redfull,
 /area/almayer/shipboard/port_missiles)
-"gKR" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer/test_floor4,
-/area/almayer/medical/upper_medical)
 "gKW" = (
 /obj/structure/surface/rack,
 /obj/structure/surface/rack{
@@ -60336,10 +60704,6 @@
 	},
 /turf/open/floor/almayer/uscm/directional/east,
 /area/almayer/living/briefing)
-"gNe" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer/flooredge/west,
-/area/almayer/medical/morgue)
 "gNg" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = -17
@@ -60774,9 +61138,6 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/medical/upper_medical)
-"gXl" = (
-/turf/open/floor/almayer/flooredge,
-/area/almayer/medical/morgue)
 "gXs" = (
 /obj/effect/step_trigger/ares_alert/terminals,
 /obj/structure/machinery/door/poddoor/shutters/almayer{
@@ -61429,13 +61790,6 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/command/cichallway)
-"hme" = (
-/obj/structure/machinery/cm_vending/clothing/senior_officer{
-	pixel_y = 19;
-	density = 0
-	},
-/turf/open/floor/almayer/flooredge/northwest,
-/area/almayer/medical/cmo_office)
 "hmj" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out";
@@ -61560,13 +61914,6 @@
 	},
 /turf/open/floor/almayer/red,
 /area/almayer/shipboard/weapon_room)
-"hpL" = (
-/obj/structure/machinery/light/blue{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/dark_sterile,
-/area/almayer/medical/cmo_office)
 "hpS" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer{
 	id = "crate_room3";
@@ -63429,9 +63776,6 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/maint/lower/constr)
-"ihH" = (
-/turf/open/floor/almayer/sterile_green_corner/east,
-/area/almayer/medical/cmo_office)
 "ihI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -63511,9 +63855,6 @@
 /obj/structure/machinery/cell_charger,
 /turf/open/floor/almayer/plate,
 /area/almayer/engineering/lower/workshop)
-"ijq" = (
-/turf/open/floor/almayer/sterile_green_side/southeast,
-/area/almayer/medical/cmo_office)
 "ijr" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 4
@@ -63806,13 +64147,6 @@
 "iqp" = (
 /turf/open/floor/wood/ship,
 /area/almayer/living/pilotbunks)
-"iqw" = (
-/obj/structure/machinery/light/red{
-	light_color = "#BB3F3F";
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk/no_build,
-/area/almayer/middeck/medical)
 "iqH" = (
 /obj/item/trash/chips{
 	pixel_x = 9;
@@ -66753,27 +67087,6 @@
 /obj/structure/barricade/handrail,
 /turf/open/floor/almayer/test_floor5,
 /area/almayer/hallways/lower/port_midship_hallway)
-"jDE" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_22";
-	pixel_y = 9;
-	pixel_x = -6
-	},
-/obj/item/alienjar{
-	pixel_x = 8;
-	pixel_y = 12
-	},
-/obj/item/reagent_container/food/snacks/toastedsandwich{
-	pixel_x = 12;
-	pixel_y = 4
-	},
-/obj/structure/sign/safety/terminal{
-	pixel_x = 7;
-	pixel_y = -26
-	},
-/turf/open/floor/almayer/sterile_green_corner/west,
-/area/almayer/medical/cmo_office)
 "jDO" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/machinery/door/airlock/almayer{
@@ -66851,17 +67164,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/upper/u_m_s)
-"jFQ" = (
-/obj/structure/flora/bush/ausbushes/var3/fullgrass{
-	desc = "Just like a real plant, but fake!";
-	name = "fake fullgrass"
-	},
-/obj/structure/machinery/status_display{
-	pixel_y = -32;
-	pixel_x = 0
-	},
-/turf/open/floor/grass,
-/area/almayer/medical/upper_medical)
 "jFY" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer/cargo,
@@ -67836,15 +68138,6 @@
 	},
 /turf/open/floor/almayer/aicore/no_build,
 /area/almayer/command/airoom)
-"kbn" = (
-/obj/structure/bed,
-/obj/item/bedsheet/green,
-/obj/structure/sign/poster/hunk{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/open/floor/almayer/flooredge/southeast,
-/area/almayer/medical/cmo_office)
 "kbv" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/upper/starboard)
@@ -67938,22 +68231,6 @@
 /obj/structure/largecrate/random/barrel/red,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_f_s)
-"kds" = (
-/obj/structure/platform/metal/almayer/north{
-	dir = 2
-	},
-/obj/structure/platform/metal/almayer/west,
-/obj/structure/platform_decoration/metal/almayer/northwest{
-	layer = 4.1;
-	dir = 10
-	},
-/obj/structure/reagent_dispensers/water_cooler/stacks{
-	pixel_y = 7;
-	pixel_x = -3;
-	density = 0
-	},
-/turf/open/floor/almayer/mono,
-/area/almayer/medical/upper_medical)
 "kdv" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -68284,10 +68561,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_f_s)
-"kmd" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/sterile_green_corner/east,
-/area/almayer/medical/cmo_office)
 "kmp" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -68360,20 +68633,6 @@
 "knU" = (
 /turf/open/floor/almayer/red/northwest,
 /area/almayer/hallways/upper/aft_hallway)
-"kol" = (
-/obj/structure/bookcase{
-	icon_state = "book-5";
-	pixel_x = -1;
-	pixel_y = 19;
-	density = 0;
-	opacity = 0
-	},
-/obj/item/book/manual/ripley_build_and_repair,
-/obj/item/book/manual/research_and_development,
-/obj/item/book/manual/surgery,
-/obj/item/book/manual/medical_diagnostics_manual,
-/turf/open/floor/almayer/flooredge/north,
-/area/almayer/medical/cmo_office)
 "kon" = (
 /obj/structure/pipes/vents/pump{
 	dir = 1
@@ -68789,14 +69048,6 @@
 	},
 /turf/open/floor/almayer/sterile_green,
 /area/almayer/medical/lower_medical_lobby)
-"kwv" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_29";
-	pixel_y = 12;
-	pixel_x = 6
-	},
-/turf/open/floor/almayer/sterile_green_corner,
-/area/almayer/medical/cmo_office)
 "kwQ" = (
 /obj/item/tool/warning_cone{
 	pixel_y = 16
@@ -69192,11 +69443,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/living/briefing)
-"kEp" = (
-/obj/structure/window/framed/almayer/white,
-/obj/structure/window/framed/almayer,
-/turf/open/floor/almayer/dark_sterile,
-/area/almayer/medical/cmo_office)
 "kEs" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/flashlight/lamp{
@@ -69258,14 +69504,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_f_s)
-"kGa" = (
-/obj/structure/closet/secure_closet/professor_dummy{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/machinery/power/apc/almayer/east,
-/turf/open/floor/almayer/sterile_green_side/east,
-/area/almayer/medical/cmo_office)
 "kGi" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
@@ -69533,9 +69771,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/plating,
 /area/almayer/shipboard/brig/yard)
-"kMI" = (
-/turf/open/floor/almayer/sterile_green_corner/west,
-/area/almayer/medical/cmo_office)
 "kMK" = (
 /obj/structure/prop/invuln{
 	desc = "An inflated membrane. This one is puncture proof. Wow!";
@@ -70370,10 +70605,6 @@
 	},
 /turf/open/floor/plating,
 /area/almayer/living/cryo_cells)
-"lgA" = (
-/obj/structure/stairs/multiz/up,
-/turf/open/space/basic,
-/area/almayer/medical/cmo_office)
 "lgC" = (
 /obj/structure/platform/metal/almayer/west,
 /turf/open/floor/almayer/uscm/directional/northwest,
@@ -70664,12 +70895,6 @@
 "llO" = (
 /turf/open/floor/almayer/orange/east,
 /area/almayer/hallways/hangar)
-"lmk" = (
-/obj/structure/stairs/multiz/down{
-	dir = 4
-	},
-/turf/closed/wall/almayer/white,
-/area/almayer/medical/upper_medical)
 "lmz" = (
 /turf/closed/wall/almayer/aicore/hull,
 /area/almayer/middeck/req)
@@ -71131,17 +71356,6 @@
 	},
 /turf/open/floor/almayer/emeraldfull,
 /area/almayer/squads/charlie)
-"lwT" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "W";
-	layer = 3.3
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "E"
-	},
-/obj/structure/largecrate/random/case/double,
-/turf/open/floor/almayer/no_build/plate,
-/area/almayer/middeck/medical)
 "lwY" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/glass{
 	name = "\improper Port Viewing Room"
@@ -72003,10 +72217,6 @@
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/living/chapel)
-"lUc" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/sterile_green_corner/north,
-/area/almayer/medical/cmo_office)
 "lUA" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/manifold/hidden/supply{
@@ -73855,20 +74065,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/underdeck/vehicle)
-"mMg" = (
-/obj/structure/stairs{
-	dir = 4;
-	icon_state = "ramptop"
-	},
-/obj/structure/machinery/door_control{
-	id = "CMO Shutters";
-	name = "\improper Office Privacy Shutters";
-	pixel_y = 24;
-	req_one_access_txt = "28";
-	pixel_x = 9
-	},
-/turf/open_space,
-/area/almayer/medical/cmo_office)
 "mMB" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -75455,16 +75651,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_a_s)
-"nvK" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/device/flashlight/lamp{
-	pixel_y = 9;
-	layer = 2.96;
-	pixel_x = 3
-	},
-/obj/item/device/megaphone,
-/turf/open/floor/almayer/sterile_green_side/west,
-/area/almayer/medical/cmo_office)
 "nvM" = (
 /obj/structure/window/framed/almayer/white,
 /obj/structure/machinery/door/poddoor/shutters/almayer{
@@ -75826,18 +76012,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/starboard_umbilical)
-"nDj" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/device/flashlight/lamp/green{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/device/camera{
-	pixel_x = 4;
-	pixel_y = 1
-	},
-/turf/open/floor/almayer/sterile_green_side/southwest,
-/area/almayer/medical/cmo_office)
 "nDo" = (
 /turf/closed/wall/almayer/white,
 /area/almayer/medical/hydroponics)
@@ -75997,10 +76171,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_a_p)
-"nGU" = (
-/obj/structure/largecrate/random/barrel/medical,
-/turf/open/floor/plating/plating_catwalk/no_build,
-/area/almayer/middeck/medical)
 "nGY" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/almayer/cargo,
@@ -77311,11 +77481,6 @@
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/lower)
-"ojs" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/device/flash,
-/turf/open/floor/almayer/sterile_green_side/west,
-/area/almayer/medical/cmo_office)
 "ojF" = (
 /obj/structure/machinery/cm_vending/clothing/tl/charlie{
 	density = 0;
@@ -77897,15 +78062,6 @@
 "osI" = (
 /turf/open/floor/almayer/orange,
 /area/almayer/engineering/lower/workshop)
-"osM" = (
-/obj/structure/machinery/photocopier{
-	layer = 2.9;
-	pixel_y = 8;
-	density = 0;
-	pixel_x = 0
-	},
-/turf/open/floor/almayer/sterile_green_side/east,
-/area/almayer/medical/cmo_office)
 "osQ" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -79267,15 +79423,6 @@
 	},
 /turf/open/floor/almayer/no_build,
 /area/almayer/stair_clone/lower/port_fore)
-"oVl" = (
-/obj/structure/toilet{
-	dir = 8;
-	layer = 2.9;
-	pixel_y = 8
-	},
-/obj/structure/machinery/light/small,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/medical/cmo_office)
 "oVo" = (
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/upper/u_a_s)
@@ -84187,12 +84334,6 @@
 "rdA" = (
 /turf/open/floor/almayer/red/south,
 /area/almayer/shipboard/brig/perma)
-"rdB" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "pottedplant_21"
-	},
-/turf/open/floor/almayer/sterile_green_corner/east,
-/area/almayer/medical/cmo_office)
 "rdI" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/technology_scanner,
@@ -84484,9 +84625,6 @@
 /obj/structure/pipes/vents/scrubber,
 /turf/open/floor/almayer,
 /area/almayer/living/gym)
-"rkL" = (
-/turf/closed/wall/almayer/reinforced,
-/area/almayer/medical/cmo_office)
 "rkV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -85488,18 +85626,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/hallways/hangar)
-"rHz" = (
-/obj/structure/morgue{
-	dir = 2
-	},
-/obj/structure/machinery/light/small/blue{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "test_square_smooth"
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/medical/morgue)
 "rHB" = (
 /obj/item/ammo_box/magazine/misc/mre/empty{
 	pixel_x = 8;
@@ -89340,27 +89466,12 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/hallways/lower/starboard_fore_hallway)
 "tpa" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/item/paper_bin/wy{
-	pixel_y = 8;
-	pixel_x = -6
+/obj/structure/flora/bush/ausbushes/var3/brflowers{
+	name = "fake brflowers";
+	desc = "Just like a real plant, but fake!"
 	},
-/obj/item/tool/stamp/cmo{
-	pixel_x = 8;
-	pixel_y = -3;
-	name = "Chief Medical Officer's rubber stamp"
-	},
-/obj/item/tool/pen{
-	pixel_y = 3;
-	pixel_x = -6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/tool/hand_labeler{
-	pixel_x = 8;
-	pixel_y = 13
-	},
-/turf/open/floor/almayer/sterile_green_side/east,
-/area/almayer/medical/cmo_office)
+/turf/open/floor/grass,
+/area/almayer/medical/upper_medical)
 "tpd" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 4
@@ -89534,10 +89645,6 @@
 	},
 /turf/open/floor/almayer/bluefull,
 /area/almayer/command/cicconference)
-"tsC" = (
-/obj/structure/foamed_metal/iron,
-/turf/open/floor/plating,
-/area/almayer/medical/upper_medical)
 "tsE" = (
 /obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/plating/plating_catwalk,
@@ -90378,13 +90485,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/squads/alpha)
-"tOr" = (
-/obj/structure/flora/bush/ausbushes/var3/brflowers{
-	name = "fake brflowers";
-	desc = "Just like a real plant, but fake!"
-	},
-/turf/open/floor/grass,
-/area/almayer/medical/upper_medical)
 "tOu" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/item/device/demo_scanner{
@@ -91352,16 +91452,6 @@
 "uiT" = (
 /turf/open/floor/almayer/orange/north,
 /area/almayer/hallways/hangar)
-"uiW" = (
-/obj/structure/closet/secure_closet/personal/cabinet{
-	req_access_txt = "5"
-	},
-/obj/structure/sign/safety/bathunisex{
-	pixel_x = 2;
-	pixel_y = 29
-	},
-/turf/open/floor/almayer/flooredge/northeast,
-/area/almayer/medical/cmo_office)
 "uiZ" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/comdoor/reinforced{
 	dir = 1;
@@ -91536,9 +91626,6 @@
 /obj/item/tool/pen,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_a_s)
-"uol" = (
-/turf/closed/wall/almayer/outer/internal,
-/area/almayer/medical/cmo_office)
 "uoA" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 5
@@ -91558,10 +91645,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk/no_build,
 /area/almayer/underdeck/hangar)
-"upM" = (
-/obj/structure/stairs/multiz/down,
-/turf/open/floor/almayer/test_floor4,
-/area/almayer/medical/upper_medical)
 "upO" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer/cargo_arrow,
@@ -92062,21 +92145,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/hangar)
-"uAd" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "N";
-	pixel_y = 1
-	},
-/obj/structure/prop/invuln/lattice_prop{
-	icon_state = "lattice12";
-	pixel_y = 16
-	},
-/obj/structure/machinery/light/red{
-	light_color = "#BB3F3F";
-	dir = 1
-	},
-/turf/open/floor/almayer/no_build/plating,
-/area/almayer/middeck/medical)
 "uAj" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -92369,13 +92437,6 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/medical/morgue)
-"uGD" = (
-/obj/structure/machinery/door/airlock/almayer/white{
-	dir = 2;
-	name = "\improper Bathroom"
-	},
-/turf/open/floor/almayer/test_floor4,
-/area/almayer/medical/cmo_office)
 "uGQ" = (
 /obj/structure/machinery/suit_storage_unit/compression_suit/uscm,
 /turf/open/floor/almayer/plate,
@@ -93535,10 +93596,6 @@
 "vgw" = (
 /turf/closed/wall/almayer/outer,
 /area/almayer/engineering/lower)
-"vgx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/dark_sterile,
-/area/almayer/medical/cmo_office)
 "vgB" = (
 /obj/structure/window/framed/almayer/white,
 /obj/structure/machinery/door/firedoor/border_only/almayer,
@@ -95806,16 +95863,6 @@
 	},
 /turf/open/floor/almayer/green/southeast,
 /area/almayer/hallways/upper/fore_hallway)
-"vZY" = (
-/obj/structure/surface/table/reinforced/prison,
-/obj/structure/machinery/faxmachine/uscm/almayer{
-	pixel_x = -3;
-	pixel_y = 5;
-	sub_name = "Chief Medical Officer"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/sterile_green_side/east,
-/area/almayer/medical/cmo_office)
 "wab" = (
 /obj/vehicle/powerloader{
 	dir = 4
@@ -95943,10 +95990,6 @@
 	},
 /turf/open/floor/almayer/silver/north,
 /area/almayer/command/cic)
-"wcl" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/sterile_green_side/west,
-/area/almayer/medical/cmo_office)
 "wcm" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NW-out";
@@ -97537,11 +97580,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/shipboard/brig/general_equipment)
-"wJo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/machinery/light/small/blue,
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/medical/morgue)
 "wJC" = (
 /obj/structure/largecrate/random/barrel/yellow,
 /turf/open/floor/plating/plating_catwalk,
@@ -97896,10 +97934,6 @@
 "wQD" = (
 /turf/open/floor/almayer/orange/southeast,
 /area/almayer/engineering/lower/engine_core)
-"wQH" = (
-/obj/structure/pipes/standard/simple/hidden/supply,
-/turf/open/floor/almayer/sterile_green_corner/north,
-/area/almayer/medical/upper_medical)
 "wQI" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/emails{
@@ -98345,9 +98379,6 @@
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor/almayer_hull/outerhull_dir/east,
 /area/almayer/engineering/upper_engineering/port)
-"wZH" = (
-/turf/open/floor/almayer/test_floor4,
-/area/almayer/medical/upper_medical)
 "wZL" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/secure_data{
@@ -98496,13 +98527,6 @@
 	},
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/underdeck/hangar)
-"xcG" = (
-/obj/structure/coatrack{
-	pixel_x = -11;
-	pixel_y = 2
-	},
-/turf/open/floor/almayer/dark_sterile,
-/area/almayer/medical/cmo_office)
 "xcV" = (
 /obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/almayer/cargo,
@@ -98770,13 +98794,6 @@
 /obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/lower/l_f_s)
-"xiL" = (
-/obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
-	name = "\improper Psychiatric Care Unit";
-	req_access = list()
-	},
-/turf/open/floor/almayer/test_floor4,
-/area/almayer/medical/upper_medical)
 "xiP" = (
 /obj/structure/closet/secure_closet/engineering_welding{
 	req_one_access_txt = "7;23;27"
@@ -99595,12 +99612,6 @@
 "xzh" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/upper/u_m_p)
-"xzy" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/almayer/dark_sterile,
-/area/almayer/medical/cmo_office)
 "xzB" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/maint/hull/lower/l_f_s)
@@ -100251,13 +100262,6 @@
 	},
 /turf/open/floor/almayer/no_build/test_floor4,
 /area/almayer/underdeck/req)
-"xNu" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S";
-	layer = 3.3
-	},
-/turf/closed/wall/almayer/reinforced,
-/area/almayer/medical/cmo_office)
 "xNv" = (
 /obj/structure/platform/metal/almayer/north,
 /obj/structure/machinery/light{
@@ -100570,10 +100574,6 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/silver,
 /area/almayer/command/cic)
-"xUE" = (
-/obj/structure/machinery/light,
-/turf/open/floor/almayer/flooredge/south,
-/area/almayer/medical/cmo_office)
 "xUV" = (
 /turf/open/floor/almayer/silver,
 /area/almayer/command/combat_correspondent)
@@ -177156,7 +177156,7 @@ bWm
 bmU
 cbk
 cbk
-dGR
+cqG
 cbk
 bWm
 bmV
@@ -177467,12 +177467,12 @@ aOY
 aOY
 aOY
 aOY
-rkL
-bXK
-bXK
-uol
-uol
-uAd
+bhz
+bic
+bic
+bgG
+bgG
+aDL
 bcO
 bWs
 avN
@@ -177570,11 +177570,11 @@ aOY
 aOY
 aOY
 aOY
-kEp
-lUc
-kMI
-lgA
-bec
+cqu
+bXL
+biO
+bhk
+aUO
 blO
 bcO
 bcj
@@ -177673,11 +177673,11 @@ aOY
 aOY
 aOY
 aOY
-kEp
-bXL
-kmd
-lgA
-bec
+cqu
+bNx
+bjI
+bhk
+aUO
 blO
 aSj
 aSc
@@ -177776,11 +177776,11 @@ aOY
 aOY
 aOY
 aOY
-rkL
+bhz
 bGr
-bXJ
-uol
-bec
+bBU
+bgG
+aUO
 blP
 aSj
 bck
@@ -177872,17 +177872,17 @@ bGl
 bnv
 blH
 cax
-rkL
-bZs
-bZs
-bZs
-bZs
-bZs
-dEM
-rkL
-mMg
+bhz
+cqI
+cqI
+cqI
+cqI
+cqI
+cqA
+bhz
+bXM
 bGr
-rkL
+bhz
 bwp
 blO
 blH
@@ -177970,22 +177970,22 @@ bGg
 baF
 aOh
 baC
-rkL
-rkL
+bhz
+bhz
 bGj
-xNu
-rkL
-rkL
+crd
+bhz
+bhz
 btP
-nvK
-cdW
-ojs
-aBd
-jDE
-rkL
-bXM
-eIc
-rkL
+bZq
+cqR
+cqO
+cqK
+cqB
+bhz
+cov
+bKI
+bhz
 bck
 blP
 blH
@@ -178073,22 +178073,22 @@ bGg
 bnY
 bnY
 bnY
-rkL
-rkL
-rkL
-hme
+bhz
+bhz
+bhz
+cre
 aVP
-rkL
-gbP
-bZq
-xzy
-vgx
-dSG
-nDj
-wcl
-dqr
-gzY
-rkL
+bhz
+cqV
+cqE
+cqS
+cqw
+cqL
+cqC
+cqv
+cqs
+bLF
+bhz
 bWW
 blP
 blH
@@ -178176,22 +178176,22 @@ boD
 bbJ
 aOh
 baC
-rkL
-bGV
-rkL
-kol
-aLS
-dtQ
-bZq
-bZq
-vgx
-vgx
-bZq
-xcG
-vgx
-ceR
-ihH
-rkL
+bhz
+crl
+bhz
+crf
+cqZ
+cqY
+cqE
+cqE
+cqw
+cqw
+cqE
+cqD
+cqw
+cqt
+bMN
+bhz
 avN
 avN
 aIA
@@ -178279,23 +178279,23 @@ boE
 aYN
 bxI
 aYN
-rkL
-cOC
-uGD
-gFK
-xUE
-rkL
-gKz
-bZq
-bZq
-vgx
-hpL
-bZq
-ijq
+bhz
+crm
+crk
+crg
+cra
+bhz
+cqW
+cqE
+cqE
+cqw
+cqN
+cqE
+cqx
 bXN
-rkL
-rkL
-lwT
+bhz
+bhz
+bha
 bcP
 bcP
 bcP
@@ -178382,25 +178382,25 @@ boE
 bjf
 bah
 baC
-rkL
-oVl
-rkL
-uiW
-kbn
-rkL
-kwv
-vZY
-tpa
-osM
-rkL
-kGa
-rdB
-rkL
-rkL
-rkL
-nGU
-nGU
-iqw
+bhz
+crn
+bhz
+crj
+crb
+bhz
+cqX
+cqU
+cqT
+cqP
+bhz
+cqF
+cqy
+bhz
+bhz
+bhz
+bbi
+bbi
+aaD
 bWm
 bWj
 baC
@@ -178485,22 +178485,22 @@ aJM
 aWK
 cbq
 aWK
-rkL
-rkL
-rkL
-rkL
-rkL
-rkL
-rkL
-rkL
-rkL
-rkL
-rkL
-rkL
-rkL
-rkL
-rkL
-rkL
+bhz
+bhz
+bhz
+bhz
+bhz
+bhz
+bhz
+bhz
+bhz
+bhz
+bhz
+bhz
+bhz
+bhz
+bhz
+bhz
 aRQ
 aRQ
 aRQ
@@ -207749,7 +207749,7 @@ ceQ
 ajn
 ajp
 ajn
-gNe
+crt
 ajg
 ccX
 akA
@@ -207848,11 +207848,11 @@ chH
 chj
 aEN
 ajt
-cGU
+crv
 ajr
-cGU
+crv
 arb
-wJo
+cru
 aoe
 aoe
 ajl
@@ -207955,7 +207955,7 @@ cfy
 aoe
 skl
 ceS
-gXl
+aEO
 cfy
 aoe
 aoe
@@ -208056,13 +208056,13 @@ cgR
 ajt
 cfS
 aoe
-rHz
+crw
 arb
 arb
 aEN
 cfy
 aoe
-tsC
+crq
 ajl
 onQ
 cct
@@ -208159,13 +208159,13 @@ wUd
 ajy
 cfU
 aoe
-cez
-gXl
+crx
+aEO
 cfG
 ceA
 cfS
 aoe
-tsC
+crq
 ajl
 fOL
 aRS
@@ -208265,10 +208265,10 @@ aoe
 skl
 mfC
 ceS
-gXl
+aEO
 cfy
 aoe
-tsC
+crq
 ajl
 tEi
 vtx
@@ -208365,7 +208365,7 @@ cgS
 cgD
 cfS
 aoe
-rHz
+crw
 arb
 arb
 aoe
@@ -208469,13 +208469,13 @@ cgF
 cfy
 aoe
 skl
-gXl
+aEO
 ceS
 aCo
-cdY
-cdY
-cdY
-upM
+crr
+crr
+crr
+crp
 ccH
 alD
 ccj
@@ -208569,16 +208569,16 @@ aoe
 aoe
 jTj
 cgG
-aEO
+cry
 isN
-aEO
+cry
 arb
-wJo
+cru
 aoe
-cdY
-cdY
-cdY
-upM
+crr
+crr
+crr
+crp
 rrD
 vQN
 ccl
@@ -208678,11 +208678,11 @@ cfW
 ePX
 jZY
 aoe
-cdY
-cdY
+crr
+crr
 ajl
 ajl
-fFO
+cro
 vQN
 ccm
 gWG
@@ -208781,8 +208781,8 @@ chr
 ceS
 ceA
 aoe
-cdY
-cdY
+crr
+crr
 ajl
 fEC
 uRt
@@ -208987,8 +208987,8 @@ aoe
 aoe
 aoe
 aoe
-lmk
-lmk
+crs
+crs
 ajl
 ccW
 uRt
@@ -209182,7 +209182,7 @@ ciE
 ciA
 ciw
 ccn
-anz
+crE
 chV
 cht
 cgW
@@ -209388,7 +209388,7 @@ rSW
 dNv
 rSW
 sqf
-bGp
+crF
 aSn
 lYL
 pNP
@@ -209698,7 +209698,7 @@ efV
 bBH
 ajl
 hng
-bWV
+axm
 hPN
 ajl
 vOy
@@ -209801,8 +209801,8 @@ lGh
 qmW
 ajl
 xyt
-axm
-tOr
+crB
+tpa
 cek
 vOy
 vOy
@@ -209902,10 +209902,10 @@ abE
 tkF
 qdJ
 bMW
-xiL
+crI
 akw
 bIM
-kds
+crA
 mzq
 sqf
 vOy
@@ -210004,9 +210004,9 @@ afs
 agA
 lXl
 iCT
-gFD
-gKR
-wQH
+crL
+crJ
+crG
 wiW
 chu
 lFn
@@ -210109,10 +210109,10 @@ lXl
 yiu
 cih
 ajl
-cbn
-aID
+crH
+crC
 ydE
-jFQ
+crz
 sqf
 cgb
 vdO
@@ -210211,11 +210211,11 @@ agA
 lXl
 yiu
 bMW
-xiL
+crI
 aAr
 pGK
 chw
-tOr
+tpa
 sqf
 cgb
 dHV
@@ -210314,8 +210314,8 @@ abE
 tkF
 yiu
 bMW
-wZH
-aID
+crK
+crC
 gLc
 wub
 mzq

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -50297,13 +50297,7 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/maint/hull/lower/l_m_s)
-"cqJ" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/processing)
-"cqK" = (
+"cqI" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/ashtray/plastic{
 	pixel_x = -6;
@@ -50326,7 +50320,13 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/west,
 /area/almayer/medical/cmo_office)
-"cqL" = (
+"cqJ" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/processing)
+"cqK" = (
 /obj/structure/machinery/door_control{
 	id = "CMO Shutters";
 	name = "\improper Office Privacy Shutters";
@@ -50336,6 +50336,13 @@
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/cmo_office)
+"cqL" = (
+/obj/structure/machinery/light/blue{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/medical/cmo_office)
 "cqM" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 8
@@ -50343,18 +50350,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/brig/processing)
 "cqN" = (
-/obj/structure/machinery/light/blue{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/dark_sterile,
-/area/almayer/medical/cmo_office)
-"cqO" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/device/flash,
 /turf/open/floor/almayer/sterile_green_side/west,
 /area/almayer/medical/cmo_office)
-"cqP" = (
+"cqO" = (
 /obj/structure/machinery/photocopier{
 	layer = 2.9;
 	pixel_y = 8;
@@ -50363,17 +50363,7 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/east,
 /area/almayer/medical/cmo_office)
-"cqQ" = (
-/obj/structure/pipes/standard/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/open/floor/almayer,
-/area/almayer/shipboard/starboard_missiles)
-"cqR" = (
+"cqP" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/structure/machinery/computer/cameras/containment{
 	name = "Research Cameras";
@@ -50388,13 +50378,23 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/west,
 /area/almayer/medical/cmo_office)
-"cqS" = (
+"cqQ" = (
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/starboard_missiles)
+"cqR" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/cmo_office)
-"cqT" = (
+"cqS" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/paper_bin/wy{
 	pixel_y = 8;
@@ -50416,7 +50416,7 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/east,
 /area/almayer/medical/cmo_office)
-"cqU" = (
+"cqT" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/structure/machinery/faxmachine/uscm/almayer{
 	pixel_x = -3;
@@ -50426,7 +50426,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/sterile_green_side/east,
 /area/almayer/medical/cmo_office)
-"cqV" = (
+"cqU" = (
 /obj/structure/filingcabinet/filingcabinet{
 	density = 0;
 	pixel_x = 7;
@@ -50450,7 +50450,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/cmo_office)
-"cqW" = (
+"cqV" = (
 /obj/structure/machinery/computer/med_data{
 	pixel_x = -9;
 	pixel_y = 0
@@ -50465,7 +50465,7 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/cmo_office)
-"cqX" = (
+"cqW" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_29";
 	pixel_y = 12;
@@ -50473,7 +50473,7 @@
 	},
 /turf/open/floor/almayer/sterile_green_corner,
 /area/almayer/medical/cmo_office)
-"cqY" = (
+"cqX" = (
 /obj/structure/machinery/door/airlock/almayer/white{
 	name = "\improper CMO's Bedroom";
 	req_one_access = list(28,206,207);
@@ -50482,14 +50482,14 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/cmo_office)
-"cqZ" = (
+"cqY" = (
 /turf/open/floor/almayer/flooredge/south,
 /area/almayer/medical/cmo_office)
-"cra" = (
+"cqZ" = (
 /obj/structure/machinery/light,
 /turf/open/floor/almayer/flooredge/south,
 /area/almayer/medical/cmo_office)
-"crb" = (
+"cra" = (
 /obj/structure/bed,
 /obj/item/bedsheet/green,
 /obj/structure/sign/poster/hunk{
@@ -50497,6 +50497,13 @@
 	pixel_y = 0
 	},
 /turf/open/floor/almayer/flooredge/southeast,
+/area/almayer/medical/cmo_office)
+"crb" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S";
+	layer = 3.3
+	},
+/turf/closed/wall/almayer/reinforced,
 /area/almayer/medical/cmo_office)
 "crc" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -50510,20 +50517,13 @@
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/hallways/lower/port_midship_hallway)
 "crd" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "S";
-	layer = 3.3
-	},
-/turf/closed/wall/almayer/reinforced,
-/area/almayer/medical/cmo_office)
-"cre" = (
 /obj/structure/machinery/cm_vending/clothing/senior_officer{
 	pixel_y = 19;
 	density = 0
 	},
 /turf/open/floor/almayer/flooredge/northwest,
 /area/almayer/medical/cmo_office)
-"crf" = (
+"cre" = (
 /obj/structure/bookcase{
 	icon_state = "book-5";
 	pixel_x = -1;
@@ -50537,8 +50537,18 @@
 /obj/item/book/manual/medical_diagnostics_manual,
 /turf/open/floor/almayer/flooredge/north,
 /area/almayer/medical/cmo_office)
-"crg" = (
+"crf" = (
 /turf/open/floor/almayer/flooredge/north,
+/area/almayer/medical/cmo_office)
+"crg" = (
+/obj/structure/closet/secure_closet/personal/cabinet{
+	req_access_txt = "5"
+	},
+/obj/structure/sign/safety/bathunisex{
+	pixel_x = 2;
+	pixel_y = 29
+	},
+/turf/open/floor/almayer/flooredge/northeast,
 /area/almayer/medical/cmo_office)
 "crh" = (
 /obj/structure/machinery/light{
@@ -50554,23 +50564,13 @@
 /turf/open/floor/almayer/plate,
 /area/almayer/maint/hull/upper/u_f_s)
 "crj" = (
-/obj/structure/closet/secure_closet/personal/cabinet{
-	req_access_txt = "5"
-	},
-/obj/structure/sign/safety/bathunisex{
-	pixel_x = 2;
-	pixel_y = 29
-	},
-/turf/open/floor/almayer/flooredge/northeast,
-/area/almayer/medical/cmo_office)
-"crk" = (
 /obj/structure/machinery/door/airlock/almayer/white{
 	dir = 2;
 	name = "\improper Bathroom"
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/cmo_office)
-"crl" = (
+"crk" = (
 /obj/structure/machinery/door/window/westright{
 	dir = 4
 	},
@@ -50587,7 +50587,7 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/cmo_office)
-"crm" = (
+"crl" = (
 /obj/structure/sink{
 	pixel_y = 22;
 	pixel_x = 0
@@ -50598,7 +50598,7 @@
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/cmo_office)
-"crn" = (
+"crm" = (
 /obj/structure/toilet{
 	dir = 8;
 	layer = 2.9;
@@ -50607,7 +50607,7 @@
 /obj/structure/machinery/light/small,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/cmo_office)
-"cro" = (
+"crn" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NE-out";
 	pixel_y = 1
@@ -50622,7 +50622,7 @@
 	},
 /turf/open/floor/almayer/no_build/plate,
 /area/almayer/middeck/medical)
-"crp" = (
+"cro" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NE-out";
 	pixel_y = 1;
@@ -50640,33 +50640,33 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/almayer/medical/upper_medical)
-"crq" = (
+"crp" = (
 /obj/structure/stairs/multiz/down,
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/upper_medical)
-"crr" = (
+"crq" = (
 /obj/structure/foamed_metal/iron,
 /turf/open/floor/plating,
 /area/almayer/medical/upper_medical)
-"crs" = (
+"crr" = (
 /turf/open_space,
 /area/almayer/medical/upper_medical)
-"crt" = (
+"crs" = (
 /obj/structure/stairs/multiz/down{
 	dir = 4
 	},
 /turf/closed/wall/almayer/white,
 /area/almayer/medical/upper_medical)
-"cru" = (
+"crt" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/flooredge/west,
 /area/almayer/medical/morgue)
-"crv" = (
+"cru" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/light/small/blue,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/morgue)
-"crw" = (
+"crv" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "test_square_smooth"
 	},
@@ -50675,7 +50675,7 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/medical/morgue)
-"crx" = (
+"crw" = (
 /obj/structure/morgue{
 	dir = 2
 	},
@@ -50687,7 +50687,7 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/medical/morgue)
-"cry" = (
+"crx" = (
 /obj/structure/morgue{
 	dir = 2
 	},
@@ -50699,14 +50699,14 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/almayer/medical/morgue)
-"crz" = (
+"cry" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "test_square_smooth"
 	},
 /obj/structure/morgue,
 /turf/open/floor/almayer/plate,
 /area/almayer/medical/morgue)
-"crA" = (
+"crz" = (
 /obj/structure/flora/bush/ausbushes/var3/fullgrass{
 	desc = "Just like a real plant, but fake!";
 	name = "fake fullgrass"
@@ -50717,7 +50717,7 @@
 	},
 /turf/open/floor/grass,
 /area/almayer/medical/upper_medical)
-"crB" = (
+"crA" = (
 /obj/structure/platform/metal/almayer/north{
 	dir = 2
 	},
@@ -50733,7 +50733,7 @@
 	},
 /turf/open/floor/almayer/mono,
 /area/almayer/medical/upper_medical)
-"crC" = (
+"crB" = (
 /obj/structure/platform/metal/almayer/north{
 	dir = 2
 	},
@@ -50748,14 +50748,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/upper_medical)
+"crC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/dark_sterile,
+/area/almayer/medical/upper_medical)
 "crD" = (
 /turf/open/floor/almayer/greencorner/north,
 /area/almayer/squads/req)
 "crE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/almayer/dark_sterile,
-/area/almayer/medical/upper_medical)
-"crF" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/safety/hazard{
@@ -50768,38 +50768,38 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/east,
 /area/almayer/medical/upper_medical)
-"crG" = (
+"crF" = (
 /obj/structure/closet/secure_closet/guncabinet/red/armory_m39_submachinegun,
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/almayer/redfull,
 /area/almayer/medical/upper_medical)
-"crH" = (
+"crG" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/sterile_green_corner/north,
 /area/almayer/medical/upper_medical)
-"crI" = (
+"crH" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	name = "ship-grade camera"
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/almayer/medical/upper_medical)
-"crJ" = (
+"crI" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Psychiatric Care Unit";
 	req_access = list()
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/upper_medical)
-"crK" = (
+"crJ" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/upper_medical)
-"crL" = (
+"crK" = (
 /turf/open/floor/almayer/test_floor4,
 /area/almayer/medical/upper_medical)
-"crM" = (
+"crL" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/flooredge/south,
 /area/almayer/hallways/upper/midship_hallway)
@@ -177973,14 +177973,14 @@ baC
 bhz
 bhz
 bGj
-crd
+crb
 bhz
 bhz
 btP
 bZq
-cqR
-cqO
-cqK
+cqP
+cqN
+cqI
 cqB
 bhz
 cov
@@ -178076,14 +178076,14 @@ bnY
 bhz
 bhz
 bhz
-cre
+crd
 aVP
 bhz
-cqV
+cqU
 cqE
-cqS
+cqR
 cqw
-cqL
+cqK
 cqC
 cqv
 cqs
@@ -178177,11 +178177,11 @@ bbJ
 aOh
 baC
 bhz
-crl
+crk
 bhz
-crf
-cqZ
+cre
 cqY
+cqX
 cqE
 cqE
 cqw
@@ -178277,19 +178277,19 @@ bjq
 bjl
 boE
 aYN
-cro
+crn
 baC
 bhz
-crm
-crk
-crg
-cra
+crl
+crj
+crf
+cqZ
 bhz
-cqW
+cqV
 cqE
 cqE
 cqw
-cqN
+cqL
 cqE
 cqx
 bXN
@@ -178383,15 +178383,15 @@ bjf
 bah
 baC
 bhz
-crn
+crm
 bhz
-crj
-crb
+crg
+cra
 bhz
-cqX
-cqU
+cqW
 cqT
-cqP
+cqS
+cqO
 bhz
 cqF
 cqy
@@ -207749,7 +207749,7 @@ ceQ
 ajn
 ajp
 ajn
-cru
+crt
 ajg
 ccX
 akA
@@ -207848,11 +207848,11 @@ chH
 chj
 aEN
 ajt
-crw
-ajr
-crw
-arb
 crv
+ajr
+crv
+arb
+cru
 aoe
 aoe
 ajl
@@ -208056,13 +208056,13 @@ cgR
 ajt
 cfS
 aoe
-crx
+crw
 arb
 arb
 aEN
 cfy
 aoe
-crr
+crq
 ajl
 onQ
 cct
@@ -208159,13 +208159,13 @@ wUd
 ajy
 cfU
 aoe
-cry
+crx
 aEO
 cfG
 ceA
 cfS
 aoe
-crr
+crq
 ajl
 fOL
 aRS
@@ -208268,7 +208268,7 @@ ceS
 aEO
 cfy
 aoe
-crr
+crq
 ajl
 tEi
 vtx
@@ -208365,7 +208365,7 @@ cgS
 cgD
 cfS
 aoe
-crx
+crw
 arb
 arb
 aoe
@@ -208472,10 +208472,10 @@ skl
 aEO
 ceS
 aoe
-crs
-crs
-crs
-crq
+crr
+crr
+crr
+crp
 ccH
 alD
 ccj
@@ -208569,16 +208569,16 @@ aoe
 aoe
 jTj
 cgG
-crz
+cry
 isN
-crz
+cry
 arb
-crv
+cru
 aoe
-crs
-crs
-crs
-crq
+crr
+crr
+crr
+crp
 rrD
 vQN
 ccl
@@ -208678,11 +208678,11 @@ cfW
 ePX
 jZY
 aoe
-crs
-crs
+crr
+crr
 ajl
 ajl
-crp
+cro
 vQN
 ccm
 gWG
@@ -208781,8 +208781,8 @@ chr
 ceS
 ceA
 aoe
-crs
-crs
+crr
+crr
 ajl
 fEC
 uRt
@@ -208987,8 +208987,8 @@ aoe
 aoe
 aoe
 aoe
-crt
-crt
+crs
+crs
 ajl
 ccW
 uRt
@@ -209182,7 +209182,7 @@ ciE
 ciA
 ciw
 ccn
-crF
+crE
 chV
 cht
 cgW
@@ -209388,7 +209388,7 @@ rSW
 dNv
 rSW
 sqf
-crG
+crF
 aSn
 lYL
 pNP
@@ -209801,7 +209801,7 @@ lGh
 qmW
 ajl
 xyt
-crC
+crB
 tpa
 cek
 vOy
@@ -209902,10 +209902,10 @@ abE
 tkF
 qdJ
 bMW
-crJ
+crI
 akw
 bIM
-crB
+crA
 mzq
 sqf
 vOy
@@ -210004,9 +210004,9 @@ afs
 agA
 lXl
 iCT
-crM
-crK
-crH
+crL
+crJ
+crG
 wiW
 chu
 lFn
@@ -210109,10 +210109,10 @@ lXl
 yiu
 cih
 ajl
-crI
-crE
+crH
+crC
 ydE
-crA
+crz
 sqf
 cgb
 vdO
@@ -210211,7 +210211,7 @@ agA
 lXl
 yiu
 bMW
-crJ
+crI
 aAr
 pGK
 chw
@@ -210314,8 +210314,8 @@ abE
 tkF
 yiu
 bMW
-crL
-crE
+crK
+crC
 gLc
 wub
 mzq

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -10996,12 +10996,6 @@
 "aCn" = (
 /turf/open/floor/almayer/orange/southeast,
 /area/almayer/engineering/upper_engineering)
-"aCo" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "test_square_smooth"
-	},
-/turf/closed/wall/almayer/white,
-/area/almayer/medical/morgue)
 "aCp" = (
 /turf/open/floor/almayer/flooredgesmooth2/west,
 /area/almayer/command/cichallway)
@@ -23618,7 +23612,7 @@
 /area/almayer/middeck/medical)
 "bic" = (
 /obj/structure/window/framed/almayer,
-/turf/open/floor/almayer/dark_sterile,
+/turf/open/floor/plating,
 /area/almayer/medical/cmo_office)
 "bid" = (
 /turf/open/floor/plating/plating_catwalk,
@@ -50195,7 +50189,7 @@
 "cqu" = (
 /obj/structure/window/framed/almayer/white,
 /obj/structure/window/framed/almayer,
-/turf/open/floor/almayer/dark_sterile,
+/turf/open/floor/plating,
 /area/almayer/medical/cmo_office)
 "cqv" = (
 /obj/effect/decal/cleanable/dirt,
@@ -50228,7 +50222,7 @@
 	id = "CMO Shutters";
 	name = "\improper CMO Office Shutters"
 	},
-/turf/open/floor/almayer/sterile_green_side/southeast,
+/turf/open/floor/plating,
 /area/almayer/medical/cmo_office)
 "cqB" = (
 /obj/structure/surface/table/reinforced/prison,
@@ -50303,15 +50297,6 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/maint/hull/lower/l_m_s)
-"cqI" = (
-/obj/structure/window/framed/almayer,
-/obj/structure/machinery/door/poddoor/shutters/almayer/open{
-	dir = 4;
-	id = "CMO Shutters";
-	name = "\improper CMO Office Shutters"
-	},
-/turf/open_space,
-/area/almayer/medical/cmo_office)
 "cqJ" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -177888,11 +177873,11 @@ bnv
 blH
 cax
 bhz
-cqI
-cqI
-cqI
-cqI
-cqI
+cqA
+cqA
+cqA
+cqA
+cqA
 cqA
 bhz
 bXM
@@ -208384,7 +208369,7 @@ crx
 arb
 arb
 aoe
-aCo
+aoe
 aoe
 ajl
 ajl
@@ -208486,7 +208471,7 @@ aoe
 skl
 aEO
 ceS
-aCo
+aoe
 crs
 crs
 crs


### PR DESCRIPTION
# About the pull request

Moves the upper CMO office from it's current location to lower deck. Armory and Psych unit moved to allow for this. Morgue expanded to fill space (needed to be more trays imho anyway)

<img width="893" height="949" alt="image" src="https://github.com/user-attachments/assets/e0aea5c0-789a-4cd8-80b2-440f7d75ecdb" />

<img width="1089" height="671" alt="image" src="https://github.com/user-attachments/assets/2e854660-1636-40c3-a05f-e473b8741a8b" />


# Explain why it's good for the game

With the Medical Remap recently, the CMO's office; which was ALREADY extremely removed from where the CMO spends most of their time became even further away. Being in your office is griefing, which sucks as CMO has heavy roleplay elements but has to be like a 20 seconds run from getting to lower (and they wont know something is wrong to begin with because of the lack of way to see lower anyway)

This resolves both of this problems, you can now see lower medical in your office at all times, AND it's closer to the ladders to actually get there.

Plus this has so much aura, I can lord over my doctors now...

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
maptweak: CMO's office has been moved to Mid-Deck, overlooking lower. Upper Medical has been remapped to compensate. You still can't build in CMO office, don't get any ideas!
/:cl: