### PR TITLE
Potato patches are STILL NOT REAL!!!!

### DIFF
--- a/code/modules/gear_presets/survivors/solaris/preset_solaris.dm
+++ b/code/modules/gear_presets/survivors/solaris/preset_solaris.dm
@@ -338,7 +338,7 @@
 	var/choice = rand(1,5)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/officer/bridge(new_human), WEAR_BODY)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/cmcap/bridge(new_human), WEAR_HEAD)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/patch(new_human), WEAR_ACCESSORY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/patch/uscmpatch(new_human), WEAR_ACCESSORY)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/patch/uasquare(new_human), WEAR_ACCESSORY)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/ranks/marine/wo(new_human), WEAR_ACCESSORY)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine(new_human), WEAR_HANDS)


### PR DESCRIPTION

# About the pull request

surely this is the last time i have to do this

# Explain why it's good for the game

fixes potato patches from being equipped on the synthetic recruiter
closes: #13039

# Testing Photographs and Procedure
line change

# Changelog
:cl:
fix: Synthetic USCM Recruiters no longer have the habit of picking up a random potato and throwing it on their shoulder to show off
/:cl:
