### PR TITLE
Grammar: SEA Drill hat now properly refers to them as drill instructors

### DIFF
--- a/code/modules/clothing/head/head.dm
+++ b/code/modules/clothing/head/head.dm
@@ -1215,7 +1215,7 @@ GLOBAL_LIST_INIT(allowed_hat_items, list(
 
 /obj/item/clothing/head/drillhat
 	name = "\improper USCM drill hat"
-	desc = "A formal hat worn by drill sergeants. Police that moustache."
+	desc = "A formal hat worn by drill instructors. Police that moustache."
 	icon_state = "drillhat"
 	icon = 'icons/obj/items/clothing/hats/hats_by_faction/UA.dmi'
 	item_icons = list(


### PR DESCRIPTION

# About the pull request

Corrects the description for the SEA-exclusive USCM drill hat from referring to the SEA as a "drill sergeant" to "drill instructor.

# Explain why it's good for the game

Drill sergeants are army, drill instructors are marines.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

# Changelog

:cl: Antlers
spellcheck: The SEA's drill hat now refers to them as drill instructors rather than drill sergeants.
/:cl:

