### PR TITLE
Fix: Tables can no longer be used to completely obscure oneself when leaning

### DIFF
--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -180,6 +180,12 @@
 		if(hiding_humans[hiding] == direction)
 			return
 
+	if(direction == NORTH)
+		for(var/obj/structure/surface/table/table in get_turf(current_mob))
+			if (table.flipped && table.dir == SOUTH)
+				to_chat(user, SPAN_WARNING("You can't lean here with the table pressed up against the wall!"))
+				return
+
 	hiding_humans += current_mob
 	hiding_humans[current_mob] = direction
 	hiding_human.Moved() //just to be safe


### PR DESCRIPTION

# About the pull request

Removes the ability for marines to lean on a wall where a table is pressed up to the north face of it. This prevents instances where a human could completely obscure themselves in an illogical way.

# Explain why it's good for the game

Fixes #12905

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

# Changelog

:cl: Antlers
fix: Tables can no longer be used to completely obscure a human sprite when leaning on a wall next to them
/:cl:

