### PR TITLE
fix runtime with adding and removing ahelp verb

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -884,7 +884,7 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 //
 
 /client/proc/giveadminhelpverb()
-	if(!src)
+	if(!src || !istype(src, /client)) // non-clients, like the dummy client, will cause a runtime if this is ran
 		return
 	add_verb(src, /client/proc/adminhelp)
 	deltimer(adminhelptimerid)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -417,8 +417,9 @@ SET_PROTECTED_DATUM(/datum/admin_help)
 
 //Removes the ahelp verb and returns it after 2 minutes
 /datum/admin_help/proc/TimeoutVerb()
-	remove_verb(initiator, /client/proc/adminhelp)
-	initiator.adminhelptimerid = addtimer(CALLBACK(initiator, /client/proc/giveadminhelpverb), 1200, TIMER_STOPPABLE) //2 minute cooldown of admin helps
+	if(istype(initiator, /client))
+		remove_verb(initiator, /client/proc/adminhelp)
+		initiator.adminhelptimerid = addtimer(CALLBACK(initiator, /client/proc/giveadminhelpverb), 1200, TIMER_STOPPABLE) //2 minute cooldown of admin helps
 
 //private
 /datum/admin_help/proc/FullMonty(ref_src)


### PR DESCRIPTION

# About the pull request

the automatic ahelps from the dummy client (datum) would runtime because it would try to remove and add the ahelp verb to a non-client

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: runtime when trying to add and remove the ahelp verb from a dummy client
/:cl:
