### PR TITLE
Removes niche Radio channels from IO headset

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -157,7 +157,7 @@
 /obj/item/device/encryptionkey/io
 	name = "\improper Marine Intelligence Officer Radio Encryption Key"
 	icon_state = "cap_key"
-	channels = list(RADIO_CHANNEL_COMMAND = TRUE, RADIO_CHANNEL_ENGI = TRUE, RADIO_CHANNEL_REQ = TRUE, RADIO_CHANNEL_JTAC = TRUE, RADIO_CHANNEL_MEDSCI = TRUE, SQUAD_MARINE_1 = FALSE, SQUAD_MARINE_2 = FALSE, SQUAD_MARINE_3 = FALSE, SQUAD_MARINE_4 = FALSE, SQUAD_MARINE_5 = FALSE, SQUAD_MARINE_CRYO = FALSE)
+	channels = list(RADIO_CHANNEL_COMMAND = TRUE, RADIO_CHANNEL_JTAC = TRUE, SQUAD_MARINE_1 = FALSE, SQUAD_MARINE_2 = FALSE, SQUAD_MARINE_3 = FALSE, SQUAD_MARINE_4 = FALSE, SQUAD_MARINE_5 = FALSE, SQUAD_MARINE_CRYO = FALSE)
 
 /obj/item/device/encryptionkey/vc
 	name = "\improper Marine Vehicle Crewman Radio Encryption Key"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -635,7 +635,7 @@
 
 /obj/item/device/radio/headset/almayer/mcom/io
 	name = "marine intel radio headset"
-	desc = "Used by Intelligence Officers. Channels are as follows: :v - marine command, :a - alpha squad, :b - bravo squad, :c - charlie squad, :d - delta squad, :n - engineering, :m - medical, :j - JTAC, :t - intel."
+	desc = "Used by Intelligence Officers. Channels are as follows: :v - marine command, :a - alpha squad, :b - bravo squad, :c - charlie squad, :d - delta squad, :j - JTAC, :t - intel."
 	initial_keys = list(/obj/item/device/encryptionkey/almayer, /obj/item/device/encryptionkey/io)
 	frequency = INTEL_FREQ
 


### PR DESCRIPTION

# About the pull request

* Removes REQ, Engi, and Medical radio channels from IO headset. Shipside channels that IO doesnt require access to in standart gameplay, or wich only have redunant uses.

# Explain why it's good for the game

IO is plauged with stuff that it really doesnt need. One of wich, being the 10 billion radio channels it starts of with.

This only removes unneded shipside radio channels.
Engi and REQ is simple. Why do they even need this? They have nothing to do with engi, and dont handel supplys in the slightest. They simply have them just because.

Medical is also completly unneded simply because Researchers have already intel channel access.
If IOs wanna talk with researchers about intel, they simply need to use their own channel meant to be used to talk about intel. Its even called the Intel channel.

All these channels MIGHT be usefull for IOs. But thats it, they only MIGHT be usefull. Generally they are completly unneded and clutter the chatbox. Yes, you can turn them of. But to bother most players with smth, just so a handfull doesnt have to walk to REQ is nonsense.
Their uses for IOs are niche, and if someone really needs em they can simply ask REQ for a radio key for them.
Tools for niche playstyles shouldnt be shoved into the regular players hands. We already have less intrusive tools to provide players with stuff for their niche playstyles. We should use em.


Anyone is free to message me on Discord under NHC for any direct feedback if they wish to.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:NHC
del: Removed IOs roundstart access to Med, REQ and Engi comms channels.
/:cl:
