### PR TITLE
Possible fix for bloody feet flaky test

### DIFF
--- a/code/datums/elements/bloody_feet.dm
+++ b/code/datums/elements/bloody_feet.dm
@@ -98,7 +98,8 @@
 /datum/element/bloody_feet/proc/blood_crossed(mob/living/carbon/human/target, amount, bcolor, dry_time_left)
 	SIGNAL_HANDLER
 	Detach(target)
-	target.AddElement(/datum/element/bloody_feet, dry_time_left, target.shoes, amount, bcolor)
+	if(!QDELETED(target))
+		target.AddElement(/datum/element/bloody_feet, dry_time_left, target.shoes, amount, bcolor)
 
 /datum/element/bloody_feet/proc/clear_blood(datum/target)
 	SIGNAL_HANDLER

--- a/code/datums/elements/bloody_feet.dm
+++ b/code/datums/elements/bloody_feet.dm
@@ -98,7 +98,7 @@
 /datum/element/bloody_feet/proc/blood_crossed(mob/living/carbon/human/target, amount, bcolor, dry_time_left)
 	SIGNAL_HANDLER
 	Detach(target)
-	if(!QDELETED(target))
+	if(!QDELETED(target) && target.stat == CONSCIOUS)
 		target.AddElement(/datum/element/bloody_feet, dry_time_left, target.shoes, amount, bcolor)
 
 /datum/element/bloody_feet/proc/clear_blood(datum/target)

--- a/code/datums/elements/bloody_feet.dm
+++ b/code/datums/elements/bloody_feet.dm
@@ -20,8 +20,8 @@
 	steps_to_take = steps
 	color = bcolor
 
-	var/mob/living/carbon/human/H = target
-	H.bloody_footsteps = steps_to_take
+	var/mob/living/carbon/human/target_human = target
+	target_human.bloody_footsteps = steps_to_take
 	LAZYADD(entered_bloody_turf, target)
 
 	RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved), override = TRUE)
@@ -45,17 +45,17 @@
 		UnregisterSignal(target_shoes[target], COMSIG_ITEM_DROPPED)
 		LAZYREMOVE(target_shoes, target)
 
-	var/mob/living/carbon/human/H = target
-	if(ishuman(H))
-		H.bloody_footsteps = 0
+	var/mob/living/carbon/human/target_human = target
+	if(ishuman(target_human))
+		target_human.bloody_footsteps = 0
 
 	return ..()
 
-/datum/element/bloody_feet/proc/on_moved(mob/living/carbon/human/target, oldLoc, direction)
+/datum/element/bloody_feet/proc/on_moved(mob/living/carbon/human/target, turf/old_loc, direction)
 	SIGNAL_HANDLER
-	INVOKE_ASYNC(src, PROC_REF(add_tracks), target, oldLoc, direction)
+	INVOKE_ASYNC(src, PROC_REF(add_tracks), target, old_loc, direction)
 
-/datum/element/bloody_feet/proc/add_tracks(mob/living/carbon/human/target, oldLoc, direction)
+/datum/element/bloody_feet/proc/add_tracks(mob/living/carbon/human/target, turf/old_loc, direction)
 	if(GLOB.perf_flags & PERF_TOGGLE_NOBLOODPRINTS)
 		Detach(target)
 		return
@@ -66,27 +66,27 @@
 		return
 
 	var/turf/T_in = target.loc
-	var/turf/T_out = oldLoc
+	var/turf/T_out = old_loc
 
 	if(istype(T_in))
-		var/obj/effect/decal/cleanable/blood/tracks/footprints/FP = LAZYACCESS(T_in.cleanables, CLEANABLE_TRACKS)
-		if(FP)
-			var/image/I = LAZYACCESS(FP.steps_in, "[direction]")
-			if(!I)
-				FP.add_tracks(direction, color, FALSE)
+		var/obj/effect/decal/cleanable/blood/tracks/footprints/print = LAZYACCESS(T_in.cleanables, CLEANABLE_TRACKS)
+		if(print)
+			var/image/steps_image = LAZYACCESS(print.steps_in, "[direction]")
+			if(!steps_image)
+				print.add_tracks(direction, color, FALSE)
 		else
-			FP = new(T_in)
-			FP.add_tracks(direction, color, FALSE)
+			print = new(T_in)
+			print.add_tracks(direction, color, FALSE)
 
 	if(istype(T_out))
-		var/obj/effect/decal/cleanable/blood/tracks/footprints/FP = LAZYACCESS(T_out.cleanables, CLEANABLE_TRACKS)
-		if(FP)
-			var/image/I = LAZYACCESS(FP.steps_out, "[direction]")
-			if(!I)
-				FP.add_tracks(direction, color, TRUE)
+		var/obj/effect/decal/cleanable/blood/tracks/footprints/print = LAZYACCESS(T_out.cleanables, CLEANABLE_TRACKS)
+		if(print)
+			var/image/steps_image = LAZYACCESS(print.steps_out, "[direction]")
+			if(!steps_image)
+				print.add_tracks(direction, color, TRUE)
 		else
-			FP = new(T_out)
-			FP.add_tracks(direction, color, TRUE)
+			print = new(T_out)
+			print.add_tracks(direction, color, TRUE)
 
 	if(--target.bloody_footsteps <= 0)
 		Detach(target)

--- a/code/datums/elements/bloody_feet.dm
+++ b/code/datums/elements/bloody_feet.dm
@@ -53,7 +53,8 @@
 
 /datum/element/bloody_feet/proc/on_moved(mob/living/carbon/human/target, turf/old_loc, direction)
 	SIGNAL_HANDLER
-	INVOKE_ASYNC(src, PROC_REF(add_tracks), target, old_loc, direction)
+	if(target.stat == CONSCIOUS)
+		INVOKE_ASYNC(src, PROC_REF(add_tracks), target, old_loc, direction)
 
 /datum/element/bloody_feet/proc/add_tracks(mob/living/carbon/human/target, turf/old_loc, direction)
 	if(GLOB.perf_flags & PERF_TOGGLE_NOBLOODPRINTS)
@@ -98,8 +99,7 @@
 /datum/element/bloody_feet/proc/blood_crossed(mob/living/carbon/human/target, amount, bcolor, dry_time_left)
 	SIGNAL_HANDLER
 	Detach(target)
-	if(target.stat == CONSCIOUS)
-		target.AddElement(/datum/element/bloody_feet, dry_time_left, target.shoes, amount, bcolor)
+	target.AddElement(/datum/element/bloody_feet, dry_time_left, target.shoes, amount, bcolor)
 
 /datum/element/bloody_feet/proc/clear_blood(datum/target)
 	SIGNAL_HANDLER

--- a/code/datums/elements/bloody_feet.dm
+++ b/code/datums/elements/bloody_feet.dm
@@ -32,7 +32,7 @@
 		RegisterSignal(shoes, COMSIG_ITEM_DROPPED, PROC_REF(on_shoes_removed), override = TRUE)
 
 	if(dry_time)
-		addtimer(CALLBACK(src, PROC_REF(clear_blood), target), dry_time)
+		addtimer(CALLBACK(src, PROC_REF(clear_blood), WEAKREF(target)), dry_time)
 
 /datum/element/bloody_feet/Detach(datum/target, force)
 	UnregisterSignal(target, list(
@@ -98,9 +98,12 @@
 /datum/element/bloody_feet/proc/blood_crossed(mob/living/carbon/human/target, amount, bcolor, dry_time_left)
 	SIGNAL_HANDLER
 	Detach(target)
-	if(!QDELETED(target) && target.stat == CONSCIOUS)
+	if(target.stat == CONSCIOUS)
 		target.AddElement(/datum/element/bloody_feet, dry_time_left, target.shoes, amount, bcolor)
 
 /datum/element/bloody_feet/proc/clear_blood(datum/target)
 	SIGNAL_HANDLER
+	if(isweakref(target))
+		var/datum/weakref/target_ref = target
+		target = target_ref.resolve()
 	Detach(target)

--- a/code/game/objects/effects/decals/cleanable/blood/blood.dm
+++ b/code/game/objects/effects/decals/cleanable/blood/blood.dm
@@ -43,34 +43,40 @@
 		dry_start_time = world.time
 		addtimer(CALLBACK(src, PROC_REF(dry)), drying_time * (amount+1))
 
-/obj/effect/decal/cleanable/blood/Crossed(atom/movable/AM)
+/obj/effect/decal/cleanable/blood/Crossed(atom/movable/crossed_by)
 	..()
 
-	if (!apply_bloody_feet)
+	if(!apply_bloody_feet)
 		return
 
 	// Check if the blood is dry and only humans
 	// can make footprints
-	if(!amount || !ishuman(AM) || QDELETED(AM))
+	if(!amount)
 		return
-
+	if(QDELETED(crossed_by))
+		return
 	if(MODE_HAS_MODIFIER(/datum/gamemode_modifier/blood_optimization))
 		return
+	if(!ishuman(crossed_by))
+		return
 
-	var/mob/living/carbon/human/H = AM
-	H.add_blood(color, BLOOD_FEET)
+	var/mob/living/carbon/human/crossing_human = crossed_by
+	if(crossing_human.stat != CONSCIOUS)
+		return
+
+	crossing_human.add_blood(color, BLOOD_FEET)
+
+	if(GLOB.perf_flags & PERF_TOGGLE_NOBLOODPRINTS)
+		return
 
 	var/dry_time_left = 0
 	if(drying_time)
 		dry_time_left = max(0, drying_time - (world.time - dry_start_time))
 
-	if(GLOB.perf_flags & PERF_TOGGLE_NOBLOODPRINTS)
-		return
-
-	if(!H.bloody_footsteps)
-		H.AddElement(/datum/element/bloody_feet, dry_time_left, H.shoes, amount, color)
+	if(!crossing_human.bloody_footsteps)
+		crossing_human.AddElement(/datum/element/bloody_feet, dry_time_left, crossing_human.shoes, amount, color)
 	else
-		SEND_SIGNAL(H, COMSIG_HUMAN_BLOOD_CROSSED, amount, color, dry_time_left)
+		SEND_SIGNAL(crossing_human, COMSIG_HUMAN_BLOOD_CROSSED, amount, color, dry_time_left)
 
 /obj/effect/decal/cleanable/blood/proc/dry()
 	amount = 0


### PR DESCRIPTION
# About the pull request

This PR does a few things:
- The clear_blood timer now hands a weakref to the mob instead of a hardref (I think normally things would handle a hardref in a timer because of the `src` of the timer getting deleted, but I guess elements don't get deleted soo)
- Adds a conscious check when a human is crossing blood and moving
- Variable cleanup

# Explain why it's good for the game

Should fix #12722 and should fix #12770 or we'll see it come up again.

> REF SEARCH Found /mob/living/carbon/human [0x300008b] in list Datums -> /datum/callback [0x210310a4] (obj: /datum/element/bloody_feet proc: clear_blood args: ["the unknown"] -> arguments (list).


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Murder 
<img width="840" height="690" alt="image" src="https://github.com/user-attachments/assets/09c34d6c-c181-4ade-8b94-7dbf30efd059" />

</details>

# Changelog
:cl: Drathek
fix: You now need to be conscious for bloody footprints to apply
code: Cleaned up code regarding bloody footprints and hopefully eliminated the cause of flaky tests
/:cl:
