### PR TITLE
Fixes PMC Synthvivor lacking a shortwave radio

### DIFF
--- a/code/modules/gear_presets/survivors/solaris/crashlanding-offices_insert_bigred.dm
+++ b/code/modules/gear_presets/survivors/solaris/crashlanding-offices_insert_bigred.dm
@@ -300,7 +300,7 @@
 
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/pmc/leader(new_human), WEAR_HEAD)
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/distress/pmc/command/hvh(new_human), WEAR_L_EAR)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/sunglasses(new_human), WEAR_EYES)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/sunglasses/big/new_bimex/black(new_human), WEAR_EYES)
 
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/veteran/pmc(new_human), WEAR_HANDS)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/veteran/pmc/knife(new_human), WEAR_FEET)
@@ -312,6 +312,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/device/defibrillator/upgraded(new_human), WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/tool/crew_monitor(new_human), WEAR_IN_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/device/defibrillator/synthetic(new_human), WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio(new_human), WEAR_IN_BACK)
 
 	new_human.equip_to_slot_or_del(new /obj/item/storage/belt/medical/lifesaver/wy/partial(new_human), WEAR_WAIST)
 


### PR DESCRIPTION

# About the pull request

Adds a shortwave radio inside the PMC Synthetic survivor's backpack.

Their sunglasses have been replaced with the new bimex tactical shades for better PMC LARPing (they didnt exist before when the gear preset was initially made so a good time to do it now)

# Explain why it's good for the game

Survivors should always start with a shortwave radio inside their inventory.


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
fix: PMC Synthetic survivors now start with a shortwave radio inside their backpack.
/:cl:

