### PR TITLE
Fix: Brig Timers display not fitting all the information

### DIFF
--- a/code/game/machinery/doors/brig_system.dm
+++ b/code/game/machinery/doors/brig_system.dm
@@ -350,7 +350,7 @@
 	overlays += image('icons/obj/structures/machinery/status_display.dmi', icon_state=picture_state)
 
 /obj/structure/machinery/brig_cell/proc/update_display(line1, line2)
-	var/new_text = {"<div style="font-family:'Roboto'; font-weight:bold; color:#09f;text-align:center;" valign="top">[line1]<br>[line2]</div>"}
+	var/new_text = {"<div style="font-family:'Roboto', sans-serif; color:#09f;text-align:center;" valign="top">[line1]<br>[line2]</div>"}
 	if(maptext != new_text)
 		maptext = new_text
 

--- a/code/game/machinery/doors/brig_system.dm
+++ b/code/game/machinery/doors/brig_system.dm
@@ -350,7 +350,7 @@
 	overlays += image('icons/obj/structures/machinery/status_display.dmi', icon_state=picture_state)
 
 /obj/structure/machinery/brig_cell/proc/update_display(line1, line2)
-	var/new_text = {"<div style="font-family:'Roboto'; font-weight:bold; font-size:1em; color:#09f;text-align:center;" valign="top">[line1]<br>[line2]</div>"}
+	var/new_text = {"<div style="font-family:'Roboto'; font-weight:bold; color:#09f;text-align:center;" valign="top">[line1]<br>[line2]</div>"}
 	if(maptext != new_text)
 		maptext = new_text
 

--- a/code/game/machinery/doors/brig_system.dm
+++ b/code/game/machinery/doors/brig_system.dm
@@ -325,7 +325,7 @@
 		if (active_report.incident.status & BRIG_SENTENCE_PERMA)
 			disp2 = "PERM"
 		else
-			disp2 = "[add_zero(num2text((time_left / 60) % 60),2)]~[add_zero(num2text(time_left % 60), 2)]"
+			disp2 = "[add_zero(num2text((time_left / 60) % 60),2)]:[add_zero(num2text(time_left % 60), 2)]"
 			if (length(disp2) > 5)
 				disp2 = "Error"
 
@@ -350,7 +350,7 @@
 	overlays += image('icons/obj/structures/machinery/status_display.dmi', icon_state=picture_state)
 
 /obj/structure/machinery/brig_cell/proc/update_display(line1, line2)
-	var/new_text = {"<div style="font-size:'5pt'; color:'#09f'; font:'Arial Black';text-align:center;" valign="top">[line1]<br>[line2]</div>"}
+	var/new_text = {"<div style="font-family:'Roboto'; font-weight:bold; font-size:1em; color:#09f;text-align:center;" valign="top">[line1]<br>[line2]</div>"}
 	if(maptext != new_text)
 		maptext = new_text
 


### PR DESCRIPTION

# About the pull request
Resolves: https://github.com/cmss13-devs/cmss13/issues/13005

Switch from just font to font-family, as we're just not using font as an all encompassing thing anyway.
Font technically needs or should need at minimum 2 arguments a font to use and a font size. It's supposed to be used as short hand so I presume that's why some people could see it as intended and some not.


Switch to Roboto cause I think it looks nicer and doesn't overflow slightly in the same amount of maptext space.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Seeing timers good.
# Testing Photographs and Procedure
<details>
<summary>CLICK ME</summary>

BEFORE:

<img width="274" height="215" alt="image" src="https://github.com/user-attachments/assets/3b90e94b-38de-4892-908e-b9f9cd9702e7" />


AFTER:

<img width="284" height="414" alt="Roboto" src="https://github.com/user-attachments/assets/60729f06-600d-46f8-b9ba-98a3d6c1e88a" />

ROBOTO (LEFT) VS ARIAL BLACK (RIGHT):

<img width="251" height="385" alt="image" src="https://github.com/user-attachments/assets/3aaa02a1-0194-4751-85ad-9bb89797c6b6" />


</details>


# Changelog
:cl:
fix: Brig Timers being oversized and flowing off of the maptext
/:cl:
