### PR TITLE
CIC Tweaks Fixes

### DIFF
--- a/code/modules/cm_marines/equipment/kit_boxes.dm
+++ b/code/modules/cm_marines/equipment/kit_boxes.dm
@@ -540,6 +540,7 @@
 	new /obj/item/device/binoculars/range/designator(src)
 	new /obj/item/device/encryptionkey/jtac(src)
 	new /obj/item/storage/backpack/marine/satchel/rto(src)
+	new /obj/item/pamphlet/upgradeable/jtac(src)
 
 /obj/item/storage/box/kit/mini_intel
 	name = "\improper Field Intelligence Support Kit"

--- a/code/modules/cm_marines/equipment/kit_boxes.dm
+++ b/code/modules/cm_marines/equipment/kit_boxes.dm
@@ -261,6 +261,8 @@
 	new /obj/item/tool/wrench(src)
 	new /obj/item/device/binoculars/range(src)
 	new /obj/item/device/binoculars/range/designator(src)
+	new /obj/item/storage/backpack/marine/satchel/rto(src)
+	new /obj/item/storage/backpack/marine/satchel/rto(src)
 
 
 //-----------------SPEC KIT BOX------------------


### PR DESCRIPTION

# About the pull request

Forgot to add a JTAC Pamphlet to the JTAC Kit in #12482 to make up for the fact i removed it from Req. Whoops.
Mortar Teams need an RTO bag to talk between themselves. Whoops.

# Explain why it's good for the game

Oversights bad.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: fixed oversight with JTAC Kits. They come with a pamphlet now.
fix: fixed oversight with Mortar Kits. They come with RTO bags now.
/:cl:
