### PR TITLE
Fix shooting target

### DIFF
--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -172,7 +172,7 @@
 
 /obj/structure/target/toggle_anchored(obj/item/wrench, mob/user)
 	//no need for movable,unbreakable bullet sponge
-	. - ..()
+	. = ..()
 	if(.)
 		density = !density
 	return .

--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -157,8 +157,8 @@
 		deconstruct(FALSE)
 		return XENO_ATTACK_ACTION
 	else
-		attack_hand(xeno)
-		return XENO_NONCOMBAT_ACTION
+		to_chat(xeno, SPAN_WARNING("We stare at \the [src] cluelessly."))
+		return XENO_NO_DELAY_ACTION
 
 /obj/structure/target/handle_tail_stab(mob/living/carbon/xenomorph/xeno, blunt_stab)
 	if(unslashable)

--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -175,6 +175,7 @@
 	. - ..()
 	if(.)
 		density = !density
+	return .
 
 
 /obj/structure/target/syndicate

--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -146,6 +146,35 @@
 	langchat_speech("[src] raises back into position!", get_mobs_in_view(7, src) , GLOB.all_languages, skip_language_check = TRUE, additional_styles = list("langchat_small"))
 	practice_health = practice_mode[1]
 
+/obj/structure/target/attack_alien(mob/living/carbon/xenomorph/xeno)
+	if(xeno.a_intent == INTENT_HARM)
+		if(unslashable)
+			return
+		xeno.animation_attack_on(src)
+		playsound(loc, 'sound/effects/metalhit.ogg', 25, 1)
+		xeno.visible_message(SPAN_DANGER("[xeno] slices [src] apart!"),
+		SPAN_DANGER("We slice [src] apart!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+		deconstruct(FALSE)
+		return XENO_ATTACK_ACTION
+	else
+		attack_hand(xeno)
+		return XENO_NONCOMBAT_ACTION
+
+/obj/structure/target/handle_tail_stab(mob/living/carbon/xenomorph/xeno, blunt_stab)
+	if(unslashable)
+		return TAILSTAB_COOLDOWN_NONE
+	playsound(src, 'sound/effects/metalhit.ogg', 25, 1)
+	deconstruct(FALSE)
+	xeno.visible_message(SPAN_DANGER("[xeno] destroys [src] with its tail!"),
+	SPAN_DANGER("We destroy [src] with our tail!"), null, 5, CHAT_TYPE_XENO_COMBAT)
+	xeno.tail_stab_animation(src, blunt_stab)
+	return TAILSTAB_COOLDOWN_NORMAL
+
+/obj/structure/target/toggle_anchored(obj/item/W, mob/user)
+	//no need for immovable,unbreakable bullet sponge
+	density = !density
+	. = ..()
+
 /obj/structure/target/syndicate
 	icon_state = "target_s"
 	desc = "A shooting target that looks like a hostile agent."

--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -172,9 +172,9 @@
 
 /obj/structure/target/toggle_anchored(obj/item/wrench, mob/user)
 	//no need for movable,unbreakable bullet sponge
-	if(. = ..())
+	if(..())
 		density = !density
-
+//
 
 /obj/structure/target/syndicate
 	icon_state = "target_s"

--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -94,7 +94,7 @@
 	desc = "A shooting target. Installed on a holographic display mount to help assess the damage done. While being a close replica of real threats a marine would encounter, it's not a real target - special firing procedures seen in weapons such as XM88 or Holotarget ammo won't have any effect."
 	icon = 'icons/obj/structures/props/target_dummies.dmi'
 	icon_state = "target_a"
-	density = FALSE
+	density = TRUE
 	health = 10000
 	wrenchable = TRUE
 	anchored = TRUE
@@ -117,7 +117,7 @@
 	. = ..()
 	if(practice_health <= 0 || !anchored)
 		return
-	var/damage_dealt = floor(armor_damage_reduction(GLOB.xeno_ranged, bullet.damage, practice_mode[2], bullet.ammo.penetration))
+	var/damage_dealt = floor(armor_damage_reduction(GLOB.xeno_ranged, bullet.calculate_damage(), practice_mode[2], bullet.ammo.penetration))
 	langchat_speech(damage_dealt, get_mobs_in_view(7, src) , GLOB.all_languages, skip_language_check = TRUE, animation_style = LANGCHAT_FAST_POP, additional_styles = list("langchat_small"))
 	practice_health -= damage_dealt
 	animation_flash_color(src, "#FF0000", 1)

--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -157,7 +157,7 @@
 		deconstruct(FALSE)
 		return XENO_ATTACK_ACTION
 	else
-		to_chat(xeno, SPAN_WARNING("We stare at \the [src] cluelessly."))
+		to_chat(xeno, SPAN_WARNING("We stare at [src] cluelessly."))
 		return XENO_NO_DELAY_ACTION
 
 /obj/structure/target/handle_tail_stab(mob/living/carbon/xenomorph/xeno, blunt_stab)
@@ -170,10 +170,11 @@
 	xeno.tail_stab_animation(src, blunt_stab)
 	return TAILSTAB_COOLDOWN_NORMAL
 
-/obj/structure/target/toggle_anchored(obj/item/W, mob/user)
-	//no need for immovable,unbreakable bullet sponge
-	density = !density
-	. = ..()
+/obj/structure/target/toggle_anchored(obj/item/wrench, mob/user)
+	//no need for movable,unbreakable bullet sponge
+	if(. = ..())
+		density = !density
+
 
 /obj/structure/target/syndicate
 	icon_state = "target_s"

--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -172,7 +172,8 @@
 
 /obj/structure/target/toggle_anchored(obj/item/wrench, mob/user)
 	//no need for movable,unbreakable bullet sponge
-	if(..())
+	. - ..()
+	if(.)
 		density = !density
 
 

--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -174,7 +174,7 @@
 	//no need for movable,unbreakable bullet sponge
 	if(..())
 		density = !density
-//
+
 
 /obj/structure/target/syndicate
 	icon_state = "target_s"


### PR DESCRIPTION
# About the pull request

Fix #11601 

-Shooting target now displays damage correctly. 
-Bullets hit target without spriteclick. As a result you can't walk through a target but you can unanchor it to pass and xeno can break it.

# Explain why it's good for the game

Bug bad, fix good.

# Testing Photographs and Procedure

<details>
<summary>Testing video inside</summary>


https://github.com/user-attachments/assets/bafe0e96-e126-4134-97e6-9b19c147a7f1



</details>


# Changelog
:cl:labeo0
fix: Shooting target damage display now accounts for damage falloff.
fix: Bullets hit shooting target without spriteclick too. As a result you can't walk through a target but you can unanchor it to pass and xeno can break it.

/:cl:
