### PR TITLE
REVERSE_DIR and IS_DIAGONAL refactoring

### DIFF
--- a/code/controllers/subsystem/hijack.dm
+++ b/code/controllers/subsystem/hijack.dm
@@ -957,7 +957,7 @@ SUBSYSTEM_DEF(hijack)
 
 	// Optionally leak water
 	if(leak)
-		var/opposite_dir = GLOB.reverse_dir[direction]
+		var/opposite_dir = REVERSE_DIR(direction)
 		var/x_adjust = 0
 		var/y_adjust = 0
 		switch(opposite_dir)

--- a/code/datums/autocells/explosion.dm
+++ b/code/datums/autocells/explosion.dm
@@ -123,7 +123,7 @@
 		survivor.exploded_atoms |= dying.exploded_atoms
 
 	// Two waves travling towards each other weakens the explosion
-	if(survivor.direction == GLOB.reverse_dir[dying.direction])
+	if(survivor.direction == REVERSE_DIR(dying.direction))
 		survivor.power -= dying.power
 
 	qdel(dying)
@@ -138,7 +138,7 @@
 	if(isnull(direction))
 		return GLOB.alldirs
 
-	var/dir = reflected ? GLOB.reverse_dir[direction] : direction
+	var/dir = reflected ? REVERSE_DIR(direction) : direction
 
 	if(dir in GLOB.cardinals)
 		propagation_dirs += list(dir, turn(dir, 45), turn(dir, -45))
@@ -196,7 +196,7 @@
 	for(var/dir in to_spread)
 		// Diagonals are longer, that should be reflected in the power falloff
 		var/dir_falloff = 1
-		if(dir in GLOB.diagonals)
+		if(IS_DIAGONAL_DIR(dir))
 			dir_falloff = 1.414
 
 		if(isnull(direction))
@@ -232,7 +232,7 @@
 			// Set the direction the explosion is traveling in
 			new_cell.direction = dir
 			//Diagonal cells have a small delay when branching off the center. This helps the explosion look circular
-			if(!direction && (dir in GLOB.diagonals))
+			if(!direction && (IS_DIAGONAL_DIR(dir)))
 				new_cell.delay = 1
 
 			setup_new_cell(new_cell)

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -147,7 +147,7 @@
 				if(prob(75))
 					triggered = TRUE
 					if(tripwire)
-						var/direction = GLOB.reverse_dir[dir]
+						var/direction = REVERSE_DIR(dir)
 						var/step_direction = get_step(src, direction)
 						tripwire.forceMove(step_direction)
 					prime()

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -1452,7 +1452,7 @@
 			// Set the direction the explosion is traveling in
 			E.direction = dir
 
-			if(dir in GLOB.diagonals)
+			if(IS_DIAGONAL_DIR(dir))
 				E.range--
 
 			switch(E.range)

--- a/code/modules/cm_aliens/weeds.dm
+++ b/code/modules/cm_aliens/weeds.dm
@@ -293,12 +293,12 @@
 	for(var/obj/O in T)
 		if(istype(O, /obj/structure/platform))
 			var/obj/structure/platform/P = O
-			if(!(P.stat & BROKEN) && P.dir == GLOB.reverse_dir[direction])
+			if(!(P.stat & BROKEN) && P.dir == REVERSE_DIR(direction))
 				return FALSE
 
 		if(istype(O, /obj/structure/barricade)) //cades on tile we're trying to expand to
 			var/obj/structure/barricade/to_blocking_cade = O
-			if(to_blocking_cade.density && to_blocking_cade.dir == GLOB.reverse_dir[direction] && to_blocking_cade.health >= (to_blocking_cade.maxhealth / 4))
+			if(to_blocking_cade.density && to_blocking_cade.dir == REVERSE_DIR(direction) && to_blocking_cade.health >= (to_blocking_cade.maxhealth / 4))
 				return FALSE
 
 		if(istype(O, /obj/structure/window/framed))

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -213,7 +213,7 @@
 
 /obj/item/clothing/mask/facehugger/Crossed(atom/target)
 	..()
-	
+
 	has_proximity(target)
 
 /obj/item/clothing/mask/facehugger/on_found(mob/finder)
@@ -585,7 +585,7 @@
 
 /datum/species/yautja/handle_hugger_attachment(mob/living/carbon/human/target, obj/item/clothing/mask/facehugger/hugger,  mob/living/carbon/xenomorph/facehugger/mob_hugger)
 	var/catch_chance = 50
-	if(target.dir == GLOB.reverse_dir[hugger.dir])
+	if(target.dir == REVERSE_DIR(hugger.dir))
 		catch_chance += 20
 	if(target.body_position == LYING_DOWN)
 		catch_chance -= 50

--- a/code/modules/mob/living/carbon/xenomorph/castes/Ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Ravager.dm
@@ -339,8 +339,8 @@
 
 	for (var/step in 0 to 3)
 		temp = get_step(turf, facing)
-		if(facing in GLOB.diagonals) // check if it goes through corners
-			var/reverse_face = GLOB.reverse_dir[facing]
+		if(IS_DIAGONAL_DIR(facing)) // check if it goes through corners
+			var/reverse_face = REVERSE_DIR(facing)
 
 			var/turf/back_left = get_step(temp, turn(reverse_face, 45))
 			var/turf/back_right = get_step(temp, turn(reverse_face, -45))

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/oppressor.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/oppressor.dm
@@ -102,8 +102,8 @@
 	var/turf/temp = abduct_user.loc
 	for(var/distance in 0 to max_distance)
 		temp = get_step(turf, facing)
-		if(facing in GLOB.diagonals) // check if it goes through corners
-			var/reverse_face = GLOB.reverse_dir[facing]
+		var/reverse_face = REVERSE_DIR(facing)
+		if(IS_DIAGONAL_DIR(facing)) // check if it goes through corners
 			var/turf/back_left = get_step(temp, turn(reverse_face, 45))
 			var/turf/back_right = get_step(temp, turn(reverse_face, -45))
 			if((!back_left || back_left.density) && (!back_right || back_right.density))
@@ -124,7 +124,7 @@
 			if(istype(structure, /obj/structure/window/reinforced))
 				var/obj/structure/window/reinforced/pane_glass = structure
 				var/pane_facing = pane_glass.dir
-				if(pane_facing == turn(facing, 180))
+				if(pane_facing == reverse_face)
 					blocked = TRUE
 				else if(pane_facing == facing)
 					allow_one_more_step = TRUE
@@ -133,7 +133,7 @@
 				var/obj/structure/surface/table/flip_table = structure
 				var/table_facing = flip_table.dir
 				if(flip_table.flipped)
-					if(table_facing == turn(facing, 180))
+					if(table_facing == reverse_face)
 						blocked = TRUE
 					else if(table_facing == facing)
 						allow_one_more_step = TRUE
@@ -141,7 +141,7 @@
 			if(istype(structure, /obj/structure/barricade))
 				var/obj/structure/barricade/cade = structure
 				var/cade_facing = cade.dir
-				if(cade_facing & turn(facing, 180))
+				if(cade_facing & reverse_face)
 					blocked = TRUE
 				else if(cade_facing == facing)
 					allow_one_more_step = TRUE

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/valkyrie.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/valkyrie.dm
@@ -476,8 +476,8 @@
 	var/turf/temp = valkyrie.loc
 	for(var/x in 0 to max_distance)
 		temp = get_step(T, facing)
-		if(facing in GLOB.diagonals) // check if it goes through corners
-			var/reverse_face = GLOB.reverse_dir[facing]
+		if(IS_DIAGONAL_DIR(facing)) // check if it goes through corners
+			var/reverse_face = REVERSE_DIR(facing)
 			var/turf/back_left = get_step(temp, turn(reverse_face, 45))
 			var/turf/back_right = get_step(temp, turn(reverse_face, -45))
 			if((!back_left || back_left.density) && (!back_right || back_right.density))

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -153,7 +153,7 @@
 	if(prob(break_stuff_probability))
 		for(var/dir in GLOB.cardinals) // North, South, East, West
 			for(var/obj/structure/window/obstacle in get_step(src, dir))
-				if(obstacle.dir == GLOB.reverse_dir[dir]) // So that windows get smashed in the right order
+				if(obstacle.dir == REVERSE_DIR(dir)) // So that windows get smashed in the right order
 					obstacle.attack_animal(src)
 					return
 			var/obj/structure/obstacle = locate(/obj/structure, get_step(src, dir))

--- a/code/modules/unit_tests/movement/movement_helpers.dm
+++ b/code/modules/unit_tests/movement/movement_helpers.dm
@@ -83,7 +83,7 @@ GLOBAL_DATUM_INIT(collide_allows_movement_blocker_configuration, /datum/blocker_
 	// a direct to go towards the target turf and specify where the blockers are
 	// relative to the mover
 	var/turf/target_turf = get_step(run_loc_floor_bottom_left, NORTHEAST)
-	var/turf/mover_start_turf = get_step(target_turf, GLOB.reverse_dir[target_direction])
+	var/turf/mover_start_turf = get_step(target_turf, REVERSE_DIR(target_direction))
 	var/atom/movable/test_mover/mover = allocate(/atom/movable/test_mover, mover_start_turf)
 	mover.add_temp_pass_flags(PASS_ALL)
 	for (var/blocker_position in blocker_positions)

--- a/code/modules/vehicles/multitile/multitile_bump.dm
+++ b/code/modules/vehicles/multitile/multitile_bump.dm
@@ -667,7 +667,7 @@
 			//Check what dir they should be facing to be looking directly at the vehicle
 			else if(dir_between == dir) //front hit (facing the vehicle)
 				blocked = TRUE
-			else if(dir_between == GLOB.reverse_dir[dir]) // rear hit (facing directly away from the vehicle)
+			else if(dir_between == REVERSE_DIR(dir)) // rear hit (facing directly away from the vehicle)
 				takes_damage = TRUE
 			//side hit
 			else if(caste.caste_type == XENO_CASTE_QUEEN) // queen blocks even with sides

--- a/code/modules/vehicles/tank/tank.dm
+++ b/code/modules/vehicles/tank/tank.dm
@@ -160,7 +160,7 @@
 	if(!T)
 		return FALSE
 
-	if(direction == GLOB.reverse_dir[T.dir] || direction == T.dir)
+	if(direction == REVERSE_DIR(T.dir) || direction == T.dir)
 		return FALSE
 
 	T.user_rotation(user, turning_angle(T.dir, direction))


### PR DESCRIPTION

# About the pull request

Changed all GLOB.reverse_dir to REVERSE_DIR and all GLOB.diagonals in if 's to IS_DIAGONAL. In oppressor.dm I calculate reverse_dir once and use it afterwards instead of recalculating it all the time

# Explain why it's good for the game

Bit operations should be faster than memory accessing. Also I am not sure whether REVERSE_DIR is faster than turn(..., 180). I don't know calculating difficulty of turn(...,180), REVERSE_DIR difficulty is 5 bit operations though
REVERSE_DIR ( (((dir) & 85) << 1) | (((dir) & 170) >> 1) )
maybe we should change REVERSE_DIR macros to call turn(dir, 180)? or change turn(dir, 180) usage for REVERSE_DIR if the second one is faster

# Testing Photographs and Procedure
Can't prove it

# Changelog
:cl: JHINgle4ce
refactor: refactored REVERSE_DIR and IS_DIAGONAL uses
refactor: small oppressor optimization
/:cl: