### PR TITLE
Changes valkyrie rage usage style

### DIFF
--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -116,8 +116,7 @@ so that it doesn't double up on the delays) so that it applies the delay immedia
 	return
 
 /mob/living/carbon/xenomorph/click(atom/target, list/mods)
-	if(queued_action)
-		handle_queued_action(target)
+	if(queued_action && handle_queued_action(target))
 		return TRUE
 
 	var/left_pressed = mods[LEFT_CLICK] == "1"

--- a/code/modules/mob/living/carbon/xenomorph/XenoOverwatch.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoOverwatch.dm
@@ -168,8 +168,12 @@
 // Sets the Xeno's view to its observed target if that target is set. Otherwise, resets the xeno's view to itself.
 // Please handle typechecking outside this proc
 /mob/living/carbon/xenomorph/reset_view(atom/A)
+	var/queued_cursor = queued_action ? client?.mouse_pointer_icon : null
+
 	. = ..(A)
 	if(.)
+		if(queued_cursor)
+			client.mouse_pointer_icon = queued_cursor
 		return
 
 	if (client)
@@ -178,6 +182,9 @@
 		if(observed_xeno && !stat)
 			client.perspective = EYE_PERSPECTIVE
 			client.set_eye(observed_xeno)
+
+	if(queued_cursor)
+		client.mouse_pointer_icon = queued_cursor
 
 // Handle HREF clicks through hive status and hivemind
 /mob/living/carbon/xenomorph/Topic(href, href_list)

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -584,17 +584,28 @@
 
 
 // Handle queued actions.
-/mob/living/carbon/xenomorph/proc/handle_queued_action(atom/A)
+/mob/living/carbon/xenomorph/proc/handle_queued_action(atom/target)
+	. = FALSE
 	if(!queued_action || !istype(queued_action) || !(queued_action in actions))
+		clear_queued_action()
 		return
 
 	if(queued_action.can_use_action() && queued_action.action_cooldown_check())
-		queued_action.use_ability_wrapper(A)
+		queued_action.use_ability_wrapper(target)
+		. = TRUE
 
+	clear_queued_action()
+
+/// Clears any queued action
+/mob/living/carbon/xenomorph/proc/clear_queued_action()
 	queued_action = null
 
+	if(queued_action_timer != TIMER_ID_NULL)
+		deltimer(queued_action_timer)
+		queued_action_timer = TIMER_ID_NULL
+
 	if(client)
-		client.mouse_pointer_icon = initial(client.mouse_pointer_icon) // Reset our mouse pointer when we no longer have an action queued.
+		client.mouse_pointer_icon = initial(client.mouse_pointer_icon)
 
 /// Called when pulling something to either upgrade the grab or restrain the pulled mob
 /mob/living/carbon/xenomorph/proc/pull_power(obj/item/grab/grab_obj)

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -249,6 +249,7 @@
 	var/datum/behavior_delegate/behavior_delegate = null // Holds behavior delegate. Governs all 'unique' hooked behavior of the Xeno. Set by caste datums and strains.
 	var/datum/action/xeno_action/activable/selected_ability // Our currently selected ability
 	var/datum/action/xeno_action/activable/queued_action // Action to perform on the next click.
+	var/queued_action_timer = TIMER_ID_NULL
 	var/is_zoomed = FALSE
 	var/list/spit_types
 	/// Caste-based spit windup
@@ -773,7 +774,7 @@
 	l_store = null
 	ammo = null
 	selected_ability = null
-	queued_action = null
+	clear_queued_action()
 
 	QDEL_NULL(strain)
 	QDEL_NULL(behavior_delegate)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ability_macro_framework.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ability_macro_framework.dm
@@ -1,3 +1,5 @@
+#define XENO_QUEUED_ACTION_TIMEOUT 5 SECONDS
+
 // Backend stuff for macros
 /proc/handle_xeno_macro(mob/living/carbon/xenomorph/xeno, action_name)
 	for(var/datum/action/xeno_action/action in xeno.actions)
@@ -39,14 +41,25 @@
 // Queue an action for the next click. This will always work but should only be used for actions that actually NEED an atom to work
 // Other ones should just use the activate proc
 /proc/handle_xeno_macro_actionqueue(mob/living/carbon/xenomorph/xeno, datum/action/xeno_action/activable/action)
-	if (!istype(action))
+	if(!istype(action))
 		return
 
+	// Cancel on second press
+	if(xeno.queued_action == action)
+		xeno.clear_queued_action()
+		to_chat(xeno, SPAN_WARNING("You will no longer use [action.name] on your next click."))
+		return
+
+	if(!action.can_use_action() || !action.action_cooldown_check())
+		return
+
+	xeno.clear_queued_action()
 	xeno.queued_action = action
+	xeno.queued_action_timer = addtimer(CALLBACK(xeno, TYPE_PROC_REF(/mob/living/carbon/xenomorph, clear_queued_action)), XENO_QUEUED_ACTION_TIMEOUT, TIMER_STOPPABLE)
 	to_chat(xeno, SPAN_WARNING("Your next click will use [action.name]!"))
 
 	if(xeno.client?.prefs?.custom_cursors)
-		xeno.client.mouse_pointer_icon = 'icons/mob/hud/mecha_mouse.dmi'
+		xeno.client.mouse_pointer_icon = 'icons/effects/mouse_pointer/mecha_mouse.dmi'
 
 
 /mob/living/carbon/xenomorph/verb/xeno_primary_action_one()

--- a/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/praetorian/praetorian_abilities.dm
@@ -311,7 +311,7 @@
 /datum/action/xeno_action/activable/valkyrie_rage
 	name = "Tantrum"
 	action_icon_state = "warden_heal"
-	action_type = XENO_ACTION_CLICK
+	action_type = XENO_ACTION_QUEUE
 	ability_primacy = XENO_PRIMARY_ACTION_1
 	macro_path = /datum/action/xeno_action/verb/verb_prae_rage
 	plasma_cost = 100


### PR DESCRIPTION

# About the pull request

Basically changes rage to XENO_ACTION_QUEUE so that instead of having to switch abilities, you can just click it and use it, this was originally ohw it was meant to be but i couldnt get it to work and now discovered this
# Explain why it's good for the game


This makes it more seamless i think


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
code: Switched Valkyrie's rage ability from XENO_ACTION_CLICK to XENO_ACTION_QUEUE this basically means that the ability no longer has to be chosen and will use on your next clicking, meaning you can indirectly use it without clicking the ability.
/:cl:
