### PR TITLE
Fix lasing stuff

### DIFF
--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -152,10 +152,18 @@
 			return FALSE
 		if(user.sight & SEE_TURFS)
 			var/list/turf/path = get_line(user, targeted_atom, include_start_atom = FALSE)
-			for(var/turf/T in path)
-				if(T.opacity)
+			var/max_distance = 23
+			if(path.len > max_distance)
+				to_chat(user, SPAN_WARNING("Target is too far!"))
+				return FALSE
+			for(var/turf/turf in path)
+				if(turf.opacity)
 					to_chat(user, SPAN_WARNING("There is something in the way of the laser!"))
 					return FALSE
+				for(var/obj/blocker in turf.contents)
+					if(blocker.opacity)
+						to_chat(user, SPAN_WARNING("[blocker] is in the way of the laser!"))
+						return FALSE
 		acquire_target(targeted_atom, user)
 		return TRUE
 	return FALSE

--- a/code/game/objects/structures/blocker.dm
+++ b/code/game/objects/structures/blocker.dm
@@ -54,7 +54,14 @@
 		return INITIALIZE_HINT_QDEL
 
 	dir = pick(CARDINAL_DIRS)
-	QDEL_IN(src, time_to_dispel + rand(-5 SECONDS, 5 SECONDS))
+
+	var/time = time_to_dispel + rand(-5 SECONDS, 5 SECONDS)
+	var/turf/turf = get_turf(src)
+	var/turf_opacity = turf.opacity
+	turf.set_opacity(TRUE)
+
+	addtimer(CALLBACK(turf, TYPE_PROC_REF(/atom, set_opacity), turf_opacity), time)
+	QDEL_IN(src, time)
 
 /obj/structure/blocker/fog/attack_hand(mob/M)
 	to_chat(M, SPAN_NOTICE("You peer through the fog, but it's impossible to tell what's on the other side..."))

--- a/code/game/objects/structures/blocker.dm
+++ b/code/game/objects/structures/blocker.dm
@@ -54,14 +54,7 @@
 		return INITIALIZE_HINT_QDEL
 
 	dir = pick(CARDINAL_DIRS)
-
-	var/time = time_to_dispel + rand(-5 SECONDS, 5 SECONDS)
-	var/turf/turf = get_turf(src)
-	var/turf_opacity = turf.opacity
-	turf.set_opacity(TRUE)
-
-	addtimer(CALLBACK(turf, TYPE_PROC_REF(/atom, set_opacity), turf_opacity), time)
-	QDEL_IN(src, time)
+	QDEL_IN(src, time_to_dispel + rand(-5 SECONDS, 5 SECONDS))
 
 /obj/structure/blocker/fog/attack_hand(mob/M)
 	to_chat(M, SPAN_NOTICE("You peer through the fog, but it's impossible to tell what's on the other side..."))


### PR DESCRIPTION
# About the pull request

Fix #11898 
-Can't laze through fog anymore
-Opaque objects will block lasing. For example doors without glass

Fix #4242
-Can't laze further than your vision in binoculars through camera view

# Explain why it's good for the game

Bug bad, fix good

# Testing Photographs and Procedure
<details>
<summary>NEW Testing video inside</summary>


https://github.com/user-attachments/assets/7c31f150-8ffd-48f0-96c0-6031a1d2fb95



</details>


# Changelog

:cl:labeo0
fix: Cannot use laser designator/rangefinder through fog
fix: Cannot laser through mortar camera beyond your vision
balance: Opaque objects block lasing. Notably thick vines, metal foam, doors with no glass and so on
/:cl:
