### PR TITLE
Reduces the fuel pump health by 20% 

### DIFF
--- a/code/game/machinery/fuelpump.dm
+++ b/code/game/machinery/fuelpump.dm
@@ -7,7 +7,7 @@
 	bound_width = 128
 	pixel_x = -64
 	bound_x = -64
-	health = 2500
+	health = 2000
 	density = TRUE
 	anchored = TRUE
 	wrenchable = FALSE


### PR DESCRIPTION
# About the pull request

It has gone from 2500 HP to 2000. 

# Explain why it's good for the game

What I've noticed with the fuel pump change during its TM and full merge is that ship crashes got drastically less common, with it seeming like almost every round making it into FTL, and station docking (aka Marine Major™️) becoming more common. I think the crash was probably too common before, but this seems excessive to me. From my experience playing on both sides and observing, it seems like in order for the ship to crash and not go straight to FTL, the following must happen: 

Xenos must attack all pumps as a group
Marines must not put up any major resistance
Reactor is killed during or immediately after the pumps are destroyed

In particular I noticed a number of rounds where despite the Marines losing pretty fast, the pumps lived long enough to get the ship just into FTL before falling out of it shortly after.

I actually think ship crash was a bit too common before these changes, and I like when I'm playing Marine to have a chance for my character to escape alive. But right now the number seems a bit overtuned to me. There is for sure a balancing act here, because Marines do need to protect these objectives throughout all of FTL. And the intent of the change as far as I can tell is that Xenos themselves need to be focusing on these objectives rather than simply tasking them to backliners and running off to chase Marines. In the ideal state of balance, IMO, if either side does not devote the majority of their resources to holding objectives they are punished by a failure state. 

Maybe it's too soon to tell from the numbers, which I don't have access to. But I think it's important that Xeno players feel like doing the intended objective is going to produce a good outcome. Instead of them being jaded, ignoring pumps, and ghosting or just looking for kills until hijack is over. 

# Testing Photographs and Procedure
Simple var edit

# Changelog

:cl: Orchidfox
balance: Hijack fuel pump health reduced by 20%, from 2500 to 2000. 
/:cl:
