### PR TITLE
Being flayed makes you unrecognizable

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -198,6 +198,7 @@
 #define MUTINY_LOYALIST (1<<8) // Allied with command.
 #define MUTINY_NONCOMBAT (1<<9) // NON COMBATANT.
 #define MOB_ABSTRACT (1<<10) //! This mob is a proxy for gameplay functions, it shouldn't be treated as a full-on mob for gameplay
+#define MOB_FLAYED (1<<11)	//set if the mob has been flayed
 
 //=================================================
 

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -267,6 +267,8 @@
 #define TRAIT_WEED_RESISTANT "weed_resistant"
 /// Mob can open xeno doors and hugger/traps ignore them
 #define TRAIT_XENO_RECOGNIZED "xeno_recognized"
+// Mob thats flayed
+#define TRAIT_FLAYED "t_flayed"
 
 // -- ability traits --
 /// Xenos with this trait cannot have plasma transferred to them

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -267,8 +267,6 @@
 #define TRAIT_WEED_RESISTANT "weed_resistant"
 /// Mob can open xeno doors and hugger/traps ignore them
 #define TRAIT_XENO_RECOGNIZED "xeno_recognized"
-// Mob thats flayed
-#define TRAIT_FLAYED "t_flayed"
 
 // -- ability traits --
 /// Xenos with this trait cannot have plasma transferred to them

--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -916,7 +916,9 @@
 				victim.apply_damage(22, BRUTE, limb, sharp = TRUE)
 			for(var/obj/item/item in victim)
 				victim.drop_inv_item_to_loc(item, victim.loc, FALSE, TRUE)
-				victim.status_flags |= PERMANENTLY_DEAD
+			victim.status_flags |= PERMANENTLY_DEAD
+			ADD_TRAIT(victim, TRAIT_FLAYED, user)
+			victim.name = "???"
 			victim.add_flay_overlay(stage = 3)
 
 			//End the loop and remove all references to the datum.

--- a/code/modules/cm_preds/yaut_weapons.dm
+++ b/code/modules/cm_preds/yaut_weapons.dm
@@ -917,7 +917,7 @@
 			for(var/obj/item/item in victim)
 				victim.drop_inv_item_to_loc(item, victim.loc, FALSE, TRUE)
 			victim.status_flags |= PERMANENTLY_DEAD
-			ADD_TRAIT(victim, TRAIT_FLAYED, user)
+			victim.mob_flags |= MOB_FLAYED
 			victim.name = "???"
 			victim.add_flay_overlay(stage = 3)
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -16,7 +16,7 @@
 			msg += "[icon2html(icon, user)] "
 		msg += "<EM>[src]</EM>"
 
-		if(HAS_TRAIT(src, TRAIT_FLAYED))
+		if(mob_flags & MOB_FLAYED)
 			msg += " Its outer flesh has been removed...\n"
 		else
 			msg += "!\n"
@@ -110,7 +110,7 @@
 
 	msg += "<EM>[src]</EM>"
 
-	if(HAS_TRAIT(src, TRAIT_FLAYED))
+	if(mob_flags & MOB_FLAYED)
 		msg += " You cannot tell anymore, [t_He] doesn't have a face!\n"
 		msg += SPAN_BOLDWARNING("[uppertext(t_his)] SKIN HAS BEEN PEELED OFF.\n")
 	else

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -14,7 +14,12 @@
 
 		if(icon)
 			msg += "[icon2html(icon, user)] "
-		msg += "<EM>[src]</EM>!\n"
+		msg += "<EM>[src]</EM>"
+
+		if(HAS_TRAIT(src, TRAIT_FLAYED))
+			msg += " Its outer flesh has been removed...\n"
+		else
+			msg += "!\n"
 
 		if(species && species.flags & IS_SYNTHETIC)
 			msg += "<span style='font-weight: bold; color: purple;'>You sense this creature is not organic.\n</span>"
@@ -102,7 +107,14 @@
 
 	if(id_paygrade)
 		msg += "<EM>[rank_display] </EM>"
-	msg += "<EM>[src]</EM>!\n"
+
+	msg += "<EM>[src]</EM>"
+
+	if(HAS_TRAIT(src, TRAIT_FLAYED))
+		msg += " You cannot tell anymore, [t_He] doesn't have a face!\n"
+		msg += SPAN_BOLDWARNING("[uppertext(t_his)] SKIN HAS BEEN PEELED OFF.\n")
+	else
+		msg += "!\n"
 
 	//uniform
 	if(w_uniform && !skipjumpsuit)


### PR DESCRIPTION

# About the pull request

If someone gets flayed, their corpse becomes unrecognizable (loses its name). Unless you're intimately familiar with every single marines bone structure/facial musculature it makes no sense why they'd be recognizable after having their face removed 

# Explain why it's good for the game

Game atmosphere, adds to the horror by correctly simulating how observing a flayed corpse would work.

# Testing Photographs and Procedure
<img width="331" height="339" alt="dreamseeker_OHoc59yYvm" src="https://github.com/user-attachments/assets/4bd10ac0-04f2-4dba-880a-407a14962c1e" />
<img width="556" height="306" alt="dreamseeker_L0nDH693E6" src="https://github.com/user-attachments/assets/dd03f353-1502-4234-86f3-229a550e367d" />

# Changelog

:cl: Kugamo
add: Flayed corpses no longer identifiable by name.
spellcheck: Wording of examined humans' age, size, and build streamlined.
/:cl:
