### PR TITLE
Fix: Field Doc Door and shutter access

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -17042,7 +17042,7 @@
 	pixel_y = -6;
 	throw_range = 15;
 	pixel_x = 25;
-	req_one_access_txt = "5;19;39"
+	req_one_access_txt = "5;19;38"
 	},
 /obj/structure/sign/safety/storage{
 	pixel_x = 32;
@@ -53861,7 +53861,7 @@
 /obj/structure/machinery/door/airlock/almayer/medical{
 	name = "\improper Field Medical Equipment Storage";
 	req_one_access = null;
-	req_one_access_txt = "5;19;39"
+	req_one_access_txt = "5;19;38"
 	},
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	layer = 1.9


### PR DESCRIPTION

# About the pull request
Fixing myself forgetting to change this when I changed Field Doc access to 38 when I killed something else.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Smol oops
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Field Doc can access their room again
/:cl:
