### PR TITLE
Fix: Runed sandstone no longer stacks with regular sandstone

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -147,8 +147,12 @@ GLOBAL_LIST_INIT(iron_recipes, list ( \
 	desc = "Sandstone is sand cemented into stone. A common building material for primitive civilizations, but it can still make a good enough wall. This one has strange runes embued into the brick."
 	singular_name = "runed sandstone brick"
 	icon_state = "sheet-runedsandstone"
+	throw_speed = SPEED_VERY_FAST
+	throw_range = 5
 	amount_sprites = TRUE
 	black_market_value = 15
+	sheettype = "runedsandstone"
+	stack_id = "runedsandstone"
 
 /obj/item/stack/sheet/mineral/sandstone/runed/large_stack
 	amount = STACK_50

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -147,9 +147,6 @@ GLOBAL_LIST_INIT(iron_recipes, list ( \
 	desc = "Sandstone is sand cemented into stone. A common building material for primitive civilizations, but it can still make a good enough wall. This one has strange runes embued into the brick."
 	singular_name = "runed sandstone brick"
 	icon_state = "sheet-runedsandstone"
-	throw_speed = SPEED_VERY_FAST
-	throw_range = 5
-	amount_sprites = TRUE
 	black_market_value = 15
 	sheettype = "runedsandstone"
 	stack_id = "runedsandstone"


### PR DESCRIPTION

# About the pull request

Runed sandstone bricks no longer stack in inventories with regular bricks.

# Explain why it's good for the game

Fixes #13125

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

# Changelog
:cl: Antlers
fix: Runed sandstone bricks no longer stack with their regular counterparts in inventories
/:cl:
