### PR TITLE
Flavor: VP78 chambered in .45 ACP

### DIFF
--- a/code/datums/ammo/bullet/pistol.dm
+++ b/code/datums/ammo/bullet/pistol.dm
@@ -258,15 +258,15 @@
 		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_incendiary)
 	))
 
-/datum/ammo/bullet/pistol/squash/heap
+/datum/ammo/bullet/pistol/acp45/heap
 	name = "high-explosive armor-piercing .45 ACP bullet"
 
 	headshot_state = HEADSHOT_OVERLAY_HEAVY
 	damage = 50
 	penetration = ARMOR_PENETRATION_TIER_10
 
-/datum/ammo/bullet/pistol/squash/rubber
-	name = "rubber squash-head .45 ACP bullet"
+/datum/ammo/bullet/pistol/acp45/rubber
+	name = "rubber .45 ACP bullet"
 	damage_type = BURN
 	shrapnel_chance = 0
 	sound_override = 'sound/weapons/gun_c99.ogg'

--- a/code/datums/ammo/bullet/pistol.dm
+++ b/code/datums/ammo/bullet/pistol.dm
@@ -200,9 +200,10 @@
 	penetration = ARMOR_PENETRATION_TIER_5
 	damage_falloff = DAMAGE_FALLOFF_TIER_7
 
-// Used by VP78 and Auto 9
-/datum/ammo/bullet/pistol/squash
-	name = "squash-head pistol bullet"
+// Used by VP78-A1
+// Formerly known as squash-head 9mm
+/datum/ammo/bullet/pistol/acp45
+	name = ".45 ACP bullet"
 	headshot_state = HEADSHOT_OVERLAY_MEDIUM
 	debilitate = list(0,0,0,0,0,0,0,2)
 
@@ -213,59 +214,59 @@
 	shrapnel_chance = SHRAPNEL_CHANCE_TIER_2
 	damage_falloff = DAMAGE_FALLOFF_TIER_6
 
-/datum/ammo/bullet/pistol/squash/toxin
-	name = "toxic squash-head pistol bullet"
+/datum/ammo/bullet/pistol/acp45/toxin
+	name = "toxic squash-head .45 ACP bullet"
 	var/acid_per_hit = 10
 	var/organic_damage_mult = 3
 
-/datum/ammo/bullet/pistol/squash/toxin/on_hit_mob(mob/M, obj/projectile/P)
+/datum/ammo/bullet/pistol/acp45/toxin/on_hit_mob(mob/M, obj/projectile/P)
 	. = ..()
 	M.AddComponent(/datum/component/status_effect/toxic_buildup, acid_per_hit)
 
-/datum/ammo/bullet/pistol/squash/toxin/on_hit_turf(turf/T, obj/projectile/P)
+/datum/ammo/bullet/pistol/acp45/toxin/on_hit_turf(turf/T, obj/projectile/P)
 	. = ..()
 	if(T.turf_flags & TURF_ORGANIC)
 		P.damage *= organic_damage_mult
 
-/datum/ammo/bullet/pistol/squash/toxin/on_hit_obj(obj/O, obj/projectile/P)
+/datum/ammo/bullet/pistol/acp45/toxin/on_hit_obj(obj/O, obj/projectile/P)
 	. = ..()
 	if(O.flags_obj & OBJ_ORGANIC)
 		P.damage *= organic_damage_mult
 
-/datum/ammo/bullet/pistol/squash/penetrating
-	name = "wall-penetrating squash-head pistol bullet"
+/datum/ammo/bullet/pistol/acp45/penetrating
+	name = "wall-penetrating squash-head .45 ACP bullet"
 	shrapnel_chance = 0
 	penetration = ARMOR_PENETRATION_TIER_10
 
-/datum/ammo/bullet/pistol/squash/penetrating/set_bullet_traits()
+/datum/ammo/bullet/pistol/acp45/penetrating/set_bullet_traits()
 	. = ..()
 	LAZYADD(traits_to_give, list(
 		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_penetrating)
 	))
 
-/datum/ammo/bullet/pistol/squash/incendiary
-	name = "incendiary squash-head pistol bullet"
+/datum/ammo/bullet/pistol/acp45/incendiary
+	name = "incendiary squash-head .45 ACP bullet"
 	damage_type = BURN
 	shrapnel_chance = 0
 	flags_ammo_behavior = AMMO_BALLISTIC
 	accuracy = HIT_ACCURACY_TIER_3
 	damage = 35
 
-/datum/ammo/bullet/pistol/squash/incendiary/set_bullet_traits()
+/datum/ammo/bullet/pistol/acp45/incendiary/set_bullet_traits()
 	..()
 	LAZYADD(traits_to_give, list(
 		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_incendiary)
 	))
 
 /datum/ammo/bullet/pistol/squash/heap
-	name = "high-explosive armor-piercing pistol bullet"
+	name = "high-explosive armor-piercing .45 ACP bullet"
 
 	headshot_state = HEADSHOT_OVERLAY_HEAVY
 	damage = 50
 	penetration = ARMOR_PENETRATION_TIER_10
 
 /datum/ammo/bullet/pistol/squash/rubber
-	name = "rubber squash-head pistol bullet"
+	name = "rubber squash-head .45 ACP bullet"
 	damage_type = BURN
 	shrapnel_chance = 0
 	sound_override = 'sound/weapons/gun_c99.ogg'

--- a/code/datums/factions/pmc.dm
+++ b/code/datums/factions/pmc.dm
@@ -69,11 +69,11 @@
 		list("NSG 23 extended magazine (10x24mm)", 5, /obj/item/ammo_magazine/rifle/nsg23/extended, null, VENDOR_ITEM_REGULAR),
 
 		list("SIDEARMS", 0, null, null, null),
-		list("VP78 pistol", 20, /obj/item/weapon/gun/pistol/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 pistol", 20, /obj/item/weapon/gun/pistol/vp78, null, VENDOR_ITEM_REGULAR),
 		list("88 Mod 4 Combat Pistol", 15, /obj/item/weapon/gun/pistol/mod88, null, VENDOR_ITEM_REGULAR),
 
 		list("SIDEARM AMMUNITION", 0, null, null, null),
-		list("VP78 magazine (9mm)", 5, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 magazine (9mm)", 5, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
 		list("88M4 AP Magazine (9mm)", 5, /obj/item/ammo_magazine/pistol/mod88, null, VENDOR_ITEM_REGULAR),
 
 		list("ATTACHMENTS", 0, null, null, null),
@@ -109,11 +109,11 @@
 		list("NSG 23 extended magazine (10x24mm)", 50, /obj/item/ammo_magazine/rifle/nsg23/extended, null, VENDOR_ITEM_REGULAR),
 
 		list("SIDEARMS", 0, null, null, null),
-		list("VP78 pistol", 20, /obj/item/weapon/gun/pistol/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 pistol", 20, /obj/item/weapon/gun/pistol/vp78, null, VENDOR_ITEM_REGULAR),
 		list("88 Mod 4 Combat Pistol", 30, /obj/item/weapon/gun/pistol/mod88, null, VENDOR_ITEM_REGULAR),
 
 		list("SIDEARM AMMUNITION", 0, null, null, null),
-		list("VP78 magazine (9mm)", 50, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Magazine (9mm)", 50, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
 		list("88M4 AP Magazine (9mm)", 50, /obj/item/ammo_magazine/pistol/mod88, null, VENDOR_ITEM_REGULAR),
 
 		list("UTILITIES", 0, null, null, null),

--- a/code/datums/factions/royalmarinescommando.dm
+++ b/code/datums/factions/royalmarinescommando.dm
@@ -46,11 +46,11 @@
 		list("F903A1 Marksman Magazine (10x24mm)", 15, /obj/item/ammo_magazine/rifle/rmc_f90/marksman, null, VENDOR_ITEM_REGULAR),
 
 		list("SIDEARMS", 0, null, null, null),
-		list("VP78 Pistol", 20, /obj/item/weapon/gun/pistol/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Pistol", 20, /obj/item/weapon/gun/pistol/vp78, null, VENDOR_ITEM_REGULAR),
 		list("88 Mod 4 Combat Pistol", 15, /obj/item/weapon/gun/pistol/mod88, null, VENDOR_ITEM_REGULAR),
 
 		list("SIDEARM AMMUNITION", 0, null, null, null),
-		list("VP78 magazine (9mm)", 5, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 magazine (9mm)", 5, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
 		list("88M4 AP Magazine (9mm)", 5, /obj/item/ammo_magazine/pistol/mod88, null, VENDOR_ITEM_REGULAR),
 
 		list("ATTACHMENTS", 0, null, null, null),
@@ -85,11 +85,11 @@
 		list("F903A1 Marksman Magazine (10x24mm)", 15, /obj/item/ammo_magazine/rifle/rmc_f90/marksman, null, VENDOR_ITEM_REGULAR),
 
 		list("SIDEARMS", -1, null, null),
-		list("VP78 Pistol", 20, /obj/item/weapon/gun/pistol/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Pistol", 20, /obj/item/weapon/gun/pistol/vp78, null, VENDOR_ITEM_REGULAR),
 		list("88 Mod 4 Combat Pistol", 15, /obj/item/weapon/gun/pistol/mod88, null, VENDOR_ITEM_REGULAR),
 
 		list("SIDEARM AMMUNITION", -1, null, null),
-		list("VP78 magazine (9mm)", 5, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 magazine (9mm)", 5, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
 		list("88M4 AP Magazine (9mm)", 5, /obj/item/ammo_magazine/pistol/mod88, null, VENDOR_ITEM_REGULAR),
 
 		list("UTILITIES", -1, null, null),

--- a/code/datums/supply_packs/ammo.dm
+++ b/code/datums/supply_packs/ammo.dm
@@ -255,13 +255,13 @@
 //------------------------Special or non common magazines----------------
 
 /datum/supply_packs/ammo_vp78_mag_box
-	name = "Magazine box (VP78, 16x mags)"
+	name = "Magazine box (VP78-A1, 16x mags)"
 	contains = list(
 		/obj/item/ammo_box/magazine/vp78,
 	)
 	cost = 40
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "\improper VP78 magazines crate"
+	containername = "\improper VP78-A1 Magazines crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_su6_mag_box

--- a/code/datums/supply_packs/weapons.dm
+++ b/code/datums/supply_packs/weapons.dm
@@ -65,14 +65,14 @@
 	group = "Weapons"
 
 /datum/supply_packs/vp78
-	name = "VP-78 Hand Cannon Crate (x2)"
+	name = "VP78-A1 Hand Cannon Crate (x2)"
 	contains = list(
 		/obj/item/storage/box/guncase/vp78,
 		/obj/item/storage/box/guncase/vp78,
 	)
 	cost = 30
 	containertype = /obj/structure/closet/crate/weapon
-	containername = "VP-78 Hand Cannon Crate"
+	containername = "VP78-A1 Hand Cannon Crate"
 	group = "Weapons"
 
 /datum/supply_packs/gun

--- a/code/datums/tutorial/marine/reqs_line.dm
+++ b/code/datums/tutorial/marine/reqs_line.dm
@@ -73,7 +73,7 @@
 		/obj/item/weapon/gun/smg/m39 = list("M39", "SMG"),
 		/obj/item/weapon/gun/rifle/m4ra = list("M4RA", "M4RA Battle Rifle"),
 		/obj/item/weapon/gun/rifle/m41a = list("M41", "M41", "M41A", "Mk2", "M4 rifle"),
-		/obj/item/storage/box/guncase/vp78 = list("VP", "VP78"),
+		/obj/item/storage/box/guncase/vp78 = list("VP", "VP78", "VP78-A1"),
 		/obj/item/storage/box/guncase/smartpistol = list("S6 pistol", "SU-6", "Smartpistol"),
 		/obj/item/storage/box/guncase/mou53 = list("MOU", "MOU53", "MOU-53", "Mouse"),
 		/obj/item/storage/box/guncase/xm88 = list("Xm88", "XM88"),

--- a/code/game/machinery/vending/vendor_types/crew/corporate_security.dm
+++ b/code/game/machinery/vending/vendor_types/crew/corporate_security.dm
@@ -65,7 +65,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_corporate_security_full, list(
 	list("SIDEARM (CHOOSE 1)", 0, null, null, null),
 	list("ES-4 Electrostatic Pistol", 0, /obj/item/storage/belt/gun/m4a3/wy/es4, MARINE_CAN_BUY_BELT, VENDOR_ITEM_RECOMMENDED),
 	list("88 Mod 4 Combat Pistol", 0, /obj/item/storage/belt/gun/m4a3/wy/mod88, MARINE_CAN_BUY_BELT, VENDOR_ITEM_REGULAR),
-	list("VP78 Pistol", 8, /obj/item/storage/belt/gun/m4a3/wy/vp78, MARINE_CAN_BUY_BELT, VENDOR_ITEM_REGULAR),
+	list("VP78-A1 Pistol", 8, /obj/item/storage/belt/gun/m4a3/wy/vp78, MARINE_CAN_BUY_BELT, VENDOR_ITEM_REGULAR),
 
 	list("PRIMARY AMMUNITION", 0, null, null, null),
 	list("X21 Shock Slugs", 10, /obj/item/ammo_magazine/shotgun/beanbag/es7, null, VENDOR_ITEM_REGULAR),
@@ -83,7 +83,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_corporate_security_full, list(
 	list("SIDEARM AMMUNITION", 0, null, null, null),
 	list("ES-4 Stun Magazine (9mm)", 4, /obj/item/ammo_magazine/pistol/es4, null, VENDOR_ITEM_REGULAR),
 	list("88M4 AP Magazine (9mm)", 4, /obj/item/ammo_magazine/pistol/mod88, null, VENDOR_ITEM_REGULAR),
-	list("VP78 Magazine (9mm)", 6, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
+	list("VP78-A1 Magazine (9mm)", 6, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
 
 	list("RAIL ATTACHMENTS (CHOOSE 2)", 0, null, null, null),
 	list("Red-Dot Sight", 0, /obj/item/attachable/reddot, CIVILIAN_CAN_BUY_GLASSES, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/crew/pilot_officer.dm
+++ b/code/game/machinery/vending/vendor_types/crew/pilot_officer.dm
@@ -38,7 +38,7 @@
 		list("M4A3 Magazine (9mm)", 20, /obj/item/ammo_magazine/pistol, VENDOR_ITEM_REGULAR),
 		list("M4A3 AP Magazine (9mm)", 12, /obj/item/ammo_magazine/pistol/ap, VENDOR_ITEM_REGULAR),
 		list("M4A3 HP Magazine (9mm)", 12, /obj/item/ammo_magazine/pistol/hp, VENDOR_ITEM_REGULAR),
-		list("VP78 Magazine (9mm)", 16, /obj/item/ammo_magazine/pistol/vp78, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Magazine (9mm)", 16, /obj/item/ammo_magazine/pistol/vp78, VENDOR_ITEM_REGULAR),
 
 		list("ATTACHMENTS", -1, null, null),
 		list("Rail Flashlight", 8, /obj/item/attachable/flashlight, VENDOR_ITEM_REGULAR),
@@ -73,7 +73,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_pilot_officer, list(
 
 		list("PERSONAL SIDEARM (CHOOSE 1)", 0, null, null, null),
 		list("88 Mod 4 Combat Pistol", 0, /obj/item/weapon/gun/pistol/mod88, MARINE_CAN_BUY_ATTACHMENT, VENDOR_ITEM_REGULAR),
-		list("VP78 Pistol", 0, /obj/item/weapon/gun/pistol/vp78, MARINE_CAN_BUY_ATTACHMENT, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Pistol", 0, /obj/item/weapon/gun/pistol/vp78, MARINE_CAN_BUY_ATTACHMENT, VENDOR_ITEM_REGULAR),
 
 		list("BELT (CHOOSE 2)", 0, null, null, null),
 		list("G8-A General Utility Pouch", 0, /obj/item/storage/backpack/general_belt, MARINE_CAN_BUY_BELT, VENDOR_ITEM_REGULAR),
@@ -194,7 +194,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_dropship_crew_chief, list(
 
 		list("PERSONAL SIDEARM (CHOOSE 1)", 0, null, null, null),
 		list("88 Mod 4 Combat Pistol", 0, /obj/item/weapon/gun/pistol/mod88, MARINE_CAN_BUY_ATTACHMENT, VENDOR_ITEM_REGULAR),
-		list("VP78 Pistol", 0, /obj/item/weapon/gun/pistol/vp78, MARINE_CAN_BUY_ATTACHMENT, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Pistol", 0, /obj/item/weapon/gun/pistol/vp78, MARINE_CAN_BUY_ATTACHMENT, VENDOR_ITEM_REGULAR),
 
 		list("BELT (CHOOSE 2)", 0, null, null, null),
 		list("G8-A General Utility Pouch", 0, /obj/item/storage/backpack/general_belt, MARINE_CAN_BUY_BELT, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/crew/senior_officers.dm
+++ b/code/game/machinery/vending/vendor_types/crew/senior_officers.dm
@@ -440,7 +440,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_xo, list(
 		list("Formal Uniform", 0, list(/obj/item/clothing/suit/storage/jacket/marine/dress, /obj/item/clothing/head/marine/peaked, /obj/item/clothing/under/marine/dress), MARINE_CAN_BUY_UNIFORM, VENDOR_ITEM_RECOMMENDED),
 
 		list("PERSONAL WEAPON (CHOOSE 1)", 0, null, null, null),
-		list("VP78 Pistol", 0, /obj/item/storage/belt/gun/m4a3/vp78, MARINE_CAN_BUY_SECONDARY, VENDOR_ITEM_RECOMMENDED),
+		list("VP78-A1 Pistol", 0, /obj/item/storage/belt/gun/m4a3/vp78, MARINE_CAN_BUY_SECONDARY, VENDOR_ITEM_RECOMMENDED),
 		list("M4A3 Service Pistol", 0, /obj/item/storage/belt/gun/m4a3/commander, MARINE_CAN_BUY_SECONDARY, VENDOR_ITEM_REGULAR),
 		list("Mod 88 Pistol", 0, /obj/item/storage/belt/gun/m4a3/mod88, MARINE_CAN_BUY_SECONDARY, VENDOR_ITEM_REGULAR),
 		list("M44 Revolver", 0, /obj/item/storage/belt/gun/m44/mp, MARINE_CAN_BUY_SECONDARY, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/crew/staff_officer.dm
+++ b/code/game/machinery/vending/vendor_types/crew/staff_officer.dm
@@ -42,7 +42,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_staff_officer, list(
 		list("M44 Revolver", 0, /obj/item/storage/belt/gun/m44/mp, MARINE_CAN_BUY_SECONDARY, VENDOR_ITEM_RECOMMENDED),
 		list("Mod 88 Pistol", 0, /obj/item/storage/belt/gun/m4a3/mod88, MARINE_CAN_BUY_SECONDARY, VENDOR_ITEM_RECOMMENDED),
 		list("M4A3 Pistol", 0, /obj/item/storage/belt/gun/m4a3/commander, MARINE_CAN_BUY_SECONDARY, VENDOR_ITEM_RECOMMENDED),
-		list("VP78 Pistol", 0, /obj/item/storage/belt/gun/m4a3/vp78, MARINE_CAN_BUY_SECONDARY, VENDOR_ITEM_RECOMMENDED),
+		list("VP78-A1 Pistol", 0, /obj/item/storage/belt/gun/m4a3/vp78, MARINE_CAN_BUY_SECONDARY, VENDOR_ITEM_RECOMMENDED),
 
 		list("ACCESSORIES (CHOOSE 1)", 0, null, null, null),
 		list("Black Webbing Vest", 0, /obj/item/clothing/accessory/storage/black_vest, MARINE_CAN_BUY_ACCESSORY, VENDOR_ITEM_RECOMMENDED),

--- a/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
+++ b/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
@@ -244,7 +244,7 @@ GLOBAL_LIST_INIT(cm_vending_vehicle_crew_arc, list(
 		list("M4A3 Magazine (9mm)", 10, /obj/item/ammo_magazine/pistol, VENDOR_ITEM_REGULAR),
 		list("M4A3 AP Magazine (9mm)", 6, /obj/item/ammo_magazine/pistol/ap, VENDOR_ITEM_REGULAR),
 		list("M4A3 HP Magazine (9mm)", 6, /obj/item/ammo_magazine/pistol/hp, VENDOR_ITEM_REGULAR),
-		list("VP78 Magazine (9mm)", 8, /obj/item/ammo_magazine/pistol/vp78, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Magazine (9mm)", 8, /obj/item/ammo_magazine/pistol/vp78, VENDOR_ITEM_REGULAR),
 
 		list("ATTACHMENTS", -1, null, null),
 		list("Magnetic Harness", 2, /obj/item/attachable/magnetic_harness, VENDOR_ITEM_REGULAR),
@@ -275,7 +275,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_vehicle_crew, list(
 
 		list("PERSONAL SIDEARM (CHOOSE 1)", 0, null, null, null),
 		list("88 Mod 4 Combat Pistol", 0, /obj/item/weapon/gun/pistol/mod88, MARINE_CAN_BUY_ATTACHMENT, VENDOR_ITEM_REGULAR),
-		list("VP78 Pistol", 0, /obj/item/weapon/gun/pistol/vp78, MARINE_CAN_BUY_ATTACHMENT, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Pistol", 0, /obj/item/weapon/gun/pistol/vp78, MARINE_CAN_BUY_ATTACHMENT, VENDOR_ITEM_REGULAR),
 
 		list("BELT (CHOOSE 1)", 0, null, null, null),
 		list("G8-A General Utility Pouch", 0, /obj/item/storage/backpack/general_belt, MARINE_CAN_BUY_BELT, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/intelligence_officer.dm
+++ b/code/game/machinery/vending/vendor_types/intelligence_officer.dm
@@ -23,11 +23,11 @@ GLOBAL_LIST_INIT(cm_vending_gear_intelligence_officer, list(
 		list("M44 Marksman Speed Loader (.44)", 5, /obj/item/ammo_magazine/revolver/marksman, null, VENDOR_ITEM_REGULAR),
 		list("M4A3 HP Magazine", 5, /obj/item/ammo_magazine/pistol/hp, null, VENDOR_ITEM_REGULAR),
 		list("M4A3 AP Magazine", 5, /obj/item/ammo_magazine/pistol/ap, null, VENDOR_ITEM_REGULAR),
-		list("VP78 Magazine", 5, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Magazine", 5, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
 		list("SU-6 Smartpistol Magazine (.45)", 10, /obj/item/ammo_magazine/pistol/smart, null, VENDOR_ITEM_REGULAR),
 
 		list("RESTRICTED FIREARMS", 0, null, null, null),
-		list("VP78 Pistol", 15, /obj/item/storage/box/guncase/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Pistol", 15, /obj/item/storage/box/guncase/vp78, null, VENDOR_ITEM_REGULAR),
 		list("SU-6 Smart Pistol", 15, /obj/item/storage/box/guncase/smartpistol, null, VENDOR_ITEM_REGULAR),
 
 		list("RESTRICTED GEAR", 0, null, null, null),
@@ -192,7 +192,7 @@ GLOBAL_LIST_INIT(cm_vending_guns_intelligence_officer, list(
 		list("M4A3 Magazine (9mm)", 20, /obj/item/ammo_magazine/pistol, VENDOR_ITEM_REGULAR),
 		list("M4A3 AP Magazine (9mm)", 8, /obj/item/ammo_magazine/pistol/ap, VENDOR_ITEM_REGULAR),
 		list("M4A3 HP Magazine (9mm)", 8, /obj/item/ammo_magazine/pistol/hp, VENDOR_ITEM_REGULAR),
-		list("VP78 Magazine (9mm)", 16, /obj/item/ammo_magazine/pistol/vp78, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Magazine (9mm)", 16, /obj/item/ammo_magazine/pistol/vp78, VENDOR_ITEM_REGULAR),
 
 		list("ATTACHMENTS", -1, null, null),
 		list("Rail Flashlight", 8, /obj/item/attachable/flashlight, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -32,7 +32,7 @@
 		list("M82F Flare Gun", floor(scale * 20), /obj/item/weapon/gun/flare, VENDOR_ITEM_REGULAR),
 
 		list("RESTRICTED FIREARMS", -1, null, null),
-		list("VP78 Pistol", floor(scale * 4), /obj/item/storage/box/guncase/vp78, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Pistol", floor(scale * 4), /obj/item/storage/box/guncase/vp78, VENDOR_ITEM_REGULAR),
 		list("SU-6 Smart Pistol", floor(scale * 3), /obj/item/storage/box/guncase/smartpistol, VENDOR_ITEM_REGULAR),
 		list("MOU-53 Shotgun", floor(scale * 2), /obj/item/storage/box/guncase/mou53, VENDOR_ITEM_REGULAR),
 		list("XM88 Heavy Rifle", floor(scale * 3), /obj/item/storage/box/guncase/xm88, VENDOR_ITEM_REGULAR),
@@ -289,7 +289,7 @@
 		list("Box Of .458 SOCOM Rounds (.458 SOCOM)", floor(scale * 4), /obj/item/ammo_magazine/lever_action/xm88, VENDOR_ITEM_REGULAR),
 
 		list("RESTRICTED FIREARM AMMUNITION", -1, null, null),
-		list("VP78 Magazine", 11, /obj/item/ammo_magazine/pistol/vp78, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Magazine", 11, /obj/item/ammo_magazine/pistol/vp78, VENDOR_ITEM_REGULAR),
 		list("SU-6 Smartpistol Magazine (.45)", 13, /obj/item/ammo_magazine/pistol/smart, VENDOR_ITEM_REGULAR),
 		list("M240 Incinerator Tank", floor(scale * 3), /obj/item/ammo_magazine/flamer_tank, VENDOR_ITEM_REGULAR),
 		list("M41AE2 Box Magazine (10x24mm)", floor(scale * 3), /obj/item/ammo_magazine/rifle/lmg, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_engineer.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_engineer.dm
@@ -51,7 +51,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_engi, list(
 		list("M44 Marksman Speed Loader (.44)", 5, /obj/item/ammo_magazine/revolver/marksman, null, VENDOR_ITEM_REGULAR),
 		list("M4A3 HP Magazine", 3, /obj/item/ammo_magazine/pistol/hp, null, VENDOR_ITEM_REGULAR),
 		list("M4A3 AP Magazine", 3, /obj/item/ammo_magazine/pistol/ap, null, VENDOR_ITEM_REGULAR),
-		list("VP78 Magazine", 3, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Magazine", 3, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
 		list("SU-6 Smartpistol Magazine (.45)", 6, /obj/item/ammo_magazine/pistol/smart, null, VENDOR_ITEM_REGULAR),
 
 		list("ARMORS", 0, null, null, null),
@@ -59,7 +59,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_engi, list(
 		list("M4 Pattern Armor", 16, /obj/item/clothing/suit/storage/marine/medium/rto, null, VENDOR_ITEM_REGULAR),
 
 		list("RESTRICTED FIREARMS", 0, null, null, null),
-		list("VP78 Pistol", 8, /obj/item/storage/box/guncase/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Pistol", 8, /obj/item/storage/box/guncase/vp78, null, VENDOR_ITEM_REGULAR),
 		list("SU-6 Smart Pistol", 12, /obj/item/storage/box/guncase/smartpistol, null, VENDOR_ITEM_REGULAR),
 		list("M240 Incinerator Unit", 12, /obj/item/storage/box/guncase/flamer, null, VENDOR_ITEM_REGULAR),
 		list("M85A1 Grenade Launcher", 24, /obj/item/storage/box/guncase/m85a1, null, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
@@ -96,7 +96,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_leader, list(
 		list("M44 Marksman Speed Loader (.44)", 5, /obj/item/ammo_magazine/revolver/marksman, null, VENDOR_ITEM_REGULAR),
 		list("M4A3 HP Magazine", 3, /obj/item/ammo_magazine/pistol/hp, null, VENDOR_ITEM_REGULAR),
 		list("M4A3 AP Magazine", 3, /obj/item/ammo_magazine/pistol/ap, null, VENDOR_ITEM_REGULAR),
-		list("VP78 Magazine", 3, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Magazine", 3, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
 		list("SU-6 Smartpistol Magazine (.45)", 6, /obj/item/ammo_magazine/pistol/smart, null, VENDOR_ITEM_REGULAR),
 
 		list("SPECIAL AMMUNITION", 0, null, null, null),
@@ -105,7 +105,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_leader, list(
 
 		list("RESTRICTED FIREARMS", 0, null, null, null),
 		list("M240 Incinerator Unit", 18, /obj/item/storage/box/guncase/flamer, null, VENDOR_ITEM_REGULAR),
-		list("VP78 Pistol", 8, /obj/item/storage/box/guncase/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Pistol", 8, /obj/item/storage/box/guncase/vp78, null, VENDOR_ITEM_REGULAR),
 		list("SU-6 Smart Pistol", 12, /obj/item/storage/box/guncase/smartpistol, null, VENDOR_ITEM_REGULAR),
 		list("M85A1 Grenade Launcher", 18, /obj/item/storage/box/guncase/m85a1, null, VENDOR_ITEM_REGULAR),
 

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_medic.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_medic.dm
@@ -71,7 +71,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_medic, list(
 		list("M44 Marksman Speed Loader (.44)", 5, /obj/item/ammo_magazine/revolver/marksman, null, VENDOR_ITEM_REGULAR),
 		list("M4A3 HP Magazine", 3, /obj/item/ammo_magazine/pistol/hp, null, VENDOR_ITEM_REGULAR),
 		list("M4A3 AP Magazine", 3, /obj/item/ammo_magazine/pistol/ap, null, VENDOR_ITEM_REGULAR),
-		list("VP78 Magazine", 3, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Magazine", 3, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
 		list("SU-6 Smartpistol Magazine (.45)", 6, /obj/item/ammo_magazine/pistol/smart, null, VENDOR_ITEM_REGULAR),
 
 		list("ARMORS", 0, null, null, null),
@@ -79,7 +79,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_medic, list(
 		list("M4 Pattern Armor", 16, /obj/item/clothing/suit/storage/marine/medium/rto, null, VENDOR_ITEM_REGULAR),
 
 		list("RESTRICTED FIREARMS", 0, null, null, null),
-		list("VP78 Pistol", 8, /obj/item/storage/box/guncase/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Pistol", 8, /obj/item/storage/box/guncase/vp78, null, VENDOR_ITEM_REGULAR),
 		list("SU-6 Smart Pistol", 12, /obj/item/storage/box/guncase/smartpistol, null, VENDOR_ITEM_REGULAR),
 
 		list("CLOTHING ITEMS", 0, null, null, null),

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
@@ -299,7 +299,7 @@
 		list("M4A3 AP Magazine", floor(scale * 2), /obj/item/ammo_magazine/pistol/ap, VENDOR_ITEM_REGULAR),
 
 		list("RESTRICTED FIREARM AMMUNITION", -1, null, null),
-		list("VP78 Magazine", floor(scale * 5), /obj/item/ammo_magazine/pistol/vp78, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Magazine", floor(scale * 5), /obj/item/ammo_magazine/pistol/vp78, VENDOR_ITEM_REGULAR),
 		list("SU-6 Smartpistol Magazine (.45)", floor(scale * 5), /obj/item/ammo_magazine/pistol/smart, VENDOR_ITEM_REGULAR),
 		list("M240 Incinerator Tank", floor(scale * 3), /obj/item/ammo_magazine/flamer_tank, VENDOR_ITEM_REGULAR),
 		list("M56D Drum Magazine", floor(scale * 2), /obj/item/ammo_magazine/m56d, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_rifleman.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_rifleman.dm
@@ -53,7 +53,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_marine, list(
 		list("Seegson MCT", 5, /obj/item/tool/weldingtool/simple, null, VENDOR_ITEM_REGULAR),
 
 		list("RESTRICTED FIREARMS", 0, null, null, null),
-		list("VP78 Pistol", 15, /obj/item/storage/box/guncase/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Pistol", 15, /obj/item/storage/box/guncase/vp78, null, VENDOR_ITEM_REGULAR),
 		list("SU-6 Smart Pistol", 15, /obj/item/storage/box/guncase/smartpistol, null, VENDOR_ITEM_REGULAR),
 		list("M85A1 Grenade Launcher", 30, /obj/item/storage/box/guncase/m85a1, null, VENDOR_ITEM_REGULAR),
 
@@ -80,7 +80,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_marine, list(
 		list("M44 Marksman Speed Loader (.44)", 5, /obj/item/ammo_magazine/revolver/marksman, null, VENDOR_ITEM_REGULAR),
 		list("M4A3 HP Magazine", 5, /obj/item/ammo_magazine/pistol/hp, null, VENDOR_ITEM_REGULAR),
 		list("M4A3 AP Magazine", 5, /obj/item/ammo_magazine/pistol/ap, null, VENDOR_ITEM_REGULAR),
-		list("VP78 Magazine", 5, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Magazine", 5, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
 		list("SU-6 Smartpistol Magazine (.45)", 10, /obj/item/ammo_magazine/pistol/smart, null, VENDOR_ITEM_REGULAR),
 
 		list("ARMORS", 0, null, null, null),

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_smartgunner.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_smartgunner.dm
@@ -7,7 +7,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_smartgun, list(
 		list("M56 Reinforced Combat Harness", 0, /obj/item/clothing/suit/storage/marine/smartgunner/reinforced, MARINE_CAN_BUY_ARMOR, VENDOR_ITEM_MANDATORY),
 
 		list("RESTRICTED FIREARMS", 0, null, null, null),
-		list("VP78 Pistol", 15, /obj/item/storage/box/guncase/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Pistol", 15, /obj/item/storage/box/guncase/vp78, null, VENDOR_ITEM_REGULAR),
 		list("SU-6 Smart Pistol", 15, /obj/item/storage/box/guncase/smartpistol, null, VENDOR_ITEM_REGULAR),
 
 		list("SIDEARM ATTACHMENTS (CHOOSE 1)", 0, null, null, null),
@@ -31,7 +31,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_smartgun, list(
 		list("M44 Marksman Speed Loader (.44)", 5, /obj/item/ammo_magazine/revolver/marksman, null, VENDOR_ITEM_REGULAR),
 		list("M4A3 HP Magazine", 5, /obj/item/ammo_magazine/pistol/hp, null, VENDOR_ITEM_REGULAR),
 		list("M4A3 AP Magazine", 5, /obj/item/ammo_magazine/pistol/ap, null, VENDOR_ITEM_REGULAR),
-		list("VP78 Magazine", 5, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Magazine", 5, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
 		list("SU-6 Smartpistol Magazine (.45)", 10, /obj/item/ammo_magazine/pistol/smart, null, VENDOR_ITEM_REGULAR),
 
 		list("CLOTHING ITEMS", 0, null, null, null),

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_specialist.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_specialist.dm
@@ -160,7 +160,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_specialist, list(
 		list("Heat Absorbent Coif", 0, /obj/item/clothing/mask/rebreather/scarf, MARINE_CAN_BUY_MASK, VENDOR_ITEM_REGULAR),
 
 		list("RESTRICTED FIREARMS", 0, null, null, null),
-		list("VP78 Pistol", 15, /obj/item/storage/box/guncase/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Pistol", 15, /obj/item/storage/box/guncase/vp78, null, VENDOR_ITEM_REGULAR),
 		list("SU-6 Smart Pistol", 15, /obj/item/storage/box/guncase/smartpistol, null, VENDOR_ITEM_REGULAR),
 
 		list("SIDEARM AMMUNITION", 0, null, null, null),
@@ -169,7 +169,7 @@ GLOBAL_LIST_INIT(cm_vending_clothing_specialist, list(
 		list("M44 Marksman Speed Loader (.44)", 5, /obj/item/ammo_magazine/revolver/marksman, null, VENDOR_ITEM_REGULAR),
 		list("M4A3 HP Magazine", 5, /obj/item/ammo_magazine/pistol/hp, null, VENDOR_ITEM_REGULAR),
 		list("M4A3 AP Magazine", 5, /obj/item/ammo_magazine/pistol/ap, null, VENDOR_ITEM_REGULAR),
-		list("VP78 Magazine", 5, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Magazine", 5, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
 		list("SU-6 Smartpistol Magazine (.45)", 10, /obj/item/ammo_magazine/pistol/smart, null, VENDOR_ITEM_REGULAR),
 
 		list("CLOTHING ITEMS", 0, null, null, null),

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_tl.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_tl.dm
@@ -26,11 +26,11 @@ GLOBAL_LIST_INIT(cm_vending_gear_tl, list(
 		list("M44 Marksman Speed Loader (.44)", 5, /obj/item/ammo_magazine/revolver/marksman, null, VENDOR_ITEM_REGULAR),
 		list("M4A3 HP Magazine", 5, /obj/item/ammo_magazine/pistol/hp, null, VENDOR_ITEM_REGULAR),
 		list("M4A3 AP Magazine", 5, /obj/item/ammo_magazine/pistol/ap, null, VENDOR_ITEM_REGULAR),
-		list("VP78 Magazine", 5, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Magazine", 5, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
 		list("SU-6 Smartpistol Magazine (.45)", 10, /obj/item/ammo_magazine/pistol/smart, null, VENDOR_ITEM_REGULAR),
 
 		list("RESTRICTED FIREARMS", 0, null, null, null),
-		list("VP78 Pistol", 10, /obj/item/storage/box/guncase/vp78, null, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Pistol", 10, /obj/item/storage/box/guncase/vp78, null, VENDOR_ITEM_REGULAR),
 		list("SU-6 Smart Pistol", 15, /obj/item/storage/box/guncase/smartpistol, null, VENDOR_ITEM_REGULAR),
 		list("M85A1 Grenade Launcher", 30, /obj/item/storage/box/guncase/m85a1, null, VENDOR_ITEM_REGULAR),
 

--- a/code/modules/cm_marines/equipment/guncases.dm
+++ b/code/modules/cm_marines/equipment/guncases.dm
@@ -25,7 +25,7 @@
 
 //------------
 /obj/item/storage/box/guncase/vp78
-	name = "\improper VP78 pistol case"
+	name = "\improper VP78-A1 Pistol case"
 	desc = "A gun case containing the VP78. Comes with two magazines."
 	can_hold = list(/obj/item/weapon/gun/pistol/vp78, /obj/item/ammo_magazine/pistol/vp78)
 	storage_slots = 3

--- a/code/modules/projectiles/ammo_boxes/magazine_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/magazine_boxes.dm
@@ -436,10 +436,10 @@
 /obj/item/ammo_box/magazine/mod88/empty
 	empty = TRUE
 
-//-----------------------VP78 Pistol Mag Box-----------------------
+//-----------------------VP78-A1 Pistol Mag Box-----------------------
 
 /obj/item/ammo_box/magazine/vp78
-	name = "magazine box (VP78 x 16)"
+	name = "magazine box (VP78-A1 x 16)"
 	icon_state = "base_vp78"
 	flags_equip_slot = SLOT_BACK
 	overlay_ammo_type = "_reg"

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1054,7 +1054,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/flashlight/laser_light_combo //Unique attachment for the VP78 based on the fact it has a Laser-Light Module in AVP2010
 	name = "VP78 Laser-Light Module"
-	desc = "A Laser-Light module for the VP78 Service Pistol which is currently undergoing limited field testing as part of the USCM's next generation pistol program. All VP78 pistols come equipped with the module."
+	desc = "A Laser-Light module for the VP78 Service Pistol which is currently undergoing limited field testing as part of the USCM's next generation pistol program. All VP78-A1 Pistols come equipped with the module."
 	icon = 'icons/obj/items/weapons/guns/attachments/under.dmi'
 	icon_state = "vplaserlight"
 	attach_icon = "vplaserlight_a"

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -856,7 +856,7 @@
 /obj/item/weapon/gun/pistol/vp78
 	name = "\improper VP78-A1 pistol"
 	desc = "A massive, formidable semi-automatic handgun chambered in .45 ACP rounds. A common sight throughout both UA and 3WE space, often held by both Weyland-Yutani PMC units and corporate executives."
-	desc_lore = "Originally chambered in 9mm, a redesign was comissioned by the Weyland-Yutani Paramilitary Division after their unrealistic performance expectations for a round chambered in such caliber were not met. While the up-gunned design is slightly bulkier than its 9mm counterpart, the PMC division was quick to appreciate the reliable and devastating performance of God's caliber.\nThis weapon is also undergoing limited field testing as part of the USCM's next generation pistol program. The slide is engraved with the Weyland-Yutani logo reminding you who's really in charge."
+	desc_lore = "Originally chambered in 9mm, a redesign was comissioned by the Weyland-Yutani Paramilitary Division after their unrealistic performance expectations for a round chambered in such caliber were not met. While the up-gunned design is slightly bulkier than its 9mm counterpart, the PMC division was quick to appreciate the reliable and devastating performance of God's caliber.\n\nThis weapon is also undergoing limited field testing as part of the USCM's next generation pistol program. The slide is engraved with the Weyland-Yutani logo reminding you who's really in charge."
 	icon = 'icons/obj/items/weapons/guns/guns_by_faction/WY/pistols.dmi'
 	icon_state = "vp78"
 	item_state = "vp78"

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -851,11 +851,12 @@
 	damage_mult = BASE_BULLET_DAMAGE_MULT + BULLET_DAMAGE_MULT_TIER_4
 
 //-------------------------------------------------------
-//VP78 - the only pistol viable as a primary.
+//VP78-A1 (formerly the VP78) - the only pistol viable as a primary.
 
 /obj/item/weapon/gun/pistol/vp78
-	name = "\improper VP78 pistol"
-	desc = "A massive, formidable semi-automatic handgun chambered in 9mm squash-head rounds. A common sight throughout both UA and 3WE space, often held by both Weyland-Yutani PMC units and corporate executives. This weapon is also undergoing limited field testing as part of the USCM's next generation pistol program. The slide is engraved with the Weyland-Yutani logo reminding you who's really in charge."
+	name = "\improper VP78-A1 pistol"
+	desc = "A massive, formidable semi-automatic handgun chambered in .45 ACP rounds. A common sight throughout both UA and 3WE space, often held by both Weyland-Yutani PMC units and corporate executives."
+	desc_lore = "Originally chambered in 9mm, a redesign was comissioned by the Weyland-Yutani Paramilitary Division after their unrealistic performance expectations for a round chambered in such caliber were not met. While the up-gunned design is slightly bulkier than its 9mm counterpart, the PMC division was quick to appreciate the reliable and devastating performance of God's caliber.\nThis weapon is also undergoing limited field testing as part of the USCM's next generation pistol program. The slide is engraved with the Weyland-Yutani logo reminding you who's really in charge."
 	icon = 'icons/obj/items/weapons/guns/guns_by_faction/WY/pistols.dmi'
 	icon_state = "vp78"
 	item_state = "vp78"

--- a/code/modules/projectiles/magazines/pistols.dm
+++ b/code/modules/projectiles/magazines/pistols.dm
@@ -370,7 +370,7 @@ It is a modified Beretta 93R, and can fire three-round burst or single fire. Whe
 /obj/item/ammo_magazine/pistol/auto9
 	name = "\improper Auto-9 magazine (9mm)"
 	desc = "A 9mm pistol magazine for the Auto-9 pistol. Squash-head to squash criminal's heads."
-	default_ammo = /datum/ammo/bullet/pistol/squash
+	default_ammo = /datum/ammo/bullet/pistol/acp45 // Technically uses the same rounds as the vp78, because I didn't want to dedicate a whole ammo type for what is essentially VP ammo
 	caliber = "9mm"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/WY/pistols.dmi'
 	icon_state = "88m4" //PLACEHOLDER

--- a/code/modules/projectiles/magazines/pistols.dm
+++ b/code/modules/projectiles/magazines/pistols.dm
@@ -145,10 +145,10 @@
 //VP78
 
 /obj/item/ammo_magazine/pistol/vp78
-	name = "\improper VP78 magazine (9mm)"
+	name = "\improper VP78-A1 Magazine (.45 ACP)"
 	desc = "A 9mm pistol magazine for the VP78."
-	default_ammo = /datum/ammo/bullet/pistol/squash
-	caliber = "9mm"
+	default_ammo = /datum/ammo/bullet/pistol/acp45
+	caliber = ".45"
 	icon = 'icons/obj/items/weapons/guns/ammo_by_faction/WY/pistols.dmi'
 	icon_state = "vp78"
 	max_rounds = 18
@@ -157,32 +157,32 @@
 	ammo_band_icon_empty = "+vp78_band_e"
 
 /obj/item/ammo_magazine/pistol/vp78/toxin
-	name = "\improper VP78 toxic magazine (9mm)"
-	desc = "A toxin 9mm pistol magazine for the VP78."
-	default_ammo = /datum/ammo/bullet/pistol/squash/toxin
+	name = "\improper VP78 toxic magazine (.45 ACP)"
+	desc = "A toxin .45 ACP pistol magazine for the VP78."
+	default_ammo = /datum/ammo/bullet/pistol/acp45/toxin
 	ammo_band_color = AMMO_BAND_COLOR_TOXIN
 
 /obj/item/ammo_magazine/pistol/vp78/penetrating
-	name = "\improper VP78 wall-penetrating magazine (9mm)"
-	desc = "A wall-penetrating 9mm pistol magazine for the VP78."
-	default_ammo = /datum/ammo/bullet/pistol/squash/penetrating
+	name = "\improper VP78 wall-penetrating magazine (.45 ACP)"
+	desc = "A wall-penetrating .45 ACP pistol magazine for the VP78."
+	default_ammo = /datum/ammo/bullet/pistol/acp45/penetrating
 	ammo_band_color = AMMO_BAND_COLOR_PENETRATING
 
 /obj/item/ammo_magazine/pistol/vp78/incendiary
-	name = "\improper VP78 incendiary magazine (9mm)"
-	desc = "An incendiary 9mm pistol magazine for the VP78."
-	default_ammo = /datum/ammo/bullet/pistol/squash/incendiary
+	name = "\improper VP78 incendiary magazine (.45 ACP)"
+	desc = "An incendiary .45 ACP pistol magazine for the VP78."
+	default_ammo = /datum/ammo/bullet/pistol/acp45/incendiary
 	ammo_band_color = AMMO_BAND_COLOR_INCENDIARY
 
 /obj/item/ammo_magazine/pistol/vp78/heap
-	name = "\improper VP78 high explosive armor piercing magazine (9mm)"
-	default_ammo = /datum/ammo/bullet/pistol/squash/heap
+	name = "\improper VP78 high explosive armor piercing magazine (.45 ACP)"
+	default_ammo = /datum/ammo/bullet/pistol/acp45/heap
 	ammo_band_color = AMMO_BAND_COLOR_HEAP
 
 /obj/item/ammo_magazine/pistol/vp78/rubber
-	name = "\improper VP78 rubber magazine (9mm)"
-	desc = "A 9mm pistol magazine for the VP78. This one is loaded with rubber bullets."
-	default_ammo = /datum/ammo/bullet/pistol/squash/rubber
+	name = "\improper VP78 rubber magazine (.45 ACP)"
+	desc = "A .45 ACP pistol magazine for the VP78. This one is loaded with rubber bullets."
+	default_ammo = /datum/ammo/bullet/pistol/acp45/rubber
 	ammo_band_color = AMMO_BAND_COLOR_RUBBER
 
 //-------------------------------------------------------

--- a/code/modules/projectiles/magazines/pistols.dm
+++ b/code/modules/projectiles/magazines/pistols.dm
@@ -157,30 +157,30 @@
 	ammo_band_icon_empty = "+vp78_band_e"
 
 /obj/item/ammo_magazine/pistol/vp78/toxin
-	name = "\improper VP78 toxic magazine (.45 ACP)"
+	name = "\improper VP78-A1 toxic magazine (.45 ACP)"
 	desc = "A toxin .45 ACP pistol magazine for the VP78."
 	default_ammo = /datum/ammo/bullet/pistol/acp45/toxin
 	ammo_band_color = AMMO_BAND_COLOR_TOXIN
 
 /obj/item/ammo_magazine/pistol/vp78/penetrating
-	name = "\improper VP78 wall-penetrating magazine (.45 ACP)"
+	name = "\improper VP78-A1 wall-penetrating magazine (.45 ACP)"
 	desc = "A wall-penetrating .45 ACP pistol magazine for the VP78."
 	default_ammo = /datum/ammo/bullet/pistol/acp45/penetrating
 	ammo_band_color = AMMO_BAND_COLOR_PENETRATING
 
 /obj/item/ammo_magazine/pistol/vp78/incendiary
-	name = "\improper VP78 incendiary magazine (.45 ACP)"
+	name = "\improper VP78-A1 incendiary magazine (.45 ACP)"
 	desc = "An incendiary .45 ACP pistol magazine for the VP78."
 	default_ammo = /datum/ammo/bullet/pistol/acp45/incendiary
 	ammo_band_color = AMMO_BAND_COLOR_INCENDIARY
 
 /obj/item/ammo_magazine/pistol/vp78/heap
-	name = "\improper VP78 high explosive armor piercing magazine (.45 ACP)"
+	name = "\improper VP78-A1 high explosive armor piercing magazine (.45 ACP)"
 	default_ammo = /datum/ammo/bullet/pistol/acp45/heap
 	ammo_band_color = AMMO_BAND_COLOR_HEAP
 
 /obj/item/ammo_magazine/pistol/vp78/rubber
-	name = "\improper VP78 rubber magazine (.45 ACP)"
+	name = "\improper VP78-A1 rubber magazine (.45 ACP)"
 	desc = "A .45 ACP pistol magazine for the VP78. This one is loaded with rubber bullets."
 	default_ammo = /datum/ammo/bullet/pistol/acp45/rubber
 	ammo_band_color = AMMO_BAND_COLOR_RUBBER

--- a/code/modules/vehicles/interior/interactable/vendors.dm
+++ b/code/modules/vehicles/interior/interactable/vendors.dm
@@ -255,7 +255,7 @@
 		list("M56 Smartgun Drum", 0, /obj/item/ammo_magazine/smartgun, VENDOR_ITEM_REGULAR),
 		list("M56D Drum Magazine",0, /obj/item/ammo_magazine/m56d, VENDOR_ITEM_REGULAR),
 		list("SU-6 Smartpistol Magazine (.45)", floor(scale * 2), /obj/item/ammo_magazine/pistol/smart, VENDOR_ITEM_REGULAR),
-		list("VP78 Magazine", floor(scale * 1.5), /obj/item/ammo_magazine/pistol/vp78, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Magazine", floor(scale * 1.5), /obj/item/ammo_magazine/pistol/vp78, VENDOR_ITEM_REGULAR),
 
 		list("BUILDING MATERIALS", -1, null, null),
 		list("Cardboard x10", 1, /obj/item/stack/sheet/cardboard/small_stack, VENDOR_ITEM_REGULAR),
@@ -469,7 +469,7 @@
 
 		list("SIDEARMS", -1, null, null),
 		list("88 Mod 4 Combat Pistol", floor(scale * 2), /obj/item/weapon/gun/pistol/mod88, VENDOR_ITEM_REGULAR),
-		list("VP78 Pistol", floor(scale * 1.5), /obj/item/weapon/gun/pistol/vp78, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Pistol", floor(scale * 1.5), /obj/item/weapon/gun/pistol/vp78, VENDOR_ITEM_REGULAR),
 
 		list("EXPLOSIVES", -1, null, null),
 		list("M12 Blast Grenade", 0, /obj/item/explosive/grenade/high_explosive/pmc, VENDOR_ITEM_REGULAR),
@@ -495,7 +495,7 @@
 		list("NSG 23 Magazine (10x24mm)", floor(scale * 5), /obj/item/ammo_magazine/rifle/nsg23, VENDOR_ITEM_REGULAR),
 		list("M41A MK2 Magazine (10x24mm)", floor(scale * 10), /obj/item/ammo_magazine/rifle, VENDOR_ITEM_REGULAR),
 		list("M39 HV Magazine (10x20mm)", floor(scale * 6), /obj/item/ammo_magazine/smg/m39, VENDOR_ITEM_REGULAR),
-		list("VP78 Magazine (9mm)", 0, /obj/item/ammo_magazine/pistol/vp78, VENDOR_ITEM_REGULAR),
+		list("VP78-A1 Magazine (9mm)", 0, /obj/item/ammo_magazine/pistol/vp78, VENDOR_ITEM_REGULAR),
 		list("ARMOR-PIERCING AMMUNITION", -1, null, null),
 		list("88 Mod 4 AP Magazine (9mm)", floor(scale * 8), /obj/item/ammo_magazine/pistol/mod88, VENDOR_ITEM_REGULAR),
 		list("M4RA AP Magazine (10x24mm)", 0, /obj/item/ammo_magazine/rifle/nsg23/ap, VENDOR_ITEM_REGULAR),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Re-chambers the VP78 in .45 ACP, making it the VP78-A1. This is completely a cosmetic change, as the VP already used a custom "squash head" 9mm round.

Adds an extended lore description to the weapon, which includes a snippit about the original caliber's performance.

# Explain why it's good for the game

9mm simply does not have the stopping power to give it the performance that we see-in game. Its distinction as a squash-head round would actually make it *worse* at penetrating armor than default pistol ammunition.

Never hurts to add some realism and flavor to the game.

# Testing Photographs and Procedure

No repathing was necessary due to the original typepath remaining the same for everything except the actual loose bullets, which are not present on any map.

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Antlers
refactor: VP78 is now chambered in .45 ACP, making it the VP78-A1
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
