### PR TITLE
Fixes boxing glove knockouts

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
@@ -17,9 +17,9 @@
 					fake_attack(src)
 				handle_hallucinations()
 				hallucination -= 2
-			if(2 to 20)
+			if(3 to 20)
 				hallucination -= 2
-			if(0 to 2)
+			if(1 to 3)
 				hallucination = 0
 				halloss = 0
 			if(-INFINITY to 0)


### PR DESCRIPTION

# About the pull request

Fixes #12226 

I know it looks silly how small this change is, but apparently due to a tiny oversight in the recent hallucination refactor, boxing stamina hasnt been working correctly

I have tested this change to be sure it doesnt interfere with any other hallucination systems

# Explain why it's good for the game

Squashing bugs is fun

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Restores the ability to knockout others in a boxing match
/:cl:
