### PR TITLE
HPR holotargetting box magazine capacity normalization

### DIFF
--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -319,21 +319,18 @@
 	name = "\improper M41AE2 ammo box (10x24mm holo-target)"
 	desc = "A semi-rectangular holo-targeting box magazine for the M41AE2 Heavy Pulse Rifle."
 	default_ammo = /datum/ammo/bullet/rifle/holo_target
-	max_rounds = 200
 	ammo_band_color = AMMO_BAND_COLOR_HOLOTARGETING
 
 /obj/item/ammo_magazine/rifle/lmg/ap
 	name = "\improper M41AE2 ammo box (10x24mm armor-piercing)"
 	desc = "A semi-rectangular armor-piercing box magazine for the M41AE2 Heavy Pulse Rifle."
 	default_ammo = /datum/ammo/bullet/rifle/ap
-	max_rounds = 300
 	ammo_band_color = AMMO_BAND_COLOR_AP
 
 /obj/item/ammo_magazine/rifle/lmg/heap
 	name = "\improper M41AE2 ammo box (10x24mm high-explosive armor-piercing)"
 	desc = "A semi-rectangular box magazine for the M41AE2 Heavy Pulse Rifle. This one contains the standard armor-piercing explosive tipped round of the USCM."
 	default_ammo = /datum/ammo/bullet/rifle/heap
-	max_rounds = 300
 	gun_type = /obj/item/weapon/gun/rifle/lmg
 	ammo_band_color = AMMO_BAND_COLOR_HEAP
 


### PR DESCRIPTION
# About the pull request

Normalizes the size of all HPR magazines to follow the base 300 rounds - the only in-game change is the holotargetting magazine being upped from 200 to 300

# Explain why it's good for the game

1) code maintenance - there's no reason for all the subtype magazines to have their own max_rounds
2) consistency - no other marine weapon has special ammo mags being smaller
3) balance and utility - the big one, a lot of people don't even take holo-targetting boxes in the first place because they consider them a waste of space; bringing them in line with other magazines would make them at least provide similar value to the normal ones, they are rarer and harder to get but less desirable at the moment

# Testing Photographs and Procedure
very simple value change

# Changelog

:cl:
balance: M41AE2 holo-targetting box magazine holds 300 rounds (previously 200)
/:cl: