### PR TITLE
Fix de-evolution logging

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Evolution.dm
@@ -425,9 +425,10 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 
 	SEND_SIGNAL(src, COMSIG_XENO_DEEVOLVE)
 
+	var/old_name = key_name(src)
 	var/mob/living/carbon/xenomorph/new_xeno = transmute(newcaste)
 	if(new_xeno)
-		log_game("EVOLVE: [key_name(new_xeno)] de-evolved into [new_xeno]. (Location: [AREACOORD(new_xeno.loc)])")
+		log_game("EVOLVE: [old_name] de-evolved into [new_xeno]. (Location: [AREACOORD(new_xeno.loc)])")
 
 	if(new_xeno.ckey)
 		GLOB.deevolved_ckeys += new_xeno.ckey


### PR DESCRIPTION

# About the pull request

This PR simply makes it so the from part in the de-evolution log mentions the old caste.

# Explain why it's good for the game

Correct logs!

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Old: 
<img width="900" height="700" alt="image" src="https://github.com/user-attachments/assets/9280822b-e628-49b6-b6f5-19482c7aec2b" />
New: 
<img width="900" height="700" alt="image" src="https://github.com/user-attachments/assets/ebe871c5-f797-415e-8bcb-2fac469c8c84" />


</details>


# Changelog

No player facing changes.
