### PR TITLE
reverses the rank pin attachment order to prioritize uniforms

### DIFF
--- a/code/modules/gear_presets/_select_equipment.dm
+++ b/code/modules/gear_presets/_select_equipment.dm
@@ -227,10 +227,10 @@
 		var/rankpath = get_rank_pins(current_rank)
 		if(rankpath)
 			var/obj/item/clothing/accessory/ranks/R = new rankpath()
-			if(new_human.wear_suit && new_human.wear_suit.can_attach_accessory(R))
-				new_human.wear_suit.attach_accessory(new_human, R, TRUE)
-			else if(new_human.w_uniform && new_human.w_uniform.can_attach_accessory(R))
+			if(new_human.w_uniform && new_human.w_uniform.can_attach_accessory(R))
 				new_human.w_uniform.attach_accessory(new_human, R, TRUE)
+			else if(new_human.wear_suit && new_human.wear_suit.can_attach_accessory(R))
+				new_human.wear_suit.attach_accessory(new_human, R, TRUE)
 			else
 				qdel(R)
 


### PR DESCRIPTION
# About the pull request
makes people spawn with rank pins attached to uniforms, even if they wear suits/jackets/armours over it
only spawns the rank pins on the suit if somehow you spawn wearing a suit without an uniform

# Explain why it's good for the game
consistency, fixes the weird issues with some roles spawning with rank pins on their armor etc.

# Testing Photographs and Procedure
simple code change

# Changelog
:cl:
code: rank pins now prioritize uniforms instead of suits
/:cl: