### PR TITLE
Fixes perma blur

### DIFF
--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -8,6 +8,9 @@
 
 	..()
 
+	// Eye blur can wear off while the client is outside the body which permanently leaves stale HUD effects
+	update_eye_blur()
+
 	GLOB.living_player_list |= src
 
 	if(LAZYLEN(pipes_shown)) //ventcrawling, need to reapply pipe vision


### PR DESCRIPTION

# About the pull request

Fixes perma-blur applying to people who re-enter their body late after being revived by updating their eye blur.

# Explain why it's good for the game

Bug fix


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Tested on localhost

</details>


# Changelog
:cl:
fix: Fixes eye-blur becoming permanent if you re-entered your body late after being revived
/:cl:
