### PR TITLE
Reverts 12678

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -165,6 +165,8 @@
 #define EXPLOSION_THRESHOLD_GIB 200
 /// prone mobs receive less damage from explosions
 #define EXPLOSION_PRONE_MULTIPLIER 0.5
+/// dead prone mobs recieve less damage from explosions, but more than alive humans
+#define EXPLOSION_DEAD_MULTIPLIER 0.75
 
 //Explosion damage multipliers for different objects
 #define EXPLOSION_DAMAGE_MULTIPLIER_DOOR 15

--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -165,8 +165,6 @@
 #define EXPLOSION_THRESHOLD_GIB 200
 /// prone mobs receive less damage from explosions
 #define EXPLOSION_PRONE_MULTIPLIER 0.5
-/// dead prone mobs recieve less damage from explosions, but more than alive humans
-#define EXPLOSION_DEAD_MULTIPLIER 0.75
 
 //Explosion damage multipliers for different objects
 #define EXPLOSION_DAMAGE_MULTIPLIER_DOOR 15

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -145,8 +145,11 @@
 			. += "Self Destruct Status: [SShijack.get_sd_eta()]"
 
 /mob/living/carbon/human/ex_act(severity, direction, datum/cause_data/cause_data, pierce=0, enviro=FALSE)
-	if(body_position == LYING_DOWN && direction)
-		severity *= EXPLOSION_PRONE_MULTIPLIER
+	if(body_position == LYING_DOWN)
+		if(stat == DEAD)
+			severity *= EXPLOSION_DEAD_MULTIPLIER
+		else if(direction)
+			severity *= EXPLOSION_PRONE_MULTIPLIER
 
 	var/b_loss = 0
 	var/f_loss = 0
@@ -201,8 +204,7 @@
 		var/knockout_minus_armor = min(knockout_value * bomb_armor_mult * 0.5, 0.5 SECONDS) // the KO time is halved from the knockdown timer. basically same stun time, you just spend less time KO'd.
 		apply_effect(floor(knockout_minus_armor), PARALYZE)
 		apply_effect(floor(knockout_minus_armor) * 2, DAZE)
-	if(stat != DEAD || severity > EXPLOSION_THRESHOLD_LOW)
-		explosion_throw(severity, direction)
+	explosion_throw(severity, direction)
 
 	if(item1 && isturf(item1.loc))
 		item1.explosion_throw(severity, direction)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -145,11 +145,8 @@
 			. += "Self Destruct Status: [SShijack.get_sd_eta()]"
 
 /mob/living/carbon/human/ex_act(severity, direction, datum/cause_data/cause_data, pierce=0, enviro=FALSE)
-	if(body_position == LYING_DOWN)
-		if(stat == DEAD)
-			severity *= EXPLOSION_DEAD_MULTIPLIER
-		else if(direction)
-			severity *= EXPLOSION_PRONE_MULTIPLIER
+	if(body_position == LYING_DOWN && direction)
+		severity *= EXPLOSION_PRONE_MULTIPLIER
 
 	var/b_loss = 0
 	var/f_loss = 0


### PR DESCRIPTION
# About the pull request

title
https://discord.com/channels/150315577943130112/964684928161808384/1529927932603142197

# Explain why it's good for the game
1. The original statement in the PR about HEDP being too available is not true. HEDP is the most expensive item in the marine vendor, and req starts with one box and around 2 more packets, and most of the time its given to the GL, and marines that don't focus on recovering people.

2. Second statement about people preferring corpses being glued to the ground instead of taking more damage is wrong, clearly seen by the amount of dislikes and overall feedback

3. The feedback on the original PR has been overwhelmingly negative, both in discord and PR feedback threads, it was speedmerged without taking any feedback. https://forum.cm-ss13.com/t/hedp-body-pushback-discussion/21038

4. Marines who recover bodies aren't usually just riflemen but medics that aren't supposed to be pushing, which I assume was the point of this PR, to make people push more, this does not fix the issue.

# Testing Photographs and Procedure


<details>
<summary>Screenshots & Videos</summary>

</details>


# Changelog

:cl: george
balance: Humans can be moved by explosions again.
/:cl:
