### PR TITLE
Adds sound to FTL ERT

### DIFF
--- a/code/controllers/subsystem/hijack.dm
+++ b/code/controllers/subsystem/hijack.dm
@@ -175,7 +175,7 @@ SUBSYSTEM_DEF(hijack)
 		var/datum/emergency_call/emergency_call = new to_spawn
 		emergency_call.name_of_spawn = /obj/effect/landmark/ert_spawns/umbilical
 		emergency_call.shuttle_id = null
-		emergency_call.alert_sound = 'sound/voice/warcry/male_wryy.ogg'
+		emergency_call.alert_sound = 'sound/items/pred_bracer.ogg'
 		emergency_call.activate(TRUE, FALSE)
 
 		TIMER_COOLDOWN_START(src, COOLDOWN_POSTHIJACK_ERT, 5 MINUTES)

--- a/code/controllers/subsystem/hijack.dm
+++ b/code/controllers/subsystem/hijack.dm
@@ -175,6 +175,7 @@ SUBSYSTEM_DEF(hijack)
 		var/datum/emergency_call/emergency_call = new to_spawn
 		emergency_call.name_of_spawn = /obj/effect/landmark/ert_spawns/umbilical
 		emergency_call.shuttle_id = null
+		emergency_call.alert_sound = 'sound/voice/warcry/male_wryy.ogg'
 		emergency_call.activate(TRUE, FALSE)
 
 		TIMER_COOLDOWN_START(src, COOLDOWN_POSTHIJACK_ERT, 5 MINUTES)

--- a/code/controllers/subsystem/hijack.dm
+++ b/code/controllers/subsystem/hijack.dm
@@ -175,7 +175,7 @@ SUBSYSTEM_DEF(hijack)
 		var/datum/emergency_call/emergency_call = new to_spawn
 		emergency_call.name_of_spawn = /obj/effect/landmark/ert_spawns/umbilical
 		emergency_call.shuttle_id = null
-		emergency_call.alert_sound = 'sound/items/pred_bracer.ogg'
+		emergency_call.alert_sound = 'sound/effects/fire_crackle.ogg'
 		emergency_call.activate(TRUE, FALSE)
 
 		TIMER_COOLDOWN_START(src, COOLDOWN_POSTHIJACK_ERT, 5 MINUTES)


### PR DESCRIPTION

# About the pull request

Adds a warcry sound to when an FTL ert is called.

# Explain why it's good for the game

Having seen the pred hunt ert sound effect in game (from https://github.com/cmss13-devs/cmss13/pull/12119 ), I think it added a really nice touch, and I remember that FTL ert calls (other than maybe the first time?), were completely silent, which results in less people knowing that the ert call even fired. 

Edit: And it's a warcry based on it being a human ERT to repel xenos.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
soundadd: ftl ert calls have a sound
/:cl:
