### PR TITLE
Invasive surgery now slices through obstructing splints

### DIFF
--- a/code/modules/surgery/surgery_steps.dm
+++ b/code/modules/surgery/surgery_steps.dm
@@ -104,6 +104,14 @@ affected_limb, or location vars. Also, in that case there may be a wait between 
 			to_chat(user, SPAN_WARNING("[blocker] [target] is wearing restricts your access to the surgical site, take it off!"))
 			return
 
+	if(surgery_limb.status & LIMB_SPLINTED && surgery.invasiveness != SURGERY_DEPTH_SURFACE)
+		if(surgery_limb.status & LIMB_SPLINTED_INDESTRUCTIBLE)
+			to_chat(user, SPAN_WARNING("The splint [target] is wearing on their [surgery_limb.display_name] restricts your access to the surgical site, and must be manually removed!"))
+			return
+		surgery_limb.status &= ~LIMB_SPLINTED
+		playsound(get_turf(target), 'sound/items/splintbreaks.ogg', 20)
+		user.visible_message(SPAN_DANGER("The splint on [target]'s [surgery_limb.display_name] comes apart!"))
+
 	var/step_duration = time
 	var/self_surgery
 	var/tool_modifier


### PR DESCRIPTION

# About the pull request

Fixes #12889 

Surgical procedures will now instantly slice apart splints without creating a wound on surgery site.

The splint is destroyed in the process, which balances the trade. You can still remove them manually beforehand.

Technically this is a bug fix, since splints should obstruct an invasive surgery, and they havent been.

# Explain why it's good for the game

Bug squashing is fun

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Invasive surgery now slices through splints
/:cl:
