### PR TITLE
Sentinel Oxy Damage Bugfix

### DIFF
--- a/code/datums/effects/xeno_strains/sentinel_neuro_stacks.dm
+++ b/code/datums/effects/xeno_strains/sentinel_neuro_stacks.dm
@@ -16,7 +16,7 @@
 	///how much oxy damage should be given per process
 	var/proc_damage_per_stack = 0.2
 	///stopgrap for oxy damage on mob when this stops causing harm
-	var/max_oxyloss = 50
+	var/max_oxyloss = 20
 	///particles
 	var/obj/effect/abstract/particle_holder/particle_holder
 


### PR DESCRIPTION


# About the pull request
Fixes the Sentinel's maximum oxygen damage from 50 to 20, as is stated in its own PR.

# Explain why it's good for the game
50 oxy damage is incredibly debilitating for a tier one caste to be able to dish out at range with little to no risk to itself. Also it aligns with the PR.


# Testing Photographs and Procedure
N/A




# Changelog



:cl:
fix: Sentinel Oxygen Damage Cap adjusted from 50 to 20, as intended in original PR.
/:cl:


