### PR TITLE
Marines with leadership can now point and outline other mobs

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -378,22 +378,38 @@
 	SIGNAL_HANDLER
 	reset_view(null)
 
-/mob/proc/point_to_atom(atom/A, turf/T)
+/mob/proc/point_to_atom(atom/pointed_at, turf/turf_pointed_at)
 	var/mob/living/carbon/human/mob = src
 	var/datum/squad/squad = null
 	if(ishuman(mob))
 		squad = mob.assigned_squad
 	if(!check_improved_pointing()) //Squad Leaders and above have reduced cooldown and get a bigger arrow
 		recently_pointed_to = world.time + 2.5 SECONDS
-		new /obj/effect/overlay/temp/point(T, src, A)
+		new /obj/effect/overlay/temp/point(turf_pointed_at, src, pointed_at)
 	else
 		recently_pointed_to = world.time + 10
+		var/outline_color = "#282d8f" // Default color for people with command skill but no squad
 		if(isnull(squad)) //If they get the big arrow but aren't in a squad, they get the default green arrow
-			new /obj/effect/overlay/temp/point/big(T, src, A)
+			new /obj/effect/overlay/temp/point/big(turf_pointed_at, src, pointed_at)
 		else
-			new /obj/effect/overlay/temp/point/big/squad(T, src, A, squad.equipment_color)
-	visible_message("<b>[src]</b> points to [A]", null, null, 5)
+			new /obj/effect/overlay/temp/point/big/squad(turf_pointed_at, src, pointed_at, squad.equipment_color)
+			outline_color = squad.equipment_color
+
+		if(ismob(pointed_at))
+			var/outline_name = "point_outline_[REF(src)]"
+			var/outline_size = 0.25
+			if(skills)
+				var/leadership_level = skills.get_skill_level(SKILL_LEADERSHIP)
+				outline_size += leadership_level * 0.25
+
+			pointed_at.add_filter(outline_name, 2, list("type" = "outline", "color" = outline_color, "size" = outline_size))
+			addtimer(CALLBACK(pointed_at, PROC_REF(disable_point_outline), outline_name), 4.5 SECONDS)
+
+	visible_message("<b>[src]</b> points to [pointed_at]", null, null, 5)
 	return TRUE
+
+/mob/proc/disable_point_outline(outline_name)
+	remove_filter(outline_name)
 
 ///Is this mob important enough to point with big arrows?
 /mob/proc/check_improved_pointing()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -395,7 +395,7 @@
 			new /obj/effect/overlay/temp/point/big/squad(turf_pointed_at, src, pointed_at, squad.equipment_color)
 			outline_color = squad.equipment_color
 
-		if(ismob(pointed_at))
+		if(ismob(pointed_at) && ishuman(mob))
 			var/outline_name = "point_outline_[REF(src)]"
 			var/outline_size = 0.25
 			if(skills)


### PR DESCRIPTION

# About the pull request

Gives an extra way for SLs/SOs/XOs/COs to visually communicate.

Outlines the mob for 4.5 seconds with varying thickness (depending on leadership level)
Visibile to everyone.


It would be nice for it to only be visible to humans/the squad the SL is in, but I don't see an elegant way to do it. Feel free to poke me if you do (Squad case is somewhat easier, but then what about COs? We don't have a list of all marines (since we don't want it appearing for CLF) as far as I know)

# Explain why it's good for the game
# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

General testing, works on mobs.

https://github.com/user-attachments/assets/53342bb1-ce0e-4d56-a5fc-22bf6bfdc352

Testing CO's thick outline
<img width="367" height="424" alt="image" src="https://github.com/user-attachments/assets/dc2335b2-3234-48ea-a0ea-d533f00e5ba8" />

Testing lurker invisibility
<img width="196" height="319" alt="image" src="https://github.com/user-attachments/assets/5edb638a-4b47-4ae7-9046-47ad5bb62f69" />

Also tested that the outline works in the dark (aka it DOESN'T highlight in darkness), but no picture of that... Since... It works, and  everything is dark.


</details>


# Changelog
:cl:
add: SLs (and other leaders, determined by having big arrow) can now highlight mobs for 4.5 seconds by pointing at them.
/:cl:
