### PR TITLE
Fix: Custom Hotkeys replacing `+` with `Add` 

### DIFF
--- a/code/modules/client/tgui_macro.dm
+++ b/code/modules/client/tgui_macro.dm
@@ -10,6 +10,16 @@ GLOBAL_LIST_EMPTY(ui_data_keybindings)
 			"classic" = kb.classic_keys,
 		))
 
+/proc/keybind_to_keyboardMap(keybind, list/mods)
+	var/list/tempList = list()
+	for(var/i in mods)
+		tempList += GLOB._kbMap[i]
+	if(GLOB._kbMap[keybind])
+		tempList += GLOB._kbMap[keybind]
+	else
+		tempList += keybind
+	return tempList.Join("+")
+
 /datum/tgui_macro
 	var/client/owner
 	var/datum/preferences/prefs
@@ -66,12 +76,6 @@ GLOBAL_LIST_EMPTY(ui_data_keybindings)
 
 			var/old_key = params["old_key"]
 
-			var/mods = sortList(params["key_mods"]).Join("+")
-
-			var/full_key = params["key"]
-			if(mods)
-				full_key = "[mods]+[full_key]"
-
 			if(!params["key"])
 				if(kbinds[old_key])
 					kbinds[old_key] -= kb_name
@@ -82,17 +86,7 @@ GLOBAL_LIST_EMPTY(ui_data_keybindings)
 				prefs.save_preferences()
 				return
 
-			var/list/tempList = list()
-			for(var/i in splittext(full_key, "+"))
-				if(full_key == "+")
-					i = "+" //we split by + so empty means input was +
-					tempList += GLOB._kbMap[i]
-					break
-				if(GLOB._kbMap[i])
-					tempList += GLOB._kbMap[i]
-				else
-					tempList += i
-			full_key = tempList.Join("+")
+			var/full_key = keybind_to_keyboardMap(params["key"], params["key_mods"])
 
 			if(kb_name in kbinds[full_key]) //We pressed the same key combination that was already bound here, so let's remove to re-add and re-sort.
 				kbinds[full_key] -= kb_name
@@ -139,10 +133,9 @@ GLOBAL_LIST_EMPTY(ui_data_keybindings)
 			var/keybind_type = params["keybind_type"]
 			if(!(keybind_type in list(KEYBIND_TYPE_SAY, KEYBIND_TYPE_ME, KEYBIND_TYPE_PICKSAY)))
 				return TRUE
-
-			var/keybind = params["keybind"]
+			var/keybind = keybind_to_keyboardMap(params["key"], params["key_mods"])
 			if(!keybind)
-				return TRUE
+				keybind = params["keybind"]
 
 			var/contents = params["contents"]
 
@@ -167,9 +160,6 @@ GLOBAL_LIST_EMPTY(ui_data_keybindings)
 					if(islist(contents))
 						contents = jointext(contents, ", ")
 					contents = strip_html(contents, MAX_MESSAGE_LEN)
-
-			for(var/i in GLOB._kbMap)
-				keybind = replacetext(keybind, i, GLOB._kbMap[i])
 
 			var/when_human = sanitize_integer(params["when_human"], FALSE, TRUE, TRUE)
 			var/when_xeno = sanitize_integer(params["when_xeno"], FALSE, TRUE, TRUE)

--- a/tgui/packages/tgui/interfaces/KeyBinds.tsx
+++ b/tgui/packages/tgui/interfaces/KeyBinds.tsx
@@ -63,6 +63,8 @@ type Data = {
 
 type CustomKeybind = {
   keybinding?: string;
+  key?: string;
+  key_mods?: string;
   type?: string;
   contents?: string | string[];
   when_xeno?: boolean;
@@ -503,12 +505,16 @@ const CustomKeybinds = (props: {
                   return {
                     ...keybind,
                     keybinding: kb,
+                    key: keys[0],
+                    key_mods: mods,
                   };
                 }
 
                 return {
                   ...pending,
                   keybinding: kb,
+                  key: keys[0],
+                  key_mods: mods,
                 };
               });
             }}
@@ -631,6 +637,8 @@ const CustomKeybinds = (props: {
                 act('set_custom_keybinds', {
                   index: index + 1,
                   keybind: pendingKeybind.keybinding,
+                  key: pendingKeybind.key,
+                  key_mods: pendingKeybind.key_mods,
                   keybind_type: pendingKeybind.type?.toLowerCase(),
                   contents: pendingKeybind.contents,
                   when_xeno: pendingKeybind.when_xeno ?? false,


### PR DESCRIPTION

# About the pull request
<img width="546" height="82" alt="image" src="https://github.com/user-attachments/assets/5fef10ff-7dff-4d40-bf27-c51e0edfb6e9" />

We don't want to do the above cause We need the + to join stuff for the key combos to work.

So I faff around with the key and mod params, giving it to the custom keybind stuff.
Turn the joining into a proc so we don't accidently include replacing the joining character with the keyboard map.

I forgot to record it but it also fixes 
<img width="374" height="108" alt="j3rKogBT0g" src="https://github.com/user-attachments/assets/c8ba6a8a-9d80-448f-8a39-9a8e70d6e599" />
The ARROWUP
Becoming ArrowNorth instead of North etc.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Probably a good idea to have our keybind stuff working...
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://github.com/user-attachments/assets/db0de5fe-e928-4cb4-8bf3-c3b058e01813

</details>


# Changelog
:cl:
fix: Custom Hotkeys saving + as Add, and ARROWUP not being saved as North etc for the arrow keys.
/:cl:
