### PR TITLE
Low-hanging SShuman/Chemicals optimizations

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_chemicals_in_body.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_chemicals_in_body.dm
@@ -14,11 +14,8 @@
 				universal_understand = FALSE
 			chem_effect_flags = 0
 
-	if(reagents && !(species.flags & NO_CHEM_METABOLIZATION))
-		var/alien = 0
-		if(species && species.reagent_tag)
-			alien = species.reagent_tag
-		reagents.metabolize(src, alien, delta_time)
+	if(!(species.flags & NO_CHEM_METABOLIZATION))
+		reagents?.metabolize(src, species.reagent_tag, delta_time)
 
 	if(status_flags & GODMODE)
 		return 0 //Godmode

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -459,6 +459,7 @@
 /// Faster version of [/datum/reagents/proc/del_reagent] for when we already have the reagent reference
 /datum/reagents/proc/del_reagent_by_reference(datum/reagent/reagent)
 	reagent.on_delete()
+	reagent_list -= reagent
 	qdel(reagent)
 	update_total()
 	my_atom?.on_reagent_change()

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -230,10 +230,10 @@
 	//handle_reactions() Don't need to handle reactions on the source since you're (presumably isolating and) transferring a specific reagent.
 	return amount
 
-/datum/reagents/proc/metabolize(mob/M, alien, delta_time)
-	for(var/datum/reagent/reagent in reagent_list)
-		if(M && reagent && !QDELETED(reagent))
-			reagent.on_mob_life(M, alien, delta_time)
+/datum/reagents/proc/metabolize(mob/mob, alien, delta_time)
+	for(var/datum/reagent/reagent as anything in reagent_list)
+		if(!QDELETED(reagent))
+			reagent.on_mob_life(mob, alien, delta_time)
 	update_total()
 
 /datum/reagents/proc/handle_reactions()
@@ -441,13 +441,13 @@
 	addtimer(CALLBACK(src, PROC_REF(handle_endothermic_reaction), reaction), 1 SECONDS, TIMER_UNIQUE)
 
 /datum/reagents/proc/isolate_reagent(reagent)
-	for(var/datum/reagent/R in reagent_list)
+	for(var/datum/reagent/R as anything in reagent_list)
 		if(R.id != reagent)
 			del_reagent(R.id)
 			update_total()
 
 /datum/reagents/proc/del_reagent(reagent)
-	for(var/datum/reagent/R in reagent_list)
+	for(var/datum/reagent/R as anything in reagent_list)
 		if(R.id == reagent)
 			R.on_delete()
 			reagent_list -= R
@@ -460,7 +460,7 @@
 // Returns FALSE if the reagent is getting deleted
 /datum/reagents/proc/update_total()
 	total_volume = 0
-	for(var/datum/reagent/R in reagent_list)
+	for(var/datum/reagent/R as anything in reagent_list)
 		if(R.volume < 0.1)
 			R.deleted = TRUE
 			del_reagent(R.id)
@@ -498,7 +498,7 @@
 		for(var/index in data)
 			new_data[index] = data[index]
 
-	for(var/datum/reagent/R in reagent_list)
+	for(var/datum/reagent/R as anything in reagent_list)
 		if(R.id == reagent)
 			R.volume += amount
 			R.last_source_mob = new_data["last_source_mob"]
@@ -506,7 +506,7 @@
 
 			if(my_atom)
 				my_atom.on_reagent_change()
-				for(var/datum/chem_property/P in R.properties)
+				for(var/datum/chem_property/P as anything in R.properties)
 					P.reagent_added(my_atom, R, R.volume)
 
 			// mix dem viruses
@@ -550,7 +550,7 @@
 		reagent_list += R
 
 		if(my_atom)
-			for(var/datum/chem_property/P in D.properties)
+			for(var/datum/chem_property/P as anything in D.properties)
 				P.reagent_added(my_atom, D, amount)
 
 		update_total()
@@ -570,7 +570,7 @@
 	if(!isnum(amount))
 		return TRUE
 
-	for(var/datum/reagent/R in reagent_list)
+	for(var/datum/reagent/R as anything in reagent_list)
 		if(R.id == reagent)
 			R.volume -= amount
 			update_total()
@@ -581,8 +581,16 @@
 
 	return TRUE
 
+/// Faster version of [/datum/reagents/proc/remove_reagent] for when we already know the reagent involved
+/datum/reagents/proc/remove_reagent_by_reference(datum/reagent/reagent, amount, safety = FALSE)
+	reagent.volume -= amount
+	update_total()
+	if(!safety)
+		handle_reactions()
+	my_atom?.on_reagent_change()
+
 /datum/reagents/proc/has_reagent(reagent, amount = -1)
-	for(var/datum/reagent/R in reagent_list)
+	for(var/datum/reagent/R as anything in reagent_list)
 		if(R.id == reagent)
 			if(!amount)
 				return R
@@ -594,14 +602,14 @@
 	return FALSE
 
 /datum/reagents/proc/get_reagent_amount(reagent)
-	for(var/datum/reagent/R in reagent_list)
+	for(var/datum/reagent/R as anything in reagent_list)
 		if(R.id == reagent)
 			return R.volume
 	return 0
 
 /datum/reagents/proc/get_reagents()
 	var/res = ""
-	for(var/datum/reagent/A in reagent_list)
+	for(var/datum/reagent/A as anything in reagent_list)
 		if(res != "")
 			res += ","
 		res += A.name
@@ -614,7 +622,7 @@
 
 	var/has_removed_reagent = FALSE
 
-	for(var/datum/reagent/R in reagent_list)
+	for(var/datum/reagent/R as anything in reagent_list)
 		var/matches = FALSE
 		// Switch between how we check the reagent type
 		if(strict)
@@ -632,12 +640,12 @@
 
 //two helper functions to preserve data across reactions (needed for xenoarch)
 /datum/reagents/proc/get_data(reagent_id)
-	for(var/datum/reagent/D in reagent_list)
+	for(var/datum/reagent/D as anything in reagent_list)
 		if(D.id == reagent_id)
 			return D.data_properties
 
 /datum/reagents/proc/set_data(reagent_id, new_data)
-	for(var/datum/reagent/D in reagent_list)
+	for(var/datum/reagent/D as anything in reagent_list)
 		if(D.id == reagent_id)
 			D.data_properties = new_data
 

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -162,9 +162,9 @@
 		return
 	to_chat(target, SPAN_NOTICE("You taste [pick(V.reagent_list)]."))
 
-	for(var/datum/reagent/RG in V.reagent_list) // If it can't be ingested, remove it.
+	for(var/datum/reagent/RG as anything in V.reagent_list) // If it can't be ingested, remove it.
 		if(RG.flags & REAGENT_NOT_INGESTIBLE)
-			V.del_reagent(RG.id)
+			V.del_reagent_by_reference(RG)
 
 	addtimer(CALLBACK(V, TYPE_PROC_REF(/datum/reagents/vessel, inject_vessel), target, INGEST, TRUE, 0.5 SECONDS), 9.5 SECONDS)
 	return amount
@@ -245,9 +245,9 @@
 	var/reaction_occurred = FALSE
 	do
 		reaction_occurred = FALSE
-		for(var/datum/reagent/reagent in reagent_list) // Usually a small list
+		for(var/datum/reagent/reagent as anything in reagent_list) // Usually a small list
 			if(reagent.original_id) //Prevent synthesised chem variants from being mixed
-				for(var/datum/reagent/current in reagent_list)
+				for(var/datum/reagent/current as anything in reagent_list)
 					if(current.id == reagent.id)
 						continue
 					else if(current.original_id == reagent.original_id || current.id == reagent.original_id)
@@ -257,8 +257,7 @@
 							volume_factor = 1
 						reagent_list -= reagent
 						add_reagent(current.id, floor(reagent.volume / volume_factor))
-						var/list/seen = viewers(4, get_turf(my_atom))
-						for(var/mob/seen_mob in seen)
+						for(var/mob/seen_mob as anything in viewers(4, get_turf(my_atom)))
 							if(volume_factor == 1)
 								to_chat(seen_mob, SPAN_NOTICE("[icon2html(my_atom, seen_mob)] The solution begins to bubble."))
 							else
@@ -276,7 +275,7 @@
 				var/matching_container = FALSE
 				var/list/multipliers = new/list()
 
-				for(var/required_reagent in reaction.required_reagents)
+				for(var/required_reagent as anything in reaction.required_reagents)
 					if(!has_reagent(required_reagent, reaction.required_reagents[required_reagent]))
 						break
 					total_matching_reagents++
@@ -443,7 +442,7 @@
 /datum/reagents/proc/isolate_reagent(reagent)
 	for(var/datum/reagent/R as anything in reagent_list)
 		if(R.id != reagent)
-			del_reagent(R.id)
+			del_reagent_by_reference(R)
 			update_total()
 
 /datum/reagents/proc/del_reagent(reagent)
@@ -457,27 +456,34 @@
 			return FALSE
 	return TRUE
 
+/// Faster version of [/datum/reagents/proc/del_reagent] for when we already have the reagent reference
+/datum/reagents/proc/del_reagent_by_reference(datum/reagent/reagent)
+	reagent.on_delete()
+	qdel(reagent)
+	update_total()
+	my_atom?.on_reagent_change()
+
 // Returns FALSE if the reagent is getting deleted
 /datum/reagents/proc/update_total()
 	total_volume = 0
 	for(var/datum/reagent/R as anything in reagent_list)
-		if(R.volume < 0.1)
+		if(R.volume < 0.1 && !R.deleted)
 			R.deleted = TRUE
-			del_reagent(R.id)
+			del_reagent_by_reference(R)
 		else
 			total_volume += R.volume
 
 	return FALSE
 
 /datum/reagents/proc/clear_reagents()
-	for(var/datum/reagent/R in reagent_list)
-		del_reagent(R.id)
+	for(var/datum/reagent/reagent as anything in reagent_list)
+		del_reagent_by_reference(reagent)
 	return FALSE
 
 /datum/reagents/proc/reaction(atom/A, method=TOUCH, volume_modifier=0, permeable_in_mobs=TRUE)
 	if(method != TOUCH && method != INGEST)
 		return
-	for(var/datum/reagent/R in reagent_list)
+	for(var/datum/reagent/R as anything in reagent_list)
 		if(ismob(A))
 			R.reaction_mob(A, method, R.volume + volume_modifier, permeable_in_mobs)
 		else if(isturf(A))

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -187,7 +187,7 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 
 //Main Processing
 /datum/reagent/proc/handle_processing(mob/living/M, list/mods, delta_time)
-	for(var/datum/chem_property/P in properties)
+	for(var/datum/chem_property/P as anything in properties)
 		//A level of 1 == 0.5 potency, which is equal to REM (0.2/0.4) in the old system
 		//That means the level of the property by default is the number of REMs the effect had in the old system
 		var/potency = mods[REAGENT_EFFECT] * ((P.level+mods[REAGENT_BOOST]) * LEVEL_TO_POTENCY_MULTIPLIER)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -153,7 +153,8 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	handle_processing(M, mods, delta_time)
 	if(QDELETED(src)) //proc above could have deleted us
 		return
-	holder.remove_reagent(id, custom_metabolism * delta_time)
+
+	holder.remove_reagent_by_reference(src, custom_metabolism * delta_time)
 
 	if(adj_temp && M.bodytemperature != target_temp)
 		if(adj_temp > 0) // heating


### PR DESCRIPTION

# About the pull request

`remove_reagent` makes up for almost 20% of SShuman tick usage

 * Quick Life optimization
 * Generally optimizes Chem backend by putting in all the `as anything` it was missing
 * Many places in Chem backend  would lookup the correct reagent, then send its id to another proc that needs to look it up again. This is espeically dramatic in remove_reagent that ends up needing to perform reagents^2 checks

There are many more things to optimize. I have another branch that kills on_reagent_change for a signal for example. handle_reactions also needs heavy optimization. And the entire chem backend would gain a lot to being refactored into using a lookup alist, rather than these silly loops.

This needs live testing, to make sure ripping off typechecks doesn't result in some bs edge case with deleted objects.

# Changelog
:cl:
code: Optimized some aspects of chemical processing.
/:cl:
