### PR TITLE
Fixes PKP magazine not having size set correctly

### DIFF
--- a/code/modules/projectiles/magazines/misc.dm
+++ b/code/modules/projectiles/magazines/misc.dm
@@ -37,6 +37,7 @@
 	caliber = "7.62x54mmR"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/UPP/machineguns.dmi'
 	icon_state = "qjy72"
+	w_class = SIZE_MEDIUM
 
 	matter = list("metal" = 10000)
 	default_ammo = /datum/ammo/bullet/pkp


### PR DESCRIPTION
# About the pull request

Fixes #11155 - PKP magazine not having size set correctly

# Explain why it's good for the game

Bug bad


# Testing Photographs and Procedure
<img width="690" height="244" alt="image" src="https://github.com/user-attachments/assets/1699ae66-af1e-41b3-84ab-06e94e472aa4" />


# Changelog

:cl: DangerRevolution
fix: Fixed the QYJ Machine Gun for the UPP having magazines that counted as "small" in a backpack, it is now set to "medium" like the Smartgun magazines
/:cl:

