### PR TITLE
Fix: Renames neuropathic property description to NPA

### DIFF
--- a/code/modules/reagents/chemistry_properties/prop_negative.dm
+++ b/code/modules/reagents/chemistry_properties/prop_negative.dm
@@ -187,7 +187,7 @@
 
 /datum/chem_property/negative/neuropathic
 	name = PROPERTY_NEUROPATHIC
-	code = "NPT"
+	code = "NPA"
 	description = "Activates the somatosensory system causing neuropathic pain all over the body. Unlike nociceptive pain, this is not caused to any tissue damage and is solely perceptive."
 	rarity = PROPERTY_UNCOMMON
 	category = PROPERTY_TYPE_STIMULANT


### PR DESCRIPTION

# About the pull request

Renames neuropathic's abbreviation to NPA from NPT, as nephrotoxic already is abbreviated as NPT.

# Explain why it's good for the game
Fixes #13110

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: Antlers
fix: Renamed neuropathic's chemical property abbreviation to "NPA," as "NPT" is already taken by nephrotoxic
/:cl:
