### PR TITLE
Nest fix

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
@@ -90,15 +90,15 @@
 	color = "#ffff80"
 	hivenumber = XENO_HIVE_K_SERIES
 
-/obj/structure/bed/nest/attackby(obj/item/W, mob/living/user)
-	if(istype(W, /obj/item/grab))
-		var/obj/item/grab/G = W
-		if(ismob(G.grabbed_thing))
-			var/mob/M = G.grabbed_thing
-			to_chat(user, SPAN_NOTICE("You place \the [M] on \the [src]."))
-			M.forceMove(loc)
+/obj/structure/bed/nest/attackby(obj/item/thing, mob/living/user)
+	if(istype(thing, /obj/item/grab))
+		var/obj/item/grab/grab_item = thing
+		if(ismob(grab_item.grabbed_thing))
+			var/mob/grabbed_mob = grab_item.grabbed_thing
+			to_chat(user, SPAN_NOTICE("You place \the [grabbed_mob] on \the [src]."))
+			grabbed_mob.forceMove(loc)
 		return TRUE
-	if(W.flags_item & NOBLUDGEON)
+	if(thing.flags_item & NOBLUDGEON)
 		return
 	if(iscarbon(user))
 		var/mob/living/carbon/carbon = user
@@ -106,25 +106,25 @@
 			to_chat(user, SPAN_XENOWARNING("We shouldn't interfere with the nest, leave that to the drones."))
 			return
 	if(buckled_mob)
-		if(iswelder(W))
-			var/obj/item/tool/weldingtool/WT = W
-			if(!WT.isOn())
-				to_chat(user, SPAN_WARNING("You need to turn \the [W] on before you can unnest someone!"))
+		if(iswelder(thing))
+			var/obj/item/tool/weldingtool/welder = thing
+			if(!welder.isOn())
+				to_chat(user, SPAN_WARNING("You need to turn \the [thing] on before you can unnest someone!"))
 				return
 			playsound(loc, 'sound/items/weldingtool_weld.ogg', 25)
 			user.visible_message(SPAN_NOTICE("\The [user] starts burning through the resin binding \the [buckled_mob] in place..."), SPAN_NOTICE("You start burning through the resin binding \the [buckled_mob] in place..."))
-			if(!do_after(user, 1 SECONDS, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_HOSTILE) || !WT.isOn())
+			if(!do_after(user, 1 SECONDS, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_HOSTILE) || !welder.isOn())
 				return
 			if(!buckled_mob)
 				return
 			buckled_mob.visible_message(SPAN_NOTICE("\The [user] pulls \the [buckled_mob] free from \the [src]!"), SPAN_NOTICE("\The [user] pulls you free from \the [src]."), SPAN_NOTICE("You hear squelching."))
 			playsound(loc, "alien_resin_move", 50)
 			if(ishuman(buckled_mob))
-				var/mob/living/carbon/human/H = buckled_mob
-				log_interact(user, H, "[key_name(user)] unnested [key_name(H)] at [get_area_name(loc)]")
+				var/mob/living/carbon/human/buckled_human = buckled_mob
+				log_interact(user, buckled_human, "[key_name(user)] unnested [key_name(buckled_human)] at [get_area_name(loc)]")
 			unbuckle()
 			return
-		if(is_sharp(W))
+		if(is_sharp(thing))
 			user.visible_message(SPAN_NOTICE("\The [user] starts cutting through the resin binding \the [buckled_mob] in place..."), SPAN_NOTICE("You start cutting through the resin binding \the [buckled_mob] in place..."))
 			if(!do_after(user, 3 SECONDS, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_HOSTILE))
 				return
@@ -133,15 +133,15 @@
 			buckled_mob.visible_message(SPAN_NOTICE("\The [user] pulls \the [buckled_mob] free from \the [src]!"), SPAN_NOTICE("\The [user] pulls you free from \the [src]."), SPAN_NOTICE("You hear squelching."))
 			playsound(loc, "alien_resin_move", 50)
 			if(ishuman(buckled_mob))
-				var/mob/living/carbon/human/H = buckled_mob
-				log_interact(user, H, "[key_name(user)] unnested [key_name(H)] at [get_area_name(loc)]")
+				var/mob/living/carbon/human/buckled_human = buckled_mob
+				log_interact(user, buckled_human, "[key_name(user)] unnested [key_name(buckled_human)] at [get_area_name(loc)]")
 			unbuckle()
 			return
-	health = max(0, health - W.force)
+	health = max(0, health - thing.force)
 	playsound(loc, "alien_resin_break", 25)
 	user.animation_attack_on(src)
-	user.visible_message(SPAN_WARNING("\The [user] hits \the [src] with \the [W]!"),
-	SPAN_WARNING("You hit \the [src] with \the [W]!"))
+	user.visible_message(SPAN_WARNING("\The [user] hits \the [src] with \the [thing]!"),
+	SPAN_WARNING("You hit \the [src] with \the [thing]!"))
 	healthcheck()
 	return ATTACKBY_HINT_UPDATE_NEXT_MOVE
 

--- a/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
@@ -143,6 +143,7 @@
 	user.visible_message(SPAN_WARNING("\The [user] hits \the [src] with \the [W]!"),
 	SPAN_WARNING("You hit \the [src] with \the [W]!"))
 	healthcheck()
+	return ATTACKBY_HINT_UPDATE_NEXT_MOVE
 
 /obj/structure/bed/nest/manual_unbuckle(mob/living/user)
 	if(!(buckled_mob && buckled_mob.buckled == src && buckled_mob != user))

--- a/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
@@ -245,6 +245,10 @@
 		to_chat(user, SPAN_WARNING("There's already someone in [src]."))
 		return
 
+	if(!loc) //In case the nest's wall no longer exists
+		to_chat(user, SPAN_WARNING("We require a wall to secure [mob] to!"))
+		return
+
 	if(human) //Improperly stunned Marines won't be nested
 		if(human.body_position != LYING_DOWN) //Don't ask me why is has to be
 			to_chat(user, SPAN_WARNING("[mob] is resisting, ground them."))


### PR DESCRIPTION

# About the pull request

Fixes #11305 by checking if the nest's wall is still there after the do_after.
Fixes #8000 by giving a missing return to the attack_by so it will have an attack delay

# Explain why it's good for the game

Bug bad


# Testing Photographs and Procedure
Tested first by trying to nest a human onto a gardener's resin surge wall. The human didnt get nested, didnt get given prompt and did not get bugged.
Tested second by knifing the nest of a nested marine. Had expected attack delay.


# Changelog
:cl:
fix: Fixed players mobs bugging out when attempted to be nested on a wall that no longer exists.
fix: Fixed attacking nests not having an attack delay.
/:cl:
