### PR TITLE
Adds the RTO for Medics

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_medic.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_medic.dm
@@ -84,6 +84,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_medic, list(
 
 		list("CLOTHING ITEMS", 0, null, null, null),
 		list("Machete Pouch (Full)", 8, /obj/item/storage/pouch/machete/full, null, VENDOR_ITEM_REGULAR),
+		list("USCM Radio Telephone Pack", 15, /obj/item/storage/backpack/marine/satchel/rto, null, VENDOR_ITEM_REGULAR),
 		list("Welding Goggles", 3, /obj/item/clothing/glasses/welding, null, VENDOR_ITEM_REGULAR),
 
 		list("UTILITIES", 0, null, null, null),


### PR DESCRIPTION

# About the pull request

This PR adds the Radio Telephone Operator Pack to the Medic vendor.

# Explain why it's good for the game

If communications are down and the Gunship Pilot player is new or does not remember to check, the Medic may need to call the Normandy while in the backline, away from anyone with the phone.

If communications are down and the CIC player(s) are not updating the Tac-Map, the Medic may need to call in order to find bodies to recover in the backline.

If communications are down and you're alone with a few riflemen at FOB while the rest of your squad pushes out, you may need to call Medical for more supplies/chems.

The RTO pack is very useful to the medic and removing it from them only serves to worsen gameplay. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

</details>


# Changelog

:cl:
add: added RTO to the medic's vendor

/:cl:
