### PR TITLE
White Antre LZ Redesign + Rebalance Of Hull Walls

### DIFF
--- a/maps/map_files/White_Antre_Research_Facility/White_Antre_Research_Facility.dmm
+++ b/maps/map_files/White_Antre_Research_Facility/White_Antre_Research_Facility.dmm
@@ -496,10 +496,6 @@
 /turf/open/floor/prison/darkbrowncorners2/west,
 /area/white_antre/indoors/main_level/east_containment)
 "abB" = (
-/obj/structure/xenoautopsy/tank/broken{
-	desc = "Something with sharp claws broke it, it didn't seem to want to save its occupant...";
-	name = "slashed apart cryo tank"
-	},
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /obj/item/shard{
@@ -560,10 +556,6 @@
 /turf/open/antre/plating/direction_west,
 /area/white_antre/indoors/main_level/east_containment)
 "abI" = (
-/obj/structure/xenoautopsy/tank/broken{
-	desc = "Something with sharp claws broke it, it didn't seem to want to save its occupant...";
-	name = "slashed apart cryo tank"
-	},
 /obj/item/prop/alien/hugger{
 	icon = 'icons/mob/xenos/castes/tier_0/larva.dmi';
 	icon_state = "Larva Dead";
@@ -1097,6 +1089,9 @@
 	},
 /obj/effect/landmark/monkey_spawn,
 /turf/open/floor/prison/floor_plate/southwest,
+/area/white_antre/indoors/main_level/east_containment_hive)
+"acU" = (
+/turf/open/floor/darkish,
 /area/white_antre/indoors/main_level/east_containment_hive)
 "acV" = (
 /obj/effect/landmark/objective_landmark/close,
@@ -2437,16 +2432,6 @@
 	},
 /turf/open/floor/almayer/silverfull,
 /area/white_antre/indoors/main_level/east_containment_hive)
-"afY" = (
-/obj/structure/machinery/door/poddoor/hybrisa/ultra_reinforced_door/open{
-	dir = 2;
-	icon_state = "udoor0"
-	},
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 5
-	},
-/turf/open/floor/corsat/marked,
-/area/white_antre/indoors/main_level/weapons)
 "afZ" = (
 /obj/structure/sink{
 	dir = 8;
@@ -2656,16 +2641,6 @@
 /obj/effect/decal/cleanable/blood/tracks/footprints,
 /turf/open/floor/almayer/research/containment/corner/west,
 /area/white_antre/indoors/upper_level/simian_storage)
-"agM" = (
-/obj/structure/machinery/door/poddoor/hybrisa/ultra_reinforced_door/open{
-	dir = 2;
-	icon_state = "udoor0"
-	},
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 9
-	},
-/turf/open/floor/corsat/marked,
-/area/white_antre/indoors/main_level/weapons)
 "agN" = (
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/white_antre/indoors/upper_level/simian_storage)
@@ -4613,7 +4588,7 @@
 /area/white_antre/indoors/main_level/west_corridor)
 "akT" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 6
+	dir = 4
 	},
 /turf/open/antre/plating/corner_dir/north_east,
 /area/white_antre/indoors/main_level/east_corridor)
@@ -11501,7 +11476,10 @@
 /obj/structure/machinery/colony_floodlight_switch/containment{
 	pixel_x = -28;
 	name = "backup containment light switch";
-	desc = "This switch controls the containment zone floodlights. This appears to be a backup switch kept within the containment zone. This needs to be powered elsewhere."
+	desc = "This switch controls the containment zone floodlights. This appears to be a backup switch kept within the containment zone. This needs to be powered elsewhere.";
+	light_on = 1;
+	light_range = 2;
+	light_power = 2
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/indoors/main_level/east_containment_hive)
@@ -13164,6 +13142,13 @@
 	},
 /turf/open/floor/almayer/silvercorner/north,
 /area/white_antre/indoors/main_level/research)
+"aEl" = (
+/obj/structure/tunnel/maint_tunnel,
+/obj/structure/machinery/colony_floodlight/venir_wall_light{
+	dir = 4
+	},
+/turf/open/floor/almayer/silverfull,
+/area/white_antre/indoors/main_level/east_containment_hive)
 "aEm" = (
 /obj/structure/machinery/space_heater/radiator/red{
 	dir = 4;
@@ -13197,6 +13182,9 @@
 	},
 /turf/open/floor/antre/metal/black/northeast,
 /area/white_antre/indoors/main_level/west_corridor)
+"aEq" = (
+/turf/closed/wall/strata_outpost,
+/area/white_antre/outdoors/south_field)
 "aEr" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -13219,6 +13207,18 @@
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/almayer/emerald2smooth/east,
 /area/white_antre/indoors/main_level/research)
+"aEt" = (
+/obj/structure/machinery/space_heater/radiator/red{
+	dir = 4
+	},
+/turf/open/floor/prison/bluefull,
+/area/white_antre/outdoors/south_field)
+"aEu" = (
+/obj/structure/machinery/light/double{
+	dir = 4
+	},
+/turf/open/floor/prison/bluefull,
+/area/white_antre/outdoors/south_field)
 "aEv" = (
 /obj/structure/machinery/light/double/blue{
 	dir = 8
@@ -13257,6 +13257,9 @@
 	},
 /turf/open/floor/almayer/emerald2smooth/west,
 /area/white_antre/indoors/main_level/research)
+"aEy" = (
+/turf/open/floor/prison/blue/east,
+/area/white_antre/landing_zone/roof)
 "aEz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall/kseries,
@@ -13272,6 +13275,12 @@
 	},
 /turf/open/floor/almayer/silver/west,
 /area/white_antre/indoors/main_level/research)
+"aEB" = (
+/obj/structure/pipes/standard/manifold/hidden/cyan{
+	dir = 1
+	},
+/turf/open/antre/plating/direction_north/north_edge,
+/area/white_antre/indoors/main_level/east_corridor)
 "aEC" = (
 /obj/structure/machinery/recharge_station/alt{
 	dir = 4
@@ -13286,6 +13295,21 @@
 /obj/effect/antre/border,
 /turf/open/floor/prison/darkred2/west,
 /area/white_antre/indoors/underground_level/west_maint)
+"aEF" = (
+/obj/item/prop/alien/hugger{
+	icon = 'icons/mob/xenos/castes/tier_0/larva.dmi';
+	icon_state = "Larva Dead";
+	name = "dead larva";
+	desc = "Looks like it was murdered by another xenomorph?"
+	},
+/obj/effect/decal/cleanable/blood/xeno,
+/obj/effect/decal/cleanable/blood/gibs/xeno,
+/turf/open/floor/prison/floor_marked/southwest,
+/area/white_antre/indoors/main_level/east_containment)
+"aEG" = (
+/obj/structure/largecrate/random/barrel/green,
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/landing_zone)
 "aEH" = (
 /obj/structure/surface/table/almayer{
 	color = "#848484"
@@ -13304,6 +13328,18 @@
 	},
 /turf/open/floor/almayer/emeraldfull2,
 /area/white_antre/indoors/main_level/research)
+"aEI" = (
+/obj/structure/cargo_container/uscm/chinook/left{
+	layer = 3.1
+	},
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/landing_zone)
+"aEJ" = (
+/obj/structure/cargo_container/uscm/chinook/mid{
+	layer = 3.1
+	},
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/landing_zone)
 "aEK" = (
 /obj/structure/machinery/light/double/blue{
 	dir = 4
@@ -13311,6 +13347,12 @@
 /obj/structure/largecrate/empty/case,
 /turf/open/floor/almayer/emerald2smooth/east,
 /area/white_antre/indoors/main_level/research)
+"aEL" = (
+/obj/structure/cargo_container/uscm/right{
+	layer = 3.1
+	},
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/landing_zone)
 "aEM" = (
 /obj/structure/surface/table/reinforced/prison{
 	color = "#6b675e"
@@ -13329,6 +13371,22 @@
 	},
 /turf/open/floor/almayer/emerald2smooth/northeast,
 /area/white_antre/indoors/main_level/research)
+"aEO" = (
+/obj/structure/largecrate/random/barrel/blue,
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/landing_zone)
+"aEP" = (
+/obj/structure/cargo_container/wy/left,
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/landing_zone)
+"aEQ" = (
+/obj/structure/cargo_container/wy/mid,
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/landing_zone)
+"aER" = (
+/obj/structure/cargo_container/wy/right,
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/landing_zone)
 "aES" = (
 /obj/structure/surface/table/reinforced/prison{
 	color = "#6b675e"
@@ -13342,6 +13400,10 @@
 	},
 /turf/open/floor/almayer/silver/west,
 /area/white_antre/indoors/main_level/research)
+"aET" = (
+/obj/structure/largecrate/random/case/double,
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/landing_zone)
 "aEU" = (
 /obj/structure/machinery/big_computers/computerwhite/computer1,
 /obj/effect/decal/warning_stripes{
@@ -13349,6 +13411,9 @@
 	},
 /turf/open/floor/almayer/silver,
 /area/white_antre/indoors/main_level/research)
+"aEV" = (
+/turf/open/floor/hybrisa/metal/zbrownfloor_full,
+/area/white_antre/landing_zone/roof)
 "aEW" = (
 /obj/item/stack/sheet/metal,
 /obj/effect/antre/border/corner{
@@ -13356,6 +13421,10 @@
 	},
 /turf/open/floor/prison/darkpurple2/southeast,
 /area/white_antre/indoors/underground_level/east_maint)
+"aEX" = (
+/obj/structure/largecrate/random,
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/landing_zone)
 "aEY" = (
 /obj/structure/surface/table/reinforced/prison{
 	color = "#6b675e"
@@ -13366,6 +13435,36 @@
 	},
 /turf/open/floor/almayer/silver,
 /area/white_antre/indoors/main_level/research)
+"aEZ" = (
+/obj/structure/machinery/door/airlock/almayer/secure/colony{
+	dir = 2
+	},
+/turf/open/floor/corsat/marked,
+/area/white_antre/landing_zone/roof)
+"aFa" = (
+/obj/structure/largecrate/random/barrel/brown,
+/turf/open/asphalt/cement/cement12,
+/area/white_antre/landing_zone)
+"aFb" = (
+/turf/open/floor/prison/darkyellowfull2,
+/area/white_antre/landing_zone/roof)
+"aFc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/door/airlock/multi_tile/hybrisa/personal/autoname,
+/turf/open/floor/corsat/marked,
+/area/white_antre/landing_zone/roof)
+"aFd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/corsat/marked,
+/area/white_antre/landing_zone/roof)
+"aFe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/framed/strata/reinforced,
+/turf/open/floor/plating,
+/area/white_antre/landing_zone/roof)
+"aFf" = (
+/turf/open/floor/prison/darkyellow2,
+/area/white_antre/landing_zone/roof)
 "aFg" = (
 /obj/item/paper/crumpled{
 	pixel_x = 15;
@@ -13921,6 +14020,9 @@
 /obj/effect/alien/weeds/node/kseries,
 /turf/open/floor/almayer/silver,
 /area/white_antre/indoors/main_level/north_containment_hive)
+"aGq" = (
+/turf/open/floor/prison/darkyellow2/southeast,
+/area/white_antre/landing_zone/roof)
 "aGr" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_21"
@@ -14657,21 +14759,6 @@
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/indoors/main_level/east_containment)
-"aHN" = (
-/obj/structure/cargo_container/hybrisa/containersextended/redleft,
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
-/turf/open/antre/plating/direction_west/west_south,
-/area/white_antre/indoors/main_level/east_corridor)
-"aHO" = (
-/obj/structure/cargo_container/hybrisa/containersextended/redright,
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 9
-	},
-/obj/structure/pipes/standard/simple/hidden/cyan,
-/turf/open/antre/plating/direction_west/west_south,
-/area/white_antre/indoors/main_level/east_corridor)
 "aHP" = (
 /obj/structure/machinery/meter{
 	pixel_y = -30
@@ -14687,11 +14774,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/corsat/marked,
-/area/white_antre/indoors/main_level/east_corridor)
-"aHR" = (
-/obj/structure/cargo_container/horizontal/blue/bottom,
-/obj/structure/pipes/standard/simple/hidden/cyan,
-/turf/open/antre/plating/direction_north/west_edge,
 /area/white_antre/indoors/main_level/east_corridor)
 "aHS" = (
 /obj/structure/flora/pottedplant{
@@ -14727,7 +14809,6 @@
 /turf/open/antre/plating/direction_west/east_east,
 /area/white_antre/indoors/main_level/east_corridor)
 "aHV" = (
-/obj/structure/cargo_container/horizontal/blue/top,
 /obj/structure/pipes/standard/manifold/hidden/cyan{
 	dir = 4
 	},
@@ -14792,19 +14873,6 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/corsat/marked,
-/area/white_antre/indoors/main_level/east_corridor)
-"aIc" = (
-/obj/vehicle/train/cargo/engine,
-/obj/structure/prop/hybrisa/airport/refuelinghose{
-	pixel_x = -25;
-	pixel_y = -87;
-	color = "#36454F";
-	name = "reinforced chain";
-	desc = "A special-issue reinforced chain, coated in a protective film that provides acid protection.";
-	layer = 2.9;
-	dir = 1
-	},
-/turf/open/antre/plating/direction_north/east_edge,
 /area/white_antre/indoors/main_level/east_corridor)
 "aId" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14984,6 +15052,10 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall/kseries,
 /turf/open/floor/prison/floor_plate/southwest,
 /area/white_antre/indoors/main_level/east_containment)
+"aIu" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/darkbrown2/southwest,
+/area/white_antre/landing_zone/roof)
 "aIv" = (
 /obj/structure/flora/bush/snow{
 	icon_state = "snowgrassall_3"
@@ -14998,6 +15070,13 @@
 	},
 /turf/open/auto_turf/snow/layer2,
 /area/white_antre/oob)
+"aIw" = (
+/turf/open/floor/prison/darkbrown2,
+/area/white_antre/landing_zone/roof)
+"aIx" = (
+/obj/structure/machinery/disposal,
+/turf/open/floor/prison/darkbrown2/southeast,
+/area/white_antre/landing_zone/roof)
 "aIy" = (
 /turf/open/floor/almayer/silver/east,
 /area/white_antre/indoors/main_level/research)
@@ -15024,6 +15103,10 @@
 /obj/item/tool/surgery/scalpel,
 /turf/open/floor/strata/white_cyan3,
 /area/white_antre/indoors/upper_level/medical)
+"aID" = (
+/obj/structure/largecrate/random/barrel/black,
+/turf/open/floor/prison/darkyellow2,
+/area/white_antre/landing_zone/roof)
 "aIE" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -15246,6 +15329,10 @@
 /obj/structure/largecrate/empty/case/double,
 /turf/open/floor/almayer/emerald2smooth/west,
 /area/white_antre/indoors/main_level/research)
+"aJb" = (
+/obj/structure/largecrate/random/barrel/medical,
+/turf/open/floor/prison/darkyellowcorners2/west,
+/area/white_antre/landing_zone/roof)
 "aJc" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4;
@@ -15277,6 +15364,12 @@
 	},
 /turf/open/floor/almayer/emerald2smooth/northeast,
 /area/white_antre/indoors/main_level/research)
+"aJg" = (
+/obj/structure/machinery/light/double{
+	dir = 4
+	},
+/turf/open/floor/prison/darkyellow2/east,
+/area/white_antre/landing_zone/roof)
 "aJh" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -15591,13 +15684,9 @@
 /turf/open/antre/plating/west_corner_dir,
 /area/white_antre/indoors/main_level/east_corridor)
 "aKt" = (
-/obj/structure/fence/slim/dark,
-/turf/open/auto_turf/shale/layer1/weedable,
-/area/white_antre/landing_zone)
-"aKu" = (
-/obj/structure/fence/slim/dark/door,
-/turf/open/auto_turf/sand_white/layer0,
-/area/white_antre/landing_zone)
+/obj/structure/largecrate/random,
+/turf/open/floor/prison/darkyellow2/southwest,
+/area/white_antre/landing_zone/roof)
 "aKv" = (
 /turf/closed/wall/hybrisa/research/reinforced,
 /area/white_antre/outdoors/facility_exterior)
@@ -16524,9 +16613,6 @@
 	},
 /turf/open/auto_turf/strata_grass/layer0,
 /area/white_antre/outdoors/north_field)
-"aNx" = (
-/turf/open/asphalt/cement/cement15,
-/area/white_antre/landing_zone)
 "aNy" = (
 /turf/open/asphalt/cement/cement9,
 /area/white_antre/outdoors/north_field)
@@ -16534,10 +16620,12 @@
 /turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/outdoors/path_north)
 "aNA" = (
-/turf/open/asphalt/cement/cement4,
-/area/white_antre/outdoors/north_field)
-"aNB" = (
-/turf/open/floor/prison/darkbrown2/southwest,
+/obj/structure/machinery/door/poddoor/almayer/closed{
+	dir = 2;
+	id = "LZ1_Lockdown_Lo";
+	name = "Emergency Lockdown"
+	},
+/turf/open/floor/corsat/marked,
 /area/white_antre/landing_zone/roof)
 "aNC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16546,13 +16634,6 @@
 "aND" = (
 /turf/open/floor/antre/metal/black,
 /area/white_antre/indoors/upper_level/director_office)
-"aNE" = (
-/turf/open/floor/prison/darkbrown2/southeast,
-/area/white_antre/landing_zone/roof)
-"aNF" = (
-/obj/structure/fence/slim/dark,
-/turf/open/auto_turf/strata_grass/layer0_mud,
-/area/white_antre/landing_zone)
 "aNG" = (
 /obj/effect/decal/strata_decals/mud_corner{
 	dir = 5
@@ -16569,7 +16650,10 @@
 "aNJ" = (
 /turf/open/floor/prison/darkbrown2/west,
 /area/white_antre/landing_zone/roof)
-"aNK" = (
+"aNL" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
 /turf/open/floor/prison/darkbrown2/east,
 /area/white_antre/landing_zone/roof)
 "aNM" = (
@@ -16602,9 +16686,6 @@
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison/darkbrown2/northeast,
 /area/white_antre/landing_zone/roof)
-"aNP" = (
-/turf/open/asphalt/cement/cement14,
-/area/white_antre/outdoors/north_field)
 "aNQ" = (
 /obj/effect/decal/hybrisa/road/corner{
 	dir = 1
@@ -16717,9 +16798,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/green/northeast,
 /area/white_antre/indoors/upper_level/west_corridor)
-"aOh" = (
-/turf/open/asphalt/cement/cement2,
-/area/white_antre/outdoors/north_field)
 "aOi" = (
 /obj/effect/decal/strata_decals/mud_corner{
 	dir = 6
@@ -17316,10 +17394,6 @@
 "aQu" = (
 /turf/open/floor/hybrisa/tile/tilewhite,
 /area/white_antre/indoors/upper_level/xenobio)
-"aQv" = (
-/obj/structure/tunnel/maint_tunnel,
-/turf/open/floor/almayer/silver/northeast,
-/area/white_antre/indoors/main_level/east_containment_hive)
 "aQw" = (
 /obj/effect/antre/border{
 	dir = 1
@@ -19787,13 +19861,6 @@
 	},
 /turf/open/auto_turf/snow/layer2,
 /area/white_antre/outdoors/south_field)
-"aXm" = (
-/obj/structure/prop/colorable_rock/colorable/alt{
-	color = "#5F5F70";
-	dir = 1
-	},
-/turf/open/auto_turf/snow/layer2,
-/area/white_antre/outdoors/south_field)
 "aXn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/cyan{
@@ -19808,12 +19875,6 @@
 /obj/structure/pipes/vents/pump_hybrisa,
 /turf/open/floor/prison/darkbrown2/southwest,
 /area/white_antre/indoors/main_level/south_containment)
-"aXp" = (
-/obj/structure/flora/bush/snow{
-	icon_state = "snowgrassbb_3"
-	},
-/turf/open/auto_turf/snow/layer1,
-/area/white_antre/outdoors/south_field)
 "aXq" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall/kseries,
 /obj/structure/pipes/standard/simple/hidden/cyan{
@@ -20105,12 +20166,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/red,
 /area/white_antre/indoors/main_level/east_containment)
-"aYg" = (
-/obj/structure/machinery/light/double{
-	dir = 4
-	},
-/turf/open/floor/prison/bluefull,
-/area/white_antre/landing_zone/roof)
 "aYh" = (
 /turf/open/antre/plating/corner_dir/south_east,
 /area/white_antre/indoors/main_level/west_corridor)
@@ -20596,6 +20651,16 @@
 	},
 /turf/open/antre/plating/direction_west,
 /area/white_antre/indoors/main_level/east_containment)
+"aZz" = (
+/obj/structure/machinery/door_control/brbutton/alt{
+	id = "LZ1_Lockdown_Lo";
+	name = "remote door-control";
+	pixel_y = -2;
+	pixel_x = 6
+	},
+/obj/structure/surface/table/almayer,
+/turf/open/floor/prison/darkbrownfull2,
+/area/white_antre/landing_zone/roof)
 "aZA" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "test_warning_smooth_red"
@@ -20734,7 +20799,6 @@
 	pixel_x = -14;
 	pixel_y = -7
 	},
-/obj/item/defenses/handheld/tesla_coil,
 /turf/open/floor/prison/redfull,
 /area/white_antre/indoors/main_level/east_containment)
 "aZS" = (
@@ -21105,7 +21169,6 @@
 /turf/open/antre/plating/direction_west/west_south,
 /area/white_antre/indoors/main_level/east_containment)
 "baK" = (
-/obj/structure/prop/hybrisa/vehicles/Small_Truck/Red,
 /obj/effect/antre/border/corner{
 	dir = 8
 	},
@@ -22556,39 +22619,15 @@
 	pixel_y = 4
 	},
 /obj/structure/machinery/light/double,
-/turf/open/floor/prison/darkbrownfull2,
+/turf/closed/wall/strata_outpost,
 /area/white_antre/landing_zone/roof)
 "bdZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkbrown2/west,
 /area/white_antre/landing_zone/roof)
-"bea" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/machinery/disposal,
-/turf/open/floor/prison/darkbrownfull2,
-/area/white_antre/landing_zone/roof)
-"beb" = (
-/obj/structure/surface/rack,
-/obj/item/clothing/head/hardhat/orange{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/clothing/head/hardhat/orange{
-	pixel_y = -8;
-	pixel_x = -7
-	},
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone/roof)
 "bec" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone/roof)
-"bed" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/open/floor/prison/darkbrownfull2,
 /area/white_antre/landing_zone/roof)
 "bee" = (
 /obj/structure/platform_decoration/stone/soro/west,
@@ -22638,22 +22677,17 @@
 	},
 /turf/open/floor/prison/darkbrown2/west,
 /area/white_antre/landing_zone/roof)
-"bem" = (
-/obj/structure/surface/rack,
-/obj/item/stack/sheet/metal/medium_stack,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone/roof)
 "ben" = (
-/obj/structure/largecrate/random/secure,
+/obj/structure/surface/rack,
+/obj/item/clothing/head/hardhat/orange{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/clothing/head/hardhat/orange{
+	pixel_y = -8;
+	pixel_x = -7
+	},
 /turf/open/floor/prison,
-/area/white_antre/landing_zone/roof)
-"beo" = (
-/obj/structure/largecrate/random/barrel/white,
-/turf/open/floor/prison,
-/area/white_antre/landing_zone/roof)
-"bep" = (
-/obj/structure/largecrate,
-/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone/roof)
 "beq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22695,17 +22729,6 @@
 "bev" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkbrown2/east,
-/area/white_antre/landing_zone/roof)
-"bew" = (
-/obj/structure/machinery/space_heater/radiator/red{
-	dir = 8;
-	pixel_x = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/machinery/light/double{
-	dir = 1
-	},
-/turf/open/floor/prison/darkbrownfull2,
 /area/white_antre/landing_zone/roof)
 "bex" = (
 /obj/structure/prop/colorable_rock/colorable{
@@ -22886,6 +22909,10 @@
 /obj/structure/prop/colorable_rock/colorable{
 	color = "#5F5F70";
 	dir = 4
+	},
+/obj/structure/flora/bush/ausbushes/var3/sparsegrass{
+	pixel_x = -14;
+	pixel_y = 3
 	},
 /turf/open/auto_turf/strata_grass/layer0_mud,
 /area/white_antre/outdoors/north_field)
@@ -26401,11 +26428,10 @@
 /turf/open/floor/prison,
 /area/white_antre/indoors/main_level/east_containment_hive)
 "bpj" = (
-/obj/item/reagent_container/food/drinks/coffeecup/wy{
-	pixel_x = -4;
-	pixel_y = -8
+/obj/effect/decal/hybrisa/trash{
+	icon_state = "trash_7"
 	},
-/turf/open/floor/prison/blue,
+/turf/open/floor/prison,
 /area/white_antre/landing_zone/roof)
 "bpk" = (
 /obj/item/weapon/twohanded/folded_metal_chair,
@@ -26905,13 +26931,6 @@
 	},
 /turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/indoors/main_level/east_containment)
-"bqz" = (
-/obj/effect/decal/strata_decals/mud_corner{
-	dir = 8
-	},
-/obj/structure/fence/slim/dark,
-/turf/open/auto_turf/sand_white/layer0,
-/area/white_antre/landing_zone)
 "bqA" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -27654,6 +27673,9 @@
 /obj/effect/spawner/gibspawner/xeno,
 /turf/open/antre/plating/direction_north/east_edge,
 /area/white_antre/indoors/upper_level/east_corridor)
+"bsr" = (
+/turf/open/floor/prison/darkyellow2/west,
+/area/white_antre/landing_zone/roof)
 "bss" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/largecrate/random/barrel,
@@ -29219,31 +29241,6 @@
 	},
 /turf/open/floor/almayer/silver/west,
 /area/white_antre/indoors/main_level/research)
-"bwt" = (
-/obj/effect/antre/border/corner,
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 5
-	},
-/turf/open/floor/antre/metal/black/northwest,
-/area/white_antre/indoors/main_level/west_corridor)
-"bwu" = (
-/obj/effect/antre/border{
-	dir = 1
-	},
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 4
-	},
-/turf/open/floor/antre/metal/black/north,
-/area/white_antre/indoors/main_level/west_corridor)
-"bwv" = (
-/obj/effect/antre/border{
-	dir = 1
-	},
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 9
-	},
-/turf/open/floor/antre/metal/black/north,
-/area/white_antre/indoors/main_level/west_corridor)
 "bww" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/antre/border{
@@ -30447,18 +30444,6 @@
 	},
 /turf/open/floor/almayer/silver/west,
 /area/white_antre/indoors/main_level/research)
-"bzh" = (
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 10
-	},
-/turf/open/antre/plating/west_corner_dir,
-/area/white_antre/indoors/main_level/west_corridor)
-"bzi" = (
-/obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 6
-	},
-/turf/open/antre/plating/direction_west/west_south,
-/area/white_antre/indoors/main_level/west_corridor)
 "bzj" = (
 /obj/item/trash/crushed_cup,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -37112,15 +37097,6 @@
 	},
 /turf/solid_open_space,
 /area/white_antre/oob)
-"bOz" = (
-/obj/structure/platform/stone/strata/east,
-/obj/structure/platform_decoration/metal/almayer_smooth,
-/obj/effect/mist/steam{
-	pixel_x = 8;
-	pixel_y = -9
-	},
-/turf/solid_open_space,
-/area/white_antre/oob)
 "bOA" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/white_antre/indoors/main_level/research)
@@ -37141,39 +37117,11 @@
 	pixel_x = 3;
 	pixel_y = 12
 	},
-/turf/solid_open_space,
-/area/white_antre/oob)
-"bOC" = (
-/obj/effect/mist/steam{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/effect/mist/steam{
-	pixel_x = 3;
-	pixel_y = 12
-	},
-/turf/solid_open_space,
-/area/white_antre/oob)
-"bOD" = (
-/obj/structure/platform/stone/strata/east,
-/obj/effect/mist/steam{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/turf/solid_open_space,
+/turf/closed/wall/strata_ice,
 /area/white_antre/oob)
 "bOE" = (
 /turf/open/floor/almayer/silver/northeast,
 /area/white_antre/indoors/main_level/research)
-"bOF" = (
-/obj/structure/platform/stone/strata/east,
-/obj/structure/platform/stone/strata,
-/obj/effect/mist/steam{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/turf/solid_open_space,
-/area/white_antre/oob)
 "bOG" = (
 /obj/structure/platform/stone/strata/east,
 /obj/effect/mist/steam{
@@ -37184,25 +37132,19 @@
 	pixel_x = 3;
 	pixel_y = 12
 	},
+/obj/structure/platform/stone/strata,
 /turf/solid_open_space,
 /area/white_antre/oob)
 "bOH" = (
-/obj/effect/mist/steam{
-	pixel_x = -12;
-	pixel_y = -14
-	},
 /obj/effect/mist/steam{
 	pixel_x = -10;
 	pixel_y = 9
 	},
 /obj/effect/mist/steam{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/effect/mist/steam{
 	pixel_x = 3;
 	pixel_y = 12
 	},
+/obj/structure/platform/stone/strata/east,
 /turf/solid_open_space,
 /area/white_antre/oob)
 "bOI" = (
@@ -38136,6 +38078,9 @@
 	},
 /turf/open/antre/plating/direction_north,
 /area/white_antre/indoors/upper_level/central_corridor)
+"bPX" = (
+/turf/open/floor/prison/darkyellow2/east,
+/area/white_antre/landing_zone/roof)
 "bPY" = (
 /obj/effect/mist/steam{
 	pixel_x = 6;
@@ -38555,6 +38500,19 @@
 	},
 /turf/open/antre/plating/corner_dir,
 /area/white_antre/indoors/upper_level/central_corridor)
+"bQQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/random/barrel/white,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone/roof)
+"bQR" = (
+/obj/structure/machinery/door/airlock/almayer/secure/colony,
+/turf/open/floor/corsat/marked,
+/area/white_antre/landing_zone/roof)
+"bQS" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/darkyellowcorners2/north,
+/area/white_antre/landing_zone/roof)
 "bQT" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/bed/chair/comfy/orange{
@@ -38589,6 +38547,10 @@
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/open/floor/prison,
 /area/white_antre/indoors/upper_level/west_corridor)
+"bQW" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/darkyellow2/northeast,
+/area/white_antre/landing_zone/roof)
 "bQX" = (
 /obj/effect/antre/border/edge{
 	dir = 1
@@ -39215,6 +39177,11 @@
 /obj/structure/pipes/standard/manifold/hidden/cyan,
 /turf/open/floor/prison,
 /area/white_antre/indoors/main_level/weapons)
+"bSn" = (
+/obj/structure/surface/rack,
+/obj/item/stack/sheet/metal/medium_stack,
+/turf/open/floor/prison,
+/area/white_antre/landing_zone/roof)
 "bSo" = (
 /obj/structure/window/framed/hybrisa/research/reinforced,
 /obj/structure/pipes/standard/simple/hidden/cyan{
@@ -39649,9 +39616,7 @@
 	dir = 2;
 	icon_state = "udoor0"
 	},
-/obj/structure/pipes/standard/manifold/hidden/cyan{
-	dir = 1
-	},
+/obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/open/floor/corsat/marked,
 /area/white_antre/indoors/main_level/weapons)
 "bTz" = (
@@ -39801,7 +39766,7 @@
 /area/white_antre/indoors/main_level/east_corridor)
 "bTR" = (
 /obj/structure/pipes/standard/simple/hidden/cyan{
-	dir = 10
+	dir = 4
 	},
 /turf/open/antre/plating/corner_dir/north_west,
 /area/white_antre/indoors/main_level/east_corridor)
@@ -40579,6 +40544,10 @@
 	},
 /turf/open/floor/prison/green,
 /area/white_antre/indoors/underground_level/east_maint)
+"bVK" = (
+/obj/structure/largecrate/random/secure,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone/roof)
 "bVL" = (
 /obj/effect/decal/hybrisa/bloodtrail/clawtrail/xeno{
 	dir = 8;
@@ -41322,6 +41291,11 @@
 /obj/effect/decal/hybrisa/dirt,
 /turf/open/floor/prison/floor_plate,
 /area/white_antre/landing_zone)
+"bXM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/random/barrel/white,
+/turf/open/floor/prison,
+/area/white_antre/landing_zone/roof)
 "bXN" = (
 /obj/structure/surface/table/reinforced/prison{
 	color = "#6b675e"
@@ -41517,6 +41491,11 @@
 	},
 /turf/open/auto_turf/hybrisa_auto_turf/layer1,
 /area/white_antre/oob)
+"bYm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/darkbrown2/east,
+/area/white_antre/landing_zone/roof)
 "bYn" = (
 /turf/open/auto_turf/hybrisa_auto_turf/layer1,
 /area/white_antre/indoors/main_level/south_containment_hive)
@@ -41612,6 +41591,12 @@
 "bYF" = (
 /turf/open/auto_turf/hybrisa_auto_turf/layer1,
 /area/white_antre/indoors/main_level/north_containment_hive)
+"bYG" = (
+/obj/item/tool/warning_cone{
+	pixel_y = 16
+	},
+/turf/open/floor/prison/darkyellow2/northwest,
+/area/white_antre/landing_zone/roof)
 "bYH" = (
 /turf/open/slippery/roof/dir/east,
 /area/white_antre/outdoors/facility_exterior)
@@ -41647,10 +41632,87 @@
 "bYR" = (
 /turf/open/slippery/roof/dir/northeast,
 /area/white_antre/outdoors/facility_exterior)
+"bYS" = (
+/turf/open/floor/prison/darkyellowcorners2/east,
+/area/white_antre/landing_zone/roof)
+"bYT" = (
+/obj/item/tool/warning_cone{
+	pixel_x = 5;
+	pixel_y = 13
+	},
+/turf/open/floor/prison/darkyellowcorners2/north,
+/area/white_antre/landing_zone/roof)
+"bYU" = (
+/turf/open/floor/prison/darkyellow2/northeast,
+/area/white_antre/landing_zone/roof)
+"bYV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/white_antre/landing_zone/roof)
+"bYW" = (
+/obj/structure/machinery/space_heater/radiator/red{
+	dir = 8;
+	pixel_x = 1
+	},
+/obj/structure/machinery/light/double{
+	dir = 1
+	},
+/turf/open/floor/prison/darkbrownfull2,
+/area/white_antre/landing_zone/roof)
+"bYX" = (
+/obj/structure/largecrate/random/barrel/brown,
+/turf/open/floor/prison/darkyellow2/northwest,
+/area/white_antre/landing_zone/roof)
+"bYY" = (
+/obj/structure/largecrate/random/case/double,
+/obj/structure/machinery/light/double{
+	dir = 1
+	},
+/turf/open/floor/prison/darkyellow2/north,
+/area/white_antre/landing_zone/roof)
 "bYZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkyellow2/east,
 /area/white_antre/indoors/exterior/prefab_3)
+"bZa" = (
+/obj/structure/cargo_container/hybrisa/containersextended/redleft,
+/turf/open/floor/prison/darkyellow2/northeast,
+/area/white_antre/landing_zone/roof)
+"bZb" = (
+/obj/structure/cargo_container/hybrisa/containersextended/redright,
+/turf/closed/wall/strata_outpost/reinforced/hull,
+/area/white_antre/landing_zone/roof)
+"bZc" = (
+/turf/open/floor/strata/multi_tiles,
+/area/white_antre/landing_zone/roof)
+"bZd" = (
+/turf/open/floor/strata/multi_tiles/west,
+/area/white_antre/landing_zone/roof)
+"bZe" = (
+/turf/open/floor/strata/floor3,
+/area/white_antre/landing_zone/roof)
+"bZf" = (
+/obj/structure/stairs/perspective{
+	dir = 9;
+	icon_state = "p_stair_full"
+	},
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/outdoors/north_field)
+"bZg" = (
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/outdoors/north_field)
+"bZh" = (
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/outdoors/north_field)
 "bZi" = (
 /turf/closed/wall/hybrisa/research/reinforced/hull,
 /area/white_antre/indoors/main_level/weapons)
@@ -41660,6 +41722,13 @@
 "bZk" = (
 /turf/closed/wall/hybrisa/colony/reinforced/hull,
 /area/white_antre/oob)
+"bZl" = (
+/obj/structure/stairs/perspective{
+	dir = 5;
+	icon_state = "p_stair_full"
+	},
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/outdoors/north_field)
 "bZm" = (
 /obj/effect/mist/steam{
 	pixel_x = 6;
@@ -41758,6 +41827,14 @@
 /obj/structure/flora/tree/tyrargo/tree_2,
 /turf/open/auto_turf/strata_grass/layer0_mud,
 /area/white_antre/oob)
+"bZy" = (
+/obj/effect/mist/steam{
+	pixel_x = -10;
+	pixel_y = 9
+	},
+/obj/structure/platform/stone/strata/east,
+/turf/solid_open_space,
+/area/white_antre/oob)
 "bZz" = (
 /obj/structure/barricade/handrail{
 	dir = 1
@@ -41774,6 +41851,15 @@
 /obj/structure/blocker/invisible_wall,
 /obj/structure/blocker/forcefield/vehicles,
 /turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/oob)
+"bZC" = (
+/obj/effect/mist/steam{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/structure/platform/stone/strata/east,
+/obj/structure/platform/stone/strata,
+/turf/solid_open_space,
 /area/white_antre/oob)
 "bZD" = (
 /obj/structure/stairs/perspective{
@@ -42310,6 +42396,9 @@
 	},
 /turf/open/floor/prison/bluefull,
 /area/white_antre/indoors/exterior/prefab_1)
+"cbb" = (
+/turf/closed/wall/strata_ice,
+/area/white_antre/outdoors/north_field)
 "cbc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/blue/west,
@@ -42704,10 +42793,6 @@
 	pixel_y = 25
 	},
 /turf/open/auto_turf/sand_white/layer0,
-/area/white_antre/outdoors/north_field)
-"cch" = (
-/obj/structure/prop/hybrisa/boulders/large_boulderdark/boulder_dark2,
-/turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/outdoors/north_field)
 "cci" = (
 /obj/structure/prop/invuln/ice_prefab,
@@ -43230,8 +43315,12 @@
 /turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/outdoors/north_field)
 "cds" = (
-/obj/structure/fence/slim/dark,
-/turf/open/asphalt/cement/cement4,
+/obj/structure/machinery/door/poddoor/almayer/closed{
+	dir = 4;
+	id = "LZ1_Lockdown_Lo";
+	name = "Emergency Lockdown"
+	},
+/turf/open/floor/corsat/marked,
 /area/white_antre/landing_zone)
 "cdt" = (
 /obj/effect/decal/warning_stripes{
@@ -43638,13 +43727,12 @@
 /turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/outdoors/south_field)
 "ceC" = (
-/obj/structure/window/framed/strata/reinforced,
-/obj/structure/machinery/door/poddoor/almayer/closed{
-	dir = 2;
-	id = "LZ1_Lockdown_Lo";
-	name = "Emergency Lockdown"
+/obj/item/reagent_container/food/drinks/coffeecup/wy{
+	pixel_x = -4;
+	pixel_y = -8
 	},
-/turf/open/floor/corsat/marked,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/blue,
 /area/white_antre/landing_zone/roof)
 "ceD" = (
 /obj/structure/girder,
@@ -43769,8 +43857,7 @@
 /turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/outdoors/south_field)
 "ceM" = (
-/obj/structure/fence/slim/dark,
-/turf/open/auto_turf/sand_white/layer0,
+/turf/closed/wall/strata_outpost,
 /area/white_antre/landing_zone)
 "ceN" = (
 /obj/structure/largecrate/random/barrel/black,
@@ -43892,11 +43979,10 @@
 /turf/open/asphalt/brown,
 /area/white_antre/landing_zone)
 "cfi" = (
-/obj/structure/machinery/door/poddoor/almayer/open{
-	name = "\improper Lockdown";
+/obj/structure/machinery/door/poddoor/almayer/closed{
+	dir = 4;
 	id = "lz_entrance";
-	vehicle_resistant = 1;
-	dir = 8
+	name = "Emergency Lockdown"
 	},
 /turf/open/floor/corsat/marked,
 /area/white_antre/outdoors/road_west)
@@ -43913,11 +43999,10 @@
 /turf/open/asphalt/brown,
 /area/white_antre/landing_zone)
 "cfl" = (
-/obj/structure/machinery/door/poddoor/almayer/open{
-	name = "\improper Lockdown";
+/obj/structure/machinery/door/poddoor/almayer/closed{
+	dir = 4;
 	id = "lz_entrance";
-	vehicle_resistant = 1;
-	dir = 8
+	name = "Emergency Lockdown"
 	},
 /turf/open/floor/corsat/marked,
 /area/white_antre/landing_zone)
@@ -44100,15 +44185,8 @@
 /turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/outdoors/north_field)
 "cfM" = (
-/obj/effect/decal/strata_decals/mud_corner{
-	dir = 8
-	},
 /obj/item/device/flashlight/lamp/tripod,
 /turf/open/auto_turf/sand_white/layer0,
-/area/white_antre/landing_zone)
-"cfN" = (
-/obj/structure/fence/slim/dark/door,
-/turf/open/auto_turf/strata_grass/layer0_mud,
 /area/white_antre/landing_zone)
 "cfO" = (
 /obj/item/device/flashlight/lamp/tripod/grey{
@@ -44360,6 +44438,9 @@
 	},
 /turf/open/auto_turf/snow/layer1,
 /area/white_antre/oob)
+"cgv" = (
+/turf/closed/wall/strata_ice/dirty/rock,
+/area/white_antre/outdoors/north_field)
 "cgw" = (
 /obj/structure/machinery/light/red{
 	light_color = "#BB3F3F";
@@ -48652,6 +48733,7 @@
 	dir = 1
 	},
 /obj/effect/antre/border,
+/obj/vehicle/train/cargo/engine,
 /turf/open/floor/prison/darkpurple2/west,
 /area/white_antre/indoors/main_level/east_corridor)
 "cpv" = (
@@ -51975,9 +52057,6 @@
 "hjx" = (
 /turf/open/floor/prison/bright_clean,
 /area/white_antre/indoors/main_level/engineering)
-"hjW" = (
-/turf/open/asphalt/cement/cement14,
-/area/white_antre/outdoors/south_field)
 "hmb" = (
 /obj/structure/pipes/standard/simple/hidden/green{
 	dir = 4
@@ -52997,7 +53076,7 @@
 /turf/open/floor/prison/cell_stripe,
 /area/white_antre/indoors/main_level/east_containment)
 "lvO" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall/kseries,
+/obj/item/defenses/handheld/tesla_coil,
 /turf/open/floor/prison/redfull,
 /area/white_antre/indoors/main_level/east_containment)
 "lvY" = (
@@ -53032,10 +53111,6 @@
 /obj/structure/platform/metal/almayer_smooth/west,
 /obj/structure/platform_decoration/metal/almayer_smooth/northwest,
 /turf/open/auto_turf/sand_white/layer0,
-/area/white_antre/landing_zone)
-"lEW" = (
-/obj/structure/fence/slim/dark,
-/turf/open/asphalt/cement/cement12,
 /area/white_antre/landing_zone)
 "lGQ" = (
 /obj/effect/decal/strata_decals/mud_corner{
@@ -54987,8 +55062,12 @@
 /turf/open/asphalt/brown,
 /area/white_antre/indoors/main_level/south_containment)
 "tFe" = (
-/obj/structure/fence/slim/dark,
-/turf/open/asphalt/cement/cement1,
+/obj/structure/machinery/door/poddoor/almayer/closed{
+	dir = 2;
+	id = "LZ1_Lockdown_Lo";
+	name = "Emergency Lockdown"
+	},
+/turf/open/floor/corsat/marked,
 /area/white_antre/landing_zone)
 "tFY" = (
 /obj/structure/machinery/gear{
@@ -55294,12 +55373,6 @@
 	},
 /turf/open/floor/prison/blue,
 /area/white_antre/indoors/main_level/dorms)
-"uUl" = (
-/obj/structure/machinery/space_heater/radiator/red{
-	dir = 4
-	},
-/turf/open/floor/prison/bluefull,
-/area/white_antre/landing_zone/roof)
 "uVc" = (
 /obj/structure/barricade/handrail{
 	dir = 1
@@ -99744,11 +99817,11 @@ bNT
 bNO
 bNW
 bOf
-bNY
+atb
 bOB
 bOi
-byZ
-bOz
+atb
+hpi
 bOy
 wrD
 wrD
@@ -99910,14 +99983,13 @@ bNU
 bNP
 bNU
 bNP
-bNX
-bOe
-bOe
-bOC
-bzb
-aOh
-aNP
-ctR
+bZy
+byZ
+iKa
+iKa
+iKa
+iKa
+bRL
 kuQ
 kuQ
 kuQ
@@ -99925,6 +99997,7 @@ kuQ
 iFy
 pWw
 aKD
+aKB
 aKF
 aKC
 aKC
@@ -100077,22 +100150,22 @@ bNY
 bNV
 bOI
 bOH
-bNQ
-bNY
-bOe
-bOD
-bzb
-aMS
-aNA
-ctR
-ctR
+bZC
+aMJ
+aMJ
+aMJ
+iKa
+iKa
+bRL
+bRL
+aNI
 beu
 bek
 aNI
 bdY
 iFy
-iFy
 aNi
+aKB
 aKB
 aKC
 aKC
@@ -100138,7 +100211,7 @@ aXN
 boZ
 aXF
 ctR
-ctR
+bRL
 lQg
 byZ
 bOj
@@ -100244,23 +100317,23 @@ bOK
 bBn
 bOJ
 bOG
-bOD
-bOG
-bOD
-bOF
-aMS
 aMJ
-aMI
-aNA
-ctR
+aMJ
+aMJ
+aMJ
+iKa
+iKa
+iKa
+bRL
 aNM
+aNJ
 aNJ
 bel
 bdZ
-bdZ
-aNB
-atH
+aIu
+iFy
 aNi
+aKB
 aKB
 aKB
 aKC
@@ -100306,11 +100379,11 @@ iDL
 aXG
 aXG
 wZd
-ctR
-hjW
-xEt
-acs
-aXl
+bRL
+aJq
+aJq
+aJq
+aJq
 aJq
 aJq
 aJq
@@ -100416,19 +100489,19 @@ aMJ
 aMJ
 aMJ
 aMJ
-aMJ
-aMI
-aMI
-aNA
-ceC
+iKa
+iKa
+iKa
+bRL
 aNN
 aKf
-bem
-beb
-aXH
+aKf
+aKf
+aKf
 aNC
-aKz
+aFc
 aNi
+aKB
 aKB
 aKB
 aKC
@@ -100474,11 +100547,11 @@ bpd
 bpa
 aXH
 aXA
-ceC
-gKr
-aJy
-acs
-aJx
+bRL
+aJq
+aJq
+aJq
+aJq
 aJq
 aJq
 aJq
@@ -100584,22 +100657,22 @@ aMS
 aMJ
 aMJ
 aMJ
-aMJ
-aMI
-aMI
-aNA
-ceC
+bZf
+ctR
+ctR
+ctR
 aNN
 aKf
+bSn
 ben
 aKf
-aKf
-aNC
-akw
+aIw
+aFd
 aNi
-aKB
-aKB
-aKB
+aKC
+aEO
+aEG
+ceR
 dwB
 bYb
 bcU
@@ -100642,11 +100715,11 @@ bpe
 bpb
 aXH
 aXA
-ceC
-gKr
-acs
-acs
-aYP
+bRL
+aJq
+aJq
+aJq
+aJq
 aJq
 aJq
 aJq
@@ -100752,21 +100825,21 @@ aMJ
 aMJ
 aMJ
 aMJ
-aMS
-aMJ
-aMI
+bZg
+bZe
+bZc
 aNA
-ceC
 aNN
 aKf
+bVK
+aKp
 aKf
-aKf
-aKf
-aNC
-akw
+aIw
+aFe
 aNi
+aEX
 aKB
-aKB
+aEI
 aKB
 dwB
 bbQ
@@ -100810,11 +100883,11 @@ aKf
 aKf
 aKf
 aXA
-ceC
-gKr
-acs
-acs
-aWy
+bRL
+aJq
+aJq
+aJq
+aJq
 aJq
 aJq
 aJq
@@ -100920,21 +100993,21 @@ aMH
 beA
 beA
 bee
-aMJ
-aMJ
-aMJ
+bZg
+bZe
+bZd
 aNA
-ceC
 aNN
 aKf
-beo
 aKf
 aKf
-aNC
-akw
+aKf
+aIw
+aFe
 aNi
 aKC
-aKB
+aEP
+aEJ
 aKB
 odB
 oSf
@@ -100978,11 +101051,11 @@ aKf
 bpc
 aKf
 qoj
-ceC
-gKr
-aJy
-acs
-boS
+bRL
+aJq
+aJq
+aJq
+aJq
 aJq
 aJq
 aJq
@@ -101088,23 +101161,23 @@ bfb
 aMH
 aMH
 bef
-aMJ
-aMJ
-aMJ
+bZg
+bZe
+bZd
 aNA
-ceC
 aNN
-aXH
-bep
-bec
 aKf
-aNC
-atH
+aXH
+aKf
+aKf
+aIw
+aFe
 aNi
 aKC
-aKB
+aEQ
+aEL
 aKF
-ceR
+aKB
 aKC
 odB
 oSf
@@ -101146,11 +101219,11 @@ aKp
 bec
 aKf
 qoj
-ceC
-gKr
-aJy
-acs
-aXm
+bRL
+aJq
+aJq
+aJq
+aJq
 aJq
 aJq
 aJq
@@ -101255,21 +101328,21 @@ aMH
 aMH
 aMH
 beX
-ber
-bee
-aMJ
-aMJ
+bef
+bZg
+bZe
+bZd
 aNA
-ctR
-aNO
-bev
-aNK
-aNK
-aNK
-aNE
-aKz
-aNi
+aNN
+aKf
+bXM
+aKf
+aKf
+aIw
+atH
+aFa
 aKC
+aER
 aKB
 aKB
 aKB
@@ -101314,10 +101387,10 @@ bpf
 kpp
 kpp
 dlI
-ctR
-gKr
-aJy
-aJx
+bRL
+aJq
+aJq
+aJq
 aJq
 aJq
 aJq
@@ -101423,21 +101496,21 @@ tpc
 beS
 uoG
 aMH
-aMH
 beP
-aMJ
-aMJ
+bZh
+bZe
+bZc
 aNA
-ctR
-ctR
-bew
-beq
-bed
-bea
-iFy
-iFy
+aNN
+bYV
+bpa
+bQQ
+aXH
+aNC
+aKz
 aNi
 aKC
+aET
 aKB
 aKB
 aKB
@@ -101481,11 +101554,11 @@ bph
 bpg
 caA
 aXI
-ctR
-ctR
-gKr
-aJy
-aXp
+iFy
+iFy
+aJq
+aJq
+aJq
 aJq
 aJq
 aJq
@@ -101591,20 +101664,20 @@ jCh
 aMH
 lGQ
 kGT
-beS
 beP
-aMI
-aMJ
-aNy
-aNl
+bZl
 ctR
-ceJ
-rMO
-ceJ
-ceJ
-iFy
-aKA
-aNx
+ctR
+ctR
+aNO
+bYm
+bYm
+bev
+aNL
+aIx
+ctR
+aNi
+aKC
 aKC
 aKC
 aKB
@@ -101649,11 +101722,11 @@ ceJ
 ceJ
 rMO
 ceJ
-ctR
-wxm
-knT
-aJy
-aJx
+iFy
+gKr
+aJq
+aJq
+aJq
 aJq
 aJq
 aJq
@@ -101759,19 +101832,19 @@ aMI
 tpc
 aMH
 aMH
-aMH
 beP
 aMI
-aMI
-aMJ
-aNy
-aNm
-aNm
-aNm
-aNm
-aNm
-tFe
-aNx
+iKa
+iKa
+bRL
+bRL
+bYW
+beq
+beq
+aZz
+ctR
+ctR
+aNi
 aKC
 aKC
 aKC
@@ -101819,9 +101892,9 @@ mui
 mui
 mui
 knT
-aJy
-aJy
-aJx
+aJq
+aJq
+aJq
 aJq
 aJq
 aJq
@@ -101927,19 +102000,19 @@ aMJ
 aMJ
 aMJ
 beL
-bey
-beg
+beP
 aMI
-aMI
-aMJ
-aMJ
-aMJ
-aMS
-aMJ
-aMJ
-aMS
-bqz
-aKC
+iKa
+iKa
+iKa
+bRL
+bRL
+akw
+bQR
+akw
+ctR
+ctR
+aNi
 aKC
 aKC
 aKC
@@ -101980,16 +102053,16 @@ aKB
 aKB
 aKF
 aKB
-aKt
+tFe
 acs
 boS
 aXM
 lvY
 acs
-aJy
-aJy
-aJy
-aJx
+acs
+xEt
+aJq
+aJq
 aJq
 aJq
 aJq
@@ -102098,16 +102171,16 @@ beY
 beT
 aMI
 aMI
-aMI
-aMI
-aMJ
-aMJ
-aMJ
-aMJ
-aMH
-aMH
-aNF
-aDc
+iKa
+iKa
+iKa
+bRL
+aFb
+aFb
+aFb
+ctR
+ctR
+aNi
 cfM
 aKB
 aKB
@@ -102148,7 +102221,7 @@ aKC
 aKB
 ceR
 aKB
-aKt
+tFe
 pzq
 aJx
 acs
@@ -102268,15 +102341,15 @@ aMI
 aMI
 iKa
 iKa
-iKa
-aMJ
-aMJ
-aMJ
-aMJ
-aMH
-cfN
-aMZ
-aMZ
+bRL
+bRL
+bYG
+bsr
+bsr
+ctR
+ctR
+aKA
+aKD
 aKB
 aKB
 aKB
@@ -102316,7 +102389,7 @@ aKC
 aKC
 aKB
 aKC
-aKu
+tFe
 pzq
 pzq
 pzq
@@ -102434,17 +102507,17 @@ aMJ
 aMJ
 aMI
 aMI
-aMI
 iKa
 iKa
-aMJ
-aMJ
-aMJ
-aMJ
-aMJ
-aNF
-aMZ
-pWw
+bRL
+bYX
+bYS
+aKf
+aKf
+aID
+ctR
+ctR
+aKA
 hNM
 hNM
 hNM
@@ -102482,9 +102555,9 @@ hNM
 hNM
 hNM
 hNM
+hNM
 aKD
-aKC
-ceM
+tFe
 pzq
 pzq
 aJy
@@ -102602,18 +102675,18 @@ aMJ
 aMJ
 aMJ
 aMJ
-aMI
 iKa
 iKa
-iKa
-cch
-aMJ
-aMJ
-aMJ
+bRL
+bYY
+aKf
+aXL
+aKp
+aJb
 aKt
-pWw
-aKA
-iFy
+ctR
+ctR
+ctR
 aKz
 aMb
 akw
@@ -102650,9 +102723,9 @@ akw
 aKz
 aMb
 iFy
-aKA
-aKD
 ceM
+ceM
+tFe
 pzq
 aJy
 aJy
@@ -102772,16 +102845,16 @@ aMJ
 aMJ
 aMJ
 iKa
-iKa
-iKa
-aMJ
-aMJ
-aMS
-aMJ
-aKt
-cds
-iFy
-iFy
+bRL
+bZa
+bYT
+aXH
+aKp
+aKf
+aFf
+aFb
+akw
+bdH
 pDy
 cNe
 cNe
@@ -102816,12 +102889,12 @@ aLd
 aYO
 bzl
 aKR
+aKR
+aKR
 aKL
-iFy
-iFy
-lEW
 ceM
-aXR
+ceM
+aJq
 acs
 aJy
 xEt
@@ -102940,16 +103013,16 @@ aMJ
 aMH
 ewE
 iKa
-iKa
-iKa
-iKa
-aMJ
-aMS
-aMJ
-aMS
-aNA
-ceC
-bdH
+bRL
+bZb
+bYU
+bQS
+aKf
+aKf
+aFf
+aFb
+aEZ
+aEV
 bpx
 aXL
 aXH
@@ -102961,7 +103034,7 @@ aNi
 aKB
 aKB
 aKC
-aKC
+iKa
 aKC
 aKC
 aLQ
@@ -102984,14 +103057,14 @@ aYW
 bzo
 aXH
 bzj
+aKf
+aXL
 aKM
-uUl
-ceC
-gKr
-aXT
-lvY
-aJy
-aJy
+aEt
+aEq
+aJq
+aJq
+acs
 aJy
 aJy
 bYt
@@ -103109,14 +103182,14 @@ aMH
 ewE
 iKa
 iKa
-iKa
-iKa
-iKa
-aMJ
-aMJ
-aMJ
-aNA
-ceC
+bRL
+bRL
+bQW
+bPX
+aJg
+aGq
+aFb
+akw
 bdI
 xJX
 aXL
@@ -103125,13 +103198,13 @@ aKp
 bpv
 bcP
 akw
-lEW
-aKt
+cds
+cds
 aLQ
 aLQ
-aLQ
-ceM
-ceM
+iKa
+iKa
+iKa
 aLQ
 cfm
 aMy
@@ -103139,12 +103212,12 @@ cfk
 aMy
 cfh
 aLQ
-ceM
-ceM
+cds
+cds
 aLQ
 aLQ
 aLQ
-aKt
+cds
 cds
 akw
 aZc
@@ -103153,13 +103226,13 @@ bzp
 bpk
 aKp
 bpj
-aYg
+aXL
 ceC
-gKr
-aXl
+aEu
+aEq
+aJq
+aJq
 acs
-aJy
-aJy
 pzq
 aJy
 aJy
@@ -103278,12 +103351,12 @@ ewE
 iKa
 iKa
 iKa
-iKa
-iKa
-iKa
-aMJ
-aMJ
-aNA
+bRL
+bRL
+bRL
+bRL
+bRL
+cfp
 ctR
 ctR
 dal
@@ -103297,9 +103370,9 @@ aNj
 aMJ
 aMJ
 aLQ
-aMJ
-aMJ
-aMJ
+iKa
+iKa
+iKa
 aLQ
 aMM
 aMy
@@ -103320,13 +103393,13 @@ aLf
 bpn
 bpl
 aKS
+aEy
+aEy
 aKN
-ctR
-ctR
-gKr
-aJy
-aJy
-aJy
+aEq
+aEq
+aJq
+aJq
 pzq
 aJy
 aJy
@@ -103449,8 +103522,8 @@ iKa
 iKa
 iKa
 iKa
-aMJ
-aMJ
+iKa
+iKa
 aNy
 aNl
 ctR
@@ -103466,8 +103539,8 @@ aMJ
 aMJ
 aMJ
 aMJ
-aMJ
-aMJ
+iKa
+iKa
 cfp
 cfi
 cfi
@@ -103490,10 +103563,10 @@ ctR
 ceJ
 ceJ
 ctR
-wxm
-knT
-aJy
-aJy
+aEq
+aEq
+aJq
+aJq
 pzq
 pzq
 pzq
@@ -103616,10 +103689,10 @@ iKa
 ewE
 ewE
 iKa
-ewE
-ewE
-aMJ
-aMJ
+iKa
+iKa
+iKa
+iKa
 aNy
 aNm
 aNm
@@ -103659,9 +103732,9 @@ mui
 mui
 mui
 knT
-aJy
-aJy
-pzq
+aJq
+aJq
+aJq
 pzq
 pzq
 pzq
@@ -103785,8 +103858,8 @@ ewE
 ewE
 ewE
 ewE
-aMH
-aMH
+iKa
+iKa
 aMJ
 aMJ
 aMJ
@@ -113874,9 +113947,9 @@ akG
 chT
 bJg
 atQ
-bHo
-bzh
-bwt
+btr
+cno
+alt
 akG
 atM
 akB
@@ -114042,9 +114115,9 @@ chU
 alr
 alm
 akZ
-bHo
-bHo
-bwu
+cpM
+cnr
+atP
 akH
 akE
 atp
@@ -114211,8 +114284,8 @@ atT
 aln
 atR
 cpM
-bzi
-bwv
+cnr
+atP
 akI
 atp
 atp
@@ -120103,10 +120176,10 @@ vbZ
 aMX
 cpn
 coM
-bHo
-bHo
+cpk
+coF
 bTR
-afY
+avw
 aVz
 aVw
 aKl
@@ -120270,10 +120343,10 @@ aDV
 bUb
 bTV
 asa
+coM
 bHo
 bHo
-bHo
-bHo
+aEB
 bTy
 bSz
 bSz
@@ -120440,9 +120513,9 @@ aMX
 cpo
 aHY
 bHo
-aHN
+coF
 akT
-agM
+avw
 aKq
 aKq
 aKq
@@ -120608,7 +120681,7 @@ aMW
 eYg
 aHZ
 aHT
-aHO
+bSc
 aoN
 frB
 aXk
@@ -122456,7 +122529,7 @@ cov
 cov
 cov
 aHV
-aHR
+cov
 cov
 cov
 cov
@@ -122622,7 +122695,7 @@ coq
 coq
 coq
 aIm
-aIc
+coq
 coq
 coq
 coq
@@ -123098,7 +123171,7 @@ byC
 bif
 aKK
 bvs
-bHo
+aKK
 bHo
 bHo
 iKa
@@ -123493,7 +123566,7 @@ aPV
 bsR
 cnj
 bbh
-iKa
+bbh
 iKa
 iKa
 bqo
@@ -123603,7 +123676,7 @@ aPV
 bwr
 bvs
 aKK
-bHo
+aKK
 bHo
 bHo
 ozb
@@ -123661,7 +123734,7 @@ aPV
 bsO
 cnj
 bbh
-iKa
+bbh
 aAY
 iKa
 bqo
@@ -123772,7 +123845,7 @@ atY
 bvt
 bfE
 aKK
-bHo
+aLT
 bHo
 aPV
 aPV
@@ -124332,7 +124405,7 @@ aAY
 bsY
 bql
 bbh
-iKa
+bbh
 iKa
 iKa
 bqr
@@ -124440,10 +124513,10 @@ byH
 bpK
 bjg
 kje
-bHo
-bHo
-bHo
-bHo
+aLw
+aKI
+aKI
+aKI
 bca
 aZH
 aZH
@@ -124465,7 +124538,7 @@ aZn
 cuF
 aKK
 abK
-abw
+aEF
 abG
 aKK
 cub
@@ -124499,7 +124572,7 @@ aAY
 aAY
 btc
 bbh
-iKa
+bbh
 iKa
 iKa
 iKa
@@ -124608,9 +124681,9 @@ byG
 bpK
 bjg
 aPV
-bHo
-bHo
-bHo
+aLw
+aKI
+aKI
 bcO
 bus
 bbL
@@ -124668,7 +124741,7 @@ bbh
 btc
 bbh
 bbh
-iKa
+bbh
 iKa
 bqw
 bqo
@@ -124776,7 +124849,7 @@ bpZ
 bpM
 bjh
 aPV
-bHo
+aLw
 aKK
 aKK
 bdb
@@ -124812,7 +124885,7 @@ baL
 aZq
 uJj
 uJj
-aZZ
+wmp
 aZQ
 bHo
 bHo
@@ -124837,7 +124910,7 @@ bqd
 bbh
 bbh
 bbh
-iKa
+bbh
 bqo
 bbh
 bbh
@@ -124980,7 +125053,7 @@ aLW
 ejX
 ejX
 ejX
-aLW
+bFj
 bHo
 bHo
 bHo
@@ -127464,21 +127537,21 @@ azn
 azl
 ayS
 aTp
-euM
-euM
-euM
-euM
-euM
+acU
+acU
+acU
+acU
+acU
 aOc
 ayS
 ayW
 ayS
 aTp
-euM
-euM
-euM
-euM
-euM
+acU
+acU
+acU
+acU
+acU
 aOc
 ayV
 ayS
@@ -127512,21 +127585,21 @@ azk
 ayS
 ayV
 aTp
-euM
-euM
-euM
-euM
-euM
+acU
+acU
+acU
+acU
+acU
 aOc
 ayS
 ayW
 ayS
 aTp
-euM
-euM
-euM
-euM
-euM
+acU
+acU
+acU
+acU
+acU
 aOc
 ayS
 ayR
@@ -127636,13 +127709,13 @@ azr
 azr
 azr
 nVc
-euM
+acU
 aOc
 ayS
 ayW
 ayS
 aTp
-euM
+acU
 ayJ
 azr
 azr
@@ -127684,13 +127757,13 @@ azr
 azr
 azr
 nVc
-euM
+acU
 aOc
 ayS
 ayW
 ayS
 aTp
-euM
+acU
 ayJ
 azr
 azr
@@ -128479,7 +128552,7 @@ aAy
 aFL
 ayU
 ayT
-azp
+azb
 azj
 ayU
 baq
@@ -128527,7 +128600,7 @@ aAy
 aFL
 ayU
 ayT
-azp
+azb
 azj
 ayU
 baq
@@ -128647,8 +128720,8 @@ euM
 ayZ
 ayT
 ayP
-aut
-aQv
+aEl
+azm
 azj
 azh
 euM
@@ -128695,8 +128768,8 @@ euM
 ayZ
 ayT
 ayP
-aut
-aQv
+aEl
+azm
 azj
 azh
 euM
@@ -128814,9 +128887,9 @@ euM
 byL
 byJ
 bjX
-aut
-aut
-aut
+euM
+euM
+euM
 bjW
 boW
 bbX
@@ -128862,9 +128935,9 @@ euM
 byL
 byJ
 bjX
-aut
-aut
-aut
+euM
+euM
+euM
 bjW
 boW
 bbX
@@ -128983,7 +129056,7 @@ euM
 byK
 ayR
 ayN
-aut
+euM
 azn
 azl
 azh
@@ -129031,7 +129104,7 @@ euM
 byK
 ayR
 ayN
-aut
+euM
 azn
 azl
 azh
@@ -129988,13 +130061,13 @@ aAy
 azc
 azc
 bbI
-euM
+acU
 aOc
 ayS
 ayW
 ayS
 aTp
-euM
+acU
 boU
 azc
 azc
@@ -130036,13 +130109,13 @@ aAy
 azc
 azc
 bbI
-euM
+acU
 aOc
 ayS
 ayW
 ayS
 aTp
-euM
+acU
 boU
 azc
 azc
@@ -130152,21 +130225,21 @@ azm
 azj
 ayS
 aTp
-euM
-euM
-euM
-euM
-euM
+acU
+acU
+acU
+acU
+acU
 aOc
 ayS
 ayW
 ayS
 aTp
-euM
-euM
-euM
-euM
-euM
+acU
+acU
+acU
+acU
+acU
 aOc
 ayV
 ayS
@@ -130200,21 +130273,21 @@ azk
 ayS
 ayV
 aTp
-euM
-euM
-euM
-euM
-euM
+acU
+acU
+acU
+acU
+acU
 aOc
 ayS
 ayW
 ayS
 aTp
-euM
-euM
-euM
-euM
-euM
+acU
+acU
+acU
+acU
+acU
 aOc
 ayS
 ayT
@@ -131518,8 +131591,8 @@ ayM
 ayM
 azk
 ayV
-euM
-euM
+ayV
+ayV
 ayV
 ayV
 ayV
@@ -131535,8 +131608,8 @@ euM
 ayV
 ayV
 ayV
-euM
-euM
+ayV
+ayV
 ayV
 ayO
 ayM
@@ -131686,9 +131759,9 @@ ayN
 hGv
 azk
 ayV
-euM
-euM
-euM
+ayV
+ayV
+ayV
 ayV
 ayV
 euM
@@ -131702,9 +131775,9 @@ ayV
 euM
 ayV
 ayV
-euM
-euM
-euM
+ayV
+ayV
+ayV
 ayV
 ayO
 ktc
@@ -131854,9 +131927,9 @@ ayO
 hGv
 azk
 ayV
-euM
 ayV
-euM
+ayV
+ayV
 ayV
 ayV
 ayV
@@ -131870,9 +131943,9 @@ ayV
 ayV
 ayV
 ayV
-euM
 ayV
-euM
+ayV
+ayV
 ayV
 ayO
 ktc
@@ -132868,13 +132941,13 @@ euM
 ayW
 ayO
 atS
-ayM
-ayM
-aut
-aut
-aut
-ayM
-ayM
+euM
+euM
+euM
+euM
+euM
+euM
+euM
 afX
 azk
 ayW
@@ -133038,9 +133111,9 @@ ayR
 ayX
 ayX
 ayN
-aut
+euM
 azY
-aut
+euM
 azn
 ayX
 ayX
@@ -140234,7 +140307,7 @@ spC
 spC
 spC
 spC
-spC
+cbb
 spC
 spC
 spC
@@ -140401,12 +140474,12 @@ spC
 spC
 spC
 spC
-spC
-spC
-spC
-cnb
-cnb
+cbb
+cbb
+cbb
+cbb
 tUu
+kDp
 kDp
 kDp
 kDp
@@ -140567,13 +140640,13 @@ spC
 spC
 spC
 spC
-spC
-spC
-spC
-spC
 cnb
 cnb
+cnb
+cbb
+cbb
 tUu
+kPj
 kPj
 kPj
 kPj
@@ -140733,15 +140806,15 @@ spC
 spC
 spC
 spC
-spC
-spC
-spC
-spC
 cnb
 cnb
 cnb
 cnb
+cbb
+cbb
+cbb
 fuj
+kPj
 kPj
 kPj
 kPj
@@ -140796,10 +140869,10 @@ kPj
 kPj
 kPj
 pHD
-cmK
-cmK
-cmK
-cmK
+aJq
+aJq
+aJq
+aJq
 aJq
 aJq
 aJq
@@ -140905,11 +140978,11 @@ cnb
 cnb
 cnb
 cnb
-cnb
-cnb
-cnb
-cnb
-fuj
+cbb
+cbb
+cbb
+jIC
+hLL
 kPj
 kPj
 kPj
@@ -140964,10 +141037,10 @@ kPj
 kPj
 kPj
 pHD
-cmK
-cmK
-cmK
-cmK
+aJq
+aJq
+aJq
+aJq
 aJq
 aJq
 aJq
@@ -141074,11 +141147,11 @@ cnb
 cnb
 cnb
 cnb
-cnb
-cnb
-cnb
+tUu
+kDp
+kDp
+vuo
 fuj
-kPj
 kPj
 kPj
 kPj
@@ -141132,10 +141205,10 @@ kPj
 kPj
 kPj
 pHD
-cmK
-cmK
-cmK
-cmK
+aJq
+aJq
+aJq
+aJq
 aJq
 aJq
 aJq
@@ -141242,11 +141315,11 @@ cnb
 cnb
 cnb
 cnb
-cnb
-cnb
-cnb
 fuj
 kPj
+kPj
+pHD
+fuj
 kPj
 kPj
 kPj
@@ -141300,10 +141373,10 @@ kPj
 kPj
 kPj
 pHD
-cmK
-cmK
-cmK
-cmK
+aJq
+aJq
+aJq
+aJq
 aJq
 aJq
 aJq
@@ -141410,11 +141483,11 @@ cnb
 cnb
 cnb
 cnb
-cnb
-cnb
-cnb
 fuj
 kPj
+kPj
+pHD
+fuj
 kPj
 kPj
 kPj
@@ -141468,10 +141541,10 @@ kPj
 kPj
 kPj
 pHD
-cmK
-cmK
-cmK
-cmK
+aJq
+aJq
+aJq
+aJq
 aJq
 aJq
 aJq
@@ -141578,11 +141651,11 @@ cnb
 cnb
 cnb
 cnb
-cnb
-cnb
-cnb
 fuj
 kPj
+kPj
+pHD
+fuj
 kPj
 kPj
 kPj
@@ -141636,10 +141709,10 @@ kPj
 kPj
 kPj
 pHD
-cmK
-cmK
-cmK
-cmK
+aJq
+aJq
+aJq
+aJq
 aJq
 aJq
 aJq
@@ -141746,11 +141819,11 @@ cnb
 cnb
 cnb
 cnb
-cnb
-cnb
-cnb
 fuj
 kPj
+kPj
+pHD
+fuj
 kPj
 kPj
 kPj
@@ -141804,9 +141877,9 @@ kPj
 kPj
 kPj
 pHD
-cmK
-cmK
-cmK
+aJq
+aJq
+aJq
 aJq
 aJq
 aJq
@@ -141914,9 +141987,56 @@ cnb
 cnb
 cnb
 cnb
-cnb
-cnb
-cnb
+fuj
+kPj
+kPj
+pHD
+fuj
+kPj
+kPj
+kPj
+kPj
+kPj
+oyK
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
+cmO
 jIC
 kPj
 kPj
@@ -141925,56 +142045,9 @@ kPj
 kPj
 kPj
 oyK
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-cmO
-jIC
-kPj
-kPj
-kPj
-kPj
-kPj
-kPj
-oyK
-cmK
-cmK
-cmK
+aJq
+aJq
+aJq
 aJq
 aJq
 aJq
@@ -142082,10 +142155,10 @@ cnb
 cnb
 cnb
 cnb
-cnb
-cnb
-cnb
-cnb
+jIC
+hLL
+hLL
+oyK
 jIC
 hLL
 hLL
@@ -142140,9 +142213,9 @@ hLL
 hLL
 oyK
 cmK
-cmK
-cmK
-cmK
+aJq
+aJq
+aJq
 aJq
 aJq
 aJq
@@ -142250,16 +142323,16 @@ cnb
 cnb
 cnb
 cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cmO
+cbb
+cbb
+jIC
+tUu
+kDp
+kDp
+kDp
+kDp
+kDp
+vuo
 cmO
 cmO
 cmO
@@ -142308,9 +142381,9 @@ cmK
 cmK
 cmK
 cmK
-cmK
-cmK
-cmK
+aJq
+aJq
+aJq
 aJq
 aJq
 aJq
@@ -142418,16 +142491,16 @@ cnb
 cnb
 cnb
 cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cmO
+cbb
+cbb
+cbb
+jIC
+kPj
+kPj
+kPj
+kPj
+kPj
+pHD
 cmO
 cmO
 cmO
@@ -142477,8 +142550,8 @@ cmK
 cmK
 cmK
 cmK
-cmK
-cmK
+aJq
+aJq
 aJq
 aJq
 aJq
@@ -142587,15 +142660,15 @@ cnb
 cnb
 cnb
 cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cmO
+cbb
+cbb
+cbb
+fuj
+kPj
+kPj
+kPj
+kPj
+pHD
 cmO
 cmO
 cmO
@@ -142755,15 +142828,15 @@ cnb
 cnb
 cnb
 cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cmO
+cbb
+cbb
+tUu
+kPj
+kPj
+kPj
+kPj
+kPj
+pHD
 cmO
 cmO
 cmO
@@ -142923,16 +142996,16 @@ cnb
 cnb
 cnb
 cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cmO
-cmO
+cbb
+cbb
+fuj
+kPj
+kPj
+kPj
+kPj
+kPj
+kPj
+vuo
 cmO
 cmO
 cmO
@@ -143091,17 +143164,17 @@ cnb
 cnb
 cnb
 cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cmO
-cmO
-cmO
+cbb
+cbb
+fuj
+kPj
+kPj
+kPj
+kPj
+kPj
+kPj
+pHD
+kPj
 tUu
 kDp
 kDp
@@ -143138,9 +143211,9 @@ kDp
 kDp
 kDp
 kDp
+kDp
+kDp
 vuo
-cmO
-cmO
 cmO
 cmK
 cmK
@@ -143260,15 +143333,15 @@ cnb
 cnb
 cnb
 cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cmO
-cmO
+cbb
+fuj
+kPj
+kPj
+kPj
+kPj
+kPj
+kPj
+pHD
 tUu
 kPj
 kPj
@@ -143307,10 +143380,10 @@ kPj
 kPj
 kPj
 kPj
+kPj
+kPj
 vuo
-cmO
-cmO
-cmK
+aJq
 cmK
 cmK
 cmK
@@ -143427,16 +143500,16 @@ cnb
 cnb
 cnb
 cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
+cgv
+cbb
+jIC
+kPj
+kPj
+kPj
+kPj
+kPj
+kPj
+pHD
 fuj
 kPj
 kPj
@@ -143450,7 +143523,7 @@ cmO
 cmO
 cmO
 cmO
-cmO
+iKa
 cmO
 cmO
 cmO
@@ -143475,11 +143548,11 @@ kPj
 kPj
 kPj
 kPj
+kPj
+kPj
 pHD
-cmK
-cmK
-cmK
-cmK
+aJq
+aJq
 cmK
 cmK
 cmK
@@ -143595,16 +143668,16 @@ cnb
 cnb
 cnb
 cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
+cgv
+cbb
+cbb
+jIC
+kPj
+kPj
+kPj
+kPj
+kPj
+pHD
 fuj
 kPj
 kPj
@@ -143618,9 +143691,9 @@ cmO
 cmO
 cmO
 cmO
-cmO
-cmO
-cmO
+iKa
+iKa
+iKa
 cmO
 cmO
 cmO
@@ -143643,11 +143716,11 @@ kPj
 kPj
 kPj
 kPj
+kPj
+kPj
 pHD
-cmK
-cmK
-cmK
-cmK
+aJq
+aJq
 cmK
 cmK
 cmK
@@ -143761,18 +143834,18 @@ cnb
 cnb
 cnb
 cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
+cgv
+cgv
+cgv
+cbb
+cbb
+cbb
+jIC
+hLL
+hLL
+hLL
+hLL
+oyK
 jIC
 kPj
 kPj
@@ -143786,9 +143859,9 @@ cnb
 cnb
 cnb
 cmO
-cnb
-cnb
-cnb
+iKa
+iKa
+iKa
 cmO
 cmO
 cmO
@@ -143811,11 +143884,11 @@ kPj
 kPj
 kPj
 kPj
+kPj
+kPj
 oyK
-cmK
-cmK
-cmK
-cmK
+aJq
+aJq
 cmK
 cmK
 cmK
@@ -143928,18 +144001,18 @@ cnb
 cnb
 cnb
 cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
+cgv
+cgv
+cgv
+cbb
+cbb
+cbb
+cbb
+cbb
+cbb
+cbb
+cbb
+cbb
 cnb
 cnb
 jIC
@@ -143955,8 +144028,8 @@ cnb
 cnb
 cnb
 cnb
-cnb
-cnb
+iKa
+iKa
 cnb
 cmZ
 cmZ
@@ -143978,11 +144051,11 @@ hLL
 hLL
 hLL
 hLL
+hLL
+hLL
 oyK
-cmK
-cmK
-cmK
-cmK
+aJq
+aJq
 cmK
 cmK
 cmK
@@ -144098,17 +144171,17 @@ cnb
 cnb
 cnb
 cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
+cbb
+cbb
+cbb
+cbb
+cgv
+cgv
+cbb
+cbb
+cbb
+cbb
+cbb
 cnb
 cnb
 cnb
@@ -144148,9 +144221,9 @@ cmK
 cmK
 cmK
 cmK
-cmK
-cmK
-cmK
+aJq
+aJq
+aJq
 cmK
 cmK
 cmK
@@ -144267,15 +144340,15 @@ cnb
 cnb
 cnb
 cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
-cnb
+cbb
+cbb
+cbb
+cgv
+cgv
+cgv
+cgv
+cbb
+cbb
 cnb
 cnb
 cnb
@@ -144440,8 +144513,8 @@ cnb
 cnb
 cnb
 cnb
-cnb
-cnb
+cgv
+cgv
 cnb
 cnb
 cnb
@@ -144609,7 +144682,7 @@ cnb
 cnb
 cnb
 cnb
-cnb
+cgv
 cnb
 cnb
 cnb

--- a/maps/map_files/White_Antre_Research_Facility/White_Antre_Research_Facility.dmm
+++ b/maps/map_files/White_Antre_Research_Facility/White_Antre_Research_Facility.dmm
@@ -1090,9 +1090,6 @@
 /obj/effect/landmark/monkey_spawn,
 /turf/open/floor/prison/floor_plate/southwest,
 /area/white_antre/indoors/main_level/east_containment_hive)
-"acU" = (
-/turf/open/floor/darkish,
-/area/white_antre/indoors/main_level/east_containment_hive)
 "acV" = (
 /obj/effect/landmark/objective_landmark/close,
 /obj/structure/filingcabinet{
@@ -13127,8 +13124,8 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/indoors/main_level/east_containment)
 "aEi" = (
-/turf/open/floor/prison/redcorner,
-/area/white_antre/indoors/main_level/east_containment)
+/turf/open/floor/darkish,
+/area/white_antre/indoors/main_level/east_containment_hive)
 "aEj" = (
 /obj/structure/largecrate/random/barrel/brown,
 /turf/open/floor/almayer/silvercorner/north,
@@ -13276,11 +13273,8 @@
 /turf/open/floor/almayer/silver/west,
 /area/white_antre/indoors/main_level/research)
 "aEB" = (
-/obj/structure/pipes/standard/manifold/hidden/cyan{
-	dir = 1
-	},
-/turf/open/antre/plating/direction_north/north_edge,
-/area/white_antre/indoors/main_level/east_corridor)
+/turf/open/floor/prison/redcorner,
+/area/white_antre/indoors/main_level/east_containment)
 "aEC" = (
 /obj/structure/machinery/recharge_station/alt{
 	dir = 4
@@ -13296,6 +13290,12 @@
 /turf/open/floor/prison/darkred2/west,
 /area/white_antre/indoors/underground_level/west_maint)
 "aEF" = (
+/obj/structure/pipes/standard/manifold/hidden/cyan{
+	dir = 1
+	},
+/turf/open/antre/plating/direction_north/north_edge,
+/area/white_antre/indoors/main_level/east_corridor)
+"aEG" = (
 /obj/item/prop/alien/hugger{
 	icon = 'icons/mob/xenos/castes/tier_0/larva.dmi';
 	icon_state = "Larva Dead";
@@ -13306,10 +13306,6 @@
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/open/floor/prison/floor_marked/southwest,
 /area/white_antre/indoors/main_level/east_containment)
-"aEG" = (
-/obj/structure/largecrate/random/barrel/green,
-/turf/open/auto_turf/shale/layer1/weedable,
-/area/white_antre/landing_zone)
 "aEH" = (
 /obj/structure/surface/table/almayer{
 	color = "#848484"
@@ -13329,13 +13325,11 @@
 /turf/open/floor/almayer/emeraldfull2,
 /area/white_antre/indoors/main_level/research)
 "aEI" = (
-/obj/structure/cargo_container/uscm/chinook/left{
-	layer = 3.1
-	},
+/obj/structure/largecrate/random/barrel/green,
 /turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/landing_zone)
 "aEJ" = (
-/obj/structure/cargo_container/uscm/chinook/mid{
+/obj/structure/cargo_container/uscm/chinook/left{
 	layer = 3.1
 	},
 /turf/open/auto_turf/shale/layer1/weedable,
@@ -13348,7 +13342,7 @@
 /turf/open/floor/almayer/emerald2smooth/east,
 /area/white_antre/indoors/main_level/research)
 "aEL" = (
-/obj/structure/cargo_container/uscm/right{
+/obj/structure/cargo_container/uscm/chinook/mid{
 	layer = 3.1
 	},
 /turf/open/auto_turf/shale/layer1/weedable,
@@ -13372,19 +13366,21 @@
 /turf/open/floor/almayer/emerald2smooth/northeast,
 /area/white_antre/indoors/main_level/research)
 "aEO" = (
-/obj/structure/largecrate/random/barrel/blue,
+/obj/structure/cargo_container/uscm/right{
+	layer = 3.1
+	},
 /turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/landing_zone)
 "aEP" = (
+/obj/structure/largecrate/random/barrel/blue,
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/landing_zone)
+"aEQ" = (
 /obj/structure/cargo_container/wy/left,
 /turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/landing_zone)
-"aEQ" = (
-/obj/structure/cargo_container/wy/mid,
-/turf/open/auto_turf/sand_white/layer0,
-/area/white_antre/landing_zone)
 "aER" = (
-/obj/structure/cargo_container/wy/right,
+/obj/structure/cargo_container/wy/mid,
 /turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/landing_zone)
 "aES" = (
@@ -13401,7 +13397,7 @@
 /turf/open/floor/almayer/silver/west,
 /area/white_antre/indoors/main_level/research)
 "aET" = (
-/obj/structure/largecrate/random/case/double,
+/obj/structure/cargo_container/wy/right,
 /turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/landing_zone)
 "aEU" = (
@@ -13412,8 +13408,9 @@
 /turf/open/floor/almayer/silver,
 /area/white_antre/indoors/main_level/research)
 "aEV" = (
-/turf/open/floor/hybrisa/metal/zbrownfloor_full,
-/area/white_antre/landing_zone/roof)
+/obj/structure/largecrate/random/case/double,
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/landing_zone)
 "aEW" = (
 /obj/item/stack/sheet/metal,
 /obj/effect/antre/border/corner{
@@ -13422,9 +13419,8 @@
 /turf/open/floor/prison/darkpurple2/southeast,
 /area/white_antre/indoors/underground_level/east_maint)
 "aEX" = (
-/obj/structure/largecrate/random,
-/turf/open/auto_turf/sand_white/layer0,
-/area/white_antre/landing_zone)
+/turf/open/floor/hybrisa/metal/zbrownfloor_full,
+/area/white_antre/landing_zone/roof)
 "aEY" = (
 /obj/structure/surface/table/reinforced/prison{
 	color = "#6b675e"
@@ -13436,34 +13432,35 @@
 /turf/open/floor/almayer/silver,
 /area/white_antre/indoors/main_level/research)
 "aEZ" = (
+/obj/structure/largecrate/random,
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/landing_zone)
+"aFa" = (
 /obj/structure/machinery/door/airlock/almayer/secure/colony{
 	dir = 2
 	},
 /turf/open/floor/corsat/marked,
 /area/white_antre/landing_zone/roof)
-"aFa" = (
+"aFb" = (
 /obj/structure/largecrate/random/barrel/brown,
 /turf/open/asphalt/cement/cement12,
 /area/white_antre/landing_zone)
-"aFb" = (
+"aFc" = (
 /turf/open/floor/prison/darkyellowfull2,
 /area/white_antre/landing_zone/roof)
-"aFc" = (
+"aFd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/door/airlock/multi_tile/hybrisa/personal/autoname,
 /turf/open/floor/corsat/marked,
 /area/white_antre/landing_zone/roof)
-"aFd" = (
+"aFe" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/corsat/marked,
 /area/white_antre/landing_zone/roof)
-"aFe" = (
+"aFf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/framed/strata/reinforced,
 /turf/open/floor/plating,
-/area/white_antre/landing_zone/roof)
-"aFf" = (
-/turf/open/floor/prison/darkyellow2,
 /area/white_antre/landing_zone/roof)
 "aFg" = (
 /obj/item/paper/crumpled{
@@ -14021,7 +14018,7 @@
 /turf/open/floor/almayer/silver,
 /area/white_antre/indoors/main_level/north_containment_hive)
 "aGq" = (
-/turf/open/floor/prison/darkyellow2/southeast,
+/turf/open/floor/prison/darkyellow2,
 /area/white_antre/landing_zone/roof)
 "aGr" = (
 /obj/structure/flora/pottedplant{
@@ -15053,8 +15050,7 @@
 /turf/open/floor/prison/floor_plate/southwest,
 /area/white_antre/indoors/main_level/east_containment)
 "aIu" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison/darkbrown2/southwest,
+/turf/open/floor/prison/darkyellow2/southeast,
 /area/white_antre/landing_zone/roof)
 "aIv" = (
 /obj/structure/flora/bush/snow{
@@ -15071,11 +15067,11 @@
 /turf/open/auto_turf/snow/layer2,
 /area/white_antre/oob)
 "aIw" = (
-/turf/open/floor/prison/darkbrown2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/darkbrown2/southwest,
 /area/white_antre/landing_zone/roof)
 "aIx" = (
-/obj/structure/machinery/disposal,
-/turf/open/floor/prison/darkbrown2/southeast,
+/turf/open/floor/prison/darkbrown2,
 /area/white_antre/landing_zone/roof)
 "aIy" = (
 /turf/open/floor/almayer/silver/east,
@@ -15104,8 +15100,8 @@
 /turf/open/floor/strata/white_cyan3,
 /area/white_antre/indoors/upper_level/medical)
 "aID" = (
-/obj/structure/largecrate/random/barrel/black,
-/turf/open/floor/prison/darkyellow2,
+/obj/structure/machinery/disposal,
+/turf/open/floor/prison/darkbrown2/southeast,
 /area/white_antre/landing_zone/roof)
 "aIE" = (
 /obj/effect/decal/warning_stripes{
@@ -15330,8 +15326,8 @@
 /turf/open/floor/almayer/emerald2smooth/west,
 /area/white_antre/indoors/main_level/research)
 "aJb" = (
-/obj/structure/largecrate/random/barrel/medical,
-/turf/open/floor/prison/darkyellowcorners2/west,
+/obj/structure/largecrate/random/barrel/black,
+/turf/open/floor/prison/darkyellow2,
 /area/white_antre/landing_zone/roof)
 "aJc" = (
 /obj/structure/bed/chair/office/dark{
@@ -15365,10 +15361,8 @@
 /turf/open/floor/almayer/emerald2smooth/northeast,
 /area/white_antre/indoors/main_level/research)
 "aJg" = (
-/obj/structure/machinery/light/double{
-	dir = 4
-	},
-/turf/open/floor/prison/darkyellow2/east,
+/obj/structure/largecrate/random/barrel/medical,
+/turf/open/floor/prison/darkyellowcorners2/west,
 /area/white_antre/landing_zone/roof)
 "aJh" = (
 /obj/effect/decal/warning_stripes{
@@ -16651,10 +16645,10 @@
 /turf/open/floor/prison/darkbrown2/west,
 /area/white_antre/landing_zone/roof)
 "aNL" = (
-/obj/structure/bed/chair{
-	dir = 1
+/obj/structure/machinery/light/double{
+	dir = 4
 	},
-/turf/open/floor/prison/darkbrown2/east,
+/turf/open/floor/prison/darkyellow2/east,
 /area/white_antre/landing_zone/roof)
 "aNM" = (
 /obj/structure/filingcabinet{
@@ -20651,16 +20645,6 @@
 	},
 /turf/open/antre/plating/direction_west,
 /area/white_antre/indoors/main_level/east_containment)
-"aZz" = (
-/obj/structure/machinery/door_control/brbutton/alt{
-	id = "LZ1_Lockdown_Lo";
-	name = "remote door-control";
-	pixel_y = -2;
-	pixel_x = 6
-	},
-/obj/structure/surface/table/almayer,
-/turf/open/floor/prison/darkbrownfull2,
-/area/white_antre/landing_zone/roof)
 "aZA" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "test_warning_smooth_red"
@@ -27674,7 +27658,10 @@
 /turf/open/antre/plating/direction_north/east_edge,
 /area/white_antre/indoors/upper_level/east_corridor)
 "bsr" = (
-/turf/open/floor/prison/darkyellow2/west,
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/floor/prison/darkbrown2/east,
 /area/white_antre/landing_zone/roof)
 "bss" = (
 /obj/effect/decal/cleanable/dirt,
@@ -38079,7 +38066,14 @@
 /turf/open/antre/plating/direction_north,
 /area/white_antre/indoors/upper_level/central_corridor)
 "bPX" = (
-/turf/open/floor/prison/darkyellow2/east,
+/obj/structure/machinery/door_control/brbutton/alt{
+	id = "LZ1_Lockdown_Lo";
+	name = "remote door-control";
+	pixel_y = -2;
+	pixel_x = 6
+	},
+/obj/structure/surface/table/almayer,
+/turf/open/floor/prison/darkbrownfull2,
 /area/white_antre/landing_zone/roof)
 "bPY" = (
 /obj/effect/mist/steam{
@@ -38501,17 +38495,15 @@
 /turf/open/antre/plating/corner_dir,
 /area/white_antre/indoors/upper_level/central_corridor)
 "bQQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/largecrate/random/barrel/white,
-/turf/open/floor/plating/plating_catwalk/prison,
+/turf/open/floor/prison/darkyellow2/west,
 /area/white_antre/landing_zone/roof)
 "bQR" = (
-/obj/structure/machinery/door/airlock/almayer/secure/colony,
-/turf/open/floor/corsat/marked,
+/turf/open/floor/prison/darkyellow2/east,
 /area/white_antre/landing_zone/roof)
 "bQS" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison/darkyellowcorners2/north,
+/obj/structure/largecrate/random/barrel/white,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone/roof)
 "bQT" = (
 /obj/effect/decal/cleanable/blood,
@@ -38548,8 +38540,8 @@
 /turf/open/floor/prison,
 /area/white_antre/indoors/upper_level/west_corridor)
 "bQW" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison/darkyellow2/northeast,
+/obj/structure/machinery/door/airlock/almayer/secure/colony,
+/turf/open/floor/corsat/marked,
 /area/white_antre/landing_zone/roof)
 "bQX" = (
 /obj/effect/antre/border/edge{
@@ -39178,9 +39170,8 @@
 /turf/open/floor/prison,
 /area/white_antre/indoors/main_level/weapons)
 "bSn" = (
-/obj/structure/surface/rack,
-/obj/item/stack/sheet/metal/medium_stack,
-/turf/open/floor/prison,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/darkyellowcorners2/north,
 /area/white_antre/landing_zone/roof)
 "bSo" = (
 /obj/structure/window/framed/hybrisa/research/reinforced,
@@ -40545,8 +40536,8 @@
 /turf/open/floor/prison/green,
 /area/white_antre/indoors/underground_level/east_maint)
 "bVK" = (
-/obj/structure/largecrate/random/secure,
-/turf/open/floor/plating/plating_catwalk/prison,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/darkyellow2/northeast,
 /area/white_antre/landing_zone/roof)
 "bVL" = (
 /obj/effect/decal/hybrisa/bloodtrail/clawtrail/xeno{
@@ -41292,8 +41283,8 @@
 /turf/open/floor/prison/floor_plate,
 /area/white_antre/landing_zone)
 "bXM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/largecrate/random/barrel/white,
+/obj/structure/surface/rack,
+/obj/item/stack/sheet/metal/medium_stack,
 /turf/open/floor/prison,
 /area/white_antre/landing_zone/roof)
 "bXN" = (
@@ -41492,9 +41483,8 @@
 /turf/open/auto_turf/hybrisa_auto_turf/layer1,
 /area/white_antre/oob)
 "bYm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison/darkbrown2/east,
+/obj/structure/largecrate/random/secure,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone/roof)
 "bYn" = (
 /turf/open/auto_turf/hybrisa_auto_turf/layer1,
@@ -41592,10 +41582,9 @@
 /turf/open/auto_turf/hybrisa_auto_turf/layer1,
 /area/white_antre/indoors/main_level/north_containment_hive)
 "bYG" = (
-/obj/item/tool/warning_cone{
-	pixel_y = 16
-	},
-/turf/open/floor/prison/darkyellow2/northwest,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/random/barrel/white,
+/turf/open/floor/prison,
 /area/white_antre/landing_zone/roof)
 "bYH" = (
 /turf/open/slippery/roof/dir/east,
@@ -41633,24 +41622,35 @@
 /turf/open/slippery/roof/dir/northeast,
 /area/white_antre/outdoors/facility_exterior)
 "bYS" = (
-/turf/open/floor/prison/darkyellowcorners2/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/darkbrown2/east,
 /area/white_antre/landing_zone/roof)
 "bYT" = (
+/obj/item/tool/warning_cone{
+	pixel_y = 16
+	},
+/turf/open/floor/prison/darkyellow2/northwest,
+/area/white_antre/landing_zone/roof)
+"bYU" = (
+/turf/open/floor/prison/darkyellowcorners2/east,
+/area/white_antre/landing_zone/roof)
+"bYV" = (
 /obj/item/tool/warning_cone{
 	pixel_x = 5;
 	pixel_y = 13
 	},
 /turf/open/floor/prison/darkyellowcorners2/north,
 /area/white_antre/landing_zone/roof)
-"bYU" = (
+"bYW" = (
 /turf/open/floor/prison/darkyellow2/northeast,
 /area/white_antre/landing_zone/roof)
-"bYV" = (
+"bYX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/white_antre/landing_zone/roof)
-"bYW" = (
+"bYY" = (
 /obj/structure/machinery/space_heater/radiator/red{
 	dir = 8;
 	pixel_x = 1
@@ -41660,58 +41660,44 @@
 	},
 /turf/open/floor/prison/darkbrownfull2,
 /area/white_antre/landing_zone/roof)
-"bYX" = (
+"bYZ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/darkyellow2/east,
+/area/white_antre/indoors/exterior/prefab_3)
+"bZa" = (
 /obj/structure/largecrate/random/barrel/brown,
 /turf/open/floor/prison/darkyellow2/northwest,
 /area/white_antre/landing_zone/roof)
-"bYY" = (
+"bZb" = (
 /obj/structure/largecrate/random/case/double,
 /obj/structure/machinery/light/double{
 	dir = 1
 	},
 /turf/open/floor/prison/darkyellow2/north,
 /area/white_antre/landing_zone/roof)
-"bYZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison/darkyellow2/east,
-/area/white_antre/indoors/exterior/prefab_3)
-"bZa" = (
+"bZc" = (
 /obj/structure/cargo_container/hybrisa/containersextended/redleft,
 /turf/open/floor/prison/darkyellow2/northeast,
 /area/white_antre/landing_zone/roof)
-"bZb" = (
+"bZd" = (
 /obj/structure/cargo_container/hybrisa/containersextended/redright,
 /turf/closed/wall/strata_outpost/reinforced/hull,
 /area/white_antre/landing_zone/roof)
-"bZc" = (
+"bZe" = (
 /turf/open/floor/strata/multi_tiles,
 /area/white_antre/landing_zone/roof)
-"bZd" = (
+"bZf" = (
 /turf/open/floor/strata/multi_tiles/west,
 /area/white_antre/landing_zone/roof)
-"bZe" = (
+"bZg" = (
 /turf/open/floor/strata/floor3,
 /area/white_antre/landing_zone/roof)
-"bZf" = (
+"bZh" = (
 /obj/structure/stairs/perspective{
 	dir = 9;
 	icon_state = "p_stair_full"
 	},
 /turf/open/auto_turf/shale/layer1/weedable,
-/area/white_antre/outdoors/north_field)
-"bZg" = (
-/obj/structure/stairs/perspective{
-	dir = 1;
-	icon_state = "p_stair_full"
-	},
-/turf/open/auto_turf/shale/layer1/weedable,
-/area/white_antre/outdoors/north_field)
-"bZh" = (
-/obj/structure/stairs/perspective{
-	dir = 1;
-	icon_state = "p_stair_full"
-	},
-/turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/outdoors/north_field)
 "bZi" = (
 /turf/closed/wall/hybrisa/research/reinforced/hull,
@@ -41724,10 +41710,10 @@
 /area/white_antre/oob)
 "bZl" = (
 /obj/structure/stairs/perspective{
-	dir = 5;
+	dir = 1;
 	icon_state = "p_stair_full"
 	},
-/turf/open/auto_turf/sand_white/layer0,
+/turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/outdoors/north_field)
 "bZm" = (
 /obj/effect/mist/steam{
@@ -41828,13 +41814,12 @@
 /turf/open/auto_turf/strata_grass/layer0_mud,
 /area/white_antre/oob)
 "bZy" = (
-/obj/effect/mist/steam{
-	pixel_x = -10;
-	pixel_y = 9
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
 	},
-/obj/structure/platform/stone/strata/east,
-/turf/solid_open_space,
-/area/white_antre/oob)
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/outdoors/north_field)
 "bZz" = (
 /obj/structure/barricade/handrail{
 	dir = 1
@@ -41853,14 +41838,12 @@
 /turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/oob)
 "bZC" = (
-/obj/effect/mist/steam{
-	pixel_x = -3;
-	pixel_y = -3
+/obj/structure/stairs/perspective{
+	dir = 5;
+	icon_state = "p_stair_full"
 	},
-/obj/structure/platform/stone/strata/east,
-/obj/structure/platform/stone/strata,
-/turf/solid_open_space,
-/area/white_antre/oob)
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/outdoors/north_field)
 "bZD" = (
 /obj/structure/stairs/perspective{
 	dir = 8
@@ -42397,8 +42380,13 @@
 /turf/open/floor/prison/bluefull,
 /area/white_antre/indoors/exterior/prefab_1)
 "cbb" = (
-/turf/closed/wall/strata_ice,
-/area/white_antre/outdoors/north_field)
+/obj/effect/mist/steam{
+	pixel_x = -10;
+	pixel_y = 9
+	},
+/obj/structure/platform/stone/strata/east,
+/turf/solid_open_space,
+/area/white_antre/oob)
 "cbc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/blue/west,
@@ -44439,8 +44427,14 @@
 /turf/open/auto_turf/snow/layer1,
 /area/white_antre/oob)
 "cgv" = (
-/turf/closed/wall/strata_ice/dirty/rock,
-/area/white_antre/outdoors/north_field)
+/obj/effect/mist/steam{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/structure/platform/stone/strata/east,
+/obj/structure/platform/stone/strata,
+/turf/solid_open_space,
+/area/white_antre/oob)
 "cgw" = (
 /obj/structure/machinery/light/red{
 	light_color = "#BB3F3F";
@@ -45016,6 +45010,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkpurple2/west,
 /area/white_antre/indoors/main_level/east_corridor)
+"chK" = (
+/turf/closed/wall/strata_ice,
+/area/white_antre/outdoors/north_field)
 "chL" = (
 /obj/structure/barricade/handrail,
 /obj/effect/antre/border,
@@ -45522,6 +45519,9 @@
 /obj/structure/platform_decoration/metal/almayer_smooth/east,
 /turf/open_space,
 /area/white_antre/indoors/upper_level/central_corridor)
+"cjc" = (
+/turf/closed/wall/strata_ice/dirty/rock,
+/area/white_antre/outdoors/north_field)
 "cjg" = (
 /obj/structure/barricade/handrail{
 	dir = 8
@@ -99983,7 +99983,7 @@ bNU
 bNP
 bNU
 bNP
-bZy
+cbb
 byZ
 iKa
 iKa
@@ -100150,7 +100150,7 @@ bNY
 bNV
 bOI
 bOH
-bZC
+cgv
 aMJ
 aMJ
 aMJ
@@ -100330,7 +100330,7 @@ aNJ
 aNJ
 bel
 bdZ
-aIu
+aIw
 iFy
 aNi
 aKB
@@ -100499,7 +100499,7 @@ aKf
 aKf
 aKf
 aNC
-aFc
+aFd
 aNi
 aKB
 aKB
@@ -100657,21 +100657,21 @@ aMS
 aMJ
 aMJ
 aMJ
-bZf
+bZh
 ctR
 ctR
 ctR
 aNN
 aKf
-bSn
+bXM
 ben
 aKf
-aIw
-aFd
+aIx
+aFe
 aNi
 aKC
-aEO
-aEG
+aEP
+aEI
 ceR
 dwB
 bYb
@@ -100825,21 +100825,21 @@ aMJ
 aMJ
 aMJ
 aMJ
+bZl
 bZg
 bZe
-bZc
 aNA
 aNN
 aKf
-bVK
+bYm
 aKp
 aKf
-aIw
-aFe
+aIx
+aFf
 aNi
-aEX
+aEZ
 aKB
-aEI
+aEJ
 aKB
 dwB
 bbQ
@@ -100993,21 +100993,21 @@ aMH
 beA
 beA
 bee
+bZl
 bZg
-bZe
-bZd
+bZf
 aNA
 aNN
 aKf
 aKf
 aKf
 aKf
-aIw
-aFe
+aIx
+aFf
 aNi
 aKC
-aEP
-aEJ
+aEQ
+aEL
 aKB
 odB
 oSf
@@ -101161,21 +101161,21 @@ bfb
 aMH
 aMH
 bef
+bZl
 bZg
-bZe
-bZd
+bZf
 aNA
 aNN
 aKf
 aXH
 aKf
 aKf
-aIw
-aFe
+aIx
+aFf
 aNi
 aKC
-aEQ
-aEL
+aER
+aEO
 aKF
 aKB
 aKC
@@ -101329,20 +101329,20 @@ aMH
 aMH
 beX
 bef
+bZl
 bZg
-bZe
-bZd
+bZf
 aNA
 aNN
 aKf
-bXM
+bYG
 aKf
 aKf
-aIw
+aIx
 atH
-aFa
+aFb
 aKC
-aER
+aET
 aKB
 aKB
 aKB
@@ -101497,20 +101497,20 @@ beS
 uoG
 aMH
 beP
-bZh
+bZy
+bZg
 bZe
-bZc
 aNA
 aNN
-bYV
+bYX
 bpa
-bQQ
+bQS
 aXH
 aNC
 aKz
 aNi
 aKC
-aET
+aEV
 aKB
 aKB
 aKB
@@ -101665,16 +101665,16 @@ aMH
 lGQ
 kGT
 beP
-bZl
+bZC
 ctR
 ctR
 ctR
 aNO
-bYm
-bYm
+bYS
+bYS
 bev
-aNL
-aIx
+bsr
+aID
 ctR
 aNi
 aKC
@@ -101838,10 +101838,10 @@ iKa
 iKa
 bRL
 bRL
-bYW
+bYY
 beq
 beq
-aZz
+bPX
 ctR
 ctR
 aNi
@@ -102008,7 +102008,7 @@ iKa
 bRL
 bRL
 akw
-bQR
+bQW
 akw
 ctR
 ctR
@@ -102175,9 +102175,9 @@ iKa
 iKa
 iKa
 bRL
-aFb
-aFb
-aFb
+aFc
+aFc
+aFc
 ctR
 ctR
 aNi
@@ -102343,9 +102343,9 @@ iKa
 iKa
 bRL
 bRL
-bYG
-bsr
-bsr
+bYT
+bQQ
+bQQ
 ctR
 ctR
 aKA
@@ -102510,11 +102510,11 @@ aMI
 iKa
 iKa
 bRL
-bYX
-bYS
+bZa
+bYU
 aKf
 aKf
-aID
+aJb
 ctR
 ctR
 aKA
@@ -102678,11 +102678,11 @@ aMJ
 iKa
 iKa
 bRL
-bYY
+bZb
 aKf
 aXL
 aKp
-aJb
+aJg
 aKt
 ctR
 ctR
@@ -102846,13 +102846,13 @@ aMJ
 aMJ
 iKa
 bRL
-bZa
-bYT
+bZc
+bYV
 aXH
 aKp
 aKf
-aFf
-aFb
+aGq
+aFc
 akw
 bdH
 pDy
@@ -103014,15 +103014,15 @@ aMH
 ewE
 iKa
 bRL
-bZb
-bYU
-bQS
+bZd
+bYW
+bSn
 aKf
 aKf
-aFf
-aFb
-aEZ
-aEV
+aGq
+aFc
+aFa
+aEX
 bpx
 aXL
 aXH
@@ -103184,11 +103184,11 @@ iKa
 iKa
 bRL
 bRL
-bQW
-bPX
-aJg
-aGq
-aFb
+bVK
+bQR
+aNL
+aIu
+aFc
 akw
 bdI
 xJX
@@ -120346,7 +120346,7 @@ asa
 coM
 bHo
 bHo
-aEB
+aEF
 bTy
 bSz
 bSz
@@ -124538,7 +124538,7 @@ aZn
 cuF
 aKK
 abK
-aEF
+aEG
 abG
 aKK
 cub
@@ -125725,7 +125725,7 @@ baM
 aKV
 bHo
 bHo
-aEi
+aEB
 lvO
 aZI
 aKV
@@ -127537,21 +127537,21 @@ azn
 azl
 ayS
 aTp
-acU
-acU
-acU
-acU
-acU
+aEi
+aEi
+aEi
+aEi
+aEi
 aOc
 ayS
 ayW
 ayS
 aTp
-acU
-acU
-acU
-acU
-acU
+aEi
+aEi
+aEi
+aEi
+aEi
 aOc
 ayV
 ayS
@@ -127585,21 +127585,21 @@ azk
 ayS
 ayV
 aTp
-acU
-acU
-acU
-acU
-acU
+aEi
+aEi
+aEi
+aEi
+aEi
 aOc
 ayS
 ayW
 ayS
 aTp
-acU
-acU
-acU
-acU
-acU
+aEi
+aEi
+aEi
+aEi
+aEi
 aOc
 ayS
 ayR
@@ -127709,13 +127709,13 @@ azr
 azr
 azr
 nVc
-acU
+aEi
 aOc
 ayS
 ayW
 ayS
 aTp
-acU
+aEi
 ayJ
 azr
 azr
@@ -127757,13 +127757,13 @@ azr
 azr
 azr
 nVc
-acU
+aEi
 aOc
 ayS
 ayW
 ayS
 aTp
-acU
+aEi
 ayJ
 azr
 azr
@@ -130061,13 +130061,13 @@ aAy
 azc
 azc
 bbI
-acU
+aEi
 aOc
 ayS
 ayW
 ayS
 aTp
-acU
+aEi
 boU
 azc
 azc
@@ -130109,13 +130109,13 @@ aAy
 azc
 azc
 bbI
-acU
+aEi
 aOc
 ayS
 ayW
 ayS
 aTp
-acU
+aEi
 boU
 azc
 azc
@@ -130225,21 +130225,21 @@ azm
 azj
 ayS
 aTp
-acU
-acU
-acU
-acU
-acU
+aEi
+aEi
+aEi
+aEi
+aEi
 aOc
 ayS
 ayW
 ayS
 aTp
-acU
-acU
-acU
-acU
-acU
+aEi
+aEi
+aEi
+aEi
+aEi
 aOc
 ayV
 ayS
@@ -130273,21 +130273,21 @@ azk
 ayS
 ayV
 aTp
-acU
-acU
-acU
-acU
-acU
+aEi
+aEi
+aEi
+aEi
+aEi
 aOc
 ayS
 ayW
 ayS
 aTp
-acU
-acU
-acU
-acU
-acU
+aEi
+aEi
+aEi
+aEi
+aEi
 aOc
 ayS
 ayT
@@ -140307,7 +140307,7 @@ spC
 spC
 spC
 spC
-cbb
+chK
 spC
 spC
 spC
@@ -140474,10 +140474,10 @@ spC
 spC
 spC
 spC
-cbb
-cbb
-cbb
-cbb
+chK
+chK
+chK
+chK
 tUu
 kDp
 kDp
@@ -140643,8 +140643,8 @@ spC
 cnb
 cnb
 cnb
-cbb
-cbb
+chK
+chK
 tUu
 kPj
 kPj
@@ -140810,9 +140810,9 @@ cnb
 cnb
 cnb
 cnb
-cbb
-cbb
-cbb
+chK
+chK
+chK
 fuj
 kPj
 kPj
@@ -140978,9 +140978,9 @@ cnb
 cnb
 cnb
 cnb
-cbb
-cbb
-cbb
+chK
+chK
+chK
 jIC
 hLL
 kPj
@@ -142323,8 +142323,8 @@ cnb
 cnb
 cnb
 cnb
-cbb
-cbb
+chK
+chK
 jIC
 tUu
 kDp
@@ -142491,9 +142491,9 @@ cnb
 cnb
 cnb
 cnb
-cbb
-cbb
-cbb
+chK
+chK
+chK
 jIC
 kPj
 kPj
@@ -142660,9 +142660,9 @@ cnb
 cnb
 cnb
 cnb
-cbb
-cbb
-cbb
+chK
+chK
+chK
 fuj
 kPj
 kPj
@@ -142828,8 +142828,8 @@ cnb
 cnb
 cnb
 cnb
-cbb
-cbb
+chK
+chK
 tUu
 kPj
 kPj
@@ -142996,8 +142996,8 @@ cnb
 cnb
 cnb
 cnb
-cbb
-cbb
+chK
+chK
 fuj
 kPj
 kPj
@@ -143164,8 +143164,8 @@ cnb
 cnb
 cnb
 cnb
-cbb
-cbb
+chK
+chK
 fuj
 kPj
 kPj
@@ -143333,7 +143333,7 @@ cnb
 cnb
 cnb
 cnb
-cbb
+chK
 fuj
 kPj
 kPj
@@ -143500,8 +143500,8 @@ cnb
 cnb
 cnb
 cnb
-cgv
-cbb
+cjc
+chK
 jIC
 kPj
 kPj
@@ -143668,9 +143668,9 @@ cnb
 cnb
 cnb
 cnb
-cgv
-cbb
-cbb
+cjc
+chK
+chK
 jIC
 kPj
 kPj
@@ -143834,12 +143834,12 @@ cnb
 cnb
 cnb
 cnb
-cgv
-cgv
-cgv
-cbb
-cbb
-cbb
+cjc
+cjc
+cjc
+chK
+chK
+chK
 jIC
 hLL
 hLL
@@ -144001,18 +144001,18 @@ cnb
 cnb
 cnb
 cnb
-cgv
-cgv
-cgv
-cbb
-cbb
-cbb
-cbb
-cbb
-cbb
-cbb
-cbb
-cbb
+cjc
+cjc
+cjc
+chK
+chK
+chK
+chK
+chK
+chK
+chK
+chK
+chK
 cnb
 cnb
 jIC
@@ -144171,17 +144171,17 @@ cnb
 cnb
 cnb
 cnb
-cbb
-cbb
-cbb
-cbb
-cgv
-cgv
-cbb
-cbb
-cbb
-cbb
-cbb
+chK
+chK
+chK
+chK
+cjc
+cjc
+chK
+chK
+chK
+chK
+chK
 cnb
 cnb
 cnb
@@ -144340,15 +144340,15 @@ cnb
 cnb
 cnb
 cnb
-cbb
-cbb
-cbb
-cgv
-cgv
-cgv
-cgv
-cbb
-cbb
+chK
+chK
+chK
+cjc
+cjc
+cjc
+cjc
+chK
+chK
 cnb
 cnb
 cnb
@@ -144513,8 +144513,8 @@ cnb
 cnb
 cnb
 cnb
-cgv
-cgv
+cjc
+cjc
 cnb
 cnb
 cnb
@@ -144682,7 +144682,7 @@ cnb
 cnb
 cnb
 cnb
-cgv
+cjc
 cnb
 cnb
 cnb

--- a/maps/map_files/White_Antre_Research_Facility/White_Antre_Research_Facility.dmm
+++ b/maps/map_files/White_Antre_Research_Facility/White_Antre_Research_Facility.dmm
@@ -1098,9 +1098,6 @@
 /obj/effect/landmark/monkey_spawn,
 /turf/open/floor/prison/floor_plate/southwest,
 /area/white_antre/indoors/main_level/east_containment_hive)
-"acU" = (
-/turf/closed/wall/mineral/bone_resin/k_series,
-/area/white_antre/indoors/main_level/east_containment_hive)
 "acV" = (
 /obj/effect/landmark/objective_landmark/close,
 /obj/structure/filingcabinet{
@@ -1270,7 +1267,7 @@
 	dir = 4
 	},
 /turf/closed/wall/mineral/bone_resin/k_series,
-/area/white_antre/indoors/main_level/east_containment_hive)
+/area/white_antre/oob)
 "adi" = (
 /obj/structure/filingcabinet{
 	density = 0;
@@ -1738,8 +1735,8 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "door_warning2"
 	},
-/turf/closed/wall/mineral/bone_resin/k_series,
-/area/white_antre/oob)
+/turf/open/floor/almayer/silver/north,
+/area/white_antre/indoors/main_level/east_containment_hive)
 "aer" = (
 /obj/structure/platform/metal/almayer,
 /turf/closed/wall/mineral/bone_resin/k_series,
@@ -13151,6 +13148,9 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/indoors/main_level/east_containment)
+"aEi" = (
+/turf/open/floor/prison/redcorner,
+/area/white_antre/indoors/main_level/east_containment)
 "aEj" = (
 /obj/structure/largecrate/random/barrel/brown,
 /turf/open/floor/almayer/silvercorner/north,
@@ -20596,15 +20596,6 @@
 	},
 /turf/open/antre/plating/direction_west,
 /area/white_antre/indoors/main_level/east_containment)
-"aZz" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "door_warning2_red";
-	dir = 8;
-	pixel_x = -2
-	},
-/obj/effect/decal/cleanable/blood/xeno,
-/turf/closed/wall/mineral/bone_resin/k_series,
-/area/white_antre/oob)
 "aZA" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "test_warning_smooth_red"
@@ -125160,7 +125151,7 @@ aLJ
 baa
 aLJ
 afQ
-aZz
+bat
 aeO
 aLC
 bHo
@@ -125661,7 +125652,7 @@ baM
 aKV
 bHo
 bHo
-bHo
+aEi
 lvO
 aZI
 aKV
@@ -125674,8 +125665,8 @@ azk
 ayS
 ayV
 bpi
-acU
-acU
+bHo
+bHo
 ayS
 ayU
 azq
@@ -125823,7 +125814,7 @@ bHo
 bHo
 bHo
 bHo
-lvO
+abe
 baW
 baN
 bHo
@@ -125838,12 +125829,12 @@ aLE
 lqX
 agk
 azu
-bHo
+azk
 ayS
 ayV
 ayV
 adh
-acU
+bHo
 ayS
 ayU
 ayO
@@ -126004,14 +125995,14 @@ aKV
 rEa
 aLD
 lqX
-bHo
+azk
 aeq
-bHo
+azk
 azj
 ayU
 ayU
-acU
-adh
+ayV
+bpi
 ayV
 ayT
 ayP

--- a/maps/map_files/White_Antre_Research_Facility/White_Antre_Research_Facility.dmm
+++ b/maps/map_files/White_Antre_Research_Facility/White_Antre_Research_Facility.dmm
@@ -1091,13 +1091,6 @@
 /obj/effect/landmark/monkey_spawn,
 /turf/open/floor/prison/floor_plate/southwest,
 /area/white_antre/indoors/main_level/east_containment_hive)
-"acU" = (
-/obj/structure/barricade/handrail/no_vault{
-	dir = 8
-	},
-/obj/structure/barricade/handrail/no_vault,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone)
 "acV" = (
 /obj/effect/landmark/objective_landmark/close,
 /obj/structure/filingcabinet{
@@ -1737,16 +1730,6 @@
 	},
 /turf/open/floor/almayer/silver/north,
 /area/white_antre/indoors/main_level/east_containment_hive)
-"aer" = (
-/obj/structure/stairs/perspective{
-	dir = 10;
-	icon_state = "p_stair_full"
-	},
-/obj/structure/barricade/handrail/no_vault{
-	dir = 8
-	},
-/turf/open/auto_turf/sand_white/layer0,
-/area/white_antre/landing_zone)
 "aes" = (
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "thermite";
@@ -2443,13 +2426,6 @@
 	},
 /turf/open/floor/almayer/silverfull,
 /area/white_antre/indoors/main_level/east_containment_hive)
-"afY" = (
-/obj/structure/machinery/door_control/brbutton{
-	pixel_y = 30;
-	id = "LZ1_Lockdown_north"
-	},
-/turf/open/floor/prison/darkbrown2/north,
-/area/white_antre/landing_zone/roof)
 "afZ" = (
 /obj/structure/sink{
 	dir = 8;
@@ -13437,14 +13413,10 @@
 /turf/open/floor/almayer/silver,
 /area/white_antre/indoors/main_level/research)
 "aEV" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s"
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
+/obj/structure/barricade/handrail/no_vault{
 	dir = 8
 	},
-/turf/open/floor/prison,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "aEW" = (
 /obj/item/stack/sheet/metal,
@@ -13454,11 +13426,14 @@
 /turf/open/floor/prison/darkpurple2/southeast,
 /area/white_antre/indoors/underground_level/east_maint)
 "aEX" = (
-/obj/item/device/flashlight/lamp/tripod,
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning_s"
 	},
-/turf/open/floor/prison/ramptop/east,
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 8
+	},
+/turf/open/floor/prison,
 /area/white_antre/landing_zone)
 "aEY" = (
 /obj/structure/surface/table/reinforced/prison{
@@ -13471,12 +13446,19 @@
 /turf/open/floor/almayer/silver,
 /area/white_antre/indoors/main_level/research)
 "aEZ" = (
+/obj/item/device/flashlight/lamp/tripod,
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning_s"
 	},
 /turf/open/floor/prison/ramptop/east,
 /area/white_antre/landing_zone)
 "aFa" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s"
+	},
+/turf/open/floor/prison/ramptop/east,
+/area/white_antre/landing_zone)
+"aFb" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning_s";
 	dir = 4;
@@ -13487,24 +13469,26 @@
 	},
 /turf/open/floor/prison,
 /area/white_antre/landing_zone)
-"aFb" = (
+"aFc" = (
 /obj/structure/largecrate/empty/secure,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
-"aFc" = (
+"aFd" = (
 /turf/open/floor/prison/blue/east,
 /area/white_antre/landing_zone/roof)
-"aFd" = (
+"aFe" = (
+/obj/structure/barricade/handrail/no_vault{
+	dir = 8
+	},
+/obj/structure/barricade/handrail/no_vault,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
+"aFf" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning_s";
 	dir = 8
 	},
 /turf/open/floor/prison/ramptop/north,
-/area/white_antre/landing_zone)
-"aFe" = (
-/obj/structure/platform/metal/almayer,
-/obj/structure/platform/metal/almayer/west,
-/turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/landing_zone)
 "aFg" = (
 /obj/item/paper/crumpled{
@@ -14061,6 +14045,11 @@
 /obj/effect/alien/weeds/node/kseries,
 /turf/open/floor/almayer/silver,
 /area/white_antre/indoors/main_level/north_containment_hive)
+"aGq" = (
+/obj/structure/platform/metal/almayer,
+/obj/structure/platform/metal/almayer/west,
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/landing_zone)
 "aGr" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_21"
@@ -15092,7 +15081,6 @@
 /area/white_antre/indoors/main_level/east_containment)
 "aIu" = (
 /obj/structure/platform/metal/almayer,
-/obj/structure/platform/metal/almayer/east,
 /turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/landing_zone)
 "aIv" = (
@@ -15110,18 +15098,15 @@
 /turf/open/auto_turf/snow/layer2,
 /area/white_antre/oob)
 "aIw" = (
+/obj/structure/platform/metal/almayer,
+/obj/structure/platform/metal/almayer/east,
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/landing_zone)
+"aIx" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning_s";
 	dir = 4;
 	layer = 2
-	},
-/turf/open/floor/prison/ramptop/north,
-/area/white_antre/landing_zone)
-"aIx" = (
-/obj/structure/platform/metal/almayer_smooth/north,
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
-	dir = 8
 	},
 /turf/open/floor/prison/ramptop/north,
 /area/white_antre/landing_zone)
@@ -15152,8 +15137,13 @@
 /turf/open/floor/strata/white_cyan3,
 /area/white_antre/indoors/upper_level/medical)
 "aID" = (
-/obj/structure/platform/metal/almayer/west,
-/obj/structure/platform_decoration/metal/almayer_smooth/east,
+/obj/structure/stairs/perspective{
+	dir = 10;
+	icon_state = "p_stair_full"
+	},
+/obj/structure/barricade/handrail/no_vault{
+	dir = 8
+	},
 /turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/landing_zone)
 "aIE" = (
@@ -15372,8 +15362,12 @@
 /turf/open/floor/almayer/emerald2smooth/west,
 /area/white_antre/indoors/main_level/research)
 "aJb" = (
-/obj/structure/platform/metal/almayer/east,
-/turf/open/auto_turf/sand_white/layer0,
+/obj/structure/platform/metal/almayer_smooth/north,
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 8
+	},
+/turf/open/floor/prison/ramptop/north,
 /area/white_antre/landing_zone)
 "aJc" = (
 /obj/structure/bed/chair/office/dark{
@@ -15407,10 +15401,9 @@
 /turf/open/floor/almayer/emerald2smooth/northeast,
 /area/white_antre/indoors/main_level/research)
 "aJg" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_c"
-	},
-/turf/open/floor/prison,
+/obj/structure/platform/metal/almayer/west,
+/obj/structure/platform_decoration/metal/almayer_smooth/east,
+/turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/landing_zone)
 "aJh" = (
 /obj/effect/decal/warning_stripes{
@@ -16694,7 +16687,7 @@
 /turf/open/floor/prison/darkbrown2/west,
 /area/white_antre/landing_zone/roof)
 "aNL" = (
-/obj/structure/platform/metal/almayer,
+/obj/structure/platform/metal/almayer/east,
 /turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/landing_zone)
 "aNM" = (
@@ -27662,12 +27655,10 @@
 /turf/open/antre/plating/direction_north/east_edge,
 /area/white_antre/indoors/upper_level/east_corridor)
 "bsr" = (
-/obj/effect/decal/hybrisa/dirt,
-/obj/structure/stairs/perspective{
-	dir = 1;
-	icon_state = "p_stair_full"
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_c"
 	},
-/turf/open/asphalt/cement/cement3,
+/turf/open/floor/prison,
 /area/white_antre/landing_zone)
 "bss" = (
 /obj/effect/decal/cleanable/dirt,
@@ -38065,12 +38056,13 @@
 /turf/open/antre/plating/direction_north,
 /area/white_antre/indoors/upper_level/central_corridor)
 "bPX" = (
-/obj/structure/flora/tree/tyrargo{
-	pixel_x = -26;
-	pixel_y = -2
+/obj/effect/decal/hybrisa/dirt,
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
 	},
-/turf/open/auto_turf/snow/layer2,
-/area/white_antre/outdoors/south_field)
+/turf/open/asphalt/cement/cement3,
+/area/white_antre/landing_zone)
 "bPY" = (
 /obj/effect/mist/steam{
 	pixel_x = 6;
@@ -38491,25 +38483,21 @@
 /turf/open/antre/plating/corner_dir,
 /area/white_antre/indoors/upper_level/central_corridor)
 "bQQ" = (
+/obj/structure/flora/tree/tyrargo{
+	pixel_x = -26;
+	pixel_y = -2
+	},
+/turf/open/auto_turf/snow/layer2,
+/area/white_antre/outdoors/south_field)
+"bQR" = (
 /turf/open/floor/prison/redcorner,
 /area/white_antre/indoors/main_level/east_containment)
-"bQR" = (
+"bQS" = (
 /obj/structure/pipes/standard/manifold/hidden/cyan{
 	dir = 1
 	},
 /turf/open/antre/plating/direction_north/north_edge,
 /area/white_antre/indoors/main_level/east_corridor)
-"bQS" = (
-/obj/item/prop/alien/hugger{
-	icon = 'icons/mob/xenos/castes/tier_0/larva.dmi';
-	icon_state = "Larva Dead";
-	name = "dead larva";
-	desc = "Looks like it was murdered by another xenomorph?"
-	},
-/obj/effect/decal/cleanable/blood/xeno,
-/obj/effect/decal/cleanable/blood/gibs/xeno,
-/turf/open/floor/prison/floor_marked/southwest,
-/area/white_antre/indoors/main_level/east_containment)
 "bQT" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/bed/chair/comfy/orange{
@@ -38545,9 +38533,16 @@
 /turf/open/floor/prison,
 /area/white_antre/indoors/upper_level/west_corridor)
 "bQW" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/auto_turf/hybrisa_auto_turf/layer1,
-/area/white_antre/landing_zone)
+/obj/item/prop/alien/hugger{
+	icon = 'icons/mob/xenos/castes/tier_0/larva.dmi';
+	icon_state = "Larva Dead";
+	name = "dead larva";
+	desc = "Looks like it was murdered by another xenomorph?"
+	},
+/obj/effect/decal/cleanable/blood/xeno,
+/obj/effect/decal/cleanable/blood/gibs/xeno,
+/turf/open/floor/prison/floor_marked/southwest,
+/area/white_antre/indoors/main_level/east_containment)
 "bQX" = (
 /obj/effect/antre/border/edge{
 	dir = 1
@@ -39175,7 +39170,7 @@
 /turf/open/floor/prison,
 /area/white_antre/indoors/main_level/weapons)
 "bSn" = (
-/obj/structure/platform/metal/almayer/north,
+/obj/structure/platform_decoration/metal/almayer/west,
 /turf/open/auto_turf/hybrisa_auto_turf/layer1,
 /area/white_antre/landing_zone)
 "bSo" = (
@@ -40540,6 +40535,10 @@
 	},
 /turf/open/floor/prison/green,
 /area/white_antre/indoors/underground_level/east_maint)
+"bVK" = (
+/obj/structure/platform/metal/almayer/north,
+/turf/open/auto_turf/hybrisa_auto_turf/layer1,
+/area/white_antre/landing_zone)
 "bVL" = (
 /obj/effect/decal/hybrisa/bloodtrail/clawtrail/xeno{
 	dir = 8;
@@ -41279,6 +41278,16 @@
 /obj/effect/decal/hybrisa/dirt,
 /turf/open/floor/prison/floor_plate,
 /area/white_antre/landing_zone)
+"bXM" = (
+/obj/structure/stairs/perspective{
+	dir = 9;
+	icon_state = "p_stair_full"
+	},
+/obj/structure/barricade/handrail/no_vault{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
 "bXN" = (
 /obj/structure/surface/table/reinforced/prison{
 	color = "#6b675e"
@@ -41476,11 +41485,8 @@
 /area/white_antre/oob)
 "bYm" = (
 /obj/structure/stairs/perspective{
-	dir = 9;
+	dir = 1;
 	icon_state = "p_stair_full"
-	},
-/obj/structure/barricade/handrail/no_vault{
-	dir = 8
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
@@ -41582,11 +41588,9 @@
 /turf/open/auto_turf/hybrisa_auto_turf/layer1,
 /area/white_antre/indoors/main_level/north_containment_hive)
 "bYG" = (
-/obj/structure/stairs/perspective{
-	dir = 1;
-	icon_state = "p_stair_full"
-	},
-/turf/open/floor/plating/plating_catwalk/prison,
+/obj/structure/platform/metal/almayer/west,
+/obj/structure/platform/metal/almayer_smooth,
+/turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/landing_zone)
 "bYH" = (
 /turf/open/slippery/roof/dir/east,
@@ -41624,23 +41628,25 @@
 /turf/open/slippery/roof/dir/northeast,
 /area/white_antre/outdoors/facility_exterior)
 "bYS" = (
-/obj/structure/platform/metal/almayer/west,
-/obj/structure/platform/metal/almayer_smooth,
-/turf/open/auto_turf/sand_white/layer0,
-/area/white_antre/landing_zone)
-"bYT" = (
 /obj/structure/platform/metal/almayer/east,
 /turf/open/auto_turf/hybrisa_auto_turf/layer1,
 /area/white_antre/landing_zone)
-"bYU" = (
+"bYT" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning_c";
 	dir = 8
 	},
 /turf/open/floor/prison,
 /area/white_antre/landing_zone)
-"bYV" = (
+"bYU" = (
 /obj/effect/decal/hybrisa/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 1
+	},
+/turf/open/floor/prison/ramptop/east,
+/area/white_antre/landing_zone)
+"bYV" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning_s";
 	dir = 1
@@ -41648,27 +41654,10 @@
 /turf/open/floor/prison/ramptop/east,
 /area/white_antre/landing_zone)
 "bYW" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
-	dir = 1
-	},
-/turf/open/floor/prison/ramptop/east,
-/area/white_antre/landing_zone)
-"bYX" = (
-/obj/structure/barricade/handrail/no_vault{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone)
-"bYY" = (
 /obj/effect/decal/hybrisa/dirt,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
-"bYZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison/darkyellow2/east,
-/area/white_antre/indoors/exterior/prefab_3)
-"bZa" = (
+"bYX" = (
 /obj/item/device/flashlight/lamp/tripod,
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning_s";
@@ -41676,28 +41665,32 @@
 	},
 /turf/open/floor/prison/ramptop,
 /area/white_antre/landing_zone)
-"bZb" = (
+"bYY" = (
 /obj/structure/platform/metal/almayer/north,
 /obj/structure/platform/metal/almayer/west,
 /turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/landing_zone)
-"bZc" = (
+"bYZ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/darkyellow2/east,
+/area/white_antre/indoors/exterior/prefab_3)
+"bZa" = (
 /obj/structure/platform/metal/almayer/north,
 /turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/landing_zone)
-"bZe" = (
+"bZb" = (
 /obj/structure/platform/metal/almayer/north,
 /obj/structure/platform/metal/almayer/east,
 /turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/landing_zone)
-"bZf" = (
+"bZc" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning_s";
 	dir = 4
 	},
 /turf/open/floor/prison/ramptop,
 /area/white_antre/landing_zone)
-"bZg" = (
+"bZd" = (
 /obj/structure/largecrate/random/barrel/green,
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning_s";
@@ -41709,10 +41702,38 @@
 	},
 /turf/open/floor/prison,
 /area/white_antre/landing_zone)
-"bZh" = (
+"bZe" = (
 /obj/structure/cargo_container/uscm/chinook/left{
 	layer = 3.1
 	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 1
+	},
+/turf/open/floor/prison/ramptop/east,
+/area/white_antre/landing_zone)
+"bZf" = (
+/obj/structure/cargo_container/uscm/chinook/mid{
+	layer = 3.1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 1
+	},
+/turf/open/floor/prison/ramptop/east,
+/area/white_antre/landing_zone)
+"bZg" = (
+/obj/structure/cargo_container/uscm/right{
+	layer = 3.1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 1
+	},
+/turf/open/floor/prison/ramptop/east,
+/area/white_antre/landing_zone)
+"bZh" = (
+/obj/structure/largecrate/random/case/double,
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning_s";
 	dir = 1
@@ -41729,14 +41750,17 @@
 /turf/closed/wall/hybrisa/colony/reinforced/hull,
 /area/white_antre/oob)
 "bZl" = (
-/obj/structure/cargo_container/uscm/chinook/mid{
-	layer = 3.1
-	},
+/obj/effect/decal/hybrisa/dirt,
+/obj/effect/decal/hybrisa/dirt,
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning_s";
 	dir = 1
 	},
-/turf/open/floor/prison/ramptop/east,
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 4
+	},
+/turf/open/floor/prison,
 /area/white_antre/landing_zone)
 "bZm" = (
 /obj/effect/mist/steam{
@@ -41837,14 +41861,9 @@
 /turf/open/auto_turf/strata_grass/layer0_mud,
 /area/white_antre/oob)
 "bZy" = (
-/obj/structure/cargo_container/uscm/right{
-	layer = 3.1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
-	dir = 1
-	},
-/turf/open/floor/prison/ramptop/east,
+/obj/effect/decal/hybrisa/dirt,
+/obj/effect/decal/hybrisa/dirt,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "bZz" = (
 /obj/structure/barricade/handrail{
@@ -41864,12 +41883,8 @@
 /turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/oob)
 "bZC" = (
-/obj/structure/largecrate/random/case/double,
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
-	dir = 1
-	},
-/turf/open/floor/prison/ramptop/east,
+/obj/structure/largecrate/random/barrel/blue,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "bZD" = (
 /obj/structure/stairs/perspective{
@@ -42407,17 +42422,8 @@
 /turf/open/floor/prison/bluefull,
 /area/white_antre/indoors/exterior/prefab_1)
 "cbb" = (
-/obj/effect/decal/hybrisa/dirt,
-/obj/effect/decal/hybrisa/dirt,
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
-	dir = 4
-	},
-/turf/open/floor/prison,
+/obj/structure/cargo_container/wy/left,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "cbc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -44453,8 +44459,7 @@
 /turf/open/auto_turf/snow/layer1,
 /area/white_antre/oob)
 "cgv" = (
-/obj/effect/decal/hybrisa/dirt,
-/obj/effect/decal/hybrisa/dirt,
+/obj/structure/cargo_container/wy/mid,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "cgw" = (
@@ -45033,7 +45038,7 @@
 /turf/open/floor/prison/darkpurple2/west,
 /area/white_antre/indoors/main_level/east_corridor)
 "chK" = (
-/obj/structure/largecrate/random/barrel/blue,
+/obj/structure/cargo_container/wy/right,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "chL" = (
@@ -45543,20 +45548,27 @@
 /turf/open_space,
 /area/white_antre/indoors/upper_level/central_corridor)
 "cjc" = (
-/obj/structure/cargo_container/wy/left,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone)
+/turf/open/floor/hybrisa/metal/zbrownfloor_full,
+/area/white_antre/landing_zone/roof)
 "cjd" = (
-/obj/structure/cargo_container/wy/mid,
+/obj/structure/barricade/handrail/no_vault{
+	dir = 8
+	},
+/obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "cje" = (
-/obj/structure/cargo_container/wy/right,
+/obj/effect/decal/hybrisa/dirt,
+/obj/item/trash/cigbutt{
+	pixel_x = -3;
+	pixel_y = 9
+	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "cjf" = (
-/turf/open/floor/hybrisa/metal/zbrownfloor_full,
-/area/white_antre/landing_zone/roof)
+/obj/structure/largecrate/random,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
 "cjg" = (
 /obj/structure/barricade/handrail{
 	dir = 8
@@ -45567,12 +45579,11 @@
 /turf/open/floor/prison/darkyellow2/northwest,
 /area/white_antre/indoors/upper_level/east_corridor)
 "cjh" = (
-/obj/structure/barricade/handrail/no_vault{
-	dir = 8
+/obj/structure/machinery/door/airlock/almayer/secure/colony{
+	dir = 2
 	},
-/obj/structure/largecrate/random/barrel/blue,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone)
+/turf/open/floor/corsat/marked,
+/area/white_antre/landing_zone/roof)
 "cji" = (
 /obj/item/stack/sheet/metal{
 	pixel_x = 5
@@ -45584,30 +45595,6 @@
 /turf/open/floor/almayer/silver/east,
 /area/white_antre/indoors/upper_level/canteen)
 "cjk" = (
-/obj/effect/decal/hybrisa/dirt,
-/obj/item/trash/cigbutt{
-	pixel_x = -3;
-	pixel_y = 9
-	},
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone)
-"cjl" = (
-/obj/structure/largecrate/random,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone)
-"cjm" = (
-/obj/structure/machinery/door/airlock/almayer/secure/colony{
-	dir = 2
-	},
-/turf/open/floor/corsat/marked,
-/area/white_antre/landing_zone/roof)
-"cjn" = (
-/obj/structure/bed/chair/comfy/orange{
-	dir = 4
-	},
-/turf/open/antre/plating/direction_west,
-/area/white_antre/indoors/upper_level/east_corridor)
-"cjo" = (
 /obj/structure/barricade/handrail/no_vault{
 	dir = 8
 	},
@@ -45618,6 +45605,32 @@
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
+"cjl" = (
+/obj/item/trash/cigbutt{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/structure/largecrate/random/case/small,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
+"cjm" = (
+/obj/structure/largecrate/random/barrel/brown,
+/obj/effect/decal/hybrisa/dirt,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
+"cjn" = (
+/obj/structure/bed/chair/comfy/orange{
+	dir = 4
+	},
+/turf/open/antre/plating/direction_west,
+/area/white_antre/indoors/upper_level/east_corridor)
+"cjo" = (
+/turf/open/floor/prison/darkyellowfull2,
+/area/white_antre/landing_zone/roof)
 "cjp" = (
 /obj/structure/platform_decoration/metal/almayer_smooth/north,
 /turf/open_space,
@@ -46246,15 +46259,10 @@
 /turf/open/auto_turf/strata_grass/layer0_mud,
 /area/white_antre/oob)
 "ckx" = (
-/obj/item/trash/cigbutt{
-	pixel_x = -3;
-	pixel_y = 9
+/obj/structure/barricade/handrail/no_vault{
+	dir = 8
 	},
-/obj/item/trash/cigbutt{
-	pixel_x = -3;
-	pixel_y = 9
-	},
-/obj/structure/largecrate/random/case/small,
+/obj/structure/largecrate/random/secure,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "cky" = (
@@ -46368,10 +46376,10 @@
 /turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/oob)
 "ckE" = (
-/obj/structure/largecrate/random/barrel/brown,
-/obj/effect/decal/hybrisa/dirt,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/door/airlock/multi_tile/hybrisa/personal/autoname,
+/turf/open/floor/corsat/marked,
+/area/white_antre/landing_zone/roof)
 "ckF" = (
 /obj/effect/mist/steam{
 	pixel_x = -3;
@@ -46650,7 +46658,8 @@
 /turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/oob)
 "ckV" = (
-/turf/open/floor/prison/darkyellowfull2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/corsat/marked,
 /area/white_antre/landing_zone/roof)
 "ckW" = (
 /obj/effect/decal/strata_decals/mud_corner{
@@ -47613,12 +47622,10 @@
 /turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/oob)
 "cmd" = (
-/obj/structure/barricade/handrail/no_vault{
-	dir = 8
-	},
-/obj/structure/largecrate/random/secure,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/framed/strata/reinforced,
+/turf/open/floor/plating,
+/area/white_antre/landing_zone/roof)
 "cme" = (
 /obj/effect/mist/steam{
 	pixel_x = 10;
@@ -48044,9 +48051,7 @@
 /turf/open/auto_turf/strata_grass/layer0_mud,
 /area/white_antre/oob)
 "cmF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/machinery/door/airlock/multi_tile/hybrisa/personal/autoname,
-/turf/open/floor/corsat/marked,
+/turf/open/floor/prison/darkyellow2,
 /area/white_antre/landing_zone/roof)
 "cmG" = (
 /obj/effect/mist/steam{
@@ -48056,8 +48061,7 @@
 /turf/open/auto_turf/strata_grass/layer0_mud,
 /area/white_antre/oob)
 "cmH" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/corsat/marked,
+/turf/open/floor/prison/darkyellow2/southeast,
 /area/white_antre/landing_zone/roof)
 "cmI" = (
 /turf/closed/wall/hybrisa/colony/reinforced,
@@ -48147,8 +48151,7 @@
 /area/white_antre/indoors/main_level/east_containment)
 "cni" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/framed/strata/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/prison/darkbrown2/southwest,
 /area/white_antre/landing_zone/roof)
 "cnj" = (
 /obj/structure/largecrate/random/barrel/yellow,
@@ -49136,20 +49139,22 @@
 /turf/open/antre/plating/direction_north/east_edge,
 /area/white_antre/indoors/upper_level/central_corridor)
 "cqv" = (
-/turf/open/floor/prison/darkyellow2,
+/turf/open/floor/prison/darkbrown2,
 /area/white_antre/landing_zone/roof)
 "cqw" = (
-/turf/open/floor/prison/darkyellow2/southeast,
+/obj/structure/machinery/disposal,
+/turf/open/floor/prison/darkbrown2/southeast,
 /area/white_antre/landing_zone/roof)
 "cqx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison/darkbrown2/southwest,
+/obj/structure/largecrate/random/barrel/black,
+/turf/open/floor/prison/darkyellow2,
 /area/white_antre/landing_zone/roof)
 "cqy" = (
 /turf/open/antre/plating/direction_west/east_north,
 /area/white_antre/indoors/upper_level/central_corridor)
 "cqz" = (
-/turf/open/floor/prison/darkbrown2,
+/obj/structure/largecrate/random/barrel/medical,
+/turf/open/floor/prison/darkyellowcorners2/west,
 /area/white_antre/landing_zone/roof)
 "cqA" = (
 /obj/effect/antre/border/edge{
@@ -49250,8 +49255,10 @@
 /turf/open/antre/plating/west_corner_dir/north_west,
 /area/white_antre/indoors/upper_level/central_corridor)
 "cqO" = (
-/obj/structure/machinery/disposal,
-/turf/open/floor/prison/darkbrown2/southeast,
+/obj/structure/machinery/light/double{
+	dir = 4
+	},
+/turf/open/floor/prison/darkyellow2/east,
 /area/white_antre/landing_zone/roof)
 "cqP" = (
 /obj/effect/decal/warning_stripes{
@@ -50270,8 +50277,8 @@
 /turf/open/floor/antre/metal/black/southwest,
 /area/white_antre/indoors/exterior/prefab_1)
 "cul" = (
-/obj/structure/largecrate/random/barrel/black,
-/turf/open/floor/prison/darkyellow2,
+/obj/structure/machinery/light/double,
+/turf/open/floor/prison/darkbrownfull2,
 /area/white_antre/landing_zone/roof)
 "cum" = (
 /obj/structure/machinery/space_heater/radiator/red,
@@ -50739,8 +50746,10 @@
 /turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/outdoors/south_field)
 "cvz" = (
-/obj/structure/largecrate/random/barrel/medical,
-/turf/open/floor/prison/darkyellowcorners2/west,
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/floor/prison/darkbrown2/east,
 /area/white_antre/landing_zone/roof)
 "cvA" = (
 /obj/effect/antre/border{
@@ -50884,93 +50893,77 @@
 /turf/open/floor/almayer_hull/outerhull_dir/east,
 /area/white_antre/indoors/upper_level/east_overwatch)
 "cvU" = (
-/obj/structure/machinery/light/double{
-	dir = 4
-	},
-/turf/open/floor/prison/darkyellow2/east,
-/area/white_antre/landing_zone/roof)
-"cvV" = (
-/obj/structure/machinery/light/double,
-/turf/open/floor/prison/darkbrownfull2,
-/area/white_antre/landing_zone/roof)
-"cvW" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/open/floor/prison/darkbrown2/east,
-/area/white_antre/landing_zone/roof)
-"cvX" = (
 /obj/structure/surface/table/almayer,
 /turf/open/floor/prison/darkbrownfull2,
 /area/white_antre/landing_zone/roof)
-"cvY" = (
+"cvV" = (
 /turf/open/floor/prison/darkyellow2/west,
 /area/white_antre/landing_zone/roof)
-"cvZ" = (
+"cvW" = (
 /turf/open/floor/prison/darkyellow2/east,
 /area/white_antre/landing_zone/roof)
-"cwa" = (
+"cvX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone/roof)
-"cwb" = (
+"cvY" = (
 /obj/structure/machinery/door/airlock/almayer/secure/colony,
 /turf/open/floor/corsat/marked,
 /area/white_antre/landing_zone/roof)
-"cwc" = (
+"cvZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkyellowcorners2/north,
 /area/white_antre/landing_zone/roof)
-"cwd" = (
+"cwa" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkyellow2/northeast,
 /area/white_antre/landing_zone/roof)
-"cwe" = (
+"cwb" = (
 /obj/structure/surface/rack,
 /obj/item/stack/sheet/metal/medium_stack,
 /turf/open/floor/prison,
 /area/white_antre/landing_zone/roof)
-"cwf" = (
+"cwc" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone/roof)
-"cwg" = (
+"cwd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/prison,
 /area/white_antre/landing_zone/roof)
-"cwh" = (
+"cwe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkbrown2/east,
 /area/white_antre/landing_zone/roof)
-"cwi" = (
+"cwf" = (
 /obj/item/tool/warning_cone{
 	pixel_y = 16
 	},
 /turf/open/floor/prison/darkyellow2/northwest,
 /area/white_antre/landing_zone/roof)
-"cwj" = (
+"cwg" = (
 /turf/open/floor/prison/darkyellowcorners2/east,
 /area/white_antre/landing_zone/roof)
-"cwk" = (
+"cwh" = (
 /obj/item/tool/warning_cone{
 	pixel_x = 5;
 	pixel_y = 13
 	},
 /turf/open/floor/prison/darkyellowcorners2/north,
 /area/white_antre/landing_zone/roof)
-"cwl" = (
+"cwi" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/prison/darkyellow2/northeast,
 /area/white_antre/landing_zone/roof)
-"cwm" = (
+"cwj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/white_antre/landing_zone/roof)
-"cwn" = (
+"cwk" = (
 /obj/structure/machinery/space_heater/radiator/red{
 	dir = 8;
 	pixel_x = 1
@@ -50980,62 +50973,69 @@
 	},
 /turf/open/floor/prison/darkbrownfull2,
 /area/white_antre/landing_zone/roof)
-"cwo" = (
+"cwl" = (
 /obj/structure/largecrate/random/barrel/brown,
 /turf/open/floor/prison/darkyellow2/northwest,
 /area/white_antre/landing_zone/roof)
-"cwp" = (
+"cwm" = (
 /obj/structure/machinery/light/double{
 	dir = 1
 	},
 /obj/structure/cargo_container/hybrisa/containersextended/redleft,
 /turf/open/floor/prison/darkyellow2/north,
 /area/white_antre/landing_zone/roof)
-"cwq" = (
+"cwn" = (
 /obj/structure/cargo_container/hybrisa/containersextended/redright,
 /turf/open/floor/prison/darkyellow2/northeast,
 /area/white_antre/landing_zone/roof)
-"cwr" = (
+"cwo" = (
 /turf/closed/wall/strata_outpost/reinforced/hull,
 /area/white_antre/landing_zone/roof)
-"cws" = (
+"cwp" = (
+/obj/structure/machinery/door_control/brbutton{
+	pixel_y = 30;
+	id = "LZ1_Lockdown_north"
+	},
+/turf/open/floor/prison/darkbrown2/north,
+/area/white_antre/landing_zone/roof)
+"cwq" = (
 /turf/open/floor/strata/multi_tiles,
 /area/white_antre/landing_zone/roof)
-"cwt" = (
+"cwr" = (
 /turf/open/floor/strata/multi_tiles/west,
 /area/white_antre/landing_zone/roof)
-"cwu" = (
+"cws" = (
 /turf/open/floor/strata/floor3,
 /area/white_antre/landing_zone/roof)
-"cwv" = (
+"cwt" = (
 /obj/structure/stairs/perspective{
 	dir = 9;
 	icon_state = "p_stair_full"
 	},
 /turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/outdoors/north_field)
-"cww" = (
+"cwu" = (
 /obj/structure/stairs/perspective{
 	dir = 1;
 	icon_state = "p_stair_full"
 	},
 /turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/outdoors/north_field)
-"cwx" = (
+"cwv" = (
 /obj/structure/stairs/perspective{
 	dir = 1;
 	icon_state = "p_stair_full"
 	},
 /turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/outdoors/north_field)
-"cwy" = (
+"cww" = (
 /obj/structure/stairs/perspective{
 	dir = 5;
 	icon_state = "p_stair_full"
 	},
 /turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/outdoors/north_field)
-"cwz" = (
+"cwx" = (
 /obj/effect/mist/steam{
 	pixel_x = -10;
 	pixel_y = 9
@@ -51043,7 +51043,7 @@
 /obj/structure/platform/stone/strata/east,
 /turf/solid_open_space,
 /area/white_antre/oob)
-"cwA" = (
+"cwy" = (
 /obj/effect/mist/steam{
 	pixel_x = -3;
 	pixel_y = -3
@@ -51052,15 +51052,15 @@
 /obj/structure/platform/stone/strata,
 /turf/solid_open_space,
 /area/white_antre/oob)
-"cwB" = (
+"cwz" = (
 /obj/structure/bed/chair/dropship/passenger,
 /obj/effect/landmark/objective_landmark/medium,
 /turf/open/shuttle/dropship/light_grey_single_wide_up_to_down,
 /area/white_antre/indoors/pmc_dropship)
-"cwC" = (
+"cwA" = (
 /turf/closed/wall/strata_ice,
 /area/white_antre/outdoors/north_field)
-"cwD" = (
+"cwB" = (
 /turf/closed/wall/strata_ice/dirty/rock,
 /area/white_antre/outdoors/north_field)
 "cxK" = (
@@ -100307,7 +100307,7 @@ bNU
 bNP
 bNU
 bNP
-cwz
+cwx
 byZ
 iKa
 iKa
@@ -100319,13 +100319,13 @@ kuQ
 kuQ
 kuQ
 iFy
-cmd
-cjo
-cjh
-bYX
-bYX
-bYX
-bYm
+ckx
+cjk
+cjd
+aEV
+aEV
+aEV
+bXM
 bYb
 cfI
 cfC
@@ -100356,8 +100356,8 @@ aZa
 ceY
 bWW
 aYD
-aer
-acU
+aID
+aFe
 byX
 bzf
 jkE
@@ -100474,7 +100474,7 @@ bNY
 bNV
 bOI
 bOH
-cwA
+cwy
 aMJ
 aMJ
 aMJ
@@ -100485,14 +100485,14 @@ bRL
 aNI
 beu
 bek
-cvV
+cul
 bdY
 iFy
-ckx
-cjk
+cjl
+cje
 bXo
 bXo
-bYY
+bYW
 bYC
 bdf
 cfJ
@@ -100526,7 +100526,7 @@ aYL
 aYD
 bYx
 bXo
-bYX
+aEV
 aEQ
 iFy
 iFy
@@ -100654,14 +100654,14 @@ aNJ
 aNJ
 bel
 bdZ
-cqx
+cni
 iFy
 bXo
-bYY
-cgv
-bYY
-bYY
-bYG
+bYW
+bZy
+bYW
+bYW
+bYm
 bdf
 bXj
 cfD
@@ -100823,9 +100823,9 @@ aKf
 aKf
 aKf
 aNC
-cmF
+ckE
 bXo
-bYY
+bYW
 bXo
 bXo
 bXo
@@ -100981,22 +100981,22 @@ aMS
 aMJ
 aMJ
 aMJ
-cwv
+cwt
 ctR
 ctR
 ctR
-afY
+cwp
 aKf
-cwe
+cwb
 ben
 aKf
-cqz
-cmH
-bYY
-cgv
-chK
-bZg
-bZa
+cqv
+ckV
+bYW
+bZy
+bZC
+bZd
+bYX
 dwB
 bYb
 bcU
@@ -101149,23 +101149,23 @@ aMJ
 aMJ
 aMJ
 aMJ
-cww
 cwu
 cws
+cwq
 aNA
 aNN
 aKf
-cwf
+cwc
 aKp
 aKf
-cqz
-cni
-cgv
-cjl
+cqv
+cmd
+bZy
+cjf
 bXo
-bZh
-bZb
-bYS
+bZe
+bYY
+bYG
 bbQ
 bWX
 bbP
@@ -101196,9 +101196,9 @@ aYL
 aYU
 bWX
 bWQ
-aIx
-aFd
-aEV
+aJb
+aFf
+aEX
 bXo
 akw
 aXU
@@ -101317,22 +101317,22 @@ aMH
 beA
 beA
 bee
-cww
 cwu
-cwt
+cws
+cwr
 aNA
 aNN
 aKf
 aKf
 aKf
 aKf
-cqz
-cni
-bYY
+cqv
+cmd
+bYW
 bXo
-cjc
-bZl
-bZc
+cbb
+bZf
+bZa
 odB
 oSf
 wvY
@@ -101364,9 +101364,9 @@ bWX
 bWQ
 lDX
 oSf
-aID
-aFe
-aEX
+aJg
+aGq
+aEZ
 bXo
 akw
 aXU
@@ -101485,22 +101485,22 @@ bfb
 aMH
 aMH
 bef
-cww
 cwu
-cwt
+cws
+cwr
 aNA
 aNN
 aKf
 aXH
 aKf
 aKf
-cqz
-cni
-bYY
+cqv
+cmd
+bYW
 bXo
-cjd
-bZy
-bZc
+cgv
+bZg
+bZa
 aKC
 aKC
 odB
@@ -101533,8 +101533,8 @@ oSf
 nQp
 aKC
 aKB
-aNL
-aEZ
+aIu
+aFa
 bXo
 atH
 aXU
@@ -101653,22 +101653,22 @@ aMH
 aMH
 beX
 bef
-cww
 cwu
-cwt
+cws
+cwr
 aNA
 aNN
 aKf
-cwg
+cwd
 aKf
 aKf
-cqz
+cqv
 atH
-ckE
+cjm
 bXo
-cje
-bZC
-bZc
+chK
+bZh
+bZa
 aKB
 aKB
 aKC
@@ -101701,8 +101701,8 @@ aKB
 aKB
 aKB
 aKB
-aNL
-aEZ
+aIu
+aFa
 bXo
 aKz
 wje
@@ -101821,22 +101821,22 @@ beS
 uoG
 aMH
 beP
-cwx
-cwu
+cwv
 cws
+cwq
 aNA
 aNN
-cwm
+cwj
 bpa
-cwa
+cvX
 aXH
 aNC
 aKz
-bYY
-bXo
-bXo
 bYW
-bZc
+bXo
+bXo
+bYV
+bZa
 aKB
 aKB
 aKB
@@ -101869,8 +101869,8 @@ aKB
 aKB
 aKB
 aKB
-aNL
-aEZ
+aIu
+aFa
 bXo
 iFy
 bph
@@ -101989,22 +101989,22 @@ aMH
 lGQ
 kGT
 beP
-cwy
+cww
 ctR
 ctR
 ctR
 aNO
-cwh
-cwh
+cwe
+cwe
 bev
-cvW
-cqO
+cvz
+cqw
 ctR
-bYY
-bYY
-bXo
 bYW
-bZc
+bYW
+bXo
+bYV
+bZa
 bYz
 aKB
 aKB
@@ -102037,8 +102037,8 @@ aLc
 aJq
 aJq
 aKC
-aNL
-aEZ
+aIu
+aFa
 bXo
 iFy
 iFy
@@ -102162,17 +102162,17 @@ iKa
 iKa
 bRL
 bRL
-cwn
+cwk
 beq
 beq
-cvX
+cvU
 ctR
 ctR
 bXo
-bYY
-bYY
 bYW
-bZc
+bYW
+bYV
+bZa
 bYz
 bYz
 aKB
@@ -102205,8 +102205,8 @@ aYV
 aJq
 aJq
 aKC
-aNL
-aEZ
+aIu
+aFa
 bXo
 bXo
 tFe
@@ -102332,17 +102332,17 @@ iKa
 bRL
 bRL
 akw
-cwb
+cvY
 akw
 ctR
 ctR
 bXo
-bYY
-cgv
-bYV
-bZe
-bYT
-bQW
+bYW
+bZy
+bYU
+bZb
+bYS
+bSn
 aKF
 aKB
 aKB
@@ -102372,9 +102372,9 @@ aKB
 aLc
 aKX
 aJq
-aJb
-aIu
-aEZ
+aNL
+aIw
+aFa
 bXo
 bXo
 tFe
@@ -102499,18 +102499,18 @@ iKa
 iKa
 iKa
 bRL
-ckV
-ckV
-ckV
+cjo
+cjo
+cjo
 ctR
 ctR
 bXo
 cfM
 bXo
-cbb
-bZf
-bYU
-bSn
+bZl
+bZc
+bYT
+bVK
 aKB
 aKB
 aKB
@@ -102538,11 +102538,11 @@ aKB
 aKB
 aKB
 aKB
-aNL
-aJg
-aIw
-aIw
-aFa
+aIu
+bsr
+aIx
+aIx
+aFb
 aER
 bXo
 tFe
@@ -102667,9 +102667,9 @@ iKa
 iKa
 bRL
 bRL
-cwi
-cvY
-cvY
+cwf
+cvV
+cvV
 ctR
 ctR
 bXo
@@ -102677,7 +102677,7 @@ bXo
 bXo
 bXo
 bXo
-bYV
+bYU
 bSC
 aKB
 aKC
@@ -102707,7 +102707,7 @@ aKB
 aKB
 aKB
 bUu
-aEZ
+aFa
 bXo
 bXo
 bXo
@@ -102834,18 +102834,18 @@ aMI
 iKa
 iKa
 bRL
-cwo
-cwj
+cwl
+cwg
 aKf
 aKf
-cul
+cqx
 ctR
 ctR
 bXo
 bXo
 bXo
 bXo
-bYW
+bYV
 bYx
 hNM
 hNM
@@ -102874,11 +102874,11 @@ aKC
 pWw
 hNM
 hNM
-bsr
-aEZ
+bPX
+aFa
 bXo
 bXo
-aFb
+aFc
 aET
 bXo
 tFe
@@ -103002,11 +103002,11 @@ aMJ
 iKa
 iKa
 bRL
-cwp
+cwm
 aKf
 aXL
 aKp
-cvz
+cqz
 aKt
 ctR
 ctR
@@ -103170,13 +103170,13 @@ aMJ
 aMJ
 iKa
 bRL
-cwq
-cwk
+cwn
+cwh
 aXH
 aKp
 aKf
-cqv
-ckV
+cmF
+cjo
 akw
 bdH
 pDy
@@ -103338,15 +103338,15 @@ aMH
 ewE
 iKa
 bRL
-cwr
-cwl
-cwc
+cwo
+cwi
+cvZ
 aKf
 aKf
-cqv
-ckV
-cjm
-cjf
+cmF
+cjo
+cjh
+cjc
 bpx
 aXL
 aXH
@@ -103508,11 +103508,11 @@ iKa
 iKa
 bRL
 bRL
-cwd
-cvZ
-cvU
-cqw
-ckV
+cwa
+cvW
+cqO
+cmH
+cjo
 akw
 bdI
 xJX
@@ -103717,8 +103717,8 @@ aLf
 bpn
 bpl
 aKS
-aFc
-aFc
+aFd
+aFd
 aKN
 iFy
 iFy
@@ -105392,7 +105392,7 @@ caP
 caP
 caP
 aJq
-bPX
+bQQ
 aJx
 acs
 acs
@@ -109201,7 +109201,7 @@ lzp
 fIR
 aRG
 hvs
-cwB
+cwz
 uKv
 xXR
 bBx
@@ -120670,7 +120670,7 @@ asa
 coM
 bHo
 bHo
-bQR
+bQS
 bTy
 bSz
 bSz
@@ -124862,7 +124862,7 @@ aZn
 cuF
 aKK
 abK
-bQS
+bQW
 abG
 aKK
 cub
@@ -126049,7 +126049,7 @@ baM
 aKV
 bHo
 bHo
-bQQ
+bQR
 lvO
 aZI
 aKV
@@ -140631,7 +140631,7 @@ spC
 spC
 spC
 spC
-cwC
+cwA
 spC
 spC
 spC
@@ -140798,10 +140798,10 @@ spC
 spC
 spC
 spC
-cwC
-cwC
-cwC
-cwC
+cwA
+cwA
+cwA
+cwA
 tUu
 kDp
 kDp
@@ -140967,8 +140967,8 @@ spC
 cnb
 cnb
 cnb
-cwC
-cwC
+cwA
+cwA
 tUu
 kPj
 kPj
@@ -141134,9 +141134,9 @@ cnb
 cnb
 cnb
 cnb
-cwC
-cwC
-cwC
+cwA
+cwA
+cwA
 fuj
 kPj
 kPj
@@ -141302,9 +141302,9 @@ cnb
 cnb
 cnb
 cnb
-cwC
-cwC
-cwC
+cwA
+cwA
+cwA
 jIC
 hLL
 kPj
@@ -142647,8 +142647,8 @@ cnb
 cnb
 cnb
 cnb
-cwC
-cwC
+cwA
+cwA
 jIC
 tUu
 kDp
@@ -142815,9 +142815,9 @@ cnb
 cnb
 cnb
 cnb
-cwC
-cwC
-cwC
+cwA
+cwA
+cwA
 jIC
 kPj
 kPj
@@ -142984,9 +142984,9 @@ cnb
 cnb
 cnb
 cnb
-cwC
-cwC
-cwC
+cwA
+cwA
+cwA
 fuj
 kPj
 kPj
@@ -143152,8 +143152,8 @@ cnb
 cnb
 cnb
 cnb
-cwC
-cwC
+cwA
+cwA
 tUu
 kPj
 kPj
@@ -143320,8 +143320,8 @@ cnb
 cnb
 cnb
 cnb
-cwC
-cwC
+cwA
+cwA
 fuj
 kPj
 kPj
@@ -143488,8 +143488,8 @@ cnb
 cnb
 cnb
 cnb
-cwC
-cwC
+cwA
+cwA
 fuj
 kPj
 kPj
@@ -143657,7 +143657,7 @@ cnb
 cnb
 cnb
 cnb
-cwC
+cwA
 fuj
 kPj
 kPj
@@ -143824,8 +143824,8 @@ cnb
 cnb
 cnb
 cnb
-cwD
-cwC
+cwB
+cwA
 jIC
 kPj
 kPj
@@ -143992,9 +143992,9 @@ cnb
 cnb
 cnb
 cnb
-cwD
-cwC
-cwC
+cwB
+cwA
+cwA
 jIC
 kPj
 kPj
@@ -144158,12 +144158,12 @@ cnb
 cnb
 cnb
 cnb
-cwD
-cwD
-cwD
-cwC
-cwC
-cwC
+cwB
+cwB
+cwB
+cwA
+cwA
+cwA
 jIC
 hLL
 hLL
@@ -144325,18 +144325,18 @@ cnb
 cnb
 cnb
 cnb
-cwD
-cwD
-cwD
-cwC
-cwC
-cwC
-cwC
-cwC
-cwC
-cwC
-cwC
-cwC
+cwB
+cwB
+cwB
+cwA
+cwA
+cwA
+cwA
+cwA
+cwA
+cwA
+cwA
+cwA
 cnb
 cnb
 jIC
@@ -144495,17 +144495,17 @@ cnb
 cnb
 cnb
 cnb
-cwC
-cwC
-cwC
-cwC
-cwD
-cwD
-cwC
-cwC
-cwC
-cwC
-cwC
+cwA
+cwA
+cwA
+cwA
+cwB
+cwB
+cwA
+cwA
+cwA
+cwA
+cwA
 cnb
 cnb
 cnb
@@ -144664,15 +144664,15 @@ cnb
 cnb
 cnb
 cnb
-cwC
-cwC
-cwC
-cwD
-cwD
-cwD
-cwD
-cwC
-cwC
+cwA
+cwA
+cwA
+cwB
+cwB
+cwB
+cwB
+cwA
+cwA
 cnb
 cnb
 cnb
@@ -144837,8 +144837,8 @@ cnb
 cnb
 cnb
 cnb
-cwD
-cwD
+cwB
+cwB
 cnb
 cnb
 cnb
@@ -145006,7 +145006,7 @@ cnb
 cnb
 cnb
 cnb
-cwD
+cwB
 cnb
 cnb
 cnb

--- a/maps/map_files/White_Antre_Research_Facility/White_Antre_Research_Facility.dmm
+++ b/maps/map_files/White_Antre_Research_Facility/White_Antre_Research_Facility.dmm
@@ -1091,6 +1091,13 @@
 /obj/effect/landmark/monkey_spawn,
 /turf/open/floor/prison/floor_plate/southwest,
 /area/white_antre/indoors/main_level/east_containment_hive)
+"acU" = (
+/obj/structure/barricade/handrail/no_vault{
+	dir = 8
+	},
+/obj/structure/barricade/handrail/no_vault,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
 "acV" = (
 /obj/effect/landmark/objective_landmark/close,
 /obj/structure/filingcabinet{
@@ -1730,6 +1737,16 @@
 	},
 /turf/open/floor/almayer/silver/north,
 /area/white_antre/indoors/main_level/east_containment_hive)
+"aer" = (
+/obj/structure/stairs/perspective{
+	dir = 10;
+	icon_state = "p_stair_full"
+	},
+/obj/structure/barricade/handrail/no_vault{
+	dir = 8
+	},
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/landing_zone)
 "aes" = (
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "thermite";
@@ -2426,6 +2443,13 @@
 	},
 /turf/open/floor/almayer/silverfull,
 /area/white_antre/indoors/main_level/east_containment_hive)
+"afY" = (
+/obj/structure/machinery/door_control/brbutton{
+	pixel_y = 30;
+	id = "LZ1_Lockdown_north"
+	},
+/turf/open/floor/prison/darkbrown2/north,
+/area/white_antre/landing_zone/roof)
 "afZ" = (
 /obj/structure/sink{
 	dir = 8;
@@ -13378,6 +13402,9 @@
 /area/white_antre/outdoors/south_field)
 "aEQ" = (
 /obj/structure/largecrate/empty/case/double,
+/obj/structure/barricade/handrail/no_vault{
+	dir = 8
+	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "aER" = (
@@ -13477,11 +13504,7 @@
 "aFe" = (
 /obj/structure/platform/metal/almayer,
 /obj/structure/platform/metal/almayer/west,
-/turf/open/auto_turf/shale/layer1/weedable,
-/area/white_antre/landing_zone)
-"aFf" = (
-/obj/structure/platform/metal/almayer,
-/turf/open/auto_turf/shale/layer1/weedable,
+/turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/landing_zone)
 "aFg" = (
 /obj/item/paper/crumpled{
@@ -14038,10 +14061,6 @@
 /obj/effect/alien/weeds/node/kseries,
 /turf/open/floor/almayer/silver,
 /area/white_antre/indoors/main_level/north_containment_hive)
-"aGq" = (
-/obj/structure/platform/metal/almayer,
-/turf/open/auto_turf/shale/layer2/weedable,
-/area/white_antre/landing_zone)
 "aGr" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_21"
@@ -15074,7 +15093,7 @@
 "aIu" = (
 /obj/structure/platform/metal/almayer,
 /obj/structure/platform/metal/almayer/east,
-/turf/open/auto_turf/shale/layer1/weedable,
+/turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/landing_zone)
 "aIv" = (
 /obj/structure/flora/bush/snow{
@@ -16646,7 +16665,7 @@
 "aNA" = (
 /obj/structure/machinery/door/poddoor/almayer/closed{
 	dir = 2;
-	id = "LZ1_Lockdown_Lo";
+	id = "LZ1_Lockdown_north";
 	name = "Emergency Lockdown"
 	},
 /turf/open/floor/corsat/marked,
@@ -40521,13 +40540,6 @@
 	},
 /turf/open/floor/prison/green,
 /area/white_antre/indoors/underground_level/east_maint)
-"bVK" = (
-/obj/structure/stairs/perspective{
-	dir = 10;
-	icon_state = "p_stair_full"
-	},
-/turf/open/auto_turf/shale/layer1/weedable,
-/area/white_antre/landing_zone)
 "bVL" = (
 /obj/effect/decal/hybrisa/bloodtrail/clawtrail/xeno{
 	dir = 8;
@@ -41267,12 +41279,6 @@
 /obj/effect/decal/hybrisa/dirt,
 /turf/open/floor/prison/floor_plate,
 /area/white_antre/landing_zone)
-"bXM" = (
-/obj/structure/stairs/perspective{
-	icon_state = "p_stair_full"
-	},
-/turf/open/auto_turf/shale/layer1/weedable,
-/area/white_antre/landing_zone)
 "bXN" = (
 /obj/structure/surface/table/reinforced/prison{
 	color = "#6b675e"
@@ -41673,20 +41679,16 @@
 "bZb" = (
 /obj/structure/platform/metal/almayer/north,
 /obj/structure/platform/metal/almayer/west,
-/turf/open/auto_turf/shale/layer1/weedable,
+/turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/landing_zone)
 "bZc" = (
 /obj/structure/platform/metal/almayer/north,
-/turf/open/auto_turf/shale/layer1/weedable,
-/area/white_antre/landing_zone)
-"bZd" = (
-/obj/structure/platform/metal/almayer/north,
-/turf/open/auto_turf/shale/layer2/weedable,
+/turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/landing_zone)
 "bZe" = (
 /obj/structure/platform/metal/almayer/north,
 /obj/structure/platform/metal/almayer/east,
-/turf/open/auto_turf/shale/layer1/weedable,
+/turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/landing_zone)
 "bZf" = (
 /obj/effect/decal/warning_stripes{
@@ -42592,6 +42594,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/tank/fuel,
 /turf/open/floor/prison/darkbrown3,
 /area/white_antre/indoors/exterior/prefab_2)
 "cbB" = (
@@ -44047,15 +44050,6 @@
 /area/white_antre/landing_zone)
 "cfp" = (
 /turf/closed/wall/strata_outpost/reinforced,
-/area/white_antre/outdoors/north_field)
-"cfq" = (
-/obj/structure/machinery/door_control/brbutton{
-	pixel_x = -28;
-	id = "lz_entrance";
-	needs_power = 0;
-	explo_proof = 0
-	},
-/turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/outdoors/north_field)
 "cfr" = (
 /obj/item/tool/warning_cone{
@@ -48165,6 +48159,7 @@
 /obj/item/explosive/plastic/breaching_charge{
 	unacidable = 1
 	},
+/obj/item/explosive/plastic,
 /turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/indoors/main_level/east_containment)
 "cnl" = (
@@ -50905,12 +50900,6 @@
 /turf/open/floor/prison/darkbrown2/east,
 /area/white_antre/landing_zone/roof)
 "cvX" = (
-/obj/structure/machinery/door_control/brbutton/alt{
-	id = "LZ1_Lockdown_Lo";
-	name = "remote door-control";
-	pixel_y = -2;
-	pixel_x = 6
-	},
 /obj/structure/surface/table/almayer,
 /turf/open/floor/prison/darkbrownfull2,
 /area/white_antre/landing_zone/roof)
@@ -50973,6 +50962,7 @@
 /turf/open/floor/prison/darkyellowcorners2/north,
 /area/white_antre/landing_zone/roof)
 "cwl" = (
+/obj/structure/largecrate/random/case/double,
 /turf/open/floor/prison/darkyellow2/northeast,
 /area/white_antre/landing_zone/roof)
 "cwm" = (
@@ -50995,18 +50985,17 @@
 /turf/open/floor/prison/darkyellow2/northwest,
 /area/white_antre/landing_zone/roof)
 "cwp" = (
-/obj/structure/largecrate/random/case/double,
 /obj/structure/machinery/light/double{
 	dir = 1
 	},
+/obj/structure/cargo_container/hybrisa/containersextended/redleft,
 /turf/open/floor/prison/darkyellow2/north,
 /area/white_antre/landing_zone/roof)
 "cwq" = (
-/obj/structure/cargo_container/hybrisa/containersextended/redleft,
+/obj/structure/cargo_container/hybrisa/containersextended/redright,
 /turf/open/floor/prison/darkyellow2/northeast,
 /area/white_antre/landing_zone/roof)
 "cwr" = (
-/obj/structure/cargo_container/hybrisa/containersextended/redright,
 /turf/closed/wall/strata_outpost/reinforced/hull,
 /area/white_antre/landing_zone/roof)
 "cws" = (
@@ -100367,8 +100356,8 @@ aZa
 ceY
 bWW
 aYD
-bSC
-bXo
+aer
+acU
 byX
 bzf
 jkE
@@ -100537,7 +100526,7 @@ aYL
 aYD
 bYx
 bXo
-bXo
+bYX
 aEQ
 iFy
 iFy
@@ -100996,7 +100985,7 @@ cwv
 ctR
 ctR
 ctR
-aNN
+afY
 aKf
 cwe
 ben
@@ -101511,8 +101500,8 @@ bYY
 bXo
 cjd
 bZy
-bZd
-aKB
+bZc
+aKC
 aKC
 odB
 oSf
@@ -101544,7 +101533,7 @@ oSf
 nQp
 aKC
 aKB
-aFf
+aNL
 aEZ
 bXo
 atH
@@ -101712,7 +101701,7 @@ aKB
 aKB
 aKB
 aKB
-aFf
+aNL
 aEZ
 bXo
 aKz
@@ -101880,7 +101869,7 @@ aKB
 aKB
 aKB
 aKB
-aGq
+aNL
 aEZ
 bXo
 iFy
@@ -102048,7 +102037,7 @@ aLc
 aJq
 aJq
 aKC
-aFf
+aNL
 aEZ
 bXo
 iFy
@@ -102216,7 +102205,7 @@ aYV
 aJq
 aJq
 aKC
-aFf
+aNL
 aEZ
 bXo
 bXo
@@ -102689,7 +102678,7 @@ bXo
 bXo
 bXo
 bYV
-bVK
+bSC
 aKB
 aKC
 aKC
@@ -102857,7 +102846,7 @@ bXo
 bXo
 bXo
 bYW
-bXM
+bYx
 hNM
 hNM
 aKD
@@ -104044,7 +104033,7 @@ aMJ
 aMJ
 aMJ
 aMJ
-cfq
+aMJ
 aLH
 aLm
 bAi

--- a/maps/map_files/White_Antre_Research_Facility/White_Antre_Research_Facility.dmm
+++ b/maps/map_files/White_Antre_Research_Facility/White_Antre_Research_Facility.dmm
@@ -1091,10 +1091,6 @@
 /obj/effect/landmark/monkey_spawn,
 /turf/open/floor/prison/floor_plate/southwest,
 /area/white_antre/indoors/main_level/east_containment_hive)
-"acU" = (
-/obj/effect/landmark/objective_landmark/medium,
-/turf/open/auto_turf/shale/layer1/weedable,
-/area/white_antre/outdoors/south_field/under_cover)
 "acV" = (
 /obj/effect/landmark/objective_landmark/close,
 /obj/structure/filingcabinet{
@@ -2430,14 +2426,6 @@
 	},
 /turf/open/floor/almayer/silverfull,
 /area/white_antre/indoors/main_level/east_containment_hive)
-"afY" = (
-/obj/structure/prop/colorable_rock/colorable{
-	color = "#5F5F70";
-	dir = 10
-	},
-/obj/effect/landmark/objective_landmark/science,
-/turf/open/auto_turf/snow/layer2,
-/area/white_antre/outdoors/south_field)
 "afZ" = (
 /obj/structure/sink{
 	dir = 8;
@@ -2647,10 +2635,6 @@
 /obj/effect/decal/cleanable/blood/tracks/footprints,
 /turf/open/floor/almayer/research/containment/corner/west,
 /area/white_antre/indoors/upper_level/simian_storage)
-"agM" = (
-/obj/effect/landmark/objective_landmark/far,
-/turf/open/auto_turf/shale/layer1/weedable,
-/area/white_antre/outdoors/south_field/under_cover)
 "agN" = (
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/white_antre/indoors/upper_level/simian_storage)
@@ -13137,8 +13121,9 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/indoors/main_level/east_containment)
 "aEi" = (
-/turf/open/floor/darkish,
-/area/white_antre/indoors/main_level/east_containment_hive)
+/obj/effect/landmark/objective_landmark/medium,
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/outdoors/south_field/under_cover)
 "aEj" = (
 /obj/structure/largecrate/random/barrel/brown,
 /turf/open/floor/almayer/silvercorner/north,
@@ -13153,12 +13138,13 @@
 /turf/open/floor/almayer/silvercorner/north,
 /area/white_antre/indoors/main_level/research)
 "aEl" = (
-/obj/structure/tunnel/maint_tunnel,
-/obj/structure/machinery/colony_floodlight/venir_wall_light{
-	dir = 4
+/obj/structure/prop/colorable_rock/colorable{
+	color = "#5F5F70";
+	dir = 10
 	},
-/turf/open/floor/almayer/silverfull,
-/area/white_antre/indoors/main_level/east_containment_hive)
+/obj/effect/landmark/objective_landmark/science,
+/turf/open/auto_turf/snow/layer2,
+/area/white_antre/outdoors/south_field)
 "aEm" = (
 /obj/structure/machinery/space_heater/radiator/red{
 	dir = 4;
@@ -13192,6 +13178,10 @@
 	},
 /turf/open/floor/antre/metal/black/northeast,
 /area/white_antre/indoors/main_level/west_corridor)
+"aEq" = (
+/obj/effect/landmark/objective_landmark/far,
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/outdoors/south_field/under_cover)
 "aEr" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -13215,17 +13205,12 @@
 /turf/open/floor/almayer/emerald2smooth/east,
 /area/white_antre/indoors/main_level/research)
 "aEt" = (
-/obj/structure/machinery/space_heater/radiator/red{
-	dir = 4
-	},
-/turf/open/floor/prison/bluefull,
-/area/white_antre/landing_zone/roof)
+/turf/open/floor/darkish,
+/area/white_antre/indoors/main_level/east_containment_hive)
 "aEu" = (
-/obj/structure/machinery/light/double{
-	dir = 4
-	},
-/turf/open/floor/prison/bluefull,
-/area/white_antre/landing_zone/roof)
+/obj/structure/platform/metal/almayer/west,
+/turf/open/asphalt/cement/cement15,
+/area/white_antre/outdoors/south_field)
 "aEv" = (
 /obj/structure/machinery/light/double/blue{
 	dir = 8
@@ -13265,8 +13250,9 @@
 /turf/open/floor/almayer/emerald2smooth/west,
 /area/white_antre/indoors/main_level/research)
 "aEy" = (
-/turf/open/floor/prison/blue/east,
-/area/white_antre/landing_zone/roof)
+/obj/structure/platform/metal/almayer/west,
+/turf/open/asphalt/cement/cement1,
+/area/white_antre/outdoors/south_field)
 "aEz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall/kseries,
@@ -13283,8 +13269,20 @@
 /turf/open/floor/almayer/silver/west,
 /area/white_antre/indoors/main_level/research)
 "aEB" = (
-/turf/open/floor/prison/redcorner,
-/area/white_antre/indoors/main_level/east_containment)
+/obj/structure/machinery/door/poddoor/hybrisa/ultra_reinforced_door/open{
+	dir = 2;
+	icon_state = "udoor0"
+	},
+/obj/structure/machinery/light/small{
+	light_color = "#ff3b3b";
+	color = "#ff3b3b";
+	needs_power = 0;
+	dir = 4;
+	name = "emergency lighting";
+	desc = "A small emergency light. Has an internal battery which should last for five hours."
+	},
+/turf/open/floor/corsat/marked,
+/area/white_antre/indoors/main_level/weapons)
 "aEC" = (
 /obj/structure/machinery/recharge_station/alt{
 	dir = 4
@@ -13300,22 +13298,13 @@
 /turf/open/floor/prison/darkred2/west,
 /area/white_antre/indoors/underground_level/west_maint)
 "aEF" = (
-/obj/structure/pipes/standard/manifold/hidden/cyan{
-	dir = 1
-	},
-/turf/open/antre/plating/direction_north/north_edge,
-/area/white_antre/indoors/main_level/east_corridor)
+/obj/structure/machinery/light/double,
+/turf/open/floor/strata/green3/east,
+/area/white_antre/indoors/main_level/weapons)
 "aEG" = (
-/obj/item/prop/alien/hugger{
-	icon = 'icons/mob/xenos/castes/tier_0/larva.dmi';
-	icon_state = "Larva Dead";
-	name = "dead larva";
-	desc = "Looks like it was murdered by another xenomorph?"
-	},
-/obj/effect/decal/cleanable/blood/xeno,
-/obj/effect/decal/cleanable/blood/gibs/xeno,
-/turf/open/floor/prison/floor_marked/southwest,
-/area/white_antre/indoors/main_level/east_containment)
+/obj/structure/machinery/light/double,
+/turf/open/floor/strata/green3/west,
+/area/white_antre/indoors/main_level/weapons)
 "aEH" = (
 /obj/structure/surface/table/almayer{
 	color = "#848484"
@@ -13335,27 +13324,20 @@
 /turf/open/floor/almayer/emeraldfull2,
 /area/white_antre/indoors/main_level/research)
 "aEI" = (
-/obj/structure/largecrate/random/barrel/green,
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
-	dir = 1
+/obj/structure/tunnel/maint_tunnel,
+/obj/structure/machinery/colony_floodlight/venir_wall_light{
+	dir = 4
 	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
-	dir = 8
-	},
-/turf/open/floor/prison,
-/area/white_antre/landing_zone)
+/turf/open/floor/almayer/silverfull,
+/area/white_antre/indoors/main_level/east_containment_hive)
 "aEJ" = (
-/obj/structure/cargo_container/uscm/chinook/left{
-	layer = 3.1
+/obj/structure/surface/table/almayer,
+/obj/item/clothing/head/hardhat/orange{
+	pixel_x = 8;
+	pixel_y = 12
 	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
-	dir = 1
-	},
-/turf/open/floor/prison/ramptop/east,
-/area/white_antre/landing_zone)
+/turf/open/floor/hybrisa/metal/bluemetalfull,
+/area/white_antre/landing_zone/roof)
 "aEK" = (
 /obj/structure/machinery/light/double/blue{
 	dir = 4
@@ -13364,15 +13346,10 @@
 /turf/open/floor/almayer/emerald2smooth/east,
 /area/white_antre/indoors/main_level/research)
 "aEL" = (
-/obj/structure/cargo_container/uscm/chinook/mid{
-	layer = 3.1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
-	dir = 1
-	},
-/turf/open/floor/prison/ramptop/east,
-/area/white_antre/landing_zone)
+/obj/structure/platform/metal/almayer/north,
+/obj/structure/platform/metal/almayer/west,
+/turf/open/asphalt/cement/cement1,
+/area/white_antre/outdoors/south_field)
 "aEM" = (
 /obj/structure/surface/table/reinforced/prison{
 	color = "#6b675e"
@@ -13392,25 +13369,19 @@
 /turf/open/floor/almayer/emerald2smooth/northeast,
 /area/white_antre/indoors/main_level/research)
 "aEO" = (
-/obj/structure/cargo_container/uscm/right{
-	layer = 3.1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
-	dir = 1
-	},
-/turf/open/floor/prison/ramptop/east,
-/area/white_antre/landing_zone)
+/obj/structure/platform/metal/almayer/north,
+/turf/open/auto_turf/snow/layer1,
+/area/white_antre/outdoors/south_field)
 "aEP" = (
-/obj/structure/largecrate/random/barrel/blue,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone)
+/obj/structure/platform/metal/almayer/north,
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/outdoors/south_field)
 "aEQ" = (
-/obj/structure/cargo_container/wy/left,
+/obj/structure/largecrate/empty/case/double,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "aER" = (
-/obj/structure/cargo_container/wy/mid,
+/obj/item/device/flashlight/lamp/tripod,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "aES" = (
@@ -13427,7 +13398,8 @@
 /turf/open/floor/almayer/silver/west,
 /area/white_antre/indoors/main_level/research)
 "aET" = (
-/obj/structure/cargo_container/wy/right,
+/obj/structure/closet/crate/green,
+/obj/effect/landmark/objective_landmark/medium,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "aEU" = (
@@ -13437,6 +13409,16 @@
 	},
 /turf/open/floor/almayer/silver,
 /area/white_antre/indoors/main_level/research)
+"aEV" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s"
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 8
+	},
+/turf/open/floor/prison,
+/area/white_antre/landing_zone)
 "aEW" = (
 /obj/item/stack/sheet/metal,
 /obj/effect/antre/border/corner{
@@ -13445,8 +13427,12 @@
 /turf/open/floor/prison/darkpurple2/southeast,
 /area/white_antre/indoors/underground_level/east_maint)
 "aEX" = (
-/turf/open/floor/hybrisa/metal/zbrownfloor_full,
-/area/white_antre/landing_zone/roof)
+/obj/item/device/flashlight/lamp/tripod,
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s"
+	},
+/turf/open/floor/prison/ramptop/east,
+/area/white_antre/landing_zone)
 "aEY" = (
 /obj/structure/surface/table/reinforced/prison{
 	color = "#6b675e"
@@ -13458,37 +13444,45 @@
 /turf/open/floor/almayer/silver,
 /area/white_antre/indoors/main_level/research)
 "aEZ" = (
-/obj/structure/largecrate/random,
-/turf/open/floor/plating/plating_catwalk/prison,
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s"
+	},
+/turf/open/floor/prison/ramptop/east,
 /area/white_antre/landing_zone)
 "aFa" = (
-/obj/structure/machinery/door/airlock/almayer/secure/colony{
-	dir = 2
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 4;
+	layer = 2
 	},
-/turf/open/floor/corsat/marked,
-/area/white_antre/landing_zone/roof)
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s"
+	},
+/turf/open/floor/prison,
+/area/white_antre/landing_zone)
 "aFb" = (
-/obj/structure/largecrate/random/barrel/brown,
-/obj/effect/decal/hybrisa/dirt,
+/obj/structure/largecrate/empty/secure,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "aFc" = (
-/turf/open/floor/prison/darkyellowfull2,
+/turf/open/floor/prison/blue/east,
 /area/white_antre/landing_zone/roof)
 "aFd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/machinery/door/airlock/multi_tile/hybrisa/personal/autoname,
-/turf/open/floor/corsat/marked,
-/area/white_antre/landing_zone/roof)
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 8
+	},
+/turf/open/floor/prison/ramptop/north,
+/area/white_antre/landing_zone)
 "aFe" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/corsat/marked,
-/area/white_antre/landing_zone/roof)
+/obj/structure/platform/metal/almayer,
+/obj/structure/platform/metal/almayer/west,
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/landing_zone)
 "aFf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/framed/strata/reinforced,
-/turf/open/floor/plating,
-/area/white_antre/landing_zone/roof)
+/obj/structure/platform/metal/almayer,
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/landing_zone)
 "aFg" = (
 /obj/item/paper/crumpled{
 	pixel_x = 15;
@@ -14045,8 +14039,9 @@
 /turf/open/floor/almayer/silver,
 /area/white_antre/indoors/main_level/north_containment_hive)
 "aGq" = (
-/turf/open/floor/prison/darkyellow2,
-/area/white_antre/landing_zone/roof)
+/obj/structure/platform/metal/almayer,
+/turf/open/auto_turf/shale/layer2/weedable,
+/area/white_antre/landing_zone)
 "aGr" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_21"
@@ -14783,14 +14778,6 @@
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/indoors/main_level/east_containment)
-"aHN" = (
-/obj/structure/platform/metal/almayer/west,
-/turf/open/asphalt/cement/cement15,
-/area/white_antre/outdoors/south_field)
-"aHO" = (
-/obj/structure/platform/metal/almayer/west,
-/turf/open/asphalt/cement/cement1,
-/area/white_antre/outdoors/south_field)
 "aHP" = (
 /obj/structure/machinery/meter{
 	pixel_y = -30
@@ -14807,21 +14794,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/corsat/marked,
 /area/white_antre/indoors/main_level/east_corridor)
-"aHR" = (
-/obj/structure/machinery/door/poddoor/hybrisa/ultra_reinforced_door/open{
-	dir = 2;
-	icon_state = "udoor0"
-	},
-/obj/structure/machinery/light/small{
-	light_color = "#ff3b3b";
-	color = "#ff3b3b";
-	needs_power = 0;
-	dir = 4;
-	name = "emergency lighting";
-	desc = "A small emergency light. Has an internal battery which should last for five hours."
-	},
-/turf/open/floor/corsat/marked,
-/area/white_antre/indoors/main_level/weapons)
 "aHS" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_22";
@@ -14921,10 +14893,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/corsat/marked,
 /area/white_antre/indoors/main_level/east_corridor)
-"aIc" = (
-/obj/structure/machinery/light/double,
-/turf/open/floor/strata/green3/east,
-/area/white_antre/indoors/main_level/weapons)
 "aId" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/tank/fuel,
@@ -15104,8 +15072,10 @@
 /turf/open/floor/prison/floor_plate/southwest,
 /area/white_antre/indoors/main_level/east_containment)
 "aIu" = (
-/turf/open/floor/prison/darkyellow2/southeast,
-/area/white_antre/landing_zone/roof)
+/obj/structure/platform/metal/almayer,
+/obj/structure/platform/metal/almayer/east,
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/landing_zone)
 "aIv" = (
 /obj/structure/flora/bush/snow{
 	icon_state = "snowgrassall_3"
@@ -15121,12 +15091,21 @@
 /turf/open/auto_turf/snow/layer2,
 /area/white_antre/oob)
 "aIw" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison/darkbrown2/southwest,
-/area/white_antre/landing_zone/roof)
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 4;
+	layer = 2
+	},
+/turf/open/floor/prison/ramptop/north,
+/area/white_antre/landing_zone)
 "aIx" = (
-/turf/open/floor/prison/darkbrown2,
-/area/white_antre/landing_zone/roof)
+/obj/structure/platform/metal/almayer_smooth/north,
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 8
+	},
+/turf/open/floor/prison/ramptop/north,
+/area/white_antre/landing_zone)
 "aIy" = (
 /turf/open/floor/almayer/silver/east,
 /area/white_antre/indoors/main_level/research)
@@ -15154,9 +15133,10 @@
 /turf/open/floor/strata/white_cyan3,
 /area/white_antre/indoors/upper_level/medical)
 "aID" = (
-/obj/structure/machinery/disposal,
-/turf/open/floor/prison/darkbrown2/southeast,
-/area/white_antre/landing_zone/roof)
+/obj/structure/platform/metal/almayer/west,
+/obj/structure/platform_decoration/metal/almayer_smooth/east,
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/landing_zone)
 "aIE" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -15373,9 +15353,9 @@
 /turf/open/floor/almayer/emerald2smooth/west,
 /area/white_antre/indoors/main_level/research)
 "aJb" = (
-/obj/structure/largecrate/random/barrel/black,
-/turf/open/floor/prison/darkyellow2,
-/area/white_antre/landing_zone/roof)
+/obj/structure/platform/metal/almayer/east,
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/landing_zone)
 "aJc" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4;
@@ -15408,9 +15388,11 @@
 /turf/open/floor/almayer/emerald2smooth/northeast,
 /area/white_antre/indoors/main_level/research)
 "aJg" = (
-/obj/structure/largecrate/random/barrel/medical,
-/turf/open/floor/prison/darkyellowcorners2/west,
-/area/white_antre/landing_zone/roof)
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_c"
+	},
+/turf/open/floor/prison,
+/area/white_antre/landing_zone)
 "aJh" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -15728,10 +15710,6 @@
 /obj/structure/largecrate/random,
 /turf/open/floor/prison/darkyellow2/southwest,
 /area/white_antre/landing_zone/roof)
-"aKu" = (
-/obj/structure/machinery/light/double,
-/turf/open/floor/strata/green3/west,
-/area/white_antre/indoors/main_level/weapons)
 "aKv" = (
 /turf/closed/wall/hybrisa/research/reinforced,
 /area/white_antre/outdoors/facility_exterior)
@@ -16659,14 +16637,6 @@
 	},
 /turf/open/auto_turf/strata_grass/layer0,
 /area/white_antre/outdoors/north_field)
-"aNx" = (
-/obj/structure/surface/table/almayer,
-/obj/item/clothing/head/hardhat/orange{
-	pixel_x = 8;
-	pixel_y = 12
-	},
-/turf/open/floor/hybrisa/metal/bluemetalfull,
-/area/white_antre/landing_zone/roof)
 "aNy" = (
 /turf/open/asphalt/cement/cement9,
 /area/white_antre/outdoors/north_field)
@@ -16681,11 +16651,6 @@
 	},
 /turf/open/floor/corsat/marked,
 /area/white_antre/landing_zone/roof)
-"aNB" = (
-/obj/structure/platform/metal/almayer/north,
-/obj/structure/platform/metal/almayer/west,
-/turf/open/asphalt/cement/cement1,
-/area/white_antre/outdoors/south_field)
 "aNC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkbrown2,
@@ -16693,14 +16658,6 @@
 "aND" = (
 /turf/open/floor/antre/metal/black,
 /area/white_antre/indoors/upper_level/director_office)
-"aNE" = (
-/obj/structure/platform/metal/almayer/north,
-/turf/open/auto_turf/snow/layer1,
-/area/white_antre/outdoors/south_field)
-"aNF" = (
-/obj/structure/platform/metal/almayer/north,
-/turf/open/auto_turf/sand_white/layer0,
-/area/white_antre/outdoors/south_field)
 "aNG" = (
 /obj/effect/decal/strata_decals/mud_corner{
 	dir = 5
@@ -16717,16 +16674,10 @@
 "aNJ" = (
 /turf/open/floor/prison/darkbrown2/west,
 /area/white_antre/landing_zone/roof)
-"aNK" = (
-/obj/structure/largecrate/empty/case/double,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone)
 "aNL" = (
-/obj/structure/machinery/light/double{
-	dir = 4
-	},
-/turf/open/floor/prison/darkyellow2/east,
-/area/white_antre/landing_zone/roof)
+/obj/structure/platform/metal/almayer,
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/landing_zone)
 "aNM" = (
 /obj/structure/filingcabinet{
 	density = 0;
@@ -16757,10 +16708,6 @@
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison/darkbrown2/northeast,
 /area/white_antre/landing_zone/roof)
-"aNP" = (
-/obj/item/device/flashlight/lamp/tripod,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone)
 "aNQ" = (
 /obj/effect/decal/hybrisa/road/corner{
 	dir = 1
@@ -16873,11 +16820,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/green/northeast,
 /area/white_antre/indoors/upper_level/west_corridor)
-"aOh" = (
-/obj/structure/closet/crate/green,
-/obj/effect/landmark/objective_landmark/medium,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone)
 "aOi" = (
 /obj/effect/decal/strata_decals/mud_corner{
 	dir = 6
@@ -17474,16 +17416,6 @@
 "aQu" = (
 /turf/open/floor/hybrisa/tile/tilewhite,
 /area/white_antre/indoors/upper_level/xenobio)
-"aQv" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s"
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
-	dir = 8
-	},
-/turf/open/floor/prison,
-/area/white_antre/landing_zone)
 "aQw" = (
 /obj/effect/antre/border{
 	dir = 1
@@ -19931,13 +19863,6 @@
 	},
 /turf/open/auto_turf/snow/layer2,
 /area/white_antre/outdoors/south_field)
-"aXm" = (
-/obj/item/device/flashlight/lamp/tripod,
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s"
-	},
-/turf/open/floor/prison/ramptop/east,
-/area/white_antre/landing_zone)
 "aXn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/cyan{
@@ -19952,12 +19877,6 @@
 /obj/structure/pipes/vents/pump_hybrisa,
 /turf/open/floor/prison/darkbrown2/southwest,
 /area/white_antre/indoors/main_level/south_containment)
-"aXp" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s"
-	},
-/turf/open/floor/prison/ramptop/east,
-/area/white_antre/landing_zone)
 "aXq" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall/kseries,
 /obj/structure/pipes/standard/simple/hidden/cyan{
@@ -20250,16 +20169,11 @@
 /turf/open/floor/prison/red,
 /area/white_antre/indoors/main_level/east_containment)
 "aYg" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
-	dir = 4;
-	layer = 2
+/obj/structure/machinery/light/double{
+	dir = 4
 	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s"
-	},
-/turf/open/floor/prison,
-/area/white_antre/landing_zone)
+/turf/open/floor/prison/bluefull,
+/area/white_antre/landing_zone/roof)
 "aYh" = (
 /turf/open/antre/plating/corner_dir/south_east,
 /area/white_antre/indoors/main_level/west_corridor)
@@ -20745,10 +20659,6 @@
 	},
 /turf/open/antre/plating/direction_west,
 /area/white_antre/indoors/main_level/east_containment)
-"aZz" = (
-/obj/structure/largecrate/empty/secure,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone)
 "aZA" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "test_warning_smooth_red"
@@ -22708,26 +22618,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkbrown2/west,
 /area/white_antre/landing_zone/roof)
-"bea" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
-	dir = 8
-	},
-/turf/open/floor/prison/ramptop/north,
-/area/white_antre/landing_zone)
-"beb" = (
-/obj/structure/platform/metal/almayer,
-/obj/structure/platform/metal/almayer/west,
-/turf/open/auto_turf/shale/layer1/weedable,
-/area/white_antre/landing_zone)
 "bec" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone/roof)
-"bed" = (
-/obj/structure/platform/metal/almayer,
-/turf/open/auto_turf/shale/layer1/weedable,
-/area/white_antre/landing_zone)
 "bee" = (
 /obj/structure/platform_decoration/stone/soro/west,
 /turf/open/auto_turf/shale/layer1/weedable,
@@ -22776,10 +22670,6 @@
 	},
 /turf/open/floor/prison/darkbrown2/west,
 /area/white_antre/landing_zone/roof)
-"bem" = (
-/obj/structure/platform/metal/almayer,
-/turf/open/auto_turf/shale/layer2/weedable,
-/area/white_antre/landing_zone)
 "ben" = (
 /obj/structure/surface/rack,
 /obj/item/clothing/head/hardhat/orange{
@@ -22792,19 +22682,6 @@
 	},
 /turf/open/floor/prison,
 /area/white_antre/landing_zone/roof)
-"beo" = (
-/obj/structure/platform/metal/almayer,
-/obj/structure/platform/metal/almayer/east,
-/turf/open/auto_turf/shale/layer1/weedable,
-/area/white_antre/landing_zone)
-"bep" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
-	dir = 4;
-	layer = 2
-	},
-/turf/open/floor/prison/ramptop/north,
-/area/white_antre/landing_zone)
 "beq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkbrownfull2,
@@ -22846,14 +22723,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkbrown2/east,
 /area/white_antre/landing_zone/roof)
-"bew" = (
-/obj/structure/platform/metal/almayer_smooth/north,
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
-	dir = 8
-	},
-/turf/open/floor/prison/ramptop/north,
-/area/white_antre/landing_zone)
 "bex" = (
 /obj/structure/prop/colorable_rock/colorable{
 	color = "#5F5F70";
@@ -27038,11 +26907,6 @@
 	},
 /turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/indoors/main_level/east_containment)
-"bqz" = (
-/obj/structure/platform/metal/almayer/west,
-/obj/structure/platform_decoration/metal/almayer_smooth/east,
-/turf/open/auto_turf/sand_white/layer0,
-/area/white_antre/landing_zone)
 "bqA" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -27779,11 +27643,13 @@
 /turf/open/antre/plating/direction_north/east_edge,
 /area/white_antre/indoors/upper_level/east_corridor)
 "bsr" = (
-/obj/structure/bed/chair{
-	dir = 1
+/obj/effect/decal/hybrisa/dirt,
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
 	},
-/turf/open/floor/prison/darkbrown2/east,
-/area/white_antre/landing_zone/roof)
+/turf/open/asphalt/cement/cement3,
+/area/white_antre/landing_zone)
 "bss" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/largecrate/random/barrel,
@@ -29342,20 +29208,6 @@
 	},
 /turf/open/floor/almayer/silver/west,
 /area/white_antre/indoors/main_level/research)
-"bwt" = (
-/obj/structure/platform/metal/almayer/east,
-/turf/open/auto_turf/sand_white/layer0,
-/area/white_antre/landing_zone)
-"bwu" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_c"
-	},
-/turf/open/floor/prison,
-/area/white_antre/landing_zone)
-"bwv" = (
-/obj/structure/platform/metal/almayer,
-/turf/open/auto_turf/sand_white/layer0,
-/area/white_antre/landing_zone)
 "bww" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/antre/border{
@@ -30559,21 +30411,6 @@
 	},
 /turf/open/floor/almayer/silver/west,
 /area/white_antre/indoors/main_level/research)
-"bzh" = (
-/obj/effect/decal/hybrisa/dirt,
-/obj/structure/stairs/perspective{
-	dir = 1;
-	icon_state = "p_stair_full"
-	},
-/turf/open/asphalt/cement/cement3,
-/area/white_antre/landing_zone)
-"bzi" = (
-/obj/structure/flora/tree/tyrargo{
-	pixel_x = -26;
-	pixel_y = -2
-	},
-/turf/open/auto_turf/snow/layer2,
-/area/white_antre/outdoors/south_field)
 "bzj" = (
 /obj/item/trash/crushed_cup,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -37227,10 +37064,6 @@
 	},
 /turf/solid_open_space,
 /area/white_antre/oob)
-"bOz" = (
-/obj/structure/platform_decoration/metal/almayer/west,
-/turf/open/auto_turf/hybrisa_auto_turf/layer1,
-/area/white_antre/landing_zone)
 "bOA" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/white_antre/indoors/main_level/research)
@@ -37253,26 +37086,9 @@
 	},
 /turf/closed/wall/strata_ice,
 /area/white_antre/oob)
-"bOC" = (
-/obj/structure/platform/metal/almayer/north,
-/turf/open/auto_turf/hybrisa_auto_turf/layer1,
-/area/white_antre/landing_zone)
-"bOD" = (
-/obj/structure/stairs/perspective{
-	dir = 10;
-	icon_state = "p_stair_full"
-	},
-/turf/open/auto_turf/shale/layer1/weedable,
-/area/white_antre/landing_zone)
 "bOE" = (
 /turf/open/floor/almayer/silver/northeast,
 /area/white_antre/indoors/main_level/research)
-"bOF" = (
-/obj/structure/stairs/perspective{
-	icon_state = "p_stair_full"
-	},
-/turf/open/auto_turf/shale/layer1/weedable,
-/area/white_antre/landing_zone)
 "bOG" = (
 /obj/structure/platform/stone/strata/east,
 /obj/effect/mist/steam{
@@ -38230,15 +38046,12 @@
 /turf/open/antre/plating/direction_north,
 /area/white_antre/indoors/upper_level/central_corridor)
 "bPX" = (
-/obj/structure/machinery/door_control/brbutton/alt{
-	id = "LZ1_Lockdown_Lo";
-	name = "remote door-control";
-	pixel_y = -2;
-	pixel_x = 6
+/obj/structure/flora/tree/tyrargo{
+	pixel_x = -26;
+	pixel_y = -2
 	},
-/obj/structure/surface/table/almayer,
-/turf/open/floor/prison/darkbrownfull2,
-/area/white_antre/landing_zone/roof)
+/turf/open/auto_turf/snow/layer2,
+/area/white_antre/outdoors/south_field)
 "bPY" = (
 /obj/effect/mist/steam{
 	pixel_x = 6;
@@ -38659,16 +38472,25 @@
 /turf/open/antre/plating/corner_dir,
 /area/white_antre/indoors/upper_level/central_corridor)
 "bQQ" = (
-/turf/open/floor/prison/darkyellow2/west,
-/area/white_antre/landing_zone/roof)
+/turf/open/floor/prison/redcorner,
+/area/white_antre/indoors/main_level/east_containment)
 "bQR" = (
-/turf/open/floor/prison/darkyellow2/east,
-/area/white_antre/landing_zone/roof)
+/obj/structure/pipes/standard/manifold/hidden/cyan{
+	dir = 1
+	},
+/turf/open/antre/plating/direction_north/north_edge,
+/area/white_antre/indoors/main_level/east_corridor)
 "bQS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/largecrate/random/barrel/white,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone/roof)
+/obj/item/prop/alien/hugger{
+	icon = 'icons/mob/xenos/castes/tier_0/larva.dmi';
+	icon_state = "Larva Dead";
+	name = "dead larva";
+	desc = "Looks like it was murdered by another xenomorph?"
+	},
+/obj/effect/decal/cleanable/blood/xeno,
+/obj/effect/decal/cleanable/blood/gibs/xeno,
+/turf/open/floor/prison/floor_marked/southwest,
+/area/white_antre/indoors/main_level/east_containment)
 "bQT" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/bed/chair/comfy/orange{
@@ -38704,9 +38526,9 @@
 /turf/open/floor/prison,
 /area/white_antre/indoors/upper_level/west_corridor)
 "bQW" = (
-/obj/structure/machinery/door/airlock/almayer/secure/colony,
-/turf/open/floor/corsat/marked,
-/area/white_antre/landing_zone/roof)
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/auto_turf/hybrisa_auto_turf/layer1,
+/area/white_antre/landing_zone)
 "bQX" = (
 /obj/effect/antre/border/edge{
 	dir = 1
@@ -39334,9 +39156,9 @@
 /turf/open/floor/prison,
 /area/white_antre/indoors/main_level/weapons)
 "bSn" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison/darkyellowcorners2/north,
-/area/white_antre/landing_zone/roof)
+/obj/structure/platform/metal/almayer/north,
+/turf/open/auto_turf/hybrisa_auto_turf/layer1,
+/area/white_antre/landing_zone)
 "bSo" = (
 /obj/structure/window/framed/hybrisa/research/reinforced,
 /obj/structure/pipes/standard/simple/hidden/cyan{
@@ -40700,9 +40522,12 @@
 /turf/open/floor/prison/green,
 /area/white_antre/indoors/underground_level/east_maint)
 "bVK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison/darkyellow2/northeast,
-/area/white_antre/landing_zone/roof)
+/obj/structure/stairs/perspective{
+	dir = 10;
+	icon_state = "p_stair_full"
+	},
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/landing_zone)
 "bVL" = (
 /obj/effect/decal/hybrisa/bloodtrail/clawtrail/xeno{
 	dir = 8;
@@ -41443,10 +41268,11 @@
 /turf/open/floor/prison/floor_plate,
 /area/white_antre/landing_zone)
 "bXM" = (
-/obj/structure/surface/rack,
-/obj/item/stack/sheet/metal/medium_stack,
-/turf/open/floor/prison,
-/area/white_antre/landing_zone/roof)
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_full"
+	},
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/landing_zone)
 "bXN" = (
 /obj/structure/surface/table/reinforced/prison{
 	color = "#6b675e"
@@ -41643,9 +41469,15 @@
 /turf/open/auto_turf/hybrisa_auto_turf/layer1,
 /area/white_antre/oob)
 "bYm" = (
-/obj/structure/largecrate/random/secure,
+/obj/structure/stairs/perspective{
+	dir = 9;
+	icon_state = "p_stair_full"
+	},
+/obj/structure/barricade/handrail/no_vault{
+	dir = 8
+	},
 /turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone/roof)
+/area/white_antre/landing_zone)
 "bYn" = (
 /turf/open/auto_turf/hybrisa_auto_turf/layer1,
 /area/white_antre/indoors/main_level/south_containment_hive)
@@ -41744,10 +41576,12 @@
 /turf/open/auto_turf/hybrisa_auto_turf/layer1,
 /area/white_antre/indoors/main_level/north_containment_hive)
 "bYG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/largecrate/random/barrel/white,
-/turf/open/floor/prison,
-/area/white_antre/landing_zone/roof)
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
 "bYH" = (
 /turf/open/slippery/roof/dir/east,
 /area/white_antre/outdoors/facility_exterior)
@@ -41784,83 +41618,105 @@
 /turf/open/slippery/roof/dir/northeast,
 /area/white_antre/outdoors/facility_exterior)
 "bYS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison/darkbrown2/east,
-/area/white_antre/landing_zone/roof)
+/obj/structure/platform/metal/almayer/west,
+/obj/structure/platform/metal/almayer_smooth,
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/landing_zone)
 "bYT" = (
-/obj/item/tool/warning_cone{
-	pixel_y = 16
-	},
-/turf/open/floor/prison/darkyellow2/northwest,
-/area/white_antre/landing_zone/roof)
+/obj/structure/platform/metal/almayer/east,
+/turf/open/auto_turf/hybrisa_auto_turf/layer1,
+/area/white_antre/landing_zone)
 "bYU" = (
-/turf/open/floor/prison/darkyellowcorners2/east,
-/area/white_antre/landing_zone/roof)
-"bYV" = (
-/obj/item/tool/warning_cone{
-	pixel_x = 5;
-	pixel_y = 13
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_c";
+	dir = 8
 	},
-/turf/open/floor/prison/darkyellowcorners2/north,
-/area/white_antre/landing_zone/roof)
-"bYW" = (
-/turf/open/floor/prison/darkyellow2/northeast,
-/area/white_antre/landing_zone/roof)
-"bYX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
-/area/white_antre/landing_zone/roof)
-"bYY" = (
-/obj/structure/machinery/space_heater/radiator/red{
-	dir = 8;
-	pixel_x = 1
-	},
-/obj/structure/machinery/light/double{
+/area/white_antre/landing_zone)
+"bYV" = (
+/obj/effect/decal/hybrisa/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
 	dir = 1
 	},
-/turf/open/floor/prison/darkbrownfull2,
-/area/white_antre/landing_zone/roof)
+/turf/open/floor/prison/ramptop/east,
+/area/white_antre/landing_zone)
+"bYW" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 1
+	},
+/turf/open/floor/prison/ramptop/east,
+/area/white_antre/landing_zone)
+"bYX" = (
+/obj/structure/barricade/handrail/no_vault{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
+"bYY" = (
+/obj/effect/decal/hybrisa/dirt,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
 "bYZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkyellow2/east,
 /area/white_antre/indoors/exterior/prefab_3)
 "bZa" = (
-/obj/structure/largecrate/random/barrel/brown,
-/turf/open/floor/prison/darkyellow2/northwest,
-/area/white_antre/landing_zone/roof)
+/obj/item/device/flashlight/lamp/tripod,
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 8
+	},
+/turf/open/floor/prison/ramptop,
+/area/white_antre/landing_zone)
 "bZb" = (
-/obj/structure/largecrate/random/case/double,
-/obj/structure/machinery/light/double{
+/obj/structure/platform/metal/almayer/north,
+/obj/structure/platform/metal/almayer/west,
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/landing_zone)
+"bZc" = (
+/obj/structure/platform/metal/almayer/north,
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/landing_zone)
+"bZd" = (
+/obj/structure/platform/metal/almayer/north,
+/turf/open/auto_turf/shale/layer2/weedable,
+/area/white_antre/landing_zone)
+"bZe" = (
+/obj/structure/platform/metal/almayer/north,
+/obj/structure/platform/metal/almayer/east,
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/landing_zone)
+"bZf" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 4
+	},
+/turf/open/floor/prison/ramptop,
+/area/white_antre/landing_zone)
+"bZg" = (
+/obj/structure/largecrate/random/barrel/green,
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
 	dir = 1
 	},
-/turf/open/floor/prison/darkyellow2/north,
-/area/white_antre/landing_zone/roof)
-"bZc" = (
-/obj/structure/cargo_container/hybrisa/containersextended/redleft,
-/turf/open/floor/prison/darkyellow2/northeast,
-/area/white_antre/landing_zone/roof)
-"bZd" = (
-/obj/structure/cargo_container/hybrisa/containersextended/redright,
-/turf/closed/wall/strata_outpost/reinforced/hull,
-/area/white_antre/landing_zone/roof)
-"bZe" = (
-/turf/open/floor/strata/multi_tiles,
-/area/white_antre/landing_zone/roof)
-"bZf" = (
-/turf/open/floor/strata/multi_tiles/west,
-/area/white_antre/landing_zone/roof)
-"bZg" = (
-/turf/open/floor/strata/floor3,
-/area/white_antre/landing_zone/roof)
-"bZh" = (
-/obj/structure/stairs/perspective{
-	dir = 9;
-	icon_state = "p_stair_full"
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 8
 	},
-/turf/open/auto_turf/shale/layer1/weedable,
-/area/white_antre/outdoors/north_field)
+/turf/open/floor/prison,
+/area/white_antre/landing_zone)
+"bZh" = (
+/obj/structure/cargo_container/uscm/chinook/left{
+	layer = 3.1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 1
+	},
+/turf/open/floor/prison/ramptop/east,
+/area/white_antre/landing_zone)
 "bZi" = (
 /turf/closed/wall/hybrisa/research/reinforced/hull,
 /area/white_antre/indoors/main_level/weapons)
@@ -41871,12 +41727,15 @@
 /turf/closed/wall/hybrisa/colony/reinforced/hull,
 /area/white_antre/oob)
 "bZl" = (
-/obj/structure/stairs/perspective{
-	dir = 1;
-	icon_state = "p_stair_full"
+/obj/structure/cargo_container/uscm/chinook/mid{
+	layer = 3.1
 	},
-/turf/open/auto_turf/shale/layer1/weedable,
-/area/white_antre/outdoors/north_field)
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 1
+	},
+/turf/open/floor/prison/ramptop/east,
+/area/white_antre/landing_zone)
 "bZm" = (
 /obj/effect/mist/steam{
 	pixel_x = 6;
@@ -41976,12 +41835,15 @@
 /turf/open/auto_turf/strata_grass/layer0_mud,
 /area/white_antre/oob)
 "bZy" = (
-/obj/structure/stairs/perspective{
-	dir = 1;
-	icon_state = "p_stair_full"
+/obj/structure/cargo_container/uscm/right{
+	layer = 3.1
 	},
-/turf/open/auto_turf/sand_white/layer0,
-/area/white_antre/outdoors/north_field)
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 1
+	},
+/turf/open/floor/prison/ramptop/east,
+/area/white_antre/landing_zone)
 "bZz" = (
 /obj/structure/barricade/handrail{
 	dir = 1
@@ -42000,12 +41862,13 @@
 /turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/oob)
 "bZC" = (
-/obj/structure/stairs/perspective{
-	dir = 5;
-	icon_state = "p_stair_full"
+/obj/structure/largecrate/random/case/double,
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 1
 	},
-/turf/open/auto_turf/sand_white/layer0,
-/area/white_antre/outdoors/north_field)
+/turf/open/floor/prison/ramptop/east,
+/area/white_antre/landing_zone)
 "bZD" = (
 /obj/structure/stairs/perspective{
 	dir = 8
@@ -42542,13 +42405,18 @@
 /turf/open/floor/prison/bluefull,
 /area/white_antre/indoors/exterior/prefab_1)
 "cbb" = (
-/obj/effect/mist/steam{
-	pixel_x = -10;
-	pixel_y = 9
+/obj/effect/decal/hybrisa/dirt,
+/obj/effect/decal/hybrisa/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 1
 	},
-/obj/structure/platform/stone/strata/east,
-/turf/solid_open_space,
-/area/white_antre/oob)
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 4
+	},
+/turf/open/floor/prison,
+/area/white_antre/landing_zone)
 "cbc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/blue/west,
@@ -42945,16 +42813,6 @@
 	},
 /turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/outdoors/north_field)
-"cch" = (
-/obj/structure/stairs/perspective{
-	dir = 9;
-	icon_state = "p_stair_full"
-	},
-/obj/structure/barricade/handrail/no_vault{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone)
 "cci" = (
 /obj/structure/prop/invuln/ice_prefab,
 /turf/open/auto_turf/sand_white/layer0,
@@ -44350,13 +44208,6 @@
 /obj/effect/decal/hybrisa/dirt,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
-"cfN" = (
-/obj/structure/stairs/perspective{
-	dir = 1;
-	icon_state = "p_stair_full"
-	},
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone)
 "cfO" = (
 /obj/item/device/flashlight/lamp/tripod/grey{
 	on = 0
@@ -44608,14 +44459,10 @@
 /turf/open/auto_turf/snow/layer1,
 /area/white_antre/oob)
 "cgv" = (
-/obj/effect/mist/steam{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/structure/platform/stone/strata/east,
-/obj/structure/platform/stone/strata,
-/turf/solid_open_space,
-/area/white_antre/oob)
+/obj/effect/decal/hybrisa/dirt,
+/obj/effect/decal/hybrisa/dirt,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
 "cgw" = (
 /obj/structure/machinery/light/red{
 	light_color = "#BB3F3F";
@@ -45192,8 +45039,9 @@
 /turf/open/floor/prison/darkpurple2/west,
 /area/white_antre/indoors/main_level/east_corridor)
 "chK" = (
-/turf/closed/wall/strata_ice,
-/area/white_antre/outdoors/north_field)
+/obj/structure/largecrate/random/barrel/blue,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
 "chL" = (
 /obj/structure/barricade/handrail,
 /obj/effect/antre/border,
@@ -45701,24 +45549,20 @@
 /turf/open_space,
 /area/white_antre/indoors/upper_level/central_corridor)
 "cjc" = (
-/turf/closed/wall/strata_ice/dirty/rock,
-/area/white_antre/outdoors/north_field)
+/obj/structure/cargo_container/wy/left,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
 "cjd" = (
-/obj/structure/platform/metal/almayer/west,
-/obj/structure/platform/metal/almayer_smooth,
-/turf/open/auto_turf/sand_white/layer0,
+/obj/structure/cargo_container/wy/mid,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "cje" = (
-/obj/structure/platform/metal/almayer/east,
-/turf/open/auto_turf/hybrisa_auto_turf/layer1,
+/obj/structure/cargo_container/wy/right,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "cjf" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_c";
-	dir = 8
-	},
-/turf/open/floor/prison,
-/area/white_antre/landing_zone)
+/turf/open/floor/hybrisa/metal/zbrownfloor_full,
+/area/white_antre/landing_zone/roof)
 "cjg" = (
 /obj/structure/barricade/handrail{
 	dir = 8
@@ -45729,12 +45573,11 @@
 /turf/open/floor/prison/darkyellow2/northwest,
 /area/white_antre/indoors/upper_level/east_corridor)
 "cjh" = (
-/obj/effect/decal/hybrisa/dirt,
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
-	dir = 1
+/obj/structure/barricade/handrail/no_vault{
+	dir = 8
 	},
-/turf/open/floor/prison/ramptop/east,
+/obj/structure/largecrate/random/barrel/blue,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "cji" = (
 /obj/item/stack/sheet/metal{
@@ -45747,22 +45590,23 @@
 /turf/open/floor/almayer/silver/east,
 /area/white_antre/indoors/upper_level/canteen)
 "cjk" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
-	dir = 1
+/obj/effect/decal/hybrisa/dirt,
+/obj/item/trash/cigbutt{
+	pixel_x = -3;
+	pixel_y = 9
 	},
-/turf/open/floor/prison/ramptop/east,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "cjl" = (
-/obj/structure/barricade/handrail/no_vault{
-	dir = 8
-	},
+/obj/structure/largecrate/random,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "cjm" = (
-/obj/effect/decal/hybrisa/dirt,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone)
+/obj/structure/machinery/door/airlock/almayer/secure/colony{
+	dir = 2
+	},
+/turf/open/floor/corsat/marked,
+/area/white_antre/landing_zone/roof)
 "cjn" = (
 /obj/structure/bed/chair/comfy/orange{
 	dir = 4
@@ -45770,12 +45614,15 @@
 /turf/open/antre/plating/direction_west,
 /area/white_antre/indoors/upper_level/east_corridor)
 "cjo" = (
-/obj/item/device/flashlight/lamp/tripod,
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
+/obj/structure/barricade/handrail/no_vault{
 	dir = 8
 	},
-/turf/open/floor/prison/ramptop,
+/obj/item/trash/cigbutt{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/structure/largecrate/random/case/double,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "cjp" = (
 /obj/structure/platform_decoration/metal/almayer_smooth/north,
@@ -46405,9 +46252,16 @@
 /turf/open/auto_turf/strata_grass/layer0_mud,
 /area/white_antre/oob)
 "ckx" = (
-/obj/structure/platform/metal/almayer/north,
-/obj/structure/platform/metal/almayer/west,
-/turf/open/auto_turf/shale/layer1/weedable,
+/obj/item/trash/cigbutt{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/structure/largecrate/random/case/small,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "cky" = (
 /obj/effect/mist/steam{
@@ -46520,8 +46374,9 @@
 /turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/oob)
 "ckE" = (
-/obj/structure/platform/metal/almayer/north,
-/turf/open/auto_turf/shale/layer1/weedable,
+/obj/structure/largecrate/random/barrel/brown,
+/obj/effect/decal/hybrisa/dirt,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "ckF" = (
 /obj/effect/mist/steam{
@@ -46801,9 +46656,8 @@
 /turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/oob)
 "ckV" = (
-/obj/structure/platform/metal/almayer/north,
-/turf/open/auto_turf/shale/layer2/weedable,
-/area/white_antre/landing_zone)
+/turf/open/floor/prison/darkyellowfull2,
+/area/white_antre/landing_zone/roof)
 "ckW" = (
 /obj/effect/decal/strata_decals/mud_corner{
 	dir = 5
@@ -47765,9 +47619,11 @@
 /turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/oob)
 "cmd" = (
-/obj/structure/platform/metal/almayer/north,
-/obj/structure/platform/metal/almayer/east,
-/turf/open/auto_turf/shale/layer1/weedable,
+/obj/structure/barricade/handrail/no_vault{
+	dir = 8
+	},
+/obj/structure/largecrate/random/secure,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "cme" = (
 /obj/effect/mist/steam{
@@ -48194,12 +48050,10 @@
 /turf/open/auto_turf/strata_grass/layer0_mud,
 /area/white_antre/oob)
 "cmF" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
-	dir = 4
-	},
-/turf/open/floor/prison/ramptop,
-/area/white_antre/landing_zone)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/door/airlock/multi_tile/hybrisa/personal/autoname,
+/turf/open/floor/corsat/marked,
+/area/white_antre/landing_zone/roof)
 "cmG" = (
 /obj/effect/mist/steam{
 	pixel_x = -10;
@@ -48208,13 +48062,9 @@
 /turf/open/auto_turf/strata_grass/layer0_mud,
 /area/white_antre/oob)
 "cmH" = (
-/obj/structure/largecrate/random/case/double,
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
-	dir = 1
-	},
-/turf/open/floor/prison/ramptop/east,
-/area/white_antre/landing_zone)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/corsat/marked,
+/area/white_antre/landing_zone/roof)
 "cmI" = (
 /turf/closed/wall/hybrisa/colony/reinforced,
 /area/white_antre/oob)
@@ -48302,18 +48152,10 @@
 /turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/indoors/main_level/east_containment)
 "cni" = (
-/obj/effect/decal/hybrisa/dirt,
-/obj/effect/decal/hybrisa/dirt,
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes{
-	icon_state = "warning_s";
-	dir = 4
-	},
-/turf/open/floor/prison,
-/area/white_antre/landing_zone)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/framed/strata/reinforced,
+/turf/open/floor/plating,
+/area/white_antre/landing_zone/roof)
 "cnj" = (
 /obj/structure/largecrate/random/barrel/yellow,
 /turf/open/floor/plating,
@@ -49299,39 +49141,21 @@
 /turf/open/antre/plating/direction_north/east_edge,
 /area/white_antre/indoors/upper_level/central_corridor)
 "cqv" = (
-/obj/effect/decal/hybrisa/dirt,
-/obj/effect/decal/hybrisa/dirt,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone)
+/turf/open/floor/prison/darkyellow2,
+/area/white_antre/landing_zone/roof)
 "cqw" = (
-/obj/structure/barricade/handrail/no_vault{
-	dir = 8
-	},
-/obj/structure/largecrate/random/barrel/blue,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone)
+/turf/open/floor/prison/darkyellow2/southeast,
+/area/white_antre/landing_zone/roof)
 "cqx" = (
-/obj/effect/decal/hybrisa/dirt,
-/obj/item/trash/cigbutt{
-	pixel_x = -3;
-	pixel_y = 9
-	},
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/darkbrown2/southwest,
+/area/white_antre/landing_zone/roof)
 "cqy" = (
 /turf/open/antre/plating/direction_west/east_north,
 /area/white_antre/indoors/upper_level/central_corridor)
 "cqz" = (
-/obj/structure/barricade/handrail/no_vault{
-	dir = 8
-	},
-/obj/item/trash/cigbutt{
-	pixel_x = -3;
-	pixel_y = 9
-	},
-/obj/structure/largecrate/random/case/double,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone)
+/turf/open/floor/prison/darkbrown2,
+/area/white_antre/landing_zone/roof)
 "cqA" = (
 /obj/effect/antre/border/edge{
 	dir = 4
@@ -49431,17 +49255,9 @@
 /turf/open/antre/plating/west_corner_dir/north_west,
 /area/white_antre/indoors/upper_level/central_corridor)
 "cqO" = (
-/obj/item/trash/cigbutt{
-	pixel_x = -3;
-	pixel_y = 9
-	},
-/obj/item/trash/cigbutt{
-	pixel_x = -3;
-	pixel_y = 9
-	},
-/obj/structure/largecrate/random/case/small,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone)
+/obj/structure/machinery/disposal,
+/turf/open/floor/prison/darkbrown2/southeast,
+/area/white_antre/landing_zone/roof)
 "cqP" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "door_warning2";
@@ -50459,12 +50275,9 @@
 /turf/open/floor/antre/metal/black/southwest,
 /area/white_antre/indoors/exterior/prefab_1)
 "cul" = (
-/obj/structure/barricade/handrail/no_vault{
-	dir = 8
-	},
-/obj/structure/largecrate/random/secure,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/white_antre/landing_zone)
+/obj/structure/largecrate/random/barrel/black,
+/turf/open/floor/prison/darkyellow2,
+/area/white_antre/landing_zone/roof)
 "cum" = (
 /obj/structure/machinery/space_heater/radiator/red,
 /turf/open/floor/antre/metal/black,
@@ -50931,8 +50744,8 @@
 /turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/outdoors/south_field)
 "cvz" = (
-/obj/structure/machinery/light/double,
-/turf/open/floor/prison/darkbrownfull2,
+/obj/structure/largecrate/random/barrel/medical,
+/turf/open/floor/prison/darkyellowcorners2/west,
 /area/white_antre/landing_zone/roof)
 "cvA" = (
 /obj/effect/antre/border{
@@ -51076,10 +50889,191 @@
 /turf/open/floor/almayer_hull/outerhull_dir/east,
 /area/white_antre/indoors/upper_level/east_overwatch)
 "cvU" = (
+/obj/structure/machinery/light/double{
+	dir = 4
+	},
+/turf/open/floor/prison/darkyellow2/east,
+/area/white_antre/landing_zone/roof)
+"cvV" = (
+/obj/structure/machinery/light/double,
+/turf/open/floor/prison/darkbrownfull2,
+/area/white_antre/landing_zone/roof)
+"cvW" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/floor/prison/darkbrown2/east,
+/area/white_antre/landing_zone/roof)
+"cvX" = (
+/obj/structure/machinery/door_control/brbutton/alt{
+	id = "LZ1_Lockdown_Lo";
+	name = "remote door-control";
+	pixel_y = -2;
+	pixel_x = 6
+	},
+/obj/structure/surface/table/almayer,
+/turf/open/floor/prison/darkbrownfull2,
+/area/white_antre/landing_zone/roof)
+"cvY" = (
+/turf/open/floor/prison/darkyellow2/west,
+/area/white_antre/landing_zone/roof)
+"cvZ" = (
+/turf/open/floor/prison/darkyellow2/east,
+/area/white_antre/landing_zone/roof)
+"cwa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/random/barrel/white,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone/roof)
+"cwb" = (
+/obj/structure/machinery/door/airlock/almayer/secure/colony,
+/turf/open/floor/corsat/marked,
+/area/white_antre/landing_zone/roof)
+"cwc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/darkyellowcorners2/north,
+/area/white_antre/landing_zone/roof)
+"cwd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/darkyellow2/northeast,
+/area/white_antre/landing_zone/roof)
+"cwe" = (
+/obj/structure/surface/rack,
+/obj/item/stack/sheet/metal/medium_stack,
+/turf/open/floor/prison,
+/area/white_antre/landing_zone/roof)
+"cwf" = (
+/obj/structure/largecrate/random/secure,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone/roof)
+"cwg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/random/barrel/white,
+/turf/open/floor/prison,
+/area/white_antre/landing_zone/roof)
+"cwh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/darkbrown2/east,
+/area/white_antre/landing_zone/roof)
+"cwi" = (
+/obj/item/tool/warning_cone{
+	pixel_y = 16
+	},
+/turf/open/floor/prison/darkyellow2/northwest,
+/area/white_antre/landing_zone/roof)
+"cwj" = (
+/turf/open/floor/prison/darkyellowcorners2/east,
+/area/white_antre/landing_zone/roof)
+"cwk" = (
+/obj/item/tool/warning_cone{
+	pixel_x = 5;
+	pixel_y = 13
+	},
+/turf/open/floor/prison/darkyellowcorners2/north,
+/area/white_antre/landing_zone/roof)
+"cwl" = (
+/turf/open/floor/prison/darkyellow2/northeast,
+/area/white_antre/landing_zone/roof)
+"cwm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/white_antre/landing_zone/roof)
+"cwn" = (
+/obj/structure/machinery/space_heater/radiator/red{
+	dir = 8;
+	pixel_x = 1
+	},
+/obj/structure/machinery/light/double{
+	dir = 1
+	},
+/turf/open/floor/prison/darkbrownfull2,
+/area/white_antre/landing_zone/roof)
+"cwo" = (
+/obj/structure/largecrate/random/barrel/brown,
+/turf/open/floor/prison/darkyellow2/northwest,
+/area/white_antre/landing_zone/roof)
+"cwp" = (
+/obj/structure/largecrate/random/case/double,
+/obj/structure/machinery/light/double{
+	dir = 1
+	},
+/turf/open/floor/prison/darkyellow2/north,
+/area/white_antre/landing_zone/roof)
+"cwq" = (
+/obj/structure/cargo_container/hybrisa/containersextended/redleft,
+/turf/open/floor/prison/darkyellow2/northeast,
+/area/white_antre/landing_zone/roof)
+"cwr" = (
+/obj/structure/cargo_container/hybrisa/containersextended/redright,
+/turf/closed/wall/strata_outpost/reinforced/hull,
+/area/white_antre/landing_zone/roof)
+"cws" = (
+/turf/open/floor/strata/multi_tiles,
+/area/white_antre/landing_zone/roof)
+"cwt" = (
+/turf/open/floor/strata/multi_tiles/west,
+/area/white_antre/landing_zone/roof)
+"cwu" = (
+/turf/open/floor/strata/floor3,
+/area/white_antre/landing_zone/roof)
+"cwv" = (
+/obj/structure/stairs/perspective{
+	dir = 9;
+	icon_state = "p_stair_full"
+	},
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/outdoors/north_field)
+"cww" = (
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/outdoors/north_field)
+"cwx" = (
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/outdoors/north_field)
+"cwy" = (
+/obj/structure/stairs/perspective{
+	dir = 5;
+	icon_state = "p_stair_full"
+	},
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/outdoors/north_field)
+"cwz" = (
+/obj/effect/mist/steam{
+	pixel_x = -10;
+	pixel_y = 9
+	},
+/obj/structure/platform/stone/strata/east,
+/turf/solid_open_space,
+/area/white_antre/oob)
+"cwA" = (
+/obj/effect/mist/steam{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/structure/platform/stone/strata/east,
+/obj/structure/platform/stone/strata,
+/turf/solid_open_space,
+/area/white_antre/oob)
+"cwB" = (
 /obj/structure/bed/chair/dropship/passenger,
 /obj/effect/landmark/objective_landmark/medium,
 /turf/open/shuttle/dropship/light_grey_single_wide_up_to_down,
 /area/white_antre/indoors/pmc_dropship)
+"cwC" = (
+/turf/closed/wall/strata_ice,
+/area/white_antre/outdoors/north_field)
+"cwD" = (
+/turf/closed/wall/strata_ice/dirty/rock,
+/area/white_antre/outdoors/north_field)
 "cxK" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -55707,6 +55701,12 @@
 	},
 /turf/open/floor/prison/blue,
 /area/white_antre/indoors/main_level/dorms)
+"uUl" = (
+/obj/structure/machinery/space_heater/radiator/red{
+	dir = 4
+	},
+/turf/open/floor/prison/bluefull,
+/area/white_antre/landing_zone/roof)
 "uVc" = (
 /obj/structure/barricade/handrail{
 	dir = 1
@@ -100318,7 +100318,7 @@ bNU
 bNP
 bNU
 bNP
-cbb
+cwz
 byZ
 iKa
 iKa
@@ -100330,13 +100330,13 @@ kuQ
 kuQ
 kuQ
 iFy
-cul
-cqz
-cqw
-cjl
-cjl
-cjl
-cch
+cmd
+cjo
+cjh
+bYX
+bYX
+bYX
+bYm
 bYb
 cfI
 cfC
@@ -100485,7 +100485,7 @@ bNY
 bNV
 bOI
 bOH
-cgv
+cwA
 aMJ
 aMJ
 aMJ
@@ -100496,14 +100496,14 @@ bRL
 aNI
 beu
 bek
-cvz
+cvV
 bdY
 iFy
-cqO
-cqx
+ckx
+cjk
 bXo
 bXo
-cjm
+bYY
 bYC
 bdf
 cfJ
@@ -100538,7 +100538,7 @@ aYD
 bYx
 bXo
 bXo
-aNK
+aEQ
 iFy
 iFy
 aXQ
@@ -100665,14 +100665,14 @@ aNJ
 aNJ
 bel
 bdZ
-aIw
+cqx
 iFy
 bXo
-cjm
-cqv
-cjm
-cjm
-cfN
+bYY
+cgv
+bYY
+bYY
+bYG
 bdf
 bXj
 cfD
@@ -100834,9 +100834,9 @@ aKf
 aKf
 aKf
 aNC
-aFd
+cmF
 bXo
-cjm
+bYY
 bXo
 bXo
 bXo
@@ -100992,22 +100992,22 @@ aMS
 aMJ
 aMJ
 aMJ
-bZh
+cwv
 ctR
 ctR
 ctR
 aNN
 aKf
-bXM
+cwe
 ben
 aKf
-aIx
-aFe
-cjm
-cqv
-aEP
-aEI
-cjo
+cqz
+cmH
+bYY
+cgv
+chK
+bZg
+bZa
 dwB
 bYb
 bcU
@@ -101160,23 +101160,23 @@ aMJ
 aMJ
 aMJ
 aMJ
-bZl
-bZg
-bZe
+cww
+cwu
+cws
 aNA
 aNN
 aKf
-bYm
+cwf
 aKp
 aKf
-aIx
-aFf
-cqv
-aEZ
+cqz
+cni
+cgv
+cjl
 bXo
-aEJ
-ckx
-cjd
+bZh
+bZb
+bYS
 bbQ
 bWX
 bbP
@@ -101207,9 +101207,9 @@ aYL
 aYU
 bWX
 bWQ
-bew
-bea
-aQv
+aIx
+aFd
+aEV
 bXo
 akw
 aXU
@@ -101328,22 +101328,22 @@ aMH
 beA
 beA
 bee
-bZl
-bZg
-bZf
+cww
+cwu
+cwt
 aNA
 aNN
 aKf
 aKf
 aKf
 aKf
-aIx
-aFf
-cjm
+cqz
+cni
+bYY
 bXo
-aEQ
-aEL
-ckE
+cjc
+bZl
+bZc
 odB
 oSf
 wvY
@@ -101375,9 +101375,9 @@ bWX
 bWQ
 lDX
 oSf
-bqz
-beb
-aXm
+aID
+aFe
+aEX
 bXo
 akw
 aXU
@@ -101496,22 +101496,22 @@ bfb
 aMH
 aMH
 bef
-bZl
-bZg
-bZf
+cww
+cwu
+cwt
 aNA
 aNN
 aKf
 aXH
 aKf
 aKf
-aIx
-aFf
-cjm
+cqz
+cni
+bYY
 bXo
-aER
-aEO
-ckV
+cjd
+bZy
+bZd
 aKB
 aKC
 odB
@@ -101544,8 +101544,8 @@ oSf
 nQp
 aKC
 aKB
-bed
-aXp
+aFf
+aEZ
 bXo
 atH
 aXU
@@ -101664,22 +101664,22 @@ aMH
 aMH
 beX
 bef
-bZl
-bZg
-bZf
+cww
+cwu
+cwt
 aNA
 aNN
 aKf
-bYG
+cwg
 aKf
 aKf
-aIx
+cqz
 atH
-aFb
-bXo
-aET
-cmH
 ckE
+bXo
+cje
+bZC
+bZc
 aKB
 aKB
 aKC
@@ -101712,8 +101712,8 @@ aKB
 aKB
 aKB
 aKB
-bed
-aXp
+aFf
+aEZ
 bXo
 aKz
 wje
@@ -101832,22 +101832,22 @@ beS
 uoG
 aMH
 beP
-bZy
-bZg
-bZe
+cwx
+cwu
+cws
 aNA
 aNN
-bYX
+cwm
 bpa
-bQS
+cwa
 aXH
 aNC
 aKz
-cjm
+bYY
 bXo
 bXo
-cjk
-ckE
+bYW
+bZc
 aKB
 aKB
 aKB
@@ -101880,12 +101880,12 @@ aKB
 aKB
 aKB
 aKB
-bem
-aXp
+aGq
+aEZ
 bXo
 iFy
 bph
-aNx
+aEJ
 bpg
 caA
 caA
@@ -102000,22 +102000,22 @@ aMH
 lGQ
 kGT
 beP
-bZC
+cwy
 ctR
 ctR
 ctR
 aNO
-bYS
-bYS
+cwh
+cwh
 bev
-bsr
-aID
+cvW
+cqO
 ctR
-cjm
-cjm
+bYY
+bYY
 bXo
-cjk
-ckE
+bYW
+bZc
 bYz
 aKB
 aKB
@@ -102048,8 +102048,8 @@ aLc
 aJq
 aJq
 aKC
-bed
-aXp
+aFf
+aEZ
 bXo
 iFy
 iFy
@@ -102173,17 +102173,17 @@ iKa
 iKa
 bRL
 bRL
-bYY
+cwn
 beq
 beq
-bPX
+cvX
 ctR
 ctR
 bXo
-cjm
-cjm
-cjk
-ckE
+bYY
+bYY
+bYW
+bZc
 bYz
 bYz
 aKB
@@ -102216,17 +102216,17 @@ aYV
 aJq
 aJq
 aKC
-bed
-aXp
+aFf
+aEZ
 bXo
 bXo
 tFe
-aNB
-aHO
-aHO
-aHO
-aHO
-aHN
+aEL
+aEy
+aEy
+aEy
+aEy
+aEu
 aJq
 aJq
 acs
@@ -102343,17 +102343,17 @@ iKa
 bRL
 bRL
 akw
-bQW
+cwb
 akw
 ctR
 ctR
 bXo
-cjm
-cqv
-cjh
-cmd
-cje
-bOz
+bYY
+cgv
+bYV
+bZe
+bYT
+bQW
 aKF
 aKB
 aKB
@@ -102383,13 +102383,13 @@ aKB
 aLc
 aKX
 aJq
-bwt
-beo
-aXp
+aJb
+aIu
+aEZ
 bXo
 bXo
 tFe
-aNE
+aEO
 boS
 aXM
 lvY
@@ -102510,18 +102510,18 @@ iKa
 iKa
 iKa
 bRL
-aFc
-aFc
-aFc
+ckV
+ckV
+ckV
 ctR
 ctR
 bXo
 cfM
 bXo
-cni
-cmF
-cjf
-bOC
+cbb
+bZf
+bYU
+bSn
 aKB
 aKB
 aKB
@@ -102549,15 +102549,15 @@ aKB
 aKB
 aKB
 aKB
-bwv
-bwu
-bep
-bep
-aYg
-aNP
+aNL
+aJg
+aIw
+aIw
+aFa
+aER
 bXo
 tFe
-aNF
+aEP
 aJx
 acs
 aJx
@@ -102678,9 +102678,9 @@ iKa
 iKa
 bRL
 bRL
-bYT
-bQQ
-bQQ
+cwi
+cvY
+cvY
 ctR
 ctR
 bXo
@@ -102688,8 +102688,8 @@ bXo
 bXo
 bXo
 bXo
-cjh
-bOD
+bYV
+bVK
 aKB
 aKC
 aKC
@@ -102718,14 +102718,14 @@ aKB
 aKB
 aKB
 bUu
-aXp
+aEZ
 bXo
 bXo
 bXo
 bXo
 bXo
 tFe
-aNF
+aEP
 pzq
 pzq
 aJy
@@ -102845,19 +102845,19 @@ aMI
 iKa
 iKa
 bRL
-bZa
-bYU
+cwo
+cwj
 aKf
 aKf
-aJb
+cul
 ctR
 ctR
 bXo
 bXo
 bXo
 bXo
-cjk
-bOF
+bYW
+bXM
 hNM
 hNM
 aKD
@@ -102885,15 +102885,15 @@ aKC
 pWw
 hNM
 hNM
-bzh
-aXp
+bsr
+aEZ
 bXo
 bXo
-aZz
-aOh
+aFb
+aET
 bXo
 tFe
-aNF
+aEP
 pzq
 aJy
 aJy
@@ -103013,11 +103013,11 @@ aMJ
 iKa
 iKa
 bRL
-bZb
+cwp
 aKf
 aXL
 aKp
-aJg
+cvz
 aKt
 ctR
 ctR
@@ -103061,7 +103061,7 @@ iFy
 iFy
 iFy
 iFy
-aNF
+aEP
 aJy
 aJy
 xEt
@@ -103181,13 +103181,13 @@ aMJ
 aMJ
 iKa
 bRL
-bZc
-bYV
+cwq
+cwk
 aXH
 aKp
 aKf
-aGq
-aFc
+cqv
+ckV
 akw
 bdH
 pDy
@@ -103349,15 +103349,15 @@ aMH
 ewE
 iKa
 bRL
-bZd
-bYW
-bSn
+cwr
+cwl
+cwc
 aKf
 aKf
-aGq
-aFc
-aFa
-aEX
+cqv
+ckV
+cjm
+cjf
 bpx
 aXL
 aXH
@@ -103395,7 +103395,7 @@ bzj
 aKf
 aXL
 aKM
-aEt
+uUl
 iFy
 aJq
 aJq
@@ -103519,11 +103519,11 @@ iKa
 iKa
 bRL
 bRL
-bVK
-bQR
-aNL
-aIu
-aFc
+cwd
+cvZ
+cvU
+cqw
+ckV
 akw
 bdI
 xJX
@@ -103563,7 +103563,7 @@ aKp
 bpj
 aXL
 ceC
-aEu
+aYg
 iFy
 aJq
 aJq
@@ -103728,8 +103728,8 @@ aLf
 bpn
 bpl
 aKS
-aEy
-aEy
+aFc
+aFc
 aKN
 iFy
 iFy
@@ -105403,7 +105403,7 @@ caP
 caP
 caP
 aJq
-bzi
+bPX
 aJx
 acs
 acs
@@ -106431,7 +106431,7 @@ ceu
 cem
 aWA
 bGO
-agM
+aEq
 bGL
 cdS
 bGI
@@ -107273,7 +107273,7 @@ aJx
 ceb
 bGI
 bGI
-acU
+aEi
 cdR
 cdQ
 aJq
@@ -108448,7 +108448,7 @@ pzq
 cvs
 cvp
 acs
-afY
+aEl
 cvn
 bYw
 aJq
@@ -109212,7 +109212,7 @@ lzp
 fIR
 aRG
 hvs
-cvU
+cwB
 uKv
 xXR
 bBx
@@ -120368,7 +120368,7 @@ aTX
 aTT
 aKq
 yhz
-aIc
+aEF
 aQi
 awO
 bWg
@@ -120681,7 +120681,7 @@ asa
 coM
 bHo
 bHo
-aEF
+bQR
 bTy
 bSz
 bSz
@@ -120873,7 +120873,7 @@ bSk
 aKq
 aKq
 aKl
-aHR
+aEB
 awO
 bWf
 aXu
@@ -121040,7 +121040,7 @@ aTZ
 bSm
 aKq
 rCT
-aKu
+aEG
 aQi
 ayE
 awq
@@ -124873,7 +124873,7 @@ aZn
 cuF
 aKK
 abK
-aEG
+bQS
 abG
 aKK
 cub
@@ -126060,7 +126060,7 @@ baM
 aKV
 bHo
 bHo
-aEB
+bQQ
 lvO
 aZI
 aKV
@@ -127872,21 +127872,21 @@ azn
 azl
 ayS
 aTp
-aEi
-aEi
-aEi
-aEi
-aEi
+aEt
+aEt
+aEt
+aEt
+aEt
 aOc
 ayS
 ayW
 ayS
 aTp
-aEi
-aEi
-aEi
-aEi
-aEi
+aEt
+aEt
+aEt
+aEt
+aEt
 aOc
 ayV
 ayS
@@ -127920,21 +127920,21 @@ azk
 ayS
 ayV
 aTp
-aEi
-aEi
-aEi
-aEi
-aEi
+aEt
+aEt
+aEt
+aEt
+aEt
 aOc
 ayS
 ayW
 ayS
 aTp
-aEi
-aEi
-aEi
-aEi
-aEi
+aEt
+aEt
+aEt
+aEt
+aEt
 aOc
 ayS
 ayR
@@ -128044,13 +128044,13 @@ azr
 azr
 azr
 nVc
-aEi
+aEt
 aOc
 ayS
 ayW
 ayS
 aTp
-aEi
+aEt
 ayJ
 azr
 azr
@@ -128092,13 +128092,13 @@ azr
 azr
 azr
 nVc
-aEi
+aEt
 aOc
 ayS
 ayW
 ayS
 aTp
-aEi
+aEt
 ayJ
 azr
 azr
@@ -129055,7 +129055,7 @@ euM
 ayZ
 ayT
 ayP
-aEl
+aEI
 azm
 azj
 azh
@@ -129103,7 +129103,7 @@ euM
 ayZ
 ayT
 ayP
-aEl
+aEI
 azm
 azj
 azh
@@ -130396,13 +130396,13 @@ aAy
 azc
 azc
 bbI
-aEi
+aEt
 aOc
 ayS
 ayW
 ayS
 aTp
-aEi
+aEt
 boU
 azc
 azc
@@ -130444,13 +130444,13 @@ aAy
 azc
 azc
 bbI
-aEi
+aEt
 aOc
 ayS
 ayW
 ayS
 aTp
-aEi
+aEt
 boU
 azc
 azc
@@ -130560,21 +130560,21 @@ azm
 azj
 ayS
 aTp
-aEi
-aEi
-aEi
-aEi
-aEi
+aEt
+aEt
+aEt
+aEt
+aEt
 aOc
 ayS
 ayW
 ayS
 aTp
-aEi
-aEi
-aEi
-aEi
-aEi
+aEt
+aEt
+aEt
+aEt
+aEt
 aOc
 ayV
 ayS
@@ -130608,21 +130608,21 @@ azk
 ayS
 ayV
 aTp
-aEi
-aEi
-aEi
-aEi
-aEi
+aEt
+aEt
+aEt
+aEt
+aEt
 aOc
 ayS
 ayW
 ayS
 aTp
-aEi
-aEi
-aEi
-aEi
-aEi
+aEt
+aEt
+aEt
+aEt
+aEt
 aOc
 ayS
 ayT
@@ -140642,7 +140642,7 @@ spC
 spC
 spC
 spC
-chK
+cwC
 spC
 spC
 spC
@@ -140809,10 +140809,10 @@ spC
 spC
 spC
 spC
-chK
-chK
-chK
-chK
+cwC
+cwC
+cwC
+cwC
 tUu
 kDp
 kDp
@@ -140978,8 +140978,8 @@ spC
 cnb
 cnb
 cnb
-chK
-chK
+cwC
+cwC
 tUu
 kPj
 kPj
@@ -141145,9 +141145,9 @@ cnb
 cnb
 cnb
 cnb
-chK
-chK
-chK
+cwC
+cwC
+cwC
 fuj
 kPj
 kPj
@@ -141313,9 +141313,9 @@ cnb
 cnb
 cnb
 cnb
-chK
-chK
-chK
+cwC
+cwC
+cwC
 jIC
 hLL
 kPj
@@ -142658,8 +142658,8 @@ cnb
 cnb
 cnb
 cnb
-chK
-chK
+cwC
+cwC
 jIC
 tUu
 kDp
@@ -142826,9 +142826,9 @@ cnb
 cnb
 cnb
 cnb
-chK
-chK
-chK
+cwC
+cwC
+cwC
 jIC
 kPj
 kPj
@@ -142995,9 +142995,9 @@ cnb
 cnb
 cnb
 cnb
-chK
-chK
-chK
+cwC
+cwC
+cwC
 fuj
 kPj
 kPj
@@ -143163,8 +143163,8 @@ cnb
 cnb
 cnb
 cnb
-chK
-chK
+cwC
+cwC
 tUu
 kPj
 kPj
@@ -143331,8 +143331,8 @@ cnb
 cnb
 cnb
 cnb
-chK
-chK
+cwC
+cwC
 fuj
 kPj
 kPj
@@ -143499,8 +143499,8 @@ cnb
 cnb
 cnb
 cnb
-chK
-chK
+cwC
+cwC
 fuj
 kPj
 kPj
@@ -143668,7 +143668,7 @@ cnb
 cnb
 cnb
 cnb
-chK
+cwC
 fuj
 kPj
 kPj
@@ -143835,8 +143835,8 @@ cnb
 cnb
 cnb
 cnb
-cjc
-chK
+cwD
+cwC
 jIC
 kPj
 kPj
@@ -144003,9 +144003,9 @@ cnb
 cnb
 cnb
 cnb
-cjc
-chK
-chK
+cwD
+cwC
+cwC
 jIC
 kPj
 kPj
@@ -144169,12 +144169,12 @@ cnb
 cnb
 cnb
 cnb
-cjc
-cjc
-cjc
-chK
-chK
-chK
+cwD
+cwD
+cwD
+cwC
+cwC
+cwC
 jIC
 hLL
 hLL
@@ -144336,18 +144336,18 @@ cnb
 cnb
 cnb
 cnb
-cjc
-cjc
-cjc
-chK
-chK
-chK
-chK
-chK
-chK
-chK
-chK
-chK
+cwD
+cwD
+cwD
+cwC
+cwC
+cwC
+cwC
+cwC
+cwC
+cwC
+cwC
+cwC
 cnb
 cnb
 jIC
@@ -144506,17 +144506,17 @@ cnb
 cnb
 cnb
 cnb
-chK
-chK
-chK
-chK
-cjc
-cjc
-chK
-chK
-chK
-chK
-chK
+cwC
+cwC
+cwC
+cwC
+cwD
+cwD
+cwC
+cwC
+cwC
+cwC
+cwC
 cnb
 cnb
 cnb
@@ -144675,15 +144675,15 @@ cnb
 cnb
 cnb
 cnb
-chK
-chK
-chK
-cjc
-cjc
-cjc
-cjc
-chK
-chK
+cwC
+cwC
+cwC
+cwD
+cwD
+cwD
+cwD
+cwC
+cwC
 cnb
 cnb
 cnb
@@ -144848,8 +144848,8 @@ cnb
 cnb
 cnb
 cnb
-cjc
-cjc
+cwD
+cwD
 cnb
 cnb
 cnb
@@ -145017,7 +145017,7 @@ cnb
 cnb
 cnb
 cnb
-cjc
+cwD
 cnb
 cnb
 cnb

--- a/maps/map_files/White_Antre_Research_Facility/White_Antre_Research_Facility.dmm
+++ b/maps/map_files/White_Antre_Research_Facility/White_Antre_Research_Facility.dmm
@@ -789,7 +789,8 @@
 /area/white_antre/indoors/main_level/east_containment)
 "acm" = (
 /obj/structure/prop/invuln/dense/excavator{
-	dir = 4
+	dir = 4;
+	pixel_y = -10
 	},
 /obj/structure/blocker/invisible_wall,
 /turf/open/auto_turf/shale/layer1/weedable,
@@ -1090,6 +1091,10 @@
 /obj/effect/landmark/monkey_spawn,
 /turf/open/floor/prison/floor_plate/southwest,
 /area/white_antre/indoors/main_level/east_containment_hive)
+"acU" = (
+/obj/effect/landmark/objective_landmark/medium,
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/outdoors/south_field/under_cover)
 "acV" = (
 /obj/effect/landmark/objective_landmark/close,
 /obj/structure/filingcabinet{
@@ -1729,10 +1734,6 @@
 	},
 /turf/open/floor/almayer/silver/north,
 /area/white_antre/indoors/main_level/east_containment_hive)
-"aer" = (
-/obj/structure/platform/metal/almayer,
-/turf/closed/wall/mineral/bone_resin/k_series,
-/area/white_antre/oob)
 "aes" = (
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "thermite";
@@ -2429,6 +2430,14 @@
 	},
 /turf/open/floor/almayer/silverfull,
 /area/white_antre/indoors/main_level/east_containment_hive)
+"afY" = (
+/obj/structure/prop/colorable_rock/colorable{
+	color = "#5F5F70";
+	dir = 10
+	},
+/obj/effect/landmark/objective_landmark/science,
+/turf/open/auto_turf/snow/layer2,
+/area/white_antre/outdoors/south_field)
 "afZ" = (
 /obj/structure/sink{
 	dir = 8;
@@ -2638,6 +2647,10 @@
 /obj/effect/decal/cleanable/blood/tracks/footprints,
 /turf/open/floor/almayer/research/containment/corner/west,
 /area/white_antre/indoors/upper_level/simian_storage)
+"agM" = (
+/obj/effect/landmark/objective_landmark/far,
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/outdoors/south_field/under_cover)
 "agN" = (
 /turf/open/floor/almayer/sterile_green_side/north,
 /area/white_antre/indoors/upper_level/simian_storage)
@@ -13179,9 +13192,6 @@
 	},
 /turf/open/floor/antre/metal/black/northeast,
 /area/white_antre/indoors/main_level/west_corridor)
-"aEq" = (
-/turf/closed/wall/strata_outpost,
-/area/white_antre/outdoors/south_field)
 "aEr" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -13209,13 +13219,13 @@
 	dir = 4
 	},
 /turf/open/floor/prison/bluefull,
-/area/white_antre/outdoors/south_field)
+/area/white_antre/landing_zone/roof)
 "aEu" = (
 /obj/structure/machinery/light/double{
 	dir = 4
 	},
 /turf/open/floor/prison/bluefull,
-/area/white_antre/outdoors/south_field)
+/area/white_antre/landing_zone/roof)
 "aEv" = (
 /obj/structure/machinery/light/double/blue{
 	dir = 8
@@ -13326,13 +13336,25 @@
 /area/white_antre/indoors/main_level/research)
 "aEI" = (
 /obj/structure/largecrate/random/barrel/green,
-/turf/open/auto_turf/shale/layer1/weedable,
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 8
+	},
+/turf/open/floor/prison,
 /area/white_antre/landing_zone)
 "aEJ" = (
 /obj/structure/cargo_container/uscm/chinook/left{
 	layer = 3.1
 	},
-/turf/open/auto_turf/shale/layer1/weedable,
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 1
+	},
+/turf/open/floor/prison/ramptop/east,
 /area/white_antre/landing_zone)
 "aEK" = (
 /obj/structure/machinery/light/double/blue{
@@ -13345,7 +13367,11 @@
 /obj/structure/cargo_container/uscm/chinook/mid{
 	layer = 3.1
 	},
-/turf/open/auto_turf/shale/layer1/weedable,
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 1
+	},
+/turf/open/floor/prison/ramptop/east,
 /area/white_antre/landing_zone)
 "aEM" = (
 /obj/structure/surface/table/reinforced/prison{
@@ -13369,19 +13395,23 @@
 /obj/structure/cargo_container/uscm/right{
 	layer = 3.1
 	},
-/turf/open/auto_turf/shale/layer1/weedable,
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 1
+	},
+/turf/open/floor/prison/ramptop/east,
 /area/white_antre/landing_zone)
 "aEP" = (
 /obj/structure/largecrate/random/barrel/blue,
-/turf/open/auto_turf/shale/layer1/weedable,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "aEQ" = (
 /obj/structure/cargo_container/wy/left,
-/turf/open/auto_turf/sand_white/layer0,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "aER" = (
 /obj/structure/cargo_container/wy/mid,
-/turf/open/auto_turf/sand_white/layer0,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "aES" = (
 /obj/structure/surface/table/reinforced/prison{
@@ -13398,7 +13428,7 @@
 /area/white_antre/indoors/main_level/research)
 "aET" = (
 /obj/structure/cargo_container/wy/right,
-/turf/open/auto_turf/sand_white/layer0,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "aEU" = (
 /obj/structure/machinery/big_computers/computerwhite/computer1,
@@ -13407,10 +13437,6 @@
 	},
 /turf/open/floor/almayer/silver,
 /area/white_antre/indoors/main_level/research)
-"aEV" = (
-/obj/structure/largecrate/random/case/double,
-/turf/open/auto_turf/sand_white/layer0,
-/area/white_antre/landing_zone)
 "aEW" = (
 /obj/item/stack/sheet/metal,
 /obj/effect/antre/border/corner{
@@ -13433,7 +13459,7 @@
 /area/white_antre/indoors/main_level/research)
 "aEZ" = (
 /obj/structure/largecrate/random,
-/turf/open/auto_turf/sand_white/layer0,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "aFa" = (
 /obj/structure/machinery/door/airlock/almayer/secure/colony{
@@ -13443,7 +13469,8 @@
 /area/white_antre/landing_zone/roof)
 "aFb" = (
 /obj/structure/largecrate/random/barrel/brown,
-/turf/open/asphalt/cement/cement12,
+/obj/effect/decal/hybrisa/dirt,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "aFc" = (
 /turf/open/floor/prison/darkyellowfull2,
@@ -14756,6 +14783,14 @@
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/indoors/main_level/east_containment)
+"aHN" = (
+/obj/structure/platform/metal/almayer/west,
+/turf/open/asphalt/cement/cement15,
+/area/white_antre/outdoors/south_field)
+"aHO" = (
+/obj/structure/platform/metal/almayer/west,
+/turf/open/asphalt/cement/cement1,
+/area/white_antre/outdoors/south_field)
 "aHP" = (
 /obj/structure/machinery/meter{
 	pixel_y = -30
@@ -14772,6 +14807,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/corsat/marked,
 /area/white_antre/indoors/main_level/east_corridor)
+"aHR" = (
+/obj/structure/machinery/door/poddoor/hybrisa/ultra_reinforced_door/open{
+	dir = 2;
+	icon_state = "udoor0"
+	},
+/obj/structure/machinery/light/small{
+	light_color = "#ff3b3b";
+	color = "#ff3b3b";
+	needs_power = 0;
+	dir = 4;
+	name = "emergency lighting";
+	desc = "A small emergency light. Has an internal battery which should last for five hours."
+	},
+/turf/open/floor/corsat/marked,
+/area/white_antre/indoors/main_level/weapons)
 "aHS" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_22";
@@ -14871,6 +14921,10 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/corsat/marked,
 /area/white_antre/indoors/main_level/east_corridor)
+"aIc" = (
+/obj/structure/machinery/light/double,
+/turf/open/floor/strata/green3/east,
+/area/white_antre/indoors/main_level/weapons)
 "aId" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/tank/fuel,
@@ -15164,13 +15218,6 @@
 	},
 /turf/open/floor/shiva,
 /area/white_antre/indoors/main_level/research)
-"aIL" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "door_warning2";
-	dir = 1
-	},
-/turf/closed/wall/mineral/bone_resin/k_series,
-/area/white_antre/oob)
 "aIM" = (
 /obj/structure/surface/table/reinforced/prison{
 	color = "#6b675e"
@@ -15681,6 +15728,10 @@
 /obj/structure/largecrate/random,
 /turf/open/floor/prison/darkyellow2/southwest,
 /area/white_antre/landing_zone/roof)
+"aKu" = (
+/obj/structure/machinery/light/double,
+/turf/open/floor/strata/green3/west,
+/area/white_antre/indoors/main_level/weapons)
 "aKv" = (
 /turf/closed/wall/hybrisa/research/reinforced,
 /area/white_antre/outdoors/facility_exterior)
@@ -15840,6 +15891,7 @@
 /area/white_antre/indoors/exterior/ext_relay_north)
 "aKX" = (
 /obj/structure/flora/tree/tyrargo,
+/obj/structure/platform_decoration/metal/almayer,
 /turf/open/auto_turf/snow/layer2,
 /area/white_antre/landing_zone)
 "aKY" = (
@@ -16607,6 +16659,14 @@
 	},
 /turf/open/auto_turf/strata_grass/layer0,
 /area/white_antre/outdoors/north_field)
+"aNx" = (
+/obj/structure/surface/table/almayer,
+/obj/item/clothing/head/hardhat/orange{
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/turf/open/floor/hybrisa/metal/bluemetalfull,
+/area/white_antre/landing_zone/roof)
 "aNy" = (
 /turf/open/asphalt/cement/cement9,
 /area/white_antre/outdoors/north_field)
@@ -16621,6 +16681,11 @@
 	},
 /turf/open/floor/corsat/marked,
 /area/white_antre/landing_zone/roof)
+"aNB" = (
+/obj/structure/platform/metal/almayer/north,
+/obj/structure/platform/metal/almayer/west,
+/turf/open/asphalt/cement/cement1,
+/area/white_antre/outdoors/south_field)
 "aNC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkbrown2,
@@ -16628,6 +16693,14 @@
 "aND" = (
 /turf/open/floor/antre/metal/black,
 /area/white_antre/indoors/upper_level/director_office)
+"aNE" = (
+/obj/structure/platform/metal/almayer/north,
+/turf/open/auto_turf/snow/layer1,
+/area/white_antre/outdoors/south_field)
+"aNF" = (
+/obj/structure/platform/metal/almayer/north,
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/outdoors/south_field)
 "aNG" = (
 /obj/effect/decal/strata_decals/mud_corner{
 	dir = 5
@@ -16644,6 +16717,10 @@
 "aNJ" = (
 /turf/open/floor/prison/darkbrown2/west,
 /area/white_antre/landing_zone/roof)
+"aNK" = (
+/obj/structure/largecrate/empty/case/double,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
 "aNL" = (
 /obj/structure/machinery/light/double{
 	dir = 4
@@ -16680,6 +16757,10 @@
 /obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison/darkbrown2/northeast,
 /area/white_antre/landing_zone/roof)
+"aNP" = (
+/obj/item/device/flashlight/lamp/tripod,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
 "aNQ" = (
 /obj/effect/decal/hybrisa/road/corner{
 	dir = 1
@@ -16792,6 +16873,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/green/northeast,
 /area/white_antre/indoors/upper_level/west_corridor)
+"aOh" = (
+/obj/structure/closet/crate/green,
+/obj/effect/landmark/objective_landmark/medium,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
 "aOi" = (
 /obj/effect/decal/strata_decals/mud_corner{
 	dir = 6
@@ -17388,6 +17474,16 @@
 "aQu" = (
 /turf/open/floor/hybrisa/tile/tilewhite,
 /area/white_antre/indoors/upper_level/xenobio)
+"aQv" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s"
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 8
+	},
+/turf/open/floor/prison,
+/area/white_antre/landing_zone)
 "aQw" = (
 /obj/effect/antre/border{
 	dir = 1
@@ -18393,18 +18489,6 @@
 /obj/structure/largecrate/empty/case/double,
 /turf/open/floor/strata/floor2,
 /area/white_antre/indoors/main_level/weapons)
-"aTy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/machinery/light/small{
-	light_color = "#ff3b3b";
-	color = "#ff3b3b";
-	needs_power = 0;
-	dir = 4;
-	name = "emergency lighting";
-	desc = "A small emergency light. Has an internal battery which should last for five hours."
-	},
-/turf/open/floor/prison,
-/area/white_antre/indoors/main_level/weapons)
 "aTz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/disposal/delivery,
@@ -18450,14 +18534,6 @@
 /obj/effect/decal/cleanable/dirt/alt_dirt/stain,
 /obj/effect/decal/cleanable/dirt/alt_dirt/stain,
 /turf/open/floor/corsat/marked,
-/area/white_antre/indoors/main_level/weapons)
-"aTG" = (
-/obj/structure/machinery/light/double,
-/turf/open/floor/strata/green4/north,
-/area/white_antre/indoors/main_level/weapons)
-"aTH" = (
-/obj/structure/machinery/light/double,
-/turf/open/floor/strata/green4,
 /area/white_antre/indoors/main_level/weapons)
 "aTI" = (
 /obj/item/prop/alien/hugger{
@@ -19855,6 +19931,13 @@
 	},
 /turf/open/auto_turf/snow/layer2,
 /area/white_antre/outdoors/south_field)
+"aXm" = (
+/obj/item/device/flashlight/lamp/tripod,
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s"
+	},
+/turf/open/floor/prison/ramptop/east,
+/area/white_antre/landing_zone)
 "aXn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/pipes/standard/simple/hidden/cyan{
@@ -19869,6 +19952,12 @@
 /obj/structure/pipes/vents/pump_hybrisa,
 /turf/open/floor/prison/darkbrown2/southwest,
 /area/white_antre/indoors/main_level/south_containment)
+"aXp" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s"
+	},
+/turf/open/floor/prison/ramptop/east,
+/area/white_antre/landing_zone)
 "aXq" = (
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall/kseries,
 /obj/structure/pipes/standard/simple/hidden/cyan{
@@ -20160,6 +20249,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/red,
 /area/white_antre/indoors/main_level/east_containment)
+"aYg" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 4;
+	layer = 2
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s"
+	},
+/turf/open/floor/prison,
+/area/white_antre/landing_zone)
 "aYh" = (
 /turf/open/antre/plating/corner_dir/south_east,
 /area/white_antre/indoors/main_level/west_corridor)
@@ -20645,6 +20745,10 @@
 	},
 /turf/open/antre/plating/direction_west,
 /area/white_antre/indoors/main_level/east_containment)
+"aZz" = (
+/obj/structure/largecrate/empty/secure,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
 "aZA" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "test_warning_smooth_red"
@@ -21495,10 +21599,6 @@
 	},
 /turf/open/floor/prison/darkbrown2,
 /area/white_antre/indoors/main_level/east_containment)
-"bbq" = (
-/obj/effect/sentry_landmark/lz_1,
-/turf/open/floor/plating,
-/area/white_antre/landing_zone)
 "bbr" = (
 /obj/structure/prop/colorable_rock/colorable{
 	color = "#5F5F70";
@@ -22602,17 +22702,32 @@
 	dir = 4;
 	pixel_y = 4
 	},
-/obj/structure/machinery/light/double,
 /turf/closed/wall/strata_outpost,
 /area/white_antre/landing_zone/roof)
 "bdZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkbrown2/west,
 /area/white_antre/landing_zone/roof)
+"bea" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 8
+	},
+/turf/open/floor/prison/ramptop/north,
+/area/white_antre/landing_zone)
+"beb" = (
+/obj/structure/platform/metal/almayer,
+/obj/structure/platform/metal/almayer/west,
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/landing_zone)
 "bec" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone/roof)
+"bed" = (
+/obj/structure/platform/metal/almayer,
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/landing_zone)
 "bee" = (
 /obj/structure/platform_decoration/stone/soro/west,
 /turf/open/auto_turf/shale/layer1/weedable,
@@ -22661,6 +22776,10 @@
 	},
 /turf/open/floor/prison/darkbrown2/west,
 /area/white_antre/landing_zone/roof)
+"bem" = (
+/obj/structure/platform/metal/almayer,
+/turf/open/auto_turf/shale/layer2/weedable,
+/area/white_antre/landing_zone)
 "ben" = (
 /obj/structure/surface/rack,
 /obj/item/clothing/head/hardhat/orange{
@@ -22673,6 +22792,19 @@
 	},
 /turf/open/floor/prison,
 /area/white_antre/landing_zone/roof)
+"beo" = (
+/obj/structure/platform/metal/almayer,
+/obj/structure/platform/metal/almayer/east,
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/landing_zone)
+"bep" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 4;
+	layer = 2
+	},
+/turf/open/floor/prison/ramptop/north,
+/area/white_antre/landing_zone)
 "beq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkbrownfull2,
@@ -22714,6 +22846,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkbrown2/east,
 /area/white_antre/landing_zone/roof)
+"bew" = (
+/obj/structure/platform/metal/almayer_smooth/north,
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 8
+	},
+/turf/open/floor/prison/ramptop/north,
+/area/white_antre/landing_zone)
 "bex" = (
 /obj/structure/prop/colorable_rock/colorable{
 	color = "#5F5F70";
@@ -22835,10 +22975,6 @@
 	},
 /turf/open/auto_turf/strata_grass/layer0_mud,
 /area/white_antre/outdoors/facility_exterior)
-"beN" = (
-/obj/effect/landmark/structure_spawner/setup/distress/xeno_wall/kseries,
-/turf/open/floor/prison/ramptop/north,
-/area/white_antre/indoors/main_level/north_containment)
 "beO" = (
 /obj/effect/mist/steam{
 	pixel_x = -7;
@@ -26380,19 +26516,10 @@
 /obj/structure/cargo_container/hybrisa/containersextended/lightgreywyright,
 /turf/open/floor/prison,
 /area/white_antre/landing_zone/roof)
-"bpf" = (
+"bpg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair{
 	dir = 1
-	},
-/turf/open/floor/hybrisa/metal/bluemetal1/east,
-/area/white_antre/landing_zone/roof)
-"bpg" = (
-/obj/structure/surface/table/almayer,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/head/hardhat/orange{
-	pixel_x = 8;
-	pixel_y = 12
 	},
 /turf/open/floor/hybrisa/metal/bluemetalfull,
 /area/white_antre/landing_zone/roof)
@@ -26429,10 +26556,6 @@
 	},
 /turf/open/floor/prison/blue/east,
 /area/white_antre/landing_zone/roof)
-"bpm" = (
-/obj/structure/prop/hybrisa/boulders/large_boulderdark/boulder_dark1,
-/turf/open/auto_turf/shale/layer1/weedable,
-/area/white_antre/outdoors/south_field)
 "bpn" = (
 /obj/structure/surface/table/almayer,
 /obj/item/paper_bin{
@@ -26915,6 +27038,11 @@
 	},
 /turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/indoors/main_level/east_containment)
+"bqz" = (
+/obj/structure/platform/metal/almayer/west,
+/obj/structure/platform_decoration/metal/almayer_smooth/east,
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/landing_zone)
 "bqA" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -27188,13 +27316,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/indoors/upper_level/east_corridor)
-"bri" = (
-/obj/structure/prop/almayer/cannon_cable_connector{
-	name = "\improper Control Module";
-	pixel_y = 15
-	},
-/turf/open/auto_turf/shale/layer1/weedable,
-/area/white_antre/indoors/main_level/east_containment)
 "brj" = (
 /obj/structure/reagent_dispensers/water_cooler/stacks{
 	density = 0;
@@ -27750,13 +27871,6 @@
 "bsD" = (
 /turf/open/floor/almayer/silvercorner/west,
 /area/white_antre/indoors/upper_level/payroll)
-"bsE" = (
-/obj/structure/prop/almayer/cannon_cables{
-	name = "\improper Large Cables";
-	pixel_y = 12
-	},
-/turf/open/auto_turf/sand_white/layer0,
-/area/white_antre/indoors/main_level/east_containment)
 "bsF" = (
 /turf/open/floor/prison/darkbrowncorners2/north,
 /area/white_antre/indoors/upper_level/ancillery_storage)
@@ -29228,6 +29342,20 @@
 	},
 /turf/open/floor/almayer/silver/west,
 /area/white_antre/indoors/main_level/research)
+"bwt" = (
+/obj/structure/platform/metal/almayer/east,
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/landing_zone)
+"bwu" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_c"
+	},
+/turf/open/floor/prison,
+/area/white_antre/landing_zone)
+"bwv" = (
+/obj/structure/platform/metal/almayer,
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/landing_zone)
 "bww" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/antre/border{
@@ -30431,6 +30559,21 @@
 	},
 /turf/open/floor/almayer/silver/west,
 /area/white_antre/indoors/main_level/research)
+"bzh" = (
+/obj/effect/decal/hybrisa/dirt,
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
+/turf/open/asphalt/cement/cement3,
+/area/white_antre/landing_zone)
+"bzi" = (
+/obj/structure/flora/tree/tyrargo{
+	pixel_x = -26;
+	pixel_y = -2
+	},
+/turf/open/auto_turf/snow/layer2,
+/area/white_antre/outdoors/south_field)
 "bzj" = (
 /obj/item/trash/crushed_cup,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -37084,6 +37227,10 @@
 	},
 /turf/solid_open_space,
 /area/white_antre/oob)
+"bOz" = (
+/obj/structure/platform_decoration/metal/almayer/west,
+/turf/open/auto_turf/hybrisa_auto_turf/layer1,
+/area/white_antre/landing_zone)
 "bOA" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/white_antre/indoors/main_level/research)
@@ -37106,9 +37253,26 @@
 	},
 /turf/closed/wall/strata_ice,
 /area/white_antre/oob)
+"bOC" = (
+/obj/structure/platform/metal/almayer/north,
+/turf/open/auto_turf/hybrisa_auto_turf/layer1,
+/area/white_antre/landing_zone)
+"bOD" = (
+/obj/structure/stairs/perspective{
+	dir = 10;
+	icon_state = "p_stair_full"
+	},
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/landing_zone)
 "bOE" = (
 /turf/open/floor/almayer/silver/northeast,
 /area/white_antre/indoors/main_level/research)
+"bOF" = (
+/obj/structure/stairs/perspective{
+	icon_state = "p_stair_full"
+	},
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/landing_zone)
 "bOG" = (
 /obj/structure/platform/stone/strata/east,
 /obj/effect/mist/steam{
@@ -40707,10 +40871,6 @@
 /obj/effect/landmark/structure_spawner/setup/distress/xeno_wall/kseries,
 /turf/open/floor/prison/floor_plate/southwest,
 /area/white_antre/indoors/main_level/south_containment)
-"bWd" = (
-/obj/structure/flora/tree/tyrargo,
-/turf/open/auto_turf/snow/layer1,
-/area/white_antre/outdoors/south_field)
 "bWe" = (
 /obj/effect/alien/egg/kseries{
 	status = 1;
@@ -41566,14 +41726,16 @@
 	dir = 1;
 	icon_state = "p_stair_full"
 	},
-/turf/open/auto_turf/sand_white/layer0,
+/obj/effect/decal/hybrisa/dirt,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "bYD" = (
 /obj/structure/stairs/perspective{
 	dir = 5;
 	icon_state = "p_stair_full"
 	},
-/turf/open/auto_turf/sand_white/layer0,
+/obj/effect/decal/hybrisa/dirt,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "bYE" = (
 /turf/open/auto_turf/hybrisa_auto_turf/layer1,
@@ -42428,6 +42590,7 @@
 /obj/item/storage/pouch/survival/full/black,
 /obj/item/storage/pouch/survival/full/black,
 /obj/item/storage/pouch/survival/full/black,
+/obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison/blue/northwest,
 /area/white_antre/indoors/exterior/prefab_1)
 "cbi" = (
@@ -42782,6 +42945,16 @@
 	},
 /turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/outdoors/north_field)
+"cch" = (
+/obj/structure/stairs/perspective{
+	dir = 9;
+	icon_state = "p_stair_full"
+	},
+/obj/structure/barricade/handrail/no_vault{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
 "cci" = (
 /obj/structure/prop/invuln/ice_prefab,
 /turf/open/auto_turf/sand_white/layer0,
@@ -43188,6 +43361,7 @@
 /obj/item/ammo_magazine/pistol/vp78,
 /obj/item/ammo_magazine/pistol/vp78,
 /obj/item/ammo_magazine/pistol/vp78,
+/obj/effect/landmark/objective_landmark/close,
 /turf/open/floor/prison/green,
 /area/white_antre/indoors/exterior/prefab_4)
 "cde" = (
@@ -43712,6 +43886,8 @@
 /obj/structure/closet/crate,
 /obj/item/tool/weldpack,
 /obj/item/tool/weldpack,
+/obj/effect/landmark/objective_landmark/far,
+/obj/effect/landmark/objective_landmark/medium,
 /turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/outdoors/south_field)
 "ceC" = (
@@ -43844,9 +44020,6 @@
 	},
 /turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/outdoors/south_field)
-"ceM" = (
-/turf/closed/wall/strata_outpost,
-/area/white_antre/landing_zone)
 "ceN" = (
 /obj/structure/largecrate/random/barrel/black,
 /turf/open/auto_turf/shale/layer1/weedable,
@@ -44174,7 +44347,15 @@
 /area/white_antre/outdoors/north_field)
 "cfM" = (
 /obj/item/device/flashlight/lamp/tripod,
-/turf/open/auto_turf/sand_white/layer0,
+/obj/effect/decal/hybrisa/dirt,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
+"cfN" = (
+/obj/structure/stairs/perspective{
+	dir = 1;
+	icon_state = "p_stair_full"
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "cfO" = (
 /obj/item/device/flashlight/lamp/tripod/grey{
@@ -45522,6 +45703,22 @@
 "cjc" = (
 /turf/closed/wall/strata_ice/dirty/rock,
 /area/white_antre/outdoors/north_field)
+"cjd" = (
+/obj/structure/platform/metal/almayer/west,
+/obj/structure/platform/metal/almayer_smooth,
+/turf/open/auto_turf/sand_white/layer0,
+/area/white_antre/landing_zone)
+"cje" = (
+/obj/structure/platform/metal/almayer/east,
+/turf/open/auto_turf/hybrisa_auto_turf/layer1,
+/area/white_antre/landing_zone)
+"cjf" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_c";
+	dir = 8
+	},
+/turf/open/floor/prison,
+/area/white_antre/landing_zone)
 "cjg" = (
 /obj/structure/barricade/handrail{
 	dir = 8
@@ -45531,6 +45728,14 @@
 	},
 /turf/open/floor/prison/darkyellow2/northwest,
 /area/white_antre/indoors/upper_level/east_corridor)
+"cjh" = (
+/obj/effect/decal/hybrisa/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 1
+	},
+/turf/open/floor/prison/ramptop/east,
+/area/white_antre/landing_zone)
 "cji" = (
 /obj/item/stack/sheet/metal{
 	pixel_x = 5
@@ -45541,12 +45746,37 @@
 /obj/structure/pipes/vents/pump_hybrisa,
 /turf/open/floor/almayer/silver/east,
 /area/white_antre/indoors/upper_level/canteen)
+"cjk" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 1
+	},
+/turf/open/floor/prison/ramptop/east,
+/area/white_antre/landing_zone)
+"cjl" = (
+/obj/structure/barricade/handrail/no_vault{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
+"cjm" = (
+/obj/effect/decal/hybrisa/dirt,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
 "cjn" = (
 /obj/structure/bed/chair/comfy/orange{
 	dir = 4
 	},
 /turf/open/antre/plating/direction_west,
 /area/white_antre/indoors/upper_level/east_corridor)
+"cjo" = (
+/obj/item/device/flashlight/lamp/tripod,
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 8
+	},
+/turf/open/floor/prison/ramptop,
+/area/white_antre/landing_zone)
 "cjp" = (
 /obj/structure/platform_decoration/metal/almayer_smooth/north,
 /turf/open_space,
@@ -46174,6 +46404,11 @@
 	},
 /turf/open/auto_turf/strata_grass/layer0_mud,
 /area/white_antre/oob)
+"ckx" = (
+/obj/structure/platform/metal/almayer/north,
+/obj/structure/platform/metal/almayer/west,
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/landing_zone)
 "cky" = (
 /obj/effect/mist/steam{
 	pixel_x = 6;
@@ -46284,6 +46519,10 @@
 	},
 /turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/oob)
+"ckE" = (
+/obj/structure/platform/metal/almayer/north,
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/landing_zone)
 "ckF" = (
 /obj/effect/mist/steam{
 	pixel_x = -3;
@@ -46561,6 +46800,10 @@
 	},
 /turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/oob)
+"ckV" = (
+/obj/structure/platform/metal/almayer/north,
+/turf/open/auto_turf/shale/layer2/weedable,
+/area/white_antre/landing_zone)
 "ckW" = (
 /obj/effect/decal/strata_decals/mud_corner{
 	dir = 5
@@ -47521,6 +47764,11 @@
 	},
 /turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/oob)
+"cmd" = (
+/obj/structure/platform/metal/almayer/north,
+/obj/structure/platform/metal/almayer/east,
+/turf/open/auto_turf/shale/layer1/weedable,
+/area/white_antre/landing_zone)
 "cme" = (
 /obj/effect/mist/steam{
 	pixel_x = 10;
@@ -47945,6 +48193,13 @@
 	},
 /turf/open/auto_turf/strata_grass/layer0_mud,
 /area/white_antre/oob)
+"cmF" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 4
+	},
+/turf/open/floor/prison/ramptop,
+/area/white_antre/landing_zone)
 "cmG" = (
 /obj/effect/mist/steam{
 	pixel_x = -10;
@@ -47952,6 +48207,14 @@
 	},
 /turf/open/auto_turf/strata_grass/layer0_mud,
 /area/white_antre/oob)
+"cmH" = (
+/obj/structure/largecrate/random/case/double,
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 1
+	},
+/turf/open/floor/prison/ramptop/east,
+/area/white_antre/landing_zone)
 "cmI" = (
 /turf/closed/wall/hybrisa/colony/reinforced,
 /area/white_antre/oob)
@@ -48038,6 +48301,19 @@
 /obj/structure/largecrate/random/barrel/yellow,
 /turf/open/auto_turf/sand_white/layer0,
 /area/white_antre/indoors/main_level/east_containment)
+"cni" = (
+/obj/effect/decal/hybrisa/dirt,
+/obj/effect/decal/hybrisa/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 4
+	},
+/turf/open/floor/prison,
+/area/white_antre/landing_zone)
 "cnj" = (
 /obj/structure/largecrate/random/barrel/yellow,
 /turf/open/floor/plating,
@@ -49022,9 +49298,40 @@
 	},
 /turf/open/antre/plating/direction_north/east_edge,
 /area/white_antre/indoors/upper_level/central_corridor)
+"cqv" = (
+/obj/effect/decal/hybrisa/dirt,
+/obj/effect/decal/hybrisa/dirt,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
+"cqw" = (
+/obj/structure/barricade/handrail/no_vault{
+	dir = 8
+	},
+/obj/structure/largecrate/random/barrel/blue,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
+"cqx" = (
+/obj/effect/decal/hybrisa/dirt,
+/obj/item/trash/cigbutt{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
 "cqy" = (
 /turf/open/antre/plating/direction_west/east_north,
 /area/white_antre/indoors/upper_level/central_corridor)
+"cqz" = (
+/obj/structure/barricade/handrail/no_vault{
+	dir = 8
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/structure/largecrate/random/case/double,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
 "cqA" = (
 /obj/effect/antre/border/edge{
 	dir = 4
@@ -49123,6 +49430,18 @@
 /obj/structure/pipes/standard/simple/hidden/cyan,
 /turf/open/antre/plating/west_corner_dir/north_west,
 /area/white_antre/indoors/upper_level/central_corridor)
+"cqO" = (
+/obj/item/trash/cigbutt{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/structure/largecrate/random/case/small,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
 "cqP" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "door_warning2";
@@ -49833,6 +50152,7 @@
 /obj/structure/closet/crate/construction,
 /obj/item/explosive/plastic,
 /obj/item/tool/pickaxe/jackhammer,
+/obj/effect/landmark/objective_landmark/medium,
 /turf/open/auto_turf/snow/layer0,
 /area/white_antre/outdoors/south_field)
 "cty" = (
@@ -50138,6 +50458,13 @@
 /obj/item/tool/weldingtool/largetank,
 /turf/open/floor/antre/metal/black/southwest,
 /area/white_antre/indoors/exterior/prefab_1)
+"cul" = (
+/obj/structure/barricade/handrail/no_vault{
+	dir = 8
+	},
+/obj/structure/largecrate/random/secure,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/white_antre/landing_zone)
 "cum" = (
 /obj/structure/machinery/space_heater/radiator/red,
 /turf/open/floor/antre/metal/black,
@@ -50603,6 +50930,10 @@
 	},
 /turf/open/auto_turf/shale/layer1/weedable,
 /area/white_antre/outdoors/south_field)
+"cvz" = (
+/obj/structure/machinery/light/double,
+/turf/open/floor/prison/darkbrownfull2,
+/area/white_antre/landing_zone/roof)
 "cvA" = (
 /obj/effect/antre/border{
 	dir = 4
@@ -50744,6 +51075,11 @@
 	},
 /turf/open/floor/almayer_hull/outerhull_dir/east,
 /area/white_antre/indoors/upper_level/east_overwatch)
+"cvU" = (
+/obj/structure/bed/chair/dropship/passenger,
+/obj/effect/landmark/objective_landmark/medium,
+/turf/open/shuttle/dropship/light_grey_single_wide_up_to_down,
+/area/white_antre/indoors/pmc_dropship)
 "cxK" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -51062,7 +51398,11 @@
 /area/white_antre/indoors/underground_level/east_maint)
 "dwB" = (
 /obj/structure/platform/metal/almayer_smooth,
-/turf/open/auto_turf/sand_white/layer0,
+/obj/effect/decal/warning_stripes{
+	icon_state = "warning_s";
+	dir = 8
+	},
+/turf/open/floor/prison/ramptop,
 /area/white_antre/landing_zone)
 "dzD" = (
 /turf/open/floor/prison/darkyellow2/north,
@@ -51980,9 +52320,6 @@
 "gIY" = (
 /turf/open/floor/plating/panelscorched,
 /area/white_antre/indoors/main_level/research)
-"gKr" = (
-/turf/open/asphalt/cement/cement12,
-/area/white_antre/outdoors/south_field)
 "gLx" = (
 /obj/structure/platform/metal/almayer_smooth/west,
 /turf/open/floor/prison,
@@ -54269,9 +54606,6 @@
 	},
 /turf/open/floor/prison/darkred2/southwest,
 /area/white_antre/indoors/underground_level/west_maint)
-"pLS" = (
-/turf/open/asphalt/cement/cement9,
-/area/white_antre/landing_zone)
 "pMG" = (
 /obj/effect/antre/border{
 	dir = 1
@@ -54865,7 +55199,7 @@
 /area/white_antre/indoors/underground_level/west_maint)
 "siB" = (
 /obj/structure/platform/metal/almayer_smooth/north,
-/turf/open/auto_turf/sand_white/layer0,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/white_antre/landing_zone)
 "sjf" = (
 /obj/structure/shuttle/part/dropship_wy/transparent/engine_left_exhaust,
@@ -56014,6 +56348,7 @@
 	dir = 8;
 	pixel_y = -5
 	},
+/obj/effect/landmark/objective_landmark/medium,
 /turf/open/shuttle/dropship/light_grey_single_wide_up_to_down,
 /area/white_antre/indoors/pmc_dropship)
 "xtM" = (
@@ -99995,13 +100330,13 @@ kuQ
 kuQ
 kuQ
 iFy
-pWw
-aKD
-aKB
-aKF
-aKC
-aKC
-bUu
+cul
+cqz
+cqw
+cjl
+cjl
+cjl
+cch
 bYb
 cfI
 cfC
@@ -100033,7 +100368,7 @@ ceY
 bWW
 aYD
 bSC
-aKC
+bXo
 byX
 bzf
 jkE
@@ -100161,14 +100496,14 @@ bRL
 aNI
 beu
 bek
-aNI
+cvz
 bdY
 iFy
-aNi
-aKB
-aKB
-aKC
-aKC
+cqO
+cqx
+bXo
+bXo
+cjm
 bYC
 bdf
 cfJ
@@ -100201,9 +100536,9 @@ aYL
 aYL
 aYD
 bYx
-aKC
-aKF
-pWw
+bXo
+bXo
+aNK
 iFy
 iFy
 aXQ
@@ -100332,12 +100667,12 @@ bel
 bdZ
 aIw
 iFy
-aNi
-aKB
-aKB
-aKB
-aKC
-bYC
+bXo
+cjm
+cqv
+cjm
+cjm
+cfN
 bdf
 bXj
 cfD
@@ -100349,7 +100684,7 @@ aLy
 aLy
 aLy
 aLy
-bbq
+aLy
 aLy
 aLy
 aLy
@@ -100369,9 +100704,9 @@ aYL
 aYL
 bWP
 bYx
-aKC
-aKB
-dea
+bXo
+bXo
+bXo
 atH
 jTp
 iDL
@@ -100500,11 +100835,11 @@ aKf
 aKf
 aNC
 aFd
-aNi
-aKB
-aKB
-aKB
-aKC
+bXo
+cjm
+bXo
+bXo
+bXo
 bYD
 bYb
 aYL
@@ -100537,9 +100872,9 @@ aYL
 aYL
 bWP
 bae
-aKC
-aKF
-dea
+bXo
+bXo
+bXo
 aKz
 lDx
 aKf
@@ -100668,11 +101003,11 @@ ben
 aKf
 aIx
 aFe
-aNi
-aKC
+cjm
+cqv
 aEP
 aEI
-ceR
+cjo
 dwB
 bYb
 bcU
@@ -100705,9 +101040,9 @@ aYL
 aYM
 bWP
 siB
-aKC
-aKB
-dea
+bXo
+bXo
+bXo
 akw
 lDx
 aKf
@@ -100836,12 +101171,12 @@ aKp
 aKf
 aIx
 aFf
-aNi
+cqv
 aEZ
-aKB
+bXo
 aEJ
-aKB
-dwB
+ckx
+cjd
 bbQ
 bWX
 bbP
@@ -100872,10 +101207,10 @@ aYL
 aYU
 bWX
 bWQ
-siB
-aKC
-aKB
-dea
+bew
+bea
+aQv
+bXo
 akw
 aXU
 aKf
@@ -101004,11 +101339,11 @@ aKf
 aKf
 aIx
 aFf
-aNi
-aKC
+cjm
+bXo
 aEQ
 aEL
-aKB
+ckE
 odB
 oSf
 wvY
@@ -101040,10 +101375,10 @@ bWX
 bWQ
 lDX
 oSf
-nQp
-aKB
-ceR
-dea
+bqz
+beb
+aXm
+bXo
 akw
 aXU
 aXH
@@ -101172,11 +101507,11 @@ aKf
 aKf
 aIx
 aFf
-aNi
-aKC
+cjm
+bXo
 aER
 aEO
-aKF
+ckV
 aKB
 aKC
 odB
@@ -101209,9 +101544,9 @@ oSf
 nQp
 aKC
 aKB
-aKB
-aKB
-dea
+bed
+aXp
+bXo
 atH
 aXU
 aXH
@@ -101341,10 +101676,10 @@ aKf
 aIx
 atH
 aFb
-aKC
+bXo
 aET
-aKB
-aKB
+cmH
+ckE
 aKB
 aKB
 aKC
@@ -101377,13 +101712,13 @@ aKB
 aKB
 aKB
 aKB
-aKB
-aKB
-dea
+bed
+aXp
+bXo
 aKz
 wje
 aXO
-bpf
+aXO
 kpp
 kpp
 dlI
@@ -101508,11 +101843,11 @@ bQS
 aXH
 aNC
 aKz
-aNi
-aKC
-aEV
-aKB
-aKB
+cjm
+bXo
+bXo
+cjk
+ckE
 aKB
 aKB
 aKB
@@ -101545,22 +101880,22 @@ aKB
 aKB
 aKB
 aKB
-aKF
-aKB
-dea
-iFy
+bem
+aXp
+bXo
 iFy
 bph
+aNx
 bpg
 caA
+caA
 aXI
-iFy
-iFy
+bRL
 aJq
 aJq
 aJq
-aJq
-aJq
+xEt
+aJy
 aJq
 aJq
 aJq
@@ -101676,11 +102011,11 @@ bev
 bsr
 aID
 ctR
-aNi
-aKC
-aKC
-aKC
-aKB
+cjm
+cjm
+bXo
+cjk
+ckE
 bYz
 aKB
 aKB
@@ -101713,23 +102048,23 @@ aLc
 aJq
 aJq
 aKC
-aKB
-aKB
-pLS
-aKA
+bed
+aXp
+bXo
+iFy
 iFy
 ceJ
 ceJ
 rMO
 ceJ
+ceJ
 iFy
-gKr
 aJq
 aJq
-aJq
-aJq
-aJq
-aJq
+acs
+aJy
+aJy
+aJy
 aJq
 aJq
 aJq
@@ -101844,11 +102179,11 @@ beq
 bPX
 ctR
 ctR
-aNi
-aKC
-aKC
-aKC
-aKB
+bXo
+cjm
+cjm
+cjk
+ckE
 bYz
 bYz
 aKB
@@ -101860,7 +102195,7 @@ iKa
 aNd
 aMZ
 bAI
-cfr
+bbR
 aKB
 aMM
 aMy
@@ -101881,23 +102216,23 @@ aYV
 aJq
 aJq
 aKC
-aKB
-aKB
-aKB
-pLS
+bed
+aXp
+bXo
+bXo
 tFe
-mui
-mui
-mui
-mui
-mui
-knT
+aNB
+aHO
+aHO
+aHO
+aHO
+aHN
 aJq
 aJq
-aJq
-aJq
-aJq
-aJq
+acs
+aJy
+aJy
+xEt
 aJq
 aJq
 aJq
@@ -102012,13 +102347,13 @@ bQW
 akw
 ctR
 ctR
-aNi
-aKC
-aKC
-aKC
-aKB
-bYz
-bYz
+bXo
+cjm
+cqv
+cjh
+cmd
+cje
+bOz
 aKF
 aKB
 aKB
@@ -102028,7 +102363,7 @@ iKa
 sTb
 tUk
 bAJ
-aKB
+cfr
 aKB
 bAq
 bAa
@@ -102048,13 +102383,13 @@ aKB
 aLc
 aKX
 aJq
-aKC
-aKB
-aKB
-aKF
-aKB
+bwt
+beo
+aXp
+bXo
+bXo
 tFe
-acs
+aNE
 boS
 aXM
 lvY
@@ -102062,10 +102397,10 @@ acs
 acs
 xEt
 aJq
-aJq
-aJq
-aJq
-aJq
+acs
+acs
+acs
+aJy
 aJq
 aJq
 aJq
@@ -102180,13 +102515,13 @@ aFc
 aFc
 ctR
 ctR
-aNi
+bXo
 cfM
-aKB
-aKB
-aKB
-aKB
-bYz
+bXo
+cni
+cmF
+cjf
+bOC
 aKB
 aKB
 aKB
@@ -102214,26 +102549,26 @@ aKB
 aKB
 aKB
 aKB
-aKC
-aKC
-aKC
-aKC
-aKB
-ceR
-aKB
+bwv
+bwu
+bep
+bep
+aYg
+aNP
+bXo
 tFe
-pzq
+aNF
 aJx
 acs
 aJx
 aJy
 aJy
 aJy
-bWd
+acs
 aJx
 aYP
-aJq
-aJq
+acs
+aJy
 aJq
 aJq
 aJq
@@ -102348,13 +102683,13 @@ bQQ
 bQQ
 ctR
 ctR
-aKA
-aKD
-aKB
-aKB
-aKB
-aKB
-aKB
+bXo
+bXo
+bXo
+bXo
+bXo
+cjh
+bOD
 aKB
 aKC
 aKC
@@ -102363,7 +102698,7 @@ aKC
 cfu
 cft
 cfs
-bbR
+aKB
 bXk
 aKB
 aMM
@@ -102382,15 +102717,15 @@ aKB
 aKB
 aKB
 aKB
-aKB
-aKC
-aKC
-aKC
-aKC
-aKB
-aKC
+bUu
+aXp
+bXo
+bXo
+bXo
+bXo
+bXo
 tFe
-pzq
+aNF
 pzq
 pzq
 aJy
@@ -102400,7 +102735,7 @@ aJy
 aJy
 acs
 aJx
-aJq
+acs
 aJq
 aJq
 aJq
@@ -102517,12 +102852,12 @@ aKf
 aJb
 ctR
 ctR
-aKA
-hNM
-hNM
-hNM
-hNM
-hNM
+bXo
+bXo
+bXo
+bXo
+cjk
+bOF
 hNM
 hNM
 aKD
@@ -102550,15 +102885,15 @@ aKC
 pWw
 hNM
 hNM
-hNM
-hNM
-hNM
-hNM
-hNM
-hNM
-aKD
+bzh
+aXp
+bXo
+bXo
+aZz
+aOh
+bXo
 tFe
-pzq
+aNF
 pzq
 aJy
 aJy
@@ -102567,7 +102902,7 @@ aJy
 aJy
 xEt
 acs
-aJx
+aWw
 aJq
 aJq
 aJq
@@ -102723,10 +103058,10 @@ akw
 aKz
 aMb
 iFy
-ceM
-ceM
-tFe
-pzq
+iFy
+iFy
+iFy
+aNF
 aJy
 aJy
 xEt
@@ -102892,8 +103227,8 @@ aKR
 aKR
 aKR
 aKL
-ceM
-ceM
+iFy
+iFy
 aJq
 acs
 aJy
@@ -103061,10 +103396,10 @@ aKf
 aXL
 aKM
 aEt
-aEq
+iFy
 aJq
 aJq
-acs
+aWL
 aJy
 aJy
 bYt
@@ -103229,7 +103564,7 @@ bpj
 aXL
 ceC
 aEu
-aEq
+iFy
 aJq
 aJq
 acs
@@ -103396,8 +103731,8 @@ aKS
 aEy
 aEy
 aKN
-aEq
-aEq
+iFy
+iFy
 aJq
 aJq
 pzq
@@ -103563,8 +103898,8 @@ ctR
 ceJ
 ceJ
 ctR
-aEq
-aEq
+iFy
+iFy
 aJq
 aJq
 pzq
@@ -104735,7 +105070,7 @@ aJq
 aJq
 aJq
 aJq
-bpm
+acs
 aJy
 aJy
 aJy
@@ -104901,8 +105236,8 @@ aJq
 aJq
 aJq
 aJq
-aJq
-aJq
+acs
+acs
 aJy
 aJy
 aJy
@@ -105068,10 +105403,10 @@ caP
 caP
 caP
 aJq
+bzi
 aJx
-aJx
-aJq
-aYx
+acs
+acs
 aJy
 aJy
 aJy
@@ -106096,7 +106431,7 @@ ceu
 cem
 aWA
 bGO
-bGL
+agM
 bGL
 cdS
 bGI
@@ -106938,7 +107273,7 @@ aJx
 ceb
 bGI
 bGI
-bGL
+acU
 cdR
 cdQ
 aJq
@@ -108113,7 +108448,7 @@ pzq
 cvs
 cvp
 acs
-aXC
+afY
 cvn
 bYw
 aJq
@@ -108877,7 +109212,7 @@ lzp
 fIR
 aRG
 hvs
-uKv
+cvU
 uKv
 xXR
 bBx
@@ -114098,7 +114433,7 @@ aOd
 aOE
 aOE
 axi
-beN
+aOe
 aOq
 aOj
 aNU
@@ -114266,7 +114601,7 @@ axZ
 aOE
 axA
 aOe
-beN
+aOe
 aOr
 aOk
 aNV
@@ -118354,7 +118689,7 @@ arw
 aTN
 aYh
 aoW
-aQi
+aJW
 awO
 atO
 aJQ
@@ -118522,8 +118857,8 @@ bSi
 aTO
 aTF
 aJW
-aQi
-aQi
+aJW
+aJW
 aTq
 aJQ
 bRT
@@ -120032,8 +120367,8 @@ aUa
 aTX
 aTT
 aKq
-aTG
-aQi
+yhz
+aIc
 aQi
 awO
 bWg
@@ -120537,8 +120872,8 @@ aKq
 bSk
 aKq
 aKq
-aTy
-avw
+aKl
+aHR
 awO
 bWf
 aXu
@@ -120704,8 +121039,8 @@ rbR
 aTZ
 bSm
 aKq
-aTH
-aQi
+rCT
+aKu
 aQi
 ayE
 awq
@@ -122892,7 +123227,7 @@ aKn
 iKa
 iKa
 iKa
-bql
+bdQ
 bbh
 bbh
 bqv
@@ -123228,8 +123563,8 @@ aKn
 iKa
 iKa
 bsJ
-bsE
-bri
+aAY
+bbh
 bbh
 bbh
 iKa
@@ -123379,7 +123714,7 @@ abn
 aZx
 bTh
 coG
-bHo
+aLw
 abi
 abd
 aLa
@@ -123396,7 +123731,7 @@ aKn
 aQi
 iKa
 cnk
-btk
+aAY
 bbh
 bqr
 iKa
@@ -123546,9 +123881,9 @@ abq
 aZF
 coO
 bTi
-bHo
-bHo
-aer
+coG
+aLw
+abi
 abe
 aLa
 cua
@@ -124387,7 +124722,7 @@ aCS
 aLx
 aKI
 cuj
-aZn
+bkb
 abi
 abd
 aLa
@@ -125370,8 +125705,8 @@ ayU
 ayR
 ayX
 ayX
-bHo
-aIL
+ayR
+azw
 agk
 oRZ
 xTl
@@ -125539,7 +125874,7 @@ ayV
 ayV
 ayS
 aAb
-aIL
+azw
 agk
 oRZ
 xTl
@@ -126038,10 +126373,10 @@ azm
 azj
 ayV
 bpi
-bHo
-bHo
-bHo
-bHo
+ayV
+ayV
+ayV
+ayV
 ayP
 azw
 agk
@@ -126207,7 +126542,7 @@ azk
 ayV
 ayV
 ayV
-bHo
+ayV
 bHo
 bHo
 bHo


### PR DESCRIPTION

# About the pull request

The landing zone for WARF has been slightly redesigned. The north and southern areas have been made more constrained in width to offer a better defensive chokepoint, additional rock walls have been scattered near the eastern entrance to offer a defensive anchor/wall to build off of for Marines and more cover for Xenomorphs to use, the outer area of the LZ now starts sealed off by blast doors, requiring either the Marines to lift the lockdown or someone (surv or marine) to use explosives to bypass the blast doors. Furthermore additional miscellaneous aesthetic changes have been added to the LZ.

A pass over of many hull wall areas in the eastern area of the map have been made. The aim is to reduce some of the more harsh and constraining hull walls to slightly ease off the heavy presence of indestructible hull walls. The xeno cave/hive areas should still be very defendable, but there will be far less 2 tile chokepoints. 



# Explain why it's good for the game

The LZ redesign has been made in the effort to make the LZ more unique and reasonable to defend. The inital design features a very open design that is very hard for Marines to cover, usually resulting in the Marines expending a huge amount of resource to construct an elaborate all encompassing defense. These changes also give attacking Xenomorphs more cover options when approaching the FOB.

The hull wall changes are meant to tone down on the excessive amount of chokepoints. During the intial testing of WARF one critical feedback was a huge lack of chokepoints and hull walls for Xenos to use in hive areas, I believe i went too far in adding too many hard chokepoints and hull walls. This is an effort to scale it back slightly. 


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
mapadd: The White Antre landing zone has been redesigned. It features a more constrained north and southern entrance, an expanded internal layout, and the outer walls are now better covered and are shut off with blast doors. These blast doors can be bypassed via the internal lockdown override, acid or explosives. 
maptweak: A pass of resin/hull walls within the eastern areas of White Antre has been made with the goal to tone down the excessive amount of harsh choke points and overly zealous use of hull walls. 
/:cl:
