### PR TITLE
No shuttle mines

### DIFF
--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -90,7 +90,12 @@
 	if(active || user.action_busy)
 		return
 
-	if(antigrief_protection && user.faction == FACTION_MARINE && explosive_antigrief_check(src, user))
+	var/turf/open/target_turf = user.loc
+	if(!istype(target_turf))
+		to_chat(user, SPAN_WARNING("You can't deploy that here!"))
+		return
+
+	if(antigrief_protection && user.faction == FACTION_MARINE && (explosive_antigrief_check(src, user) || !target_turf.allow_mines))
 		to_chat(user, SPAN_WARNING("\The [name]'s safe-area accident inhibitor prevents you from planting!"))
 		msg_admin_niche("[key_name(user)] attempted to plant \a [name] in [ADMIN_VERBOSEJMP(src)]")
 		return

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -8,6 +8,8 @@
 	var/allow_construction = TRUE //whether you can build things like barricades on this turf.
 	var/wet = 0 //whether the turf is wet (only used by floors).
 	var/supports_surgery = TRUE
+	/// Whether the turf allows mines when doing antigrief_protection checks
+	var/allow_mines = TRUE
 	var/scorchable = FALSE //if TRUE set to be an icon_state which is the full sprite version of whatever gets scorched --> for border turfs like grass edges and shorelines
 	var/scorchedness = 0 //how scorched is this turf 0 to 3
 	var/icon_state_before_scorching //this is really dumb, blame the mappers...
@@ -1316,10 +1318,12 @@
 	icon = 'icons/turf/shuttle.dmi'
 	allow_construction = FALSE
 	supports_surgery = FALSE
+	allow_mines = FALSE
 
 /turf/open/shuttle/can_surgery
 	allow_construction = TRUE
 	supports_surgery = TRUE
+	allow_mines = TRUE
 
 /turf/open/shuttle/can_surgery/blue
 	name = "floor"


### PR DESCRIPTION

# About the pull request

This PR makes it so marines cannot deploy antigrief checking mines in shuttle turfs; as well as just generally in non-open turfs.

Leme know if there's other turf types that need to be included or excluded; or if I shouldn't even check antigrief mines at all.

# Explain why it's good for the game

Mechanical enforcement against rule breaks.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

<img width="1802" height="843" alt="image" src="https://github.com/user-attachments/assets/d95e0bc8-e3c2-4909-aa8e-f4b97bbe4ec2" />

</details>


# Changelog
:cl: Drathek
balance: Marines can no longer deploy mines in shuttle turfs
/:cl:
