### PR TITLE
allows the M4RA battle rifle to have underbarrel flamethrowers and grenade launchers + adds a minimum wield time to those attachments

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -427,6 +427,7 @@
 		recoil_unwielded += attached_attachment.recoil_unwielded_mod
 		aim_slowdown += attached_attachment.aim_speed_mod
 		wield_delay += attached_attachment.wield_delay_mod
+		wield_delay = max(wield_delay, attached_attachment.min_wield_delay_mod) //if the wield delay is higher just use that
 		movement_onehanded_acc_penalty_mult += attached_attachment.movement_onehanded_acc_penalty_mod
 		force += attached_attachment.melee_mod
 		w_class += attached_attachment.size_mod

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -69,6 +69,7 @@ Defined in conflicts.dm of the #defines folder.
 	var/size_mod = 0 //Increases the weight class.
 	var/aim_speed_mod = 0 //Changes the aiming speed slowdown of the wearer by this value.
 	var/wield_delay_mod = 0 //How long ADS takes (time before firing)
+	var/min_wield_delay_mod = 0 //The minimum ADS time
 	var/movement_onehanded_acc_penalty_mod = 0 //Modifies accuracy/scatter penalty when firing onehanded while moving.
 	var/velocity_mod = 0 // Added velocity to bullets
 	var/hud_offset_mod  = 0 //How many pixels to adjust the gun's sprite coords by. Ideally, this should keep the gun approximately centered.
@@ -3139,6 +3140,7 @@ Defined in conflicts.dm of the #defines folder.
 	max_range = 7
 	attachment_action_type = /datum/action/item_action/toggle/ugl
 	slot = "under"
+	min_wield_delay_mod = WEAPON_DELAY_NORMAL
 	fire_sound = 'sound/weapons/gun_m92_attachable.ogg'
 	flags_attach_features = ATTACH_REMOVABLE|ATTACH_ACTIVATION|ATTACH_RELOADABLE|ATTACH_WEAPON
 	var/grenade_pass_flags
@@ -3343,6 +3345,7 @@ Defined in conflicts.dm of the #defines folder.
 	max_rounds = 40
 	max_range = 5
 	slot = "under"
+	min_wield_delay_mod = WEAPON_DELAY_NORMAL
 	fire_sound = 'sound/weapons/gun_flamethrower3.ogg'
 	gun_activate_sound = 'sound/weapons/handling/gun_underbarrel_flamer_activate.ogg'
 	flags_attach_features = ATTACH_REMOVABLE|ATTACH_ACTIVATION|ATTACH_RELOADABLE|ATTACH_WEAPON

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1993,7 +1993,6 @@
 		/obj/item/attachable/attached_gun/grenade,
 		/obj/item/attachable/attached_gun/flamer,
 		/obj/item/attachable/attached_gun/flamer/advanced,
-		/obj/item/attachable/attached_gun/shotgun,
 		/obj/item/attachable/attached_gun/extinguisher,
 		/obj/item/attachable/attached_gun/flare_launcher,
 	)

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1990,6 +1990,10 @@
 		/obj/item/attachable/scope/mini,
 		/obj/item/attachable/alt_iff_scope,
 		/obj/item/attachable/flashlight/grip,
+		/obj/item/attachable/attached_gun/grenade,
+		/obj/item/attachable/attached_gun/flamer,
+		/obj/item/attachable/attached_gun/flamer/advanced,
+		/obj/item/attachable/attached_gun/shotgun,
 		/obj/item/attachable/attached_gun/extinguisher,
 		/obj/item/attachable/attached_gun/flare_launcher,
 	)


### PR DESCRIPTION

# About the pull request
title, im not too sure why this hasn't been done before so sorry if i am retreading old ground.

underbarrel flamethrowers and grenade launchers give the weapon they are attached to a minimum wield delay of  0.6 seconds.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
more customization options for the less used primary weapon of the USCM.

the M4RA battle rifle in Aliens: Colonial Marines can have an underbarrel grenade launcher or shotgun so it feels off that our version cannot. 

these changes don't apply to scout's custom M4RA battle rifle since that gun has enough going for it.

# Testing Photographs and Procedure
<img width="504" height="504" alt="image" src="https://github.com/user-attachments/assets/b93952bd-489f-4083-af79-f3d6ed5ac15b" />




# Changelog

:cl:
balance: the M4RA battle rifle can have underbarrel flamethrowers and  grenade launchers attached.
balance: underbarrel flamethrowers and grenade launchers give the weapon they are attached to a minimum wield delay of  0.6 seconds.
/:cl:

