### PR TITLE
fix runtime in clean_observe_target()

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -368,8 +368,9 @@ GLOBAL_LIST_EMPTY_TYPED(all_cameras, /obj/structure/machinery/camera)
 
 /obj/structure/machinery/camera/cas/proc/view_directly(mob/living/carbon/human/user)
 	viewing_users += user
-	user.client?.set_eye(get_turf(src))
-	user.client?.perspective = EYE_PERSPECTIVE
+	if(user.client)
+		user.client.set_eye(get_turf(src))
+		user.client.perspective = EYE_PERSPECTIVE
 
 /obj/structure/machinery/camera/cas/proc/remove_from_view(mob/living/carbon/human/user)
 	viewing_users -= user

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -368,9 +368,10 @@ GLOBAL_LIST_EMPTY_TYPED(all_cameras, /obj/structure/machinery/camera)
 
 /obj/structure/machinery/camera/cas/proc/view_directly(mob/living/carbon/human/user)
 	viewing_users += user
-	if(user.client)
-		user.client.set_eye(get_turf(src))
-		user.client.perspective = EYE_PERSPECTIVE
+	var/client/user_client = user.client
+	if(user_client)
+		user_client.set_eye(get_turf(src))
+		user_client.perspective = EYE_PERSPECTIVE
 
 /obj/structure/machinery/camera/cas/proc/remove_from_view(mob/living/carbon/human/user)
 	viewing_users -= user

--- a/code/game/objects/effects/landmarks/landmarks.dm
+++ b/code/game/objects/effects/landmarks/landmarks.dm
@@ -778,7 +778,7 @@
 		GLOB.zombie_landmarks -= src
 	anim(loc, loc, 'icons/mob/mob.dmi', null, "zombie_rise", 12, SOUTH)
 	observer.see_invisible = SEE_INVISIBLE_LIVING
-	observer.client.set_eye(src) // gives the player a second to orient themselves to the spawn zone
+	observer.client?.set_eye(src) // gives the player a second to orient themselves to the spawn zone
 	addtimer(CALLBACK(src, PROC_REF(handle_zombie_spawn), observer), 1 SECONDS)
 
 /obj/effect/landmark/zombie/proc/handle_zombie_spawn(mob/dead/observer/observer)
@@ -786,7 +786,7 @@
 	if(!zombie.hud_used)
 		zombie.create_hud()
 	arm_equipment(zombie, /datum/equipment_preset/other/zombie, randomise = TRUE, count_participant = TRUE, mob_client = observer.client, show_job_gear = TRUE)
-	observer.client.set_eye(zombie)
+	observer.client?.set_eye(zombie)
 	observer.mind.transfer_to(zombie)
 	if(spawns_left <= 0)
 		qdel(src)

--- a/code/game/objects/structures/pipes/pipes.dm
+++ b/code/game/objects/structures/pipes/pipes.dm
@@ -151,7 +151,7 @@
 		return
 
 	user.forceMove(next_pipe)
-	user.client.set_eye(next_pipe) //if we don't do this, Byond only updates the eye every tick - required for smooth movement
+	user.client?.set_eye(next_pipe) //if we don't do this, Byond only updates the eye every tick - required for smooth movement
 	user.update_pipe_icons(next_pipe)
 
 	if(world.time - user.last_played_vent > VENT_SOUND_DELAY)

--- a/code/modules/admin/verbs/mob_verbs.dm
+++ b/code/modules/admin/verbs/mob_verbs.dm
@@ -298,7 +298,7 @@
 	usr.forceMove(O)
 	usr.real_name = O.name
 	usr.name = O.name
-	usr.client.set_eye(O)
+	usr.client?.set_eye(O)
 	usr.control_object = O
 
 /client/proc/release(obj/O as obj in world)
@@ -318,7 +318,7 @@
 			H.change_real_name(H, usr.name_archive)
 
 	usr.forceMove(O.loc )// Appear where the object you were controlling is -- TLE
-	usr.client.set_eye(usr)
+	usr.client?.set_eye(usr)
 	usr.control_object = null
 
 /client/proc/cmd_admin_drop_everything(mob/M as mob in GLOB.mob_list)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -193,8 +193,7 @@
 	observe_target_mob = null
 	observe_target_client = null
 
-	if(client)
-		client.set_eye(src)
+	client?.set_eye(src)
 	hud_used.show_hud(hud_used.hud_version, src)
 	UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -193,7 +193,8 @@
 	observe_target_mob = null
 	observe_target_client = null
 
-	client.set_eye(src)
+	if(client)
+		client.set_eye(src)
 	hud_used.show_hud(hud_used.hud_version, src)
 	UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
 


### PR DESCRIPTION

# About the pull request

fixed a runtime in clean_observe_target() by adding a check for a client
fixes: #13134

# Explain why it's good for the game

it is better to miss out on calling this proc than to have 8000 runtimes


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: fixed runtime in clean_observe_target() by adding a check for a client
fix: other possible set_eye related runtimes from lacking a client
/:cl:
