### PR TITLE
Fix blocking sentry requests

### DIFF
--- a/code/controllers/subsystem/sentry.dm
+++ b/code/controllers/subsystem/sentry.dm
@@ -139,7 +139,7 @@ SUBSYSTEM_DEF(sentry)
 		var/event_header = "{\"type\":\"event\",\"length\":[length(event)]}"
 		var/assembled = "[header]\n[event_header]\n[event]\n"
 
-		rustg_http_request_blocking(RUSTG_HTTP_METHOD_POST, endpoint, assembled, headers, null)
+		rustg_http_request_fire_and_forget(RUSTG_HTTP_METHOD_POST, endpoint, assembled, headers, null)
 
 	envelopes.Cut()
 


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #11902 where a change for debugging purposes ended up being merged.

# Explain why it's good for the game

There is no need to have subsystems waiting for a sentry runtime notification to finish resolving.

# Changelog
:cl: Drathek
fix: Fixed sentry subsystem using blocking http requests
/:cl:
