### PR TITLE
Add multitile vehicles force field for LV522 Chances Claim

### DIFF
--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -1311,6 +1311,15 @@
 /obj/effect/landmark/survivor_spawner/lv522_forecon_synth,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/lv522/indoors/a_block/admin)
+"aeB" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/turf/closed/wall/strata_outpost/reinforced,
+/area/lv522/atmos/way_in_command_centre)
+"aeC" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/turf/closed/wall/strata_outpost/reinforced,
+/area/lv522/atmos/east_reactor/south)
 "aeD" = (
 /obj/structure/largecrate/random,
 /obj/effect/decal/cleanable/dirt,
@@ -1322,6 +1331,27 @@
 	},
 /turf/open/floor/prison/darkbrownfull2,
 /area/lv522/indoors/c_block/mining)
+"aeE" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/turf/closed/wall/strata_outpost/reinforced,
+/area/lv522/atmos/east_reactor/south)
+"aeF" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/turf/closed/wall/strata_outpost/reinforced,
+/area/lv522/atmos/way_in_command_centre)
+"aeG" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/turf/closed/wall/strata_outpost/reinforced,
+/area/lv522/atmos/filt)
+"aeH" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/turf/open/floor/corsat,
+/area/lv522/atmos/cargo_intake)
+"aeI" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/turf/closed/wall/strata_outpost/reinforced,
+/area/lv522/atmos/cargo_intake)
 "aff" = (
 /obj/structure/platform_decoration/metal/almayer/west,
 /obj/effect/decal/warning_stripes{
@@ -2010,10 +2040,6 @@
 	},
 /turf/open/floor/plating,
 /area/lv522/outdoors/colony_streets/north_east_street)
-"aDx" = (
-/obj/structure/blocker/forcefield/multitile_vehicles,
-/turf/closed/wall/strata_outpost/reinforced,
-/area/lv522/atmos/filt)
 "aDE" = (
 /obj/docking_port/stationary/marine_dropship/lz2{
 	name = "LZ2: Southeast Landing Zone"
@@ -11765,11 +11791,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/dorms)
-"gdw" = (
-/obj/structure/blocker/forcefield/multitile_vehicles,
-/obj/structure/blocker/forcefield/multitile_vehicles,
-/turf/closed/wall/strata_outpost/reinforced,
-/area/lv522/atmos/way_in_command_centre)
 "gdA" = (
 /obj/structure/barricade/deployable,
 /obj/effect/decal/cleanable/dirt,
@@ -14367,10 +14388,6 @@
 /obj/effect/landmark/objective_landmark/science,
 /turf/open/floor/strata/white_cyan1/east,
 /area/lv522/indoors/a_block/medical)
-"hBH" = (
-/obj/structure/blocker/forcefield/multitile_vehicles,
-/turf/closed/wall/strata_outpost/reinforced,
-/area/lv522/atmos/east_reactor/south)
 "hCi" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 9
@@ -14438,10 +14455,6 @@
 	},
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/central_streets)
-"hDM" = (
-/obj/structure/blocker/forcefield/multitile_vehicles,
-/turf/open/floor/corsat,
-/area/lv522/atmos/cargo_intake)
 "hDZ" = (
 /obj/structure/window_frame/strata,
 /obj/item/shard{
@@ -18248,10 +18261,6 @@
 /obj/structure/largecrate/random,
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/mining)
-"jGD" = (
-/obj/structure/blocker/forcefield/multitile_vehicles,
-/turf/closed/wall/strata_outpost/reinforced,
-/area/lv522/atmos/cargo_intake)
 "jGK" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/auto_turf/shale/layer1,
@@ -26427,10 +26436,6 @@
 	},
 /turf/open/floor/plating,
 /area/lv522/landing_zone_forecon/UD6_Tornado)
-"nPU" = (
-/obj/structure/blocker/forcefield/multitile_vehicles,
-/turf/closed/wall/strata_outpost/reinforced,
-/area/lv522/atmos/way_in_command_centre)
 "nPV" = (
 /turf/open/asphalt/cement/cement2,
 /area/lv522/outdoors/colony_streets/north_street)
@@ -31499,11 +31504,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/lv522/indoors/c_block/casino)
-"qAv" = (
-/obj/structure/blocker/forcefield/multitile_vehicles,
-/obj/structure/blocker/forcefield/multitile_vehicles,
-/turf/closed/wall/strata_outpost/reinforced,
-/area/lv522/atmos/east_reactor/south)
 "qAy" = (
 /obj/item/toy/beach_ball,
 /turf/open/floor/prison/floor_plate,
@@ -56871,7 +56871,7 @@ ijv
 eyM
 iTX
 ePK
-jGD
+aeI
 ePK
 auG
 gat
@@ -58107,7 +58107,7 @@ dAG
 jmW
 iTX
 iTX
-jGD
+aeI
 fol
 fGh
 fYP
@@ -58313,7 +58313,7 @@ iEq
 eAz
 iTX
 ePK
-jGD
+aeI
 ePK
 fGH
 bcU
@@ -63256,7 +63256,7 @@ dXX
 saC
 saC
 saC
-hDM
+aeH
 iAv
 mEG
 alx
@@ -63462,7 +63462,7 @@ saC
 saC
 saC
 wBR
-hDM
+aeH
 iAv
 fsV
 fLA
@@ -63668,7 +63668,7 @@ saC
 saC
 oXk
 wBR
-hDM
+aeH
 rKS
 qqJ
 urp
@@ -64080,7 +64080,7 @@ saC
 saC
 oXk
 wBR
-hDM
+aeH
 rKS
 fuf
 qqJ
@@ -64287,7 +64287,7 @@ iyE
 eGs
 rdf
 xXV
-hDM
+aeH
 rKS
 rKS
 iAv
@@ -64494,9 +64494,9 @@ nMl
 wBR
 eUs
 xXV
-hDM
+aeH
 rvg
-hDM
+aeH
 iAv
 iAv
 iAv
@@ -66354,7 +66354,7 @@ aaW
 aaW
 aaU
 wGq
-nPU
+aeF
 tnN
 hKK
 lzb
@@ -66560,7 +66560,7 @@ qjG
 qjG
 qjG
 wGq
-nPU
+aeF
 dNe
 hMb
 lzb
@@ -66766,7 +66766,7 @@ qjG
 qjG
 oeU
 mkh
-nPU
+aeF
 tnN
 hNf
 sLc
@@ -66972,7 +66972,7 @@ iGl
 qjG
 qjG
 mkh
-nPU
+aeF
 oUq
 qpy
 vnX
@@ -68413,19 +68413,19 @@ qjG
 saC
 saC
 saC
-nPU
-nPU
+aeF
+aeF
 qHD
 hPq
 hPq
 iGM
 hPq
-nPU
-nPU
-nPU
-nPU
-nPU
-gdw
+aeF
+aeF
+aeF
+aeF
+aeF
+aeB
 yjp
 sOe
 uhF
@@ -68631,7 +68631,7 @@ jFG
 xZE
 xZE
 xZE
-hBH
+aeC
 men
 wrC
 kZe
@@ -68837,7 +68837,7 @@ nMC
 nNi
 kco
 xZE
-hBH
+aeC
 xZE
 wrC
 wrC
@@ -69043,7 +69043,7 @@ nMT
 nOg
 kdf
 xZE
-hBH
+aeC
 xZE
 xZE
 wrC
@@ -69249,7 +69249,7 @@ nNf
 yld
 kdL
 xZE
-hBH
+aeC
 dHF
 dHF
 dHF
@@ -69455,7 +69455,7 @@ nNf
 yld
 kel
 xZE
-hBH
+aeC
 vGp
 qSH
 qSH
@@ -69661,7 +69661,7 @@ jJa
 jWZ
 yaC
 xZE
-hBH
+aeC
 spy
 qnS
 uRL
@@ -69867,7 +69867,7 @@ faK
 fwo
 hQU
 xZE
-hBH
+aeC
 nQQ
 qSH
 trV
@@ -70073,7 +70073,7 @@ faZ
 jXp
 jlh
 xZE
-hBH
+aeC
 jGa
 qSH
 adz
@@ -70279,7 +70279,7 @@ faZ
 jYj
 tiQ
 xZE
-hBH
+aeC
 xZE
 qSH
 trV
@@ -70485,7 +70485,7 @@ faZ
 yaC
 kgb
 xZE
-hBH
+aeC
 kKD
 qSH
 trV
@@ -70691,7 +70691,7 @@ jJj
 jYu
 kdf
 xZE
-hBH
+aeC
 jOw
 qSH
 trV
@@ -70897,7 +70897,7 @@ jJa
 kaQ
 sfc
 xZE
-hBH
+aeC
 xZE
 qSH
 trV
@@ -71103,7 +71103,7 @@ nNf
 yld
 yaC
 xZE
-hBH
+aeC
 kdx
 vGp
 trV
@@ -71309,7 +71309,7 @@ nNf
 qjG
 kgm
 xZE
-hBH
+aeC
 svK
 sRI
 trV
@@ -71515,7 +71515,7 @@ jJI
 fwo
 khG
 xZE
-hBH
+aeC
 xZE
 isa
 trV
@@ -71721,7 +71721,7 @@ hSO
 yaC
 kiT
 xZE
-hBH
+aeC
 iel
 svK
 trV
@@ -71927,7 +71927,7 @@ xZE
 xZE
 xZE
 xZE
-hBH
+aeC
 sRI
 vGp
 trV
@@ -72133,7 +72133,7 @@ xZE
 xZE
 xZE
 xZE
-hBH
+aeC
 xZE
 isa
 trV
@@ -72339,7 +72339,7 @@ xZE
 xZE
 xZE
 xZE
-hBH
+aeC
 tNQ
 vGp
 trV
@@ -72540,12 +72540,12 @@ hSi
 xZE
 xZE
 xZE
-qAv
-hBH
-hBH
-hBH
-hBH
-qAv
+aeE
+aeC
+aeC
+aeC
+aeC
+aeE
 vTx
 vTx
 trV
@@ -72746,7 +72746,7 @@ aaK
 xZE
 xZE
 xZE
-hBH
+aeC
 xZE
 wDj
 wDj
@@ -72952,7 +72952,7 @@ yaC
 xZE
 xZE
 xZE
-hBH
+aeC
 wDj
 nJV
 elX
@@ -73158,7 +73158,7 @@ yaC
 xZE
 xZE
 xZE
-hBH
+aeC
 wDj
 aJS
 ezo
@@ -73364,7 +73364,7 @@ yaC
 xZE
 xZE
 xZE
-hBH
+aeC
 wDj
 cPg
 eJR
@@ -74600,7 +74600,7 @@ xZE
 xZE
 xZE
 xZE
-hBH
+aeC
 wDj
 rhh
 rtX
@@ -76646,14 +76646,14 @@ cpy
 cpy
 cpy
 cpy
-aDx
+aeG
 acQ
 fzK
 fzK
 fzK
 fzK
-aDx
-aDx
+aeG
+aeG
 cpy
 ien
 cpy

--- a/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
+++ b/maps/map_files/LV522_Chances_Claim/LV522_Chances_Claim.dmm
@@ -386,11 +386,13 @@
 /area/lv522/outdoors/nw_rockies)
 "abu" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/floor/corsat/marked,
 /area/lv522/atmos/cargo_intake)
 "abv" = (
 /obj/structure/pipes/standard/simple/hidden/green,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_door,
+/obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/floor/corsat/marked,
 /area/lv522/atmos/cargo_intake)
 "abw" = (
@@ -726,6 +728,7 @@
 /obj/structure/machinery/door_control/brbutton{
 	id = "Reactor_e_entry_4"
 	},
+/obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/closed/wall/strata_outpost/reinforced,
 /area/lv522/atmos/filt)
 "acR" = (
@@ -2007,6 +2010,10 @@
 	},
 /turf/open/floor/plating,
 /area/lv522/outdoors/colony_streets/north_east_street)
+"aDx" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/turf/closed/wall/strata_outpost/reinforced,
+/area/lv522/atmos/filt)
 "aDE" = (
 /obj/docking_port/stationary/marine_dropship/lz2{
 	name = "LZ2: Southeast Landing Zone"
@@ -9928,6 +9935,7 @@
 /area/lv522/outdoors/colony_streets/south_east_street)
 "eZq" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/closed/wall/strata_outpost/reinforced,
 /area/lv522/atmos/cargo_intake)
 "eZC" = (
@@ -10778,6 +10786,7 @@
 	dir = 4;
 	id = "Reactor_e_entry_4"
 	},
+/obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/floor/corsat/marked,
 /area/lv522/atmos/filt)
 "fzV" = (
@@ -11756,6 +11765,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/lv522/indoors/a_block/dorms)
+"gdw" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/turf/closed/wall/strata_outpost/reinforced,
+/area/lv522/atmos/way_in_command_centre)
 "gdA" = (
 /obj/structure/barricade/deployable,
 /obj/effect/decal/cleanable/dirt,
@@ -14353,6 +14367,10 @@
 /obj/effect/landmark/objective_landmark/science,
 /turf/open/floor/strata/white_cyan1/east,
 /area/lv522/indoors/a_block/medical)
+"hBH" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/turf/closed/wall/strata_outpost/reinforced,
+/area/lv522/atmos/east_reactor/south)
 "hCi" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 9
@@ -14420,6 +14438,10 @@
 	},
 /turf/open/auto_turf/shale/layer1,
 /area/lv522/outdoors/colony_streets/central_streets)
+"hDM" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/turf/open/floor/corsat,
+/area/lv522/atmos/cargo_intake)
 "hDZ" = (
 /obj/structure/window_frame/strata,
 /obj/item/shard{
@@ -14852,6 +14874,7 @@
 	dir = 4;
 	id = "Reactor_entry_2"
 	},
+/obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/floor/corsat/marked,
 /area/lv522/atmos/way_in_command_centre)
 "hPI" = (
@@ -16270,6 +16293,7 @@
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
 	},
+/obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/floor/corsat/marked,
 /area/lv522/atmos/way_in_command_centre)
 "iGQ" = (
@@ -18224,6 +18248,10 @@
 /obj/structure/largecrate/random,
 /turf/open/floor/plating,
 /area/lv522/indoors/c_block/mining)
+"jGD" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/turf/closed/wall/strata_outpost/reinforced,
+/area/lv522/atmos/cargo_intake)
 "jGK" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/auto_turf/shale/layer1,
@@ -26399,6 +26427,10 @@
 	},
 /turf/open/floor/plating,
 /area/lv522/landing_zone_forecon/UD6_Tornado)
+"nPU" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/turf/closed/wall/strata_outpost/reinforced,
+/area/lv522/atmos/way_in_command_centre)
 "nPV" = (
 /turf/open/asphalt/cement/cement2,
 /area/lv522/outdoors/colony_streets/north_street)
@@ -31467,6 +31499,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/lv522/indoors/c_block/casino)
+"qAv" = (
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/obj/structure/blocker/forcefield/multitile_vehicles,
+/turf/closed/wall/strata_outpost/reinforced,
+/area/lv522/atmos/east_reactor/south)
 "qAy" = (
 /obj/item/toy/beach_ball,
 /turf/open/floor/prison/floor_plate,
@@ -31824,6 +31861,7 @@
 /obj/structure/machinery/door_control/brbutton{
 	id = "Reactor_entry_2"
 	},
+/obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/closed/wall/r_wall/biodome/biodome_unmeltable,
 /area/lv522/oob)
 "qHI" = (
@@ -33622,6 +33660,7 @@
 /area/lv522/indoors/a_block/medical)
 "rvg" = (
 /obj/item/stack/sheet/metal,
+/obj/structure/blocker/forcefield/multitile_vehicles,
 /turf/open/floor/corsat,
 /area/lv522/atmos/cargo_intake)
 "rvh" = (
@@ -56832,7 +56871,7 @@ ijv
 eyM
 iTX
 ePK
-ePK
+jGD
 ePK
 auG
 gat
@@ -58068,7 +58107,7 @@ dAG
 jmW
 iTX
 iTX
-ePK
+jGD
 fol
 fGh
 fYP
@@ -58274,7 +58313,7 @@ iEq
 eAz
 iTX
 ePK
-ePK
+jGD
 ePK
 fGH
 bcU
@@ -63217,7 +63256,7 @@ dXX
 saC
 saC
 saC
-xXV
+hDM
 iAv
 mEG
 alx
@@ -63423,7 +63462,7 @@ saC
 saC
 saC
 wBR
-xXV
+hDM
 iAv
 fsV
 fLA
@@ -63629,7 +63668,7 @@ saC
 saC
 oXk
 wBR
-xXV
+hDM
 rKS
 qqJ
 urp
@@ -64041,7 +64080,7 @@ saC
 saC
 oXk
 wBR
-xXV
+hDM
 rKS
 fuf
 qqJ
@@ -64248,7 +64287,7 @@ iyE
 eGs
 rdf
 xXV
-xXV
+hDM
 rKS
 rKS
 iAv
@@ -64455,9 +64494,9 @@ nMl
 wBR
 eUs
 xXV
-xXV
+hDM
 rvg
-xXV
+hDM
 iAv
 iAv
 iAv
@@ -66315,7 +66354,7 @@ aaW
 aaW
 aaU
 wGq
-oUq
+nPU
 tnN
 hKK
 lzb
@@ -66521,7 +66560,7 @@ qjG
 qjG
 qjG
 wGq
-oUq
+nPU
 dNe
 hMb
 lzb
@@ -66727,7 +66766,7 @@ qjG
 qjG
 oeU
 mkh
-oUq
+nPU
 tnN
 hNf
 sLc
@@ -66933,7 +66972,7 @@ iGl
 qjG
 qjG
 mkh
-oUq
+nPU
 oUq
 qpy
 vnX
@@ -68374,19 +68413,19 @@ qjG
 saC
 saC
 saC
-oUq
-oUq
+nPU
+nPU
 qHD
 hPq
 hPq
 iGM
 hPq
-oUq
-oUq
-oUq
-oUq
-oUq
-oUq
+nPU
+nPU
+nPU
+nPU
+nPU
+gdw
 yjp
 sOe
 uhF
@@ -68592,7 +68631,7 @@ jFG
 xZE
 xZE
 xZE
-xZE
+hBH
 men
 wrC
 kZe
@@ -68798,7 +68837,7 @@ nMC
 nNi
 kco
 xZE
-xZE
+hBH
 xZE
 wrC
 wrC
@@ -69004,7 +69043,7 @@ nMT
 nOg
 kdf
 xZE
-xZE
+hBH
 xZE
 xZE
 wrC
@@ -69210,7 +69249,7 @@ nNf
 yld
 kdL
 xZE
-xZE
+hBH
 dHF
 dHF
 dHF
@@ -69416,7 +69455,7 @@ nNf
 yld
 kel
 xZE
-xZE
+hBH
 vGp
 qSH
 qSH
@@ -69622,7 +69661,7 @@ jJa
 jWZ
 yaC
 xZE
-xZE
+hBH
 spy
 qnS
 uRL
@@ -69828,7 +69867,7 @@ faK
 fwo
 hQU
 xZE
-xZE
+hBH
 nQQ
 qSH
 trV
@@ -70034,7 +70073,7 @@ faZ
 jXp
 jlh
 xZE
-xZE
+hBH
 jGa
 qSH
 adz
@@ -70240,7 +70279,7 @@ faZ
 jYj
 tiQ
 xZE
-xZE
+hBH
 xZE
 qSH
 trV
@@ -70446,7 +70485,7 @@ faZ
 yaC
 kgb
 xZE
-xZE
+hBH
 kKD
 qSH
 trV
@@ -70652,7 +70691,7 @@ jJj
 jYu
 kdf
 xZE
-xZE
+hBH
 jOw
 qSH
 trV
@@ -70858,7 +70897,7 @@ jJa
 kaQ
 sfc
 xZE
-xZE
+hBH
 xZE
 qSH
 trV
@@ -71064,7 +71103,7 @@ nNf
 yld
 yaC
 xZE
-xZE
+hBH
 kdx
 vGp
 trV
@@ -71270,7 +71309,7 @@ nNf
 qjG
 kgm
 xZE
-xZE
+hBH
 svK
 sRI
 trV
@@ -71476,7 +71515,7 @@ jJI
 fwo
 khG
 xZE
-xZE
+hBH
 xZE
 isa
 trV
@@ -71682,7 +71721,7 @@ hSO
 yaC
 kiT
 xZE
-xZE
+hBH
 iel
 svK
 trV
@@ -71888,7 +71927,7 @@ xZE
 xZE
 xZE
 xZE
-xZE
+hBH
 sRI
 vGp
 trV
@@ -72094,7 +72133,7 @@ xZE
 xZE
 xZE
 xZE
-xZE
+hBH
 xZE
 isa
 trV
@@ -72300,7 +72339,7 @@ xZE
 xZE
 xZE
 xZE
-xZE
+hBH
 tNQ
 vGp
 trV
@@ -72501,12 +72540,12 @@ hSi
 xZE
 xZE
 xZE
-xZE
-xZE
-xZE
-xZE
-xZE
-xZE
+qAv
+hBH
+hBH
+hBH
+hBH
+qAv
 vTx
 vTx
 trV
@@ -72707,7 +72746,7 @@ aaK
 xZE
 xZE
 xZE
-xZE
+hBH
 xZE
 wDj
 wDj
@@ -72913,7 +72952,7 @@ yaC
 xZE
 xZE
 xZE
-xZE
+hBH
 wDj
 nJV
 elX
@@ -73119,7 +73158,7 @@ yaC
 xZE
 xZE
 xZE
-xZE
+hBH
 wDj
 aJS
 ezo
@@ -73325,7 +73364,7 @@ yaC
 xZE
 xZE
 xZE
-xZE
+hBH
 wDj
 cPg
 eJR
@@ -74561,7 +74600,7 @@ xZE
 xZE
 xZE
 xZE
-xZE
+hBH
 wDj
 rhh
 rtX
@@ -76607,14 +76646,14 @@ cpy
 cpy
 cpy
 cpy
-shD
+aDx
 acQ
 fzK
 fzK
 fzK
 fzK
-shD
-shD
+aDx
+aDx
 cpy
 ien
 cpy


### PR DESCRIPTION

# About the pull request

Currently, there are no restrictions preventing vehicles from entering the caves on the "LV522 Chances Claim" map. 
This PR adds a force field to restrict vehicle access to the caves.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="6176" height="6528" alt="LV-522" src="https://github.com/user-attachments/assets/b6214c2c-0874-46c5-9d01-9b3ac9518d37" />

</details>


# Changelog

:cl:
mapadd: added vehicle restrictions for caves on the LV522 Chances Claim map.
/:cl:
