### PR TITLE
UPP CO Survivor Language fix

### DIFF
--- a/code/modules/gear_presets/survivors/trijent/crashlanding_upp_bar_insert_trijent.dm
+++ b/code/modules/gear_presets/survivors/trijent/crashlanding_upp_bar_insert_trijent.dm
@@ -183,7 +183,15 @@
 	role_comm_title = "MSS-Off."
 	minimap_icon = "upp_plt"
 	skills = /datum/skills/military/survivor/upp_sl/mss
-	languages = ALL_HUMAN_LANGUAGES
+	languages = list(
+		LANGUAGE_RUSSIAN,
+		LANGUAGE_ENGLISH,
+		LANGUAGE_JAPANESE,
+		LANGUAGE_CHINESE,
+		LANGUAGE_GERMAN,
+		LANGUAGE_SPANISH,
+		LANGUAGE_FRENCH,
+	)
 	access = list(
 		ACCESS_UPP_GENERAL,
 		ACCESS_UPP_MEDICAL,


### PR DESCRIPTION

# About the pull request

This PR makes the UPP CO survivor speak Russian by default

# Explain why it's good for the game
# Testing Photographs and Procedure
Issue caused by ALL_HUMAN_LANGUAGES having English at the top.

</details>


# Changelog
:cl:
fix: the UPP MSS CO Survivor now speaks Russian by default
/:cl:
