### PR TITLE
Sleep Linter fixes - Chapter 1

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1463,7 +1463,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 			return QDEL_HINT_LETMELIVE
 
 		log_world("EVACUATE THE SHITCODE IS TRYING TO STEAL MUH JOBS")
-		GLOB.dview_mob = new
+		GLOB.dview_mob = new /mob/dview()
 	return ..()
 
 

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -42,9 +42,6 @@
 	else
 		unlock(TRUE)
 
-/obj/structure/machinery/power/apc/AICtrlClick() // turns off/on APCs.
-	Topic("breaker=1", list("breaker"="1"), 0) // 0 meaning no window (consistency! wait...)
-
 /obj/structure/machinery/door/airlock/AIAltClick() // Electrifies doors.
 	if(!secondsElectrified)
 		// permanent shock

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -137,6 +137,7 @@
 
 /datum/action/proc/remove_from(mob/L)
 	SHOULD_CALL_PARENT(TRUE)
+	SHOULD_NOT_SLEEP(TRUE)
 	SEND_SIGNAL(src, COMSIG_ACTION_REMOVED, L)
 	if(listen_signal)
 		UnregisterSignal(L, listen_signal)
@@ -144,6 +145,7 @@
 	owner = null
 
 /mob/proc/handle_remove_action(datum/action/action)
+	SHOULD_NOT_SLEEP(TRUE)
 	actions?.Remove(action)
 	if(client)
 		client.remove_from_screen(action.button)
@@ -151,7 +153,7 @@
 
 /mob/living/carbon/human/handle_remove_action(datum/action/action)
 	if(selected_ability == action)
-		action.action_activate()
+		INVOKE_ASYNC(action, TYPE_PROC_REF(/datum/action, action_activate))
 	return ..()
 
 /proc/hide_action(mob/L, action_path)

--- a/code/game/area/admin_level.dm
+++ b/code/game/area/admin_level.dm
@@ -92,16 +92,6 @@
 	ceiling = CEILING_UNDERGROUND_ALLOW_CAS
 	flags_area = AREA_NOBURROW|AREA_ALLOW_XENO_JOIN
 
-	var/hivenumber = XENO_HIVE_ALPHA
-
-/area/adminlevel/bunker01/caves/xeno/Entered(A, atom/OldLoc)
-	. = ..()
-	if(isxeno(A))
-		var/mob/living/carbon/xenomorph/X = A
-
-		X.away_timer = XENO_LEAVE_TIMER
-		X.set_hive_and_update(hivenumber)
-
 // ERT Station
 /area/adminlevel/ert_station
 	name = "ERT Station"

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -20,6 +20,9 @@
 		return
 	if(istype(crossed_by, /mob/dead/observer) && !affect_ghosts)
 		return
+	INVOKE_ASYNC(src, PROC_REF(PreTrigger), crossed_by)
+
+/obj/effect/step_trigger/proc/PreTrigger(atom/movable/crossed_by)
 	/// If we have a proc to validate trigger, call it to see whether trigger can occur
 	if(can_trigger_proc_ref && !call(src, can_trigger_proc_ref)(crossed_by))
 		return

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -20,9 +20,9 @@
 		return
 	if(istype(crossed_by, /mob/dead/observer) && !affect_ghosts)
 		return
-	INVOKE_ASYNC(src, PROC_REF(PreTrigger), crossed_by)
+	INVOKE_ASYNC(src, PROC_REF(pretrigger), crossed_by)
 
-/obj/effect/step_trigger/proc/PreTrigger(atom/movable/crossed_by)
+/obj/effect/step_trigger/proc/pretrigger(atom/movable/crossed_by)
 	/// If we have a proc to validate trigger, call it to see whether trigger can occur
 	if(can_trigger_proc_ref && !call(src, can_trigger_proc_ref)(crossed_by))
 		return

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -387,9 +387,8 @@
 
 	remove_item_verbs(user)
 
-	for(var/X in actions)
-		var/datum/action/A = X
-		A.remove_from(user)
+	for(var/datum/action/action as anything in actions)
+		action.remove_from(user)
 
 	if(flags_item & DELONDROP)
 		qdel(src)

--- a/code/game/objects/items/backpack_sprayers.dm
+++ b/code/game/objects/items/backpack_sprayers.dm
@@ -365,10 +365,11 @@
 			var/obj/effect/resin_container/ball = new (get_turf(src))
 			playsound(src,'sound/items/syringeproj.ogg',40,TRUE)
 			//projectile movement
+			var/step_delay = 0
 			for(var/i in 1 to 5)
-				step_towards(ball, target)
-				sleep(2)
-			ball.Smoke()
+				addtimer(CALLBACK(src, PROC_REF(move_ball), ball, target), 0.2 SECONDS * step_delay)
+				step_delay++
+			addtimer(CALLBACK(src, PROC_REF(smoke_ball), ball), 0.2 SECONDS * step_delay)
 			return
 
 		if(METAL_FOAM)
@@ -393,6 +394,11 @@
 			foam.set_up(0, target, null, metal_foam = FOAM_METAL_TYPE_ALUMINIUM)
 			foam.start()
 			return
+
+/obj/item/reagent_container/spray/mister/atmos/proc/move_ball(obj/effect/resin_container/ball, target)
+	step_towards(ball, target)
+/obj/item/reagent_container/spray/mister/atmos/proc/smoke_ball(obj/effect/resin_container/ball)
+	ball.Smoke()
 
 /obj/effect/resin_container //the projectile that the launcher fires
 	name = "metal foam ball"

--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -535,13 +535,15 @@
 
 	COOLDOWN_START(designator, spotting_cooldown, designator.spotting_cooldown_delay)
 	return TRUE
+
 /obj/item/device/binoculars/range/designator/spotter/equipped(mob/living/user, slot)
 	. = ..()
 	//Toggle Spot Target on equip in hands. Avoids toggle in pockets
 	if(slot == WEAR_R_HAND || slot == WEAR_L_HAND)
 		var /datum/action/toggling_action = locate(/datum/action/item_action/specialist/spotter_target) in user.actions
 		if(toggling_action)
-			toggling_action.action_activate()
+			INVOKE_ASYNC(toggling_action, TYPE_PROC_REF(/datum/action/item_action/specialist/spotter_target, action_activate))
+
 //ADVANCED LASER DESIGNATER, Calls in immediate CAS/arty, for WO
 /obj/item/device/binoculars/designator
 	name = "advanced laser designator" // Make sure they know this will kill people in the desc below.

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -228,9 +228,6 @@
 	update_icon()
 	update_sound()
 
-/obj/item/device/taperecorder/proc/play_as_proc()
-	play() // What are you making me do
-
 /obj/item/device/taperecorder/verb/play()
 	set name = "Play Tape"
 	set category = "Object"
@@ -303,7 +300,7 @@
 			if("Record")
 				record()
 			if("Play")
-				INVOKE_ASYNC(src, PROC_REF(play_as_proc))
+				INVOKE_ASYNC(src, VERB_REF(play))
 			if("Print Transcript")
 				print_transcript()
 			if("Eject")

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -228,6 +228,9 @@
 	update_icon()
 	update_sound()
 
+/obj/item/device/taperecorder/proc/play_as_proc()
+	play() // What are you making me do
+
 /obj/item/device/taperecorder/verb/play()
 	set name = "Play Tape"
 	set category = "Object"
@@ -300,7 +303,7 @@
 			if("Record")
 				record()
 			if("Play")
-				INVOKE_ASYNC(src, PROC_REF(play))
+				INVOKE_ASYNC(src, PROC_REF(play_as_proc))
 			if("Print Transcript")
 				print_transcript()
 			if("Eject")

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -300,7 +300,7 @@
 			if("Record")
 				record()
 			if("Play")
-				play()
+				INVOKE_ASYNC(src, PROC_REF(play))
 			if("Print Transcript")
 				print_transcript()
 			if("Eject")

--- a/code/game/objects/items/implants/implant.dm
+++ b/code/game/objects/items/implants/implant.dm
@@ -184,7 +184,6 @@ Implant Specifics:<BR>"}
 					var/malf_msg = "Something beeps inside [imp_in][part ? "'s [part.display_name]" : ""]!"
 					imp_in.visible_message(SPAN_DANGER(malf_msg))
 					playsound(loc, 'sound/items/countdown.ogg', 25, 1, 6)
-					sleep(25)
 					addtimer(CALLBACK(PROC_REF(kaboom), part), 2.5 SECONDS)
 					return
 			if (elevel == "Destroy Body")

--- a/code/game/objects/items/implants/implant.dm
+++ b/code/game/objects/items/implants/implant.dm
@@ -185,16 +185,8 @@ Implant Specifics:<BR>"}
 					imp_in.visible_message(SPAN_DANGER(malf_msg))
 					playsound(loc, 'sound/items/countdown.ogg', 25, 1, 6)
 					sleep(25)
-					if (istype(part,/obj/limb/chest) || \
-						istype(part,/obj/limb/groin) || \
-						istype(part,/obj/limb/head))
-						part.createwound(BRUISE, 60) //mangle them instead
-						explosion(get_turf(imp_in), -1, -1, 2, 3)
-						qdel(src)
-					else
-						explosion(get_turf(imp_in), -1, -1, 2, 3)
-						part.droplimb(0, 0, "dismemberment")
-						qdel(src)
+					addtimer(CALLBACK(PROC_REF(kaboom), part), 2.5 SECONDS)
+					return
 			if (elevel == "Destroy Body")
 				explosion(get_turf(T), -1, 0, 1, 6)
 				T.gib()
@@ -208,6 +200,16 @@ Implant Specifics:<BR>"}
 	if(need_gib)
 		imp_in.gib()
 
+/obj/item/implant/explosive/proc/kaboom(obj/limb/part)
+	if (istype(part,/obj/limb/chest) || \
+		istype(part,/obj/limb/groin) || \
+		istype(part,/obj/limb/head))
+		part.createwound(BRUISE, 60) //mangle them instead
+		explosion(get_turf(imp_in), -1, -1, 2, 3)
+	else
+		explosion(get_turf(imp_in), -1, -1, 2, 3)
+		part.droplimb(0, 0, "dismemberment")
+	qdel(src)
 
 /obj/item/implant/explosive/implanted(mob/source as mob)
 	elevel = alert("What sort of explosion would you prefer?", "Implant Intent", "Localized Limb", "Destroy Body", "Full Explosion")

--- a/code/game/objects/structures/bookcase.dm
+++ b/code/game/objects/structures/bookcase.dm
@@ -21,9 +21,7 @@
 		SPAN_DANGER("We slice [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 		deconstruct(FALSE)
 		return XENO_ATTACK_ACTION
-	else
-		attack_hand(xeno)
-		return XENO_NONCOMBAT_ACTION
+	return XENO_NONCOMBAT_ACTION
 
 /obj/structure/bookcase/handle_tail_stab(mob/living/carbon/xenomorph/xeno, blunt_stab)
 	if(unslashable)

--- a/code/modules/cm_aliens/structures/special/egg_morpher.dm
+++ b/code/modules/cm_aliens/structures/special/egg_morpher.dm
@@ -151,7 +151,7 @@
 	stored_huggers = max(0, stored_huggers - 1)
 
 	var/obj/item/clothing/mask/facehugger/child = new(loc, linked_hive.hivenumber)
-	child.leap_at_nearest_target()
+	INVOKE_ASYNC(child, TYPE_PROC_REF(/obj/item/clothing/mask/facehugger, leap_at_nearest_target))
 
 /obj/effect/alien/resin/special/eggmorph/attack_alien(mob/living/carbon/xenomorph/M)
 	if(!istype(M))

--- a/code/modules/defenses/defenses.dm
+++ b/code/modules/defenses/defenses.dm
@@ -433,10 +433,11 @@
 	visible_message("[icon2html(src, viewers(src))] [SPAN_WARNING("The [name] starts to blink rapidly!")]")
 	playsound(loc, 'sound/mecha/critdestrsyndi.ogg', 25, 1)
 
-	sleep(5)
+	addtimer(CALLBACK(src, PROC_REF(final_destroyed_action)), 0.5 SECONDS)
 
-	cell_explosion(loc, 10, 10, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, create_cause_data("defense explosion"))
+/obj/structure/machinery/defenses/proc/final_destroyed_action()
 	if(!QDELETED(src))
+		cell_explosion(loc, 10, 10, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, create_cause_data("defense explosion"))
 		qdel(src)
 
 /obj/structure/machinery/defenses/proc/damaged_action(damage)

--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -275,14 +275,14 @@
 /obj/structure/machinery/defenses/sentry/destroyed_action()
 	visible_message("[icon2html(src, viewers(src))] [SPAN_WARNING("The [name] starts spitting out sparks and smoke!")]")
 	playsound(loc, 'sound/mecha/critdestrsyndi.ogg', 25, 1)
+	INVOKE_ASYNC(src, PROC_REF(spin_and_explode))
+
+/obj/structure/machinery/defenses/sentry/proc/spin_and_explode()
 	for(var/i = 1 to 6)
 		setDir(pick(NORTH, EAST, SOUTH, WEST))
 		update_minimap_icon()
 		sleep(2)
-
-	cell_explosion(loc, 10, 10, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, create_cause_data("sentry explosion", owner_mob))
-	if(!QDELETED(src))
-		qdel(src)
+	final_destroyed_action()
 
 /obj/structure/machinery/defenses/sentry/damaged_action(damage)
 	if(prob(10))

--- a/code/modules/defenses/sentry_flamer.dm
+++ b/code/modules/defenses/sentry_flamer.dm
@@ -19,6 +19,9 @@
 		SENTRY_CATEGORY_IFF = FACTION_MARINE,
 	)
 
+	/// The type of flames to spill upon destruction
+	var/destruction_spill_type = /datum/reagent/napalm/blue
+
 /obj/structure/machinery/defenses/sentry/flamer/handle_rof(level)
 	switch(level)
 		if(ROF_SINGLE)
@@ -39,19 +42,14 @@
 		visible_message("[icon2html(src, viewers(src))] [SPAN_WARNING("The [name] beeps steadily and its ammo light blinks red.")]")
 		playsound(loc, 'sound/weapons/smg_empty_alarm.ogg', 25, 1)
 
-/obj/structure/machinery/defenses/sentry/flamer/destroyed_action()
-	visible_message("[icon2html(src, viewers(src))] [SPAN_WARNING("The [name] starts spitting out sparks and smoke!")]")
-	playsound(loc, 'sound/mecha/critdestrsyndi.ogg', 25, 1)
-	for(var/i = 1 to 6)
-		setDir(pick(NORTH, EAST, SOUTH, WEST))
-		sleep(2)
+	final_destroyed_action()
 
-	if(ammo.current_rounds != 0)
-		var/datum/reagent/napalm/blue/R = new()
-		new /obj/flamer_fire(loc, create_cause_data("sentry explosion", owner_mob), R, 2)
-	cell_explosion(loc, 10, 10, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, create_cause_data("sentry explosion", owner_mob))
+/obj/structure/machinery/defenses/sentry/flamer/final_destroyed_action()
 	if(!QDELETED(src))
-		qdel(src)
+		if(ammo.current_rounds != 0 && destruction_spill_type)
+			var/datum/reagent/R = new destruction_spill_type
+			new /obj/flamer_fire(loc, create_cause_data("sentry explosion", owner_mob), R, 2)
+	. = ..()
 
 
 /obj/structure/machinery/defenses/sentry/flamer/mini
@@ -119,21 +117,7 @@
 		SENTRY_CATEGORY_ROF = ROF_SINGLE,
 		SENTRY_CATEGORY_IFF = SENTRY_FACTION_WEYLAND,
 	)
-
-/obj/structure/machinery/defenses/sentry/flamer/wy/destroyed_action()
-	visible_message("[icon2html(src, viewers(src))] [SPAN_WARNING("The [name] starts spitting out sparks and smoke!")]")
-	playsound(loc, 'sound/mecha/critdestrsyndi.ogg', 25, 1)
-	for(var/i = 1 to 6)
-		setDir(pick(NORTH, EAST, SOUTH, WEST))
-		sleep(2)
-
-	if(ammo.current_rounds != 0)
-		var/datum/reagent/napalm/sticky/sticky_napalm = new()
-		new /obj/flamer_fire(loc, create_cause_data("sentry explosion", owner_mob), sticky_napalm, 2)
-	cell_explosion(loc, 10, 10, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, create_cause_data("sentry explosion", owner_mob))
-	if(!QDELETED(src))
-		qdel(src)
-
+	destruction_spill_type = /datum/reagent/napalm/sticky
 
 /obj/structure/machinery/defenses/sentry/flamer/upp
 	name = "UPP SDS-R5 Sentry Flamer"
@@ -150,17 +134,4 @@
 		SENTRY_CATEGORY_ROF = ROF_SINGLE,
 		SENTRY_CATEGORY_IFF = FACTION_UPP,
 	)
-
-/obj/structure/machinery/defenses/sentry/flamer/upp/destroyed_action()
-	visible_message("[icon2html(src, viewers(src))] [SPAN_WARNING("The [name] starts spitting out sparks and smoke!")]")
-	playsound(loc, 'sound/mecha/critdestrsyndi.ogg', 25, 1)
-	for(var/i = 1 to 6)
-		setDir(pick(NORTH, EAST, SOUTH, WEST))
-		sleep(2)
-
-	if(ammo.current_rounds != 0)
-		var/datum/reagent/napalm/gel/gel_napalm = new()
-		new /obj/flamer_fire(loc, create_cause_data("sentry explosion", owner_mob), gel_napalm, 2)
-	cell_explosion(loc, 10, 10, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, create_cause_data("sentry explosion", owner_mob))
-	if(!QDELETED(src))
-		qdel(src)
+	destruction_spill_type = /datum/reagent/napalm/gel

--- a/code/modules/defenses/sentry_flamer.dm
+++ b/code/modules/defenses/sentry_flamer.dm
@@ -42,8 +42,6 @@
 		visible_message("[icon2html(src, viewers(src))] [SPAN_WARNING("The [name] beeps steadily and its ammo light blinks red.")]")
 		playsound(loc, 'sound/weapons/smg_empty_alarm.ogg', 25, 1)
 
-	final_destroyed_action()
-
 /obj/structure/machinery/defenses/sentry/flamer/final_destroyed_action()
 	if(!QDELETED(src))
 		if(ammo.current_rounds != 0 && destruction_spill_type)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1483,7 +1483,7 @@
 	else
 		dirs = GLOB.alldirs.Copy()
 
-	INVOKE_ASYNC(streak(dirs))
+	INVOKE_ASYNC(src, PROC_REF(streak), dirs)
 
 /obj/effect/decal/cleanable/blood/gibs/robot/pipe_eject(direction)
 	var/list/dirs
@@ -1492,7 +1492,7 @@
 	else
 		dirs = GLOB.alldirs.Copy()
 
-	INVOKE_ASYNC(streak(dirs))
+	INVOKE_ASYNC(src, PROC_REF(streak), dirs)
 
 #undef DISPOSALS_OFF
 #undef DISPOSALS_CHARGING


### PR DESCRIPTION
# About the pull request

Last update to SpacemanDMM / Dreamchecker expands on the sleep detection from SHOULD_NOT_SLEEP linter directive.

Unfortunately it is not perfect, and by nature of our broken game static analysis is bound to pick on false positives. By expanding the detection, it uncovers things that have been missed, but there are also more false positives.

This solves the low hanging fruits in Linter warnings with the new version, from 43 errors down to 21. 

The vast majority of what remains will require a refactor of attachables and actions. They almost all amount to the following call chain:  item dropped --> actions/attachies removed --> actions/attachies disabled --> action/attachies activated as a way to toggle it off. Because the action of activating it usually has other side effects such as a windup or user input, this causes sleeping errors.

Untested, too much random stuff. TM it.

# Changelog


:cl:
del: Xenos cannot remove books from bookcases to put them on the floor anymore.
/:cl:
