### PR TITLE
Fix turf upper_wall runtime

### DIFF
--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -955,9 +955,8 @@
 	if(!(turf_flags & TURF_HULL))
 		var/area/area = get_area(src)
 		area?.current_resin_count--
-	if(upper_wall)
+	if(!QDESTROYING(upper_wall))
 		upper_wall.dismantle_wall()
-		upper_wall = null
 	var/turf/above = SSmapping.get_turf_above(src)
 	while(above && istransparentturf(above))
 		above.update_vis_contents()
@@ -1045,14 +1044,15 @@
 
 /turf/closed/wall/resin/above/Destroy(force)
 	. = ..()
-	if(wall_below)
+	// Keep a local copy in case we accidentally destroy ourselves, or the proc will crash
+	var/turf/closed/wall/resin/wall_below = src.wall_below
+	var/obj/structure/mineral_door/resin/door_below = src.door_below
+	if(!QDESTROYING(wall_below)) // Don't cause a delete loop
 		wall_below.upper_wall = null
 		wall_below.dismantle_wall()
-		wall_below = null
 	if(door_below)
 		door_below.upper_wall = null
 		door_below.Dismantle(TRUE)
-		door_below = null
 	var/turf/above = SSmapping.get_turf_above(src)
 	if(above && istransparentturf(above))
 		above.update_vis_contents()

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -499,9 +499,8 @@
 	..()
 
 /obj/structure/mineral_door/resin/Destroy()
-	if(upper_wall)
+	if(!QDESTROYING(upper_wall))
 		upper_wall.dismantle_wall()
-		upper_wall = null
 	var/turf/above = SSmapping.get_turf_above(src)
 	while(above && istransparentturf(above))
 		above.update_vis_contents()
@@ -510,9 +509,11 @@
 	var/area/area = get_area(src)
 	area?.current_resin_count--
 	var/turf/base_turf = loc
-	if(upper_wall)
+
+	if(!QDESTROYING(upper_wall)) // Why is this done twice? Hell if i know.
 		upper_wall.dismantle_wall()
-	spawn(0)
+
+	spawn(0) // <--- Don't do that, src probably won't even be valid anymore when it executes
 		var/turf/adjacent_turf
 		for(var/cardinal in GLOB.cardinals)
 			adjacent_turf = get_step(base_turf, cardinal)


### PR DESCRIPTION

# About the pull request

Fixes a recurring runtime with resin wall Destroy logic. Once either top or bottom wall is deleted, the other is too, which causes a change in `src` type due to how turfs work.

The first fix is to remove nulling of the upper_wall. We don't need to null it because these are turfs, so once Destroy is over it's getting snapped anyway.

This lets the proc continue, and instead results in a very logical Destroy loop. The simplest way to avoid this is through the use of QDESTROYING. I wish I had a better solution but I don't.

# Testing

Instanciated resin walls in multi-z and deleted them