### PR TITLE
Fix stacking/unstacking when acided

### DIFF
--- a/code/__DEFINES/dcs/signals/atom/signals_item.dm
+++ b/code/__DEFINES/dcs/signals/atom/signals_item.dm
@@ -28,7 +28,6 @@
 #define COMSIG_SNACK_EATEN "snack_eaten"
 
 #define COMSIG_ITEM_PICKUP "item_pickup"
-	#define COMSIG_ITEM_PICKUP_CANCELLED (1<<0)
 
 ///from /obj/item/device/broadcasting
 #define COMSIG_BROADCAST_GO_LIVE "broadcast_live"

--- a/code/__DEFINES/dcs/signals/atom/signals_movable.dm
+++ b/code/__DEFINES/dcs/signals/atom/signals_movable.dm
@@ -19,6 +19,9 @@
 #define COMSIG_MOVABLE_XENO_START_PULLING "movable_xeno_start_pulling"
 	#define COMPONENT_ALLOW_PULL (1<<0)
 
+#define COMSIG_MOVABLE_PRE_PICKUP "movable_pre_pickup"
+	#define COMPONENT_PICKUP_CANCELED_ACID (1<<0)
+
 #define COMSIG_MOVABLE_PULLED "movable_pulled"
 	#define COMPONENT_IGNORE_ANCHORED (1<<0)
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -548,3 +548,11 @@
 		return NO_BLOCKED_MOVEMENT
 
 	return ..()
+
+/**
+ * Sends the COMSIG_MOVABLE_PRE_PICKUP signal and returns the bitfield result.
+ *
+ * Returns NONE if the pickup should be allowed, otherwise the bitfield canceled reason(s) (e.g. COMPONENT_PICKUP_CANCELED_ACID)
+ */
+/atom/movable/proc/check_pickup_blocked(mob/user)
+	return SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_PICKUP, user)

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -373,7 +373,7 @@
 			ticks_left = 10
 	handle_weather()
 	RegisterSignal(SSdcs, COMSIG_GLOB_WEATHER_CHANGE, PROC_REF(handle_weather))
-	RegisterSignal(acid_t, COMSIG_ITEM_PICKUP, PROC_REF(attempt_pickup))
+	RegisterSignal(acid_t, COMSIG_MOVABLE_PRE_PICKUP, PROC_REF(attempt_pickup))
 	RegisterSignal(acid_t, COMSIG_MOVABLE_MOVED, PROC_REF(move_acid))
 	RegisterSignal(acid_t, COMSIG_PARENT_QDELETING, PROC_REF(cleanup))
 	START_PROCESSING(SSoldeffects, src)
@@ -396,10 +396,10 @@
 		return
 	forceMove(new_loc)
 
-/// Called by COMSIG_ITEM_PICKUP when an item is attempted to be picked up but has acid
+/// Called by COMSIG_MOVABLE_PRE_PICKUP to signal that acid_t can't be picked up because of acid
 /obj/effect/xenomorph/acid/proc/attempt_pickup()
 	SIGNAL_HANDLER
-	return COMSIG_ITEM_PICKUP_CANCELLED
+	return COMPONENT_PICKUP_CANCELED_ACID
 
 /obj/effect/xenomorph/acid/proc/handle_weather()
 	SIGNAL_HANDLER

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -405,11 +405,12 @@
 /// Called just as an item is picked up (loc is not yet changed) and will return TRUE if the pickup wasn't canceled.
 /obj/item/proc/pickup(mob/user, silent)
 	SHOULD_CALL_PARENT(TRUE)
-	if((SEND_SIGNAL(src, COMSIG_ITEM_PICKUP, user)) & COMSIG_ITEM_PICKUP_CANCELLED)
+	if(check_pickup_blocked(user))
 		if(!silent)
 			to_chat(user, SPAN_WARNING("Can't pick [src] up!"))
 			balloon_alert(user, "can't pick up")
 		return FALSE
+	SEND_SIGNAL(src, COMSIG_ITEM_PICKUP, user)
 	SEND_SIGNAL(user, COMSIG_MOB_PICKUP_ITEM, src)
 	setDir(SOUTH)//Always rotate it south. This resets it to default position, so you wouldn't be putting things on backwards
 	if(pickup_sound && !silent && src.loc?.z)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -416,11 +416,15 @@ Also change the icon to reflect the amount of sheets, if possible.*/
 			return
 		if(amount <= 1)
 			return
+		if((SEND_SIGNAL(src, COMSIG_ITEM_PICKUP, user)) & COMSIG_ITEM_PICKUP_CANCELLED) //acided
+			to_chat(user, SPAN_WARNING("[src] is covered in acid!"))
+			balloon_alert(user, "its covered in acid!")
+			return TRUE
 		var/desired = tgui_input_number(user, "How much would you like to split off from this stack?", "How much?", 1, amount-1, 1)
 		if(!desired)
-			return
+			return TRUE
 		if(!use(desired))
-			return
+			return TRUE
 		var/obj/item/stack/newstack = new type(user, desired)
 		transfer_fingerprints_to(newstack)
 		user.put_in_hands(newstack)
@@ -484,6 +488,11 @@ Also change the icon to reflect the amount of sheets, if possible.*/
 /obj/item/stack/attackby(obj/item/stack/used_stack, mob/user)
 	if(!istype(used_stack) || used_stack.stack_id != stack_id) //not the same stack type :)
 		return ..()
+
+	if((SEND_SIGNAL(src, COMSIG_ITEM_PICKUP, user)) & COMSIG_ITEM_PICKUP_CANCELLED) //acided
+		to_chat(user, SPAN_WARNING("[src] is covered in acid!"))
+		balloon_alert(user, "its covered in acid!")
+		return
 
 	if(used_stack.amount >= max_amount)
 		to_chat(user, SPAN_WARNING("The [name] is full!"))

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -416,7 +416,7 @@ Also change the icon to reflect the amount of sheets, if possible.*/
 			return
 		if(amount <= 1)
 			return
-		if((SEND_SIGNAL(src, COMSIG_ITEM_PICKUP, user)) & COMSIG_ITEM_PICKUP_CANCELLED) //acided
+		if(check_pickup_blocked(user) & COMPONENT_PICKUP_CANCELED_ACID) //acided
 			to_chat(user, SPAN_WARNING("[src] is covered in acid!"))
 			balloon_alert(user, "its covered in acid!")
 			return TRUE
@@ -489,7 +489,7 @@ Also change the icon to reflect the amount of sheets, if possible.*/
 	if(!istype(used_stack) || used_stack.stack_id != stack_id) //not the same stack type :)
 		return ..()
 
-	if((SEND_SIGNAL(src, COMSIG_ITEM_PICKUP, user)) & COMSIG_ITEM_PICKUP_CANCELLED) //acided
+	if(check_pickup_blocked(user) & COMPONENT_PICKUP_CANCELED_ACID) //acided
 		to_chat(user, SPAN_WARNING("[src] is covered in acid!"))
 		balloon_alert(user, "its covered in acid!")
 		return TRUE

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -492,13 +492,13 @@ Also change the icon to reflect the amount of sheets, if possible.*/
 	if((SEND_SIGNAL(src, COMSIG_ITEM_PICKUP, user)) & COMSIG_ITEM_PICKUP_CANCELLED) //acided
 		to_chat(user, SPAN_WARNING("[src] is covered in acid!"))
 		balloon_alert(user, "its covered in acid!")
-		return
+		return TRUE
 
 	if(used_stack.amount >= max_amount)
 		to_chat(user, SPAN_WARNING("The [name] is full!"))
 		return TRUE
-	var/to_transfer = min(amount, used_stack.max_amount - used_stack.amount)
 
+	var/to_transfer = min(amount, used_stack.max_amount - used_stack.amount)
 	if(to_transfer <= 0)
 		return
 

--- a/code/modules/cm_marines/dropship_equipment.dm
+++ b/code/modules/cm_marines/dropship_equipment.dm
@@ -69,7 +69,7 @@
 
 /obj/structure/dropship_equipment/attackby(obj/item/item, mob/user)
 	if(istype(item, /obj/item/powerloader_clamp))
-		if((SEND_SIGNAL(src, COMSIG_ITEM_PICKUP, user)) & COMSIG_ITEM_PICKUP_CANCELLED) //acided
+		if(check_pickup_blocked(user) & COMPONENT_PICKUP_CANCELED_ACID) //acided
 			to_chat(user, SPAN_WARNING("[src] is covered in acid!"))
 			balloon_alert(user, "its covered in acid!")
 			return


### PR DESCRIPTION

# About the pull request

This PR simply adds some additional checks to prevent stacking/unstacking when the stack on the ground is covered in acid. Leme know if there's more interactions than this.

To fix the confusion with signals `COMSIG_ITEM_PICKUP` now fires if an item is picked up and `COMSIG_MOVABLE_PRE_PICKUP` is sent in `check_pickup_blocked` which now `/obj/effect/xenomorph/acid` uses to signal `COMPONENT_PICKUP_CANCELED_ACID` to indicate the pickup should not be allowed.

# Explain why it's good for the game

Fixes #11356

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

https://youtu.be/F5oKIjn8UpU

</details>


# Changelog
:cl: Drathek
fix: Fixed an exploit where you could stack/unstack acided things on the ground
code: COMSIG_ITEM_PICKUP now fires properly on pickup and COMSIG_MOVABLE_PRE_PICKUP is used to check if pickup/interaction is allowed
/:cl:
