### PR TITLE
Sentries and machine guns can no longer be deployed inside tents

### DIFF
--- a/code/__DEFINES/dcs/signals/atom/signals_turf.dm
+++ b/code/__DEFINES/dcs/signals/atom/signals_turf.dm
@@ -21,6 +21,10 @@
  */
 #define COMSIG_TURF_ENTERED "turf_entered"
 
+/// Called when something attempts to deploy on the turf
+#define COMSIG_TURF_PRE_DEPLOYMENT "turf_pre_deployment"
+	#define COMPONENT_TURF_PRE_DEPLOYMENT_BLOCKED (1<<0)
+
 /// Called when a bullet hits a turf
 #define COMSIG_TURF_BULLET_ACT "turf_bullet_act"
 	#define COMPONENT_BULLET_ACT_OVERRIDE (1<<0)

--- a/code/__DEFINES/turfs.dm
+++ b/code/__DEFINES/turfs.dm
@@ -34,3 +34,9 @@
 #define TURF_FROM_COORDS_LIST(List) (locate(List[1], List[2], List[3]))
 
 #define IS_OPAQUE_TURF(turf) (turf.directional_opacity == ALL_CARDINALS)
+
+// Types of deployables for the purpose of COMSIG_TURF_PRE_DEPLOYMENT
+/// Deployable is a mounted gun
+#define TURF_DEPLOYABLE_GUN "gun"
+/// Deployable is an automated sentry
+#define TURF_DEPLOYABLE_SENTRY "sentry"

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -941,6 +941,11 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	if(damage_modifier > 0.5)
 		playsound(loc, "slam", 50, 1)
 
+/// Validate that a type of object can be deployed on this turf
+/turf/proc/validate_deployment(deployment_type)
+	var/ret = SEND_SIGNAL(src, COMSIG_TURF_PRE_DEPLOYMENT, deployment_type)
+	return !(ret && COMPONENT_TURF_PRE_DEPLOYMENT_BLOCKED)
+
 /turf/proc/on_climb_down(victim)
 	if(!isxeno(victim))
 		return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -944,7 +944,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 /// Validate that a type of object can be deployed on this turf
 /turf/proc/validate_deployment(deployment_type)
 	var/ret = SEND_SIGNAL(src, COMSIG_TURF_PRE_DEPLOYMENT, deployment_type)
-	return !(ret && COMPONENT_TURF_PRE_DEPLOYMENT_BLOCKED)
+	return !(ret & COMPONENT_TURF_PRE_DEPLOYMENT_BLOCKED)
 
 /turf/proc/on_climb_down(victim)
 	if(!isxeno(victim))

--- a/code/modules/cm_marines/m2c.dm
+++ b/code/modules/cm_marines/m2c.dm
@@ -109,12 +109,13 @@
 	if(!area.allow_construction)
 		to_chat(user, SPAN_WARNING("You can't set up \the [src] here."))
 		return
-	if(OT.density || !isturf(OT) || !OT.allow_construction)
+	if(OT.density || !isturf(OT) || !OT.allow_construction  || !OT.validate_deployment(TURF_DEPLOYABLE_GUN))
 		to_chat(user, SPAN_WARNING("You can't set up \the [src] here."))
 		return FALSE
 	if(rotate_check.density)
 		to_chat(user, SPAN_WARNING("You can't set up \the [src] that way, there's a wall behind you!"))
 		return FALSE
+
 	for(var/obj/structure/potential_blocker in rotate_check)
 		if(potential_blocker.density)
 			to_chat(user, SPAN_WARNING("You can't set up \the [src] that way, there's \a [potential_blocker] behind you!"))

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -146,7 +146,7 @@
 	var/turf/T = get_turf(usr)
 	if(istype(T, /turf/open))
 		var/turf/open/floor = T
-		if(!floor.allow_construction)
+		if(!floor.allow_construction || !floor.validate_deployment(TURF_DEPLOYABLE_GUN))
 			to_chat(user, SPAN_WARNING("You cannot install \the [src] here, find a more secure surface!"))
 			return FALSE
 	var/fail = FALSE
@@ -250,7 +250,7 @@
 	var/turf/T = get_turf(user)
 	if(istype(T, /turf/open))
 		var/turf/open/floor = T
-		if(!floor.allow_construction)
+		if(!floor.allow_construction || !floor.validate_deployment(TURF_DEPLOYABLE_GUN))
 			to_chat(user, SPAN_WARNING("You cannot install \the [src] here, find a more secure surface!"))
 			return FALSE
 	var/fail = FALSE

--- a/code/modules/defenses/defenses.dm
+++ b/code/modules/defenses/defenses.dm
@@ -319,7 +319,7 @@
 				to_chat(user, SPAN_WARNING("You cannot secure \the [src] here, find a more secure surface!"))
 				return
 			var/turf/open/floor = get_turf(src)
-			if(!floor.allow_construction)
+			if(!floor.allow_construction || !floor.validate_deployment(TURF_DEPLOYABLE_SENTRY))
 				to_chat(user, SPAN_WARNING("You cannot secure \the [src] here, find a more secure surface!"))
 				return FALSE
 			user.visible_message(SPAN_NOTICE("[user] begins securing [src] to the ground."),

--- a/code/modules/defenses/handheld.dm
+++ b/code/modules/defenses/handheld.dm
@@ -71,7 +71,7 @@
 		return
 	if(istype(T, /turf/open))
 		var/turf/open/floor = T
-		if(!floor.allow_construction)
+		if(!floor.allow_construction || !floor.validate_deployment(TURF_DEPLOYABLE_SENTRY))
 			to_chat(user, SPAN_WARNING("You cannot deploy \a [src] here, find a more secure surface!"))
 			return FALSE
 	else

--- a/code/modules/tents/deployed_tents.dm
+++ b/code/modules/tents/deployed_tents.dm
@@ -50,8 +50,19 @@
 /// Handler for callback of COMSIG_MOVABLE_TURF_ENTERED (turf changed)
 /obj/structure/tent/proc/register_turf_signals()
 	SIGNAL_HANDLER
-	for(var/turf/turf in locs)
+	for(var/turf/turf as anything in locs) // Make sure to change that and overriding if the tent can one day move.
 		RegisterSignal(turf, COMSIG_TURF_ENTERED, PROC_REF(movable_entering_tent), override = TRUE)
+		RegisterSignal(turf, COMSIG_TURF_PRE_DEPLOYMENT, PROC_REF(filter_turf_deployment), override = TRUE)
+
+/// Prevents deployment of sentries and mounted guns in the tent
+/obj/structure/tent/proc/filter_turf_deployment(turf/source, deployable_type)
+	SIGNAL_HANDLER
+	switch(deployable_type)
+		if(TURF_DEPLOYABLE_GUN)
+			return COMPONENT_TURF_PRE_DEPLOYMENT_BLOCKED
+		if(TURF_DEPLOYABLE_SENTRY)
+			return COMPONENT_TURF_PRE_DEPLOYMENT_BLOCKED
+	return NO_FLAGS
 
 /obj/structure/tent/proc/movable_entering_tent(turf/hooked, atom/movable/subject)
 	SIGNAL_HANDLER

--- a/code/modules/tents/folded_tents.dm
+++ b/code/modules/tents/folded_tents.dm
@@ -147,13 +147,13 @@
 /obj/item/folded_tent/big
 	name = "folded USCM Big Tent"
 	icon_state = "big"
-	desc = "A standard USCM Tent. This one is just a bigger, general purpose version. Unfold in a suitable location for maximum FOB vibes.. ENTRANCE TO THE SOUTH."
+	desc = "A standard USCM Tent. This one is just a bigger, general purpose version. Unfold in a suitable location to maximize FOB vibes. Bravo not included. ENTRANCE TO THE SOUTH."
 	template_preset = "tent_big"
 
 /obj/item/folded_tent/mess
 	name = "folded USCM Mess Tent"
 	icon_state = "mess"
-	desc = "A standard USCM Mess Tent. This one comes equipped with a kitchen and dining utilities. Unfold in a suitable location to maximize meal handouts ENTRANCE TO THE SOUTH."
+	desc = "A standard USCM Mess Tent. This one comes equipped with a kitchen and dining utilities. Unfold in a suitable location to maximize meal handouts. Mess Technician not included. ENTRANCE TO THE SOUTH."
 	template_preset = "tent_mess"
 
 /obj/effect/overlay/temp/tent_deployment_error


### PR DESCRIPTION

# About the pull request

Remake of #12971 based on signals instead of using extra objects - this prevent deploying sentries and mounted guns inside tents where they can shoot but are out of sight for xenos.  

Also a quick 2-liner flavor text fix back to the originally intended style of tents.

# Explain why it's good for the game

Ask @antlersss but presumably you don't want people shooting high-impact weapons from tents where they can't be seen.


# Testing Photographs and Procedure

Tested on Runtime deploying in/out of tents.


# Changelog

:cl: Fira, antlersss
balance: Sentries and mounted guns like M56D and M2C cannot be deployed inside tents anymore.
/:cl:
