### PR TITLE
Body Examine Text

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -108,15 +108,15 @@
 		var/age_description
 		switch(clamp(age, AGE_MIN, AGE_MAX))
 			if(AGE_MIN to 25)
-				age_description = "very young"
+				age_description = "a young adult"
 			if(26 to 35)
-				age_description = "young"
+				age_description = "an adult"
 			if(36 to 55)
-				age_description = "middle-aged"
+				age_description = "a middle-aged adult"
 			if(56 to 75)
-				age_description = "older"
+				age_description = "an older adult"
 			if(76 to AGE_MAX)
-				age_description = "elderly"
+				age_description = "an elderly adult"
 
 		var/body_size_description
 		switch(body_size)
@@ -137,9 +137,9 @@
 				body_type_description = "muscular"
 
 		if(!skipface && !skipjumpsuit && body_size_description && body_type_description)
-			msg += "[t_He] [t_seem] [SPAN_BOLD(age_description)], with a build that appears [SPAN_BOLD(body_size_description)] and [SPAN_BOLD(body_type_description)].\n"
+			msg += "[t_He] [t_seem] to be [SPAN_BOLD(age_description)], with a build that appears [SPAN_BOLD(body_size_description)] and [SPAN_BOLD(body_type_description)].\n"
 		else if(!skipface)
-			msg += "[t_He] [t_seem] [SPAN_BOLD(age_description)].\n"
+			msg += "[t_He] [t_seem] to be [SPAN_BOLD(age_description)].\n"
 		else if(!skipjumpsuit && body_size_description && body_type_description)
 			msg += "[capitalize(t_his)] build appears [SPAN_BOLD(body_size_description)] and [SPAN_BOLD(body_type_description)].\n"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -136,11 +136,12 @@
 			if(BODY_TYPE_RIPPED)
 				body_type_description = "muscular"
 
-		if(!skipface && !skipjumpsuit && body_size_description && body_type_description)
+		var/skipbody = wear_suit || (w_uniform && (w_uniform.undershirt || !(w_uniform.flags_jumpsuit & UNIFORM_JACKET_REMOVED)))
+		if(!skipface && !skipbody && body_size_description && body_type_description)
 			msg += "[t_He] [t_seem] to be [SPAN_BOLD(age_description)], with a build that appears [SPAN_BOLD(body_size_description)] and [SPAN_BOLD(body_type_description)].\n"
 		else if(!skipface)
 			msg += "[t_He] [t_seem] to be [SPAN_BOLD(age_description)].\n"
-		else if(!skipjumpsuit && body_size_description && body_type_description)
+		else if(!skipbody && body_size_description && body_type_description)
 			msg += "[capitalize(t_his)] build appears [SPAN_BOLD(body_size_description)] and [SPAN_BOLD(body_type_description)].\n"
 
 	//uniform

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -104,6 +104,45 @@
 		msg += "<EM>[rank_display] </EM>"
 	msg += "<EM>[src]</EM>!\n"
 
+	if(ishuman_strict(src))
+		var/age_description
+		switch(clamp(age, AGE_MIN, AGE_MAX))
+			if(AGE_MIN to 25)
+				age_description = "very young"
+			if(26 to 35)
+				age_description = "young"
+			if(36 to 55)
+				age_description = "middle-aged"
+			if(56 to 75)
+				age_description = "older"
+			if(76 to AGE_MAX)
+				age_description = "elderly"
+
+		var/body_size_description
+		switch(body_size)
+			if(BODY_SIZE_THIN)
+				body_size_description = "thin"
+			if(BODY_SIZE_AVERAGE)
+				body_size_description = "average-sized"
+			if(BODY_SIZE_LARGE)
+				body_size_description = "large"
+
+		var/body_type_description
+		switch(body_type)
+			if(BODY_TYPE_NOMUSCLE)
+				body_type_description = "unmuscular"
+			if(BODY_TYPE_LEAN)
+				body_type_description = "lean"
+			if(BODY_TYPE_RIPPED)
+				body_type_description = "muscular"
+
+		if(!skipface && !skipjumpsuit && body_size_description && body_type_description)
+			msg += "[t_He] [t_seem] [SPAN_BOLD(age_description)], with a build that appears [SPAN_BOLD(body_size_description)] and [SPAN_BOLD(body_type_description)].\n"
+		else if(!skipface)
+			msg += "[t_He] [t_seem] [SPAN_BOLD(age_description)].\n"
+		else if(!skipjumpsuit && body_size_description && body_type_description)
+			msg += "[capitalize(t_his)] build appears [SPAN_BOLD(body_size_description)] and [SPAN_BOLD(body_type_description)].\n"
+
 	//uniform
 	if(w_uniform && !skipjumpsuit)
 		msg += "[t_He] [t_is] [w_uniform.get_examine_location(src, user, WEAR_BODY, t_He, t_his, t_him, t_has, t_is)].\n"


### PR DESCRIPTION

# About the pull request

Your character's body type, as well as a rough estimation of their age, now shows up when someone examines you.


<img width="770" height="55" alt="grafik" src="https://github.com/user-attachments/assets/25cd97ba-d496-4bcd-85f3-435c0f9ecd23" />
<img width="697" height="53" alt="grafik" src="https://github.com/user-attachments/assets/482dd4bd-d1c0-4c81-b76e-c9f4f1b84edf" />
<img width="825" height="53" alt="grafik" src="https://github.com/user-attachments/assets/02945490-9cfe-4959-a669-0a8eb6beb3c5" />
<img width="826" height="47" alt="grafik" src="https://github.com/user-attachments/assets/17f26e49-bdec-4b7c-ab8e-bdfdb56a6e48" />
<img width="771" height="59" alt="grafik" src="https://github.com/user-attachments/assets/3d9b49f3-824f-4453-a9d1-a0eb02f34999" />

Age is estimated from the character's face, so if their face is obstructed, you can't tell how old they are.


<img width="859" height="353" alt="grafik" src="https://github.com/user-attachments/assets/6a760434-98ca-4b3d-82a3-0302181e19cd" />

If your body is fully covered, but your face is visible, then people will only be able to tell your age (added this as a fallback, but from my testing this is only possible when wearing an EOD suit without a hood)
25 and below: a young adult
26-35: an adult
36-55: a middle-aged adult
56-75: an older adult
76 and above: an elderly adult
# Explain why it's good for the game

Exposes a couple of character details that aren't communicated. Useful for RP


# Changelog

:cl:
qol: Examining a character now shows their body type and a rough estimate of their age. 
/:cl:

