### PR TITLE
fix: reference old body huds

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -85,7 +85,7 @@
 	var/datum/highlight_keywords_payload/payload = new(new_character)
 	current.client.tgui_panel.window.send_message("settings/updateHighlightKeywords", payload.to_list())
 
-	new_character.refresh_huds(current) //inherit the HUDs from the old body
+	new_character.refresh_huds(old_current) //inherit the HUDs from the old body
 	new_character.aghosted = FALSE //reset aghost and away timer
 	new_character.away_timer = 0
 


### PR DESCRIPTION

Some Mentors mentioned the new players were loosing their "New Players Marker" after a character is edited while in game, so i jsut found that the old body huds was not beign linked to the new one.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Currently under testes(Draft).
But this change is good to keepthe correct huds to the players after they change their characters in game.
# Testing Photographs and Procedure
<details>
Under tests!
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: fixed new players mark after edit character ingame
/:cl:
