### PR TITLE
Disable mob in src verbs from being added on equip + Deck keybinds

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -111,6 +111,10 @@
 #define COMSIG_KB_LIVING_LOOKDOWN_DOWN "keybinding_living_lookdown_down"
 #define COMSIG_KB_LIVING_REST_DOWN "keybinding_living_rest_down"
 #define COMSIG_KB_LIVING_CANCEL_CAMERA_VIEW "keybinding_movement_cancel_camera_view"
+#define COMSIG_KB_LIVING_DRAW_CARD "keybinding_draw_card"
+#define COMSIG_KB_LIVING_DRAW_X_CARDS "keybinding_draw_x_cards"
+#define COMSIG_KB_LIVING_DRAW_PILE_CONCEALED "keybinding_draw_pile_concealed"
+#define COMSIG_KB_LIVING_DEAL_CARD "keybinding_deal_card"
 
 //Mob
 #define COMSIG_KB_MOB_FACENORTH_DOWN "keybinding_mob_facenorth_down"

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -113,3 +113,83 @@
 	var/mob/living/user_mob = user.mob
 	user_mob.look_up()
 	return TRUE
+
+/datum/keybinding/living/draw_card
+	hotkey_keys = list("Unbound")
+	classic_keys = list("Unbound")
+	name = "draw_card"
+	full_name = "Draw Card"
+	description = ""
+	keybind_signal = COMSIG_KB_LIVING_DRAW_CARD
+
+/datum/keybinding/living/draw_card/down(client/user)
+	. = ..()
+	if (.)
+		return
+
+	if(!isliving(user.mob))
+		return
+
+	var/mob/living/user_mob = user.mob
+	winset(user_mob, null, "command=draw")
+	return TRUE
+
+/datum/keybinding/living/draw_x_cards
+	hotkey_keys = list("Unbound")
+	classic_keys = list("Unbound")
+	name = "draw_x_cards"
+	full_name = "Draw X Cards"
+	description = ""
+	keybind_signal = COMSIG_KB_LIVING_DRAW_X_CARDS
+
+/datum/keybinding/living/draw_x_cards/down(client/user)
+	. = ..()
+	if (.)
+		return
+
+	if(!isliving(user.mob))
+		return
+
+	var/mob/living/user_mob = user.mob
+	winset(user_mob, null, "command=draw-x-cards")
+	return TRUE
+
+/datum/keybinding/living/draw_pile_concealed
+	hotkey_keys = list("Unbound")
+	classic_keys = list("Unbound")
+	name = "draw_pile_concealed"
+	full_name = "Draw Pile (Concealed)"
+	description = ""
+	keybind_signal = COMSIG_KB_LIVING_DRAW_PILE_CONCEALED
+
+/datum/keybinding/living/draw_pile_concealed/down(client/user)
+	. = ..()
+	if (.)
+		return
+
+	if(!isliving(user.mob))
+		return
+
+	var/mob/living/user_mob = user.mob
+	winset(user_mob, null, "command=draw-pile-(concealed)")
+	return TRUE
+
+/datum/keybinding/living/deal_card
+	hotkey_keys = list("Unbound")
+	classic_keys = list("Unbound")
+	name = "deal_card"
+	full_name = "Deal Card"
+	description = ""
+	keybind_signal = COMSIG_KB_LIVING_DEAL_CARD
+
+/datum/keybinding/living/deal_card/down(client/user)
+	. = ..()
+	if (.)
+		return
+
+	if(!isliving(user.mob))
+		return
+
+	var/mob/living/user_mob = user.mob
+	winset(user_mob, null, "command=deal")
+	return TRUE

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -288,6 +288,9 @@ Buildable meters
 	..()
 	setDir(old_dir) // Retain old dir since these rotate in hand
 
+/obj/item/pipe/item_action_slot_check(mob/user, slot)
+	return FALSE // Do not add our verbs to mobs
+
 // rotate the pipe item clockwise
 /obj/item/pipe/verb/rotate()
 	set category = "Object"

--- a/code/game/objects/items/cpr_dummy.dm
+++ b/code/game/objects/items/cpr_dummy.dm
@@ -69,6 +69,9 @@
 		failed_cprs++
 	cpr_cooldown = world.time + 7 SECONDS
 
+/obj/item/cpr_dummy/item_action_slot_check(mob/user, slot)
+	return FALSE // Do not add our verbs to mobs
+
 /obj/item/cpr_dummy/verb/reset_counter()
 	set name = "Reset CPR Counter"
 	set category = "Object"

--- a/code/game/objects/items/devices/autopsy_scanner.dm
+++ b/code/game/objects/items/devices/autopsy_scanner.dm
@@ -70,6 +70,9 @@
 		if(O.trace_chemicals[V] > 0 && !chemtraces.Find(V))
 			chemtraces += V
 
+/obj/item/device/autopsy_scanner/item_action_slot_check(mob/user, slot)
+	return FALSE // Do not add our verbs to mobs
+
 /obj/item/device/autopsy_scanner/verb/print_data()
 	set category = "Object"
 	set src in view(usr, 1)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -297,6 +297,9 @@
 /obj/item/device/flashlight/lamp/tripod/grey
 	icon_state = "tripod_lamp_grey"
 
+/obj/item/device/flashlight/lamp/item_action_slot_check(mob/user, slot)
+	return FALSE // Do not add our verbs to mobs
+
 /obj/item/device/flashlight/lamp/verb/toggle_light()
 	set name = "Toggle light"
 	set category = "Object"

--- a/code/game/objects/items/devices/pinpointer.dm
+++ b/code/game/objects/items/devices/pinpointer.dm
@@ -112,6 +112,9 @@
 			icon_state = "pinonfar"
 	spawn(5) .()
 
+/obj/item/device/pinpointer/advpinpointer/item_action_slot_check(mob/user, slot)
+	return FALSE // Do not add our verbs to mobs
+
 /obj/item/device/pinpointer/advpinpointer/verb/toggle_mode()
 	set category = "Object"
 	set name = "Toggle Pinpointer Mode"

--- a/code/game/objects/items/reagent_containers/blood_pack.dm
+++ b/code/game/objects/items/reagent_containers/blood_pack.dm
@@ -162,6 +162,9 @@
 	connected_from = null
 	update_beam()
 
+/obj/item/reagent_container/blood/item_action_slot_check(mob/user, slot)
+	return FALSE // Do not add our verbs to mobs
+
 /obj/item/reagent_container/blood/verb/toggle_mode()
 	set category = "Object"
 	set name = "Toggle Mode"

--- a/code/game/objects/items/toys/cards.dm
+++ b/code/game/objects/items/toys/cards.dm
@@ -108,6 +108,9 @@
 	else
 		icon_state = "[base_icon]_open"
 
+/obj/item/toy/deck/item_action_slot_check(mob/user, slot)
+	return FALSE // Do not add our verbs to mobs because set src sucks
+
 /obj/item/toy/deck/verb/draw_card()
 	set category = "Object"
 	set name = "Draw"

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -117,6 +117,8 @@
 	icon_state = "mousetraparmed"
 	armed = 1
 
+/obj/item/device/assembly/mousetrap/item_action_slot_check(mob/user, slot)
+	return FALSE // Do not add our verbs to mobs
 
 /obj/item/device/assembly/mousetrap/verb/hide_under()
 	set src in oview(1)

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -89,6 +89,9 @@
 	else
 		icon_state = "paper_bin1"
 
+/obj/item/paper_bin/item_action_slot_check(mob/user, slot)
+	return FALSE // Do not add our verbs to mobs
+
 /obj/item/paper_bin/verb/set_paper_type()
 	set name = "Switch Paper Type"
 	set category = "Object"


### PR DESCRIPTION

# About the pull request

This PR disables all item verbs being added to stat panel on equip I could find that use `set src in view` or `set src in oview` (This one just would be a dead verb tho). Also adds 4 deck verb keybinds since they aren't as easily accessible now with the change.

Leme know if I should do it some other way than winset tho. Just seemed unnecessary to need to replicate the same src set logic in each keybind to search for nearby decks.

https://www.byond.com/forum/post/2952549 Is also related to verbs but remains an outstanding byond issue.

# Explain why it's good for the game

Fixes runtimes like https://runtimes.cm-ss13.com/cm13/issues/3873
<img width="761" height="230" alt="image" src="https://github.com/user-attachments/assets/7883b46b-bdb2-4c12-8e6b-8cc2bd0acf28" />


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Broken: 
<img width="304" height="264" alt="image" src="https://github.com/user-attachments/assets/559827bb-eded-43cd-9d65-780485c0d6f6" />

Broken: 
<img width="511" height="784" alt="image" src="https://github.com/user-attachments/assets/a5e8ca5c-149e-4f6a-9edb-e20b2d62eca8" />

Fixed: 
<img width="1919" height="1279" alt="image" src="https://github.com/user-attachments/assets/b54c78ad-24ed-44eb-b255-595d2a4e0223" />

Still works on the deck: 
<img width="447" height="388" alt="image" src="https://github.com/user-attachments/assets/dff597d9-a69e-4f03-9815-f7f52de3b8a7" />

New keybinds: 
<img width="400" height="500" alt="image" src="https://github.com/user-attachments/assets/e08f9d08-da0a-48ce-b7a6-24fa2f528218" />

<img width="957" height="947" alt="winset" src="https://github.com/user-attachments/assets/bcbef422-5b66-4290-bf57-a1f8dd460ee3" />

</details>


# Changelog
:cl: Drathek
fix: Fixed some item verbs being able to use a mob as source (this removes them from the object verbs in stat panel tho)
qol: Added 4 deck verb keybinds (draw card, draw x cards, draw pile, deal)
/:cl:
