### PR TITLE
Fix scuttle and hugger infecting through barricades

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -1228,7 +1228,7 @@
 	if (mob_size != MOB_SIZE_SMALL)
 		return FALSE
 
-	var/move_dir = get_dir(src, loc)
+	var/move_dir = get_dir(src, current_structure)
 	for(var/atom/movable/atom in get_turf(current_structure))
 		if(atom != current_structure && atom.density && atom.BlockedPassDirs(src, move_dir))
 			to_chat(src, SPAN_WARNING("[atom] prevents us from squeezing under [current_structure]!"))

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -1229,6 +1229,10 @@
 		return FALSE
 
 	var/move_dir = get_dir(src, current_structure)
+	for(var/atom/movable/atom in get_turf(src))
+		if(atom != current_structure && atom.density && atom.BlockedExitDirs(src, move_dir))
+			to_chat(src, SPAN_WARNING("[atom] prevents us from squeezing under [current_structure]!"))
+			return FALSE
 	for(var/atom/movable/atom in get_turf(current_structure))
 		if(atom != current_structure && atom.density && atom.BlockedPassDirs(src, move_dir))
 			to_chat(src, SPAN_WARNING("[atom] prevents us from squeezing under [current_structure]!"))

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -152,6 +152,11 @@
 		if(!can_hug(human, hivenumber))
 			to_chat(src, SPAN_WARNING("You can't infect \the [human]..."))
 			return
+		var/hug_dir = get_dir(src, human)
+		for(var/atom/movable/atom in get_turf(human))
+			if(atom != human && atom.density && atom.BlockedPassDirs(src, hug_dir))
+				to_chat(src, SPAN_WARNING("[atom] prevents us from infecting [human]!"))
+				return
 		visible_message(SPAN_WARNING("\The [src] starts climbing onto \the [human]'s face..."), SPAN_XENONOTICE("You start climbing onto \the [human]'s face..."))
 		if(!do_after(src, FACEHUGGER_CLIMB_DURATION, INTERRUPT_ALL, BUSY_ICON_HOSTILE, human, INTERRUPT_MOVED, BUSY_ICON_HOSTILE))
 			return

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -166,6 +166,11 @@
 		if(!can_hug(human, hivenumber))
 			to_chat(src, SPAN_WARNING("You can't infect \the [human]..."))
 			return
+		hug_dir = get_dir(src, human)
+		for(var/atom/movable/atom in get_turf(human))
+			if(atom != human && atom.density && atom.BlockedPassDirs(src, hug_dir))
+				to_chat(src, SPAN_WARNING("[atom] prevents us from infecting [human]!"))
+				return
 		handle_hug(human)
 		return
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -153,6 +153,10 @@
 			to_chat(src, SPAN_WARNING("You can't infect \the [human]..."))
 			return
 		var/hug_dir = get_dir(src, human)
+		for(var/atom/movable/atom in get_turf(src))
+			if(atom != src && atom.density && atom.BlockedExitDirs(src, hug_dir))
+				to_chat(src, SPAN_WARNING("[atom] prevents us from infecting [human]!"))
+				return
 		for(var/atom/movable/atom in get_turf(human))
 			if(atom != human && atom.density && atom.BlockedPassDirs(src, hug_dir))
 				to_chat(src, SPAN_WARNING("[atom] prevents us from infecting [human]!"))
@@ -167,6 +171,10 @@
 			to_chat(src, SPAN_WARNING("You can't infect \the [human]..."))
 			return
 		hug_dir = get_dir(src, human)
+		for(var/atom/movable/atom in get_turf(src))
+			if(atom != src && atom.density && atom.BlockedExitDirs(src, hug_dir))
+				to_chat(src, SPAN_WARNING("[atom] prevents us from infecting [human]!"))
+				return
 		for(var/atom/movable/atom in get_turf(human))
 			if(atom != human && atom.density && atom.BlockedPassDirs(src, hug_dir))
 				to_chat(src, SPAN_WARNING("[atom] prevents us from infecting [human]!"))


### PR DESCRIPTION
# About the pull request

Fix #6429 

-Facehuggers and larvas can no longer scuttle under the doors if there is an obstacle in the way (barricade, foldable)

Fix #9283 
-Facehuggers can no longer "click to hug" over obstacles (barricade, foldable, rails). They can hug with jump ability if they can pass over the obstacle (cade with no wire for example)

# Explain why it's good for the game

Bug bad, fix good.


# Testing Photographs and Procedure

Testing video inside

<details>
<summary>Screenshots & Videos</summary>


https://github.com/user-attachments/assets/8e5b6ddb-bc08-44e8-88f2-5d5cbd7a039e



</details>

<details>
<summary>Latest video inside</summary>



https://github.com/user-attachments/assets/e0a41671-8ef3-483b-9a4f-d8003349211a





</details>


# Changelog
:cl:labeo0
fix: Facehuggers/larvas can no longer scuttle under doors with placed barricades to bypass them.
fix: Facehuggers can no longer click-hug humans lying down behind the barricades
/:cl:
