### PR TITLE
Optimization: icon2base64 rust-g call optimization

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -844,9 +844,13 @@ world
 	)
 	var/extern_result = rustg_iconforge_generate_headless("tmp/forged.png", json_encode(list("sprite" = sprite_object)), TRUE)
 
-	if (extern_result["file_path"] != "tmp/forged.png" || !fexists("tmp/forged.png"))
+	var/icon64 = ""
+	if (fexists("tmp/forged.png"))
+		icon64 = rustg_hash_file(RUSTG_RNG_FORMAT_BASE64, "tmp/forged.png")
+
+	if (extern_result["file_path"] != "tmp/forged.png" || icon64 == "")
 		// Rust-g errored out, fall back to old implementation
-		log_debug("External rust-g library call for icon2base64 errored out! Reverting to legacy fallback implementation.")
+		log_debug("External rust-g library call for icon2base64 failed! Reverting to legacy fallback implementation.")
 
 		var/savefile/save_buffer = new /savefile("tmp/forged.sav")
 		save_buffer["icon"] << icon(icon_file, icon_state = icon_state)
@@ -861,7 +865,7 @@ world
 		return
 
 	// No need to delete temp file, it'll be overridden by next proc call
-	return rustg_encode_base64(rustg_file_read("tmp/forged.png"))
+	return icon64
 
 /**
  * Center's an image.

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -873,6 +873,7 @@ world
 	fdel("tmp/forged.sav")
 
 /// Applies rustg TRANSFORM_OBJECT calls in-house, allowing icons to be manipulated even if rustg fails during the iconforge process.
+/// This function will continue execution even if an individual transform object fails. In the case that it does, it will return FALSE. Otherwise, it will return TRUE.
 ///
 /// YOU SHOULD NOT BE USING THIS UNLESS YOU KNOW WHAT YOU'RE DOING!
 /// To learn, read the documentation for iconforge at:
@@ -1007,6 +1008,14 @@ world
 				if (isnull(y2))
 					y2 = y1
 				icon.DrawBox(color, x1, y1, x2, y2)
+
+			else
+				var/mystery_type = transform["type"]
+				if (isnull(mystery_type))
+					stack_trace("encountered a null rustg transform object during transform processing")
+				else
+					stack_trace("unknown rustg transform object [transform["type"]] encountered during transform processing")
+				. = FALSE
 
 /**
  * Center's an image.

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -831,7 +831,7 @@ world
 /proc/BlendRGB(rgb1, rgb2, amount)
 	return rgb_gradient(amount, 0, rgb1, 1, rgb2, "loop")
 
-/proc/icon2base64(icon_file, icon_state)
+/proc/icon2base64(icon_file, icon_state, list/list/transforms = list())
 	if (!icon_exists(icon_file, icon_state, TRUE))
 		return
 
@@ -840,7 +840,7 @@ world
 		icon_state = icon_state,
 		dir = SOUTH,
 		frame = 1,
-		transform = list()
+		transform = transforms
 	)
 	var/extern_result = rustg_iconforge_generate_headless("tmp/forged.png", json_encode(list("sprite" = sprite_object)), TRUE)
 
@@ -850,22 +850,163 @@ world
 
 	if (extern_result["file_path"] != "tmp/forged.png" || icon64 == "")
 		// Rust-g errored out, fall back to old implementation
-		log_debug("External rust-g library call for icon2base64 failed! Reverting to legacy fallback implementation.")
-
-		var/savefile/save_buffer = new /savefile("tmp/forged.sav")
-		save_buffer["icon"] << icon(icon_file, icon_state = icon_state)
-
-		var/icon_data = save_buffer.ExportText("icon")
-		var/list/split_data = splittext(icon_data, "{")
-		. = replacetext(copytext_char(split_data[2], 3, -5), "\n", "")
-
-		save_buffer.Unlock()
-		save_buffer = null
-		fdel("tmp/forged.sav")
-		return
+		stack_trace("External rust-g library call for icon2base64 failed! Reverting to legacy fallback implementation.")
+		var/icon/icon = icon(icon = icon_file, icon_state = icon_state)
+		apply_rustg_transforms(icon, transforms)
+		return icon2base64_costly(icon)
 
 	// No need to delete temp file, it'll be overridden by next proc call
 	return icon64
+
+/// Costly version of icon2base64 that should only really be used if the base function fails for some reason.
+/// Uses native /savefile calls and therefore should be more robust in the event of an error.
+/proc/icon2base64_costly(icon/icon)
+	var/savefile/save_buffer = new /savefile("tmp/forged.sav")
+	save_buffer["icon"] << icon
+
+	var/icon_data = save_buffer.ExportText("icon")
+	var/list/split_data = splittext(icon_data, "{")
+	. = replacetext(copytext_char(split_data[2], 3, -5), "\n", "")
+
+	save_buffer.Unlock()
+	save_buffer = null
+	fdel("tmp/forged.sav")
+
+/// Applies rustg TRANSFORM_OBJECT calls in-house, allowing icons to be manipulated even if rustg fails during the iconforge process.
+///
+/// YOU SHOULD NOT BE USING THIS UNLESS YOU KNOW WHAT YOU'RE DOING!
+/// To learn, read the documentation for iconforge at:
+/// https://github.com/cmss13-devs/cmss13/blob/5811a26e6389ab4d06f960efc8db59bb6dd7b380/code/__DEFINES/__rust_g.dm#L337
+/proc/apply_rustg_transforms(icon/icon, list/list/transforms)
+	. = TRUE
+	for (var/list/transform in transforms)
+		switch (transform["type"])
+			if (RUSTG_ICONFORGE_BLEND_COLOR)
+				var/color = transform["color"]
+				var/blend_mode = transform["blend_mode"]
+				if (isnull(color) || isnull(blend_mode))
+					stack_trace("rustg transform object BLEND_COLOR is missing required fields")
+					. = FALSE
+					continue
+				icon.Blend(transform["color"], transform["blend_mode"])
+
+			if (RUSTG_ICONFORGE_BLEND_ICON)
+				var/sprite_object = transform["icon"]
+				var/blend_mode = transform["blend_mode"]
+				if (isnull(sprite_object) || isnull(blend_mode))
+					stack_trace("rustg transform object BLEND_ICON is missing required fields")
+					. = FALSE
+					continue
+
+				var/icon_file = sprite_object["icon_file"]
+				var/icon_state = sprite_object["icon_state"]
+				if (!icon_exists(icon_file, icon_state))
+					stack_trace("rustg transform object BLEND_ICON has a SPRITE_OBJECT that points to a non-existant icon ([sprite_object["icon_file"]], state:[sprite_object["icon_state"]])")
+					. = FALSE
+					continue
+				var/icon/blend_sprite = icon(icon_file, icon_state = icon_state)
+
+				var/x_offset = transform["x"]
+				var/y_offset = transform["y"]
+				if (!isnull(x_offset) && !isnull(y_offset))
+					icon.Blend(blend_sprite, transform["blend_mode"], x_offset, y_offset)
+				else if (!isnull(x_offset))
+					icon.Blend(blend_sprite, transform["blend_mode"], x_offset)
+				else if (!isnull(y_offset))
+					icon.Blend(blend_sprite, transform["blend_mode"], y = y_offset)
+				else
+					icon.Blend(blend_sprite, transform["blend_mode"])
+
+			if (RUSTG_ICONFORGE_SCALE)
+				var/width = transform["width"]
+				var/height = transform["height"]
+				if (isnull(width) || isnull(height))
+					stack_trace("rustg transform object SCALE is missing required fields")
+					. = FALSE
+					continue
+				icon.Scale(width, height)
+
+			if (RUSTG_ICONFORGE_CROP)
+				var/x1 = transform["x1"]
+				var/y1 = transform["y1"]
+				var/x2 = transform["x2"]
+				var/y2 = transform["y2"]
+
+				if (isnull(x1) || isnull(y1) || isnull(x1) || isnull(y2))
+					stack_trace("rustg transform object CROP is missing required fields")
+					. = FALSE
+					continue
+				icon.Crop(x1, y1, x2, y2)
+
+			if (RUSTG_ICONFORGE_MAP_COLORS)
+				var/list/required_fields = list("rr", "rg", "rb", "ra", "gr", "gg", "gb", "ga", "br", "bg", "bb", "ba", "ar", "ag", "ab", "aa")
+				var/missing_required_field = FALSE
+				for (var/field_key in required_fields)
+					if (isnull(transform[field_key]))
+						stack_trace("rustg transform object MAP_COLORS is missing required field: [field_key]")
+						missing_required_field = TRUE
+						break
+				if (missing_required_field)
+					. = FALSE
+					continue
+
+				icon.MapColors(
+					transform["rr"], transform["rg"], transform["rb"], transform["ra"],
+					transform["gr"], transform["gg"], transform["gb"], transform["ga"],
+					transform["br"], transform["bg"], transform["bb"], transform["ba"],
+					transform["ar"], transform["ag"], transform["ab"], transform["aa"]
+				)
+
+			if (RUSTG_ICONFORGE_FLIP)
+				var/dir = transform["dir"]
+				if (isnull(dir))
+					stack_trace("rustg transform object FLIP is missing required field: dir")
+					. = FALSE
+					continue
+				icon.Flip(dir)
+
+			if (RUSTG_ICONFORGE_TURN)
+				var/angle = transform["angle"]
+				if (isnull(angle))
+					stack_trace("rustg transform object TURN is missing required field: angle")
+					. = FALSE
+					continue
+				icon.Turn(angle)
+
+			if (RUSTG_ICONFORGE_SHIFT)
+				var/dir = transform["dir"]
+				var/offset = transform["offset"]
+				var/wrap = transform["wrap"]
+				if (isnull(dir) || isnull(offset) || isnull(wrap))
+					stack_trace("rustg transform object SHIFT is missing required fields")
+					. = FALSE
+					continue
+				icon.Shift(dir, offset, wrap)
+
+			if (RUSTG_ICONFORGE_SWAP_COLOR)
+				var/src_color = transform["src_color"]
+				var/dst_color = transform["dst_color"]
+				if (isnull(src_color) || isnull(dst_color))
+					stack_trace("rustg transform object SWAP_COLOR is missing required fields")
+					. = FALSE
+					continue
+				icon.SwapColor(src_color, dst_color)
+
+			if (RUSTG_ICONFORGE_DRAW_BOX)
+				var/color = transform["color"]
+				var/x1 = transform["x1"]
+				var/y1 = transform["y1"]
+				var/x2 = transform["x2"]
+				var/y2 = transform["y2"]
+				if (isnull(color) || isnull(x1) || isnull(y1))
+					stack_trace("rustg transform object DRAW_BOX is missing required fields")
+					. = FALSE
+					continue
+				if (isnull(x2))
+					x2 = x1
+				if (isnull(y2))
+					y2 = y1
+				icon.DrawBox(color, x1, y1, x2, y2)
 
 /**
  * Center's an image.

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -846,6 +846,8 @@ world
 
 	if (extern_result["file_path"] != 'tmp/forged.png')
 		// Rust-g errored out, fall back to old implementation
+		log_debug("External rust-g library call for icon2base64 errored out! Reverting to legacy fallback implementation.")
+
 		var/savefile/save_buffer = new /savefile("tmp/forged.sav")
 		save_buffer["icon"] << icon(icon_file, icon_state = icon_state)
 

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1019,7 +1019,7 @@ world
 				if (isnull(mystery_type))
 					stack_trace("encountered a null rustg transform object during transform processing")
 				else
-					stack_trace("unknown rustg transform object [transform["type"]] encountered during transform processing")
+					stack_trace("unknown rustg transform object [mystery_type] encountered during transform processing")
 				. = FALSE
 
 /**

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -844,7 +844,7 @@ world
 	)
 	var/extern_result = rustg_iconforge_generate_headless("tmp/forged.png", json_encode(list("sprite" = sprite_object)), TRUE)
 
-	if (extern_result["file_path"] != 'tmp/forged.png')
+	if (extern_result["file_path"] != "tmp/forged.png" || !fexists("tmp/forged.png"))
 		// Rust-g errored out, fall back to old implementation
 		log_debug("External rust-g library call for icon2base64 errored out! Reverting to legacy fallback implementation.")
 

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -831,6 +831,11 @@ world
 /proc/BlendRGB(rgb1, rgb2, amount)
 	return rgb_gradient(amount, 0, rgb1, 1, rgb2, "loop")
 
+/// Converts a given icon_file with an icon_state into a base64 string.
+/// Accepts a list of TRANSFORM_OBJECTs that can be applied to perform icon manipulation before the icon is "rendered" to base64.
+///
+/// For more information about TRANSFORM_OBJECTs, see rust-g documentation:
+/// https://github.com/cmss13-devs/cmss13/blob/5811a26e6389ab4d06f960efc8db59bb6dd7b380/code/__DEFINES/__rust_g.dm#L337-L347
 /proc/icon2base64(icon_file, icon_state, list/list/transforms = list())
 	if (!icon_exists(icon_file, icon_state, TRUE))
 		return
@@ -877,7 +882,7 @@ world
 ///
 /// YOU SHOULD NOT BE USING THIS UNLESS YOU KNOW WHAT YOU'RE DOING!
 /// To learn, read the documentation for iconforge at:
-/// https://github.com/cmss13-devs/cmss13/blob/5811a26e6389ab4d06f960efc8db59bb6dd7b380/code/__DEFINES/__rust_g.dm#L337
+/// https://github.com/cmss13-devs/cmss13/blob/5811a26e6389ab4d06f960efc8db59bb6dd7b380/code/__DEFINES/__rust_g.dm#L337-L347
 /proc/apply_rustg_transforms(icon/icon, list/list/transforms)
 	. = TRUE
 	for (var/list/transform in transforms)

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -850,7 +850,7 @@ world
 
 	if (extern_result["file_path"] != "tmp/forged.png" || icon64 == "")
 		// Rust-g errored out, fall back to old implementation
-		stack_trace("External rust-g library call for icon2base64 failed! Reverting to legacy fallback implementation.")
+		log_debug("External rust-g library call for icon2base64 failed! Reverting to legacy fallback implementation.")
 		var/icon/icon = icon(icon = icon_file, icon_state = icon_state)
 		apply_rustg_transforms(icon, transforms)
 		return icon2base64_costly(icon)

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -831,17 +831,35 @@ world
 /proc/BlendRGB(rgb1, rgb2, amount)
 	return rgb_gradient(amount, 0, rgb1, 1, rgb2, "loop")
 
-/proc/icon2base64(icon/icon)
-	if(!isicon(icon))
-		return FALSE
-	var/savefile/dummySave = new("tmp/dummySave.sav")
-	dummySave["dummy"] << icon
-	var/iconData = dummySave.ExportText("dummy")
-	var/list/partial = splittext(iconData, "{")
-	. = replacetext(copytext_char(partial[2], 3, -5), "\n", "")  //if cleanup fails we want to still return the correct base64
-	dummySave.Unlock()
-	dummySave = null
-	fdel("tmp/dummySave.sav")  //if you get the idea to try and make this more optimized, make sure to still call unlock on the savefile after every write to unlock it.
+/proc/icon2base64(icon_file, icon_state)
+	if (!icon_exists(icon_file, icon_state, TRUE))
+		return
+
+	var/sprite_object = list(
+		icon_file = icon_file,
+		icon_state = icon_state,
+		dir = SOUTH,
+		frame = 1,
+		transform = list()
+	)
+	var/extern_result = rustg_iconforge_generate_headless("tmp/forged.png", json_encode(list("sprite" = sprite_object)), TRUE)
+
+	if (extern_result["file_path"] != 'tmp/forged.png')
+		// Rust-g errored out, fall back to old implementation
+		var/savefile/save_buffer = new /savefile("tmp/forged.sav")
+		save_buffer["icon"] << icon(icon_file, icon_state = icon_state)
+
+		var/icon_data = save_buffer.ExportText("icon")
+		var/list/split_data = splittext(icon_data, "{")
+		. = replacetext(copytext_char(split_data[2], 3, -5), "\n", "")
+
+		save_buffer.Unlock()
+		save_buffer = null
+		fdel("tmp/forged.sav")
+		return
+
+	// No need to delete temp file, it'll be overridden by next proc call
+	return rustg_encode_base64(rustg_file_read("tmp/forged.png"))
 
 /**
  * Center's an image.

--- a/code/_globalvars/global_lists.dm
+++ b/code/_globalvars/global_lists.dm
@@ -44,17 +44,11 @@ GLOBAL_LIST_EMPTY(mainship_pipes)
 GLOBAL_LIST_EMPTY(cached_maps)
 
 /proc/initiate_minimap_icons()
-	var/list/icons = list()
+	var/base64_icons = list()
 	for(var/iconstate in icon_states('icons/UI_icons/map_blips.dmi'))
-		var/icon/image = icon('icons/UI_icons/map_blips.dmi', icon_state = iconstate)
-		icons[iconstate] += image
-
-	var/list/base64_icons = list()
-	for(var/iconstate in icons)
-		base64_icons[iconstate] = icon2base64(icons[iconstate])
+		base64_icons[iconstate] = icon2base64('icons/UI_icons/map_blips.dmi', iconstate)
 
 	GLOB.minimap_icons = base64_icons
-
 
 
 // Xeno stuff //

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -384,7 +384,7 @@
 
 		LAZYINITLIST(result)
 
-		result["icon"] = icon2base64(icon(item.icon, item.icon_state, frame = 1))
+		result["icon"] = icon2base64(item.icon, item.icon_state)
 		result["name"] = item.name
 		result["alternate"] = item_data.get_alternate_action(owner, user)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Optimizes `icon2base64` by replacing slow, native savefile calls with a call to `rust-g`'s `rustg_iconforge_generate_headless`, making icon conversion 2.5x as fast.
Legacy icon conversion is kept in the codebase as a fallback option.

This should make server initialization faster, as well as mitigate lag spikes related to opening the inventory stripping panel on individuals.

# Explain why it's good for the game

Currently `icon2base64` takes up quite a significant amount of self time when reviewing aggregated data from the most recent 100 rounds. It's no surprise why, considering it writes to a temporary save file and then uses that to return a base64 representation of an icon. Using rust-g's library calls to bypass the native savefile implementation in its entirety promises better performance.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

Benchmarked using [wrench-extra](https://github.com/Lohikar/wrench-extra/blob/master/util.dm):

<details>
<summary>Original implementation: (60 runs/tick)</summary>

Benchmark verb:
```
CLIENT_VERB(bench_icon_conversion)
	set name = "Bench icon2base64"
	set category = "Admin"

	var/icon/icon = icon('icons/UI_icons/map_blips.dmi')
	var/list/icon/icon_states = list()
	for(var/icon_state in icon_states(icon))
		icon_states += icon('icons/UI_icons/map_blips.dmi', icon_state = icon_state)

	BEGIN_BENCH_WITH_SAMPLES(1, 1000)
		BENCH_EXPR("init_minimap_icons", icon2base64(pick(icon_states)))
	END_BENCH
	to_chat(mob, SPAN_INFO("Benchmark complete."))
```
Benchmark output:
```
<~>
n (samples) = 1000
tick_lag = 0.5 (~20 Hz)

init_minimap_icons:
	~60 (± 4) runs/tick (95% confidence: 59 .. 60)
<~>
```
</details>

<details>
<summary>Rust-g implementation: (163 runs/tick)</summary>

Benchmark verb:
```
CLIENT_VERB(bench_icon_conversion)
	set name = "Bench icon2base64"
	set category = "Admin"

	var/icon/icon = icon('icons/UI_icons/map_blips.dmi')
	var/list/icon_states = list()
	for(var/icon_state in icon_states(icon))
		icon_states += icon_state

	BEGIN_BENCH_WITH_SAMPLES(1, 1000)
		BENCH_EXPR("init_minimap_icons", icon2base64('icons/UI_icons/map_blips.dmi', pick(icon_states)))
	END_BENCH
	to_chat(mob, SPAN_INFO("Benchmark complete."))
```
Benchmark output:
```
<~>
n (samples) = 1000
tick_lag = 0.5 (~20 Hz)

init_minimap_icons:
	~163 (± 14) runs/tick (95% confidence: 162 .. 164)
<~>
```
</details>

<details>
<summary>Screenshots & Videos</summary>
<img width="250" height="200" alt="image" src="https://github.com/user-attachments/assets/871a0c44-cc85-4802-9952-478eeee39c6c" />

<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/19992ff6-d025-4a39-8a5b-746a756c6d13" />
</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
code: icon2base64 now uses external rust-g calls instead of slow native /savefile calls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
