### PR TITLE
hybrisa shuttle door fix

### DIFF
--- a/maps/map_files/LV759_Hybrisa_Prospera/LV759_Hybrisa_Prospera.dmm
+++ b/maps/map_files/LV759_Hybrisa_Prospera/LV759_Hybrisa_Prospera.dmm
@@ -146036,7 +146036,8 @@
 	},
 /obj/structure/machinery/door/airlock/multi_tile/almayer/dropshiprear/dropshipside/ds2{
 	id = "sh_dropship2";
-	name = "\improper WY-LWI StarGlider SG-200 airlock"
+	name = "\improper WY-LWI StarGlider SG-200 airlock";
+	dir = 2
 	},
 /turf/open/floor/corsat/officetiles,
 /area/lv759/indoors/spaceport/starglider)


### PR DESCRIPTION

# About the pull request

https://discord.com/channels/150315577943130112/746325498896056329/1534648119147499672
+ fixes hybrisa door dir to match the new icon state

# Explain why it's good for the game

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

<img width="973" height="984" alt="image" src="https://github.com/user-attachments/assets/322b2100-175f-4d98-aa91-1e64b62af789" />

<img width="1044" height="1060" alt="image" src="https://github.com/user-attachments/assets/d7a359de-f547-4d12-b4e1-ab64faada4c6" />


</details>


# Changelog

:cl:
maptweak: changed dir on a door in a shuttle on hybrisa to match the new directions for icon states
/:cl:

