### PR TITLE
Remove rotation updates each-tick on projectiles

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -280,6 +280,11 @@
 	var/dy = p_y + aim_turf.y * 32 - source_turf.y * 32
 	angle = delta_to_angle(dx, dy)
 
+	//Change the bullet angle to match
+	var/matrix/rotate = matrix()
+	rotate.Turn(angle)
+	apply_transform(rotate)
+
 /obj/projectile/process(delta_time)
 	. = PROC_RETURN_SLEEP
 
@@ -314,13 +319,6 @@
 	var/turf/vis_target = path[length(path)]
 	var/pixel_x_target = vis_target.x * world.icon_size + p_x
 	var/pixel_y_target = vis_target.y * world.icon_size + p_y
-
-	//Change the bullet angle to its visual path
-
-	var/vis_angle = delta_to_angle(pixel_x_target - pixel_x_source, pixel_y_target - pixel_y_source)
-	var/matrix/rotate = matrix()
-	rotate.Turn(vis_angle)
-	apply_transform(rotate)
 
 	//Determine apparent position along visual path, then lerp between start and end positions
 


### PR DESCRIPTION

# About the pull request
Projectiles are updating their rotation angle and applying a matrix transform every tick.
This is unnecessary load because the angle should be correct already 99.99% of the time.
In addition NOT doing it means upholding the expectation that a bullet angle doesn't noticeably change when fired. 
They might just possibly strafe instead of turn and home (visually) sometimes.
The angle is still updated when re targeting the bullet for (gameplay) homing.

# Explain why it's good for the game
Lessens SendMaps load! Also animate_flight in general is a hot proc and i'm hoping this helps it too.


# Testing Photographs and Procedure
Pew Pew. Only tested standard gun. Tested off angles.


# Changelog
:cl:
code: Removed unnecessary rotation updates for projectiles. They may in rare cases strafe a little rather than turning, but you shouldn't notice the difference.
/:cl:
