### PR TITLE
Bag ID lock oversights

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -2,20 +2,19 @@
 //returns FALSE otherwise
 /obj/proc/allowed(mob/M)
 	//check if it doesn't require any access at all
-	if(check_access() || isRemoteControlling(M))
-		return TRUE
-
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		//if they are holding or wearing a card that has access, that works
-		if(check_access(H.get_active_hand()) || check_access(H.wear_id))
-			return TRUE
-		return check_yautja_access(H)
-	if(istype(M, /mob/living/carbon/xenomorph))
-		var/mob/living/carbon/C = M
-		if(check_access(C.get_active_hand()))
-			return TRUE
-		return FALSE
+	if(!check_access() || !isRemoteControlling(M))
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			//if they are holding or wearing a card that has access, that works
+			if(check_access(H.get_active_hand()) || check_access(H.wear_id))
+				return TRUE
+			return check_yautja_access(H)
+		if(istype(M, /mob/living/carbon/xenomorph))
+			var/mob/living/carbon/C = M
+			if(check_access(C.get_active_hand()))
+				return TRUE
+			return FALSE
+	return TRUE
 
 /obj/proc/check_yautja_access(mob/living/carbon/human/yautja)
 	if(!ishuman(yautja) || !HAS_TRAIT(yautja, TRAIT_YAUTJA_TECH))

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -126,6 +126,11 @@
 		return
 	..()
 
+/obj/item/storage/backpack/can_storage_interact(mob/user)
+	if(locking_id && !compare_id(user))
+		return FALSE
+	. = ..()
+
 /obj/item/storage/backpack/storage_close(mob/user)
 	UnregisterSignal(user, COMSIG_MOVABLE_PRE_MOVE)
 	..()

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -121,15 +121,25 @@
 /obj/item/storage/backpack/open(mob/user)
 	if(!is_accessible_by(user))
 		return
-	if(locking_id && !compare_id(user))//if id locked we the user's id against the locker's
+	if(!check_id_lock(user))
 		to_chat(user, SPAN_NOTICE("[src] is locked by [locking_id.registered_name]'s ID! You decide to leave it alone."))
 		return
 	..()
 
 /obj/item/storage/backpack/can_storage_interact(mob/user)
-	if(locking_id && !compare_id(user))
+	if(!check_id_lock(user))
 		return FALSE
 	. = ..()
+
+/obj/item/storage/backpack/can_be_inserted(obj/item/W, mob/user, stop_messages = FALSE)
+	if(!check_id_lock(user))
+		return FALSE
+	. = ..()
+
+/obj/item/storage/backpack/proc/check_id_lock(mob/user)
+	if(locking_id && !compare_id(user)) //if id locked we check the user's id against the locker's
+		return FALSE
+	return TRUE
 
 /obj/item/storage/backpack/storage_close(mob/user)
 	UnregisterSignal(user, COMSIG_MOVABLE_PRE_MOVE)


### PR DESCRIPTION

# About the pull request

Fixes #12710
Shake action never checked for id locks, only id access requirements. Or when putting an item inside.
Also had to change the allowed() proc around a bit so the lack of an id access requirement doesnt make it return a false positive for id locked bags.

# Explain why it's good for the game

Bug !good

# Testing Photographs and Procedure
Spawned in as CL, locked bag, put stuff in it, shook it, worked, picked an item out of it, worked, emptied it, worked.
Refilled the bag and with another mob tried doing all the same, access denied.

Also ran around Almayer with different mobs and interacted with access restricted stuff to make sure the access() change didnt bork anything.


# Changelog
:cl:
fix: Fixed being able to bypass id locks on bags by shaking or being able to put an item inside.
/:cl:
