### PR TITLE
Remote resin construction nerf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Powers.dm
@@ -184,7 +184,7 @@
 
 /mob/living/carbon/xenomorph/proc/can_remote_build_resin_at(turf/target)
 	for(var/mob/living/carbon/human/human in range(2, target))
-		if(human.stat == DEAD)
+		if(human.stat == DEAD || HAS_TRAIT(human, TRAIT_NESTED) || HAS_TRAIT(human, TRAIT_HAULED))
 			continue
 		to_chat(src, SPAN_XENOWARNING("A nearby tallhost is disrupting our connection to the resin!"))
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/Powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Powers.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/xenomorph/proc/build_resin(atom/target, thick = FALSE, message = TRUE, use_plasma = TRUE, add_build_mod = 1)
+/mob/living/carbon/xenomorph/proc/build_resin(atom/target, thick = FALSE, message = TRUE, use_plasma = TRUE, add_build_mod = 1, blocked = FALSE)
 	if(!selected_resin)
 		return SECRETE_RESIN_FAIL
 
@@ -32,6 +32,8 @@
 			return SECRETE_RESIN_FAIL
 
 	var/turf/current_turf = get_turf(target)
+	if(blocked && !can_remote_build_resin_at(current_turf))
+		return SECRETE_RESIN_FAIL
 
 	if(extra_build_dist != IGNORE_BUILD_DISTANCE && get_dist(src, target) > src.caste.max_build_dist + extra_build_dist) // Hivelords and eggsac carriers have max_build_dist of 1, drones and queens 0
 		to_chat(src, SPAN_XENOWARNING("We can't build from that far!"))
@@ -137,6 +139,8 @@
 
 	if(!succeeded)
 		return SECRETE_RESIN_INTERRUPT
+	if(blocked && !can_remote_build_resin_at(current_turf))
+		return SECRETE_RESIN_FAIL
 
 	if(maybe_convert_to_weedbound(current_turf, resin_construct, thick))
 		if(use_plasma)
@@ -177,6 +181,14 @@
 				msg_admin_niche("[src.ckey]/([src]) has built a closed resin structure, [new_resin.name], on top of a dead human, [enclosed_human.ckey]/([enclosed_human]), at [new_resin.x],[new_resin.y],[new_resin.z] [ADMIN_JMP(new_resin)]")
 
 	return SECRETE_RESIN_SUCCESS
+
+/mob/living/carbon/xenomorph/proc/can_remote_build_resin_at(turf/target)
+	for(var/mob/living/carbon/human/human in range(2, target))
+		if(human.stat == DEAD)
+			continue
+		to_chat(src, SPAN_XENOWARNING("A nearby tallhost is disrupting our connection to the resin!"))
+		return FALSE
+	return TRUE
 
 /mob/living/carbon/xenomorph/proc/maybe_convert_to_weedbound(turf/current_turf, datum/resin_construction/resin_construct, thick = FALSE)
 	if(current_turf.is_weedable != SEMI_WEEDABLE)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_abilities.dm
@@ -98,6 +98,8 @@
 	var/xeno_cooldown_fail = 1
 	/// Placement time increase modifier
 	var/build_speed_mod = 1
+	/// Whether living humans near the target block construction
+	var/blocked = FALSE
 
 	plasma_cost = 1
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/general_powers.dm
@@ -271,7 +271,7 @@
 		to_chat(owner, SPAN_XENOWARNING("This area is too far away to affect!"))
 		return
 	apply_cooldown()
-	switch(xeno_owner.build_resin(target, thick, make_message, plasma_cost != 0, build_speed_mod))
+	switch(xeno_owner.build_resin(target, thick, make_message, plasma_cost != 0, build_speed_mod, blocked))
 		if(SECRETE_RESIN_INTERRUPT)
 			if(xeno_cooldown || xeno_cooldown_interrupt_penalty)
 				apply_cooldown_override(xeno_cooldown + xeno_cooldown_interrupt_penalty)
@@ -1132,4 +1132,3 @@
 
 	target.handle_blood_splatter(get_dir(owner.loc, target.loc))
 	return target
-

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/hivelord/resin_whisperer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/hivelord/resin_whisperer.dm
@@ -44,6 +44,7 @@
 	xeno_cooldown = 2.5 SECONDS
 	thick = FALSE
 	make_message = FALSE
+	blocked = TRUE
 
 	no_cooldown_msg = TRUE
 


### PR DESCRIPTION
# About the pull request

Queen Eye Projected Resin and Resin Whisperer remote construction can no longer build within two tiles of a living human.

# Explain why it's good for the game

Remote resin construction can currently be used to quickly box in players from complete safety. It has a massive impact on a fight, but the person using it takes basically no risk, while the player being trapped has very little they can actually do about it.

This change still lets Queen Eye and Resin Whisperer build defenses remotely, but stops them from directly trapping living humans who cannot meaningfully fight back against it.

# Testing Photographs and Procedure
Verified to work on a local server. I was not able to construct resin near a human.

# Changelog
:cl:
balance: Queen Eye and Resin Whisperer remote resin construction is now blocked within two tiles of a living human.
/:cl: