### PR TITLE
Implements Abstract Datums

### DIFF
--- a/code/__HELPERS/_types.dm
+++ b/code/__HELPERS/_types.dm
@@ -1,0 +1,7 @@
+/// Like [subtypesof] but returns only datum types that haven't been marked as abstract
+/proc/subtypesof_real(input_path)
+	var/list/paths = subtypesof(input_path)
+	. = list()
+	for(var/datum/path as anything in paths)
+		if(path.abstract_type != path)
+			. += path

--- a/code/__HELPERS/datums.dm
+++ b/code/__HELPERS/datums.dm
@@ -1,3 +1,6 @@
+/// Marks a type as abstract. This means that it should not be instantiated and only exists as a type
+#define ABSTRACT_TYPE(type) type/abstract_type = type
+
 ///Check if a datum has not been deleted and is a valid source
 /proc/is_valid_src(datum/source_datum)
 	if(istype(source_datum))

--- a/code/_globalvars/bitfields.dm
+++ b/code/_globalvars/bitfields.dm
@@ -1,5 +1,6 @@
 GLOBAL_LIST_INIT(bitfields, generate_bitfields())
 
+ABSTRACT_TYPE(/datum/bitfield)
 /// Specifies a bitfield for smarter debugging
 /datum/bitfield
 	/// The variable name that contains the bitfield

--- a/code/_globalvars/global_lists.dm
+++ b/code/_globalvars/global_lists.dm
@@ -396,16 +396,14 @@ GLOBAL_LIST_INIT(wy_droid_emotes, setup_wy_droid_emotes())
 	return ammo_list
 
 /proc/setup_ammo()
-	var/list/blacklist = list(/datum/ammo/energy, /datum/ammo/energy/yautja, /datum/ammo/energy/yautja/rifle, /datum/ammo/bullet/shotgun, /datum/ammo/xeno)
-	var/list/ammo_list = list()
-	for(var/T in subtypesof(/datum/ammo) - blacklist)
+	. = list()
+	for(var/T in subtypesof_real(/datum/ammo))
 		var/datum/ammo/A = new T
-		ammo_list[A.type] = A
-	return ammo_list
+		.[A.type] = A
 
 /proc/setup_resin_constructions()
 	var/list/resin_constructions_list = list()
-	for (var/T in subtypesof(/datum/resin_construction) - list(/datum/resin_construction/resin_obj, /datum/resin_construction/resin_turf))
+	for (var/T in subtypesof_real(/datum/resin_construction))
 		var/datum/resin_construction/RC = new T
 		resin_constructions_list[T] = RC
 	return sortAssoc(resin_constructions_list)

--- a/code/controllers/configuration/config_entry.dm
+++ b/code/controllers/configuration/config_entry.dm
@@ -6,6 +6,7 @@
 #define KEY_MODE_TYPE 1
 #define KEY_MODE_TEXT_UNALTERED 2
 
+ABSTRACT_TYPE(/datum/config_entry)
 SET_PROTECTED_DATUM(/datum/config_entry)
 
 /datum/config_entry
@@ -19,7 +20,6 @@ SET_PROTECTED_DATUM(/datum/config_entry)
 	var/deprecated_by //the /datum/config_entry type that supercedes this one
 
 	var/protection = NONE
-	var/abstract_type = /datum/config_entry //do not instantiate if type matches this
 
 	var/vv_VAS = TRUE //Force validate and set on VV. VAS proccall guard will run regardless.
 
@@ -59,9 +59,9 @@ SET_PROTECTED_DATUM(/datum/config_entry)
 /datum/config_entry/proc/DeprecationUpdate(value)
 	return
 
+ABSTRACT_TYPE(/datum/config_entry/string)
 /datum/config_entry/string
 	config_entry_value = ""
-	abstract_type = /datum/config_entry/string
 	var/auto_trim = TRUE
 
 /datum/config_entry/string/ValidateAndSet(str_val)
@@ -70,9 +70,9 @@ SET_PROTECTED_DATUM(/datum/config_entry)
 	config_entry_value = auto_trim ? trim(str_val) : str_val
 	return TRUE
 
+ABSTRACT_TYPE(/datum/config_entry/number)
 /datum/config_entry/number
 	config_entry_value = 0
-	abstract_type = /datum/config_entry/number
 	var/integer = TRUE
 	var/max_val = INFINITY
 	var/min_val = -INFINITY
@@ -88,9 +88,9 @@ SET_PROTECTED_DATUM(/datum/config_entry)
 		return TRUE
 	return FALSE
 
+ABSTRACT_TYPE(/datum/config_entry/flag)
 /datum/config_entry/flag
 	config_entry_value = FALSE
-	abstract_type = /datum/config_entry/flag
 
 /datum/config_entry/flag/ValidateAndSet(str_val)
 	if(!VASProcCallGuard(str_val))
@@ -98,9 +98,9 @@ SET_PROTECTED_DATUM(/datum/config_entry)
 	config_entry_value = text2num(trim(str_val)) != 0
 	return TRUE
 
+ABSTRACT_TYPE(/datum/config_entry/str_list)
 /// List config entry, used for configuring a list of strings
 /datum/config_entry/str_list
-	abstract_type = /datum/config_entry/str_list
 	config_entry_value = list()
 	dupes_allowed = TRUE
 
@@ -112,8 +112,8 @@ SET_PROTECTED_DATUM(/datum/config_entry)
 		config_entry_value += str_val
 	return TRUE
 
+ABSTRACT_TYPE(/datum/config_entry/number_list)
 /datum/config_entry/number_list
-	abstract_type = /datum/config_entry/number_list
 	config_entry_value = list()
 
 /datum/config_entry/number_list/ValidateAndSet(str_val)
@@ -132,8 +132,8 @@ SET_PROTECTED_DATUM(/datum/config_entry)
 	config_entry_value = new_list
 	return TRUE
 
+ABSTRACT_TYPE(/datum/config_entry/keyed_list)
 /datum/config_entry/keyed_list
-	abstract_type = /datum/config_entry/keyed_list
 	config_entry_value = list()
 	dupes_allowed = TRUE
 	vv_VAS = FALSE //VAS will not allow things like deleting from lists, it'll just bug horribly.

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -30,8 +30,8 @@
 	integer = FALSE
 	min_val = -1
 
-/datum/config_entry/number/movedelay //Used for modifying movement speed for mobs.
-	abstract_type = /datum/config_entry/number/movedelay
+ABSTRACT_TYPE(/datum/config_entry/number/movedelay)
+/datum/config_entry/number/movedelay //! Used for modifying movement speed for mobs.
 
 /datum/config_entry/number/movedelay/run_delay
 	config_entry_value = 0

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -311,8 +311,7 @@ Master controller and performance related.
 /datum/config_entry/number/mc_tick_rate/disable_high_pop_mc_mode_amount
 	config_entry_value = 60
 
-/datum/config_entry/number/mc_tick_rate
-	abstract_type = /datum/config_entry/number/mc_tick_rate
+ABSTRACT_TYPE(/datum/config_entry/number/mc_tick_rate)
 
 /datum/config_entry/number/mc_tick_rate/ValidateAndSet(str_val)
 	. = ..()

--- a/code/controllers/subsystem/reagents.dm
+++ b/code/controllers/subsystem/reagents.dm
@@ -67,8 +67,7 @@ SUBSYSTEM_DEF(reagents)
 	//I dislike having these here but map-objects are initialised before world/New() is called. >_>
 	set waitfor = FALSE
 	//Chemical Reagents - Initialises all /datum/reagent into a list indexed by reagent id
-	//Generated chemicals should be initialized last, hence the substract then readd.
-	var/list/paths = subtypesof(/datum/reagent) - typesof(/datum/reagent/generated) - subtypesof(/datum/reagent/generated) + subtypesof(/datum/reagent/generated)
+	var/list/paths = subtypesof(/datum/reagent) - /datum/reagent/generated
 	GLOB.chemical_reagents_list = list()
 	for(var/path in paths)
 		var/datum/reagent/chem = new path()
@@ -79,12 +78,11 @@ SUBSYSTEM_DEF(reagents)
 	// It is filtered into multiple lists within a list.
 	// For example:
 	// chemical_reaction_list["phoron"] is a list of all reactions relating to phoron
-	var/list/regular_paths = subtypesof(/datum/chemical_reaction) - typesof(/datum/chemical_reaction/generated)
-	var/list/generated_paths = subtypesof(/datum/chemical_reaction/generated) //Generated chemicals should be initialized last
+	var/list/regular_paths = subtypesof(/datum/chemical_reaction) - /datum/chemical_reaction/generated
 	GLOB.chemical_reactions_filtered_list = list()
 	GLOB.chemical_reactions_list = list()
 
-	for(paths in list(regular_paths, generated_paths))
+	for(paths in regular_paths)
 		for(var/path in paths)
 			var/datum/chemical_reaction/react = new path()
 			GLOB.chemical_reactions_list[react.id] = react

--- a/code/datums/ammo/ammo.dm
+++ b/code/datums/ammo/ammo.dm
@@ -1,3 +1,4 @@
+ABSTRACT_TYPE(/datum/ammo)
 /datum/ammo
 	var/name = "generic bullet"
 	//Icon state when a human is permanently killed with it by execution/suicide.

--- a/code/datums/ammo/bullet/shotgun.dm
+++ b/code/datums/ammo/bullet/shotgun.dm
@@ -4,6 +4,7 @@
 //======
 */
 
+ABSTRACT_TYPE(/datum/ammo/bullet/shotgun)
 /datum/ammo/bullet/shotgun
 	headshot_state = HEADSHOT_OVERLAY_HEAVY
 	handful_type = /obj/item/ammo_magazine/handful/shotgun

--- a/code/datums/ammo/energy.dm
+++ b/code/datums/ammo/energy.dm
@@ -4,6 +4,7 @@
 //======
 */
 
+ABSTRACT_TYPE(/datum/ammo/energy)
 /datum/ammo/energy
 	ping = null //no bounce off. We can have one later.
 	sound_hit = "energy_hit"
@@ -71,6 +72,7 @@
 	accuracy = HIT_ACCURACY_TIER_3
 	damage_falloff = DAMAGE_FALLOFF_TIER_8
 
+ABSTRACT_TYPE(/datum/ammo/energy/yautja)
 /datum/ammo/energy/yautja
 	headshot_state = HEADSHOT_OVERLAY_MEDIUM
 	accurate_range = 12
@@ -133,7 +135,7 @@
 		any_target.apply_effect(stun_time, STUN)
 	..()
 
-/datum/ammo/energy/yautja/caster/sphere/aoe_stun
+/datum/ammo/energy/yautja/caster/sphere_aoe_stun
 	name = "plasma immobilizer"
 	damage = 0
 	flags_ammo_behavior = AMMO_ENERGY|AMMO_IGNORE_RESIST
@@ -143,19 +145,19 @@
 	var/stun_range = 7 // Big
 	var/stun_time = 6
 
-/datum/ammo/energy/yautja/caster/sphere/aoe_stun/on_hit_mob(mob/all_targets, obj/projectile/stun_projectile)
+/datum/ammo/energy/yautja/caster/sphere_aoe_stun/on_hit_mob(mob/all_targets, obj/projectile/stun_projectile)
 	do_area_stun(stun_projectile)
 
-/datum/ammo/energy/yautja/caster/sphere/aoe_stun/on_hit_turf(turf/any_turf, obj/projectile/stun_projectile)
+/datum/ammo/energy/yautja/caster/sphere_aoe_stun/on_hit_turf(turf/any_turf, obj/projectile/stun_projectile)
 	do_area_stun(stun_projectile)
 
-/datum/ammo/energy/yautja/caster/sphere/aoe_stun/on_hit_obj(obj/any_object, obj/projectile/stun_projectile)
+/datum/ammo/energy/yautja/caster/sphere_aoe_stun/on_hit_obj(obj/any_object, obj/projectile/stun_projectile)
 	do_area_stun(stun_projectile)
 
-/datum/ammo/energy/yautja/caster/sphere/aoe_stun/do_at_max_range(obj/projectile/stun_projectile)
+/datum/ammo/energy/yautja/caster/sphere_aoe_stun/do_at_max_range(obj/projectile/stun_projectile)
 	do_area_stun(stun_projectile)
 
-/datum/ammo/energy/yautja/caster/sphere/aoe_stun/proc/do_area_stun(obj/projectile/stun_projectile)
+/datum/ammo/energy/yautja/caster/sphere_aoe_stun/proc/do_area_stun(obj/projectile/stun_projectile)
 	playsound(stun_projectile, 'sound/weapons/wave.ogg', 75, 1, 25)
 
 	for(var/mob/living/carbon/any_target in orange(stun_range, stun_projectile))
@@ -293,7 +295,7 @@
 	shaboomboom(projectile, get_turf(projectile))
 	cell_explosion(get_turf(projectile), 100, 50, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, projectile.weapon_cause_data)
 
-/datum/ammo/energy/yautja/rifle/bolt
+/datum/ammo/energy/yautja/rifle_bolt
 	name = "plasma rifle bolt"
 	icon_state = "ion"
 	damage_type = BURN
@@ -303,13 +305,13 @@
 	damage = 55
 	penetration = ARMOR_PENETRATION_TIER_10
 
-/datum/ammo/energy/yautja/rifle/bolt/on_hit_mob(mob/hit_mob, obj/projectile/hit_projectile)
+/datum/ammo/energy/yautja/rifle_bolt/on_hit_mob(mob/hit_mob, obj/projectile/hit_projectile)
 	if(isxeno(hit_mob))
 		var/mob/living/carbon/xenomorph/xeno = hit_mob
 		xeno.apply_damage(damage * 0.75, BURN)
 		xeno.AddComponent(/datum/component/status_effect/interference, 30, 30)
 
-/datum/ammo/energy/yautja/rifle/bolt/set_bullet_traits()
+/datum/ammo/energy/yautja/rifle_bolt/set_bullet_traits()
 	. = ..()
 	LAZYADD(traits_to_give, list(
 		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_incendiary)

--- a/code/datums/ammo/xeno.dm
+++ b/code/datums/ammo/xeno.dm
@@ -3,6 +3,7 @@
 					Xeno Spits
 //======
 */
+ABSTRACT_TYPE(/datum/ammo/xeno)
 /datum/ammo/xeno
 	icon_state = "neurotoxin"
 	ping = "ping_x"

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -9,6 +9,8 @@
 * use of variables at this level
 */
 /datum
+
+
 	/**
 	* Tick count time when this object was destroyed.
 	*
@@ -56,6 +58,18 @@
 
 	/// The weakref pointing to this datum; ref reuse can cause weakrefs to resolve to the wrong object, so we compare it against this.
 	var/datum/weakref/weak_reference
+
+	/**
+	 * Parent types.
+	 *
+	 * Abstract-ness is a meta-property of a class that is used to indicate
+	 * that the class is intended to be used as a base class for others, and
+	 * should not (or cannot) be instantiated.
+	 * We have no such language concept in DM, and so we provide a datum member
+	 * that can be used to hint at abstractness for circumstances where we would
+	 * like that to be the case, such as base behavior providers.
+	 */
+	var/abstract_type = /datum
 
 #ifdef REFERENCE_TRACKING
 	/// When was this datum last touched by a reftracker?

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1,4 +1,5 @@
 
+ABSTRACT_TYPE(/atom)
 /atom
 	var/desc_lore = null
 

--- a/code/game/gamemodes/round_modifiers.dm
+++ b/code/game/gamemodes/round_modifiers.dm
@@ -34,11 +34,11 @@
 	modifier.set_active(enabled)
 	return TRUE
 
+ABSTRACT_TYPE(/datum/gamemode_modifier)
 /datum/gamemode_modifier
 	var/active = FALSE
 	var/modifier_name
 	var/modifier_desc
-	var/datum/gamemode_modifier/abstract_type = /datum/gamemode_modifier
 
 /datum/gamemode_modifier/proc/set_active(enabled = FALSE)
 	SHOULD_CALL_PARENT(TRUE)

--- a/code/game/objects/effects/decals/posters.dm
+++ b/code/game/objects/effects/decals/posters.dm
@@ -114,6 +114,7 @@
 	SSclues.create_print(get_turf(user), user, "The fingerprint contains paper pieces.")
 	SEND_SIGNAL(P, COMSIG_POSTER_PLACED, user)
 
+ABSTRACT_TYPE(/datum/poster)
 /datum/poster
 	// Name suffix. Poster - [name]
 	var/name=""

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -1,3 +1,4 @@
+ABSTRACT_TYPE(/obj)
 /obj
 	/// Used to store information about the contents of the object.
 	var/list/matter

--- a/code/modules/cm_preds/mcaste_weapons.dm
+++ b/code/modules/cm_preds/mcaste_weapons.dm
@@ -8,7 +8,7 @@
 	item_state = "plasmacarbine"
 	unacidable = TRUE
 	fire_sound = 'sound/weapons/pred_plasma_shot.ogg'
-	ammo = /datum/ammo/energy/yautja/rifle/bolt
+	ammo = /datum/ammo/energy/yautja/rifle_bolt
 	flags_equip_slot = SLOT_BACK
 	w_class = SIZE_LARGE
 	pixel_x = -2
@@ -109,7 +109,7 @@
 			shot_cost = 1
 			fire_delay = FIRE_DELAY_TIER_8
 			to_chat(usr, SPAN_NOTICE("[src] will now fire incendiary plasma bolts."))
-			ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/rifle/bolt] // high ap and incendiary, but lower damage than the impact-explosive
+			ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/rifle_bolt] // high ap and incendiary, but lower damage than the impact-explosive
 
 #undef FIRE_MODE_INCENDIARY
 #undef FIRE_MODE_EXPLOSIVE

--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -1414,7 +1414,7 @@
 	item_state = "plasmarifle"
 	unacidable = TRUE
 	fire_sound = 'sound/weapons/pred_plasma_shot.ogg'
-	ammo = /datum/ammo/energy/yautja/rifle/bolt
+	ammo = /datum/ammo/energy/yautja/rifle_bolt
 	zoomdevicename = "scope"
 	flags_equip_slot = SLOT_BACK
 	w_class = SIZE_HUGE
@@ -1472,7 +1472,7 @@
 	return ..()
 
 /obj/item/weapon/gun/energy/yautja/plasmarifle/load_into_chamber()
-	ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/rifle/bolt]
+	ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/rifle_bolt]
 	charge_time -= 7
 	var/obj/projectile/projectile = create_bullet(ammo, initial(name))
 	projectile.set_light(1)
@@ -1681,7 +1681,7 @@
 					set_fire_delay(FIRE_DELAY_TIER_2 * 8)
 					fire_sound = 'sound/weapons/pulse.ogg'
 					to_chat(user, SPAN_NOTICE("[src] will now fire [strength]."))
-					ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/sphere/aoe_stun]
+					ammo = GLOB.ammo_list[/datum/ammo/energy/yautja/caster/sphere_aoe_stun]
 				if("plasma immobilizers")
 					strength = "stun bolts"
 					charge_cost = 30

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -110,8 +110,6 @@ GLOBAL_LIST_INIT_TYPED(sentry_spawns, /list/obj/effect/sentry_landmark, list())
 	icon = 'icons/landmarks.dmi'
 	icon_state = "map_sentry"
 
-	var/abstract_type = /obj/effect/sentry_landmark
-
 	/// Which landing zone this landmark should be connected to
 	var/landing_zone
 
@@ -132,8 +130,8 @@ GLOBAL_LIST_INIT_TYPED(sentry_spawns, /list/obj/effect/sentry_landmark, list())
 
 	return INITIALIZE_HINT_QDEL
 
+ABSTRACT_TYPE(/obj/effect/sentry_landmark/lz_1)
 /obj/effect/sentry_landmark/lz_1
-	abstract_type = /obj/effect/sentry_landmark/lz_1
 	landing_zone = /obj/docking_port/stationary/marine_dropship/lz1
 
 /obj/effect/sentry_landmark/lz_1/top_left
@@ -148,8 +146,8 @@ GLOBAL_LIST_INIT_TYPED(sentry_spawns, /list/obj/effect/sentry_landmark, list())
 /obj/effect/sentry_landmark/lz_1/bottom_right
 	position = SENTRY_BOTTOM_RIGHT
 
+ABSTRACT_TYPE(/obj/effect/sentry_landmark/lz_2)
 /obj/effect/sentry_landmark/lz_2
-	abstract_type = /obj/effect/sentry_landmark/lz_2
 	landing_zone = /obj/docking_port/stationary/marine_dropship/lz2
 
 /obj/effect/sentry_landmark/lz_2/top_left

--- a/code/modules/mob/dead/death.dm
+++ b/code/modules/mob/dead/death.dm
@@ -1,3 +1,5 @@
+ABSTRACT_TYPE(/mob/dead)
+
 /mob/dead/dust() //ghosts can't be vaporised.
 	return
 

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -1,3 +1,4 @@
+ABSTRACT_TYPE(/mob/living/carbon)
 /mob/living/carbon
 	gender = MALE
 	mobility_flags = MOBILITY_FLAGS_CARBON_DEFAULT

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -2,6 +2,7 @@
 	Datum-based species. Should make for much cleaner and easier to maintain mutantrace code.
 */
 
+ABSTRACT_TYPE(/datum/species)
 /datum/species
 	///Used for isx(y) checking of species groups
 	var/group

--- a/code/modules/mob/living/carbon/xenomorph/castes/caste_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/caste_datum.dm
@@ -1,4 +1,5 @@
 // Actual caste datum basedef
+ABSTRACT_TYPE(/datum/caste_datum)
 /datum/caste_datum
 	var/caste_type = ""
 	var/display_name = ""

--- a/code/modules/mob/living/carbon/xenomorph/resin_constructions.dm
+++ b/code/modules/mob/living/carbon/xenomorph/resin_constructions.dm
@@ -106,6 +106,7 @@
 		return TRUE
 	return FALSE
 
+ABSTRACT_TYPE(/datum/resin_construction/resin_obj)
 // Subtype encompassing all resin constructions that are of type /obj
 /datum/resin_construction/resin_obj/build(turf/build_turf, hivenumber, mob/living/carbon/xenomorph/builder)
 	var/path = check_thick_build(build_turf, hivenumber, builder) ? build_path_thick : build_path
@@ -113,6 +114,7 @@
 		return new path(build_turf, hivenumber, builder)
 	return new path(build_turf)
 
+ABSTRACT_TYPE(/datum/resin_construction/resin_turf)
 // Subtype encompassing all resin constructions that are of type /turf
 /datum/resin_construction/resin_turf/build(turf/build_turf, hivenumber, mob/living/carbon/xenomorph/builder)
 	var/path = check_thick_build(build_turf, hivenumber, builder) ? build_path_thick : build_path

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -1,3 +1,4 @@
+ABSTRACT_TYPE(/mob/living)
 /mob/living
 	see_invisible = SEE_INVISIBLE_LIVING
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -1,3 +1,4 @@
+ABSTRACT_TYPE(/mob)
 /mob
 	density = TRUE
 	layer = MOB_LAYER

--- a/code/modules/unit_tests/missing_icons.dm
+++ b/code/modules/unit_tests/missing_icons.dm
@@ -43,12 +43,7 @@
 	var/original_baseturf_count = length(original_baseturfs)
 
 	// Check objects:
-	for(var/obj/obj_path as anything in subtypesof(/obj))
-		if(ispath(obj_path, /obj/item))
-			var/obj/item/item_path = obj_path
-			if(initial(item_path.flags_item) & ITEM_ABSTRACT)
-				continue // Ignore abstract
-
+	for(var/obj/obj_path as anything in subtypesof_real(/obj))
 		// Ensure that it's not invisible/honk in mapping
 		var/initial_icon = initial(obj_path.icon)
 		var/initial_icon_state = initial(obj_path.icon_state)

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -181,6 +181,7 @@
 #include "code\__HELPERS\#maths.dm"
 #include "code\__HELPERS\_lists.dm"
 #include "code\__HELPERS\_time.dm"
+#include "code\__HELPERS\_types.dm"
 #include "code\__HELPERS\animations.dm"
 #include "code\__HELPERS\chat.dm"
 #include "code\__HELPERS\cmp.dm"


### PR DESCRIPTION
# About the pull request

Implements Abstract Datums, those that we mark as only existing for inheritance or static checking. 

The point of this is mainly twofold: 
 * Allow code using subtypesof for example to instantiate things to skip abstract ones
 * Allow unit tests to skip checking things that won't normally exist in the game anyway and might lack critical props

The first is exposed through a new proc `subtypesof_real` which filters abstract types.
The second in particular is used for the icon checking unit test. 

I also killed a few non-warranted empty subtypes in ammo.
**This also re-elects ITEM_ABSTRACT items for icon unit tests, but might require reverting if it turns out to allow too many false positives.**

# Testing

Did basic testing only, but the failure surface is pretty low. Short of a blatant mistake with the first case, there shouldn't be any issues.