### PR TITLE
Bugfix Rebalance: Chem storage charges faster and gets a roundstart boost

### DIFF
--- a/code/modules/reagents/chemistry_machinery/chem_storage.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_storage.dm
@@ -4,6 +4,9 @@
 #define DYNAMIC_SCALING_CHEM_MAX_ENERGY_PER_MEDIC 60
 #define DYNAMIC_SCALING_CHEM_ENERGY_MINIMUM_SCALE 4
 
+/// How much the recharge rate of chem storages are scaled by during roundstart (<00:20)
+#define ROUNDSTART_RECHARGE_RATE_MULTIPLIER 5
+
 /obj/structure/machinery/chem_storage
 	name = "Chemical Storage System"
 	desc = "Storage system for a large supply of chemicals, which slowly recharges."
@@ -15,11 +18,12 @@
 	bound_x = 32
 
 	var/network = "Ground"
-	var/recharge_cooldown = 15
+	var/recharge_cooldown = 8
 	var/recharge_rate = BASE_CHEM_STORAGE_RECHARGE_RATE
 	var/energy = BASE_CHEM_STORAGE_MAX_ENERGY
 	var/max_energy = BASE_CHEM_STORAGE_MAX_ENERGY
 	var/dynamic_storage = FALSE
+	var/roundstart_buff = FALSE
 
 	unslashable = TRUE
 	unacidable = TRUE
@@ -28,6 +32,7 @@
 	name = "Chemical Storage System (Medbay)"
 	network = "Medbay"
 	dynamic_storage = TRUE
+	roundstart_buff = TRUE
 
 /obj/structure/machinery/chem_storage/research
 	name = "Chemical Storage System (Research)"
@@ -75,5 +80,13 @@
 		return
 	if(energy >= max_energy)
 		return
-	energy = min(energy + recharge_rate, max_energy)
+	var/roundstart_multiplier = (ROUND_TIME < 20 MINUTES && roundstart_buff) ? ROUNDSTART_RECHARGE_RATE_MULTIPLIER : 1
+	energy = min(energy + recharge_rate * roundstart_multiplier, max_energy)
 	use_power(1500) // This thing uses up a lot of power (this is still low as shit for creating reagents from thin air)
+
+#undef BASE_CHEM_STORAGE_RECHARGE_RATE
+#undef BASE_CHEM_STORAGE_MAX_ENERGY
+#undef DYNAMIC_SCALING_CHEM_ENERGY_RATE_PER_MEDIC
+#undef DYNAMIC_SCALING_CHEM_MAX_ENERGY_PER_MEDIC
+#undef DYNAMIC_SCALING_CHEM_ENERGY_MINIMUM_SCALE
+#undef ROUNDSTART_RECHARGE_RATE_MULTIPLIER

--- a/code/modules/reagents/chemistry_machinery/chem_storage.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_storage.dm
@@ -5,7 +5,7 @@
 #define DYNAMIC_SCALING_CHEM_ENERGY_MINIMUM_SCALE 4
 
 /// How much the recharge rate of chem storages are scaled by during roundstart (<00:20)
-#define ROUNDSTART_RECHARGE_RATE_MULTIPLIER 3
+#define ROUNDSTART_RECHARGE_RATE_MULTIPLIER 4
 
 /obj/structure/machinery/chem_storage
 	name = "Chemical Storage System"

--- a/code/modules/reagents/chemistry_machinery/chem_storage.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_storage.dm
@@ -5,7 +5,7 @@
 #define DYNAMIC_SCALING_CHEM_ENERGY_MINIMUM_SCALE 4
 
 /// How much the recharge rate of chem storages are scaled by during roundstart (<00:20)
-#define ROUNDSTART_RECHARGE_RATE_MULTIPLIER 5
+#define ROUNDSTART_RECHARGE_RATE_MULTIPLIER 3
 
 /obj/structure/machinery/chem_storage
 	name = "Chemical Storage System"


### PR DESCRIPTION

# About the pull request

Attempts to somewhat counteract the nerf to roundstart energy generation caused by the #12270 bugfix by both halving the length of chem storage's recharge cooldown (also doubling its energy consumption), as well as adding a boost to reagent generation during roundstart (<00:20 round time) that quadruples reagents generated.

Also cleans up some defines that were not used outside of their files.

# Explain why it's good for the game

The bugfix that removed the chem storage completely refilling itself upon a new medic latejoining disproportionately nerfed the capacity of chemline doctors to properly handle the influx of requests during roundstart. Previously, they had access to the trickle of latejoining corpsmen during roundstart that refilled the storage and slowly tapered off as the round went on. Now, the regeneration of chemicals is nearly completely linear, without regard to the high demand and traffic that still exists roundstart.

This PR seeks to allow doctors to handle that surge of corpsman with the efficiency that they previously were able to do, as well as generally buffing reagent generation through reducing its recharge cooldown.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Antlers
balance: Chem storage's recharge cooldown has been halved, overall doubling reagent production (and power usage)
balance: The medical chem storage machine receives a boost to production during roundstart, tripling its output until 00:20 roundtime
/:cl:
