### PR TITLE
Deadmin persists through reconnect/reloadadmin

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -2,6 +2,9 @@ GLOBAL_LIST_EMPTY(clients) //all clients
 GLOBAL_LIST_EMPTY(admins) //all clients whom are admins
 GLOBAL_PROTECT(admins)
 
+GLOBAL_LIST_EMPTY(deadmins)
+GLOBAL_PROTECT(deadmins)
+
 GLOBAL_LIST_EMPTY(directory) //all ckeys with associated client
 
 GLOBAL_DATUM(all_player_keys_regex, /regex)

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -160,7 +160,7 @@ GLOBAL_LIST_EMPTY(admin_ranks) //list of all ranks with associated rights
 	var/datum/admins/D = new /datum/admins(rank, rights, ckey, extra_titles)
 
 	//find the client for a ckey if they are connected and associate them with the new admin datum
-	INVOKE_ASYNC(D, TYPE_PROC_REF(/datum/admins, associate), GLOB.directory[ckey])
+	INVOKE_ASYNC(D, TYPE_PROC_REF(/datum/admins, associate_or_deadmin), GLOB.directory[ckey])
 
 /datum/config_entry/string/cmdb_url
 	protection = CONFIG_ENTRY_LOCKED
@@ -351,7 +351,7 @@ GLOBAL_LIST_EMPTY(admin_ranks) //list of all ranks with associated rights
 
 		var/datum/admins/admin_datum = new(changed_user["display_name"], final_rights, changed_user["ckey"], additional_title)
 
-		INVOKE_ASYNC(admin_datum, TYPE_PROC_REF(/datum/admins, associate), GLOB.directory[changed_user["ckey"]])
+		INVOKE_ASYNC(admin_datum, TYPE_PROC_REF(/datum/admins, associate_or_deadmin), GLOB.directory[changed_user["ckey"]])
 
 		cached_api_response[changed_user["ckey"]] = changed_user
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -386,6 +386,7 @@ GLOBAL_LIST_INIT(mentor_verbs, list(
 		GLOB.admin_verbs_hideable,
 		GLOB.debug_verbs,
 		GLOB.admin_verbs_stealth,
+		GLOB.admin_verbs_logs
 	))
 
 /client/proc/jobbans()

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -52,6 +52,15 @@ GLOBAL_PROTECT(href_token)
 		return FALSE
 	return ..()
 
+/datum/admins/proc/associate_or_deadmin(client/target, force = FALSE)
+	if(!istype(target))
+		return
+
+	if(GLOB.deadmins[target.ckey])
+		add_verb(target, /client/proc/readmin_self)
+		return
+	associate(target, force)
+
 /datum/admins/proc/associate(client/C, force = FALSE)
 	if(!istype(C))
 		return
@@ -66,6 +75,7 @@ GLOBAL_PROTECT(href_token)
 	owner.tgui_say.load()
 	owner.update_special_keybinds()
 	GLOB.admins |= C
+	GLOB.deadmins[owner.ckey] = FALSE
 
 	if(rights & R_MOD)
 		notify_login()
@@ -156,7 +166,7 @@ you will have to do something like if(client.admin_holder.rights & R_ADMIN) your
 		return PROC_BLOCKED
 	if(admin_holder)
 		admin_holder.disassociate()
-		QDEL_NULL(admin_holder)
+		GLOB.deadmins[ckey] = TRUE
 	return TRUE
 
 /client/proc/readmin()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -452,7 +452,7 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 	//Admin Authorisation
 	var/holder = GLOB.admin_datums[ckey]
 	if(holder)
-		INVOKE_ASYNC(holder, TYPE_PROC_REF(/datum/admins, associate), src)
+		INVOKE_ASYNC(holder, TYPE_PROC_REF(/datum/admins, associate_or_deadmin), src)
 
 	add_pref_verbs()
 	//preferences datum - also holds some persistent data for the client (because we may as well keep these datums to a minimum)


### PR DESCRIPTION

# About the pull request

As title says
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
I want to stay deadminned without having to redeadmin any time IP/CID 2auth gets reloaded or I disconnect/reconnect.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
admin: Admins will stay deadminned when they deadmin through reconnects/reloadadmin
/:cl:
