### PR TITLE
Limit all survivors to the same limit

### DIFF
--- a/code/game/jobs/job/antag/xeno/queen.dm
+++ b/code/game/jobs/job/antag/xeno/queen.dm
@@ -7,7 +7,7 @@
 	spawn_positions = 1
 
 /datum/job/antag/xenos/queen/set_spawn_positions(count)
-	return spawn_positions
+	return
 
 /datum/job/antag/xenos/queen/transform_to_xeno(mob/living/carbon/human/human_to_transform, hive_index)
 	SSticker.mode.pick_queen_spawn(human_to_transform, hive_index)

--- a/code/game/jobs/job/civilians/other/survivors.dm
+++ b/code/game/jobs/job/civilians/other/survivors.dm
@@ -29,6 +29,26 @@ GLOBAL_LIST_EMPTY(spawned_survivors)
 	spawn_positions = clamp((floor(count * SURVIVOR_TO_TOTAL_SPAWN_RATIO)), 2, 8)
 	total_positions = spawn_positions
 
+/datum/job/civilian/survivor/get_total_positions(latejoin)
+	var/normal_positions = ..()
+
+	// Determine the normal surv limit
+	var/datum/job/civilian/survivor/base_job = GLOB.RoleAuthority.roles_by_path[/datum/job/civilian/survivor]
+	if(!base_job)
+		stack_trace("/datum/job/civilian/survivor is not present in GLOB.RoleAuthority.roles_by_path!")
+		return 0
+	var/base_positions = latejoin ? base_job.total_positions : base_job.spawn_positions
+
+	// Count all current_positions
+	var/exisiting_positions = 0
+	for(var/other_surv_type in typesof(/datum/job/civilian/survivor))
+		var/datum/job/civilian/survivor/surv_job = GLOB.RoleAuthority.roles_by_path[other_surv_type]
+		if(surv_job)
+			exisiting_positions += surv_job.current_positions
+
+	var/available_positions = max(min(base_positions - exisiting_positions, normal_positions), 0)
+	return available_positions + current_positions // check_role_entry() checks our own current_positions count already
+
 /datum/job/civilian/survivor/create_landmark_lists()
 	slotted_landmarks = list()
 	available_landmarks = list()

--- a/code/game/jobs/job/civilians/other/survivors.dm
+++ b/code/game/jobs/job/civilians/other/survivors.dm
@@ -41,8 +41,8 @@ GLOBAL_LIST_EMPTY(spawned_survivors)
 
 	// Count all current_positions
 	var/exisiting_positions = 0
-	for(var/other_surv_type in typesof(/datum/job/civilian/survivor))
-		var/datum/job/civilian/survivor/surv_job = GLOB.RoleAuthority.roles_by_path[other_surv_type]
+	for(var/surv_type in typesof(/datum/job/civilian/survivor))
+		var/datum/job/civilian/survivor/surv_job = GLOB.RoleAuthority.roles_by_path[surv_type]
 		if(surv_job)
 			exisiting_positions += surv_job.current_positions
 

--- a/code/game/jobs/job/civilians/other/survivors.dm
+++ b/code/game/jobs/job/civilians/other/survivors.dm
@@ -281,7 +281,7 @@ AddTimelock(/datum/job/civilian/survivor, list(
 	job_options = null
 
 /datum/job/civilian/survivor/synth/set_spawn_positions(count)
-	return spawn_positions
+	return
 
 /datum/job/civilian/survivor/synth/create_landmark_lists()
 	slotted_landmarks = list()
@@ -355,7 +355,6 @@ AddTimelock(/datum/job/civilian/survivor, list(
 		return
 	total_positions = 1
 	spawn_positions = 1
-	return spawn_positions
 
 /datum/job/civilian/survivor/commanding_officer/create_landmark_lists()
 	slotted_landmarks = list()

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -206,7 +206,7 @@
 	return ""
 
 /datum/job/proc/set_spawn_positions(count)
-	return spawn_positions
+	return
 
 /datum/job/proc/create_landmark_lists()
 	return


### PR DESCRIPTION

# About the pull request

This PR does a couple things:
- Limits all survivors to the same limit (meaning CO & Synth survivors no longer can exceed normal count)
- Cleans up some inconsistent return values for `set_spawn_positions` (it doesn't need a retval)

This means that https://github.com/cmss13-devs/cmss13/blob/86fa7620deba224e3f380e006ed431a629e3bad2/code/game/jobs/job/civilians/other/survivors.dm#L28-L29

is respected for all survivors such that if the population only allows 3, its only 3 (rather than 3 + 0-2). No longer should it be possible to see 10 survivors in a single round.

# Explain why it's good for the game

During lowpop previously survivors could nearly double their intended count which is undesired.

# Testing Photographs and Procedure
<details>
<summary>Procedure</summary

1 normal + 1 synth (min 2) -> both spawned, one is synth
1 normal + 1 synth (min 1) -> only one spawned
2 normal (min 1) -> only one spawned
2 normal (min 2) -> both spawned
2 co (min 2) -> only one spawned
1 co + 1 synth (min 2) -> both spawned, one is synth
1 co + 1 synth (min 1) -> only one spawned

(When I say min 1 I mean changing `spawn_positions = clamp((floor(count * SURVIVOR_TO_TOTAL_SPAWN_RATIO)), 2, 8)` to `spawn_positions = clamp((floor(count * SURVIVOR_TO_TOTAL_SPAWN_RATIO)), 1, 8)`)

</details>


# Changelog
:cl: Drathek
balance: Synth and CO survivors now respect the normal survivor limit
/:cl:
