### PR TITLE
Ferret Heavy Industries Mk4-L Crate Loader

### DIFF
--- a/code/__DEFINES/equipment.dm
+++ b/code/__DEFINES/equipment.dm
@@ -52,6 +52,8 @@
 #define MAP_COLOR_INDEX (1<<21)
 /// If an object will fall through open space, use this when dashing \ jumping for example
 #define NO_ZFALL (1<<22)
+/// Allows a non-mob movable to use multi-Z stairs
+#define CAN_USE_MULTIZ_STAIRS (1<<23)
 
 //==========================================================================================
 

--- a/code/game/objects/structures/multiz_stairs.dm
+++ b/code/game/objects/structures/multiz_stairs.dm
@@ -25,7 +25,7 @@
 
 /obj/structure/stairs/multiz/proc/on_stairs_moved(turf/source, atom/movable/enterer)
 	SIGNAL_HANDLER
-	if(!istype(enterer, /mob))
+	if(!istype(enterer, /mob) && !(enterer.flags_atom & CAN_USE_MULTIZ_STAIRS))
 		return
 
 	RegisterSignal(enterer, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(on_premove))

--- a/code/modules/vehicles/powerloader.dm
+++ b/code/modules/vehicles/powerloader.dm
@@ -17,6 +17,7 @@
 	var/open_state = "powerloader_open"
 	var/overlay_state = "powerloader_overlay"
 	var/wreckage = /obj/structure/powerloader_wreckage
+	var/crate_hauler_only = FALSE //restricts claws to standard and large crates
 	var/obj/item/powerloader_clamp/PC_left
 	var/obj/item/powerloader_clamp/PC_right
 
@@ -124,7 +125,7 @@
 		icon_state = base_state
 		overlays += image(icon_state = overlay_state, layer = MOB_LAYER + 0.1)
 		if(M.mind && M.skills)
-			move_delay = max(4, move_delay - 2 * M.skills.get_skill_level(SKILL_POWERLOADER))
+			move_delay -= 2 * M.skills.get_skill_level(SKILL_POWERLOADER)
 		if(!M.put_in_l_hand(PC_left))
 			PC_left.forceMove(src)
 			unbuckle()
@@ -164,13 +165,17 @@
 
 /obj/item/powerloader_clamp/Destroy()
 	if(loaded)
-		loaded.forceMove(get_turf(src))
+		var/turf/drop_turf = get_turf(src)
+		if(drop_turf)
+			loaded.forceMove(drop_turf)
+		loaded = null
 	linked_powerloader = null
 	return ..()
 
 /obj/item/powerloader_clamp/dropped(mob/user)
-	if(!linked_powerloader)
+	if(!linked_powerloader || QDELETED(linked_powerloader))
 		qdel(src)
+		return
 	..()
 	forceMove(linked_powerloader)
 	if(linked_powerloader.buckled_mob && linked_powerloader.buckled_mob == user)
@@ -314,6 +319,16 @@
 	if(!linked_powerloader)
 		qdel(src)
 		return
+	if(linked_powerloader.crate_hauler_only && !istype(target, /obj/structure/closet/crate) && !istype(target, /obj/structure/largecrate))
+		var/obj/vehicle/powerloader/overloaded_loader = linked_powerloader
+		overloaded_loader.visible_message(SPAN_DANGER("\The [overloaded_loader]'s frame groans and begins to buckle under the strain of lifting \the [target]!"))
+		playsound(overloaded_loader.loc, "alien_doorpry", 25, TRUE)
+		if(!do_after(user, 5 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE, overloaded_loader, INTERRUPT_MOVED, BUSY_ICON_HOSTILE))
+			return
+		if(QDELETED(overloaded_loader) || linked_powerloader != overloaded_loader)
+			return
+		overloaded_loader.explode()
+		return
 	loaded = target
 	loaded.forceMove(src)
 	to_chat(user, SPAN_NOTICE("You grab \the [target] with \the [src]."))
@@ -406,3 +421,33 @@
 	open_state = "powerloader_open_ft"
 	overlay_state = "powerloader_overlay_ft"
 	wreckage = /obj/structure/powerloader_wreckage/ft
+
+/obj/vehicle/powerloader/ft/lightweight
+	name = "\improper Ferret Heavy Industries Mk4-L Crate Loader"
+	desc = "A lightweight crate hauler produced shortly before Ferret Heavy Industries collapsed. Its stripped frame is quicker than a standard Mk4, but the cheapened clamps catastrophically buckle under non-crate loads. The USCM bought thousands during Ferret's liquidation; a warning placard reads: 'NOT FLIGHT RATED - FRAME WILL NOT WITHSTAND DROPSHIP TURBULENCE.'"
+	flags_atom = FPRINT|CAN_USE_MULTIZ_STAIRS
+	move_delay = 7
+	crate_hauler_only = TRUE
+	var/dropship_transit = FALSE
+
+/obj/vehicle/powerloader/ft/lightweight/explode()
+	var/turf/drop_turf = get_turf(src)
+	if(drop_turf && PC_left?.loaded)
+		PC_left.loaded.forceMove(drop_turf)
+		PC_left.loaded = null
+	if(drop_turf && PC_right?.loaded)
+		PC_right.loaded.forceMove(drop_turf)
+		PC_right.loaded = null
+	return ..()
+
+/obj/vehicle/powerloader/ft/lightweight/beforeShuttleMove(turf/newT, rotation, move_mode, obj/docking_port/mobile/moving_dock)
+	. = ..()
+	dropship_transit = istype(moving_dock, /obj/docking_port/mobile/marine_dropship)
+
+/obj/vehicle/powerloader/ft/lightweight/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
+	. = ..()
+	if(!dropship_transit)
+		return
+	dropship_transit = FALSE
+	visible_message(SPAN_DANGER("Dropship turbulence violently shakes \the [src]'s flimsy frame apart!"))
+	explode()

--- a/code/modules/vehicles/powerloader.dm
+++ b/code/modules/vehicles/powerloader.dm
@@ -424,7 +424,7 @@
 
 /obj/vehicle/powerloader/ft/lightweight
 	name = "\improper Ferret Heavy Industries Mk4-L Crate Loader"
-	desc = "A lightweight crate hauler produced shortly before Ferret Heavy Industries collapsed. Its stripped frame is quicker than a standard Mk4, but the cheapened clamps catastrophically buckle under non-crate loads. The USCM bought thousands during Ferret's liquidation; a warning placard reads: 'NOT FLIGHT RATED - FRAME WILL NOT WITHSTAND DROPSHIP TURBULENCE.'"
+	desc = "A lightweight crate hauler produced shortly before Ferret Heavy Industries collapsed. Its stripped frame is quicker than a standard Mk4, but the cheap clamps catastrophically break under non-crate loads. A warning label reads: 'NOT FLIGHT RATED - FRAME WILL NOT WITHSTAND DROPSHIP TURBULENCE.'"
 	flags_atom = FPRINT|CAN_USE_MULTIZ_STAIRS
 	move_delay = 7
 	crate_hauler_only = TRUE

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -36633,7 +36633,7 @@
 /turf/open/floor/almayer/orange/north,
 /area/almayer/engineering/lower)
 "bLX" = (
-/obj/vehicle/powerloader,
+/obj/vehicle/powerloader/ft/lightweight,
 /turf/open/floor/almayer/cargo,
 /area/almayer/squads/req)
 "bLY" = (
@@ -68586,6 +68586,10 @@
 	},
 /turf/open/floor/almayer/green/north,
 /area/almayer/squads/req)
+"ksa" = (
+/obj/vehicle/powerloader/ft/lightweight,
+/turf/open/floor/plating,
+/area/almayer/maint/lower/constr)
 "ksm" = (
 /obj/item/device/radio/listening_bug/radio_linked/fax/uscm_pvst{
 	nametag = "Foyer 2"
@@ -141902,7 +141906,7 @@ bcm
 uTk
 tTC
 tTC
-tTC
+ksa
 cyR
 tTC
 hOV

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -199,6 +199,10 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"aaD" = (
+/obj/vehicle/powerloader/ft/lightweight,
+/turf/open/floor/plating,
+/area/almayer/maint/lower/constr)
 "aaE" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/almayer/plating_striped/south,
@@ -68586,10 +68590,6 @@
 	},
 /turf/open/floor/almayer/green/north,
 /area/almayer/squads/req)
-"ksa" = (
-/obj/vehicle/powerloader/ft/lightweight,
-/turf/open/floor/plating,
-/area/almayer/maint/lower/constr)
 "ksm" = (
 /obj/item/device/radio/listening_bug/radio_linked/fax/uscm_pvst{
 	nametag = "Foyer 2"
@@ -141906,7 +141906,7 @@ bcm
 uTk
 tTC
 tTC
-ksa
+aaD
 cyR
 tTC
 hOV


### PR DESCRIPTION

# About the pull request

This PR adds the Ferret Heavy Industries Mk4-L Crate Loader to requisitions and the construction area south of the hangar.

The Mk4-L is a faster variant of the standard powerloader (being exactly one move_delay faster), which is unable to haul anything but crates. 

https://github.com/user-attachments/assets/20761dae-0cfb-4461-ae7a-814c0583d53d


If you try to pick up anything else, the powerloader will blow apart. 

https://github.com/user-attachments/assets/11470a6e-ebf7-499c-a0e6-d1dbb10e047a


It will also blow apart if you try to transport it on a dropship, to prevent marines from using it groundside.

https://github.com/user-attachments/assets/1f15153d-4542-4877-8686-e06ccfdb977d

<img width="932" height="34" alt="grafik" src="https://github.com/user-attachments/assets/5a453247-350d-4de3-a7aa-19c82f1aa38c" />

Also adds a flag that allows non-mob movables to traverse multi-Z stairs. (modularity)

# Explain why it's good for the game

One of my least favorite shipside activities is hauling crates around the ship at a snails pace. This should hopefully make the job of requisitions and the ASO not as tedious.


<summary>Screenshots & Videos</summary>

<img width="942" height="371" alt="grafik" src="https://github.com/user-attachments/assets/46f8e6ca-7d5d-464f-b750-a59e97a132f5" />
<img width="493" height="458" alt="grafik" src="https://github.com/user-attachments/assets/3865bea7-1119-46e6-b7e9-6b3cbcdfb62d" />



# Changelog
:cl:
add: Added the Ferret Heavy Industries Mk4-L Crate Loader. A faster powerloader which can only haul crates.
code: Added a flag allowing non-mob movables to traverse multi-Z stairs.
maptweak: Added an Mk4-L Crate Loader to the construction area south of the hangar.
/:cl: