### PR TITLE
Add Multi-Z handling to get_line

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1339,9 +1339,9 @@ GLOBAL_LIST_INIT(WALLITEMS, list(
 
 	if(!reservation && z_level_transitions)
 		var/list/mutli_z_cross_points = list()
-		if(start_atom.z == end_atom.z)
+		if(start_turf.z == end_turf.z)
 			return line
-		if(!SSmapping.same_z_map(start_atom.z, end_atom.z))
+		if(!SSmapping.same_z_map(start_atom.z, end_turf.z))
 			line.Cut()
 			line = list(start_turf) //We're trying to throw things accross maps somehow. Let's not.
 			return line
@@ -1364,14 +1364,14 @@ GLOBAL_LIST_INIT(WALLITEMS, list(
 			mutli_z_cross_points += line[1]
 			mutli_z_cross_points[line[1]] = path_position
 
-		var/offset = SSmapping.level_trait(start_atom.z, ZTRAIT_UP)
+		var/offset = SSmapping.level_trait(start_turf.z, ZTRAIT_UP)
 		var/turf/first_cross_point = mutli_z_cross_points[1]
-		if(first_cross_point.z != start_atom.z + offset)
+		if(first_cross_point.z != start_turf.z + offset)
 			offset = 0 // We only need to offset if we're entering from a lower Z.
 
 		for(var/turf/crossing_point in mutli_z_cross_points)
 			var/switching_cross_point
-			switching_cross_point = locate(crossing_point.x, crossing_point.y, start_atom.z + offset)
+			switching_cross_point = locate(crossing_point.x, crossing_point.y, start_turf.z + offset)
 			line.Insert(mutli_z_cross_points[crossing_point], switching_cross_point)
 
 			if(!istype(switching_cross_point, /turf/open_space))

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1370,8 +1370,12 @@ GLOBAL_LIST_INIT(WALLITEMS, list(
 			offset = 0 // We only need to offset if we're entering from a lower Z.
 
 		for(var/turf/crossing_point in mutli_z_cross_points)
-			var/switching_cross_point
+			var/turf/switching_cross_point
 			switching_cross_point = locate(crossing_point.x, crossing_point.y, start_turf.z + offset)
+			if(offset > 0) //If we're ending up with multiple cross points, we're throwing across multiple Zs - This is probably only going to happen for throwing down, but just incase.
+				offset = offset + SSmapping.level_trait(switching_cross_point.z, ZTRAIT_UP)
+			else //So we need to adjust the offset for the next cross point.
+				offset = offset + SSmapping.level_trait(switching_cross_point.z, ZTRAIT_DOWN)
 			line.Insert(mutli_z_cross_points[crossing_point], switching_cross_point)
 
 			if(!istype(switching_cross_point, /turf/open_space))

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1291,11 +1291,12 @@ GLOBAL_LIST_INIT(WALLITEMS, list(
  * * start_atom - starting point of the line
  * * end_atom - ending point of the line
  * * include_start_atom - when truthy includes start_atom in the list, default TRUE
+ * * z_level_transitions - prevent diagonal avoidance of obstacles, only needed for actual object traversal, default FALSE
  *
  * Returns:
  * list - turfs from start_atom (in/exclusive) to end_atom (inclusive)
  */
-/proc/get_line(atom/start_atom, atom/end_atom, include_start_atom = TRUE)
+/proc/get_line(atom/start_atom, atom/end_atom, include_start_atom = TRUE, z_level_transitions = FALSE)
 	var/turf/start_turf = get_turf(start_atom)
 	var/turf/end_turf = get_turf(end_atom)
 	var/turf/end_turf_fall = end_turf //in case we are going cross fake z levels we store here the end tile to fall to
@@ -1335,6 +1336,47 @@ GLOBAL_LIST_INIT(WALLITEMS, list(
 		line += locate(x, y, start_z)
 
 	line += end_turf_fall
+
+	if(!reservation && z_level_transitions)
+		var/list/mutli_z_cross_points = list()
+		if(start_atom.z == end_atom.z)
+			return line
+		if(!SSmapping.same_z_map(start_atom.z, end_atom.z))
+			line.Cut()
+			line = list(start_turf) //We're trying to throw things accross maps somehow. Let's not.
+			return line
+
+		//Throwing accross Z levels on the same map. Fill in the vertical swapping over points so we're not diagnonally avoiding obstacle turfs.
+		var/turf/comparing_turf = start_turf
+		var/path_position = 0
+		if(length(line) > 1)
+			for(var/turf/turf_cross_point in line)
+				path_position++
+				if(comparing_turf.z == turf_cross_point.z)
+					comparing_turf = turf_cross_point
+					continue
+				else
+					mutli_z_cross_points += turf_cross_point
+					mutli_z_cross_points[turf_cross_point] = path_position
+					comparing_turf = turf_cross_point
+		else
+			path_position++ //Only one position in line and it's immediately into another Z.
+			mutli_z_cross_points += line[1]
+			mutli_z_cross_points[line[1]] = path_position
+
+		var/offset = SSmapping.level_trait(start_atom.z, ZTRAIT_UP)
+		var/turf/first_cross_point = mutli_z_cross_points[1]
+		if(first_cross_point.z != start_atom.z + offset)
+			offset = 0 // We only need to offset if we're entering from a lower Z.
+
+		for(var/turf/crossing_point in mutli_z_cross_points)
+			var/switching_cross_point
+			switching_cross_point = locate(crossing_point.x, crossing_point.y, start_atom.z + offset)
+			line.Insert(mutli_z_cross_points[crossing_point], switching_cross_point)
+
+			if(!istype(switching_cross_point, /turf/open_space))
+				line.Cut(max(1, mutli_z_cross_points[crossing_point] + 1), length(line) + 1) //Hit a non open_space turf. Shouldn't go through anything else. Stop here.
+				break
 
 	return line
 

--- a/code/modules/movement/launching/launching.dm
+++ b/code/modules/movement/launching/launching.dm
@@ -165,94 +165,59 @@
 	if(end_turf)
 		end_turf.on_throw_end(src)
 
-#define LAUNCHED_SAME 0
-#define LAUNCHED_UP 1
-#define LAUNCHED_DOWN 2
-
 // Proc for throwing or propelling movable atoms towards a target
-/atom/movable/proc/launch_towards(datum/launch_metadata/LM, tracking = FALSE)
-	if (!istype(LM))
+/atom/movable/proc/launch_towards(datum/launch_metadata/launching_data, tracking = FALSE)
+	if (!istype(launching_data))
 		CRASH("invalid launch_metadata passed to launch_towards")
-	if (!LM.target || !src)
+	if (!launching_data.target || !src)
 		return
 
-	if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_THROW, LM.thrower) & COMPONENT_CANCEL_THROW)
+	if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_THROW, launching_data.thrower) & COMPONENT_CANCEL_THROW)
 		return
 
 	// If we already have launch_metadata (from a previous throw), reset it and qdel the old launch_metadata datum
 	if (istype(launch_metadata))
 		qdel(launch_metadata)
-	launch_metadata = LM
+	launch_metadata = launching_data
 
-	if (LM.spin)
-		animation_spin(5, 1 + min(1, LM.range/20))
+	if (launching_data.spin)
+		animation_spin(5, 1 + min(1, launching_data.range/20))
 
 	var/old_speed = cur_speed
-	cur_speed = clamp(LM.speed, MIN_SPEED, MAX_SPEED) // Sanity check, also ~1 sec delay between each launch move is not very reasonable
+	cur_speed = clamp(launching_data.speed, MIN_SPEED, MAX_SPEED) // Sanity check, also ~1 sec delay between each launch move is not very reasonable
 	var/delay = 10/cur_speed - 0.5 // scales delay back to deciseconds for when sleep is called
-	var/pass_flags = LM.pass_flags
+	var/pass_flags = launching_data.pass_flags
 
 	throwing = TRUE
 
 	add_temp_pass_flags(pass_flags)
-	var/turf/start_turf = get_step_towards(src, LM.target)
+	var/turf/start_turf = get_step_towards(src, launching_data.target)
 	var/turf/above = SSmapping.get_turf_above(loc)
+	var/turf/target_turf = get_turf(launching_data.target)
 	var/datum/turf_reservation/reservation = SSmapping.used_turfs[loc]
 	if(reservation)
-		if((reservation.is_below(loc, get_turf(LM.target))) || (LM.target.z > z) && istype(above, /turf/open_space))
+		if((reservation.is_below(loc, target_turf)) || (launching_data.target.z > z) && istype(above, /turf/open_space))
 			start_turf = above
-		else if(reservation && reservation.is_below(get_turf(LM.target), loc))
-			start_turf = get_step_towards(src, SSmapping.get_turf_above(LM.target))
+		else if(reservation && reservation.is_below(target_turf, loc))
+			start_turf = get_step_towards(src, SSmapping.get_turf_above(launching_data.target))
 
-	var/list/turf/path = get_line(start_turf, LM.target)
+	var/list/turf/path = get_line(start_turf, launching_data.target, z_level_transitions = TRUE)
 	var/last_loc = loc
-	var/multi_z_launch
-	var/turf/mutli_z_cross_point
 	var/early_exit = FALSE
 
-	if(!reservation)
-		var/z_difference = LM.target.z - z
-		switch(z_difference)
-			if(1)
-				multi_z_launch = LAUNCHED_UP
-			if(0)
-				multi_z_launch = LAUNCHED_SAME
-			if(-1)
-				multi_z_launch = LAUNCHED_DOWN
-			else
-				early_exit = TRUE
-
-		if(multi_z_launch)
-			var/turf/comparing_turf = start_turf
-			var/path_position
-			for(var/turf/turf_cross_point in path)
-				path_position++
-				if(comparing_turf.z == turf_cross_point.z)
-					comparing_turf = turf_cross_point
-					continue
-				else
-					mutli_z_cross_point = turf_cross_point
-					break
-			var/end_cross_point
-			if(multi_z_launch == LAUNCHED_UP)
-				end_cross_point = locate(mutli_z_cross_point.x, mutli_z_cross_point.y, mutli_z_cross_point.z - 1)
-			else
-				end_cross_point = locate(mutli_z_cross_point.x, mutli_z_cross_point.y, mutli_z_cross_point.z + 1)
-			path.Insert(path_position, end_cross_point)
-
-	LM.dist = 0
+	launching_data.dist = 0
 	for (var/turf/T in path)
 		if (!src || !throwing || loc != last_loc || !isturf(src.loc))
 			break
-		if (!LM || QDELETED(LM))
+		if (!launching_data || QDELETED(launching_data))
 			early_exit = TRUE
 			break
-		if (LM.dist >= LM.range)
+		if (launching_data.dist >= launching_data.range)
 			break
 		if (!Move(T)) // If this returns FALSE, then a collision happened
 			break
 		last_loc = loc
-		if (++LM.dist >= LM.range)
+		if (++launching_data.dist >= launching_data.range)
 			break
 		sleep(delay)
 
@@ -261,21 +226,21 @@
 		var/turf/T = get_turf(src)
 		if(!istype(T))
 			return
-		var/atom/hit_atom = ismob(LM.target) ? null : T // TODO, just check for LM.target, the ismob is to prevent funky behavior with grenades 'n crates
+		var/atom/hit_atom = ismob(launching_data.target) ? null : T // TODO, just check for LM.target, the ismob is to prevent funky behavior with grenades 'n crates
 		if(!hit_atom)
 			for(var/atom/A in T)
-				if(A == LM.target)
+				if(A == launching_data.target)
 					hit_atom = A
 					break
-			if(!hit_atom && tracking && get_dist(src, LM.target) <= 1 && get_dist(start_turf, LM.target) <= 1) // If we missed, but we are tracking and the target is still next to us and the turf we launched from, then we still count it as a hit
-				hit_atom = LM.target
+			if(!hit_atom && tracking && get_dist(src, launching_data.target) <= 1 && get_dist(start_turf, launching_data.target) <= 1) // If we missed, but we are tracking and the target is still next to us and the turf we launched from, then we still count it as a hit
+				hit_atom = launching_data.target
 		launch_impact(hit_atom)
 	if (loc)
 		throwing = FALSE
 		rebounding = FALSE
 		cur_speed = old_speed
 		remove_temp_pass_flags(pass_flags)
-		LM.invoke_end_throw_callbacks(src)
+		launching_data.invoke_end_throw_callbacks(src)
 	QDEL_NULL(launch_metadata)
 
 /atom/movable/proc/throw_random_direction(range, speed = 0, atom/thrower, spin, launch_type = NORMAL_LAUNCH, pass_flags = NO_FLAGS)

--- a/code/modules/movement/launching/launching.dm
+++ b/code/modules/movement/launching/launching.dm
@@ -165,6 +165,9 @@
 	if(end_turf)
 		end_turf.on_throw_end(src)
 
+#define LAUNCHED_SAME 0
+#define LAUNCHED_UP 1
+#define LAUNCHED_DOWN 2
 
 // Proc for throwing or propelling movable atoms towards a target
 /atom/movable/proc/launch_towards(datum/launch_metadata/LM, tracking = FALSE)
@@ -192,19 +195,51 @@
 	throwing = TRUE
 
 	add_temp_pass_flags(pass_flags)
-	var/turf/start_turf
+	var/turf/start_turf = get_step_towards(src, LM.target)
 	var/turf/above = SSmapping.get_turf_above(loc)
 	var/datum/turf_reservation/reservation = SSmapping.used_turfs[loc]
-	if(reservation && (reservation.is_below(loc, get_turf(LM.target))) || (LM.target.z > z) && istype(above, /turf/open_space))
-		start_turf = above
-	else
-		start_turf = get_step_towards(src, LM.target)
-		if(reservation && reservation.is_below(get_turf(LM.target), loc))
+	if(reservation)
+		if((reservation.is_below(loc, get_turf(LM.target))) || (LM.target.z > z) && istype(above, /turf/open_space))
+			start_turf = above
+		else if(reservation && reservation.is_below(get_turf(LM.target), loc))
 			start_turf = get_step_towards(src, SSmapping.get_turf_above(LM.target))
+
 	var/list/turf/path = get_line(start_turf, LM.target)
 	var/last_loc = loc
-
+	var/multi_z_launch
+	var/turf/mutli_z_cross_point
 	var/early_exit = FALSE
+
+	if(!reservation)
+		var/z_difference = LM.target.z - z
+		switch(z_difference)
+			if(1)
+				multi_z_launch = LAUNCHED_UP
+			if(0)
+				multi_z_launch = LAUNCHED_SAME
+			if(-1)
+				multi_z_launch = LAUNCHED_DOWN
+			else
+				early_exit = TRUE
+
+		if(multi_z_launch)
+			var/turf/comparing_turf = start_turf
+			var/path_position
+			for(var/turf/turf_cross_point in path)
+				path_position++
+				if(comparing_turf.z == turf_cross_point.z)
+					comparing_turf = turf_cross_point
+					continue
+				else
+					mutli_z_cross_point = turf_cross_point
+					break
+			var/end_cross_point
+			if(multi_z_launch == LAUNCHED_UP)
+				end_cross_point = locate(mutli_z_cross_point.x, mutli_z_cross_point.y, mutli_z_cross_point.z - 1)
+			else
+				end_cross_point = locate(mutli_z_cross_point.x, mutli_z_cross_point.y, mutli_z_cross_point.z + 1)
+			path.Insert(path_position, end_cross_point)
+
 	LM.dist = 0
 	for (var/turf/T in path)
 		if (!src || !throwing || loc != last_loc || !isturf(src.loc))

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -240,7 +240,7 @@
 		ammo.fire_bonus_projectiles(src, gun_damage_mult, projectile_max_range_add, gun_bonus_proj_scatter)
 		bonus_projectile_check = PROJECTILE_ORIGINAL //Mark this projectile as having spawned a set of bonus projectiles.
 
-	path = get_line(starting, target_turf)
+	path = get_line(starting, target_turf, z_level_transitions = TRUE)
 	p_x += clamp((rand()-0.5)*scatter*3, -8, 8)
 	p_y += clamp((rand()-0.5)*scatter*3, -8, 8)
 	update_angle(starting, target_turf)


### PR DESCRIPTION

# About the pull request
Both launch_atom and fire_at use get_line to pass up and down z levels.
This doesn't consider if something is in the way, or if the z levels are connected.

So add that to get_line, lord knows how anything else will react to that, so just limit it to the two cases above for now via an optional argument.

Basically what this does is find the cross over points where the atom is transitioning to the next z level. And make sure that we add the extra tile into consideration, and making sure it's an open_space rather than phasing through diagonally.

Resolves: #11904, Resolves: #13023

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Bugs bad. Phasing through stuff bad. Shooting xenos on the ground from the comfort of your CIC chair also bad.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
code: Add an arugment to get_line to account for objects transitioning z levels. Currently used for throwing and shooting.
fix: Being able to throw people off the map on WARF. Being able to shoot xenos on the ground from CIC.
/:cl:
