### PR TITLE
gives queen lz console tracker

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -546,6 +546,9 @@
 
 		if(user.hive.hive_location)
 			options["Hive Core"] = list(null, TRACKER_HIVE)
+		var/obj/structure/machinery/computer/shuttle/dropship/flight/primary_lz_console = SSticker.mode.active_lz
+		if(primary_lz_console)
+			options["Primazy LZ"] = list(primary_lz_console, TRACKER_LZ)
 
 		for(var/mob/living/carbon/xenomorph/leader in user.hive.xeno_leader_list)
 			options["Xeno Leader [leader]"] = list(leader, TRACKER_LEADER)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -420,6 +420,8 @@ Make sure their actual health updates immediately.*/
 				tracking_atom = leader
 		if(TRACKER_TUNNEL)
 			tracking_atom = locator.tracking_ref?.resolve()
+		if(TRACKER_LZ)
+			tracking_atom = locator.tracking_ref?.resolve()
 
 	// If the atom can't be found/has been deleted.
 	if(!tracking_atom)


### PR DESCRIPTION

# About the pull request

gives option for queen to track primary console so queen can hijack without memorizing all the locations. marines can already track that anyway

# Explain why it's good for the game

Not having to prop hunt for lz console under all the fob stuff covered in acid is not fun and you already won at that point, needless delay


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
qol: queen can track primary lz console
/:cl:
