### PR TITLE
Predaliens and Kings can pry open dropships and lock them + ERT shuttles can be interacted by Queen/Predalien/King

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -107,8 +107,8 @@
 
 #define XENO_STARTING_CRYSTAL 100 //How much building resource the queen gets to start with
 
-/// Whether the xeno in question is capable of unlocking dropships and starting hijack
-#define IS_XENO_DROPSHIP_CAPABLE(X) (X.hive_pos == XENO_QUEEN || X.caste_type == XENO_CASTE_PREDALIEN)
+/// Whether the xeno in question is capable of prying open dropships, starting hijack (queen) and disabling ERT shuttles
+#define IS_XENO_DROPSHIP_CAPABLE(X) (X.hive_pos == XENO_QUEEN || X.caste_type == XENO_CASTE_PREDALIEN || X.caste_type == XENO_CASTE_KING)
 
 // Queen permission toggles
 #define COOLDOWN_TOGGLE_SLASH "cooldown_toggle_slash"

--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -107,6 +107,9 @@
 
 #define XENO_STARTING_CRYSTAL 100 //How much building resource the queen gets to start with
 
+/// Whether the xeno in question is capable of unlocking dropships and starting hijack
+#define IS_XENO_DROPSHIP_CAPABLE(X) (X.hive_pos == XENO_QUEEN || X.caste_type == XENO_CASTE_PREDALIEN)
+
 // Queen permission toggles
 #define COOLDOWN_TOGGLE_SLASH "cooldown_toggle_slash"
 #define COOLDOWN_TOGGLE_CONSTRUCTION "cooldown_toggle_construction"

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -621,6 +621,29 @@
 	name = "Press Office"
 	req_access = list(ACCESS_PRESS)
 
+/obj/structure/machinery/door/airlock/almayer/generic/shuttle
+	name = "\improper Shuttle Airlock"
+	no_panel = TRUE
+	not_weldable = TRUE
+	unslashable = TRUE
+	unacidable = TRUE
+
+/obj/structure/machinery/door/airlock/almayer/generic/shuttle/attack_alien(mob/living/carbon/xenomorph/xeno)
+	if(!IS_XENO_DROPSHIP_CAPABLE(xeno))
+		return ..()
+
+	if(!locked)
+		return ..()
+
+	if(xeno.action_busy)
+		return
+
+	to_chat(xeno, SPAN_NOTICE("You try and force the doors open!"))
+	if(do_after(xeno, 5 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
+		unlock(TRUE)
+		open(TRUE)
+		lock(TRUE)
+
 /obj/structure/machinery/door/airlock/almayer/marine
 	name = "\improper Airlock"
 	icon = 'icons/obj/structures/doors/prepdoor.dmi'
@@ -906,7 +929,7 @@
 	return ..()
 
 /obj/structure/machinery/door/airlock/dropship_hatch/attack_alien(mob/living/carbon/xenomorph/xeno)
-	if(xeno.hive_pos != XENO_QUEEN)
+	if(!IS_XENO_DROPSHIP_CAPABLE(xeno))
 		return ..()
 
 	if(!locked)

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -275,7 +275,7 @@
 	if(!queen_pryable)
 		return ..()
 
-	if(xeno.hive_pos != XENO_QUEEN)
+	if(!IS_XENO_DROPSHIP_CAPABLE(xeno))
 		return ..()
 
 	if(xeno.action_busy)
@@ -347,7 +347,7 @@
 	return ..()
 
 /obj/structure/machinery/door/airlock/multi_tile/almayer/dropshiprear/attack_alien(mob/living/carbon/xenomorph/xeno)
-	if(xeno.hive_pos != XENO_QUEEN)
+	if(!IS_XENO_DROPSHIP_CAPABLE(xeno))
 		return ..()
 
 	if(!queen_pryable)

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -272,10 +272,10 @@
 	queen_pryable = TRUE
 
 /obj/structure/machinery/door/airlock/multi_tile/almayer/containment/attack_alien(mob/living/carbon/xenomorph/xeno)
-	if(!queen_pryable)
+	if(!IS_XENO_DROPSHIP_CAPABLE(xeno))
 		return ..()
 
-	if(!IS_XENO_DROPSHIP_CAPABLE(xeno))
+	if(!queen_pryable)
 		return ..()
 
 	if(xeno.action_busy)
@@ -702,6 +702,29 @@
 
 /obj/structure/machinery/door/airlock/multi_tile/almayer/generic2/glass/autoname
 	autoname = TRUE
+
+/obj/structure/machinery/door/airlock/multi_tile/almayer/generic2/shuttle
+	name = "\improper Shuttle Airlock"
+	no_panel = TRUE
+	not_weldable = TRUE
+	unslashable = TRUE
+	unacidable = TRUE
+
+/obj/structure/machinery/door/airlock/multi_tile/almayer/generic2/shuttle/attack_alien(mob/living/carbon/xenomorph/xeno)
+	if(!IS_XENO_DROPSHIP_CAPABLE(xeno))
+		return ..()
+
+	if(!locked)
+		return ..()
+
+	if(xeno.action_busy)
+		return
+
+	to_chat(xeno, SPAN_NOTICE("You try and force the doors open!"))
+	if(do_after(xeno, 5 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
+		unlock(TRUE)
+		open(TRUE)
+		lock(TRUE)
 
 // Hybrisa
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/King.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/King.dm
@@ -2,6 +2,7 @@
 	caste_type = XENO_CASTE_KING
 	caste_desc = "The end of the line."
 	tier = 4
+	is_intelligent = TRUE
 
 	melee_damage_lower = XENO_DAMAGE_TIER_6
 	melee_damage_upper = XENO_DAMAGE_TIER_8

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -9,7 +9,6 @@
 
 	var/hivenumber = XENO_HIVE_NORMAL
 	var/mob/living/carbon/xenomorph/queen/living_xeno_queen
-	var/mob/living/carbon/xenomorph/predalien/living_xeno_predalien
 	var/egg_planting_range = 15
 
 	/// Toggles for the hive that are reset on queen death unless hive_flags_locked
@@ -828,7 +827,7 @@
 	return length(hive_structures[name_ref])
 
 /datum/hive_status/proc/abandon_on_hijack()
-	var/area/hijacked_dropship = get_area(living_xeno_queen && living_xeno_predalien)
+	var/area/hijacked_dropship = get_area(living_xeno_queen)
 	if(!hijacked_dropship)
 		return FALSE
 	var/shipside_humans_weighted_count = 0

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -9,6 +9,7 @@
 
 	var/hivenumber = XENO_HIVE_NORMAL
 	var/mob/living/carbon/xenomorph/queen/living_xeno_queen
+	var/mob/living/carbon/xenomorph/predalien/living_xeno_predalien
 	var/egg_planting_range = 15
 
 	/// Toggles for the hive that are reset on queen death unless hive_flags_locked
@@ -827,7 +828,7 @@
 	return length(hive_structures[name_ref])
 
 /datum/hive_status/proc/abandon_on_hijack()
-	var/area/hijacked_dropship = get_area(living_xeno_queen)
+	var/area/hijacked_dropship = get_area(living_xeno_queen && living_xeno_predalien)
 	if(!hijacked_dropship)
 		return FALSE
 	var/shipside_humans_weighted_count = 0

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -340,6 +340,19 @@
 		return TRUE
 	tgui_interact(user)
 
+/obj/structure/machinery/computer/shuttle/ert/attack_alien(mob/living/carbon/xenomorph/xeno)
+	// If the attacking xeno isn't the queen or predalien.
+	if(IS_XENO_DROPSHIP_CAPABLE(xeno))
+		xeno.animation_attack_on(src)
+		disabled = TRUE
+		to_chat(xeno, SPAN_XENONOTICE("We slash at [src], rendering it inoperable!"))
+		playsound(loc, 'sound/machines/terminal_shutdown.ogg', 20)
+	else
+		to_chat(xeno, SPAN_NOTICE("Lights flash from the terminal but we can't comprehend their meaning."))
+		playsound(loc, 'sound/machines/terminal_error.ogg', KEYBOARD_SOUND_VOLUME, TRUE)
+	return XENO_NONCOMBAT_ACTION
+
+
 /obj/structure/machinery/computer/shuttle/ert/small
 	name = "transport shuttle"
 	desc = "A transport shuttle flight computer."

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -289,10 +289,11 @@
 		shuttleId = pick(alternatives)["id"]
 
 	var/obj/docking_port/mobile/marine_dropship/dropship = SSshuttle.getShuttle(shuttleId)
-
-	// If the attacking xeno isn't the queen or predalien.
+	var/hivenumber = XENO_HIVE_NORMAL
+	var/datum/hive_status/hive = GLOB.hive_datum[hivenumber]
+	// If the attacking xeno isn't the queen, king or predalien.
 	if(!IS_XENO_DROPSHIP_CAPABLE(xeno))
-		// If the 'about to launch' alarm is playing, a xeno can whack the computer to stop it.
+	// If the 'about to launch' alarm is playing, a xeno can whack the computer to stop it.
 		if(dropship.playing_launch_announcement_alarm)
 			stop_playing_launch_announcement_alarm()
 			xeno.animation_attack_on(src)
@@ -302,6 +303,11 @@
 			to_chat(xeno, SPAN_NOTICE("Lights flash from the terminal but we can't comprehend their meaning."))
 			playsound(loc, 'sound/machines/terminal_error.ogg', KEYBOARD_SOUND_VOLUME, TRUE)
 		return XENO_NONCOMBAT_ACTION
+
+	// Only the queen should have the authority to start hijack.
+	if(xeno.caste_type != XENO_CASTE_QUEEN)
+		to_chat(xeno, SPAN_XENODANGER("We shouldn't be tampering with the controls."))
+		return
 
 	if(!is_ground_level(z))
 		// "you" rather than "we" for this one since non-queen castes will have returned above.

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -302,11 +302,6 @@
 			playsound(loc, 'sound/machines/terminal_error.ogg', KEYBOARD_SOUND_VOLUME, TRUE)
 		return XENO_NONCOMBAT_ACTION
 
-	// Only the queen should have the authority to start hijack.
-	if(xeno.caste_type != XENO_CASTE_QUEEN)
-		to_chat(xeno, SPAN_XENODANGER("We shouldn't be tampering with the controls."))
-		return
-
 	if(!is_ground_level(z))
 		// "you" rather than "we" for this one since non-queen castes will have returned above.
 		to_chat(xeno, SPAN_NOTICE("Lights flash from the terminal but you can't comprehend their meaning."))
@@ -338,6 +333,11 @@
 		message_admins("[key_name(xeno)] has locked the dropship '[dropship]'", xeno.x, xeno.y, xeno.z)
 		notify_ghosts(header = "Dropship Locked", message = "[xeno] has locked [dropship]!", source = xeno, action = NOTIFY_ORBIT)
 		SScmtv.spectate_event("Dropship Locked", src)
+		return
+
+	// Only the queen should have the authority to start hijack.
+	if(xeno.caste_type != XENO_CASTE_QUEEN)
+		to_chat(xeno, SPAN_XENODANGER("We shouldn't be tampering with the controls any further."))
 		return
 
 	if(dropship_control_lost)

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -289,8 +289,6 @@
 		shuttleId = pick(alternatives)["id"]
 
 	var/obj/docking_port/mobile/marine_dropship/dropship = SSshuttle.getShuttle(shuttleId)
-	var/hivenumber = XENO_HIVE_NORMAL
-	var/datum/hive_status/hive = GLOB.hive_datum[hivenumber]
 	// If the attacking xeno isn't the queen, king or predalien.
 	if(!IS_XENO_DROPSHIP_CAPABLE(xeno))
 	// If the 'about to launch' alarm is playing, a xeno can whack the computer to stop it.

--- a/code/modules/shuttle/computers/dropship_computer.dm
+++ b/code/modules/shuttle/computers/dropship_computer.dm
@@ -290,8 +290,8 @@
 
 	var/obj/docking_port/mobile/marine_dropship/dropship = SSshuttle.getShuttle(shuttleId)
 
-	// If the attacking xeno isn't the queen.
-	if(xeno.hive_pos != XENO_QUEEN)
+	// If the attacking xeno isn't the queen or predalien.
+	if(!IS_XENO_DROPSHIP_CAPABLE(xeno))
 		// If the 'about to launch' alarm is playing, a xeno can whack the computer to stop it.
 		if(dropship.playing_launch_announcement_alarm)
 			stop_playing_launch_announcement_alarm()

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -40786,7 +40786,8 @@
 	id = "Containment Cell 3";
 	dir = 2;
 	req_one_access = list(28,206,207);
-	locked = 1
+	locked = 1;
+	queen_pryable = 0
 	},
 /obj/structure/machinery/door/poddoor/almayer/biohazard/white{
 	dir = 4
@@ -43050,7 +43051,8 @@
 	id = "Containment Cell 2";
 	dir = 2;
 	req_one_access = list(28,206,207);
-	locked = 1
+	locked = 1;
+	queen_pryable = 0
 	},
 /obj/structure/machinery/door/poddoor/almayer/biohazard/white{
 	dir = 4

--- a/maps/map_files/USS_Almayer/USS_Almayer.dmm
+++ b/maps/map_files/USS_Almayer/USS_Almayer.dmm
@@ -40786,7 +40786,6 @@
 	id = "Containment Cell 3";
 	dir = 2;
 	req_one_access = list(28,206,207);
-	queen_pryable = 0;
 	locked = 1
 	},
 /obj/structure/machinery/door/poddoor/almayer/biohazard/white{
@@ -43051,7 +43050,6 @@
 	id = "Containment Cell 2";
 	dir = 2;
 	req_one_access = list(28,206,207);
-	queen_pryable = 0;
 	locked = 1
 	},
 /obj/structure/machinery/door/poddoor/almayer/biohazard/white{

--- a/maps/shuttles/ert_pmc_shuttle.dmm
+++ b/maps/shuttles/ert_pmc_shuttle.dmm
@@ -76,7 +76,7 @@
 	},
 /area/shuttle/ert)
 "q" = (
-/obj/structure/machinery/door/airlock/almayer/generic{
+/obj/structure/machinery/door/airlock/almayer/generic/shuttle{
 	dir = 2
 	},
 /turf/open/shuttle/dropship/light_grey_single_wide_left_to_right,
@@ -90,7 +90,7 @@
 /turf/open/shuttle/dropship/light_grey_single_wide_up_to_down,
 /area/shuttle/ert)
 "t" = (
-/obj/structure/machinery/door/airlock/almayer/generic,
+/obj/structure/machinery/door/airlock/almayer/generic/shuttle,
 /turf/open/shuttle/dropship/light_grey_single_wide_up_to_down,
 /area/shuttle/ert)
 "u" = (

--- a/maps/shuttles/ert_response_shuttle.dmm
+++ b/maps/shuttles/ert_response_shuttle.dmm
@@ -13,7 +13,7 @@
 /turf/template_noop,
 /area/shuttle/ert)
 "d" = (
-/obj/structure/machinery/door/airlock/almayer/generic{
+/obj/structure/machinery/door/airlock/almayer/generic/shuttle{
 	dir = 2
 	},
 /turf/open/shuttle/dropship/light_grey_single_wide_left_to_right,
@@ -76,7 +76,7 @@
 	},
 /area/shuttle/ert)
 "y" = (
-/obj/structure/machinery/door/airlock/almayer/generic,
+/obj/structure/machinery/door/airlock/almayer/generic/shuttle,
 /turf/open/shuttle/dropship/light_grey_single_wide_up_to_down,
 /area/shuttle/ert)
 "z" = (

--- a/maps/shuttles/ert_shuttle_big.dmm
+++ b/maps/shuttles/ert_shuttle_big.dmm
@@ -327,7 +327,7 @@
 /turf/open/floor/almayer/plate,
 /area/shuttle/ert)
 "uO" = (
-/obj/structure/machinery/door/airlock/multi_tile/almayer/generic2{
+/obj/structure/machinery/door/airlock/multi_tile/almayer/generic2/shuttle{
 	dir = 1;
 	id = "starboard_door"
 	},
@@ -684,7 +684,7 @@
 /turf/open/floor/almayer/plate,
 /area/shuttle/ert)
 "Ro" = (
-/obj/structure/machinery/door/airlock/multi_tile/almayer/generic2{
+/obj/structure/machinery/door/airlock/multi_tile/almayer/generic2/shuttle{
 	dir = 1;
 	id = "port_door"
 	},

--- a/maps/shuttles/ert_small_shuttle_north.dmm
+++ b/maps/shuttles/ert_small_shuttle_north.dmm
@@ -137,7 +137,7 @@
 /turf/open/floor/almayer/tcomms,
 /area/shuttle/ert)
 "F" = (
-/obj/structure/machinery/door/airlock/multi_tile/almayer/generic2{
+/obj/structure/machinery/door/airlock/multi_tile/almayer/generic2/shuttle{
 	dir = 1;
 	id = "port_door"
 	},
@@ -190,7 +190,7 @@
 /turf/open/floor/almayer/tcomms,
 /area/shuttle/ert)
 "W" = (
-/obj/structure/machinery/door/airlock/multi_tile/almayer/generic2{
+/obj/structure/machinery/door/airlock/multi_tile/almayer/generic2/shuttle{
 	dir = 1;
 	id = "starboard_door"
 	},

--- a/maps/shuttles/ert_twe_shuttle.dmm
+++ b/maps/shuttles/ert_twe_shuttle.dmm
@@ -96,7 +96,7 @@
 	},
 /area/shuttle/ert)
 "D" = (
-/obj/structure/machinery/door/airlock/almayer/generic,
+/obj/structure/machinery/door/airlock/almayer/generic/shuttle,
 /turf/open/shuttle/dropship/light_grey_single_wide_up_to_down,
 /area/shuttle/ert)
 "E" = (
@@ -133,7 +133,7 @@
 /turf/open/shuttle/dropship/light_grey_top_left,
 /area/shuttle/ert)
 "M" = (
-/obj/structure/machinery/door/airlock/almayer/generic{
+/obj/structure/machinery/door/airlock/almayer/generic/shuttle{
 	dir = 2
 	},
 /turf/open/shuttle/dropship/light_grey_single_wide_left_to_right,

--- a/maps/shuttles/ert_upp_shuttle.dmm
+++ b/maps/shuttles/ert_upp_shuttle.dmm
@@ -127,7 +127,7 @@
 /turf/template_noop,
 /area/shuttle/ert)
 "G" = (
-/obj/structure/machinery/door/airlock/almayer/generic,
+/obj/structure/machinery/door/airlock/almayer/generic/shuttle,
 /turf/open/shuttle/dropship/light_grey_single_wide_up_to_down,
 /area/shuttle/ert)
 "I" = (
@@ -186,7 +186,7 @@
 /turf/open/shuttle/dropship/medium_grey_single_wide_up_to_down,
 /area/shuttle/ert)
 "Y" = (
-/obj/structure/machinery/door/airlock/almayer/generic{
+/obj/structure/machinery/door/airlock/almayer/generic/shuttle{
 	dir = 2
 	},
 /turf/open/shuttle/dropship/light_grey_single_wide_left_to_right,


### PR DESCRIPTION

# About the pull request

Predaliens and Kings are now smarter, they can pry open locked dropships and containment doors. King can now also disable lifeboats along with the Predalien (who already could).

Predaliens and Kings can also lock the dropships but they are unable to start hijack themselves.

ERT Shuttles have proper reinforced airlocks now but they can be forced open by Queens, Predaliens and Kings and their console can also be disabled by the aforementioned castes.

**Queen is still the only one who can start hijack.**

# Explain why it's good for the game

Believe it or not but Predaliens were USED to be able to do this already, it was a niche undocumented feature that not many people knew. However at some point the code was refactored around hijack and dropships and their aforementioned consoles and the predalien lost the ability to do it anymore. I believe whoever did it forgot about the predalien there since they were the only other xeno who had the mechanic (is_intelligent, the proc that handled hijacking before. Now it only handles lifeboats, yes predalien can disable lifeboats RIGHT NOW) apart from the queen.

Well I've returned it back now in a working state. Technically this should have been a bug/oversight fix but i'll keep it as a balance change since its been so long and it was a very niche feature that almost nobody knew about.

As for ERT shuttles, I now made their airlocks much more reinforced, since they're supposed to act like dropship hatches (but we dont have unique hatches for shuttles), no longer you can manipulate them via wiring or welding nor slash them as a xeno but now Queens and Predaliens can force them open. They can also now disable the ERT shuttle entirely by interacting with the console. A good way to prevent people from delaying or fleeing now.

NOTE: disabling the shuttle does not cancel it from already spooling if someone managed to make it start flying before you disabled it, you should probably still leave while you can.

**edit: The new direction of the PR is to provide additional xenos who can pry open locked down dropships without allowing them to start hijack as that should be the Queen's authority.**

# Testing Photographs and Procedure
Made sure things work normally, predalien and king still cant hijack while queen can.

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
balance: Predaliens and Kings are now able to pry open locked dropships and containment airlocks.
balance: Predaliens and Kings are now able to lock the dropship but cannot start hijack on their own.
balance: King can now disable the lifeboats along with the Queen and Predalien.
balance: ERT Shuttles' airlocks are now reinforced but can be forced open by Queens/Predaliens/Kings and their consoles can also now be disabled by them.
/:cl:

