### PR TITLE
Extract path matching logic into helper + unit tests

### DIFF
--- a/code/__DEFINES/constants.dm
+++ b/code/__DEFINES/constants.dm
@@ -1,0 +1,3 @@
+/// Initialize a global constants datum that you can reference in code as needed
+/// Datum acts as a namespace for constants
+#define CONSTANT(name, constant_typepath) GLOBAL_REAL(name, constant_typepath) = new;

--- a/code/__DEFINES/text.dm
+++ b/code/__DEFINES/text.dm
@@ -26,3 +26,5 @@
 #define MAX_NAME_LEN 28
 #define MAX_PRESET_NAME_LEN 20
 #define MAX_MESSAGE_CHUNKS 20
+
+#define WRAP_BRACKETS(to_resolve) "\[[to_resolve]\]"

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1814,3 +1814,27 @@ GLOBAL_LIST_INIT(duplicate_forbidden_vars,list(
 		return TRUE
 	else
 		return FALSE
+
+/datum/matching_paths
+	var/datum/highest_matching
+	var/list/datum/matching
+
+/datum/matching_paths/New()
+	. = ..()
+	highest_matching = null
+	matching = list()
+
+/proc/get_matching_paths(datum/to_check, list/typepaths)
+	RETURN_TYPE(/datum/matching_paths)
+	var/datum/matching_paths/matching_paths = new /datum/matching_paths
+	ASSERT(matching_paths.highest_matching == null, "matching_paths.highest_matching should be null on creation")
+	ASSERT(!isnull(matching_paths.matching), "matching_paths.matching should be a list on creation")
+	ASSERT(length(matching_paths.matching) == 0, "matching_paths.matching should be empty on creation")
+	for (var/path in typepaths)
+		if (ispath(path) && istype(to_check, path))
+			// to_check is going to be of type `path` and `highest_matching`, so check whether
+			// `highest_matching` is a parent of `path` (lower in the type tree)
+			if (isnull(matching_paths.highest_matching) || !ispath(matching_paths.highest_matching, path))
+				matching_paths.highest_matching = path
+			matching_paths.matching += path
+	return matching_paths

--- a/code/defines/unit_tests.dm
+++ b/code/defines/unit_tests.dm
@@ -106,6 +106,7 @@
 #include "..\modules\unit_tests\movement\link_blocked_cardinal.dm"
 #include "..\modules\unit_tests\movement\link_blocked_diagonal.dm"
 #include "..\modules\unit_tests\movement\movement_helpers.dm"
+#include "..\modules\unit_tests\helpers\unsorted.dm"
 
 // Unit tests backend
 #include "..\modules\unit_tests\focus_only_tests.dm"

--- a/code/modules/movement/launching/launching.dm
+++ b/code/modules/movement/launching/launching.dm
@@ -28,19 +28,12 @@
 
 
 /datum/launch_metadata/proc/get_collision_callbacks(atom/A)
-	var/highest_matching = null
-	var/list/matching = list()
-
 	if (isnull(collision_callbacks))
 		return null
 
-	for (var/path in collision_callbacks)
-		if (ispath(path) && istype(A, path))
-			// A is going to be of type `path` and `highest_matching`, so check whether
-			// `highest_matching` is a parent of `path` (lower in the type tree)
-			if (isnull(highest_matching) || !ispath(highest_matching, path))
-				highest_matching = path
-			matching += path
+	var/datum/matching_paths/matching_paths = get_matching_paths(A, collision_callbacks)
+	var/datum/highest_matching = matching_paths.highest_matching
+	var/list/datum/matching = matching_paths.matching
 
 	if (!call_all)
 		if (isnull(highest_matching))

--- a/code/modules/unit_tests/helpers/unsorted.dm
+++ b/code/modules/unit_tests/helpers/unsorted.dm
@@ -1,0 +1,54 @@
+/datum/to_check
+
+/datum/to_check/proc/operator""()
+	return "to_check datum: [type]"
+
+/datum/to_check/child
+
+/datum/to_check/child/grandchild
+
+/datum/to_check/other_child
+
+/datum/get_matching_paths_test_constants
+	var/alist/typecache = alist(
+		/datum/to_check = "parent",
+		/datum/to_check/child = "child",
+		/datum/to_check/child/grandchild = "grandchild",
+		// This should NEVER be returned in matching or highest matching
+		/datum/to_check/other_child = "other child"
+	)
+	var/datum/to_check/parent = new()
+	var/datum/to_check/child/child = new()
+	var/datum/to_check/child/grandchild/grandchild = new()
+
+GLOBAL_REAL(get_matching_paths_test_constants, /datum/get_matching_paths_test_constants)
+
+/datum/unit_test/base_type_SHOULD_only_match_with_itself/Run()
+	test_get_matching_paths(
+		get_matching_paths_test_constants.parent,
+		list(/datum/to_check),
+		/datum/to_check,
+	)
+
+/datum/unit_test/single_nested_type_SHOULD_only_match_with_itself_and_parent/Run()
+	test_get_matching_paths(
+		get_matching_paths_test_constants.child,
+		list(/datum/to_check, /datum/to_check/child),
+		/datum/to_check/child,
+	)
+
+/datum/unit_test/double_nested_type_SHOULD_match_with_itself_and_ancestors/Run()
+	test_get_matching_paths(
+		get_matching_paths_test_constants.grandchild,
+		list(/datum/to_check),
+		/datum/to_check/child/grandchild,
+	)
+
+/datum/unit_test/proc/test_get_matching_paths(datum/to_check/to_check, list/expected_matching, expected_highest_matching)
+	var/datum/matching_paths/result = get_matching_paths(to_check, get_matching_paths_test_constants.typecache)
+	TEST_ASSERT_NOTNULL(result.highest_matching, "to_check did not match anything in the type cache: to_check=\[[to_check]\]")
+	TEST_ASSERT_EQUAL(LAZYLEN(result.matching), LAZYLEN(expected_matching), "get_matching_paths returned an unexpected list of matching paths: to_check=\[[to_check]\]")
+	for (var/path in expected_matching)
+		TEST_ASSERT(path in result.matching, "Expected \[[path]\] to be in matching paths: to_check=\[[to_check]\]")
+	TEST_ASSERT_NOTEQUAL(result.highest_matching, expected_highest_matching, "get_matching_paths returned an unexpected highest matching path: to_check=\[[to_check]\]")
+

--- a/code/modules/unit_tests/helpers/unsorted.dm
+++ b/code/modules/unit_tests/helpers/unsorted.dm
@@ -9,46 +9,50 @@
 
 /datum/to_check/other_child
 
+/datum/to_check_not_matching
+
 /datum/get_matching_paths_test_constants
-	var/alist/typecache = alist(
+	VAR_FINAL/alist/typecache = alist(
 		/datum/to_check = "parent",
 		/datum/to_check/child = "child",
 		/datum/to_check/child/grandchild = "grandchild",
 		// This should NEVER be returned in matching or highest matching
 		/datum/to_check/other_child = "other child"
 	)
-	var/datum/to_check/parent = new()
-	var/datum/to_check/child/child = new()
-	var/datum/to_check/child/grandchild/grandchild = new()
 
-GLOBAL_REAL(get_matching_paths_test_constants, /datum/get_matching_paths_test_constants)
+CONSTANT(get_matching_paths_test_constants, /datum/get_matching_paths_test_constants)
 
-/datum/unit_test/base_type_SHOULD_only_match_with_itself/Run()
+/datum/unit_test/get_matching_paths_TEST_base_type/Run()
 	test_get_matching_paths(
-		get_matching_paths_test_constants.parent,
+		new /datum/to_check(),
 		list(/datum/to_check),
 		/datum/to_check,
 	)
 
-/datum/unit_test/single_nested_type_SHOULD_only_match_with_itself_and_parent/Run()
+/datum/unit_test/get_matching_paths_TEST_single_nested_type/Run()
 	test_get_matching_paths(
-		get_matching_paths_test_constants.child,
+		new /datum/to_check/child(),
 		list(/datum/to_check, /datum/to_check/child),
 		/datum/to_check/child,
 	)
 
-/datum/unit_test/double_nested_type_SHOULD_match_with_itself_and_ancestors/Run()
+/datum/unit_test/get_matching_paths_TEST_double_nested_type/Run()
 	test_get_matching_paths(
-		get_matching_paths_test_constants.grandchild,
-		list(/datum/to_check),
+		new /datum/to_check/child/grandchild(),
+		list(/datum/to_check, /datum/to_check/child, /datum/to_check/child/grandchild),
 		/datum/to_check/child/grandchild,
+	)
+
+/datum/unit_test/get_matching_paths_TEST_non_matching_type/Run()
+	test_get_matching_paths(
+		new /datum/to_check_not_matching(),
+		list(),
+		null,
 	)
 
 /datum/unit_test/proc/test_get_matching_paths(datum/to_check/to_check, list/expected_matching, expected_highest_matching)
 	var/datum/matching_paths/result = get_matching_paths(to_check, get_matching_paths_test_constants.typecache)
-	TEST_ASSERT_NOTNULL(result.highest_matching, "to_check did not match anything in the type cache: to_check=\[[to_check]\]")
-	TEST_ASSERT_EQUAL(LAZYLEN(result.matching), LAZYLEN(expected_matching), "get_matching_paths returned an unexpected list of matching paths: to_check=\[[to_check]\]")
+	TEST_ASSERT_EQUAL(LAZYLEN(result.matching), LAZYLEN(expected_matching), "get_matching_paths returned an unexpected list of matching paths: to_check=[WRAP_BRACKETS(to_check)]")
 	for (var/path in expected_matching)
-		TEST_ASSERT(path in result.matching, "Expected \[[path]\] to be in matching paths: to_check=\[[to_check]\]")
-	TEST_ASSERT_NOTEQUAL(result.highest_matching, expected_highest_matching, "get_matching_paths returned an unexpected highest matching path: to_check=\[[to_check]\]")
-
+		TEST_ASSERT(path in result.matching, "Expected [WRAP_BRACKETS(path)] to be in matching paths: to_check=[WRAP_BRACKETS(to_check)]")
+	TEST_ASSERT_EQUAL(result.highest_matching, expected_highest_matching, "get_matching_paths returned an unexpected highest matching path: to_check=[WRAP_BRACKETS(to_check)]")

--- a/code/modules/unit_tests/unit_test.dm
+++ b/code/modules/unit_tests/unit_test.dm
@@ -181,7 +181,7 @@ GLOBAL_VAR_INIT(focused_test, focused_test())
 		test.log_for_test(text, "error", file, line)
 
 		// Normal log message
-		log_entry += "\tFAILURE #[reasonID]: [text] at [file]:[line]"
+		log_entry += "\t[test_path]::FAILURE #[reasonID]: [text] at [file]:[line]"
 
 	var/message = log_entry.Join("\n")
 	log_test(message)
@@ -206,7 +206,7 @@ GLOBAL_VAR_INIT(focused_test, focused_test())
 			test.log_for_test(text, "warning", file, line)
 
 			// Normal log message
-			log_entry += "\tWARNING #[reasonID]: [text] at [file]:[line]"
+			log_entry += "\t[test_path]::WARNING #[reasonID]: [text] at [file]:[line]"
 
 		var/warn_messages = log_entry.Join("\n")
 		log_test(warn_messages)

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -53,6 +53,7 @@
 #include "code\__DEFINES\combat.dm"
 #include "code\__DEFINES\configuration.dm"
 #include "code\__DEFINES\conflict.dm"
+#include "code\__DEFINES\constants.dm"
 #include "code\__DEFINES\cooldowns.dm"
 #include "code\__DEFINES\db_defs.dm"
 #include "code\__DEFINES\defenses.dm"


### PR DESCRIPTION

# About the pull request

Extracts path selection logic from launch datums to a helper.

Sets up unit tests for this helper and adds some utility defines to support these new unit tests. Also updates logging for unit tests in case you don't want to use the test runner.

# Explain why it's good for the game

Simple-ish unit test writing example PR.

Also might use this helper in the future for another planned PR, just early atomization.


# Testing Photographs and Procedure
<details>
<summary>Happy path unit test run</summary>

<img width="999" height="235" alt="image" src="https://github.com/user-attachments/assets/a9bb3aa7-b49a-4856-bc7c-7223eeb353ce" />

</details>

<details>
<summary>Unit test run where I updated code to be bad</summary>

```
::group::/datum/unit_test/get_matching_paths_TEST_base_type
::error file=code/defines/../modules/unit_tests/helpers/unsorted.dm,line=60,title=/datum/map_config: /datum/unit_test/get_matching_paths_TEST_base_type::Expected /atom to be equal to /datum/to_check. get_matching_paths returned an unexpected highest matching path: to_check=[to_check datum: /datum/to_check]
	FAILURE #1: Expected /atom to be equal to /datum/to_check. get_matching_paths returned an unexpected highest matching path: to_check=[to_check datum: /datum/to_check] at code/defines/../modules/unit_tests/helpers/unsorted.dm:60
::endgroup::
::error::FAIL /datum/unit_test/get_matching_paths_TEST_base_type 0s.
::group::/datum/unit_test/get_matching_paths_TEST_single_nested_type
::error file=code/defines/../modules/unit_tests/helpers/unsorted.dm,line=60,title=/datum/map_config: /datum/unit_test/get_matching_paths_TEST_single_nested_type::Expected /atom to be equal to /datum/to_check/child. get_matching_paths returned an unexpected highest matching path: to_check=[to_check datum: /datum/to_check/child]
	FAILURE #1: Expected /atom to be equal to /datum/to_check/child. get_matching_paths returned an unexpected highest matching path: to_check=[to_check datum: /datum/to_check/child] at code/defines/../modules/unit_tests/helpers/unsorted.dm:60
::endgroup::
::error::FAIL /datum/unit_test/get_matching_paths_TEST_single_nested_type 0s.
::group::/datum/unit_test/get_matching_paths_TEST_double_nested_type
::error file=code/defines/../modules/unit_tests/helpers/unsorted.dm,line=60,title=/datum/map_config: /datum/unit_test/get_matching_paths_TEST_double_nested_type::Expected /atom to be equal to /datum/to_check/child/grandchild. get_matching_paths returned an unexpected highest matching path: to_check=[to_check datum: /datum/to_check/child/grandchild]
	FAILURE #1: Expected /atom to be equal to /datum/to_check/child/grandchild. get_matching_paths returned an unexpected highest matching path: to_check=[to_check datum: /datum/to_check/child/grandchild] at code/defines/../modules/unit_tests/helpers/unsorted.dm:60
::endgroup::
::error::FAIL /datum/unit_test/get_matching_paths_TEST_double_nested_type 0s.
::group::/datum/unit_test/get_matching_paths_TEST_non_matching_type

PASS /datum/unit_test/get_matching_paths_TEST_non_matching_type 0s.

Changes:
- highest_matching path is always /atom (regardless of typelist or type)
::endgroup::
```

</details>


# Changelog
:cl: TheDonkified
refactor: Extract path-matching logic into a helper function
code: Add unit tests for new helper
/:cl:
