### PR TITLE
Fix some maps having dropship subtype MG emplacements

### DIFF
--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -3520,7 +3520,7 @@
 /obj/structure/barricade/metal/wired{
 	dir = 4
 	},
-/obj/structure/machinery/m56d_hmg/mg_turret/dropship{
+/obj/structure/machinery/m56d_hmg/mg_turret{
 	dir = 4
 	},
 /turf/open/floor/prison/cell_stripe/north,

--- a/maps/map_files/LV759_Hybrisa_Prospera/LV759_Hybrisa_Prospera.dmm
+++ b/maps/map_files/LV759_Hybrisa_Prospera/LV759_Hybrisa_Prospera.dmm
@@ -101765,7 +101765,7 @@
 /turf/open/floor/corsat/officetiles,
 /area/lv759/indoors/mining_outpost/northeast)
 "oiA" = (
-/obj/structure/machinery/m56d_hmg/mg_turret/dropship,
+/obj/structure/machinery/m56d_hmg/mg_turret,
 /obj/structure/barricade/sandbags,
 /obj/item/ammo_casing/bullet,
 /obj/structure/pipes/standard/simple/hidden/dark,

--- a/maps/map_files/Tyrargo_Rift/standalone/dropship_bunker_crash.dmm
+++ b/maps/map_files/Tyrargo_Rift/standalone/dropship_bunker_crash.dmm
@@ -184,7 +184,7 @@
 /obj/effect/decal/grass_overlay/grass1/dark{
 	dir = 1
 	},
-/obj/structure/machinery/m56d_hmg/mg_turret/dropship,
+/obj/structure/machinery/m56d_hmg/mg_turret,
 /turf/open/auto_turf/tyrargo_grass/layer0_mud,
 /area/tyrargo/outdoors/outskirts/central)
 "ap" = (


### PR DESCRIPTION

# About the pull request

Fixes #12689


# Explain why it's good for the game
# Testing Photographs and Procedure
Now the MGs indeed take damage.

# Changelog
:cl:
fix: Fixed some maps having indestructible machinegun emplacements
/:cl:
