### PR TITLE
Atomizing #11357 Part Two: Fixes #10916 and makes smart tanks flushable.

### DIFF
--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -390,6 +390,30 @@
 		filling.color = mix_color_from_reagents(reagents.reagent_list)
 		overlays += filling
 
+/obj/item/reagent_container/glass/minitank/verb/flush_tank()
+	set category = "Object"
+	set name = "Flush Tank"
+	set desc = "Flush the minitank to empty its reagents."
+	set src in usr
+
+	if(usr.is_mob_incapacitated())
+		return
+
+	if(reagents.total_volume <= 0)
+		to_chat(usr, SPAN_NOTICE("[src] is already empty."))
+		return
+
+	to_chat(usr, SPAN_NOTICE("You hold down the emergency flush button. Wait 3 seconds..."))
+
+	if(!do_after(usr, 3 SECONDS, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
+		to_chat(usr, SPAN_WARNING("You get distracted and stop trying to empty [src]."))
+		return
+
+	playsound(src.loc, 'sound/effects/slosh.ogg', 25, 1, 3)
+	to_chat(usr, SPAN_WARNING("You work the flush valve and successfully flush [src]'s contents!"))
+	reagents.clear_reagents()
+	update_icon()
+
 /obj/item/reagent_container/glass/beaker/large
 	name = "large beaker"
 	desc = "A large beaker. Can hold up to 120 units."

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -352,29 +352,32 @@
 		var/obj/item/reagent_container/hypospray/autoinjector/autoinjector = thing
 		//how much to subtract from the tank to refill the autoinjector
 		var/amount = (autoinjector.reagents.maximum_volume - autoinjector.reagents.total_volume)
-
 		if(autoinjector.reagents.total_volume >= autoinjector.reagents.maximum_volume) //Autoinjector is full!
 			to_chat(user, SPAN_NOTICE("[autoinjector] is full."))
 			return FALSE
 		else
-			if(istype(autoinjector, /obj/item/reagent_container/hypospray/autoinjector/research)) //Autoinjector says, "Where's my pouch?"
-				to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'MS-11 SmartFlow valve compatibility test with [autoinjector]'s pressurized reagent canister receiver valve failed."))
-				return FALSE
-			if(autoinjector.is_stimpack) //Wait a minute...
-				to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'MS-11 SmartFlow valve compatibility test with [autoinjector]'s stimpack receiver valve failed."))
-				return FALSE
-			if(autoinjector.is_crystal) //No error message. It's a crystal, right? It totally doesn't have medicine in it.
-				return FALSE
-			else if(autoinjector.cannot_refill)
-				to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'MS-11 SmartFlow valve compatibility test with [autoinjector]'s custom multi-reagent receiver valve failed.'"))
-				return FALSE
-			else if(!reagents.has_reagent(autoinjector.chemname, amount)) // Not enough reagents in the tank to refill the autoinjector.
+			if(!(is_type_in_list(autoinjector, chem_refill)))
+				if(istype(autoinjector, /obj/item/reagent_container/hypospray/autoinjector/research)) //Autoinjector says, "Where's my pouch?"
+					to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'MS-11 SmartFlow valve compatibility test with [autoinjector]'s pressurized reagent canister receiver valve failed."))
+					return FALSE
+				if(autoinjector.is_stimpack) //Wait a minute...
+					to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'MS-11 SmartFlow valve compatibility test with [autoinjector]'s stimpack receiver valve failed."))
+					return FALSE
+				if(istype(autoinjector, /obj/item/reagent_container/hypospray/autoinjector/yautja))//No error message. It's a crystal, right? It totally doesn't have medicine in it.
+					return FALSE
+				else if(autoinjector.cannot_refill)
+					to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'MS-11 SmartFlow valve compatibility test with [autoinjector]'s custom multi-reagent receiver valve failed.'"))
+					return FALSE
+				else
+					to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'MS-11 SmartFlow valve compatibility test with [autoinjector]'s receiver valve failed.'"))
+					return FALSE
+			if(!reagents.has_reagent(autoinjector.chemname, amount)) // Not enough reagents in the tank to refill the autoinjector.
 				to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'Refill failed. [amount]u [autoinjector.chemname] is required to completely refill [autoinjector].'"))
 				return FALSE
 
 		//FINALLY, the good shit that actually fills the autoinjector!
 		reagents.trans_id_to(autoinjector, autoinjector.chemname, amount) //fill this bih
-		autoinjector.uses_left = autoinjector.max_uses
+		autoinjector.uses_left =  autoinjector.initial(volume) / autoinjector.amount_per_transfer_from_this
 		autoinjector.update_icon()
 		playsound(src.loc, 'sound/effects/refill.ogg', 25, 1, 3)
 		to_chat(user, SPAN_INFO("You successfully refill [autoinjector] with [src]!"))

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -347,9 +347,9 @@
 /obj/item/reagent_container/glass/minitank/on_reagent_change()
 	update_icon()
 
-/obj/item/reagent_container/glass/minitank/attackby(obj/item/item as obj, mob/user as mob)
-	if(istype(item, /obj/item/reagent_container/hypospray/autoinjector))
-		var/obj/item/reagent_container/hypospray/autoinjector/autoinjector = item
+/obj/item/reagent_container/glass/minitank/attackby(obj/item/thing as obj, mob/user as mob)
+	if(istype(thing, /obj/item/reagent_container/hypospray/autoinjector))
+		var/obj/item/reagent_container/hypospray/autoinjector/autoinjector = thing
 		var/amount = (autoinjector.reagents.maximum_volume - autoinjector.reagents.total_volume)
 
 		if(autoinjector.reagents.total_volume >= autoinjector.reagents.maximum_volume) //Autoinjector is full!
@@ -357,12 +357,16 @@
 			return FALSE
 		else
 			if(istype(autoinjector, /obj/item/reagent_container/hypospray/autoinjector/research)) //Autoinjector says, "Where's my pouch?"
-				to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'Custom PRCP valve detected in [autoinjector]. Compatibility test failed.'"))
+				to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'MS-11 SmartFlow valve compatibility test with [autoinjector]'s pressurized reagent canister receiver valve failed."))
 				return FALSE
-			else if(autoinjector.is_crystal || autoinjector.is_stimpack) //These aren't autoinjectors. The tank won't bother for error messages.
+			if(autoinjector.is_stimpack) //Wait a minute...
+				to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'MS-11 SmartFlow valve compatibility test with [autoinjector]'s stimpack receiver valve failed."))
+				return FALSE
+			if(autoinjector.is_crystal) //Hold up...
+				to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'MS-11 SmartFlow valve compatibility test with %ERROR!%'s %UNDEFINED% receiver valve failed.'"))
 				return FALSE
 			else if(autoinjector.cannot_refill)
-				to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'No refill valve detected on [autoinjector].'"))
+				to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'MS-11 SmartFlow valve compatibility test with [autoinjector]'s custom multi-reagent receiver valve failed.'"))
 				return FALSE
 			else if(!reagents.has_reagent(autoinjector.chemname, amount)) // Not enough reagents in the tank to refill the autoinjector.
 				to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'Refill failed. [amount]u [autoinjector.chemname] required to completely refill [autoinjector].'"))

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -338,43 +338,43 @@
 		/obj/structure/machinery/autodispenser,
 		/obj/structure/machinery/constructable_frame,
 	)
-
+	/// A list of item types that allow reagent refilling.
+	var/list/chem_refill = list(
+		/obj/item/reagent_container/hypospray/autoinjector/standard,
+		/obj/item/reagent_container/hypospray/autoinjector/ez,
+		/obj/item/reagent_container/hypospray/autoinjector/tutorial,
+	)
 /obj/item/reagent_container/glass/minitank/on_reagent_change()
 	update_icon()
 
+/obj/item/reagent_container/glass/minitank/attackby(obj/item/item as obj, mob/user as mob)
+	if(istype(item, /obj/item/reagent_container/hypospray/autoinjector))
+		var/obj/item/reagent_container/hypospray/autoinjector/autoinjector = item
+		var/amount = (autoinjector.reagents.maximum_volume - autoinjector.reagents.total_volume)
 
-/obj/item/reagent_container/glass/minitank/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/reagent_container/hypospray/autoinjector))
-		var/obj/item/reagent_container/hypospray/autoinjector/A = W
-		if(A.mixed_chem)
-			to_chat(user, SPAN_WARNING("The autoinjector doesn't fit into [src]'s valve. It's probably not compatible."))
-			return
-		if(reagents.has_reagent(A.chemname, A.volume))
-			reagents.trans_id_to(A, A.chemname, A.volume)
-			A.uses_left = 3
-			A.update_icon()
-			playsound(src.loc, 'sound/effects/refill.ogg', 25, 1, 3)
+		if(autoinjector.reagents.total_volume >= autoinjector.reagents.maximum_volume) //Autoinjector is full!
+			to_chat(user, SPAN_NOTICE("[autoinjector] is full."))
+			return FALSE
 		else
-			to_chat(user, SPAN_WARNING("A small LED on [src] blinks. The tank can't refill [A] - it's either incompatible or out of chemicals to fill it with!"))
-			. = ..()
-			return
-		to_chat(user, SPAN_INFO("You successfully refill [A] with [src]!"))
+			if(istype(autoinjector, /obj/item/reagent_container/hypospray/autoinjector/research)) //Autoinjector says, "Where's my pouch?"
+				to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'Custom PRCP valve detected in [autoinjector]. Compatibility test failed.'"))
+				return FALSE
+			else if(autoinjector.is_crystal || autoinjector.is_stimpack) //These aren't autoinjectors. The tank won't bother for error messages.
+				return FALSE
+			else if(autoinjector.cannot_refill)
+				to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'No refill valve detected on [autoinjector].'"))
+				return FALSE
+			else if(!reagents.has_reagent(autoinjector.chemname, amount)) // Not enough reagents in the tank to refill the autoinjector.
+				to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'Refill failed. [amount]u [autoinjector.chemname] required to completely refill [autoinjector].'"))
+				return FALSE
 
-/obj/item/reagent_container/glass/minitank/verb/flush_tank()
-	set category = "Object"
-	set name = "Flush Tank"
-	set src in usr
-
-	if(usr.is_mob_incapacitated())
-		return
-	if(src.reagents.total_volume == 0)
-		to_chat(usr, SPAN_WARNING("It's already empty!"))
-		return
-	playsound(src.loc, 'sound/effects/slosh.ogg', 25, 1, 3)
-	to_chat(usr, SPAN_WARNING("You work the flush valve and successfully flush [src]'s contents!"))
-	reagents.clear_reagents()
-	update_icon() // just to be sure
-	return
+		//FINALLY, the good shit that actually fills the autoinjector!
+		reagents.trans_id_to(autoinjector, autoinjector.chemname, amount) //fill this bih
+		autoinjector.uses_left = autoinjector.max_uses
+		autoinjector.update_icon()
+		playsound(src.loc, 'sound/effects/refill.ogg', 25, 1, 3)
+		to_chat(user, SPAN_INFO("You successfully refill [autoinjector] with [src]!"))
+		return TRUE
 
 /obj/item/reagent_container/glass/minitank/update_icon()
 	overlays.Cut()

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -350,6 +350,7 @@
 /obj/item/reagent_container/glass/minitank/attackby(obj/item/thing as obj, mob/user as mob)
 	if(istype(thing, /obj/item/reagent_container/hypospray/autoinjector))
 		var/obj/item/reagent_container/hypospray/autoinjector/autoinjector = thing
+		//how much to subtract from the tank to refill the autoinjector
 		var/amount = (autoinjector.reagents.maximum_volume - autoinjector.reagents.total_volume)
 
 		if(autoinjector.reagents.total_volume >= autoinjector.reagents.maximum_volume) //Autoinjector is full!
@@ -368,7 +369,7 @@
 				to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'MS-11 SmartFlow valve compatibility test with [autoinjector]'s custom multi-reagent receiver valve failed.'"))
 				return FALSE
 			else if(!reagents.has_reagent(autoinjector.chemname, amount)) // Not enough reagents in the tank to refill the autoinjector.
-				to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'Refill failed. [amount]u [autoinjector.chemname] required to completely refill [autoinjector].'"))
+				to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'Refill failed. [amount]u [autoinjector.chemname] is required to completely refill [autoinjector].'"))
 				return FALSE
 
 		//FINALLY, the good shit that actually fills the autoinjector!

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -362,8 +362,7 @@
 			if(autoinjector.is_stimpack) //Wait a minute...
 				to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'MS-11 SmartFlow valve compatibility test with [autoinjector]'s stimpack receiver valve failed."))
 				return FALSE
-			if(autoinjector.is_crystal) //Hold up...
-				to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'MS-11 SmartFlow valve compatibility test with %ERROR!%'s %UNDEFINED% receiver valve failed.'"))
+			if(autoinjector.is_crystal) //No error message. It's a crystal, right? It totally doesn't have medicine in it.
 				return FALSE
 			else if(autoinjector.cannot_refill)
 				to_chat(user, SPAN_WARNING("[src]'s small LED blinks red and its robotic synthesizer says, 'MS-11 SmartFlow valve compatibility test with [autoinjector]'s custom multi-reagent receiver valve failed.'"))

--- a/code/modules/cm_tech/implements/stims.dm
+++ b/code/modules/cm_tech/implements/stims.dm
@@ -62,11 +62,13 @@
 	chemname = "speed_stimulant"
 	desc = "A stimpack loaded with an experimental performance enhancement stimulant. Extremely muscle-stimulating. Lasts 5 minutes."
 	maptext_label = "StSp"
+
 /obj/item/reagent_container/hypospray/autoinjector/stimulant/brain_stimulant
 	name = "brain stimulant stimpack"
 	chemname = "brain_stimulant"
 	desc = "A stimpack loaded with an experimental CNS stimulant. Extremely nerve-stimulating. Lasts 5 minutes."
 	maptext_label = "StBr"
+
 /obj/item/reagent_container/hypospray/autoinjector/stimulant/redemption_stimulant
 	amount_per_transfer_from_this = 5
 	volume = 5

--- a/code/modules/cm_tech/implements/stims.dm
+++ b/code/modules/cm_tech/implements/stims.dm
@@ -40,6 +40,7 @@
 	volume = 5
 	uses_left = 1
 	display_maptext = TRUE
+	is_stimpack = TRUE
 
 /obj/item/reagent_container/hypospray/autoinjector/stimulant/update_icon()
 	overlays.Cut()
@@ -61,13 +62,11 @@
 	chemname = "speed_stimulant"
 	desc = "A stimpack loaded with an experimental performance enhancement stimulant. Extremely muscle-stimulating. Lasts 5 minutes."
 	maptext_label = "StSp"
-
 /obj/item/reagent_container/hypospray/autoinjector/stimulant/brain_stimulant
 	name = "brain stimulant stimpack"
 	chemname = "brain_stimulant"
 	desc = "A stimpack loaded with an experimental CNS stimulant. Extremely nerve-stimulating. Lasts 5 minutes."
 	maptext_label = "StBr"
-
 /obj/item/reagent_container/hypospray/autoinjector/stimulant/redemption_stimulant
 	amount_per_transfer_from_this = 5
 	volume = 5


### PR DESCRIPTION

# About the pull request

**IGNORE THE LINTER. THIS SHOULD BE MERGED WITH 12785 OR AFTER #12785 IS MERGED.**
Fixes #10916 

And makes smart tanks flushable.

# Explain why it's good for the game
#12785 might break smart tanks. This fixes it.

Makes 11357 easier to review. Already tested in that PR.

Fixes #10916 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Puckaboo2
add: Smart tanks are now flushable.
add: Smart tanks now accept the correct autoinjectors and reject the rest. They currently accept Wey-Med Standard, Wey-Med EZ, Wey-Med one-use autoinjectors, and Wey-Med training autoinjectors.
code: Smart tanks utilize the new autoinjector pathing system to decide what to refill, so any future autoinjector paths nested within the accepted parent paths will automatically be accepted.
fix: Smart tanks are no longer ambiguous about what they fill.
fix: Smart tanks no longer waste chemicals. They know the maximum volume and current volume of every autoinjector they analyze and will dispense accordingly.
qol: Smart tanks know when they're empty and know when an autoinjector is full. Instead of an 'empty' error message, they tell you how much of a reagent they need to top off a partially-used or refill an empty autoinjector.
qol: Smart tanks only fill 4 types of autoinjectors and that's it. No stimpacks, no custom and research autos, and no strange rocks. There are error messages for each of them. 
/:cl:
