### PR TITLE
Adds spare Reagent Pouch Autoinjectors to Wey-Med Plus

### DIFF
--- a/code/game/machinery/vending/vendor_types/medical.dm
+++ b/code/game/machinery/vending/vendor_types/medical.dm
@@ -556,7 +556,11 @@
 		list("M276 Pattern Medical Storage Rig", floor(scale * 2), /obj/item/storage/belt/medical, VENDOR_ITEM_REGULAR),
 		list("Medical HUD Glasses", floor(scale * 3), /obj/item/clothing/glasses/hud/health, VENDOR_ITEM_REGULAR),
 		list("Stasis Bag", floor(scale * 3), /obj/item/bodybag/cryobag, VENDOR_ITEM_REGULAR),
-		list("Syringe", floor(scale * 7), /obj/item/reagent_container/syringe, VENDOR_ITEM_REGULAR)
+		list("Syringe", floor(scale * 7), /obj/item/reagent_container/syringe, VENDOR_ITEM_REGULAR),
+		list("30u Empty Autoinjector", floor(scale * 3), /obj/item/reagent_container/hypospray/autoinjector/empty/medic/large, VENDOR_ITEM_REGULAR),
+		list("15u Empty Autoinjector", floor(scale * 3), /obj/item/reagent_container/hypospray/autoinjector/empty/medic, VENDOR_ITEM_REGULAR),
+		list("5u Empty Autoinjector", floor(scale * 3), /obj/item/reagent_container/hypospray/autoinjector/empty/medic/small, VENDOR_ITEM_REGULAR),
+		list("1u Empty Autoinjector", floor(scale * 3), /obj/item/reagent_container/hypospray/autoinjector/empty/medic/tiny, VENDOR_ITEM_REGULAR)
 	)
 
 /obj/structure/machinery/cm_vending/sorted/medical/populate_product_list_and_boxes(scale)

--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -603,3 +603,13 @@
 	name = "30u Reagent Pouch Autoinjector"
 	volume = 180
 	amount_per_transfer_from_this = 30
+
+/obj/item/reagent_container/hypospray/autoinjector/empty/medic/small
+	name = "5u Reagent Pouch Autoinjector"
+	volume = 30
+	amount_per_transfer_from_this = 5
+
+/obj/item/reagent_container/hypospray/autoinjector/empty/medic/tiny
+	name = "1u Reagent Pouch Autoinjector"
+	volume = 6
+	amount_per_transfer_from_this = 1


### PR DESCRIPTION

# About the pull request

* Adds 2 additional Reagent Pouch Autoinjectors. Small, injecting 5u per use. Tiny, injecting 1u per use. Each having 6 uses before being empty, as is the standart for Reagent Pouch Autoinjectors.
* Adds in the Wey-Med Plus, under Medical Utilities, 3 each of 4 diffrent Reagent Pouch Autojinjectors. 30u, 15u, 5u, 1u. 

# Explain why it's good for the game

Simple thing. Its very easy to just.. lose the pens as HM. So having some spares around in medbay is very helpfull.

Additonally added to the Wey-Med Plus are diffrent size pens alongside the standart 15u one. 30u, 5u and 1u.
1. Chems have all diffrent OD levels. You run into problems if you only have one size of medpens.
2. HM are a very specalized role. They excel at being able to give exact treatment for a problem, compared to a normal marines shotgun aproach via UNGA mix. Giving them some tools to have more controll over the medicin they prescribe helps in cementing that role.

Also they go in the WeyMed because HMs prep vendors REALLY dont need more shit, and spare pens are not worth it enough to spend points on. Free is better.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="436" height="439" alt="grafik" src="https://github.com/user-attachments/assets/6d8778b3-f95b-407c-8b6b-10cc58ef7110" />


</details>


# Changelog
:cl:NHC
add: Added Reagent Pouch Autoinjectors in size 5u and 1u
add: Adds 30u, 15u, 5u, 1u Reagent Pouch Autoinjectors to Wey-Med Plus 3 each
/:cl:
