### PR TITLE
Nightmare prefs hotfix

### DIFF
--- a/code/game/jobs/job/civilians/other/survivors.dm
+++ b/code/game/jobs/job/civilians/other/survivors.dm
@@ -90,6 +90,7 @@ GLOBAL_LIST_EMPTY(spawned_survivors)
 		if(LAZYISIN(valid_prefs, spawner.archetype) || (spawner.archetype == INSERT_NONE && spawner.spawn_priority != LOWEST_SPAWN_PRIORITY)) //only add landmarks that match prefs or generic ones with elevated priority (none exist yet)
 			slotted_landmarks[new_player] = spawner
 			available_landmarks -= spawner
+			GLOB.survivor_spawns_by_priority -= spawner
 			return TRUE
 
 	if(insert_present_flag) // There is an insert, but you didn't qualify for ANY spots in it, likely due to disabling most (but not all!) prefs. A shame... a real shame...
@@ -101,6 +102,7 @@ GLOBAL_LIST_EMPTY(spawned_survivors)
 	if(spawner) //if there is a generic spawn, use it
 		slotted_landmarks[new_player] = spawner
 		generic_landmarks -= spawner
+		GLOB.generic_survivor_spawns -= spawner
 		return TRUE
 	return FALSE
 
@@ -266,6 +268,9 @@ AddTimelock(/datum/job/civilian/survivor, list(
 	available_landmarks = list()
 	generic_landmarks = list()
 
+	for(var/obj/effect/landmark/survivor_spawner/spawner as anything in GLOB.generic_survivor_spawns) //make a list of all valid generic spawns
+		generic_landmarks += spawner
+
 	var/hostile_scenario = SSnightmare.get_scenario_is_hostile_survivor()
 	for(var/priority = 1 to LOWEST_SPAWN_PRIORITY)
 		if(length(GLOB.survivor_spawns_by_priority["[priority]"]))
@@ -279,10 +284,6 @@ AddTimelock(/datum/job/civilian/survivor, list(
 	if(!new_player?.client)
 		return FALSE
 
-	for(var/obj/effect/landmark/survivor_spawner/spawner as anything in GLOB.generic_survivor_spawns) //make a list of all valid generic spawns
-		if(spawner.check_can_spawn(new_player))
-			generic_landmarks += spawner
-
 	for(var/obj/effect/landmark/survivor_spawner/spawner as anything in available_landmarks)
 		if(spawner.archetype == INSERT_SYNTH) //only pass synth landmarks
 			// If there's an insert but we don't have the pref, return FALSE
@@ -290,12 +291,15 @@ AddTimelock(/datum/job/civilian/survivor, list(
 				return FALSE
 			slotted_landmarks[new_player] = spawner
 			available_landmarks -= spawner
+			GLOB.survivor_spawns_by_priority -= spawner
 			return TRUE
 
 	// There is no insert, so now we have to assign a random generic spawn
 	var/obj/effect/landmark/survivor_spawner/spawner = SAFEPICK(generic_landmarks)
 	if(spawner) //if there is a generic spawn, use it
 		slotted_landmarks[new_player] = spawner
+		generic_landmarks -= spawner
+		GLOB.generic_survivor_spawns -= spawner
 		return TRUE
 
 	return FALSE
@@ -338,6 +342,10 @@ AddTimelock(/datum/job/civilian/survivor, list(
 	available_landmarks = list()
 	generic_landmarks = list()
 
+	for(var/obj/effect/landmark/survivor_spawner/spawner as anything in GLOB.generic_survivor_spawns) //make a list of all valid generic spawns
+		generic_landmarks += spawner
+
+
 	var/hostile_scenario = SSnightmare.get_scenario_is_hostile_survivor()
 	for(var/priority = 1 to LOWEST_SPAWN_PRIORITY)
 		if(length(GLOB.survivor_spawns_by_priority["[priority]"]))
@@ -351,10 +359,6 @@ AddTimelock(/datum/job/civilian/survivor, list(
 	if(!new_player?.client)
 		return FALSE
 
-	for(var/obj/effect/landmark/survivor_spawner/spawner as anything in GLOB.generic_survivor_spawns) //make a list of all valid generic spawns
-		if(spawner.check_can_spawn(new_player))
-			generic_landmarks += spawner
-
 	//insert CO or map that allowed a CO to roll but has an insert with no CO, spawn as if normal survivor
 	var/list/valid_prefs
 	LAZYINITLIST(valid_prefs)
@@ -366,12 +370,14 @@ AddTimelock(/datum/job/civilian/survivor, list(
 				return FALSE
 			slotted_landmarks[new_player] = spawner
 			available_landmarks -= spawner
+			GLOB.survivor_spawns_by_priority -= spawner
 			return TRUE
 	// There is no insert, so now we have to assign a random generic spawn
-	var/obj/effect/landmark/survivor_spawner/spawner = pick(generic_landmarks)
+	var/obj/effect/landmark/survivor_spawner/spawner = SAFEPICK(generic_landmarks)
 	if(spawner) //if there is a generic spawn, use it
 		slotted_landmarks[new_player] = spawner
 		generic_landmarks -= spawner
+		GLOB.generic_survivor_spawns -= spawner
 		return TRUE
 	return FALSE
 

--- a/code/game/jobs/job/civilians/other/survivors.dm
+++ b/code/game/jobs/job/civilians/other/survivors.dm
@@ -99,7 +99,7 @@ GLOBAL_LIST_EMPTY(spawned_survivors)
 	var/obj/effect/landmark/survivor_spawner/spawner = SAFEPICK(generic_landmarks)
 
 	if(spawner) //if there is a generic spawn, use it
-		generic_landmarks -= spawner
+		slotted_landmarks[new_player] = spawner
 		slotted_landmarks[new_player] = spawner
 		return TRUE
 	return FALSE

--- a/code/game/jobs/job/civilians/other/survivors.dm
+++ b/code/game/jobs/job/civilians/other/survivors.dm
@@ -100,7 +100,7 @@ GLOBAL_LIST_EMPTY(spawned_survivors)
 
 	if(spawner) //if there is a generic spawn, use it
 		slotted_landmarks[new_player] = spawner
-		slotted_landmarks[new_player] = spawner
+		generic_landmarks -= spawner
 		return TRUE
 	return FALSE
 

--- a/code/game/jobs/job/civilians/other/survivors.dm
+++ b/code/game/jobs/job/civilians/other/survivors.dm
@@ -22,6 +22,8 @@ GLOBAL_LIST_EMPTY(spawned_survivors)
 	var/list/available_landmarks
 	/// List of all generic survivor landmarks (INSERT_NONE and lowest priority)
 	var/list/generic_landmarks
+ 	/// Flag to determine if there is an insert, if there is but a player has opted out of too many archetypes, we can know to simply not spawn them.
+	var/insert_present_flag = FALSE
 
 /datum/job/civilian/survivor/set_spawn_positions(count)
 	spawn_positions = clamp((floor(count * SURVIVOR_TO_TOTAL_SPAWN_RATIO)), 2, 8)
@@ -32,10 +34,15 @@ GLOBAL_LIST_EMPTY(spawned_survivors)
 	available_landmarks = list()
 	generic_landmarks = list()
 
+	for(var/obj/effect/landmark/survivor_spawner/spawner as anything in GLOB.generic_survivor_spawns) //make a list of all valid generic spawns
+		generic_landmarks += spawner
+
 	var/hostile_scenario = SSnightmare.get_scenario_is_hostile_survivor()
 	for(var/priority = 1 to LOWEST_SPAWN_PRIORITY)
 		if(length(GLOB.survivor_spawns_by_priority["[priority]"]))
 			for(var/obj/effect/landmark/survivor_spawner/spawner as anything in GLOB.survivor_spawns_by_priority["[priority]"])
+				if(!insert_present_flag && spawner.archetype != INSERT_NONE) //set flag for an insert being present
+					insert_present_flag = TRUE
 				if(spawner.archetype == INSERT_SYNTH) //Don't add synths or COs to normal survivor spawns
 					continue
 				if(spawner.archetype == INSERT_CO)
@@ -70,10 +77,6 @@ GLOBAL_LIST_EMPTY(spawned_survivors)
 	if(!new_player?.client)
 		return FALSE
 
-	for(var/obj/effect/landmark/survivor_spawner/spawner as anything in GLOB.generic_survivor_spawns) //make a list of all valid generic spawns
-		if(spawner.check_can_spawn(new_player))
-			generic_landmarks += spawner
-
 	var/list/valid_prefs
 	LAZYINITLIST(valid_prefs)
 	valid_prefs = get_valid_prefs(new_player)
@@ -82,17 +85,21 @@ GLOBAL_LIST_EMPTY(spawned_survivors)
 		no_insert_archetypes = TRUE
 	for(var/obj/effect/landmark/survivor_spawner/spawner as anything in available_landmarks) // for inserts with a higher than default priority to spawn (all of them)
 		// There is an insert and player has opted out of inserts, return FALSE
-		if(spawner.archetype != INSERT_NONE && no_insert_archetypes)
+		if(no_insert_archetypes && spawner.archetype != INSERT_NONE)
 			return FALSE
 		if(LAZYISIN(valid_prefs, spawner.archetype) || (spawner.archetype == INSERT_NONE && spawner.spawn_priority != LOWEST_SPAWN_PRIORITY)) //only add landmarks that match prefs or generic ones with elevated priority (none exist yet)
 			slotted_landmarks[new_player] = spawner
 			available_landmarks -= spawner
 			return TRUE
 
+	if(insert_present_flag) // There is an insert, but you didn't qualify for ANY spots in it, likely due to disabling most (but not all!) prefs. A shame... a real shame...
+		return FALSE
+
 	// There is no insert, so now we have to assign a random generic spawn
 	var/obj/effect/landmark/survivor_spawner/spawner = SAFEPICK(generic_landmarks)
 
 	if(spawner) //if there is a generic spawn, use it
+		generic_landmarks -= spawner
 		slotted_landmarks[new_player] = spawner
 		return TRUE
 	return FALSE

--- a/code/game/jobs/job/civilians/other/survivors.dm
+++ b/code/game/jobs/job/civilians/other/survivors.dm
@@ -22,7 +22,7 @@ GLOBAL_LIST_EMPTY(spawned_survivors)
 	var/list/available_landmarks
 	/// List of all generic survivor landmarks (INSERT_NONE and lowest priority)
 	var/list/generic_landmarks
- 	/// Flag to determine if there is an insert, if there is but a player has opted out of too many archetypes, we can know to simply not spawn them.
+	/// Flag to determine if there is an insert, if there is but a player has opted out of too many archetypes, we can know to simply not spawn them.
 	var/insert_present_flag = FALSE
 
 /datum/job/civilian/survivor/set_spawn_positions(count)


### PR DESCRIPTION

# About the pull request

Fixes edge case where a player could disable most insert options, which would then cause them to not roll any insert rolls and automatically move onto the generic fallback spawns. Now, if you fail to roll when there is an insert because you disabled most insert options, you will go back to the lobby instead of generic spawning. Also fixes survivors sometimes spawning on top of each other in generic spawns because I was creating the list on a per player basis instead of just once like an idiot. Also now the global lists get updated instead of just the local filtering ones so when role authority moves on to co survs/synth survs the landmarks that were already taken can't be repeated.

Resolves: #12923

# Explain why it's good for the game

bugs bad


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

trust me

</details>


# Changelog
:cl: BOBAMA
fix: generic survivors should no longer spawn during survivor team inserts,  generic survivors should also no longer spawn on top of each other sometimes, and CO survivors should no longer be able to duplicate non-co archetypes.
/:cl:
