### PR TITLE
Adds a 'Strain Information' verb to Xenomorph statpanel

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/xeno_strain.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/xeno_strain.dm
@@ -138,6 +138,18 @@
 	log_strain("[new_xeno.name] reset their strain.")
 	COOLDOWN_START(new_xeno, next_strain_reset, 40 MINUTES)
 
+/mob/living/carbon/xenomorph/verb/strain_info()
+	set name = "Strain Information"
+	set desc = "Gives information about your strain."
+	set category = "Alien.Essentials"
+
+	// Checks if user has a strain.
+	if(!strain)
+		return
+
+	to_chat(src, SPAN_XENOANNOUNCE(strain.description))
+	return TRUE
+
 /// Is this xeno currently able to take a strain?
 /mob/living/carbon/xenomorph/proc/can_take_strain(reset=FALSE)
 	if(!length(caste.available_strains) || !check_state(TRUE))


### PR DESCRIPTION

# About the pull request
This adds a 'Strain Information' verb that will output user's strain (if they have one) information/description in Essentials tab.  (screenshots included)

# Explain why it's good for the game

I keep forgetting the abilities of my strain; and this helps with that! 


# Testing Photographs and Procedure


<details>

<summary>Screenshots & Videos</summary>
<img width="685" height="122" alt="Ekran görüntüsü 2026-09-13 000645" src="https://github.com/user-attachments/assets/9bc80a34-abd5-4224-a708-767acb82b861" />

<img width="697" height="197" alt="Ekran görüntüsü 2026-09-13 002114" src="https://github.com/user-attachments/assets/13d33f72-92ae-4f0c-a7c8-18e421214e6d" />

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

# Changelog

:cl:
add: Added 'Strain Information' Verb
/:cl:
