### PR TITLE
Communications Tweaks: Locked RTO Bags

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -723,7 +723,7 @@ GLOBAL_LIST_EMPTY_TYPED(radio_packs, /obj/item/storage/backpack/marine/satchel/r
 	flags_atom = FPRINT|NO_GAMEMODE_SKIN // same sprite for all gamemodes
 	actions_types = list(/datum/action/item_action/rto_pack/use_phone)
 
-	flags_item = ITEM_OVERRIDE_NORTHFACE
+	flags_item = ITEM_OVERRIDE_NORTHFACE|MOB_LOCK_ON_EQUIP
 
 	var/obj/structure/transmitter/internal/internal_transmitter
 


### PR DESCRIPTION

# About the pull request

Locks RTO bags until unlocked or perma-death.

# Explain why it's good for the game

We cant have nice things arghhhhhhhhhh.

People are stealing RTO bags from people while dead. This adds a hurdle. Stop being cringe guys please.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Adds equip locks to RTO bags until unlock or permadeath.
/:cl:
