### PR TITLE
Adjust eye_protection on NVG toggle

### DIFF
--- a/code/modules/clothing/glasses/night.dm
+++ b/code/modules/clothing/glasses/night.dm
@@ -21,6 +21,13 @@
 	fullscreen_vision = null
 	eye_protection = EYE_PROTECTION_NEGATIVE
 
+/obj/item/clothing/glasses/night/toggle_glasses_effect()
+	..()
+	if(active) //Being turned on
+		eye_protection = initial(eye_protection)
+	else
+		eye_protection = EYE_PROTECTION_NONE
+
 /obj/item/clothing/glasses/night/M4RA
 	name = "\improper M4RA Battle sight"
 	gender = NEUTER


### PR DESCRIPTION

# About the pull request

Related to #12675
Eyepiece NVGs would confer their negative welding protection even when turned off. Fixed it by adding lines to adjust the protection level when toggling.

(Welding eye protection is calculated via addition. NVGs have negative protection. So if you have both welding and NVGs, you take as much eye damage as you would with security sunglasses)

# Explain why it's good for the game

Having to take off your NVGs to weld when you could just turn them off is annoying.


# Testing Photographs and Procedure
Put on scout NVG eyepiece and welding visor into helmet.
Weld a wall, increased eye damage
Turn off NVG, weld, normal eye damage
Turn on welding visor, weld, no eye damage
Turn on NVG, weld, reduced eye damage


# Changelog
:cl:
fix: Eyepiece NVGs no longer increase eye damage from welding when turned off.
/:cl:
