### PR TITLE
Fix: Onehanding Lever Action chambering runtime

### DIFF
--- a/code/modules/projectiles/guns/lever_action.dm
+++ b/code/modules/projectiles/guns/lever_action.dm
@@ -278,12 +278,13 @@ their unique feature is that a direct hit will buff your damage and firerate
 		cur_onehand_chance = cur_onehand_chance - 20 //gets steadily worse if you spam it
 	else
 		to_chat(user, SPAN_DANGER("Augh! Your hand catches on the [lever_name]!!"))
+		user.drop_held_item()
 		var/obj/limb/holding_hand = user.get_limb(user.hand ? "l_hand" : "r_hand")
-		if(holding_hand.status & LIMB_BROKEN)
-			holding_hand = user.get_limb(user.hand ? "l_arm" : "r_arm")
-			user.drop_held_item()
-		else
-			holding_hand.fracture()
+		if(holding_hand.status & LIMB_BROKEN) //Hand already broken? Break their arm next
+			var/obj/limb/holding_arm = user.get_limb(user.hand ? "l_arm" : "r_arm")
+			holding_arm.fracture()
+			holding_arm.status &= ~LIMB_SPLINTED
+		holding_hand.fracture()
 		holding_hand.status &= ~LIMB_SPLINTED
 		user.pain.recalculate_pain()
 	addtimer(VARSET_CALLBACK(src, cur_onehand_chance, initial(cur_onehand_chance)), 4 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE)

--- a/code/modules/projectiles/guns/lever_action.dm
+++ b/code/modules/projectiles/guns/lever_action.dm
@@ -37,7 +37,6 @@ their unique feature is that a direct hit will buff your damage and firerate
 	var/levered = FALSE
 	var/message_cooldown
 	var/cur_onehand_chance = 85
-	var/reset_onehand_chance = 85
 	var/hit_buff_reset_cooldown = 1 SECONDS //how much time after a direct hit until streaks reset
 	var/lever_message = "You work the lever."
 	var/lever_name = "lever" //the thing we use to chamber the next round. Lever, button, etc. for to_chats
@@ -80,29 +79,12 @@ their unique feature is that a direct hit will buff your damage and firerate
 	reset_hit_buff(user)
 	if(flags_gun_lever_action & USES_STREAKS)
 		UnregisterSignal(user, COMSIG_BULLET_DIRECT_HIT)
-	addtimer(VARSET_CALLBACK(src, cur_onehand_chance, reset_onehand_chance), 4 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE)
+	addtimer(VARSET_CALLBACK(src, cur_onehand_chance, initial(cur_onehand_chance)), 4 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE)
 
-/obj/item/weapon/gun/lever_action/proc/direct_hit_buff(mob/user, mob/target, obj/item/weapon/gun/projectile_source, one_hand_lever = FALSE)
+/obj/item/weapon/gun/lever_action/proc/direct_hit_buff(mob/user, mob/target, obj/item/weapon/gun/projectile_source)
 	SIGNAL_HANDLER
 	if(projectile_source != src)
 		return FALSE
-	var/mob/living/carbon/human/human_user = user
-	if(one_hand_lever && !(flags_gun_lever_action & DANGEROUS_TO_ONEHAND_LEVER))
-		return FALSE
-	else if(one_hand_lever) //base marines should never be able to easily pass the skillcheck, only specialists and etc.
-		if(prob(cur_onehand_chance) || skillcheck(human_user, SKILL_FIREARMS, SKILL_FIREARMS_SKILLED))
-			cur_onehand_chance = cur_onehand_chance - 20 //gets steadily worse if you spam it
-			return FALSE
-		else
-			to_chat(user, SPAN_DANGER("Augh! Your hand catches on the [lever_name]!!"))
-			var/obj/limb/O = human_user.get_limb(human_user.hand ? "l_hand" : "r_hand")
-			if(O.status & LIMB_BROKEN)
-				O = human_user.get_limb(user.hand ? "l_arm" : "r_arm")
-				human_user.drop_held_item()
-			O.fracture()
-			O.status &= ~LIMB_SPLINTED
-			human_user.pain.recalculate_pain()
-			return FALSE
 
 	if(!istype(target))
 		return FALSE //sanity...
@@ -119,10 +101,10 @@ their unique feature is that a direct hit will buff your damage and firerate
 		playsound(user, lever_hitsound, 25, FALSE)
 	if(!(flags_gun_lever_action & USES_STREAKS))
 		return FALSE
-	apply_hit_buff(user, target, one_hand_lever) //this is a separate proc so it's configgable
-	addtimer(CALLBACK(src, PROC_REF(reset_hit_buff), user, one_hand_lever), hit_buff_reset_cooldown, TIMER_OVERRIDE|TIMER_UNIQUE)
+	apply_hit_buff(user, target) //this is a separate proc so it's configgable
+	addtimer(CALLBACK(src, PROC_REF(reset_hit_buff), user), hit_buff_reset_cooldown, TIMER_OVERRIDE|TIMER_UNIQUE)
 
-/obj/item/weapon/gun/lever_action/proc/apply_hit_buff(mob/user, mob/target, one_hand_lever = FALSE)
+/obj/item/weapon/gun/lever_action/proc/apply_hit_buff(mob/user, mob/target)
 	lever_sound = lever_super_sound
 	lever_message = SPAN_BOLD("You quickly work the [lever_name]!")
 	last_fired = world.time - buff_fire_reduc //to shoot the next round faster
@@ -136,7 +118,7 @@ their unique feature is that a direct hit will buff your damage and firerate
 			modify_fire_delay(AM.delay_mod)
 	wield_delay = 0 //for one-handed levering
 
-/obj/item/weapon/gun/lever_action/proc/reset_hit_buff(mob/user, one_hand_lever)
+/obj/item/weapon/gun/lever_action/proc/reset_hit_buff(mob/user)
 	if(!(flags_gun_lever_action & USES_STREAKS))
 		return
 	streak = 0
@@ -149,8 +131,6 @@ their unique feature is that a direct hit will buff your damage and firerate
 	set_fire_delay(FIRE_DELAY_TIER_1)
 	damage_mult = BASE_BULLET_DAMAGE_MULT
 	recalculate_attachment_bonuses() //stock wield delay
-	if(one_hand_lever)
-		addtimer(VARSET_CALLBACK(src, cur_onehand_chance, reset_onehand_chance), 4 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE)
 
 /obj/item/weapon/gun/lever_action/proc/replace_internal_mag(number_to_replace)
 	if(!current_mag)
@@ -289,8 +269,24 @@ their unique feature is that a direct hit will buff your damage and firerate
 		return
 	if(flags_gun_lever_action & MOVES_WHEN_LEVERING)
 		to_chat(user, SPAN_WARNING("<i>You spin \the [src] one-handed! Fuck yeah!<i>"))
-		animation_wrist_flick(src)
-	direct_hit_buff(user, projectile_source=src, one_hand_lever=TRUE)
+		animation_spin(loop_amount = 1, clockwise = FALSE)
+	else
+		to_chat(user, SPAN_WARNING(lever_message))
+	if(!(flags_gun_lever_action & DANGEROUS_TO_ONEHAND_LEVER) || skillcheck(user, SKILL_FIREARMS, SKILL_FIREARMS_SKILLED))
+		return
+	if(prob(cur_onehand_chance))
+		cur_onehand_chance = cur_onehand_chance - 20 //gets steadily worse if you spam it
+	else
+		to_chat(user, SPAN_DANGER("Augh! Your hand catches on the [lever_name]!!"))
+		var/obj/limb/holding_hand = user.get_limb(user.hand ? "l_hand" : "r_hand")
+		if(holding_hand.status & LIMB_BROKEN)
+			holding_hand = user.get_limb(user.hand ? "l_arm" : "r_arm")
+			user.drop_held_item()
+		else
+			holding_hand.fracture()
+		holding_hand.status &= ~LIMB_SPLINTED
+		user.pain.recalculate_pain()
+	addtimer(VARSET_CALLBACK(src, cur_onehand_chance, initial(cur_onehand_chance)), 4 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE)
 
 /obj/item/weapon/gun/lever_action/reload_into_chamber(mob/user)
 	if(!current_mag)
@@ -531,7 +527,7 @@ their unique feature is that a direct hit will buff your damage and firerate
 		levered = FALSE
 	return empty_chamber(user)
 
-/obj/item/weapon/gun/lever_action/xm88/reset_hit_buff(mob/user, one_hand_lever)
+/obj/item/weapon/gun/lever_action/xm88/reset_hit_buff(mob/user)
 	if(!(flags_gun_lever_action & USES_STREAKS))
 		return
 	if(streak > 0)
@@ -551,10 +547,8 @@ their unique feature is that a direct hit will buff your damage and firerate
 	lever_delay = FIRE_DELAY_TIER_3
 	damage_mult = BASE_BULLET_DAMAGE_MULT
 	recalculate_attachment_bonuses() //stock wield delay
-	if(one_hand_lever)
-		addtimer(VARSET_CALLBACK(src, cur_onehand_chance, reset_onehand_chance), 4 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE)
 
-/obj/item/weapon/gun/lever_action/xm88/direct_hit_buff(mob/user, mob/target, /obj/item/weapon/gun/projectile_source, one_hand_lever = FALSE)
+/obj/item/weapon/gun/lever_action/xm88/direct_hit_buff(mob/user, mob/target, /obj/item/weapon/gun/projectile_source)
 	. = ..()
 	if(!.)
 		return


### PR DESCRIPTION

# About the pull request
For some reason I glossed over that this is bottled to a signal handler proc. And that it really doesn't need to be in this proc at all.
Not really any player facing effects as the R4T isn't really seen anywhere.
But it now spins in the opposite direction, and uses `animation_spin` instead. For one handed lever actioning.


<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Runtimes bad. Code nonsensically in the code for when you direct hit something, when it's about chambering a weapon... also bad.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: R4T now spins anti clockwise. As spinning it clockwise makes no sense...
code: Clean up some code related to lever action, onehanded chambering
fix: A runtime related to the above.
fix: If your hand is already broken, failing the r4t levering breaks your arm and removes splints from both your hand and arm. As well as interrupting knitting time. Otherwise just does it only for the hand.
/:cl:
