### PR TITLE
hardcore now triggers undefib signal

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -63,7 +63,8 @@
 		else //Dead
 			if(!undefibbable)
 				handle_necro_chemicals_in_body(delta_time) //Specifically for chemicals that still work while dead.
-				if(life_tick > 5 && timeofdeath && (timeofdeath < 5 || world.time - timeofdeath > revive_grace_period) && !issynth(src)) //We are dead beyond revival, or we're junk mobs spawned like the clowns on the clown shuttle
+				var/hardcore = HAS_TRAIT(src, TRAIT_HARDCORE) || MODE_HAS_MODIFIER(/datum/gamemode_modifier/permadeath)
+				if(life_tick > 5 && timeofdeath && (timeofdeath < 5 || hardcore || world.time - timeofdeath > revive_grace_period) && !issynth(src)) //We are dead beyond revival, or we're junk mobs spawned like the clowns on the clown shuttle
 					undefibbable = TRUE
 					SEND_SIGNAL(src, COMSIG_HUMAN_SET_UNDEFIBBABLE)
 					med_hud_set_status()


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #12599 just making it where hardcore trait players (or hard core game modifier) will trigger the undefib signal which is used to unlock equipment like this.

# Explain why it's good for the game

Fixes #12766 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/CjcEnX17S2Q

</details>


# Changelog
:cl: Drathek
fix: Hardcore trait/mode now triggers undefib signal to unlock stuff like spotter sight
/:cl:
