### PR TITLE
Valkyrae retrieve no check for fury

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/valkyrie.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/valkyrie.dm
@@ -458,14 +458,14 @@
 		to_chat(valkyrie, SPAN_WARNING("[targetXeno] is already dead!"))
 		return
 
-	if(!action_cooldown_check() || valkyrie.action_busy)
+	if(valkyrie.action_busy)
 		return
 
-	if(!valkyrie.check_state())
+	if(behavior.base_fury < retrieve_cost)
+		to_chat(valkyrie, SPAN_XENODANGER("Мы не достаточно разозлены, чтобы сделать это!"))
 		return
 
-	if(!check_plasma_owner())
-		return
+	XENO_ACTION_CHECK(valkyrie)
 
 	// Build our turflist
 	var/list/turf/turflist = list()

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/valkyrie.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/valkyrie.dm
@@ -462,7 +462,7 @@
 		return
 
 	if(behavior.base_fury < retrieve_cost)
-		to_chat(valkyrie, SPAN_XENODANGER("Мы не достаточно разозлены, чтобы сделать это!"))
+		to_chat(valkyrie, SPAN_XENODANGER("We don't feel angry enough to do this!"))
 		return
 
 	XENO_ACTION_CHECK(valkyrie)


### PR DESCRIPTION

# About the pull request

This https://github.com/cmss13-devs/cmss13/pull/12772 forgot a check for fury. Now valkyrie places a green hook line even she has no fury. It won't retrieve a target xeno, it's only misleading whether you have fury or do not.

# Explain why it's good for the game

It's obvious, also a little refactoring - not even worth mentioning

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>
<img width="1446" height="1440" alt="image" src="https://github.com/user-attachments/assets/36321cb8-9c22-49fb-8a8e-42046132c641" />

</details>


# Changelog 
:cl: JHINgle4ce
fix: fixes valkyria fake use of retrieve
/:cl:

