### PR TITLE
Adds a megaphone to the Squad Leader gear rack for 5 points.

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
@@ -26,6 +26,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_leader, list(
 
 		list("UTILITIES", 0, null, null, null),
 		list("Fire Extinguisher (Portable)", 3, /obj/item/tool/extinguisher/mini, null, VENDOR_ITEM_REGULAR),
+		list("Megaphone", 5, /obj/item/device/megaphone, null, VENDOR_ITEM_REGULAR),
 		list("Motion Detector", 5, /obj/item/device/motiondetector, null, VENDOR_ITEM_REGULAR),
 		list("Fulton Device Stack", 5, /obj/item/stack/fulton, null, VENDOR_ITEM_REGULAR),
 		list("SensorMate Medical HUD", 4, /obj/item/clothing/glasses/hud/sensor, null, VENDOR_ITEM_REGULAR),
@@ -225,5 +226,4 @@ GLOBAL_LIST_INIT(cm_vending_clothing_leader, list(
 		/obj/item/tool/extinguisher/mini,
 		/obj/item/storage/box/zipcuffs/small,
 		/obj/item/clothing/accessory/device/whistle/trench,
-		/obj/item/device/megaphone,
 	)

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
@@ -225,4 +225,5 @@ GLOBAL_LIST_INIT(cm_vending_clothing_leader, list(
 		/obj/item/tool/extinguisher/mini,
 		/obj/item/storage/box/zipcuffs/small,
 		/obj/item/clothing/accessory/device/whistle/trench,
+		/obj/item/device/megaphone,
 	)


### PR DESCRIPTION
# About the pull request

Adds a megaphone to the Squad Leader gear rack for 5 points.

# Explain why it's good for the game

Megaphones help Squad Leaders communicate orders to nearby marines, who are often distracted by the battlefield around them

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

</details>

# Changelog

:cl:
add: Squad Leaders now buy a megaphone from their vendor for 5 points.
/:cl: