### PR TITLE
Tweaks to the MOU anticheat cooldown

### DIFF
--- a/code/__DEFINES/guns.dm
+++ b/code/__DEFINES/guns.dm
@@ -3,7 +3,7 @@
 #define TASER_MODE_P "precision"
 #define TASER_MODE_F "free"
 
-#define MOU_ACTION_COOLDOWN 1.1 SECONDS
+#define MOU_ACTION_COOLDOWN 0.8 SECONDS
 
 // Common
 #define AMMO_BAND_COLOR_AP "#1F951F"


### PR DESCRIPTION
# About the pull request

Its a simple change of cooldown from 1.1 to 0.8 seconds.

# Explain why it's good for the game

The MOU shotgun currently feels unrewarding and punishing to use for wrong reasons. The cooldown on it closing and opening is too long which leads to players getting frustrated as they reload faster than the anticheat enables them too even though they are using their mouse and keyboard. It frankly makes the gun much more harder to reload and I myself personally stopped using it because 75% of my reload would not be able to go through because of the cooldown.

The original PRs goal was to simply make it so hotkey users would have to wait 1.1 seconds though it heavily and unexpectedly impacted a lot of noncheaters which was not the point of the PR. https://github.com/cmss13-devs/cmss13/pull/10411

Changing the cooldown to 0.8 seconds would still leave a blockade against cheaters but also not punish the players for simply reloading faster than the original PR creator thought they could.


# Testing Photographs and Procedure

https://youtu.be/-1Snyqy8pQs

The video shows how much difference simple change of 0,3 seconds makes. The gun feels more smooth in use and you are able to close it after every reload compared to the 1.1 second cooldown where almost every reload was met with the 1.1 second cooldown stopping it from coming through.

# Changelog

:cl: szczypak
balance: Changed the AntiCheat cooldown from 1.1 seconds to 0.8

/:cl: