### PR TITLE
Eggsac Carrier Exploit fix

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -800,6 +800,7 @@
 #define MIN_IMPREGNATION_TIME 10 SECONDS //Time it takes to impregnate someone
 #define MAX_IMPREGNATION_TIME 15 SECONDS
 
+#define HUGGER_TIME_TO_LIVE 30 SECONDS
 #define HUGGER_ACTIVE_TIME 4 SECONDS //Time between being dropped and being able to jump
 
 #define FACEHUGGER_JUMP_RANGE 1 // dont really want them to hug you immediately as you break down a corner or a door when a carrier stacks them on a tile

--- a/code/modules/cm_aliens/structures/egg.dm
+++ b/code/modules/cm_aliens/structures/egg.dm
@@ -21,6 +21,8 @@
 	/// Whether to convert/orphan once EGG_BURSTING is complete
 	var/convert_on_release = FALSE
 	var/huggers_can_spawn = TRUE
+	/// Timer holder for the tolerance of how long a fragile egg will last without a hugger inside
+	var/empty_orphan_timer = null
 
 /obj/effect/alien/egg/Initialize(mapload, hive)
 	. = ..()
@@ -273,6 +275,8 @@
 				status = EGG_GROWN
 				icon_state = "Egg"
 
+				deltimer(empty_orphan_timer)
+
 				flags_embryo = F.flags_embryo
 
 				qdel(F)
@@ -445,11 +449,14 @@ SPECIAL EGG USED BY EGG CARRIER
 
 /obj/effect/alien/egg/carrier_egg/Burst(kill, instant_trigger, mob/living/carbon/xenomorph/X, is_hugger_player_controlled)
 	. = ..()
-	if(owner)
-		var/datum/behavior_delegate/carrier_eggsac/behavior = owner.behavior_delegate
-		behavior.remove_egg_owner(src)
-	if(kill && life_timer)
-		deltimer(life_timer)
+	if(!kill)
+		empty_orphan_timer = addtimer(CALLBACK(src, PROC_REF(Burst), TRUE), HUGGER_TIME_TO_LIVE, TIMER_STOPPABLE)
+	else
+		if(life_timer)
+			deltimer(life_timer)
+		if(owner)
+			var/datum/behavior_delegate/carrier_eggsac/behavior = owner.behavior_delegate
+			behavior.remove_egg_owner(src)
 
 /obj/effect/alien/egg/carrier_egg/on_weed_deletion()
 	return

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -48,7 +48,7 @@
 	/// the nearest human before dying
 	var/jumps_left = 5
 
-	var/time_to_live = 30 SECONDS
+	var/time_to_live = HUGGER_TIME_TO_LIVE
 	var/death_timer
 
 	var/icon_xeno = 'icons/mob/xenos/effects.dmi'
@@ -502,11 +502,12 @@
 /obj/item/clothing/mask/facehugger/flamer_fire_act()
 	die()
 
-/obj/item/clothing/mask/facehugger/proc/return_to_egg(obj/effect/alien/egg/E)
-	visible_message(SPAN_XENOWARNING("[src] crawls back into [E]!"))
-	E.status = EGG_GROWN
-	E.icon_state = "Egg"
-	E.deploy_egg_triggers()
+/obj/item/clothing/mask/facehugger/proc/return_to_egg(obj/effect/alien/egg/egg)
+	visible_message(SPAN_XENOWARNING("[src] crawls back into [egg]!"))
+	egg.status = EGG_GROWN
+	egg.icon_state = "Egg"
+	deltimer(egg.empty_orphan_timer)
+	egg.deploy_egg_triggers()
 	qdel(src)
 
 /**


### PR DESCRIPTION

# About the pull request

Fixes #8938

Previously the hugger coming out of the egg removed it from the max sustained fragile eggs count.
Fixed it by making eggs keep being counted against the limit as long as they dont get destroyed. Plus added a shortened expiration timer onto the the fragile egg that the hugger came out of, so it wont stick around and count after the hugger is long gone.

# Explain why it's good for the game

Bug bad

# Testing Photographs and Procedure
Be eggsac carrier.
Plant 4 eggs on normal weeds in rapid succession.
Take the hugger out of Number 1 and throw it away.
Take the hugger out of Number 2 and drop it back on the egg's tile.
Take the hugger out of Number 3 and place it back into it.
Dont do anything with Number 4.

N1's hugger dies and shortly after N1 too.
N2's hugger crawls back in.
Minutes later N2, N3, N4 burst in rapid succession.

# Changelog
:cl:
fix: Fixed a bug where an eggsac carrier could sustain infinite fragile eggs.
add: Fragile eggs are now counted against the sustain limit until they are destroyed.
add: Fragile eggs that no longer have a hugger will quickly die.
/:cl:
