### PR TITLE
Fix: Disallows crawling through holes in the wall by click-dragging while resting/incapacitated

### DIFF
--- a/code/game/objects/effects/acid_hole.dm
+++ b/code/game/objects/effects/acid_hole.dm
@@ -36,11 +36,19 @@
 	return
 
 
-/obj/effect/acid_hole/MouseDrop_T(mob/M, mob/user)
+/obj/effect/acid_hole/MouseDrop_T(mob/entity, mob/user)
 	if (!holed_wall)
 		return
 
-	if(M == user && isxeno(user))
+	if(entity == user && isxeno(user))
+		if (entity.resting)
+			to_chat(user, SPAN_WARNING("You cannot do that while resting!"))
+			return
+
+		if (entity.is_mob_incapacitated())
+			to_chat(user, SPAN_WARNING("You cannot do that while incapacitated!"))
+			return
+
 		use_wall_hole(user)
 
 


### PR DESCRIPTION
…hile resting/incapacitated
# About the pull request

Fixes an issue where xenomorphs could manage to crawl through holes in walls by click-dragging their sprite onto the hole while resting or incapacitated.

# Explain why it's good for the game

Fixes #13086

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

# Changelog
:cl: Antlers
fix: Xenos can no longer crawl through holes in walls while incapacitated or resting by click-dragging their sprite onto the hole
/:cl:
