### PR TITLE
Forbids reviving DNR'd corpses

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -322,6 +322,10 @@
 	if(revive_target.stat != DEAD)
 		return FALSE
 
+	if(!revive_target.client && !(revive_target.status_flags & FAKESOUL) && !revive_target.get_ghost(FALSE, TRUE))
+		visible_message(SPAN_WARNING("[icon2html(src, viewers(src))] \The [src] buzzes: DNR order detected. Reactivation aborted."))
+		return FALSE
+
 	if(!revive_target.is_revivable())
 		visible_message(SPAN_WARNING("[icon2html(src, viewers(src))] \The [src] buzzes: Synthetic's general condition does not allow reviving."))
 		return FALSE
@@ -341,8 +345,8 @@
 	playsound(get_turf(src), 'sound/mecha/powerup.ogg' , 25, 0)
 	sleep(3 SECONDS)
 
-	if(!revived_target.is_revivable())
-		visible_message(SPAN_WARNING("[icon2html(src, viewers(src))] \The [src] buzzes: Synthetic's general condition does not allow reviving."))
+	if(!check_revive(revived_target))
+		return
 
 	if(!revived_target.client && !(revived_target.status_flags & FAKESOUL)) //Freak case, no client at all. This is a braindead mob (like a colonist)
 		visible_message(SPAN_WARNING("[icon2html(src, viewers(src))] \The [src] buzzes: Non-specific core damage detected, Attempting to re-activate..."))

--- a/code/game/objects/items/devices/defibrillator.dm
+++ b/code/game/objects/items/devices/defibrillator.dm
@@ -173,6 +173,10 @@
 		user.visible_message(SPAN_WARNING("[icon2html(src, viewers(src))] \The [src] buzzes: Vital signs detected. Aborting."))
 		return
 
+	if(!H.client && !(H.status_flags & FAKESOUL) && !H.get_ghost(FALSE, TRUE))
+		user.visible_message(SPAN_WARNING("[icon2html(src, viewers(src))] \The [src] buzzes: DNR order detected. Reactivation aborted."))
+		return
+
 	if(!H.is_revivable())
 		user.visible_message(SPAN_WARNING("[icon2html(src, viewers(src))] \The [src] buzzes: Patient's general condition does not allow reviving."))
 		return
@@ -408,6 +412,10 @@
 		return FALSE
 	if(H.stat != DEAD)
 		user.visible_message(SPAN_WARNING("[icon2html(src, viewers(src))] \The [src] buzzes: Function signs detected. Aborting."))
+		return FALSE
+
+	if(!H.client && !(H.status_flags & FAKESOUL) && !H.get_ghost(FALSE, TRUE))
+		user.visible_message(SPAN_WARNING("[icon2html(src, viewers(src))] \The [src] buzzes: DNR order detected. Resuscitation aborted."))
 		return FALSE
 
 	if(!H.is_revivable())


### PR DESCRIPTION
# About the pull request

Prevents defibrillators, SMART keys, and synth maintenance stations from reviving DNR'd people

# Explain why it's good for the game

DNR is an explicit choice by a player not to be revived and should therefore be respected.

This also fixes a cheesy exploit where a DNR'd corpse could be revived without its player, placed into cryosleep, and used to free the occupied role slot.

# Testing Photographs and Procedure

Tested locally and confirmed all three to work.

# Changelog

:cl:
fix: Defibrillators, SMART  keys, and synth maintenance stations now refuse to revive DNR'd people.
/:cl: