### PR TITLE
Add arrest disclaimer to CMB ERT

### DIFF
--- a/code/datums/emergency_calls/inspection.dm
+++ b/code/datums/emergency_calls/inspection.dm
@@ -247,7 +247,7 @@
 		to_chat(mob, SPAN_ROLE_HEADER("You are a CMB Deputy!"))
 		arm_equipment(mob, /datum/equipment_preset/cmb/standard, TRUE, TRUE)
 
-	to_chat(mob, SPAN_ROLE_HEADER("You are not here to perform arrests independantly. You have no authority to do so unless granted by the [MAIN_SHIP_NAME]'s Commander."))
+	to_chat(mob, SPAN_ROLE_HEADER("You are not here to perform arrests independantly. You have no authority to do so unless granted by the [MAIN_SHIP_NAME]'s Commander or USCM High Command"))
 	to_chat(mob, SPAN_ROLE_HEADER("Work with the [MAIN_SHIP_NAME]'s Commander, and military police force."))
 	print_backstory(mob)
 
@@ -334,7 +334,7 @@
 		arm_equipment(mob, /datum/equipment_preset/cmb/standard, TRUE, TRUE)
 
 	print_backstory(mob)
-	to_chat(mob, SPAN_ROLE_HEADER("You are not here to perform arrests independantly. You have no authority to do so unless granted by the [MAIN_SHIP_NAME]'s Commander."))
+	to_chat(mob, SPAN_ROLE_HEADER("You are not here to perform arrests independantly. You have no authority to do so unless granted by the [MAIN_SHIP_NAME]'s Commander or USCM High Command."))
 	to_chat(mob, SPAN_ROLE_HEADER("Work with the [MAIN_SHIP_NAME]'s Commander, and military police force."))
 
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), mob, SPAN_BOLD("Objectives:</b> [objectives]")), 1 SECONDS)

--- a/code/datums/emergency_calls/inspection.dm
+++ b/code/datums/emergency_calls/inspection.dm
@@ -247,7 +247,7 @@
 		to_chat(mob, SPAN_ROLE_HEADER("You are a CMB Deputy!"))
 		arm_equipment(mob, /datum/equipment_preset/cmb/standard, TRUE, TRUE)
 
-	to_chat(mob, SPAN_ROLE_HEADER("You are not here to perform arrests independantly. You have no authority to do so unless granted by the Commander."))
+	to_chat(mob, SPAN_ROLE_HEADER("You are not here to perform arrests independantly. You have no authority to do so unless granted by the [MAIN_SHIP_NAME]'s Commander."))
 	to_chat(mob, SPAN_ROLE_HEADER("Work with the [MAIN_SHIP_NAME]'s Commander, and military police force."))
 	print_backstory(mob)
 
@@ -334,7 +334,7 @@
 		arm_equipment(mob, /datum/equipment_preset/cmb/standard, TRUE, TRUE)
 
 	print_backstory(mob)
-	to_chat(mob, SPAN_ROLE_HEADER("You are not here to perform arrests independantly. You have no authority to do so unless granted by the Ship's Commander."))
+	to_chat(mob, SPAN_ROLE_HEADER("You are not here to perform arrests independantly. You have no authority to do so unless granted by the [MAIN_SHIP_NAME]'s Commander."))
 	to_chat(mob, SPAN_ROLE_HEADER("Work with the [MAIN_SHIP_NAME]'s Commander, and military police force."))
 
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), mob, SPAN_BOLD("Objectives:</b> [objectives]")), 1 SECONDS)

--- a/code/datums/emergency_calls/inspection.dm
+++ b/code/datums/emergency_calls/inspection.dm
@@ -247,6 +247,8 @@
 		to_chat(mob, SPAN_ROLE_HEADER("You are a CMB Deputy!"))
 		arm_equipment(mob, /datum/equipment_preset/cmb/standard, TRUE, TRUE)
 
+	to_chat(mob, SPAN_ROLE_HEADER("You are not here to perform arrests independantly. You have no authority to do so unless granted by the Commanding Officer."))
+	to_chat(mob, SPAN_ROLE_HEADER("Work with the [MAIN_SHIP_NAME]'s Commanding Officer, and military police force."))
 	print_backstory(mob)
 
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), mob, SPAN_BOLD("Objectives:</b> [objectives]")), 1 SECONDS)
@@ -332,5 +334,7 @@
 		arm_equipment(mob, /datum/equipment_preset/cmb/standard, TRUE, TRUE)
 
 	print_backstory(mob)
+	to_chat(mob, SPAN_ROLE_HEADER("You are not here to perform arrests independantly. You have no authority to do so unless granted by the Commanding Officer."))
+	to_chat(mob, SPAN_ROLE_HEADER("Work with the [MAIN_SHIP_NAME]'s Commanding Officer, and military police force."))
 
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), mob, SPAN_BOLD("Objectives:</b> [objectives]")), 1 SECONDS)

--- a/code/datums/emergency_calls/inspection.dm
+++ b/code/datums/emergency_calls/inspection.dm
@@ -247,8 +247,8 @@
 		to_chat(mob, SPAN_ROLE_HEADER("You are a CMB Deputy!"))
 		arm_equipment(mob, /datum/equipment_preset/cmb/standard, TRUE, TRUE)
 
-	to_chat(mob, SPAN_ROLE_HEADER("You are not here to perform arrests independantly. You have no authority to do so unless granted by the Commanding Officer."))
-	to_chat(mob, SPAN_ROLE_HEADER("Work with the [MAIN_SHIP_NAME]'s Commanding Officer, and military police force."))
+	to_chat(mob, SPAN_ROLE_HEADER("You are not here to perform arrests independantly. You have no authority to do so unless granted by the Commander."))
+	to_chat(mob, SPAN_ROLE_HEADER("Work with the [MAIN_SHIP_NAME]'s Commander, and military police force."))
 	print_backstory(mob)
 
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), mob, SPAN_BOLD("Objectives:</b> [objectives]")), 1 SECONDS)
@@ -334,7 +334,7 @@
 		arm_equipment(mob, /datum/equipment_preset/cmb/standard, TRUE, TRUE)
 
 	print_backstory(mob)
-	to_chat(mob, SPAN_ROLE_HEADER("You are not here to perform arrests independantly. You have no authority to do so unless granted by the Commanding Officer."))
-	to_chat(mob, SPAN_ROLE_HEADER("Work with the [MAIN_SHIP_NAME]'s Commanding Officer, and military police force."))
+	to_chat(mob, SPAN_ROLE_HEADER("You are not here to perform arrests independantly. You have no authority to do so unless granted by the Ship's Commander."))
+	to_chat(mob, SPAN_ROLE_HEADER("Work with the [MAIN_SHIP_NAME]'s Commander, and military police force."))
 
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), mob, SPAN_BOLD("Objectives:</b> [objectives]")), 1 SECONDS)


### PR DESCRIPTION

# About the pull request
Add a disclaimer to the CMB ERT so they don't assume that they can just arrest people without working with the Ship's MPs, CoC.
Starting needless battles over jurisdiction and/or worse.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Stops CMB BE baiting hopefully.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="1179" height="759" alt="image" src="https://github.com/user-attachments/assets/34c71cf0-8ed6-459b-be99-a889790e544f" />

</details>


# Changelog
:cl:
add: Disclaimer regarding arrests to CMB Inspection ERTs
/:cl:
