### PR TITLE
changes regulating property

### DIFF
--- a/code/modules/reagents/chemistry_properties/prop_special.dm
+++ b/code/modules/reagents/chemistry_properties/prop_special.dm
@@ -120,7 +120,7 @@
 	var/datum/reagent/regulating_chemical = GLOB.chemical_reagents_list[holder.id]
 	if(regulating_chemical)
 		regulating_chemical.overdose = max(level * 5,1)
-		regulating_chemical.overdose_critical = max((level * 5) + 5,2)
+		regulating_chemical.overdose_critical = max(level * 7.5,1.5)
 	. = ..()
 
 /datum/chem_property/special/ciphering

--- a/code/modules/reagents/chemistry_properties/prop_special.dm
+++ b/code/modules/reagents/chemistry_properties/prop_special.dm
@@ -109,19 +109,19 @@
 /datum/chem_property/special/regulating
 	name = PROPERTY_REGULATING
 	code = "REG"
-	description = "The chemical regulates its metabolization and can never cause an overdose."
+	description = "The chemical regulates its metabolization and the overdose levels are always static."
 	rarity = PROPERTY_LEGENDARY
 	category = PROPERTY_TYPE_METABOLITE
-	max_level = 1
+	max_level = 8
 	value = 6
 
-/datum/chem_property/special/regulating/reset_reagent()
-	holder.flags = initial(holder.flags)
-	..()
-
 /datum/chem_property/special/regulating/update_reagent()
-	holder.flags |= REAGENT_CANNOT_OVERDOSE
-	..()
+
+	var/datum/reagent/regulating_chemical = GLOB.chemical_reagents_list[holder.id]
+	if(regulating_chemical)
+		regulating_chemical.overdose = max(level * 5,1)
+		regulating_chemical.overdose_critical = max((level * 5) + 5,2)
+	. = ..()
 
 /datum/chem_property/special/ciphering
 	name = PROPERTY_CIPHERING


### PR DESCRIPTION

# About the pull request

Regulating property now sets the overdose level at that level. it doesn't prevent overdosing, but the OD will never go below the level regulating is at. (meaning amplifying regulating will *increase* the OD, capped at 35 units, but nothing prevents actually going over the OD). Overall, this is a nerf, but not having to worry about OD for a legendary property is still invaluable(good)

# Explain why it's good for the game
Surgically striking infinistims due to recent discovery of the gold mines research players been sitting on

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: Changed regulating property to instead set the OD of the chemical its in rather than prevent OD entirely.
/:cl:
