### PR TITLE
Fix adjust brute and fireloss usages that don't update health

### DIFF
--- a/code/datums/tutorial/marine/medical_basic.dm
+++ b/code/datums/tutorial/marine/medical_basic.dm
@@ -20,6 +20,7 @@
 	message_to_player("The first kind of damage is <b>Brute</b>, the most common kind. It represents physical trauma from things like punches, weapons, or guns.")
 	var/mob/living/living_mob = tutorial_mob
 	living_mob.adjustBruteLoss(10)
+	living_mob.updatehealth()
 	addtimer(CALLBACK(src, PROC_REF(brute_tutorial_2)), 4 SECONDS)
 
 /datum/tutorial/marine/medical_basic/proc/brute_tutorial_2()
@@ -54,6 +55,7 @@
 	update_objective("")
 	var/mob/living/living_mob = tutorial_mob
 	living_mob.adjustFireLoss(10)
+	living_mob.updatehealth()
 	addtimer(CALLBACK(src, PROC_REF(burn_tutorial)), 4 SECONDS)
 
 /datum/tutorial/marine/medical_basic/proc/burn_tutorial()

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -914,6 +914,7 @@
 	recalculate_stats()
 	var/amt_to_death = health - health_threshold_dead
 	adjustBruteLoss(amt_to_death - 5)
+	updatehealth()
 
 /mob/living/carbon/xenomorph/prepare_huds()
 	..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Facehugger.dm
@@ -284,9 +284,10 @@
 	name = "Base Facehugger Behavior Delegate"
 
 /datum/behavior_delegate/facehugger_base/on_life()
-	if(!(locate(/obj/effect/alien/weeds) in get_turf(bound_xeno)))
-		bound_xeno.adjustBruteLoss(2)
-
+	if(locate(/obj/effect/alien/weeds) in get_turf(bound_xeno))
+		return
+	bound_xeno.adjustBruteLoss(2)
+	bound_xeno.updatehealth()
 
 /datum/action/xeno_action/activable/pounce/facehugger/use_ability(atom/target_atom)
 	for(var/obj/structure/machinery/door/airlock/current_airlock in get_turf(owner))

--- a/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/lesser_drone.dm
@@ -127,8 +127,11 @@
 	name = "Base Lesser Drone Behavior Delegate"
 
 /datum/behavior_delegate/lesser_drone_base/on_life()
-	if(bound_xeno.body_position == STANDING_UP && !(locate(/obj/effect/alien/weeds) in get_turf(bound_xeno)))
+	if(locate(/obj/effect/alien/weeds) in get_turf(bound_xeno))
+		return
+	if(bound_xeno.body_position == STANDING_UP)
 		bound_xeno.adjustBruteLoss(5)
+		bound_xeno.updatehealth()
 
 
 /datum/action/xeno_action/onclick/plant_weeds/lesser/use_ability(atom/target_atom)

--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -1675,6 +1675,7 @@
 		return
 	xeno.visible_message(SPAN_XENOWARNING("[xeno] rips out [xeno.iff_tag]!"), SPAN_XENOWARNING("We rip out [xeno.iff_tag]! For the Hive!"))
 	xeno.adjustBruteLoss(50)
+	xeno.updatehealth()
 	xeno.iff_tag.forceMove(get_turf(xeno))
 	xeno.iff_tag = null
 
@@ -1688,6 +1689,7 @@
 			continue
 		xeno.visible_message(SPAN_XENOWARNING("[xeno] rips out [xeno.iff_tag]!"), SPAN_XENOWARNING("We rip out [xeno.iff_tag]! For the hive!"))
 		xeno.adjustBruteLoss(50)
+		xeno.updatehealth()
 		xeno.iff_tag.forceMove(get_turf(xeno))
 		xeno.iff_tag = null
 	if(!length(defectors))

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -197,11 +197,14 @@
 
 
 /mob/living/carbon/xenomorph/handle_regular_status_updates(regular_update = TRUE)
+	var/need_update_health = TRUE
+
 	if(regular_update && health <= 0 && (!caste || (fire_immunity & FIRE_IMMUNITY_NO_IGNITE) || !on_fire)) //Sleeping Xenos are also unconscious, but all crit Xenos are under 0 HP. Go figure
 		if(!check_weeds_for_healing()) //In crit, damage is maximal if you're caught off weeds
 			apply_damage(2.5 - warding_aura*0.5, BRUTE) //Warding can heavily lower the impact of bleedout. Halved at 2.5 phero, stopped at 5 phero
 		else
 			apply_damage(-warding_aura, BRUTE)
+		need_update_health = FALSE
 
 	if(health > 0 && stat != DEAD) //alive and not in crit! Turn on their vision.
 		see_in_dark = 50
@@ -214,9 +217,11 @@
 			blinded = TRUE
 			if(regular_update && halloss > 0)
 				apply_damage(-3, HALLOSS)
+				need_update_health = FALSE
 		else if(sleeping)
 			if(regular_update && halloss > 0)
 				apply_damage(-3, HALLOSS)
+				need_update_health = FALSE
 			if(regular_update && mind)
 				if((mind.active && client != null) || immune_to_ssd)
 					sleeping = max(sleeping - 1, 0)
@@ -231,12 +236,16 @@
 					apply_damage(-3, HALLOSS)
 				else
 					apply_damage(-1, HALLOSS)
+				need_update_health = FALSE
 
 		if(regular_update)
 			if(eye_blurry)
-				src.ReduceEyeBlur(1)
+				ReduceEyeBlur(1)
 
 			handle_statuses()//natural decrease of stunned, knocked_down, etc...
+
+	if(need_update_health)
+		updatehealth()
 
 	return TRUE
 

--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/facehugger/watcher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/facehugger/watcher.dm
@@ -27,3 +27,4 @@
 	if(locate(/obj/effect/alien/weeds) in get_turf(bound_xeno))
 		return
 	bound_xeno.adjustBruteLoss(2)
+	bound_xeno.updatehealth()


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #13018 which removed `updatehealth()` from `/mob/living/carbon/xenomorph/handle_regular_status_updates` so this would mean that huggers/lessers for example would no longer take damage off weeds until they're shot (and then gib for tons of damage)

In addition to just adding some missing `updatehealth()` calls I also situationally restored `updatehealth()` to `/mob/living/carbon/xenomorph/handle_regular_status_updates(regular_update = TRUE)`

# Explain why it's good for the game
Fixes 
<img width="870" height="660" alt="image" src="https://github.com/user-attachments/assets/53f05e1b-9ddd-494e-aaf9-b6a7a6d8ca96" />

and several other places calling `adjustBruteLoss` or `adjustFireLoss` without `updatehealth`


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="1005" height="586" alt="image" src="https://github.com/user-attachments/assets/854b30fa-8ac7-4d86-8698-1eb945e366aa" />

</details>


# Changelog
:cl: Drathek
fix: Fixed some places where damage wasn't updating health (namely facehuggers and lessers off weeds)
/:cl:
