### PR TITLE
PR Stack - Movement Optimizations

### DIFF
--- a/code/__DEFINES/dcs/signals/atom/signals_atom.dm
+++ b/code/__DEFINES/dcs/signals/atom/signals_atom.dm
@@ -53,8 +53,6 @@
 /// Called when an atom has emp_act called on it, from /atom/emp_act: (severity)
 #define COMSIG_ATOM_EMP_ACT "atom_emp_act"
 
-//from base of atom/Exited(): (atom/movable/exiting, direction)
-#define COMSIG_ATOM_EXITED "atom_exited"
-
 /// Called when an atom is crossed by a movable atom
 #define COMSIG_ATOM_CROSSED "atom_crossed"
+

--- a/code/__DEFINES/dcs/signals/atom/signals_movable.dm
+++ b/code/__DEFINES/dcs/signals/atom/signals_movable.dm
@@ -36,9 +36,6 @@
 
 #define COMSIG_MOVABLE_TURF_ENTER "movable_turf_enter"
 
-/// Called when a movable atom enters an obj's contents (obj/entered, atom/old_loc)
-#define COMSIG_MOVABLE_ENTERED_OBJ "atom_entered"
-
 #define COMSIG_MOVABLE_PREBUCKLE "prebuckle" // this is the last chance to interrupt and block a buckle before it finishes
 	#define COMPONENT_BLOCK_BUCKLE	(1<<0)
 

--- a/code/controllers/subsystem/cmtv.dm
+++ b/code/controllers/subsystem/cmtv.dm
@@ -291,7 +291,7 @@ SUBSYSTEM_DEF(cmtv)
 		return
 
 	RegisterSignal(future_perspective_mob, list(COMSIG_PARENT_QDELETING, COMSIG_MOB_STAT_SET_DEAD, COMSIG_MOB_NESTED, COMSIG_MOB_LOGOUT, COMSIG_MOB_DEATH), PROC_REF(handle_reset_signal))
-	RegisterSignal(future_perspective_mob, COMSIG_MOVABLE_ENTERED_OBJ, PROC_REF(handle_reset_signal_immediate))
+	RegisterSignal(future_perspective_mob, COMSIG_MOVABLE_MOVED, PROC_REF(handle_reset_signal_immediate))
 	RegisterSignal(future_perspective_mob, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(handle_z_change))
 	RegisterSignal(future_perspective_mob.client, COMSIG_CLIENT_EYE_CHANGED, PROC_REF(handle_eye_change))
 	RegisterSignal(future_perspective_mob.client, COMSIG_CLIENT_PIXEL_X_CHANGED, PROC_REF(handle_pixel_x_change))
@@ -329,7 +329,7 @@ SUBSYSTEM_DEF(cmtv)
 		COMSIG_MOB_LOGOUT,
 		COMSIG_MOB_DEATH,
 		COMSIG_MOVABLE_Z_CHANGED,
-		COMSIG_MOVABLE_ENTERED_OBJ,
+		COMSIG_MOVABLE_MOVED,
 	))
 
 	if(current_perspective.client)
@@ -371,10 +371,10 @@ SUBSYSTEM_DEF(cmtv)
 	reset_perspective("Current perspective is no longer eligible (signal)")
 
 /// Reset handler that immediately switches perspective to something generic while we wait
-/datum/controller/subsystem/cmtv/proc/handle_reset_signal_immediate()
+/datum/controller/subsystem/cmtv/proc/handle_reset_signal_immediate(atom/movable/source, oldloc, direct)
 	SIGNAL_HANDLER
-
-	reset_perspective("Current perspective is no longer eligible (instant signal)", instant = TRUE)
+	if(source.loc != oldloc && isobj(source.loc))
+		reset_perspective("Current perspective is no longer eligible (instant signal)", instant = TRUE)
 
 /datum/controller/subsystem/cmtv/proc/handle_eye_change(client/source_client, new_eye)
 	SIGNAL_HANDLER

--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -636,20 +636,12 @@ SUBSYSTEM_DEF(minimaps)
 	pixel_x = MINIMAP_PIXEL_FROM_WORLD(movable_loc.x) + minimap.x_offset
 	pixel_y = MINIMAP_PIXEL_FROM_WORLD(movable_loc.y) + minimap.y_offset
 
+	UnregisterSignal(source, COMSIG_MOVABLE_MOVED)
+
 ///Used to handle minimap tracking inside other movables
 /atom/movable/proc/override_minimap_tracking()
 	var/image/blip = SSminimaps.images_by_source[src]
 	blip.RegisterSignal(loc, COMSIG_MOVABLE_MOVED, TYPE_PROC_REF(/image, minimap_on_move))
-	RegisterSignal(loc, COMSIG_ATOM_EXITED, PROC_REF(cancel_override_minimap_tracking))
-
-///Stops minimap override tracking
-/atom/movable/proc/cancel_override_minimap_tracking(atom/movable/source, atom/movable/mover)
-	SIGNAL_HANDLER
-	if(mover != src)
-		return
-	var/image/blip = SSminimaps.images_by_source[src]
-	blip?.UnregisterSignal(source, COMSIG_MOVABLE_MOVED)
-	UnregisterSignal(source, COMSIG_ATOM_EXITED)
 
 
 /**
@@ -1183,7 +1175,7 @@ SUBSYSTEM_DEF(minimaps)
 		if(to_track)
 			RegisterSignal(to_track, COMSIG_PARENT_QDELETING, TYPE_PROC_REF(/datum/action/minimap, clear_locator_override))
 			if(owner && owner.loc == to_track)
-				RegisterSignal(to_track, COMSIG_ATOM_EXITED, TYPE_PROC_REF(/datum/action/minimap, on_exit_check))
+				RegisterSignal(to_track, COMSIG_MOVABLE_MOVED, TYPE_PROC_REF(/datum/action/minimap, on_exit_check))
 		if(owner)
 			RegisterSignal(new_track, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(on_owner_z_change))
 			var/turf/old_turf = get_turf(tracking)
@@ -1195,7 +1187,7 @@ SUBSYSTEM_DEF(minimaps)
 	if(to_track)
 		RegisterSignal(to_track, COMSIG_PARENT_QDELETING, TYPE_PROC_REF(/datum/action/minimap, clear_locator_override))
 		if(owner.loc == to_track)
-			RegisterSignal(to_track, COMSIG_ATOM_EXITED, TYPE_PROC_REF(/datum/action/minimap, on_exit_check))
+			RegisterSignal(to_track, COMSIG_MOVABLE_MOVED, TYPE_PROC_REF(/datum/action/minimap, on_exit_check))
 	RegisterSignal(new_track, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(on_owner_z_change))
 	var/turf/old_turf = get_turf(tracking)
 	if(old_turf.z != new_track.z)
@@ -1205,18 +1197,17 @@ SUBSYSTEM_DEF(minimaps)
 	locator.update(new_track)
 
 ///checks if we should clear override if the owner exits this atom
-/datum/action/minimap/proc/on_exit_check(datum/source, atom/movable/mover)
+/datum/action/minimap/proc/on_exit_check(atom/movable/source, oldloc, direction, Forced)
 	SIGNAL_HANDLER
-	if(mover && mover != owner)
-		return
-	clear_locator_override()
+	if(source.loc != oldloc)
+		clear_locator_override()
 
 ///CLears the locator override in case the override target is deleted
 /datum/action/minimap/proc/clear_locator_override()
 	SIGNAL_HANDLER
 	if(!locator_override)
 		return
-	UnregisterSignal(locator_override, list(COMSIG_PARENT_QDELETING, COMSIG_ATOM_EXITED))
+	UnregisterSignal(locator_override, list(COMSIG_PARENT_QDELETING, COMSIG_MOVABLE_MOVED))
 	if(owner)
 		UnregisterSignal(locator_override, COMSIG_MOVABLE_Z_CHANGED)
 		RegisterSignal(owner, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(on_owner_z_change))

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -815,5 +815,3 @@ Parameters are passed from New.
 	. += "[VV_HREF_TARGETREF(refid, VV_HK_AUTO_RENAME, "<b id='name'>[src]</b>")]"
 	. += "<br><font size='1'><a href='byond://?_src_=vars;[HrefToken()];rotatedatum=[refid];rotatedir=left'><<</a> <a href='byond://?_src_=vars;[HrefToken()];datumedit=[refid];varnameedit=dir' id='dir'>[dir2text(dir) || dir]</a> <a href='byond://?_src_=vars;[HrefToken()];rotatedatum=[refid];rotatedir=right'>>></a></font>"
 
-/atom/Exited(atom/movable/AM, direction)
-	SEND_SIGNAL(src, COMSIG_ATOM_EXITED, AM, direction)

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -769,24 +769,6 @@
 /obj/structure/machinery/bot/mulebot/alter_health()
 	return get_turf(src)
 
-
-// called from mob/living/carbon/human/Crossed()
-// when mulebot is in the same loc
-/obj/structure/machinery/bot/mulebot/proc/RunOver(mob/living/carbon/human/H)
-	src.visible_message(SPAN_DANGER("[src] drives over [H]!"))
-	playsound(src.loc, 'sound/effects/splat.ogg', 25, 1)
-
-	var/damage = rand(5,15)
-	H.apply_damage(2*damage, BRUTE, "head")
-	H.apply_damage(2*damage, BRUTE, "chest")
-	H.apply_damage(0.5*damage, BRUTE, "l_leg")
-	H.apply_damage(0.5*damage, BRUTE, "r_leg")
-	H.apply_damage(0.5*damage, BRUTE, "l_arm")
-	H.apply_damage(0.5*damage, BRUTE, "r_arm")
-
-	H.add_splatter_floor(loc, 1)
-	bloodiness += 4
-
 // player on mulebot attempted to move
 /obj/structure/machinery/bot/mulebot/relaymove(mob/user)
 	if(user.is_mob_incapacitated(TRUE))

--- a/code/game/objects/effects/effect_system/foam.dm
+++ b/code/game/objects/effects/effect_system/foam.dm
@@ -68,7 +68,7 @@
 		if(!T)
 			continue
 
-		if(!T.Enter(src))
+		if(!T.Enter(src, loc))
 			continue
 
 		var/obj/effect/particle_effect/foam/F = locate() in T

--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -72,7 +72,7 @@
 
 	if(istype(M, /mob/living/carbon))
 		var/mob/living/carbon/C = M
-		var/fullness = M.nutrition + (M.reagents.get_reagent_amount("nutriment") * 25)
+		var/fullness = C.nutrition + (M.reagents.get_reagent_amount("nutriment") * 25)
 		if(fullness > NUTRITION_HIGH && world.time < C.overeat_cooldown)
 			to_chat(user, SPAN_WARNING("[user == M ? "You" : "They"] don't feel like eating more right now."))
 			return FALSE

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -86,11 +86,6 @@
 		if (alert(usr, "Would you like to enable pixel scaling?", "Confirm", "Yes", "No") == "Yes")
 			enable_pixel_scaling()
 
-/obj/Entered(atom/movable/moved_obj, atom/old_loc)
-	. = ..()
-
-	SEND_SIGNAL(moved_obj, COMSIG_MOVABLE_ENTERED_OBJ, src, old_loc)
-
 // object is being physically reduced into parts
 /obj/proc/deconstruct(disassembled = TRUE)
 	density = FALSE

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -19,6 +19,11 @@
 	handle_rotation()
 	if(!can_rotate)
 		verbs.Remove(/obj/structure/bed/chair/verb/rotate)
+	RegisterSignal(src, COMSIG_ATOM_DIR_CHANGE, PROC_REF(handle_rotation_on_dir_change)) // If this annoys you due to signal collision just remove it and override setDir, it's not that big a deal.
+
+/obj/structure/bed/chair/proc/handle_rotation_on_dir_change(atom/self, dir, newdir)
+	SIGNAL_HANDLER
+	handle_rotation()
 
 /obj/structure/bed/chair/initialize_pass_flags(datum/pass_flags_container/PF)
 	if(PF)
@@ -217,7 +222,6 @@
 
 	if(CONFIG_GET(flag/ghost_interaction))
 		src.setDir(turn(src.dir, 90))
-		handle_rotation()
 		return
 	else
 		if(!ishuman(usr))
@@ -231,7 +235,6 @@
 	if(usr.is_mob_incapacitated())
 		return
 	setDir(turn(src.dir, 90))
-	handle_rotation()
 	return
 
 //Chair types

--- a/code/game/objects/structures/stool_bed_chair_nest/janicart.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/janicart.dm
@@ -18,7 +18,6 @@
 
 /obj/structure/bed/chair/janicart/Initialize()
 	. = ..()
-	handle_rotation()
 	create_reagents(100)
 
 

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -8,7 +8,6 @@
 	var/bloodiness = 0
 	var/move_delay = 6
 
-
 /obj/structure/bed/chair/wheelchair/handle_rotation()
 	overlays.Cut()
 	var/image/O = image(icon = 'icons/obj/structures/props/furniture/chairs.dmi', icon_state = "w_overlay", layer = FLY_LAYER, dir = src.dir)

--- a/code/game/turfs/open_space.dm
+++ b/code/game/turfs/open_space.dm
@@ -46,9 +46,21 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 
 /turf/open_space/Enter(atom/movable/mover, atom/old_loc)
 	. = ..()
-	if(. && !mover.throwing && isliving(mover) && check_blocked())
+
+	if(!isliving(mover))
+		return
+
+	if(. && mover.move_intentionally)
+		var/mob/living/climber = mover
+		if(climber.a_intent == INTENT_HARM)
+			return TRUE
+		climb_down(climber)
+		. = FALSE
+
+	if(. && !mover.throwing && check_blocked())
 		to_chat(mover, SPAN_WARNING("It would be too dangerous to go that way."))
-		return FALSE
+		. = FALSE
+
 
 /turf/open_space/Entered(atom/movable/entered_movable, atom/old_loc)
 	. = ..()

--- a/code/game/turfs/open_space.dm
+++ b/code/game/turfs/open_space.dm
@@ -53,9 +53,10 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 	if(. && mover.move_intentionally)
 		var/mob/living/climber = mover
 		if(climber.a_intent == INTENT_HARM)
-			return TRUE
-		climb_down(climber)
-		. = FALSE
+			. = TRUE
+		else
+			. = FALSE
+			climb_down(climber)
 
 	if(. && !mover.throwing && check_blocked())
 		to_chat(mover, SPAN_WARNING("It would be too dangerous to go that way."))

--- a/code/game/turfs/space.dm
+++ b/code/game/turfs/space.dm
@@ -73,88 +73,8 @@
 			to_chat(user, SPAN_DANGER("The plating is going to need some support."))
 	return
 
-
-// Ported from unstable r355
-
-/turf/open/space/Entered(atom/movable/A)
+/turf/open/space/Entered(atom/movable/A, atom/OldLoc)
 	..()
 	if(isnewplayer(A))
 		return
-
-	if ((!(A) || src != A.loc)) return
-
 	inertial_drift(A)
-
-	if(SSticker.mode)
-
-
-		// Okay, so let's make it so that people can travel z levels but not nuke disks!
-		// if(ticker.mode.name == "nuclear emergency") return
-		if(A.z > 6)
-			return
-		if(A.x <= TRANSITIONEDGE || A.x >= (world.maxx - TRANSITIONEDGE - 1) || A.y <= TRANSITIONEDGE || A.y >= (world.maxy - TRANSITIONEDGE - 1))
-
-			if(istype(A, /obj/item/disk/nuclear)) // Don't let nuke disks travel Z levels  ... And moving this shit down here so it only fires when they're actually trying to change z-level.
-				qdel(A) //The disk's Dispose() proc ensures a new one is created
-				return
-
-			var/list/disk_search = A.search_contents_for(/obj/item/disk/nuclear)
-			if(length(disk_search))
-				if(istype(A, /mob/living))
-					var/mob/living/MM = A
-					if(MM.client && !MM.stat)
-						to_chat(MM, SPAN_WARNING("Something you are carrying is preventing you from leaving. Don't play stupid; you know exactly what it is."))
-						if(MM.x <= TRANSITIONEDGE)
-							MM.inertia_dir = 4
-						else if(MM.x >= world.maxx -TRANSITIONEDGE)
-							MM.inertia_dir = 8
-						else if(MM.y <= TRANSITIONEDGE)
-							MM.inertia_dir = 1
-						else if(MM.y >= world.maxy -TRANSITIONEDGE)
-							MM.inertia_dir = 2
-					else
-						for(var/obj/item/disk/nuclear/N in disk_search)
-							disk_search -= N
-							qdel(N)//Make the disk respawn it is on a clientless mob or corpse
-				else
-					for(var/obj/item/disk/nuclear/N in disk_search)
-						disk_search -= N
-						qdel(N)//Make the disk respawn if it is floating on its own
-				return
-
-			var/move_to_z = src.z
-			var/safety = 1
-
-			while(move_to_z == src.z)
-				move_to_z = pick(SSmapping.levels_by_trait(ZTRAIT_GROUND))
-				safety++
-				if(safety > 10)
-					break
-
-			if(!move_to_z)
-				return
-
-			A.z = move_to_z
-
-			if(src.x <= TRANSITIONEDGE)
-				A.x = world.maxx - TRANSITIONEDGE - 2
-				A.y = rand(TRANSITIONEDGE + 2, world.maxy - TRANSITIONEDGE - 2)
-
-			else if (A.x >= (world.maxx - TRANSITIONEDGE - 1))
-				A.x = TRANSITIONEDGE + 1
-				A.y = rand(TRANSITIONEDGE + 2, world.maxy - TRANSITIONEDGE - 2)
-
-			else if (src.y <= TRANSITIONEDGE)
-				A.y = world.maxy - TRANSITIONEDGE -2
-				A.x = rand(TRANSITIONEDGE + 2, world.maxx - TRANSITIONEDGE - 2)
-
-			else if (A.y >= (world.maxy - TRANSITIONEDGE - 1))
-				A.y = TRANSITIONEDGE + 1
-				A.x = rand(TRANSITIONEDGE + 2, world.maxx - TRANSITIONEDGE - 2)
-
-
-
-
-			spawn (0)
-				if ((A && A.loc))
-					A.loc.Entered(A)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -344,19 +344,19 @@
 
 	return TRUE //Nothing found to block so return success!
 
-/turf/Entered(atom/movable/entered_movable, atom/old_loc)
+/turf/Entered(atom/movable/entered_movable, atom/OldLoc)
 	SHOULD_CALL_PARENT(TRUE)
 
 	..() // Shouldn't do anything but to satisfy lint
 
 	if(QDELETED(entered_movable))
-		return
+		return // Shouldn't be needed, we already fence it in Enter, but just in case
 
 	SEND_SIGNAL(src, COMSIG_TURF_ENTERED, entered_movable)
 	SEND_SIGNAL(entered_movable, COMSIG_MOVABLE_TURF_ENTERED, src)
 
 	// Let explosions know that the atom entered
-	if(old_loc != src)
+	if(OldLoc != src)
 		for(var/datum/automata_cell/explosion/cell as anything in autocells)
 			cell.on_turf_entered(entered_movable)
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -255,8 +255,10 @@
 	return
 
 // Handles whether an atom is able to enter the src turf
-/turf/Enter(atom/movable/mover, atom/old_loc)
-	if(QDELETED(mover) || !isturf(mover.loc))
+/turf/Enter(atom/movable/mover, atom/oldloc)
+	if(QDELETED(mover))
+		return FALSE // Prevent anything deleted from moving to limit side effects
+	if(!isturf(oldloc))
 		return FALSE
 
 	var/override = SEND_SIGNAL(mover, COMSIG_MOVABLE_TURF_ENTER, src)
@@ -276,66 +278,54 @@
 
 	var/blocking_dir = 0 // The directions that the mover's path is being blocked by
 
-	var/obstacle
-	var/turf/T
-	var/atom/A
-
-	T = mover.loc
-	blocking_dir |= T.BlockedExitDirs(mover, fdir)
+	blocking_dir |= oldloc.BlockedExitDirs(mover, fdir)
 	if ((!fd1 || blocking_dir & fd1) && (!fd2 || blocking_dir & fd2))
-		mover.Collide(T)
+		mover.Collide(oldloc)
 		return FALSE
-	for (obstacle in T) //First, check objects to block exit
-		if (mover == obstacle || old_loc == obstacle)
+	for (var/atom/movable/obstacle as anything in oldloc) //First, check objects to block exit
+		if (mover == obstacle)
 			continue
-		A = obstacle
-		if (!istype(A) || !A.can_block_movement)
+		if (!obstacle.can_block_movement)
 			continue
-		blocking_dir |= A.BlockedExitDirs(mover, fdir)
+		blocking_dir |= obstacle.BlockedExitDirs(mover, fdir)
 		if ((!fd1 || blocking_dir & fd1) && (!fd2 || blocking_dir & fd2))
-			mover.Collide(A)
+			mover.Collide(obstacle)
 			return FALSE
 
 	// if we are thrown, moved, dragged, or in any other way abused by code - check our diagonals
 	if(!mover.move_intentionally)
 		// Check objects in adjacent turf EAST/WEST
 		if(fd1 && fd1 != fdir)
-			T = get_step(mover, fd1)
+			var/turf/T = get_step(mover, fd1)
 			if (T.BlockedExitDirs(mover, fd2) || T.BlockedPassDirs(mover, fd1))
 				blocking_dir |= fd1
 				if ((!fd1 || blocking_dir & fd1) && (!fd2 || blocking_dir & fd2))
 					mover.Collide(T)
 					return FALSE
-			for(obstacle in T)
-				if(old_loc == obstacle)
+			for(var/atom/movable/obstacle as anything in T)
+				if (!obstacle.can_block_movement)
 					continue
-				A = obstacle
-				if (!istype(A) || !A.can_block_movement)
-					continue
-				if (A.BlockedExitDirs(mover, fd2) || A.BlockedPassDirs(mover, fd1))
+				if (obstacle.BlockedExitDirs(mover, fd2) || obstacle.BlockedPassDirs(mover, fd1))
 					blocking_dir |= fd1
 					if ((!fd1 || blocking_dir & fd1) && (!fd2 || blocking_dir & fd2))
-						mover.Collide(A)
+						mover.Collide(obstacle)
 						return FALSE
 
 		// Check for borders in adjacent turf NORTH/SOUTH
 		if(fd2 && fd2 != fdir)
-			T = get_step(mover, fd2)
+			var/turf/T = get_step(mover, fd2)
 			if (T.BlockedExitDirs(mover, fd1) || T.BlockedPassDirs(mover, fd2))
 				blocking_dir |= fd2
 				if ((!fd1 || blocking_dir & fd1) && (!fd2 || blocking_dir & fd2))
 					mover.Collide(T)
 					return FALSE
-			for(obstacle in T)
-				if(old_loc == obstacle)
+			for(var/atom/movable/obstacle as anything in T)
+				if (!obstacle.can_block_movement)
 					continue
-				A = obstacle
-				if (!istype(A) || !A.can_block_movement)
-					continue
-				if (A.BlockedExitDirs(mover, fd1) || A.BlockedPassDirs(mover, fd2))
+				if (obstacle.BlockedExitDirs(mover, fd1) || obstacle.BlockedPassDirs(mover, fd2))
 					blocking_dir |= fd2
 					if ((!fd1 || blocking_dir & fd1) && (!fd2 || blocking_dir & fd2))
-						mover.Collide(A)
+						mover.Collide(obstacle)
 						return FALSE
 					break
 
@@ -344,25 +334,13 @@
 	if ((!fd1 || blocking_dir & fd1) && (!fd2 || blocking_dir & fd2))
 		mover.Collide(src)
 		return FALSE
-	for(obstacle in src) //Then, check atoms in the target turf
-		if(old_loc == obstacle)
+	for(var/atom/movable/obstacle as anything in src) //Then, check atoms in the target turf
+		if (!obstacle.can_block_movement)
 			continue
-		A = obstacle
-		if (!istype(A) || !A.can_block_movement)
-			continue
-		blocking_dir |= A.BlockedPassDirs(mover, fdir)
+		blocking_dir |= obstacle.BlockedPassDirs(mover, fdir)
 		if ((!fd1 || blocking_dir & fd1) && (!fd2 || blocking_dir & fd2))
-			if(!mover.Collide(A))
+			if(!mover.Collide(obstacle))
 				return FALSE
-
-	if(mover.move_intentionally && istype(src, /turf/open_space) && istype(mover,/mob/living))
-		var/turf/open_space/space = src
-		var/mob/living/climber = mover
-		if(climber.a_intent == INTENT_HARM)
-			return TRUE
-		space.climb_down(climber)
-		return FALSE
-
 
 	return TRUE //Nothing found to block so return success!
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -30,12 +30,6 @@
 	halbody = null
 
 
-/mob/living/carbon/Move(NewLoc, direct)
-	. = ..()
-	if(.)
-		if(nutrition && stat != DEAD)
-			nutrition -= HUNGER_FACTOR/5
-
 /mob/living/carbon/relaymove(mob/user, direction)
 	if(user.is_mob_incapacitated(TRUE))
 		return

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -323,19 +323,6 @@
 		observer.client.add_to_screen(s_active.storage_continue)
 		observer.client.add_to_screen(s_active.storage_end)
 
-// called when something steps onto a human
-// this handles mulebots and vehicles
-/mob/living/carbon/human/Crossed(atom/movable/AM)
-	..()
-	if(istype(AM, /obj/structure/machinery/bot/mulebot))
-		var/obj/structure/machinery/bot/mulebot/MB = AM
-		MB.RunOver(src)
-
-	if(istype(AM, /obj/vehicle))
-		var/obj/vehicle/V = AM
-		V.RunOver(src)
-
-
 //gets assignment from ID or ID inside PDA or PDA itself
 //Useful when player do something with computers
 /mob/living/carbon/human/proc/get_assignment(if_no_id = "No id", if_no_job = "No job")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -221,6 +221,8 @@
 	if(back && (back.flags_item & ITEM_OVERRIDE_NORTHFACE))
 		update_inv_back()
 
+	if(. && nutrition && stat != DEAD)
+		nutrition -= HUNGER_FACTOR/5
 
 
 /mob/proc/resist_grab(moving_resist)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -149,3 +149,5 @@
 
 	// for multiz looking up
 	var/atom/observed_atom
+
+	var/nutrition = NUTRITION_NORMAL // This should be on /human

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -125,7 +125,7 @@
 	var/old_x = 0
 	var/old_y = 0
 
-	var/nutrition = NUTRITION_NORMAL//Carbon
+	var/charges = 0
 
 	var/a_intent = INTENT_HELP//Living
 	var/m_intent = MOVE_INTENT_RUN

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -125,8 +125,6 @@
 	var/old_x = 0
 	var/old_y = 0
 
-	var/charges = 0
-
 	var/a_intent = INTENT_HELP//Living
 	var/m_intent = MOVE_INTENT_RUN
 	var/lastKnownIP = null

--- a/code/modules/movement/movement.dm
+++ b/code/modules/movement/movement.dm
@@ -78,8 +78,6 @@
 	if (.)
 		Moved(oldloc, direct)
 
-	handle_rotation()
-
 /// Called when `crossed_by` enters the atom's turf (via native Move() or doMove() if allowed).
 /// Does not return anything, only handles side effects from Crossed.
 /atom/Crossed(atom/movable/crossed_by)

--- a/code/modules/vehicles/multitile/multitile_movement.dm
+++ b/code/modules/vehicles/multitile/multitile_movement.dm
@@ -166,7 +166,7 @@
 		if(T in old_turfs)
 			continue
 
-		if(!T.Enter(src))
+		if(!T.Enter(src, loc))
 			can_move = FALSE
 
 	// Crashed with something that stopped us

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -252,9 +252,6 @@
 	cell = null
 	powercheck()
 
-/obj/vehicle/proc/RunOver(mob/living/carbon/human/H)
-	return //write specifics for different vehicles
-
 /obj/vehicle/afterbuckle(mob/M)
 	. = ..()
 	if(. && buckled_mob == M)


### PR DESCRIPTION

# About the pull request

8 independent changes to optimize/maintain core movement code that has been untouched since forever.
None of these is a real gamechanger, but together they should improve performance slightly. We have a lot of players and we do a lot of movement, you see. And not only the players move. It adds up, really fast.

# Contents

### Chapter 1: Refactor nutrition
Moves nutrition around to kill an unncessary `/mob/living/carbon/Move` that did nothing else.

### Chapter 2: Remove COMSIG_ATOM_EXITED
Swaps that signal for a more traditional COMSIG_MOVABLE_MOVED in minimap. 
This allows to remove the /atom/Exited handler, which is executed for every move of everything, all the time. 
At a glance this should net 0.5% perf on movement. Could not properly test it though...

### Chapter 3: Remove COMSIG_MOVABLE_ENTERED_OBJ 
Same story as above. This one only fires on /obj moves so it's less of a deal.

### Chapter 4: Modernize /turf/Enter
This is the fun one! It's mostly maintenance save for a few removed typechecks.
Renames and shuffles all the relevant variables in collision checks for movement to be on par with standard code.
Also clears a very weird misconception (forget -> oldloc) and uses BYOND provided oldloc, instead of infering it from object.

### Chapter 5: Nukes nuke disk code
We simply don't use that.

### Chapter 6: /turf/Entered optimization
Just removes an unneeded typecheck. That's it.

### Chapter 7: Signalify handle_rotation
As for Chapter 2, that was firing in every /atom/movable/Move when it was only needed in a couple cases. 
I implemented it by COMSIG_ATOM_DIR_CHANGE in chairs, but as far as i can see, everything already has handlers for it already? It's possible i missed some cases though.

### Chapter 8: kill /mob/living/carbon/human/Crossed
This is probably the biggest offender for mob movement, Crossed() is fired against every content of everything you move to.
As it turns out, MuleBots don't work anyway so they don't need to run over anything.
As for vehicles, RunOver() was a placeholder proc that didn't do anything.
Gone.



# Testing Photographs and Procedure
Changes were tested individually in a basic fashion, but changes in move code reach out everywhere, so this will need live testing.

# Changelog
:cl:
del: MULEbots cannot run people over anymore. They still can't really move either way.
/:cl:
