### PR TITLE
Alternative Sentinel Oxy Damage Nerf

### DIFF
--- a/code/datums/effects/xeno_strains/sentinel_neuro_stacks.dm
+++ b/code/datums/effects/xeno_strains/sentinel_neuro_stacks.dm
@@ -16,9 +16,9 @@
 	///how much oxy damage should be given per process
 	var/proc_damage_per_stack = 0.2
 	///Maximum oxyloss is clamped between these two bounds, this prevents someone from achieving high oxyloss by keeping someone on 5-10 stacks for a long time. To get high damage, you need high stacks.
-	var/max_oxyloss_lower_bound = 15
-	var/max_oxyloss_upper_bound = 45
-	var/max_oxyloss = 15
+	var/max_oxyloss_lower_bound = 10
+	var/max_oxyloss_upper_bound = 40
+	var/max_oxyloss = 10
 	///particles
 	var/obj/effect/abstract/particle_holder/particle_holder
 

--- a/code/datums/effects/xeno_strains/sentinel_neuro_stacks.dm
+++ b/code/datums/effects/xeno_strains/sentinel_neuro_stacks.dm
@@ -15,8 +15,10 @@
 	var/increment_grace_time = 50
 	///how much oxy damage should be given per process
 	var/proc_damage_per_stack = 0.2
-	///stopgrap for oxy damage on mob when this stops causing harm
-	var/max_oxyloss = 50
+	///Maximum oxyloss is clamped between these two bounds, this prevents someone from achieving high oxyloss by keeping someone on 5-10 stacks for a long time. To get high damage, you need high stacks.
+	var/max_oxyloss_lower_bound = 15
+	var/max_oxyloss_upper_bound = 45
+	var/max_oxyloss = 15
 	///particles
 	var/obj/effect/abstract/particle_holder/particle_holder
 
@@ -39,6 +41,8 @@
 	. = ..()
 
 	var/mob/living/carbon/human/human = affected_atom
+	var/stack_ratio = stack_count / max_stacks
+	max_oxyloss = max_oxyloss_lower_bound + (stack_ratio * (max_oxyloss_upper_bound - max_oxyloss_lower_bound))
 	if(human.oxyloss < max_oxyloss)
 		human.apply_damage(min(max_oxyloss - human.oxyloss, proc_damage_per_stack * stack_count, 5), OXY)
 	human.update_xeno_hostile_hud()


### PR DESCRIPTION
# About the pull request

The way this works is basically that the amount of oxy damage you can accumulate is based on the max stacks. What this means is that if a Sentinel is going to repeatedly peek out of cover and take pot shots you, you won't accumulate nearly as much oxy damage as before. To build big oxy damage on a Marine, you need to try and get as many stacks on them as possible, ideally hitting the cap. This changes nothing as well about how oxyloss healing works. Suggestion by DaTimeSmog.

Closes https://github.com/cmss13-devs/cmss13/pull/12998

# Explain why it's good for the game

Ideally I'd still like Sentinels to be able to play aggressively and deal decent damage as a reward. This should deal with the issue while still allowing Sentinels to be scary on an isolated target beyond just the moveslow. I also think doing it this way makes more sense to players, because the way it worked before is rather unintuitive. Now even without perfectly understanding oxygen damage, you don't get surprised by a lot of oxygen damage with only 5-10 stacks. 


# Testing Photographs and Procedure
<details>
<summary>Video</summary>

https://www.youtube.com/watch?v=7qLyfK_Pyv8

</details>


# Changelog

:cl: Orchidfox
balance: Sentinel max neuro oxyloss now scales with neuro stacks
balance: Sentinel maximum oxyloss lowered to 40
/:cl:
