### PR TITLE
boons need on ovi queen

### DIFF
--- a/code/modules/cm_aliens/hivebuffs/hivebuff.dm
+++ b/code/modules/cm_aliens/hivebuffs/hivebuff.dm
@@ -71,6 +71,8 @@
 
 	/// _on_cease timer id
 	var/cease_timer_id
+	/// can you buy and use this buff off ovi
+	var/works_oviless = FALSE
 
 /datum/hivebuff/New(datum/hive_status/xenohive)
 	. = ..()
@@ -382,6 +384,7 @@
 	cost = 2
 	number_of_required_pylons = 2
 	radial_icon = "health_m"
+	works_oviless = TRUE
 
 /datum/hivebuff/evo_buff/major/on_engage(obj/effect/alien/resin/special/pylon/purchased_pylon)
 	hive.allow_no_queen_evo = TRUE

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -414,6 +414,10 @@
 			if(initial(buff.tier) == HIVEBUFF_TIER_MAJOR)
 				major_available = TRUE
 
+	if(!length(buffs))
+		to_chat(xeno, SPAN_XENONOTICE("No boons are available to us!"))
+		return
+
 	var/selection
 	var/list/radial_images_tiers = list(HIVEBUFF_TIER_MINOR = image('icons/ui_icons/hivebuff_radial.dmi', "minor"), HIVEBUFF_TIER_MAJOR = image('icons/ui_icons/hivebuff_radial.dmi', "major"))
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -414,14 +414,6 @@
 			if(initial(buff.tier) == HIVEBUFF_TIER_MAJOR)
 				major_available = TRUE
 
-	if(!xeno.ovipositor)
-		to_chat(xeno, SPAN_XENONOTICE("You need to be on oviposition to purchase boons!"))
-		return
-
-	if(!length(buffs))
-		to_chat(xeno, SPAN_XENONOTICE("No boons are available to us!"))
-		return
-
 	var/selection
 	var/list/radial_images_tiers = list(HIVEBUFF_TIER_MINOR = image('icons/ui_icons/hivebuff_radial.dmi', "minor"), HIVEBUFF_TIER_MAJOR = image('icons/ui_icons/hivebuff_radial.dmi', "major"))
 
@@ -448,13 +440,16 @@
 	if(!selection)
 		return FALSE
 
-	if(!xeno.ovipositor) //so you do not go off ovi with the radial being open or something
-		to_chat(xeno, SPAN_XENONOTICE("You need to be on oviposition to purchase boons!"))
-		return
+
 
 	if(!buffs[selection])
 		to_chat(xeno, "This selection is impossible!")
 		return FALSE
+
+	var/datum/hivebuff/hivebuff = buffs[selection]
+	if(!xeno.ovipositor && !hivebuff.works_oviless) //so you do not go off ovi with the radial being open or something
+		to_chat(xeno, SPAN_XENONOTICE("You need to be on oviposition to purchase boons!"))
+		return
 
 	if(buffs[selection].must_select_pylon)
 		var/list/pylon_to_area_dictionary = list()

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_powers.dm
@@ -414,6 +414,10 @@
 			if(initial(buff.tier) == HIVEBUFF_TIER_MAJOR)
 				major_available = TRUE
 
+	if(!xeno.ovipositor)
+		to_chat(xeno, SPAN_XENONOTICE("You need to be on oviposition to purchase boons!"))
+		return
+
 	if(!length(buffs))
 		to_chat(xeno, SPAN_XENONOTICE("No boons are available to us!"))
 		return
@@ -443,6 +447,10 @@
 
 	if(!selection)
 		return FALSE
+
+	if(!xeno.ovipositor) //so you do not go off ovi with the radial being open or something
+		to_chat(xeno, SPAN_XENONOTICE("You need to be on oviposition to purchase boons!"))
+		return
 
 	if(!buffs[selection])
 		to_chat(xeno, "This selection is impossible!")

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -886,6 +886,9 @@
 	if(!instant_dismount)
 		xeno_message(SPAN_XENOANNOUNCE("The Queen has shed her ovipositor, evolution progress paused."), 3, hivenumber)
 
+	for(var/datum/hivebuff/buff in hive.active_hivebuffs)
+		buff._on_cease()
+
 	// Close tacmap drawing tools if open, and reopen the regular minimap
 	var/datum/component/tacmap/tacmap_component = GetComponent(/datum/component/tacmap)
 	var/had_tacmap_open = FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -887,7 +887,8 @@
 		xeno_message(SPAN_XENOANNOUNCE("The Queen has shed her ovipositor, evolution progress paused."), 3, hivenumber)
 
 	for(var/datum/hivebuff/buff in hive.active_hivebuffs)
-		buff._on_cease()
+		if(!buff.works_oviless)
+			buff._on_cease()
 
 	// Close tacmap drawing tools if open, and reopen the regular minimap
 	var/datum/component/tacmap/tacmap_component = GetComponent(/datum/component/tacmap)


### PR DESCRIPTION

# About the pull request

Queen needs to be on ovi in order to pourchase buffs, if queen leaves ovi any acitivate buffs get deactivated (same as on hijack). King keep growing with queen off ovi. Major evo boon can both be bought and works off ovi

# Explain why it's good for the game

More incentive for queen to be on ovi in lategame, after queen leave ovi there is little reason for her to go back until xenos have won. 
!Google suggested this change!


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: queen can purchase boons only on oviposition
balance: when queen leaves oviposition all boons get canceled instantly (same as on hijack)
balance: major evo boon works without oviposition
balance: king needs to be pourchased on oviposition but grows without one
/:cl:
