### PR TITLE
Fix: Sentries and machine guns can no longer be deployed inside tents

### DIFF
--- a/code/modules/cm_marines/m2c.dm
+++ b/code/modules/cm_marines/m2c.dm
@@ -115,6 +115,9 @@
 	if(rotate_check.density)
 		to_chat(user, SPAN_WARNING("You can't set up \the [src] that way, there's a wall behind you!"))
 		return FALSE
+	if((locate(/obj/structure/blocker/tent/interior_blocker) in OT))
+		to_chat(user, SPAN_WARNING("You can't set up [src] inside of a tent!"))
+		return FALSE
 	for(var/obj/structure/potential_blocker in rotate_check)
 		if(potential_blocker.density)
 			to_chat(user, SPAN_WARNING("You can't set up \the [src] that way, there's \a [potential_blocker] behind you!"))

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -149,6 +149,9 @@
 		if(!floor.allow_construction)
 			to_chat(user, SPAN_WARNING("You cannot install \the [src] here, find a more secure surface!"))
 			return FALSE
+	if(locate(/obj/structure/blocker/tent/interior_blocker) in get_turf(user))
+		to_chat(user, SPAN_WARNING("You cannot install [src] inside of a tent!"))
+		return FALSE
 	var/fail = FALSE
 	if(T.density)
 		fail = TRUE
@@ -253,6 +256,10 @@
 		if(!floor.allow_construction)
 			to_chat(user, SPAN_WARNING("You cannot install \the [src] here, find a more secure surface!"))
 			return FALSE
+	if(locate(/obj/structure/blocker/tent/interior_blocker) in get_turf(user))
+		to_chat(user, SPAN_WARNING("You cannot install [src] inside of a tent!"))
+		return FALSE
+
 	var/fail = FALSE
 	if(T.density)
 		fail = TRUE

--- a/code/modules/defenses/defenses.dm
+++ b/code/modules/defenses/defenses.dm
@@ -322,6 +322,8 @@
 			if(!floor.allow_construction)
 				to_chat(user, SPAN_WARNING("You cannot secure \the [src] here, find a more secure surface!"))
 				return FALSE
+			if(locate(/obj/structure/blocker/tent/interior_blocker) in floor)
+				to_chat(user, SPAN_WARNING("You cannot secure [src] inside of a tent!"))
 			user.visible_message(SPAN_NOTICE("[user] begins securing [src] to the ground."),
 			SPAN_NOTICE("You begin securing [src] to the ground."))
 

--- a/code/modules/defenses/handheld.dm
+++ b/code/modules/defenses/handheld.dm
@@ -58,7 +58,7 @@
 
 	if(locate(/obj/structure/blocker/tent/interior_blocker) in T)
 		to_chat(user, SPAN_WARNING("You cannot deploy [src] inside of a tent!"))
-		break
+		return FALSE
 
 	var/blocked = FALSE
 	for(var/obj/O in T)

--- a/code/modules/defenses/handheld.dm
+++ b/code/modules/defenses/handheld.dm
@@ -56,6 +56,10 @@
 	var/turf/T = get_step(user, user.dir)
 	var/direction = user.dir
 
+	if(locate(/obj/structure/blocker/tent/interior_blocker) in T)
+		to_chat(user, SPAN_WARNING("You cannot deploy [src] inside of a tent!"))
+		break
+
 	var/blocked = FALSE
 	for(var/obj/O in T)
 		if(O.density)

--- a/code/modules/tents/blockers.dm
+++ b/code/modules/tents/blockers.dm
@@ -43,3 +43,11 @@
 	flags_atom = NO_FLAGS
 	icon = 'icons/landmarks.dmi'
 	icon_state = "invisible_wall"
+
+// A blocker that denotes the interior of the tent. Does not actually prevent movement, but blocks things like machine guns from being placed.
+/obj/structure/blocker/tent/interior_blocker
+	flags_atom = NO_FLAGS
+	icon = 'icons/landmarks.dmi'
+	icon_state = "invisible_wall"
+
+	density = FALSE

--- a/maps/tents/tent_big.dmm
+++ b/maps/tents/tent_big.dmm
@@ -18,18 +18,21 @@
 /obj/structure/blocker/tent{
 	dir = 1
 	},
+/obj/structure/blocker/tent/interior_blocker,
 /turf/template_noop,
 /area/template_noop)
 "s" = (
 /obj/structure/blocker/tent{
 	dir = 4
 	},
+/obj/structure/blocker/tent/interior_blocker,
 /turf/template_noop,
 /area/template_noop)
 "v" = (
 /obj/structure/blocker/tent{
 	dir = 8
 	},
+/obj/structure/blocker/tent/interior_blocker,
 /turf/template_noop,
 /area/template_noop)
 "x" = (
@@ -50,15 +53,18 @@
 /obj/structure/blocker/tent{
 	dir = 1
 	},
+/obj/structure/blocker/tent/interior_blocker,
 /turf/template_noop,
 /area/template_noop)
 "O" = (
+/obj/structure/blocker/tent/interior_blocker,
 /turf/template_noop,
 /area/template_noop)
 "S" = (
 /obj/structure/blocker/tent{
 	dir = 1
 	},
+/obj/structure/blocker/tent/interior_blocker,
 /turf/template_noop,
 /area/template_noop)
 

--- a/maps/tents/tent_cmd.dmm
+++ b/maps/tents/tent_cmd.dmm
@@ -4,6 +4,7 @@
 	dir = 8
 	},
 /obj/structure/bed/chair,
+/obj/structure/blocker/tent/interior_blocker,
 /turf/template_noop,
 /area/template_noop)
 "d" = (
@@ -11,6 +12,7 @@
 	dir = 4
 	},
 /obj/structure/bed/chair,
+/obj/structure/blocker/tent/interior_blocker,
 /turf/template_noop,
 /area/template_noop)
 "o" = (
@@ -27,6 +29,7 @@
 	pixel_x = -2;
 	pixel_y = 6
 	},
+/obj/structure/blocker/tent/interior_blocker,
 /turf/template_noop,
 /area/template_noop)
 "p" = (
@@ -49,6 +52,7 @@
 	dir = 1
 	},
 /obj/structure/machinery/computer/overwatch/tent,
+/obj/structure/blocker/tent/interior_blocker,
 /turf/template_noop,
 /area/template_noop)
 "X" = (

--- a/maps/tents/tent_med.dmm
+++ b/maps/tents/tent_med.dmm
@@ -3,6 +3,7 @@
 /obj/structure/blocker/tent{
 	dir = 8
 	},
+/obj/structure/blocker/tent/interior_blocker,
 /turf/template_noop,
 /area/template_noop)
 "o" = (
@@ -13,6 +14,7 @@
 	dir = 1
 	},
 /obj/structure/bed/roller,
+/obj/structure/blocker/tent/interior_blocker,
 /turf/template_noop,
 /area/template_noop)
 "p" = (
@@ -23,6 +25,7 @@
 /obj/structure/blocker/tent{
 	dir = 4
 	},
+/obj/structure/blocker/tent/interior_blocker,
 /turf/template_noop,
 /area/template_noop)
 "A" = (
@@ -36,6 +39,7 @@
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med/tent{
 	pixel_y = 22
 	},
+/obj/structure/blocker/tent/interior_blocker,
 /turf/template_noop,
 /area/template_noop)
 "H" = (

--- a/maps/tents/tent_reqs.dmm
+++ b/maps/tents/tent_reqs.dmm
@@ -1,5 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
+/obj/structure/blocker/tent/interior_blocker,
 /turf/template_noop,
 /area/template_noop)
 "c" = (
@@ -15,6 +16,7 @@
 	dir = 4
 	},
 /obj/structure/filingcabinet,
+/obj/structure/blocker/tent/interior_blocker,
 /turf/template_noop,
 /area/template_noop)
 "k" = (
@@ -37,12 +39,14 @@
 	dir = 4
 	},
 /obj/structure/machinery/cm_vending/sorted/vehicle_supply/tent,
+/obj/structure/blocker/tent/interior_blocker,
 /turf/template_noop,
 /area/template_noop)
 "w" = (
 /obj/structure/blocker/tent{
 	dir = 1
 	},
+/obj/structure/blocker/tent/interior_blocker,
 /turf/template_noop,
 /area/template_noop)
 "B" = (
@@ -59,6 +63,7 @@
 	phone_category = "Command";
 	phone_id = "Ground Requisitions"
 	},
+/obj/structure/blocker/tent/interior_blocker,
 /turf/template_noop,
 /area/template_noop)
 "J" = (
@@ -68,6 +73,7 @@
 /obj/structure/machinery/computer/supply/tent{
 	pixel_y = 25
 	},
+/obj/structure/blocker/tent/interior_blocker,
 /turf/template_noop,
 /area/template_noop)
 "R" = (
@@ -79,10 +85,12 @@
 	dir = 8
 	},
 /obj/structure/surface/table,
+/obj/structure/blocker/tent/interior_blocker,
 /turf/template_noop,
 /area/template_noop)
 "U" = (
 /obj/structure/blocker/tent,
+/obj/structure/blocker/tent/interior_blocker,
 /turf/template_noop,
 /area/template_noop)
 


### PR DESCRIPTION

# About the pull request

Disables the ability to deploy machine guns and anchor sentries inside of tents.

# Explain why it's good for the game

Fixes #12956

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Antlers
fix: Sentries and machine guns can no longer be deployed inside tents
/:cl:
