### PR TITLE
Fixes message

### DIFF
--- a/code/game/objects/structures/props.dm
+++ b/code/game/objects/structures/props.dm
@@ -302,7 +302,8 @@
 		return
 	else if (ishuman(user) && HAS_TRAIT(W, TRAIT_TOOL_CROWBAR))
 		on = !on
-		visible_message("You pry at the control valve on [src]. The machine shudders." , "[user] pries at the control valve on [src]. The entire machine shudders.")
+		to_chat(user, SPAN_NOTICE("You pry at the control valve on [src]. The machine shudders."))
+		visible_message(SPAN_NOTICE("[user] pries at the control valve on [src]. The entire machine shudders."))
 
 		Update()
 

--- a/code/game/objects/structures/props.dm
+++ b/code/game/objects/structures/props.dm
@@ -302,8 +302,7 @@
 		return
 	else if (ishuman(user) && HAS_TRAIT(W, TRAIT_TOOL_CROWBAR))
 		on = !on
-		to_chat(user, SPAN_NOTICE("You pry at the control valve on [src]. The machine shudders."))
-		visible_message(SPAN_NOTICE("[user] pries at the control valve on [src]. The entire machine shudders."))
+		user.visible_message("[user] pries at the control valve on [src]. The entire machine shudders." , "You pry at the control valve on [src]. The machine shudders.")
 
 		Update()
 


### PR DESCRIPTION

# About the pull request

Fixes a message telling everyone nearby that they pried open a control valve. I guess the argument is in the wrong order and just needs to be reversed, but I think the code is more easily understood the way I did it now, so I did it this way. And also it's already done this way in some places anyways.

Edit: fira sold me on doing it the other way 🫡

# Explain why it's good for the game

Messages should make sense


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: fixed a message telling everyone nearby that they pried a valve
/:cl:
