### PR TITLE
Revert "removes f1 for adminhelp hardcoded keybind"

### DIFF
--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -24,15 +24,10 @@ SUBSYSTEM_DEF(input)
 		"Any" = "\"KeyDown \[\[*\]\]\"",
 		"Any+UP" = "\"KeyUp \[\[*\]\]\"",
 		"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"",
-		"F1" = "dummy", //overriding .options menu being triggered by assigning F1 to proc a verb that actually does nothing
+		"F1" = "adminhelp", // Need to unbind F1 because by default, it is bound to .options
 		"CTRL+SHIFT+F1+REP" = ".options",
 		"Escape" = "Open-Escape-Menu",
 		)
-
-CLIENT_VERB(dummy) // idk where else to put it
-	set category = null
-	set name = "dummy"
-	set hidden = TRUE
 
 // Badmins just wanna have fun ♪
 /datum/controller/subsystem/input/proc/refresh_client_macro_sets()

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -24,10 +24,16 @@ SUBSYSTEM_DEF(input)
 		"Any" = "\"KeyDown \[\[*\]\]\"",
 		"Any+UP" = "\"KeyUp \[\[*\]\]\"",
 		"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"",
-		"F1" = "adminhelp", // Need to unbind F1 because by default, it is bound to .options
+		"F1" = "dummy", //overriding .options menu being triggered by assigning F1 to proc a verb that actually does nothing
+		"F2" = "dummy",
 		"CTRL+SHIFT+F1+REP" = ".options",
 		"Escape" = "Open-Escape-Menu",
 		)
+
+CLIENT_VERB(dummy) // idk where else to put it
+	set category = null
+	set name = "dummy"
+	set hidden = TRUE
 
 // Badmins just wanna have fun ♪
 /datum/controller/subsystem/input/proc/refresh_client_macro_sets()

--- a/code/datums/keybinding/client.dm
+++ b/code/datums/keybinding/client.dm
@@ -12,7 +12,7 @@
 
 /datum/keybinding/client/admin_help
 	hotkey_keys = list("Unbound")
-	classic_keys = list("F1")
+	classic_keys = list("Unbound")
 	name = "admin_help"
 	full_name = "Admin Help"
 	description = "Ask an admin for help."
@@ -70,4 +70,3 @@
 		return
 	user.mob.button_pressed_F12()
 	return TRUE
-

--- a/code/datums/keybinding/client.dm
+++ b/code/datums/keybinding/client.dm
@@ -12,7 +12,7 @@
 
 /datum/keybinding/client/admin_help
 	hotkey_keys = list("Unbound")
-	classic_keys = list("Unbound")
+	classic_keys = list("F1")
 	name = "admin_help"
 	full_name = "Admin Help"
 	description = "Ask an admin for help."
@@ -27,8 +27,8 @@
 
 
 /datum/keybinding/client/screenshot
-	hotkey_keys = list("F2")
-	classic_keys = list("Unbound")
+	hotkey_keys = list("Unbound")
+	classic_keys = list("F2")
 	name = "screenshot"
 	full_name = "Screenshot"
 	description = "Take a screenshot."

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -49,7 +49,7 @@
 		//SECURITY//
 		////////////
 	var/next_allowed_topic_time = 10
-	control_freak = CONTROL_FREAK_ALL | CONTROL_FREAK_SKIN
+	control_freak = CONTROL_FREAK_MACROS
 
 	var/received_irc_pm = -99999
 


### PR DESCRIPTION

# About the pull request

Reverts cmss13-devs/cmss13#10802 via working around control freak but otherwise the same aa messages and options still works

# Explain why it's good for the game

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

[Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.](https://discord.com/channels/150315577943130112/964684928161808384/1534552769115983962)

</details>


# Changelog

:cl:
code: no more freaky control freaks, f1 and f2 keys are now unhardcoded
/:cl:

