### PR TITLE
Pillbottle restocking

### DIFF
--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -1023,26 +1023,26 @@ GLOBAL_LIST_EMPTY(vending_products)
 	.["vendor_type"] = "sorted"
 	.["displayed_categories"] = vendor_user_inventory_list(user, null, 4)
 
-/obj/structure/machinery/cm_vending/sorted/MouseDrop_T(atom/movable/A, mob/user)
+/obj/structure/machinery/cm_vending/sorted/MouseDrop_T(atom/movable/dropped_thing, mob/user)
 
 	if(inoperable())
 		return
 
-	if(!isturf(A.loc) && !ishuman(A.loc))
+	if(!isturf(dropped_thing.loc) && !ishuman(dropped_thing.loc))
 		return
 
 	if(user.stat || user.is_mob_restrained())
 		return
 
-	if(get_dist(user, src) > 1 || get_dist(src, A) > 1)
+	if(get_dist(user, src) > 1 || get_dist(src, dropped_thing) > 1)
 		return
 
 	if(!ishuman(user))
 		return
 
 	// Try to bulk restock using a container
-	if(istype(A, /obj/item/storage) && !istype(A, /obj/item/storage/pill_bottle))
-		var/obj/item/storage/container = A
+	if(istype(dropped_thing, /obj/item/storage) && !istype(dropped_thing, /obj/item/storage/pill_bottle))
+		var/obj/item/storage/container = dropped_thing
 		if(!length(container.contents))
 			return
 		if(being_restocked)
@@ -1071,8 +1071,8 @@ GLOBAL_LIST_EMPTY(vending_products)
 		SPAN_NOTICE("You finish stocking [src] with supplies."))
 		return
 
-	if(istype(A, /obj/item))
-		stock(A, user)
+	if(istype(dropped_thing, /obj/item))
+		stock(dropped_thing, user)
 
 /obj/structure/machinery/cm_vending/sorted/proc/stock(obj/item/item_to_stock, mob/user)
 	if(istype(item_to_stock, /obj/item/storage) && !istype(item_to_stock, /obj/item/storage/pill_bottle))

--- a/code/game/machinery/vending/cm_vending.dm
+++ b/code/game/machinery/vending/cm_vending.dm
@@ -1041,7 +1041,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 		return
 
 	// Try to bulk restock using a container
-	if(istype(A, /obj/item/storage))
+	if(istype(A, /obj/item/storage) && !istype(A, /obj/item/storage/pill_bottle))
 		var/obj/item/storage/container = A
 		if(!length(container.contents))
 			return
@@ -1075,7 +1075,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 		stock(A, user)
 
 /obj/structure/machinery/cm_vending/sorted/proc/stock(obj/item/item_to_stock, mob/user)
-	if(istype(item_to_stock, /obj/item/storage))
+	if(istype(item_to_stock, /obj/item/storage) && !istype(item_to_stock, /obj/item/storage/pill_bottle))
 		return FALSE
 
 	var/list/stock_listed_products = get_listed_products(user)
@@ -1101,6 +1101,16 @@ GLOBAL_LIST_EMPTY(vending_products)
 			else if(istype(item_to_stock, /obj/item/stack))
 				var/obj/item/stack/item_stack = item_to_stock
 				partial_stacks = item_stack.amount % item_stack.max_amount
+
+			else if(istype(item_to_stock, /obj/item/storage/pill_bottle))
+				var/obj/item/storage/pill_bottle/pillbottle = item_to_stock
+				var/count = 0
+				for(var/obj/item/reagent_container/pill in pillbottle.contents)
+					if(pill.type == pillbottle.pill_type_to_fill)
+						count++
+				if(count != pillbottle.max_storage_space)
+					to_chat(user, SPAN_WARNING("[pillbottle] needs to be full of it's own kind of pills to restocked!"))
+					return FALSE
 
 			if(!additional_restock_checks(item_to_stock, user, vendspec))
 				// the error message needs to go in the proc


### PR DESCRIPTION

# About the pull request

Fixes #12231

Makes pillbottles that are full of its own type of pills restockable.

# Explain why it's good for the game

Would be nice if dozens of pillbottles didnt end up on the floor of medbay or in disposals every round. Plus makes medbay vendors more consistent with their restockability.

# Testing Photographs and Procedure
Took pillbottle of out Wey-Med Plus vendor. Clicked on the vendor, restocked.
Took pillbottle, click and drag dropped it on vendor, restocked.
Took pillbottle, took one pill out of it, tried to restock, didnt. Put different pill in it, didnt restock. Made an identical looking pill in ChemMaster, put it in, didnt restock. Put back original pill, restocked.


# Changelog
:cl:
qol: Made full pillbottles restockable.
/:cl:
