### PR TITLE
Barrel charger fix and barrels rebalance + logic

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -542,6 +542,7 @@ Defined in conflicts.dm of the #defines folder.
 /obj/item/attachable/extended_barrel/New()
 	..()
 	accuracy_mod = HIT_ACCURACY_MULT_TIER_4
+	damage_mod = BULLET_DAMAGE_MULT_TIER_1
 	velocity_mod = AMMO_SPEED_TIER_1
 
 /obj/item/attachable/extended_barrel/vented
@@ -604,6 +605,7 @@ Defined in conflicts.dm of the #defines folder.
 	accuracy_mod = -HIT_ACCURACY_MULT_TIER_3
 	damage_mod = BULLET_DAMAGE_MULT_TIER_6
 	delay_mod = FIRE_DELAY_TIER_11
+	velocity_mod = AMMO_SPEED_TIER_1
 
 	accuracy_unwielded_mod = -HIT_ACCURACY_MULT_TIER_7
 
@@ -779,6 +781,8 @@ Defined in conflicts.dm of the #defines folder.
 	accuracy_mod = HIT_ACCURACY_MULT_TIER_4
 	scatter_mod = -SCATTER_AMOUNT_TIER_6
 	delay_mod = FIRE_DELAY_TIER_7
+	damage_mod = BULLET_DAMAGE_MULT_TIER_2
+	velocity_mod = AMMO_SPEED_TIER_1
 
 /obj/item/attachable/mateba/long/Attach(obj/item/weapon/gun/G)
 	..()
@@ -801,6 +805,7 @@ Defined in conflicts.dm of the #defines folder.
 	accuracy_mod = -HIT_ACCURACY_MULT_TIER_4
 	scatter_mod = SCATTER_AMOUNT_TIER_6
 	delay_mod = -FIRE_DELAY_TIER_7
+	damage_mod = -BULLET_DAMAGE_MULT_TIER_4
 
 /obj/item/attachable/mateba/short/Attach(obj/item/weapon/gun/G)
 	..()


### PR DESCRIPTION

# About the pull request
Gives more logic to extended barrel, barrel charger and rebalancing mateba marksman and snub nosed barrel.

# Explain why it's good for the game
Barrel charger description says - A hyper threaded barrel extender that fits to the muzzle of most firearms. INCREASES BULLET SPEED AND VELOCITY
Greatly increases projectile damage at the cost of accuracy and firing speed. So where? Now it really gives bonus to bullet speed as it should be.
Extended barrel now gives +5% damage boost. The primer ignites the powder, burning powder creates high-pressure gas, that gas pushes the bullet down the barrel a longer barrel lets the gas push the bullet for a longer time/distance, so the bullet accelerates more which means more stopping power and kinetic energy (+ damage).
Marksman barrel using the same logic and gives more reasons to use it
Snub nosed barrel gives -20% damage because it's really meta to spam stun xenos at close range.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: extended barrel gives +5% bullet damage, mateba marksman barrel gives bullet speed bonus and +10% damage, snub nosed gives -20% damage debuff.
balance: barrel charger gives bonus to bullet velocity
/:cl:
