### PR TITLE
Bugfix Rebalance: Crusher melee attacks slow for 3.5 seconds (was 2 seconds)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/Crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Crusher.dm
@@ -237,7 +237,7 @@
 	if (!isxeno_human(target))
 		return
 
-	new /datum/effects/xeno_slow(target, bound_xeno, ttl = 2 SECONDS)
+	new /datum/effects/xeno_slow(target, bound_xeno, ttl = 3.5 SECONDS)
 
 	var/damage = bound_xeno.melee_damage_upper * aoe_slash_damage_reduction
 


### PR DESCRIPTION

# About the pull request

Un-nerfs the crusher's melee slow from 2 seconds to 3.5 seconds, after bugfix #12241 nerfed them.

# Explain why it's good for the game

Crusher is currently the weakest T3 caste in the game. We should not have nerfed it in the first place.

Additionally, bugfixes should not seek to actively rebalance the game. If returning code to intended behavior has the side effect of numbers or stats being changed, the fix should adjust their values accordingly to return balance to how it was beforehand.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Antlers
balance: Un-nerfs the crusher's melee attack slow after its bugfix, returning it to 3.5 seconds
/:cl:
