### PR TITLE
[Bug Fix] Reinforced wood window frames are now visible

### DIFF
--- a/code/game/objects/structures/window_frame.dm
+++ b/code/game/objects/structures/window_frame.dm
@@ -261,7 +261,7 @@
 
 /obj/structure/window_frame/wood/reinforced
 	icon_state = "wood_window0_frame"
-	basestate = "wood_rwindow"
+	basestate = "wood_window"
 	reinforced = TRUE
 	window_type = /obj/structure/window/framed/wood/reinforced
 


### PR DESCRIPTION

# About the pull request

Reinforced window frames will now appear in game. Previously the frame was referencing an icon that did not exist. 

Fixes #12572

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Reinforced woden window frames will now be visible in game. They were previously invisible. 
/:cl:
