### PR TITLE
Armour light tweaks

### DIFF
--- a/code/modules/clothing/suits/marine_armor/_marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor/_marine_armor.dm
@@ -84,7 +84,7 @@
 		/obj/item/storage/belt/gun/xm51,
 	)
 
-	light_power = 3
+	light_power = 4
 	light_range = 4
 	light_color = LIGHT_COLOR_TUNGSTEN
 	light_system = MOVABLE_LIGHT
@@ -280,7 +280,6 @@
 	armor_rad = CLOTHING_ARMOR_MEDIUM
 	flags_bodypart_hidden = BODY_FLAG_CHEST|BODY_FLAG_LEGS
 	storage_slots = 4
-	light_range = 5 //slightly higher
 	specialty = "M4 pattern marine"
 
 /obj/item/clothing/suit/storage/marine/medium/rto/army
@@ -437,7 +436,7 @@
 // M3 pattern marine armor
 /obj/item/clothing/suit/storage/marine/medium
 	armor_variation = 6
-	light_power = 4
+	light_range = 5
 
 /obj/item/clothing/suit/storage/marine/medium/padded
 	name = "M3 pattern padded marine armor"
@@ -666,7 +665,6 @@
 	storage_slots = 2
 	slowdown = SLOWDOWN_ARMOR_LOWHEAVY
 	movement_compensation = SLOWDOWN_ARMOR_MEDIUM
-	light_power = 4
 	light_range = 5
 
 /obj/item/clothing/suit/storage/marine/heavy/padded


### PR DESCRIPTION

# About the pull request
Buffs medium armour light to 5 tiles (in line with heavy) increases light armour power to 4 (slightly more clarity on tiles you can already see)
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Medium armour has always been seen as more of a noob trap than anything, considering there are actual direct upgrades in multiple forms, technically heavy armour has the downside of suffering from slowdowns faster than medium, however everything else including the extra tile of light makes you feel like youre just running light armour but worse. equalising it to be in the same boat as heavy in regards of lighting should help it feel like an upgrade to light armour.

Minor change to light armour, improved clarity in what you can see within the 4 tiles of lighting range you get, medium and heavy are still clear upgrades but makes seeing slightly less frustrating, shouldnt be a major benefit to those who already run it.
# Testing Photographs and Procedure
<img width="700" height="350" alt="image" src="https://github.com/user-attachments/assets/a6b86de9-6ca8-4db5-b3dc-799b905c080b" /> 
<img width="554" height="554" alt="image" src="https://github.com/user-attachments/assets/6a99e9c5-0ec2-4289-a3a4-0dae144e2427" />



# Changelog
:cl:
balance: medium armour range increased to 5
balance: light armour power increased to 4
/:cl:
