### PR TITLE
xeno fire resistance buff cost 1 -> 2

### DIFF
--- a/code/modules/cm_aliens/hivebuffs/hivebuff.dm
+++ b/code/modules/cm_aliens/hivebuffs/hivebuff.dm
@@ -464,6 +464,7 @@
 	name = "Boon of Fire Resistance"
 	desc = "Makes all xenomorphs immune to fire for 5 minutes."
 	tier = HIVEBUFF_TIER_MINOR
+	cost = 2 // Needs both pylons active to keep 100% uptime.
 
 	engage_flavourmessage = "The Queen has imbued us with flame-resistant chitin."
 	duration = 5 MINUTES


### PR DESCRIPTION

# About the pull request

this pr increases the cost of fire resistance boon from 1 to 2 resin

# Explain why it's good for the game

the fire resistance boon was buffed to confer total fire immunity as opposed to before when it was only immunity to being *set on fire* and not the contact damage, which drastically increased its utility, with the cost remaining the same. By bumping the cost from 1 to 2 it's still cheap and xenos can easily afford it to suit their needs; but they can't keep it up forever with just one pylon active, they'll have to have periods of vulnerability in between.



# Changelog
:cl:
balance: fire resistance boon cost increased from 1 to 2.
/:cl:
