### PR TITLE
Fixes floating light bulb off the Normandy Pad

### DIFF
--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -20568,15 +20568,6 @@
 /obj/effect/decal/heavy_cable/node_s_w,
 /turf/open/floor/plating/plating_catwalk/no_build,
 /area/almayer/middeck/maintenance/sp)
-"baM" = (
-/obj/structure/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/machinery/landinglight/delaythree{
-	dir = 8
-	},
-/turf/open/floor/almayer/plate,
-/area/almayer/hallways/hangar)
 "baN" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/plate,
@@ -142100,7 +142091,7 @@ yeN
 qrp
 mUI
 xBr
-baM
+baX
 bcb
 bHB
 aYt


### PR DESCRIPTION
# About the pull request

Fixes #12643, floating light bulb off the Normandy Pad

# Explain why it's good for the game

Magic Lamp Bad-


# Testing Photographs and Procedure

Check MDB


# Changelog

:cl:
fix: Removed a light bulb floating off the side of the Normandy in mid air.
/:cl: