### PR TITLE
Optimize /datum/controller/subsystem/minimaps/proc/add_marker

### DIFF
--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -527,7 +527,15 @@ SUBSYSTEM_DEF(minimaps)
 	var/turf/target_turf = get_turf(target)
 	if(!hud_flags || !blip || !target_turf)
 		CRASH("Invalid marker added to subsystem")
-	var/z = "[target_turf.z]"
+
+	// Legacy behavior: track mobs one level in
+	var/z = target.z
+	if(ismob(target) && !z && target.loc)
+		z = target.loc.z
+	if(!z)
+		return
+	z = "[z]"
+
 	var/datum/hud_displays/minimap = minimaps_by_z[z]
 
 	if(!initialized || !minimap) //the minimap doesn't exist yet, z level was probably loaded after init

--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -524,11 +524,11 @@ SUBSYSTEM_DEF(minimaps)
  * * marker: image or mutable_appearance we want to be using on the map
  */
 /datum/controller/subsystem/minimaps/proc/add_marker(atom/target, hud_flags = NONE, image/blip, image_x, image_y, is_label=FALSE)
-	var/turf/target_turf = get_turf(target)
-	if(!hud_flags || !blip || !target_turf)
+	if(!hud_flags || !blip)
 		CRASH("Invalid marker added to subsystem")
 
 	// Legacy behavior: track mobs one level in
+	var/turf/target_turf = get_turf(target)
 	var/z = target.z
 	if(ismob(target) && !z && target.loc)
 		z = target.loc.z

--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -524,35 +524,29 @@ SUBSYSTEM_DEF(minimaps)
  * * marker: image or mutable_appearance we want to be using on the map
  */
 /datum/controller/subsystem/minimaps/proc/add_marker(atom/target, hud_flags = NONE, image/blip, image_x, image_y, is_label=FALSE)
-	if(!isatom(target) || !hud_flags || !blip)
+	var/turf/target_turf = get_turf(target)
+	if(!hud_flags || !blip || !target_turf)
 		CRASH("Invalid marker added to subsystem")
+	var/z = "[target_turf.z]"
+	var/datum/hud_displays/minimap = minimaps_by_z[z]
 
-	var/actual_z = target.z
-	if(ismob(target) && target.loc && !isturf(target.loc))
-		actual_z = target.loc.z
-
-	if(!initialized || !(minimaps_by_z["[actual_z]"])) //the minimap doesn't exist yet, z level was probably loaded after init
-		for(var/datum/callback/callback as anything in LAZYACCESS(earlyadds, "[actual_z]"))
+	if(!initialized || !minimap) //the minimap doesn't exist yet, z level was probably loaded after init
+		for(var/datum/callback/callback as anything in LAZYACCESS(earlyadds, z))
 			if(callback.arguments[1] == target)
 				return
-		LAZYADDASSOCLIST(earlyadds, "[actual_z]", CALLBACK(src, PROC_REF(add_marker), target, hud_flags, blip))
+		LAZYADDASSOCLIST(earlyadds, z, CALLBACK(src, PROC_REF(add_marker), target, hud_flags, blip))
 		RegisterSignal(target, COMSIG_PARENT_QDELETING, PROC_REF(remove_earlyadd), override = TRUE) //Override required for late z-level loading to prevent hard dels where an atom is initiated during z load, but is qdel'd before it finishes
 		return
 
-
-	var/turf/target_turf = get_turf(target)
-	if(ismob(target) && target.loc && !isturf(target.loc))
-		target_turf = get_turf(target.loc)
-
-	blip.pixel_x = MINIMAP_PIXEL_FROM_WORLD(target_turf.x) + minimaps_by_z["[target_turf.z]"].x_offset + image_x
-	blip.pixel_y = MINIMAP_PIXEL_FROM_WORLD(target_turf.y) + minimaps_by_z["[target_turf.z]"].y_offset + image_y
+	blip.pixel_x = MINIMAP_PIXEL_FROM_WORLD(target_turf.x) + minimap.x_offset + image_x
+	blip.pixel_y = MINIMAP_PIXEL_FROM_WORLD(target_turf.y) + minimap.y_offset + image_y
 
 	images_by_source[target] = blip
 	for(var/flag in bitfield2list(hud_flags))
 		if(is_label)
 			flag = "[flag]label"
-		minimaps_by_z["[target_turf.z]"].images_assoc["[flag]"][target] = blip
-		minimaps_by_z["[target_turf.z]"].images_raw["[flag]"] += blip
+		minimap.images_assoc["[flag]"][target] = blip
+		minimap.images_raw["[flag]"] += blip
 		for(var/datum/minimap_updater/updater as anything in update_targets["[flag]"])
 			if(target_turf.z == updater.ztarget)
 				updater.raw_blips += blip


### PR DESCRIPTION

# About the pull request

This is an extremely hot proc because it gets triggered by [every Human Life tick + every Damage taken] through Med HUD (see #12827), and by every Sentry processing.

So optimizing it a lil' to offset. Needs the go-ahead from Nivrak on this because I'm also changing the way the z-detection works. Tested locally in the matter of adding several living mobs and checking minimap as ghost, i'm not sure how else to do it.

:cl:
code: Optimized minimap marker logic.
/:cl:
