### PR TITLE
Fast cryo fix

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -514,8 +514,8 @@ GLOBAL_LIST_INIT(frozen_items, list(SQUAD_MARINE_1 = list(), SQUAD_MARINE_2 = li
 			to_chat(usr, SPAN_WARNING("[src] is occupied."))
 			return
 
-		go_in_cryopod(usr)
 		willing = TRUE
+		go_in_cryopod(usr)
 		add_fingerprint(usr)
 
 


### PR DESCRIPTION

# About the pull request

Climbing into a cryopod by yourself set the 'willing' variable after it was checked for, causing cryo timer to be left at default.
Somehow missed this during testing (probably cause being aCO bypassed the problem).

# Explain why it's good for the game

Bug made by me bad


# Testing Photographs and Procedure
Spawn in as not aCO.
Climb into cryopod.
Despawned in 1 minute.


# Changelog
:cl:
fix: Fixed fast cryo not properly applying to players that climbed into a cryopod by themselves.
/:cl: