### PR TITLE
Halfs FOB turrets time

### DIFF
--- a/code/modules/defenses/sentry.dm
+++ b/code/modules/defenses/sentry.dm
@@ -673,7 +673,7 @@
 	sentry_range = 10
 	omni_directional = TRUE
 	/// How long the battery for this turret lasts. Will warn low at 70% and critical at 90% use.
-	var/battery_duration = 20 MINUTES
+	var/battery_duration = 10 MINUTES
 	/// The current battery state
 	var/battery_state = TURRET_BATTERY_STATE_OK
 


### PR DESCRIPTION

# About the pull request
This PR makes FOB turret remain active for ten minutes, down from twenty.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Twenty minutes is too long for something this strong. The FOB turrets completely shut down early backliner pressure on the FOB and makes attacking the FOB nonviable for most of the early game.

I've chosen ten minutes because it's just barely enough time to get basic barricades up. Engineers will have to use that time effectively instead of relying on the turrets.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Reduced the first-drop FOB turret duration from 20 minutes to 10 minutes.
/:cl: