### PR TITLE
Fix Rocket/LTB/Caster ground firing and retire AMMO_EXPLOSIVE

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -12,7 +12,7 @@
 #define HEADSHOT_OVERLAY_HEAVY "heavy_headshot"
 
 // flags_ammo_behaviour
-#define AMMO_EXPLOSIVE (1<<0)
+// (1<<0) was formerly AMMO_EXPLOSIVE. Reuse it only if you must. I encourage you to use components.
 #define AMMO_ACIDIC (1<<1)
 #define AMMO_XENO (1<<2)
 #define AMMO_LASER (1<<3)

--- a/code/_globalvars/bitfields.dm
+++ b/code/_globalvars/bitfields.dm
@@ -83,7 +83,6 @@ DEFINE_BITFIELD(reaction_type, list(
 ))
 
 DEFINE_BITFIELD(flags_ammo_behaviour, list(
-	"AMMO_EXPLOSIVE" = AMMO_EXPLOSIVE,
 	"AMMO_ACIDIC" = AMMO_ACIDIC,
 	"AMMO_XENO" = AMMO_XENO,
 	"AMMO_LASER" = AMMO_LASER,

--- a/code/datums/ammo/bullet/revolver.dm
+++ b/code/datums/ammo/bullet/revolver.dm
@@ -163,7 +163,7 @@
 	damage_var_low = PROJECTILE_VARIANCE_TIER_10
 	damage_var_high = PROJECTILE_VARIANCE_TIER_1
 	penetration = ARMOR_PENETRATION_TIER_10
-	flags_ammo_behavior = AMMO_EXPLOSIVE|AMMO_BALLISTIC
+	flags_ammo_behavior = AMMO_BALLISTIC
 
 /datum/ammo/bullet/revolver/mateba/highimpact/explosive/on_hit_mob(mob/M, obj/projectile/P)
 	..()

--- a/code/datums/ammo/energy.dm
+++ b/code/datums/ammo/energy.dm
@@ -187,7 +187,7 @@
 /datum/ammo/energy/yautja/caster/aoe_lethal
 	name = "plasma eradicator"
 	icon_state = "bluespace"
-	flags_ammo_behavior = AMMO_EXPLOSIVE|AMMO_HITS_TARGET_TURF
+	flags_ammo_behavior = AMMO_HITS_TARGET_TURF
 	shell_speed = AMMO_SPEED_TIER_4
 	accuracy = HIT_ACCURACY_TIER_8
 
@@ -219,7 +219,7 @@
 
 /datum/ammo/energy/yautja/caster/lance
 	name = "plasma lance"
-	flags_ammo_behavior = AMMO_EXPLOSIVE|AMMO_HITS_TARGET_TURF|AMMO_ANTISTRUCT
+	flags_ammo_behavior = AMMO_HITS_TARGET_TURF|AMMO_ANTISTRUCT
 	shell_speed = AMMO_SPEED_INSTANT // travels 300 tiles in one tick
 	scatter = SCATTER_AMOUNT_NONE
 	accuracy = HIT_ACCURACY_MULT_TIER_10

--- a/code/datums/ammo/rocket.dm
+++ b/code/datums/ammo/rocket.dm
@@ -10,7 +10,7 @@
 	ping = null //no bounce off.
 	sound_bounce = "rocket_bounce"
 	damage_falloff = 0
-	flags_ammo_behavior = AMMO_EXPLOSIVE|AMMO_ROCKET|AMMO_STRIKES_SURFACE
+	flags_ammo_behavior = AMMO_ROCKET|AMMO_STRIKES_SURFACE|AMMO_HITS_TARGET_TURF
 
 	accuracy = HIT_ACCURACY_TIER_2
 	accurate_range = 7
@@ -39,7 +39,7 @@
 /datum/ammo/rocket/ap
 	name = "anti-armor rocket"
 	damage_falloff = 0
-	flags_ammo_behavior = AMMO_EXPLOSIVE|AMMO_ROCKET
+	flags_ammo_behavior = AMMO_ROCKET|AMMO_HITS_TARGET_TURF
 
 	accuracy = HIT_ACCURACY_TIER_8
 	accuracy_var_low = PROJECTILE_VARIANCE_TIER_9
@@ -131,7 +131,7 @@
 /datum/ammo/rocket/ltb
 	name = "cannon round"
 	icon_state = "ltb"
-	flags_ammo_behavior = AMMO_EXPLOSIVE|AMMO_ROCKET|AMMO_STRIKES_SURFACE
+	flags_ammo_behavior = AMMO_ROCKET|AMMO_STRIKES_SURFACE|AMMO_HITS_TARGET_TURF
 
 	accuracy = HIT_ACCURACY_TIER_3
 	accurate_range = 32
@@ -157,7 +157,7 @@
 
 /datum/ammo/rocket/wp
 	name = "white phosphorous rocket"
-	flags_ammo_behavior = AMMO_ROCKET|AMMO_EXPLOSIVE|AMMO_STRIKES_SURFACE
+	flags_ammo_behavior = AMMO_ROCKET|AMMO_HITS_TARGET_TURF|AMMO_STRIKES_SURFACE
 	damage_type = BURN
 
 	accuracy_var_low = PROJECTILE_VARIANCE_TIER_6
@@ -197,7 +197,7 @@
 
 /datum/ammo/rocket/wp/upp
 	name = "extreme-intensity incendiary rocket"
-	flags_ammo_behavior = AMMO_ROCKET|AMMO_EXPLOSIVE|AMMO_STRIKES_SURFACE
+	flags_ammo_behavior = AMMO_ROCKET|AMMO_HITS_TARGET_TURF|AMMO_STRIKES_SURFACE
 	damage_type = BURN
 
 	accuracy_var_low = PROJECTILE_VARIANCE_TIER_6

--- a/code/datums/ammo/xeno.dm
+++ b/code/datums/ammo/xeno.dm
@@ -296,7 +296,7 @@
 	icon_state = "neuro_glob"
 	ping = "ping_x"
 	debilitate = list(2,2,0,1,11,12,1,10) // Stun,knockdown,knockout,irradiate,stutter,eyeblur,drowsy,agony
-	flags_ammo_behavior = AMMO_SKIPS_ALIENS|AMMO_EXPLOSIVE|AMMO_IGNORE_RESIST|AMMO_HITS_TARGET_TURF|AMMO_ACIDIC
+	flags_ammo_behavior = AMMO_SKIPS_ALIENS|AMMO_IGNORE_RESIST|AMMO_HITS_TARGET_TURF|AMMO_ACIDIC
 	spit_cost = 200
 	pre_spit_warn = TRUE
 	spit_windup = 5 SECONDS

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1793,7 +1793,7 @@ and you're good to go.
 				admin_msg = "[key_name(user)] lost at Russian Roulette with \a [name] in [get_area(user)] [ffl]"
 
 			var/obj/limb/head = user.get_limb("head") // carnage
-			if(projectile_to_fire.ammo.bonus_projectiles_type || projectile_to_fire.ammo.flags_ammo_behavior == AMMO_EXPLOSIVE || (projectile_to_fire.ammo.damage * damage_mult) >= 80)
+			if(projectile_to_fire.ammo.bonus_projectiles_type || (projectile_to_fire.ammo.damage * damage_mult) >= 80)
 				user.visible_message(SPAN_HIGHDANGER(uppertext("[user]'s head explodes into a cloud of blood and bone by their [name], oh God.")))
 				head.droplimb(FALSE, TRUE)
 				user.spawn_gibs()
@@ -2563,7 +2563,7 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 	simulate_recoil(2, user)
 
 	var/obj/limb/head = execution_target.get_limb("head")
-	if(projectile_to_fire.ammo.bonus_projectiles_type || projectile_to_fire.ammo.flags_ammo_behavior & AMMO_EXPLOSIVE || (projectile_to_fire.ammo.damage * damage_mult) >= 80)
+	if(projectile_to_fire.ammo.bonus_projectiles_type || (projectile_to_fire.ammo.damage * damage_mult) >= 80)
 		execution_target.visible_message(SPAN_HIGHDANGER(uppertext("[execution_target]'s head explodes into a cloud of blood and bone by [user]'s [name], oh God.")),
 			SPAN_HIGHDANGER("Your head explodes into a cloud of blood and bone, goddamn.")) // lol
 		head.droplimb(FALSE, TRUE)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -468,7 +468,7 @@
 	var/hit_turf = FALSE
 	// Explosive ammo always explodes on the turf of the clicked target
 	// So does ammo that's flagged to always hit the target
-	if(((ammo_flags & AMMO_EXPLOSIVE) || (ammo_flags & AMMO_HITS_TARGET_TURF)) && turf == target_turf)
+	if((ammo_flags & AMMO_HITS_TARGET_TURF) && turf == target_turf)
 		hit_turf = TRUE
 
 	for(var/atom/movable/clone/clone in turf) //Handle clones if there are any

--- a/code/modules/vehicles/hardpoints/hardpoint.dm
+++ b/code/modules/vehicles/hardpoints/hardpoint.dm
@@ -592,7 +592,7 @@
 
 	// turf-targeted projectiles are fired without scatter, because proc would raytrace them further away
 	var/ammo_flags = projectile_to_fire.ammo.flags_ammo_behavior | projectile_to_fire.projectile_override_flags
-	if(!HAS_FLAG(ammo_flags, AMMO_HITS_TARGET_TURF) && !HAS_FLAG(ammo_flags, AMMO_EXPLOSIVE)) //AMMO_EXPLOSIVE is also a turf-targeted projectile
+	if(!HAS_FLAG(ammo_flags, AMMO_HITS_TARGET_TURF))
 		projectile_to_fire.scatter = scatter
 		target = simulate_scatter(projectile_to_fire, target, origin_turf, get_turf(target), user)
 


### PR DESCRIPTION

# About the pull request

For about 4 years, Rocket Launchers and LTB have been unable to fire at the ground. Apparently nobody realized.

I actually fixed that bug for Flare Guns way back in 2022 in #2031 but in my grand ignorance I did not realize that AMMO_EXPLOSIVE implicitely means AMMO_HITS_TARGET_TURF because people were too lazy to type both.

## Why does it break ?

As said in #2031 - essentially projectiles subjected to AMMO_HITS_TARGET_TURF must ignore scatter calculation. Scatter re-targets the projectile by raycasting it, so you're now aiming somewhere else than you clicked, far away. It forgets what turf you wanted to hit.

## Won't removing scatter from LTB / M5 RPG / Caster be a big difference?

I don't think so, they're spec'ed to zero scatter anyway.
Technically the HPC and Dual Plasma Cannons have a small amount of scatter, but I don't think that's really the biggest worry if HPCs are in play.

## Wait, you're removing AMMO_EXPLOSIVE entirely.

Yes because it actually only did two things:
 * Act as AMMO_HITS_TARGET_TURF
 * Cause BE/Suicide to be explosive, which only matters for Mateba HE, which already deals >80 damage to trigger the check, so why even bother?

The first obviously doesn't warrant a flag. The second... I don't know, I guess maybe if you were to somehow try to suicide point blank with a WP rocket it'd make a difference, but i'm pretty sure it's impossible too.

## What about HE Mateba?

Well fixing without removing AMMO_EXPLOSIVE would give it ground targeting, which you don't want on small arms, so I didn't give it AMMO_HITS_TARGET_TURF. Happy ending.

## HPC/RPG warning

This means HPC and RPG will explode where you click, even if you click 2 tiles from you. So be careful. Point at what you want to blow up, don't shoot in the general direction.

## I can't believe you found a holy projectile flag in the land of terrible 24-flags BYOND drought!

Yeah well this goes to show how RELEVANT our flags are and why this is a false problem.


# Changelog
:cl:
fix: Rocket/LTB/HPC now explode on clicked turf properly again rather than flying by. Make SURE you click on what you want to explode, not the general direction.
del: Removed Explosive Ammo properties. It only mattered for BE/Suicide with HE Mateba, and it does that anyway.
balance: Caster Eradicator (HPC) / Dual Plasma Cannons had scatter disabled to target ground properly. Little difference that makes if that thing is pointed at you.
/:cl:
