### PR TITLE
Add UNIT_TESTS variants for VSC + Fix build target changing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -60,6 +60,20 @@
         {
             "type": "byond",
             "request": "launch",
+            "name": "Launch DreamSeeker (unit testing)",
+            "preLaunchTask": "Build All (unit testing)",
+            "dmb": "${workspaceFolder}/${command:CurrentDMB}"
+        },
+        {
+            "type": "byond",
+            "request": "launch",
+            "name": "Launch DreamSeeker (runtime map + unit testing)",
+            "preLaunchTask": "Build All (runtime map + unit testing)",
+            "dmb": "${workspaceFolder}/${command:CurrentDMB}"
+        },
+        {
+            "type": "byond",
+            "request": "launch",
             "name": "Launch DreamDaemon",
             "preLaunchTask": "Build All",
             "dmb": "${workspaceFolder}/${command:CurrentDMB}",
@@ -119,6 +133,22 @@
             "request": "launch",
             "name": "Launch DreamDaemon (runtime map + quickstart + testing)",
             "preLaunchTask": "Build All (runtime map + quickstart + testing)",
+            "dmb": "${workspaceFolder}/${command:CurrentDMB}",
+            "dreamDaemon": true
+        },
+        {
+            "type": "byond",
+            "request": "launch",
+            "name": "Launch DreamDaemon (unit testing)",
+            "preLaunchTask": "Build All (unit testing)",
+            "dmb": "${workspaceFolder}/${command:CurrentDMB}",
+            "dreamDaemon": true
+        },
+        {
+            "type": "byond",
+            "request": "launch",
+            "name": "Launch DreamDaemon (runtime map + unit testing)",
+            "preLaunchTask": "Build All (runtime map + unit testing)",
             "dmb": "${workspaceFolder}/${command:CurrentDMB}",
             "dreamDaemon": true
         }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -193,6 +193,54 @@
             "label": "Build All (runtime map + quickstart + testing)"
         },
         {
+            "type": "process",
+            "command": "tools/build/build.sh",
+            "windows": {
+                "command": ".\\tools\\build\\build.bat",
+                "args": ["-DUNIT_TESTS"]
+            },
+            "options": {
+                "env": {
+                    "DM_EXE": "${config:dreammaker.byondPath}"
+                }
+            },
+            "problemMatcher": [
+                "$dreammaker",
+                "$tsc",
+                "$eslint-stylish"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "dependsOn": "dm: reparse",
+            "label": "Build All (unit testing)"
+        },
+        {
+            "type": "process",
+            "command": "tools/build/build.sh",
+            "windows": {
+                "command": ".\\tools\\build\\build.bat",
+                "args": ["-DRUNTIME_MAP", "-DUNIT_TESTS"]
+            },
+            "options": {
+                "env": {
+                    "DM_EXE": "${config:dreammaker.byondPath}"
+                }
+            },
+            "problemMatcher": [
+                "$dreammaker",
+                "$tsc",
+                "$eslint-stylish"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "dependsOn": "dm: reparse",
+            "label": "Build All (runtime map + unit testing)"
+        },
+        {
             "type": "dreammaker",
             "dme": "colonialmarines.dme",
             "problemMatcher": [

--- a/tools/build/build.ts
+++ b/tools/build/build.ts
@@ -32,6 +32,21 @@ const dependencies: Record<string, string> = await Bun.file('dependencies.sh')
     throw new Juke.ExitCode(1);
   });
 
+const define_params_file = 'data/last_define_params.json'
+
+// Have compilation defines changed since last build?
+async function defineParametersChanged(defines: string[]): Promise<boolean> {
+  const defines_string = JSON.stringify(defines);
+  const params_file = Bun.file(define_params_file);
+  if(!await params_file.exists()) {
+    await params_file.write(defines_string);
+    return true;
+  }
+  const last_params = await params_file.text();
+  await params_file.write(defines_string);
+  return last_params !== defines_string;
+}
+
 export const DefineParameter = new Juke.Parameter({
   type: "string[]",
   alias: "D",
@@ -90,9 +105,10 @@ export const DmTarget = new Juke.Target({
     `${DME_NAME}.dme`,
     NamedVersionFile,
   ],
-  outputs: ({ get }) => {
-    if (get(DmVersionParameter)) {
-      return []; // Always rebuild when dm version is provided
+  outputs: async ({ get }) => {
+    if (get(DmVersionParameter) || await defineParametersChanged(get(DefineParameter))) {
+      // Always rebuild when a dm version is provided or CLI defines have changed from last run
+      return [];
     }
     return [`${DME_NAME}.dmb`, `${DME_NAME}.rsc`];
   },


### PR DESCRIPTION
# About the pull request

This PR is a follow up to #10773 doing a couple things:
- Adds 4 new variants for UNIT_TESTS defines (current map | runtime map) + (dreamseeker | dreamdaemon)
- Ports https://github.com/tgstation/tgstation/pull/97273 so that now changing the launch option will dirty the DM build in juke so the defines will actually apply.

# Explain why it's good for the game

More debugging QoL

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="615" height="1075" alt="image" src="https://github.com/user-attachments/assets/f6be26e3-fae6-4f7c-a8c9-c702714bf379" />

</details>


# Changelog
:cl: Drathek
server: Juke build now checks last_define_params for whether to rebuild dm
/:cl:
