### PR TITLE
Poppy Pretzel Fix

### DIFF
--- a/code/datums/recipe.dm
+++ b/code/datums/recipe.dm
@@ -966,7 +966,7 @@
 
 /datum/recipe/poppypretzel
 	items = list(
-		/obj/item/seeds/poppyseed,
+		/obj/item/reagent_container/food/snacks/grown/poppy,
 		/obj/item/reagent_container/food/snacks/dough,
 	)
 	result = /obj/item/reagent_container/food/snacks/poppypretzel


### PR DESCRIPTION

# About the pull request

You can make more then 3 pretzels a round!

This was the easiest way to do this without needing to rewrite hydroponics.dm or microwave.dm which both suck.

# Explain why it's good for the game
Mess techs should be allowed to make more then 3 pretzels per round. Also bug bad
Fixes https://github.com/cmss13-devs/cmss13/issues/12890
# Changelog
:cl: Armsdealer9876
fix: Poppy Pretzel recipe now uses poppies instead of seeds
/:cl:
