### PR TITLE
Bundles Wound Overlay Updates

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_organs.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_organs.dm
@@ -7,9 +7,13 @@
 	for(var/datum/internal_organ/I as anything in internal_organs)
 		I.process(delta_time)
 
+	// Bundle wound overlay updates if they are needed instead of doing it once per limb
+	var/update_wound_overlays = FALSE
+
 	for(var/obj/limb/E as anything in limbs_to_process)
-		if(!E)
-			continue
+		if(!(E.status & LIMB_DESTROYED))
+			update_wound_overlays = TRUE
+
 		if(!E.need_process())
 			E.stop_processing()
 			continue
@@ -60,5 +64,6 @@
 			custom_pain("You can't stand on broken legs!", 1)
 			apply_effect(5, WEAKEN)
 
-	// Essentially limbs want to update damage overlays every tick. So do it once for the whole tick, it'll be a little less awful.
-	update_damage_overlays()
+	// Essentially limbs want to update damage overlays each individually. We update them all at same time to optimize.
+	if(update_wound_overlays)
+		update_damage_overlays()

--- a/code/modules/mob/living/carbon/human/life/handle_organs.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_organs.dm
@@ -59,3 +59,6 @@
 				emote("pain")
 			custom_pain("You can't stand on broken legs!", 1)
 			apply_effect(5, WEAKEN)
+
+	// Essentially limbs want to update damage overlays every tick. So do it once for the whole tick, it'll be a little less awful.
+	update_damage_overlays()

--- a/code/modules/mob/living/carbon/human/life/handle_organs.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_organs.dm
@@ -10,30 +10,30 @@
 	// Bundle wound overlay updates if they are needed instead of doing it once per limb
 	var/update_wound_overlays = FALSE
 
-	for(var/obj/limb/E as anything in limbs_to_process)
-		if(!(E.status & LIMB_DESTROYED))
+	for(var/obj/limb/limb as anything in limbs_to_process)
+		if(!(limb.status & LIMB_DESTROYED))
 			update_wound_overlays = TRUE
 
-		if(!E.need_process())
-			E.stop_processing()
+		if(!limb.need_process())
+			limb.stop_processing()
 			continue
 		else
-			E.process()
+			limb.process()
 
 			if(body_position == STANDING_UP && world.time - l_move_time < 15)
 			// Moving around with fractured ribs won't do you any good
-				if(E.is_broken() && E.internal_organs && prob(15))
-					var/datum/internal_organ/I = pick(E.internal_organs)
-					custom_pain("You feel broken bones moving in your [E.display_name]!", 1)
+				if(limb.is_broken() && limb.internal_organs && prob(15))
+					var/datum/internal_organ/organ = pick(limb.internal_organs)
+					custom_pain("You feel broken bones moving in your [limb.display_name]!", 1)
 					var/damage = rand(3,5)
-					I.take_damage(damage)
+					organ.take_damage(damage)
 					pain.apply_pain(damage * PAIN_ORGAN_DAMAGE_MULTIPLIER)
-				if(E.is_broken() && prob(2))
+				if(limb.is_broken() && prob(2))
 					var/damage = rand(3,5)
 					var/datum/wound/internal_bleeding/internal_bleed = new
-					E.add_bleeding(internal_bleed, TRUE, damage)
-					E.wounds += internal_bleed
-					custom_pain("You feel broken bones cutting at you in your [E.display_name]!", 1)
+					limb.add_bleeding(internal_bleed, TRUE, damage)
+					limb.wounds += internal_bleed
+					custom_pain("You feel broken bones cutting at you in your [limb.display_name]!", 1)
 					pain.apply_pain(damage * 1.5)
 
 	if(body_position == STANDING_UP && !buckled && prob(2))

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -51,9 +51,6 @@
 	///Embedded or implanter implanted items.
 	var/list/implants = list()
 
-	// how often wounds should be updated, a higher number means less often
-	var/wound_update_accuracy = 1
-
 	var/mob/living/carbon/human/owner = null
 	var/vital //Lose a vital limb, die immediately.
 
@@ -641,8 +638,7 @@ This function completely restores a damaged organ to perfect condition.
 
 /obj/limb/process()
 	// Process wounds, doing healing etc. Only do this every few ticks to save processing power
-	if(owner.life_tick % wound_update_accuracy == 0)
-		update_wounds()
+	update_wounds()
 
 	//Chem traces slowly vanish
 	if(owner.life_tick % 10 == 0)
@@ -705,8 +701,7 @@ This function completely restores a damaged organ to perfect condition.
 			heal_amt += 0.5 * 0.75 //Treated wounds heal faster
 
 		if(heal_amt)
-			//we only update wounds once in [wound_update_accuracy] ticks so have to emulate realtime
-			heal_amt = heal_amt * wound_update_accuracy
+			heal_amt = heal_amt
 			//configurable regen speed woo, no-regen hardcore or instaheal hugbox, choose your destiny
 			heal_amt = heal_amt * CONFIG_GET(number/organ_regeneration_multiplier)
 			// amount of healing is spread over all the wounds
@@ -734,7 +729,7 @@ This function completely restores a damaged organ to perfect condition.
 
 	// sync the organ's damage with its wounds
 	update_damages()
-	owner.update_damage_overlays()
+
 	if(wound_disappeared)
 		owner.update_med_icon()
 		remove_wound_bleeding()


### PR DESCRIPTION

# About the pull request

Wound overlays were regenerated every time a limb needed it, which is good. The problem is, currently our code will effectively consider it's always needed if the limb is processing, short of the limbs being destroyed entirely.

This meant that basically every tick, every person with 4 damaged limbs regenerates all wound overlays 4 times. It adds up quickly, and this accounts for around 10% of time spent in Human Life. 

I don't know how to fix this properly with granular updates, so I took the the easy route: the overlays are still updated every tick, but now it's done for the human as a whole, rather than triggered by each limb. This should cut down drastically on the time spent doing this by effectively dividing it by 4.

:cl:
code: Optimized human wound overlays by bundling updates
/:cl:
