### PR TITLE
Survivors get a tacmap

### DIFF
--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -1416,6 +1416,11 @@ SUBSYSTEM_DEF(minimaps)
 	live = TRUE
 	drawing = FALSE
 
+/datum/action/minimap/survivor
+	minimap_flags = NONE
+	marker_flags = NONE
+	drawing = FALSE
+
 /datum/action/minimap/observer/action_activate()
 	. = ..()
 	if(!.)

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -1122,6 +1122,7 @@
 	name = "colony headset"
 	desc = "A standard headset used by colonists."
 	frequency = COLONY_FREQ
+	minimap_type = /datum/action/minimap/survivor
 
 /obj/item/device/radio/headset/distress/WY
 	name = "WY corporate headset"


### PR DESCRIPTION

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->
Survivors now get a tacmap, it displays no icons.

# Explain why it's good for the game
Makes it easier for newer survivors to learn the role, as they don't need to have the map memorized. (They still need to know where all the good gear is.)

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Survivors now get a tacmap.
/:cl:
