### PR TITLE
Lets Xenos track the King in the queen/leaders compass HUD thing

### DIFF
--- a/code/__DEFINES/mob_hud.dm
+++ b/code/__DEFINES/mob_hud.dm
@@ -94,6 +94,7 @@
 
 //for tracking the queen/hivecore on xeno locator huds
 #define TRACKER_QUEEN "Queen"
+#define TRACKER_KING "King"
 #define TRACKER_HIVE "Hive Core"
 #define TRACKER_LEADER "Leader"
 #define TRACKER_TUNNEL "Tunnel"

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -544,6 +544,9 @@
 			// Don't need weakrefs to this or the hive core, since there's only one possible target.
 			options["Queen"] = list(null, TRACKER_QUEEN)
 
+		if(user.hive.living_xeno_king)
+			options["King"] = list(user.hive.living_xeno_king, TRACKER_KING)
+
 		if(user.hive.hive_location)
 			options["Hive Core"] = list(null, TRACKER_HIVE)
 
@@ -567,7 +570,7 @@
 	if(HAS_TRAIT(user, TRAIT_ABILITY_BURROWED) || user.is_mob_incapacitated() || user.buckled)
 		return FALSE
 	//Xenos should not be able to track tunnels. Queen's weakref is equal to null if selected.
-	if(tracker_type != TRACKER_LEADER || !tracking_ref)
+	if((tracker_type != TRACKER_LEADER && tracker_type  != TRACKER_KING) || !tracking_ref)
 		user.overwatch(user.hive.living_xeno_queen)
 		return
 	user.overwatch(tracking_ref.resolve())

--- a/code/modules/mob/living/carbon/xenomorph/castes/King.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/King.dm
@@ -135,6 +135,7 @@
 
 /mob/living/carbon/xenomorph/king/death(cause, gibbed)
 	. = ..()
+	hive.living_xeno_king = null
 	if(hive)
 		hive.setup_banned_allies()
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/King.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/King.dm
@@ -77,7 +77,7 @@
 
 /mob/living/carbon/xenomorph/king/Destroy()
 	UnregisterSignal(src, COMSIG_MOVABLE_PRE_MOVE)
-
+	hive.living_xeno_king = null
 	return ..()
 
 /mob/living/carbon/xenomorph/king/Initialize()
@@ -134,7 +134,6 @@
 	icon = 'icons/mob/xenos/castes/tier_4/rogueking.dmi'
 
 /mob/living/carbon/xenomorph/king/death(cause, gibbed)
-	hive.living_xeno_king = null
 	. = ..()
 	if(hive)
 		hive.setup_banned_allies()

--- a/code/modules/mob/living/carbon/xenomorph/castes/King.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/King.dm
@@ -89,6 +89,7 @@
 		hive.banned_allies = list("All")
 		if(hive.break_all_alliances())
 			xeno_message(SPAN_XENOANNOUNCE("With the arrival of the King, all alliances have been broken."), 3, hivenumber)
+		hive.living_xeno_king = src
 
 /mob/living/carbon/xenomorph/king/initialize_pass_flags(datum/pass_flags_container/pass_flags)
 	. = ..()
@@ -133,6 +134,7 @@
 	icon = 'icons/mob/xenos/castes/tier_4/rogueking.dmi'
 
 /mob/living/carbon/xenomorph/king/death(cause, gibbed)
+	hive.living_xeno_king = null
 	. = ..()
 	if(hive)
 		hive.setup_banned_allies()

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -9,6 +9,7 @@
 
 	var/hivenumber = XENO_HIVE_NORMAL
 	var/mob/living/carbon/xenomorph/queen/living_xeno_queen
+	var/mob/living/carbon/xenomorph/king/living_xeno_king
 	var/egg_planting_range = 15
 
 	/// Toggles for the hive that are reset on queen death unless hive_flags_locked

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -411,6 +411,8 @@ Make sure their actual health updates immediately.*/
 	switch(locator.tracker_type)
 		if(TRACKER_QUEEN)
 			tracking_atom = hive.living_xeno_queen
+		if(TRACKER_KING)
+			tracking_atom = hive.living_xeno_king
 		if(TRACKER_HIVE)
 			tracking_atom = hive.hive_location
 		if(TRACKER_LEADER)


### PR DESCRIPTION

# About the pull request

When the hive gets a king, the king will now show up in the options for tracking in the HUD compass alongside the existing options of queen, leaders, hive core, and tunnels

# Explain why it's good for the game

Its a bit of functionality thats been lacking for xenos since the addition of the king. Its on par with the Queen in leadership surely, bizarre its not in the options for the HUD compass

# Changelog
:cl: Kugamo
add:  xenos can now track their KING in their HUD compass
/:cl:
