### PR TITLE
Code: macros IS_DIAGONAL_DIR(dir) returns incorrect value

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -99,7 +99,7 @@
 
 #define FLAGS_EQUALS(flag, flags) (((flag) & (flags)) == (flags))
 
-#define IS_DIAGONAL_DIR(dir) (dir & ~(NORTH|SOUTH))
+#define IS_DIAGONAL_DIR(dir) (dir & (NORTH|SOUTH) && dir & (EAST|WEST))
 
 // Inverse direction, taking into account UP|DOWN if necessary.
 #define REVERSE_DIR(dir) ( (((dir) & 85) << 1) | (((dir) & 170) >> 1) )

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -168,7 +168,7 @@
 		return 1
 	var/adir = get_dir(A,B)
 	var/rdir = get_dir(B,A)
-	if((adir & (NORTH|SOUTH)) && (adir & (EAST|WEST))) //diagonal
+	if(IS_DIAGONAL_DIR(adir)) //diagonal
 		var/iStep = get_step(A,adir&(NORTH|SOUTH))
 		if(!LinkBlockedWithAccess(A,iStep, ID) && !LinkBlockedWithAccess(iStep,B,ID))
 			return 0

--- a/code/modules/movement/movement.dm
+++ b/code/modules/movement/movement.dm
@@ -32,7 +32,7 @@
 			return NO_BLOCKED_MOVEMENT
 
 		// This is to properly handle diagonal movement (a cade to your NE facing west when you are trying to move NE should block for north instead of east)
-		if(target_dir & (NORTH|SOUTH) && target_dir & (EAST|WEST))
+		if(IS_DIAGONAL_DIR(target_dir))
 			return target_dir - (target_dir & reverse_dir)
 		return target_dir & reverse_dir
 	else


### PR DESCRIPTION

# About the pull request
> #define IS_DIAGONAL_DIR(dir) (dir & ~(NORTH|SOUTH)) - here it is.

Returns incorrect checking for horizontal movement. If we pass EAST (4 = 0100) we will have as a result of & operation 4 = 0100 which is considered TRUE, but obviously EAST is not a diagonal direction

# Explain why it's good for the game

I am not sure whether you want to fix it. Maybe it was intentional decision to work only for vertical directions? Idk. It's up to maintainers to decide.

The only place I found it'd been used is in bloodsplatter.dm in a single line but I don't think it will need any changes.

# Testing Photographs and Procedure
Can't really - it's obvious.

# Changelog
:cl: JHINgle4ce
fix: fixed IS_DIAGONAL_DIR check
refactor: usage of IS_DIAGONAL_DIR implemented
/:cl: