### PR TITLE
Assorted Sound Fixes

### DIFF
--- a/code/__DEFINES/sounds.dm
+++ b/code/__DEFINES/sounds.dm
@@ -31,6 +31,9 @@
 #define SOUND_CHANNEL_LOBBY 1023
 #define SOUND_CHANNEL_Z 1024
 
+/// How far do we consider a change in Z plane is for the purpose of calculating Y coordinates in 3D Sound, relative to tiles on the same level
+#define MULTI_Z_SOUND_DISTANCE 5
+
 //default byond sound echo list index positions.
 //ECHO_DIRECT and ECHO_ROOM are the only two that actually appear to do anything, and represent the dry and wet channels of the environment effects, respectively.
 #define ECHO_DIRECT 1

--- a/code/__DEFINES/sounds.dm
+++ b/code/__DEFINES/sounds.dm
@@ -31,6 +31,8 @@
 #define SOUND_CHANNEL_LOBBY 1023
 #define SOUND_CHANNEL_Z 1024
 
+/// How far do we consider a change in Z plane is for the purpose of calculating Y coordinates in 3D Sound, relative to tiles on the same level
+#define MULTI_Z_SOUND_DISTANCE 5
 
 //default byond sound echo list index positions.
 //ECHO_DIRECT and ECHO_ROOM are the only two that actually appear to do anything, and represent the dry and wet channels of the environment effects, respectively.

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -147,6 +147,7 @@
 #define SS_INIT_ASSETS 1
 #define SS_INIT_TIMER   100
 #define SS_INIT_UNSPECIFIED 0
+#define SS_INIT_SOUND -5 // Just to ignore all sounds above notably during SSatoms init
 #define SS_INIT_TICKER -21
 #define SS_INIT_VOTE   -23
 #define SS_INIT_DATABASE   -27

--- a/code/controllers/subsystem/interior.dm
+++ b/code/controllers/subsystem/interior.dm
@@ -58,4 +58,7 @@ SUBSYSTEM_DEF(interior)
 
 	return TRUE
 
+/// See [/datum/controller/subsystem/interior/proc/in_interior]
+#define SSINTERIOR_TURF_IN_INTERIOR_FAST(loc) (!!SSmapping.used_turfs[loc])
+
 #undef INTERIOR_BORDER_SIZE

--- a/code/controllers/subsystem/sound.dm
+++ b/code/controllers/subsystem/sound.dm
@@ -15,9 +15,16 @@ SUBSYSTEM_DEF(sound)
 		template_queue = list()
 		run_hearers = null // null explicitely indicates we need to do ranging!
 
-	for(var/datum/sound_template/run_template in run_queue)
+	for(var/datum/sound_template/run_template, base_run_hearers in run_queue)
 		if(!run_hearers) // Initialize for handling next template
-			run_hearers = run_queue[run_template] // get base hearers
+			run_hearers = base_run_hearers // get base hearers
+			if(run_template.atom) // Resolve exact location now. We could do that in process_sound to be like REAL SURE there's as little delay as possible, but this would be much more expensive.
+				var/turf/turf = get_turf(run_template.atom)
+				if(turf)
+					run_template.x = turf.x
+					run_template.y = turf.y
+					run_template.z = turf.z
+				run_template.atom = null // Or it won't GC!
 			if(run_template.range) // ranging
 				if(!run_hearers)
 					run_hearers = run_template.get_hearers() // I hate |=
@@ -29,8 +36,7 @@ SUBSYSTEM_DEF(sound)
 		while(length(run_hearers)) // Output sound to hearers
 			var/client/C = run_hearers[length(run_hearers)]
 			run_hearers.len--
-			if(C && C.soundOutput)
-				C.soundOutput.process_sound(run_template)
+			C?.soundOutput?.process_sound(run_template)
 			if(MC_TICK_CHECK)
 				return
 		run_queue.Remove(run_template) // Everyone that had to get this sound got it. Bye, template

--- a/code/controllers/subsystem/sound.dm
+++ b/code/controllers/subsystem/sound.dm
@@ -11,7 +11,7 @@ SUBSYSTEM_DEF(sound)
 	var/list/run_hearers = null // Hearers for currently being processed template
 
 /datum/controller/subsystem/sound/Initialize()
- 	// We just defer accepting sounds to play until SS is initialized
+	// We just defer accepting sounds to play until SS is initialized
 	// That lets us ignore all the sounds caused ie. by rustling abstract items... Yep.
 	return SS_INIT_SUCCESS
 

--- a/code/controllers/subsystem/sound.dm
+++ b/code/controllers/subsystem/sound.dm
@@ -1,13 +1,19 @@
 SUBSYSTEM_DEF(sound)
-	name   = "Sound"
-	flags   = SS_POST_FIRE_TIMING | SS_NO_INIT
-	wait   = 2
+	name       = "Sound"
+	wait       = 2
+	flags      = SS_POST_FIRE_TIMING
 	priority   = SS_PRIORITY_SOUND
-	runlevels   = RUNLEVELS_DEFAULT|RUNLEVEL_LOBBY
+	init_order = SS_INIT_SOUND
+	runlevels  = RUNLEVELS_DEFAULT|RUNLEVEL_LOBBY
 
 	var/list/template_queue = list() // Full Template Queue
 	var/list/run_queue = list() // Queue subset being processed during this tick
 	var/list/run_hearers = null // Hearers for currently being processed template
+
+/datum/controller/subsystem/sound/Initialize()
+ 	// We just defer accepting sounds to play until SS is initialized
+	// That lets us ignore all the sounds caused ie. by rustling abstract items... Yep.
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/sound/fire(resumed = FALSE)
 	if(!resumed) // Controller first firing for this tick
@@ -43,7 +49,10 @@ SUBSYSTEM_DEF(sound)
 		run_hearers = null // Reset so we know next one is new
 
 /datum/controller/subsystem/sound/proc/queue(datum/sound_template/template, list/client/hearers, list/datum/interior/extra_interiors)
-
+	if(!initialized)
+		return
+	if(!hearers)
+		hearers = list()
 	if(extra_interiors && SSmapping)
 		if(!hearers)
 			hearers = list()

--- a/code/datums/soundOutput.dm
+++ b/code/datums/soundOutput.dm
@@ -22,21 +22,32 @@
 	owner = null
 	return ..()
 
+/// Called when processing every sound on every client
+/// This is a VERY hot proc, it's advised to keep it as lean as possible
+/// Consider if there are 400 sounds/second and 150 clients get to hear them,
+/// that could be 60K calls/second
 /datum/soundOutput/proc/process_sound(datum/sound_template/T)
 	var/sound/S = sound(T.file, T.wait, T.repeat)
 	S.volume = owner.prefs.volume_preferences[T.volume_cat] * T.volume
-	if(T.channel == 0)
+
+	// This should never happen and you don't want it to happen, because
+	// channels are allocated globally. If you start allocating a global
+	// channel per-sound per-person, you'll rotate through them really
+	// fast and it'll cause running sounds to be randomly overwritten.
+	if(T.channel == NONE)
 		S.channel = get_free_channel()
 	else
 		S.channel = T.channel
+
 	S.frequency = T.frequency
 	S.falloff = T.falloff
 	S.status = T.status
-	if(T.x && T.y && T.z)
+
+	if(T.x && T.y && T.z) // Patch up 3D Sound based on in-world coordinates
 		var/turf/owner_turf = get_turf(owner.mob)
 		if(owner_turf)
 			// We're in an interior and sound came from outside
-			if(SSinterior.in_interior(owner_turf) && owner_turf.z != T.z)
+			if(SSINTERIOR_TURF_IN_INTERIOR_FAST(owner_turf) && owner_turf.z != T.z)
 				var/datum/interior/VI = SSinterior.get_interior_by_coords(owner_turf.x, owner_turf.y, owner_turf.z)
 				if(VI && VI.exterior)
 					var/turf/candidate = get_turf(VI.exterior)
@@ -44,16 +55,21 @@
 						return // Invalid location
 					S.falloff /= 2
 					owner_turf = candidate
+
 			S.x = T.x - owner_turf.x
-			S.y = (T.z - owner_turf.z) * 5
+			S.y = (T.z - owner_turf.z) * MULTI_Z_SOUND_DISTANCE
 			S.z = T.y - owner_turf.y
-		S.y += T.y_s_offset
+
+		S.z += T.z_s_offset // Please read the codedoc for z_s_offset
 		S.x += T.x_s_offset
+
 		S.echo = SOUND_ECHO_REVERB_ON //enable environment reverb for positional sounds
+
 	for(var/pos = 1 to length(T.echo))
-		if(!T.echo[pos])
+		if(isnull(T.echo[pos]))
 			continue
 		S.echo[pos] = T.echo[pos]
+
 	if(owner.mob.ear_deaf > 0)
 		S.status |= SOUND_MUTE
 

--- a/code/datums/soundOutput.dm
+++ b/code/datums/soundOutput.dm
@@ -65,10 +65,8 @@
 
 		S.echo = SOUND_ECHO_REVERB_ON //enable environment reverb for positional sounds
 
-	for(var/pos = 1 to length(T.echo))
-		if(isnull(T.echo[pos]))
-			continue
-		S.echo[pos] = T.echo[pos]
+	if(T.echo)
+		S.echo = T.echo
 
 	if(owner.mob.ear_deaf > 0)
 		S.status |= SOUND_MUTE

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -182,7 +182,7 @@
 
 
 /// Play sound for all on-map clients on a given Z-level. Good for ambient sounds.
-/proc/playsound_z(z, soundin, volume = 100, vol_cat = VOLUME_SFX, echo, z_s_offset, x_s_offset)
+/proc/playsound_z(z, soundin, volume = 100, vol_cat = VOLUME_SFX, list/echo, z_s_offset, x_s_offset)
 	var/datum/sound_template/template = new()
 	template.file = soundin
 	template.volume = volume

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -13,7 +13,7 @@
 	var/falloff = 1
 	var/volume_cat = VOLUME_SFX
 	var/range = 0
-	var/list/echo = new /list(18)
+	var/list/echo
 	var/atom/atom //! Tracked atom so we get the exact position even after delay in SSsound firing - replaces x/y/z if applicable
 	var/x //Map coordinates, not sound coordinates
 	var/y
@@ -65,10 +65,8 @@
 	template.falloff = falloff
 	template.volume = vol
 	template.volume_cat = vol_cat
-	for(var/pos = 1 to length(echo))
-		if(!echo[pos])
-			continue
-		template.echo[pos] = echo[pos]
+	if(echo)
+		template.echo = echo.Copy()
 	template.z_s_offset = z_s_offset
 	template.x_s_offset = x_s_offset
 	if(vary != FALSE)
@@ -149,10 +147,8 @@
 	template.volume_cat = vol_cat
 	template.channel = channel
 	template.status = status
-	for(var/pos = 1 to length(echo))
-		if(!echo[pos])
-			continue
-		template.echo[pos] = echo[pos]
+	if(echo)
+		template.echo = echo.Copy()
 	template.z_s_offset = z_s_offset
 	template.x_s_offset = x_s_offset
 	SSsound.queue(template, list(client))
@@ -168,10 +164,8 @@
 	template.channel = channel
 	template.status = status
 	template.volume_cat = vol_cat
-	for(var/pos = 1 to length(echo))
-		if(!echo[pos])
-			continue
-		template.echo[pos] = echo[pos]
+	if(echo)
+		template.echo = echo.Copy()
 
 	var/list/hearers = list()
 	for(var/mob/living/M in A.contents)
@@ -194,10 +188,8 @@
 	template.volume = volume
 	template.channel = SOUND_CHANNEL_Z
 	template.volume_cat = vol_cat
-	for(var/pos = 1 to length(echo))
-		if(!echo[pos])
-			continue
-		template.echo[pos] = echo[pos]
+	if(echo)
+		template.echo = echo.Copy()
 	template.z_s_offset = z_s_offset
 	template.x_s_offset = x_s_offset
 	var/list/hearers = list()

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -14,11 +14,14 @@
 	var/volume_cat = VOLUME_SFX
 	var/range = 0
 	var/list/echo = new /list(18)
+	var/atom/atom //! Tracked atom so we get the exact position even after delay in SSsound firing - replaces x/y/z if applicable
 	var/x //Map coordinates, not sound coordinates
 	var/y
 	var/z
-	var/y_s_offset // Vertical sound offset
-	var/x_s_offset // Horizontal sound offset
+	/// Horizontal sound offset, added to the dynamic offsets calculated using map coordinates above.
+	var/x_s_offset
+	/// Vertical (as in on screen) sound offset, added to the dynamic offsets calculated using map coordinates above. Get it right: Y in sound is up from the ground. Y in game is up on the screen. Game North is Sound Z axis.
+	var/z_s_offset
 
 /datum/sound_template/proc/get_hearers()
 	RETURN_TYPE(/list/client)
@@ -45,7 +48,7 @@
 //status: the regular 4 sound flags
 //falloff: max range till sound volume starts dropping as distance increases
 
-/proc/playsound(atom/source, sound/soundin, vol = 100, vary = FALSE, sound_range, vol_cat = VOLUME_SFX, channel = 0, status, falloff = 1, list/echo, y_s_offset, x_s_offset)
+/proc/playsound(atom/source, sound/soundin, vol = 100, vary = FALSE, sound_range, vol_cat = VOLUME_SFX, channel = 0, status, falloff = 1, list/echo, z_s_offset, x_s_offset)
 	if(isarea(source))
 		error("[source] is an area and is trying to make the sound: [soundin]")
 		return FALSE
@@ -66,7 +69,7 @@
 		if(!echo[pos])
 			continue
 		template.echo[pos] = echo[pos]
-	template.y_s_offset = y_s_offset
+	template.z_s_offset = z_s_offset
 	template.x_s_offset = x_s_offset
 	if(vary != FALSE)
 		if(vary > 1)
@@ -77,6 +80,9 @@
 	if(!sound_range)
 		sound_range = floor(0.25*vol) //if no specific range, the max range is equal to a quarter of the volume.
 	template.range = sound_range
+
+	if(ismovable(source))
+		template.atom = source
 
 	var/turf/turf_source = get_turf(source)
 	if(!turf_source || !turf_source.z)
@@ -96,6 +102,7 @@
 		if(vehicle_interior?.ready)
 			extra_interiors |= vehicle_interior
 			if(vehicle_interior.exterior)
+				template.atom = vehicle_interior.exterior
 				var/turf/new_turf_source = get_turf(vehicle_interior.exterior)
 				template.x = new_turf_source.x
 				template.y = new_turf_source.y
@@ -113,12 +120,14 @@
 
 
 //This is the replacement for playsound_local. Use this for sending sounds directly to a client
-/proc/playsound_client(client/client, sound/soundin, atom/origin, vol = 100, random_freq, vol_cat = VOLUME_SFX, channel = 0, status, list/echo, y_s_offset, x_s_offset)
+/proc/playsound_client(client/client, sound/soundin, atom/origin, vol = 100, random_freq, vol_cat = VOLUME_SFX, channel = 0, status, list/echo, z_s_offset, x_s_offset)
 	if(!istype(client) || !client.soundOutput)
 		return FALSE
 
 	var/datum/sound_template/template = new()
 	if(origin)
+		if(isatom(origin))
+			template.atom = origin
 		var/turf/T = get_turf(origin)
 		if(T)
 			template.x = T.x
@@ -144,12 +153,12 @@
 		if(!echo[pos])
 			continue
 		template.echo[pos] = echo[pos]
-	template.y_s_offset = y_s_offset
+	template.z_s_offset = z_s_offset
 	template.x_s_offset = x_s_offset
 	SSsound.queue(template, list(client))
 
 /// Plays sound to all mobs that are map-level contents of an area
-/proc/playsound_area(area/A, soundin, vol = 100, channel = 0, status, vol_cat = VOLUME_SFX, list/echo, y_s_offset, x_s_offset)
+/proc/playsound_area(area/A, soundin, vol = 100, channel = 0, status, vol_cat = VOLUME_SFX, list/echo, z_s_offset, x_s_offset)
 	if(!isarea(A))
 		return FALSE
 
@@ -179,7 +188,7 @@
 
 
 /// Play sound for all on-map clients on a given Z-level. Good for ambient sounds.
-/proc/playsound_z(z, soundin, volume = 100, vol_cat = VOLUME_SFX, echo, y_s_offset, x_s_offset)
+/proc/playsound_z(z, soundin, volume = 100, vol_cat = VOLUME_SFX, echo, z_s_offset, x_s_offset)
 	var/datum/sound_template/template = new()
 	template.file = soundin
 	template.volume = volume
@@ -189,7 +198,7 @@
 		if(!echo[pos])
 			continue
 		template.echo[pos] = echo[pos]
-	template.y_s_offset = y_s_offset
+	template.z_s_offset = z_s_offset
 	template.x_s_offset = x_s_offset
 	var/list/hearers = list()
 	for(var/mob/M in GLOB.player_list)


### PR DESCRIPTION

# List of changes

 * Introduce atom tracking in sound templates. This lets us resolve the location at latest possible. This vastly improves fidelity of sounds that are centered on a player, as they would previously be heard further away when moving due to the 0.2s delay in SSsound firing. FWIW 80% of game wrongly uses get_turf/loc when calling playsound, so it won't affect most things.
 * Streamline echo handling in hot sound procs. It was creating an unused pre-allocated list, and then copying element-by-element every time even though it's only used in space-to-space combat. 
 * Fix echo handling - it would previously not let you set 0 values because they're falsey
 * As a side effect, a space-to-space weapon heard from an interior won't use reverb anymore unless explicitely requested (has that even ever happened?!)
 * Fix static sound offsets. These are only used on PVE i believe, but they were wrong because (x,y,z) in game is (x,z,y) in sound coordinates, it uses a different frame of reference.
 * Small code optimizations such as using for(var/key, value) or inlining the interior check in soundOutput
 * Comments
 * Sound queueing is disabled during early Subsystem Initialization. This avoids it coming to life with 500 sounds to play and causing a small hiccup. I don't know where the sounds come from. Presumably they're rustling from manipulating items and such, but they should all be in nullspace.


# Changelog
:cl:
code: Some sounds will now be emitted from the emitting object rather than the ground position. This especially makes a difference for sounds originating from your character, which won't be shifted when you move due to delay.
/:cl:
