### PR TITLE
Clamp lower end of scuffle damage and reduce variability

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -133,8 +133,8 @@
 	if(istype(get_active_hand(), /obj/item))
 		var/obj/item/item = get_active_hand()
 		if(item.force > 0)
-			var/limited_force = min(item.force, 35)
-			var/damage_of_item = rand(floor(limited_force / 4), limited_force)
+			var/force_range = clamp(item.force, MELEE_FORCE_NORMAL, MELEE_FORCE_STRONG)
+			var/damage_of_item = rand(floor(force_range / 2), force_range)
 
 			xeno.last_damage_data = create_cause_data("scuffling", src)
 			attack_log += "\[[time_stamp()]\]<font color='red'> Attacked [key_name(xeno)] with [item.name] (INTENT: [uppertext(intent_text(a_intent))]) (DAMTYPE: [uppertext(BRUTE)])</font>"


### PR DESCRIPTION

# About the pull request

This PR does a couple things:
- If the item does any damage at all, struggling in the grip of a xeno now has a lower end damage of 25 (/obj/item/attachable/bayonet damage) - up from 1? (whatever the item had)
- Struggling in the grip of a xeno now only randomizes between half the above damage and full damage - up from 1/4th damage and full damage

Alongside these changes, I have also changed the config on the server:
```diff 
  EXTRA_LARVA_PER_BURST 0.0
- EXTRA_LARVA_PER_NESTED_BURST 0.34
+ EXTRA_LARVA_PER_NESTED_BURST 0.5
  ## Time in seconds for a burst OUTSIDE OF NEST (Inside nest currently 1.5x the speed)
  ## 450s is 7.5 mins (5 in nest) 540s is 9 mins (6 in nest) 720s is 12 mins (8 in nest)
- EMBRYO_BURST_TIMER 540
+ EMBRYO_BURST_TIMER 720
```
Meaning that we're once again back to 1.5 larva per burst (I wasn't happy to find out after the fact that this was changed) and that the time it takes to burst is longer. Goal with the config changes is much like below in trying to achieve more reward for more risk with more possibility for rescue.

# Explain why it's good for the game

This should make it more difficult to transport conscious marines, more unify what weapons can even be used to damage them efficiently with, and reduce some of the randomness in damage applied. Keep in mind the above config changes too.

# Changelog
:cl: Drathek
balance: Struggling when restrained by a xeno with a item that does any damage now has a clamped lower end damage of 25
balance: Struggling when restrained by a xeno with a item now only varies between 1/2-full of the damage instead of 1/4-full
/:cl:
