### PR TITLE
Fix welding goggles tint

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -135,6 +135,7 @@
 		user.glasses = null
 		user.update_inv_glasses()
 		user.update_glass_vision(src)
+		user.update_tint()
 	user.update_sight()
 	return ..()
 


### PR DESCRIPTION

# About the pull request

Fix #13062 

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this addresses a reported issue, you can include "Fixes #92345" to link the PR to the corresponding Issue number #92345.
For multiple issues you must include the "Fixes" keyword for each, e.g. "Fixes #92345, Fixes #92346, Fixes #92347". You cannot use multiple issue numbers with only one keyword.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Bug bad, fix good
# Testing Photographs and Procedure
<details>
<summary>Video inside</summary>


https://github.com/user-attachments/assets/cd1271dc-c9d1-4030-af93-c6d4a5469625


</details>


# Changelog
:cl:labeo0
fix: welding goggles tint does not stay when they are taken off
/:cl:
