### PR TITLE
Fix: AMR doing Wall damage to mobs on reflection.

### DIFF
--- a/code/datums/elements/bullet_trait/damage_boost.dm
+++ b/code/datums/elements/bullet_trait/damage_boost.dm
@@ -79,7 +79,7 @@ GLOBAL_LIST_INIT(damage_boost_vehicles, typecacheof(/obj/vehicle/multitile))
 				active_damage_mult = damage_mult
 		if("wall")
 			var/turf/closed/wall/hit_wall = hit_atom
-			if(locate(/mob/living) in hit_wall)
+			if(locate(/mob/living/carbon) in hit_wall)
 				active_damage_mult = 1 //block bonus damage reflected on mobs from wall turfs
 			else
 				active_damage_mult = damage_mult

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -1481,7 +1481,7 @@
 		return
 
 	//Ineffective if someone is sitting on the wall
-	if(locate(/mob) in contents)
+	if(locate(/mob/living/carbon) in contents)
 		return ..()
 
 	if(!prob(chance_to_reflect))

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -1489,6 +1489,10 @@
 			proj_bullet.damage *= brute_multiplier
 		return ..()
 
+	if(proj_bullet.damage_boosted)
+		proj_bullet.damage = proj_bullet.ammo.damage
+		proj_bullet.damage_boosted = 0
+
 	var/atom/target = proj_bullet.firer
 	if(!target)
 		return ..()


### PR DESCRIPTION

# About the pull request
Resolves: #13016

Stops Walls from doing funny number damage to mobs. Still hurts... a lot.
Achieved by just resetting the damage to base on reflect.

Stops Reflective walls being disabled when a ghost or simple mob is ontop of them.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Funny insta kill from 1375~ damage bad... apparently.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Bullets affected by reflective walls keeping their boosted damage.
fix: Limits the amount of mobs that can stop reflective walls reflecting to mob/living/carbon derivatives 
/:cl:
