### PR TITLE
FIX: Roller Beds and Surgical Beds are now always collapsed when spawned in

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/medical.dm
+++ b/code/game/machinery/vending/vendor_types/crew/medical.dm
@@ -391,8 +391,8 @@ GLOBAL_LIST_INIT(cm_vending_clothing_field_doctor, list(
 		/obj/item/storage/surgical_case/regular,
 		/obj/item/clothing/accessory/stethoscope,
 		/obj/item/device/flashlight/pen,
-		/obj/structure/bed/portable_surgery,
-		/obj/structure/bed/roller,
+		/obj/item/roller/surgical,
+		/obj/item/roller,
 	)
 
 /obj/effect/essentials_set/medical/doctor
@@ -406,8 +406,8 @@ GLOBAL_LIST_INIT(cm_vending_clothing_field_doctor, list(
 		/obj/item/clothing/accessory/stethoscope,
 		/obj/item/device/flashlight/pen,
 		/obj/item/storage/syringe_case,
-		/obj/structure/bed/portable_surgery,
-		/obj/structure/bed/roller,
+		/obj/item/roller/surgical,
+		/obj/item/roller,
 	)
 
 /obj/effect/essentials_set/medical/doctor/field
@@ -421,8 +421,8 @@ GLOBAL_LIST_INIT(cm_vending_clothing_field_doctor, list(
 		/obj/item/clothing/accessory/stethoscope,
 		/obj/item/device/flashlight/pen,
 		/obj/item/storage/syringe_case,
-		/obj/structure/bed/portable_surgery,
-		/obj/structure/bed/roller,
+		/obj/item/roller/surgical,
+		/obj/item/roller,
 		/obj/item/clothing/shoes/marine,
 		/obj/item/storage/box/mre,
 		/obj/item/device/radio/marine,

--- a/code/game/machinery/vending/vendor_types/crew/synthetic.dm
+++ b/code/game/machinery/vending/vendor_types/crew/synthetic.dm
@@ -40,7 +40,7 @@
 		list("Stasis Bag", 6, /obj/item/bodybag/cryobag, null, VENDOR_ITEM_REGULAR),
 		list("MS-11 Smart Refill Tank", 6, /obj/item/reagent_container/glass/minitank, null, VENDOR_ITEM_REGULAR),
 		list("Blood", 5, /obj/item/reagent_container/blood/OMinus, null, VENDOR_ITEM_REGULAR),
-		list("Surgical Bed", 10, /obj/structure/bed/portable_surgery, null, VENDOR_ITEM_REGULAR),
+		list("Surgical Bed", 10, /obj/item/roller/surgical, null, VENDOR_ITEM_REGULAR),
 
 		list("Pill Bottle (Bicaridine)", 5, /obj/item/storage/pill_bottle/bicaridine, null, VENDOR_ITEM_RECOMMENDED),
 		list("Pill Bottle (Dexalin)", 5, /obj/item/storage/pill_bottle/dexalin, null, VENDOR_ITEM_REGULAR),

--- a/code/modules/gear_presets/clf.dm
+++ b/code/modules/gear_presets/clf.dm
@@ -319,7 +319,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/explosive/grenade/custom/ied(new_human), WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/firstaid/adv(new_human), WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/firstaid/adv(new_human), WEAR_IN_BACK)
-	new_human.equip_to_slot_or_del(new /obj/structure/bed/portable_surgery(new_human), WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/roller/surgical(new_human), WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/box/packet/smoke, WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/mre_food_packet/clf, WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/tool/surgery/synthgraft, WEAR_IN_BACK)

--- a/code/modules/gear_presets/survivors/lv_624/clfship_insert_lv624.dm
+++ b/code/modules/gear_presets/survivors/lv_624/clfship_insert_lv624.dm
@@ -119,7 +119,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/explosive/grenade/custom/ied(new_human), WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/firstaid/adv(new_human), WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/firstaid/adv(new_human), WEAR_IN_BACK)
-	new_human.equip_to_slot_or_del(new /obj/structure/bed/portable_surgery(new_human), WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/roller/surgical(new_human), WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/box/packet/smoke, WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/tool/surgery/surgical_line, WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/tool/surgery/synthgraft, WEAR_IN_BACK)


### PR DESCRIPTION

# About the pull request
This PR fixes an unreported bug that caused roller beds and surgical beds, in some instances, to be vended or spawned on characters already deployed, so you could not interact with them unless you rolled them back up.

Will test later

This was caused by (myself) and other people using the `/obj/structure/bed/portable_surgery` and `/obj/structure/bed/roller` item paths instead of `/obj/item/roller` and `/obj/item/roller/surgical_bed` paths. 
`
# Explain why it's good for the game

For obvious reasons, structures should not be vended or spawn in inventories. In this case, bended Roller Beds and Surgical Beds needed to be rolled up before being picked up. For those who *spawn* with said bed in their inventory, well... That item slot is forever broken because they cannot drop or roll up that bed. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: CLF Soldiers and CLF Survivor Medics no longer spawn with deployed Surgical Beds in their inventories.
fix: Roller Beds and Surgical Beds longer vend from vending machines and Doctor/Field Doctor Essentials already deployed, so you no longer need to roll them up. 
/:cl:
