### PR TITLE
Prevents placing eggs near ladders

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/egg_item.dm
+++ b/code/modules/mob/living/carbon/xenomorph/egg_item.dm
@@ -99,6 +99,9 @@
 		return
 	if(!user.check_alien_construction(T, ignore_nest = TRUE))
 		return
+	if(locate(/obj/structure/ladder) in range(2, T))
+		to_chat(user, SPAN_XENOWARNING("We cannot plant [src] so close to a ladder."))
+		return
 	if(!user.check_plasma(30))
 		return
 


### PR DESCRIPTION

# About the pull request

This prevents xenos from planting eggs within two tiles of ladders.

# Explain why it's good for the game

Placing eggs near ladders is unfair because players arriving through them have little opportunity to see or avoid the eggs before triggering them. 


# Testing Photographs and Procedure
<img width="437" height="22" alt="grafik" src="https://github.com/user-attachments/assets/8519636c-29dd-4156-8f00-98240261a6d5" />

Tested ingame, and it worked.

# Changelog
:cl:
balance: Xenos can no longer plant eggs within two tiles of ladders.
/:cl:
