### PR TITLE
Sentinel Oxy Damage Nerf

### DIFF
--- a/code/datums/effects/xeno_strains/sentinel_neuro_stacks.dm
+++ b/code/datums/effects/xeno_strains/sentinel_neuro_stacks.dm
@@ -16,7 +16,7 @@
 	///how much oxy damage should be given per process
 	var/proc_damage_per_stack = 0.2
 	///stopgrap for oxy damage on mob when this stops causing harm
-	var/max_oxyloss = 50
+	var/max_oxyloss = 20
 	///particles
 	var/obj/effect/abstract/particle_holder/particle_holder
 


### PR DESCRIPTION
# About the pull request

Yes this is very similar to a prior PR, it was suggested in the Discord that the prior PR was not something that the maintainers were wholly disinterested in and the original author closed it simply because she realized it was intended to have the current values. 

# Explain why it's good for the game

Sentinel post rework is highly oppressive and many people are complaining about it regularly, 50 oxyloss is too much damage for the lowest risk offensive caste. I have seen many people say that they believe Sentinel is stronger than Spitter now, and I'm inclined to agree based on my experience. This needs adjusting. Not particularly attached to the value of 20 if a maintainer wants it somewhere else. 

# Changelog

:cl: Orchidfox
balance: Sentinel max neuro oxyloss reduced from 50 to 20
/:cl: