### PR TITLE
Chair Shimmy

### DIFF
--- a/code/datums/components/shimmy_around.dm
+++ b/code/datums/components/shimmy_around.dm
@@ -6,12 +6,15 @@
  * NOTE: If any part of the Collided proc chain is overriden from obj/structure you must ensure the signal is sent
  */
 /datum/component/shimmy_around
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 	/// The structure that we are bound to
 	var/obj/structure/parent_structure
 	/// Approachable directions bitfield
 	var/approach_dirs = NORTH|SOUTH|EAST|WEST
 	/// Approach directions bitfield that override the mob's layer to be above our structure's
 	var/approach_dirs_layer_override = NORTH|SOUTH|EAST|WEST
+	/// internal movement allowed dirs bitfield
+	var/internal_dirs = NORTH|SOUTH|EAST|WEST
 	/// The pixel_x offset when approaching and facing NORTH
 	var/north_offset = 12
 	/// The pixel_x offset when approaching and facing SOUTH
@@ -28,6 +31,7 @@
 /datum/component/shimmy_around/Initialize(\
 	approach_dirs = NORTH|SOUTH|EAST|WEST,\
 	approach_dirs_layer_override = NORTH|SOUTH|EAST|WEST,\
+	internal_dirs =  NORTH|SOUTH|EAST|WEST,\
 	north_offset = 12,\
 	south_offset = -12,\
 	east_offset = -5,\
@@ -41,12 +45,36 @@
 
 	src.approach_dirs = approach_dirs
 	src.approach_dirs_layer_override = approach_dirs_layer_override
+	src.internal_dirs = internal_dirs
 	src.north_offset = north_offset
 	src.south_offset = south_offset
 	src.east_offset = east_offset
 	src.west_offset = west_offset
 	src.additional_offset = additional_offset
 	src.extra_delay = extra_delay
+
+/datum/component/shimmy_around/InheritComponent(datum/component/C, i_am_original,
+	approach_dirs, approach_dirs_layer_override, internal_dirs, north_offset,\
+	south_offset, east_offset, west_offset,	additional_offset, extra_delay)
+	. = ..()
+	if(approach_dirs && src.approach_dirs != approach_dirs)
+		src.approach_dirs =  approach_dirs
+	if(approach_dirs_layer_override && approach_dirs_layer_override != src.approach_dirs_layer_override)
+		src.approach_dirs_layer_override = approach_dirs_layer_override
+	if(internal_dirs && internal_dirs != src.internal_dirs)
+		src.internal_dirs = internal_dirs
+	if(north_offset && north_offset != src.north_offset)
+		src.north_offset = north_offset
+	if(south_offset && south_offset != src.south_offset)
+		src.south_offset = south_offset
+	if(east_offset && east_offset != src.east_offset)
+		src.east_offset = east_offset
+	if(west_offset &&  west_offset != src.west_offset)
+		src.west_offset = west_offset
+	if(additional_offset &&  additional_offset != src.additional_offset)
+		src.additional_offset = additional_offset
+	if(extra_delay && extra_delay != src.extra_delay)
+		src.extra_delay = extra_delay
 
 /datum/component/shimmy_around/Destroy(force, silent)
 	. = ..()
@@ -237,24 +265,28 @@
 	if(offset_x)
 		if(offset_x > 0)
 			if(new_direction & WEST)
-				var/extra_offset = additional_offset ? parent_structure.pixel_y : 0
-				animate(mob, time = animate_time, pixel_x = initial(mob.pixel_x), pixel_y = mob.pixel_y + west_offset + extra_offset)
+				if(internal_dirs & WEST)
+					var/extra_offset = additional_offset ? parent_structure.pixel_y : 0
+					animate(mob, time = animate_time, pixel_x = initial(mob.pixel_x), pixel_y = mob.pixel_y + west_offset + extra_offset)
 				. = COMPONENT_CANCEL_MOVE
 		else
 			if(new_direction & EAST)
-				var/extra_offset = additional_offset ? parent_structure.pixel_y : 0
-				animate(mob, time = animate_time, pixel_x = initial(mob.pixel_x), pixel_y = mob.pixel_y + east_offset + extra_offset)
+				if(internal_dirs & EAST)
+					var/extra_offset = additional_offset ? parent_structure.pixel_y : 0
+					animate(mob, time = animate_time, pixel_x = initial(mob.pixel_x), pixel_y = mob.pixel_y + east_offset + extra_offset)
 				. = COMPONENT_CANCEL_MOVE
 	else if(offset_y)
 		if(offset_y > 0)
 			if(new_direction & SOUTH)
-				var/extra_offset = additional_offset ? parent_structure.pixel_x : 0
-				animate(mob, time = animate_time, pixel_y = initial(mob.pixel_y), pixel_x = mob.pixel_x + south_offset + extra_offset)
+				if(internal_dirs & SOUTH)
+					var/extra_offset = additional_offset ? parent_structure.pixel_x : 0
+					animate(mob, time = animate_time, pixel_y = initial(mob.pixel_y), pixel_x = mob.pixel_x + south_offset + extra_offset)
 				. = COMPONENT_CANCEL_MOVE
 		else
 			if(new_direction & NORTH)
-				var/extra_offset = additional_offset ? parent_structure.pixel_x : 0
-				animate(mob, time = animate_time, pixel_y = initial(mob.pixel_y), pixel_x = mob.pixel_x + north_offset + extra_offset)
+				if(internal_dirs & NORTH)
+					var/extra_offset = additional_offset ? parent_structure.pixel_x : 0
+					animate(mob, time = animate_time, pixel_y = initial(mob.pixel_y), pixel_x = mob.pixel_x + north_offset + extra_offset)
 				. = COMPONENT_CANCEL_MOVE
 
 	// If we are swinging them around, so set dir, delay, and layer as needed

--- a/code/datums/components/shimmy_around.dm
+++ b/code/datums/components/shimmy_around.dm
@@ -53,6 +53,18 @@
 	src.additional_offset = additional_offset
 	src.extra_delay = extra_delay
 
+/datum/component/shimmy_around/Destroy(force, silent)
+	var/turf/my_turf = get_turf(parent_structure)
+	if(my_turf)
+		for(var/mob/living/shimmied_mob in my_turf)	// we need to unshimmy shimmied mobs if this component is seeya byebye
+			if(shimmied_mob.pixel_x != initial(shimmied_mob.pixel_x) || shimmied_mob.pixel_y != initial(shimmied_mob.pixel_y) || shimmied_mob.layer != initial(shimmied_mob.layer))
+				UnregisterSignal(shimmied_mob, list(COMSIG_MOVABLE_PRE_MOVE, COMSIG_MOVABLE_MOVED, COMSIG_LIVING_SHIMMY_LAYER))
+				animate(shimmied_mob, pixel_x = initial(shimmied_mob.pixel_x), pixel_y = initial(shimmied_mob.pixel_y), time = 0)
+				if(shimmied_mob.layer != XENO_HIDING_LAYER)	// leave xeno hide alone
+					shimmied_mob.layer = initial(shimmied_mob.layer)
+	parent_structure = null
+	return ..()
+
 /datum/component/shimmy_around/InheritComponent(datum/component/C, i_am_original,
 	approach_dirs, approach_dirs_layer_override, internal_dirs, north_offset,\
 	south_offset, east_offset, west_offset,	additional_offset, extra_delay)
@@ -75,10 +87,6 @@
 		src.additional_offset = additional_offset
 	if(extra_delay && extra_delay != src.extra_delay)
 		src.extra_delay = extra_delay
-
-/datum/component/shimmy_around/Destroy(force, silent)
-	. = ..()
-	parent_structure = null
 
 /datum/component/shimmy_around/RegisterWithParent()
 	RegisterSignal(parent_structure, COMSIG_STRUCTURE_COLLIDED, PROC_REF(on_collide))
@@ -245,84 +253,57 @@
 	SIGNAL_HANDLER
 	return COMSIG_LIVING_SHIMMY_LAYER_CANCEL
 
-/// Signal handler for COMSIG_MOVABLE_PRE_MOVE to prevent movement into us
 /datum/component/shimmy_around/proc/on_mob_pre_move(atom/movable/source, new_loc)
 	SIGNAL_HANDLER
 
 	var/mob/living/mob = source
 	var/animate_time = min(mob.move_delay + extra_delay, MAX_ANIMATE_TIME)
 	var/new_direction = get_dir(mob, new_loc)
-	var/offset_x = mob.pixel_x - initial(mob.pixel_x)
-	var/offset_y = mob.pixel_y - initial(mob.pixel_y)
-	if(additional_offset)
-		// compensate for any additional adjustment we made
-		if(offset_x)
-			offset_x -= parent_structure.pixel_x
-		else if(offset_y)
-			offset_y -= parent_structure.pixel_y
+
+	var/list/offsets = get_compensated_offsets(mob)
+	var/offset_x = offsets[1]
+	var/offset_y = offsets[2]
 
 	// Block movement into parent, but swing around instead
 	if(offset_x)
 		if(offset_x > 0)
 			if(new_direction & WEST)
 				if(internal_dirs & WEST)
-					var/extra_offset = additional_offset ? parent_structure.pixel_y : 0
-					animate(mob, time = animate_time, pixel_x = initial(mob.pixel_x), pixel_y = mob.pixel_y + west_offset + extra_offset)
+					apply_directional_offset(mob, WEST, animate_time)
 				. = COMPONENT_CANCEL_MOVE
 		else
 			if(new_direction & EAST)
 				if(internal_dirs & EAST)
-					var/extra_offset = additional_offset ? parent_structure.pixel_y : 0
-					animate(mob, time = animate_time, pixel_x = initial(mob.pixel_x), pixel_y = mob.pixel_y + east_offset + extra_offset)
+					apply_directional_offset(mob, EAST, animate_time)
 				. = COMPONENT_CANCEL_MOVE
 	else if(offset_y)
 		if(offset_y > 0)
 			if(new_direction & SOUTH)
 				if(internal_dirs & SOUTH)
-					var/extra_offset = additional_offset ? parent_structure.pixel_x : 0
-					animate(mob, time = animate_time, pixel_y = initial(mob.pixel_y), pixel_x = mob.pixel_x + south_offset + extra_offset)
+					apply_directional_offset(mob, SOUTH, animate_time)
 				. = COMPONENT_CANCEL_MOVE
 		else
 			if(new_direction & NORTH)
 				if(internal_dirs & NORTH)
-					var/extra_offset = additional_offset ? parent_structure.pixel_x : 0
-					animate(mob, time = animate_time, pixel_y = initial(mob.pixel_y), pixel_x = mob.pixel_x + north_offset + extra_offset)
+					apply_directional_offset(mob, NORTH, animate_time)
 				. = COMPONENT_CANCEL_MOVE
 
-	// If we are swinging them around, so set dir, delay, and layer as needed
 	if(. == COMPONENT_CANCEL_MOVE)
 		source.dir = new_direction
 		if(extra_delay && mob.client)
 			mob.client.move_delay += extra_delay
-		var/desired_layer = round(parent_structure.layer + 0.05, 0.01) // Byond floats are garbage
-		if(desired_layer == XENO_HIDING_LAYER)
-			desired_layer += 0.01
-		var/layer_changing = mob.plane == parent_structure.plane && (new_direction & approach_dirs_layer_override) && initial(mob.layer) < desired_layer
-		if(layer_changing)
-			RegisterSignal(mob, COMSIG_LIVING_SHIMMY_LAYER, PROC_REF(on_mob_shimmy_layer), override = TRUE) // Override because we're just ensuring its set if not already set
-			if(mob.layer == XENO_HIDING_LAYER && isxeno(mob))
-				var/datum/action/xeno_action/onclick/xenohide/hide = get_action(mob, /datum/action/xeno_action/onclick/xenohide)
-				if(hide)
-					hide.post_attack()
-			mob.layer = desired_layer
-		else
-			UnregisterSignal(mob, COMSIG_LIVING_SHIMMY_LAYER)
-			if(mob.layer != XENO_HIDING_LAYER || !isxeno(mob))
-				mob.layer = initial(mob.layer)
+		update_shimmy_layer(mob, new_direction)
 
 	return .
 
 /// Signal handler for COMSIG_MOVABLE_MOVED to reset their pixel offsets
 /datum/component/shimmy_around/proc/on_mob_move(atom/movable/source, atom/old_loc, dir, forced)
 	SIGNAL_HANDLER
-
 	var/mob/living/mob = source
 	UnregisterSignal(source, list(COMSIG_MOVABLE_PRE_MOVE, COMSIG_MOVABLE_MOVED, COMSIG_LIVING_SHIMMY_LAYER))
-
 	// Undo changes
 	var/animate_time = min(mob.move_delay + extra_delay, MAX_ANIMATE_TIME)
 	animate(mob, time = animate_time, pixel_x = initial(mob.pixel_x), pixel_y = initial(mob.pixel_y))
-
 	// Undo layer change only if we aren't shimmying again
 	if(!(SEND_SIGNAL(mob, COMSIG_LIVING_SHIMMY_LAYER) & COMSIG_LIVING_SHIMMY_LAYER_CANCEL))
 		if(mob.layer != XENO_HIDING_LAYER || !isxeno(mob))
@@ -330,9 +311,115 @@
 				mob.layer = initial(mob.layer)
 			else
 				addtimer(VARSET_CALLBACK(mob, layer, initial(mob.layer)), animate_time * 0.5)
-
 	// Delay them if needed
 	if(extra_delay && mob.client)
 		mob.client.move_delay += extra_delay
 
-#undef MAX_ANIMATE_TIME
+//used when we want to inherit shimmying mobs from another /datum/component/shimmy_around, or if our offsets changed and mobs' need to be refreshed
+/datum/component/shimmy_around/proc/refresh_mob_offsets(mob/living/shimmied_living, list/old_data)
+	if(!shimmied_living || !old_data || shimmied_living.loc != get_turf(parent_structure))
+		return
+
+	// old_data layout you are currently using:
+	// 1 north, 2 south, 3 east, 4 west, 5 additional_offset
+	var/old_north   = old_data[1]
+	var/old_south   = old_data[2]
+	var/old_east    = old_data[3]
+	var/old_west    = old_data[4]
+	var/old_add_off = old_data[5]
+
+	var/delta_x = shimmied_living.pixel_x - initial(shimmied_living.pixel_x)
+	var/delta_y = shimmied_living.pixel_y - initial(shimmied_living.pixel_y)
+	if(old_add_off)
+		if(delta_x)
+			delta_x -= parent_structure.pixel_x
+		if(delta_y)
+			delta_y -= parent_structure.pixel_y
+
+	var/recovered_dir = 0
+	#define OFFSET_TOLERANCE 3
+
+	if(abs(delta_x) > OFFSET_TOLERANCE && abs(delta_y) <= OFFSET_TOLERANCE)
+		if(abs(delta_x - old_north) <= OFFSET_TOLERANCE)
+			recovered_dir = NORTH
+		else if(abs(delta_x - old_south) <= OFFSET_TOLERANCE)
+			recovered_dir = SOUTH
+	else if(abs(delta_y) > OFFSET_TOLERANCE && abs(delta_x) <= OFFSET_TOLERANCE)
+		if(abs(delta_y - old_east) <= OFFSET_TOLERANCE)
+			recovered_dir = EAST
+		else if(abs(delta_y - old_west) <= OFFSET_TOLERANCE)
+			recovered_dir = WEST
+
+	#undef OFFSET_TOLERANCE
+
+	if(!recovered_dir)
+		animate(shimmied_living, pixel_x = initial(shimmied_living.pixel_x), pixel_y = initial(shimmied_living.pixel_y), time = 0)
+		return
+
+	var/animate_time = min(shimmied_living.move_delay + extra_delay, MAX_ANIMATE_TIME)
+	apply_directional_offset(shimmied_living, recovered_dir, animate_time)
+
+	// Re-own the mob
+	RegisterSignal(shimmied_living, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(on_mob_pre_move), override = TRUE)
+	RegisterSignal(shimmied_living, COMSIG_MOVABLE_MOVED, PROC_REF(on_mob_move), override = TRUE)
+
+	update_shimmy_layer(shimmied_living, recovered_dir)
+
+/// Returns the current pixel deltas after stripping any additional_offset the
+/// component previously applied.  Used by both the signal path and refresh.
+/datum/component/shimmy_around/proc/get_compensated_offsets(mob/living/mob)
+	var/offset_x = mob.pixel_x - initial(mob.pixel_x)
+	var/offset_y = mob.pixel_y - initial(mob.pixel_y)
+	if(additional_offset)
+		if(offset_x)
+			offset_x -= parent_structure.pixel_x
+		else if(offset_y)
+			offset_y -= parent_structure.pixel_y
+	return list(offset_x, offset_y)
+
+/// Animate the mob to the visual offset that belongs to the given approach
+/// direction.  Always goes from initial() so it is safe for both a fresh shimmy and a refresh.
+/datum/component/shimmy_around/proc/apply_directional_offset(mob/living/mob, direction, animate_time)
+	switch(direction)
+		if(NORTH)
+			var/extra = additional_offset ? parent_structure.pixel_x : 0
+			animate(mob, time = animate_time,
+				pixel_x = initial(mob.pixel_x) + north_offset + extra,
+				pixel_y = initial(mob.pixel_y))
+		if(SOUTH)
+			var/extra = additional_offset ? parent_structure.pixel_x : 0
+			animate(mob, time = animate_time,
+				pixel_x = initial(mob.pixel_x) + south_offset + extra,
+				pixel_y = initial(mob.pixel_y))
+		if(EAST)
+			var/extra = additional_offset ? parent_structure.pixel_y : 0
+			animate(mob, time = animate_time,
+				pixel_x = initial(mob.pixel_x),
+				pixel_y = initial(mob.pixel_y) + east_offset + extra)
+		if(WEST)
+			var/extra = additional_offset ? parent_structure.pixel_y : 0
+			animate(mob, time = animate_time,
+				pixel_x = initial(mob.pixel_x),
+				pixel_y = initial(mob.pixel_y) + west_offset + extra)
+
+/// Layer override / restore logic shared by the signal path and refresh.
+/datum/component/shimmy_around/proc/update_shimmy_layer(mob/living/mob, direction)
+	var/desired_layer = round(parent_structure.layer + 0.05, 0.01)
+	if(desired_layer == XENO_HIDING_LAYER)
+		desired_layer += 0.01
+
+	var/layer_changing = mob.plane == parent_structure.plane \
+		&& (direction & approach_dirs_layer_override) \
+		&& initial(mob.layer) < desired_layer
+
+	if(layer_changing)
+		RegisterSignal(mob, COMSIG_LIVING_SHIMMY_LAYER, PROC_REF(on_mob_shimmy_layer), override = TRUE)
+		if(mob.layer == XENO_HIDING_LAYER && isxeno(mob))
+			var/datum/action/xeno_action/onclick/xenohide/hide = get_action(mob, /datum/action/xeno_action/onclick/xenohide)
+			if(hide)
+				hide.post_attack()
+		mob.layer = desired_layer
+	else
+		UnregisterSignal(mob, COMSIG_LIVING_SHIMMY_LAYER)
+		if(mob.layer != XENO_HIDING_LAYER || !isxeno(mob))
+			mob.layer = initial(mob.layer)

--- a/code/datums/components/shimmy_around.dm
+++ b/code/datums/components/shimmy_around.dm
@@ -27,8 +27,8 @@
 	var/additional_offset = TRUE
 	/// Extra time added to next_move to shimmy around
 	var/extra_delay = 1 DECISECONDS
-	/// List of mob types to exclude from being able to shimmy
-	var/list/disallowed_types
+	/// bitflag for allowing mobs to enter the turf before shimmying them
+	var/allowed_pass_flag = PASS_MOB_IS
 
 /datum/component/shimmy_around/Initialize(\
 	approach_dirs = NORTH|SOUTH|EAST|WEST,\
@@ -40,7 +40,8 @@
 	west_offset = -5,\
 	additional_offset = TRUE,\
 	extra_delay = 1 DECISECONDS,\
-	disallowed_types = list())
+	allowed_pass_flag = PASS_MOB_IS, \
+	existing_shimmiers = list())
 
 	parent_structure = parent
 	if(!istype(parent_structure))
@@ -55,7 +56,10 @@
 	src.west_offset = west_offset
 	src.additional_offset = additional_offset
 	src.extra_delay = extra_delay
-	src.disallowed_types = disallowed_types
+	src.allowed_pass_flag = allowed_pass_flag
+
+	for(var/mob/existing_shimmieds in existing_shimmiers)
+		refresh_mob_offsets(existing_shimmieds)
 
 /datum/component/shimmy_around/Destroy(force, silent)
 	var/turf/my_turf = get_turf(parent_structure)
@@ -69,30 +73,40 @@
 	parent_structure = null
 	return ..()
 
-/datum/component/shimmy_around/InheritComponent(datum/component/C, i_am_original,
-	approach_dirs, approach_dirs_layer_override, internal_dirs, north_offset,\
-	south_offset, east_offset, west_offset,	additional_offset, extra_delay, disallowed_types)
+/datum/component/shimmy_around/InheritComponent(datum/component/C, i_am_original, \
+		approach_dirs, \
+		approach_dirs_layer_override, \
+		internal_dirs, north_offset,\
+		south_offset, \
+		east_offset, \
+		west_offset, \
+		additional_offset, \
+		extra_delay, \
+		allowed_pass_flag, \
+		existing_shimmiers)
 	. = ..()
-	if(approach_dirs != null && src.approach_dirs != approach_dirs)
+	if(approach_dirs != null)
 		src.approach_dirs = approach_dirs
-	if(approach_dirs_layer_override != null && approach_dirs_layer_override != src.approach_dirs_layer_override)
+	if(approach_dirs_layer_override != null)
 		src.approach_dirs_layer_override = approach_dirs_layer_override
-	if(internal_dirs != null && internal_dirs != src.internal_dirs)
+	if(internal_dirs != null)
 		src.internal_dirs = internal_dirs
-	if(north_offset != null && north_offset != src.north_offset)
+	if(north_offset != null)
 		src.north_offset = north_offset
-	if(south_offset != null && south_offset != src.south_offset)
+	if(south_offset != null)
 		src.south_offset = south_offset
-	if(east_offset != null && east_offset != src.east_offset)
+	if(east_offset != null)
 		src.east_offset = east_offset
-	if(west_offset != null && west_offset != src.west_offset)
+	if(west_offset != null)
 		src.west_offset = west_offset
-	if(additional_offset != null && additional_offset != src.additional_offset)
+	if(additional_offset != null)
 		src.additional_offset = additional_offset
-	if(extra_delay != null && extra_delay != src.extra_delay)
+	if(extra_delay != null)
 		src.extra_delay = extra_delay
-	if(disallowed_types != null && disallowed_types != src.disallowed_types)
-		src.disallowed_types = disallowed_types	//just going to do a complete reassignment, let the inheritor initiator handle this
+	if(allowed_pass_flag != null)
+		src.allowed_pass_flag = allowed_pass_flag
+	for(var/mob/existing_shimmieds in existing_shimmiers)
+		refresh_mob_offsets(existing_shimmieds)
 
 /datum/component/shimmy_around/RegisterWithParent()
 	RegisterSignal(parent_structure, COMSIG_STRUCTURE_COLLIDED, PROC_REF(on_collide))
@@ -190,9 +204,8 @@
 	if(!istype(mob))
 		return
 
-	for(var/disallowed_type as anything in disallowed_types)
-		if(istype(mob, disallowed_type))
-			return	//disallowed type of mob trying to shimmy, NOT IN MY HOUSE!
+	if(!(mob.pass_flags?.flags_pass & allowed_pass_flag))
+		return
 
 	// See if we allow this approach direction
 	var/direction = get_dir(mob, parent_structure)
@@ -326,50 +339,41 @@
 		mob.client.move_delay += extra_delay
 
 //used when we want to inherit shimmying mobs from another /datum/component/shimmy_around, or if our offsets changed and mobs' need to be refreshed
-/datum/component/shimmy_around/proc/refresh_mob_offsets(mob/living/shimmied_living, list/old_data)
-	if(!shimmied_living || !old_data || shimmied_living.loc != get_turf(parent_structure))
+/datum/component/shimmy_around/proc/refresh_mob_offsets(mob/living/shimmied_living)
+	if(!shimmied_living || shimmied_living.loc != get_turf(parent_structure))
 		return
 
-	// old_data layout you are currently using:
-	// 1 north, 2 south, 3 east, 4 west, 5 additional_offset
-	var/old_north   = old_data[1]
-	var/old_south   = old_data[2]
-	var/old_east    = old_data[3]
-	var/old_west    = old_data[4]
-	var/old_add_off = old_data[5]
-
+	// Current visual offset relative to the mob's natural position
 	var/delta_x = shimmied_living.pixel_x - initial(shimmied_living.pixel_x)
 	var/delta_y = shimmied_living.pixel_y - initial(shimmied_living.pixel_y)
-	if(old_add_off)
-		if(delta_x)
-			delta_x -= parent_structure.pixel_x
-		if(delta_y)
-			delta_y -= parent_structure.pixel_y
-
 	var/recovered_dir = 0
+
 	#define OFFSET_TOLERANCE 3
 
+	// Prefer matching against our *current* offset values
 	if(abs(delta_x) > OFFSET_TOLERANCE && abs(delta_y) <= OFFSET_TOLERANCE)
-		if(abs(delta_x - old_north) <= OFFSET_TOLERANCE)
+		if(abs(delta_x - north_offset) <= OFFSET_TOLERANCE)
 			recovered_dir = NORTH
-		else if(abs(delta_x - old_south) <= OFFSET_TOLERANCE)
+		else if(abs(delta_x - south_offset) <= OFFSET_TOLERANCE)
 			recovered_dir = SOUTH
 	else if(abs(delta_y) > OFFSET_TOLERANCE && abs(delta_x) <= OFFSET_TOLERANCE)
-		if(abs(delta_y - old_east) <= OFFSET_TOLERANCE)
+		if(abs(delta_y - east_offset) <= OFFSET_TOLERANCE)
 			recovered_dir = EAST
-		else if(abs(delta_y - old_west) <= OFFSET_TOLERANCE)
+		else if(abs(delta_y - west_offset) <= OFFSET_TOLERANCE)
 			recovered_dir = WEST
 
 	#undef OFFSET_TOLERANCE
 
-	if(!recovered_dir)
+	if(!recovered_dir)	//use the mob's last movement direction if we couldn't match an offset
+		recovered_dir = shimmied_living.last_move_dir
+
+	if(!recovered_dir)	//if we STILL couldn't figure out where they were supposed to be — just reset them
 		animate(shimmied_living, pixel_x = initial(shimmied_living.pixel_x), pixel_y = initial(shimmied_living.pixel_y), time = 0)
 		return
 
 	var/animate_time = min(shimmied_living.move_delay + extra_delay, MAX_ANIMATE_TIME)
 	apply_directional_offset(shimmied_living, recovered_dir, animate_time)
 
-	// Re-own the mob
 	RegisterSignal(shimmied_living, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(on_mob_pre_move), override = TRUE)
 	RegisterSignal(shimmied_living, COMSIG_MOVABLE_MOVED, PROC_REF(on_mob_move), override = TRUE)
 

--- a/code/datums/components/shimmy_around.dm
+++ b/code/datums/components/shimmy_around.dm
@@ -27,6 +27,8 @@
 	var/additional_offset = TRUE
 	/// Extra time added to next_move to shimmy around
 	var/extra_delay = 1 DECISECONDS
+	/// List of mob types to exclude from being able to shimmy
+	var/list/disallowed_types
 
 /datum/component/shimmy_around/Initialize(\
 	approach_dirs = NORTH|SOUTH|EAST|WEST,\
@@ -37,7 +39,8 @@
 	east_offset = -5,\
 	west_offset = -5,\
 	additional_offset = TRUE,\
-	extra_delay = 1 DECISECONDS)
+	extra_delay = 1 DECISECONDS,\
+	disallowed_types = list())
 
 	parent_structure = parent
 	if(!istype(parent_structure))
@@ -52,6 +55,7 @@
 	src.west_offset = west_offset
 	src.additional_offset = additional_offset
 	src.extra_delay = extra_delay
+	src.disallowed_types = disallowed_types
 
 /datum/component/shimmy_around/Destroy(force, silent)
 	var/turf/my_turf = get_turf(parent_structure)
@@ -67,26 +71,28 @@
 
 /datum/component/shimmy_around/InheritComponent(datum/component/C, i_am_original,
 	approach_dirs, approach_dirs_layer_override, internal_dirs, north_offset,\
-	south_offset, east_offset, west_offset,	additional_offset, extra_delay)
+	south_offset, east_offset, west_offset,	additional_offset, extra_delay, disallowed_types)
 	. = ..()
-	if(approach_dirs && src.approach_dirs != approach_dirs)
-		src.approach_dirs =  approach_dirs
-	if(approach_dirs_layer_override && approach_dirs_layer_override != src.approach_dirs_layer_override)
+	if(approach_dirs != null && src.approach_dirs != approach_dirs)
+		src.approach_dirs = approach_dirs
+	if(approach_dirs_layer_override != null && approach_dirs_layer_override != src.approach_dirs_layer_override)
 		src.approach_dirs_layer_override = approach_dirs_layer_override
-	if(internal_dirs && internal_dirs != src.internal_dirs)
+	if(internal_dirs != null && internal_dirs != src.internal_dirs)
 		src.internal_dirs = internal_dirs
-	if(north_offset && north_offset != src.north_offset)
+	if(north_offset != null && north_offset != src.north_offset)
 		src.north_offset = north_offset
-	if(south_offset && south_offset != src.south_offset)
+	if(south_offset != null && south_offset != src.south_offset)
 		src.south_offset = south_offset
-	if(east_offset && east_offset != src.east_offset)
+	if(east_offset != null && east_offset != src.east_offset)
 		src.east_offset = east_offset
-	if(west_offset &&  west_offset != src.west_offset)
+	if(west_offset != null && west_offset != src.west_offset)
 		src.west_offset = west_offset
-	if(additional_offset &&  additional_offset != src.additional_offset)
+	if(additional_offset != null && additional_offset != src.additional_offset)
 		src.additional_offset = additional_offset
-	if(extra_delay && extra_delay != src.extra_delay)
+	if(extra_delay != null && extra_delay != src.extra_delay)
 		src.extra_delay = extra_delay
+	if(disallowed_types != null && disallowed_types != src.disallowed_types)
+		src.disallowed_types = disallowed_types	//just going to do a complete reassignment, let the inheritor initiator handle this
 
 /datum/component/shimmy_around/RegisterWithParent()
 	RegisterSignal(parent_structure, COMSIG_STRUCTURE_COLLIDED, PROC_REF(on_collide))
@@ -183,6 +189,10 @@
 	var/mob/living/mob = collided_atom
 	if(!istype(mob))
 		return
+
+	for(var/disallowed_type as anything in disallowed_types)
+		if(istype(mob, disallowed_type))
+			return	//disallowed type of mob trying to shimmy, NOT IN MY HOUSE!
 
 	// See if we allow this approach direction
 	var/direction = get_dir(mob, parent_structure)

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -33,7 +33,7 @@
 		layer = non_north_layer
 	if(buckled_mob)
 		buckled_mob.setDir(dir)
-		update_shimmy_data(force_update = TRUE)
+		update_shimmy_data(null, TRUE)
 	else
 		update_shimmy_data()
 

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -7,12 +7,13 @@
 	desc = "A rectangular metallic frame sitting on four legs with a back panel. Designed to fit the sitting position, more or less comfortably."
 	icon_state = "chair"
 	buckle_lying = 0
+	foldabletype = /obj/item/weapon/twohanded/folded_metal_chair
 	var/north_layer = FLY_LAYER
 	var/non_north_layer = OBJ_LAYER
 	var/propelled = FALSE //Check for fire-extinguisher-driven chairs
 	var/can_rotate = TRUE
-	var/picked_up_item = /obj/item/weapon/twohanded/folded_metal_chair
 	var/stacked_size = 0
+	var/shimmy = TRUE
 
 /obj/structure/bed/chair/Initialize()
 	. = ..()
@@ -34,8 +35,7 @@
 		buckled_mob.setDir(dir)
 
 /obj/structure/bed/chair/MouseDrop(atom/over)
-	. = ..()
-	if(!picked_up_item)
+	if(!foldabletype)
 		return
 	var/mob/living/carbon/human/H = over
 	if(usr != H)
@@ -48,14 +48,12 @@
 	if(stacked_size)
 		to_chat(H, SPAN_NOTICE("You cannot fold a chair while its stacked!"))
 		return
-	var/obj/item/weapon/twohanded/folded_metal_chair/FMC = new picked_up_item(loc)
-	if(H.put_in_active_hand(FMC))
-		qdel(src)
-	else if(H.put_in_inactive_hand(FMC))
+	var/obj/item/weapon/twohanded/folded_metal_chair/folded_char = new foldabletype(loc)
+	if(H.put_in_hands(folded_char))
 		qdel(src)
 	else
 		to_chat(H, SPAN_NOTICE("You need a free hand to fold up the chair."))
-		qdel(FMC)
+		qdel(folded_char)
 
 /obj/structure/bed/chair/attack_hand(mob/user)
 	. = ..()
@@ -88,7 +86,7 @@
 	if(HAS_TRAIT(I, TRAIT_TOOL_WRENCH) && stacked_size)
 		to_chat(user, SPAN_NOTICE("You'll need to unstack the chairs before you can take one apart."))
 		return FALSE
-	if(istype(I, /obj/item/weapon/twohanded/folded_metal_chair) && picked_up_item)
+	if(istype(I, /obj/item/weapon/twohanded/folded_metal_chair) && foldabletype)
 		if(I.flags_item & WIELDED)
 			return ..()
 		if(locate(/mob/living) in loc)
@@ -165,7 +163,7 @@
 		falling_chair.pixel_x = rand(-8, 8)
 		falling_chair.pixel_y = rand(-8, 8)
 		falling_chair.throw_atom(target_turf, rand(2, 5), SPEED_FAST, null, TRUE)
-	var/obj/item/weapon/twohanded/folded_metal_chair/I = new picked_up_item(starting_turf)
+	var/obj/item/weapon/twohanded/folded_metal_chair/I = new foldabletype(starting_turf)
 	I.throw_atom(starting_turf, rand(2, 5), SPEED_FAST, null, TRUE)
 	qdel(src)
 
@@ -234,16 +232,38 @@
 	handle_rotation()
 	return
 
+/obj/structure/bed/chair/do_buckle(mob/living/target, mob/user)
+	. = ..()
+	if(!shimmy)
+		return
+	density = TRUE
+	if(target.density)
+		target.density = FALSE
+	var/approachness
+	switch(dir)
+		if(NORTH, SOUTH)
+			approachness = EAST | WEST
+		if(EAST, WEST)
+			approachness = NORTH | SOUTH
+	AddComponent(/datum/component/shimmy_around, north_offset = -14, south_offset = -14, east_offset = -14, west_offset = -14, extra_delay = 0.5 SECONDS, approach_dirs = approachness)
+
+/obj/structure/bed/chair/unbuckle()
+	. = ..()
+	density = FALSE
+	var/datum/component/shimmy_around/shimster = GetComponent(/datum/component/shimmy_around)
+	if(shimster)
+		qdel(shimster)
+
 //Chair types
 /obj/structure/bed/chair/bolted
 	desc = "A rectangular metallic frame sitting on four legs with a back panel. Designed to fit the sitting position, more or less comfortably. It appears to be bolted to the ground."
-	picked_up_item = null
+	foldabletype = null
 
 /obj/structure/bed/chair/wood
 	buildstacktype = /obj/item/stack/sheet/wood
 	debris = list(/obj/item/stack/sheet/wood)
 	hit_bed_sound = 'sound/effects/woodhit.ogg'
-	picked_up_item = null
+	foldabletype = null
 
 /obj/structure/bed/chair/wood/normal
 	icon_state = "wooden_chair"
@@ -262,7 +282,7 @@
 	color = rgb(255,255,255)
 	hit_bed_sound = 'sound/weapons/bladeslice.ogg'
 	debris = list()
-	picked_up_item = null
+	foldabletype = null
 
 /obj/structure/bed/chair/comfy/arc
 	non_north_layer = BELOW_OBJ_LAYER
@@ -319,7 +339,8 @@
 /obj/structure/bed/chair/office
 	anchored = FALSE
 	drag_delay = 1 //Pulling something on wheels is easy
-	picked_up_item = null
+	foldabletype = null
+	shimmy = FALSE
 
 /obj/structure/bed/chair/office/Initialize(mapload, ...)
 	. = ..()
@@ -369,7 +390,7 @@
 
 /obj/structure/bed/chair/dropship
 	can_rotate = FALSE
-	picked_up_item = null
+	foldabletype = null
 
 /obj/structure/bed/chair/dropship/pilot
 	icon_state = "pilot_chair"
@@ -551,7 +572,7 @@
 	unslashable = TRUE
 	unacidable = TRUE
 	dir = WEST
-	picked_up_item = null
+	foldabletype = null
 
 /obj/structure/bed/chair/hunter
 	name = "hunter chair"
@@ -561,7 +582,7 @@
 	color = rgb(255,255,255)
 	hit_bed_sound = 'sound/weapons/bladeslice.ogg'
 	debris = list()
-	picked_up_item = null
+	foldabletype = null
 
 /obj/item/weapon/twohanded/folded_metal_chair //used for when someone picks up the chair
 	name = "metal folding chair"

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -33,7 +33,9 @@
 		layer = non_north_layer
 	if(buckled_mob)
 		buckled_mob.setDir(dir)
-	update_shimmy_data()
+		update_shimmy_data(force_update = TRUE)
+	else
+		update_shimmy_data()
 
 /obj/structure/bed/chair/MouseDrop(atom/over)
 	if(!foldabletype)
@@ -73,7 +75,7 @@
 			flags_can_pass_all_temp |= PASS_OVER
 			projectile_coverage = PROJECTILE_COVERAGE_MEDIUM
 
-/obj/structure/bed/chair/attack_alien(mob/living/carbon/xenomorph/M)
+/obj/structure/bed/chair/attack_alien(mob/living/carbon/xenomorph/found_living)
 	. = ..()
 	if(stacked_size)
 		stack_collapse()
@@ -135,11 +137,11 @@
 /obj/structure/bed/chair/hitby(atom/movable/AM)
 	. = ..()
 	if(istype(AM, /mob/living) && stacked_size)
-		var/mob/living/M = AM
+		var/mob/living/found_living = AM
 		stack_collapse()
-		if(ishumansynth_strict(M))
-			M.apply_effect(2, STUN)
-			M.apply_effect(2, WEAKEN)
+		if(ishumansynth_strict(found_living))
+			found_living.apply_effect(2, STUN)
+			found_living.apply_effect(2, WEAKEN)
 	else if(stacked_size > 8 && prob(50))
 		stack_collapse()
 
@@ -241,7 +243,7 @@
 			continue
 		if(found_obj.buckled_mob && ispath(found_obj.type, /obj/structure/bed/chair))
 			var/obj/structure/bed/chair/found_chair = found_obj
-			found_chair.update_shimmy_data(src)	//we need to update the shimmy handler chair to block walking into this buckled chair
+			found_chair.update_shimmy_data(src)	//we need to update the shimmy other_buckled_chair chair to block walking into this buckled chair
 			found_chair.AddComponent(/datum/component/shimmy_around, approach_dirs = found_chair.shimmy_data[5], internal_dirs = found_chair.shimmy_data[6])
 			if(target.density)
 				target.density = FALSE
@@ -258,7 +260,7 @@
 		approach_dirs = shimmy_data[5],\
 		internal_dirs = shimmy_data[6])
 
-/obj/structure/bed/chair/proc/update_shimmy_data(obj/structure/bed/chair/neighbor = null)
+/obj/structure/bed/chair/proc/update_shimmy_data(obj/structure/bed/chair/neighbor = null, force_update = FALSE)
 	if(shimmy_data == null)
 		return	//this chair doesnt shimmy
 	var/approachness
@@ -285,35 +287,83 @@
 		if(WEST)
 			shimmy_data[3] = offset
 			shimmy_data[4] = offset
+	if(force_update && buckled_mob)
+		buckled_mob.density = FALSE
+		density = TRUE
+		AddComponent(/datum/component/shimmy_around, \
+			north_offset = shimmy_data[1], \
+			south_offset = shimmy_data[2], \
+			east_offset  = shimmy_data[3], \
+			west_offset  = shimmy_data[4], \
+			extra_delay  = 0.5 SECONDS, \
+			approach_dirs = shimmy_data[5], \
+			internal_dirs = shimmy_data[6])
 
 /obj/structure/bed/chair/unbuckle()
 	if(buckled_mob)
 		buckled_mob.update_density()
 	. = ..()
 	density = FALSE
-	var/datum/component/shimmy_around/shimster = GetComponent(/datum/component/shimmy_around)
-	if(shimster)
-		qdel(shimster)
-	for(var/obj/found_obj in get_turf(src))
-		if(found_obj == src)
-			continue
-		if(found_obj.buckled_mob && ispath(found_obj.type, /obj/structure/bed/chair))
-			var/obj/structure/bed/chair/found_chair = found_obj
-			var/datum/component/shimmy_around/shimmier = found_chair.GetComponent(/datum/component/shimmy_around)
-			found_chair.update_shimmy_data(src)	//we need to update the shimmy handler chair to block walking into this buckled chair
-			if(shimmier)
-				found_chair.AddComponent(/datum/component/shimmy_around, approach_dirs = found_chair.shimmy_data[5], internal_dirs = found_chair.shimmy_data[6])
-			else
-				found_chair.density = TRUE
-				found_chair.AddComponent(/datum/component/shimmy_around, \
-					north_offset = found_chair.shimmy_data[1], \
-					south_offset = found_chair.shimmy_data[2], \
-					east_offset = found_chair.shimmy_data[3], \
-					west_offset = found_chair.shimmy_data[4],\
-					extra_delay = 0.5 SECONDS, \
-					approach_dirs = found_chair.shimmy_data[5],\
-					internal_dirs = found_chair.shimmy_data[6])
 
+	var/obj/structure/bed/chair/other_buckled_chair
+	var/list/mob/living/shimmied_mobs = list()
+	var/datum/component/shimmy_around/shimster = GetComponent(/datum/component/shimmy_around)
+	var/list/old_data
+	if(shimster)
+		old_data = list(
+			shimster.north_offset,
+			shimster.south_offset,
+			shimster.east_offset,
+			shimster.west_offset,
+			shimster.additional_offset)
+
+	for(var/obj/structure/bed/chair/found_chair in get_turf(src))
+		if(found_chair == src)
+			continue
+		if(found_chair.buckled_mob)
+			other_buckled_chair = found_chair
+			break
+
+	for(var/mob/living/found_living in get_turf(src))	//any living mobs currently shimmied ??? (have the pixel offsets)
+		if(!found_living.buckled && found_living.pixel_x != initial(found_living.pixel_x) || found_living.pixel_y != initial(found_living.pixel_y))
+			shimmied_mobs += found_living
+
+	if(!other_buckled_chair)	// No other chair is holding anyone → remove all the shimmy offsets from every shimmied mob
+		if(shimster)
+			qdel(shimster)
+		for(var/mob/living/shimmied_living in shimmied_mobs)
+			animate(shimmied_living, pixel_x = initial(shimmied_living.pixel_x), pixel_y = initial(shimmied_living.pixel_y), time = 0)
+			if(shimmied_living.layer != initial(shimmied_living.layer) && shimmied_living.layer != XENO_HIDING_LAYER)	//shimmy component also alters layering
+				shimmied_living.layer = initial(shimmied_living.layer)
+		return
+	else	// At least one other chair is still occupied – we need to either create one and then refresh mobs' offsets - OR just refresh mobs' offsets to whatd they'd be without another buckled chair
+		var/datum/component/shimmy_around/other_buckled_shimster = other_buckled_chair.GetComponent(/datum/component/shimmy_around)
+		if(!other_buckled_shimster)
+			other_buckled_chair.density = TRUE
+			other_buckled_chair.update_shimmy_data(src)
+			other_buckled_chair.AddComponent(/datum/component/shimmy_around, \
+				north_offset = other_buckled_chair.shimmy_data[1], \
+				south_offset = other_buckled_chair.shimmy_data[2], \
+				east_offset  = other_buckled_chair.shimmy_data[3], \
+				west_offset  = other_buckled_chair.shimmy_data[4], \
+				extra_delay  = 0.5 SECONDS, \
+				approach_dirs = other_buckled_chair.shimmy_data[5], \
+				internal_dirs = other_buckled_chair.shimmy_data[6])
+			other_buckled_shimster = other_buckled_chair.GetComponent(/datum/component/shimmy_around)
+		else	//it posses one, we just need to pass in the new approach and internal_dirs values
+			old_data = list(
+				other_buckled_shimster.north_offset,
+				other_buckled_shimster.south_offset,
+				other_buckled_shimster.east_offset,
+				other_buckled_shimster.west_offset,
+				other_buckled_shimster.additional_offset)
+			other_buckled_chair.update_shimmy_data(src)
+			other_buckled_chair.AddComponent(/datum/component/shimmy_around, \
+				approach_dirs = other_buckled_chair.shimmy_data[5], \
+				internal_dirs = other_buckled_chair.shimmy_data[6])
+
+		for(var/mob/living/found_living in shimmied_mobs)	// although we sent the new data, existing shimmied mobs still need to be updated
+			other_buckled_shimster.refresh_mob_offsets(found_living, old_data)
 
 //Chair types
 /obj/structure/bed/chair/bolted
@@ -432,7 +482,7 @@
 			victim.apply_damage(10, BRUTE, def_zone)
 		occupant.visible_message(SPAN_DANGER("[occupant] crashed into \the [A]!"))
 
-/// Signal handler for COMSIG_MOVABLE_PREBUCKLE to potentially block buckling.
+/// Signal other_buckled_chair for COMSIG_MOVABLE_PREBUCKLE to potentially block buckling.
 /obj/structure/bed/chair/office/proc/check_buckle(obj/bed, mob/buckle_target, mob/user)
 	SIGNAL_HANDLER
 
@@ -510,7 +560,7 @@
 		overlays -= chairbar
 
 
-/obj/structure/bed/chair/dropship/passenger/buckle_mob(mob/M, mob/user)
+/obj/structure/bed/chair/dropship/passenger/buckle_mob(mob/found_living, mob/user)
 	if(chair_state != DROPSHIP_CHAIR_UNFOLDED)
 		return
 	..()
@@ -547,7 +597,7 @@
 		chair_state = DROPSHIP_CHAIR_UNFOLDED
 		icon_state = "hotseat"
 
-/obj/structure/bed/chair/dropship/passenger/shuttle_chair/buckle_mob(mob/living/M, mob/living/user)
+/obj/structure/bed/chair/dropship/passenger/shuttle_chair/buckle_mob(mob/living/found_living, mob/living/user)
 	if(chair_state != DROPSHIP_CHAIR_UNFOLDED)
 		return
 	..()
@@ -665,12 +715,12 @@
 	flags_item = TWOHANDED
 	var/placed_object = /obj/structure/bed/chair
 
-/obj/item/weapon/twohanded/folded_metal_chair/attack(mob/living/M as mob, mob/living/user as mob)
+/obj/item/weapon/twohanded/folded_metal_chair/attack(mob/living/found_living as mob, mob/living/user as mob)
 	. = ..()
 	if(!.)
 		return
 	if(flags_item & WIELDED)
-		M.apply_stamina_damage(17, check_zone(user.zone_selected))
+		found_living.apply_stamina_damage(17, check_zone(user.zone_selected))
 	playsound(get_turf(user), 'sound/weapons/metal_chair_clang.ogg', 20, 1)
 	return ATTACKBY_HINT_UPDATE_NEXT_MOVE
 

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -13,7 +13,7 @@
 	var/propelled = FALSE //Check for fire-extinguisher-driven chairs
 	var/can_rotate = TRUE
 	var/stacked_size = 0
-	var/shimmy = TRUE
+	var/list/shimmy_data = list()
 
 /obj/structure/bed/chair/Initialize()
 	. = ..()
@@ -33,6 +33,7 @@
 		layer = non_north_layer
 	if(buckled_mob)
 		buckled_mob.setDir(dir)
+	update_shimmy_data()
 
 /obj/structure/bed/chair/MouseDrop(atom/over)
 	if(!foldabletype)
@@ -212,7 +213,6 @@
 	set name = "Rotate Chair"
 	set category = "Object"
 	set src in oview(1)
-
 	if(CONFIG_GET(flag/ghost_interaction))
 		src.setDir(turn(src.dir, 90))
 		handle_rotation()
@@ -234,25 +234,86 @@
 
 /obj/structure/bed/chair/do_buckle(mob/living/target, mob/user)
 	. = ..()
-	if(!shimmy)
+	if(shimmy_data == null)
 		return
+	for(var/obj/found_obj in get_turf(src))
+		if(found_obj == src)
+			continue
+		if(found_obj.buckled_mob && ispath(found_obj.type, /obj/structure/bed/chair))
+			var/obj/structure/bed/chair/found_chair = found_obj
+			found_chair.update_shimmy_data(src)	//we need to update the shimmy handler chair to block walking into this buckled chair
+			found_chair.AddComponent(/datum/component/shimmy_around, approach_dirs = found_chair.shimmy_data[5], internal_dirs = found_chair.shimmy_data[6])
+			if(target.density)
+				target.density = FALSE
+			return	//shimmying is already handled, we dont want to offset shimmiers twice!
 	density = TRUE
 	if(target.density)
 		target.density = FALSE
+	AddComponent(/datum/component/shimmy_around, \
+		north_offset = shimmy_data[1], \
+		south_offset = shimmy_data[2], \
+		east_offset = shimmy_data[3], \
+		west_offset = shimmy_data[4],\
+		extra_delay = 0.5 SECONDS, \
+		approach_dirs = shimmy_data[5],\
+		internal_dirs = shimmy_data[6])
+
+/obj/structure/bed/chair/proc/update_shimmy_data(obj/structure/bed/chair/neighbor = null)
+	if(shimmy_data == null)
+		return	//this chair doesnt shimmy
 	var/approachness
 	switch(dir)
 		if(NORTH, SOUTH)
 			approachness = EAST | WEST
 		if(EAST, WEST)
 			approachness = NORTH | SOUTH
-	AddComponent(/datum/component/shimmy_around, north_offset = -14, south_offset = -14, east_offset = -14, west_offset = -14, extra_delay = 0.5 SECONDS, approach_dirs = approachness)
+	var/internalness = NORTH|SOUTH|EAST|WEST
+	if(neighbor && neighbor.buckled_mob)
+		internalness &= ~turn(dir, 180)	//cant walk into filled seats
+		approachness &= !turn(dir, 180)
+	var/offset = 14
+	shimmy_data = list(-offset, -offset, -offset, -offset, approachness, internalness)
+	switch(dir)
+		if(NORTH)
+			shimmy_data[3] = offset
+			shimmy_data[4] = offset
+		if(EAST)
+			shimmy_data[1] = offset
+			shimmy_data[2] = offset
+			shimmy_data[3] = offset
+			shimmy_data[4] = offset
+		if(WEST)
+			shimmy_data[3] = offset
+			shimmy_data[4] = offset
 
 /obj/structure/bed/chair/unbuckle()
+	if(buckled_mob)
+		buckled_mob.update_density()
 	. = ..()
 	density = FALSE
 	var/datum/component/shimmy_around/shimster = GetComponent(/datum/component/shimmy_around)
 	if(shimster)
 		qdel(shimster)
+	for(var/obj/found_obj in get_turf(src))
+		if(found_obj == src)
+			continue
+		if(found_obj.buckled_mob && ispath(found_obj.type, /obj/structure/bed/chair))
+			var/obj/structure/bed/chair/found_chair = found_obj
+			var/datum/component/shimmy_around/shimmier = found_chair.GetComponent(/datum/component/shimmy_around)
+			found_chair.update_shimmy_data(src)	//we need to update the shimmy handler chair to block walking into this buckled chair
+			if(shimmier)
+				found_chair.AddComponent(/datum/component/shimmy_around, approach_dirs = found_chair.shimmy_data[5], internal_dirs = found_chair.shimmy_data[6])
+			else
+				found_chair.density = TRUE
+				found_chair.AddComponent(/datum/component/shimmy_around, \
+					north_offset = found_chair.shimmy_data[1], \
+					south_offset = found_chair.shimmy_data[2], \
+					east_offset = found_chair.shimmy_data[3], \
+					west_offset = found_chair.shimmy_data[4],\
+					extra_delay = 0.5 SECONDS, \
+					approach_dirs = found_chair.shimmy_data[5],\
+					internal_dirs = found_chair.shimmy_data[6])
+
 
 //Chair types
 /obj/structure/bed/chair/bolted
@@ -340,7 +401,7 @@
 	anchored = FALSE
 	drag_delay = 1 //Pulling something on wheels is easy
 	foldabletype = null
-	shimmy = FALSE
+	shimmy_data = null
 
 /obj/structure/bed/chair/office/Initialize(mapload, ...)
 	. = ..()

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -249,6 +249,7 @@
 				target.density = FALSE
 			return	//shimmying is already handled, we dont want to offset shimmiers twice!
 	density = TRUE
+	pass_flags.flags_can_pass_all = null
 	if(target.density)
 		target.density = FALSE
 	AddComponent(/datum/component/shimmy_around, \
@@ -258,7 +259,11 @@
 		west_offset = shimmy_data[4],\
 		extra_delay = 0.5 SECONDS, \
 		approach_dirs = shimmy_data[5],\
-		internal_dirs = shimmy_data[6])
+		internal_dirs = shimmy_data[6], \
+			disallowed_types = list( \
+				/mob/living/carbon/xenomorph, \
+			) \
+		)
 
 /obj/structure/bed/chair/proc/update_shimmy_data(obj/structure/bed/chair/neighbor = null, force_update = FALSE)
 	if(shimmy_data == null)
@@ -297,13 +302,18 @@
 			west_offset  = shimmy_data[4], \
 			extra_delay  = 0.5 SECONDS, \
 			approach_dirs = shimmy_data[5], \
-			internal_dirs = shimmy_data[6])
+			internal_dirs = shimmy_data[6], \
+			disallowed_types = list( \
+				/mob/living/carbon/xenomorph, \
+			) \
+		)
 
 /obj/structure/bed/chair/unbuckle()
 	if(buckled_mob)
 		buckled_mob.update_density()
 	. = ..()
 	density = FALSE
+	pass_flags.flags_can_pass_all = PASS_UNDER|PASS_OVER|PASS_AROUND
 
 	var/obj/structure/bed/chair/other_buckled_chair
 	var/list/mob/living/shimmied_mobs = list()
@@ -325,7 +335,7 @@
 			break
 
 	for(var/mob/living/found_living in get_turf(src))	//any living mobs currently shimmied ??? (have the pixel offsets)
-		if(!found_living.buckled && found_living.pixel_x != initial(found_living.pixel_x) || found_living.pixel_y != initial(found_living.pixel_y))
+		if(!found_living.buckled && (found_living.pixel_x != initial(found_living.pixel_x) || found_living.pixel_y != initial(found_living.pixel_y)))
 			shimmied_mobs += found_living
 
 	if(!other_buckled_chair)	// No other chair is holding anyone → remove all the shimmy offsets from every shimmied mob
@@ -348,7 +358,8 @@
 				west_offset  = other_buckled_chair.shimmy_data[4], \
 				extra_delay  = 0.5 SECONDS, \
 				approach_dirs = other_buckled_chair.shimmy_data[5], \
-				internal_dirs = other_buckled_chair.shimmy_data[6])
+				internal_dirs = other_buckled_chair.shimmy_data[6], \
+				disallowed_types = list(/mob/living/carbon/xenomorph))
 			other_buckled_shimster = other_buckled_chair.GetComponent(/datum/component/shimmy_around)
 		else	//it posses one, we just need to pass in the new approach and internal_dirs values
 			old_data = list(

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -51,12 +51,12 @@
 	if(stacked_size)
 		to_chat(H, SPAN_NOTICE("You cannot fold a chair while its stacked!"))
 		return
-	var/obj/item/weapon/twohanded/folded_metal_chair/folded_char = new foldabletype(loc)
-	if(H.put_in_hands(folded_char))
+	var/obj/item/weapon/twohanded/folded_metal_chair/folded_chair = new foldabletype(loc)
+	if(H.put_in_hands(folded_chair))
 		qdel(src)
 	else
 		to_chat(H, SPAN_NOTICE("You need a free hand to fold up the chair."))
-		qdel(folded_char)
+		qdel(folded_chair)
 
 /obj/structure/bed/chair/attack_hand(mob/user)
 	. = ..()
@@ -234,6 +234,13 @@
 	handle_rotation()
 	return
 
+#define INDEX_NORTH_OFFSET 1
+#define INDEX_SOUTH_OFFSET 2
+#define INDEX_EAST_OFFSET 3
+#define INDEX_WEST_OFFSET 4
+#define INDEX_APPORACH_DIRS 5
+#define INDEX_INTERNAL_DIRS 6
+
 /obj/structure/bed/chair/do_buckle(mob/living/target, mob/user)
 	. = ..()
 	if(shimmy_data == null)
@@ -244,26 +251,21 @@
 		if(found_obj.buckled_mob && ispath(found_obj.type, /obj/structure/bed/chair))
 			var/obj/structure/bed/chair/found_chair = found_obj
 			found_chair.update_shimmy_data(src)	//we need to update the shimmy other_buckled_chair chair to block walking into this buckled chair
-			found_chair.AddComponent(/datum/component/shimmy_around, approach_dirs = found_chair.shimmy_data[5], internal_dirs = found_chair.shimmy_data[6])
-			if(target.density)
-				target.density = FALSE
+			found_chair.AddComponent(/datum/component/shimmy_around, approach_dirs = found_chair.shimmy_data[INDEX_APPORACH_DIRS], internal_dirs = found_chair.shimmy_data[INDEX_INTERNAL_DIRS])
+			target.set_density(FALSE)
 			return	//shimmying is already handled, we dont want to offset shimmiers twice!
-	density = TRUE
-	pass_flags.flags_can_pass_all = null
-	if(target.density)
-		target.density = FALSE
+	set_density(TRUE)
+	add_temp_pass_flags() //you shall not pass
+	target.set_density(FALSE)
 	AddComponent(/datum/component/shimmy_around, \
-		north_offset = shimmy_data[1], \
-		south_offset = shimmy_data[2], \
-		east_offset = shimmy_data[3], \
-		west_offset = shimmy_data[4],\
+		north_offset = shimmy_data[INDEX_NORTH_OFFSET], \
+		south_offset = shimmy_data[INDEX_SOUTH_OFFSET], \
+		east_offset = shimmy_data[INDEX_EAST_OFFSET], \
+		west_offset = shimmy_data[INDEX_WEST_OFFSET],\
 		extra_delay = 0.5 SECONDS, \
-		approach_dirs = shimmy_data[5],\
-		internal_dirs = shimmy_data[6], \
-			disallowed_types = list( \
-				/mob/living/carbon/xenomorph, \
-			) \
-		)
+		approach_dirs = shimmy_data[INDEX_APPORACH_DIRS],\
+		internal_dirs = shimmy_data[INDEX_INTERNAL_DIRS], \
+		allowed_pass_flag = PASS_MOB_IS_HUMAN)
 
 /obj/structure/bed/chair/proc/update_shimmy_data(obj/structure/bed/chair/neighbor = null, force_update = FALSE)
 	if(shimmy_data == null)
@@ -282,50 +284,38 @@
 	shimmy_data = list(-offset, -offset, -offset, -offset, approachness, internalness)
 	switch(dir)
 		if(NORTH)
-			shimmy_data[3] = offset
-			shimmy_data[4] = offset
+			shimmy_data[INDEX_EAST_OFFSET] = offset
+			shimmy_data[INDEX_WEST_OFFSET] = offset
 		if(EAST)
-			shimmy_data[1] = offset
-			shimmy_data[2] = offset
-			shimmy_data[3] = offset
-			shimmy_data[4] = offset
+			shimmy_data[INDEX_NORTH_OFFSET] = offset
+			shimmy_data[INDEX_SOUTH_OFFSET] = offset
+			shimmy_data[INDEX_EAST_OFFSET] = offset
+			shimmy_data[INDEX_WEST_OFFSET] = offset
 		if(WEST)
-			shimmy_data[3] = offset
-			shimmy_data[4] = offset
+			shimmy_data[INDEX_EAST_OFFSET] = offset
+			shimmy_data[INDEX_WEST_OFFSET] = offset
 	if(force_update && buckled_mob)
-		buckled_mob.density = FALSE
-		density = TRUE
+		buckled_mob.set_density(FALSE)
+		set_density(TRUE)
 		AddComponent(/datum/component/shimmy_around, \
-			north_offset = shimmy_data[1], \
-			south_offset = shimmy_data[2], \
-			east_offset  = shimmy_data[3], \
-			west_offset  = shimmy_data[4], \
+			north_offset = shimmy_data[INDEX_NORTH_OFFSET], \
+			south_offset = shimmy_data[INDEX_SOUTH_OFFSET], \
+			east_offset  = shimmy_data[INDEX_EAST_OFFSET], \
+			west_offset  = shimmy_data[INDEX_WEST_OFFSET], \
 			extra_delay  = 0.5 SECONDS, \
-			approach_dirs = shimmy_data[5], \
-			internal_dirs = shimmy_data[6], \
-			disallowed_types = list( \
-				/mob/living/carbon/xenomorph, \
-			) \
-		)
+			approach_dirs = shimmy_data[INDEX_APPORACH_DIRS], \
+			internal_dirs = shimmy_data[INDEX_INTERNAL_DIRS], \
+			allowed_pass_flag = PASS_MOB_IS_HUMAN)
 
 /obj/structure/bed/chair/unbuckle()
 	if(buckled_mob)
 		buckled_mob.update_density()
 	. = ..()
-	density = FALSE
-	pass_flags.flags_can_pass_all = PASS_UNDER|PASS_OVER|PASS_AROUND
+	set_density(FALSE)
+	remove_temp_pass_flags()
 
 	var/obj/structure/bed/chair/other_buckled_chair
 	var/list/mob/living/shimmied_mobs = list()
-	var/datum/component/shimmy_around/shimster = GetComponent(/datum/component/shimmy_around)
-	var/list/old_data
-	if(shimster)
-		old_data = list(
-			shimster.north_offset,
-			shimster.south_offset,
-			shimster.east_offset,
-			shimster.west_offset,
-			shimster.additional_offset)
 
 	for(var/obj/structure/bed/chair/found_chair in get_turf(src))
 		if(found_chair == src)
@@ -339,42 +329,31 @@
 			shimmied_mobs += found_living
 
 	if(!other_buckled_chair)	// No other chair is holding anyone → remove all the shimmy offsets from every shimmied mob
-		if(shimster)
-			qdel(shimster)
 		for(var/mob/living/shimmied_living in shimmied_mobs)
 			animate(shimmied_living, pixel_x = initial(shimmied_living.pixel_x), pixel_y = initial(shimmied_living.pixel_y), time = 0)
 			if(shimmied_living.layer != initial(shimmied_living.layer) && shimmied_living.layer != XENO_HIDING_LAYER)	//shimmy component also alters layering
 				shimmied_living.layer = initial(shimmied_living.layer)
 		return
-	else	// At least one other chair is still occupied – we need to either create one and then refresh mobs' offsets - OR just refresh mobs' offsets to whatd they'd be without another buckled chair
-		var/datum/component/shimmy_around/other_buckled_shimster = other_buckled_chair.GetComponent(/datum/component/shimmy_around)
-		if(!other_buckled_shimster)
-			other_buckled_chair.density = TRUE
-			other_buckled_chair.update_shimmy_data(src)
-			other_buckled_chair.AddComponent(/datum/component/shimmy_around, \
-				north_offset = other_buckled_chair.shimmy_data[1], \
-				south_offset = other_buckled_chair.shimmy_data[2], \
-				east_offset  = other_buckled_chair.shimmy_data[3], \
-				west_offset  = other_buckled_chair.shimmy_data[4], \
-				extra_delay  = 0.5 SECONDS, \
-				approach_dirs = other_buckled_chair.shimmy_data[5], \
-				internal_dirs = other_buckled_chair.shimmy_data[6], \
-				disallowed_types = list(/mob/living/carbon/xenomorph))
-			other_buckled_shimster = other_buckled_chair.GetComponent(/datum/component/shimmy_around)
-		else	//it posses one, we just need to pass in the new approach and internal_dirs values
-			old_data = list(
-				other_buckled_shimster.north_offset,
-				other_buckled_shimster.south_offset,
-				other_buckled_shimster.east_offset,
-				other_buckled_shimster.west_offset,
-				other_buckled_shimster.additional_offset)
-			other_buckled_chair.update_shimmy_data(src)
-			other_buckled_chair.AddComponent(/datum/component/shimmy_around, \
-				approach_dirs = other_buckled_chair.shimmy_data[5], \
-				internal_dirs = other_buckled_chair.shimmy_data[6])
+	else	// At least one other chair is still occupied –> add a component, if one exists its inheritence will handle everything
+		other_buckled_chair.set_density(TRUE)
+		other_buckled_chair.update_shimmy_data(src)
+		other_buckled_chair.AddComponent(/datum/component/shimmy_around, \
+			north_offset = other_buckled_chair.shimmy_data[INDEX_NORTH_OFFSET], \
+			south_offset = other_buckled_chair.shimmy_data[INDEX_SOUTH_OFFSET], \
+			east_offset  = other_buckled_chair.shimmy_data[3], \
+			west_offset  = other_buckled_chair.shimmy_data[INDEX_WEST_OFFSET], \
+			extra_delay  = 0.5 SECONDS, \
+			approach_dirs = other_buckled_chair.shimmy_data[INDEX_APPORACH_DIRS], \
+			internal_dirs = other_buckled_chair.shimmy_data[INDEX_INTERNAL_DIRS], \
+			allowed_pass_flag = PASS_MOB_IS_HUMAN, \
+			existing_shimmiers = shimmied_mobs)
 
-		for(var/mob/living/found_living in shimmied_mobs)	// although we sent the new data, existing shimmied mobs still need to be updated
-			other_buckled_shimster.refresh_mob_offsets(found_living, old_data)
+#undef INDEX_NORTH_OFFSET
+#undef INDEX_SOUTH_OFFSET
+#undef INDEX_EAST_OFFSET
+#undef INDEX_WEST_OFFSET
+#undef INDEX_APPORACH_DIRS
+#undef INDEX_INTERNAL_DIRS
 
 //Chair types
 /obj/structure/bed/chair/bolted

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -252,11 +252,13 @@
 			var/obj/structure/bed/chair/found_chair = found_obj
 			found_chair.update_shimmy_data(src)	//we need to update the shimmy other_buckled_chair chair to block walking into this buckled chair
 			found_chair.AddComponent(/datum/component/shimmy_around, approach_dirs = found_chair.shimmy_data[INDEX_APPORACH_DIRS], internal_dirs = found_chair.shimmy_data[INDEX_INTERNAL_DIRS])
-			target.set_density(FALSE)
-			return	//shimmying is already handled, we dont want to offset shimmiers twice!
+			ADD_TRAIT(target, TRAIT_UNDENSE, TRAIT_SOURCE_BUCKLE)
+			target.update_density()	//theres already another buckled chair handling shimmies, but we still dont want our buckled mob to interfere
+			return	//shimmying is already handled
 	set_density(TRUE)
 	add_temp_pass_flags() //you shall not pass
-	target.set_density(FALSE)
+	ADD_TRAIT(target, TRAIT_UNDENSE, TRAIT_SOURCE_BUCKLE)
+	target.update_density()
 	AddComponent(/datum/component/shimmy_around, \
 		north_offset = shimmy_data[INDEX_NORTH_OFFSET], \
 		south_offset = shimmy_data[INDEX_SOUTH_OFFSET], \
@@ -295,7 +297,8 @@
 			shimmy_data[INDEX_EAST_OFFSET] = offset
 			shimmy_data[INDEX_WEST_OFFSET] = offset
 	if(force_update && buckled_mob)
-		buckled_mob.set_density(FALSE)
+		ADD_TRAIT(buckled_mob, TRAIT_UNDENSE, TRAIT_SOURCE_BUCKLE)
+		buckled_mob.update_density()
 		set_density(TRUE)
 		AddComponent(/datum/component/shimmy_around, \
 			north_offset = shimmy_data[INDEX_NORTH_OFFSET], \
@@ -309,6 +312,7 @@
 
 /obj/structure/bed/chair/unbuckle()
 	if(buckled_mob)
+		REMOVE_TRAIT(buckled_mob, TRAIT_UNDENSE, TRAIT_SOURCE_BUCKLE)
 		buckled_mob.update_density()
 	. = ..()
 	set_density(FALSE)
@@ -335,6 +339,8 @@
 				shimmied_living.layer = initial(shimmied_living.layer)
 		return
 	else	// At least one other chair is still occupied –> add a component, if one exists its inheritence will handle everything
+		ADD_TRAIT(other_buckled_chair.buckled_mob, TRAIT_UNDENSE, TRAIT_SOURCE_BUCKLE)
+		other_buckled_chair.buckled_mob.update_density()
 		other_buckled_chair.set_density(TRUE)
 		other_buckled_chair.update_shimmy_data(src)
 		other_buckled_chair.AddComponent(/datum/component/shimmy_around, \

--- a/code/game/objects/structures/stool_bed_chair_nest/janicart.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/janicart.dm
@@ -10,7 +10,7 @@
 	flags_atom = OPENCONTAINER
 	buildstacktype = null //can't be disassembled and doesn't drop anything when destroyed
 	//copypaste sorry
-	picked_up_item = null
+	foldabletype = null
 	var/amount_per_transfer_from_this = 5 //shit I dunno, adding this so syringes stop runtime erroring. --NeoFite
 	var/obj/item/storage/bag/trash/mybag = null
 	var/callme = "pimpin' ride" //how do people refer to it?

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -4,7 +4,7 @@
 	icon_state = "wheelchair"
 	anchored = FALSE
 	drag_delay = 1 //pulling something on wheels is easy
-	picked_up_item = null
+	foldabletype = null
 	var/bloodiness = 0
 	var/move_delay = 6
 

--- a/code/modules/vehicles/interior/interactable/seats.dm
+++ b/code/modules/vehicles/interior/interactable/seats.dm
@@ -343,33 +343,45 @@
 	init_pixel_y = pixel_y
 	init_pixel_x = pixel_x
 
-/obj/structure/bed/chair/vehicle/do_buckle(mob/living/target, mob/user)
-	. = ..()
-	if(!shimmy)
-		return
-	density = TRUE
-	if(target.density)
-		target.density = FALSE
-	var/approachness
+/obj/structure/bed/chair/vehicle/update_shimmy_data(obj/structure/bed/chair/neighbor = null)
+	if(shimmy_data == null)
+		return	//this chair doesnt shimmy
+	var/approachness = NORTH|SOUTH|EAST|WEST
+	var/internalness = NORTH|SOUTH|EAST|WEST
+	var/offset = 14
+	if(neighbor && neighbor.buckled_mob)
+		internalness &= ~turn(dir, 180)	//cant walk into filled seats
+		approachness &= ~turn(dir, 180)
+	approachness &= ~dir
+	shimmy_data = list(-offset, -offset, -offset, -offset, approachness, internalness)
+
 	switch(dir)
 		if(NORTH)
-			approachness = EAST|WEST|SOUTH
-		if(SOUTH)
-			approachness = EAST|WEST|NORTH
+			shimmy_data[3] = offset
+			shimmy_data[4] = offset
 		if(EAST)
-			approachness = WEST|NORTH|SOUTH
+			shimmy_data[1] = offset
+			shimmy_data[2] = offset
+			shimmy_data[3] = offset
+			shimmy_data[4] = offset
 		if(WEST)
-			approachness = EAST|NORTH|SOUTH
-	var/easterly_value = dir == EAST ? -14 : 14
-	var/northerly_value = dir == NORTH ? -14 : 14
-	var/list/offsets = list(						//what a headache, broken for E/W facing chairs.
-		pixel_x >= 0 ? -1*easterly_value : easterly_value,
-		pixel_x >= 0 ? -1*easterly_value : easterly_value,
-		pixel_y <= 14 ? -1*northerly_value : northerly_value,
-		pixel_y <= 14 ? -1*northerly_value : northerly_value,
-	)
-	AddComponent(/datum/component/shimmy_around, north_offset = offsets[1],	south_offset = offsets[2], east_offset = offsets[3], west_offset = offsets[4], extra_delay = 0.3 SECONDS, approach_dirs = approachness)
+			shimmy_data[3] = offset
+			shimmy_data[4] = offset
 
+	if(dir == NORTH || dir == SOUTH)
+		if(pixel_x < 0)
+			shimmy_data[1] = offset
+			shimmy_data[2] = offset
+		else
+			shimmy_data[1] = -offset
+			shimmy_data[2] = -offset
+	else // EAST || WEST
+		if(pixel_y >= 16)
+			shimmy_data[3] = -offset
+			shimmy_data[4] = -offset
+		else
+			shimmy_data[3] = offset
+			shimmy_data[4] = offset
 
 /obj/structure/bed/chair/vehicle/proc/setup_buckle_offsets()
 	if(pixel_x != 0)
@@ -387,6 +399,7 @@
 			layer = BELOW_MOB_LAYER
 	if(buckled_mob)
 		buckled_mob.setDir(dir)
+	update_shimmy_data()
 
 //------BUCKLING AND UNBUCKLING
 //trying to buckle a mob
@@ -421,21 +434,6 @@
 		if(buckle_offset_y != 0)
 			M.pixel_y = mob_old_y
 			mob_old_y = 0
-
-	for(var/obj/structure/bed/chair/vehicle/VS in get_turf(src))
-		if(VS != src)
-			//if both seats on same tile have buckled mob, we become dense, otherwise, not dense.
-			if(buckled_mob)
-				if(VS.buckled_mob)
-					REMOVE_TRAIT(buckled_mob, TRAIT_UNDENSE, DOUBLE_SEATS_TRAIT)
-					REMOVE_TRAIT(VS.buckled_mob, TRAIT_UNDENSE, DOUBLE_SEATS_TRAIT)
-				else
-					ADD_TRAIT(buckled_mob, TRAIT_UNDENSE, DOUBLE_SEATS_TRAIT)
-			else
-				if(VS.buckled_mob)
-					ADD_TRAIT(VS.buckled_mob, TRAIT_UNDENSE, DOUBLE_SEATS_TRAIT)
-				REMOVE_TRAIT(M, TRAIT_UNDENSE, DOUBLE_SEATS_TRAIT)
-			break
 
 	handle_rotation()
 

--- a/code/modules/vehicles/interior/interactable/seats.dm
+++ b/code/modules/vehicles/interior/interactable/seats.dm
@@ -318,8 +318,7 @@
 	var/broken = FALSE
 	buildstackamount = 0
 	can_rotate = FALSE
-	picked_up_item = null
-
+	foldabletype = null
 	unslashable = FALSE
 	unacidable = TRUE
 
@@ -343,6 +342,33 @@
 
 	init_pixel_y = pixel_y
 	init_pixel_x = pixel_x
+
+/obj/structure/bed/chair/vehicle/do_buckle(mob/living/target, mob/user)
+	. = ..()
+	if(!shimmy)
+		return
+	density = TRUE
+	if(target.density)
+		target.density = FALSE
+	var/approachness
+	switch(dir)
+		if(NORTH)
+			approachness = EAST|WEST|SOUTH
+		if(SOUTH)
+			approachness = EAST|WEST|NORTH
+		if(EAST)
+			approachness = WEST|NORTH|SOUTH
+		if(WEST)
+			approachness = EAST|NORTH|SOUTH
+	var/easterly_value = dir == EAST ? -14 : 14
+	var/northerly_value = dir == NORTH ? -14 : 14
+	var/list/offsets = list(						//what a headache, broken for E/W facing chairs.
+		pixel_x >= 0 ? -1*easterly_value : easterly_value,
+		pixel_x >= 0 ? -1*easterly_value : easterly_value,
+		pixel_y <= 14 ? -1*northerly_value : northerly_value,
+		pixel_y <= 14 ? -1*northerly_value : northerly_value,
+	)
+	AddComponent(/datum/component/shimmy_around, north_offset = offsets[1],	south_offset = offsets[2], east_offset = offsets[3], west_offset = offsets[4], extra_delay = 0.3 SECONDS, approach_dirs = approachness)
 
 
 /obj/structure/bed/chair/vehicle/proc/setup_buckle_offsets()

--- a/code/modules/vehicles/interior/interactable/seats.dm
+++ b/code/modules/vehicles/interior/interactable/seats.dm
@@ -343,7 +343,7 @@
 	init_pixel_y = pixel_y
 	init_pixel_x = pixel_x
 
-/obj/structure/bed/chair/vehicle/update_shimmy_data(obj/structure/bed/chair/neighbor = null)
+/obj/structure/bed/chair/vehicle/update_shimmy_data(obj/structure/bed/chair/neighbor = null, force_update = FALSE)
 	if(shimmy_data == null)
 		return	//this chair doesnt shimmy
 	var/approachness = NORTH|SOUTH|EAST|WEST
@@ -382,6 +382,21 @@
 		else
 			shimmy_data[3] = offset
 			shimmy_data[4] = offset
+
+	if(force_update && buckled_mob)
+		buckled_mob.density = FALSE
+		density = TRUE
+		AddComponent(/datum/component/shimmy_around, \
+			north_offset = shimmy_data[1], \
+			south_offset = shimmy_data[2], \
+			east_offset  = shimmy_data[3], \
+			west_offset  = shimmy_data[4], \
+			extra_delay  = 0.5 SECONDS, \
+			approach_dirs = shimmy_data[5], \
+			internal_dirs = shimmy_data[6], \
+			disallowed_types = list( \
+				/mob/living/carbon/xenomorph,) \
+			)
 
 /obj/structure/bed/chair/vehicle/proc/setup_buckle_offsets()
 	if(pixel_x != 0)

--- a/code/modules/vehicles/interior/interactable/seats.dm
+++ b/code/modules/vehicles/interior/interactable/seats.dm
@@ -394,9 +394,7 @@
 			extra_delay  = 0.5 SECONDS, \
 			approach_dirs = shimmy_data[5], \
 			internal_dirs = shimmy_data[6], \
-			disallowed_types = list( \
-				/mob/living/carbon/xenomorph,) \
-			)
+			allowed_pass_flag = PASS_MOB_IS_HUMAN)
 
 /obj/structure/bed/chair/vehicle/proc/setup_buckle_offsets()
 	if(pixel_x != 0)


### PR DESCRIPTION

# About the pull request

This PR lets you shimmy past people seated in immovable chairs..
While occupied movement into the chair tile is blocked in columnar direction, have to move up and down rows.
Occupied dropship seats only block movement from behind, and the back of the seats there anyways

Also I removed an unnecessary variable from chairs, since beds have a similar variable already that can be used.

# Explain why it's good for the game

QOL: Makes it easier to find a seat, and adds a bit more organization to dropship seat behavior as well. The shimmying component is neat. :0)

FIX: Currently if an object that shimmies stuff is destroyed shimmied mobs dont have their pixel_x/pixel_y/layers reset back to normal. This PR also fixes that

<img width="415" height="373" alt="dreamseeker_Fe4mI6oSFi" src="https://github.com/user-attachments/assets/979f0543-9e9e-4f7f-ac96-1cefbb58fe63" />

<details><summary><sub>no ulterior motives</sub></summary>... itd be nice for if perhaps two dropship seats were vertically aligned in a 1 wide room 👀 </details>

# Changelog
:cl: Kugamo
code: removed an unnecessary chair variable
fix: shimmied mobs now get their offsets reset if the object being shimmied around gets destroyed
qol: you can now shimmy past seated people in immovable seats!
/:cl:
