### PR TITLE
Fix div by zero explosion prop falloff

### DIFF
--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -965,7 +965,7 @@
 /datum/chem_property/positive/explosive/update_reagent()
 	holder.explosive = TRUE
 	holder.power += level
-	holder.falloff_modifier += -3 / level
+	holder.falloff_modifier += -3 / max(level, 1)
 	..()
 
 //properties for CAS matrixes


### PR DESCRIPTION

# About the pull request

This PR simply fixes a place where a level 0 property would cause a division by zero runtime. From what I can tell there are no other places where level is the divisor. Falloff now is just at the worst level (1).

# Explain why it's good for the game

Fixes https://runtimes.cm-ss13.com/cm13/issues/3874

# Changelog
:cl: Drathek
fix: Fixed a div by zero runtime with explosion properties at level 0
/:cl:
