### PR TITLE
[Bug Fix] White Antre Fix Missing Window Floor

### DIFF
--- a/maps/map_files/White_Antre_Research_Facility/White_Antre_Research_Facility.dmm
+++ b/maps/map_files/White_Antre_Research_Facility/White_Antre_Research_Facility.dmm
@@ -55790,10 +55790,6 @@
 	},
 /turf/open/floor/prison/darkpurple2/northeast,
 /area/white_antre/indoors/main_level/east_corridor)
-"wFD" = (
-/obj/structure/window/framed/corsat/hull/research,
-/turf/open_space,
-/area/white_antre/indoors/upper_level/east_overwatch)
 "wGj" = (
 /obj/structure/shuttle/part/dropship_wy/transparent/engine_right_exhaust,
 /turf/open/auto_turf/shale/layer1/weedable,
@@ -167301,11 +167297,11 @@ euM
 euM
 euM
 bZq
-wFD
-wFD
-wFD
-wFD
-wFD
+bFG
+bFG
+bFG
+bFG
+bFG
 bZq
 bZq
 bZq


### PR DESCRIPTION

# About the pull request

Adds a floor to several hull windows that did not have a floor. 

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
maptweak: Fixes several hull window tiles in the researcher observation deck on White Antre Research Facility not having floors underneath them. 
/:cl:
