### PR TITLE
TCOMMS: Please no on when off

### DIFF
--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -317,11 +317,10 @@ GLOBAL_LIST_EMPTY(all_static_telecomms_towers)
 
 /obj/structure/machinery/telecomms/relay/preset/tower/mapcomms/power_change()
 	..()
-	if((stat & NOPOWER))
-		if(on)
-			toggled = FALSE
-			update_state()
-			SSradio.update_cache()
+	if((stat & NOPOWER) && on)
+		toggled = FALSE
+		update_state()
+		SSradio.update_cache()
 
 /obj/structure/machinery/telecomms/relay/preset/tower/mapcomms/update_state()
 	..()

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -109,7 +109,7 @@ GLOBAL_LIST_EMPTY(all_static_telecomms_towers)
 
 /obj/structure/machinery/telecomms/relay/preset/tower/toggle_state(mob/user)
 	if(!toggled && (inoperable() || (health <= initial(health) / 2)))
-		to_chat(user, SPAN_WARNING("\The [src.name] needs repairs to be turned back on!"))
+		to_chat(user, SPAN_WARNING("[src] needs repairs to be turned back on!"))
 		return
 	..()
 
@@ -157,7 +157,7 @@ GLOBAL_LIST_EMPTY(all_static_telecomms_towers)
 	if(isSilicon(user))
 		return ..()
 	if(on)
-		to_chat(user, SPAN_WARNING("\The [src.name] blinks and beeps incomprehensibly as it operates, better not touch this..."))
+		to_chat(user, SPAN_WARNING("[src] blinks and beeps incomprehensibly as it operates, better not touch this..."))
 		return
 	toggle_state(user) // just flip dat switch
 
@@ -277,7 +277,7 @@ GLOBAL_LIST_EMPTY(all_static_telecomms_towers)
 /obj/structure/machinery/telecomms/relay/preset/tower/mapcomms/attackby(obj/item/I, mob/user)
 	if(HAS_TRAIT(I, TRAIT_TOOL_MULTITOOL))
 		if(inoperable() || (health <= initial(health) * 0.5))
-			to_chat(user, SPAN_WARNING("\The [src.name] needs repairs to have frequencies added to its software!"))
+			to_chat(user, SPAN_WARNING("[src] needs repairs to have frequencies added to its software!"))
 			return
 		var/choice = tgui_input_list(user, "What do you wish to do?", "TC-3T comms tower", list("Wipe communication frequencies", "Add your faction's frequencies"))
 		if(choice == "Wipe communication frequencies")
@@ -319,9 +319,8 @@ GLOBAL_LIST_EMPTY(all_static_telecomms_towers)
 	..()
 	if((stat & NOPOWER))
 		if(on)
-			toggle_state()
-			on = FALSE
-			update_icon()
+			toggled = FALSE
+			update_state()
 			SSradio.update_cache()
 
 /obj/structure/machinery/telecomms/relay/preset/tower/mapcomms/update_state()

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -201,6 +201,7 @@ GLOBAL_LIST_EMPTY(all_static_telecomms_towers)
 	icon = 'icons/obj/structures/machinery/comm_tower3.dmi'
 	icon_state = "static1"
 	toggled = FALSE
+	on = FALSE
 	bound_height = 64
 	bound_width = 64
 	freq_listening = list(COLONY_FREQ)

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -64,6 +64,8 @@ GLOBAL_LIST_EMPTY_TYPED(telecomms_list, /obj/structure/machinery/telecomms)
 
 // When effectively started up
 /obj/structure/machinery/telecomms/proc/tcomms_startup()
+	if(!toggled)
+		return
 	on = TRUE
 	if(tcomms_machine)
 		SSradio.add_tcomm_machine(src)

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -45,11 +45,13 @@ GLOBAL_LIST_EMPTY_TYPED(telecomms_list, /obj/structure/machinery/telecomms)
 /obj/structure/machinery/telecomms/Initialize(mapload, ...)
 	. = ..()
 	GLOB.telecomms_list += src
-	tcomms_startup()
+	if(toggled)
+		tcomms_startup()
 
 /obj/structure/machinery/telecomms/Destroy()
 	GLOB.telecomms_list -= src
-	tcomms_shutdown()
+	if(on)
+		tcomms_shutdown()
 	return ..()
 
 /obj/structure/machinery/telecomms/update_icon()
@@ -64,8 +66,6 @@ GLOBAL_LIST_EMPTY_TYPED(telecomms_list, /obj/structure/machinery/telecomms)
 
 // When effectively started up
 /obj/structure/machinery/telecomms/proc/tcomms_startup()
-	if(!toggled)
-		return
 	on = TRUE
 	if(tcomms_machine)
 		SSradio.add_tcomm_machine(src)


### PR DESCRIPTION
# About the pull request

This PR corrects an issue where tcomms were calling `tcomms_startup()` with the assumption they should always be `on` when spawned, and nuke only checks the `on` value so leaving a tower alone was allowing the nuke to be decrypted with a tower effectively ignored.

I also cleaned up some messages of "\The [src.name]" and removed a usage of `toggle_state` without a user (that could potentially prevent a power change from turning it off)

# Explain why it's good for the game

Was intended for all towers to be needed for nuke even if you leave the second tower alone.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

When testing in USS runtime I had change the results for the is_ground_z define, and set the area to allow special structures (be sure to spawn the towers before the nuke)
<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/9aa68262-bb6b-4e7f-93f2-cabcc833149d" />

Also testing on a normal ground map.

</details>


# Changelog
:cl: Drathek
fix: Static tcomms no longer are "on" when initialized (namely for the purpose of nuke decryption checks)
/:cl:
