### PR TITLE
Fix: Burn kits not being able to be used on Dropships etc.

### DIFF
--- a/code/__DEFINES/surgery.dm
+++ b/code/__DEFINES/surgery.dm
@@ -69,7 +69,9 @@ unless the surgical tool is completely unsuited to what it's being used for.*/
 ///Tools routinely used to hit people, which wouldn't make sense to give 'you can't open an incision with xyz' messages.
 #define SURGERY_TOOLS_NO_INIT_MSG list(\
 	/obj/item/stack/medical/advanced/bruise_pack,\
+	/obj/item/stack/medical/advanced/ointment,\
 	/obj/item/stack/medical/bruise_pack,\
+	/obj/item/stack/medical/ointment,\
 	/obj/item/tool/kitchen/utensil/fork,\
 	/obj/item/stack/cable_coil,\
 	/obj/item/tool/lighter,\


### PR DESCRIPTION

# About the pull request
Add Burnkits and ointment to the funny list to make things work.
Woe on me for thinking that they were already apart of them
Truly the Ass-of-u-and-me example

Resolves: #12906
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Aaaaaaaaaaaaaaaargh
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Burn kits and ointment are usable again on areas like the dropship
/:cl:
