### PR TITLE
Mute xenomorphs

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -110,6 +110,8 @@
 	var/counts_for_roundend = TRUE
 	var/refunds_larva_if_banished = TRUE
 	var/can_hivemind_speak = TRUE
+	/// If TRUE, the Queen has silenced this xeno's ability to send hivemind messages. They can still read the hivemind.
+	var/hivemind_muted = FALSE
 
 	// Tackles
 	var/tackle_min = 2

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_abilities.dm
@@ -46,6 +46,12 @@
 	ability_primacy = XENO_PRIMARY_ACTION_2
 	xeno_cooldown = 12 SECONDS
 
+/datum/action/xeno_action/activable/queen_mute_xeno
+	name = "Silence Xenomorph"
+	action_icon_state = "xeno_banish"
+	plasma_cost = 0
+	xeno_cooldown = 3 SECONDS
+
 /datum/action/xeno_action/onclick/queen_word
 	name = "Word of the Queen (50)"
 	action_icon_state = "queen_word"

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -989,6 +989,37 @@
 	to_chat(queen, SPAN_XENONOTICE("You transfer some plasma to [target_xeno]."))
 	return ..()
 
+/datum/action/xeno_action/activable/queen_mute_xeno/use_ability(atom/target)
+	var/mob/living/carbon/xenomorph/queen/queen = owner
+	if(!queen.check_state())
+		return
+
+	if(!action_cooldown_check())
+		return
+
+	var/mob/living/carbon/xenomorph/target_xeno = target
+	if(!istype(target_xeno) || target_xeno.stat == DEAD)
+		to_chat(queen, SPAN_WARNING("You must target the xeno you want to silence."))
+		return
+
+	if(target_xeno == queen)
+		to_chat(queen, SPAN_XENOWARNING("We cannot silence ourselves!"))
+		return
+
+	if(!queen.can_not_harm(target_xeno))
+		to_chat(queen, SPAN_WARNING("You can only target xenos part of your hive!"))
+		return
+
+	apply_cooldown()
+	target_xeno.hivemind_muted = !target_xeno.hivemind_muted
+	if(target_xeno.hivemind_muted)
+		to_chat(queen, SPAN_XENONOTICE("You sever [target_xeno]'s voice from the hivemind."))
+		to_chat(target_xeno, SPAN_XENOWARNING("The Queen has severed your voice from the hivemind! You can no longer speak to your sisters."))
+	else
+		to_chat(queen, SPAN_XENONOTICE("You restore [target_xeno]'s voice in the hivemind."))
+		to_chat(target_xeno, SPAN_XENONOTICE("The Queen has restored your voice in the hivemind."))
+	return ..()
+
 /datum/action/xeno_action/onclick/send_thoughts/proc/queen_order()
 	var/mob/living/carbon/xenomorph/queen/xenomorph = owner
 	var/give_order_plasma_cost = 100

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -793,6 +793,7 @@
 		// These are new and their arrangement matters:
 		/datum/action/xeno_action/onclick/remove_eggsac,
 		/datum/action/xeno_action/onclick/set_xeno_lead,
+		/datum/action/xeno_action/activable/queen_mute_xeno,
 		/datum/action/xeno_action/activable/queen_heal, //first macro
 		/datum/action/xeno_action/activable/queen_give_plasma, //second macro
 		/datum/action/xeno_action/activable/expand_weeds, //third macro

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -590,6 +590,7 @@
 			"tier" = xeno.tier, // This one is only important for sorting
 			"is_leader" = (IS_XENO_LEADER(xeno)),
 			"is_queen" = istype(xeno.caste, /datum/caste_datum/queen),
+			"is_muted" = xeno.hivemind_muted,
 			"caste_type" = xeno.caste_type
 		))
 

--- a/code/modules/mob/living/carbon/xenomorph/hive_status_ui.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status_ui.dm
@@ -235,6 +235,19 @@
 			var/datum/action/xeno_action/A = get_action(xenoSrc, /datum/action/xeno_action/activable/queen_heal)
 			A?.use_ability_wrapper(xenoTarget, TRUE)
 
+		if("mute")
+			var/mob/living/carbon/xenomorph/xenoTarget = locate(params["target_ref"]) in GLOB.living_xeno_list
+			var/mob/living/carbon/xenomorph/xenoSrc = ui.user
+
+			if(QDELETED(xenoTarget) || xenoTarget.stat == DEAD || should_block_game_interaction(xenoTarget))
+				return
+
+			if(xenoSrc.stat == DEAD)
+				return
+
+			var/datum/action/xeno_action/A = get_action(xenoSrc, /datum/action/xeno_action/activable/queen_mute_xeno)
+			A?.use_ability_wrapper(xenoTarget)
+
 		if("overwatch")
 			var/mob/living/carbon/xenomorph/xenoTarget = locate(params["target_ref"]) in GLOB.living_xeno_list
 			var/mob/living/carbon/xenomorph/xenoSrc = ui.user

--- a/code/modules/mob/living/carbon/xenomorph/say.dm
+++ b/code/modules/mob/living/carbon/xenomorph/say.dm
@@ -82,6 +82,10 @@
 
 //General proc for hivemind. Lame, but effective.
 /mob/living/carbon/xenomorph/proc/hivemind_talk(message)
+	if(hivemind_muted)
+		to_chat(src, SPAN_WARNING("The Queen has severed your voice from the hivemind!"))
+		return
+
 	if(HAS_TRAIT(src, TRAIT_HIVEMIND_INTERFERENCE))
 		to_chat(src, SPAN_WARNING("Our psychic connection has been temporarily disabled!"))
 		return

--- a/tgui/packages/tgui/interfaces/HiveStatus.tsx
+++ b/tgui/packages/tgui/interfaces/HiveStatus.tsx
@@ -58,6 +58,7 @@ const filterXenos = (data: {
       is_ssd: xeno_vitals[nicknumber].is_ssd,
       is_leader: key.is_leader,
       is_queen: key.is_queen,
+      is_muted: key.is_muted,
     };
     xeno_entries.push(entry);
   });
@@ -110,6 +111,7 @@ type XenoEntry = {
   is_ssd: BooleanLike;
   is_leader: BooleanLike;
   is_queen: BooleanLike;
+  is_muted: BooleanLike;
 };
 
 type XenoKey = {
@@ -117,6 +119,7 @@ type XenoKey = {
   tier: string;
   is_leader: BooleanLike;
   is_queen: BooleanLike;
+  is_muted: BooleanLike;
   caste_type: string;
 };
 
@@ -524,7 +527,12 @@ const XenoList = (props) => {
                       Watch
                     </Button>
                   </Flex.Item>
-                  {!!is_in_ovi && <QueenOviButtons target_ref={entry.ref} />}
+                  {!!is_in_ovi && (
+                    <QueenOviButtons
+                      target_ref={entry.ref}
+                      is_muted={entry.is_muted}
+                    />
+                  )}
                 </Flex>
               )}
             </Table.Cell>
@@ -570,9 +578,12 @@ const XenoCollapsible = (props: {
   );
 };
 
-const QueenOviButtons = (props: { readonly target_ref: string }) => {
-  const { act, data } = useBackend<Data>();
-  const { target_ref } = props;
+const QueenOviButtons = (props: {
+  readonly target_ref: string;
+  readonly is_muted: BooleanLike;
+}) => {
+  const { act } = useBackend<Data>();
+  const { target_ref, is_muted } = props;
 
   return (
     <>
@@ -598,6 +609,18 @@ const QueenOviButtons = (props: { readonly target_ref: string }) => {
           }
         >
           Give Plasma
+        </Button>
+      </Flex.Item>
+      <Flex.Item>
+        <Button
+          color={is_muted ? 'good' : 'bad'}
+          onClick={() =>
+            act('mute', {
+              target_ref: target_ref,
+            })
+          }
+        >
+          {is_muted ? 'Unmute' : 'Mute'}
         </Button>
       </Flex.Item>
     </>


### PR DESCRIPTION
# About the pull request

Allows queen to mute xenomorphes from text in hivemind (they still can see hivemind)

Taken from this PR https://github.com/RU-CMSS13/RU-CMSS13/pull/638

# Explain why it's good for the game

Less spam in hivemind, easier to keep chat focused.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Allowes Queen to mute some xenos
/:cl:
