### PR TITLE
Empty Full Brazier BE GONE

### DIFF
--- a/code/game/objects/structures/props.dm
+++ b/code/game/objects/structures/props.dm
@@ -506,8 +506,8 @@
 	state = STATE_FUEL
 
 /obj/structure/prop/brazier/frame/full
-	name = "empty full brazier"
-	desc = "An empty brazier. Yet it's also full. What??? Use something hot to ignite it, like a welding tool."
+	name = "unlit brazier"
+	desc = "A brazier full of wood, though unlit. Something hot could ignite it."
 	icon_state = "brazier_frame_filled"
 	frame_type = /obj/structure/prop/brazier
 	state = STATE_IGNITE


### PR DESCRIPTION


# About the pull request

Changes the description of the Yautja's brazier when it's full of wood

# Explain why it's good for the game

"Empty Full Brazier" is not a series of words that should exist in CM


# Testing Photographs and Procedure
N/A



# Changelog


:cl:
spellcheck: fixed a typo.
/:cl:


