### PR TITLE
Acid hole direction handling

### DIFF
--- a/code/game/objects/effects/acid_hole.dm
+++ b/code/game/objects/effects/acid_hole.dm
@@ -16,10 +16,10 @@
 		holed_wall = acided_wall
 		holed_wall.opacity = FALSE
 		// Original intended way for mappers to set the direction was to set wall.acided_hole_dir, but mappers didnt know that, so we will just handle all ways they could have set it.
-		// Since holes can only have two states (vertical/horizontal) we assume no varedits to be vertical and any edits horizontal.
+		// Since holes can only have two states (vertical/horizontal), default is vertical.
 		if(icon_state != initial(icon_state)) // Mapper varedited icon_state to horizontal, so we update code to reflect it.
 			holed_wall.acided_hole_dir = EAST
-		if(dir != EAST) // Mapper didnt varedit dir, so we will use acided_hole_dir. If he did thats fine that will work.
+		if(dir != EAST && dir != WEST) // Mapper didnt varedit dir to horizontal, so we will use acided_hole_dir.
 			setDir(acided_wall.acided_hole_dir)
 
 /obj/effect/acid_hole/Destroy()

--- a/code/game/objects/effects/acid_hole.dm
+++ b/code/game/objects/effects/acid_hole.dm
@@ -16,8 +16,8 @@
 		holed_wall = W
 		holed_wall.opacity = FALSE
 		// Original intended way for mappers to set the direction was to set wall.acided_hole_dir, but mappers didnt know that, so we will just handle all ways they could have set it.
-		// Since holes can only have two states (S-N, E-W) we assume no varedits to be S-N and any edits W-E.
-		if(icon_state != initial(icon_state)) // Mapper varedited icon_state to east/west, so we update code to reflect it.
+		// Since holes can only have two states (vertical/horizontal) we assume no varedits to be vertical and any edits horizontal.
+		if(icon_state != initial(icon_state)) // Mapper varedited icon_state to horizontal, so we update code to reflect it.
 			holed_wall.acided_hole_dir = EAST
 		if(dir != EAST) // Mapper didnt varedit dir, so we will use acided_hole_dir. If he did thats fine that will work.
 			setDir(W.acided_hole_dir)

--- a/code/game/objects/effects/acid_hole.dm
+++ b/code/game/objects/effects/acid_hole.dm
@@ -11,16 +11,16 @@
 /obj/effect/acid_hole/Initialize()
 	. = ..()
 	if(istype(loc, /turf/closed/wall))
-		var/turf/closed/wall/W = loc
-		W.acided_hole = src
-		holed_wall = W
+		var/turf/closed/wall/acided_wall = loc
+		acided_wall.acided_hole = src
+		holed_wall = acided_wall
 		holed_wall.opacity = FALSE
 		// Original intended way for mappers to set the direction was to set wall.acided_hole_dir, but mappers didnt know that, so we will just handle all ways they could have set it.
 		// Since holes can only have two states (vertical/horizontal) we assume no varedits to be vertical and any edits horizontal.
 		if(icon_state != initial(icon_state)) // Mapper varedited icon_state to horizontal, so we update code to reflect it.
 			holed_wall.acided_hole_dir = EAST
 		if(dir != EAST) // Mapper didnt varedit dir, so we will use acided_hole_dir. If he did thats fine that will work.
-			setDir(W.acided_hole_dir)
+			setDir(acided_wall.acided_hole_dir)
 
 /obj/effect/acid_hole/Destroy()
 	if(holed_wall)

--- a/code/game/objects/effects/acid_hole.dm
+++ b/code/game/objects/effects/acid_hole.dm
@@ -15,7 +15,12 @@
 		W.acided_hole = src
 		holed_wall = W
 		holed_wall.opacity = FALSE
-		setDir(W.acided_hole_dir)
+		// Original intended way for mappers to set the direction was to set wall.acided_hole_dir, but mappers didnt know that, so we will just handle all ways they could have set it.
+		// Since holes can only have two states (S-N, E-W) we assume no varedits to be S-N and any edits W-E.
+		if(icon_state != initial(icon_state)) // Mapper varedited icon_state to east/west, so we update code to reflect it.
+			holed_wall.acided_hole_dir = EAST
+		if(dir != EAST) // Mapper didnt varedit dir, so we will use acided_hole_dir. If he did thats fine that will work.
+			setDir(W.acided_hole_dir)
 
 /obj/effect/acid_hole/Destroy()
 	if(holed_wall)

--- a/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
+++ b/maps/map_files/FOP_v3_Sciannex/Fiorina_SciAnnex.dmm
@@ -5299,15 +5299,6 @@
 /obj/structure/platform_decoration/metal/almayer,
 /turf/open/floor/prison/bluefull,
 /area/fiorina/station/power_ring)
-"dRO" = (
-/obj/effect/acid_hole{
-	dir = 4
-	},
-/turf/closed/wall/r_wall/prison_unmeltable{
-	desc = "A huge chunk of metal used to seperate rooms.";
-	name = "metal wall"
-	},
-/area/fiorina/oob)
 "dSM" = (
 /obj/effect/spawner/random/tool,
 /turf/open/floor/prison/darkpurplefull2,
@@ -70042,7 +70033,7 @@ tPB
 vUP
 kIO
 pvD
-dRO
+pvD
 pvD
 pvD
 cKa

--- a/maps/map_files/LV759_Hybrisa_Prospera/LV759_Hybrisa_Prospera.dmm
+++ b/maps/map_files/LV759_Hybrisa_Prospera/LV759_Hybrisa_Prospera.dmm
@@ -156454,9 +156454,6 @@
 /turf/open/floor/kutjevo/grey,
 /area/lv759/indoors/recycling_plant/garage)
 "woF" = (
-/obj/effect/acid_hole{
-	explo_proof = 1
-	},
 /obj/structure/blocker/invisible_wall,
 /turf/closed/shuttle/dropship_wy/StarGlider{
 	icon_state = "79";


### PR DESCRIPTION

# About the pull request

Made acid holes have their direction properly set no matter how the mapper decided to varedit them.
At first I thought about just fixing each instance by hand and leaving a couple Crash() lines to make sure mappers dont make the mistakes again, but I rather went with this approach.

Originally the hole's direction was intended to be set by the acided_hole_dir variable on the wall. However mappers didnt use this (probably because it didnt cause the hole to change direction in the map editor).
Expanded it so that if either the acided_hole_dir, dir or icon_state is varedited to anything other than default (which is vertical) then it will set the hole up as being horizontal. 
Hopefully mappers dont invent any more new and exciting ways to try to set the direction.

Also removed two instances of invalid hole placements (which got deleted anyways after init).

# Explain why it's good for the game

Vertical holes in vertical walls bad


# Testing Photographs and Procedure

Checked one of each varedit variant on each map (nightmares not included) and crawled through them as a drone.
Also melted a horizontal and vertical hole for myself as a boiler, which also worked properly.


<details>
<summary>Before</summary>
<img width="675" height="557" alt="image" src="https://github.com/user-attachments/assets/d96bf9e6-8a9f-4b5f-9716-38afd97edd78" />
</details>
<details>
<summary>After</summary>
<img width="675" height="557" alt="Screenshot_20260730_130031" src="https://github.com/user-attachments/assets/946e3fbd-c7a2-4fbf-b13b-1d287ea31ccd" />
</details>

# Changelog
:cl:
fix: Fixed some acid holes on maps having the wrong orientation.
/:cl:
