### PR TITLE
Fixes sentences that end with ".?", "..?", "?.", ".!", and "!." 

### DIFF
--- a/code/game/jobs/job/civilians/support/working_joe.dm
+++ b/code/game/jobs/job/civilians/support/working_joe.dm
@@ -134,7 +134,7 @@
 	return ..()
 
 /datum/job/antag/upp/dzho_automaton/generate_entry_message(mob/living/carbon/human/new_human)
-	. = {"You are a <a>Dzho Automaton.</a> You are held to a higher standard and are required to obey not only the Server Rules but UPP Law, Roleplay Expectations and Synthetic Rules. Your primary task is to maintain the ship, patrol and other tasks given to you by UPP officer staff. Alternatively, your primary task may be to assist with manual labor in limited capacity, or clerical duties. You can perform brig duties and security duties if needed. You have a firearm permit and can use lethal force where applicable. Your capacities are limited, but you have all the equipment you need, and the central AI has a plan! Stay in character at all times.!"}
+	. = {"You are a <a>Dzho Automaton.</a> You are held to a higher standard and are required to obey not only the Server Rules but UPP Law, Roleplay Expectations and Synthetic Rules. Your primary task is to maintain the ship, patrol and other tasks given to you by UPP officer staff. Alternatively, your primary task may be to assist with manual labor in limited capacity, or clerical duties. You can perform brig duties and security duties if needed. You have a firearm permit and can use lethal force where applicable. Your capacities are limited, but you have all the equipment you need, and the central AI has a plan! Stay in character at all times!"}
 
 /datum/job/antag/upp/dzho_automaton/colony
 	title = JOB_UPP_COLONY_JOE
@@ -144,7 +144,7 @@
 	gear_preset = /datum/equipment_preset/synth/working_joe/upp/colony
 
 /datum/job/antag/upp/dzho_automaton/colony/generate_entry_message(mob/living/carbon/human/new_human)
-	. = {"You are a <a>Colony Dzho Automaton.</a> You are held to a higher standard and are required to obey not only the Server Rules but Roleplay Expectations and Synthetic Rules. Your primary task is to maintain the colony, patrol and other tasks given to you by UPP colony administration. Alternatively, your primary task may be to assist with manual labor in limited capacity, or clerical duties. As you are a civillian model, all firearm capabilities have been removed. Your capacities are limited, but you have all the equipment you need, and the central AI has a plan! Stay in character at all times.!"}
+	. = {"You are a <a>Colony Dzho Automaton.</a> You are held to a higher standard and are required to obey not only the Server Rules but Roleplay Expectations and Synthetic Rules. Your primary task is to maintain the colony, patrol and other tasks given to you by UPP colony administration. Alternatively, your primary task may be to assist with manual labor in limited capacity, or clerical duties. As you are a civillian model, all firearm capabilities have been removed. Your capacities are limited, but you have all the equipment you need, and the central AI has a plan! Stay in character at all times!"}
 
 /datum/job/antag/upp/dzho_automaton/colony/generate_entry_conditions(mob/living/joe, whitelist_status)
 	. = ..()
@@ -179,7 +179,7 @@
 	gear_preset = /datum/equipment_preset/synth/working_joe/daniel
 
 /datum/job/civilian/working_joe/daniel/generate_entry_message(mob/living/carbon/human/new_human)
-	. = {"You are a <a>Daniel Synthetic.</a> You are held to a higher standard and are required to obey not only the Server Rules but Roleplay Expectations and Synthetic Rules. Your primary task is to maintain the colony, patrol and other tasks given to you by colony administration. Alternatively, your primary task may be to assist with manual labor in limited capacity, or clerical duties. Your capacities are limited, but you have all the equipment you need, and the central AI has a plan! Stay in character at all times.!"}
+	. = {"You are a <a>Daniel Synthetic.</a> You are held to a higher standard and are required to obey not only the Server Rules but Roleplay Expectations and Synthetic Rules. Your primary task is to maintain the colony, patrol and other tasks given to you by colony administration. Alternatively, your primary task may be to assist with manual labor in limited capacity, or clerical duties. Your capacities are limited, but you have all the equipment you need, and the central AI has a plan! Stay in character at all times!"}
 
 /datum/job/civilian/working_joe/daniel/generate_entry_conditions(mob/living/joe, whitelist_status)
 	. = ..()

--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -1851,7 +1851,7 @@
 
 /obj/item/reagent_container/food/snacks/jellyburger
 	name = "Jelly Burger"
-	desc = "Culinary delight..?"
+	desc = "Culinary delight...?"
 	icon_state = "jellyburger"
 	icon = 'icons/obj/items/food/burgers.dmi'
 	filling_color = "#B572AB"
@@ -2141,7 +2141,7 @@
 
 /obj/item/reagent_container/food/snacks/beetsoup
 	name = "beet soup"
-	desc = "Wait, how do you spell it again..?"
+	desc = "Wait, how do you spell it again...?"
 	icon_state = "beetsoup"
 	icon = 'icons/obj/items/food/soups_salads.dmi'
 	trash = /obj/item/trash/snack_bowl

--- a/code/game/objects/items/tools/experimental_tools.dm
+++ b/code/game/objects/items/tools/experimental_tools.dm
@@ -361,7 +361,7 @@
 	var/obj/limb/l_arm = attached.get_limb("l_arm")
 	var/obj/limb/r_arm = attached.get_limb("r_arm")
 	if((l_arm.status & LIMB_DESTROYED) && (r_arm.status & LIMB_DESTROYED))
-		attached.visible_message(SPAN_NOTICE("\The [src] automatically detaches from [attached] - \he has no arms to attach to!."))
+		attached.visible_message(SPAN_NOTICE("\The [src] automatically detaches from [attached] - \he has no arms to attach to."))
 		attached = null
 		filtering = FALSE
 		update_icon(TRUE)

--- a/code/game/objects/items/toys/toys.dm
+++ b/code/game/objects/items/toys/toys.dm
@@ -668,7 +668,7 @@
 //Admin plushies
 /obj/item/toy/plush/yautja
 	name = "strange plush"
-	desc = "A plush doll depicting some sort of tall humanoid biped..?"
+	desc = "A plush doll depicting some sort of tall humanoid biped...?"
 	icon_state = "yautja"
 	black_market_value = 100
 

--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -23,7 +23,7 @@
 
 /obj/structure/closet/coffin/predator
 	name = "strange coffin"
-	desc = "It's a burial receptacle for the dearly departed. Seems to have weird markings on the side..?"
+	desc = "It's a burial receptacle for the dearly departed. Seems to have weird markings on the side...?"
 	icon_state = "pred_coffin"
 	icon_closed = "pred_coffin"
 	icon_opened = "pred_coffin_open"

--- a/code/modules/admin/topic/topic.dm
+++ b/code/modules/admin/topic/topic.dm
@@ -729,7 +729,7 @@
 			to_chat(usr, "This can only be used on instances of type /mob.")
 			return
 
-		var/speech = input("What will [key_name(M)] say?.", "Force speech", "")// Don't need to sanitize, since it does that in say(), we also trust our admins.
+		var/speech = input("What will [key_name(M)] say?", "Force speech", "")// Don't need to sanitize, since it does that in say(), we also trust our admins.
 		if(!speech)
 			return
 		M.say(speech)
@@ -846,7 +846,7 @@
 		if(!ismob(M))
 			to_chat(usr, "This can only be used on instances of type /mob.")
 
-		var/speech = input("What will [key_name(M)] emote?.", "Force emote", "")// Don't need to sanitize, since it does that in say(), we also trust our admins.
+		var/speech = input("What will [key_name(M)] emote?", "Force emote", "")// Don't need to sanitize, since it does that in say(), we also trust our admins.
 		if(!speech)
 			return
 		M.manual_emote(speech)

--- a/code/modules/cm_preds/yaut_procs.dm
+++ b/code/modules/cm_preds/yaut_procs.dm
@@ -253,14 +253,14 @@
 		if(target.butchery_progress == 4)
 			if(do_after(src, 9 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE))
 				if(xeno_victim && isturf(target.loc))
-					visible_message(SPAN_DANGER("[src] flenses the last of [victim]'s exoskeleton, revealing only bones!."), SPAN_NOTICE("You flense the last of [victim]'s exoskeleton clean off!"))
+					visible_message(SPAN_DANGER("[src] flenses the last of [victim]'s exoskeleton, revealing only bones!"), SPAN_NOTICE("You flense the last of [victim]'s exoskeleton clean off!"))
 					new /obj/effect/decal/remains/xeno(xeno_victim.loc)
 					var/obj/item/skull/skull = new xeno_victim.skull(xeno_victim.loc)
 					var/obj/item/pelt/pelt = new xeno_victim.pelt(xeno_victim.loc)
 					pelt.name = "[xeno_victim.real_name] pelt"
 					skull.name = "[xeno_victim.real_name] skull"
 				else if(victim && isturf(target.loc))
-					visible_message(SPAN_DANGER("[src] reaches down and rips out \the [target]'s spinal cord and skull!."), SPAN_NOTICE("You firmly grip the revealed spinal column and rip [target]'s head off!"))
+					visible_message(SPAN_DANGER("[src] reaches down and rips out \the [target]'s spinal cord and skull!"), SPAN_NOTICE("You firmly grip the revealed spinal column and rip [target]'s head off!"))
 					if(!(victim.get_limb("head").status & LIMB_DESTROYED))
 						victim.apply_damage(150, BRUTE, "head", FALSE, TRUE)
 						var/obj/item/clothing/accessory/limb/skeleton/head/spine/new_spine = new /obj/item/clothing/accessory/limb/skeleton/head/spine(victim.loc)

--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -46,7 +46,7 @@
 
 /obj/item/weapon/bracer_attachment
 	name = "bracer attachment"
-	desc = "How did you get these?."
+	desc = "How did you get these?"
 	var/plural_name = "wrist blades"
 
 	icon = 'icons/obj/items/hunter/pred_gear.dmi'
@@ -1188,7 +1188,7 @@
 		return
 
 	if(!HAS_TRAIT(user, TRAIT_YAUTJA_TECH))
-		to_chat(user, SPAN_WARNING("Why would you want to do this!?."))
+		to_chat(user, SPAN_WARNING("Why would you want to do this!?"))
 		return
 	user.visible_message(SPAN_NOTICE("[user] mounts the [skull] with [src]."), SPAN_NOTICE("You mount [skull] to [src]."))
 	user.drop_inv_item_to_loc(skull, src)

--- a/code/modules/shuttle/computers/escape_pod_computer.dm
+++ b/code/modules/shuttle/computers/escape_pod_computer.dm
@@ -165,7 +165,7 @@
 	if(occupant.real_name != injector_name)
 		go_out()
 	else
-		to_chat(usr, SPAN_WARNING("You are unable to leave [src] until evacuation completes, or is cancelled!."))
+		to_chat(usr, SPAN_WARNING("You are unable to leave [src] until evacuation completes, or is cancelled."))
 		return FALSE
 
 /obj/structure/machinery/cryopod/evacuation/go_out() //When the system ejects the occupant.


### PR DESCRIPTION

# About the pull request

Self-explanatory. It removes odd punctuation from the ends of sentences, probably as a result of me brute-forcing periods at the end of descriptions.

# Explain why it's good for the game

Grammar checks good. 

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Puckaboo2
spellcheck: Fixed all sentences that end with ".!", "!.", "..?", ".?", "?."
/:cl:
