### PR TITLE
fixes minimap crash when traversing z level inside of an object

### DIFF
--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -622,13 +622,20 @@ SUBSYSTEM_DEF(minimaps)
 /**
  * Simple proc, updates overlay position on the map when a atom moves
  */
-/image/proc/minimap_on_move(atom/movable/source, oldloc)
+/image/proc/minimap_on_move(atom/movable/source, atom/oldloc)
 	SIGNAL_HANDLER
 	if(source.z)
 		var/datum/hud_displays/minimap = SSminimaps.minimaps_by_z["[source.z]"]
 		pixel_x = MINIMAP_PIXEL_FROM_WORLD(source.x) + minimap.x_offset
 		pixel_y = MINIMAP_PIXEL_FROM_WORLD(source.y) + minimap.y_offset
 		return
+
+	var/atom/movable/movable_loc = source.loc // How does none of this just crash if the loc isn't on map?
+	if(oldloc) //if we are not crossing z level inside of a an object
+		source.override_minimap_tracking()
+		var/datum/hud_displays/minimap = SSminimaps.minimaps_by_z["[movable_loc.z]"]
+		pixel_x = MINIMAP_PIXEL_FROM_WORLD(movable_loc.x) + minimap.x_offset
+		pixel_y = MINIMAP_PIXEL_FROM_WORLD(movable_loc.y) + minimap.y_offset
 
 ///Used to handle minimap tracking inside other movables
 /atom/movable/proc/override_minimap_tracking()

--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -630,12 +630,6 @@ SUBSYSTEM_DEF(minimaps)
 		pixel_y = MINIMAP_PIXEL_FROM_WORLD(source.y) + minimap.y_offset
 		return
 
-	var/atom/movable/movable_loc = source.loc // How does none of this just crash if the loc isn't on map?
-	source.override_minimap_tracking()
-	var/datum/hud_displays/minimap = SSminimaps.minimaps_by_z["[movable_loc.z]"]
-	pixel_x = MINIMAP_PIXEL_FROM_WORLD(movable_loc.x) + minimap.x_offset
-	pixel_y = MINIMAP_PIXEL_FROM_WORLD(movable_loc.y) + minimap.y_offset
-
 ///Used to handle minimap tracking inside other movables
 /atom/movable/proc/override_minimap_tracking()
 	var/image/blip = SSminimaps.images_by_source[src]


### PR DESCRIPTION

# About the pull request

fixes the crash when traversing z level inside of bodybag or multiz pipe. I could not find any inconsistency caused by removing this part of code. checked that moving people in bags still updates them on minimap

# Explain why it's good for the game

fixes crash on pipes and bags


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: fixes runtime caused by crossing z levels using pipes and bodybags
/:cl:
