### PR TITLE
WO Fixes and Relaxed Requirements to Occur

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -138,7 +138,7 @@
 
 /datum/config_entry/number/whiskey_required_players
 	min_val = 0
-	config_entry_value = 140
+	config_entry_value = 120
 	integer = TRUE
 
 /datum/config_entry/number/nuclear_lock_marines_percentage

--- a/code/datums/medal_awards.dm
+++ b/code/datums/medal_awards.dm
@@ -310,11 +310,10 @@ GLOBAL_LIST_INIT(medal_references, generate_medal_references())
 		to_chat(user, SPAN_WARNING("You must have an authenticated ID Card to award medals."))
 		return
 
-	var/is_xo_medal
-	if(user.job == JOB_XO)
-		is_xo_medal = TRUE
+	var/is_xo = user.job == JOB_XO || user.job == JOB_WO_XO
+	var/is_co = (card.paygrade in GLOB.co_paygrades) || (card.paygrade in GLOB.uscm_highcom_paygrades) || user.job == JOB_WO_CO
 
-	if(!((card.paygrade in GLOB.co_paygrades) || (card.paygrade in GLOB.uscm_highcom_paygrades) || is_xo_medal))
+	if(!is_xo && !is_co)
 		to_chat(user, SPAN_WARNING("Only a Senior Officer can award medals!"))
 		return
 
@@ -651,11 +650,10 @@ GLOBAL_DATUM_INIT(ic_medals_panel, /datum/ic_medal_panel, new)
 		to_chat(user, SPAN_WARNING("You must have an authenticated ID Card to award medals."))
 		return
 
-	var/is_xo_medal
-	if(user.job == JOB_XO)
-		is_xo_medal = TRUE
+	var/is_xo = user.job == JOB_XO || user.job == JOB_WO_XO
+	var/is_co = (card.paygrade in GLOB.co_paygrades) || (card.paygrade in GLOB.uscm_highcom_paygrades) || user.job == JOB_WO_CO
 
-	if(!((card.paygrade in GLOB.co_paygrades) || (card.paygrade in GLOB.uscm_highcom_paygrades) || is_xo_medal))
+	if(!is_xo && !is_co)
 		to_chat(user, SPAN_WARNING("Only a Senior Officer can award medals!"))
 		return
 
@@ -683,9 +681,10 @@ GLOBAL_DATUM_INIT(ic_medals_panel, /datum/ic_medal_panel, new)
 		if("approve_medal")
 			var/recommendation_ref = params["ref"]
 			var/medal_type = params["medal_type"]
-			if(!(medal_type in GLOB.medal_options["marine_medals_co"]) && !(medal_type in GLOB.medal_options["marine_medals_xo"]))
+			if(is_xo && !(medal_type in GLOB.medal_options["marine_medals_xo"]))
+				to_chat(user, SPAN_WARNING("You cannot award this medal!"))
 				return
-			if((is_xo_medal && !(medal_type in GLOB.medal_options["marine_medals_xo"])) || (!is_xo_medal && !(medal_type in GLOB.medal_options["marine_medals_co"])))
+			if(!is_xo && !(medal_type in GLOB.medal_options["marine_medals_co"]))
 				to_chat(user, SPAN_WARNING("You cannot award this medal!"))
 				return
 			var/datum/medal_recommendation/recommendation = locate(recommendation_ref) in GLOB.medal_recommendations
@@ -694,7 +693,7 @@ GLOBAL_DATUM_INIT(ic_medals_panel, /datum/ic_medal_panel, new)
 			if(recommendation.recipient_name == user.real_name)
 				to_chat(user, SPAN_WARNING("You cannot give medals to yourself!"))
 				return
-			if(recommendation.recipient_rank == JOB_CO)
+			if(recommendation.recipient_rank == JOB_CO || recommendation.recipient_rank == JOB_WO_CO)
 				to_chat(user, SPAN_WARNING("You cannot give a ribbon or medal to the Commanding Officer!"))
 				return
 			if(recommendation.recipient_rank == JOB_SYNTH)

--- a/code/datums/medal_awards.dm
+++ b/code/datums/medal_awards.dm
@@ -68,27 +68,9 @@ GLOBAL_LIST_INIT(medal_references, generate_medal_references())
 	return options_list
 
 /proc/get_medal_path(medal_type)
-	switch(medal_type)
-		if(MARINE_RIBBON_COMMENDATION)
-			return /obj/item/clothing/accessory/medal/ribbon/commendation
-		if(MARINE_RIBBON_LEADERSHIP)
-			return /obj/item/clothing/accessory/medal/ribbon/leadership
-		if(MARINE_RIBBON_PROFICIENCY)
-			return /obj/item/clothing/accessory/medal/ribbon/proficiency
-		if(MARINE_MEDAL_PURPLE_HEART)
-			return /obj/item/clothing/accessory/medal/purple_heart
-		if(MARINE_MEDAL_VALOR)
-			return /obj/item/clothing/accessory/medal/silver/valor
-		if(MARINE_MEDAL_SILVER_STAR)
-			return /obj/item/clothing/accessory/medal/silver/star
-		if(MARINE_MEDAL_GALACTIC_CROSS)
-			return /obj/item/clothing/accessory/medal/gold/cross
-		if(MARINE_MEDAL_HONOR)
-			return /obj/item/clothing/accessory/medal/platinum/honor
-		if(WY_MEDAL_AWARD_1)
-			return /obj/item/clothing/accessory/medal/gold/corporate_award
-		if(WY_MEDAL_AWARD_2)
-			return /obj/item/clothing/accessory/medal/gold/corporate_award2
+	for(var/obj/item/clothing/accessory/medal/medal as anything in GLOB.medal_references)
+		if(medal.name == medal_type)
+			return medal.type
 
 /proc/give_medal_award(medal_location, as_admin = FALSE, as_xo = FALSE)
 	if(as_admin && !check_rights(R_ADMIN))
@@ -122,7 +104,7 @@ GLOBAL_LIST_INIT(medal_references, generate_medal_references())
 		return FALSE
 
 	// Write a citation
-	var/citation = strip_html(input("What should the medal citation read?", "Medal Citation", null, null) as message|null, MAX_PAPER_MESSAGE_LEN)
+	var/citation = tgui_input_text(usr, "What should the medal citation read?", "Medal Citation", multiline = TRUE)
 	if(!citation)
 		return FALSE
 
@@ -372,15 +354,15 @@ GLOBAL_LIST_INIT(xeno_medals, list(XENO_SLAUGHTER_MEDAL, XENO_RESILIENCE_MEDAL, 
 		return FALSE
 
 	// Write the pheromone
-	var/citation = strip_html(input("What should the pheromone read?", "Jelly Pheromone", null, null) as message|null, MAX_PAPER_MESSAGE_LEN)
+	var/citation = tgui_input_text(usr, "What should the pheromone read?", "Jelly Pheromone", multiline=TRUE)
 	if(!citation)
 		return FALSE
 
 	// Admin: Override attribution
 	var/admin_attribution = null
 	if(as_admin)
-		admin_attribution = strip_html(input("Override the jelly attribution? Press cancel for no attribution.", "Jelly Attribution", "Queen Mother", null) as text|null, MAX_NAME_LEN)
-		if(!admin_attribution) // Its actually "" but this also seems to check that
+		admin_attribution = tgui_input_text(usr, "Override the jelly attribution? Cancel or 'none' for no attribution.", "Jelly Attribution", "Queen Mother", max_length=MAX_NAME_LEN)
+		if(!admin_attribution)
 			admin_attribution = "none"
 
 	// Get mob information
@@ -520,6 +502,9 @@ GLOBAL_LIST_INIT(xeno_medals, list(XENO_SLAUGHTER_MEDAL, XENO_RESILIENCE_MEDAL, 
 	var/reason
 	var/recommended_by_rank
 
+/datum/medal_recommendation/Destroy(force, ...)
+	GLOB.medal_recommendations -= src
+	return ..()
 
 /proc/add_medal_recommendation(mob/recommendation_giver)
 	// Pick a marine
@@ -710,7 +695,6 @@ GLOBAL_DATUM_INIT(ic_medals_panel, /datum/ic_medal_panel, new)
 				return
 
 			if(give_medal_award_prefilled(actual_loc, user, recommendation.recipient_name, recommendation.recipient_rank, recommendation.recipient_ckey, medal_citation, medal_type, recommendation.recommended_by_ckey, recommendation.recommended_by_name))
-				GLOB.medal_recommendations -= recommendation
 				qdel(recommendation)
 				user.visible_message(SPAN_NOTICE("[actual_loc] prints a medal."))
 				. = TRUE
@@ -723,7 +707,6 @@ GLOBAL_DATUM_INIT(ic_medals_panel, /datum/ic_medal_panel, new)
 			var/confirm = tgui_alert(user, "Are you sure you want to deny this medal recommendation?", "Medal Confirmation", list("Yes", "No"))
 			if(confirm != "Yes")
 				return
-			GLOB.medal_recommendations -= recommendation
 			qdel(recommendation)
 			. = TRUE
 

--- a/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
+++ b/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
@@ -11,7 +11,8 @@
 /datum/game_mode/whiskey_outpost
 	name = GAMEMODE_WHISKEY_OUTPOST
 	config_tag = GAMEMODE_WHISKEY_OUTPOST
-	required_players = 140
+	required_players = 120 // Ultimately controlled by /datum/config_entry/number/whiskey_required_players
+	required_ready_players = 60
 	xeno_bypass_timer = 1
 	static_comms_amount = 0
 	flags_round_type = MODE_NEW_SPAWN
@@ -80,13 +81,15 @@
 	starting_round_modifiers = list(/datum/gamemode_modifier/permadeath, /datum/gamemode_modifier/more_crit, /datum/gamemode_modifier/disable_wj_spawns)
 
 	votable = TRUE
-	vote_cycle = 75 // approx. once every 5 days, if it wins the vote
+	vote_cycle = 65 // approx. once every 5 days, if it wins the vote
 
 	taskbar_icon = 'icons/taskbar/gml_wo.png'
 
 /datum/game_mode/whiskey_outpost/New()
 	. = ..()
 	required_players = CONFIG_GET(number/whiskey_required_players)
+	if(!isnull(required_ready_players))
+		required_ready_players = min(required_ready_players, required_players) // Don't ever require more ready than voting
 
 /datum/game_mode/whiskey_outpost/get_roles_list()
 	return GLOB.ROLES_WO

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -21,8 +21,12 @@ GLOBAL_VAR_INIT(cas_tracking_id_increment, 0) //this var used to assign unique t
 	var/vote_cycle = null
 	var/probability = 0
 	var/list/datum/mind/modePlayer = new
+	/// The number of players required to vote to start this gamemode
 	var/required_players = 0
-	var/required_players_secret = 0 //Minimum number of players for that game mode to be chose in Secret
+	/// The number of players required to start this gamemode (uses required_players if null)
+	var/required_ready_players = null
+	/// The number of players required to start this gamemode when secret
+	var/required_players_secret = 0
 	var/ert_disabled = 0
 	var/force_end_at = 0
 	var/xeno_evo_speed = 0 // if not 0 - gives xeno an evo boost/nerf
@@ -65,7 +69,8 @@ GLOBAL_VAR_INIT(cas_tracking_id_increment, 0) //this var used to assign unique t
 		if(players >= required_players_secret)
 			return TRUE
 	else
-		if(players >= required_players)
+		var/needed_players = isnull(required_ready_players) ? required_players : required_ready_players
+		if(players >= needed_players)
 			return TRUE
 	return FALSE
 

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -586,7 +586,7 @@ GLOBAL_LIST_EMPTY_TYPED(active_overwatch_consoles, /obj/structure/machinery/comp
 		data["ob_safety"] = ob_cannon_safety
 		if(current_orbital_cannon.tray.warhead)
 			data["ob_warhead"] = current_orbital_cannon.tray.warhead.warhead_kind
-	if(GLOB.almayer_aa_cannon.protecting_section)
+	if(GLOB.almayer_aa_cannon?.protecting_section)
 		data["aa_targeting"] = GLOB.almayer_aa_cannon.protecting_section
 
 	data["marines"] = list()


### PR DESCRIPTION

# About the pull request

This PR does a few things:
- Fixes a runtime in the ui_data for the ground operations console expecting an AA cannon to exist
- Fixes WO CO/XO being unable to grant medals
- TGUIfies some text inputs for medals
- Cleans up some medal code
- Reduces the required vote amount for WO from 140 to 120
- Reduces the cycle count for WO from 75 to 65 (Although 75 is often a 5 day interval, this means that it keeps more or less attempting at the same time. At 65 it should shift around timezones more.
- Introduces a gamemode variable `required_ready_players` which when non-null this is used as the ready count for the gamemode rather than `required_players` (The value needed to vote for the gamemode). For WO I want this to be generally about half the voting amount so its set to 60.

Although there's still more in the groundside operations panel that ought to be disabled for WO, they didn't really seem game breaking (e.g. changing almayer alert level or initiating evac do occur but I didn't see it *actually* do anything). Setting primary LZ just spits out a runtime about no LZs found.

# Explain why it's good for the game

- We've only had a WO round about 7 times in the last 6 months... It doesn't need to be *that* rare.
- Having the same voting requirement as a ready vote (especially for a gamemode that has xenos that don't normally ready at round start) is also very awkward for ever getting the mode to successfully start w/o admin intervention
- WO CO is still a whitelisted role so no point not giving them access to medals; nor should there be a reason XO can't do their typical medals.
- Working UI panels (groundside operations) is better

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="1132" height="387" alt="image" src="https://github.com/user-attachments/assets/0a333b23-e36a-4f62-89af-adc9570f9442" />

<img width="850" height="700" alt="image" src="https://github.com/user-attachments/assets/4786a416-5dce-43f6-ae0e-bab80500f9eb" />

</details>


# Changelog
:cl: Drathek
code: Gamemodes can now specify a required_ready_players which is how many must be ready to start the gamemode (set to 60 for WO)
config: WO will now by default require 120 pop for voting instead of 140 (Also cycles on 65 rounds instead of 75)
fix: Fixed groundside operation panel not working on WO because there's no almayer AA gun
fix: Fixed WO CO and XO being unable to issue medals
ui: Set TGUI input text for some medal writing inputs
/:cl:
